### PR TITLE
Add a compiler coloring tool to highlight warning and errors in the output

### DIFF
--- a/Tools/make_color.sh
+++ b/Tools/make_color.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# make_color.sh
+# 
+#   Author: Simon Wilks (simon@uaventure.com)
+#
+# A compiler color coder.
+#
+# To invoke this script everytime you run make simply create the alias:
+#
+#     alias make='<your-firmware-directory>/Tools/make_color.sh'
+#
+# Color codes:
+#
+# white        "\033[1,37m"
+# yellow       "\033[1,33m"
+# green        "\033[1,32m"
+# blue         "\033[1,34m"
+# cyan         "\033[1,36m"
+# red          "\033[1,31m"
+# magenta      "\033[1,35m"
+# black        "\033[1,30m"
+# darkwhite    "\033[0,37m"
+# darkyellow   "\033[0,33m"
+# darkgreen    "\033[0,32m"
+# darkblue     "\033[0,34m"
+# darkcyan     "\033[0,36m"
+# darkred      "\033[0,31m"
+# darkmagenta  "\033[0,35m"
+# off          "\033[0,0m"
+#
+OFF="\o033[0m"
+WARN="\o033[1;33m"
+ERROR="\o033[1;31m" 
+INFO="\o033[0;37m"
+
+make ${@} 2>&1 | sed "s/make\[[0-9]\].*/$INFO & $OFF/;s/.*: warning: .*/$WARN & $OFF/;s/.*: error: .*/$ERROR & $OFF/" 


### PR DESCRIPTION
It looks like gcc 4.9 might add color output support but until then here is a simple script that will highlight errors and warnings in the output to help you find it faster.

The easiest way to use it is to create an alias for make for a drop in replacement, for example:
```
alias make='/my_firmware/Tools/make_color.sh'
```