### PR TITLE
Moved ADC channel defines for battery voltage, battery current, and a…

### DIFF
--- a/src/drivers/boards/aerocore/board_config.h
+++ b/src/drivers/boards/aerocore/board_config.h
@@ -119,6 +119,11 @@ __BEGIN_DECLS
  */
 #define ADC_CHANNELS (1 << 10) | (1 << 11) | (1 << 12) | (1 << 13)
 
+// ADC defines to be used in sensors.cpp to read from a particular channel
+#define ADC_BATTERY_VOLTAGE_CHANNEL	10
+#define ADC_BATTERY_CURRENT_CHANNEL	((uint8_t)(-1))
+#define ADC_AIRSPEED_VOLTAGE_CHANNEL	((uint8_t)(-1))
+
 /* PWM
  *
  * Eight PWM outputs are configured.

--- a/src/drivers/boards/px4fmu-v1/board_config.h
+++ b/src/drivers/boards/px4fmu-v1/board_config.h
@@ -127,6 +127,11 @@ __BEGIN_DECLS
  */
 #define ADC_CHANNELS (1 << 10) | (1 << 11) | (1 << 12) | (1 << 13)
 
+// ADC defines to be used in sensors.cpp to read from a particular channel
+#define ADC_BATTERY_VOLTAGE_CHANNEL	10
+#define ADC_BATTERY_CURRENT_CHANNEL	((uint8_t)(-1))
+#define ADC_AIRSPEED_VOLTAGE_CHANNEL	11
+
 /* User GPIOs
  *
  * GPIO0-1 are the buffered high-power GPIOs.

--- a/src/drivers/boards/px4fmu-v2/board_config.h
+++ b/src/drivers/boards/px4fmu-v2/board_config.h
@@ -153,6 +153,12 @@ __BEGIN_DECLS
  */
 #define ADC_CHANNELS (1 << 2) | (1 << 3) | (1 << 4) | (1 << 10) | (1 << 11) | (1 << 12) | (1 << 13) | (1 << 14) | (1 << 15)
 
+// ADC defines to be used in sensors.cpp to read from a particular channel
+#define ADC_BATTERY_VOLTAGE_CHANNEL	2
+#define ADC_BATTERY_CURRENT_CHANNEL	3
+#define ADC_5V_RAIL_SENSE		4
+#define ADC_AIRSPEED_VOLTAGE_CHANNEL	15
+
 /* User GPIOs
  *
  * GPIO0-5 are the PWM servo outputs.

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -46,6 +46,8 @@
  * @author Anton Babushkin <anton@px4.io>
  */
 
+#include <board_config.h>
+
 #include <px4_config.h>
 #include <px4_tasks.h>
 #include <px4_posix.h>
@@ -111,26 +113,10 @@
  * IO:
  * IN4 - servo supply rail
  * IN5 - analog RSSI
+ *
+ * The channel definitions (e.g., ADC_BATTERY_VOLTAGE_CHANNEL, ADC_BATTERY_CURRENT_CHANNEL, and ADC_AIRSPEED_VOLTAGE_CHANNEL) are defined in board_config.h
  */
 
-#ifdef CONFIG_ARCH_BOARD_PX4FMU_V1
-#define ADC_BATTERY_VOLTAGE_CHANNEL	10
-#define ADC_BATTERY_CURRENT_CHANNEL	((uint8_t)(-1))
-#define ADC_AIRSPEED_VOLTAGE_CHANNEL	11
-#endif
-
-#ifdef CONFIG_ARCH_BOARD_PX4FMU_V2
-#define ADC_BATTERY_VOLTAGE_CHANNEL	2
-#define ADC_BATTERY_CURRENT_CHANNEL	3
-#define ADC_5V_RAIL_SENSE		4
-#define ADC_AIRSPEED_VOLTAGE_CHANNEL	15
-#endif
-
-#ifdef CONFIG_ARCH_BOARD_AEROCORE
-#define ADC_BATTERY_VOLTAGE_CHANNEL	10
-#define ADC_BATTERY_CURRENT_CHANNEL	((uint8_t)(-1))
-#define ADC_AIRSPEED_VOLTAGE_CHANNEL	((uint8_t)(-1))
-#endif
 
 #define BATT_V_LOWPASS			0.001f
 #define BATT_V_IGNORE_THRESHOLD		2.5f


### PR DESCRIPTION
…irspeed voltage from sensors.cpp to board_config.h. This allows for better portability of code from one board to another, since it removes the hardcoded #ifdef sections from the Px4 sensors code.

This complements my change that I made last week that you merged in today (Friday 17 July 2015).