### PR TITLE
IO RSSI handling: Fix RSSI for all protocols.

### DIFF
--- a/src/drivers/drv_rc_input.h
+++ b/src/drivers/drv_rc_input.h
@@ -65,7 +65,7 @@
 /**
  * Maximum RSSI value
  */
-#define RC_INPUT_RSSI_MAX	255
+#define RC_INPUT_RSSI_MAX	100
 
 /**
  * @addtogroup topics

--- a/src/lib/rc/sumd.c
+++ b/src/lib/rc/sumd.c
@@ -269,7 +269,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 			uint8_t _cnt = *rx_count + 1;
 			*rx_count = _cnt;
 		
-			*rssi = 255;
+			*rssi = 100;
 
 			/* received Channels */
 			if ((uint16_t)_rxpacket.length > max_chan_count) {

--- a/src/modules/px4iofirmware/controls.c
+++ b/src/modules/px4iofirmware/controls.c
@@ -191,7 +191,10 @@ controls_tick() {
 			unsigned mV = counts * 3300 / 4096;
 
 			/* scale to 0..253 and lowpass */
-			rssi = (rssi * 0.99f) + ((mV / 13) * 0.01f);
+			rssi = (rssi * 0.99f) + ((mV / (3300 / RC_INPUT_RSSI_MAX)) * 0.01f);
+			if (rssi > RC_INPUT_RSSI_MAX) {
+				rssi = RC_INPUT_RSSI_MAX;
+			}
 		}
 	}
 #endif
@@ -223,11 +226,11 @@ controls_tick() {
 	if (sbus_updated) {
 		r_status_flags |= PX4IO_P_STATUS_FLAGS_RC_SBUS;
 
-		unsigned sbus_rssi = 254;
+		unsigned sbus_rssi = RC_INPUT_RSSI_MAX;
 
 		if (sbus_frame_drop) {
 			r_raw_rc_flags |= PX4IO_P_RAW_RC_FLAGS_FRAME_DROP;
-			sbus_rssi = 100;
+			sbus_rssi = RC_INPUT_RSSI_MAX / 2;
 		} else {
 			r_raw_rc_flags &= ~(PX4IO_P_RAW_RC_FLAGS_FRAME_DROP);
 		}


### PR DESCRIPTION
@AndreasAntener @dogmaphobic @NosDE This is a general RSSI logic cleanup, plus the addition of low-pass filtering the ADC signal.

@tumbili Could you please connect RSSI of your D4R-II and cross-check what you get in QGC?