### PR TITLE
hotfix:

### DIFF
--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -203,3 +203,12 @@ PARAM_DEFINE_FLOAT(VT_ARSP_BLEND, 8.0f);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_FLOAT(VT_ARSP_TRANS, 10.0f);
+
+/**
+ * Enable optimal recovery strategy for pitch-weak tailsitters
+ *
+ * @min 0
+ * @max 1
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_INT32(VT_OPT_RECOV_EN, 0);


### PR DESCRIPTION
multirotors shouldn't use tailsitter recovery code.