### PR TITLE
add GPS glitch detection based on the implementation in AP_NavEKF

### DIFF
--- a/src/modules/ekf_att_pos_estimator/estimator_22states.h
+++ b/src/modules/ekf_att_pos_estimator/estimator_22states.h
@@ -160,6 +160,14 @@ public:
     uint8_t fusionModeGPS; // 0 = GPS outputs 3D velocity, 1 = GPS outputs 2D velocity, 2 = GPS outputs no velocity
     float innovVelPos[6]; // innovation output
     float varInnovVelPos[6]; // innovation variance output
+    int16_t gpsGlitchAccel;    // Magnitude of discrepancy between inertial and GPS Horizontal acceleration above which GPS data is ignored : cm/s^2
+    int8_t gpsGlitchRadius;    // Magnitude of discrepancy between inertial and GPS Horizontal position before GPS glitch is declared : m
+    int8_t  gpsVelInnovNSTD;      // Number of standard deviations allowed in GPS velocity innovation consistency check
+    int8_t  gpsPosInnovNSTD;      // Number of standard deviations allowed in GPS position innovation consistency check
+    float gpsHorizPosNoise;     // GPS horizontal position measurement noise m
+    Vector2f gpsPosGlitchOffsetNE;  // offset applied to GPS data in the NE direction to compensate for rapid changes in GPS solution
+    uint32_t lastDecayTime_ms;      // time of last decay of GPS position offset
+    Vector2f gpsVelGlitchOffset;    // Offset applied to the GPS velocity when the gltch radius is being  decayed back to zero
 
     float velNED[3]; // North, East, Down velocity obs (m/s)
     float posNE[2]; // North, East position obs (m)
@@ -378,6 +386,8 @@ public:
      *   Reset internal filter states and clear all variables to zero value
      */
     void ZeroVariables();
+
+    void decayGpsOffset();
 
 protected:
 

--- a/src/modules/ekf_att_pos_estimator/estimator_utilities.cpp
+++ b/src/modules/ekf_att_pos_estimator/estimator_utilities.cpp
@@ -72,6 +72,17 @@ ekf_debug(const char *fmt, ...)
 void ekf_debug(const char *fmt, ...) { while(0){} }
 #endif
 
+float Vector2f::length(void) const
+{
+    return sqrt(x*x + y*y);
+}
+
+void Vector2f::zero(void)
+{
+    x = 0.0f;
+    y = 0.0f;
+}
+
 float Vector3f::length(void) const
 {
     return sqrt(x*x + y*y + z*z);
@@ -136,6 +147,24 @@ void calcLLH(float posNEDi[3], double &lat, double &lon, float &hgt, double latR
 }
 
 // overload + operator to provide a vector addition
+Vector2f operator+(const Vector2f &vecIn1, const Vector2f &vecIn2)
+{
+    Vector2f vecOut;
+    vecOut.x = vecIn1.x + vecIn2.x;
+    vecOut.y = vecIn1.y + vecIn2.y;
+    return vecOut;
+}
+
+// overload - operator to provide a vector subtraction
+Vector2f operator-(const Vector2f &vecIn1, const Vector2f &vecIn2)
+{
+    Vector2f vecOut;
+    vecOut.x = vecIn1.x - vecIn2.x;
+    vecOut.y = vecIn1.y - vecIn2.y;
+    return vecOut;
+}
+
+// overload + operator to provide a vector addition
 Vector3f operator+(const Vector3f &vecIn1, const Vector3f &vecIn2)
 {
     Vector3f vecOut;
@@ -195,6 +224,24 @@ Vector3f operator%(const Vector3f &vecIn1, const Vector3f &vecIn2)
 }
 
 // overload * operator to provide a vector scaler product
+Vector2f operator*(const Vector2f &vecIn1, const float sclIn1)
+{
+    Vector2f vecOut;
+    vecOut.x = vecIn1.x * sclIn1;
+    vecOut.y = vecIn1.y * sclIn1;
+    return vecOut;
+}
+
+// overload * operator to provide a vector scaler product
+Vector2f operator*(float sclIn1, const Vector2f &vecIn1)
+{
+    Vector2f vecOut;
+    vecOut.x = vecIn1.x * sclIn1;
+    vecOut.y = vecIn1.y * sclIn1;
+    return vecOut;
+}
+
+// overload * operator to provide a vector scaler product
 Vector3f operator*(const Vector3f &vecIn1, const float sclIn1)
 {
     Vector3f vecOut;
@@ -211,6 +258,15 @@ Vector3f operator*(float sclIn1, const Vector3f &vecIn1)
     vecOut.x = vecIn1.x * sclIn1;
     vecOut.y = vecIn1.y * sclIn1;
     vecOut.z = vecIn1.z * sclIn1;
+    return vecOut;
+}
+
+// overload / operator to provide a vector scalar division
+Vector2f operator/(const Vector2f &vec, const float scalar)
+{
+    Vector2f vecOut;
+    vecOut.x = vec.x / scalar;
+    vecOut.y = vec.y / scalar;
     return vecOut;
 }
 

--- a/src/modules/ekf_att_pos_estimator/estimator_utilities.h
+++ b/src/modules/ekf_att_pos_estimator/estimator_utilities.h
@@ -49,6 +49,21 @@
 #define earthRadius 6378145.0
 #define earthRadiusInv  1.5678540e-7
 
+class Vector2f
+{
+public:
+    float x;
+    float y;
+
+    Vector2f(float a=0.0f, float b=0.0f) :
+    x(a),
+    y(b)
+    {}
+
+    float length() const;
+    void zero();
+};
+
 class Vector3f
 {
 public:
@@ -80,14 +95,22 @@ public:
     Mat3f transpose() const;
 };
 
+Vector2f operator*(const float sclIn1, const Vector2f &vecIn1);
+Vector2f operator*(const Vector2f &vecIn1, const float sclIn1);
+Vector2f operator+(const Vector2f &vecIn1, const Vector2f &vecIn2);
+Vector2f operator-(const Vector2f &vecIn1, const Vector2f &vecIn2);
+Vector2f operator%(const Vector2f &vecIn1, const Vector2f &vecIn2);
+Vector2f operator/(const Vector2f &vec, const float scalar);
+
 Vector3f operator*(const float sclIn1, const Vector3f &vecIn1);
 Vector3f operator+(const Vector3f &vecIn1, const Vector3f &vecIn2);
 Vector3f operator-(const Vector3f &vecIn1, const Vector3f &vecIn2);
 Vector3f operator*(const Mat3f &matIn, const Vector3f &vecIn);
-Mat3f operator*(const Mat3f &matIn1, const Mat3f &matIn2);
 Vector3f operator%(const Vector3f &vecIn1, const Vector3f &vecIn2);
 Vector3f operator*(const Vector3f &vecIn1, const float sclIn1);
 Vector3f operator/(const Vector3f &vec, const float scalar);
+
+Mat3f operator*(const Mat3f &matIn1, const Mat3f &matIn2);
 
 enum GPS_FIX {
     GPS_FIX_NOFIX = 0,


### PR DESCRIPTION
checks for abrupt change in GPS horizontal position; if detected the current North and East innovations are added to gpsPosGlitchOffsetNE, and this offset is subsequently added to the GPS posNE vector to form the observation vector. gpsPosGlitchOffsetNE is decayed radially to zero at a hardcoded rate.

Testing indicates that this eliminates attitude estimate glitches caused by GPS glitches. Not sure what the effect is on EKF position estimation accuracy, but no position glitches have been observed (yet) to be caused by this change.