### PR TITLE
mc_pos_control: velocity control with pos. hold

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -770,6 +770,8 @@ MulticopterPositionControl::control_offboard(float dt)
 			/* set position setpoint move rate */
 			_vel_sp(0) = _pos_sp_triplet.current.vx;
 			_vel_sp(1) = _pos_sp_triplet.current.vy;
+
+			_run_pos_control = false; /* request velocity setpoint to be used, instead of position setpoint */
 		}
 
 		if (_pos_sp_triplet.current.yaw_valid) {
@@ -787,6 +789,8 @@ MulticopterPositionControl::control_offboard(float dt)
 
 			/* set altitude setpoint move rate */
 			_vel_sp(2) = _pos_sp_triplet.current.vz;
+
+			_run_alt_control = false; /* request velocity setpoint to be used, instead of position setpoint */
 		}
 	} else {
 		reset_pos_sp();

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -177,7 +177,8 @@ private:
 		param_t man_pitch_max;
 		param_t man_yaw_max;
 		param_t mc_att_yaw_p;
-		param_t hold_dz;
+		param_t hold_xy_dz;
+		param_t hold_z_dz;
 		param_t hold_max_xy;
 		param_t hold_max_z;
 	}		_params_handles;		/**< handles for interesting parameters */
@@ -192,7 +193,8 @@ private:
 		float man_pitch_max;
 		float man_yaw_max;
 		float mc_att_yaw_p;
-		float hold_dz;
+		float hold_xy_dz;
+		float hold_z_dz;
 		float hold_max_xy;
 		float hold_max_z;
 
@@ -389,7 +391,8 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_params_handles.man_pitch_max = param_find("MPC_MAN_P_MAX");
 	_params_handles.man_yaw_max = param_find("MPC_MAN_Y_MAX");
 	_params_handles.mc_att_yaw_p = param_find("MC_YAW_P");
-	_params_handles.hold_dz = param_find("MPC_HOLD_DZ");
+	_params_handles.hold_xy_dz = param_find("MPC_HOLD_XY_DZ");
+	_params_handles.hold_z_dz = param_find("MPC_HOLD_Z_DZ");
 	_params_handles.hold_max_xy = param_find("MPC_HOLD_MAX_XY");
 	_params_handles.hold_max_z = param_find("MPC_HOLD_MAX_Z");
 
@@ -480,9 +483,12 @@ MulticopterPositionControl::parameters_update(bool force)
 		param_get(_params_handles.z_ff, &v);
 		v = math::constrain(v, 0.0f, 1.0f);
 		_params.vel_ff(2) = v;
-		param_get(_params_handles.hold_dz, &v);
+		param_get(_params_handles.hold_xy_dz, &v);
 		v = math::constrain(v, 0.0f, 1.0f);
-		_params.hold_dz = v;
+		_params.hold_xy_dz = v;
+		param_get(_params_handles.hold_z_dz, &v);
+		v = math::constrain(v, 0.0f, 1.0f);
+		_params.hold_z_dz = v;
 		param_get(_params_handles.hold_max_xy, &v);
 		_params.hold_max_xy = (v < 0.0f ? 0.0f : v);
 		param_get(_params_handles.hold_max_z, &v);
@@ -695,7 +701,7 @@ MulticopterPositionControl::control_manual(float dt)
 	if (_control_mode.flag_control_position_enabled)
 	{
 		/* check for pos. hold */
-		if (fabsf(req_vel_sp(0)) < _params.hold_dz && fabsf(req_vel_sp(1)) < _params.hold_dz)
+		if (fabsf(req_vel_sp(0)) < _params.hold_xy_dz && fabsf(req_vel_sp(1)) < _params.hold_xy_dz)
 		{
 			if (!_pos_hold_engaged && (_params.hold_max_xy < FLT_EPSILON ||
 																 (fabsf(_vel(0)) < _params.hold_max_xy && fabsf(_vel(1)) < _params.hold_max_xy)))
@@ -721,7 +727,7 @@ MulticopterPositionControl::control_manual(float dt)
 	if (_control_mode.flag_control_altitude_enabled)
 	{
 		/* check for pos. hold */
-		if (fabsf(req_vel_sp(2)) < _params.hold_dz)
+		if (fabsf(req_vel_sp(2)) < _params.hold_z_dz)
 		{
 			if (!_alt_hold_engaged && (_params.hold_max_z < FLT_EPSILON || fabsf(_vel(2)) < _params.hold_max_z))
 			{

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -696,7 +696,7 @@ MulticopterPositionControl::control_manual(float dt)
 		/* check for pos. hold */
 		if (fabsf(req_vel_sp(0)) < _params.hold_dz && fabsf(req_vel_sp(1)) < _params.hold_dz)
 		{
-			if (!_pos_hold_engaged && (_params.hold_max_xy == 0.0f ||
+			if (!_pos_hold_engaged && (_params.hold_max_xy < FLT_EPSILON ||
 																 (fabsf(_vel(0)) < _params.hold_max_xy && fabsf(_vel(1)) < _params.hold_max_xy)))
 			{
 				_pos_hold_engaged = true;
@@ -725,7 +725,7 @@ MulticopterPositionControl::control_manual(float dt)
 		/* check for pos. hold */
 		if (fabsf(req_vel_sp(2)) < _params.hold_dz)
 		{
-			if (!_alt_hold_engaged && (_params.hold_max_z == 0.0f || fabsf(_vel(2)) < _params.hold_max_z))
+			if (!_alt_hold_engaged && (_params.hold_max_z < FLT_EPSILON || fabsf(_vel(2)) < _params.hold_max_z))
 			{
 				_alt_hold_engaged = true;
 				_pos_hold_engaged = true;

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -265,3 +265,31 @@ PARAM_DEFINE_FLOAT(MPC_MAN_P_MAX, 35.0f);
  */
 PARAM_DEFINE_FLOAT(MPC_MAN_Y_MAX, 120.0f);
 
+/**
+ * Deadzone of X,Y,Z where position hold is enabled
+ *
+ * @unit percent
+ * @min 0.0
+ * @max 1.0
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_HOLD_DZ, 0.1f);
+
+/**
+ * Maximum horizontal velocity for which position hold is enabled (use 0 to disable check)
+ *
+ * @unit m/s
+ * @min 0.0
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_HOLD_MAX_XY, 0.5f);
+
+/**
+ * Maximum vertical velocity for which position hold is enabled (use 0 to disable check)
+ *
+ * @unit m/s
+ * @min 0.0
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_HOLD_MAX_Z, 0.5f);
+

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -266,14 +266,24 @@ PARAM_DEFINE_FLOAT(MPC_MAN_P_MAX, 35.0f);
 PARAM_DEFINE_FLOAT(MPC_MAN_Y_MAX, 120.0f);
 
 /**
- * Deadzone of X,Y,Z where position hold is enabled
+ * Deadzone of X,Y sticks where position hold is enabled
  *
  * @unit %
  * @min 0.0
  * @max 1.0
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_HOLD_DZ, 0.1f);
+PARAM_DEFINE_FLOAT(MPC_HOLD_XY_DZ, 0.1f);
+
+/**
+ * Deadzone of Z stick where altitude hold is enabled
+ *
+ * @unit %
+ * @min 0.0
+ * @max 1.0
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_HOLD_Z_DZ, 0.1f);
 
 /**
  * Maximum horizontal velocity for which position hold is enabled (use 0 to disable check)

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -268,7 +268,7 @@ PARAM_DEFINE_FLOAT(MPC_MAN_Y_MAX, 120.0f);
 /**
  * Deadzone of X,Y,Z where position hold is enabled
  *
- * @unit percent
+ * @unit %
  * @min 0.0
  * @max 1.0
  * @group Multicopter Position Control


### PR DESCRIPTION
This PR is the follow up of @tumbili 's work in #2305 

# Overview

Following original idea, manual control in POSCTL directly commands velocity (sets velocity setpoint). To aid manual control, whenever user centers sticks, XY and/or Z positions are held (position hold to that position is enabled).

# Summary of features

* Original work by @tumbili targeted only modified behavior for manual mode. This PR implements actual velocity setpoints (instead of move rate of position setpoint, as it is now) for offboard mode, when a velocity setpoint is received. Positions setpoints are still handled as before
* Position hold when centering sticks is only an aid during manual control. Velocity setpoints received in offboard mode do not have this behavior. User could mimic this on offboard side by switching to sending position setpoints if desired.
* Four parameters are introduced: the deadzone (in % of stick throw) for XY and Z sticks are considered centered (which is required for pos. hold to enable) and maximum XY and Z velocities that are allowed when switching to pos. hold.
* Deadzones can be set to 0 to completely disable position hold feature (pure velocity commands). Max velocities can also be set to 0 to not require this condition and always activate pos. hold when sticks are centered.
* Separate deadzones for XY and Z allow setting XY_DZ=0 and Z_DZ!=0, thus hold altitude while using velocity control for XY (the reverse might not be that useful).

# Implementation aspects

* @tumbili initial implementation had all code running on main task, dependent on manual mode enabled. I've thus moved most of pos. hold handling to control_manual() function to keep things clean.
* the P controller for position/altitude runs on main_task (as before) by default, but control_* functions can choose to not run it (when it is then assumed that these functions directly set velocity setpoint)
* sp_move_rate variable was removed (actually renamed). The input from sticks is termed "requested velocity setpoint" and is only local to control_manual() function
* in pos hold mode for either XY or Z, the position setpoint is set, and the velicity setpoint is computed (P control) computed. Otherwise, the velocity setpoint is updated from stick inputs.
* Offboard mode was modified to directly set the velocity setpoint instead of playing with the sp_move_rate
* As in #2886 , the handling of velocity setpoint resetting was corrected to only be performed when the corresponding velocity control is disabled. Similarly the resetting of the alt/position setpoints is only performed when the corresponding position/alt control modes are disabled. This allows offboard to work as expected.
* vel_ff is unused at the moment since now I believe there's no place for it. But I may be wrong.

# Possible improvements

1. Initially I wanted to implement (as suggested in a TODO comment) separate X,Y hold. This is non trivial since PID controllers work in NED frame. Thus, even while moving "forward" this translates to both _vel_sp(0) and _vel_sp(1) values, depending on yaw direction. I guess it could be done, by updating the axis to be held based on current yaw, but to me it doesn't warrant such work. If the user is commanding the copter in XY, it is better to let him feel in control of all axis.
2. The current code base would also allow for offboard mode to follow horizontal velocity setpoints while maintaining altitude. To achieve this, in commander.cpp, a simple modification could be done to allow these combinations. I'm interested in this position. Let me know if you are also and I can try it and make a PR.

# Testing status

I've tested this under SITL, both in manual and offboard modes. I have trouble getting good PID values for jmavsim, but the response is as expected. I will port this now to stable on my fork, to be able to use it on my quad. However, testing on master would also be nice if someone wants to do it.

UPDATE: I have ported this to stable branch and tested in manual mode. I have it set to maintain vertical position and follow horizontal velocity. This greatly helps in tuning the vel. PIDs. I will test offboard mode on the real quad soon.