### PR TITLE
POSIX: px4_getpid() fix

### DIFF
--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -39,6 +39,7 @@
 #include <px4_log.h>
 #include <px4_tasks.h>
 #include <px4_time.h>
+#include <pthread.h>
 #include <poll.h>
 #include <systemlib/err.h>
 #include <errno.h>

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -276,7 +276,7 @@ private:
 	void send_mavlink_message(const uint8_t msgid, const void *msg, uint8_t component_ID);
 	void update_sensors(struct sensor_combined_s *sensor, mavlink_hil_sensor_t *imu);
 	void update_gps(mavlink_hil_gps_t *gps_sim);
-	static int sending_trampoline(int argc, char *argv[]);
+	static void *sending_trampoline(void *);
 	void send();
 #endif
 };

--- a/src/modules/uORB/uORBDevices_posix.hpp
+++ b/src/modules/uORB/uORBDevices_posix.hpp
@@ -114,7 +114,7 @@ private:
   uint8_t     *_data;   /**< allocated object buffer */
   hrt_abstime   _last_update; /**< time the object was last updated */
   volatile unsigned   _generation;  /**< object generation count */
-  pid_t     _publisher; /**< if nonzero, current publisher */
+  unsigned long  _publisher; /**< if nonzero, current publisher */
   const int   _priority;  /**< priority of topic */
 
   SubscriberData    *filp_to_sd(device::file_t *filp);

--- a/src/platforms/posix/px4_layer/px4_posix_tasks.cpp
+++ b/src/platforms/posix/px4_layer/px4_posix_tasks.cpp
@@ -278,21 +278,9 @@ void px4_show_tasks()
 
 __BEGIN_DECLS
 
-int px4_getpid()
+unsigned long px4_getpid()
 {
-	pthread_t pid = pthread_self();
-
-	if (pid == _shell_task_id)
-		return SHELL_TASK_ID;
-
-	// Get pthread ID from the opaque ID
-	for (int i=0; i<PX4_MAX_TASKS; ++i) {
-		if (taskmap[i].isused && taskmap[i].pid == pid) {
-			return i;
-		}
-	}
-	PX4_ERR("px4_getpid() called from unknown thread context!");
-	return -EINVAL;
+	return (unsigned long)pthread_self();
 }
 
 const char *getprogname();

--- a/src/platforms/px4_posix.h
+++ b/src/platforms/px4_posix.h
@@ -99,7 +99,7 @@ __EXPORT int		px4_ioctl(int fd, int cmd, unsigned long arg);
 __EXPORT int		px4_poll(px4_pollfd_struct_t *fds, nfds_t nfds, int timeout);
 __EXPORT int		px4_fsync(int fd);
 __EXPORT int		px4_access(const char *pathname, int mode);
-__EXPORT int		px4_getpid(void);
+__EXPORT unsigned long	px4_getpid(void);
 
 __END_DECLS
 #else


### PR DESCRIPTION
Since the PX4 code uses both px4_task and pthread APIs,
px4_getpid() must be save to call from either context.

On posix, this means we have to always return the pthread ID.

Reverted simulator change of pthread to px4_task

There may have been side effects if this was build for a target that
has process/task scoped file descriptors. It is now safe to call
px4_getpid() from this pthread context with this change for the
posix build for px4_getpid().

Signed-off-by: Mark Charlebois <charlebm@gmail.com>