### PR TITLE
Add landing detector for V1 boards as well.

### DIFF
--- a/makefiles/config_px4fmu-v1_default.mk
+++ b/makefiles/config_px4fmu-v1_default.mk
@@ -62,6 +62,7 @@ MODULES		+= modules/commander
 MODULES		+= modules/navigator
 MODULES		+= modules/mavlink
 MODULES		+= modules/gpio_led
+MODULES 	+= modules/land_detector
 
 #
 # Estimation modules (EKF / other filters)


### PR DESCRIPTION
This adds the landing detector module to V1 setups. This will also fix a startup failure on V1's as it's in the startup script already.

Note that "free" shows a drop from 32k to 19k once this module is active. @Zefz I noticed the reserved stack space is 1200 but after boot it's using 400. Does it go much higher than this?