### PR TITLE
uORBManager: allocate instance on first use

### DIFF
--- a/src/modules/uORB/module.mk
+++ b/src/modules/uORB/module.mk
@@ -50,15 +50,18 @@ SRCS			= uORBDevices_posix.cpp \
 endif
 
 ifeq ($(PX4_TARGET_OS),posix)
-SRCS += uORBTest_UnitTest.cpp
+SRCS 			+= uORBTest_UnitTest.cpp
 endif
 ifeq ($(PX4_TARGET_OS),posix-arm)
-SRCS += uORBTest_UnitTest.cpp
+SRCS 			+= uORBTest_UnitTest.cpp
+endif
+
+ifneq ($(PX4_TARGET_OS),qurt)
+SRCS 			+= Publication.cpp \
+			   Subscription.cpp
 endif
 
 SRCS	+= 		  objects_common.cpp \
-			  Publication.cpp \
-			  Subscription.cpp \
 			  uORBUtils.cpp \
 			  uORB.cpp \
 			  uORBMain.cpp

--- a/src/modules/uORB/uORBManager.hpp
+++ b/src/modules/uORB/uORBManager.hpp
@@ -346,7 +346,7 @@ private: // class methods
 	);
 
 private: // data members
-	static Manager _Instance;
+	static Manager *_Instance;
 	// the communicator channel instance.
 	uORBCommunicator::IChannel *_comm_channel;
 	ORBSet _remote_subscriber_topics;

--- a/src/modules/uORB/uORBManager_nuttx.cpp
+++ b/src/modules/uORB/uORBManager_nuttx.cpp
@@ -42,13 +42,17 @@
 
 
 //=========================  Static initializations =================
-uORB::Manager uORB::Manager::_Instance;
+uORB::Manager *uORB::Manager::_Instance = nullptr;
 
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 uORB::Manager *uORB::Manager::get_instance()
 {
-	return &_Instance;
+	if (_Instance == nullptr) {
+		_Instance = new uORB::Manager();
+	}
+
+	return _Instance;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/modules/uORB/uORBManager_posix.cpp
+++ b/src/modules/uORB/uORBManager_posix.cpp
@@ -44,13 +44,17 @@
 
 
 //=========================  Static initializations =================
-uORB::Manager uORB::Manager::_Instance;
+uORB::Manager *uORB::Manager::_Instance = nullptr;
 
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 uORB::Manager *uORB::Manager::get_instance()
 {
-	return &_Instance;
+	if (_Instance == nullptr) {
+		_Instance = new uORB::Manager();
+	}
+
+	return _Instance;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Previously _Instance was statically initialized. Now it is
allocated at first use.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>