### PR TITLE
Frysky SmartPort Telemetry Improvement

### DIFF
--- a/src/drivers/frsky_telemetry/CMakeLists.txt
+++ b/src/drivers/frsky_telemetry/CMakeLists.txt
@@ -33,7 +33,7 @@
 px4_add_module(
 	MODULE drivers__frsky_telemetry
 	MAIN frsky_telemetry
-	STACK 1200
+	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Os
 	SRCS
@@ -43,4 +43,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/frsky_telemetry/CMakeLists.txt
+++ b/src/drivers/frsky_telemetry/CMakeLists.txt
@@ -33,7 +33,7 @@
 px4_add_module(
 	MODULE drivers__frsky_telemetry
 	MAIN frsky_telemetry
-	STACK_MAIN 1200
+	STACK 1200
 	COMPILE_FLAGS
 		-Os
 	SRCS

--- a/src/drivers/frsky_telemetry/frsky_data.c
+++ b/src/drivers/frsky_telemetry/frsky_data.c
@@ -92,20 +92,43 @@
 
 #define frac(f) (f - (int)f)
 
-static int battery_sub = -1;
-static int sensor_sub = -1;
-static int global_position_sub = -1;
+static struct battery_status_s *battery_status;
+static struct vehicle_global_position_s *global_pos;
+static struct vehicle_status_s *vehicle_status;
+static struct sensor_combined_s *sensor_combined;
+
+static int battery_status_sub = -1;
+static int vehicle_global_position_sub = -1;
 static int vehicle_status_sub = -1;
+static int sensor_sub = -1;
 
 /**
  * Initializes the uORB subscriptions.
  */
-void frsky_init()
+bool frsky_init()
 {
-	battery_sub = orb_subscribe(ORB_ID(battery_status));
-	global_position_sub = orb_subscribe(ORB_ID(vehicle_global_position));
-	sensor_sub = orb_subscribe(ORB_ID(sensor_combined));
+	battery_status = malloc(sizeof(struct battery_status_s));
+	global_pos = malloc(sizeof(struct vehicle_global_position_s));
+	sensor_combined = malloc(sizeof(struct sensor_combined_s));
+	vehicle_status = malloc(sizeof(struct vehicle_status_s));
+
+	if (battery_status == NULL || global_pos == NULL || sensor_combined == NULL || vehicle_status) {
+	return false;
+	}
+
+	battery_status_sub = orb_subscribe(ORB_ID(battery_status));
+	vehicle_global_position_sub = orb_subscribe(ORB_ID(vehicle_global_position));
 	vehicle_status_sub = orb_subscribe(ORB_ID(vehicle_status));
+	sensor_sub = orb_subscribe(ORB_ID(sensor_combined));
+	return true;
+}
+
+void frsky_deinit()
+{
+	free(battery_status);
+	free(global_pos);
+	free(sensor_combined);
+	free(vehicle_status);
 }
 
 /**
@@ -155,42 +178,58 @@ static void frsky_send_data(int uart, uint8_t id, int16_t data)
 	frsky_send_byte(uart, udata >> 8); /* MSB */
 }
 
+void frsky_update_topics()
+{
+	bool updated;
+	/* get a local copy of the current sensor values */
+	orb_check(sensor_sub, &updated);
+	if (updated) {
+		orb_copy(ORB_ID(sensor_combined), sensor_sub, sensor_combined);
+	}
+	/* get a local copy of the battery data */
+	orb_check(battery_status_sub, &updated);
+	if (updated) {
+		orb_copy(ORB_ID(battery_status), battery_status_sub, battery_status);
+	}
+	/* get a local copy of the global position data */
+	orb_check(vehicle_global_position_sub, &updated);
+	if (updated) {
+		orb_copy(ORB_ID(vehicle_global_position), vehicle_global_position_sub, global_pos);
+	}
+
+	/* get a local copy of the vehicle status data */
+	orb_check(vehicle_status_sub, &updated);
+	if (updated) {
+		orb_copy(ORB_ID(vehicle_status), vehicle_status_sub, vehicle_status);
+	}
+}
+
 /**
  * Sends frame 1 (every 200ms):
  *   acceleration values, barometer altitude, temperature, battery voltage & current
  */
 void frsky_send_frame1(int uart)
 {
-	/* get a local copy of the current sensor values */
-	struct sensor_combined_s raw;
-	memset(&raw, 0, sizeof(raw));
-	orb_copy(ORB_ID(sensor_combined), sensor_sub, &raw);
-
-	/* get a local copy of the battery data */
-	struct battery_status_s battery;
-	memset(&battery, 0, sizeof(battery));
-	orb_copy(ORB_ID(battery_status), battery_sub, &battery);
-
 	/* send formatted frame */
 	frsky_send_data(uart, FRSKY_ID_ACCEL_X,
-			roundf(raw.accelerometer_m_s2[0] * 1000.0f));
+			roundf(sensor_combined->accelerometer_m_s2[0] * 1000.0f));
 	frsky_send_data(uart, FRSKY_ID_ACCEL_Y,
-			roundf(raw.accelerometer_m_s2[1] * 1000.0f));
+			roundf(sensor_combined->accelerometer_m_s2[1] * 1000.0f));
 	frsky_send_data(uart, FRSKY_ID_ACCEL_Z,
-			roundf(raw.accelerometer_m_s2[2] * 1000.0f));
+			roundf(sensor_combined->accelerometer_m_s2[2] * 1000.0f));
 
 	frsky_send_data(uart, FRSKY_ID_BARO_ALT_BP,
-			raw.baro_alt_meter[0]);
+			sensor_combined->baro_alt_meter[0]);
 	frsky_send_data(uart, FRSKY_ID_BARO_ALT_AP,
-			roundf(frac(raw.baro_alt_meter[0]) * 100.0f));
+			roundf(frac(sensor_combined->baro_alt_meter[0]) * 100.0f));
 
 	frsky_send_data(uart, FRSKY_ID_TEMP1,
-			roundf(raw.baro_temp_celcius[0]));
+			roundf(sensor_combined->baro_temp_celcius[0]));
 
 	frsky_send_data(uart, FRSKY_ID_VFAS,
-			roundf(battery.voltage_v * 10.0f));
+			roundf(battery_status->voltage_v * 10.0f));
 	frsky_send_data(uart, FRSKY_ID_CURRENT,
-			(battery.current_a < 0) ? 0 : roundf(battery.current_a * 10.0f));
+			(battery_status->current_a < 0) ? 0 : roundf(battery_status->current_a * 10.0f));
 
 	frsky_send_startstop(uart);
 }
@@ -210,38 +249,23 @@ static float frsky_format_gps(float dec)
  */
 void frsky_send_frame2(int uart)
 {
-	/* get a local copy of the global position data */
-	struct vehicle_global_position_s global_pos;
-	memset(&global_pos, 0, sizeof(global_pos));
-	orb_copy(ORB_ID(vehicle_global_position), global_position_sub, &global_pos);
-
-	/* get a local copy of the vehicle status data */
-	struct vehicle_status_s vehicle_status;
-	memset(&vehicle_status, 0, sizeof(vehicle_status));
-	orb_copy(ORB_ID(vehicle_status), vehicle_status_sub, &vehicle_status);
-
-	/* get a local copy of the battery data */
-	struct battery_status_s battery;
-	memset(&battery, 0, sizeof(battery));
-	orb_copy(ORB_ID(battery_status), battery_sub, &battery);
-
 	/* send formatted frame */
 	float course = 0, lat = 0, lon = 0, speed = 0, alt = 0;
 	char lat_ns = 0, lon_ew = 0;
 	int sec = 0;
 
-	if (global_pos.timestamp != 0 && hrt_absolute_time() < global_pos.timestamp + 20000) {
-		time_t time_gps = global_pos.time_utc_usec / 1000000ULL;
+	if (global_pos->timestamp != 0 && hrt_absolute_time() < global_pos->timestamp + 20000) {
+		time_t time_gps = global_pos->time_utc_usec / 1000000ULL;
 		struct tm *tm_gps = gmtime(&time_gps);
 
-		course = (global_pos.yaw + M_PI_F) / M_PI_F * 180.0f;
-		lat    = frsky_format_gps(fabsf(global_pos.lat));
-		lat_ns = (global_pos.lat < 0) ? 'S' : 'N';
-		lon    = frsky_format_gps(fabsf(global_pos.lon));
-		lon_ew = (global_pos.lon < 0) ? 'W' : 'E';
-		speed  = sqrtf(global_pos.vel_n * global_pos.vel_n + global_pos.vel_e * global_pos.vel_e)
+		course = (global_pos->yaw + M_PI_F) / M_PI_F * 180.0f;
+		lat    = frsky_format_gps(fabsf(global_pos->lat));
+		lat_ns = (global_pos->lat < 0) ? 'S' : 'N';
+		lon    = frsky_format_gps(fabsf(global_pos->lon));
+		lon_ew = (global_pos->lon < 0) ? 'W' : 'E';
+		speed  = sqrtf(global_pos->vel_n * global_pos->vel_n + global_pos->vel_e * global_pos->vel_e)
 			 * 25.0f / 46.0f;
-		alt    = global_pos.alt;
+		alt    = global_pos->alt;
 		sec    = tm_gps->tm_sec;
 	}
 
@@ -263,7 +287,7 @@ void frsky_send_frame2(int uart)
 	frsky_send_data(uart, FRSKY_ID_GPS_ALT_AP, frac(alt) * 100.0f);
 
 	frsky_send_data(uart, FRSKY_ID_FUEL,
-			roundf(battery.remaining * 100.0f));
+			roundf(battery_status->remaining * 100.0f));
 
 	frsky_send_data(uart, FRSKY_ID_GPS_SEC, sec);
 
@@ -276,13 +300,8 @@ void frsky_send_frame2(int uart)
  */
 void frsky_send_frame3(int uart)
 {
-	/* get a local copy of the battery data */
-	struct vehicle_global_position_s global_pos;
-	memset(&global_pos, 0, sizeof(global_pos));
-	orb_copy(ORB_ID(vehicle_global_position), global_position_sub, &global_pos);
-
 	/* send formatted frame */
-	time_t time_gps = global_pos.time_utc_usec / 1000000ULL;
+	time_t time_gps = global_pos->time_utc_usec / 1000000ULL;
 	struct tm *tm_gps = gmtime(&time_gps);
 	uint16_t hour_min = (tm_gps->tm_min << 8) | (tm_gps->tm_hour & 0xff);
 	frsky_send_data(uart, FRSKY_ID_GPS_DAY_MONTH, tm_gps->tm_mday);
@@ -342,7 +361,7 @@ bool frsky_parse_host(uint8_t *sbuf, int nbytes, struct adc_linkquality *v)
 			state = HEADER;
 
 			if (sbuf[i] != 0x7E) {
-				warnx("host packet error: %x", sbuf[i]);
+//				warnx("host packet error: %x", sbuf[i]);
 
 			} else {
 				data_ready = true;

--- a/src/drivers/frsky_telemetry/frsky_data.c
+++ b/src/drivers/frsky_telemetry/frsky_data.c
@@ -113,7 +113,7 @@ bool frsky_init()
 	vehicle_status = malloc(sizeof(struct vehicle_status_s));
 
 	if (battery_status == NULL || global_pos == NULL || sensor_combined == NULL || vehicle_status) {
-	return false;
+		return false;
 	}
 
 	battery_status_sub = orb_subscribe(ORB_ID(battery_status));
@@ -183,22 +183,28 @@ void frsky_update_topics()
 	bool updated;
 	/* get a local copy of the current sensor values */
 	orb_check(sensor_sub, &updated);
+
 	if (updated) {
 		orb_copy(ORB_ID(sensor_combined), sensor_sub, sensor_combined);
 	}
+
 	/* get a local copy of the battery data */
 	orb_check(battery_status_sub, &updated);
+
 	if (updated) {
 		orb_copy(ORB_ID(battery_status), battery_status_sub, battery_status);
 	}
+
 	/* get a local copy of the global position data */
 	orb_check(vehicle_global_position_sub, &updated);
+
 	if (updated) {
 		orb_copy(ORB_ID(vehicle_global_position), vehicle_global_position_sub, global_pos);
 	}
 
 	/* get a local copy of the vehicle status data */
 	orb_check(vehicle_status_sub, &updated);
+
 	if (updated) {
 		orb_copy(ORB_ID(vehicle_status), vehicle_status_sub, vehicle_status);
 	}

--- a/src/drivers/frsky_telemetry/frsky_data.h
+++ b/src/drivers/frsky_telemetry/frsky_data.h
@@ -45,7 +45,9 @@
 #include <stdbool.h>
 
 // Public functions
-void frsky_init(void);
+bool frsky_init(void);
+void frsky_deinit(void);
+void frsky_update_topics(void);
 void frsky_send_frame1(int uart);
 void frsky_send_frame2(int uart);
 void frsky_send_frame3(int uart);

--- a/src/drivers/frsky_telemetry/frsky_data.h
+++ b/src/drivers/frsky_telemetry/frsky_data.h
@@ -45,9 +45,7 @@
 #include <stdbool.h>
 
 // Public functions
-bool frsky_init(void);
-void frsky_deinit(void);
-void frsky_update_topics(void);
+void frsky_init(void);
 void frsky_send_frame1(int uart);
 void frsky_send_frame2(int uart);
 void frsky_send_frame3(int uart);

--- a/src/drivers/frsky_telemetry/frsky_telemetry.c
+++ b/src/drivers/frsky_telemetry/frsky_telemetry.c
@@ -402,6 +402,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 				break;
 
 			case SMARTPORT_POLL_8:
+
 				/* report nav_state as DIY_NAVSTATE at 1Hz */
 				if (now - lastNAV_STATE > 1000 * 1000) {
 					lastNAV_STATE = now;

--- a/src/drivers/frsky_telemetry/frsky_telemetry.c
+++ b/src/drivers/frsky_telemetry/frsky_telemetry.c
@@ -274,8 +274,8 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 			static hrt_abstime lastGPS_SPD = 0;
 			static hrt_abstime lastGPS_CRS = 0;
 			static hrt_abstime lastGPS_TIME = 0;
-			static hrt_abstime lastNAVSTATE = 0;
-			static hrt_abstime lastGPSFIX = 0;
+			static hrt_abstime lastNAV_STATE = 0;
+			static hrt_abstime lastGPS_FIX = 0;
 
 			switch (sbuf[1]) {
 
@@ -403,17 +403,17 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 
 			case SMARTPORT_POLL_8:
 				/* report nav_state as DIY_NAVSTATE at 1Hz */
-				if (now - lastNAVSTATE > 1000 * 1000) {
-					lastNAVSTATE = now;
+				if (now - lastNAV_STATE > 1000 * 1000) {
+					lastNAV_STATE = now;
 					/* send T1 */
-					sPort_send_NAVSTATE(uart);
+					sPort_send_NAV_STATE(uart);
 				}
 
 				/* report satcount and fix as DIY_GPSFIX at 1Hz */
-				else if (now - lastGPSFIX > 1000 * 1000) {
-					lastGPSFIX = now;
+				else if (now - lastGPS_FIX > 1000 * 1000) {
+					lastGPS_FIX = now;
 					/* send T2 */
-					sPort_send_GPSFIX(uart);
+					sPort_send_GPS_FIX(uart);
 				}
 
 				break;

--- a/src/drivers/frsky_telemetry/frsky_telemetry.c
+++ b/src/drivers/frsky_telemetry/frsky_telemetry.c
@@ -270,6 +270,12 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 			static hrt_abstime lastVSPD = 0;
 			static hrt_abstime lastT1 = 0;
 			static hrt_abstime lastT2 = 0;
+			static hrt_abstime lastGPS_LON = 0;
+			static hrt_abstime lastGPS_LAT = 0;
+			static hrt_abstime lastGPS_ALT = 0;
+			static hrt_abstime lastGPS_SPD = 0;
+			static hrt_abstime lastGPS_CRS = 0;
+			static hrt_abstime lastGPS_TIME = 0;
 
 			switch (sbuf[1]) {
 
@@ -365,7 +371,55 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 				}
 
 				break;
+
+
+			case SMARTPORT_POLL_8:
+
+				/* report GPS_LON at 5Hz */
+				if (now - lastGPS_LON > 200 * 1000) {
+					lastGPS_LON = now;
+					/* send GPS_LON */
+					sPort_send_GPS_LON(uart);
+				}
+
+				/* report GPS_LAT at 5Hz */
+				else if (now - lastGPS_LAT > 200 * 1000) {
+					lastGPS_LAT = now;
+					/* send GPS_LAT */
+					sPort_send_GPS_LAT(uart);
+				}
+
+				/* report GPS_ALT at 5Hz */
+				else if (now - lastGPS_ALT > 200 * 1000) {
+					lastGPS_ALT = now;
+					/* send GPS_ALT */
+					sPort_send_GPS_ALT(uart);
+				}
+
+				/* report GPS_SPD at 5Hz */
+				else if (now - lastGPS_SPD > 200 * 1000) {
+					lastGPS_SPD = now;
+					/* send GPS_SPD */
+					sPort_send_GPS_SPD(uart);
+				}
+
+				/* report GPS_CRS at 5Hz */
+				else if (now - lastGPS_CRS > 200 * 1000) {
+					lastGPS_CRS = now;
+					/* send GPS_CRS */
+					sPort_send_GPS_CRS(uart);
+				}
+
+				/* report GPS_TIME at 5Hz */
+				else if (now - lastGPS_TIME > 200 * 1000) {
+					lastGPS_TIME = now;
+					/* send GPS_TIME */
+					sPort_send_GPS_TIME(uart);
+				}
+
+				break;
 			}
+
 		}
 
 	} else if (status >= 0) {

--- a/src/drivers/frsky_telemetry/frsky_telemetry.c
+++ b/src/drivers/frsky_telemetry/frsky_telemetry.c
@@ -416,15 +416,15 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 
 			case SMARTPORT_POLL_8:
 
-				/* report nav_state as DIY_NAVSTATE at 1Hz */
-				if (now - lastNAV_STATE > 1000 * 1000) {
+				/* report nav_state as DIY_NAVSTATE 2Hz */
+				if (now - lastNAV_STATE > 500 * 1000) {
 					lastNAV_STATE = now;
 					/* send T1 */
 					sPort_send_NAV_STATE(uart);
 				}
 
-				/* report satcount and fix as DIY_GPSFIX at 1Hz */
-				else if (now - lastGPS_FIX > 1000 * 1000) {
+				/* report satcount and fix as DIY_GPSFIX at 2Hz */
+				else if (now - lastGPS_FIX > 500 * 1000) {
 					lastGPS_FIX = now;
 					/* send T2 */
 					sPort_send_GPS_FIX(uart);

--- a/src/drivers/frsky_telemetry/frsky_telemetry.c
+++ b/src/drivers/frsky_telemetry/frsky_telemetry.c
@@ -268,14 +268,14 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 			static hrt_abstime lastSPD = 0;
 			static hrt_abstime lastFUEL = 0;
 			static hrt_abstime lastVSPD = 0;
-			static hrt_abstime lastT1 = 0;
-			static hrt_abstime lastT2 = 0;
 			static hrt_abstime lastGPS_LON = 0;
 			static hrt_abstime lastGPS_LAT = 0;
 			static hrt_abstime lastGPS_ALT = 0;
 			static hrt_abstime lastGPS_SPD = 0;
 			static hrt_abstime lastGPS_CRS = 0;
 			static hrt_abstime lastGPS_TIME = 0;
+			static hrt_abstime lastNAVSTATE = 0;
+			static hrt_abstime lastGPSFIX = 0;
 
 			switch (sbuf[1]) {
 
@@ -356,24 +356,6 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 
 			case SMARTPORT_POLL_7:
 
-				/* report flightmode as T1 at 1Hz */
-				if (now - lastT1 > 1000 * 1000) {
-					lastT1 = now;
-					/* send T1 */
-					sPort_send_T1(uart);
-				}
-
-				/* report satcount and fix as T2 at 1Hz */
-				else if (now - lastT2 > 1000 * 1000) {
-					lastT2 = now;
-					/* send T2 */
-					sPort_send_T2(uart);
-				}
-
-				break;
-
-
-			case SMARTPORT_POLL_8:
 
 				/* report GPS_LON at 5Hz */
 				if (now - lastGPS_LON > 200 * 1000) {
@@ -415,6 +397,23 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					lastGPS_TIME = now;
 					/* send GPS_TIME */
 					sPort_send_GPS_TIME(uart);
+				}
+
+				break;
+
+			case SMARTPORT_POLL_8:
+				/* report nav_state as DIY_NAVSTATE at 1Hz */
+				if (now - lastNAVSTATE > 1000 * 1000) {
+					lastNAVSTATE = now;
+					/* send T1 */
+					sPort_send_NAVSTATE(uart);
+				}
+
+				/* report satcount and fix as DIY_GPSFIX at 1Hz */
+				else if (now - lastGPSFIX > 1000 * 1000) {
+					lastGPSFIX = now;
+					/* send T2 */
+					sPort_send_GPSFIX(uart);
 				}
 
 				break;

--- a/src/drivers/frsky_telemetry/sPort_data.c
+++ b/src/drivers/frsky_telemetry/sPort_data.c
@@ -313,7 +313,7 @@ void sPort_send_GPS_TIME(int uart)
 /*
  * Sends nav_state + 128
  */
-void sPort_send_NAVSTATE(int uart)
+void sPort_send_NAV_STATE(int uart)
 {
 	/* get a local copy of the vehicle status data */
 	struct vehicle_status_s vehicle_status;
@@ -328,7 +328,7 @@ void sPort_send_NAVSTATE(int uart)
 
 // verified scaling
 // sends number of sats and type of gps fix
-void sPort_send_GPSFIX(int uart)
+void sPort_send_GPS_FIX(int uart)
 {
 	/* get a local copy of the global position data */
 	struct vehicle_gps_position_s gps_pos;

--- a/src/drivers/frsky_telemetry/sPort_data.c
+++ b/src/drivers/frsky_telemetry/sPort_data.c
@@ -227,38 +227,6 @@ void sPort_send_FUEL(int uart)
 	sPort_send_data(uart, SMARTPORT_ID_FUEL, fuel);
 }
 
-/*
- * Sends nav_state + 128
- */
-void sPort_send_T1(int uart)
-{
-	/* get a local copy of the vehicle status data */
-	struct vehicle_status_s vehicle_status;
-	memset(&vehicle_status, 0, sizeof(vehicle_status));
-	orb_copy(ORB_ID(vehicle_status), vehicle_status_sub, &vehicle_status);
-
-	uint32_t navstate = (int)(128 + vehicle_status.nav_state);
-
-	/* send data */
-	sPort_send_data(uart, SMARTPORT_ID_T1, navstate);
-}
-
-// verified scaling
-// sends number of sats and type of gps fix
-void sPort_send_T2(int uart)
-{
-	/* get a local copy of the global position data */
-	struct vehicle_gps_position_s gps_pos;
-	memset(&gps_pos, 0, sizeof(gps_pos));
-	orb_copy(ORB_ID(vehicle_gps_position), gps_position_sub, &gps_pos);
-
-	/* send data */
-	uint32_t satcount = (int)(gps_pos.satellites_used);
-	uint32_t fixtype = (int)(gps_pos.fix_type);
-	uint32_t t2 = satcount * 10 + fixtype;
-	sPort_send_data(uart, SMARTPORT_ID_T2, t2);
-}
-
 void sPort_send_GPS_LON(int uart)
 {
 	/* get a local copy of the global position data */
@@ -340,4 +308,36 @@ void sPort_send_GPS_TIME(int uart)
 	orb_copy(ORB_ID(vehicle_gps_position), gps_position_sub, &gps_pos);
 
 	sPort_send_data(uart, SMARTPORT_ID_GPS_TIME, gps_pos.time_utc_usec);
+}
+
+/*
+ * Sends nav_state + 128
+ */
+void sPort_send_NAVSTATE(int uart)
+{
+	/* get a local copy of the vehicle status data */
+	struct vehicle_status_s vehicle_status;
+	memset(&vehicle_status, 0, sizeof(vehicle_status));
+	orb_copy(ORB_ID(vehicle_status), vehicle_status_sub, &vehicle_status);
+
+	uint32_t navstate = (int)(128 + vehicle_status.nav_state);
+
+	/* send data */
+	sPort_send_data(uart, SMARTPORT_ID_DIY_NAVSTATE, navstate);
+}
+
+// verified scaling
+// sends number of sats and type of gps fix
+void sPort_send_GPSFIX(int uart)
+{
+	/* get a local copy of the global position data */
+	struct vehicle_gps_position_s gps_pos;
+	memset(&gps_pos, 0, sizeof(gps_pos));
+	orb_copy(ORB_ID(vehicle_gps_position), gps_position_sub, &gps_pos);
+
+	/* send data */
+	uint32_t satcount = (int)(gps_pos.satellites_used);
+	uint32_t fixtype = (int)(gps_pos.fix_type);
+	uint32_t t2 = satcount * 10 + fixtype;
+	sPort_send_data(uart, SMARTPORT_ID_DIY_GPSFIX, t2);
 }

--- a/src/drivers/frsky_telemetry/sPort_data.c
+++ b/src/drivers/frsky_telemetry/sPort_data.c
@@ -271,6 +271,7 @@ void sPort_send_GPS_LON(int uart)
 	/* precision is approximately 0.1m */
 	uint32_t iLon = 6E5 * fabs(gps_pos.lon);
 	iLon |= (1 << 31);
+
 	if (gps_pos.lon < 0) { iLon |= (1 << 30); }
 
 	sPort_send_data(uart, SMARTPORT_ID_GPS_LON_LAT, iLon);
@@ -286,6 +287,7 @@ void sPort_send_GPS_LAT(int uart)
 	/* send latitude */
 	/* convert to 30 bit signed magnitude degrees*6E5 with MSb = 0 and bit 30=sign */
 	uint32_t iLat = 6E5 * fabs(gps_pos.lat);
+
 	if (gps_pos.lat < 0) { iLat |= (1 << 30); }
 
 	sPort_send_data(uart, SMARTPORT_ID_GPS_LON_LAT, iLat);
@@ -299,9 +301,9 @@ void sPort_send_GPS_ALT(int uart)
 	orb_copy(ORB_ID(vehicle_gps_position), gps_position_sub, &gps_pos);
 
 	/* send altitude */
- 	/* convert to 100 * m/sec */
- 	uint32_t iAlt = 100 * gps_pos.alt;
- 	sPort_send_data(uart, SMARTPORT_ID_GPS_ALT, iAlt);
+	/* convert to 100 * m/sec */
+	uint32_t iAlt = 100 * gps_pos.alt;
+	sPort_send_data(uart, SMARTPORT_ID_GPS_ALT, iAlt);
 }
 
 void sPort_send_GPS_SPD(int uart)

--- a/src/drivers/frsky_telemetry/sPort_data.c
+++ b/src/drivers/frsky_telemetry/sPort_data.c
@@ -324,12 +324,7 @@ void sPort_send_GPS_SPD(int uart)
  */
 void sPort_send_NAV_STATE(int uart)
 {
-	/* get a local copy of the vehicle status data */
-	struct vehicle_status_s vehicle_status;
-	memset(&vehicle_status, 0, sizeof(vehicle_status));
-	orb_copy(ORB_ID(vehicle_status), vehicle_status_sub, &vehicle_status);
-
-	uint32_t navstate = (int)(128 + vehicle_status.nav_state);
+	uint32_t navstate = (int)(128 + vehicle_status->nav_state);
 
 	/* send data */
 	sPort_send_data(uart, SMARTPORT_ID_DIY_NAVSTATE, navstate);

--- a/src/drivers/frsky_telemetry/sPort_data.c
+++ b/src/drivers/frsky_telemetry/sPort_data.c
@@ -85,7 +85,8 @@ bool sPort_init()
 	gps_position = malloc(sizeof(struct vehicle_gps_position_s));
 
 
-	if (sensor_combined == NULL || global_pos == NULL || battery_status == NULL || vehicle_status == NULL || gps_position == NULL) {
+	if (sensor_combined == NULL || global_pos == NULL || battery_status == NULL || vehicle_status == NULL
+	    || gps_position == NULL) {
 		return false;
 	}
 
@@ -113,26 +114,35 @@ void sPort_update_topics()
 	bool updated;
 	/* get a local copy of the current sensor values */
 	orb_check(sensor_sub, &updated);
+
 	if (updated) {
 		orb_copy(ORB_ID(sensor_combined), sensor_sub, sensor_combined);
 	}
+
 	/* get a local copy of the battery data */
 	orb_check(battery_status_sub, &updated);
+
 	if (updated) {
 		orb_copy(ORB_ID(battery_status), battery_status_sub, battery_status);
 	}
+
 	/* get a local copy of the global position data */
 	orb_check(global_position_sub, &updated);
+
 	if (updated) {
 		orb_copy(ORB_ID(vehicle_global_position), global_position_sub, global_pos);
 	}
+
 	/* get a local copy of the vehicle status data */
 	orb_check(vehicle_status_sub, &updated);
+
 	if (updated) {
 		orb_copy(ORB_ID(vehicle_status), vehicle_status_sub, vehicle_status);
 	}
+
 	/* get a local copy of the gps position data */
 	orb_check(gps_position_sub, &updated);
+
 	if (updated) {
 		orb_copy(ORB_ID(vehicle_gps_position), gps_position_sub, gps_position);
 	}

--- a/src/drivers/frsky_telemetry/sPort_data.c
+++ b/src/drivers/frsky_telemetry/sPort_data.c
@@ -258,3 +258,84 @@ void sPort_send_T2(int uart)
 	uint32_t t2 = satcount * 10 + fixtype;
 	sPort_send_data(uart, SMARTPORT_ID_T2, t2);
 }
+
+void sPort_send_GPS_LON(int uart)
+{
+	/* get a local copy of the global position data */
+	struct vehicle_gps_position_s gps_pos;
+	memset(&gps_pos, 0, sizeof(gps_pos));
+	orb_copy(ORB_ID(vehicle_gps_position), gps_position_sub, &gps_pos);
+
+	/* send longitude */
+	/* convert to 30 bit signed magnitude degrees*6E5 with MSb = 1 and bit 30=sign */
+	/* precision is approximately 0.1m */
+	uint32_t iLon = 6E5 * fabs(gps_pos.lon);
+	iLon |= (1 << 31);
+	if (gps_pos.lon < 0) { iLon |= (1 << 30); }
+
+	sPort_send_data(uart, SMARTPORT_ID_GPS_LON_LAT, iLon);
+}
+
+void sPort_send_GPS_LAT(int uart)
+{
+	/* get a local copy of the global position data */
+	struct vehicle_gps_position_s gps_pos;
+	memset(&gps_pos, 0, sizeof(gps_pos));
+	orb_copy(ORB_ID(vehicle_gps_position), gps_position_sub, &gps_pos);
+
+	/* send latitude */
+	/* convert to 30 bit signed magnitude degrees*6E5 with MSb = 0 and bit 30=sign */
+	uint32_t iLat = 6E5 * fabs(gps_pos.lat);
+	if (gps_pos.lat < 0) { iLat |= (1 << 30); }
+
+	sPort_send_data(uart, SMARTPORT_ID_GPS_LON_LAT, iLat);
+}
+
+void sPort_send_GPS_ALT(int uart)
+{
+	/* get a local copy of the global position data */
+	struct vehicle_gps_position_s gps_pos;
+	memset(&gps_pos, 0, sizeof(gps_pos));
+	orb_copy(ORB_ID(vehicle_gps_position), gps_position_sub, &gps_pos);
+
+	/* send altitude */
+ 	/* convert to 100 * m/sec */
+ 	uint32_t iAlt = 100 * gps_pos.alt;
+ 	sPort_send_data(uart, SMARTPORT_ID_GPS_ALT, iAlt);
+}
+
+void sPort_send_GPS_SPD(int uart)
+{
+	/* get a local copy of the global position data */
+	struct vehicle_gps_position_s gps_pos;
+	memset(&gps_pos, 0, sizeof(gps_pos));
+	orb_copy(ORB_ID(vehicle_gps_position), gps_position_sub, &gps_pos);
+
+	/* send 100 * knots */
+	float speed  = sqrtf(gps_pos.vel_n_m_s * gps_pos.vel_n_m_s + gps_pos.vel_e_m_s * gps_pos.vel_e_m_s);
+	uint32_t ispeed = (int)(1944 * speed);
+	sPort_send_data(uart, SMARTPORT_ID_GPS_SPD, ispeed);
+}
+
+void sPort_send_GPS_CRS(int uart)
+{
+	/* get a local copy of the global position data */
+	struct vehicle_global_position_s global_pos;
+	memset(&global_pos, 0, sizeof(global_pos));
+	orb_copy(ORB_ID(vehicle_global_position), global_position_sub, &global_pos);
+
+	/* send course */
+	int32_t iYaw = 100 * global_pos.yaw;
+
+	sPort_send_data(uart, SMARTPORT_ID_GPS_CRS, iYaw);
+}
+
+void sPort_send_GPS_TIME(int uart)
+{
+	/* get a local copy of the global position data */
+	struct vehicle_gps_position_s gps_pos;
+	memset(&gps_pos, 0, sizeof(gps_pos));
+	orb_copy(ORB_ID(vehicle_gps_position), gps_position_sub, &gps_pos);
+
+	sPort_send_data(uart, SMARTPORT_ID_GPS_TIME, gps_pos.time_utc_usec);
+}

--- a/src/drivers/frsky_telemetry/sPort_data.h
+++ b/src/drivers/frsky_telemetry/sPort_data.h
@@ -43,7 +43,6 @@
 #define _SPORT_DATA_H
 
 #include <sys/types.h>
-#include <stdbool.h>
 
 /* FrSky SmartPort polling IDs captured from X4R */
 #define SMARTPORT_POLL_1    0x1B
@@ -52,46 +51,45 @@
 #define SMARTPORT_POLL_4    0x16
 #define SMARTPORT_POLL_5    0xB7
 #define SMARTPORT_POLL_6    0x00
-#define SMARTPORT_POLL_7    0x83
+#define SMARTPORT_POLL_7    0xBA
 
-/* FrSky SmartPort sensor IDs */
+/* FrSky SmartPort sensor IDs. See more here: https://github.com/opentx/opentx/blob/master/radio/src/telemetry/frsky.h#L109 */
 #define SMARTPORT_ID_RSSI          0xf101
 #define SMARTPORT_ID_RXA1          0xf102	// supplied by RX
 #define SMARTPORT_ID_RXA2          0xf103	// supplied by RX
 #define SMARTPORT_ID_BATV          0xf104
-#define SMARTPORT_ID_SWR           0xf105
+#define SMARTPORT_ID_SWR           0xf105   // Standing Wave Ratio
 #define SMARTPORT_ID_T1            0x0400
 #define SMARTPORT_ID_T2            0x0410
 #define SMARTPORT_ID_RPM           0x0500
 #define SMARTPORT_ID_FUEL          0x0600
 #define SMARTPORT_ID_ALT           0x0100
-#define SMARTPORT_ID_VARIO         0x0110
+#define SMARTPORT_ID_VARIO         0x0110   //VSPEED
 #define SMARTPORT_ID_ACCX          0x0700
 #define SMARTPORT_ID_ACCY          0x0710
 #define SMARTPORT_ID_ACCZ          0x0720
 #define SMARTPORT_ID_CURR          0x0200
-#define SMARTPORT_ID_VFAS          0x0210
+#define SMARTPORT_ID_VFAS          0x0210  //Volt per Cell
 #define SMARTPORT_ID_CELLS         0x0300
 #define SMARTPORT_ID_GPS_LON_LAT   0x0800
 #define SMARTPORT_ID_GPS_ALT       0x0820
 #define SMARTPORT_ID_GPS_SPD       0x0830
-#define SMARTPORT_ID_GPS_CRS       0x0840
+#define SMARTPORT_ID_GPS_CRS       0x0840  //CRS = Course... Something?!?
 #define SMARTPORT_ID_GPS_TIME      0x0850
 
 // Public functions
-bool sPort_init(void);
-void sPort_deinit(void);
+//TODO: Add GPS_ALT, GPS_SPEED, GPS_LON_LAT, GPS_CRS, GPS_TIME,
+void sPort_init(void);
 void sPort_send_data(int uart, uint16_t id, uint32_t data);
 void sPort_send_BATV(int uart);
 void sPort_send_CUR(int uart);
 void sPort_send_ALT(int uart);
 void sPort_send_SPD(int uart);
 void sPort_send_VSPD(int uart, float speed);
-void sPort_send_GPS_LON(int uart);
-void sPort_send_GPS_LAT(int uart);
-void sPort_send_GPS_ALT(int uart);
-void sPort_send_GPS_COG(int uart);
-void sPort_send_GPS_SPD(int uart);
 void sPort_send_FUEL(int uart);
+void sPort_send_T1(int uart);
+void sPort_send_T2(int uart);
+
+
 
 #endif /* _SPORT_TELEMETRY_H */

--- a/src/drivers/frsky_telemetry/sPort_data.h
+++ b/src/drivers/frsky_telemetry/sPort_data.h
@@ -98,7 +98,7 @@ void sPort_send_GPS_SPD(int uart);
 void sPort_send_GPS_CRS(int uart);
 void sPort_send_GPS_TIME(int uart);
 
-void sPort_send_NAVSTATE(int uart);
-void sPort_send_GPSFIX(int uart);
+void sPort_send_NAV_STATE(int uart);
+void sPort_send_GPS_FIX(int uart);
 
 #endif /* _SPORT_TELEMETRY_H */

--- a/src/drivers/frsky_telemetry/sPort_data.h
+++ b/src/drivers/frsky_telemetry/sPort_data.h
@@ -43,6 +43,7 @@
 #define _SPORT_DATA_H
 
 #include <sys/types.h>
+#include <stdbool.h>
 
 /* FrSky SmartPort polling IDs captured from X4R */
 #define SMARTPORT_POLL_1    0x1B
@@ -83,7 +84,9 @@
 #define SMARTPORT_ID_DIY_GPSFIX    0x5001
 
 // Public functions
-void sPort_init(void);
+bool sPort_init(void);
+void sPort_deinit(void);
+void sPort_update_topics(void);
 void sPort_send_data(int uart, uint16_t id, uint32_t data);
 void sPort_send_BATV(int uart);
 void sPort_send_CUR(int uart);

--- a/src/drivers/frsky_telemetry/sPort_data.h
+++ b/src/drivers/frsky_telemetry/sPort_data.h
@@ -51,7 +51,8 @@
 #define SMARTPORT_POLL_4    0x16
 #define SMARTPORT_POLL_5    0xB7
 #define SMARTPORT_POLL_6    0x00
-#define SMARTPORT_POLL_7    0xBA
+#define SMARTPORT_POLL_7    0x83
+#define SMARTPORT_POLL_8    0xBA
 
 /* FrSky SmartPort sensor IDs. See more here: https://github.com/opentx/opentx/blob/master/radio/src/telemetry/frsky.h#L109 */
 #define SMARTPORT_ID_RSSI          0xf101
@@ -74,11 +75,10 @@
 #define SMARTPORT_ID_GPS_LON_LAT   0x0800
 #define SMARTPORT_ID_GPS_ALT       0x0820
 #define SMARTPORT_ID_GPS_SPD       0x0830
-#define SMARTPORT_ID_GPS_CRS       0x0840  //CRS = Course... Something?!?
+#define SMARTPORT_ID_GPS_CRS       0x0840
 #define SMARTPORT_ID_GPS_TIME      0x0850
 
 // Public functions
-//TODO: Add GPS_ALT, GPS_SPEED, GPS_LON_LAT, GPS_CRS, GPS_TIME,
 void sPort_init(void);
 void sPort_send_data(int uart, uint16_t id, uint32_t data);
 void sPort_send_BATV(int uart);
@@ -89,7 +89,11 @@ void sPort_send_VSPD(int uart, float speed);
 void sPort_send_FUEL(int uart);
 void sPort_send_T1(int uart);
 void sPort_send_T2(int uart);
-
-
+void sPort_send_GPS_LON(int uart);
+void sPort_send_GPS_LAT(int uart);
+void sPort_send_GPS_ALT(int uart);
+void sPort_send_GPS_SPD(int uart);
+void sPort_send_GPS_CRS(int uart);
+void sPort_send_GPS_TIME(int uart);
 
 #endif /* _SPORT_TELEMETRY_H */

--- a/src/drivers/frsky_telemetry/sPort_data.h
+++ b/src/drivers/frsky_telemetry/sPort_data.h
@@ -78,7 +78,9 @@
 #define SMARTPORT_ID_GPS_CRS       0x0840
 #define SMARTPORT_ID_GPS_TIME      0x0850
 #define SMARTPORT_ID_DIY_FIRST     0x5000
-#define SMARTPORT_ID_DIY_LAST      0x50ff
+#define SMARTPORT_ID_DIY_LAST      0x50ff  //We have 256 possible ID's for custom values :)
+#define SMARTPORT_ID_DIY_NAVSTATE  0x5000
+#define SMARTPORT_ID_DIY_GPSFIX    0x5001
 
 // Public functions
 void sPort_init(void);
@@ -89,13 +91,14 @@ void sPort_send_ALT(int uart);
 void sPort_send_SPD(int uart);
 void sPort_send_VSPD(int uart, float speed);
 void sPort_send_FUEL(int uart);
-void sPort_send_T1(int uart);
-void sPort_send_T2(int uart);
 void sPort_send_GPS_LON(int uart);
 void sPort_send_GPS_LAT(int uart);
 void sPort_send_GPS_ALT(int uart);
 void sPort_send_GPS_SPD(int uart);
 void sPort_send_GPS_CRS(int uart);
 void sPort_send_GPS_TIME(int uart);
+
+void sPort_send_NAVSTATE(int uart);
+void sPort_send_GPSFIX(int uart);
 
 #endif /* _SPORT_TELEMETRY_H */

--- a/src/drivers/frsky_telemetry/sPort_data.h
+++ b/src/drivers/frsky_telemetry/sPort_data.h
@@ -77,6 +77,8 @@
 #define SMARTPORT_ID_GPS_SPD       0x0830
 #define SMARTPORT_ID_GPS_CRS       0x0840
 #define SMARTPORT_ID_GPS_TIME      0x0850
+#define SMARTPORT_ID_DIY_FIRST     0x5000
+#define SMARTPORT_ID_DIY_LAST      0x50ff
 
 // Public functions
 void sPort_init(void);


### PR DESCRIPTION
This adds support for pretty much any SmartPort Sensor possible.
It will transmit flightmodes (nav_state), gps fix and sattelite count, GPS Longtitude and Attitude, GPS Speed, GPS Altitude, GPS Course and GPS Time via FrSky Telemetry to be displayed directly on the radio or interpreted by a script (like LuaPilot, which I will release a update for to use all these values).

The only values supported by the smartport protocol that are *not* implemented are:
SWR, RPM, ACCX, ACCY, ACCX, VFAS and CELLS. Everything else is implemented.
The list of all sensor IDs can be found [https://github.com/thedevleon/Firmware/blob/frysky_telemetry_improvement/src/drivers/frsky_telemetry/sPort_data.h#L57](here).

Inspired by https://github.com/PX4/Firmware/pull/3762 and https://github.com/PX4/Firmware/pull/4348
This is also based on the latest master, so rebasing should be easy.