### PR TITLE
commander: Refresh safety tests

### DIFF
--- a/src/modules/commander/commander_tests/state_machine_helper_test.cpp
+++ b/src/modules/commander/commander_tests/state_machine_helper_test.cpp
@@ -280,6 +280,7 @@ bool StateMachineHelperTest::armingStateTransitionTest(void)
         status.arming_state = test->current_state.arming_state;
         status.condition_system_sensors_initialized = test->condition_system_sensors_initialized;
         status.hil_state = test->hil_state;
+        status.circuit_breaker_engaged_power_check = true;
         safety.safety_switch_available = test->safety_switch_available;
         safety.safety_off = test->safety_off;
         armed.armed = test->current_state.armed;


### PR DESCRIPTION
This fixes false positives for safety unit tests.