### PR TITLE
Better granularity for flight failsafe modes

### DIFF
--- a/Tools/px4params/xmlout.py
+++ b/Tools/px4params/xmlout.py
@@ -25,7 +25,7 @@ class XMLOutput():
         xml_version = ET.SubElement(xml_parameters, "parameter_version_major")
         xml_version.text = "1"
         xml_version = ET.SubElement(xml_parameters, "parameter_version_minor")
-        xml_version.text = "4"
+        xml_version.text = "5"
         importtree = ET.parse(inject_xml_file_name)
         injectgroups = importtree.getroot().findall("group")
         for igroup in injectgroups:

--- a/posix-configs/SITL/init/rc.fixed_wing
+++ b/posix-configs/SITL/init/rc.fixed_wing
@@ -21,7 +21,7 @@ param set MPC_XY_P 0.4
 param set MPC_XY_VEL_P 0.2
 param set MPC_XY_VEL_D 0.005
 param set COM_RC_IN_MODE 1
-param set COM_DL_LOSS_EN 1
+param set NAV_DLL_ACT 2
 simulator start -s
 rgbled start
 tone_alarm start

--- a/posix-configs/SITL/init/rcS_ekf2_jmavsim_iris
+++ b/posix-configs/SITL/init/rcS_ekf2_jmavsim_iris
@@ -29,7 +29,7 @@ param set MPC_XY_VEL_D 0.005
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set COM_DL_LOSS_EN 1
+param set NAV_DLL_ACT 2
 param set NAV_ACC_RAD 2.0
 param set RTL_RETURN_ALT 30.0
 param set RTL_DESCEND_ALT 10.0

--- a/posix-configs/SITL/init/rcS_gazebo_iris
+++ b/posix-configs/SITL/init/rcS_gazebo_iris
@@ -20,7 +20,7 @@ param set CAL_MAG0_XOFF 0.01
 param set SENS_BOARD_ROT 8
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set COM_DL_LOSS_EN 1
+param set NAV_DLL_ACT 2
 param set COM_DISARM_LAND 3
 param set NAV_ACC_RAD 2.0
 param set RTL_RETURN_ALT 30.0

--- a/posix-configs/SITL/init/rcS_gazebo_iris_opt_flow
+++ b/posix-configs/SITL/init/rcS_gazebo_iris_opt_flow
@@ -20,7 +20,7 @@ param set CAL_MAG0_XOFF 0.01
 param set SENS_BOARD_ROT 8
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set COM_DL_LOSS_EN 1
+param set NAV_DLL_ACT 2
 param set COM_DISARM_LAND 3
 param set NAV_ACC_RAD 12.0
 param set RTL_RETURN_ALT 30.0

--- a/posix-configs/SITL/init/rcS_gazebo_plane
+++ b/posix-configs/SITL/init/rcS_gazebo_plane
@@ -21,7 +21,7 @@ param set SENS_BOARD_ROT 8
 param set SENS_DPRES_OFF 0.001
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set COM_DL_LOSS_EN 1
+param set NAV_DLL_ACT 2
 param set NAV_ACC_RAD 15.0
 param set FW_THR_IDLE 0.8
 simulator start -s

--- a/posix-configs/SITL/init/rcS_gazebo_standard_vtol
+++ b/posix-configs/SITL/init/rcS_gazebo_standard_vtol
@@ -31,7 +31,7 @@ param set SENS_BOARD_ROT 8
 param set SENS_DPRES_OFF 0.001
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set COM_DL_LOSS_EN 1
+param set NAV_DLL_ACT 2
 param set NAV_ACC_RAD 3.0
 param set MPC_TKO_SPEED 1.0
 param set MIS_YAW_TMT 10

--- a/posix-configs/SITL/init/rcS_gazebo_tailsitter
+++ b/posix-configs/SITL/init/rcS_gazebo_tailsitter
@@ -31,7 +31,7 @@ param set SENS_BOARD_ROT 8
 param set SENS_DPRES_OFF 0.001
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set COM_DL_LOSS_EN 1
+param set NAV_DLL_ACT 2
 simulator start -s
 rgbledsim start
 tone_alarm start

--- a/posix-configs/SITL/init/rcS_jmavsim_iris
+++ b/posix-configs/SITL/init/rcS_jmavsim_iris
@@ -29,7 +29,7 @@ param set MPC_XY_VEL_D 0.005
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set COM_DL_LOSS_EN 1
+param set NAV_DLL_ACT 2
 param set COM_DISARM_LAND 3
 param set NAV_ACC_RAD 2.0
 param set RTL_RETURN_ALT 30.0

--- a/posix-configs/SITL/init/rcS_lpe_gazebo_iris
+++ b/posix-configs/SITL/init/rcS_lpe_gazebo_iris
@@ -30,7 +30,7 @@ param set SENS_BOARD_X_OFF 0.000001
 
 # changes for LPE
 param set COM_RC_IN_MODE 1
-param set COM_DL_LOSS_EN 1
+param set NAV_DLL_ACT 2
 param set LPE_BETA_MAX 10000
 simulator start -s
 rgbled start

--- a/posix-configs/SITL/init/rcS_lpe_gazebo_iris_opt_flow
+++ b/posix-configs/SITL/init/rcS_lpe_gazebo_iris_opt_flow
@@ -34,7 +34,7 @@ param set RTL_DESCEND_ALT 10.0
 
 # changes for LPE
 param set COM_RC_IN_MODE 1
-param set COM_DL_LOSS_EN 1
+param set NAV_DLL_ACT 2
 param set LPE_BETA_MAX 10000
 simulator start -s
 rgbledsim start

--- a/posix-configs/SITL/init/rcS_lpe_jmavsim_iris
+++ b/posix-configs/SITL/init/rcS_lpe_jmavsim_iris
@@ -33,7 +33,7 @@ param set NAV_ACC_RAD 2.0
 param set RTL_RETURN_ALT 30.0
 param set RTL_DESCEND_ALT 10.0
 param set COM_RC_IN_MODE 1
-param set COM_DL_LOSS_EN 1
+param set NAV_DLL_ACT 2
 simulator start -s
 rgbledsim start
 tone_alarm start

--- a/posix-configs/SITL/init/rc_iris_ros
+++ b/posix-configs/SITL/init/rc_iris_ros
@@ -41,7 +41,7 @@ param set MP_ROLLRATE_D 0.001
 param set MP_PITCH_P 4
 param set MP_PITCHRATE_P 0.3
 param set COM_RC_IN_MODE 1
-param set COM_DL_LOSS_EN 1
+param set NAV_DLL_ACT 2
 simulator start -s
 rgbled start
 tone_alarm start

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1171,7 +1171,8 @@ int commander_thread_main(int argc, char *argv[])
 	param_t _param_sys_type = param_find("MAV_TYPE");
 	param_t _param_system_id = param_find("MAV_SYS_ID");
 	param_t _param_component_id = param_find("MAV_COMP_ID");
-	param_t _param_enable_datalink_loss = param_find("COM_DL_LOSS_EN");
+	param_t _param_enable_datalink_loss = param_find("NAV_DLL_ACT");
+	param_t _param_enable_rc_loss = param_find("NAV_RCL_ACT");
 	param_t _param_datalink_loss_timeout = param_find("COM_DL_LOSS_T");
 	param_t _param_rc_loss_timeout = param_find("COM_RC_LOSS_T");
 	param_t _param_datalink_regain_timeout = param_find("COM_DL_REG_T");
@@ -1524,7 +1525,8 @@ int commander_thread_main(int argc, char *argv[])
 
 	transition_result_t arming_ret;
 
-	int32_t datalink_loss_enabled = false;
+	int32_t datalink_loss_enabled = 0;
+	int32_t rc_loss_enabled = 0;
 	int32_t datalink_loss_timeout = 10;
 	float rc_loss_timeout = 0.5;
 	int32_t datalink_regain_timeout = 0;
@@ -1608,6 +1610,7 @@ int commander_thread_main(int argc, char *argv[])
 
 			/* Safety parameters */
 			param_get(_param_enable_datalink_loss, &datalink_loss_enabled);
+			param_get(_param_enable_rc_loss, &rc_loss_enabled);
 			param_get(_param_datalink_loss_timeout, &datalink_loss_timeout);
 			param_get(_param_rc_loss_timeout, &rc_loss_timeout);
 			param_get(_param_rc_in_off, &rc_in_off);
@@ -2681,11 +2684,12 @@ int commander_thread_main(int argc, char *argv[])
 		/* now set navigation state according to failsafe and main state */
 		bool nav_state_changed = set_nav_state(&status,
 						       &internal_state,
-						       (bool)datalink_loss_enabled,
+						       (datalink_loss_enabled > 0),
 						       mission_result.finished,
 						       mission_result.stay_in_failsafe,
 						       &status_flags,
-						       land_detector.landed);
+						       land_detector.landed,
+						       (rc_loss_enabled > 0));
 
 		if (status.failsafe != failsafe_old) {
 			status_changed = true;

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -93,16 +93,6 @@ PARAM_DEFINE_FLOAT(TRIM_PITCH, 0.0f);
 PARAM_DEFINE_FLOAT(TRIM_YAW, 0.0f);
 
 /**
- * Datalink loss mode enabled.
- *
- * Set to 1 to enable actions triggered when the datalink is lost.
- *
- * @group Commander
- * @boolean
- */
-PARAM_DEFINE_INT32(COM_DL_LOSS_EN, 0);
-
-/**
  * Datalink loss time threshold
  *
  * After this amount of seconds without datalink the data link lost mode triggers

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -99,7 +99,7 @@ PARAM_DEFINE_FLOAT(TRIM_YAW, 0.0f);
  *
  * @group Commander
  * @unit s
- * @min 0
+ * @min 5
  * @max 300
  * @decimal 1
  * @increment 0.5
@@ -115,7 +115,7 @@ PARAM_DEFINE_INT32(COM_DL_LOSS_T, 10);
  * @group Commander
  * @unit s
  * @min 0
- * @max 30
+ * @max 3
  * @decimal 1
  * @increment 0.5
  */

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -585,7 +585,7 @@ transition_result_t hil_state_transition(hil_state_t new_state, orb_advert_t sta
  */
 bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *internal_state,
 		   const bool data_link_loss_enabled, const bool mission_finished,
-		   const bool stay_in_failsafe, status_flags_s *status_flags, bool landed)
+		   const bool stay_in_failsafe, status_flags_s *status_flags, bool landed, const bool rc_loss_enabled)
 {
 	navigation_state_t nav_state_old = status->nav_state;
 
@@ -601,7 +601,7 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 	case commander_state_s::MAIN_STATE_ALTCTL:
 	case commander_state_s::MAIN_STATE_POSCTL:
 		/* require RC for all manual modes */
-		if ((status->rc_signal_lost || status_flags->rc_signal_lost_cmd) && armed && !landed) {
+		if (rc_loss_enabled && (status->rc_signal_lost || status_flags->rc_signal_lost_cmd) && armed && !landed) {
 			status->failsafe = true;
 
 			if (status_flags->condition_global_position_valid && status_flags->condition_home_position_valid) {

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -112,7 +112,8 @@ transition_result_t hil_state_transition(hil_state_t new_state, orb_advert_t sta
 
 bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *internal_state,
 		   const bool data_link_loss_enabled, const bool mission_finished,
-		   const bool stay_in_failsafe, status_flags_s *status_flags, bool landed);
+		   const bool stay_in_failsafe, status_flags_s *status_flags, bool landed,
+		   const bool rc_loss_enabled);
 
 int preflight_check(struct vehicle_status_s *status, orb_advert_t *mavlink_log_pub, bool prearm, bool force_report, status_flags_s *status_flags, battery_status_s *battery);
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -518,13 +518,13 @@ Navigator::task_main()
 				break;
 			case vehicle_status_s::NAVIGATION_STATE_AUTO_RCRECOVER:
 				_pos_sp_triplet_published_invalid_once = false;
-				if (_param_rcloss_act.get() == 0) {
+				if (_param_rcloss_act.get() == 1) {
 					_navigation_mode = &_loiter;
-				} else if (_param_rcloss_act.get() == 2) {
-					_navigation_mode = &_land;
 				} else if (_param_rcloss_act.get() == 3) {
+					_navigation_mode = &_land;
+				} else if (_param_rcloss_act.get() == 4) {
 					_navigation_mode = &_rcLoss;
-				} else { /* if == 1 or unknown, RTL */
+				} else { /* if == 2 or unknown, RTL */
 					_navigation_mode = &_rtl;
 				}
 				break;
@@ -548,13 +548,13 @@ Navigator::task_main()
 				/* Use complex data link loss mode only when enabled via param
 				* otherwise use rtl */
 				_pos_sp_triplet_published_invalid_once = false;
-				if (_param_datalinkloss_act.get() == 0) {
+				if (_param_datalinkloss_act.get() == 1) {
 					_navigation_mode = &_loiter;
-				} else if (_param_datalinkloss_act.get() == 2) {
-					_navigation_mode = &_land;
 				} else if (_param_datalinkloss_act.get() == 3) {
+					_navigation_mode = &_land;
+				} else if (_param_datalinkloss_act.get() == 4) {
 					_navigation_mode = &_dataLinkLoss;
-				} else { /* if == 1 or unknown, RTL */
+				} else { /* if == 2 or unknown, RTL */
 					_navigation_mode = &_rtl;
 				}
 				break;

--- a/src/modules/navigator/navigator_params.c
+++ b/src/modules/navigator/navigator_params.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2014, 2015 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2014-2016 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/modules/navigator/navigator_params.c
+++ b/src/modules/navigator/navigator_params.c
@@ -68,13 +68,15 @@ PARAM_DEFINE_FLOAT(NAV_ACC_RAD, 10.0f);
  * Set data link loss failsafe mode
  *
  * The data link loss failsafe will only be entered after a timeout,
- * set by COM_RC_LOSS_T in seconds.
+ * set by COM_RC_LOSS_T in seconds. Once the timeout occurs the selected
+ * action will be executed. Setting this parameter to 4 will enable CASA
+ * Outback Challenge rules, which are only recommended to participants
+ * of that competition.
  *
  * @value 0 Disabled
  * @value 1 Loiter
  * @value 2 Return to Land
  * @value 3 Land at current position
- * @value 4 Outback Challenge (OBC) rules
  *
  * @group Mission
  */
@@ -84,15 +86,15 @@ PARAM_DEFINE_INT32(NAV_DLL_ACT, 0);
  * Set RC loss failsafe mode
  *
  * The RC loss failsafe will only be entered after a timeout,
- * set by COM_RC_LOSS_T in seconds. If the timeout value is smaller than
- * zero it will never be entered. If RC input checks have been disabled
- * by setting the COM_RC_IN_MODE param it will also not be triggered.
+ * set by COM_RC_LOSS_T in seconds. If RC input checks have been disabled
+ * by setting the COM_RC_IN_MODE param it will not be triggered.
+ * Setting this parameter to 4 will enable CASA Outback Challenge rules,
+ * which are only recommended to participants of that competition.
  *
  * @value 0 Disabled
  * @value 1 Loiter
  * @value 2 Return to Land
  * @value 3 Land at current position
- * @value 4 Outback Challenge (OBC) rules
  *
  * @group Mission
  */

--- a/src/modules/navigator/navigator_params.c
+++ b/src/modules/navigator/navigator_params.c
@@ -68,34 +68,35 @@ PARAM_DEFINE_FLOAT(NAV_ACC_RAD, 10.0f);
  * Set data link loss failsafe mode
  *
  * The data link loss failsafe will only be entered after a timeout,
- * set by a DIFFERENT parameter. If the timeout value is smaller than
- * zero it will never be entered.
+ * set by COM_RC_LOSS_T in seconds.
  *
- * @value 0 Loiter
- * @value 1 Return to Land
- * @value 2 Land at current position
- * @value 3 Outback Challenge (OBC) rules
+ * @value 0 Disabled
+ * @value 1 Loiter
+ * @value 2 Return to Land
+ * @value 3 Land at current position
+ * @value 4 Outback Challenge (OBC) rules
  *
  * @group Mission
  */
-PARAM_DEFINE_INT32(NAV_DLL_ACT, 1);
+PARAM_DEFINE_INT32(NAV_DLL_ACT, 0);
 
 /**
  * Set RC loss failsafe mode
  *
  * The RC loss failsafe will only be entered after a timeout,
- * set by a DIFFERENT parameter. If the timeout value is smaller than
+ * set by COM_RC_LOSS_T in seconds. If the timeout value is smaller than
  * zero it will never be entered. If RC input checks have been disabled
  * by setting the COM_RC_IN_MODE param it will also not be triggered.
  *
- * @value 0 Loiter
- * @value 1 Return to Land
- * @value 2 Land at current position
- * @value 3 Outback Challenge (OBC) rules
+ * @value 0 Disabled
+ * @value 1 Loiter
+ * @value 2 Return to Land
+ * @value 3 Land at current position
+ * @value 4 Outback Challenge (OBC) rules
  *
  * @group Mission
  */
-PARAM_DEFINE_INT32(NAV_RCL_ACT, 1);
+PARAM_DEFINE_INT32(NAV_RCL_ACT, 0);
 
 /**
  * Airfield home Lat

--- a/src/modules/navigator/navigator_params.c
+++ b/src/modules/navigator/navigator_params.c
@@ -68,7 +68,7 @@ PARAM_DEFINE_FLOAT(NAV_ACC_RAD, 10.0f);
  * Set data link loss failsafe mode
  *
  * The data link loss failsafe will only be entered after a timeout,
- * set by COM_RC_LOSS_T in seconds. Once the timeout occurs the selected
+ * set by COM_DL_LOSS_T in seconds. Once the timeout occurs the selected
  * action will be executed. Setting this parameter to 4 will enable CASA
  * Outback Challenge rules, which are only recommended to participants
  * of that competition.

--- a/src/modules/navigator/rcloss_params.c
+++ b/src/modules/navigator/rcloss_params.c
@@ -51,6 +51,8 @@
  *
  * @unit s
  * @min -1.0
+ * @decimal 1
+ * @increment 0.1
  * @group Radio Signal Loss
  */
 PARAM_DEFINE_FLOAT(NAV_RCL_LT, 120.0f);

--- a/src/modules/navigator/rtl_params.c
+++ b/src/modules/navigator/rtl_params.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2014 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2014-2016 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -83,7 +83,7 @@ PARAM_DEFINE_FLOAT(RTL_DESCEND_ALT, 30);
  * @min -1
  * @max 300
  * @decimal 1
- * @increment 1
+ * @increment 0.5
  * @group Return To Land
  */
 PARAM_DEFINE_FLOAT(RTL_LAND_DELAY, -1.0f);

--- a/src/modules/systemlib/battery.cpp
+++ b/src/modules/systemlib/battery.cpp
@@ -48,6 +48,8 @@ Battery::Battery() :
 	_param_n_cells(this, "N_CELLS"),
 	_param_capacity(this, "CAPACITY"),
 	_param_v_load_drop(this, "V_LOAD_DROP"),
+	_param_low_thr(this, "LOW_THR"),
+	_param_crit_thr(this, "CRIT_THR"),
 	_voltage_filtered_v(0.0f),
 	_throttle_filtered(0.0f),
 	_discharged_mah(0.0f),
@@ -162,13 +164,11 @@ Battery::estimateRemaining(float voltage_v, float throttle_normalized)
 void
 Battery::determineWarning()
 {
-	// TODO: Determine threshold or make params.
-
 	// Smallest values must come first
-	if (_remaining < 0.09f) {
+	if (_remaining < _param_crit_thr.get()) {
 		_warning = battery_status_s::BATTERY_WARNING_CRITICAL;
 
-	} else if (_remaining < 0.18f) {
+	} else if (_remaining < _param_low_thr.get()) {
 		_warning = battery_status_s::BATTERY_WARNING_LOW;
 	}
 }

--- a/src/modules/systemlib/battery.h
+++ b/src/modules/systemlib/battery.h
@@ -101,6 +101,8 @@ private:
 	control::BlockParamInt _param_n_cells;
 	control::BlockParamFloat _param_capacity;
 	control::BlockParamFloat _param_v_load_drop;
+	control::BlockParamFloat _param_low_thr;
+	control::BlockParamFloat _param_crit_thr;
 
 	float _voltage_filtered_v;
 	float _throttle_filtered;

--- a/src/modules/systemlib/battery_params.c
+++ b/src/modules/systemlib/battery_params.c
@@ -67,6 +67,36 @@ PARAM_DEFINE_FLOAT(BAT_V_EMPTY, 3.4f);
 PARAM_DEFINE_FLOAT(BAT_V_CHARGED, 4.2f);
 
 /**
+ * Low threshold
+ *
+ * Sets the threshold (between 0 and 1, which is equivalent to between 0 and 100%)
+ * when the battery will be reported as low. This has to be higher than the critical
+ * threshold.
+ *
+ * @group Battery Calibration
+ * @decimal 2
+ * @min 0.15
+ * @max 0.5
+ * @increment 0.01
+ */
+PARAM_DEFINE_FLOAT(BAT_LOW_THR, 0.18f);
+
+/**
+ * Critical threshold
+ *
+ * Sets the threshold (between 0 and 1, which is equivalent to between 0 and 100%)
+ * when the battery will be reported as critically low. This has to be lower than
+ * the low threshold. This threshold commonly will trigger RTL or landing.
+ *
+ * @group Battery Calibration
+ * @decimal 2
+ * @min 0.05
+ * @max 0.14
+ * @increment 0.01
+ */
+PARAM_DEFINE_FLOAT(BAT_CRIT_THR, 0.09f);
+
+/**
  * Voltage drop per cell on 100% load
  *
  * This implicitely defines the internal resistance

--- a/src/modules/systemlib/battery_params.c
+++ b/src/modules/systemlib/battery_params.c
@@ -52,7 +52,7 @@
  * @decimal 2
  * @increment 0.01
  */
-PARAM_DEFINE_FLOAT(BAT_V_EMPTY, 3.4f);
+PARAM_DEFINE_FLOAT(BAT_V_EMPTY, 3.35f);
 
 /**
  * Full cell voltage.


### PR DESCRIPTION
@kd0aij Testing this with props off would be great. Main documentation:

```C++
/**
 * Set data link loss failsafe mode
 *
 * The data link loss failsafe will only be entered after a timeout,
 * set by COM_RC_LOSS_T in seconds.
 *
 * @value 0 Disabled
 * @value 1 Loiter
 * @value 2 Return to Land
 * @value 3 Land at current position
 * @value 4 Outback Challenge (OBC) rules
 *
 * @group Mission
 */
PARAM_DEFINE_INT32(NAV_DLL_ACT, 0);

/**
 * Set RC loss failsafe mode
 *
 * The RC loss failsafe will only be entered after a timeout,
 * set by COM_RC_LOSS_T in seconds. If the timeout value is smaller than
 * zero it will never be entered. If RC input checks have been disabled
 * by setting the COM_RC_IN_MODE param it will also not be triggered.
 *
 * @value 0 Disabled
 * @value 1 Loiter
 * @value 2 Return to Land
 * @value 3 Land at current position
 * @value 4 Outback Challenge (OBC) rules
 *
 * @group Mission
 */
PARAM_DEFINE_INT32(NAV_RCL_ACT, 0);
```

@DonLakeFlyer The comments above should also be enough to re-do the safety screen. I've broken the param system with this change, I need to think how we address that.