### PR TITLE
Store the port so the in use port will be referenced when reopening.

### DIFF
--- a/src/drivers/sf0x/sf0x.cpp
+++ b/src/drivers/sf0x/sf0x.cpp
@@ -114,6 +114,7 @@ protected:
 	virtual int			probe();
 
 private:
+	char 				_port[20];
 	float				_min_distance;
 	float				_max_distance;
 	work_s				_work;
@@ -199,8 +200,13 @@ SF0X::SF0X(const char *port) :
 	_comms_errors(perf_alloc(PC_COUNT, "sf0x_comms_errors")),
 	_buffer_overflows(perf_alloc(PC_COUNT, "sf0x_buffer_overflows"))
 {
+	/* store port name */
+	strncpy(_port, port, sizeof(_port));
+	/* enforce null termination */
+	_port[sizeof(_port) - 1] = '\0';
+
 	/* open fd */
-	_fd = ::open(port, O_RDWR | O_NOCTTY | O_NONBLOCK);
+	_fd = ::open(_port, O_RDWR | O_NOCTTY | O_NONBLOCK);
 
 	if (_fd < 0) {
 		warnx("FAIL: laser fd");
@@ -633,7 +639,7 @@ SF0X::cycle()
 	/* fds initialized? */
 	if (_fd < 0) {
 		/* open fd */
-		_fd = ::open(SF0X_DEFAULT_PORT, O_RDWR | O_NOCTTY | O_NONBLOCK);
+		_fd = ::open(_port, O_RDWR | O_NOCTTY | O_NONBLOCK);
 	}
 
 	/* collection phase? */


### PR DESCRIPTION
This allows the SF0x lasers to operate on non-default ports and resolves #2004. Tested on both the default port (Serial4) and Telem2:

```
nsh> sf0x start /dev/ttyS2
nsh> sf0x test
sf0x: single read
sf0x: val:  0.08 m
sf0x: time: 28345363
sf0x: read #0
sf0x: val:  0.080 m
sf0x: time: 28429739
sf0x: read #1
sf0x: val:  0.080 m
sf0x: time: 29103631
sf0x: read #2
sf0x: val:  0.080 m
sf0x: time: 29606865
sf0x: read #3
sf0x: val:  0.080 m
sf0x: time: 30109990
sf0x: read #4
sf0x: val:  0.080 m
sf0x: time: 30613180
sf0x: PASS
nsh> sf0x test
sf0x: single read
sf0x: val:  0.40 m
sf0x: time: 50787312
sf0x: read #0
sf0x: val:  0.400 m
sf0x: time: 50870123
sf0x: read #1
sf0x: val:  0.400 m
sf0x: time: 50953459
sf0x: read #2
sf0x: val:  0.400 m
sf0x: time: 51457711
sf0x: read #3
sf0x: val:  0.370 m
sf0x: time: 51961960
sf0x: read #4
sf0x: val:  0.120 m
sf0x: time: 52466071
sf0x: PASS
nsh> 
```
