### PR TITLE
unconfigure GPIO_PPM_IN to disable PPM input

### DIFF
--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -901,6 +901,7 @@ PX4FMU::cycle()
 		// assume SBUS input
 		sbus_config(_rcs_fd, false);
 		// disable CPPM input by mapping it away from the timer capture input
+		stm32_unconfiggpio(GPIO_PPM_IN);
 		stm32_configgpio(GPIO_PPM_IN & ~(GPIO_AF_MASK | GPIO_PUPD_MASK));
 #endif
 
@@ -1331,6 +1332,7 @@ PX4FMU::cycle()
 
 		} else {
 			// disable CPPM input by mapping it away from the timer capture input
+			stm32_unconfiggpio(GPIO_PPM_IN);
 			stm32_configgpio(GPIO_PPM_IN & ~(GPIO_AF_MASK | GPIO_PUPD_MASK));
 			// Scan the next protocol
 			set_rc_scan_state(RC_SCAN_SBUS);

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -902,7 +902,6 @@ PX4FMU::cycle()
 		sbus_config(_rcs_fd, false);
 		// disable CPPM input by mapping it away from the timer capture input
 		stm32_unconfiggpio(GPIO_PPM_IN);
-		stm32_configgpio(GPIO_PPM_IN & ~(GPIO_AF_MASK | GPIO_PUPD_MASK));
 #endif
 
 		_initialized = true;
@@ -1333,7 +1332,6 @@ PX4FMU::cycle()
 		} else {
 			// disable CPPM input by mapping it away from the timer capture input
 			stm32_unconfiggpio(GPIO_PPM_IN);
-			stm32_configgpio(GPIO_PPM_IN & ~(GPIO_AF_MASK | GPIO_PUPD_MASK));
 			// Scan the next protocol
 			set_rc_scan_state(RC_SCAN_SBUS);
 		}


### PR DESCRIPTION
Code to disable PWM_IN pin was actually configuring it as an output:

Name: stm32_configgpio
Description:Configure a GPIO pin based on bit-encoded description of the pin.
**Once it is configured as Alternative (GPIO_ALT|GPIO_CNF_AFPP|...)
function, it must be unconfigured with stm32_unconfiggpio() with
the same cfgset first before it can be set to non-alternative function.**

Replacing the stm32_configgpio call with stm32_unconfiggpio fixes the problem; header file says
"set it into default HiZ state"