### PR TITLE
Vtol transition failsafe with RTL for standard VTOL

### DIFF
--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -150,6 +150,8 @@ bool data_link_lost_cmd				# datalink to GCS lost mode commanded
 uint8 data_link_lost_counter			# counts unique data link lost events
 bool engine_failure				# Set to true if an engine failure is detected
 bool engine_failure_cmd				# Set to true if an engine failure mode is commanded
+bool vtol_transition_failure		# Set to true if vtol transition failed
+bool vtol_transition_failure_cmd	# Set to true if vtol transition failure mode is commanded
 bool gps_failure				# Set to true if a gps failure is detected
 bool gps_failure_cmd				# Set to true if a gps failure mode is commanded
 

--- a/msg/vtol_vehicle_status.msg
+++ b/msg/vtol_vehicle_status.msg
@@ -1,5 +1,6 @@
-uint64 timestamp		# Microseconds since system boot
-bool vtol_in_rw_mode		# true: vtol vehicle is in rotating wing mode
+uint64 timestamp				# Microseconds since system boot
+bool vtol_in_rw_mode			# true: vtol vehicle is in rotating wing mode
 bool vtol_in_trans_mode
-bool fw_permanent_stab		# In fw mode stabilize attitude even if in manual mode
-float32 airspeed_tot		# Estimated airspeed over control surfaces
+bool vtol_transition_failsafe	# vtol in transition failsafe mode
+bool fw_permanent_stab			# In fw mode stabilize attitude even if in manual mode
+float32 airspeed_tot			# Estimated airspeed over control surfaces

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -35,11 +35,12 @@
  * @file commander.cpp
  * Main fail-safe handling.
  *
- * @author Petri Tanskanen <petri.tanskanen@inf.ethz.ch>
- * @author Lorenz Meier <lorenz@px4.io>
- * @author Thomas Gubler <thomas@px4.io>
- * @author Julian Oes <julian@px4.io>
- * @author Anton Babushkin <anton@px4.io>
+ * @author Petri Tanskanen	<petri.tanskanen@inf.ethz.ch>
+ * @author Lorenz Meier		<lorenz@px4.io>
+ * @author Thomas Gubler	<thomas@px4.io>
+ * @author Julian Oes		<julian@px4.io>
+ * @author Anton Babushkin	<anton@px4.io>
+ * @author Sander Smeets	<sander@droneslab.com>
  */
 
 #include <px4_config.h>
@@ -796,6 +797,7 @@ bool handle_command(struct vehicle_status_s *status_local, const struct safety_s
 			status_local->data_link_lost_cmd = false;
 			status_local->gps_failure_cmd = false;
 			status_local->rc_signal_lost_cmd = false;
+			status_local->vtol_transition_failure_cmd = false;
 
 			if ((int)cmd->param2 <= 0) {
 				/* reset all commanded failure modes */
@@ -820,7 +822,14 @@ bool handle_command(struct vehicle_status_s *status_local, const struct safety_s
 				/* trigger rc loss mode */
 				status_local->rc_signal_lost_cmd = true;
 				warnx("rc loss mode commanded");
+
+			} else if ((int)cmd->param2 == 5) {
+				/* trigger vtol transition failure mode */
+				status_local->vtol_transition_failure_cmd = true;
+				warnx("vtol transition failure mode commanded");
 			}
+
+
 
 			cmd_result = vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED;
 		}
@@ -1718,6 +1727,8 @@ int commander_thread_main(int argc, char *argv[])
 			if (is_vtol(&status)) {
 				status.is_rotary_wing = vtol_status.vtol_in_rw_mode;
 				status.in_transition_mode = vtol_status.vtol_in_trans_mode;
+				status.vtol_transition_failure = vtol_status.vtol_transition_failsafe;
+				status.vtol_transition_failure_cmd = vtol_status.vtol_transition_failsafe;
 			}
 
 			status_changed = true;

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -35,8 +35,9 @@
  * @file state_machine_helper.cpp
  * State machine helper functions implementations
  *
- * @author Thomas Gubler <thomas@px4.io>
- * @author Julian Oes <julian@oes.ch>
+ * @author Thomas Gubler	<thomas@px4.io>
+ * @author Julian Oes		<julian@oes.ch>
+ * @author Sander Smeets	<sander@droneslab.com>
  */
 
 #include <stdio.h>
@@ -636,6 +637,7 @@ bool set_nav_state(struct vehicle_status_s *status, const bool data_link_loss_en
 		/* go into failsafe
 		 * - if commanded to do so
 		 * - if we have an engine failure
+		 * - if we have vtol transition failure
 		 * - depending on datalink, RC and if the mission is finished */
 
 		/* first look at the commands */
@@ -647,12 +649,16 @@ bool set_nav_state(struct vehicle_status_s *status, const bool data_link_loss_en
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDGPSFAIL;
 		} else if (status->rc_signal_lost_cmd) {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_RCRECOVER;
+		} else if (status->vtol_transition_failure_cmd) {
+			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_RTL;
 
 		/* finished handling commands which have priority, now handle failures */
 		} else if (status->gps_failure) {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDGPSFAIL;
 		} else if (status->engine_failure) {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
+		} else if (status->vtol_transition_failure) {
+			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_RTL;
 
 		/* datalink loss enabled:
 		 * check for datalink lost: this should always trigger RTGS */

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -38,6 +38,7 @@
 *
 * @author Simon Wilks 		<simon@uaventure.com>
 * @author Roman Bapst 		<bapstroman@gmail.com>
+* @author Sander Smeets 	<sander@droneslab.com>
 *
 */
 
@@ -69,6 +70,7 @@ private:
 		float pusher_trans;
 		float airspeed_blend;
 		float airspeed_trans;
+		float front_trans_timeout;
 	} _params_standard;
 
 	struct {
@@ -77,6 +79,7 @@ private:
 		param_t pusher_trans;
 		param_t airspeed_blend;
 		param_t airspeed_trans;
+		param_t front_trans_timeout;
 	} _params_handles_standard;
 
 	enum vtol_mode {

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -454,6 +454,7 @@ VtolAttitudeControl::abort_front_transition()
 	if(!_abort_front_transition) {
 		mavlink_log_critical(_mavlink_fd, "Front transition timeout occured, aborting");
 		_abort_front_transition = true;
+		_vtol_vehicle_status.vtol_transition_failsafe = true;
 	}
 }
 
@@ -739,8 +740,8 @@ void VtolAttitudeControl::task_main()
 
 		/* Only publish if the proper mode(s) are enabled */
 		if (_v_control_mode.flag_control_attitude_enabled ||
-		    _v_control_mode.flag_control_rates_enabled ||
-		    _v_control_mode.flag_control_manual_enabled) {
+			_v_control_mode.flag_control_rates_enabled ||
+			_v_control_mode.flag_control_manual_enabled) {
 			if (_actuators_0_pub != nullptr) {
 				orb_publish(ORB_ID(actuator_controls_0), _actuators_0_pub, &_actuators_out_0);
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -43,6 +43,7 @@
  * @author Thomas Gubler	<thomasgubler@gmail.com>
  * @author David Vorsin		<davidvorsin@gmail.com>
  * @author Sander Smeets	<sander@droneslab.com>
+ * @author Andreas Antener 	<andreas@uaventure.com>
  *
  */
 #include "vtol_att_control_main.h"
@@ -428,13 +429,14 @@ VtolAttitudeControl::is_fixed_wing_requested()
 {
 	bool to_fw = _manual_control_sp.aux1 > 0.0f;
 
-	if (_v_control_mode.flag_control_offboard_enabled || _v_control_mode.flag_control_auto_enabled) {
+	// listen to transition commands if not in manual
+	if (!_v_control_mode.flag_control_manual_enabled) {
 		to_fw = _transition_command == vehicle_status_s::VEHICLE_VTOL_STATE_FW;
 	}
 
 	// handle abort request
-	if(_abort_front_transition) {
-		if(to_fw) {
+	if (_abort_front_transition) {
+		if (to_fw) {
 			to_fw = false;
 		} else {
 			// the state changed to mc mode, reset the abort request
@@ -666,8 +668,8 @@ void VtolAttitudeControl::task_main()
 		// update the vtol state machine which decides which mode we are in
 		_vtol_type->update_vtol_state();
 
-		// reset transition command if not in offboard control
-		if (!_v_control_mode.flag_control_offboard_enabled) {
+		// reset transition command if not auto control
+		if (_v_control_mode.flag_control_manual_enabled) {
 			if (_vtol_type->get_mode() == ROTARY_WING) {
 				_transition_command = vehicle_status_s::VEHICLE_VTOL_STATE_MC;
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -441,6 +441,7 @@ VtolAttitudeControl::is_fixed_wing_requested()
 		} else {
 			// the state changed to mc mode, reset the abort request
 			_abort_front_transition = false;
+			_vtol_vehicle_status.vtol_transition_failsafe = false;
 		}
 	}
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -43,6 +43,7 @@
  * @author Thomas Gubler	<thomasgubler@gmail.com>
  * @author David Vorsin		<davidvorsin@gmail.com>
  * @author Sander Smeets	<sander@droneslab.com>
+ * @author Andreas Antener 	<andreas@uaventure.com>
  *
  */
 #ifndef VTOL_ATT_CONTROL_MAIN_H

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -41,7 +41,8 @@
  * @author Roman Bapst 		<bapstr@ethz.ch>
  * @author Lorenz Meier 	<lm@inf.ethz.ch>
  * @author Thomas Gubler	<thomasgubler@gmail.com>
- * @author David Vorsin     <davidvorsin@gmail.com>
+ * @author David Vorsin		<davidvorsin@gmail.com>
+ * @author Sander Smeets	<sander@droneslab.com>
  *
  */
 #ifndef VTOL_ATT_CONTROL_MAIN_H
@@ -106,6 +107,7 @@ public:
 
 	int start();	/* start the task and return OK on success */
 	bool is_fixed_wing_requested();
+	void abort_front_transition();
 
 	struct vehicle_attitude_s 				*get_att() {return &_v_att;}
 	struct vehicle_attitude_setpoint_s		*get_att_sp() {return &_v_att_sp;}
@@ -133,6 +135,7 @@ private:
 //******************flags & handlers******************************************************
 	bool _task_should_exit;
 	int _control_task;		//task handle for VTOL attitude controller
+	int _mavlink_fd;		// mavlink log device
 
 	/* handlers for subscriptions */
 	int		_v_att_sub;				//vehicle attitude subscription
@@ -201,6 +204,7 @@ private:
 	 * for fixed wings we want to have an idle speed of zero since we do not want
 	 * to waste energy when gliding. */
 	int _transition_command;
+	bool _abort_front_transition;
 
 	VtolType *_vtol_type;	// base class for different vtol types
 	Tiltrotor *_tiltrotor;	// tailsitter vtol type

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -212,3 +212,14 @@ PARAM_DEFINE_FLOAT(VT_ARSP_TRANS, 10.0f);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_INT32(VT_OPT_RECOV_EN, 0);
+
+/**
+ * Front transition timeout
+ *
+ * Time in seconds after which transition will be cancelled. Disabled if set to 0.
+ *
+ * @min 0.0
+ * @max 30.0
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_TRANS_TIMEOUT, 15.0f);

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 /**
-* @file airframe.cpp
+* @file vtol_type.cpp
 *
 * @author Roman Bapst 		<bapstroman@gmail.com>
 *

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 /**
-* @file airframe.h
+* @file vtol_type.h
 *
 * @author Roman Bapst 		<bapstroman@gmail.com>
 *


### PR DESCRIPTION
@sanderux 2 additional fixes
- reset transition command when not in any of the auto modes (missed that on my last push)
- reset failsafe state after switched out. otherwise you cannot engage mission again

Partly replaces #3676
Fixes: #3663