### PR TITLE
Adaptive EKF noise

### DIFF
--- a/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
+++ b/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
@@ -937,7 +937,7 @@ void AttitudePositionEstimatorEKF::updateSensorFusion(const bool fuseGPS, const 
 		// Convert GPS measurements to Pos NE, hgt and Vel NED
 
 		// set fusion flags
-		_ekf->fuseVelData = true;
+		_ekf->fuseVelData = _gps.vel_ned_valid;
 		_ekf->fusePosData = true;
 
 		// recall states stored at time of measurement after adjusting for delays


### PR DESCRIPTION
Implements adaptive noise for GPS observations. This makes the EKF weigh the GPS position/velocity data more or less depending on the fix accuracy.

This has been flight tested, but should not be merged until we can somehow verify that this has an positive effect on the state estimations of the EKF.