### PR TITLE
px_uploader: Small fix to properly display timeouts

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -287,11 +287,12 @@ class uploader(object):
 
                         #Draw progress bar (erase usually takes about 9 seconds to complete)
                         estimatedTimeRemaining = deadline-time.time()
-                        if estimatedTimeRemaining > 0:
+                        if estimatedTimeRemaining >= 9.0:
                             self.__drawProgressBar(20.0-estimatedTimeRemaining, 9.0)
                         else:
                             self.__drawProgressBar(10.0, 10.0)
-                            sys.stdout.write(" (timeout: %d seconds) " % int(time.time()-deadline) )
+                            sys.stdout.write(" (timeout: %d seconds) " % int(deadline-time.time()) )
+                            sys.stdout.flush()
 
                         if self.__trySync():
                             self.__drawProgressBar(10.0, 10.0)


### PR DESCRIPTION
This tiny fix solves a issue where the the timeout was not properly drawn.

If for some reason the erase takes longer than usual or didn't work, then the loading bar got stuck on 100% with no feedback to user. This fixes and displays number of seconds remaining until a abort timeout.