### PR TITLE
add Frsky 2-way D type telemetry fix

### DIFF
--- a/src/drivers/frsky_telemetry/frsky_telemetry.c
+++ b/src/drivers/frsky_telemetry/frsky_telemetry.c
@@ -198,11 +198,12 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 	 */
 	int status = poll(fds, sizeof(fds) / sizeof(fds[0]), 3000);
 
+//	warnx("poll status: %u", status);
 	if (status > 0) {
 		/* received some data; check size of packet */
 		usleep(5000);
 		status = read(uart, &sbuf[0], sizeof(sbuf));
-		warnx("received %u bytes", status);
+//		warnx("received %u bytes", status);
 	}
 
 	if (status > 0 && status < 3) {


### PR DESCRIPTION
check for incoming D type telemetry data and distinguish it from SmartPort
tested using X4R-SB on smartport of PixRacer, D4R-II on /dev/ttyS2 of FMUv2

not parsing the incoming data, but it contains both RSSI and the AD2 input which would be useful additions
