### PR TITLE
mathlib: Bugfix to print function

### DIFF
--- a/src/lib/mathlib/math/Matrix.hpp
+++ b/src/lib/mathlib/math/Matrix.hpp
@@ -375,7 +375,7 @@ public:
 			printf("[ ");
 
 			for (unsigned int j = 0; j < N; j++)
-				printf("%.3f\t", data[i][j]);
+				printf("%.3f\t", (double)data[i][j]);
 
 			printf(" ]\n");
 		}


### PR DESCRIPTION
Another bug fix to the mathlib library. Why does the automatic build system not detect these bugs? Are the settings different there (in this case, this is a float -> double conversion compile error that pops up).