### PR TITLE
prevent use of PX4 param system in ArduPilot

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1038,8 +1038,10 @@ PX4IO::task_main()
 					param_set(dsm_bind_param, &dsm_bind_val);
 				}
 
-				/* re-upload RC input config as it may have changed */
-				io_set_rc_config();
+				if (!_rc_handling_disabled) {
+					/* re-upload RC input config as it may have changed */
+					io_set_rc_config();
+				}
 
 				/* re-set the battery scaling */
 				int32_t voltage_scaling_val;

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -675,9 +675,11 @@ PX4IO::init()
 	if (_max_rc_input > RC_INPUT_MAX_CHANNELS)
 		_max_rc_input = RC_INPUT_MAX_CHANNELS;
 
-	param_get(param_find("RC_RSSI_PWM_CHAN"), &_rssi_pwm_chan);
-	param_get(param_find("RC_RSSI_PWM_MAX"), &_rssi_pwm_max);
-	param_get(param_find("RC_RSSI_PWM_MIN"), &_rssi_pwm_min);
+	if (!_rc_handling_disabled) {
+		param_get(param_find("RC_RSSI_PWM_CHAN"), &_rssi_pwm_chan);
+		param_get(param_find("RC_RSSI_PWM_MAX"), &_rssi_pwm_max);
+		param_get(param_find("RC_RSSI_PWM_MIN"), &_rssi_pwm_min);
+	}
 
 	/*
 	 * Check for IO flight state - if FMU was flagged to be in
@@ -1026,7 +1028,7 @@ PX4IO::task_main()
 				parameter_update_s pupdate;
 				orb_copy(ORB_ID(parameter_update), _t_param, &pupdate);
 
-				int32_t dsm_bind_val;
+				int32_t dsm_bind_val = -1;
 				param_t dsm_bind_param;
 
 				/* see if bind parameter has been set, and reset it to -1 */
@@ -1044,7 +1046,7 @@ PX4IO::task_main()
 				}
 
 				/* re-set the battery scaling */
-				int32_t voltage_scaling_val;
+				int32_t voltage_scaling_val = 10000;
 				param_t voltage_scaling_param;
 
 				/* set battery voltage scaling */

--- a/src/modules/systemlib/circuit_breaker.cpp
+++ b/src/modules/systemlib/circuit_breaker.cpp
@@ -48,7 +48,7 @@
 
 bool circuit_breaker_enabled(const char *breaker, int32_t magic)
 {
-	int32_t val;
+	int32_t val = 0;
 	(void)PX4_PARAM_GET_BYNAME(breaker, &val);
 
 	return (val == magic);

--- a/src/modules/systemlib/module.mk
+++ b/src/modules/systemlib/module.mk
@@ -37,13 +37,11 @@
 
 SRCS		 = \
 		   perf_counter.c \
-		   param/param.c \
 		   conversions.c \
 		   cpuload.c \
 		   getopt_long.c \
 		   pid/pid.c \
 		   airspeed.c \
-		   system_params.c \
 		   mavlink_log.c \
 		   rc_check.c \
 		   otp.c \
@@ -52,8 +50,14 @@ SRCS		 = \
 		   mcu_version.c \
 		   bson/tinybson.c \
 		   circuit_breaker.cpp \
-		   circuit_breaker_params.c \
 		   $(BUILD_DIR)git_version.c
+
+ifneq ($(ARDUPILOT_BUILD),1)
+# ArduPilot uses its own parameter system
+SRCS		+= param/param.c \
+		   system_params.c \
+		   circuit_breaker_params.c
+endif
 
 ifeq ($(PX4_TARGET_OS),nuttx)
 SRCS		+= err.c \


### PR DESCRIPTION
This prevents the use of the PX4 parameter system in ArduPilot. ArduPilot now has its own stub functions for the px4 parameter system here:
https://github.com/diydrones/ardupilot/blob/master/libraries/AP_HAL_PX4/px4_param.cpp
this fixes an issue where servos would not operate correctly on helicopters, as the INIT_OK flag was not set by px4io
