### PR TITLE
Proposal to change Astyle base to KR

### DIFF
--- a/Tools/astylerc
+++ b/Tools/astylerc
@@ -1,5 +1,5 @@
 indent=force-tab=8
-style=linux
+style=kr
 indent-preprocessor
 indent-cases
 break-blocks=all


### PR DESCRIPTION
I was surprised by the weird conditional indent formatting from Astyle: https://github.com/PX4/Firmware/commit/fc071e018613f9735135e79468507c032130b965
Note how it adds half on an indent with spaces instead of double tabs.

Apparently this is an issue with the Linux base style and this kind of conditional indent: http://astyle.sourceforge.net/astyle.html#_style=linux

I changed it to KR according to the docs and the result is much more satisfying: https://github.com/PX4/Firmware/commit/68e8f3f94218a140c2d4d85f5428b60e7bfeb7f2

I'm not actually sure how it's supposed to be (or if there was a discussion about that), I just like this one better :)