### PR TITLE
VTOL: only publish attitude setpoint if in correct mode

### DIFF
--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
@@ -1762,11 +1762,11 @@ FixedwingPositionControl::task_main()
 				_att_sp.timestamp = hrt_absolute_time();
 
 				/* lazily publish the setpoint only once available */
-				if (_attitude_sp_pub > 0) {
+				if (_attitude_sp_pub > 0 && !_vehicle_status.is_rotary_wing) {
 					/* publish the attitude setpoint */
 					orb_publish(ORB_ID(vehicle_attitude_setpoint), _attitude_sp_pub, &_att_sp);
 
-				} else {
+				} else if (_attitude_sp_pub <= 0 && !_vehicle_status.is_rotary_wing) {
 					/* advertise and publish */
 					_attitude_sp_pub = orb_advertise(ORB_ID(vehicle_attitude_setpoint), &_att_sp);
 				}


### PR DESCRIPTION
This should fix the double publishing we have been seeing in the VTOL logs.