### PR TITLE
l3gd20: faster gyro interrupts

### DIFF
--- a/src/drivers/l3gd20/l3gd20.cpp
+++ b/src/drivers/l3gd20/l3gd20.cpp
@@ -195,7 +195,7 @@ static const int ERROR = -1;
   This time reduction is enough to cope with worst case timing jitter
   due to other timers
  */
-#define L3GD20_TIMER_REDUCTION				200
+#define L3GD20_TIMER_REDUCTION				600
 
 extern "C" { __EXPORT int l3gd20_main(int argc, char *argv[]); }
 


### PR DESCRIPTION
In APM:Copter we have found that we have enough timing jitter that we are occasionally not getting an l3gd20 sample on every iteration.  This patch increases the frequency of the interrupts enough that a sample is always available.
By the way, this change has no noticeable effect on CPU utilisation at least for ardupilot.