### PR TITLE
support for new GPIO_SET_OUTPUT options

### DIFF
--- a/src/drivers/drv_gpio.h
+++ b/src/drivers/drv_gpio.h
@@ -194,4 +194,10 @@
 
 #define GPIO_PERIPHERAL_RAIL_RESET	GPIOC(14)
 
+/** configure the board GPIOs in (arg) as outputs, initially low */
+#define GPIO_SET_OUTPUT_LOW	GPIOC(15)
+
+/** configure the board GPIOs in (arg) as outputs, initially high */
+#define GPIO_SET_OUTPUT_HIGH	GPIOC(16)
+
 #endif /* _DRV_GPIO_H */

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -2377,7 +2377,9 @@ PX4FMU::gpio_set_function(uint32_t gpios, int function)
 		gpios |= 3;
 
 		/* flip the buffer to output mode if required */
-		if (GPIO_SET_OUTPUT == function) {
+		if (GPIO_SET_OUTPUT == function ||
+		    GPIO_SET_OUTPUT_LOW == function ||
+		    GPIO_SET_OUTPUT_HIGH == function) {
 			stm32_gpiowrite(GPIO_GPIO_DIR, 1);
 		}
 	}
@@ -2394,6 +2396,14 @@ PX4FMU::gpio_set_function(uint32_t gpios, int function)
 
 			case GPIO_SET_OUTPUT:
 				stm32_configgpio(_gpio_tab[i].output);
+				break;
+
+			case GPIO_SET_OUTPUT_LOW:
+				stm32_configgpio((_gpio_tab[i].output & ~(GPIO_OUTPUT_SET)) | GPIO_OUTPUT_CLEAR);
+				break;
+
+			case GPIO_SET_OUTPUT_HIGH:
+				stm32_configgpio((_gpio_tab[i].output & ~(GPIO_OUTPUT_CLEAR)) | GPIO_OUTPUT_SET);
 				break;
 
 			case GPIO_SET_ALT_1:
@@ -2591,6 +2601,8 @@ PX4FMU::gpio_ioctl(struct file *filp, int cmd, unsigned long arg)
 		break;
 
 	case GPIO_SET_OUTPUT:
+	case GPIO_SET_OUTPUT_LOW:
+	case GPIO_SET_OUTPUT_HIGH:
 	case GPIO_SET_INPUT:
 	case GPIO_SET_ALT_1:
 		gpio_set_function(arg, cmd);


### PR DESCRIPTION
This is needed to prevent a race condition triggering a device while configuring it. For example, you can end up triggering a parachute release on boot, or a camera shutter release.

