### PR TITLE
uavcan : start before sensors

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -298,6 +298,10 @@ then
 	if dataman start
 	then
 	fi
+	
+	# UAVCAN (start before sensors so that UAVCAN sensors can interface first)
+	#
+	sh /etc/init.d/rc.uavcan
 
 	#
 	# Sensors System (start before Commander so Preflight checks are properly run)
@@ -490,10 +494,6 @@ then
 			mavlink start -d /dev/ttyS2 -b 57600 -m osd -r 1000
 		fi
 	fi
-
-	# UAVCAN
-	#
-	sh /etc/init.d/rc.uavcan
 
 	#
 	# Logging


### PR DESCRIPTION
Allows uavcan interfaced sensors (e.g mag) to work as primary.

This probably needs to go into release as well if we want a proper UAVCAN setup running on it.

Tested.