### PR TITLE
POSIX: Increased number of devmap entries

### DIFF
--- a/src/drivers/device/vdev.cpp
+++ b/src/drivers/device/vdev.cpp
@@ -64,7 +64,7 @@ private:
 	px4_dev_t() {}
 };
 
-#define PX4_MAX_DEV 50
+#define PX4_MAX_DEV 100
 static px4_dev_t *devmap[PX4_MAX_DEV];
 
 /*


### PR DESCRIPTION
The orb_advertise and/or orb_publish calls were failing because
there were not enough devmap entries allocated for all the orb
topics advertised.

The number of entries was increased from 50 to 100.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>