### PR TITLE
BUGFIX:Take 2! CLI "commander calibrate acel" resulted in hardfault

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -301,7 +301,7 @@ int commander_main(int argc, char *argv[])
 		daemon_task = px4_task_spawn_cmd("commander",
 					     SCHED_DEFAULT,
 					     SCHED_PRIORITY_MAX - 40,
-					     3500,
+					     3600,
 					     commander_thread_main,
 					     (char * const *)&argv[0]);
 
@@ -1304,7 +1304,7 @@ int commander_thread_main(int argc, char *argv[])
 	/* initialize low priority thread */
 	pthread_attr_t commander_low_prio_attr;
 	pthread_attr_init(&commander_low_prio_attr);
-	pthread_attr_setstacksize(&commander_low_prio_attr, 2600);
+	pthread_attr_setstacksize(&commander_low_prio_attr, 2880);
 
 	struct sched_param param;
 	(void)pthread_attr_getschedparam(&commander_low_prio_attr, &param);


### PR DESCRIPTION
Processes: 20 total, 4 running, 16 sleeping
CPU usage: 65.19% tasks, 0.56% sched, 34.24% idle
Uptime: 387.573s total, 135.045s idle

 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE
   0 Idle Task                  135045 34.242     0/    0   0 (  0)  READY
   1 hpwork                       7495  1.693   956/ 1592 192 (192)  w:sig
   2 lpwork                       1576  0.376   572/ 1592  50 ( 50)  w:sig
   3 init                         1655  0.000  1404/ 2496 100 (100)  w:sem
 170 top                             9  0.000  1204/ 1696 100 (100)  RUN
  87 dataman                         1  0.000   652/ 1192  90 ( 90)  w:sem
 105 sensors                     31810  8.090  1644/ 1992 250 (250)  w:sem
 107 gps                          1217  0.000   708/ 1192 220 (220)  w:sem
 109 commander                   49016 17.027  3412/ 3596 215 (215)  w:sig +100 184 head room
 114 mavlink_if0                  2607  0.564  2092/ 2392 100 (100)  READY
 115 mavlink_rcv_if0                27  0.000   804/ 2096 175 (175)  w:sem
 122 sdlog2                        849  0.188  2068/ 2992  70 ( 70)  READY
 125 commander_low_prio           4678  0.000  2740/ 2872  50 ( 50)  w:sem +200 132 head room
 142 attitude_estimator_q        65555 16.933  1956/ 2096 250 (250)  w:sem
 144 position_estimator_inav     23877  6.208  4588/ 4992 250 (250)  w:sem
 148 mc_att_control              31210  7.902  1132/ 1496 250 (250)  w:sem
 150 mc_pos_control               2901  0.658  1044/ 1496 250 (250)  w:sem
 155 navigator                    2219  0.470   828/ 1496 105 (105)  w:sem
 165 mavlink_if1                 21195  5.079  2156/ 2392 100 (100)  w:sig
 167 mavlink_rcv_if1               116  0.000  1236/ 2096 175 (175)  w:sem