### PR TITLE
Change FW airspeed defaults

### DIFF
--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -302,10 +302,9 @@ PARAM_DEFINE_INT32(FW_YCO_METHOD, 0);
  *
  * @unit m/s
  * @min 0.0
- * @max 30.0
  * @group FW Attitude Control
  */
-PARAM_DEFINE_FLOAT(FW_AIRSPD_MIN, 13.0f);
+PARAM_DEFINE_FLOAT(FW_AIRSPD_MIN, 10.0f);
 
 /**
  * Trim Airspeed
@@ -314,10 +313,9 @@ PARAM_DEFINE_FLOAT(FW_AIRSPD_MIN, 13.0f);
  *
  * @unit m/s
  * @min 0.0
- * @max 30.0
  * @group FW Attitude Control
  */
-PARAM_DEFINE_FLOAT(FW_AIRSPD_TRIM, 20.0f);
+PARAM_DEFINE_FLOAT(FW_AIRSPD_TRIM, 15.0f);
 
 /**
  * Maximum Airspeed
@@ -327,10 +325,9 @@ PARAM_DEFINE_FLOAT(FW_AIRSPD_TRIM, 20.0f);
  *
  * @unit m/s
  * @min 0.0
- * @max 30.0
  * @group FW Attitude Control
  */
-PARAM_DEFINE_FLOAT(FW_AIRSPD_MAX, 50.0f);
+PARAM_DEFINE_FLOAT(FW_AIRSPD_MAX, 20.0f);
 
 /**
  * Roll Setpoint Offset

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -302,6 +302,7 @@ PARAM_DEFINE_INT32(FW_YCO_METHOD, 0);
  *
  * @unit m/s
  * @min 0.0
+ * @max 40
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_AIRSPD_MIN, 10.0f);
@@ -313,6 +314,7 @@ PARAM_DEFINE_FLOAT(FW_AIRSPD_MIN, 10.0f);
  *
  * @unit m/s
  * @min 0.0
+ * @max 40
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_AIRSPD_TRIM, 15.0f);
@@ -325,6 +327,7 @@ PARAM_DEFINE_FLOAT(FW_AIRSPD_TRIM, 15.0f);
  *
  * @unit m/s
  * @min 0.0
+ * @max 40
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_AIRSPD_MAX, 20.0f);


### PR DESCRIPTION
Something that nagged me for a while now ;)

The airspeed defaults are currently too high, if you start with a new frame this will make it descend in POSCTL (and crash if you don't pay enough attention).
I also removed the max annotation (or is there really a max?)

