### PR TITLE
DJI F450 / F330 configs: Differentiate between the original kit and D…

### DIFF
--- a/ROMFS/px4fmu_common/init.d/4010_dji_f330
+++ b/ROMFS/px4fmu_common/init.d/4010_dji_f330
@@ -1,6 +1,6 @@
 #!nsh
 #
-# @name DJI Flame Wheel F330
+# @name ORIGINAL DJI F330 Kit
 #
 # @type Quadrotor x
 #
@@ -11,22 +11,10 @@
 # @maintainer Lorenz Meier <lorenz@px4.io>
 #
 
-sh /etc/init.d/4001_quad_x
+sh /etc/init.d/4014_gen_f330
 
 if [ $AUTOCNF == yes ]
 then
-	param set MC_ROLL_P 7.0
-	param set MC_ROLLRATE_P 0.15
-	param set MC_ROLLRATE_I 0.05
-	param set MC_ROLLRATE_D 0.003
-	param set MC_PITCH_P 7.0
-	param set MC_PITCHRATE_P 0.15
-	param set MC_PITCHRATE_I 0.05
-	param set MC_PITCHRATE_D 0.003
-	param set MC_YAW_P 2.8
-	param set MC_YAWRATE_P 0.2
-	param set MC_YAWRATE_I 0.1
-	param set MC_YAWRATE_D 0.0
 	# DJI ESCs do not support calibration and need a higher min
 	param set PWM_MIN 1230
 fi

--- a/ROMFS/px4fmu_common/init.d/4011_dji_f450
+++ b/ROMFS/px4fmu_common/init.d/4011_dji_f450
@@ -1,6 +1,6 @@
 #!nsh
 #
-# @name DJI Flame Wheel F450
+# @name ORIGINAL DJI F450 Kit
 #
 # @type Quadrotor x
 #
@@ -11,22 +11,10 @@
 # @maintainer Lorenz Meier <lorenz@px4.io>
 #
 
-sh /etc/init.d/4001_quad_x
+sh /etc/init.d/4013_gen_f450
 
 if [ $AUTOCNF == yes ]
 then
-	param set MC_ROLL_P 7.0
-	param set MC_ROLLRATE_P 0.15
-	param set MC_ROLLRATE_I 0.05
-	param set MC_ROLLRATE_D 0.01
-	param set MC_PITCH_P 7.0
-	param set MC_PITCHRATE_P 0.15
-	param set MC_PITCHRATE_I 0.05
-	param set MC_PITCHRATE_D 0.01
-	param set MC_YAW_P 2.8
-	param set MC_YAWRATE_P 0.3
-	param set MC_YAWRATE_I 0.1
-	param set MC_YAWRATE_D 0.0
 	# DJI ESCs do not support calibration and need a higher min
 	param set PWM_MIN 1230
 fi

--- a/ROMFS/px4fmu_common/init.d/4013_gen_f450
+++ b/ROMFS/px4fmu_common/init.d/4013_gen_f450
@@ -1,0 +1,31 @@
+#!nsh
+#
+# @name F450 Class Quad
+#
+# @type Quadrotor x
+#
+# @output AUX1 feed-through of RC AUX1 channel
+# @output AUX2 feed-through of RC AUX2 channel
+# @output AUX3 feed-through of RC AUX3 channel
+#
+# @maintainer Lorenz Meier <lorenz@px4.io>
+#
+
+sh /etc/init.d/4001_quad_x
+
+if [ $AUTOCNF == yes ]
+then
+	param set MC_ROLL_P 7.0
+	param set MC_ROLLRATE_P 0.15
+	param set MC_ROLLRATE_I 0.05
+	param set MC_ROLLRATE_D 0.01
+	param set MC_PITCH_P 7.0
+	param set MC_PITCHRATE_P 0.15
+	param set MC_PITCHRATE_I 0.05
+	param set MC_PITCHRATE_D 0.01
+	param set MC_YAW_P 2.8
+	param set MC_YAWRATE_P 0.3
+	param set MC_YAWRATE_I 0.1
+	param set MC_YAWRATE_D 0.0
+	param set PWM_MIN 1075
+fi

--- a/ROMFS/px4fmu_common/init.d/4014_gen_f330
+++ b/ROMFS/px4fmu_common/init.d/4014_gen_f330
@@ -1,0 +1,31 @@
+#!nsh
+#
+# @name F330 Class Quad
+#
+# @type Quadrotor x
+#
+# @output AUX1 feed-through of RC AUX1 channel
+# @output AUX2 feed-through of RC AUX2 channel
+# @output AUX3 feed-through of RC AUX3 channel
+#
+# @maintainer Lorenz Meier <lorenz@px4.io>
+#
+
+sh /etc/init.d/4001_quad_x
+
+if [ $AUTOCNF == yes ]
+then
+	param set MC_ROLL_P 7.0
+	param set MC_ROLLRATE_P 0.15
+	param set MC_ROLLRATE_I 0.05
+	param set MC_ROLLRATE_D 0.003
+	param set MC_PITCH_P 7.0
+	param set MC_PITCHRATE_P 0.15
+	param set MC_PITCHRATE_I 0.05
+	param set MC_PITCHRATE_D 0.003
+	param set MC_YAW_P 2.8
+	param set MC_YAWRATE_P 0.2
+	param set MC_YAWRATE_I 0.1
+	param set MC_YAWRATE_D 0.0
+	param set PWM_MIN 1075
+fi


### PR DESCRIPTION
…IY kits int he same size. This is required because people not actually owning a F450 kit still pick it and then complain that the DJI-configured min motor value is set incorrectly. 

![](http://cdn.backyardchickens.com/1/1d/1d9a3dda_21169_facepalm_picard2.jpeg)