### PR TITLE
mavlink: fix Snapdragon build

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -383,8 +383,10 @@ private:
 #endif
 
 protected:
-	explicit MavlinkStreamStatustext(Mavlink *mavlink) : MavlinkStream(mavlink),
-	fp(nullptr)
+	explicit MavlinkStreamStatustext(Mavlink *mavlink) : MavlinkStream(mavlink)
+#ifndef __PX4_POSIX_EAGLE
+	, fp(nullptr)
+#endif
 	{}
 
 	~MavlinkStreamStatustext() {


### PR DESCRIPTION
Fixes:

```
Firmware/src/modules/mavlink/mavlink_messages.cpp: In constructor 'MavlinkStreamStatustext::MavlinkStreamStatustext(Mavlink*)':
Firmware/src/modules/mavlink/mavlink_messages.cpp:387:2: error: class 'MavlinkStreamStatustext' does not have any field named 'fp'
  fp(nullptr)
```

Let's wait for travis to merge.