### PR TITLE
WIP: send (nav_state + 128) as frsky sensor T1 value

### DIFF
--- a/src/drivers/frsky_telemetry/frsky_telemetry.c
+++ b/src/drivers/frsky_telemetry/frsky_telemetry.c
@@ -290,6 +290,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 			static hrt_abstime lastFUEL = 0;
 			static hrt_abstime lastVSPD = 0;
 			static hrt_abstime lastGPS = 0;
+			static hrt_abstime lastT1 = 0;
 
 			switch (sbuf[1]) {
 
@@ -405,6 +406,18 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 				}
 
 				break;
+
+			case SMARTPORT_POLL_8:
+
+				/* report flightmode at 5Hz */
+				if (now - lastT1 > 200 * 1000) {
+					lastT1 = now;
+
+					sPort_send_flightmode(uart);
+				}
+
+				break;
+
 			}
 		}
 

--- a/src/drivers/frsky_telemetry/sPort_data.h
+++ b/src/drivers/frsky_telemetry/sPort_data.h
@@ -53,6 +53,7 @@
 #define SMARTPORT_POLL_5    0xB7
 #define SMARTPORT_POLL_6    0x00
 #define SMARTPORT_POLL_7    0x83
+#define SMARTPORT_POLL_8    0xBA
 
 /* FrSky SmartPort sensor IDs */
 #define SMARTPORT_ID_RSSI          0xf101
@@ -87,6 +88,7 @@ void sPort_send_CUR(int uart);
 void sPort_send_ALT(int uart);
 void sPort_send_SPD(int uart);
 void sPort_send_VSPD(int uart, float speed);
+void sPort_send_flightmode(int uart);
 void sPort_send_GPS_LON(int uart);
 void sPort_send_GPS_LAT(int uart);
 void sPort_send_GPS_ALT(int uart);


### PR DESCRIPTION
offset PX4 nav_state by 128 and send it as smartport sensor T1 value.
This PR is based on latest master, but will require a change in the offset for compatibility with https://github.com/PX4/Firmware/pull/4345
@thedevleon this might save you some rebasing pain.