### PR TITLE
Remove bottle_drop as it should be optional.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.fw_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.fw_apps
@@ -13,5 +13,3 @@ ekf_att_pos_estimator start
 #
 fw_att_control start
 fw_pos_control_l1 start
-
-bottle_drop start


### PR DESCRIPTION
Note that since it was not called like this:

if bottle_drop start
then
fi

it resulted in V1 fixedwing setups that don't have the app terminating this script and the parent startup script (rcS) immediately, which resulted in the navigator not being started.  