### PR TITLE
Update land detector parameters at startup.

### DIFF
--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -66,6 +66,8 @@ void FixedwingLandDetector::initialize()
 	// Subscribe to local position and airspeed data
 	_vehicleLocalPositionSub = orb_subscribe(ORB_ID(vehicle_local_position));
 	_airspeedSub = orb_subscribe(ORB_ID(airspeed));
+
+	updateParameterCache(true);
 }
 
 void FixedwingLandDetector::updateSubscriptions()


### PR DESCRIPTION
By default fixed wing land detector does not read parameter values and it think aircraft is always in the air.