### PR TITLE
make romfs pruner script windows compatible

### DIFF
--- a/Tools/px_romfs_pruner.py
+++ b/Tools/px_romfs_pruner.py
@@ -76,7 +76,7 @@ def main():
                                                         pruned_content += line
 
                         # overwrite old scratch file
-                        with open(file_path, "w") as f:
+                        with open(file_path, "wb") as f:
                                 f.write(pruned_content)
 
 


### PR DESCRIPTION
When we open the file handle to write back the lines in binary mode, we don't change the line endings but instead leave them as they were before. This is impotant for Windows users as Python on Windows otherwise adds CRLF endings to the parameter files and they can't be correctly parsed by NuttX any more.