### PR TITLE
px4_param_def to QGC fix

### DIFF
--- a/Tools/px4params/srcscanner.py
+++ b/Tools/px4params/srcscanner.py
@@ -13,10 +13,16 @@ class SourceScanner(object):
         Scans provided path and passes all found contents to the parser using
         parser.Parse method.
         """
-        extensions = tuple(parser.GetSupportedExtensions())
+        extensions1 = tuple([".h"])
+        extensions2 = tuple([".cpp", ".c"])
         for dirname, dirnames, filenames in os.walk(srcdir):
             for filename in filenames:
-                if filename.endswith(extensions):
+                if filename.endswith(extensions1):
+                    path = os.path.join(dirname, filename)
+                    if not self.ScanFile(path, parser):
+                        return False
+            for filename in filenames:
+                if filename.endswith(extensions2):
                     path = os.path.join(dirname, filename)
                     if not self.ScanFile(path, parser):
                         return False


### PR DESCRIPTION
This is proposed solution to #2680.
The change makes sure that the code will be parsed firstly from headers, stores values in dictionary, and then assigns them to corresponding names. It will work only if default value is in header file located in the same folder as parameter definition. 