### PR TITLE
Two point curve

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -122,7 +122,7 @@ public:
 
 private:
     const float alt_ctl_dz = 0.05f;
-    const float alt_ctl_dy = 0.025f;
+    const float alt_ctl_dy = 0.05f;
 
 	bool		_task_should_exit;		/**< if true, task should exit */
 	int		_control_task;			/**< task handle for task */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -121,15 +121,12 @@ public:
 	int		start();
 
 private:
-    const float alt_ctl_dz = 0.05f;
-    const float alt_ctl_dy = 0.05f;
-
 	bool		_task_should_exit;		/**< if true, task should exit */
 	int		_control_task;			/**< task handle for task */
 	int		_mavlink_fd;			/**< mavlink fd */
 
 	int		_vehicle_status_sub;		/**< vehicle status subscription */
-	int		_ctrl_state_sub;			/**< control state subscription */
+	int		_ctrl_state_sub;		/**< control state subscription */
 	int		_att_sp_sub;			/**< vehicle attitude setpoint */
 	int		_control_mode_sub;		/**< vehicle control mode subscription */
 	int		_params_sub;			/**< notification of parameter updates */
@@ -168,6 +165,8 @@ private:
 		param_t thr_min;
 		param_t thr_max;
 		param_t thr_hover;
+		param_t alt_ctl_dz;
+		param_t alt_ctl_dy;
 		param_t z_p;
 		param_t z_vel_p;
 		param_t z_vel_i;
@@ -200,6 +199,8 @@ private:
 		float thr_min;
 		float thr_max;
 		float thr_hover;
+		float alt_ctl_dz;
+		float alt_ctl_dy;
 		float tilt_max_air;
 		float land_speed;
 		float tko_speed;
@@ -420,7 +421,9 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_params_handles.thr_min		= param_find("MPC_THR_MIN");
 	_params_handles.thr_max		= param_find("MPC_THR_MAX");
 	_params_handles.thr_hover	= param_find("MPC_THR_HOVER");
-	_params_handles.z_p			= param_find("MPC_Z_P");
+	_params_handles.alt_ctl_dz	= param_find("MPC_ALTCTL_DZ");
+	_params_handles.alt_ctl_dy	= param_find("MPC_ALTCTL_DY");
+	_params_handles.z_p		= param_find("MPC_Z_P");
 	_params_handles.z_vel_p		= param_find("MPC_Z_VEL_P");
 	_params_handles.z_vel_i		= param_find("MPC_Z_VEL_I");
 	_params_handles.z_vel_d		= param_find("MPC_Z_VEL_D");
@@ -496,6 +499,8 @@ MulticopterPositionControl::parameters_update(bool force)
 		param_get(_params_handles.thr_min, &_params.thr_min);
 		param_get(_params_handles.thr_max, &_params.thr_max);
 		param_get(_params_handles.thr_hover, &_params.thr_hover);
+		param_get(_params_handles.alt_ctl_dz, &_params.alt_ctl_dz);
+		param_get(_params_handles.alt_ctl_dy, &_params.alt_ctl_dy);
 		param_get(_params_handles.tilt_max_air, &_params.tilt_max_air);
 		_params.tilt_max_air = math::radians(_params.tilt_max_air);
 		param_get(_params_handles.land_speed, &_params.land_speed);
@@ -754,7 +759,7 @@ MulticopterPositionControl::control_manual(float dt)
 
 	if (_control_mode.flag_control_altitude_enabled) {
 		/* set vertical velocity setpoint with throttle stick */
-		req_vel_sp(2) = -scale_control(_manual.z - 0.5f, 0.5f, alt_ctl_dz, alt_ctl_dy); // D
+		req_vel_sp(2) = -scale_control(_manual.z - 0.5f, 0.5f, _params.alt_ctl_dz, _params.alt_ctl_dy); // D
 	}
 
 	if (_control_mode.flag_control_position_enabled) {

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -121,7 +121,8 @@ public:
 	int		start();
 
 private:
-	const float alt_ctl_dz = 0.1f;
+    const float alt_ctl_dz = 0.1f;
+    const float alt_ctl_dy = 0.05f;
 
 	bool		_task_should_exit;		/**< if true, task should exit */
 	int		_control_task;			/**< task handle for task */
@@ -266,7 +267,7 @@ private:
 	 */
 	void		poll_subscriptions();
 
-	static float	scale_control(float ctl, float end, float dz);
+    static float	scale_control(float ctl, float end, float dz, float dy);
 
 	/**
 	 * Update reference for local position projection
@@ -633,16 +634,16 @@ MulticopterPositionControl::poll_subscriptions()
 }
 
 float
-MulticopterPositionControl::scale_control(float ctl, float end, float dz)
+MulticopterPositionControl::scale_control(float ctl, float end, float dz, float dy)
 {
 	if (ctl > dz) {
-		return (ctl - dz) / (end - dz);
+        return dy + (ctl - dz) * (1.0f - dy) / (end - dz);
 
 	} else if (ctl < -dz) {
-		return (ctl + dz) / (end - dz);
+        return -dy + (ctl + dz) * (1.0f - dy) / (end - dz);
 
 	} else {
-		return 0.0f;
+        return ctl * (dy / dz);
 	}
 }
 
@@ -735,8 +736,8 @@ MulticopterPositionControl::control_manual(float dt)
 
 	if (_control_mode.flag_control_altitude_enabled) {
 		/* set vertical velocity setpoint with throttle stick */
-		req_vel_sp(2) = -scale_control(_manual.z - 0.5f, 0.5f, alt_ctl_dz); // D
-	}
+        req_vel_sp(2) = -scale_control(_manual.z - 0.5f, 0.5f, alt_ctl_dz, alt_ctl_dy); // D
+    }
 
 	if (_control_mode.flag_control_position_enabled) {
 		/* set horizontal velocity setpoint with roll/pitch stick */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -189,7 +189,6 @@ private:
 		param_t global_yaw_max;
 		param_t mc_att_yaw_p;
 		param_t hold_xy_dz;
-		param_t hold_z_dz;
 		param_t hold_max_xy;
 		param_t hold_max_z;
 		param_t acc_hor_max;
@@ -211,7 +210,6 @@ private:
 		float global_yaw_max;
 		float mc_att_yaw_p;
 		float hold_xy_dz;
-		float hold_z_dz;
 		float hold_max_xy;
 		float hold_max_z;
 		float acc_hor_max;
@@ -445,7 +443,6 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_params_handles.global_yaw_max = param_find("MC_YAWRATE_MAX");
 	_params_handles.mc_att_yaw_p = param_find("MC_YAW_P");
 	_params_handles.hold_xy_dz = param_find("MPC_HOLD_XY_DZ");
-	_params_handles.hold_z_dz = param_find("MPC_HOLD_Z_DZ");
 	_params_handles.hold_max_xy = param_find("MPC_HOLD_MAX_XY");
 	_params_handles.hold_max_z = param_find("MPC_HOLD_MAX_Z");
 	_params_handles.acc_hor_max = param_find("MPC_ACC_HOR_MAX");
@@ -544,9 +541,6 @@ MulticopterPositionControl::parameters_update(bool force)
 		param_get(_params_handles.hold_xy_dz, &v);
 		v = math::constrain(v, 0.0f, 1.0f);
 		_params.hold_xy_dz = v;
-		param_get(_params_handles.hold_z_dz, &v);
-		v = math::constrain(v, 0.0f, 1.0f);
-		_params.hold_z_dz = v;
 		param_get(_params_handles.hold_max_xy, &v);
 		_params.hold_max_xy = (v < 0.0f ? 0.0f : v);
 		param_get(_params_handles.hold_max_z, &v);
@@ -827,7 +821,7 @@ MulticopterPositionControl::control_manual(float dt)
 	/* vertical axis */
 	if (_control_mode.flag_control_altitude_enabled) {
 		/* check for pos. hold */
-		if (fabsf(req_vel_sp(2)) < _params.hold_z_dz) {
+		if (fabsf(req_vel_sp(2)) < FLT_EPSILON) {
 			if (!_alt_hold_engaged) {
 				if (_params.hold_max_z < FLT_EPSILON || fabsf(_vel(2)) < _params.hold_max_z) {
 					_alt_hold_engaged = true;

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -50,6 +50,17 @@
 PARAM_DEFINE_FLOAT(MPC_THR_MIN, 0.12f);
 
 /**
+ * Hover thrust
+ *
+ * Vertical thrust required to hover.
+ *
+ * @min 0.2
+ * @max 0.8
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_THR_HOVER, 0.5f);
+
+/**
  * Maximum thrust in auto thrust control
  *
  * Limit max allowed thrust. Setting a value of one can put

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -53,6 +53,11 @@ PARAM_DEFINE_FLOAT(MPC_THR_MIN, 0.12f);
  * Hover thrust
  *
  * Vertical thrust required to hover.
+ * This value is mapped to center stick for manual throttle control.
+ * With this value set to the thrust required to hover, transition
+ * from manual to ALTCTL mode while hovering will occur with the
+ * throttle stick near center, which is then interpreted as (near)
+ * zero demand for vertical speed.
  *
  * @min 0.2
  * @max 0.8

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -325,16 +325,6 @@ PARAM_DEFINE_FLOAT(MPC_MAN_Y_MAX, 120.0f);
 PARAM_DEFINE_FLOAT(MPC_HOLD_XY_DZ, 0.1f);
 
 /**
- * Deadzone of Z stick where altitude hold is enabled
- *
- * @unit %
- * @min 0.0
- * @max 1.0
- * @group Multicopter Position Control
- */
-PARAM_DEFINE_FLOAT(MPC_HOLD_Z_DZ, 0.1f);
-
-/**
  * Maximum horizontal velocity for which position hold is enabled (use 0 to disable check)
  *
  * @unit m/s

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -66,6 +66,32 @@ PARAM_DEFINE_FLOAT(MPC_THR_MIN, 0.12f);
 PARAM_DEFINE_FLOAT(MPC_THR_HOVER, 0.5f);
 
 /**
+ * ALTCTL throttle curve breakpoint
+ *
+ * Halfwidth of deadband or reduced sensitivity center portion of curve.
+ * This is the halfwidth of the center region of the ALTCTL throttle
+ * curve. It extends from center-dz to center+dz.
+ *
+ * @min 0.0
+ * @max 0.2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_ALTCTL_DZ, 0.1f);
+
+/**
+ * ALTCTL throttle curve breakpoint height
+ *
+ * Controls the slope of the reduced sensitivity region.
+ * This is the height of the ALTCTL throttle
+ * curve at center-dz and center+dz.
+ *
+ * @min 0.0
+ * @max 0.2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_ALTCTL_DY, 0.0f);
+
+/**
  * Maximum thrust in auto thrust control
  *
  * Limit max allowed thrust. Setting a value of one can put


### PR DESCRIPTION
This PR adds parameter MPC_THR_HOVER to specify the thrust required to hover, and two additional parameters to give the pilot control over the sensitivity of the throttle stick near center when in ALTCTL mode. The default for these parameters provides a deadband of +/-0.1 (the current hardwired value), but they may be adjusted to narrow the deadband or to simply reduce sensitivity near stick center.

add parameter for hover thrust level and map throttle center stick to it
also reduce ALTCTL deadband
