### PR TITLE
Avoid violation of acos' domain in map_projection

### DIFF
--- a/src/lib/geo/geo.c
+++ b/src/lib/geo/geo.c
@@ -149,11 +149,14 @@ __EXPORT int map_projection_project(const struct map_projection_reference_s *ref
 	double cos_d_lon = cos(lon_rad - ref->lon_rad);
 
 	double arg = ref->sin_lat * sin_lat + ref->cos_lat * cos_lat * cos_d_lon;
+
 	if (arg > 1.0) {
 		arg = 1.0;
+
 	} else if (arg < -1.0) {
 		arg = -1.0;
 	}
+
 	double c = acos(arg);
 	double k = (fabs(c) < DBL_EPSILON) ? 1.0 : (c / sin(c));
 

--- a/src/lib/geo/geo.c
+++ b/src/lib/geo/geo.c
@@ -148,7 +148,13 @@ __EXPORT int map_projection_project(const struct map_projection_reference_s *ref
 	double cos_lat = cos(lat_rad);
 	double cos_d_lon = cos(lon_rad - ref->lon_rad);
 
-	double c = acos(ref->sin_lat * sin_lat + ref->cos_lat * cos_lat * cos_d_lon);
+	double arg = ref->sin_lat * sin_lat + ref->cos_lat * cos_lat * cos_d_lon;
+	if (arg > 1.0) {
+		arg = 1.0;
+	} else if (arg < -1.0) {
+		arg = -1.0;
+	}
+	double c = acos(arg);
 	double k = (fabs(c) < DBL_EPSILON) ? 1.0 : (c / sin(c));
 
 	*x = k * (ref->cos_lat * sin_lat - ref->sin_lat * cos_lat * cos_d_lon) * CONSTANTS_RADIUS_OF_EARTH;


### PR DESCRIPTION
* There are pathological cases (e.g., setpoint very close to reference
  for certain reference latitudes), where numerical errors lead to a sum
  larger than 1.0 passed to acos, resulting in NaN values.
* This code is not tested

This should fix issue #2813