### PR TITLE
only use the default acceptance radius for checking mission feasibility

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -277,7 +277,7 @@ Mission::update_offboard_mission()
 				dm_current, (size_t) _offboard_mission.count, _navigator->get_geofence(),
 				_navigator->get_home_position()->alt, _navigator->home_position_valid(),
 				_navigator->get_global_position()->lat, _navigator->get_global_position()->lon,
-				_param_dist_1wp.get(), _navigator->get_mission_result()->warning, _navigator->get_acceptance_radius(),
+				_param_dist_1wp.get(), _navigator->get_mission_result()->warning, _navigator->get_default_acceptance_radius(),
 				_navigator->get_vstatus()->condition_landed);
 
 		_navigator->get_mission_result()->valid = !failed;
@@ -1120,7 +1120,7 @@ Mission::check_mission_valid()
 				dm_current, (size_t) _offboard_mission.count, _navigator->get_geofence(),
 				_navigator->get_home_position()->alt, _navigator->home_position_valid(),
 				_navigator->get_global_position()->lat, _navigator->get_global_position()->lon,
-				_param_dist_1wp.get(), _navigator->get_mission_result()->warning, _navigator->get_acceptance_radius(),
+				_param_dist_1wp.get(), _navigator->get_mission_result()->warning, _navigator->get_default_acceptance_radius(),
 				_navigator->get_vstatus()->condition_landed);
 
 		_navigator->increment_mission_instance_count();

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -151,6 +151,11 @@ public:
 	float		get_loiter_radius() { return _param_loiter_radius.get(); }
 
 	/**
+	 * Returns the default acceptance radius defined by the parameter
+	 */
+	float get_default_acceptance_radius();
+
+	/**
 	 * Get the acceptance radius
 	 *
 	 * @return the distance at which the next waypoint should be used

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -611,6 +611,12 @@ Navigator::publish_position_setpoint_triplet()
 }
 
 float
+Navigator::get_default_acceptance_radius()
+{
+	return _param_acceptance_radius.get();
+}
+
+float
 Navigator::get_acceptance_radius()
 {
 	return get_acceptance_radius(_param_acceptance_radius.get());


### PR DESCRIPTION
Using the acceptance radius from the navigator blocks a mission upload for VTOLs while in fixed-wing flight because takeoff altitude is most likely smaller than the current acceptance radius from the nav caps.

SITL tested