### PR TITLE
Firmware update process bug fixes

### DIFF
--- a/nuttx-configs/s2740vc/scripts/bootloaderld.script
+++ b/nuttx-configs/s2740vc/scripts/bootloaderld.script
@@ -43,7 +43,7 @@
 
 MEMORY
 {
-    flash (rx) : ORIGIN = 0x08000000, LENGTH = 16K
+    flash (rx) : ORIGIN = 0x08000000, LENGTH = 8K
     sram (rwx) : ORIGIN = 0x20000000, LENGTH = 16K
 }
 

--- a/src/drivers/bootloaders/include/flash.h
+++ b/src/drivers/bootloaders/include/flash.h
@@ -69,17 +69,21 @@ typedef enum {
  * Name: bl_flash_erase
  *
  * Description:
- *   This function erases the flash starting at the given address
+ *   This function erases the flash starting at address and ending at
+ *   address + nbytes.
  *
  * Input Parameters:
- *   address - The word aligned address of the flash to erase
+ *   address - A word-aligned address within the first page of flash to erase
+ *   nbytes - The number of bytes to erase, rounding up to the next page.
+ *
+ *
  *
  * Returned value:
  *   On success FLASH_OK On Error one of the flash_error_t
  *
  ****************************************************************************/
 
-flash_error_t bl_flash_erase(size_t address);
+flash_error_t bl_flash_erase(size_t address, size_t nbytes);
 
 /****************************************************************************
  * Name: bl_flash_write_word

--- a/src/drivers/bootloaders/include/uavcan.h
+++ b/src/drivers/bootloaders/include/uavcan.h
@@ -268,7 +268,7 @@ size_t uavcan_pack_logmessage(uint8_t *data,
                               const uavcan_logmessage_t *message);
 
 /****************************************************************************
- * Name: uavcan_make_frame_id
+ * Name: uavcan_make_service_frame_id
  *
  * Description:
  *   This function formats the data of a uavcan_frame_id_t structure
@@ -282,7 +282,7 @@ size_t uavcan_pack_logmessage(uint8_t *data,
  *
  ****************************************************************************/
 
-uint32_t uavcan_make_frame_id(const uavcan_frame_id_t *frame_id);
+uint32_t uavcan_make_service_frame_id(const uavcan_frame_id_t *frame_id);
 
 
 /****************************************************************************
@@ -328,6 +328,26 @@ int uavcan_parse_frame_id(uavcan_frame_id_t *out_frame_id,
 
 void uavcan_tx_nodestatus(uint8_t node_id, uint32_t uptime_sec,
                           uint8_t status_code);
+
+/****************************************************************************
+ * Name: uavcan_tx_log_message
+ *
+ * Description:
+ *   This functions sends uavcan logmessage type data. See uavcan/protocol.h
+ *   UAVCAN_LOGMESSAGE_xxx defines.
+ *
+ * Input Parameters:
+ *   node_id - This node's node id
+ *   level   - Log Level of the logmessage DEBUG, INFO, WARN, ERROR
+ *   stage   - The Stage the application is at. see UAVCAN_LOGMESSAGE_STAGE_x
+ *   status  - The status of that stage. Start, Fail OK
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+void uavcan_tx_log_message(uint8_t node_id, uint8_t level, uint8_t stage,
+                           uint8_t status);
 
 /****************************************************************************
  * Name: uavcan_tx_allocation_message


### PR DESCRIPTION
* Fixed flash erase page index.
* Refactored broadcast frame ID generation to reduce code size.
* Moved uavcan.protocol.debug.LogMessage send procedure into uavcan.c.
* Fixed file read rate limit timer.
* Fixed tboot timer config.
* Fixed firmware image size lookup when jumping to application without updating firmware.