### PR TITLE
astyle configuration for Sublime

### DIFF
--- a/Firmware.sublime-project
+++ b/Firmware.sublime-project
@@ -33,7 +33,20 @@
 	{
 		"tab_size": 8,
 		"translate_tabs_to_spaces": false,
-	       "highlight_line": true
+		"highlight_line": true,
+		"AStyleFormatter":
+		{
+			"options_c":
+			{
+				"use_only_additional_options": true,
+				"additional_options_file": "${project_path}/Tools/astylerc"
+			},
+			"options_c++":
+			{
+				"use_only_additional_options": true,
+				"additional_options_file": "${project_path}/Tools/astylerc"
+			}
+		}
 	},
 	"build_systems":
 	[

--- a/Tools/astylerc
+++ b/Tools/astylerc
@@ -1,0 +1,18 @@
+indent=force-tab=8
+style=linux
+indent-preprocessor
+indent-cases
+break-blocks=all
+pad-oper
+pad-header
+unpad-paren
+keep-one-line-blocks
+keep-one-line-statements
+align-pointer=name
+align-reference=name
+-n #--suffix=none
+ignore-exclude-errors-x
+lineend=linux
+exclude=EASTL
+add-brackets
+max-code-length=120

--- a/Tools/fix_code_style.sh
+++ b/Tools/fix_code_style.sh
@@ -1,22 +1,6 @@
 #!/bin/sh
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 astyle \
-    --style=linux		\
-    --indent=force-tab=8	\
-    --indent-cases		\
-    --indent-preprocessor	\
-    --break-blocks=all		\
-    --pad-oper			\
-    --pad-header		\
-    --unpad-paren		\
-    --keep-one-line-blocks	\
-    --keep-one-line-statements	\
-    --align-pointer=name	\
-    --align-reference=name	\
-    --suffix=none		\
-    --ignore-exclude-errors-x	\
-    --lineend=linux		\
-    --exclude=EASTL		\
-    --add-brackets		\
-    --max-code-length=120	\
+    --options=$DIR/astylerc          \
     --preserve-date             \
     $*


### PR DESCRIPTION
Works for me, needs to be tested in different environments.

This adds configuration for the Sublime astyle plugin: https://github.com/timonwong/SublimeAStyleFormatter

I moved the options from `fix_code_style.sh` into an astyle options file and referenced it from the script as from the Sublime configuration.