### PR TITLE
pixhawk test runner script

### DIFF
--- a/Tools/pixhawk_watch_tests.py
+++ b/Tools/pixhawk_watch_tests.py
@@ -1,0 +1,33 @@
+#! /usr/bin/env python
+
+"""
+This is a simple helper for running pixhawk onboard unit tests.
+
+The script returns 0 if the tests successfully pass, or -1 otherwise.
+"""
+
+from __future__ import print_function
+
+import serial
+import sys
+
+def main(port):
+    ser = serial.Serial(port, 57600, timeout=20)
+    rc = 1
+    line = 1
+    while line:
+        line = ser.readline()
+        print(line, end="")
+        if "All tests passed" in line:
+            rc = 0
+        if "NuttShell (NSH)" in line:
+            return rc
+    return rc
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Error, specify serial port", file=sys.stderr)
+        sys.exit(1)
+
+    sys.exit(main(sys.argv[1]))
+


### PR DESCRIPTION
I'm not sure if this is worth contributing, but I find it useful. It's just a simple python script that I run right after a successful upload that shows the console output as the tests are running and returns a failure code if the onboard tests fail. It makes it easy to setup jenkins or equivalent for hardware tests.

    make upload px4fmu-v2_test && ./Tools/pixhawk_watch_tests.py /dev/serial/by-id/usb-Keyspan__a_division_of_InnoSys_Inc._Keyspan_USA-19H-if00-port0