### PR TITLE
Add new config for the Sparkle Tech 1.2m Pigeon flying wing.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/3036_pigeon
+++ b/ROMFS/px4fmu_common/init.d/3036_pigeon
@@ -1,0 +1,55 @@
+#!nsh
+#
+# @name Sparkle Tech Pigeon
+#
+# @url http://www.sparkletech.hk/
+#
+# @type Flying Wing
+#
+# @output MAIN1 left aileron
+# @output MAIN2 right aileron
+# @output MAIN4 throttle
+#
+# @output AUX1 feed-through of RC AUX1 channel
+# @output AUX2 feed-through of RC AUX2 channel
+# @output AUX3 feed-through of RC AUX3 channel
+#
+# @maintainer Simon Wilks <simon@px4.io>
+#
+
+sh /etc/init.d/rc.fw_defaults
+
+if [ $AUTOCNF == yes ]
+then
+	param set FW_AIRSPD_MIN 15
+	param set FW_AIRSPD_TRIM 20
+	param set FW_AIRSPD_MAX 27
+	param set FW_ATT_TC 0.3
+	param set FW_L1_DAMPING 0.75
+	param set FW_L1_PERIOD 15
+	param set FW_PR_FF 0.35
+	param set FW_PR_IMAX 0.2
+	param set FW_PR_P 0.05
+	param set FW_P_LIM_MAX 45
+	param set FW_P_LIM_MIN -45
+	param set FW_P_ROLLFF 1
+	param set FW_P_TC 0.3
+	param set FW_RR_FF 0.3
+	param set FW_RR_IMAX 0.2
+	param set FW_RR_P 0.03
+	param set FW_R_LIM 40
+	param set FW_R_RMAX 50
+	param set FW_R_TC 0.3
+
+	# Bottom of bay and nominal zero-pitch attitude differ
+	# the payload bay is pitched up about 7 degrees
+	param set SENS_BOARD_Y_OFF 11.9
+
+	param set FW_L1_PERIOD 20.0
+fi
+
+set MIXER phantom
+
+# Provide ESC a constant 1000 us pulse
+set PWM_OUT 4
+set PWM_DISARMED 1000


### PR DESCRIPTION
Test flown on a full composite 1.2m wingspan flying wing from Sparkle Tech.

![](http://www.sparkletech.hk/wp-content/uploads/2015/08/pigeon.jpg)

Product details: http://www.sparkletech.hk/%E9%B9%B0%E7%9C%BC-%E6%97%A0%E4%BA%BA%E6%9C%BA/electric-power/1-2m-pigeon/

It flies and lands fast (actually has a parachute bay as an alternative landing method). Fly too slow and it will punish you with a big stall. 