### PR TITLE
systemcmds: the mixer shuts up now

### DIFF
--- a/src/systemcmds/mixer/mixer.cpp
+++ b/src/systemcmds/mixer/mixer.cpp
@@ -80,8 +80,10 @@ mixer_main(int argc, char *argv[])
 			warnx("failed to load mixer");
 			return 1;
 		}
+	} else {
+		usage("Unknown command");
+		return 1;
 	}
-	usage("Unknown command");
 	return 0;
 }
 


### PR DESCRIPTION
The mixer kept complaining:
```
[px4io] mixer sent
Unknown command
usage:
  mixer load <device> <filename>
[i] Mixer: /etc/mixers/quad_w.main.mix on /dev/pwm_output0
```

Fixed:
```
[px4io] mixer sent
[i] Mixer: /etc/mixers/quad_w.main.mix on /dev/pwm_output0 
```