### PR TITLE
Remove policy that broke posix and fix gcc warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,6 @@ project(px4 CXX C ASM)
 if (NOT ${CMAKE_VERSION} VERSION_LESS 3.0.0)
 	cmake_policy(SET CMP0045 NEW) # error on non-existent target in get prop
 	cmake_policy(SET CMP0046 NEW) # no non-existent targets as dependencies
-	cmake_policy(SET CMP0054 NEW) # don't dereference quoted variables
 endif()
 
 set(version_major 1)

--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -498,7 +498,6 @@ function(px4_add_common_flags)
 		-Werror=reorder
 		-Werror=uninitialized
 		-Werror=init-self
-		-Wno-unused-const-variable
 		#-Wcast-qual  - generates spurious noreturn attribute warnings,
 		#               try again later
 		#-Wconversion - would be nice, but too many "risky-but-safe"
@@ -507,7 +506,11 @@ function(px4_add_common_flags)
 		#               but generates too many false positives
 		)
 
-	if (NOT ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+	if (${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+		list(APPEND warnings
+			-Wno-unused-const-variable
+		)
+	else(${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
 		list(APPEND warnings
 			-Werror=unused-but-set-variable
 			-Wformat=1


### PR DESCRIPTION
A Clang only flag was set for all builds. The policy change to upstream was reverted.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>