### PR TITLE
px4fmu: allow control of safety state on FMUv4

### DIFF
--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1517,9 +1517,16 @@ PX4FMU::pwm_ioctl(file *filp, int cmd, unsigned long arg)
 
 	case PWM_SERVO_SET_ARM_OK:
 	case PWM_SERVO_CLEAR_ARM_OK:
+		break;
+
 	case PWM_SERVO_SET_FORCE_SAFETY_OFF:
+		/* force safety switch off */
+		_safety_off = true;
+		break;
+
 	case PWM_SERVO_SET_FORCE_SAFETY_ON:
-		// these are no-ops, as no safety switch
+		/* force safety switch on */
+		_safety_off = false;
 		break;
 
 	case PWM_SERVO_DISARM:


### PR DESCRIPTION
allows for MAVLink control of safety state