### PR TITLE
Set altitude control flag for velocity control

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2637,7 +2637,8 @@ set_control_mode()
 
 		control_mode.flag_control_position_enabled = !offboard_control_mode.ignore_position;
 
-		control_mode.flag_control_altitude_enabled = !offboard_control_mode.ignore_position;
+		control_mode.flag_control_altitude_enabled = !offboard_control_mode.ignore_velocity ||
+			!offboard_control_mode.ignore_position;
 
 		break;
 

--- a/src/platforms/ros/nodes/commander/commander.cpp
+++ b/src/platforms/ros/nodes/commander/commander.cpp
@@ -135,7 +135,8 @@ void Commander::SetOffboardControl(const px4::offboard_control_mode &msg_offboar
 
 	msg_vehicle_control_mode.flag_control_position_enabled = !msg_offboard_control_mode.ignore_position;
 
-	msg_vehicle_control_mode.flag_control_altitude_enabled = !msg_offboard_control_mode.ignore_position;
+	msg_vehicle_control_mode.flag_control_altitude_enabled = !msg_offboard_control_mode.ignore_velocity ||
+		!msg_offboard_control_mode.ignore_position;
 }
 
 void Commander::EvalSwitches(const px4::manual_control_setpointConstPtr &msg,


### PR DESCRIPTION
@LorenzMeier @thomasgubler The only thing missing for velocity control was the right control flag setting, fixes #1856

Tested in SITL. Can anyone test this on a real one?