### PR TITLE
Snapdragon: Fix passthrough

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -822,6 +822,7 @@ then
 		fi
 
 		pwm failsafe -c 1234 -p 900
+		pwm disarmed -c 1234 -p 900
 
 		# Arm straightaway.
 		pwm arm

--- a/src/drivers/snapdragon_rc_pwm/snapdragon_rc_pwm.cpp
+++ b/src/drivers/snapdragon_rc_pwm/snapdragon_rc_pwm.cpp
@@ -75,7 +75,7 @@ static int _uart_fd = -1;
 int _pwm_fd = -1;
 static bool _flow_control_enabled = false;
 int _rc_sub = -1;
-uint16_t _pwm_disarmed;
+int32_t _pwm_disarmed;
 
 hrt_abstime _last_actuator_controls_received = 0;
 

--- a/src/drivers/uart_esc/uart_esc.cpp
+++ b/src/drivers/uart_esc/uart_esc.cpp
@@ -90,9 +90,9 @@ input_rc_s 		_rc;
 pwm_limit_t	_pwm_limit;
 
 // esc parameters
-uint16_t _pwm_disarmed;
-uint16_t _pwm_min;
-uint16_t _pwm_max;
+int32_t _pwm_disarmed;
+int32_t _pwm_min;
+int32_t _pwm_max;
 
 MultirotorMixer *_mixer = nullptr;
 


### PR DESCRIPTION
Fix snapdragon passthrough. Passthrough mode did not work reliably on all pixfalcon devices.

This makes sure that snapdragon_rc_pwm sends PWM_DISARMED if it does not receive anything from the snapdragon, ensuring that the ESCs are happy.

Also change parameter type from uint16 to int32 to prevent stack smashing.