### PR TITLE
Fixed loop limit errors in Matrix.h

### DIFF
--- a/src/lib/mathlib/math/Matrix.hpp
+++ b/src/lib/mathlib/math/Matrix.hpp
@@ -180,8 +180,8 @@ public:
 	Matrix<M, N> operator -(void) const {
 		Matrix<M, N> res;
 
-		for (unsigned int i = 0; i < N; i++)
-			for (unsigned int j = 0; j < M; j++)
+		for (unsigned int i = 0; i < M; i++)
+			for (unsigned int j = 0; j < N; j++)
 				res.data[i][j] = -data[i][j];
 
 		return res;
@@ -193,16 +193,16 @@ public:
 	Matrix<M, N> operator +(const Matrix<M, N> &m) const {
 		Matrix<M, N> res;
 
-		for (unsigned int i = 0; i < N; i++)
-			for (unsigned int j = 0; j < M; j++)
+		for (unsigned int i = 0; i < M; i++)
+			for (unsigned int j = 0; j < N; j++)
 				res.data[i][j] = data[i][j] + m.data[i][j];
 
 		return res;
 	}
 
 	Matrix<M, N> &operator +=(const Matrix<M, N> &m) {
-		for (unsigned int i = 0; i < N; i++)
-			for (unsigned int j = 0; j < M; j++)
+		for (unsigned int i = 0; i < M; i++)
+			for (unsigned int j = 0; j < N; j++)
 				data[i][j] += m.data[i][j];
 
 		return *static_cast<Matrix<M, N>*>(this);
@@ -222,8 +222,8 @@ public:
 	}
 
 	Matrix<M, N> &operator -=(const Matrix<M, N> &m) {
-		for (unsigned int i = 0; i < N; i++)
-			for (unsigned int j = 0; j < M; j++)
+		for (unsigned int i = 0; i < M; i++)
+			for (unsigned int j = 0; j < N; j++)
 				data[i][j] -= m.data[i][j];
 
 		return *static_cast<Matrix<M, N>*>(this);


### PR DESCRIPTION
In few of the overloaded operators the loop limits (i.e. M and N) were swapped.