### PR TITLE
VTOL: Tiltrotor VT_FW_MOT_OFF interpretation fix

### DIFF
--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -145,7 +145,7 @@ int Tiltrotor::get_motor_off_channels(int channels)
 			break;
 		}
 
-		channel_bitmap |= 1 << channel;
+		channel_bitmap |= 1 << (channel - 1);
 		channels = channels / 10;
 	}
 


### PR DESCRIPTION
This fixes bug which makes all off channels shifted. For example when you set VT_FW_MOT_OFF to 13 code actually shuts off channels 2 and 4.

After this change everyone should check how VTOL behaves in FW mode and adjust VT_FW_MOT_OFF.