### PR TITLE
Sensor IDs

### DIFF
--- a/src/modules/commander/accelerometer_calibration.cpp
+++ b/src/modules/commander/accelerometer_calibration.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2015 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -221,17 +221,17 @@ int do_accel_calibration(int mavlink_fd)
 		accel_scale.z_scale = accel_T_rotated(2, 2);
 
 		/* set parameters */
-		if (param_set(param_find("SENS_ACC_XOFF"), &(accel_scale.x_offset))
-		    || param_set(param_find("SENS_ACC_YOFF"), &(accel_scale.y_offset))
-		    || param_set(param_find("SENS_ACC_ZOFF"), &(accel_scale.z_offset))
-		    || param_set(param_find("SENS_ACC_XSCALE"), &(accel_scale.x_scale))
-		    || param_set(param_find("SENS_ACC_YSCALE"), &(accel_scale.y_scale))
-		    || param_set(param_find("SENS_ACC_ZSCALE"), &(accel_scale.z_scale))) {
+		if (param_set(param_find("CAL_ACC0_XOFF"), &(accel_scale.x_offset))
+		    || param_set(param_find("CAL_ACC0_YOFF"), &(accel_scale.y_offset))
+		    || param_set(param_find("CAL_ACC0_ZOFF"), &(accel_scale.z_offset))
+		    || param_set(param_find("CAL_ACC0_XSCALE"), &(accel_scale.x_scale))
+		    || param_set(param_find("CAL_ACC0_YSCALE"), &(accel_scale.y_scale))
+		    || param_set(param_find("CAL_ACC0_ZSCALE"), &(accel_scale.z_scale))) {
 			mavlink_log_critical(mavlink_fd, CAL_FAILED_SET_PARAMS_MSG);
 			res = ERROR;
 		}
 
-		if (param_set(param_find("SENS_ACC_ID"), &(device_id))) {
+		if (param_set(param_find("CAL_ACC0_ID"), &(device_id))) {
 				res = ERROR;
 		}
 	}

--- a/src/modules/commander/gyro_calibration.cpp
+++ b/src/modules/commander/gyro_calibration.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2013 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2015 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,6 +51,7 @@
 #include <mavlink/mavlink_log.h>
 #include <systemlib/param/param.h>
 #include <systemlib/err.h>
+#include <systemlib/mcu_version.h>
 
 /* oddly, ERROR is not defined for c++ */
 #ifdef ERROR
@@ -79,6 +80,13 @@ int do_gyro_calibration(int mavlink_fd)
 	};
 
 	int res = OK;
+
+	/* store board ID */
+	uint32_t mcu_id[3];
+	mcu_unique_id(&mcu_id[0]);
+
+	/* store last 32bit number - not unique, but unique in a given set */
+	param_set(param_find("CAL_BOARD_ID"), &mcu_id[2]);
 
 	/* reset all offsets to zero and all scales to one */
 	int fd = open(GYRO_DEVICE_PATH, 0);
@@ -149,9 +157,9 @@ int do_gyro_calibration(int mavlink_fd)
 
 	if (res == OK) {
 		/* set offset parameters to new values */
-		if (param_set(param_find("SENS_GYRO_XOFF"), &(gyro_scale.x_offset))
-		    || param_set(param_find("SENS_GYRO_YOFF"), &(gyro_scale.y_offset))
-		    || param_set(param_find("SENS_GYRO_ZOFF"), &(gyro_scale.z_offset))) {
+		if (param_set(param_find("CAL_GYRO0_XOFF"), &(gyro_scale.x_offset))
+		    || param_set(param_find("CAL_GYRO0_YOFF"), &(gyro_scale.y_offset))
+		    || param_set(param_find("CAL_GYRO0_ZOFF"), &(gyro_scale.z_offset))) {
 			mavlink_log_critical(mavlink_fd, "ERROR: failed to set offset params");
 			res = ERROR;
 		}
@@ -275,13 +283,13 @@ int do_gyro_calibration(int mavlink_fd)
 
 	if (res == OK) {
 		/* set scale parameters to new values */
-		if (param_set(param_find("SENS_GYRO_XSCALE"), &(gyro_scale.x_scale))
-		    || param_set(param_find("SENS_GYRO_YSCALE"), &(gyro_scale.y_scale))
-		    || param_set(param_find("SENS_GYRO_ZSCALE"), &(gyro_scale.z_scale))) {
+		if (param_set(param_find("CAL_GYRO0_XSCALE"), &(gyro_scale.x_scale))
+		    || param_set(param_find("CAL_GYRO0_YSCALE"), &(gyro_scale.y_scale))
+		    || param_set(param_find("CAL_GYRO0_ZSCALE"), &(gyro_scale.z_scale))) {
 			mavlink_log_critical(mavlink_fd, "ERROR: failed to set scale params");
 			res = ERROR;
 		}
-		if (param_set(param_find("SENS_GYRO_ID"), &(device_id))) {
+		if (param_set(param_find("CAL_GYRO0_ID"), &(device_id))) {
 				res = ERROR;
 			}
 	}

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2013 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2015 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -263,30 +263,30 @@ int do_mag_calibration(int mavlink_fd)
 
 		if (res == OK) {
 			/* set parameters */
-			if (param_set(param_find("SENS_MAG_ID"), &(device_id))) {
+			if (param_set(param_find("CAL_MAG0_ID"), &(device_id))) {
 				res = ERROR;
 			}
-			if (param_set(param_find("SENS_MAG_XOFF"), &(mscale.x_offset))) {
-				res = ERROR;
-			}
-
-			if (param_set(param_find("SENS_MAG_YOFF"), &(mscale.y_offset))) {
+			if (param_set(param_find("CAL_MAG0_XOFF"), &(mscale.x_offset))) {
 				res = ERROR;
 			}
 
-			if (param_set(param_find("SENS_MAG_ZOFF"), &(mscale.z_offset))) {
+			if (param_set(param_find("CAL_MAG0_YOFF"), &(mscale.y_offset))) {
 				res = ERROR;
 			}
 
-			if (param_set(param_find("SENS_MAG_XSCALE"), &(mscale.x_scale))) {
+			if (param_set(param_find("CAL_MAG0_ZOFF"), &(mscale.z_offset))) {
 				res = ERROR;
 			}
 
-			if (param_set(param_find("SENS_MAG_YSCALE"), &(mscale.y_scale))) {
+			if (param_set(param_find("CAL_MAG0_XSCALE"), &(mscale.x_scale))) {
 				res = ERROR;
 			}
 
-			if (param_set(param_find("SENS_MAG_ZSCALE"), &(mscale.z_scale))) {
+			if (param_set(param_find("CAL_MAG0_YSCALE"), &(mscale.y_scale))) {
+				res = ERROR;
+			}
+
+			if (param_set(param_find("CAL_MAG0_ZSCALE"), &(mscale.z_scale))) {
 				res = ERROR;
 			}
 

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2014 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2015 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,20 +36,27 @@
  *
  * Parameters defined by the sensors task.
  *
- * @author Lorenz Meier <lm@inf.ethz.ch>
- * @author Julian Oes <joes@student.ethz.ch>
- * @author Thomas Gubler <thomasgubler@student.ethz.ch>
+ * @author Lorenz Meier <lorenz@px4.io>
+ * @author Julian Oes <julian@px4.io>
+ * @author Thomas Gubler <thomas@px4.io>
  */
 
 #include <nuttx/config.h>
 #include <systemlib/param/param.h>
 
 /**
+ * ID of the board this parameter set was calibrated on.
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_BOARD_ID, 0);
+
+/**
  * ID of the Gyro that the calibration is for.
  *
  * @group Sensor Calibration
  */
-PARAM_DEFINE_INT32(SENS_GYRO_ID, 0);
+PARAM_DEFINE_INT32(CAL_GYRO0_ID, 0);
 
 /**
  * Gyro X-axis offset
@@ -58,7 +65,7 @@ PARAM_DEFINE_INT32(SENS_GYRO_ID, 0);
  * @max 10.0
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_GYRO_XOFF, 0.0f);
+PARAM_DEFINE_FLOAT(CAL_GYRO0_XOFF, 0.0f);
 
 /**
  * Gyro Y-axis offset
@@ -67,7 +74,7 @@ PARAM_DEFINE_FLOAT(SENS_GYRO_XOFF, 0.0f);
  * @max 10.0
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_GYRO_YOFF, 0.0f);
+PARAM_DEFINE_FLOAT(CAL_GYRO0_YOFF, 0.0f);
 
 /**
  * Gyro Z-axis offset
@@ -76,7 +83,7 @@ PARAM_DEFINE_FLOAT(SENS_GYRO_YOFF, 0.0f);
  * @max 5.0
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_GYRO_ZOFF, 0.0f);
+PARAM_DEFINE_FLOAT(CAL_GYRO0_ZOFF, 0.0f);
 
 /**
  * Gyro X-axis scaling factor
@@ -85,7 +92,7 @@ PARAM_DEFINE_FLOAT(SENS_GYRO_ZOFF, 0.0f);
  * @max 1.5
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_GYRO_XSCALE, 1.0f);
+PARAM_DEFINE_FLOAT(CAL_GYRO0_XSCALE, 1.0f);
 
 /**
  * Gyro Y-axis scaling factor
@@ -94,7 +101,7 @@ PARAM_DEFINE_FLOAT(SENS_GYRO_XSCALE, 1.0f);
  * @max 1.5
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_GYRO_YSCALE, 1.0f);
+PARAM_DEFINE_FLOAT(CAL_GYRO0_YSCALE, 1.0f);
 
 /**
  * Gyro Z-axis scaling factor
@@ -103,14 +110,14 @@ PARAM_DEFINE_FLOAT(SENS_GYRO_YSCALE, 1.0f);
  * @max 1.5
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_GYRO_ZSCALE, 1.0f);
+PARAM_DEFINE_FLOAT(CAL_GYRO0_ZSCALE, 1.0f);
 
 /**
  * ID of Magnetometer the calibration is for.
  *
  * @group Sensor Calibration
  */
-PARAM_DEFINE_INT32(SENS_MAG_ID, 0);
+PARAM_DEFINE_INT32(CAL_MAG0_ID, 0);
 
 /**
  * Magnetometer X-axis offset
@@ -119,7 +126,7 @@ PARAM_DEFINE_INT32(SENS_MAG_ID, 0);
  * @max 500.0
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_MAG_XOFF, 0.0f);
+PARAM_DEFINE_FLOAT(CAL_MAG0_XOFF, 0.0f);
 
 /**
  * Magnetometer Y-axis offset
@@ -128,7 +135,7 @@ PARAM_DEFINE_FLOAT(SENS_MAG_XOFF, 0.0f);
  * @max 500.0
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_MAG_YOFF, 0.0f);
+PARAM_DEFINE_FLOAT(CAL_MAG0_YOFF, 0.0f);
 
 /**
  * Magnetometer Z-axis offset
@@ -137,78 +144,407 @@ PARAM_DEFINE_FLOAT(SENS_MAG_YOFF, 0.0f);
  * @max 500.0
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_MAG_ZOFF, 0.0f);
+PARAM_DEFINE_FLOAT(CAL_MAG0_ZOFF, 0.0f);
 
 /**
  * Magnetometer X-axis scaling factor
  *
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_MAG_XSCALE, 1.0f);
+PARAM_DEFINE_FLOAT(CAL_MAG0_XSCALE, 1.0f);
 
 /**
  * Magnetometer Y-axis scaling factor
  *
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_MAG_YSCALE, 1.0f);
+PARAM_DEFINE_FLOAT(CAL_MAG0_YSCALE, 1.0f);
 
 /**
  * Magnetometer Z-axis scaling factor
  *
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_MAG_ZSCALE, 1.0f);
+PARAM_DEFINE_FLOAT(CAL_MAG0_ZSCALE, 1.0f);
 
 /**
  * ID of the Accelerometer that the calibration is for.
  *
  * @group Sensor Calibration
  */
-PARAM_DEFINE_INT32(SENS_ACC_ID, 0);
+PARAM_DEFINE_INT32(CAL_ACC0_ID, 0);
 
 /**
  * Accelerometer X-axis offset
  *
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_ACC_XOFF, 0.0f);
+PARAM_DEFINE_FLOAT(CAL_ACC0_XOFF, 0.0f);
 
 /**
  * Accelerometer Y-axis offset
  *
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_ACC_YOFF, 0.0f);
+PARAM_DEFINE_FLOAT(CAL_ACC0_YOFF, 0.0f);
 
 /**
  * Accelerometer Z-axis offset
  *
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_ACC_ZOFF, 0.0f);
+PARAM_DEFINE_FLOAT(CAL_ACC0_ZOFF, 0.0f);
 
 /**
  * Accelerometer X-axis scaling factor
  *
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_ACC_XSCALE, 1.0f);
+PARAM_DEFINE_FLOAT(CAL_ACC0_XSCALE, 1.0f);
 
 /**
  * Accelerometer Y-axis scaling factor
  *
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_ACC_YSCALE, 1.0f);
+PARAM_DEFINE_FLOAT(CAL_ACC0_YSCALE, 1.0f);
 
 /**
  * Accelerometer Z-axis scaling factor
  *
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_ACC_ZSCALE, 1.0f);
+PARAM_DEFINE_FLOAT(CAL_ACC0_ZSCALE, 1.0f);
 
+/**
+ * ID of the Gyro that the calibration is for.
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_GYRO1_ID, 0);
+
+/**
+ * Gyro X-axis offset
+ *
+ * @min -10.0
+ * @max 10.0
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO1_XOFF, 0.0f);
+
+/**
+ * Gyro Y-axis offset
+ *
+ * @min -10.0
+ * @max 10.0
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO1_YOFF, 0.0f);
+
+/**
+ * Gyro Z-axis offset
+ *
+ * @min -5.0
+ * @max 5.0
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO1_ZOFF, 0.0f);
+
+/**
+ * Gyro X-axis scaling factor
+ *
+ * @min -1.5
+ * @max 1.5
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO1_XSCALE, 1.0f);
+
+/**
+ * Gyro Y-axis scaling factor
+ *
+ * @min -1.5
+ * @max 1.5
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO1_YSCALE, 1.0f);
+
+/**
+ * Gyro Z-axis scaling factor
+ *
+ * @min -1.5
+ * @max 1.5
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO1_ZSCALE, 1.0f);
+
+/**
+ * ID of Magnetometer the calibration is for.
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_MAG1_ID, 0);
+
+/**
+ * Magnetometer X-axis offset
+ *
+ * @min -500.0
+ * @max 500.0
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG1_XOFF, 0.0f);
+
+/**
+ * Magnetometer Y-axis offset
+ *
+ * @min -500.0
+ * @max 500.0
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG1_YOFF, 0.0f);
+
+/**
+ * Magnetometer Z-axis offset
+ *
+ * @min -500.0
+ * @max 500.0
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG1_ZOFF, 0.0f);
+
+/**
+ * Magnetometer X-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG1_XSCALE, 1.0f);
+
+/**
+ * Magnetometer Y-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG1_YSCALE, 1.0f);
+
+/**
+ * Magnetometer Z-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG1_ZSCALE, 1.0f);
+
+/**
+ * ID of the Accelerometer that the calibration is for.
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_ACC1_ID, 0);
+
+/**
+ * Accelerometer X-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC1_XOFF, 0.0f);
+
+/**
+ * Accelerometer Y-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC1_YOFF, 0.0f);
+
+/**
+ * Accelerometer Z-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC1_ZOFF, 0.0f);
+
+/**
+ * Accelerometer X-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC1_XSCALE, 1.0f);
+
+/**
+ * Accelerometer Y-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC1_YSCALE, 1.0f);
+
+/**
+ * Accelerometer Z-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC1_ZSCALE, 1.0f);
+
+/**
+ * ID of the Gyro that the calibration is for.
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_GYRO2_ID, 0);
+
+/**
+ * Gyro X-axis offset
+ *
+ * @min -10.0
+ * @max 10.0
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO2_XOFF, 0.0f);
+
+/**
+ * Gyro Y-axis offset
+ *
+ * @min -10.0
+ * @max 10.0
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO2_YOFF, 0.0f);
+
+/**
+ * Gyro Z-axis offset
+ *
+ * @min -5.0
+ * @max 5.0
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO2_ZOFF, 0.0f);
+
+/**
+ * Gyro X-axis scaling factor
+ *
+ * @min -1.5
+ * @max 1.5
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO2_XSCALE, 1.0f);
+
+/**
+ * Gyro Y-axis scaling factor
+ *
+ * @min -1.5
+ * @max 1.5
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO2_YSCALE, 1.0f);
+
+/**
+ * Gyro Z-axis scaling factor
+ *
+ * @min -1.5
+ * @max 1.5
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO2_ZSCALE, 1.0f);
+
+/**
+ * ID of Magnetometer the calibration is for.
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_MAG2_ID, 0);
+
+/**
+ * Magnetometer X-axis offset
+ *
+ * @min -500.0
+ * @max 500.0
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG2_XOFF, 0.0f);
+
+/**
+ * Magnetometer Y-axis offset
+ *
+ * @min -500.0
+ * @max 500.0
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG2_YOFF, 0.0f);
+
+/**
+ * Magnetometer Z-axis offset
+ *
+ * @min -500.0
+ * @max 500.0
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG2_ZOFF, 0.0f);
+
+/**
+ * Magnetometer X-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG2_XSCALE, 1.0f);
+
+/**
+ * Magnetometer Y-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG2_YSCALE, 1.0f);
+
+/**
+ * Magnetometer Z-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG2_ZSCALE, 1.0f);
+
+/**
+ * ID of the Accelerometer that the calibration is for.
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_ACC2_ID, 0);
+
+/**
+ * Accelerometer X-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC2_XOFF, 0.0f);
+
+/**
+ * Accelerometer Y-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC2_YOFF, 0.0f);
+
+/**
+ * Accelerometer Z-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC2_ZOFF, 0.0f);
+
+/**
+ * Accelerometer X-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC2_XSCALE, 1.0f);
+
+/**
+ * Accelerometer Y-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC2_YSCALE, 1.0f);
+
+/**
+ * Accelerometer Z-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC2_ZSCALE, 1.0f);
 
 /**
  * Differential pressure sensor offset

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -619,29 +619,29 @@ Sensors::Sensors() :
 	_parameter_handles.rc_offboard_th = param_find("RC_OFFB_TH");
 
 	/* gyro offsets */
-	_parameter_handles.gyro_offset[0] = param_find("SENS_GYRO_XOFF");
-	_parameter_handles.gyro_offset[1] = param_find("SENS_GYRO_YOFF");
-	_parameter_handles.gyro_offset[2] = param_find("SENS_GYRO_ZOFF");
-	_parameter_handles.gyro_scale[0] = param_find("SENS_GYRO_XSCALE");
-	_parameter_handles.gyro_scale[1] = param_find("SENS_GYRO_YSCALE");
-	_parameter_handles.gyro_scale[2] = param_find("SENS_GYRO_ZSCALE");
+	_parameter_handles.gyro_offset[0] = param_find("CAL_GYRO0_XOFF");
+	_parameter_handles.gyro_offset[1] = param_find("CAL_GYRO0_YOFF");
+	_parameter_handles.gyro_offset[2] = param_find("CAL_GYRO0_ZOFF");
+	_parameter_handles.gyro_scale[0] = param_find("CAL_GYRO0_XSCALE");
+	_parameter_handles.gyro_scale[1] = param_find("CAL_GYRO0_YSCALE");
+	_parameter_handles.gyro_scale[2] = param_find("CAL_GYRO0_ZSCALE");
 
 	/* accel offsets */
-	_parameter_handles.accel_offset[0] = param_find("SENS_ACC_XOFF");
-	_parameter_handles.accel_offset[1] = param_find("SENS_ACC_YOFF");
-	_parameter_handles.accel_offset[2] = param_find("SENS_ACC_ZOFF");
-	_parameter_handles.accel_scale[0] = param_find("SENS_ACC_XSCALE");
-	_parameter_handles.accel_scale[1] = param_find("SENS_ACC_YSCALE");
-	_parameter_handles.accel_scale[2] = param_find("SENS_ACC_ZSCALE");
+	_parameter_handles.accel_offset[0] = param_find("CAL_ACC0_XOFF");
+	_parameter_handles.accel_offset[1] = param_find("CAL_ACC0_YOFF");
+	_parameter_handles.accel_offset[2] = param_find("CAL_ACC0_ZOFF");
+	_parameter_handles.accel_scale[0] = param_find("CAL_ACC0_XSCALE");
+	_parameter_handles.accel_scale[1] = param_find("CAL_ACC0_YSCALE");
+	_parameter_handles.accel_scale[2] = param_find("CAL_ACC0_ZSCALE");
 
 	/* mag offsets */
-	_parameter_handles.mag_offset[0] = param_find("SENS_MAG_XOFF");
-	_parameter_handles.mag_offset[1] = param_find("SENS_MAG_YOFF");
-	_parameter_handles.mag_offset[2] = param_find("SENS_MAG_ZOFF");
+	_parameter_handles.mag_offset[0] = param_find("CAL_MAG0_XOFF");
+	_parameter_handles.mag_offset[1] = param_find("CAL_MAG0_YOFF");
+	_parameter_handles.mag_offset[2] = param_find("CAL_MAG0_ZOFF");
 
-	_parameter_handles.mag_scale[0] = param_find("SENS_MAG_XSCALE");
-	_parameter_handles.mag_scale[1] = param_find("SENS_MAG_YSCALE");
-	_parameter_handles.mag_scale[2] = param_find("SENS_MAG_ZSCALE");
+	_parameter_handles.mag_scale[0] = param_find("CAL_MAG0_XSCALE");
+	_parameter_handles.mag_scale[1] = param_find("CAL_MAG0_YSCALE");
+	_parameter_handles.mag_scale[2] = param_find("CAL_MAG0_ZSCALE");
 
 	/* Differential pressure offset */
 	_parameter_handles.diff_pres_offset_pa = param_find("SENS_DPRES_OFF");

--- a/src/modules/systemlib/mcu_version.h
+++ b/src/modules/systemlib/mcu_version.h
@@ -35,6 +35,8 @@
 
 #include <stdint.h>
 
+__BEGIN_DECLS
+
 /* magic numbers from reference manual */
 enum MCU_REV {
 	MCU_REV_STM32F4_REV_A = 0x1000,
@@ -61,3 +63,5 @@ __EXPORT void mcu_unique_id(uint32_t *uid_96_bit);
  * @return The silicon revision / version number as integer
  */
 __EXPORT int mcu_version(char* rev, char** revstr);
+
+__END_DECLS

--- a/src/systemcmds/config/config.c
+++ b/src/systemcmds/config/config.c
@@ -195,7 +195,7 @@ do_gyro(int argc, char *argv[])
 		int id = ioctl(fd, DEVIOCGDEVICEID,0);
 		int32_t calibration_id = 0;
 
-		param_get(param_find("SENS_GYRO_ID"), &(calibration_id));
+		param_get(param_find("CAL_GYRO0_ID"), &(calibration_id));
 
 		warnx("gyro: \n\tdevice id:\t0x%X\t(calibration is for device id 0x%X)\n\tsample rate:\t%d Hz\n\tread rate:\t%d Hz\n\trange:\t%d dps", id, calibration_id, srate, prate, range);
 
@@ -272,7 +272,7 @@ do_mag(int argc, char *argv[])
 		int id = ioctl(fd, DEVIOCGDEVICEID,0);
 		int32_t calibration_id = 0;
 
-		param_get(param_find("SENS_MAG_ID"), &(calibration_id));
+		param_get(param_find("CAL_MAG0_ID"), &(calibration_id));
 
 		warnx("mag: \n\tdevice id:\t0x%X\t(calibration is for device id 0x%X)\n\tsample rate:\t%d Hz\n\tread rate:\t%d Hz\n\trange:\t%d Ga", id, calibration_id, srate, prate, range);
 
@@ -349,7 +349,7 @@ do_accel(int argc, char *argv[])
 		int id = ioctl(fd, DEVIOCGDEVICEID,0);
 		int32_t calibration_id = 0;
 
-		param_get(param_find("SENS_ACC_ID"), &(calibration_id));
+		param_get(param_find("CAL_ACC0_ID"), &(calibration_id));
 
 		warnx("accel: \n\tdevice id:\t0x%X\t(calibration is for device id 0x%X)\n\tsample rate:\t%d Hz\n\tread rate:\t%d Hz\n\trange:\t%d G", id, calibration_id, srate, prate, range);
 

--- a/src/systemcmds/preflight_check/preflight_check.c
+++ b/src/systemcmds/preflight_check/preflight_check.c
@@ -99,7 +99,7 @@ int preflight_check_main(int argc, char *argv[])
 	}
 
 	devid = ioctl(fd, DEVIOCGDEVICEID,0);
-	param_get(param_find("SENS_MAG_ID"), &(calibration_devid));
+	param_get(param_find("CAL_MAG0_ID"), &(calibration_devid));
 	if (devid != calibration_devid){
 		warnx("magnetometer calibration is for a different device - calibrate magnetometer first");
 		mavlink_log_critical(mavlink_fd, "SENSOR FAIL: MAG CAL ID");
@@ -122,7 +122,7 @@ int preflight_check_main(int argc, char *argv[])
 	fd = open(ACCEL_DEVICE_PATH, O_RDONLY);
 
 	devid = ioctl(fd, DEVIOCGDEVICEID,0);
-	param_get(param_find("SENS_ACC_ID"), &(calibration_devid));
+	param_get(param_find("CAL_ACC0_ID"), &(calibration_devid));
 	if (devid != calibration_devid){
 		warnx("accelerometer calibration is for a different device - calibrate accelerometer first");
 		mavlink_log_critical(mavlink_fd, "SENSOR FAIL: ACC CAL ID");
@@ -168,7 +168,7 @@ int preflight_check_main(int argc, char *argv[])
 	fd = open(GYRO_DEVICE_PATH, 0);
 
 	devid = ioctl(fd, DEVIOCGDEVICEID,0);
-	param_get(param_find("SENS_GYRO_ID"), &(calibration_devid));
+	param_get(param_find("CAL_GYRO0_ID"), &(calibration_devid));
 	if (devid != calibration_devid){
 		warnx("gyro calibration is for a different device - calibrate gyro first");
 		mavlink_log_critical(mavlink_fd, "SENSOR FAIL: GYRO CAL ID");


### PR DESCRIPTION
@thomasgubler @sjwilks @AndreasAntener This one should go in quick to mitigate grief. We have introduced sensor IDs on the weekend to handle the "silent failure" issue where sensors could stop work unnoticed or worse, even use another sensor's calibration. However, in order to fail over automatically, we need to calibrate all of our sensors. This rename allows this, as it introduces consistent parameter names for 3 sensor sets.

Because we are enforcing IDs on master already, everybody needs to recalibrate on updating *anyway*. Doing the param rename now allows us to phase in the additional sensors without further forcing users to recalibrate (they need to enable the new sensors though).