### PR TITLE
Use real yaw, not commanded yaw to transform velocity

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1648,7 +1648,7 @@ MulticopterPositionControl::task_main()
 						}
 
 						/* vector of desired yaw direction in XY plane, rotated by PI/2 */
-						math::Vector<3> y_C(-sinf(_att_sp.yaw_body), cosf(_att_sp.yaw_body), 0.0f);
+						math::Vector<3> y_C(-sinf(_yaw), cosf(_yaw), 0.0f);
 
 						if (fabsf(body_z(2)) > SIGMA) {
 							/* desired body_x axis, orthogonal to body_z */


### PR DESCRIPTION
@AndreasAntener This might be worth testing in SITL and with a quad. I did not see a change in SITL, but it might very well lead to a straight takeoff in reality.