### PR TITLE
enable esc calibration over QGroundControl

### DIFF
--- a/msg/actuator_armed.msg
+++ b/msg/actuator_armed.msg
@@ -4,3 +4,4 @@ bool armed		# Set to true if system is armed
 bool ready_to_arm	# Set to true if system is ready to be armed
 bool lockdown		# Set to true if actuators are forced to being disabled (due to emergency or HIL)
 bool force_failsafe	# Set to true if the actuators are forced to the failsafe position
+bool ignore_controls # IO/FMU should ignore messages from the actuator controls topics (used for esc calibration)

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -302,6 +302,7 @@ private:
 	float			_battery_mamphour_total;///< amp hours consumed so far
 	uint64_t		_battery_last_timestamp;///< last amp hour calculation timestamp
 	bool			_cb_flighttermination;	///< true if the flight termination circuit breaker is enabled
+	bool 			_ignore_actuators;		///< do not send control outputs to IO (used for esc calibration)
 
 	int32_t			_rssi_pwm_chan; ///< RSSI PWM input channel
 	int32_t			_rssi_pwm_max; ///< max RSSI input on PWM channel
@@ -529,6 +530,7 @@ PX4IO::PX4IO(device::Device *interface) :
 	_battery_mamphour_total(0),
 	_battery_last_timestamp(0),
 	_cb_flighttermination(true),
+	_ignore_actuators(false),
 	_rssi_pwm_chan(0),
 	_rssi_pwm_max(0),
 	_rssi_pwm_min(0)
@@ -1167,7 +1169,7 @@ PX4IO::io_set_control_state(unsigned group)
 		break;
 	}
 
-	if (!changed) {
+	if (!changed || _ignore_actuators) {
 		return -1;
 	}
 
@@ -1192,7 +1194,8 @@ PX4IO::io_set_arming_state()
 	uint16_t set = 0;
 	uint16_t clear = 0;
 
-        if (have_armed == OK) {
+    if (have_armed == OK) {
+		_ignore_actuators = armed.ignore_controls;
 		if (armed.armed) {
 			set |= PX4IO_P_SETUP_ARMING_FMU_ARMED;
 		} else {

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -114,6 +114,7 @@
 #include "baro_calibration.h"
 #include "rc_calibration.h"
 #include "airspeed_calibration.h"
+#include "esc_calibration.h"
 #include "PreflightCheck.h"
 
 /* oddly, ERROR is not defined for c++ */
@@ -2711,6 +2712,13 @@ void *commander_low_prio_loop(void *arg)
 						answer_command(cmd, VEHICLE_CMD_RESULT_ACCEPTED);
 						calib_ret = do_airspeed_calibration(mavlink_fd);
 
+					} else if ((int)(cmd.param7) == 1) {
+						/* do esc calibration */
+						answer_command(cmd,VEHICLE_CMD_RESULT_ACCEPTED);
+						armed.ignore_controls = true;
+						calib_ret = do_esc_calibration(mavlink_fd);
+						armed.ignore_controls = false;
+
 					} else if ((int)(cmd.param4) == 0) {
 						/* RC calibration ended - have we been in one worth confirming? */
 						if (status.rc_input_blocked) {
@@ -2722,7 +2730,6 @@ void *commander_low_prio_loop(void *arg)
 
 						/* this always succeeds */
 						calib_ret = OK;
-
 					}
 
 					if (calib_ret == OK) {

--- a/src/modules/commander/esc_calibration.cpp
+++ b/src/modules/commander/esc_calibration.cpp
@@ -1,0 +1,199 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file esc_calibration.cpp
+ *
+ * Definition of esc calibration
+ *
+ * @author Roman Bapst <bapstr@ethz.ch>
+ */
+
+#include "esc_calibration.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <systemlib/err.h>
+#include <fcntl.h>
+#include <poll.h>
+#include "drivers/drv_pwm_output.h"
+#include <uORB/topics/battery_status.h>
+#include <uORB/topics/vehicle_command.h>
+#include <uORB/uORB.h>
+#include <drivers/drv_hrt.h>
+#include <mavlink/mavlink_log.h>
+
+
+int do_esc_calibration(int mavlink_fd) {
+	struct battery_status_s battery;
+	memset(&battery,0,sizeof(battery));
+	int batt_sub = orb_subscribe(ORB_ID(battery_status));
+	memset(&battery,0,sizeof(battery));
+	orb_copy(ORB_ID(battery_status), batt_sub, &battery);
+
+	if (battery.voltage_filtered_v > 3.0f && !(hrt_absolute_time() - battery.timestamp > 500000)) {
+		warnx("Please disconnect battery before calibration!");
+		mavlink_log_info(mavlink_fd, "Please disconnect battery and try again!");
+		return -1;
+	}
+
+	unsigned max_channels = 0;
+
+	mavlink_log_info(mavlink_fd, "Please select pins on which ESC's are attached.");
+
+	// wait for the user to provide the number of engines connected
+	int cmd_sub = orb_subscribe(ORB_ID(vehicle_command));
+	struct vehicle_command_s cmd;
+	bool updated = false;
+	while(true) {
+		orb_check(cmd_sub,&updated);
+		if(updated) {
+			orb_copy(ORB_ID(vehicle_command), cmd_sub, &cmd);
+			if((int)(cmd.param7) > 100 && cmd.command == VEHICLE_CMD_PREFLIGHT_CALIBRATION) {
+				break;
+			}
+		}
+		usleep(500000);
+	}
+
+	// parse user input
+	uint32_t set_mask = 0;
+	int config = (int)(cmd.param7);
+	int multiplier = 10000000;
+	for(unsigned i = 0;i<8;i++) {
+		if(2*multiplier > config) {
+			// this pin does not have an esc
+			config -= multiplier;
+		} else {
+			// this pin has an esc
+			set_mask |= (1<<i);
+			config -= 2*multiplier;
+		}
+		multiplier /= 10;
+	}
+
+	uint16_t pwm_high = PWM_DEFAULT_MAX;
+	uint16_t pwm_low = PWM_DEFAULT_MIN;
+
+	int fd = open(PWM_OUTPUT0_DEVICE_PATH, 0);
+
+	if(fd < 0) {
+		err(1,"Can't open %s", PWM_OUTPUT0_DEVICE_PATH);
+	}
+
+	/* get number of channels available on the device */
+	int ret;
+	ret = ioctl(fd, PWM_SERVO_GET_COUNT, (unsigned long)&max_channels);
+	if (ret != OK)
+		err(1, "PWM_SERVO_GET_COUNT");
+
+	/* tell IO/FMU that its ok to disable its safety with the switch */
+	ret = ioctl(fd, PWM_SERVO_SET_ARM_OK, 0);
+	if (ret != OK)
+		err(1, "PWM_SERVO_SET_ARM_OK");
+	/* tell IO/FMU that the system is armed (it will output values if safety is off) */
+	ret = ioctl(fd, PWM_SERVO_ARM, 0);
+	if (ret != OK)
+		err(1, "PWM_SERVO_ARM");
+	/* tell IO to switch off safety without using the safety switch */
+	ret = ioctl(fd, PWM_SERVO_SET_FORCE_SAFETY_OFF, 0);
+	if(ret!=0) {
+		err(1,"PWM_SERVO_SET_FORCE_SAFETY_OFF");
+	}
+
+	warnx("Please connect battery now");
+	mavlink_log_info(mavlink_fd,"Please connect battery now");
+
+	/* wait for one of the following events:
+		1) user has pressed the button in QGroundControl
+		2) timeout of 5 seconds is reached
+	*/
+	hrt_abstime start_time = hrt_absolute_time();
+
+	while(true) {
+		for (unsigned i = 0; i < max_channels; i++) {
+			if (set_mask & 1<<i) {
+				ret = ioctl(fd, PWM_SERVO_SET(i), pwm_high);
+
+				if (ret != OK)
+					err(1, "PWM_SERVO_SET(%d), value: %d", i, pwm_high);
+			}
+		}
+
+		orb_check(batt_sub,&updated);
+		if(updated) {
+			orb_copy(ORB_ID(battery_status), batt_sub, &battery);
+		}
+		// user has connected battery
+		if(battery.voltage_filtered_v > 3.0f) {
+			orb_check(cmd_sub,&updated);
+			if(updated) {
+				orb_copy(ORB_ID(vehicle_command), cmd_sub, &cmd);
+			}
+			if((int)(cmd.param7) == 2 && cmd.command == VEHICLE_CMD_PREFLIGHT_CALIBRATION) {
+				break;
+			} else if (hrt_absolute_time() - start_time > 5000000) {
+				// waited for 5 seconds, switch to low pwm
+				break;
+			}
+		}
+		else {
+			start_time = hrt_absolute_time();
+		}
+	}
+
+	/* set low PWM */
+	for (unsigned i = 0; i < max_channels; i++) {
+		if (set_mask & 1<<i) {
+			ret = ioctl(fd, PWM_SERVO_SET(i), pwm_low);
+
+			if (ret != OK)
+				err(1, "PWM_SERVO_SET(%d), value: %d", i, pwm_low);
+		}
+	}
+
+	usleep(2000000);	// give esc some time to save low pwm value
+
+	/* disarm */
+	ret = ioctl(fd, PWM_SERVO_DISARM, 0);
+	if (ret != OK)
+		err(1, "PWM_SERVO_DISARM");
+
+	warnx("ESC calibration finished");
+	mavlink_log_info(mavlink_fd,"ESC calibration finished");
+
+	exit(0);
+ }

--- a/src/modules/commander/esc_calibration.h
+++ b/src/modules/commander/esc_calibration.h
@@ -1,0 +1,47 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file esc_calibration.h
+ *
+ * Definition of esc calibration
+ *
+ * @author Roman Bapst <bapstr@ethz.ch>
+ */
+
+#ifndef ESC_CALIBRATION_H_
+#define ESC_CALIBRATION_H_
+
+int do_esc_calibration(int mavlink_fd);
+
+#endif

--- a/src/modules/commander/module.mk
+++ b/src/modules/commander/module.mk
@@ -47,6 +47,7 @@ SRCS		 	= commander.cpp \
 			baro_calibration.cpp \
 			rc_calibration.cpp \
 			airspeed_calibration.cpp \
+			esc_calibration.cpp \
 			PreflightCheck.cpp
 
 MODULE_STACKSIZE = 5000


### PR DESCRIPTION
Not for merging yet, just for discussion. Open question:
How do we determine on which pins motors are attached? We could ask user but it would be better to read a configuration file for the vehicle.