### PR TITLE
Tecs logging

### DIFF
--- a/msg/tecs_status.msg
+++ b/msg/tecs_status.msg
@@ -23,7 +23,7 @@ float32 energyDistributionError
 float32 totalEnergyRateError
 float32 energyDistributionRateError
 
-float32 throttle_sp
-float32 pitch_sp
+float32 throttle_integ
+float32 pitch_integ
 
 uint8 mode

--- a/src/lib/external_lgpl/tecs/tecs.cpp
+++ b/src/lib/external_lgpl/tecs/tecs.cpp
@@ -620,9 +620,8 @@ void TECS::update_pitch_throttle(const math::Matrix<3,3> &rotMat, float pitch, f
 	_tecs_state.energy_error_integ = _integ6_state;
 	_tecs_state.energy_distribution_error_integ = _integ7_state;
 
-
-	_tecs_state.throttle_sp = _throttle_dem;
-	_tecs_state.pitch_sp = _pitch_dem;
+	_tecs_state.throttle_integ 	= _integ6_state;
+	_tecs_state.pitch_integ 	= _integ7_state;
 
 	_update_pitch_throttle_last_usec = now;
 

--- a/src/lib/external_lgpl/tecs/tecs.cpp
+++ b/src/lib/external_lgpl/tecs/tecs.cpp
@@ -62,6 +62,10 @@ void TECS::update_state(float baro_altitude, float airspeed, const math::Matrix<
 		_integ3_state = baro_altitude;
 		_integ2_state = 0.0f;
 		_integ1_state = 0.0f;
+
+		// Reset the filter state as we just switched from non-altitude control
+		// to altitude control mode
+		_states_initalized = false;
 	}
 
 	_update_50hz_last_usec = now;

--- a/src/lib/external_lgpl/tecs/tecs.h
+++ b/src/lib/external_lgpl/tecs/tecs.h
@@ -155,8 +155,8 @@ public:
 		float total_energy_rate_error;
 		float energy_distribution_error;
 		float energy_distribution_rate_error;
-		float throttle_sp;
-		float pitch_sp;
+		float throttle_integ;
+		float pitch_integ;
 		enum ECL_TECS_MODE mode;
 	};
 

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
@@ -1937,8 +1937,8 @@ void FixedwingPositionControl::tecs_update_pitch_throttle(float alt_sp, float v_
 		t.energyDistributionError 		= s.energy_distribution_error;
 		t.energyDistributionRateError 	= s.energy_distribution_rate_error;
 		
-		t.throttle_sp 	= s.throttle_sp;
-		t.pitch_sp 		= s.pitch_sp;
+		t.throttle_integ 	= s.throttle_integ;
+		t.pitch_integ 		= s.pitch_integ;
 
 		if (_tecs_status_pub > 0) {
 			orb_publish(ORB_ID(tecs_status), _tecs_status_pub, &t);

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1886,8 +1886,8 @@ int sdlog2_thread_main(int argc, char *argv[])
 			log_msg.body.log_TECS.energyDistributionError = buf.tecs_status.energyDistributionError;
 			log_msg.body.log_TECS.totalEnergyRateError = buf.tecs_status.totalEnergyRateError;
 			log_msg.body.log_TECS.energyDistributionRateError = buf.tecs_status.energyDistributionRateError;
-			log_msg.body.log_TECS.throttle_sp = buf.tecs_status.throttle_sp;
-			log_msg.body.log_TECS.pitch_sp = buf.tecs_status.pitch_sp;
+			log_msg.body.log_TECS.throttle_integ = buf.tecs_status.throttle_integ;
+			log_msg.body.log_TECS.pitch_integ = buf.tecs_status.pitch_integ;
 			log_msg.body.log_TECS.mode = (uint8_t)buf.tecs_status.mode;
 			LOGBUFFER_WRITE_AND_COUNT(TECS);
 		}

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -368,8 +368,8 @@ struct log_TECS_s {
 	float totalEnergyRateError;
 	float energyDistributionError;
 	float energyDistributionRateError;
-	float throttle_sp;
-	float pitch_sp;
+	float pitch_integ;
+	float throttle_integ;
 
 	uint8_t mode;
 };
@@ -527,7 +527,7 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT(GS0B, "BBBBBBBBBBBBBBBB",	"s0,s1,s2,s3,s4,s5,s6,s7,s8,s9,s10,s11,s12,s13,s14,s15"),
 	LOG_FORMAT(GS1A, "BBBBBBBBBBBBBBBB",	"s0,s1,s2,s3,s4,s5,s6,s7,s8,s9,s10,s11,s12,s13,s14,s15"),
 	LOG_FORMAT(GS1B, "BBBBBBBBBBBBBBBB",	"s0,s1,s2,s3,s4,s5,s6,s7,s8,s9,s10,s11,s12,s13,s14,s15"),
-	LOG_FORMAT(TECS, "ffffffffffffffB",	"ASP,AF,FSP,F,AsSP,AsF,AsDSP,AsD,EE,EDE,ERE,EDRE,Thr,Ptch,M"),
+	LOG_FORMAT(TECS, "ffffffffffffffB",	"ASP,AF,FSP,F,AsSP,AsF,AsDSP,AsD,EE,EDE,ERE,EDRE,PtchI,ThrI,M"),
 	LOG_FORMAT(WIND, "ffff",	"X,Y,CovX,CovY"),
 	LOG_FORMAT(ENCD, "qfqf",	"cnt0,vel0,cnt1,vel1"),
 	LOG_FORMAT(TSYN, "Q", 		"TimeOffset"),


### PR DESCRIPTION
This fixes an initialization bug of TECS which probably lead to the airplane performing strong climbs/dives when switching into any altitude controlled modes. Flight tested this and haven't noticed this phenomena any more, also logs show that throttle/pitch integrators always reset to zero when TECS becomes active.

Log:  http://dash.oznet.ch/view/7XjHRACepBcV5dEippiuNF