### PR TITLE
uORB: add API method: orb_unadvertise

### DIFF
--- a/src/modules/uORB/Publication.cpp
+++ b/src/modules/uORB/Publication.cpp
@@ -96,6 +96,7 @@ void PublicationBase::update(void *data)
 
 PublicationBase::~PublicationBase()
 {
+	orb_unadvertise(getHandle());
 }
 
 PublicationNode::PublicationNode(const struct orb_metadata *meta,

--- a/src/modules/uORB/uORB.cpp
+++ b/src/modules/uORB/uORB.cpp
@@ -51,6 +51,11 @@ orb_advert_t orb_advertise_multi(const struct orb_metadata *meta, const void *da
 	return uORB::Manager::get_instance()->orb_advertise_multi(meta, data, instance, priority);
 }
 
+int orb_unadvertise(orb_advert_t handle)
+{
+	return uORB::Manager::get_instance()->orb_unadvertise(handle);
+}
+
 int orb_publish_auto(const struct orb_metadata *meta, orb_advert_t *handle, const void *data, int *instance,
 		     int priority)
 {

--- a/src/modules/uORB/uORB.h
+++ b/src/modules/uORB/uORB.h
@@ -143,6 +143,11 @@ extern orb_advert_t orb_advertise_multi(const struct orb_metadata *meta, const v
 					int priority) __EXPORT;
 
 /**
+ * @see uORB::Manager::orb_unadvertise()
+ */
+extern int orb_unadvertise(orb_advert_t handle) __EXPORT;
+
+/**
  * Advertise as the publisher of a topic.
  *
  * This performs the initial advertisement of a topic; it creates the topic

--- a/src/modules/uORB/uORBDevices_nuttx.cpp
+++ b/src/modules/uORB/uORBDevices_nuttx.cpp
@@ -336,6 +336,30 @@ uORB::DeviceNode::publish
 	return OK;
 }
 
+int uORB::DeviceNode::unadvertise(orb_advert_t handle)
+{
+	if (handle == nullptr) {
+		return -EINVAL;
+	}
+
+	uORB::DeviceNode *devnode = (uORB::DeviceNode *)handle;
+
+	/*
+	 * We are cheating a bit here. First, with the current implementation, we can only
+	 * have multiple publishers for instance 0. In this case the caller will have
+	 * instance=nullptr and _published has no effect at all. Thus no unadvertise is
+	 * necessary.
+	 * In case of multiple instances, we have at most 1 publisher per instance and
+	 * we can signal an instance as 'free' by setting _published to false.
+	 * We never really free the DeviceNode, for this we would need reference counting
+	 * of subscribers and publishers. But we also do not have a leak since future
+	 * publishers reuse the same DeviceNode object.
+	 */
+	devnode->_published = false;
+
+	return PX4_OK;
+}
+
 pollevent_t
 uORB::DeviceNode::poll_state(struct file *filp)
 {

--- a/src/modules/uORB/uORBDevices_nuttx.hpp
+++ b/src/modules/uORB/uORBDevices_nuttx.hpp
@@ -122,6 +122,8 @@ public:
 		const void *data
 	);
 
+	static int        unadvertise(orb_advert_t handle);
+
 	/**
 	 * processes a request for add subscription from remote
 	 * @param rateInHz
@@ -184,7 +186,8 @@ private:
 	uint8_t     *_data;   /**< allocated object buffer */
 	hrt_abstime   _last_update; /**< time the object was last updated */
 	volatile unsigned   _generation;  /**< object generation count */
-	pid_t     _publisher; /**< if nonzero, current publisher */
+	pid_t     _publisher; /**< if nonzero, current publisher. Only used inside the advertise call.
+					We allow one publisher to have an open file descriptor at the same time. */
 	const int   _priority;  /**< priority of topic */
 	bool _published;  /**< has ever data been published */
 

--- a/src/modules/uORB/uORBDevices_posix.cpp
+++ b/src/modules/uORB/uORBDevices_posix.cpp
@@ -352,6 +352,30 @@ uORB::DeviceNode::publish(const orb_metadata *meta, orb_advert_t handle, const v
 	return PX4_OK;
 }
 
+int uORB::DeviceNode::unadvertise(orb_advert_t handle)
+{
+	if (handle == nullptr) {
+		return -EINVAL;
+	}
+
+	uORB::DeviceNode *devnode = (uORB::DeviceNode *)handle;
+
+	/*
+	 * We are cheating a bit here. First, with the current implementation, we can only
+	 * have multiple publishers for instance 0. In this case the caller will have
+	 * instance=nullptr and _published has no effect at all. Thus no unadvertise is
+	 * necessary.
+	 * In case of multiple instances, we have at most 1 publisher per instance and
+	 * we can signal an instance as 'free' by setting _published to false.
+	 * We never really free the DeviceNode, for this we would need reference counting
+	 * of subscribers and publishers. But we also do not have a leak since future
+	 * publishers reuse the same DeviceNode object.
+	 */
+	devnode->_published = false;
+
+	return PX4_OK;
+}
+
 pollevent_t
 uORB::DeviceNode::poll_state(device::file_t *filp)
 {

--- a/src/modules/uORB/uORBDevices_posix.hpp
+++ b/src/modules/uORB/uORBDevices_posix.hpp
@@ -59,6 +59,8 @@ public:
 
 	static ssize_t    publish(const orb_metadata *meta, orb_advert_t handle, const void *data);
 
+	static int        unadvertise(orb_advert_t handle);
+
 	/**
 	 * processes a request for add subscription from remote
 	 * @param rateInHz
@@ -122,7 +124,8 @@ private:
 	uint8_t     *_data;   /**< allocated object buffer */
 	hrt_abstime   _last_update; /**< time the object was last updated */
 	volatile unsigned   _generation;  /**< object generation count */
-	unsigned long     _publisher; /**< if nonzero, current publisher */
+	unsigned long     _publisher; /**< if nonzero, current publisher. Only used inside the advertise call.
+					We allow one publisher to have an open file descriptor at the same time. */
 	const int   _priority;  /**< priority of topic */
 	bool _published;  /**< has ever data been published */
 

--- a/src/modules/uORB/uORBManager.cpp
+++ b/src/modules/uORB/uORBManager.cpp
@@ -129,6 +129,11 @@ orb_advert_t uORB::Manager::orb_advertise_multi(const struct orb_metadata *meta,
 	return advertiser;
 }
 
+int uORB::Manager::orb_unadvertise(orb_advert_t handle)
+{
+	return uORB::DeviceNode::unadvertise(handle);
+}
+
 int uORB::Manager::orb_subscribe(const struct orb_metadata *meta)
 {
 	return node_open(PUBSUB, meta, nullptr, false);

--- a/src/modules/uORB/uORBManager.hpp
+++ b/src/modules/uORB/uORBManager.hpp
@@ -131,6 +131,14 @@ public:
 
 
 	/**
+	 * Unadvertise a topic.
+	 *
+	 * @param handle  handle returned by orb_advertise or orb_advertise_multi.
+	 * @return 0 on success
+	 */
+	int orb_unadvertise(orb_advert_t handle);
+
+	/**
 	 * Publish new data to a topic.
 	 *
 	 * The data is atomically published to the topic and any waiting subscribers

--- a/src/modules/uORB/uORBTest_UnitTest.cpp
+++ b/src/modules/uORB/uORBTest_UnitTest.cpp
@@ -158,7 +158,45 @@ int uORBTest::UnitTest::test()
 		return ret;
 	}
 
+	ret = test_unadvertise();
+
+	if (ret != OK) {
+		return ret;
+	}
+
 	return test_multi2();
+}
+
+int uORBTest::UnitTest::test_unadvertise()
+{
+	test_note("Testing unadvertise");
+
+	//we still have the advertisements from the previous test_multi calls.
+	for (int i = 0; i < 4; ++i) {
+		int ret = orb_unadvertise(_pfd[i]);
+
+		if (ret != PX4_OK) {
+			return test_fail("orb_unadvertise failed (%i)", ret);
+		}
+	}
+
+	//try to advertise and see whether we get the right instance
+	int instance[4];
+	struct orb_test t;
+
+	for (int i = 0; i < 4; ++i) {
+		_pfd[i] = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance[i], ORB_PRIO_MAX);
+
+		if (instance[i] != i) {
+			return test_fail("got wrong instance (should be %i, is %i)", i, instance[i]);
+		}
+	}
+
+	for (int i = 0; i < 4; ++i) {
+		orb_unadvertise(_pfd[i]);
+	}
+
+	return test_note("PASS unadvertise");
 }
 
 
@@ -234,6 +272,12 @@ int uORBTest::UnitTest::test_single()
 
 	orb_unsubscribe(sfd);
 
+	int ret = orb_unadvertise(ptopic);
+
+	if (ret != PX4_OK) {
+		return test_fail("orb_unadvertise failed: %i", ret);
+	}
+
 	return test_note("PASS single-topic test");
 }
 
@@ -245,12 +289,12 @@ int uORBTest::UnitTest::test_multi()
 	struct orb_test t, u;
 	t.val = 0;
 	int instance0;
-	orb_advert_t pfd0 = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance0, ORB_PRIO_MAX);
+	_pfd[0] = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance0, ORB_PRIO_MAX);
 
 	test_note("advertised");
 
 	int instance1;
-	orb_advert_t pfd1 = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance1, ORB_PRIO_MIN);
+	_pfd[1] = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance1, ORB_PRIO_MIN);
 
 	if (instance0 != 0) {
 		return test_fail("mult. id0: %d", instance0);
@@ -262,7 +306,7 @@ int uORBTest::UnitTest::test_multi()
 
 	t.val = 103;
 
-	if (PX4_OK != orb_publish(ORB_ID(orb_multitest), pfd0, &t)) {
+	if (PX4_OK != orb_publish(ORB_ID(orb_multitest), _pfd[0], &t)) {
 		return test_fail("mult. pub0 fail");
 	}
 
@@ -270,7 +314,7 @@ int uORBTest::UnitTest::test_multi()
 
 	t.val = 203;
 
-	if (PX4_OK != orb_publish(ORB_ID(orb_multitest), pfd1, &t)) {
+	if (PX4_OK != orb_publish(ORB_ID(orb_multitest), _pfd[1], &t)) {
 		return test_fail("mult. pub1 fail");
 	}
 
@@ -376,12 +420,17 @@ int uORBTest::UnitTest::pub_test_multi2_main()
 	usleep(100 * 1000);
 	_thread_should_exit = true;
 
+	for (int i = 0; i < num_instances; ++i) {
+		orb_unadvertise(orb_pub[i]);
+	}
+
 	return 0;
 }
 
 int uORBTest::UnitTest::test_multi2()
 {
 
+	test_note("Testing multi-topic 2 test (queue simulation)");
 	//test: first subscribe, then advertise
 
 	_thread_should_exit = false;
@@ -456,11 +505,11 @@ int uORBTest::UnitTest::test_multi_reversed()
 
 	int instance2;
 
-	orb_advert_t pfd2 = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance2, ORB_PRIO_MAX);
+	_pfd[2] = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance2, ORB_PRIO_MAX);
 
 	int instance3;
 
-	orb_advert_t pfd3 = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance3, ORB_PRIO_MIN);
+	_pfd[3] = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance3, ORB_PRIO_MIN);
 
 	test_note("advertised");
 
@@ -474,14 +523,14 @@ int uORBTest::UnitTest::test_multi_reversed()
 
 	t.val = 204;
 
-	if (PX4_OK != orb_publish(ORB_ID(orb_multitest), pfd2, &t)) {
+	if (PX4_OK != orb_publish(ORB_ID(orb_multitest), _pfd[2], &t)) {
 		return test_fail("mult. pub0 fail");
 	}
 
 
 	t.val = 304;
 
-	if (PX4_OK != orb_publish(ORB_ID(orb_multitest), pfd3, &t)) {
+	if (PX4_OK != orb_publish(ORB_ID(orb_multitest), _pfd[3], &t)) {
 		return test_fail("mult. pub1 fail");
 	}
 

--- a/src/modules/uORB/uORBTest_UnitTest.hpp
+++ b/src/modules/uORB/uORBTest_UnitTest.hpp
@@ -93,6 +93,9 @@ private:
 	bool pubsubtest_print;
 	int pubsubtest_res = OK;
 
+	int test_unadvertise();
+	orb_advert_t _pfd[4]; ///< used for test_multi and test_multi_reversed
+
 	int test_single();
 	int test_multi();
 	int test_multi2();
@@ -145,6 +148,8 @@ int uORBTest::UnitTest::latency_test(orb_id_t T, bool print)
 	if (pubsub_task < 0) {
 		return test_fail("failed launching task");
 	}
+
+	orb_unadvertise(pfd0);
 
 	return pubsubtest_res;
 }


### PR DESCRIPTION
Makes it possible to undo an orb advertisement, necessary eg. for some multi-instance topic scenarios.

Note that it does not free the underlying DeviceNode resources, as there could still be other publishers & subscribers. But there is also no leak, as future advertisers will just re-use an existing DeviceNode.

Extended unit tests for that, and as a side-effect, `uorb test` can now be called multiple times w/o failing the second time.