### PR TITLE
mc_pos_control: Protect against NaN and Inf setpoints

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -726,11 +726,18 @@ MulticopterPositionControl::control_auto(float dt)
 		reset_alt_sp();
 	}
 
+	//Poll position setpoint
 	bool updated;
 	orb_check(_pos_sp_triplet_sub, &updated);
-
 	if (updated) {
 		orb_copy(ORB_ID(position_setpoint_triplet), _pos_sp_triplet_sub, &_pos_sp_triplet);
+
+		//Make sure that the position setpoint is valid
+		if (!isfinite(_pos_sp_triplet.current.lat) || 
+			!isfinite(_pos_sp_triplet.current.lon) || 
+			!isfinite(_pos_sp_triplet.current.alt)) {
+			_pos_sp_triplet.current.valid = false;
+		}
 	}
 
 	if (_pos_sp_triplet.current.valid) {


### PR DESCRIPTION
This small fix prevents NaN and Inf floats in position setpoints from infecting the rest of the position controller in AUTO mode. If a non-finite float is detected, the setpoint is marked as invalid and should make the vehicle hold position because of ```reset_pos_sp()``` and  ```reset_alt_sp()```.

Without this fix the vehicle fell down from the sky and crashed.