### PR TITLE
Beta uavcan servers fix

### DIFF
--- a/src/modules/uavcan/uavcan_servers.cpp
+++ b/src/modules/uavcan/uavcan_servers.cpp
@@ -98,6 +98,7 @@ UavcanServers::~UavcanServers()
 	if (_mutex_inited) {
 		(void)Lock::deinit(_subnode_mutex);
 	}
+	_main_node.getDispatcher().removeRxFrameListener();
 }
 
 int UavcanServers::stop(void)

--- a/src/modules/uavcan/uavcan_servers.cpp
+++ b/src/modules/uavcan/uavcan_servers.cpp
@@ -142,8 +142,9 @@ int UavcanServers::start(unsigned num_ifaces, uavcan::INode &main_node)
 	int rv  = _instance->init(num_ifaces);
 
 	if (rv < 0) {
-		warnx("Node init failed %i", rv);
+		warnx("Node init failed: %d", rv);
 		delete _instance;
+		_instance = nullptr;
 		return rv;
 	}
 
@@ -163,9 +164,10 @@ int UavcanServers::start(unsigned num_ifaces, uavcan::INode &main_node)
 	rv = pthread_create(&_instance->_subnode_thread, &tattr, static_cast<pthread_startroutine_t>(run_trampoline), NULL);
 
 	if (rv < 0) {
-		warnx("start failed: %d", errno);
+		warnx("pthread_create() failed: %d", errno);
 		rv =  -errno;
 		delete _instance;
+		_instance = nullptr;
 	}
 
 	return rv;
@@ -173,6 +175,8 @@ int UavcanServers::start(unsigned num_ifaces, uavcan::INode &main_node)
 
 int UavcanServers::init(unsigned num_ifaces)
 {
+	errno = 0;
+
 	/*
 	 * Initialize the mutex.
 	 * giving it its path
@@ -181,6 +185,7 @@ int UavcanServers::init(unsigned num_ifaces)
 	int ret = Lock::init(_subnode_mutex);
 
 	if (ret < 0) {
+		warnx("Lock init: %d", errno);
 		return ret;
 	}
 
@@ -197,6 +202,7 @@ int UavcanServers::init(unsigned num_ifaces)
 	ret = _fw_version_checker.createFwPaths(UAVCAN_FIRMWARE_PATH);
 
 	if (ret < 0) {
+		warnx("FirmwareVersionChecker init: %d, errno: %d", ret, errno);
 		return ret;
 	}
 
@@ -205,6 +211,7 @@ int UavcanServers::init(unsigned num_ifaces)
 	ret = _fw_server.start();
 
 	if (ret < 0) {
+		warnx("BasicFileServer init: %d, errno: %d", ret, errno);
 		return ret;
 	}
 
@@ -213,6 +220,7 @@ int UavcanServers::init(unsigned num_ifaces)
 	ret = _storage_backend.init(UAVCAN_NODE_DB_PATH);
 
 	if (ret < 0) {
+		warnx("FileStorageBackend init: %d, errno: %d", ret, errno);
 		return ret;
 	}
 
@@ -221,6 +229,7 @@ int UavcanServers::init(unsigned num_ifaces)
 	ret = _tracer.init(UAVCAN_LOG_FILE);
 
 	if (ret < 0) {
+		warnx("FileEventTracer init: %d, errno: %d", ret, errno);
 		return ret;
 	}
 
@@ -232,6 +241,7 @@ int UavcanServers::init(unsigned num_ifaces)
 	ret = _server_instance.init(hwver.unique_id);
 
 	if (ret < 0) {
+		warnx("CentralizedServer init: %d", ret);
 		return ret;
 	}
 
@@ -240,6 +250,7 @@ int UavcanServers::init(unsigned num_ifaces)
 	ret = _node_info_retriever.start();
 
 	if (ret < 0) {
+		warnx("NodeInfoRetriever init: %d", ret);
 		return ret;
 	}
 
@@ -248,6 +259,7 @@ int UavcanServers::init(unsigned num_ifaces)
 	ret = _fw_upgrade_trigger.start(_node_info_retriever, _fw_version_checker.getFirmwarePath());
 
 	if (ret < 0) {
+		warnx("FirmwareUpdateTrigger init: %d", ret);
 		return ret;
 	}
 


### PR DESCRIPTION
@davids5 This fix prevents the UAVCAN thread from dying when FW servers fail to initialize. One of the ways to reproduce the problem is to execute `uavcan start fw` while the SD card is missing.

The problem is fixed on [this line](https://github.com/PX4/Firmware/blob/36f91d30ebf6d617e4d3dc3299855a59598b4170/src/modules/uavcan/uavcan_servers.cpp#L101); it was caused by the main UAVCAN thread trying to relay incoming CAN frames to a deleted listener object via `uavcan::IRxFrameListener`.

Here's the stack trace:

```
        12 __cxa_pure_virtual() libxx_cxapurevirtual.cxx:66 0x0808ca42
        11 notifyRxFrameListener() uc_dispatcher.cpp:216 0x080787ce
        10 uavcan::Dispatcher::spinOnce() uc_dispatcher.cpp:276 0x080787ce
        9 uavcan::Scheduler::spinOnce() uc_scheduler.cpp:196 0x0807b4e0
        8 spinOnce() abstract_node.hpp:88 0x080659fc
        7 spinOnce() node.hpp:132 0x080659fc
        6 UavcanNode::node_spin_once() uavcan_main.cpp:428 0x080659fc
        5 UavcanNode::run() uavcan_main.cpp:542 0x08065e74
        4 operator() uavcan_main.cpp:343 0x0806626a
        3 UavcanNode::__lambda0::_FUN() uavcan_main.cpp:343 0x0806626a
        2 task_start() task_start.c:138 0x08087720
        1 <symbol is not available> 0x00000000
```