### PR TITLE
Correct formatting of FW_P_ROLLFF definition to unbreak doc generation

### DIFF
--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -136,8 +136,8 @@ PARAM_DEFINE_FLOAT(FW_PR_IMAX, 0.2f);
  * @max 2.0
  * @group FW Attitude Control
  */
-PARAM_DEFINE_FLOAT(FW_P_ROLLFF,
-		   0.0f); //xxx: set to 0 as default, see comment in ECL_PitchController::control_attitude (float turn_offset = ...)
+//xxx: set to 0 as default, see comment on turn_offset in ECL_PitchController::control_attitude(...)
+PARAM_DEFINE_FLOAT(FW_P_ROLLFF, 0.0f);
 
 /**
  * Roll rate proportional Gain


### PR DESCRIPTION
I assume the line break prevents FW_P_ROLLFF from appearing in the auto-generated docs which probably wasn't intentional.