### PR TITLE
mavlink_log refactor

### DIFF
--- a/msg/mavlink_log.msg
+++ b/msg/mavlink_log.msg
@@ -1,0 +1,4 @@
+uint64 timestamp		# Timestamp in microseconds since boot
+
+uint8[51] text
+uint8 severity

--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -51,6 +51,8 @@
 #include <systemlib/systemlib.h>
 #include <systemlib/err.h>
 #include <systemlib/param/param.h>
+#include <systemlib/mavlink_log.h>
+
 #include <uORB/uORB.h>
 #include <uORB/topics/camera_trigger.h>
 #include <uORB/topics/sensor_combined.h>
@@ -59,7 +61,6 @@
 #include <poll.h>
 #include <drivers/drv_gpio.h>
 #include <drivers/drv_hrt.h>
-#include <mavlink/mavlink_log.h>
 #include <board_config.h>
 
 #define TRIGGER_PIN_DEFAULT 1

--- a/src/drivers/md25/md25.cpp
+++ b/src/drivers/md25/md25.cpp
@@ -50,7 +50,7 @@
 
 #include <systemlib/err.h>
 #include <arch/board/board.h>
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 
 #include <uORB/Publication.hpp>
 #include <uORB/topics/debug_key_value.h>
@@ -78,9 +78,6 @@ enum {
 	REG_MODE_RW,
 	REG_COMMAND_RW,
 };
-
-// File descriptors
-static int mavlink_fd;
 
 MD25::MD25(const char *deviceName, int bus,
 	   uint16_t address, uint32_t speed) :

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -2515,18 +2515,18 @@ void
 PX4FMU::dsm_bind_ioctl(int dsmMode)
 {
 	if (!_armed.armed) {
-//      mavlink_log_info(_mavlink_fd, "[FMU] binding DSM%s RX", (dsmMode == 0) ? "2" : ((dsmMode == 1) ? "-X" : "-X8"));
+//      mavlink_log_info("[FMU] binding DSM%s RX", (dsmMode == 0) ? "2" : ((dsmMode == 1) ? "-X" : "-X8"));
 		warnx("[FMU] binding DSM%s RX", (dsmMode == 0) ? "2" : ((dsmMode == 1) ? "-X" : "-X8"));
 		int ret = ioctl(nullptr, DSM_BIND_START,
 				(dsmMode == 0) ? DSM2_BIND_PULSES : ((dsmMode == 1) ? DSMX_BIND_PULSES : DSMX8_BIND_PULSES));
 
 		if (ret) {
-//            mavlink_log_critical(_mavlink_fd, "binding failed.");
+//            mavlink_log_critical("binding failed.");
 			warnx("binding failed.");
 		}
 
 	} else {
-//        mavlink_log_info(_mavlink_fd, "[FMU] system armed, bind request rejected");
+//        mavlink_log_info("[FMU] system armed, bind request rejected");
 		warnx("[FMU] system armed, bind request rejected");
 	}
 }

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -73,6 +73,7 @@
 #include <systemlib/scheduling_priorities.h>
 #include <systemlib/param/param.h>
 #include <systemlib/circuit_breaker.h>
+#include <systemlib/mavlink_log.h>
 
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/actuator_controls_0.h>
@@ -92,7 +93,6 @@
 
 #include <debug.h>
 
-#include <mavlink/mavlink_log.h>
 #include <modules/px4iofirmware/protocol.h>
 
 #include "uploader.h"
@@ -263,8 +263,6 @@ private:
 
 	volatile int		_task;			///< worker task id
 	volatile bool		_task_should_exit;	///< worker terminate flag
-
-	int			_mavlink_fd;		///< mavlink file descriptor.
 
 	perf_counter_t		_perf_update;		///< local performance counter for status updates
 	perf_counter_t		_perf_write;		///< local performance counter for PWM control writes
@@ -505,7 +503,6 @@ PX4IO::PX4IO(device::Device *interface) :
 	_rc_last_valid(0),
 	_task(-1),
 	_task_should_exit(false),
-	_mavlink_fd(-1),
 	_perf_update(perf_alloc(PC_ELAPSED, "io update")),
 	_perf_write(perf_alloc(PC_ELAPSED, "io write")),
 	_perf_sample_latency(perf_alloc(PC_ELAPSED, "io latency")),
@@ -604,7 +601,7 @@ PX4IO::detect()
 
 			} else {
 				DEVICE_LOG("IO version error");
-				mavlink_log_emergency(_mavlink_fd, "IO VERSION MISMATCH, PLEASE UPGRADE SOFTWARE!");
+				mavlink_log_emergency("IO VERSION MISMATCH, PLEASE UPGRADE SOFTWARE!");
 			}
 
 			return -1;
@@ -662,12 +659,12 @@ PX4IO::init()
 
 	/* if the error still persists after timing out, we give up */
 	if (protocol == _io_reg_get_error) {
-		mavlink_and_console_log_emergency(_mavlink_fd, "Failed to communicate with IO, abort.");
+		mavlink_and_console_log_emergency("Failed to communicate with IO, abort.");
 		return -1;
 	}
 
 	if (protocol != PX4IO_PROTOCOL_VERSION) {
-		mavlink_and_console_log_emergency(_mavlink_fd, "IO protocol/firmware mismatch, abort.");
+		mavlink_and_console_log_emergency("IO protocol/firmware mismatch, abort.");
 		return -1;
 	}
 
@@ -684,7 +681,7 @@ PX4IO::init()
 	    (_max_rc_input < 1)  || (_max_rc_input > 255)) {
 
 		DEVICE_LOG("config read error");
-		mavlink_log_emergency(_mavlink_fd, "[IO] config read fail, abort.");
+		mavlink_log_emergency("[IO] config read fail, abort.");
 		return -1;
 	}
 
@@ -722,7 +719,7 @@ PX4IO::init()
 		/* get a status update from IO */
 		io_get_status();
 
-		mavlink_and_console_log_emergency(_mavlink_fd, "RECOVERING FROM FMU IN-AIR RESTART");
+		mavlink_and_console_log_emergency("RECOVERING FROM FMU IN-AIR RESTART");
 
 		/* WARNING: COMMANDER app/vehicle status must be initialized.
 		 * If this fails (or the app is not started), worst-case IO
@@ -751,7 +748,7 @@ PX4IO::init()
 
 			/* abort after 5s */
 			if ((hrt_absolute_time() - try_start_time) / 1000 > 3000) {
-				mavlink_and_console_log_emergency(_mavlink_fd, "Failed to recover from in-air restart (1), abort");
+				mavlink_and_console_log_emergency("Failed to recover from in-air restart (1), abort");
 				return 1;
 			}
 
@@ -807,7 +804,7 @@ PX4IO::init()
 
 			/* abort after 5s */
 			if ((hrt_absolute_time() - try_start_time) / 1000 > 2000) {
-				mavlink_and_console_log_emergency(_mavlink_fd, "Failed to recover from in-air restart (2), abort");
+				mavlink_and_console_log_emergency("Failed to recover from in-air restart (2), abort");
 				return 1;
 			}
 
@@ -854,7 +851,7 @@ PX4IO::init()
 			ret = io_set_rc_config();
 
 			if (ret != OK) {
-				mavlink_and_console_log_critical(_mavlink_fd, "IO RC config upload fail");
+				mavlink_and_console_log_critical("IO RC config upload fail");
 				return ret;
 			}
 		}
@@ -910,8 +907,6 @@ PX4IO::task_main()
 {
 	hrt_abstime poll_last = 0;
 	hrt_abstime orb_check_last = 0;
-
-	_mavlink_fd = ::open(MAVLINK_LOG_DEVICE, 0);
 
 	/*
 	 * Subscribe to the appropriate PWM output topic based on whether we are the
@@ -1027,11 +1022,6 @@ PX4IO::task_main()
 			/* run at 5Hz */
 			orb_check_last = now;
 
-			/* try to claim the MAVLink log FD */
-			if (_mavlink_fd < 0) {
-				_mavlink_fd = ::open(MAVLINK_LOG_DEVICE, 0);
-			}
-
 			/* check updates on uORB topics and handle it */
 			bool updated = false;
 
@@ -1087,7 +1077,7 @@ PX4IO::task_main()
 				int pret = io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_VBATT_SCALE, &scaling, 1);
 
 				if (pret != OK) {
-					mavlink_and_console_log_critical(_mavlink_fd, "IO vscale upload failed");
+					mavlink_and_console_log_critical("IO vscale upload failed");
 				}
 
 				/* send RC throttle failsafe value to IO */
@@ -1104,7 +1094,7 @@ PX4IO::task_main()
 						pret = io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_RC_THR_FAILSAFE_US, &failsafe_thr, 1);
 
 						if (pret != OK) {
-							mavlink_and_console_log_critical(_mavlink_fd, "failsafe upload failed, FS: %d us", (int)failsafe_thr);
+							mavlink_and_console_log_critical("failsafe upload failed, FS: %d us", (int)failsafe_thr);
 						}
 					}
 				}
@@ -1546,7 +1536,7 @@ PX4IO::io_set_rc_config()
 
 		/* check the IO initialisation flag */
 		if (!(io_reg_get(PX4IO_PAGE_STATUS, PX4IO_P_STATUS_FLAGS) & PX4IO_P_STATUS_FLAGS_INIT_OK)) {
-			mavlink_and_console_log_critical(_mavlink_fd, "config for RC%d rejected by IO", i + 1);
+			mavlink_and_console_log_critical("config for RC%d rejected by IO", i + 1);
 			break;
 		}
 
@@ -1619,16 +1609,16 @@ void
 PX4IO::dsm_bind_ioctl(int dsmMode)
 {
 	if (!(_status & PX4IO_P_STATUS_FLAGS_SAFETY_OFF)) {
-		mavlink_log_info(_mavlink_fd, "[IO] binding DSM%s RX", (dsmMode == 0) ? "2" : ((dsmMode == 1) ? "-X" : "-X8"));
+		mavlink_log_info("[IO] binding DSM%s RX", (dsmMode == 0) ? "2" : ((dsmMode == 1) ? "-X" : "-X8"));
 		int ret = ioctl(nullptr, DSM_BIND_START,
 				(dsmMode == 0) ? DSM2_BIND_PULSES : ((dsmMode == 1) ? DSMX_BIND_PULSES : DSMX8_BIND_PULSES));
 
 		if (ret) {
-			mavlink_log_critical(_mavlink_fd, "binding failed.");
+			mavlink_log_critical("binding failed.");
 		}
 
 	} else {
-		mavlink_log_info(_mavlink_fd, "[IO] system armed, bind request rejected");
+		mavlink_log_info("[IO] system armed, bind request rejected");
 	}
 }
 
@@ -2148,7 +2138,7 @@ PX4IO::mixer_send(const char *buf, unsigned buflen, unsigned retries)
 	} while (retries > 0);
 
 	if (retries == 0) {
-		mavlink_and_console_log_info(_mavlink_fd, "[IO] mixer upload fail");
+		mavlink_and_console_log_info("[IO] mixer upload fail");
 		/* load must have failed for some reason */
 		return -EINVAL;
 

--- a/src/drivers/roboclaw/RoboClaw.cpp
+++ b/src/drivers/roboclaw/RoboClaw.cpp
@@ -50,8 +50,8 @@
 #include <termios.h>
 
 #include <systemlib/err.h>
+#include <systemlib/mavlink_log.h>
 #include <arch/board/board.h>
-#include <mavlink/mavlink_log.h>
 
 #include <uORB/Publication.hpp>
 #include <uORB/topics/actuator_controls_0.h>

--- a/src/lib/runway_takeoff/RunwayTakeoff.cpp
+++ b/src/lib/runway_takeoff/RunwayTakeoff.cpp
@@ -45,7 +45,7 @@
 #include "RunwayTakeoff.h"
 #include <controllib/blocks.hpp>
 #include <controllib/block/BlockParam.hpp>
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <mathlib/mathlib.h>
 
 namespace runwaytakeoff
@@ -92,7 +92,7 @@ void RunwayTakeoff::init(float yaw, double current_lat, double current_lon)
 }
 
 void RunwayTakeoff::update(float airspeed, float alt_agl,
-			   double current_lat, double current_lon, int mavlink_fd)
+			   double current_lat, double current_lon)
 {
 
 	switch (_state) {
@@ -106,7 +106,7 @@ void RunwayTakeoff::update(float airspeed, float alt_agl,
 	case RunwayTakeoffState::CLAMPED_TO_RUNWAY:
 		if (airspeed > _airspeed_min.get() * _min_airspeed_scaling.get()) {
 			_state = RunwayTakeoffState::TAKEOFF;
-			mavlink_log_info(mavlink_fd, "#Takeoff airspeed reached");
+			mavlink_log_info("#Takeoff airspeed reached");
 		}
 
 		break;
@@ -124,7 +124,7 @@ void RunwayTakeoff::update(float airspeed, float alt_agl,
 				_start_wp(1) = (float)current_lon;
 			}
 
-			mavlink_log_info(mavlink_fd, "#Climbout");
+			mavlink_log_info("#Climbout");
 		}
 
 		break;
@@ -133,7 +133,7 @@ void RunwayTakeoff::update(float airspeed, float alt_agl,
 		if (alt_agl > _climbout_diff.get()) {
 			_climbout = false;
 			_state = RunwayTakeoffState::FLY;
-			mavlink_log_info(mavlink_fd, "#Navigating to waypoint");
+			mavlink_log_info("#Navigating to waypoint");
 		}
 
 		break;

--- a/src/lib/runway_takeoff/RunwayTakeoff.h
+++ b/src/lib/runway_takeoff/RunwayTakeoff.h
@@ -48,7 +48,7 @@
 #include <drivers/drv_hrt.h>
 #include <controllib/blocks.hpp>
 #include <controllib/block/BlockParam.hpp>
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <mathlib/mathlib.h>
 
 namespace runwaytakeoff
@@ -69,7 +69,7 @@ public:
 	~RunwayTakeoff();
 
 	void init(float yaw, double current_lat, double current_lon);
-	void update(float airspeed, float alt_agl, double current_lat, double current_lon, int mavlink_fd);
+	void update(float airspeed, float alt_agl, double current_lat, double current_lon);
 
 	RunwayTakeoffState getState() { return _state; };
 	bool isInitialized() { return _initialized; };

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -68,12 +68,12 @@
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
 #include <lib/geo/geo.h>
 #include <lib/ecl/validation/data_validator_group.h>
-#include <mavlink/mavlink_log.h>
 
 #include <systemlib/systemlib.h>
 #include <systemlib/param/param.h>
 #include <systemlib/perf_counter.h>
 #include <systemlib/err.h>
+#include <systemlib/mavlink_log.h>
 
 extern "C" __EXPORT int attitude_estimator_q_main(int argc, char *argv[]);
 
@@ -191,8 +191,6 @@ private:
 	bool		_failsafe = false;
 	bool		_vibration_warning = false;
 	bool		_ext_hdg_good = false;
-
-	int		_mavlink_fd = -1;
 
 	perf_counter_t _update_perf;
 	perf_counter_t _loop_perf;
@@ -326,15 +324,6 @@ void AttitudeEstimatorQ::task_main()
 	while (!_task_should_exit) {
 		int ret = px4_poll(fds, 1, 1000);
 
-#ifndef __PX4_QURT
-
-		if (_mavlink_fd < 0) {
-			/* TODO: This call currently stalls the thread on QURT */
-			_mavlink_fd = open(MAVLINK_LOG_DEVICE, 0);
-		}
-
-#endif
-
 		if (ret < 0) {
 			// Poll error, sleep and try again
 			usleep(10000);
@@ -422,7 +411,7 @@ void AttitudeEstimatorQ::task_main()
 				if (_voter_gyro.failover_count() > 0) {
 					_failsafe = true;
 					flags = _voter_gyro.failover_state();
-					mavlink_and_console_log_emergency(_mavlink_fd, "Gyro #%i failure :%s%s%s%s%s!",
+					mavlink_and_console_log_emergency("Gyro #%i failure :%s%s%s%s%s!",
 									  _voter_gyro.failover_index(),
 									  ((flags & DataValidator::ERROR_FLAG_NO_DATA) ? " No data" : ""),
 									  ((flags & DataValidator::ERROR_FLAG_STALE_DATA) ? " Stale data" : ""),
@@ -434,7 +423,7 @@ void AttitudeEstimatorQ::task_main()
 				if (_voter_accel.failover_count() > 0) {
 					_failsafe = true;
 					flags = _voter_accel.failover_state();
-					mavlink_and_console_log_emergency(_mavlink_fd, "Accel #%i failure :%s%s%s%s%s!",
+					mavlink_and_console_log_emergency("Accel #%i failure :%s%s%s%s%s!",
 									  _voter_accel.failover_index(),
 									  ((flags & DataValidator::ERROR_FLAG_NO_DATA) ? " No data" : ""),
 									  ((flags & DataValidator::ERROR_FLAG_STALE_DATA) ? " Stale data" : ""),
@@ -446,7 +435,7 @@ void AttitudeEstimatorQ::task_main()
 				if (_voter_mag.failover_count() > 0) {
 					_failsafe = true;
 					flags = _voter_mag.failover_state();
-					mavlink_and_console_log_emergency(_mavlink_fd, "Mag #%i failure :%s%s%s%s%s!",
+					mavlink_and_console_log_emergency("Mag #%i failure :%s%s%s%s%s!",
 									  _voter_mag.failover_index(),
 									  ((flags & DataValidator::ERROR_FLAG_NO_DATA) ? " No data" : ""),
 									  ((flags & DataValidator::ERROR_FLAG_STALE_DATA) ? " Stale data" : ""),
@@ -456,7 +445,7 @@ void AttitudeEstimatorQ::task_main()
 				}
 
 				if (_failsafe) {
-					mavlink_and_console_log_emergency(_mavlink_fd, "SENSOR FAILSAFE! RETURN TO LAND IMMEDIATELY");
+					mavlink_and_console_log_emergency("SENSOR FAILSAFE! RETURN TO LAND IMMEDIATELY");
 				}
 			}
 
@@ -469,7 +458,7 @@ void AttitudeEstimatorQ::task_main()
 
 				} else if (hrt_elapsed_time(&_vibration_warning_timestamp) > 10000000) {
 					_vibration_warning = true;
-					mavlink_and_console_log_critical(_mavlink_fd, "HIGH VIBRATION! g: %d a: %d m: %d",
+					mavlink_and_console_log_critical("HIGH VIBRATION! g: %d a: %d m: %d",
 									 (int)(100 * _voter_gyro.get_vibration_factor(curr_time)),
 									 (int)(100 * _voter_accel.get_vibration_factor(curr_time)),
 									 (int)(100 * _voter_mag.get_vibration_factor(curr_time)));

--- a/src/modules/bottle_drop/bottle_drop.cpp
+++ b/src/modules/bottle_drop/bottle_drop.cpp
@@ -67,10 +67,10 @@
 #include <systemlib/systemlib.h>
 #include <systemlib/param/param.h>
 #include <systemlib/err.h>
+#include <systemlib/mavlink_log.h>
 #include <geo/geo.h>
 #include <dataman/dataman.h>
 #include <mathlib/mathlib.h>
-#include <mavlink/mavlink_log.h>
 
 
 /**
@@ -113,7 +113,6 @@ public:
 private:
 	bool		_task_should_exit;		/**< if true, task should exit */
 	int		_main_task;			/**< handle for task */
-	int		_mavlink_fd;
 
 	int		_command_sub;
 	int		_wind_estimate_sub;
@@ -174,7 +173,6 @@ BottleDrop::BottleDrop() :
 
 	_task_should_exit(false),
 	_main_task(-1),
-	_mavlink_fd(-1),
 	_command_sub(-1),
 	_wind_estimate_sub(-1),
 	_command {},
@@ -341,8 +339,7 @@ void
 BottleDrop::task_main()
 {
 
-	_mavlink_fd = px4_open(MAVLINK_LOG_DEVICE, 0);
-	mavlink_log_info(_mavlink_fd, "[bottle_drop] started");
+	mavlink_log_info("[bottle_drop] started");
 
 	_command_sub = orb_subscribe(ORB_ID(vehicle_command));
 	_wind_estimate_sub = orb_subscribe(ORB_ID(wind_estimate));
@@ -533,7 +530,7 @@ BottleDrop::task_main()
 				approach_error = _wrap_pi(ground_direction - approach_direction);
 
 				if (counter % 90 == 0) {
-					mavlink_log_info(_mavlink_fd, "drop distance %u, heading error %u", (unsigned)distance_real,
+					mavlink_log_info("drop distance %u, heading error %u", (unsigned)distance_real,
 							 (unsigned)math::degrees(approach_error));
 				}
 			}
@@ -638,7 +635,7 @@ BottleDrop::task_main()
 
 					float approach_direction = get_bearing_to_next_waypoint(flight_vector_s.lat, flight_vector_s.lon, flight_vector_e.lat,
 								   flight_vector_e.lon);
-					mavlink_log_critical(_mavlink_fd, "position set, approach heading: %u", (unsigned)distance_real,
+					mavlink_log_critical("position set, approach heading: %u", (unsigned)distance_real,
 							     (unsigned)math::degrees(approach_direction + M_PI_F));
 
 					_drop_state = DROP_STATE_TARGET_SET;
@@ -662,7 +659,7 @@ BottleDrop::task_main()
 						    fabsf(approach_error) < math::radians(20.0f)) {
 							open_bay();
 							_drop_state = DROP_STATE_BAY_OPEN;
-							mavlink_log_info(_mavlink_fd, "#audio: opening bay");
+							mavlink_log_info("#audio: opening bay");
 						}
 					}
 				}
@@ -680,7 +677,7 @@ BottleDrop::task_main()
 						    (distance_real < precision) && ((distance_real < future_distance))) {
 							drop();
 							_drop_state = DROP_STATE_DROPPED;
-							mavlink_log_info(_mavlink_fd, "#audio: payload dropped");
+							mavlink_log_info("#audio: payload dropped");
 
 						} else {
 
@@ -704,7 +701,7 @@ BottleDrop::task_main()
 					_drop_approval = false;
 					lock_release();
 					close_bay();
-					mavlink_log_info(_mavlink_fd, "#audio: closing bay");
+					mavlink_log_info("#audio: closing bay");
 
 					// remove onboard mission
 					_onboard_mission.current_seq = -1;
@@ -751,16 +748,16 @@ BottleDrop::handle_command(struct vehicle_command_s *cmd)
 		if (cmd->param1 > 0.5f && cmd->param2 > 0.5f) {
 			open_bay();
 			drop();
-			mavlink_log_critical(_mavlink_fd, "drop bottle");
+			mavlink_log_critical("drop bottle");
 
 		} else if (cmd->param1 > 0.5f) {
 			open_bay();
-			mavlink_log_critical(_mavlink_fd, "opening bay");
+			mavlink_log_critical("opening bay");
 
 		} else {
 			lock_release();
 			close_bay();
-			mavlink_log_critical(_mavlink_fd, "closing bay");
+			mavlink_log_critical("closing bay");
 		}
 
 		answer_command(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED);
@@ -771,12 +768,12 @@ BottleDrop::handle_command(struct vehicle_command_s *cmd)
 		switch ((int)(cmd->param1 + 0.5f)) {
 		case 0:
 			_drop_approval = false;
-			mavlink_log_critical(_mavlink_fd, "got drop position, no approval");
+			mavlink_log_critical("got drop position, no approval");
 			break;
 
 		case 1:
 			_drop_approval = true;
-			mavlink_log_critical(_mavlink_fd, "got drop position and approval");
+			mavlink_log_critical("got drop position and approval");
 			break;
 
 		default:
@@ -791,7 +788,7 @@ BottleDrop::handle_command(struct vehicle_command_s *cmd)
 		_target_position.lon = cmd->param6;
 		_target_position.alt = cmd->param7;
 		_drop_state = DROP_STATE_TARGET_VALID;
-		mavlink_log_info(_mavlink_fd, "got target: %8.4f, %8.4f, %8.4f", (double)_target_position.lat,
+		mavlink_log_info("got target: %8.4f, %8.4f, %8.4f", (double)_target_position.lat,
 				 (double)_target_position.lon, (double)_target_position.alt);
 		map_projection_init(&ref, _target_position.lat, _target_position.lon);
 		answer_command(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED);
@@ -820,7 +817,7 @@ BottleDrop::handle_command(struct vehicle_command_s *cmd)
 
 			case 1:
 				_drop_approval = true;
-				mavlink_log_info(_mavlink_fd, "#audio: got drop approval");
+				mavlink_log_info("#audio: got drop approval");
 				break;
 
 			default:
@@ -846,19 +843,19 @@ BottleDrop::answer_command(struct vehicle_command_s *cmd, unsigned result)
 		break;
 
 	case vehicle_command_s::VEHICLE_CMD_RESULT_DENIED:
-		mavlink_log_critical(_mavlink_fd, "command denied: %u", cmd->command);
+		mavlink_log_critical("command denied: %u", cmd->command);
 		break;
 
 	case vehicle_command_s::VEHICLE_CMD_RESULT_FAILED:
-		mavlink_log_critical(_mavlink_fd, "command failed: %u", cmd->command);
+		mavlink_log_critical("command failed: %u", cmd->command);
 		break;
 
 	case vehicle_command_s::VEHICLE_CMD_RESULT_TEMPORARILY_REJECTED:
-		mavlink_log_critical(_mavlink_fd, "command temporarily rejected: %u", cmd->command);
+		mavlink_log_critical("command temporarily rejected: %u", cmd->command);
 		break;
 
 	case vehicle_command_s::VEHICLE_CMD_RESULT_UNSUPPORTED:
-		mavlink_log_critical(_mavlink_fd, "command unsupported: %u", cmd->command);
+		mavlink_log_critical("command unsupported: %u", cmd->command);
 		break;
 
 	default:

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -54,6 +54,7 @@
 #include <systemlib/err.h>
 #include <systemlib/param/param.h>
 #include <systemlib/rc_check.h>
+#include <systemlib/mavlink_log.h>
 
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_mag.h>
@@ -65,7 +66,6 @@
 #include <uORB/topics/airspeed.h>
 #include <uORB/topics/vehicle_gps_position.h>
 
-#include <mavlink/mavlink_log.h>
 
 #include "PreflightCheck.h"
 
@@ -84,7 +84,7 @@ static int check_calibration(DevHandle &h, const char* param_template, int &devi
 	int ret = h.ioctl(SENSORIOCCALTEST, 0);
 
 	calibration_found = (ret == OK);
-	
+
 	devid = h.ioctl(DEVIOCGDEVICEID, 0);
 
 	char s[20];
@@ -116,7 +116,7 @@ static int check_calibration(DevHandle &h, const char* param_template, int &devi
 	return !calibration_found;
 }
 
-static bool magnometerCheck(int mavlink_fd, unsigned instance, bool optional, int &device_id, bool report_fail)
+static bool magnometerCheck(unsigned instance, bool optional, int &device_id, bool report_fail)
 {
 	bool success = true;
 
@@ -128,8 +128,7 @@ static bool magnometerCheck(int mavlink_fd, unsigned instance, bool optional, in
 	if (!h.isValid()) {
 		if (!optional) {
 			if (report_fail) {
-				mavlink_and_console_log_critical(mavlink_fd,
-							 "PREFLIGHT FAIL: NO MAG SENSOR #%u", instance);
+				mavlink_and_console_log_critical("PREFLIGHT FAIL: NO MAG SENSOR #%u", instance);
 			}
 		}
 
@@ -140,8 +139,7 @@ static bool magnometerCheck(int mavlink_fd, unsigned instance, bool optional, in
 
 	if (ret) {
 		if (report_fail) {
-			mavlink_and_console_log_critical(mavlink_fd,
-						 "PREFLIGHT FAIL: MAG #%u UNCALIBRATED", instance);
+			mavlink_and_console_log_critical("PREFLIGHT FAIL: MAG #%u UNCALIBRATED", instance);
 		}
 		success = false;
 		goto out;
@@ -151,8 +149,7 @@ static bool magnometerCheck(int mavlink_fd, unsigned instance, bool optional, in
 
 	if (ret != OK) {
 		if (report_fail) {
-			mavlink_and_console_log_critical(mavlink_fd,
-						 "PREFLIGHT FAIL: MAG #%u SELFTEST FAILED", instance);
+			mavlink_and_console_log_critical("PREFLIGHT FAIL: MAG #%u SELFTEST FAILED", instance);
 		}
 		success = false;
 		goto out;
@@ -163,7 +160,7 @@ out:
 	return success;
 }
 
-static bool accelerometerCheck(int mavlink_fd, unsigned instance, bool optional, bool dynamic, int &device_id, bool report_fail)
+static bool accelerometerCheck(unsigned instance, bool optional, bool dynamic, int &device_id, bool report_fail)
 {
 	bool success = true;
 
@@ -175,8 +172,7 @@ static bool accelerometerCheck(int mavlink_fd, unsigned instance, bool optional,
 	if (!h.isValid()) {
 		if (!optional) {
 			if (report_fail) {
-				mavlink_and_console_log_critical(mavlink_fd,
-							 "PREFLIGHT FAIL: NO ACCEL SENSOR #%u", instance);
+				mavlink_and_console_log_critical("PREFLIGHT FAIL: NO ACCEL SENSOR #%u", instance);
 			}
 		}
 
@@ -187,8 +183,7 @@ static bool accelerometerCheck(int mavlink_fd, unsigned instance, bool optional,
 
 	if (ret) {
 		if (report_fail) {
-			mavlink_and_console_log_critical(mavlink_fd,
-						 "PREFLIGHT FAIL: ACCEL #%u UNCALIBRATED", instance);
+			mavlink_and_console_log_critical("PREFLIGHT FAIL: ACCEL #%u UNCALIBRATED", instance);
 		}
 		success = false;
 		goto out;
@@ -198,8 +193,7 @@ static bool accelerometerCheck(int mavlink_fd, unsigned instance, bool optional,
 
 	if (ret != OK) {
 		if (report_fail) {
-			mavlink_and_console_log_critical(mavlink_fd,
-						 "PREFLIGHT FAIL: ACCEL #%u TEST FAILED: %d", instance, ret);
+			mavlink_and_console_log_critical("PREFLIGHT FAIL: ACCEL #%u TEST FAILED: %d", instance, ret);
 		}
 		success = false;
 		goto out;
@@ -217,7 +211,7 @@ static bool accelerometerCheck(int mavlink_fd, unsigned instance, bool optional,
 
 			if (accel_magnitude < 4.0f || accel_magnitude > 15.0f /* m/s^2 */) {
 				if (report_fail) {
-					mavlink_and_console_log_critical(mavlink_fd, "PREFLIGHT FAIL: ACCEL RANGE, hold still on arming");
+					mavlink_and_console_log_critical("PREFLIGHT FAIL: ACCEL RANGE, hold still on arming");
 				}
 				/* this is frickin' fatal */
 				success = false;
@@ -225,7 +219,7 @@ static bool accelerometerCheck(int mavlink_fd, unsigned instance, bool optional,
 			}
 		} else {
 			if (report_fail) {
-				mavlink_and_console_log_critical(mavlink_fd, "PREFLIGHT FAIL: ACCEL READ");
+				mavlink_and_console_log_critical("PREFLIGHT FAIL: ACCEL READ");
 			}
 			/* this is frickin' fatal */
 			success = false;
@@ -239,7 +233,7 @@ out:
 	return success;
 }
 
-static bool gyroCheck(int mavlink_fd, unsigned instance, bool optional, int &device_id, bool report_fail)
+static bool gyroCheck(unsigned instance, bool optional, int &device_id, bool report_fail)
 {
 	bool success = true;
 
@@ -251,8 +245,7 @@ static bool gyroCheck(int mavlink_fd, unsigned instance, bool optional, int &dev
 	if (!h.isValid()) {
 		if (!optional) {
 			if (report_fail) {
-				mavlink_and_console_log_critical(mavlink_fd,
-							 "PREFLIGHT FAIL: NO GYRO SENSOR #%u", instance);
+				mavlink_and_console_log_critical("PREFLIGHT FAIL: NO GYRO SENSOR #%u", instance);
 			}
 		}
 
@@ -263,8 +256,7 @@ static bool gyroCheck(int mavlink_fd, unsigned instance, bool optional, int &dev
 
 	if (ret) {
 		if (report_fail) {
-			mavlink_and_console_log_critical(mavlink_fd,
-						 "PREFLIGHT FAIL: GYRO #%u UNCALIBRATED", instance);
+			mavlink_and_console_log_critical("PREFLIGHT FAIL: GYRO #%u UNCALIBRATED", instance);
 		}
 		success = false;
 		goto out;
@@ -274,8 +266,7 @@ static bool gyroCheck(int mavlink_fd, unsigned instance, bool optional, int &dev
 
 	if (ret != OK) {
 		if (report_fail) {
-			mavlink_and_console_log_critical(mavlink_fd,
-						 "PREFLIGHT FAIL: GYRO #%u SELFTEST FAILED", instance);
+			mavlink_and_console_log_critical("PREFLIGHT FAIL: GYRO #%u SELFTEST FAILED", instance);
 		}
 		success = false;
 		goto out;
@@ -286,7 +277,7 @@ out:
 	return success;
 }
 
-static bool baroCheck(int mavlink_fd, unsigned instance, bool optional, int &device_id, bool report_fail)
+static bool baroCheck(unsigned instance, bool optional, int &device_id, bool report_fail)
 {
 	bool success = true;
 
@@ -298,8 +289,7 @@ static bool baroCheck(int mavlink_fd, unsigned instance, bool optional, int &dev
 	if (!h.isValid()) {
 		if (!optional) {
 			if (report_fail) {
-				mavlink_and_console_log_critical(mavlink_fd,
-							 "PREFLIGHT FAIL: NO BARO SENSOR #%u", instance);
+				mavlink_and_console_log_critical("PREFLIGHT FAIL: NO BARO SENSOR #%u", instance);
 			}
 		}
 
@@ -312,8 +302,7 @@ static bool baroCheck(int mavlink_fd, unsigned instance, bool optional, int &dev
 	// int ret = check_calibration(fd, "CAL_BARO%u_ID");
 
 	// if (ret) {
-	// 	mavlink_and_console_log_critical(mavlink_fd,
-	// 					 "PREFLIGHT FAIL: BARO #%u UNCALIBRATED", instance);
+	// 	mavlink_and_console_log_critical("PREFLIGHT FAIL: BARO #%u UNCALIBRATED", instance);
 	// 	success = false;
 	// 	goto out;
 	// }
@@ -324,7 +313,7 @@ static bool baroCheck(int mavlink_fd, unsigned instance, bool optional, int &dev
 	return success;
 }
 
-static bool airspeedCheck(int mavlink_fd, bool optional, bool report_fail)
+static bool airspeedCheck(bool optional, bool report_fail)
 {
 	bool success = true;
 	int ret;
@@ -335,7 +324,7 @@ static bool airspeedCheck(int mavlink_fd, bool optional, bool report_fail)
 	if ((ret = orb_copy(ORB_ID(airspeed), fd, &airspeed)) ||
 	    (hrt_elapsed_time(&airspeed.timestamp) > (500 * 1000))) {
 		if (report_fail) {
-			mavlink_and_console_log_critical(mavlink_fd, "PREFLIGHT FAIL: AIRSPEED SENSOR MISSING");
+			mavlink_and_console_log_critical("PREFLIGHT FAIL: AIRSPEED SENSOR MISSING");
 		}
 		success = false;
 		goto out;
@@ -343,7 +332,7 @@ static bool airspeedCheck(int mavlink_fd, bool optional, bool report_fail)
 
 	if (fabsf(airspeed.confidence) < 0.99f) {
 		if (report_fail) {
-			mavlink_and_console_log_critical(mavlink_fd, "PREFLIGHT FAIL: AIRSPEED SENSOR COMM ERROR");
+			mavlink_and_console_log_critical("PREFLIGHT FAIL: AIRSPEED SENSOR COMM ERROR");
 		}
 		success = false;
 		goto out;
@@ -351,7 +340,7 @@ static bool airspeedCheck(int mavlink_fd, bool optional, bool report_fail)
 
 	if (fabsf(airspeed.indicated_airspeed_m_s) > 6.0f) {
 		if (report_fail) {
-			mavlink_and_console_log_critical(mavlink_fd, "AIRSPEED WARNING: WIND OR CALIBRATION ISSUE");
+			mavlink_and_console_log_critical("AIRSPEED WARNING: WIND OR CALIBRATION ISSUE");
 		}
 		// XXX do not make this fatal yet
 	}
@@ -361,7 +350,7 @@ out:
 	return success;
 }
 
-static bool gnssCheck(int mavlink_fd, bool report_fail)
+static bool gnssCheck(bool report_fail)
 {
 	bool success = true;
 
@@ -385,7 +374,7 @@ static bool gnssCheck(int mavlink_fd, bool report_fail)
 	//Report failure to detect module
 	if (!success) {
 		if (report_fail) {
-			mavlink_and_console_log_critical(mavlink_fd, "PREFLIGHT FAIL: GPS RECEIVER MISSING");
+			mavlink_and_console_log_critical("PREFLIGHT FAIL: GPS RECEIVER MISSING");
 		}
 	}
 
@@ -393,7 +382,7 @@ static bool gnssCheck(int mavlink_fd, bool report_fail)
 	return success;
 }
 
-bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro,
+bool preflightCheck(bool checkMag, bool checkAcc, bool checkGyro,
 		    bool checkBaro, bool checkAirspeed, bool checkRC, bool checkGNSS, bool checkDynamic, bool reportFailures)
 {
 	bool failed = false;
@@ -409,7 +398,7 @@ bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro
 			bool required = (i < max_mandatory_mag_count);
 			int device_id = -1;
 
-			if (!magnometerCheck(mavlink_fd, i, !required, device_id, reportFailures) && required) {
+			if (!magnometerCheck(i, !required, device_id, reportFailures) && required) {
 				failed = true;
 			}
 
@@ -421,7 +410,7 @@ bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro
 		/* check if the primary device is present */
 		if (!prime_found && prime_id != 0) {
 			if (reportFailures) {
-				mavlink_and_console_log_critical(mavlink_fd, "Warning: Primary compass not found");
+				mavlink_and_console_log_critical("Warning: Primary compass not found");
 			}
 			failed = true;
 		}
@@ -438,7 +427,7 @@ bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro
 			bool required = (i < max_mandatory_accel_count);
 			int device_id = -1;
 
-			if (!accelerometerCheck(mavlink_fd, i, !required, checkDynamic, device_id, reportFailures) && required) {
+			if (!accelerometerCheck(i, !required, checkDynamic, device_id, reportFailures) && required) {
 				failed = true;
 			}
 
@@ -450,7 +439,7 @@ bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro
 		/* check if the primary device is present */
 		if (!prime_found && prime_id != 0) {
 			if (reportFailures) {
-				mavlink_and_console_log_critical(mavlink_fd, "Warning: Primary accelerometer not found");
+				mavlink_and_console_log_critical("Warning: Primary accelerometer not found");
 			}
 			failed = true;
 		}
@@ -467,7 +456,7 @@ bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro
 			bool required = (i < max_mandatory_gyro_count);
 			int device_id = -1;
 
-			if (!gyroCheck(mavlink_fd, i, !required, device_id, reportFailures) && required) {
+			if (!gyroCheck(i, !required, device_id, reportFailures) && required) {
 				failed = true;
 			}
 
@@ -479,7 +468,7 @@ bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro
 		/* check if the primary device is present */
 		if (!prime_found && prime_id != 0) {
 			if (reportFailures) {
-				mavlink_and_console_log_critical(mavlink_fd, "Warning: Primary gyro not found");
+				mavlink_and_console_log_critical("Warning: Primary gyro not found");
 			}
 			failed = true;
 		}
@@ -496,7 +485,7 @@ bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro
 			bool required = (i < max_mandatory_baro_count);
 			int device_id = -1;
 
-			if (!baroCheck(mavlink_fd, i, !required, device_id, reportFailures) && required) {
+			if (!baroCheck(i, !required, device_id, reportFailures) && required) {
 				failed = true;
 			}
 
@@ -506,10 +495,10 @@ bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro
 		}
 
 		// TODO there is no logic in place to calibrate the primary baro yet
-		// // check if the primary device is present 
+		// // check if the primary device is present
 		if (!prime_found && prime_id != 0) {
 			if (reportFailures) {
-				mavlink_and_console_log_critical(mavlink_fd, "warning: primary barometer not operational");
+				mavlink_and_console_log_critical("warning: primary barometer not operational");
 			}
 			failed = true;
 		}
@@ -517,16 +506,16 @@ bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro
 
 	/* ---- AIRSPEED ---- */
 	if (checkAirspeed) {
-		if (!airspeedCheck(mavlink_fd, true, reportFailures)) {
+		if (!airspeedCheck(true, reportFailures)) {
 			failed = true;
 		}
 	}
 
 	/* ---- RC CALIBRATION ---- */
 	if (checkRC) {
-		if (rc_calibration_check(mavlink_fd, reportFailures) != OK) {
+		if (rc_calibration_check(reportFailures) != OK) {
 			if (reportFailures) {
-				mavlink_and_console_log_critical(mavlink_fd, "RC calibration check failed");
+				mavlink_and_console_log_critical("RC calibration check failed");
 			}
 			failed = true;
 		}
@@ -534,7 +523,7 @@ bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc, bool checkGyro
 
 	/* ---- Global Navigation Satellite System receiver ---- */
 	if (checkGNSS) {
-		if (!gnssCheck(mavlink_fd, reportFailures)) {
+		if (!gnssCheck(reportFailures)) {
 			failed = true;
 		}
 	}

--- a/src/modules/commander/PreflightCheck.h
+++ b/src/modules/commander/PreflightCheck.h
@@ -49,8 +49,6 @@ namespace Commander
 * The function won't fail the test if optional sensors are not found, however,
 * it will fail the test if optional sensors are found but not in working condition.
 *
-* @param mavlink_fd
-*   Mavlink output file descriptor for feedback when a sensor fails
 * @param checkMag
 *   true if the magneteometer should be checked
 * @param checkAcc
@@ -66,7 +64,7 @@ namespace Commander
 * @param checkGNSS
 *   true if the GNSS receiver should be checked
 **/
-bool preflightCheck(int mavlink_fd, bool checkMag, bool checkAcc,
+bool preflightCheck(bool checkMag, bool checkAcc,
     bool checkGyro, bool checkBaro, bool checkAirspeed, bool checkRC, bool checkGNSS, bool checkDynamic, bool reportFailures = false);
 
 const unsigned max_mandatory_gyro_count = 1;

--- a/src/modules/commander/accelerometer_calibration.cpp
+++ b/src/modules/commander/accelerometer_calibration.cpp
@@ -145,7 +145,7 @@
 #include <conversion/rotation.h>
 #include <systemlib/param/param.h>
 #include <systemlib/err.h>
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <uORB/topics/vehicle_attitude.h>
 
 /* oddly, ERROR is not defined for c++ */
@@ -159,26 +159,25 @@ static const char *sensor_name = "accel";
 static int32_t device_id[max_accel_sens];
 static int32_t device_id_primary = 0;
 
-calibrate_return do_accel_calibration_measurements(int mavlink_fd, float (&accel_offs)[max_accel_sens][3], float (&accel_T)[max_accel_sens][3][3], unsigned *active_sensors);
+calibrate_return do_accel_calibration_measurements(float (&accel_offs)[max_accel_sens][3], float (&accel_T)[max_accel_sens][3][3], unsigned *active_sensors);
 calibrate_return read_accelerometer_avg(int (&subs)[max_accel_sens], float (&accel_avg)[max_accel_sens][detect_orientation_side_count][3], unsigned orient, unsigned samples_num);
 int mat_invert3(float src[3][3], float dst[3][3]);
 calibrate_return calculate_calibration_values(unsigned sensor, float (&accel_ref)[max_accel_sens][detect_orientation_side_count][3], float (&accel_T)[max_accel_sens][3][3], float (&accel_offs)[max_accel_sens][3], float g);
 
 /// Data passed to calibration worker routine
 typedef struct  {
-	int		mavlink_fd;
 	unsigned	done_count;
 	int		subs[max_accel_sens];
 	float		accel_ref[max_accel_sens][detect_orientation_side_count][3];
 } accel_worker_data_t;
 
-int do_accel_calibration(int mavlink_fd)
+int do_accel_calibration()
 {
 #ifndef __PX4_QURT
 	int fd;
 #endif
 
-	mavlink_and_console_log_info(mavlink_fd, CAL_QGC_STARTED_MSG, sensor_name);
+	mavlink_and_console_log_info(CAL_QGC_STARTED_MSG, sensor_name);
 
 	struct accel_calibration_s accel_scale;
 	accel_scale.x_offset = 0.0f;
@@ -209,7 +208,7 @@ int do_accel_calibration(int mavlink_fd)
 		px4_close(fd);
 
 		if (res != OK) {
-			mavlink_and_console_log_critical(mavlink_fd, CAL_ERROR_RESET_CAL_MSG, s);
+			mavlink_and_console_log_critical(CAL_ERROR_RESET_CAL_MSG, s);
 		}
 #else
 		(void)sprintf(str, "CAL_ACC%u_XOFF", s);
@@ -251,7 +250,7 @@ int do_accel_calibration(int mavlink_fd)
 
 	/* measure and calculate offsets & scales */
 	if (res == OK) {
-		calibrate_return cal_return = do_accel_calibration_measurements(mavlink_fd, accel_offs, accel_T, &active_sensors);
+		calibrate_return cal_return = do_accel_calibration_measurements(accel_offs, accel_T, &active_sensors);
 		if (cal_return == calibrate_return_cancelled) {
 			// Cancel message already displayed, nothing left to do
 			return ERROR;
@@ -264,7 +263,7 @@ int do_accel_calibration(int mavlink_fd)
 
 	if (res != OK) {
 		if (active_sensors == 0) {
-			mavlink_and_console_log_critical(mavlink_fd, CAL_ERROR_SENSOR_MSG);
+			mavlink_and_console_log_critical(CAL_ERROR_SENSOR_MSG);
 		}
 		return ERROR;
 	}
@@ -324,7 +323,7 @@ int do_accel_calibration(int mavlink_fd)
 		failed |= (OK != param_set_no_notification(param_find(str), &(device_id[i])));
 
 		if (failed) {
-			mavlink_and_console_log_critical(mavlink_fd, CAL_ERROR_SET_PARAMS_MSG, i);
+			mavlink_and_console_log_critical(CAL_ERROR_SET_PARAMS_MSG, i);
 			return ERROR;
 		}
 
@@ -333,7 +332,7 @@ int do_accel_calibration(int mavlink_fd)
 		fd = px4_open(str, 0);
 
 		if (fd < 0) {
-			mavlink_and_console_log_critical(mavlink_fd, CAL_QGC_FAILED_MSG, "sensor does not exist");
+			mavlink_and_console_log_critical(CAL_QGC_FAILED_MSG, "sensor does not exist");
 			res = ERROR;
 		} else {
 			res = px4_ioctl(fd, ACCELIOCSSCALE, (long unsigned int)&accel_scale);
@@ -341,7 +340,7 @@ int do_accel_calibration(int mavlink_fd)
 		}
 
 		if (res != OK) {
-			mavlink_and_console_log_critical(mavlink_fd, CAL_ERROR_APPLY_CAL_MSG, i);
+			mavlink_and_console_log_critical(CAL_ERROR_APPLY_CAL_MSG, i);
 		}
 #endif
 	}
@@ -351,16 +350,16 @@ int do_accel_calibration(int mavlink_fd)
 		res = param_save_default();
 
 		if (res != OK) {
-			mavlink_and_console_log_critical(mavlink_fd, CAL_ERROR_SAVE_PARAMS_MSG);
+			mavlink_and_console_log_critical(CAL_ERROR_SAVE_PARAMS_MSG);
 		}
 
 		/* if there is a any preflight-check system response, let the barrage of messages through */
 		usleep(200000);
 
-		mavlink_and_console_log_info(mavlink_fd, CAL_QGC_DONE_MSG, sensor_name);
+		mavlink_and_console_log_info(CAL_QGC_DONE_MSG, sensor_name);
 
 	} else {
-		mavlink_and_console_log_critical(mavlink_fd, CAL_QGC_FAILED_MSG, sensor_name);
+		mavlink_and_console_log_critical(CAL_QGC_FAILED_MSG, sensor_name);
 	}
 
 	/* give this message enough time to propagate */
@@ -374,22 +373,22 @@ static calibrate_return accel_calibration_worker(detect_orientation_return orien
 	const unsigned samples_num = 750;
 	accel_worker_data_t* worker_data = (accel_worker_data_t*)(data);
 
-	mavlink_and_console_log_info(worker_data->mavlink_fd, "[cal] Hold still, measuring %s side", detect_orientation_str(orientation));
+	mavlink_and_console_log_info("[cal] Hold still, measuring %s side", detect_orientation_str(orientation));
 
 	read_accelerometer_avg(worker_data->subs, worker_data->accel_ref, orientation, samples_num);
 
-	mavlink_and_console_log_info(worker_data->mavlink_fd, "[cal] %s side result: [%8.4f %8.4f %8.4f]", detect_orientation_str(orientation),
+	mavlink_and_console_log_info("[cal] %s side result: [%8.4f %8.4f %8.4f]", detect_orientation_str(orientation),
 				     (double)worker_data->accel_ref[0][orientation][0],
 				     (double)worker_data->accel_ref[0][orientation][1],
 				     (double)worker_data->accel_ref[0][orientation][2]);
 
 	worker_data->done_count++;
-	mavlink_and_console_log_info(worker_data->mavlink_fd, CAL_QGC_PROGRESS_MSG, 17 * worker_data->done_count);
+	mavlink_and_console_log_info(CAL_QGC_PROGRESS_MSG, 17 * worker_data->done_count);
 
 	return calibrate_return_ok;
 }
 
-calibrate_return do_accel_calibration_measurements(int mavlink_fd, float (&accel_offs)[max_accel_sens][3], float (&accel_T)[max_accel_sens][3][3], unsigned *active_sensors)
+calibrate_return do_accel_calibration_measurements(float (&accel_offs)[max_accel_sens][3], float (&accel_T)[max_accel_sens][3][3], unsigned *active_sensors)
 {
 	calibrate_return result = calibrate_return_ok;
 
@@ -397,7 +396,6 @@ calibrate_return do_accel_calibration_measurements(int mavlink_fd, float (&accel
 
 	accel_worker_data_t worker_data;
 
-	worker_data.mavlink_fd = mavlink_fd;
 	worker_data.done_count = 0;
 
 	bool data_collected[detect_orientation_side_count] = { false, false, false, false, false, false };
@@ -441,7 +439,7 @@ calibrate_return do_accel_calibration_measurements(int mavlink_fd, float (&accel
 
 	if (result == calibrate_return_ok) {
 		int cancel_sub = calibrate_cancel_subscribe();
-		result = calibrate_from_orientation(mavlink_fd, cancel_sub, data_collected, accel_calibration_worker, &worker_data, false /* normal still */);
+		result = calibrate_from_orientation(cancel_sub, data_collected, accel_calibration_worker, &worker_data, false /* normal still */);
 		calibrate_cancel_unsubscribe(cancel_sub);
 	}
 
@@ -464,7 +462,7 @@ calibrate_return do_accel_calibration_measurements(int mavlink_fd, float (&accel
 			result = calculate_calibration_values(i, worker_data.accel_ref, accel_T, accel_offs, CONSTANTS_ONE_G);
 
 			if (result != calibrate_return_ok) {
-				mavlink_and_console_log_critical(mavlink_fd, "[cal] ERROR: calibration calculation error");
+				mavlink_and_console_log_critical("[cal] ERROR: calibration calculation error");
 				break;
 			}
 		}
@@ -624,7 +622,7 @@ calibrate_return calculate_calibration_values(unsigned sensor, float (&accel_ref
 	return calibrate_return_ok;
 }
 
-int do_level_calibration(int mavlink_fd) {
+int do_level_calibration() {
 	const unsigned cal_time = 5;
 	const unsigned cal_hz = 100;
 	unsigned settle_time = 30;
@@ -634,7 +632,7 @@ int do_level_calibration(int mavlink_fd) {
 	struct vehicle_attitude_s att;
 	memset(&att, 0, sizeof(att));
 
-	mavlink_and_console_log_info(mavlink_fd, CAL_QGC_STARTED_MSG, "level");
+	mavlink_and_console_log_info(CAL_QGC_STARTED_MSG, "level");
 
 	param_t roll_offset_handle = param_find("SENS_BOARD_X_OFF");
 	param_t pitch_offset_handle = param_find("SENS_BOARD_Y_OFF");
@@ -669,7 +667,7 @@ int do_level_calibration(int mavlink_fd) {
 	// sleep for some time
 	hrt_abstime start = hrt_absolute_time();
 	while(hrt_elapsed_time(&start) < settle_time * 1000000) {
-		mavlink_and_console_log_info(mavlink_fd, CAL_QGC_PROGRESS_MSG, (int)(90*hrt_elapsed_time(&start)/1e6f/(float)settle_time));
+		mavlink_and_console_log_info(CAL_QGC_PROGRESS_MSG, (int)(90*hrt_elapsed_time(&start)/1e6f/(float)settle_time));
 		sleep(settle_time / 10);
 	}
 
@@ -680,8 +678,8 @@ int do_level_calibration(int mavlink_fd) {
 
 		if (pollret <= 0) {
 			// attitude estimator is not running
-			mavlink_and_console_log_critical(mavlink_fd, "attitude estimator not running - check system boot");
-			mavlink_and_console_log_critical(mavlink_fd, CAL_QGC_FAILED_MSG, "level");
+			mavlink_and_console_log_critical("attitude estimator not running - check system boot");
+			mavlink_and_console_log_critical(CAL_QGC_FAILED_MSG, "level");
 			goto out;
 		}
 
@@ -691,21 +689,21 @@ int do_level_calibration(int mavlink_fd) {
 		counter++;
 	}
 
-	mavlink_and_console_log_info(mavlink_fd, CAL_QGC_PROGRESS_MSG, 100);
+	mavlink_and_console_log_info(CAL_QGC_PROGRESS_MSG, 100);
 
 	if (counter > (cal_time * cal_hz / 2 )) {
 		roll_mean /= counter;
 		pitch_mean /= counter;
 	} else {
-		mavlink_and_console_log_info(mavlink_fd, "not enough measurements taken");
+		mavlink_and_console_log_info("not enough measurements taken");
 		success = false;
 		goto out;
 	}
 
 	if (fabsf(roll_mean) > 0.8f ) {
-		mavlink_and_console_log_critical(mavlink_fd, "excess roll angle");
+		mavlink_and_console_log_critical("excess roll angle");
 	} else if (fabsf(pitch_mean) > 0.8f ) {
-		mavlink_and_console_log_critical(mavlink_fd, "excess pitch angle");
+		mavlink_and_console_log_critical("excess pitch angle");
 	} else {
 		roll_mean *= (float)M_RAD_TO_DEG;
 		pitch_mean *= (float)M_RAD_TO_DEG;
@@ -716,13 +714,13 @@ int do_level_calibration(int mavlink_fd) {
 
 out:
 	if (success) {
-		mavlink_and_console_log_info(mavlink_fd, CAL_QGC_DONE_MSG, "level");
+		mavlink_and_console_log_info(CAL_QGC_DONE_MSG, "level");
 		return 0;
 	} else {
 		// set old parameters
 		param_set(roll_offset_handle, &roll_offset_current);
 		param_set(pitch_offset_handle, &pitch_offset_current);
-		mavlink_and_console_log_critical(mavlink_fd, CAL_QGC_FAILED_MSG, "level");
+		mavlink_and_console_log_critical(CAL_QGC_FAILED_MSG, "level");
 		return 1;
 	}
 }

--- a/src/modules/commander/accelerometer_calibration.h
+++ b/src/modules/commander/accelerometer_calibration.h
@@ -44,7 +44,7 @@
 
 #include <stdint.h>
 
-int do_accel_calibration(int mavlink_fd);
-int do_level_calibration(int mavlink_fd);
+int do_accel_calibration();
+int do_level_calibration();
 
 #endif /* ACCELEROMETER_CALIBRATION_H_ */

--- a/src/modules/commander/airspeed_calibration.cpp
+++ b/src/modules/commander/airspeed_calibration.cpp
@@ -52,7 +52,7 @@
 #include <drivers/drv_airspeed.h>
 #include <uORB/topics/sensor_combined.h>
 #include <uORB/topics/differential_pressure.h>
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <systemlib/param/param.h>
 #include <systemlib/err.h>
 #include <systemlib/airspeed.h>
@@ -65,20 +65,20 @@ static const int ERROR = -1;
 
 static const char *sensor_name = "dpress";
 
-static void feedback_calibration_failed(int mavlink_fd)
+static void feedback_calibration_failed()
 {
 	sleep(5);
-	mavlink_and_console_log_critical(mavlink_fd, CAL_QGC_FAILED_MSG, sensor_name);
+	mavlink_and_console_log_critical(CAL_QGC_FAILED_MSG, sensor_name);
 }
 
-int do_airspeed_calibration(int mavlink_fd)
+int do_airspeed_calibration()
 {
 	int result = OK;
 	unsigned calibration_counter = 0;
 	const unsigned maxcount = 2400;
 
 	/* give directions */
-	mavlink_and_console_log_info(mavlink_fd, CAL_QGC_STARTED_MSG, sensor_name);
+	mavlink_and_console_log_info(CAL_QGC_STARTED_MSG, sensor_name);
 
 	const unsigned calibration_count = (maxcount * 2) / 3;
 
@@ -101,12 +101,12 @@ int do_airspeed_calibration(int mavlink_fd)
 			paramreset_successful = true;
 
 		} else {
-			mavlink_and_console_log_critical(mavlink_fd, "[cal] airspeed offset zero failed");
+			mavlink_and_console_log_critical("[cal] airspeed offset zero failed");
 		}
 
 		px4_close(fd);
 	}
-    
+
 	int cancel_sub = calibrate_cancel_subscribe();
 
 	if (!paramreset_successful) {
@@ -115,26 +115,26 @@ int do_airspeed_calibration(int mavlink_fd)
 		float analog_scaling = 0.0f;
 		param_get(param_find("SENS_DPRES_ANSC"), &(analog_scaling));
 		if (fabsf(analog_scaling) < 0.1f) {
-			mavlink_and_console_log_critical(mavlink_fd, "[cal] No airspeed sensor, see http://px4.io/help/aspd");
+			mavlink_and_console_log_critical("[cal] No airspeed sensor, see http://px4.io/help/aspd");
 			goto error_return;
 		}
 
 		/* set scaling offset parameter */
 		if (param_set(param_find("SENS_DPRES_OFF"), &(diff_pres_offset))) {
-			mavlink_and_console_log_critical(mavlink_fd, CAL_ERROR_SET_PARAMS_MSG, 1);
+			mavlink_and_console_log_critical(CAL_ERROR_SET_PARAMS_MSG, 1);
 			goto error_return;
 		}
 	}
 
-	mavlink_and_console_log_critical(mavlink_fd, "[cal] Ensure sensor is not measuring wind");
+	mavlink_and_console_log_critical("[cal] Ensure sensor is not measuring wind");
 	usleep(500 * 1000);
 
 	while (calibration_counter < calibration_count) {
 
-		if (calibrate_cancel_check(mavlink_fd, cancel_sub)) {
+		if (calibrate_cancel_check(cancel_sub)) {
 			goto error_return;
 		}
-        
+
 		/* wait blocking for new data */
 		px4_pollfd_struct_t fds[1];
 		fds[0].fd = diff_pres_sub;
@@ -149,12 +149,12 @@ int do_airspeed_calibration(int mavlink_fd)
 			calibration_counter++;
 
 			if (calibration_counter % (calibration_count / 20) == 0) {
-				mavlink_and_console_log_info(mavlink_fd, CAL_QGC_PROGRESS_MSG, (calibration_counter * 80) / calibration_count);
+				mavlink_and_console_log_info(CAL_QGC_PROGRESS_MSG, (calibration_counter * 80) / calibration_count);
 			}
 
 		} else if (poll_ret == 0) {
 			/* any poll failure for 1s is a reason to abort */
-			feedback_calibration_failed(mavlink_fd);
+			feedback_calibration_failed();
 			goto error_return;
 		}
 	}
@@ -167,14 +167,14 @@ int do_airspeed_calibration(int mavlink_fd)
 		airscale.offset_pa = diff_pres_offset;
 		if (fd_scale > 0) {
 			if (OK != px4_ioctl(fd_scale, AIRSPEEDIOCSSCALE, (long unsigned int)&airscale)) {
-				mavlink_and_console_log_critical(mavlink_fd, "[cal] airspeed offset update failed");
+				mavlink_and_console_log_critical("[cal] airspeed offset update failed");
 			}
 
 			px4_close(fd_scale);
 		}
 
 		if (param_set(param_find("SENS_DPRES_OFF"), &(diff_pres_offset))) {
-			mavlink_and_console_log_critical(mavlink_fd, CAL_ERROR_SET_PARAMS_MSG, 1);
+			mavlink_and_console_log_critical(CAL_ERROR_SET_PARAMS_MSG, 1);
 			goto error_return;
 		}
 
@@ -183,28 +183,28 @@ int do_airspeed_calibration(int mavlink_fd)
 
 		if (save_ret != 0) {
 			warn("WARNING: auto-save of params to storage failed");
-			mavlink_and_console_log_critical(mavlink_fd, CAL_ERROR_SAVE_PARAMS_MSG);
+			mavlink_and_console_log_critical(CAL_ERROR_SAVE_PARAMS_MSG);
 			goto error_return;
 		}
 
 	} else {
-		feedback_calibration_failed(mavlink_fd);
+		feedback_calibration_failed();
 		goto error_return;
 	}
 
-	mavlink_and_console_log_critical(mavlink_fd, "[cal] Offset of %d Pascal", (int)diff_pres_offset);
+	mavlink_and_console_log_critical("[cal] Offset of %d Pascal", (int)diff_pres_offset);
 
 	/* wait 500 ms to ensure parameter propagated through the system */
 	usleep(500 * 1000);
 
-	mavlink_and_console_log_critical(mavlink_fd, "[cal] Create airflow now");
+	mavlink_and_console_log_critical("[cal] Create airflow now");
 
 	calibration_counter = 0;
 
 	/* just take a few samples and make sure pitot tubes are not reversed, timeout after ~30 seconds */
 	while (calibration_counter < maxcount) {
 
-		if (calibrate_cancel_check(mavlink_fd, cancel_sub)) {
+		if (calibrate_cancel_check(cancel_sub)) {
 			goto error_return;
 		}
 
@@ -222,7 +222,7 @@ int do_airspeed_calibration(int mavlink_fd)
 
 			if (fabsf(diff_pres.differential_pressure_raw_pa) < 50.0f) {
 				if (calibration_counter % 500 == 0) {
-					mavlink_and_console_log_info(mavlink_fd, "[cal] Create air pressure! (got %d, wanted: 50 Pa)",
+					mavlink_and_console_log_info("[cal] Create air pressure! (got %d, wanted: 50 Pa)",
 						(int)diff_pres.differential_pressure_raw_pa);
 				}
 				continue;
@@ -230,56 +230,56 @@ int do_airspeed_calibration(int mavlink_fd)
 
 			/* do not allow negative values */
 			if (diff_pres.differential_pressure_raw_pa < 0.0f) {
-				mavlink_and_console_log_info(mavlink_fd, "[cal] Negative pressure difference detected (%d Pa)",
+				mavlink_and_console_log_info("[cal] Negative pressure difference detected (%d Pa)",
 						(int)diff_pres.differential_pressure_raw_pa);
-				mavlink_and_console_log_info(mavlink_fd, "[cal] Swap static and dynamic ports!");
+				mavlink_and_console_log_info("[cal] Swap static and dynamic ports!");
 
 				/* the user setup is wrong, wipe the calibration to force a proper re-calibration */
 
 				diff_pres_offset = 0.0f;
 				if (param_set(param_find("SENS_DPRES_OFF"), &(diff_pres_offset))) {
-					mavlink_and_console_log_critical(mavlink_fd, CAL_ERROR_SET_PARAMS_MSG, 1);
+					mavlink_and_console_log_critical(CAL_ERROR_SET_PARAMS_MSG, 1);
 					goto error_return;
 				}
 
 				/* save */
-				mavlink_and_console_log_info(mavlink_fd, CAL_QGC_PROGRESS_MSG, 0);
+				mavlink_and_console_log_info(CAL_QGC_PROGRESS_MSG, 0);
 				(void)param_save_default();
 
-				feedback_calibration_failed(mavlink_fd);
+				feedback_calibration_failed();
 				goto error_return;
 			} else {
-				mavlink_and_console_log_info(mavlink_fd, "[cal] Positive pressure: OK (%d Pa)",
+				mavlink_and_console_log_info("[cal] Positive pressure: OK (%d Pa)",
 					(int)diff_pres.differential_pressure_raw_pa);
 				break;
 			}
 
 		} else if (poll_ret == 0) {
 			/* any poll failure for 1s is a reason to abort */
-			feedback_calibration_failed(mavlink_fd);
+			feedback_calibration_failed();
 			goto error_return;
 		}
 	}
 
 	if (calibration_counter == maxcount) {
-		feedback_calibration_failed(mavlink_fd);
+		feedback_calibration_failed();
 		goto error_return;
 	}
 
-	mavlink_and_console_log_info(mavlink_fd, CAL_QGC_PROGRESS_MSG, 100);
+	mavlink_and_console_log_info(CAL_QGC_PROGRESS_MSG, 100);
 
-	mavlink_and_console_log_info(mavlink_fd, CAL_QGC_DONE_MSG, sensor_name);
+	mavlink_and_console_log_info(CAL_QGC_DONE_MSG, sensor_name);
 	tune_neutral(true);
 
 normal_return:
 	calibrate_cancel_unsubscribe(cancel_sub);
 	px4_close(diff_pres_sub);
-	
+
 	// This give a chance for the log messages to go out of the queue before someone else stomps on then
 	sleep(1);
-	
+
 	return result;
-    
+
 error_return:
 	result = ERROR;
 	goto normal_return;

--- a/src/modules/commander/airspeed_calibration.h
+++ b/src/modules/commander/airspeed_calibration.h
@@ -41,6 +41,6 @@
 
 #include <stdint.h>
 
-int do_airspeed_calibration(int mavlink_fd);
+int do_airspeed_calibration();
 
 #endif /* AIRSPEED_CALIBRATION_H_ */

--- a/src/modules/commander/baro_calibration.cpp
+++ b/src/modules/commander/baro_calibration.cpp
@@ -44,7 +44,7 @@
 #include <drivers/drv_hrt.h>
 #include <uORB/topics/sensor_combined.h>
 #include <drivers/drv_baro.h>
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <systemlib/param/param.h>
 
 /* oddly, ERROR is not defined for c++ */
@@ -53,7 +53,7 @@
 #endif
 static const int ERROR = -1;
 
-int do_baro_calibration(int mavlink_fd)
+int do_baro_calibration()
 {
 	// TODO implement this
 	return ERROR;

--- a/src/modules/commander/baro_calibration.h
+++ b/src/modules/commander/baro_calibration.h
@@ -41,6 +41,6 @@
 
 #include <stdint.h>
 
-int do_baro_calibration(int mavlink_fd);
+int do_baro_calibration();
 
 #endif /* BARO_CALIBRATION_H_ */

--- a/src/modules/commander/calibration_routines.cpp
+++ b/src/modules/commander/calibration_routines.cpp
@@ -47,7 +47,7 @@
 #include <float.h>
 #include <poll.h>
 #include <drivers/drv_hrt.h>
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <geo/geo.h>
 #include <string.h>
 
@@ -233,10 +233,10 @@ int sphere_fit_least_squares(const float x[], const float y[], const float z[],
 	return 0;
 }
 
-enum detect_orientation_return detect_orientation(int mavlink_fd, int cancel_sub, int accel_sub, bool lenient_still_position)
+enum detect_orientation_return detect_orientation(int cancel_sub, int accel_sub, bool lenient_still_position)
 {
 	const unsigned ndim = 3;
-	
+
 	struct sensor_combined_s sensor;
 	float		accel_ema[ndim] = { 0.0f };		// exponential moving average of accel
 	float		accel_disp[3] = { 0.0f, 0.0f, 0.0f };	// max-hold dispersion of accel
@@ -245,11 +245,11 @@ enum detect_orientation_return detect_orientation(int mavlink_fd, int cancel_sub
 	float		still_thr2 = powf(lenient_still_position ? (normal_still_thr * 3) : normal_still_thr, 2);
 	float		accel_err_thr = 5.0f;			// set accel error threshold to 5m/s^2
 	hrt_abstime	still_time = lenient_still_position ? 500000 : 1300000;	// still time required in us
-    
+
 	px4_pollfd_struct_t fds[1];
 	fds[0].fd = accel_sub;
 	fds[0].events = POLLIN;
-	
+
 	hrt_abstime t_start = hrt_absolute_time();
 	/* set timeout to 30s */
 	hrt_abstime timeout = 30000000;
@@ -257,22 +257,22 @@ enum detect_orientation_return detect_orientation(int mavlink_fd, int cancel_sub
 	hrt_abstime t = t_start;
 	hrt_abstime t_prev = t_start;
 	hrt_abstime t_still = 0;
-	
+
 	unsigned poll_errcount = 0;
-	
+
 	while (true) {
 		/* wait blocking for new data */
 		int poll_ret = px4_poll(fds, 1, 1000);
-		
+
 		if (poll_ret) {
 			orb_copy(ORB_ID(sensor_combined), accel_sub, &sensor);
 			t = hrt_absolute_time();
 			float dt = (t - t_prev) / 1000000.0f;
 			t_prev = t;
 			float w = dt / ema_len;
-			
+
 			for (unsigned i = 0; i < ndim; i++) {
-				
+
 				float di = 0.0f;
 				switch (i) {
 					case 0:
@@ -285,21 +285,21 @@ enum detect_orientation_return detect_orientation(int mavlink_fd, int cancel_sub
 						di = sensor.accelerometer_m_s2[2];
 						break;
 				}
-				
+
 				float d = di - accel_ema[i];
 				accel_ema[i] += d * w;
 				d = d * d;
 				accel_disp[i] = accel_disp[i] * (1.0f - w);
-				
+
 				if (d > still_thr2 * 8.0f) {
 					d = still_thr2 * 8.0f;
 				}
-				
+
 				if (d > accel_disp[i]) {
 					accel_disp[i] = d;
 				}
 			}
-			
+
 			/* still detector with hysteresis */
 			if (accel_disp[0] < still_thr2 &&
 			    accel_disp[1] < still_thr2 &&
@@ -307,10 +307,10 @@ enum detect_orientation_return detect_orientation(int mavlink_fd, int cancel_sub
 				/* is still now */
 				if (t_still == 0) {
 					/* first time */
-					mavlink_and_console_log_info(mavlink_fd, "[cal] detected rest position, hold still...");
+					mavlink_and_console_log_info("[cal] detected rest position, hold still...");
 					t_still = t;
 					t_timeout = t + timeout;
-					
+
 				} else {
 					/* still since t_still */
 					if (t > t_still + still_time) {
@@ -318,28 +318,28 @@ enum detect_orientation_return detect_orientation(int mavlink_fd, int cancel_sub
 						break;
 					}
 				}
-				
+
 			} else if (accel_disp[0] > still_thr2 * 4.0f ||
 				   accel_disp[1] > still_thr2 * 4.0f ||
 				   accel_disp[2] > still_thr2 * 4.0f) {
 				/* not still, reset still start time */
 				if (t_still != 0) {
-					mavlink_and_console_log_info(mavlink_fd, "[cal] detected motion, hold still...");
+					mavlink_and_console_log_info("[cal] detected motion, hold still...");
 					usleep(200000);
 					t_still = 0;
 				}
 			}
-			
+
 		} else if (poll_ret == 0) {
 			poll_errcount++;
 		}
-		
+
 		if (t > t_timeout) {
 			poll_errcount++;
 		}
-		
+
 		if (poll_errcount > 1000) {
-			mavlink_and_console_log_critical(mavlink_fd, CAL_ERROR_SENSOR_MSG);
+			mavlink_and_console_log_critical(CAL_ERROR_SENSOR_MSG);
 			return DETECT_ORIENTATION_ERROR;
 		}
 	}
@@ -349,39 +349,39 @@ enum detect_orientation_return detect_orientation(int mavlink_fd, int cancel_sub
 	    fabsf(accel_ema[2]) < accel_err_thr) {
 		return DETECT_ORIENTATION_TAIL_DOWN;        // [ g, 0, 0 ]
 	}
-	
+
 	if (fabsf(accel_ema[0] + CONSTANTS_ONE_G) < accel_err_thr &&
 	    fabsf(accel_ema[1]) < accel_err_thr &&
 	    fabsf(accel_ema[2]) < accel_err_thr) {
 		return DETECT_ORIENTATION_NOSE_DOWN;        // [ -g, 0, 0 ]
 	}
-	
+
 	if (fabsf(accel_ema[0]) < accel_err_thr &&
 	    fabsf(accel_ema[1] - CONSTANTS_ONE_G) < accel_err_thr &&
 	    fabsf(accel_ema[2]) < accel_err_thr) {
 		return DETECT_ORIENTATION_LEFT;        // [ 0, g, 0 ]
 	}
-	
+
 	if (fabsf(accel_ema[0]) < accel_err_thr &&
 	    fabsf(accel_ema[1] + CONSTANTS_ONE_G) < accel_err_thr &&
 	    fabsf(accel_ema[2]) < accel_err_thr) {
 		return DETECT_ORIENTATION_RIGHT;        // [ 0, -g, 0 ]
 	}
-	
+
 	if (fabsf(accel_ema[0]) < accel_err_thr &&
 	    fabsf(accel_ema[1]) < accel_err_thr &&
 	    fabsf(accel_ema[2] - CONSTANTS_ONE_G) < accel_err_thr) {
 		return DETECT_ORIENTATION_UPSIDE_DOWN;        // [ 0, 0, g ]
 	}
-	
+
 	if (fabsf(accel_ema[0]) < accel_err_thr &&
 	    fabsf(accel_ema[1]) < accel_err_thr &&
 	    fabsf(accel_ema[2] + CONSTANTS_ONE_G) < accel_err_thr) {
 		return DETECT_ORIENTATION_RIGHTSIDE_UP;        // [ 0, 0, -g ]
 	}
-	
-	mavlink_and_console_log_critical(mavlink_fd, "[cal] ERROR: invalid orientation");
-	
+
+	mavlink_and_console_log_critical("[cal] ERROR: invalid orientation");
+
 	return DETECT_ORIENTATION_ERROR;	// Can't detect orientation
 }
 
@@ -396,106 +396,105 @@ const char* detect_orientation_str(enum detect_orientation_return orientation)
 		"down",		// right-side up
 		"error"
 	};
-	
+
 	return rgOrientationStrs[orientation];
 }
 
-calibrate_return calibrate_from_orientation(int		mavlink_fd,
-					    int		cancel_sub,
+calibrate_return calibrate_from_orientation(int		cancel_sub,
 					    bool	side_data_collected[detect_orientation_side_count],
 					    calibration_from_orientation_worker_t calibration_worker,
 					    void*	worker_data,
 					    bool	lenient_still_position)
 {
 	calibrate_return result = calibrate_return_ok;
-	
+
 	// Setup subscriptions to onboard accel sensor
-	
+
 	int sub_accel = orb_subscribe(ORB_ID(sensor_combined));
 	if (sub_accel < 0) {
-		mavlink_and_console_log_critical(mavlink_fd, CAL_QGC_FAILED_MSG, "No onboard accel");
+		mavlink_and_console_log_critical(CAL_QGC_FAILED_MSG, "No onboard accel");
 		return calibrate_return_error;
 	}
-	
+
 	unsigned orientation_failures = 0;
-	
+
 	// Rotate through all requested orientation
 	while (true) {
-		if (calibrate_cancel_check(mavlink_fd, cancel_sub)) {
+		if (calibrate_cancel_check(cancel_sub)) {
 			result = calibrate_return_cancelled;
 			break;
 		}
-		
+
 		if (orientation_failures > 4) {
 			result = calibrate_return_error;
-			mavlink_and_console_log_critical(mavlink_fd, CAL_QGC_FAILED_MSG, "timeout: no motion");
+			mavlink_and_console_log_critical(CAL_QGC_FAILED_MSG, "timeout: no motion");
 			break;
 		}
-		
+
 		unsigned int side_complete_count = 0;
-		
+
 		// Update the number of completed sides
 		for (unsigned i = 0; i < detect_orientation_side_count; i++) {
 			if (side_data_collected[i]) {
 				side_complete_count++;
 			}
 		}
-		
+
 		if (side_complete_count == detect_orientation_side_count) {
 			// We have completed all sides, move on
 			break;
 		}
-		
+
 		/* inform user which orientations are still needed */
 		char pendingStr[256];
 		pendingStr[0] = 0;
-		
+
 		for (unsigned int cur_orientation=0; cur_orientation<detect_orientation_side_count; cur_orientation++) {
 			if (!side_data_collected[cur_orientation]) {
 				strcat(pendingStr, " ");
 				strcat(pendingStr, detect_orientation_str((enum detect_orientation_return)cur_orientation));
 			}
 		}
-		mavlink_and_console_log_info(mavlink_fd, "[cal] pending:%s", pendingStr);
-		
-		mavlink_and_console_log_info(mavlink_fd, "[cal] hold vehicle still on a pending side");
-		enum detect_orientation_return orient = detect_orientation(mavlink_fd, cancel_sub, sub_accel, lenient_still_position);
-		
+		mavlink_and_console_log_info("[cal] pending:%s", pendingStr);
+
+		mavlink_and_console_log_info("[cal] hold vehicle still on a pending side");
+		enum detect_orientation_return orient = detect_orientation(cancel_sub, sub_accel, lenient_still_position);
+
 		if (orient == DETECT_ORIENTATION_ERROR) {
 			orientation_failures++;
-			mavlink_and_console_log_info(mavlink_fd, "[cal] detected motion, hold still...");
+			mavlink_and_console_log_info("[cal] detected motion, hold still...");
 			continue;
 		}
-		
+
 		/* inform user about already handled side */
 		if (side_data_collected[orient]) {
 			orientation_failures++;
-			mavlink_and_console_log_critical(mavlink_fd, "%s side already completed", detect_orientation_str(orient));
-			mavlink_and_console_log_critical(mavlink_fd, "rotate to a pending side");
+			mavlink_and_console_log_critical("%s side already completed", detect_orientation_str(orient));
+			mavlink_and_console_log_critical("rotate to a pending side");
 			continue;
 		}
-		
-		mavlink_and_console_log_info(mavlink_fd, CAL_QGC_ORIENTATION_DETECTED_MSG, detect_orientation_str(orient));
+
+		mavlink_and_console_log_info(CAL_QGC_ORIENTATION_DETECTED_MSG, detect_orientation_str(orient));
 		orientation_failures = 0;
-		
+
 		// Call worker routine
 		result = calibration_worker(orient, cancel_sub, worker_data);
 		if (result != calibrate_return_ok ) {
 			break;
 		}
-		
-		mavlink_and_console_log_info(mavlink_fd, CAL_QGC_SIDE_DONE_MSG, detect_orientation_str(orient));
-		
+
+		mavlink_and_console_log_info(CAL_QGC_SIDE_DONE_MSG, detect_orientation_str(orient));
+
 		// Note that this side is complete
 		side_data_collected[orient] = true;
 		tune_neutral(true);
 		usleep(200000);
 	}
-	
+
 	if (sub_accel >= 0) {
 		px4_close(sub_accel);
 	}
-	
+
 	return result;
 }
 
@@ -509,24 +508,24 @@ void calibrate_cancel_unsubscribe(int cmd_sub)
 	orb_unsubscribe(cmd_sub);
 }
 
-static void calibrate_answer_command(int mavlink_fd, struct vehicle_command_s &cmd, unsigned result)
+static void calibrate_answer_command(struct vehicle_command_s &cmd, unsigned result)
 {
 	switch (result) {
 		case vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED:
 			tune_positive(true);
 			break;
-			
+
 		case vehicle_command_s::VEHICLE_CMD_RESULT_DENIED:
-			mavlink_log_critical(mavlink_fd, "command denied during calibration: %u", cmd.command);
+			mavlink_log_critical("command denied during calibration: %u", cmd.command);
 			tune_negative(true);
 			break;
-			
+
 		default:
 			break;
 	}
 }
 
-bool calibrate_cancel_check(int mavlink_fd, int cancel_sub)
+bool calibrate_cancel_check(int cancel_sub)
 {
 	px4_pollfd_struct_t fds[1];
 	fds[0].fd = cancel_sub;
@@ -535,9 +534,9 @@ bool calibrate_cancel_check(int mavlink_fd, int cancel_sub)
 	if (px4_poll(&fds[0], 1, 0) > 0) {
 		struct vehicle_command_s cmd;
 		memset(&cmd, 0, sizeof(cmd));
-		
+
 		orb_copy(ORB_ID(vehicle_command), cancel_sub, &cmd);
-		
+
 		if (cmd.command == vehicle_command_s::VEHICLE_CMD_PREFLIGHT_CALIBRATION &&
 		    (int)cmd.param1 == 0 &&
 		    (int)cmd.param2 == 0 &&
@@ -545,13 +544,13 @@ bool calibrate_cancel_check(int mavlink_fd, int cancel_sub)
 		    (int)cmd.param4 == 0 &&
 		    (int)cmd.param5 == 0 &&
 		    (int)cmd.param6 == 0) {
-			calibrate_answer_command(mavlink_fd, cmd, vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED);
-			mavlink_log_critical(mavlink_fd, CAL_QGC_CANCELLED_MSG);
+			calibrate_answer_command(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED);
+			mavlink_log_critical(CAL_QGC_CANCELLED_MSG);
 			return true;
 		} else {
-			calibrate_answer_command(mavlink_fd, cmd, vehicle_command_s::VEHICLE_CMD_RESULT_DENIED);
+			calibrate_answer_command(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_DENIED);
 		}
 	}
-	
+
 	return false;
 }

--- a/src/modules/commander/calibration_routines.h
+++ b/src/modules/commander/calibration_routines.h
@@ -74,8 +74,7 @@ static const unsigned detect_orientation_side_count = 6;
 /// Wait for vehicle to become still and detect it's orientation
 ///	@return Returns detect_orientation_return according to orientation when vehicle
 ///		and ready for measurements
-enum detect_orientation_return detect_orientation(int	mavlink_fd,			///< Mavlink fd to write output to
-						  int	cancel_sub,			///< Cancel subscription from calibration_cancel_subscribe
+enum detect_orientation_return detect_orientation(int	cancel_sub,			///< Cancel subscription from calibration_cancel_subscribe
 						  int	accel_sub,			///< Orb subcription to accel sensor
 						  bool	lenient_still_detection);	///< true: Use more lenient still position detection
 
@@ -95,8 +94,7 @@ typedef calibrate_return (*calibration_from_orientation_worker_t)(detect_orienta
 
 /// Perform calibration sequence which require a rest orientation detection prior to calibration.
 ///	@return OK: Calibration succeeded, ERROR: Calibration failed
-calibrate_return calibrate_from_orientation(int		mavlink_fd,						///< Mavlink fd to write output to
-					    int		cancel_sub,						///< Cancel subscription from calibration_cancel_subscribe
+calibrate_return calibrate_from_orientation(int		cancel_sub,						///< Cancel subscription from calibration_cancel_subscribe
 					    bool	side_data_collected[detect_orientation_side_count],	///< Sides for which data still needs calibration
 					    calibration_from_orientation_worker_t calibration_worker,		///< Worker routine which performs the actual calibration
 					    void*	worker_data,						///< Opaque data passed to worker routine
@@ -111,5 +109,4 @@ int calibrate_cancel_subscribe(void);
 void calibrate_cancel_unsubscribe(int cancel_sub);
 
 /// Used to periodically check for a cancel command
-bool calibrate_cancel_check(int mavlink_fd,	///< Mavlink fd for output
-			    int cancel_sub);	///< Cancel subcription fromcalibration_cancel_subscribe
+bool calibrate_cancel_check(int cancel_sub);	///< Cancel subcription fromcalibration_cancel_subscribe

--- a/src/modules/commander/commander_tests/state_machine_helper_test.cpp
+++ b/src/modules/commander/commander_tests/state_machine_helper_test.cpp
@@ -288,7 +288,7 @@ bool StateMachineHelperTest::armingStateTransitionTest(void)
         armed.ready_to_arm = test->current_state.ready_to_arm;
 
         // Attempt transition
-        transition_result_t result = arming_state_transition(&status, &safety, test->requested_state, &armed, false /* no pre-arm checks */, 0 /* no mavlink_fd */);
+        transition_result_t result = arming_state_transition(&status, &safety, test->requested_state, &armed, false /* no pre-arm checks */);
 
         // Validate result of transition
         ut_assert(test->assertMsg, test->expected_transition_result == result);

--- a/src/modules/commander/esc_calibration.cpp
+++ b/src/modules/commander/esc_calibration.cpp
@@ -57,7 +57,7 @@
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/uORB.h>
 #include <drivers/drv_hrt.h>
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 
 /* oddly, ERROR is not defined for c++ */
 #ifdef ERROR
@@ -65,82 +65,82 @@
 #endif
 static const int ERROR = -1;
 
-int do_esc_calibration(int mavlink_fd, struct actuator_armed_s* armed)
+int do_esc_calibration(struct actuator_armed_s* armed)
 {
 	int	return_code = OK;
-	
+
 	int	fd = -1;
-	
+
 	struct	battery_status_s battery;
 	int	batt_sub = -1;
 	bool	batt_updated = false;
 	bool	batt_connected = false;
-	
+
 	hrt_abstime battery_connect_wait_timeout = 30000000;
 	hrt_abstime pwm_high_timeout = 10000000;
 	hrt_abstime timeout_start;
-	
-	mavlink_and_console_log_info(mavlink_fd, CAL_QGC_STARTED_MSG, "esc");
-	
+
+	mavlink_and_console_log_info(CAL_QGC_STARTED_MSG, "esc");
+
 	batt_sub = orb_subscribe(ORB_ID(battery_status));
 	if (batt_sub < 0) {
-		mavlink_and_console_log_critical(mavlink_fd, CAL_QGC_FAILED_MSG, "Subscribe to battery");
+		mavlink_and_console_log_critical(CAL_QGC_FAILED_MSG, "Subscribe to battery");
 		goto Error;
 	}
 
 	// Make sure battery is disconnected
 	orb_copy(ORB_ID(battery_status), batt_sub, &battery);
 	if (battery.voltage_filtered_v > 3.0f) {
-		mavlink_and_console_log_critical(mavlink_fd, CAL_QGC_FAILED_MSG, "Disconnect battery and try again");
+		mavlink_and_console_log_critical(CAL_QGC_FAILED_MSG, "Disconnect battery and try again");
 		goto Error;
 	}
-	
+
 	armed->in_esc_calibration_mode = true;
-	
+
 	fd = px4_open(PWM_OUTPUT0_DEVICE_PATH, 0);
 
 	if (fd < 0) {
-		mavlink_and_console_log_critical(mavlink_fd, CAL_QGC_FAILED_MSG, "Can't open PWM device");
+		mavlink_and_console_log_critical(CAL_QGC_FAILED_MSG, "Can't open PWM device");
 		goto Error;
 	}
 
 	/* tell IO/FMU that its ok to disable its safety with the switch */
 	if (px4_ioctl(fd, PWM_SERVO_SET_ARM_OK, 0) != OK) {
-		mavlink_and_console_log_critical(mavlink_fd, CAL_QGC_FAILED_MSG, "Unable to disable safety switch");
-		goto Error;
-	}
-	
-	/* tell IO/FMU that the system is armed (it will output values if safety is off) */
-	if (px4_ioctl(fd, PWM_SERVO_ARM, 0) != OK) {
-		mavlink_and_console_log_critical(mavlink_fd, CAL_QGC_FAILED_MSG, "Unable to arm system");
-		goto Error;
-	}
-	
-	/* tell IO to switch off safety without using the safety switch */
-	if (px4_ioctl(fd, PWM_SERVO_SET_FORCE_SAFETY_OFF, 0) != OK) {
-		mavlink_and_console_log_critical(mavlink_fd, CAL_QGC_FAILED_MSG, "Unable to force safety off");
+		mavlink_and_console_log_critical(CAL_QGC_FAILED_MSG, "Unable to disable safety switch");
 		goto Error;
 	}
 
-	mavlink_and_console_log_info(mavlink_fd, "[cal] Connect battery now");
-	
+	/* tell IO/FMU that the system is armed (it will output values if safety is off) */
+	if (px4_ioctl(fd, PWM_SERVO_ARM, 0) != OK) {
+		mavlink_and_console_log_critical(CAL_QGC_FAILED_MSG, "Unable to arm system");
+		goto Error;
+	}
+
+	/* tell IO to switch off safety without using the safety switch */
+	if (px4_ioctl(fd, PWM_SERVO_SET_FORCE_SAFETY_OFF, 0) != OK) {
+		mavlink_and_console_log_critical(CAL_QGC_FAILED_MSG, "Unable to force safety off");
+		goto Error;
+	}
+
+	mavlink_and_console_log_info("[cal] Connect battery now");
+
 	timeout_start = hrt_absolute_time();
 
 	while (true) {
 		// We are either waiting for the user to connect the battery. Or we are waiting to let the PWM
 		// sit high.
 		hrt_abstime timeout_wait = batt_connected ? pwm_high_timeout : battery_connect_wait_timeout;
-        
+
 		if (hrt_absolute_time() - timeout_start > timeout_wait) {
 			if (!batt_connected) {
-				mavlink_and_console_log_critical(mavlink_fd, CAL_QGC_FAILED_MSG, "Timeout waiting for battery");
+				mavlink_and_console_log_critical(CAL_QGC_FAILED_MSG, "Timeout waiting for battery");
 				goto Error;
 			}
-			
+
 			// PWM was high long enough
 			break;
 		}
-		
+
 		if (!batt_connected) {
 			orb_check(batt_sub, &batt_updated);
 			if (batt_updated) {
@@ -149,7 +149,7 @@ int do_esc_calibration(int mavlink_fd, struct actuator_armed_s* armed)
 					// Battery is connected, signal to user and start waiting again
 					batt_connected = true;
 					timeout_start = hrt_absolute_time();
-					mavlink_and_console_log_info(mavlink_fd, "[cal] Battery connected");
+					mavlink_and_console_log_info("[cal] Battery connected");
 				}
 			}
 		}
@@ -162,24 +162,24 @@ Out:
 	}
 	if (fd != -1) {
 		if (px4_ioctl(fd, PWM_SERVO_SET_FORCE_SAFETY_ON, 0) != OK) {
-			mavlink_and_console_log_info(mavlink_fd, CAL_QGC_WARNING_MSG, "Safety switch still off");
+			mavlink_and_console_log_info(CAL_QGC_WARNING_MSG, "Safety switch still off");
 		}
 		if (px4_ioctl(fd, PWM_SERVO_DISARM, 0) != OK) {
-			mavlink_and_console_log_info(mavlink_fd, CAL_QGC_WARNING_MSG, "Servos still armed");
+			mavlink_and_console_log_info(CAL_QGC_WARNING_MSG, "Servos still armed");
 		}
 		if (px4_ioctl(fd, PWM_SERVO_CLEAR_ARM_OK, 0) != OK) {
-			mavlink_and_console_log_info(mavlink_fd, CAL_QGC_WARNING_MSG, "Safety switch still deactivated");
+			mavlink_and_console_log_info(CAL_QGC_WARNING_MSG, "Safety switch still deactivated");
 		}
 		px4_close(fd);
 	}
 	armed->in_esc_calibration_mode = false;
-	
+
 	if (return_code == OK) {
-		mavlink_and_console_log_info(mavlink_fd, CAL_QGC_DONE_MSG, "esc");
+		mavlink_and_console_log_info(CAL_QGC_DONE_MSG, "esc");
 	}
-	
+
 	return return_code;
-	
+
 Error:
 	return_code = ERROR;
 	goto Out;

--- a/src/modules/commander/esc_calibration.h
+++ b/src/modules/commander/esc_calibration.h
@@ -44,6 +44,6 @@
 
 #include <uORB/topics/actuator_armed.h>
 
-int do_esc_calibration(int mavlink_fd, struct actuator_armed_s* armed);
+int do_esc_calibration(struct actuator_armed_s* armed);
 
 #endif

--- a/src/modules/commander/gyro_calibration.h
+++ b/src/modules/commander/gyro_calibration.h
@@ -41,6 +41,6 @@
 
 #include <stdint.h>
 
-int do_gyro_calibration(int mavlink_fd);
+int do_gyro_calibration();
 
 #endif /* GYRO_CALIBRATION_H_ */

--- a/src/modules/commander/mag_calibration.h
+++ b/src/modules/commander/mag_calibration.h
@@ -41,6 +41,6 @@
 
 #include <stdint.h>
 
-int do_mag_calibration(int mavlink_fd);
+int do_mag_calibration();
 
 #endif /* MAG_CALIBRATION_H_ */

--- a/src/modules/commander/rc_calibration.cpp
+++ b/src/modules/commander/rc_calibration.cpp
@@ -46,7 +46,7 @@
 #include <unistd.h>
 #include <uORB/topics/sensor_combined.h>
 #include <uORB/topics/manual_control_setpoint.h>
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <systemlib/param/param.h>
 #include <systemlib/err.h>
 
@@ -56,7 +56,7 @@
 #endif
 static const int ERROR = -1;
 
-int do_trim_calibration(int mavlink_fd)
+int do_trim_calibration()
 {
 	int sub_man = orb_subscribe(ORB_ID(manual_control_setpoint));
 	usleep(400000);
@@ -65,7 +65,7 @@ int do_trim_calibration(int mavlink_fd)
 	orb_check(sub_man, &changed);
 
 	if (!changed) {
-		mavlink_log_critical(mavlink_fd, "no inputs, aborting");
+		mavlink_log_critical("no inputs, aborting");
 		return ERROR;
 	}
 
@@ -98,12 +98,12 @@ int do_trim_calibration(int mavlink_fd)
 	int save_ret = param_save_default();
 
 	if (save_ret != 0 || p1r != 0 || p2r != 0 || p3r != 0) {
-		mavlink_log_critical(mavlink_fd, "TRIM: PARAM SET FAIL");
+		mavlink_log_critical("TRIM: PARAM SET FAIL");
 		px4_close(sub_man);
 		return ERROR;
 	}
 
-	mavlink_log_info(mavlink_fd, "trim cal done");
+	mavlink_log_info("trim cal done");
 	px4_close(sub_man);
 	return OK;
 }

--- a/src/modules/commander/rc_calibration.h
+++ b/src/modules/commander/rc_calibration.h
@@ -41,6 +41,6 @@
 
 #include <stdint.h>
 
-int do_trim_calibration(int mavlink_fd);
+int do_trim_calibration();
 
 #endif /* RC_CALIBRATION_H_ */

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -58,10 +58,10 @@
 #include <systemlib/systemlib.h>
 #include <systemlib/param/param.h>
 #include <systemlib/err.h>
+#include <systemlib/mavlink_log.h>
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_accel.h>
 #include <drivers/drv_device.h>
-#include <mavlink/mavlink_log.h>
 
 #include "state_machine_helper.h"
 #include "commander_helper.h"
@@ -106,8 +106,7 @@ arming_state_transition(struct vehicle_status_s *status,		///< current vehicle s
 			const struct safety_s   *safety,		///< current safety settings
 			arming_state_t          new_arming_state,	///< arming state requested
 			struct actuator_armed_s *armed,			///< current armed status
-			bool			fRunPreArmChecks,	///< true: run the pre-arm checks, false: no pre-arm checks, for unit testing
-			const int               mavlink_fd)		///< mavlink fd for error reporting, 0 for none
+			bool			fRunPreArmChecks)	///< true: run the pre-arm checks, false: no pre-arm checks, for unit testing
 {
 	// Double check that our static arrays are still valid
 	ASSERT(vehicle_status_s::ARMING_STATE_INIT == 0);
@@ -132,16 +131,16 @@ arming_state_transition(struct vehicle_status_s *status,		///< current vehicle s
 		if (fRunPreArmChecks && new_arming_state == vehicle_status_s::ARMING_STATE_ARMED
 				&& status->hil_state == vehicle_status_s::HIL_STATE_OFF) {
 
-			prearm_ret = preflight_check(status, mavlink_fd, true /* pre-arm */ );
+			prearm_ret = preflight_check(status, true /* pre-arm */ );
 		}
 		/* re-run the pre-flight check as long as sensors are failing */
-		if (!status->condition_system_sensors_initialized 
+		if (!status->condition_system_sensors_initialized
 				&& (new_arming_state == vehicle_status_s::ARMING_STATE_ARMED
 				|| new_arming_state == vehicle_status_s::ARMING_STATE_STANDBY)
 				&& status->hil_state == vehicle_status_s::HIL_STATE_OFF) {
 
 			if (last_preflight_check == 0 || hrt_absolute_time() - last_preflight_check > 1000 * 1000) {
-				prearm_ret = preflight_check(status, mavlink_fd, false /* pre-flight */);
+				prearm_ret = preflight_check(status, false /* pre-flight */);
 				status->condition_system_sensors_initialized = !prearm_ret;
 				last_preflight_check = hrt_absolute_time();
 				last_prearm_ret = prearm_ret;
@@ -193,7 +192,7 @@ arming_state_transition(struct vehicle_status_s *status,		///< current vehicle s
 					// Fail transition if we need safety switch press
 					} else if (safety->safety_switch_available && !safety->safety_off) {
 
-						mavlink_and_console_log_critical(mavlink_fd, "NOT ARMING: Press safety switch first!");
+						mavlink_and_console_log_critical("NOT ARMING: Press safety switch first!");
 						feedback_provided = true;
 						valid_transition = false;
 					}
@@ -204,7 +203,7 @@ arming_state_transition(struct vehicle_status_s *status,		///< current vehicle s
 						// Fail transition if power is not good
 						if (!status->condition_power_input_valid) {
 
-							mavlink_and_console_log_critical(mavlink_fd, "NOT ARMING: Connect power module.");
+							mavlink_and_console_log_critical("NOT ARMING: Connect power module.");
 							feedback_provided = true;
 							valid_transition = false;
 						}
@@ -214,14 +213,14 @@ arming_state_transition(struct vehicle_status_s *status,		///< current vehicle s
 						if (status->condition_power_input_valid && (status->avionics_power_rail_voltage > 0.0f)) {
 							// Check avionics rail voltages
 							if (status->avionics_power_rail_voltage < 4.5f) {
-								mavlink_and_console_log_critical(mavlink_fd, "NOT ARMING: Avionics power low: %6.2f Volt", (double)status->avionics_power_rail_voltage);
+								mavlink_and_console_log_critical("NOT ARMING: Avionics power low: %6.2f Volt", (double)status->avionics_power_rail_voltage);
 								feedback_provided = true;
 								valid_transition = false;
 							} else if (status->avionics_power_rail_voltage < 4.9f) {
-								mavlink_and_console_log_critical(mavlink_fd, "CAUTION: Avionics power low: %6.2f Volt", (double)status->avionics_power_rail_voltage);
+								mavlink_and_console_log_critical("CAUTION: Avionics power low: %6.2f Volt", (double)status->avionics_power_rail_voltage);
 								feedback_provided = true;
 							} else if (status->avionics_power_rail_voltage > 5.4f) {
-								mavlink_and_console_log_critical(mavlink_fd, "CAUTION: Avionics power high: %6.2f Volt", (double)status->avionics_power_rail_voltage);
+								mavlink_and_console_log_critical("CAUTION: Avionics power high: %6.2f Volt", (double)status->avionics_power_rail_voltage);
 								feedback_provided = true;
 							}
 						}
@@ -245,15 +244,15 @@ arming_state_transition(struct vehicle_status_s *status,		///< current vehicle s
 			if (new_arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
 
 				if (status->condition_system_sensors_initialized) {
-					mavlink_and_console_log_critical(mavlink_fd, "Preflight check resolved, reboot before arming");
+					mavlink_and_console_log_critical("Preflight check resolved, reboot before arming");
 				} else {
-					mavlink_and_console_log_critical(mavlink_fd, "Preflight check failed, refusing to arm");
+					mavlink_and_console_log_critical("Preflight check failed, refusing to arm");
 				}
 				feedback_provided = true;
 
 			} else if ((new_arming_state == vehicle_status_s::ARMING_STATE_STANDBY) &&
 					status->condition_system_sensors_initialized) {
-				mavlink_and_console_log_critical(mavlink_fd, "Preflight check resolved, reboot to complete");
+				mavlink_and_console_log_critical("Preflight check resolved, reboot to complete");
 				feedback_provided = true;
 			} else {
 				// Silent ignore
@@ -265,10 +264,10 @@ arming_state_transition(struct vehicle_status_s *status,		///< current vehicle s
 			(new_arming_state == vehicle_status_s::ARMING_STATE_STANDBY) &&
 			(status->arming_state != vehicle_status_s::ARMING_STATE_STANDBY_ERROR) &&
 			(!status->condition_system_sensors_initialized)) {
-			if ((!status->condition_system_prearm_error_reported && 
-			      status->condition_system_hotplug_timeout) || 
+			if ((!status->condition_system_prearm_error_reported &&
+			      status->condition_system_hotplug_timeout) ||
 			     (new_arming_state == vehicle_status_s::ARMING_STATE_ARMED)) {
-				mavlink_and_console_log_critical(mavlink_fd, "Not ready to fly: Sensors need inspection");
+				mavlink_and_console_log_critical("Not ready to fly: Sensors need inspection");
 				status->condition_system_prearm_error_reported = true;
 			}
 			feedback_provided = true;
@@ -299,7 +298,7 @@ arming_state_transition(struct vehicle_status_s *status,		///< current vehicle s
 	if (ret == TRANSITION_DENIED) {
 		/* print to MAVLink and console if we didn't provide any feedback yet */
 		if (!feedback_provided) {
-			mavlink_and_console_log_critical(mavlink_fd, "INVAL: %s - %s", state_names[status->arming_state], state_names[new_arming_state]);
+			mavlink_and_console_log_critical("INVAL: %s - %s", state_names[status->arming_state], state_names[new_arming_state]);
 		}
 	}
 
@@ -397,7 +396,7 @@ main_state_transition(struct vehicle_status_s *status, main_state_t new_main_sta
 /**
  * Transition from one hil state to another
  */
-transition_result_t hil_state_transition(hil_state_t new_state, orb_advert_t status_pub, struct vehicle_status_s *current_status, const int mavlink_fd)
+transition_result_t hil_state_transition(hil_state_t new_state, orb_advert_t status_pub, struct vehicle_status_s *current_status)
 {
 	transition_result_t ret = TRANSITION_DENIED;
 
@@ -408,7 +407,7 @@ transition_result_t hil_state_transition(hil_state_t new_state, orb_advert_t sta
 		switch (new_state) {
 		case vehicle_status_s::HIL_STATE_OFF:
 			/* we're in HIL and unexpected things can happen if we disable HIL now */
-			mavlink_and_console_log_critical(mavlink_fd, "Not switching off HIL (safety)");
+			mavlink_and_console_log_critical("Not switching off HIL (safety)");
 			ret = TRANSITION_DENIED;
 			break;
 
@@ -481,11 +480,11 @@ transition_result_t hil_state_transition(hil_state_t new_state, orb_advert_t sta
 					closedir(d);
 
 					ret = TRANSITION_CHANGED;
-					mavlink_and_console_log_critical(mavlink_fd, "Switched to ON hil state");
+					mavlink_and_console_log_critical("Switched to ON hil state");
 
 				} else {
 					/* failed opening dir */
-					mavlink_log_info(mavlink_fd, "FAILED LISTING DEVICE ROOT DIRECTORY");
+					mavlink_log_info("FAILED LISTING DEVICE ROOT DIRECTORY");
 					ret = TRANSITION_DENIED;
 				}
 
@@ -542,11 +541,11 @@ transition_result_t hil_state_transition(hil_state_t new_state, orb_advert_t sta
 				}
 
 				ret = TRANSITION_CHANGED;
-				mavlink_and_console_log_critical(mavlink_fd, "Switched to ON hil state");
+				mavlink_and_console_log_critical("Switched to ON hil state");
 #endif
 
 			} else {
-				mavlink_and_console_log_critical(mavlink_fd, "Not switching to HIL when armed");
+				mavlink_and_console_log_critical("Not switching to HIL when armed");
 				ret = TRANSITION_DENIED;
 			}
 			break;
@@ -830,13 +829,13 @@ bool set_nav_state(struct vehicle_status_s *status, const bool data_link_loss_en
 	return status->nav_state != nav_state_old;
 }
 
-int preflight_check(struct vehicle_status_s *status, const int mavlink_fd, bool prearm, bool force_report)
+int preflight_check(struct vehicle_status_s *status, bool prearm, bool force_report)
 {
-	/* 
+	/*
 	 */
 	bool reportFailures = force_report || (!status->condition_system_prearm_error_reported &&
 		status->condition_system_hotplug_timeout);
-	
+
 	bool checkAirspeed = false;
 	/* Perform airspeed check only if circuit breaker is not
 	 * engaged and it's not a rotary wing */
@@ -844,19 +843,19 @@ int preflight_check(struct vehicle_status_s *status, const int mavlink_fd, bool 
 		checkAirspeed = true;
 	}
 
-	bool preflight_ok = Commander::preflightCheck(mavlink_fd, true, true, true, true,
+	bool preflight_ok = Commander::preflightCheck(true, true, true, true,
 				checkAirspeed, (status->rc_input_mode == vehicle_status_s::RC_IN_MODE_DEFAULT),
 				!status->circuit_breaker_engaged_gpsfailure_check, true, reportFailures);
-		
+
 	if (!status->cb_usb && status->usb_connected && prearm) {
 		preflight_ok = false;
 		if (reportFailures) {
-			mavlink_and_console_log_critical(mavlink_fd, "NOT ARMING: Flying with USB connected prohibited");
+			mavlink_and_console_log_critical("NOT ARMING: Flying with USB connected prohibited");
 		}
 	}
 
 	/* report once, then set the flag */
-	if (mavlink_fd >= 0 && reportFailures && !preflight_ok) {
+	if (reportFailures && !preflight_ok) {
 		status->condition_system_prearm_error_reported = true;
 	}
 

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -57,14 +57,14 @@ typedef enum {
 bool is_safe(const struct vehicle_status_s *current_state, const struct safety_s *safety, const struct actuator_armed_s *armed);
 
 transition_result_t arming_state_transition(struct vehicle_status_s *current_state, const struct safety_s *safety,
-		arming_state_t new_arming_state, struct actuator_armed_s *armed, bool fRunPreArmChecks, const int mavlink_fd);
+		arming_state_t new_arming_state, struct actuator_armed_s *armed, bool fRunPreArmChecks);
 
 transition_result_t main_state_transition(struct vehicle_status_s *current_state, main_state_t new_main_state);
 
-transition_result_t hil_state_transition(hil_state_t new_state, orb_advert_t status_pub, struct vehicle_status_s *current_state, const int mavlink_fd);
+transition_result_t hil_state_transition(hil_state_t new_state, orb_advert_t status_pub, struct vehicle_status_s *current_state);
 
 bool set_nav_state(struct vehicle_status_s *status, const bool data_link_loss_enabled, const bool mission_finished, const bool stay_in_failsafe);
 
-int preflight_check(struct vehicle_status_s *status, const int mavlink_fd, bool prearm, bool force_report=false);
+int preflight_check(struct vehicle_status_s *status, bool prearm, bool force_report=false);
 
 #endif /* STATE_MACHINE_HELPER_H_ */

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -60,7 +60,7 @@
 #include <systemlib/systemlib.h>
 #include <mathlib/mathlib.h>
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <platforms/px4_defines.h>
 #include <drivers/drv_hrt.h>
 #include <controllib/uorb/blocks.hpp>

--- a/src/modules/ekf_att_pos_estimator/AttitudePositionEstimatorEKF.h
+++ b/src/modules/ekf_att_pos_estimator/AttitudePositionEstimatorEKF.h
@@ -229,8 +229,6 @@ private:
     bool            _newDataMag;
     bool            _newRangeData;
 
-    int             _mavlink_fd;
-
     control::BlockParamFloat _mag_offset_x;
     control::BlockParamFloat _mag_offset_y;
     control::BlockParamFloat _mag_offset_z;
@@ -356,7 +354,7 @@ private:
     *   Runs the sensor fusion step of the filter. The parameters determine which of the sensors
     *   are fused with each other
     **/
-    void updateSensorFusion(const bool fuseGPS, const bool fuseMag, const bool fuseRangeSensor, 
+    void updateSensorFusion(const bool fuseGPS, const bool fuseMag, const bool fuseRangeSensor,
             const bool fuseBaro, const bool fuseAirSpeed);
 
     /**

--- a/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
+++ b/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
@@ -63,9 +63,9 @@
 #include <systemlib/param/param.h>
 #include <systemlib/err.h>
 #include <systemlib/systemlib.h>
+#include <systemlib/mavlink_log.h>
 #include <mathlib/mathlib.h>
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
-#include <mavlink/mavlink_log.h>
 #include <platforms/px4_defines.h>
 
 static uint64_t IMUusec = 0;
@@ -213,7 +213,6 @@ AttitudePositionEstimatorEKF::AttitudePositionEstimatorEKF() :
 	_newDataMag(false),
 	_newRangeData(false),
 
-	_mavlink_fd(-1),
 	_mag_offset_x(this, "MAGB_X"),
 	_mag_offset_y(this, "MAGB_Y"),
 	_mag_offset_z(this, "MAGB_Z"),
@@ -405,7 +404,7 @@ int AttitudePositionEstimatorEKF::check_filter_state()
 		// Do not warn about accel offset if we have no position updates
 		if (!(warn_index == 5 && _ekf->staticMode)) {
 			PX4_WARN("reset: %s", feedback[warn_index]);
-			mavlink_log_critical(_mavlink_fd, "[ekf check] %s", feedback[warn_index]);
+			mavlink_log_critical("[ekf check] %s", feedback[warn_index]);
 		}
 	}
 
@@ -511,8 +510,6 @@ void AttitudePositionEstimatorEKF::task_main_trampoline(int argc, char *argv[])
 
 void AttitudePositionEstimatorEKF::task_main()
 {
-	_mavlink_fd = px4_open(MAVLINK_LOG_DEVICE, 0);
-
 	_ekf = new AttPosEKF();
 
 	if (!_ekf) {
@@ -769,7 +766,7 @@ void AttitudePositionEstimatorEKF::initReferencePosition(hrt_abstime timestamp,
 		_local_pos.ref_timestamp = timestamp;
 
 		map_projection_init(&_pos_ref, lat, lon);
-		mavlink_and_console_log_info(_mavlink_fd, "[ekf] ref: LA %.4f,LO %.4f,ALT %.2f", lat, lon, (double)gps_alt);
+		mavlink_and_console_log_info("[ekf] ref: LA %.4f,LO %.4f,ALT %.2f", lat, lon, (double)gps_alt);
 	}
 }
 
@@ -1442,7 +1439,7 @@ void AttitudePositionEstimatorEKF::pollData()
 			   _voter_mag.failover_count() > 0)) {
 
 		_failsafe = true;
-		mavlink_and_console_log_emergency(_mavlink_fd, "SENSOR FAILSAFE! RETURN TO LAND IMMEDIATELY");
+		mavlink_and_console_log_emergency("SENSOR FAILSAFE! RETURN TO LAND IMMEDIATELY");
 	}
 
 	if (!_vibration_warning && (_voter_gyro.get_vibration_factor(curr_time) > _vibration_warning_threshold ||
@@ -1454,7 +1451,7 @@ void AttitudePositionEstimatorEKF::pollData()
 
 		} else if (hrt_elapsed_time(&_vibration_warning_timestamp) > 10000000) {
 			_vibration_warning = true;
-			mavlink_and_console_log_critical(_mavlink_fd, "HIGH VIBRATION! g: %d a: %d m: %d",
+			mavlink_and_console_log_critical("HIGH VIBRATION! g: %d a: %d m: %d",
 							 (int)(100 * _voter_gyro.get_vibration_factor(curr_time)),
 							 (int)(100 * _voter_accel.get_vibration_factor(curr_time)),
 							 (int)(100 * _voter_mag.get_vibration_factor(curr_time)));
@@ -1570,7 +1567,7 @@ void AttitudePositionEstimatorEKF::pollData()
 
 			//Stop dead-reckoning mode
 			if (_global_pos.dead_reckoning) {
-				mavlink_log_info(_mavlink_fd, "[ekf] stop dead-reckoning");
+				mavlink_log_info("[ekf] stop dead-reckoning");
 			}
 
 			_global_pos.dead_reckoning = false;
@@ -1637,7 +1634,7 @@ void AttitudePositionEstimatorEKF::pollData()
 	if (dtLastGoodGPS >= POS_RESET_THRESHOLD) {
 
 		if (_global_pos.dead_reckoning) {
-			mavlink_log_info(_mavlink_fd, "[ekf] gave up dead-reckoning after long timeout");
+			mavlink_log_info("[ekf] gave up dead-reckoning after long timeout");
 		}
 
 		_gpsIsGood = false;
@@ -1648,7 +1645,7 @@ void AttitudePositionEstimatorEKF::pollData()
 	else if (dtLastGoodGPS >= 0.5f) {
 		if (_armed.armed) {
 			if (!_global_pos.dead_reckoning) {
-				mavlink_log_info(_mavlink_fd, "[ekf] dead-reckoning enabled");
+				mavlink_log_info("[ekf] dead-reckoning enabled");
 			}
 
 			_global_pos.dead_reckoning = true;

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
@@ -86,11 +86,11 @@
 #include <systemlib/param/param.h>
 #include <systemlib/err.h>
 #include <systemlib/pid/pid.h>
+#include <systemlib/mavlink_log.h>
 #include <geo/geo.h>
 #include <systemlib/perf_counter.h>
 #include <systemlib/systemlib.h>
 #include <mathlib/mathlib.h>
-#include <mavlink/mavlink_log.h>
 #include <launchdetection/LaunchDetector.h>
 #include <ecl/l1/ecl_l1_pos_controller.h>
 #include <external_lgpl/tecs/tecs.h>
@@ -151,8 +151,6 @@ public:
 	bool		task_running() { return _task_running; }
 
 private:
-	int		_mavlink_fd;
-
 	bool		_task_should_exit;		/**< if true, sensor task should exit */
 	bool		_task_running;			/**< if true, task is running in its mainloop */
 
@@ -506,7 +504,6 @@ FixedwingPositionControl	*g_control = nullptr;
 
 FixedwingPositionControl::FixedwingPositionControl() :
 
-	_mavlink_fd(-1),
 	_task_should_exit(false),
 	_task_running(false),
 
@@ -1063,7 +1060,7 @@ float FixedwingPositionControl::get_terrain_altitude_landing(float land_setpoint
 	 * for the whole landing */
 	if (_parameters.land_use_terrain_estimate && global_pos.terrain_alt_valid) {
 		if (!land_useterrain) {
-			mavlink_log_info(_mavlink_fd, "Landing, using terrain estimate");
+			mavlink_log_info("Landing, using terrain estimate");
 			land_useterrain = true;
 		}
 
@@ -1394,7 +1391,7 @@ FixedwingPositionControl::control_position(const math::Vector<2> &current_positi
 						target_bearing = _yaw;
 					}
 
-					mavlink_log_info(_mavlink_fd, "#Landing, heading hold");
+					mavlink_log_info("#Landing, heading hold");
 				}
 
 //					warnx("NORET: %d, target_bearing: %d, yaw: %d", (int)land_noreturn_horizontal, (int)math::degrees(target_bearing), (int)math::degrees(_yaw));
@@ -1500,7 +1497,7 @@ FixedwingPositionControl::control_position(const math::Vector<2> &current_positi
 
 					if (!land_motor_lim) {
 						land_motor_lim  = true;
-						mavlink_log_info(_mavlink_fd, "#Landing, limiting throttle");
+						mavlink_log_info("#Landing, limiting throttle");
 					}
 
 				}
@@ -1528,7 +1525,7 @@ FixedwingPositionControl::control_position(const math::Vector<2> &current_positi
 					// just started with the flaring phase
 					_att_sp.pitch_body = 0.0f;
 					height_flare = _global_pos.alt - terrain_alt;
-					mavlink_log_info(_mavlink_fd, "#Landing, flaring");
+					mavlink_log_info("#Landing, flaring");
 					land_noreturn_vertical = true;
 
 				} else {
@@ -1561,7 +1558,7 @@ FixedwingPositionControl::control_position(const math::Vector<2> &current_positi
 					altitude_desired_rel = landing_slope_alt_rel_desired;
 
 					if (!land_onslope) {
-						mavlink_log_info(_mavlink_fd, "#Landing, on slope");
+						mavlink_log_info("#Landing, on slope");
 						land_onslope = true;
 					}
 
@@ -1596,7 +1593,7 @@ FixedwingPositionControl::control_position(const math::Vector<2> &current_positi
 					 * doesn't matter if it gets reset when takeoff is detected eventually */
 					_takeoff_ground_alt = _global_pos.alt;
 
-					mavlink_log_info(_mavlink_fd, "#Takeoff on runway");
+					mavlink_log_info("#Takeoff on runway");
 				}
 
 				float terrain_alt = get_terrain_altitude_takeoff(_takeoff_ground_alt, _global_pos);
@@ -1606,8 +1603,7 @@ FixedwingPositionControl::control_position(const math::Vector<2> &current_positi
 					_ctrl_state.airspeed,
 					_global_pos.alt - terrain_alt,
 					_global_pos.lat,
-					_global_pos.lon,
-					_mavlink_fd);
+					_global_pos.lon);
 
 				/*
 				 * Update navigation: _runway_takeoff returns the start WP according to mode and phase.
@@ -1659,7 +1655,7 @@ FixedwingPositionControl::control_position(const math::Vector<2> &current_positi
 					static hrt_abstime last_sent = 0;
 
 					if (hrt_absolute_time() - last_sent > 4e6) {
-						mavlink_log_critical(_mavlink_fd, "#Launchdetection running");
+						mavlink_log_critical("#Launchdetection running");
 						last_sent = hrt_absolute_time();
 					}
 
@@ -2119,12 +2115,6 @@ FixedwingPositionControl::task_main()
 		/* only run controller if position changed */
 		if (fds[1].revents & POLLIN) {
 			perf_begin(_loop_perf);
-
-			/* XXX Hack to get mavlink output going */
-			if (_mavlink_fd < 0) {
-				/* try to open the mavlink log device every once in a while */
-				_mavlink_fd = px4_open(MAVLINK_LOG_DEVICE, 0);
-			}
 
 			/* load local copies */
 			orb_copy(ORB_ID(vehicle_global_position), _global_pos_sub, &_global_pos);

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -1,5 +1,5 @@
 #include "BlockLocalPositionEstimator.hpp"
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <fcntl.h>
 #include <systemlib/err.h>
 #include <matrix/math.hpp>
@@ -123,9 +123,6 @@ BlockLocalPositionEstimator::BlockLocalPositionEstimator() :
 	_time_last_sonar(0),
 	_time_last_vision_p(0),
 	_time_last_mocap(0),
-
-	// mavlink log
-	_mavlink_fd(open(MAVLINK_LOG_DEVICE, 0)),
 
 	// initialization flags
 	_baroInitialized(false),
@@ -330,7 +327,7 @@ void BlockLocalPositionEstimator::update()
 			_x(i) = 0;
 		}
 
-		mavlink_log_info(_mavlink_fd, "[lpe] reinit x");
+		mavlink_log_info("[lpe] reinit x");
 		warnx("[lpe] reinit x");
 	}
 
@@ -349,7 +346,7 @@ void BlockLocalPositionEstimator::update()
 	}
 
 	if (reinit_P) {
-		mavlink_log_info(_mavlink_fd, "[lpe] reinit P");
+		mavlink_log_info("[lpe] reinit P");
 		warnx("[lpe] reinit P");
 		initP();
 	}
@@ -445,7 +442,7 @@ void BlockLocalPositionEstimator::checkTimeouts()
 	if (_timeStamp - _time_last_xy > EST_SRC_TIMEOUT) {
 		if (!_xyTimeout) {
 			_xyTimeout = true;
-			mavlink_log_info(_mavlink_fd, "[lpe] xy timeout ");
+			mavlink_log_info("[lpe] xy timeout ");
 			warnx("[lpe] xy timeout ");
 		}
 
@@ -456,7 +453,7 @@ void BlockLocalPositionEstimator::checkTimeouts()
 	if (_timeStamp - _time_last_z > EST_SRC_TIMEOUT) {
 		if (!_zTimeout) {
 			_zTimeout = true;
-			mavlink_log_info(_mavlink_fd, "[lpe] z timeout ");
+			mavlink_log_info("[lpe] z timeout ");
 			warnx("[lpe] z timeout ");
 		}
 
@@ -467,7 +464,7 @@ void BlockLocalPositionEstimator::checkTimeouts()
 	if (_timeStamp - _time_last_tz > EST_SRC_TIMEOUT) {
 		if (!_tzTimeout) {
 			_tzTimeout = true;
-			mavlink_log_info(_mavlink_fd, "[lpe] tz timeout ");
+			mavlink_log_info("[lpe] tz timeout ");
 			warnx("[lpe] tz timeout ");
 		}
 
@@ -478,7 +475,7 @@ void BlockLocalPositionEstimator::checkTimeouts()
 	if (_timeStamp - _time_last_baro > BARO_TIMEOUT) {
 		if (_baroInitialized) {
 			_baroInitialized = false;
-			mavlink_log_info(_mavlink_fd, "[lpe] baro timeout ");
+			mavlink_log_info("[lpe] baro timeout ");
 			warnx("[lpe] baro timeout ");
 		}
 	}
@@ -486,7 +483,7 @@ void BlockLocalPositionEstimator::checkTimeouts()
 	if (_timeStamp - _time_last_gps > GPS_TIMEOUT) {
 		if (_gpsInitialized) {
 			_gpsInitialized = false;
-			mavlink_log_info(_mavlink_fd, "[lpe] GPS timeout ");
+			mavlink_log_info("[lpe] GPS timeout ");
 			warnx("[lpe] GPS timeout ");
 		}
 	}
@@ -494,7 +491,7 @@ void BlockLocalPositionEstimator::checkTimeouts()
 	if (_timeStamp - _time_last_flow > FLOW_TIMEOUT) {
 		if (_flowInitialized) {
 			_flowInitialized = false;
-			mavlink_log_info(_mavlink_fd, "[lpe] flow timeout ");
+			mavlink_log_info("[lpe] flow timeout ");
 			warnx("[lpe] flow timeout ");
 		}
 	}
@@ -502,7 +499,7 @@ void BlockLocalPositionEstimator::checkTimeouts()
 	if (_timeStamp - _time_last_sonar > RANGER_TIMEOUT) {
 		if (_sonarInitialized) {
 			_sonarInitialized = false;
-			mavlink_log_info(_mavlink_fd, "[lpe] sonar timeout ");
+			mavlink_log_info("[lpe] sonar timeout ");
 			warnx("[lpe] sonar timeout ");
 		}
 	}
@@ -510,7 +507,7 @@ void BlockLocalPositionEstimator::checkTimeouts()
 	if (_timeStamp - _time_last_lidar > RANGER_TIMEOUT) {
 		if (_lidarInitialized) {
 			_lidarInitialized = false;
-			mavlink_log_info(_mavlink_fd, "[lpe] lidar timeout ");
+			mavlink_log_info("[lpe] lidar timeout ");
 			warnx("[lpe] lidar timeout ");
 		}
 	}
@@ -518,7 +515,7 @@ void BlockLocalPositionEstimator::checkTimeouts()
 	if (_timeStamp - _time_last_vision_p > VISION_TIMEOUT) {
 		if (_visionInitialized) {
 			_visionInitialized = false;
-			mavlink_log_info(_mavlink_fd, "[lpe] vision position timeout ");
+			mavlink_log_info("[lpe] vision position timeout ");
 			warnx("[lpe] vision position timeout ");
 		}
 	}
@@ -526,7 +523,7 @@ void BlockLocalPositionEstimator::checkTimeouts()
 	if (_timeStamp - _time_last_mocap > MOCAP_TIMEOUT) {
 		if (_mocapInitialized) {
 			_mocapInitialized = false;
-			mavlink_log_info(_mavlink_fd, "[lpe] mocap timeout ");
+			mavlink_log_info("[lpe] mocap timeout ");
 			warnx("[lpe] mocap timeout ");
 		}
 	}
@@ -543,7 +540,7 @@ void BlockLocalPositionEstimator::updateHome()
 	// to reset by resetting covariance
 	initP();
 
-	mavlink_log_info(_mavlink_fd, "[lpe] home: lat %5.0f, lon %5.0f, alt %5.0f", lat, lon, double(alt));
+	mavlink_log_info("[lpe] home: lat %5.0f, lon %5.0f, alt %5.0f", lat, lon, double(alt));
 	warnx("[lpe] home: lat %5.0f, lon %5.0f, alt %5.0f", lat, lon, double(alt));
 	map_projection_init(&_map_ref, lat, lon);
 	float delta_alt = alt - _altHome;
@@ -563,8 +560,7 @@ void BlockLocalPositionEstimator::initBaro()
 
 	if (_baroStats.getCount() > REQ_BARO_INIT_COUNT) {
 		_baroAltHome = _baroStats.getMean()(0);
-		mavlink_log_info(_mavlink_fd,
-				 "[lpe] baro offs: %d m stddev %d cm",
+		mavlink_log_info("[lpe] baro offs: %d m stddev %d cm",
 				 (int)_baroStats.getMean()(0),
 				 (int)(100 * _baroStats.getStdDev()(0)));
 		warnx("[lpe] baro offs: %d m stddev %d cm",
@@ -608,7 +604,7 @@ void BlockLocalPositionEstimator::initGps()
 		_gpsAltHome = _gpsStats.getMean()(2);
 		map_projection_init(&_map_ref,
 				    _gpsLatHome, _gpsLonHome);
-		mavlink_log_info(_mavlink_fd, "[lpe] gps init: "
+		mavlink_log_info("[lpe] gps init: "
 				 "lat %d, lon %d, alt %d m",
 				 int(_gpsLatHome),
 				 int(_gpsLonHome),
@@ -654,7 +650,7 @@ void BlockLocalPositionEstimator::initLidar()
 		}
 
 		// not, might want to hard code this to zero
-		mavlink_log_info(_mavlink_fd, "[lpe] lidar init: "
+		mavlink_log_info("[lpe] lidar init: "
 				 "mean %d cm, stddev %d cm",
 				 int(100 * _lidarStats.getMean()(0)),
 				 int(100 * _lidarStats.getStdDev()(0)));
@@ -694,7 +690,7 @@ void BlockLocalPositionEstimator::initSonar()
 		}
 
 		// not, might want to hard code this to zero
-		mavlink_log_info(_mavlink_fd, "[lpe] sonar init: "
+		mavlink_log_info("[lpe] sonar init: "
 				 "mean %d cm, stddev %d cm",
 				 int(100 * _sonarStats.getMean()(0)),
 				 int(100 * _sonarStats.getStdDev()(0)));
@@ -721,7 +717,7 @@ void BlockLocalPositionEstimator::initFlow()
 	_time_last_flow = _timeStamp;
 
 	if (_flowQStats.getCount() > REQ_FLOW_INIT_COUNT) {
-		mavlink_log_info(_mavlink_fd, "[lpe] flow init: "
+		mavlink_log_info("[lpe] flow init: "
 				 "quality %d stddev %d",
 				 int(_flowQStats.getMean()(0)),
 				 int(_flowQStats.getStdDev()(0)));
@@ -748,7 +744,7 @@ void BlockLocalPositionEstimator::initVision()
 
 	if (_visionStats.getCount() > REQ_VISION_INIT_COUNT) {
 		_visionHome = _visionStats.getMean();
-		mavlink_log_info(_mavlink_fd, "[lpe] vision position init: "
+		mavlink_log_info("[lpe] vision position init: "
 				 "%f, %f, %f m std dev. %f, %f, %f m",
 				 double(_visionStats.getMean()(0)),
 				 double(_visionStats.getMean()(1)),
@@ -788,7 +784,7 @@ void BlockLocalPositionEstimator::initMocap()
 
 	if (_mocapStats.getCount() > REQ_MOCAP_INIT_COUNT) {
 		_mocapHome = _mocapStats.getMean();
-		mavlink_log_info(_mavlink_fd, "[lpe] mocap position init: "
+		mavlink_log_info("[lpe] mocap position init: "
 				 "%f, %f, %f m std dev. %f, %f, %f m",
 				 double(_mocapStats.getMean()(0)),
 				 double(_mocapStats.getMean()(1)),
@@ -1048,7 +1044,7 @@ void BlockLocalPositionEstimator::correctFlow()
 
 	if (qual < _flow_min_q.get()) {
 		if (_flowFault < FAULT_SEVERE) {
-			mavlink_log_info(_mavlink_fd, "[lpe] low flow quality %d", int(qual));
+			mavlink_log_info("[lpe] low flow quality %d", int(qual));
 			warnx("[lpe] low flow quality %d", int(qual));
 			_flowFault = FAULT_SEVERE;
 		}
@@ -1073,7 +1069,7 @@ void BlockLocalPositionEstimator::correctFlow()
 	} else {
 		// no valid distance sensor, so return
 		if (_flowFault < FAULT_SEVERE) {
-			mavlink_log_info(_mavlink_fd, "[lpe] no distance for flow");
+			mavlink_log_info("[lpe] no distance for flow");
 			warnx("[lpe] no distance for flow");
 			_flowFault = FAULT_SEVERE;
 		}
@@ -1151,14 +1147,14 @@ void BlockLocalPositionEstimator::correctFlow()
 
 	if (beta > BETA_TABLE[n_y_flow]) {
 		if (_flowFault < FAULT_MINOR) {
-			mavlink_log_info(_mavlink_fd, "[lpe] flow fault,  beta %5.2f", double(beta));
+			mavlink_log_info("[lpe] flow fault,  beta %5.2f", double(beta));
 			warnx("[lpe] flow fault,  beta %5.2f", double(beta));
 			_flowFault = FAULT_MINOR;
 		}
 
 	} else if (_flowFault) {
 		_flowFault = FAULT_NONE;
-		mavlink_log_info(_mavlink_fd, "[lpe] flow OK");
+		mavlink_log_info("[lpe] flow OK");
 		warnx("[lpe] flow OK");
 	}
 
@@ -1187,14 +1183,14 @@ void BlockLocalPositionEstimator::correctSonar()
 	float max_dist = _sub_sonar->get().max_distance - eps;
 
 	if (d < min_dist) {
-		//mavlink_log_info(_mavlink_fd, "[lpe] sonar min dist");
+		//mavlink_log_info("[lpe] sonar min dist");
 		warnx("[lpe] sonar min dist");
 		// can't correct, so return
 		return;
 
 	} else if (d > max_dist) {
 		if (_sonarFault < FAULT_SEVERE) {
-			mavlink_log_info(_mavlink_fd, "[lpe] sonar max distance");
+			mavlink_log_info("[lpe] sonar max distance");
 			warnx("[lpe] sonar max distance");
 			_sonarFault = FAULT_SEVERE;
 		}
@@ -1247,14 +1243,14 @@ void BlockLocalPositionEstimator::correctSonar()
 
 	if (beta > BETA_TABLE[n_y_sonar]) {
 		if (_sonarFault < FAULT_MINOR) {
-			mavlink_log_info(_mavlink_fd, "[lpe] sonar fault,  beta %5.2f", double(beta));
+			mavlink_log_info("[lpe] sonar fault,  beta %5.2f", double(beta));
 			warnx("[lpe] sonar fault,  beta %5.2f", double(beta));
 			_sonarFault = FAULT_MINOR;
 		}
 
 	} else if (_sonarFault) {
 		_sonarFault = FAULT_NONE;
-		mavlink_log_info(_mavlink_fd, "[lpe] sonar OK");
+		mavlink_log_info("[lpe] sonar OK");
 		warnx("[lpe] sonar OK");
 	}
 
@@ -1303,7 +1299,7 @@ void BlockLocalPositionEstimator::correctBaro()
 
 	if (beta > BETA_TABLE[n_y_baro]) {
 		if (_baroFault < FAULT_MINOR) {
-			mavlink_log_info(_mavlink_fd, "[lpe] baro fault, beta %5.2f", double(beta));
+			mavlink_log_info("[lpe] baro fault, beta %5.2f", double(beta));
 			warnx("[lpe] baro fault, beta %5.2f", double(beta));
 			_baroFault = FAULT_MINOR;
 		}
@@ -1313,7 +1309,7 @@ void BlockLocalPositionEstimator::correctBaro()
 
 	} else if (_baroFault) {
 		_baroFault = FAULT_NONE;
-		mavlink_log_info(_mavlink_fd, "[lpe] baro OK");
+		mavlink_log_info("[lpe] baro OK");
 		warnx("[lpe] baro OK");
 	}
 
@@ -1345,7 +1341,7 @@ void BlockLocalPositionEstimator::correctLidar()
 	// if out of range, this is an error
 	if (d < min_dist || d > max_dist) {
 		if (_lidarFault < FAULT_SEVERE) {
-			mavlink_log_info(_mavlink_fd, "[lpe] lidar out of range");
+			mavlink_log_info("[lpe] lidar out of range");
 			warnx("[lpe] lidar out of range");
 			_lidarFault = FAULT_SEVERE;
 		}
@@ -1389,14 +1385,14 @@ void BlockLocalPositionEstimator::correctLidar()
 
 	if (beta > BETA_TABLE[n_y_lidar]) {
 		if (_lidarFault < FAULT_MINOR) {
-			mavlink_log_info(_mavlink_fd, "[lpe] lidar fault, beta %5.2f", double(beta));
+			mavlink_log_info("[lpe] lidar fault, beta %5.2f", double(beta));
 			warnx("[lpe] lidar fault, beta %5.2f", double(beta));
 			_lidarFault = FAULT_MINOR;
 		}
 
 	} else if (_lidarFault) { // disable fault if ok
 		_lidarFault = FAULT_NONE;
-		mavlink_log_info(_mavlink_fd, "[lpe] lidar OK");
+		mavlink_log_info("[lpe] lidar OK");
 		warnx("[lpe] lidar OK");
 	}
 
@@ -1425,7 +1421,7 @@ void BlockLocalPositionEstimator::correctGps()
 
 	if (nSat < 6 || eph > _gps_eph_max.get()) {
 		if (!_gpsFault) {
-			mavlink_log_info(_mavlink_fd, "[lpe] gps fault nSat: %d eph: %5.2f", nSat, double(eph));
+			mavlink_log_info("[lpe] gps fault nSat: %d eph: %5.2f", nSat, double(eph));
 			warnx("[lpe] gps fault nSat: %d eph: %5.2f", nSat, double(eph));
 			_gpsFault = FAULT_SEVERE;
 		}
@@ -1511,12 +1507,12 @@ void BlockLocalPositionEstimator::correctGps()
 
 	if (beta > BETA_TABLE[n_y_gps]) {
 		if (!_gpsFault) {
-			mavlink_log_info(_mavlink_fd, "[lpe] gps fault, beta: %5.2f", double(beta));
+			mavlink_log_info("[lpe] gps fault, beta: %5.2f", double(beta));
 			warnx("[lpe] gps fault, beta: %5.2f", double(beta));
-			mavlink_log_info(_mavlink_fd, "[lpe] r: %5.2f %5.2f %5.2f %5.2f %5.2f %5.2f",
+			mavlink_log_info("[lpe] r: %5.2f %5.2f %5.2f %5.2f %5.2f %5.2f",
 					 double(r(0)),  double(r(1)), double(r(2)),
 					 double(r(3)), double(r(4)), double(r(5)));
-			mavlink_log_info(_mavlink_fd, "[lpe] S_I: %5.2f %5.2f %5.2f %5.2f %5.2f %5.2f",
+			mavlink_log_info("[lpe] S_I: %5.2f %5.2f %5.2f %5.2f %5.2f %5.2f",
 					 double(S_I(0, 0)),  double(S_I(1, 1)), double(S_I(2, 2)),
 					 double(S_I(3, 3)),  double(S_I(4, 4)), double(S_I(5, 5)));
 			warnx("[lpe] r: %5.2f %5.2f %5.2f %5.2f %5.2f %5.2f",
@@ -1530,7 +1526,7 @@ void BlockLocalPositionEstimator::correctGps()
 
 	} else if (_gpsFault) {
 		_gpsFault = FAULT_NONE;
-		mavlink_log_info(_mavlink_fd, "[lpe] GPS OK");
+		mavlink_log_info("[lpe] GPS OK");
 		warnx("[lpe] GPS OK");
 	}
 
@@ -1575,7 +1571,7 @@ void BlockLocalPositionEstimator::correctVision()
 
 	if (beta > BETA_TABLE[n_y_vision]) {
 		if (!_visionFault) {
-			mavlink_log_info(_mavlink_fd, "[lpe] vision position fault, beta %5.2f", double(beta));
+			mavlink_log_info("[lpe] vision position fault, beta %5.2f", double(beta));
 			warnx("[lpe] vision position fault, beta %5.2f", double(beta));
 			_visionFault = FAULT_MINOR;
 		}
@@ -1585,7 +1581,7 @@ void BlockLocalPositionEstimator::correctVision()
 
 	} else if (_visionFault) {
 		_visionFault = FAULT_NONE;
-		mavlink_log_info(_mavlink_fd, "[lpe] vision position OK");
+		mavlink_log_info("[lpe] vision position OK");
 		warnx("[lpe] vision position OK");
 	}
 
@@ -1632,7 +1628,7 @@ void BlockLocalPositionEstimator::correctMocap()
 
 	if (beta > BETA_TABLE[n_y_mocap]) {
 		if (!_mocapFault) {
-			mavlink_log_info(_mavlink_fd, "[lpe] mocap fault, beta %5.2f", double(beta));
+			mavlink_log_info("[lpe] mocap fault, beta %5.2f", double(beta));
 			warnx("[lpe] mocap fault, beta %5.2f", double(beta));
 			_mocapFault = FAULT_MINOR;
 		}
@@ -1642,7 +1638,7 @@ void BlockLocalPositionEstimator::correctMocap()
 
 	} else if (_mocapFault) {
 		_mocapFault = FAULT_NONE;
-		mavlink_log_info(_mavlink_fd, "[lpe] mocap OK");
+		mavlink_log_info("[lpe] mocap OK");
 		warnx("[lpe] mocap OK");
 	}
 

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -276,7 +276,6 @@ private:
 	uint64_t _time_last_sonar;
 	uint64_t _time_last_vision_p;
 	uint64_t _time_last_mocap;
-	int 	 _mavlink_fd;
 
 	// initialization flags
 	bool _baroInitialized;

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -53,7 +53,7 @@
 #include <systemlib/param/param.h>
 #include <systemlib/perf_counter.h>
 #include <pthread.h>
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 
 #include <uORB/uORB.h>
 #include <uORB/topics/mission.h>
@@ -251,8 +251,6 @@ public:
 
 	bool			_task_should_exit;	/**< if true, mavlink task should exit */
 
-	int			get_mavlink_fd() { return _mavlink_fd; }
-
 	/**
 	 * Send a status text with loglevel INFO
 	 *
@@ -362,7 +360,6 @@ protected:
 private:
 	int			_instance_id;
 
-	int			_mavlink_fd;
 	bool			_task_running;
 	static bool		_boot_complete;
 
@@ -513,12 +510,6 @@ private:
 	void update_rate_mult();
 
 	void init_udp();
-
-#ifdef __PX4_NUTTX
-	static int	mavlink_dev_ioctl(struct file *filep, int cmd, unsigned long arg);
-#else
-	virtual int	ioctl(device::file_t *filp, int cmd, unsigned long arg);
-#endif
 
 	/**
 	 * Main mavlink task.

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -75,10 +75,11 @@
 #include <uORB/topics/camera_trigger.h>
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/estimator_status.h>
+#include <uORB/topics/mavlink_log.h>
 #include <drivers/drv_rc_input.h>
 #include <drivers/drv_pwm_output.h>
 #include <systemlib/err.h>
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 
 #include <mathlib/mathlib.h>
 
@@ -355,90 +356,82 @@ public:
 	}
 
 	unsigned get_size() {
-		return mavlink_logbuffer_is_empty(_mavlink->get_logbuffer()) ? 0 : (MAVLINK_MSG_ID_STATUSTEXT_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES);
+		return MAVLINK_MSG_ID_STATUSTEXT_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
 	}
 
 private:
+	MavlinkOrbSubscription *_mavlink_log_sub;
+	uint64_t _mavlink_log_time;
+
 	/* do not allow top copying this class */
 	MavlinkStreamStatustext(MavlinkStreamStatustext &);
 	MavlinkStreamStatustext& operator = (const MavlinkStreamStatustext &);
-	FILE *fp = nullptr;
-	unsigned write_err_count = 0;
-	static const unsigned write_err_threshold = 5;
 
 protected:
-	explicit MavlinkStreamStatustext(Mavlink *mavlink) : MavlinkStream(mavlink)
+	explicit MavlinkStreamStatustext(Mavlink *mavlink) : MavlinkStream(mavlink),
+		_mavlink_log_sub(_mavlink->add_orb_subscription(ORB_ID(mavlink_log)))
 	{}
 
-	~MavlinkStreamStatustext() {
-		if (fp) {
-			fclose(fp);
-		}
-	}
-
-#ifndef __PX4_QURT
 	void send(const hrt_abstime t)
 	{
-		if (!mavlink_logbuffer_is_empty(_mavlink->get_logbuffer())) {
-			struct mavlink_logmessage logmsg;
-			int lb_ret = mavlink_logbuffer_read(_mavlink->get_logbuffer(), &logmsg);
+		struct mavlink_log_s mavlink_log;
 
-			if (lb_ret == OK) {
-				mavlink_statustext_t msg;
+		if (_mavlink_log_sub->update(&_mavlink_log_time, &mavlink_log)) {
 
-				msg.severity = logmsg.severity;
-				strncpy(msg.text, logmsg.text, sizeof(msg.text));
+			mavlink_statustext_t msg;
+			msg.severity = mavlink_log.severity;
 
-				_mavlink->send_message(MAVLINK_MSG_ID_STATUSTEXT, &msg);
+			strncpy(msg.text, (const char*)mavlink_log.text, sizeof(msg.text));
 
-				/* write log messages in first instance to disk */
-				if (_mavlink->get_instance_id() == 0) {
-					if (fp) {
-						if (EOF == fputs(msg.text, fp)) {
-							write_err_count++;
-						} else {
-							write_err_count = 0;
-						}
+		_mavlink->send_message(MAVLINK_MSG_ID_STATUSTEXT, &msg);
 
-						if (write_err_count >= write_err_threshold) {
-							(void)fclose(fp);
-							fp = nullptr;
-						} else {
-							(void)fputs("\n", fp);
-							(void)fsync(fileno(fp));
-						}
+#if 0
+		/* write log messages in first instance to disk */
+		if (_mavlink->get_instance_id() == 0) {
+			if (fp) {
+				if (EOF == fputs(msg.text, fp)) {
+					write_err_count++;
+				} else {
+					write_err_count = 0;
+				}
 
-					} else if (write_err_count < write_err_threshold) {
-						/* string to hold the path to the log */
-						char log_file_name[32] = "";
-						char log_file_path[70] = "";
+				if (write_err_count >= write_err_threshold) {
+					(void)fclose(fp);
+					fp = nullptr;
+				} else {
+					(void)fputs("\n", fp);
+					(void)fsync(fileno(fp));
+				}
 
-						timespec ts;
-						px4_clock_gettime(CLOCK_REALTIME, &ts);
-						/* use GPS time for log file naming, e.g. /fs/microsd/2014-01-19/19_37_52.bin */
-						time_t gps_time_sec = ts.tv_sec + (ts.tv_nsec / 1e9);
-						struct tm tt;
-						gmtime_r(&gps_time_sec, &tt);
+			} else if (write_err_count < write_err_threshold) {
+				/* string to hold the path to the log */
+				char log_file_name[32] = "";
+				char log_file_path[70] = "";
 
-						// XXX we do not want to interfere here with the SD log app
-						strftime(log_file_name, sizeof(log_file_name), "msgs_%Y_%m_%d_%H_%M_%S.txt", &tt);
-						snprintf(log_file_path, sizeof(log_file_path), PX4_ROOTFSDIR"/fs/microsd/%s", log_file_name);
-						fp = fopen(log_file_path, "ab");
+				timespec ts;
+				px4_clock_gettime(CLOCK_REALTIME, &ts);
+				/* use GPS time for log file naming, e.g. /fs/microsd/2014-01-19/19_37_52.bin */
+				time_t gps_time_sec = ts.tv_sec + (ts.tv_nsec / 1e9);
+				struct tm tt;
+				gmtime_r(&gps_time_sec, &tt);
 
-						if (fp != NULL) {
-							/* write first message */
-							fputs(msg.text, fp);
-							fputs("\n", fp);
-						}
-						else {
-							warn("Failed to open %s errno=%d", log_file_path, errno);
-						}
-					}
+				// XXX we do not want to interfere here with the SD log app
+				strftime(log_file_name, sizeof(log_file_name), "msgs_%Y_%m_%d_%H_%M_%S.txt", &tt);
+				snprintf(log_file_path, sizeof(log_file_path), PX4_ROOTFSDIR"/fs/microsd/%s", log_file_name);
+				fp = fopen(log_file_path, "ab");
+
+				if (fp != NULL) {
+					/* write first message */
+					fputs(msg.text, fp);
+					fputs("\n", fp);
+				}
+				else {
+					warn("Failed to open %s errno=%d", log_file_path, errno);
 				}
 			}
+#endif
 		}
 	}
-#endif
 };
 
 class MavlinkStreamCommandLong : public MavlinkStream
@@ -2694,7 +2687,7 @@ protected:
 
 			if (land_detected.landed) {
 				_msg.landed_state = MAV_LANDED_STATE_ON_GROUND;
-			
+
 			} else {
 				_msg.landed_state = MAV_LANDED_STATE_IN_AIR;
 			}

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -75,9 +75,9 @@
 
 #include <systemlib/param/param.h>
 #include <systemlib/systemlib.h>
+#include <systemlib/mavlink_log.h>
 #include <systemlib/err.h>
 #include <systemlib/airspeed.h>
-#include <mavlink/mavlink_log.h>
 #include <commander/px4_custom_mode.h>
 #include <geo/geo.h>
 
@@ -1827,7 +1827,7 @@ MavlinkReceiver::receive_thread(void *arg)
 			struct sockaddr_in * srcaddr_last = _mavlink->get_client_source_address();
 			int localhost = (127 << 24) + 1;
 			if (!_mavlink->get_client_source_initialized()) {
-				
+
 				// set the address either if localhost or if 3 seconds have passed
 				// this ensures that a GCS running on localhost can get a hold of
 				// the system within the first N seconds

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -79,9 +79,9 @@
 #include <uORB/topics/vehicle_local_position_setpoint.h>
 
 #include <systemlib/systemlib.h>
+#include <systemlib/mavlink_log.h>
 #include <mathlib/mathlib.h>
 #include <lib/geo/geo.h>
-#include <mavlink/mavlink_log.h>
 #include <platforms/px4_defines.h>
 
 #include <controllib/blocks.hpp>
@@ -123,7 +123,6 @@ public:
 private:
 	bool		_task_should_exit;		/**< if true, task should exit */
 	int		_control_task;			/**< task handle for task */
-	int		_mavlink_fd;			/**< mavlink fd */
 
 	int		_vehicle_status_sub;		/**< vehicle status subscription */
 	int		_ctrl_state_sub;		/**< control state subscription */
@@ -346,7 +345,6 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	SuperBlock(NULL, "MPC"),
 	_task_should_exit(false),
 	_control_task(-1),
-	_mavlink_fd(-1),
 
 	/* subscriptions */
 	_ctrl_state_sub(-1),
@@ -1126,8 +1124,6 @@ void MulticopterPositionControl::control_auto(float dt)
 void
 MulticopterPositionControl::task_main()
 {
-
-	_mavlink_fd = px4_open(MAVLINK_LOG_DEVICE, 0);
 
 	/*
 	 * do subscriptions
@@ -1941,7 +1937,7 @@ MulticopterPositionControl::task_main()
 				     && !_control_mode.flag_control_climb_rate_enabled;
 	}
 
-	mavlink_log_info(_mavlink_fd, "[mpc] stopped");
+	mavlink_log_info("[mpc] stopped");
 
 	_control_task = -1;
 }

--- a/src/modules/mc_pos_control_multiplatform/mc_pos_control.cpp
+++ b/src/modules/mc_pos_control_multiplatform/mc_pos_control.cpp
@@ -53,7 +53,6 @@ MulticopterPositionControlMultiplatform::MulticopterPositionControlMultiplatform
 
 	_task_should_exit(false),
 	_control_task(-1),
-	_mavlink_fd(-1),
 
 	/* publications */
 	_att_sp_pub(nullptr),
@@ -232,7 +231,7 @@ MulticopterPositionControlMultiplatform::reset_pos_sp()
 				// - _params.vel_ff(1) * _sp_move_rate(1)) / _params.pos_p(1);
 
 		//XXX: port this once a mavlink like interface is available
-		// mavlink_log_info(_mavlink_fd, "[mpc] reset pos sp: %d, %d", (int)_pos_sp(0), (int)_pos_sp(1));
+		// mavlink_log_info("[mpc] reset pos sp: %d, %d", (int)_pos_sp(0), (int)_pos_sp(1));
 		PX4_INFO("[mpc] reset pos sp: %2.3f, %2.3f", (double)_pos_sp(0), (double)_pos_sp(1));
 	}
 }
@@ -249,7 +248,7 @@ MulticopterPositionControlMultiplatform::reset_alt_sp()
 		_att_sp_msg.data().yaw_body = _att->data().yaw;
 
 		//XXX: port this once a mavlink like interface is available
-		// mavlink_log_info(_mavlink_fd, "[mpc] reset alt sp: %d", -(int)_pos_sp(2));
+		// mavlink_log_info("[mpc] reset alt sp: %d", -(int)_pos_sp(2));
 		PX4_INFO("[mpc] reset alt sp: %2.3f", -(double)_pos_sp(2));
 	}
 }

--- a/src/modules/mc_pos_control_multiplatform/mc_pos_control.h
+++ b/src/modules/mc_pos_control_multiplatform/mc_pos_control.h
@@ -84,7 +84,6 @@ protected:
 
 	bool		_task_should_exit;		/**< if true, task should exit */
 	int		_control_task;			/**< task handle for task */
-	int		_mavlink_fd;			/**< mavlink fd */
 
 	Publisher<px4_vehicle_attitude_setpoint>	*_att_sp_pub;			/**< attitude setpoint publication */
 	Publisher<px4_vehicle_local_position_setpoint>	*_local_pos_sp_pub;		/**< vehicle local position setpoint publication */

--- a/src/modules/navigator/datalinkloss.cpp
+++ b/src/modules/navigator/datalinkloss.cpp
@@ -42,7 +42,7 @@
 #include <math.h>
 #include <fcntl.h>
 
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <systemlib/err.h>
 #include <geo/geo.h>
 #include <navigator/navigation.h>
@@ -187,7 +187,7 @@ DataLinkLoss::advance_dll()
 		if (_navigator->get_vstatus()->data_link_lost_counter > _param_numberdatalinklosses.get()) {
 			warnx("%d data link losses, limit is %d, fly to airfield home",
 					_navigator->get_vstatus()->data_link_lost_counter, _param_numberdatalinklosses.get());
-			mavlink_log_critical(_navigator->get_mavlink_fd(), "too many DL losses, fly to airfield home");
+			mavlink_log_critical("too many DL losses, fly to airfield home");
 			_navigator->get_mission_result()->stay_in_failsafe = true;
 			_navigator->set_mission_result_updated();
 			reset_mission_item_reached();
@@ -195,19 +195,19 @@ DataLinkLoss::advance_dll()
 		} else {
 			if (!_param_skipcommshold.get()) {
 				warnx("fly to comms hold, datalink loss counter: %d", _navigator->get_vstatus()->data_link_lost_counter);
-				mavlink_log_critical(_navigator->get_mavlink_fd(), "fly to comms hold");
+				mavlink_log_critical("fly to comms hold");
 				_dll_state = DLL_STATE_FLYTOCOMMSHOLDWP;
 			} else {
 				/* comms hold wp not active, fly to airfield home directly */
 				warnx("Skipping comms hold wp. Flying directly to airfield home");
-				mavlink_log_critical(_navigator->get_mavlink_fd(), "fly to airfield home, comms hold skipped");
+				mavlink_log_critical("fly to airfield home, comms hold skipped");
 				_dll_state = DLL_STATE_FLYTOAIRFIELDHOMEWP;
 			}
 		}
 		break;
 	case DLL_STATE_FLYTOCOMMSHOLDWP:
 		warnx("fly to airfield home");
-			mavlink_log_critical(_navigator->get_mavlink_fd(), "fly to airfield home");
+			mavlink_log_critical("fly to airfield home");
 		_dll_state = DLL_STATE_FLYTOAIRFIELDHOMEWP;
 		_navigator->get_mission_result()->stay_in_failsafe = true;
 		_navigator->set_mission_result_updated();
@@ -216,7 +216,7 @@ DataLinkLoss::advance_dll()
 	case DLL_STATE_FLYTOAIRFIELDHOMEWP:
 		_dll_state = DLL_STATE_TERMINATE;
 		warnx("time is up, state should have been changed manually by now");
-		mavlink_log_critical(_navigator->get_mavlink_fd(), "no manual control, terminating");
+		mavlink_log_critical("no manual control, terminating");
 		_navigator->get_mission_result()->stay_in_failsafe = true;
 		_navigator->set_mission_result_updated();
 		reset_mission_item_reached();

--- a/src/modules/navigator/enginefailure.cpp
+++ b/src/modules/navigator/enginefailure.cpp
@@ -41,7 +41,7 @@
 #include <math.h>
 #include <fcntl.h>
 
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <systemlib/err.h>
 #include <geo/geo.h>
 #include <navigator/navigation.h>
@@ -141,7 +141,7 @@ EngineFailure::advance_ef()
 {
 	switch (_ef_state) {
 	case EF_STATE_NONE:
-		mavlink_log_emergency(_navigator->get_mavlink_fd(), "Engine failure. Loitering down");
+		mavlink_log_emergency("Engine failure. Loitering down");
 		_ef_state = EF_STATE_LOITERDOWN;
 		break;
 	default:

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -44,12 +44,12 @@
 #include <string.h>
 #include <dataman/dataman.h>
 #include <systemlib/err.h>
+#include <systemlib/mavlink_log.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <ctype.h>
 #include <px4_config.h>
 #include <unistd.h>
-#include <mavlink/mavlink_log.h>
 #include <geo/geo.h>
 #include <drivers/drv_hrt.h>
 
@@ -77,8 +77,7 @@ Geofence::Geofence() :
 	_param_counter_threshold(this, "COUNT"),
 	_param_max_hor_distance(this, "MAX_HOR_DIST"),
 	_param_max_ver_distance(this, "MAX_VER_DIST"),
-	_outside_counter(0),
-	_mavlinkFd(-1)
+	_outside_counter(0)
 {
 	/* Load initial params */
 	updateParams();
@@ -145,7 +144,7 @@ bool Geofence::inside(double lat, double lon, float altitude)
 
 				if (max_vertical_distance > 0 && (dist_z > max_vertical_distance)) {
 					if (hrt_elapsed_time(&_last_vertical_range_warning) > GEOFENCE_RANGE_WARNING_LIMIT) {
-						mavlink_and_console_log_critical(_mavlinkFd, "Geofence exceeded max vertical distance by %.1f m",
+						mavlink_and_console_log_critical("Geofence exceeded max vertical distance by %.1f m",
 								     (double)(dist_z - max_vertical_distance));
 						_last_vertical_range_warning = hrt_absolute_time();
 					}
@@ -155,7 +154,7 @@ bool Geofence::inside(double lat, double lon, float altitude)
 
 				if (max_horizontal_distance > 0 && (dist_xy > max_horizontal_distance)) {
 					if (hrt_elapsed_time(&_last_horizontal_range_warning) > GEOFENCE_RANGE_WARNING_LIMIT) {
-						mavlink_and_console_log_critical(_mavlinkFd, "Geofence exceeded max horizontal distance by %.1f m",
+						mavlink_and_console_log_critical("Geofence exceeded max horizontal distance by %.1f m",
 								     (double)(dist_xy - max_horizontal_distance));
 						_last_horizontal_range_warning = hrt_absolute_time();
 					}
@@ -403,12 +402,12 @@ Geofence::loadFromFile(const char *filename)
 	if (gotVertical && pointCounter > 0) {
 		_vertices_count = pointCounter;
 		warnx("Geofence: imported successfully");
-		mavlink_log_info(_mavlinkFd, "Geofence imported");
+		mavlink_log_info("Geofence imported");
 		rc = OK;
 
 	} else {
 		warnx("Geofence: import error");
-		mavlink_log_critical(_mavlinkFd, "Geofence import error");
+		mavlink_log_critical("Geofence import error");
 	}
 
 error:

--- a/src/modules/navigator/gpsfailure.cpp
+++ b/src/modules/navigator/gpsfailure.cpp
@@ -42,7 +42,7 @@
 #include <math.h>
 #include <fcntl.h>
 
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <systemlib/err.h>
 #include <geo/geo.h>
 #include <navigator/navigation.h>
@@ -162,12 +162,12 @@ GpsFailure::advance_gpsf()
 	case GPSF_STATE_NONE:
 		_gpsf_state = GPSF_STATE_LOITER;
 		warnx("gpsf loiter");
-		mavlink_log_critical(_navigator->get_mavlink_fd(), "GPS failed: open loop loiter");
+		mavlink_log_critical("GPS failed: open loop loiter");
 		break;
 	case GPSF_STATE_LOITER:
 		_gpsf_state = GPSF_STATE_TERMINATE;
 		warnx("gpsf terminate");
-		mavlink_log_emergency(_navigator->get_mavlink_fd(), "no gps recovery, termination");
+		mavlink_log_emergency("no gps recovery, termination");
 		warnx("mavlink sent");
 		break;
 	case GPSF_STATE_TERMINATE:

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -44,8 +44,8 @@
 #include <math.h>
 #include <fcntl.h>
 
-#include <mavlink/mavlink_log.h>
 #include <systemlib/err.h>
+#include <systemlib/mavlink_log.h>
 
 #include <uORB/uORB.h>
 #include <uORB/topics/position_setpoint_triplet.h>

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -45,7 +45,7 @@
 #include <math.h>
 #include <fcntl.h>
 
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <systemlib/err.h>
 
 #include <uORB/uORB.h>

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -52,7 +52,7 @@
 #include <drivers/drv_hrt.h>
 
 #include <dataman/dataman.h>
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <systemlib/err.h>
 #include <geo/geo.h>
 #include <lib/mathlib/mathlib.h>
@@ -257,7 +257,7 @@ Mission::update_offboard_mission()
 		 * however warnings are issued to the gcs via mavlink from inside the MissionFeasiblityChecker */
 		dm_item_t dm_current = DM_KEY_WAYPOINTS_OFFBOARD(_offboard_mission.dataman_id);
 
-		failed = !_missionFeasibilityChecker.checkMissionFeasible(_navigator->get_mavlink_fd(), (_navigator->get_vstatus()->is_rotary_wing || _navigator->get_vstatus()->is_vtol),
+		failed = !_missionFeasibilityChecker.checkMissionFeasible((_navigator->get_vstatus()->is_rotary_wing || _navigator->get_vstatus()->is_vtol),
 				dm_current, (size_t) _offboard_mission.count, _navigator->get_geofence(),
 				_navigator->get_home_position()->alt, _navigator->home_position_valid(),
 				_navigator->get_global_position()->lat, _navigator->get_global_position()->lon,
@@ -351,7 +351,7 @@ Mission::set_mission_items()
 	if (_param_onboard_enabled.get() && prepare_mission_items(true, &_mission_item, &mission_item_next_position, &has_next_position_item)) {
 		/* if mission type changed, notify */
 		if (_mission_type != MISSION_TYPE_ONBOARD) {
-			mavlink_log_critical(_navigator->get_mavlink_fd(), "onboard mission now running");
+			mavlink_log_critical("onboard mission now running");
 			user_feedback_done = true;
 		}
 		_mission_type = MISSION_TYPE_ONBOARD;
@@ -360,7 +360,7 @@ Mission::set_mission_items()
 	} else if (prepare_mission_items(false, &_mission_item, &mission_item_next_position, &has_next_position_item)) {
 		/* if mission type changed, notify */
 		if (_mission_type != MISSION_TYPE_OFFBOARD) {
-			mavlink_log_info(_navigator->get_mavlink_fd(), "offboard mission now running");
+			mavlink_log_info("offboard mission now running");
 			user_feedback_done = true;
 		}
 		_mission_type = MISSION_TYPE_OFFBOARD;
@@ -368,7 +368,7 @@ Mission::set_mission_items()
 		/* no mission available or mission finished, switch to loiter */
 		if (_mission_type != MISSION_TYPE_NONE) {
 			/* https://en.wikipedia.org/wiki/Loiter_(aeronautics) */
-			mavlink_log_critical(_navigator->get_mavlink_fd(), "mission finished, loitering");
+			mavlink_log_critical("mission finished, loitering");
 			user_feedback_done = true;
 
 			/* use last setpoint for loiter */
@@ -400,9 +400,9 @@ Mission::set_mission_items()
 			if (_navigator->get_vstatus()->condition_landed) {
 				/* landed, refusing to take off without a mission */
 
-				mavlink_log_critical(_navigator->get_mavlink_fd(), "no valid mission available, refusing takeoff");
+				mavlink_log_critical("no valid mission available, refusing takeoff");
 			} else {
-				mavlink_log_critical(_navigator->get_mavlink_fd(), "no valid mission available, loitering");
+				mavlink_log_critical("no valid mission available, loitering");
 			}
 
 			user_feedback_done = true;
@@ -432,7 +432,7 @@ Mission::set_mission_items()
 
 			float takeoff_alt = calculate_takeoff_altitude(&_mission_item);
 
-			mavlink_log_info(_navigator->get_mavlink_fd(), "takeoff to %.1f meters above home", (double)(takeoff_alt - _navigator->get_home_position()->alt));
+			mavlink_log_info("takeoff to %.1f meters above home", (double)(takeoff_alt - _navigator->get_home_position()->alt));
 
 			_mission_item.nav_cmd = NAV_CMD_TAKEOFF;
 			_mission_item.lat = _navigator->get_global_position()->lat;
@@ -821,7 +821,7 @@ Mission::prepare_mission_items(bool onboard, struct mission_item_s *mission_item
 	int offset = 1;
 
 	if (read_mission_item(onboard, 0, mission_item)) {
-		
+
 		first_res = true;
 
 		/* trying to find next position mission item */
@@ -873,7 +873,7 @@ Mission::read_mission_item(bool onboard, int offset, struct mission_item_s *miss
 		if (*mission_index_ptr < 0 || *mission_index_ptr >= (int)mission->count) {
 			/* mission item index out of bounds - if they are equal, we just reached the end */
 			if (*mission_index_ptr != (int)mission->count) {
-				mavlink_and_console_log_critical(_navigator->get_mavlink_fd(), "[wpm] err: index: %d, max: %d", *mission_index_ptr, (int)mission->count);
+				mavlink_and_console_log_critical("[wpm] err: index: %d, max: %d", *mission_index_ptr, (int)mission->count);
 			}
 			return false;
 		}
@@ -886,8 +886,7 @@ Mission::read_mission_item(bool onboard, int offset, struct mission_item_s *miss
 		/* read mission item from datamanager */
 		if (dm_read(dm_item, *mission_index_ptr, &mission_item_tmp, len) != len) {
 			/* not supposed to happen unless the datamanager can't access the SD card, etc. */
-			mavlink_and_console_log_critical(_navigator->get_mavlink_fd(),
-			                     "ERROR waypoint could not be read");
+			mavlink_and_console_log_critical("ERROR waypoint could not be read");
 			return false;
 		}
 
@@ -906,8 +905,7 @@ Mission::read_mission_item(bool onboard, int offset, struct mission_item_s *miss
 					    &mission_item_tmp, len) != len) {
 						/* not supposed to happen unless the datamanager can't access the
 						 * dataman */
-						mavlink_log_critical(_navigator->get_mavlink_fd(),
-								     "ERROR DO JUMP waypoint could not be written");
+						mavlink_log_critical("ERROR DO JUMP waypoint could not be written");
 						return false;
 					}
 					report_do_jump_mission_changed(*mission_index_ptr,
@@ -919,8 +917,7 @@ Mission::read_mission_item(bool onboard, int offset, struct mission_item_s *miss
 
 			} else {
 				if (offset == 0) {
-					mavlink_log_info(_navigator->get_mavlink_fd(),
-							     "DO JUMP repetitions completed");
+					mavlink_log_info("DO JUMP repetitions completed");
 				}
 				/* no more DO_JUMPS, therefore just try to continue with next mission item */
 				(*mission_index_ptr)++;
@@ -934,8 +931,7 @@ Mission::read_mission_item(bool onboard, int offset, struct mission_item_s *miss
 	}
 
 	/* we have given up, we don't want to cycle forever */
-	mavlink_log_critical(_navigator->get_mavlink_fd(),
-			     "ERROR DO JUMP is cycling, giving up");
+	mavlink_log_critical("ERROR DO JUMP is cycling, giving up");
 	return false;
 }
 
@@ -957,7 +953,7 @@ Mission::save_offboard_mission_state()
 			if (mission_state.current_seq != _current_offboard_mission_index) {
 				if (dm_write(DM_KEY_MISSION_STATE, 0, DM_PERSIST_POWER_ON_RESET, &mission_state, sizeof(mission_s)) != sizeof(mission_s)) {
 					warnx("ERROR: can't save mission state");
-					mavlink_log_critical(_navigator->get_mavlink_fd(), "ERROR: can't save mission state");
+					mavlink_log_critical("ERROR: can't save mission state");
 				}
 			}
 		}
@@ -969,12 +965,12 @@ Mission::save_offboard_mission_state()
 		mission_state.current_seq = _current_offboard_mission_index;
 
 		warnx("ERROR: invalid mission state");
-		mavlink_log_critical(_navigator->get_mavlink_fd(), "ERROR: invalid mission state");
+		mavlink_log_critical("ERROR: invalid mission state");
 
 		/* write modified state only if changed */
 		if (dm_write(DM_KEY_MISSION_STATE, 0, DM_PERSIST_POWER_ON_RESET, &mission_state, sizeof(mission_s)) != sizeof(mission_s)) {
 			warnx("ERROR: can't save mission state");
-			mavlink_log_critical(_navigator->get_mavlink_fd(), "ERROR: can't save mission state");
+			mavlink_log_critical("ERROR: can't save mission state");
 		}
 	}
 
@@ -1027,7 +1023,7 @@ Mission::check_mission_valid()
 
 		dm_item_t dm_current = DM_KEY_WAYPOINTS_OFFBOARD(_offboard_mission.dataman_id);
 
-		_navigator->get_mission_result()->valid = _missionFeasibilityChecker.checkMissionFeasible(_navigator->get_mavlink_fd(), (_navigator->get_vstatus()->is_rotary_wing || _navigator->get_vstatus()->is_vtol),
+		_navigator->get_mission_result()->valid = _missionFeasibilityChecker.checkMissionFeasible((_navigator->get_vstatus()->is_rotary_wing || _navigator->get_vstatus()->is_vtol),
 				dm_current, (size_t) _offboard_mission.count, _navigator->get_geofence(),
 				_navigator->get_home_position()->alt, _navigator->home_position_valid(),
 				_navigator->get_global_position()->lat, _navigator->get_global_position()->lon,

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -49,7 +49,7 @@
 
 #include <systemlib/err.h>
 #include <geo/geo.h>
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <mathlib/mathlib.h>
 
 #include <uORB/uORB.h>
@@ -224,7 +224,7 @@ MissionBlock::is_mission_item_reached()
 			_time_first_inside_orbit = now;
 
 			// if (_mission_item.time_inside > 0.01f) {
-			// 	mavlink_log_critical(_mavlink_fd, "waypoint reached, wait for %.1fs",
+			// 	mavlink_log_critical("waypoint reached, wait for %.1fs",
 			// 		(double)_mission_item.time_inside);
 			// }
 		}
@@ -473,7 +473,7 @@ MissionBlock::set_land_item(struct mission_item_s *item, bool at_current_locatio
 	if (at_current_location) {
 		item->lat = _navigator->get_global_position()->lat;
 		item->lon = _navigator->get_global_position()->lon;
-	
+
 	/* use home position */
 	} else {
 		item->lat = _navigator->get_home_position()->lat;

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -44,7 +44,7 @@
 #include <geo/geo.h>
 #include <math.h>
 #include <mathlib/mathlib.h>
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <fw_pos_control_l1/landingslope.h>
 #include <systemlib/err.h>
 #include <stdio.h>
@@ -53,7 +53,6 @@
 #include <uORB/topics/fence.h>
 
 MissionFeasibilityChecker::MissionFeasibilityChecker() :
-	_mavlink_fd(-1),
 	_capabilities_sub(-1),
 	_initDone(false),
 	_dist_1wp_ok(false)
@@ -62,7 +61,7 @@ MissionFeasibilityChecker::MissionFeasibilityChecker() :
 }
 
 
-bool MissionFeasibilityChecker::checkMissionFeasible(int mavlink_fd, bool isRotarywing,
+bool MissionFeasibilityChecker::checkMissionFeasible(bool isRotarywing,
 	dm_item_t dm_current, size_t nMissionItems, Geofence &geofence,
 	float home_alt, bool home_valid, double curr_lat, double curr_lon, float max_waypoint_distance, bool &warning_issued,
 	float default_acceptance_rad,
@@ -73,13 +72,11 @@ bool MissionFeasibilityChecker::checkMissionFeasible(int mavlink_fd, bool isRota
 	/* Init if not done yet */
 	init();
 
-	_mavlink_fd = mavlink_fd;
-
 	// first check if we have a valid position
 	if (!home_valid /* can later use global / local pos for finer granularity */) {
 		failed = true;
 		warned = true;
-		mavlink_log_info(_mavlink_fd, "Not yet ready for mission, no position lock.");
+		mavlink_log_info("Not yet ready for mission, no position lock.");
 	} else {
 		failed = failed || !check_dist_1wp(dm_current, nMissionItems, curr_lat, curr_lon, max_waypoint_distance, warning_issued);
 	}
@@ -126,7 +123,7 @@ bool MissionFeasibilityChecker::checkMissionFeasibleRotarywing(dm_item_t dm_curr
 			}
 
 			if (takeoff_alt - 1.0f < acceptance_radius) {
-				mavlink_log_critical(_mavlink_fd, "Mission rejected: Takeoff altitude too low!");
+				mavlink_log_critical("Mission rejected: Takeoff altitude too low!");
 				return false;
 			}
 		}
@@ -162,7 +159,7 @@ bool MissionFeasibilityChecker::checkGeofence(dm_item_t dm_current, size_t nMiss
 			}
 
 			if (!geofence.inside_polygon(missionitem.lat, missionitem.lon, missionitem.altitude)) {
-				mavlink_log_critical(_mavlink_fd, "Geofence violation for waypoint %d", i);
+				mavlink_log_critical("Geofence violation for waypoint %d", i);
 				return false;
 			}
 		}
@@ -191,10 +188,10 @@ bool MissionFeasibilityChecker::checkHomePositionAltitude(dm_item_t dm_current, 
 			warning_issued = true;
 
 			if (throw_error) {
-				mavlink_log_critical(_mavlink_fd, "Rejecting mission: No home pos, WP %d uses rel alt", i+1);
+				mavlink_log_critical("Rejecting mission: No home pos, WP %d uses rel alt", i+1);
 				return false;
 			} else	{
-				mavlink_log_critical(_mavlink_fd, "Warning: No home pos, WP %d uses rel alt", i+1);
+				mavlink_log_critical("Warning: No home pos, WP %d uses rel alt", i+1);
 				return true;
 			}
 		}
@@ -207,10 +204,10 @@ bool MissionFeasibilityChecker::checkHomePositionAltitude(dm_item_t dm_current, 
 			warning_issued = true;
 
 			if (throw_error) {
-				mavlink_log_critical(_mavlink_fd, "Rejecting mission: Waypoint %d below home", i+1);
+				mavlink_log_critical("Rejecting mission: Waypoint %d below home", i+1);
 				return false;
 			} else	{
-				mavlink_log_critical(_mavlink_fd, "Warning: Waypoint %d below home", i+1);
+				mavlink_log_critical("Warning: Waypoint %d below home", i+1);
 				return true;
 			}
 		}
@@ -227,7 +224,7 @@ bool MissionFeasibilityChecker::checkMissionItemValidity(dm_item_t dm_current, s
 
 		if (dm_read(dm_current, i, &missionitem, len) != len) {
 			// not supposed to happen unless the datamanager can't access the SD card, etc.
-			mavlink_log_critical(_mavlink_fd, "Rejecting Mission: Cannot access SD card");
+			mavlink_log_critical("Rejecting Mission: Cannot access SD card");
 			return false;
 		}
 
@@ -246,7 +243,7 @@ bool MissionFeasibilityChecker::checkMissionItemValidity(dm_item_t dm_current, s
 			missionitem.nav_cmd != NAV_CMD_DO_SET_CAM_TRIGG_DIST &&
 			missionitem.nav_cmd != NAV_CMD_DO_VTOL_TRANSITION) {
 
-			mavlink_log_critical(_mavlink_fd, "Rejecting mission item %i: unsupported action.", (int)(i+1));
+			mavlink_log_critical("Rejecting mission item %i: unsupported action.", (int)(i+1));
 			return false;
 		}
 
@@ -255,7 +252,7 @@ bool MissionFeasibilityChecker::checkMissionItemValidity(dm_item_t dm_current, s
 			i == 0 &&
 			condition_landed) {
 
-			mavlink_log_critical(_mavlink_fd, "Rejecting mission that starts with LAND command while vehicle is landed.");
+			mavlink_log_critical("Rejecting mission that starts with LAND command while vehicle is landed.");
 			return false;
 		}
 
@@ -304,25 +301,25 @@ bool MissionFeasibilityChecker::checkFixedWingLanding(dm_item_t dm_current, size
 							return true;
 						} else {
 							/* Landing waypoint is above altitude of slope at the given waypoint distance */
-							mavlink_log_critical(_mavlink_fd, "Landing: last waypoint too high/too close");
-							mavlink_log_critical(_mavlink_fd, "Move down to %.1fm or move further away by %.1fm",
+							mavlink_log_critical("Landing: last waypoint too high/too close");
+							mavlink_log_critical("Move down to %.1fm or move further away by %.1fm",
 									(double)(slope_alt_req),
 									(double)(wp_distance_req - wp_distance));
 							return false;
 						}
 					} else {
 						/* Landing waypoint is above last waypoint */
-						mavlink_log_critical(_mavlink_fd, "Landing waypoint above last nav waypoint");
+						mavlink_log_critical("Landing waypoint above last nav waypoint");
 						return false;
 					}
 				} else {
 					/* Last wp is in flare region */
 					//xxx give recommendations
-					mavlink_log_critical(_mavlink_fd, "Warning: Landing: last waypoint in flare region");
+					mavlink_log_critical("Warning: Landing: last waypoint in flare region");
 					return false;
 				}
 			} else {
-				mavlink_log_critical(_mavlink_fd, "Warning: starting with land waypoint");
+				mavlink_log_critical("Warning: starting with land waypoint");
 				return false;
 			}
 		}
@@ -349,13 +346,13 @@ MissionFeasibilityChecker::check_dist_1wp(dm_item_t dm_current, size_t nMissionI
 
 					/* check actuator number */
 					if (mission_item.params[0] < 0 || mission_item.params[0] > 5) {
-						mavlink_log_critical(_mavlink_fd, "Actuator number %d is out of bounds 0..5", (int)mission_item.params[0]);
+						mavlink_log_critical("Actuator number %d is out of bounds 0..5", (int)mission_item.params[0]);
 						warning_issued = true;
 						return false;
 					}
 					/* check actuator value */
 					if (mission_item.params[1] < -2000 || mission_item.params[1] > 2000) {
-						mavlink_log_critical(_mavlink_fd, "Actuator value %d is out of bounds -2000..2000", (int)mission_item.params[1]);
+						mavlink_log_critical("Actuator value %d is out of bounds -2000..2000", (int)mission_item.params[1]);
 						warning_issued = true;
 						return false;
 					}
@@ -371,14 +368,14 @@ MissionFeasibilityChecker::check_dist_1wp(dm_item_t dm_current, size_t nMissionI
 						_dist_1wp_ok = true;
 						if (dist_to_1wp > ((dist_first_wp * 3) / 2)) {
 							/* allow at 2/3 distance, but warn */
-							mavlink_log_critical(_mavlink_fd, "Warning: First waypoint very far: %d m", (int)dist_to_1wp);
+							mavlink_log_critical("Warning: First waypoint very far: %d m", (int)dist_to_1wp);
 							warning_issued = true;
 						}
 						return true;
 
 					} else {
 						/* item is too far from home */
-						mavlink_log_critical(_mavlink_fd, "First waypoint too far: %d m,refusing mission", (int)dist_to_1wp, (int)dist_first_wp);
+						mavlink_log_critical("First waypoint too far: %d m,refusing mission", (int)dist_to_1wp, (int)dist_first_wp);
 						warning_issued = true;
 						return false;
 					}
@@ -386,7 +383,7 @@ MissionFeasibilityChecker::check_dist_1wp(dm_item_t dm_current, size_t nMissionI
 
 			} else {
 				/* error reading, mission is invalid */
-				mavlink_log_info(_mavlink_fd, "error reading offboard mission");
+				mavlink_log_info("error reading offboard mission");
 				return false;
 			}
 		}

--- a/src/modules/navigator/mission_feasibility_checker.h
+++ b/src/modules/navigator/mission_feasibility_checker.h
@@ -52,8 +52,6 @@
 class MissionFeasibilityChecker
 {
 private:
-	int		_mavlink_fd;
-
 	int _capabilities_sub;
 	struct navigation_capabilities_s _nav_caps;
 
@@ -83,7 +81,7 @@ public:
 	/*
 	 * Returns true if mission is feasible and false otherwise
 	 */
-	bool checkMissionFeasible(int mavlink_fd, bool isRotarywing, dm_item_t dm_current,
+	bool checkMissionFeasible(bool isRotarywing, dm_item_t dm_current,
 		size_t nMissionItems, Geofence &geofence, float home_alt, bool home_valid,
 		double curr_lat, double curr_lon, float max_waypoint_distance, bool &warning_issued, float default_acceptance_rad,
 		bool condition_landed);

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -164,7 +164,6 @@ public:
 	 * @return the distance at which the next waypoint should be used
 	 */
 	float		get_acceptance_radius(float mission_item_radius);
-	int		get_mavlink_fd() { return _mavlink_fd; }
 
 	void		increment_mission_instance_count() { _mission_instance_count++; }
 
@@ -174,8 +173,6 @@ private:
 
 	bool		_task_should_exit;		/**< if true, sensor task should exit */
 	int		_navigator_task;		/**< task handle for sensor task */
-
-	int		_mavlink_fd;			/**< the file descriptor to send messages over mavlink */
 
 	int		_global_pos_sub;		/**< global position subscription */
 	int		_gps_pos_sub;		/**< gps position subscription */

--- a/src/modules/navigator/rcloss.cpp
+++ b/src/modules/navigator/rcloss.cpp
@@ -42,7 +42,7 @@
 #include <math.h>
 #include <fcntl.h>
 
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <systemlib/err.h>
 #include <geo/geo.h>
 
@@ -155,11 +155,11 @@ RCLoss::advance_rcl()
 	case RCL_STATE_NONE:
 		if (_param_loitertime.get() > 0.0f) {
 			warnx("RC loss, OBC mode, loiter");
-			mavlink_log_critical(_navigator->get_mavlink_fd(), "rc loss, loitering");
+			mavlink_log_critical("rc loss, loitering");
 			_rcl_state = RCL_STATE_LOITER;
 		} else {
 			warnx("RC loss, OBC mode, slip loiter, terminate");
-			mavlink_log_critical(_navigator->get_mavlink_fd(), "rc loss, terminating");
+			mavlink_log_critical("rc loss, terminating");
 			_rcl_state = RCL_STATE_TERMINATE;
 			_navigator->get_mission_result()->stay_in_failsafe = true;
 			_navigator->set_mission_result_updated();
@@ -169,7 +169,7 @@ RCLoss::advance_rcl()
 	case RCL_STATE_LOITER:
 		_rcl_state = RCL_STATE_TERMINATE;
 		warnx("time is up, no RC regain, terminating");
-		mavlink_log_critical(_navigator->get_mavlink_fd(), "RC not regained, terminating");
+		mavlink_log_critical("RC not regained, terminating");
 		_navigator->get_mission_result()->stay_in_failsafe = true;
 		_navigator->set_mission_result_updated();
 		reset_mission_item_reached();

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -42,7 +42,7 @@
 #include <math.h>
 #include <fcntl.h>
 
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <systemlib/err.h>
 #include <geo/geo.h>
 
@@ -90,7 +90,7 @@ RTL::on_activation()
 		/* for safety reasons don't go into RTL if landed */
 		if (_navigator->get_vstatus()->condition_landed) {
 			_rtl_state = RTL_STATE_LANDED;
-			mavlink_log_critical(_navigator->get_mavlink_fd(), "no RTL when landed");
+			mavlink_log_critical("no RTL when landed");
 
 		/* if lower than return altitude, climb up first */
 		} else if (_navigator->get_global_position()->alt < _navigator->get_home_position()->alt
@@ -153,7 +153,7 @@ RTL::set_rtl_item()
 		_mission_item.autocontinue = true;
 		_mission_item.origin = ORIGIN_ONBOARD;
 
-		mavlink_log_critical(_navigator->get_mavlink_fd(), "RTL: climb to %d m (%d m above home)",
+		mavlink_log_critical("RTL: climb to %d m (%d m above home)",
 			(int)(climb_alt),
 			(int)(climb_alt - _navigator->get_home_position()->alt));
 		break;
@@ -185,7 +185,7 @@ RTL::set_rtl_item()
 		_mission_item.autocontinue = true;
 		_mission_item.origin = ORIGIN_ONBOARD;
 
-		mavlink_log_critical(_navigator->get_mavlink_fd(), "RTL: return at %d m (%d m above home)",
+		mavlink_log_critical("RTL: return at %d m (%d m above home)",
 			(int)(_mission_item.altitude),
 			(int)(_mission_item.altitude - _navigator->get_home_position()->alt));
 
@@ -208,7 +208,7 @@ RTL::set_rtl_item()
 		_mission_item.autocontinue = false;
 		_mission_item.origin = ORIGIN_ONBOARD;
 
-		mavlink_log_critical(_navigator->get_mavlink_fd(), "RTL: descend to %d m (%d m above home)",
+		mavlink_log_critical("RTL: descend to %d m (%d m above home)",
 			(int)(_mission_item.altitude),
 			(int)(_mission_item.altitude - _navigator->get_home_position()->alt));
 		break;
@@ -234,10 +234,10 @@ RTL::set_rtl_item()
 		_navigator->set_can_loiter_at_sp(true);
 
 		if (autoland) {
-			mavlink_log_critical(_navigator->get_mavlink_fd(), "RTL: loiter %.1fs", (double)_mission_item.time_inside);
+			mavlink_log_critical("RTL: loiter %.1fs", (double)_mission_item.time_inside);
 
 		} else {
-			mavlink_log_critical(_navigator->get_mavlink_fd(), "RTL: completed, loiter");
+			mavlink_log_critical("RTL: completed, loiter");
 		}
 		break;
 	}
@@ -245,14 +245,14 @@ RTL::set_rtl_item()
 	case RTL_STATE_LAND: {
 		set_land_item(&_mission_item, false);
 
-		mavlink_log_critical(_navigator->get_mavlink_fd(), "RTL: land at home");
+		mavlink_log_critical("RTL: land at home");
 		break;
 	}
 
 	case RTL_STATE_LANDED: {
 		set_idle_item(&_mission_item);
 
-		mavlink_log_critical(_navigator->get_mavlink_fd(), "RTL: completed, landed");
+		mavlink_log_critical("RTL: completed, landed");
 		break;
 	}
 

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -44,7 +44,7 @@
 #include <math.h>
 #include <fcntl.h>
 
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <systemlib/err.h>
 
 #include <uORB/uORB.h>

--- a/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
@@ -66,9 +66,9 @@
 #include <uORB/topics/att_pos_mocap.h>
 #include <uORB/topics/optical_flow.h>
 #include <uORB/topics/distance_sensor.h>
-#include <mavlink/mavlink_log.h>
 #include <poll.h>
 #include <systemlib/err.h>
+#include <systemlib/mavlink_log.h>
 #include <geo/geo.h>
 #include <systemlib/systemlib.h>
 #include <drivers/drv_hrt.h>
@@ -234,9 +234,6 @@ static void write_debug_log(const char *msg, float dt, float x_est[2], float y_e
  ****************************************************************************/
 int position_estimator_inav_thread_main(int argc, char *argv[])
 {
-	int mavlink_fd;
-	mavlink_fd = px4_open(MAVLINK_LOG_DEVICE, 0);
-
 	float x_est[2] = { 0.0f, 0.0f };	// pos, vel
 	float y_est[2] = { 0.0f, 0.0f };	// pos, vel
 	float z_est[2] = { 0.0f, 0.0f };	// pos, vel
@@ -421,10 +418,10 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 
 		if (ret < 0) {
 			/* poll error */
-			mavlink_log_info(mavlink_fd, "[inav] poll error on init");
+			mavlink_log_info("[inav] poll error on init");
 		} else if (hrt_absolute_time() - baro_wait_for_sample_time > MAX_WAIT_FOR_BARO_SAMPLE) {
 			wait_baro = false;
-			mavlink_log_info(mavlink_fd, "[inav] timed out waiting for a baro sample");
+			mavlink_log_info("[inav] timed out waiting for a baro sample");
 		}
 		else if (ret > 0) {
 			if (fds_init[0].revents & POLLIN) {
@@ -466,7 +463,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 
 		if (ret < 0) {
 			/* poll error */
-			mavlink_log_info(mavlink_fd, "[inav] poll error on init");
+			mavlink_log_info("[inav] poll error on init");
 			continue;
 
 		} else if (ret > 0) {
@@ -549,9 +546,9 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 				orb_copy(ORB_ID(distance_sensor), distance_sensor_sub, &lidar);
 				lidar.current_distance += params.lidar_calibration_offset;
 			}
-			
+
 			if (updated) { //check if altitude estimation for lidar is enabled and new sensor data
-				
+
 				if (params.enable_lidar_alt_est && lidar.current_distance > lidar.min_distance && lidar.current_distance < lidar.max_distance
 			    		&& (PX4_R(att.R, 2, 2) > 0.7f)) {
 
@@ -567,7 +564,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 					if (lidar_first) {
 						lidar_first = false;
 						lidar_offset = dist_ground + z_est[0];
-						mavlink_log_info(mavlink_fd, "[inav] LIDAR: new ground offset");
+						mavlink_log_info("[inav] LIDAR: new ground offset");
 						warnx("[inav] LIDAR: new ground offset");
 					}
 
@@ -764,7 +761,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 						last_vision_z = vision.z;
 
 						warnx("VISION estimate valid");
-						mavlink_log_info(mavlink_fd, "[inav] VISION estimate valid");
+						mavlink_log_info("[inav] VISION estimate valid");
 					}
 
 					/* calculate correction for position */
@@ -818,7 +815,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 						mocap_valid = true;
 
 						warnx("MOCAP data valid");
-						mavlink_log_info(mavlink_fd, "[inav] MOCAP data valid");
+						mavlink_log_info("[inav] MOCAP data valid");
 					}
 
 					/* calculate correction for position */
@@ -842,7 +839,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 				if (gps_valid) {
 					if (gps.eph > max_eph_epv || gps.epv > max_eph_epv || gps.fix_type < 3) {
 						gps_valid = false;
-						mavlink_log_info(mavlink_fd, "[inav] GPS signal lost");
+						mavlink_log_info("[inav] GPS signal lost");
 						warnx("[inav] GPS signal lost");
 					}
 
@@ -850,7 +847,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 					if (gps.eph < max_eph_epv * 0.7f && gps.epv < max_eph_epv * 0.7f && gps.fix_type >= 3) {
 						gps_valid = true;
 						reset_est = true;
-						mavlink_log_info(mavlink_fd, "[inav] GPS signal found");
+						mavlink_log_info("[inav] GPS signal found");
 						warnx("[inav] GPS signal found");
 					}
 				}
@@ -883,7 +880,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 							map_projection_init(&ref, lat, lon);
 							// XXX replace this print
 							warnx("init ref: lat=%.7f, lon=%.7f, alt=%8.4f", (double)lat, (double)lon, (double)alt);
-							mavlink_log_info(mavlink_fd, "[inav] init ref: %.7f, %.7f, %8.4f", (double)lat, (double)lon, (double)alt);
+							mavlink_log_info("[inav] init ref: %.7f, %.7f, %8.4f", (double)lat, (double)lon, (double)alt);
 						}
 					}
 
@@ -945,35 +942,35 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 		if ((flow_valid || lidar_valid) && t > (flow_time + flow_topic_timeout)) {
 			flow_valid = false;
 			warnx("FLOW timeout");
-			mavlink_log_info(mavlink_fd, "[inav] FLOW timeout");
+			mavlink_log_info("[inav] FLOW timeout");
 		}
 
 		/* check for timeout on GPS topic */
 		if (gps_valid && (t > (gps.timestamp_position + gps_topic_timeout))) {
 			gps_valid = false;
 			warnx("GPS timeout");
-			mavlink_log_info(mavlink_fd, "[inav] GPS timeout");
+			mavlink_log_info("[inav] GPS timeout");
 		}
 
 		/* check for timeout on vision topic */
 		if (vision_valid && (t > (vision.timestamp_boot + vision_topic_timeout))) {
 			vision_valid = false;
 			warnx("VISION timeout");
-			mavlink_log_info(mavlink_fd, "[inav] VISION timeout");
+			mavlink_log_info("[inav] VISION timeout");
 		}
 
 		/* check for timeout on mocap topic */
 		if (mocap_valid && (t > (mocap.timestamp_boot + mocap_topic_timeout))) {
 			mocap_valid = false;
 			warnx("MOCAP timeout");
-			mavlink_log_info(mavlink_fd, "[inav] MOCAP timeout");
+			mavlink_log_info("[inav] MOCAP timeout");
 		}
 
 		/* check for lidar measurement timeout */
 		if (lidar_valid && (t > (lidar_time + lidar_timeout))) {
 			lidar_valid = false;
 			warnx("LIDAR timeout");
-			mavlink_log_info(mavlink_fd, "[inav] LIDAR timeout");
+			mavlink_log_info("[inav] LIDAR timeout");
 		}
 
 		float dt = t_prev > 0 ? (t - t_prev) / 1000000.0f : 0.0f;
@@ -1380,7 +1377,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 	}
 
 	warnx("stopped");
-	mavlink_log_info(mavlink_fd, "[inav] stopped");
+	mavlink_log_info("[inav] stopped");
 	thread_running = false;
 	return 0;
 }

--- a/src/modules/systemlib/mavlink_log.c
+++ b/src/modules/systemlib/mavlink_log.c
@@ -44,93 +44,38 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-#include <mavlink/mavlink_log.h>
+#include <uORB/topics/mavlink_log.h>
+#include "mavlink_log.h"
 
-__EXPORT void mavlink_logbuffer_init(struct mavlink_logbuffer *lb, int size)
+
+static orb_advert_t mavlink_log_pub = NULL;
+
+
+__EXPORT void mavlink_vasprintf(int severity, const char *fmt, ...)
 {
-	lb->size  = size;
-	lb->start = 0;
-	lb->count = 0;
-	lb->elems = calloc(lb->size, sizeof(struct mavlink_logmessage));
-}
+	// TODO: add compile check for maxlen
 
-__EXPORT void mavlink_logbuffer_destroy(struct mavlink_logbuffer *lb)
-{
-	lb->size  = 0;
-	lb->start = 0;
-	lb->count = 0;
-	free(lb->elems);
-}
-
-__EXPORT int mavlink_logbuffer_is_full(struct mavlink_logbuffer *lb)
-{
-	return lb->count == (int)lb->size;
-}
-
-__EXPORT int mavlink_logbuffer_is_empty(struct mavlink_logbuffer *lb)
-{
-	return lb->count == 0;
-}
-
-__EXPORT void mavlink_logbuffer_write(struct mavlink_logbuffer *lb, const struct mavlink_logmessage *elem)
-{
-	int end = (lb->start + lb->count) % lb->size;
-	memcpy(&(lb->elems[end]), elem, sizeof(struct mavlink_logmessage));
-
-	if (mavlink_logbuffer_is_full(lb)) {
-		lb->start = (lb->start + 1) % lb->size; /* full, overwrite */
-
-	} else {
-		++lb->count;
-	}
-}
-
-__EXPORT int mavlink_logbuffer_read(struct mavlink_logbuffer *lb, struct mavlink_logmessage *elem)
-{
-	if (!mavlink_logbuffer_is_empty(lb)) {
-		memcpy(elem, &(lb->elems[lb->start]), sizeof(struct mavlink_logmessage));
-		lb->start = (lb->start + 1) % lb->size;
-		--lb->count;
-
-		return 0;
-
-	} else {
-		return 1;
-	}
-}
-
-__EXPORT void mavlink_logbuffer_vasprintf(struct mavlink_logbuffer *lb, int severity, const char *fmt, ...)
-{
 	if (!fmt) {
 		return;
 	}
 
+	struct mavlink_log_s log_msg;
+
+	log_msg.severity = severity;
+
 	va_list ap;
+
 	va_start(ap, fmt);
-	int end = (lb->start + lb->count) % lb->size;
-	lb->elems[end].severity = severity;
-	vsnprintf(lb->elems[end].text, sizeof(lb->elems[end].text), fmt, ap);
+
+	vsnprintf((char *)log_msg.text, sizeof(log_msg.text), fmt, ap);
+
 	va_end(ap);
 
-	/* increase count */
-	if (mavlink_logbuffer_is_full(lb)) {
-		lb->start = (lb->start + 1) % lb->size; /* full, overwrite */
+	if (mavlink_log_pub != NULL) {
+		orb_publish(ORB_ID(mavlink_log), mavlink_log_pub, &log_msg);
 
 	} else {
-		++lb->count;
+		mavlink_log_pub = orb_advertise(ORB_ID(mavlink_log), &log_msg);
 	}
 }
 
-__EXPORT void mavlink_vasprintf(int _fd, int severity, const char *fmt, ...)
-{
-	if (!fmt) {
-		return;
-	}
-
-	va_list ap;
-	va_start(ap, fmt);
-	char text[MAVLINK_LOG_MAXLEN + 1];
-	vsnprintf(text, sizeof(text), fmt, ap);
-	va_end(ap);
-	px4_ioctl(_fd, severity, (unsigned long)&text[0]);
-}

--- a/src/modules/systemlib/mavlink_log.h
+++ b/src/modules/systemlib/mavlink_log.h
@@ -36,16 +36,11 @@
  * MAVLink text logging.
  *
  * @author Lorenz Meier <lorenz@px4.io>
+ * @author Julian Oes <julian@oes.ch>
  */
 
 #ifndef MAVLINK_LOG
 #define MAVLINK_LOG
-
-/*
- * IOCTL interface for sending log messages.
- */
-#include <px4_defines.h>
-#include <sys/ioctl.h>
 
 /**
  * The mavlink log device node; must be opened before messages
@@ -57,14 +52,10 @@
  */
 #define MAVLINK_LOG_MAXLEN			50
 
-#define MAVLINK_IOC_SEND_TEXT_INFO		_PX4_IOC(0x1100, 1)
-#define MAVLINK_IOC_SEND_TEXT_CRITICAL		_PX4_IOC(0x1100, 2)
-#define MAVLINK_IOC_SEND_TEXT_EMERGENCY		_PX4_IOC(0x1100, 3)
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-__EXPORT void mavlink_vasprintf(int _fd, int severity, const char *fmt, ...);
+__EXPORT void mavlink_vasprintf(int severity, const char *fmt, ...);
 #ifdef __cplusplus
 }
 #endif
@@ -79,59 +70,59 @@ __EXPORT void mavlink_vasprintf(int _fd, int severity, const char *fmt, ...);
 /**
  * Send a mavlink emergency message.
  *
- * @param _fd		A file descriptor returned from open(MAVLINK_LOG_DEVICE, 0);
  * @param _text		The text to log;
  */
-#define mavlink_log_emergency(_fd, _text, ...)		mavlink_vasprintf(_fd, MAVLINK_IOC_SEND_TEXT_EMERGENCY, _text, ##__VA_ARGS__);
+#define mavlink_log_emergency(_text, ...)	mavlink_vasprintf(3, _text, ##__VA_ARGS__);
 
 /**
  * Send a mavlink critical message.
  *
- * @param _fd		A file descriptor returned from open(MAVLINK_LOG_DEVICE, 0);
  * @param _text		The text to log;
  */
-#define mavlink_log_critical(_fd, _text, ...)		mavlink_vasprintf(_fd, MAVLINK_IOC_SEND_TEXT_CRITICAL, _text, ##__VA_ARGS__);
+#define mavlink_log_critical(_text, ...)	mavlink_vasprintf(2, _text, ##__VA_ARGS__);
 
 /**
  * Send a mavlink info message.
  *
- * @param _fd		A file descriptor returned from open(MAVLINK_LOG_DEVICE, 0);
  * @param _text		The text to log;
  */
-#define mavlink_log_info(_fd, _text, ...)		mavlink_vasprintf(_fd, MAVLINK_IOC_SEND_TEXT_INFO, _text, ##__VA_ARGS__);
+#define mavlink_log_info(_text, ...)		mavlink_vasprintf(1, _text, ##__VA_ARGS__);
 
 /**
  * Send a mavlink emergency message and print to console.
  *
- * @param _fd		A file descriptor returned from open(MAVLINK_LOG_DEVICE, 0);
  * @param _text		The text to log;
  */
-#define mavlink_and_console_log_emergency(_fd, _text, ...)		do { mavlink_vasprintf(_fd, MAVLINK_IOC_SEND_TEXT_EMERGENCY, _text, ##__VA_ARGS__); \
+#define mavlink_and_console_log_emergency(_text, ...) \
+	do { \
+		mavlink_log_emergency(_text, ##__VA_ARGS__); \
 		PX4_ERR("telem> "); \
 		PX4_ERR(_text, ##__VA_ARGS__); \
-		PX4_ERR("\n"); } while(0);
+	} while(0);
 
 /**
  * Send a mavlink critical message and print to console.
  *
- * @param _fd		A file descriptor returned from open(MAVLINK_LOG_DEVICE, 0);
  * @param _text		The text to log;
  */
-#define mavlink_and_console_log_critical(_fd, _text, ...)		do { mavlink_vasprintf(_fd, MAVLINK_IOC_SEND_TEXT_CRITICAL, _text, ##__VA_ARGS__); \
+#define mavlink_and_console_log_critical(_text, ...) \
+	do { \
+		mavlink_log_critical(_text, ##__VA_ARGS__); \
 		PX4_WARN("telem> "); \
 		PX4_WARN(_text, ##__VA_ARGS__); \
-		PX4_WARN("\n");  } while(0);
+	} while(0);
 
 /**
  * Send a mavlink emergency message and print to console.
  *
- * @param _fd		A file descriptor returned from open(MAVLINK_LOG_DEVICE, 0);
  * @param _text		The text to log;
  */
-#define mavlink_and_console_log_info(_fd, _text, ...)			do { mavlink_vasprintf(_fd, MAVLINK_IOC_SEND_TEXT_INFO, _text, ##__VA_ARGS__); \
+#define mavlink_and_console_log_info(_text, ...)			\
+	do { \
+		mavlink_log_info(_text, ##__VA_ARGS__); \
 		PX4_INFO("telem> "); \
 		PX4_INFO(_text, ##__VA_ARGS__); \
-		PX4_INFO("\n"); } while(0);
+	} while(0);
 
 struct mavlink_logmessage {
 	char text[MAVLINK_LOG_MAXLEN + 1];
@@ -159,6 +150,7 @@ void mavlink_logbuffer_write(struct mavlink_logbuffer *lb, const struct mavlink_
 int mavlink_logbuffer_read(struct mavlink_logbuffer *lb, struct mavlink_logmessage *elem);
 
 void mavlink_logbuffer_vasprintf(struct mavlink_logbuffer *lb, int severity, const char *fmt, ...);
+
 __END_DECLS
 
 #endif

--- a/src/modules/systemlib/rc_check.c
+++ b/src/modules/systemlib/rc_check.c
@@ -47,12 +47,12 @@
 #include <systemlib/err.h>
 #include <systemlib/rc_check.h>
 #include <systemlib/param/param.h>
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 #include <drivers/drv_rc_input.h>
 
 #define RC_INPUT_MAP_UNMAPPED 0
 
-int rc_calibration_check(int mavlink_fd, bool report_fail)
+int rc_calibration_check(bool report_fail)
 {
 
 	char nbuf[20];
@@ -74,7 +74,7 @@ int rc_calibration_check(int mavlink_fd, bool report_fail)
 		param_t map_parm = param_find(rc_map_mandatory[j]);
 
 		if (map_parm == PARAM_INVALID) {
-			if (report_fail) { mavlink_and_console_log_critical(mavlink_fd, "RC ERR: PARAM %s MISSING", rc_map_mandatory[j]); }
+			if (report_fail) { mavlink_and_console_log_critical("RC ERR: PARAM %s MISSING", rc_map_mandatory[j]); }
 
 			/* give system time to flush error message in case there are more */
 			usleep(100000);
@@ -87,7 +87,7 @@ int rc_calibration_check(int mavlink_fd, bool report_fail)
 		param_get(map_parm, &mapping);
 
 		if (mapping > RC_INPUT_MAX_CHANNELS) {
-			if (report_fail) { mavlink_and_console_log_critical(mavlink_fd, "RC ERR: %s >= # CHANS", rc_map_mandatory[j]); }
+			if (report_fail) { mavlink_and_console_log_critical("RC ERR: %s >= # CHANS", rc_map_mandatory[j]); }
 
 			/* give system time to flush error message in case there are more */
 			usleep(100000);
@@ -95,7 +95,7 @@ int rc_calibration_check(int mavlink_fd, bool report_fail)
 		}
 
 		if (mapping == 0) {
-			if (report_fail) { mavlink_and_console_log_critical(mavlink_fd, "RC ERR: Mandatory %s is unmapped", rc_map_mandatory[j]); }
+			if (report_fail) { mavlink_and_console_log_critical("RC ERR: Mandatory %s is unmapped", rc_map_mandatory[j]); }
 
 			/* give system time to flush error message in case there are more */
 			usleep(100000);
@@ -148,7 +148,7 @@ int rc_calibration_check(int mavlink_fd, bool report_fail)
 		if (param_min < RC_INPUT_LOWEST_MIN_US) {
 			count++;
 
-			if (report_fail) { mavlink_and_console_log_critical(mavlink_fd, "RC ERR: RC_%d_MIN < %u", i + 1, RC_INPUT_LOWEST_MIN_US); }
+			if (report_fail) { mavlink_and_console_log_critical("RC ERR: RC_%d_MIN < %u", i + 1, RC_INPUT_LOWEST_MIN_US); }
 
 			/* give system time to flush error message in case there are more */
 			usleep(100000);
@@ -157,7 +157,7 @@ int rc_calibration_check(int mavlink_fd, bool report_fail)
 		if (param_max > RC_INPUT_HIGHEST_MAX_US) {
 			count++;
 
-			if (report_fail) { mavlink_and_console_log_critical(mavlink_fd, "RC ERR: RC_%d_MAX > %u", i + 1, RC_INPUT_HIGHEST_MAX_US); }
+			if (report_fail) { mavlink_and_console_log_critical("RC ERR: RC_%d_MAX > %u", i + 1, RC_INPUT_HIGHEST_MAX_US); }
 
 			/* give system time to flush error message in case there are more */
 			usleep(100000);
@@ -166,7 +166,7 @@ int rc_calibration_check(int mavlink_fd, bool report_fail)
 		if (param_trim < param_min) {
 			count++;
 
-			if (report_fail) { mavlink_and_console_log_critical(mavlink_fd, "RC ERR: RC_%d_TRIM < MIN (%d/%d)", i + 1, (int)param_trim, (int)param_min); }
+			if (report_fail) { mavlink_and_console_log_critical("RC ERR: RC_%d_TRIM < MIN (%d/%d)", i + 1, (int)param_trim, (int)param_min); }
 
 			/* give system time to flush error message in case there are more */
 			usleep(100000);
@@ -175,7 +175,7 @@ int rc_calibration_check(int mavlink_fd, bool report_fail)
 		if (param_trim > param_max) {
 			count++;
 
-			if (report_fail) { mavlink_and_console_log_critical(mavlink_fd, "RC ERR: RC_%d_TRIM > MAX (%d/%d)", i + 1, (int)param_trim, (int)param_max); }
+			if (report_fail) { mavlink_and_console_log_critical("RC ERR: RC_%d_TRIM > MAX (%d/%d)", i + 1, (int)param_trim, (int)param_max); }
 
 			/* give system time to flush error message in case there are more */
 			usleep(100000);
@@ -183,7 +183,7 @@ int rc_calibration_check(int mavlink_fd, bool report_fail)
 
 		/* assert deadzone is sane */
 		if (param_dz > RC_INPUT_MAX_DEADZONE_US) {
-			if (report_fail) { mavlink_and_console_log_critical(mavlink_fd, "RC ERR: RC_%d_DZ > %u", i + 1, RC_INPUT_MAX_DEADZONE_US); }
+			if (report_fail) { mavlink_and_console_log_critical("RC ERR: RC_%d_DZ > %u", i + 1, RC_INPUT_MAX_DEADZONE_US); }
 
 			/* give system time to flush error message in case there are more */
 			usleep(100000);
@@ -201,7 +201,7 @@ int rc_calibration_check(int mavlink_fd, bool report_fail)
 		sleep(2);
 
 		if (report_fail) {
-			mavlink_and_console_log_critical(mavlink_fd, "%d config error%s for %d RC channel%s.",
+			mavlink_and_console_log_critical("%d config error%s for %d RC channel%s.",
 							 total_fail_count,
 							 (total_fail_count > 1) ? "s" : "", channels_failed, (channels_failed > 1) ? "s" : "");
 		}

--- a/src/modules/systemlib/rc_check.h
+++ b/src/modules/systemlib/rc_check.h
@@ -48,6 +48,6 @@ __BEGIN_DECLS
  * @return			0 / OK if RC calibration is ok, index + 1 of the first
  *				channel that failed else (so 1 == first channel failed)
  */
-__EXPORT int	rc_calibration_check(int mavlink_fd, bool report_fail);
+__EXPORT int	rc_calibration_check(bool report_fail);
 
 __END_DECLS

--- a/src/modules/uORB/objects_common.cpp
+++ b/src/modules/uORB/objects_common.cpp
@@ -279,3 +279,6 @@ ORB_DEFINE(ekf2_innovations, struct ekf2_innovations_s);
 
 #include "topics/ekf2_replay.h"
 ORB_DEFINE(ekf2_replay, struct ekf2_replay_s);
+
+#include "topics/mavlink_log.h"
+ORB_DEFINE(mavlink_log, struct mavlink_log_s);

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -47,7 +47,7 @@
  *
  */
 #include "vtol_att_control_main.h"
-#include <mavlink/mavlink_log.h>
+#include <systemlib/mavlink_log.h>
 
 namespace VTOL_att_control
 {
@@ -60,9 +60,6 @@ VtolAttitudeControl *g_control;
 VtolAttitudeControl::VtolAttitudeControl() :
 	_task_should_exit(false),
 	_control_task(-1),
-
-	// mavlink log
-	_mavlink_fd(-1),
 
 	//init subscription handlers
 	_v_att_sub(-1),
@@ -491,7 +488,7 @@ void
 VtolAttitudeControl::abort_front_transition()
 {
 	if(!_abort_front_transition) {
-		mavlink_log_critical(_mavlink_fd, "Front transition timeout occured, aborting");
+		mavlink_log_critical("Front transition timeout occured, aborting");
 		_abort_front_transition = true;
 		_vtol_vehicle_status.vtol_transition_failsafe = true;
 	}
@@ -596,8 +593,6 @@ void VtolAttitudeControl::task_main()
 {
 	fflush(stdout);
 
-	_mavlink_fd = px4_open(MAVLINK_LOG_DEVICE, 0);
-
 	/* do subscriptions */
 	_v_att_sp_sub          = orb_subscribe(ORB_ID(vehicle_attitude_setpoint));
 	_mc_virtual_att_sp_sub = orb_subscribe(ORB_ID(mc_virtual_attitude_setpoint));
@@ -627,9 +622,6 @@ void VtolAttitudeControl::task_main()
 
 	// make sure we start with idle in mc mode
 	_vtol_type->set_idle_mc();
-
-	hrt_abstime mavlink_open_time = 0;
-	const hrt_abstime mavlink_open_interval = 500000;
 
 	/* wakeup source*/
 	px4_pollfd_struct_t fds[3] = {};	/*input_mc, input_fw, parameters*/
@@ -667,13 +659,6 @@ void VtolAttitudeControl::task_main()
 			usleep(100000);
 			continue;
 		}
-
-		if (_mavlink_fd < 0 && hrt_absolute_time() > mavlink_open_time) {
-			/* try to reopen the mavlink log device with specified interval */
-			mavlink_open_time = hrt_abstime() + mavlink_open_interval;
-			_mavlink_fd = px4_open(MAVLINK_LOG_DEVICE, 0);
-		}
-
 
 		if (fds[2].revents & POLLIN) {	//parameters were updated, read them now
 			/* read from param to clear updated flag */

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -140,7 +140,6 @@ private:
 //******************flags & handlers******************************************************
 	bool _task_should_exit;
 	int _control_task;		//task handle for VTOL attitude controller
-	int _mavlink_fd;		// mavlink log device
 
 	/* handlers for subscriptions */
 	int	_v_att_sub;				//vehicle attitude subscription


### PR DESCRIPTION
Since we can't use the ioctl call on Snapdragon, let's move the mavlink_log calls from ioctls to the uORB interface.

This is currently on top of feature_calib_refactor.