### PR TITLE
WIP: fix LidarLite PWM driver for missing pulses

### DIFF
--- a/src/drivers/ll40ls/LidarLitePWM.cpp
+++ b/src/drivers/ll40ls/LidarLitePWM.cpp
@@ -179,6 +179,8 @@ int LidarLitePWM::measure()
 		return ERROR;
 	}
 
+	static uint64_t lastTimeStamp = 0;
+
 	_range.timestamp = hrt_absolute_time();
 	_range.type = distance_sensor_s::MAV_DISTANCE_SENSOR_LASER;
 	_range.max_distance = get_maximum_distance();
@@ -195,6 +197,15 @@ int LidarLitePWM::measure()
 		perf_end(_sample_perf);
 		return reset_sensor();
 	}
+
+	// for distances near zero (and possibly for distances > 60m), no PWM pulse is generated
+	// At 60m AGL, the PWM pulse will be 60*100*10 usec long, and the period will be slightly longer
+	uint32_t period = _range.timestamp - lastTimeStamp;
+	if (period > 60000) {
+		//printf("lidar pulse period: %d\n", period);
+		_range.current_distance = 0.0f;
+	}
+	lastTimeStamp = _range.timestamp;
 
 	if (_distance_sensor_topic != nullptr) {
 		orb_publish(ORB_ID(distance_sensor), _distance_sensor_topic, &_range);


### PR DESCRIPTION
@mhkabir LidarLite V1 stops generating pulses when the range drops below 0cm (or possibly there is no return pulse when the ground is too close). The current driver logic falsely reports large distances when pulses resume.
This change modifies the driver to return a range of zero when the pulse period is greater than 60msec.
The choice of zero range (rather than some maximum value) allows one to take off in ALTCTL mode without major glitches in distance readings. Perhaps it would be preferable to use NaN instead to indicate lack of data, but that might require additional modifications to consumers of DIST data.