### PR TITLE
mc attitude setpoint generation

### DIFF
--- a/msg/vehicle_attitude_setpoint.msg
+++ b/msg/vehicle_attitude_setpoint.msg
@@ -3,7 +3,9 @@ uint64 timestamp				# in microseconds since system start, is set whenever the wr
 
 float32 roll_body				# body angle in NED frame
 float32 pitch_body				# body angle in NED frame
-float32 yaw_body					# body angle in NED frame
+float32 yaw_body				# body angle in NED frame
+
+float32 yaw_sp_move_rate		# rad/s (commanded by user)
 
 float32[9] R_body				# Rotation matrix describing the setpoint as rotation from the current body frame
 bool R_valid					# Set to true if rotation matrix is valid

--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -188,35 +188,6 @@ PARAM_DEFINE_FLOAT(MC_YAW_FF, 0.5f);
 PARAM_DEFINE_FLOAT(MC_YAWRATE_MAX, 120.0f);
 
 /**
- * Max manual roll
- *
- * @unit deg
- * @min 0.0
- * @max 90.0
- * @group Multicopter Attitude Control
- */
-PARAM_DEFINE_FLOAT(MC_MAN_R_MAX, 35.0f);
-
-/**
- * Max manual pitch
- *
- * @unit deg
- * @min 0.0
- * @max 90.0
- * @group Multicopter Attitude Control
- */
-PARAM_DEFINE_FLOAT(MC_MAN_P_MAX, 35.0f);
-
-/**
- * Max manual yaw rate
- *
- * @unit deg/s
- * @min 0.0
- * @group Multicopter Attitude Control
- */
-PARAM_DEFINE_FLOAT(MC_MAN_Y_MAX, 120.0f);
-
-/**
  * Max acro roll rate
  *
  * @unit deg/s

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -208,3 +208,32 @@ PARAM_DEFINE_FLOAT(MPC_TILTMAX_LND, 15.0f);
  */
 PARAM_DEFINE_FLOAT(MPC_LAND_SPEED, 1.0f);
 
+/**
+ * Max manual roll
+ *
+ * @unit deg
+ * @min 0.0
+ * @max 90.0
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_MAN_R_MAX, 35.0f);
+
+/**
+ * Max manual pitch
+ *
+ * @unit deg
+ * @min 0.0
+ * @max 90.0
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_MAN_P_MAX, 35.0f);
+
+/**
+ * Max manual yaw rate
+ *
+ * @unit deg/s
+ * @min 0.0
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_MAN_Y_MAX, 120.0f);
+


### PR DESCRIPTION
Summary:
- mc_att_controller only polls attitude setpoint topic and does control, no more setpoint generation for manual/non-assisted mode
- attitude setpoint is generated in mc_pos_control
- R.is_valid actually becomes obsolete but still in the code