### PR TITLE
bug fixes for SITL cmake files

### DIFF
--- a/cmake/configs/posix_sitl_default.cmake
+++ b/cmake/configs/posix_sitl_default.cmake
@@ -70,7 +70,7 @@ set(config_extra_builtin_cmds
 	)
 
 set(config_sitl_rcS
-	posix-configs/SITL/init/rcS
+	posix-configs/SITL/init
 	CACHE FILEPATH "init script for sitl"
 	)
 

--- a/cmake/configs/posix_sitl_ekf2.cmake
+++ b/cmake/configs/posix_sitl_ekf2.cmake
@@ -70,7 +70,7 @@ set(config_extra_builtin_cmds
 	)
 
 set(config_sitl_rcS
-	posix-configs/SITL/init/rcS_ekf2
+	posix-configs/SITL/init
 	CACHE FILEPATH "init script for sitl"
 	)
 

--- a/cmake/configs/posix_sitl_lpe.cmake
+++ b/cmake/configs/posix_sitl_lpe.cmake
@@ -5,5 +5,5 @@ list(APPEND config_module_list
 	)
 
 set(config_sitl_rcS
-	posix-configs/SITL/init/rcS_lpe
+	posix-configs/SITL/init
 	)

--- a/cmake/configs/posix_sitl_replay.cmake
+++ b/cmake/configs/posix_sitl_replay.cmake
@@ -33,7 +33,7 @@ set(config_extra_builtin_cmds
 	)
 
 set(config_sitl_rcS
-	posix-configs/SITL/init/rcS
+	posix-configs/SITL/init
 	CACHE FILEPATH "init script for sitl"
 	)
 


### PR DESCRIPTION
Fixes the following error by changing the 'config_sitl_rcS' path to 'posix-configs/SITL/init/'. Before, there was the following error at 87% when running 'make posix_sitl_default gazebo':

[ 87%] Built target rotors_gazebo_motor_model
make[1]: *** [all] Error 2
FAILED: cd /Users/$USER/src/Firmware && Tools/sitl_run.sh posix-configs/SITL/init/rcS none gazebo none /Users/$USER/src/Firmware/build_posix_sitl_default
ninja: build stopped: subcommand failed.
make: *** [posix_sitl_default] Error 1