### PR TITLE
add simple nonsymmetric Matrix testing to test_mathlib

### DIFF
--- a/src/systemcmds/tests/module.mk
+++ b/src/systemcmds/tests/module.mk
@@ -35,5 +35,5 @@ SRCS			 = test_adc.c \
 			   test_mount.c \
 			   test_mtd.c
 
-EXTRACXXFLAGS = -Wframe-larger-than=2500
+EXTRACXXFLAGS = -Wframe-larger-than=2500 -Wno-float-equal -Wno-double-promotion
 

--- a/src/systemcmds/tests/test_mathlib.cpp
+++ b/src/systemcmds/tests/test_mathlib.cpp
@@ -54,6 +54,7 @@ using namespace math;
 
 int test_mathlib(int argc, char *argv[])
 {
+	int rc = 0;
 	warnx("testing mathlib");
 
 	{
@@ -156,5 +157,53 @@ int test_mathlib(int argc, char *argv[])
 		TEST_OP("Matrix<10, 10> * Matrix<10, 10>", m1 * m2);
 	}
 
-	return 0;
+	{
+		// test nonsymmetric +, -, +=, -=
+
+		float data1[2][3] = {{1,2,3},{4,5,6}};
+		float data2[2][3] = {{2,4,6},{8,10,12}};
+		float data3[2][3] = {{3,6,9},{12,15,18}};
+		
+		Matrix<2, 3> m1(data1);
+		Matrix<2, 3> m2(data2);
+		Matrix<2, 3> m3(data3);
+
+		if (m1 + m2 != m3) {
+			warnx("Matrix<2, 3> + Matrix<2, 3> failed!");
+			(m1 + m2).print();
+			printf("!=\n");
+			m3.print();
+			rc = 1;
+		}
+
+		if (m3 - m2 != m1) {
+			warnx("Matrix<2, 3> - Matrix<2, 3> failed!");
+			(m3 - m2).print();
+			printf("!=\n");
+			m1.print();
+			rc = 1;
+		}
+
+		m1 += m2;
+		if (m1 != m3) {
+			warnx("Matrix<2, 3> += Matrix<2, 3> failed!");
+			m1.print();
+			printf("!=\n");
+			m3.print();
+			rc = 1;
+		}
+
+		m1 -= m2;
+		Matrix<2, 3> m1_orig(data1);
+		if (m1 != m1_orig) {
+			warnx("Matrix<2, 3> -= Matrix<2, 3> failed!");
+			m1.print();
+			printf("!=\n");
+			m1_orig.print();
+			rc = 1;
+		}
+	
+	}
+
+	return rc;
 }


### PR DESCRIPTION
This is crude and doesn't fit with the existing test_mathlib, but it verifies the problem in PR #1517 and passes once the change is applied. After I convert the host unittests to gtest I'll look at using it here as well.