### PR TITLE
ms5611: cope with early Pixracer prototypes

### DIFF
--- a/src/drivers/ms5611/ms5611_nuttx.cpp
+++ b/src/drivers/ms5611/ms5611_nuttx.cpp
@@ -830,6 +830,10 @@ struct ms5611_bus_option {
 #endif
 #ifdef PX4_SPIDEV_BARO
 	{ MS5611_BUS_SPI_INTERNAL, "/dev/ms5611_spi_int", &MS5611_spi_interface, PX4_SPI_BUS_BARO, NULL },
+#if PX4_SPI_BUS_BARO != PX4_SPI_BUS_SENSORS
+	// cope with early prototypes of the Pixracer, where baro is on sensors bus
+	{ MS5611_BUS_SPI_INTERNAL, "/dev/ms5611_spi_int2", &MS5611_spi_interface, PX4_SPI_BUS_SENSORS, NULL },
+#endif
 #endif
 #ifdef PX4_I2C_BUS_ONBOARD
 	{ MS5611_BUS_I2C_INTERNAL, "/dev/ms5611_int", &MS5611_i2c_interface, PX4_I2C_BUS_ONBOARD, NULL },


### PR DESCRIPTION
ms5611 was on sensors bus in earlier prototypes