### PR TITLE
Chage use of fabsf for int to abs

### DIFF
--- a/src/systemcmds/tests/test_mixer.cpp
+++ b/src/systemcmds/tests/test_mixer.cpp
@@ -259,7 +259,7 @@ int test_mixer(int argc, char *argv[])
 		for (unsigned i = 0; i < mixed; i++) {
 			servo_predicted[i] = 1500 + outputs[i] * (r_page_servo_control_max[i] - r_page_servo_control_min[i]) / 2.0f;
 
-			if (fabsf(servo_predicted[i] - r_page_servos[i]) > 2) {
+			if (abs(servo_predicted[i] - r_page_servos[i]) > 2) {
 				printf("\t %d: %8.4f predicted: %d, servo: %d\n", i, (double)outputs[i], servo_predicted[i], (int)r_page_servos[i]);
 				warnx("mixer violated predicted value");
 				return 1;
@@ -333,7 +333,7 @@ int test_mixer(int argc, char *argv[])
 
 			/* check post ramp phase */
 			if (hrt_elapsed_time(&starttime) > RAMP_TIME_US &&
-			    fabsf(servo_predicted[i] - r_page_servos[i]) > 2) {
+			    abs(servo_predicted[i] - r_page_servos[i]) > 2) {
 				printf("\t %d: %8.4f predicted: %d, servo: %d\n", i, (double)outputs[i], servo_predicted[i], (int)r_page_servos[i]);
 				warnx("mixer violated predicted value");
 				return 1;

--- a/src/systemcmds/tests/test_ppm_loopback.c
+++ b/src/systemcmds/tests/test_ppm_loopback.c
@@ -162,7 +162,7 @@ int test_ppm_loopback(int argc, char *argv[])
 
 		/* go and check values */
 		for (unsigned i = 0; (i < servo_count) && (i < sizeof(pwm_values) / sizeof(pwm_values[0])); i++) {
-			if (fabsf(rc_input.values[i] - pwm_values[i]) > 10) {
+			if (abs(rc_input.values[i] - pwm_values[i]) > 10) {
 				warnx("comparison fail: RC: %d, expected: %d", rc_input.values[i], pwm_values[i]);
 				(void)close(servo_fd);
 				return ERROR;


### PR DESCRIPTION
Use of fabsf() for int arg failed for clang. Changed to use abs().

Signed-off-by: Mark Charlebois <charlebm@gmail.com>