### PR TITLE
reduce ALTCTL Z deadband from 40% to 5%

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -119,7 +119,7 @@ public:
 	int		start();
 
 private:
-	const float alt_ctl_dz = 0.2f;
+	const float alt_ctl_dz = 0.025f;
 
 	bool		_task_should_exit;		/**< if true, task should exit */
 	int		_control_task;			/**< task handle for task */


### PR DESCRIPTION
I like this a lot better for LOS ALTCTL with the QAV250. Will try FPV goggles tomorrow.