### PR TITLE
On Hold: Translate MC actuators to FW actuators during VTOL transitions

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -144,7 +144,7 @@ void Standard::update_vtol_state()
 		} else if (_vtol_schedule.flight_mode == TRANSITION_TO_MC) {
 			// transition to MC mode if transition time has passed
 			if (hrt_elapsed_time(&_vtol_schedule.transition_start) >
-			    (_params_standard.back_trans_dur * 1000000.0f)) {
+				(_params_standard.back_trans_dur * 1000000.0f)) {
 				_vtol_schedule.flight_mode = MC_MODE;
 			}
 		}
@@ -170,9 +170,9 @@ void Standard::update_vtol_state()
 		} else if (_vtol_schedule.flight_mode == TRANSITION_TO_FW) {
 			// continue the transition to fw mode while monitoring airspeed for a final switch to fw mode
 			if ((_airspeed->indicated_airspeed_m_s >= _params_standard.airspeed_trans &&
-			     (float)hrt_elapsed_time(&_vtol_schedule.transition_start)
-			     > (_params_standard.front_trans_time_min * 1000000.0f)) ||
-			    !_armed->armed) {
+				 (float)hrt_elapsed_time(&_vtol_schedule.transition_start)
+				 > (_params_standard.front_trans_time_min * 1000000.0f)) ||
+				!_armed->armed) {
 				_vtol_schedule.flight_mode = FW_MODE;
 				// we can turn off the multirotor motors now
 				_flag_enable_mc_motors = false;
@@ -221,11 +221,11 @@ void Standard::update_transition_state()
 
 		// do blending of mc and fw controls if a blending airspeed has been provided and the minimum transition time has passed
 		if (_airspeed_trans_blend_margin > 0.0f &&
-		    _airspeed->indicated_airspeed_m_s >= _params_standard.airspeed_blend &&
-		    (float)hrt_elapsed_time(&_vtol_schedule.transition_start) > (_params_standard.front_trans_time_min * 1000000.0f)
+			_airspeed->indicated_airspeed_m_s >= _params_standard.airspeed_blend &&
+			(float)hrt_elapsed_time(&_vtol_schedule.transition_start) > (_params_standard.front_trans_time_min * 1000000.0f)
 		   ) {
 			float weight = 1.0f - fabsf(_airspeed->indicated_airspeed_m_s - _params_standard.airspeed_blend) /
-				       _airspeed_trans_blend_margin;
+					   _airspeed_trans_blend_margin;
 			_mc_roll_weight = weight;
 			_mc_pitch_weight = weight;
 			_mc_yaw_weight = weight;
@@ -315,6 +315,13 @@ void Standard::fill_actuator_outputs()
 		(_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH] + _params->fw_pitch_trim) * (1 - _mc_pitch_weight);	//pitch
 	_actuators_out_1->control[actuator_controls_s::INDEX_YAW] = _actuators_fw_in->control[actuator_controls_s::INDEX_YAW]
 			* (1 - _mc_yaw_weight);	// yaw
+
+
+	/* translate MC actuators to FW actuators */
+	if (_vtol_schedule.flight_mode == TRANSITION_TO_FW || _vtol_schedule.flight_mode == TRANSITION_TO_MC) {
+		_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] = -_actuators_mc_in->control[actuator_controls_s::INDEX_YAW];
+		_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] = _actuators_mc_in->control[actuator_controls_s::INDEX_THROTTLE] - 0.5f;
+	}
 
 	// set the fixed wing throttle control
 	if (_vtol_schedule.flight_mode == FW_MODE && _armed->armed) {


### PR DESCRIPTION
This addresses the altitude and drift problems during vtol transitions of quadplanes.
The problem:
During transitions the MC attitude setpoints are published, these setpoints apply the following logic
 - To correct heading apply yaw
 - To correct altitude apply throttle

The FW cannot actuate this as by default yaw (rudder) is disabled and throttle is overwritten by pusher ramp-up during transition. The MC tries hard to apply this attitude but while the airspeed increases and lift is created it cannot fight this for long. Eventually the MC is blended out and the FW is flying blind. The result below shows a SITL flight where the transition airspeed was set too high to exaggerate the problem:

![qgc](https://cloud.githubusercontent.com/assets/14801663/14078933/03f4ee7e-f4fa-11e5-9eea-84824225e662.png)
 
The proposed solution is to apply translation logic in the vtol attitude controller for quadplanes;
- Heading should be corrected by roll (rudder would be better but not all planes have one)
- Altitude should be corrected by pitch 

The roll setpoint is taken from the MC yaw setpoint, the pitch setpoint is taken from the MC throttle setpoint. The resulting transition under the same conditions in SITL:

![after translation](https://cloud.githubusercontent.com/assets/14801663/14078988/8b56ffa6-f4fa-11e5-9d2d-242dcf27f820.png)

Fixes https://github.com/PX4/Firmware/issues/4079
Replaces https://github.com/PX4/Firmware/pull/4084