### PR TITLE
Created px4_access to handle check of virtual files

### DIFF
--- a/src/drivers/device/vdev_posix.cpp
+++ b/src/drivers/device/vdev_posix.cpp
@@ -293,6 +293,16 @@ int px4_fsync(int fd)
 	return 0;
 }
 
+int px4_access(const char *pathname, int mode)
+{
+	if (mode == F_OK) {
+		errno = EINVAL;
+		return -1;
+	}
+	VDev *dev = VDev::getDev(pathname);
+	return (dev != nullptr) ? 0 : -1;
+}
+
 void px4_show_devices()
 {
 	VDev::showDevices();

--- a/src/modules/uORB/uORBManager_posix.cpp
+++ b/src/modules/uORB/uORBManager_posix.cpp
@@ -32,15 +32,14 @@
  ****************************************************************************/
 
 #include <sys/types.h>
-#include <sys/stat.h>
 #include <stdarg.h>
-#include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <px4_config.h>
+#include <px4_posix.h>
 #include "uORBUtils.hpp"
 #include "uORBManager.hpp"
 #include "uORBDevices.hpp"
-#include "px4_config.h"
 
 
 //=========================  Static initializations =================
@@ -73,8 +72,7 @@ int uORB::Manager::orb_exists(const struct orb_metadata *meta, int instance)
     return ERROR;
   }
 
-  struct stat buffer;
-  return stat(path, &buffer);
+  return px4_access(path, F_OK);
 }
 
 orb_advert_t uORB::Manager::orb_advertise(const struct orb_metadata *meta, const void *data)

--- a/src/platforms/px4_posix.h
+++ b/src/platforms/px4_posix.h
@@ -67,6 +67,7 @@ typedef struct pollfd px4_pollfd_struct_t;
 #define px4_read 	_GLOBAL read
 #define px4_poll 	_GLOBAL poll
 #define px4_fsync 	_GLOBAL fsync
+#define px4_access 	_GLOBAL access
 
 #elif defined(__PX4_POSIX)
 
@@ -96,6 +97,7 @@ __EXPORT ssize_t	px4_write(int fd, const void *buffer, size_t buflen);
 __EXPORT int		px4_ioctl(int fd, int cmd, unsigned long arg);
 __EXPORT int		px4_poll(px4_pollfd_struct_t *fds, nfds_t nfds, int timeout);
 __EXPORT int		px4_fsync(int fd);
+__EXPORT int		px4_access(const char *pathname, int mode);
 
 __END_DECLS
 #else


### PR DESCRIPTION
uORBManager_posix.cpp did a stat to see if a file exists but the
file is actually a virtual file. Using stat was incorrect because
it required a stat buffer that was never used. The POSIX access
function is a better choice so I created a px4_access version to
handle virtual files.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>