### PR TITLE
systemlib: properly check for MULT_COUNT value

### DIFF
--- a/src/modules/systemlib/systemlib.h
+++ b/src/modules/systemlib/systemlib.h
@@ -55,9 +55,9 @@ enum MULT_PORTS {
 	MULT_COUNT
 };
 
+#if defined(__cplusplus)
 /* Check max multi port count */
-#if (MULT_COUNT > 33)
-#error "MULT_COUNT HAS TO BE LESS THAN OR EQUAL 33"
+static_assert(MULT_COUNT <= 33, "MULT_COUNT HAS TO BE LESS THAN OR EQUAL 33");
 #endif
 
 /* FMU board info, to be stored in the first 64 bytes of the FMU EEPROM */


### PR DESCRIPTION
Checking with preprocessor directives doesn't have any effect because
MULT_COUNT is an enum value rather than a macro. Thus, since MULT_COUNT is
undefined from the preprocessor perspective, even if the number of items in
`enum MULT_PORTS` (except MULT_COUNT) was greater than 33, the error wouldn't
be raised.