### PR TITLE
PWM command: Do not modify disarmed PWM values

### DIFF
--- a/src/systemcmds/pwm/pwm.c
+++ b/src/systemcmds/pwm/pwm.c
@@ -337,13 +337,19 @@ pwm_main(int argc, char *argv[])
 		if (pwm_value == 0)
 			warnx("reading disarmed value of zero, disabling disarmed PWM");
 
-		struct pwm_output_values pwm_values = {.values = {0}, .channel_count = 0};
+		struct pwm_output_values pwm_values;
+		/* first get current state before modifying it */
+		ret = ioctl(fd, PWM_SERVO_GET_DISARMED_PWM, (long unsigned int)&pwm_values.values);
+		if (ret != OK) {
+			errx(ret, "failed get disarmed values");
+		}
 
 		for (unsigned i = 0; i < servo_count; i++) {
 			if (set_mask & 1<<i) {
 				pwm_values.values[i] = pwm_value;
-				if (print_verbose)
-					warnx("channel %d: disarmed PWM: %d", i+1, pwm_value);
+				if (print_verbose) {
+					warnx("chan %d: disarmed PWM: %d", i+1, pwm_value);
+				}
 			}
 			pwm_values.channel_count++;
 		}
@@ -353,8 +359,9 @@ pwm_main(int argc, char *argv[])
 		} else {
 
 			ret = ioctl(fd, PWM_SERVO_SET_DISARMED_PWM, (long unsigned int)&pwm_values);
-			if (ret != OK)
+			if (ret != OK) {
 				errx(ret, "failed setting disarmed values");
+			}
 		}
 		exit(0);
 

--- a/src/systemcmds/pwm/pwm.c
+++ b/src/systemcmds/pwm/pwm.c
@@ -279,7 +279,14 @@ pwm_main(int argc, char *argv[])
 		if (pwm_value == 0)
 			usage("no PWM value provided");
 
-		struct pwm_output_values pwm_values = {.values = {0}, .channel_count = 0};
+		struct pwm_output_values pwm_values;
+		memset(&pwm_values, 0, sizeof(pwm_values));
+		pwm_values.channel_count = servo_count;
+		/* first get current state before modifying it */
+		ret = ioctl(fd, PWM_SERVO_GET_MIN_PWM, (long unsigned int)&pwm_values);
+		if (ret != OK) {
+			errx(ret, "failed get min values");
+		}
 
 		for (unsigned i = 0; i < servo_count; i++) {
 			if (set_mask & 1<<i) {
@@ -287,7 +294,6 @@ pwm_main(int argc, char *argv[])
 				if (print_verbose)
 					warnx("Channel %d: min PWM: %d", i+1, pwm_value);
 			}
-			pwm_values.channel_count++;
 		}
 
 		if (pwm_values.channel_count == 0) {
@@ -308,7 +314,14 @@ pwm_main(int argc, char *argv[])
 		if (pwm_value == 0)
 			usage("no PWM value provided");
 
-		struct pwm_output_values pwm_values = {.values = {0}, .channel_count = 0};
+		struct pwm_output_values pwm_values;
+		memset(&pwm_values, 0, sizeof(pwm_values));
+		pwm_values.channel_count = servo_count;
+		/* first get current state before modifying it */
+		ret = ioctl(fd, PWM_SERVO_GET_MAX_PWM, (long unsigned int)&pwm_values);
+		if (ret != OK) {
+			errx(ret, "failed get max values");
+		}
 
 		for (unsigned i = 0; i < servo_count; i++) {
 			if (set_mask & 1<<i) {
@@ -316,7 +329,6 @@ pwm_main(int argc, char *argv[])
 				if (print_verbose)
 					warnx("Channel %d: max PWM: %d", i+1, pwm_value);
 			}
-			pwm_values.channel_count++;
 		}
 
 		if (pwm_values.channel_count == 0) {
@@ -338,8 +350,10 @@ pwm_main(int argc, char *argv[])
 			warnx("reading disarmed value of zero, disabling disarmed PWM");
 
 		struct pwm_output_values pwm_values;
+		memset(&pwm_values, 0, sizeof(pwm_values));
+		pwm_values.channel_count = servo_count;
 		/* first get current state before modifying it */
-		ret = ioctl(fd, PWM_SERVO_GET_DISARMED_PWM, (long unsigned int)&pwm_values.values);
+		ret = ioctl(fd, PWM_SERVO_GET_DISARMED_PWM, (long unsigned int)&pwm_values);
 		if (ret != OK) {
 			errx(ret, "failed get disarmed values");
 		}
@@ -351,7 +365,6 @@ pwm_main(int argc, char *argv[])
 					warnx("chan %d: disarmed PWM: %d", i+1, pwm_value);
 				}
 			}
-			pwm_values.channel_count++;
 		}
 
 		if (pwm_values.channel_count == 0) {
@@ -373,7 +386,14 @@ pwm_main(int argc, char *argv[])
 		if (pwm_value == 0)
 			usage("no PWM provided");
 
-		struct pwm_output_values pwm_values = {.values = {0}, .channel_count = 0};
+		struct pwm_output_values pwm_values;
+		memset(&pwm_values, 0, sizeof(pwm_values));
+		pwm_values.channel_count = servo_count;
+		/* first get current state before modifying it */
+		ret = ioctl(fd, PWM_SERVO_GET_FAILSAFE_PWM, (long unsigned int)&pwm_values);
+		if (ret != OK) {
+			errx(ret, "failed get failsafe values");
+		}
 
 		for (unsigned i = 0; i < servo_count; i++) {
 			if (set_mask & 1<<i) {
@@ -381,7 +401,6 @@ pwm_main(int argc, char *argv[])
 				if (print_verbose)
 					warnx("Channel %d: failsafe PWM: %d", i+1, pwm_value);
 			}
-			pwm_values.channel_count++;
 		}
 
 		if (pwm_values.channel_count == 0) {


### PR DESCRIPTION
The title says it all - allows to set just one channel and leave the rest.