### PR TITLE
GPS hdop

### DIFF
--- a/msg/vehicle_gps_position.msg
+++ b/msg/vehicle_gps_position.msg
@@ -10,8 +10,11 @@ float32 s_variance_m_s		# GPS speed accuracy estimate, (metres/sec)
 float32 c_variance_rad		# GPS course accuracy estimate, (radians) 
 uint8 fix_type # 0-1: no fix, 2: 2D fix, 3: 3D fix, 4: RTCM code differential, 5: Real-Time Kinematic, float, 6: Real-Time Kinematic, fixed, 8: Extrapolated. Some applications will not use the value of this field unless it is at least two, so always correctly fill in the fix.   
 
-float32 eph			# GPS horizontal position accuracy (metres) 
-float32 epv			# GPS vertical position accuracy (metres) 
+float32 eph			# GPS horizontal position accuracy (metres)
+float32 epv			# GPS vertical position accuracy (metres)
+
+float32 hdop			# Horizontal dilution of precision
+float32 vdop			# Vertical dilution of precision
 
 int32 noise_per_ms		# GPS noise per millisecond
 int32 jamming_indicator		# indicates jamming is occurring

--- a/src/drivers/gps/ashtech.cpp
+++ b/src/drivers/gps/ashtech.cpp
@@ -270,7 +270,7 @@ int ASHTECH::handle_message(int len)
 		int num_of_sv __attribute__((unused)) = 0, fix_quality = 0;
 		double track_true = 0.0, ground_speed = 0.0 , age_of_corr __attribute__((unused)) = 0.0;
 		double hdop = 99.9, vdop = 99.9,  pdop __attribute__((unused)) = 99.9,
-		tdop __attribute__((unused)) = 99.9, vertic_vel = 0.0;
+		       tdop __attribute__((unused)) = 99.9, vertic_vel = 0.0;
 		char ns = '?', ew = '?';
 
 		if (bufptr && *(++bufptr) != ',') { fix_quality = strtol(bufptr, &endp, 10); bufptr = endp; }

--- a/src/drivers/gps/ashtech.cpp
+++ b/src/drivers/gps/ashtech.cpp
@@ -269,7 +269,7 @@ int ASHTECH::handle_message(int len)
 		double ashtech_time __attribute__((unused)) = 0.0, lat = 0.0, lon = 0.0, alt = 0.0;
 		int num_of_sv __attribute__((unused)) = 0, fix_quality = 0;
 		double track_true = 0.0, ground_speed = 0.0 , age_of_corr __attribute__((unused)) = 0.0;
-		double hdop __attribute__((unused)) = 99.9, vdop __attribute__((unused)) = 99.9,  pdop __attribute__((unused)) = 99.9,
+		double hdop = 99.9, vdop = 99.9,  pdop __attribute__((unused)) = 99.9,
 		tdop __attribute__((unused)) = 99.9, vertic_vel = 0.0;
 		char ns = '?', ew = '?';
 
@@ -338,6 +338,8 @@ int ASHTECH::handle_message(int len)
 		_gps_position->lat = static_cast<int>((int(lat * 0.01) + (lat * 0.01 - int(lat * 0.01)) * 100.0 / 60.0) * 10000000);
 		_gps_position->lon = static_cast<int>((int(lon * 0.01) + (lon * 0.01 - int(lon * 0.01)) * 100.0 / 60.0) * 10000000);
 		_gps_position->alt = static_cast<int>(alt * 1000);
+		_gps_position->hdop = (float)hdop / 100.0f;
+		_gps_position->vdop = (float)vdop / 100.0f;
 		_rate_count_lat_lon++;
 
 		if (coordinatesFound < 3) {

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -553,6 +553,7 @@ GPS::print_info()
 		warnx("lat: %d, lon: %d, alt: %d", _report_gps_pos.lat, _report_gps_pos.lon, _report_gps_pos.alt);
 		warnx("vel: %.2fm/s, %.2fm/s, %.2fm/s", (double)_report_gps_pos.vel_n_m_s,
 		      (double)_report_gps_pos.vel_e_m_s, (double)_report_gps_pos.vel_d_m_s);
+		warnx("hdop: %.2f, vdop: %.2f", (double)_report_gps_pos.hdop, (double)_report_gps_pos.vdop);
 		warnx("eph: %.2fm, epv: %.2fm", (double)_report_gps_pos.eph, (double)_report_gps_pos.epv);
 		warnx("rate position: \t%6.2f Hz", (double)_Helper->get_position_update_rate());
 		warnx("rate velocity: \t%6.2f Hz", (double)_Helper->get_velocity_update_rate());

--- a/src/drivers/gps/mtk.cpp
+++ b/src/drivers/gps/mtk.cpp
@@ -261,6 +261,8 @@ MTK::handle_message(gps_mtk_packet_t &packet)
 	_gps_position->fix_type = packet.fix_type;
 	_gps_position->eph = packet.hdop / 100.0f; // from cm to m
 	_gps_position->epv = _gps_position->eph; // unknown in mtk custom mode, so we cheat with eph
+	_gps_position->hdop = packet.hdop / 100.0f;
+	_gps_position->vdop = _gps_position->hdop;
 	_gps_position->vel_m_s = ((float)packet.ground_speed) / 100.0f; // from cm/s to m/s
 	_gps_position->cog_rad = ((float)packet.heading) * M_DEG_TO_RAD_F * 1e-2f; //from deg *100 to rad
 	_gps_position->satellites_used = packet.satellites;

--- a/src/drivers/gps/ubx.cpp
+++ b/src/drivers/gps/ubx.cpp
@@ -808,6 +808,9 @@ UBX::payload_rx_done(void)
 		_gps_position->epv		= (float)_buf.payload_rx_nav_pvt.vAcc * 1e-3f;
 		_gps_position->s_variance_m_s	= (float)_buf.payload_rx_nav_pvt.sAcc * 1e-3f;
 
+		_gps_position->hdop		= (float)_buf.payload_rx_nav_pvt.pDOP * 0.01f;
+		_gps_position->vdop		= _gps_position->hdop;
+
 		_gps_position->vel_m_s		= (float)_buf.payload_rx_nav_pvt.gSpeed * 1e-3f;
 
 		_gps_position->vel_n_m_s	= (float)_buf.payload_rx_nav_pvt.velN * 1e-3f;
@@ -890,6 +893,9 @@ UBX::payload_rx_done(void)
 		_gps_position->fix_type		= _buf.payload_rx_nav_sol.gpsFix;
 		_gps_position->s_variance_m_s	= (float)_buf.payload_rx_nav_sol.sAcc * 1e-2f;	// from cm to m
 		_gps_position->satellites_used	= _buf.payload_rx_nav_sol.numSV;
+
+		_gps_position->hdop		= (float)_buf.payload_rx_nav_sol.pDOP * 0.01f;
+		_gps_position->vdop		= _gps_position->hdop;
 
 		_gps_position->timestamp_variance = hrt_absolute_time();
 

--- a/src/drivers/gps/ubx.h
+++ b/src/drivers/gps/ubx.h
@@ -62,6 +62,7 @@
 
 /* Message IDs */
 #define UBX_ID_NAV_POSLLH	0x02
+#define UBX_ID_NAV_DOP		0x04
 #define UBX_ID_NAV_SOL		0x06
 #define UBX_ID_NAV_PVT		0x07
 #define UBX_ID_NAV_VELNED	0x12
@@ -80,6 +81,7 @@
 /* Message Classes & IDs */
 #define UBX_MSG_NAV_POSLLH	((UBX_CLASS_NAV) | UBX_ID_NAV_POSLLH << 8)
 #define UBX_MSG_NAV_SOL		((UBX_CLASS_NAV) | UBX_ID_NAV_SOL << 8)
+#define UBX_MSG_NAV_DOP		((UBX_CLASS_NAV) | UBX_ID_NAV_DOP << 8)
 #define UBX_MSG_NAV_PVT		((UBX_CLASS_NAV) | UBX_ID_NAV_PVT << 8)
 #define UBX_MSG_NAV_VELNED	((UBX_CLASS_NAV) | UBX_ID_NAV_VELNED << 8)
 #define UBX_MSG_NAV_TIMEUTC	((UBX_CLASS_NAV) | UBX_ID_NAV_TIMEUTC << 8)
@@ -169,6 +171,18 @@ typedef struct {
 	uint32_t	vAcc;  		/**< Vertical accuracy estimate [mm] */
 } ubx_payload_rx_nav_posllh_t;
 
+/* Rx NAV-DOP */
+typedef struct {
+	uint32_t	iTOW;		/**< GPS Time of Week [ms] */
+	uint16_t	gDOP;		/**< Geometric DOP [0.01] */
+	uint16_t	pDOP;		/**< Position DOP [0.01] */
+	uint16_t	tDOP;		/**< Time DOP [0.01] */
+	uint16_t	vDOP;		/**< Vertical DOP [0.01] */
+	uint16_t	hDOP;		/**< Horizontal DOP [0.01] */
+	uint16_t	nDOP;		/**< Northing DOP [0.01] */
+	uint16_t	eDOP;		/**< Easting DOP [0.01] */
+} ubx_payload_rx_nav_dop_t;
+
 /* Rx NAV-SOL */
 typedef struct {
 	uint32_t	iTOW;		/**< GPS Time of Week [ms] */
@@ -184,7 +198,7 @@ typedef struct {
 	int32_t		ecefVY;
 	int32_t		ecefVZ;
 	uint32_t	sAcc;
-	uint16_t	pDOP;
+	uint16_t	pDOP;		/**< Position DOP [0.01] */
 	uint8_t		reserved1;
 	uint8_t		numSV;		/**< Number of SVs used in Nav Solution */
 	uint32_t	reserved2;
@@ -416,6 +430,7 @@ typedef union {
 	ubx_payload_rx_nav_pvt_t		payload_rx_nav_pvt;
 	ubx_payload_rx_nav_posllh_t		payload_rx_nav_posllh;
 	ubx_payload_rx_nav_sol_t		payload_rx_nav_sol;
+	ubx_payload_rx_nav_dop_t		payload_rx_nav_dop;
 	ubx_payload_rx_nav_timeutc_t		payload_rx_nav_timeutc;
 	ubx_payload_rx_nav_svinfo_part1_t	payload_rx_nav_svinfo_part1;
 	ubx_payload_rx_nav_svinfo_part2_t	payload_rx_nav_svinfo_part2;

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -1000,8 +1000,8 @@ protected:
 			msg.lat = gps.lat;
 			msg.lon = gps.lon;
 			msg.alt = gps.alt;
-			msg.eph = cm_uint16_from_m_float(gps.eph);
-			msg.epv = cm_uint16_from_m_float(gps.epv);
+			msg.eph = gps.hdop * 100; //cm_uint16_from_m_float(gps.eph);
+			msg.epv = gps.vdop * 100; //cm_uint16_from_m_float(gps.epv);
 			msg.vel = cm_uint16_from_m_float(gps.vel_m_s),
 			msg.cog = _wrap_2pi(gps.cog_rad) * M_RAD_TO_DEG_F * 1e2f,
 			msg.satellites_visible = gps.satellites_used;


### PR DESCRIPTION
@gervaisK @DonLakeFlyer we used the position accuracy in meters so far (which seems more intuitive since you can judge wether you think its accurate enough or not). However, the MAVLink spec (that I wrote myself) calls for hdop / vdop, and this PR changes to use them.

I'm not sure this is an "improvement", but I think consistency is more important in that case. PX4 will continue to use the position accuracy in meters internally to determine when its safe to set home and lock.