### PR TITLE
Moved ADC channel definitions to the board_config.h file. This way ne…

### DIFF
--- a/src/drivers/boards/aerocore/board_config.h
+++ b/src/drivers/boards/aerocore/board_config.h
@@ -112,6 +112,13 @@ __BEGIN_DECLS
 #define GPIO_GPIO10_OUTPUT	(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTB|GPIO_PIN5)
 #define GPIO_GPIO11_OUTPUT	(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTB|GPIO_PIN8)
 
+/*
+ * ADC channels
+ *
+ * These are the channel numbers of the ADCs of the microcontroller that can be used by the Px4 Firmware in the adc driver
+ */
+#define ADC_CHANNELS (1 << 10) | (1 << 11) | (1 << 12) | (1 << 13)
+
 /* PWM
  *
  * Eight PWM outputs are configured.

--- a/src/drivers/boards/px4fmu-v1/board_config.h
+++ b/src/drivers/boards/px4fmu-v1/board_config.h
@@ -120,6 +120,13 @@ __BEGIN_DECLS
 #define PX4_I2C_OBDEV_PX4IO_BL	0x18
 #define PX4_I2C_OBDEV_PX4IO	0x1a
 
+/*
+ * ADC channels
+ *
+ * These are the channel numbers of the ADCs of the microcontroller that can be used by the Px4 Firmware in the adc driver
+ */
+#define ADC_CHANNELS (1 << 10) | (1 << 11) | (1 << 12) | (1 << 13)
+
 /* User GPIOs
  *
  * GPIO0-1 are the buffered high-power GPIOs.

--- a/src/drivers/boards/px4fmu-v2/board_config.h
+++ b/src/drivers/boards/px4fmu-v2/board_config.h
@@ -146,6 +146,13 @@ __BEGIN_DECLS
 #define PX4_I2C_OBDEV_LED	0x55
 #define PX4_I2C_OBDEV_HMC5883	0x1e
 
+/*
+ * ADC channels
+ *
+ * These are the channel numbers of the ADCs of the microcontroller that can be used by the Px4 Firmware in the adc driver
+ */
+#define ADC_CHANNELS (1 << 2) | (1 << 3) | (1 << 4) | (1 << 10) | (1 << 11) | (1 << 12) | (1 << 13) | (1 << 14) | (1 << 15)
+
 /* User GPIOs
  *
  * GPIO0-5 are the PWM servo outputs.

--- a/src/drivers/stm32/adc/adc.cpp
+++ b/src/drivers/stm32/adc/adc.cpp
@@ -410,19 +410,8 @@ int
 adc_main(int argc, char *argv[])
 {
 	if (g_adc == nullptr) {
-#ifdef CONFIG_ARCH_BOARD_PX4FMU_V1
-		/* XXX this hardcodes the default channel set for PX4FMUv1 - should be configurable */
-		g_adc = new ADC((1 << 10) | (1 << 11) | (1 << 12) | (1 << 13));
-#endif
-#ifdef CONFIG_ARCH_BOARD_PX4FMU_V2
-		/* XXX this hardcodes the default channel set for PX4FMUv2 - should be configurable */
-		g_adc = new ADC((1 << 2) | (1 << 3) | (1 << 4) | 
-			(1 << 10) | (1 << 11) | (1 << 12) | (1 << 13) | (1 << 14) | (1 << 15));
-#endif
-#ifdef CONFIG_ARCH_BOARD_AEROCORE
-		/* XXX this hardcodes the default channel set for AeroCore - should be configurable */
-		g_adc = new ADC((1 << 10) | (1 << 11) | (1 << 12) | (1 << 13));
-#endif
+        /* XXX this hardcodes the default channel set for the board in board_config.h - should be configurable */
+        g_adc = new ADC(ADC_CHANNELS);
 
 		if (g_adc == nullptr)
 			errx(1, "couldn't allocate the ADC driver");


### PR DESCRIPTION
…w boards with different ADC channel sets can still use the Px4 adc.c driver; the setup of the ADC channels is determined by the board-specific board_config.h file instead of hard_coded #ifdef precompiler commands.