### PR TITLE
simulator: fix mavlink parsing of sim+RC stream

### DIFF
--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -575,7 +575,7 @@ void Simulator::pollForMAVLinkMessages(bool publish)
 				mavlink_status_t status;
 
 				for (int i = 0; i < len; ++i) {
-					if (mavlink_parse_char(MAVLINK_COMM_0, serial_buf[i], &msg, &status)) {
+					if (mavlink_parse_char(MAVLINK_COMM_1, serial_buf[i], &msg, &status)) {
 						// have a message, handle it
 						handle_message(&msg, true);
 					}


### PR DESCRIPTION
The mavlink stream from the simulator and the mavlink stream over serial
(used for RC input) both had the same MAVLINK_COMM channel and were
therefore sharing an internal buffer in mavlink_parse_char. This meant
that most (low rate) serial messages were getting swallowed by the high
rate simulator stream.

This change fixes the issue where RC input was not properly arriving in
Gazebo, however it breaks the `commander takeoff` command in SITL which
needs to be investigated.