### PR TITLE
Add easy Snapdragon upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,8 @@ posix_eagle_release:
 qurt_eagle_default:
 	$(call cmake-build,$@)
 
+eagle_default: posix_eagle_default qurt_eagle_default
+
 posix_eagle_default:
 	$(call cmake-build,$@)
 

--- a/Tools/adb_upload.sh
+++ b/Tools/adb_upload.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [[ "$#" < 2 ]]; then
+	echo "usage: adb_upload.sh SRC1 [SRC2 ...] DEST"
+	exit
+fi
+
+echo "Wait for device..."
+adb wait-for-device
+echo "Uploading..."
+
+# Get last argument
+for last; do true; done
+
+# Go through source files and push them one by one.
+i=0
+for arg
+do
+	if [[ $((i+1)) == "$#" ]]; then
+		break
+	fi
+	# echo "Pushing $arg to $last"
+	adb push $arg $last
+	((i+=1))
+done

--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -443,6 +443,26 @@ function(px4_add_upload)
 		)
 endfunction()
 
+
+function(px4_add_adb_push)
+	px4_parse_function_args(
+		NAME px4_add_upload
+		ONE_VALUE OS BOARD OUT DEST
+		MULTI_VALUE FILES DEPENDS
+		REQUIRED OS BOARD OUT FILES DEPENDS DEST
+		ARGN ${ARGN})
+
+	add_custom_target(${OUT}
+		COMMAND ${CMAKE_SOURCE_DIR}/Tools/adb_upload.sh ${FILES} ${DEST}
+		DEPENDS ${DEPENDS}
+		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+		COMMENT "uploading ${BUNDLE}"
+		VERBATIM
+		USES_TERMINAL
+		)
+endfunction()
+
+
 #=============================================================================
 #
 #	px4_add_common_flags

--- a/src/firmware/posix/CMakeLists.txt
+++ b/src/firmware/posix/CMakeLists.txt
@@ -25,6 +25,15 @@ if ("${BOARD}" STREQUAL "eagle")
 		pthread m rt
 		-Wl,--end-group
 		)
+
+	px4_add_adb_push(OUT upload
+			 OS ${OS}
+			 BOARD ${BOARD}
+			 FILES ${CMAKE_CURRENT_BINARY_DIR}/mainapp
+				 ${CMAKE_SOURCE_DIR}/posix-configs/eagle/flight/mainapp.config
+			 DEPENDS build_mainapp_apps
+			 DEST /home/linaro)
+
 else()
 	add_executable(mainapp
 		${CMAKE_SOURCE_DIR}/src/platforms/posix/main.cpp

--- a/src/firmware/qurt/CMakeLists.txt
+++ b/src/firmware/qurt/CMakeLists.txt
@@ -15,7 +15,7 @@ if ("${QURT_ENABLE_STUBS}" STREQUAL "1")
                 ${CMAKE_CURRENT_BINARY_DIR}
                 ${FASTRPC_DSP_INCLUDES}
                 )
-	add_executable(mainapp 
+	add_executable(mainapp
 		${CMAKE_BINARY_DIR}/src/firmware/qurt/px4muorb_skel.c
 		${CMAKE_BINARY_DIR}/apps.h)
 
@@ -44,6 +44,15 @@ else()
 		${df_driver_libs}
 		m
 		)
+
+	px4_add_adb_push(OUT upload
+			 OS ${OS}
+			 BOARD ${BOARD}
+			 FILES ${CMAKE_CURRENT_BINARY_DIR}/libmainapp.so
+				 ${CMAKE_CURRENT_BINARY_DIR}/libpx4muorb_skel.so
+				 ${CMAKE_SOURCE_DIR}/posix-configs/eagle/flight/px4.config
+			 DEPENDS build_mainapp_dsp build_mainapp_dsp
+			 DEST /usr/share/data/adsp)
 endif()
 
 # vim: set noet ft=cmake fenc=utf-8 ff=unix :


### PR DESCRIPTION
This adds a a target ```make eagle_default```` to build both the POSIX and
the QURT side in one command. Also, it adds an upload target for both to
push the files over adb to the device. This doesn't just push the
executables and lib files, but also the startup config files.