### PR TITLE
Clang fixes

### DIFF
--- a/src/modules/position_estimator_inav/module.mk
+++ b/src/modules/position_estimator_inav/module.mk
@@ -42,5 +42,7 @@ SRCS		 	= position_estimator_inav_main.c \
 
 MODULE_STACKSIZE = 1200
 
+ifeq ($(PX4_TARGEGT_OS),nuttx)
 EXTRACFLAGS = -Wframe-larger-than=3800
+endif
 

--- a/src/systemcmds/tests/module.mk
+++ b/src/systemcmds/tests/module.mk
@@ -35,5 +35,18 @@ SRCS			 = test_adc.c \
 			   test_mount.c \
 			   test_eigen.cpp
 
-EXTRACXXFLAGS = -Wframe-larger-than=2500 -Wno-float-equal -Wno-double-promotion -Wno-error=logical-op
+ifeq ($(PX4_TARGET_OS), nuttx)
+SRCS			+= test_time.c
+
+EXTRACXXFLAGS = -Wframe-larger-than=2500
+else
+EXTRACXXFLAGS =
+endif
+
+EXTRACXXFLAGS += -Wno-float-equal
+
+# Flag is only valid for GCC, not clang
+ifneq ($(USE_GCC), 0)
+EXTRACXXFLAGS += -Wno-double-promotion -Wno-error=logical-op
+endif
 

--- a/src/systemcmds/tests/test_mixer.cpp
+++ b/src/systemcmds/tests/test_mixer.cpp
@@ -259,7 +259,7 @@ int test_mixer(int argc, char *argv[])
 		for (unsigned i = 0; i < mixed; i++) {
 			servo_predicted[i] = 1500 + outputs[i] * (r_page_servo_control_max[i] - r_page_servo_control_min[i]) / 2.0f;
 
-			if (fabsf(servo_predicted[i] - r_page_servos[i]) > 2) {
+			if (abs(servo_predicted[i] - r_page_servos[i]) > 2) {
 				printf("\t %d: %8.4f predicted: %d, servo: %d\n", i, (double)outputs[i], servo_predicted[i], (int)r_page_servos[i]);
 				warnx("mixer violated predicted value");
 				return 1;
@@ -333,7 +333,7 @@ int test_mixer(int argc, char *argv[])
 
 			/* check post ramp phase */
 			if (hrt_elapsed_time(&starttime) > RAMP_TIME_US &&
-			    fabsf(servo_predicted[i] - r_page_servos[i]) > 2) {
+			    abs(servo_predicted[i] - r_page_servos[i]) > 2) {
 				printf("\t %d: %8.4f predicted: %d, servo: %d\n", i, (double)outputs[i], servo_predicted[i], (int)r_page_servos[i]);
 				warnx("mixer violated predicted value");
 				return 1;

--- a/src/systemcmds/tests/test_ppm_loopback.c
+++ b/src/systemcmds/tests/test_ppm_loopback.c
@@ -162,7 +162,7 @@ int test_ppm_loopback(int argc, char *argv[])
 
 		/* go and check values */
 		for (unsigned i = 0; (i < servo_count) && (i < sizeof(pwm_values) / sizeof(pwm_values[0])); i++) {
-			if (fabsf(rc_input.values[i] - pwm_values[i]) > 10) {
+			if (abs(rc_input.values[i] - pwm_values[i]) > 10) {
 				warnx("comparison fail: RC: %d, expected: %d", rc_input.values[i], pwm_values[i]);
 				(void)close(servo_fd);
 				return ERROR;


### PR DESCRIPTION
Use of fabsf() for int arg failed for clang. Changed to use abs().
Updated modules to conditionally check stack for NuttX only as the stack size checks fail for the posix build.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>