### PR TITLE
Simulation lockstep

### DIFF
--- a/src/drivers/device/vdev_posix.cpp
+++ b/src/drivers/device/vdev_posix.cpp
@@ -422,6 +422,11 @@ extern "C" {
 		sim_delay = false;
 	}
 
+	bool px4_sim_delay_enabled()
+	{
+		return sim_delay;
+	}
+
 	const char *px4_get_device_names(unsigned int *handle)
 	{
 		return VDev::devList(handle);

--- a/src/drivers/device/vdev_posix.cpp
+++ b/src/drivers/device/vdev_posix.cpp
@@ -53,6 +53,9 @@
 using namespace device;
 
 pthread_mutex_t filemutex = PTHREAD_MUTEX_INITIALIZER;
+px4_sem_t lockstep_sem;
+bool sim_lockstep = false;
+bool sim_delay = false;
 
 extern "C" {
 
@@ -270,6 +273,10 @@ extern "C" {
 
 #endif
 
+		while (sim_delay) {
+			usleep(100);
+		}
+
 		PX4_DEBUG("Called px4_poll timeout = %d", timeout);
 		px4_sem_init(&sem, 0, 0);
 
@@ -396,6 +403,23 @@ extern "C" {
 	void px4_show_files()
 	{
 		VDev::showFiles();
+	}
+
+	void px4_enable_sim_lockstep()
+	{
+		px4_sem_init(&lockstep_sem, 0, 0);
+		sim_lockstep = true;
+		sim_delay = false;
+	}
+
+	void px4_sim_start_delay()
+	{
+		sim_delay = true;
+	}
+
+	void px4_sim_stop_delay()
+	{
+		sim_delay = false;
 	}
 
 	const char *px4_get_device_names(unsigned int *handle)

--- a/src/drivers/drv_hrt.h
+++ b/src/drivers/drv_hrt.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2012 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,7 +49,7 @@
 
 __BEGIN_DECLS
 
-/*
+/**
  * Absolute time, in microsecond units.
  *
  * Absolute time is measured from some arbitrary epoch shortly after
@@ -57,7 +57,7 @@ __BEGIN_DECLS
  */
 typedef uint64_t	hrt_abstime;
 
-/*
+/**
  * Callout function type.
  *
  * Note that callouts run in the timer interrupt context, so
@@ -66,7 +66,7 @@ typedef uint64_t	hrt_abstime;
  */
 typedef void	(* hrt_callout)(void *arg);
 
-/*
+/**
  * Callout record.
  */
 typedef struct hrt_call {
@@ -78,22 +78,22 @@ typedef struct hrt_call {
 	void			*arg;
 } *hrt_call_t;
 
-/*
+/**
  * Get absolute time.
  */
 __EXPORT extern hrt_abstime hrt_absolute_time(void);
 
-/*
+/**
  * Convert a timespec to absolute time.
  */
 __EXPORT extern hrt_abstime ts_to_abstime(struct timespec *ts);
 
-/*
+/**
  * Convert absolute time to a timespec.
  */
 __EXPORT extern void	abstime_to_ts(struct timespec *ts, hrt_abstime abstime);
 
-/*
+/**
  * Compute the delta between a timestamp taken in the past
  * and now.
  *
@@ -102,14 +102,14 @@ __EXPORT extern void	abstime_to_ts(struct timespec *ts, hrt_abstime abstime);
  */
 __EXPORT extern hrt_abstime hrt_elapsed_time(const volatile hrt_abstime *then);
 
-/*
+/**
  * Store the absolute time in an interrupt-safe fashion.
  *
  * This function ensures that the timestamp cannot be seen half-written by an interrupt handler.
  */
 __EXPORT extern hrt_abstime hrt_store_absolute_time(volatile hrt_abstime *now);
 
-/*
+/**
  * Call callout(arg) after delay has elapsed.
  *
  * If callout is NULL, this can be used to implement a timeout by testing the call
@@ -117,12 +117,12 @@ __EXPORT extern hrt_abstime hrt_store_absolute_time(volatile hrt_abstime *now);
  */
 __EXPORT extern void	hrt_call_after(struct hrt_call *entry, hrt_abstime delay, hrt_callout callout, void *arg);
 
-/*
+/**
  * Call callout(arg) at absolute time calltime.
  */
 __EXPORT extern void	hrt_call_at(struct hrt_call *entry, hrt_abstime calltime, hrt_callout callout, void *arg);
 
-/*
+/**
  * Call callout(arg) after delay, and then after every interval.
  *
  * Note thet the interval is timed between scheduled, not actual, call times, so the call rate may
@@ -131,7 +131,7 @@ __EXPORT extern void	hrt_call_at(struct hrt_call *entry, hrt_abstime calltime, h
 __EXPORT extern void	hrt_call_every(struct hrt_call *entry, hrt_abstime delay, hrt_abstime interval,
 				       hrt_callout callout, void *arg);
 
-/*
+/**
  * If this returns true, the entry has been invoked and removed from the callout list,
  * or it has never been entered.
  *
@@ -139,13 +139,13 @@ __EXPORT extern void	hrt_call_every(struct hrt_call *entry, hrt_abstime delay, h
  */
 __EXPORT extern bool	hrt_called(struct hrt_call *entry);
 
-/*
+/**
  * Remove the entry from the callout list.
  */
 __EXPORT extern void	hrt_cancel(struct hrt_call *entry);
 
-/*
- * initialise a hrt_call structure
+/**
+ * Initialise a hrt_call structure
  */
 __EXPORT extern void	hrt_call_init(struct hrt_call *entry);
 
@@ -162,5 +162,22 @@ __EXPORT extern void	hrt_call_delay(struct hrt_call *entry, hrt_abstime delay);
  * Initialise the HRT.
  */
 __EXPORT extern void	hrt_init(void);
+
+#ifdef __PX4_POSIX
+
+/**
+ * Start to delay the HRT return value.
+ *
+ * Until hrt_stop_delay() is called the HRT calls will return the timestamp
+ * at the instance then hrt_start_delay() was called.
+ */
+__EXPORT extern	void	hrt_start_delay(void);
+
+/**
+ * Stop to delay the HRT.
+ */
+__EXPORT extern void	hrt_stop_delay(void);
+
+#endif
 
 __END_DECLS

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -3266,7 +3266,7 @@ void *commander_low_prio_loop(void *arg)
 			}
 		} else if (pret < 0) {
 		/* this is undesirable but not much we can do - might want to flag unhappy status */
-			warn("poll error %d, %d", pret, errno);
+			warn("commander: poll error %d, %d", pret, errno);
 			continue;
 		} else {
 

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -813,7 +813,7 @@ MulticopterAttitudeControl::task_main()
 
 		/* this is undesirable but not much we can do - might want to flag unhappy status */
 		if (pret < 0) {
-			warn("poll error %d, %d", pret, errno);
+			warn("mc att ctrl: poll error %d, %d", pret, errno);
 			/* sleep a bit before next try */
 			usleep(100000);
 			continue;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -331,7 +331,7 @@ Navigator::task_main()
 
 		} else if (pret < 0) {
 			/* this is undesirable but not much we can do - might want to flag unhappy status */
-			PX4_WARN("poll error %d, %d", pret, errno);
+			PX4_WARN("nav: poll error %d, %d", pret, errno);
 			continue;
 		}
 

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -2216,6 +2216,7 @@ Sensors::task_main()
 		baro_poll(raw);
 
 #ifndef __PX4_POSIX
+
 		/* work out if main gyro timed out and fail over to alternate gyro */
 		if (raw.gyro_timestamp[0] > 0 && hrt_elapsed_time(&raw.gyro_timestamp[0]) > 20 * 1000) {
 
@@ -2229,6 +2230,7 @@ Sensors::task_main()
 				warnx("failing over to second gyro");
 			}
 		}
+
 #endif
 
 		/* check battery voltage */

--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -175,10 +175,14 @@ extern "C" {
 			if (strcmp(argv[2], "-s") == 0 ||
 			    strcmp(argv[2], "-p") == 0 ||
 			    strcmp(argv[2], "-t") == 0) {
+
 				if (g_sim_task >= 0) {
 					warnx("Simulator already started");
 					return 0;
 				}
+
+				// enable lockstep support
+				px4_enable_sim_lockstep();
 
 				g_sim_task = px4_task_spawn_cmd("simulator",
 								SCHED_DEFAULT,

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -551,6 +551,7 @@ void Simulator::pollForMAVLinkMessages(bool publish)
 				hrt_start_delay();
 				px4_sim_start_delay();
 			}
+
 			continue;
 		}
 

--- a/src/modules/uORB/uORBDevices_posix.cpp
+++ b/src/modules/uORB/uORBDevices_posix.cpp
@@ -384,6 +384,11 @@ uORB::DeviceNode::poll_notify_one(px4_pollfd_struct_t *fds, pollevent_t events)
 bool
 uORB::DeviceNode::appears_updated(SubscriberData *sd)
 {
+	/* block if in simulation mode */
+	while (px4_sim_delay_enabled()) {
+		usleep(100);
+	}
+
 	//warnx("uORB::DeviceNode::appears_updated sd = %p", sd);
 	/* assume it doesn't look updated */
 	bool ret = false;

--- a/src/platforms/posix/px4_layer/drv_hrt.c
+++ b/src/platforms/posix/px4_layer/drv_hrt.c
@@ -147,6 +147,7 @@ hrt_abstime hrt_absolute_time(void)
 
 	if (_start_delay_time > 0) {
 		ret = _start_delay_time;
+
 	} else {
 		ret = _hrt_absolute_time_internal();
 	}
@@ -285,9 +286,11 @@ void	hrt_stop_delay()
 	int64_t delta = _hrt_absolute_time_internal() - _start_delay_time;
 	_delay_interval += delta;
 	_start_delay_time = 0;
+
 	if (delta > 10000) {
 		PX4_INFO("simulator is slow. Delay added: %llu us", delta);
 	}
+
 	pthread_mutex_unlock(&_hrt_mutex);
 
 }

--- a/src/platforms/posix/px4_layer/drv_hrt.c
+++ b/src/platforms/posix/px4_layer/drv_hrt.c
@@ -193,7 +193,7 @@ hrt_abstime ts_to_abstime(struct timespec *ts)
  */
 hrt_abstime hrt_elapsed_time(const volatile hrt_abstime *then)
 {
-	hrt_abstime delta = _hrt_absolute_time_internal() - *then;
+	hrt_abstime delta = hrt_absolute_time() - *then;
 	return delta;
 }
 
@@ -204,7 +204,7 @@ hrt_abstime hrt_elapsed_time(const volatile hrt_abstime *then)
  */
 hrt_abstime hrt_store_absolute_time(volatile hrt_abstime *now)
 {
-	hrt_abstime ts = _hrt_absolute_time_internal();
+	hrt_abstime ts = hrt_absolute_time();
 	return ts;
 }
 
@@ -254,7 +254,7 @@ void	hrt_call_init(struct hrt_call *entry)
  */
 void	hrt_call_delay(struct hrt_call *entry, hrt_abstime delay)
 {
-	entry->deadline = _hrt_absolute_time_internal() + delay;
+	entry->deadline = hrt_absolute_time() + delay;
 }
 
 /*
@@ -353,7 +353,7 @@ hrt_tim_isr(void *p)
 static void
 hrt_call_reschedule()
 {
-	hrt_abstime	now = _hrt_absolute_time_internal();
+	hrt_abstime	now = hrt_absolute_time();
 	hrt_abstime	delay = HRT_INTERVAL_MAX;
 	struct hrt_call	*next = (struct hrt_call *)sq_peek(&callout_queue);
 	hrt_abstime	deadline = now + HRT_INTERVAL_MAX;
@@ -441,7 +441,7 @@ void	hrt_call_after(struct hrt_call *entry, hrt_abstime delay, hrt_callout callo
 {
 	//printf("hrt_call_after\n");
 	hrt_call_internal(entry,
-			  _hrt_absolute_time_internal() + delay,
+			  hrt_absolute_time() + delay,
 			  0,
 			  callout,
 			  arg);
@@ -456,7 +456,7 @@ void	hrt_call_after(struct hrt_call *entry, hrt_abstime delay, hrt_callout callo
 void	hrt_call_every(struct hrt_call *entry, hrt_abstime delay, hrt_abstime interval, hrt_callout callout, void *arg)
 {
 	hrt_call_internal(entry,
-			  _hrt_absolute_time_internal() + delay,
+			  hrt_absolute_time() + delay,
 			  interval,
 			  callout,
 			  arg);
@@ -487,7 +487,7 @@ hrt_call_invoke(void)
 
 	while (true) {
 		/* get the current time */
-		hrt_abstime now = _hrt_absolute_time_internal();
+		hrt_abstime now = hrt_absolute_time();
 
 		call = (struct hrt_call *)sq_peek(&callout_queue);
 

--- a/src/platforms/px4_posix.h
+++ b/src/platforms/px4_posix.h
@@ -149,6 +149,7 @@ __EXPORT unsigned long	px4_getpid(void);
 __EXPORT void		px4_enable_sim_lockstep(void);
 __EXPORT void		px4_sim_start_delay(void);
 __EXPORT void		px4_sim_stop_delay(void);
+__EXPORT bool		px4_sim_delay_enabled(void);
 
 __END_DECLS
 #else

--- a/src/platforms/px4_posix.h
+++ b/src/platforms/px4_posix.h
@@ -146,6 +146,10 @@ __EXPORT int		px4_fsync(int fd);
 __EXPORT int		px4_access(const char *pathname, int mode);
 __EXPORT unsigned long	px4_getpid(void);
 
+__EXPORT void		px4_enable_sim_lockstep(void);
+__EXPORT void		px4_sim_start_delay(void);
+__EXPORT void		px4_sim_stop_delay(void);
+
 __END_DECLS
 #else
 #error "No TARGET OS Provided"


### PR DESCRIPTION
This PR implements the Simulator -> SITL direction and blocks the execution of SITL if the simulator is lagging. It also does time bookkeeping and ensures the blocked execution does not lead to jumping timestamps. "Flight tested" in Sim, leads to a lot more stability.

@liamstask @tumbili You probably will enjoy this.