### PR TITLE
SDLOG2: Use RTC, not GPS time for file naming

### DIFF
--- a/src/drivers/gps/gps_helper.h
+++ b/src/drivers/gps/gps_helper.h
@@ -43,6 +43,8 @@
 #include <uORB/uORB.h>
 #include <uORB/topics/vehicle_gps_position.h>
 
+#define GPS_EPOCH_SECS 1234567890ULL
+
 class GPS_Helper
 {
 public:

--- a/src/drivers/gps/ubx.cpp
+++ b/src/drivers/gps/ubx.cpp
@@ -748,19 +748,23 @@ UBX::payload_rx_done(void)
 			timeinfo.tm_sec		= _buf.payload_rx_nav_pvt.sec;
 			time_t epoch = mktime(&timeinfo);
 
-			// FMUv2+ boards have a hardware RTC, but GPS helps us to configure it
-			// and control its drift. Since we rely on the HRT for our monotonic
-			// clock, updating it from time to time is safe.
+			if (epoch > GPS_EPOCH_SECS) {
+				// FMUv2+ boards have a hardware RTC, but GPS helps us to configure it
+				// and control its drift. Since we rely on the HRT for our monotonic
+				// clock, updating it from time to time is safe.
 
-			timespec ts;
-			ts.tv_sec = epoch;
-			ts.tv_nsec = _buf.payload_rx_nav_pvt.nano;
-			if (clock_settime(CLOCK_REALTIME, &ts)) {
-				warn("failed setting clock");
+				timespec ts;
+				ts.tv_sec = epoch;
+				ts.tv_nsec = _buf.payload_rx_nav_pvt.nano;
+				if (clock_settime(CLOCK_REALTIME, &ts)) {
+					warn("failed setting clock");
+				}
+
+				_gps_position->time_utc_usec = static_cast<uint64_t>(epoch) * 1000000ULL;
+				_gps_position->time_utc_usec += _buf.payload_rx_nav_timeutc.nano / 1000;
+			} else {
+				_gps_position->time_utc_usec = 0;
 			}
-
-			_gps_position->time_utc_usec = static_cast<uint64_t>(epoch) * 1000000ULL;
-			_gps_position->time_utc_usec += _buf.payload_rx_nav_timeutc.nano / 1000;
 		}
 
 		_gps_position->timestamp_time		= hrt_absolute_time();
@@ -820,19 +824,25 @@ UBX::payload_rx_done(void)
 			timeinfo.tm_sec		= _buf.payload_rx_nav_timeutc.sec;
 			time_t epoch = mktime(&timeinfo);
 
-			// FMUv2+ boards have a hardware RTC, but GPS helps us to configure it
-			// and control its drift. Since we rely on the HRT for our monotonic
-			// clock, updating it from time to time is safe.
+			// only set the time if it makes sense
 
-			timespec ts;
-			ts.tv_sec = epoch;
-			ts.tv_nsec = _buf.payload_rx_nav_timeutc.nano;
-			if (clock_settime(CLOCK_REALTIME, &ts)) {
-				warn("failed setting clock");
+			if (epoch > GPS_EPOCH_SECS) {
+				// FMUv2+ boards have a hardware RTC, but GPS helps us to configure it
+				// and control its drift. Since we rely on the HRT for our monotonic
+				// clock, updating it from time to time is safe.
+
+				timespec ts;
+				ts.tv_sec = epoch;
+				ts.tv_nsec = _buf.payload_rx_nav_timeutc.nano;
+				if (clock_settime(CLOCK_REALTIME, &ts)) {
+					warn("failed setting clock");
+				}
+
+				_gps_position->time_utc_usec = static_cast<uint64_t>(epoch) * 1000000ULL;
+				_gps_position->time_utc_usec += _buf.payload_rx_nav_timeutc.nano / 1000;
+			} else {
+				_gps_position->time_utc_usec = 0;
 			}
-
-			_gps_position->time_utc_usec = static_cast<uint64_t>(epoch) * 1000000ULL;
-			_gps_position->time_utc_usec += _buf.payload_rx_nav_timeutc.nano / 1000;
 		}
 
 		_gps_position->timestamp_time = hrt_absolute_time();

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -57,6 +57,7 @@
 #include <unistd.h>
 #include <drivers/drv_hrt.h>
 #include <math.h>
+#include <time.h>
 
 #include <drivers/drv_range_finder.h>
 
@@ -340,7 +341,7 @@ int create_log_dir()
 	uint16_t dir_number = 1; // start with dir sess001
 	int mkdir_ret;
 
-	timespec ts;
+	struct timespec ts;
 	clock_gettime(CLOCK_REALTIME, &ts);
 	/* use RTC time for log file naming, e.g. /fs/microsd/2014-01-19/19_37_52.bin */
 	time_t utc_time_sec = ts.tv_sec + (ts.tv_nsec / 1e9);
@@ -400,7 +401,7 @@ int open_log_file()
 	char log_file_name[32] = "";
 	char log_file_path[64] = "";
 
-	timespec ts;
+	struct timespec ts;
 	clock_gettime(CLOCK_REALTIME, &ts);
 	/* use RTC time for log file naming, e.g. /fs/microsd/2014-01-19/19_37_52.bin */
 	time_t utc_time_sec = ts.tv_sec + (ts.tv_nsec / 1e9);
@@ -455,7 +456,7 @@ int open_perf_file(const char* str)
 	char log_file_name[32] = "";
 	char log_file_path[64] = "";
 
-	timespec ts;
+	struct timespec ts;
 	clock_gettime(CLOCK_REALTIME, &ts);
 	/* use RTC time for log file naming, e.g. /fs/microsd/2014-01-19/19_37_52.bin */
 	time_t utc_time_sec = ts.tv_sec + (ts.tv_nsec / 1e9);


### PR DESCRIPTION
@mhkabir @thomasgubler @bansiesta This here uses the RTC in sdlog2 consistently.