### PR TITLE
Hexagon vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,11 +33,14 @@ Vagrant.configure(2) do |config|
   # your network.
   # config.vm.network "public_network"
 
+  # Virtualbox requires a private network to use NFS
+  config.vm.network "private_network", type: "dhcp"
+
   # Share an additional folder to the guest VM. The first argument is
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder ".", "/Firmware"
+  config.vm.synced_folder ".", "/Firmware", type: "nfs"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -85,6 +85,8 @@ Vagrant.configure(2) do |config|
     tar -jxf gcc-arm-none-eabi-4_8-2014q3-20140805-linux.tar.bz2
     exportline="export PATH=$HOME/gcc-arm-none-eabi-4_8-2014q3/bin:\$PATH"
     if grep -Fxq "$exportline" ~/.profile; then echo nothing to do ; else echo $exportline >> ~/.profile; fi
+    exportline2="export HEXAGON_TOOLS_ROOT=$HOME/Qualcomm/HEXAGON_Tools/7.2.10/Tools"
+    if grep -Fxq "$exportline2" ~/.profile; then echo nothing to do ; else echo $exportline2 >> ~/.profile; fi
     . ~/.profile
     popd
     # setup ccache

--- a/cmake/toolchains/Toolchain-hexagon-7.2.10.cmake
+++ b/cmake/toolchains/Toolchain-hexagon-7.2.10.cmake
@@ -34,8 +34,12 @@ include(CMakeForceCompiler)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 include(common/px4_base)
 
-if(NOT HEXAGON_TOOLS_ROOT)
-	set(HEXAGON_TOOLS_ROOT $ENV{HOME}/Qualcomm/HEXAGON_Tools/7.2.10/Tools)
+if ("$ENV{HEXAGON_TOOLS_ROOT}" STREQUAL "")
+	message(FATAL_ERROR
+		"The HexagonTools version 7.2.10 must be installed and the environment variable HEXAGON_TOOLS_ROOT must be set"
+		"(e.g. export HEXAGON_TOOLS_ROOT=/opt/HEXAGON_Tools/7.2.10/Tools)")
+else()
+	set(HEXAGON_TOOLS_ROOT $ENV{HEXAGON_TOOLS_ROOT})
 endif()
 
 macro (list2string out in)
@@ -239,3 +243,12 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 # for libraries and headers in the target directories
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# The Hexagon compiler doesn't support the -rdynamic flag and this is set
+# in the base cmake scripts. We have to redefine the __linux_compiler_gnu
+# macro for cmake 2.8 to work
+set(__LINUX_COMPILER_GNU 1)
+macro(__linux_compiler_gnu lang)
+  set(CMAKE_SHARED_LIBRARY_LINK_${lang}_FLAGS "")
+endmacro()
+


### PR DESCRIPTION
Fixes to support cmake 2.8 (used by vagrant image) and provide the environment variable in the vagrant provisioning for the HexagonTools.

This will allow the HexagonTools to be installed in the vagrant image using the installer defaults.

The default file sharing mechanism breaks when mmap is used for files in the shared folder. Using NFS for shared folders resolves this issue and works out of the box for MacOS.

On Ubuntu: sudo apt-get install nfs-kernel-server