### PR TITLE
Added support for external shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,7 +360,7 @@ foreach(module ${config_module_list})
 endforeach()
 
 # Keep track of external shared libs required for modules
-set(module_shared_libraries "${module_shared_libraries}" CACHE INTERNAL "module_shared_libraries")
+set(module_external_libraries "${module_external_libraries}" CACHE INTERNAL "module_external_libraries")
 
 add_subdirectory(src/firmware/${OS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,9 @@ foreach(module ${config_module_list})
 	#message(STATUS "adding module: ${module}")
 endforeach()
 
+# Keep track of external shared libs required for modules
+set(module_shared_libraries "${module_shared_libraries}" CACHE INTERNAL "module_shared_libraries")
+
 add_subdirectory(src/firmware/${OS})
 
 add_subdirectory(src/lib/DriverFramework/framework/src)

--- a/src/firmware/qurt/CMakeLists.txt
+++ b/src/firmware/qurt/CMakeLists.txt
@@ -35,6 +35,7 @@ else()
 	message("module_libraries = ${module_libraries}")
 	message("target_libraries = ${target_libraries}")
 	message("df_driver_libs = ${df_driver_libs}")
+	message("module_external_libraries = ${module_external_libraries}")
 	# Generate the DSP lib and stubs but not the apps side executable
 	# The Apps side executable is generated via the posix_eagle_xxxx target
 	QURT_LIB(LIB_NAME mainapp
@@ -47,6 +48,7 @@ else()
 			df_driver_framework
 			${df_driver_libs}
 			m
+			${module_external_libraries}
 		)
 
 	px4_add_adb_push(OUT upload


### PR DESCRIPTION
The FC_ADDON drivers are shared libraries that have PX4 wrappers.
The wrappers are built as modules which are static libraries and
cannot have shared library dependencies.

The shared libraries are required to resolve the symbols at runtime
and need to be linked with the libmainapp shared library.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>