### PR TITLE
WIP: Dual GPS support implementation

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -124,8 +124,8 @@ private:
 	GPSHelper			*_helper;					///< instance of GPS parser
 	GPS_Sat_Info			*_sat_info;					///< instance of GPS sat info data object
 	struct vehicle_gps_position_s	_report_gps_pos;				///< uORB topic for gps position
-	orb_advert_t			_report_gps_pos_pub[2];				///< uORB pub for gps position
-	int					_gps_orb_instance[2];				///< uORB multi-topic instance
+	orb_advert_t			_report_gps_pos_pub;				///< uORB pub for gps position
+	int					_gps_orb_instance;				///< uORB multi-topic instance
 	struct satellite_info_s		*_p_report_sat_info;				///< pointer to uORB topic for satellite info
 	orb_advert_t			_report_sat_info_pub;				///< uORB pub for satellite info
 	float				_rate;						///< position update rate
@@ -226,8 +226,8 @@ GPS::GPS(const char *uart_path, bool fake_gps, bool enable_sat_info, int gps_num
 	_mode(GPS_DRIVER_MODE_UBX),
 	_helper(nullptr),
 	_sat_info(nullptr),
-	_report_gps_pos_pub{ nullptr, nullptr},
-	_gps_orb_instance{ -1, -1},
+	_report_gps_pos_pub{nullptr},
+	_gps_orb_instance(-1),
 	_p_report_sat_info(nullptr),
 	_report_sat_info_pub(nullptr),
 	_rate(0.0f),
@@ -803,24 +803,7 @@ GPS::print_info()
 void
 GPS::publish()
 {
-	if (_gps_num == 1) {
-		if (_report_gps_pos_pub[0] != nullptr) {
-			orb_publish(ORB_ID(vehicle_gps_position), _report_gps_pos_pub[0], &_report_gps_pos);
-
-		} else {
-			_report_gps_pos_pub[0] = orb_advertise_multi(ORB_ID(vehicle_gps_position), &_report_gps_pos, &_gps_orb_instance[0], ORB_PRIO_DEFAULT);
-			orb_publish(ORB_ID(vehicle_gps_position), _report_gps_pos_pub[0], &_report_gps_pos);
-		}
-
-	} else {
-		if (_report_gps_pos_pub[1] != nullptr) {
-			orb_publish(ORB_ID(vehicle_gps_position), _report_gps_pos_pub[1], &_report_gps_pos);
-
-		} else {
-			_report_gps_pos_pub[1] = orb_advertise_multi(ORB_ID(vehicle_gps_position), &_report_gps_pos, &_gps_orb_instance[1], ORB_PRIO_DEFAULT);
-			orb_publish(ORB_ID(vehicle_gps_position), _report_gps_pos_pub[1], &_report_gps_pos);
-		}
-	}
+			orb_publish_auto(ORB_ID(vehicle_gps_position), &_report_gps_pos_pub, &_report_gps_pos, &_gps_orb_instance, ORB_PRIO_DEFAULT);
 }
 
 /**

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -303,10 +303,12 @@ int GPS::init()
 
 void GPS::task_main_trampoline(int argc, char *argv[])
 {
-	 if (!strcmp(argv[1], "1"))
-	 g_dev[0]->task_main();
-	 else if (!strcmp(argv[1], "2"))
-	 g_dev[1]->task_main();
+	if (!strcmp(argv[1], "1")) {
+		g_dev[0]->task_main();
+
+	} else if (!strcmp(argv[1], "2")) {
+		g_dev[1]->task_main();
+	}
 }
 
 int GPS::callback(GPSCallbackType type, void *data1, int data2, void *user)
@@ -813,14 +815,14 @@ GPS::print_info()
 void
 GPS::publish()
 {
-	if(_gps_num == 1){
-	orb_publish_auto(ORB_ID(vehicle_gps_position), &_report_gps_pos_pub, &_report_gps_pos, &_gps_orb_instance,
-			 ORB_PRIO_DEFAULT);
-	is_gps1_advertised = true;
-	}
-	else if(is_gps1_advertised){
-			orb_publish_auto(ORB_ID(vehicle_gps_position), &_report_gps_pos_pub, &_report_gps_pos, &_gps_orb_instance,
-			 ORB_PRIO_DEFAULT);
+	if (_gps_num == 1) {
+		orb_publish_auto(ORB_ID(vehicle_gps_position), &_report_gps_pos_pub, &_report_gps_pos, &_gps_orb_instance,
+				 ORB_PRIO_DEFAULT);
+		is_gps1_advertised = true;
+
+	} else if (is_gps1_advertised) {
+		orb_publish_auto(ORB_ID(vehicle_gps_position), &_report_gps_pos_pub, &_report_gps_pos, &_gps_orb_instance,
+				 ORB_PRIO_DEFAULT);
 	}
 
 }
@@ -860,6 +862,7 @@ start(const char *uart_path, bool fake_gps, bool enable_sat_info, int gps_num)
 		if (OK != g_dev[0]->init()) {
 			goto fail1;
 		}
+
 		return;
 
 	} else {
@@ -879,6 +882,7 @@ start(const char *uart_path, bool fake_gps, bool enable_sat_info, int gps_num)
 			if (OK != g_dev[1]->init()) {
 				goto fail2;
 			}
+
 			return;
 
 		}

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -803,7 +803,8 @@ GPS::print_info()
 void
 GPS::publish()
 {
-			orb_publish_auto(ORB_ID(vehicle_gps_position), &_report_gps_pos_pub, &_report_gps_pos, &_gps_orb_instance, ORB_PRIO_DEFAULT);
+	orb_publish_auto(ORB_ID(vehicle_gps_position), &_report_gps_pos_pub, &_report_gps_pos, &_gps_orb_instance,
+			 ORB_PRIO_DEFAULT);
 }
 
 /**
@@ -900,6 +901,7 @@ stop()
 	if (g_dev2 != nullptr) {
 		delete g_dev2;
 	}
+
 	g_dev2 = nullptr;
 
 	px4_task_exit(0);

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -215,7 +215,7 @@ namespace
 {
 
 GPS	*g_dev[2] = {nullptr, nullptr};
-
+volatile bool is_gps1_advertised = false;
 }
 
 
@@ -814,8 +814,16 @@ GPS::print_info()
 void
 GPS::publish()
 {
+	if(_gps_num == 1){
 	orb_publish_auto(ORB_ID(vehicle_gps_position), &_report_gps_pos_pub, &_report_gps_pos, &_gps_orb_instance,
 			 ORB_PRIO_DEFAULT);
+	is_gps1_advertised = true;
+	}
+	else if(is_gps1_advertised){
+			orb_publish_auto(ORB_ID(vehicle_gps_position), &_report_gps_pos_pub, &_report_gps_pos, &_gps_orb_instance,
+			 ORB_PRIO_DEFAULT);
+	}
+
 }
 
 /**

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -278,6 +278,7 @@ GPS::~GPS()
 	}
 
 	g_dev = nullptr;
+	orb_unadvertise(_report_gps_pos_pub);
 
 }
 

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -303,7 +303,6 @@ int GPS::init()
 
 void GPS::task_main_trampoline(int argc, char *argv[])
 {
-	warnx("arg = %i %c %i", argc, *argv[0], *argv[0]);
 	 if (!strcmp(argv[1], "1"))
 	 g_dev[0]->task_main();
 	 else if (!strcmp(argv[1], "2"))

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -741,7 +741,7 @@ GPS::task_main()
 
 	::close(_serial_fd);
 
-	// free multitopic instances	
+	// free multitopic instances
 	orb_unadvertise(_report_gps_pos_pub);
 
 	/* tell the dtor that we are exiting */

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -215,6 +215,7 @@ namespace
 {
 
 GPS	*g_dev[2] = {nullptr, nullptr};
+// Variable to ensure that gps1 is always publishing to first topic
 volatile bool is_gps1_advertised = false;
 }
 
@@ -282,9 +283,9 @@ GPS::~GPS()
 int GPS::init()
 {
 
+	// needed in order to give task_main_trampoline the information which gps instance shall be called
 	char gps_num;
 	sprintf(&gps_num, "%d", _gps_num);
-
 	static char *gps_num_ptr;
 	gps_num_ptr = &gps_num;
 
@@ -303,6 +304,7 @@ int GPS::init()
 
 void GPS::task_main_trampoline(int argc, char *argv[])
 {
+	// check which gps instance to call
 	if (!strcmp(argv[1], "1")) {
 		g_dev[0]->task_main();
 
@@ -739,6 +741,7 @@ GPS::task_main()
 
 	::close(_serial_fd);
 
+	// free multitopic instances	
 	orb_unadvertise(_report_gps_pos_pub);
 
 	/* tell the dtor that we are exiting */
@@ -815,6 +818,7 @@ GPS::print_info()
 void
 GPS::publish()
 {
+	// publish to correct topic
 	if (_gps_num == 1) {
 		orb_publish_auto(ORB_ID(vehicle_gps_position), &_report_gps_pos_pub, &_report_gps_pos, &_gps_orb_instance,
 				 ORB_PRIO_DEFAULT);

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1255,7 +1255,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 		int local_pos_sp_sub;
 		int global_pos_sub;
 		int triplet_sub;
-		int gps_pos_sub;
+		int gps_pos_sub[2];
 		int sat_info_sub;
 		int att_pos_mocap_sub;
 		int vision_pos_sub;
@@ -1286,7 +1286,8 @@ int sdlog2_thread_main(int argc, char *argv[])
 	subs.cmd_sub = -1;
 	subs.status_sub = -1;
 	subs.vtol_status_sub = -1;
-	subs.gps_pos_sub = -1;
+	subs.gps_pos_sub[0] = -1;
+	subs.gps_pos_sub[1] = -1;
 	subs.sensor_sub = -1;
 	subs.att_sub = -1;
 	subs.att_sp_sub = -1;
@@ -1350,7 +1351,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 	if (log_on_start) {
 		/* check GPS topic to get GPS time */
 		if (log_name_timestamp) {
-			if (!copy_if_updated_multi(ORB_ID(vehicle_gps_position), 0, &subs.gps_pos_sub, &buf_gps_pos)) {
+			if (!copy_if_updated_multi(ORB_ID(vehicle_gps_position), 0, &subs.gps_pos_sub[0], &buf_gps_pos)) {
 				gps_time_sec = buf_gps_pos.time_utc_usec / 1e6;
 			}
 		}
@@ -1439,7 +1440,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 		}
 
 		/* --- GPS POSITION - LOG MANAGEMENT --- */
-		bool gps_pos_updated = copy_if_updated_multi(ORB_ID(vehicle_gps_position), 0, &subs.gps_pos_sub, &buf_gps_pos);
+		bool gps_pos_updated = copy_if_updated_multi(ORB_ID(vehicle_gps_position), 0, &subs.gps_pos_sub[0], &buf_gps_pos);
 
 		if (gps_pos_updated && log_name_timestamp) {
 			gps_time_sec = buf_gps_pos.time_utc_usec / 1e6;
@@ -1651,7 +1652,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 			}
 
 			/* --- GPS POSITION - UNIT #2 --- */
-			if (copy_if_updated_multi(ORB_ID(vehicle_gps_position), 1, &subs.gps_pos_sub, &buf.dual_gps_pos)) {
+			if (copy_if_updated_multi(ORB_ID(vehicle_gps_position), 1, &subs.gps_pos_sub[1], &buf.dual_gps_pos)) {
 				log_msg.msg_type = LOG_GPS_MSG;
 				log_msg.body.log_GPS.gps_time = buf.dual_gps_pos.time_utc_usec;
 				log_msg.body.log_GPS.fix_type = buf.dual_gps_pos.fix_type;

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1173,6 +1173,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 		struct camera_trigger_s camera_trigger;
 		struct ekf2_replay_s replay;
 		struct vehicle_land_detected_s land_detected;
+		struct vehicle_gps_position_s dual_gps_pos;
 	} buf;
 
 	memset(&buf, 0, sizeof(buf));
@@ -1349,7 +1350,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 	if (log_on_start) {
 		/* check GPS topic to get GPS time */
 		if (log_name_timestamp) {
-			if (!orb_copy(ORB_ID(vehicle_gps_position), subs.gps_pos_sub, &buf_gps_pos)) {
+			if (!copy_if_updated_multi(ORB_ID(vehicle_gps_position), 0, &subs.gps_pos_sub, &buf_gps_pos)) {
 				gps_time_sec = buf_gps_pos.time_utc_usec / 1e6;
 			}
 		}
@@ -1438,7 +1439,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 		}
 
 		/* --- GPS POSITION - LOG MANAGEMENT --- */
-		bool gps_pos_updated = copy_if_updated(ORB_ID(vehicle_gps_position), &subs.gps_pos_sub, &buf_gps_pos);
+		bool gps_pos_updated = copy_if_updated_multi(ORB_ID(vehicle_gps_position), 0, &subs.gps_pos_sub, &buf_gps_pos);
 
 		if (gps_pos_updated && log_name_timestamp) {
 			gps_time_sec = buf_gps_pos.time_utc_usec / 1e6;
@@ -1646,6 +1647,27 @@ int sdlog2_thread_main(int argc, char *argv[])
 				log_msg.body.log_GPS.snr_mean = snr_mean;
 				log_msg.body.log_GPS.noise_per_ms = buf_gps_pos.noise_per_ms;
 				log_msg.body.log_GPS.jamming_indicator = buf_gps_pos.jamming_indicator;
+				LOGBUFFER_WRITE_AND_COUNT(GPS);
+			}
+
+			/* --- GPS POSITION - UNIT #2 --- */
+			if (copy_if_updated_multi(ORB_ID(vehicle_gps_position), 1, &subs.gps_pos_sub, &buf.dual_gps_pos)) {
+				log_msg.msg_type = LOG_GPS_MSG;
+				log_msg.body.log_GPS.gps_time = buf.dual_gps_pos.time_utc_usec;
+				log_msg.body.log_GPS.fix_type = buf.dual_gps_pos.fix_type;
+				log_msg.body.log_GPS.eph = buf.dual_gps_pos.eph;
+				log_msg.body.log_GPS.epv = buf.dual_gps_pos.epv;
+				log_msg.body.log_GPS.lat = buf.dual_gps_pos.lat;
+				log_msg.body.log_GPS.lon = buf.dual_gps_pos.lon;
+				log_msg.body.log_GPS.alt = buf.dual_gps_pos.alt * 0.001f;
+				log_msg.body.log_GPS.vel_n = buf.dual_gps_pos.vel_n_m_s;
+				log_msg.body.log_GPS.vel_e = buf.dual_gps_pos.vel_e_m_s;
+				log_msg.body.log_GPS.vel_d = buf.dual_gps_pos.vel_d_m_s;
+				log_msg.body.log_GPS.cog = buf.dual_gps_pos.cog_rad;
+				log_msg.body.log_GPS.sats = buf.dual_gps_pos.satellites_used;
+				log_msg.body.log_GPS.snr_mean = snr_mean;
+				log_msg.body.log_GPS.noise_per_ms = buf.dual_gps_pos.noise_per_ms;
+				log_msg.body.log_GPS.jamming_indicator = buf.dual_gps_pos.jamming_indicator;
 				LOGBUFFER_WRITE_AND_COUNT(GPS);
 			}
 

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -146,6 +146,7 @@ struct log_LPSP_s {
 
 /* --- GPS - GPS POSITION --- */
 #define LOG_GPS_MSG 8
+#define LOG_DGPS_MSG 58
 struct log_GPS_s {
 	uint64_t gps_time;
 	uint8_t fix_type;
@@ -628,6 +629,7 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT(LPOS, "ffffffffLLfBBff",	"X,Y,Z,Dist,DistR,VX,VY,VZ,RLat,RLon,RAlt,PFlg,GFlg,EPH,EPV"),
 	LOG_FORMAT(LPSP, "ffffffffff",		"X,Y,Z,Yaw,VX,VY,VZ,AX,AY,AZ"),
 	LOG_FORMAT(GPS, "QBffLLfffffBHHH",	"GPSTime,Fix,EPH,EPV,Lat,Lon,Alt,VelN,VelE,VelD,Cog,nSat,SNR,N,J"),
+	LOG_FORMAT_S(DGPS, GPS,	 "QBffLLfffffBHHH",	"GPSTime,Fix,EPH,EPV,Lat,Lon,Alt,VelN,VelE,VelD,Cog,nSat,SNR,N,J"),
 	LOG_FORMAT_S(ATTC, ATTC, "ffff",		"Roll,Pitch,Yaw,Thrust"),
 	LOG_FORMAT_S(ATC1, ATTC, "ffff",		"Roll,Pitch,Yaw,Thrust"),
 	LOG_FORMAT(STAT, "BBBBf",		"MainState,NavState,ArmS,Failsafe,Load"),

--- a/src/modules/uORB/objects_common.cpp
+++ b/src/modules/uORB/objects_common.cpp
@@ -300,3 +300,7 @@ ORB_DEFINE(gps_inject_data, struct gps_inject_data_s);
 
 #include "topics/adc_report.h"
 ORB_DEFINE(adc_report, struct adc_report_s);
+
+#include <drivers/drv_gps.h>
+ORB_DEFINE(vehicle_gps_1_position, struct vehicle_gps_position_s);
+ORB_DEFINE(vehicle_gps_2_position, struct vehicle_gps_position_s);


### PR DESCRIPTION
This PR solves https://github.com/PX4/Firmware/issues/4005.

* The driver supports a second GPS. Can be started by calling `gps start -d /dev/tty3 -dualgps /dev/tty2`
* GPS signals are read out to vehicle_gps_1_position and vehicle_gps_2_position, for which logging is added (following multiple wishes in https://github.com/PX4/Firmware/issues/4005).
* By default vehicle_gps_1_position is mapped to the original topic vehicle_gps_position. A variable USE_DUAL_GPS = 1 allows the use of the second GPS according to specific needs. Within this PR a prototype of switching for VTOL in cruise or hover regime is implemented.
* Backward compatible: When calling `gps start -d /dev/tty3` or even `gps start`, only the primary GPS is started and mapped to the original topic.

Has been flight-tested in multiple occasions.