### PR TITLE
Initialize abort_transition bool

### DIFF
--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -87,7 +87,9 @@ VtolAttitudeControl::VtolAttitudeControl() :
 	_actuators_1_pub(nullptr),
 	_vtol_vehicle_status_pub(nullptr),
 	_v_rates_sp_pub(nullptr),
-	_v_att_sp_pub(nullptr)
+	_v_att_sp_pub(nullptr),
+
+	_abort_front_transition(false)
 
 {
 	memset(& _vtol_vehicle_status, 0, sizeof(_vtol_vehicle_status));


### PR DESCRIPTION
Fixes https://github.com/PX4/Firmware/issues/3794
Transition was in a constant abort loop when to_fw switch was on at boot