### PR TITLE
MC pos control: Enforce minimum throttle in manual attitude control m…

### DIFF
--- a/msg/actuator_controls.msg
+++ b/msg/actuator_controls.msg
@@ -1,5 +1,11 @@
 uint8 NUM_ACTUATOR_CONTROLS = 8
 uint8 NUM_ACTUATOR_CONTROL_GROUPS = 4
+uint8 INDEX_ROLL = 0
+uint8 INDEX_PITCH = 1
+uint8 INDEX_YAW = 2
+uint8 INDEX_THROTTLE = 3
+uint8 INDEX_FLAPS = 4
+uint8 GROUP_INDEX_ATTITUDE = 0
 uint64 timestamp
 uint64 timestamp_sample	    # the timestamp the data this control response is based on was sampled
 float32[8] control

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -100,6 +100,14 @@ bool MulticopterLandDetector::update()
 		return true;
 	}
 
+	// return status based on armed state if no position lock is available
+	if (_vehicleGlobalPosition.timestamp == 0 ||
+		hrt_elapsed_time(&_vehicleGlobalPosition.timestamp) > 500000) {
+
+		// no position lock - not landed if armed
+		return !_arming.armed;
+	}
+
 	const uint64_t now = hrt_absolute_time();
 
 	// check if we are moving vertically

--- a/src/modules/land_detector/land_detector_params.c
+++ b/src/modules/land_detector/land_detector_params.c
@@ -49,7 +49,7 @@
  *
  * @group Land Detector
  */
-PARAM_DEFINE_FLOAT(LNDMC_Z_VEL_MAX, 1.00f);
+PARAM_DEFINE_FLOAT(LNDMC_Z_VEL_MAX, 0.60f);
 
 /**
  * Multicopter max horizontal velocity

--- a/src/modules/land_detector/land_detector_params.c
+++ b/src/modules/land_detector/land_detector_params.c
@@ -43,29 +43,29 @@
 /**
  * Multicopter max climb rate
  *
- * Maximum vertical velocity allowed to trigger a land (m/s up and down)
+ * Maximum vertical velocity allowed in the landed state (m/s up and down)
  *
  * @unit m/s
  *
  * @group Land Detector
  */
-PARAM_DEFINE_FLOAT(LNDMC_Z_VEL_MAX, 0.30f);
+PARAM_DEFINE_FLOAT(LNDMC_Z_VEL_MAX, 1.00f);
 
 /**
  * Multicopter max horizontal velocity
  *
- * Maximum horizontal velocity allowed to trigger a land (m/s)
+ * Maximum horizontal velocity allowed in the landed state (m/s)
  *
  * @unit m/s
  *
  * @group Land Detector
  */
-PARAM_DEFINE_FLOAT(LNDMC_XY_VEL_MAX, 1.00f);
+PARAM_DEFINE_FLOAT(LNDMC_XY_VEL_MAX, 1.50f);
 
 /**
  * Multicopter max rotation
  *
- * Maximum allowed around each axis to trigger a land (degrees per second)
+ * Maximum allowed around each axis allowed in the landed state (degrees per second)
  *
  * @unit deg/s
  *
@@ -76,19 +76,19 @@ PARAM_DEFINE_FLOAT(LNDMC_ROT_MAX, 20.0f);
 /**
  * Multicopter max throttle
  *
- * Maximum actuator output on throttle before triggering a land
+ * Maximum actuator output on throttle allowed in the landed state
  *
  * @min 0.1
  * @max 0.5
  *
  * @group Land Detector
  */
-PARAM_DEFINE_FLOAT(LNDMC_THR_MAX, 0.20f);
+PARAM_DEFINE_FLOAT(LNDMC_THR_MAX, 0.15f);
 
 /**
  * Fixedwing max horizontal velocity
  *
- * Maximum horizontal velocity allowed to trigger a land (m/s)
+ * Maximum horizontal velocity allowed in the landed state (m/s)
  *
  * @min 0.5
  * @max 10
@@ -101,7 +101,7 @@ PARAM_DEFINE_FLOAT(LNDFW_VEL_XY_MAX, 5.0f);
 /**
  * Fixedwing max climb rate
  *
- * Maximum vertical velocity allowed to trigger a land (m/s up and down)
+ * Maximum vertical velocity allowed in the landed state (m/s up and down)
  *
  * @min 5
  * @max 20
@@ -114,7 +114,7 @@ PARAM_DEFINE_FLOAT(LNDFW_VEL_Z_MAX, 10.0f);
 /**
  * Airspeed max
  *
- * Maximum airspeed allowed to trigger a land (m/s)
+ * Maximum airspeed allowed in the landed state (m/s)
  *
  * @min 4
  * @max 20

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1414,7 +1414,11 @@ MulticopterPositionControl::task_main()
 			/* control throttle directly if no climb rate controller is active */
 			if (!_control_mode.flag_control_climb_rate_enabled) {
 				_att_sp.thrust = math::min(_manual.z, _params.thr_max);
-				_att_sp.thrust = math::max(_att_sp.thrust, _params.thr_min);
+
+				/* enforce minimum throttle if not landed */
+				if (!_vehicle_status.condition_landed) {
+					_att_sp.thrust = math::max(_att_sp.thrust, _params.thr_min);
+				}
 			}
 
 			/* construct attitude setpoint rotation matrix */

--- a/src/modules/px4iofirmware/mixer.cpp
+++ b/src/modules/px4iofirmware/mixer.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2014 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2015 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,7 @@
 
 #include <systemlib/pwm_limit/pwm_limit.h>
 #include <systemlib/mixer/mixer.h>
+#include <uORB/topics/actuator_controls.h>
 
 extern "C" {
 //#define DEBUG
@@ -318,13 +319,6 @@ mixer_callback(uintptr_t handle,
 	case MIX_OVERRIDE:
 		if (r_page_rc_input[PX4IO_P_RC_VALID] & (1 << CONTROL_PAGE_INDEX(control_group, control_index))) {
 			control = REG_TO_FLOAT(r_page_rc_input[PX4IO_P_RC_BASE + control_index]);
-			if (control_group == 0 && control_index == 0) {
-				control += REG_TO_FLOAT(r_setup_trim_roll);
-			} else if (control_group == 0 && control_index == 1) {
-				control += REG_TO_FLOAT(r_setup_trim_pitch);
-			} else if (control_group == 0 && control_index == 2) {
-				control += REG_TO_FLOAT(r_setup_trim_yaw);
-			}
 			break;
 		}
 		return -1;
@@ -333,13 +327,6 @@ mixer_callback(uintptr_t handle,
 		/* FMU is ok but we are in override mode, use direct rc control for the available rc channels. The remaining channels are still controlled by the fmu */
 		if (r_page_rc_input[PX4IO_P_RC_VALID] & (1 << CONTROL_PAGE_INDEX(control_group, control_index))) {
 			control = REG_TO_FLOAT(r_page_rc_input[PX4IO_P_RC_BASE + control_index]);
-			if (control_group == 0 && control_index == 0) {
-				control += REG_TO_FLOAT(r_setup_trim_roll);
-			} else if (control_group == 0 && control_index == 1) {
-				control += REG_TO_FLOAT(r_setup_trim_pitch);
-			} else if (control_group == 0 && control_index == 2) {
-				control += REG_TO_FLOAT(r_setup_trim_yaw);
-			}
 			break;
 		} else if (control_index < PX4IO_CONTROL_CHANNELS && control_group < PX4IO_CONTROL_GROUPS) {
 			control = REG_TO_FLOAT(r_page_controls[CONTROL_PAGE_INDEX(control_group, control_index)]);
@@ -351,6 +338,33 @@ mixer_callback(uintptr_t handle,
 	case MIX_NONE:
 		control = 0.0f;
 		return -1;
+	}
+
+	/* apply trim offsets for override channels */
+	if (source == MIX_OVERRIDE || source == MIX_OVERRIDE_FMU_OK) {
+		if (control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE &&
+			control_index == actuator_controls_s::INDEX_ROLL) {
+			control += REG_TO_FLOAT(r_setup_trim_roll);
+
+		} else if (control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE &&
+			control_index == actuator_controls_s::INDEX_PITCH) {
+			control += REG_TO_FLOAT(r_setup_trim_pitch);
+
+		} else if (control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE &&
+			control_index == actuator_controls_s::INDEX_YAW) {
+			control += REG_TO_FLOAT(r_setup_trim_yaw);
+		}
+	}
+
+	/* motor spinup phase - lock throttle to zero */
+	if (pwm_limit.state == PWM_LIMIT_STATE_RAMP) {
+		if (control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE &&
+			control_index == actuator_controls_s::INDEX_THROTTLE) {
+			/* limit the throttle output to zero during motor spinup,
+			 * as the motors cannot follow any demand yet
+			 */
+			control = 0.0f;
+		}
 	}
 
 	/* limit output */

--- a/src/modules/systemlib/pwm_limit/pwm_limit.c
+++ b/src/modules/systemlib/pwm_limit/pwm_limit.c
@@ -1,7 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013, 2014 PX4 Development Team. All rights reserved.
- *   Author: Julian Oes <joes@student.ethz.ch>
+ *   Copyright (c) 2013-2015 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,9 +34,9 @@
 /**
  * @file pwm_limit.c
  *
- * Lib to limit PWM output
+ * Library for PWM output limiting
  *
- * @author Julian Oes <joes@student.ethz.ch>
+ * @author Julian Oes <julian@px4.io>
  */
 
 #include "pwm_limit.h"
@@ -45,6 +44,8 @@
 #include <stdbool.h>
 #include <drivers/drv_hrt.h>
 #include <stdio.h>
+
+#define PROGRESS_INT_SCALING	10000
 
 void pwm_limit_init(pwm_limit_t *limit)
 {
@@ -112,7 +113,11 @@ void pwm_limit_calc(const bool armed, const unsigned num_channels, const uint16_
 			{
 				hrt_abstime diff = hrt_elapsed_time(&limit->time_armed);
 
-				progress = diff * 10000 / RAMP_TIME_US;
+				progress = diff * PROGRESS_INT_SCALING / RAMP_TIME_US;
+
+				if (progress > PROGRESS_INT_SCALING) {
+					progress = PROGRESS_INT_SCALING;
+				}
 
 				for (unsigned i=0; i<num_channels; i++) {
 	                
@@ -128,7 +133,7 @@ void pwm_limit_calc(const bool armed, const unsigned num_channels, const uint16_
 						}
 
 						unsigned disarmed_min_diff = min_pwm[i] - disarmed;
-						ramp_min_pwm = disarmed + (disarmed_min_diff * progress) / 10000;
+						ramp_min_pwm = disarmed + (disarmed_min_diff * progress) / PROGRESS_INT_SCALING;
 
 					} else {
 	                    

--- a/src/modules/systemlib/pwm_limit/pwm_limit.h
+++ b/src/modules/systemlib/pwm_limit/pwm_limit.h
@@ -1,7 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2013 PX4 Development Team. All rights reserved.
- *   Author: Julian Oes <joes@student.ethz.ch>
+ *   Copyright (c) 2013-2015 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,11 +32,11 @@
  ****************************************************************************/
 
 /**
- * @file pwm_limit.h
+ * @file pwm_limit.c
  *
- * Lib to limit PWM output
+ * Library for PWM output limiting
  *
- * @author Julian Oes <joes@student.ethz.ch>
+ * @author Julian Oes <julian@px4.io>
  */
 
 #ifndef PWM_LIMIT_H_

--- a/src/systemcmds/tests/test_mixer.cpp
+++ b/src/systemcmds/tests/test_mixer.cpp
@@ -200,7 +200,7 @@ int test_mixer(int argc, char *argv[])
 	hrt_abstime starttime = hrt_absolute_time();
 	unsigned sleepcount = 0;
 
-	while (hrt_elapsed_time(&starttime) < INIT_TIME_US + RAMP_TIME_US) {
+	while (hrt_elapsed_time(&starttime) < INIT_TIME_US + RAMP_TIME_US + 2 * sleep_quantum_us) {
 
 		/* mix */
 		mixed = mixer_group.mix(&outputs[0], output_max, NULL);

--- a/src/systemcmds/tests/test_mixer.cpp
+++ b/src/systemcmds/tests/test_mixer.cpp
@@ -259,7 +259,7 @@ int test_mixer(int argc, char *argv[])
 		for (unsigned i = 0; i < mixed; i++) {
 			servo_predicted[i] = 1500 + outputs[i] * (r_page_servo_control_max[i] - r_page_servo_control_min[i]) / 2.0f;
 
-			if (fabsf(servo_predicted[i] - r_page_servos[i]) > 2) {
+			if (abs(servo_predicted[i] - r_page_servos[i]) > 2) {
 				printf("\t %d: %8.4f predicted: %d, servo: %d\n", i, (double)outputs[i], servo_predicted[i], (int)r_page_servos[i]);
 				warnx("mixer violated predicted value");
 				return 1;
@@ -333,7 +333,7 @@ int test_mixer(int argc, char *argv[])
 
 			/* check post ramp phase */
 			if (hrt_elapsed_time(&starttime) > RAMP_TIME_US &&
-			    fabsf(servo_predicted[i] - r_page_servos[i]) > 2) {
+			    abs(servo_predicted[i] - r_page_servos[i]) > 2) {
 				printf("\t %d: %8.4f predicted: %d, servo: %d\n", i, (double)outputs[i], servo_predicted[i], (int)r_page_servos[i]);
 				warnx("mixer violated predicted value");
 				return 1;


### PR DESCRIPTION
…ode only if not landed, else default to idle throttle.

@sjwilks This is not the fix to your problem, but it should help generally with the convenience of manual attitude control flights as the idle throttle is now less high, but can still be set for in-flight to a level where the stabilisation is safe. False detections are unlikely in a steep descend situation, so the only potential issue is to have too high idle on the ground, which will be fine once you have resolved the spin-up issue.