### PR TITLE
use multicopter landing detector for vtol

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.vtol_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_apps
@@ -16,6 +16,6 @@ fw_pos_control_l1 start
 
 #
 # Start Land Detector
-# Fixed wing for now until we have something for VTOL
+# Multicopter for now until we have something for VTOL
 #
-land_detector start fixedwing
+land_detector start multicopter


### PR DESCRIPTION
This has shown at least temporarily to be the better choice for vtol. The fw landing detector indicates landing as soon as the vehicle hovers.