### PR TITLE
WIP: Rate mode implemented with full attitude control

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -3072,7 +3072,7 @@ set_control_mode()
 		control_mode.flag_control_manual_enabled = true;
 		control_mode.flag_control_auto_enabled = false;
 		control_mode.flag_control_rates_enabled = true;
-		control_mode.flag_control_attitude_enabled = false;
+		control_mode.flag_control_attitude_enabled = true;
 		control_mode.flag_control_altitude_enabled = false;
 		control_mode.flag_control_climb_rate_enabled = false;
 		control_mode.flag_control_position_enabled = false;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1869,7 +1869,10 @@ MulticopterPositionControl::task_main()
 				if (_vehicle_status.main_state == vehicle_status_s::MAIN_STATE_ACRO) {
 					/* rate mode - interpret roll/pitch inputs as rate demands */
 					_att_sp.roll_body += _manual.y * _params.acro_rollRate_max * dt;
+					if (_att_sp.roll_body < -M_PI_F) _att_sp.roll_body += M_TWOPI_F;
+					if (_att_sp.roll_body >  M_PI_F) _att_sp.roll_body -= M_TWOPI_F;
 					_att_sp.pitch_body -= _manual.x * _params.acro_pitchRate_max * dt;
+					math::constrain(_att_sp.pitch_body, math::radians(-85.0f), math::radians(85.0f));
 				} else {
 					/* angle mode - interpret roll/pitch inputs as angles */
 					_att_sp.roll_body = _manual.y * _params.man_roll_max;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -192,6 +192,9 @@ private:
 		param_t hold_max_xy;
 		param_t hold_max_z;
 		param_t acc_hor_max;
+		param_t acro_rollRate_max;
+		param_t acro_pitchRate_max;
+		param_t acro_yawRate_max;
 
 	}		_params_handles;		/**< handles for interesting parameters */
 
@@ -214,6 +217,9 @@ private:
 		float hold_max_xy;
 		float hold_max_z;
 		float acc_hor_max;
+		float acro_rollRate_max;
+		float acro_pitchRate_max;
+		float acro_yawRate_max;
 
 		math::Vector<3> pos_p;
 		math::Vector<3> vel_p;
@@ -449,6 +455,9 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_params_handles.hold_max_xy = param_find("MPC_HOLD_MAX_XY");
 	_params_handles.hold_max_z = param_find("MPC_HOLD_MAX_Z");
 	_params_handles.acc_hor_max = param_find("MPC_ACC_HOR_MAX");
+	_params_handles.acro_rollRate_max	= 	param_find("MC_ACRO_R_MAX");
+	_params_handles.acro_pitchRate_max	= 	param_find("MC_ACRO_P_MAX");
+	_params_handles.acro_yawRate_max	= 	param_find("MC_ACRO_Y_MAX");
 
 	/* fetch initial parameter values */
 	parameters_update(true);
@@ -558,10 +567,16 @@ MulticopterPositionControl::parameters_update(bool force)
 		param_get(_params_handles.man_pitch_max, &_params.man_pitch_max);
 		param_get(_params_handles.man_yaw_max, &_params.man_yaw_max);
 		param_get(_params_handles.global_yaw_max, &_params.global_yaw_max);
+		param_get(_params_handles.acro_rollRate_max, &_params.acro_rollRate_max);
+		param_get(_params_handles.acro_pitchRate_max, &_params.acro_pitchRate_max);
+		param_get(_params_handles.acro_yawRate_max, &_params.acro_yawRate_max);
 		_params.man_roll_max = math::radians(_params.man_roll_max);
 		_params.man_pitch_max = math::radians(_params.man_pitch_max);
 		_params.man_yaw_max = math::radians(_params.man_yaw_max);
 		_params.global_yaw_max = math::radians(_params.global_yaw_max);
+		_params.acro_rollRate_max = math::radians(_params.acro_rollRate_max);
+		_params.acro_pitchRate_max = math::radians(_params.acro_pitchRate_max);
+		_params.acro_yawRate_max = math::radians(_params.acro_yawRate_max);
 
 		param_get(_params_handles.mc_att_yaw_p, &v);
 		_params.mc_att_yaw_p = v;
@@ -1849,10 +1864,17 @@ MulticopterPositionControl::task_main()
 				}
 			}
 
-			/* control roll and pitch directly if we no aiding velocity controller is active */
+			/* control roll and pitch directly if no aiding velocity controller is active */
 			if (!_control_mode.flag_control_velocity_enabled) {
-				_att_sp.roll_body = _manual.y * _params.man_roll_max;
-				_att_sp.pitch_body = -_manual.x * _params.man_pitch_max;
+				if (_vehicle_status.main_state == vehicle_status_s::MAIN_STATE_ACRO) {
+					/* rate mode - interpret roll/pitch inputs as rate demands */
+					_att_sp.roll_body += _manual.y * _params.acro_rollRate_max * dt;
+					_att_sp.pitch_body -= _manual.x * _params.acro_pitchRate_max * dt;
+				} else {
+					/* angle mode - interpret roll/pitch inputs as angles */
+					_att_sp.roll_body = _manual.y * _params.man_roll_max;
+					_att_sp.pitch_body = -_manual.x * _params.man_pitch_max;
+				}
 			}
 
 			/* control throttle directly if no climb rate controller is active */


### PR DESCRIPTION
move "acro" mode handling to mc_pos_control to validate attitude estimation and control

must change the computation of attitude setpoint to operate on quaternion or rotation matrix instead of Euler angles
Bench testing indicates that the MC attitude controller responds correctly for all roll/pitch orientation setpoints, but it seems the mixer doesn't work properly for inverted poses.