### PR TITLE
MPU6000: Correct temperature scaling for use with ICM20608

### DIFF
--- a/src/drivers/mpu6000/mpu6000.cpp
+++ b/src/drivers/mpu6000/mpu6000.cpp
@@ -1915,7 +1915,14 @@ MPU6000::measure()
 	arb.scaling = _accel_range_scale;
 	arb.range_m_s2 = _accel_range_m_s2;
 
-	_last_temperature = (report.temp) / 361.0f + 35.0f;
+    if(is_icm_device()) // if it is an ICM20608
+    {
+        _last_temperature = (report.temp) / 326.8f + 25.0f;
+    }
+    else // If it is an MPU6000
+    {
+        _last_temperature = (report.temp) / 361.0f + 35.0f;
+    }
 
 	arb.temperature_raw = report.temp;
 	arb.temperature = _last_temperature;


### PR DESCRIPTION
Fixes the temperature scaling issue, so that the MPU6000 driver can be used with ICM20608 chip.

The MPU6000 temperature conversion  to degC is:
  temp_degC = TEMP_out / 361.0f + 35.0f;
where as the ICM20608 temperature conversion  to degC is:
  temp_degC = TEMP_out / 326.8f + 25.0f;

Fixes #3300.