### PR TITLE
Upload latest master, beta and stable builds to AWS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ after_script:
 # upload newest build for this branch with s3 index
   - ./CI-Tools/s3cmd-put Images/px4*.px4 CI-Tools/directory/index.html $TRAVIS_BRANCH/
 # archive newest build by date with s3 index
-  - ./CI-Tools/s3cmd-put Images/px4*.px4 CI-Tools/directory/index.html $TRAVIS_BRANCH/archives/`date "+%Y-%m-%d"`-$TRAVIS_BUILD_ID/
+  - ./CI-Tools/s3cmd-put Firmware.zip CI-Tools/directory/index.html archives/$TRAVIS_BRANCH/`date "+%Y-%m-%d"`-$TRAVIS_BUILD_ID/
 # upload top level index.html and timestamp.html
   - ./CI-Tools/s3cmd-put CI-Tools/index.html timestamp.html /
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,21 +62,6 @@ after_script:
 # upload top level index.html and timestamp.html
   - ./CI-Tools/s3cmd-put CI-Tools/index.html timestamp.html /
 
-# We use an encrypted env variable to ensure this only executes when artifacts are uploaded.
-#after_script:
-#  - echo "Branch $TRAVIS_BRANCH (pull request: $TRAVIS_PULL_REQUEST) ready for flight testing." >> $PX4_REPORT
-#  - git log -n1 > $PX4_REPORT
-#  - echo " " >> $PX4_REPORT
-#  - echo "Files available at:" >> $PX4_REPORT
-#  - echo "https://px4-travis.s3.amazonaws.com/PX4/Firmware/$TRAVIS_BUILD_NUMBER/$TRAVIS_BUILD_NUMBER.1/Firmware.zip" >> $PX4_REPORT
-#  - echo "Description of desired tests is available at:" >> $PX4_REPORT
-#  - echo "https://github.com/PX4/Firmware/pull/$TRAVIS_PULL_REQUEST" >> $PX4_REPORT
-#  - echo " " >> $PX4_REPORT
-#  - echo "Thanks for testing!" >> $PX4_REPORT
-#  - echo " " >> $PX4_REPORT
-#  - /usr/bin/mail -s "$SUBJECT ($TRAVIS_COMMIT)" "$PX4_EMAIL" < "$PX4_REPORT"
-#  - s3cmd put --acl-public --guess-mime-type --config=.s3cfg Firmware.zip s3://s3-website-us-east-1.amazonaws.com/#$TRAVIS_JOB_ID/
-
 deploy:
   provider: releases
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,18 +73,6 @@ deploy:
     all_branches: true
     repo: PX4/Firmware
 
-addons:
-  artifacts:
-    paths:
-    - "Firmware.zip"
-    key:
-      secure: j4y9x9KXUiarGrnpFBLPIkEKIH8X6oSRUO61TwxTOamsE0eEKnIaCz1Xq83q7DoqzomHBD3qXAFPV9dhLr1zdKEPJDIyV45GVD4ClIQIzh/P3Uc7kDNxKzdmxY12SH6D0orMpC4tCf1sNK7ETepltWfcnjaDk1Rjs9+TVY7LuzM=
-    secret:
-      secure: CJC7VPGtEhJu8Pix85iPF8xUvMPZvTgnHyd9MrSlPKCFFMrlgz9eMT0WWW/TPQ+s4LPwJIfEQx2Q0BRT5tOXuvsTLuOG68mplVddhTWbHb0m0qTQErXFHEppvW4ayuSdeLJ4TjTWphBVainL0mcLLRwQfuAJJDDs/sGan3WrG+Y=
-    bucket: px4-travis
-    region: us-east-1
-    endpoint: s3-website-us-east-1.amazonaws.com
-
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,16 @@ script:
   - echo -en 'travis_fold:end:script.3\\r'
   - zip Firmware.zip Images/*.px4
 
+after_script:
+  - git clone git://github.com/PX4/CI-Tools.git
+  - ./CI-Tools/s3cmd-configure
+# upload newest build for this branch with s3 index
+  - ./CI-Tools/s3cmd-put Images/px4*.px4 CI-Tools/directory/index.html $TRAVIS_BRANCH/
+# archive newest build by date with s3 index
+  - ./CI-Tools/s3cmd-put Images/px4*.px4 CI-Tools/directory/index.html $TRAVIS_BRANCH/archives/`date "+%Y-%m-%d"`-$TRAVIS_BUILD_ID/
+# upload top level index.html and timestamp.html
+  - ./CI-Tools/s3cmd-put CI-Tools/index.html timestamp.html /
+
 # We use an encrypted env variable to ensure this only executes when artifacts are uploaded.
 #after_script:
 #  - echo "Branch $TRAVIS_BRANCH (pull request: $TRAVIS_PULL_REQUEST) ready for flight testing." >> $PX4_REPORT

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,10 @@ after_script:
   - git clone git://github.com/PX4/CI-Tools.git
   - ./CI-Tools/s3cmd-configure
 # upload newest build for this branch with s3 index
-  - ./CI-Tools/s3cmd-put Images/px4*.px4 CI-Tools/directory/index.html $TRAVIS_BRANCH/
+  - ./CI-Tools/s3cmd-put Images/px4*.px4 CI-Tools/directory/index.html Firmware/$TRAVIS_BRANCH/
 # archive newest build by date with s3 index
-  - ./CI-Tools/s3cmd-put Firmware.zip CI-Tools/directory/index.html archives/$TRAVIS_BRANCH/`date "+%Y-%m-%d"`-$TRAVIS_BUILD_ID/
+  - ./CI-Tools/s3cmd-put Firmware.zip archives/Firmware/$TRAVIS_BRANCH/`date "+%Y-%m-%d"`-$TRAVIS_BUILD_ID/
+  - ./CI-Tools/s3cmd-put CI-Tools/directory/index.html archives/Firmware/$TRAVIS_BRANCH/
 # upload top level index.html and timestamp.html
   - ./CI-Tools/s3cmd-put CI-Tools/index.html timestamp.html /
 


### PR DESCRIPTION
I removed the other s3 artifacts upload assuming you don't also want to keep every Firmware.zip on s3.

I uploaded some unnecessary files when attempting to use the travis builtin s3 upload. You could probably delete everything in the bucket at this point and travis will repopulate. 