### PR TITLE
Remove branch switch for euroc simulator

### DIFF
--- a/Tools/ros/px4_workspace_setup.sh
+++ b/Tools/ros/px4_workspace_setup.sh
@@ -10,9 +10,6 @@ git clone https://github.com/PX4/Firmware.git
 
 # euroc simulator
 git clone https://github.com/PX4/euroc_simulator.git
-cd euroc_simulator
-git checkout px4_nodes
-cd ..
 
 # mav comm
 git clone https://github.com/PX4/mav_comm.git


### PR DESCRIPTION
for reference: #1910 (no fix)
@LorenzMeier euroc master should not have that odometry plugin issue