### PR TITLE
prevent alternate flight control group (1) throttle from being active…

### DIFF
--- a/msg/actuator_controls.msg
+++ b/msg/actuator_controls.msg
@@ -9,6 +9,7 @@ uint8 INDEX_SPOILERS = 5
 uint8 INDEX_AIRBRAKES = 6
 uint8 INDEX_LANDING_GEAR = 7
 uint8 GROUP_INDEX_ATTITUDE = 0
+uint8 GROUP_INDEX_ATTITUDE_ALTERNATE = 1
 uint64 timestamp
 uint64 timestamp_sample	    # the timestamp the data this control response is based on was sampled
 float32[8] control

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1419,7 +1419,7 @@ PX4FMU::control_callback(uintptr_t handle,
 	/* motor spinup phase - lock throttle to zero */
 	if (_pwm_limit.state == PWM_LIMIT_STATE_RAMP) {
 		if ((control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE ||
-			control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE_ALTERNATE) &&
+		     control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE_ALTERNATE) &&
 		    control_index == actuator_controls_s::INDEX_THROTTLE) {
 			/* limit the throttle output to zero during motor spinup,
 			 * as the motors cannot follow any demand yet
@@ -1431,7 +1431,7 @@ PX4FMU::control_callback(uintptr_t handle,
 	/* throttle not arming - mark throttle input as invalid */
 	if (arm_nothrottle()) {
 		if ((control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE ||
-			control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE_ALTERNATE) &&
+		     control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE_ALTERNATE) &&
 		    control_index == actuator_controls_s::INDEX_THROTTLE) {
 			/* set the throttle to an invalid value */
 			input = NAN_VALUE;

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1418,7 +1418,8 @@ PX4FMU::control_callback(uintptr_t handle,
 
 	/* motor spinup phase - lock throttle to zero */
 	if (_pwm_limit.state == PWM_LIMIT_STATE_RAMP) {
-		if (control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE &&
+		if ((control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE ||
+			control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE_ALTERNATE) &&
 		    control_index == actuator_controls_s::INDEX_THROTTLE) {
 			/* limit the throttle output to zero during motor spinup,
 			 * as the motors cannot follow any demand yet
@@ -1429,7 +1430,8 @@ PX4FMU::control_callback(uintptr_t handle,
 
 	/* throttle not arming - mark throttle input as invalid */
 	if (arm_nothrottle()) {
-		if (control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE &&
+		if ((control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE ||
+			control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE_ALTERNATE) &&
 		    control_index == actuator_controls_s::INDEX_THROTTLE) {
 			/* set the throttle to an invalid value */
 			input = NAN_VALUE;

--- a/src/modules/px4iofirmware/mixer.cpp
+++ b/src/modules/px4iofirmware/mixer.cpp
@@ -397,7 +397,7 @@ mixer_callback(uintptr_t handle,
 	/* motor spinup phase - lock throttle to zero */
 	if ((pwm_limit.state == PWM_LIMIT_STATE_RAMP) || (should_arm_nothrottle && !should_arm)) {
 		if ((control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE ||
-			control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE_ALTERNATE) &&
+		     control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE_ALTERNATE) &&
 		    control_index == actuator_controls_s::INDEX_THROTTLE) {
 			/* limit the throttle output to zero during motor spinup,
 			 * as the motors cannot follow any demand yet
@@ -409,7 +409,7 @@ mixer_callback(uintptr_t handle,
 	/* only safety off, but not armed - set throttle as invalid */
 	if (should_arm_nothrottle && !should_arm) {
 		if ((control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE ||
-			control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE_ALTERNATE) &&
+		     control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE_ALTERNATE) &&
 		    control_index == actuator_controls_s::INDEX_THROTTLE) {
 			/* mark the throttle as invalid */
 			control = NAN_VALUE;

--- a/src/modules/px4iofirmware/mixer.cpp
+++ b/src/modules/px4iofirmware/mixer.cpp
@@ -396,7 +396,8 @@ mixer_callback(uintptr_t handle,
 
 	/* motor spinup phase - lock throttle to zero */
 	if ((pwm_limit.state == PWM_LIMIT_STATE_RAMP) || (should_arm_nothrottle && !should_arm)) {
-		if (control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE &&
+		if ((control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE ||
+			control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE_ALTERNATE) &&
 		    control_index == actuator_controls_s::INDEX_THROTTLE) {
 			/* limit the throttle output to zero during motor spinup,
 			 * as the motors cannot follow any demand yet
@@ -407,7 +408,8 @@ mixer_callback(uintptr_t handle,
 
 	/* only safety off, but not armed - set throttle as invalid */
 	if (should_arm_nothrottle && !should_arm) {
-		if (control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE &&
+		if ((control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE ||
+			control_group == actuator_controls_s::GROUP_INDEX_ATTITUDE_ALTERNATE) &&
 		    control_index == actuator_controls_s::INDEX_THROTTLE) {
 			/* mark the throttle as invalid */
 			control = NAN_VALUE;


### PR DESCRIPTION
… when safety is disabled

@tumbili : can you review this quickly? I did a bench test and it worked (at least on FMU level).