### PR TITLE
check_submodules: Don't override submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ endif
 # describe how to build a cmake config
 define cmake-build
 +@if [ $(PX4_CMAKE_GENERATOR) = "Ninja" ] && [ -e $(PWD)/build_$@/Makefile ]; then rm -rf $(PWD)/build_$@; fi
-+@if [ ! -e $(PWD)/build_$@/CMakeCache.txt ]; then git submodule sync && git submodule update --init --recursive && mkdir -p $(PWD)/build_$@ && cd $(PWD)/build_$@ && cmake .. -G$(PX4_CMAKE_GENERATOR) -DCONFIG=$(1); fi
++@if [ ! -e $(PWD)/build_$@/CMakeCache.txt ]; then mkdir -p $(PWD)/build_$@ && cd $(PWD)/build_$@ && cmake .. -G$(PX4_CMAKE_GENERATOR) -DCONFIG=$(1); fi
 +Tools/check_submodules.sh
 +$(PX4_MAKE) -C $(PWD)/build_$@ $(PX4_MAKE_ARGS) $(ARGS)
 endef
@@ -169,7 +169,7 @@ qurt_eagle_default:
 
 posix_eagle_default:
 	$(call cmake-build,$@)
-	
+
 posix_rpi2_default:
 	$(call cmake-build,$@)
 

--- a/Tools/check_submodules.sh
+++ b/Tools/check_submodules.sh
@@ -6,18 +6,13 @@
     exit 0
 }
 
-if [ -f src/modules/uavcan/libuavcan/CMakeLists.txt ]
-then
-	echo "Git submodule config valid."
-else
-	git submodule update --init --recursive
-fi
 
 GITSTATUS=$(git status)
 
 function check_git_submodule {
 
-if [ -d $1 ];
+# The .git exists in a submodule if init and update have been done.
+if [ -f $1"/.git" ];
 	then
 	SUBMODULE_STATUS=$(git submodule summary "$1")
 	STATUSRETVAL=$(echo $SUBMODULE_STATUS | grep -A20 -i "$1")
@@ -58,7 +53,7 @@ if [ -d $1 ];
 		fi
 	fi
 else
-	git submodule update --init --recursive;
+	git submodule update --init --recursive $1;
 fi
 
 }


### PR DESCRIPTION
Previously make would override a submodule, now it only does submodule
init and override if the submodule is not already checked out.

This fixes #3733 for me.