### PR TITLE
Upgrade Eigen to latest commit

### DIFF
--- a/src/lib/px4_eigen.h
+++ b/src/lib/px4_eigen.h
@@ -46,8 +46,6 @@
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 #define _GLIBCXX_USE_C99_FP_MACROS_DYNAMIC 1
 
-#define EIGEN_MAX_STATIC_ALIGN_BYTES 16
-
 #include <eigen/Eigen/Core>
 #include <eigen/Eigen/Geometry>
 #pragma GCC diagnostic pop


### PR DESCRIPTION
The latest Eigen commit fixes the problem with the `EIGEN_MAX_STATIC_ALIGN_BYTES` macro, so now it can be fully used without workarounds on `px4_eigen.h`.

@LorenzMeier please if you may, push latest `default` branch of my Eigen repo (https://github.com/TSC21/Eigen) to `PX4/eigen` and update the git tag so this can compile ok.