### PR TITLE
Rename the standard VTOL airframe config name to Fun Cub Quad VTOL.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/13005_vtol_AAERT_quad
+++ b/ROMFS/px4fmu_common/init.d/13005_vtol_AAERT_quad
@@ -1,6 +1,6 @@
 #!nsh
 #
-# @name Generic AAERT tailplane airframe with Quad VTOL.
+# @name Fun Cub Quad VTOL.
 #
 # @type Standard VTOL
 #


### PR DESCRIPTION
There seems to be general confusion as to which airframe to select in QGC for a standard VTOL. Renaming the config since this was taken directly from the Fun Cub VTOL plus it will shorten the name that appears in QGC, which is currently too long.

Leaving the config filename as it is as it might still suggest that this can be used for any similar VTOL airframe as a starting point.