### PR TITLE
qurt: Change to Hexagon 7.2.10 compiler

### DIFF
--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -492,7 +492,6 @@ function(px4_add_common_flags)
 		-Wpointer-arith
 		-Wmissing-declarations
 		-Wno-unused-parameter
-		-Wno-varargs
 		-Werror=format-security
 		-Werror=array-bounds
 		-Wfatal-errors
@@ -517,6 +516,7 @@ function(px4_add_common_flags)
 		if (NOT ${OS} STREQUAL "qurt")
 			list(APPEND warnings
 				-Wno-unused-const-variable
+				-Wno-varargs
 			)
 		endif()
 	else()

--- a/cmake/configs/qurt_eagle_hello.cmake
+++ b/cmake/configs/qurt_eagle_hello.cmake
@@ -1,6 +1,6 @@
 include(qurt/px4_impl_qurt)
 
-set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/cmake/toolchains/Toolchain-hexagon-7.4.cmake)
+set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/cmake/toolchains/Toolchain-hexagon-7.2.10.cmake)
 
 set(config_module_list
 	drivers/device

--- a/cmake/configs/qurt_eagle_hil.cmake
+++ b/cmake/configs/qurt_eagle_hil.cmake
@@ -1,6 +1,6 @@
 include(qurt/px4_impl_qurt)
 
-set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/cmake/toolchains/Toolchain-hexagon-7.4.cmake)
+set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/cmake/toolchains/Toolchain-hexagon-7.2.10.cmake)
 
 set(config_module_list
 	drivers/device

--- a/cmake/configs/qurt_eagle_muorb.cmake
+++ b/cmake/configs/qurt_eagle_muorb.cmake
@@ -1,6 +1,6 @@
 include(qurt/px4_impl_qurt)
 
-set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/cmake/toolchains/Toolchain-hexagon-7.4.cmake)
+set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/cmake/toolchains/Toolchain-hexagon-7.2.10.cmake)
 
 set(config_module_list
 	drivers/device

--- a/cmake/configs/qurt_eagle_release.cmake
+++ b/cmake/configs/qurt_eagle_release.cmake
@@ -20,7 +20,7 @@ set(target_libraries
 	)
 
 
-set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/cmake/toolchains/Toolchain-hexagon-7.4.cmake)
+set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/cmake/toolchains/Toolchain-hexagon-7.2.10.cmake)
 
 set(config_module_list
 	#

--- a/cmake/configs/qurt_eagle_test.cmake
+++ b/cmake/configs/qurt_eagle_test.cmake
@@ -1,6 +1,6 @@
 include(qurt/px4_impl_qurt)
 
-set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/cmake/toolchains/Toolchain-hexagon-7.4.cmake)
+set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/cmake/toolchains/Toolchain-hexagon-7.2.10.cmake)
 
 set(config_module_list
 	drivers/device

--- a/cmake/configs/qurt_eagle_travis.cmake
+++ b/cmake/configs/qurt_eagle_travis.cmake
@@ -3,7 +3,7 @@ include(qurt/px4_impl_qurt)
 # Run a full link with build stubs to make sure qurt target isn't broken
 set(QURT_ENABLE_STUBS "1")
 
-set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/cmake/toolchains/Toolchain-hexagon-7.4.cmake)
+set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/cmake/toolchains/Toolchain-hexagon-7.2.10.cmake)
 
 set(config_module_list
 	drivers/device

--- a/cmake/toolchains/Toolchain-hexagon-7.2.10.cmake
+++ b/cmake/toolchains/Toolchain-hexagon-7.2.10.cmake
@@ -35,7 +35,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 include(common/px4_base)
 
 if(NOT HEXAGON_TOOLS_ROOT)
-	set(HEXAGON_TOOLS_ROOT /opt/7.4/Tools)
+	set(HEXAGON_TOOLS_ROOT /opt/HEXAGON_Tools/7.2.10/Tools)
 endif()
 
 macro (list2string out in)
@@ -53,7 +53,7 @@ set(HEXAGON_LIB_DIR ${HEXAGON_TOOLS_ROOT}/gnu/hexagon/lib)
 set(HEXAGON_ISS_DIR ${HEXAGON_TOOLS_ROOT}/lib/iss)
 set(TOOLSLIB ${HEXAGON_TOOLS_ROOT}/target/hexagon/lib/${V_ARCH}/G0)
 
-# Use the HexagonTools compiler (6.4.05)
+# Use the HexagonTools compiler (7.2.10)
 set(CMAKE_C_COMPILER	${HEXAGON_BIN}/${CROSSDEV}clang)
 set(CMAKE_CXX_COMPILER  ${HEXAGON_BIN}/${CROSSDEV}clang++)
 
@@ -82,6 +82,7 @@ set(ARCHCPUFLAGS
 add_definitions(
 	-D_PID_T -D_UID_T -D_TIMER_T
 	-Dnoreturn_function= 
+	-D_HAS_C9X
 	-D__EXPORT= 
 	-Drestrict=
 	-D_DEBUG

--- a/src/platforms/px4_defines.h
+++ b/src/platforms/px4_defines.h
@@ -224,8 +224,6 @@ __END_DECLS
 
 #endif
 
-#if defined(__PX4_QURT)
-
 #define PX4_ROOTFSDIR
 #define DEFAULT_PARAM_FILE "/fs/eeprom/parameters"
 
@@ -233,16 +231,6 @@ __END_DECLS
 
 // Missing math.h defines
 #define PX4_ISFINITE(x) __builtin_isfinite(x)
-
-// FIXME - these are missing for clang++ but not for clang
-#if defined(__cplusplus)
-#define isfinite(x) true
-#define isnan(x) false
-#define isinf(x) false
-#define fminf(x, y) ((x) > (y) ? y : x)
-#endif
-
-#endif
 
 /*
  *Defines for all platforms

--- a/src/platforms/px4_defines.h
+++ b/src/platforms/px4_defines.h
@@ -224,6 +224,8 @@ __END_DECLS
 
 #endif
 
+#if defined(__PX4_QURT)
+
 #define PX4_ROOTFSDIR
 #define DEFAULT_PARAM_FILE "/fs/eeprom/parameters"
 
@@ -231,6 +233,8 @@ __END_DECLS
 
 // Missing math.h defines
 #define PX4_ISFINITE(x) __builtin_isfinite(x)
+
+#endif
 
 /*
  *Defines for all platforms


### PR DESCRIPTION
Switched to 7.2.10 since the Linux version of this is available.

Added -DHAS_C9X flag to fix isses with undefined math functions
when using hexagon-clang++.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>