### PR TITLE
Check supported extensions for rc.autostart generation

### DIFF
--- a/Tools/px4airframes/srcparser.py
+++ b/Tools/px4airframes/srcparser.py
@@ -151,7 +151,7 @@ class SourceParser(object):
         Returns list of supported file extensions that can be parsed by this
         parser. The parser uses any extension.
         """
-        return [""]
+        return ["", ".hil"]
 
     def Parse(self, path, contents):
         """

--- a/Tools/px4airframes/srcscanner.py
+++ b/Tools/px4airframes/srcscanner.py
@@ -16,9 +16,11 @@ class SourceScanner(object):
         extensions = tuple(parser.GetSupportedExtensions())
         for dirname, dirnames, filenames in os.walk(srcdir):
             for filename in filenames:
-                path = os.path.join(dirname, filename)
-                if not self.ScanFile(path, parser):
-                    return False
+                extension = os.path.splitext(filename)[1]
+                if extension in extensions:
+                    path = os.path.join(dirname, filename)
+                    if not self.ScanFile(path, parser):
+                        return False
         return True
 
     def ScanFile(self, path, parser):


### PR DESCRIPTION
Had an issue after resolving merge conflicts in airframe config files. Git left the `*.orig` files lying around so they ended up in `rc.autostart`. It seemed someone already had the idea of checking the extensions but never got around to do it ;)? Works for "empty" extensions as it is now and should just work once we introduce an extension.