### PR TITLE
PX4IO driver: Add mapping of AUX1-3 channels, in case these are also use...

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1291,6 +1291,24 @@ PX4IO::io_set_rc_config()
 		input_map[ichan - 1] = 4;
 	}
 
+	/* AUX 1*/
+	param_get(param_find("RC_MAP_AUX1"), &ichan);
+	if ((ichan > 0) && (ichan <= (int)_max_rc_input)) {
+		input_map[ichan - 1] = 5;
+	}
+
+	/* AUX 2*/
+	param_get(param_find("RC_MAP_AUX2"), &ichan);
+	if ((ichan > 0) && (ichan <= (int)_max_rc_input)) {
+		input_map[ichan - 1] = 6;
+	}
+
+	/* AUX 3*/
+	param_get(param_find("RC_MAP_AUX3"), &ichan);
+	if ((ichan > 0) && (ichan <= (int)_max_rc_input)) {
+		input_map[ichan - 1] = 7;
+	}
+
 	/* MAIN MODE SWITCH */
 	param_get(param_find("RC_MAP_MODE_SW"), &ichan);
 	if ((ichan > 0) && (ichan <= (int)_max_rc_input)) {


### PR DESCRIPTION
...d as control surface inputs.

This is a fix as discussed with Lorenz offline. At the moment, FMU maps all control functions, while IO was only mapping throttle, roll, pitch, yaw, flaps and main mode. This can result in inconsistencies when switching between FMU-controlled operation and IO-controlled flight operation (e.g. when FMU crashes).