### PR TITLE
FW generalize auto takeoff

### DIFF
--- a/ROMFS/px4fmu_common/init.d/1000_rc_fw_easystar.hil
+++ b/ROMFS/px4fmu_common/init.d/1000_rc_fw_easystar.hil
@@ -38,7 +38,7 @@ then
 	param set FW_RR_I 0.1
 	param set FW_RR_IMAX 0.2
 	param set FW_RR_P 0.3
-	param set RWTO_TKOFF 1
+	param set FW_RWTO 1
 fi
 
 set HIL yes

--- a/ROMFS/px4fmu_common/init.d/2107_bixler
+++ b/ROMFS/px4fmu_common/init.d/2107_bixler
@@ -1,0 +1,53 @@
+#!nsh
+#
+# @name HobbyKing Bixler
+#
+# @type Standard Plane
+#
+# @output MAIN1 aileron
+# @output MAIN2 aileron
+# @output MAIN3 elevator
+# @output MAIN4 rudder
+# @output MAIN5 throttle
+# @output MAIN6 wheel
+# @output MAIN7 flaps
+#
+# @output AUX1 feed-through of RC AUX1 channel
+# @output AUX2 feed-through of RC AUX2 channel
+# @output AUX3 feed-through of RC AUX3 channel
+#
+# @maintainer Daniel Agar <daniel@agar.ca>
+#
+
+sh /etc/init.d/rc.fw_defaults
+
+if [ $AUTOCNF == yes ]
+then
+    param set FW_AIRSPD_MIN 10
+    param set FW_AIRSPD_TRIM 15
+    param set FW_AIRSPD_MAX 20
+
+    param set FW_MAN_P_MAX 55
+    param set FW_MAN_R_MAX 55
+    param set FW_R_LIM 55
+
+    param set FW_WR_FF 0.2
+    param set FW_WR_I 0.2
+    param set FW_WR_IMAX 0.8
+    param set FW_WR_P 1
+    param set FW_W_RMAX 0
+    
+    # runway takeoff
+    # flags
+
+    # set disarmed value for the ESC
+    param set PWM_DISARMED 1000
+fi
+
+set MIXER AAERTWF
+
+# use PWM parameters for throttle channel
+set PWM_OUT 5
+set PWM_DISARMED p:PWM_DISARMED
+set PWM_MIN p:PWM_MIN
+set PWM_MAX p:PWM_MAX

--- a/Tools/check_code_style_all.sh
+++ b/Tools/check_code_style_all.sh
@@ -11,6 +11,7 @@ find \
     src/include \
     src/lib/controllib \
     src/lib/conversion \
+    src/lib/fw_takeoff \
     src/lib/geo \
     src/lib/geo_lookup \
     src/lib/launchdetection \

--- a/cmake/configs/nuttx_mindpx-v2_default.cmake
+++ b/cmake/configs/nuttx_mindpx-v2_default.cmake
@@ -129,7 +129,7 @@ set(config_module_list
 	lib/conversion
 	lib/launchdetection
 	lib/terrain_estimation
-	lib/runway_takeoff
+	lib/fw_takeoff
 	lib/tailsitter_recovery
 	lib/DriverFramework/framework
 	platforms/nuttx

--- a/cmake/configs/nuttx_px4fmu-v1_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v1_default.cmake
@@ -115,7 +115,7 @@ set(config_module_list
 	lib/conversion
 	lib/launchdetection
 	lib/terrain_estimation
-	lib/runway_takeoff
+	lib/fw_takeoff
 	lib/tailsitter_recovery
 	lib/DriverFramework/framework
 	platforms/nuttx

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -126,7 +126,7 @@ set(config_module_list
 	lib/conversion
 	lib/launchdetection
 	lib/terrain_estimation
-	lib/runway_takeoff
+	lib/fw_takeoff
 	lib/tailsitter_recovery
 	lib/DriverFramework/framework
 	platforms/nuttx

--- a/cmake/configs/nuttx_px4fmu-v2_ekf2.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_ekf2.cmake
@@ -123,7 +123,7 @@ set(config_module_list
 	lib/conversion
 	lib/launchdetection
 	lib/terrain_estimation
-	lib/runway_takeoff
+	lib/fw_takeoff
 	lib/tailsitter_recovery
 	lib/DriverFramework/framework
 	platforms/nuttx

--- a/cmake/configs/nuttx_px4fmu-v2_lpe.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_lpe.cmake
@@ -125,7 +125,7 @@ set(config_module_list
 	lib/conversion
 	lib/launchdetection
 	lib/terrain_estimation
-	lib/runway_takeoff
+	lib/fw_takeoff
 	lib/tailsitter_recovery
 	lib/DriverFramework/framework
 	platforms/nuttx

--- a/cmake/configs/nuttx_px4fmu-v2_test.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_test.cmake
@@ -137,7 +137,7 @@ set(config_module_list
 	lib/conversion
 	lib/launchdetection
 	lib/terrain_estimation
-	lib/runway_takeoff
+	lib/fw_takeoff
 	lib/tailsitter_recovery
 	lib/DriverFramework/framework
 	platforms/nuttx

--- a/cmake/configs/nuttx_px4fmu-v4_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v4_default.cmake
@@ -128,7 +128,7 @@ set(config_module_list
 	lib/conversion
 	lib/launchdetection
 	lib/terrain_estimation
-	lib/runway_takeoff
+	lib/fw_takeoff
 	lib/tailsitter_recovery
 	lib/DriverFramework/framework
 	platforms/nuttx

--- a/cmake/configs/posix_eagle_legacy_driver_default.cmake
+++ b/cmake/configs/posix_eagle_legacy_driver_default.cmake
@@ -57,7 +57,7 @@ set(config_module_list
 	lib/geo
 	lib/geo_lookup
 	lib/terrain_estimation
-	lib/runway_takeoff
+	lib/fw_takeoff
 	lib/tailsitter_recovery
 	lib/DriverFramework/framework
 

--- a/cmake/configs/posix_rpi2_default.cmake
+++ b/cmake/configs/posix_rpi2_default.cmake
@@ -44,7 +44,7 @@ set(config_module_list
 	lib/geo_lookup
 	lib/launchdetection
 	lib/terrain_estimation
-	lib/runway_takeoff
+	lib/fw_takeoff
 	lib/tailsitter_recovery
 	lib/DriverFramework/framework
 )

--- a/cmake/configs/posix_rpi2_release.cmake
+++ b/cmake/configs/posix_rpi2_release.cmake
@@ -87,7 +87,7 @@ set(config_module_list
 	lib/external_lgpl
 	lib/conversion
 	lib/terrain_estimation
-	lib/runway_takeoff
+	lib/fw_takeoff
 	lib/tailsitter_recovery
 	lib/DriverFramework/framework
 

--- a/cmake/configs/posix_sdflight_default.cmake
+++ b/cmake/configs/posix_sdflight_default.cmake
@@ -52,7 +52,7 @@ set(config_module_list
 	lib/geo
 	lib/geo_lookup
 	lib/terrain_estimation
-	lib/runway_takeoff
+	lib/fw_takeoff
 	lib/tailsitter_recovery
 	lib/DriverFramework/framework
 

--- a/cmake/configs/posix_sitl_broadcast.cmake
+++ b/cmake/configs/posix_sitl_broadcast.cmake
@@ -61,7 +61,7 @@ set(config_module_list
 	lib/geo_lookup
 	lib/launchdetection
 	lib/terrain_estimation
-	lib/runway_takeoff
+	lib/fw_takeoff
 	lib/tailsitter_recovery
 	lib/DriverFramework/framework
 	examples/px4_simple_app

--- a/cmake/configs/posix_sitl_default.cmake
+++ b/cmake/configs/posix_sitl_default.cmake
@@ -63,12 +63,12 @@ set(config_module_list
 	lib/DriverFramework/framework
 	lib/ecl
 	lib/external_lgpl
+	lib/fw_takeoff
 	lib/geo
 	lib/geo_lookup
 	lib/launchdetection
 	lib/mathlib
 	lib/mathlib/math/filter
-	lib/runway_takeoff
 	lib/tailsitter_recovery
 	lib/terrain_estimation
 

--- a/cmake/configs/posix_sitl_ekf2.cmake
+++ b/cmake/configs/posix_sitl_ekf2.cmake
@@ -61,7 +61,7 @@ set(config_module_list
 	lib/geo_lookup
 	lib/launchdetection
 	lib/terrain_estimation
-	lib/runway_takeoff
+	lib/fw_takeoff
 	lib/tailsitter_recovery
 	lib/DriverFramework/framework
 	examples/px4_simple_app

--- a/cmake/configs/posix_sitl_test.cmake
+++ b/cmake/configs/posix_sitl_test.cmake
@@ -68,7 +68,7 @@ set(config_module_list
 	lib/launchdetection
 	lib/mathlib
 	lib/mathlib/math/filter
-	lib/runway_takeoff
+	lib/fw_takeoff
 	lib/tailsitter_recovery
 	lib/terrain_estimation
 

--- a/cmake/configs/qurt_eagle_hil.cmake
+++ b/cmake/configs/qurt_eagle_hil.cmake
@@ -59,7 +59,7 @@ set(config_module_list
 	lib/geo_lookup
 	lib/conversion
 	lib/terrain_estimation
-	lib/runway_takeoff
+	lib/fw_takeoff
 	lib/tailsitter_recovery
 	lib/controllib
 	lib/DriverFramework/framework

--- a/cmake/configs/qurt_eagle_legacy_driver_default.cmake
+++ b/cmake/configs/qurt_eagle_legacy_driver_default.cmake
@@ -78,7 +78,7 @@ set(config_module_list
 	lib/geo_lookup
 	lib/conversion
 	lib/terrain_estimation
-	lib/runway_takeoff
+	lib/fw_takeoff
 	lib/tailsitter_recovery
 	lib/DriverFramework/framework
 

--- a/cmake/configs/qurt_eagle_travis.cmake
+++ b/cmake/configs/qurt_eagle_travis.cmake
@@ -68,7 +68,7 @@ set(config_module_list
 	lib/conversion
 	lib/ecl
 	lib/terrain_estimation
-	lib/runway_takeoff
+	lib/fw_takeoff
 	lib/tailsitter_recovery
 	lib/DriverFramework/framework
 

--- a/cmake/configs/qurt_sdflight_default.cmake
+++ b/cmake/configs/qurt_sdflight_default.cmake
@@ -75,7 +75,7 @@ set(config_module_list
 	lib/geo_lookup
 	lib/conversion
 	lib/terrain_estimation
-	lib/runway_takeoff
+	lib/fw_takeoff
 	lib/tailsitter_recovery
 	lib/DriverFramework/framework
 

--- a/src/lib/external_lgpl/tecs/tecs.cpp
+++ b/src/lib/external_lgpl/tecs/tecs.cpp
@@ -505,7 +505,7 @@ void TECS::_initialise_states(float pitch, float throttle_cruise, float baro_alt
 		_integ6_state = 0.0f;
 		_integ7_state = 0.0f;
 		_last_throttle_dem = throttle_cruise;
-		_last_pitch_dem = pitch;
+		_last_pitch_dem = constrain(pitch, _PITCHminf, _PITCHmaxf);
 		_hgt_dem_adj_last = baro_altitude;
 		_hgt_dem_adj = _hgt_dem_adj_last;
 		_hgt_dem_prev = _hgt_dem_adj_last;

--- a/src/lib/fw_takeoff/CMakeLists.txt
+++ b/src/lib/fw_takeoff/CMakeLists.txt
@@ -31,11 +31,11 @@
 #
 ############################################################################
 px4_add_module(
-	MODULE lib__runway_takeoff
+	MODULE lib__fw_takeoff
 	COMPILE_FLAGS
 		-Os
 	SRCS
-		RunwayTakeoff.cpp
+		FixedWingTakeoff.cpp
 	DEPENDS
 		platforms__common
 	)

--- a/src/lib/fw_takeoff/FixedWingTakeoff.cpp
+++ b/src/lib/fw_takeoff/FixedWingTakeoff.cpp
@@ -31,8 +31,8 @@
  *
  ****************************************************************************/
 /**
- * @file RunwayTakeoff.cpp
- * Runway takeoff handling for fixed-wing UAVs with steerable wheels.
+ * @file FixedWingTakeoff.cpp
+ * Fixed wing takeoff handling for UAVs including those with steerable wheels.
  *
  * @author Roman Bapst <roman@px4.io>
  * @author Andreas Antener <andreas@uaventure.com>
@@ -42,78 +42,91 @@
 #include <stdint.h>
 #include <math.h>
 
-#include "RunwayTakeoff.h"
+#include "FixedWingTakeoff.h"
 #include <controllib/blocks.hpp>
 #include <controllib/block/BlockParam.hpp>
 #include <systemlib/mavlink_log.h>
 #include <mathlib/mathlib.h>
 
-namespace runwaytakeoff
+namespace FixedWingTakeoff
 {
 
-RunwayTakeoff::RunwayTakeoff() :
-	SuperBlock(NULL, "RWTO"),
+FixedWingTakeoff::FixedWingTakeoff() :
+	SuperBlock(NULL, "FW_TO"),
 	_state(),
 	_initialized(false),
 	_initialized_time(0),
 	_init_yaw(0),
-	_climbout(false),
-	_throttle_ramp_time(2 * 1e6),
+	_throttle_ramp_time(2),
+	_min_airspeed_time(2),
 	_start_wp(),
-	_runway_takeoff_enabled(this, "TKOFF"),
+	_runway_takeoff(this, "RWTO"),
 	_heading_mode(this, "HDG"),
 	_nav_alt(this, "NAV_ALT"),
 	_takeoff_throttle(this, "MAX_THR"),
-	_runway_pitch_sp(this, "PSP"),
+	_pitch_sp(this, "PSP"),
 	_max_takeoff_pitch(this, "MAX_PITCH"),
 	_max_takeoff_roll(this, "MAX_ROLL"),
 	_min_airspeed_scaling(this, "AIRSPD_SCL"),
 	_airspeed_min(this, "FW_AIRSPD_MIN", false),
 	_climbout_diff(this, "FW_CLMBOUT_DIFF", false)
 {
-
 	updateParams();
 }
 
-RunwayTakeoff::~RunwayTakeoff()
+FixedWingTakeoff::~FixedWingTakeoff()
 {
 
 }
 
-void RunwayTakeoff::init(float yaw, double current_lat, double current_lon)
+void FixedWingTakeoff::init(float yaw, double current_lat, double current_lon, float waypoint_alt)
 {
+	updateParams();
+
 	_init_yaw = yaw;
 	_initialized = true;
-	_state = RunwayTakeoffState::THROTTLE_RAMP;
+	_state = FixedWingTakeoffState::THROTTLE_RAMP;
 	_initialized_time = hrt_absolute_time();
-	_climbout = true; // this is true until climbout is finished
+	_last_timestamp = 0;
+	_airspeed_achieved_integrator = 0;
 	_start_wp(0) = (float)current_lat;
 	_start_wp(1) = (float)current_lon;
+	_waypoint_alt = waypoint_alt;
 }
 
-void RunwayTakeoff::update(float airspeed, float alt_agl,
-			   double current_lat, double current_lon, orb_advert_t *mavlink_log_pub)
+void FixedWingTakeoff::update(float airspeed, float alt, float alt_agl,
+			      double current_lat, double current_lon, orb_advert_t *mavlink_log_pub)
 {
 
+	float dt = (float)hrt_elapsed_time(&_last_timestamp) * 1e-6f;
+	_last_timestamp = hrt_absolute_time();
+
 	switch (_state) {
-	case RunwayTakeoffState::THROTTLE_RAMP:
-		if (hrt_elapsed_time(&_initialized_time) > _throttle_ramp_time) {
-			_state = RunwayTakeoffState::CLAMPED_TO_RUNWAY;
+	case FixedWingTakeoffState::THROTTLE_RAMP:
+		if (hrt_elapsed_time(&_initialized_time) > (_throttle_ramp_time * 1000 * 1000)) {
+			_state = FixedWingTakeoffState::ACCELERATE;
 		}
 
 		break;
 
-	case RunwayTakeoffState::CLAMPED_TO_RUNWAY:
+	case FixedWingTakeoffState::ACCELERATE:
 		if (airspeed > _airspeed_min.get() * _min_airspeed_scaling.get()) {
-			_state = RunwayTakeoffState::TAKEOFF;
-			mavlink_log_info(mavlink_log_pub, "#Takeoff airspeed reached");
+			_airspeed_achieved_integrator += dt;
+
+		} else {
+			_airspeed_achieved_integrator = 0;
+		}
+
+		if (_airspeed_achieved_integrator > _min_airspeed_time) {
+			_state = FixedWingTakeoffState::TAKEOFF;
+			mavlink_log_info(mavlink_log_pub, "#Takeoff airspeed achieved");
 		}
 
 		break;
 
-	case RunwayTakeoffState::TAKEOFF:
+	case FixedWingTakeoffState::TAKEOFF:
 		if (alt_agl > _nav_alt.get()) {
-			_state = RunwayTakeoffState::CLIMBOUT;
+			_state = FixedWingTakeoffState::CLIMBOUT;
 
 			/*
 			 * If we started in heading hold mode, move the navigation start WP to the current location now.
@@ -124,16 +137,17 @@ void RunwayTakeoff::update(float airspeed, float alt_agl,
 				_start_wp(1) = (float)current_lon;
 			}
 
-			mavlink_log_info(mavlink_log_pub, "#Climbout");
+			mavlink_log_info(mavlink_log_pub, "#Takeoff safe altitude achieved, climbing");
 		}
 
 		break;
 
-	case RunwayTakeoffState::CLIMBOUT:
-		if (alt_agl > _climbout_diff.get()) {
-			_climbout = false;
-			_state = RunwayTakeoffState::FLY;
-			mavlink_log_info(mavlink_log_pub, "#Navigating to waypoint");
+	case FixedWingTakeoffState::CLIMBOUT:
+
+		// move on to navigation if climbout diff is not set or less than altitude error
+		if (!(_climbout_diff.get() > 0.001f) || (_waypoint_alt - alt < _climbout_diff.get())) {
+			_state = FixedWingTakeoffState::FLY;
+			mavlink_log_info(mavlink_log_pub, "#Climbout complete, navigating to waypoint");
 		}
 
 		break;
@@ -146,42 +160,24 @@ void RunwayTakeoff::update(float airspeed, float alt_agl,
 /*
  * Returns true as long as we're below navigation altitude
  */
-bool RunwayTakeoff::controlYaw()
+bool FixedWingTakeoff::controlYaw()
 {
-	// keep controlling yaw directly until we start navigation
-	return _state < RunwayTakeoffState::CLIMBOUT;
-}
-
-/*
- * Returns pitch setpoint to use.
- *
- * Limited (parameter) as long as the plane is on runway. Otherwise
- * use the one from TECS
- */
-float RunwayTakeoff::getPitch(float tecsPitch)
-{
-	if (_state <= RunwayTakeoffState::CLAMPED_TO_RUNWAY) {
-		return math::radians(_runway_pitch_sp.get());
-	}
-
-	return tecsPitch;
+	// keep controlling yaw directly until we start navigation if a runway takeoff
+	return runwayTakeoffEnabled() && _state < FixedWingTakeoffState::CLIMBOUT;
 }
 
 /*
  * Returns the roll setpoint to use.
  */
-float RunwayTakeoff::getRoll(float navigatorRoll)
+float FixedWingTakeoff::getRoll(float navigatorRoll)
 {
-	// until we have enough ground clearance, set roll to 0
-	if (_state < RunwayTakeoffState::CLIMBOUT) {
+	if (_state < FixedWingTakeoffState::CLIMBOUT) {
+		// until we have enough ground clearance, set roll to 0
 		return 0.0f;
-	}
 
-	// allow some roll during climbout
-	else if (_state < RunwayTakeoffState::FLY) {
-		return math::constrain(navigatorRoll,
-				       math::radians(-_max_takeoff_roll.get()),
-				       math::radians(_max_takeoff_roll.get()));
+	} else if (_state < FixedWingTakeoffState::FLY) {
+		// allow some roll during climbout
+		return math::constrain(navigatorRoll, math::radians(-_max_takeoff_roll.get()), math::radians(_max_takeoff_roll.get()));
 	}
 
 	return navigatorRoll;
@@ -193,9 +189,9 @@ float RunwayTakeoff::getRoll(float navigatorRoll)
  * In heading hold mode (_heading_mode == 0), it returns initial yaw as long as it's on the
  * runway. When it has enough ground clearance we start navigation towards WP.
  */
-float RunwayTakeoff::getYaw(float navigatorYaw)
+float FixedWingTakeoff::getYaw(float navigatorYaw)
 {
-	if (_heading_mode.get() == 0 && _state < RunwayTakeoffState::CLIMBOUT) {
+	if (_heading_mode.get() == 0 && _state < FixedWingTakeoffState::CLIMBOUT) {
 		return _init_yaw;
 
 	} else {
@@ -204,23 +200,35 @@ float RunwayTakeoff::getYaw(float navigatorYaw)
 }
 
 /*
+ * Returns the airspeed setpoint to use.
+ *
+ * FW_AIRSPEED_MIN * FW_TO_AIRSPD_SCL until flying
+ */
+float FixedWingTakeoff::getAirspeed(float missionAirspeed)
+{
+	if (_state < FixedWingTakeoffState::FLY) {
+		return _min_airspeed_scaling.get() * _airspeed_min.get();
+
+	} else {
+		return missionAirspeed;
+	}
+};
+
+/*
  * Returns the throttle setpoint to use.
  *
  * Ramps up in the beginning, until it lifts off the runway it is set to
  * parameter value, then it returns the TECS throttle.
  */
-float RunwayTakeoff::getThrottle(float tecsThrottle)
+float FixedWingTakeoff::getThrottle(float tecsThrottle)
 {
 	switch (_state) {
-	case RunwayTakeoffState::THROTTLE_RAMP: {
-			float throttle = hrt_elapsed_time(&_initialized_time) / (float)_throttle_ramp_time *
-					 _takeoff_throttle.get();
-			return throttle < _takeoff_throttle.get() ?
-			       throttle :
-			       _takeoff_throttle.get();
+	case FixedWingTakeoffState::THROTTLE_RAMP: {
+			float throttle_ramp_percent = hrt_elapsed_time(&_initialized_time) / (_throttle_ramp_time * 1000.0 * 1000.0);
+			return math::min(_takeoff_throttle.get(), throttle_ramp_percent * _takeoff_throttle.get());
 		}
 
-	case RunwayTakeoffState::CLAMPED_TO_RUNWAY:
+	case FixedWingTakeoffState::ACCELERATE:
 		return _takeoff_throttle.get();
 
 	default:
@@ -228,26 +236,33 @@ float RunwayTakeoff::getThrottle(float tecsThrottle)
 	}
 }
 
-bool RunwayTakeoff::resetIntegrators()
+bool FixedWingTakeoff::resetIntegrators()
 {
 	// reset integrators if we're still on runway
-	return _state < RunwayTakeoffState::TAKEOFF;
+	if (runwayTakeoffEnabled()) {
+		return _state < FixedWingTakeoffState::TAKEOFF;
+
+	} else {
+		return false;
+	}
 }
 
 /*
  * Returns the minimum pitch for TECS to use.
  *
  * In climbout we either want what was set on the waypoint (sp_min) but at least
- * the climbtout minimum pitch (parameter).
+ * the climbout minimum pitch (parameter).
  * Otherwise use the minimum that is enforced generally (parameter).
  */
-float RunwayTakeoff::getMinPitch(float sp_min, float climbout_min, float min)
+float FixedWingTakeoff::getMinPitch(float sp_min, float climbout_min, float min)
 {
-	if (_state < RunwayTakeoffState::FLY) {
-		return math::max(sp_min, climbout_min);
-	}
+	if (_state <= FixedWingTakeoffState::ACCELERATE) {
+		return math::radians(_pitch_sp.get());
 
-	else {
+	} else if (_state < FixedWingTakeoffState::FLY) {
+		return math::max(sp_min, climbout_min);
+
+	} else {
 		return min;
 	}
 }
@@ -257,14 +272,16 @@ float RunwayTakeoff::getMinPitch(float sp_min, float climbout_min, float min)
  *
  * Limited by parameter (if set) until climbout is done.
  */
-float RunwayTakeoff::getMaxPitch(float max)
+float FixedWingTakeoff::getMaxPitch(float max)
 {
-	// use max pitch from parameter if set (> 0.1)
-	if (_state < RunwayTakeoffState::FLY && _max_takeoff_pitch.get() > 0.1f) {
-		return _max_takeoff_pitch.get();
-	}
+	if (_state <= FixedWingTakeoffState::ACCELERATE) {
+		return math::radians(_pitch_sp.get());
 
-	else {
+	} else if (_state < FixedWingTakeoffState::FLY && _max_takeoff_pitch.get() > 0.1f) {
+		// use max pitch from parameter if set (> 0.1)
+		return _max_takeoff_pitch.get();
+
+	} else {
 		return max;
 	}
 }
@@ -272,15 +289,15 @@ float RunwayTakeoff::getMaxPitch(float max)
 /*
  * Returns the "previous" (start) WP for navigation.
  */
-math::Vector<2> RunwayTakeoff::getStartWP()
+math::Vector<2> FixedWingTakeoff::getStartWP()
 {
 	return _start_wp;
 }
 
-void RunwayTakeoff::reset()
+void FixedWingTakeoff::reset()
 {
 	_initialized = false;
-	_state = RunwayTakeoffState::THROTTLE_RAMP;
+	_state = FixedWingTakeoffState::THROTTLE_RAMP;
 }
 
 }

--- a/src/lib/fw_takeoff/fw_takeoff_params.c
+++ b/src/lib/fw_takeoff/fw_takeoff_params.c
@@ -32,9 +32,9 @@
  ****************************************************************************/
 
 /**
- * @file runway_takeoff_params.c
+ * @file fw_takeoff_params.c
  *
- * Parameters for runway takeoff
+ * Parameters for fixed wing takeoff
  *
  * @author Andreas Antener <andreas@uaventure.com>
  */
@@ -43,12 +43,12 @@
  * Runway takeoff with landing gear
  *
  * @boolean
- * @group Runway Takeoff
+ * @group FW Takeoff
  */
-PARAM_DEFINE_INT32(RWTO_TKOFF, 0);
+PARAM_DEFINE_INT32(FW_TO_RWTO, 0);
 
 /**
- * Specifies which heading should be held during runnway takeoff.
+ * Specifies which heading should be held during takeoff.
  *
  * 0: airframe heading, 1: heading towards takeoff waypoint
  *
@@ -56,14 +56,14 @@ PARAM_DEFINE_INT32(RWTO_TKOFF, 0);
  * @value 1 Waypoint
  * @min 0
  * @max 1
- * @group Runway Takeoff
+ * @group FW Takeoff
  */
-PARAM_DEFINE_INT32(RWTO_HDG, 0);
+PARAM_DEFINE_INT32(FW_TO_HDG, 0);
 
 /**
  * Altitude AGL at which we have enough ground clearance to allow some roll.
- * Until RWTO_NAV_ALT is reached the plane is held level and only
- * rudder is used to keep the heading (see RWTO_HDG). This should be below
+ * Until FW_NAV_ALT is reached the plane is held level and only
+ * rudder is used to keep the heading (see FW_HDG). This should be below
  * FW_CLMBOUT_DIFF if FW_CLMBOUT_DIFF > 0.
  *
  * @unit m
@@ -71,12 +71,12 @@ PARAM_DEFINE_INT32(RWTO_HDG, 0);
  * @max 100.0
  * @decimal 1
  * @increment 1
- * @group Runway Takeoff
+ * @group FW Takeoff
  */
-PARAM_DEFINE_FLOAT(RWTO_NAV_ALT, 5.0);
+PARAM_DEFINE_FLOAT(FW_TO_NAV_ALT, 5.0);
 
 /**
- * Max throttle during runway takeoff.
+ * Max throttle during takeoff.
  * (Can be used to test taxi on runway)
  *
  * @unit norm
@@ -84,12 +84,12 @@ PARAM_DEFINE_FLOAT(RWTO_NAV_ALT, 5.0);
  * @max 1.0
  * @decimal 2
  * @increment 0.01
- * @group Runway Takeoff
+ * @group FW Takeoff
  */
-PARAM_DEFINE_FLOAT(RWTO_MAX_THR, 1.0);
+PARAM_DEFINE_FLOAT(FW_TO_MAX_THR, 1.0);
 
 /**
- * Pitch setpoint during taxi / before takeoff airspeed is reached.
+ * Pitch setpoint during before takeoff airspeed is reached.
  * A taildragger with stearable wheel might need to pitch up
  * a little to keep it's wheel on the ground before airspeed
  * to takeoff is reached.
@@ -99,9 +99,9 @@ PARAM_DEFINE_FLOAT(RWTO_MAX_THR, 1.0);
  * @max 20.0
  * @decimal 1
  * @increment 0.5
- * @group Runway Takeoff
+ * @group FW Takeoff
  */
-PARAM_DEFINE_FLOAT(RWTO_PSP, 0.0);
+PARAM_DEFINE_FLOAT(FW_TO_PSP, 0.0);
 
 /**
  * Max pitch during takeoff.
@@ -113,9 +113,9 @@ PARAM_DEFINE_FLOAT(RWTO_PSP, 0.0);
  * @max 60.0
  * @decimal 1
  * @increment 0.5
- * @group Runway Takeoff
+ * @group FW Takeoff
  */
-PARAM_DEFINE_FLOAT(RWTO_MAX_PITCH, 20.0);
+PARAM_DEFINE_FLOAT(FW_TO_MAX_PITCH, 20.0);
 
 /**
  * Max roll during climbout.
@@ -127,9 +127,9 @@ PARAM_DEFINE_FLOAT(RWTO_MAX_PITCH, 20.0);
  * @max 60.0
  * @decimal 1
  * @increment 0.5
- * @group Runway Takeoff
+ * @group FW Takeoff
  */
-PARAM_DEFINE_FLOAT(RWTO_MAX_ROLL, 25.0);
+PARAM_DEFINE_FLOAT(FW_TO_MAX_ROLL, 15.0);
 
 /**
  * Min. airspeed scaling factor for takeoff.
@@ -141,6 +141,6 @@ PARAM_DEFINE_FLOAT(RWTO_MAX_ROLL, 25.0);
  * @max 2.0
  * @decimal 2
  * @increment 0.01
- * @group Runway Takeoff
+ * @group FW Takeoff
  */
-PARAM_DEFINE_FLOAT(RWTO_AIRSPD_SCL, 1.3);
+PARAM_DEFINE_FLOAT(FW_TO_AIRSPD_SCL, 1.3);

--- a/src/lib/launchdetection/CatapultLaunchMethod.cpp
+++ b/src/lib/launchdetection/CatapultLaunchMethod.cpp
@@ -127,16 +127,4 @@ void CatapultLaunchMethod::reset()
 	state = LAUNCHDETECTION_RES_NONE;
 }
 
-float CatapultLaunchMethod::getPitchMax(float pitchMaxDefault)
-{
-	/* If motor is turned on do not impose the extra limit on maximum pitch */
-	if (state == LAUNCHDETECTION_RES_DETECTED_ENABLEMOTORS) {
-		return pitchMaxDefault;
-
-	} else {
-		return pitchMaxPreThrottle.get();
-	}
-
-}
-
 }

--- a/src/lib/launchdetection/CatapultLaunchMethod.h
+++ b/src/lib/launchdetection/CatapultLaunchMethod.h
@@ -59,7 +59,6 @@ public:
 	void update(float accel_x);
 	LaunchDetectionResult getLaunchDetected() const;
 	void reset();
-	float getPitchMax(float pitchMaxDefault);
 
 private:
 	hrt_abstime last_timestamp;

--- a/src/lib/launchdetection/LaunchDetector.cpp
+++ b/src/lib/launchdetection/LaunchDetector.cpp
@@ -53,7 +53,6 @@ LaunchDetector::LaunchDetector() :
 	/* init all detectors */
 	launchMethods[0] = new CatapultLaunchMethod(this);
 
-
 	/* update all parameters of all detectors */
 	updateParams();
 }
@@ -106,27 +105,24 @@ LaunchDetectionResult LaunchDetector::getLaunchDetected()
 	return LAUNCHDETECTION_RES_NONE;
 }
 
-float LaunchDetector::getPitchMax(float pitchMaxDefault)
+float LaunchDetector::getThrottle(float tecsThrottle)
 {
-	if (!launchdetection_on.get()) {
-		return pitchMaxDefault;
-	}
+	float throttle = tecsThrottle;
 
-	/* if a lauchdetectionmethod is active or only one exists return the pitch limit from this method,
-	 * otherwise use the default limit */
-	if (activeLaunchDetectionMethodIndex < 0) {
-		if (sizeof(launchMethods) / sizeof(LaunchMethod *) > 1) {
-			return pitchMaxDefault;
+	if (launchdetection_on.get()) {
+		switch (getLaunchDetected()) {
+		case LAUNCHDETECTION_RES_NONE:
+		case LAUNCHDETECTION_RES_DETECTED_ENABLECONTROL:
+			throttle = throttlePreTakeoff.get();
+			break;
 
-		} else {
-			return launchMethods[0]->getPitchMax(pitchMaxDefault);
+		case LAUNCHDETECTION_RES_DETECTED_ENABLEMOTORS:
+			/* do nothing */
+			break;
 		}
-
-	} else {
-		return launchMethods[activeLaunchDetectionMethodIndex]->getPitchMax(pitchMaxDefault);
 	}
 
+	return throttle;
 }
-
 
 }

--- a/src/lib/launchdetection/LaunchDetector.h
+++ b/src/lib/launchdetection/LaunchDetector.h
@@ -62,10 +62,7 @@ public:
 	LaunchDetectionResult getLaunchDetected();
 	bool launchDetectionEnabled() { return (bool)launchdetection_on.get(); };
 
-	float getThrottlePreTakeoff() {return throttlePreTakeoff.get(); }
-
-	/* Returns a maximum pitch in deg. Different launch methods may impose upper pitch limits during launch */
-	float getPitchMax(float pitchMaxDefault);
+	float getThrottle(float tecsThrottle);
 
 //	virtual bool getLaunchDetected();
 protected:
@@ -73,7 +70,7 @@ private:
 	int activeLaunchDetectionMethodIndex; /**< holds a index to the launchMethod in the array launchMethods
 					       which detected a Launch. If no launchMethod has detected a launch yet the
 					       value is -1. Once one launchMetthod has detected a launch only this
-					       method is checked for further adavancing in the state machine (e.g. when
+					       method is checked for further advancing in the state machine (e.g. when
 					       to power up the motors) */
 
 	LaunchMethod *launchMethods[1];

--- a/src/lib/launchdetection/LaunchMethod.h
+++ b/src/lib/launchdetection/LaunchMethod.h
@@ -62,9 +62,6 @@ public:
 	virtual LaunchDetectionResult getLaunchDetected() const = 0;
 	virtual void reset() = 0;
 
-	/* Returns a upper pitch limit if required, otherwise returns pitchMaxDefault */
-	virtual float getPitchMax(float pitchMaxDefault) = 0;
-
 protected:
 private:
 };

--- a/src/lib/launchdetection/launchdetection_params.c
+++ b/src/lib/launchdetection/launchdetection_params.c
@@ -48,7 +48,7 @@
  * Launch detection
  *
  * @boolean
- * @group Launch detection
+ * @group FW Launch detection
  */
 PARAM_DEFINE_INT32(LAUN_ALL_ON, 0);
 
@@ -61,7 +61,7 @@ PARAM_DEFINE_INT32(LAUN_ALL_ON, 0);
  * @min 0
  * @decimal 1
  * @increment 0.5
- * @group Launch detection
+ * @group FW Launch detection
  */
 PARAM_DEFINE_FLOAT(LAUN_CAT_A, 30.0f);
 
@@ -75,7 +75,7 @@ PARAM_DEFINE_FLOAT(LAUN_CAT_A, 30.0f);
  * @max 5.0
  * @decimal 2
  * @increment 0.05
- * @group Launch detection
+ * @group FW Launch detection
  */
 PARAM_DEFINE_FLOAT(LAUN_CAT_T, 0.05f);
 
@@ -90,7 +90,7 @@ PARAM_DEFINE_FLOAT(LAUN_CAT_T, 0.05f);
  * @max 10.0
  * @decimal 1
  * @increment 0.5
- * @group Launch detection
+ * @group FW Launch detection
  */
 PARAM_DEFINE_FLOAT(LAUN_CAT_MDEL, 0.0f);
 
@@ -105,6 +105,6 @@ PARAM_DEFINE_FLOAT(LAUN_CAT_MDEL, 0.0f);
  * @max 45.0
  * @decimal 1
  * @increment 0.5
- * @group Launch detection
+ * @group FW Launch detection
  */
 PARAM_DEFINE_FLOAT(LAUN_CAT_PMAX, 30.0f);

--- a/src/modules/fw_att_control/fw_att_control_main.cpp
+++ b/src/modules/fw_att_control/fw_att_control_main.cpp
@@ -1180,9 +1180,8 @@ FixedwingAttitudeControl::task_main()
 
 					if (_att_sp.fw_control_yaw == true) {
 						yaw_u = _wheel_ctrl.control_bodyrate(control_input);
-					}
 
-					else {
+					} else {
 						yaw_u = _yaw_ctrl.control_bodyrate(control_input);
 					}
 

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -145,6 +145,7 @@ protected:
 	control::BlockParamFloat _param_yaw_err;
 	control::BlockParamInt _param_vtol_wv_land;
 	control::BlockParamInt _param_vtol_wv_loiter;
+	control::BlockParamFloat _param_climbout_diff;
 };
 
 #endif


### PR DESCRIPTION
This PR refactors RunwayTakeoff to be used for all FW auto takeoff, which then simplifies the handling within the FW position controller.

This is based on the observation that hand launching larger aircraft require roughly the same phases as runway takeoff.

**ACCELERATE** (formerly CLAMPED_TO_RUNWAY for RunwayTakeoff)
 - no roll or pitch until min airspeed * scaling is reached
 - fixed heading

**TAKEOFF**
 - no roll, small pitch until we have enough ground clearance
 - fixed heading

**CLIMBOUT**
 - roll constrained to MAX_ROLL while navigating to takeoff point

**FLY**
 - proceed to takeoff waypoint normally

All runway specific functionality should be encapsulated within the FixedwingTakeoff class, with the defaults being appropriate for hand launch.

There should be no change to runway takeoff other than renamed params. Existing auto takeoff for small aircraft should be roughly the same as they quickly hit min airspeed after a throw. They'll now have heading hold (while under climbout diff), but that can be disabled. Hand launching larger heavier aircraft that require time to accelerate before climbout should be much more reliable with this change.

TODO
 - [x] match existing launch detection throttle behaviour
 - [x] test runway takeoff
 - [x] test hand launch
 - [ ] test hand launch with launchdetection
 - [ ] @AndreasAntener getYaw() takeoff in current heading direction idea
 - [x] modify navigator takeoff waypoint acceptance (see #3922)
 - [x] update airspeed setpoint to calculate_target_airspeed(mission_airspeed) after climbout

-closes issue #3812