### PR TITLE
qurt: Must use latest version of Eigen

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,6 +22,3 @@
 [submodule "src/lib/dspal"]
 	path = src/lib/dspal
 	url = https://github.com/mcharleb/dspal.git
-[submodule "src/lib/eigen-3.2"]
-	path = src/lib/eigen-3.2
-	url = https://github.com/PX4/eigen.git

--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -139,7 +139,7 @@ function(px4_add_git_submodule)
 	add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/git_${NAME}.stamp
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 		COMMAND git submodule init ${PATH}
-		COMMAND git submodule update ${PATH}
+		COMMAND git submodule update -f ${PATH}
 		COMMAND touch ${CMAKE_BINARY_DIR}/git_${NAME}.stamp
 		)
 	add_custom_target(${TARGET}

--- a/cmake/qurt/px4_impl_qurt.cmake
+++ b/cmake/qurt/px4_impl_qurt.cmake
@@ -225,6 +225,7 @@ function(px4_os_prebuild_targets)
 	add_custom_target(git_eigen_patched
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/lib/eigen
 		COMMAND git checkout .
+		COMMAND git checkout master
 		COMMAND patch -p1 -i ${CMAKE_SOURCE_DIR}/cmake/qurt/qurt_eigen.patch
 		DEPENDS git_eigen)
 	add_custom_target(${OUT} DEPENDS git_dspal git_eigen_patched)


### PR DESCRIPTION
The latest version of Eigen is required to build with the Hexagon
7.4 toolchain. Only certain C++11 features are supported and the
latest version if Eigen provides these tests. A patch is required
to add support for the Hexagon compiler.

These changes force the sync and then update of eigen and allow it
to be patched for qurt.

The eigen-3.2 submodule was removed as it is no longer needed by the
qurt build with the updated toolchain.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>