### PR TITLE
Fix mavlink broadcast

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -884,7 +884,7 @@ Mavlink::send_message(const uint8_t msgid, const void *msg, uint8_t component_ID
 			int bret = sendto(_socket_fd, buf, packet_len, 0, (struct sockaddr *)&_bcast_addr, sizeof(_bcast_addr));
 
 			if (bret <= 0) {
-				PX4_WARN("sending broadcast failed");
+				PX4_WARN("sending broadcast failed, errno: %d: %s", errno, strerror(errno));
 			}
 		}
 

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2015 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,7 +35,7 @@
  * MAVLink 1.0 protocol implementation.
  *
  * @author Lorenz Meier <lm@inf.ethz.ch>
- * @author Julian Oes <joes@student.ethz.ch>
+ * @author Julian Oes <julian@oes.ch>
  * @author Anton Babushkin <anton.babushkin@me.com>
  */
 


### PR DESCRIPTION
This fixes the broadcast issue that we've seen on Snapdragon if it was configured in AP mode.
See #3939.

Tested on Snapdragon and POSIX gazebo.