### PR TITLE
batt_smbus: Improvements for accessing more SBS data

### DIFF
--- a/msg/battery_status.msg
+++ b/msg/battery_status.msg
@@ -3,3 +3,4 @@ float32 voltage_v		# Battery voltage in volts, 0 if unknown
 float32 voltage_filtered_v	# Battery voltage in volts, filtered, 0 if unknown
 float32 current_a		# Battery current in amperes, -1 if unknown
 float32 discharged_mah		# Discharged amount in mAh, -1 if unknown
+bool is_powering_off		# Power off event imminent indication, false if unknown

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -451,6 +451,7 @@ BATT_SMBUS::cycle()
 			}
 		}
 
+        /*
 		// read the button press indicator
         if (read_block(BATT_SMBUS_MANUFACTURER_DATA, buff, 6, false) == 6) {
 			bool pressed = (buff[1] >> 3) & 0x01;
@@ -471,6 +472,7 @@ BATT_SMBUS::cycle()
 				new_report.is_powering_off = false;
 			}
 		}
+        */
 
 		// publish to orb
 		if (_batt_topic != -1) {


### PR DESCRIPTION
Also fixes the the PEC calculation for writing. See
http://cache.freescale.com/files/32bit/doc/app_note/AN4471.pdf and
http://www.ti.com/lit/an/sloa132/sloa132.pdf or more
details on SMBus reading and writing including with and without PECs.