### PR TITLE
ms5611 creating virtual functions with wrong name

### DIFF
--- a/src/drivers/ms5611/ms5611_i2c.cpp
+++ b/src/drivers/ms5611/ms5611_i2c.cpp
@@ -71,8 +71,8 @@ public:
 	virtual ~MS5611_I2C();
 
 	virtual int	init();
-	virtual int	read(unsigned offset, void *data, unsigned count);
-	virtual int	ioctl(unsigned operation, unsigned &arg);
+	virtual int	dev_read(unsigned offset, void *data, unsigned count);
+	virtual int	dev_ioctl(unsigned operation, unsigned &arg);
 
 #ifdef __PX4_NUTTX
 protected:
@@ -139,7 +139,7 @@ MS5611_I2C::init()
 }
 
 int
-MS5611_I2C::read(unsigned offset, void *data, unsigned count)
+MS5611_I2C::dev_read(unsigned offset, void *data, unsigned count)
 {
 	union _cvt {
 		uint8_t	b[4];
@@ -162,7 +162,7 @@ MS5611_I2C::read(unsigned offset, void *data, unsigned count)
 }
 
 int
-MS5611_I2C::ioctl(unsigned operation, unsigned &arg)
+MS5611_I2C::dev_ioctl(unsigned operation, unsigned &arg)
 {
 	int ret;
 


### PR DESCRIPTION
ms5611 wants to override the firtual functions dev_read() and dev_ioctl()
but is instead defining new virtual functions (read() and ioctl()).

Signed-off-by: Mark Charlebois <charlebm@gmail.com>