### PR TITLE
Mark FILESYSTEM_ERRCOUNT_NOTIFY_LIMIT as an unsigned int

### DIFF
--- a/src/modules/mavlink/mavlink_mission.h
+++ b/src/modules/mavlink/mavlink_mission.h
@@ -133,7 +133,7 @@ private:
 
 	bool _verbose;
 
-	static constexpr int	FILESYSTEM_ERRCOUNT_NOTIFY_LIMIT = 2;	///< Error count limit before stopping to report FS errors
+	static constexpr unsigned int	FILESYSTEM_ERRCOUNT_NOTIFY_LIMIT = 2;	///< Error count limit before stopping to report FS errors
 
 	/* do not allow top copying this class */
 	MavlinkMissionManager(MavlinkMissionManager &);


### PR DESCRIPTION
Fix the compilationof mavlink_mission.cpp failing with

error: comparison between signed and unsigned integer expressions
[-Werror=sign-compare]