### PR TITLE
VTOL transition command

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.usb
+++ b/ROMFS/px4fmu_common/init.d/rc.usb
@@ -22,6 +22,7 @@ mavlink stream -d /dev/ttyACM0 -s MANUAL_CONTROL -r 5
 mavlink stream -d /dev/ttyACM0 -s HIGHRES_IMU -r 100
 mavlink stream -d /dev/ttyACM0 -s GPS_RAW_INT -r 20
 mavlink stream -d /dev/ttyACM0 -s CAMERA_TRIGGER -r 500
+mavlink stream -d /dev/ttyACM0 -s VTOL_STATE -r 2
 
 # Exit shell to make it available to MAVLink
 exit

--- a/msg/vehicle_command.msg
+++ b/msg/vehicle_command.msg
@@ -50,6 +50,7 @@ uint32 VEHICLE_CMD_MISSION_START = 300			# start running a mission |first_item: 
 uint32 VEHICLE_CMD_COMPONENT_ARM_DISARM = 400		# Arms / Disarms a component |1 to arm, 0 to disarm| 
 uint32 VEHICLE_CMD_START_RX_PAIR = 500			# Starts receiver pairing |0:Spektrum| 0:Spektrum DSM2, 1:Spektrum DSMX|
 uint32 VEHICLE_CMD_DO_TRIGGER_CONTROL = 2003            # Enable or disable on-board camera triggering system
+uint32 VEHICLE_CMD_DO_VTOL_TRANSITION = 3000    # Command VTOL transition
 uint32 VEHICLE_CMD_PAYLOAD_PREPARE_DEPLOY = 30001	# Prepare a payload deployment in the flight plan
 uint32 VEHICLE_CMD_PAYLOAD_CONTROL_DEPLOY = 30002	# Control a pre-programmed payload deployment
 

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -79,6 +79,13 @@ uint8 VEHICLE_TYPE_VTOL_HEXAROTOR = 21 		# Vtol with six engines
 uint8 VEHICLE_TYPE_VTOL_OCTOROTOR = 22		# Vtol with eight engines
 uint8 VEHICLE_TYPE_ENUM_END = 23
 
+# VEHICLE_VTOL_STATE, should match 1:1 MAVLinks's MAV_VTOL_STATE
+uint8 VEHICLE_VTOL_STATE_UNDEFINED = 0
+uint8 VEHICLE_VTOL_STATE_TRANSITION_TO_FW = 1
+uint8 VEHICLE_VTOL_STATE_TRANSITION_TO_MC = 2
+uint8 VEHICLE_VTOL_STATE_MC = 3
+uint8 VEHICLE_VTOL_STATE_FW = 4
+
 uint8 VEHICLE_BATTERY_WARNING_NONE = 0	    # no battery low voltage warning active
 uint8 VEHICLE_BATTERY_WARNING_LOW = 1	    # warning of low voltage
 uint8 VEHICLE_BATTERY_WARNING_CRITICAL = 2  # alerting of critical voltage

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -794,6 +794,7 @@ bool handle_command(struct vehicle_status_s *status_local, const struct safety_s
 	case vehicle_command_s::VEHICLE_CMD_DO_MOUNT_CONTROL_QUAT:
 	case vehicle_command_s::VEHICLE_CMD_DO_MOUNT_CONFIGURE:
 	case vehicle_command_s::VEHICLE_CMD_DO_TRIGGER_CONTROL:
+	case vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION:
 		/* ignore commands that handled in low prio loop */
 		break;
 

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1654,6 +1654,7 @@ Mavlink::task_main(int argc, char *argv[])
 		configure_stream("ATTITUDE_TARGET", 8.0f);
 		configure_stream("DISTANCE_SENSOR", 0.5f);
 		configure_stream("OPTICAL_FLOW_RAD", 5.0f);
+		configure_stream("VTOL_STATE", 0.5f);
 		break;
 
 	case MAVLINK_MODE_ONBOARD:
@@ -1676,6 +1677,7 @@ Mavlink::task_main(int argc, char *argv[])
 		configure_stream("ACTUATOR_CONTROL_TARGET0", 10.0f);
 		/* camera trigger is rate limited at the source, do not limit here */
 		configure_stream("CAMERA_TRIGGER", 500.0f);
+		configure_stream("VTOL_STATE", 2.0f);
 		break;
 
 	case MAVLINK_MODE_OSD:
@@ -1688,6 +1690,7 @@ Mavlink::task_main(int argc, char *argv[])
 		configure_stream("BATTERY_STATUS", 1.0f);
 		configure_stream("SYSTEM_TIME", 1.0f);
 		configure_stream("RC_CHANNELS", 5.0f);
+		configure_stream("VTOL_STATE", 0.5f);
 		break;
 
 	default:

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -53,6 +53,7 @@
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/home_position.h>
 #include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/vtol_vehicle_status.h>
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_local_position_setpoint.h>
 #include <uORB/topics/att_pos_mocap.h>
@@ -2340,6 +2341,79 @@ protected:
 	}
 };
 
+class MavlinkStreamVtolState : public MavlinkStream
+{
+public:
+	const char *get_name() const
+	{
+		return MavlinkStreamVtolState::get_name_static();
+	}
+
+	static const char *get_name_static()
+	{
+		return "VTOL_STATE";
+	}
+
+	uint8_t get_id()
+	{
+		return MAVLINK_MSG_ID_VTOL_STATE;
+	}
+
+	static MavlinkStream *new_instance(Mavlink *mavlink)
+	{
+		return new MavlinkStreamVtolState(mavlink);
+	}
+
+	unsigned get_size()
+	{
+		return MAVLINK_MSG_ID_VTOL_STATE_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+	}
+
+private:
+	MavlinkOrbSubscription *_status_sub;
+
+	/* do not allow top copying this class */
+	MavlinkStreamVtolState(MavlinkStreamVtolState &);
+	MavlinkStreamVtolState& operator = (const MavlinkStreamVtolState &);
+
+protected:
+	explicit MavlinkStreamVtolState(Mavlink *mavlink) : MavlinkStream(mavlink),
+		_status_sub(_mavlink->add_orb_subscription(ORB_ID(vehicle_status)))
+	{}
+
+	void send(const hrt_abstime t)
+	{
+		struct vehicle_status_s status;
+
+		if (_status_sub->update(&status)) {
+			mavlink_vtol_state_t msg;
+
+			if (status.is_vtol)
+			{
+				if (status.is_rotary_wing)
+				{
+					if (status.in_transition_mode) {
+						msg.state = MAV_VTOL_STATE_TRANSITION_TO_FW;
+					} else {
+						msg.state = MAV_VTOL_STATE_MC;
+					}
+				}
+				else {
+					if (status.in_transition_mode) {
+						msg.state = MAV_VTOL_STATE_TRANSITION_TO_MC;
+					} else {
+						msg.state = MAV_VTOL_STATE_FW;
+					}
+				}
+			}
+			else {
+				msg.state = MAV_VTOL_STATE_UNDEFINED;
+			}
+
+			_mavlink->send_message(MAVLINK_MSG_ID_VTOL_STATE, &msg);
+		}
+	}
+};
 
 const StreamListItem *streams_list[] = {
 	new StreamListItem(&MavlinkStreamHeartbeat::new_instance, &MavlinkStreamHeartbeat::get_name_static),

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -2374,7 +2374,7 @@ private:
 
 	/* do not allow top copying this class */
 	MavlinkStreamVtolState(MavlinkStreamVtolState &);
-	MavlinkStreamVtolState& operator = (const MavlinkStreamVtolState &);
+	MavlinkStreamVtolState &operator = (const MavlinkStreamVtolState &);
 
 protected:
 	explicit MavlinkStreamVtolState(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -2388,25 +2388,25 @@ protected:
 		if (_status_sub->update(&status)) {
 			mavlink_vtol_state_t msg;
 
-			if (status.is_vtol)
-			{
-				if (status.is_rotary_wing)
-				{
+			if (status.is_vtol) {
+				if (status.is_rotary_wing) {
 					if (status.in_transition_mode) {
 						msg.state = MAV_VTOL_STATE_TRANSITION_TO_FW;
+
 					} else {
 						msg.state = MAV_VTOL_STATE_MC;
 					}
-				}
-				else {
+
+				} else {
 					if (status.in_transition_mode) {
 						msg.state = MAV_VTOL_STATE_TRANSITION_TO_MC;
+
 					} else {
 						msg.state = MAV_VTOL_STATE_FW;
 					}
 				}
-			}
-			else {
+
+			} else {
 				msg.state = MAV_VTOL_STATE_UNDEFINED;
 			}
 

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -2450,5 +2450,6 @@ const StreamListItem *streams_list[] = {
 	new StreamListItem(&MavlinkStreamCameraCapture::new_instance, &MavlinkStreamCameraCapture::get_name_static),
 	new StreamListItem(&MavlinkStreamCameraTrigger::new_instance, &MavlinkStreamCameraTrigger::get_name_static),
 	new StreamListItem(&MavlinkStreamDistanceSensor::new_instance, &MavlinkStreamDistanceSensor::get_name_static),
+	new StreamListItem(&MavlinkStreamVtolState::new_instance, &MavlinkStreamVtolState::get_name_static),
 	nullptr
 };

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -105,7 +105,7 @@ void Standard::update_vtol_state()
 	 * For the back transition the pusher motor is immediately stopped and rotors reactivated.
  	 */
 
-	if (_manual_control_sp->aux1 < 0.0f) {
+	if (!is_fixed_wing_requested()) {
 		// the transition to fw mode switch is off
 		if (_vtol_schedule.flight_mode == MC_MODE) {
 			// in mc mode

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -105,7 +105,7 @@ void Standard::update_vtol_state()
 	 * For the back transition the pusher motor is immediately stopped and rotors reactivated.
  	 */
 
-	if (!is_fixed_wing_requested()) {
+	if (!_attc->is_fixed_wing_requested()) {
 		// the transition to fw mode switch is off
 		if (_vtol_schedule.flight_mode == MC_MODE) {
 			// in mc mode

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -58,7 +58,7 @@ Tailsitter::~Tailsitter()
 void Tailsitter::update_vtol_state()
 {
 	// simply switch between the two modes
-	if (!is_fixed_wing_requested()) {
+	if (!_attc->is_fixed_wing_requested()) {
 		_vtol_mode = ROTARY_WING;
 	} else {
 		_vtol_mode = FIXED_WING;

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -58,9 +58,9 @@ Tailsitter::~Tailsitter()
 void Tailsitter::update_vtol_state()
 {
 	// simply switch between the two modes
-	if (_manual_control_sp->aux1 < 0.0f) {
+	if (!is_fixed_wing_requested()) {
 		_vtol_mode = ROTARY_WING;
-	} else if (_manual_control_sp->aux1 > 0.0f) {
+	} else {
 		_vtol_mode = FIXED_WING;
 	}
 }

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -158,7 +158,7 @@ void Tiltrotor::update_vtol_state()
 	 * forward completely. For the backtransition the motors simply rotate back.
  	*/
 
-	if (!is_fixed_wing_requested()) {
+	if (!_attc->is_fixed_wing_requested()) {
 
 		// plane is in multicopter mode
 		switch(_vtol_schedule.flight_mode) {

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -158,7 +158,7 @@ void Tiltrotor::update_vtol_state()
 	 * forward completely. For the backtransition the motors simply rotate back.
  	*/
 
-	if (_manual_control_sp->aux1 < 0.0f) {
+	if (!is_fixed_wing_requested()) {
 
 		// plane is in multicopter mode
 		switch(_vtol_schedule.flight_mode) {

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -318,7 +318,8 @@ VtolAttitudeControl::vehicle_local_pos_poll()
 * Check for command updates.
 */
 void
-VtolAttitudeControl::vehicle_cmd_poll() {
+VtolAttitudeControl::vehicle_cmd_poll()
+{
 	bool updated;
 	orb_check(_vehicle_cmd_sub, &updated);
 
@@ -332,7 +333,8 @@ VtolAttitudeControl::vehicle_cmd_poll() {
 * Check received command
 */
 void
-VtolAttitudeControl::handle_command() {
+VtolAttitudeControl::handle_command()
+{
 	// update transition command if necessary
 	if (_vehicle_cmd.command == vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION) {
 		_transition_command = int(_vehicle_cmd.param1 + 0.5f);
@@ -347,10 +349,12 @@ bool
 VtolAttitudeControl::is_fixed_wing_requested()
 {
 	bool to_fw = _manual_control_sp.aux1 > 0.0f;
- 	if (_v_control_mode.flag_control_offboard_enabled) {
- 		to_fw = _transition_command == vehicle_status_s::VEHICLE_VTOL_STATE_FW;
- 	}
- 	return to_fw;
+
+	if (_v_control_mode.flag_control_offboard_enabled) {
+		to_fw = _transition_command == vehicle_status_s::VEHICLE_VTOL_STATE_FW;
+	}
+
+	return to_fw;
 }
 
 /**
@@ -531,12 +535,11 @@ void VtolAttitudeControl::task_main()
 		_vtol_type->update_vtol_state();
 
 		// reset transition command if not in offboard control
-		if (!_v_control_mode.flag_control_offboard_enabled)
-		{
+		if (!_v_control_mode.flag_control_offboard_enabled) {
 			if (_vtol_type->get_mode() == ROTARY_WING) {
 				_transition_command = vehicle_status_s::VEHICLE_VTOL_STATE_MC;
-			}
-			else if (_vtol_type->get_mode() == FIXED_WING) {
+
+			} else if (_vtol_type->get_mode() == FIXED_WING) {
 				_transition_command = vehicle_status_s::VEHICLE_VTOL_STATE_FW;
 			}
 		}
@@ -555,6 +558,7 @@ void VtolAttitudeControl::task_main()
 
 				fill_mc_att_rates_sp();
 			}
+
 		} else if (_vtol_type->get_mode() == FIXED_WING) {
 			// vehicle is in fw mode
 			_vtol_vehicle_status.vtol_in_rw_mode = false;
@@ -569,11 +573,13 @@ void VtolAttitudeControl::task_main()
 
 				fill_fw_att_rates_sp();
 			}
+
 		} else if (_vtol_type->get_mode() == TRANSITION) {
 			// vehicle is doing a transition
 			_vtol_vehicle_status.vtol_in_trans_mode = true;
 
 			bool got_new_data = false;
+
 			if (fds[0].revents & POLLIN) {
 				orb_copy(ORB_ID(actuator_controls_virtual_mc), _actuator_inputs_mc, &_actuators_mc_in);
 				got_new_data = true;
@@ -598,29 +604,30 @@ void VtolAttitudeControl::task_main()
 		_vtol_type->fill_actuator_outputs();
 
 		/* Only publish if the proper mode(s) are enabled */
-		if(_v_control_mode.flag_control_attitude_enabled ||
-		   _v_control_mode.flag_control_rates_enabled ||
-		   _v_control_mode.flag_control_manual_enabled)
-		{
+		if (_v_control_mode.flag_control_attitude_enabled ||
+		    _v_control_mode.flag_control_rates_enabled ||
+		    _v_control_mode.flag_control_manual_enabled) {
 			if (_actuators_0_pub != nullptr) {
 				orb_publish(ORB_ID(actuator_controls_0), _actuators_0_pub, &_actuators_out_0);
+
 			} else {
 				_actuators_0_pub = orb_advertise(ORB_ID(actuator_controls_0), &_actuators_out_0);
 			}
 
 			if (_actuators_1_pub != nullptr) {
 				orb_publish(ORB_ID(actuator_controls_1), _actuators_1_pub, &_actuators_out_1);
+
 			} else {
 				_actuators_1_pub = orb_advertise(ORB_ID(actuator_controls_1), &_actuators_out_1);
 			}
 		}
 
 		// publish the attitude rates setpoint
-		if(_v_rates_sp_pub != nullptr) {
-			orb_publish(ORB_ID(vehicle_rates_setpoint),_v_rates_sp_pub,&_v_rates_sp);
-		}
-		else {
-			_v_rates_sp_pub = orb_advertise(ORB_ID(vehicle_rates_setpoint),&_v_rates_sp);
+		if (_v_rates_sp_pub != nullptr) {
+			orb_publish(ORB_ID(vehicle_rates_setpoint), _v_rates_sp_pub, &_v_rates_sp);
+
+		} else {
+			_v_rates_sp_pub = orb_advertise(ORB_ID(vehicle_rates_setpoint), &_v_rates_sp);
 		}
 	}
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -99,6 +99,7 @@ public:
 	~VtolAttitudeControl();
 
 	int start();	/* start the task and return OK on success */
+	bool is_fixed_wing_requested();
 
 	struct vehicle_attitude_s* 			get_att () {return &_v_att;}
 	struct vehicle_attitude_setpoint_s* get_att_sp () {return &_v_att_sp;}

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -117,7 +117,6 @@ public:
 	struct vehicle_local_position_s* 	get_local_pos () {return &_local_pos;}
 	struct airspeed_s* 					get_airspeed () {return &_airspeed;}
 	struct battery_status_s* 			get_batt_status () {return &_batt_status;}
-	struct vehicle_command_s*			get_vehicle_transition_cmd () {return &_vehicle_transition_cmd;}
 
 	struct Params* 						get_params () {return &_params;}
 
@@ -167,7 +166,6 @@ private:
 	struct airspeed_s 					_airspeed;			// airspeed
 	struct battery_status_s 			_batt_status; 		// battery status
 	struct vehicle_command_s			_vehicle_cmd;
-	struct vehicle_command_s			_vehicle_transition_cmd; // stores transition commands only
 
 	Params _params;	// struct holding the parameters
 
@@ -191,6 +189,7 @@ private:
 	 * to waste energy when gliding. */
 	unsigned _motor_count;	// number of motors
 	float _airspeed_tot;
+	int _transition_command;
 
 	VtolType * _vtol_type;	// base class for different vtol types
 	Tiltrotor * _tiltrotor;	// tailsitter vtol type
@@ -217,6 +216,7 @@ private:
 	int 		parameters_update();			//Update local paraemter cache
 	void 		fill_mc_att_rates_sp();
 	void 		fill_fw_att_rates_sp();
+	void		handle_command();
 };
 
 #endif

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -73,6 +73,7 @@
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/battery_status.h>
+#include <uORB/topics/vehicle_command.h>
 #include <systemlib/param/param.h>
 #include <systemlib/err.h>
 #include <systemlib/systemlib.h>
@@ -115,6 +116,7 @@ public:
 	struct vehicle_local_position_s* 	get_local_pos () {return &_local_pos;}
 	struct airspeed_s* 					get_airspeed () {return &_airspeed;}
 	struct battery_status_s* 			get_batt_status () {return &_batt_status;}
+	struct vehicle_command_s*			get_vehicle_transition_cmd () {return &_vehicle_transition_cmd;}
 
 	struct Params* 						get_params () {return &_params;}
 
@@ -136,6 +138,7 @@ private:
 	int 	_local_pos_sub;			// sensor subscription
 	int 	_airspeed_sub;			// airspeed subscription
 	int 	_battery_status_sub;	// battery status subscription
+	int 	_vehicle_cmd_sub;
 
 	int 	_actuator_inputs_mc;	//topic on which the mc_att_controller publishes actuator inputs
 	int 	_actuator_inputs_fw;	//topic on which the fw_att_controller publishes actuator inputs
@@ -162,6 +165,8 @@ private:
 	struct vehicle_local_position_s		_local_pos;
 	struct airspeed_s 					_airspeed;			// airspeed
 	struct battery_status_s 			_batt_status; 		// battery status
+	struct vehicle_command_s			_vehicle_cmd;
+	struct vehicle_command_s			_vehicle_transition_cmd; // stores transition commands only
 
 	Params _params;	// struct holding the parameters
 
@@ -206,6 +211,7 @@ private:
 	void 		vehicle_local_pos_poll();		// Check for changes in sensor values
 	void 		vehicle_airspeed_poll();		// Check for changes in airspeed
 	void 		vehicle_battery_poll();			// Check for battery updates
+	void		vehicle_cmd_poll();
 	void 		parameters_update_poll();		//Check if parameters have changed
 	int 		parameters_update();			//Update local paraemter cache
 	void 		fill_mc_att_rates_sp();

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -134,8 +134,8 @@ void VtolType::set_idle_fw()
 }
 
 /*
- * Return true if fixed-wing mode is requested.
- * Either via switch or via command.
+ * Returns true if fixed-wing mode is requested.
+ * Changed either via switch or via command.
  */
 bool VtolType::is_fixed_wing_requested()
 {

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -63,6 +63,7 @@ _vtol_mode(ROTARY_WING)
 	_local_pos = _attc->get_local_pos();
 	_airspeed = _attc->get_airspeed();
 	_batt_status = _attc->get_batt_status();
+	_vehicle_transition_cmd = _attc->get_vehicle_transition_cmd();
 	_params = _attc->get_params();
 
 	flag_idle_mc = true;
@@ -130,4 +131,17 @@ void VtolType::set_idle_fw()
 	if (ret != OK) {errx(ret, "failed setting min values");}
 
 	close(fd);
+}
+
+/*
+ * Return true if fixed-wing mode is requested.
+ * Either via switch or via command.
+ */
+bool VtolType::is_fixed_wing_requested()
+{
+	bool to_fw = _manual_control_sp->aux1 > 0.0f;
+ 	if (_v_control_mode->flag_control_offboard_enabled) {
+ 		to_fw = fabsf(_vehicle_transition_cmd->param1 - vehicle_status_s::VEHICLE_VTOL_STATE_FW) < FLT_EPSILON;
+ 	}
+ 	return to_fw;
 }

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -63,7 +63,6 @@ _vtol_mode(ROTARY_WING)
 	_local_pos = _attc->get_local_pos();
 	_airspeed = _attc->get_airspeed();
 	_batt_status = _attc->get_batt_status();
-	_vehicle_transition_cmd = _attc->get_vehicle_transition_cmd();
 	_params = _attc->get_params();
 
 	flag_idle_mc = true;
@@ -131,17 +130,4 @@ void VtolType::set_idle_fw()
 	if (ret != OK) {errx(ret, "failed setting min values");}
 
 	close(fd);
-}
-
-/*
- * Returns true if fixed-wing mode is requested.
- * Changed either via switch or via command.
- */
-bool VtolType::is_fixed_wing_requested()
-{
-	bool to_fw = _manual_control_sp->aux1 > 0.0f;
- 	if (_v_control_mode->flag_control_offboard_enabled) {
- 		to_fw = fabsf(_vehicle_transition_cmd->param1 - vehicle_status_s::VEHICLE_VTOL_STATE_FW) < FLT_EPSILON;
- 	}
- 	return to_fw;
 }

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -87,6 +87,8 @@ public:
 
 	mode get_mode () {return _vtol_mode;};
 
+	bool is_fixed_wing_requested();
+
 protected:
 	VtolAttitudeControl *_attc;
 	mode _vtol_mode;
@@ -107,6 +109,7 @@ protected:
 	struct vehicle_local_position_s		*_local_pos;
 	struct airspeed_s 					*_airspeed;			// airspeed
 	struct battery_status_s 			*_batt_status; 		// battery status
+	struct vehicle_command_s			*_vehicle_transition_cmd;
 
 	struct Params 						*_params;
 

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -87,8 +87,6 @@ public:
 
 	mode get_mode () {return _vtol_mode;};
 
-	bool is_fixed_wing_requested();
-
 protected:
 	VtolAttitudeControl *_attc;
 	mode _vtol_mode;
@@ -109,7 +107,6 @@ protected:
 	struct vehicle_local_position_s		*_local_pos;
 	struct airspeed_s 					*_airspeed;			// airspeed
 	struct battery_status_s 			*_batt_status; 		// battery status
-	struct vehicle_command_s			*_vehicle_transition_cmd;
 
 	struct Params 						*_params;
 


### PR DESCRIPTION
For the VTOL auto flight demo we used a hacked mavlink command. This adds a properly setup command for VTOL transitions. Goals
- Listening to a new transition command (MAVLink PR coming)
- Pulling transition switch one level up

Waiting on VTOL cleanup and transition state flag. @tumbili, @LorenzMeier : is that going into the right direction?

TODO:
- [x] pull switch up for all types
- [x] implement vtol state message
- [x] reset transition command when dropping out of offboard
- [x] review
- [x] bench tested