### PR TITLE
param_shmem: be less chatty, printf cleanup

### DIFF
--- a/src/modules/systemlib/param/param_shmem.c
+++ b/src/modules/systemlib/param/param_shmem.c
@@ -537,15 +537,15 @@ param_get(param_t param, void *val)
 #ifdef ENABLE_SHMEM_DEBUG
 
 	if (param_type(param) == PARAM_TYPE_INT32) {
-		PX4_INFO("param_get for %s : %d\n", param_name(param), ((union param_value_u *)val)->i);
+		PX4_INFO("param_get for %s : %d", param_name(param), ((union param_value_u *)val)->i);
 	}
 
 	else if (param_type(param) == PARAM_TYPE_FLOAT) {
-		PX4_INFO("param_get for %s : %f\n", param_name(param), (double)((union param_value_u *)val)->f);
+		PX4_INFO("param_get for %s : %f", param_name(param), (double)((union param_value_u *)val)->f);
 	}
 
 	else {
-		PX4_INFO("Unknown param type for %s\n", param_name(param));
+		PX4_INFO("Unknown param type for %s", param_name(param));
 	}
 
 #endif
@@ -656,15 +656,15 @@ out:
 #ifdef ENABLE_SHMEM_DEBUG
 
 	if (param_type(param) == PARAM_TYPE_INT32) {
-		PX4_INFO("param_set for %s : %d\n", param_name(param), ((union param_value_u *)val)->i);
+		PX4_INFO("param_set for %s : %d", param_name(param), ((union param_value_u *)val)->i);
 	}
 
 	else if (param_type(param) == PARAM_TYPE_FLOAT) {
-		PX4_INFO("param_set for %s : %f\n", param_name(param), (double)((union param_value_u *)val)->f);
+		PX4_INFO("param_set for %s : %f", param_name(param), (double)((union param_value_u *)val)->f);
 	}
 
 	else {
-		PX4_INFO("Unknown param type for %s\n", param_name(param));
+		PX4_INFO("Unknown param type for %s", param_name(param));
 	}
 
 #endif
@@ -836,7 +836,7 @@ param_save_default(void)
 	const char *filename = param_get_default_file();
 
 	if (get_shmem_lock(__FILE__, __LINE__) != 0) {
-		PX4_ERR("Could not get shmem lock\n");
+		PX4_ERR("Could not get shmem lock");
 		res = ERROR;
 		goto exit;
 	}
@@ -881,7 +881,7 @@ exit:
 	}
 
 	if (res == OK) {
-		PX4_INFO("saving params completed successfully\n");
+		PX4_INFO("saving params completed successfully");
 	}
 
 	return res;
@@ -893,13 +893,12 @@ exit:
 int
 param_load_default(void)
 {
-	warnx("param_load_default\n");
 	int fd_load = PARAM_OPEN(param_get_default_file(), O_RDONLY);
 
 	if (fd_load < 0) {
 		/* no parameter file is OK, otherwise this is an error */
 		if (errno != ENOENT) {
-			warn("open '%s' for reading failed", param_get_default_file());
+			PX4_ERR("open '%s' for reading failed", param_get_default_file());
 			return -1;
 		}
 
@@ -911,7 +910,7 @@ param_load_default(void)
 	PARAM_CLOSE(fd_load);
 
 	if (result != 0) {
-		warn("error reading parameters from '%s'", param_get_default_file());
+		PX4_ERR("error reading parameters from '%s'", param_get_default_file());
 		return -2;
 	}
 
@@ -931,7 +930,7 @@ param_load_default_no_notify(void)
 
 		/* no parameter file is OK, otherwise this is an error */
 		if (errno != ENOENT) {
-			debug("open '%s' for reading failed", param_get_default_file());
+			PX4_DEBUG("open '%s' for reading failed", param_get_default_file());
 			return -1;
 		}
 
@@ -942,10 +941,10 @@ param_load_default_no_notify(void)
 
 	close(fd_load);
 
-	PX4_INFO("param loading done\n");
+	PX4_INFO("param loading done");
 
 	if (result != 0) {
-		warn("error reading parameters from '%s'", param_get_default_file());
+		PX4_WARN("error reading parameters from '%s'", param_get_default_file());
 		return -2;
 	}
 
@@ -995,7 +994,7 @@ param_export(int fd, bool only_unsaved)
 			i = s->val.i;
 
 			if (bson_encoder_append_int(&encoder, param_name(s->param), i)) {
-				debug("BSON append failed for '%s'", param_name(s->param));
+				PX4_DEBUG("BSON append failed for '%s'", param_name(s->param));
 				goto out;
 			}
 
@@ -1005,7 +1004,7 @@ param_export(int fd, bool only_unsaved)
 			f = s->val.f;
 
 			if (bson_encoder_append_double(&encoder, param_name(s->param), f)) {
-				debug("BSON append failed for '%s'", param_name(s->param));
+				PX4_DEBUG("BSON append failed for '%s'", param_name(s->param));
 				goto out;
 			}
 
@@ -1017,14 +1016,14 @@ param_export(int fd, bool only_unsaved)
 						       BSON_BIN_BINARY,
 						       param_size(s->param),
 						       param_get_value_ptr(s->param))) {
-				debug("BSON append failed for '%s'", param_name(s->param));
+				PX4_DEBUG("BSON append failed for '%s'", param_name(s->param));
 				goto out;
 			}
 
 			break;
 
 		default:
-			debug("unrecognized parameter type");
+			PX4_DEBUG("unrecognized parameter type");
 			goto out;
 		}
 	}
@@ -1059,7 +1058,7 @@ param_import_callback(bson_decoder_t decoder, void *private, bson_node_t node)
 	 * nested BSON objects).
 	 */
 	if (node->type == BSON_EOO) {
-		debug("end of parameters");
+		PX4_DEBUG("end of parameters");
 		return 0;
 	}
 
@@ -1070,7 +1069,7 @@ param_import_callback(bson_decoder_t decoder, void *private, bson_node_t node)
 	param_t param = param_find_no_notification(node->name);
 
 	if (param == PARAM_INVALID) {
-		debug("ignoring unrecognised parameter '%s'", node->name);
+		PX4_DEBUG("ignoring unrecognised parameter '%s'", node->name);
 		return 1;
 	}
 
@@ -1081,34 +1080,34 @@ param_import_callback(bson_decoder_t decoder, void *private, bson_node_t node)
 	switch (node->type) {
 	case BSON_INT32:
 		if (param_type(param) != PARAM_TYPE_INT32) {
-			debug("unexpected type for '%s", node->name);
+			PX4_DEBUG("unexpected type for '%s", node->name);
 			goto out;
 		}
 
 		i = node->i;
 		v = &i;
-		PX4_INFO("Imported %s with value %d\n", param_name(param), i);
+		PX4_DEBUG("Imported %s with value %d", param_name(param), i);
 		break;
 
 	case BSON_DOUBLE:
 		if (param_type(param) != PARAM_TYPE_FLOAT) {
-			debug("unexpected type for '%s", node->name);
+			PX4_DEBUG("unexpected type for '%s", node->name);
 			goto out;
 		}
 
 		f = node->d;
 		v = &f;
-		PX4_INFO("Imported %s with value %f\n", param_name(param), (double)f);
+		PX4_DEBUG("Imported %s with value %f", param_name(param), (double)f);
 		break;
 
 	case BSON_BINDATA:
 		if (node->subtype != BSON_BIN_BINARY) {
-			debug("unexpected subtype for '%s", node->name);
+			PX4_DEBUG("unexpected subtype for '%s", node->name);
 			goto out;
 		}
 
 		if (bson_decoder_data_pending(decoder) != param_size(param)) {
-			debug("bad size for '%s'", node->name);
+			PX4_DEBUG("bad size for '%s'", node->name);
 			goto out;
 		}
 
@@ -1116,12 +1115,12 @@ param_import_callback(bson_decoder_t decoder, void *private, bson_node_t node)
 		tmp = malloc(param_size(param));
 
 		if (tmp == NULL) {
-			debug("failed allocating for '%s'", node->name);
+			PX4_DEBUG("failed allocating for '%s'", node->name);
 			goto out;
 		}
 
 		if (bson_decoder_copy_data(decoder, tmp)) {
-			debug("failed copying data for '%s'", node->name);
+			PX4_DEBUG("failed copying data for '%s'", node->name);
 			goto out;
 		}
 
@@ -1129,12 +1128,12 @@ param_import_callback(bson_decoder_t decoder, void *private, bson_node_t node)
 		break;
 
 	default:
-		debug("unrecognised node type");
+		PX4_DEBUG("unrecognised node type");
 		goto out;
 	}
 
 	if (param_set_internal(param, v, state->mark_saved, true, false)) {
-		debug("error setting value for '%s'", node->name);
+		PX4_DEBUG("error setting value for '%s'", node->name);
 		goto out;
 	}
 
@@ -1163,7 +1162,7 @@ param_import_internal(int fd, bool mark_saved)
 	struct param_import_state state;
 
 	if (bson_decoder_init_file(&decoder, fd, param_import_callback, &state)) {
-		debug("decoder init failed");
+		PX4_DEBUG("decoder init failed");
 		goto out;
 	}
 
@@ -1177,7 +1176,7 @@ param_import_internal(int fd, bool mark_saved)
 out:
 
 	if (result < 0) {
-		debug("BSON error decoding parameters");
+		PX4_DEBUG("BSON error decoding parameters");
 	}
 
 	return result;
@@ -1254,8 +1253,8 @@ void init_params(void)
 
 
 #ifdef ENABLE_SHMEM_DEBUG
-	PX4_INFO("Offsets: \n");
-	PX4_INFO("params_val %lu, krait_changed %lu, adsp_changed %lu\n",
+	PX4_INFO("Offsets:");
+	PX4_INFO("params_val %lu, krait_changed %lu, adsp_changed %lu",
 		 (unsigned char *)shmem_info_p->params_val - (unsigned char *)shmem_info_p,
 		 (unsigned char *)&shmem_info_p->krait_changed_index - (unsigned char *)shmem_info_p,
 		 (unsigned char *)&shmem_info_p->adsp_changed_index - (unsigned char *)shmem_info_p);

--- a/src/platforms/posix/px4_layer/shmem_posix.c
+++ b/src/platforms/posix/px4_layer/shmem_posix.c
@@ -52,7 +52,7 @@
 
 #include <shmem.h>
 
-#define SHMEM_DEBUG
+//#define SHMEM_DEBUG
 
 int mem_fd;
 unsigned char *map_base, *virt_addr;


### PR DESCRIPTION
This removes a bunch of unnecessary param printfs (and newlines) on Snapdragon.