### PR TITLE
Vtol virtual attitude setpoint

### DIFF
--- a/msg/fw_virtual_attitude_setpoint.msg
+++ b/msg/fw_virtual_attitude_setpoint.msg
@@ -1,0 +1,23 @@
+
+uint64 timestamp				# in microseconds since system start, is set whenever the writing thread stores new data
+
+float32 roll_body				# body angle in NED frame
+float32 pitch_body				# body angle in NED frame
+float32 yaw_body				# body angle in NED frame
+
+float32 yaw_sp_move_rate		# rad/s (commanded by user)
+
+float32[9] R_body				# Rotation matrix describing the setpoint as rotation from the current body frame
+bool R_valid					# Set to true if rotation matrix is valid
+
+# For quaternion-based attitude control
+float32[4] q_d					# Desired quaternion for quaternion control
+bool q_d_valid					# Set to true if quaternion vector is valid
+float32[4] q_e					# Attitude error in quaternion
+bool q_e_valid					# Set to true if quaternion error vector is valid
+
+float32 thrust					# Thrust in Newton the power system should generate
+
+bool roll_reset_integral			# Reset roll integral part (navigation logic change)
+bool pitch_reset_integral			# Reset pitch integral part (navigation logic change)
+bool yaw_reset_integral				# Reset yaw integral part (navigation logic change)

--- a/msg/mc_virtual_attitude_setpoint.msg
+++ b/msg/mc_virtual_attitude_setpoint.msg
@@ -1,0 +1,23 @@
+
+uint64 timestamp				# in microseconds since system start, is set whenever the writing thread stores new data
+
+float32 roll_body				# body angle in NED frame
+float32 pitch_body				# body angle in NED frame
+float32 yaw_body				# body angle in NED frame
+
+float32 yaw_sp_move_rate		# rad/s (commanded by user)
+
+float32[9] R_body				# Rotation matrix describing the setpoint as rotation from the current body frame
+bool R_valid					# Set to true if rotation matrix is valid
+
+# For quaternion-based attitude control
+float32[4] q_d					# Desired quaternion for quaternion control
+bool q_d_valid					# Set to true if quaternion vector is valid
+float32[4] q_e					# Attitude error in quaternion
+bool q_e_valid					# Set to true if quaternion error vector is valid
+
+float32 thrust					# Thrust in Newton the power system should generate
+
+bool roll_reset_integral			# Reset roll integral part (navigation logic change)
+bool pitch_reset_integral			# Reset pitch integral part (navigation logic change)
+bool yaw_reset_integral				# Reset yaw integral part (navigation logic change)

--- a/src/modules/fw_att_control/fw_att_control_main.cpp
+++ b/src/modules/fw_att_control/fw_att_control_main.cpp
@@ -60,6 +60,7 @@
 #include <uORB/uORB.h>
 #include <uORB/topics/airspeed.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
+#include <uORB/topics/fw_virtual_attitude_setpoint.h>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/actuator_controls_virtual_fw.h>
@@ -143,6 +144,7 @@ private:
 
 	orb_id_t _rates_sp_id;	// pointer to correct rates setpoint uORB metadata structure
 	orb_id_t _actuators_id;	// pointer to correct actuator controls0 uORB metadata structure
+	orb_id_t _attitude_setpoint_id;
 
 	struct vehicle_attitude_s			_att;			/**< vehicle attitude */
 	struct accel_report				_accel;			/**< body frame accelerations */
@@ -343,6 +345,7 @@ FixedwingAttitudeControl::FixedwingAttitudeControl() :
 
 	_rates_sp_id(0),
 	_actuators_id(0),
+	_attitude_setpoint_id(0),
 
 /* performance counters */
 	_loop_perf(perf_alloc(PC_ELAPSED, "fw att control")),
@@ -602,9 +605,11 @@ FixedwingAttitudeControl::vehicle_status_poll()
 			if (_vehicle_status.is_vtol) {
 				_rates_sp_id = ORB_ID(fw_virtual_rates_setpoint);
 				_actuators_id = ORB_ID(actuator_controls_virtual_fw);
+				_attitude_setpoint_id = ORB_ID(fw_virtual_attitude_setpoint);
 			} else {
 				_rates_sp_id = ORB_ID(vehicle_rates_setpoint);
 				_actuators_id = ORB_ID(actuator_controls_0);
+				_attitude_setpoint_id = ORB_ID(vehicle_attitude_setpoint);
 			}
 		}
 	}
@@ -937,15 +942,12 @@ FixedwingAttitudeControl::task_main()
 					att_sp.thrust = throttle_sp;
 
 					/* lazily publish the setpoint only once available */
-					if (!_vehicle_status.is_rotary_wing && !_vehicle_status.in_transition_mode) {
-						if (_attitude_sp_pub != nullptr) {
-							/* publish the attitude setpoint */
-							orb_publish(ORB_ID(vehicle_attitude_setpoint), _attitude_sp_pub, &att_sp);
-
-						} else {
-							/* advertise and publish */
-							_attitude_sp_pub = orb_advertise(ORB_ID(vehicle_attitude_setpoint), &att_sp);
-						}
+					if (_attitude_sp_pub != nullptr) {
+						/* publish the attitude setpoint */
+						orb_publish(_attitude_setpoint_id, _attitude_sp_pub, &att_sp);
+					} else if (_attitude_setpoint_id) {
+						/* advertise and publish */
+						_attitude_sp_pub = orb_advertise(_attitude_setpoint_id, &att_sp);
 					}
 				}
 

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
@@ -72,6 +72,7 @@
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
+#include <uORB/topics/fw_virtual_attitude_setpoint.h>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/vehicle_rates_setpoint.h>
@@ -163,6 +164,8 @@ private:
 	orb_advert_t	_attitude_sp_pub;		/**< attitude setpoint */
 	orb_advert_t	_tecs_status_pub;		/**< TECS status publication */
 	orb_advert_t	_nav_capabilities_pub;		/**< navigation capabilities publication */
+
+	orb_id_t _attitude_setpoint_id;
 
 	struct vehicle_attitude_s			_att;				/**< vehicle attitude */
 	struct vehicle_attitude_setpoint_s		_att_sp;			/**< vehicle attitude setpoint */
@@ -493,6 +496,9 @@ FixedwingPositionControl::FixedwingPositionControl() :
 	_tecs_status_pub(nullptr),
 	_nav_capabilities_pub(nullptr),
 
+/* publication ID */
+	_attitude_setpoint_id(0),
+
 /* states */
 	_att(),
 	_att_sp(),
@@ -745,6 +751,14 @@ FixedwingPositionControl::vehicle_status_poll()
 
 	if (updated) {
 		orb_copy(ORB_ID(vehicle_status), _vehicle_status_sub, &_vehicle_status);
+		/* set correct uORB ID, depending on if vehicle is VTOL or not */
+		if (!_attitude_setpoint_id) {
+			if (_vehicle_status.is_vtol) {
+				_attitude_setpoint_id = ORB_ID(fw_virtual_attitude_setpoint);
+			} else {
+				_attitude_setpoint_id = ORB_ID(vehicle_attitude_setpoint);
+			}
+		}
 	}
 }
 
@@ -1796,13 +1810,13 @@ FixedwingPositionControl::task_main()
 				_att_sp.timestamp = hrt_absolute_time();
 
 				/* lazily publish the setpoint only once available */
-				if (_attitude_sp_pub != nullptr && !_vehicle_status.is_rotary_wing && !_vehicle_status.in_transition_mode) {
+				if (_attitude_sp_pub != nullptr) {
 					/* publish the attitude setpoint */
-					orb_publish(ORB_ID(vehicle_attitude_setpoint), _attitude_sp_pub, &_att_sp);
+					orb_publish(_attitude_setpoint_id, _attitude_sp_pub, &_att_sp);
 
-				} else if (_attitude_sp_pub == nullptr && !_vehicle_status.is_rotary_wing && !_vehicle_status.in_transition_mode) {
+				} else if (_attitude_setpoint_id) {
 					/* advertise and publish */
-					_attitude_sp_pub = orb_advertise(ORB_ID(vehicle_attitude_setpoint), &_att_sp);
+					_attitude_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp);
 				}
 
 				/* XXX check if radius makes sense here */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -69,6 +69,7 @@
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/vehicle_rates_setpoint.h>
 #include <uORB/topics/vehicle_attitude.h>
+#include <uORB/topics/mc_virtual_attitude_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/actuator_armed.h>
 #include <uORB/topics/parameter_update.h>
@@ -140,6 +141,8 @@ private:
 	orb_advert_t	_att_sp_pub;			/**< attitude setpoint publication */
 	orb_advert_t	_local_pos_sp_pub;		/**< vehicle local position setpoint publication */
 	orb_advert_t	_global_vel_sp_pub;		/**< vehicle global velocity setpoint publication */
+
+	orb_id_t _attitude_setpoint_id;
 
 	struct vehicle_status_s 			_vehicle_status; 	/**< vehicle status */
 	struct vehicle_attitude_s			_att;			/**< vehicle attitude */
@@ -318,6 +321,7 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_att_sp_pub(nullptr),
 	_local_pos_sp_pub(nullptr),
 	_global_vel_sp_pub(nullptr),
+	_attitude_setpoint_id(0),
 	_manual_thr_min(this, "MANTHR_MIN"),
 	_manual_thr_max(this, "MANTHR_MAX"),
 	_ref_alt(0.0f),
@@ -491,6 +495,14 @@ MulticopterPositionControl::poll_subscriptions()
 
 	if (updated) {
 		orb_copy(ORB_ID(vehicle_status), _vehicle_status_sub, &_vehicle_status);
+		/* set correct uORB ID, depending on if vehicle is VTOL or not */
+		if (!_attitude_setpoint_id) {
+			if (_vehicle_status.is_vtol) {
+				_attitude_setpoint_id = ORB_ID(mc_virtual_attitude_setpoint);
+			} else {
+				_attitude_setpoint_id = ORB_ID(vehicle_attitude_setpoint);
+			}
+		}
 	}
 
 	orb_check(_att_sub, &updated);
@@ -1053,10 +1065,9 @@ MulticopterPositionControl::task_main()
 
 				/* publish attitude setpoint */
 				if (_att_sp_pub != nullptr) {
-					orb_publish(ORB_ID(vehicle_attitude_setpoint), _att_sp_pub, &_att_sp);
-
-				} else {
-					_att_sp_pub = orb_advertise(ORB_ID(vehicle_attitude_setpoint), &_att_sp);
+					orb_publish(_attitude_setpoint_id, _att_sp_pub, &_att_sp);
+				} else if (_attitude_setpoint_id) {
+					_att_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp);
 				}
 
 			} else {
@@ -1462,15 +1473,18 @@ MulticopterPositionControl::task_main()
 
 		/* publish attitude setpoint
 		 * Do not publish if offboard is enabled but position/velocity control is disabled,
-		 * in this case the attitude setpoint is published by the mavlink app
+		 * in this case the attitude setpoint is published by the mavlink app. Also do not publish
+		 * if the vehicle is a VTOL and it's just doing a transition (the VTOL attitude control module will generate
+		 * attitude setpoints for the transition).
 		 */
 		if (!(_control_mode.flag_control_offboard_enabled &&
 					!(_control_mode.flag_control_position_enabled ||
 						_control_mode.flag_control_velocity_enabled))) {
-			if (_att_sp_pub != nullptr && (_vehicle_status.is_rotary_wing || _vehicle_status.in_transition_mode)) {
-				orb_publish(ORB_ID(vehicle_attitude_setpoint), _att_sp_pub, &_att_sp);
-			} else if (_att_sp_pub == nullptr && (_vehicle_status.is_rotary_wing || _vehicle_status.in_transition_mode)) {
-				_att_sp_pub = orb_advertise(ORB_ID(vehicle_attitude_setpoint), &_att_sp);
+
+			if (_att_sp_pub != nullptr) {
+				orb_publish(_attitude_setpoint_id, _att_sp_pub, &_att_sp);
+			} else if (_attitude_setpoint_id) {
+				_att_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp);
 			}
 		}
 

--- a/src/modules/uORB/objects_common.cpp
+++ b/src/modules/uORB/objects_common.cpp
@@ -161,8 +161,12 @@ ORB_DEFINE(fence_vertex, struct fence_vertex_s);
 
 #include "topics/vehicle_attitude_setpoint.h"
 ORB_DEFINE(vehicle_attitude_setpoint, struct vehicle_attitude_setpoint_s);
-ORB_DEFINE(mc_virtual_attitude_setpoint, struct vehicle_attitude_setpoint_s);
-ORB_DEFINE(fw_virtual_attitude_setpoint, struct vehicle_attitude_setpoint_s);
+
+#include "topics/mc_virtual_attitude_setpoint.h"
+ORB_DEFINE(mc_virtual_attitude_setpoint, struct mc_virtual_attitude_setpoint_s);
+
+#include "topics/fw_virtual_attitude_setpoint.h"
+ORB_DEFINE(fw_virtual_attitude_setpoint, struct fw_virtual_attitude_setpoint_s);
 
 #include "topics/manual_control_setpoint.h"
 ORB_DEFINE(manual_control_setpoint, struct manual_control_setpoint_s);

--- a/src/modules/uORB/uORB.h
+++ b/src/modules/uORB/uORB.h
@@ -372,7 +372,6 @@ __END_DECLS
 
 /* Diverse uORB header defines */ //XXX: move to better location
 #define ORB_ID_VEHICLE_ATTITUDE_CONTROLS    ORB_ID(actuator_controls_0)
-typedef struct vehicle_attitude_setpoint_s fw_virtual_attitude_setpoint_s;
 typedef uint8_t arming_state_t;
 typedef uint8_t main_state_t;
 typedef uint8_t hil_state_t;

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -184,6 +184,9 @@ void Standard::update_vtol_state()
 
 void Standard::update_transition_state()
 {
+	// copy virtual attitude setpoint to real attitude setpoint
+	memcpy(_v_att_sp, _mc_virtual_att_sp, sizeof(vehicle_attitude_setpoint_s));
+
 	if (_vtol_schedule.flight_mode == TRANSITION_TO_FW) {
 		if (_params_standard.front_trans_dur <= 0.0f) {
 			// just set the final target throttle value
@@ -235,11 +238,15 @@ void Standard::update_transition_state()
 
 void Standard::update_mc_state()
 {
-	// do nothing
+	// copy virtual attitude setpoint to real attitude setpoint
+	memcpy(_v_att_sp, _mc_virtual_att_sp, sizeof(vehicle_attitude_setpoint_s));
 }
 
  void Standard::update_fw_state()
 {
+	// copy virtual attitude setpoint to real attitude setpoint
+	memcpy(_v_att_sp, _fw_virtual_att_sp, sizeof(vehicle_attitude_setpoint_s));
+
 	// in fw mode we need the multirotor motors to stop spinning, in backtransition mode we let them spin up again	
 	if (!_flag_enable_mc_motors) {
 		set_max_mc(950);

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -71,6 +71,9 @@ void Tailsitter::update_mc_state()
 		set_idle_mc();
 		flag_idle_mc = true;
 	}
+
+	// copy virtual attitude setpoint to real attitude setpoint
+	memcpy(_v_att_sp, _mc_virtual_att_sp, sizeof(vehicle_attitude_setpoint_s));
 }
 
 void Tailsitter::update_fw_state()
@@ -79,6 +82,9 @@ void Tailsitter::update_fw_state()
 		set_idle_fw();
 		flag_idle_mc = false;
 	}
+
+	// copy virtual attitude setpoint to real attitude setpoint
+	memcpy(_v_att_sp, _fw_virtual_att_sp, sizeof(vehicle_attitude_setpoint_s));
 }
 
 void Tailsitter::update_transition_state()

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -217,20 +217,26 @@ void Tiltrotor::update_vtol_state()
 	switch(_vtol_schedule.flight_mode) {
 		case MC_MODE:
 			_vtol_mode = ROTARY_WING;
+			_vtol_vehicle_status->vtol_in_trans_mode = false;
 			break;
 		case FW_MODE:
 			_vtol_mode = FIXED_WING;
+			_vtol_vehicle_status->vtol_in_trans_mode = false;
 			break;
 		case TRANSITION_FRONT_P1:
 		case TRANSITION_FRONT_P2:
 		case TRANSITION_BACK:
 			_vtol_mode = TRANSITION;
+			_vtol_vehicle_status->vtol_in_trans_mode = true;
 			break;
 	}
 }
 
 void Tiltrotor::update_mc_state()
 {
+	// copy virtual attitude setpoint to real attitude setpoint
+	memcpy(_v_att_sp, _mc_virtual_att_sp, sizeof(vehicle_attitude_setpoint_s));
+
 	// make sure motors are not tilted
 	_tilt_control = _params_tiltrotor.tilt_mc;
 
@@ -252,6 +258,9 @@ void Tiltrotor::update_mc_state()
 
  void Tiltrotor::update_fw_state()
 {
+	// copy virtual attitude setpoint to real attitude setpoint
+	memcpy(_v_att_sp, _fw_virtual_att_sp, sizeof(vehicle_attitude_setpoint_s));
+
 	// make sure motors are tilted forward
 	_tilt_control = _params_tiltrotor.tilt_fw;
 
@@ -327,6 +336,9 @@ void Tiltrotor::update_transition_state()
 
 	_mc_roll_weight = math::constrain(_mc_roll_weight, 0.0f, 1.0f);
 	_mc_yaw_weight = math::constrain(_mc_yaw_weight, 0.0f, 1.0f);
+
+	// copy virtual attitude setpoint to real attitude setpoint (we use multicopter att sp)
+	memcpy(_v_att_sp, _mc_virtual_att_sp, sizeof(vehicle_attitude_setpoint_s));
 }
 
 void Tiltrotor::update_external_state()

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -58,6 +58,8 @@
 #include <drivers/drv_pwm_output.h>
 #include <uORB/uORB.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
+#include <uORB/topics/mc_virtual_attitude_setpoint.h>
+#include <uORB/topics/fw_virtual_attitude_setpoint.h>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/actuator_controls_virtual_mc.h>
@@ -101,22 +103,24 @@ public:
 	int start();	/* start the task and return OK on success */
 	bool is_fixed_wing_requested();
 
-	struct vehicle_attitude_s* 			get_att () {return &_v_att;}
-	struct vehicle_attitude_setpoint_s* get_att_sp () {return &_v_att_sp;}
-	struct vehicle_rates_setpoint_s* 	get_rates_sp () {return &_v_rates_sp;}
-	struct vehicle_rates_setpoint_s* 	get_mc_virtual_rates_sp () {return &_mc_virtual_v_rates_sp;}
-	struct vehicle_rates_setpoint_s* 	get_fw_virtual_rates_sp () {return &_fw_virtual_v_rates_sp;}
-	struct manual_control_setpoint_s* 	get_manual_control_sp () {return &_manual_control_sp;}
-	struct vehicle_control_mode_s* 		get_control_mode () {return &_v_control_mode;}
-	struct vtol_vehicle_status_s*		get_vehicle_status () {return &_vtol_vehicle_status;}
-	struct actuator_controls_s* 		get_actuators_out0 () {return &_actuators_out_0;}
-	struct actuator_controls_s* 		get_actuators_out1 () {return &_actuators_out_1;}
-	struct actuator_controls_s* 		get_actuators_mc_in () {return &_actuators_mc_in;}
-	struct actuator_controls_s* 		get_actuators_fw_in () {return &_actuators_fw_in;}
-	struct actuator_armed_s* 			get_armed () {return &_armed;}
-	struct vehicle_local_position_s* 	get_local_pos () {return &_local_pos;}
-	struct airspeed_s* 					get_airspeed () {return &_airspeed;}
-	struct battery_status_s* 			get_batt_status () {return &_batt_status;}
+	struct vehicle_attitude_s* 				get_att () {return &_v_att;}
+	struct vehicle_attitude_setpoint_s*		get_att_sp () {return &_v_att_sp;}
+	struct mc_virtual_attitude_setpoint_s* 	get_mc_virtual_att_sp () {return &_mc_virtual_att_sp;}
+	struct fw_virtual_attitude_setpoint_s* 	get_fw_virtual_att_sp () {return &_fw_virtual_att_sp;}
+	struct vehicle_rates_setpoint_s* 		get_rates_sp () {return &_v_rates_sp;}
+	struct vehicle_rates_setpoint_s* 		get_mc_virtual_rates_sp () {return &_mc_virtual_v_rates_sp;}
+	struct vehicle_rates_setpoint_s* 		get_fw_virtual_rates_sp () {return &_fw_virtual_v_rates_sp;}
+	struct manual_control_setpoint_s* 		get_manual_control_sp () {return &_manual_control_sp;}
+	struct vehicle_control_mode_s* 			get_control_mode () {return &_v_control_mode;}
+	struct vtol_vehicle_status_s*			get_vehicle_status () {return &_vtol_vehicle_status;}
+	struct actuator_controls_s* 			get_actuators_out0 () {return &_actuators_out_0;}
+	struct actuator_controls_s* 			get_actuators_out1 () {return &_actuators_out_1;}
+	struct actuator_controls_s* 			get_actuators_mc_in () {return &_actuators_mc_in;}
+	struct actuator_controls_s* 			get_actuators_fw_in () {return &_actuators_fw_in;}
+	struct actuator_armed_s* 				get_armed () {return &_armed;}
+	struct vehicle_local_position_s* 		get_local_pos () {return &_local_pos;}
+	struct airspeed_s* 						get_airspeed () {return &_airspeed;}
+	struct battery_status_s* 				get_batt_status () {return &_batt_status;}
 
 	struct Params* 						get_params () {return &_params;}
 
@@ -129,6 +133,8 @@ private:
 	/* handlers for subscriptions */
 	int		_v_att_sub;				//vehicle attitude subscription
 	int		_v_att_sp_sub;			//vehicle attitude setpoint subscription
+	int 	_mc_virtual_att_sp_sub;
+	int 	_fw_virtual_att_sp_sub;
 	int		_mc_virtual_v_rates_sp_sub;		//vehicle rates setpoint subscription
 	int		_fw_virtual_v_rates_sp_sub;		//vehicle rates setpoint subscription
 	int		_v_control_mode_sub;	//vehicle control mode subscription
@@ -148,9 +154,12 @@ private:
 	orb_advert_t 	_actuators_1_pub;
 	orb_advert_t	_vtol_vehicle_status_pub;
 	orb_advert_t	_v_rates_sp_pub;
+	orb_advert_t	_v_att_sp_pub;
 //*******************data containers***********************************************************
 	struct vehicle_attitude_s			_v_att;				//vehicle attitude
 	struct vehicle_attitude_setpoint_s	_v_att_sp;			//vehicle attitude setpoint
+	struct mc_virtual_attitude_setpoint_s _mc_virtual_att_sp;	// virtual mc attitude setpoint
+	struct fw_virtual_attitude_setpoint_s _fw_virtual_att_sp;	// virtual fw attitude setpoint
 	struct vehicle_rates_setpoint_s		_v_rates_sp;		//vehicle rates setpoint
 	struct vehicle_rates_setpoint_s		_mc_virtual_v_rates_sp;		// virtual mc vehicle rates setpoint
 	struct vehicle_rates_setpoint_s		_fw_virtual_v_rates_sp;		// virtual fw vehicle rates setpoint
@@ -204,6 +213,8 @@ private:
 	void		vehicle_control_mode_poll();	//Check for changes in vehicle control mode.
 	void		vehicle_manual_poll();			//Check for changes in manual inputs.
 	void		arming_status_poll();			//Check for arming status updates.
+	void 		mc_virtual_att_sp_poll();
+	void 		fw_virtual_att_sp_poll();
 	void 		actuator_controls_mc_poll();	//Check for changes in mc_attitude_control output
 	void 		actuator_controls_fw_poll();	//Check for changes in fw_attitude_control output
 	void 		vehicle_rates_sp_mc_poll();
@@ -217,6 +228,7 @@ private:
 	void 		fill_mc_att_rates_sp();
 	void 		fill_fw_att_rates_sp();
 	void		handle_command();
+	void 		publish_att_sp();
 };
 
 #endif

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -49,6 +49,8 @@ _vtol_mode(ROTARY_WING)
 {
 	_v_att = _attc->get_att();
 	_v_att_sp = _attc->get_att_sp();
+	_mc_virtual_att_sp = _attc->get_mc_virtual_att_sp();
+	_fw_virtual_att_sp = _attc->get_fw_virtual_att_sp();
 	_v_rates_sp = _attc->get_rates_sp();
 	_mc_virtual_v_rates_sp = _attc->get_mc_virtual_rates_sp();
 	_fw_virtual_v_rates_sp = _attc->get_fw_virtual_rates_sp();

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -93,6 +93,8 @@ protected:
 
 	struct vehicle_attitude_s		*_v_att;				//vehicle attitude
 	struct vehicle_attitude_setpoint_s	*_v_att_sp;			//vehicle attitude setpoint
+	struct mc_virtual_attitude_setpoint_s *_mc_virtual_att_sp;	// virtual mc attitude setpoint
+	struct fw_virtual_attitude_setpoint_s *_fw_virtual_att_sp;	// virtual fw attitude setpoint
 	struct vehicle_rates_setpoint_s		*_v_rates_sp;		//vehicle rates setpoint
 	struct vehicle_rates_setpoint_s		*_mc_virtual_v_rates_sp;		// virtual mc vehicle rates setpoint
 	struct vehicle_rates_setpoint_s		*_fw_virtual_v_rates_sp;		// virtual fw vehicle rates setpoint
@@ -115,6 +117,10 @@ protected:
 	float _mc_roll_weight;	// weight for multicopter attitude controller roll output
 	float _mc_pitch_weight;	// weight for multicopter attitude controller pitch output
 	float _mc_yaw_weight;	// weight for multicopter attitude controller yaw output
+
+	float _yaw_transition;	// yaw angle in which transition will take place
+	float _throttle_transition; // throttle value used for the transition phase
+	bool _flag_was_in_trans_mode;	// true if mode has just switched to transition
 
 };
 


### PR DESCRIPTION
This introduces virtual attitude setpoints for vtol:
The mc/fw control modules should publish on virtual attitude setpoint topics.
The vtol att control modules subscribes on these topics and will then publish on the real attitude setpoint topic. This moves the entire attitude setpoint logic into the vtol module and allows us to integrate tailsitters more conveniently (where we need to generate att setpoints for the transition).

Things we still need to look at:

1) The attitude setpoint generation should be removed out of the fw_att control module. At the moment it will use it's own attitude setpoint e.g. in manual mode.

2) At the moment the vtol module is driven by actuator controls from the attitude controllers. Maybe we should instead use attitude setpoints or both in separate loops.

3) The attitude transformation for tailsitters (90 degrees rotation) in the fw_att_control module should be removed. It's much cleaner to rotate the desired attitude in the vtol module. 
