### PR TITLE
Move cpu load out of vehicle_status (cherry-picked)

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -331,6 +331,11 @@ then
 	fi
 
 	#
+	# Start CPU load monitor
+	#
+	load_mon start
+
+	#
 	# Start primary output
 	#
 	set TTYS1_BUSY no

--- a/cmake/configs/nuttx_px4fmu-v1_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v1_default.cmake
@@ -61,6 +61,7 @@ set(config_module_list
 	# General system control
 	#
 	modules/commander
+	modules/load_mon
 	modules/navigator
 	modules/mavlink
 	modules/gpio_led

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -72,6 +72,7 @@ set(config_module_list
 	# General system control
 	#
 	modules/commander
+	modules/load_mon
 	modules/navigator
 	modules/mavlink
 	modules/gpio_led

--- a/cmake/configs/nuttx_px4fmu-v2_ekf2.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_ekf2.cmake
@@ -69,6 +69,7 @@ set(config_module_list
 	# General system control
 	#
 	modules/commander
+	modules/load_mon
 	modules/navigator
 	modules/mavlink
 	modules/gpio_led

--- a/cmake/configs/nuttx_px4fmu-v4_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v4_default.cmake
@@ -70,6 +70,7 @@ set(config_module_list
 	# General system control
 	#
 	modules/commander
+	modules/load_mon
 	modules/navigator
 	modules/mavlink
 	modules/gpio_led

--- a/cmake/configs/posix_eagle_hil.cmake
+++ b/cmake/configs/posix_eagle_hil.cmake
@@ -29,6 +29,7 @@ set(config_module_list
 	modules/sdlog2
 	modules/simulator
 	modules/commander
+	modules/load_mon
 
 	lib/mathlib
 	lib/mathlib/math/filter

--- a/cmake/configs/posix_rpi2_default.cmake
+++ b/cmake/configs/posix_rpi2_default.cmake
@@ -32,6 +32,7 @@ set(config_module_list
 	modules/dataman
 	modules/sdlog2
 	modules/commander
+	modules/load_mon
 	lib/controllib
 	lib/mathlib
 	lib/mathlib/math/filter

--- a/cmake/configs/posix_rpi2_release.cmake
+++ b/cmake/configs/posix_rpi2_release.cmake
@@ -4,7 +4,7 @@ if ("${RPI_TOOLCHAIN_DIR}" STREQUAL "")
 	set(RPI_TOOLCHAIN_DIR /opt/rpi_toolchain)
 endif()
 
-set(CMAKE_PROGRAM_PATH 
+set(CMAKE_PROGRAM_PATH
 	"${RPI_TOOLCHAIN_DIR}/gcc-linaro-arm-linux-gnueabihf-raspbian/bin"
 	${CMAKE_PROGRAM_PATH}
 	)
@@ -41,6 +41,7 @@ set(config_module_list
 	modules/dataman
 	modules/sdlog2
 	modules/commander
+	modules/load_mon
 	lib/controllib
 	lib/mathlib
 	lib/mathlib/math/filter

--- a/cmake/configs/posix_sdflight_default.cmake
+++ b/cmake/configs/posix_sdflight_default.cmake
@@ -40,6 +40,7 @@ set(config_module_list
 	modules/sdlog2
 	modules/simulator
 	modules/commander
+	modules/load_mon
 
 	lib/controllib
 	lib/mathlib

--- a/cmake/configs/posix_sitl_default.cmake
+++ b/cmake/configs/posix_sitl_default.cmake
@@ -51,6 +51,7 @@ set(config_module_list
 	modules/dataman
 	modules/sdlog2
 	modules/commander
+	modules/load_mon
 	lib/controllib
 	lib/mathlib
 	lib/mathlib/math/filter

--- a/cmake/configs/posix_sitl_ekf2.cmake
+++ b/cmake/configs/posix_sitl_ekf2.cmake
@@ -49,6 +49,7 @@ set(config_module_list
 	modules/dataman
 	modules/sdlog2
 	modules/commander
+	modules/load_mon
 	lib/controllib
 	lib/mathlib
 	lib/mathlib/math/filter

--- a/cmake/configs/qurt_eagle_hil.cmake
+++ b/cmake/configs/qurt_eagle_hil.cmake
@@ -48,6 +48,7 @@ set(config_module_list
 	modules/systemlib/mixer
 	modules/uORB
 	modules/commander
+	modules/load_mon
 
 	#
 	# Libraries

--- a/cmake/configs/qurt_eagle_legacy_driver_default.cmake
+++ b/cmake/configs/qurt_eagle_legacy_driver_default.cmake
@@ -58,6 +58,7 @@ set(config_module_list
 	modules/uORB
 	modules/commander
 	modules/land_detector
+	modules/load_mon
 
 	#
 	# PX4 drivers

--- a/cmake/configs/qurt_eagle_travis.cmake
+++ b/cmake/configs/qurt_eagle_travis.cmake
@@ -55,6 +55,7 @@ set(config_module_list
 	modules/systemlib/mixer
 	modules/uORB
 	modules/commander
+	modules/load_mon
 
 	#
 	# Libraries

--- a/cmake/configs/qurt_sdflight_default.cmake
+++ b/cmake/configs/qurt_sdflight_default.cmake
@@ -55,6 +55,7 @@ set(config_module_list
 	modules/uORB
 	modules/commander
 	modules/land_detector
+	modules/load_mon
 
 	#
 	# PX4 drivers

--- a/msg/cpuload.msg
+++ b/msg/cpuload.msg
@@ -1,0 +1,2 @@
+uint64 timestamp                # in microseconds since system start, is set whenever the writing thread stores new data
+float32 load                    # processor load from 0 to 1

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -70,6 +70,3 @@ bool mission_failure				# Set to true if mission could not continue/finish
 uint32 onboard_control_sensors_present
 uint32 onboard_control_sensors_enabled
 uint32 onboard_control_sensors_health
-
-float32 load					# processor load from 0 to 1
-

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -133,8 +133,6 @@
 #endif
 static const int ERROR = -1;
 
-extern struct system_load_s system_load;
-
 static constexpr uint8_t COMMANDER_MAX_GPS_NOISE = 60;		/**< Maximum percentage signal to noise ratio allowed for GPS reception */
 
 /* Decouple update interval and hysteris counters, all depends on intervals */

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2872,6 +2872,7 @@ check_valid(hrt_abstime timestamp, hrt_abstime timeout, bool valid_in, bool *val
 	}
 }
 
+void
 control_status_leds(vehicle_status_s *status_local, const actuator_armed_s *actuator_armed, bool changed, battery_status_s *battery, const cpuload_s *cpuload_local)
 {
 	/* driving rgbled */

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -256,7 +256,7 @@ bool handle_command(struct vehicle_status_s *status, const struct safety_s *safe
 int commander_thread_main(int argc, char *argv[]);
 
 void control_status_leds(vehicle_status_s *status_local, const actuator_armed_s *actuator_armed, bool changed,
-			 battery_status_s *battery, const cpuload_s *cpuload_local);
+			 battery_status_s *battery_local, const cpuload_s *cpuload_local);
 
 void get_circuit_breaker_params();
 
@@ -2873,7 +2873,7 @@ check_valid(hrt_abstime timestamp, hrt_abstime timeout, bool valid_in, bool *val
 }
 
 void
-control_status_leds(vehicle_status_s *status_local, const actuator_armed_s *actuator_armed, bool changed, battery_status_s *battery, const cpuload_s *cpuload_local)
+control_status_leds(vehicle_status_s *status_local, const actuator_armed_s *actuator_armed, bool changed, battery_status_s *battery_local, const cpuload_s *cpuload_local)
 {
 	/* driving rgbled */
 	if (changed) {
@@ -2906,9 +2906,9 @@ control_status_leds(vehicle_status_s *status_local, const actuator_armed_s *actu
 			/* set color */
 			if (status.failsafe) {
 				rgbled_set_color(RGBLED_COLOR_PURPLE);
-			} else if (battery_status->warning == battery_status_s::BATTERY_WARNING_LOW) {
+			} else if (battery_local->warning == battery_status_s::BATTERY_WARNING_LOW) {
 				rgbled_set_color(RGBLED_COLOR_AMBER);
-			} else if (battery_status->warning == battery_status_s::BATTERY_WARNING_CRITICAL) {
+			} else if (battery_local->warning == battery_status_s::BATTERY_WARNING_CRITICAL) {
 				rgbled_set_color(RGBLED_COLOR_RED);
 			} else {
 				if (status_flags.condition_home_position_valid && status_flags.condition_global_position_valid) {

--- a/src/modules/load_mon/CMakeLists.txt
+++ b/src/modules/load_mon/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2016 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,4 +39,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/load_mon/CMakeLists.txt
+++ b/src/modules/load_mon/CMakeLists.txt
@@ -1,0 +1,42 @@
+############################################################################
+#
+#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+px4_add_module(
+	MODULE modules__load_mon
+	MAIN load_mon
+	STACK 1200
+	SRCS
+		load_mon.cpp
+	DEPENDS
+		platforms__common
+	)
+# vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/modules/load_mon/load_mon.cpp
+++ b/src/modules/load_mon/load_mon.cpp
@@ -1,0 +1,174 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file load_mon.c
+ *
+ * @author Jonathan Challinger <jonathan@3drobotics.com>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <poll.h>
+
+#include <px4_config.h>
+
+#include <drivers/drv_hrt.h>
+
+#include <systemlib/systemlib.h>
+#include <systemlib/err.h>
+#include <systemlib/cpuload.h>
+
+#include <uORB/uORB.h>
+#include <uORB/topics/cpuload.h>
+
+#define LOAD_MON_INTERVAL_SEC 1.0f
+#define LOAD_MON_INTERVAL_US (LOAD_MON_INTERVAL_SEC*1.0e6f)
+
+extern "C" __EXPORT int load_mon_main(int argc, char *argv[]);
+int load_mon_thread(int argc, char *argv[]);
+
+static const char *module_name = "load_mon";
+static bool thread_should_exit = false;		/**< daemon exit flag */
+static bool thread_running = false;		/**< daemon status flag */
+static int daemon_task;				/**< Handle of daemon task / thread */
+
+
+extern struct system_load_s system_load;
+struct cpuload_s cpuload;
+static orb_advert_t cpuload_publish_handle = nullptr;
+
+/**
+ * Mainloop of load_mon.
+ */
+int load_mon_thread(int argc, char *argv[])
+{
+	warnx("[%s] starting\n", module_name);
+	thread_running = true;
+
+	hrt_abstime last_idle_time = system_load.tasks[0].total_runtime;
+
+	while (!thread_should_exit) {
+		usleep(LOAD_MON_INTERVAL_US);
+
+		/* compute system load */
+		uint64_t interval_idletime = system_load.tasks[0].total_runtime - last_idle_time;
+		last_idle_time = system_load.tasks[0].total_runtime;
+
+		cpuload.timestamp = hrt_absolute_time();
+		cpuload.load = 1.0f - (float)interval_idletime / LOAD_MON_INTERVAL_US;
+
+		if (cpuload_publish_handle == nullptr) {
+			cpuload_publish_handle = orb_advertise(ORB_ID(cpuload), &cpuload);
+		} else {
+			orb_publish(ORB_ID(cpuload), cpuload_publish_handle, &cpuload);
+		}
+	}
+
+	warnx("[%s] exiting.\n", module_name);
+
+	thread_running = false;
+
+	return 0;
+}
+
+/**
+ * Print the correct usage.
+ */
+static void usage(const char *reason);
+
+static void
+usage(const char *reason)
+{
+	if (reason) {
+		warnx("%s\n", reason);
+	}
+
+	warnx("usage: %s {start|stop|status} [-p <additional params>]\n\n", module_name);
+}
+
+/**
+ * The daemon app only briefly exists to start
+ * the background job. The stack size assigned in the
+ * Makefile does only apply to this management task.
+ *
+ * The actual stack size should be set in the call
+ * to task_create().
+ */
+int load_mon_main(int argc, char *argv[])
+{
+	if (argc < 2) {
+		usage("missing command");
+		return 1;
+	}
+
+	if (!strcmp(argv[1], "start")) {
+
+		if (thread_running) {
+			warnx("daemon already running\n");
+			/* this is not an error */
+			return 0;
+		}
+
+		thread_should_exit = false;
+		daemon_task = px4_task_spawn_cmd(module_name,
+						 SCHED_DEFAULT,
+						 SCHED_PRIORITY_DEFAULT,
+						 2000,
+						 load_mon_thread,
+						 (argv) ? (char *const *)&argv[2] : (char *const *)NULL);
+		return 0;
+	}
+
+	if (!strcmp(argv[1], "stop")) {
+		thread_should_exit = true;
+		return 0;
+	}
+
+	if (!strcmp(argv[1], "status")) {
+		if (thread_running) {
+			warnx("\trunning\n");
+		} else {
+			warnx("\tnot started\n");
+		}
+
+		return 0;
+	}
+
+	usage("unrecognized command");
+	return 1;
+}
+

--- a/src/modules/load_mon/load_mon.cpp
+++ b/src/modules/load_mon/load_mon.cpp
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 /**
- * @file load_mon.c
+ * @file load_mon.cpp
  *
  * @author Jonathan Challinger <jonathan@3drobotics.com>
  */

--- a/src/modules/load_mon/load_mon.cpp
+++ b/src/modules/load_mon/load_mon.cpp
@@ -45,6 +45,7 @@
 
 #include <px4_config.h>
 #include <px4_workqueue.h>
+#include <px4_defines.h>
 
 #include <drivers/drv_hrt.h>
 

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -575,7 +575,7 @@ public:
 
 private:
 	MavlinkOrbSubscription *_status_sub;
-    MavlinkOrbSubscription *_cpuload_sub;
+	MavlinkOrbSubscription *_cpuload_sub;
 	MavlinkOrbSubscription *_battery_status_sub;
 
 	/* do not allow top copying this class */

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1195,6 +1195,8 @@ int sdlog2_thread_main(int argc, char *argv[])
 			struct log_GPS_s log_GPS;
 			struct log_ATTC_s log_ATTC;
 			struct log_STAT_s log_STAT;
+			struct log_LOAD_s log_LOAD;
+			struct log_COMM_s log_COMM;
 			struct log_VTOL_s log_VTOL;
 			struct log_RC_s log_RC;
 			struct log_OUT_s log_OUT;
@@ -1472,6 +1474,24 @@ int sdlog2_thread_main(int argc, char *argv[])
 			log_msg.body.log_STAT.arming_state = buf_status.arming_state;
 			log_msg.body.log_STAT.failsafe = (uint8_t) buf_status.failsafe;
 			LOGBUFFER_WRITE_AND_COUNT(STAT);
+		}
+
+		/* --- COMMANDER INTERNAL STATE --- */
+		bool commander_state_updated = copy_if_updated(ORB_ID(commander_state), &subs.commander_state_sub,
+							       &buf.commander_state);
+
+		if (commander_state_updated) {
+			log_msg.msg_type = LOG_COMM_MSG;
+			log_msg.body.log_COMM.main_state = buf.commander_state.main_state;
+			LOGBUFFER_WRITE_AND_COUNT(COMM);
+		}
+
+
+		bool cpuload_updated = copy_if_updated(ORB_ID(cpuload), &subs.cpuload_sub, &buf.cpuload);
+		if (cpuload_updated) {
+			log_msg.msg_type = LOG_LOAD_MSG;
+			log_msg.body.log_LOAD.cpu_load = buf.cpuload.load;
+			LOGBUFFER_WRITE_AND_COUNT(LOAD);
 		}
 
 		/* --- EKF2 REPLAY --- */

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -115,6 +115,7 @@
 #include <uORB/topics/ekf2_replay.h>
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/commander_state.h>
+#include <uORB/topics/cpuload.h>
 
 #include <systemlib/systemlib.h>
 #include <systemlib/param/param.h>
@@ -1174,6 +1175,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 		struct camera_trigger_s camera_trigger;
 		struct ekf2_replay_s replay;
 		struct vehicle_land_detected_s land_detected;
+		struct cpuload_s cpuload;
 	} buf;
 
 	memset(&buf, 0, sizeof(buf));
@@ -1282,6 +1284,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 		int replay_sub;
 		int land_detected_sub;
 		int commander_state_sub;
+		int cpuload_sub;
 	} subs;
 
 	subs.cmd_sub = -1;
@@ -1323,6 +1326,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 	subs.replay_sub = -1;
 	subs.land_detected_sub = -1;
 	subs.commander_state_sub = -1;
+	subs.cpuload_sub = -1;
 
 	/* add new topics HERE */
 
@@ -1467,7 +1471,6 @@ int sdlog2_thread_main(int argc, char *argv[])
 			log_msg.body.log_STAT.nav_state = buf_status.nav_state;
 			log_msg.body.log_STAT.arming_state = buf_status.arming_state;
 			log_msg.body.log_STAT.failsafe = (uint8_t) buf_status.failsafe;
-			log_msg.body.log_STAT.load = buf_status.load;
 			LOGBUFFER_WRITE_AND_COUNT(STAT);
 		}
 
@@ -2181,6 +2184,14 @@ int sdlog2_thread_main(int argc, char *argv[])
 			log_msg.msg_type = LOG_LAND_MSG;
 			log_msg.body.log_LAND.landed = buf.land_detected.landed;
 			LOGBUFFER_WRITE_AND_COUNT(LAND);
+		}
+
+		/* --- LOAD --- */
+		if (copy_if_updated(ORB_ID(cpuload), &subs.cpuload_sub, &buf.cpuload)) {
+			log_msg.msg_type = LOG_LOAD_MSG;
+			log_msg.body.log_LOAD.cpu = buf.load.cpu;
+			LOGBUFFER_WRITE_AND_COUNT(LOAD);
+
 		}
 
 		pthread_mutex_lock(&logbuffer_mutex);

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1195,8 +1195,6 @@ int sdlog2_thread_main(int argc, char *argv[])
 			struct log_GPS_s log_GPS;
 			struct log_ATTC_s log_ATTC;
 			struct log_STAT_s log_STAT;
-			struct log_LOAD_s log_LOAD;
-			struct log_COMM_s log_COMM;
 			struct log_VTOL_s log_VTOL;
 			struct log_RC_s log_RC;
 			struct log_OUT_s log_OUT;
@@ -1237,6 +1235,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 			struct log_RPL4_s log_RPL4;
 			struct log_RPL6_s log_RPL6;
 			struct log_LAND_s log_LAND;
+			struct log_LOAD_s log_LOAD;
 		} body;
 	} log_msg = {
 		LOG_PACKET_HEADER_INIT(0)
@@ -1474,24 +1473,6 @@ int sdlog2_thread_main(int argc, char *argv[])
 			log_msg.body.log_STAT.arming_state = buf_status.arming_state;
 			log_msg.body.log_STAT.failsafe = (uint8_t) buf_status.failsafe;
 			LOGBUFFER_WRITE_AND_COUNT(STAT);
-		}
-
-		/* --- COMMANDER INTERNAL STATE --- */
-		bool commander_state_updated = copy_if_updated(ORB_ID(commander_state), &subs.commander_state_sub,
-							       &buf.commander_state);
-
-		if (commander_state_updated) {
-			log_msg.msg_type = LOG_COMM_MSG;
-			log_msg.body.log_COMM.main_state = buf.commander_state.main_state;
-			LOGBUFFER_WRITE_AND_COUNT(COMM);
-		}
-
-
-		bool cpuload_updated = copy_if_updated(ORB_ID(cpuload), &subs.cpuload_sub, &buf.cpuload);
-		if (cpuload_updated) {
-			log_msg.msg_type = LOG_LOAD_MSG;
-			log_msg.body.log_LOAD.cpu_load = buf.cpuload.load;
-			LOGBUFFER_WRITE_AND_COUNT(LOAD);
 		}
 
 		/* --- EKF2 REPLAY --- */
@@ -2209,7 +2190,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 		/* --- LOAD --- */
 		if (copy_if_updated(ORB_ID(cpuload), &subs.cpuload_sub, &buf.cpuload)) {
 			log_msg.msg_type = LOG_LOAD_MSG;
-			log_msg.body.log_LOAD.cpu = buf.load.cpu;
+			log_msg.body.log_LOAD.cpu_load = buf.cpuload.load;
 			LOGBUFFER_WRITE_AND_COUNT(LOAD);
 
 		}

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -177,6 +177,7 @@ struct log_ATTC_s {
 /* --- STAT - VEHICLE STATE --- */
 #define LOG_STAT_MSG 10
 struct log_STAT_s {
+	uint8_t main_state;
 	uint8_t nav_state;
 	uint8_t arming_state;
 	uint8_t failsafe;
@@ -607,12 +608,6 @@ struct log_LOAD_s {
 	float cpu_load;
 };
 
-/* --- COMMANDER INTERNAL STATE --- */
-#define LOG_COMM_MSG 59
-struct log_COMM_s {
-	uint8_t main_state;
-};
-
 /********** SYSTEM MESSAGES, ID > 0x80 **********/
 
 /* --- TIME - TIME STAMP --- */
@@ -654,7 +649,7 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT(GPS, "QBffLLfffffBHHH",	"GPSTime,Fix,EPH,EPV,Lat,Lon,Alt,VelN,VelE,VelD,Cog,nSat,SNR,N,J"),
 	LOG_FORMAT_S(ATTC, ATTC, "ffff",		"Roll,Pitch,Yaw,Thrust"),
 	LOG_FORMAT_S(ATC1, ATTC, "ffff",		"Roll,Pitch,Yaw,Thrust"),
-	LOG_FORMAT(STAT, "BBB",		"NavState,ArmS,Failsafe"),
+	LOG_FORMAT(STAT, "BBBB",		"MainState,NavState,ArmS,Failsafe"),
 	LOG_FORMAT(VTOL, "fBBB",		"Arsp,RwMode,TransMode,Failsafe"),
 	LOG_FORMAT(CTS, "fffffff", "Vx_b,Vy_b,Vz_b,Vinf,P,Q,R"),
 	LOG_FORMAT(RC, "ffffffffffffBBBL",		"C0,C1,C2,C3,C4,C5,C6,C7,C8,C9,C10,C11,RSSI,CNT,Lost,Drop"),
@@ -700,7 +695,6 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT(RPL6, "Qfffff", "Tasp,inAsp,trAsp,ufAsp,tpAsp,confAsp"),
 	LOG_FORMAT(LAND, "B", "Landed"),
 	LOG_FORMAT(LOAD, "f", "CPU"),
-	LOG_FORMAT(COMM, "B", "MainState"),
 	/* system-level messages, ID >= 0x80 */
 	/* FMT: don't write format of format message, it's useless */
 	LOG_FORMAT(TIME, "Q", "StartTime"),

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -177,11 +177,9 @@ struct log_ATTC_s {
 /* --- STAT - VEHICLE STATE --- */
 #define LOG_STAT_MSG 10
 struct log_STAT_s {
-	uint8_t main_state;
 	uint8_t nav_state;
 	uint8_t arming_state;
 	uint8_t failsafe;
-	float load;
 };
 
 /* --- RC - RC INPUT CHANNELS --- */
@@ -597,9 +595,22 @@ struct log_CAMT_s {
 	uint32_t seq;
 };
 
+/* --- LAND DETECTOR --- */
 #define LOG_LAND_MSG 57
 struct log_LAND_s {
 	uint8_t landed;
+};
+
+/* --- SYSTEM LOAD --- */
+#define LOG_LOAD_MSG 58
+struct log_LOAD_s {
+	float cpu_load;
+};
+
+/* --- COMMANDER INTERNAL STATE --- */
+#define LOG_COMM_MSG 59
+struct log_COMM_s {
+	uint8_t main_state;
 };
 
 /********** SYSTEM MESSAGES, ID > 0x80 **********/
@@ -643,7 +654,7 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT(GPS, "QBffLLfffffBHHH",	"GPSTime,Fix,EPH,EPV,Lat,Lon,Alt,VelN,VelE,VelD,Cog,nSat,SNR,N,J"),
 	LOG_FORMAT_S(ATTC, ATTC, "ffff",		"Roll,Pitch,Yaw,Thrust"),
 	LOG_FORMAT_S(ATC1, ATTC, "ffff",		"Roll,Pitch,Yaw,Thrust"),
-	LOG_FORMAT(STAT, "BBBBf",		"MainState,NavState,ArmS,Failsafe,Load"),
+	LOG_FORMAT(STAT, "BBB",		"NavState,ArmS,Failsafe"),
 	LOG_FORMAT(VTOL, "fBBB",		"Arsp,RwMode,TransMode,Failsafe"),
 	LOG_FORMAT(CTS, "fffffff", "Vx_b,Vy_b,Vz_b,Vinf,P,Q,R"),
 	LOG_FORMAT(RC, "ffffffffffffBBBL",		"C0,C1,C2,C3,C4,C5,C6,C7,C8,C9,C10,C11,RSSI,CNT,Lost,Drop"),
@@ -688,6 +699,8 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT(RPL4, "Qf", "Trng,rng"),
 	LOG_FORMAT(RPL6, "Qfffff", "Tasp,inAsp,trAsp,ufAsp,tpAsp,confAsp"),
 	LOG_FORMAT(LAND, "B", "Landed"),
+	LOG_FORMAT(LOAD, "f", "CPU"),
+	LOG_FORMAT(COMM, "B", "MainState"),
 	/* system-level messages, ID >= 0x80 */
 	/* FMT: don't write format of format message, it's useless */
 	LOG_FORMAT(TIME, "Q", "StartTime"),

--- a/src/modules/uORB/objects_common.cpp
+++ b/src/modules/uORB/objects_common.cpp
@@ -300,3 +300,6 @@ ORB_DEFINE(gps_inject_data, struct gps_inject_data_s);
 
 #include "topics/adc_report.h"
 ORB_DEFINE(adc_report, struct adc_report_s);
+
+#include "topics/cpuload.h"
+ORB_DEFINE(cpuload, struct cpuload_s);


### PR DESCRIPTION
These are the cherry-picked commits from #3882.

The load computation is moved out of vehicle status and the commander.

Still to do:
- [x]  Move it to the work queue instead of its own task