### PR TITLE
Remove run-once procedure on check_dist_1wp

### DIFF
--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -335,10 +335,6 @@ bool MissionFeasibilityChecker::checkFixedWingLanding(dm_item_t dm_current, size
 bool
 MissionFeasibilityChecker::check_dist_1wp(dm_item_t dm_current, size_t nMissionItems, double curr_lat, double curr_lon, float dist_first_wp, bool &warning_issued)
 {
-	if (_dist_1wp_ok) {
-		/* always return true after at least one successful check */
-		return true;
-	}
 
 	/* check if first waypoint is not too far from home */
 	if (dist_first_wp > 0.0f) {


### PR DESCRIPTION
Fixes: https://github.com/PX4/Firmware/issues/3688

The stored mission is checked at system startup. When no mission is loaded the check returns OK and sets a param that it does not need to check again. When a new mission is uploaded this bool is not reset.

In light of future adjustments to the feasibility checker (soft check on load, hard check on execute) i have chosen to remove the run-once procedure. I will soon add the ability to load a mission on a location far from the first waypoint, it will warn the user but still accept the mission. Upon execution it will run the check again and fail to execute if still too far away.