### PR TITLE
WIP: VTOL roll trim 

### DIFF
--- a/posix-configs/SITL/init/rcS_gazebo_standard_vtol
+++ b/posix-configs/SITL/init/rcS_gazebo_standard_vtol
@@ -9,6 +9,8 @@ param set MC_YAWRATE_P 0.35
 param set VT_TYPE 2
 param set SYS_AUTOSTART 4010
 param set SYS_RESTART_TYPE 2
+param set VT_FW_PITCH_TRIM -0.25
+param set VT_FW_ROLL_TRIM 0.25
 dataman start
 param set CAL_GYRO0_ID 2293768
 param set CAL_ACC0_ID 1376264

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -309,12 +309,16 @@ void Standard::fill_actuator_outputs()
 
 	/* fixed wing controls */
 	_actuators_out_1->timestamp = _actuators_fw_in->timestamp;
-	_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] = -_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL]
-			* (1 - _mc_roll_weight);	//roll
+
+	_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] =
+		(-_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL] + _params->fw_roll_trim);
+
 	_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =
-		(_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH] + _params->fw_pitch_trim) * (1 - _mc_pitch_weight);	//pitch
-	_actuators_out_1->control[actuator_controls_s::INDEX_YAW] = _actuators_fw_in->control[actuator_controls_s::INDEX_YAW]
-			* (1 - _mc_yaw_weight);	// yaw
+		(_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH] + _params->fw_pitch_trim);
+
+	_actuators_out_1->control[actuator_controls_s::INDEX_YAW] =
+		_actuators_fw_in->control[actuator_controls_s::INDEX_YAW] * (1 - _mc_yaw_weight);	// yaw
+
 
 	// set the fixed wing throttle control
 	if (_vtol_schedule.flight_mode == FW_MODE && _armed->armed) {

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -127,6 +127,7 @@ VtolAttitudeControl::VtolAttitudeControl() :
 	_params_handles.mc_airspeed_max = param_find("VT_MC_ARSPD_MAX");
 	_params_handles.mc_airspeed_trim = param_find("VT_MC_ARSPD_TRIM");
 	_params_handles.fw_pitch_trim = param_find("VT_FW_PITCH_TRIM");
+	_params_handles.fw_roll_trim = param_find("VT_FW_ROLL_TRIM");
 	_params_handles.power_max = param_find("VT_POWER_MAX");
 	_params_handles.prop_eff = param_find("VT_PROP_EFF");
 	_params_handles.arsp_lp_gain = param_find("VT_ARSP_LP_GAIN");
@@ -529,6 +530,10 @@ VtolAttitudeControl::parameters_update()
 	/* vtol pitch trim for fw mode */
 	param_get(_params_handles.fw_pitch_trim, &v);
 	_params.fw_pitch_trim = v;
+
+	/* vtol roll trim for fw mode */
+	param_get(_params_handles.fw_roll_trim, &v);
+	_params.fw_roll_trim = v;
 
 	/* vtol maximum power engine can produce */
 	param_get(_params_handles.power_max, &v);

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -202,6 +202,7 @@ private:
 		param_t mc_airspeed_trim;
 		param_t mc_airspeed_max;
 		param_t fw_pitch_trim;
+		param_t fw_roll_trim;
 		param_t power_max;
 		param_t prop_eff;
 		param_t arsp_lp_gain;

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -129,6 +129,20 @@ PARAM_DEFINE_INT32(VT_FW_PERM_STAB, 0);
 PARAM_DEFINE_FLOAT(VT_FW_PITCH_TRIM, 0.0f);
 
 /**
+ * Fixed wing roll trim
+ *
+ * This parameter allows to adjust the neutral aileron position in fixed wing mode.
+ *
+ * @min -1.0
+ * @max 1.0
+ * @increment 0.01
+ * @decimal 2
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_FW_ROLL_TRIM, 0.0f);
+
+
+/**
  * Motor max power
  *
  * Indicates the maximum power the motor is able to produce. Used to calculate

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -54,6 +54,7 @@ struct Params {
 	float mc_airspeed_trim;		// trim airspeed in multicopter mode
 	float mc_airspeed_max;		// max airpseed in multicopter mode
 	float fw_pitch_trim;		// trim for neutral elevon position in fw mode
+	float fw_roll_trim;			// trim for neutral roll position in fw mode
 	float power_max;			// maximum power of one engine
 	float prop_eff;				// factor to calculate prop efficiency
 	float arsp_lp_gain;			// total airspeed estimate low pass gain


### PR DESCRIPTION
This adds a roll trim param to combat roll produced by the inertia of the pusher prop.
Also, the scaling was removed for roll and pitch during transition in order to correctly apply these values.

With this param, and the already existing pitch trim the climbing and rolling during transition can be corrected. The roll trim will have to be set depending on the rotation direction of the pusher / puller. In SITL the following values produce a stable result;
VT_FW_PITCH_TRIM: -0.25
VT_FW_ROLL_TRIM: 0.25

The MC, during transition blending does not have enough authority to correct roll and pitch and the FW is not yet in control to apply these corrections.

Setting the above values fixes https://github.com/PX4/Firmware/issues/4079
Airframes should independently be analyzed for correct values.
Roll should be set positive CCW pusher prop and negative with a CW pusher prop
Pitch (in all the logs i have seen) always seems to angle up and therefor needs a negative value

I'm not sure if this is a permanent solution or if we should revisit the control authority of MC/FW during transitions.

@AndreasAntener @tumbili @LorenzMeier   