### PR TITLE
support setting the rate of SBUS output

### DIFF
--- a/src/drivers/drv_pwm_output.h
+++ b/src/drivers/drv_pwm_output.h
@@ -241,6 +241,9 @@ struct pwm_output_rc_config {
 /** setup OVERRIDE_IMMEDIATE behaviour on FMU fail */
 #define PWM_SERVO_SET_OVERRIDE_IMMEDIATE	_PX4_IOC(_PWM_SERVO_BASE, 30)
 
+/** set SBUS output frame rate in Hz */
+#define PWM_SERVO_SET_SBUS_RATE			_PX4_IOC(_PWM_SERVO_BASE, 31)
+
 /*
  *
  *

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -2607,7 +2607,11 @@ PX4IO::ioctl(file *filep, int cmd, unsigned long arg)
 			/* set override immediate flag */
 			ret = io_reg_modify(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_ARMING, 0, PX4IO_P_SETUP_ARMING_OVERRIDE_IMMEDIATE);
 		}
+		break;
 
+	case PWM_SERVO_SET_SBUS_RATE:
+		/* set the requested SBUS frame rate */
+		ret = io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_SBUS_RATE, arg);
 		break;
 
 	case DSM_BIND_START:

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -2333,10 +2333,11 @@ PX4IO::print_status(bool extended_status)
 	       io_reg_get(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_RELAYS));
 #endif
 #ifdef CONFIG_ARCH_BOARD_PX4FMU_V2
-	printf("rates 0x%04x default %u alt %u\n",
+	printf("rates 0x%04x default %u alt %u sbus %u\n",
 	       io_reg_get(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_PWM_RATES),
 	       io_reg_get(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_PWM_DEFAULTRATE),
-	       io_reg_get(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_PWM_ALTRATE));
+	       io_reg_get(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_PWM_ALTRATE),
+	       io_reg_get(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_SBUS_RATE));
 #endif
 	printf("debuglevel %u\n", io_reg_get(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_SET_DEBUG));
 

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -2608,6 +2608,7 @@ PX4IO::ioctl(file *filep, int cmd, unsigned long arg)
 			/* set override immediate flag */
 			ret = io_reg_modify(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_ARMING, 0, PX4IO_P_SETUP_ARMING_OVERRIDE_IMMEDIATE);
 		}
+
 		break;
 
 	case PWM_SERVO_SET_SBUS_RATE:

--- a/src/lib/rc/sbus.c
+++ b/src/lib/rc/sbus.c
@@ -117,7 +117,7 @@ static enum SBUS2_DECODE_STATE {
 static uint8_t	sbus_frame[SBUS_FRAME_SIZE + (SBUS_FRAME_SIZE / 2)];
 
 static unsigned partial_frame_count;
-static unsigned sbus1_frame_delay = (1000U*1000U)/SBUS1_DEFAULT_RATE_HZ;
+static unsigned sbus1_frame_delay = (1000U * 1000U) / SBUS1_DEFAULT_RATE_HZ;
 
 static unsigned sbus_frame_drops;
 
@@ -646,8 +646,10 @@ void sbus1_set_output_rate_hz(uint16_t rate_hz)
 	if (rate_hz > SBUS1_MAX_RATE_HZ) {
 		rate_hz = SBUS1_MAX_RATE_HZ;
 	}
+
 	if (rate_hz < SBUS1_MIN_RATE_HZ) {
 		rate_hz = SBUS1_MIN_RATE_HZ;
 	}
-	sbus1_frame_delay = (1000U*1000U) / rate_hz;
+
+	sbus1_frame_delay = (1000U * 1000U) / rate_hz;
 }

--- a/src/lib/rc/sbus.h
+++ b/src/lib/rc/sbus.h
@@ -76,6 +76,7 @@ __EXPORT bool	sbus_parse(uint64_t now, uint8_t *frame, unsigned len, uint16_t *v
 			   uint16_t *num_values, bool *sbus_failsafe, bool *sbus_frame_drop, unsigned *frame_drops, uint16_t max_channels);
 __EXPORT void	sbus1_output(int sbus_fd, uint16_t *values, uint16_t num_values);
 __EXPORT void	sbus2_output(int sbus_fd, uint16_t *values, uint16_t num_values);
+__EXPORT void	sbus1_set_output_rate_hz(uint16_t rate_hz);
 
 /**
  * The number of incomplete frames we encountered

--- a/src/modules/px4iofirmware/protocol.h
+++ b/src/modules/px4iofirmware/protocol.h
@@ -239,6 +239,8 @@ enum {							/* DSM bind states */
 #define PX4IO_P_SETUP_TRIM_PITCH		17	/**< Pitch trim, in actuator units */
 #define PX4IO_P_SETUP_TRIM_YAW			18	/**< Yaw trim, in actuator units */
 
+#define PX4IO_P_SETUP_SBUS_RATE			19	/* frame rate of SBUS1 output in Hz */
+
 /* autopilot control values, -10000..10000 */
 #define PX4IO_PAGE_CONTROLS			51	/**< actuator control groups, one after the other, 8 wide */
 #define PX4IO_P_CONTROLS_GROUP_0		(PX4IO_PROTOCOL_MAX_CONTROL_COUNT * 0)	/**< 0..PX4IO_PROTOCOL_MAX_CONTROL_COUNT - 1 */

--- a/src/modules/px4iofirmware/px4io.h
+++ b/src/modules/px4iofirmware/px4io.h
@@ -122,6 +122,7 @@ extern uint16_t			r_page_servo_disarmed[];	/* PX4IO_PAGE_DISARMED_PWM */
 #define r_setup_trim_roll	r_page_setup[PX4IO_P_SETUP_TRIM_ROLL]
 #define r_setup_trim_pitch	r_page_setup[PX4IO_P_SETUP_TRIM_PITCH]
 #define r_setup_trim_yaw	r_page_setup[PX4IO_P_SETUP_TRIM_YAW]
+#define r_setup_sbus_rate	r_page_setup[PX4IO_P_SETUP_SBUS_RATE]
 
 #define r_control_values	(&r_page_controls[0])
 

--- a/src/modules/px4iofirmware/registers.c
+++ b/src/modules/px4iofirmware/registers.c
@@ -48,6 +48,7 @@
 #include <systemlib/systemlib.h>
 #include <stm32_pwr.h>
 #include <rc/dsm.h>
+#include <rc/sbus.h>
 
 #include "px4io.h"
 #include "protocol.h"
@@ -157,6 +158,7 @@ volatile uint16_t	r_page_setup[] = {
 	[PX4IO_P_SETUP_PWM_RATES]		= 0,
 	[PX4IO_P_SETUP_PWM_DEFAULTRATE]		= 50,
 	[PX4IO_P_SETUP_PWM_ALTRATE]		= 200,
+	[PX4IO_P_SETUP_SBUS_RATE]		= 72,
 #ifdef CONFIG_ARCH_BOARD_PX4IO_V1
 	[PX4IO_P_SETUP_RELAYS]			= 0,
 #else
@@ -674,6 +676,10 @@ registers_set_one(uint8_t page, uint8_t offset, uint16_t value)
 		case PX4IO_P_SETUP_TRIM_PITCH:
 		case PX4IO_P_SETUP_TRIM_YAW:
 			r_page_setup[offset] = value;
+			break;
+
+		case PX4IO_P_SETUP_SBUS_RATE:
+			sbus1_set_output_rate_hz(value);
 			break;
 
 		default:

--- a/src/modules/px4iofirmware/registers.c
+++ b/src/modules/px4iofirmware/registers.c
@@ -679,6 +679,7 @@ registers_set_one(uint8_t page, uint8_t offset, uint16_t value)
 			break;
 
 		case PX4IO_P_SETUP_SBUS_RATE:
+			r_page_setup[offset] = value;
 			sbus1_set_output_rate_hz(value);
 			break;
 


### PR DESCRIPTION
useful for multicopters and quadplanes 
especially OctaQuad setups. This greatly reduces wiring complexity
