### PR TITLE
Versioned param/airframe meta data

### DIFF
--- a/Tools/px4airframes/xmlout.py
+++ b/Tools/px4airframes/xmlout.py
@@ -22,6 +22,10 @@ class XMLOutput():
         xml_parameters = ET.Element("airframes")
         xml_version = ET.SubElement(xml_parameters, "version")
         xml_version.text = "1"
+        xml_version = ET.SubElement(xml_parameters, "airframe_version_major")
+        xml_version.text = "1"
+        xml_version = ET.SubElement(xml_parameters, "airframe_version_minor")
+        xml_version.text = "1"
         last_param_name = ""
         board_specific_param_set = False
         for group in groups:

--- a/Tools/px4params/xmlout.py
+++ b/Tools/px4params/xmlout.py
@@ -22,6 +22,10 @@ class XMLOutput():
         xml_parameters = ET.Element("parameters")
         xml_version = ET.SubElement(xml_parameters, "version")
         xml_version.text = "3"
+        xml_version = ET.SubElement(xml_parameters, "parameter_version_major")
+        xml_version.text = "1"
+        xml_version = ET.SubElement(xml_parameters, "parameter_version_minor")
+        xml_version.text = "2"
         importtree = ET.parse(inject_xml_file_name)
         injectgroups = importtree.getroot().findall("group")
         for igroup in injectgroups:

--- a/Tools/px_mkfw.py
+++ b/Tools/px_mkfw.py
@@ -108,6 +108,7 @@ if args.parameter_xml != None:
 	bytes = f.read()
 	desc['parameter_xml_size'] = len(bytes)
 	desc['parameter_xml'] = base64.b64encode(zlib.compress(bytes,9)).decode('utf-8')
+        desc['mav_autopilot'] = 12 # 12 = MAV_AUTOPILOT_PX4
 if args.airframe_xml != None:
 	f = open(args.airframe_xml, "rb")
 	bytes = f.read()


### PR DESCRIPTION
Both param and airframe meta data needs to be versioned so that ground stations can correctly cache meta data and know which versions are newer/older than other versions of meta data. The important thing here is:
* parameter_major_version must match the current parameter set version: SYS_PARAM_VER
* parameter_minor_version must be bumped when you want to cause this meta data to override an older version of meta data which may be compiled into a ground station