### PR TITLE
commander: Increase timeout on airspeed sensor for the prearm_check

### DIFF
--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -699,7 +699,7 @@ int prearm_check(const struct vehicle_status_s *status, const int mavlink_fd)
 		struct airspeed_s airspeed;
 
 		if ((ret = orb_copy(ORB_ID(airspeed), fd, &airspeed)) ||
-			(hrt_elapsed_time(&airspeed.timestamp) > (50 * 1000))) {
+			(hrt_elapsed_time(&airspeed.timestamp) > (500 * 1000))) {
 			mavlink_log_critical(mavlink_fd, "ARM FAIL: AIRSPEED SENSOR MISSING");
 			failed = true;
 			goto system_eval;


### PR DESCRIPTION
The previously set 50ms (20Hz) timeout for checking whether an airspeed sensor is present and OK is very low. Systems may fail to arm when their airspeed sensor deliver data at less than 20Hz. This PR therefore slightly increases the airspeed sensor timeout check to 500ms (2Hz), which is still more than enough to determine whether the airspeed sensor is present and OK.