### PR TITLE
drivers: added filter control ioctls

### DIFF
--- a/src/drivers/drv_accel.h
+++ b/src/drivers/drv_accel.h
@@ -103,4 +103,10 @@ struct accel_calibration_s {
 /** get the result of a sensor self-test */
 #define ACCELIOCSELFTEST	_ACCELIOC(9)
 
+/** set the hardware low-pass filter cut-off no lower than (arg) Hz */
+#define ACCELIOCSHWLOWPASS	_ACCELIOC(10)
+
+/** get the hardware low-pass filter cut-off in Hz*/
+#define ACCELIOCGHWLOWPASS	_ACCELIOC(11)
+
 #endif /* _DRV_ACCEL_H */

--- a/src/drivers/drv_gyro.h
+++ b/src/drivers/drv_gyro.h
@@ -100,4 +100,10 @@ struct gyro_calibration_s {
 /** check the status of the sensor */
 #define GYROIOCSELFTEST		_GYROIOC(8)
 
+/** set the hardware low-pass filter cut-off no lower than (arg) Hz */
+#define GYROIOCSHWLOWPASS	_GYROIOC(9)
+
+/** get the hardware low-pass filter cut-off in Hz*/
+#define GYROIOCGHWLOWPASS	_GYROIOC(10)
+
 #endif /* _DRV_GYRO_H */


### PR DESCRIPTION
these are used by the ArduPilot version of the drivers. I'd like to get the ioctl defines in now to minimise future merge errors
