### PR TITLE
px4_poll fix - was sleeping for usec instead of ms

### DIFF
--- a/src/drivers/device/vdev_posix.cpp
+++ b/src/drivers/device/vdev_posix.cpp
@@ -242,7 +242,7 @@ int px4_poll(px4_pollfd_struct_t *fds, nfds_t nfds, int timeout)
 			void *res;
 
 			ts.tv_sec = timeout/1000;
-			ts.tv_nsec = (timeout % 1000)*1000;
+			ts.tv_nsec = (timeout % 1000)*1000000;
 
 			// Create a timer to unblock
 			struct timerData td(sem, ts);


### PR DESCRIPTION
There was a conversion error in the timeout (in ms)
passed in and the ts.tv_nsec field of the struct timeval.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>