### PR TITLE
Nuttx bringup fix headers

### DIFF
--- a/src/drivers/boards/px4fmu-v1/px4fmu_init.c
+++ b/src/drivers/boards/px4fmu-v1/px4fmu_init.c
@@ -69,6 +69,12 @@
 
 #include <systemlib/cpuload.h>
 
+/* todo: This is constant but not proper */
+__BEGIN_DECLS
+extern void led_off(int led);
+__END_DECLS
+
+
 /****************************************************************************
  * Pre-Processor Definitions
  ****************************************************************************/

--- a/src/drivers/boards/px4fmu-v2/px4fmu2_init.c
+++ b/src/drivers/boards/px4fmu-v2/px4fmu2_init.c
@@ -72,6 +72,11 @@
 #include <systemlib/cpuload.h>
 #include <systemlib/perf_counter.h>
 
+/* todo: This is constant but not proper */
+__BEGIN_DECLS
+extern void led_off(int led);
+__END_DECLS
+
 /****************************************************************************
  * Pre-Processor Definitions
  ****************************************************************************/

--- a/src/modules/px4iofirmware/px4io.h
+++ b/src/modules/px4iofirmware/px4io.h
@@ -63,7 +63,7 @@
 
 #ifdef DEBUG
 # include <debug.h>
-# define debug(fmt, args...)	lowsyslog(fmt "\n", ##args)
+# define debug(fmt, args...)	lowsyslog(LOG_DEBUG,fmt "\n", ##args)
 #else
 # define debug(fmt, args...)	do {} while(0)
 #endif

--- a/src/modules/systemlib/px4_macros.h
+++ b/src/modules/systemlib/px4_macros.h
@@ -51,6 +51,7 @@
  * CCASSERT(predicate) Will generate a compile time error it the
  * predicate is false
  */
+#include <assert.h>
 
 #ifndef _PX4_MACROS_H
 #define _PX4_MACROS_H
@@ -86,10 +87,14 @@
 #endif
 
 #if !defined(CCASSERT)
-#define CCASSERT(predicate) _x_CCASSERT_LINE(predicate, __LINE__)
-#if !defined(_x_CCASSERT_LINE)
-#define _x_CCASSERT_LINE(predicate, line) typedef char CAT(constraint_violated_on_line_,line)[2*((predicate)!=0)-1];
-#endif
+#if defined(static_assert)
+#		define CCASSERT(predicate) static_assert(predicate)
+#	else
+#		define CCASSERT(predicate) _x_CCASSERT_LINE(predicate, __LINE__)
+#		if !defined(_x_CCASSERT_LINE)
+#			define _x_CCASSERT_LINE(predicate, line) typedef char CAT(constraint_violated_on_line_,line)[2*((predicate)!=0)-1] __attribute__ ((unused)) ;
+#		endif
+#	endif
 #endif
 
 


### PR DESCRIPTION
This is the clean up that made sense for the Firmware:

But I ran into issues with the px4fmu-v1 build for: src/drivers/boards/px4fmu-v1/px4fmu_spi.c 
```
void stm32_spi2select(FAR struct spi_dev_s *dev, enum spi_dev_e devid, bool selected);
uint8_t stm32_spi2status(FAR struct spi_dev_s *dev, enum spi_dev_e devid);
```
are missing as prototypes. I have to trace what is going on because they are defined in nuttx'sarch/arm/src/stm32/stm32_spi.h (which should be pulled in from the stm32.h)  when the CONFIG_STM32_SPIn (n = 2-6)  are set but I just could  not get the build to run if I did not kluge it by adding the prototypes :
```
void stm32_spi2select(FAR struct spi_dev_s *dev, enum spi_dev_e devid, bool selected);
uint8_t stm32_spi2status(FAR struct spi_dev_s *dev, enum spi_dev_e devid);**
```
directly into src/drivers/boards/px4fmu-v1/px4fmu_spi.c
