### PR TITLE
Reduce stack size for multiplatform apps

### DIFF
--- a/src/modules/mc_att_control_multiplatform/mc_att_control_start_nuttx.cpp
+++ b/src/modules/mc_att_control_multiplatform/mc_att_control_start_nuttx.cpp
@@ -71,7 +71,7 @@ int mc_att_control_m_main(int argc, char *argv[])
 		daemon_task = task_spawn_cmd("mc_att_control_m",
 				       SCHED_DEFAULT,
 				       SCHED_PRIORITY_MAX - 5,
-				       3000,
+				       1900,
 				       main,
 					(argv) ? (char* const*)&argv[2] : (char* const*)NULL);
 

--- a/src/modules/mc_pos_control_multiplatform/mc_pos_control_start_nuttx.cpp
+++ b/src/modules/mc_pos_control_multiplatform/mc_pos_control_start_nuttx.cpp
@@ -71,7 +71,7 @@ int mc_pos_control_m_main(int argc, char *argv[])
 		daemon_task = task_spawn_cmd("mc_pos_control_m",
 				       SCHED_DEFAULT,
 				       SCHED_PRIORITY_MAX - 5,
-				       3000,
+				       2500,
 				       main,
 					(argv) ? (char* const*)&argv[2] : (char* const*)NULL);
 


### PR DESCRIPTION
@LorenzMeier
The pos controller needs significantly more stack than the old version. We need to follow up on this. My guess is that most of it stems from inefficient use of the subscription/publication and parameter types because the port was done without changing most of the update logic/patterns.

fixes #1843