### PR TITLE
Multi sensor interfacing cleanup

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -33,9 +33,9 @@ then
 
 	if [ $OUTPUT_MODE == mkblctrl ]
 	then
-		set OUTPUT_DEV /dev/mkblctrl
+		set OUTPUT_DEV /dev/mkblctrl0
 	else
-		set OUTPUT_DEV /dev/pwm_output
+		set OUTPUT_DEV /dev/pwm_output0
 	fi
 
 	if [ $OUTPUT_MODE == uavcan_esc ]

--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -8,10 +8,12 @@ adc start
 
 if ver hwcmp PX4FMU_V2
 then
+	# External I2C bus
 	if hmc5883 -C -X start
 	then
 	fi
 
+	# Internal I2C bus
 	if hmc5883 -C -I -R 4 start
 	then
 	fi
@@ -38,6 +40,10 @@ then
 
 		# internal MPU6000 is rotated 180 deg roll, 270 deg yaw
 		if mpu6000 -R 14 start
+		then
+		fi
+
+		if hmc5883 -S -R 8 start
 		then
 		fi
 

--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -1,60 +1,89 @@
 #!nsh
 #
-# Standard startup script for PX4FMU onboard sensor drivers.
+# Standard startup script for PX4FMU v1, v2, v3 onboard sensor drivers.
 #
 
 ms5611 start
 adc start
 
-if mpu6000 -X start
+if ver hwcmp PX4FMU_V2
 then
-fi
-
-if mpu6000 start
-then
-fi
-
-if l3gd20 -X start
-then
-fi
-
-if l3gd20 start
-then
-fi
-
-# MAG selection
-if param compare SENS_EXT_MAG 2
-then
-	if hmc5883 -I start
+	if hmc5883 -C -X start
 	then
 	fi
-else
-	# Use only external as primary
-	if param compare SENS_EXT_MAG 1
+
+	if hmc5883 -C -I -R 4 start
 	then
-		if hmc5883 -X start
+	fi
+
+	# external MPU6K is rotated 180 degrees yaw
+	if mpu6000 -X -R 4 start
+	then
+		set BOARD_FMUV3 true
+	else
+		set BOARD_FMUV3 false
+	fi
+
+	if [ $BOARD_FMUV3 == true ]
+	then
+		# external L3GD20H is rotated 180 degrees yaw
+		if l3gd20 -X -R 4 start
+		then
+		fi
+
+		# external LSM303D is rotated 270 degrees yaw
+		if lsm303d -X -R 6 start
+		then
+		fi
+
+		# internal MPU6000 is rotated 180 deg roll, 270 deg yaw
+		if mpu6000 -R 14 start
+		then
+		fi
+
+	else
+		# FMUv2
+		if mpu6000 start
+		then
+		fi
+
+		if l3gd20 start
+		then
+		fi
+
+		if lsm303d start
+		then
+		fi
+	fi
+else
+	# FMUv1
+	if mpu6000 start
+	then
+	fi
+
+	if l3gd20 start
+	then
+	fi
+
+	# MAG selection
+	if param compare SENS_EXT_MAG 2
+	then
+		if hmc5883 -C -I start
 		then
 		fi
 	else
-	# auto-detect the primary, prefer external
-		if hmc5883 start
+		# Use only external as primary
+		if param compare SENS_EXT_MAG 1
 		then
+			if hmc5883 -C -X start
+			then
+			fi
+		else
+		# auto-detect the primary, prefer external
+			if hmc5883 start
+			then
+			fi
 		fi
-	fi
-fi
-
-if ver hwcmp PX4FMU_V2
-then
-	if lsm303d -X start
-	then
-	fi
-
-	if lsm303d start
-	then
-	fi
-
-	if ms5611 -X start
-	then
 	fi
 fi
 

--- a/src/drivers/airspeed/airspeed.cpp
+++ b/src/drivers/airspeed/airspeed.cpp
@@ -106,7 +106,7 @@ Airspeed::~Airspeed()
 	stop();
 
 	if (_class_instance != -1)
-		unregister_class_devname(AIRSPEED_DEVICE_PATH, _class_instance);
+		unregister_class_devname(AIRSPEED_BASE_DEVICE_PATH, _class_instance);
 
 	/* free any existing reports */
 	if (_reports != nullptr)
@@ -133,7 +133,7 @@ Airspeed::init()
 		goto out;
 
 	/* register alternate interfaces if we have to */
-	_class_instance = register_class_devname(AIRSPEED_DEVICE_PATH);
+	_class_instance = register_class_devname(AIRSPEED_BASE_DEVICE_PATH);
 
 	/* publication init */
 	if (_class_instance == CLASS_DEVICE_PRIMARY) {

--- a/src/drivers/blinkm/blinkm.cpp
+++ b/src/drivers/blinkm/blinkm.cpp
@@ -275,7 +275,7 @@ const char *const BlinkM::script_names[] = {
 extern "C" __EXPORT int blinkm_main(int argc, char *argv[]);
 
 BlinkM::BlinkM(int bus, int blinkm) :
-	I2C("blinkm", BLINKM_DEVICE_PATH, bus, blinkm, 100000),
+	I2C("blinkm", BLINKM0_DEVICE_PATH, bus, blinkm, 100000),
 	led_color_1(LED_OFF),
 	led_color_2(LED_OFF),
 	led_color_3(LED_OFF),
@@ -1002,7 +1002,7 @@ blinkm_main(int argc, char *argv[])
 	}
 
 	/* things that require access to the device */
-	int fd = open(BLINKM_DEVICE_PATH, 0);
+	int fd = open(BLINKM0_DEVICE_PATH, 0);
 	if (fd < 0)
 		err(1, "can't open BlinkM device");
 

--- a/src/drivers/device/cdev.cpp
+++ b/src/drivers/device/cdev.cpp
@@ -116,34 +116,30 @@ CDev::register_class_devname(const char *class_devname)
 	if (class_devname == nullptr) {
 		return -EINVAL;
 	}
+
 	int class_instance = 0;
 	int ret = -ENOSPC;
+
 	while (class_instance < 4) {
-		if (class_instance == 0) {
-			ret = register_driver(class_devname, &fops, 0666, (void *)this);
-			if (ret == OK) break;
-		} else {
-			char name[32];
-			snprintf(name, sizeof(name), "%s%d", class_devname, class_instance);
-			ret = register_driver(name, &fops, 0666, (void *)this);
-			if (ret == OK) break;
-		}
+		char name[32];
+		snprintf(name, sizeof(name), "%s%d", class_devname, class_instance);
+		ret = register_driver(name, &fops, 0666, (void *)this);
+		if (ret == OK) break;
 		class_instance++;
 	}
-	if (class_instance == 4)
+
+	if (class_instance == 4) {
 		return ret;
+	}
 	return class_instance;
 }
 
 int
 CDev::unregister_class_devname(const char *class_devname, unsigned class_instance)
 {
-	if (class_instance > 0) {
-		char name[32];
-		snprintf(name, sizeof(name), "%s%u", class_devname, class_instance);
-		return unregister_driver(name);
-	}
-	return unregister_driver(class_devname);
+	char name[32];
+	snprintf(name, sizeof(name), "%s%u", class_devname, class_instance);
+	return unregister_driver(name);
 }
 
 int

--- a/src/drivers/drv_accel.h
+++ b/src/drivers/drv_accel.h
@@ -46,7 +46,10 @@
 #include "drv_sensor.h"
 #include "drv_orb_dev.h"
 
-#define ACCEL_DEVICE_PATH	"/dev/accel"
+#define ACCEL_BASE_DEVICE_PATH	"/dev/accel"
+#define ACCEL0_DEVICE_PATH	"/dev/accel0"
+#define ACCEL1_DEVICE_PATH	"/dev/accel1"
+#define ACCEL2_DEVICE_PATH	"/dev/accel2"
 
 /**
  * accel report structure.  Reads from the device must be in multiples of this

--- a/src/drivers/drv_adc.h
+++ b/src/drivers/drv_adc.h
@@ -45,7 +45,7 @@
 #include <stdint.h>
 #include <sys/ioctl.h>
 
-#define ADC_DEVICE_PATH		"/dev/adc0"
+#define ADC0_DEVICE_PATH	"/dev/adc0"
 
 /*
  * ioctl definitions

--- a/src/drivers/drv_airspeed.h
+++ b/src/drivers/drv_airspeed.h
@@ -48,7 +48,8 @@
 #include "drv_sensor.h"
 #include "drv_orb_dev.h"
 
-#define AIRSPEED_DEVICE_PATH	"/dev/airspeed"
+#define AIRSPEED_BASE_DEVICE_PATH "/dev/airspeed"
+#define AIRSPEED0_DEVICE_PATH	"/dev/airspeed0"
 
 /*
  * ioctl() definitions

--- a/src/drivers/drv_baro.h
+++ b/src/drivers/drv_baro.h
@@ -46,7 +46,8 @@
 #include "drv_sensor.h"
 #include "drv_orb_dev.h"
 
-#define BARO_DEVICE_PATH	"/dev/baro"
+#define BARO_BASE_DEVICE_PATH	"/dev/baro"
+#define BARO0_DEVICE_PATH	"/dev/baro0"
 
 /**
  * baro report structure.  Reads from the device must be in multiples of this

--- a/src/drivers/drv_batt_smbus.h
+++ b/src/drivers/drv_batt_smbus.h
@@ -44,4 +44,4 @@
 #include "drv_orb_dev.h"
 
 /* device path */
-#define BATT_SMBUS_DEVICE_PATH "/dev/batt_smbus"
+#define BATT_SMBUS0_DEVICE_PATH "/dev/batt_smbus0"

--- a/src/drivers/drv_blinkm.h
+++ b/src/drivers/drv_blinkm.h
@@ -45,7 +45,7 @@
 #include <stdint.h>
 #include <sys/ioctl.h>
 
-#define BLINKM_DEVICE_PATH	"/dev/blinkm"
+#define BLINKM0_DEVICE_PATH	"/dev/blinkm0"
 
 /*
  * ioctl() definitions

--- a/src/drivers/drv_gps.h
+++ b/src/drivers/drv_gps.h
@@ -52,7 +52,7 @@
 #define GPS_DEFAULT_UART_PORT "/dev/ttyS3"
 #endif
 
-#define GPS_DEVICE_PATH	"/dev/gps"
+#define GPS0_DEVICE_PATH	"/dev/gps0"
 
 typedef enum {
 	GPS_DRIVER_MODE_NONE = 0,

--- a/src/drivers/drv_gyro.h
+++ b/src/drivers/drv_gyro.h
@@ -46,7 +46,10 @@
 #include "drv_sensor.h"
 #include "drv_orb_dev.h"
 
-#define GYRO_DEVICE_PATH	"/dev/gyro"
+#define GYRO_BASE_DEVICE_PATH	"/dev/gyro"
+#define GYRO0_DEVICE_PATH	"/dev/gyro0"
+#define GYRO1_DEVICE_PATH	"/dev/gyro1"
+#define GYRO2_DEVICE_PATH	"/dev/gyro2"
 
 /**
  * gyro report structure.  Reads from the device must be in multiples of this

--- a/src/drivers/drv_led.h
+++ b/src/drivers/drv_led.h
@@ -42,7 +42,7 @@
 #include <stdint.h>
 #include <sys/ioctl.h>
 
-#define LED_DEVICE_PATH		"/dev/led"
+#define LED0_DEVICE_PATH		"/dev/led0"
 
 #define _LED_BASE		0x2800
 

--- a/src/drivers/drv_mag.h
+++ b/src/drivers/drv_mag.h
@@ -44,8 +44,10 @@
 #include "drv_sensor.h"
 #include "drv_orb_dev.h"
 
-
-#define MAG_DEVICE_PATH		"/dev/mag"
+#define MAG_BASE_DEVICE_PATH	"/dev/mag"
+#define MAG0_DEVICE_PATH	"/dev/mag0"
+#define MAG1_DEVICE_PATH	"/dev/mag0"
+#define MAG2_DEVICE_PATH	"/dev/mag0"
 
 /**
  * mag report structure.  Reads from the device must be in multiples of this

--- a/src/drivers/drv_mixer.h
+++ b/src/drivers/drv_mixer.h
@@ -56,7 +56,7 @@
 #include <stdint.h>
 #include <sys/ioctl.h>
 
-#define MIXER_DEVICE_PATH		"/dev/mixer"
+#define MIXER0_DEVICE_PATH		"/dev/mixer0"
 
 /*
  * ioctl() definitions

--- a/src/drivers/drv_pwm_output.h
+++ b/src/drivers/drv_pwm_output.h
@@ -57,7 +57,8 @@ __BEGIN_DECLS
  * PX4FMU with PX4IO connected) there may be other devices that
  * respond to this protocol.
  */
-#define PWM_OUTPUT_DEVICE_PATH	"/dev/pwm_output"
+#define PWM_OUTPUT_BASE_DEVICE_PATH "dev/pwm_output"
+#define PWM_OUTPUT0_DEVICE_PATH	"/dev/pwm_output0"
 
 /**
  * Maximum number of PWM output channels supported by the device.

--- a/src/drivers/drv_px4flow.h
+++ b/src/drivers/drv_px4flow.h
@@ -44,7 +44,7 @@
 #include "drv_sensor.h"
 #include "drv_orb_dev.h"
 
-#define PX4FLOW_DEVICE_PATH	"/dev/px4flow"
+#define PX4FLOW0_DEVICE_PATH	"/dev/px4flow0"
 
 /*
  * ObjDev tag for px4flow data.

--- a/src/drivers/drv_range_finder.h
+++ b/src/drivers/drv_range_finder.h
@@ -44,7 +44,8 @@
 #include "drv_sensor.h"
 #include "drv_orb_dev.h"
 
-#define RANGE_FINDER_DEVICE_PATH	"/dev/range_finder"
+#define RANGE_FINDER_BASE_DEVICE_PATH	"/dev/range_finder"
+#define RANGE_FINDER0_DEVICE_PATH	"/dev/range_finder0"
 #define MB12XX_MAX_RANGEFINDERS	12	//Maximum number of RangeFinders that can be connected
 
 enum RANGE_FINDER_TYPE {

--- a/src/drivers/drv_rc_input.h
+++ b/src/drivers/drv_rc_input.h
@@ -55,7 +55,7 @@
  * Input data may be obtained by subscribing to the input_rc
  * object, or by poll/reading from the device.
  */
-#define RC_INPUT_DEVICE_PATH	"/dev/input_rc"
+#define RC_INPUT0_DEVICE_PATH	"/dev/input_rc0"
 
 /**
  * Maximum number of R/C input channels in the system. S.Bus has up to 18 channels.

--- a/src/drivers/drv_rgbled.h
+++ b/src/drivers/drv_rgbled.h
@@ -43,7 +43,7 @@
 #include <sys/ioctl.h>
 
 /* more devices will be 1, 2, etc */
-#define RGBLED_DEVICE_PATH "/dev/rgbled0"
+#define RGBLED0_DEVICE_PATH "/dev/rgbled0"
 
 /*
  * ioctl() definitions

--- a/src/drivers/drv_sbus.h
+++ b/src/drivers/drv_sbus.h
@@ -48,7 +48,7 @@
 /**
  * Path for the default S.BUS device
  */
-#define SBUS_DEVICE_PATH	"/dev/sbus"
+#define SBUS0_DEVICE_PATH	"/dev/sbus0"
 
 #define _SBUS_BASE		0x2c00
 

--- a/src/drivers/drv_tone_alarm.h
+++ b/src/drivers/drv_tone_alarm.h
@@ -62,7 +62,7 @@
 
 #include <sys/ioctl.h>
 
-#define TONEALARM_DEVICE_PATH "/dev/tone_alarm"
+#define TONEALARM0_DEVICE_PATH "/dev/tone_alarm0"
 
 #define _TONE_ALARM_BASE	0x7400
 #define TONE_SET_ALARM		_IOC(_TONE_ALARM_BASE, 1)

--- a/src/drivers/ets_airspeed/ets_airspeed.cpp
+++ b/src/drivers/ets_airspeed/ets_airspeed.cpp
@@ -300,7 +300,7 @@ start(int i2c_bus)
 		goto fail;
 
 	/* set the poll rate to default, starts automatic data collection */
-	fd = open(AIRSPEED_DEVICE_PATH, O_RDONLY);
+	fd = open(AIRSPEED0_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0)
 		goto fail;
@@ -349,10 +349,10 @@ test()
 	ssize_t sz;
 	int ret;
 
-	int fd = open(AIRSPEED_DEVICE_PATH, O_RDONLY);
+	int fd = open(ETS_PATH, O_RDONLY);
 
 	if (fd < 0)
-		err(1, "%s open failed (try 'ets_airspeed start' if the driver is not running", AIRSPEED_DEVICE_PATH);
+		err(1, "%s open failed (try 'ets_airspeed start' if the driver is not running", ETS_PATH);
 
 	/* do a simple demand read */
 	sz = read(fd, &report, sizeof(report));
@@ -402,7 +402,7 @@ test()
 void
 reset()
 {
-	int fd = open(AIRSPEED_DEVICE_PATH, O_RDONLY);
+	int fd = open(ETS_PATH, O_RDONLY);
 
 	if (fd < 0)
 		err(1, "failed ");

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -168,7 +168,7 @@ GPS	*g_dev;
 
 
 GPS::GPS(const char *uart_path, bool fake_gps, bool enable_sat_info) :
-	CDev("gps", GPS_DEVICE_PATH),
+	CDev("gps", GPS0_DEVICE_PATH),
 	_task_should_exit(false),
 	_healthy(false),
 	_mode_changed(false),
@@ -549,10 +549,10 @@ start(const char *uart_path, bool fake_gps, bool enable_sat_info)
 		goto fail;
 
 	/* set the poll rate to default, starts automatic data collection */
-	fd = open(GPS_DEVICE_PATH, O_RDONLY);
+	fd = open(GPS0_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
-		errx(1, "open: %s\n", GPS_DEVICE_PATH);
+		errx(1, "open: %s\n", GPS0_DEVICE_PATH);
 		goto fail;
 	}
 
@@ -598,7 +598,7 @@ test()
 void
 reset()
 {
-	int fd = open(GPS_DEVICE_PATH, O_RDONLY);
+	int fd = open(GPS0_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0)
 		err(1, "failed ");

--- a/src/drivers/hil/hil.cpp
+++ b/src/drivers/hil/hil.cpp
@@ -158,7 +158,7 @@ HIL	*g_hil;
 } // namespace
 
 HIL::HIL() :
-	CDev("hilservo", PWM_OUTPUT_DEVICE_PATH/*"/dev/hil" XXXL*/),
+	CDev("hilservo", PWM_OUTPUT0_DEVICE_PATH/*"/dev/hil" XXXL*/),
 	_mode(MODE_NONE),
 	_update_rate(50),
 	_current_update_rate(0),
@@ -751,7 +751,7 @@ test(void)
 {
 	int	fd;
 
-	fd = open(PWM_OUTPUT_DEVICE_PATH, 0);
+	fd = open(PWM_OUTPUT0_DEVICE_PATH, 0);
 
 	if (fd < 0) {
 		puts("open fail");

--- a/src/drivers/hmc5883/hmc5883.cpp
+++ b/src/drivers/hmc5883/hmc5883.cpp
@@ -1355,10 +1355,9 @@ start_bus(struct hmc5883_bus_option &bus, enum Rotation rotation)
 void
 start(enum HMC5883_BUS busid, enum Rotation rotation)
 {
-	uint8_t i;
 	bool started = false;
 
-	for (i=0; i<NUM_BUS_OPTIONS; i++) {
+	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
 		if (busid == HMC5883_BUS_ALL && bus_options[i].dev != NULL) {
 			// this device is already started
 			continue;
@@ -1373,7 +1372,6 @@ start(enum HMC5883_BUS busid, enum Rotation rotation)
 	if (!started)
 		errx(1, "driver start failed");
 
-	// one or more drivers started OK
 	exit(0);
 }
 
@@ -1382,13 +1380,13 @@ start(enum HMC5883_BUS busid, enum Rotation rotation)
  */
 struct hmc5883_bus_option &find_bus(enum HMC5883_BUS busid)
 {
-	for (uint8_t i=0; i<NUM_BUS_OPTIONS; i++) {
+	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
 		if ((busid == HMC5883_BUS_ALL ||
 		     busid == bus_options[i].busid) && bus_options[i].dev != NULL) {
 			return bus_options[i];
 		}
 	}	
-	errx(1,"bus %u not started", (unsigned)busid);
+	errx(1, "bus %u not started", (unsigned)busid);
 }
 
 
@@ -1625,6 +1623,8 @@ hmc5883_main(int argc, char *argv[])
 			} else {
 				errx(1, "calibration failed");
 			}
+		} else {
+			exit(0);
 		}
 	}
 

--- a/src/drivers/hmc5883/hmc5883.cpp
+++ b/src/drivers/hmc5883/hmc5883.cpp
@@ -386,7 +386,7 @@ HMC5883::~HMC5883()
 		delete _reports;
 
 	if (_class_instance != -1)
-		unregister_class_devname(MAG_DEVICE_PATH, _class_instance);
+		unregister_class_devname(MAG_BASE_DEVICE_PATH, _class_instance);
 
 	// free perf counters
 	perf_free(_sample_perf);
@@ -415,7 +415,7 @@ HMC5883::init()
 	/* reset the device configuration */
 	reset();
 
-	_class_instance = register_class_devname(MAG_DEVICE_PATH);
+	_class_instance = register_class_devname(MAG_BASE_DEVICE_PATH);
 
 	ret = OK;
 	/* sensor is ok, but not calibrated */

--- a/src/drivers/l3gd20/l3gd20.cpp
+++ b/src/drivers/l3gd20/l3gd20.cpp
@@ -445,7 +445,7 @@ L3GD20::~L3GD20()
 		delete _reports;
 
 	if (_class_instance != -1)
-		unregister_class_devname(GYRO_DEVICE_PATH, _class_instance);
+		unregister_class_devname(GYRO_BASE_DEVICE_PATH, _class_instance);
 
 	/* delete the perf counter */
 	perf_free(_sample_perf);
@@ -469,7 +469,7 @@ L3GD20::init()
 	if (_reports == nullptr)
 		goto out;
 
-	_class_instance = register_class_devname(GYRO_DEVICE_PATH);
+	_class_instance = register_class_devname(GYRO_BASE_DEVICE_PATH);
 
 	reset();
 

--- a/src/drivers/led/led.cpp
+++ b/src/drivers/led/led.cpp
@@ -66,7 +66,7 @@ public:
 };
 
 LED::LED() :
-	CDev("led", LED_DEVICE_PATH)
+	CDev("led", LED0_DEVICE_PATH)
 {
 	// force immediate init/device registration
 	init();

--- a/src/drivers/ll40ls/ll40ls.cpp
+++ b/src/drivers/ll40ls/ll40ls.cpp
@@ -235,7 +235,7 @@ LL40LS::~LL40LS()
 	}
 
 	if (_class_instance != -1) {
-		unregister_class_devname(RANGE_FINDER_DEVICE_PATH, _class_instance);
+		unregister_class_devname(RANGE_FINDER_BASE_DEVICE_PATH, _class_instance);
 	}
 
 	// free perf counters
@@ -261,7 +261,7 @@ LL40LS::init()
 		goto out;
 	}
 
-	_class_instance = register_class_devname(RANGE_FINDER_DEVICE_PATH);
+	_class_instance = register_class_devname(RANGE_FINDER_BASE_DEVICE_PATH);
 
 	if (_class_instance == CLASS_DEVICE_PRIMARY) {
 		/* get a publish handle on the range finder topic */

--- a/src/drivers/lsm303d/lsm303d.cpp
+++ b/src/drivers/lsm303d/lsm303d.cpp
@@ -609,7 +609,7 @@ LSM303D::~LSM303D()
 		delete _mag_reports;
 
 	if (_accel_class_instance != -1)
-		unregister_class_devname(ACCEL_DEVICE_PATH, _accel_class_instance);
+		unregister_class_devname(ACCEL_BASE_DEVICE_PATH, _accel_class_instance);
 
 	delete _mag;
 
@@ -668,7 +668,7 @@ LSM303D::init()
 	}
 
 
-	_accel_class_instance = register_class_devname(ACCEL_DEVICE_PATH);
+	_accel_class_instance = register_class_devname(ACCEL_BASE_DEVICE_PATH);
 
 	/* advertise sensor topic, measure manually to initialize valid report */
 	struct accel_report arp;
@@ -1745,7 +1745,7 @@ LSM303D_mag::LSM303D_mag(LSM303D *parent) :
 LSM303D_mag::~LSM303D_mag()
 {
 	if (_mag_class_instance != -1)
-		unregister_class_devname(MAG_DEVICE_PATH, _mag_class_instance);
+		unregister_class_devname(MAG_BASE_DEVICE_PATH, _mag_class_instance);
 }
 
 int
@@ -1757,7 +1757,7 @@ LSM303D_mag::init()
 	if (ret != OK)
 		goto out;
 
-	_mag_class_instance = register_class_devname(MAG_DEVICE_PATH);
+	_mag_class_instance = register_class_devname(MAG_BASE_DEVICE_PATH);
 
 out:
 	return ret;

--- a/src/drivers/mb12xx/mb12xx.cpp
+++ b/src/drivers/mb12xx/mb12xx.cpp
@@ -235,7 +235,7 @@ MB12XX::~MB12XX()
 	}
 
 	if (_class_instance != -1) {
-		unregister_class_devname(RANGE_FINDER_DEVICE_PATH, _class_instance);
+		unregister_class_devname(RANGE_FINDER_BASE_DEVICE_PATH, _class_instance);
 	}
 
 	/* free perf counters */
@@ -264,7 +264,7 @@ MB12XX::init()
 		goto out;
 	}
 
-	_class_instance = register_class_devname(RANGE_FINDER_DEVICE_PATH);
+	_class_instance = register_class_devname(RANGE_FINDER_BASE_DEVICE_PATH);
 
 	if (_class_instance == CLASS_DEVICE_PRIMARY) {
 		/* get a publish handle on the range finder topic */

--- a/src/drivers/meas_airspeed/meas_airspeed.cpp
+++ b/src/drivers/meas_airspeed/meas_airspeed.cpp
@@ -437,7 +437,7 @@ start(int i2c_bus)
 	}
 
 	/* set the poll rate to default, starts automatic data collection */
-	fd = open(AIRSPEED_DEVICE_PATH, O_RDONLY);
+	fd = open(PATH_MS4525, O_RDONLY);
 
 	if (fd < 0) {
 		goto fail;
@@ -488,10 +488,10 @@ test()
 	ssize_t sz;
 	int ret;
 
-	int fd = open(AIRSPEED_DEVICE_PATH, O_RDONLY);
+	int fd = open(PATH_MS4525, O_RDONLY);
 
 	if (fd < 0) {
-		err(1, "%s open failed (try 'meas_airspeed start' if the driver is not running", AIRSPEED_DEVICE_PATH);
+		err(1, "%s open failed (try 'meas_airspeed start' if the driver is not running", PATH_MS4525);
 	}
 
 	/* do a simple demand read */
@@ -548,7 +548,7 @@ test()
 void
 reset()
 {
-	int fd = open(AIRSPEED_DEVICE_PATH, O_RDONLY);
+	int fd = open(PATH_MS4525, O_RDONLY);
 
 	if (fd < 0) {
 		err(1, "failed ");

--- a/src/drivers/mpu6000/mpu6000.cpp
+++ b/src/drivers/mpu6000/mpu6000.cpp
@@ -563,7 +563,7 @@ MPU6000::~MPU6000()
 		delete _gyro_reports;
 
 	if (_accel_class_instance != -1)
-		unregister_class_devname(ACCEL_DEVICE_PATH, _accel_class_instance);
+		unregister_class_devname(ACCEL_BASE_DEVICE_PATH, _accel_class_instance);
 
 	/* delete the perf counter */
 	perf_free(_sample_perf);
@@ -624,7 +624,7 @@ MPU6000::init()
 		return ret;
 	}
 
-	_accel_class_instance = register_class_devname(ACCEL_DEVICE_PATH);
+	_accel_class_instance = register_class_devname(ACCEL_BASE_DEVICE_PATH);
 
 	measure();
 
@@ -1824,7 +1824,7 @@ MPU6000_gyro::MPU6000_gyro(MPU6000 *parent, const char *path) :
 MPU6000_gyro::~MPU6000_gyro()
 {
 	if (_gyro_class_instance != -1)
-		unregister_class_devname(GYRO_DEVICE_PATH, _gyro_class_instance);
+		unregister_class_devname(GYRO_BASE_DEVICE_PATH, _gyro_class_instance);
 }
 
 int
@@ -1841,7 +1841,7 @@ MPU6000_gyro::init()
 		return ret;
 	}
 
-	_gyro_class_instance = register_class_devname(GYRO_DEVICE_PATH);
+	_gyro_class_instance = register_class_devname(GYRO_BASE_DEVICE_PATH);
 
 	return ret;
 }

--- a/src/drivers/ms5611/ms5611.cpp
+++ b/src/drivers/ms5611/ms5611.cpp
@@ -278,7 +278,7 @@ MS5611::init()
 	}
 
 	/* register alternate interfaces if we have to */
-	_class_instance = register_class_devname(BARO_DEVICE_PATH);
+	_class_instance = register_class_devname(BARO_BASE_DEVICE_PATH);
 
 	struct baro_report brp;
 	/* do a first measurement cycle to populate reports with valid data */

--- a/src/drivers/px4flow/px4flow.cpp
+++ b/src/drivers/px4flow/px4flow.cpp
@@ -177,7 +177,7 @@ private:
 extern "C" __EXPORT int px4flow_main(int argc, char *argv[]);
 
 PX4FLOW::PX4FLOW(int bus, int address, enum Rotation rotation) :
-	I2C("PX4FLOW", PX4FLOW_DEVICE_PATH, bus, address, PX4FLOW_I2C_MAX_BUS_SPEED), /* 100-400 KHz */
+	I2C("PX4FLOW", PX4FLOW0_DEVICE_PATH, bus, address, PX4FLOW_I2C_MAX_BUS_SPEED), /* 100-400 KHz */
 	_reports(nullptr),
 	_sensor_ok(false),
 	_measure_ticks(0),
@@ -655,7 +655,7 @@ start()
 	}
 
 	/* set the poll rate to default, starts automatic data collection */
-	fd = open(PX4FLOW_DEVICE_PATH, O_RDONLY);
+	fd = open(PX4FLOW0_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		goto fail;
@@ -706,10 +706,10 @@ test()
 	ssize_t sz;
 	int ret;
 
-	int fd = open(PX4FLOW_DEVICE_PATH, O_RDONLY);
+	int fd = open(PX4FLOW0_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
-		err(1, "%s open failed (try 'px4flow start' if the driver is not running", PX4FLOW_DEVICE_PATH);
+		err(1, "%s open failed (try 'px4flow start' if the driver is not running", PX4FLOW0_DEVICE_PATH);
 	}
 
 
@@ -782,7 +782,7 @@ test()
 void
 reset()
 {
-	int fd = open(PX4FLOW_DEVICE_PATH, O_RDONLY);
+	int fd = open(PX4FLOW0_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		err(1, "failed ");

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -306,7 +306,7 @@ PX4FMU::~PX4FMU()
 	}
 
 	/* clean up the alternate device node */
-	unregister_class_devname(PWM_OUTPUT_DEVICE_PATH, _class_instance);
+	unregister_class_devname(PWM_OUTPUT_BASE_DEVICE_PATH, _class_instance);
 
 	g_fmu = nullptr;
 }
@@ -325,7 +325,7 @@ PX4FMU::init()
 		return ret;
 
 	/* try to claim the generic PWM output device node as well - it's OK if we fail at this */
-	_class_instance = register_class_devname(PWM_OUTPUT_DEVICE_PATH);
+	_class_instance = register_class_devname(PWM_OUTPUT_BASE_DEVICE_PATH);
 
 	if (_class_instance == CLASS_DEVICE_PRIMARY) {
 		log("default PWM output device");

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -830,7 +830,7 @@ PX4IO::init()
 	}
 
 	/* try to claim the generic PWM output device node as well - it's OK if we fail at this */
-	ret = register_driver(PWM_OUTPUT_DEVICE_PATH, &fops, 0666, (void *)this);
+	ret = register_driver(PWM_OUTPUT0_DEVICE_PATH, &fops, 0666, (void *)this);
 
 	if (ret == OK) {
 		log("default PWM output device");
@@ -1080,7 +1080,7 @@ out:
 
 	/* clean up the alternate device node */
 	if (_primary_pwm_device)
-		unregister_driver(PWM_OUTPUT_DEVICE_PATH);
+		unregister_driver(PWM_OUTPUT0_DEVICE_PATH);
 
 	/* tell the dtor that we are exiting */
 	_task = -1;

--- a/src/drivers/rgbled/rgbled.cpp
+++ b/src/drivers/rgbled/rgbled.cpp
@@ -129,7 +129,7 @@ void rgbled_usage();
 extern "C" __EXPORT int rgbled_main(int argc, char *argv[]);
 
 RGBLED::RGBLED(int bus, int rgbled) :
-	I2C("rgbled", RGBLED_DEVICE_PATH, bus, rgbled, 100000),
+	I2C("rgbled", RGBLED0_DEVICE_PATH, bus, rgbled, 100000),
 	_mode(RGBLED_MODE_OFF),
 	_r(0),
 	_g(0),
@@ -649,10 +649,10 @@ rgbled_main(int argc, char *argv[])
 	}
 
 	if (!strcmp(verb, "test")) {
-		fd = open(RGBLED_DEVICE_PATH, 0);
+		fd = open(RGBLED0_DEVICE_PATH, 0);
 
 		if (fd == -1) {
-			errx(1, "Unable to open " RGBLED_DEVICE_PATH);
+			errx(1, "Unable to open " RGBLED0_DEVICE_PATH);
 		}
 
 		rgbled_pattern_t pattern = { {RGBLED_COLOR_RED, RGBLED_COLOR_GREEN, RGBLED_COLOR_BLUE, RGBLED_COLOR_WHITE, RGBLED_COLOR_OFF, RGBLED_COLOR_OFF},
@@ -672,10 +672,10 @@ rgbled_main(int argc, char *argv[])
 	}
 
 	if (!strcmp(verb, "off") || !strcmp(verb, "stop")) {
-		fd = open(RGBLED_DEVICE_PATH, 0);
+		fd = open(RGBLED0_DEVICE_PATH, 0);
 
 		if (fd == -1) {
-			errx(1, "Unable to open " RGBLED_DEVICE_PATH);
+			errx(1, "Unable to open " RGBLED0_DEVICE_PATH);
 		}
 
 		ret = ioctl(fd, RGBLED_SET_MODE, (unsigned long)RGBLED_MODE_OFF);
@@ -694,10 +694,10 @@ rgbled_main(int argc, char *argv[])
 			errx(1, "Usage: rgbled rgb <red> <green> <blue>");
 		}
 
-		fd = open(RGBLED_DEVICE_PATH, 0);
+		fd = open(RGBLED0_DEVICE_PATH, 0);
 
 		if (fd == -1) {
-			errx(1, "Unable to open " RGBLED_DEVICE_PATH);
+			errx(1, "Unable to open " RGBLED0_DEVICE_PATH);
 		}
 
 		rgbled_rgbset_t v;

--- a/src/drivers/sf0x/sf0x.cpp
+++ b/src/drivers/sf0x/sf0x.cpp
@@ -182,7 +182,7 @@ private:
 extern "C" __EXPORT int sf0x_main(int argc, char *argv[]);
 
 SF0X::SF0X(const char *port) :
-	CDev("SF0X", RANGE_FINDER_DEVICE_PATH),
+	CDev("SF0X", RANGE_FINDER0_DEVICE_PATH),
 	_min_distance(SF02F_MIN_DISTANCE),
 	_max_distance(SF02F_MAX_DISTANCE),
 	_reports(nullptr),
@@ -757,7 +757,7 @@ start(const char *port)
 	}
 
 	/* set the poll rate to default, starts automatic data collection */
-	fd = open(RANGE_FINDER_DEVICE_PATH, 0);
+	fd = open(RANGE_FINDER0_DEVICE_PATH, 0);
 
 	if (fd < 0) {
 		warnx("device open fail");
@@ -807,10 +807,10 @@ test()
 	struct range_finder_report report;
 	ssize_t sz;
 
-	int fd = open(RANGE_FINDER_DEVICE_PATH, O_RDONLY);
+	int fd = open(RANGE_FINDER0_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
-		err(1, "%s open failed (try 'sf0x start' if the driver is not running", RANGE_FINDER_DEVICE_PATH);
+		err(1, "%s open failed (try 'sf0x start' if the driver is not running", RANGE_FINDER0_DEVICE_PATH);
 	}
 
 	/* do a simple demand read */
@@ -870,7 +870,7 @@ test()
 void
 reset()
 {
-	int fd = open(RANGE_FINDER_DEVICE_PATH, O_RDONLY);
+	int fd = open(RANGE_FINDER0_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		err(1, "failed ");

--- a/src/drivers/stm32/adc/adc.cpp
+++ b/src/drivers/stm32/adc/adc.cpp
@@ -144,7 +144,7 @@ private:
 };
 
 ADC::ADC(uint32_t channels) :
-	CDev("adc", ADC_DEVICE_PATH),
+	CDev("adc", ADC0_DEVICE_PATH),
 	_sample_perf(perf_alloc(PC_ELAPSED, "adc_samples")),
 	_channel_count(0),
 	_samples(nullptr),
@@ -381,7 +381,7 @@ void
 test(void)
 {
 
-	int fd = open(ADC_DEVICE_PATH, O_RDONLY);
+	int fd = open(ADC0_DEVICE_PATH, O_RDONLY);
 	if (fd < 0)
 		err(1, "can't open ADC device");
 

--- a/src/drivers/stm32/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/stm32/tone_alarm/tone_alarm.cpp
@@ -317,7 +317,7 @@ extern "C" __EXPORT int tone_alarm_main(int argc, char *argv[]);
 
 
 ToneAlarm::ToneAlarm() :
-	CDev("tone_alarm", TONEALARM_DEVICE_PATH),
+	CDev("tone_alarm", TONEALARM0_DEVICE_PATH),
 	_default_tune_number(0),
 	_user_tune(nullptr),
 	_tune(nullptr),
@@ -830,10 +830,10 @@ play_tune(unsigned tune)
 {
 	int	fd, ret;
 
-	fd = open(TONEALARM_DEVICE_PATH, 0);
+	fd = open(TONEALARM0_DEVICE_PATH, 0);
 
 	if (fd < 0)
-		err(1, TONEALARM_DEVICE_PATH);
+		err(1, TONEALARM0_DEVICE_PATH);
 
 	ret = ioctl(fd, TONE_SET_ALARM, tune);
 	close(fd);
@@ -849,10 +849,10 @@ play_string(const char *str, bool free_buffer)
 {
 	int	fd, ret;
 
-	fd = open(TONEALARM_DEVICE_PATH, O_WRONLY);
+	fd = open(TONEALARM0_DEVICE_PATH, O_WRONLY);
 
 	if (fd < 0)
-		err(1, TONEALARM_DEVICE_PATH);
+		err(1, TONEALARM0_DEVICE_PATH);
 
 	ret = write(fd, str, strlen(str) + 1);
 	close(fd);

--- a/src/drivers/trone/trone.cpp
+++ b/src/drivers/trone/trone.cpp
@@ -258,7 +258,7 @@ TRONE::~TRONE()
 	}
 
 	if (_class_instance != -1) {
-		unregister_class_devname(RANGE_FINDER_DEVICE_PATH, _class_instance);
+		unregister_class_devname(RANGE_FINDER_BASE_DEVICE_PATH, _class_instance);
 	}
 
 	// free perf counters
@@ -284,7 +284,7 @@ TRONE::init()
 		goto out;
 	}
 
-	_class_instance = register_class_devname(RANGE_FINDER_DEVICE_PATH);
+	_class_instance = register_class_devname(RANGE_FINDER_BASE_DEVICE_PATH);
 
 	if (_class_instance == CLASS_DEVICE_PRIMARY) {
 		/* get a publish handle on the range finder topic */

--- a/src/modules/commander/airspeed_calibration.cpp
+++ b/src/modules/commander/airspeed_calibration.cpp
@@ -89,7 +89,7 @@ int do_airspeed_calibration(int mavlink_fd)
 	};
 
 	bool paramreset_successful = false;
-	int  fd = open(AIRSPEED_DEVICE_PATH, 0);
+	int  fd = open(AIRSPEED0_DEVICE_PATH, 0);
 
 	if (fd > 0) {
 		if (OK == ioctl(fd, AIRSPEEDIOCSSCALE, (long unsigned int)&airscale)) {
@@ -157,7 +157,7 @@ int do_airspeed_calibration(int mavlink_fd)
 
 	if (isfinite(diff_pres_offset)) {
 
-		int  fd_scale = open(AIRSPEED_DEVICE_PATH, 0);
+		int  fd_scale = open(AIRSPEED0_DEVICE_PATH, 0);
 		airscale.offset_pa = diff_pres_offset;
 		if (fd_scale > 0) {
 			if (OK != ioctl(fd_scale, AIRSPEEDIOCSSCALE, (long unsigned int)&airscale)) {

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2013-2014 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2015 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,7 +36,7 @@
  * Main fail-safe handling.
  *
  * @author Petri Tanskanen <petri.tanskanen@inf.ethz.ch>
- * @author Lorenz Meier <lm@inf.ethz.ch>
+ * @author Lorenz Meier <lorenz@px4.io>
  * @author Thomas Gubler <thomasgubler@student.ethz.ch>
  * @author Julian Oes <julian@oes.ch>
  * @author Anton Babushkin <anton.babushkin@me.com>
@@ -318,6 +318,29 @@ int commander_main(int argc, char *argv[])
 		exit(0);
 	}
 
+	if (!strcmp(argv[1], "calibrate")) {
+		if (argc > 2) {
+			int calib_ret = OK;
+			if (!strcmp(argv[2], "mag")) {
+				calib_ret = do_mag_calibration(mavlink_fd);
+			} else if (!strcmp(argv[2], "accel")) {
+				calib_ret = do_accel_calibration(mavlink_fd);
+			} else if (!strcmp(argv[2], "gyro")) {
+				calib_ret = do_gyro_calibration(mavlink_fd);
+			} else {
+				warnx("argument %s unsupported.", argv[2]);
+			}
+
+			if (calib_ret) {
+				errx(1, "calibration failed, exiting.");
+			} else {
+				exit(0);
+			}
+		} else {
+			warnx("missing argument");
+		}
+	}
+
 	if (!strcmp(argv[1], "check")) {
 		int mavlink_fd_local = open(MAVLINK_LOG_DEVICE, 0);
 		int checkres = prearm_check(&status, mavlink_fd_local);
@@ -350,7 +373,7 @@ void usage(const char *reason)
 		fprintf(stderr, "%s\n", reason);
 	}
 
-	fprintf(stderr, "usage: daemon {start|stop|status} [-p <additional params>]\n\n");
+	fprintf(stderr, "usage: commander {start|stop|status|calibrate|check|arm|disarm}\n\n");
 	exit(1);
 }
 

--- a/src/modules/commander/commander_helper.cpp
+++ b/src/modules/commander/commander_helper.cpp
@@ -100,7 +100,7 @@ int buzzer_init()
 	tune_durations[TONE_NOTIFY_NEUTRAL_TUNE] = 500000;
 	tune_durations[TONE_ARMING_WARNING_TUNE] = 3000000;
 
-	buzzer = open(TONEALARM_DEVICE_PATH, O_WRONLY);
+	buzzer = open(TONEALARM0_DEVICE_PATH, O_WRONLY);
 
 	if (buzzer < 0) {
 		warnx("Buzzer: open fail\n");
@@ -201,7 +201,7 @@ int led_init()
 	blink_msg_end = 0;
 
 	/* first open normal LEDs */
-	leds = open(LED_DEVICE_PATH, 0);
+	leds = open(LED0_DEVICE_PATH, 0);
 
 	if (leds < 0) {
 		warnx("LED: open fail\n");
@@ -224,10 +224,10 @@ int led_init()
 	led_off(LED_AMBER);
 
 	/* then try RGB LEDs, this can fail on FMUv1*/
-	rgbleds = open(RGBLED_DEVICE_PATH, 0);
+	rgbleds = open(RGBLED0_DEVICE_PATH, 0);
 
 	if (rgbleds == -1) {
-		warnx("No RGB LED found at " RGBLED_DEVICE_PATH);
+		warnx("No RGB LED found at " RGBLED0_DEVICE_PATH);
 	}
 
 	return 0;

--- a/src/modules/commander/gyro_calibration.cpp
+++ b/src/modules/commander/gyro_calibration.cpp
@@ -45,6 +45,7 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <math.h>
+#include <string.h>
 #include <drivers/drv_hrt.h>
 #include <uORB/topics/sensor_combined.h>
 #include <drivers/drv_gyro.h>
@@ -63,20 +64,23 @@ static const char *sensor_name = "gyro";
 
 int do_gyro_calibration(int mavlink_fd)
 {
-	int32_t device_id;
+	const unsigned max_gyros = 3;
+
+	int32_t device_id[3];
 	mavlink_log_info(mavlink_fd, CAL_STARTED_MSG, sensor_name);
 	mavlink_log_info(mavlink_fd, "HOLD STILL");
 
 	/* wait for the user to respond */
 	sleep(2);
 
-	struct gyro_scale gyro_scale = {
+	struct gyro_scale gyro_scale[max_gyros] = { {
 		0.0f,
 		1.0f,
 		0.0f,
 		1.0f,
 		0.0f,
 		1.0f,
+	}
 	};
 
 	int res = OK;
@@ -86,47 +90,75 @@ int do_gyro_calibration(int mavlink_fd)
 	mcu_unique_id(&mcu_id[0]);
 
 	/* store last 32bit number - not unique, but unique in a given set */
-	param_set(param_find("CAL_BOARD_ID"), &mcu_id[2]);
+	(void)param_set(param_find("CAL_BOARD_ID"), &mcu_id[2]);
 
-	/* reset all offsets to zero and all scales to one */
-	int fd = open(GYRO_DEVICE_PATH, 0);
+	char str[30];
 
-	device_id = ioctl(fd, DEVIOCGDEVICEID, 0);
+	for (unsigned s = 0; s < max_gyros; s++) {
 
-	res = ioctl(fd, GYROIOCSSCALE, (long unsigned int)&gyro_scale);
-	close(fd);
+		/* ensure all scale fields are initialized tha same as the first struct */
+		(void)memcpy(&gyro_scale[s], &gyro_scale[0], sizeof(gyro_scale[0]));
 
-	if (res != OK) {
-		mavlink_log_critical(mavlink_fd, CAL_FAILED_RESET_CAL_MSG);
+		sprintf(str, "%s%u", GYRO_BASE_DEVICE_PATH, s);
+		/* reset all offsets to zero and all scales to one */
+		int fd = open(str, 0);
+
+		if (fd < 0) {
+			continue;
+		}
+
+		device_id[s] = ioctl(fd, DEVIOCGDEVICEID, 0);
+
+		res = ioctl(fd, GYROIOCSSCALE, (long unsigned int)&gyro_scale);
+		close(fd);
+
+		if (res != OK) {
+			mavlink_log_critical(mavlink_fd, CAL_FAILED_RESET_CAL_MSG);
+		}
 	}
+
+	unsigned calibration_counter[max_gyros] = { 0 };
+	const unsigned calibration_count = 5000;
 
 	if (res == OK) {
 		/* determine gyro mean values */
-		const unsigned calibration_count = 5000;
-		unsigned calibration_counter = 0;
 		unsigned poll_errcount = 0;
 
 		/* subscribe to gyro sensor topic */
-		int sub_sensor_gyro = orb_subscribe_multi(ORB_ID(sensor_gyro), 0);
+		int sub_sensor_gyro[max_gyros];
+		struct pollfd fds[max_gyros];
+
+		for (unsigned s = 0; s < max_gyros; s++) {
+			sub_sensor_gyro[s] = orb_subscribe_multi(ORB_ID(sensor_gyro), s);
+			fds[s].fd = sub_sensor_gyro[s];
+			fds[s].events = POLLIN;
+		}
+
 		struct gyro_report gyro_report;
 
-		while (calibration_counter < calibration_count) {
+		/* use first gyro to pace, but count correctly per-gyro for statistics */
+		while (calibration_counter[0] < calibration_count) {
 			/* wait blocking for new data */
-			struct pollfd fds[1];
-			fds[0].fd = sub_sensor_gyro;
-			fds[0].events = POLLIN;
 
 			int poll_ret = poll(fds, 1, 1000);
 
 			if (poll_ret > 0) {
-				orb_copy(ORB_ID(sensor_gyro), sub_sensor_gyro, &gyro_report);
-				gyro_scale.x_offset += gyro_report.x;
-				gyro_scale.y_offset += gyro_report.y;
-				gyro_scale.z_offset += gyro_report.z;
-				calibration_counter++;
 
-				if (calibration_counter % (calibration_count / 20) == 0) {
-					mavlink_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, (calibration_counter * 100) / calibration_count);
+				for (unsigned s = 0; s < max_gyros; s++) {
+					bool changed;
+					orb_check(sub_sensor_gyro[s], &changed);
+
+					if (changed) {
+						orb_copy(ORB_ID(sensor_gyro), sub_sensor_gyro[s], &gyro_report);
+						gyro_scale[s].x_offset += gyro_report.x;
+						gyro_scale[s].y_offset += gyro_report.y;
+						gyro_scale[s].z_offset += gyro_report.z;
+						calibration_counter[s]++;
+					}
+
+					if (s == 0 && calibration_counter[0] % (calibration_count / 20) == 0) {
+						mavlink_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, (calibration_counter[0] * 100) / calibration_count);
+					}
 				}
 
 			} else {
@@ -140,16 +172,18 @@ int do_gyro_calibration(int mavlink_fd)
 			}
 		}
 
-		close(sub_sensor_gyro);
+		for (unsigned s = 0; s < max_gyros; s++) {
+			close(sub_sensor_gyro[s]);
 
-		gyro_scale.x_offset /= calibration_count;
-		gyro_scale.y_offset /= calibration_count;
-		gyro_scale.z_offset /= calibration_count;
+			gyro_scale[s].x_offset /= calibration_counter[s];
+			gyro_scale[s].y_offset /= calibration_counter[s];
+			gyro_scale[s].z_offset /= calibration_counter[s];
+		}
 	}
 
 	if (res == OK) {
 		/* check offsets */
-		if (!isfinite(gyro_scale.x_offset) || !isfinite(gyro_scale.y_offset) || !isfinite(gyro_scale.z_offset)) {
+		if (!isfinite(gyro_scale[0].x_offset) || !isfinite(gyro_scale[0].y_offset) || !isfinite(gyro_scale[0].z_offset)) {
 			mavlink_log_critical(mavlink_fd, "ERROR: offset is NaN");
 			res = ERROR;
 		}
@@ -157,9 +191,41 @@ int do_gyro_calibration(int mavlink_fd)
 
 	if (res == OK) {
 		/* set offset parameters to new values */
-		if (param_set(param_find("CAL_GYRO0_XOFF"), &(gyro_scale.x_offset))
-		    || param_set(param_find("CAL_GYRO0_YOFF"), &(gyro_scale.y_offset))
-		    || param_set(param_find("CAL_GYRO0_ZOFF"), &(gyro_scale.z_offset))) {
+		bool failed = false;
+
+		for (unsigned s = 0; s < max_gyros; s++) {
+
+			/* if any reasonable amount of data is missing, skip */
+			if (calibration_counter[s] < calibration_count / 2) {
+				continue;
+			}
+
+			(void)sprintf(str, "CAL_GYRO%u_XOFF", s);
+			failed |= (OK != param_set(param_find(str), &(gyro_scale[s].x_offset)));
+			(void)sprintf(str, "CAL_GYRO%u_YOFF", s);
+			failed |= (OK != param_set(param_find(str), &(gyro_scale[s].y_offset)));
+			(void)sprintf(str, "CAL_GYRO%u_ZOFF", s);
+			failed |= (OK != param_set(param_find(str), &(gyro_scale[s].z_offset)));
+			(void)sprintf(str, "CAL_GYRO%u_ID", s);
+			failed |= (OK != param_set(param_find(str), &(device_id[s])));
+
+			/* apply new scaling and offsets */
+			(void)sprintf(str, "%s%u", GYRO_BASE_DEVICE_PATH, s);
+			int fd = open(str, 0);
+
+			if (fd < 0) {
+				continue;
+			}
+
+			res = ioctl(fd, GYROIOCSSCALE, (long unsigned int)&gyro_scale[s]);
+			close(fd);
+
+			if (res != OK) {
+				mavlink_log_critical(mavlink_fd, CAL_FAILED_APPLY_CAL_MSG);
+			}
+		}
+		
+		if (failed) {
 			mavlink_log_critical(mavlink_fd, "ERROR: failed to set offset params");
 			res = ERROR;
 		}
@@ -279,8 +345,6 @@ int do_gyro_calibration(int mavlink_fd)
 	mavlink_log_info(mavlink_fd, "gyro scale calibration done");
 	tune_neutral();
 
-#endif
-
 	if (res == OK) {
 		/* set scale parameters to new values */
 		if (param_set(param_find("CAL_GYRO0_XSCALE"), &(gyro_scale.x_scale))
@@ -289,21 +353,9 @@ int do_gyro_calibration(int mavlink_fd)
 			mavlink_log_critical(mavlink_fd, "ERROR: failed to set scale params");
 			res = ERROR;
 		}
-		if (param_set(param_find("CAL_GYRO0_ID"), &(device_id))) {
-				res = ERROR;
-			}
 	}
 
-	if (res == OK) {
-		/* apply new scaling and offsets */
-		fd = open(GYRO_DEVICE_PATH, 0);
-		res = ioctl(fd, GYROIOCSSCALE, (long unsigned int)&gyro_scale);
-		close(fd);
-
-		if (res != OK) {
-			mavlink_log_critical(mavlink_fd, CAL_FAILED_APPLY_CAL_MSG);
-		}
-	}
+	#endif
 
 	if (res == OK) {
 		/* auto-save to EEPROM */

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -70,7 +70,7 @@ int do_mag_calibration(int mavlink_fd)
 	const unsigned max_mags = 3;
 
 	int32_t device_id[max_mags];
-	mavlink_log_info(mavlink_fd, CAL_STARTED_MSG, sensor_name);
+	mavlink_and_console_log_info(mavlink_fd, CAL_STARTED_MSG, sensor_name);
 	sleep(1);
 
 	struct mag_scale mscale_null[max_mags] = {
@@ -100,7 +100,7 @@ int do_mag_calibration(int mavlink_fd)
 			continue;
 		}
 
-		mavlink_log_info(mavlink_fd, "Calibrating magnetometer #%u..", s);
+		mavlink_and_console_log_info(mavlink_fd, "Calibrating magnetometer #%u..", s);
 		sleep(3);
 
 		device_id[s] = ioctl(fd, DEVIOCGDEVICEID, 0);
@@ -111,7 +111,7 @@ int do_mag_calibration(int mavlink_fd)
 		res = ioctl(fd, MAGIOCSSCALE, (long unsigned int)&mscale_null[s]);
 
 		if (res != OK) {
-			mavlink_log_critical(mavlink_fd, CAL_FAILED_RESET_CAL_MSG);
+			mavlink_and_console_log_critical(mavlink_fd, CAL_FAILED_RESET_CAL_MSG);
 		}
 
 		if (res == OK) {
@@ -119,7 +119,7 @@ int do_mag_calibration(int mavlink_fd)
 			res = ioctl(fd, MAGIOCCALIBRATE, fd);
 
 			if (res != OK) {
-				mavlink_log_info(mavlink_fd, "Skipped scale calibration");
+				mavlink_and_console_log_info(mavlink_fd, "Skipped scale calibration");
 				/* this is non-fatal - mark it accordingly */
 				res = OK;
 			}
@@ -137,7 +137,7 @@ int do_mag_calibration(int mavlink_fd)
 	}
 
 	if (calibrated_ok) {
-		mavlink_log_info(mavlink_fd, CAL_DONE_MSG, sensor_name);
+		mavlink_and_console_log_info(mavlink_fd, CAL_DONE_MSG, sensor_name);
 
 		/* auto-save to EEPROM */
 		res = param_save_default();
@@ -169,14 +169,14 @@ int calibrate_instance(int mavlink_fd, unsigned s, unsigned device_id)
 	int res = OK;
 	
 	/* allocate memory */
-	mavlink_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 20);
+	mavlink_and_console_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 20);
 
 	x = reinterpret_cast<float *>(malloc(sizeof(float) * calibration_maxcount));
 	y = reinterpret_cast<float *>(malloc(sizeof(float) * calibration_maxcount));
 	z = reinterpret_cast<float *>(malloc(sizeof(float) * calibration_maxcount));
 
 	if (x == NULL || y == NULL || z == NULL) {
-		mavlink_log_critical(mavlink_fd, "ERROR: out of memory");
+		mavlink_and_console_log_critical(mavlink_fd, "ERROR: out of memory");
 
 		/* clean up */
 		if (x != NULL) {
@@ -199,7 +199,7 @@ int calibrate_instance(int mavlink_fd, unsigned s, unsigned device_id)
 		int sub_mag = orb_subscribe_multi(ORB_ID(sensor_mag), s);
 
 		if (sub_mag < 0) {
-			mavlink_log_critical(mavlink_fd, "No mag found, abort");
+			mavlink_and_console_log_critical(mavlink_fd, "No mag found, abort");
 			res = ERROR;
 		}  else {
 			struct mag_report mag;
@@ -211,7 +211,7 @@ int calibrate_instance(int mavlink_fd, unsigned s, unsigned device_id)
 			uint64_t calibration_deadline = hrt_absolute_time() + calibration_interval;
 			unsigned poll_errcount = 0;
 
-			mavlink_log_info(mavlink_fd, "Turn on all sides: front/back,left/right,up/down");
+			mavlink_and_console_log_info(mavlink_fd, "Turn on all sides: front/back,left/right,up/down");
 
 			calibration_counter = 0U;
 
@@ -235,7 +235,7 @@ int calibrate_instance(int mavlink_fd, unsigned s, unsigned device_id)
 					calibration_counter++;
 
 					if (calibration_counter % (calibration_maxcount / 20) == 0) {
-						mavlink_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 20 + (calibration_counter * 50) / calibration_maxcount);
+						mavlink_and_console_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 20 + (calibration_counter * 50) / calibration_maxcount);
 					}
 
 				} else {
@@ -243,7 +243,7 @@ int calibrate_instance(int mavlink_fd, unsigned s, unsigned device_id)
 				}
 
 				if (poll_errcount > 1000) {
-					mavlink_log_critical(mavlink_fd, CAL_FAILED_SENSOR_MSG);
+					mavlink_and_console_log_critical(mavlink_fd, CAL_FAILED_SENSOR_MSG);
 					res = ERROR;
 					break;
 				}
@@ -261,12 +261,12 @@ int calibrate_instance(int mavlink_fd, unsigned s, unsigned device_id)
 	if (res == OK && calibration_counter > (calibration_maxcount / 2)) {
 
 		/* sphere fit */
-		mavlink_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 70);
+		mavlink_and_console_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 70);
 		sphere_fit_least_squares(x, y, z, calibration_counter, 100, 0.0f, &sphere_x, &sphere_y, &sphere_z, &sphere_radius);
-		mavlink_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 80);
+		mavlink_and_console_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 80);
 
 		if (!isfinite(sphere_x) || !isfinite(sphere_y) || !isfinite(sphere_z)) {
-			mavlink_log_critical(mavlink_fd, "ERROR: NaN in sphere fit");
+			mavlink_and_console_log_critical(mavlink_fd, "ERROR: NaN in sphere fit");
 			res = ERROR;
 		}
 	}
@@ -291,7 +291,7 @@ int calibrate_instance(int mavlink_fd, unsigned s, unsigned device_id)
 		res = ioctl(fd, MAGIOCGSCALE, (long unsigned int)&mscale);
 
 		if (res != OK) {
-			mavlink_log_critical(mavlink_fd, "ERROR: failed to get current calibration");
+			mavlink_and_console_log_critical(mavlink_fd, "ERROR: failed to get current calibration");
 		}
 
 		if (res == OK) {
@@ -302,7 +302,7 @@ int calibrate_instance(int mavlink_fd, unsigned s, unsigned device_id)
 			res = ioctl(fd, MAGIOCSSCALE, (long unsigned int)&mscale);
 
 			if (res != OK) {
-				mavlink_log_critical(mavlink_fd, CAL_FAILED_APPLY_CAL_MSG);
+				mavlink_and_console_log_critical(mavlink_fd, CAL_FAILED_APPLY_CAL_MSG);
 			}
 		}
 
@@ -329,15 +329,15 @@ int calibrate_instance(int mavlink_fd, unsigned s, unsigned device_id)
 
 			if (failed) {
 				res = ERROR;
-				mavlink_log_critical(mavlink_fd, CAL_FAILED_SET_PARAMS_MSG);
+				mavlink_and_console_log_critical(mavlink_fd, CAL_FAILED_SET_PARAMS_MSG);
 			}
 
-			mavlink_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 90);
+			mavlink_and_console_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 90);
 		}
 
-		mavlink_log_info(mavlink_fd, "mag off: x:%.2f y:%.2f z:%.2f Ga", (double)mscale.x_offset,
+		mavlink_and_console_log_info(mavlink_fd, "mag off: x:%.2f y:%.2f z:%.2f Ga", (double)mscale.x_offset,
 				 (double)mscale.y_offset, (double)mscale.z_offset);
-		mavlink_log_info(mavlink_fd, "mag scale: x:%.2f y:%.2f z:%.2f", (double)mscale.x_scale,
+		mavlink_and_console_log_info(mavlink_fd, "mag scale: x:%.2f y:%.2f z:%.2f", (double)mscale.x_scale,
 				 (double)mscale.y_scale, (double)mscale.z_scale);
 	}
 

--- a/src/modules/commander/module.mk
+++ b/src/modules/commander/module.mk
@@ -48,7 +48,7 @@ SRCS		 	= commander.cpp \
 			rc_calibration.cpp \
 			airspeed_calibration.cpp
 
-MODULE_STACKSIZE = 1200
+MODULE_STACKSIZE = 5000
 
 MAXOPTIMIZATION	 = -Os
 

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -652,7 +652,7 @@ int prearm_check(const struct vehicle_status_s *status, const int mavlink_fd)
 	int ret;
 	bool failed = false;
 
-	int fd = open(ACCEL_DEVICE_PATH, O_RDONLY);
+	int fd = open(ACCEL0_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		mavlink_log_critical(mavlink_fd, "ARM FAIL: ACCEL SENSOR MISSING");

--- a/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
+++ b/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
@@ -209,9 +209,13 @@ private:
 	struct wind_estimate_s				_wind;			/**< wind estimate */
 	struct range_finder_report			_distance;		/**< distance estimate */
 
-	struct gyro_scale				_gyro_offsets;
-	struct accel_scale				_accel_offsets;
-	struct mag_scale				_mag_offsets;
+	struct gyro_scale				_gyro_offsets[3];
+	struct accel_scale				_accel_offsets[3];
+	struct mag_scale				_mag_offsets[3];
+
+	struct gyro_scale				_gyro1_offsets;
+	struct accel_scale				_accel1_offsets;
+	struct mag_scale				_mag1_offsets;
 
 #ifdef SENSOR_COMBINED_SUB
 	struct sensor_combined_s			_sensor_combined;
@@ -386,6 +390,10 @@ FixedwingEstimator::FixedwingEstimator() :
 	_accel_offsets({}),
 	_mag_offsets({}),
 
+	_gyro1_offsets({}),
+	_accel1_offsets({}),
+	_mag1_offsets({}),
+
 	#ifdef SENSOR_COMBINED_SUB
 	_sensor_combined{},
 	#endif
@@ -452,36 +460,42 @@ FixedwingEstimator::FixedwingEstimator() :
 
 	int fd, res;
 
-	fd = open(GYRO_DEVICE_PATH, O_RDONLY);
+	for (unsigned s = 0; s < 3; s++) {
+		char str[30];
+		(void)sprintf(str, "%s%u", GYRO_BASE_DEVICE_PATH, s);
+		fd = open(str, O_RDONLY);
 
-	if (fd > 0) {
-		res = ioctl(fd, GYROIOCGSCALE, (long unsigned int)&_gyro_offsets);
-		close(fd);
+		if (fd >= 0) {
+			res = ioctl(fd, GYROIOCGSCALE, (long unsigned int)&_gyro_offsets[s]);
+			close(fd);
 
-		if (res) {
-			warnx("G SCALE FAIL");
+			if (res) {
+				warnx("G%u SCALE FAIL", s);
+			}
 		}
-	}
 
-	fd = open(ACCEL_DEVICE_PATH, O_RDONLY);
+		(void)sprintf(str, "%s%u", ACCEL_BASE_DEVICE_PATH, s);
+		fd = open(str, O_RDONLY);
 
-	if (fd > 0) {
-		res = ioctl(fd, ACCELIOCGSCALE, (long unsigned int)&_accel_offsets);
-		close(fd);
+		if (fd >= 0) {
+			res = ioctl(fd, ACCELIOCGSCALE, (long unsigned int)&_accel_offsets[s]);
+			close(fd);
 
-		if (res) {
-			warnx("A SCALE FAIL");
+			if (res) {
+				warnx("A%u SCALE FAIL", s);
+			}
 		}
-	}
 
-	fd = open(MAG_DEVICE_PATH, O_RDONLY);
+		(void)sprintf(str, "%s%u", MAG_BASE_DEVICE_PATH, s);
+		fd = open(str, O_RDONLY);
 
-	if (fd > 0) {
-		res = ioctl(fd, MAGIOCGSCALE, (long unsigned int)&_mag_offsets);
-		close(fd);
+		if (fd >= 0) {
+			res = ioctl(fd, MAGIOCGSCALE, (long unsigned int)&_mag_offsets[s]);
+			close(fd);
 
-		if (res) {
-			warnx("M SCALE FAIL");
+			if (res) {
+				warnx("M%u SCALE FAIL", s);
+			}
 		}
 	}
 }

--- a/src/modules/ekf_att_pos_estimator/estimator_22states.cpp
+++ b/src/modules/ekf_att_pos_estimator/estimator_22states.cpp
@@ -2355,6 +2355,11 @@ int AttPosEKF::RecallStates(float* statesForFusion, uint64_t msec)
         }
     }
 
+    float q[4];
+    float eul[3];
+
+    eul2quat(q, eul);
+
     return ret;
 }
 

--- a/src/modules/ekf_att_pos_estimator/estimator_22states.cpp
+++ b/src/modules/ekf_att_pos_estimator/estimator_22states.cpp
@@ -2355,11 +2355,6 @@ int AttPosEKF::RecallStates(float* statesForFusion, uint64_t msec)
         }
     }
 
-    float q[4];
-    float eul[3];
-
-    eul2quat(q, eul);
-
     return ret;
 }
 

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -2074,6 +2074,21 @@ Sensors::task_main()
 	raw.adc_voltage_v[2] = 0.0f;
 	raw.adc_voltage_v[3] = 0.0f;
 
+	/* set high initial error counts to deselect gyros */
+	raw.gyro_errcount = 100000;
+	raw.gyro1_errcount = 100000;
+	raw.gyro2_errcount = 100000;
+
+	/* set high initial error counts to deselect accels */
+	raw.accelerometer_errcount = 100000;
+	raw.accelerometer1_errcount = 100000;
+	raw.accelerometer2_errcount = 100000;
+
+	/* set high initial error counts to deselect mags */
+	raw.magnetometer_errcount = 100000;
+	raw.magnetometer1_errcount = 100000;
+	raw.magnetometer2_errcount = 100000;
+
 	memset(&_battery_status, 0, sizeof(_battery_status));
 	_battery_status.voltage_v = -1.0f;
 	_battery_status.voltage_filtered_v = -1.0f;

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -1363,7 +1363,7 @@ Sensors::parameter_update_poll(bool forced)
 				/* initially status is ok per config */
 				failed = false;
 
-				(void)sprintf(str, "CAL_GYRO%u_ID", s);
+				(void)sprintf(str, "CAL_GYRO%u_ID", i);
 				int device_id;
 				failed |= (OK != param_get(param_find(str), &device_id));
 
@@ -1395,9 +1395,10 @@ Sensors::parameter_update_poll(bool forced)
 						res = ioctl(fd, GYROIOCSSCALE, (long unsigned int)&gscale);
 						if (res) {
 							warnx(CAL_FAILED_APPLY_CAL_MSG);
+						} else {
+							gyro_count++;
+							config_ok = true;
 						}
-						gyro_count++;
-						config_ok = true;
 					}
 					break;
 				}
@@ -1429,7 +1430,7 @@ Sensors::parameter_update_poll(bool forced)
 				/* initially status is ok per config */
 				failed = false;
 
-				(void)sprintf(str, "CAL_ACC%u_ID", s);
+				(void)sprintf(str, "CAL_ACC%u_ID", i);
 				int device_id;
 				failed |= (OK != param_get(param_find(str), &device_id));
 
@@ -1461,9 +1462,10 @@ Sensors::parameter_update_poll(bool forced)
 						res = ioctl(fd, ACCELIOCSSCALE, (long unsigned int)&gscale);
 						if (res) {
 							warnx(CAL_FAILED_APPLY_CAL_MSG);
+						} else {
+							accel_count++;
+							config_ok = true;
 						}
-						accel_count++;
-						config_ok = true;
 					}
 					break;
 				}
@@ -1495,7 +1497,7 @@ Sensors::parameter_update_poll(bool forced)
 				/* initially status is ok per config */
 				failed = false;
 
-				(void)sprintf(str, "CAL_MAG%u_ID", s);
+				(void)sprintf(str, "CAL_MAG%u_ID", i);
 				int device_id;
 				failed |= (OK != param_get(param_find(str), &device_id));
 
@@ -1527,9 +1529,10 @@ Sensors::parameter_update_poll(bool forced)
 						res = ioctl(fd, MAGIOCSSCALE, (long unsigned int)&gscale);
 						if (res) {
 							warnx(CAL_FAILED_APPLY_CAL_MSG);
+						} else {
+							mag_count++;
+							config_ok = true;
 						}
-						mag_count++;
-						config_ok = true;
 					}
 					break;
 				}

--- a/src/modules/uORB/topics/sensor_combined.h
+++ b/src/modules/uORB/topics/sensor_combined.h
@@ -1,9 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2008-2012 PX4 Development Team. All rights reserved.
- *   Author: @author Thomas Gubler <thomasgubler@student.ethz.ch>
- *           @author Julian Oes <joes@student.ethz.ch>
- *           @author Lorenz Meier <lm@inf.ethz.ch>
+ *   Copyright (c) 2012-2015 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,6 +34,10 @@
 /**
  * @file sensor_combined.h
  * Definition of the sensor_combined uORB topic.
+ *
+ * @author Thomas Gubler <thomas@px4.io>
+ * @author Julian Oes <julian@px4.io>
+ * @author Lorenz Meier <lorenz@px4.io>
  */
 
 #ifndef SENSOR_COMBINED_H_
@@ -81,12 +82,14 @@ struct sensor_combined_s {
 
 	int16_t	gyro_raw[3];			/**< Raw sensor values of angular velocity        */
 	float gyro_rad_s[3];			/**< Angular velocity in radian per seconds       */
+	unsigned gyro_errcount;			/**< Error counter for gyro 0 */
 
 	int16_t accelerometer_raw[3];		/**< Raw acceleration in NED body frame           */
 	float accelerometer_m_s2[3];		/**< Acceleration in NED body frame, in m/s^2     */
 	int accelerometer_mode;			/**< Accelerometer measurement mode */
 	float accelerometer_range_m_s2;		/**< Accelerometer measurement range in m/s^2 */
 	uint64_t accelerometer_timestamp;	/**< Accelerometer timestamp        */
+	unsigned accelerometer_errcount;	/**< Error counter for accel 0 */
 
 	int16_t	magnetometer_raw[3];		/**< Raw magnetic field in NED body frame         */
 	float magnetometer_ga[3];		/**< Magnetic field in NED body frame, in Gauss   */
@@ -94,30 +97,37 @@ struct sensor_combined_s {
 	float magnetometer_range_ga;		/**< ± measurement range in Gauss */
 	float magnetometer_cuttoff_freq_hz;	/**< Internal analog low pass frequency of sensor */
 	uint64_t magnetometer_timestamp;	/**< Magnetometer timestamp         */
+	unsigned magnetometer_errcount;		/**< Error counter for mag 0 */
 
 	int16_t	gyro1_raw[3];			/**< Raw sensor values of angular velocity        */
 	float gyro1_rad_s[3];			/**< Angular velocity in radian per seconds       */
 	uint64_t gyro1_timestamp;		/**< Gyro timestamp */
+	unsigned gyro1_errcount;		/**< Error counter for gyro 1 */
 
 	int16_t accelerometer1_raw[3];		/**< Raw acceleration in NED body frame           */
 	float accelerometer1_m_s2[3];		/**< Acceleration in NED body frame, in m/s^2     */
 	uint64_t accelerometer1_timestamp;	/**< Accelerometer timestamp        */
+	unsigned accelerometer1_errcount;	/**< Error counter for accel 1 */
 
 	int16_t	magnetometer1_raw[3];		/**< Raw magnetic field in NED body frame         */
 	float magnetometer1_ga[3];		/**< Magnetic field in NED body frame, in Gauss   */
 	uint64_t magnetometer1_timestamp;	/**< Magnetometer timestamp         */
+	unsigned magnetometer1_errcount;		/**< Error counter for mag 0 */
 
 	int16_t	gyro2_raw[3];			/**< Raw sensor values of angular velocity        */
 	float gyro2_rad_s[3];			/**< Angular velocity in radian per seconds       */
 	uint64_t gyro2_timestamp;		/**< Gyro timestamp */
+	unsigned gyro2_errcount;		/**< Error counter for gyro 1 */
 
 	int16_t accelerometer2_raw[3];		/**< Raw acceleration in NED body frame           */
 	float accelerometer2_m_s2[3];		/**< Acceleration in NED body frame, in m/s^2     */
 	uint64_t accelerometer2_timestamp;	/**< Accelerometer timestamp        */
+	unsigned accelerometer2_errcount;	/**< Error counter for accel 2 */
 
 	int16_t	magnetometer2_raw[3];		/**< Raw magnetic field in NED body frame         */
 	float magnetometer2_ga[3];		/**< Magnetic field in NED body frame, in Gauss   */
 	uint64_t magnetometer2_timestamp;	/**< Magnetometer timestamp         */
+	unsigned magnetometer2_errcount;	/**< Error counter for mag 2 */
 
 	float baro_pres_mbar;			/**< Barometric pressure, already temp. comp.     */
 	float baro_alt_meter;			/**< Altitude, already temp. comp.                */

--- a/src/modules/uavcan/sensors/baro.cpp
+++ b/src/modules/uavcan/sensors/baro.cpp
@@ -41,7 +41,7 @@
 const char *const UavcanBarometerBridge::NAME = "baro";
 
 UavcanBarometerBridge::UavcanBarometerBridge(uavcan::INode& node) :
-UavcanCDevSensorBridgeBase("uavcan_baro", "/dev/uavcan/baro", BARO_DEVICE_PATH, ORB_ID(sensor_baro)),
+UavcanCDevSensorBridgeBase("uavcan_baro", "/dev/uavcan/baro", BARO_BASE_DEVICE_PATH, ORB_ID(sensor_baro)),
 _sub_air_data(node)
 {
 }

--- a/src/modules/uavcan/sensors/mag.cpp
+++ b/src/modules/uavcan/sensors/mag.cpp
@@ -42,7 +42,7 @@
 const char *const UavcanMagnetometerBridge::NAME = "mag";
 
 UavcanMagnetometerBridge::UavcanMagnetometerBridge(uavcan::INode& node) :
-UavcanCDevSensorBridgeBase("uavcan_mag", "/dev/uavcan/mag", MAG_DEVICE_PATH, ORB_ID(sensor_mag)),
+UavcanCDevSensorBridgeBase("uavcan_mag", "/dev/uavcan/mag", MAG_BASE_DEVICE_PATH, ORB_ID(sensor_mag)),
 _sub_mag(node)
 {
 	_device_id.devid_s.devtype = DRV_MAG_DEVTYPE_HMC5883;

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -569,7 +569,7 @@ void VtolAttitudeControl::fill_fw_att_rates_sp()
 void VtolAttitudeControl::set_idle_fw()
 {
 	int ret;
-	char *dev = PWM_OUTPUT_DEVICE_PATH;
+	char *dev = PWM_OUTPUT0_DEVICE_PATH;
 	int fd = open(dev, 0);
 
 	if (fd < 0) {err(1, "can't open %s", dev);}
@@ -598,7 +598,7 @@ void VtolAttitudeControl::set_idle_mc()
 {
 	int ret;
 	unsigned servo_count;
-	char *dev = PWM_OUTPUT_DEVICE_PATH;
+	char *dev = PWM_OUTPUT0_DEVICE_PATH;
 	int fd = open(dev, 0);
 
 	if (fd < 0) {err(1, "can't open %s", dev);}

--- a/src/systemcmds/esc_calib/esc_calib.c
+++ b/src/systemcmds/esc_calib/esc_calib.c
@@ -81,7 +81,7 @@ usage(const char *reason)
 	errx(1,
 		"usage:\n"
 		"esc_calib\n"
-		"    [-d <device>        PWM output device (defaults to " PWM_OUTPUT_DEVICE_PATH ")\n"
+		"    [-d <device>        PWM output device (defaults to " PWM_OUTPUT0_DEVICE_PATH ")\n"
 		"    [-l <pwm>           Low PWM value in us (default: %dus)\n"
 		"    [-h <pwm>           High PWM value in us (default: %dus)\n"
 		"    [-c <channels>]     Supply channels (e.g. 1234)\n"
@@ -93,7 +93,7 @@ usage(const char *reason)
 int
 esc_calib_main(int argc, char *argv[])
 {
-	char *dev = PWM_OUTPUT_DEVICE_PATH;
+	char *dev = PWM_OUTPUT0_DEVICE_PATH;
 	char *ep;
 	int ch;
 	int ret;

--- a/src/systemcmds/preflight_check/preflight_check.c
+++ b/src/systemcmds/preflight_check/preflight_check.c
@@ -90,7 +90,7 @@ int preflight_check_main(int argc, char *argv[])
 	usleep(150000);
 
 	/* ---- MAG ---- */
-	fd = open(MAG_DEVICE_PATH, 0);
+	fd = open(MAG0_DEVICE_PATH, 0);
 	if (fd < 0) {
 		warn("failed to open magnetometer - start with 'hmc5883 start' or 'lsm303d start'");
 		mavlink_log_critical(mavlink_fd, "SENSOR FAIL: NO MAG");
@@ -119,7 +119,7 @@ int preflight_check_main(int argc, char *argv[])
 	/* ---- ACCEL ---- */
 
 	close(fd);
-	fd = open(ACCEL_DEVICE_PATH, O_RDONLY);
+	fd = open(ACCEL0_DEVICE_PATH, O_RDONLY);
 
 	devid = ioctl(fd, DEVIOCGDEVICEID,0);
 	param_get(param_find("CAL_ACC0_ID"), &(calibration_devid));
@@ -165,7 +165,7 @@ int preflight_check_main(int argc, char *argv[])
 	/* ---- GYRO ---- */
 
 	close(fd);
-	fd = open(GYRO_DEVICE_PATH, 0);
+	fd = open(GYRO0_DEVICE_PATH, 0);
 
 	devid = ioctl(fd, DEVIOCGDEVICEID,0);
 	param_get(param_find("CAL_GYRO0_ID"), &(calibration_devid));
@@ -188,7 +188,7 @@ int preflight_check_main(int argc, char *argv[])
 	/* ---- BARO ---- */
 
 	close(fd);
-	fd = open(BARO_DEVICE_PATH, 0);
+	fd = open(BARO0_DEVICE_PATH, 0);
 	close(fd);
 
 	/* ---- RC CALIBRATION ---- */
@@ -216,8 +216,8 @@ system_eval:
 		warnx("PREFLIGHT CHECK ERROR! TRIGGERING ALARM");
 		fflush(stderr);
 
-		int buzzer = open(TONEALARM_DEVICE_PATH, O_WRONLY);
-		int leds = open(LED_DEVICE_PATH, 0);
+		int buzzer = open(TONEALARM0_DEVICE_PATH, O_WRONLY);
+		int leds = open(LED0_DEVICE_PATH, 0);
 
 		if (leds < 0) {
 			close(buzzer);

--- a/src/systemcmds/preflight_check/preflight_check.c
+++ b/src/systemcmds/preflight_check/preflight_check.c
@@ -1,7 +1,6 @@
 /****************************************************************************
  *
  *   Copyright (c) 2012, 2013 PX4 Development Team. All rights reserved.
- *   Author: @author Lorenz Meier <lm@inf.ethz.ch>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,8 +32,11 @@
  ****************************************************************************/
 
 /**
- * @file reboot.c
- * Tool similar to UNIX reboot command
+ * @file preflight_check.c
+ *
+ * Preflight check for main system components
+ *
+ * @author Lorenz Meier <lorenz@px4.io>
  */
 
 #include <nuttx/config.h>

--- a/src/systemcmds/pwm/pwm.c
+++ b/src/systemcmds/pwm/pwm.c
@@ -101,7 +101,7 @@ usage(const char *reason)
 		"info\t\t\t\tPrint information\n"
 		"\n"
 		"\t-v\t\t\tVerbose\n"
-		"\t-d <dev>\t\t(default " PWM_OUTPUT_DEVICE_PATH ")\n"
+		"\t-d <dev>\t\t(default " PWM_OUTPUT0_DEVICE_PATH ")\n"
 		);
 
 }
@@ -109,7 +109,7 @@ usage(const char *reason)
 int
 pwm_main(int argc, char *argv[])
 {
-	const char *dev = PWM_OUTPUT_DEVICE_PATH;
+	const char *dev = PWM_OUTPUT0_DEVICE_PATH;
 	unsigned alt_rate = 0;
 	uint32_t alt_channel_groups = 0;
 	bool alt_channels_set = false;

--- a/src/systemcmds/tests/test_adc.c
+++ b/src/systemcmds/tests/test_adc.c
@@ -58,7 +58,7 @@
 
 int test_adc(int argc, char *argv[])
 {
-	int fd = open(ADC_DEVICE_PATH, O_RDONLY);
+	int fd = open(ADC0_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		warnx("ERROR: can't open ADC device");

--- a/src/systemcmds/tests/test_hrt.c
+++ b/src/systemcmds/tests/test_hrt.c
@@ -124,10 +124,10 @@ int test_tone(int argc, char *argv[])
 	int fd, result;
 	unsigned long tone;
 
-	fd = open(TONEALARM_DEVICE_PATH, O_WRONLY);
+	fd = open(TONEALARM0_DEVICE_PATH, O_WRONLY);
 
 	if (fd < 0) {
-		printf("failed opening " TONEALARM_DEVICE_PATH "\n");
+		printf("failed opening " TONEALARM0_DEVICE_PATH "\n");
 		goto out;
 	}
 

--- a/src/systemcmds/tests/test_jig_voltages.c
+++ b/src/systemcmds/tests/test_jig_voltages.c
@@ -90,7 +90,7 @@
 
 int test_jig_voltages(int argc, char *argv[])
 {
-	int fd = open(ADC_DEVICE_PATH, O_RDONLY);
+	int fd = open(ADC0_DEVICE_PATH, O_RDONLY);
 	int ret = OK;
 
 	if (fd < 0) {

--- a/src/systemcmds/tests/test_led.c
+++ b/src/systemcmds/tests/test_led.c
@@ -91,7 +91,7 @@ int test_led(int argc, char *argv[])
 	int		fd;
 	int		ret = 0;
 
-	fd = open(LED_DEVICE_PATH, 0);
+	fd = open(LED0_DEVICE_PATH, 0);
 
 	if (fd < 0) {
 		printf("\tLED: open fail\n");

--- a/src/systemcmds/tests/test_ppm_loopback.c
+++ b/src/systemcmds/tests/test_ppm_loopback.c
@@ -67,7 +67,7 @@ int test_ppm_loopback(int argc, char *argv[])
 	int servo_fd, result;
 	servo_position_t pos;
 
-	servo_fd = open(PWM_OUTPUT_DEVICE_PATH, O_RDWR);
+	servo_fd = open(PWM_OUTPUT0_DEVICE_PATH, O_RDWR);
 
 	if (servo_fd < 0) {
 		printf("failed opening /dev/pwm_servo\n");

--- a/src/systemcmds/tests/test_sensors.c
+++ b/src/systemcmds/tests/test_sensors.c
@@ -76,12 +76,12 @@ struct {
 	const char	*path;
 	int	(* test)(int argc, char *argv[], const char* path);
 } sensors[] = {
-	{"accel0",	ACCEL_DEVICE_PATH,	accel},
-	{"accel1",	"/dev/accel1",	accel},
-	{"gyro0",	GYRO_DEVICE_PATH,	gyro},
-	{"gyro1",	"/dev/gyro1",	gyro},
-	{"mag0",	MAG_DEVICE_PATH,	mag},
-	{"baro0",	BARO_DEVICE_PATH,	baro},
+	{"accel0",	ACCEL0_DEVICE_PATH,	accel},
+	{"accel1",	ACCEL1_DEVICE_PATH,	accel},
+	{"gyro0",	GYRO0_DEVICE_PATH,	gyro},
+	{"gyro1",	GYRO1_DEVICE_PATH,	gyro},
+	{"mag0",	MAG0_DEVICE_PATH,	mag},
+	{"baro0",	BARO0_DEVICE_PATH,	baro},
 	{NULL, NULL, NULL}
 };
 

--- a/src/systemcmds/tests/test_servo.c
+++ b/src/systemcmds/tests/test_servo.c
@@ -63,7 +63,7 @@ int test_servo(int argc, char *argv[])
 	servo_position_t data[PWM_OUTPUT_MAX_CHANNELS];
 	servo_position_t pos;
 
-	fd = open(PWM_OUTPUT_DEVICE_PATH, O_RDWR);
+	fd = open(PWM_OUTPUT0_DEVICE_PATH, O_RDWR);
 
 	if (fd < 0) {
 		printf("failed opening /dev/pwm_servo\n");


### PR DESCRIPTION
This PR adds a clean and consistent 0-index based enumeration scheme for all sensor FDs and implements the calibration for gyro, accel and mag for up to three sensors at once. Furthermore it does allow arbitrary sensor startup order and still applies the right calibration values for each sensor based on the sensor ID.

Currently in bench testing phase, would benefit from flight testing starting tomorrow.