### PR TITLE
lower default gains for qav_250 to be on the safe side

### DIFF
--- a/ROMFS/px4fmu_common/init.d/4009_qav250
+++ b/ROMFS/px4fmu_common/init.d/4009_qav250
@@ -15,14 +15,14 @@ sh /etc/init.d/4001_quad_x
 
 if [ $AUTOCNF == yes ]
 then
-	param set MC_ROLL_P 7.0
-	param set MC_ROLLRATE_P 0.05
+	param set MC_ROLL_P 6.0
+	param set MC_ROLLRATE_P 0.04
 	param set MC_ROLLRATE_I 0.05
-	param set MC_ROLLRATE_D 0.002
-	param set MC_PITCH_P 7.0
-	param set MC_PITCHRATE_P 0.08
-	param set MC_PITCHRATE_I 0.1
-	param set MC_PITCHRATE_D 0.003
+	param set MC_ROLLRATE_D 0.001
+	param set MC_PITCH_P 6.0
+	param set MC_PITCHRATE_P 0.045
+	param set MC_PITCHRATE_I 0.05
+	param set MC_PITCHRATE_D 0.0025
 	param set MC_YAW_P 2.8
 	param set MC_YAWRATE_P 0.2
 	param set MC_YAWRATE_I 0.1


### PR DESCRIPTION
@kd0aij My 250 was oscillating when I tried it with the new XRacer board. We guess that the system has less intertia and therefore the default gains were too high.