### PR TITLE
Correct the QU4D yaw gains to flyable values.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/10017_steadidrone_qu4d
+++ b/ROMFS/px4fmu_common/init.d/10017_steadidrone_qu4d
@@ -18,10 +18,11 @@ then
 	param set MC_PITCHRATE_P 0.13
 	param set MC_PITCHRATE_I 0.05
 	param set MC_PITCHRATE_D 0.004
-	param set MC_YAW_P 0.5
+	param set MC_YAW_P 2.8
 	param set MC_YAWRATE_P 0.2
-	param set MC_YAWRATE_I 0.0
+	param set MC_YAWRATE_I 0.1
 	param set MC_YAWRATE_D 0.0
+	param set MC_YAW_FF 0.5
 
 	param set BAT_N_CELLS 4
 fi


### PR DESCRIPTION
The current yaw gains are too low and control inputs are effectively rotated by 45 degrees (pitch forwards ends up commanding roll + pitch) making it unflyable.