### PR TITLE
POSIX: Critical fix for vdev_posix

### DIFF
--- a/src/modules/uORB/uORBDevices_posix.cpp
+++ b/src/modules/uORB/uORBDevices_posix.cpp
@@ -421,10 +421,6 @@ uORB::DeviceNode::appears_updated(SubscriberData *sd)
 			break;
 		}
 
-// FIXME - the calls to hrt_called and hrt_call_after seem not to work in the
-//         POSIX build
-#ifndef __PX4_POSIX
-
 		/*
 		 * If the interval timer is still running, the topic should not
 		 * appear updated, even though at this point we know that it has.
@@ -445,7 +441,6 @@ uORB::DeviceNode::appears_updated(SubscriberData *sd)
 			       sd->update_interval,
 			       &uORB::DeviceNode::update_deferred_trampoline,
 			       (void *)this);
-#endif
 
 		/*
 		 * Remember that we have told the subscriber that there is data.

--- a/src/platforms/posix/include/hrt_work.h
+++ b/src/platforms/posix/include/hrt_work.h
@@ -46,12 +46,14 @@ void hrt_work_queue_init(void);
 int hrt_work_queue(struct work_s *work, worker_t worker, void *arg, uint32_t usdelay);
 void hrt_work_cancel(struct work_s *work);
 
+static inline void hrt_work_lock(void);
 static inline void hrt_work_lock()
 {
 	//PX4_INFO("hrt_work_lock");
 	sem_wait(&_hrt_work_lock);
 }
 
+static inline void hrt_work_unlock(void);
 static inline void hrt_work_unlock()
 {
 	//PX4_INFO("hrt_work_unlock");


### PR DESCRIPTION
Last fix for vdev_posix.cpp introduced a sleep from within
a HRT work item callback which blocks the HRT queue.

The code in uORBDevices_posix.cpp that handles message
throttling was commented out for posix. The code was re-enabled
and now seems to work.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>