### PR TITLE
px4io firmware: Allow actuator update rates down to 45Hz, as this is exa...

### DIFF
--- a/src/modules/px4iofirmware/registers.c
+++ b/src/modules/px4iofirmware/registers.c
@@ -543,8 +543,8 @@ registers_set_one(uint8_t page, uint8_t offset, uint16_t value)
 			break;
 
 		case PX4IO_P_SETUP_PWM_DEFAULTRATE:
-			if (value < 50) {
-				value = 50;
+			if (value < 25) {
+				value = 25;
 			}
 			if (value > 400) {
 				value = 400;
@@ -553,8 +553,8 @@ registers_set_one(uint8_t page, uint8_t offset, uint16_t value)
 			break;
 
 		case PX4IO_P_SETUP_PWM_ALTRATE:
-			if (value < 50) {
-				value = 50;
+			if (value < 25) {
+				value = 25;
 			}
 			if (value > 400) {
 				value = 400;


### PR DESCRIPTION
...ctly where standard Spektrum receivers work. 

Note that the default update rate stays at 50Hz, so this is only an optional change for users who want to adapt their PX4IO output to the 45Hz/22ms output by Spektrum RC receivers.