### PR TITLE
git_version.* not removed on clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ endif
 GIT_DESC_SHORT := $(shell echo $(GIT_DESC) | cut -c1-16)
 
 $(shell mkdir -p $(BUILD_DIR))
+$(shell rm -f $(BUILD_DIR)git_version.*)
 $(shell echo "#include <systemlib/git_version.h>" > $(BUILD_DIR)git_version.c)
 $(shell echo "const char* px4_git_version = \"$(GIT_DESC)\";" >> $(BUILD_DIR)git_version.c)
 $(shell echo "const uint64_t px4_git_version_binary = 0x$(GIT_DESC_SHORT);" >> $(BUILD_DIR)git_version.c)

--- a/Makefile
+++ b/Makefile
@@ -317,6 +317,7 @@ check_format:
 clean:
 	@echo > /dev/null
 	$(Q) $(RMDIR) $(BUILD_DIR)*.build
+	$(Q) $(REMOVE) $(BUILD_DIR)git_version.*
 	$(Q) $(REMOVE) $(IMAGE_DIR)*.px4
 
 .PHONY:	distclean

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1009,7 +1009,7 @@ PX4IO::task_main()
 				orb_copy(ORB_ID(vehicle_command), _t_vehicle_command, &cmd);
 
 				// Check for a DSM pairing command
-				if (((int)cmd.command == vehicle_command_s::VEHICLE_CMD_START_RX_PAIR) && ((int)cmd.param1 == 0)) {
+				if (((unsigned int)cmd.command == vehicle_command_s::VEHICLE_CMD_START_RX_PAIR) && ((int)cmd.param1 == 0)) {
 					dsm_bind_ioctl((int)cmd.param2);
 				}
 			}


### PR DESCRIPTION
The Build/git_version.* files need to be removed on make clean.

If the files are not removed, they create problems for header dependencies that may not exist. Specifically, trying make posix after having previously built for NuttX failed because it could not find stdint.h in the nuttx-exports subdir tree and the dependency existed in git_version.c.d

Signed-off-by: Mark Charlebois <charlebm@gmail.com>