### PR TITLE
Keep current altitude for vtol move to land after transition

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -555,9 +555,6 @@ Mission::set_mission_items()
 			 * what the altitude means on this waypoint type.
 			 */
 			float altitude = _navigator->get_global_position()->alt;
-			if (pos_sp_triplet->current.valid) {
-				altitude = pos_sp_triplet->current.alt;
-			}
 
 			_mission_item.altitude = altitude;
 			_mission_item.altitude_is_relative = false;


### PR DESCRIPTION
This keeps the current altitude when moving to land as the LAND command may contain 0 altitude setpoint. This seems to be default in QGC now