### PR TITLE
circuit_breaker: prevent param fetch failure from disabling safety

### DIFF
--- a/src/modules/systemlib/circuit_breaker.cpp
+++ b/src/modules/systemlib/circuit_breaker.cpp
@@ -48,9 +48,10 @@
 
 bool circuit_breaker_enabled(const char *breaker, int32_t magic)
 {
-	int32_t val;
-	(void)PX4_PARAM_GET_BYNAME(breaker, &val);
-
-	return (val == magic);
+	int32_t val = -1;
+	if (PX4_PARAM_GET_BYNAME(breaker, &val) == 0 && val == magic) {
+		return true;
+	}
+	return false;
 }
 


### PR DESCRIPTION
If the param get failed then an uninitialised stack variable was used
for the safety disable on boot. In ArduPilot that value happened to
equal the correct magic due to stack passing from caller. This forced
safety off on boot