### PR TITLE
MPU6000: Increase gyro offset tolerance to 7 dps

### DIFF
--- a/src/drivers/mpu6000/mpu6000.cpp
+++ b/src/drivers/mpu6000/mpu6000.cpp
@@ -921,24 +921,25 @@ MPU6000::gyro_self_test()
 	if (self_test())
 		return 1;
 
-	/* evaluate gyro offsets, complain if offset -> zero or larger than 6 dps */
-	if (fabsf(_gyro_scale.x_offset) > 0.1f || fabsf(_gyro_scale.x_offset) < 0.000001f)
+	/* evaluate gyro offsets, complain if offset -> zero or larger than 7 dps */
+	if (fabsf(_gyro_scale.x_offset) > 0.12f || fabsf(_gyro_scale.x_offset) < 0.000001f)
 		return 1;
 	if (fabsf(_gyro_scale.x_scale - 1.0f) > 0.3f)
 		return 1;
 
-	if (fabsf(_gyro_scale.y_offset) > 0.1f || fabsf(_gyro_scale.y_offset) < 0.000001f)
+	if (fabsf(_gyro_scale.y_offset) > 0.12f || fabsf(_gyro_scale.y_offset) < 0.000001f)
 		return 1;
 	if (fabsf(_gyro_scale.y_scale - 1.0f) > 0.3f)
 		return 1;
 
-	if (fabsf(_gyro_scale.z_offset) > 0.1f || fabsf(_gyro_scale.z_offset) < 0.000001f)
+	if (fabsf(_gyro_scale.z_offset) > 0.12f || fabsf(_gyro_scale.z_offset) < 0.000001f)
 		return 1;
 	if (fabsf(_gyro_scale.z_scale - 1.0f) > 0.3f)
 		return 1;
 
 	return 0;
 }
+
 
 
 /*


### PR DESCRIPTION
Increased the offset tolerance for gyroscopes to 7 degrees per second (was 6 dps). My Pixhawk had an average gyro offset of 0.114 which made the pre-arm check fail.