### PR TITLE
Make sure the generic fixed wing types AERT/AETR can arm the ESC.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/2101_fw_AERT
+++ b/ROMFS/px4fmu_common/init.d/2101_fw_AERT
@@ -20,3 +20,7 @@
 sh /etc/init.d/rc.fw_defaults
 
 set MIXER AERT
+
+# The ESC requires a specific pulse to arm.
+set PWM_OUT 4
+set PWM_DISARMED p:PWM_DISARMED

--- a/ROMFS/px4fmu_common/init.d/2104_fw_AETR
+++ b/ROMFS/px4fmu_common/init.d/2104_fw_AETR
@@ -20,3 +20,7 @@
 sh /etc/init.d/rc.fw_defaults
 
 set MIXER AETR
+
+# The ESC requires a specific pulse to arm.
+set PWM_OUT 3
+set PWM_DISARMED p:PWM_DISARMED


### PR DESCRIPTION
Taking the pulse value from the PWM_DISARMED parameter as there are generic configs. Without this the ESC won't arm when using these configs.