### PR TITLE
POSIX: do not error on stack size warning

### DIFF
--- a/src/systemcmds/tests/module.mk
+++ b/src/systemcmds/tests/module.mk
@@ -36,9 +36,13 @@ SRCS			 = test_adc.c \
 
 ifeq ($(PX4_TARGET_OS), nuttx)
 SRCS			+= test_time.c
+
+EXTRACXXFLAGS = -Wframe-larger-than=2500
+else
+EXTRACXXFLAGS =
 endif
 
-EXTRACXXFLAGS = -Wframe-larger-than=2500 -Wno-float-equal
+EXTRACXXFLAGS += -Wno-float-equal
 
 # Flag is only valid for GCC, not clang
 ifneq ($(USE_GCC), 0)


### PR DESCRIPTION
posix build fails on x86_64 with this check enabled.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>