### PR TITLE
Sensor cal updates

### DIFF
--- a/src/modules/commander/accelerometer_calibration.cpp
+++ b/src/modules/commander/accelerometer_calibration.cpp
@@ -120,8 +120,11 @@
  * @author Anton Babushkin <anton.babushkin@me.com>
  */
 
+// FIXME: Can some of these headers move out with detect_ move?
+
 #include "accelerometer_calibration.h"
 #include "calibration_messages.h"
+#include "calibration_routines.h"
 #include "commander_helper.h"
 
 #include <unistd.h>
@@ -149,18 +152,24 @@ static const int ERROR = -1;
 
 static const char *sensor_name = "accel";
 
-static const unsigned max_sens = 3;
-
-int do_accel_calibration_measurements(int mavlink_fd, float (&accel_offs)[max_sens][3], float (&accel_T)[max_sens][3][3], unsigned *active_sensors);
-int detect_orientation(int mavlink_fd, int (&subs)[max_sens]);
-int read_accelerometer_avg(int (&subs)[max_sens], float (&accel_avg)[max_sens][6][3], unsigned orient, unsigned samples_num);
+int do_accel_calibration_measurements(int mavlink_fd, float (&accel_offs)[max_accel_sens][3], float (&accel_T)[max_accel_sens][3][3], unsigned *active_sensors);
+int read_accelerometer_avg(int (&subs)[max_accel_sens], float (&accel_avg)[max_accel_sens][detect_orientation_side_count][3], unsigned orient, unsigned samples_num);
 int mat_invert3(float src[3][3], float dst[3][3]);
-int calculate_calibration_values(unsigned sensor, float (&accel_ref)[max_sens][6][3], float (&accel_T)[max_sens][3][3], float (&accel_offs)[max_sens][3], float g);
+int calculate_calibration_values(unsigned sensor, float (&accel_ref)[max_accel_sens][detect_orientation_side_count][3], float (&accel_T)[max_accel_sens][3][3], float (&accel_offs)[max_accel_sens][3], float g);
+int accel_calibration_worker(detect_orientation_return orientation, void* worker_data);
+
+/// Data passed to calibration worker routine
+typedef struct  {
+	int		mavlink_fd;
+	unsigned	done_count;
+	int		subs[max_accel_sens];
+	float		accel_ref[max_accel_sens][detect_orientation_side_count][3];
+} accel_worker_data_t;
 
 int do_accel_calibration(int mavlink_fd)
 {
 	int fd;
-	int32_t device_id[max_sens];
+	int32_t device_id[max_accel_sens];
 
 	mavlink_and_console_log_info(mavlink_fd, CAL_STARTED_MSG, sensor_name);
 
@@ -178,7 +187,7 @@ int do_accel_calibration(int mavlink_fd)
 	char str[30];
 
 	/* reset all sensors */
-	for (unsigned s = 0; s < max_sens; s++) {
+	for (unsigned s = 0; s < max_accel_sens; s++) {
 		sprintf(str, "%s%u", ACCEL_BASE_DEVICE_PATH, s);
 		/* reset all offsets to zero and all scales to one */
 		fd = open(str, 0);
@@ -193,12 +202,12 @@ int do_accel_calibration(int mavlink_fd)
 		close(fd);
 
 		if (res != OK) {
-			mavlink_and_console_log_critical(mavlink_fd, CAL_FAILED_RESET_CAL_MSG);
+			mavlink_and_console_log_critical(mavlink_fd, CAL_FAILED_RESET_CAL_MSG, s);
 		}
 	}
 
-	float accel_offs[max_sens][3];
-	float accel_T[max_sens][3][3];
+	float accel_offs[max_accel_sens][3];
+	float accel_T[max_accel_sens][3][3];
 	unsigned active_sensors;
 
 	if (res == OK) {
@@ -234,27 +243,27 @@ int do_accel_calibration(int mavlink_fd)
 		accel_scale.y_scale = accel_T_rotated(1, 1);
 		accel_scale.z_offset = accel_offs_rotated(2);
 		accel_scale.z_scale = accel_T_rotated(2, 2);
-
+		
 		bool failed = false;
 
 		/* set parameters */
 		(void)sprintf(str, "CAL_ACC%u_XOFF", i);
-		failed |= (OK != param_set(param_find(str), &(accel_scale.x_offset)));
+		failed |= (OK != param_set_no_notification(param_find(str), &(accel_scale.x_offset)));
 		(void)sprintf(str, "CAL_ACC%u_YOFF", i);
-		failed |= (OK != param_set(param_find(str), &(accel_scale.y_offset)));
+		failed |= (OK != param_set_no_notification(param_find(str), &(accel_scale.y_offset)));
 		(void)sprintf(str, "CAL_ACC%u_ZOFF", i);
-		failed |= (OK != param_set(param_find(str), &(accel_scale.z_offset)));
+		failed |= (OK != param_set_no_notification(param_find(str), &(accel_scale.z_offset)));
 		(void)sprintf(str, "CAL_ACC%u_XSCALE", i);
-		failed |= (OK != param_set(param_find(str), &(accel_scale.x_scale)));
+		failed |= (OK != param_set_no_notification(param_find(str), &(accel_scale.x_scale)));
 		(void)sprintf(str, "CAL_ACC%u_YSCALE", i);
-		failed |= (OK != param_set(param_find(str), &(accel_scale.y_scale)));
+		failed |= (OK != param_set_no_notification(param_find(str), &(accel_scale.y_scale)));
 		(void)sprintf(str, "CAL_ACC%u_ZSCALE", i);
-		failed |= (OK != param_set(param_find(str), &(accel_scale.z_scale)));
+		failed |= (OK != param_set_no_notification(param_find(str), &(accel_scale.z_scale)));
 		(void)sprintf(str, "CAL_ACC%u_ID", i);
-		failed |= (OK != param_set(param_find(str), &(device_id[i])));
+		failed |= (OK != param_set_no_notification(param_find(str), &(device_id[i])));
 		
 		if (failed) {
-			mavlink_and_console_log_critical(mavlink_fd, CAL_FAILED_SET_PARAMS_MSG);
+			mavlink_and_console_log_critical(mavlink_fd, CAL_FAILED_SET_PARAMS_MSG, i);
 			return ERROR;
 		}
 
@@ -270,7 +279,7 @@ int do_accel_calibration(int mavlink_fd)
 		}
 
 		if (res != OK) {
-			mavlink_and_console_log_critical(mavlink_fd, CAL_FAILED_APPLY_CAL_MSG);
+			mavlink_and_console_log_critical(mavlink_fd, CAL_FAILED_APPLY_CAL_MSG, i);
 		}
 	}
 
@@ -291,309 +300,117 @@ int do_accel_calibration(int mavlink_fd)
 	return res;
 }
 
-int do_accel_calibration_measurements(int mavlink_fd, float (&accel_offs)[max_sens][3], float (&accel_T)[max_sens][3][3], unsigned *active_sensors)
+int accel_calibration_worker(detect_orientation_return orientation, void* data)
 {
 	const unsigned samples_num = 3000;
+	accel_worker_data_t* worker_data = (accel_worker_data_t*)(data);
+	
+	mavlink_and_console_log_info(worker_data->mavlink_fd, "Hold still, starting to measure %s side", detect_orientation_str(orientation));
+	sleep(1);
+	
+	read_accelerometer_avg(worker_data->subs, worker_data->accel_ref, orientation, samples_num);
+	
+	mavlink_and_console_log_info(worker_data->mavlink_fd, "%s side result: [ %8.4f %8.4f %8.4f ]", detect_orientation_str(orientation),
+				     (double)worker_data->accel_ref[0][orientation][0],
+				     (double)worker_data->accel_ref[0][orientation][1],
+				     (double)worker_data->accel_ref[0][orientation][2]);
+	
+	worker_data->done_count++;
+	mavlink_and_console_log_info(worker_data->mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 17 * worker_data->done_count);
+	
+	return OK;
+}
+
+int do_accel_calibration_measurements(int mavlink_fd, float (&accel_offs)[max_accel_sens][3], float (&accel_T)[max_accel_sens][3][3], unsigned *active_sensors)
+{
+	int result = OK;
+	
 	*active_sensors = 0;
+	
+	accel_worker_data_t worker_data;
+	
+	worker_data.mavlink_fd = mavlink_fd;
+	worker_data.done_count = 0;
 
-	float accel_ref[max_sens][6][3];
-	bool data_collected[6] = { false, false, false, false, false, false };
-	const char *orientation_strs[6] = { "back", "front", "left", "right", "up", "down" };
+	bool data_collected[detect_orientation_side_count] = { false, false, false, false, false, false };
 
-	int subs[max_sens];
+	// Initialize subs to error condition so we know which ones are open and which are not
+	for (size_t i=0; i<max_accel_sens; i++) {
+		worker_data.subs[i] = -1;
+	}
 
-	uint64_t timestamps[max_sens];
+	uint64_t timestamps[max_accel_sens];
 
-	for (unsigned i = 0; i < max_sens; i++) {
-		subs[i] = orb_subscribe_multi(ORB_ID(sensor_accel), i);
+	for (unsigned i = 0; i < max_accel_sens; i++) {
+		worker_data.subs[i] = orb_subscribe_multi(ORB_ID(sensor_accel), i);
+		if (worker_data.subs[i] < 0) {
+			result = ERROR;
+			break;
+		}
+		
 		/* store initial timestamp - used to infer which sensors are active */
 		struct accel_report arp = {};
-		(void)orb_copy(ORB_ID(sensor_accel), subs[i], &arp);
+		(void)orb_copy(ORB_ID(sensor_accel), worker_data.subs[i], &arp);
 		timestamps[i] = arp.timestamp;
 	}
 
-	unsigned done_count = 0;
-	int res = OK;
-
-	while (true) {
-		bool done = true;
-		unsigned old_done_count = done_count;
-		done_count = 0;
-
-		for (int i = 0; i < 6; i++) {
-			if (data_collected[i]) {
-				done_count++;
-
-			} else {
-				done = false;
-			}
-		}
-
-		if (old_done_count != done_count) {
-			mavlink_and_console_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 17 * done_count);
-		}
-
-		if (done) {
-			break;
-		}
-
-		/* inform user which axes are still needed */
-		mavlink_and_console_log_info(mavlink_fd, "pending: %s%s%s%s%s%s",
-				 (!data_collected[5]) ? "down " : "",
-				 (!data_collected[0]) ? "back " : "",
-				 (!data_collected[1]) ? "front " : "",
-				 (!data_collected[2]) ? "left " : "",
-				 (!data_collected[3]) ? "right " : "",
-				 (!data_collected[4]) ? "up " : "");
-
-		/* allow user enough time to read the message */
-		sleep(1);
-
-		int orient = detect_orientation(mavlink_fd, subs);
-
-		if (orient < 0) {
-			mavlink_and_console_log_info(mavlink_fd, "invalid motion, hold still...");
-			sleep(2);
-			continue;
-		}
-
-		/* inform user about already handled side */
-		if (data_collected[orient]) {
-			mavlink_and_console_log_info(mavlink_fd, "%s side done, rotate to a different side", orientation_strs[orient]);
-			sleep(1);
-			continue;
-		}
-
-		mavlink_and_console_log_info(mavlink_fd, "Hold still, starting to measure %s side", orientation_strs[orient]);
-		sleep(1);
-		read_accelerometer_avg(subs, accel_ref, orient, samples_num);
-		mavlink_and_console_log_info(mavlink_fd, "%s side done, rotate to a different side", orientation_strs[orient]);
-		usleep(100000);
-		mavlink_and_console_log_info(mavlink_fd, "result for %s side: [ %8.4f %8.4f %8.4f ]", orientation_strs[orient],
-				 (double)accel_ref[0][orient][0],
-				 (double)accel_ref[0][orient][1],
-				 (double)accel_ref[0][orient][2]);
-
-		data_collected[orient] = true;
-		tune_neutral(true);
+	if (result == OK) {
+		result = calibrate_from_orientation(mavlink_fd, data_collected, accel_calibration_worker, &worker_data);
 	}
 
 	/* close all subscriptions */
-	for (unsigned i = 0; i < max_sens; i++) {
-		/* figure out which sensors were active */
-		struct accel_report arp = {};
-		(void)orb_copy(ORB_ID(sensor_accel), subs[i], &arp);
-		if (arp.timestamp != 0 && timestamps[i] != arp.timestamp) {
-			(*active_sensors)++;
+	for (unsigned i = 0; i < max_accel_sens; i++) {
+		if (worker_data.subs[i] >= 0) {
+			/* figure out which sensors were active */
+			struct accel_report arp = {};
+			(void)orb_copy(ORB_ID(sensor_accel), worker_data.subs[i], &arp);
+			if (arp.timestamp != 0 && timestamps[i] != arp.timestamp) {
+				(*active_sensors)++;
+			}
+			close(worker_data.subs[i]);
 		}
-		close(subs[i]);
 	}
 
-	if (res == OK) {
+	if (result == OK) {
 		/* calculate offsets and transform matrix */
 		for (unsigned i = 0; i < (*active_sensors); i++) {
-			res = calculate_calibration_values(i, accel_ref, accel_T, accel_offs, CONSTANTS_ONE_G);
+			result = calculate_calibration_values(i, worker_data.accel_ref, accel_T, accel_offs, CONSTANTS_ONE_G);
 
-			if (res != OK) {
+			if (result != OK) {
 				mavlink_and_console_log_critical(mavlink_fd, "ERROR: calibration values calculation error");
 				break;
 			}
 		}
 	}
 
-	return res;
-}
-
-/**
- * Wait for vehicle become still and detect it's orientation.
- *
- * @param mavlink_fd the MAVLink file descriptor to print output to
- * @param subs the accelerometer subscriptions. Only the first one will be used.
- *
- * @return 0..5 according to orientation when vehicle is still and ready for measurements,
- * ERROR if vehicle is not still after 30s or orientation error is more than 5m/s^2
- */
-int detect_orientation(int mavlink_fd, int (&subs)[max_sens])
-{
-	const unsigned ndim = 3;
-
-	struct accel_report sensor;
-	/* exponential moving average of accel */
-	float accel_ema[ndim] = { 0.0f };
-	/* max-hold dispersion of accel */
-	float accel_disp[3] = { 0.0f, 0.0f, 0.0f };
-	/* EMA time constant in seconds*/
-	float ema_len = 0.5f;
-	/* set "still" threshold to 0.25 m/s^2 */
-	float still_thr2 = powf(0.25f, 2);
-	/* set accel error threshold to 5m/s^2 */
-	float accel_err_thr = 5.0f;
-	/* still time required in us */
-	hrt_abstime still_time = 2000000;
-	struct pollfd fds[1];
-	fds[0].fd = subs[0];
-	fds[0].events = POLLIN;
-
-	hrt_abstime t_start = hrt_absolute_time();
-	/* set timeout to 30s */
-	hrt_abstime timeout = 30000000;
-	hrt_abstime t_timeout = t_start + timeout;
-	hrt_abstime t = t_start;
-	hrt_abstime t_prev = t_start;
-	hrt_abstime t_still = 0;
-
-	unsigned poll_errcount = 0;
-
-	while (true) {
-		/* wait blocking for new data */
-		int poll_ret = poll(fds, 1, 1000);
-
-		if (poll_ret) {
-			orb_copy(ORB_ID(sensor_accel), subs[0], &sensor);
-			t = hrt_absolute_time();
-			float dt = (t - t_prev) / 1000000.0f;
-			t_prev = t;
-			float w = dt / ema_len;
-
-			for (unsigned i = 0; i < ndim; i++) {
-
-				float di = 0.0f;
-				switch (i) {
-					case 0:
-						di = sensor.x;
-						break;
-					case 1:
-						di = sensor.y;
-						break;
-					case 2:
-						di = sensor.z;
-						break;
-				}
-
-				float d = di - accel_ema[i];
-				accel_ema[i] += d * w;
-				d = d * d;
-				accel_disp[i] = accel_disp[i] * (1.0f - w);
-
-				if (d > still_thr2 * 8.0f) {
-					d = still_thr2 * 8.0f;
-				}
-
-				if (d > accel_disp[i]) {
-					accel_disp[i] = d;
-				}
-			}
-
-			/* still detector with hysteresis */
-			if (accel_disp[0] < still_thr2 &&
-			    accel_disp[1] < still_thr2 &&
-			    accel_disp[2] < still_thr2) {
-				/* is still now */
-				if (t_still == 0) {
-					/* first time */
-					mavlink_and_console_log_info(mavlink_fd, "detected rest position, hold still...");
-					t_still = t;
-					t_timeout = t + timeout;
-
-				} else {
-					/* still since t_still */
-					if (t > t_still + still_time) {
-						/* vehicle is still, exit from the loop to detection of its orientation */
-						break;
-					}
-				}
-
-			} else if (accel_disp[0] > still_thr2 * 4.0f ||
-				   accel_disp[1] > still_thr2 * 4.0f ||
-				   accel_disp[2] > still_thr2 * 4.0f) {
-				/* not still, reset still start time */
-				if (t_still != 0) {
-					mavlink_and_console_log_info(mavlink_fd, "detected motion, hold still...");
-					sleep(3);
-					t_still = 0;
-				}
-			}
-
-		} else if (poll_ret == 0) {
-			poll_errcount++;
-		}
-
-		if (t > t_timeout) {
-			poll_errcount++;
-		}
-
-		if (poll_errcount > 1000) {
-			mavlink_and_console_log_critical(mavlink_fd, CAL_FAILED_SENSOR_MSG);
-			return ERROR;
-		}
-	}
-
-	if (fabsf(accel_ema[0] - CONSTANTS_ONE_G) < accel_err_thr &&
-	    fabsf(accel_ema[1]) < accel_err_thr &&
-	    fabsf(accel_ema[2]) < accel_err_thr) {
-		return 0;        // [ g, 0, 0 ]
-	}
-
-	if (fabsf(accel_ema[0] + CONSTANTS_ONE_G) < accel_err_thr &&
-	    fabsf(accel_ema[1]) < accel_err_thr &&
-	    fabsf(accel_ema[2]) < accel_err_thr) {
-		return 1;        // [ -g, 0, 0 ]
-	}
-
-	if (fabsf(accel_ema[0]) < accel_err_thr &&
-	    fabsf(accel_ema[1] - CONSTANTS_ONE_G) < accel_err_thr &&
-	    fabsf(accel_ema[2]) < accel_err_thr) {
-		return 2;        // [ 0, g, 0 ]
-	}
-
-	if (fabsf(accel_ema[0]) < accel_err_thr &&
-	    fabsf(accel_ema[1] + CONSTANTS_ONE_G) < accel_err_thr &&
-	    fabsf(accel_ema[2]) < accel_err_thr) {
-		return 3;        // [ 0, -g, 0 ]
-	}
-
-	if (fabsf(accel_ema[0]) < accel_err_thr &&
-	    fabsf(accel_ema[1]) < accel_err_thr &&
-	    fabsf(accel_ema[2] - CONSTANTS_ONE_G) < accel_err_thr) {
-		return 4;        // [ 0, 0, g ]
-	}
-
-	if (fabsf(accel_ema[0]) < accel_err_thr &&
-	    fabsf(accel_ema[1]) < accel_err_thr &&
-	    fabsf(accel_ema[2] + CONSTANTS_ONE_G) < accel_err_thr) {
-		return 5;        // [ 0, 0, -g ]
-	}
-
-	mavlink_and_console_log_critical(mavlink_fd, "ERROR: invalid orientation");
-
-	return ERROR;	// Can't detect orientation
+	return result;
 }
 
 /*
  * Read specified number of accelerometer samples, calculate average and dispersion.
  */
-int read_accelerometer_avg(int (&subs)[max_sens], float (&accel_avg)[max_sens][6][3], unsigned orient, unsigned samples_num)
+int read_accelerometer_avg(int (&subs)[max_accel_sens], float (&accel_avg)[max_accel_sens][detect_orientation_side_count][3], unsigned orient, unsigned samples_num)
 {
-	struct pollfd fds[max_sens];
+	struct pollfd fds[max_accel_sens];
 
-	for (unsigned i = 0; i < max_sens; i++) {
+	for (unsigned i = 0; i < max_accel_sens; i++) {
 		fds[i].fd = subs[i];
 		fds[i].events = POLLIN;
 	}
 
-	unsigned counts[max_sens] = { 0 };
-	float accel_sum[max_sens][3];
+	unsigned counts[max_accel_sens] = { 0 };
+	float accel_sum[max_accel_sens][3];
 	memset(accel_sum, 0, sizeof(accel_sum));
 
 	unsigned errcount = 0;
 
 	/* use the first sensor to pace the readout, but do per-sensor counts */
 	while (counts[0] < samples_num) {
-		int poll_ret = poll(&fds[0], max_sens, 1000);
+		int poll_ret = poll(&fds[0], max_accel_sens, 1000);
 
 		if (poll_ret > 0) {
 
-			for (unsigned s = 0; s < max_sens; s++) {
+			for (unsigned s = 0; s < max_accel_sens; s++) {
 				bool changed;
 				orb_check(subs[s], &changed);
 
@@ -620,7 +437,7 @@ int read_accelerometer_avg(int (&subs)[max_sens], float (&accel_avg)[max_sens][6
 		}
 	}
 
-	for (unsigned s = 0; s < max_sens; s++) {
+	for (unsigned s = 0; s < max_accel_sens; s++) {
 		for (unsigned i = 0; i < 3; i++) {
 			accel_avg[s][orient][i] = accel_sum[s][i] / counts[s];
 		}
@@ -652,7 +469,7 @@ int mat_invert3(float src[3][3], float dst[3][3])
 	return OK;
 }
 
-int calculate_calibration_values(unsigned sensor, float (&accel_ref)[max_sens][6][3], float (&accel_T)[max_sens][3][3], float (&accel_offs)[max_sens][3], float g)
+int calculate_calibration_values(unsigned sensor, float (&accel_ref)[max_accel_sens][detect_orientation_side_count][3], float (&accel_T)[max_accel_sens][3][3], float (&accel_offs)[max_accel_sens][3], float g)
 {
 	/* calculate offsets */
 	for (unsigned i = 0; i < 3; i++) {

--- a/src/modules/commander/calibration_messages.h
+++ b/src/modules/commander/calibration_messages.h
@@ -47,10 +47,12 @@
 #define CAL_FAILED_MSG	"%s calibration: failed"
 #define CAL_PROGRESS_MSG	"%s calibration: progress <%u>"
 
-#define CAL_FAILED_SENSOR_MSG	"ERROR: failed reading sensor"
-#define CAL_FAILED_RESET_CAL_MSG	"ERROR: failed to reset calibration"
-#define CAL_FAILED_APPLY_CAL_MSG	"ERROR: failed to apply calibration"
-#define CAL_FAILED_SET_PARAMS_MSG	"ERROR: failed to set parameters"
+#define	CAL_FAILED_UNKNOWN_ERROR	"ERROR: unknown error"
+#define CAL_FAILED_SENSOR_MSG		"ERROR: failed reading sensor"
+#define CAL_FAILED_RESET_CAL_MSG	"ERROR: failed to reset calibration, sensor %u"
+#define CAL_FAILED_APPLY_CAL_MSG	"ERROR: failed to apply calibration, sensor %u"
+#define CAL_FAILED_SET_PARAMS_MSG	"ERROR: failed to set parameters, sensor %u"
 #define CAL_FAILED_SAVE_PARAMS_MSG	"ERROR: failed to save parameters"
+#define CAL_FAILED_ORIENTATION_TIMEOUT	"ERROR: timed out waiting for correct orientation"
 
 #endif /* CALIBRATION_MESSAGES_H_ */

--- a/src/modules/commander/calibration_routines.cpp
+++ b/src/modules/commander/calibration_routines.cpp
@@ -38,11 +38,22 @@
  * @author Lorenz Meier <lm@inf.ethz.ch>
  */
 
+#include <stdio.h>
 #include <math.h>
 #include <float.h>
+#include <poll.h>
+#include <drivers/drv_hrt.h>
+#include <drivers/drv_accel.h>
+#include <mavlink/mavlink_log.h>
+#include <geo/geo.h>
+#include <string.h>
 
 #include "calibration_routines.h"
+#include "calibration_messages.h"
+#include "commander_helper.h"
 
+// FIXME: Fix return codes
+static const int ERROR = -1;
 
 int sphere_fit_least_squares(const float x[], const float y[], const float z[],
 			     unsigned int size, unsigned int max_iterations, float delta, float *sphere_x, float *sphere_y, float *sphere_z, float *sphere_radius)
@@ -218,3 +229,264 @@ int sphere_fit_least_squares(const float x[], const float y[], const float z[],
 	return 0;
 }
 
+enum detect_orientation_return detect_orientation(int mavlink_fd, int accel_sub)
+{
+	const unsigned ndim = 3;
+	
+	struct accel_report sensor;
+	/* exponential moving average of accel */
+	float accel_ema[ndim] = { 0.0f };
+	/* max-hold dispersion of accel */
+	float accel_disp[3] = { 0.0f, 0.0f, 0.0f };
+	/* EMA time constant in seconds*/
+	float ema_len = 0.5f;
+	/* set "still" threshold to 0.25 m/s^2 */
+	float still_thr2 = powf(0.25f, 2);
+	/* set accel error threshold to 5m/s^2 */
+	float accel_err_thr = 5.0f;
+	/* still time required in us */
+	hrt_abstime still_time = 2000000;
+	struct pollfd fds[1];
+	fds[0].fd = accel_sub;
+	fds[0].events = POLLIN;
+	
+	hrt_abstime t_start = hrt_absolute_time();
+	/* set timeout to 30s */
+	hrt_abstime timeout = 30000000;
+	hrt_abstime t_timeout = t_start + timeout;
+	hrt_abstime t = t_start;
+	hrt_abstime t_prev = t_start;
+	hrt_abstime t_still = 0;
+	
+	unsigned poll_errcount = 0;
+	
+	while (true) {
+		/* wait blocking for new data */
+		int poll_ret = poll(fds, 1, 1000);
+		
+		if (poll_ret) {
+			orb_copy(ORB_ID(sensor_accel), accel_sub, &sensor);
+			t = hrt_absolute_time();
+			float dt = (t - t_prev) / 1000000.0f;
+			t_prev = t;
+			float w = dt / ema_len;
+			
+			for (unsigned i = 0; i < ndim; i++) {
+				
+				float di = 0.0f;
+				switch (i) {
+					case 0:
+						di = sensor.x;
+						break;
+					case 1:
+						di = sensor.y;
+						break;
+					case 2:
+						di = sensor.z;
+						break;
+				}
+				
+				float d = di - accel_ema[i];
+				accel_ema[i] += d * w;
+				d = d * d;
+				accel_disp[i] = accel_disp[i] * (1.0f - w);
+				
+				if (d > still_thr2 * 8.0f) {
+					d = still_thr2 * 8.0f;
+				}
+				
+				if (d > accel_disp[i]) {
+					accel_disp[i] = d;
+				}
+			}
+			
+			/* still detector with hysteresis */
+			if (accel_disp[0] < still_thr2 &&
+			    accel_disp[1] < still_thr2 &&
+			    accel_disp[2] < still_thr2) {
+				/* is still now */
+				if (t_still == 0) {
+					/* first time */
+					mavlink_and_console_log_info(mavlink_fd, "detected rest position, hold still...");
+					t_still = t;
+					t_timeout = t + timeout;
+					
+				} else {
+					/* still since t_still */
+					if (t > t_still + still_time) {
+						/* vehicle is still, exit from the loop to detection of its orientation */
+						break;
+					}
+				}
+				
+			} else if (accel_disp[0] > still_thr2 * 4.0f ||
+				   accel_disp[1] > still_thr2 * 4.0f ||
+				   accel_disp[2] > still_thr2 * 4.0f) {
+				/* not still, reset still start time */
+				if (t_still != 0) {
+					mavlink_and_console_log_info(mavlink_fd, "detected motion, hold still...");
+					sleep(3);
+					t_still = 0;
+				}
+			}
+			
+		} else if (poll_ret == 0) {
+			poll_errcount++;
+		}
+		
+		if (t > t_timeout) {
+			poll_errcount++;
+		}
+		
+		if (poll_errcount > 1000) {
+			mavlink_and_console_log_critical(mavlink_fd, CAL_FAILED_SENSOR_MSG);
+			return DETECT_ORIENTATION_ERROR;
+		}
+	}
+
+	if (fabsf(accel_ema[0] - CONSTANTS_ONE_G) < accel_err_thr &&
+	    fabsf(accel_ema[1]) < accel_err_thr &&
+	    fabsf(accel_ema[2]) < accel_err_thr) {
+		return DETECT_ORIENTATION_TAIL_DOWN;        // [ g, 0, 0 ]
+	}
+	
+	if (fabsf(accel_ema[0] + CONSTANTS_ONE_G) < accel_err_thr &&
+	    fabsf(accel_ema[1]) < accel_err_thr &&
+	    fabsf(accel_ema[2]) < accel_err_thr) {
+		return DETECT_ORIENTATION_NOSE_DOWN;        // [ -g, 0, 0 ]
+	}
+	
+	if (fabsf(accel_ema[0]) < accel_err_thr &&
+	    fabsf(accel_ema[1] - CONSTANTS_ONE_G) < accel_err_thr &&
+	    fabsf(accel_ema[2]) < accel_err_thr) {
+		return DETECT_ORIENTATION_LEFT;        // [ 0, g, 0 ]
+	}
+	
+	if (fabsf(accel_ema[0]) < accel_err_thr &&
+	    fabsf(accel_ema[1] + CONSTANTS_ONE_G) < accel_err_thr &&
+	    fabsf(accel_ema[2]) < accel_err_thr) {
+		return DETECT_ORIENTATION_RIGHT;        // [ 0, -g, 0 ]
+	}
+	
+	if (fabsf(accel_ema[0]) < accel_err_thr &&
+	    fabsf(accel_ema[1]) < accel_err_thr &&
+	    fabsf(accel_ema[2] - CONSTANTS_ONE_G) < accel_err_thr) {
+		return DETECT_ORIENTATION_UPSIDE_DOWN;        // [ 0, 0, g ]
+	}
+	
+	if (fabsf(accel_ema[0]) < accel_err_thr &&
+	    fabsf(accel_ema[1]) < accel_err_thr &&
+	    fabsf(accel_ema[2] + CONSTANTS_ONE_G) < accel_err_thr) {
+		return DETECT_ORIENTATION_RIGHTSIDE_UP;        // [ 0, 0, -g ]
+	}
+	
+	mavlink_and_console_log_critical(mavlink_fd, "ERROR: invalid orientation");
+	
+	return DETECT_ORIENTATION_ERROR;	// Can't detect orientation
+}
+
+const char* detect_orientation_str(enum detect_orientation_return orientation)
+{
+	static const char* rgOrientationStrs[] = {
+		"back",		// tail down
+		"front",	// nose down
+		"left",
+		"right",
+		"up",		// upside-down
+		"down",		// right-side up
+		"error"
+	};
+	
+	return rgOrientationStrs[orientation];
+}
+
+int calibrate_from_orientation(int	mavlink_fd,
+			       bool	side_data_collected[detect_orientation_side_count],
+			       calibration_from_orientation_worker_t calibration_worker,
+			       void*	worker_data)
+{
+	int result = OK;
+	
+	// Setup subscriptions to onboard accel sensor
+	
+	int sub_accel = orb_subscribe_multi(ORB_ID(sensor_accel), 0);
+	if (sub_accel < 0) {
+		mavlink_and_console_log_critical(mavlink_fd, "No onboard accel found, abort");
+		return ERROR;
+	}
+	
+	unsigned orientation_failures = 0;
+	
+	// Rotate through all three main positions
+	while (true) {
+		if (orientation_failures > 10) {
+			result = ERROR;
+			mavlink_and_console_log_info(mavlink_fd, CAL_FAILED_ORIENTATION_TIMEOUT);
+			break;
+		}
+		
+		unsigned int side_complete_count = 0;
+		
+		// Update the number of completed sides
+		for (unsigned i = 0; i < detect_orientation_side_count; i++) {
+			if (side_data_collected[i]) {
+				side_complete_count++;
+			}
+		}
+		
+		if (side_complete_count == detect_orientation_side_count) {
+			// We have completed all sides, move on
+			break;
+		}
+		
+		/* inform user which orientations are still needed */
+		char pendingStr[256];
+		pendingStr[0] = 0;
+		
+		for (unsigned int cur_orientation=0; cur_orientation<detect_orientation_side_count; cur_orientation++) {
+			if (!side_data_collected[cur_orientation]) {
+				strcat(pendingStr, " ");
+				strcat(pendingStr, detect_orientation_str((enum detect_orientation_return)cur_orientation));
+			}
+		}
+		mavlink_and_console_log_info(mavlink_fd, "pending:%s", pendingStr);
+		
+		mavlink_and_console_log_info(mavlink_fd, "hold the vehicle still on one of the pending sides");
+		enum detect_orientation_return orient = detect_orientation(mavlink_fd, sub_accel);
+		
+		if (orient == DETECT_ORIENTATION_ERROR) {
+			orientation_failures++;
+			mavlink_and_console_log_info(mavlink_fd, "detected motion, hold still...");
+			continue;
+		}
+		
+		/* inform user about already handled side */
+		if (side_data_collected[orient]) {
+			orientation_failures++;
+			mavlink_and_console_log_info(mavlink_fd, "%s side already completed or not needed", detect_orientation_str(orient));
+			mavlink_and_console_log_info(mavlink_fd, "rotate to a pending side");
+			continue;
+		}
+		
+		mavlink_and_console_log_info(mavlink_fd, "%s orientation detected", detect_orientation_str(orient));
+		orientation_failures = 0;
+		
+		// Call worker routine
+		calibration_worker(orient, worker_data);
+		
+		mavlink_and_console_log_info(mavlink_fd, "%s side done, rotate to a different side", detect_orientation_str(orient));
+		
+		// Note that this side is complete
+		side_data_collected[orient] = true;
+		tune_neutral(true);
+		sleep(1);
+	}
+	
+	if (sub_accel >= 0) {
+		close(sub_accel);
+	}
+	
+	// FIXME: Do we need an orientation complete routine?
+	
+	return result;
+}

--- a/src/modules/commander/calibration_routines.h
+++ b/src/modules/commander/calibration_routines.h
@@ -59,3 +59,46 @@
 int sphere_fit_least_squares(const float x[], const float y[], const float z[],
 			     unsigned int size, unsigned int max_iterations, float delta, float *sphere_x, float *sphere_y, float *sphere_z,
 			     float *sphere_radius);
+
+// FIXME: Change the name
+static const unsigned max_accel_sens = 3;
+
+// The order of these cannot change since the calibration calculations depend on them in this order
+enum detect_orientation_return {
+	DETECT_ORIENTATION_TAIL_DOWN,
+	DETECT_ORIENTATION_NOSE_DOWN,
+	DETECT_ORIENTATION_LEFT,
+	DETECT_ORIENTATION_RIGHT,
+	DETECT_ORIENTATION_UPSIDE_DOWN,
+	DETECT_ORIENTATION_RIGHTSIDE_UP,
+	DETECT_ORIENTATION_ERROR
+};
+static const unsigned detect_orientation_side_count = 6;
+
+/**
+ * Wait for vehicle to become still and detect it's orientation.
+ *
+ * @param mavlink_fd the MAVLink file descriptor to print output to
+ * @param accel_sub Subscription to onboard accel
+ *
+ * @return detect_orientation)_return according to orientation when vehicle is still and ready for measurements,
+ * DETECT_ORIENTATION_ERROR if vehicle is not still after 30s or orientation error is more than 5m/s^2
+ */
+enum detect_orientation_return detect_orientation(int mavlink_fd, int accel_sub);
+
+
+/**
+ * Returns the human readable string representation of the orientation
+ *
+ * @param orientation Orientation to return string for, "error" if buffer is too small
+ *
+ * @return str Returned orientation string
+ */
+const char* detect_orientation_str(enum detect_orientation_return orientation);
+
+typedef int (*calibration_from_orientation_worker_t)(detect_orientation_return orientation, void* worker_data);
+
+int calibrate_from_orientation(int mavlink_fd,
+			       bool side_data_collected[detect_orientation_side_count],
+			       calibration_from_orientation_worker_t calibration_worker,
+			       void* worker_data);

--- a/src/modules/commander/gyro_calibration.cpp
+++ b/src/modules/commander/gyro_calibration.cpp
@@ -114,7 +114,7 @@ int do_gyro_calibration(int mavlink_fd)
 		close(fd);
 
 		if (res != OK) {
-			mavlink_log_critical(mavlink_fd, CAL_FAILED_RESET_CAL_MSG);
+			mavlink_log_critical(mavlink_fd, CAL_FAILED_RESET_CAL_MSG, s);
 		}
 	}
 

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -49,6 +49,7 @@
 #include <math.h>
 #include <fcntl.h>
 #include <drivers/drv_hrt.h>
+#include <drivers/drv_accel.h>
 #include <uORB/topics/sensor_combined.h>
 #include <drivers/drv_mag.h>
 #include <mavlink/mavlink_log.h>
@@ -62,283 +63,401 @@
 static const int ERROR = -1;
 
 static const char *sensor_name = "mag";
+static const unsigned max_mags = 3;
 
-int calibrate_instance(int mavlink_fd, unsigned s, unsigned device_id);
+int mag_calibrate_all(int mavlink_fd, int32_t (&device_ids)[max_mags]);
+int mag_calibration_worker(detect_orientation_return orientation, void* worker_data);
+
+/// Data passed to calibration worker routine
+typedef struct  {
+	int		mavlink_fd;
+	unsigned	done_count;
+	int		sub_mag[max_mags];
+	unsigned int	calibration_points_perside;
+	unsigned int	calibration_interval_perside_seconds;
+	uint64_t	calibration_interval_perside_useconds;
+	unsigned int	calibration_counter_total;
+	bool		side_data_collected[detect_orientation_side_count];
+	float*		x[max_mags];
+	float*		y[max_mags];
+	float*		z[max_mags];
+} mag_worker_data_t;
+
 
 int do_mag_calibration(int mavlink_fd)
 {
-	const unsigned max_mags = 3;
-
-	int32_t device_id[max_mags];
 	mavlink_and_console_log_info(mavlink_fd, CAL_STARTED_MSG, sensor_name);
-	sleep(1);
 
-	struct mag_scale mscale_null[max_mags] = {
-	{
+	struct mag_scale mscale_null = {
 		0.0f,
 		1.0f,
 		0.0f,
 		1.0f,
 		0.0f,
 		1.0f,
-	}
-	} ;
+	};
 
-	int res = ERROR;
+	int result = OK;
+	
+	// Determine which mags are available and reset each
 
+	int32_t	device_ids[max_mags];
 	char str[30];
 
-	unsigned calibrated_ok = 0;
+	for (size_t i=0; i<max_mags; i++) {
+		device_ids[i] = 0; // signals no mag
+	}
+	
+	for (unsigned cur_mag = 0; cur_mag < max_mags; cur_mag++) {
+		// Reset mag id to mag not available
+		(void)sprintf(str, "CAL_MAG%u_ID", cur_mag);
+		result = param_set_no_notification(param_find(str), &(device_ids[cur_mag]));;
+		if (result != OK) {
+			mavlink_and_console_log_info(mavlink_fd, "Unabled to reset CAL_MAG%u_ID", cur_mag);
+			break;
+		}
 
-	for (unsigned s = 0; s < max_mags; s++) {
-
-		/* erase old calibration */
-		(void)sprintf(str, "%s%u", MAG_BASE_DEVICE_PATH, s);
+		// Attempt to open mag
+		(void)sprintf(str, "%s%u", MAG_BASE_DEVICE_PATH, cur_mag);
 		int fd = open(str, O_RDONLY);
-
 		if (fd < 0) {
 			continue;
 		}
 
-		mavlink_and_console_log_info(mavlink_fd, "Calibrating magnetometer #%u..", s);
-		sleep(3);
+		// Get device id for this mag
+		device_ids[cur_mag] = ioctl(fd, DEVIOCGDEVICEID, 0);
 
-		device_id[s] = ioctl(fd, DEVIOCGDEVICEID, 0);
+		// Reset mag scale
+		result = ioctl(fd, MAGIOCSSCALE, (long unsigned int)&mscale_null);
 
-		/* ensure all scale fields are initialized tha same as the first struct */
-		(void)memcpy(&mscale_null[s], &mscale_null[0], sizeof(mscale_null[0]));
-
-		res = ioctl(fd, MAGIOCSSCALE, (long unsigned int)&mscale_null[s]);
-
-		if (res != OK) {
-			mavlink_and_console_log_critical(mavlink_fd, CAL_FAILED_RESET_CAL_MSG);
+		if (result != OK) {
+			mavlink_and_console_log_critical(mavlink_fd, CAL_FAILED_RESET_CAL_MSG, cur_mag);
 		}
 
-		if (res == OK) {
+		if (result == OK) {
 			/* calibrate range */
-			res = ioctl(fd, MAGIOCCALIBRATE, fd);
+			result = ioctl(fd, MAGIOCCALIBRATE, fd);
 
-			if (res != OK) {
-				mavlink_and_console_log_info(mavlink_fd, "Skipped scale calibration");
+			if (result != OK) {
+				mavlink_and_console_log_info(mavlink_fd, "Skipped scale calibration, sensor %u", cur_mag);
 				/* this is non-fatal - mark it accordingly */
-				res = OK;
+				result = OK;
 			}
 		}
 
 		close(fd);
-
-		if (res == OK) {
-			res = calibrate_instance(mavlink_fd, s, device_id[s]);
-
-			if (res == OK) {
-				calibrated_ok++;
-			}
-		}
 	}
 
-	if (calibrated_ok) {
-
-		mavlink_and_console_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 100);
-		usleep(100000);
-		mavlink_and_console_log_info(mavlink_fd, CAL_DONE_MSG, sensor_name);
-
+	if (result == OK) {
+		// Calibrate all mags at the same time
+		result = mag_calibrate_all(mavlink_fd, device_ids);
+	}
+	
+	if (result == OK) {
 		/* auto-save to EEPROM */
-		res = param_save_default();
-
-		if (res != OK) {
+		result = param_save_default();
+		if (result != OK) {
 			mavlink_and_console_log_critical(mavlink_fd, CAL_FAILED_SAVE_PARAMS_MSG);
 		}
+	}
+	
+	if (result == OK) {
+		mavlink_and_console_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 100);
+		mavlink_and_console_log_info(mavlink_fd, CAL_DONE_MSG, sensor_name);
 	} else {
 		mavlink_and_console_log_critical(mavlink_fd, CAL_FAILED_MSG, sensor_name);
 	}
 
-	return res;
+	return result;
 }
 
-int calibrate_instance(int mavlink_fd, unsigned s, unsigned device_id)
+int mag_calibration_worker(detect_orientation_return orientation, void* data)
 {
-	/* 45 seconds */
-	uint64_t calibration_interval = 25 * 1000 * 1000;
-
-	/* maximum 500 values */
-	const unsigned int calibration_maxcount = 240;
-	unsigned int calibration_counter;
-
-	float *x = new float[calibration_maxcount];
-	float *y = new float[calibration_maxcount];
-	float *z = new float[calibration_maxcount];
-
-	char str[30];
-	int res = OK;
+	int result = OK;
 	
-	/* allocate memory */
-	mavlink_and_console_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 20);
+	unsigned int calibration_counter_side;
 
-	if (x == nullptr || y == nullptr || z == nullptr) {
-		mavlink_and_console_log_critical(mavlink_fd, "ERROR: out of memory");
-
-		/* clean up */
-		if (x != nullptr) {
-			delete x;
+	mag_worker_data_t* worker_data = (mag_worker_data_t*)(data);
+	
+	mavlink_and_console_log_info(worker_data->mavlink_fd, "Rotate vehicle around the detected orientation");
+	mavlink_and_console_log_info(worker_data->mavlink_fd, "Continue rotation for %u seconds", worker_data->calibration_interval_perside_seconds);
+	sleep(2);
+	
+	uint64_t calibration_deadline = hrt_absolute_time() + worker_data->calibration_interval_perside_useconds;
+	unsigned poll_errcount = 0;
+	
+	calibration_counter_side = 0;
+	
+	while (hrt_absolute_time() < calibration_deadline &&
+	       calibration_counter_side < worker_data->calibration_points_perside) {
+		
+		// Wait clocking for new data on all mags
+		struct pollfd fds[max_mags];
+		size_t fd_count = 0;
+		for (size_t cur_mag=0; cur_mag<max_mags; cur_mag++) {
+			if (worker_data->sub_mag[cur_mag] >= 0) {
+				fds[fd_count].fd = worker_data->sub_mag[cur_mag];
+				fds[fd_count].events = POLLIN;
+				fd_count++;
+			}
 		}
+		int poll_ret = poll(fds, fd_count, 1000);
+		
+		if (poll_ret > 0) {
+			for (size_t cur_mag=0; cur_mag<max_mags; cur_mag++) {
+				if (worker_data->sub_mag[cur_mag] >= 0) {
+					struct mag_report mag;
 
-		if (y != nullptr) {
-			delete y;
+					orb_copy(ORB_ID(sensor_mag), worker_data->sub_mag[cur_mag], &mag);
+					
+					worker_data->x[cur_mag][worker_data->calibration_counter_total] = mag.x;
+					worker_data->y[cur_mag][worker_data->calibration_counter_total] = mag.y;
+					worker_data->z[cur_mag][worker_data->calibration_counter_total] = mag.z;
+					
+				}
+			}
+			
+			worker_data->calibration_counter_total++;
+			calibration_counter_side++;
+			
+			// Progress indicator for side
+			mavlink_and_console_log_info(worker_data->mavlink_fd,
+						     "%s %s side calibration: progress <%u>",
+						     sensor_name,
+						     detect_orientation_str(orientation),
+						     (unsigned)(100 * ((float)calibration_counter_side / (float)worker_data->calibration_points_perside)));
+		} else {
+			poll_errcount++;
 		}
-
-		if (z != nullptr) {
-			delete z;
+		
+		if (poll_errcount > worker_data->calibration_points_perside * 3) {
+			result = ERROR;
+			mavlink_and_console_log_info(worker_data->mavlink_fd, CAL_FAILED_SENSOR_MSG);
+			break;
 		}
+	}
+	
+	// Mark the opposite side as collected as well. No need to collect opposite side since it
+	// would generate similar points.
+	switch (orientation) {
+		case DETECT_ORIENTATION_TAIL_DOWN:
+			worker_data->side_data_collected[DETECT_ORIENTATION_NOSE_DOWN] = true;
+			break;
+		case DETECT_ORIENTATION_NOSE_DOWN:
+			worker_data->side_data_collected[DETECT_ORIENTATION_TAIL_DOWN] = true;
+			break;
+		case DETECT_ORIENTATION_LEFT:
+			worker_data->side_data_collected[DETECT_ORIENTATION_RIGHT] = true;
+			break;
+		case DETECT_ORIENTATION_RIGHT:
+			worker_data->side_data_collected[DETECT_ORIENTATION_LEFT] = true;
+			break;
+		case DETECT_ORIENTATION_UPSIDE_DOWN:
+			worker_data->side_data_collected[DETECT_ORIENTATION_RIGHTSIDE_UP] = true;
+			break;
+		case DETECT_ORIENTATION_RIGHTSIDE_UP:
+			worker_data->side_data_collected[DETECT_ORIENTATION_UPSIDE_DOWN] = true;
+			break;
+		case DETECT_ORIENTATION_ERROR:
+			warnx("Invalid orientation in mag_calibration_worker");
+			break;
+	}
+	
+	worker_data->done_count++;
+	mavlink_and_console_log_info(worker_data->mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 34 * worker_data->done_count);
+	
+	return result;
+}
 
-		res = ERROR;
-		return res;
+int mag_calibrate_all(int mavlink_fd, int32_t (&device_ids)[max_mags])
+{
+	int result = OK;
+
+	mag_worker_data_t worker_data;
+	
+	worker_data.mavlink_fd = mavlink_fd;
+	worker_data.done_count = 0;
+	worker_data.calibration_counter_total = 0;
+	worker_data.calibration_points_perside = 80;
+	worker_data.calibration_interval_perside_seconds = 20;
+	worker_data.calibration_interval_perside_useconds = worker_data.calibration_interval_perside_seconds * 1000 * 1000;
+
+	// Initialize to collect all sides
+	for (size_t cur_side=0; cur_side<6; cur_side++) {
+		worker_data.side_data_collected[cur_side] = false;
+	}
+	
+	for (size_t cur_mag=0; cur_mag<max_mags; cur_mag++) {
+		// Initialize to no subscription
+		worker_data.sub_mag[cur_mag] = -1;
+		
+		// Initialize to no memory allocated
+		worker_data.x[cur_mag] = NULL;
+		worker_data.y[cur_mag] = NULL;
+		worker_data.z[cur_mag] = NULL;
 	}
 
-	if (res == OK) {
-		int sub_mag = orb_subscribe_multi(ORB_ID(sensor_mag), s);
+	const unsigned int calibration_sides = 3;
+	const unsigned int calibration_points_maxcount = calibration_sides * worker_data.calibration_points_perside;
+	
+	char str[30];
+	
+	for (size_t cur_mag=0; cur_mag<max_mags; cur_mag++) {
+		worker_data.x[cur_mag] = reinterpret_cast<float *>(malloc(sizeof(float) * calibration_points_maxcount));
+		worker_data.y[cur_mag] = reinterpret_cast<float *>(malloc(sizeof(float) * calibration_points_maxcount));
+		worker_data.z[cur_mag] = reinterpret_cast<float *>(malloc(sizeof(float) * calibration_points_maxcount));
+		if (worker_data.x[cur_mag] == NULL || worker_data.y[cur_mag] == NULL || worker_data.z[cur_mag] == NULL) {
+			mavlink_and_console_log_critical(mavlink_fd, "ERROR: out of memory");
+			result = ERROR;
+		}
+	}
 
-		if (sub_mag < 0) {
-			mavlink_and_console_log_critical(mavlink_fd, "No mag found, abort");
-			res = ERROR;
-		}  else {
-			struct mag_report mag;
-
-			/* limit update rate to get equally spaced measurements over time (in ms) */
-			orb_set_interval(sub_mag, (calibration_interval / 1000) / calibration_maxcount);
-
-			/* calibrate offsets */
-			uint64_t calibration_deadline = hrt_absolute_time() + calibration_interval;
-			unsigned poll_errcount = 0;
-
-			mavlink_and_console_log_info(mavlink_fd, "Turn on all sides: front/back,left/right,up/down");
-
-			calibration_counter = 0U;
-
-			while (hrt_absolute_time() < calibration_deadline &&
-			       calibration_counter < calibration_maxcount) {
-
-				/* wait blocking for new data */
-				struct pollfd fds[1];
-				fds[0].fd = sub_mag;
-				fds[0].events = POLLIN;
-
-				int poll_ret = poll(fds, 1, 1000);
-
-				if (poll_ret > 0) {
-					orb_copy(ORB_ID(sensor_mag), sub_mag, &mag);
-
-					x[calibration_counter] = mag.x;
-					y[calibration_counter] = mag.y;
-					z[calibration_counter] = mag.z;
-
-					calibration_counter++;
-
-					if (calibration_counter % (calibration_maxcount / 20) == 0) {
-						mavlink_and_console_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 20 + (calibration_counter * 50) / calibration_maxcount);
-					}
-
-				} else {
-					poll_errcount++;
-				}
-
-				if (poll_errcount > 1000) {
-					mavlink_and_console_log_critical(mavlink_fd, CAL_FAILED_SENSOR_MSG);
-					res = ERROR;
+	
+	// Setup subscriptions to mag sensors
+	if (result == OK) {
+		for (unsigned cur_mag=0; cur_mag<max_mags; cur_mag++) {
+			if (device_ids[cur_mag] != 0) {
+				// Mag in this slot is available
+				worker_data.sub_mag[cur_mag] = orb_subscribe_multi(ORB_ID(sensor_mag), cur_mag);
+				if (worker_data.sub_mag[cur_mag] < 0) {
+					mavlink_and_console_log_critical(mavlink_fd, "Mag #%u not found, abort", cur_mag);
+					result = ERROR;
 					break;
 				}
 			}
-
-			close(sub_mag);
 		}
 	}
-
-	float sphere_x;
-	float sphere_y;
-	float sphere_z;
-	float sphere_radius;
-
-	if (res == OK && calibration_counter > (calibration_maxcount / 2)) {
-
-		/* sphere fit */
-		mavlink_and_console_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 70);
-		sphere_fit_least_squares(x, y, z, calibration_counter, 100, 0.0f, &sphere_x, &sphere_y, &sphere_z, &sphere_radius);
-		mavlink_and_console_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 80);
-
-		if (!isfinite(sphere_x) || !isfinite(sphere_y) || !isfinite(sphere_z)) {
-			mavlink_and_console_log_critical(mavlink_fd, "ERROR: NaN in sphere fit");
-			res = ERROR;
-		}
-	}
-
-	if (x != nullptr) {
-		delete x;
-	}
-
-	if (y != nullptr) {
-		delete y;
-	}
-
-	if (z != nullptr) {
-		delete z;
-	}
-
-	if (res == OK) {
-		/* apply calibration and set parameters */
-		struct mag_scale mscale;
-		(void)sprintf(str, "%s%u", MAG_BASE_DEVICE_PATH, s);
-		int fd = open(str, 0);
-		res = ioctl(fd, MAGIOCGSCALE, (long unsigned int)&mscale);
-
-		if (res != OK) {
-			mavlink_and_console_log_critical(mavlink_fd, "ERROR: failed to get current calibration");
-		}
-
-		if (res == OK) {
-			mscale.x_offset = sphere_x;
-			mscale.y_offset = sphere_y;
-			mscale.z_offset = sphere_z;
-
-			res = ioctl(fd, MAGIOCSSCALE, (long unsigned int)&mscale);
-
-			if (res != OK) {
-				mavlink_and_console_log_critical(mavlink_fd, CAL_FAILED_APPLY_CAL_MSG);
+	
+	// Limit update rate to get equally spaced measurements over time (in ms)
+	if (result == OK) {
+		for (unsigned cur_mag=0; cur_mag<max_mags; cur_mag++) {
+			if (device_ids[cur_mag] != 0) {
+				// Mag in this slot is available
+				unsigned int orb_interval_msecs = (worker_data.calibration_interval_perside_useconds / 1000) / worker_data.calibration_points_perside;
+				
+				//mavlink_and_console_log_info(mavlink_fd, "Orb interval %u msecs", orb_interval_msecs);
+				orb_set_interval(worker_data.sub_mag[cur_mag], orb_interval_msecs);
 			}
 		}
-
-		close(fd);
-
-		if (res == OK) {
-
-			bool failed = false;
-			/* set parameters */
-			(void)sprintf(str, "CAL_MAG%u_ID", s);
-			failed |= (OK != param_set(param_find(str), &(device_id)));
-			(void)sprintf(str, "CAL_MAG%u_XOFF", s);
-			failed |= (OK != param_set(param_find(str), &(mscale.x_offset)));
-			(void)sprintf(str, "CAL_MAG%u_YOFF", s);
-			failed |= (OK != param_set(param_find(str), &(mscale.y_offset)));
-			(void)sprintf(str, "CAL_MAG%u_ZOFF", s);
-			failed |= (OK != param_set(param_find(str), &(mscale.z_offset)));
-			(void)sprintf(str, "CAL_MAG%u_XSCALE", s);
-			failed |= (OK != param_set(param_find(str), &(mscale.x_scale)));
-			(void)sprintf(str, "CAL_MAG%u_YSCALE", s);
-			failed |= (OK != param_set(param_find(str), &(mscale.y_scale)));
-			(void)sprintf(str, "CAL_MAG%u_ZSCALE", s);
-			failed |= (OK != param_set(param_find(str), &(mscale.z_scale)));
-
-			if (failed) {
-				res = ERROR;
-				mavlink_and_console_log_critical(mavlink_fd, CAL_FAILED_SET_PARAMS_MSG);
-			}
-
-			mavlink_and_console_log_info(mavlink_fd, CAL_PROGRESS_MSG, sensor_name, 90);
-		}
-
-		mavlink_and_console_log_info(mavlink_fd, "mag off: x:%.2f y:%.2f z:%.2f Ga", (double)mscale.x_offset,
-				 (double)mscale.y_offset, (double)mscale.z_offset);
-		mavlink_and_console_log_info(mavlink_fd, "mag scale: x:%.2f y:%.2f z:%.2f", (double)mscale.x_scale,
-				 (double)mscale.y_scale, (double)mscale.z_scale);
+		
 	}
 
-	return res;
+	result = calibrate_from_orientation(mavlink_fd, worker_data.side_data_collected, mag_calibration_worker, &worker_data);
+	
+	// Close subscriptions
+	for (unsigned cur_mag=0; cur_mag<max_mags; cur_mag++) {
+		if (worker_data.sub_mag[cur_mag] >= 0) {
+			close(worker_data.sub_mag[cur_mag]);
+		}
+	}
+	
+	// Calculate calibration values for each mag
+	
+	
+	float sphere_x[max_mags];
+	float sphere_y[max_mags];
+	float sphere_z[max_mags];
+	float sphere_radius[max_mags];
+	
+	// Sphere fit the data to get calibration values
+	if (result == OK) {
+		for (unsigned cur_mag=0; cur_mag<max_mags; cur_mag++) {
+			if (device_ids[cur_mag] != 0) {
+				// Mag in this slot is available and we should have values for it to calibrate
+				
+				sphere_fit_least_squares(worker_data.x[cur_mag], worker_data.y[cur_mag], worker_data.z[cur_mag],
+							 worker_data.calibration_counter_total,
+							 100, 0.0f,
+							 &sphere_x[cur_mag], &sphere_y[cur_mag], &sphere_z[cur_mag],
+							 &sphere_radius[cur_mag]);
+				
+				if (!isfinite(sphere_x[cur_mag]) || !isfinite(sphere_y[cur_mag]) || !isfinite(sphere_z[cur_mag])) {
+					mavlink_and_console_log_info(mavlink_fd, "ERROR: NaN in sphere fit for mag #%u", cur_mag);
+					result = ERROR;
+				}
+			}
+		}
+	}
+	
+	// Data points are no longer needed
+	for (size_t cur_mag=0; cur_mag<max_mags; cur_mag++) {
+		free(worker_data.x[cur_mag]);
+		free(worker_data.y[cur_mag]);
+		free(worker_data.z[cur_mag]);
+	}
+	
+	if (result == OK) {
+		for (unsigned cur_mag=0; cur_mag<max_mags; cur_mag++) {
+			if (device_ids[cur_mag] != 0) {
+				int fd_mag = -1;
+				struct mag_scale mscale;
+				
+				// Set new scale
+				
+				(void)sprintf(str, "%s%u", MAG_BASE_DEVICE_PATH, cur_mag);
+				fd_mag = open(str, 0);
+				if (fd_mag < 0) {
+					mavlink_and_console_log_info(mavlink_fd, "ERROR: unable to open mag device #%u", cur_mag);
+					result = ERROR;
+				}
+				
+				if (result == OK) {
+					result = ioctl(fd_mag, MAGIOCGSCALE, (long unsigned int)&mscale);
+					if (result != OK) {
+						mavlink_and_console_log_info(mavlink_fd, "ERROR: failed to get current calibration #%u", cur_mag);
+						result = ERROR;
+					}
+				}
+
+				if (result == OK) {
+					mscale.x_offset = sphere_x[cur_mag];
+					mscale.y_offset = sphere_y[cur_mag];
+					mscale.z_offset = sphere_z[cur_mag];
+
+					result = ioctl(fd_mag, MAGIOCSSCALE, (long unsigned int)&mscale);
+					if (result != OK) {
+						mavlink_and_console_log_info(mavlink_fd, CAL_FAILED_APPLY_CAL_MSG, cur_mag);
+						result = ERROR;
+					}
+				}
+				
+				// Mag device no longer needed
+				if (fd_mag >= 0) {
+					close(fd_mag);
+				}
+
+				if (result == OK) {
+					bool failed = false;
+					
+					/* set parameters */
+					(void)sprintf(str, "CAL_MAG%u_XOFF", cur_mag);
+					failed |= (OK != param_set_no_notification(param_find(str), &(mscale.x_offset)));
+					(void)sprintf(str, "CAL_MAG%u_YOFF", cur_mag);
+					failed |= (OK != param_set_no_notification(param_find(str), &(mscale.y_offset)));
+					(void)sprintf(str, "CAL_MAG%u_ZOFF", cur_mag);
+					failed |= (OK != param_set_no_notification(param_find(str), &(mscale.z_offset)));
+					(void)sprintf(str, "CAL_MAG%u_XSCALE", cur_mag);
+					failed |= (OK != param_set_no_notification(param_find(str), &(mscale.x_scale)));
+					(void)sprintf(str, "CAL_MAG%u_YSCALE", cur_mag);
+					failed |= (OK != param_set_no_notification(param_find(str), &(mscale.y_scale)));
+					(void)sprintf(str, "CAL_MAG%u_ZSCALE", cur_mag);
+					failed |= (OK != param_set_no_notification(param_find(str), &(mscale.z_scale)));
+
+					if (failed) {
+						mavlink_and_console_log_info(mavlink_fd, CAL_FAILED_SET_PARAMS_MSG, cur_mag);
+						result = ERROR;
+					} else {
+						mavlink_and_console_log_info(mavlink_fd, "mag #%u off: x:%.2f y:%.2f z:%.2f Ga",
+									     cur_mag,
+									     (double)mscale.x_offset, (double)mscale.y_offset, (double)mscale.z_offset);
+						mavlink_and_console_log_info(mavlink_fd, "mag #%u scale: x:%.2f y:%.2f z:%.2f",
+									     cur_mag,
+									     (double)mscale.x_scale, (double)mscale.y_scale, (double)mscale.z_scale);
+					}
+				}
+			}
+		}
+	}
+
+	return result;
 }

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -111,7 +111,7 @@ int do_mag_calibration(int mavlink_fd)
 	for (unsigned cur_mag = 0; cur_mag < max_mags; cur_mag++) {
 		// Reset mag id to mag not available
 		(void)sprintf(str, "CAL_MAG%u_ID", cur_mag);
-		result = param_set_no_notification(param_find(str), &(device_ids[cur_mag]));;
+		result = param_set_no_notification(param_find(str), &(device_ids[cur_mag]));
 		if (result != OK) {
 			mavlink_and_console_log_info(mavlink_fd, "Unabled to reset CAL_MAG%u_ID", cur_mag);
 			break;
@@ -430,6 +430,8 @@ int mag_calibrate_all(int mavlink_fd, int32_t (&device_ids)[max_mags])
 					bool failed = false;
 					
 					/* set parameters */
+					(void)sprintf(str, "CAL_MAG%u_ID", cur_mag);
+					failed |= (OK != param_set_no_notification(param_find(str), &(device_ids[cur_mag])));
 					(void)sprintf(str, "CAL_MAG%u_XOFF", cur_mag);
 					failed |= (OK != param_set_no_notification(param_find(str), &(mscale.x_offset)));
 					(void)sprintf(str, "CAL_MAG%u_YOFF", cur_mag);

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -145,7 +145,7 @@
 #endif
 static const int ERROR = -1;
 
-#define CAL_FAILED_APPLY_CAL_MSG "FAILED APPLYING SENSOR CAL"
+#define CAL_FAILED_APPLY_CAL_MSG "FAILED APPLYING %s CAL #%u"
 
 /**
  * Sensor app start / stop handling function
@@ -1373,12 +1373,12 @@ Sensors::parameter_update_poll(bool forced)
 					failed = failed || (OK != param_get(param_find(str), &gscale.z_scale));
 
 					if (failed) {
-						warnx("%s: gyro #%u", CAL_FAILED_APPLY_CAL_MSG, gyro_count);
+						warnx(CAL_FAILED_APPLY_CAL_MSG, "gyro", i);
 					} else {
 						/* apply new scaling and offsets */
 						res = ioctl(fd, GYROIOCSSCALE, (long unsigned int)&gscale);
 						if (res) {
-							warnx(CAL_FAILED_APPLY_CAL_MSG);
+							warnx(CAL_FAILED_APPLY_CAL_MSG, "gyro", i);
 						} else {
 							gyro_count++;
 							config_ok = true;
@@ -1440,12 +1440,12 @@ Sensors::parameter_update_poll(bool forced)
 					failed = failed || (OK != param_get(param_find(str), &gscale.z_scale));
 
 					if (failed) {
-						warnx("%s: acc #%u", CAL_FAILED_APPLY_CAL_MSG, accel_count);
+						warnx(CAL_FAILED_APPLY_CAL_MSG, "accel", i);
 					} else {
 						/* apply new scaling and offsets */
 						res = ioctl(fd, ACCELIOCSSCALE, (long unsigned int)&gscale);
 						if (res) {
-							warnx(CAL_FAILED_APPLY_CAL_MSG);
+							warnx(CAL_FAILED_APPLY_CAL_MSG, "accel", i);
 						} else {
 							accel_count++;
 							config_ok = true;
@@ -1557,12 +1557,12 @@ Sensors::parameter_update_poll(bool forced)
 					}
 
 					if (failed) {
-						warnx("%s: mag #%u", CAL_FAILED_APPLY_CAL_MSG, mag_count);
+						warnx(CAL_FAILED_APPLY_CAL_MSG, "mag", i);
 					} else {
 						/* apply new scaling and offsets */
 						res = ioctl(fd, MAGIOCSSCALE, (long unsigned int)&gscale);
 						if (res) {
-							warnx(CAL_FAILED_APPLY_CAL_MSG);
+							warnx(CAL_FAILED_APPLY_CAL_MSG, "mag", i);
 						} else {
 							mag_count++;
 							config_ok = true;


### PR DESCRIPTION
Smaller changes:
- Added new calibrate_from_orientation worker routines which is used by both mag and accel cal. It waits for the vehicle to be put into an orientation and then calls a worker routine to do the actual calibration. It will time out after 10 failed tried at detected an orientation
- Many updates/fixes to log messages

New mag calibration:
- All available mags are calibrated at the same time
- Calibration points are collected one side at a time. You need to get points from 3 sides to form the sphere.
- There a now two progress indicators: The overall progress indicator as well as the progress indicator for a specific side. The reason for this if for QGC to be able to display both of these separately.

I tested these changes on my Iris+ and also ran calibration from the current master. Both runs have nearly identical calibration values. That said this is a fairly major changes to mag cal, and some smaller changes to accel cal. They both could use some testing by someone other than me before this gets merged.