### PR TITLE
Replace the EKF attitude estimator for VTOL as it is no longer included.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.vtol_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_apps
@@ -4,7 +4,7 @@
 # att & pos estimator, att & pos control.
 #
 
-attitude_estimator_ekf start
+attitude_estimator_q start
 #ekf_att_pos_estimator start
 position_estimator_inav start
 


### PR DESCRIPTION
The EKF estimator was removed in https://github.com/PX4/Firmware/commit/95eaebb28d85290fb7077def31477cedfe325e17