### PR TITLE
Getopt cleanup

### DIFF
--- a/makefiles/posix/config_posix_sitl.mk
+++ b/makefiles/posix/config_posix_sitl.mk
@@ -20,6 +20,8 @@ MODULES	+= systemcmds/param
 MODULES += systemcmds/mixer
 MODULES += systemcmds/topic_listener
 MODULES	+= systemcmds/ver
+MODULES	+= systemcmds/esc_calib
+MODULES	+= systemcmds/reboot
 
 #
 # General system control

--- a/makefiles/posix/posix_elf.mk
+++ b/makefiles/posix/posix_elf.mk
@@ -56,9 +56,11 @@ $(PRODUCT_SHARED_PRELINK):	$(OBJS) $(MODULE_OBJS) $(LIBRARY_LIBS) $(GLOBAL_DEPS)
 $(PRODUCT_SHARED_LIB):		$(PRODUCT_SHARED_PRELINK)
 	$(call LINK_A,$@,$(PRODUCT_SHARED_PRELINK))
 
+$(WORK_DIR)apps.h: $(WORK_DIR)builtin_commands
+	$(PX4_BASE)/Tools/posix_apps.py > $(WORK_DIR)apps.h
+
 MAIN = $(PX4_BASE)/src/platforms/posix/main.cpp
-$(WORK_DIR)mainapp: $(PRODUCT_SHARED_LIB)
-	$(PX4_BASE)/Tools/posix_apps.py > apps.h
+$(WORK_DIR)mainapp: $(PRODUCT_SHARED_LIB) $(WORK_DIR)apps.h
 	$(call LINK,$@, -I. $(MAIN) $(PRODUCT_SHARED_LIB))
 
 #

--- a/makefiles/posix/toolchain_native.mk
+++ b/makefiles/posix/toolchain_native.mk
@@ -120,7 +120,7 @@ ifeq ($(CONFIG_BOARD),)
 $(error Board config does not define CONFIG_BOARD)
 endif
 ARCHDEFINES		+= -DCONFIG_ARCH_BOARD_$(CONFIG_BOARD) \
-			-Dnoreturn_function= \
+			-Dnoreturn_function=__attribute__\(\(noreturn\)\) \
 			-I$(PX4_BASE)/src/modules/systemlib \
 			-I$(PX4_BASE)/src/lib/eigen \
 			-I$(PX4_BASE)/src/platforms/posix/include \

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -44,6 +44,7 @@
 
 #include <px4_config.h>
 #include <px4_defines.h>
+#include <px4_getopt.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/prctl.h>
@@ -895,10 +896,12 @@ int sdlog2_thread_main(int argc, char *argv[])
 	 * set error flag instead */
 	bool err_flag = false;
 
-	while ((ch = getopt(argc, argv, "r:b:eatx")) != EOF) {
+	int myoptind = 1;
+	const char *myoptarg = NULL;
+	while ((ch = px4_getopt(argc, argv, "r:b:eatx", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'r': {
-				unsigned long r = strtoul(optarg, NULL, 10);
+				unsigned long r = strtoul(myoptarg, NULL, 10);
 
 				if (r == 0) {
 					r = 1;
@@ -909,7 +912,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 			break;
 
 		case 'b': {
-				unsigned long s = strtoul(optarg, NULL, 10);
+				unsigned long s = strtoul(myoptarg, NULL, 10);
 
 				if (s < 1) {
 					s = 1;

--- a/src/platforms/posix/px4_layer/px4_posix_tasks.cpp
+++ b/src/platforms/posix/px4_layer/px4_posix_tasks.cpp
@@ -98,6 +98,7 @@ void
 px4_systemreset(bool to_bootloader)
 {
 	PX4_WARN("Called px4_system_reset");
+	exit(0);
 }
 
 px4_task_t px4_task_spawn_cmd(const char *name, int scheduler, int priority, int stack_size, px4_main_t entry, char * const argv[])

--- a/src/systemcmds/reboot/reboot.c
+++ b/src/systemcmds/reboot/reboot.c
@@ -38,12 +38,10 @@
  */
 
 #include <px4_config.h>
-#include <unistd.h>
-#include <stdio.h>
-#include <getopt.h>
-
+#include <px4_getopt.h>
+#include <px4_tasks.h>
+#include <px4_log.h>
 #include <systemlib/systemlib.h>
-#include <systemlib/err.h>
 
 __EXPORT int reboot_main(int argc, char *argv[]);
 
@@ -52,14 +50,16 @@ int reboot_main(int argc, char *argv[])
 	int ch;
 	bool to_bootloader = false;
 
-	while ((ch = getopt(argc, argv, "b")) != -1) {
+	int myoptind = 1;
+	const char *myoptarg = NULL;
+	while ((ch = px4_getopt(argc, argv, "b", &myoptind, &myoptarg)) != -1) {
 		switch (ch) {
 		case 'b':
 			to_bootloader = true;
 			break;
 
 		default:
-			errx(1, "usage: reboot [-b]\n"
+			PX4_ERR("usage: reboot [-b]\n"
 			     "   -b   reboot into the bootloader");
 
 		}
@@ -67,5 +67,3 @@ int reboot_main(int argc, char *argv[])
 
 	px4_systemreset(to_bootloader);
 }
-
-


### PR DESCRIPTION
Converted uses of getopt to px4_getopt. The use of getopt is not thread safe in the posix and qurt builds.
