### PR TITLE
Rate experiments

### DIFF
--- a/src/drivers/mpu6000/mpu6000.cpp
+++ b/src/drivers/mpu6000/mpu6000.cpp
@@ -192,7 +192,7 @@
 #define MPU6000_GYRO_MAX_OUTPUT_RATE			MPU6000_ACCEL_MAX_OUTPUT_RATE
 #define MPU6000_GYRO_DEFAULT_DRIVER_FILTER_FREQ		30
 
-#define MPU6000_DEFAULT_ONCHIP_FILTER_FREQ		42
+#define MPU6000_DEFAULT_ONCHIP_FILTER_FREQ		188	/* valid values: 42, 98, 188, 256 */
 
 #define MPU6000_ONE_G					9.80665f
 
@@ -1319,14 +1319,14 @@ MPU6000::ioctl(struct file *filp, int cmd, unsigned long arg)
 					// adjust filters
 					float cutoff_freq_hz = _accel_filter_x.get_cutoff_freq();
 					float sample_rate = 1.0e6f / ticks;
-					_set_dlpf_filter(cutoff_freq_hz);
+					//_set_dlpf_filter(cutoff_freq_hz);
 					_accel_filter_x.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
 					_accel_filter_y.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
 					_accel_filter_z.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
 
 
 					float cutoff_freq_hz_gyro = _gyro_filter_x.get_cutoff_freq();
-					_set_dlpf_filter(cutoff_freq_hz_gyro);
+					//_set_dlpf_filter(cutoff_freq_hz_gyro);
 					_gyro_filter_x.set_cutoff_frequency(sample_rate, cutoff_freq_hz_gyro);
 					_gyro_filter_y.set_cutoff_frequency(sample_rate, cutoff_freq_hz_gyro);
 					_gyro_filter_z.set_cutoff_frequency(sample_rate, cutoff_freq_hz_gyro);
@@ -1393,7 +1393,7 @@ MPU6000::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case ACCELIOCSLOWPASS:
 		// set hardware filtering
-		_set_dlpf_filter(arg);
+		//_set_dlpf_filter(arg);
 		// set software filtering
 		_accel_filter_x.set_cutoff_frequency(1.0e6f / _call_interval, arg);
 		_accel_filter_y.set_cutoff_frequency(1.0e6f / _call_interval, arg);
@@ -1478,7 +1478,7 @@ MPU6000::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case GYROIOCSLOWPASS:
 		// set hardware filtering
-		_set_dlpf_filter(arg);
+		//_set_dlpf_filter(arg);
 		_gyro_filter_x.set_cutoff_frequency(1.0e6f / _call_interval, arg);
 		_gyro_filter_y.set_cutoff_frequency(1.0e6f / _call_interval, arg);
 		_gyro_filter_z.set_cutoff_frequency(1.0e6f / _call_interval, arg);

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -556,9 +556,9 @@ void AttitudeEstimatorQ::task_main()
 		att.pitch = euler(1);
 		att.yaw = euler(2);
 
-		att.rollspeed = _rates(0);
-		att.pitchspeed = _rates(1);
-		att.yawspeed = _rates(2);
+		att.rollspeed = sensors.gyro_rad_s[best_gyro * 3 + 0] + _gyro_bias(0); //_rates(0);
+		att.pitchspeed = sensors.gyro_rad_s[best_gyro * 3 + 1] + _gyro_bias(1); //_rates(1);
+		att.yawspeed = sensors.gyro_rad_s[best_gyro * 3 + 2] + _gyro_bias(2); //_rates(2);
 
 		for (int i = 0; i < 3; i++) {
 			att.g_comp[i] = _accel(i) - _pos_acc(i);
@@ -598,11 +598,11 @@ void AttitudeEstimatorQ::task_main()
 		ctrl_state.q[3] = _q(3);
 
 		/* Attitude rates for control state */
-		ctrl_state.roll_rate = _lp_roll_rate.apply(_rates(0));
+		ctrl_state.roll_rate = sensors.gyro_rad_s[best_gyro * 3 + 0] + _gyro_bias(0);//_lp_roll_rate.apply(_rates(0));
 
-		ctrl_state.pitch_rate = _lp_pitch_rate.apply(_rates(1));
+		ctrl_state.pitch_rate = sensors.gyro_rad_s[best_gyro * 3 + 1] + _gyro_bias(1);//_lp_pitch_rate.apply(_rates(1));
 
-		ctrl_state.yaw_rate = _lp_yaw_rate.apply(_rates(2));
+		ctrl_state.yaw_rate = sensors.gyro_rad_s[best_gyro * 3 + 2] + _gyro_bias(2);//_lp_yaw_rate.apply(_rates(2));
 
 		/* Airspeed - take airspeed measurement directly here as no wind is estimated */
 		ctrl_state.airspeed = _airspeed.indicated_airspeed_m_s;


### PR DESCRIPTION
@tumbili Note that the issues with the Pixracer were due to slow PWM output updates. This is already fixed. However, people also have issues with Pixhawk. These commits try different approaches of increasing the phase margin:

  * The first commit just increases the cutoff frequency. That should be pretty safe
  * The 2nd commit disables the internal hardware filters almost entirely and only relies on the software filtering. This needs testing, but should be fine.
  * The 3rd commit switches from the low passed estimate based on the integral to the directly low-passed gyro. This might have benefits in terms of noise to phase margin.

I would like to get to a point where there is no gain difference between stable and master.