### PR TITLE
Fixes for gcc 4.8

### DIFF
--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -104,7 +104,7 @@ static void fill_manual_control_sp_msg(struct manual_control_setpoint_s *manual,
 	manual->z = man_msg->z / 1000.0f;
 }
 
-void fill_sensors_from_imu_msg(struct sensor_combined_s *sensor, mavlink_hil_sensor_t *imu) {
+static void fill_sensors_from_imu_msg(struct sensor_combined_s *sensor, mavlink_hil_sensor_t *imu) {
 	hrt_abstime timestamp = hrt_absolute_time();
 	sensor->timestamp = timestamp;
 	sensor->gyro_raw[0] = imu->xgyro * 1000.0f;

--- a/src/platforms/posix/px4_layer/px4_posix_tasks.cpp
+++ b/src/platforms/posix/px4_layer/px4_posix_tasks.cpp
@@ -273,6 +273,7 @@ void px4_show_tasks()
 }
 
 __BEGIN_DECLS
+const char *getprogname();
 const char *getprogname()
 {
         pthread_t pid = pthread_self();


### PR DESCRIPTION
The use of a non-static function without a declaration generates a
warning for gcc 4.8.

Clang-3.4 does not work when compiling for gprof. The executable always
generates a segv.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>