### PR TITLE
gps: fix build, unused var ERROR

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -77,12 +77,6 @@
 #define TIMEOUT_5HZ 500
 #define RATE_MEASUREMENT_PERIOD 5000000
 
-/* oddly, ERROR is not defined for c++ */
-#ifdef ERROR
-# undef ERROR
-#endif
-static const int ERROR = -1;
-
 
 /* class for dynamic allocation of satellite info data */
 class GPS_Sat_Info


### PR DESCRIPTION
Fixes:

```
/home/julianoes/src/Firmware/src/drivers/gps/gps.cpp:84:18: fatal error: unused variable 'ERROR'
      [-Wunused-const-variable]
static const int ERROR = -1;
                 ^
1 error generated.
```