### PR TITLE
enable commander hil option when  hils mode

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -330,7 +330,12 @@ then
 	sh /etc/init.d/rc.sensors
 
 	# Needs to be this early for in-air-restarts
-	commander start
+	if [ $OUTPUT_MODE == hil ]
+	then
+	    commander start -hil
+	else
+	    commander start
+	fi
 
 	#
 	# Start primary output

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1132,10 +1132,10 @@ int commander_thread_main(int argc, char *argv[])
 #endif
 
 	if (argc > 2) {
-		if (!strcmp(argv[2],"-hil")) {
+		if (!strcmp(argv[3],"-hil")) {
 			startup_in_hil = true;
 		} else {
-			PX4_ERR("Argument %s not supported.", argv[2]);
+			PX4_ERR("Argument %s not supported.", argv[3]);
 			PX4_ERR("COMMANDER NOT STARTED");
 			thread_should_exit = true;
 		}

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1132,10 +1132,10 @@ int commander_thread_main(int argc, char *argv[])
 #endif
 
 	if (argc > 2) {
-		if (!strcmp(argv[3],"-hil")) {
+		if (!strcmp(argv[2],"-hil")) {
 			startup_in_hil = true;
 		} else {
-			PX4_ERR("Argument %s not supported.", argv[3]);
+			PX4_ERR("Argument %s not supported.", argv[2]);
 			PX4_ERR("COMMANDER NOT STARTED");
 			thread_should_exit = true;
 		}


### PR DESCRIPTION
Recently, I developed gazebo HILS.  and I found there are problem about altitude and attitude because of initial real sensor information.

So, If there is hils mode, real sensor information is removed.

Thanks 
STMOON

P.S.

refer to the video. (not applied version)
  https://youtu.be/dW9w_trGjvc 
  https://youtu.be/zxe9y-d_jTk

also refer to the group news
 https://groups.google.com/forum/#!searchin/px4users/gazebo$20HILS/px4users/dGUZfkzhGi8/MOHDdE97AwAJ