### PR TITLE
increase stack size for frsky telemetry daemon

### DIFF
--- a/src/drivers/frsky_telemetry/frsky_telemetry.c
+++ b/src/drivers/frsky_telemetry/frsky_telemetry.c
@@ -443,7 +443,7 @@ int frsky_telemetry_main(int argc, char *argv[])
 		frsky_task = px4_task_spawn_cmd("frsky_telemetry",
 						SCHED_DEFAULT,
 						200,
-						2000,
+						2200,
 						frsky_telemetry_thread_main,
 						(char *const *)argv);
 


### PR DESCRIPTION
before:
```
Processes: 22 total, 3 running, 19 sleeping
CPU usage: 29.93% tasks, 6.55% sched, 63.52% idle
Uptime: 513.364s total, 327.685s idle

 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE 
   0 Idle Task                  327685 63.517     0/    0   0 (  0)  READY 
   1 hpwork                      28100  5.144   884/ 1592 192 (192)  w:sig 
   2 lpwork                       1845  0.280   356/ 1592  50 ( 50)  w:sig 
   3 init                         1545  0.000  1676/ 2496 100 (100)  w:sem 
  83 dataman                         1  0.000   652/ 1192  90 ( 90)  w:sem 
 102 sensors                     22151  4.022  1748/ 1992 250 (250)  w:sem 
 104 gps                           884  0.093   676/ 1192 220 (220)  w:sem 
 106 commander                    2476  0.374  3236/ 3592 140 (140)  w:sig 
 107 commander_low_prio           1241  0.000   756/ 2872  50 ( 50)  w:sem 
 113 mavlink_if0                 28698  5.051  2364/ 2696 100 (100)  w:sig 
 114 mavlink_rcv_if0               128  0.000  1316/ 2096 175 (175)  w:sem 
 117 mavlink_if1                  4397  0.748  2364/ 2696 100 (100)  w:sig 
 118 mavlink_rcv_if1                40  0.000   828/ 2096 175 (175)  w:sem 
 121 mavlink_if2                  3898  0.654  2364/ 2696 100 (100)  w:sig 
 122 mavlink_rcv_if2                40  0.000   828/ 2096 175 (175)  w:sem 
 132 sdlog2                      18641  0.000  2892/ 3296  70 ( 70)  RUN   
 151 attitude_estimator_q        25876  5.051  1916/ 2392 250 (250)  w:sem 
 155 position_estimator_inav     18589  3.554  4836/ 5296 250 (250)  w:sem 
 157 mc_att_control              10656  2.057  1148/ 1496 250 (250)  w:sem 
 159 mc_pos_control               4083  0.841  1124/ 1896 250 (250)  w:sem 
 169 navigator                    4012  0.748   868/ 1496 105 (105)  w:sem 
 176 frsky_telemetry              7681  1.309  1992/ 1992 200 (200)  w:sem 
```
after:
```
Processes: 25 total, 3 running, 22 sleeping
CPU usage: 38.86% tasks, 0.59% sched, 60.55% idle
Uptime: 18.462s total, 11.113s idle

 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE 
   0 Idle Task                   11113 60.545     0/    0   0 (  0)  READY 
   1 hpwork                        721  4.867   828/ 1592 192 (192)  w:sem 
   2 lpwork                         60  0.368   356/ 1592  50 ( 50)  w:sig 
   3 init                         1576  0.000  1612/ 2496 100 (100)  w:sem 
 197 top                           111  3.687  1204/ 1696 100 (100)  RUN   
  83 dataman                         1  0.000   652/ 1192  90 ( 90)  w:sem 
 102 sensors                       674  4.203  1668/ 1992 250 (250)  w:sem 
 104 gps                            24  0.147   676/ 1192 220 (220)  w:sem 
 106 commander                     146  0.442  3164/ 3592 140 (140)  w:sig 
 107 commander_low_prio              0  0.000   548/ 2872  50 ( 50)  w:sem 
 113 mavlink_if0                   810  5.678  2356/ 2696 100 (100)  w:sig 
 114 mavlink_rcv_if0                 1  0.000   828/ 2096 175 (175)  w:sem 
 117 mavlink_if1                   133  0.884  2348/ 2696 100 (100)  w:sig 
 118 mavlink_rcv_if1                 1  0.000   780/ 2096 175 (175)  w:sem 
 121 mavlink_if2                   119  0.737  2348/ 2696 100 (100)  w:sig 
 122 mavlink_rcv_if2                 1  0.000   820/ 2096 175 (175)  w:sem 
 132 sdlog2                         48  0.294  2076/ 3296  70 ( 70)  w:sig 
 151 attitude_estimator_q          703  5.309  1916/ 2392 250 (250)  w:sem 
 155 position_estimator_inav       308  2.507  4836/ 5296 250 (250)  w:sem 
 157 mc_att_control                323  2.359  1140/ 1496 250 (250)  w:sem 
 159 mc_pos_control                 76  0.663   996/ 1896 250 (250)  w:sem 
 169 navigator                       6  0.000   884/ 1496 105 (105)  w:sem 
 176 frsky_telemetry               183  1.327  2084/ 2192 200 (200)  w:sem 
 188 mavlink_if3                   740  5.383  2348/ 2696 100 (100)  w:sig 
 190 mavlink_rcv_if3                 1  0.000   796/ 2096 175 (175)  w:sem 
```
```
nsh> free
             total       used       free    largest
Mem:        227840     192768      35072      33376
```