### PR TITLE
FW stabalized mode properly initialize att_sp

### DIFF
--- a/src/modules/fw_att_control/fw_att_control_main.cpp
+++ b/src/modules/fw_att_control/fw_att_control_main.cpp
@@ -1063,12 +1063,16 @@ FixedwingAttitudeControl::task_main()
 					 * emit the manual setpoint here to allow attitude controller tuning
 					 * in attitude control mode.
 					 */
-					struct vehicle_attitude_setpoint_s att_sp;
+					struct vehicle_attitude_setpoint_s att_sp = {};
 					att_sp.timestamp = hrt_absolute_time();
 					att_sp.roll_body = roll_sp;
 					att_sp.pitch_body = pitch_sp;
 					att_sp.yaw_body = 0.0f - _parameters.trim_yaw;
 					att_sp.thrust = throttle_sp;
+
+					att_sp.roll_reset_integral = false;
+					att_sp.pitch_reset_integral = false;
+					att_sp.yaw_reset_integral = false;
 
 					/* lazily publish the setpoint only once available */
 					if (_attitude_sp_pub != nullptr) {

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -2201,11 +2201,17 @@ Sensors::task_main()
 			/* If the secondary failed as well, go to the tertiary, also only if available. */
 			if (hrt_elapsed_time(&raw.gyro_timestamp[1]) > 20 * 1000 && _gyro_sub[2] >= 0) {
 				fds[0].fd = _gyro_sub[2];
-				warnx("failing over to third gyro");
+
+				if (!_hil_enabled) {
+					warnx("failing over to third gyro");
+				}
 
 			} else if (_gyro_sub[1] >= 0) {
 				fds[0].fd = _gyro_sub[1];
-				warnx("failing over to second gyro");
+
+				if (!_hil_enabled) {
+					warnx("failing over to second gyro");
+				}
 			}
 		}
 


### PR DESCRIPTION
In fixed wing stabilized mode the ECL integrators were being constantly reset. The attitude setpoint published in fw_att_control during stabilized mode wasn't initialized and att_sp.pitch_reset_integral was interpreted as set.

I discovered this after a rather spectacular crash 30s after takeoff.