### PR TITLE
Yaw timeout for VTOL forwards transition

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -47,7 +47,7 @@ then
 	param set MPC_LAND_SPEED 0.7
 	param set MPC_Z_VEL_MAX 1.5
 	param set MPC_XY_VEL_MAX 4.0
-	param set MIS_YAW_TMT 10
+	param set MIS_YAW_TMT 5
 fi
 
 set PWM_DISARMED 900

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -47,7 +47,7 @@ then
 	param set MPC_LAND_SPEED 0.7
 	param set MPC_Z_VEL_MAX 1.5
 	param set MPC_XY_VEL_MAX 4.0
-	param set MIS_YAW_TMT 5
+	param set MIS_YAW_TMT 10
 fi
 
 set PWM_DISARMED 900

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -47,6 +47,7 @@ then
 	param set MPC_LAND_SPEED 0.7
 	param set MPC_Z_VEL_MAX 1.5
 	param set MPC_XY_VEL_MAX 4.0
+	param set MIS_YAW_TMT 10
 fi
 
 set PWM_DISARMED 900

--- a/msg/mission_result.msg
+++ b/msg/mission_result.msg
@@ -6,7 +6,8 @@ bool warning			# true if mission is valid, but has potentially problematic items
 bool reached			# true if mission has been reached
 bool finished			# true if mission has been completed
 bool stay_in_failsafe		# true if the commander should not switch out of the failsafe mode
-bool flight_termination	# true if the navigator demands a flight termination from the commander app
+bool flight_termination		# true if the navigator demands a flight termination from the commander app
 bool item_do_jump_changed	# true if the number of do jumps remaining has changed
 uint32 item_changed_index	# indicate which item has changed
 uint32 item_do_jump_remaining	# set to the number of do jumps remaining for that item
+bool mission_failure		# true if the mission cannot continue or be completed for some reason

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -154,7 +154,7 @@ bool vtol_transition_failure		# Set to true if vtol transition failed
 bool vtol_transition_failure_cmd	# Set to true if vtol transition failure mode is commanded
 bool gps_failure				# Set to true if a gps failure is detected
 bool gps_failure_cmd				# Set to true if a gps failure mode is commanded
-
+bool mission_failure				# Set to true if mission could not continue/finish
 bool barometer_failure				# Set to true if a barometer failure is detected
 
 bool offboard_control_signal_found_once

--- a/posix-configs/SITL/init/rcS_gazebo_standard_vtol
+++ b/posix-configs/SITL/init/rcS_gazebo_standard_vtol
@@ -32,6 +32,7 @@ param set SENS_BOARD_ROT 8
 param set COM_RC_IN_MODE 1
 param set NAV_ACC_RAD 3.0
 param set MPC_TKO_SPEED 1.0
+param set MIS_YAW_TMT 5
 rgbledsim start
 tone_alarm start
 gyrosim start

--- a/posix-configs/SITL/init/rcS_gazebo_standard_vtol
+++ b/posix-configs/SITL/init/rcS_gazebo_standard_vtol
@@ -32,7 +32,7 @@ param set SENS_BOARD_ROT 8
 param set COM_RC_IN_MODE 1
 param set NAV_ACC_RAD 3.0
 param set MPC_TKO_SPEED 1.0
-param set MIS_YAW_TMT 5
+param set MIS_YAW_TMT 10
 rgbledsim start
 tone_alarm start
 gyrosim start

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2043,6 +2043,15 @@ int commander_thread_main(int argc, char *argv[])
 
 		if (updated) {
 			orb_copy(ORB_ID(mission_result), mission_result_sub, &mission_result);
+
+			if (status.mission_failure != mission_result.mission_failure) {
+				status.mission_failure = mission_result.mission_failure;
+				status_changed = true;
+
+				if (status.mission_failure) {
+					mavlink_log_critical(mavlink_fd, "mission cannot be completed");
+				}
+			}
 		}
 
 		/* start geofence result check */

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -659,6 +659,8 @@ bool set_nav_state(struct vehicle_status_s *status, const bool data_link_loss_en
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 		} else if (status->vtol_transition_failure) {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_RTL;
+		} else if (status->mission_failure) {
+			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_RTL;
 
 		/* datalink loss enabled:
 		 * check for datalink lost: this should always trigger RTGS */

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -219,6 +219,8 @@ Mission::update_onboard_mission()
 
 		// XXX check validity here as well
 		_navigator->get_mission_result()->valid = true;
+		/* reset mission failure if we have an updated valid mission */
+		_navigator->get_mission_result()->mission_failure = false;
 		_navigator->increment_mission_instance_count();
 		_navigator->set_mission_result_updated();
 
@@ -263,6 +265,10 @@ Mission::update_offboard_mission()
 				_navigator->get_vstatus()->condition_landed);
 
 		_navigator->get_mission_result()->valid = !failed;
+		if (!failed) {
+			/* reset mission failure if we have an updated valid mission */
+			_navigator->get_mission_result()->mission_failure = false;
+		}
 		_navigator->increment_mission_instance_count();
 		_navigator->set_mission_result_updated();
 
@@ -510,6 +516,7 @@ Mission::set_mission_items()
 				_navigator->get_global_position()->lon,
 				mission_item_next_position.lat,
 				mission_item_next_position.lon);
+			_mission_item.force_heading = true;
 		}
 
 		/* yaw is aligned now */

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -505,10 +505,7 @@ Mission::set_mission_items()
 			new_work_item_type = WORK_ITEM_TYPE_ALIGN;
 
 			_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
-			_mission_item.lat = _navigator->get_global_position()->lat;
-			_mission_item.lon = _navigator->get_global_position()->lon;
-			_mission_item.altitude = _navigator->get_global_position()->alt;
-			_mission_item.altitude_is_relative = false;
+			copy_positon_if_valid(_mission_item, pos_sp_triplet->current);
 			_mission_item.autocontinue = true;
 			_mission_item.time_inside = 0;
 			_mission_item.yaw = get_bearing_to_next_waypoint(
@@ -541,10 +538,7 @@ Mission::set_mission_items()
 			new_work_item_type = WORK_ITEM_TYPE_DEFAULT;
 
 			_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
-			_mission_item.lat = pos_sp_triplet->current.lat;
-			_mission_item.lon = pos_sp_triplet->current.lon;
-			_mission_item.altitude = pos_sp_triplet->current.alt;
-			_mission_item.altitude_is_relative = false;
+			copy_positon_if_valid(_mission_item, pos_sp_triplet->current);
 			_mission_item.autocontinue = true;
 			_mission_item.time_inside = 0;
 		}
@@ -601,6 +595,23 @@ Mission::set_mission_items()
 	}
 
 	_navigator->set_position_setpoint_triplet_updated();
+}
+
+void
+Mission::copy_positon_if_valid(struct mission_item_s &mission_item, struct position_setpoint_s &setpoint)
+{
+	if (setpoint.valid) {
+		_mission_item.lat = setpoint.lat;
+		_mission_item.lon = setpoint.lon;
+		_mission_item.altitude = setpoint.alt;
+
+	} else {
+		_mission_item.lat = _navigator->get_global_position()->lat;
+		_mission_item.lon = _navigator->get_global_position()->lon;
+		_mission_item.altitude = _navigator->get_global_position()->alt;
+	}
+
+	_mission_item.altitude_is_relative = false;
 }
 
 bool

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -120,6 +120,11 @@ private:
 	void set_mission_items();
 
 	/**
+	 * Copies position from setpoint if valid, otherwise copies current position
+	 */
+	void copy_positon_if_valid(struct mission_item_s &mission_item, struct position_setpoint_s &setpoint);
+
+	/**
 	 * Returns true if we need to do a takeoff at the current state
 	 */
 	bool do_need_takeoff();

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -196,9 +196,17 @@ MissionBlock::is_mission_item_reached()
 			float yaw_err = _wrap_pi(_mission_item.yaw - _navigator->get_global_position()->yaw);
 
 			if (fabsf(yaw_err) < math::radians(_param_yaw_err.get())
+					/* check if we should accept heading after a timeout, 0 means accept instantly */
 					|| (_param_yaw_timeout.get() >= -FLT_EPSILON &&
 						now - _time_wp_reached >= (hrt_abstime)_param_yaw_timeout.get() * 1e6f)) {
-				_waypoint_yaw_reached = true;
+
+				/* if heading needs to be reached but we got here because of the timeout, abort mission */
+				if (_mission_item.force_heading && !(fabsf(yaw_err) < math::radians(_param_yaw_err.get()))) {
+					_navigator->set_mission_failure("unable to reach heading within timeout");
+
+				} else {
+					_waypoint_yaw_reached = true;
+				}
 			}
 
 		} else {

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -45,9 +45,6 @@
 
 #include <navigator/navigation.h>
 
-#include <controllib/blocks.hpp>
-#include <controllib/block/BlockParam.hpp>
-
 #include <uORB/topics/mission.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/position_setpoint_triplet.h>
@@ -128,10 +125,14 @@ protected:
 	bool _waypoint_yaw_reached;
 	hrt_abstime _time_first_inside_orbit;
 	hrt_abstime _action_start;
+	hrt_abstime _time_wp_reached;
 
 	actuator_controls_s _actuators;
 	orb_advert_t    _actuator_pub;
 	orb_advert_t	_cmd_pub;
+
+	control::BlockParamFloat _param_yaw_timeout;
+	control::BlockParamFloat _param_yaw_err;
 	control::BlockParamInt _param_vtol_wv_land;
 	control::BlockParamInt _param_vtol_wv_loiter;
 };

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -113,7 +113,8 @@ PARAM_DEFINE_INT32(MIS_YAWMODE, 1);
  *
  * Prevents missions getting blocked at waypoints because it cannot reach target yaw.
  * Mainly useful for VTOLs that have less yaw authority and might not reach target
- * yaw in wind. Disabled by default. Can be set to 0 if it should not care for yaw on waypoints.
+ * yaw in wind. Disabled by default. If set to 0 it will not wait for yaw to align,
+ * however VTOL transitions will abort if heading is not reached.
  *
  * @min -1
  * @max 20

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -107,3 +107,25 @@ PARAM_DEFINE_INT32(MIS_ALTMODE, 1);
  * @group Mission
  */
 PARAM_DEFINE_INT32(MIS_YAWMODE, 1);
+
+/**
+ * Time in seconds we wait on reaching target heading at a waypoint.
+ *
+ * Prevents missions getting blocked at waypoints because it cannot reach target yaw.
+ * Mainly useful for VTOLs that have less yaw authority and might not reach target
+ * yaw in wind. Disabled by default. Can be set to 0 if it should not care for yaw on waypoints.
+ *
+ * @min -1
+ * @max 20
+ * @group Mission
+ */
+PARAM_DEFINE_FLOAT(MIS_YAW_TMT, -1.0f);
+
+/**
+ * Max yaw error in degree needed for waypoint heading acceptance.
+ *
+ * @min 0
+ * @max 90
+ * @group Mission
+ */
+PARAM_DEFINE_FLOAT(MIS_YAW_ERR, 12.0f);

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -109,12 +109,12 @@ PARAM_DEFINE_INT32(MIS_ALTMODE, 1);
 PARAM_DEFINE_INT32(MIS_YAWMODE, 1);
 
 /**
- * Time in seconds we wait on reaching target heading at a waypoint.
+ * Time in seconds we wait on reaching target heading at a waypoint if it is forced.
  *
- * Prevents missions getting blocked at waypoints because it cannot reach target yaw.
+ * If set > 0 it will ignore the target heading for normal waypoint acceptance. If the
+ * waypoint forces the heading the timeout will matter. For example on VTOL forwards transiton.
  * Mainly useful for VTOLs that have less yaw authority and might not reach target
- * yaw in wind. Disabled by default. If set to 0 it will not wait for yaw to align,
- * however VTOL transitions will abort if heading is not reached.
+ * yaw in wind. Disabled by default.
  *
  * @min -1
  * @max 20

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -105,6 +105,7 @@ struct mission_item_s {
 	unsigned do_jump_current_count;	/**< count how many times the jump has been done	*/
 	float params[7];		/**< array to store mission command values for MAV_FRAME_MISSION ***/
 	int8_t frame;			/**< mission frame ***/
+	bool force_heading;		/**< heading needs to be reached ***/
 };
 #pragma pack(pop)
 #include <uORB/topics/mission.h>

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -168,6 +168,8 @@ public:
 
 	void		increment_mission_instance_count() { _mission_instance_count++; }
 
+	void 		set_mission_failure(const char *reason);
+
 private:
 
 	bool		_task_should_exit;		/**< if true, sensor task should exit */

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -750,3 +750,13 @@ Navigator::publish_att_sp()
 		_att_sp_pub = orb_advertise(ORB_ID(vehicle_attitude_setpoint), &_att_sp);
 	}
 }
+
+void
+Navigator::set_mission_failure(const char* reason)
+{
+	if (!_mission_result.mission_failure) {
+		_mission_result.mission_failure = true;
+		set_mission_result_updated();
+		mavlink_log_critical(_mavlink_fd, "%s", reason);
+	}
+}


### PR DESCRIPTION
This adds a yaw timeout on accepting the waypoint for the VTOL forwards transition because a VTOL might not reach yaw in wind. Fixes #3728

MIS_YAW_TMT
- default: -1
- > 0: timeout active on waypoints which force heading, ignore heading for acceptance on normal waypoints

MIS_YAW_TMT set to 10 seconds for default VTOL configurations