### PR TITLE
Allow GCS to clearly identify a non-calibrated RC control

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -89,6 +89,70 @@ then
 		fi
 	fi
 
+	# Compare existing params and save defaults
+	# this only needs to be in for 1-2 releases
+	if param compare RC_MAP_THROTTLE 0
+	then
+		# So this is a default setup,
+		# now lets find out if channel 3
+		# is calibrated
+		if param compare RC3_MIN 1000
+		then
+			# This is default, do nothing
+		else
+			# Set old default
+			param set RC_MAP_THROTTLE 3
+		fi
+	fi
+
+	# Compare existing params and save defaults
+	# this only needs to be in for 1-2 releases
+	if param compare RC_MAP_ROLL 0
+	then
+		# So this is a default setup,
+		# now lets find out if channel 3
+		# is calibrated
+		if param compare RC1_MIN 1000
+		then
+			# This is default, do nothing
+		else
+			# Set old default
+			param set RC_MAP_ROLL 1
+		fi
+	fi
+
+	# Compare existing params and save defaults
+	# this only needs to be in for 1-2 releases
+	if param compare RC_MAP_PITCH 0
+	then
+		# So this is a default setup,
+		# now lets find out if channel 3
+		# is calibrated
+		if param compare RC2_MIN 1000
+		then
+			# This is default, do nothing
+		else
+			# Set old default
+			param set RC_MAP_ROLL 2
+		fi
+	fi
+
+	# Compare existing params and save defaults
+	# this only needs to be in for 1-2 releases
+	if param compare RC_MAP_YAW 0
+	then
+		# So this is a default setup,
+		# now lets find out if channel 3
+		# is calibrated
+		if param compare RC4_MIN 1000
+		then
+			# This is default, do nothing
+		else
+			# Set old default
+			param set RC_MAP_ROLL 4
+		fi
+	fi
+
 	#
 	# Start system state indicator
 	#

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -1887,7 +1887,7 @@ PARAM_DEFINE_INT32(RC_TH_USER, 1);
  * @max 18
  * @group Radio Calibration
  */
-PARAM_DEFINE_INT32(RC_MAP_ROLL, 1);
+PARAM_DEFINE_INT32(RC_MAP_ROLL, 0);
 
 /**
  * Pitch control channel mapping.
@@ -1900,7 +1900,7 @@ PARAM_DEFINE_INT32(RC_MAP_ROLL, 1);
  * @max 18
  * @group Radio Calibration
  */
-PARAM_DEFINE_INT32(RC_MAP_PITCH, 2);
+PARAM_DEFINE_INT32(RC_MAP_PITCH, 0);
 
 /**
  * Failsafe channel mapping.
@@ -1927,7 +1927,7 @@ PARAM_DEFINE_INT32(RC_MAP_FAILSAFE, 0);  //Default to throttle function
  * @max 18
  * @group Radio Calibration
  */
-PARAM_DEFINE_INT32(RC_MAP_THROTTLE, 3);
+PARAM_DEFINE_INT32(RC_MAP_THROTTLE, 0);
 
 /**
  * Yaw control channel mapping.
@@ -1940,7 +1940,7 @@ PARAM_DEFINE_INT32(RC_MAP_THROTTLE, 3);
  * @max 18
  * @group Radio Calibration
  */
-PARAM_DEFINE_INT32(RC_MAP_YAW, 4);
+PARAM_DEFINE_INT32(RC_MAP_YAW, 0);
 
 /**
  * Mode switch channel mapping.


### PR DESCRIPTION
This should not affect existing users but allow new users to have a better RC calibration experience.