### PR TITLE
Master uavcan start issue

### DIFF
--- a/src/modules/uavcan/uavcan_servers.cpp
+++ b/src/modules/uavcan/uavcan_servers.cpp
@@ -98,6 +98,7 @@ UavcanServers::~UavcanServers()
 	if (_mutex_inited) {
 		(void)Lock::deinit(_subnode_mutex);
 	}
+
 	_main_node.getDispatcher().removeRxFrameListener();
 }
 
@@ -164,9 +165,9 @@ int UavcanServers::start(uavcan::INode &main_node)
 
 	rv = pthread_create(&_instance->_subnode_thread, &tattr, static_cast<pthread_startroutine_t>(run_trampoline), NULL);
 
-	if (rv < 0) {
-		warnx("pthread_create() failed: %d", errno);
-		rv =  -errno;
+	if (rv != 0) {
+		rv = -rv;
+		warnx("pthread_create() failed: %d", rv);
 		delete _instance;
 		_instance = nullptr;
 	}


### PR DESCRIPTION
This resolves the issue were the command ```uavcan start fw`` would hang in low memory situations. The problem was 2 fold:
1) nuttx had a bug where the owing group (task) would have it's resources deleted if a pthread_create failed.
2) The code checking the return from  pthread_create was not correct.
