### PR TITLE
WIP: Vtol cleanup

### DIFF
--- a/ROMFS/px4fmu_common/init.d/13002_firefly6
+++ b/ROMFS/px4fmu_common/init.d/13002_firefly6
@@ -46,5 +46,6 @@ set PWM_AUX_MAX 2000
 set MAV_TYPE 21
 
 param set VT_MOT_COUNT 6
+param set VT_FW_MOT_OFF 23
 param set VT_IDLE_PWM_MC 1080
 param set VT_TYPE 1

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -106,6 +106,7 @@ uint32 component_id			# subsystem / component id, inspired by MAVLink's componen
 bool is_rotary_wing			# True if system is in rotary wing configuration, so for a VTOL this is only true while flying as a multicopter
 bool is_vtol				# True if the system is VTOL capable
 bool vtol_fw_permanent_stab		# True if vtol should stabilize attitude for fw in manual mode
+bool in_transition_mode
 
 bool condition_battery_voltage_valid
 bool condition_system_in_air_restore		# true if we can restore in mid air

--- a/msg/vtol_vehicle_status.msg
+++ b/msg/vtol_vehicle_status.msg
@@ -1,4 +1,5 @@
 uint64 timestamp		# Microseconds since system boot
 bool vtol_in_rw_mode		# true: vtol vehicle is in rotating wing mode
+bool vtol_in_trans_mode
 bool fw_permanent_stab		# In fw mode stabilize attitude even if in manual mode
 float32 airspeed_tot		# Estimated airspeed over control surfaces

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1498,6 +1498,7 @@ int commander_thread_main(int argc, char *argv[])
 			/* Make sure that this is only adjusted if vehicle really is of type vtol*/
 			if (is_vtol(&status)) {
 				status.is_rotary_wing = vtol_status.vtol_in_rw_mode;
+				status.in_transition_mode = vtol_status.vtol_in_trans_mode;
 			}
 		}
 

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -197,6 +197,8 @@ static struct home_position_s _home;
 
 static unsigned _last_mission_instance = 0;
 
+struct vtol_vehicle_status_s vtol_status;
+
 /**
  * The daemon app only briefly exists to start
  * the background job. The stack size assigned in the
@@ -1169,7 +1171,7 @@ int commander_thread_main(int argc, char *argv[])
 
 	/* Subscribe to vtol vehicle status topic */
 	int vtol_vehicle_status_sub = orb_subscribe(ORB_ID(vtol_vehicle_status));
-	struct vtol_vehicle_status_s vtol_status;
+	//struct vtol_vehicle_status_s vtol_status;
 	memset(&vtol_status, 0, sizeof(vtol_status));
 	vtol_status.vtol_in_rw_mode = true;		//default for vtol is rotary wing
 
@@ -2682,13 +2684,13 @@ set_control_mode()
 			!offboard_control_mode.ignore_velocity ||
 			!offboard_control_mode.ignore_acceleration_force;
 
-		control_mode.flag_control_velocity_enabled = !offboard_control_mode.ignore_velocity ||
-			!offboard_control_mode.ignore_position;
+		control_mode.flag_control_velocity_enabled = (!offboard_control_mode.ignore_velocity ||
+			!offboard_control_mode.ignore_position) && !vtol_status.vtol_in_trans_mode;
 
 		control_mode.flag_control_climb_rate_enabled = !offboard_control_mode.ignore_velocity ||
 			!offboard_control_mode.ignore_position;
 
-		control_mode.flag_control_position_enabled = !offboard_control_mode.ignore_position;
+		control_mode.flag_control_position_enabled = !offboard_control_mode.ignore_position && !vtol_status.vtol_in_trans_mode;
 
 		control_mode.flag_control_altitude_enabled = !offboard_control_mode.ignore_velocity ||
 			!offboard_control_mode.ignore_position;

--- a/src/modules/fw_att_control/fw_att_control_main.cpp
+++ b/src/modules/fw_att_control/fw_att_control_main.cpp
@@ -941,7 +941,7 @@ FixedwingAttitudeControl::task_main()
 					att_sp.thrust = throttle_sp;
 
 					/* lazily publish the setpoint only once available */
-					if (!_vehicle_status.is_rotary_wing) {
+					if (!_vehicle_status.is_rotary_wing && !_vehicle_status.in_transition_mode) {
 						if (_attitude_sp_pub != nullptr) {
 							/* publish the attitude setpoint */
 							orb_publish(ORB_ID(vehicle_attitude_setpoint), _attitude_sp_pub, &att_sp);

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1459,7 +1459,7 @@ MulticopterPositionControl::task_main()
 		if (!(_control_mode.flag_control_offboard_enabled &&
 					!(_control_mode.flag_control_position_enabled ||
 						_control_mode.flag_control_velocity_enabled))) {
-			if (_att_sp_pub != nullptr && _vehicle_status.is_rotary_wing) {
+			if (_att_sp_pub != nullptr && (_vehicle_status.is_rotary_wing || _vehicle_status.in_transition_mode)) {
 				orb_publish(ORB_ID(vehicle_attitude_setpoint), _att_sp_pub, &_att_sp);
 			} else if (_att_sp_pub == nullptr && _vehicle_status.is_rotary_wing){
 				_att_sp_pub = orb_advertise(ORB_ID(vehicle_attitude_setpoint), &_att_sp);

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -993,6 +993,11 @@ MulticopterPositionControl::task_main()
 			reset_yaw_sp = true;
 		}
 
+		// XXX Temporary: for vtol use we need to reset the yaw setpoint when we are doing a transition
+		if (_vehicle_status.in_transition_mode) {
+			reset_yaw_sp = true;
+		}
+
 		//Update previous arming state
 		was_armed = _control_mode.flag_armed;
 

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -46,11 +46,14 @@ Standard::Standard(VtolAttitudeControl *attc) :
 	VtolType(attc),
 	_flag_enable_mc_motors(true),
 	_pusher_throttle(0.0f),
-	_mc_att_ctl_weight(1.0f),
 	_airspeed_trans_blend_margin(0.0f)
 {
 	_vtol_schedule.flight_mode = MC_MODE;
 	_vtol_schedule.transition_start = 0;
+
+	_mc_roll_weight = 1.0f;
+	_mc_pitch_weight = 1.0f;
+	_mc_yaw_weight = 1.0f;
 
 	_params_handles_standard.front_trans_dur = param_find("VT_F_TRANS_DUR");
 	_params_handles_standard.back_trans_dur = param_find("VT_B_TRANS_DUR");
@@ -107,7 +110,9 @@ void Standard::update_vtol_state()
 		if (_vtol_schedule.flight_mode == MC_MODE) {
 			// in mc mode
 			_vtol_schedule.flight_mode = MC_MODE;
-			_mc_att_ctl_weight = 1.0f;
+			_mc_roll_weight = 1.0f;
+			_mc_pitch_weight = 1.0f;
+			_mc_yaw_weight = 1.0f;
 
 		} else if (_vtol_schedule.flight_mode == FW_MODE) {
 			// transition to mc mode
@@ -118,7 +123,9 @@ void Standard::update_vtol_state()
 		} else if (_vtol_schedule.flight_mode == TRANSITION_TO_FW) {
 			// failsafe back to mc mode
 			_vtol_schedule.flight_mode = MC_MODE;
-			_mc_att_ctl_weight = 1.0f;
+			_mc_roll_weight = 1.0f;
+			_mc_pitch_weight = 1.0f;
+			_mc_yaw_weight = 1.0f;
 
 		} else if (_vtol_schedule.flight_mode == TRANSITION_TO_MC) {
 			// keep transitioning to mc mode
@@ -138,7 +145,9 @@ void Standard::update_vtol_state()
 		} else if (_vtol_schedule.flight_mode == FW_MODE) {
 			// in fw mode
 			_vtol_schedule.flight_mode = FW_MODE;
-			_mc_att_ctl_weight = 0.0f;
+			_mc_roll_weight = 0.0f;
+			_mc_pitch_weight = 0.0f;
+			_mc_yaw_weight = 0.0f;
 
 		} else if (_vtol_schedule.flight_mode == TRANSITION_TO_FW) {
 			// continue the transition to fw mode while monitoring airspeed for a final switch to fw mode
@@ -184,18 +193,28 @@ void Standard::update_transition_state()
 
 		// do blending of mc and fw controls if a blending airspeed has been provided
 		if (_airspeed_trans_blend_margin > 0.0f && _airspeed->true_airspeed_m_s >= _params_standard.airspeed_blend) {
-			_mc_att_ctl_weight = 1.0f - fabsf(_airspeed->true_airspeed_m_s - _params_standard.airspeed_blend) / _airspeed_trans_blend_margin;
+			float weight = 1.0f - fabsf(_airspeed->true_airspeed_m_s - _params_standard.airspeed_blend) / _airspeed_trans_blend_margin;
+			_mc_roll_weight = weight;
+			_mc_pitch_weight = weight;
+			_mc_yaw_weight = weight;
 		} else {
 			// at low speeds give full weight to mc
-			_mc_att_ctl_weight = 1.0f;
+			_mc_roll_weight = 1.0f;
+			_mc_pitch_weight = 1.0f;
+			_mc_yaw_weight = 1.0f;
 		}
 
 	} else if (_vtol_schedule.flight_mode == TRANSITION_TO_MC) {
 		// continually increase mc attitude control as we transition back to mc mode
 		if (_params_standard.back_trans_dur > 0.0f) {
-			_mc_att_ctl_weight = (float)hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params_standard.back_trans_dur * 1000000.0f);
+			float weight = (float)hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params_standard.back_trans_dur * 1000000.0f);
+			_mc_roll_weight = weight;
+			_mc_pitch_weight = weight;
+			_mc_yaw_weight = weight;
 		} else {
-			_mc_att_ctl_weight = 1.0f;	
+			_mc_roll_weight = 1.0f;
+			_mc_pitch_weight = 1.0f;
+			_mc_yaw_weight = 1.0f;
 		}
 
 		// in fw mode we need the multirotor motors to stop spinning, in backtransition mode we let them spin up again	
@@ -206,7 +225,9 @@ void Standard::update_transition_state()
 		}
 	}
 
-	_mc_att_ctl_weight = math::constrain(_mc_att_ctl_weight, 0.0f, 1.0f);
+	_mc_roll_weight = math::constrain(_mc_roll_weight, 0.0f, 1.0f);
+	_mc_pitch_weight = math::constrain(_mc_pitch_weight, 0.0f, 1.0f);
+	_mc_yaw_weight = math::constrain(_mc_yaw_weight, 0.0f, 1.0f);
 }
 
 void Standard::update_mc_state()
@@ -235,24 +256,23 @@ void Standard::update_external_state()
 void Standard::fill_actuator_outputs()
 {
 	/* multirotor controls */
-	_actuators_out_0->control[0] = _actuators_mc_in->control[0] * _mc_att_ctl_weight;	// roll
-	_actuators_out_0->control[1] = _actuators_mc_in->control[1] * _mc_att_ctl_weight;	// pitch
-	_actuators_out_0->control[2] = _actuators_mc_in->control[2] * _mc_att_ctl_weight;	// yaw
-	_actuators_out_0->control[3] = _actuators_mc_in->control[3];	// throttle
+	_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] = _actuators_mc_in->control[actuator_controls_s::INDEX_ROLL] * _mc_roll_weight;	// roll
+	_actuators_out_0->control[actuator_controls_s::INDEX_PITCH] = _actuators_mc_in->control[actuator_controls_s::INDEX_PITCH] * _mc_pitch_weight;	// pitch
+	_actuators_out_0->control[actuator_controls_s::INDEX_YAW] = _actuators_mc_in->control[actuator_controls_s::INDEX_YAW] * _mc_yaw_weight;	// yaw
+	_actuators_out_0->control[actuator_controls_s::INDEX_THROTTLE] = _actuators_mc_in->control[actuator_controls_s::INDEX_THROTTLE];	// throttle
 
 	/* fixed wing controls */
-	const float fw_att_ctl_weight = 1.0f - _mc_att_ctl_weight;
-	_actuators_out_1->control[0] = -_actuators_fw_in->control[0] * fw_att_ctl_weight;	//roll
-	_actuators_out_1->control[1] = (_actuators_fw_in->control[1] + _params->fw_pitch_trim) * fw_att_ctl_weight;	//pitch
-	_actuators_out_1->control[2] = _actuators_fw_in->control[2] * fw_att_ctl_weight;	// yaw
+	_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] = -_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL] * (1 - _mc_roll_weight);	//roll
+	_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] = (_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH] + _params->fw_pitch_trim) * (1 - _mc_pitch_weight);	//pitch
+	_actuators_out_1->control[actuator_controls_s::INDEX_YAW] = _actuators_fw_in->control[actuator_controls_s::INDEX_YAW] * (1 - _mc_yaw_weight);	// yaw
 
 	// set the fixed wing throttle control
 	if (_vtol_schedule.flight_mode == FW_MODE) {
 		// take the throttle value commanded by the fw controller
-		_actuators_out_1->control[3] = _actuators_fw_in->control[3];
+		_actuators_out_1->control[actuator_controls_s::INDEX_THROTTLE] = _actuators_fw_in->control[actuator_controls_s::INDEX_THROTTLE];
 	} else {
 		// otherwise we may be ramping up the throttle during the transition to fw mode 
-		_actuators_out_1->control[3] = _pusher_throttle;
+		_actuators_out_1->control[actuator_controls_s::INDEX_THROTTLE] = _pusher_throttle;
 	}
 }
 

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -214,16 +214,6 @@ void Standard::update_mc_state()
 	// do nothing
 }
 
-void Standard::process_mc_data()
-{
-	fill_att_control_output();
-}
-
-void Standard::process_fw_data()
-{
-	fill_att_control_output();
-}
-
  void Standard::update_fw_state()
 {
 	// in fw mode we need the multirotor motors to stop spinning, in backtransition mode we let them spin up again	
@@ -242,7 +232,7 @@ void Standard::update_external_state()
  * Prepare message to acutators with data from mc and fw attitude controllers. An mc attitude weighting will determine
  * what proportion of control should be applied to each of the control groups (mc and fw).
  */
-void Standard::fill_att_control_output()
+void Standard::fill_actuator_outputs()
 {
 	/* multirotor controls */
 	_actuators_out_0->control[0] = _actuators_mc_in->control[0] * _mc_att_ctl_weight;	// roll

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -93,7 +93,6 @@ private:
 
 	bool _flag_enable_mc_motors;
 	float _pusher_throttle;
-	float _mc_att_ctl_weight;	// the amount of multicopter attitude control that should be applied in fixed wing mode while transitioning 
 	float _airspeed_trans_blend_margin;
 
 	void fill_actuator_outputs();

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -57,9 +57,7 @@ public:
 
 	void update_vtol_state();
 	void update_mc_state();
-	void process_mc_data();
 	void update_fw_state();
-	void process_fw_data();
 	void update_transition_state();
 	void update_external_state();
 
@@ -98,7 +96,7 @@ private:
 	float _mc_att_ctl_weight;	// the amount of multicopter attitude control that should be applied in fixed wing mode while transitioning 
 	float _airspeed_trans_blend_margin;
 
-	void fill_att_control_output();
+	void fill_actuator_outputs();
 	void set_max_mc(unsigned pwm_value);
 
 	int parameters_update();

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -73,24 +73,12 @@ void Tailsitter::update_mc_state()
 	}
 }
 
-void Tailsitter::process_mc_data()
-{
-	// scale pitch control with total airspeed
-	//scale_mc_output();
-	fill_mc_att_control_output();
-}
-
 void Tailsitter::update_fw_state()
 {
 	if (flag_idle_mc) {
 		set_idle_fw();
 		flag_idle_mc = false;
 	}
-}
-
-void Tailsitter::process_fw_data()
-{
-	fill_fw_att_control_output();
 }
 
 void Tailsitter::update_transition_state()
@@ -152,38 +140,41 @@ Tailsitter::scale_mc_output()
 }
 
 /**
-* Prepare message to acutators with data from fw attitude controller.
+* Write data to actuator output topic.
 */
-void Tailsitter::fill_fw_att_control_output()
+void Tailsitter::fill_actuator_outputs()
 {
-	/*For the first test in fw mode, only use engines for thrust!!!*/
-	_actuators_out_0->control[0] = 0;
-	_actuators_out_0->control[1] = 0;
-	_actuators_out_0->control[2] = 0;
-	_actuators_out_0->control[3] = _actuators_fw_in->control[3];
-	/*controls for the elevons */
-	_actuators_out_1->control[0] = -_actuators_fw_in->control[0];	// roll elevon
-	_actuators_out_1->control[1] = _actuators_fw_in->control[1] + _params->fw_pitch_trim;	// pitch elevon
-	// unused now but still logged
-	_actuators_out_1->control[2] = _actuators_fw_in->control[2];	// yaw
-	_actuators_out_1->control[3] = _actuators_fw_in->control[3];	// throttle
-}
+	switch(_vtol_mode) {
+		case ROTARY_WING:
+			_actuators_out_0->control[0] = _actuators_mc_in->control[0];
+			_actuators_out_0->control[1] = _actuators_mc_in->control[1];
+			_actuators_out_0->control[2] = _actuators_mc_in->control[2];
+			_actuators_out_0->control[3] = _actuators_mc_in->control[3];
 
-/**
-* Prepare message to acutators with data from mc attitude controller.
-*/
-void Tailsitter::fill_mc_att_control_output()
-{
-	_actuators_out_0->control[0] = _actuators_mc_in->control[0];
-	_actuators_out_0->control[1] = _actuators_mc_in->control[1];
-	_actuators_out_0->control[2] = _actuators_mc_in->control[2];
-	_actuators_out_0->control[3] = _actuators_mc_in->control[3];
-
-	if (_params->elevons_mc_lock == 1) {
-		_actuators_out_1->control[0] = 0;
-		_actuators_out_1->control[1] = 0;
-	} else {
-		_actuators_out_1->control[0] = _actuators_mc_in->control[2];	//roll elevon
-		_actuators_out_1->control[1] = _actuators_mc_in->control[1];	//pitch elevon
+			if (_params->elevons_mc_lock == 1) {
+				_actuators_out_1->control[0] = 0;
+				_actuators_out_1->control[1] = 0;
+			} else {
+				_actuators_out_1->control[0] = _actuators_mc_in->control[2];	//roll elevon
+				_actuators_out_1->control[1] = _actuators_mc_in->control[1];	//pitch elevon
+			}
+			break;
+		case FIXED_WING:
+			/*For the first test in fw mode, only use engines for thrust!!!*/
+			_actuators_out_0->control[0] = 0;
+			_actuators_out_0->control[1] = 0;
+			_actuators_out_0->control[2] = 0;
+			_actuators_out_0->control[3] = _actuators_fw_in->control[3];
+			/*controls for the elevons */
+			_actuators_out_1->control[0] = -_actuators_fw_in->control[0];	// roll elevon
+			_actuators_out_1->control[1] = _actuators_fw_in->control[1] + _params->fw_pitch_trim;	// pitch elevon
+			// unused now but still logged
+			_actuators_out_1->control[2] = _actuators_fw_in->control[2];	// yaw
+			_actuators_out_1->control[3] = _actuators_fw_in->control[3];	// throttle
+			break;
+		case TRANSITION:
+		case EXTERNAL:
+			// not yet implemented, we are switching brute force at the moment
+			break;
 	}
 }

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -146,31 +146,31 @@ void Tailsitter::fill_actuator_outputs()
 {
 	switch(_vtol_mode) {
 		case ROTARY_WING:
-			_actuators_out_0->control[0] = _actuators_mc_in->control[0];
-			_actuators_out_0->control[1] = _actuators_mc_in->control[1];
-			_actuators_out_0->control[2] = _actuators_mc_in->control[2];
-			_actuators_out_0->control[3] = _actuators_mc_in->control[3];
+			_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] = _actuators_mc_in->control[actuator_controls_s::INDEX_ROLL];
+			_actuators_out_0->control[actuator_controls_s::INDEX_PITCH] = _actuators_mc_in->control[actuator_controls_s::INDEX_PITCH];
+			_actuators_out_0->control[actuator_controls_s::INDEX_YAW] = _actuators_mc_in->control[actuator_controls_s::INDEX_YAW];
+			_actuators_out_0->control[actuator_controls_s::INDEX_THROTTLE] = _actuators_mc_in->control[actuator_controls_s::INDEX_THROTTLE];
 
 			if (_params->elevons_mc_lock == 1) {
 				_actuators_out_1->control[0] = 0;
 				_actuators_out_1->control[1] = 0;
 			} else {
-				_actuators_out_1->control[0] = _actuators_mc_in->control[2];	//roll elevon
-				_actuators_out_1->control[1] = _actuators_mc_in->control[1];	//pitch elevon
+				// NOTE: There is no mistake in the line below, multicopter yaw axis is controlled by elevon roll actuation!
+				_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] = _actuators_mc_in->control[actuator_controls_s::INDEX_YAW];	//roll elevon
+				_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] = _actuators_mc_in->control[actuator_controls_s::INDEX_PITCH];	//pitch elevon
 			}
 			break;
 		case FIXED_WING:
-			/*For the first test in fw mode, only use engines for thrust!!!*/
-			_actuators_out_0->control[0] = 0;
-			_actuators_out_0->control[1] = 0;
-			_actuators_out_0->control[2] = 0;
-			_actuators_out_0->control[3] = _actuators_fw_in->control[3];
-			/*controls for the elevons */
-			_actuators_out_1->control[0] = -_actuators_fw_in->control[0];	// roll elevon
-			_actuators_out_1->control[1] = _actuators_fw_in->control[1] + _params->fw_pitch_trim;	// pitch elevon
-			// unused now but still logged
-			_actuators_out_1->control[2] = _actuators_fw_in->control[2];	// yaw
-			_actuators_out_1->control[3] = _actuators_fw_in->control[3];	// throttle
+			// in fixed wing mode we use engines only for providing thrust, no moments are generated
+			_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] = 0;
+			_actuators_out_0->control[actuator_controls_s::INDEX_PITCH] = 0;
+			_actuators_out_0->control[actuator_controls_s::INDEX_YAW] = 0;
+			_actuators_out_0->control[actuator_controls_s::INDEX_THROTTLE] = _actuators_fw_in->control[actuator_controls_s::INDEX_THROTTLE];
+
+			_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] = -_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL];	// roll elevon
+			_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] = _actuators_fw_in->control[actuator_controls_s::INDEX_PITCH] + _params->fw_pitch_trim;	// pitch elevon
+			_actuators_out_1->control[actuator_controls_s::INDEX_YAW] = _actuators_fw_in->control[actuator_controls_s::INDEX_YAW];	// yaw
+			_actuators_out_1->control[actuator_controls_s::INDEX_THROTTLE] = _actuators_fw_in->control[actuator_controls_s::INDEX_THROTTLE];	// throttle
 			break;
 		case TRANSITION:
 		case EXTERNAL:

--- a/src/modules/vtol_att_control/tailsitter.h
+++ b/src/modules/vtol_att_control/tailsitter.h
@@ -53,15 +53,12 @@ public:
 
 	void update_vtol_state();
 	void update_mc_state();
-	void process_mc_data();
 	void update_fw_state();
-	void process_fw_data();
 	void update_transition_state();
 	void update_external_state();
 
 private:
-	void fill_mc_att_control_output();
-	void fill_fw_att_control_output();
+	void fill_actuator_outputs();
 	void calc_tot_airspeed();
 	void scale_mc_output();
 

--- a/src/modules/vtol_att_control/tiltrotor.h
+++ b/src/modules/vtol_att_control/tiltrotor.h
@@ -89,6 +89,7 @@ private:
 		float airspeed_blend_start;		/**< airspeed at which we start blending mc/fw controls */
 		int elevons_mc_lock;			/**< lock elevons in multicopter mode */
 		float front_trans_dur_p2;
+		int fw_motors_off;			/**< bitmask of all motors that should be off in fixed wing mode */
 	} _params_tiltrotor;
 
 	struct {
@@ -101,6 +102,7 @@ private:
 		param_t airspeed_blend_start;
 		param_t elevons_mc_lock;
 		param_t front_trans_dur_p2;
+		param_t fw_motors_off;
 	} _params_handles_tiltrotor;
 
 	enum vtol_mode {
@@ -132,6 +134,16 @@ private:
 	float _yaw_weight_mc;		/**< multicopter desired yaw moment weight */
 
 	const float _min_front_trans_dur;	/**< min possible time in which rotors are rotated into the first position */
+
+	/**
+	 * Return a bitmap of channels that should be turned off in fixed wing mode.
+	 */
+	int get_motor_off_channels(const int channels);
+
+	/**
+	 * Return true if the motor channel is off in fixed wing mode.
+	 */
+	bool is_motor_off_channel(const int channel);
 
 	/**
 	 * Write control values to actuator output topics.

--- a/src/modules/vtol_att_control/tiltrotor.h
+++ b/src/modules/vtol_att_control/tiltrotor.h
@@ -86,7 +86,9 @@ private:
 		float tilt_transition;			/**< actuator value corresponding to transition tilt (e.g 45 degrees) */
 		float tilt_fw;					/**< actuator value corresponding to fw tilt */
 		float airspeed_trans;			/**< airspeed at which we switch to fw mode after transition */
+		float airspeed_blend_start;		/**< airspeed at which we start blending mc/fw controls */
 		int elevons_mc_lock;			/**< lock elevons in multicopter mode */
+		float front_trans_dur_p2;
 	} _params_tiltrotor;
 
 	struct {
@@ -96,7 +98,9 @@ private:
 		param_t tilt_transition;
 		param_t tilt_fw;
 		param_t airspeed_trans;
+		param_t airspeed_blend_start;
 		param_t elevons_mc_lock;
+		param_t front_trans_dur_p2;
 	} _params_handles_tiltrotor;
 
 	enum vtol_mode {
@@ -126,6 +130,8 @@ private:
 	float _tilt_control;		/**< actuator value for the tilt servo */
 	float _roll_weight_mc;		/**< multicopter desired roll moment weight */
 	float _yaw_weight_mc;		/**< multicopter desired yaw moment weight */
+
+	const float _min_front_trans_dur;	/**< min possible time in which rotors are rotated into the first position */
 
 	/**
 	 * Write control values to actuator output topics.

--- a/src/modules/vtol_att_control/tiltrotor_params.c
+++ b/src/modules/vtol_att_control/tiltrotor_params.c
@@ -72,3 +72,15 @@ PARAM_DEFINE_FLOAT(VT_TILT_TRANS, 0.3f);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_FLOAT(VT_TILT_FW, 1.0f);
+
+/**
+ * Duration of front transition phase 2
+ *
+ * Time in seconds it should take for the rotors to rotate forward completely from the point
+ * when the plane has picked up enough airspeed and is ready to go into fixed wind mode.
+ *
+ * @min 0.1
+ * @max 2
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_TRANS_P2_DUR, 0.5f);

--- a/src/modules/vtol_att_control/tiltrotor_params.c
+++ b/src/modules/vtol_att_control/tiltrotor_params.c
@@ -84,3 +84,13 @@ PARAM_DEFINE_FLOAT(VT_TILT_FW, 1.0f);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_FLOAT(VT_TRANS_P2_DUR, 0.5f);
+
+/**
+ * The channel number of motors that must be turned off in fixed wing mode.
+ *
+ *
+ * @min 0
+ * @max 123456
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_INT32(VT_FW_MOT_OFF, 0);

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -491,6 +491,7 @@ void VtolAttitudeControl::task_main()
 		if (_vtol_type->get_mode() == ROTARY_WING) {
 			// vehicle is in rotary wing mode
 			_vtol_vehicle_status.vtol_in_rw_mode = true;
+			_vtol_vehicle_status.vtol_in_trans_mode = false;
 
 			// got data from mc attitude controller
 			if (fds[0].revents & POLLIN) {
@@ -503,6 +504,7 @@ void VtolAttitudeControl::task_main()
 		} else if (_vtol_type->get_mode() == FIXED_WING) {
 			// vehicle is in fw mode
 			_vtol_vehicle_status.vtol_in_rw_mode = false;
+			_vtol_vehicle_status.vtol_in_trans_mode = false;
 
 			// got data from fw attitude controller
 			if (fds[1].revents & POLLIN) {
@@ -515,6 +517,8 @@ void VtolAttitudeControl::task_main()
 			}
 		} else if (_vtol_type->get_mode() == TRANSITION) {
 			// vehicle is doing a transition
+			_vtol_vehicle_status.vtol_in_trans_mode = true;
+
 			bool got_new_data = false;
 			if (fds[0].revents & POLLIN) {
 				orb_copy(ORB_ID(actuator_controls_virtual_mc), _actuator_inputs_mc, &_actuators_mc_in);

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -43,7 +43,6 @@
  * @author Thomas Gubler	<thomasgubler@gmail.com>
  *
  */
-
 #include "vtol_att_control_main.h"
 
 namespace VTOL_att_control
@@ -493,13 +492,11 @@ void VtolAttitudeControl::task_main()
 			// vehicle is in rotary wing mode
 			_vtol_vehicle_status.vtol_in_rw_mode = true;
 
-			_vtol_type->update_mc_state();
-
 			// got data from mc attitude controller
 			if (fds[0].revents & POLLIN) {
 				orb_copy(ORB_ID(actuator_controls_virtual_mc), _actuator_inputs_mc, &_actuators_mc_in);
 
-				_vtol_type->process_mc_data();
+				_vtol_type->update_mc_state();
 
 				fill_mc_att_rates_sp();
 			}
@@ -507,14 +504,12 @@ void VtolAttitudeControl::task_main()
 			// vehicle is in fw mode
 			_vtol_vehicle_status.vtol_in_rw_mode = false;
 
-			_vtol_type->update_fw_state();
-
 			// got data from fw attitude controller
 			if (fds[1].revents & POLLIN) {
 				orb_copy(ORB_ID(actuator_controls_virtual_fw), _actuator_inputs_fw, &_actuators_fw_in);
 				vehicle_manual_poll();
 
-				_vtol_type->process_fw_data();
+				_vtol_type->update_fw_state();
 
 				fill_fw_att_rates_sp();
 			}
@@ -534,8 +529,6 @@ void VtolAttitudeControl::task_main()
 			// update transition state if got any new data
 			if (got_new_data) {
 				_vtol_type->update_transition_state();
-
-				_vtol_type->process_mc_data();
 				fill_mc_att_rates_sp();
 			}
 
@@ -544,6 +537,7 @@ void VtolAttitudeControl::task_main()
 			_vtol_type->update_external_state();
 		}
 
+		_vtol_type->fill_actuator_outputs();
 
 		/* Only publish if the proper mode(s) are enabled */
 		if(_v_control_mode.flag_control_attitude_enabled ||

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -75,11 +75,10 @@ public:
 
 	virtual void update_vtol_state() = 0;
 	virtual void update_mc_state() = 0;
-	virtual void process_mc_data() = 0;
 	virtual void update_fw_state() = 0;
-	virtual void process_fw_data() = 0;
 	virtual void update_transition_state() = 0;
 	virtual void update_external_state() = 0;
+	virtual void fill_actuator_outputs() = 0;
 
 	void set_idle_mc();
 	void set_idle_fw();

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -41,6 +41,8 @@
 #ifndef VTOL_TYPE_H
 #define VTOL_TYPE_H
 
+#include <lib/mathlib/mathlib.h>
+
 struct Params {
 	int idle_pwm_mc;			// pwm value for idle in mc mode
 	int vtol_motor_count;		// number of motors
@@ -109,6 +111,10 @@ protected:
 	struct Params 						*_params;
 
 	bool flag_idle_mc;		//false = "idle is set for fixed wing mode"; true = "idle is set for multicopter mode"
+
+	float _mc_roll_weight;	// weight for multicopter attitude controller roll output
+	float _mc_pitch_weight;	// weight for multicopter attitude controller pitch output
+	float _mc_yaw_weight;	// weight for multicopter attitude controller yaw output
 
 };
 


### PR DESCRIPTION
This is some cleanup work, especially for the tiltrotor code. Changes include:

- removed the process_mc_data() and process_fw_data() calls. We already have the update_mc_state() function calls so we do not need the former ones.

- the method of how to change the max pwm for the firefly6 rear engines was messy and the function names were not good. I tried to structure it a bit more and gave some better function names.

- there is now one function call to fill_actuator_outputs. The different modes are treated inside the function

- general comments cleanup

@SimonWilks @AndreasAntener Changes to the standard vtol code are minimal but still we should test it. 