### PR TITLE
Attitude filter for multirotors: Let users choose between filters, default to old one

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.mc_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_apps
@@ -9,10 +9,10 @@
 # filter by setting INAV_ENABLED = 0
 if param compare INAV_ENABLED 1
 then
-	# The system is defaulting to EKF_ATT_ENABLED = 0
-	# and uses the new quaternion based complimentary
-	# filter. However users can enable the older EKF
-	# filter if they choose to.
+	# The system is defaulting to EKF_ATT_ENABLED = 1
+	# and uses the older EKF filter. However users can
+	# enable the new quaternion based complimentary
+	# filter by setting EKF_ATT_ENABLED = 0.
 	if param compare EKF_ATT_ENABLED 1
 	then
 		attitude_estimator_ekf start

--- a/ROMFS/px4fmu_common/init.d/rc.mc_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_apps
@@ -4,11 +4,21 @@
 # att & pos estimator, att & pos control.
 #
 
-# previously (2014) the system was relying on
-# INAV, which defaults to 0 now. 
+# The system is defaulting to INAV_ENABLED = 1
+# but users can alternatively try the EKF-based
+# filter by setting INAV_ENABLED = 0
 if param compare INAV_ENABLED 1
 then
-	attitude_estimator_q start
+	# The system is defaulting to EKF_ATT_ENABLED = 0
+	# and uses the new quaternion based complimentary
+	# filter. However users can enable the older EKF
+	# filter if they choose to.
+	if param compare EKF_ATT_ENABLED 1
+	then
+		attitude_estimator_ekf start
+	else
+		attitude_estimator_q start
+	fi
 	position_estimator_inav start
 else
 	ekf_att_pos_estimator start

--- a/src/modules/attitude_estimator_ekf/attitude_estimator_ekf_params.c
+++ b/src/modules/attitude_estimator_ekf/attitude_estimator_ekf_params.c
@@ -94,8 +94,18 @@ PARAM_DEFINE_FLOAT(EKF_ATT_V4_R1, 10000.0f);
  */
 PARAM_DEFINE_FLOAT(EKF_ATT_V4_R2, 100.0f);
 
-/* magnetic declination, in degrees */
-PARAM_DEFINE_INT32(EKF_ATT_ENABLED, 0);
+/**
+ * EKF attitude estimator enabled
+ *
+ * If enabled, it uses the older EKF filter.
+ * However users can enable the new quaternion
+ * based complimentary filter by setting EKF_ATT_ENABLED = 0.
+ *
+ * @min 0
+ * @max 1
+ * @group Attitude EKF estimator
+ */
+PARAM_DEFINE_INT32(EKF_ATT_ENABLED, 1);
 
 /* magnetic declination, in degrees */
 PARAM_DEFINE_FLOAT(ATT_MAG_DECL, 0.0f);

--- a/src/modules/attitude_estimator_ekf/attitude_estimator_ekf_params.c
+++ b/src/modules/attitude_estimator_ekf/attitude_estimator_ekf_params.c
@@ -95,6 +95,9 @@ PARAM_DEFINE_FLOAT(EKF_ATT_V4_R1, 10000.0f);
 PARAM_DEFINE_FLOAT(EKF_ATT_V4_R2, 100.0f);
 
 /* magnetic declination, in degrees */
+PARAM_DEFINE_INT32(EKF_ATT_ENABLED, 0);
+
+/* magnetic declination, in degrees */
 PARAM_DEFINE_FLOAT(ATT_MAG_DECL, 0.0f);
 
 PARAM_DEFINE_INT32(ATT_ACC_COMP, 2);

--- a/src/modules/position_estimator_inav/position_estimator_inav_params.c
+++ b/src/modules/position_estimator_inav/position_estimator_inav_params.c
@@ -291,8 +291,8 @@ PARAM_DEFINE_INT32(CBRK_NO_VISION, 0);
 /**
  * INAV enabled
  *
- * If set to 1, use INAV for position estimation
- * the system uses the combined attitude / position
+ * If set to 1, use INAV for position estimation.
+ * Else the system uses the combined attitude / position
  * filter framework.
  *
  * @min 0


### PR DESCRIPTION
@LorenzMeier I didn't want to hijack your branch #2135, so here's a new one (also **untested**) with the default changed and the param docs updated.

When I read #2013 it sounds like there are still issues to be taken care of?