### PR TITLE
VTOL mission item handling

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -38,6 +38,8 @@ then
 	param set PE_POSNE_NOISE 0.5
 	param set PE_POSD_NOISE 1.25
 	param set PE_ABIAS_PNOISE 0.0001
+
+	param set NAV_ACC_RAD 3
 fi
 
 set PWM_DISARMED 900

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -39,7 +39,14 @@ then
 	param set PE_POSD_NOISE 1.25
 	param set PE_ABIAS_PNOISE 0.0001
 
+	#
+	# Default parameters for mission and position handling
+	#
 	param set NAV_ACC_RAD 3
+	param set MPC_TKO_SPEED 1.0
+	param set MPC_LAND_SPEED 0.7
+	param set MPC_Z_VEL_MAX 1.5
+	param set MPC_XY_VEL_MAX 4.0
 fi
 
 set PWM_DISARMED 900

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -117,10 +117,9 @@ uint32 system_id			# system id, inspired by MAVLink's system ID field
 uint32 component_id			# subsystem / component id, inspired by MAVLink's component ID field
 
 bool is_rotary_wing			# True if system is in rotary wing configuration, so for a VTOL this is only true while flying as a multicopter
-bool vtol_in_transition		# True if VTOL is doing a transition
 bool is_vtol				# True if the system is VTOL capable
 bool vtol_fw_permanent_stab		# True if vtol should stabilize attitude for fw in manual mode
-bool in_transition_mode
+bool in_transition_mode			# True if VTOL is doing a transition
 
 bool condition_battery_voltage_valid
 bool condition_system_in_air_restore		# true if we can restore in mid air

--- a/posix-configs/SITL/init/rcS_gazebo_standard_vtol
+++ b/posix-configs/SITL/init/rcS_gazebo_standard_vtol
@@ -30,6 +30,7 @@ param set MPC_XY_FF 0.1
 param set MPC_Z_VEL_MAX 1.0
 param set SENS_BOARD_ROT 8
 param set COM_RC_IN_MODE 1
+param set NAV_ACC_RAD 3.0
 rgbledsim start
 tone_alarm start
 gyrosim start

--- a/posix-configs/SITL/init/rcS_gazebo_standard_vtol
+++ b/posix-configs/SITL/init/rcS_gazebo_standard_vtol
@@ -27,10 +27,11 @@ param set MPC_XY_P 0.15
 param set MPC_XY_VEL_P 0.05
 param set MPC_XY_VEL_D 0.005
 param set MPC_XY_FF 0.1
-param set MPC_Z_VEL_MAX 1.0
+param set MPC_Z_VEL_MAX 1.5
 param set SENS_BOARD_ROT 8
 param set COM_RC_IN_MODE 1
 param set NAV_ACC_RAD 3.0
+param set MPC_TKO_SPEED 1.0
 rgbledsim start
 tone_alarm start
 gyrosim start

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1719,6 +1719,8 @@ int commander_thread_main(int argc, char *argv[])
 				status.is_rotary_wing = vtol_status.vtol_in_rw_mode;
 				status.in_transition_mode = vtol_status.vtol_in_trans_mode;
 			}
+
+			status_changed = true;
 		}
 
 		/* update global position estimate */

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -805,7 +805,6 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 		break;
 
 	case MAV_CMD_DO_SET_SERVO:
-
 		mission_item->actuator_num = mavlink_mission_item->param1;
 		mission_item->actuator_value = mavlink_mission_item->param2;
 		mission_item->time_inside=0.0f;

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -793,6 +793,8 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 		return MAV_MISSION_UNSUPPORTED_FRAME;
 	}
 
+	mission_item->frame = mavlink_mission_item->frame;
+
 	switch (mavlink_mission_item->command) {
 	case MAV_CMD_NAV_TAKEOFF:
 		mission_item->pitch_min = mavlink_mission_item->param1;
@@ -802,12 +804,6 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 		mission_item->do_jump_mission_index = mavlink_mission_item->param1;
 		mission_item->do_jump_current_count = 0;
 		mission_item->do_jump_repeat_count = mavlink_mission_item->param2;
-		break;
-
-	case MAV_CMD_DO_SET_SERVO:
-		mission_item->actuator_num = mavlink_mission_item->param1;
-		mission_item->actuator_value = mavlink_mission_item->param2;
-		mission_item->time_inside=0.0f;
 		break;
 
 	default:
@@ -842,51 +838,46 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 int
 MavlinkMissionManager::format_mavlink_mission_item(const struct mission_item_s *mission_item, mavlink_mission_item_t *mavlink_mission_item)
 {
-	if (mission_item->altitude_is_relative) {
-		mavlink_mission_item->frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
+	mavlink_mission_item->frame = mission_item->frame;
+	mavlink_mission_item->command = mission_item->nav_cmd;
+	mavlink_mission_item->autocontinue = mission_item->autocontinue;
 
+	/* default mappings for generic commands */
+	if (mission_item->frame == MAV_FRAME_MISSION) {
+		mavlink_mission_item->param1 = mission_item->params[0];
+		mavlink_mission_item->param2 = mission_item->params[1];
+		mavlink_mission_item->param3 = mission_item->params[2];
+		mavlink_mission_item->param4 = mission_item->params[3];
+		mavlink_mission_item->x = mission_item->params[4];
+		mavlink_mission_item->y = mission_item->params[5];
+		mavlink_mission_item->z = mission_item->params[6];
+
+	// default mappings for regular waypoints
 	} else {
-		mavlink_mission_item->frame = MAV_FRAME_GLOBAL;
+		mavlink_mission_item->x = (float)mission_item->lat;
+		mavlink_mission_item->y = (float)mission_item->lon;
+		mavlink_mission_item->z = mission_item->altitude;
+
+		mavlink_mission_item->param4 = mission_item->yaw * M_RAD_TO_DEG_F;
+		mavlink_mission_item->param3 = mission_item->loiter_radius * (float)mission_item->loiter_direction;
 	}
 
+	// specific item handling
 	switch (mission_item->nav_cmd) {
 	case NAV_CMD_TAKEOFF:
 		mavlink_mission_item->param1 = mission_item->pitch_min;
 		break;
 
-	case NAV_CMD_DO_SET_SERVO:
-		mavlink_mission_item->frame = MAV_FRAME_MISSION;
-		mavlink_mission_item->param1 = mission_item->actuator_num;
-		mavlink_mission_item->param2 = mission_item->actuator_value;
-		break;
-
 	case NAV_CMD_DO_JUMP:
-		mavlink_mission_item->frame = MAV_FRAME_MISSION;
 		mavlink_mission_item->param1 = mission_item->do_jump_mission_index;
 		mavlink_mission_item->param2 = mission_item->do_jump_repeat_count - mission_item->do_jump_current_count;
 		break;
-
-	case NAV_CMD_DO_VTOL_TRANSITION:
-		mavlink_mission_item->frame = MAV_FRAME_MISSION;
-		mavlink_mission_item->param1 = mission_item->params[0];
-		break;
-
 
 	default:
 		mavlink_mission_item->param2 = mission_item->acceptance_radius;
 		mavlink_mission_item->param1 = mission_item->time_inside;
 		break;
 	}
-
-	mavlink_mission_item->x = (float)mission_item->lat;
-	mavlink_mission_item->y = (float)mission_item->lon;
-	mavlink_mission_item->z = mission_item->altitude;
-
-	mavlink_mission_item->param4 = mission_item->yaw * M_RAD_TO_DEG_F;
-	mavlink_mission_item->param3 = mission_item->loiter_radius * (float)mission_item->loiter_direction;
-	mavlink_mission_item->command = mission_item->nav_cmd;
-	mavlink_mission_item->autocontinue = mission_item->autocontinue;
-	// mavlink_mission_item->seq = mission_item->index;
 
 	return OK;
 }

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -908,9 +908,10 @@ MulticopterPositionControl::cross_sphere_line(const math::Vector<3> &sphere_c, f
 
 void MulticopterPositionControl::control_auto(float dt)
 {
+	/* reset position setpoint on AUTO mode activation or when reentering MC mode */
 	if (!_mode_auto || _vehicle_status.in_transition_mode || !_vehicle_status.is_rotary_wing) {
 		_mode_auto = true;
-		/* reset position setpoint on AUTO mode activation */
+
 		if (_vehicle_status.in_transition_mode || !_vehicle_status.is_rotary_wing) {
 			_reset_pos_sp = true;
 			_reset_alt_sp = true;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -908,9 +908,13 @@ MulticopterPositionControl::cross_sphere_line(const math::Vector<3> &sphere_c, f
 
 void MulticopterPositionControl::control_auto(float dt)
 {
-	if (!_mode_auto) {
+	if (!_mode_auto || _vehicle_status.in_transition_mode || !_vehicle_status.is_rotary_wing) {
 		_mode_auto = true;
 		/* reset position setpoint on AUTO mode activation */
+		if (_vehicle_status.in_transition_mode || !_vehicle_status.is_rotary_wing) {
+			_reset_pos_sp = true;
+			_reset_alt_sp = true;
+		}
 		reset_pos_sp();
 		reset_alt_sp();
 		/* set current velocity as last target velocity to smooth out transition */

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -432,7 +432,7 @@ Mission::set_mission_items()
 
 			float takeoff_alt = calculate_takeoff_altitude(&_mission_item);
 
-			mavlink_log_critical(_navigator->get_mavlink_fd(), "takeoff to %.1f meters above home", (double)(takeoff_alt - _navigator->get_home_position()->alt));
+			mavlink_log_info(_navigator->get_mavlink_fd(), "takeoff to %.1f meters above home", (double)(takeoff_alt - _navigator->get_home_position()->alt));
 
 			_mission_item.nav_cmd = NAV_CMD_TAKEOFF;
 			_mission_item.lat = _navigator->get_global_position()->lat;

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -463,16 +463,19 @@ Mission::set_mission_items()
 			 * Ignoring waypoint altitude:
 			 * Set altitude to the same as we have now to prevent descending too fast into
 			 * the ground. Actual landing will descend anyway until it touches down.
+			 * XXX: We might want to change that at some point if it is clear to the user
+			 * what the altitude means on this waypoint type.
 			 */
 			float altitude = _navigator->get_global_position()->alt;
 			if (pos_sp_triplet->current.valid) {
 				altitude = pos_sp_triplet->current.alt;
 			}
 
+			_mission_item.altitude = altitude;
+			_mission_item.altitude_is_relative = false;
 			_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
 			_mission_item.autocontinue = true;
 			_mission_item.time_inside = 0;
-			_mission_item.altitude = altitude;
 		}
 
 		/* we just moved to the landing waypoint, now descend */

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -458,9 +458,20 @@ Mission::set_mission_items()
 			memcpy(&mission_item_next_position, &_mission_item, sizeof(struct mission_item_s));
 			has_next_position_item = true;
 
+			/*
+			 * Ignoring waypoint altitude:
+			 * Set altitude to the same as we have now to prevent descending too fast into
+			 * the ground. Actual landing will descend anyway until it touches down.
+			 */
+			float altitude = _navigator->get_global_position()->alt;
+			if (pos_sp_triplet->current.valid) {
+				altitude = pos_sp_triplet->current.alt;
+			}
+
 			_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
 			_mission_item.autocontinue = true;
 			_mission_item.time_inside = 0;
+			_mission_item.altitude = altitude;
 		}
 
 		/* we just moved to the landing waypoint, now descend */

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -480,7 +480,7 @@ Mission::set_mission_items()
 
 			new_work_item_type = WORK_ITEM_TYPE_ALIGN;
 
-			_mission_item.nav_cmd = NAV_CMD_TAKEOFF;
+			_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
 			_mission_item.lat = _navigator->get_global_position()->lat;
 			_mission_item.lon = _navigator->get_global_position()->lon;
 			_mission_item.altitude = _navigator->get_global_position()->alt;

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -501,6 +501,31 @@ Mission::set_mission_items()
 			new_work_item_type = WORK_ITEM_TYPE_DEFAULT;
 		}
 
+		/* don't advance mission after FW to MC command */
+		if (_mission_item.nav_cmd == NAV_CMD_DO_VTOL_TRANSITION
+				&& _work_item_type != WORK_ITEM_TYPE_CMD_BEFORE_MOVE
+				&& !_navigator->get_vstatus()->is_rotary_wing
+				&& !_navigator->get_vstatus()->condition_landed
+				&& pos_sp_triplet->previous.valid) {
+
+			new_work_item_type = WORK_ITEM_TYPE_CMD_BEFORE_MOVE;
+		}
+
+		/* after FW to MC transition finish moving to the waypoint */
+		if (_work_item_type == WORK_ITEM_TYPE_CMD_BEFORE_MOVE
+				&& pos_sp_triplet->previous.valid) {
+
+			new_work_item_type = WORK_ITEM_TYPE_DEFAULT;
+
+			_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
+			_mission_item.lat = pos_sp_triplet->previous.lat;
+			_mission_item.lon = pos_sp_triplet->previous.lon;
+			_mission_item.altitude = pos_sp_triplet->previous.alt;
+			_mission_item.altitude_is_relative = false;
+			_mission_item.autocontinue = true;
+			_mission_item.time_inside = 0;
+		}
+
 	}
 
 	/*********************************** set setpoints and check next *********************************************/

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -432,7 +432,7 @@ Mission::set_mission_items()
 
 			float takeoff_alt = calculate_takeoff_altitude(&_mission_item);
 
-			mavlink_log_info(_navigator->get_mavlink_fd(), "takeoff to %.1f meters above home", (double)(takeoff_alt - _navigator->get_home_position()->alt));
+			mavlink_log_critical(_navigator->get_mavlink_fd(), "takeoff to %.1f meters above home", (double)(takeoff_alt - _navigator->get_home_position()->alt));
 
 			_mission_item.nav_cmd = NAV_CMD_TAKEOFF;
 			_mission_item.lat = _navigator->get_global_position()->lat;

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -437,6 +437,7 @@ Mission::set_mission_items()
 			_mission_item.nav_cmd = NAV_CMD_TAKEOFF;
 			_mission_item.lat = _navigator->get_global_position()->lat;
 			_mission_item.lon = _navigator->get_global_position()->lon;
+			/* ignore yaw for takeoff items */
 			_mission_item.yaw = NAN;
 			_mission_item.altitude = takeoff_alt;
 			_mission_item.altitude_is_relative = false;
@@ -477,6 +478,13 @@ Mission::set_mission_items()
 		/* we just moved to the landing waypoint, now descend */
 		if (_work_item_type == WORK_ITEM_TYPE_MOVE_TO_LAND) {
 			new_work_item_type = WORK_ITEM_TYPE_DEFAULT;
+		}
+
+		/* ignore yaw for landing items */
+		/* XXX: if specified heading for landing is desired we could add another step before the descent
+		 * that aligns the vehicle first */
+		if (_mission_item.nav_cmd == NAV_CMD_LAND) {
+			_mission_item.yaw = NAN;
 		}
 
 	/* handle non-position mission items such as commands */

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -432,7 +432,7 @@ Mission::set_mission_items()
 
 			float takeoff_alt = calculate_takeoff_altitude(&_mission_item);
 
-			mavlink_log_critical(_navigator->get_mavlink_fd(), "takeoff to %.1f meters above home", (double)(takeoff_alt - _navigator->get_home_position()->alt));
+			mavlink_log_info(_navigator->get_mavlink_fd(), "takeoff to %.1f meters above home", (double)(takeoff_alt - _navigator->get_home_position()->alt));
 
 			_mission_item.nav_cmd = NAV_CMD_TAKEOFF;
 			_mission_item.lat = _navigator->get_global_position()->lat;
@@ -875,7 +875,7 @@ Mission::read_mission_item(bool onboard, int offset, struct mission_item_s *miss
 
 			} else {
 				if (offset == 0) {
-					mavlink_log_critical(_navigator->get_mavlink_fd(),
+					mavlink_log_info(_navigator->get_mavlink_fd(),
 							     "DO JUMP repetitions completed");
 				}
 				/* no more DO_JUMPS, therefore just try to continue with next mission item */

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -694,26 +694,22 @@ Mission::read_mission_item(bool onboard, int offset, struct mission_item_s *miss
 	dm_item_t dm_item;
 
 	struct mission_s *mission = (onboard) ? &_onboard_mission : &_offboard_mission;
-	int index_to_read = (onboard) ? _current_onboard_mission_index : _current_offboard_mission_index;
+	int current_index = (onboard) ? _current_onboard_mission_index : _current_offboard_mission_index;
+	int index_to_read = current_index + offset;
 
 	/* do not work on empty missions */
 	if (mission->count == 0) {
 		return false;
 	}
 
-	/* move to next item if there is one */
-	if (index_to_read + offset < ((int)mission->count - 1)) {
-		index_to_read += offset;
-	}
-
-	mission_index_ptr = &index_to_read;
-
 	if (onboard) {
 		/* onboard mission */
+		mission_index_ptr = (offset == 0) ? &_current_onboard_mission_index : &index_to_read;
 		dm_item = DM_KEY_WAYPOINTS_ONBOARD;
 
 	} else {
 		/* offboard mission */
+		mission_index_ptr = (offset == 0) ? &_current_offboard_mission_index : &index_to_read;
 		dm_item = DM_KEY_WAYPOINTS_OFFBOARD(_offboard_mission.dataman_id);
 	}
 
@@ -749,7 +745,7 @@ Mission::read_mission_item(bool onboard, int offset, struct mission_item_s *miss
 			if (mission_item_tmp.do_jump_current_count < mission_item_tmp.do_jump_repeat_count) {
 
 				/* only raise the repeat count if this is for the current mission item
-				* but not for the next mission item */
+				* but not for the read ahead mission item */
 				if (offset == 0) {
 					(mission_item_tmp.do_jump_current_count)++;
 					/* save repeat count */

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -136,11 +136,14 @@ private:
 
 	float get_absolute_altitude_for_item(struct mission_item_s &mission_item);
 
+	bool prepare_mission_items(bool onboard, struct mission_item_s *mission_item,
+		struct mission_item_s *next_mission_item, bool *has_next_item);
+
 	/**
 	 * Read current or next mission item from the dataman and watch out for DO_JUMPS
 	 * @return true if successful
 	 */
-	bool read_mission_item(bool onboard, bool is_current, struct mission_item_s *mission_item);
+	bool read_mission_item(bool onboard, int offset, struct mission_item_s *mission_item);
 
 	/**
 	 * Save current offboard mission state to dataman
@@ -204,6 +207,15 @@ private:
 	float _on_arrival_yaw; /**< holds the yaw value that should be applied when the current waypoint is reached */
 	float _distance_current_previous; /**< distance from previous to current sp in pos_sp_triplet,
 					    only use if current and previous are valid */
+
+	enum {
+		WORK_ITEM_TYPE_DEFAULT,
+		WORK_ITEM_TYPE_TAKEOFF,
+		WORK_ITEM_TYPE_LAND,
+		WORK_ITEM_TYPE_TRANSITION,
+		WORK_ITEM_TYPE_YAW
+	} _work_item_type;		/**< current type of work to do, intermediate to complete mission item */
+
 };
 
 #endif

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -233,7 +233,8 @@ private:
 		WORK_ITEM_TYPE_DEFAULT,		/**< default mission item */
 		WORK_ITEM_TYPE_TAKEOFF,		/**< takeoff before moving to waypoint */
 		WORK_ITEM_TYPE_MOVE_TO_LAND,	/**< move to land waypoint before descent */
-		WORK_ITEM_TYPE_ALIGN		/**< align for next waypoint */
+		WORK_ITEM_TYPE_ALIGN,		/**< align for next waypoint */
+		WORK_ITEM_TYPE_CMD_BEFORE_MOVE	/**<  */
 	} _work_item_type;	/**< current type of work to do (sub mission item) */
 
 };

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -185,7 +185,6 @@ MissionBlock::is_mission_item_reached()
 
 			/* check yaw if defined only for rotary wing except takeoff */
 			float yaw_err = _wrap_pi(_mission_item.yaw - _navigator->get_global_position()->yaw);
-			PX4_WARN("yaw err: %.3f", (float)yaw_err);
 
 			if (fabsf(yaw_err) < 0.2f) { /* TODO: get rid of magic number */
 				_waypoint_yaw_reached = true;

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -105,10 +105,10 @@ MissionBlock::is_mission_item_reached()
 		case NAV_CMD_LOITER_UNLIMITED:
 			return false;
 
-		case vehicle_command_s::VEHICLE_CMD_DO_DIGICAM_CONTROL: /* fallthrough */
-		case vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION:
+		case NAV_CMD_DO_DIGICAM_CONTROL: /* fallthrough */
+		case NAV_CMD_DO_VTOL_TRANSITION:
 			// XXX: we should wait on command ACK or status change instead
-			// currently we just wait so the command be processed
+			// currently we just wait so the command can be processed
 			if (hrt_absolute_time() - _action_start > 1000) {
 				return true;
 
@@ -185,6 +185,7 @@ MissionBlock::is_mission_item_reached()
 
 			/* check yaw if defined only for rotary wing except takeoff */
 			float yaw_err = _wrap_pi(_mission_item.yaw - _navigator->get_global_position()->yaw);
+			PX4_WARN("yaw err: %.3f", (float)yaw_err);
 
 			if (fabsf(yaw_err) < 0.2f) { /* TODO: get rid of magic number */
 				_waypoint_yaw_reached = true;
@@ -251,7 +252,7 @@ MissionBlock::issue_command(const struct mission_item_s *item)
 		return;
 	}
 
-	warnx("forwarding command.\n");
+	warnx("forwarding command %d\n", item->nav_cmd);
 	struct vehicle_command_s cmd = {};
 	mission_item_to_vehicle_command(item, &cmd);
 	_action_start = hrt_absolute_time();
@@ -268,8 +269,8 @@ bool
 MissionBlock::item_contains_position(const struct mission_item_s *item)
 {
 	// XXX: maybe extend that check onto item properties
-	if (item->nav_cmd == vehicle_command_s::VEHICLE_CMD_DO_DIGICAM_CONTROL ||
-			item->nav_cmd == vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION) {
+	if (item->nav_cmd == NAV_CMD_DO_DIGICAM_CONTROL ||
+			item->nav_cmd == NAV_CMD_DO_VTOL_TRANSITION) {
 		return false;
 	}
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -83,7 +83,7 @@ MissionBlock::is_mission_item_reached()
 {
 	/* handle non-navigation or indefinite waypoints */
 	switch (_mission_item.nav_cmd) {
-		// XXX: move handling to mission as well
+		// XXX: move handling to issue_command() as well
 		case NAV_CMD_DO_SET_SERVO: {
 			memset(&actuators, 0, sizeof(actuators));
 			actuators.control[_mission_item.actuator_num] = 1.0f / 2000 * -_mission_item.actuator_value;
@@ -296,7 +296,7 @@ MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *ite
 	sp->acceptance_radius = item->acceptance_radius;
 
 	switch (item->nav_cmd) {
-	case NAV_CMD_DO_SET_SERVO: // XXX: should be also return in the beginning for this?
+	case NAV_CMD_DO_SET_SERVO: // XXX: actually also a non position item
 			/* Set current position for loitering set point*/
 			sp->lat = _navigator->get_global_position()->lat;
 			sp->lon = _navigator->get_global_position()->lon;

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -67,6 +67,7 @@ MissionBlock::MissionBlock(Navigator *navigator, const char *name) :
 	_waypoint_position_reached(false),
 	_waypoint_yaw_reached(false),
 	_time_first_inside_orbit(0),
+	_action_start(0),
 	_actuators{},
 	_actuator_pub(nullptr),
 	_cmd_pub(nullptr)
@@ -82,6 +83,7 @@ MissionBlock::is_mission_item_reached()
 {
 	/* handle non-navigation or indefinite waypoints */
 	switch (_mission_item.nav_cmd) {
+		// XXX: move handling to mission as well
 		case NAV_CMD_DO_SET_SERVO: {
 			memset(&actuators, 0, sizeof(actuators));
 			actuators.control[_mission_item.actuator_num] = 1.0f / 2000 * -_mission_item.actuator_value;
@@ -105,18 +107,13 @@ MissionBlock::is_mission_item_reached()
 
 		case vehicle_command_s::VEHICLE_CMD_DO_DIGICAM_CONTROL: /* fallthrough */
 		case vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION:
-			{
-			/* forward the command to other processes */
-			warnx("got instantaneous command, forwarding.\n");
-			struct vehicle_command_s cmd = {};
-			cmd.command = _mission_item.nav_cmd;
-			mission_item_to_vehicle_command(&_mission_item, &cmd);
-			if (_cmd_pub != nullptr) {
-				orb_publish(ORB_ID(vehicle_command), _cmd_pub, &cmd);
+			// XXX: we should wait on command ACK or status change instead
+			// currently we just wait so the command be processed
+			if (hrt_absolute_time() - _action_start > 1000) {
+				return true;
+
 			} else {
-				_cmd_pub = orb_advertise(ORB_ID(vehicle_command), &cmd);
-			}
-			return true;
+				return false;
 			}
 
 		default:
@@ -238,6 +235,7 @@ MissionBlock::mission_item_to_vehicle_command(const struct mission_item_s *item,
 	cmd->param5 = item->params[4];
 	cmd->param6 = item->params[5];
 	cmd->param7 = item->params[6];
+	cmd->command = item->nav_cmd;
 
 	cmd->target_system = _navigator->get_vstatus()->system_id;
 	cmd->target_component = _navigator->get_vstatus()->component_id;
@@ -247,8 +245,45 @@ MissionBlock::mission_item_to_vehicle_command(const struct mission_item_s *item,
 }
 
 void
+MissionBlock::issue_command(const struct mission_item_s *item)
+{
+	if (item_contains_position(item)) {
+		return;
+	}
+
+	warnx("forwarding command.\n");
+	struct vehicle_command_s cmd = {};
+	mission_item_to_vehicle_command(item, &cmd);
+	_action_start = hrt_absolute_time();
+
+	if (_cmd_pub != nullptr) {
+		orb_publish(ORB_ID(vehicle_command), _cmd_pub, &cmd);
+
+	} else {
+		_cmd_pub = orb_advertise(ORB_ID(vehicle_command), &cmd);
+	}
+}
+
+bool
+MissionBlock::item_contains_position(const struct mission_item_s *item)
+{
+	// XXX: maybe extend that check onto item properties
+	if (item->nav_cmd == vehicle_command_s::VEHICLE_CMD_DO_DIGICAM_CONTROL ||
+			item->nav_cmd == vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION) {
+		return false;
+	}
+
+	return true;
+}
+
+void
 MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *item, struct position_setpoint_s *sp)
 {
+	/* don't change the setpoint for non-position items */
+	if (!item_contains_position(item)) {
+		return;
+	}
+
 	sp->valid = true;
 	sp->lat = item->lat;
 	sp->lon = item->lon;
@@ -261,7 +296,7 @@ MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *ite
 	sp->acceptance_radius = item->acceptance_radius;
 
 	switch (item->nav_cmd) {
-	case NAV_CMD_DO_SET_SERVO:
+	case NAV_CMD_DO_SET_SERVO: // XXX: should be also return in the beginning for this?
 			/* Set current position for loitering set point*/
 			sp->lat = _navigator->get_global_position()->lat;
 			sp->lon = _navigator->get_global_position()->lon;

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -105,11 +105,18 @@ MissionBlock::is_mission_item_reached()
 		case NAV_CMD_LOITER_UNLIMITED:
 			return false;
 
-		case NAV_CMD_DO_DIGICAM_CONTROL: /* fallthrough */
+		case NAV_CMD_DO_DIGICAM_CONTROL:
+			return true;
+
 		case NAV_CMD_DO_VTOL_TRANSITION:
-			// XXX: we should wait on command ACK or status change instead
-			// currently we just wait so the command can be processed
-			if (hrt_absolute_time() - _action_start > 1000) {
+			/*
+			 * We wait half a second to give the transition command time to propagate.
+			 * As soon as the timeout is over or when we're in transition mode let the mission continue.
+			 */
+			if (hrt_absolute_time() - _action_start > 500000 ||
+					_navigator->get_vstatus()->in_transition_mode) {
+				_action_start = 0;
+
 				return true;
 
 			} else {

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -78,6 +78,8 @@ protected:
 	 */
 	void reset_mission_item_reached();
 
+	bool item_contains_position(const struct mission_item_s *item);
+
 	/**
 	 * Convert a mission item to a position setpoint
 	 *
@@ -116,10 +118,13 @@ protected:
 	 */
 	void mission_item_to_vehicle_command(const struct mission_item_s *item, struct vehicle_command_s *cmd);
 
+	void issue_command(const struct mission_item_s *item);
+
 	mission_item_s _mission_item;
 	bool _waypoint_position_reached;
 	bool _waypoint_yaw_reached;
 	hrt_abstime _time_first_inside_orbit;
+	hrt_abstime _action_start;
 
 	actuator_controls_s _actuators;
 	orb_advert_t    _actuator_pub;

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -51,7 +51,6 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <uORB/topics/fence.h>
-#include <uORB/topics/vehicle_command.h>
 
 MissionFeasibilityChecker::MissionFeasibilityChecker() :
 	_mavlink_fd(-1),

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -347,14 +347,14 @@ MissionFeasibilityChecker::check_dist_1wp(dm_item_t dm_current, size_t nMissionI
 				if (mission_item.nav_cmd == NAV_CMD_DO_SET_SERVO){
 
 					/* check actuator number */
-					if (mission_item.actuator_num < 0 || mission_item.actuator_num > 5) {
-						mavlink_log_critical(_mavlink_fd, "Actuator number %d is out of bounds 0..5", (int)mission_item.actuator_num);
+					if (mission_item.params[0] < 0 || mission_item.params[0] > 5) {
+						mavlink_log_critical(_mavlink_fd, "Actuator number %d is out of bounds 0..5", (int)mission_item.params[0]);
 						warning_issued = true;
 						return false;
 					}
 					/* check actuator value */
-					if (mission_item.actuator_value < -2000 || mission_item.actuator_value > 2000) {
-						mavlink_log_critical(_mavlink_fd, "Actuator value %d is out of bounds -2000..2000", (int)mission_item.actuator_value);
+					if (mission_item.params[1] < -2000 || mission_item.params[1] > 2000) {
+						mavlink_log_critical(_mavlink_fd, "Actuator value %d is out of bounds -2000..2000", (int)mission_item.params[1]);
 						warning_issued = true;
 						return false;
 					}

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -103,9 +103,8 @@ struct mission_item_s {
 	int do_jump_mission_index;	/**< index where the do jump will go to                 */
 	unsigned do_jump_repeat_count;	/**< how many times do jump needs to be done            */
 	unsigned do_jump_current_count;	/**< count how many times the jump has been done	*/
-	int actuator_num;		/**< actuator number to be set 0..5 ( corresponds to AUX outputs 1..6    */
-	int actuator_value;		/**< new value for selected actuator in ms 900...2000         */
 	float params[7];		/**< array to store mission command values for MAV_FRAME_MISSION ***/
+	int8_t frame;			/**< mission frame ***/
 };
 #pragma pack(pop)
 #include <uORB/topics/mission.h>

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -103,8 +103,8 @@ struct mission_item_s {
 	int do_jump_mission_index;	/**< index where the do jump will go to                 */
 	unsigned do_jump_repeat_count;	/**< how many times do jump needs to be done            */
 	unsigned do_jump_current_count;	/**< count how many times the jump has been done	*/
-	int actuator_num;               /**< actuator number to be set 0..5 ( corresponds to AUX outputs 1..6    */
-	int actuator_value;             /**< new value for selected actuator in ms 900...2000         */
+	int actuator_num;		/**< actuator number to be set 0..5 ( corresponds to AUX outputs 1..6    */
+	int actuator_value;		/**< new value for selected actuator in ms 900...2000         */
 	float params[7];		/**< array to store mission command values for MAV_FRAME_MISSION ***/
 };
 #pragma pack(pop)


### PR DESCRIPTION
In general this will fix handling for 2 part mission items (takeoff, landing, transitions)
Fixes #3583
Fixes #3581
Fixes #3501
Fixes #3414

Should handle the following cases consistently:
 - [x] transition: yaw into direction of next wp then transition
 - [x] back transition: transition then move to wp
 - [x] back transition yaw issue
 - [x] takeoff: climb then move to wp
 - [x] land: move to wp then descend (fixes #3388)
 - [x] back transition: yaw north when flying south
