### PR TITLE
Improved sensor failsafe reporting 

### DIFF
--- a/src/lib/ecl/validation/data_validator.h
+++ b/src/lib/ecl/validation/data_validator.h
@@ -91,7 +91,18 @@ public:
 	 * Get the priority of this validator
 	 * @return		the stored priority
 	 */
-	int			priority();
+	int			priority() { return (_priority); }
+	
+	/**
+	 * Get the error state of this validator
+	 * @return		the bitmask with the error status
+	 */
+	uint32_t		state() { return (_error_mask); }
+	
+	/**
+	 * Reset the error state of this validator
+	 */
+	void			reset_state() { _error_mask = ERROR_FLAG_NO_ERROR; }
 
 	/**
 	 * Get the RMS values of this validator
@@ -111,9 +122,20 @@ public:
 	 * @param timeout_interval_us The timeout interval in microseconds
 	 */
 	void			set_timeout(uint64_t timeout_interval_us) { _timeout_interval = timeout_interval_us; }
+	
+	/**
+	 * Data validator error states 
+	 */
+	static constexpr uint32_t ERROR_FLAG_NO_ERROR      	= (0x00000000U);
+	static constexpr uint32_t ERROR_FLAG_NO_DATA       	= (0x00000001U);
+	static constexpr uint32_t ERROR_FLAG_STALE_DATA    	= (0x00000001U << 1);
+	static constexpr uint32_t ERROR_FLAG_TIMEOUT 	   	= (0x00000001U << 2);
+	static constexpr uint32_t ERROR_FLAG_HIGH_ERRCOUNT 	= (0x00000001U << 3);
+	static constexpr uint32_t ERROR_FLAG_HIGH_ERRDENSITY 	= (0x00000001U << 4);
 
 private:
 	static const unsigned _dimensions = 3;
+	uint32_t _error_mask;			/**< sensor error state */
 	uint64_t _time_last;			/**< last timestamp */
 	uint64_t _timeout_interval;		/**< interval in which the datastream times out in us */
 	uint64_t _event_count;			/**< total data counter */

--- a/src/lib/ecl/validation/data_validator_group.cpp
+++ b/src/lib/ecl/validation/data_validator_group.cpp
@@ -199,7 +199,7 @@ void
 DataValidatorGroup::print()
 {
 	/* print the group's state */
-	ECL_INFO("validator: best: %d, prev best: %d, failsafe: %s (# %u)",
+	ECL_INFO("validator: best: %d, prev best: %d, failsafe: %s (%u events)",
 		_curr_best, _prev_best, (_toggle_count > 0) ? "YES" : "NO",
 		_toggle_count);
 

--- a/src/lib/ecl/validation/data_validator_group.cpp
+++ b/src/lib/ecl/validation/data_validator_group.cpp
@@ -240,7 +240,7 @@ DataValidatorGroup::failover_index()
 	unsigned i = 0;
 	
 	while (next != nullptr) {
-		if (next->used() && (next->state() != DataValidator::ERROR_FLAG_NO_ERROR) && (i == _prev_best)) {
+		if (next->used() && (next->state() != DataValidator::ERROR_FLAG_NO_ERROR) && (i == (unsigned)_prev_best)) {
 			return i;
 		}
 		next = next->sibling();
@@ -256,7 +256,7 @@ DataValidatorGroup::failover_state()
 	unsigned i = 0;
 	
 	while (next != nullptr) {
-		if (next->used() && (next->state() != DataValidator::ERROR_FLAG_NO_ERROR) && (i == _prev_best)) {
+		if (next->used() && (next->state() != DataValidator::ERROR_FLAG_NO_ERROR) && (i == (unsigned)_prev_best)) {
 			return next->state();
 		}
 		next = next->sibling();

--- a/src/lib/ecl/validation/data_validator_group.h
+++ b/src/lib/ecl/validation/data_validator_group.h
@@ -80,6 +80,20 @@ public:
 	 * @return		the number of failovers
 	 */
 	unsigned		failover_count();
+	
+	/**
+	 * Get the index of the failed sensor in the group
+	 *
+	 * @return		index of the failed sensor
+	 */
+	int			failover_index();
+	
+	/**
+	 * Get the error state of the failed sensor in the group
+	 *
+	 * @return		bitmask with erro states of the failed sensor
+	 */
+	uint32_t		failover_state();
 
 	/**
 	 * Print the validator value

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -347,11 +347,16 @@ void AttitudeEstimatorQ::task_main()
 
 					_voter_gyro.put(i, sensors.gyro_timestamp[i], &gyro[0], sensors.gyro_errcount[i], sensors.gyro_priority[i]);
 				}
-
-				_voter_accel.put(i, sensors.accelerometer_timestamp[i], &sensors.accelerometer_m_s2[i * 3],
-						 sensors.accelerometer_errcount[i], sensors.accelerometer_priority[i]);
-				_voter_mag.put(i, sensors.magnetometer_timestamp[i], &sensors.magnetometer_ga[i * 3],
+				/* ignore empty fields */
+				if (sensors.accelerometer_timestamp[i] > 0) {
+					_voter_accel.put(i, sensors.accelerometer_timestamp[i], &sensors.accelerometer_m_s2[i * 3],
+						sensors.accelerometer_errcount[i], sensors.accelerometer_priority[i]);
+				}
+				/* ignore empty fields */
+				if (sensors.magnetometer_timestamp[i] > 0) {
+					_voter_mag.put(i, sensors.magnetometer_timestamp[i], &sensors.magnetometer_ga[i * 3],
 					       sensors.magnetometer_errcount[i], sensors.magnetometer_priority[i]);
+				}
 			}
 
 			int best_gyro, best_accel, best_mag;

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -369,12 +369,25 @@ void AttitudeEstimatorQ::task_main()
 
 			_data_good = true;
 
-			if (!_failsafe && (_voter_gyro.failover_count() > 0 ||
-					   _voter_accel.failover_count() > 0 ||
-					   _voter_mag.failover_count() > 0)) {
+			if (!_failsafe) {
+				if (_voter_gyro.failover_count() > 0) {
+					_failsafe = true;
+					mavlink_and_console_log_emergency(_mavlink_fd, "Gyro failure!");
+				}
 
-				_failsafe = true;
-				mavlink_and_console_log_emergency(_mavlink_fd, "SENSOR FAILSAFE! RETURN TO LAND IMMEDIATELY");
+				if (_voter_accel.failover_count() > 0) {
+					_failsafe = true;
+					mavlink_and_console_log_emergency(_mavlink_fd, "Accel failure!");
+				}
+
+				if (_voter_mag.failover_count() > 0) {
+					_failsafe = true;
+					mavlink_and_console_log_emergency(_mavlink_fd, "Mag failure!");
+				}
+
+				if (_failsafe) {
+					mavlink_and_console_log_emergency(_mavlink_fd, "SENSOR FAILSAFE! RETURN TO LAND IMMEDIATELY");
+				}
 			}
 
 			if (!_vibration_warning && (_voter_gyro.get_vibration_factor(curr_time) > _vibration_warning_threshold ||

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -347,15 +347,17 @@ void AttitudeEstimatorQ::task_main()
 
 					_voter_gyro.put(i, sensors.gyro_timestamp[i], &gyro[0], sensors.gyro_errcount[i], sensors.gyro_priority[i]);
 				}
+
 				/* ignore empty fields */
 				if (sensors.accelerometer_timestamp[i] > 0) {
 					_voter_accel.put(i, sensors.accelerometer_timestamp[i], &sensors.accelerometer_m_s2[i * 3],
-						sensors.accelerometer_errcount[i], sensors.accelerometer_priority[i]);
+							 sensors.accelerometer_errcount[i], sensors.accelerometer_priority[i]);
 				}
+
 				/* ignore empty fields */
 				if (sensors.magnetometer_timestamp[i] > 0) {
 					_voter_mag.put(i, sensors.magnetometer_timestamp[i], &sensors.magnetometer_ga[i * 3],
-					       sensors.magnetometer_errcount[i], sensors.magnetometer_priority[i]);
+						       sensors.magnetometer_errcount[i], sensors.magnetometer_priority[i]);
 				}
 			}
 
@@ -375,19 +377,42 @@ void AttitudeEstimatorQ::task_main()
 			_data_good = true;
 
 			if (!_failsafe) {
+				uint32_t flags = DataValidator::ERROR_FLAG_NO_ERROR;
+
 				if (_voter_gyro.failover_count() > 0) {
 					_failsafe = true;
-					mavlink_and_console_log_emergency(_mavlink_fd, "Gyro failure!");
+					flags = _voter_gyro.failover_state();
+					mavlink_and_console_log_emergency(_mavlink_fd, "Gyro #%i failure :%s%s%s%s%s!",
+									  _voter_gyro.failover_index(),
+									  ((flags & DataValidator::ERROR_FLAG_NO_DATA) ? " No data" : ""),
+									  ((flags & DataValidator::ERROR_FLAG_STALE_DATA) ? " Stale data" : ""),
+									  ((flags & DataValidator::ERROR_FLAG_TIMEOUT) ? " Data timeout" : ""),
+									  ((flags & DataValidator::ERROR_FLAG_HIGH_ERRCOUNT) ? " High error count" : ""),
+									  ((flags & DataValidator::ERROR_FLAG_HIGH_ERRDENSITY) ? " High error density" : ""));
 				}
 
 				if (_voter_accel.failover_count() > 0) {
 					_failsafe = true;
-					mavlink_and_console_log_emergency(_mavlink_fd, "Accel failure!");
+					flags = _voter_accel.failover_state();
+					mavlink_and_console_log_emergency(_mavlink_fd, "Accel #%i failure :%s%s%s%s%s!",
+									  _voter_accel.failover_index(),
+									  ((flags & DataValidator::ERROR_FLAG_NO_DATA) ? " No data" : ""),
+									  ((flags & DataValidator::ERROR_FLAG_STALE_DATA) ? " Stale data" : ""),
+									  ((flags & DataValidator::ERROR_FLAG_TIMEOUT) ? " Data timeout" : ""),
+									  ((flags & DataValidator::ERROR_FLAG_HIGH_ERRCOUNT) ? " High error count" : ""),
+									  ((flags & DataValidator::ERROR_FLAG_HIGH_ERRDENSITY) ? " High error density" : ""));
 				}
 
 				if (_voter_mag.failover_count() > 0) {
 					_failsafe = true;
-					mavlink_and_console_log_emergency(_mavlink_fd, "Mag failure!");
+					flags = _voter_mag.failover_state();
+					mavlink_and_console_log_emergency(_mavlink_fd, "Mag #%i failure :%s%s%s%s%s!",
+									  _voter_mag.failover_index(),
+									  ((flags & DataValidator::ERROR_FLAG_NO_DATA) ? " No data" : ""),
+									  ((flags & DataValidator::ERROR_FLAG_STALE_DATA) ? " Stale data" : ""),
+									  ((flags & DataValidator::ERROR_FLAG_TIMEOUT) ? " Data timeout" : ""),
+									  ((flags & DataValidator::ERROR_FLAG_HIGH_ERRCOUNT) ? " High error count" : ""),
+									  ((flags & DataValidator::ERROR_FLAG_HIGH_ERRDENSITY) ? " High error density" : ""));
 				}
 
 				if (_failsafe) {


### PR DESCRIPTION
This adds verbose and complete failure reporting to the data validation class, so you know what exactly went wrong. 
Sensor fail-safes, when triggered will now give the user a full story of what went wrong, in the GCS. Command-line validator output also includes error states for each sensor.

This is a result of debugging for #3122. The fix for that issue was to increase the mag data-rate, something we would have figured out long earlier if this framework had been in place. Hope this helps everyone in the future!!
This also fixes https://github.com/PX4/Firmware/issues/2934