### PR TITLE
hmc5883 temperature compensation

### DIFF
--- a/src/drivers/drv_mag.h
+++ b/src/drivers/drv_mag.h
@@ -129,4 +129,7 @@ ORB_DECLARE(sensor_mag);
 /** determine if mag is external or onboard */
 #define MAGIOCGEXTERNAL		_MAGIOC(11)
 
+/** enable/disable temperature compensation */
+#define MAGIOCSTEMPCOMP		_MAGIOC(12)
+
 #endif /* _DRV_MAG_H */


### PR DESCRIPTION
this also fixes the -C option to hmc5883 start for automatic scaling calibration on startup
