### PR TITLE
try meas airspeed on I2C bus 2 on fmu rev 3

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -146,6 +146,11 @@ else
 	else
 		if ets_airspeed start -b 1
 		then
+		else
+			if [ $BOARD_FMUV3 == true ]
+			then
+				meas_airspeed start -b 2
+			fi
 		fi
 	fi
 fi


### PR DESCRIPTION
@LorenzMeier getting airspeed on PH2 working if one doesn't modify the puck cable, using the other I2C bus on the large break out board. Do you think this is the right fix?