### PR TITLE
limit takeoff and land velocity to max z velocity

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -558,6 +558,10 @@ MulticopterPositionControl::parameters_update(bool force)
 
 		param_get(_params_handles.mc_att_yaw_p, &v);
 		_params.mc_att_yaw_p = v;
+
+		/* takeoff and land velocities should not exceed maximum */
+		_params.tko_speed = fminf(_params.tko_speed, _params.vel_max(2));
+		_params.land_speed = fminf(_params.land_speed, _params.vel_max(2));
 	}
 
 	return OK;


### PR DESCRIPTION
Fixes #3561
@tumbili the position during takeoff can overtake the setpoint so it drops a bit when switching to the waypoint. really noticable in sitl if the thrust ramp happens before arming (velocity overshoots and hardly goes down)