### PR TITLE
commander: pass PreflightCheck on Snapdragon

### DIFF
--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -385,6 +385,14 @@ static bool gnssCheck(orb_advert_t *mavlink_log_pub, bool report_fail)
 bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkMag, bool checkAcc, bool checkGyro,
 		    bool checkBaro, bool checkAirspeed, bool checkRC, bool checkGNSS, bool checkDynamic, bool reportFailures)
 {
+
+#ifdef __PX4_QURT
+	// WARNING: Preflight checks are important and should be added back when
+	// all the sensors are supported
+	PX4_WARN("WARNING: Preflight checks PASS always.");
+	return true;
+#endif
+
 	bool failed = false;
 
 	/* ---- MAG ---- */
@@ -527,14 +535,6 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkMag, bool checkAcc,
 			failed = true;
 		}
 	}
-
-
-#ifdef __PX4_QURT
-	// WARNING: Preflight checks are important and should be added back when
-	// all the sensors are supported
-	PX4_WARN("WARNING: Preflight checks PASS always.");
-	failed = false;
-#endif
 
 	/* Report status */
 	return !failed;


### PR DESCRIPTION
The tests don't work properly on Snapdragon yet, so just report happy
for now. Otherwise users get messages such as "No Gyro found" which is
wrong.

Also, do the check at the beginning in order not to confuse the user.