### PR TITLE
Shifted the set() function for Matrix3x3, Vector2, Vector3, Vector4 to a...

### DIFF
--- a/src/lib/mathlib/math/Matrix.hpp
+++ b/src/lib/mathlib/math/Matrix.hpp
@@ -126,15 +126,6 @@ public:
 		memcpy(data, d, sizeof(data));
 	}
 
-#if defined(__PX4_ROS)
-	/**
-	 * set data from boost::array
-	 */
-	void set(const boost::array<float, 9ul> d) {
-	set(static_cast<const float*>(d.data()));
-	}
-#endif
-
 	/**
 	 * access by index
 	 */
@@ -427,6 +418,21 @@ public:
 	Matrix(const float *d) : MatrixBase<3, 3>(d) {}
 
 	Matrix(const float d[3][3]) : MatrixBase<3, 3>(d) {}
+	/**
+	 * set data
+	 */
+	void set(const float d[9]) {
+		memcpy(data, d, sizeof(data));
+	}
+
+#if defined(__PX4_ROS)
+	/**
+	 * set data from boost::array
+	 */
+	void set(const boost::array<float, 9ul> d) {
+	set(static_cast<const float*>(d.data()));
+	}
+#endif
 
 	/**
 	 * set to value

--- a/src/lib/mathlib/math/Vector.hpp
+++ b/src/lib/mathlib/math/Vector.hpp
@@ -407,7 +407,14 @@ public:
 		data[0] = d[0];
 		data[1] = d[1];
 	}
-
+#if defined(__PX4_ROS)
+	/**
+	 * set data from boost::array
+	 */
+	void set(const boost::array<float, 2ul> d) {
+	set(static_cast<const float*>(d.data()));
+	}
+#endif
 	/**
 	 * set to value
 	 */
@@ -444,6 +451,14 @@ public:
 		data[1] = y;
 		data[2] = z;
 	}
+#if defined(__PX4_ROS)
+	/**
+	 * set data from boost::array
+	 */
+	void set(const boost::array<float, 3ul> d) {
+	set(static_cast<const float*>(d.data()));
+	}
+#endif
 
 	/**
 	 * set data
@@ -494,6 +509,14 @@ public:
 		data[2] = x2;
 		data[3] = x3;
 	}
+#if defined(__PX4_ROS)
+	/**
+	 * set data from boost::array
+	 */
+	void set(const boost::array<float, 4ul> d) {
+	set(static_cast<const float*>(d.data()));
+	}
+#endif
 
 	/**
 	 * set data


### PR DESCRIPTION
Fix issue #1963 

In file lib/mathlib/math/Matrix.hpp
```
#if defined(__PX4_ROS)
	/**
	 * set data from boost::array
	 */
	void set(const boost::array<float, 9ul> d) {
	set(static_cast<const float*>(d.data()));
	}
#endif
```
Shifted to derived class. Also added similar functions to vector class
