### PR TITLE
GF range warning limit mavlink critical messages

### DIFF
--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -48,6 +48,7 @@
 #include <uORB/topics/home_position.h>
 #include <controllib/blocks.hpp>
 #include <controllib/block/BlockParam.hpp>
+#include <drivers/drv_hrt.h>
 
 #define GEOFENCE_FILENAME "/fs/microsd/etc/geofence.txt"
 
@@ -108,6 +109,9 @@ private:
 
 	home_position_s _home_pos;
 	bool _home_pos_set;
+
+	hrt_abstime _last_horizontal_range_warning;
+	hrt_abstime _last_vertical_range_warning;
 
 	float			_altitude_min;
 	float			_altitude_max;


### PR DESCRIPTION
This changes the geofence range warning to only send a mavlink critical message when your distance outside the max horizontal/vertical has increased instead of every time it's checked (quite annoying).