### PR TITLE
VTOL Airbrakes

### DIFF
--- a/ROMFS/px4fmu_common/mixers/standard_vtol_sitl.main.mix
+++ b/ROMFS/px4fmu_common/mixers/standard_vtol_sitl.main.mix
@@ -8,15 +8,18 @@ in order to make the standard vtol simulation compatible with the tailsitter sim
 R: 4x 10000 10000 10000 0
 
 # mixer for the elevons
-M: 2
+M: 3
 O:      10000  10000   0 -10000  10000
 S: 1 0  5000   5000    0 -10000  10000
-S: 1 1 -5000 -5000     0 -10000  10000
+S: 1 1 -5000  -5000     0 -10000  10000
+S: 1 6  -5000  -5000      0 -10000  10000
 
-M: 2
+
+M: 3
 O:       10000   10000   0 -10000  10000
 S: 1 0   5000    5000    0 -10000  10000
 S: 1 1   5000    5000    0 -10000  10000
+S: 1 6   5000    5000      0 -10000  10000
 
 # mixer for the pusher/puller throttle
 M: 1

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -65,6 +65,7 @@ Standard::Standard(VtolAttitudeControl *attc) :
 	_params_handles_standard.airspeed_trans = param_find("VT_ARSP_TRANS");
 	_params_handles_standard.front_trans_timeout = param_find("VT_TRANS_TIMEOUT");
 	_params_handles_standard.front_trans_time_min = param_find("VT_TRANS_MIN_TM");
+	_params_handles_standard.b_trans_airbrakes = param_find("VT_B_AIRBRAKES");
 }
 
 Standard::~Standard()
@@ -103,6 +104,9 @@ Standard::parameters_update()
 
 	/* minimum time for transition to fw mode */
 	param_get(_params_handles_standard.front_trans_time_min, &_params_standard.front_trans_time_min);
+
+	/* back transition flaperons */
+	param_get(_params_handles_standard.b_trans_airbrakes, &_params_standard.b_trans_airbrakes);
 
 
 	return OK;
@@ -315,6 +319,13 @@ void Standard::fill_actuator_outputs()
 		(_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH] + _params->fw_pitch_trim) * (1 - _mc_pitch_weight);	//pitch
 	_actuators_out_1->control[actuator_controls_s::INDEX_YAW] = _actuators_fw_in->control[actuator_controls_s::INDEX_YAW]
 			* (1 - _mc_yaw_weight);	// yaw
+
+	// apply airbrakes
+	if (_vtol_schedule.flight_mode == TRANSITION_TO_MC) {
+		_actuators_out_1->control[actuator_controls_s::INDEX_AIRBRAKES] = _params_standard.b_trans_airbrakes;
+	} else {
+		_actuators_out_1->control[actuator_controls_s::INDEX_AIRBRAKES] = 0.0f;
+	}
 
 	// set the fixed wing throttle control
 	if (_vtol_schedule.flight_mode == FW_MODE && _armed->armed) {

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -73,6 +73,7 @@ private:
 		float airspeed_trans;
 		float front_trans_timeout;
 		float front_trans_time_min;
+		float b_trans_airbrakes;
 	} _params_standard;
 
 	struct {
@@ -83,6 +84,7 @@ private:
 		param_t airspeed_trans;
 		param_t front_trans_timeout;
 		param_t front_trans_time_min;
+		param_t b_trans_airbrakes;
 	} _params_handles_standard;
 
 	enum vtol_mode {

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -312,3 +312,13 @@ PARAM_DEFINE_FLOAT(VT_TRANS_TIMEOUT, 15.0f);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_FLOAT(VT_TRANS_MIN_TM, 2.0f);
+
+/**
+ * Flaperons scale during back transition
+ *
+ * @min 0.00
+ * @max 1.00
+ * @increment 0.1
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_B_AIRBRAKES, 0.0f);


### PR DESCRIPTION
Use flaperons for VTOL back transition
This helps the back transition decrease speed and makes the MC takeover much smoother.
It will mostly benefit from this when https://github.com/PX4/Firmware/pull/4055/commits/1bb9b29cf560e479a2cdafa626f6bb27c20dbf72 has been applied.

SITL was altered to include flaperons, but currently SITL is an elevon setup so there will be an increase in altitude as there is no elevator to control this.

To test set VT_AIRBRAKES param to 0.5