### PR TITLE
hmc5883: fixed handling of 3 bus options

### DIFF
--- a/src/drivers/hmc5883/hmc5883.h
+++ b/src/drivers/hmc5883/hmc5883.h
@@ -50,3 +50,4 @@
 /* interface factories */
 extern device::Device *HMC5883_SPI_interface(int bus) weak_function;
 extern device::Device *HMC5883_I2C_interface(int bus) weak_function;
+typedef device::Device* (*HMC5883_constructor)(int);


### PR DESCRIPTION
use a table of possible bus options. This prevents us starting two
drivers on the same bus