### PR TITLE
Quick fix for broken master

### DIFF
--- a/src/modules/position_estimator_inav/position_estimator_inav_main.c
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.c
@@ -897,7 +897,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 		}
 
 		float dt = t_prev > 0 ? (t - t_prev) / 1000000.0f : 0.0f;
-		dt = fmaxf(fminf(0.02, dt), 0.002);		// constrain dt from 2 to 20 ms
+		dt = fmaxf(fminf(0.02, dt), 0.0002);		// constrain dt from 0.2 to 20 ms
 		t_prev = t;
 
 		/* increase EPH/EPV on each step */


### PR DESCRIPTION
At least in SITL attitude updated with 1000 Hz and the delta T was constrained to 2ms. This was the reason why the velocity estimation was not working.
TODO: Investigate why attitude updates at 1000Hz.