### PR TITLE
EKF Init fix

### DIFF
--- a/src/modules/ekf_att_pos_estimator/AttitudePositionEstimatorEKF.h
+++ b/src/modules/ekf_att_pos_estimator/AttitudePositionEstimatorEKF.h
@@ -335,7 +335,7 @@ private:
     /**
      * Initialize the reference position for the local coordinate frame
      */
-    void initReferencePosition(hrt_abstime timestamp,
+    void initReferencePosition(hrt_abstime timestamp, bool gps_valid,
             double lat, double lon, float gps_alt, float baro_alt);
 
     /**


### PR DESCRIPTION
This fixes an issue where the EKF reports initialisation and sets the local origin timestamp and position when it resets before it has GPS lock.