### PR TITLE
Back Port of Git Versioning - without side effects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,12 +58,6 @@ endif
 
 GIT_DESC_SHORT := $(shell echo $(GIT_DESC) | cut -c1-16)
 
-$(shell mkdir -p $(BUILD_DIR))
-$(shell rm -f $(BUILD_DIR)git_version.*)
-$(shell echo "#include <systemlib/git_version.h>" > $(BUILD_DIR)git_version.c)
-$(shell echo "const char* px4_git_version = \"$(GIT_DESC)\";" >> $(BUILD_DIR)git_version.c)
-$(shell echo "const uint64_t px4_git_version_binary = 0x$(GIT_DESC_SHORT);" >> $(BUILD_DIR)git_version.c)
-
 #
 # Canned firmware configurations that we (know how to) build.
 #
@@ -139,7 +133,7 @@ $(STAGED_FIRMWARES): $(IMAGE_DIR)%.px4: $(BUILD_DIR)%.build/firmware.px4
 .PHONY: $(FIRMWARES)
 $(BUILD_DIR)%.build/firmware.px4: config   = $(patsubst $(BUILD_DIR)%.build/firmware.px4,%,$@)
 $(BUILD_DIR)%.build/firmware.px4: work_dir = $(BUILD_DIR)$(config).build/
-$(FIRMWARES): $(BUILD_DIR)%.build/firmware.px4:	generateuorbtopicheaders checksubmodules
+$(FIRMWARES): $(BUILD_DIR)%.build/firmware.px4:	checkgitversion generateuorbtopicheaders checksubmodules
 	@$(ECHO) %%%%
 	@$(ECHO) %%%% Building $(config) in $(work_dir)
 	@$(ECHO) %%%%
@@ -227,7 +221,7 @@ menuconfig:
 
 endif
 
-$(NUTTX_SRC): checksubmodules
+$(NUTTX_SRC): checkgitversion checksubmodules
 
 $(UAVCAN_DIR):
 	$(Q) (./Tools/check_submodules.sh)
@@ -248,6 +242,32 @@ ifeq ($(PX4_TARGET_OS),qurt)
 include $(PX4_BASE)makefiles/firmware_qurt.mk
 endif
 
+#
+# Versioning
+#
+
+GIT_VER_FILE = $(PX4_VERSIONING_DIR).build_git_ver
+GIT_HEADER_FILE = $(PX4_VERSIONING_DIR)build_git_version.h
+
+$(GIT_VER_FILE) :
+	$(Q) if [ ! -f $(GIT_VER_FILE) ]; then \
+		$(MKDIR) -p $(PX4_VERSIONING_DIR); \
+		$(ECHO) "" > $(GIT_VER_FILE); \
+	fi
+
+.PHONY: checkgitversion
+checkgitversion: $(GIT_VER_FILE)
+	$(Q) if [ "$(GIT_DESC)" != "$(shell cat $(GIT_VER_FILE))" ]; then \
+		$(ECHO) "/* Auto Magically Generated file */" > $(GIT_HEADER_FILE); \
+		$(ECHO) "/* Do not edit! */" >> $(GIT_HEADER_FILE); \
+		$(ECHO) "#define PX4_GIT_VERSION_STR  \"$(GIT_DESC)\"" >> $(GIT_HEADER_FILE); \
+		$(ECHO) "#define PX4_GIT_VERSION_BINARY 0x$(GIT_DESC_SHORT)" >> $(GIT_HEADER_FILE); \
+		$(ECHO) $(GIT_DESC) > $(GIT_VER_FILE); \
+	fi
+
+#
+# Submodule Checks
+#
 
 .PHONY: checksubmodules
 checksubmodules:
@@ -321,7 +341,7 @@ check_format:
 clean:
 	@echo > /dev/null
 	$(Q) $(RMDIR) $(BUILD_DIR)*.build
-	$(Q) $(REMOVE) $(BUILD_DIR)git_version.*
+	$(Q) $(RMDIR) $(PX4_VERSIONING_DIR)
 	$(Q) $(REMOVE) $(IMAGE_DIR)*.px4
 
 .PHONY:	distclean

--- a/makefiles/firmware_posix.mk
+++ b/makefiles/firmware_posix.mk
@@ -42,7 +42,7 @@ all: 	$(FIRMWARES)
 .PHONY: $(FIRMWARES)
 $(BUILD_DIR)%.build/firmware.a: config   = $(patsubst $(BUILD_DIR)%.build/firmware.a,%,$@)
 $(BUILD_DIR)%.build/firmware.a: work_dir = $(BUILD_DIR)$(config).build/
-$(FIRMWARES): $(BUILD_DIR)%.build/firmware.a:	generateuorbtopicheaders
+$(FIRMWARES): $(BUILD_DIR)%.build/firmware.a:	checkgitversion generateuorbtopicheaders
 	@$(ECHO) %%%%
 	@$(ECHO) %%%% Building $(config) in $(work_dir)
 	@$(ECHO) %%%%

--- a/makefiles/posix/config_posix_default.mk
+++ b/makefiles/posix/config_posix_default.mk
@@ -19,6 +19,7 @@ MODULES		+= modules/sensors
 MODULES	+= systemcmds/param
 MODULES += systemcmds/mixer
 MODULES += systemcmds/topic_listener
+MODULES	+= systemcmds/ver
 
 #
 # General system control

--- a/makefiles/setup.mk
+++ b/makefiles/setup.mk
@@ -62,6 +62,7 @@ export ROMFS_SRC	 = $(abspath $(PX4_BASE)/ROMFS)/
 export IMAGE_DIR	 = $(abspath $(PX4_BASE)/Images)/
 export BUILD_DIR	 = $(abspath $(PX4_BASE)/Build)/
 export ARCHIVE_DIR	 = $(abspath $(PX4_BASE)/Archives)/
+export PX4_VERSIONING_DIR = $(BUILD_DIR)versioning/
 
 #
 # Default include paths
@@ -70,7 +71,8 @@ export INCLUDE_DIRS	:= $(PX4_MODULE_SRC) \
 			   $(PX4_MODULE_SRC)/modules/ \
 			   $(PX4_INCLUDE_DIR) \
 			   $(PX4_LIB_DIR) \
-			   $(PX4_PLATFORMS_DIR)
+			   $(PX4_PLATFORMS_DIR) \
+			   $(PX4_VERSIONING_DIR)
 
 #
 # Tools

--- a/src/modules/systemlib/git_version.h
+++ b/src/modules/systemlib/git_version.h
@@ -41,6 +41,8 @@
 
 #include <stdint.h>
 
+#include "build_git_version.h"
+
 __BEGIN_DECLS
 
 __EXPORT extern const char* px4_git_version;

--- a/src/modules/systemlib/module.mk
+++ b/src/modules/systemlib/module.mk
@@ -52,8 +52,7 @@ SRCS		 = \
 		   mcu_version.c \
 		   bson/tinybson.c \
 		   circuit_breaker.cpp \
-		   circuit_breaker_params.c \
-		   $(BUILD_DIR)git_version.c
+		   circuit_breaker_params.c
 
 ifeq ($(PX4_TARGET_OS),nuttx)
 SRCS		+= err.c \

--- a/src/platforms/posix/include/board_config.h
+++ b/src/platforms/posix/include/board_config.h
@@ -9,3 +9,5 @@
 #define PX4_I2C_BUS_LED		3
 
 #define PX4_I2C_OBDEV_LED	0x55
+
+#define STM32_SYSMEM_UID "SIMULATIONID"

--- a/src/platforms/px4_defines.h
+++ b/src/platforms/px4_defines.h
@@ -125,6 +125,7 @@ typedef param_t px4_param_t;
 /* FIXME - Used to satisfy build */
 //STM DocID018909 Rev 8 Sect 39.1 (Unique device ID Register)
 #define UNIQUE_ID       0x1FFF7A10  
+#define STM32_SYSMEM_UID "SIMULATIONID"
 
 /* FIXME - Used to satisfy build */
 #define getreg32(a)    (*(volatile uint32_t *)(a))

--- a/src/systemcmds/ver/ver.c
+++ b/src/systemcmds/ver/ver.c
@@ -41,6 +41,7 @@
 */
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <string.h>
 #include <version/version.h>
 #include <systemlib/err.h>
@@ -91,7 +92,8 @@ int ver_main(int argc, char *argv[])
 					return ret;
 
 				} else {
-					errx(1, "Not enough arguments, try 'ver hwcmp PX4FMU_V2'");
+					warn("Not enough arguments, try 'ver hwcmp PX4FMU_V2'");
+					return 1;
 				}
 			}
 
@@ -158,7 +160,8 @@ int ver_main(int argc, char *argv[])
 
 
 			if (ret == 1) {
-				errx(1, "unknown command.\n");
+				warn("unknown command.\n");
+				return 1;
 			}
 
 		} else {

--- a/src/systemcmds/ver/ver.c
+++ b/src/systemcmds/ver/ver.c
@@ -57,6 +57,9 @@ static const char sz_ver_all_str[] 	= "all";
 static const char mcu_ver_str[]		= "mcu";
 static const char mcu_uid_str[]		= "uid";
 
+const char* px4_git_version = PX4_GIT_VERSION_STR;
+const uint64_t px4_git_version_binary = PX4_GIT_VERSION_BINARY;
+
 static void usage(const char *reason)
 {
 	if (reason != NULL) {


### PR DESCRIPTION
@LorenzMeier - This is the fixes issues with ```Make clean all``` and prevents linker errors due to ARM EABI differences attributed to hard/soft FPU support.

@mcharleb contributed Part 2

If travis likes it, please merge.