### PR TITLE
Added battery current sensor offset

### DIFF
--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -1960,6 +1960,14 @@ PARAM_DEFINE_FLOAT(BAT_V_SCALING, -1.0f);
  */
 PARAM_DEFINE_FLOAT(BAT_C_SCALING, -1.0);
 
+/**
+ * Offset for battery current sensor.
+ *
+ * @group Battery Calibration
+ * @decimal 8
+ */
+PARAM_DEFINE_FLOAT(BAT_C_OFFSET, -1.0);
+
 
 /**
  * RC channel count


### PR DESCRIPTION
We're trying to get this sensor running: http://www.drotek.com/shop/en/home/749-voltage-current-sensor-board.html?search_query=current+sensor&results=33

APM seems to have an offset setting for current sensing, in Volts, so I added an offset for us as well. APM is calculating based on the ADC voltage, we use the raw value. Based on the conversion factor 4096/3.3 our values for this module should be:

V_SCALING: ~0.01249
C_SCALING: ~0.12206
C_OFFSET: 2048