### PR TITLE
Takeoff idle throttle, fixes #3640

### DIFF
--- a/src/lib/launchdetection/LaunchDetector.cpp
+++ b/src/lib/launchdetection/LaunchDetector.cpp
@@ -48,7 +48,7 @@ LaunchDetector::LaunchDetector() :
 	SuperBlock(NULL, "LAUN"),
 	activeLaunchDetectionMethodIndex(-1),
 	launchdetection_on(this, "ALL_ON"),
-	throttlePreTakeoff(this, "THR_PRE")
+	throttlePreTakeoff(nullptr, "FW_THR_IDLE")
 {
 	/* init all detectors */
 	launchMethods[0] = new CatapultLaunchMethod(this);

--- a/src/lib/launchdetection/launchdetection_params.c
+++ b/src/lib/launchdetection/launchdetection_params.c
@@ -77,7 +77,7 @@ PARAM_DEFINE_FLOAT(LAUN_CAT_T, 0.05f);
  * Motor delay
  *
  * Delay between starting attitude control and powering up the throttle (giving throttle control to the controller)
- * Before this timespan is up the throttle will be set to LAUN_THR_PRE, set to 0 to deactivate
+ * Before this timespan is up the throttle will be set to FW_THR_IDLE, set to 0 to deactivate
  *
  * @unit seconds
  * @min 0
@@ -97,14 +97,3 @@ PARAM_DEFINE_FLOAT(LAUN_CAT_MDEL, 0.0f);
  * @group Launch detection
  */
 PARAM_DEFINE_FLOAT(LAUN_CAT_PMAX, 30.0f);
-
-/**
- * Throttle setting while detecting launch.
- *
- * The throttle is set to this value while the system is waiting for the take-off.
- *
- * @min 0
- * @max 1
- * @group Launch detection
- */
-PARAM_DEFINE_FLOAT(LAUN_THR_PRE, 0.0f);

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
@@ -1935,7 +1935,7 @@ FixedwingPositionControl::control_position(const math::Vector<2> &current_positi
 		/* making sure again that the correct thrust is used,
 		 * without depending on library calls for safety reasons.
 		   the pre-takeoff throttle and the idle throttle normally map to the same parameter. */
-		_att_sp.thrust = (launchDetectionEnabled()) ? launchDetector.getThrottlePreTakeoff() : _parameters.throttle_idle;
+		_att_sp.thrust = (launchDetector.launchDetectionEnabled()) ? launchDetector.getThrottlePreTakeoff() : _parameters.throttle_idle;
 
 	} else if (_control_mode_current ==  FW_POSCTRL_MODE_AUTO &&
 		   pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF &&

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -156,6 +156,20 @@ PARAM_DEFINE_FLOAT(FW_THR_MAX, 1.0f);
 PARAM_DEFINE_FLOAT(FW_THR_MIN, 0.0f);
 
 /**
+ * Idle throttle
+ *
+ * This is the minimum throttle while on the ground
+ *
+ * For aircraft with internal combustion engine this parameter should be set
+ * above desired idle rpm.
+ *
+ * @min 0.0
+ * @max 0.4
+ * @group L1 Control
+ */
+PARAM_DEFINE_FLOAT(FW_THR_IDLE, 0.15f);
+
+/**
  * Throttle limit value before flare
  *
  * This throttle value will be set as throttle limit at FW_LND_TLALT,


### PR DESCRIPTION
@tumbili This should fix #3640. Will merge after a bench test.

@AndreasAntener @sanderux Please review. This should help with hand-launched planes in auto, as the idle throttle will help with the "ready to launch" indication.