### PR TITLE
Removes warning as Cmake now using STACK_MAIN

### DIFF
--- a/src/drivers/lis3mdl/CMakeLists.txt
+++ b/src/drivers/lis3mdl/CMakeLists.txt
@@ -34,7 +34,7 @@ px4_add_module(
 	MODULE drivers__lis3mdl
 	MAIN lis3mdl
 
-	STACK 1200
+	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Weffc++
 		-Os


### PR DESCRIPTION
Removes warning as Cmake now using STACK_MAIN