### PR TITLE
Add max velocity constraints to multiplatform MPC

### DIFF
--- a/src/modules/mc_pos_control_multiplatform/mc_pos_control.cpp
+++ b/src/modules/mc_pos_control_multiplatform/mc_pos_control.cpp
@@ -647,6 +647,21 @@ void  MulticopterPositionControl::handle_vehicle_attitude(const px4_vehicle_atti
 
 			_vel_sp = pos_err.emult(_params.pos_p) + _vel_ff;
 
+			/* make sure velocity setpoint is saturated in xy*/
+			float vel_norm_xy = sqrtf(_vel_sp(0)*_vel_sp(0) +
+				_vel_sp(1)*_vel_sp(1));
+			if (vel_norm_xy > _params.vel_max(0)) {
+				/* note assumes vel_max(0) == vel_max(1) */
+				_vel_sp(0) = _vel_sp(0)*_params.vel_max(0)/vel_norm_xy;
+				_vel_sp(1) = _vel_sp(1)*_params.vel_max(1)/vel_norm_xy;
+			}
+
+			/* make sure velocity setpoint is saturated in z*/
+			float vel_norm_z = sqrtf(_vel_sp(2)*_vel_sp(2));
+			if (vel_norm_z > _params.vel_max(2)) {
+				_vel_sp(2) = _vel_sp(2)*_params.vel_max(2)/vel_norm_z;
+			}
+
 			if (!_control_mode->data().flag_control_altitude_enabled) {
 				_reset_alt_sp = true;
 				_vel_sp(2) = 0.0f;


### PR DESCRIPTION
@LorenzMeier, @thomasgubler  I just added this to our "old" SITL now since this makes a real difference depending on what we do. But it raises the question again on what to do with the multiplatform position controller in general. Should we even bother to update it (there were quite a few other improvements that didn't make it here)? Does this play a role in new SITL?

This change is tested in SITL