### PR TITLE
A sdlog2 self deadlock bug prevents logging

### DIFF
--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -634,8 +634,6 @@ static void *logwriter_thread(void *arg)
 			pthread_cond_wait(&logbuffer_cond, &logbuffer_mutex);
 		}
 
-		pthread_mutex_lock(&logbuffer_mutex);
-
 		/* only get pointer to thread-safe data, do heavy I/O a few lines down */
 		int available = logbuffer_get_ptr(logbuf, &read_ptr, &is_part);
 


### PR DESCRIPTION
`sdlog2.c` tries to [lock](https://github.com/PX4/Firmware/blob/c10b37c2edd27e7b03bc465dff06dead3cc8af07/src/modules/sdlog2/sdlog2.c#L637) an already [locked lock](https://github.com/PX4/Firmware/blob/c10b37c2edd27e7b03bc465dff06dead3cc8af07/src/modules/sdlog2/sdlog2.c#L624), which leads to slog2 hanging forever w/o writing log data to disk.

Deleting [this line](https://github.com/PX4/Firmware/blob/c10b37c2edd27e7b03bc465dff06dead3cc8af07/src/modules/sdlog2/sdlog2.c#L637) fixed the bug.