### PR TITLE
mag_calibration: bugfix for device ID of mag

### DIFF
--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -352,7 +352,7 @@ static calibrate_return mag_calibration_worker(detect_orientation_return orienta
 		px4_pollfd_struct_t fds[max_mags];
 		size_t fd_count = 0;
 		for (size_t cur_mag=0; cur_mag<max_mags; cur_mag++) {
-			if (worker_data->sub_mag[cur_mag] >= 0 && device_ids[cur_mag] > 0) {
+			if (worker_data->sub_mag[cur_mag] >= 0 && device_ids[cur_mag] != 0) {
 				fds[fd_count].fd = worker_data->sub_mag[cur_mag];
 				fds[fd_count].events = POLLIN;
 				fd_count++;


### PR DESCRIPTION
The device ID is defined as a uint32_t in the driver and topic but
stored as a int32_t param. It is therefore sufficient if the device ID
is not 0 in order to be valid.

This should resolve #4342.

@mhkabir and @ndepal: can you test if the compass calibration works for you with this fix?