### PR TITLE
WIP: Do not Merge - Master icm20608 4k

### DIFF
--- a/src/drivers/mpu6000/mpu6000.cpp
+++ b/src/drivers/mpu6000/mpu6000.cpp
@@ -2394,7 +2394,7 @@ usage()
 	warnx("missing command: try 'start', 'info', 'test', 'stop',\n'reset', 'regdump', 'factorytest', 'testerror'");
 	warnx("options:");
 	warnx("    -X    (external bus)");
-	warnx("    -M 6000|20608 (default 6000)");
+	warnx("    -T 6000|20608 (default 6000)");
 	warnx("    -R rotation");
 	warnx("    -a accel range (in g)");
 }


### PR DESCRIPTION
@LorenzMeier 

Would you please have a look at this. It is not 100% done, as I need to look at how the sample rate is set and returned (right now it is always 1kHz)  but I wanted to get your feedback on the approach,  

What will the effects be on the integrators and time stamps be with this approach? 

Do you think I will need to back calculate the timestamps and pass that into process as well?

Another question that comes to mind is: 

There are several returns from 
https://github.com/PX4/Firmware/blob/master/src/drivers/mpu6000/mpu6000.cpp#L1732-L1985

Like
https://github.com/PX4/Firmware/blob/master/src/drivers/mpu6000/mpu6000.cpp#L1768

https://github.com/PX4/Firmware/blob/master/src/drivers/mpu6000/mpu6000.cpp#L1781

https://github.com/PX4/Firmware/blob/master/src/drivers/mpu6000/mpu6000.cpp#L1830

Notice that in the 3 returns the _sample_perf may be left running.

Is this intended?

