### PR TITLE
Set default node id to 1, default bitrate to 1M

### DIFF
--- a/src/modules/uavcan/uavcan_main.cpp
+++ b/src/modules/uavcan/uavcan_main.cpp
@@ -1252,7 +1252,7 @@ int uavcan_main(int argc, char *argv[])
 		}
 
 		// Node ID
-		int32_t node_id = 0;
+		int32_t node_id = 1;
 		(void)param_get(param_find("UAVCAN_NODE_ID"), &node_id);
 
 		if (node_id < 0 || node_id > uavcan::NodeID::Max || !uavcan::NodeID(node_id).isUnicast()) {
@@ -1261,7 +1261,7 @@ int uavcan_main(int argc, char *argv[])
 		}
 
 		// CAN bitrate
-		int32_t bitrate = 0;
+		int32_t bitrate = 1000000;
 		(void)param_get(param_find("UAVCAN_BITRATE"), &bitrate);
 
 		// Start


### PR DESCRIPTION
This change would allow to get the bus running on default settings, if the PX4 parameter system is unavailable (e.g. in APM).