### PR TITLE
Fixed wing POSCTL heading hold

### DIFF
--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
@@ -96,7 +96,7 @@
 static int	_control_task = -1;			/**< task handle for sensor task */
 #define HDG_HOLD_DIST_NEXT 			3000.0f 	// initial distance of waypoint in front of plane in heading hold mode
 #define HDG_HOLD_REACHED_DIST 		1000.0f 	// distance (plane to waypoint in front) at which waypoints are reset in heading hold mode
-#define HDG_HOLD_SET_BACK_DIST 		100.0f 		// distance by which previous waypoint is set behind the plane
+#define HDG_HOLD_SET_BACK_DIST 		3000.0f		// distance by which previous waypoint is set behind the plane
 #define HDG_HOLD_YAWRATE_THRESH 	0.1f 		// max yawrate at which plane locks yaw for heading hold mode
 #define HDG_HOLD_MAN_INPUT_THRESH 	0.01f 	// max manual roll input from user which does not change the locked heading
 


### PR DESCRIPTION
Opened this PR to report a flight test of modified heading hold code since:
This is my version of the deleted PX4/flight_mode branch which seemed to be working properly in HIL.

Test of heading hold on a Ninox today: no obvious problems observed.
![posctl_hh](https://cloud.githubusercontent.com/assets/2300221/8026568/1695248a-0d39-11e5-8058-7cc6ff3f5871.png)

Full log: http://dash.oznet.ch/view/zrrCoYP2rkxotUJE5HoPPV
Since both angle and rate tracking look horrible in this log, but the plane is flying well in both manual and stabilized modes (trimmed out pretty well, needed some right aileron and down elevator trim at the TX for manual mode), @LorenzMeier @sjwilks **I need advice on roll/pitch tuning**
 

