### PR TITLE
Removed qurt patch for Eigen and updated eigen commit

### DIFF
--- a/cmake/qurt/px4_impl_qurt.cmake
+++ b/cmake/qurt/px4_impl_qurt.cmake
@@ -222,14 +222,7 @@ function(px4_os_prebuild_targets)
 			ONE_VALUE OUT BOARD THREADS
 			REQUIRED OUT BOARD
 			ARGN ${ARGN})
-	add_custom_target(git_eigen_patched
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/lib/eigen
-		COMMAND git checkout .
-		COMMAND git checkout master
-		COMMAND patch -p1 -i ${CMAKE_SOURCE_DIR}/cmake/qurt/qurt_eigen.patch
-		DEPENDS git_eigen)
-	add_custom_target(${OUT} DEPENDS git_dspal git_eigen_patched)
-	add_custom_target(ALL DEPENDS git_eigen_patched)
+	add_custom_target(${OUT} DEPENDS git_dspal git_eigen)
 
 endfunction()
 

--- a/cmake/toolchains/Toolchain-posix-clang-native.cmake
+++ b/cmake/toolchains/Toolchain-posix-clang-native.cmake
@@ -53,6 +53,8 @@ set(C_WARNINGS
 set(C_FLAGS
 	-std=gnu99
 	-fno-common
+	-fsanitize=address
+	-fno-omit-frame-pointer
 	)
 
 #=============================================================================
@@ -67,6 +69,8 @@ set(CXX_FLAGS
 	-fno-rtti
 	-std=gnu++0x
 	-fno-threadsafe-statics
+	-fsanitize=address
+	-fno-omit-frame-pointer
 	-DCONFIG_WCHAR_BUILTIN
 	-D__CUSTOM_FILE_IO__
 	)
@@ -75,6 +79,7 @@ set(CXX_FLAGS
 #		ld flags
 #
 set(LD_FLAGS
+	-fsanitize=address
 	-Wl,--warn-common
 	-Wl,--gc-sections
 	)


### PR DESCRIPTION
The patches for Hexagon support are in the eigen repo so the patch can now be removed.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>