### PR TITLE
FW ALTCTL/POSCTL remove 0 throttle threshold

### DIFF
--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
@@ -1804,7 +1804,7 @@ FixedwingPositionControl::control_position(const math::Vector<2> &current_positi
 		/* throttle limiting */
 		throttle_max = _parameters.throttle_max;
 
-		if (fabsf(_manual.z) < THROTTLE_THRESH) {
+		if (_vehicle_status.condition_landed && (fabsf(_manual.z) < THROTTLE_THRESH)) {
 			throttle_max = 0.0f;
 		}
 
@@ -1919,7 +1919,7 @@ FixedwingPositionControl::control_position(const math::Vector<2> &current_positi
 		/* throttle limiting */
 		throttle_max = _parameters.throttle_max;
 
-		if (fabsf(_manual.z) < THROTTLE_THRESH) {
+		if (_vehicle_status.condition_landed && (fabsf(_manual.z) < THROTTLE_THRESH)) {
 			throttle_max = 0.0f;
 		}
 


### PR DESCRIPTION
This PR removes the the check in FW ALTCTL/POSCTL that limits throttle to 0 if the throttle stick is below 0.05.

I debated removing this feature as it arguably improves safety on the ground, however in flight it was extremely confusing when I pulled the throttle back expecting min airspeed, but instead completely lost throttle and began to dive.

I think there's no need for this as a safety feature now that we have the RC kill switch.