### PR TITLE
reduce PID rollrate P and D in QAV250 config

### DIFF
--- a/ROMFS/px4fmu_common/init.d/4009_qav250
+++ b/ROMFS/px4fmu_common/init.d/4009_qav250
@@ -16,9 +16,9 @@ sh /etc/init.d/4001_quad_x
 if [ $AUTOCNF == yes ]
 then
 	param set MC_ROLL_P 7.0
-	param set MC_ROLLRATE_P 0.08
+	param set MC_ROLLRATE_P 0.05
 	param set MC_ROLLRATE_I 0.05
-	param set MC_ROLLRATE_D 0.003
+	param set MC_ROLLRATE_D 0.002
 	param set MC_PITCH_P 7.0
 	param set MC_PITCHRATE_P 0.08
 	param set MC_PITCHRATE_I 0.1


### PR DESCRIPTION
eliminates roll oscillation at high throttle settings.
THR_MIN values of .06 are low enough to allow some wobble at max descent rate, but acceptable for this platform.

Note that these settings are dependent on both propeller type and flight altitude (in addition to moments of inertia and total mass).