### PR TITLE
sdlog2: workaround for Snapdragon

### DIFF
--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -910,7 +910,7 @@ bool copy_if_updated_multi(orb_id_t topic, int multi_instance, int *handle, void
 		// The orb_exists call doesn't work correctly on Snapdragon yet.
 		// (No data gets sent from the QURT to the Linux side because there
 		// are no subscribers. However, there won't be any subscribers, if
-		// they check using orb_exists() before subscribing.
+		// they check using orb_exists() before subscribing.)
 		if (true)
 #else
 		if (OK == orb_exists(topic, multi_instance))

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -906,7 +906,17 @@ bool copy_if_updated_multi(orb_id_t topic, int multi_instance, int *handle, void
 	bool updated = false;
 
 	if (*handle < 0) {
-		if (OK == orb_exists(topic, multi_instance)) {
+#if __PX4_POSIX_EAGLE
+		// The orb_exists call doesn't work correctly on Snapdragon yet.
+		// (No data gets sent from the QURT to the Linux side because there
+		// are no subscribers. However, there won't be any subscribers, if
+		// they check using orb_exists() before subscribing.
+		if (true)
+#else
+		if (OK == orb_exists(topic, multi_instance))
+#endif
+
+		{
 			*handle = orb_subscribe_multi(topic, multi_instance);
 			/* copy first data */
 			if (*handle >= 0) {


### PR DESCRIPTION
This fixes an issue where topics where not subscribed to on the Linux
side on Snapdragon. It's a hack until there is a proper fix for the
orb_exists() call.

Tested on Snapdragon.