### PR TITLE
Fix double build when using new make target syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ TARGETS	:= nuttx posix qurt
 EXPLICIT_TARGET	:= $(filter $(TARGETS),$(MAKECMDGOALS))
 ifneq ($(EXPLICIT_TARGET),)
     export PX4_TARGET_OS=$(EXPLICIT_TARGET)
+    export GOALS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 endif
 
 #
@@ -277,14 +278,12 @@ testbuild:
 	$(Q) (cd $(PX4_BASE) && $(MAKE) distclean && $(MAKE) archives && $(MAKE) -j8)
 	$(Q) (zip -r Firmware.zip $(PX4_BASE)/Images)
 
-nuttx: 
-	make PX4_TARGET_OS=$@ $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
-
-posix: 
-	make PX4_TARGET_OS=$@ $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
-
-qurt: 
-	make PX4_TARGET_OS=$@ $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+nuttx posix qurt: 
+ifeq ($(GOALS),)
+	make PX4_TARGET_OS=$@ $(GOALS)
+else
+	export PX4_TARGET_OS=$@
+endif
 
 posixrun:
 	Tools/posix_run.sh

--- a/src/drivers/device/vdev.cpp
+++ b/src/drivers/device/vdev.cpp
@@ -64,7 +64,7 @@ private:
 	px4_dev_t() {}
 };
 
-#define PX4_MAX_DEV 30
+#define PX4_MAX_DEV 50
 static px4_dev_t *devmap[PX4_MAX_DEV];
 
 /*
@@ -99,7 +99,7 @@ VDev::~VDev()
 int
 VDev::register_class_devname(const char *class_devname)
 {
-	PX4_DEBUG("VDev::register_class_devname");
+	PX4_DEBUG("VDev::register_class_devname %s", class_devname);
 	if (class_devname == nullptr) {
 		return -EINVAL;
 	}
@@ -124,7 +124,7 @@ VDev::register_class_devname(const char *class_devname)
 int
 VDev::register_driver(const char *name, void *data)
 {
-	PX4_DEBUG("VDev::register_driver");
+	PX4_DEBUG("VDev::register_driver %s", name);
 	int ret = -ENOSPC;
 
 	if (name == NULL || data == NULL)
@@ -145,14 +145,17 @@ VDev::register_driver(const char *name, void *data)
 			break;
 		}
 	}
+	if (ret != PX4_OK) {
+		PX4_ERR("No free devmap entries - increase PX4_MAX_DEV");
+	}
 	return ret;
 }
 
 int
 VDev::unregister_driver(const char *name)
 {
-	PX4_DEBUG("VDev::unregister_driver");
-	int ret = -ENOSPC;
+	PX4_DEBUG("VDev::unregister_driver %s", name);
+	int ret = -EINVAL;
 
 	if (name == NULL)
 		return -EINVAL;

--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -63,6 +63,9 @@ Simulator *Simulator::getInstance()
 
 bool Simulator::getMPUReport(uint8_t *buf, int len)
 {
+	// Reads are paced from reading gyrosim and if
+	// we don't delay here we read too fast
+	usleep(50000);
 	return _mpu.copyData(buf, len);
 }
 

--- a/src/platforms/posix/px4_layer/work_thread.c
+++ b/src/platforms/posix/px4_layer/work_thread.c
@@ -138,10 +138,11 @@ static void work_process(FAR struct wqueue_s *wqueue, int lock_id)
 
           work_unlock(lock_id);
 	  if (!worker) {
-             printf("MESSED UP: worker = 0\n");
+             PX4_ERR("MESSED UP: worker = 0");
           }
-          else
+          else {
             worker(arg);
+          }
 
           /* Now, unfortunately, since we re-enabled interrupts we don't
            * know the state of the work list and we will have to start

--- a/src/platforms/px4_log.h
+++ b/src/platforms/px4_log.h
@@ -53,7 +53,7 @@
 #if defined(__PX4_QURT)
 #include <stdio.h>
 
-#define PX4_DEBUG(...)	__px4_log_verbose("DEBUG", __VA_ARGS__);
+#define PX4_DEBUG(...)	__px4_log_omit("DEBUG", __VA_ARGS__);
 #define PX4_INFO(...) 	__px4_log("INFO",  __VA_ARGS__);
 #define PX4_WARN(...) 	__px4_log_verbose("WARN",  __VA_ARGS__);
 #define PX4_ERR(...)	__px4_log_verbose("ERROR", __VA_ARGS__);

--- a/src/platforms/px4_log.h
+++ b/src/platforms/px4_log.h
@@ -50,19 +50,24 @@
 	printf(__VA_ARGS__);\
 	printf(" (file %s line %d)\n", __FILE__, __LINE__);\
 }
-
 #if defined(__PX4_QURT)
 #include <stdio.h>
 
-#define PX4_DEBUG(...)	__px4_log_omit("DEBUG", __VA_ARGS__);
+#define PX4_DEBUG(...)	__px4_log_verbose("DEBUG", __VA_ARGS__);
 #define PX4_INFO(...) 	__px4_log("INFO",  __VA_ARGS__);
 #define PX4_WARN(...) 	__px4_log_verbose("WARN",  __VA_ARGS__);
 #define PX4_ERR(...)	__px4_log_verbose("ERROR", __VA_ARGS__);
 
 #elif defined(__PX4_LINUX)
 #include <stdio.h>
+#include <pthread.h>
 
-//#define PX4_DEBUG(...)	{ }
+#define __px4_log_threads(level, ...)   { \
+	printf("%-5s %ld ", level, pthread_self());\
+	printf(__VA_ARGS__);\
+	printf(" (file %s line %d)\n", __FILE__, __LINE__);\
+}
+
 #define PX4_DEBUG(...) 	__px4_log_omit("DEBUG", __VA_ARGS__);
 #define PX4_INFO(...) 	__px4_log("INFO",  __VA_ARGS__);
 #define PX4_WARN(...) 	__px4_log_verbose("WARN",  __VA_ARGS__);


### PR DESCRIPTION
When make is invoked as "make posix posix_default"
it will build the posix_default target twice. The Makefile was
fixed to correct this.

If "make posix" is run, the Makefile still calls "make PX4_TARGET_OS=posix".

If "make posix posix_default" is run, the posix target just exports
PX4_TARGET_OS=posix and then make evaluates the next goal (posix_default).

Signed-off-by: Mark Charlebois <charlebm@gmail.com>