### PR TITLE
MAVLink app: added static of struct vehicle_attitude_setpoint_s att_sp, preserving previous value

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -822,7 +822,7 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 
 				/* Publish attitude setpoint if attitude and thrust ignore bits are not set */
 				if (!(_offboard_control_mode.ignore_attitude)) {
-					struct vehicle_attitude_setpoint_s att_sp = {};
+					static struct vehicle_attitude_setpoint_s att_sp = {};
 					att_sp.timestamp = hrt_absolute_time();
 					mavlink_quaternion_to_euler(set_attitude_target.q,
 							&att_sp.roll_body, &att_sp.pitch_body, &att_sp.yaw_body);


### PR DESCRIPTION
1d283bf3c15b79ad2aa23ed3e2de7ff80f0261fe removed 'static' incorrectly making it unable to preserve the value of struct vehicle_attitude_setpoint_s att_sp.

The detail is well explained by the comment above this code: 

The tricky part in parsing this message is that the offboard sender *can* set attitude and thrust using different messages. Eg.: First send set_attitude_target containing the attitude and ignore bits set for everything else and then send set_attitude_target containing the thrust and ignore bits set for everything else.