### PR TITLE
Compile Time - Conditional inclusion of the Node Allocation and FW Server

### DIFF
--- a/src/modules/uavcan/uavcan_main.hpp
+++ b/src/modules/uavcan/uavcan_main.hpp
@@ -34,6 +34,7 @@
 #pragma once
 
 #include <px4_config.h>
+
 #include <uavcan_stm32/uavcan_stm32.hpp>
 #include <drivers/device/device.h>
 #include <systemlib/perf_counter.h>
@@ -47,13 +48,13 @@
 #include "actuators/esc.hpp"
 #include "sensors/sensor_bridge.hpp"
 
-
-#include <uavcan/protocol/dynamic_node_id_server/centralized.hpp>
-#include <uavcan/protocol/node_info_retriever.hpp>
-#include <uavcan_posix/basic_file_server_backend.hpp>
-#include <uavcan/protocol/firmware_update_trigger.hpp>
-#include <uavcan/protocol/file_server.hpp>
-
+#if defined(USE_FW_NODE_SERVER)
+# include <uavcan/protocol/dynamic_node_id_server/centralized.hpp>
+# include <uavcan/protocol/node_info_retriever.hpp>
+# include <uavcan_posix/basic_file_server_backend.hpp>
+# include <uavcan/protocol/firmware_update_trigger.hpp>
+# include <uavcan/protocol/file_server.hpp>
+#endif
 
 /**
  * @file uavcan_main.hpp
@@ -147,7 +148,6 @@ private:
 	unsigned		_output_count = 0;		///< number of actuators currently available
 
 	static UavcanNode	*_instance;			///< singleton pointer
-	static uavcan::dynamic_node_id_server::CentralizedServer *_server_instance;              ///< server singleton pointer
 
 	Node			_node;				///< library instance
 	pthread_mutex_t		_node_mutex;
@@ -155,11 +155,14 @@ private:
 	UavcanEscController	_esc_controller;
 
 
+#if defined(USE_FW_NODE_SERVER)
+	static uavcan::dynamic_node_id_server::CentralizedServer *_server_instance;              ///< server singleton pointer
+
 	uavcan_posix::BasicFileSeverBackend _fileserver_backend;
 	uavcan::NodeInfoRetriever  _node_info_retriever;
 	uavcan::FirmwareUpdateTrigger  _fw_upgrade_trigger;
 	uavcan::BasicFileServer        _fw_server;
-
+#endif
 	List<IUavcanSensorBridge *> _sensor_bridges;		///< List of active sensor bridges
 
 	MixerGroup		*_mixers = nullptr;


### PR DESCRIPTION
The default is off, which saves 15,040 Bytes

This is a interim solution for the issues related to excessive memory use of the uavcan's features for Dynamic Node ID Allocation and File servers used for bootloading.

![image](https://cloud.githubusercontent.com/assets/1945821/8212799/8ae6bc04-14b9-11e5-83c4-0f180664de09.png)

