### PR TITLE
OreoLED: add send_bytes so custom patterns can be sent to LEDs from ardupilot or even GCS

### DIFF
--- a/src/drivers/drv_oreoled.h
+++ b/src/drivers/drv_oreoled.h
@@ -58,6 +58,9 @@
 /** run macro */
 #define OREOLED_RUN_MACRO		_OREOLEDIOC(2)
 
+/** send bytes */
+#define OREOLED_SEND_BYTES		_OREOLEDIOC(3)
+
 /* Oreo LED driver supports up to 4 leds */
 #define OREOLED_NUM_LEDS		4
 
@@ -65,7 +68,7 @@
 #define OREOLED_ALL_INSTANCES	0xff
 
 /* maximum command length that can be sent to LEDs */
-#define OREOLED_CMD_LENGTH_MAX	10
+#define OREOLED_CMD_LENGTH_MAX	24
 
 /* enum passed to OREOLED_SET_MODE ioctl()
  *	defined by hardware */


### PR DESCRIPTION
Also increase maximum command length to 24 bytes