### PR TITLE
Read RSSI from RC input channel

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -111,6 +111,10 @@ extern device::Device *PX4IO_serial_interface() weak_function;
 #define ORB_CHECK_INTERVAL		200000		// 200 ms -> 5 Hz
 #define IO_POLL_INTERVAL		20000		// 20 ms -> 50 Hz
 
+#define RC_RSSI_PWM_MAX			1000
+#define RC_RSSI_PWM_MIN 		1800
+#define RC_RSSI_PWM_CHAN		8
+
 /**
  * The PX4IO class.
  *
@@ -1631,6 +1635,12 @@ PX4IO::io_get_raw_rc_input(rc_input_values &input_rc)
 	/* last thing set are the actual channel values as 16 bit values */
 	for (unsigned i = 0; i < channel_count; i++) {
 		input_rc.values[i] = regs[prolog + i];
+	}
+
+	// get RSSI from channel 8, input range 1000 - 2000
+	if (RC_RSSI_PWM_CHAN > -1 && RC_RSSI_PWM_CHAN <= RC_INPUT_MAX_CHANNELS) {
+		input_rc.rssi = (input_rc.values[RC_RSSI_PWM_CHAN - 1] - RC_RSSI_PWM_MIN) *
+			((RC_RSSI_PWM_MAX - RC_RSSI_PWM_MIN) / 255);
 	}
 
 	return ret;

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -111,10 +111,6 @@ extern device::Device *PX4IO_serial_interface() weak_function;
 #define ORB_CHECK_INTERVAL		200000		// 200 ms -> 5 Hz
 #define IO_POLL_INTERVAL		20000		// 20 ms -> 50 Hz
 
-#define RC_RSSI_PWM_MAX			1000
-#define RC_RSSI_PWM_MIN 		1800
-#define RC_RSSI_PWM_CHAN		8
-
 /**
  * The PX4IO class.
  *
@@ -306,6 +302,10 @@ private:
 	float			_battery_mamphour_total;///< amp hours consumed so far
 	uint64_t		_battery_last_timestamp;///< last amp hour calculation timestamp
 	bool			_cb_flighttermination;	///< true if the flight termination circuit breaker is enabled
+
+	int32_t			_rssi_pwm_chan; ///< RSSI PWM input channel
+	int32_t			_rssi_pwm_max; ///< max RSSI input on PWM channel
+	int32_t			_rssi_pwm_min; ///< min RSSI input on PWM channel
 
 #ifdef CONFIG_ARCH_BOARD_PX4FMU_V1
 	bool			_dsm_vcc_ctl;		///< true if relay 1 controls DSM satellite RX power
@@ -528,7 +528,10 @@ PX4IO::PX4IO(device::Device *interface) :
 	_battery_amp_bias(0),
 	_battery_mamphour_total(0),
 	_battery_last_timestamp(0),
-	_cb_flighttermination(true)
+	_cb_flighttermination(true),
+	_rssi_pwm_chan(0),
+	_rssi_pwm_max(0),
+	_rssi_pwm_min(0)
 #ifdef CONFIG_ARCH_BOARD_PX4FMU_V1
 	, _dsm_vcc_ctl(false)
 #endif
@@ -667,6 +670,10 @@ PX4IO::init()
 
 	if (_max_rc_input > RC_INPUT_MAX_CHANNELS)
 		_max_rc_input = RC_INPUT_MAX_CHANNELS;
+
+	param_get(param_find("RC_RSSI_PWM_CHAN"), &_rssi_pwm_chan);
+	param_get(param_find("RC_RSSI_PWM_MAX"), &_rssi_pwm_max);
+	param_get(param_find("RC_RSSI_PWM_MIN"), &_rssi_pwm_min);
 
 	/*
 	 * Check for IO flight state - if FMU was flagged to be in
@@ -1072,6 +1079,10 @@ PX4IO::task_main()
 
 				/* Update Circuit breakers */
 				_cb_flighttermination = circuit_breaker_enabled("CBRK_FLIGHTTERM", CBRK_FLIGHTTERM_KEY);
+
+				param_get(param_find("RC_RSSI_PWM_CHAN"), &_rssi_pwm_chan);
+				param_get(param_find("RC_RSSI_PWM_MAX"), &_rssi_pwm_max);
+				param_get(param_find("RC_RSSI_PWM_MIN"), &_rssi_pwm_min);
 
 			}
 
@@ -1637,10 +1648,13 @@ PX4IO::io_get_raw_rc_input(rc_input_values &input_rc)
 		input_rc.values[i] = regs[prolog + i];
 	}
 
-	// get RSSI from channel 8, input range 1000 - 2000
-	if (RC_RSSI_PWM_CHAN > -1 && RC_RSSI_PWM_CHAN <= RC_INPUT_MAX_CHANNELS) {
-		input_rc.rssi = (input_rc.values[RC_RSSI_PWM_CHAN - 1] - RC_RSSI_PWM_MIN) *
-			((RC_RSSI_PWM_MAX - RC_RSSI_PWM_MIN) / 255);
+	/* get RSSI from input channel */
+	if (_rssi_pwm_chan > 0 && _rssi_pwm_chan <= RC_INPUT_MAX_CHANNELS && _rssi_pwm_max - _rssi_pwm_min != 0) {
+		int rssi = (input_rc.values[_rssi_pwm_chan - 1] - _rssi_pwm_min) /
+			((_rssi_pwm_max - _rssi_pwm_min) / 100);
+		rssi = rssi > 100 ? 100 : rssi;
+		rssi = rssi < 0 ? 0 : rssi;
+		input_rc.rssi = rssi;
 	}
 
 	return ret;

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -1360,3 +1360,42 @@ PARAM_DEFINE_FLOAT(RC_ACRO_TH, 0.5f);
  *
  */
 PARAM_DEFINE_FLOAT(RC_OFFB_TH, 0.5f);
+
+/**
+ * PWM input channel that provides RSSI.
+ *
+ * 0: do not read RSSI from input channel
+ * 1-18: read RSSI from specified input channel
+ *
+ * Specify the range for RSSI input with RC_RSSI_PWM_MIN and RC_RSSI_PWM_MAX parameters.
+ *
+ * @min 0
+ * @max 18
+ * @group Radio Calibration
+ *
+ */
+PARAM_DEFINE_INT32(RC_RSSI_PWM_CHAN, 0);
+
+/**
+ * Max input value for RSSI reading.
+ *
+ * Only used if RC_RSSI_PWM_CHAN > 0
+ *
+ * @min 0
+ * @max 2000
+ * @group Radio Calibration
+ *
+ */
+PARAM_DEFINE_INT32(RC_RSSI_PWM_MAX, 1000);
+
+/**
+ * Min input value for RSSI reading.
+ *
+ * Only used if RC_RSSI_PWM_CHAN > 0
+ *
+ * @min 0
+ * @max 2000
+ * @group Radio Calibration
+ *
+ */
+PARAM_DEFINE_INT32(RC_RSSI_PWM_MIN, 2000);


### PR DESCRIPTION
This adds the possibility to specify an RC input channel that contains the RSSI value from the receiver. PWM range can be specified.

It's bench tested and works, a quick review would be appreciated (regarding parameters).
