### PR TITLE
QuRT: Added new drivers and build fixes

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -137,7 +137,6 @@ private:
 	int		_vehicle_status_sub;	/**< vehicle status subscription */
 	int 	_motor_limits_sub;		/**< motor limits subscription */
 
-	orb_advert_t	_att_sp_pub;			/**< attitude setpoint publication */
 	orb_advert_t	_v_rates_sp_pub;		/**< rate setpoint publication */
 	orb_advert_t	_actuators_0_pub;		/**< attitude actuator controls publication */
 	orb_advert_t	_controller_status_pub;	/**< controller status publication */
@@ -169,8 +168,6 @@ private:
 	math::Vector<3>		_att_control;	/**< attitude control vector */
 
 	math::Matrix<3, 3>  _I;				/**< identity matrix */
-
-	bool	_reset_yaw_sp;			/**< reset yaw setpoint flag */
 
 	struct {
 		param_t roll_p;
@@ -315,7 +312,6 @@ MulticopterAttitudeControl::MulticopterAttitudeControl() :
 	_vehicle_status_sub(-1),
 
 /* publications */
-	_att_sp_pub(nullptr),
 	_v_rates_sp_pub(nullptr),
 	_actuators_0_pub(nullptr),
 	_controller_status_pub(nullptr),

--- a/src/modules/position_estimator_inav/position_estimator_inav_main.c
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.c
@@ -46,7 +46,6 @@
 #include <fcntl.h>
 #include <string.h>
 #include <px4_config.h>
-#include <sys/prctl.h>
 #include <termios.h>
 #include <math.h>
 #include <float.h>

--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -115,10 +115,8 @@ int Simulator::start(int argc, char *argv[])
 		drv_led_start();
 		if (argv[2][1] == 's') {
 			_instance->initializeSensorData();
-#ifndef __PX4_QURT
 			// Update sensor data
 			_instance->pollForMAVLinkMessages(false);
-#endif
 		} else {
 			// Update sensor data
 			_instance->pollForMAVLinkMessages(true);

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -210,16 +210,17 @@ private:
 	_baro_pub(nullptr),
 	_gyro_pub(nullptr),
 	_mag_pub(nullptr),
-	_initialized(false),
+	_initialized(false)
 #ifndef __PX4_QURT
+	,
 	_rc_channels_pub(nullptr),
 	_actuator_outputs_sub(-1),
 	_vehicle_attitude_sub(-1),
 	_manual_sub(-1),
-	_rc_input{},
-	_actuators{},
-	_attitude{},
-	_manual{}
+	_rc_input(),
+	_actuators(),
+	_attitude(),
+	_manual()
 #endif
 	{}
 	~Simulator() { _instance=NULL; }
@@ -272,5 +273,7 @@ private:
 	void update_gps(mavlink_hil_gps_t *gps_sim);
 	static void *sending_trampoline(void *);
 	void send();
+#else
+	void pollForMAVLinkMessages(bool publish) {}
 #endif
 };

--- a/src/platforms/px4_time.h
+++ b/src/platforms/px4_time.h
@@ -10,9 +10,7 @@
 
 #elif defined(__PX4_QURT)
 
-#include <sys/timespec.h>
-
-#define CLOCK_REALTIME 1
+#include <dspal_time.h>
 
 __BEGIN_DECLS
 

--- a/src/platforms/px4_workqueue.h
+++ b/src/platforms/px4_workqueue.h
@@ -35,6 +35,8 @@
 
 #pragma once
 
+#include <px4_tasks.h>
+
 #if defined(__PX4_ROS)
 #error "Work queue not supported on ROS"
 #elif defined(__PX4_NUTTX)
@@ -54,7 +56,7 @@ __BEGIN_DECLS
 
 struct wqueue_s
 {
-  pid_t             pid; /* The task ID of the worker thread */
+  px4_task_t        pid; /* The task ID of the worker thread */
   struct dq_queue_s q;   /* The queue of pending work */
 };
 

--- a/src/platforms/qurt/drivers/mpu9x50/module.mk
+++ b/src/platforms/qurt/drivers/mpu9x50/module.mk
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015 MArk Charlebois. All rights reserved.
+#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,19 +32,17 @@
 ############################################################################
 
 #
-# Makefile to build simulator 
+# Makefile to build the MPU9x50 driver.
 #
 
-MODULE_COMMAND	= simulator
+MODULE_COMMAND	= mpu9x50
 
-SRCS		= simulator.cpp
+SRCS		+= mpu9x50_main.cpp
+SRCS		+= mpu9x50_params.c
 
-ifneq ($(PX4_TARGET_OS), qurt)
-SRCS		+= simulator_mavlink.cpp
-endif
+MODULE_STACKSIZE	= 1200
 
-INCLUDE_DIRS	+= $(MAVLINK_SRC)/include/mavlink
+EXTRACXXFLAGS	= -Weffc++
 
-EXTRACXXFLAGS	= -Weffc++ -Wno-attributes -Wno-packed
+MAXOPTIMIZATION	= -Os
 
-EXTRACFLAGS	= -Wno-packed

--- a/src/platforms/qurt/drivers/mpu9x50/mpu9x50_main.cpp
+++ b/src/platforms/qurt/drivers/mpu9x50/mpu9x50_main.cpp
@@ -1,0 +1,591 @@
+/****************************************************************************
+ *
+ * Copyright (C) 2015 Mark Charlebois. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <stdint.h>
+
+#include <px4_tasks.h>
+#include <px4_log.h>
+#include <px4_getopt.h>
+
+#include <uORB/uORB.h>
+#include <drivers/drv_accel.h>
+#include <drivers/drv_gyro.h>
+#include <drivers/drv_mag.h>
+#include <semaphore.h>
+#include <dev_fs_lib.h>
+#include <mpu9x50.h>
+
+/** driver 'main' command */
+extern "C" { __EXPORT int mpu9x50_main(int argc, char *argv[]); }
+
+// TODO: need to load this from parameter file
+#define SPI_INT_GPIO 65  // GPIO pin for Data Ready Interrupt
+namespace mpu9x50
+{
+
+/** SPI device path that mpu9x50 is connected to */
+static const char* _device = NULL;
+
+/** flag indicating if mpu9x50 app is running */
+static bool _is_running = false;
+/** flag indicating if measurement thread should exit */
+static bool _task_should_exit = false;
+
+/** handle to the task main thread */
+static px4_task_t _task_handle = -1;
+/** IMU data ready semaphore */
+static sem_t _dri_semaphore;
+
+/** IMU measurement data */
+static struct mpu9x50_data _data;
+
+static orb_advert_t _gyro_pub = nullptr;	/**< gyro data publication */
+static orb_advert_t _accel_pub = nullptr;	/**< accelerameter data publication */
+static orb_advert_t _mag_pub = nullptr;		/**< compass data publication */
+
+static struct gyro_report _gyro;		/**< gyro report */
+static struct accel_report _accel;		/**< accel report */
+static struct mag_report _mag;			/**< mag report */
+static struct gyro_scale _gyro_sc;		/**< gyro scale */
+static struct accel_scale _accel_sc;		/**< accel scale */
+static struct mag_scale _mag_sc;		/**< mag scale */
+
+static enum gyro_lpf_e _gyro_lpf = MPU9X50_GYRO_LPF_20HZ;	/**< gyro lpf enum value */
+static enum acc_lpf_e _accel_lpf = MPU9X50_ACC_LPF_20HZ;	/**< accel lpf enum value */
+static enum gyro_sample_rate_e _imu_sample_rate = MPU9x50_SAMPLE_RATE_500HZ;	/**< IMU sample rate enum */
+
+struct {
+	param_t accel_x_offset;
+	param_t accel_x_scale;
+	param_t accel_y_offset;
+	param_t accel_y_scale;
+	param_t accel_z_offset;
+	param_t accel_z_scale;
+	param_t gyro_x_offset;
+	param_t gyro_x_scale;
+	param_t gyro_y_offset;
+	param_t gyro_y_scale;
+	param_t gyro_z_offset;
+	param_t gyro_z_scale;
+	param_t mag_x_offset;
+	param_t mag_x_scale;
+	param_t mag_y_offset;
+	param_t mag_y_scale;
+	param_t mag_z_offset;
+	param_t mag_z_scale;
+	param_t gyro_lpf_enum;
+	param_t accel_lpf_enum;
+	param_t imu_sample_rate_enum;
+} _params_handles;  /**< parameter handles */
+
+
+/** Print out the usage information */
+static void usage();
+
+/** mpu9x50 start measurement */
+static void start(const char* device);
+
+/** mpu9x50 stop measurement */
+static void stop();
+
+/** task main trampoline function */
+static void	task_main_trampoline(int argc, char *argv[]);
+
+/** mpu9x50 measurement thread primary entry point */
+static void task_main(int argc, char *argv[]);
+/**
+ * create and advertise all publicatoins
+ * @return   true on success, false otherwise
+ */
+static bool create_pubs();
+
+/** update all sensor reports with the latest sensor reading */
+static void update_reports();
+
+/** publish all sensor reports */
+static void publish_reports();
+
+/** update all parameters */
+static void parameters_update();
+
+/** initialize all parameter handles and load the initial parameter values */
+static void parameters_init();
+
+/**
+ * MPU9x50 data ready interrupt service routine
+ * @param[out]	data	address of the mpu9x50 measurement data which
+ *			just becomes ready
+ * @param[out]	context	address of the context data provided by user while
+ *			registering the interrupt servcie routine
+ */
+static void data_ready_isr(struct mpu9x50_data* data, void* context);
+
+void data_ready_isr(struct mpu9x50_data* data, void* context)
+{
+	memcpy(&_data, data, sizeof(struct mpu9x50_data));
+	sem_post(&_dri_semaphore);
+}
+
+void parameters_update()
+{
+	PX4_DEBUG("mpu9x50_parameters_update");
+	float v;
+	int v_int;
+
+	// accel params
+	if (param_get(_params_handles.accel_x_offset, &v) == 0)
+	{
+		_accel_sc.x_offset = v;
+		PX4_DEBUG("mpu9x50_parameters_update accel_x_offset %f", v);
+	}
+
+	if (param_get(_params_handles.accel_x_scale, &v) == 0)
+	{
+		_accel_sc.x_scale  = v;
+		PX4_DEBUG("mpu9x50_parameters_update accel_x_scale %f", v);
+	}
+
+	if (param_get(_params_handles.accel_y_offset, &v) == 0)
+	{
+		_accel_sc.y_offset  = v;
+		PX4_DEBUG("mpu9x50_parameters_update accel_y_offset %f", v);
+	}
+
+	if (param_get(_params_handles.accel_y_scale, &v) == 0)
+	{
+		_accel_sc.y_scale  = v;
+		PX4_DEBUG("mpu9x50_parameters_update accel_y_scale %f", v);
+	}
+
+	if (param_get(_params_handles.accel_z_offset, &v) == 0)
+	{
+		_accel_sc.z_offset  = v;
+		PX4_DEBUG("mpu9x50_parameters_update accel_z_offset %f", v);
+	}
+
+	if (param_get(_params_handles.accel_z_scale, &v) == 0)
+	{
+		_accel_sc.z_scale  = v;
+		PX4_DEBUG("mpu9x50_parameters_update accel_z_scale %f", v);
+	}
+
+	// gyro params
+	if (param_get(_params_handles.gyro_x_offset, &v) == 0)
+	{
+		_gyro_sc.x_offset = v;
+		PX4_DEBUG("mpu9x50_parameters_update gyro_x_offset %f", v);
+	}
+
+	if (param_get(_params_handles.gyro_x_scale, &v) == 0)
+	{
+		_gyro_sc.x_scale  = v;
+		PX4_DEBUG("mpu9x50_parameters_update gyro_x_scale %f", v);
+	}
+
+	if (param_get(_params_handles.gyro_y_offset, &v) == 0)
+	{
+		_gyro_sc.y_offset  = v;
+		PX4_DEBUG("mpu9x50_parameters_update gyro_y_offset %f", v);
+	}
+
+	if (param_get(_params_handles.gyro_y_scale, &v) == 0)
+	{
+		_gyro_sc.y_scale  = v;
+		PX4_DEBUG("mpu9x50_parameters_update gyro_y_scale %f", v);
+	}
+
+	if (param_get(_params_handles.gyro_z_offset, &v) == 0)
+	{
+		_gyro_sc.z_offset  = v;
+		PX4_DEBUG("mpu9x50_parameters_update gyro_z_offset %f", v);
+	}
+
+	if (param_get(_params_handles.gyro_z_scale, &v) == 0)
+	{
+		_gyro_sc.z_scale  = v;
+		PX4_DEBUG("mpu9x50_parameters_update gyro_z_scale %f", v);
+	}
+
+	// mag params
+	if (param_get(_params_handles.mag_x_offset, &v) == 0)
+	{
+		_mag_sc.x_offset = v;
+		PX4_DEBUG("mpu9x50_parameters_update mag_x_offset %f", v);
+	}
+
+	if (param_get(_params_handles.mag_x_scale, &v) == 0)
+	{
+		_mag_sc.x_scale  = v;
+		PX4_DEBUG("mpu9x50_parameters_update mag_x_scale %f", v);
+	}
+
+	if (param_get(_params_handles.mag_y_offset, &v) == 0)
+	{
+		_mag_sc.y_offset  = v;
+		PX4_DEBUG("mpu9x50_parameters_update mag_y_offset %f", v);
+	}
+
+	if (param_get(_params_handles.mag_y_scale, &v) == 0)
+	{
+		_mag_sc.y_scale  = v;
+		PX4_DEBUG("mpu9x50_parameters_update mag_y_scale %f", v);
+	}
+
+	if (param_get(_params_handles.mag_z_offset, &v) == 0)
+	{
+		_mag_sc.z_offset  = v;
+		PX4_DEBUG("mpu9x50_parameters_update mag_z_offset %f", v);
+	}
+
+	if (param_get(_params_handles.mag_z_scale, &v) == 0)
+	{
+		_mag_sc.z_scale  = v;
+		PX4_DEBUG("mpu9x50_parameters_update mag_z_scale %f", v);
+	}
+
+	// LPF params
+	if (param_get(_params_handles.gyro_lpf_enum, &v_int) == 0)
+	{
+		if (v_int >= NUM_MPU9X50_GYRO_LPF) {
+			PX4_WARN("invalid gyro_lpf_enum %d use default %d", v_int, _gyro_lpf);
+		}
+		else {
+			_gyro_lpf = (enum gyro_lpf_e)v_int;
+			PX4_DEBUG("mpu9x50_parameters_update gyro_lpf_enum %d", _gyro_lpf);
+		}
+	}
+
+	if (param_get(_params_handles.accel_lpf_enum, &v_int) == 0)
+	{
+		if (v_int >= NUM_MPU9X50_ACC_LPF) {
+			PX4_WARN("invalid accel_lpf_enum %d use default %d", v_int, _accel_lpf);
+		}
+		else {
+			_accel_lpf = (enum acc_lpf_e)v_int;
+			PX4_DEBUG("mpu9x50_parameters_update accel_lpf_enum %d", _accel_lpf);
+		}
+	}
+
+	if (param_get(_params_handles.imu_sample_rate_enum, &v_int) == 0)
+	{
+		if (v_int >= NUM_MPU9X50_SAMPLE_RATE) {
+			PX4_WARN("invalid imu_sample_rate %d use default %d", v_int, _imu_sample_rate);
+		}
+		else {
+			_imu_sample_rate = (enum gyro_sample_rate_e)v_int;
+			PX4_DEBUG("mpu9x50_parameters_update imu_sample_rate %d", _imu_sample_rate);
+		}
+	}
+}
+
+void parameters_init()
+{
+	_params_handles.accel_x_offset	=	param_find("CAL_ACC0_XOFF");
+	_params_handles.accel_x_scale		=	param_find("CAL_ACC0_XSCALE");
+	_params_handles.accel_y_offset	=	param_find("CAL_ACC0_YOFF");
+	_params_handles.accel_y_scale		=	param_find("CAL_ACC0_YSCALE");
+	_params_handles.accel_z_offset	=	param_find("CAL_ACC0_ZOFF");
+	_params_handles.accel_z_scale		=	param_find("CAL_ACC0_ZSCALE");
+
+	_params_handles.gyro_x_offset		=	param_find("CAL_GYRO0_XOFF");
+	_params_handles.gyro_x_scale		=	param_find("CAL_GYRO0_XSCALE");
+	_params_handles.gyro_y_offset		=	param_find("CAL_GYRO0_YOFF");
+	_params_handles.gyro_y_scale		=	param_find("CAL_GYRO0_YSCALE");
+	_params_handles.gyro_z_offset		=	param_find("CAL_GYRO0_ZOFF");
+	_params_handles.gyro_z_scale		=	param_find("CAL_GYRO0_ZSCALE");
+
+	_params_handles.mag_x_offset		=	param_find("CAL_MAG0_XOFF");
+	_params_handles.mag_x_scale			=	param_find("CAL_MAG0_XSCALE");
+	_params_handles.mag_y_offset		=	param_find("CAL_MAG0_YOFF");
+	_params_handles.mag_y_scale			=	param_find("CAL_MAG0_YSCALE");
+	_params_handles.mag_z_offset		=	param_find("CAL_MAG0_ZOFF");
+	_params_handles.mag_z_scale			=	param_find("CAL_MAG0_ZSCALE");
+
+	_params_handles.gyro_lpf_enum		=	param_find("MPU_GYRO_LPF_ENUM");
+	_params_handles.accel_lpf_enum	=	param_find("MPU_ACC_LPF_ENUM");
+
+	_params_handles.imu_sample_rate_enum	=	param_find("MPU_SAMPLE_RATE_ENUM");
+
+	parameters_update();
+}
+
+bool create_pubs()
+{
+	// initialize the reports
+	memset(&_gyro, 0, sizeof(struct gyro_report));
+	memset(&_accel, 0, sizeof(struct accel_report));
+	memset(&_mag, 0, sizeof(struct mag_report));
+
+	_gyro_pub = orb_advertise(ORB_ID(sensor_gyro), &_gyro);
+	if (_gyro_pub == nullptr) {
+		PX4_WARN("failed to advertise sensor_gyro topic");
+		return false;
+	}
+
+	_accel_pub = orb_advertise(ORB_ID(sensor_accel), &_accel);
+	if (_accel_pub == nullptr) {
+		PX4_WARN("failed to advertise sensor_accel topic");
+		return false;
+	}
+
+	_mag_pub = orb_advertise(ORB_ID(sensor_mag), &_mag);
+	if (_mag_pub == nullptr) {
+		PX4_WARN("failed to advertise sensor_mag topic");
+		return false;
+	}
+
+	return true;
+}
+
+void update_reports()
+{
+	_gyro.timestamp = _data.timestamp;
+	_gyro.x = ((_data.gyro_raw[0] * _data.gyro_scaling) - _gyro_sc.x_offset) * _gyro_sc.x_scale;
+	_gyro.y = ((_data.gyro_raw[1] * _data.gyro_scaling) - _gyro_sc.y_offset) * _gyro_sc.y_scale;
+	_gyro.z = ((_data.gyro_raw[2] * _data.gyro_scaling) - _gyro_sc.z_offset) * _gyro_sc.z_scale;
+	_gyro.temperature = _data.temperature;
+	_gyro.range_rad_s = _data.gyro_range_rad_s;
+	_gyro.scaling = _data.gyro_scaling;
+	_gyro.x_raw = _data.gyro_raw[0];
+	_gyro.y_raw = _data.gyro_raw[1];
+	_gyro.z_raw = _data.gyro_raw[2];
+	_gyro.temperature_raw = _data.temperature_raw;
+
+	_accel.timestamp = _data.timestamp;
+	_accel.x = ((_data.accel_raw[0] * _data.accel_scaling) - _accel_sc.x_offset) * _accel_sc.x_scale;
+	_accel.y = ((_data.accel_raw[1] * _data.accel_scaling) - _accel_sc.y_offset) * _accel_sc.y_scale;
+	_accel.z = ((_data.accel_raw[2] * _data.accel_scaling) - _accel_sc.z_offset) * _accel_sc.z_scale;
+	_accel.temperature = _data.temperature;
+	_accel.range_m_s2 = _data.accel_range_m_s2;
+	_accel.scaling = _data.accel_scaling;
+	_accel.x_raw = _data.accel_raw[0];
+	_accel.y_raw = _data.accel_raw[1];
+	_accel.z_raw = _data.accel_raw[2];
+	_accel.temperature_raw = _data.temperature_raw;
+
+	if (_data.mag_data_ready) {
+		_mag.timestamp = _data.timestamp;
+		_mag.x = ((_data.mag_raw[0] * _data.mag_scaling) - _mag_sc.x_offset) * _mag_sc.x_scale;
+		_mag.y = ((_data.mag_raw[1] * _data.mag_scaling) - _mag_sc.y_offset) * _mag_sc.y_scale;
+		_mag.z = ((_data.mag_raw[2] * _data.mag_scaling) - _mag_sc.z_offset) * _mag_sc.z_scale;
+		_mag.range_ga = _data.mag_range_ga;
+		_mag.scaling = _data.mag_scaling;
+		_mag.temperature = _data.temperature;
+		_mag.x_raw = _data.mag_raw[0];
+		_mag.y_raw = _data.mag_raw[1];
+		_mag.z_raw = _data.mag_raw[2];
+	}
+}
+
+void publish_reports()
+{
+	if (orb_publish(ORB_ID(sensor_gyro), _gyro_pub, &_gyro) != OK) {
+		PX4_WARN("failed to publish gyro report");
+	}
+	else {
+		//PX4_DEBUG("MPU_GYRO_RAW: %d %d %d", _gyro.x_raw, _gyro.y_raw, _gyro.z_raw)
+		//PX4_DEBUG("MPU_GYRO: %f %f %f", _gyro.x, _gyro.y, _gyro.z)
+	}
+
+	if (orb_publish(ORB_ID(sensor_accel), _accel_pub, &_accel) != OK) {
+		PX4_WARN("failed to publish accel report");
+	}
+	else {
+		//PX4_DEBUG("MPU_ACCEL_RAW: %d %d %d", _accel.x_raw, _accel.y_raw, _accel.z_raw)
+		//PX4_DEBUG("MPU_ACCEL: %f %f %f", _accel.x, _accel.y, _accel.z)
+	}
+
+	if (_data.mag_data_ready) {
+		if (orb_publish(ORB_ID(sensor_mag), _mag_pub, &_mag) != OK) {
+			PX4_WARN("failed to publish mag report");
+		}
+		else {
+			//PX4_DEBUG("MPU_MAG_RAW: %d %d %d", _mag.x_raw, _mag.y_raw, _mag.z_raw)
+			//PX4_DEBUG("MPU_MAG: %f %f %f", _mag.x, _mag.y, _mag.z)
+		}
+	}
+}
+
+void task_main(int argc, char *argv[])
+{
+	PX4_WARN("enter task_main");
+
+	parameters_init();
+
+	// create the mpu9x50 default configuration structure
+	struct mpu9x50_config config = {
+		.gyro_lpf = _gyro_lpf,
+		.acc_lpf  = _accel_lpf,
+		.gyro_fsr = MPU9X50_GYRO_FSR_500DPS,
+		.acc_fsr  = MPU9X50_ACC_FSR_4G,
+		.gyro_sample_rate = _imu_sample_rate,
+		.compass_enabled = true,
+		.compass_sample_rate = MPU9x50_COMPASS_SAMPLE_RATE_100HZ,
+		.spi_dev_path = _device,
+	};
+
+	if (mpu9x50_initialize(&config) != 0) {
+		PX4_WARN("error initializing mpu9x50. Quit!");
+		goto exit;
+	}
+
+	// initialize semaphore
+	sem_init(&_dri_semaphore, 0, 0);
+
+	if (mpu9x50_register_interrupt(SPI_INT_GPIO, &mpu9x50::data_ready_isr, NULL)
+			!= 0) {
+		PX4_WARN("error registering data ready interrupt. Quit!");
+		goto exit;
+	}
+
+	// create all uorb publications
+	if (!create_pubs()) {
+		goto exit;
+	}
+
+	// do IMU measurement periodically
+	while(!_task_should_exit) {
+
+		// wait on the new IMU measurement data
+		sem_wait(&_dri_semaphore);
+
+		// data is ready
+		update_reports();
+
+		// publish all sensor reports
+		publish_reports();
+	}
+
+exit:
+	PX4_WARN("closing mpu9x50");
+	mpu9x50_close();
+}
+
+/** mpu9x50 main entrance */
+void task_main_trampoline(int argc, char *argv[])
+{
+	PX4_WARN("task_main_trampoline");
+	task_main(argc, argv);
+}
+
+void start(const char* device)
+{
+	ASSERT(_task_handle == -1);
+
+	_device = device;
+
+	/* start the task */
+	_task_handle = px4_task_spawn_cmd("mpu9x50_main",
+				       SCHED_DEFAULT,
+				       SCHED_PRIORITY_MAX,
+				       1500,
+				       (px4_main_t)&task_main_trampoline,
+				       nullptr);
+
+	if (_task_handle < 0) {
+		warn("task start failed");
+		return;
+	}
+
+	_is_running = true;
+}
+
+void stop()
+{
+	// TODO: set thread exit signal to terminate the task main thread
+
+	_is_running = false;
+	_device = NULL;
+	_task_handle = -1;
+}
+
+void usage()
+{
+	PX4_WARN("missing command: try 'start', 'stop', 'status'");
+	PX4_WARN("options:");
+	PX4_WARN("    -D device");
+}
+
+}; // namespace mpu9x50
+
+
+int mpu9x50_main(int argc, char *argv[])
+{
+	const char* device = NULL;
+	int ch;
+	int myoptind = 1;
+	const char *myoptarg = NULL;
+
+	// TODO: need to obtain the two parameters from command line arguments.
+	// Should add this feature later
+	device = "/dev/spi-1";
+
+	// Check on required arguments
+	if (device == NULL)
+	{
+		mpu9x50::usage();
+		return 1;
+	}
+
+	const char *verb = argv[1];
+	PX4_WARN("verb = %s", verb);
+	PX4_WARN("result = %d", strcmp(verb, "start"));
+
+	/*
+	 * Start/load the driver.
+	 */
+	if (!strcmp(verb, "start")) {
+		if (mpu9x50::_is_running) {
+			PX4_WARN("mpu9x50 already running");
+			return 1;
+		}
+		mpu9x50::start(device);
+	}
+	else if (!strcmp(verb, "stop")) {
+		if (mpu9x50::_is_running) {
+			PX4_WARN("mpu9x50 is not running");
+			return 1;
+		}
+		mpu9x50::stop();
+	}
+	else if (!strcmp(verb, "status")) {
+		PX4_WARN("mpu9x50 is %s", mpu9x50::_is_running ? "running":"stopped");
+		return 0;
+	}
+	else {
+		mpu9x50::usage();
+		return 1;
+	}
+
+	return 0;
+}

--- a/src/platforms/qurt/drivers/mpu9x50/mpu9x50_params.c
+++ b/src/platforms/qurt/drivers/mpu9x50/mpu9x50_params.c
@@ -1,0 +1,89 @@
+/****************************************************************************
+ *
+ * Copyright (C) 2015 Mark Charlebois. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file mpu9x50_params.c
+ *
+ * Parameters defined by the mpu9x50 driver
+ */
+
+#include <px4_config.h>
+#include <systemlib/param/param.h>
+
+/**
+ * IMU Low pass filter enum value for Gyro
+ *
+ * Acceptable values:
+ *
+ * MPU9X50_GYRO_LPF_250HZ = 0,
+ * MPU9X50_GYRO_LPF_184HZ = 1,
+ * MPU9X50_GYRO_LPF_92HZ = 2,
+ * MPU9X50_GYRO_LPF_41HZ = 3,
+ * MPU9X50_GYRO_LPF_20HZ = 4 (default),
+ * MPU9X50_GYRO_LPF_10HZ = 5,
+ * MPU9X50_GYRO_LPF_5HZ = 6,
+ * MPU9X50_GYRO_LPF_3600HZ_NOLPF = 7,
+ *
+ * @group MPU9x50 Configuration
+ */
+PARAM_DEFINE_INT32(MPU_GYRO_LPF_ENUM, 4);
+
+/**
+ * IMU Low pass filter enum value for Accelerometer
+ *
+ * Acceptable values:
+ *
+ *  MPU9X50_ACC_LPF_460HZ = 0,
+ *  MPU9X50_ACC_LPF_184HZ = 1,
+ *  MPU9X50_ACC_LPF_92HZ = 2,
+ *  MPU9X50_ACC_LPF_41HZ = 3,
+ *  MPU9X50_ACC_LPF_20HZ = 4 (default),
+ *  MPU9X50_ACC_LPF_10HZ = 5,
+ *  MPU9X50_ACC_LPF_5HZ = 6,
+ *  MPU9X50_ACC_LPF_460HZ_NOLPF = 7,
+ *
+ * @group MPU9x50 Configuration
+ */
+PARAM_DEFINE_INT32(MPU_ACC_LPF_ENUM, 4);
+
+/**
+ * IMU sample rate in Hz
+ * acceptable values:
+ * MPU9x50_SAMPLE_RATE_100HZ = 0,
+ * MPU9x50_SAMPLE_RATE_200HZ,
+ * MPU9x50_SAMPLE_RATE_500HZ, (default)
+ * MPU9x50_SAMPLE_RATE_1000HZ,
+ *
+ * @group MPU9x50 Configuration
+ */
+PARAM_DEFINE_INT32(MPU_SAMPLE_RATE_ENUM, 2);

--- a/src/platforms/qurt/drivers/uart_esc/module.mk
+++ b/src/platforms/qurt/drivers/uart_esc/module.mk
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015 MArk Charlebois. All rights reserved.
+#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,19 +32,15 @@
 ############################################################################
 
 #
-# Makefile to build simulator 
+# Makefile to build the UART_ESC driver.
 #
 
-MODULE_COMMAND	= simulator
+MODULE_COMMAND	= uart_esc
 
-SRCS		= simulator.cpp
+SRCS		= uart_esc_main.cpp
 
-ifneq ($(PX4_TARGET_OS), qurt)
-SRCS		+= simulator_mavlink.cpp
-endif
+MODULE_STACKSIZE	= 1200
 
-INCLUDE_DIRS	+= $(MAVLINK_SRC)/include/mavlink
+EXTRACXXFLAGS	= -Weffc++
 
-EXTRACXXFLAGS	= -Weffc++ -Wno-attributes -Wno-packed
-
-EXTRACFLAGS	= -Wno-packed
+MAXOPTIMIZATION	= -Os

--- a/src/platforms/qurt/drivers/uart_esc/uart_esc_main.cpp
+++ b/src/platforms/qurt/drivers/uart_esc/uart_esc_main.cpp
@@ -1,0 +1,424 @@
+/****************************************************************************
+*
+* Copyright (c) 2015 Mark Charlebois. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+*
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+* 3. Neither the name PX4 nor the names of its contributors may be
+*    used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+* ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*
+****************************************************************************/
+
+#include <stdint.h>
+
+#include <px4_tasks.h>
+#include <px4_getopt.h>
+#include <px4_posix.h>
+#include <errno.h>
+
+#include <uORB/uORB.h>
+#include <uORB/topics/actuator_controls.h>
+#include <uORB/topics/actuator_armed.h>
+#include <uORB/topics/actuator_outputs.h>
+#include <uORB/topics/parameter_update.h>
+
+#include <drivers/drv_hrt.h>
+#include <drivers/drv_mixer.h>
+#include <systemlib/mixer/mixer.h>
+#include <systemlib/param/param.h>
+#include <uart_esc.h>
+
+/* driver 'main' command */
+extern "C" { __EXPORT int uart_esc_main(int argc, char *argv[]); }
+
+namespace uart_esc
+{
+	volatile bool _task_should_exit = false; // flag indicating if uart_esc task should exit
+	static const char* _device = NULL;       // SPI device path that uart_esc is connected to
+	static bool _is_running = false;         // flag indicating if uart_esc app is running
+	static px4_task_t _task_handle = -1;     // handle to the task main thread
+	static struct esc_feedback_s _feedback;  // esc feedback
+	void uart_esc_rotate_motors(int* motor_rpm,int num_rotors); // motor re-mapping
+
+	// subscriptions
+	int		_controls_sub;
+	int		_armed_sub;
+	int		_param_sub;
+
+	// publications
+	orb_advert_t	_outputs_pub;
+
+	// topic structures
+	actuator_controls_s     _controls;
+	actuator_armed_s	_armed;
+	parameter_update_s      _param_update;
+	actuator_outputs_s      _outputs;
+
+	/** Print out the usage information */
+	static void usage();
+
+	/** uart_esc start */
+	static void start(const char* device);
+
+	/** uart_esc stop */
+	static void stop();
+
+	/** task main trampoline function */
+	static void	task_main_trampoline(int argc, char *argv[]);
+
+	/** uart_esc thread primary entry point */
+	static void task_main(int argc, char *argv[]);
+
+	/** mixer initialization */
+	static MultirotorMixer* mixer;
+	static int initialize_mixer(const char* mixer_filename);
+	static int mixer_control_callback(uintptr_t handle, uint8_t control_group, uint8_t control_index, float &input);
+	unsigned int _num_mixer_outputs;
+
+int mixer_control_callback(uintptr_t handle,
+			 uint8_t control_group,
+			 uint8_t control_index,
+			 float &input)
+{
+	const actuator_controls_s *controls = (actuator_controls_s *)handle;
+
+	input = controls[control_group].control[control_index];
+
+	return 0;
+}
+
+
+int initialize_mixer(const char* mixer_filename)
+{
+	int mixer_initialized = -1;
+
+#ifndef QURT_FILE_READ_SUPPORTED
+	static const char *buf=
+		/**
+                Multirotor mixer for Eagle
+		==========================
+		This buffer defines a single mixer for a quadrotor in the X configuration.
+		All controls are mixed 100%.
+		*/
+		"R: 4x 10000 10000 10000 0\n"
+		/**
+		Gimbal / payload mixer for last four channels
+		---------------------------------------------"
+		*/
+		"M: 1\n"
+		"O: 10000 10000 0 -10000 10000\n"
+		"S: 0 4 10000 10000 0 -10000 10000\n"
+		"M: 1\n"
+		"O: 10000 10000 0 -10000 10000\n"
+		"S: 0 5 10000 10000 0 -10000 10000\n"
+		"M: 1\n"
+		"O: 10000 10000 0 -10000 10000\n"
+		"S: 0 6 10000 10000 0 -10000 10000\n"
+		"M: 1\n"
+		"O: 10000 10000 0 -10000 10000\n"
+		"S: 0 7 10000 10000 0 -10000 10000\n";
+	unsigned int buflen = strlen(buf);
+	_num_mixer_outputs  = 4;
+
+#else
+	// This is the intended way to read the charater description of the mixer, and should be re-enabled
+	// when file reading is supported
+	int fd_load = open(mixer_filename, O_RDONLY, 0);
+	char buf[512];
+	unsigned int buflen = sizeof(buf);
+
+	if(fd_load != -1)
+	{
+		int nRead = read(fd_load, buf, buflen);
+		if(nRead > 0)
+		{
+			if(mixer_load_from_buf(buf, nRead))
+			{
+				PX4_INFO("Successfully initialized mixer from config file in /mnt/persist/flightparams/");
+				mixer_initialized = 1;
+			}
+		}
+		close(fd_load);
+	}
+	if(!mixer_initialized)
+	{
+		float pitch_scale = 1;
+		float yaw_scale = 1;
+		float deadband = 0;
+		if(!mixer_initialize_quad_x(roll_scale, pitch_scale, yaw_scale, deadband))
+		{
+			PX4_ERR("mixer initialization failed");
+			mixer_initialized = -1;
+			return mixer_initialized;
+		}
+		PX4_WARN("mixer config file not found, successfully initialized default quad x mixer");
+		mixer_initialized = true;
+	}
+#endif
+
+	mixer = MultirotorMixer::from_text(mixer_control_callback, (uintptr_t)&_controls, buf, buflen);
+	if(!(mixer == nullptr)) mixer_initialized = true;
+	return mixer_initialized;
+}
+
+/**
+* Rotate the motor rpm values based on the motor mappings configuration stored
+* in motor_mapping
+*/
+void uart_esc_rotate_motors(int* motor_rpm,int num_rotors)
+{
+	ASSERT(num_rotors==4);
+	int i;
+	int motor_mapping[4] = {2,4,1,3};
+	int motor_rpm_copy[4];
+
+	memcpy(motor_rpm_copy, motor_rpm, sizeof(int)*num_rotors);
+
+	for (i = 0; i < num_rotors; i++)
+	{
+		// motor_rpm[i] = motor_rpm_copy[motor_mapping[i]-1];
+		motor_rpm[motor_mapping[i]-1] = motor_rpm_copy[i];
+	}
+}
+
+void task_main(int argc, char *argv[])
+{
+	PX4_INFO("enter task_main");
+
+	_outputs_pub = nullptr;
+
+	// Hard coded options for now
+	enum esc_model_t model = ESC_200QX;
+	int baud_rate          = 250000;
+
+	UartEsc* esc = UartEsc::get_instance();
+	if (esc == nullptr)
+	{
+		PX4_ERR("failed to new UartEsc instance");
+		return;
+	}
+	else if (esc->initialize(model, _device, baud_rate) < 0)
+	{
+		PX4_ERR("failed to initialize UartEsc");
+	}
+	else
+	{
+		// Subscribe for orb topics
+		_controls_sub = orb_subscribe(ORB_ID(actuator_controls_0)); // single group for now
+		_armed_sub    = orb_subscribe(ORB_ID(actuator_armed));
+		_param_sub    = orb_subscribe(ORB_ID(parameter_update));
+
+		// initialize publication structures
+		memset(&_outputs, 0, sizeof(_outputs));
+
+		// set up poll topic and limit poll interval
+		px4_pollfd_struct_t fds[1];
+		fds[0].fd     = _controls_sub;
+		fds[0].events = POLLIN;
+		//orb_set_interval(_controls_sub, 10);  // max actuator update period, ms
+
+		// set up mixer
+		const char* mixer_filename = "/mnt/persist/flightparams/mixer_config.txt";
+		if(initialize_mixer(mixer_filename) < 0)
+		{
+			PX4_ERR("Mixer initialization failed.");
+			_task_should_exit = true;
+		}
+
+		// Main loop
+		while(!_task_should_exit)
+		{
+			int pret = px4_poll(&fds[0], (sizeof(fds) / sizeof(fds[0])), 100);
+
+			/* timed out - periodic check for _task_should_exit */
+			if (pret == 0)
+				continue;
+
+			/* this is undesirable but not much we can do - might want to flag unhappy status */
+			if (pret < 0) {
+				PX4_WARN("poll error %d, %d", pret, errno);
+				/* sleep a bit before next try */
+				usleep(100000);
+				continue;
+			}
+
+			// Handle new actuator controls data
+			if (fds[0].revents & POLLIN) {
+
+				// Grab new controls data
+				orb_copy(ORB_ID(actuator_controls_0), _controls_sub, &_controls);
+
+				// Mix to the outputs
+				_outputs.timestamp = hrt_absolute_time();
+				int motor_rpms[4]; //not yet supporting variable numbers
+
+				if(_armed.armed)
+				{
+					_outputs.noutputs = mixer->mix(&_outputs.output[0], _num_mixer_outputs, NULL);
+
+					// Send outputs to the ESCs
+					for (unsigned outIdx=0; outIdx < _num_mixer_outputs; outIdx++)
+					{
+						// map -1.0 - 1.0 outputs to RPMs
+						motor_rpms[outIdx] = ( ( _outputs.output[outIdx] + 1.0 ) / 2.0 ) *
+							( esc->max_rpm()-esc->min_rpm() ) + esc->min_rpm();
+
+					}
+					uart_esc_rotate_motors(motor_rpms,_num_mixer_outputs);
+				} else {
+					for (unsigned outIdx=0; outIdx < _num_mixer_outputs; outIdx++)
+					{
+						motor_rpms[outIdx] = 0;
+						_outputs.output[outIdx] = -1.0;
+					}
+				}
+				esc->send_rpms(motor_rpms, _num_mixer_outputs, false);
+
+				/* Publish mixed control outputs */
+				if (_outputs_pub != nullptr) {
+					orb_publish(ORB_ID(actuator_outputs), _outputs_pub, &_outputs);
+				} else {
+					_outputs_pub = orb_advertise(ORB_ID(actuator_outputs), &_outputs);
+				}
+			}
+
+			// Check for updates in other subscripions
+			bool updated = false;
+			orb_check(_armed_sub, &updated);
+			if (updated) {
+				orb_copy(ORB_ID(actuator_armed), _armed_sub, &_armed);
+			}
+
+			orb_check(_param_sub, &updated);
+			if (updated) {
+				orb_copy(ORB_ID(parameter_update), _param_sub, &_param_update);
+				// The param update struct only contains a timestamp. You can use or not.
+				// Update parameters relevant to this task (TBD)
+			}
+		}
+	}
+
+	PX4_WARN("closing uart_esc");
+
+	delete esc;
+}
+
+/** uart_esc main entrance */
+void task_main_trampoline(int argc, char *argv[])
+{
+	PX4_WARN("task_main_trampoline");
+	task_main(argc, argv);
+}
+
+void start(const char* device)
+{
+	ASSERT(_task_handle == -1);
+
+	_device = device;
+
+	/* start the task */
+	_task_handle = px4_task_spawn_cmd("uart_esc_main",
+					SCHED_DEFAULT,
+					SCHED_PRIORITY_ACTUATOR_OUTPUTS,
+					1500,
+					(px4_main_t)&task_main_trampoline,
+					nullptr);
+
+	if (_task_handle < 0) {
+		warn("task start failed");
+		return;
+	}
+
+	_is_running = true;
+}
+
+void stop()
+{
+	// TODO: set thread exit signal to terminate the task main thread
+
+	_is_running = false;
+	_device = NULL;
+	_task_handle = -1;
+}
+
+void usage()
+{
+	PX4_WARN("uart_esc missing command: try 'start', 'stop', 'status'");
+	PX4_WARN("options:");
+	PX4_WARN("    -D device");
+}
+
+}; // namespace uart_esc
+
+int uart_esc_main(int argc, char *argv[])
+{
+	const char* device = NULL;
+	int ch;
+	int myoptind = 1;
+	const char *myoptarg = NULL;
+
+	// TODO: need to obtain the two parameters from command line arguments.
+	// Should add this feature later
+	device = "/dev/tty-2";
+
+	// Check on required arguments
+	if (device == NULL)
+	{
+		uart_esc::usage();
+		return 1;
+	}
+
+	const char *verb = argv[1];
+
+	/*
+	 * Start/load the driver.
+	 */
+	if (!strcmp(verb, "start")) {
+		if (uart_esc::_is_running) {
+			PX4_WARN("uart_esc already running");
+			return 1;
+		}
+		uart_esc::start(device);
+	}
+
+	else if (!strcmp(verb, "stop")) {
+		if (uart_esc::_is_running) {
+			PX4_WARN("uart_esc is not running");
+			return 1;
+		}
+		uart_esc::stop();
+	}
+
+	else if (!strcmp(verb, "status")) {
+		PX4_WARN("uart_esc is %s", uart_esc::_is_running ? "running":"stopped");
+		return 0;
+	}
+	else {
+		uart_esc::usage();
+		return 1;
+	}
+
+	return 0;
+}

--- a/src/platforms/qurt/px4_layer/module.mk
+++ b/src/platforms/qurt/px4_layer/module.mk
@@ -58,9 +58,7 @@ SRCS		 = 	\
 			sq_remfirst.c \
 			sq_addafter.c \
 			dq_rem.c \
-                        hrt_work.c \
                         qurt_stubs.c \
-                        qurt_hacks.c \
                         main.cpp
 ifeq ($(CONFIG),qurt_hello)
 SRCS +=			commands_hello.c

--- a/src/platforms/qurt/px4_layer/px4_qurt_tasks.cpp
+++ b/src/platforms/qurt/px4_layer/px4_qurt_tasks.cpp
@@ -278,7 +278,7 @@ void px4_show_tasks()
 	for (idx=0; idx < PX4_MAX_TASKS; idx++)
 	{
 		if (taskmap[idx].isused) {
-			PX4_INFO("   %-10s %lu", taskmap[idx].name.c_str(), taskmap[idx].pid);
+			PX4_INFO("   %-10s %u", taskmap[idx].name.c_str(), taskmap[idx].pid);
 			count++;
 		}
 	}

--- a/src/platforms/qurt/tests/muorb/muorb_test_example.cpp
+++ b/src/platforms/qurt/tests/muorb/muorb_test_example.cpp
@@ -178,6 +178,12 @@ int MuorbTestExample::uSleepTest()
 	return 0;
 }
 
+// FIXME - Remove this when DSPAL supports getline()
+ssize_t getline(char **lineptr, size_t *n, FILE *fp)
+{
+	return -1;
+}
+
 int MuorbTestExample::FileReadTest()
 {
 	int rc = OK;


### PR DESCRIPTION
    - Removed unused member variables
    - Fixed Simulator to stub out call to poll for MAVLink messages
    - Fixes for changes to DSPAL headers
    - Stub out call to getline() as not yet implemented in DSPAL
    - Added QuRT drivers for mpu9x50 and uart_esc

Signed-off-by: Mark Charlebois <charlebm@gmail.com>