### PR TITLE
param_shmem: fix the "unknown param id" bug

### DIFF
--- a/src/modules/systemlib/param/param_shmem.c
+++ b/src/modules/systemlib/param/param_shmem.c
@@ -344,6 +344,7 @@ param_for_index(unsigned index)
 param_t
 param_for_used_index(unsigned index)
 {
+#if 0
 	int count = get_param_info_count();
 
 	if (count && index < count) {
@@ -368,6 +369,9 @@ param_for_used_index(unsigned index)
 	}
 
 	return PARAM_INVALID;
+#else
+	return param_for_index(index);
+#endif
 }
 
 int


### PR DESCRIPTION
The recent workaround to flag all params as used did not include
param_for_used_index(). However, this function got used in the case if
one param had not been received by QGC and was requested by its index.