### PR TITLE
land detector: Improve performance for fixed wing setups

### DIFF
--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -84,11 +84,15 @@ bool FixedwingLandDetector::update()
 	const uint64_t now = hrt_absolute_time();
 	bool landDetected = false;
 
-	// TODO: reset filtered values on arming?
-	_velocity_xy_filtered = 0.95f * _velocity_xy_filtered + 0.05f * sqrtf(_vehicleLocalPosition.vx *
-				_vehicleLocalPosition.vx + _vehicleLocalPosition.vy * _vehicleLocalPosition.vy);
-	_velocity_z_filtered = 0.95f * _velocity_z_filtered + 0.05f * fabsf(_vehicleLocalPosition.vz);
-	_airspeed_filtered = 0.95f * _airspeed_filtered + 0.05f * _airspeed.true_airspeed_m_s;
+	if (hrt_elapsed_time(&_vehicleLocalPosition.timestamp) < 500 * 1000) {
+		_velocity_xy_filtered = 0.95f * _velocity_xy_filtered + 0.05f * sqrtf(_vehicleLocalPosition.vx *
+					_vehicleLocalPosition.vx + _vehicleLocalPosition.vy * _vehicleLocalPosition.vy);
+		_velocity_z_filtered = 0.95f * _velocity_z_filtered + 0.05f * fabsf(_vehicleLocalPosition.vz);
+	}
+
+	if (hrt_elapsed_time(&_airspeed.timestamp) < 500 * 1000) {
+		_airspeed_filtered = 0.95f * _airspeed_filtered + 0.05f * _airspeed.true_airspeed_m_s;
+	}
 
 	// crude land detector for fixedwing
 	if (_velocity_xy_filtered < _params.maxVelocity

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -87,7 +87,7 @@ protected:
 	virtual void initialize() = 0;
 
 	/**
-	* @brief Convinience function for polling uORB subscriptions
+	* @brief Convenience function for polling uORB subscriptions
 	* @return true if there was new data and it was successfully copied
 	**/
 	bool orb_update(const struct orb_metadata *meta, int handle, void *buffer);

--- a/src/modules/land_detector/land_detector_params.c
+++ b/src/modules/land_detector/land_detector_params.c
@@ -45,6 +45,8 @@
  *
  * Maximum vertical velocity allowed to trigger a land (m/s up and down)
  *
+ * @unit m/s
+ *
  * @group Land Detector
  */
 PARAM_DEFINE_FLOAT(LNDMC_Z_VEL_MAX, 0.30f);
@@ -53,6 +55,8 @@ PARAM_DEFINE_FLOAT(LNDMC_Z_VEL_MAX, 0.30f);
  * Multicopter max horizontal velocity
  *
  * Maximum horizontal velocity allowed to trigger a land (m/s)
+ *
+ * @unit m/s
  *
  * @group Land Detector
  */
@@ -63,6 +67,8 @@ PARAM_DEFINE_FLOAT(LNDMC_XY_VEL_MAX, 1.00f);
  *
  * Maximum allowed around each axis to trigger a land (degrees per second)
  *
+ * @unit deg/s
+ *
  * @group Land Detector
  */
 PARAM_DEFINE_FLOAT(LNDMC_ROT_MAX, 20.0f);
@@ -71,6 +77,9 @@ PARAM_DEFINE_FLOAT(LNDMC_ROT_MAX, 20.0f);
  * Multicopter max throttle
  *
  * Maximum actuator output on throttle before triggering a land
+ *
+ * @min 0.1
+ * @max 0.5
  *
  * @group Land Detector
  */
@@ -81,24 +90,36 @@ PARAM_DEFINE_FLOAT(LNDMC_THR_MAX, 0.20f);
  *
  * Maximum horizontal velocity allowed to trigger a land (m/s)
  *
+ * @min 0.5
+ * @max 10
+ * @unit m/s
+ *
  * @group Land Detector
  */
-PARAM_DEFINE_FLOAT(LNDFW_VEL_XY_MAX, 0.40f);
+PARAM_DEFINE_FLOAT(LNDFW_VEL_XY_MAX, 4.0f);
 
 /**
  * Fixedwing max climb rate
  *
  * Maximum vertical velocity allowed to trigger a land (m/s up and down)
  *
+ * @min 5
+ * @max 20
+ * @unit m/s
+ *
  * @group Land Detector
  */
-PARAM_DEFINE_FLOAT(LNDFW_VEL_Z_MAX, 10.00f);
+PARAM_DEFINE_FLOAT(LNDFW_VEL_Z_MAX, 10.0f);
 
 /**
  * Airspeed max
  *
  * Maximum airspeed allowed to trigger a land (m/s)
  *
+ * @min 4
+ * @max 20
+ * @unit m/s
+ *
  * @group Land Detector
  */
-PARAM_DEFINE_FLOAT(LNDFW_AIRSPD_MAX, 10.00f);
+PARAM_DEFINE_FLOAT(LNDFW_AIRSPD_MAX, 8.00f);


### PR DESCRIPTION
This prevents fixed wing setups from oscillating between in air and landet.