### PR TITLE
batt_smbus: add ioctl to return batt capacity

### DIFF
--- a/src/drivers/drv_batt_smbus.h
+++ b/src/drivers/drv_batt_smbus.h
@@ -45,3 +45,13 @@
 
 /* device path */
 #define BATT_SMBUS0_DEVICE_PATH "/dev/batt_smbus0"
+
+/*
+ * ioctl() definitions
+ */
+
+#define _BATT_SMBUS_IOCBASE             (0x2e00)
+#define _BATT_SMBUS_IOC(_n)             (_IOC(_BATT_SMBUS_IOCBASE, _n))
+
+/** retrieve battery capacity */
+#define BATT_SMBUS_GET_CAPACITY         _BATT_SMBUS_IOC(1)


### PR DESCRIPTION
Also use full charge capacity instead of design capacity so that an old
battery's capacity will appear as lower than its original capacity but
it will still report 100% charged after charging