### PR TITLE
Fix potential null pointer deref in Mavlink dtor if task_main returns error

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -249,7 +249,9 @@ Mavlink::~Mavlink()
 		} while (_task_running);
 	}
 
-	LL_DELETE(_mavlink_instances, this);
+	if (_mavlink_instances) {
+		LL_DELETE(_mavlink_instances, this);
+	}
 }
 
 void


### PR DESCRIPTION
LL_APPEND is called just before the loop spins up but various error conditions can cause the task to exit before then. When that happens Mavlink::start_helper calls delete on the instance which tries to prune it from the global list. If this is the first Mavlink instance to attempt starting the list head is null and we hardfault in the Mavlink dtor.

Only call LL_DELETE after checking the list head for a null pointer.

This fixes a startup condition where our boards hang on boot without a USB CDC/ACM connection (mavlink_open_uart fails) but boot successfully when connected to USB. 