### PR TITLE
Added flag to uorb publish wrapper...resolves no actuators in manual mod...

### DIFF
--- a/src/modules/fw_att_control/fw_att_control_main.cpp
+++ b/src/modules/fw_att_control/fw_att_control_main.cpp
@@ -1079,7 +1079,8 @@ FixedwingAttitudeControl::task_main()
 
 			/* Only publish if any of the proper modes are enabled */
 			if(_vcontrol_mode.flag_control_rates_enabled ||
-			   _vcontrol_mode.flag_control_attitude_enabled)
+               _vcontrol_mode.flag_control_attitude_enabled ||
+               _vcontrol_mode.flag_control_manual_enabled)
 			{
 				/* publish the actuator controls */
 				if (_actuators_0_pub > 0) {


### PR DESCRIPTION
...e in fw_att_control.     Uorb actuator publish needed a manual mode flag. Manual mode previously resulted in no actuator response.