### PR TITLE
do not run fw attitude controller when in rotary wing mode (VTOL)

### DIFF
--- a/src/modules/fw_att_control/fw_att_control_main.cpp
+++ b/src/modules/fw_att_control/fw_att_control_main.cpp
@@ -796,6 +796,11 @@ FixedwingAttitudeControl::task_main()
 				//warnx("_actuators_airframe.control[1] = -1.0f;");
 			}
 
+			/* if we are in rotary wing mode, do nothing */
+			if (_vehicle_status.is_rotary_wing) {
+				continue;
+			}
+
 			/* decide if in stabilized or full manual control */
 
 			if (_vcontrol_mode.flag_control_attitude_enabled) {


### PR DESCRIPTION
The fw controller is disabled when the vehicle is in rotary wing mode.
This should fix the strange behaviour with the elevons which people have been seeing  when switching from mc to fw mode.