### PR TITLE
Automatic CAN node upgrading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ before_script:
   - mkdir -p ~/bin
   - ln -s /usr/bin/ccache ~/bin/arm-none-eabi-g++
   - ln -s /usr/bin/ccache ~/bin/arm-none-eabi-gcc
+  - ln -s /usr/bin/ccache ~/bin/arm-none-eabi-size
   - ln -s /usr/bin/ccache ~/bin/clang++
   - ln -s /usr/bin/ccache ~/bin/clang++-3.4
   - ln -s /usr/bin/ccache ~/bin/clang++-3.5
@@ -96,10 +97,7 @@ script:
   - make check_format
   - arm-none-eabi-gcc --version
   - echo 'Building POSIX Firmware..' && make posix_sitl_simple
-  - echo 'Running Tests..' && make posix_sitl_simple test && cat build_posix_sitl_simple/src/modules/systemlib/mixer/mixer_multirotor.generated.h
-  - echo 'Building NuttX px4fmu-v1 Firmware..' && make px4fmu-v1_default
-  - echo 'Building NuttX px4fmu-v2 Firmware..' && make px4fmu-v2_default
-  - echo 'Running Tests..' && make px4fmu-v2_default test
+  - echo 'Running Tests..' && make posix_sitl_simple test
   - echo 'Building UAVCAN node firmware..' && git clone https://github.com/thiemar/vectorcontrol
   - cd vectorcontrol
   - BOARD=s2740vc_1_0 make && BOARD=px4esc_1_6 make
@@ -108,6 +106,9 @@ script:
   - mkdir -p ROMFS/px4fmu_common/uavcan/fw/org.pixhawk.px4esc-v1/1.0/
   - cp vectorcontrol/firmware/com.thiemar.s2740vc-v1-1.0.00000000.uavcan.bin ROMFS/px4fmu_common/uavcan/fw/com.thiemar.s2740vc-v1/1.0/00000000.uavcan.bin
   - cp vectorcontrol/firmware/org.pixhawk.px4esc-v1-1.0.00000000.uavcan.bin ROMFS/px4fmu_common/uavcan/fw/org.pixhawk.px4esc-v1/1.0/00000000.uavcan.bin
+  - echo 'Building NuttX px4fmu-v1 Firmware..' && make px4fmu-v1_default
+  - echo 'Building NuttX px4fmu-v2 Firmware..' && make px4fmu-v2_default
+  - echo 'Running Tests..' && make px4fmu-v2_default test
 
 after_success:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,14 @@ script:
   - echo 'Building NuttX px4fmu-v1 Firmware..' && make px4fmu-v1_default
   - echo 'Building NuttX px4fmu-v2 Firmware..' && make px4fmu-v2_default
   - echo 'Running Tests..' && make px4fmu-v2_default test
+  - echo 'Building UAVCAN node firmware..' && git clone https://github.com/thiemar/vectorcontrol
+  - cd vectorcontrol
+  - BOARD=s2740vc_1_0 make && BOARD=px4esc_1_6 make
+  - cd ..
+  - mkdir -p ROMFS/px4fmu_common/uavcan/fw/com.thiemar.s2740vc-v1/1.0/
+  - mkdir -p ROMFS/px4fmu_common/uavcan/fw/org.pixhawk.px4esc-v1/1.0/
+  - cp vectorcontrol/firmware/com.thiemar.s2740vc-v1-1.0.00000000.uavcan.bin ROMFS/px4fmu_common/uavcan/fw/com.thiemar.s2740vc-v1/1.0/00000000.uavcan.bin
+  - cp vectorcontrol/firmware/org.pixhawk.px4esc-v1-1.0.00000000.uavcan.bin ROMFS/px4fmu_common/uavcan/fw/org.pixhawk.px4esc-v1/1.0/00000000.uavcan.bin
 
 after_success:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,8 +105,8 @@ script:
   - cd ..
   - mkdir -p ROMFS/px4fmu_common/uavcan/fw/com.thiemar.s2740vc-v1/1.0/
   - mkdir -p ROMFS/px4fmu_common/uavcan/fw/org.pixhawk.px4esc-v1/1.0/
-  - cp vectorcontrol/firmware/com.thiemar.s2740vc-v1-1.0.00000000.uavcan.bin ROMFS/px4fmu_common/uavcan/fw/com.thiemar.s2740vc-v1/1.0/00000000.uavcan.bin
-  - cp vectorcontrol/firmware/org.pixhawk.px4esc-v1-1.0.00000000.uavcan.bin ROMFS/px4fmu_common/uavcan/fw/org.pixhawk.px4esc-v1/1.0/00000000.uavcan.bin
+  - cp vectorcontrol/firmware/com.thiemar.s2740vc-v1-1.0.00000000.uavcan.bin ROMFS/px4fmu_common/uavcan/fw/com.thiemar.s2740vc-v1/1.0/00000000.bin
+  - cp vectorcontrol/firmware/org.pixhawk.px4esc-v1-1.0.00000000.uavcan.bin ROMFS/px4fmu_common/uavcan/fw/org.pixhawk.px4esc-v1/1.0/00000000.bin
   - echo 'Building NuttX px4fmu-v1 Firmware..' && make px4fmu-v1_default
   - echo 'Building NuttX px4fmu-v2 Firmware..' && make px4fmu-v2_default
   - echo 'Running Tests..' && make px4fmu-v2_default test

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ before_script:
   - ln -s /usr/bin/ccache ~/bin/arm-none-eabi-g++
   - ln -s /usr/bin/ccache ~/bin/arm-none-eabi-gcc
   - ln -s /usr/bin/ccache ~/bin/arm-none-eabi-size
+  - ln -s /usr/bin/ccache ~/bin/arm-none-eabi-objcopy
   - ln -s /usr/bin/ccache ~/bin/clang++
   - ln -s /usr/bin/ccache ~/bin/clang++-3.4
   - ln -s /usr/bin/ccache ~/bin/clang++-3.5

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -37,7 +37,7 @@ set(config_module_list
 	drivers/meas_airspeed
 	drivers/frsky_telemetry
 	modules/sensors
-	drivers/mkblctrl
+	#drivers/mkblctrl
 	drivers/px4flow
 	drivers/oreoled
 	drivers/gimbal
@@ -54,7 +54,7 @@ set(config_module_list
 	systemcmds/pwm
 	systemcmds/esc_calib
 	systemcmds/reboot
-	systemcmds/topic_listener
+	#systemcmds/topic_listener
 	systemcmds/top
 	systemcmds/config
 	systemcmds/nshterm


### PR DESCRIPTION
@bendyer This builds vectorcontrol master and embeds the ESC binaries. This is a stopgap for UAVCAN users. I will also enable the UAVCAN FW server by default, which should then allow all ESCs which come pre-flashed with the boot loader to just work.