### PR TITLE
FMUv1 setup w/o IO

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -11,7 +11,7 @@ then
 	# Load main mixer
 	#
 
-	if [ $MIXER_AUX == none ]
+	if [ $MIXER_AUX == none  -a $USE_IO == yes]
 	then
 		set MIXER_AUX $MIXER.aux
 	fi

--- a/src/drivers/drv_pwm_output.h
+++ b/src/drivers/drv_pwm_output.h
@@ -57,7 +57,6 @@ __BEGIN_DECLS
  * PX4FMU with PX4IO connected) there may be other devices that
  * respond to this protocol.
  */
-#define PWM_OUTPUT_BASE_DEVICE_PATH "dev/pwm_output"
 #define PWM_OUTPUT0_DEVICE_PATH	"/dev/pwm_output0"
 
 /**

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1904,7 +1904,7 @@ fmu_main(int argc, char *argv[])
 
 	fprintf(stderr, "FMU: unrecognised command %s, try:\n", verb);
 #if defined(CONFIG_ARCH_BOARD_PX4FMU_V1)
-	fprintf(stderr, "  mode_gpio, mode_serial, mode_pwm, mode_gpio_serial, mode_pwm_serial, mode_pwm_gpio, test\n");
+	fprintf(stderr, "  mode_gpio, mode_serial, mode_pwm, mode_gpio_serial, mode_pwm_serial, mode_pwm_gpio, test, fake, sensor_reset, id\n");
 #elif defined(CONFIG_ARCH_BOARD_PX4FMU_V2) || defined(CONFIG_ARCH_BOARD_AEROCORE)
 	fprintf(stderr, "  mode_gpio, mode_pwm, test, sensor_reset [milliseconds], i2c <bus> <hz>\n");
 #endif


### PR DESCRIPTION
This brings the FMUv1 only setup back to live. Tested on bench.

However, I am not sure if this breaks the auxiliary capabilites on Pixhawk. If someone could verify this, that would be great.