### PR TITLE
major simulator update

### DIFF
--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -63,9 +63,6 @@ Simulator *Simulator::getInstance()
 
 bool Simulator::getMPUReport(uint8_t *buf, int len)
 {
-	// Reads are paced from reading gyrosim and if
-	// we don't delay here we read too fast
-	usleep(50000);
 	return _mpu.copyData(buf, len);
 }
 
@@ -74,9 +71,29 @@ bool Simulator::getRawAccelReport(uint8_t *buf, int len)
 	return _accel.copyData(buf, len);
 }
 
+bool Simulator::getMagReport(uint8_t *buf, int len) {
+	return _mag.copyData(buf, len);
+}
+
 bool Simulator::getBaroSample(uint8_t *buf, int len)
 {
 	return _baro.copyData(buf, len);
+}
+
+void Simulator::write_MPU_data(void *buf) {
+	_mpu.writeData(buf);
+}
+
+void Simulator::write_accel_data(void *buf) {
+	_accel.writeData(buf);
+}
+
+void Simulator::write_mag_data(void *buf) {
+	_mag.writeData(buf);
+}
+
+void Simulator::write_baro_data(void *buf) {
+	_baro.writeData(buf);
 }
 
 int Simulator::start(int argc, char *argv[])


### PR DESCRIPTION
- do not publish sensor combined directly anymore
- copy sensor data to memory so sensor drivers can read
- removed gyro sleeping interval on reading because driver should have timing
- removed publishing of sensor topics in simulator which was used before
to keep the attitude estimator happy