### PR TITLE
RAM Efficiency

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.mc_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_apps
@@ -4,9 +4,10 @@
 # att & pos estimator, att & pos control.
 #
 
-attitude_estimator_ekf start
-#ekf_att_pos_estimator start
-position_estimator_inav start
+# previously (2014) the system was relying on 
+#attitude_estimator_ekf start
+#position_estimator_inav start
+ekf_att_pos_estimator start
 
 if mc_att_control start
 then

--- a/ROMFS/px4fmu_common/init.d/rc.mc_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_apps
@@ -4,10 +4,15 @@
 # att & pos estimator, att & pos control.
 #
 
-# previously (2014) the system was relying on 
-#attitude_estimator_ekf start
-#position_estimator_inav start
-ekf_att_pos_estimator start
+# previously (2014) the system was relying on
+# INAV, which defaults to 0 now. 
+if param compare INAV_ENABLED 1
+then
+	attitude_estimator_ekf start
+	position_estimator_inav start
+else
+	ekf_att_pos_estimator start
+fi
 
 if mc_att_control start
 then

--- a/src/drivers/mkblctrl/mkblctrl.cpp
+++ b/src/drivers/mkblctrl/mkblctrl.cpp
@@ -296,7 +296,7 @@ MK::init(unsigned motors)
 	_task = task_spawn_cmd("mkblctrl",
 			       SCHED_DEFAULT,
 			       SCHED_PRIORITY_MAX - 20,
-			       2048,
+			       1500,
 			       (main_t)&MK::task_main_trampoline,
 			       nullptr);
 

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -966,7 +966,7 @@ int commander_thread_main(int argc, char *argv[])
 
 	pthread_attr_t commander_low_prio_attr;
 	pthread_attr_init(&commander_low_prio_attr);
-	pthread_attr_setstacksize(&commander_low_prio_attr, 2900);
+	pthread_attr_setstacksize(&commander_low_prio_attr, 2600);
 
 	struct sched_param param;
 	(void)pthread_attr_getschedparam(&commander_low_prio_attr, &param);

--- a/src/modules/land_detector/land_detector_main.cpp
+++ b/src/modules/land_detector/land_detector_main.cpp
@@ -139,7 +139,7 @@ static int land_detector_start(const char *mode)
 	_landDetectorTaskID = task_spawn_cmd("land_detector",
 					     SCHED_DEFAULT,
 					     SCHED_PRIORITY_DEFAULT,
-					     1200,
+					     1000,
 					     (main_t)&land_detector_deamon_thread,
 					     nullptr);
 
@@ -179,8 +179,7 @@ int land_detector_main(int argc, char *argv[])
 {
 
 	if (argc < 1) {
-		warnx("usage: land_detector {start|stop|status} [mode]\nmode can either be 'fixedwing' or 'multicopter'");
-		exit(0);
+		goto exiterr;
 	}
 
 	if (argc >= 2 && !strcmp(argv[1], "start")) {
@@ -209,6 +208,8 @@ int land_detector_main(int argc, char *argv[])
 		}
 	}
 
-	warn("usage: land_detector {start|stop|status} [mode]\nmode can either be 'fixedwing' or 'multicopter'");
+exiterr:
+	warnx("usage: land_detector {start|stop|status} [mode]");
+	warnx("mode can either be 'fixedwing' or 'multicopter'");
 	return 1;
 }

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1621,7 +1621,7 @@ Mavlink::start(int argc, char *argv[])
 	task_spawn_cmd(buf,
 		       SCHED_DEFAULT,
 		       SCHED_PRIORITY_DEFAULT,
-		       2800,
+		       2700,
 		       (main_t)&Mavlink::start_helper,
 		       (char * const *)argv);
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1549,7 +1549,7 @@ MavlinkReceiver::receive_start(Mavlink *parent)
 	param.sched_priority = SCHED_PRIORITY_MAX - 80;
 	(void)pthread_attr_setschedparam(&receiveloop_attr, &param);
 
-	pthread_attr_setstacksize(&receiveloop_attr, 2900);
+	pthread_attr_setstacksize(&receiveloop_attr, 2100);
 	pthread_t thread;
 	pthread_create(&thread, &receiveloop_attr, MavlinkReceiver::start_helper, (void *)parent);
 

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -835,7 +835,7 @@ MulticopterAttitudeControl::start()
 	_control_task = task_spawn_cmd("mc_att_control",
 				       SCHED_DEFAULT,
 				       SCHED_PRIORITY_MAX - 5,
-				       2000,
+				       1800,
 				       (main_t)&MulticopterAttitudeControl::task_main_trampoline,
 				       nullptr);
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1419,7 +1419,7 @@ MulticopterPositionControl::start()
 	_control_task = task_spawn_cmd("mc_pos_control",
 				       SCHED_DEFAULT,
 				       SCHED_PRIORITY_MAX - 5,
-				       2000,
+				       1800,
 				       (main_t)&MulticopterPositionControl::task_main_trampoline,
 				       nullptr);
 

--- a/src/modules/position_estimator_inav/position_estimator_inav_params.c
+++ b/src/modules/position_estimator_inav/position_estimator_inav_params.c
@@ -288,6 +288,20 @@ PARAM_DEFINE_FLOAT(INAV_DELAY_GPS, 0.2f);
  */
 PARAM_DEFINE_INT32(CBRK_NO_VISION, 0);
 
+/**
+ * INAV enabled
+ *
+ * If set to 1, use INAV for position estimation
+ * the system uses the compined attitude / position
+ * filter framework.
+ *
+ * @min 0.0
+ * @max 1.0
+ * @unit s
+ * @group Position Estimator INAV
+ */
+PARAM_DEFINE_INT32(INAV_ENABLED, 0);
+
 int parameters_init(struct position_estimator_inav_param_handles *h)
 {
 	h->w_z_baro = param_find("INAV_W_Z_BARO");


### PR DESCRIPTION
This branch implements all the intended efficiency wins for various modules. Bench, but not flight tested. Trying it on FMUv2 with sdlog2 set at 4K buffer space leaves 51K free, which should bring it close for FMUv1.

Once the real usage during arming has been estimated, low-hanging further optimisation potentials are:

  * mkblctrl
  * mc_att_control
  * mc_pos_control

Each app should have at least 500 bytes free space remaining after a flight.

```
Processes: 21 total, 2 running, 19 sleeping
CPU usage: 35.95% tasks, 0.87% sched, 63.18% idle
Uptime: 66.476s total, 42.351s idle

 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE 
   0 Idle Task                   42351 63.178     0/    0   0 (  0)  READY 
   1 hpwork                       1720  2.616   732/ 1792 192 (192)  w:sig 
   2 lpwork                        204  0.193   356/ 1792  50 ( 50)  w:sig 
   3 init                         1426  0.000  1452/ 2592 100 (100)  w:sem 
   6 nshterm                         6  0.000   892/ 1496  70 ( 70)  w:sem 
 155 top                            15  1.065  1148/ 1696 100 (100)  RUN   
  77 dataman                        21  0.000   660/ 1792 100 (100)  w:sem 
  79 commander                     140  0.096  2692/ 3192 215 (215)  w:sig 
  80 commander_low_prio             11  0.000   484/ 2592  50 ( 50)  w:sem 
  82 mavlink_if0                   460  0.678  1804/ 2696 100 (100)  READY 
  83 mavlink_rcv_if0                 5  0.000   788/ 2096 175 (175)  w:sem 
  87 mavlink_if1                  2264  3.488  1708/ 2696 100 (100)  READY 
  88 mavlink_rcv_if1                 4  0.000   796/ 2096 175 (175)  w:sem 
 116 sensors_task                 1891  3.100  1212/ 1992 250 (250)  w:sem 
 154 sdlog2                         76  0.096  1916/ 2992  70 ( 70)  READY 
 124 gps                           163  0.000   708/ 1496 220 (220)  w:sem 
 133 ekf_att_pos_estimator       13710 22.383  3524/ 7496 215 (215)  w:sem 
 136 mc_att_control                607  0.968  1052/ 1792 250 (250)  w:sem 
 138 mc_pos_control                456  0.678  1012/ 1792 250 (250)  w:sem 
 140 land_detector                 116  0.096   524/  992 100 (100)  READY 
 145 navigator                     397  0.484   852/ 1792 120 (120)  w:sem 
nsh> free
             total       used       free    largest
Mem:        219968     168304      51664      29408
```