### PR TITLE
mpc parameter INAV_W_Z_VIS_P increased

### DIFF
--- a/src/modules/position_estimator_inav/position_estimator_inav_params.c
+++ b/src/modules/position_estimator_inav/position_estimator_inav_params.c
@@ -83,7 +83,7 @@ PARAM_DEFINE_FLOAT(INAV_W_Z_GPS_V, 0.0f);
  * @max 10.0
  * @group Position Estimator INAV
  */
-PARAM_DEFINE_FLOAT(INAV_W_Z_VIS_P, 0.5f);
+PARAM_DEFINE_FLOAT(INAV_W_Z_VIS_P, 5.0f);
 
 /**
  * Z axis weight for sonar


### PR DESCRIPTION
Originally INAV_W_Z_VIS_P was 0.5, with this value the correction of the vision estimate is pretty null. The estimate was with noise and with a variable offset. Increasing the parameter to 5 the estimation improved significantly, checked with flightplot.