### PR TITLE
Minor fix in UAVCAN driver startup logic

### DIFF
--- a/src/modules/uavcan/uavcan_main.cpp
+++ b/src/modules/uavcan/uavcan_main.cpp
@@ -698,7 +698,9 @@ int uavcan_main(int argc, char *argv[])
 
 	if (!std::strcmp(argv[1], "start")) {
 		if (UavcanNode::instance()) {
-			errx(1, "already started");
+			// Already running, no error
+			warnx("already started");
+			::exit(0);
 		}
 
 		// Node ID


### PR DESCRIPTION
UAVCAN driver silently ignores repeated start commands without error. This allows to avoid failures when UAVCAN driver is started from extras script before default initialization sequence is executed.