### PR TITLE
rename adsb timestamp to timestamp2

### DIFF
--- a/msg/transponder_report.msg
+++ b/msg/transponder_report.msg
@@ -1,4 +1,4 @@
-uint64 timestamp	# Timestamp of this position report
+uint64 timestamp2	# Timestamp automatically generated
 uint32 ICAO_address 	# ICAO address
 float64 lat 		# Latitude, expressed as degrees
 float64 lon 		# Longitude, expressed as degrees

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1659,7 +1659,7 @@ void MavlinkReceiver::handle_message_adsb_vehicle(mavlink_message_t *msg)
 
 	mavlink_msg_adsb_vehicle_decode(msg, &adsb);
 
-	t.timestamp = hrt_absolute_time();
+	t.timestamp2 = hrt_absolute_time();
 
 	t.ICAO_address = adsb.ICAO_address;
 	t.lat = adsb.lat*1e-7;


### PR DESCRIPTION
this avoids a conflict with the new uORB autogen code