### PR TITLE
WIP: Frsky D telemetry parsing

### DIFF
--- a/src/drivers/frsky_telemetry/frsky_data.c
+++ b/src/drivers/frsky_telemetry/frsky_data.c
@@ -289,7 +289,7 @@ void frsky_send_frame3(int uart)
 }
 
 /* parse 11 byte frames */
-bool frsky_parse_host(uint8_t * sbuf, int nbytes, struct adc_linkquality * v)
+bool frsky_parse_host(uint8_t *sbuf, int nbytes, struct adc_linkquality *v)
 {
 	bool data_ready = false;
 	static int dcount = 0;
@@ -302,36 +302,46 @@ bool frsky_parse_host(uint8_t * sbuf, int nbytes, struct adc_linkquality * v)
 		TRAILER
 	} state = HEADER;
 
-	for (int i=0; i<nbytes; i++) {
+	for (int i = 0; i < nbytes; i++) {
 		switch (state) {
 		case HEADER:
 			if (sbuf[i] == 0x7E) {
 				state = TYPE;
 			}
+
 			break;
+
 		case TYPE:
 			if (sbuf[i] != 0x7E) {
 				state = DATA;
 				type = sbuf[i];
 				dcount = 0;
 			}
+
 			break;
+
 		case DATA:
+
 			/* read 8 data bytes */
 			if (dcount < 7) {
 				data[dcount++] = sbuf[i];
-			}
-			else {
+
+			} else {
 				/* received all data bytes */
 				state = TRAILER;
 			}
+
 			break;
+
 		case TRAILER:
 			state = HEADER;
+
 			if (sbuf[i] != 0x7E) {
 				warnx("host packet error: %x", sbuf[i]);
+
 			} else {
 				data_ready = true;
+
 				if (type == 0xFE) {
 					/* this is an adc_linkquality packet */
 					v->ad1 = data[0];
@@ -339,9 +349,11 @@ bool frsky_parse_host(uint8_t * sbuf, int nbytes, struct adc_linkquality * v)
 					v->linkq = data[2];
 				}
 			}
+
 			break;
 		}
 	}
+
 	return data_ready;
 }
 

--- a/src/drivers/frsky_telemetry/frsky_data.h
+++ b/src/drivers/frsky_telemetry/frsky_data.h
@@ -42,10 +42,19 @@
 #ifndef _FRSKY_DATA_H
 #define _FRSKY_DATA_H
 
+#include <stdbool.h>
+
 // Public functions
 void frsky_init(void);
 void frsky_send_frame1(int uart);
 void frsky_send_frame2(int uart);
 void frsky_send_frame3(int uart);
+
+struct adc_linkquality {
+	uint8_t ad1;
+	uint8_t ad2;
+	uint8_t linkq;
+};
+bool frsky_parse_host(uint8_t * sbuf, int nbytes, struct adc_linkquality * v);
 
 #endif /* _FRSKY_TELEMETRY_H */

--- a/src/drivers/frsky_telemetry/frsky_data.h
+++ b/src/drivers/frsky_telemetry/frsky_data.h
@@ -55,6 +55,6 @@ struct adc_linkquality {
 	uint8_t ad2;
 	uint8_t linkq;
 };
-bool frsky_parse_host(uint8_t * sbuf, int nbytes, struct adc_linkquality * v);
+bool frsky_parse_host(uint8_t *sbuf, int nbytes, struct adc_linkquality *v);
 
 #endif /* _FRSKY_TELEMETRY_H */

--- a/src/drivers/frsky_telemetry/frsky_telemetry.c
+++ b/src/drivers/frsky_telemetry/frsky_telemetry.c
@@ -345,8 +345,8 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 			int nbytes = read(uart, &dbuf[0], sizeof(dbuf));
 			bool new_input = frsky_parse_host(&dbuf[0], nbytes, &host_frame);
 			if (new_input) {
-//				warnx("host frame: ad1:%u, ad2: %u, rssi: %u",
-//						host_frame.ad1, host_frame.ad2, host_frame.linkq);
+				warnx("host frame: ad1:%u, ad2: %u, rssi: %u",
+						host_frame.ad1, host_frame.ad2, host_frame.linkq);
 			}
 
 			/* Send frame 1 (every 200ms): acceleration values, altitude (vario), temperatures, current & voltages, RPM */

--- a/src/drivers/frsky_telemetry/frsky_telemetry.c
+++ b/src/drivers/frsky_telemetry/frsky_telemetry.c
@@ -345,7 +345,8 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 			int nbytes = read(uart, &dbuf[0], sizeof(dbuf));
 			bool new_input = frsky_parse_host(&dbuf[0], nbytes, &host_frame);
 
-			if (new_input) {
+			/* the RSSI value could be useful */
+			if (false && new_input) {
 				warnx("host frame: ad1:%u, ad2: %u, rssi: %u",
 				      host_frame.ad1, host_frame.ad2, host_frame.linkq);
 			}

--- a/src/drivers/frsky_telemetry/frsky_telemetry.c
+++ b/src/drivers/frsky_telemetry/frsky_telemetry.c
@@ -344,9 +344,10 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 			/* parse incoming data */
 			int nbytes = read(uart, &dbuf[0], sizeof(dbuf));
 			bool new_input = frsky_parse_host(&dbuf[0], nbytes, &host_frame);
+
 			if (new_input) {
 				warnx("host frame: ad1:%u, ad2: %u, rssi: %u",
-						host_frame.ad1, host_frame.ad2, host_frame.linkq);
+				      host_frame.ad1, host_frame.ad2, host_frame.linkq);
 			}
 
 			/* Send frame 1 (every 200ms): acceleration values, altitude (vario), temperatures, current & voltages, RPM */

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -654,9 +654,9 @@ void PX4FMU::fill_rc_in(uint16_t raw_rc_count,
 	_rc_in.timestamp_last_signal = _rc_in.timestamp_publication;
 	_rc_in.rc_ppm_frame_length = 0;
 
-	if (rssi == -1) {
-		_rc_in.rssi =
-			(!frame_drop) ? RC_INPUT_RSSI_MAX : (RC_INPUT_RSSI_MAX / 2);
+	/* don't touch rssi if no value was provided */
+	if (rssi >= 0) {
+		_rc_in.rssi = rssi;
 	}
 
 	_rc_in.rc_failsafe = failsafe;

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -654,8 +654,12 @@ void PX4FMU::fill_rc_in(uint16_t raw_rc_count,
 	_rc_in.timestamp_last_signal = _rc_in.timestamp_publication;
 	_rc_in.rc_ppm_frame_length = 0;
 
-	/* don't touch rssi if no value was provided */
-	if (rssi >= 0) {
+	/* fake rssi if no value was provided */
+	if (rssi == -1) {
+		_rc_in.rssi =
+			(!frame_drop) ? RC_INPUT_RSSI_MAX : (RC_INPUT_RSSI_MAX / 2);
+
+	} else {
 		_rc_in.rssi = rssi;
 	}
 


### PR DESCRIPTION
parse the AD1,2 and "link quality" message (OpenTX reports it as dB)  transmitted by D series receivers

There is an RSSI field in the input_rc uORB topic, but I don't see a simple way to push this info into there.
(for now, it just prints the values to the console)