### PR TITLE
added descend into navigator

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -493,6 +493,10 @@ Navigator::task_main()
 				_pos_sp_triplet_published_invalid_once = false;
 				_navigation_mode = &_land;
 				break;
+			case vehicle_status_s::NAVIGATION_STATE_DESCEND:
+				_pos_sp_triplet_published_invalid_once = false;
+				_navigation_mode = &_land;
+				break;
 			case vehicle_status_s::NAVIGATION_STATE_AUTO_RTGS:
 				/* Use complex data link loss mode only when enabled via param
 				* otherwise use rtl */


### PR DESCRIPTION
Descend was unimplemented in navigator, and thus had no effect when the navigation state was changed. Utilized same land helper. Downstream logic in pos_control and commander successfully ignore position data that is applied in the setpoint message. Tested in gazebo for multi-rotors.