### PR TITLE
set SYS_RESTART_TYPE in sitl startup, normally IO does that

### DIFF
--- a/posix-configs/SITL/init/rcS
+++ b/posix-configs/SITL/init/rcS
@@ -4,6 +4,7 @@ param set MAV_TYPE 2
 param set MC_PITCHRATE_P 0.05
 param set MC_ROLLRATE_P 0.05
 param set SYS_AUTOSTART 4010
+param set SYS_RESTART_TYPE 2
 param set COM_RC_IN_MODE 2
 dataman start
 mavlink start -u 14556 -r 60000


### PR DESCRIPTION
This should make the dataman stop complaining.