### PR TITLE
param_shmem: do fsync after param write

### DIFF
--- a/src/modules/systemlib/param/param_shmem.c
+++ b/src/modules/systemlib/param/param_shmem.c
@@ -859,6 +859,7 @@ param_save_default(void)
 
 	// After writing the file, also do a fsync to prevent loosing params if power is cut.
 	res = fsync(fd);
+
 	if (res != 0) {
 		PX4_ERR("failed to do fsync: %s", strerror(errno));
 		goto exit;

--- a/src/modules/systemlib/param/param_shmem.c
+++ b/src/modules/systemlib/param/param_shmem.c
@@ -857,7 +857,16 @@ param_save_default(void)
 		goto exit;
 	}
 
+	// After writing the file, also do a fsync to prevent loosing params if power is cut.
+	res = fsync(fd);
+	if (res != 0) {
+		PX4_ERR("failed to do fsync: %s", strerror(errno));
+		goto exit;
+	}
+
 	PARAM_CLOSE(fd);
+
+
 	fd = -1;
 
 exit:


### PR DESCRIPTION
We have seen cases on Snapdragon where the params were "saved" but still didn't persist after a power-cycle, presumably because power was yanked before the param file had been synced to disk.

Therefore, we now do fsync after param save.

@priseborough FYI