### PR TITLE
Enable hash generation of parameters block

### DIFF
--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -1049,9 +1049,10 @@ uint32_t param_hash_check(void)
 		if (!param_used(param)) {
 			continue;
 		}
+
 		const char *name = param_name(param);
 		const void *val = param_get_value_ptr(param);
-		param_hash = crc32part((const uint8_t*)name, strlen(name), param_hash);
+		param_hash = crc32part((const uint8_t *)name, strlen(name), param_hash);
 		param_hash = crc32part(val, sizeof(union param_value_u), param_hash);
 	}
 

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -65,6 +65,8 @@
 #include "uORB/topics/parameter_update.h"
 #include "px4_parameters.h"
 
+#include <crc32.h>
+
 #if 0
 # define debug(fmt, args...)		do { warnx(fmt, ##args); } while(0)
 #else
@@ -1034,4 +1036,26 @@ param_foreach(void (*func)(void *arg, param_t param), void *arg, bool only_chang
 
 		func(arg, param);
 	}
+}
+
+uint32_t param_hash_check(void)
+{
+	uint32_t param_hash = 0;
+
+	param_lock();
+
+	/* compute the CRC32 over all string param names and 4 byte values */
+	for (param_t param = 0; handle_in_range(param); param++) {
+		if (!param_used(param)) {
+			continue;
+		}
+		const char *name = param_name(param);
+		const void *val = param_get_value_ptr(param);
+		param_hash = crc32part((const uint8_t*)name, strlen(name), param_hash);
+		param_hash = crc32part(val, sizeof(union param_value_u), param_hash);
+	}
+
+	param_unlock();
+
+	return param_hash;
 }

--- a/src/modules/systemlib/param/param.h
+++ b/src/modules/systemlib/param/param.h
@@ -333,6 +333,13 @@ __EXPORT int 		param_save_default(void);
  */
 __EXPORT int 		param_load_default(void);
 
+/**
+ * Generate the hash of all parameters and their values
+ *
+ * @return		CRC32 hash of all param_ids and values
+ */
+__EXPORT uint32_t	param_hash_check(void);
+
 /*
  * Macros creating static parameter definitions.
  *


### PR DESCRIPTION
This branch enables requesting the "magic" parameter _HASH_CHECK which computes the CRC32 of all used parameter names and values. This hash value can be used by the GCS software to verify that a locally cached copy of the parameters matches what is currently on the autopilot so that parameter sync over the radio link can be skipped. 

I'm looking for constructive criticism and feedback for this approach, we'll probably undergo a few iterations before we find a solution that everybody is happy with. 

Here is the QGC pull request to enable this feature: https://github.com/mavlink/qgroundcontrol/pull/1965