### PR TITLE
Revert "mavlink: send out parameters faster over UDP"

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2015 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,7 +35,7 @@
  * MAVLink 1.0 protocol implementation.
  *
  * @author Lorenz Meier <lm@inf.ethz.ch>
- * @author Julian Oes <julian@oes.ch>
+ * @author Julian Oes <joes@student.ethz.ch>
  * @author Anton Babushkin <anton.babushkin@me.com>
  */
 
@@ -1889,11 +1889,6 @@ Mavlink::task_main(int argc, char *argv[])
 	/* if the protocol is serial, we send the system version blindly */
 	if (get_protocol() == SERIAL) {
 		send_autopilot_capabilites();
-	}
-
-	/* send parameters faster over UDP */
-	if (get_protocol() == UDP) {
-		configure_stream("PARAM_VALUE", 100000.0f);
 	}
 
 	while (!_task_should_exit) {


### PR DESCRIPTION
This reverts commit 213cdf1a9139488f156721a72feded53d839d964.

Raising the stream rate of param values had the nice effect that
receiving the params became really quick. However, on the downside it
set all other streams pretty slow. This needs to be fixed differently.