### PR TITLE
Fix att_estimator_q slowly reacting to declination change #3270

### DIFF
--- a/src/lib/mathlib/math/Quaternion.hpp
+++ b/src/lib/mathlib/math/Quaternion.hpp
@@ -212,6 +212,16 @@ public:
 	}
 
 	/**
+	 * simplified version of the above method to create quaternion representing rotation only by yaw
+	 */
+	void from_yaw(float yaw) {
+		data[0] = cosf(yaw / 2.0f);
+		data[1] = 0.0f;
+		data[2] = 0.0f;
+		data[3] = sinf(yaw / 2.0f);
+	}
+
+	/**
 	 * create Euler angles vector from the quaternion
 	 */
 	Vector<3> to_euler() const {

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -202,6 +202,9 @@ private:
 	bool init();
 
 	bool update(float dt);
+
+	// Update magnetic declination (in rads) immediately changing yaw rotation
+	void update_mag_declination(float new_declination);
 };
 
 
@@ -503,7 +506,7 @@ void AttitudeEstimatorQ::task_main()
 
 			if (_mag_decl_auto && _gpos.eph < 20.0f && hrt_elapsed_time(&_gpos.timestamp) < 1000000) {
 				/* set magnetic declination automatically */
-				_mag_decl = math::radians(get_mag_declination(_gpos.lat, _gpos.lon));
+				update_mag_declination(math::radians(get_mag_declination(_gpos.lat, _gpos.lon)));
 			}
 		}
 
@@ -631,7 +634,7 @@ void AttitudeEstimatorQ::update_parameters(bool force)
 		param_get(_params_handles.w_gyro_bias, &_w_gyro_bias);
 		float mag_decl_deg = 0.0f;
 		param_get(_params_handles.mag_decl, &mag_decl_deg);
-		_mag_decl = math::radians(mag_decl_deg);
+		update_mag_declination(math::radians(mag_decl_deg));
 		int32_t mag_decl_auto_int;
 		param_get(_params_handles.mag_decl_auto, &mag_decl_auto_int);
 		_mag_decl_auto = mag_decl_auto_int != 0;
@@ -666,6 +669,12 @@ bool AttitudeEstimatorQ::init()
 
 	// Convert to quaternion
 	_q.from_dcm(R);
+
+	// Compensate for magnetic declination
+	Quaternion decl_rotation;
+	decl_rotation.from_yaw(_mag_decl);
+	_q = decl_rotation * _q;
+
 	_q.normalize();
 
 	if (PX4_ISFINITE(_q(0)) && PX4_ISFINITE(_q(1)) &&
@@ -767,6 +776,19 @@ bool AttitudeEstimatorQ::update(float dt)
 	return true;
 }
 
+void AttitudeEstimatorQ::update_mag_declination(float new_declination) {
+	// Apply initial declination or trivial rotations without changing estimation
+	if (!_inited || fabsf(new_declination - _mag_decl) < 0.0001f) {
+		_mag_decl = new_declination;
+	}
+	else {
+		// Immediately rotate current estimation to avoid gyro bias growth
+		Quaternion decl_rotation;
+		decl_rotation.from_yaw(new_declination - _mag_decl);
+		_q = decl_rotation * _q;
+		_mag_decl = new_declination;
+	}
+}
 
 int attitude_estimator_q_main(int argc, char *argv[])
 {

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -776,12 +776,13 @@ bool AttitudeEstimatorQ::update(float dt)
 	return true;
 }
 
-void AttitudeEstimatorQ::update_mag_declination(float new_declination) {
+void AttitudeEstimatorQ::update_mag_declination(float new_declination)
+{
 	// Apply initial declination or trivial rotations without changing estimation
 	if (!_inited || fabsf(new_declination - _mag_decl) < 0.0001f) {
 		_mag_decl = new_declination;
-	}
-	else {
+
+	} else {
 		// Immediately rotate current estimation to avoid gyro bias growth
 		Quaternion decl_rotation;
 		decl_rotation.from_yaw(new_declination - _mag_decl);


### PR DESCRIPTION
This fixes the slow reaction and stops the estimator from calculating the false gyro bias by applying the declination instantly when the parameter changes or GPS-calculated declination greatly differs.
Screenshot of the same scenario as described in the issue:
![yawvsmag](https://cloud.githubusercontent.com/assets/8501086/11407436/780f48e0-93bb-11e5-932e-f33189b313d0.png)

Tested on the table, but similar fix was tested in a different fork in simulator.
I'm not sure if arbitrary chosen "ignorable" change of declination by 0.0001f is any good. Seemed ok in simulator. I've added this to avoid calls to expensive decl_rotation.from_yaw (sin and cos calls) and quaternion multiplication on each GPS declination update.