### PR TITLE
sdlog2 fixes

### DIFF
--- a/src/modules/sdlog2/logbuffer.c
+++ b/src/modules/sdlog2/logbuffer.c
@@ -156,3 +156,10 @@ void logbuffer_free(struct logbuffer_s *lb)
 		perf_free(lb->perf_dropped);
 	}
 }
+
+void logbuffer_reset(struct logbuffer_s *lb)
+{
+	// Keep the buffer but reset the pointers.
+	lb->write_ptr = 0;
+	lb->read_ptr = 0;
+}

--- a/src/modules/sdlog2/logbuffer.h
+++ b/src/modules/sdlog2/logbuffer.h
@@ -69,4 +69,6 @@ void logbuffer_mark_read(struct logbuffer_s *lb, int n);
 
 void logbuffer_free(struct logbuffer_s *lb);
 
+void logbuffer_reset(struct logbuffer_s *lb);
+
 #endif

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -936,9 +936,6 @@ int sdlog2_thread_main(int argc, char *argv[])
 
 	flag_system_armed = false;
 
-	/* work around some stupidity in task_create's argv handling */
-	argc -= 2;
-	argv += 2;
 	int ch;
 
 	/* don't exit from getopt loop to leave getopt global variables in consistent state,

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -936,6 +936,12 @@ int sdlog2_thread_main(int argc, char *argv[])
 
 	flag_system_armed = false;
 
+#ifdef __PX4_NUTTX
+	/* work around some stupidity in NuttX's task_create's argv handling */
+	argc -= 2;
+	argv += 2;
+#endif
+
 	int ch;
 
 	/* don't exit from getopt loop to leave getopt global variables in consistent state,

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -807,8 +807,8 @@ void sdlog2_stop_log()
 	/* free log writer performance counter */
 	perf_free(perf_write);
 
-	/* free log buffer */
-	logbuffer_free(&lb);
+	/* reset the logbuffer */
+	logbuffer_reset(&lb);
 
 	mavlink_and_console_log_info(&mavlink_log_pub, "[blackbox] stopped (%lu drops)", skipped_count);
 
@@ -2136,7 +2136,8 @@ int sdlog2_thread_main(int argc, char *argv[])
 	pthread_mutex_destroy(&logbuffer_mutex);
 	pthread_cond_destroy(&logbuffer_cond);
 
-	free(lb.data);
+	/* free log buffer */
+	logbuffer_free(&lb);
 
 	thread_running = false;
 


### PR DESCRIPTION
This fixes #4108, as well as a second bug where `sdlog2 start` without more arguments would cause a segfault.