### PR TITLE
Replay fix

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -189,7 +189,8 @@ private:
 	control::BlockParamFloat *_mag_declination_deg;	// magnetic declination in degrees
 	control::BlockParamFloat *_heading_innov_gate;	// innovation gate for heading innovation test
 	control::BlockParamFloat *_mag_innov_gate;	// innovation gate for magnetometer innovation test
-	control::BlockParamInt *_mag_decl_source;       // bitmasked integer used to control the handling of magnetic declination
+	control::BlockParamInt
+	*_mag_decl_source;       // bitmasked integer used to control the handling of magnetic declination
 	control::BlockParamInt *_mag_fuse_type;         // integer ued to control the type of magnetometer fusion used
 
 	control::BlockParamInt *_gps_check_mask;        // bitmasked integer used to activate the different GPS quality checks
@@ -203,7 +204,8 @@ private:
 	control::BlockParamInt *_param_record_replay_msg; // indicates if we want to record ekf2 replay messages
 
 	// measurement source control
-	control::BlockParamInt *_fusion_mode;		// bitmasked integer that selects which of the GPS and optical flow aiding sources will be used
+	control::BlockParamInt
+	*_fusion_mode;		// bitmasked integer that selects which of the GPS and optical flow aiding sources will be used
 	control::BlockParamInt *_vdist_sensor_type;	// selects the primary source for height data
 
 	// range finder fusion
@@ -212,8 +214,10 @@ private:
 	control::BlockParamFloat *_rng_gnd_clearance;	// minimum valid value for range when on ground (m)
 
 	// optical flow fusion
-	control::BlockParamFloat *_flow_noise;		// best quality observation noise for optical flow LOS rate measurements (rad/sec)
-	control::BlockParamFloat *_flow_noise_qual_min;	// worst quality observation noise for optical flow LOS rate measurements (rad/sec)
+	control::BlockParamFloat
+	*_flow_noise;		// best quality observation noise for optical flow LOS rate measurements (rad/sec)
+	control::BlockParamFloat
+	*_flow_noise_qual_min;	// worst quality observation noise for optical flow LOS rate measurements (rad/sec)
 	control::BlockParamInt *_flow_qual_min;		// minimum acceptable quality integer from  the flow sensor
 	control::BlockParamFloat *_flow_innov_gate;	// optical flow fusion innovation consistency gate size (STD)
 	control::BlockParamFloat *_flow_rate_max;	// maximum valid optical flow rate (rad/sec)
@@ -625,6 +629,7 @@ void Ekf2::task_main()
 					orb_publish(ORB_ID(vehicle_global_position), _vehicle_global_position_pub, &global_pos);
 				}
 			}
+
 		} else if (_replay_mode) {
 			// in replay mode we have to tell the replay module not to wait for an update
 			// we do this by publishing an attitude with zero timestamp

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -468,7 +468,6 @@ void Ekf2::task_main()
 
 		// run the EKF update and output
 		if (_ekf->update()) {
-
 			// generate vehicle attitude quaternion data
 			struct vehicle_attitude_s att = {};
 			_ekf->copy_quaternion(att.q);
@@ -625,6 +624,18 @@ void Ekf2::task_main()
 				} else {
 					orb_publish(ORB_ID(vehicle_global_position), _vehicle_global_position_pub, &global_pos);
 				}
+			}
+		} else if (_replay_mode) {
+			// in replay mode we have to tell the replay module not to wait for an update
+			// we do this by publishing an attitude with zero timestamp
+			struct vehicle_attitude_s att = {};
+			att.timestamp = 0;
+
+			if (_att_pub == nullptr) {
+				_att_pub = orb_advertise(ORB_ID(vehicle_attitude), &att);
+
+			} else {
+				orb_publish(ORB_ID(vehicle_attitude), _att_pub, &att);
 			}
 		}
 

--- a/src/modules/ekf2_replay/ekf2_replay_main.cpp
+++ b/src/modules/ekf2_replay/ekf2_replay_main.cpp
@@ -436,6 +436,13 @@ void Ekf2Replay::logIfUpdated()
 	// update attitude
 	struct vehicle_attitude_s att = {};
 	orb_copy(ORB_ID(vehicle_attitude), _att_sub, &att);
+
+	// if the timestamp of the attitude is zero, then this means that the ekf did not
+	// do an update so we can ignore this message and just continue
+	if (att.timestamp == 0) {
+		return;
+	}
+
 	memset(&log_message.body.att.q_w, 0, sizeof(log_ATT_s));
 
 	log_message.type = LOG_ATT_MSG;
@@ -695,8 +702,9 @@ void Ekf2Replay::task_main()
 
 		read_first_header = true;
 
-		if (header[0] != HEAD_BYTE1 || header[1] != HEAD_BYTE2) {
-			PX4_WARN("bad log header\n");
+		if ((header[0] != HEAD_BYTE1 || header[1] != HEAD_BYTE2)) {
+			// we assume that the log file is finished here
+			PX4_WARN("Done!");
 			_task_should_exit = true;
 			continue;
 		}


### PR DESCRIPTION
@priseborough This fixes the replay. It was broken due to the change you made about only publishing the estimator topics when an update occurred. The replay module is now informed if no update happened and it will not time out anymore. I tested this on a replay log file from the snapdragon and the results look ok.
I still need to investigate some time in making sure the snapdragon logging data is good.