### PR TITLE
fixed: path to init.d not ending with slash

### DIFF
--- a/makefiles/nuttx/nuttx_px4.mk
+++ b/makefiles/nuttx/nuttx_px4.mk
@@ -49,7 +49,7 @@ $(PRODUCT_BUNDLE):	$(PRODUCT_BIN)
 	@$(ECHO) %% Generating $@
 ifdef GEN_PARAM_XML
 	$(Q) $(PYTHON) $(PX4_BASE)/Tools/px_process_params.py --src-path $(PX4_BASE)/src --board CONFIG_ARCH_BOARD_$(CONFIG_BOARD) --xml
-	$(Q) $(PYTHON) $(PX4_BASE)/Tools/px_process_airframes.py -a $(PX4_BASE)/ROMFS/px4fmu_common/init.d --board CONFIG_ARCH_BOARD_$(CONFIG_BOARD) --xml
+	$(Q) $(PYTHON) $(PX4_BASE)/Tools/px_process_airframes.py -a $(PX4_BASE)/ROMFS/px4fmu_common/init.d/ --board CONFIG_ARCH_BOARD_$(CONFIG_BOARD) --xml
 	$(Q) $(MKFW) --prototype $(IMAGE_DIR)/$(BOARD).prototype \
 		--git_identity $(PX4_BASE) \
 		--parameter_xml $(PRODUCT_PARAMXML) \

--- a/makefiles/nuttx/nuttx_romfs.mk
+++ b/makefiles/nuttx/nuttx_romfs.mk
@@ -93,10 +93,10 @@ ifneq ($(ROMFS_EXTRA_FILES),)
 	$(Q) $(MKDIR) -p $(ROMFS_SCRATCH)/extras
 	$(Q) $(COPY) $(ROMFS_EXTRA_FILES) $(ROMFS_SCRATCH)/extras
 endif
-	$(Q) $(PYTHON) -u $(ROMFS_AUTOSTART)  -a $(ROMFS_ROOT)/init.d -s $(ROMFS_SCRATCH)/init.d/rc.autostart
+	$(Q) $(PYTHON) -u $(ROMFS_AUTOSTART)  -a $(ROMFS_ROOT)/init.d/ -s $(ROMFS_SCRATCH)/init.d/rc.autostart
 	# Execute in standard dir as well
 	# so developers notice the generated file
-	$(Q) $(PYTHON) -u $(ROMFS_AUTOSTART)  -a $(ROMFS_ROOT)/init.d -s $(ROMFS_ROOT)/init.d/rc.autostart
+	$(Q) $(PYTHON) -u $(ROMFS_AUTOSTART)  -a $(ROMFS_ROOT)/init.d/ -s $(ROMFS_ROOT)/init.d/rc.autostart
 	$(Q) $(PYTHON) -u $(ROMFS_PRUNER) --folder $(ROMFS_SCRATCH)
 
 EXTRA_CLEANS		+= $(ROMGS_OBJ) $(ROMFS_IMG)


### PR DESCRIPTION
under windows path to init.d without slash breaks airframes.xml and rc.autostart autogeneration