### PR TITLE
Gyrosim: Fixed constant looping

### DIFF
--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -63,9 +63,6 @@ Simulator *Simulator::getInstance()
 
 bool Simulator::getMPUReport(uint8_t *buf, int len)
 {
-	// Reads are paced from reading gyrosim and if
-	// we don't delay here we read too fast
-	usleep(50000);
 	return _mpu.copyData(buf, len);
 }
 


### PR DESCRIPTION
Gyrosim would call measure continuously because the write_checked_reg
was failing. There is no need to check faked reg writes in the
simulator so that code was removed.

The delay that was added to the simulator to pace the gyrosim reads
was also removed now that the source of the problem was determined.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>