### PR TITLE
Mathlib: Fix to matrix division operator

### DIFF
--- a/src/lib/mathlib/math/Matrix.hpp
+++ b/src/lib/mathlib/math/Matrix.hpp
@@ -285,7 +285,7 @@ public:
 
 		for (unsigned int i = 0; i < M; i++)
 			for (unsigned int j = 0; j < N; j++)
-				res[i][j] = data[i][j] / num;
+				res.data[i][j] = data[i][j] / num;
 
 		return res;
 	}


### PR DESCRIPTION
Seems to be a bug there which caused compilation errors for me (only when actually using this operator in the code!). Compare to the multiplication operator, which was implemented correctly.