### PR TITLE
Launching UAVCAN driver after the on-board sensors are initialized

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -366,11 +366,6 @@ then
 	fi
 
 	#
-	# UAVCAN
-	#
-	sh /etc/init.d/rc.uavcan
-
-	#
 	# Sensors System (start before Commander so Preflight checks are properly run)
 	#
 	sh /etc/init.d/rc.sensors
@@ -575,6 +570,11 @@ then
 			camera_trigger start
 		fi
 	fi
+
+	#
+	# UAVCAN
+	#
+	sh /etc/init.d/rc.uavcan
 
 	#
 	# Logging


### PR DESCRIPTION
This PR completely reverts a temporary timing fix applied earlier. Even though the UAVCAN initialization delay has already been removed, the UAVCAN driver can still be quick enough to snatch the lowest instance ID values, possibly causing problems with sensor calibration.

With this change, onboard sensors will be consistently allocated on lower instance ID values.