### PR TITLE
High performance optical flow and ranger-based altitude hold for LPE

### DIFF
--- a/msg/filtered_bottom_flow.msg
+++ b/msg/filtered_bottom_flow.msg
@@ -7,5 +7,5 @@ float32 sumy				# Integrated bodyframe y flow in meters
 float32 vx 				# Flow bodyframe x speed, m/s
 float32 vy				# Flow bodyframe y Speed, m/s
 
-float32 gyro_rad_s[3] 			# Flow module rotational speed, rad/s (filtered)
-float32 gyro_bias[3]			# Flow module gyroscope biases
+float32[3] gyro_rad_s 			# Flow module rotational speed, rad/s (filtered)
+float32[3] gyro_bias			# Flow module estimated gyroscope bias

--- a/msg/filtered_bottom_flow.msg
+++ b/msg/filtered_bottom_flow.msg
@@ -6,3 +6,6 @@ float32 sumy				# Integrated bodyframe y flow in meters
 
 float32 vx 				# Flow bodyframe x speed, m/s
 float32 vy				# Flow bodyframe y Speed, m/s
+
+float32 gyro_rad_s[3] 			# Flow module rotational speed, rad/s (filtered)
+float32 gyro_bias[3]			# Flow module gyroscope biases

--- a/src/drivers/ll40ls/LidarLite.h
+++ b/src/drivers/ll40ls/LidarLite.h
@@ -48,10 +48,10 @@
 #define LL40LS_MAX_DISTANCE (25.00f)
 
 // normal conversion wait time
-#define LL40LS_CONVERSION_INTERVAL 50*1000UL /* 50ms */
+#define LL40LS_CONVERSION_INTERVAL (50*1000UL) /* 50ms */
 
 // maximum time to wait for a conversion to complete.
-#define LL40LS_CONVERSION_TIMEOUT 100*1000UL /* 100ms */
+#define LL40LS_CONVERSION_TIMEOUT (100*1000UL) /* 100ms */
 
 class LidarLite
 {

--- a/src/drivers/ll40ls/LidarLitePWM.cpp
+++ b/src/drivers/ll40ls/LidarLitePWM.cpp
@@ -45,6 +45,7 @@
 #include "LidarLitePWM.h"
 #include <stdio.h>
 #include <string.h>
+#include <math.h>
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_pwm_input.h>
 
@@ -63,6 +64,9 @@ LidarLitePWM::LidarLitePWM(const char *path) :
 	_pwm{},
 	_distance_sensor_topic(nullptr),
 	_range{},
+	_lastTimeStamp(0),
+	_pulseCount(0),
+	_lastDistance(0.0f),
 	_sample_perf(perf_alloc(PC_ELAPSED, "ll40ls_pwm_read")),
 	_read_errors(perf_alloc(PC_COUNT, "ll40ls_pwm_read_errors")),
 	_buffer_overflows(perf_alloc(PC_COUNT, "ll40ls_pwm_buffer_overflows")),
@@ -194,6 +198,27 @@ int LidarLitePWM::measure()
 		perf_count(_sensor_zero_resets);
 		perf_end(_sample_perf);
 		return reset_sensor();
+	}
+
+	uint32_t pulse_interval = _range.timestamp - _lastTimeStamp;
+	_lastTimeStamp = _range.timestamp;
+
+	// Normal reporting interval for LidarLite in PWM mode is 50msec
+	if (pulse_interval > 60 * 1000UL) { // TODO : Should we increase this to *not* miss longer range meas?
+		// missed pulse, frequently associated with invalid pulsewidth measurements
+		_pulseCount = 0;
+
+	} else {
+		// wait for 4 successive pulses at 50msec intervals before accepting pulsewidth
+		if (_pulseCount < 4) {
+			_pulseCount++;
+			// hold last valid range reported to avoid glitches
+			_range.current_distance = _lastDistance;
+
+		} else {
+			// valid pulse train, reset lastDistance
+			_lastDistance = _range.current_distance;
+		}
 	}
 
 	if (_distance_sensor_topic != nullptr) {

--- a/src/drivers/ll40ls/LidarLitePWM.h
+++ b/src/drivers/ll40ls/LidarLitePWM.h
@@ -55,8 +55,6 @@
 #include <uORB/topics/pwm_input.h>
 #include <uORB/topics/distance_sensor.h>
 
-
-
 class LidarLitePWM : public LidarLite, public device::CDev
 {
 public:
@@ -113,6 +111,9 @@ private:
 	struct pwm_input_s	_pwm;
 	orb_advert_t	        _distance_sensor_topic;
 	struct distance_sensor_s _range;
+	uint64_t		_lastTimeStamp;
+	int			_pulseCount;
+	float			_lastDistance;
 
 	perf_counter_t	        _sample_perf;
 	perf_counter_t	        _read_errors;

--- a/src/drivers/px4flow/px4flow.cpp
+++ b/src/drivers/px4flow/px4flow.cpp
@@ -531,6 +531,8 @@ PX4FLOW::collect()
 
 	rotate_3f(_sensor_rotation, report.pixel_flow_x_integral, report.pixel_flow_y_integral, zeroval);
 
+	rotate_3f(_sensor_rotation, report.gyro_x_rate_integral, report.gyro_y_rate_integral, report.gyro_z_rate_integral);
+
 	if (_px4flow_topic == nullptr) {
 		_px4flow_topic = orb_advertise(ORB_ID(optical_flow), &report);
 

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -34,7 +34,10 @@ BlockLocalPositionEstimator::BlockLocalPositionEstimator() :
 	_sub_gps(ORB_ID(vehicle_gps_position), 0, 0, &getSubscriptions()),
 	_sub_vision_pos(ORB_ID(vision_position_estimate), 0, 0, &getSubscriptions()),
 	_sub_mocap(ORB_ID(att_pos_mocap), 0, 0, &getSubscriptions()),
-
+	_distance_subs(),
+	_sub_lidar(NULL),
+	_sub_sonar(NULL),
+	
 	// publications
 	_pub_lpos(ORB_ID(vehicle_local_position), -1, &getPublications()),
 	_pub_gpos(ORB_ID(vehicle_global_position), -1, &getPublications()),

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -65,8 +65,8 @@ BlockLocalPositionEstimator::BlockLocalPositionEstimator() :
 	_no_vision(this, "NO_VISION"),
 	_beta_max(this, "BETA_MAX"),
 	_mocap_p_stddev(this, "VIC_P"),
-	_flow_board_x_offs(this, "FLOW_X_OFF"),	// TODO fix
-	_flow_board_y_offs(this, "FLOW_Y_OFF"),  // TODO
+	_flow_board_x_offs(NULL, "SENS_FLOW_X_OFF"),
+	_flow_board_y_offs(NULL, "SENS_FLOW_Y_OFF"),
 	_pn_p_noise_power(this, "PN_P"),
 	_pn_v_noise_power(this, "PN_V"),
 	_pn_b_noise_power(this, "PN_B"),

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -903,15 +903,29 @@ void BlockLocalPositionEstimator::correctFlow()
 	} else {
 		flow_speed[0] = 0;
 		flow_speed[1] = 0;
+		flow_gyrospeed[0] = 0;
+		flow_gyrospeed[1] = 0;
+		flow_gyrospeed[2] = 0;
 	}
 
 	flow_speed[2] = 0.0f;
+	
+	// filtered gyro readings for logging
+	flow_gyrospeed[0] -= _flowGyroBias[0];
+	flow_gyrospeed[1] -= _flowGyroBias[1];
+	flow_gyrospeed[2] -= _flowGyroBias[2];
 
 	// update filtered flow 
 	_pub_filtered_flow.get().sumx += flow_speed[0] * dt;
 	_pub_filtered_flow.get().sumy += flow_speed[1] * dt;
 	_pub_filtered_flow.get().vx = flow_speed[0];
 	_pub_filtered_flow.get().vy = flow_speed[1];
+	_pub_filtered_flow.get().gyro_rad_s[0] = flow_gyrospeed[0];
+	_pub_filtered_flow.get().gyro_rad_s[1] = flow_gyrospeed[1];
+	_pub_filtered_flow.get().gyro_rad_s[2] = flow_gyrospeed[2];
+	_pub_filtered_flow.get().gyro_bias[0] = _flowGyroBias[0];
+	_pub_filtered_flow.get().gyro_bias[1] = _flowGyroBias[1];
+	_pub_filtered_flow.get().gyro_bias[2] = _flowGyroBias[2];
 
 	// convert to globalframe velocity
 	for (uint8_t i = 0; i < 3; i++) {

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -3,8 +3,8 @@
 #include <fcntl.h>
 #include <systemlib/err.h>
 
-static const int 		MIN_FLOW_QUALITY = 100;
-static const int 		REQ_INIT_COUNT = 100;
+static const int 		MIN_FLOW_QUALITY = 50;
+static const int 		REQ_INIT_COUNT = 75;
 
 static const uint32_t 		VISION_POSITION_TIMEOUT = 500000;
 static const uint32_t 		MOCAP_TIMEOUT = 200000;

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -402,10 +402,10 @@ void BlockLocalPositionEstimator::update()
 
 	if (mocapUpdated) {
 		if (!_mocapInitialized) {
-			initmocap();
+			initMocap();
 
 		} else {
-			correctmocap();
+			correctMocap();
 		}
 	}
 
@@ -609,7 +609,7 @@ void BlockLocalPositionEstimator::initVision()
 	}
 }
 
-void BlockLocalPositionEstimator::initmocap()
+void BlockLocalPositionEstimator::initMocap()
 {
 	// collect mocap data
 	if (!_mocapInitialized) {
@@ -1353,7 +1353,7 @@ void BlockLocalPositionEstimator::correctVision()
 	_time_last_vision_p = _sub_vision_pos.get().timestamp_boot;
 }
 
-void BlockLocalPositionEstimator::correctmocap()
+void BlockLocalPositionEstimator::correctMocap()
 {
 
 	Vector<float, n_y_mocap> y;

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -206,14 +206,15 @@ void BlockLocalPositionEstimator::update()
 	float dt = (newTimeStamp - _timeStamp) / 1.0e6f;
 	_timeStamp = newTimeStamp;
 
-	//printf("dt: %0.5g\n", double(dt));
-
 	// set dt for all child blocks
 	setDt(dt);
 
 	// auto-detect connected rangefinders while not armed
 	if (!_sub_armed.get().armed && (_sub_lidar == NULL || _sub_sonar == NULL)) {
 		for (int i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
+			if(_distance_subs[i]->get().timestamp == 0) {	
+				continue; // ignore sensors with no data coming in
+			}
 			if (_distance_subs[i]->get().type == distance_sensor_s::MAV_DISTANCE_SENSOR_LASER &&
 			    _sub_lidar == NULL) {
 				_sub_lidar = _distance_subs[i];

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -212,9 +212,10 @@ void BlockLocalPositionEstimator::update()
 	// auto-detect connected rangefinders while not armed
 	if (!_sub_armed.get().armed && (_sub_lidar == NULL || _sub_sonar == NULL)) {
 		for (int i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
-			if(_distance_subs[i]->get().timestamp == 0) {	
+			if (_distance_subs[i]->get().timestamp == 0) {
 				continue; // ignore sensors with no data coming in
 			}
+
 			if (_distance_subs[i]->get().type == distance_sensor_s::MAV_DISTANCE_SENSOR_LASER &&
 			    _sub_lidar == NULL) {
 				_sub_lidar = _distance_subs[i];
@@ -898,13 +899,13 @@ void BlockLocalPositionEstimator::correctFlow()
 		yaw_comp[1] =   _flow_board_x_offs.get() * (flow_gyrospeed[2] - _flowGyroBias[2]);
 
 		// calculate velocity over ground
-		flow_speed[0] = ((_sub_flow.get().pixel_flow_x_integral - _sub_flow.get().gyro_x_rate_integral) /
-				 (_sub_flow.get().integration_timespan / 1e6f)
-				 + _flowGyroBias[0] - yaw_comp[0]) *
+		flow_speed[0] = - ((_sub_flow.get().pixel_flow_x_integral - _sub_flow.get().gyro_x_rate_integral) /
+				   (_sub_flow.get().integration_timespan / 1e6f)
+				   + _flowGyroBias[0] - yaw_comp[0]) *
 				-_x(X_z);		// TODO use terrain estimate here
-		flow_speed[1] = ((_sub_flow.get().pixel_flow_y_integral - _sub_flow.get().gyro_y_rate_integral) /
-				 (_sub_flow.get().integration_timespan / 1e6f) -
-				 + _flowGyroBias[1] - yaw_comp[1]) *
+		flow_speed[1] = - ((_sub_flow.get().pixel_flow_y_integral - _sub_flow.get().gyro_y_rate_integral) /
+				   (_sub_flow.get().integration_timespan / 1e6f) -
+				   + _flowGyroBias[1] - yaw_comp[1]) *
 				-_x(X_z);		// TODO use terrain estimate here
 
 	} else {

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -510,7 +510,8 @@ void BlockLocalPositionEstimator::initLidar()
 	float d = _sub_lidar->get().current_distance;
 
 	if (d < _sub_lidar->get().max_distance &&
-	    d > _sub_lidar->get().min_distance) {
+	    d > _sub_lidar->get().min_distance &&
+	    _sub_lidar->get().timestamp != 0) {
 		valid = true;
 	}
 
@@ -538,7 +539,8 @@ void BlockLocalPositionEstimator::initSonar()
 	float d = _sub_sonar->get().current_distance;
 
 	if (d < _sub_sonar->get().max_distance &&
-	    d > _sub_sonar->get().min_distance) {
+	    d > _sub_sonar->get().min_distance &&
+	    _sub_sonar->get().timestamp != 0) {
 		valid = true;
 	}
 
@@ -1000,6 +1002,9 @@ void BlockLocalPositionEstimator::correctFlow()
 
 void BlockLocalPositionEstimator::correctSonar()
 {
+
+	if (_sub_sonar->get().timestamp == 0) { return; }
+
 	float d = _sub_sonar->get().current_distance;
 
 	// sonar measurement matrix and noise matrix
@@ -1119,6 +1124,8 @@ void BlockLocalPositionEstimator::correctBaro()
 
 void BlockLocalPositionEstimator::correctLidar()
 {
+
+	if (_sub_lidar->get().timestamp == 0) { return; }
 
 	float d = _sub_lidar->get().current_distance;
 

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -569,9 +569,13 @@ void BlockLocalPositionEstimator::initSonar()
 
 void BlockLocalPositionEstimator::initFlow()
 {
-
+	bool rangefinder_available = false;
+	
+	rangefinder_available = (_sonarInitialized && !_sonarFault) ||
+				(_lidarInitialized && !_lidarFault);
+	
 	// collect pixel flow data
-	if (!_flowInitialized) {
+	if (!_flowInitialized && rangefinder_available) {
 		// increament sums for mean
 		_flowMeanQual += _sub_flow.get().quality;
 

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -1062,6 +1062,9 @@ void BlockLocalPositionEstimator::correctSonar()
 {
 
 	if (_sub_sonar->get().timestamp == 0) { return; }
+	
+	// do not use sonar if lidar is active
+	if (_lidarInitialized && !_lidarFault) { return; }
 
 	float d = _sub_sonar->get().current_distance;
 

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -32,7 +32,7 @@ BlockLocalPositionEstimator::BlockLocalPositionEstimator() :
 	_sub_att_sp(ORB_ID(vehicle_attitude_setpoint),
 		    0, 0, &getSubscriptions()),
 	_sub_rates_sp(ORB_ID(vehicle_rates_setpoint),
-		    0, 0, &getSubscriptions()),
+		      0, 0, &getSubscriptions()),
 	_sub_flow(ORB_ID(optical_flow), 0, 0, &getSubscriptions()),
 	_sub_sensor(ORB_ID(sensor_combined), 0, 0, &getSubscriptions()),
 	_sub_param_update(ORB_ID(parameter_update), 0, 0, &getSubscriptions()),
@@ -272,11 +272,11 @@ void BlockLocalPositionEstimator::update()
 	if (homeUpdated) {
 		updateHome();
 	}
-	
+
 	checkTimeouts();
 
 	// determine if we should start estimating
-	_canEstimateZ = 
+	_canEstimateZ =
 		(_baroInitialized && !_baroFault) ||
 		(_lidarInitialized && !_lidarFault) ||
 		(_sonarInitialized && !_sonarFault);
@@ -289,6 +289,7 @@ void BlockLocalPositionEstimator::update()
 	if (_canEstimateXY) {
 		_time_last_xy = hrt_absolute_time();
 	}
+
 	if (_canEstimateZ) {
 		_time_last_z = hrt_absolute_time();
 	}
@@ -437,7 +438,7 @@ void BlockLocalPositionEstimator::checkTimeouts()
 	} else {
 		_baroTimeout = false;
 	}
-	
+
 	if ((hrt_absolute_time() - _time_last_gps > GPS_TIMEOUT) && _gpsInitialized) {
 		if (!_gpsTimeout) {
 			_gpsTimeout = true;
@@ -448,7 +449,7 @@ void BlockLocalPositionEstimator::checkTimeouts()
 	} else {
 		_gpsTimeout = false;
 	}
-	
+
 	if ((hrt_absolute_time() - _time_last_gps > FLOW_TIMEOUT) && _flowInitialized) {
 		if (!_flowTimeout) {
 			_flowTimeout = true;
@@ -459,7 +460,7 @@ void BlockLocalPositionEstimator::checkTimeouts()
 	} else {
 		_flowTimeout = false;
 	}
-	
+
 	if ((hrt_absolute_time() - _time_last_sonar > RANGER_TIMEOUT) && _sonarInitialized) {
 		if (!_sonarTimeout) {
 			_sonarTimeout = true;
@@ -470,7 +471,7 @@ void BlockLocalPositionEstimator::checkTimeouts()
 	} else {
 		_sonarTimeout = false;
 	}
-	
+
 	if ((hrt_absolute_time() - _time_last_lidar > RANGER_TIMEOUT) && _lidarInitialized) {
 		if (!_lidarTimeout) {
 			_lidarTimeout = true;
@@ -481,7 +482,7 @@ void BlockLocalPositionEstimator::checkTimeouts()
 	} else {
 		_lidarTimeout = false;
 	}
-	
+
 	if ((hrt_absolute_time() - _time_last_vision_p > VISION_TIMEOUT) && _visionInitialized) {
 		if (!_visionTimeout) {
 			_visionTimeout = true;
@@ -594,10 +595,10 @@ void BlockLocalPositionEstimator::initLidar()
 		if (_lidarInitCount++ > REQ_INIT_COUNT) {
 			_lidarInitialized = true;
 		}
-		
+
 		if (!_altHomeInitialized) {
-				_altHomeInitialized = true;
-				_altHome = _lidarAltHome;
+			_altHomeInitialized = true;
+			_altHome = _lidarAltHome;
 		}
 	}
 }
@@ -623,10 +624,10 @@ void BlockLocalPositionEstimator::initSonar()
 			_sonarAltHome /= _sonarInitCount;
 			_sonarInitialized = true;
 		}
-		
+
 		if (!_altHomeInitialized) {
-				_altHomeInitialized = true;
-				_altHome = _sonarAltHome;
+			_altHomeInitialized = true;
+			_altHome = _sonarAltHome;
 		}
 	}
 }
@@ -634,10 +635,10 @@ void BlockLocalPositionEstimator::initSonar()
 void BlockLocalPositionEstimator::initFlow()
 {
 	bool rangefinder_available = false;
-	
+
 	rangefinder_available = (_sonarInitialized && !_sonarFault) ||
 				(_lidarInitialized && !_lidarFault);
-	
+
 	// collect pixel flow data
 	if (!_flowInitialized && rangefinder_available) {
 		// increament sums for mean
@@ -652,6 +653,7 @@ void BlockLocalPositionEstimator::initFlow()
 				_flowInitCount = 0;
 				return;
 			}
+
 			_flowInitialized = true;
 		}
 	}
@@ -672,10 +674,10 @@ void BlockLocalPositionEstimator::initVision()
 			_visionHome /= _visionInitCount;
 			_visionInitialized = true;
 		}
-		
+
 		if (!_altHomeInitialized) {
-				_altHomeInitialized = true;
-				_altHome = _visionHome(2);
+			_altHomeInitialized = true;
+			_altHome = _visionHome(2);
 		}
 	}
 }
@@ -695,10 +697,10 @@ void BlockLocalPositionEstimator::initMocap()
 			_mocapHome /= _mocapInitCount;
 			_mocapInitialized = true;
 		}
-		
+
 		if (!_altHomeInitialized) {
-				_altHomeInitialized = true;
-				_altHome = _mocapHome(2);
+			_altHomeInitialized = true;
+			_altHome = _mocapHome(2);
 		}
 	}
 }
@@ -953,7 +955,7 @@ void BlockLocalPositionEstimator::correctFlow()
 	float alpha = 0.2; // lowpass gyro bias
 
 	if (_sub_flow.get().integration_timespan > 0) {
-	
+
 		// TODO : estimate bias as a filter state
 
 		// estimate gyro bias for the flow board's gyro using flight controller's calibrated gyro
@@ -965,7 +967,7 @@ void BlockLocalPositionEstimator::correctFlow()
 		_flowGyroBias[0] = alpha * (flow_gyrospeed[0] - _sub_att.get().pitchspeed) + (1.0f - alpha) * _flowGyroBias[0];
 		_flowGyroBias[1] = alpha * (flow_gyrospeed[1] - _sub_att.get().rollspeed) + (1.0f - alpha) * _flowGyroBias[1];
 		_flowGyroBias[2] = alpha * (flow_gyrospeed[2] - _sub_att.get().yawspeed) + (1.0f - alpha) * _flowGyroBias[2];
-		
+
 		// filtered gyro readings
 		flow_gyrospeed[0] -= _flowGyroBias[0];
 		flow_gyrospeed[1] -= _flowGyroBias[1];
@@ -976,29 +978,29 @@ void BlockLocalPositionEstimator::correctFlow()
 
 		yaw_comp[0] = - _flow_board_y_offs.get() * flow_gyrospeed[2];
 		yaw_comp[1] =   _flow_board_x_offs.get() * flow_gyrospeed[2];
-		
+
 		// Perform gyro-compensation only for large body rates
 		bool gyro_compX = (float)fabs(_sub_rates_sp.get().pitch) > FLOW_GYROCOMP_THRESHOLD;
 		bool gyro_compY = (float)fabs(_sub_rates_sp.get().roll) > FLOW_GYROCOMP_THRESHOLD;
 		bool gyro_compZ = (float)fabs(_sub_rates_sp.get().yaw) > FLOW_GYROCOMP_THRESHOLD;
-		
+
 		// actual distance to ground
 		float ground_distance = -_x(X_z) / 			// TODO use terrain estimate here
-	       				cosf(_sub_att.get().roll) /
-	      				cosf(_sub_att.get().pitch);
-		
+					cosf(_sub_att.get().roll) /
+					cosf(_sub_att.get().pitch);
+
 		// calculate velocity over ground
-		flow_speed[0] = - ((_sub_flow.get().pixel_flow_x_integral - (gyro_compX ? flow_gyrospeed[0] : 0.0f) ) /
+		flow_speed[0] = - ((_sub_flow.get().pixel_flow_x_integral - (gyro_compX ? flow_gyrospeed[0] : 0.0f)) /
 				   (_sub_flow.get().integration_timespan / 1e6f) -
-				   (gyro_compZ ? yaw_comp[0] : 0.0f) ) *
+				   (gyro_compZ ? yaw_comp[0] : 0.0f)) *
 				ground_distance *
 				_flow_x_scaler.get();
-		flow_speed[1] = - ((_sub_flow.get().pixel_flow_y_integral - (gyro_compY ? flow_gyrospeed[1] : 0.0f) ) /
+		flow_speed[1] = - ((_sub_flow.get().pixel_flow_y_integral - (gyro_compY ? flow_gyrospeed[1] : 0.0f)) /
 				   (_sub_flow.get().integration_timespan / 1e6f) -
-				   (gyro_compZ ? yaw_comp[1] : 0.0f) ) *
+				   (gyro_compZ ? yaw_comp[1] : 0.0f)) *
 				ground_distance *
 				_flow_y_scaler.get();
-				
+
 	} else {
 		flow_speed[0] = 0;
 		flow_speed[1] = 0;
@@ -1020,7 +1022,7 @@ void BlockLocalPositionEstimator::correctFlow()
 	_pub_filtered_flow.get().gyro_bias[0] = _flowGyroBias[0];
 	_pub_filtered_flow.get().gyro_bias[1] = _flowGyroBias[1];
 	_pub_filtered_flow.get().gyro_bias[2] = _flowGyroBias[2];
-	
+
 	publishFilteredFlow();
 
 	// convert to globalframe velocity
@@ -1087,7 +1089,7 @@ void BlockLocalPositionEstimator::correctSonar()
 {
 
 	if (_sub_sonar->get().timestamp == 0) { return; }
-	
+
 	// do not use sonar if lidar is active
 	if (_lidarInitialized && !_lidarFault) { return; }
 

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -982,18 +982,21 @@ void BlockLocalPositionEstimator::correctFlow()
 		bool gyro_compY = (float)fabs(_sub_rates_sp.get().roll) > FLOW_GYROCOMP_THRESHOLD;
 		bool gyro_compZ = (float)fabs(_sub_rates_sp.get().yaw) > FLOW_GYROCOMP_THRESHOLD;
 		
-		float ground_distance = -_x(X_z) * 
+		// actual distance to ground
+		float ground_distance = -_x(X_z) / 			// TODO use terrain estimate here
+	       				cosf(_sub_att.get().roll) /
+	      				cosf(_sub_att.get().pitch);
 		
 		// calculate velocity over ground
 		flow_speed[0] = - ((_sub_flow.get().pixel_flow_x_integral - (gyro_compX ? flow_gyrospeed[0] : 0.0f) ) /
 				   (_sub_flow.get().integration_timespan / 1e6f) -
 				   (gyro_compZ ? yaw_comp[0] : 0.0f) ) *
-				-_x(X_z) *			// TODO use terrain estimate here
+				ground_distance *
 				_flow_x_scaler.get();
 		flow_speed[1] = - ((_sub_flow.get().pixel_flow_y_integral - (gyro_compY ? flow_gyrospeed[1] : 0.0f) ) /
 				   (_sub_flow.get().integration_timespan / 1e6f) -
 				   (gyro_compZ ? yaw_comp[1] : 0.0f) ) *
-				-_x(X_z) *			// TODO use terrain estimate here
+				ground_distance *
 				_flow_y_scaler.get();
 				
 	} else {

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -741,10 +741,13 @@ void BlockLocalPositionEstimator::publishEstimatorStatus()
 			+ ((_visionFault > 0) << SENSOR_VISION)
 			+ ((_mocapFault > 0) << SENSOR_MOCAP);
 		_pub_est_status.get().timeout_flags =
-			(_xyTimeout << 0)
-			+ (_zTimeout << 1)
-			+ (_visionTimeout << 2)
-			+ (_mocapTimeout << 3);
+			(_baroTimeout << SENSOR_BARO)
+			+ (_gpsTimeout << SENSOR_GPS)
+			+ (_flowTimeout << SENSOR_FLOW)
+			+ (_lidarTimeout << SENSOR_LIDAR)
+			+ (_sonarTimeout << SENSOR_SONAR)
+			+ (_visionTimeout << SENSOR_VISION)
+			+ (_mocapTimeout << SENSOR_MOCAP);
 		_pub_est_status.update();
 	}
 }

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -594,6 +594,11 @@ void BlockLocalPositionEstimator::initLidar()
 		if (_lidarInitCount++ > REQ_INIT_COUNT) {
 			_lidarInitialized = true;
 		}
+		
+		if (!_altHomeInitialized) {
+				_altHomeInitialized = true;
+				_altHome = _lidarAltHome;
+		}
 	}
 }
 
@@ -617,6 +622,11 @@ void BlockLocalPositionEstimator::initSonar()
 		if (_sonarInitCount++ > REQ_INIT_COUNT) {
 			_sonarAltHome /= _sonarInitCount;
 			_sonarInitialized = true;
+		}
+		
+		if (!_altHomeInitialized) {
+				_altHomeInitialized = true;
+				_altHome = _sonarAltHome;
 		}
 	}
 }
@@ -662,6 +672,11 @@ void BlockLocalPositionEstimator::initVision()
 			_visionHome /= _visionInitCount;
 			_visionInitialized = true;
 		}
+		
+		if (!_altHomeInitialized) {
+				_altHomeInitialized = true;
+				_altHome = _visionHome(2);
+		}
 	}
 }
 
@@ -679,6 +694,11 @@ void BlockLocalPositionEstimator::initMocap()
 		if (_mocapInitCount++ > REQ_INIT_COUNT) {
 			_mocapHome /= _mocapInitCount;
 			_mocapInitialized = true;
+		}
+		
+		if (!_altHomeInitialized) {
+				_altHomeInitialized = true;
+				_altHome = _mocapHome(2);
 		}
 	}
 }
@@ -961,6 +981,8 @@ void BlockLocalPositionEstimator::correctFlow()
 		bool gyro_compX = (float)fabs(_sub_rates_sp.get().pitch) > FLOW_GYROCOMP_THRESHOLD;
 		bool gyro_compY = (float)fabs(_sub_rates_sp.get().roll) > FLOW_GYROCOMP_THRESHOLD;
 		bool gyro_compZ = (float)fabs(_sub_rates_sp.get().yaw) > FLOW_GYROCOMP_THRESHOLD;
+		
+		float ground_distance = -_x(X_z) * 
 		
 		// calculate velocity over ground
 		flow_speed[0] = - ((_sub_flow.get().pixel_flow_x_integral - (gyro_compX ? flow_gyrospeed[0] : 0.0f) ) /

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -416,7 +416,7 @@ void BlockLocalPositionEstimator::update()
 		publishEstimatorStatus();
 		publishGlobalPos();
 
-	} else if (_altHomeInitialized) {
+	} else if (!_zTimeout && _altHomeInitialized) {
 		// publish only Z estimate
 		publishLocalPos();
 		publishEstimatorStatus();
@@ -521,6 +521,8 @@ void BlockLocalPositionEstimator::updateHome()
 	_baroAltHome +=  delta_alt;
 	_lidarAltHome +=  delta_alt;
 	_sonarAltHome +=  delta_alt;
+	_visionHome(2) += delta_alt;
+	_mocapHome(2) += delta_alt;
 }
 
 void BlockLocalPositionEstimator::initBaro()

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -181,13 +181,15 @@ private:
 	uORB::Subscription<vehicle_attitude_setpoint_s> _sub_att_sp;
 	uORB::Subscription<optical_flow_s> _sub_flow;
 	uORB::Subscription<sensor_combined_s> _sub_sensor;
-	uORB::Subscription<distance_sensor_s> _sub_distance;
 	uORB::Subscription<parameter_update_s> _sub_param_update;
 	uORB::Subscription<manual_control_setpoint_s> _sub_manual;
 	uORB::Subscription<home_position_s> _sub_home;
 	uORB::Subscription<vehicle_gps_position_s> _sub_gps;
 	uORB::Subscription<vision_position_estimate_s> _sub_vision_pos;
 	uORB::Subscription<att_pos_mocap_s> _sub_mocap;
+	uORB::Subscription<distance_sensor_s> * _distance_subs[ORB_MULTI_MAX_INSTANCES];
+	uORB::Subscription<distance_sensor_s> * _sub_lidar;
+	uORB::Subscription<distance_sensor_s> * _sub_sonar;
 
 	// publications
 	uORB::Publication<vehicle_local_position_s> _pub_lpos;

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -187,9 +187,9 @@ private:
 	uORB::Subscription<vehicle_gps_position_s> _sub_gps;
 	uORB::Subscription<vision_position_estimate_s> _sub_vision_pos;
 	uORB::Subscription<att_pos_mocap_s> _sub_mocap;
-	uORB::Subscription<distance_sensor_s> * _distance_subs[ORB_MULTI_MAX_INSTANCES];
-	uORB::Subscription<distance_sensor_s> * _sub_lidar;
-	uORB::Subscription<distance_sensor_s> * _sub_sonar;
+	uORB::Subscription<distance_sensor_s> *_distance_subs[ORB_MULTI_MAX_INSTANCES];
+	uORB::Subscription<distance_sensor_s> *_sub_lidar;
+	uORB::Subscription<distance_sensor_s> *_sub_sonar;
 
 	// publications
 	uORB::Publication<vehicle_local_position_s> _pub_lpos;
@@ -227,10 +227,10 @@ private:
 	BlockParamFloat  _beta_max;
 
 	BlockParamFloat  _mocap_p_stddev;
-	
+
 	BlockParamFloat  _flow_board_x_offs;
 	BlockParamFloat  _flow_board_y_offs;
-	
+
 	// process noise
 	BlockParamFloat  _pn_p_noise_power;
 	BlockParamFloat  _pn_v_noise_power;

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -227,7 +227,10 @@ private:
 	BlockParamFloat  _beta_max;
 
 	BlockParamFloat  _mocap_p_stddev;
-
+	
+	BlockParamFloat  _flow_board_x_offs;
+	BlockParamFloat  _flow_board_y_offs;
+	
 	// process noise
 	BlockParamFloat  _pn_p_noise_power;
 	BlockParamFloat  _pn_v_noise_power;
@@ -278,6 +281,7 @@ private:
 	// flow integration
 	float _flowX;
 	float _flowY;
+	float _flowGyroBias[3];
 	float _flowMeanQual;
 
 	// referene lat/lon

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -152,7 +152,7 @@ private:
 	void correctFlow();
 	void correctSonar();
 	void correctVision();
-	void correctmocap();
+	void correctMocap();
 
 	// sensor initialization
 	void updateHome();
@@ -162,7 +162,7 @@ private:
 	void initSonar();
 	void initFlow();
 	void initVision();
-	void initmocap();
+	void initMocap();
 
 	// publications
 	void publishLocalPos();

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -153,6 +153,9 @@ private:
 	void correctSonar();
 	void correctVision();
 	void correctMocap();
+	
+	// sensor timeout checks
+	void checkTimeouts();
 
 	// sensor initialization
 	void updateHome();
@@ -308,7 +311,12 @@ private:
 	fault_t _sonarFault;
 	fault_t _visionFault;
 	fault_t _mocapFault;
-
+	
+	bool _baroTimeout;
+	bool _gpsTimeout;
+	bool _flowTimeout;
+	bool _lidarTimeout;
+	bool _sonarTimeout;
 	bool _visionTimeout;
 	bool _mocapTimeout;
 

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -153,7 +153,7 @@ private:
 	void correctSonar();
 	void correctVision();
 	void correctMocap();
-	
+
 	// sensor timeout checks
 	void checkTimeouts();
 
@@ -234,7 +234,7 @@ private:
 
 	BlockParamFloat  _flow_board_x_offs;
 	BlockParamFloat  _flow_board_y_offs;
-	
+
 	BlockParamFloat  _flow_x_scaler;
 	BlockParamFloat  _flow_y_scaler;
 	BlockParamInt    _flow_min_q;
@@ -311,7 +311,7 @@ private:
 	fault_t _sonarFault;
 	fault_t _visionFault;
 	fault_t _mocapFault;
-	
+
 	bool _baroTimeout;
 	bool _gpsTimeout;
 	bool _flowTimeout;

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -179,6 +179,7 @@ private:
 	uORB::Subscription<vehicle_control_mode_s> _sub_control_mode;
 	uORB::Subscription<vehicle_attitude_s> _sub_att;
 	uORB::Subscription<vehicle_attitude_setpoint_s> _sub_att_sp;
+	uORB::Subscription<vehicle_rates_setpoint_s> _sub_rates_sp;
 	uORB::Subscription<optical_flow_s> _sub_flow;
 	uORB::Subscription<sensor_combined_s> _sub_sensor;
 	uORB::Subscription<parameter_update_s> _sub_param_update;
@@ -230,6 +231,10 @@ private:
 
 	BlockParamFloat  _flow_board_x_offs;
 	BlockParamFloat  _flow_board_y_offs;
+	
+	BlockParamFloat  _flow_x_scaler;
+	BlockParamFloat  _flow_y_scaler;
+	BlockParamInt    _flow_min_q;
 
 	// process noise
 	BlockParamFloat  _pn_p_noise_power;

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -245,6 +245,7 @@ private:
 	struct pollfd _polls[3];
 	uint64_t _timeStamp;
 	uint64_t _time_last_xy;
+	uint64_t _time_last_z;
 	uint64_t _time_last_flow;
 	uint64_t _time_last_baro;
 	uint64_t _time_last_gps;
@@ -297,6 +298,7 @@ private:
 	bool _canEstimateXY;
 	bool _canEstimateZ;
 	bool _xyTimeout;
+	bool _zTimeout;
 
 	// sensor faults
 	fault_t _baroFault;

--- a/src/modules/local_position_estimator/params.c
+++ b/src/modules/local_position_estimator/params.c
@@ -28,6 +28,33 @@ PARAM_DEFINE_INT32(LPE_INTEGRATE, 1);
 PARAM_DEFINE_FLOAT(LPE_FLW_XY, 0.01f);
 
 /**
+ * Optical flow X scaling factor
+ *
+ * @group Local Position Estimator
+ * @min 0.0
+ * @max 2.0
+ */
+PARAM_DEFINE_FLOAT(LPE_FLW_XSCLR, 1.35f);
+
+/**
+ * Optical flow Y scaling factor
+ *
+ * @group Local Position Estimator
+ * @min 0.0
+ * @max 2.0
+ */
+PARAM_DEFINE_FLOAT(LPE_FLW_YSCLR, 1.35f);
+
+/**
+ * Optical flow minimum quality threshold
+ *
+ * @group Local Position Estimator
+ * @min 0
+ * @max 255
+ */
+PARAM_DEFINE_INT32(LPE_FLW_QMIN, 75);
+
+/**
  * Sonar z standard deviation.
  *
  * @group Local Position Estimator

--- a/src/modules/local_position_estimator/params.c
+++ b/src/modules/local_position_estimator/params.c
@@ -34,7 +34,7 @@ PARAM_DEFINE_FLOAT(LPE_FLW_XY, 0.01f);
  * @min 0.0
  * @max 2.0
  */
-PARAM_DEFINE_FLOAT(LPE_FLW_XSCLR, 1.35f);
+PARAM_DEFINE_FLOAT(LPE_FLW_XSCLR, 1.0f);
 
 /**
  * Optical flow Y scaling factor
@@ -43,7 +43,7 @@ PARAM_DEFINE_FLOAT(LPE_FLW_XSCLR, 1.35f);
  * @min 0.0
  * @max 2.0
  */
-PARAM_DEFINE_FLOAT(LPE_FLW_YSCLR, 1.35f);
+PARAM_DEFINE_FLOAT(LPE_FLW_YSCLR, 1.0f);
 
 /**
  * Optical flow minimum quality threshold

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -456,6 +456,7 @@ MavlinkReceiver::handle_message_optical_flow_rad(mavlink_message_t *msg)
 	/* rotate measurements according to parameter */
 	float zeroval = 0.0f;
 	rotate_3f(flow_rot, f.pixel_flow_x_integral, f.pixel_flow_y_integral, zeroval);
+	rotate_3f(flow_rot, f.gyro_x_rate_integral, f.gyro_y_rate_integral, f.gyro_z_rate_integral);
 
 	if (_flow_pub == nullptr) {
 		_flow_pub = orb_advertise(ORB_ID(optical_flow), &f);

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -93,6 +93,7 @@
 #include <uORB/topics/vision_position_estimate.h>
 #include <uORB/topics/vehicle_global_velocity_setpoint.h>
 #include <uORB/topics/optical_flow.h>
+#include <uORB/topics/filtered_bottom_flow.h>
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/differential_pressure.h>
 #include <uORB/topics/airspeed.h>
@@ -1078,6 +1079,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 		struct att_pos_mocap_s att_pos_mocap;
 		struct vision_position_estimate_s vision_pos;
 		struct optical_flow_s flow;
+		struct filtered_bottom_flow_s filtered_flow;
 		struct rc_channels_s rc;
 		struct differential_pressure_s diff_pres;
 		struct airspeed_s airspeed;
@@ -1123,6 +1125,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 			struct log_AIRS_s log_AIRS;
 			struct log_ARSP_s log_ARSP;
 			struct log_FLOW_s log_FLOW;
+			struct log_FFLW_s log_FFLW;
 			struct log_GPOS_s log_GPOS;
 			struct log_GPSP_s log_GPSP;
 			struct log_ESC_s log_ESC;
@@ -1177,6 +1180,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 		int att_pos_mocap_sub;
 		int vision_pos_sub;
 		int flow_sub;
+		int filtered_flow_sub;
 		int rc_sub;
 		int airspeed_sub;
 		int esc_sub;
@@ -1215,6 +1219,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 	subs.att_pos_mocap_sub = -1;
 	subs.vision_pos_sub = -1;
 	subs.flow_sub = -1;
+	subs.filtered_flow_sub = -1;
 	subs.rc_sub = -1;
 	subs.airspeed_sub = -1;
 	subs.esc_sub = -1;
@@ -1687,6 +1692,22 @@ int sdlog2_thread_main(int argc, char *argv[])
 			log_msg.body.log_FLOW.quality = buf.flow.quality;
 			log_msg.body.log_FLOW.sensor_id = buf.flow.sensor_id;
 			LOGBUFFER_WRITE_AND_COUNT(FLOW);
+		}
+		
+		/* --- FILTERED FLOW --- */
+		if (copy_if_updated(ORB_ID(filtered_bottom_flow), &subs.filtered_flow_sub, &buf.filtered_flow)) {
+			log_msg.msg_type = LOG_FFLW_MSG;
+			log_msg.body.log_FFLW.x_vel_integ = buf.filtered_flow.sumx;
+			log_msg.body.log_FFLW.y_vel_integ = buf.filtered_flow.sumy;
+			log_msg.body.log_FFLW.x_vel = buf.filtered_flow.vx;
+			log_msg.body.log_FFLW.y_vel = buf.filtered_flow.vy;
+			log_msg.body.log_FFLW.gyro_x_rate = buf.filtered_flow.gyro_rad_s[0];
+			log_msg.body.log_FFLW.gyro_y_rate = buf.filtered_flow.gyro_rad_s[1];
+			log_msg.body.log_FFLW.gyro_z_rate = buf.filtered_flow.gyro_rad_s[2];
+			log_msg.body.log_FFLW.gyro_x_bias = buf.filtered_flow.gyro_bias[0];
+			log_msg.body.log_FFLW.gyro_y_bias = buf.filtered_flow.gyro_bias[1];
+			log_msg.body.log_FFLW.gyro_z_bias = buf.filtered_flow.gyro_bias[2];
+			LOGBUFFER_WRITE_AND_COUNT(FFLW);
 		}
 
 		/* --- RC CHANNELS --- */

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -505,7 +505,25 @@ struct log_CTS_s {
 	float yaw_rate;
 };
 
+/* WARNING: ID 48, 49 is already in use for estimator innovations */
+
 #define LOG_OUT1_MSG 50
+
+/* --- FFLW - FILTERED OPTICAL FLOW STATUS */
+#define LOG_FFLW_MSG 51
+struct log_FFLW_s {
+	float x_vel_integ;
+	float y_vel_integ;
+	float x_vel;
+	float y_vel;
+	float gyro_x_rate;
+	float gyro_y_rate;
+	float gyro_z_rate;
+	float gyro_x_bias;
+	float gyro_y_bias;
+	float gyro_z_bias;
+};
+
 
 /********** SYSTEM MESSAGES, ID > 0x80 **********/
 
@@ -582,6 +600,7 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT(ENCD, "qfqf",	"cnt0,vel0,cnt1,vel1"),
 	LOG_FORMAT(TSYN, "Q", 		"TimeOffset"),
 	LOG_FORMAT(MACS, "fff", "RRint,PRint,YRint"),
+	LOG_FORMAT(FFLW, "ffffffffff", "XIntg,YIntg,VelX,VelY,RateX,RateY,RateZ,BiasX,BiasY,BiasZ"),
 
 	/* system-level messages, ID >= 0x80 */
 	/* FMT: don't write format of format message, it's useless */

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -733,6 +733,24 @@ PARAM_DEFINE_FLOAT(SENS_BOARD_X_OFF, 0.0f);
 PARAM_DEFINE_FLOAT(SENS_BOARD_Z_OFF, 0.0f);
 
 /**
+ * PX4Flow module offset (from center of rotation) in X direction
+ *
+ * This parameter defines the translational offset (X) of the PX4Flow board for yaw-rotation compensation
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(SENS_FLOW_X_OFF, 0.0f);
+
+/**
+ * PX4Flow module offset (from center of rotation) in Y direction
+ *
+ * This parameter defines the translational offset (Y) of the PX4Flow board for yaw-rotation compensation
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(SENS_FLOW_Y_OFF, 0.0f);
+
+/**
  * External magnetometer rotation
  *
  * This parameter defines the rotation of the external magnetometer relative

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -739,7 +739,7 @@ PARAM_DEFINE_FLOAT(SENS_BOARD_Z_OFF, 0.0f);
  *
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_FLOW_X_OFF, 0.0f);
+PARAM_DEFINE_FLOAT(SENS_FLW_XOFF, 0.0f);
 
 /**
  * PX4Flow module offset (from center of rotation) in Y direction
@@ -748,7 +748,7 @@ PARAM_DEFINE_FLOAT(SENS_FLOW_X_OFF, 0.0f);
  *
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_FLOW_Y_OFF, 0.0f);
+PARAM_DEFINE_FLOAT(SENS_FLW_YOFF, 0.0f);
 
 /**
  * External magnetometer rotation


### PR DESCRIPTION
See commit messages for exact changes. This fixes all outstanding LPE flow bugs as well.

Essentially this adds : 
- Automatic lidar/sonar detection and use. Auto-uses whichever one is available, or both.
- yaw rotation compensation
- gyro bias estimation for flow board gyro
- logging for flow gyro bias
- high-performance altitude hold for multi-copters using LPE estimator and any suitable rangefinder.(#3188)

To test this state, flash the latest flow firmware and then the PX4 firmware like this :
```
make px4fmu-v2_lpe upload
```
This results in this video (position control from 0:12 to 0:28) : 
[![.](http://img.youtube.com/vi/513MnFSAVS0/0.jpg)](http://www.youtube.com/watch?v=513MnFSAVS0 "LPE high-performance optical flow estimation")

@jgoppert @LorenzMeier @kd0aij @AndreasAntener 