### PR TITLE
navigator only accept waypoint if !landed

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -128,7 +128,9 @@ MissionBlock::is_mission_item_reached()
 
 	hrt_abstime now = hrt_absolute_time();
 
-	if (!_waypoint_position_reached) {
+	if ((_navigator->get_vstatus()->condition_landed == false)
+		&& !_waypoint_position_reached) {
+
 		float dist = -1.0f;
 		float dist_xy = -1.0f;
 		float dist_z = -1.0f;


### PR DESCRIPTION
This also includes a minor fw_pos_control_l1 cleanup where the const arg pos_sp_triplet and _pos_sp_triplet were being used interchangeably.

Possible fix for #3902