### PR TITLE
tailsitter gazebo: lower max climb/descend velocity

### DIFF
--- a/posix-configs/SITL/init/rcS_gazebo_tailsitter
+++ b/posix-configs/SITL/init/rcS_gazebo_tailsitter
@@ -27,6 +27,7 @@ param set MPC_XY_P 0.15
 param set MPC_XY_VEL_P 0.05
 param set MPC_XY_VEL_D 0.005
 param set MPC_XY_FF 0.1
+param set MPC_Z_VEL_MAX 1.0
 param set SENS_BOARD_ROT 8
 param set COM_RC_IN_MODE 1
 rgbledsim start


### PR DESCRIPTION
This prevents the tailsitter becoming unstable in hover mode when it tries to descend too quickly.
This PR enables to fly full missions from hover to forward flight and back. 