### PR TITLE
Firmware rename for px4io to avoid using board label in name.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -260,11 +260,11 @@ then
 		#
 		# Check if PX4IO present and update firmware if needed
 		#
-		if [ -f /etc/extras/px4io-v2_default.bin ]
+		if [ -f /etc/extras/px4io-v2.bin ]
 		then
-			set IO_FILE /etc/extras/px4io-v2_default.bin
+			set IO_FILE /etc/extras/px4io-v2.bin
 		else
-			set IO_FILE /etc/extras/px4io-v1_default.bin
+			set IO_FILE /etc/extras/px4io-v1.bin
 		fi
 
 		if px4io checkcrc ${IO_FILE}

--- a/ROMFS/px4fmu_test/init.d/rcS
+++ b/ROMFS/px4fmu_test/init.d/rcS
@@ -55,11 +55,11 @@ else
 	echo "[param] FAILED loading $PARAM_FILE"
 fi
 
-if [ -f /etc/extras/px4io-v2_default.bin ]
+if [ -f /etc/extras/px4io-v2.bin ]
 then
-	set io_file /etc/extras/px4io-v2_default.bin
+	set io_file /etc/extras/px4io-v2.bin
 else
-	set io_file /etc/extras/px4io-v1_default.bin
+	set io_file /etc/extras/px4io-v1.bin
 fi
 
 if px4io start

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -3468,12 +3468,12 @@ px4io_main(int argc, char *argv[])
 
 		} else {
 #if defined(CONFIG_ARCH_BOARD_PX4FMU_V1)
-			fn[0] = "/etc/extras/px4io-v1_default.bin";
+			fn[0] = "/etc/extras/px4io-v1.bin";
 			fn[1] =	"/fs/microsd/px4io1.bin";
 			fn[2] =	"/fs/microsd/px4io.bin";
 			fn[3] =	nullptr;
 #elif defined(CONFIG_ARCH_BOARD_PX4FMU_V2)
-			fn[0] = "/etc/extras/px4io-v2_default.bin";
+			fn[0] = "/etc/extras/px4io-v2.bin";
 			fn[1] =	"/fs/microsd/px4io2.bin";
 			fn[2] =	"/fs/microsd/px4io.bin";
 			fn[3] =	nullptr;

--- a/src/firmware/nuttx/CMakeLists.txt
+++ b/src/firmware/nuttx/CMakeLists.txt
@@ -7,7 +7,7 @@ px4_nuttx_generate_builtin_commands(
 
 px4_nuttx_add_romfs(OUT romfs
 	ROOT ROMFS/px4fmu_common
-	EXTRAS ${CMAKE_BINARY_DIR}/src/modules/px4iofirmware/${config_io_board}_${LABEL}.bin
+	EXTRAS ${CMAKE_BINARY_DIR}/src/modules/px4iofirmware/${config_io_board}.bin
 	)
 
 add_dependencies(romfs fw_io)
@@ -81,21 +81,21 @@ if(NOT ${BOARD} STREQUAL "sim")
 
 	add_custom_target(debug_io
 		COMMAND ${GDB}
-			${CMAKE_BINARY_DIR}/src/modules/px4iofirmware/${config_io_board}_${LABEL}
+			${CMAKE_BINARY_DIR}/src/modules/px4iofirmware/${config_io_board}
 		DEPENDS firmware_nuttx
 			${CMAKE_CURRENT_BINARY_DIR}/.gdbinit
 		)
 
 	add_custom_target(debug_io_tui
 		COMMAND ${GDBTUI}
-			${CMAKE_BINARY_DIR}/src/modules/px4iofirmware/${config_io_board}_${LABEL}
+			${CMAKE_BINARY_DIR}/src/modules/px4iofirmware/${config_io_board}
 		DEPENDS firmware_nuttx
 			${CMAKE_CURRENT_BINARY_DIR}/.gdbinit
 		)
 
 	add_custom_target(debug_io_ddd
 		COMMAND ${DDD} --debugger ${GDB}
-			${CMAKE_BINARY_DIR}/src/modules/px4iofirmware/${config_io_board}_${LABEL}
+			${CMAKE_BINARY_DIR}/src/modules/px4iofirmware/${config_io_board}
 		DEPENDS firmware_nuttx
 			${CMAKE_CURRENT_BINARY_DIR}/.gdbinit
 		)

--- a/src/modules/px4iofirmware/CMakeLists.txt
+++ b/src/modules/px4iofirmware/CMakeLists.txt
@@ -103,7 +103,7 @@ elseif(${config_io_board} STREQUAL "px4io-v2")
 		)
 endif()
 
-set(fw_io_name ${config_io_board}_${LABEL})
+set(fw_io_name ${config_io_board})
 
 add_executable(${fw_io_name}
 	${srcs})


### PR DESCRIPTION
This allows us to build multiple configs with different labels without the label for the px4io firmware changing. Which confuses the init script.