### PR TITLE
Fix sensor_reset method for PX4FMU_V4

### DIFF
--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -2169,6 +2169,10 @@ PX4FMU::sensor_reset(int ms)
 	stm32_gpiowrite(GPIO_SPI_CS_OFF_MS5611, 1);
 	stm32_gpiowrite(GPIO_SPI_CS_OFF_ICM_20608_G, 1);
 
+	stm32_configgpio(GPIO_SPI1_SCK);
+	stm32_configgpio(GPIO_SPI1_MISO);
+	stm32_configgpio(GPIO_SPI1_MOSI);
+
 	// // XXX bring up the EXTI pins again
 	// stm32_configgpio(GPIO_GYRO_DRDY);
 	// stm32_configgpio(GPIO_MAG_DRDY);


### PR DESCRIPTION
Hello,

As you can see SPI line are restored after sensor reset for PX4FMU_V2:
https://github.com/PX4/Firmware/blob/master/src/drivers/px4fmu/fmu.cpp#L2095-L2097

But restore of SPI  lines still missing for PX4FMU_V4:
https://github.com/PX4/Firmware/blob/master/src/drivers/px4fmu/fmu.cpp#L2171

So I fixed it. Would you be so kind to merge this PR?

WBR