### PR TITLE
Figuring out how RC RSSI is packaged.

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -1913,53 +1913,9 @@ protected:
 			msg.chan17_raw = (rc.channel_count > 16) ? rc.values[16] : UINT16_MAX;
 			msg.chan18_raw = (rc.channel_count > 17) ? rc.values[17] : UINT16_MAX;
 
-			/* RSSI has a max value of 100, and when Spektrum or S.BUS are
-			 * available, the RSSI field is invalid, as they do not provide
-			 * an RSSI measurement. Use an out of band magic value to signal
-			 * these digital ports. XXX revise MAVLink spec to address this.
-			 * One option would be to use the top bit to toggle between RSSI
-			 * and input source mode.
-			 *
-			 * Full RSSI field: 0b 1 111 1111
-			 *                     | |   |
-			 *                     | |   ^ These four bits encode a total of
-			 *                     | |     16 RSSI levels. 15 = full, 0 = no signal
-			 *                     | |
-			 *                     | ^ These three bits encode a total of 8
-			 *                     |   digital RC input types.
-			 *                     |   0: PPM, 1: SBUS, 2: Spektrum, 3: ST24
-			 *                     |
-			 *                     ^ If bit is set, RSSI encodes type + RSSI
-			 *
-			 */
+			msg.rssi = rc.rssi;
 
-			/* Initialize RSSI with the special mode level flag */
-			msg.rssi = (1 << 7);
-
-			/* Set RSSI */
-			msg.rssi |= (rc.rssi <= 100) ? ((rc.rssi / 7) + 1) : 15;
-
-			switch (rc.input_source) {
-				case RC_INPUT_SOURCE_PX4FMU_PPM:
-				/* fallthrough */
-				case RC_INPUT_SOURCE_PX4IO_PPM:
-					msg.rssi |= (0 << 4);
-					break;
-				case RC_INPUT_SOURCE_PX4IO_SPEKTRUM:
-					msg.rssi |= (1 << 4);
-					break;
-				case RC_INPUT_SOURCE_PX4IO_SBUS:
-					msg.rssi |= (2 << 4);
-					break;
-				case RC_INPUT_SOURCE_PX4IO_ST24:
-					msg.rssi |= (3 << 4);
-					break;
-				case RC_INPUT_SOURCE_UNKNOWN:
-					// do nothing
-					break;
-			}
-
-			// TODO: (gg 20150420 This is never set/true)
+			// TODO: (gg 20150420 This is never set/true but from observation, it seems rc.rssi does come as 0 when connection is gone)
 			if (rc.rc_lost) {
 				/* RSSI is by definition zero */
 				msg.rssi = 0;

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -1921,14 +1921,15 @@ protected:
 			 * and input source mode.
 			 *
 			 * Full RSSI field: 0b 1 111 1111
-			 *
+			 *                     | |   |
+			 *                     | |   ^ These four bits encode a total of
+			 *                     | |     16 RSSI levels. 15 = full, 0 = no signal
+			 *                     | |
+			 *                     | ^ These three bits encode a total of 8
+			 *                     |   digital RC input types.
+			 *                     |   0: PPM, 1: SBUS, 2: Spektrum, 3: ST24
+			 *                     |
 			 *                     ^ If bit is set, RSSI encodes type + RSSI
-			 *
-			 *                       ^ These three bits encode a total of 8
-			 *                         digital RC input types.
-			 *                         0: PPM, 1: SBUS, 2: Spektrum, 2: ST24
-			 *                           ^ These four bits encode a total of
-			 *                             16 RSSI levels. 15 = full, 0 = no signal
 			 *
 			 */
 
@@ -1958,6 +1959,7 @@ protected:
 					break;
 			}
 
+			// TODO: (gg 20150420 This is never set/true)
 			if (rc.rc_lost) {
 				/* RSSI is by definition zero */
 				msg.rssi = 0;


### PR DESCRIPTION
This code builds a bitmap with the RC RSSI status, which does not match the MAVLink specs. I've fixed a (comment) error with the value for ST24, reformatted the comments to be a bit more understandable and made a note that ```rc.rc_lost``` is never set, even when you turn the RC off. The loss can still be detected because rc.rssi & 0x0F will be 0. I'm adding these same comments on the QGC side where this message is parsed.

MAVLINK_MSG_ID_RC_CHANNELS needs to be updated but I wasn't sure where to do it. It is now:
```
uint8_t rssi; ///< Receive signal strength indicator, 0: 0%, 100: 100%, 255: invalid/unknown.
```
and should be updated to:
```
uint8_t rssi; ///< Receive signal strength indicator. (Bitmap) Bits 0-3: 16 RSSI levels (15 = full, 0 = no signal) Bits 4-6: 8 Digital RC Types (0: PPM, 1: SBUS, 2: Spektrum, 3: ST24) Bit 7: Flag (1 = RSSI encodes type + RSSI)
```