### PR TITLE
Adjust the duration of the BIND pulse

### DIFF
--- a/src/modules/px4iofirmware/dsm.c
+++ b/src/modules/px4iofirmware/dsm.c
@@ -292,9 +292,9 @@ dsm_bind(uint16_t cmd, int pulses)
 
 		/*Pulse RX pin a number of times*/
 		for (int i = 0; i < pulses; i++) {
-			up_udelay(25);
+			up_udelay(120);
 			stm32_gpiowrite(usart1RxAsOutp, false);
-			up_udelay(25);
+			up_udelay(120);
 			stm32_gpiowrite(usart1RxAsOutp, true);
 		}
 		break;


### PR DESCRIPTION
Some DSMX Remote Receiver can't enter BIND mode with the duration about 25us but 120us.