### PR TITLE
has_key is not available in python > 3.0

### DIFF
--- a/Tools/px4params/srcparser.py
+++ b/Tools/px4params/srcparser.py
@@ -200,7 +200,7 @@ class SourceParser(object):
                     m = self.re_px4_parameter_definition.match(line)
                     if m:
                         tp, name = m.group(1, 2)
-                        if default_var.has_key(name+'_DEFAULT'):
+                        if (name+'_DEFAULT') in default_var:
                             defval = default_var[name+'_DEFAULT']
                 if tp is not None:
                     # Remove trailing type specifier from numbers: 0.1f => 0.1


### PR DESCRIPTION
Replacing with 'in'

See https://docs.python.org/3.1/whatsnew/3.0.html#builtins

I did not test with python2, so let's wait for the CI results!