### PR TITLE
Broadcast / re-connect fix

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1637,12 +1637,12 @@ Mavlink::task_main(int argc, char *argv[])
 			}
 			break;
 #else
-			case 'u':
-			case 'o':
-			case 't':
-				warnx("UDP options not supported on this platform");
-				err_flag = true;
-				break;
+		case 'u':
+		case 'o':
+		case 't':
+			warnx("UDP options not supported on this platform");
+			err_flag = true;
+			break;
 #endif
 
 //		case 'e':

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1100,11 +1100,13 @@ Mavlink::find_broadcast_address()
 
 	delete[] ifconf.ifc_req;
 
+#endif
 }
 
 void
 Mavlink::init_udp()
 {
+#if defined (__PX4_LINUX) || defined (__PX4_DARWIN)
 
 	PX4_INFO("Setting up UDP w/port %d", _network_port);
 

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -510,6 +510,8 @@ private:
 	 */
 	void update_rate_mult();
 
+	void find_broadcast_address();
+
 	void init_udp();
 
 	/**


### PR DESCRIPTION
This is a follow up on #4183.

It avoid spitting out too many warnings while still managing to reconnect.

Tested cases:
- SITL gazebo with QGC on localhost
- Snapdragon in station mode connecting to QGC with wifi connected late, or disconnected in-between.
- Snapdragon in station mode connecting to QGC with wifi already up but QGC not started, or restarted.