### PR TITLE
add 'make check_format' to enforce astyle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ Firmware.zip
 unittests/build
 *.generated.h
 .vagrant
+*.pretty
+

--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,10 @@ testbuild:
 tests:	generateuorbtopicheaders
 	$(Q) (mkdir -p $(PX4_BASE)/unittests/build && cd $(PX4_BASE)/unittests/build && cmake .. && $(MAKE) unittests)
 
+.PHONY: format check_format
+check_format:
+	$(Q) (./Tools/check_code_style.sh | sort -n)
+
 #
 # Cleanup targets.  'clean' should remove all built products and force
 # a complete re-compilation, 'distclean' should remove everything

--- a/Tools/check_code_style.sh
+++ b/Tools/check_code_style.sh
@@ -2,6 +2,7 @@
 set -eu
 failed=0
 for fn in $(find . -path './src/lib/uavcan' -prune -o \
+                   -path './src/lib/mathlib/CMSIS' -prune -o \
                    -path './NuttX' -prune -o \
                    -path './Build' -prune -o \
                    -path './mavlink' -prune -o \

--- a/Tools/check_code_style.sh
+++ b/Tools/check_code_style.sh
@@ -6,6 +6,7 @@ for fn in $(find . -path './src/lib/uavcan' -prune -o \
                    -path './Build' -prune -o \
                    -path './mavlink' -prune -o \
                    -path './unittests/gtest' -prune -o \
+                   -path './unittests/build' -prune -o \
                    -name '*.c' -o -name '*.cpp' -o -name '*.hpp' -o -name '*.h' -type f); do
   if [ -f "$fn" ];
   then

--- a/Tools/check_code_style.sh
+++ b/Tools/check_code_style.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -eu
+failed=0
+for fn in $(find . -path './src/lib/uavcan' -prune -o \
+                   -path './NuttX' -prune -o \
+                   -path './Build' -prune -o \
+                   -path './mavlink' -prune -o \
+                   -path './unittests/gtest' -prune -o \
+                   -name '*.c' -o -name '*.cpp' -o -name '*.hpp' -o -name '*.h' -type f); do
+  if [ -f "$fn" ];
+  then
+    ./Tools/fix_code_style.sh --quiet < $fn > $fn.pretty
+    diffsize=$(diff -y --suppress-common-lines $fn $fn.pretty | wc -l)
+    rm -f $fn.pretty
+    if [ $diffsize -ne 0 ]; then
+      failed=1
+      echo $diffsize $fn
+    fi
+  fi
+done
+
+if [ $failed -eq 0 ]; then
+    echo "Format checks passed"
+    exit 0
+else
+    echo "Format checks failed; please run ./Tools/fix_code_style.sh on each file"
+    exit 1
+fi

--- a/Tools/check_code_style.sh
+++ b/Tools/check_code_style.sh
@@ -3,6 +3,7 @@ set -eu
 failed=0
 for fn in $(find . -path './src/lib/uavcan' -prune -o \
                    -path './src/lib/mathlib/CMSIS' -prune -o \
+                   -path './src/modules/attitude_estimator_ekf/codegen/' -prune -o \
                    -path './NuttX' -prune -o \
                    -path './Build' -prune -o \
                    -path './mavlink' -prune -o \

--- a/Tools/fix_code_style.sh
+++ b/Tools/fix_code_style.sh
@@ -18,4 +18,5 @@ astyle \
     --exclude=EASTL		\
     --add-brackets		\
     --max-code-length=120	\
+    --preserve-date             \
     $*

--- a/Tools/pre-commit
+++ b/Tools/pre-commit
@@ -1,6 +1,4 @@
 #!/bin/sh
-echo "hello world"
-
 if git rev-parse --verify HEAD >/dev/null 2>&1
 then
   against=HEAD
@@ -15,7 +13,6 @@ exec 1>&2
 CHANGED_FILES=`git diff --cached --name-only --diff-filter=ACM $against | grep '\.c\|\.cpp\|\.h\|\.hpp'`
 FAILED=0
 if [ ! -z "$CHANGED_FILES" -a "$CHANGED_FILES" != " " ]; then
-  echo $CHANGED_FILES
   for FILE in $CHANGED_FILES; do
     ./Tools/fix_code_style.sh --quiet < $FILE > $FILE.pretty
     diff -u $FILE $FILE.pretty || FAILED=1

--- a/Tools/pre-commit
+++ b/Tools/pre-commit
@@ -1,0 +1,29 @@
+#!/bin/sh
+echo "hello world"
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+  against=HEAD
+else
+  # Initial commit: diff against an empty tree object
+  against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+# Redirect output to stderr.
+exec 1>&2
+
+CHANGED_FILES=`git diff --cached --name-only --diff-filter=ACM $against | grep '\.c\|\.cpp\|\.h\|\.hpp'`
+FAILED=0
+if [ ! -z "$CHANGED_FILES" -a "$CHANGED_FILES" != " " ]; then
+  echo $CHANGED_FILES
+  for FILE in $CHANGED_FILES; do
+    ./Tools/fix_code_style.sh --quiet < $FILE > $FILE.pretty
+    diff -u $FILE $FILE.pretty || FAILED=1
+    rm -f $FILE.pretty
+    if [ $FAILED -ne 0 ]; then
+      echo "There are code formatting errors. Please fix them by running ./Tools/fix_code_style.sh $FILE"
+      exit $FAILED
+    fi
+  done
+fi
+exit 0


### PR DESCRIPTION
The idea is to fix formatting once and for all so we don't have to waste time discussing it. Once the formatting is fixed (make format) and committed, 'make check_format' can be added to travis to catch formatting errors as they're created.

make format runs ./Tools/fix_code_style.sh on all sources files and headers in src. 
make check_format runs astyle, but displays a diff of the change and doesn't modify the original.

This is what running 'make format' will do. It looks like we may want to tweak the case indenting.
https://github.com/dagar/Firmware/compare/format_fix?expand=1

