### PR TITLE
cmake trivial fix to allow out of source builds

### DIFF
--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -698,6 +698,7 @@ function(px4_create_git_hash_header)
 		COMMAND git log -n 1 --pretty=format:"%H"
 		OUTPUT_VARIABLE git_desc
 		OUTPUT_STRIP_TRAILING_WHITESPACE
+		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 		)
 	message(STATUS "GIT_DESC = ${git_desc}")
 	set(git_desc_short)


### PR DESCRIPTION
This is needed to uses cmake outside of the source tree which eclipse prefers (eg cmake -G"Eclipse CDT4 - Unix Makefiles").