### PR TITLE
uavcan: add IOCTL interface for queryiung node discovery progress

### DIFF
--- a/src/modules/uavcan/uavcan_main.cpp
+++ b/src/modules/uavcan/uavcan_main.cpp
@@ -1121,6 +1121,24 @@ UavcanNode::ioctl(file *filp, int cmd, unsigned long arg)
 		}
 		break;
 
+	case UAVCAN_IOCG_NODEID_INPROGRESS: {
+		UavcanServers   *_servers = UavcanServers::instance();
+
+		if (_servers == nullptr) {
+			// status unavailable
+			ret = -EINVAL;
+			break;
+		} else if (_servers->guessIfAllDynamicNodesAreAllocated()) {
+			// node discovery complete
+			ret = -ETIME;
+			break;
+		} else {
+			// node discovery in progress
+			ret = OK;
+			break;
+		}
+	}
+
 	default:
 		ret = -ENOTTY;
 		break;

--- a/src/modules/uavcan/uavcan_servers.hpp
+++ b/src/modules/uavcan/uavcan_servers.hpp
@@ -100,6 +100,8 @@ public:
 
 	void requestCheckAllNodesFirmwareAndUpdate() { _check_fw = true; }
 
+	bool guessIfAllDynamicNodesAreAllocated() { return _server_instance.guessIfAllDynamicNodesAreAllocated(); }
+
 private:
 	pthread_t         _subnode_thread;
 	pthread_mutex_t   _subnode_mutex;


### PR DESCRIPTION
libuavcan recently got extended by @pavel-kirienko to provide information about the node discovery / dynamic id allocation progress. This information is made available via ioctl interface.