### PR TITLE
EKF: Move to 1000 Hz sampling / 250 Hz prediction / 62.5 Hz updates, 250 Hz output

### DIFF
--- a/src/modules/ekf_att_pos_estimator/AttitudePositionEstimatorEKF.h
+++ b/src/modules/ekf_att_pos_estimator/AttitudePositionEstimatorEKF.h
@@ -133,6 +133,8 @@ public:
      */
     int set_debuglevel(unsigned debug) { _debug = debug; return 0; }
 
+    static constexpr unsigned MAX_PREDICITION_STEPS = 3; /**< maximum number of prediction steps between updates */
+
 private:
     bool        _task_should_exit;      /**< if true, sensor task should exit */
     bool        _task_running;          /**< if true, task is running in its mainloop */
@@ -174,6 +176,7 @@ private:
 
     hrt_abstime _last_accel;
     hrt_abstime _last_mag;
+    unsigned _prediction_steps;
 
     struct sensor_combined_s            _sensor_combined;
 

--- a/src/modules/ekf_att_pos_estimator/CMakeLists.txt
+++ b/src/modules/ekf_att_pos_estimator/CMakeLists.txt
@@ -42,7 +42,6 @@ px4_add_module(
 	COMPILE_FLAGS ${MODULE_CFLAGS}
 	SRCS
 		ekf_att_pos_estimator_main.cpp
-		ekf_att_pos_estimator_params.c
 		estimator_22states.cpp
 		estimator_utilities.cpp
 	DEPENDS

--- a/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_params.c
+++ b/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_params.c
@@ -36,12 +36,8 @@
  *
  * Parameters defined by the attitude and position estimator task
  *
- * @author Lorenz Meier <lm@inf.ethz.ch>
+ * @author Lorenz Meier <lorenz@px4.io>
  */
-
-#include <px4_config.h>
-
-#include <systemlib/param/param.h>
 
 /*
  * Estimator parameters, accessible via MAVLink


### PR DESCRIPTION
Much more friendly CPU load now.

```
Processes: 22 total, 2 running, 20 sleeping
CPU usage: 42.45% tasks, 0.79% sched, 56.76% idle
Uptime: 6.647s total, 3.029s idle

 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE 
   0 Idle Task                    3028 56.762     0/    0   0 (  0)  READY 
   1 hpwork                        122  2.665   812/ 1792 192 (192)  w:sig 
   2 lpwork                         13  0.296   572/ 1792  50 ( 50)  READY 
   3 init                         1474  0.000  1220/ 2496 100 (100)  w:sem 
   6 nshterm                         0  0.000   756/ 1496  70 ( 70)  w:sem 
 106 commander_low_prio            308  0.000   732/ 2592  50 ( 50)  w:sem 
  80 dataman                        23  0.000   652/ 1496  90 ( 90)  w:sem 
  92 sensors                       225  2.961  1652/ 1992 250 (250)  w:sem 
  94 gps                             9  0.098   700/ 1496 220 (220)  w:sem 
 100 commander                     126  0.394  3036/ 3392 215 (215)  w:sig 
 103 px4io                         171  3.455   932/ 1496 240 (240)  w:sem 
 172 px4flow                         1  0.000   572/ 1192 100 (100)  w:sig 
 109 mavlink_if0                    42  0.888  2076/ 2392 105 (100)  w:sig 
 110 mavlink_rcv_if0                 2  0.000  1084/ 2096 175 (175)  w:sem 
 122 sdlog2                         10  0.197  2068/ 2992  70 ( 70)  w:sig 
 137 fmuservo                        9  0.098   620/  896 100 (100)  w:sem 
 148 ekf_att_pos_estimator         767 27.147  3388/ 4192 235 (235)  w:sem 
 150 fw_att_control                 64  2.171   868/ 1592 250 (250)  w:sem 
 152 fw_pos_control_l1              49  0.394   836/ 1592 250 (250)  w:sem 
 155 land_detector                   7  0.197   548/  992 100 (100)  w:sig 
 159 navigator                      50  1.480   852/ 1496 105 (105)  w:sem 
 175 top                            41  0.000  1204/ 1696 100 (100)  RUN  
```

@AndreasAntener @SimonWilks @tumbili I suspect the high CPU load on arming (when sdlog2 kicked in) made things unstable. With this change the load is as before, without paying any performance hit. Most likely the update rate could still be dropped.