### PR TITLE
VTOL - Reset altitude and yaw setpoints

### DIFF
--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
@@ -1027,7 +1027,11 @@ bool FixedwingPositionControl::update_desired_altitude(float dt)
 		_althold_epv = _global_pos.epv;
 		_was_in_deadband = true;
 	}
-
+	if (_vehicle_status.is_vtol) {
+		if (_vehicle_status.is_rotary_wing || _vehicle_status.in_transition_mode) {
+			_hold_alt = _global_pos.alt;
+		}
+	}
 	return climbout_mode;
 }
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -993,9 +993,12 @@ MulticopterPositionControl::task_main()
 			reset_yaw_sp = true;
 		}
 
-		// XXX Temporary: for vtol use we need to reset the yaw setpoint when we are doing a transition
-		if (_vehicle_status.in_transition_mode) {
-			reset_yaw_sp = true;
+		/* reset yaw and altitude setpoint for VTOL which are in fw mode */
+		if (_vehicle_status.is_vtol) {
+			if (!_vehicle_status.is_rotary_wing && !_vehicle_status.in_transition_mode) {
+				reset_yaw_sp = true;
+				_reset_alt_sp = true;
+			}
 		}
 
 		//Update previous arming state

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -995,7 +995,7 @@ MulticopterPositionControl::task_main()
 
 		/* reset yaw and altitude setpoint for VTOL which are in fw mode */
 		if (_vehicle_status.is_vtol) {
-			if (!_vehicle_status.is_rotary_wing && !_vehicle_status.in_transition_mode) {
+			if (!_vehicle_status.is_rotary_wing) {
 				reset_yaw_sp = true;
 				_reset_alt_sp = true;
 			}


### PR DESCRIPTION
This prevents altitude and yaw changes after a transition to a previous setpoint.

Flight tested against beta on a standard and tiltrotor.