### PR TITLE
Fixes stack frame size error when compiling mc_pos_control_m on vagrant

### DIFF
--- a/src/modules/mc_pos_control_multiplatform/module.mk
+++ b/src/modules/mc_pos_control_multiplatform/module.mk
@@ -42,4 +42,4 @@ SRCS		= mc_pos_control_main.cpp \
 		  mc_pos_control.cpp \
 		  mc_pos_control_params.c
 
-EXTRACXXFLAGS = -Wframe-larger-than=1200
+EXTRACXXFLAGS = -Wframe-larger-than=2500


### PR DESCRIPTION
I don't know why the error didn't show up when not compiling on vagrant but on native machine. Maybe different versions of compilers ?

Tested on both native machine and vagrant with sitl. I don't have a pixhawk to testrun it on nuttx right now.