### PR TITLE
Tools: don't try to generate messages for hidden files starting with a dot.

### DIFF
--- a/Tools/px_generate_uorb_topic_headers.py
+++ b/Tools/px_generate_uorb_topic_headers.py
@@ -54,7 +54,7 @@ On a Debian/Ubuntu system please run:
 
   sudo apt-get install python-empy
   sudo pip install catkin_pkg
-  
+
 On MacOS please run:
   sudo pip install empy catkin_pkg
 
@@ -95,13 +95,19 @@ def convert_dir(inputdir, outputdir, templatedir):
         """
         includepath = incl_default + [':'.join([package, inputdir])]
         for f in os.listdir(inputdir):
+                # Ignore hidden files
+                if f.startswith("."):
+                        continue
+
                 fn = os.path.join(inputdir, f)
-                if os.path.isfile(fn):
-                        convert_file(
-                            fn,
-                            outputdir,
-                            templatedir,
-                            includepath)
+                # Only look at actual files
+                if not os.path.isfile(fn):
+                        continue
+
+                convert_file(fn,
+                             outputdir,
+                             templatedir,
+                             includepath)
 
 
 def copy_changed(inputdir, outputdir, prefix=''):


### PR DESCRIPTION
My editor made backup files in the directory starting with ```.```.
With this fix, they are ignored.