### PR TITLE
parameter for parameter autosave

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1409,14 +1409,14 @@ int commander_thread_main(int argc, char *argv[])
 			if(status.condition_global_position_valid) {
 				set_tune_override(TONE_GPS_WARNING_TUNE);
 				status_changed = true;
-				status.condition_global_position_valid = false;		
+				status.condition_global_position_valid = false;
 			}
 		}
 		else if(global_position.timestamp != 0) {
 			//Got good global position estimate
 			if(!status.condition_global_position_valid) {
 				status_changed = true;
-				status.condition_global_position_valid = true;				
+				status.condition_global_position_valid = true;
 			}
 		}
 

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -164,7 +164,7 @@ static bool commander_initialized = false;
 static volatile bool thread_should_exit = false;	/**< daemon exit flag */
 static volatile bool thread_running = false;		/**< daemon status flag */
 static int daemon_task;					/**< Handle of daemon task / thread */
-static bool _param_autosave = false;
+static bool need_param_autosave = false;		/**< Flag set to true if parameters should be autosaved in next iteration (happens on param update and if functionality is enabled) */
 
 static unsigned int leds_counter;
 /* To remember when last notification was sent */
@@ -1163,7 +1163,7 @@ int commander_thread_main(int argc, char *argv[])
 
 		if (updated) {
 			/* trigger an autosave */
-			_param_autosave = true;
+			need_param_autosave = true;
 		}
 
 		if (updated || param_init_forced) {
@@ -2543,7 +2543,7 @@ void *commander_low_prio_loop(void *arg)
 	memset(&cmd, 0, sizeof(cmd));
 
 	/* timeout for param autosave */
-	hrt_abstime _param_autosave_timeout = 0;
+	hrt_abstime need_param_autosave_timeout = 0;
 
 	/* wakeup source(s) */
 	struct pollfd fds[1];
@@ -2559,8 +2559,8 @@ void *commander_low_prio_loop(void *arg)
 		/* timed out - periodic check for thread_should_exit, etc. */
 		if (pret == 0) {
 			/* trigger a param autosave if required */
-			if (_param_autosave) {
-				if (_param_autosave_timeout > 0 && hrt_elapsed_time(&_param_autosave_timeout) > 200000ULL) {
+			if (need_param_autosave) {
+				if (need_param_autosave_timeout > 0 && hrt_elapsed_time(&need_param_autosave_timeout) > 200000ULL) {
 					int ret = param_save_default();
 
 					if (ret == OK) {
@@ -2570,10 +2570,10 @@ void *commander_low_prio_loop(void *arg)
 						mavlink_and_console_log_critical(mavlink_fd, "settings save error");
 					}
 
-					_param_autosave = false;
-					_param_autosave_timeout = 0;
+					need_param_autosave = false;
+					need_param_autosave_timeout = 0;
 				} else {
-					_param_autosave_timeout = hrt_absolute_time();
+					need_param_autosave_timeout = hrt_absolute_time();
 				}
 			}
 		} else if (pret < 0) {

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -156,7 +156,7 @@ enum MAV_MODE_FLAG {
 /* Mavlink file descriptors */
 static int mavlink_fd = 0;
 
-/* Syste autostart ID */
+/* System autostart ID */
 static int autostart_id;
 
 /* flags */
@@ -824,6 +824,7 @@ int commander_thread_main(int argc, char *argv[])
 	param_t _param_ef_current2throttle_thres = param_find("COM_EF_C2T");
 	param_t _param_ef_time_thres = param_find("COM_EF_TIME");
 	param_t _param_autostart_id = param_find("SYS_AUTOSTART");
+	param_t _param_autosave_params = param_find("COM_AUTOS_PAR");
 
 	const char *main_states_str[vehicle_status_s::MAIN_STATE_MAX];
 	main_states_str[vehicle_status_s::MAIN_STATE_MANUAL]			= "MANUAL";
@@ -1129,6 +1130,8 @@ int commander_thread_main(int argc, char *argv[])
 	int32_t ef_time_thres = 1000.0f;
 	uint64_t timestamp_engine_healthy = 0; /**< absolute time when engine was healty */
 
+	int autosave_params; /**< Autosave of parameters enabled/disabled, loaded from parameter */
+
 	/* check which state machines for changes, clear "changed" flag */
 	bool arming_state_changed = false;
 	bool main_state_changed = false;
@@ -1160,11 +1163,6 @@ int commander_thread_main(int argc, char *argv[])
 
 		/* update parameters */
 		orb_check(param_changed_sub, &updated);
-
-		if (updated) {
-			/* trigger an autosave */
-			need_param_autosave = true;
-		}
 
 		if (updated || param_init_forced) {
 			param_init_forced = false;
@@ -1233,6 +1231,15 @@ int commander_thread_main(int argc, char *argv[])
 
 			/* Autostart id */
 			param_get(_param_autostart_id, &autostart_id);
+
+			/* Parameter autosave setting */
+			param_get(_param_autosave_params, &autosave_params);
+		}
+
+		/* Set flag to autosave parameters if necessary */
+		if (updated && autosave_params != 0) {
+			/* trigger an autosave */
+			need_param_autosave = true;
 		}
 
 		orb_check(sp_man_sub, &updated);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -176,3 +176,13 @@ PARAM_DEFINE_FLOAT(COM_EF_TIME, 10.0f);
  * @max 35
  */
 PARAM_DEFINE_FLOAT(COM_RC_LOSS_T, 0.5);
+
+/** Autosaving of params
+ *
+ * If not equal to zero the commander will automatically save parameters to persistent storage once changed
+ *
+ * @group commander
+ * @min 0
+ * @max 1
+ */
+PARAM_DEFINE_INT32(COM_AUTOS_PAR, 0);


### PR DESCRIPTION
This is a follow up on https://github.com/PX4/Firmware/issues/1903 and https://github.com/PX4/Firmware/commit/f8fd67d3e17e8f32b7ee5a7d9e112bf944e2735f

Adding a parameter to control the parameter autosave functionality. Turn autosave off by default as it is not according to mavlink specifications. If I remember correctly we talked about the same "one save button" option for qgroundcontrol. However the GCS should adhere to the protocol and send 2 commands (set/write).

The autosave functionality is a good workaround as long as the Tower app does not support the parameter feature correctly.

tested with qgc and command line