### PR TITLE
Improvements to make support, added debug target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ file(GLOB_RECURSE configs RELATIVE cmake/configs "cmake/configs/*.cmake")
 set_property(CACHE CONFIG PROPERTY STRINGS ${configs})
 set(THREADS "4" CACHE STRING
 	"number of threads to use for external build processes")
+set(DEBUG_PORT "/dev/ttyACM0" CACHE STRING "debugging port")
 
 #=============================================================================
 # configuration

--- a/Makefile
+++ b/Makefile
@@ -54,16 +54,22 @@
 # rest are arguments to pass to the makefile generated
 # by cmake in the subdirectory
 ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
-j ?= 1
+j ?= 4
 
 # Functions
 # --------------------------------------------------------------------
-# define a make function to describe how to build a cmake config
+# describe how to build a cmake config
 define cmake-build
 +mkdir -p $(PWD)/build_$@ && cd $(PWD)/build_$@ && cmake .. -DCONFIG=$(1)
-+make -C $(PWD)/build_$@ --no-print-directory $(ARGS)
++make -j$(j) -C $(PWD)/build_$@ --no-print-directory $(ARGS)
 endef
 
+# create empty targets to avoid msgs for targets passed to cmake
+define cmake-targ
+$(1):
+	@#
+.PHONY: $(1)
+endef
 
 # ADD CONFIGS HERE
 # --------------------------------------------------------------------
@@ -104,12 +110,10 @@ clean:
 	rm -rf build_*/
 
 # targets handled by cmake
-test: ;
-upload: ;
-package: ;
-package_source: ;
+cmake_targets = test upload packag package_source debug check_weak
+$(foreach targ,$(cmake_targets),$(eval $(call cmake-targ,$(targ))))
 
-.PHONY: clean test upload package package_source
+.PHONY: clean
 
 CONFIGS:=$(shell ls cmake/configs | sed -e "s~.*/~~" | sed -e "s~\..*~~")
 

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ clean:
 	rm -rf build_*/
 
 # targets handled by cmake
-cmake_targets = test upload packag package_source debug check_weak
+cmake_targets = test upload package package_source debug check_weak
 $(foreach targ,$(cmake_targets),$(eval $(call cmake-targ,$(targ))))
 
 .PHONY: clean

--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -551,6 +551,7 @@ function(px4_add_common_flags)
 	endif()
 
 	set(c_compile_flags
+		-g3
 		-std=gnu99
 		-fno-common
 		)
@@ -559,6 +560,7 @@ function(px4_add_common_flags)
 		-Wno-missing-field-initializers
 		)
 	set(cxx_compile_flags
+		-g3
 		-fno-exceptions
 		-fno-rtti
 		-std=gnu++0x

--- a/cmake/nuttx/bin_to_obj.py
+++ b/cmake/nuttx/bin_to_obj.py
@@ -55,10 +55,19 @@ run_cmd("{ld:s} -r -o {obj:s}.bin.o {obj:s}.c.o -b binary {in_bin:s}",
 
 # get size of image
 stdout = run_cmd("{nm:s} -p --radix=x {obj:s}.bin.o", locals())
-re_size = re.compile("(^[0-9A-Fa-f]*) .*{sym:s}_size".format(
-    **locals()))
-size_match = re.match(re_size, stdout)
-size = size_match.group(1)
+re_string = r"^([0-9A-F-a-f]+) .*{sym:s}_size\n".format(**locals())
+re_size = re.compile(re_string, re.MULTILINE)
+size_match = re.search(re_size, stdout)
+try:
+    size = size_match.group(1)
+except AttributeError as e:
+    raise RuntimeError("{:s}\nre:{:s}\n{:s}".format(
+        e, re_string, stdout))
+except IndexError as e:
+    group0 = size_match.group(0)
+    raise RuntimeError("{:s}\ngroup 0:{:s}\n{:s}".format(
+        e, group0, stdout))
+
 #print("romfs size: ", size)
 
 # write size to file

--- a/cmake/toolchains/Toolchain-arm-none-eabi.cmake
+++ b/cmake/toolchains/Toolchain-arm-none-eabi.cmake
@@ -37,7 +37,7 @@ endif()
 cmake_force_cxx_compiler(${CXX_COMPILER} GNU)
 
 # compiler tools
-foreach(tool objcopy nm ld)
+foreach(tool objcopy nm ld gdb)
 	string(TOUPPER ${tool} TOOL)
 	find_program(${TOOL} arm-none-eabi-${tool})
 	if(NOT ${TOOL})

--- a/src/firmware/nuttx/CMakeLists.txt
+++ b/src/firmware/nuttx/CMakeLists.txt
@@ -31,9 +31,22 @@ target_link_libraries(firmware_nuttx
 
 set(fw_file ${CMAKE_CURRENT_BINARY_DIR}/${OS}-${BOARD}-${LABEL}.px4)
 
+add_custom_target(check_weak
+	COMMAND ${NM} firmware_nuttx | grep " w "
+	DEPENDS firmware_nuttx
+	)
+
 px4_nuttx_add_firmware(OUT ${fw_file}
-	EXE ${CMAKE_CURRENT_BINARY_DIR}/firmware_nuttx
+	EXE firmware_nuttx
 	${config_firmware_options}
+	)
+
+configure_file(gdbinit.in .gdbinit)
+
+add_custom_target(debug
+	COMMAND ${GDB} ${CMAKE_CURRENT_BINARY_DIR}/firmware_nuttx
+	DEPENDS firmware_nuttx
+		${CMAKE_CURRENT_BINARY_DIR}/.gdbinit
 	)
 
 px4_add_upload(OUT upload OS ${OS} BOARD ${BOARD}

--- a/src/firmware/nuttx/gdbinit.in
+++ b/src/firmware/nuttx/gdbinit.in
@@ -1,0 +1,7 @@
+target extended ${DEBUG_PORT}
+monitor swdp_scan
+attach 1
+monitor vector_catch disable hard
+set mem inaccessible-by-default off
+set print pretty
+source Debug/PX4


### PR DESCRIPTION
* Defaulted to j4 parallel make bulid

* Enabled autostart script, since boot is now working.

* Added debug target that creates a gdbinit script and calls gdb on the firmware for you. Note that you will need to set the follwing in your root .gdbiint:
~/.gdbinit:
set auto-load safe-path /

* Added check_weak target that prints all weak symbols in the firmware, the current list is:
This removes the weak attribute from some functions that caused the symbols to get thrown away when linking as static libraries to the executable in the new build.
