### PR TITLE
mavlink: Allow mavlink_send to take component_ID into account. Still use...

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -746,7 +746,7 @@ Mavlink::get_free_tx_buf()
 }
 
 void
-Mavlink::send_message(const uint8_t msgid, const void *msg)
+Mavlink::send_message(const uint8_t msgid, const void *msg, uint8_t component_ID)
 {
 	/* If the wait until transmit flag is on, only transmit after we've received messages.
 	   Otherwise, transmit all the time. */
@@ -780,7 +780,7 @@ Mavlink::send_message(const uint8_t msgid, const void *msg)
 	/* use mavlink's internal counter for the TX seq */
 	buf[2] = mavlink_get_channel_status(_channel)->current_tx_seq++;
 	buf[3] = mavlink_system.sysid;
-	buf[4] = mavlink_system.compid;
+	buf[4] = component_ID==0 ? mavlink_system.compid:component_ID;
 	buf[5] = msgid;
 
 	/* payload */

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -169,7 +169,7 @@ public:
 	 */
 	int			set_hil_enabled(bool hil_enabled);
 
-	void			send_message(const uint8_t msgid, const void *msg);
+	void			send_message(const uint8_t msgid, const void *msg, uint8_t component_ID = 0);
 
 	/**
 	 * Resend message as is, don't change sequence number and CRC.


### PR DESCRIPTION
... a default argument in case the user does not supply a component_ID, so no further changes to the other sections of the PX4 code are necessary. Alternatively, the same functionality could be provided via overloading that function, let me know if that should be the preferred method.

This PR is set up to provide the functionality described here : https://groups.google.com/forum/?fromgroups=#!topic/px4users/YWGhS0seTiI . It was tested successfully with QGC 2.3.