### PR TITLE
Commander : Effectively track failure reporting and handle hotplug sensors

### DIFF
--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -120,6 +120,8 @@ bool in_transition_mode
 bool condition_battery_voltage_valid
 bool condition_system_in_air_restore		# true if we can restore in mid air
 bool condition_system_sensors_initialized
+bool condition_system_prearm_error_reported	# true if errors have already been reported 
+bool condition_system_hotplug_timeout		# true if the hotplug sensor search is over
 bool condition_system_returned_to_home
 bool condition_auto_mission_available
 bool condition_global_position_valid		# set to true by the commander app if the quality of the position estimate is good enough to use it for navigation
@@ -139,6 +141,7 @@ bool rc_signal_lost_cmd				# true if RC lost mode is commanded
 bool rc_input_blocked				# set if RC input should be ignored temporarily
 uint8 rc_input_mode				# set to 1 to disable the RC input, 2 to enable manual control to RC in mapping.
 
+bool data_link_found_new			# new datalink to GCS found
 bool data_link_lost				# datalink to GCS lost
 bool data_link_lost_cmd				# datalink to GCS lost mode commanded
 uint8 data_link_lost_counter			# counts unique data link lost events

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -114,7 +114,7 @@ int check_calibration(int fd, const char* param_template, int &devid)
 	return !calibration_found;
 }
 
-static bool magnometerCheck(int mavlink_fd, unsigned instance, bool optional, int &device_id)
+static bool magnometerCheck(int mavlink_fd, unsigned instance, bool optional, int &device_id, bool report_fail)
 {
 	bool success = true;
 
@@ -124,7 +124,7 @@ static bool magnometerCheck(int mavlink_fd, unsigned instance, bool optional, in
 
 	if (fd < 0) {
 		if (!optional) {
-			mavlink_and_console_log_critical(mavlink_fd,
+			if(report_fail) mavlink_and_console_log_critical(mavlink_fd,
 							 "PREFLIGHT FAIL: NO MAG SENSOR #%u", instance);
 		}
 
@@ -134,7 +134,7 @@ static bool magnometerCheck(int mavlink_fd, unsigned instance, bool optional, in
 	int ret = check_calibration(fd, "CAL_MAG%u_ID", device_id);
 
 	if (ret) {
-		mavlink_and_console_log_critical(mavlink_fd,
+		if(report_fail) mavlink_and_console_log_critical(mavlink_fd,
 						 "PREFLIGHT FAIL: MAG #%u UNCALIBRATED", instance);
 		success = false;
 		goto out;
@@ -143,7 +143,7 @@ static bool magnometerCheck(int mavlink_fd, unsigned instance, bool optional, in
 	ret = px4_ioctl(fd, MAGIOCSELFTEST, 0);
 
 	if (ret != OK) {
-		mavlink_and_console_log_critical(mavlink_fd,
+		if(report_fail) mavlink_and_console_log_critical(mavlink_fd,
 						 "PREFLIGHT FAIL: MAG #%u SELFTEST FAILED", instance);
 		success = false;
 		goto out;
@@ -154,7 +154,7 @@ out:
 	return success;
 }
 
-static bool accelerometerCheck(int mavlink_fd, unsigned instance, bool optional, bool dynamic, int &device_id)
+static bool accelerometerCheck(int mavlink_fd, unsigned instance, bool optional, bool dynamic, int &device_id, bool report_fail)
 {
 	bool success = true;
 
@@ -164,7 +164,7 @@ static bool accelerometerCheck(int mavlink_fd, unsigned instance, bool optional,
 
 	if (fd < 0) {
 		if (!optional) {
-			mavlink_and_console_log_critical(mavlink_fd,
+			if(report_fail) mavlink_and_console_log_critical(mavlink_fd,
 							 "PREFLIGHT FAIL: NO ACCEL SENSOR #%u", instance);
 		}
 
@@ -174,7 +174,7 @@ static bool accelerometerCheck(int mavlink_fd, unsigned instance, bool optional,
 	int ret = check_calibration(fd, "CAL_ACC%u_ID", device_id);
 
 	if (ret) {
-		mavlink_and_console_log_critical(mavlink_fd,
+		if(report_fail) mavlink_and_console_log_critical(mavlink_fd,
 						 "PREFLIGHT FAIL: ACCEL #%u UNCALIBRATED", instance);
 		success = false;
 		goto out;
@@ -183,7 +183,7 @@ static bool accelerometerCheck(int mavlink_fd, unsigned instance, bool optional,
 	ret = px4_ioctl(fd, ACCELIOCSELFTEST, 0);
 
 	if (ret != OK) {
-		mavlink_and_console_log_critical(mavlink_fd,
+		if(report_fail) mavlink_and_console_log_critical(mavlink_fd,
 						 "PREFLIGHT FAIL: ACCEL #%u SELFTEST FAILED", instance);
 		success = false;
 		goto out;
@@ -200,13 +200,13 @@ static bool accelerometerCheck(int mavlink_fd, unsigned instance, bool optional,
 			float accel_magnitude = sqrtf(acc.x * acc.x + acc.y * acc.y + acc.z * acc.z);
 
 			if (accel_magnitude < 4.0f || accel_magnitude > 15.0f /* m/s^2 */) {
-				mavlink_and_console_log_critical(mavlink_fd, "PREFLIGHT FAIL: ACCEL RANGE, hold still on arming");
+				if(report_fail) mavlink_and_console_log_critical(mavlink_fd, "PREFLIGHT FAIL: ACCEL RANGE, hold still on arming");
 				/* this is frickin' fatal */
 				success = false;
 				goto out;
 			}
 		} else {
-			mavlink_log_critical(mavlink_fd, "PREFLIGHT FAIL: ACCEL READ");
+			if(report_fail) mavlink_log_critical(mavlink_fd, "PREFLIGHT FAIL: ACCEL READ");
 			/* this is frickin' fatal */
 			success = false;
 			goto out;
@@ -219,7 +219,7 @@ out:
 	return success;
 }
 
-static bool gyroCheck(int mavlink_fd, unsigned instance, bool optional, int &device_id)
+static bool gyroCheck(int mavlink_fd, unsigned instance, bool optional, int &device_id, bool report_fail)
 {
 	bool success = true;
 
@@ -229,7 +229,7 @@ static bool gyroCheck(int mavlink_fd, unsigned instance, bool optional, int &dev
 
 	if (fd < 0) {
 		if (!optional) {
-			mavlink_and_console_log_critical(mavlink_fd,
+			if(report_fail) mavlink_and_console_log_critical(mavlink_fd,
 							 "PREFLIGHT FAIL: NO GYRO SENSOR #%u", instance);
 		}
 
@@ -239,7 +239,7 @@ static bool gyroCheck(int mavlink_fd, unsigned instance, bool optional, int &dev
 	int ret = check_calibration(fd, "CAL_GYRO%u_ID", device_id);
 
 	if (ret) {
-		mavlink_and_console_log_critical(mavlink_fd,
+		if(report_fail) mavlink_and_console_log_critical(mavlink_fd,
 						 "PREFLIGHT FAIL: GYRO #%u UNCALIBRATED", instance);
 		success = false;
 		goto out;
@@ -248,7 +248,7 @@ static bool gyroCheck(int mavlink_fd, unsigned instance, bool optional, int &dev
 	ret = px4_ioctl(fd, GYROIOCSELFTEST, 0);
 
 	if (ret != OK) {
-		mavlink_and_console_log_critical(mavlink_fd,
+		if(report_fail) mavlink_and_console_log_critical(mavlink_fd,
 						 "PREFLIGHT FAIL: GYRO #%u SELFTEST FAILED", instance);
 		success = false;
 		goto out;
@@ -259,7 +259,7 @@ out:
 	return success;
 }
 
-static bool baroCheck(int mavlink_fd, unsigned instance, bool optional, int &device_id)
+static bool baroCheck(int mavlink_fd, unsigned instance, bool optional, int &device_id, bool report_fail)
 {
 	bool success = true;
 
@@ -269,7 +269,7 @@ static bool baroCheck(int mavlink_fd, unsigned instance, bool optional, int &dev
 
 	if (fd < 0) {
 		if (!optional) {
-			mavlink_and_console_log_critical(mavlink_fd,
+			if(report_fail) mavlink_and_console_log_critical(mavlink_fd,
 							 "PREFLIGHT FAIL: NO BARO SENSOR #%u", instance);
 		}
 
@@ -294,7 +294,7 @@ static bool baroCheck(int mavlink_fd, unsigned instance, bool optional, int &dev
 	return success;
 }
 
-static bool airspeedCheck(int mavlink_fd, bool optional)
+static bool airspeedCheck(int mavlink_fd, bool optional, bool report_fail)
 {
 	bool success = true;
 	int ret;
@@ -304,13 +304,13 @@ static bool airspeedCheck(int mavlink_fd, bool optional)
 
 	if ((ret = orb_copy(ORB_ID(airspeed), fd, &airspeed)) ||
 	    (hrt_elapsed_time(&airspeed.timestamp) > (500 * 1000))) {
-		mavlink_and_console_log_critical(mavlink_fd, "PREFLIGHT FAIL: AIRSPEED SENSOR MISSING");
+		if(report_fail) mavlink_and_console_log_critical(mavlink_fd, "PREFLIGHT FAIL: AIRSPEED SENSOR MISSING");
 		success = false;
 		goto out;
 	}
 
 	if (fabsf(airspeed.indicated_airspeed_m_s) > 6.0f) {
-		mavlink_and_console_log_critical(mavlink_fd, "AIRSPEED WARNING: WIND OR CALIBRATION ISSUE");
+		if(report_fail) mavlink_and_console_log_critical(mavlink_fd, "AIRSPEED WARNING: WIND OR CALIBRATION ISSUE");
 		// XXX do not make this fatal yet
 	}
 
@@ -319,7 +319,7 @@ out:
 	return success;
 }
 
-static bool gnssCheck(int mavlink_fd)
+static bool gnssCheck(int mavlink_fd, bool report_fail)
 {
 	bool success = true;
 
@@ -342,7 +342,7 @@ static bool gnssCheck(int mavlink_fd)
 
 	//Report failure to detect module
 	if(!success) {
-		mavlink_and_console_log_critical(mavlink_fd, "PREFLIGHT FAIL: GPS RECEIVER MISSING");
+		if(report_fail) mavlink_and_console_log_critical(mavlink_fd, "PREFLIGHT FAIL: GPS RECEIVER MISSING");
 	}
 
 	px4_close(gpsSub);
@@ -350,7 +350,7 @@ static bool gnssCheck(int mavlink_fd)
 }
 
 bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro,
-		    bool checkBaro, bool checkAirspeed, bool checkRC, bool checkGNSS, bool checkDynamic)
+		    bool checkBaro, bool checkAirspeed, bool checkRC, bool checkGNSS, bool checkDynamic, bool reportFailures)
 {
 	bool failed = false;
 
@@ -365,7 +365,7 @@ bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro
 			bool required = (i < max_mandatory_mag_count);
 			int device_id = -1;
 
-			if (!magnometerCheck(mavlink_fd, i, !required, device_id) && required) {
+			if (!magnometerCheck(mavlink_fd, i, !required, device_id, reportFailures) && required) {
 				failed = true;
 			}
 
@@ -376,7 +376,7 @@ bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro
 
 		/* check if the primary device is present */
 		if (!prime_found && prime_id != 0) {
-			mavlink_log_critical(mavlink_fd, "warning: primary compass not operational");
+			if(reportFailures) mavlink_log_critical(mavlink_fd, "Warning: Primary compass not found");
 			failed = true;
 		}
 	}
@@ -392,7 +392,7 @@ bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro
 			bool required = (i < max_mandatory_accel_count);
 			int device_id = -1;
 
-			if (!accelerometerCheck(mavlink_fd, i, !required, checkDynamic, device_id) && required) {
+			if (!accelerometerCheck(mavlink_fd, i, !required, checkDynamic, device_id, reportFailures) && required) {
 				failed = true;
 			}
 
@@ -403,7 +403,7 @@ bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro
 
 		/* check if the primary device is present */
 		if (!prime_found && prime_id != 0) {
-			mavlink_log_critical(mavlink_fd, "warning: primary accelerometer not operational");
+			if(reportFailures) mavlink_log_critical(mavlink_fd, "Warning: Primary accelerometer not found");
 			failed = true;
 		}
 	}
@@ -419,7 +419,7 @@ bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro
 			bool required = (i < max_mandatory_gyro_count);
 			int device_id = -1;
 
-			if (!gyroCheck(mavlink_fd, i, !required, device_id) && required) {
+			if (!gyroCheck(mavlink_fd, i, !required, device_id, reportFailures) && required) {
 				failed = true;
 			}
 
@@ -430,7 +430,7 @@ bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro
 
 		/* check if the primary device is present */
 		if (!prime_found && prime_id != 0) {
-			mavlink_log_critical(mavlink_fd, "warning: primary gyro not operational");
+			if(reportFailures) mavlink_log_critical(mavlink_fd, "Warning: Primary gyro not found");
 			failed = true;
 		}
 	}
@@ -446,7 +446,7 @@ bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro
 			bool required = (i < max_mandatory_baro_count);
 			int device_id = -1;
 
-			if (!baroCheck(mavlink_fd, i, !required, device_id) && required) {
+			if (!baroCheck(mavlink_fd, i, !required, device_id, reportFailures) && required) {
 				failed = true;
 			}
 
@@ -458,29 +458,29 @@ bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro
 		// TODO there is no logic in place to calibrate the primary baro yet
 		// // check if the primary device is present 
 		if (!prime_found && prime_id != 0) {
-			mavlink_log_critical(mavlink_fd, "warning: primary barometer not operational");
+			if(reportFailures) mavlink_log_critical(mavlink_fd, "warning: primary barometer not operational");
 			failed = true;
 		}
 	}
 
 	/* ---- AIRSPEED ---- */
 	if (checkAirspeed) {
-		if (!airspeedCheck(mavlink_fd, true)) {
+		if (!airspeedCheck(mavlink_fd, true, reportFailures)) {
 			failed = true;
 		}
 	}
 
 	/* ---- RC CALIBRATION ---- */
 	if (checkRC) {
-		if (rc_calibration_check(mavlink_fd) != OK) {
-			mavlink_log_critical(mavlink_fd, "RC calibration check failed");
+		if (rc_calibration_check(mavlink_fd, reportFailures) != OK) {
+			if(reportFailures) mavlink_log_critical(mavlink_fd, "RC calibration check failed");
 			failed = true;
 		}
 	}
 
 	/* ---- Global Navigation Satellite System receiver ---- */
 	if (checkGNSS) {
-		if(!gnssCheck(mavlink_fd)) {
+		if(!gnssCheck(mavlink_fd, reportFailures)) {
 			failed = true;
 		}
 	}

--- a/src/modules/commander/PreflightCheck.h
+++ b/src/modules/commander/PreflightCheck.h
@@ -67,7 +67,7 @@ namespace Commander
 *   true if the GNSS receiver should be checked
 **/
 bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc,
-    bool checkGyro, bool checkBaro, bool checkAirspeed, bool checkRC, bool checkGNSS, bool checkDynamic = false);
+    bool checkGyro, bool checkBaro, bool checkAirspeed, bool checkRC, bool checkGNSS, bool checkDynamic, bool reportFailures = false);
 
 const unsigned max_mandatory_gyro_count = 1;
 const unsigned max_optional_gyro_count = 3;

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -65,6 +65,6 @@ transition_result_t hil_state_transition(hil_state_t new_state, orb_advert_t sta
 
 bool set_nav_state(struct vehicle_status_s *status, const bool data_link_loss_enabled, const bool mission_finished, const bool stay_in_failsafe);
 
-int prearm_check(const struct vehicle_status_s *status, const int mavlink_fd);
+int preflight_check(const struct vehicle_status_s *status, const int mavlink_fd, bool prearm);
 
 #endif /* STATE_MACHINE_HELPER_H_ */

--- a/src/modules/systemlib/rc_check.c
+++ b/src/modules/systemlib/rc_check.c
@@ -52,7 +52,7 @@
 
 #define RC_INPUT_MAP_UNMAPPED 0
 
-int rc_calibration_check(int mavlink_fd)
+int rc_calibration_check(int mavlink_fd, bool report_fail)
 {
 
 	char nbuf[20];
@@ -74,7 +74,8 @@ int rc_calibration_check(int mavlink_fd)
 		param_t map_parm = param_find(rc_map_mandatory[j]);
 
 		if (map_parm == PARAM_INVALID) {
-			mavlink_log_critical(mavlink_fd, "RC ERR: PARAM %s MISSING", rc_map_mandatory[j]);
+			if (report_fail) { mavlink_log_critical(mavlink_fd, "RC ERR: PARAM %s MISSING", rc_map_mandatory[j]); }
+
 			/* give system time to flush error message in case there are more */
 			usleep(100000);
 			map_fail_count++;
@@ -86,14 +87,16 @@ int rc_calibration_check(int mavlink_fd)
 		param_get(map_parm, &mapping);
 
 		if (mapping > RC_INPUT_MAX_CHANNELS) {
-			mavlink_log_critical(mavlink_fd, "RC ERR: %s >= # CHANS", rc_map_mandatory[j]);
+			if (report_fail) { mavlink_log_critical(mavlink_fd, "RC ERR: %s >= # CHANS", rc_map_mandatory[j]); }
+
 			/* give system time to flush error message in case there are more */
 			usleep(100000);
 			map_fail_count++;
 		}
 
 		if (mapping == 0) {
-			mavlink_log_critical(mavlink_fd, "RC ERR: Mandatory %s is unmapped", rc_map_mandatory[j]);
+			if (report_fail) { mavlink_log_critical(mavlink_fd, "RC ERR: Mandatory %s is unmapped", rc_map_mandatory[j]); }
+
 			/* give system time to flush error message in case there are more */
 			usleep(100000);
 			map_fail_count++;
@@ -144,35 +147,44 @@ int rc_calibration_check(int mavlink_fd)
 		/* assert min..center..max ordering */
 		if (param_min < RC_INPUT_LOWEST_MIN_US) {
 			count++;
-			mavlink_log_critical(mavlink_fd, "RC ERR: RC_%d_MIN < %u", i + 1, RC_INPUT_LOWEST_MIN_US);
+
+			if (report_fail) { mavlink_log_critical(mavlink_fd, "RC ERR: RC_%d_MIN < %u", i + 1, RC_INPUT_LOWEST_MIN_US); }
+
 			/* give system time to flush error message in case there are more */
 			usleep(100000);
 		}
 
 		if (param_max > RC_INPUT_HIGHEST_MAX_US) {
 			count++;
-			mavlink_log_critical(mavlink_fd, "RC ERR: RC_%d_MAX > %u", i + 1, RC_INPUT_HIGHEST_MAX_US);
+
+			if (report_fail) { mavlink_log_critical(mavlink_fd, "RC ERR: RC_%d_MAX > %u", i + 1, RC_INPUT_HIGHEST_MAX_US); }
+
 			/* give system time to flush error message in case there are more */
 			usleep(100000);
 		}
 
 		if (param_trim < param_min) {
 			count++;
-			mavlink_log_critical(mavlink_fd, "RC ERR: RC_%d_TRIM < MIN (%d/%d)", i + 1, (int)param_trim, (int)param_min);
+
+			if (report_fail) { mavlink_log_critical(mavlink_fd, "RC ERR: RC_%d_TRIM < MIN (%d/%d)", i + 1, (int)param_trim, (int)param_min); }
+
 			/* give system time to flush error message in case there are more */
 			usleep(100000);
 		}
 
 		if (param_trim > param_max) {
 			count++;
-			mavlink_log_critical(mavlink_fd, "RC ERR: RC_%d_TRIM > MAX (%d/%d)", i + 1, (int)param_trim, (int)param_max);
+
+			if (report_fail) { mavlink_log_critical(mavlink_fd, "RC ERR: RC_%d_TRIM > MAX (%d/%d)", i + 1, (int)param_trim, (int)param_max); }
+
 			/* give system time to flush error message in case there are more */
 			usleep(100000);
 		}
 
 		/* assert deadzone is sane */
 		if (param_dz > RC_INPUT_MAX_DEADZONE_US) {
-			mavlink_log_critical(mavlink_fd, "RC ERR: RC_%d_DZ > %u", i + 1, RC_INPUT_MAX_DEADZONE_US);
+			if (report_fail) { mavlink_log_critical(mavlink_fd, "RC ERR: RC_%d_DZ > %u", i + 1, RC_INPUT_MAX_DEADZONE_US); }
+
 			/* give system time to flush error message in case there are more */
 			usleep(100000);
 			count++;
@@ -187,8 +199,11 @@ int rc_calibration_check(int mavlink_fd)
 
 	if (channels_failed) {
 		sleep(2);
-		mavlink_and_console_log_critical(mavlink_fd, "%d config error%s for %d RC channel%s.", total_fail_count,
-						 (total_fail_count > 1) ? "s" : "", channels_failed, (channels_failed > 1) ? "s" : "");
+
+		if (report_fail) mavlink_and_console_log_critical(mavlink_fd, "%d config error%s for %d RC channel%s.",
+					total_fail_count,
+					(total_fail_count > 1) ? "s" : "", channels_failed, (channels_failed > 1) ? "s" : "");
+
 		usleep(100000);
 	}
 

--- a/src/modules/systemlib/rc_check.h
+++ b/src/modules/systemlib/rc_check.h
@@ -47,6 +47,6 @@ __BEGIN_DECLS
  * @return			0 / OK if RC calibration is ok, index + 1 of the first
  *				channel that failed else (so 1 == first channel failed)
  */
-__EXPORT int	rc_calibration_check(int mavlink_fd);
+__EXPORT int	rc_calibration_check(int mavlink_fd, bool report_fail);
 
 __END_DECLS


### PR DESCRIPTION
Now commander will report all issues when a new link is connected. So no messages are lost.
:) Also, with my changes, it will now wait in ARMING_STATE_INIT till all primary sensors come online.

This will need some careful review, but I'm confident this works 100% as tested. Please let me know what else is needed.

New output when link first connects (hotplug sensor not up yet though) : 
```
[20:14:12.645 - COMP:1] Info: new data link connected #0
[20:14:12.861 - COMP:1] Critical: warning: primary compass not operational
[20:14:12.964 - COMP:1] Critical: Not ready to fly: Flying with USB connected prohibited
[20:14:13.068 - COMP:1] Critical: Not ready to fly: Sensors need inspection
```