### PR TITLE
WIP: VTOL weathervane

### DIFF
--- a/msg/fw_virtual_attitude_setpoint.msg
+++ b/msg/fw_virtual_attitude_setpoint.msg
@@ -1,3 +1,12 @@
+###############################################################################################
+# The vehicle_attitude_setpoint.msg needs to be in sync with the virtual setpoint messages
+#
+# Please keep the following messages identical;
+#	vehicle_attitude_setpoint.msg
+#	mc_virtual_attitude_setpoint.msg
+#	fw_virtual_attitude_setpoint.msg
+#
+###############################################################################################
 
 uint64 timestamp				# in microseconds since system start, is set whenever the writing thread stores new data
 
@@ -21,3 +30,8 @@ float32 thrust					# Thrust in Newton the power system should generate
 bool roll_reset_integral			# Reset roll integral part (navigation logic change)
 bool pitch_reset_integral			# Reset pitch integral part (navigation logic change)
 bool yaw_reset_integral				# Reset yaw integral part (navigation logic change)
+
+bool fw_control_yaw					# control heading with rudder (used for auto takeoff on runway)
+bool disable_mc_yaw_control			# control yaw for mc (used for vtol weather-vane mode)
+
+bool apply_flaps

--- a/msg/fw_virtual_rates_setpoint.msg
+++ b/msg/fw_virtual_rates_setpoint.msg
@@ -1,6 +1,16 @@
+###############################################################################################
+# The vehicle_rates_setpoint.msg needs to be in sync with the virtual setpoint messages
+#
+# Please keep the following messages identical;
+#	vehicle_rates_setpoint.msg
+#	mc_virtual_rates_setpoint.msg
+#	fw_virtual_rates_setpoint.msg
+#
+###############################################################################################
+
 uint64 timestamp    # in microseconds since system start
 
 float32 roll	    # body angular rates in NED frame
 float32 pitch	    # body angular rates in NED frame
-float32 yaw	    # body angular rates in NED frame
+float32 yaw			# body angular rates in NED frame
 float32 thrust	    # thrust normalized to 0..1

--- a/msg/mc_virtual_attitude_setpoint.msg
+++ b/msg/mc_virtual_attitude_setpoint.msg
@@ -1,3 +1,12 @@
+###############################################################################################
+# The vehicle_attitude_setpoint.msg needs to be in sync with the virtual setpoint messages
+#
+# Please keep the following messages identical;
+#	vehicle_attitude_setpoint.msg
+#	mc_virtual_attitude_setpoint.msg
+#	fw_virtual_attitude_setpoint.msg
+#
+###############################################################################################
 
 uint64 timestamp				# in microseconds since system start, is set whenever the writing thread stores new data
 
@@ -21,3 +30,8 @@ float32 thrust					# Thrust in Newton the power system should generate
 bool roll_reset_integral			# Reset roll integral part (navigation logic change)
 bool pitch_reset_integral			# Reset pitch integral part (navigation logic change)
 bool yaw_reset_integral				# Reset yaw integral part (navigation logic change)
+
+bool fw_control_yaw					# control heading with rudder (used for auto takeoff on runway)
+bool disable_mc_yaw_control			# control yaw for mc (used for vtol weather-vane mode)
+
+bool apply_flaps

--- a/msg/mc_virtual_rates_setpoint.msg
+++ b/msg/mc_virtual_rates_setpoint.msg
@@ -1,6 +1,16 @@
+###############################################################################################
+# The vehicle_rates_setpoint.msg needs to be in sync with the virtual setpoint messages
+#
+# Please keep the following messages identical;
+#	vehicle_rates_setpoint.msg
+#	mc_virtual_rates_setpoint.msg
+#	fw_virtual_rates_setpoint.msg
+#
+###############################################################################################
+
 uint64 timestamp    # in microseconds since system start
 
 float32 roll	    # body angular rates in NED frame
 float32 pitch	    # body angular rates in NED frame
-float32 yaw	    # body angular rates in NED frame
+float32 yaw			# body angular rates in NED frame
 float32 thrust	    # thrust normalized to 0..1

--- a/msg/position_setpoint.msg
+++ b/msg/position_setpoint.msg
@@ -23,6 +23,7 @@ float64 lon			# longitude, in deg
 float32 alt			# altitude AMSL, in m
 float32 yaw			# yaw (only for multirotors), in rad [-PI..PI), NaN = hold current yaw
 bool yaw_valid			# true if yaw setpoint valid
+bool mc_control_yaw		# control yaw for mc (used for vtol weather-vane mode)
 float32 yawspeed		# yawspeed (only for multirotors, in rad/s)
 bool yawspeed_valid		# true if yawspeed setpoint valid
 float32 loiter_radius		# loiter radius (only for fixed wing), in m

--- a/msg/position_setpoint.msg
+++ b/msg/position_setpoint.msg
@@ -23,7 +23,7 @@ float64 lon			# longitude, in deg
 float32 alt			# altitude AMSL, in m
 float32 yaw			# yaw (only for multirotors), in rad [-PI..PI), NaN = hold current yaw
 bool yaw_valid			# true if yaw setpoint valid
-bool mc_control_yaw		# control yaw for mc (used for vtol weather-vane mode)
+bool disable_mc_yaw_control		# control yaw for mc (used for vtol weather-vane mode)
 float32 yawspeed		# yawspeed (only for multirotors, in rad/s)
 bool yawspeed_valid		# true if yawspeed setpoint valid
 float32 loiter_radius		# loiter radius (only for fixed wing), in m

--- a/msg/vehicle_attitude_setpoint.msg
+++ b/msg/vehicle_attitude_setpoint.msg
@@ -1,3 +1,12 @@
+###############################################################################################
+# The vehicle_attitude_setpoint.msg needs to be in sync with the virtual setpoint messages
+#
+# Please keep the following messages identical;
+#	vehicle_attitude_setpoint.msg
+#	mc_virtual_attitude_setpoint.msg
+#	fw_virtual_attitude_setpoint.msg
+#
+###############################################################################################
 
 uint64 timestamp				# in microseconds since system start, is set whenever the writing thread stores new data
 

--- a/msg/vehicle_attitude_setpoint.msg
+++ b/msg/vehicle_attitude_setpoint.msg
@@ -23,6 +23,6 @@ bool pitch_reset_integral			# Reset pitch integral part (navigation logic change
 bool yaw_reset_integral				# Reset yaw integral part (navigation logic change)
 
 bool fw_control_yaw					# control heading with rudder (used for auto takeoff on runway)
-bool mc_control_yaw					# control yaw for mc (used for vtol weather-vane mode)
+bool disable_mc_yaw_control			# control yaw for mc (used for vtol weather-vane mode)
 
 bool apply_flaps

--- a/msg/vehicle_attitude_setpoint.msg
+++ b/msg/vehicle_attitude_setpoint.msg
@@ -23,5 +23,6 @@ bool pitch_reset_integral			# Reset pitch integral part (navigation logic change
 bool yaw_reset_integral				# Reset yaw integral part (navigation logic change)
 
 bool fw_control_yaw					# control heading with rudder (used for auto takeoff on runway)
+bool mc_control_yaw					# control yaw for mc (used for vtol weather-vane mode)
 
 bool apply_flaps

--- a/msg/vehicle_rates_setpoint.msg
+++ b/msg/vehicle_rates_setpoint.msg
@@ -1,6 +1,16 @@
+###############################################################################################
+# The vehicle_rates_setpoint.msg needs to be in sync with the virtual setpoint messages
+#
+# Please keep the following messages identical;
+#	vehicle_rates_setpoint.msg
+#	mc_virtual_rates_setpoint.msg
+#	fw_virtual_rates_setpoint.msg
+#
+###############################################################################################
+
 uint64 timestamp    # in microseconds since system start
 
 float32 roll	    # body angular rates in NED frame
 float32 pitch	    # body angular rates in NED frame
-float32 yaw	    # body angular rates in NED frame
+float32 yaw			# body angular rates in NED frame
 float32 thrust	    # thrust normalized to 0..1

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -877,6 +877,14 @@ MulticopterAttitudeControl::task_main()
 					}
 				}
 
+				/* weather-vane mode: disable yaw control */
+				if(_v_att_sp.mc_control_yaw == false){
+					warnx("attctl: disabled yaw control");
+					_rates_sp(2) = _ctrl_state.yaw_rate;
+				} else {
+					warnx("attctl: NOT disabled yaw control");
+				}
+
 				/* publish attitude rates setpoint */
 				_v_rates_sp.roll = _rates_sp(0);
 				_v_rates_sp.pitch = _rates_sp(1);

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -878,11 +878,8 @@ MulticopterAttitudeControl::task_main()
 				}
 
 				/* weather-vane mode: disable yaw control */
-				if(_v_att_sp.mc_control_yaw == false){
-					warnx("attctl: disabled yaw control");
+				if(_v_att_sp.disable_mc_yaw_control == true){
 					_rates_sp(2) = _ctrl_state.yaw_rate;
-				} else {
-					warnx("attctl: NOT disabled yaw control");
 				}
 
 				/* publish attitude rates setpoint */

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -519,6 +519,8 @@ MulticopterAttitudeControl::parameters_update()
 	param_get(_params_handles.vtol_opt_recovery_enabled, &tmp);
 	_params.vtol_opt_recovery_enabled = (bool)tmp;
 
+	param_get(_params_handles.vtol_wv_yaw_rate_d, &_params.vtol_wv_yaw_rate_d);
+
 	_actuators_0_circuit_breaker_enabled = circuit_breaker_enabled("CBRK_RATE_CTRL", CBRK_RATE_CTRL_KEY);
 
 	return OK;

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -201,6 +201,7 @@ private:
 		param_t roll_tc;
 		param_t pitch_tc;
 		param_t vtol_opt_recovery_enabled;
+		param_t vtol_wv_yaw_rate_d;
 
 	}		_params_handles;		/**< handles for interesting parameters */
 
@@ -222,6 +223,7 @@ private:
 		float rattitude_thres;
 		int vtol_type;						/**< 0 = Tailsitter, 1 = Tiltrotor, 2 = Standard airframe */
 		bool vtol_opt_recovery_enabled;
+		float vtol_wv_yaw_rate_d;			/**< yaw rate dampener for weather-vane mode */
 	}		_params;
 
 	TailsitterRecovery *_ts_opt_recovery;	/**< Computes optimal rates for tailsitter recovery */
@@ -353,6 +355,8 @@ MulticopterAttitudeControl::MulticopterAttitudeControl() :
 	_params.acro_rate_max.zero();
 	_params.rattitude_thres = 1.0f;
 	_params.vtol_opt_recovery_enabled = false;
+	_params.vtol_wv_yaw_rate_d = 0.0f;
+
 
 	_rates_prev.zero();
 	_rates_sp.zero();
@@ -390,7 +394,11 @@ MulticopterAttitudeControl::MulticopterAttitudeControl() :
 	_params_handles.vtol_type 		= 	param_find("VT_TYPE");
 	_params_handles.roll_tc			= 	param_find("MC_ROLL_TC");
 	_params_handles.pitch_tc		= 	param_find("MC_PITCH_TC");
-	_params_handles.vtol_opt_recovery_enabled = param_find("VT_OPT_RECOV_EN");
+	_params_handles.vtol_opt_recovery_enabled	= param_find("VT_OPT_RECOV_EN");
+	_params_handles.vtol_wv_yaw_rate_d			= param_find("VT_OPT_WV_RATE_D");
+
+
+
 
 	/* fetch initial parameter values */
 	parameters_update();
@@ -724,6 +732,12 @@ MulticopterAttitudeControl::control_attitude(float dt)
 		}
 	}
 
+	/* weather-vane mode, dampen yaw rate */
+	if (_v_att_sp.disable_mc_yaw_control == true && _v_control_mode.flag_control_velocity_enabled && !_v_control_mode.flag_control_manual_enabled) {
+		float wv_max_yaw_rate = _params.auto_rate_max(2) * _params.vtol_wv_yaw_rate_d;
+		_rates_sp(2) = math::constrain(_rates_sp(2), -wv_max_yaw_rate, wv_max_yaw_rate);
+	}
+
 	/* feed forward yaw setpoint rate */
 	_rates_sp(2) += _v_att_sp.yaw_sp_move_rate * yaw_w * _params.yaw_ff;
 }
@@ -875,11 +889,6 @@ MulticopterAttitudeControl::task_main()
 					for (int i = 0; i < 3; i++) {
 						_rates_sp(i) = math::constrain(_rates_sp(i), -_params.mc_rate_max(i), _params.mc_rate_max(i));
 					}
-				}
-
-				/* weather-vane mode: disable yaw control */
-				if(_v_att_sp.disable_mc_yaw_control == true){
-					_rates_sp(2) = _ctrl_state.yaw_rate;
 				}
 
 				/* publish attitude rates setpoint */

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -736,6 +736,7 @@ MulticopterAttitudeControl::control_attitude(float dt)
 	if (_v_att_sp.disable_mc_yaw_control == true && _v_control_mode.flag_control_velocity_enabled && !_v_control_mode.flag_control_manual_enabled) {
 		float wv_max_yaw_rate = _params.auto_rate_max(2) * _params.vtol_wv_yaw_rate_d;
 		_rates_sp(2) = math::constrain(_rates_sp(2), -wv_max_yaw_rate, wv_max_yaw_rate);
+		_rates_int(2) = 0.0f;
 	}
 
 	/* feed forward yaw setpoint rate */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1266,6 +1266,9 @@ MulticopterPositionControl::task_main()
 			/* weather-vane mode: disable yaw control */
 			if(_mode_auto && _pos_sp_triplet.current.disable_mc_yaw_control == true) {
 				_att_sp.disable_mc_yaw_control = true;
+			} else {
+				/* reset in case of setpoint updates */
+				_att_sp.disable_mc_yaw_control = false;
 			}
 
 			if (!_control_mode.flag_control_manual_enabled && _pos_sp_triplet.current.valid

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1263,6 +1263,14 @@ MulticopterPositionControl::task_main()
 				control_auto(dt);
 			}
 
+			/* weather-vane mode: disable yaw control */
+			if(_pos_sp_triplet.current.mc_control_yaw == false) {
+				_att_sp.mc_control_yaw = false;
+				warnx("posctl: disabling yaw control");
+			} else {
+				_att_sp.mc_control_yaw = true;
+			}
+
 			if (!_control_mode.flag_control_manual_enabled && _pos_sp_triplet.current.valid
 			    && _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_IDLE) {
 				/* idle state, don't run controller and set zero thrust */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1263,13 +1263,14 @@ MulticopterPositionControl::task_main()
 				control_auto(dt);
 			}
 
-			/* weather-vane mode: disable yaw control */
+			/* weather-vane mode: disable yaw control
 			if(_pos_sp_triplet.current.mc_control_yaw == false) {
 				_att_sp.mc_control_yaw = false;
 				warnx("posctl: disabling yaw control");
 			} else {
 				_att_sp.mc_control_yaw = true;
 			}
+			*/
 
 			if (!_control_mode.flag_control_manual_enabled && _pos_sp_triplet.current.valid
 			    && _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_IDLE) {

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1266,7 +1266,6 @@ MulticopterPositionControl::task_main()
 			/* weather-vane mode: disable yaw control */
 			if(_mode_auto && _pos_sp_triplet.current.disable_mc_yaw_control == true) {
 				_att_sp.disable_mc_yaw_control = true;
-				warnx("yaw disabled");
 			}
 
 			if (!_control_mode.flag_control_manual_enabled && _pos_sp_triplet.current.valid

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -192,6 +192,7 @@ private:
 		param_t hold_max_xy;
 		param_t hold_max_z;
 		param_t acc_hor_max;
+
 	}		_params_handles;		/**< handles for interesting parameters */
 
 	struct {
@@ -441,7 +442,6 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_params_handles.hold_max_xy = param_find("MPC_HOLD_MAX_XY");
 	_params_handles.hold_max_z = param_find("MPC_HOLD_MAX_Z");
 	_params_handles.acc_hor_max = param_find("MPC_ACC_HOR_MAX");
-
 
 	/* fetch initial parameter values */
 	parameters_update(true);
@@ -1264,9 +1264,9 @@ MulticopterPositionControl::task_main()
 			}
 
 			/* weather-vane mode: disable yaw control */
-			if(_pos_sp_triplet.current.disable_mc_yaw_control == true) {
+			if(_mode_auto && _pos_sp_triplet.current.disable_mc_yaw_control == true) {
 				_att_sp.disable_mc_yaw_control = true;
-				warnx("posctl: disabling yaw control");
+				warnx("yaw disabled");
 			}
 
 			if (!_control_mode.flag_control_manual_enabled && _pos_sp_triplet.current.valid

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1263,14 +1263,11 @@ MulticopterPositionControl::task_main()
 				control_auto(dt);
 			}
 
-			/* weather-vane mode: disable yaw control
-			if(_pos_sp_triplet.current.mc_control_yaw == false) {
-				_att_sp.mc_control_yaw = false;
+			/* weather-vane mode: disable yaw control */
+			if(_pos_sp_triplet.current.disable_mc_yaw_control == true) {
+				_att_sp.disable_mc_yaw_control = true;
 				warnx("posctl: disabling yaw control");
-			} else {
-				_att_sp.mc_control_yaw = true;
 			}
-			*/
 
 			if (!_control_mode.flag_control_manual_enabled && _pos_sp_triplet.current.valid
 			    && _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_IDLE) {

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -71,7 +71,8 @@ MissionBlock::MissionBlock(Navigator *navigator, const char *name) :
 	_actuators{},
 	_actuator_pub(nullptr),
 	_cmd_pub(nullptr),
-	_param_vtol_wv_land(this, "VT_OPT_WV_LND", false)
+	_param_vtol_wv_land(this, "VT_OPT_WV_LND", false),
+	_param_vtol_wv_loiter(this, "VT_OPT_WV_LTR", false)
 {
 }
 
@@ -334,6 +335,9 @@ MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *ite
 	case NAV_CMD_LOITER_TURN_COUNT:
 	case NAV_CMD_LOITER_UNLIMITED:
 		sp->type = position_setpoint_s::SETPOINT_TYPE_LOITER;
+		if(_navigator->get_vstatus()->is_vtol && _param_vtol_wv_loiter.get()){
+			sp->disable_mc_yaw_control = true;
+		}
 		break;
 
 	default:

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -70,7 +70,8 @@ MissionBlock::MissionBlock(Navigator *navigator, const char *name) :
 	_action_start(0),
 	_actuators{},
 	_actuator_pub(nullptr),
-	_cmd_pub(nullptr)
+	_cmd_pub(nullptr),
+	_param_vtol_wv_land(this, "VT_OPT_WV_LND", false)
 {
 }
 
@@ -305,7 +306,7 @@ MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *ite
 	sp->lat = item->lat;
 	sp->lon = item->lon;
 	sp->alt = item->altitude_is_relative ? item->altitude + _navigator->get_home_position()->alt : item->altitude;
-	sp->yaw = item->yaw;	
+	sp->yaw = item->yaw;
 	sp->loiter_radius = (item->loiter_radius > NAV_EPSILON_POSITION) ? item->loiter_radius :
 				_navigator->get_loiter_radius();
 	sp->loiter_direction = item->loiter_direction;
@@ -324,7 +325,7 @@ MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *ite
 
 	case NAV_CMD_LAND:
 		sp->type = position_setpoint_s::SETPOINT_TYPE_LAND;
-		if(_navigator->get_vstatus()->is_vtol){
+		if(_navigator->get_vstatus()->is_vtol && _param_vtol_wv_land.get()){
 			sp->disable_mc_yaw_control = true;
 		}
 		break;

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -311,7 +311,7 @@ MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *ite
 	sp->loiter_direction = item->loiter_direction;
 	sp->pitch_min = item->pitch_min;
 	sp->acceptance_radius = item->acceptance_radius;
-	//sp->mc_control_yaw = true;
+	sp->disable_mc_yaw_control = false;
 
 	switch (item->nav_cmd) {
 	case NAV_CMD_IDLE:
@@ -324,7 +324,9 @@ MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *ite
 
 	case NAV_CMD_LAND:
 		sp->type = position_setpoint_s::SETPOINT_TYPE_LAND;
-		//sp->mc_control_yaw = false;
+		if(_navigator->get_vstatus()->is_vtol){
+			sp->disable_mc_yaw_control = true;
+		}
 		break;
 
 	case NAV_CMD_LOITER_TIME_LIMIT:

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -311,7 +311,7 @@ MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *ite
 	sp->loiter_direction = item->loiter_direction;
 	sp->pitch_min = item->pitch_min;
 	sp->acceptance_radius = item->acceptance_radius;
-	sp->mc_control_yaw = true;
+	//sp->mc_control_yaw = true;
 
 	switch (item->nav_cmd) {
 	case NAV_CMD_IDLE:
@@ -324,7 +324,7 @@ MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *ite
 
 	case NAV_CMD_LAND:
 		sp->type = position_setpoint_s::SETPOINT_TYPE_LAND;
-		sp->mc_control_yaw = false;
+		//sp->mc_control_yaw = false;
 		break;
 
 	case NAV_CMD_LOITER_TIME_LIMIT:

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -175,6 +175,7 @@ MissionBlock::is_mission_item_reached()
 	}
 
 	/* Check if the waypoint and the requested yaw setpoint. */
+
 	if (_waypoint_position_reached && !_waypoint_yaw_reached) {
 
 		/* TODO: removed takeoff, why? */
@@ -304,12 +305,13 @@ MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *ite
 	sp->lat = item->lat;
 	sp->lon = item->lon;
 	sp->alt = item->altitude_is_relative ? item->altitude + _navigator->get_home_position()->alt : item->altitude;
-	sp->yaw = item->yaw;
+	sp->yaw = item->yaw;	
 	sp->loiter_radius = (item->loiter_radius > NAV_EPSILON_POSITION) ? item->loiter_radius :
 				_navigator->get_loiter_radius();
 	sp->loiter_direction = item->loiter_direction;
 	sp->pitch_min = item->pitch_min;
 	sp->acceptance_radius = item->acceptance_radius;
+	sp->mc_control_yaw = true;
 
 	switch (item->nav_cmd) {
 	case NAV_CMD_IDLE:
@@ -322,6 +324,7 @@ MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *ite
 
 	case NAV_CMD_LAND:
 		sp->type = position_setpoint_s::SETPOINT_TYPE_LAND;
+		sp->mc_control_yaw = false;
 		break;
 
 	case NAV_CMD_LOITER_TIME_LIMIT:

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -45,6 +45,9 @@
 
 #include <navigator/navigation.h>
 
+#include <controllib/blocks.hpp>
+#include <controllib/block/BlockParam.hpp>
+
 #include <uORB/topics/mission.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/position_setpoint_triplet.h>
@@ -129,6 +132,7 @@ protected:
 	actuator_controls_s _actuators;
 	orb_advert_t    _actuator_pub;
 	orb_advert_t	_cmd_pub;
+	control::BlockParamInt _param_vtol_wv_land;
 };
 
 #endif

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -133,6 +133,7 @@ protected:
 	orb_advert_t    _actuator_pub;
 	orb_advert_t	_cmd_pub;
 	control::BlockParamInt _param_vtol_wv_land;
+	control::BlockParamInt _param_vtol_wv_loiter;
 };
 
 #endif

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -41,7 +41,8 @@
  * @author Roman Bapst 		<bapstr@ethz.ch>
  * @author Lorenz Meier 	<lm@inf.ethz.ch>
  * @author Thomas Gubler	<thomasgubler@gmail.com>
- * @author David Vorsin     <davidvorsin@gmail.com>
+ * @author David Vorsin		<davidvorsin@gmail.com>
+ * @author Sander Smeets	<sander@droneslab.com>
  *
  */
 #ifndef VTOL_ATT_CONTROL_MAIN_H
@@ -109,24 +110,24 @@ public:
 
 	struct vehicle_attitude_s 				*get_att() {return &_v_att;}
 	struct vehicle_attitude_setpoint_s		*get_att_sp() {return &_v_att_sp;}
-	struct mc_virtual_attitude_setpoint_s 	*get_mc_virtual_att_sp() {return &_mc_virtual_att_sp;}
-	struct fw_virtual_attitude_setpoint_s 	*get_fw_virtual_att_sp() {return &_fw_virtual_att_sp;}
+	struct vehicle_attitude_setpoint_s		*get_mc_virtual_att_sp() {return &_mc_virtual_att_sp;}
+	struct vehicle_attitude_setpoint_s		*get_fw_virtual_att_sp() {return &_fw_virtual_att_sp;}
 	struct vehicle_rates_setpoint_s 		*get_rates_sp() {return &_v_rates_sp;}
 	struct vehicle_rates_setpoint_s 		*get_mc_virtual_rates_sp() {return &_mc_virtual_v_rates_sp;}
 	struct vehicle_rates_setpoint_s 		*get_fw_virtual_rates_sp() {return &_fw_virtual_v_rates_sp;}
 	struct manual_control_setpoint_s 		*get_manual_control_sp() {return &_manual_control_sp;}
 	struct vehicle_control_mode_s 			*get_control_mode() {return &_v_control_mode;}
 	struct vtol_vehicle_status_s			*get_vehicle_status() {return &_vtol_vehicle_status;}
-	struct actuator_controls_s 			*get_actuators_out0() {return &_actuators_out_0;}
-	struct actuator_controls_s 			*get_actuators_out1() {return &_actuators_out_1;}
-	struct actuator_controls_s 			*get_actuators_mc_in() {return &_actuators_mc_in;}
-	struct actuator_controls_s 			*get_actuators_fw_in() {return &_actuators_fw_in;}
+	struct actuator_controls_s				*get_actuators_out0() {return &_actuators_out_0;}
+	struct actuator_controls_s				*get_actuators_out1() {return &_actuators_out_1;}
+	struct actuator_controls_s				*get_actuators_mc_in() {return &_actuators_mc_in;}
+	struct actuator_controls_s				*get_actuators_fw_in() {return &_actuators_fw_in;}
 	struct actuator_armed_s 				*get_armed() {return &_armed;}
 	struct vehicle_local_position_s 		*get_local_pos() {return &_local_pos;}
 	struct airspeed_s 						*get_airspeed() {return &_airspeed;}
 	struct battery_status_s 				*get_batt_status() {return &_batt_status;}
 
-	struct Params 						*get_params() {return &_params;}
+	struct Params							*get_params() {return &_params;}
 
 
 private:
@@ -162,8 +163,8 @@ private:
 //*******************data containers***********************************************************
 	struct vehicle_attitude_s			_v_att;				//vehicle attitude
 	struct vehicle_attitude_setpoint_s	_v_att_sp;			//vehicle attitude setpoint
-	struct mc_virtual_attitude_setpoint_s _mc_virtual_att_sp;	// virtual mc attitude setpoint
-	struct fw_virtual_attitude_setpoint_s _fw_virtual_att_sp;	// virtual fw attitude setpoint
+	struct vehicle_attitude_setpoint_s	_mc_virtual_att_sp;	// virtual mc attitude setpoint
+	struct vehicle_attitude_setpoint_s	_fw_virtual_att_sp;	// virtual fw attitude setpoint
 	struct vehicle_rates_setpoint_s		_v_rates_sp;		//vehicle rates setpoint
 	struct vehicle_rates_setpoint_s		_mc_virtual_v_rates_sp;		// virtual mc vehicle rates setpoint
 	struct vehicle_rates_setpoint_s		_fw_virtual_v_rates_sp;		// virtual fw vehicle rates setpoint

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -41,8 +41,7 @@
  * @author Roman Bapst 		<bapstr@ethz.ch>
  * @author Lorenz Meier 	<lm@inf.ethz.ch>
  * @author Thomas Gubler	<thomasgubler@gmail.com>
- * @author David Vorsin		<davidvorsin@gmail.com>
- * @author Sander Smeets	<sander@droneslab.com>
+ * @author David Vorsin     <davidvorsin@gmail.com>
  *
  */
 #ifndef VTOL_ATT_CONTROL_MAIN_H
@@ -110,24 +109,24 @@ public:
 
 	struct vehicle_attitude_s 				*get_att() {return &_v_att;}
 	struct vehicle_attitude_setpoint_s		*get_att_sp() {return &_v_att_sp;}
-	struct vehicle_attitude_setpoint_s		*get_mc_virtual_att_sp() {return &_mc_virtual_att_sp;}
-	struct vehicle_attitude_setpoint_s		*get_fw_virtual_att_sp() {return &_fw_virtual_att_sp;}
+	struct mc_virtual_attitude_setpoint_s 	*get_mc_virtual_att_sp() {return &_mc_virtual_att_sp;}
+	struct fw_virtual_attitude_setpoint_s 	*get_fw_virtual_att_sp() {return &_fw_virtual_att_sp;}
 	struct vehicle_rates_setpoint_s 		*get_rates_sp() {return &_v_rates_sp;}
-	struct vehicle_rates_setpoint_s 		*get_mc_virtual_rates_sp() {return &_mc_virtual_v_rates_sp;}
-	struct vehicle_rates_setpoint_s 		*get_fw_virtual_rates_sp() {return &_fw_virtual_v_rates_sp;}
+	struct mc_virtual_rates_setpoint_s 		*get_mc_virtual_rates_sp() {return &_mc_virtual_v_rates_sp;}
+	struct fw_virtual_rates_setpoint_s 		*get_fw_virtual_rates_sp() {return &_fw_virtual_v_rates_sp;}
 	struct manual_control_setpoint_s 		*get_manual_control_sp() {return &_manual_control_sp;}
 	struct vehicle_control_mode_s 			*get_control_mode() {return &_v_control_mode;}
 	struct vtol_vehicle_status_s			*get_vehicle_status() {return &_vtol_vehicle_status;}
-	struct actuator_controls_s				*get_actuators_out0() {return &_actuators_out_0;}
-	struct actuator_controls_s				*get_actuators_out1() {return &_actuators_out_1;}
-	struct actuator_controls_s				*get_actuators_mc_in() {return &_actuators_mc_in;}
-	struct actuator_controls_s				*get_actuators_fw_in() {return &_actuators_fw_in;}
+	struct actuator_controls_s 			*get_actuators_out0() {return &_actuators_out_0;}
+	struct actuator_controls_s 			*get_actuators_out1() {return &_actuators_out_1;}
+	struct actuator_controls_s 			*get_actuators_mc_in() {return &_actuators_mc_in;}
+	struct actuator_controls_s 			*get_actuators_fw_in() {return &_actuators_fw_in;}
 	struct actuator_armed_s 				*get_armed() {return &_armed;}
 	struct vehicle_local_position_s 		*get_local_pos() {return &_local_pos;}
 	struct airspeed_s 						*get_airspeed() {return &_airspeed;}
 	struct battery_status_s 				*get_batt_status() {return &_batt_status;}
 
-	struct Params							*get_params() {return &_params;}
+	struct Params 						*get_params() {return &_params;}
 
 
 private:
@@ -161,25 +160,25 @@ private:
 	orb_advert_t	_v_rates_sp_pub;
 	orb_advert_t	_v_att_sp_pub;
 //*******************data containers***********************************************************
-	struct vehicle_attitude_s			_v_att;				//vehicle attitude
-	struct vehicle_attitude_setpoint_s	_v_att_sp;			//vehicle attitude setpoint
-	struct vehicle_attitude_setpoint_s	_mc_virtual_att_sp;	// virtual mc attitude setpoint
-	struct vehicle_attitude_setpoint_s	_fw_virtual_att_sp;	// virtual fw attitude setpoint
-	struct vehicle_rates_setpoint_s		_v_rates_sp;		//vehicle rates setpoint
-	struct vehicle_rates_setpoint_s		_mc_virtual_v_rates_sp;		// virtual mc vehicle rates setpoint
-	struct vehicle_rates_setpoint_s		_fw_virtual_v_rates_sp;		// virtual fw vehicle rates setpoint
-	struct manual_control_setpoint_s	_manual_control_sp; //manual control setpoint
-	struct vehicle_control_mode_s		_v_control_mode;	//vehicle control mode
-	struct vtol_vehicle_status_s 		_vtol_vehicle_status;
-	struct actuator_controls_s			_actuators_out_0;	//actuator controls going to the mc mixer
-	struct actuator_controls_s			_actuators_out_1;	//actuator controls going to the fw mixer (used for elevons)
-	struct actuator_controls_s			_actuators_mc_in;	//actuator controls from mc_att_control
-	struct actuator_controls_s			_actuators_fw_in;	//actuator controls from fw_att_control
-	struct actuator_armed_s				_armed;				//actuator arming status
-	struct vehicle_local_position_s		_local_pos;
-	struct airspeed_s 					_airspeed;			// airspeed
-	struct battery_status_s 			_batt_status; 		// battery status
-	struct vehicle_command_s			_vehicle_cmd;
+	struct vehicle_attitude_s				_v_att;				//vehicle attitude
+	struct vehicle_attitude_setpoint_s		_v_att_sp;			//vehicle attitude setpoint
+	struct mc_virtual_attitude_setpoint_s	_mc_virtual_att_sp;	// virtual mc attitude setpoint
+	struct fw_virtual_attitude_setpoint_s	_fw_virtual_att_sp;	// virtual fw attitude setpoint
+	struct vehicle_rates_setpoint_s			_v_rates_sp;		//vehicle rates setpoint
+	struct mc_virtual_rates_setpoint_s		_mc_virtual_v_rates_sp;		// virtual mc vehicle rates setpoint
+	struct fw_virtual_rates_setpoint_s		_fw_virtual_v_rates_sp;		// virtual fw vehicle rates setpoint
+	struct manual_control_setpoint_s		_manual_control_sp; //manual control setpoint
+	struct vehicle_control_mode_s			_v_control_mode;	//vehicle control mode
+	struct vtol_vehicle_status_s			_vtol_vehicle_status;
+	struct actuator_controls_s				_actuators_out_0;	//actuator controls going to the mc mixer
+	struct actuator_controls_s				_actuators_out_1;	//actuator controls going to the fw mixer (used for elevons)
+	struct actuator_controls_s				_actuators_mc_in;	//actuator controls from mc_att_control
+	struct actuator_controls_s				_actuators_fw_in;	//actuator controls from fw_att_control
+	struct actuator_armed_s					_armed;				//actuator arming status
+	struct vehicle_local_position_s			_local_pos;
+	struct airspeed_s						_airspeed;			// airspeed
+	struct battery_status_s					_batt_status; 		// battery status
+	struct vehicle_command_s				_vehicle_cmd;
 
 	Params _params;	// struct holding the parameters
 

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -221,3 +221,12 @@ PARAM_DEFINE_INT32(VT_OPT_RECOV_EN, 0);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_INT32(VT_OPT_WV_LND, 0);
+
+/**
+ * Weather-vane yaw rate dampener
+ *
+ * @min 0
+ * @max 1
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_OPT_WV_RATE_D, 0.15f);

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -212,3 +212,12 @@ PARAM_DEFINE_FLOAT(VT_ARSP_TRANS, 10.0f);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_INT32(VT_OPT_RECOV_EN, 0);
+
+/**
+ * Enable weather-vane mode landings for missions
+ *
+ * @min 0
+ * @max 1
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_INT32(VT_OPT_WV_LND, 0);

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -230,3 +230,13 @@ PARAM_DEFINE_INT32(VT_OPT_WV_LND, 0);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_FLOAT(VT_OPT_WV_RATE_D, 0.15f);
+
+/**
+ * Enable weather-vane mode for loiter
+ *
+ * @min 0
+ * @max 1
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_INT32(VT_OPT_WV_LTR, 0);
+

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -32,9 +32,10 @@
  ****************************************************************************/
 
 /**
-* @file airframe.h
+* @file vtol_type.h
 *
 * @author Roman Bapst 		<bapstroman@gmail.com>
+* @author Sander Smeets		<sander@droneslab.com>
 *
 */
 
@@ -91,10 +92,10 @@ protected:
 	VtolAttitudeControl *_attc;
 	mode _vtol_mode;
 
-	struct vehicle_attitude_s		*_v_att;				//vehicle attitude
+	struct vehicle_attitude_s			*_v_att;				//vehicle attitude
 	struct vehicle_attitude_setpoint_s	*_v_att_sp;			//vehicle attitude setpoint
-	struct mc_virtual_attitude_setpoint_s *_mc_virtual_att_sp;	// virtual mc attitude setpoint
-	struct fw_virtual_attitude_setpoint_s *_fw_virtual_att_sp;	// virtual fw attitude setpoint
+	struct vehicle_attitude_setpoint_s	*_mc_virtual_att_sp;	// virtual mc attitude setpoint
+	struct vehicle_attitude_setpoint_s	*_fw_virtual_att_sp;	// virtual fw attitude setpoint
 	struct vehicle_rates_setpoint_s		*_v_rates_sp;		//vehicle rates setpoint
 	struct vehicle_rates_setpoint_s		*_mc_virtual_v_rates_sp;		// virtual mc vehicle rates setpoint
 	struct vehicle_rates_setpoint_s		*_fw_virtual_v_rates_sp;		// virtual fw vehicle rates setpoint

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 /**
-* @file vtol_type.h
+* @file airframe.h
 *
 * @author Roman Bapst 		<bapstroman@gmail.com>
 * @author Sander Smeets		<sander@droneslab.com>
@@ -92,26 +92,26 @@ protected:
 	VtolAttitudeControl *_attc;
 	mode _vtol_mode;
 
-	struct vehicle_attitude_s			*_v_att;				//vehicle attitude
-	struct vehicle_attitude_setpoint_s	*_v_att_sp;			//vehicle attitude setpoint
-	struct vehicle_attitude_setpoint_s	*_mc_virtual_att_sp;	// virtual mc attitude setpoint
-	struct vehicle_attitude_setpoint_s	*_fw_virtual_att_sp;	// virtual fw attitude setpoint
-	struct vehicle_rates_setpoint_s		*_v_rates_sp;		//vehicle rates setpoint
-	struct vehicle_rates_setpoint_s		*_mc_virtual_v_rates_sp;		// virtual mc vehicle rates setpoint
-	struct vehicle_rates_setpoint_s		*_fw_virtual_v_rates_sp;		// virtual fw vehicle rates setpoint
-	struct manual_control_setpoint_s	*_manual_control_sp; //manual control setpoint
-	struct vehicle_control_mode_s		*_v_control_mode;	//vehicle control mode
-	struct vtol_vehicle_status_s 		*_vtol_vehicle_status;
-	struct actuator_controls_s			*_actuators_out_0;			//actuator controls going to the mc mixer
-	struct actuator_controls_s			*_actuators_out_1;			//actuator controls going to the fw mixer (used for elevons)
-	struct actuator_controls_s			*_actuators_mc_in;			//actuator controls from mc_att_control
-	struct actuator_controls_s			*_actuators_fw_in;			//actuator controls from fw_att_control
-	struct actuator_armed_s				*_armed;					//actuator arming status
-	struct vehicle_local_position_s		*_local_pos;
-	struct airspeed_s 					*_airspeed;					// airspeed
-	struct battery_status_s 			*_batt_status; 				// battery status
+	struct vehicle_attitude_s				*_v_att;				//vehicle attitude
+	struct vehicle_attitude_setpoint_s		*_v_att_sp;			//vehicle attitude setpoint
+	struct mc_virtual_attitude_setpoint_s	*_mc_virtual_att_sp;	// virtual mc attitude setpoint
+	struct fw_virtual_attitude_setpoint_s	*_fw_virtual_att_sp;	// virtual fw attitude setpoint
+	struct vehicle_rates_setpoint_s			*_v_rates_sp;		//vehicle rates setpoint
+	struct mc_virtual_rates_setpoint_s		*_mc_virtual_v_rates_sp;		// virtual mc vehicle rates setpoint
+	struct fw_virtual_rates_setpoint_s		*_fw_virtual_v_rates_sp;		// virtual fw vehicle rates setpoint
+	struct manual_control_setpoint_s		*_manual_control_sp; //manual control setpoint
+	struct vehicle_control_mode_s			*_v_control_mode;	//vehicle control mode
+	struct vtol_vehicle_status_s			*_vtol_vehicle_status;
+	struct actuator_controls_s				*_actuators_out_0;			//actuator controls going to the mc mixer
+	struct actuator_controls_s				*_actuators_out_1;			//actuator controls going to the fw mixer (used for elevons)
+	struct actuator_controls_s				*_actuators_mc_in;			//actuator controls from mc_att_control
+	struct actuator_controls_s				*_actuators_fw_in;			//actuator controls from fw_att_control
+	struct actuator_armed_s					*_armed;					//actuator arming status
+	struct vehicle_local_position_s			*_local_pos;
+	struct airspeed_s						*_airspeed;					// airspeed
+	struct battery_status_s					*_batt_status; 				// battery status
 
-	struct Params 						*_params;
+	struct Params							*_params;
 
 	bool flag_idle_mc;		//false = "idle is set for fixed wing mode"; true = "idle is set for multicopter mode"
 


### PR DESCRIPTION
Fixes https://github.com/PX4/Firmware/issues/3679
cherry-picked all commits onto new branch

To enable weathervane mode set param VT_OPT_WV_LND to 1
The VT_OPT_WV_RATE_D param defines the yaw dampening during landing

todo:

- [x] Rename param to vtol_wv_yawrate_scale
- [x] Disable MC_YAWRATE_I when weathervaning
- [x] Add option to weathervane in loiter
- [ ] Implement weathervane strategy when yaw is over-demanded during MC auto flight
- [ ] flight test