### PR TITLE
fix syntax in uorb header generation script

### DIFF
--- a/Tools/px_generate_uorb_topic_headers.py
+++ b/Tools/px_generate_uorb_topic_headers.py
@@ -44,10 +44,13 @@ import filecmp
 import argparse
 
 try:
- import genmsg.template_tools
-except ImportError, e:
- print("Package empy not installed. Please run 'sudo apt-get install python-empy' on a Debian/Ubuntu system, 'sudo pip install empy' on a Mac OS system or 'easy_install empy' on  Windows system.")
- exit(1)
+        import genmsg.template_tools
+except ImportError as e:
+        print("Package empy not installed. Please run 'sudo apt-get install"
+              " python-empy' on a Debian/Ubuntu system, 'sudo pip install"
+              " empy' on a Mac OS system or 'easy_install empy' on"
+              " a Windows system.")
+        exit(1)
 
 __author__ = "Thomas Gubler"
 __copyright__ = "Copyright (C) 2013-2014 PX4 Development Team."


### PR DESCRIPTION
This fixes syntax and indentation of a58d73b5d084c6229610c17f3c443a2925d714ef