### PR TITLE
Make sdlog2_dump.py compatible with APM .bin files

### DIFF
--- a/Tools/sdlog2/sdlog2_dump.py
+++ b/Tools/sdlog2/sdlog2_dump.py
@@ -48,6 +48,7 @@ class SDLog2Parser:
         "i": ("i", None),
         "I": ("I", None),
         "f": ("f", None),
+        "d": ("d", None),
         "n": ("4s", None),
         "N": ("16s", None),
         "Z": ("64s", None),


### PR DESCRIPTION
sdlog2_dump.py didn't know what to do with data types "d" and was causing errors when trying to dump APM .bin files to .csv.