### PR TITLE
Properly handle takeoff waypoint when not currently at takeoff location

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -286,6 +286,7 @@ Mission::advance_mission()
 {
 	if (_takeoff) {
 		_takeoff = false;
+		_takeoff_finished = true;
 
 	} else {
 		switch (_mission_type) {
@@ -430,6 +431,8 @@ Mission::set_mission_items()
 		/* do takeoff before going to setpoint */
 		/* set mission item as next position setpoint */
 		mission_item_to_position_setpoint(&_mission_item, &pos_sp_triplet->next);
+		/* next SP is not takeoff anymore */
+		pos_sp_triplet->next.type = position_setpoint_s::SETPOINT_TYPE_POSITION;
 
 		/* calculate takeoff altitude */
 		float takeoff_alt = get_absolute_altitude_for_item(_mission_item);
@@ -464,6 +467,13 @@ Mission::set_mission_items()
 			/* skip takeoff */
 			_takeoff = false;
 		}
+	}
+
+	if (_takeoff_finished) {
+		/* we just finished takeoff */
+		/* in case we still have to move to the takeoff waypoint we need a waypoint mission item */
+		_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
+		_takeoff_finished = false;
 	}
 
 	/* set current position setpoint from mission item */

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -185,6 +185,7 @@ private:
 	int _current_offboard_mission_index;
 	bool _need_takeoff;					/**< if true, then takeoff must be performed before going to the first waypoint (if needed) */
 	bool _takeoff;						/**< takeoff state flag */
+	bool _takeoff_finished;					/**< set if takeoff was requested before and is now done */
 
 	enum {
 		MISSION_TYPE_NONE,


### PR DESCRIPTION
Fixes #3387 

Instead of taking off like this:
![screen shot 2016-01-07 at 15 01 38](https://cloud.githubusercontent.com/assets/5750020/12174890/8cb62cd0-b55f-11e5-94e1-05624b7419d4.png)

It will now do this:
![screen shot 2016-01-07 at 15 08 12](https://cloud.githubusercontent.com/assets/5750020/12174892/8e6dc330-b55f-11e5-8b6e-1bcc4df9e956.png)

This should also fix a bug where the "next" setpoint kept the type takeoff and just never stopped climbing. Although that one occurred randomly for me and I could never really pin it down.

Tested with takeoff WP at current location and away from current location. Fixed-wing should not be affected because the already existing takeoff flag is only set for MC