### PR TITLE
Update NuttX submodule to last_master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = git://github.com/mavlink/c_library.git
 [submodule "NuttX"]
 	path = NuttX
-	url = git://github.com/PX4/NuttX.git
+	url = git://github.com/PX4/PX4NuttX.git
 [submodule "libuavcan"]
 	path = src/lib/uavcan
 	url = git://github.com/UAVCAN/libuavcan.git

--- a/Tools/check_submodules.sh
+++ b/Tools/check_submodules.sh
@@ -25,8 +25,7 @@ if [ -d NuttX/nuttx ];
 		exit 1
 	fi
 else
-	git submodule init;
-	git submodule update;
+	git submodule update --init --recursive
 fi
 
 
@@ -47,8 +46,7 @@ if [ -d mavlink/include/mavlink/v1.0 ];
 		exit 1
 	fi
 else
-	git submodule init;
-	git submodule update;
+	git submodule update --init --recursive
 fi
 
 
@@ -70,8 +68,7 @@ then
 		exit 1
 	fi
 else
-	git submodule init;
-	git submodule update;
+	git submodule update --init --recursive
 fi
 
 if [ -d src/lib/eigen ]
@@ -92,8 +89,7 @@ then
 		exit 1
 	fi
 else
-	git submodule init;
-	git submodule update;
+	git submodule update --init --recursive
 fi
 
 if [ -d Tools/gencpp ]
@@ -114,8 +110,7 @@ then
 		exit 1
 	fi
 else
-	git submodule init;
-	git submodule update;
+	git submodule update --init --recursive
 fi
 
 if [ -d Tools/genmsg ]
@@ -136,8 +131,7 @@ then
 		exit 1
 	fi
 else
-	git submodule init;
-	git submodule update;
+	git submodule update --init --recursive
 fi
 
 exit 0


### PR DESCRIPTION
@LorenzMeier This is prep for moving to the new nuttx repo format. This should have the equivalent code to PX4 Firmware master but NuttX is now submodules 

981a0b1a78c6593be4a001f78a1bb43ebb7a0bc0 NxWidgets (nuttx-6.27-14-g981a0b1)
9859e4bfbdc733c8df5de33563c5e925c0794700 apps (nuttx-6.27-52-g9859e4b)
d1bbc8d925763aa56e2e83f4f498cfe01464a51c misc (nuttx-6.28)
57702669ab9835aa880b294318a84249c6c3ca54 nuttx (nuttx-6.27-274-g5770266)

