### PR TITLE
WIP: PWM invert

### DIFF
--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -157,6 +157,7 @@ private:
 	uint16_t	_disarmed_pwm[_max_actuators];
 	uint16_t	_min_pwm[_max_actuators];
 	uint16_t	_max_pwm[_max_actuators];
+	uint16_t	_reverse_pwm_mask;
 	unsigned	_num_failsafe_set;
 	unsigned	_num_disarmed_set;
 
@@ -269,6 +270,7 @@ PX4FMU::PX4FMU() :
 	_pwm_limit{},
 	_failsafe_pwm{0},
 	_disarmed_pwm{0},
+	_reverse_pwm_mask(0),
 	_num_failsafe_set(0),
 	_num_disarmed_set(0)
 {
@@ -684,7 +686,7 @@ PX4FMU::task_main()
 				uint16_t pwm_limited[num_outputs];
 
 				/* the PWM limit call takes care of out of band errors and constrains */
-				pwm_limit_calc(_servo_armed, num_outputs, _disarmed_pwm, _min_pwm, _max_pwm, outputs.output, pwm_limited, &_pwm_limit);
+				pwm_limit_calc(_servo_armed, num_outputs, _reverse_pwm_mask, _disarmed_pwm, _min_pwm, _max_pwm, outputs.output, pwm_limited, &_pwm_limit);
 
 				/* output to the servos */
 				for (unsigned i = 0; i < num_outputs; i++) {

--- a/src/drivers/px4fmu/module.mk
+++ b/src/drivers/px4fmu/module.mk
@@ -3,7 +3,8 @@
 #
 
 MODULE_COMMAND	 = fmu
-SRCS		 = fmu.cpp
+SRCS		 = fmu.cpp \
+		   px4fmu_params.c
 
 MODULE_STACKSIZE = 1200
 

--- a/src/drivers/px4fmu/px4fmu_params.c
+++ b/src/drivers/px4fmu/px4fmu_params.c
@@ -51,7 +51,7 @@
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_AUX_SCALE1, 1);
+PARAM_DEFINE_INT32(PWM_AUX_REV1, 1);
 
 /**
  * Inverter for main output channel 2
@@ -62,7 +62,7 @@ PARAM_DEFINE_INT32(PWM_AUX_SCALE1, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_AUX_SCALE2, 1);
+PARAM_DEFINE_INT32(PWM_AUX_REV2, 1);
 
 /**
  * Inverter for main output channel 3
@@ -73,7 +73,7 @@ PARAM_DEFINE_INT32(PWM_AUX_SCALE2, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_AUX_SCALE3, 1);
+PARAM_DEFINE_INT32(PWM_AUX_REV3, 1);
 
 /**
  * Inverter for main output channel 4
@@ -84,7 +84,7 @@ PARAM_DEFINE_INT32(PWM_AUX_SCALE3, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_AUX_SCALE4, 1);
+PARAM_DEFINE_INT32(PWM_AUX_REV4, 1);
 
 /**
  * Inverter for main output channel 5
@@ -95,7 +95,7 @@ PARAM_DEFINE_INT32(PWM_AUX_SCALE4, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_AUX_SCALE5, 1);
+PARAM_DEFINE_INT32(PWM_AUX_REV5, 1);
 
 /**
  * Inverter for main output channel 6
@@ -106,4 +106,4 @@ PARAM_DEFINE_INT32(PWM_AUX_SCALE5, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_AUX_SCALE6, 1);
+PARAM_DEFINE_INT32(PWM_AUX_REV6, 1);

--- a/src/drivers/px4fmu/px4fmu_params.c
+++ b/src/drivers/px4fmu/px4fmu_params.c
@@ -1,0 +1,109 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file px4fmu_params.c
+ *
+ * Parameters defined by the PX4FMU driver
+ *
+ * @author Lorenz Meier <lorenz@px4.io>
+ */
+
+#include <nuttx/config.h>
+#include <systemlib/param/param.h>
+
+/**
+ * Inverter for main output channel 1
+ *
+ * Set to 1 to invert the channel.
+ *
+ * @min 0
+ * @max 1
+ * @group PWM Outputs
+ */
+PARAM_DEFINE_INT32(PWM_AUX_SCALE1, 1);
+
+/**
+ * Inverter for main output channel 2
+ *
+ * Set to 1 to invert the channel.
+ *
+ * @min 0
+ * @max 1
+ * @group PWM Outputs
+ */
+PARAM_DEFINE_INT32(PWM_AUX_SCALE2, 1);
+
+/**
+ * Inverter for main output channel 3
+ *
+ * Set to 1 to invert the channel.
+ *
+ * @min 0
+ * @max 1
+ * @group PWM Outputs
+ */
+PARAM_DEFINE_INT32(PWM_AUX_SCALE3, 1);
+
+/**
+ * Inverter for main output channel 4
+ *
+ * Set to 1 to invert the channel.
+ *
+ * @min 0
+ * @max 1
+ * @group PWM Outputs
+ */
+PARAM_DEFINE_INT32(PWM_AUX_SCALE4, 1);
+
+/**
+ * Inverter for main output channel 5
+ *
+ * Set to 1 to invert the channel.
+ *
+ * @min 0
+ * @max 1
+ * @group PWM Outputs
+ */
+PARAM_DEFINE_INT32(PWM_AUX_SCALE5, 1);
+
+/**
+ * Inverter for main output channel 6
+ *
+ * Set to 1 to invert the channel.
+ *
+ * @min 0
+ * @max 1
+ * @group PWM Outputs
+ */
+PARAM_DEFINE_INT32(PWM_AUX_SCALE6, 1);

--- a/src/drivers/px4fmu/px4fmu_params.c
+++ b/src/drivers/px4fmu/px4fmu_params.c
@@ -51,7 +51,7 @@
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_AUX_REV1, 1);
+PARAM_DEFINE_INT32(PWM_AUX_REV1, 0);
 
 /**
  * Inverter for main output channel 2
@@ -62,7 +62,7 @@ PARAM_DEFINE_INT32(PWM_AUX_REV1, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_AUX_REV2, 1);
+PARAM_DEFINE_INT32(PWM_AUX_REV2, 0);
 
 /**
  * Inverter for main output channel 3
@@ -73,7 +73,7 @@ PARAM_DEFINE_INT32(PWM_AUX_REV2, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_AUX_REV3, 1);
+PARAM_DEFINE_INT32(PWM_AUX_REV3, 0);
 
 /**
  * Inverter for main output channel 4
@@ -84,7 +84,7 @@ PARAM_DEFINE_INT32(PWM_AUX_REV3, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_AUX_REV4, 1);
+PARAM_DEFINE_INT32(PWM_AUX_REV4, 0);
 
 /**
  * Inverter for main output channel 5
@@ -95,7 +95,7 @@ PARAM_DEFINE_INT32(PWM_AUX_REV4, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_AUX_REV5, 1);
+PARAM_DEFINE_INT32(PWM_AUX_REV5, 0);
 
 /**
  * Inverter for main output channel 6
@@ -106,4 +106,4 @@ PARAM_DEFINE_INT32(PWM_AUX_REV5, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_AUX_REV6, 1);
+PARAM_DEFINE_INT32(PWM_AUX_REV6, 0);

--- a/src/drivers/px4fmu/px4fmu_params.c
+++ b/src/drivers/px4fmu/px4fmu_params.c
@@ -43,9 +43,9 @@
 #include <systemlib/param/param.h>
 
 /**
- * Inverter for main output channel 1
+ * Invert direction of aux output channel 1
  *
- * Set to 1 to invert the channel.
+ * Set to 1 to invert the channel, 0 for default direction.
  *
  * @min 0
  * @max 1
@@ -54,9 +54,9 @@
 PARAM_DEFINE_INT32(PWM_AUX_REV1, 0);
 
 /**
- * Inverter for main output channel 2
+ * Invert direction of aux output channel 2
  *
- * Set to 1 to invert the channel.
+ * Set to 1 to invert the channel, 0 for default direction.
  *
  * @min 0
  * @max 1
@@ -65,9 +65,9 @@ PARAM_DEFINE_INT32(PWM_AUX_REV1, 0);
 PARAM_DEFINE_INT32(PWM_AUX_REV2, 0);
 
 /**
- * Inverter for main output channel 3
+ * Invert direction of aux output channel 3
  *
- * Set to 1 to invert the channel.
+ * Set to 1 to invert the channel, 0 for default direction.
  *
  * @min 0
  * @max 1
@@ -76,9 +76,9 @@ PARAM_DEFINE_INT32(PWM_AUX_REV2, 0);
 PARAM_DEFINE_INT32(PWM_AUX_REV3, 0);
 
 /**
- * Inverter for main output channel 4
+ * Invert direction of aux output channel 4
  *
- * Set to 1 to invert the channel.
+ * Set to 1 to invert the channel, 0 for default direction.
  *
  * @min 0
  * @max 1
@@ -87,9 +87,9 @@ PARAM_DEFINE_INT32(PWM_AUX_REV3, 0);
 PARAM_DEFINE_INT32(PWM_AUX_REV4, 0);
 
 /**
- * Inverter for main output channel 5
+ * Invert direction of aux output channel 5
  *
- * Set to 1 to invert the channel.
+ * Set to 1 to invert the channel, 0 for default direction.
  *
  * @min 0
  * @max 1
@@ -98,9 +98,9 @@ PARAM_DEFINE_INT32(PWM_AUX_REV4, 0);
 PARAM_DEFINE_INT32(PWM_AUX_REV5, 0);
 
 /**
- * Inverter for main output channel 6
+ * Invert direction of aux output channel 6
  *
- * Set to 1 to invert the channel.
+ * Set to 1 to invert the channel, 0 for default direction.
  *
  * @min 0
  * @max 1

--- a/src/drivers/px4io/module.mk
+++ b/src/drivers/px4io/module.mk
@@ -40,7 +40,8 @@ MODULE_COMMAND		= px4io
 SRCS			= px4io.cpp \
 			  px4io_uploader.cpp \
 			  px4io_serial.cpp \
-			  px4io_i2c.cpp
+			  px4io_i2c.cpp \
+			  px4io_params.c
 
 # XXX prune to just get UART registers
 INCLUDE_DIRS    += $(NUTTX_SRC)/arch/arm/src/stm32 $(NUTTX_SRC)/arch/arm/src/common

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -281,6 +281,7 @@ private:
 	int			_t_actuator_armed;	///< system armed control topic
 	int 			_t_vehicle_control_mode;///< vehicle control mode topic
 	int			_t_param;		///< parameter update topic
+	bool			_param_update_force;	///< force a parameter update
 	int			_t_vehicle_command;	///< vehicle command topic
 
 	/* advertised topics */
@@ -514,6 +515,7 @@ PX4IO::PX4IO(device::Device *interface) :
 	_t_actuator_armed(-1),
 	_t_vehicle_control_mode(-1),
 	_t_param(-1),
+	_param_update_force(false),
 	_t_vehicle_command(-1),
 	_to_input_rc(0),
 	_to_outputs(0),
@@ -917,6 +919,8 @@ PX4IO::task_main()
 	fds[0].fd = _t_actuator_controls_0;
 	fds[0].events = POLLIN;
 
+	_param_update_force = true;
+
 	/* lock against the ioctl handler */
 	lock();
 
@@ -1017,7 +1021,8 @@ PX4IO::task_main()
 			 */
 			orb_check(_t_param, &updated);
 
-			if (updated) {
+			if (updated || _param_update_force) {
+				_param_update_force = false;
 				parameter_update_s pupdate;
 				orb_copy(ORB_ID(parameter_update), _t_param, &pupdate);
 

--- a/src/drivers/px4io/px4io_params.c
+++ b/src/drivers/px4io/px4io_params.c
@@ -1,0 +1,131 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file px4io_params.c
+ *
+ * Parameters defined by the PX4IO driver
+ *
+ * @author Lorenz Meier <lorenz@px4.io>
+ */
+
+#include <nuttx/config.h>
+#include <systemlib/param/param.h>
+
+/**
+ * Pre-scaler / Inverter for main output channel 1
+ *
+ * Set to 1 to invert the channel.
+ *
+ * @min 0
+ * @max 1
+ * @group PWM Outputs
+ */
+PARAM_DEFINE_INT32(PWM_MAIN_SCALE1, 1);
+
+/**
+ * Pre-scaler / Inverter for main output channel 2
+ *
+ * Set to 1 to invert the channel.
+ *
+ * @min 0
+ * @max 1
+ * @group PWM Outputs
+ */
+PARAM_DEFINE_INT32(PWM_MAIN_SCALE2, 1);
+
+/**
+ * Pre-scaler / Inverter for main output channel 3
+ *
+ * Set to 1 to invert the channel.
+ *
+ * @min 0
+ * @max 1
+ * @group PWM Outputs
+ */
+PARAM_DEFINE_INT32(PWM_MAIN_SCALE3, 1);
+
+/**
+ * Pre-scaler / Inverter for main output channel 4
+ *
+ * Set to 1 to invert the channel.
+ *
+ * @min 0
+ * @max 1
+ * @group PWM Outputs
+ */
+PARAM_DEFINE_INT32(PWM_MAIN_SCALE4, 1);
+
+/**
+ * Pre-scaler / Inverter for main output channel 5
+ *
+ * Set to 1 to invert the channel.
+ *
+ * @min 0
+ * @max 1
+ * @group PWM Outputs
+ */
+PARAM_DEFINE_INT32(PWM_MAIN_SCALE5, 1);
+
+/**
+ * Pre-scaler / Inverter for main output channel 6
+ *
+ * Set to 1 to invert the channel.
+ *
+ * @min 0
+ * @max 1
+ * @group PWM Outputs
+ */
+PARAM_DEFINE_INT32(PWM_MAIN_SCALE6, 1);
+
+/**
+ * Pre-scaler / Inverter for main output channel 7
+ *
+ * Set to 1 to invert the channel.
+ *
+ * @min 0
+ * @max 1
+ * @group PWM Outputs
+ */
+PARAM_DEFINE_INT32(PWM_MAIN_SCALE7, 1);
+
+/**
+ * Pre-scaler / Inverter for main output channel 8
+ *
+ * Set to 1 to invert the channel.
+ *
+ * @min 0
+ * @max 1
+ * @group PWM Outputs
+ */
+PARAM_DEFINE_INT32(PWM_MAIN_SCALE8, 1);

--- a/src/drivers/px4io/px4io_params.c
+++ b/src/drivers/px4io/px4io_params.c
@@ -51,7 +51,7 @@
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_MAIN_SCALE1, 1);
+PARAM_DEFINE_INT32(PWM_MAIN_REV1, 1);
 
 /**
  * Pre-scaler / Inverter for main output channel 2
@@ -62,7 +62,7 @@ PARAM_DEFINE_INT32(PWM_MAIN_SCALE1, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_MAIN_SCALE2, 1);
+PARAM_DEFINE_INT32(PWM_MAIN_REV2, 1);
 
 /**
  * Pre-scaler / Inverter for main output channel 3
@@ -73,7 +73,7 @@ PARAM_DEFINE_INT32(PWM_MAIN_SCALE2, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_MAIN_SCALE3, 1);
+PARAM_DEFINE_INT32(PWM_MAIN_REV3, 1);
 
 /**
  * Pre-scaler / Inverter for main output channel 4
@@ -84,7 +84,7 @@ PARAM_DEFINE_INT32(PWM_MAIN_SCALE3, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_MAIN_SCALE4, 1);
+PARAM_DEFINE_INT32(PWM_MAIN_REV4, 1);
 
 /**
  * Pre-scaler / Inverter for main output channel 5
@@ -95,7 +95,7 @@ PARAM_DEFINE_INT32(PWM_MAIN_SCALE4, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_MAIN_SCALE5, 1);
+PARAM_DEFINE_INT32(PWM_MAIN_REV5, 1);
 
 /**
  * Pre-scaler / Inverter for main output channel 6
@@ -106,7 +106,7 @@ PARAM_DEFINE_INT32(PWM_MAIN_SCALE5, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_MAIN_SCALE6, 1);
+PARAM_DEFINE_INT32(PWM_MAIN_REV6, 1);
 
 /**
  * Pre-scaler / Inverter for main output channel 7
@@ -117,7 +117,7 @@ PARAM_DEFINE_INT32(PWM_MAIN_SCALE6, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_MAIN_SCALE7, 1);
+PARAM_DEFINE_INT32(PWM_MAIN_REV7, 1);
 
 /**
  * Pre-scaler / Inverter for main output channel 8
@@ -128,4 +128,4 @@ PARAM_DEFINE_INT32(PWM_MAIN_SCALE7, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_MAIN_SCALE8, 1);
+PARAM_DEFINE_INT32(PWM_MAIN_REV8, 1);

--- a/src/drivers/px4io/px4io_params.c
+++ b/src/drivers/px4io/px4io_params.c
@@ -51,7 +51,7 @@
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_MAIN_REV1, 1);
+PARAM_DEFINE_INT32(PWM_MAIN_REV1, 0);
 
 /**
  * Pre-scaler / Inverter for main output channel 2
@@ -62,7 +62,7 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV1, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_MAIN_REV2, 1);
+PARAM_DEFINE_INT32(PWM_MAIN_REV2, 0);
 
 /**
  * Pre-scaler / Inverter for main output channel 3
@@ -73,7 +73,7 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV2, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_MAIN_REV3, 1);
+PARAM_DEFINE_INT32(PWM_MAIN_REV3, 0);
 
 /**
  * Pre-scaler / Inverter for main output channel 4
@@ -84,7 +84,7 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV3, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_MAIN_REV4, 1);
+PARAM_DEFINE_INT32(PWM_MAIN_REV4, 0);
 
 /**
  * Pre-scaler / Inverter for main output channel 5
@@ -95,7 +95,7 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV4, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_MAIN_REV5, 1);
+PARAM_DEFINE_INT32(PWM_MAIN_REV5, 0);
 
 /**
  * Pre-scaler / Inverter for main output channel 6
@@ -106,7 +106,7 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV5, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_MAIN_REV6, 1);
+PARAM_DEFINE_INT32(PWM_MAIN_REV6, 0);
 
 /**
  * Pre-scaler / Inverter for main output channel 7
@@ -117,7 +117,7 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV6, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_MAIN_REV7, 1);
+PARAM_DEFINE_INT32(PWM_MAIN_REV7, 0);
 
 /**
  * Pre-scaler / Inverter for main output channel 8
@@ -128,4 +128,4 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV7, 1);
  * @max 1
  * @group PWM Outputs
  */
-PARAM_DEFINE_INT32(PWM_MAIN_REV8, 1);
+PARAM_DEFINE_INT32(PWM_MAIN_REV8, 0);

--- a/src/drivers/px4io/px4io_params.c
+++ b/src/drivers/px4io/px4io_params.c
@@ -43,9 +43,9 @@
 #include <systemlib/param/param.h>
 
 /**
- * Pre-scaler / Inverter for main output channel 1
+ * Invert direction of main output channel 1
  *
- * Set to 1 to invert the channel.
+ * Set to 1 to invert the channel, 0 for default direction.
  *
  * @min 0
  * @max 1
@@ -54,9 +54,9 @@
 PARAM_DEFINE_INT32(PWM_MAIN_REV1, 0);
 
 /**
- * Pre-scaler / Inverter for main output channel 2
+ * Invert direction of main output channel 2
  *
- * Set to 1 to invert the channel.
+ * Set to 1 to invert the channel, 0 for default direction.
  *
  * @min 0
  * @max 1
@@ -65,9 +65,9 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV1, 0);
 PARAM_DEFINE_INT32(PWM_MAIN_REV2, 0);
 
 /**
- * Pre-scaler / Inverter for main output channel 3
+ * Invert direction of main output channel 3
  *
- * Set to 1 to invert the channel.
+ * Set to 1 to invert the channel, 0 for default direction.
  *
  * @min 0
  * @max 1
@@ -76,9 +76,9 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV2, 0);
 PARAM_DEFINE_INT32(PWM_MAIN_REV3, 0);
 
 /**
- * Pre-scaler / Inverter for main output channel 4
+ * Invert direction of main output channel 4
  *
- * Set to 1 to invert the channel.
+ * Set to 1 to invert the channel, 0 for default direction.
  *
  * @min 0
  * @max 1
@@ -87,9 +87,9 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV3, 0);
 PARAM_DEFINE_INT32(PWM_MAIN_REV4, 0);
 
 /**
- * Pre-scaler / Inverter for main output channel 5
+ * Invert direction of main output channel 5
  *
- * Set to 1 to invert the channel.
+ * Set to 1 to invert the channel, 0 for default direction.
  *
  * @min 0
  * @max 1
@@ -98,9 +98,9 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV4, 0);
 PARAM_DEFINE_INT32(PWM_MAIN_REV5, 0);
 
 /**
- * Pre-scaler / Inverter for main output channel 6
+ * Invert direction of main output channel 6
  *
- * Set to 1 to invert the channel.
+ * Set to 1 to invert the channel, 0 for default direction.
  *
  * @min 0
  * @max 1
@@ -109,9 +109,9 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV5, 0);
 PARAM_DEFINE_INT32(PWM_MAIN_REV6, 0);
 
 /**
- * Pre-scaler / Inverter for main output channel 7
+ * Invert direction of main output channel 7
  *
- * Set to 1 to invert the channel.
+ * Set to 1 to invert the channel, 0 for default direction.
  *
  * @min 0
  * @max 1
@@ -120,9 +120,9 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV6, 0);
 PARAM_DEFINE_INT32(PWM_MAIN_REV7, 0);
 
 /**
- * Pre-scaler / Inverter for main output channel 8
+ * Invert direction of main output channel 8
  *
- * Set to 1 to invert the channel.
+ * Set to 1 to invert the channel, 0 for default direction.
  *
  * @min 0
  * @max 1

--- a/src/modules/px4iofirmware/mixer.cpp
+++ b/src/modules/px4iofirmware/mixer.cpp
@@ -234,7 +234,7 @@ mixer_tick(void)
 		in_mixer = false;
 
 		/* the pwm limit call takes care of out of band errors */
-		pwm_limit_calc(should_arm, mixed, r_page_servo_disarmed, r_page_servo_control_min, r_page_servo_control_max, outputs, r_page_servos, &pwm_limit);
+		pwm_limit_calc(should_arm, mixed, r_setup_pwm_reverse, r_page_servo_disarmed, r_page_servo_control_min, r_page_servo_control_max, outputs, r_page_servos, &pwm_limit);
 
 		for (unsigned i = mixed; i < PX4IO_SERVO_COUNT; i++)
 			r_page_servos[i] = 0;
@@ -272,8 +272,9 @@ mixer_tick(void)
 
 	if (mixer_servos_armed && should_arm) {
 		/* update the servo outputs. */
-		for (unsigned i = 0; i < PX4IO_SERVO_COUNT; i++)
+		for (unsigned i = 0; i < PX4IO_SERVO_COUNT; i++) {
 			up_pwm_servo_set(i, r_page_servos[i]);
+		}
 
 		/* set S.BUS1 or S.BUS2 outputs */
 

--- a/src/modules/px4iofirmware/protocol.h
+++ b/src/modules/px4iofirmware/protocol.h
@@ -233,6 +233,8 @@ enum {							/* DSM bind states */
 #define PX4IO_P_SETUP_FORCE_SAFETY_ON		14	/* force safety switch into 'disarmed' (PWM disabled state) */
 #define PX4IO_FORCE_SAFETY_MAGIC		22027	/* required argument for force safety (random) */
 
+#define PX4IO_P_SETUP_PWM_REVERSE		15	/**< Bitmask to reverse PWM channels 1-8 */
+
 /* autopilot control values, -10000..10000 */
 #define PX4IO_PAGE_CONTROLS			51	/**< actuator control groups, one after the other, 8 wide */
 #define PX4IO_P_CONTROLS_GROUP_0		(PX4IO_PROTOCOL_MAX_CONTROL_COUNT * 0)	/**< 0..PX4IO_PROTOCOL_MAX_CONTROL_COUNT - 1 */

--- a/src/modules/px4iofirmware/px4io.h
+++ b/src/modules/px4iofirmware/px4io.h
@@ -111,6 +111,8 @@ extern uint16_t			r_page_servo_disarmed[];	/* PX4IO_PAGE_DISARMED_PWM */
 #endif
 #define r_setup_rc_thr_failsafe	r_page_setup[PX4IO_P_SETUP_RC_THR_FAILSAFE_US]
 
+#define r_setup_pwm_reverse	r_page_setup[PX4IO_P_SETUP_PWM_REVERSE]
+
 #define r_control_values	(&r_page_controls[0])
 
 /*

--- a/src/modules/px4iofirmware/registers.c
+++ b/src/modules/px4iofirmware/registers.c
@@ -173,6 +173,7 @@ volatile uint16_t	r_page_setup[] =
 	[PX4IO_P_SETUP_REBOOT_BL]		= 0,
 	[PX4IO_P_SETUP_CRC ... (PX4IO_P_SETUP_CRC+1)] = 0,
 	[PX4IO_P_SETUP_RC_THR_FAILSAFE_US] = 0,
+	[PX4IO_P_SETUP_PWM_REVERSE] = 0,
 };
 
 #ifdef CONFIG_ARCH_BOARD_PX4IO_V2
@@ -620,6 +621,10 @@ registers_set_one(uint8_t page, uint8_t offset, uint16_t value)
 			if (value > 650 && value < 2350) {
 				r_page_setup[PX4IO_P_SETUP_RC_THR_FAILSAFE_US] = value;
 			}
+			break;
+
+		case PX4IO_P_SETUP_PWM_REVERSE:
+			r_page_setup[PX4IO_P_SETUP_PWM_REVERSE] = value;
 			break;
 
 		default:

--- a/src/modules/systemlib/pwm_limit/pwm_limit.c
+++ b/src/modules/systemlib/pwm_limit/pwm_limit.c
@@ -53,7 +53,9 @@ void pwm_limit_init(pwm_limit_t *limit)
 	return;
 }
 
-void pwm_limit_calc(const bool armed, const unsigned num_channels, const uint16_t *disarmed_pwm, const uint16_t *min_pwm, const uint16_t *max_pwm, const float *output, uint16_t *effective_pwm, pwm_limit_t *limit)
+void pwm_limit_calc(const bool armed, const unsigned num_channels, const uint16_t reverse_mask,
+	const uint16_t *disarmed_pwm, const uint16_t *min_pwm, const uint16_t *max_pwm,
+	const float *output, uint16_t *effective_pwm, pwm_limit_t *limit)
 {
 
 	/* first evaluate state changes */
@@ -134,7 +136,13 @@ void pwm_limit_calc(const bool armed, const unsigned num_channels, const uint16_
 						ramp_min_pwm = min_pwm[i];
 					}
 
-					effective_pwm[i] = output[i] * (max_pwm[i] - ramp_min_pwm)/2 + (max_pwm[i] + ramp_min_pwm)/2;
+					float control_value = output[i];
+
+					if (reverse_mask & (1 << i)) {
+						control_value = -1.0f * control_value;
+					}
+
+					effective_pwm[i] = control_value * (max_pwm[i] - ramp_min_pwm)/2 + (max_pwm[i] + ramp_min_pwm)/2;
 
 					/* last line of defense against invalid inputs */
 					if (effective_pwm[i] < ramp_min_pwm) {
@@ -147,7 +155,14 @@ void pwm_limit_calc(const bool armed, const unsigned num_channels, const uint16_
 			break;
 		case PWM_LIMIT_STATE_ON:
 			for (unsigned i=0; i<num_channels; i++) {
-				effective_pwm[i] = output[i] * (max_pwm[i] - min_pwm[i])/2 + (max_pwm[i] + min_pwm[i])/2;
+
+				float control_value = output[i];
+
+				if (reverse_mask & (1 << i)) {
+					control_value = -1.0f * control_value;
+				}
+
+				effective_pwm[i] = control_value * (max_pwm[i] - min_pwm[i])/2 + (max_pwm[i] + min_pwm[i])/2;
 
 				/* last line of defense against invalid inputs */
 				if (effective_pwm[i] < min_pwm[i]) {

--- a/src/modules/systemlib/pwm_limit/pwm_limit.h
+++ b/src/modules/systemlib/pwm_limit/pwm_limit.h
@@ -72,7 +72,7 @@ typedef struct {
 
 __EXPORT void pwm_limit_init(pwm_limit_t *limit);
 
-__EXPORT void pwm_limit_calc(const bool armed, const unsigned num_channels, const uint16_t *disarmed_pwm,
+__EXPORT void pwm_limit_calc(const bool armed, const unsigned num_channels, const uint16_t reverse_mask, const uint16_t *disarmed_pwm,
 			     const uint16_t *min_pwm, const uint16_t *max_pwm, const float *output, uint16_t *effective_pwm, pwm_limit_t *limit);
 
 __END_DECLS

--- a/src/systemcmds/tests/test_mixer.cpp
+++ b/src/systemcmds/tests/test_mixer.cpp
@@ -78,6 +78,7 @@ int test_mixer(int argc, char *argv[])
 	uint16_t r_page_servo_control_max[output_max];
 	uint16_t r_page_servos[output_max];
 	uint16_t servo_predicted[output_max];
+	int16_t reverse_pwm_mask = 0;
 
 	warnx("testing mixer");
 
@@ -204,8 +205,8 @@ int test_mixer(int argc, char *argv[])
 		/* mix */
 		mixed = mixer_group.mix(&outputs[0], output_max, NULL);
 
-		pwm_limit_calc(should_arm, mixed, r_page_servo_disarmed, r_page_servo_control_min, r_page_servo_control_max, outputs,
-			       r_page_servos, &pwm_limit);
+		pwm_limit_calc(should_arm, mixed, reverse_pwm_mask, r_page_servo_disarmed, r_page_servo_control_min,
+			r_page_servo_control_max, outputs, r_page_servos, &pwm_limit);
 
 		//warnx("mixed %d outputs (max %d), values:", mixed, output_max);
 		for (unsigned i = 0; i < mixed; i++) {
@@ -250,7 +251,7 @@ int test_mixer(int argc, char *argv[])
 		/* mix */
 		mixed = mixer_group.mix(&outputs[0], output_max, NULL);
 
-		pwm_limit_calc(should_arm, mixed, r_page_servo_disarmed, r_page_servo_control_min, r_page_servo_control_max, outputs,
+		pwm_limit_calc(should_arm, mixed, reverse_pwm_mask, r_page_servo_disarmed, r_page_servo_control_min, r_page_servo_control_max, outputs,
 			       r_page_servos, &pwm_limit);
 
 		warnx("mixed %d outputs (max %d)", mixed, output_max);
@@ -277,7 +278,7 @@ int test_mixer(int argc, char *argv[])
 		/* mix */
 		mixed = mixer_group.mix(&outputs[0], output_max, NULL);
 
-		pwm_limit_calc(should_arm, mixed, r_page_servo_disarmed, r_page_servo_control_min, r_page_servo_control_max, outputs,
+		pwm_limit_calc(should_arm, mixed, reverse_pwm_mask, r_page_servo_disarmed, r_page_servo_control_min, r_page_servo_control_max, outputs,
 			       r_page_servos, &pwm_limit);
 
 		//warnx("mixed %d outputs (max %d), values:", mixed, output_max);
@@ -313,7 +314,7 @@ int test_mixer(int argc, char *argv[])
 		/* mix */
 		mixed = mixer_group.mix(&outputs[0], output_max, NULL);
 
-		pwm_limit_calc(should_arm, mixed, r_page_servo_disarmed, r_page_servo_control_min, r_page_servo_control_max, outputs,
+		pwm_limit_calc(should_arm, mixed, reverse_pwm_mask, r_page_servo_disarmed, r_page_servo_control_min, r_page_servo_control_max, outputs,
 			       r_page_servos, &pwm_limit);
 
 		//warnx("mixed %d outputs (max %d), values:", mixed, output_max);


### PR DESCRIPTION
This branch allows to invert the PWM channels individually on a per-driver level. Helpful to deal with the non-standard CW / CCW rotation directions servo manufacturers chose randomly.