### PR TITLE
fixing all "argc < 1"

### DIFF
--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -842,7 +842,7 @@ void AttitudeEstimatorQ::update_mag_declination(float new_declination)
 
 int attitude_estimator_q_main(int argc, char *argv[])
 {
-	if (argc < 1) {
+	if (argc < 2) {
 		warnx("usage: attitude_estimator_q {start|stop|status}");
 		return 1;
 	}

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -646,7 +646,7 @@ int Ekf2::start()
 
 int ekf2_main(int argc, char *argv[])
 {
-	if (argc < 1) {
+	if (argc < 2) {
 		PX4_WARN("usage: ekf2 {start|stop|status}");
 		return 1;
 	}

--- a/src/modules/local_position_estimator/local_position_estimator_main.cpp
+++ b/src/modules/local_position_estimator/local_position_estimator_main.cpp
@@ -95,7 +95,7 @@ usage(const char *reason)
 int local_position_estimator_main(int argc, char *argv[])
 {
 
-	if (argc < 1) {
+	if (argc < 2) {
 		usage("missing command");
 	}
 


### PR DESCRIPTION
to avoid segmentation fault when calling the module with no parameters
argc is never smaller than one because the first element of the array is the program name!