### PR TITLE
ms5611: Fix to start drivers for all devices present at boot.

### DIFF
--- a/src/drivers/ms5611/ms5611_nuttx.cpp
+++ b/src/drivers/ms5611/ms5611_nuttx.cpp
@@ -963,7 +963,7 @@ start(enum MS5611_BUS busid)
 			continue;
 		}
 
-		started = started || start_bus(bus_options[i]);
+		started = started | start_bus(bus_options[i]);
 	}
 
 	if (!started) {


### PR DESCRIPTION
This is needed to prevent boolean short-circuit eval stopping the start of a 2nd ms5611
