### PR TITLE
fixed incorrect return type for bool ORBSet::erase(...)

### DIFF
--- a/src/modules/uORB/ORBSet.hpp
+++ b/src/modules/uORB/ORBSet.hpp
@@ -120,7 +120,7 @@ public:
 			}
 		}
 
-		return nullptr;
+		return false;
 	}
 
 private:


### PR DESCRIPTION
bool ORBSet::erase(...) originally had a return nullptr. It should return a false instead.