### PR TITLE
commander accel calibration: Use pre-rotated topic in board frame

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1159,7 +1159,7 @@ int commander_thread_main(int argc, char *argv[])
 	/* initialize low priority thread */
 	pthread_attr_t commander_low_prio_attr;
 	pthread_attr_init(&commander_low_prio_attr);
-	pthread_attr_setstacksize(&commander_low_prio_attr, 2000);
+	pthread_attr_setstacksize(&commander_low_prio_attr, 2600);
 
 	struct sched_param param;
 	(void)pthread_attr_getschedparam(&commander_low_prio_attr, &param);


### PR DESCRIPTION
@AndreasAntener This is untested, but should fix your issue. @DonLakeFlyer in case you want to include this in your testing - this now really uses the board rotation param, whereas the individual sensor topics don't.