### PR TITLE
WIP: VTOL updates for assisted modes

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2578,8 +2578,8 @@ set_control_mode()
 		control_mode.flag_control_attitude_enabled = true;
 		control_mode.flag_control_altitude_enabled = true;
 		control_mode.flag_control_climb_rate_enabled = true;
-		control_mode.flag_control_position_enabled = !vtol_status.vtol_in_trans_mode;
-		control_mode.flag_control_velocity_enabled = !vtol_status.vtol_in_trans_mode;
+		control_mode.flag_control_position_enabled = !status.in_transition_mode;
+		control_mode.flag_control_velocity_enabled = !status.in_transition_mode;
 		control_mode.flag_control_termination_enabled = false;
 		break;
 
@@ -2688,12 +2688,12 @@ set_control_mode()
 			!offboard_control_mode.ignore_acceleration_force;
 
 		control_mode.flag_control_velocity_enabled = (!offboard_control_mode.ignore_velocity ||
-			!offboard_control_mode.ignore_position) && !vtol_status.vtol_in_trans_mode;
+			!offboard_control_mode.ignore_position) && !status.in_transition_mode;
 
 		control_mode.flag_control_climb_rate_enabled = !offboard_control_mode.ignore_velocity ||
 			!offboard_control_mode.ignore_position;
 
-		control_mode.flag_control_position_enabled = !offboard_control_mode.ignore_position && !vtol_status.vtol_in_trans_mode;
+		control_mode.flag_control_position_enabled = !offboard_control_mode.ignore_position && !status.in_transition_mode;
 
 		control_mode.flag_control_altitude_enabled = !offboard_control_mode.ignore_velocity ||
 			!offboard_control_mode.ignore_position;

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2578,8 +2578,8 @@ set_control_mode()
 		control_mode.flag_control_attitude_enabled = true;
 		control_mode.flag_control_altitude_enabled = true;
 		control_mode.flag_control_climb_rate_enabled = true;
-		control_mode.flag_control_position_enabled = true;
-		control_mode.flag_control_velocity_enabled = true;
+		control_mode.flag_control_position_enabled = !vtol_status.vtol_in_trans_mode;
+		control_mode.flag_control_velocity_enabled = !vtol_status.vtol_in_trans_mode;
 		control_mode.flag_control_termination_enabled = false;
 		break;
 


### PR DESCRIPTION
* Use multicopter landed detector as it will register takeoff at ground level and therefore give the fixed-wing position controller the correct home position later
* Also consider transition state in posctl


Tested on a standard VTOL: http://dash.oznet.ch/view/zqm9GvcUzafR8SnaPYEHf9
Doing transitions in alt and posctl
