### PR TITLE
Free-fall / throw detection

### DIFF
--- a/msg/vehicle_land_detected.msg
+++ b/msg/vehicle_land_detected.msg
@@ -1,2 +1,3 @@
 uint64 timestamp	# timestamp of the setpoint
 bool landed		# true if vehicle is currently landed on the ground
+bool freefall	# true if vehicle is currently in free-fall

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1119,6 +1119,7 @@ int commander_thread_main(int argc, char *argv[])
 	bool sensor_fail_tune_played = false;
 	bool arm_tune_played = false;
 	bool was_landed = true;
+	bool was_falling = false;
 	bool was_armed = false;
 
 	bool startup_in_hil = false;
@@ -1918,10 +1919,11 @@ int commander_thread_main(int argc, char *argv[])
 		}
 
 		if ((updated && status_flags.condition_local_altitude_valid) || check_for_disarming) {
-			if (was_landed != land_detector.landed) {
-				if (land_detector.landed) {
+			if ((was_landed != land_detector.landed) || (was_falling != land_detector.freefall)) {
+				if (land_detector.freefall) {
+					mavlink_and_console_log_info(&mavlink_log_pub, "FREEFALL DETECTED");
+				} else if (land_detector.landed) {
 					mavlink_and_console_log_info(&mavlink_log_pub, "LANDING DETECTED");
-
 				} else {
 					mavlink_and_console_log_info(&mavlink_log_pub, "TAKEOFF DETECTED");
 				}
@@ -2624,6 +2626,7 @@ int commander_thread_main(int argc, char *argv[])
 		}
 
 		was_landed = land_detector.landed;
+		was_falling = land_detector.freefall;
 		was_armed = armed.armed;
 
 		/* print new state */

--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -46,6 +46,9 @@
 #include <cmath>
 #include <drivers/drv_hrt.h>
 
+namespace landdetection
+{
+
 FixedwingLandDetector::FixedwingLandDetector() : LandDetector(),
 	_paramHandle(),
 	_params(),
@@ -84,11 +87,30 @@ void FixedwingLandDetector::updateSubscriptions()
 	orb_update(ORB_ID(airspeed), _airspeedSub, &_airspeed);
 }
 
-bool FixedwingLandDetector::update()
+LandDetectionResult FixedwingLandDetector::update()
 {
 	// First poll for new data from our subscriptions
 	updateSubscriptions();
 
+	if (get_freefall_state()) {
+		_state = LANDDETECTION_RES_FREEFALL;
+	}else if(get_landed_state()){
+		_state = LANDDETECTION_RES_LANDED;
+	}else{
+		_state = LANDDETECTION_RES_FLYING;
+	}
+
+	return _state;
+}
+
+bool FixedwingLandDetector::get_freefall_state()
+{
+	//TODO
+	return false;
+}
+
+bool FixedwingLandDetector::get_landed_state()
+{
 	// only trigger flight conditions if we are armed
 	if (!_arming.armed) {
 		return true;
@@ -158,4 +180,6 @@ void FixedwingLandDetector::updateParameterCache(const bool force)
 		param_get(_paramHandle.maxAirSpeed, &_params.maxAirSpeed);
 		param_get(_paramHandle.maxIntVelocity, &_params.maxIntVelocity);
 	}
+}
+
 }

--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -94,9 +94,11 @@ LandDetectionResult FixedwingLandDetector::update()
 
 	if (get_freefall_state()) {
 		_state = LANDDETECTION_RES_FREEFALL;
-	}else if(get_landed_state()){
+
+	} else if (get_landed_state()) {
 		_state = LANDDETECTION_RES_LANDED;
-	}else{
+
+	} else {
 		_state = LANDDETECTION_RES_FLYING;
 	}
 

--- a/src/modules/land_detector/FixedwingLandDetector.h
+++ b/src/modules/land_detector/FixedwingLandDetector.h
@@ -49,6 +49,9 @@
 #include <uORB/topics/airspeed.h>
 #include <systemlib/param/param.h>
 
+namespace landdetection
+{
+
 class FixedwingLandDetector : public LandDetector
 {
 public:
@@ -58,7 +61,7 @@ protected:
 	/**
 	* @brief  blocking loop, should be run in a separate thread or task. Runs at 50Hz
 	**/
-	bool update() override;
+	LandDetectionResult update() override;
 
 	/**
 	* @brief Initializes the land detection algorithm
@@ -69,6 +72,16 @@ protected:
 	* @brief  polls all subscriptions and pulls any data that has changed
 	**/
 	void updateSubscriptions();
+
+	/**
+	* @brief get UAV landed state
+	**/
+	bool get_landed_state();
+
+	/**
+	* @brief returns true if UAV is in free-fall state
+	**/
+	bool get_freefall_state();
 
 private:
 	/**
@@ -108,5 +121,7 @@ private:
 	float _accel_horz_lp;
 	uint64_t _landDetectTrigger;
 };
+
+}
 
 #endif //__FIXED_WING_LAND_DETECTOR_H__

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -103,8 +103,8 @@ void LandDetector::cycle()
 	}
 
 	LandDetectionResult current_state = update();
-	bool landDetected = (current_state==LANDDETECTION_RES_LANDED);
-	bool freefallDetected = (current_state==LANDDETECTION_RES_FREEFALL);
+	bool landDetected = (current_state == LANDDETECTION_RES_LANDED);
+	bool freefallDetected = (current_state == LANDDETECTION_RES_FREEFALL);
 
 	// publish if land detection state has changed
 	if ((_landDetected.landed != landDetected) || (_landDetected.freefall != freefallDetected)) {

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -45,6 +45,9 @@
 #include <px4_config.h>
 #include <px4_defines.h>
 
+namespace landdetection
+{
+
 LandDetector::LandDetector() :
 	_landDetectedPub(0),
 	_landDetected( {0, false}),
@@ -88,6 +91,7 @@ void LandDetector::cycle()
 		// advertise the first land detected uORB
 		_landDetected.timestamp = hrt_absolute_time();
 		_landDetected.landed = false;
+		_landDetected.freefall = false;
 		_landDetectedPub = orb_advertise(ORB_ID(vehicle_land_detected), &_landDetected);
 
 		// initialize land detection algorithm
@@ -98,12 +102,15 @@ void LandDetector::cycle()
 		_taskShouldExit = false;
 	}
 
-	bool landDetected = update();
+	LandDetectionResult current_state = update();
+	bool landDetected = (current_state==LANDDETECTION_RES_LANDED);
+	bool freefallDetected = (current_state==LANDDETECTION_RES_FREEFALL);
 
 	// publish if land detection state has changed
-	if (_landDetected.landed != landDetected) {
+	if ((_landDetected.landed != landDetected) || (_landDetected.freefall != freefallDetected)) {
 		_landDetected.timestamp = hrt_absolute_time();
 		_landDetected.landed = landDetected;
+		_landDetected.freefall = freefallDetected;
 
 		// publish the land detected broadcast
 		orb_publish(ORB_ID(vehicle_land_detected), (orb_advert_t)_landDetectedPub, &_landDetected);
@@ -134,4 +141,6 @@ bool LandDetector::orb_update(const struct orb_metadata *meta, int handle, void 
 	}
 
 	return true;
+}
+
 }

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -108,6 +108,8 @@ protected:
 
 	static constexpr uint64_t LAND_DETECTOR_TRIGGER_TIME = 2000000;  /**< usec that landing conditions have to hold
                                                                           before triggering a land */
+	static constexpr uint64_t FREEFALL_DETECTOR_TRIGGER_TIME = 300000;  /**< usec that freefall conditions have to hold
+                                                                          before triggering a freefall */
 	static constexpr uint64_t LAND_DETECTOR_ARM_PHASE_TIME =
 		2000000;	/**< time interval in which wider acceptance thresholds are used after arming */
 

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -45,6 +45,15 @@
 #include <uORB/uORB.h>
 #include <uORB/topics/vehicle_land_detected.h>
 
+namespace landdetection
+{
+
+enum LandDetectionResult {
+	LANDDETECTION_RES_FLYING = 0,	/**< UAV is flying */
+	LANDDETECTION_RES_LANDED = 1,	/**< Land has been detected */
+	LANDDETECTION_RES_FREEFALL = 2	/**< Free-fall has been detected */
+};
+
 class LandDetector
 {
 public:
@@ -81,7 +90,7 @@ protected:
 	* @brief Pure abstract method that must be overriden by sub-classes. This actually runs the underlying algorithm
 	* @return true if a landing was detected and this should be broadcast to the rest of the system
 	**/
-	virtual bool update() = 0;
+	virtual LandDetectionResult update() = 0;
 
 	/**
 	* @brief Pure abstract method that is called by this class once for initializing the uderlying algorithm (memory allocation,
@@ -106,6 +115,7 @@ protected:
 	orb_advert_t				_landDetectedPub;		/**< publisher for position in local frame */
 	struct vehicle_land_detected_s		_landDetected;			/**< local vehicle position */
 	uint64_t				_arming_time;			/**< timestamp of arming time */
+	LandDetectionResult _state;		/**< Result of land detection. Can be LANDDETECTION_RES_FLYING, LANDDETECTION_RES_LANDED or LANDDETECTION_RES_FREEFALL */
 
 private:
 	bool _taskShouldExit;                                               /**< true if it is requested that this task should exit */
@@ -114,5 +124,7 @@ private:
 
 	void		cycle();
 };
+
+}
 
 #endif //__LAND_DETECTOR_H__

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -108,13 +108,15 @@ protected:
 
 	static constexpr uint64_t LAND_DETECTOR_TRIGGER_TIME = 2000000;  /**< usec that landing conditions have to hold
                                                                           before triggering a land */
-	static constexpr uint64_t LAND_DETECTOR_ARM_PHASE_TIME = 2000000;	/**< time interval in which wider acceptance thresholds are used after arming */
+	static constexpr uint64_t LAND_DETECTOR_ARM_PHASE_TIME =
+		2000000;	/**< time interval in which wider acceptance thresholds are used after arming */
 
 protected:
 	orb_advert_t				_landDetectedPub;		/**< publisher for position in local frame */
 	struct vehicle_land_detected_s		_landDetected;			/**< local vehicle position */
 	uint64_t				_arming_time;			/**< timestamp of arming time */
-	LandDetectionResult _state;		/**< Result of land detection. Can be LANDDETECTION_RES_FLYING, LANDDETECTION_RES_LANDED or LANDDETECTION_RES_FREEFALL */
+	LandDetectionResult
+	_state;		/**< Result of land detection. Can be LANDDETECTION_RES_FLYING, LANDDETECTION_RES_LANDED or LANDDETECTION_RES_FREEFALL */
 
 private:
 	bool _taskShouldExit;                                               /**< true if it is requested that this task should exit */

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -108,10 +108,7 @@ protected:
 
 	static constexpr uint64_t LAND_DETECTOR_TRIGGER_TIME = 2000000;  /**< usec that landing conditions have to hold
                                                                           before triggering a land */
-	static constexpr uint64_t FREEFALL_DETECTOR_TRIGGER_TIME = 300000;  /**< usec that freefall conditions have to hold
-                                                                          before triggering a freefall */
-	static constexpr uint64_t LAND_DETECTOR_ARM_PHASE_TIME =
-		2000000;	/**< time interval in which wider acceptance thresholds are used after arming */
+	static constexpr uint64_t LAND_DETECTOR_ARM_PHASE_TIME = 2000000;	/**< time interval in which wider acceptance thresholds are used after arming */
 
 protected:
 	orb_advert_t				_landDetectedPub;		/**< publisher for position in local frame */

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -107,8 +107,10 @@ LandDetectionResult MulticopterLandDetector::update()
 
 	if (get_freefall_state()) {
 		_state = LANDDETECTION_RES_FREEFALL;
+
 	} else if (get_landed_state()) {
 		_state = LANDDETECTION_RES_LANDED;
+
 	} else {
 		_state = LANDDETECTION_RES_FLYING;
 	}
@@ -118,19 +120,23 @@ LandDetectionResult MulticopterLandDetector::update()
 
 bool MulticopterLandDetector::get_freefall_state()
 {
-	if(_params.acc_threshold_m_s2 < 0.1f || _params.acc_threshold_m_s2 > 10.0f){	//if parameter is set to zero or invalid, disable free-fall detection.
+	if (_params.acc_threshold_m_s2 < 0.1f
+	    || _params.acc_threshold_m_s2 > 10.0f) {	//if parameter is set to zero or invalid, disable free-fall detection.
 		return false;
 	}
 
 	const uint64_t now = hrt_absolute_time();
 
 	float acc_norm = 0.0;
+
 	for (int i = 0; i < 3; i++) {
 		acc_norm += _sensors.accelerometer_m_s2[i] * _sensors.accelerometer_m_s2[i];
 	}
+
 	acc_norm = sqrtf(acc_norm);	//norm of specific force. Should be close to 9.8 m/s^2 when landed.
 
 	bool freefall = (acc_norm < _params.acc_threshold_m_s2);	//true if we are currently falling
+
 	if (!freefall || _freefallTimer == 0) {	//reset timer if uav not falling
 		_freefallTimer = now;
 		return false;
@@ -191,8 +197,8 @@ bool MulticopterLandDetector::get_landed_state()
 	float maxRotationScaled = _params.maxRotation_rad_s * armThresholdFactor;
 
 	bool rotating = (fabsf(_vehicleAttitude.rollspeed)  > maxRotationScaled) ||
-	                (fabsf(_vehicleAttitude.pitchspeed) > maxRotationScaled) ||
-	                (fabsf(_vehicleAttitude.yawspeed) > maxRotationScaled);
+			(fabsf(_vehicleAttitude.pitchspeed) > maxRotationScaled) ||
+			(fabsf(_vehicleAttitude.yawspeed) > maxRotationScaled);
 
 
 	if (verticalMovement || rotating || !minimalThrust || horizontalMovement) {

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -126,7 +126,7 @@ bool MulticopterLandDetector::get_freefall_state()
 	}
 	acc_norm = sqrtf(acc_norm);	//norm of specific force
 
-	int32_t elapsed_time_ms = (now - _freefallTimer)/1000;
+	int32_t elapsed_time_ms = (now - _freefallTimer) / 1000;
 	bool freefall = (acc_norm < _params.acc_threshold_m_s2);
 	if (!freefall || _freefallTimer == 0) {	//reset timer if uav not falling
 		_freefallTimer = now;

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -45,6 +45,9 @@
 #include <drivers/drv_hrt.h>
 #include <mathlib/mathlib.h>
 
+namespace landdetection
+{
+
 MulticopterLandDetector::MulticopterLandDetector() : LandDetector(),
 	_paramHandle(),
 	_params(),
@@ -89,14 +92,28 @@ void MulticopterLandDetector::updateSubscriptions()
 	orb_update(ORB_ID(manual_control_setpoint), _manualSub, &_manual);
 }
 
-bool MulticopterLandDetector::update()
+LandDetectionResult MulticopterLandDetector::update()
 {
 	// first poll for new data from our subscriptions
 	updateSubscriptions();
 
 	updateParameterCache(false);
 
-	return get_landed_state();
+	if (get_freefall_state()) {
+		_state = LANDDETECTION_RES_FREEFALL;
+	}else if(get_landed_state()){
+		_state = LANDDETECTION_RES_LANDED;
+	}else{
+		_state = LANDDETECTION_RES_FLYING;
+	}
+
+	return _state;
+}
+
+bool MulticopterLandDetector::get_freefall_state()
+{
+	//TODO
+	return false;
 }
 
 bool MulticopterLandDetector::get_landed_state()
@@ -182,4 +199,6 @@ void MulticopterLandDetector::updateParameterCache(const bool force)
 		_params.maxRotation_rad_s = math::radians(_params.maxRotation_rad_s);
 		param_get(_paramHandle.maxThrottle, &_params.maxThrottle);
 	}
+}
+
 }

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -128,8 +128,8 @@ bool MulticopterLandDetector::get_freefall_state()
 	const uint64_t now = hrt_absolute_time();
 
 	float acc_norm = _ctrl_state.x_acc * _ctrl_state.x_acc
-		+ _ctrl_state.y_acc * _ctrl_state.y_acc
-		+ _ctrl_state.z_acc * _ctrl_state.z_acc;
+			 + _ctrl_state.y_acc * _ctrl_state.y_acc
+			 + _ctrl_state.z_acc * _ctrl_state.z_acc;
 	acc_norm = sqrtf(acc_norm);	//norm of specific force. Should be close to 9.8 m/s^2 when landed.
 
 	bool freefall = (acc_norm < _params.acc_threshold_m_s2);	//true if we are currently falling

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -52,6 +52,9 @@
 #include <uORB/topics/manual_control_setpoint.h>
 #include <systemlib/param/param.h>
 
+namespace landdetection
+{
+
 class MulticopterLandDetector : public LandDetector
 {
 public:
@@ -66,7 +69,7 @@ protected:
 	/**
 	* @brief Runs one iteration of the land detection algorithm
 	**/
-	virtual bool update() override;
+	virtual LandDetectionResult update() override;
 
 	/**
 	* @brief Initializes the land detection algorithm
@@ -82,6 +85,11 @@ protected:
 	* @brief get multicopter landed state
 	**/
 	bool get_landed_state();
+
+	/**
+	* @brief returns true if multicopter is in free-fall state
+	**/
+	bool get_freefall_state();
 
 private:
 
@@ -119,5 +127,7 @@ private:
 	/* timestamp in microseconds since a possible land was detected */
 	uint64_t _landTimer;
 };
+
+}
 
 #endif //__MULTICOPTER_LAND_DETECTOR_H__

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -50,7 +50,7 @@
 #include <uORB/topics/actuator_armed.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/manual_control_setpoint.h>
-#include <uORB/topics/sensor_combined.h>
+#include <uORB/topics/control_state.h>
 #include <systemlib/param/param.h>
 
 namespace landdetection
@@ -122,14 +122,14 @@ private:
 	int _parameterSub;
 	int _attitudeSub;
 	int _manualSub;
-	int _sensorsSub;
+	int _ctrl_state_sub;
 
 	struct vehicle_local_position_s		_vehicleLocalPosition;
 	struct actuator_controls_s		_actuators;
 	struct actuator_armed_s			_arming;
 	struct vehicle_attitude_s		_vehicleAttitude;
 	struct manual_control_setpoint_s	_manual;
-	struct sensor_combined_s 		_sensors;
+	struct control_state_s				_ctrl_state;
 
 	uint64_t _landTimer;							/**< timestamp in microseconds since a possible land was detected*/
 	uint64_t _freefallTimer;							/**< timestamp in microseconds since a possible freefall was detected*/

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -103,6 +103,7 @@ private:
 		param_t maxRotation;
 		param_t maxThrottle;
 		param_t acc_threshold_m_s2;
+		param_t ff_trigger_time_ms;
 	}		_paramHandle;
 
 	struct {
@@ -111,6 +112,7 @@ private:
 		float maxRotation_rad_s;
 		float maxThrottle;
 		float acc_threshold_m_s2;
+		uint32_t ff_trigger_time_ms;
 	} _params;
 
 private:

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -50,6 +50,7 @@
 #include <uORB/topics/actuator_armed.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/manual_control_setpoint.h>
+#include <uORB/topics/sensor_combined.h>
 #include <systemlib/param/param.h>
 
 namespace landdetection
@@ -101,6 +102,7 @@ private:
 		param_t maxVelocity;
 		param_t maxRotation;
 		param_t maxThrottle;
+		param_t acc_threshold_m_s2;
 	}		_paramHandle;
 
 	struct {
@@ -108,6 +110,7 @@ private:
 		float maxVelocity;
 		float maxRotation_rad_s;
 		float maxThrottle;
+		float acc_threshold_m_s2;
 	} _params;
 
 private:
@@ -117,15 +120,17 @@ private:
 	int _parameterSub;
 	int _attitudeSub;
 	int _manualSub;
+	int _sensorsSub;
 
 	struct vehicle_local_position_s		_vehicleLocalPosition;
 	struct actuator_controls_s		_actuators;
 	struct actuator_armed_s			_arming;
 	struct vehicle_attitude_s		_vehicleAttitude;
 	struct manual_control_setpoint_s	_manual;
+	struct sensor_combined_s 		_sensors;
 
-	/* timestamp in microseconds since a possible land was detected */
-	uint64_t _landTimer;
+	uint64_t _landTimer;							/**< timestamp in microseconds since a possible land was detected*/
+	uint64_t _freefallTimer;							/**< timestamp in microseconds since a possible freefall was detected*/
 };
 
 }

--- a/src/modules/land_detector/VtolLandDetector.cpp
+++ b/src/modules/land_detector/VtolLandDetector.cpp
@@ -41,6 +41,9 @@
 #include "VtolLandDetector.h"
 #include <drivers/drv_hrt.h>
 
+namespace landdetection
+{
+
 VtolLandDetector::VtolLandDetector() : MulticopterLandDetector(),
 	_paramHandle(),
 	_params(),
@@ -69,7 +72,7 @@ void VtolLandDetector::updateSubscriptions()
 	orb_update(ORB_ID(airspeed), _airspeedSub, &_airspeed);
 }
 
-bool VtolLandDetector::update()
+LandDetectionResult VtolLandDetector::update()
 {
 	updateSubscriptions();
 	updateParameterCache(false);
@@ -94,7 +97,9 @@ bool VtolLandDetector::update()
 
 	_was_in_air = !landed;
 
-	return landed;
+	_state = (landed) ? LANDDETECTION_RES_LANDED : LANDDETECTION_RES_FLYING;
+
+	return _state;
 }
 
 void VtolLandDetector::updateParameterCache(const bool force)
@@ -113,4 +118,6 @@ void VtolLandDetector::updateParameterCache(const bool force)
 	if (updated || force) {
 		param_get(_paramHandle.maxAirSpeed, &_params.maxAirSpeed);
 	}
+}
+
 }

--- a/src/modules/land_detector/VtolLandDetector.h
+++ b/src/modules/land_detector/VtolLandDetector.h
@@ -44,6 +44,9 @@
 #include "MulticopterLandDetector.h"
 #include <uORB/topics/airspeed.h>
 
+namespace landdetection
+{
+
 class VtolLandDetector : public MulticopterLandDetector
 {
 public:
@@ -59,7 +62,7 @@ private:
 	/**
 	* @brief Runs one iteration of the land detection algorithm
 	**/
-	bool update() override;
+	LandDetectionResult update() override;
 
 	/**
 	* @brief Initializes the land detection algorithm
@@ -92,3 +95,5 @@ private:
 };
 
 #endif
+
+}

--- a/src/modules/land_detector/land_detector_main.cpp
+++ b/src/modules/land_detector/land_detector_main.cpp
@@ -55,6 +55,9 @@
 #include "MulticopterLandDetector.h"
 #include "VtolLandDetector.h"
 
+namespace landdetection
+{
+
 //Function prototypes
 static int land_detector_start(const char *mode);
 static void land_detector_stop();
@@ -207,4 +210,6 @@ exiterr:
 	PX4_WARN("usage: land_detector {start|stop|status} [mode]");
 	PX4_WARN("mode can either be 'fixedwing' or 'multicopter'");
 	return 1;
+}
+
 }

--- a/src/modules/land_detector/land_detector_params.c
+++ b/src/modules/land_detector/land_detector_params.c
@@ -93,7 +93,19 @@ PARAM_DEFINE_FLOAT(LNDMC_THR_MAX, 0.15f);
  *
  * @group Land Detector
  */
-PARAM_DEFINE_FLOAT(LNDMC_FFALL_THR, 1.0f);
+PARAM_DEFINE_FLOAT(LNDMC_FFALL_THR, 2.0f);
+
+/**
+ * Multicopter free-fall trigger time
+ *
+ * milliseconds that freefall conditions have to hold before triggering a freefall
+ *
+ * @min 20
+ * @max 5000
+ *
+ * @group Land Detector
+ */
+PARAM_DEFINE_INT32(LNDMC_FFALL_TRIG, 200);	//minimal value is limited by LAND_DETECTOR_UPDATE_RATE=50Hz in landDetector.h
 
 /**
  * Fixedwing max horizontal velocity

--- a/src/modules/land_detector/land_detector_params.c
+++ b/src/modules/land_detector/land_detector_params.c
@@ -84,6 +84,18 @@ PARAM_DEFINE_FLOAT(LNDMC_ROT_MAX, 20.0f);
 PARAM_DEFINE_FLOAT(LNDMC_THR_MAX, 0.15f);
 
 /**
+ * Multicopter specific force threshold
+ *
+ * Multicopter threshold on the specific force measured by accelerometers in m/s^2 for free-fall detection
+ *
+ * @min 0.1
+ * @max 10
+ *
+ * @group Land Detector
+ */
+PARAM_DEFINE_FLOAT(LNDMC_FFALL_THR, 1.0f);
+
+/**
  * Fixedwing max horizontal velocity
  *
  * Maximum horizontal velocity allowed in the landed state (m/s)

--- a/src/modules/land_detector/land_detector_params.c
+++ b/src/modules/land_detector/land_detector_params.c
@@ -105,7 +105,7 @@ PARAM_DEFINE_FLOAT(LNDMC_FFALL_THR, 2.0f);
  *
  * @group Land Detector
  */
-PARAM_DEFINE_INT32(LNDMC_FFALL_TRIG, 200);	//minimal value is limited by LAND_DETECTOR_UPDATE_RATE=50Hz in landDetector.h
+PARAM_DEFINE_INT32(LNDMC_FFALL_TRIG, 300);	//minimal value is limited by LAND_DETECTOR_UPDATE_RATE=50Hz in landDetector.h
 
 /**
  * Fixedwing max horizontal velocity

--- a/src/modules/land_detector/land_detector_params.c
+++ b/src/modules/land_detector/land_detector_params.c
@@ -105,7 +105,8 @@ PARAM_DEFINE_FLOAT(LNDMC_FFALL_THR, 2.0f);
  *
  * @group Land Detector
  */
-PARAM_DEFINE_INT32(LNDMC_FFALL_TRIG, 300);	//minimal value is limited by LAND_DETECTOR_UPDATE_RATE=50Hz in landDetector.h
+PARAM_DEFINE_INT32(LNDMC_FFALL_TRIG,
+		   300);	//minimal value is limited by LAND_DETECTOR_UPDATE_RATE=50Hz in landDetector.h
 
 /**
  * Fixedwing max horizontal velocity

--- a/src/modules/land_detector/land_detector_params.c
+++ b/src/modules/land_detector/land_detector_params.c
@@ -98,15 +98,15 @@ PARAM_DEFINE_FLOAT(LNDMC_FFALL_THR, 2.0f);
 /**
  * Multicopter free-fall trigger time
  *
- * milliseconds that freefall conditions have to hold before triggering a freefall
+ * Milliseconds that freefall conditions have to hold before triggering a freefall.
+ * Minimal value is limited by LAND_DETECTOR_UPDATE_RATE=50Hz in landDetector.h
  *
  * @min 20
  * @max 5000
  *
  * @group Land Detector
  */
-PARAM_DEFINE_INT32(LNDMC_FFALL_TRIG,
-		   300);	//minimal value is limited by LAND_DETECTOR_UPDATE_RATE=50Hz in landDetector.h
+PARAM_DEFINE_INT32(LNDMC_FFALL_TRIG, 300);
 
 /**
  * Fixedwing max horizontal velocity


### PR DESCRIPTION
This adds free-fall/throw detection capabilities to the land_detector class and in the commander.
- One can set a detection threshold using LNDMC_FFALL_THR parameter.
- LNDMC_FFALL_TRIG parameter sets the time that free-fall conditions have to hold before triggering.
- Commander is notified and vehicle_status is updated.
