### PR TITLE
set mavlink data rate for snapdragon

### DIFF
--- a/posix-configs/eagle/flight/mainapp.config
+++ b/posix-configs/eagle/flight/mainapp.config
@@ -1,6 +1,6 @@
 uorb start
 muorb start
-mavlink start -u 14556
+mavlink start -u 14556 -r 1000000
 sleep 1
 mavlink stream -u 14556 -s HIGHRES_IMU -r 50
 mavlink stream -u 14556 -s ATTITUDE -r 50


### PR DESCRIPTION
@julianoes Will give this another letter as discussed since "r" is used for rate in Hz. But for now this solves low data rate problem in QGC.