### PR TITLE
px4iofirmware: ignore safety when override is enabled

### DIFF
--- a/src/modules/px4iofirmware/mixer.cpp
+++ b/src/modules/px4iofirmware/mixer.cpp
@@ -180,9 +180,10 @@ mixer_tick(void)
 	 * FMU or from the mixer.
 	 *
 	 */
+	bool effective_safety_off = (r_status_flags & PX4IO_P_STATUS_FLAGS_SAFETY_OFF) != 0 || override_enabled;
 	should_arm = (
 			     /* IO initialised without error */ (r_status_flags & PX4IO_P_STATUS_FLAGS_INIT_OK)
-			     /* and IO is armed */ 		  && (r_status_flags & PX4IO_P_STATUS_FLAGS_SAFETY_OFF)
+			     /* and IO is armed */ 		  && effective_safety_off
 			     /* and FMU is armed */ 		  && (
 				     ((r_setup_arming & PX4IO_P_SETUP_ARMING_FMU_ARMED)
 				      /* and there is valid input via or mixer */         && (r_status_flags & PX4IO_P_STATUS_FLAGS_MIXER_OK))

--- a/src/modules/px4iofirmware/px4io.h
+++ b/src/modules/px4iofirmware/px4io.h
@@ -80,6 +80,7 @@
 extern uint16_t			r_page_status[];	/* PX4IO_PAGE_STATUS */
 extern uint16_t			r_page_actuators[];	/* PX4IO_PAGE_ACTUATORS */
 extern uint16_t			r_page_servos[];	/* PX4IO_PAGE_SERVOS */
+extern uint16_t			r_page_direct_pwm[];	/* PX4IO_PAGE_DIRECT_PWM */
 extern uint16_t			r_page_raw_rc_input[];	/* PX4IO_PAGE_RAW_RC_INPUT */
 extern uint16_t			r_page_rc_input[];	/* PX4IO_PAGE_RC_INPUT */
 extern uint16_t			r_page_adc[];		/* PX4IO_PAGE_RAW_ADC_INPUT */

--- a/src/modules/px4iofirmware/registers.c
+++ b/src/modules/px4iofirmware/registers.c
@@ -142,6 +142,13 @@ uint16_t		r_page_rc_input[] = {
 uint16_t		r_page_scratch[32];
 
 /**
+ * PAGE 8
+ *
+ * RAW PWM values
+ */
+uint16_t		r_page_direct_pwm[PX4IO_SERVO_COUNT];
+
+/**
  * PAGE 100
  *
  * Setup registers
@@ -292,7 +299,7 @@ registers_set(uint8_t page, uint8_t offset, const uint16_t *values, unsigned num
 
 			/* XXX range-check value? */
 			if (*values != PWM_IGNORE_THIS_CHANNEL) {
-				r_page_servos[offset] = *values;
+				r_page_direct_pwm[offset] = *values;
 			}
 
 			offset++;
@@ -961,7 +968,7 @@ registers_get(uint8_t page, uint8_t offset, uint16_t **values, unsigned *num_val
 		break;
 
 	case PX4IO_PAGE_DIRECT_PWM:
-		SELECT_PAGE(r_page_servos);
+		SELECT_PAGE(r_page_direct_pwm);
 		break;
 
 	case PX4IO_PAGE_FAILSAFE_PWM:


### PR DESCRIPTION
this forces PWM outputs in override, ignoring the safety state. This
makes in-flight reboot safer. ArduPilot has had this behaviour for a
while, but it was done in the FMU code by overriding the safety
state. That was not ideal as it didn't work during bootup and was racy
at all times.
