### PR TITLE
uORB synchronization issues

### DIFF
--- a/src/drivers/device/device_nuttx.h
+++ b/src/drivers/device/device_nuttx.h
@@ -188,6 +188,8 @@ protected:
 	 * Each driver instance has its own lock/semaphore.
 	 *
 	 * Note that we must loop as the wait may be interrupted by a signal.
+	 *
+	 * Careful: lock() calls cannot be nested!
 	 */
 	void		lock()
 	{
@@ -202,10 +204,11 @@ protected:
 		sem_post(&_lock);
 	}
 
+	sem_t		_lock; /**< lock to protect access to all class members (also for derived classes) */
+
 private:
 	int		_irq;
 	bool		_irq_attached;
-	sem_t		_lock;
 
 	/** disable copy construction for this and all subclasses */
 	Device(const Device &);

--- a/src/drivers/device/vdev.h
+++ b/src/drivers/device/vdev.h
@@ -178,6 +178,8 @@ protected:
 	 * Each driver instance has its own lock/semaphore.
 	 *
 	 * Note that we must loop as the wait may be interrupted by a signal.
+	 *
+	 * Careful: lock() calls cannot be nested!
 	 */
 	void		lock()
 	{
@@ -195,7 +197,7 @@ protected:
 	}
 
 private:
-	px4_sem_t		_lock;
+	px4_sem_t		_lock; /**< lock to protect access to all class members (also for derived classes) */
 
 	/** disable copy construction for this and all subclasses */
 	Device(const Device &);
@@ -348,6 +350,8 @@ protected:
 	 *
 	 * The default implementation returns no events.
 	 *
+	 * Lock must already be held when calling this.
+	 *
 	 * @param filep		The file that's interested.
 	 * @return		The current set of poll events.
 	 */
@@ -365,6 +369,8 @@ protected:
 
 	/**
 	 * Internal implementation of poll_notify.
+	 *
+	 * Lock must already be held when calling this.
 	 *
 	 * @param fds		A poll waiter to notify.
 	 * @param events	The event(s) to send to the waiter.

--- a/src/drivers/device/vdev.h
+++ b/src/drivers/device/vdev.h
@@ -196,6 +196,26 @@ protected:
 		px4_sem_post(&_lock);
 	}
 
+	/**
+	 * @class Smart locking object that uses the same lock as lock(), but automatically
+	 * takes the lock when created and releases the lock when the object goes out of
+	 * scope. Use like this:
+	 *   {
+	 *       SmartLock smart_lock(*this);
+	 *       //critical section start
+	 *       ...
+	 *       //critical section end
+	 *   }
+	 */
+	class SmartLock
+	{
+	public:
+		SmartLock(Device &device) : _device(device) { _device.lock(); }
+		~SmartLock() { _device.unlock(); }
+	private:
+		Device &_device;
+	};
+
 private:
 	px4_sem_t		_lock; /**< lock to protect access to all class members (also for derived classes) */
 

--- a/src/drivers/device/vdev.h
+++ b/src/drivers/device/vdev.h
@@ -196,29 +196,9 @@ protected:
 		px4_sem_post(&_lock);
 	}
 
-	/**
-	 * @class Smart locking object that uses the same lock as lock(), but automatically
-	 * takes the lock when created and releases the lock when the object goes out of
-	 * scope. Use like this:
-	 *   {
-	 *       SmartLock smart_lock(*this);
-	 *       //critical section start
-	 *       ...
-	 *       //critical section end
-	 *   }
-	 */
-	class SmartLock
-	{
-	public:
-		SmartLock(Device &device) : _device(device) { _device.lock(); }
-		~SmartLock() { _device.unlock(); }
-	private:
-		Device &_device;
-	};
-
-private:
 	px4_sem_t		_lock; /**< lock to protect access to all class members (also for derived classes) */
 
+private:
 	/** disable copy construction for this and all subclasses */
 	Device(const Device &);
 

--- a/src/modules/uORB/uORBDevices_nuttx.cpp
+++ b/src/modules/uORB/uORBDevices_nuttx.cpp
@@ -267,9 +267,12 @@ uORB::DeviceNode::ioctl(struct file *filp, int cmd, unsigned long arg)
 	SubscriberData *sd = filp_to_sd(filp);
 
 	switch (cmd) {
-	case ORBIOCLASTUPDATE:
-		*(hrt_abstime *)arg = _last_update;
-		return OK;
+	case ORBIOCLASTUPDATE: {
+			irqstate_t state = irqsave();
+			*(hrt_abstime *)arg = _last_update;
+			irqrestore(state);
+			return OK;
+		}
 
 	case ORBIOCUPDATED:
 		*(bool *)arg = appears_updated(sd);

--- a/src/modules/uORB/uORBDevices_nuttx.cpp
+++ b/src/modules/uORB/uORBDevices_nuttx.cpp
@@ -245,16 +245,17 @@ uORB::DeviceNode::write(struct file *filp, const char *buffer, size_t buflen)
 	/* Perform an atomic copy. */
 	irqstate_t flags = irqsave();
 	memcpy(_data, buffer, _meta->o_size);
-	irqrestore(flags);
 
 	/* update the timestamp and generation count */
 	_last_update = hrt_absolute_time();
 	_generation++;
 
+	_published = true;
+
+	irqrestore(flags);
+
 	/* notify any poll waiters */
 	poll_notify(POLLIN);
-
-	_published = true;
 
 	return _meta->o_size;
 }

--- a/src/modules/uORB/uORBDevices_nuttx.hpp
+++ b/src/modules/uORB/uORBDevices_nuttx.hpp
@@ -190,7 +190,7 @@ private:
 
 private: // private class methods.
 
-	SubscriberData    *filp_to_sd(struct file *filp)
+	static SubscriberData    *filp_to_sd(struct file *filp)
 	{
 		SubscriberData *sd = (SubscriberData *)(filp->f_priv);
 		return sd;

--- a/src/modules/uORB/uORBDevices_nuttx.hpp
+++ b/src/modules/uORB/uORBDevices_nuttx.hpp
@@ -239,7 +239,7 @@ public:
 	static uORB::DeviceNode *GetDeviceNode(const char *node_name);
 	virtual int   ioctl(struct file *filp, int cmd, unsigned long arg);
 private:
-	Flavor      _flavor;
+	const Flavor  _flavor;
 	static ORBMap _node_map;
 };
 

--- a/src/modules/uORB/uORBDevices_posix.cpp
+++ b/src/modules/uORB/uORBDevices_posix.cpp
@@ -41,6 +41,7 @@
 #include "uORBUtils.hpp"
 #include "uORBManager.hpp"
 #include "uORBCommunicator.hpp"
+#include <px4_sem.hpp>
 #include <stdlib.h>
 
 std::map<std::string, uORB::DeviceNode *> uORB::DeviceMaster::_node_map;
@@ -605,7 +606,7 @@ uORB::DeviceMaster::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 				}
 			}
 
-			SmartLock smart_lock(*this);
+			SmartLock smart_lock(_lock);
 
 			do {
 				/* if path is modifyable change try index */

--- a/src/modules/uORB/uORBDevices_posix.hpp
+++ b/src/modules/uORB/uORBDevices_posix.hpp
@@ -126,7 +126,7 @@ private:
 	const int   _priority;  /**< priority of topic */
 	bool _published;  /**< has ever data been published */
 
-	SubscriberData    *filp_to_sd(device::file_t *filp);
+	static SubscriberData    *filp_to_sd(device::file_t *filp);
 
 	int32_t _subscriber_count;
 

--- a/src/modules/uORB/uORBDevices_posix.hpp
+++ b/src/modules/uORB/uORBDevices_posix.hpp
@@ -168,7 +168,7 @@ class uORB::DeviceMaster : public device::VDev
 {
 public:
 	DeviceMaster(Flavor f);
-	~DeviceMaster();
+	virtual ~DeviceMaster();
 
 	static uORB::DeviceNode *GetDeviceNode(const char *node_name);
 

--- a/src/modules/uORB/uORBDevices_posix.hpp
+++ b/src/modules/uORB/uORBDevices_posix.hpp
@@ -145,6 +145,8 @@ private:
 	/**
 	 * Check whether a topic appears updated to a subscriber.
 	 *
+	 * Lock must already be held when calling this.
+	 *
 	 * @param sd    The subscriber for whom to check.
 	 * @return    True if the topic should appear updated to the subscriber
 	 */

--- a/src/modules/uORB/uORBDevices_posix.hpp
+++ b/src/modules/uORB/uORBDevices_posix.hpp
@@ -172,7 +172,7 @@ public:
 
 	virtual int   ioctl(device::file_t *filp, int cmd, unsigned long arg);
 private:
-	Flavor      _flavor;
+	const Flavor      _flavor;
 	static std::map<std::string, uORB::DeviceNode *> _node_map;
 };
 

--- a/src/modules/uORB/uORBMain.cpp
+++ b/src/modules/uORB/uORBMain.cpp
@@ -33,6 +33,7 @@
 
 #include <string.h>
 #include "uORBDevices.hpp"
+#include "uORBManager.hpp"
 #include "uORB.h"
 #include "uORBCommon.hpp"
 
@@ -68,6 +69,11 @@ uorb_main(int argc, char *argv[])
 			PX4_WARN("already loaded");
 			/* user wanted to start uorb, its already running, no error */
 			return 0;
+		}
+
+		if (!uORB::Manager::initialize()) {
+			PX4_ERR("uorb manager alloc failed");
+			return -ENOMEM;
 		}
 
 		/* create the driver */

--- a/src/modules/uORB/uORBManager.cpp
+++ b/src/modules/uORB/uORBManager.cpp
@@ -49,13 +49,13 @@ uORB::Manager *uORB::Manager::_Instance = nullptr;
 
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
-uORB::Manager *uORB::Manager::get_instance()
+bool uORB::Manager::initialize()
 {
 	if (_Instance == nullptr) {
 		_Instance = new uORB::Manager();
 	}
 
-	return _Instance;
+	return _Instance != nullptr;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/modules/uORB/uORBManager.hpp
+++ b/src/modules/uORB/uORBManager.hpp
@@ -63,10 +63,20 @@ public:
 	// public interfaces for this class.
 
 	/**
+	 * Initialize the singleton. Call this before everything else.
+	 * @return true on success
+	 */
+	static bool initialize();
+
+	/**
 	 * Method to get the singleton instance for the uORB::Manager.
+	 * Make sure initialize() is called first.
 	 * @return uORB::Manager*
 	 */
-	static uORB::Manager *get_instance();
+	static uORB::Manager *get_instance()
+	{
+		return _Instance;
+	}
 
 	// ==== uORB interface methods ====
 	/**

--- a/src/platforms/px4_posix.h
+++ b/src/platforms/px4_posix.h
@@ -44,7 +44,6 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <poll.h>
-#include <semaphore.h>
 #include <stdint.h>
 
 #if defined(__PX4_QURT)
@@ -53,50 +52,8 @@
 #include <sys/types.h>
 #endif
 
-/* Semaphore handling */
+#include "px4_sem.h"
 
-#ifdef __PX4_DARWIN
-
-__BEGIN_DECLS
-
-typedef struct {
-	pthread_mutex_t lock;
-	pthread_cond_t wait;
-	int value;
-} px4_sem_t;
-
-__EXPORT int		px4_sem_init(px4_sem_t *s, int pshared, unsigned value);
-__EXPORT int		px4_sem_wait(px4_sem_t *s);
-__EXPORT int		px4_sem_timedwait(px4_sem_t *sem, const struct timespec *abstime);
-__EXPORT int		px4_sem_post(px4_sem_t *s);
-__EXPORT int		px4_sem_getvalue(px4_sem_t *s, int *sval);
-__EXPORT int		px4_sem_destroy(px4_sem_t *s);
-
-__END_DECLS
-
-#else
-
-__BEGIN_DECLS
-
-typedef sem_t px4_sem_t;
-
-#define px4_sem_init	 sem_init
-#define px4_sem_wait	 sem_wait
-#define px4_sem_post	 sem_post
-#define px4_sem_getvalue sem_getvalue
-#define px4_sem_destroy	 sem_destroy
-
-#ifdef __PX4_QURT
-__EXPORT int		px4_sem_timedwait(px4_sem_t *sem, const struct timespec *abstime);
-#else
-#define px4_sem_timedwait	 sem_timedwait
-#endif
-
-__END_DECLS
-
-#endif
-
-//###################################
 
 #ifdef __PX4_NUTTX
 

--- a/src/platforms/px4_sem.h
+++ b/src/platforms/px4_sem.h
@@ -1,0 +1,84 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file px4_sem.h
+ *
+ * Synchronization primitive: Semaphore
+ */
+
+#pragma once
+
+#include <semaphore.h>
+
+
+#ifdef __PX4_DARWIN
+
+__BEGIN_DECLS
+
+typedef struct {
+	pthread_mutex_t lock;
+	pthread_cond_t wait;
+	int value;
+} px4_sem_t;
+
+__EXPORT int		px4_sem_init(px4_sem_t *s, int pshared, unsigned value);
+__EXPORT int		px4_sem_wait(px4_sem_t *s);
+__EXPORT int		px4_sem_timedwait(px4_sem_t *sem, const struct timespec *abstime);
+__EXPORT int		px4_sem_post(px4_sem_t *s);
+__EXPORT int		px4_sem_getvalue(px4_sem_t *s, int *sval);
+__EXPORT int		px4_sem_destroy(px4_sem_t *s);
+
+__END_DECLS
+
+#else
+
+__BEGIN_DECLS
+
+typedef sem_t px4_sem_t;
+
+#define px4_sem_init	 sem_init
+#define px4_sem_wait	 sem_wait
+#define px4_sem_post	 sem_post
+#define px4_sem_getvalue sem_getvalue
+#define px4_sem_destroy	 sem_destroy
+
+#ifdef __PX4_QURT
+__EXPORT int		px4_sem_timedwait(px4_sem_t *sem, const struct timespec *abstime);
+#else
+#define px4_sem_timedwait	 sem_timedwait
+#endif
+
+__END_DECLS
+
+#endif

--- a/src/platforms/px4_sem.hpp
+++ b/src/platforms/px4_sem.hpp
@@ -1,0 +1,68 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file px4_sem.hpp
+ *
+ * C++ synchronization helpers
+ */
+
+#pragma once
+
+#include "px4_sem.h"
+
+
+/**
+ * @class Smart locking object that uses a semaphore. It automatically
+ * takes the lock when created and releases the lock when the object goes out of
+ * scope. Use like this:
+ *
+ *   px4_sem_t my_lock;
+ *   int ret = px4_sem_init(&my_lock, 0, 1);
+ *   ...
+ *
+ *   {
+ *       SmartLock smart_lock(my_lock);
+ *       //critical section start
+ *       ...
+ *       //critical section end
+ *   }
+ */
+class SmartLock
+{
+public:
+	SmartLock(px4_sem_t &sem) : _sem(sem) { do {} while (px4_sem_wait(&_sem) != 0); }
+	~SmartLock() { px4_sem_post(&_sem); }
+private:
+	px4_sem_t &_sem;
+};


### PR DESCRIPTION
This fixes some multi-threading issues in uORB.

There are some subtle issues here, for example:
* `uint64_t t = ...` is not atomic in general
* neither is `++x`

One remaining thing is that DeviceMaster::_node_map is static, which requires a static lock as well. However there exists only a single instance of DeviceMaster, so I suggest to make this non-static. DeviceMaster can be used with PARAM Flavor as well, but in this case the paths are different, so that _node_map still does not need to be static.

Tested both under Posix & NuttX.