### PR TITLE
Ekf2 param fix

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -72,7 +72,6 @@
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/control_state.h>
 #include <uORB/topics/vehicle_global_position.h>
-#include <uORB/topics/parameter_update.h>
 
 #include <ecl/EKF/ekf.h>
 
@@ -161,9 +160,6 @@ private:
 	control::BlockParamFloat *_heading_innov_gate;	// innovation gate for heading innovation test
 
 	EstimatorBase *_ekf;
-
-
-	void update_parameters(bool force);
 
 	int update_subscriptions();
 


### PR DESCRIPTION
Small cleanup on params.
Reference the correct submodule commit.