### PR TITLE
Enable ekf2 to use optical flow and range finder data

### DIFF
--- a/msg/ekf2_innovations.msg
+++ b/msg/ekf2_innovations.msg
@@ -3,7 +3,9 @@ float32[6] vel_pos_innov  # velocity and position innovations
 float32[3] mag_innov 	# earth magnetic field innovations
 float32 heading_innov 	# heading innovation
 float32[2] flow_innov   # flow innovation
+float32 hagl_innov      # innovation from the terrain estimator for the height above ground level measurement  (m)
 float32[6] vel_pos_innov_var 	# velocity and position innovation variances
 float32[3] mag_innov_var	# earth magnetic field innovation variance
 float32 heading_innov_var 	# heading innovation variance
 float32[2] flow_innov_var	# flow innovation variance
+float32 hagl_innov_var          # innovation variance from the terrain estimator for the height above ground level measurement (m^2)

--- a/msg/ekf2_innovations.msg
+++ b/msg/ekf2_innovations.msg
@@ -2,6 +2,8 @@ uint64 timestamp		# Timestamp in microseconds since boot
 float32[6] vel_pos_innov  # velocity and position innovations
 float32[3] mag_innov 	# earth magnetic field innovations
 float32 heading_innov 	# heading innovation
+float32[2] flow_innov   # flow innovation
 float32[6] vel_pos_innov_var 	# velocity and position innovation variances
 float32[3] mag_innov_var	# earth magnetic field innovation variance
 float32 heading_innov_var 	# heading innovation variance
+float32[2] flow_innov_var	# flow innovation variance

--- a/msg/ekf2_replay.msg
+++ b/msg/ekf2_replay.msg
@@ -1,26 +1,37 @@
-uint64 time_ref 					# ekf2 reference time. This is a timestamp passed to the
-									# estimator which it uses a absolute reference.
-uint64 gyro_integral_dt				# gyro integration period in us
+uint64 time_ref 			# ekf2 reference time. This is a timestamp passed to the
+					# estimator which it uses a absolute reference.
+uint64 gyro_integral_dt			# gyro integration period in us
 uint64 accelerometer_integral_dt 	# accelerometer integration period in us
 uint64 magnetometer_timestamp 		# timestamp of magnetometer measurement in us
-uint64 baro_timestamp 				# timestamp of barometer measurement in us
+uint64 baro_timestamp			# timestamp of barometer measurement in us
+uint64 rng_timestamp			# timestamp of range finder measurement in us
+uint64 flow_timestamp			# timestamp of optical flow measurement in us
 
-float32[3] gyro_integral_rad			# integrated gyro vector in rad
+float32[3] gyro_integral_rad		# integrated gyro vector in rad
 float32[3] accelerometer_integral_m_s  	# integrated accelerometer vector in m/s
 
-float32[3] magnetometer_ga 			# magnetometer measurement vector (body fixed NED) in ga
-float32 baro_alt_meter				# barometer altitude measurement in m
+float32[3] magnetometer_ga 		# magnetometer measurement vector (body fixed NED) in ga
+float32 baro_alt_meter			# barometer altitude measurement in m
 
-uint64 time_usec # timestamp of gps position measurement in us
-uint64 time_usec_vel # timestamp of gps velocity measurement in us
-int32 lat			# Latitude in 1E-7 degrees
-int32 lon			# Longitude in 1E-7 degrees 
-int32 alt			# Altitude in 1E-3 meters above MSL, (millimetres)
+uint64 time_usec			# timestamp of gps position measurement in us
+uint64 time_usec_vel			# timestamp of gps velocity measurement in us
+int32 lat				# Latitude in 1E-7 degrees
+int32 lon				# Longitude in 1E-7 degrees
+int32 alt				# Altitude in 1E-3 meters above MSL, (millimetres)
 uint8 fix_type
-float32 eph			# GPS horizontal position accuracy (metres) 
-float32 epv			# GPS vertical position accuracy (metres)
-float32 vel_m_s			# GPS ground speed, (metres/sec) 
-float32 vel_n_m_s		# GPS North velocity, (metres/sec) 
-float32 vel_e_m_s		# GPS East velocity, (metres/sec)
-float32 vel_d_m_s		# GPS Down velocity, (metres/sec) 
-bool vel_ned_valid		# True if NED velocity is valid 
+float32 eph				# GPS horizontal position accuracy (metres)
+float32 epv				# GPS vertical position accuracy (metres)
+float32 vel_m_s				# GPS ground speed, (metres/sec)
+float32 vel_n_m_s			# GPS North velocity, (metres/sec)
+float32 vel_e_m_s			# GPS East velocity, (metres/sec)
+float32 vel_d_m_s			# GPS Down velocity, (metres/sec)
+bool vel_ned_valid			# True if NED velocity is valid
+
+# range finder measurements
+float32 range_to_ground			# range finder measured range to ground (m)
+
+# optical flow sensor measurements
+float32[2] flow_pixel_integral		# integrated optical flow rate around x and y axes (rad)
+float32[2] flow_gyro_integral		# integrated gyro rate around x and y axes (rad)
+uint32 flow_time_integral		# integration timespan (usec)
+uint8 flow_quality			# Quality of accumulated optical flow data (0 - 255)

--- a/msg/ekf2_replay.msg
+++ b/msg/ekf2_replay.msg
@@ -19,8 +19,10 @@ int32 lat				# Latitude in 1E-7 degrees
 int32 lon				# Longitude in 1E-7 degrees
 int32 alt				# Altitude in 1E-3 meters above MSL, (millimetres)
 uint8 fix_type
+uint8 nsats				# number of GPS satellites used by the receiver
 float32 eph				# GPS horizontal position accuracy (metres)
 float32 epv				# GPS vertical position accuracy (metres)
+float32 sacc				# GPS speed accuracy (metres/sec)
 float32 vel_m_s				# GPS ground speed, (metres/sec)
 float32 vel_n_m_s			# GPS North velocity, (metres/sec)
 float32 vel_e_m_s			# GPS East velocity, (metres/sec)

--- a/src/drivers/px4flow/px4flow.cpp
+++ b/src/drivers/px4flow/px4flow.cpp
@@ -239,17 +239,17 @@ PX4FLOW::init()
 		return ret;
 	}
 
-	_class_instance = register_class_devname(RANGE_FINDER_BASE_DEVICE_PATH);
+	//_class_instance = register_class_devname(RANGE_FINDER_BASE_DEVICE_PATH);
 
 	/* get a publish handle on the range finder topic */
-	struct distance_sensor_s ds_report = {};
+	//struct distance_sensor_s ds_report = {};
 
-	_distance_sensor_topic = orb_advertise_multi(ORB_ID(distance_sensor), &ds_report,
-				 &_orb_class_instance, ORB_PRIO_HIGH);
+	//_distance_sensor_topic = orb_advertise_multi(ORB_ID(distance_sensor), &ds_report,
+	//			 &_orb_class_instance, ORB_PRIO_HIGH);
 
-	if (_distance_sensor_topic == nullptr) {
-		DEVICE_LOG("failed to create distance_sensor object. Did you start uOrb?");
-	}
+	//if (_distance_sensor_topic == nullptr) {
+	//	DEVICE_LOG("failed to create distance_sensor object. Did you start uOrb?");
+	//}
 
 	ret = OK;
 	/* sensor is ok, but we don't really know if it is within range */
@@ -542,18 +542,18 @@ PX4FLOW::collect()
 	}
 
 	/* publish to the distance_sensor topic as well */
-	struct distance_sensor_s distance_report;
+	/*struct distance_sensor_s distance_report;
 	distance_report.timestamp = report.timestamp;
 	distance_report.min_distance = PX4FLOW_MIN_DISTANCE;
 	distance_report.max_distance = PX4FLOW_MAX_DISTANCE;
 	distance_report.current_distance = report.ground_distance_m;
 	distance_report.covariance = 0.0f;
 	distance_report.type = distance_sensor_s::MAV_DISTANCE_SENSOR_ULTRASOUND;
-	/* TODO: the ID needs to be properly set */
-	distance_report.id = 0;
-	distance_report.orientation = 8;
+	*//* TODO: the ID needs to be properly set */
+	//distance_report.id = 0;
+	//distance_report.orientation = 8;
 
-	orb_publish(ORB_ID(distance_sensor), _distance_sensor_topic, &distance_report);
+	//orb_publish(ORB_ID(distance_sensor), _distance_sensor_topic, &distance_report);
 
 	/* post a report to the ring */
 	if (_reports->force(&report)) {

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -186,8 +186,7 @@ private:
 	control::BlockParamFloat *_mag_declination_deg;	// magnetic declination in degrees
 	control::BlockParamFloat *_heading_innov_gate;	// innovation gate for heading innovation test
 	control::BlockParamFloat *_mag_innov_gate;	// innovation gate for magnetometer innovation test
-	control::BlockParamInt
-	*_mag_decl_source;       // bitmasked integer used to control the handling of magnetic declination
+	control::BlockParamInt *_mag_decl_source;       // bitmasked integer used to control the handling of magnetic declination
 	control::BlockParamInt *_mag_fuse_type;         // integer ued to control the type of magnetometer fusion used
 
 	control::BlockParamInt *_gps_check_mask;        // bitmasked integer used to activate the different GPS quality checks
@@ -199,6 +198,22 @@ private:
 	control::BlockParamFloat *_requiredHdrift;      // maximum acceptable horizontal drift speed (m/s)
 	control::BlockParamFloat *_requiredVdrift;      // maximum acceptable vertical drift speed (m/s)
 	control::BlockParamInt *_param_record_replay_msg; // indicates if we want to record ekf2 replay messages
+
+	// measurement source control
+	control::BlockParamInt *_fusion_mode;		// bitmasked integer that selects which of the GPS and optical flow aiding sources will be used
+	control::BlockParamInt *_vdist_sensor_type;	// selects the primary source for height data
+
+	// range finder fusion
+	control::BlockParamFloat *_range_noise;		// observation noise for range finder measurements (m)
+	control::BlockParamFloat *_range_innov_gate;	// range finder fusion innovation consistency gate size (STD)
+	control::BlockParamFloat *_rng_gnd_clearance;	// minimum valid value for range when on ground (m)
+
+	// optical flow fusion
+	control::BlockParamFloat *_flow_noise;		// best quality observation noise for optical flow LOS rate measurements (rad/sec)
+	control::BlockParamFloat *_flow_noise_qual_min;	// worst quality observation noise for optical flow LOS rate measurements (rad/sec)
+	control::BlockParamInt *_flow_qual_min;		// minimum acceptable quality integer from  the flow sensor
+	control::BlockParamFloat *_flow_innov_gate;	// optical flow fusion innovation consistency gate size (STD)
+	control::BlockParamFloat *_flow_rate_max;	// maximum valid optical flow rate (rad/sec)
 
 	int update_subscriptions();
 
@@ -253,7 +268,17 @@ Ekf2::Ekf2():
 	_requiredGDoP(new control::BlockParamFloat(this, "EKF2_REQ_GDOP", false, &_params->req_gdop)),
 	_requiredHdrift(new control::BlockParamFloat(this, "EKF2_REQ_HDRIFT", false, &_params->req_hdrift)),
 	_requiredVdrift(new control::BlockParamFloat(this, "EKF2_REQ_VDRIFT", false, &_params->req_vdrift)),
-	_param_record_replay_msg(new control::BlockParamInt(this, "EKF2_REC_RPL", false, &_publish_replay_mode))
+	_param_record_replay_msg(new control::BlockParamInt(this, "EKF2_REC_RPL", false, &_publish_replay_mode)),
+	_fusion_mode(new control::BlockParamInt(this, "EKF2_AID_MASK", false, &_params->fusion_mode)),
+	_vdist_sensor_type(new control::BlockParamInt(this, "EKF2_HGT_MODE", false, &_params->vdist_sensor_type)),
+	_range_noise(new control::BlockParamFloat(this, "EKF2_RNG_NOISE", false, &_params->range_noise)),
+	_range_innov_gate(new control::BlockParamFloat(this, "EKF2_RNG_GATE", false, &_params->range_innov_gate)),
+	_rng_gnd_clearance(new control::BlockParamFloat(this, "EKF2_MIN_RNG", false, &_params->rng_gnd_clearance)),
+	_flow_noise(new control::BlockParamFloat(this, "EKF2_OF_N_MIN", false, &_params->flow_noise)),
+	_flow_noise_qual_min(new control::BlockParamFloat(this, "EKF2_OF_N_MAX", false, &_params->flow_noise_qual_min)),
+	_flow_qual_min(new control::BlockParamInt(this, "EKF2_OF_QMIN", false, &_params->flow_qual_min)),
+	_flow_innov_gate(new control::BlockParamFloat(this, "EKF2_OF_GATE", false, &_params->flow_innov_gate)),
+	_flow_rate_max(new control::BlockParamFloat(this, "EKF2_OF_RMAX", false, &_params->flow_rate_max))
 {
 
 }

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -612,11 +612,12 @@ void Ekf2::task_main()
 		_ekf->get_vel_pos_innov(&innovations.vel_pos_innov[0]);
 		_ekf->get_mag_innov(&innovations.mag_innov[0]);
 		_ekf->get_heading_innov(&innovations.heading_innov);
+		_ekf->get_flow_innov(&innovations.flow_innov[0]);
 
 		_ekf->get_vel_pos_innov_var(&innovations.vel_pos_innov_var[0]);
 		_ekf->get_mag_innov_var(&innovations.mag_innov_var[0]);
 		_ekf->get_heading_innov_var(&innovations.heading_innov_var);
-
+		_ekf->get_flow_innov_var(&innovations.flow_innov_var[0]);
 		if (_estimator_innovations_pub == nullptr) {
 			_estimator_innovations_pub = orb_advertise(ORB_ID(ekf2_innovations), &innovations);
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -690,16 +690,24 @@ void Ekf2::task_main()
 				replay.time_usec = 0;
 			}
 
-			replay.flow_timestamp = optical_flow.timestamp;
-			replay.range_to_ground = range_finder.current_distance;
+			if (optical_flow_updated) {
+				replay.flow_timestamp = optical_flow.timestamp;
+				replay.flow_pixel_integral[0] = optical_flow.pixel_flow_x_integral;
+				replay.flow_pixel_integral[1] = optical_flow.pixel_flow_y_integral;
+				replay.flow_gyro_integral[0] = optical_flow.gyro_x_rate_integral;
+				replay.flow_gyro_integral[1] = optical_flow.gyro_y_rate_integral;
+				replay.flow_time_integral = optical_flow.integration_timespan;
+				replay.flow_quality = optical_flow.quality;
+			} else {
+				replay.flow_timestamp = 0;
+			}
 
-			replay.rng_timestamp = range_finder.timestamp;
-			replay.flow_pixel_integral[0] = optical_flow.pixel_flow_x_integral;
-			replay.flow_pixel_integral[1] = optical_flow.pixel_flow_y_integral;
-			replay.flow_gyro_integral[0] = optical_flow.gyro_x_rate_integral;
-			replay.flow_gyro_integral[1] = optical_flow.gyro_y_rate_integral;
-			replay.flow_time_integral = optical_flow.integration_timespan;
-			replay.flow_quality = optical_flow.quality;
+			if (range_finder_updated) {
+				replay.rng_timestamp = range_finder.timestamp;
+				replay.range_to_ground = range_finder.current_distance;
+			} else {
+				replay.rng_timestamp = 0;
+			}
 
 			if (_replay_pub == nullptr) {
 				_replay_pub = orb_advertise(ORB_ID(ekf2_replay), &replay);

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -669,19 +669,26 @@ void Ekf2::task_main()
 			memcpy(&replay.accelerometer_integral_m_s[0], &sensors.accelerometer_integral_m_s[0], sizeof(replay.accelerometer_integral_m_s));
 			memcpy(&replay.magnetometer_ga[0], &sensors.magnetometer_ga[0], sizeof(replay.magnetometer_ga));
 			replay.baro_alt_meter = sensors.baro_alt_meter[0];
-			replay.time_usec = gps.timestamp_position;
-			replay.time_usec_vel = gps.timestamp_velocity;
-			replay.lat = gps.lat;
-			replay.lon = gps.lon;
-			replay.alt = gps.alt;
-			replay.fix_type = gps.fix_type;
-			replay.eph = gps.eph;
-			replay.epv = gps.epv;
-			replay.vel_m_s = gps.vel_m_s;
-			replay.vel_n_m_s = gps.vel_n_m_s;
-			replay.vel_e_m_s = gps.vel_e_m_s;
-			replay.vel_d_m_s = gps.vel_d_m_s;
-			replay.vel_ned_valid = gps.vel_ned_valid;
+
+			// only write gps data if we had a gps update.
+			if (gps_updated) {
+				replay.time_usec = gps.timestamp_position;
+				replay.time_usec_vel = gps.timestamp_velocity;
+				replay.lat = gps.lat;
+				replay.lon = gps.lon;
+				replay.alt = gps.alt;
+				replay.fix_type = gps.fix_type;
+				replay.eph = gps.eph;
+				replay.epv = gps.epv;
+				replay.vel_m_s = gps.vel_m_s;
+				replay.vel_n_m_s = gps.vel_n_m_s;
+				replay.vel_e_m_s = gps.vel_e_m_s;
+				replay.vel_d_m_s = gps.vel_d_m_s;
+				replay.vel_ned_valid = gps.vel_ned_valid;
+			} else {
+				// this will tell the logging app not to bother logging any gps replay data
+				replay.time_usec = 0;
+			}
 
 			replay.flow_timestamp = optical_flow.timestamp;
 			replay.range_to_ground = range_finder.current_distance;

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -497,8 +497,12 @@ void Ekf2::task_main()
 
 		// TODO: uORB definition does not define what thes variables are. We have assumed them to be horizontal and vertical 1-std dev accuracy in metres
 		// TODO: Should use sqrt of filter position variances
-		lpos.eph = gps.eph;
-		lpos.epv = gps.epv;
+		// get pos vel state variance
+		Vector3f pos_var, vel_var;
+		_ekf->get_pos_var(pos_var);
+		_ekf->get_vel_var(vel_var);
+		lpos.eph = sqrt(pos_var(0)+pos_var(1));
+		lpos.epv = sqrt(pos_var(2));
 
 		// publish vehicle local position data
 		if (_lpos_pub == nullptr) {
@@ -569,8 +573,8 @@ void Ekf2::task_main()
 
 			global_pos.yaw = euler(2); // Yaw in radians -PI..+PI.
 
-			global_pos.eph = gps.eph; // Standard deviation of position estimate horizontally
-			global_pos.epv = gps.epv; // Standard deviation of position vertically
+			global_pos.eph = sqrt(pos_var(0)+pos_var(1));; // Standard deviation of position estimate horizontally
+			global_pos.epv = sqrt(pos_var(2)); // Standard deviation of position vertically
 
 			// TODO: implement terrain estimator
 			global_pos.terrain_alt = 0.0f; // Terrain altitude in m, WGS84

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -490,10 +490,10 @@ void Ekf2::task_main()
 		// The rotation of the tangent plane vs. geographical north
 		lpos.yaw = 0.0f;
 
-		lpos.dist_bottom = 0.0f; // Distance to bottom surface (ground) in meters
-		lpos.dist_bottom_rate = 0.0f; // Distance to bottom surface (ground) change rate
-		lpos.surface_bottom_timestamp	= 0; // Time when new bottom surface found
-		lpos.dist_bottom_valid = false; // true if distance to bottom surface is valid
+		lpos.dist_bottom = -pos[2] + lpos.ref_alt; // Distance to bottom surface (ground) in meters
+		lpos.dist_bottom_rate = -vel[2]; // Distance to bottom surface (ground) change rate
+		lpos.surface_bottom_timestamp	= hrt_absolute_time(); // Time when new bottom surface found
+		lpos.dist_bottom_valid = true; // true if distance to bottom surface is valid
 
 		// TODO: uORB definition does not define what thes variables are. We have assumed them to be horizontal and vertical 1-std dev accuracy in metres
 		// TODO: Should use sqrt of filter position variances

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -605,11 +605,13 @@ void Ekf2::task_main()
 		_ekf->get_mag_innov(&innovations.mag_innov[0]);
 		_ekf->get_heading_innov(&innovations.heading_innov);
 		_ekf->get_flow_innov(&innovations.flow_innov[0]);
+		_ekf->get_hagl_innov(&innovations.hagl_innov);
 
 		_ekf->get_vel_pos_innov_var(&innovations.vel_pos_innov_var[0]);
 		_ekf->get_mag_innov_var(&innovations.mag_innov_var[0]);
 		_ekf->get_heading_innov_var(&innovations.heading_innov_var);
 		_ekf->get_flow_innov_var(&innovations.flow_innov_var[0]);
+		_ekf->get_hagl_innov_var(&innovations.hagl_innov_var);
 		if (_estimator_innovations_pub == nullptr) {
 			_estimator_innovations_pub = orb_advertise(ORB_ID(ekf2_innovations), &innovations);
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -488,7 +488,7 @@ void Ekf2::task_main()
 		lpos.ref_lon = ekf_origin.lon_rad * 180.0 / M_PI; // Reference point longitude in degrees
 
 		// The rotation of the tangent plane vs. geographical north
-		lpos.yaw = 0.0f;
+		lpos.yaw = att.yaw;
 
 		lpos.dist_bottom = -pos[2] + lpos.ref_alt; // Distance to bottom surface (ground) in meters
 		lpos.dist_bottom_rate = -vel[2]; // Distance to bottom surface (ground) change rate

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -683,6 +683,17 @@ void Ekf2::task_main()
 			replay.vel_d_m_s = gps.vel_d_m_s;
 			replay.vel_ned_valid = gps.vel_ned_valid;
 
+			replay.flow_timestamp = optical_flow.timestamp;
+			replay.range_to_ground = range_finder.current_distance;
+
+			replay.rng_timestamp = range_finder.timestamp;
+			replay.flow_pixel_integral[0] = optical_flow.pixel_flow_x_integral;
+			replay.flow_pixel_integral[1] = optical_flow.pixel_flow_y_integral;
+			replay.flow_gyro_integral[0] = optical_flow.gyro_x_rate_integral;
+			replay.flow_gyro_integral[1] = optical_flow.gyro_y_rate_integral;
+			replay.flow_time_integral = optical_flow.integration_timespan;
+			replay.flow_quality = optical_flow.quality;
+
 			if (_replay_pub == nullptr) {
 				_replay_pub = orb_advertise(ORB_ID(ekf2_replay), &replay);
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -172,6 +172,8 @@ private:
 	control::BlockParamFloat *_gyro_scale_p_noise;
 	control::BlockParamFloat *_mag_p_noise;
 	control::BlockParamFloat *_wind_vel_p_noise;
+	control::BlockParamFloat *_terrain_p_noise;	// terrain offset state random walk (m/s)
+	control::BlockParamFloat *_terrain_gradient;	// magnitude of terrain gradient (m/m)
 
 	control::BlockParamFloat *_gps_vel_noise;
 	control::BlockParamFloat *_gps_pos_noise;
@@ -246,6 +248,8 @@ Ekf2::Ekf2():
 	_gyro_scale_p_noise(new control::BlockParamFloat(this, "EKF2_GYR_S_NOISE", false, &_params->gyro_scale_p_noise)),
 	_mag_p_noise(new control::BlockParamFloat(this, "EKF2_MAG_B_NOISE", false, &_params->mag_p_noise)),
 	_wind_vel_p_noise(new control::BlockParamFloat(this, "EKF2_WIND_NOISE", false, &_params->wind_vel_p_noise)),
+	_terrain_p_noise(new control::BlockParamFloat(this, "EKF2_TERR_NOISE", false, &_params->terrain_p_noise)),
+	_terrain_gradient(new control::BlockParamFloat(this, "EKF2_TERR_GRAD", false, &_params->terrain_gradient)),
 	_gps_vel_noise(new control::BlockParamFloat(this, "EKF2_GPS_V_NOISE", false, &_params->gps_vel_noise)),
 	_gps_pos_noise(new control::BlockParamFloat(this, "EKF2_GPS_P_NOISE", false, &_params->gps_pos_noise)),
 	_pos_noaid_noise(new control::BlockParamFloat(this, "EKF2_NOAID_NOISE", false, &_params->pos_noaid_noise)),

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -482,10 +482,11 @@ void Ekf2::task_main()
 		// The rotation of the tangent plane vs. geographical north
 		lpos.yaw = att.yaw;
 
-		lpos.dist_bottom = -pos[2] + lpos.ref_alt; // Distance to bottom surface (ground) in meters
+		float terrain_vpos;
+		lpos.dist_bottom_valid = _ekf->get_terrain_vert_pos(&terrain_vpos);
+		lpos.dist_bottom = terrain_vpos - pos[2]; // Distance to bottom surface (ground) in meters
 		lpos.dist_bottom_rate = -vel[2]; // Distance to bottom surface (ground) change rate
 		lpos.surface_bottom_timestamp	= hrt_absolute_time(); // Time when new bottom surface found
-		lpos.dist_bottom_valid = true; // true if distance to bottom surface is valid
 
 		// TODO: uORB definition does not define what thes variables are. We have assumed them to be horizontal and vertical 1-std dev accuracy in metres
 		// TODO: Should use sqrt of filter position variances

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -357,14 +357,6 @@ void Ekf2::task_main()
 		if(range_finder_updated) {
 			orb_copy(ORB_ID(distance_sensor), _range_finder_sub, &range_finder);
 		}
-		// Use the control model data to determine if the motors are armed as a surrogate for an on-ground vs in-air status
-		// TODO implement a global vehicle on-ground/in-air check
-		orb_check(_control_mode_sub, &control_mode_updated);
-
-		if (control_mode_updated) {
-			orb_copy(ORB_ID(vehicle_control_mode), _control_mode_sub, &vehicle_control_mode);
-			_ekf->set_arm_status(vehicle_control_mode.flag_armed);
-		}
 
 		// in replay mode we are getting the actual timestamp from the sensor topic
 		hrt_abstime now = 0;

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -678,8 +678,10 @@ void Ekf2::task_main()
 				replay.lon = gps.lon;
 				replay.alt = gps.alt;
 				replay.fix_type = gps.fix_type;
+				replay.nsats = gps.satellites_used;
 				replay.eph = gps.eph;
 				replay.epv = gps.epv;
+				replay.sacc = gps.s_variance_m_s;
 				replay.vel_m_s = gps.vel_m_s;
 				replay.vel_n_m_s = gps.vel_n_m_s;
 				replay.vel_e_m_s = gps.vel_e_m_s;

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -327,7 +327,7 @@ PARAM_DEFINE_FLOAT(EKF2_HDG_GATE, 3.0f);
 PARAM_DEFINE_FLOAT(EKF2_MAG_GATE, 3.0f);
 
 /**
- * Integer bitmask controlling handling of magnetic declination. Set bits to in the following positions to enable functions.
+ * Integer bitmask controlling handling of magnetic declination. Set bits in the following positions to enable functions.
  * 0 : Set to true to use the declination from the geo_lookup library when the GPS position becomes available, set to false to always use the EKF2_MAG_DECL value.
  * 1 : Set to true to save the EKF2_MAG_DECL parameter to the value returned by the EKF when the vehicle disarms.
  * 2 : Set to true to always use the declination as an observaton when 3-axis magnetometer fusion is being used.
@@ -388,3 +388,99 @@ PARAM_DEFINE_FLOAT(EKF2_GPS_V_GATE, 3.0f);
  * @max 1
  */
 PARAM_DEFINE_INT32(EKF2_REC_RPL, 0);
+
+/**
+ * Integer bitmask controlling which external aiding sources will be used. Set bits in the following positions to enable:
+ * 0 : Set to true to use GPS data if available
+ * 1 : Set to true to use optical flow data if available
+ *
+ * @group EKF2
+ * @min 0
+ * @max 3
+ */
+PARAM_DEFINE_INT32(EKF2_AID_MASK, 1);
+
+/**
+ * Determines the primary source of height data used by the EKF.
+ * 0 : Barometric pressure
+ * 1 : GPS
+ * 2 : Range to ground
+ *
+ * @group EKF2
+ * @min 0
+ * @max 2
+ */
+PARAM_DEFINE_INT32(EKF2_HGT_MODE, 0);
+
+/**
+ * Measurement noise for range finder fusion
+ *
+ * @group EKF2
+ * @min 0.01
+ * @unit m
+ */
+PARAM_DEFINE_FLOAT(EKF2_RNG_NOISE, 0.1f);
+
+/**
+ * Gate size for range finder fusion
+ *
+ * @group EKF2
+ * @min 1.0
+ * @unit SD
+ */
+PARAM_DEFINE_FLOAT(EKF2_RNG_GATE, 5.0f);
+
+/**
+ * Minimum valid range for the range finder
+ *
+ * @group EKF2
+ * @min 0.01
+ * @unit m
+ */
+PARAM_DEFINE_FLOAT(EKF2_MIN_RNG, 0.1f);
+
+/**
+ * Measurement noise for the optical flow sensor when it's reported quality metric is at the maximum
+ *
+ * @group EKF2
+ * @min 0.05
+ * @unit rad/sec
+ */
+PARAM_DEFINE_FLOAT(EKF2_OF_N_MIN, 0.15f);
+
+/**
+ * Measurement noise for the optical flow sensor when it's reported quality metric is at the minimum set by EKF2_OF_QMIN
+ * The following condition must be met: EKF2_OF_N_MAXN >= EKF2_OF_N_MIN
+ *
+ * @group EKF2
+ * @min 0.05
+ * @unit rad/sec
+ */
+PARAM_DEFINE_FLOAT(EKF2_OF_N_MAX, 0.5f);
+
+/**
+ * Optical Flow data will only be used if the sensor reports a quality metric >= EKF2_OF_QMIN.
+ *
+ * @group EKF2
+ * @min 0
+ * @max 255
+ */
+PARAM_DEFINE_INT32(EKF2_OF_QMIN, 1);
+
+/**
+ * Gate size for optical flow fusion
+ *
+ * @group EKF2
+ * @min 1.0
+ * @unit SD
+ */
+PARAM_DEFINE_FLOAT(EKF2_OF_GATE, 3.0f);
+
+/**
+ * Optical Flow data will not fused if the magnitude of the flow rate > EKF2_OF_RMAX
+ *
+ * @group EKF2
+ * @min 1.0
+ * @unit rad/sec
+ */
+PARAM_DEFINE_FLOAT(EKF2_OF_RMAX, 2.5f);

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -484,3 +484,21 @@ PARAM_DEFINE_FLOAT(EKF2_OF_GATE, 3.0f);
  * @unit rad/sec
  */
 PARAM_DEFINE_FLOAT(EKF2_OF_RMAX, 2.5f);
+
+/**
+ * Terrain altitude process noise - accounts for instability in vehicle height estimate
+ *
+ * @group EKF2
+ * @min 0.5
+ * @unit m/sec
+ */
+PARAM_DEFINE_FLOAT(EKF2_TERR_NOISE, 5.0f);
+
+/**
+ * Magnitude of terrain gradient
+ *
+ * @group EKF2
+ * @min 0.0
+ * @unit m/m
+ */
+PARAM_DEFINE_FLOAT(EKF2_TERR_GRAD, 0.5f);

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -403,12 +403,12 @@ PARAM_DEFINE_INT32(EKF2_AID_MASK, 1);
 /**
  * Determines the primary source of height data used by the EKF.
  * 0 : Barometric pressure
- * 1 : GPS
- * 2 : Range to ground
+ * 1 : Reserved (placeholder for GPS)
+ * 2 : Reserved (placeholder for range finder)
  *
  * @group EKF2
  * @min 0
- * @max 2
+ * @max 0
  */
 PARAM_DEFINE_INT32(EKF2_HGT_MODE, 0);
 

--- a/src/modules/ekf2_replay/ekf2_replay_main.cpp
+++ b/src/modules/ekf2_replay/ekf2_replay_main.cpp
@@ -296,6 +296,11 @@ void Ekf2Replay::parseMessage(uint8_t *source, uint8_t *destination, uint8_t typ
 			write_index += sizeof(uint8_t);
 			break;
 
+		case 'I':
+			memcpy(&destination[write_index], &source[write_index], sizeof(int32_t));
+			write_index += sizeof(int32_t);
+			break;
+
 		default:
 			PX4_WARN("found unsupported data type in replay message, exiting!");
 			_task_should_exit = true;

--- a/src/modules/ekf2_replay/ekf2_replay_main.cpp
+++ b/src/modules/ekf2_replay/ekf2_replay_main.cpp
@@ -353,8 +353,10 @@ void Ekf2Replay::setEstimatorInput(uint8_t *data, uint8_t type)
 		_gps.lat = replay_part2.lat;
 		_gps.lon = replay_part2.lon;
 		_gps.fix_type = replay_part2.fix_type;
+		_gps.satellites_used = replay_part2.nsats;
 		_gps.eph = replay_part2.eph;
 		_gps.epv = replay_part2.epv;
+		_gps.s_variance_m_s = replay_part2.sacc;
 		_gps.vel_m_s = replay_part2.vel_m_s;
 		_gps.vel_n_m_s = replay_part2.vel_n_m_s;
 		_gps.vel_e_m_s = replay_part2.vel_e_m_s;

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1465,21 +1465,26 @@ int sdlog2_thread_main(int argc, char *argv[])
 			log_msg.body.log_RPL1.magnetometer_z_ga = buf.replay.magnetometer_ga[2];
 			log_msg.body.log_RPL1.baro_alt_meter = buf.replay.baro_alt_meter;
 			LOGBUFFER_WRITE_AND_COUNT(RPL1);
-			log_msg.msg_type = LOG_RPL2_MSG;
-			log_msg.body.log_RPL2.time_pos_usec = buf.replay.time_usec;
-			log_msg.body.log_RPL2.time_vel_usec = buf.replay.time_usec_vel;
-			log_msg.body.log_RPL2.lat = buf.replay.lat;
-			log_msg.body.log_RPL2.lon = buf.replay.lon;
-			log_msg.body.log_RPL2.alt = buf.replay.alt;
-			log_msg.body.log_RPL2.fix_type = buf.replay.fix_type;
-			log_msg.body.log_RPL2.eph = buf.replay.eph;
-			log_msg.body.log_RPL2.epv = buf.replay.epv;
-			log_msg.body.log_RPL2.vel_m_s = buf.replay.vel_m_s;
-			log_msg.body.log_RPL2.vel_n_m_s = buf.replay.vel_n_m_s;
-			log_msg.body.log_RPL2.vel_e_m_s = buf.replay.vel_e_m_s;
-			log_msg.body.log_RPL2.vel_d_m_s = buf.replay.vel_d_m_s;
-			log_msg.body.log_RPL2.vel_ned_valid = buf.replay.vel_ned_valid;
-			LOGBUFFER_WRITE_AND_COUNT(RPL2);
+
+			// only log the gps replay data if it actually updated
+			if (buf.replay.time_usec > 0) {
+				log_msg.msg_type = LOG_RPL2_MSG;
+				log_msg.body.log_RPL2.time_pos_usec = buf.replay.time_usec;
+				log_msg.body.log_RPL2.time_vel_usec = buf.replay.time_usec_vel;
+				log_msg.body.log_RPL2.lat = buf.replay.lat;
+				log_msg.body.log_RPL2.lon = buf.replay.lon;
+				log_msg.body.log_RPL2.alt = buf.replay.alt;
+				log_msg.body.log_RPL2.fix_type = buf.replay.fix_type;
+				log_msg.body.log_RPL2.eph = buf.replay.eph;
+				log_msg.body.log_RPL2.epv = buf.replay.epv;
+				log_msg.body.log_RPL2.vel_m_s = buf.replay.vel_m_s;
+				log_msg.body.log_RPL2.vel_n_m_s = buf.replay.vel_n_m_s;
+				log_msg.body.log_RPL2.vel_e_m_s = buf.replay.vel_e_m_s;
+				log_msg.body.log_RPL2.vel_d_m_s = buf.replay.vel_d_m_s;
+				log_msg.body.log_RPL2.vel_ned_valid = buf.replay.vel_ned_valid;
+				LOGBUFFER_WRITE_AND_COUNT(RPL2);
+			}
+
 			log_msg.msg_type = LOG_RPL3_MSG;
 			log_msg.body.log_RPL3.time_rng_usec = buf.replay.rng_timestamp;
 			log_msg.body.log_RPL3.time_flow_usec = buf.replay.flow_timestamp;

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -2002,6 +2002,8 @@ int sdlog2_thread_main(int argc, char *argv[])
 					log_msg.body.log_INO3.s[i] = buf.innovations.flow_innov[i];
 					log_msg.body.log_INO3.s[i + 2] = buf.innovations.flow_innov_var[i];
 				}
+				log_msg.body.log_INO3.s[4] = buf.innovations.hagl_innov;
+				log_msg.body.log_INO3.s[5] = buf.innovations.hagl_innov_var;
 				LOGBUFFER_WRITE_AND_COUNT(EST6);
 			}
 

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1201,6 +1201,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 			struct log_RPL1_s log_RPL1;
 			struct log_RPL2_s log_RPL2;
 			struct log_EST6_s log_INO3;
+			struct log_RPL3_s log_RPL3;
 		} body;
 	} log_msg = {
 		LOG_PACKET_HEADER_INIT(0)
@@ -1479,6 +1480,17 @@ int sdlog2_thread_main(int argc, char *argv[])
 			log_msg.body.log_RPL2.vel_d_m_s = buf.replay.vel_d_m_s;
 			log_msg.body.log_RPL2.vel_ned_valid = buf.replay.vel_ned_valid;
 			LOGBUFFER_WRITE_AND_COUNT(RPL2);
+			log_msg.msg_type = LOG_RPL3_MSG;
+			log_msg.body.log_RPL3.time_rng_usec = buf.replay.rng_timestamp;
+			log_msg.body.log_RPL3.time_flow_usec = buf.replay.flow_timestamp;
+			log_msg.body.log_RPL3.range_to_ground = buf.replay.range_to_ground;
+			log_msg.body.log_RPL3.flow_integral_x = buf.replay.flow_pixel_integral[0];
+			log_msg.body.log_RPL3.flow_integral_y = buf.replay.flow_pixel_integral[1];
+			log_msg.body.log_RPL3.gyro_integral_x = buf.replay.flow_gyro_integral[0];
+			log_msg.body.log_RPL3.gyro_integral_y = buf.replay.flow_gyro_integral[1];
+			log_msg.body.log_RPL3.flow_time_integral = buf.replay.flow_time_integral;
+			log_msg.body.log_RPL3.flow_quality = buf.replay.flow_quality;
+			LOGBUFFER_WRITE_AND_COUNT(RPL3);
 		}
 
 		/* --- ATTITUDE --- */

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1200,6 +1200,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 			struct log_CAMT_s log_CAMT;
 			struct log_RPL1_s log_RPL1;
 			struct log_RPL2_s log_RPL2;
+			struct log_EST6_s log_INO3;
 		} body;
 	} log_msg = {
 		LOG_PACKET_HEADER_INIT(0)
@@ -1858,6 +1859,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 				log_msg.body.log_AIRS.air_temperature_celsius = buf.airspeed.air_temperature_celsius;
 				LOGBUFFER_WRITE_AND_COUNT(AIRS);
 			}
+<<<<<<< HEAD
 
 			/* --- ESCs --- */
 			if (copy_if_updated(ORB_ID(esc_status), &subs.esc_sub, &buf.esc)) {
@@ -1995,6 +1997,13 @@ int sdlog2_thread_main(int argc, char *argv[])
 				log_msg.body.log_INO2.s[7] = buf.innovations.heading_innov_var;
 				LOGBUFFER_WRITE_AND_COUNT(EST5);
 
+				log_msg.msg_type = LOG_EST6_MSG;
+				memset(&(log_msg.body.log_INO3.s), 0, sizeof(log_msg.body.log_INO3.s));
+				for(unsigned i = 0; i < 2; i++) {
+					log_msg.body.log_INO3.s[i] = buf.innovations.flow_innov[i];
+					log_msg.body.log_INO3.s[i + 2] = buf.innovations.flow_innov_var[i];
+				}
+				LOGBUFFER_WRITE_AND_COUNT(EST6);
 			}
 
 			/* --- TECS STATUS --- */

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1202,6 +1202,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 			struct log_RPL2_s log_RPL2;
 			struct log_EST6_s log_INO3;
 			struct log_RPL3_s log_RPL3;
+			struct log_RPL4_s log_RPL4;
 		} body;
 	} log_msg = {
 		LOG_PACKET_HEADER_INIT(0)
@@ -1485,17 +1486,24 @@ int sdlog2_thread_main(int argc, char *argv[])
 				LOGBUFFER_WRITE_AND_COUNT(RPL2);
 			}
 
-			log_msg.msg_type = LOG_RPL3_MSG;
-			log_msg.body.log_RPL3.time_rng_usec = buf.replay.rng_timestamp;
-			log_msg.body.log_RPL3.time_flow_usec = buf.replay.flow_timestamp;
-			log_msg.body.log_RPL3.range_to_ground = buf.replay.range_to_ground;
-			log_msg.body.log_RPL3.flow_integral_x = buf.replay.flow_pixel_integral[0];
-			log_msg.body.log_RPL3.flow_integral_y = buf.replay.flow_pixel_integral[1];
-			log_msg.body.log_RPL3.gyro_integral_x = buf.replay.flow_gyro_integral[0];
-			log_msg.body.log_RPL3.gyro_integral_y = buf.replay.flow_gyro_integral[1];
-			log_msg.body.log_RPL3.flow_time_integral = buf.replay.flow_time_integral;
-			log_msg.body.log_RPL3.flow_quality = buf.replay.flow_quality;
-			LOGBUFFER_WRITE_AND_COUNT(RPL3);
+			if (buf.replay.flow_timestamp > 0) {
+				log_msg.msg_type = LOG_RPL3_MSG;
+				log_msg.body.log_RPL3.time_flow_usec = buf.replay.flow_timestamp;
+				log_msg.body.log_RPL3.flow_integral_x = buf.replay.flow_pixel_integral[0];
+				log_msg.body.log_RPL3.flow_integral_y = buf.replay.flow_pixel_integral[1];
+				log_msg.body.log_RPL3.gyro_integral_x = buf.replay.flow_gyro_integral[0];
+				log_msg.body.log_RPL3.gyro_integral_y = buf.replay.flow_gyro_integral[1];
+				log_msg.body.log_RPL3.flow_time_integral = buf.replay.flow_time_integral;
+				log_msg.body.log_RPL3.flow_quality = buf.replay.flow_quality;
+				LOGBUFFER_WRITE_AND_COUNT(RPL3);
+			}
+
+			if (buf.replay.rng_timestamp > 0) {
+				log_msg.msg_type = LOG_RPL4_MSG;
+				log_msg.body.log_RPL4.time_rng_usec = buf.replay.rng_timestamp;
+				log_msg.body.log_RPL4.range_to_ground = buf.replay.range_to_ground;
+				LOGBUFFER_WRITE_AND_COUNT(RPL4);
+			}
 		}
 
 		/* --- ATTITUDE --- */

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1859,7 +1859,6 @@ int sdlog2_thread_main(int argc, char *argv[])
 				log_msg.body.log_AIRS.air_temperature_celsius = buf.airspeed.air_temperature_celsius;
 				LOGBUFFER_WRITE_AND_COUNT(AIRS);
 			}
-<<<<<<< HEAD
 
 			/* --- ESCs --- */
 			if (copy_if_updated(ORB_ID(esc_status), &subs.esc_sub, &buf.esc)) {

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1476,8 +1476,10 @@ int sdlog2_thread_main(int argc, char *argv[])
 				log_msg.body.log_RPL2.lon = buf.replay.lon;
 				log_msg.body.log_RPL2.alt = buf.replay.alt;
 				log_msg.body.log_RPL2.fix_type = buf.replay.fix_type;
+				log_msg.body.log_RPL2.nsats = buf.replay.nsats;
 				log_msg.body.log_RPL2.eph = buf.replay.eph;
 				log_msg.body.log_RPL2.epv = buf.replay.epv;
+				log_msg.body.log_RPL2.sacc = buf.replay.sacc;
 				log_msg.body.log_RPL2.vel_m_s = buf.replay.vel_m_s;
 				log_msg.body.log_RPL2.vel_n_m_s = buf.replay.vel_n_m_s;
 				log_msg.body.log_RPL2.vel_e_m_s = buf.replay.vel_e_m_s;

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -432,7 +432,7 @@ struct log_EST5_s {
 /* --- EST6 - ESTIMATOR INNOVATIONS --- */
 #define LOG_EST6_MSG 53
 struct log_EST6_s {
-    float s[4];
+    float s[6];
 };
 
 /* --- TEL0..3 - TELEMETRY STATUS --- */
@@ -627,7 +627,7 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT(EST3, "ffffffffffffffff",    "P12,P13,P14,P15,P16,P17,P18,P19,P20,P21,P22,P23,P24,P25,P26,P27"),
 	LOG_FORMAT(EST4, "ffffffffffff", "VxI,VyI,VzI,PxI,PyI,PzI,VxIV,VyIV,VzIV,PxIV,PyIV,PzIV"),
 	LOG_FORMAT(EST5, "ffffffff", "MAGxI,MAGyI,MAGzI,MAGxIV,MAGyIV,MAGzIV,HeadI,HeadIV"),
-	LOG_FORMAT(EST6, "ffff", "FxI,FyI,FxIV,FyIV"),
+	LOG_FORMAT(EST6, "ffffff", "FxI,FyI,FxIV,FyIV,HAGLI,HAGLIV"),
 	LOG_FORMAT(PWR, "fffBBBBB",		"Periph5V,Servo5V,RSSI,UsbOk,BrickOk,ServoOk,PeriphOC,HipwrOC"),
 	LOG_FORMAT(MOCP, "fffffff",		"QuatW,QuatX,QuatY,QuatZ,X,Y,Z"),
 	LOG_FORMAT(VISN, "ffffffffff",		"X,Y,Z,VX,VY,VZ,QuatW,QuatX,QuatY,QuatZ"),

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -556,9 +556,7 @@ struct log_RPL2_s {
 /* --- EKF2 REPLAY Part 3 --- */
 #define LOG_RPL3_MSG 54
 struct log_RPL3_s {
-	uint64_t time_rng_usec;
 	uint64_t time_flow_usec;
-	float range_to_ground;
 	float flow_integral_x;
 	float flow_integral_y;
 	float gyro_integral_x;
@@ -566,6 +564,14 @@ struct log_RPL3_s {
 	uint32_t flow_time_integral;
 	uint8_t flow_quality;
 };
+
+/* --- EKF2 REPLAY Part 4 --- */
+#define LOG_RPL4_MSG 56
+struct log_RPL4_s {
+	uint64_t time_rng_usec;
+	float range_to_ground;
+};
+
 
 /* --- CAMERA TRIGGER --- */
 #define LOG_CAMT_MSG 55
@@ -656,7 +662,8 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT(CAMT, "QI", "timestamp,seq"),
 	LOG_FORMAT(RPL1, "QQQQQffffffffff", "t,gIdt,aIdt,Tm,Tb,gIx,gIy,gIz,aIx,aIy,aIz,magX,magY,magZ,b_alt"),
 	LOG_FORMAT(RPL2, "QQLLLMffffffM", "Tpos,Tvel,lat,lon,alt,fix_type,eph,epv,v,vN,vE,vD,v_val"),
-	LOG_FORMAT(RPL3, "QQfffffIB", "Trng,Tflow,rng,fx,fy,gx,gy,delT,qual"),
+	LOG_FORMAT(RPL3, "QffffIB", "Tflow,fx,fy,gx,gy,delT,qual"),
+	LOG_FORMAT(RPL4, "Qf", "Trng,rng"),
 	/* system-level messages, ID >= 0x80 */
 	/* FMT: don't write format of format message, it's useless */
 	LOG_FORMAT(TIME, "Q", "StartTime"),

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -553,6 +553,19 @@ struct log_RPL2_s {
 	float vel_d_m_s;
 	bool vel_ned_valid;
 };
+/* --- EKF2 REPLAY Part 3 --- */
+#define LOG_RPL3_MSG 54
+struct log_RPL3_s {
+	uint64_t time_rng_usec;
+	uint64_t time_flow_usec;
+	float range_to_ground;
+	float flow_integral_x;
+	float flow_integral_y;
+	float gyro_integral_x;
+	float gyro_integral_y;
+	uint32_t flow_time_integral;
+	uint8_t flow_quality;
+};
 
 /* --- CAMERA TRIGGER --- */
 #define LOG_CAMT_MSG 55
@@ -643,6 +656,7 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT(CAMT, "QI", "timestamp,seq"),
 	LOG_FORMAT(RPL1, "QQQQQffffffffff", "t,gIdt,aIdt,Tm,Tb,gIx,gIy,gIz,aIx,aIy,aIz,magX,magY,magZ,b_alt"),
 	LOG_FORMAT(RPL2, "QQLLLMffffffM", "Tpos,Tvel,lat,lon,alt,fix_type,eph,epv,v,vN,vE,vD,v_val"),
+	LOG_FORMAT(RPL3, "QQfffffIB", "Trng,Tflow,rng,fx,fy,gx,gy,delT,qual"),
 	/* system-level messages, ID >= 0x80 */
 	/* FMT: don't write format of format message, it's useless */
 	LOG_FORMAT(TIME, "Q", "StartTime"),

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -430,7 +430,7 @@ struct log_EST5_s {
 };
 
 /* --- EST6 - ESTIMATOR INNOVATIONS --- */
-#define LOG_EST6_MSG 51
+#define LOG_EST6_MSG 53
 struct log_EST6_s {
     float s[4];
 };

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -423,10 +423,16 @@ struct log_EST4_s {
     float s[12];
 };
 
-/* --- EST4 - ESTIMATOR INNOVATIONS --- */
+/* --- EST5 - ESTIMATOR INNOVATIONS --- */
 #define LOG_EST5_MSG 49
 struct log_EST5_s {
     float s[8];
+};
+
+/* --- EST6 - ESTIMATOR INNOVATIONS --- */
+#define LOG_EST6_MSG 51
+struct log_EST6_s {
+    float s[4];
 };
 
 /* --- TEL0..3 - TELEMETRY STATUS --- */
@@ -621,6 +627,7 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT(EST3, "ffffffffffffffff",    "P12,P13,P14,P15,P16,P17,P18,P19,P20,P21,P22,P23,P24,P25,P26,P27"),
 	LOG_FORMAT(EST4, "ffffffffffff", "VxI,VyI,VzI,PxI,PyI,PzI,VxIV,VyIV,VzIV,PxIV,PyIV,PzIV"),
 	LOG_FORMAT(EST5, "ffffffff", "MAGxI,MAGyI,MAGzI,MAGxIV,MAGyIV,MAGzIV,HeadI,HeadIV"),
+	LOG_FORMAT(EST6, "ffff", "FxI,FyI,FxIV,FyIV"),
 	LOG_FORMAT(PWR, "fffBBBBB",		"Periph5V,Servo5V,RSSI,UsbOk,BrickOk,ServoOk,PeriphOC,HipwrOC"),
 	LOG_FORMAT(MOCP, "fffffff",		"QuatW,QuatX,QuatY,QuatZ,X,Y,Z"),
 	LOG_FORMAT(VISN, "ffffffffff",		"X,Y,Z,VX,VY,VZ,QuatW,QuatX,QuatY,QuatZ"),

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -545,8 +545,10 @@ struct log_RPL2_s {
 	int32_t lon;
 	int32_t alt;
 	uint8_t fix_type;
+	uint8_t nsats;
 	float eph;
 	float epv;
+	float sacc;
 	float vel_m_s;
 	float vel_n_m_s;
 	float vel_e_m_s;
@@ -661,7 +663,7 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT(MACS, "fff", "RRint,PRint,YRint"),
 	LOG_FORMAT(CAMT, "QI", "timestamp,seq"),
 	LOG_FORMAT(RPL1, "QQQQQffffffffff", "t,gIdt,aIdt,Tm,Tb,gIx,gIy,gIz,aIx,aIy,aIz,magX,magY,magZ,b_alt"),
-	LOG_FORMAT(RPL2, "QQLLLMffffffM", "Tpos,Tvel,lat,lon,alt,fix_type,eph,epv,v,vN,vE,vD,v_val"),
+	LOG_FORMAT(RPL2, "QQLLLMMfffffffM", "Tpos,Tvel,lat,lon,alt,fix,nsats,eph,epv,sacc,v,vN,vE,vD,v_val"),
 	LOG_FORMAT(RPL3, "QffffIB", "Tflow,fx,fy,gx,gy,delT,qual"),
 	LOG_FORMAT(RPL4, "Qf", "Trng,rng"),
 	/* system-level messages, ID >= 0x80 */


### PR DESCRIPTION
This PR:

Provides EKF2 with optical flow and range finder data
Adds optical flow and range finder data to the replay logging
Enables replay of optical flow and range finder data
Improves logging efficiency
Allows optical flow and range finder fusion to be tuned over mavlink
Adds logging of range finder and optical flow innovations and innovation variances
Allows any combination of GPS and optical flow fusion to be specified.

The default parameter settings are optical flow disabled and baro alt used as the primary height reference.

Test results for the EKF2 optical flow functionality can be viewed here:

https://github.com/PX4/ecl/pull/74