### PR TITLE
Consider protocol when checking for already started mavlink instances

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1570,14 +1570,20 @@ Mavlink::task_main(int argc, char *argv[])
 		_datarate = MAX_DATA_RATE;
 	}
 
-	if (Mavlink::instance_exists(_device_name, this)) {
-		warnx("%s already running", _device_name);
-		return ERROR;
-	}
-
 	if (get_protocol() == SERIAL) {
-	warnx("mode: %u, data rate: %d B/s on %s @ %dB", _mode, _datarate, _device_name, _baudrate);
+		if (Mavlink::instance_exists(_device_name, this)) {
+			warnx("%s already running", _device_name);
+			return ERROR;
+		}
+
+		warnx("mode: %u, data rate: %d B/s on %s @ %dB", _mode, _datarate, _device_name, _baudrate);
+
 	} else if (get_protocol() == UDP) {
+		if (Mavlink::get_instance_for_network_port(_network_port) != nullptr) {
+			warnx("port %d already occupied", _network_port);
+			return ERROR;
+		}
+
 		warnx("mode: %u, data rate: %d B/s on udp port %hu", _mode, _datarate, _network_port);
 	}
 	/* flush stdout in case MAVLink is about to take it over */

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1817,6 +1817,7 @@ MavlinkReceiver::receive_thread(void *arg)
 			if (srcaddr_last->sin_addr.s_addr == htonl(localhost) && srcaddr.sin_addr.s_addr != htonl(localhost)) {
 				// if we were sending to localhost before but have a new host then accept him
 				memcpy(srcaddr_last, &srcaddr, sizeof(srcaddr));
+				PX4_WARN("UDP source addr changed: %s", inet_ntoa(srcaddr.sin_addr));
 			}
 #endif
 			/* if read failed, this loop won't execute */


### PR DESCRIPTION
Before, the instance on port 14557 wasn't started for `rcS_jmavsim_iris`. This now allows offboard connection to 14557 in parallel with QGC.

SITL tested.