### PR TITLE
Renamed shadowed variable

### DIFF
--- a/src/modules/uavcan/uavcan_servers.cpp
+++ b/src/modules/uavcan/uavcan_servers.cpp
@@ -1050,15 +1050,15 @@ void UavcanServers::unpackFwFromROMFS(const char* sd_path, const char* romfs_pat
 						 */
 						copy_fw = false;
 					} else if (!memcmp(fw_dirent->d_name, UAVCAN_ROMFS_FW_PREFIX, sizeof(UAVCAN_ROMFS_FW_PREFIX) - 1)) {
-						size_t fw_len = strlen(fw_dirent->d_name);
-						size_t dstpath_fw_len = dstpath_ver_len + fw_len;
+						size_t dst_fw_len = strlen(fw_dirent->d_name);
+						size_t dstpath_fw_len = dstpath_ver_len + dst_fw_len;
 						if (dstpath_fw_len > maxlen) {
 							// sizeof(prefix) includes trailing NUL, cancelling out the +1 for the path separator
 							warnx("unlink: path '%s/%s' too long", dstpath, fw_dirent->d_name);
 						} else {
 							// File name starts with "_", delete it.
 							dstpath[dstpath_ver_len] = '/';
-							memcpy(&dstpath[dstpath_ver_len + 1], fw_dirent->d_name, fw_len + 1);
+							memcpy(&dstpath[dstpath_ver_len + 1], fw_dirent->d_name, dst_fw_len + 1);
 							unlink(dstpath);
 							warnx("unlink: removed '%s'", dstpath);
 						}


### PR DESCRIPTION
Fixes compile error with APM and gcc 4.9.3