### PR TITLE
mavlink: option to specify the UDP remote port

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -185,6 +185,7 @@ Mavlink::Mavlink() :
 	_socket_fd(-1),
 	_protocol(SERIAL),
 	_network_port(14556),
+	_remote_port(DEFAULT_REMOTE_PORT_UDP),
 	_rstatus {},
 	_message_buffer {},
 	_message_buffer_mutex {},
@@ -1057,7 +1058,7 @@ Mavlink::init_udp()
 	if (_mode != MAVLINK_MODE_ONBOARD) {
 		_src_addr.sin_family = AF_INET;
 		inet_aton("127.0.0.1", &_src_addr.sin_addr);
-		_src_addr.sin_port = htons(DEFAULT_REMOTE_PORT_UDP);
+		_src_addr.sin_port = htons(_remote_port);
 		set_client_source_initialized();
 	}
 
@@ -1065,7 +1066,7 @@ Mavlink::init_udp()
 	memset((char *)&_bcast_addr, 0, sizeof(_bcast_addr));
 	_bcast_addr.sin_family = AF_INET;
 	inet_aton("255.255.255.255", &_bcast_addr.sin_addr);
-	_bcast_addr.sin_port = htons(DEFAULT_REMOTE_PORT_UDP);
+	_bcast_addr.sin_port = htons(_remote_port);
 
 #endif
 }
@@ -1522,7 +1523,7 @@ Mavlink::task_main(int argc, char *argv[])
 	char* eptr;
 	int temp_int_arg;
 
-	while ((ch = px4_getopt(argc, argv, "b:r:d:u:m:fpvwx", &myoptind, &myoptarg)) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "b:r:d:u:o:m:fpvwx", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'b':
 			_baudrate = strtoul(myoptarg, NULL, 10);
@@ -1548,7 +1549,7 @@ Mavlink::task_main(int argc, char *argv[])
 			_device_name = myoptarg;
 			set_protocol(SERIAL);
 			break;
-			
+
 		case 'u':
 			temp_int_arg = strtoul(myoptarg, &eptr, 10);
 			if ( *eptr == '\0' ) {
@@ -1556,6 +1557,18 @@ Mavlink::task_main(int argc, char *argv[])
 				set_protocol(UDP);
 			} else {
 				warnx("invalid data udp_port '%s'", myoptarg);
+				err_flag = true;
+			}
+			break;
+
+		case 'o':
+			temp_int_arg = strtoul(myoptarg, &eptr, 10);
+			if ( *eptr == '\0' ) {
+				warnx("set remote port %d", temp_int_arg);
+				_remote_port = temp_int_arg;
+				set_protocol(UDP);
+			} else {
+				warnx("invalid remote udp_port '%s'", myoptarg);
 				err_flag = true;
 			}
 			break;
@@ -1869,7 +1882,7 @@ Mavlink::task_main(int argc, char *argv[])
 		hrt_abstime t = hrt_absolute_time();
 
 		update_rate_mult();
-		
+
 		_mission_manager->check_active_mission();
 
 		if (param_sub->update(&param_time, nullptr)) {
@@ -1881,7 +1894,7 @@ Mavlink::task_main(int argc, char *argv[])
 		if (_uart_fd >= 0 && _radio_id != 0 && _rstatus.type == telemetry_status_s::TELEMETRY_STATUS_RADIO_TYPE_3DR_RADIO) {
 			/* request to configure radio and radio is present */
 			FILE *fs = fdopen(_uart_fd, "w");
-			
+
 			if (fs) {
 				/* switch to AT command mode */
 				usleep(1200000);
@@ -2321,7 +2334,7 @@ Mavlink::stream_command(int argc, char *argv[])
 
 static void usage()
 {
-	warnx("usage: mavlink {start|stop-all|stream} [-d device] [-u udp_port] [-b baudrate]\n\t[-r rate][-m mode] [-s stream] [-f] [-p] [-v] [-w] [-x]");
+	warnx("usage: mavlink {start|stop-all|stream} [-d device] [-u network_port] [-o remote_port] [-b baudrate]\n\t[-r rate][-m mode] [-s stream] [-f] [-p] [-v] [-w] [-x]");
 }
 
 int mavlink_main(int argc, char *argv[])

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -337,6 +337,8 @@ public:
 
 	unsigned short		get_network_port() { return _network_port; }
 
+	unsigned short		get_remote_port() { return _remote_port; }
+
 	int 			get_socket_fd () { return _socket_fd; };
 #ifdef __PX4_POSIX
 	struct sockaddr_in *	get_client_source_address() {return &_src_addr;};
@@ -436,6 +438,7 @@ private:
 	int _socket_fd;
 	Protocol	_protocol;
 	unsigned short _network_port;
+	unsigned short _remote_port;
 
 	struct telemetry_status_s	_rstatus;			///< receive status
 


### PR DESCRIPTION
This enables using several mavlink instances for SITL.

For instance you can connect with QGroundControl on 14550 and at the same time with mavros on 14540.