### PR TITLE
Fix generating $3_len in BIN_TO_OBJ makefile function

### DIFF
--- a/makefiles/toolchain_gnu-arm-eabi.mk
+++ b/makefiles/toolchain_gnu-arm-eabi.mk
@@ -296,6 +296,9 @@ endef
 #
 # - compile an empty file to generate a suitable object file
 # - relink the object and insert the binary file
+# - extract the length
+# - create const unsigned $3_len with the extracted length as its value and compile it to an object file
+# - link the two generated object files together
 # - edit symbol names to suit
 #
 # NOTE: exercise caution using this with absolute pathnames; it looks
@@ -320,11 +323,14 @@ define BIN_TO_OBJ
 	@$(MKDIR) -p $(dir $2)
 	$(Q) $(ECHO) > $2.c
 	$(call COMPILE,$2.c,$2.c.o)
-	$(Q) $(LD) -r -o $2 $2.c.o -b binary $1
+	$(Q) $(LD) -r -o $2.bin.o $2.c.o -b binary $1
+	$(Q) $(ECHO) "const unsigned int $3_len = 0x`$(NM) $2.bin.o | egrep $(call BIN_SYM_PREFIX,$1)_size$$ | cut -d' ' -f1`;" > $2.c
+	$(call COMPILE,$2.c,$2.c.o)
+	$(Q) $(LD) -r -o $2 $2.c.o $2.bin.o
 	$(Q) $(OBJCOPY) $2 \
 		--redefine-sym $(call BIN_SYM_PREFIX,$1)_start=$3 \
-		--redefine-sym $(call BIN_SYM_PREFIX,$1)_size=$3_len \
+		--strip-symbol $(call BIN_SYM_PREFIX,$1)_size \
 		--strip-symbol $(call BIN_SYM_PREFIX,$1)_end \
 		--rename-section .data=.rodata
-	$(Q) $(REMOVE) $2.c $2.c.o
+	$(Q) $(REMOVE) $2.c $2.c.o $2.bin.o
 endef

--- a/makefiles/toolchain_gnu-arm-eabi.mk
+++ b/makefiles/toolchain_gnu-arm-eabi.mk
@@ -324,7 +324,7 @@ define BIN_TO_OBJ
 	$(Q) $(ECHO) > $2.c
 	$(call COMPILE,$2.c,$2.c.o)
 	$(Q) $(LD) -r -o $2.bin.o $2.c.o -b binary $1
-	$(Q) $(ECHO) "const unsigned int $3_len = `$(NM) -p --radix=d $2.bin.o | $(GREP) $(call BIN_SYM_PREFIX,$1)_size$$ | $(GREP) -o ^[0-9]*`;" > $2.c
+	$(Q) $(ECHO) "const unsigned int $3_len = 0x`$(NM) -p --radix=x $2.bin.o | $(GREP) $(call BIN_SYM_PREFIX,$1)_size$$ | $(GREP) -o ^[0-9a-fA-F]*`;" > $2.c
 	$(call COMPILE,$2.c,$2.c.o)
 	$(Q) $(LD) -r -o $2 $2.c.o $2.bin.o
 	$(Q) $(OBJCOPY) $2 \

--- a/makefiles/toolchain_gnu-arm-eabi.mk
+++ b/makefiles/toolchain_gnu-arm-eabi.mk
@@ -324,7 +324,7 @@ define BIN_TO_OBJ
 	$(Q) $(ECHO) > $2.c
 	$(call COMPILE,$2.c,$2.c.o)
 	$(Q) $(LD) -r -o $2.bin.o $2.c.o -b binary $1
-	$(Q) $(ECHO) "const unsigned int $3_len = 0x`$(NM) $2.bin.o | egrep $(call BIN_SYM_PREFIX,$1)_size$$ | cut -d' ' -f1`;" > $2.c
+	$(Q) $(ECHO) "const unsigned int $3_len = `$(NM) -p --radix=d $2.bin.o | $(GREP) $(call BIN_SYM_PREFIX,$1)_size$$ | $(GREP) -o ^[0-9]*`;" > $2.c
 	$(call COMPILE,$2.c,$2.c.o)
 	$(Q) $(LD) -r -o $2 $2.c.o $2.bin.o
 	$(Q) $(OBJCOPY) $2 \


### PR DESCRIPTION
Till now the length of the binary has been represented as a symbol, which is an address and the right way to get an address in C++/C is use &symbol.

The $3_len should be read-only variable holding the length of the binary IMO, so the symbol represent an address in the data, where length is stored and can be used in following way:
printf(%x, $3_len).

See https://groups.google.com/forum/#!topic/px4users/eMGtCpS24WM