### PR TITLE
Logging rate was limited to 1 Hz

### DIFF
--- a/src/modules/sdlog2/params.c
+++ b/src/modules/sdlog2/params.c
@@ -43,7 +43,7 @@
  * commonly is before arming).
  *
  * @min -1
- * @max  1
+ * @max  100
  * @group SD Logging
  */
 PARAM_DEFINE_INT32(SDLOG_RATE, -1);


### PR DESCRIPTION
I set the maximum to 100 Hz, since most SD cards are not fast enough for more. (but more is still possible with forcing)