### PR TITLE
Set I2C bus frequency on first instantiation of I2C class

### DIFF
--- a/src/drivers/device/i2c_nuttx.cpp
+++ b/src/drivers/device/i2c_nuttx.cpp
@@ -45,7 +45,7 @@
 namespace device
 {
 
-unsigned int I2C::_bus_clocks[3] = { 100000, 100000, 100000 };
+unsigned int I2C::_bus_clocks[3] = { 0, 0, 0 };
 
 I2C::I2C(const char *name,
 	 const char *devname,


### PR DESCRIPTION
Currently the I2C bus frequencies were preset to 100000, and could not
be changed. Now they are now set to 0 and on the first instantiation of
the class they are set to the given frequency. This allows one to use
higher frequencies, e.g. 400000, if the attached device allows.

Note: The frequency can still not be changed after the first I2C
device has been instantiated (as is currently the case).