### PR TITLE
Master param mem usage redux

### DIFF
--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -298,7 +298,7 @@ param_for_used_index(unsigned index)
 		/* walk all params and count */
 		int count = 0;
 
-		for (unsigned i = 0; i < (unsigned)param_info_count + 1; i++) {
+		for (unsigned i = 0; i < (unsigned)size_param_changed_storage_bytes; i++) {
 			for (unsigned j = 0; j < 8; j++) {
 				if (param_changed_storage[i] & (1 << j)) {
 

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -44,6 +44,7 @@
 #include <debug.h>
 #include <string.h>
 #include <stdbool.h>
+#include <stdlib.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <systemlib/err.h>
@@ -105,7 +106,7 @@ get_param_info_count(void)
     if (!param_changed_storage)
       {
         size_param_changed_storage_bytes  = (param_info_count / bits_per_allocation_unit ) + 1;
-        param_changed_storage = zalloc(size_param_changed_storage_bytes);
+        param_changed_storage = calloc(size_param_changed_storage_bytes, 1);
       }
     return param_info_count;
 }

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -365,7 +365,7 @@ param_get_used_index(param_t param)
 const char *
 param_name(param_t param)
 {
-	return handle_in_range(param) ? param_info_base[param].name : NULL;;
+	return handle_in_range(param) ? param_info_base[param].name : NULL;
 }
 
 bool

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -283,7 +283,7 @@ param_count_used(void)
 param_t
 param_for_index(unsigned index)
 {
-	if (index < get_param_info_count())
+	if (index < get_param_info_count()) {
 		return (param_t)index;
 	}
 

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -542,8 +542,6 @@ param_set_internal(param_t param, const void *val, bool mark_saved, bool notify_
 	}
 
 out:
-	param_set_used_internal(param);
-
 	param_unlock();
 
 	/*

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -58,7 +58,6 @@
 #include "systemlib/param/param.h"
 #include "systemlib/uthash/utarray.h"
 #include "systemlib/bson/tinybson.h"
-#include <systemlib/px4_macros.h>
 
 #include "uORB/uORB.h"
 #include "uORB/topics/parameter_update.h"

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -338,20 +338,19 @@ param_get_index(param_t param)
 int
 param_get_used_index(param_t param)
 {
-	int param_storage_index = param_get_index(param);
-
-	if (param_storage_index < 0) {
+	/* this tests for out of bounds and does a constant time lookup */
+	if (!param_used(param)) {
 		return -1;
 	}
 
-	/* walk all params and count */
+	/* walk all params and count, now knowing that it has a valid index */
 	int count = 0;
 
-	for (unsigned i = 0; i < (unsigned)param + 1; i++) {
-		for (unsigned j = 0; j < bits_per_allocation_unit; j++) {
+	for (unsigned i = 0; i < (unsigned)size_param_changed_storage_bytes; i++) {
+		for (unsigned j = 0; j < 8; j++) {
 			if (param_changed_storage[i] & (1 << j)) {
 
-				if (param_storage_index == i) {
+				if ((unsigned)param == i * 8 + j) {
 					return count;
 				}
 

--- a/src/modules/systemlib/param/param.h
+++ b/src/modules/systemlib/param/param.h
@@ -249,7 +249,7 @@ __EXPORT void		param_reset_all(void);
  *							at the end to exclude parameters with a certain prefix.
  * @param num_excludes		The number of excludes provided.
  */
- __EXPORT void		param_reset_excludes(const char* excludes[], int num_excludes);
+__EXPORT void		param_reset_excludes(const char *excludes[], int num_excludes);
 
 /**
  * Export changed parameters to a file.
@@ -306,16 +306,16 @@ __EXPORT void		param_foreach(void (*func)(void *arg, param_t param), void *arg, 
  *			exist.
  * @return		Zero on success.
  */
-__EXPORT int 		param_set_default_file(const char* filename);
+__EXPORT int 		param_set_default_file(const char *filename);
 
 /**
  * Get the default parameter file name.
  *
  * @return		The path to the current default parameter file; either as
- *			a result of a call to param_set_default_file, or the 
+ *			a result of a call to param_set_default_file, or the
  *			built-in default.
  */
-__EXPORT const char*	param_get_default_file(void);
+__EXPORT const char	*param_get_default_file(void);
 
 /**
  * Save parameters to the default file.


### PR DESCRIPTION
@LorenzMeier Please Ignore https://github.com/PX4/Firmware/commit/9c6a70d4a75b5909a3f7fede2805bdf4b62d05c2 

Use this instead - NB https://github.com/PX4/Firmware/compare/master_param_mem_usage_redux?expand=1#diff-a953b7046039fd7cd55c5860953df79cL562 - the old code looks very wrong.

