### PR TITLE
Modify uORB API to allow cleaner in-app use

### DIFF
--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -473,7 +473,7 @@ void AttitudeEstimatorQ::task_main()
 			_vel_prev_t = 0;
 		}
 
-		// Time from previous iteration
+		/* time from previous iteration */
 		hrt_abstime now = hrt_absolute_time();
 		float dt = (last_time > 0) ? ((now  - last_time) / 1000000.0f) : 0.00001f;
 		last_time = now;
@@ -516,18 +516,15 @@ void AttitudeEstimatorQ::task_main()
 		att.accel_vibration = _voter_accel.get_vibration_factor(hrt_absolute_time());
 		att.mag_vibration = _voter_mag.get_vibration_factor(hrt_absolute_time());
 
-		if (_att_pub == nullptr) {
-			_att_pub = orb_advertise(ORB_ID(vehicle_attitude), &att);
-
-		} else {
-			orb_publish(ORB_ID(vehicle_attitude), _att_pub, &att);
-		}
+		/* the instance count is not used here */
+		int att_inst;
+		orb_publish_auto(ORB_ID(vehicle_attitude), &_att_pub, &att, &att_inst, ORB_PRIO_HIGH);
 
 		struct control_state_s ctrl_state = {};
 
 		ctrl_state.timestamp = sensors.timestamp;
 
-		/* Attitude quaternions for control state */
+		/* attitude quaternions for control state */
 		ctrl_state.q[0] = _q(0);
 
 		ctrl_state.q[1] = _q(1);
@@ -536,20 +533,17 @@ void AttitudeEstimatorQ::task_main()
 
 		ctrl_state.q[3] = _q(3);
 
-		/* Attitude rates for control state */
+		/* attitude rates for control state */
 		ctrl_state.roll_rate = _lp_roll_rate.apply(_rates(0));
 
 		ctrl_state.pitch_rate = _lp_pitch_rate.apply(_rates(1));
 
 		ctrl_state.yaw_rate = _lp_yaw_rate.apply(_rates(2));
 
-		/* Publish to control state topic */
-		if (_ctrl_state_pub == nullptr) {
-			_ctrl_state_pub = orb_advertise(ORB_ID(control_state), &ctrl_state);
-
-		} else {
-			orb_publish(ORB_ID(control_state), _ctrl_state_pub, &ctrl_state);
-		}
+		/* the instance count is not used here */
+		int ctrl_inst;
+		/* publish to control state topic */
+		orb_publish_auto(ORB_ID(control_state), &_ctrl_state_pub, &ctrl_state, &ctrl_inst, ORB_PRIO_HIGH);
 	}
 }
 

--- a/src/modules/uORB/uORB.cpp
+++ b/src/modules/uORB/uORB.cpp
@@ -96,6 +96,44 @@ orb_advert_t orb_advertise_multi(const struct orb_metadata *meta, const void *da
 	return uORB::Manager::get_instance()->orb_advertise_multi(meta, data, instance, priority);
 }
 
+/**
+ * Advertise as the publisher of a topic.
+ *
+ * This performs the initial advertisement of a topic; it creates the topic
+ * node in /obj if required and publishes the initial data.
+ *
+ * Any number of advertisers may publish to a topic; publications are atomic
+ * but co-ordination between publishers is not provided by the ORB.
+ *
+ * @param meta    The uORB metadata (usually from the ORB_ID() macro)
+ *      for the topic.
+ * @param data    A pointer to the initial data to be published.
+ *      For topics updated by interrupt handlers, the advertisement
+ *      must be performed from non-interrupt context.
+ * @param instance  Pointer to an integer which will yield the instance ID (0-based)
+ *      of the publication.
+ * @param priority  The priority of the instance. If a subscriber subscribes multiple
+ *      instances, the priority allows the subscriber to prioritize the best
+ *      data source as long as its available.
+ * @return   ERROR on error, zero on success.
+ *      If the topic in question is not known (due to an
+ *      ORB_DEFINE with no corresponding ORB_DECLARE)
+ *      this function will return -1 and set errno to ENOENT.
+ */
+int orb_publish_auto(const struct orb_metadata *meta, orb_advert_t *handle, const void *data, int *instance,
+		     int priority)
+{
+	if (*handle == nullptr) {
+		*handle = orb_advertise_multi(meta, data, instance, priority);
+
+		if (handle != nullptr) {
+			return 0;
+		}
+
+	} else {
+		return orb_publish(meta, handle, data);
+	}
+}
 
 /**
  * Publish new data to a topic.

--- a/src/modules/uORB/uORB.cpp
+++ b/src/modules/uORB/uORB.cpp
@@ -133,6 +133,8 @@ int orb_publish_auto(const struct orb_metadata *meta, orb_advert_t *handle, cons
 	} else {
 		return orb_publish(meta, handle, data);
 	}
+
+	return -1;
 }
 
 /**

--- a/src/modules/uORB/uORB.h
+++ b/src/modules/uORB/uORB.h
@@ -181,6 +181,29 @@ extern orb_advert_t orb_advertise(const struct orb_metadata *meta, const void *d
 extern orb_advert_t orb_advertise_multi(const struct orb_metadata *meta, const void *data, int *instance,
 					int priority) __EXPORT;
 
+/**
+ * Advertise and publish as the publisher of a topic.
+ *
+ * This performs the initial advertisement of a topic; it creates the topic
+ * node in /obj if required and publishes the initial data.
+ *
+ * Any number of advertisers may publish to a topic; publications are atomic
+ * but co-ordination between publishers is not provided by the ORB.
+ *
+ * @param meta		The uORB metadata (usually from the ORB_ID() macro)
+ *			for the topic.
+ * @param data		A pointer to the initial data to be published.
+ *			For topics updated by interrupt handlers, the advertisement
+ *			must be performed from non-interrupt context.
+ * @param instance	Pointer to an integer which will yield the instance ID (0-based,
+ *			limited by ORB_MULTI_MAX_INSTANCES) of the publication.
+ * @param priority	The priority of the instance. If a subscriber subscribes multiple
+ *			instances, the priority allows the subscriber to prioritize the best
+ *			data source as long as its available.
+ * @return	zero on success, error number on failure
+ */
+extern int orb_publish_auto(const struct orb_metadata *meta, orb_advert_t *handle, const void *data, int *instance,
+			    int priority)
 
 /**
  * Publish new data to a topic.

--- a/src/modules/uORB/uORB.h
+++ b/src/modules/uORB/uORB.h
@@ -203,7 +203,7 @@ extern orb_advert_t orb_advertise_multi(const struct orb_metadata *meta, const v
  * @return	zero on success, error number on failure
  */
 extern int orb_publish_auto(const struct orb_metadata *meta, orb_advert_t *handle, const void *data, int *instance,
-			    int priority)
+			    int priority);
 
 /**
  * Publish new data to a topic.


### PR DESCRIPTION
The goal of this branch is to reduce the number of lines per application, or to express it more generally: We need to get rid of boilerplate.

