### PR TITLE
EKF memory usage fix

### DIFF
--- a/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
+++ b/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
@@ -1112,7 +1112,7 @@ int AttitudePositionEstimatorEKF::start()
 	_estimator_task = task_spawn_cmd("ekf_att_pos_estimator",
 					 SCHED_DEFAULT,
 					 SCHED_PRIORITY_MAX - 40,
-					 7500,
+					 4800,
 					 (main_t)&AttitudePositionEstimatorEKF::task_main_trampoline,
 					 nullptr);
 

--- a/src/modules/ekf_att_pos_estimator/module.mk
+++ b/src/modules/ekf_att_pos_estimator/module.mk
@@ -42,5 +42,5 @@ SRCS		= ekf_att_pos_estimator_main.cpp \
 		  estimator_22states.cpp \
 		  estimator_utilities.cpp
 
-EXTRACXXFLAGS	= -Weffc++ -Wframe-larger-than=6100
+EXTRACXXFLAGS	= -Weffc++ -Wframe-larger-than=3400
 


### PR DESCRIPTION
The allocated memory was excessive. While still maintaining safeguards this PR reduces the memory footprint significantly.