### PR TITLE
Enable ms5611 driver and fix build errors.

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -2,4 +2,4 @@
 
 mkdir -p Build/posix_sitl.build/rootfs/fs/microsd
 mkdir -p Build/posix_sitl.build/rootfs/eeprom
-cd Build/posix_sitl.build && ./mainapp ../../$1
+cd Build/posix_sitl.build && ./mainapp ../$1

--- a/makefiles/posix/config_posix_sitl.mk
+++ b/makefiles/posix/config_posix_sitl.mk
@@ -11,7 +11,7 @@ MODULES		+= drivers/pwm_out_sim
 MODULES		+= drivers/rgbled
 MODULES		+= drivers/led
 MODULES		+= modules/sensors
-#MODULES	+= drivers/ms5611
+MODULES		+= drivers/ms5611
 
 #
 # System commands

--- a/src/drivers/device/i2c_posix.cpp
+++ b/src/drivers/device/i2c_posix.cpp
@@ -49,7 +49,7 @@
 #include <fcntl.h>
 #include <sys/ioctl.h>
 
-#define PX4_SIMULATE_I2C 1
+#define PX4_SIMULATE_I2C 0
 static int simulate = PX4_SIMULATE_I2C;
 
 namespace device

--- a/src/drivers/ms5611/ms5611_posix.cpp
+++ b/src/drivers/ms5611/ms5611_posix.cpp
@@ -110,8 +110,8 @@ public:
 
 	virtual int		init();
 
-	virtual ssize_t		read(device::px4_dev_handle_t *handlep, char *buffer, size_t buflen);
-	virtual int		ioctl(device::px4_dev_handle_t *handlep, int cmd, unsigned long arg);
+	virtual ssize_t		read(device::file_t *handlep, char *buffer, size_t buflen);
+	virtual int		ioctl(device::file_t *handlep, int cmd, unsigned long arg);
 
 	/**
 	 * Diagnostics - print some basic information about the driver.
@@ -126,7 +126,7 @@ protected:
 	struct work_s		_work;
 	unsigned		_measure_ticks;
 
-	RingBuffer		*_reports;
+	ringbuffer::RingBuffer	*_reports;
 
 	bool			_collect_phase;
 	unsigned		_measure_phase;
@@ -269,7 +269,7 @@ MS5611::init()
 	}
 
 	/* allocate basic report buffers */
-	_reports = new RingBuffer(2, sizeof(baro_report));
+	_reports = new ringbuffer::RingBuffer(2, sizeof(baro_report));
 
 	if (_reports == nullptr) {
 		DEVICE_DEBUG("can't get memory for reports");
@@ -337,7 +337,7 @@ out:
 }
 
 ssize_t
-MS5611::read(device::px4_dev_handle_t *handlep, char *buffer, size_t buflen)
+MS5611::read(device::file_t *handlep, char *buffer, size_t buflen)
 {
 	unsigned count = buflen / sizeof(struct baro_report);
 	struct baro_report *brp = reinterpret_cast<struct baro_report *>(buffer);
@@ -407,7 +407,7 @@ MS5611::read(device::px4_dev_handle_t *handlep, char *buffer, size_t buflen)
 }
 
 int
-MS5611::ioctl(device::px4_dev_handle_t *handlep, int cmd, unsigned long arg)
+MS5611::ioctl(device::file_t *handlep, int cmd, unsigned long arg)
 {
 	switch (cmd) {
 
@@ -452,7 +452,7 @@ MS5611::ioctl(device::px4_dev_handle_t *handlep, int cmd, unsigned long arg)
 					unsigned ticks = USEC2TICK(1000000 / arg);
 
 					/* check against maximum rate */
-					if ((long)ticks < USEC2TICK(MS5611_CONVERSION_INTERVAL))
+					if ((unsigned long)ticks < USEC2TICK(MS5611_CONVERSION_INTERVAL))
 						return -EINVAL;
 
 					/* update interval for next measurement */
@@ -579,7 +579,7 @@ MS5611::cycle()
 		 * doing pressure measurements at something close to the desired rate.
 		 */
 		if ((_measure_phase != 0) &&
-		    ((long)_measure_ticks > USEC2TICK(MS5611_CONVERSION_INTERVAL))) {
+		    ((unsigned long)_measure_ticks > USEC2TICK(MS5611_CONVERSION_INTERVAL))) {
 
 			/* schedule a fresh cycle call when we are ready to measure again */
 			work_queue(HPWORK,
@@ -829,7 +829,7 @@ struct ms5611_bus_option {
 #define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
 
 bool	start_bus(struct ms5611_bus_option &bus);
-struct ms5611_bus_option &find_bus(enum MS5611_BUS busid);
+bool	find_bus(enum MS5611_BUS busid, ms5611_bus_option &bus);
 int	start(enum MS5611_BUS busid);
 int	test(enum MS5611_BUS busid);
 int	reset(enum MS5611_BUS busid);
@@ -966,16 +966,18 @@ start(enum MS5611_BUS busid)
 /**
  * find a bus structure for a busid
  */
-struct ms5611_bus_option &find_bus(enum MS5611_BUS busid)
+bool find_bus(enum MS5611_BUS busid, ms5611_bus_option &bus)
 {
 	for (uint8_t i=0; i<NUM_BUS_OPTIONS; i++) {
 		if ((busid == MS5611_BUS_ALL ||
 		     busid == bus_options[i].busid) && bus_options[i].dev != NULL) {
-			return bus_options[i];
+			bus = bus_options[i];
+                        return true;
 		}
-	}	
-	// FIXME - This is fatal to all threads
-	errx(1, "bus %u not started", (unsigned)busid);
+	}
+
+        PX4_WARN("bus %u not started", (unsigned)busid);
+	return false;
 }
 
 /**
@@ -986,7 +988,11 @@ struct ms5611_bus_option &find_bus(enum MS5611_BUS busid)
 int
 test(enum MS5611_BUS busid)
 {
-	struct ms5611_bus_option &bus = find_bus(busid);
+	struct ms5611_bus_option bus;
+	if (!find_bus(busid, bus)) {
+		return 1;
+	}
+
 	struct baro_report report;
 	ssize_t sz;
 	int ret;
@@ -1064,7 +1070,11 @@ test(enum MS5611_BUS busid)
 int
 reset(enum MS5611_BUS busid)
 {
-	struct ms5611_bus_option &bus = find_bus(busid);
+	struct ms5611_bus_option bus;
+	if (!find_bus(busid, bus)) {
+		return 1;
+	}
+
 	int fd;
 
 	fd = open(bus.devpath, O_RDONLY);
@@ -1107,7 +1117,11 @@ info()
 int
 calibrate(unsigned altitude, enum MS5611_BUS busid)
 {
-	struct ms5611_bus_option &bus = find_bus(busid);
+	struct ms5611_bus_option bus;
+	if (!find_bus(busid, bus)) {
+		return 1;
+	}
+
 	struct baro_report report;
 	float	pressure;
 	float	p1;
@@ -1258,8 +1272,8 @@ ms5611_main(int argc, char *argv[])
 	 * Perform MSL pressure calibration given an altitude in metres
 	 */
 	else if (!strcmp(verb, "calibrate")) {
-		if (argc < 2)
-			errx(1, "missing altitude");
+               if (argc < 2)
+                       PX4_WARN("missing altitude");
 
 		long altitude = strtol(argv[optind+1], nullptr, 10);
 

--- a/src/modules/mc_pos_control_multiplatform/mc_pos_control_start_nuttx.cpp
+++ b/src/modules/mc_pos_control_multiplatform/mc_pos_control_start_nuttx.cpp
@@ -55,7 +55,7 @@ extern "C" __EXPORT int mc_pos_control_m_main(int argc, char *argv[]);
 int mc_pos_control_m_main(int argc, char *argv[])
 {
 	if (argc < 2) {
-		errx(1, "usage: mc_pos_control_m {start|stop|status}");
+		PX4_WARN("usage: mc_pos_control_m {start|stop|status}");
 	}
 
 	if (!strcmp(argv[1], "start")) {

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -282,13 +282,13 @@ Geofence::addPoint(int argc, char *argv[])
 	}
 
 	if (argc < 3) {
-		errx(1, "Specify: -clear | sequence latitude longitude [-publish]");
+		PX4_WARN("Specify: -clear | sequence latitude longitude [-publish]");
 	}
 
 	ix = atoi(argv[0]);
 
 	if (ix >= DM_KEY_FENCE_POINTS_MAX) {
-		errx(1, "Sequence must be less than %d", DM_KEY_FENCE_POINTS_MAX);
+		PX4_WARN("Sequence must be less than %d", DM_KEY_FENCE_POINTS_MAX);
 	}
 
 	lat = strtod(argv[1], &end);
@@ -311,7 +311,7 @@ Geofence::addPoint(int argc, char *argv[])
 		return;
 	}
 
-	errx(1, "can't store fence point");
+	PX4_WARN("can't store fence point");
 }
 
 void


### PR DESCRIPTION
This fixes:
- what appears to be a path error in the sitl_run script (we need a non sitl script?)
- general compile errors
- converts errx to PX4_WARN
- fixes the find_bus() calls