### PR TITLE
px4 nuttx bringup: with new nuttx layer, EKF now needs a little bit more headroom.  

### DIFF
--- a/src/modules/attitude_estimator_ekf/module.mk
+++ b/src/modules/attitude_estimator_ekf/module.mk
@@ -43,6 +43,6 @@ SRCS		 = attitude_estimator_ekf_main.cpp \
 
 MODULE_STACKSIZE = 1200
 
-EXTRACFLAGS = -Wno-float-equal -Wframe-larger-than=3600
+EXTRACFLAGS = -Wno-float-equal -Wframe-larger-than=3700
 
 EXTRACXXFLAGS = -Wframe-larger-than=2400


### PR DESCRIPTION
On my build, it needed 3656 bytes, so I've given it headroom to go to 3700.
