### PR TITLE
gps: fix Snapdragon build

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -36,13 +36,11 @@
  * Driver for the GPS on a serial port
  */
 
-#ifndef __PX4_QURT
 #ifdef __PX4_NUTTX
 #include <nuttx/clock.h>
 #include <nuttx/arch.h>
 #endif
-#include <fcntl.h>
-#endif
+
 
 #ifndef __PX4_QURT
 #include <termios.h>
@@ -53,6 +51,7 @@
 #endif
 
 
+#include <fcntl.h>
 #include <sys/types.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/src/platforms/posix/px4_layer/drv_hrt.c
+++ b/src/platforms/posix/px4_layer/drv_hrt.c
@@ -118,15 +118,15 @@ int px4_clock_gettime(clockid_t clk_id, struct timespec *tp)
 	return 0;
 }
 
+#elif defined(__QURT)
+
+#include "dspal_time.h"
+
 int px4_clock_settime(clockid_t clk_id, struct timespec *tp)
 {
 	/* do nothing right now */
 	return 0;
 }
-
-#elif defined(__QURT)
-
-#include "dspal_time.h"
 
 int px4_clock_gettime(clockid_t clk_id, struct timespec *tp)
 {

--- a/src/platforms/posix/px4_layer/drv_hrt.c
+++ b/src/platforms/posix/px4_layer/drv_hrt.c
@@ -118,6 +118,12 @@ int px4_clock_gettime(clockid_t clk_id, struct timespec *tp)
 	return 0;
 }
 
+int px4_clock_settime(clockid_t clk_id, struct timespec *tp)
+{
+	/* do nothing right now */
+	return 0;
+}
+
 #elif defined(__QURT)
 
 #include "dspal_time.h"


### PR DESCRIPTION
This fixes this build issues:

```
[ 43%] Building CXX object src/drivers/gps/CMakeFiles/drivers__gps.dir/gps.cpp.o
/home/julianoes/src/Firmware/src/drivers/gps/gps.cpp:519:17: fatal error: no member named 'open' in the global
      namespace; did you mean 'fopen'?
        _serial_fd = ::open(_port, O_RDWR | O_NOCTTY);
                     ~~^~~~
                       fopen
/home/julianoes/Qualcomm/HEXAGON_Tools/7.2.10/Tools/bin/../target/hexagon/include/stdio.h:121:7: note: 'fopen'
      declared here
FILE *fopen(const char *_Restrict, const char *_Restrict) _NO_THROW;
```

```
/home/julianoes/src/Firmware/src/drivers/gps/gps.cpp:519:27: fatal error: use of undeclared identifier 'O_RDWR'
        _serial_fd = open(_port, O_RDWR | O_NOCTTY);
                                 ^
1 error generated.
```

As well as a linking error for `px4_clock_settime`.