### PR TITLE
MAVLink app: Add broadcast until GCS is connected

### DIFF
--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -417,6 +417,7 @@ private:
 #ifdef __PX4_POSIX
 	struct sockaddr_in _myaddr;
 	struct sockaddr_in _src_addr;
+	struct sockaddr_in _bcast_addr;
 
 #endif
 	int _socket_fd;


### PR DESCRIPTION
This helps to find the system by the GCS more effectively.