### PR TITLE
Snapdragon: switch to 8kHz sampling

### DIFF
--- a/src/drivers/device/integrator.cpp
+++ b/src/drivers/device/integrator.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2015-2016 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,19 +37,18 @@
  * A resettable integrator
  *
  * @author Lorenz Meier <lorenz@px4.io>
+ * @author Julian Oes <julian@oes.ch>
  */
 
 #include "integrator.h"
 
 Integrator::Integrator(uint64_t auto_reset_interval, bool coning_compensation) :
 	_auto_reset_interval(auto_reset_interval),
-	_last_integration(0),
-	_last_auto(0),
-	_integral_auto(0.0f, 0.0f, 0.0f),
-	_integral_read(0.0f, 0.0f, 0.0f),
+	_last_integration_time(0),
+	_last_reset_time(0),
+	_integral(0.0f, 0.0f, 0.0f),
 	_last_val(0.0f, 0.0f, 0.0f),
 	_last_delta(0.0f, 0.0f, 0.0f),
-	_auto_callback(nullptr),
 	_coning_comp_on(coning_compensation)
 {
 
@@ -63,19 +62,25 @@ Integrator::~Integrator()
 bool
 Integrator::put(uint64_t timestamp, math::Vector<3> &val, math::Vector<3> &integral, uint64_t &integral_dt)
 {
-	bool auto_reset = false;
-
-	if (_last_integration == 0) {
+	if (_last_integration_time == 0) {
 		/* this is the first item in the integrator */
-		_last_integration = timestamp;
-		_last_auto = timestamp;
+		_last_integration_time = timestamp;
+		_last_reset_time = timestamp;
 		_last_val = val;
+
 		return false;
 	}
 
-	// Integrate
-	double dt = (double)(timestamp - _last_integration) / 1000000.0;
-	math::Vector<3> i = (val + _last_val) * dt * 0.5f;
+	double dt = 0.0;
+
+	// Integrate:
+	// Leave dt at 0 if the integration time does not make sense.
+	// Without this check the integral is likely to explode.
+	if (timestamp >= _last_integration_time) {
+		dt = (double)(timestamp - _last_integration_time) / 1000000.0;
+	}
+
+	math::Vector<3> delta = (val + _last_val) * dt * 0.5f;
 
 	// Apply coning compensation if required
 	if (_coning_comp_on) {
@@ -84,45 +89,46 @@ Integrator::put(uint64_t timestamp, math::Vector<3> &val, math::Vector<3> &integ
 		// Tian et al (2010) Three-loop Integration of GPS and Strapdown INS with Coning and Sculling Compensation
 		// Available: http://www.sage.unsw.edu.au/snap/publications/tian_etal2010b.pdf
 
-		i += ((_integral_auto + _last_delta * (1.0f / 6.0f)) % i) * 0.5f;
+		delta += ((_integral + _last_delta * (1.0f / 6.0f)) % delta) * 0.5f;
 	}
 
-	_integral_auto += i;
-	_integral_read += i;
+	_integral += delta;
 
-	_last_integration = timestamp;
+	_last_integration_time = timestamp;
 	_last_val = val;
-	_last_delta = i;
+	_last_delta = delta;
 
-	if ((timestamp - _last_auto) > _auto_reset_interval) {
-		if (_auto_callback) {
-			/* call the callback */
-			_auto_callback(timestamp, _integral_auto);
-		}
+	// Only do auto reset if auto reset interval is not 0.
+	if (_auto_reset_interval > 0 && (timestamp - _last_reset_time) > _auto_reset_interval) {
 
-		integral = _integral_auto;
-		integral_dt = (timestamp - _last_auto);
+		integral = _integral;
+		_reset(integral_dt);
 
-		auto_reset = true;
-		_last_auto = timestamp;
-		_integral_auto(0) = 0.0f;
-		_integral_auto(1) = 0.0f;
-		_integral_auto(2) = 0.0f;
+		return true;
+	} else {
+		return false;
 	}
-
-	return auto_reset;
 }
 
 math::Vector<3>
-Integrator::read(bool auto_reset)
+Integrator::get(bool reset, uint64_t &integral_dt)
 {
-	math::Vector<3> val = _integral_read;
+	math::Vector<3> val = _integral;
 
-	if (auto_reset) {
-		_integral_read(0) = 0.0f;
-		_integral_read(1) = 0.0f;
-		_integral_read(2) = 0.0f;
+	if (reset) {
+		_reset(integral_dt);
 	}
 
 	return val;
+}
+
+void
+Integrator::_reset(uint64_t &integral_dt)
+{
+	_integral(0) = 0.0f;
+	_integral(1) = 0.0f;
+	_integral(2) = 0.0f;
+
+	integral_dt = (_last_integration_time - _last_reset_time);
+	_last_reset_time = _last_integration_time;
 }

--- a/src/drivers/device/integrator.cpp
+++ b/src/drivers/device/integrator.cpp
@@ -105,6 +105,7 @@ Integrator::put(uint64_t timestamp, math::Vector<3> &val, math::Vector<3> &integ
 		_reset(integral_dt);
 
 		return true;
+
 	} else {
 		return false;
 	}

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1256,7 +1256,7 @@ PX4IO::io_set_control_state(unsigned group)
 
 			if (changed) {
 				orb_copy(ORB_ID(actuator_controls_0), _t_actuator_controls_0, &controls);
-				perf_set(_perf_sample_latency, hrt_elapsed_time(&controls.timestamp_sample));
+				perf_set_elapsed(_perf_sample_latency, hrt_elapsed_time(&controls.timestamp_sample));
 			}
 		}
 		break;

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -250,7 +250,7 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 			px4_clock_gettime(CLOCK_REALTIME, &ts);
 			uint64_t timestamp = ts.tv_sec * 1000 * 1000 + ts.tv_nsec / 1000;
 
-			perf_set(_perf_sim_delay, timestamp - sim_timestamp);
+			perf_set_elapsed(_perf_sim_delay, timestamp - sim_timestamp);
 			perf_count(_perf_sim_interval);
 
 			if (publish) {

--- a/src/modules/systemlib/perf_counter.c
+++ b/src/modules/systemlib/perf_counter.c
@@ -299,7 +299,7 @@ perf_end(perf_counter_t handle)
 #include <systemlib/err.h>
 
 void
-perf_set(perf_counter_t handle, int64_t elapsed)
+perf_set_elapsed(perf_counter_t handle, int64_t elapsed)
 {
 	if (handle == NULL) {
 		return;
@@ -340,6 +340,25 @@ perf_set(perf_counter_t handle, int64_t elapsed)
 	default:
 		break;
 	}
+}
+
+void
+perf_set_count(perf_counter_t handle, uint64_t count)
+{
+	if (handle == NULL) {
+		return;
+	}
+
+	switch (handle->type) {
+	case PC_COUNT: {
+			((struct perf_ctr_count *)handle)->event_count = count;
+		}
+		break;
+
+	default:
+		break;
+	}
+
 }
 
 void

--- a/src/modules/systemlib/perf_counter.c
+++ b/src/modules/systemlib/perf_counter.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2012 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2012-2016 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,10 +46,8 @@
 #include "perf_counter.h"
 
 #ifdef __PX4_QURT
-#define dprintf(...)
-#define ddeclare(...)
-#else
-#define ddeclare(...) __VA_ARGS__
+// There is presumably no dprintf on QURT. Therefore use the usual output to mini-dm.
+#define dprintf(_fd, _text, ...) ((_fd) == 1 ? PX4_INFO((_text), ##__VA_ARGS__) : (void)(_fd))
 #endif
 
 /**
@@ -439,8 +437,8 @@ perf_print_counter_fd(int fd, perf_counter_t handle)
 		break;
 
 	case PC_ELAPSED: {
-			ddeclare(struct perf_ctr_elapsed *pce = (struct perf_ctr_elapsed *)handle;)
-			ddeclare(float rms = sqrtf(pce->M2 / (pce->event_count - 1));)
+			struct perf_ctr_elapsed *pce = (struct perf_ctr_elapsed *)handle;
+			float rms = sqrtf(pce->M2 / (pce->event_count - 1));
 			dprintf(fd, "%s: %llu events, %llu overruns, %lluus elapsed, %lluus avg, min %lluus max %lluus %5.3fus rms\n",
 				handle->name,
 				(unsigned long long)pce->event_count,
@@ -454,8 +452,8 @@ perf_print_counter_fd(int fd, perf_counter_t handle)
 		}
 
 	case PC_INTERVAL: {
-			ddeclare(struct perf_ctr_interval *pci = (struct perf_ctr_interval *)handle;)
-			ddeclare(float rms = sqrtf(pci->M2 / (pci->event_count - 1));)
+			struct perf_ctr_interval *pci = (struct perf_ctr_interval *)handle;
+			float rms = sqrtf(pci->M2 / (pci->event_count - 1));
 
 			dprintf(fd, "%s: %llu events, %lluus avg, min %lluus max %lluus %5.3fus rms\n",
 				handle->name,

--- a/src/modules/systemlib/perf_counter.h
+++ b/src/modules/systemlib/perf_counter.h
@@ -122,7 +122,17 @@ __EXPORT extern void		perf_end(perf_counter_t handle);
  * @param handle		The handle returned from perf_alloc.
  * @param elapsed		The time elapsed. Negative values lead to incrementing the overrun counter.
  */
-__EXPORT extern void		perf_set(perf_counter_t handle, int64_t elapsed);
+__EXPORT extern void		perf_set_elapsed(perf_counter_t handle, int64_t elapsed);
+
+/**
+ * Set a counter
+ *
+ * This call applies to counters of type PC_COUNT. It (re-)sets the count.
+ *
+ * @param handle		The handle returned from perf_alloc.
+ * @param count			The counter value to be set.
+ */
+__EXPORT extern void		perf_set_count(perf_counter_t handle, uint64_t count);
 
 /**
  * Cancel a performance event.

--- a/src/modules/systemlib/perf_counter.h
+++ b/src/modules/systemlib/perf_counter.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2012 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2012-2016 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
@@ -449,6 +449,7 @@ int DfMpu9250Wrapper::_publish(struct imu_sensor_data &data)
 
 	// Bail out if it's not the 4th time yet.
 	++_publish_count;
+
 	if (_publish_count < 4) {
 		return 0;
 	}

--- a/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
@@ -51,9 +51,9 @@
 #include <px4_getopt.h>
 #include <errno.h>
 
-#include <systemlib/perf_counter.h>
 #include <systemlib/err.h>
 
+#include <drivers/drv_hrt.h>
 #include <drivers/drv_accel.h>
 #include <drivers/drv_gyro.h>
 #include <drivers/device/integrator.h>
@@ -63,9 +63,8 @@
 #include <mpu9250/MPU9250.hpp>
 #include <DevMgr.hpp>
 
-
-// publish frequency of 250 Hz
-#define MPU9250_PUBLISH_INTERVAL_US 4000
+// We don't want to auto publish, therefore set this to 0.
+#define MPU9250_NEVER_AUTOPUBLISH_US 0
 
 
 extern "C" { __EXPORT int df_mpu9250_wrapper_main(int argc, char *argv[]); }
@@ -131,9 +130,8 @@ private:
 	Integrator		    _accel_int;
 	Integrator		    _gyro_int;
 
-	perf_counter_t		    _accel_sample_perf;
-	perf_counter_t		    _gyro_sample_perf;
-
+	unsigned		    _publish_count;
+	hrt_abstime		    _first_sample_time;
 };
 
 DfMpu9250Wrapper::DfMpu9250Wrapper(/*enum Rotation rotation*/) :
@@ -145,11 +143,11 @@ DfMpu9250Wrapper::DfMpu9250Wrapper(/*enum Rotation rotation*/) :
 	_gyro_calibration{},
 	_accel_orb_class_instance(-1),
 	_gyro_orb_class_instance(-1),
-	_accel_int(MPU9250_PUBLISH_INTERVAL_US, false),
-	_gyro_int(MPU9250_PUBLISH_INTERVAL_US, true),
-	_accel_sample_perf(perf_alloc(PC_ELAPSED, "df_accel_read")),
-	_gyro_sample_perf(perf_alloc(PC_ELAPSED, "df_gyro_read"))
+	_accel_int(MPU9250_NEVER_AUTOPUBLISH_US, false),
+	_gyro_int(MPU9250_NEVER_AUTOPUBLISH_US, true),
 	/*_rotation(rotation)*/
+	_publish_count(0),
+	_first_sample_time(0)
 {
 	// Set sane default calibration values
 	_accel_calibration.x_scale = 1.0f;
@@ -169,8 +167,6 @@ DfMpu9250Wrapper::DfMpu9250Wrapper(/*enum Rotation rotation*/) :
 
 DfMpu9250Wrapper::~DfMpu9250Wrapper()
 {
-	perf_free(_accel_sample_perf);
-	perf_free(_gyro_sample_perf);
 }
 
 int DfMpu9250Wrapper::start()
@@ -390,8 +386,6 @@ void DfMpu9250Wrapper::_update_accel_calibration()
 
 int DfMpu9250Wrapper::_publish(struct imu_sensor_data &data)
 {
-	bool should_notify = false;
-
 	/* Check if calibration values are still up-to-date. */
 	bool updated;
 	orb_check(_param_update_sub, &updated);
@@ -404,16 +398,17 @@ int DfMpu9250Wrapper::_publish(struct imu_sensor_data &data)
 		_update_gyro_calibration();
 	}
 
-	/* Publish accel first. */
-	perf_begin(_accel_sample_perf);
-
 	accel_report accel_report = {};
-	accel_report.timestamp = hrt_absolute_time();
+	gyro_report gyro_report = {};
 
-	// TODO: remove these (or get the values)
-	accel_report.x_raw = NAN;
-	accel_report.y_raw = NAN;
-	accel_report.z_raw = NAN;
+	// Only take a timestamp once for a series of consecutive samples.
+	// 0 is the reset value.
+	if (_first_sample_time == 0) {
+		_first_sample_time = hrt_absolute_time();
+	}
+
+	accel_report.timestamp = gyro_report.timestamp = _first_sample_time + data.time_offset_us;
+
 	accel_report.x = (data.accel_m_s2_x - _accel_calibration.x_offset) * _accel_calibration.x_scale;
 	accel_report.y = (data.accel_m_s2_y - _accel_calibration.y_offset) * _accel_calibration.y_scale;
 	accel_report.z = (data.accel_m_s2_z - _accel_calibration.z_offset) * _accel_calibration.z_scale;
@@ -421,47 +416,13 @@ int DfMpu9250Wrapper::_publish(struct imu_sensor_data &data)
 	math::Vector<3> accel_val(accel_report.x,
 				  accel_report.y,
 				  accel_report.z);
-	math::Vector<3> accel_val_integrated;
+	math::Vector<3> accel_val_integrated_unused;
 
-	const bool should_publish_accel = _accel_int.put(accel_report.timestamp,
-					  accel_val,
-					  accel_val_integrated,
-					  accel_report.integral_dt);
+	_accel_int.put(accel_report.timestamp,
+		       accel_val,
+		       accel_val_integrated_unused,
+		       accel_report.integral_dt);
 
-	accel_report.x_integral = accel_val_integrated(0);
-	accel_report.y_integral = accel_val_integrated(1);
-	accel_report.z_integral = accel_val_integrated(2);
-
-
-	// TODO: get these right
-	accel_report.scaling = -1.0f;
-	accel_report.range_m_s2 = -1.0f;
-
-	accel_report.device_id = m_id.dev_id;
-
-	// TODO: when is this ever blocked?
-	if (!(m_pub_blocked) && should_publish_accel) {
-
-		if (_accel_topic != nullptr) {
-			orb_publish(ORB_ID(sensor_accel), _accel_topic, &accel_report);
-		}
-
-		should_notify = true;
-	}
-
-	perf_end(_accel_sample_perf);
-
-
-	/* Then publish gyro. */
-	perf_begin(_gyro_sample_perf);
-
-	gyro_report gyro_report = {};
-	gyro_report.timestamp = hrt_absolute_time();
-
-	// TODO: remove these (or get the values)
-	gyro_report.x_raw = NAN;
-	gyro_report.y_raw = NAN;
-	gyro_report.z_raw = NAN;
 	gyro_report.x = (data.gyro_rad_s_x - _gyro_calibration.x_offset) * _gyro_calibration.x_scale;
 	gyro_report.y = (data.gyro_rad_s_y - _gyro_calibration.y_offset) * _gyro_calibration.y_scale;
 	gyro_report.z = (data.gyro_rad_s_z - _gyro_calibration.z_offset) * _gyro_calibration.z_scale;
@@ -469,38 +430,72 @@ int DfMpu9250Wrapper::_publish(struct imu_sensor_data &data)
 	math::Vector<3> gyro_val(gyro_report.x,
 				 gyro_report.y,
 				 gyro_report.z);
-	math::Vector<3> gyro_val_integrated(gyro_report.x,
-					    gyro_report.y,
-					    gyro_report.z);
+	math::Vector<3> gyro_val_integrated_unused;
 
-	const bool should_publish_gyro = _gyro_int.put(gyro_report.timestamp,
-					 gyro_val,
-					 gyro_val_integrated,
-					 gyro_report.integral_dt);
+	_gyro_int.put(gyro_report.timestamp,
+		      gyro_val,
+		      gyro_val_integrated_unused,
+		      gyro_report.integral_dt);
+
+	/* If the time offset is 0, we are receiving the latest sample and can publish,
+	 * at least every 4th time because the driver is running at 1kHz but we should
+	 * only publish at 250 Hz. */
+	if (data.time_offset_us != 0) {
+		return 0;
+	}
+
+	/* reset the first sample time to the reset value */
+	_first_sample_time = 0;
+
+	// Bail out if it's not the 4th time yet.
+	++_publish_count;
+	if (_publish_count < 4) {
+		return 0;
+	}
+
+	_publish_count = 0;
+
+	// TODO: get these right
+	gyro_report.scaling = -1.0f;
+	gyro_report.range_rad_s = -1.0f;
+	gyro_report.device_id = m_id.dev_id;
+
+	accel_report.scaling = -1.0f;
+	accel_report.range_m_s2 = -1.0f;
+	accel_report.device_id = m_id.dev_id;
+
+	// TODO: remove these (or get the values)
+	gyro_report.x_raw = NAN;
+	gyro_report.y_raw = NAN;
+	gyro_report.z_raw = NAN;
+
+	accel_report.x_raw = NAN;
+	accel_report.y_raw = NAN;
+	accel_report.z_raw = NAN;
+
+	// Read and reset.
+	math::Vector<3> gyro_val_integrated = _gyro_int.get(true, gyro_report.integral_dt);
+	math::Vector<3> accel_val_integrated = _accel_int.get(true, accel_report.integral_dt);
 
 	gyro_report.x_integral = gyro_val_integrated(0);
 	gyro_report.y_integral = gyro_val_integrated(1);
 	gyro_report.z_integral = gyro_val_integrated(2);
 
-	// TODO: get these right
-	gyro_report.scaling = -1.0f;
-	gyro_report.range_rad_s = -1.0f;
-
-	gyro_report.device_id = m_id.dev_id;
+	accel_report.x_integral = accel_val_integrated(0);
+	accel_report.y_integral = accel_val_integrated(1);
+	accel_report.z_integral = accel_val_integrated(2);
 
 	// TODO: when is this ever blocked?
-	if (!(m_pub_blocked) && should_publish_gyro) {
+	if (!(m_pub_blocked)) {
 
 		if (_gyro_topic != nullptr) {
 			orb_publish(ORB_ID(sensor_gyro), _gyro_topic, &gyro_report);
 		}
 
-		should_notify = true;
-	}
+		if (_accel_topic != nullptr) {
+			orb_publish(ORB_ID(sensor_accel), _accel_topic, &accel_report);
+		}
 
-	perf_end(_gyro_sample_perf);
-
-	if (should_notify) {
 		/* Notify anyone waiting for data. */
 		DevMgr::updateNotify(*this);
 	}

--- a/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
@@ -183,6 +183,13 @@ DfMpu9250Wrapper::DfMpu9250Wrapper(/*enum Rotation rotation*/) :
 
 DfMpu9250Wrapper::~DfMpu9250Wrapper()
 {
+	perf_free(_read_counter);
+	perf_free(_error_counter);
+	perf_free(_fifo_overflow_counter);
+	perf_free(_fifo_corruption_counter);
+	perf_free(_gyro_range_hit_counter);
+	perf_free(_accel_range_hit_counter);
+	perf_free(_publish_perf);
 }
 
 int DfMpu9250Wrapper::start()

--- a/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
@@ -94,6 +94,11 @@ public:
 	 */
 	int		stop();
 
+	/**
+	 * Print some debug info.
+	 */
+	void		info();
+
 private:
 	int _publish(struct imu_sensor_data &data);
 
@@ -141,6 +146,9 @@ private:
 	perf_counter_t		    _gyro_range_hit_counter;
 	perf_counter_t		    _accel_range_hit_counter;
 	perf_counter_t		    _publish_perf;
+
+	hrt_abstime		    _last_accel_range_hit_time;
+	uint64_t		    _last_accel_range_hit_count;
 };
 
 DfMpu9250Wrapper::DfMpu9250Wrapper(/*enum Rotation rotation*/) :
@@ -163,7 +171,9 @@ DfMpu9250Wrapper::DfMpu9250Wrapper(/*enum Rotation rotation*/) :
 	_fifo_corruption_counter(perf_alloc(PC_COUNT, "mpu9250_fifo_corruptions")),
 	_gyro_range_hit_counter(perf_alloc(PC_COUNT, "mpu9250_gyro_range_hits")),
 	_accel_range_hit_counter(perf_alloc(PC_COUNT, "mpu9250_accel_range_hits")),
-	_publish_perf(perf_alloc(PC_ELAPSED, "mpu9250_publish"))
+	_publish_perf(perf_alloc(PC_ELAPSED, "mpu9250_publish")),
+	_last_accel_range_hit_time(0),
+	_last_accel_range_hit_count(0)
 {
 	// Set sane default calibration values
 	_accel_calibration.x_scale = 1.0f;
@@ -254,6 +264,17 @@ int DfMpu9250Wrapper::stop()
 	}
 
 	return 0;
+}
+
+void DfMpu9250Wrapper::info()
+{
+	perf_print_counter(_read_counter);
+	perf_print_counter(_error_counter);
+	perf_print_counter(_fifo_overflow_counter);
+	perf_print_counter(_fifo_corruption_counter);
+	perf_print_counter(_gyro_range_hit_counter);
+	perf_print_counter(_accel_range_hit_counter);
+	perf_print_counter(_publish_perf);
 }
 
 void DfMpu9250Wrapper::_update_gyro_calibration()
@@ -607,7 +628,8 @@ info()
 		return 1;
 	}
 
-	PX4_DEBUG("state @ %p", g_dev);
+	PX4_INFO("state @ %p", g_dev);
+	g_dev->info();
 
 	return 0;
 }

--- a/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
@@ -505,6 +505,8 @@ int DfMpu9250Wrapper::_publish(struct imu_sensor_data &data)
 		return 0;
 	}
 
+	perf_begin(_publish_perf);
+
 	_publish_count = 0;
 
 	// TODO: get these right
@@ -551,6 +553,8 @@ int DfMpu9250Wrapper::_publish(struct imu_sensor_data &data)
 		/* Notify anyone waiting for data. */
 		DevMgr::updateNotify(*this);
 	}
+
+	perf_end(_publish_perf);
 
 	// TODO: check the return codes of this function
 	return 0;


### PR DESCRIPTION
This enables 8kHz sampling for the MPU9250 on the Snapdragon.

The changes which include fixes to the integrator lib have been bench tested on Snapdragon but need regression testing on NuttX and SITL as well.

Presumably, this should address #4330.

@LorenzMeier and @priseborough Please review, as well as: https://github.com/PX4/DriverFramework/pull/57