### PR TITLE
POSIX: don't check stack size for position_estimator_inav

### DIFF
--- a/src/modules/position_estimator_inav/module.mk
+++ b/src/modules/position_estimator_inav/module.mk
@@ -42,5 +42,7 @@ SRCS		 	= position_estimator_inav_main.c \
 
 MODULE_STACKSIZE = 1200
 
+ifeq ($(PX4_TARGEGT_OS),nuttx)
 EXTRACFLAGS = -Wframe-larger-than=3800
+endif
 


### PR DESCRIPTION
posix build fails on x86_64 with this check enabled.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>