### PR TITLE
rc.interface: expand mixer variables

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -13,21 +13,21 @@ then
 
 	if [ $MIXER_AUX == none ]
 	then
-		set MIXER_AUX $MIXER.aux
+		set MIXER_AUX ${MIXER}.aux
 	fi
 
 	# Use the mixer file from the SD-card if it exists
-	if [ -f $SDCARD_MIXERS_PATH/$MIXER.main.mix ]
+	if [ -f ${SDCARD_MIXERS_PATH}/${MIXER}.main.mix ]
 	then
-		set MIXER_FILE $SDCARD_MIXERS_PATH/$MIXER.main.mix
+		set MIXER_FILE ${SDCARD_MIXERS_PATH}/${MIXER}.main.mix
 	# Try out the old convention, for backward compatibility
 	else
 
-		if [ -f $SDCARD_MIXERS_PATH/$MIXER.mix ]
+		if [ -f ${SDCARD_MIXERS_PATH}/${MIXER}.mix ]
 		then
-			set MIXER_FILE $SDCARD_MIXERS_PATH/$MIXER.mix
+			set MIXER_FILE ${SDCARD_MIXERS_PATH}/${MIXER}.mix
 		else
-			set MIXER_FILE /etc/mixers/$MIXER.main.mix
+			set MIXER_FILE /etc/mixers/${MIXER}.main.mix
 		fi
 	fi
 
@@ -104,14 +104,14 @@ then
 
 	set MIXER_AUX_FILE none
 
-	if [ -f $SDCARD_MIXERS_PATH/$MIXER_AUX.mix ]
+	if [ -f ${SDCARD_MIXERS_PATH}/${MIXER_AUX}.mix ]
 	then
-		set MIXER_AUX_FILE $SDCARD_MIXERS_PATH/$MIXER_AUX.mix
+		set MIXER_AUX_FILE ${SDCARD_MIXERS_PATH}/${MIXER_AUX}.mix
 	else
 
-		if [ -f /etc/mixers/$MIXER_AUX.mix ]
+		if [ -f /etc/mixers/${MIXER_AUX}.mix ]
 		then
-			set MIXER_AUX_FILE /etc/mixers/$MIXER_AUX.mix
+			set MIXER_AUX_FILE /etc/mixers/${MIXER_AUX}.mix
 		fi
 	fi
 


### PR DESCRIPTION
@davids5 @LorenzMeier I am not sure if the behavior of nsh/NuttX changed. If I remember correctly we had our own string concatenation implementation and I guess this is now the standard NuttX version.

Fixes #1706 