### PR TITLE
DO NOT MERGE Nuttx next update to uavcan

### DIFF
--- a/src/modules/uavcan/sensors/baro.cpp
+++ b/src/modules/uavcan/sensors/baro.cpp
@@ -39,6 +39,7 @@
 #include <drivers/device/ringbuffer.h>
 #include <cmath>
 
+
 const char *const UavcanBarometerBridge::NAME = "baro";
 
 UavcanBarometerBridge::UavcanBarometerBridge(uavcan::INode& node) :
@@ -128,12 +129,14 @@ int UavcanBarometerBridge::ioctl(struct file *filp, int cmd, unsigned long arg)
 	}
 }
 
-void UavcanBarometerBridge::air_data_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticAirData> &msg)
+void UavcanBarometerBridge::air_data_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticPressure> &msg)
 {
 	baro_report report;
 
 	report.timestamp   = msg.getMonotonicTimestamp().toUSec();
-	report.temperature = msg.static_temperature;
+#pragma message "THIS CODE IS WRONG! It was StaticAirData that had both temp and Pressure now just pressure"
+
+//fixme:report.temperature = msg.static_temperature;
 	report.pressure    = msg.static_pressure / 100.0F;  // Convert to millibar
 	report.error_count = 0;
 

--- a/src/modules/uavcan/sensors/baro.hpp
+++ b/src/modules/uavcan/sensors/baro.hpp
@@ -40,7 +40,10 @@
 #include "sensor_bridge.hpp"
 #include <drivers/drv_baro.h>
 
-#include <uavcan/equipment/air_data/StaticAirData.hpp>
+#pragma message "THIS CODE IS WRONG! It was StaticAirData that had both temp and Pressure now just pressure"
+//fixme:
+#include <uavcan/equipment/air_data/StaticPressure.hpp>
+#include <uavcan/equipment/air_data/StaticTemperature.hpp>
 
 class RingBuffer;
 
@@ -59,14 +62,14 @@ private:
 	ssize_t	read(struct file *filp, char *buffer, size_t buflen);
 	int ioctl(struct file *filp, int cmd, unsigned long arg) override;
 
-	void air_data_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticAirData> &msg);
+	void air_data_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticPressure> &msg);
 
 	typedef uavcan::MethodBinder < UavcanBarometerBridge *,
 		void (UavcanBarometerBridge::*)
-		(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticAirData> &) >
+		(const uavcan::ReceivedDataStructure<uavcan::equipment::air_data::StaticPressure> &) >
 		AirDataCbBinder;
 
-	uavcan::Subscriber<uavcan::equipment::air_data::StaticAirData, AirDataCbBinder> _sub_air_data;
+	uavcan::Subscriber<uavcan::equipment::air_data::StaticPressure, AirDataCbBinder> _sub_air_data;
 	unsigned _msl_pressure = 101325;
 	RingBuffer	*_reports;
 };


### PR DESCRIPTION
@LorenzMeier FYI:

 @pavel-kirienko This and the other PR I sent was the only changes I had to make to compile 
nuttx_next on the uavcan@df2a38c217a101bba77260e8de51deeba2903dac 

It looks to me like StaticAirData was bifurcated into  StaticPressure and StaticTemperature in the latest 
uavcan. 

I did not know how to bring both StaticTemperature  and StaticPressure  in.

Please advise (or PR) as to how this should be done (No rush as I can budl now)

Thank you,

David
