### PR TITLE
Added configuration file for coaxial helicopter

### DIFF
--- a/ROMFS/px4fmu_common/init.d/15001_coax_heli
+++ b/ROMFS/px4fmu_common/init.d/15001_coax_heli
@@ -1,0 +1,65 @@
+#!nsh
+#
+# @name Coaxial Helicopter (such as Esky Lama v4 or Esky Big Lama)
+#
+# @type Coaxial Helicopter
+# 
+# @output MAIN1 Left swashplate servomotor, pitch axis
+# @output MAIN2 Right swashplate servomotor, roll axis
+# @output MAIN3 Upper rotor (CCW)
+# @output MAIN4 Lower rotor (CW)
+#
+# @maintainer Emmanuel Roussel
+#
+
+set VEHICLE_TYPE mc
+
+if [ $AUTOCNF == yes ]
+then
+	param set PE_VELNE_NOISE 0.5
+	param set PE_VELD_NOISE 0.35
+	param set PE_POSNE_NOISE 0.5
+	param set PE_POSD_NOISE 1.25
+
+	param set NAV_ACC_RAD 2.0
+	param set RTL_RETURN_ALT 30.0
+	param set RTL_DESCEND_ALT 10.0
+
+	param set PWM_DISARMED 900
+	param set PWM_MIN 1075
+	param set PWM_MAX 1950
+
+	param set MC_ROLL_P 6.5
+	param set MC_ROLLRATE_P 0.17
+	param set MC_ROLLRATE_I 0.05
+	param set MC_ROLLRATE_D 0.005
+	param set MC_ROLLRATE_FF 0
+	param set MC_PITCH_P 6.5
+	param set MC_PITCHRATE_P 0.17
+	param set MC_PITCHRATE_I 0.05
+	param set MC_PITCHRATE_D 0.005
+	param set MC_PITCHRATE_FF 0
+	param set MC_YAW_P 2
+	param set MC_YAW_FF 0.5
+	param set MC_YAWRATE_P 0.1
+	param set MC_YAWRATE_I 0.1
+	param set MC_YAWRATE_D 0.0
+	param set MC_YAWRATE_FF 0
+fi
+
+set MIXER coax
+# use PWM parameters for throttle channel
+set PWM_OUT 34
+set PWM_RATE 400
+set PWM_DISARMED p:PWM_DISARMED
+set PWM_MIN p:PWM_MIN
+set PWM_MAX p:PWM_MAX
+
+# This is the gimbal pass mixer
+set MIXER_AUX pass
+set PWM_AUX_RATE 50
+set PWM_AUX_OUT 1234
+set PWM_AUX_DISARMED 1500
+set PWM_AUX_MIN 1000
+set PWM_AUX_MAX 2000
+

--- a/ROMFS/px4fmu_common/mixers/coax.main.mix
+++ b/ROMFS/px4fmu_common/mixers/coax.main.mix
@@ -1,0 +1,33 @@
+Coaxial helicopter mixer
+- Two servomotors act on the swashplate (90° angle on the swashplate, decoupled effect on roll and pitch).
+- No collective pitch.
+- One motor per rotor.
+===========================
+
+Left swashplate servomotor, pitch axis
+-------------
+M: 1
+O:      10000  10000      0 -10000  10000
+S: 0 1  -10000  -10000      0 -10000  10000
+
+Right swashplate servomotor, roll axis
+-------------
+M: 1
+O:      10000  10000      0 -10000  10000
+S: 0 0  10000  10000      0 -10000  10000
+
+Upper rotor (CCW)
+Mixing between yaw and thrust
+-------------
+M: 2
+O:      10000  10000      0 -10000  10000
+S: 0 2  10000  10000      0 -10000  10000
+S: 0 3      0  20000 -10000 -10000  10000
+
+Lower rotor (CW)
+Mixing between yaw and thrust
+-------------
+M: 2
+O:      10000  10000      0 -10000  10000
+S: 0 2  -10000  -10000      0 -10000  10000
+S: 0 3      0  20000 -10000 -10000  10000


### PR DESCRIPTION
- New configuration file for coaxial helicopter airframe.
- Default PID gains for stable flight with tested airframe (based on Esky Lama v4).

see here for a short video using this configuration: https://vimeo.com/145538599
and this thread: https://groups.google.com/forum/#!searchin/px4users/helicopter/px4users/DfMwAbL2Xl0/bTCL3d2dDgAJ
