### PR TITLE
px4io: set reasonable default voltage scaling

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1076,7 +1076,7 @@ PX4IO::task_main()
 				io_set_rc_config();
 
 				/* re-set the battery scaling */
-				int32_t voltage_scaling_val;
+				int32_t voltage_scaling_val = 10000;
 				param_t voltage_scaling_param;
 
 				/* set battery voltage scaling */


### PR DESCRIPTION
needed for when px4 param system not available in ardupilot