### PR TITLE
QuRT: build configuration changes

### DIFF
--- a/makefiles/qurt/config_qurt_adsp.mk
+++ b/makefiles/qurt/config_qurt_adsp.mk
@@ -1,33 +1,28 @@
 #
-# Makefile for the Foo *default* configuration
+# Makefile for the EAGLE QuRT *default* configuration
 #
 
 #
 # Board support modules
 #
 MODULES		+= drivers/device
-#MODULES		+= drivers/blinkm
-MODULES		+= drivers/hil
-MODULES		+= drivers/led
-MODULES		+= drivers/rgbled
 MODULES		+= modules/sensors
-#MODULES		+= drivers/ms5611
+#MODULES		+= platforms/qurt/drivers/mpu9x50
+#MODULES		+= platforms/qurt/drivers/uart_esc
 
 #
 # System commands
 #
 MODULES	+= systemcmds/param
-MODULES += systemcmds/mixer
+
 
 #
 # General system control
 #
-#MODULES		+= modules/mavlink
 
 #
 # Estimation modules (EKF/ SO3 / other filters)
 #
-#MODULES		+= modules/attitude_estimator_ekf
 MODULES		+= modules/ekf_att_pos_estimator
 MODULES		+= modules/attitude_estimator_q
 MODULES		+= modules/position_estimator_inav
@@ -45,8 +40,6 @@ MODULES		+= modules/systemlib
 MODULES		+= modules/systemlib/mixer
 MODULES		+= modules/uORB
 #MODULES		+= modules/dataman
-#MODULES		+= modules/sdlog2
-#MODULES		+= modules/simulator
 MODULES		+= modules/commander
 
 #
@@ -62,19 +55,10 @@ MODULES		+= lib/conversion
 # QuRT port
 #
 MODULES		+= platforms/qurt/px4_layer
-MODULES		+= platforms/posix/work_queue
-#MODULES		+= platforms/posix/drivers/accelsim
-#MODULES		+= platforms/posix/drivers/gyrosim
-#MODULES		+= platforms/posix/drivers/adcsim
-#MODULES		+= platforms/posix/drivers/barosim
 
 #
 # Unit tests
 #
-#MODULES		+= platforms/qurt/tests/muorb
-#MODULES		+= platforms/posix/tests/vcdev_test
-#MODULES		+= platforms/posix/tests/hrt_test
-#MODULES		+= platforms/posix/tests/wqueue
 
 #
 # sources for muorb over fastrpc

--- a/makefiles/qurt/config_qurt_muorb_test.mk
+++ b/makefiles/qurt/config_qurt_muorb_test.mk
@@ -7,17 +7,17 @@
 #
 MODULES		+= drivers/device
 #MODULES		+= drivers/blinkm
-MODULES		+= drivers/hil
-MODULES		+= drivers/led
-MODULES		+= drivers/rgbled
-MODULES		+= modules/sensors
+#MODULES		+= drivers/hil
+#MODULES		+= drivers/led
+#MODULES		+= drivers/rgbled
+#MODULES		+= modules/sensors
 #MODULES		+= drivers/ms5611
 
 #
 # System commands
 #
-MODULES	+= systemcmds/param
-MODULES += systemcmds/mixer
+#MODULES	+= systemcmds/param
+#MODULES += systemcmds/mixer
 
 #
 # General system control
@@ -28,24 +28,24 @@ MODULES += systemcmds/mixer
 # Estimation modules (EKF/ SO3 / other filters)
 #
 #MODULES		+= modules/attitude_estimator_ekf
-MODULES		+= modules/ekf_att_pos_estimator
+#MODULES		+= modules/ekf_att_pos_estimator
 
 #
 # Vehicle Control
 #
-MODULES		+= modules/mc_att_control
-MODULES		+= modules/mc_pos_control
+#MODULES		+= modules/mc_att_control
+#MODULES		+= modules/mc_pos_control
 
 #
 # Library modules
 #
 MODULES		+= modules/systemlib
-MODULES		+= modules/systemlib/mixer
+#MODULES		+= modules/systemlib/mixer
 MODULES		+= modules/uORB
 #MODULES		+= modules/dataman
 #MODULES		+= modules/sdlog2
-MODULES		+= modules/simulator
-MODULES		+= modules/commander
+#MODULES		+= modules/simulator
+#MODULES		+= modules/commander
 
 #
 # Libraries
@@ -61,10 +61,10 @@ MODULES		+= lib/conversion
 #
 MODULES		+= platforms/qurt/px4_layer
 MODULES		+= platforms/posix/work_queue
-MODULES		+= platforms/posix/drivers/accelsim
-MODULES		+= platforms/posix/drivers/gyrosim
-MODULES		+= platforms/posix/drivers/adcsim
-MODULES		+= platforms/posix/drivers/barosim
+#MODULES		+= platforms/posix/drivers/accelsim
+#MODULES		+= platforms/posix/drivers/gyrosim
+#MODULES		+= platforms/posix/drivers/adcsim
+#MODULES		+= platforms/posix/drivers/barosim
 
 #
 # Unit tests

--- a/makefiles/qurt/qurt.mk
+++ b/makefiles/qurt/qurt.mk
@@ -35,5 +35,5 @@
 #
 
 MODULES += \
-		platforms/common 
+	platforms/common 
 

--- a/makefiles/qurt/toolchain_hexagon.mk
+++ b/makefiles/qurt/toolchain_hexagon.mk
@@ -35,9 +35,17 @@
 
 #$(info TOOLCHAIN  gnu-arm-eabi)
 
+#
+# Stop making if ADSP_LIB_ROOT is not set. This defines the path to
+# DspAL headers and driver headers
+#
+ifndef DSPAL_ROOT
+$(error DSPAL_ROOT is not set)
+endif
+
 # Toolchain commands. Normally only used inside this file.
 #
-HEXAGON_TOOLS_ROOT	 = /opt/6.4.03
+HEXAGON_TOOLS_ROOT	 ?= /opt/6.4.03
 #HEXAGON_TOOLS_ROOT	 = /opt/6.4.05
 HEXAGON_SDK_ROOT	 = /opt/Hexagon_SDK/2.0
 V_ARCH			 = v5
@@ -115,8 +123,12 @@ ARCHDEFINES		+= -DCONFIG_ARCH_BOARD_$(CONFIG_BOARD) \
 			    -D__EXPORT= \
 			    -Drestrict= \
                             -D_DEBUG \
-			    -I$(PX4_BASE)/../dspal/include \
-			    -I$(PX4_BASE)/../dspal/sys \
+			    -I$(DSPAL_ROOT)/ \
+			    -I$(DSPAL_ROOT)/dspal/include \
+			    -I$(DSPAL_ROOT)/dspal/sys \
+			    -I$(DSPAL_ROOT)/dspal/sys/sys \
+			    -I$(DSPAL_ROOT)/mpu_spi/inc/ \
+			    -I$(DSPAL_ROOT)/uart_esc/inc/ \
 			    -I$(HEXAGON_TOOLS_ROOT)/gnu/hexagon/include \
 			    -I$(PX4_BASE)/src/lib/eigen \
 			    -I$(PX4_BASE)/src/platforms/qurt/include \
@@ -232,6 +244,10 @@ LDFLAGS			+=  -g -mv5 -mG0lib -G0 -fpic -shared \
                            -lc \
 			   $(EXTRALDFLAGS) \
 			   $(addprefix -L,$(LIB_DIRS))
+
+# driver dynamic libraries
+LDFLAGS	+= -L${DSPAL_ROOT}/mpu_spi/hexagon_Debug_dynamic_toolv64/ship -lmpu9x50
+LDFLAGS	+= -L${DSPAL_ROOT}/uart_esc/hexagon_Debug_dynamic_toolv64/ship -luart_esc
 
 # Compiler support library
 #


### PR DESCRIPTION
Added DSPAL header paths to toolchain_hexagon.mk.

Made changes to build configuraion for QuRT to support HIL testing.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>