### PR TITLE
Adds valgrind support, started to correct some bugs in SITL

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -83,6 +83,12 @@ then
 elif [ "$debugger" == "gdb" ]
 then
 	gdb --args mainapp ../../../../${rc_script}_${program}
+elif [ "$debugger" == "ddd" ]
+then
+	ddd --debugger gdb --args mainapp ../../../../${rc_script}_${program}
+elif [ "$debugger" == "valgrind" ]
+then
+	valgrind ./mainapp ../../../../${rc_script}_${program}
 else
 	./mainapp ../../../../${rc_script}_${program}
 fi

--- a/src/firmware/posix/CMakeLists.txt
+++ b/src/firmware/posix/CMakeLists.txt
@@ -33,7 +33,7 @@ add_custom_target(run_config
 add_dependencies(run_config mainapp)
 
 foreach(viewer none jmavsim gazebo)
-	foreach(debugger none gdb lldb)
+	foreach(debugger none gdb lldb ddd valgrind)
 		foreach(model none iris vtol)
 			if (debugger STREQUAL "none")
 				if (model STREQUAL "none")

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -1250,7 +1250,7 @@ Sensors::vehicle_control_mode_poll()
 void
 Sensors::parameter_update_poll(bool forced)
 {
-	bool param_updated;
+	bool param_updated=false;
 
 	/* Check if any parameter has changed */
 	orb_check(_params_sub, &param_updated);

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -1250,7 +1250,7 @@ Sensors::vehicle_control_mode_poll()
 void
 Sensors::parameter_update_poll(bool forced)
 {
-	bool param_updated=false;
+	bool param_updated = false;
 
 	/* Check if any parameter has changed */
 	orb_check(_params_sub, &param_updated);

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -463,9 +463,11 @@ void Simulator::pollForMAVLinkMessages(bool publish)
 	char serial_buf[1024];
 
 	struct pollfd fds[2];
+	memset(fds, 0, sizeof(fds));
 	unsigned fd_count = 1;
 	fds[0].fd = _fd;
 	fds[0].events = POLLIN;
+
 
 	if (serial_fd >= 0) {
 		fds[1].fd = serial_fd;

--- a/src/platforms/posix/drivers/adcsim/adcsim.cpp
+++ b/src/platforms/posix/drivers/adcsim/adcsim.cpp
@@ -111,6 +111,7 @@ private:
 
 ADCSIM::ADCSIM(uint32_t channels) :
 	VDev("adcsim", ADCSIM0_DEVICE_PATH),
+	_call(),
 	_sample_perf(perf_alloc(PC_ELAPSED, "adc_samples")),
 	_channel_count(0),
 	_samples(nullptr)

--- a/src/platforms/posix/px4_layer/px4_posix_tasks.cpp
+++ b/src/platforms/posix/px4_layer/px4_posix_tasks.cpp
@@ -81,9 +81,7 @@ typedef struct {
 
 static void *entry_adapter(void *ptr)
 {
-	pthdata_t *data;
-	data = (pthdata_t *) ptr;
-
+	pthdata_t *data = (pthdata_t *) ptr;
 	data->entry(data->argc, data->argv);
 	free(ptr);
 	PX4_DEBUG("Before px4_task_exit");


### PR DESCRIPTION
So far valgrind has helped find a lot of "branch depends on unitialized value" issues. Mostly in our polling for SITL. There are a ton of other unfixed memory errors,  you can run this using:

```bash
make posix_sitl_default jmavsim___valgrind
```