### PR TITLE
init sbus uart in full duplex mode

### DIFF
--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -632,7 +632,7 @@ PX4FMU::cycle()
 		update_pwm_rev_mask();
 
 #ifdef SBUS_SERIAL_PORT
-		_sbus_fd = sbus_init(SBUS_SERIAL_PORT, true);
+		_sbus_fd = sbus_init(SBUS_SERIAL_PORT, false);
 #endif
 
 #ifdef DSM_SERIAL_PORT


### PR DESCRIPTION
with this change, the beta pixracer R07 board handles SBUS input from FrSky X4R correctly