### PR TITLE
Limit auto roll/pitch rates

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -202,7 +202,7 @@ private:
 		float roll_rate_max;
 		float pitch_rate_max;
 		float yaw_rate_max;
-		math::Vector<3> mc_rate_max;		/**< attitude rate limits in all modes */
+		math::Vector<3> mc_rate_max;		/**< attitude rate limits in stabilized modes */
 
 		float man_roll_max;
 		float man_pitch_max;

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -639,6 +639,11 @@ MulticopterAttitudeControl::control_attitude(float dt)
 	/* calculate angular rates setpoint */
 	_rates_sp = _params.att_p.emult(e_R);
 
+	/* limit roll and pitch rates */
+	for (int i = 0; i < 2; i++) {
+		_rates_sp(i) = math::constrain(_rates_sp(i), -_params.acro_rate_max(i), _params.acro_rate_max(i));
+	}
+
 	/* limit yaw rate */
 	_rates_sp(2) = math::constrain(_rates_sp(2), -_params.yaw_rate_max, _params.yaw_rate_max);
 

--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -206,6 +206,30 @@ PARAM_DEFINE_FLOAT(MC_YAWRATE_FF, 0.0f);
 PARAM_DEFINE_FLOAT(MC_YAW_FF, 0.5f);
 
 /**
+ * Max roll rate
+ *
+ * Limit for roll rate, has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation.
+ *
+ * @unit deg/s
+ * @min 0.0
+ * @max 360.0
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MC_ROLLRATE_MAX, 120.0f);
+
+/**
+ * Max pitch rate
+ *
+ * Limit for pitch rate, has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation.
+ *
+ * @unit deg/s
+ * @min 0.0
+ * @max 360.0
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MC_PITCHRATE_MAX, 120.0f);
+
+/**
  * Max yaw rate
  *
  * Limit for yaw rate, has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation.

--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -215,7 +215,7 @@ PARAM_DEFINE_FLOAT(MC_YAW_FF, 0.5f);
  * @max 360.0
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MC_ROLLRATE_MAX, 120.0f);
+PARAM_DEFINE_FLOAT(MC_ROLLRATE_MAX, 360.0f);
 
 /**
  * Max pitch rate
@@ -227,7 +227,7 @@ PARAM_DEFINE_FLOAT(MC_ROLLRATE_MAX, 120.0f);
  * @max 360.0
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MC_PITCHRATE_MAX, 120.0f);
+PARAM_DEFINE_FLOAT(MC_PITCHRATE_MAX, 360.0f);
 
 /**
  * Max yaw rate


### PR DESCRIPTION
This change limits the MC attitude controller roll and pitch rate setpoints to the values specified by two new parameters.
Ths PR adds two new parameters for MC attitude controller rate limiting; 
In addition to MC_YAWRATE_MAX, there are: MC_PITCHRATE_MAX and MC_ROLLRATE_MAX
The default value for each is 120 deg/sec.

Note that MC "ACRO" mode bypasses the attitude controller, so these limits do not apply to that mode.

