### PR TITLE
px4io: on config error ask IO to reboot to bootloader

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -692,6 +692,12 @@ PX4IO::init()
 
 		DEVICE_LOG("config read error");
 		mavlink_log_emergency(&_mavlink_log_pub, "[IO] config read fail, abort.");
+
+		// ask IO to reboot into bootloader as the failure may
+		// be due to mismatched firmware versions and we want
+		// the startup script to be able to load a new IO
+		// firmware
+		io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_REBOOT_BL, PX4IO_REBOOT_BL_MAGIC);
 		return -1;
 	}
 


### PR DESCRIPTION
this allows us to update fw when core config settings have changed,
such as the actuators/servos change that happened recently