### PR TITLE
Do not wipe out params with SYS_AUTOCONFIG=1

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -122,8 +122,6 @@ then
 	#
 	if param compare SYS_AUTOCONFIG 1
 	then
-		# Wipe out params
-		param reset_nostart
 		set AUTOCNF yes
 	else
 		set AUTOCNF no


### PR DESCRIPTION
Because of the wipe people using qgc to switch their model will loose
all parameters including RC and sensor calibration. The SYS_AUTOCONFIG
param should just make the system configure the relevant parameters for
the new airframe. People who want to wipe the params can use the nsh
command.