### PR TITLE
External heading support for AttitudeEstimatorQ (Vision/Mocap)

### DIFF
--- a/src/modules/attitude_estimator_q/attitude_estimator_q_params.c
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_params.c
@@ -62,6 +62,15 @@ PARAM_DEFINE_FLOAT(ATT_W_ACC, 0.2f);
 PARAM_DEFINE_FLOAT(ATT_W_MAG, 0.1f);
 
 /**
+ * Complimentary filter external heading weight
+ *
+ * @group Attitude Q estimator
+ * @min 0
+ * @max 1
+ */
+PARAM_DEFINE_FLOAT(ATT_W_EXT_HDG, 0.1f);
+
+/**
  * Complimentary filter gyroscope bias weight
  *
  * @group Attitude Q estimator
@@ -92,6 +101,17 @@ PARAM_DEFINE_FLOAT(ATT_MAG_DECL, 0.0f);
  * @max 1
  */
 PARAM_DEFINE_INT32(ATT_MAG_DECL_A, 1);
+
+/**
+ * External heading usage mode (from Motion capture/Vision)
+ * Set to 1 to use heading estimate from vision.
+ * Set to 2 to use heading from motion capture.
+ *
+ * @group Attitude Q estimator
+ * @min 0
+ * @max 2
+ */
+PARAM_DEFINE_INT32(ATT_EXT_HDG_M, 0);
 
 /**
  * Enable acceleration compensation based on GPS


### PR DESCRIPTION
This is the WIP for using external heading in the quaternion estimator. This is a heavily requested feature, so I would appreciate inputs from the motion capture community on testing and keeping this maintained.

I have added 3 modes to use the heading :
- Mode 0 : Ignore external heading.
- Mode 1 : Just use the external heading and do not perform magnetometer corrections. (Current implementation does this ; Use where mag is completely useless)
- Mode 2: Use both external heading and magnetometer. Useful for having a correct global yaw for use cases like mine. This still needs much work, and I will remove it from *this* PR if it holds up the primary integration.

Regarding mode 2, I would like some inputs from @DrTon. Basically we have the magnetometer and "fake" triaxial yaw readings from vision/mocap. What I would like to do is use both sources concurrently such that there is an accurate global heading (I need this) but also prevent bad mag readings indoors from throwing off the estimate by using the vision yaw. Maybe implement some dynamic weighting for the sources depending on RMS error or similar. I'd appreciate your comments and how we can best do this. 

Currently I'm testing this with a AR marker setup. Currently my vehicle is down, but will be flying soon again. Again, I would like some other testers on this, especially those who've be working with indoor motion capture, and occasionally pop up on the mailing list...

@LorenzMeier @TSC21 @blackcoder