### PR TITLE
add rotation for stryker vtol

### DIFF
--- a/cmake/configs/nuttx_px4fmu-v1_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v1_default.cmake
@@ -113,6 +113,7 @@ set(config_module_list
 	lib/launchdetection
 	lib/terrain_estimation
 	lib/runway_takeoff
+	lib/tailsitter_recovery
 	platforms/nuttx
 
 	# had to add for cmake, not sure why wasn't in original config

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -123,6 +123,7 @@ set(config_module_list
 	lib/launchdetection
 	lib/terrain_estimation
 	lib/runway_takeoff
+	lib/tailsitter_recovery
 	platforms/nuttx
 
 	# had to add for cmake, not sure why wasn't in original config

--- a/cmake/configs/nuttx_px4fmu-v4_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v4_default.cmake
@@ -121,6 +121,7 @@ set(config_module_list
 	lib/launchdetection
 	lib/terrain_estimation
 	lib/runway_takeoff
+	lib/tailsitter_recovery
 	platforms/nuttx
 
 	# had to add for cmake, not sure why wasn't in original config

--- a/cmake/configs/posix_eagle_default.cmake
+++ b/cmake/configs/posix_eagle_default.cmake
@@ -40,6 +40,7 @@ set(config_module_list
 	lib/conversion
 	lib/terrain_estimation
 	lib/runway_takeoff
+	lib/tailsitter_recovery
 
 	platforms/common
 	platforms/posix/px4_layer

--- a/cmake/configs/posix_sitl_default.cmake
+++ b/cmake/configs/posix_sitl_default.cmake
@@ -59,6 +59,7 @@ set(config_module_list
 	lib/launchdetection
 	lib/terrain_estimation
 	lib/runway_takeoff
+	lib/tailsitter_recovery
 	)
 
 set(config_extra_builtin_cmds

--- a/cmake/configs/qurt_eagle_hil.cmake
+++ b/cmake/configs/qurt_eagle_hil.cmake
@@ -49,6 +49,7 @@ set(config_module_list
 	lib/conversion
 	lib/terrain_estimation
 	lib/runway_takeoff
+	lib/tailsitter_recovery
 	modules/controllib
 
 	#

--- a/cmake/configs/qurt_eagle_release.cmake
+++ b/cmake/configs/qurt_eagle_release.cmake
@@ -72,6 +72,7 @@ set(config_module_list
 	lib/conversion
 	lib/terrain_estimation
 	lib/runway_takeoff
+	lib/tailsitter_recovery
 
 	#
 	# QuRT port

--- a/cmake/configs/qurt_eagle_travis.cmake
+++ b/cmake/configs/qurt_eagle_travis.cmake
@@ -54,6 +54,7 @@ set(config_module_list
 	lib/ecl
 	lib/terrain_estimation
 	lib/runway_takeoff
+	lib/tailsitter_recovery
 
 	#
 	# QuRT port

--- a/msg/manual_control_setpoint.msg
+++ b/msg/manual_control_setpoint.msg
@@ -38,8 +38,9 @@ float32 aux5			 # default function: payload drop
 
 uint8 mode_switch		 # main mode 3 position switch (mandatory): _MANUAL_, ASSIST, AUTO
 uint8 return_switch		 # return to launch 2 position switch (mandatory): _NORMAL_, RTL
-uint8 rattitude_switch		 # rattitude control 2 position switch (optional): _MANUAL, RATTITUDE
+uint8 rattitude_switch	 # rattitude control 2 position switch (optional): _MANUAL, RATTITUDE
 uint8 posctl_switch		 # position control 2 position switch (optional): _ALTCTL_, POSCTL
 uint8 loiter_switch		 # loiter 2 position switch (optional): _MISSION_, LOITER
 uint8 acro_switch		 # acro 2 position switch (optional): _MANUAL_, ACRO
-uint8 offboard_switch		 # offboard 2 position switch (optional): _NORMAL_, OFFBOARD
+uint8 offboard_switch	 # offboard 2 position switch (optional): _NORMAL_, OFFBOARD
+uint8 kill_switch		 # throttle kill: _NORMAL_, KILL

--- a/msg/rc_channels.msg
+++ b/msg/rc_channels.msg
@@ -1,4 +1,4 @@
-int32 RC_CHANNELS_FUNCTION_MAX=20
+int32 RC_CHANNELS_FUNCTION_MAX=21
 uint8 RC_CHANNELS_FUNCTION_THROTTLE=0
 uint8 RC_CHANNELS_FUNCTION_ROLL=1
 uint8 RC_CHANNELS_FUNCTION_PITCH=2
@@ -19,11 +19,12 @@ uint8 RC_CHANNELS_FUNCTION_PARAM_1=16
 uint8 RC_CHANNELS_FUNCTION_PARAM_2=17
 uint8 RC_CHANNELS_FUNCTION_PARAM_3_5=18
 uint8 RC_CHANNELS_FUNCTION_RATTITUDE=19
+uint8 RC_CHANNELS_FUNCTION_KILLSWITCH=20
 uint64 timestamp						# Timestamp in microseconds since boot time
 uint64 timestamp_last_valid					# Timestamp of last valid RC signal
-float32[20] channels						# Scaled to -1..1 (throttle: 0..1)
+float32[18] channels						# Scaled to -1..1 (throttle: 0..1)
 uint8 channel_count						# Number of valid channels
-int8[20] function						# Functions mapping
+int8[21] function						# Functions mapping
 uint8 rssi							# Receive signal strength index
 bool signal_lost						# Control signal lost, should be checked together with topic timeout
 uint32 frame_drop_count						# Number of dropped frames

--- a/src/lib/conversion/rotation.cpp
+++ b/src/lib/conversion/rotation.cpp
@@ -233,5 +233,10 @@ rotate_3f(enum Rotation rot, float &x, float &y, float &z)
 			y = -y;
 			return;
 		}
+	case ROTATION_PITCH_90_ROLL_90: {
+			tmp = x; x = y;
+			y = -z; z = -tmp;
+			return;
+		}
 	}
 }

--- a/src/lib/conversion/rotation.cpp
+++ b/src/lib/conversion/rotation.cpp
@@ -233,6 +233,7 @@ rotate_3f(enum Rotation rot, float &x, float &y, float &z)
 			y = -y;
 			return;
 		}
+
 	case ROTATION_PITCH_90_ROLL_90: {
 			tmp = x; x = y;
 			y = -z; z = -tmp;

--- a/src/lib/conversion/rotation.h
+++ b/src/lib/conversion/rotation.h
@@ -77,6 +77,7 @@ enum Rotation {
 	ROTATION_ROLL_270_YAW_270    = 26,
 	ROTATION_ROLL_180_PITCH_270  = 27,
 	ROTATION_PITCH_90_YAW_180    = 28,
+	ROTATION_PITCH_90_ROLL_90	 = 29,
 	ROTATION_MAX
 };
 
@@ -115,7 +116,8 @@ const rot_lookup_t rot_lookup[] = {
 	{  0, 270,   0 },
 	{270,   0, 270 },
 	{180, 270,   0 },
-	{  0,  90, 180 }
+	{  0,  90, 180 },
+	{ 90,  90,   0 }
 };
 
 /**

--- a/src/lib/tailsitter_recovery/CMakeLists.txt
+++ b/src/lib/tailsitter_recovery/CMakeLists.txt
@@ -1,0 +1,42 @@
+############################################################################
+#
+#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+px4_add_module(
+	MODULE lib__tailsitter_recovery
+	COMPILE_FLAGS
+		-Os
+	SRCS
+		tailsitter_recovery.cpp
+	DEPENDS
+		platforms__common
+	)
+# vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/lib/tailsitter_recovery/tailsitter_recovery.cpp
+++ b/src/lib/tailsitter_recovery/tailsitter_recovery.cpp
@@ -1,0 +1,182 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file tailsitter_recovery.cpp
+*/
+
+#include "tailsitter_recovery.h"
+#include <math.h>
+
+TailsitterRecovery::TailsitterRecovery():
+	_in_recovery_mode(false)
+{
+	_att_p(0) = _att_p(1) = _att_p(2) = 4.0f;
+}
+
+TailsitterRecovery::~TailsitterRecovery()
+{
+
+}
+
+void TailsitterRecovery::setAttGains(math::Vector<3> &att_p, float yaw_ff)
+{
+	_att_p = att_p;
+	_yaw_ff = yaw_ff;
+}
+
+void TailsitterRecovery::calcOptimalRates(math::Quaternion &q, math::Quaternion &q_sp, float yaw_move_rate,
+		math::Vector<3> &rates_opt)
+{
+	math::Matrix<3, 3> R = q.to_dcm();
+
+	// compute error quaternion
+	math::Quaternion q_sp_inv = {q_sp(0), -q_sp(1), -q_sp(2), -q_sp(3)};
+	math::Quaternion q_error = q * q_sp_inv;
+
+	// compute tilt angle and corresponding tilt axis
+	math::Vector<3> zB = {0, 0, -1.0f};
+
+	math::Vector<3> zI = q_error.conjugate(zB);
+
+	float tilt_angle;
+	float inner_prod = zI * zB;
+
+	if (inner_prod >= 1.0f) {
+		tilt_angle = 0.0f;
+
+	} else if (inner_prod <= -1.0f) {
+		tilt_angle = M_PI_F;
+
+	} else {
+		tilt_angle = acosf(inner_prod);
+	}
+
+	math::Vector<3> tilt_axis = {0, 0, -1};
+
+	if (math::min(fabsf(tilt_angle), fabsf(tilt_angle - M_PI_F)) > 0.00001f) {
+		tilt_axis = zI % zB;
+	}
+
+	tilt_axis = R.transposed() * tilt_axis;
+
+	// compute desired rates based on tilt angle and tilt axis
+	float tilt_dir = atan2f(tilt_axis(0), tilt_axis(1));
+	float sign_x;
+	float sign_y;
+	float sign_z;
+
+	if (tilt_dir < -M_PI_2_F) {
+		tilt_dir += M_PI_F;
+		sign_x = -1;
+		sign_y = -1;
+		sign_z = 1;
+
+	} else if (tilt_dir < 0.0f) {
+		tilt_dir = 0.0f - tilt_dir;
+		sign_x = -1;
+		sign_y = 1;
+		sign_z = -1;
+
+	} else if (tilt_dir < M_PI_2_F) {
+		tilt_dir += 0;
+		sign_x = 1;
+		sign_y = 1;
+		sign_z = 1;
+
+	} else {
+		tilt_dir = M_PI_F - tilt_dir;
+		sign_x = 1;
+		sign_y = -1;
+		sign_z = -1;
+	}
+
+	// optimal coefficients
+	float pwx_kx1 = -1.676f;
+	float pwx_ky1 = 1.38f;
+	float pwx_ky2 = 0.8725f;
+	float pwx_sx0 = 0.3586f;
+	float pwx_sx1 = 2.642f;
+
+	float pwy_kx1 = -3.997f;
+	float pwy_sx0 = 2.133f;
+	float pwy_sx1 = 4.013f;
+
+	float pwz_kx1 = 2.726f;
+	float pwz_ky1 = 3.168f;
+	float pwz_ky2 = -0.3913f;
+	float pwz_sx0 = 1.75f;
+	float pwz_sx1 = 2.298f;
+
+	float x = tilt_angle;
+	float y = tilt_dir;
+
+	rates_opt(1) = (pwx_ky1 * (M_PI_2_F - y) + pwx_ky2 * powf(M_PI_2_F - y, 2)) *
+		       (pwx_kx1 * x * SigmoidFunction(pwx_sx1 * (pwx_sx0 - x)) - pwx_kx1 * x * expf(pwx_sx1 *
+				       (pwx_sx0 - M_PI_F)) * SigmoidFunction(pwx_sx1 * (M_PI_F - pwx_sx0)));
+	rates_opt(0) = pwy_kx1 * x + powf((M_PI_2_F - y) / (M_PI_2_F),
+					  2) * (-pwy_kx1 * x * SigmoidFunction(pwy_sx1 * (pwy_sx0 - x)));
+	rates_opt(2) = (pwz_ky1 * (M_PI_2_F - y) + pwz_ky2 * powf(M_PI_2_F - y, 2)) *
+		       (pwz_kx1 * (x - M_PI_F) * SigmoidFunction(pwz_sx1 * (x - pwz_sx0)) - pwz_kx1 * (x - M_PI_F) * SigmoidFunction(
+				-pwz_sx0 * pwz_sx1));
+	rates_opt(0) *= -sign_x;
+	rates_opt(1) *= -sign_y * 1.5f;
+	rates_opt(2) *= -sign_z;
+
+	float yaw_w = R(2, 2) > 0.0f ? R(2, 2) : 0.0f;
+	yaw_w = math::constrain(yaw_w, 0.0f, 1.0f);
+
+	// we activate recovery mode if our tilt error is more that 30 degrees or
+	if (!_in_recovery_mode) {
+		if (fabsf(tilt_angle) > math::radians(30.0f)) {
+			_in_recovery_mode = true;
+		}
+
+	} else {
+		if (fabsf(tilt_angle) < math::radians(5.0f)) {
+			_in_recovery_mode = false;
+		}
+	}
+
+	// do normal attitude control, the other case has already been handled
+	if (!_in_recovery_mode) {
+		q_error = q_sp_inv * q;
+		rates_opt = q_error(0) > 0.0f ? _att_p.emult(q_error.imag()) * (-2.0f) : _att_p.emult(q_error.imag()) * (2.0f);
+		// don't want too strong yaw control. after recovery vehicle might have
+		// very large yaw error and shouldn't turn too fast
+		rates_opt(2) = math::constrain(rates_opt(2), -1.0f, 1.0f);
+	}
+
+	rates_opt(2) += yaw_move_rate * yaw_w * _yaw_ff;
+
+}

--- a/src/lib/tailsitter_recovery/tailsitter_recovery.h
+++ b/src/lib/tailsitter_recovery/tailsitter_recovery.h
@@ -1,0 +1,74 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file tailsitter_recovery.h
+ *
+ * Tailsitter optimal rate controller (underactuated pitch axis)
+ *
+ * This function can be used to compute desired body rates of a tailsitter
+ * suffering from an underactuated pitch axis. Tailsitters which produce a pitching moment
+ * from airflow over control surfaces mostly suffer from an underactuated pitch axis.
+ * This functions captures the solution of an optimal control problem which minimises
+ * the vehicle's tilt error and which penalises the desired rates of the underactuated
+ * pitch axis.
+ * Publication:
+ * Robin Ritz and Raffaello D'Andrea. A Global Strategy for Tailsitter Hover Control.
+ *
+ * @author Roman Bapst <bapstroman@gmail.com>
+*/
+#include <lib/mathlib/mathlib.h>
+
+#define SigmoidFunction(val) 1/(1 + expf(-val))
+
+class TailsitterRecovery
+{
+public:
+	TailsitterRecovery();
+	~TailsitterRecovery();
+
+	// Calculate the optimal rates:
+	// If the vehicle is not in need of a recovery, this function will do normal
+	// attitude control based on attitude error. If a recovery situation is detected
+	// then the rates are computed in an optimal way as described above.
+	void calcOptimalRates(math::Quaternion &q, math::Quaternion &q_sp, float yaw_move_rate, math::Vector<3> &rates_opt);
+
+	// Set the gains of the controller attitude loop.
+	void setAttGains(math::Vector<3> &att_p, float yaw_ff);
+
+private:
+	bool _in_recovery_mode;	// indicates that the tailsitter is performing a recovery to hover
+
+	math::Vector<3> _att_p;	// gains for attitude loop
+	float _yaw_ff;			// yaw feed forward gain
+};

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2236,15 +2236,15 @@ int commander_thread_main(int argc, char *argv[])
 			}
 
 			/* check throttle kill switch */
-			int prevLockdown = armed.lockdown;
+			int prev_lockdown = armed.lockdown;
 			if (sp_man.kill_switch == manual_control_setpoint_s::SWITCH_POS_ON) {
 				/* set lockdown flag */
-				armed.lockdown = TRUE;
-			} else {
-				armed.lockdown = FALSE;
+				armed.lockdown = true;
 			}
-			if (prevLockdown != armed.lockdown) {
-				warnx("armed.lockdown: %d\n", armed.lockdown);
+
+			if (sp_man.kill_switch == manual_control_setpoint_s::SWITCH_POS_ON &&
+				prev_lockdown != armed.lockdown) {
+				mavlink_and_console_log_critical(mavlink_fd, "RC KILL SWITCH ON");
 			}
 
 		} else {

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2235,6 +2235,18 @@ int commander_thread_main(int argc, char *argv[])
 				mavlink_log_critical(mavlink_fd, "main state transition denied");
 			}
 
+			/* check throttle kill switch */
+			int prevLockdown = armed.lockdown;
+			if (sp_man.kill_switch == manual_control_setpoint_s::SWITCH_POS_ON) {
+				/* set lockdown flag */
+				armed.lockdown = TRUE;
+			} else {
+				armed.lockdown = FALSE;
+			}
+			if (prevLockdown != armed.lockdown) {
+				warnx("armed.lockdown: %d\n", armed.lockdown);
+			}
+
 		} else {
 			if (!status.rc_input_blocked && !status.rc_signal_lost) {
 				mavlink_log_critical(mavlink_fd, "MANUAL CONTROL LOST (at t=%llums)", hrt_absolute_time() / 1000);

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -387,9 +387,8 @@ MulticopterAttitudeControl::MulticopterAttitudeControl() :
 
 	/* fetch initial parameter values */
 	parameters_update();
-	vehicle_status_poll();
 
-	if (_vehicle_status.is_vtol && _params.vtol_type == 0) {
+	if (_params.vtol_type == 0) {
 		// the vehicle is a tailsitter, use optimal recovery control strategy
 		_ts_opt_recovery = new TailsitterRecovery();
 	}
@@ -835,6 +834,8 @@ MulticopterAttitudeControl::task_main()
 					control_attitude(dt);
 
 				} else {
+					vehicle_attitude_setpoint_poll();
+					_thrust_sp = _v_att_sp.thrust;
 					math::Quaternion q(_ctrl_state.q[0], _ctrl_state.q[1], _ctrl_state.q[2], _ctrl_state.q[3]);
 					math::Quaternion q_sp(&_v_att_sp.q_d[0]);
 					_ts_opt_recovery->setAttGains(_params.att_p, _params.yaw_ff);

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -2010,6 +2010,15 @@ PARAM_DEFINE_INT32(RC_MAP_ACRO_SW, 0);
 PARAM_DEFINE_INT32(RC_MAP_OFFB_SW, 0);
 
 /**
+ * Kill switch channel mapping.
+ *
+ * @min 0
+ * @max 18
+ * @group Radio Switches
+ */
+PARAM_DEFINE_INT32(RC_MAP_KILL_SW, 0);
+
+/**
  * Flaps channel mapping.
  *
  * @min 0
@@ -2242,6 +2251,25 @@ PARAM_DEFINE_FLOAT(RC_ACRO_TH, 0.5f);
  *
  */
 PARAM_DEFINE_FLOAT(RC_OFFB_TH, 0.5f);
+
+
+/**
+ * Threshold for selecting offboard mode
+ *
+ * 0-1 indicate where in the full channel range the threshold sits
+ * 		0 : min
+ * 		1 : max
+ * sign indicates polarity of comparison
+ * 		positive : true when channel>th
+ * 		negative : true when channel<th
+ *
+ * @min -1
+ * @max 1
+ * @group Radio Switches
+ *
+ *
+ */
+PARAM_DEFINE_FLOAT(RC_KILLSWITCH_TH, 0.25f);
 
 /**
  * PWM input channel that provides RSSI.

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -277,6 +277,7 @@ private:
 		int rc_map_loiter_sw;
 		int rc_map_acro_sw;
 		int rc_map_offboard_sw;
+		int rc_map_kill_sw;
 
 		int rc_map_flaps;
 
@@ -297,6 +298,7 @@ private:
 		float rc_loiter_th;
 		float rc_acro_th;
 		float rc_offboard_th;
+		float rc_killswitch_th;
 		bool rc_assist_inv;
 		bool rc_auto_inv;
 		bool rc_rattitude_inv;
@@ -305,6 +307,7 @@ private:
 		bool rc_loiter_inv;
 		bool rc_acro_inv;
 		bool rc_offboard_inv;
+		bool rc_killswitch_inv;
 
 		float battery_voltage_scaling;
 		float battery_current_scaling;
@@ -336,6 +339,7 @@ private:
 		param_t rc_map_loiter_sw;
 		param_t rc_map_acro_sw;
 		param_t rc_map_offboard_sw;
+		param_t rc_map_kill_sw;
 
 		param_t rc_map_flaps;
 
@@ -360,6 +364,7 @@ private:
 		param_t rc_loiter_th;
 		param_t rc_acro_th;
 		param_t rc_offboard_th;
+		param_t rc_killswitch_th;
 
 		param_t battery_voltage_scaling;
 		param_t battery_current_scaling;
@@ -589,6 +594,7 @@ Sensors::Sensors() :
 	_parameter_handles.rc_map_loiter_sw = param_find("RC_MAP_LOITER_SW");
 	_parameter_handles.rc_map_acro_sw = param_find("RC_MAP_ACRO_SW");
 	_parameter_handles.rc_map_offboard_sw = param_find("RC_MAP_OFFB_SW");
+	_parameter_handles.rc_map_kill_sw = param_find("RC_MAP_KILL_SW");
 
 	_parameter_handles.rc_map_aux1 = param_find("RC_MAP_AUX1");
 	_parameter_handles.rc_map_aux2 = param_find("RC_MAP_AUX2");
@@ -614,6 +620,7 @@ Sensors::Sensors() :
 	_parameter_handles.rc_loiter_th = param_find("RC_LOITER_TH");
 	_parameter_handles.rc_acro_th = param_find("RC_ACRO_TH");
 	_parameter_handles.rc_offboard_th = param_find("RC_OFFB_TH");
+	_parameter_handles.rc_killswitch_th = param_find("RC_KILLSWITCH_TH");
 
 	/* Differential pressure offset */
 	_parameter_handles.diff_pres_offset_pa = param_find("SENS_DPRES_OFF");
@@ -773,6 +780,10 @@ Sensors::parameters_update()
 		warnx("%s", paramerr);
 	}
 
+	if (param_get(_parameter_handles.rc_map_kill_sw, &(_parameters.rc_map_kill_sw)) != OK) {
+		warnx("%s", paramerr);
+	}
+
 	if (param_get(_parameter_handles.rc_map_flaps, &(_parameters.rc_map_flaps)) != OK) {
 		warnx("%s", paramerr);
 	}
@@ -812,6 +823,9 @@ Sensors::parameters_update()
 	param_get(_parameter_handles.rc_offboard_th, &(_parameters.rc_offboard_th));
 	_parameters.rc_offboard_inv = (_parameters.rc_offboard_th < 0);
 	_parameters.rc_offboard_th = fabs(_parameters.rc_offboard_th);
+	param_get(_parameter_handles.rc_killswitch_th, &(_parameters.rc_killswitch_th));
+	_parameters.rc_killswitch_inv = (_parameters.rc_killswitch_th < 0);
+	_parameters.rc_killswitch_th = fabs(_parameters.rc_killswitch_th);
 
 	/* update RC function mappings */
 	_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_THROTTLE] = _parameters.rc_map_throttle - 1;
@@ -826,6 +840,7 @@ Sensors::parameters_update()
 	_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_LOITER] = _parameters.rc_map_loiter_sw - 1;
 	_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_ACRO] = _parameters.rc_map_acro_sw - 1;
 	_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_OFFBOARD] = _parameters.rc_map_offboard_sw - 1;
+	_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_KILLSWITCH] = _parameters.rc_map_kill_sw - 1;
 
 	_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_FLAPS] = _parameters.rc_map_flaps - 1;
 
@@ -1953,6 +1968,8 @@ Sensors::rc_poll()
 					     _parameters.rc_acro_inv);
 			manual.offboard_switch = get_rc_sw2pos_position(rc_channels_s::RC_CHANNELS_FUNCTION_OFFBOARD,
 						 _parameters.rc_offboard_th, _parameters.rc_offboard_inv);
+			manual.kill_switch = get_rc_sw2pos_position(rc_channels_s::RC_CHANNELS_FUNCTION_KILLSWITCH,
+					     _parameters.rc_killswitch_th, _parameters.rc_killswitch_inv);
 
 			/* publish manual_control_setpoint topic */
 			if (_manual_control_pub != nullptr) {

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -273,6 +273,7 @@ void Standard::update_external_state()
 void Standard::fill_actuator_outputs()
 {
 	/* multirotor controls */
+	_actuators_out_0->timestamp = _actuators_mc_in->timestamp;
 	_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] = _actuators_mc_in->control[actuator_controls_s::INDEX_ROLL]
 			* _mc_roll_weight;	// roll
 	_actuators_out_0->control[actuator_controls_s::INDEX_PITCH] =
@@ -283,6 +284,7 @@ void Standard::fill_actuator_outputs()
 		_actuators_mc_in->control[actuator_controls_s::INDEX_THROTTLE];	// throttle
 
 	/* fixed wing controls */
+	_actuators_out_1->timestamp = _actuators_fw_in->timestamp;
 	_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] = -_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL]
 			* (1 - _mc_roll_weight);	//roll
 	_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -178,7 +178,7 @@ void Tailsitter::update_vtol_state()
 
 			// check if we have reached airspeed  and pitch angle to switch to TRANSITION P2 mode
 			if ((_airspeed->true_airspeed_m_s >= _params_tailsitter.airspeed_trans
-			    && _v_att->pitch <= PITCH_TRANSITION_FRONT_P1) || !_armed->armed) {
+			     && _v_att->pitch <= PITCH_TRANSITION_FRONT_P1) || !_armed->armed) {
 				_vtol_schedule.flight_mode = FW_MODE;
 				//_vtol_schedule.transition_start = hrt_absolute_time();
 			}
@@ -446,12 +446,15 @@ void Tailsitter::fill_actuator_outputs()
 {
 	switch (_vtol_mode) {
 	case ROTARY_WING:
+		_actuators_out_0->timestamp = _actuators_mc_in->timestamp;
 		_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] = _actuators_mc_in->control[actuator_controls_s::INDEX_ROLL];
 		_actuators_out_0->control[actuator_controls_s::INDEX_PITCH] =
 			_actuators_mc_in->control[actuator_controls_s::INDEX_PITCH];
 		_actuators_out_0->control[actuator_controls_s::INDEX_YAW] = _actuators_mc_in->control[actuator_controls_s::INDEX_YAW];
 		_actuators_out_0->control[actuator_controls_s::INDEX_THROTTLE] =
 			_actuators_mc_in->control[actuator_controls_s::INDEX_THROTTLE];
+
+		_actuators_out_1->timestamp = _actuators_mc_in->timestamp;
 
 		if (_params->elevons_mc_lock == 1) {
 			_actuators_out_1->control[0] = 0;
@@ -461,13 +464,15 @@ void Tailsitter::fill_actuator_outputs()
 			// NOTE: There is no mistake in the line below, multicopter yaw axis is controlled by elevon roll actuation!
 			_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] =
 				_actuators_mc_in->control[actuator_controls_s::INDEX_YAW];	//roll elevon
-			_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] = _actuators_mc_in->control[actuator_controls_s::INDEX_PITCH];	//pitch elevon
+			_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =
+				_actuators_mc_in->control[actuator_controls_s::INDEX_PITCH];	//pitch elevon
 		}
 
 		break;
 
 	case FIXED_WING:
 		// in fixed wing mode we use engines only for providing thrust, no moments are generated
+		_actuators_out_0->timestamp = _actuators_fw_in->timestamp;
 		_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] = 0;
 		_actuators_out_0->control[actuator_controls_s::INDEX_PITCH] = 0;
 		_actuators_out_0->control[actuator_controls_s::INDEX_YAW] = 0;
@@ -486,6 +491,8 @@ void Tailsitter::fill_actuator_outputs()
 
 	case TRANSITION:
 		// in transition engines are mixed by weight (BACK TRANSITION ONLY)
+		_actuators_out_0->timestamp = _actuators_mc_in->timestamp;
+		_actuators_out_1->timestamp = _actuators_mc_in->timestamp;
 		_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] = _actuators_mc_in->control[actuator_controls_s::INDEX_ROLL]
 				* _mc_roll_weight;
 		_actuators_out_0->control[actuator_controls_s::INDEX_PITCH] =

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -384,6 +384,7 @@ void Tiltrotor::update_external_state()
 */
 void Tiltrotor::fill_actuator_outputs()
 {
+	_actuators_out_0->timestamp = _actuators_mc_in->timestamp;
 	_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] = _actuators_mc_in->control[actuator_controls_s::INDEX_ROLL]
 			* _mc_roll_weight;
 	_actuators_out_0->control[actuator_controls_s::INDEX_PITCH] =
@@ -400,6 +401,7 @@ void Tiltrotor::fill_actuator_outputs()
 			_actuators_mc_in->control[actuator_controls_s::INDEX_THROTTLE];;
 	}
 
+	_actuators_out_1->timestamp = _actuators_fw_in->timestamp;
 	_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] = -_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL]
 			* (1 - _mc_roll_weight);
 	_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =


### PR DESCRIPTION
seems like this table should be replaced by init code to compute sines and cosines for the euler angles
Then the rotation enum parameter would be replaced by 3 Euler angles, and one would not need to add code to both Firmware and QGC every time he built a new airframe. 
Unless there's a significant performance impact for doing a 3x3 matrix multiply versus rotate_3f in the sensor drivers?