### PR TITLE
reduce make verbosity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,12 @@ before_script:
   - mkdir -p ~/bin
   - ln -s /usr/bin/ccache ~/bin/arm-none-eabi-g++
   - ln -s /usr/bin/ccache ~/bin/arm-none-eabi-gcc
+  - ln -s /usr/bin/ccache ~/bin/clang++
+  - ln -s /usr/bin/ccache ~/bin/clang++-3.4
+  - ln -s /usr/bin/ccache ~/bin/clang++-3.5
+  - ln -s /usr/bin/ccache ~/bin/clang
+  - ln -s /usr/bin/ccache ~/bin/clang-3.4
+  - ln -s /usr/bin/ccache ~/bin/clang-3.5
   - ln -s /usr/bin/ccache ~/bin/g++-4.8
   - ln -s /usr/bin/ccache ~/bin/gcc-4.8
   - export PATH=~/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
 addons:
   apt:
     sources:
+    - kubuntu-backports
     - ubuntu-toolchain-r-test
     packages:
     - build-essential

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ qurtrun:
 # unit tests.
 .PHONY: tests
 tests:	generateuorbtopicheaders
-	$(Q) (mkdir -p $(PX4_BASE)/unittests/build && cd $(PX4_BASE)/unittests/build && cmake .. && $(MAKE) unittests)
+	$(Q) (mkdir -p $(PX4_BASE)/unittests/build && cd $(PX4_BASE)/unittests/build && cmake .. && $(MAKE) --no-print-directory unittests)
 
 .PHONY: format check_format
 check_format:

--- a/makefiles/firmware.mk
+++ b/makefiles/firmware.mk
@@ -232,7 +232,7 @@ $(MODULE_OBJS):		workdir = $(@D)
 $(MODULE_OBJS):		$(GLOBAL_DEPS) $(NUTTX_CONFIG_HEADER)
 	$(Q) $(MKDIR) -p $(workdir)
 	$(Q) $(MAKE) -r -f $(PX4_MK_DIR)module.mk \
-		-C $(workdir) \
+		--no-print-directory -C $(workdir) \
 		MODULE_WORK_DIR=$(workdir) \
 		MODULE_OBJ=$@ \
 		MODULE_MK=$(mkfile) \
@@ -292,7 +292,7 @@ $(LIBRARY_LIBS):	workdir = $(@D)
 $(LIBRARY_LIBS):	$(GLOBAL_DEPS) $(NUTTX_CONFIG_HEADER)
 	$(Q) $(MKDIR) -p $(workdir)
 	$(Q) $(MAKE) -r -f $(PX4_MK_DIR)library.mk \
-		-C $(workdir) \
+		--no-print-directory -C $(workdir) \
 		LIBRARY_WORK_DIR=$(workdir) \
 		LIBRARY_LIB=$@ \
 		LIBRARY_MK=$(mkfile) \

--- a/makefiles/firmware.mk
+++ b/makefiles/firmware.mk
@@ -106,8 +106,6 @@ ifneq ($(words $(PX4_BASE)),1)
 $(error Cannot build when the PX4_BASE path contains one or more space characters.)
 endif
 
-$(info %  GIT_DESC            = $(GIT_DESC))
-
 #
 # Set a default target so that included makefiles or errors here don't
 # cause confusion.

--- a/makefiles/module.mk
+++ b/makefiles/module.mk
@@ -113,7 +113,9 @@
 ifeq ($(MODULE_MK),)
 $(error No module makefile specified)
 endif
+ifeq ($(V),1)
 $(info %% MODULE_MK           = $(MODULE_MK))
+endif
 
 #
 # Get the board/toolchain config
@@ -125,10 +127,12 @@ include $(BOARD_FILE)
 #
 include $(MODULE_MK)
 MODULE_SRC		:= $(dir $(MODULE_MK))
+ifeq ($(V),1)
 $(info %  MODULE_NAME         = $(MODULE_NAME))
 $(info %  MODULE_SRC          = $(MODULE_SRC))
 $(info %  MODULE_OBJ          = $(MODULE_OBJ))
 $(info %  MODULE_WORK_DIR     = $(MODULE_WORK_DIR))
+endif
 
 #
 # Things that, if they change, might affect everything

--- a/makefiles/nuttx/firmware_nuttx.mk
+++ b/makefiles/nuttx/firmware_nuttx.mk
@@ -30,7 +30,7 @@ $(FIRMWARES): $(BUILD_DIR)%.build/firmware.px4:	checkgitversion generateuorbtopi
 	@$(ECHO) %%%% Building $(config) in $(work_dir)
 	@$(ECHO) %%%%
 	$(Q) $(MKDIR) -p $(work_dir)
-	$(Q) $(MAKE) -r -C $(work_dir) \
+	$(Q) $(MAKE) -r --no-print-directory -C $(work_dir) \
 		-f $(PX4_MK_DIR)firmware.mk \
 		CONFIG=$(config) \
 		WORK_DIR=$(work_dir) \
@@ -77,11 +77,11 @@ $(ARCHIVE_DIR)%.export:	configuration = nsh
 $(NUTTX_ARCHIVES): $(ARCHIVE_DIR)%.export: $(NUTTX_SRC)
 	@$(ECHO) %% Configuring NuttX for $(board)
 	$(Q) (cd $(NUTTX_SRC) && $(RMDIR) nuttx-export)
-	$(Q) $(MAKE) -r -j$(J) -C $(NUTTX_SRC) -r $(MQUIET) distclean
+	$(Q) $(MAKE) -r -j$(J) --no-print-directory -C $(NUTTX_SRC) -r $(MQUIET) distclean
 	$(Q) (cd $(NUTTX_SRC)/configs && $(COPYDIR) $(PX4_BASE)nuttx-configs/$(board) .)
 	$(Q) (cd $(NUTTX_SRC)tools && ./configure.sh $(board)/$(configuration))
 	@$(ECHO) %% Exporting NuttX for $(board)
-	$(Q) $(MAKE) -r -j$(J) -C $(NUTTX_SRC) -r $(MQUIET) CONFIG_ARCH_BOARD=$(board) export
+	$(Q) $(MAKE) -r -j$(J) --no-print-directory -C $(NUTTX_SRC) -r $(MQUIET) CONFIG_ARCH_BOARD=$(board) export
 	$(Q) $(MKDIR) -p $(dir $@)
 	$(Q) $(COPY) $(NUTTX_SRC)nuttx-export.zip $@
 	$(Q) (cd $(NUTTX_SRC)/configs && $(RMDIR) $(board))
@@ -98,12 +98,12 @@ BOARD			 = $(BOARDS)
 menuconfig: $(NUTTX_SRC)
 	@$(ECHO) %% Configuring NuttX for $(BOARD)
 	$(Q) (cd $(NUTTX_SRC) && $(RMDIR) nuttx-export)
-	$(Q) $(MAKE) -r -j$(J) -C $(NUTTX_SRC) -r $(MQUIET) distclean
+	$(Q) $(MAKE) -r -j$(J) --no-print-directory -C $(NUTTX_SRC) -r $(MQUIET) distclean
 	$(Q) (cd $(NUTTX_SRC)/configs && $(COPYDIR) $(PX4_BASE)nuttx-configs/$(BOARD) .)
 	$(Q) (cd $(NUTTX_SRC)tools && ./configure.sh $(BOARD)/nsh)
 	@$(ECHO) %% Running menuconfig for $(BOARD)
-	$(Q) $(MAKE) -r -j$(J) -C $(NUTTX_SRC) -r $(MQUIET) oldconfig
-	$(Q) $(MAKE) -r -j$(J) -C $(NUTTX_SRC) -r $(MQUIET) menuconfig
+	$(Q) $(MAKE) -r -j$(J) --no-print-directory -C $(NUTTX_SRC) -r $(MQUIET) oldconfig
+	$(Q) $(MAKE) -r -j$(J) --no-print-directory -C $(NUTTX_SRC) -r $(MQUIET) menuconfig
 	@$(ECHO) %% Saving configuration file
 	$(Q)$(COPY) $(NUTTX_SRC).config $(PX4_BASE)nuttx-configs/$(BOARD)/nsh/defconfig
 else

--- a/makefiles/nuttx/toolchain_gnu-arm-eabi.mk
+++ b/makefiles/nuttx/toolchain_gnu-arm-eabi.mk
@@ -147,7 +147,6 @@ ARCHWARNINGS		 = -Wall \
 			   -Wshadow \
 			   -Wfloat-equal \
 			   -Wpointer-arith \
-			   -Wlogical-op \
 			   -Wmissing-declarations \
 			   -Wpacked \
 			   -Wno-unused-parameter \

--- a/makefiles/nuttx/toolchain_gnu-arm-eabi.mk
+++ b/makefiles/nuttx/toolchain_gnu-arm-eabi.mk
@@ -271,7 +271,6 @@ define PRELINK
 	@$(ECHO) "PRELINK: $1"
 	@$(MKDIR) -p $(dir $1)
 	$(Q) $(LD) -Ur -Map $1.map  -o $1 $2 && $(OBJCOPY) --localize-hidden $1
-	#$(Q) $(LD) -Ur -Map $1.map  -o $1 $2 && $(OBJCOPY) --localize-hidden $1
 endef
 
 # Update the archive $1 with the files in $2

--- a/makefiles/posix-arm/toolchain_gnu-arm-linux-gnueabihf.mk
+++ b/makefiles/posix-arm/toolchain_gnu-arm-linux-gnueabihf.mk
@@ -157,8 +157,6 @@ ARCHWARNINGS		 = -Wall \
 			   -Werror=reorder \
 			   -Werror=uninitialized \
 			   -Werror=init-self \
-			   -Wno-error=logical-op \
-			   -Wlogical-op \
 			   -Wformat=1 \
 			   -Werror=unused-but-set-variable \
 			   -Wno-error=double-promotion \

--- a/makefiles/posix/firmware_posix.mk
+++ b/makefiles/posix/firmware_posix.mk
@@ -47,7 +47,7 @@ $(FIRMWARES): $(BUILD_DIR)%.build/firmware.a:	checkgitversion generateuorbtopich
 	@$(ECHO) %%%% Building $(config) in $(work_dir)
 	@$(ECHO) %%%%
 	$(Q) $(MKDIR) -p $(work_dir)
-	$(Q) $(MAKE) -r -C $(work_dir) \
+	$(Q) $(MAKE) -r --no-print-directory -C $(work_dir) \
 		-f $(PX4_MK_DIR)firmware.mk \
 		CONFIG=$(config) \
 		WORK_DIR=$(work_dir) \

--- a/makefiles/posix/toolchain_native.mk
+++ b/makefiles/posix/toolchain_native.mk
@@ -183,9 +183,8 @@ ARCHWARNINGS		 = -Wall \
 
 # Add compiler specific options
 ifeq ($(USE_GCC),1)
-ARCHDEFINES		+= -Wno-error=logical-op
+ARCHDEFINES		+=
 ARCHWARNINGS		+= -Wdouble-promotion \
-			   -Wlogical-op \
 			   -Wformat=1 \
 			   -Werror=unused-but-set-variable \
 			   -Werror=double-promotion

--- a/makefiles/posix/toolchain_native.mk
+++ b/makefiles/posix/toolchain_native.mk
@@ -348,7 +348,6 @@ endef
 define LINK_A
 	@$(ECHO) "LINK_A:    $1"
 	@$(MKDIR) -p $(dir $1)
-	echo "$(Q) $(AR) $1 $2"
 	$(Q) $(AR) $1 $2
 endef
 
@@ -357,7 +356,6 @@ endef
 define LINK_SO
 	@$(ECHO) "LINK_SO:    $1"
 	@$(MKDIR) -p $(dir $1)
-	echo "$(Q) $(CXX) $(LDFLAGS) -shared -Wl,-soname,`basename $1`.1 -o $1 $2 $(LIBS) $(EXTRA_LIBS)"
 	$(Q) $(CXX) $(LDFLAGS) -shared -Wl,-soname,`basename $1`.1 -o $1 $2 $(LIBS) -pthread -lc
 endef
 

--- a/makefiles/qurt/firmware_qurt.mk
+++ b/makefiles/qurt/firmware_qurt.mk
@@ -47,7 +47,7 @@ $(FIRMWARES): $(BUILD_DIR)%.build/firmware.a:	generateuorbtopicheaders
 	@$(ECHO) %%%% Building $(config) in $(work_dir)
 	@$(ECHO) %%%%
 	$(Q) $(MKDIR) -p $(work_dir)
-	$(Q) $(MAKE) -r -C $(work_dir) \
+	$(Q) $(MAKE) -r --no-print-directory -C $(work_dir) \
 		-f $(PX4_MK_DIR)firmware.mk \
 		CONFIG=$(config) \
 		WORK_DIR=$(work_dir) \

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -11,6 +11,13 @@ CMAKE_FORCE_CXX_COMPILER( clang++ Clang )
 #set( CMAKE_FIND_ROOT_PATH_MODE_LIBARARY_ONLY )
 #set( CMAKE_FIND_ROOT_PATH_MODE_INCLUDE_ONLY )
 
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+  add_compile_options(-Qunused-arguments)
+endif()
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  add_compile_options(-Qunused-arguments)
+endif()
+
 project(unittests)
 enable_testing()
 
@@ -123,8 +130,7 @@ add_executable(mixer_test mixer_test.cpp hrt.cpp
                           ${PX_SRC}/modules/systemlib/mixer/mixer_simple.cpp
                           ${PX_SRC}/modules/systemlib/pwm_limit/pwm_limit.c
                           ${PX_SRC}/systemcmds/tests/test_mixer.cpp)
-
-target_link_libraries( mixer_test LINK_PUBLIC px4_platform )
+target_link_libraries( mixer_test px4_platform )
 
                           
 add_gtest(mixer_test)

--- a/unittests/sbus2_test.cpp
+++ b/unittests/sbus2_test.cpp
@@ -33,7 +33,7 @@ TEST(SBUS2Test, SBUS2)
 	// Init the parser
 	uint8_t frame[30];
 	unsigned partial_frame_count = 0;
-	uint16_t rc_values[18];
+	//uint16_t rc_values[18];
 	//uint16_t num_values;
 	//bool sbus_failsafe;
 	//bool sbus_frame_drop;

--- a/unittests/st24_test.cpp
+++ b/unittests/st24_test.cpp
@@ -41,7 +41,7 @@ TEST(ST24Test, ST24)
 		last_time = f;
 
 		// Pipe the data into the parser
-		hrt_abstime now = hrt_absolute_time();
+		//hrt_abstime now = hrt_absolute_time();
 
 		uint8_t rssi;
 		uint8_t rx_count;
@@ -53,8 +53,7 @@ TEST(ST24Test, ST24)
 			//warnx("decoded: %u channels (converted to PPM range)", (unsigned)channel_count);
 
 			for (unsigned i = 0; i < channel_count; i++) {
-
-				int16_t val = channels[i];
+				//int16_t val = channels[i];
 				//warnx("channel %u: %d 0x%03X", i, static_cast<int>(val), static_cast<int>(val));
 			}
 		}

--- a/unittests/sumd_test.cpp
+++ b/unittests/sumd_test.cpp
@@ -41,7 +41,7 @@ TEST(SUMDTest, SUMD)
 		last_time = f;
 
 		// Pipe the data into the parser
-		hrt_abstime now = hrt_absolute_time();
+		//hrt_abstime now = hrt_absolute_time();
 
 		uint8_t rssi;
 		uint8_t rx_count;
@@ -53,8 +53,7 @@ TEST(SUMDTest, SUMD)
 			//warnx("decoded: %u channels (converted to PPM range)", (unsigned)channel_count);
 
 			for (unsigned i = 0; i < channel_count; i++) {
-
-				int16_t val = channels[i];
+				//int16_t val = channels[i];
 				//warnx("channel %u: %d 0x%03X", i, static_cast<int>(val), static_cast<int>(val));
 			}
 		}

--- a/unittests/uorb_unittests/uORBCommunicatorMock.hpp
+++ b/unittests/uorb_unittests/uORBCommunicatorMock.hpp
@@ -126,8 +126,8 @@ class uORB_test::uORBCommunicatorMock : public uORBCommunicator::IChannel
 
  private:
   uORBCommunicator::IChannelRxHandler* _rx_handler;
-  int _sub_topicA_copy_fd;
-  int _sub_topicB_copy_fd;
+  //int _sub_topicA_copy_fd;
+  //int _sub_topicB_copy_fd;
 
   std::map<std::string, std::string> _topic_translation_map;
 


### PR DESCRIPTION
This PR silences `%  MODULE_*`  and `make: Entering directory` `make: Leaving directory` messages by default (enable with make V=1).

Overall it reduces the console output significantly to the point where it can be properly displayed on travis-ci.