### PR TITLE
Changes for qurt SITL and other minor qurt fixes

### DIFF
--- a/Tools/check_submodules.sh
+++ b/Tools/check_submodules.sh
@@ -50,7 +50,7 @@ else
 fi
 
 
-if [ -d uavcan ]
+if [ -d src/lib/uavcan ]
 then
 	STATUSRETVAL=$(git submodule summary | grep -A20 -i uavcan | grep "<")
 	if [ -z "$STATUSRETVAL" ]
@@ -73,8 +73,7 @@ fi
 
 if [ -d src/lib/eigen ]
 then
-	echo "ARG = $1"
-	if [ $1 = "qurt" ]
+	if [ "$1" = "qurt" ]
 	then
 		# QuRT needs to use Eigen 3.2 because the toolchain doews not support C++11
 		STATUSRETVAL=$(true)

--- a/makefiles/posix-arm/config_eagle_adsp.mk
+++ b/makefiles/posix-arm/config_eagle_adsp.mk
@@ -1,0 +1,57 @@
+#
+# Makefile for the EAGLE *default* configuration
+#
+
+#
+# Board support modules
+#
+MODULES		+= drivers/device
+
+#
+# System commands
+#
+MODULES	+= systemcmds/param
+MODULES	+= systemcmds/ver
+
+#
+# General system control
+#
+MODULES		+= modules/mavlink
+
+#
+# Estimation modules (EKF/ SO3 / other filters)
+#
+
+#
+# Vehicle Control
+#
+
+#
+# Library modules
+#
+MODULES		+= modules/systemlib
+MODULES		+= modules/uORB
+MODULES		+= modules/dataman
+
+#
+# Libraries
+#
+MODULES		+= lib/mathlib
+MODULES		+= lib/mathlib/math/filter
+MODULES		+= lib/geo
+MODULES		+= lib/geo_lookup
+MODULES		+= lib/conversion
+#
+# Linux port
+#
+MODULES		+= platforms/posix/px4_layer
+MODULES		+= platforms/posix/work_queue
+
+#
+# Unit tests
+#
+
+#
+# muorb fastrpc changes.
+#
+MODULES		+= modules/muorb/krait

--- a/makefiles/posix-arm/config_eagle_hil.mk
+++ b/makefiles/posix-arm/config_eagle_hil.mk
@@ -6,6 +6,7 @@
 # Board support modules
 #
 MODULES		+= drivers/device
+MODULES		+= drivers/boards/sitl
 #MODULES		+= drivers/blinkm
 #MODULES		+= drivers/pwm_out_sim
 #MODULES		+= drivers/rgbled

--- a/makefiles/qurt/config_qurt_hil.mk
+++ b/makefiles/qurt/config_qurt_hil.mk
@@ -6,6 +6,7 @@
 # Board support modules
 #
 MODULES		+= drivers/device
+MODULES		+= drivers/boards/sitl
 #MODULES		+= drivers/blinkm
 MODULES		+= drivers/pwm_out_sim
 MODULES		+= drivers/led

--- a/makefiles/qurt/toolchain_hexagon.mk
+++ b/makefiles/qurt/toolchain_hexagon.mk
@@ -129,6 +129,7 @@ ARCHDEFINES		+= -DCONFIG_ARCH_BOARD_$(CONFIG_BOARD) \
 			    -I$(DSPAL_ROOT)/dspal/sys/sys \
 			    -I$(DSPAL_ROOT)/mpu_spi/inc/ \
 			    -I$(DSPAL_ROOT)/uart_esc/inc/ \
+			    -I$(DSPAL_ROOT)/bmp280/inc/ \
 			    -I$(HEXAGON_TOOLS_ROOT)/gnu/hexagon/include \
 			    -I$(PX4_BASE)/src/lib/eigen \
 			    -I$(PX4_BASE)/src/platforms/qurt/include \

--- a/src/drivers/boards/sitl/module.mk
+++ b/src/drivers/boards/sitl/module.mk
@@ -1,0 +1,8 @@
+#
+# Board-specific startup code for SITL
+#
+
+SRCS		 =  \
+		   sitl_led.c
+
+MAXOPTIMIZATION	 = -Os

--- a/src/drivers/boards/sitl/sitl_led.c
+++ b/src/drivers/boards/sitl/sitl_led.c
@@ -1,0 +1,84 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2013 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file sitl_led.c
+ *
+ * sitl LED backend.
+ */
+
+#include <px4_config.h>
+#include <px4_log.h>
+#include <stdbool.h>
+
+__BEGIN_DECLS
+extern void led_init(void);
+extern void led_on(int led);
+extern void led_off(int led);
+extern void led_toggle(int led);
+__END_DECLS
+
+static bool _led_state[2] = { false , false };
+
+__EXPORT void led_init()
+{
+	PX4_DEBUG("LED_INIT");
+}
+
+__EXPORT void led_on(int led)
+{
+	if (led == 1 || led == 0)
+	{
+		PX4_DEBUG("LED%d_ON", led);
+		_led_state[led] = true;
+	}
+}
+
+__EXPORT void led_off(int led)
+{
+	if (led == 1 || led == 0)
+	{
+		PX4_DEBUG("LED%d_OFF", led);
+		_led_state[led] = false;
+	}
+}
+
+__EXPORT void led_toggle(int led)
+{
+	if (led == 1 || led == 0)
+	{
+		_led_state[led] = !_led_state[led];
+		PX4_DEBUG("LED%d_TOGGLE: %s", led, _led_state[led] ? "ON" : "OFF");
+
+	}
+}

--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -141,10 +141,6 @@ static void usage()
 
 __BEGIN_DECLS
 extern int simulator_main(int argc, char *argv[]);
-extern void led_init(void);
-extern void led_on(int led);
-extern void led_off(int led);
-extern void led_toggle(int led);
 __END_DECLS
 
 extern "C" {
@@ -197,40 +193,5 @@ int simulator_main(int argc, char *argv[])
 	return ret;
 }
 
-}
-
-bool static _led_state[2] = { false , false };
-
-__EXPORT void led_init()
-{
-	PX4_DEBUG("LED_INIT");
-}
-
-__EXPORT void led_on(int led)
-{
-	if (led == 1 || led == 0)
-	{
-		PX4_DEBUG("LED%d_ON", led);
-		_led_state[led] = true;
-	}
-}
-
-__EXPORT void led_off(int led)
-{
-	if (led == 1 || led == 0)
-	{
-		PX4_DEBUG("LED%d_OFF", led);
-		_led_state[led] = false;
-	}
-}
-
-__EXPORT void led_toggle(int led)
-{
-	if (led == 1 || led == 0)
-	{
-		_led_state[led] = !_led_state[led];
-		PX4_DEBUG("LED%d_TOGGLE: %s", led, _led_state[led] ? "ON" : "OFF");
-
-	}
 }
 

--- a/src/modules/uORB/uORB.cpp
+++ b/src/modules/uORB/uORB.cpp
@@ -270,7 +270,7 @@ int  orb_exists(const struct orb_metadata *meta, int instance)
  *      priority, independent of the startup order of the associated publishers.
  * @return    OK on success, ERROR otherwise with errno set accordingly.
  */
-int  orb_priority(int handle, int *priority)
+int  orb_priority(int handle, int32_t *priority)
 {
 	return uORB::Manager::get_instance()->orb_priority(handle, priority);
 }

--- a/src/modules/uORB/uORBManager.hpp
+++ b/src/modules/uORB/uORBManager.hpp
@@ -269,7 +269,7 @@ public:
 	 *      priority, independent of the startup order of the associated publishers.
 	 * @return    OK on success, ERROR otherwise with errno set accordingly.
 	 */
-	int  orb_priority(int handle, int *priority) ;
+	int  orb_priority(int handle, int32_t *priority) ;
 
 	/**
 	 * Set the minimum interval between which updates are seen for a subscription.

--- a/src/modules/uORB/uORBManager_nuttx.cpp
+++ b/src/modules/uORB/uORBManager_nuttx.cpp
@@ -166,7 +166,7 @@ int uORB::Manager::orb_stat(int handle, uint64_t *time)
 	return ioctl(handle, ORBIOCLASTUPDATE, (unsigned long)(uintptr_t)time);
 }
 
-int uORB::Manager::orb_priority(int handle, int *priority)
+int uORB::Manager::orb_priority(int handle, int32_t *priority)
 {
 	return ioctl(handle, ORBIOCGPRIORITY, (unsigned long)(uintptr_t)priority);
 }

--- a/src/modules/uORB/uORBManager_posix.cpp
+++ b/src/modules/uORB/uORBManager_posix.cpp
@@ -172,7 +172,7 @@ int uORB::Manager::orb_stat(int handle, uint64_t *time)
 	return px4_ioctl(handle, ORBIOCLASTUPDATE, (unsigned long)(uintptr_t)time);
 }
 
-int uORB::Manager::orb_priority(int handle, int *priority)
+int uORB::Manager::orb_priority(int handle, int32_t *priority)
 {
 	return px4_ioctl(handle, ORBIOCGPRIORITY, (unsigned long)(uintptr_t)priority);
 }

--- a/src/platforms/qurt/eagle_px4_firmware_patch.patch
+++ b/src/platforms/qurt/eagle_px4_firmware_patch.patch
@@ -45,12 +45,6 @@ index 4ba2f98..a7b664e 100644
  struct mavlink_logmessage {
  	char text[MAVLINK_LOG_MAXLEN + 1];
  	unsigned char severity;
-diff --git a/src/lib/eigen b/src/lib/eigen
---- a/src/lib/eigen
-+++ b/src/lib/eigen
-@@ -1 +1 @@
--Subproject commit e7850ed81f9c469e02df496ef09ae32ec0379b71
-+Subproject commit e7850ed81f9c469e02df496ef09ae32ec0379b71-dirty
 diff --git a/src/modules/commander/PreflightCheck.cpp b/src/modules/commander/PreflightCheck.cpp
 index bbf5f8e..50c7d8b 100644
 --- a/src/modules/commander/PreflightCheck.cpp

--- a/src/platforms/qurt/px4_layer/commands_hil.c
+++ b/src/platforms/qurt/px4_layer/commands_hil.c
@@ -56,7 +56,7 @@ const char *get_commands()
 		"mc_pos_control start\n"
 		"mc_att_control start\n"
 		"sleep 1\n"
-		"hil mode_pwm\n"
+		"pwm_out_sim mode_pwm\n"
 		"param set RC1_MAX 2015\n"
 		"param set RC1_MIN 996\n"
 		"param set RC1_TRIM 1502\n"


### PR DESCRIPTION
Qurt build configuration fixes

Moved LED functions from simulator to src/drivers/boards/sitl
so it can also be used from QuRT when not running simulator.
This is needed for HIL.

Fixed parameter type in uorb_priority

Signed-off-by: Mark Charlebois <charlebm@gmail.com>

Reverted rate limiting deletion

Signed-off-by: Mark Charlebois <charlebm@gmail.com>