### PR TITLE
VTOL updats for assisted modes

### DIFF
--- a/ROMFS/px4fmu_common/init.d/13002_firefly6
+++ b/ROMFS/px4fmu_common/init.d/13002_firefly6
@@ -46,5 +46,6 @@ set PWM_AUX_MAX 2000
 set MAV_TYPE 21
 
 param set VT_MOT_COUNT 6
+param set VT_FW_MOT_OFF 23
 param set VT_IDLE_PWM_MC 1080
 param set VT_TYPE 1

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_apps
@@ -18,4 +18,4 @@ fw_pos_control_l1 start
 # Start Land Detector
 # Fixed wing for now until we have something for VTOL
 #
-land_detector start fixedwing
+land_detector start multicopter

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -106,6 +106,7 @@ uint32 component_id			# subsystem / component id, inspired by MAVLink's componen
 bool is_rotary_wing			# True if system is in rotary wing configuration, so for a VTOL this is only true while flying as a multicopter
 bool is_vtol				# True if the system is VTOL capable
 bool vtol_fw_permanent_stab		# True if vtol should stabilize attitude for fw in manual mode
+bool in_transition_mode
 
 bool condition_battery_voltage_valid
 bool condition_system_in_air_restore		# true if we can restore in mid air

--- a/msg/vtol_vehicle_status.msg
+++ b/msg/vtol_vehicle_status.msg
@@ -1,4 +1,5 @@
 uint64 timestamp		# Microseconds since system boot
 bool vtol_in_rw_mode		# true: vtol vehicle is in rotating wing mode
+bool vtol_in_trans_mode
 bool fw_permanent_stab		# In fw mode stabilize attitude even if in manual mode
 float32 airspeed_tot		# Estimated airspeed over control surfaces

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1498,6 +1498,7 @@ int commander_thread_main(int argc, char *argv[])
 			/* Make sure that this is only adjusted if vehicle really is of type vtol*/
 			if (is_vtol(&status)) {
 				status.is_rotary_wing = vtol_status.vtol_in_rw_mode;
+				status.in_transition_mode = vtol_status.vtol_in_trans_mode;
 			}
 		}
 

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -197,6 +197,8 @@ static struct home_position_s _home;
 
 static unsigned _last_mission_instance = 0;
 
+struct vtol_vehicle_status_s vtol_status;
+
 /**
  * The daemon app only briefly exists to start
  * the background job. The stack size assigned in the
@@ -1169,7 +1171,7 @@ int commander_thread_main(int argc, char *argv[])
 
 	/* Subscribe to vtol vehicle status topic */
 	int vtol_vehicle_status_sub = orb_subscribe(ORB_ID(vtol_vehicle_status));
-	struct vtol_vehicle_status_s vtol_status;
+	//struct vtol_vehicle_status_s vtol_status;
 	memset(&vtol_status, 0, sizeof(vtol_status));
 	vtol_status.vtol_in_rw_mode = true;		//default for vtol is rotary wing
 
@@ -2682,13 +2684,13 @@ set_control_mode()
 			!offboard_control_mode.ignore_velocity ||
 			!offboard_control_mode.ignore_acceleration_force;
 
-		control_mode.flag_control_velocity_enabled = !offboard_control_mode.ignore_velocity ||
-			!offboard_control_mode.ignore_position;
+		control_mode.flag_control_velocity_enabled = (!offboard_control_mode.ignore_velocity ||
+			!offboard_control_mode.ignore_position) && !vtol_status.vtol_in_trans_mode;
 
 		control_mode.flag_control_climb_rate_enabled = !offboard_control_mode.ignore_velocity ||
 			!offboard_control_mode.ignore_position;
 
-		control_mode.flag_control_position_enabled = !offboard_control_mode.ignore_position;
+		control_mode.flag_control_position_enabled = !offboard_control_mode.ignore_position && !vtol_status.vtol_in_trans_mode;
 
 		control_mode.flag_control_altitude_enabled = !offboard_control_mode.ignore_velocity ||
 			!offboard_control_mode.ignore_position;

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2576,8 +2576,8 @@ set_control_mode()
 		control_mode.flag_control_attitude_enabled = true;
 		control_mode.flag_control_altitude_enabled = true;
 		control_mode.flag_control_climb_rate_enabled = true;
-		control_mode.flag_control_position_enabled = true;
-		control_mode.flag_control_velocity_enabled = true;
+		control_mode.flag_control_position_enabled = !vtol_status.vtol_in_trans_mode;
+		control_mode.flag_control_velocity_enabled = !vtol_status.vtol_in_trans_mode;
 		control_mode.flag_control_termination_enabled = false;
 		break;
 

--- a/src/modules/fw_att_control/fw_att_control_main.cpp
+++ b/src/modules/fw_att_control/fw_att_control_main.cpp
@@ -941,7 +941,7 @@ FixedwingAttitudeControl::task_main()
 					att_sp.thrust = throttle_sp;
 
 					/* lazily publish the setpoint only once available */
-					if (!_vehicle_status.is_rotary_wing) {
+					if (!_vehicle_status.is_rotary_wing && !_vehicle_status.in_transition_mode) {
 						if (_attitude_sp_pub != nullptr) {
 							/* publish the attitude setpoint */
 							orb_publish(ORB_ID(vehicle_attitude_setpoint), _attitude_sp_pub, &att_sp);

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1459,7 +1459,7 @@ MulticopterPositionControl::task_main()
 		if (!(_control_mode.flag_control_offboard_enabled &&
 					!(_control_mode.flag_control_position_enabled ||
 						_control_mode.flag_control_velocity_enabled))) {
-			if (_att_sp_pub != nullptr && _vehicle_status.is_rotary_wing) {
+			if (_att_sp_pub != nullptr && (_vehicle_status.is_rotary_wing || _vehicle_status.in_transition_mode)) {
 				orb_publish(ORB_ID(vehicle_attitude_setpoint), _att_sp_pub, &_att_sp);
 			} else if (_att_sp_pub == nullptr && _vehicle_status.is_rotary_wing){
 				_att_sp_pub = orb_advertise(ORB_ID(vehicle_attitude_setpoint), &_att_sp);

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -993,6 +993,11 @@ MulticopterPositionControl::task_main()
 			reset_yaw_sp = true;
 		}
 
+		// XXX Temporary: for vtol use we need to reset the yaw setpoint when we are doing a transition
+		if (_vehicle_status.in_transition_mode) {
+			reset_yaw_sp = true;
+		}
+
 		//Update previous arming state
 		was_armed = _control_mode.flag_armed;
 

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -41,15 +41,15 @@
 #include "tiltrotor.h"
 #include "vtol_att_control_main.h"
 
-#define ARSP_BLEND_START 8.0f	// airspeed at which we start blending mc/fw controls
 #define ARSP_YAW_CTRL_DISABLE 7.0f	// airspeed at which we stop controlling yaw during a front transition
-#define DELTA 	0.5f	// the time it should take to tilt the rotors forward completly after the airspeed
-						// for transitioning into fixed wing mode has been reached
 
 Tiltrotor::Tiltrotor(VtolAttitudeControl *attc) :
 VtolType(attc),
 _rear_motors(ENABLED),
-_tilt_control(0.0f)
+_tilt_control(0.0f),
+_roll_weight_mc(1.0f),
+_yaw_weight_mc(1.0f)
+_min_front_trans_dur(0.5f)
 {
 	_vtol_schedule.flight_mode = MC_MODE;
 	_vtol_schedule.transition_start = 0;
@@ -64,7 +64,9 @@ _tilt_control(0.0f)
 	_params_handles_tiltrotor.tilt_transition = param_find("VT_TILT_TRANS");
 	_params_handles_tiltrotor.tilt_fw = param_find("VT_TILT_FW");
 	_params_handles_tiltrotor.airspeed_trans = param_find("VT_ARSP_TRANS");
+	_params_handles_tiltrotor.airspeed_blend_start = param_find("VT_ARSP_BLEND");
 	_params_handles_tiltrotor.elevons_mc_lock = param_find("VT_ELEV_MC_LOCK");
+	_params_handles_tiltrotor.front_trans_dur_p2 = param_find("VT_TRANS_P2_DUR");
 }
 
 Tiltrotor::~Tiltrotor()
@@ -102,15 +104,23 @@ Tiltrotor::parameters_update()
 	param_get(_params_handles_tiltrotor.airspeed_trans, &v);
 	_params_tiltrotor.airspeed_trans = v;
 
+	/* vtol airspeed at which we start blending mc/fw controls */
+	param_get(_params_handles_tiltrotor.airspeed_blend_start, &v);
+	_params_tiltrotor.airspeed_blend_start = v;
+
 	/* vtol lock elevons in multicopter */
 	param_get(_params_handles_tiltrotor.elevons_mc_lock, &l);
 	_params_tiltrotor.elevons_mc_lock = l;
 
-	/* avoid parameters which will lead to zero division in the transition code */
-	_params.front_trans_dur = math::constrain(_params.front_trans_dur, 0.5f, 10.0f);
+	/* vtol front transition phase 2 duration */
+	param_get(_params_handles_tiltrotor.front_trans_dur_p2, &v);
+	_params_tiltrotor.front_trans_dur_p2 = v;
 
-	if (fabsf(_params.airspeed_trans - ARSP_BLEND_START) < 1.0f ) {
-		_params.airspeed_trans = ARSP_BLEND_START + 1.0f;
+	/* avoid parameters which will lead to zero division in the transition code */
+	_params_tiltrotor.front_trans_dur = math::max(_params_tiltrotor.front_trans_dur, _min_front_trans_dur);
+
+	if ( _params_tiltrotor.airspeed_trans < _params_tiltrotor.airspeed_blend_start + 1.0f ) {
+		_params_tiltrotor.airspeed_trans = _params_tiltrotor.airspeed_blend_start + 1.0f;
 	}
 
 	return OK;
@@ -253,8 +263,8 @@ void Tiltrotor::update_transition_state()
 		}
 
 		// do blending of mc and fw controls
-		if (_airspeed->true_airspeed_m_s >= ARSP_BLEND_START) {
-			_mc_roll_weight = 1.0f - (_airspeed->true_airspeed_m_s - ARSP_BLEND_START) / (_params_tiltrotor.airspeed_trans - ARSP_BLEND_START);
+		if (_airspeed->true_airspeed_m_s >= _params_tiltrotor.airspeed_blend_start) {
+			_mc_roll_weight = 1.0f - (_airspeed->true_airspeed_m_s - _params_tiltrotor.airspeed_blend_start) / (_params_tiltrotor.airspeed_trans - _params_tiltrotor.airspeed_blend_start);
 		} else {
 			// at low speeds give full weight to mc
 			_mc_roll_weight = 1.0f;
@@ -269,7 +279,7 @@ void Tiltrotor::update_transition_state()
 	} else if (_vtol_schedule.flight_mode == TRANSITION_FRONT_P2) {
 		// the plane is ready to go into fixed wing mode, tilt the rotors forward completely
 		_tilt_control = _params_tiltrotor.tilt_transition +
-			fabsf(_params_tiltrotor.tilt_fw - _params_tiltrotor.tilt_transition)*(float)hrt_elapsed_time(&_vtol_schedule.transition_start)/(DELTA*1000000.0f);
+			fabsf(_params_tiltrotor.tilt_fw - _params_tiltrotor.tilt_transition)*(float)hrt_elapsed_time(&_vtol_schedule.transition_start)/(_params_tiltrotor.front_trans_dur_p2*1000000.0f);
 		_mc_roll_weight = 0.0f;
 	} else if (_vtol_schedule.flight_mode == TRANSITION_BACK) {
 		if (_rear_motors != IDLE) {

--- a/src/modules/vtol_att_control/tiltrotor.h
+++ b/src/modules/vtol_att_control/tiltrotor.h
@@ -89,6 +89,7 @@ private:
 		float airspeed_blend_start;		/**< airspeed at which we start blending mc/fw controls */
 		int elevons_mc_lock;			/**< lock elevons in multicopter mode */
 		float front_trans_dur_p2;
+		int fw_motors_off;			/**< bitmask of all motors that should be off in fixed wing mode */
 	} _params_tiltrotor;
 
 	struct {
@@ -101,6 +102,7 @@ private:
 		param_t airspeed_blend_start;
 		param_t elevons_mc_lock;
 		param_t front_trans_dur_p2;
+		param_t fw_motors_off;
 	} _params_handles_tiltrotor;
 
 	enum vtol_mode {
@@ -132,6 +134,16 @@ private:
 	float _yaw_weight_mc;		/**< multicopter desired yaw moment weight */
 
 	const float _min_front_trans_dur;	/**< min possible time in which rotors are rotated into the first position */
+
+	/**
+	 * Return a bitmap of channels that should be turned off in fixed wing mode.
+	 */
+	int get_motor_off_channels(const int channels);
+
+	/**
+	 * Return true if the motor channel is off in fixed wing mode.
+	 */
+	bool is_motor_off_channel(const int channel);
 
 	/**
 	 * Write control values to actuator output topics.

--- a/src/modules/vtol_att_control/tiltrotor.h
+++ b/src/modules/vtol_att_control/tiltrotor.h
@@ -86,7 +86,9 @@ private:
 		float tilt_transition;			/**< actuator value corresponding to transition tilt (e.g 45 degrees) */
 		float tilt_fw;					/**< actuator value corresponding to fw tilt */
 		float airspeed_trans;			/**< airspeed at which we switch to fw mode after transition */
+		float airspeed_blend_start;		/**< airspeed at which we start blending mc/fw controls */
 		int elevons_mc_lock;			/**< lock elevons in multicopter mode */
+		float front_trans_dur_p2;
 	} _params_tiltrotor;
 
 	struct {
@@ -96,7 +98,9 @@ private:
 		param_t tilt_transition;
 		param_t tilt_fw;
 		param_t airspeed_trans;
+		param_t airspeed_blend_start;
 		param_t elevons_mc_lock;
+		param_t front_trans_dur_p2;
 	} _params_handles_tiltrotor;
 
 	enum vtol_mode {
@@ -126,6 +130,8 @@ private:
 	float _tilt_control;		/**< actuator value for the tilt servo */
 	float _roll_weight_mc;		/**< multicopter desired roll moment weight */
 	float _yaw_weight_mc;		/**< multicopter desired yaw moment weight */
+
+	const float _min_front_trans_dur;	/**< min possible time in which rotors are rotated into the first position */
 
 	/**
 	 * Write control values to actuator output topics.

--- a/src/modules/vtol_att_control/tiltrotor_params.c
+++ b/src/modules/vtol_att_control/tiltrotor_params.c
@@ -72,3 +72,15 @@ PARAM_DEFINE_FLOAT(VT_TILT_TRANS, 0.3f);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_FLOAT(VT_TILT_FW, 1.0f);
+
+/**
+ * Duration of front transition phase 2
+ *
+ * Time in seconds it should take for the rotors to rotate forward completely from the point
+ * when the plane has picked up enough airspeed and is ready to go into fixed wind mode.
+ *
+ * @min 0.1
+ * @max 2
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_TRANS_P2_DUR, 0.5f);

--- a/src/modules/vtol_att_control/tiltrotor_params.c
+++ b/src/modules/vtol_att_control/tiltrotor_params.c
@@ -84,3 +84,13 @@ PARAM_DEFINE_FLOAT(VT_TILT_FW, 1.0f);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_FLOAT(VT_TRANS_P2_DUR, 0.5f);
+
+/**
+ * The channel number of motors that must be turned off in fixed wing mode.
+ *
+ *
+ * @min 0
+ * @max 123456
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_INT32(VT_FW_MOT_OFF, 0);

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -491,6 +491,7 @@ void VtolAttitudeControl::task_main()
 		if (_vtol_type->get_mode() == ROTARY_WING) {
 			// vehicle is in rotary wing mode
 			_vtol_vehicle_status.vtol_in_rw_mode = true;
+			_vtol_vehicle_status.vtol_in_trans_mode = false;
 
 			// got data from mc attitude controller
 			if (fds[0].revents & POLLIN) {
@@ -503,6 +504,7 @@ void VtolAttitudeControl::task_main()
 		} else if (_vtol_type->get_mode() == FIXED_WING) {
 			// vehicle is in fw mode
 			_vtol_vehicle_status.vtol_in_rw_mode = false;
+			_vtol_vehicle_status.vtol_in_trans_mode = false;
 
 			// got data from fw attitude controller
 			if (fds[1].revents & POLLIN) {
@@ -515,6 +517,8 @@ void VtolAttitudeControl::task_main()
 			}
 		} else if (_vtol_type->get_mode() == TRANSITION) {
 			// vehicle is doing a transition
+			_vtol_vehicle_status.vtol_in_trans_mode = true;
+
 			bool got_new_data = false;
 			if (fds[0].revents & POLLIN) {
 				orb_copy(ORB_ID(actuator_controls_virtual_mc), _actuator_inputs_mc, &_actuators_mc_in);


### PR DESCRIPTION
- Use multicopter landed detector as it will register takeoff at ground level and therefore give the fixed-wing position controller the correct home position later
- Also consider transition state in posctl