### PR TITLE
VDev: get rid of those nasty "node_open as advertiser failed"

### DIFF
--- a/src/drivers/device/vdev.cpp
+++ b/src/drivers/device/vdev.cpp
@@ -64,7 +64,7 @@ private:
 	px4_dev_t() {}
 };
 
-#define PX4_MAX_DEV 100
+#define PX4_MAX_DEV 200
 static px4_dev_t *devmap[PX4_MAX_DEV];
 
 /*

--- a/src/drivers/device/vdev_posix.cpp
+++ b/src/drivers/device/vdev_posix.cpp
@@ -75,7 +75,7 @@ static void *timer_handler(void *data)
 	return 0;
 }
 
-#define PX4_MAX_FD 100
+#define PX4_MAX_FD 200
 static device::file_t *filemap[PX4_MAX_FD] = {};
 
 int px4_errno;
@@ -117,6 +117,7 @@ int px4_open(const char *path, int flags, ...)
 			ret = dev->open(filemap[i]);
 		}
 		else {
+			PX4_WARN("exceeded maximum number of file descriptors!");
 			ret = -ENOENT;
 		}
 	}


### PR DESCRIPTION
- increase max number of devices to 200
- increase max number of file descriptors to 200
- add warning if number of file descriptor exceeds max value