### PR TITLE
implemented range warning

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -171,3 +171,21 @@ PARAM_DEFINE_FLOAT(COM_EF_TIME, 10.0f);
  * @max 35
  */
 PARAM_DEFINE_FLOAT(COM_RC_LOSS_T, 0.5);
+
+/**
+ * Max horizontal distance in meters.
+ *
+ * Set to > 0 to activate RTL if horizontal distance to home exceeds this value.
+ *
+ * @group commander
+ */
+PARAM_DEFINE_INT32(COM_MX_HOR_DIST, 1500);
+
+/**
+ * Max vertical distance in meters.
+ *
+ * Set to > 0 to activate RTL if vertical distance to home exceeds this value.
+ *
+ * @group commander
+ */
+PARAM_DEFINE_INT32(COM_MX_VER_DIST, 1500);

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -519,6 +519,20 @@ bool set_nav_state(struct vehicle_status_s *status, const bool data_link_loss_en
 		} else if (status->engine_failure) {
 			status->nav_state = NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
+		/* range violation, return to home */
+		} else if (status->rc_signal_lost && status->condition_range_violated) {
+			status->failsafe = true;
+
+			if (status->condition_global_position_valid && status->condition_home_position_valid) {
+				status->nav_state = NAVIGATION_STATE_AUTO_RTGS;
+			} else if (status->condition_local_position_valid) {
+				status->nav_state = NAVIGATION_STATE_LAND;
+			} else if (status->condition_local_altitude_valid) {
+				status->nav_state = NAVIGATION_STATE_DESCEND;
+			} else {
+				status->nav_state = NAVIGATION_STATE_TERMINATION;
+			}
+
 		/* datalink loss enabled:
 		 * check for datalink lost: this should always trigger RTGS */
 		} else if (data_link_loss_enabled && status->data_link_lost) {

--- a/src/modules/uORB/topics/vehicle_status.h
+++ b/src/modules/uORB/topics/vehicle_status.h
@@ -197,6 +197,7 @@ struct vehicle_status_s {
 	bool condition_airspeed_valid;			/**< set to true by the commander app if there is a valid airspeed measurement available */
 	bool condition_landed;					/**< true if vehicle is landed, always true if disarmed */
 	bool condition_power_input_valid;		/**< set if input power is valid */
+	bool condition_range_violated;          /**< set if allowed distance from home was exceeded */
 	float avionics_power_rail_voltage;		/**< voltage of the avionics power rail */
 
 	bool rc_signal_found_once;


### PR DESCRIPTION
This functionality is a simple security feature avoiding vehicles going out of control. If the horizontal and vertical distance exceeds a configurable value and RC connection is lost, the vehicle transfer into failsafe state and e.g. returns to home.