### PR TITLE
tailsitter: go into mc mode it transition switch not assigned

### DIFF
--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -129,7 +129,7 @@ void Tailsitter::update_vtol_state()
 	 * For the backtransition the pitch is controlled in MC mode again and switches to full MC control reaching the sufficient pitch angle.
 	*/
 
-	if (_manual_control_sp->aux1 < 0.0f) {
+	if (!_attc->is_fixed_wing_requested()) {
 
 
 		switch (_vtol_schedule.flight_mode) { // user switchig to MC mode


### PR DESCRIPTION
This should allow the tailsitter to takeoff even if the transition switch is not assigned.
I don't see any uorb resource problem on my side.
I am able to launch the simulation and takeoff via
```commander takeoff```
