### PR TITLE
Fix MAVLink USB UART detection

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -575,7 +575,7 @@ int Mavlink::get_component_id()
 }
 
 #ifndef __PX4_POSIX
-int Mavlink::mavlink_open_uart(int baud, const char *uart_name, struct termios *uart_config_original, bool *is_usb)
+int Mavlink::mavlink_open_uart(int baud, const char *uart_name, struct termios *uart_config_original)
 {
 	/* process baud rate */
 	int speed;
@@ -640,7 +640,7 @@ int Mavlink::mavlink_open_uart(int baud, const char *uart_name, struct termios *
 	/* Try to set baud rate */
 	struct termios uart_config;
 	int termios_state;
-	*is_usb = false;
+	_is_usb_uart = false;
 
 	/* Back up the original uart configuration to restore it after exit */
 	if ((termios_state = tcgetattr(_uart_fd, uart_config_original)) < 0) {
@@ -665,6 +665,8 @@ int Mavlink::mavlink_open_uart(int baud, const char *uart_name, struct termios *
 			return -1;
 		}
 
+	} else {
+		_is_usb_uart = true;
 	}
 
 	if ((termios_state = tcsetattr(_uart_fd, TCSANOW, &uart_config)) < 0) {
@@ -1350,7 +1352,7 @@ Mavlink::task_main(int argc, char *argv[])
 	struct termios uart_config_original;
 
 	/* default values for arguments */
-	_uart_fd = mavlink_open_uart(_baudrate, _device_name, &uart_config_original, &_is_usb_uart);
+	_uart_fd = mavlink_open_uart(_baudrate, _device_name, &uart_config_original);
 
 	if (_uart_fd < 0) {
 		warn("could not open %s", _device_name);

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -387,7 +387,7 @@ private:
 	void			mavlink_update_system();
 
 #ifndef __PX4_QURT
-	int			mavlink_open_uart(int baudrate, const char *uart_name, struct termios *uart_config_original, bool *is_usb);
+	int			mavlink_open_uart(int baudrate, const char *uart_name, struct termios *uart_config_original);
 #endif
 
 	static unsigned int	interval_from_rate(float rate);


### PR DESCRIPTION
The MAVLink module was improperly tracking USB UARTs and trying to enable flow control on them. This patch fixes the correct behavior and removes the unnecessary pointer parameter in mavlink_open_uart.