### PR TITLE
LidarLitePWM: suppress invalid PWM measurements at driver level

### DIFF
--- a/src/drivers/ll40ls/LidarLitePWM.cpp
+++ b/src/drivers/ll40ls/LidarLitePWM.cpp
@@ -184,6 +184,7 @@ int LidarLitePWM::measure()
 	 * Require a minimum number of pulses with less than max interval before accepting data.
 	 */
 	_range.current_distance = 0.0f;
+
 	if (_pwm.period > LIDAR_LITE_MAX_PWM_PERIOD) {
 		_valid_count = 0;
 		warnx("break in sequence: reported range %u, period: %u", _pwm.pulse_width, _pwm.period);
@@ -191,6 +192,7 @@ int LidarLitePWM::measure()
 	} else {
 		if (_valid_count < 5) {
 			_valid_count++;
+
 		} else {
 			_range.current_distance = float(_pwm.pulse_width) * 1e-3f;   /* .001 m/usec for LIDAR-Lite */
 		}

--- a/src/drivers/ll40ls/LidarLitePWM.cpp
+++ b/src/drivers/ll40ls/LidarLitePWM.cpp
@@ -63,6 +63,7 @@ LidarLitePWM::LidarLitePWM(const char *path) :
 	_pwm{},
 	_distance_sensor_topic(nullptr),
 	_range{},
+	_valid_count(0),
 	_sample_perf(perf_alloc(PC_ELAPSED, "ll40ls_pwm_read")),
 	_read_errors(perf_alloc(PC_COUNT, "ll40ls_pwm_read_errors")),
 	_buffer_overflows(perf_alloc(PC_COUNT, "ll40ls_pwm_buffer_overflows")),
@@ -179,22 +180,30 @@ int LidarLitePWM::measure()
 		return ERROR;
 	}
 
+	/* for distances near zero and > 40m, no PWM pulse is generated:
+	 * Require a minimum number of pulses with less than max interval before accepting data.
+	 */
+	_range.current_distance = 0.0f;
+	if (_pwm.period > LIDAR_LITE_MAX_PWM_PERIOD) {
+		_valid_count = 0;
+		warnx("break in sequence: reported range %u, period: %u", _pwm.pulse_width, _pwm.period);
+
+	} else {
+		if (_valid_count < 5) {
+			_valid_count++;
+		} else {
+			_range.current_distance = float(_pwm.pulse_width) * 1e-3f;   /* .001 m/usec for LIDAR-Lite */
+		}
+	}
+
 	_range.timestamp = hrt_absolute_time();
 	_range.type = distance_sensor_s::MAV_DISTANCE_SENSOR_LASER;
 	_range.max_distance = get_maximum_distance();
 	_range.min_distance = get_minimum_distance();
-	_range.current_distance = float(_pwm.pulse_width) * 1e-3f;   /* 10 usec = 1 cm distance for LIDAR-Lite */
 	_range.covariance = 0.0f;
 	_range.orientation = 8;
 	/* TODO: set proper ID */
 	_range.id = 0;
-
-	/* Due to a bug in older versions of the LidarLite firmware, we have to reset sensor on (distance == 0) */
-	if (_range.current_distance <= 0.0f) {
-		perf_count(_sensor_zero_resets);
-		perf_end(_sample_perf);
-		return reset_sensor();
-	}
 
 	if (_distance_sensor_topic != nullptr) {
 		orb_publish(ORB_ID(distance_sensor), _distance_sensor_topic, &_range);

--- a/src/drivers/ll40ls/LidarLitePWM.cpp
+++ b/src/drivers/ll40ls/LidarLitePWM.cpp
@@ -180,7 +180,7 @@ int LidarLitePWM::measure()
 		return ERROR;
 	}
 
-	/* for distances near zero and > 40m, no PWM pulse is generated:
+	/* for distances near zero and exceeding max range no PWM pulse is generated:
 	 * Require a minimum number of pulses with less than max interval before accepting data.
 	 */
 	_range.current_distance = 0.0f;
@@ -190,7 +190,7 @@ int LidarLitePWM::measure()
 		warnx("break in sequence: reported range %u, period: %u", _pwm.pulse_width, _pwm.period);
 
 	} else {
-		if (_valid_count < 5) {
+		if (_valid_count < MIN_STREAM_LEN) {
 			_valid_count++;
 
 		} else {

--- a/src/drivers/ll40ls/LidarLitePWM.h
+++ b/src/drivers/ll40ls/LidarLitePWM.h
@@ -107,6 +107,8 @@ protected:
 private:
 	/* expect maximum PWM period of max distance * 1000 usec + 5000 usec */
 	static const int	LIDAR_LITE_MAX_PWM_PERIOD = (int)(LL40LS_MAX_DISTANCE * 1000 + 5000);
+	/* minimum number of continuous PWM pulses to accept measurement */
+	static const int	MIN_STREAM_LEN = 5;
 	work_s			_work;
 	ringbuffer::RingBuffer	*_reports;
 	int			_class_instance;

--- a/src/drivers/ll40ls/LidarLitePWM.h
+++ b/src/drivers/ll40ls/LidarLitePWM.h
@@ -105,6 +105,8 @@ protected:
 	void task_main_trampoline(int argc, char *argv[]);
 
 private:
+	/* expect maximum PWM period of max distance * 1000 usec + 5000 usec */
+	static const int	LIDAR_LITE_MAX_PWM_PERIOD = (int)(LL40LS_MAX_DISTANCE * 1000 + 5000);
 	work_s			_work;
 	ringbuffer::RingBuffer	*_reports;
 	int			_class_instance;
@@ -113,6 +115,8 @@ private:
 	struct pwm_input_s	_pwm;
 	orb_advert_t	        _distance_sensor_topic;
 	struct distance_sensor_s _range;
+	/* number of pulses received at intervals < LIDAR_LITE_MAX_PWM_PERIOD */
+	int			_valid_count;
 
 	perf_counter_t	        _sample_perf;
 	perf_counter_t	        _read_errors;


### PR DESCRIPTION
require multiple measurements at a minimum PWM frequency to ensure validity of range measurement

This puts data validation at the driver level where it belongs, instead of in the estimators.

Tested on V1 at ranges from 0 to 3 meters. Typical latency is about 200msec.

@mhkabir If you're interested, this needs flight testing to determine whether any glitches remain.
