### PR TITLE
remove long long from union param_value_u

### DIFF
--- a/src/modules/systemlib/param/param.h
+++ b/src/modules/systemlib/param/param.h
@@ -382,7 +382,6 @@ union param_value_u {
 	void		*p;
 	int32_t		i;
 	float		f;
-	long long	x;
 };
 
 /**


### PR DESCRIPTION
The long long was mistakenly added when debugging an alignment issue
on x86_64.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>