### PR TITLE
Fix Snapdragon param save

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -3621,6 +3621,12 @@ void *commander_low_prio_loop(void *arg)
 
 					} else if (((int)(cmd.param1)) == 1) {
 
+#ifdef __PX4_QURT
+						// TODO FIXME: on snapdragon the save happens to early when the params
+						// are not set yet. We therefore need to wait some time first.
+						usleep(1000000);
+#endif
+
 						int ret = param_save_default();
 
 						if (ret == OK) {

--- a/src/modules/systemlib/param/param_shmem.c
+++ b/src/modules/systemlib/param/param_shmem.c
@@ -974,6 +974,9 @@ param_export(int fd, bool only_unsaved)
 
 		s->unsaved = false;
 
+		/* Make sure to get latest from shmem before saving. */
+		update_from_shmem(s->param, &s->val);
+
 		/* append the appropriate BSON type object */
 
 		switch (param_type(s->param)) {


### PR DESCRIPTION
If a param is set in QGC for Snapdragon, it doesn't get saved correctly.

There seemed to be two bugs:
- The param were not updated from shmem before saving.
- The set and save command sent by QGC seem to lead to a race. Somehow the save command will get executed first (or too early) on the DSP side, therefore saving the old param instead of the newly set one.

This has been tested on the Snapdragon and should not touch anything else, so it's good to be merged once the checks pass.

@mcharleb, @jywilson FYI

This should resolve https://github.com/mavlink/qgroundcontrol/issues/3120.