### PR TITLE
Motor ramp test app

### DIFF
--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -68,6 +68,7 @@ set(config_module_list
 	systemcmds/ver
 	#systemcmds/sd_bench
 	#systemcmds/tests
+	systemcmds/motor_ramp
 
 	#
 	# General system control

--- a/cmake/configs/nuttx_px4fmu-v4_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v4_default.cmake
@@ -68,6 +68,7 @@ set(config_module_list
 	systemcmds/ver
 	systemcmds/sd_bench
 	systemcmds/tests
+	systemcmds/motor_ramp
 
 	#
 	# General system control

--- a/cmake/configs/posix_sitl_default.cmake
+++ b/cmake/configs/posix_sitl_default.cmake
@@ -30,6 +30,7 @@ set(config_module_list
 	systemcmds/topic_listener
 	systemcmds/ver
 	systemcmds/top
+	systemcmds/motor_ramp
 
 	modules/attitude_estimator_ekf
 	modules/attitude_estimator_q

--- a/src/systemcmds/motor_ramp/CMakeLists.txt
+++ b/src/systemcmds/motor_ramp/CMakeLists.txt
@@ -1,0 +1,44 @@
+############################################################################
+#
+#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+px4_add_module(
+    MODULE systemcmds__motor_ramp
+    MAIN motor_ramp
+    STACK 1200
+    COMPILE_FLAGS
+        -Wno-write-strings
+    SRCS
+        motor_ramp.cpp
+    DEPENDS
+        platforms__common
+    )
+# vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/systemcmds/motor_ramp/motor_ramp.cpp
+++ b/src/systemcmds/motor_ramp/motor_ramp.cpp
@@ -1,0 +1,299 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2015 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file motor_ramp.cpp
+ * Application to test motor ramp up.
+ *
+ * @author Andreas Antener <andreas@uaventure.com>
+ */
+
+#include <px4_config.h>
+#include <px4_defines.h>
+#include <px4_tasks.h>
+#include <px4_posix.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <math.h>
+#include <poll.h>
+
+#include <arch/board/board.h>
+#include <drivers/drv_hrt.h>
+#include <drivers/drv_pwm_output.h>
+#include <uORB/uORB.h>
+#include <uORB/topics/actuator_outputs.h>
+#include <uORB/topics/control_state.h>
+#include <platforms/px4_defines.h>
+
+#include "systemlib/systemlib.h"
+#include "systemlib/err.h"
+
+static bool thread_should_exit = false;		/**< motor_ramp exit flag */
+static bool thread_running = false;		/**< motor_ramp status flag */
+static int motor_ramp_task;				/**< Handle of motor_ramp task / thread */
+
+enum RampState {
+	RAMP_INIT,
+	RAMP_MIN,
+	RAMP_RAMP,
+	RAMP_WAIT
+};
+
+/**
+ * motor_ramp management function.
+ */
+extern "C" __EXPORT int motor_ramp_main(int argc, char *argv[]);
+
+/**
+ * Mainloop of motor_ramp.
+ */
+int motor_ramp_thread_main(int argc, char *argv[]);
+
+/**
+ * Print the correct usage.
+ */
+static void usage(const char *reason);
+
+static void
+usage(const char *reason)
+{
+	if (reason) {
+		PX4_WARN("%s\n", reason);
+	}
+
+	PX4_WARN("usage: motor_ramp {start|stop|status} [-p <additional params>]\n\n");
+}
+
+/**
+ * The motor_ramp app only briefly exists to start
+ * the background job. The stack size assigned in the
+ * Makefile does only apply to this management task.
+ *
+ * The actual stack size should be set in the call
+ * to task_create().
+ */
+int motor_ramp_main(int argc, char *argv[])
+{
+	if (argc < 2) {
+		usage("missing command");
+		return 1;
+	}
+
+	if (!strcmp(argv[1], "start")) {
+
+		if (thread_running) {
+			PX4_WARN("motor_ramp already running\n");
+			/* this is not an error */
+			return 0;
+		}
+
+		thread_should_exit = false;
+		motor_ramp_task = px4_task_spawn_cmd("motor_ramp",
+						     SCHED_DEFAULT,
+						     SCHED_PRIORITY_DEFAULT,
+						     2000,
+						     motor_ramp_thread_main,
+						     (argv) ? (char *const *)&argv[2] : (char *const *)NULL);
+		return 0;
+	}
+
+	if (!strcmp(argv[1], "stop")) {
+		thread_should_exit = true;
+		return 0;
+	}
+
+	if (!strcmp(argv[1], "status")) {
+		if (thread_running) {
+			PX4_WARN("\trunning\n");
+
+		} else {
+			PX4_WARN("\tnot started\n");
+		}
+
+		return 0;
+	}
+
+	usage("unrecognized command");
+	return 1;
+}
+
+void set_min_pwm(unsigned pwm_value)
+{
+	int ret;
+	unsigned servo_count;
+	char *dev = PWM_OUTPUT0_DEVICE_PATH;
+	int fd = px4_open(dev, 0);
+
+	if (fd < 0) {PX4_WARN("can't open %s", dev);}
+
+	ret = px4_ioctl(fd, PWM_SERVO_GET_COUNT, (unsigned long)&servo_count);
+	struct pwm_output_values pwm_values;
+	memset(&pwm_values, 0, sizeof(pwm_values));
+
+	pwm_values.channel_count = servo_count;
+
+	for (int i = 0; i < servo_count; i++) {
+		pwm_values.values[i] = pwm_value;
+	}
+
+	ret = px4_ioctl(fd, PWM_SERVO_SET_MIN_PWM, (long unsigned int)&pwm_values);
+
+	if (ret != OK) {PX4_WARN("failed setting min values");}
+
+	px4_close(fd);
+}
+
+void publish(orb_advert_t actuator_outputs_pub, struct actuator_outputs_s &actuator_outputs, float output)
+{
+	//PX4_WARN("[motor_ramp] publish %f", (double)output);
+	for (int i = 0; i < actuator_outputs_s::NUM_ACTUATOR_OUTPUTS; i++) {
+		actuator_outputs.output[i] = output;
+	}
+	
+	orb_publish(ORB_ID(actuator_outputs), actuator_outputs_pub, &actuator_outputs);
+}
+
+int motor_ramp_thread_main(int argc, char *argv[])
+{
+	PX4_WARN("[motor_ramp] starting");
+
+	thread_running = true;
+
+	struct actuator_outputs_s actuator_outputs = {};
+	orb_advert_t actuator_outputs_pub = orb_advertise(ORB_ID(actuator_outputs), &actuator_outputs);
+	int ctrl_state_sub = orb_subscribe(ORB_ID(control_state));
+
+	/* wakeup source */
+	px4_pollfd_struct_t fds[1];
+
+	/* Setup of loop */
+	fds[0].fd = ctrl_state_sub;
+	fds[0].events = POLLIN;
+
+	float dt = 0.01f; // prevent division with 0
+	float timer = 0.0f;
+	hrt_abstime start = 0;
+	hrt_abstime last_run = 0;
+
+	enum RampState ramp_state = RAMP_INIT;
+	unsigned min_pwm = 1100;
+	float ramp_time = 0.5f;
+	float output = 0.0f;
+
+	publish(actuator_outputs_pub, actuator_outputs, 0.0f);
+
+	while (!thread_should_exit) {
+		if (last_run > 0) {
+			dt = hrt_elapsed_time(&last_run) * 1e-6;
+
+		} else {
+			start = hrt_absolute_time();
+		}
+
+		last_run = hrt_absolute_time();
+		timer = hrt_elapsed_time(&start) * 1e-6;
+
+		/* wait for up to 500ms for data */
+		int pret = px4_poll(&fds[0], (sizeof(fds) / sizeof(fds[0])), 100);
+
+		/* timed out - periodic check for _task_should_exit, etc. */
+		if (pret == 0) {
+			continue;
+		}
+
+		/* this is undesirable but not much we can do - might want to flag unhappy status */
+		if (pret < 0) {
+			PX4_WARN("[motor_ramp] poll error %d", pret);
+			continue;
+		}
+
+		switch (ramp_state) {
+		case RAMP_INIT: {
+				if (min_pwm > 1350) {
+					thread_should_exit = true;
+					PX4_WARN("[motor_ramp] pwm min too high %d", min_pwm);
+					break;
+				}
+
+				PX4_WARN("[motor_ramp] setting pwm min %d", min_pwm);
+				set_min_pwm(min_pwm);
+				ramp_state = RAMP_MIN;
+				break;
+			}
+
+		case RAMP_MIN: {
+				if (timer > 3.0f) {
+					PX4_WARN("[motor_ramp] min set, starting ramp");
+					start = hrt_absolute_time();
+					ramp_state = RAMP_RAMP;
+				}
+
+				break;
+			}
+
+		case RAMP_RAMP: {
+				output += dt / ramp_time;
+
+				if (output > 1.0f) {
+					output = 1.0f;
+					start = hrt_absolute_time();
+					ramp_state = RAMP_WAIT;
+					PX4_WARN("[motor_ramp] ramp finished, waiting");
+				}
+
+				publish(actuator_outputs_pub, actuator_outputs, output);
+				break;
+			}
+
+		case RAMP_WAIT: {
+				if (timer > 3.0f) {
+					thread_should_exit = true;
+					break;
+				}
+
+				break;
+			}
+		}
+	}
+
+	publish(actuator_outputs_pub, actuator_outputs, 0.0f);
+
+	PX4_WARN("[motor_ramp] exiting");
+
+	thread_running = false;
+
+	return 0;
+}

--- a/src/systemcmds/motor_ramp/motor_ramp.cpp
+++ b/src/systemcmds/motor_ramp/motor_ramp.cpp
@@ -135,7 +135,7 @@ int motor_ramp_main(int argc, char *argv[])
 		return 1;
 	}
 
-	_ramp_time = strtof(argv[2], NULL);
+	_ramp_time = atof(argv[2]);
 
 	if (!(_ramp_time > 0)) {
 		usage("ramp time must be greater than 0");

--- a/src/systemcmds/motor_ramp/motor_ramp.cpp
+++ b/src/systemcmds/motor_ramp/motor_ramp.cpp
@@ -101,8 +101,11 @@ usage(const char *reason)
 		PX4_WARN("[motor_ramp] %s", reason);
 	}
 
-	PX4_WARN("[motor_ramp] usage:   motor_ramp <min_pwm> <ramp_time>");
-	PX4_WARN("[motor_ramp] example: motor_ramp 1100 0.5\n");
+	PX4_WARN("[motor_ramp] usage: motor_ramp <min_pwm> <ramp_time>");
+	PX4_WARN("[motor_ramp] example:\n");
+	PX4_WARN("[motor_ramp] nsh> sdlog2 on");
+	PX4_WARN("[motor_ramp] nsh> mc_att_control stop");
+	PX4_WARN("[motor_ramp] nsh> motor_ramp 1100 0.5\n");
 }
 
 /**
@@ -143,7 +146,7 @@ int motor_ramp_main(int argc, char *argv[])
 	_thread_should_exit = false;
 	_motor_ramp_task = px4_task_spawn_cmd("motor_ramp",
 					      SCHED_DEFAULT,
-					      SCHED_PRIORITY_DEFAULT,
+					      SCHED_PRIORITY_DEFAULT + 40,
 					      2000,
 					      motor_ramp_thread_main,
 					      (argv) ? (char *const *)&argv[2] : (char *const *)NULL);
@@ -304,7 +307,7 @@ int motor_ramp_thread_main(int argc, char *argv[])
 			}
 
 		case RAMP_WAIT: {
-				if (timer > 3.0f) {
+				if (timer > 2.0f) {
 					_thread_should_exit = true;
 					break;
 				}

--- a/src/systemcmds/motor_ramp/motor_ramp.cpp
+++ b/src/systemcmds/motor_ramp/motor_ramp.cpp
@@ -98,11 +98,12 @@ static void
 usage(const char *reason)
 {
 	if (reason) {
-		PX4_WARN("[motor_ramp] %s", reason);
+		PX4_ERR("[motor_ramp] %s", reason);
 	}
 
+	PX4_WARN("[motor_ramp]\n\nWARNING: motors will ramp up to full speed!\n");
 	PX4_WARN("[motor_ramp] usage: motor_ramp <min_pwm> <ramp_time>");
-	PX4_WARN("[motor_ramp] example:\n");
+	PX4_WARN("[motor_ramp] example:");
 	PX4_WARN("[motor_ramp] nsh> sdlog2 on");
 	PX4_WARN("[motor_ramp] nsh> mc_att_control stop");
 	PX4_WARN("[motor_ramp] nsh> motor_ramp 1100 0.5\n");
@@ -250,7 +251,7 @@ int motor_ramp_thread_main(int argc, char *argv[])
 		_thread_should_exit = true;
 	}
 
-	PX4_WARN("[motor_ramp] max chan %d", max_channels);
+	PX4_WARN("[motor_ramp] max chan: %d", max_channels);
 
 	set_out(fd, max_channels, 0.0f);
 
@@ -275,7 +276,7 @@ int motor_ramp_thread_main(int argc, char *argv[])
 
 		switch (ramp_state) {
 		case RAMP_INIT: {
-				PX4_WARN("[motor_ramp] setting pwm min %d", _min_pwm);
+				PX4_WARN("[motor_ramp] setting pwm min: %d", _min_pwm);
 				set_min_pwm(fd, max_channels, _min_pwm);
 				ramp_state = RAMP_MIN;
 				break;
@@ -283,7 +284,7 @@ int motor_ramp_thread_main(int argc, char *argv[])
 
 		case RAMP_MIN: {
 				if (timer > 3.0f) {
-					PX4_WARN("[motor_ramp] starting ramp");
+					PX4_WARN("[motor_ramp] starting ramp: %.2f sec", (double)_ramp_time);
 					start = hrt_absolute_time();
 					ramp_state = RAMP_RAMP;
 				}
@@ -307,7 +308,7 @@ int motor_ramp_thread_main(int argc, char *argv[])
 			}
 
 		case RAMP_WAIT: {
-				if (timer > 2.0f) {
+				if (timer > 1.0f) {
 					_thread_should_exit = true;
 					break;
 				}

--- a/src/systemcmds/motor_ramp/motor_ramp.cpp
+++ b/src/systemcmds/motor_ramp/motor_ramp.cpp
@@ -251,7 +251,7 @@ int motor_ramp_thread_main(int argc, char *argv[])
 		_thread_should_exit = true;
 	}
 
-	PX4_WARN("[motor_ramp] max chan: %d", max_channels);
+	PX4_WARN("[motor_ramp] max chan: %lu", max_channels);
 
 	set_out(fd, max_channels, 0.0f);
 

--- a/src/systemcmds/motor_ramp/motor_ramp.cpp
+++ b/src/systemcmds/motor_ramp/motor_ramp.cpp
@@ -105,12 +105,12 @@ usage(const char *reason)
 	}
 
 	PX4_WARN("\n\nWARNING: motors will ramp up to full speed!\n\n"
-		"Usage: motor_ramp <min_pwm> <ramp_time> <-s>\n"
-		"Setting option <-s> will enable sinus output with period <ramp_time>\n\n"
-		"Example:\n"
-		"nsh> sdlog2 on\n"
-		"nsh> mc_att_control stop\n"
-		"nsh> motor_ramp 1100 0.5\n");
+		 "Usage: motor_ramp <min_pwm> <ramp_time> <-s>\n"
+		 "Setting option <-s> will enable sinus output with period <ramp_time>\n\n"
+		 "Example:\n"
+		 "nsh> sdlog2 on\n"
+		 "nsh> mc_att_control stop\n"
+		 "nsh> motor_ramp 1100 0.5\n");
 }
 
 /**

--- a/src/systemcmds/motor_ramp/motor_ramp.cpp
+++ b/src/systemcmds/motor_ramp/motor_ramp.cpp
@@ -148,6 +148,9 @@ int motor_ramp_main(int argc, char *argv[])
 		if (strcmp(argv[3], "-s") == 0) {
 			_sine_output = true;
 		}
+
+	} else {
+		_sine_output = false;
 	}
 
 	if (!(_ramp_time > 0)) {
@@ -311,10 +314,10 @@ int motor_ramp_thread_main(int argc, char *argv[])
 				} else {
 					// sine outpout with period T = _ramp_time and magnitude between [0,1]
 					// phase shift makes sure that it starts at zero when timer is zero
-					output = 0.5f * (1.0f + sinf(M_TWOPI_F * timer / (_ramp_time * 1e6f) - M_PI_2_F));
+					output = 0.5f * (1.0f + sinf(M_TWOPI_F * timer / _ramp_time - M_PI_2_F));
 				}
 
-				if ((output > 1.0f && !_sine_output) || (timer > 3.0f * _ramp_time * 1e6f && _sine_output)) {
+				if ((output > 1.0f && !_sine_output) || (timer > 3.0f * _ramp_time && _sine_output)) {
 					// for ramp mode we set output to 1, for sine mode we just leave it as is
 					output = _sine_output ? output : 1.0f;
 					start = hrt_absolute_time();

--- a/src/systemcmds/motor_ramp/motor_ramp.cpp
+++ b/src/systemcmds/motor_ramp/motor_ramp.cpp
@@ -101,16 +101,16 @@ static void
 usage(const char *reason)
 {
 	if (reason) {
-		PX4_ERR("[motor_ramp] %s", reason);
+		PX4_ERR("%s", reason);
 	}
 
-	PX4_WARN("[motor_ramp]\n\nWARNING: motors will ramp up to full speed!\n");
-	PX4_WARN("[motor_ramp] usage: motor_ramp <min_pwm> <ramp_time> <-s>");
-	PX4_WARN("[motor_ramp] setting option <-s> will enable sinus output with period <ramp_time>");
-	PX4_WARN("[motor_ramp] example:");
-	PX4_WARN("[motor_ramp] nsh> sdlog2 on");
-	PX4_WARN("[motor_ramp] nsh> mc_att_control stop");
-	PX4_WARN("[motor_ramp] nsh> motor_ramp 1100 0.5\n");
+	PX4_WARN("\n\nWARNING: motors will ramp up to full speed!\n");
+	PX4_WARN("Usage: motor_ramp <min_pwm> <ramp_time> <-s>");
+	PX4_WARN("Setting option <-s> will enable sinus output with period <ramp_time>");
+	PX4_WARN("Example:");
+	PX4_WARN("nsh> sdlog2 on");
+	PX4_WARN("nsh> mc_att_control stop");
+	PX4_WARN("nsh> motor_ramp 1100 0.5\n");
 }
 
 /**
@@ -189,7 +189,7 @@ int set_min_pwm(int fd, unsigned long max_channels, unsigned pwm_value)
 	ret = px4_ioctl(fd, PWM_SERVO_SET_MIN_PWM, (long unsigned int)&pwm_values);
 
 	if (ret != OK) {
-		PX4_ERR("[motor_ramp] failed setting min values");
+		PX4_ERR("failed setting min values");
 		return 1;
 	}
 
@@ -218,25 +218,25 @@ int prepare(int fd, unsigned long *max_channels)
 {
 	/* get number of channels available on the device */
 	if (px4_ioctl(fd, PWM_SERVO_GET_COUNT, (unsigned long)max_channels) != OK) {
-		PX4_ERR("[motor_ramp] PWM_SERVO_GET_COUNT");
+		PX4_ERR("PWM_SERVO_GET_COUNT");
 		return 1;
 	}
 
 	/* tell IO/FMU that its ok to disable its safety with the switch */
 	if (px4_ioctl(fd, PWM_SERVO_SET_ARM_OK, 0) != OK) {
-		PX4_ERR("[motor_ramp] PWM_SERVO_SET_ARM_OK");
+		PX4_ERR("PWM_SERVO_SET_ARM_OK");
 		return 1;
 	}
 
 	/* tell IO/FMU that the system is armed (it will output values if safety is off) */
 	if (px4_ioctl(fd, PWM_SERVO_ARM, 0) != OK) {
-		PX4_ERR("[motor_ramp] PWM_SERVO_ARM");
+		PX4_ERR("PWM_SERVO_ARM");
 		return 1;
 	}
 
 	/* tell IO to switch off safety without using the safety switch */
 	if (px4_ioctl(fd, PWM_SERVO_SET_FORCE_SAFETY_OFF, 0) != OK) {
-		PX4_ERR("[motor_ramp] PWM_SERVO_SET_FORCE_SAFETY_OFF");
+		PX4_ERR("PWM_SERVO_SET_FORCE_SAFETY_OFF");
 		return 1;
 	}
 
@@ -245,7 +245,7 @@ int prepare(int fd, unsigned long *max_channels)
 
 int motor_ramp_thread_main(int argc, char *argv[])
 {
-	PX4_WARN("[motor_ramp] starting");
+	PX4_WARN("starting");
 
 	_thread_running = true;
 
@@ -255,14 +255,14 @@ int motor_ramp_thread_main(int argc, char *argv[])
 	int fd = px4_open(dev, 0);
 
 	if (fd < 0) {
-		PX4_ERR("[motor_ramp] can't open %s", dev);
+		PX4_ERR("can't open %s", dev);
 	}
 
 	if (prepare(fd, &max_channels) != OK) {
 		_thread_should_exit = true;
 	}
 
-	PX4_WARN("[motor_ramp] max chan: %lu", max_channels);
+	PX4_WARN("max chan: %lu", max_channels);
 
 	set_out(fd, max_channels, 0.0f);
 
@@ -287,7 +287,7 @@ int motor_ramp_thread_main(int argc, char *argv[])
 
 		switch (ramp_state) {
 		case RAMP_INIT: {
-				PX4_WARN("[motor_ramp] setting pwm min: %d", _min_pwm);
+				PX4_WARN("setting pwm min: %d", _min_pwm);
 				set_min_pwm(fd, max_channels, _min_pwm);
 				ramp_state = RAMP_MIN;
 				break;
@@ -295,7 +295,7 @@ int motor_ramp_thread_main(int argc, char *argv[])
 
 		case RAMP_MIN: {
 				if (timer > 3.0f) {
-					PX4_WARN("[motor_ramp] starting %s: %.2f sec", _sine_output ? "sine" : "ramp", (double)_ramp_time);
+					PX4_WARN("starting %s: %.2f sec", _sine_output ? "sine" : "ramp", (double)_ramp_time);
 					start = hrt_absolute_time();
 					ramp_state = RAMP_RAMP;
 				}
@@ -319,7 +319,7 @@ int motor_ramp_thread_main(int argc, char *argv[])
 					output = _sine_output ? output : 1.0f;
 					start = hrt_absolute_time();
 					ramp_state = RAMP_WAIT;
-					PX4_WARN("[motor_ramp] %s finished, waiting", _sine_output ? "sine" : "ramp");
+					PX4_WARN("%s finished, waiting", _sine_output ? "sine" : "ramp");
 				}
 
 				set_out(fd, max_channels, output);
@@ -348,7 +348,7 @@ int motor_ramp_thread_main(int argc, char *argv[])
 		px4_close(fd);
 	}
 
-	PX4_WARN("[motor_ramp] exiting");
+	PX4_WARN("exiting");
 
 	_thread_running = false;
 


### PR DESCRIPTION
**WARNING: do not use this command unless you know exactly what you are doing, it will spin up all connected motors!**

This adds a new system command to do motor ramp tests. Based on bad experience with low KV quad setups we felt it is necessary to analyze this more closely. The issue with low KV setups is that you can easily over tune them and get props to stall. This app should accomplish 2 things:

- clarify and quantify the problem
- measure the limits of a specific system so we can tune it accordingly

If we understand the problem well enough we could then add protective measures, for example a PWM output slew rate limit.

TODO:
- [x] safety: what kind of protective measures should still be built in here to prevent this from accidentally going off? (at least I'll take the same protection over from the esc_calib routine)
- [x] sinus ramp: @tumbili 
