### PR TITLE
added SET_MODE ioctl for px4fmu

### DIFF
--- a/src/drivers/drv_pwm_output.h
+++ b/src/drivers/drv_pwm_output.h
@@ -241,6 +241,23 @@ struct pwm_output_rc_config {
 /** setup OVERRIDE_IMMEDIATE behaviour on FMU fail */
 #define PWM_SERVO_SET_OVERRIDE_IMMEDIATE	_PX4_IOC(_PWM_SERVO_BASE, 30)
 
+/** set SBUS output frame rate in Hz */
+#define PWM_SERVO_SET_SBUS_RATE			_PX4_IOC(_PWM_SERVO_BASE, 31)
+
+/** set auxillary output mode. These correspond to enum Mode in px4fmu/fmu.cpp */
+#define PWM_SERVO_MODE_NONE			0
+#define PWM_SERVO_MODE_2PWM			1
+#define PWM_SERVO_MODE_2PWM2CAP			2
+#define PWM_SERVO_MODE_3PWM			3
+#define PWM_SERVO_MODE_3PWM1CAP			4
+#define PWM_SERVO_MODE_4PWM			5
+#define PWM_SERVO_MODE_6PWM			6
+#define PWM_SERVO_MODE_8PWM			7
+#define PWM_SERVO_MODE_4CAP			8
+#define PWM_SERVO_MODE_5CAP			9
+#define PWM_SERVO_MODE_6CAP		       10
+#define PWM_SERVO_SET_MODE			_PX4_IOC(_PWM_SERVO_BASE, 32)
+
 /*
  *
  *

--- a/src/drivers/drv_pwm_output.h
+++ b/src/drivers/drv_pwm_output.h
@@ -244,21 +244,21 @@ struct pwm_output_rc_config {
 /*
  *
  *
- * WARNING WARNING WARNING! DO NOT EXCEED 31 IN IOC INDICES HERE!
+ * WARNING WARNING WARNING! DO NOT EXCEED 47 IN IOC INDICES HERE!
  *
  *
  */
 
 /** set a single servo to a specific value */
-#define PWM_SERVO_SET(_servo)	_PX4_IOC(_PWM_SERVO_BASE, 0x20 + _servo)
+#define PWM_SERVO_SET(_servo)	_PX4_IOC(_PWM_SERVO_BASE, 0x30 + _servo)
 
 /** get a single specific servo value */
-#define PWM_SERVO_GET(_servo)	_PX4_IOC(_PWM_SERVO_BASE, 0x40 + _servo)
+#define PWM_SERVO_GET(_servo)	_PX4_IOC(_PWM_SERVO_BASE, 0x50 + _servo)
 
 /** get the _n'th rate group's channels; *(uint32_t *)arg returns a bitmap of channels
  *  whose update rates must be the same.
  */
-#define PWM_SERVO_GET_RATEGROUP(_n) _PX4_IOC(_PWM_SERVO_BASE, 0x60 + _n)
+#define PWM_SERVO_GET_RATEGROUP(_n) _PX4_IOC(_PWM_SERVO_BASE, 0x70 + _n)
 
 /*
  * Low-level PWM output interface.

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1897,6 +1897,59 @@ PX4FMU::pwm_ioctl(file *filp, int cmd, unsigned long arg)
 			break;
 		}
 
+	case PWM_SERVO_SET_MODE: {
+			switch (arg) {
+			case PWM_SERVO_MODE_NONE:
+				ret = set_mode(MODE_NONE);
+				break;
+
+			case PWM_SERVO_MODE_2PWM:
+				ret = set_mode(MODE_2PWM);
+				break;
+
+			case PWM_SERVO_MODE_2PWM2CAP:
+				ret = set_mode(MODE_2PWM2CAP);
+				break;
+
+			case PWM_SERVO_MODE_3PWM:
+				ret = set_mode(MODE_3PWM);
+				break;
+
+			case PWM_SERVO_MODE_3PWM1CAP:
+				ret = set_mode(MODE_3PWM1CAP);
+				break;
+
+			case PWM_SERVO_MODE_4PWM:
+				ret = set_mode(MODE_4PWM);
+				break;
+
+			case PWM_SERVO_MODE_6PWM:
+				ret = set_mode(MODE_6PWM);
+				break;
+
+			case PWM_SERVO_MODE_8PWM:
+				ret = set_mode(MODE_8PWM);
+				break;
+
+			case PWM_SERVO_MODE_4CAP:
+				ret = set_mode(MODE_4CAP);
+				break;
+
+			case PWM_SERVO_MODE_5CAP:
+				ret = set_mode(MODE_5CAP);
+				break;
+
+			case PWM_SERVO_MODE_6CAP:
+				ret = set_mode(MODE_6CAP);
+				break;
+
+			default:
+				ret = -EINVAL;
+			}
+
+			break;
+		}
+
 #ifdef RC_SERIAL_PORT
 
 	case DSM_BIND_START:


### PR DESCRIPTION
allows ioctl control of the new AUX channel timer capture from David Sidrane
