### PR TITLE
Make all params used on Snapdragon

### DIFF
--- a/src/modules/systemlib/param/param_shmem.c
+++ b/src/modules/systemlib/param/param_shmem.c
@@ -677,6 +677,9 @@ param_set_no_notification(param_t param, const void *val)
 bool
 param_used(param_t param)
 {
+	// TODO FIXME: for now all params are used
+	return true;
+
 	int param_index = param_get_index(param);
 
 	if (param_index < 0) {


### PR DESCRIPTION
This is a workaround for the fact that the used information is not
shared between the ADSP and the Linux side on the Snapdragon. By
flagging all params used, we can at least receive them on QGC.