### PR TITLE
WIP: Attitude message cleanup

### DIFF
--- a/cmake/configs/posix_sitl_default.cmake
+++ b/cmake/configs/posix_sitl_default.cmake
@@ -77,6 +77,7 @@ set(config_module_list
 	examples/mc_pos_control_multiplatform
 	examples/ekf_att_pos_estimator
 	examples/attitude_estimator_ekf
+	examples/fixedwing_control
 
 	#
 	# Testing

--- a/msg/vehicle_attitude.msg
+++ b/msg/vehicle_attitude.msg
@@ -4,5 +4,6 @@ float32 rollspeed	# Angular velocity about body north axis (x) in rad/s
 float32 pitchspeed	# Angular velocity about body east axis (y) in rad/s
 float32 yawspeed	# Angular velocity about body down axis (z) in rad/s
 float32[4] q		# Quaternion (NED)
+bool q_valid		# Quaternion valid
 
 # TOPICS vehicle_attitude vehicle_attitude_groundtruth

--- a/msg/vehicle_attitude.msg
+++ b/msg/vehicle_attitude.msg
@@ -1,8 +1,7 @@
-# This is similar to the mavlink message ATTITUDE, but for onboard use
+# This is similar to the mavlink message ATTITUDE_QUATERNION, but for onboard use
 float32 rollspeed	# Angular velocity about body north axis (x) in rad/s
 float32 pitchspeed	# Angular velocity about body east axis (y) in rad/s
 float32 yawspeed	# Angular velocity about body down axis (z) in rad/s
 float32[4] q		# Quaternion (NED)
-bool q_valid		# Quaternion valid
 
 # TOPICS vehicle_attitude vehicle_attitude_groundtruth

--- a/msg/vehicle_attitude.msg
+++ b/msg/vehicle_attitude.msg
@@ -1,5 +1,4 @@
-# This is similar to the mavlink message ATTITUDE, but for onboard use */
-uint64 timestamp	# in microseconds since system start
+# This is similar to the mavlink message ATTITUDE, but for onboard use
 float32 rollspeed	# Angular velocity about body north axis (x) in rad/s
 float32 pitchspeed	# Angular velocity about body east axis (y) in rad/s
 float32 yawspeed	# Angular velocity about body down axis (z) in rad/s

--- a/msg/vehicle_attitude.msg
+++ b/msg/vehicle_attitude.msg
@@ -1,22 +1,8 @@
 # This is similar to the mavlink message ATTITUDE, but for onboard use */
-# @warning roll, pitch and yaw have always to be valid, the rotation matrix and quaternion are optional
-float32 roll		# Roll angle (rad, Tait-Bryan, NED)
-float32 pitch		# Pitch angle (rad, Tait-Bryan, NED)
-float32 yaw		# Yaw angle (rad, Tait-Bryan, NED)
-float32 rollspeed	# Roll body angular rate (rad/s, x forward/y right/z down)
-float32 pitchspeed	# Pitch body angular rate (rad/s, x forward/y right/z down)
-float32 yawspeed	# Yaw body angular rate (rad/s, x forward/y right/z down)
-float32 rollacc		# Roll angular accelration (rad/s^2, x forward/y right/z down)
-float32 pitchacc	# Pitch angular acceleration (rad/s^2, x forward/y right/z down)
-float32 yawacc		# Yaw angular acceleration (rad/s^2, x forward/y right/z down)
-float32 rate_vibration	# Value between 0 and 1 indicating vibration. A value of 0 means no vibration, a value of 1 indicates unbearable vibration levels.
-float32 accel_vibration	# Value between 0 and 1 indicating vibration. A value of 0 means no vibration, a value of 1 indicates unbearable vibration levels.
-float32 mag_vibration	# Value between 0 and 1 indicating vibration. A value of 0 means no vibration, a value of 1 indicates unbearable vibration levels.
-float32[3] rate_offsets	# Offsets of the body angular rates from zero
-float32[9] R		# Rotation matrix, body to world, (Tait-Bryan, NED)
+uint64 timestamp	# in microseconds since system start
+float32 rollspeed	# Angular velocity about body north axis (x) in rad/s
+float32 pitchspeed	# Angular velocity about body east axis (y) in rad/s
+float32 yawspeed	# Angular velocity about body down axis (z) in rad/s
 float32[4] q		# Quaternion (NED)
-float32[3] g_comp	# Compensated gravity vector
-bool R_valid		# Rotation matrix valid
-bool q_valid		# Quaternion valid
 
 # TOPICS vehicle_attitude vehicle_attitude_groundtruth

--- a/msg/vehicle_attitude_setpoint.msg
+++ b/msg/vehicle_attitude_setpoint.msg
@@ -21,8 +21,6 @@ bool R_valid					# Set to true if rotation matrix is valid
 # For quaternion-based attitude control
 float32[4] q_d					# Desired quaternion for quaternion control
 bool q_d_valid					# Set to true if quaternion vector is valid
-float32[4] q_e					# Attitude error in quaternion
-bool q_e_valid					# Set to true if quaternion error vector is valid
 
 float32 thrust					# Thrust in Newton the power system should generate
 

--- a/src/drivers/bst/bst.cpp
+++ b/src/drivers/bst/bst.cpp
@@ -51,6 +51,8 @@
 #include <uORB/topics/battery_status.h>
 #include <mathlib/math/Quaternion.hpp>
 
+using namespace matrix;
+
 #define BST_DEVICE_PATH "/dev/bst0"
 
 static const char commandline_usage[] = "usage: bst start|status|stop";
@@ -290,13 +292,13 @@ void BST::cycle()
 		if (updated) {
 			vehicle_attitude_s att;
 			orb_copy(ORB_ID(vehicle_attitude), _attitude_sub, &att);
-			matrix::Quaternion<float> q(&att.q[0]);
-			matrix::Euler<float> euler(q);
+			Quatf q(att.q);
+			Eulerf euler(q);
 			BSTPacket<BSTAttitude> bst_att = {};
 			bst_att.type = 0x1E;
-			bst_att.payload.roll = swap_int32(euler(0) * 10000);
-			bst_att.payload.pitch = swap_int32(euler(1) * 10000);
-			bst_att.payload.yaw = swap_int32(euler(2) * 10000);
+			bst_att.payload.roll = swap_int32(euler.phi() * 10000);
+			bst_att.payload.pitch = swap_int32(euler.theta() * 10000);
+			bst_att.payload.yaw = swap_int32(euler.psi() * 10000);
 			send_packet(bst_att);
 		}
 

--- a/src/drivers/bst/bst.cpp
+++ b/src/drivers/bst/bst.cpp
@@ -49,6 +49,7 @@
 #include <math.h>
 #include <uORB/topics/vehicle_gps_position.h>
 #include <uORB/topics/battery_status.h>
+#include <mathlib/math/Quaternion.hpp>
 
 #define BST_DEVICE_PATH "/dev/bst0"
 
@@ -289,11 +290,13 @@ void BST::cycle()
 		if (updated) {
 			vehicle_attitude_s att;
 			orb_copy(ORB_ID(vehicle_attitude), _attitude_sub, &att);
+			matrix::Quaternion<float> q(&att.q[0]);
+			matrix::Euler<float> euler(q);
 			BSTPacket<BSTAttitude> bst_att = {};
 			bst_att.type = 0x1E;
-			bst_att.payload.roll = swap_int32(att.roll * 10000);
-			bst_att.payload.pitch = swap_int32(att.pitch * 10000);
-			bst_att.payload.yaw = swap_int32(att.yaw * 10000);
+			bst_att.payload.roll = swap_int32(euler(0) * 10000);
+			bst_att.payload.pitch = swap_int32(euler(1) * 10000);
+			bst_att.payload.yaw = swap_int32(euler(2) * 10000);
 			send_packet(bst_att);
 		}
 

--- a/src/drivers/vmount/output.cpp
+++ b/src/drivers/vmount/output.cpp
@@ -46,6 +46,7 @@
 #include <px4_defines.h>
 #include <geo/geo.h>
 #include <math.h>
+#include <mathlib/mathlib.h>
 
 namespace vmount
 {
@@ -186,11 +187,12 @@ void OutputBase::_calculate_output_angles(const hrt_abstime &t)
 		orb_copy(ORB_ID(vehicle_attitude), _vehicle_attitude_sub, &vehicle_attitude);
 	}
 
-	float att[3] = { vehicle_attitude.roll, vehicle_attitude.pitch, vehicle_attitude.yaw };
+	matrix::Quaternion<float> q(&vehicle_attitude.q[0]);
+	matrix::Euler<float> euler(q);
 
 	for (int i = 0; i < 3; ++i) {
 		if (_stabilize[i]) {
-			_angle_outputs[i] = _angle_setpoints[i] - att[i];
+			_angle_outputs[i] = _angle_setpoints[i] - euler(i);
 
 		} else {
 			_angle_outputs[i] = _angle_setpoints[i];

--- a/src/drivers/vmount/output.cpp
+++ b/src/drivers/vmount/output.cpp
@@ -187,8 +187,7 @@ void OutputBase::_calculate_output_angles(const hrt_abstime &t)
 		orb_copy(ORB_ID(vehicle_attitude), _vehicle_attitude_sub, &vehicle_attitude);
 	}
 
-	matrix::Quaternion<float> q(&vehicle_attitude.q[0]);
-	matrix::Euler<float> euler(q);
+	matrix::Eulerf euler = matrix::Quatf(vehicle_attitude.q);
 
 	for (int i = 0; i < 3; ++i) {
 		if (_stabilize[i]) {

--- a/src/examples/attitude_estimator_ekf/attitude_estimator_ekf_main.cpp
+++ b/src/examples/attitude_estimator_ekf/attitude_estimator_ekf_main.cpp
@@ -613,7 +613,6 @@ int attitude_estimator_ekf_thread_main(int argc, char *argv[])
 					/* magnetic declination */
 					matrix::Dcmf Ro(&Rot_matrix[0]);
 					matrix::Dcmf R_declination(&R_decl.data[0][0]);
-					Ro = R_declination * Ro;
 					matrix::Quatf q = matrix::Quatf(R_declination * Ro);
 
 					memcpy(&att.q[0],&q._data[0],sizeof(att.q));

--- a/src/examples/attitude_estimator_ekf/attitude_estimator_ekf_main.cpp
+++ b/src/examples/attitude_estimator_ekf/attitude_estimator_ekf_main.cpp
@@ -611,10 +611,10 @@ int attitude_estimator_ekf_thread_main(int argc, char *argv[])
 					att.yawspeed = x_aposteriori[2];
 
 					/* magnetic declination */
-					matrix::Dcm<float> R(&Rot_matrix[0]);
+					matrix::Dcm<float> Ro(&Rot_matrix[0]);
 					matrix::Dcm<float> R_declination(&R_decl.data[0][0]);
-					R = R_declination * R;
-					matrix::Quaternion<float> q(R);
+					Ro = R_declination * Ro;
+					matrix::Quaternion<float> q(Ro);
 
 					memcpy(&att.q[0],&q._data[0],sizeof(att.q));
 					att.q_valid = true;

--- a/src/examples/attitude_estimator_ekf/attitude_estimator_ekf_main.cpp
+++ b/src/examples/attitude_estimator_ekf/attitude_estimator_ekf_main.cpp
@@ -605,34 +605,30 @@ int attitude_estimator_ekf_thread_main(int argc, char *argv[])
 					/* send out */
 					att.timestamp = raw.timestamp;
 
-					att.roll = euler[0];
-					att.pitch = euler[1];
-					att.yaw = euler[2] + mag_decl;
 
 					att.rollspeed = x_aposteriori[0];
 					att.pitchspeed = x_aposteriori[1];
 					att.yawspeed = x_aposteriori[2];
-					att.rollacc = x_aposteriori[3];
-					att.pitchacc = x_aposteriori[4];
-					att.yawacc = x_aposteriori[5];
+					// att.rollacc = x_aposteriori[3];
+					// att.pitchacc = x_aposteriori[4];
+					// att.yawacc = x_aposteriori[5];
 
-					att.g_comp[0] = raw.accelerometer_m_s2[0] - acc(0);
-					att.g_comp[1] = raw.accelerometer_m_s2[1] - acc(1);
-					att.g_comp[2] = raw.accelerometer_m_s2[2] - acc(2);
+					// att.g_comp[0] = raw.accelerometer_m_s2[0] - acc(0);
+					// att.g_comp[1] = raw.accelerometer_m_s2[1] - acc(1);
+					// att.g_comp[2] = raw.accelerometer_m_s2[2] - acc(2);
 
-					/* copy offsets */
-					memcpy(&att.rate_offsets, &(x_aposteriori[3]), sizeof(att.rate_offsets));
+					// /* copy offsets */
+					// memcpy(&att.rate_offsets, &(x_aposteriori[3]), sizeof(att.rate_offsets));
 
 					/* magnetic declination */
 
-					math::Matrix<3, 3> R_body = (&Rot_matrix[0]);
-					R = R_decl * R_body;
-					math::Quaternion q;
-					q.from_dcm(R);
-					/* copy rotation matrix */
-					memcpy(&att.R[0], &R.data[0][0], sizeof(att.R));
-					memcpy(&att.q[0],&q.data[0],sizeof(att.q));
-					att.R_valid = true;
+					matrix::Dcm<float> R(&Rot_matrix[0]);
+					matrix::Dcm<float> R_declination(&R_decl.data[0][0]);
+					R = R_declination * R;
+					matrix::Quaternion<float> q(R);
+
+					memcpy(&att.q[0],&q._data[0],sizeof(att.q));
+					att.q_valid = true;
 
 					if (PX4_ISFINITE(att.q[0]) && PX4_ISFINITE(att.q[1])
 						&& PX4_ISFINITE(att.q[2]) && PX4_ISFINITE(att.q[3])) {

--- a/src/examples/attitude_estimator_ekf/attitude_estimator_ekf_main.cpp
+++ b/src/examples/attitude_estimator_ekf/attitude_estimator_ekf_main.cpp
@@ -609,19 +609,8 @@ int attitude_estimator_ekf_thread_main(int argc, char *argv[])
 					att.rollspeed = x_aposteriori[0];
 					att.pitchspeed = x_aposteriori[1];
 					att.yawspeed = x_aposteriori[2];
-					// att.rollacc = x_aposteriori[3];
-					// att.pitchacc = x_aposteriori[4];
-					// att.yawacc = x_aposteriori[5];
-
-					// att.g_comp[0] = raw.accelerometer_m_s2[0] - acc(0);
-					// att.g_comp[1] = raw.accelerometer_m_s2[1] - acc(1);
-					// att.g_comp[2] = raw.accelerometer_m_s2[2] - acc(2);
-
-					// /* copy offsets */
-					// memcpy(&att.rate_offsets, &(x_aposteriori[3]), sizeof(att.rate_offsets));
 
 					/* magnetic declination */
-
 					matrix::Dcm<float> R(&Rot_matrix[0]);
 					matrix::Dcm<float> R_declination(&R_decl.data[0][0]);
 					R = R_declination * R;

--- a/src/examples/attitude_estimator_ekf/attitude_estimator_ekf_main.cpp
+++ b/src/examples/attitude_estimator_ekf/attitude_estimator_ekf_main.cpp
@@ -614,7 +614,7 @@ int attitude_estimator_ekf_thread_main(int argc, char *argv[])
 					matrix::Dcmf Ro(&Rot_matrix[0]);
 					matrix::Dcmf R_declination(&R_decl.data[0][0]);
 					Ro = R_declination * Ro;
-					matrix::Quatf q = R_declination * Ro;
+					matrix::Quatf q = matrix::Quatf(R_declination * Ro);
 
 					memcpy(&att.q[0],&q._data[0],sizeof(att.q));
 

--- a/src/examples/attitude_estimator_ekf/attitude_estimator_ekf_main.cpp
+++ b/src/examples/attitude_estimator_ekf/attitude_estimator_ekf_main.cpp
@@ -611,10 +611,10 @@ int attitude_estimator_ekf_thread_main(int argc, char *argv[])
 					att.yawspeed = x_aposteriori[2];
 
 					/* magnetic declination */
-					matrix::Dcm<float> Ro(&Rot_matrix[0]);
-					matrix::Dcm<float> R_declination(&R_decl.data[0][0]);
+					matrix::Dcmf Ro(&Rot_matrix[0]);
+					matrix::Dcmf R_declination(&R_decl.data[0][0]);
 					Ro = R_declination * Ro;
-					matrix::Quaternion<float> q(Ro);
+					matrix::Quatf q = R_declination * Ro;
 
 					memcpy(&att.q[0],&q._data[0],sizeof(att.q));
 

--- a/src/examples/attitude_estimator_ekf/attitude_estimator_ekf_main.cpp
+++ b/src/examples/attitude_estimator_ekf/attitude_estimator_ekf_main.cpp
@@ -617,7 +617,6 @@ int attitude_estimator_ekf_thread_main(int argc, char *argv[])
 					matrix::Quaternion<float> q(Ro);
 
 					memcpy(&att.q[0],&q._data[0],sizeof(att.q));
-					att.q_valid = true;
 
 					if (PX4_ISFINITE(att.q[0]) && PX4_ISFINITE(att.q[1])
 						&& PX4_ISFINITE(att.q[2]) && PX4_ISFINITE(att.q[3])) {
@@ -625,7 +624,7 @@ int attitude_estimator_ekf_thread_main(int argc, char *argv[])
 						orb_publish(ORB_ID(vehicle_attitude), pub_att, &att);
 
 					} else {
-						warnx("ERR: NaN estimate!");
+						PX4_ERR("ERR: NaN estimate!");
 					}
 
 					perf_end(ekf_loop_perf);

--- a/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
+++ b/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
@@ -821,14 +821,6 @@ void AttitudePositionEstimatorEKF::publishAttitude()
 {
 	// Output results
 	matrix::Quaternion<float> q(_ekf->states[0], _ekf->states[1], _ekf->states[2], _ekf->states[3]);
-	//math::Matrix<3, 3> R = q.to_dcm();
-	//math::Vector<3> euler = R.to_euler();
-
-	/*for (int i = 0; i < 3; i++) {
-		for (int j = 0; j < 3; j++) {
-			PX4_R(_att.R, i, j) = R(i, j);
-		}
-	}*/
 
 	_att.timestamp = _last_sensor_timestamp;
 	_att.q[0] = _ekf->states[0];
@@ -840,11 +832,6 @@ void AttitudePositionEstimatorEKF::publishAttitude()
 	_att.rollspeed = _ekf->dAngIMU.x / _ekf->dtIMU - _ekf->states[10] / _ekf->dtIMUfilt;
 	_att.pitchspeed = _ekf->dAngIMU.y / _ekf->dtIMU - _ekf->states[11] / _ekf->dtIMUfilt;
 	_att.yawspeed = _ekf->dAngIMU.z / _ekf->dtIMU - _ekf->states[12] / _ekf->dtIMUfilt;
-
-	// gyro offsets
-	//_att.rate_offsets[0] = _ekf->states[10] / _ekf->dtIMUfilt;
-	//_att.rate_offsets[1] = _ekf->states[11] / _ekf->dtIMUfilt;
-	//_att.rate_offsets[2] = _ekf->states[12] / _ekf->dtIMUfilt;
 
 	/* lazily publish the attitude only once available */
 	if (_att_pub != nullptr) {

--- a/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
+++ b/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
@@ -820,7 +820,6 @@ void AttitudePositionEstimatorEKF::initializeGPS()
 void AttitudePositionEstimatorEKF::publishAttitude()
 {
 	// Output results
-	matrix::Quaternion<float> q(_ekf->states[0], _ekf->states[1], _ekf->states[2], _ekf->states[3]);
 
 	_att.timestamp = _last_sensor_timestamp;
 	_att.q[0] = _ekf->states[0];

--- a/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
+++ b/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
@@ -836,12 +836,6 @@ void AttitudePositionEstimatorEKF::publishAttitude()
 	_att.q[2] = _ekf->states[2];
 	_att.q[3] = _ekf->states[3];
 	_att.q_valid = true;
-	//_att.R_valid = true;
-
-	//_att.timestamp = _last_sensor_timestamp;
-	//_att.roll = euler(0);
-	//_att.pitch = euler(1);
-	//_att.yaw = euler(2);
 
 	_att.rollspeed = _ekf->dAngIMU.x / _ekf->dtIMU - _ekf->states[10] / _ekf->dtIMUfilt;
 	_att.pitchspeed = _ekf->dAngIMU.y / _ekf->dtIMU - _ekf->states[11] / _ekf->dtIMUfilt;

--- a/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
+++ b/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
@@ -820,15 +820,15 @@ void AttitudePositionEstimatorEKF::initializeGPS()
 void AttitudePositionEstimatorEKF::publishAttitude()
 {
 	// Output results
-	math::Quaternion q(_ekf->states[0], _ekf->states[1], _ekf->states[2], _ekf->states[3]);
-	math::Matrix<3, 3> R = q.to_dcm();
-	math::Vector<3> euler = R.to_euler();
+	matrix::Quaternion<float> q(_ekf->states[0], _ekf->states[1], _ekf->states[2], _ekf->states[3]);
+	//math::Matrix<3, 3> R = q.to_dcm();
+	//math::Vector<3> euler = R.to_euler();
 
-	for (int i = 0; i < 3; i++) {
+	/*for (int i = 0; i < 3; i++) {
 		for (int j = 0; j < 3; j++) {
 			PX4_R(_att.R, i, j) = R(i, j);
 		}
-	}
+	}*/
 
 	_att.timestamp = _last_sensor_timestamp;
 	_att.q[0] = _ekf->states[0];
@@ -836,21 +836,21 @@ void AttitudePositionEstimatorEKF::publishAttitude()
 	_att.q[2] = _ekf->states[2];
 	_att.q[3] = _ekf->states[3];
 	_att.q_valid = true;
-	_att.R_valid = true;
+	//_att.R_valid = true;
 
-	_att.timestamp = _last_sensor_timestamp;
-	_att.roll = euler(0);
-	_att.pitch = euler(1);
-	_att.yaw = euler(2);
+	//_att.timestamp = _last_sensor_timestamp;
+	//_att.roll = euler(0);
+	//_att.pitch = euler(1);
+	//_att.yaw = euler(2);
 
 	_att.rollspeed = _ekf->dAngIMU.x / _ekf->dtIMU - _ekf->states[10] / _ekf->dtIMUfilt;
 	_att.pitchspeed = _ekf->dAngIMU.y / _ekf->dtIMU - _ekf->states[11] / _ekf->dtIMUfilt;
 	_att.yawspeed = _ekf->dAngIMU.z / _ekf->dtIMU - _ekf->states[12] / _ekf->dtIMUfilt;
 
 	// gyro offsets
-	_att.rate_offsets[0] = _ekf->states[10] / _ekf->dtIMUfilt;
-	_att.rate_offsets[1] = _ekf->states[11] / _ekf->dtIMUfilt;
-	_att.rate_offsets[2] = _ekf->states[12] / _ekf->dtIMUfilt;
+	//_att.rate_offsets[0] = _ekf->states[10] / _ekf->dtIMUfilt;
+	//_att.rate_offsets[1] = _ekf->states[11] / _ekf->dtIMUfilt;
+	//_att.rate_offsets[2] = _ekf->states[12] / _ekf->dtIMUfilt;
 
 	/* lazily publish the attitude only once available */
 	if (_att_pub != nullptr) {
@@ -973,7 +973,9 @@ void AttitudePositionEstimatorEKF::publishLocalPosition()
 	_local_pos.xy_global = _gps_initialized; //TODO: Handle optical flow mode here
 
 	_local_pos.z_global = false;
-	_local_pos.yaw = _att.yaw;
+	matrix::Quaternion<float> q(_ekf->states[0], _ekf->states[1], _ekf->states[2], _ekf->states[3]);
+	matrix::Euler<float> euler(q);
+	_local_pos.yaw = euler(2);
 
 	if (!PX4_ISFINITE(_local_pos.x) ||
 	    !PX4_ISFINITE(_local_pos.y) ||

--- a/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
+++ b/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
@@ -826,7 +826,6 @@ void AttitudePositionEstimatorEKF::publishAttitude()
 	_att.q[1] = _ekf->states[1];
 	_att.q[2] = _ekf->states[2];
 	_att.q[3] = _ekf->states[3];
-	_att.q_valid = true;
 
 	_att.rollspeed = _ekf->dAngIMU.x / _ekf->dtIMU - _ekf->states[10] / _ekf->dtIMUfilt;
 	_att.pitchspeed = _ekf->dAngIMU.y / _ekf->dtIMU - _ekf->states[11] / _ekf->dtIMUfilt;

--- a/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
+++ b/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
@@ -952,9 +952,8 @@ void AttitudePositionEstimatorEKF::publishLocalPosition()
 	_local_pos.xy_global = _gps_initialized; //TODO: Handle optical flow mode here
 
 	_local_pos.z_global = false;
-	matrix::Quaternion<float> q(_ekf->states[0], _ekf->states[1], _ekf->states[2], _ekf->states[3]);
-	matrix::Euler<float> euler(q);
-	_local_pos.yaw = euler(2);
+	matrix::Eulerf euler = matrix::Quatf(_ekf->states[0], _ekf->states[1], _ekf->states[2], _ekf->states[3]);
+	_local_pos.yaw = euler.psi();
 
 	if (!PX4_ISFINITE(_local_pos.x) ||
 	    !PX4_ISFINITE(_local_pos.y) ||

--- a/src/examples/fixedwing_control/CMakeLists.txt
+++ b/src/examples/fixedwing_control/CMakeLists.txt
@@ -36,7 +36,7 @@ px4_add_module(
 	STACK_MAIN 1200
 	STACK_MAX 1300
 	SRCS
-		main.c
+		main.cpp
 		params.c
 	DEPENDS
 		platforms__common

--- a/src/examples/fixedwing_control/main.cpp
+++ b/src/examples/fixedwing_control/main.cpp
@@ -177,19 +177,16 @@ void control_attitude(const struct vehicle_attitude_setpoint_s *att_sp, const st
 	 * Calculate roll error and apply P gain
 	 */
 
-	matrix::Quaternion<float> qa(&att->q[0]);
-	matrix::Euler<float> att_euler(qa);
+	matrix::Eulerf att_euler = matrix::Quatf(att->q);
+	matrix::Eulerf att_sp_euler = matrix::Quatf(att_sp->q_d);
 
-	matrix::Quaternion<float> qd(&att_sp->q_d[0]);
-	matrix::Euler<float> att_sp_euler(qd);
-
-	float roll_err = att_euler(0) - att_sp_euler(0);
+	float roll_err = att_euler.phi() - att_sp_euler.phi();
 	actuators->control[0] = roll_err * p.roll_p;
 
 	/*
 	 * Calculate pitch error and apply P gain
 	 */
-	float pitch_err = att_euler(1) - att_sp_euler(1);
+	float pitch_err = att_euler.theta() - att_sp_euler.theta();
 	actuators->control[1] = pitch_err * p.pitch_p;
 }
 
@@ -203,11 +200,10 @@ void control_heading(const struct vehicle_global_position_s *pos, const struct p
 
 	float bearing = get_bearing_to_next_waypoint(pos->lat, pos->lon, sp->lat, sp->lon);
 
-	matrix::Quaternion<float> qa(&att->q[0]);
-	matrix::Euler<float> att_euler(qa);
+	matrix::Eulerf att_euler = matrix::Quatf(att->q);
 
 	/* calculate heading error */
-	float yaw_err = att_euler(2) - bearing;
+	float yaw_err = att_euler.psi() - bearing;
 	/* apply control gain */
 	float roll_body = yaw_err * p.hdng_p;
 
@@ -219,9 +215,9 @@ void control_heading(const struct vehicle_global_position_s *pos, const struct p
 		roll_body = 0.6f;
 	}
 
-	matrix::Euler<float> att_spe(roll_body, 0, bearing);
+	matrix::Eulerf att_spe(roll_body, 0, bearing);
 
-	matrix::Quaternion<float> qd(att_spe);
+	matrix::Quatf qd(att_spe);
 
 	att_sp->q_d[0] = qd(0);
 	att_sp->q_d[1] = qd(1);

--- a/src/examples/fixedwing_control/main.cpp
+++ b/src/examples/fixedwing_control/main.cpp
@@ -71,10 +71,24 @@
 #include <systemlib/systemlib.h>
 #include <systemlib/err.h>
 
+#include <matrix/math.hpp>
+
 /* process-specific header files */
 #include "params.h"
 
 /* Prototypes */
+
+/**
+ * Initialize all parameter handles and values
+ *
+ */
+extern "C" int parameters_init(struct param_handles *h);
+
+/**
+ * Update all parameters
+ *
+ */
+extern "C" int parameters_update(const struct param_handles *h, struct params *p);
 
 /**
  * Daemon management function.
@@ -85,7 +99,7 @@
  * the command line to one particular process or the need for bg/fg
  * ^Z support by the shell.
  */
-__EXPORT int ex_fixedwing_control_main(int argc, char *argv[]);
+extern "C" __EXPORT int ex_fixedwing_control_main(int argc, char *argv[]);
 
 /**
  * Mainloop of daemon.
@@ -162,13 +176,20 @@ void control_attitude(const struct vehicle_attitude_setpoint_s *att_sp, const st
 	/*
 	 * Calculate roll error and apply P gain
 	 */
-	float roll_err = att->roll - att_sp->roll_body;
+
+	matrix::Quaternion<float> qa(&att->q[0]);
+	matrix::Euler<float> att_euler(qa);
+
+	matrix::Quaternion<float> qd(&att_sp->q_d[0]);
+	matrix::Euler<float> att_sp_euler(qd);
+
+	float roll_err = att_euler(0) - att_sp_euler(0);
 	actuators->control[0] = roll_err * p.roll_p;
 
 	/*
 	 * Calculate pitch error and apply P gain
 	 */
-	float pitch_err = att->pitch - att_sp->pitch_body;
+	float pitch_err = att_euler(1) - att_sp_euler(1);
 	actuators->control[1] = pitch_err * p.pitch_p;
 }
 
@@ -182,18 +203,30 @@ void control_heading(const struct vehicle_global_position_s *pos, const struct p
 
 	float bearing = get_bearing_to_next_waypoint(pos->lat, pos->lon, sp->lat, sp->lon);
 
+	matrix::Quaternion<float> qa(&att->q[0]);
+	matrix::Euler<float> att_euler(qa);
+
 	/* calculate heading error */
-	float yaw_err = att->yaw - bearing;
+	float yaw_err = att_euler(2) - bearing;
 	/* apply control gain */
-	att_sp->roll_body = yaw_err * p.hdng_p;
+	float roll_body = yaw_err * p.hdng_p;
 
 	/* limit output, this commonly is a tuning parameter, too */
-	if (att_sp->roll_body < -0.6f) {
-		att_sp->roll_body = -0.6f;
+	if (roll_body < -0.6f) {
+		roll_body = -0.6f;
 
 	} else if (att_sp->roll_body > 0.6f) {
-		att_sp->roll_body = 0.6f;
+		roll_body = 0.6f;
 	}
+
+	matrix::Euler<float> att_spe(roll_body, 0, bearing);
+
+	matrix::Quaternion<float> qd(att_spe);
+
+	att_sp->q_d[0] = qd(0);
+	att_sp->q_d[1] = qd(1);
+	att_sp->q_d[2] = qd(2);
+	att_sp->q_d[3] = qd(3);
 }
 
 /* Main Thread */
@@ -262,7 +295,7 @@ int fixedwing_control_thread_main(int argc, char *argv[])
 
 
 	/* publish actuator controls with zero values */
-	for (unsigned i = 0; i < NUM_ACTUATOR_CONTROLS; i++) {
+	for (unsigned i = 0; i < actuator_controls_s::NUM_ACTUATOR_CONTROLS; i++) {
 		actuators.control[i] = 0.0f;
 	}
 
@@ -380,7 +413,7 @@ int fixedwing_control_thread_main(int argc, char *argv[])
 	thread_running = false;
 
 	/* kill all outputs */
-	for (unsigned i = 0; i < NUM_ACTUATOR_CONTROLS; i++) {
+	for (unsigned i = 0; i < actuator_controls_s::NUM_ACTUATOR_CONTROLS; i++) {
 		actuators.control[i] = 0.0f;
 	}
 
@@ -456,6 +489,3 @@ int ex_fixedwing_control_main(int argc, char *argv[])
 	usage("unrecognized command");
 	exit(1);
 }
-
-
-

--- a/src/examples/fixedwing_control/main.cpp
+++ b/src/examples/fixedwing_control/main.cpp
@@ -383,7 +383,7 @@ int fixedwing_control_thread_main(int argc, char *argv[])
 				}
 
 				/* check if the throttle was ever more than 50% - go later only to failsafe if yes */
-				if (isfinite(manual_sp.z) &&
+				if (PX4_ISFINITE(manual_sp.z) &&
 				    (manual_sp.z >= 0.6f) &&
 				    (manual_sp.z <= 1.0f)) {
 				}
@@ -395,10 +395,10 @@ int fixedwing_control_thread_main(int argc, char *argv[])
 				orb_publish(ORB_ID(vehicle_rates_setpoint), rates_pub, &rates_sp);
 
 				/* sanity check and publish actuator outputs */
-				if (isfinite(actuators.control[0]) &&
-				    isfinite(actuators.control[1]) &&
-				    isfinite(actuators.control[2]) &&
-				    isfinite(actuators.control[3])) {
+				if (PX4_ISFINITE(actuators.control[0]) &&
+				    PX4_ISFINITE(actuators.control[1]) &&
+				    PX4_ISFINITE(actuators.control[2]) &&
+				    PX4_ISFINITE(actuators.control[3])) {
 					orb_publish(ORB_ID_VEHICLE_ATTITUDE_CONTROLS, actuator_pub, &actuators);
 
 					if (verbose) {

--- a/src/examples/fixedwing_control/params.c
+++ b/src/examples/fixedwing_control/params.c
@@ -57,6 +57,14 @@ PARAM_DEFINE_FLOAT(EXFW_ROLL_P, 0.2f);
  */
 PARAM_DEFINE_FLOAT(EXFW_PITCH_P, 0.2f);
 
+int parameters_init(struct param_handles *h);
+
+/**
+ * Update all parameters
+ *
+ */
+int parameters_update(const struct param_handles *h, struct params *p);
+
 int parameters_init(struct param_handles *h)
 {
 	/* PID parameters */
@@ -64,7 +72,7 @@ int parameters_init(struct param_handles *h)
 	h->roll_p 	=	param_find("EXFW_ROLL_P");
 	h->pitch_p 	=	param_find("EXFW_PITCH_P");
 
-	return OK;
+	return 0;
 }
 
 int parameters_update(const struct param_handles *h, struct params *p)
@@ -73,5 +81,5 @@ int parameters_update(const struct param_handles *h, struct params *p)
 	param_get(h->roll_p, &(p->roll_p));
 	param_get(h->pitch_p, &(p->pitch_p));
 
-	return OK;
+	return 0;
 }

--- a/src/examples/fixedwing_control/params.h
+++ b/src/examples/fixedwing_control/params.h
@@ -51,15 +51,3 @@ struct param_handles {
 	param_t roll_p;
 	param_t pitch_p;
 };
-
-/**
- * Initialize all parameter handles and values
- *
- */
-int parameters_init(struct param_handles *h);
-
-/**
- * Update all parameters
- *
- */
-int parameters_update(const struct param_handles *h, struct params *p);

--- a/src/examples/mc_att_control_multiplatform/mc_att_control_base.cpp
+++ b/src/examples/mc_att_control_multiplatform/mc_att_control_base.cpp
@@ -147,11 +147,11 @@ void MulticopterAttitudeControlBase::control_attitude(float dt)
 	if (e_R_z_cos < 0.0f) {
 		/* for large thrust vector rotations use another rotation method:
 		 * calculate angle and axis for R -> R_sp rotation directly */
-		math::Quaternion q;
-		q.from_dcm(R.transposed() * R_sp);
-		math::Vector <3> e_R_d = q.imag();
+		math::Quaternion ql;
+		ql.from_dcm(R.transposed() * R_sp);
+		math::Vector <3> e_R_d = ql.imag();
 		e_R_d.normalize();
-		e_R_d *= 2.0f * atan2f(e_R_d.length(), q(0));
+		e_R_d *= 2.0f * atan2f(e_R_d.length(), ql(0));
 
 		/* use fusion of Z axis based rotation and direct rotation */
 		float direct_w = e_R_z_cos * e_R_z_cos * yaw_w;

--- a/src/examples/mc_att_control_multiplatform/mc_att_control_base.cpp
+++ b/src/examples/mc_att_control_multiplatform/mc_att_control_base.cpp
@@ -87,11 +87,13 @@ void MulticopterAttitudeControlBase::control_attitude(float dt)
 
 	/* construct attitude setpoint rotation matrix */
 	math::Matrix<3, 3> R_sp;
-	R_sp.set(_v_att_sp->data().R_body);
+	matrix::Quaternion<float> q_sp(&_v_att_sp->data().q_d[0]);
+	R_sp.set(&q_sp._data[0][0]);
 
 	/* rotation matrix for current state */
 	math::Matrix<3, 3> R;
-	R.set(_v_att->data().R);
+	matrix::Quaternion<float> q(&_v_att->data().q[0]);
+	R.set(&q._data[0][0]);
 
 	/* all input data is ready, run controller itself */
 

--- a/src/examples/mc_att_control_multiplatform/mc_att_control_base.cpp
+++ b/src/examples/mc_att_control_multiplatform/mc_att_control_base.cpp
@@ -86,14 +86,12 @@ void MulticopterAttitudeControlBase::control_attitude(float dt)
 	_thrust_sp = _v_att_sp->data().thrust;
 
 	/* construct attitude setpoint rotation matrix */
-	math::Matrix<3, 3> R_sp;
-	matrix::Quaternion<float> q_sp(&_v_att_sp->data().q_d[0]);
-	R_sp.set(&q_sp._data[0][0]);
+	math::Quaternion q_sp(&_v_att_sp->data().q_d[0]);
+	math::Matrix<3, 3> R_sp = q_sp.to_dcm();
 
 	/* rotation matrix for current state */
-	math::Matrix<3, 3> R;
-	matrix::Quaternion<float> q(&_v_att->data().q[0]);
-	R.set(&q._data[0][0]);
+	math::Quaternion q(&_v_att->data().q[0]);
+	math::Matrix<3, 3> R = q.to_dcm();
 
 	/* all input data is ready, run controller itself */
 

--- a/src/examples/mc_pos_control_multiplatform/mc_pos_control.cpp
+++ b/src/examples/mc_pos_control_multiplatform/mc_pos_control.cpp
@@ -937,9 +937,9 @@ void  MulticopterPositionControlMultiplatform::handle_vehicle_attitude(const px4
 					_att_sp_msg.data().R_valid = true;
 
 					/* calculate euler angles, for logging only, must not be used for control */
-					math::Vector<3> euler = _R.to_euler();
-					_att_sp_msg.data().roll_body = euler(0);
-					_att_sp_msg.data().pitch_body = euler(1);
+					math::Vector<3> eul = _R.to_euler();
+					_att_sp_msg.data().roll_body = eul(0);
+					_att_sp_msg.data().pitch_body = eul(1);
 					/* yaw already used to construct rot matrix, but actual rotation matrix can have different yaw near singularity */
 
 				} else if (!_control_mode->data().flag_control_manual_enabled) {

--- a/src/examples/mc_pos_control_multiplatform/mc_pos_control.cpp
+++ b/src/examples/mc_pos_control_multiplatform/mc_pos_control.cpp
@@ -250,7 +250,9 @@ MulticopterPositionControlMultiplatform::reset_alt_sp()
 
 		//XXX hack until #1741 is in/ported
 		/* reset yaw sp */
-		_att_sp_msg.data().yaw_body = _att->data().yaw;
+		matrix::Quaternion<float> q(&_att->data().q[0]);
+		matrix::Euler<float> euler(q);
+		_att_sp_msg.data().yaw_body = euler(2);
 
 		//XXX: port this once a mavlink like interface is available
 		// mavlink_log_info(&_mavlink_log_pub, "[mpc] reset alt sp: %d", -(int)_pos_sp(2));
@@ -582,6 +584,10 @@ void  MulticopterPositionControlMultiplatform::handle_vehicle_attitude(const px4
 	static bool was_armed = false;
 	static uint64_t t_prev = 0;
 
+	matrix::Quaternion<float> q(&_att->data().q[0]);
+	matrix::Euler<float> euler(q);
+	matrix::Dcm<float> R(q);
+
 	uint64_t t = get_time_micros();
 	float dt = t_prev != 0 ? (t - t_prev) * 0.000001f : 0.005f;
 	t_prev = t;
@@ -641,7 +647,7 @@ void  MulticopterPositionControlMultiplatform::handle_vehicle_attitude(const px4
 
 			_att_sp_msg.data().roll_body = 0.0f;
 			_att_sp_msg.data().pitch_body = 0.0f;
-			_att_sp_msg.data().yaw_body = _att->data().yaw;
+			_att_sp_msg.data().yaw_body = euler(2);
 			_att_sp_msg.data().thrust = 0.0f;
 
 			_att_sp_msg.data().timestamp = get_time_micros();
@@ -815,11 +821,11 @@ void  MulticopterPositionControlMultiplatform::handle_vehicle_attitude(const px4
 					/* thrust compensation for altitude only control mode */
 					float att_comp;
 
-					if (PX4_R(_att->data().R, 2, 2) > TILT_COS_MAX) {
-						att_comp = 1.0f / PX4_R(_att->data().R, 2, 2);
+					if (R(2, 2) > TILT_COS_MAX) {
+						att_comp = 1.0f / R(2, 2);
 
-					} else if (PX4_R(_att->data().R, 2, 2) > 0.0f) {
-						att_comp = ((1.0f / TILT_COS_MAX - 1.0f) / TILT_COS_MAX) * PX4_R(_att->data().R, 2, 2) + 1.0f;
+					} else if (R(2, 2) > 0.0f) {
+						att_comp = ((1.0f / TILT_COS_MAX - 1.0f) / TILT_COS_MAX) * R(2, 2) + 1.0f;
 						saturation_z = true;
 
 					} else {
@@ -1005,7 +1011,7 @@ void  MulticopterPositionControlMultiplatform::handle_vehicle_attitude(const px4
 		/* reset yaw setpoint to current position if needed */
 		if (reset_yaw_sp) {
 			reset_yaw_sp = false;
-			_att_sp_msg.data().yaw_body = _att->data().yaw;
+			_att_sp_msg.data().yaw_body = euler(2);
 		}
 
 		/* do not move yaw while arming */
@@ -1014,13 +1020,13 @@ void  MulticopterPositionControlMultiplatform::handle_vehicle_attitude(const px4
 
 			_att_sp_msg.data().yaw_sp_move_rate = _manual_control_sp->data().r * _params.man_yaw_max;
 			_att_sp_msg.data().yaw_body = _wrap_pi(_att_sp_msg.data().yaw_body + _att_sp_msg.data().yaw_sp_move_rate * dt);
-			float yaw_offs = _wrap_pi(_att_sp_msg.data().yaw_body - _att->data().yaw);
+			float yaw_offs = _wrap_pi(_att_sp_msg.data().yaw_body - euler(2));
 
 			if (yaw_offs < - YAW_OFFSET_MAX) {
-				_att_sp_msg.data().yaw_body = _wrap_pi(_att->data().yaw - YAW_OFFSET_MAX);
+				_att_sp_msg.data().yaw_body = _wrap_pi(euler(2) - YAW_OFFSET_MAX);
 
 			} else if (yaw_offs > YAW_OFFSET_MAX) {
-				_att_sp_msg.data().yaw_body = _wrap_pi(_att->data().yaw + YAW_OFFSET_MAX);
+				_att_sp_msg.data().yaw_body = _wrap_pi(euler(2) + YAW_OFFSET_MAX);
 			}
 		}
 

--- a/src/examples/px4_simple_app/px4_simple_app.c
+++ b/src/examples/px4_simple_app/px4_simple_app.c
@@ -107,9 +107,13 @@ int px4_simple_app_main(int argc, char *argv[])
 					 (double)raw.accelerometer_m_s2[2]);
 
 				/* set att and publish this information for other apps */
-				att.roll = raw.accelerometer_m_s2[0];
-				att.pitch = raw.accelerometer_m_s2[1];
-				att.yaw = raw.accelerometer_m_s2[2];
+				//att.roll = raw.accelerometer_m_s2[0];
+				//att.pitch = raw.accelerometer_m_s2[1];
+				//att.yaw = raw.accelerometer_m_s2[2];
+				att.q[0] = raw.accelerometer_m_s2[0];
+				att.q[1] = raw.accelerometer_m_s2[1];
+				att.q[2] = raw.accelerometer_m_s2[2];
+
 				orb_publish(ORB_ID(vehicle_attitude), att_pub, &att);
 			}
 

--- a/src/examples/px4_simple_app/px4_simple_app.c
+++ b/src/examples/px4_simple_app/px4_simple_app.c
@@ -106,10 +106,9 @@ int px4_simple_app_main(int argc, char *argv[])
 					 (double)raw.accelerometer_m_s2[1],
 					 (double)raw.accelerometer_m_s2[2]);
 
-				/* set att and publish this information for other apps */
-				//att.roll = raw.accelerometer_m_s2[0];
-				//att.pitch = raw.accelerometer_m_s2[1];
-				//att.yaw = raw.accelerometer_m_s2[2];
+				/* set att and publish this information for other apps
+				 the following does not have any meaning, it's just an example
+				*/
 				att.q[0] = raw.accelerometer_m_s2[0];
 				att.q[1] = raw.accelerometer_m_s2[1];
 				att.q[2] = raw.accelerometer_m_s2[2];

--- a/src/examples/rover_steering_control/main.cpp
+++ b/src/examples/rover_steering_control/main.cpp
@@ -177,7 +177,7 @@ void control_attitude(const struct vehicle_attitude_setpoint_s *att_sp, const st
 	actuators->control[1] = 0.0f;
 
 	/*
-	 * Calculate roll error and apply P gain
+	 * Calculate yaw error and apply P gain
 	 */
 	float yaw_err = Eulerf(Quaternion(att->q)).psi() - Eulerf(Quaternion(att->q_d)).psi();
 	actuators->control[2] = yaw_err * pp.yaw_p;

--- a/src/examples/rover_steering_control/main.cpp
+++ b/src/examples/rover_steering_control/main.cpp
@@ -179,7 +179,7 @@ void control_attitude(const struct vehicle_attitude_setpoint_s *att_sp, const st
 	/*
 	 * Calculate yaw error and apply P gain
 	 */
-	float yaw_err = Eulerf(Quaternion(att->q)).psi() - Eulerf(Quaternion(att->q_d)).psi();
+	float yaw_err = matrix::Eulerf(matrix::Quatf(att->q)).psi() - matrix::Eulerf(matrix::Quatf(att_sp->q_d)).psi();
 	actuators->control[2] = yaw_err * pp.yaw_p;
 
 	/* copy throttle */

--- a/src/examples/rover_steering_control/main.cpp
+++ b/src/examples/rover_steering_control/main.cpp
@@ -66,6 +66,7 @@
 #include <systemlib/perf_counter.h>
 #include <systemlib/systemlib.h>
 #include <systemlib/err.h>
+#include <matrix/math.hpp>
 
 /* process-specific header files */
 #include "params.h"
@@ -178,7 +179,11 @@ void control_attitude(const struct vehicle_attitude_setpoint_s *att_sp, const st
 	/*
 	 * Calculate roll error and apply P gain
 	 */
-	float yaw_err = att->yaw - att_sp->yaw_body;
+	matrix::Quaternion<float> q(&att->q[0]);
+	matrix::Euler<float> euler(q);
+	matrix::Quaternion<float> q_sp(&att_sp->q_d[0]);
+	matrix::Euler<float> euler_sp(q_sp);
+	float yaw_err = euler(2) - euler_sp(2);
 	actuators->control[2] = yaw_err * pp.yaw_p;
 
 	/* copy throttle */
@@ -354,10 +359,10 @@ int rover_steering_control_thread_main(int argc, char *argv[])
 				orb_copy(ORB_ID(vehicle_status), vstatus_sub, &vstatus);
 
 				/* sanity check and publish actuator outputs */
-				if (isfinite(actuators.control[0]) &&
-				    isfinite(actuators.control[1]) &&
-				    isfinite(actuators.control[2]) &&
-				    isfinite(actuators.control[3])) {
+				if (PX4_ISFINITE(actuators.control[0]) &&
+				    PX4_ISFINITE(actuators.control[1]) &&
+				    PX4_ISFINITE(actuators.control[2]) &&
+				    PX4_ISFINITE(actuators.control[3])) {
 					orb_publish(ORB_ID_VEHICLE_ATTITUDE_CONTROLS, actuator_pub, &actuators);
 
 					if (verbose) {

--- a/src/examples/rover_steering_control/main.cpp
+++ b/src/examples/rover_steering_control/main.cpp
@@ -179,11 +179,7 @@ void control_attitude(const struct vehicle_attitude_setpoint_s *att_sp, const st
 	/*
 	 * Calculate roll error and apply P gain
 	 */
-	matrix::Quaternion<float> q(&att->q[0]);
-	matrix::Euler<float> euler(q);
-	matrix::Quaternion<float> q_sp(&att_sp->q_d[0]);
-	matrix::Euler<float> euler_sp(q_sp);
-	float yaw_err = euler(2) - euler_sp(2);
+	float yaw_err = Eulerf(Quaternion(att->q)).psi() - Eulerf(Quaternion(att->q_d)).psi();
 	actuators->control[2] = yaw_err * pp.yaw_p;
 
 	/* copy throttle */

--- a/src/lib/terrain_estimation/terrain_estimator.cpp
+++ b/src/lib/terrain_estimation/terrain_estimator.cpp
@@ -65,9 +65,10 @@ void TerrainEstimator::predict(float dt, const struct vehicle_attitude_s *attitu
 			       const struct sensor_combined_s *sensor,
 			       const struct distance_sensor_s *distance)
 {
-	if (attitude->R_valid) {
-		matrix::Matrix<float, 3, 3> R_att(attitude->R);
-		matrix::Vector<float, 3> a(sensor->accelerometer_m_s2);
+	if (attitude->q_valid) {
+		matrix::Quaternion<float> q(&attitude->q[0]);
+		matrix::Dcm<float> R_att(q);
+		matrix::Vector<float, 3> a(&sensor->accelerometer_m_s2[0]);
 		matrix::Vector<float, 3> u;
 		u = R_att * a;
 		_u_z = u(2) + 9.81f; // compensate for gravity
@@ -115,7 +116,8 @@ void TerrainEstimator::measurement_update(uint64_t time_ref, const struct vehicl
 	}
 
 	if (distance->timestamp > _time_last_distance) {
-
+		matrix::Quaternion<float> q(&attitude->q[0]);
+		matrix::Euler<float> euler(q);
 		float d = distance->current_distance;
 
 		matrix::Matrix<float, 1, n_x> C;
@@ -124,7 +126,7 @@ void TerrainEstimator::measurement_update(uint64_t time_ref, const struct vehicl
 		float R = 0.009f;
 
 		matrix::Vector<float, 1> y;
-		y(0) = d * cosf(attitude->roll) * cosf(attitude->pitch);
+		y(0) = d * cosf(euler(0)) * cosf(euler(1));
 
 		// residual
 		matrix::Matrix<float, 1, 1> S_I = (C * _P * C.transpose());

--- a/src/lib/terrain_estimation/terrain_estimator.cpp
+++ b/src/lib/terrain_estimation/terrain_estimator.cpp
@@ -37,6 +37,7 @@
  */
 
 #include "terrain_estimator.h"
+#include <geo/geo.h>
 
 #define DISTANCE_TIMEOUT 100000		// time in usec after which laser is considered dead
 
@@ -65,17 +66,12 @@ void TerrainEstimator::predict(float dt, const struct vehicle_attitude_s *attitu
 			       const struct sensor_combined_s *sensor,
 			       const struct distance_sensor_s *distance)
 {
-	if (attitude->q_valid) {
-		matrix::Quaternion<float> q(&attitude->q[0]);
-		matrix::Dcm<float> R_att(q);
-		matrix::Vector<float, 3> a(&sensor->accelerometer_m_s2[0]);
-		matrix::Vector<float, 3> u;
-		u = R_att * a;
-		_u_z = u(2) + 9.81f; // compensate for gravity
-
-	} else {
-		_u_z = 0.0f;
-	}
+	matrix::Quaternion<float> q(&attitude->q[0]);
+	matrix::Dcm<float> R_att(q);
+	matrix::Vector<float, 3> a(&sensor->accelerometer_m_s2[0]);
+	matrix::Vector<float, 3> u;
+	u = R_att * a;
+	_u_z = u(2) + CONSTANTS_ONE_G; // compensate for gravity
 
 	// dynamics matrix
 	matrix::Matrix<float, n_x, n_x> A;

--- a/src/lib/terrain_estimation/terrain_estimator.cpp
+++ b/src/lib/terrain_estimation/terrain_estimator.cpp
@@ -66,8 +66,7 @@ void TerrainEstimator::predict(float dt, const struct vehicle_attitude_s *attitu
 			       const struct sensor_combined_s *sensor,
 			       const struct distance_sensor_s *distance)
 {
-	matrix::Quaternion<float> q(&attitude->q[0]);
-	matrix::Dcm<float> R_att(q);
+	matrix::Dcmf R_att = matrix::Quatf(attitude->q);
 	matrix::Vector<float, 3> a(&sensor->accelerometer_m_s2[0]);
 	matrix::Vector<float, 3> u;
 	u = R_att * a;
@@ -112,8 +111,8 @@ void TerrainEstimator::measurement_update(uint64_t time_ref, const struct vehicl
 	}
 
 	if (distance->timestamp > _time_last_distance) {
-		matrix::Quaternion<float> q(&attitude->q[0]);
-		matrix::Euler<float> euler(q);
+		matrix::Quatf q(attitude->q);
+		matrix::Eulerf euler(q);
 		float d = distance->current_distance;
 
 		matrix::Matrix<float, 1, n_x> C;
@@ -122,7 +121,7 @@ void TerrainEstimator::measurement_update(uint64_t time_ref, const struct vehicl
 		float R = 0.009f;
 
 		matrix::Vector<float, 1> y;
-		y(0) = d * cosf(euler(0)) * cosf(euler(1));
+		y(0) = d * cosf(euler.phi()) * cosf(euler.theta());
 
 		// residual
 		matrix::Matrix<float, 1, 1> S_I = (C * _P * C.transpose());

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -468,26 +468,26 @@ void AttitudeEstimatorQ::task_main()
 		struct vehicle_attitude_s att = {};
 		att.timestamp = sensors.timestamp;
 
-		att.roll = euler(0);
-		att.pitch = euler(1);
-		att.yaw = euler(2);
+		//att.roll = euler(0);
+		//att.pitch = euler(1);
+		//att.yaw = euler(2);
 
 		att.rollspeed = _rates(0);
 		att.pitchspeed = _rates(1);
 		att.yawspeed = _rates(2);
 
-		for (int i = 0; i < 3; i++) {
-			att.g_comp[i] = _accel(i) - _pos_acc(i);
-		}
+		//for (int i = 0; i < 3; i++) {
+		//	att.g_comp[i] = _accel(i) - _pos_acc(i);
+		//}
 
-		/* copy offsets */
-		memcpy(&att.rate_offsets, _gyro_bias.data, sizeof(att.rate_offsets));
+		///* copy offsets */
+		//memcpy(&att.rate_offsets, _gyro_bias.data, sizeof(att.rate_offsets));
 
-		Matrix<3, 3> R = _q.to_dcm();
+		//Matrix<3, 3> R = _q.to_dcm();
 
-		/* copy rotation matrix */
-		memcpy(&att.R[0], R.data, sizeof(att.R));
-		att.R_valid = true;
+		///* copy rotation matrix */
+		//memcpy(&att.R[0], R.data, sizeof(att.R));
+		//att.R_valid = true;
 		memcpy(&att.q[0], _q.data, sizeof(att.q));
 		att.q_valid = true;
 

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -473,7 +473,6 @@ void AttitudeEstimatorQ::task_main()
 		att.yawspeed = _rates(2);
 
 		memcpy(&att.q[0], _q.data, sizeof(att.q));
-		att.q_valid = true;
 
 		/* the instance count is not used here */
 		int att_inst;

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -468,10 +468,6 @@ void AttitudeEstimatorQ::task_main()
 		struct vehicle_attitude_s att = {};
 		att.timestamp = sensors.timestamp;
 
-		//att.roll = euler(0);
-		//att.pitch = euler(1);
-		//att.yaw = euler(2);
-
 		att.rollspeed = _rates(0);
 		att.pitchspeed = _rates(1);
 		att.yawspeed = _rates(2);
@@ -483,11 +479,6 @@ void AttitudeEstimatorQ::task_main()
 		///* copy offsets */
 		//memcpy(&att.rate_offsets, _gyro_bias.data, sizeof(att.rate_offsets));
 
-		//Matrix<3, 3> R = _q.to_dcm();
-
-		///* copy rotation matrix */
-		//memcpy(&att.R[0], R.data, sizeof(att.R));
-		//att.R_valid = true;
 		memcpy(&att.q[0], _q.data, sizeof(att.q));
 		att.q_valid = true;
 

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -472,13 +472,6 @@ void AttitudeEstimatorQ::task_main()
 		att.pitchspeed = _rates(1);
 		att.yawspeed = _rates(2);
 
-		//for (int i = 0; i < 3; i++) {
-		//	att.g_comp[i] = _accel(i) - _pos_acc(i);
-		//}
-
-		///* copy offsets */
-		//memcpy(&att.rate_offsets, _gyro_bias.data, sizeof(att.rate_offsets));
-
 		memcpy(&att.q[0], _q.data, sizeof(att.q));
 		att.q_valid = true;
 

--- a/src/modules/commander/accelerometer_calibration.cpp
+++ b/src/modules/commander/accelerometer_calibration.cpp
@@ -687,10 +687,9 @@ int do_level_calibration(orb_advert_t *mavlink_log_pub) {
 		}
 
 		orb_copy(ORB_ID(vehicle_attitude), att_sub, &att);
-		matrix::Quaternion<float> q(&att.q[0]);
-		matrix::Euler<float> euler(q);
-		roll_mean += euler(0);
-		pitch_mean += euler(1);
+		matrix::Eulerf euler = matrix::Quatf(att.q);
+		roll_mean += euler.phi();
+		pitch_mean += euler.theta();
 		counter++;
 	}
 

--- a/src/modules/commander/accelerometer_calibration.cpp
+++ b/src/modules/commander/accelerometer_calibration.cpp
@@ -687,8 +687,10 @@ int do_level_calibration(orb_advert_t *mavlink_log_pub) {
 		}
 
 		orb_copy(ORB_ID(vehicle_attitude), att_sub, &att);
-		roll_mean += att.roll;
-		pitch_mean += att.pitch;
+		matrix::Quaternion<float> q(&att.q[0]);
+		matrix::Euler<float> euler(q);
+		roll_mean += euler(0);
+		pitch_mean += euler(1);
 		counter++;
 	}
 

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1168,9 +1168,8 @@ static void commander_set_home_position(orb_advert_t &homePub, home_position_s &
 	home.y = localPosition.y;
 	home.z = localPosition.z;
 
-	matrix::Quaternion<float> q(&attitude.q[0]);
-	matrix::Euler<float> euler(q);
-	home.yaw = euler(2);
+	matrix::Eulerf euler = matrix::Quatf(attitude.q);
+	home.yaw = euler.psi();
 
 	PX4_INFO("home: %.7f, %.7f, %.2f", home.lat, home.lon, (double)home.alt);
 

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -78,6 +78,15 @@
 #include <systemlib/state_table.h>
 #include <systemlib/systemlib.h>
 #include <systemlib/hysteresis/hysteresis.h>
+
+#include <sys/stat.h>
+#include <string.h>
+#include <math.h>
+#include <poll.h>
+#include <float.h>
+#include <matrix/math.hpp>
+
+#include <uORB/uORB.h>
 #include <uORB/topics/actuator_armed.h>
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/battery_status.h>
@@ -106,7 +115,6 @@
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vtol_vehicle_status.h>
-#include <uORB/uORB.h>
 
 typedef enum VEHICLE_MODE_FLAG
 {
@@ -1160,7 +1168,9 @@ static void commander_set_home_position(orb_advert_t &homePub, home_position_s &
 	home.y = localPosition.y;
 	home.z = localPosition.z;
 
-	home.yaw = attitude.yaw;
+	matrix::Quaternion<float> q(&attitude.q[0]);
+	matrix::Euler<float> euler(q);
+	home.yaw = euler(2);
 
 	PX4_INFO("home: %.7f, %.7f, %.2f", home.lat, home.lon, (double)home.alt);
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -726,7 +726,6 @@ void Ekf2::task_main()
 			att.q[1] = q(1);
 			att.q[2] = q(2);
 			att.q[3] = q(3);
-			att.q_valid = true;
 
 			att.rollspeed = gyro_rad[0];
 			att.pitchspeed = gyro_rad[1];

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -721,10 +721,10 @@ void Ekf2::task_main()
 
 			// generate remaining vehicle attitude data
 			att.timestamp = hrt_absolute_time();
-			matrix::Euler<float> euler(q);
-			att.roll = euler(0);
-			att.pitch = euler(1);
-			att.yaw = euler(2);
+			//matrix::Euler<float> euler(q);
+			//att.roll = euler(0);
+			//att.pitch = euler(1);
+			//att.yaw = euler(2);
 
 			att.q[0] = q(0);
 			att.q[1] = q(1);
@@ -777,7 +777,8 @@ void Ekf2::task_main()
 			lpos.ref_lon = ekf_origin.lon_rad * 180.0 / M_PI; // Reference point longitude in degrees
 
 			// The rotation of the tangent plane vs. geographical north
-			lpos.yaw = att.yaw;
+			matrix::Euler<float> euler(q);
+			lpos.yaw = euler(2);
 
 			float terrain_vpos;
 			lpos.dist_bottom_valid = _ekf.get_terrain_vert_pos(&terrain_vpos);

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -721,10 +721,6 @@ void Ekf2::task_main()
 
 			// generate remaining vehicle attitude data
 			att.timestamp = hrt_absolute_time();
-			//matrix::Euler<float> euler(q);
-			//att.roll = euler(0);
-			//att.pitch = euler(1);
-			//att.yaw = euler(2);
 
 			att.q[0] = q(0);
 			att.q[1] = q(1);

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -772,8 +772,8 @@ void Ekf2::task_main()
 			lpos.ref_lon = ekf_origin.lon_rad * 180.0 / M_PI; // Reference point longitude in degrees
 
 			// The rotation of the tangent plane vs. geographical north
-			matrix::Euler<float> euler(q);
-			lpos.yaw = euler(2);
+			matrix::Eulerf euler(q);
+			lpos.yaw = euler.psi();
 
 			float terrain_vpos;
 			lpos.dist_bottom_valid = _ekf.get_terrain_vert_pos(&terrain_vpos);

--- a/src/modules/ekf2_replay/ekf2_replay_main.cpp
+++ b/src/modules/ekf2_replay/ekf2_replay_main.cpp
@@ -535,15 +535,15 @@ void Ekf2Replay::logIfUpdated()
 	log_message.body.att.q_x = att.q[1];
 	log_message.body.att.q_y = att.q[2];
 	log_message.body.att.q_z = att.q[3];
-	log_message.body.att.roll = att.roll;
-	log_message.body.att.pitch = att.pitch;
-	log_message.body.att.yaw = att.yaw;
+	log_message.body.att.roll = 0;
+	log_message.body.att.pitch = 0;
+	log_message.body.att.yaw = 0;
 	log_message.body.att.roll_rate = att.rollspeed;
 	log_message.body.att.pitch_rate = att.pitchspeed;
 	log_message.body.att.yaw_rate = att.yawspeed;
-	log_message.body.att.gx = att.g_comp[0];
-	log_message.body.att.gy = att.g_comp[1];
-	log_message.body.att.gz = att.g_comp[2];
+	log_message.body.att.gx = 0;
+	log_message.body.att.gy = 0;
+	log_message.body.att.gz = 0;
 
 	writeMessage(_write_fd, (void *)&log_message.head1, _formats[LOG_ATT_MSG].length);
 

--- a/src/modules/ekf2_replay/ekf2_replay_main.cpp
+++ b/src/modules/ekf2_replay/ekf2_replay_main.cpp
@@ -535,15 +535,14 @@ void Ekf2Replay::logIfUpdated()
 	log_message.body.att.q_x = att.q[1];
 	log_message.body.att.q_y = att.q[2];
 	log_message.body.att.q_z = att.q[3];
-	log_message.body.att.roll = 0;
-	log_message.body.att.pitch = 0;
-	log_message.body.att.yaw = 0;
+	log_message.body.att.roll = atan2f(2 * (att.q[0] * att.q[1] + att.q[2] * att.q[3]),
+					   1 - 2 * (att.q[1] * att.q[1] + att.q[2] * att.q[2]));
+	log_message.body.att.pitch = asinf(2 * (att.q[0] * att.q[2] - att.q[3] * att.q[1]));
+	log_message.body.att.yaw = atan2f(2 * (att.q[0] * att.q[3] + att.q[1] * att.q[2]),
+					  1 - 2 * (att.q[2] * att.q[2] + att.q[3] * att.q[3]));
 	log_message.body.att.roll_rate = att.rollspeed;
 	log_message.body.att.pitch_rate = att.pitchspeed;
 	log_message.body.att.yaw_rate = att.yawspeed;
-	log_message.body.att.gx = 0;
-	log_message.body.att.gy = 0;
-	log_message.body.att.gz = 0;
 
 	writeMessage(_write_fd, (void *)&log_message.head1, _formats[LOG_ATT_MSG].length);
 

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -180,7 +180,7 @@ BlockLocalPositionEstimator::BlockLocalPositionEstimator() :
 	_err_perf(),
 
 	// kf matrices
-	_x(), _u(), _P()
+	_x(), _u(), _P(), _R_att(), _eul()
 {
 	// assign distance subs to array
 	_dist_subs[0] = &_sub_dist0;
@@ -731,7 +731,8 @@ void BlockLocalPositionEstimator::publishLocalPos()
 		_pub_lpos.get().vx = xLP(X_vx); // north
 		_pub_lpos.get().vy = xLP(X_vy); // east
 		_pub_lpos.get().vz = xLP(X_vz); // down
-		_pub_lpos.get().yaw = _sub_att.get().yaw;
+
+		_pub_lpos.get().yaw = _eul(2);
 		_pub_lpos.get().xy_global = _validXY;
 		_pub_lpos.get().z_global = _baroInitialized;
 		_pub_lpos.get().ref_timestamp = _timeStamp;
@@ -822,7 +823,7 @@ void BlockLocalPositionEstimator::publishGlobalPos()
 		_pub_gpos.get().vel_n = xLP(X_vx);
 		_pub_gpos.get().vel_e = xLP(X_vy);
 		_pub_gpos.get().vel_d = xLP(X_vz);
-		_pub_gpos.get().yaw = _sub_att.get().yaw;
+		_pub_gpos.get().yaw = _eul(2);
 		_pub_gpos.get().eph = eph;
 		_pub_gpos.get().epv = epv;
 		_pub_gpos.get().terrain_alt = _altOrigin - xLP(X_tz);
@@ -874,18 +875,17 @@ void BlockLocalPositionEstimator::updateSSStates()
 {
 	// derivative of velocity is accelerometer acceleration
 	// (in input matrix) - bias (in body frame)
-	Matrix3f R_att(_sub_att.get().R);
-	_A(X_vx, X_bx) = -R_att(0, 0);
-	_A(X_vx, X_by) = -R_att(0, 1);
-	_A(X_vx, X_bz) = -R_att(0, 2);
+	_A(X_vx, X_bx) = -_R_att(0, 0);
+	_A(X_vx, X_by) = -_R_att(0, 1);
+	_A(X_vx, X_bz) = -_R_att(0, 2);
 
-	_A(X_vy, X_bx) = -R_att(1, 0);
-	_A(X_vy, X_by) = -R_att(1, 1);
-	_A(X_vy, X_bz) = -R_att(1, 2);
+	_A(X_vy, X_bx) = -_R_att(1, 0);
+	_A(X_vy, X_by) = -_R_att(1, 1);
+	_A(X_vy, X_bz) = -_R_att(1, 2);
 
-	_A(X_vz, X_bx) = -R_att(2, 0);
-	_A(X_vz, X_by) = -R_att(2, 1);
-	_A(X_vz, X_bz) = -R_att(2, 2);
+	_A(X_vz, X_bx) = -_R_att(2, 0);
+	_A(X_vz, X_by) = -_R_att(2, 1);
+	_A(X_vz, X_bz) = -_R_att(2, 2);
 }
 
 void BlockLocalPositionEstimator::updateSSParams()
@@ -929,11 +929,13 @@ void BlockLocalPositionEstimator::predict()
 	// state or covariance
 	if (!_validXY && !_validZ) { return; }
 
-	if (integrate && _sub_att.get().R_valid) {
-		Matrix3f R_att(_sub_att.get().R);
+	if (integrate && _sub_att.get().q_valid) {
+		matrix::Quaternion<float> q(&_sub_att.get().q[0]);
+		_eul = matrix::Euler<float>(q);
+		_R_att = matrix::Dcm<float>(q);
 		Vector3f a(_sub_sensor.get().accelerometer_m_s2);
 		// note, bias is removed in dynamics function
-		_u = R_att * a;
+		_u = _R_att * a;
 		_u(U_az) += 9.81f; // add g
 
 	} else {

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -929,7 +929,7 @@ void BlockLocalPositionEstimator::predict()
 	// state or covariance
 	if (!_validXY && !_validZ) { return; }
 
-	if (integrate && _sub_att.get().q_valid) {
+	if (integrate) {
 		matrix::Quaternion<float> q(&_sub_att.get().q[0]);
 		_eul = matrix::Euler<float>(q);
 		_R_att = matrix::Dcm<float>(q);

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -401,6 +401,10 @@ private:
 	Vector<float, n_x>  _x; // state vector
 	Vector<float, n_u>  _u; // input vector
 	Matrix<float, n_x, n_x>  _P; // state covariance matrix
+
+	matrix::Dcm<float> _R_att;
+	Vector3f _eul;
+
 	Matrix<float, n_x, n_x>  _A; // dynamics matrix
 	Matrix<float, n_x, n_u>  _B; // input matrix
 	Matrix<float, n_u, n_u>  _R; // input covariance

--- a/src/modules/local_position_estimator/sensors/flow.cpp
+++ b/src/modules/local_position_estimator/sensors/flow.cpp
@@ -64,7 +64,10 @@ int BlockLocalPositionEstimator::flowMeasure(Vector<float, n_y_flow> &y)
 		return -1;
 	}
 
-	float d = agl() * cosf(_sub_att.get().roll) * cosf(_sub_att.get().pitch);
+	matrix::Quaternion<float> q(&_sub_att.get().q[0]);
+	matrix::Euler<float> euler(q);
+
+	float d = agl() * cosf(euler(0)) * cosf(euler(1));
 
 	// optical flow in x, y axis
 	// TODO consider making flow scale a states of the kalman filter
@@ -98,8 +101,7 @@ int BlockLocalPositionEstimator::flowMeasure(Vector<float, n_y_flow> &y)
 		0);
 
 	// rotation of flow from body to nav frame
-	Matrix3f R_nb(_sub_att.get().R);
-	Vector3f delta_n = R_nb * delta_b;
+	Vector3f delta_n = _R_att * delta_b;
 
 	// imporant to timestamp flow even if distance is bad
 	_time_last_flow = _timeStamp;

--- a/src/modules/local_position_estimator/sensors/flow.cpp
+++ b/src/modules/local_position_estimator/sensors/flow.cpp
@@ -43,7 +43,7 @@ void BlockLocalPositionEstimator::flowDeinit()
 int BlockLocalPositionEstimator::flowMeasure(Vector<float, n_y_flow> &y)
 {
 	// check for sane pitch/roll
-	if (_sub_att.get().roll > 0.5f || _sub_att.get().pitch > 0.5f) {
+	if (_eul(0) > 0.5f || _eul(1) > 0.5f) {
 		return -1;
 	}
 

--- a/src/modules/local_position_estimator/sensors/flow.cpp
+++ b/src/modules/local_position_estimator/sensors/flow.cpp
@@ -64,10 +64,9 @@ int BlockLocalPositionEstimator::flowMeasure(Vector<float, n_y_flow> &y)
 		return -1;
 	}
 
-	matrix::Quaternion<float> q(&_sub_att.get().q[0]);
-	matrix::Euler<float> euler(q);
+	matrix::Eulerf euler = matrix::Quatf(_sub_att.get().q);
 
-	float d = agl() * cosf(euler(0)) * cosf(euler(1));
+	float d = agl() * cosf(euler.phi()) * cosf(euler.theta());
 
 	// optical flow in x, y axis
 	// TODO consider making flow scale a states of the kalman filter

--- a/src/modules/local_position_estimator/sensors/lidar.cpp
+++ b/src/modules/local_position_estimator/sensors/lidar.cpp
@@ -53,8 +53,8 @@ int BlockLocalPositionEstimator::lidarMeasure(Vector<float, n_y_lidar> &y)
 	_time_last_lidar = _timeStamp;
 	y.setZero();
 	y(0) = (d + _lidar_z_offset.get()) *
-	       cosf(_sub_att.get().roll) *
-	       cosf(_sub_att.get().pitch);
+	       cosf(_eul(0)) *
+	       cosf(_eul(1));
 	return OK;
 }
 
@@ -67,8 +67,8 @@ void BlockLocalPositionEstimator::lidarCorrect()
 
 	// account for leaning
 	y(0) = y(0) *
-	       cosf(_eul.phi()) *
-	       cosf(_eul.theta());
+	       cosf(_eul(0)) *
+	       cosf(_eul(1));
 
 	// measurement matrix
 	Matrix<float, n_y_lidar, n_x> C;

--- a/src/modules/local_position_estimator/sensors/lidar.cpp
+++ b/src/modules/local_position_estimator/sensors/lidar.cpp
@@ -65,6 +65,11 @@ void BlockLocalPositionEstimator::lidarCorrect()
 
 	if (lidarMeasure(y) != OK) { return; }
 
+	// account for leaning
+	y(0) = y(0) *
+	       cosf(_eul.phi()) *
+	       cosf(_eul.theta());
+
 	// measurement matrix
 	Matrix<float, n_y_lidar, n_x> C;
 	C.setZero();

--- a/src/modules/local_position_estimator/sensors/sonar.cpp
+++ b/src/modules/local_position_estimator/sensors/sonar.cpp
@@ -67,8 +67,8 @@ int BlockLocalPositionEstimator::sonarMeasure(Vector<float, n_y_sonar> &y)
 	_time_last_sonar = _timeStamp;
 	y.setZero();
 	y(0) = (d + _sonar_z_offset.get()) *
-	       cosf(_sub_att.get().roll) *
-	       cosf(_sub_att.get().pitch);
+	       cosf(_eul(0)) *
+	       cosf(_eul(1));
 	return OK;
 }
 

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -841,12 +841,11 @@ protected:
 
 		if (_att_sub->update(&_att_time, &att)) {
 			mavlink_attitude_t msg;
-			matrix::Quaternion<float> q(&att.q[0]);
-			matrix::Euler<float> euler(q);
+			matrix::Eulerf euler = matrix::Quatf(att.q);
 			msg.time_boot_ms = att.timestamp / 1000;
-			msg.roll = euler(0);
-			msg.pitch = euler(1);
-			msg.yaw = euler(2);
+			msg.roll = euler.phi();
+			msg.pitch = euler.theta();
+			msg.yaw = euler.psi();
 			msg.rollspeed = att.rollspeed;
 			msg.pitchspeed = att.pitchspeed;
 			msg.yawspeed = att.yawspeed;
@@ -1015,11 +1014,10 @@ protected:
 
 		if (updated) {
 			mavlink_vfr_hud_t msg;
-			matrix::Quaternion<float> q(&att.q[0]);
-			matrix::Euler<float> euler(q);
+			matrix::Eulerf euler = matrix::Quatf(att.q);
 			msg.airspeed = airspeed.indicated_airspeed_m_s;
 			msg.groundspeed = sqrtf(pos.vel_n * pos.vel_n + pos.vel_e * pos.vel_e);
-			msg.heading = _wrap_2pi(euler(2)) * M_RAD_TO_DEG_F;
+			msg.heading = _wrap_2pi(euler.psi()) * M_RAD_TO_DEG_F;
 			msg.throttle = armed.armed ? act.control[3] * 100.0f : 0.0f;
 
 			if (_pos_time > 0) {

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -841,11 +841,12 @@ protected:
 
 		if (_att_sub->update(&_att_time, &att)) {
 			mavlink_attitude_t msg;
-
+			matrix::Quaternion<float> q(&att.q[0]);
+			matrix::Euler<float> euler(q);
 			msg.time_boot_ms = att.timestamp / 1000;
-			msg.roll = att.roll;
-			msg.pitch = att.pitch;
-			msg.yaw = att.yaw;
+			msg.roll = euler(0);
+			msg.pitch = euler(1);
+			msg.yaw = euler(2);
 			msg.rollspeed = att.rollspeed;
 			msg.pitchspeed = att.pitchspeed;
 			msg.yawspeed = att.yawspeed;
@@ -1014,10 +1015,11 @@ protected:
 
 		if (updated) {
 			mavlink_vfr_hud_t msg;
-
+			matrix::Quaternion<float> q(&att.q[0]);
+			matrix::Euler<float> euler(q);
 			msg.airspeed = airspeed.indicated_airspeed_m_s;
 			msg.groundspeed = sqrtf(pos.vel_n * pos.vel_n + pos.vel_e * pos.vel_e);
-			msg.heading = _wrap_2pi(att.yaw) * M_RAD_TO_DEG_F;
+			msg.heading = _wrap_2pi(euler(2)) * M_RAD_TO_DEG_F;
 			msg.throttle = armed.armed ? act.control[3] * 100.0f : 0.0f;
 
 			if (_pos_time > 0) {

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1920,8 +1920,8 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 		math::Vector<3> euler = C_nb.to_euler();
 
 		hil_attitude.timestamp = timestamp;
-		memcpy(hil_attitude.R, C_nb.data, sizeof(hil_attitude.R));
-		hil_attitude.R_valid = true;
+		//memcpy(hil_attitude.R, C_nb.data, sizeof(hil_attitude.R));
+		//hil_attitude.R_valid = true;
 
 		hil_attitude.q[0] = q(0);
 		hil_attitude.q[1] = q(1);
@@ -1929,9 +1929,9 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 		hil_attitude.q[3] = q(3);
 		hil_attitude.q_valid = true;
 
-		hil_attitude.roll = euler(0);
-		hil_attitude.pitch = euler(1);
-		hil_attitude.yaw = euler(2);
+		//hil_attitude.roll = euler(0);
+		//hil_attitude.pitch = euler(1);
+		//hil_attitude.yaw = euler(2);
 		hil_attitude.rollspeed = hil_state.rollspeed;
 		hil_attitude.pitchspeed = hil_state.pitchspeed;
 		hil_attitude.yawspeed = hil_state.yawspeed;
@@ -1948,7 +1948,8 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 	{
 		struct vehicle_global_position_s hil_global_pos;
 		memset(&hil_global_pos, 0, sizeof(hil_global_pos));
-
+		matrix::Quaternion<float> q(&hil_attitude.q[0]);
+		matrix::Euler<float> euler(q);
 		hil_global_pos.timestamp = timestamp;
 		hil_global_pos.lat = hil_state.lat / ((double)1e7);
 		hil_global_pos.lon = hil_state.lon / ((double)1e7);
@@ -1956,7 +1957,7 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 		hil_global_pos.vel_n = hil_state.vx / 100.0f;
 		hil_global_pos.vel_e = hil_state.vy / 100.0f;
 		hil_global_pos.vel_d = hil_state.vz / 100.0f;
-		hil_global_pos.yaw = hil_attitude.yaw;
+		hil_global_pos.yaw = euler(1);
 		hil_global_pos.eph = 2.0f;
 		hil_global_pos.epv = 4.0f;
 
@@ -1997,7 +1998,9 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 		hil_local_pos.vx = hil_state.vx / 100.0f;
 		hil_local_pos.vy = hil_state.vy / 100.0f;
 		hil_local_pos.vz = hil_state.vz / 100.0f;
-		hil_local_pos.yaw = hil_attitude.yaw;
+		matrix::Quaternion<float> q(&hil_attitude.q[0]);
+		matrix::Euler<float> euler(q);
+		hil_local_pos.yaw = euler(2);
 		hil_local_pos.xy_global = true;
 		hil_local_pos.z_global = true;
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1925,7 +1925,6 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 		hil_attitude.q[1] = q(1);
 		hil_attitude.q[2] = q(2);
 		hil_attitude.q[3] = q(3);
-		hil_attitude.q_valid = true;
 
 		hil_attitude.rollspeed = hil_state.rollspeed;
 		hil_attitude.pitchspeed = hil_state.pitchspeed;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1920,8 +1920,6 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 		math::Vector<3> euler = C_nb.to_euler();
 
 		hil_attitude.timestamp = timestamp;
-		//memcpy(hil_attitude.R, C_nb.data, sizeof(hil_attitude.R));
-		//hil_attitude.R_valid = true;
 
 		hil_attitude.q[0] = q(0);
 		hil_attitude.q[1] = q(1);
@@ -1929,9 +1927,6 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 		hil_attitude.q[3] = q(3);
 		hil_attitude.q_valid = true;
 
-		//hil_attitude.roll = euler(0);
-		//hil_attitude.pitch = euler(1);
-		//hil_attitude.yaw = euler(2);
 		hil_attitude.rollspeed = hil_state.rollspeed;
 		hil_attitude.pitchspeed = hil_state.pitchspeed;
 		hil_attitude.yawspeed = hil_state.yawspeed;
@@ -1957,7 +1952,7 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 		hil_global_pos.vel_n = hil_state.vx / 100.0f;
 		hil_global_pos.vel_e = hil_state.vy / 100.0f;
 		hil_global_pos.vel_d = hil_state.vz / 100.0f;
-		hil_global_pos.yaw = euler(1);
+		hil_global_pos.yaw = euler(2);
 		hil_global_pos.eph = 2.0f;
 		hil_global_pos.epv = 4.0f;
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1942,8 +1942,7 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 	{
 		struct vehicle_global_position_s hil_global_pos;
 		memset(&hil_global_pos, 0, sizeof(hil_global_pos));
-		matrix::Quaternion<float> q(&hil_attitude.q[0]);
-		matrix::Euler<float> euler(q);
+		matrix::Eulerf euler = matrix::Quatf(hil_attitude.q);
 		hil_global_pos.timestamp = timestamp;
 		hil_global_pos.lat = hil_state.lat / ((double)1e7);
 		hil_global_pos.lon = hil_state.lon / ((double)1e7);
@@ -1951,7 +1950,7 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 		hil_global_pos.vel_n = hil_state.vx / 100.0f;
 		hil_global_pos.vel_e = hil_state.vy / 100.0f;
 		hil_global_pos.vel_d = hil_state.vz / 100.0f;
-		hil_global_pos.yaw = euler(2);
+		hil_global_pos.yaw = euler.psi();
 		hil_global_pos.eph = 2.0f;
 		hil_global_pos.epv = 4.0f;
 
@@ -1992,9 +1991,8 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 		hil_local_pos.vx = hil_state.vx / 100.0f;
 		hil_local_pos.vy = hil_state.vy / 100.0f;
 		hil_local_pos.vz = hil_state.vz / 100.0f;
-		matrix::Quaternion<float> q(&hil_attitude.q[0]);
-		matrix::Euler<float> euler(q);
-		hil_local_pos.yaw = euler(2);
+		matrix::Eulerf euler = matrix::Quatf(hil_attitude.q);
+		hil_local_pos.yaw = euler.psi();
 		hil_local_pos.xy_global = true;
 		hil_local_pos.z_global = true;
 

--- a/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
@@ -500,8 +500,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 			/* sensor combined */
 			orb_check(sensor_combined_sub, &updated);
 
-			matrix::Quaternion<float> q(&att.q[0]);
-			matrix::Dcm<float> R(q);
+			matrix::Dcmf R = matrix::Quatf(att.q);
 
 			if (updated) {
 				orb_copy(ORB_ID(sensor_combined), sensor_combined_sub, &sensor);
@@ -944,8 +943,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 			}
 		}
 
-		matrix::Quaternion<float> q(&att.q[0]);
-		matrix::Dcm<float> R(q);
+		matrix::Dcm<float> R = matrix::Quatf(att.q);
 
 		/* check for timeout on FLOW topic */
 		if ((flow_valid || lidar_valid) && t > (flow_time + flow_topic_timeout)) {

--- a/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
@@ -1330,8 +1330,8 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 			local_pos.vy = y_est[1];
 			local_pos.z = z_est[0];
 			local_pos.vz = z_est[1];
-			matrix::Euler<float> euler(R);
-			local_pos.yaw = euler(2);
+			matrix::Eulerf euler(R);
+			local_pos.yaw = euler.psi();
 			local_pos.dist_bottom_valid = dist_bottom_valid;
 			local_pos.eph = eph;
 			local_pos.epv = epv;

--- a/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
@@ -1337,7 +1337,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 			local_pos.z = z_est[0];
 			local_pos.vz = z_est[1];
 			matrix::Euler<float> euler(R);
-			local_pos.yaw = euler(0);
+			local_pos.yaw = euler(2);
 			local_pos.dist_bottom_valid = dist_bottom_valid;
 			local_pos.eph = eph;
 			local_pos.epv = epv;

--- a/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
@@ -507,26 +507,21 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 				orb_copy(ORB_ID(sensor_combined), sensor_combined_sub, &sensor);
 
 				if (sensor.timestamp + sensor.accelerometer_timestamp_relative != accel_timestamp) {
-					if (att.q_valid) {
-						/* correct accel bias */
-						sensor.accelerometer_m_s2[0] -= acc_bias[0];
-						sensor.accelerometer_m_s2[1] -= acc_bias[1];
-						sensor.accelerometer_m_s2[2] -= acc_bias[2];
+					/* correct accel bias */
+					sensor.accelerometer_m_s2[0] -= acc_bias[0];
+					sensor.accelerometer_m_s2[1] -= acc_bias[1];
+					sensor.accelerometer_m_s2[2] -= acc_bias[2];
 
-						/* transform acceleration vector from body frame to NED frame */
-						for (int i = 0; i < 3; i++) {
-							acc[i] = 0.0f;
+					/* transform acceleration vector from body frame to NED frame */
+					for (int i = 0; i < 3; i++) {
+						acc[i] = 0.0f;
 
-							for (int j = 0; j < 3; j++) {
-								acc[i] += R(i, j) * sensor.accelerometer_m_s2[j];
-							}
+						for (int j = 0; j < 3; j++) {
+							acc[i] += R(i, j) * sensor.accelerometer_m_s2[j];
 						}
-
-						acc[2] += CONSTANTS_ONE_G;
-
-					} else {
-						memset(acc, 0, sizeof(acc));
 					}
+
+					acc[2] += CONSTANTS_ONE_G;
 
 					accel_timestamp = sensor.timestamp + sensor.accelerometer_timestamp_relative;
 					accel_updates++;
@@ -551,8 +546,9 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 
 			if (updated) { //check if altitude estimation for lidar is enabled and new sensor data
 
-				if (params.enable_lidar_alt_est && lidar.current_distance > lidar.min_distance && lidar.current_distance < lidar.max_distance
-			    		&& (R(2, 2) > 0.7f)) {
+				if (params.enable_lidar_alt_est && lidar.current_distance > lidar.min_distance
+				    && lidar.current_distance < lidar.max_distance
+				    && (R(2, 2) > 0.7f)) {
 
 					if (!use_lidar_prev && use_lidar) {
 						lidar_first = true;
@@ -614,7 +610,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 					float body_v_est[2] = { 0.0f, 0.0f };
 
 					for (int i = 0; i < 2; i++) {
-						body_v_est[i] = R( 0, i) * x_est[1] + R(1, i) * y_est[1] + R(2, i) * z_est[1];
+						body_v_est[i] = R(0, i) * x_est[1] + R(1, i) * y_est[1] + R(2, i) * z_est[1];
 					}
 
 					/* set this flag if flow should be accurate according to current velocity and attitude rate estimate */

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -2279,9 +2279,6 @@ int sdlog2_thread_main(int argc, char *argv[])
 			log_msg.body.log_ATT.roll_rate = buf.att.rollspeed;
 			log_msg.body.log_ATT.pitch_rate = buf.att.pitchspeed;
 			log_msg.body.log_ATT.yaw_rate = buf.att.yawspeed;
-			log_msg.body.log_ATT.gx = 0;
-			log_msg.body.log_ATT.gy = 0;
-			log_msg.body.log_ATT.gz = 0;
 			LOGBUFFER_WRITE_AND_COUNT(ATT);
 		}
 

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -2269,15 +2269,15 @@ int sdlog2_thread_main(int argc, char *argv[])
 			log_msg.body.log_ATT.q_x = buf.att.q[1];
 			log_msg.body.log_ATT.q_y = buf.att.q[2];
 			log_msg.body.log_ATT.q_z = buf.att.q[3];
-			log_msg.body.log_ATT.roll = buf.att.roll;
-			log_msg.body.log_ATT.pitch = buf.att.pitch;
-			log_msg.body.log_ATT.yaw = buf.att.yaw;
+			log_msg.body.log_ATT.roll = 0;
+			log_msg.body.log_ATT.pitch = 0;
+			log_msg.body.log_ATT.yaw = 0;
 			log_msg.body.log_ATT.roll_rate = buf.att.rollspeed;
 			log_msg.body.log_ATT.pitch_rate = buf.att.pitchspeed;
 			log_msg.body.log_ATT.yaw_rate = buf.att.yawspeed;
-			log_msg.body.log_ATT.gx = buf.att.g_comp[0];
-			log_msg.body.log_ATT.gy = buf.att.g_comp[1];
-			log_msg.body.log_ATT.gz = buf.att.g_comp[2];
+			log_msg.body.log_ATT.gx = 0;
+			log_msg.body.log_ATT.gy = 0;
+			log_msg.body.log_ATT.gz = 0;
 			LOGBUFFER_WRITE_AND_COUNT(ATT);
 		}
 

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -2265,13 +2265,17 @@ int sdlog2_thread_main(int argc, char *argv[])
 		/* --- ATTITUDE --- */
 		if (copy_if_updated(ORB_ID(vehicle_attitude), &subs.att_sub, &buf.att)) {
 			log_msg.msg_type = LOG_ATT_MSG;
-			log_msg.body.log_ATT.q_w = buf.att.q[0];
-			log_msg.body.log_ATT.q_x = buf.att.q[1];
-			log_msg.body.log_ATT.q_y = buf.att.q[2];
-			log_msg.body.log_ATT.q_z = buf.att.q[3];
-			log_msg.body.log_ATT.roll = 0;
-			log_msg.body.log_ATT.pitch = 0;
-			log_msg.body.log_ATT.yaw = 0;
+			float q0 = buf.att.q[0];
+			float q1 = buf.att.q[1];
+			float q2 = buf.att.q[2];
+			float q3 = buf.att.q[3];
+			log_msg.body.log_ATT.q_w = q0;
+			log_msg.body.log_ATT.q_x = q1;
+			log_msg.body.log_ATT.q_y = q2;
+			log_msg.body.log_ATT.q_z = q3;
+			log_msg.body.log_ATT.roll = atan2f(2*(q0*q1 + q2*q3), 1 - 2*(q1*q1 + q2*q2));
+			log_msg.body.log_ATT.pitch = asinf(2*(q0*q2 - q3*q1));
+			log_msg.body.log_ATT.yaw = atan2f(2*(q0*q3 + q1*q2), 1 - 2*(q2*q2 + q3*q3));
 			log_msg.body.log_ATT.roll_rate = buf.att.rollspeed;
 			log_msg.body.log_ATT.pitch_rate = buf.att.pitchspeed;
 			log_msg.body.log_ATT.yaw_rate = buf.att.yawspeed;

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -62,9 +62,6 @@ struct log_ATT_s {
 	float roll_rate;
 	float pitch_rate;
 	float yaw_rate;
-	float gx;
-	float gy;
-	float gz;
 };
 
 /* --- ATSP - ATTITUDE SET POINT --- */
@@ -655,7 +652,7 @@ struct log_PARM_s {
 /* construct list of all message formats */
 static const struct log_format_s log_formats[] = {
 	/* business-level messages, ID < 0x80 */
-	LOG_FORMAT(ATT, "fffffffffffff",	"qw,qx,qy,qz,Roll,Pitch,Yaw,RollRate,PitchRate,YawRate,GX,GY,GZ"),
+	LOG_FORMAT(ATT, "ffffffffff",	"qw,qx,qy,qz,Roll,Pitch,Yaw,RollRate,PitchRate,YawRate"),
 	LOG_FORMAT(ATSP, "ffffffff",		"RollSP,PitchSP,YawSP,ThrustSP,qw,qx,qy,qz"),
 	LOG_FORMAT_S(IMU, IMU, "ffffffffffff",		"AccX,AccY,AccZ,GyroX,GyroY,GyroZ,MagX,MagY,MagZ,tA,tG,tM"),
 	LOG_FORMAT_S(IMU1, IMU, "ffffffffffff",		"AccX,AccY,AccZ,GyroX,GyroY,GyroZ,MagX,MagY,MagZ,tA,tG,tM"),

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -316,18 +316,12 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 			hil_attitude.timestamp = timestamp;
 
 			math::Quaternion q(hil_state.attitude_quaternion);
-			math::Matrix<3, 3> C_nb = q.to_dcm();
-			math::Vector<3> euler = C_nb.to_euler();
 
 			hil_attitude.q[0] = q(0);
 			hil_attitude.q[1] = q(1);
 			hil_attitude.q[2] = q(2);
 			hil_attitude.q[3] = q(3);
 			hil_attitude.q_valid = true;
-
-			hil_attitude.roll = euler(0);
-			hil_attitude.pitch = euler(1);
-			hil_attitude.yaw = euler(2);
 
 			hil_attitude.rollspeed = hil_state.rollspeed;
 			hil_attitude.pitchspeed = hil_state.pitchspeed;

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -321,7 +321,6 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 			hil_attitude.q[1] = q(1);
 			hil_attitude.q[2] = q(2);
 			hil_attitude.q[3] = q(3);
-			hil_attitude.q_valid = true;
 
 			hil_attitude.rollspeed = hil_state.rollspeed;
 			hil_attitude.pitchspeed = hil_state.pitchspeed;

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -131,9 +131,8 @@ void Tailsitter::update_vtol_state()
 	 * For the backtransition the pitch is controlled in MC mode again and switches to full MC control reaching the sufficient pitch angle.
 	*/
 
-	matrix::Quaternion<float> q(&_v_att->q[0]);
-	matrix::Euler<float> euler(q);
-	float pitch = euler(1);
+	matrix::Eulerf euler = matrix::Quatf(_v_att->q);
+	float pitch = euler.theta();
 
 	if (!_attc->is_fixed_wing_requested()) {
 

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -131,6 +131,10 @@ void Tailsitter::update_vtol_state()
 	 * For the backtransition the pitch is controlled in MC mode again and switches to full MC control reaching the sufficient pitch angle.
 	*/
 
+	matrix::Quaternion<float> q(&_v_att->q[0]);
+	matrix::Euler<float> euler(q);
+	float pitch = euler(1);
+
 	if (!_attc->is_fixed_wing_requested()) {
 
 
@@ -157,7 +161,7 @@ void Tailsitter::update_vtol_state()
 		case TRANSITION_BACK:
 
 			// check if we have reached pitch angle to switch to MC mode
-			if (_v_att->pitch >= PITCH_TRANSITION_BACK) {
+			if (pitch >= PITCH_TRANSITION_BACK) {
 				_vtol_schedule.flight_mode = MC_MODE;
 			}
 
@@ -180,7 +184,7 @@ void Tailsitter::update_vtol_state()
 
 			// check if we have reached airspeed  and pitch angle to switch to TRANSITION P2 mode
 			if ((_airspeed->indicated_airspeed_m_s >= _params_tailsitter.airspeed_trans
-			     && _v_att->pitch <= PITCH_TRANSITION_FRONT_P1) || can_transition_on_ground()) {
+			     && pitch <= PITCH_TRANSITION_FRONT_P1) || can_transition_on_ground()) {
 				_vtol_schedule.flight_mode = FW_MODE;
 				//_vtol_schedule.transition_start = hrt_absolute_time();
 			}

--- a/src/platforms/ros/nodes/attitude_estimator/attitude_estimator.cpp
+++ b/src/platforms/ros/nodes/attitude_estimator/attitude_estimator.cpp
@@ -75,21 +75,6 @@ void AttitudeEstimator::ModelStatesCallback(const gazebo_msgs::ModelStatesConstP
 	msg_v_att.q[2] = quat(2);
 	msg_v_att.q[3] = quat(3);
 
-	math::Matrix<3, 3> rot = quat.to_dcm();
-
-	for (int i = 0; i < 3; i++) {
-		for (int j = 0; j < 3; j++) {
-			PX4_R(msg_v_att.R, i, j) = rot(i, j);
-		}
-	}
-
-	msg_v_att.R_valid = true;
-
-	math::Vector<3> euler = rot.to_euler();
-	msg_v_att.roll = euler(0);
-	msg_v_att.pitch = euler(1);
-	msg_v_att.yaw = euler(2);
-
 	//XXX this is in inertial frame
 	// msg_v_att.rollspeed = (float)msg->twist[index].angular.x;
 	// msg_v_att.pitchspeed = -(float)msg->twist[index].angular.y;


### PR DESCRIPTION
This removes out all the irrelevant and redundant data out of the attitude topic.
The main reason why we do this is because the new logger app #4282 will log entire topics and so we don't want to burn the logging bandwidth on redundant data.

This needs review, testing in SITL and testing outdoors.
At several locations code has been commented out. If we agree on the content of the attitude message then this code can be removed.