### PR TITLE
AttPosEKF: Reset magnetic field estimates for vertical takeoff at 3m above ground

### DIFF
--- a/src/modules/ekf_att_pos_estimator/estimator_22states.cpp
+++ b/src/modules/ekf_att_pos_estimator/estimator_22states.cpp
@@ -2569,7 +2569,7 @@ void AttPosEKF::setOnGround(const bool isLanded)
     if(!_isFixedWing) {
 
         //We are landed, clear reset flag and require a new reset once we reach altitude
-        if(!_onGround) {
+        if(_onGround) {
             _resetInAirMagneticField = false;
             _takeoffGroundAltitude = states[9];
         }

--- a/src/modules/ekf_att_pos_estimator/estimator_22states.h
+++ b/src/modules/ekf_att_pos_estimator/estimator_22states.h
@@ -306,8 +306,6 @@ public:
 
     static void quat2eul(float (&eul)[3], const float (&quat)[4]);
 
-    //static void quat2Tnb(Mat3f &Tnb, const float (&quat)[4]);
-
     static inline float sq(float valIn) {return valIn * valIn;}
 
     /**
@@ -407,10 +405,18 @@ protected:
 
     void ResetStoredStates();
 
+    /**
+    * @brief
+    *   Reset the state estimates for attitude quaternions and magnetic field
+    **/
+    void resetMagneticAttitude();
+
 private:
     bool _isFixedWing;               ///< True if the vehicle is a fixed-wing frame type
     bool _onGround;                  ///< boolean true when the flight vehicle is on the ground (not flying)
     float _accNavMagHorizontal;      ///< First-order low-pass filtered rate of change maneuver velocity
+    bool _resetInAirMagneticField;   ///< Resets magnetic field in-air to remove magnetic interference caused by the ground (vertical takeoff only)
+    float _takeoffGroundAltitude;    ///< Altitude estimate at takeoff
 };
 
 uint32_t millis();


### PR DESCRIPTION
This patch makes the EKF reset magnetic field estimates at 3 meters altitude above ground. This is to remove any strong magnetic interference caused by the ground. This only applies to vehicles that can do a vertical takeoff. The need for this arised from observations of inaccuracy in Compass yaw after takeoff.

This solution is similar to ArduPilot's fix for this exact same problem. This is not currently flight-tested and I will do so as soon as I can.