### PR TITLE
Support of Bootloader Rev 5 - silicon rev check 

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -148,6 +148,7 @@ class uploader(object):
         OK              = b'\x10'
         FAILED          = b'\x11'
         INVALID         = b'\x13'     # rev3+
+        BAD_SILICON_REV = b'\x14'     # rev5+
 
         # command bytes
         NOP             = b'\x00'     # guaranteed to be discarded by the bootloader
@@ -162,11 +163,14 @@ class uploader(object):
         GET_SN          = b'\x2b'     # rev4+  , get a word from SN area
         GET_CHIP        = b'\x2c'     # rev5+  , get chip version
         SET_BOOT_DELAY  = b'\x2d'     # rev5+  , set boot delay
+        GET_CHIP_DES    = b'\x2e'     # rev5+  , get chip description in ASCII
+        MAX_DES_LENGTH  = 20
+
         REBOOT          = b'\x30'
         
         INFO_BL_REV     = b'\x01'        # bootloader protocol revision
-        BL_REV_MIN      = 2             # minimum supported bootloader protocol 
-        BL_REV_MAX      = 4             # maximum supported bootloader protocol 
+        BL_REV_MIN      = 2              # minimum supported bootloader protocol
+        BL_REV_MAX      = 5              # maximum supported bootloader protocol
         INFO_BOARD_ID   = b'\x02'        # board type
         INFO_BOARD_REV  = b'\x03'        # board revision
         INFO_FLASH_SIZE = b'\x04'        # max firmware size in bytes
@@ -235,12 +239,16 @@ class uploader(object):
                     if (self.__recv() != self.INSYNC):
                             #print("unexpected 0x%x instead of INSYNC" % ord(c))
                             return False;
-
-                    if (self.__recv() != self.OK):
+                    c = self.__recv()
+                    if (c == self.BAD_SILICON_REV):
+                        raise NotImplementedError()
+                    if (c != self.OK):
                             #print("unexpected 0x%x instead of OK" % ord(c))
                             return False
                     return True
 
+                except NotImplementedError:
+                    raise RuntimeError("Programing not supported for this version of silicon!\n See https://pixhawk.org/help/errata")
                 except RuntimeError:
                     #timeout, no response yet
                     return False
@@ -274,6 +282,14 @@ class uploader(object):
                 value = self.__recv_int()
                 self.__getSync()
                 return value
+        # send the GET_CHIP command
+        def __getCHIPDes(self):
+                self.__send(uploader.GET_CHIP_DES + uploader.EOC)
+                length = self.__recv_int()
+                value = self.__recv(length)
+                self.__getSync()
+                peices = value.split(",")
+                return peices
 
         def __drawProgressBar(self, label, progress, maxVal):
                 if maxVal < progress:
@@ -467,6 +483,12 @@ class uploader(object):
                                     print(binascii.hexlify(x).decode('Latin-1'), end='') # show user
                             print('')
                             print("chip: %08x" % self.__getCHIP())
+                            if (self.bl_rev >= 5):
+                                des = self.__getCHIPDes()
+                                if (len(des) == 2):
+                                    print("family: %s" % des[0])
+                                    print("revision: %s" % des[1])
+                                    print("flash %d" % self.fw_maxsize)
                     except Exception:
                             # ignore bad character encodings
                             pass

--- a/src/drivers/px4io/uploader.h
+++ b/src/drivers/px4io/uploader.h
@@ -76,7 +76,7 @@ private:
 		PROTO_REBOOT			= 0x30,
 
 		INFO_BL_REV			= 1,		/**< bootloader protocol revision */
-			BL_REV			= 5,		/**< supported bootloader protocol  */
+		BL_REV			= 5,		/**< supported bootloader protocol  */
 		INFO_BOARD_ID		= 2,		/**< board type */
 		INFO_BOARD_REV		= 3,		/**< board revision */
 		INFO_FLASH_SIZE		= 4,		/**< max firmware size in bytes */

--- a/src/drivers/px4io/uploader.h
+++ b/src/drivers/px4io/uploader.h
@@ -54,22 +54,29 @@ public:
 private:
 	enum {
 
-		PROTO_NOP		= 0x00,
-		PROTO_OK		= 0x10,
-		PROTO_FAILED		= 0x11,
-		PROTO_INSYNC		= 0x12,
-		PROTO_EOC		= 0x20,
-		PROTO_GET_SYNC		= 0x21,
-		PROTO_GET_DEVICE	= 0x22,
-		PROTO_CHIP_ERASE	= 0x23,
-		PROTO_CHIP_VERIFY	= 0x24,
-		PROTO_PROG_MULTI	= 0x27,
-		PROTO_READ_MULTI	= 0x28,
-		PROTO_GET_CRC		= 0x29,
-		PROTO_REBOOT		= 0x30,
+		PROTO_NOP				= 0x00,
+		PROTO_OK				= 0x10,
+		PROTO_FAILED			= 0x11,
+		PROTO_INSYNC			= 0x12,
+		PROTO_INVALID			= 0x13,
+		PROTO_BAD_SILICON_REV  	= 0x14,
+		PROTO_EOC				= 0x20,
+		PROTO_GET_SYNC			= 0x21,
+		PROTO_GET_DEVICE		= 0x22,
+		PROTO_CHIP_ERASE		= 0x23,
+		PROTO_CHIP_VERIFY		= 0x24,
+		PROTO_PROG_MULTI		= 0x27,
+		PROTO_READ_MULTI		= 0x28,
+		PROTO_GET_CRC			= 0x29,
+		PROTO_GET_OTP			= 0x2a,
+		PROTO_GET_SN			= 0x2b,
+		PROTO_GET_CHIP			= 0x2c,
+		PROTO_SET_DELAY			= 0x2d,
+		PROTO_GET_CHIP_DES		= 0x2e,
+		PROTO_REBOOT			= 0x30,
 
-		INFO_BL_REV		= 1,		/**< bootloader protocol revision */
-		BL_REV			= 4,		/**< supported bootloader protocol  */
+		INFO_BL_REV			= 1,		/**< bootloader protocol revision */
+			BL_REV			= 5,		/**< supported bootloader protocol  */
 		INFO_BOARD_ID		= 2,		/**< board type */
 		INFO_BOARD_REV		= 3,		/**< board revision */
 		INFO_FLASH_SIZE		= 4,		/**< max firmware size in bytes */


### PR DESCRIPTION
Support for Sister PR https://github.com/PX4/Bootloader/pull/47

1) It support Rev 5 and the new ASCII reporting of version and (adjusted) flash flash size
2) FMU side support for Rev 5.