### PR TITLE
Hotfix for issue #4408 - FrSky D-Port Telemetry broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,11 @@ CMakeLists.txt.user
 GPATH
 GRTAGS
 GTAGS
+*.config
+*.creator
+*.creator.user
+*.files
+*.includes
 
 # uavcan firmware
 ROMFS/px4fmu_common/uavcan/

--- a/src/drivers/frsky_telemetry/frsky_data.c
+++ b/src/drivers/frsky_telemetry/frsky_data.c
@@ -53,7 +53,6 @@
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/sensor_combined.h>
 #include <uORB/topics/vehicle_global_position.h>
-#include <uORB/topics/vehicle_status.h>
 
 #include <drivers/drv_hrt.h>
 
@@ -94,12 +93,10 @@
 
 static struct battery_status_s *battery_status;
 static struct vehicle_global_position_s *global_pos;
-static struct vehicle_status_s *vehicle_status;
 static struct sensor_combined_s *sensor_combined;
 
 static int battery_status_sub = -1;
 static int vehicle_global_position_sub = -1;
-static int vehicle_status_sub = -1;
 static int sensor_sub = -1;
 
 /**
@@ -110,15 +107,13 @@ bool frsky_init()
 	battery_status = malloc(sizeof(struct battery_status_s));
 	global_pos = malloc(sizeof(struct vehicle_global_position_s));
 	sensor_combined = malloc(sizeof(struct sensor_combined_s));
-	vehicle_status = malloc(sizeof(struct vehicle_status_s));
 
-	if (battery_status == NULL || global_pos == NULL || sensor_combined == NULL || vehicle_status) {
+	if (battery_status == NULL || global_pos == NULL || sensor_combined == NULL) {
 		return false;
 	}
 
 	battery_status_sub = orb_subscribe(ORB_ID(battery_status));
 	vehicle_global_position_sub = orb_subscribe(ORB_ID(vehicle_global_position));
-	vehicle_status_sub = orb_subscribe(ORB_ID(vehicle_status));
 	sensor_sub = orb_subscribe(ORB_ID(sensor_combined));
 	return true;
 }
@@ -128,7 +123,6 @@ void frsky_deinit()
 	free(battery_status);
 	free(global_pos);
 	free(sensor_combined);
-	free(vehicle_status);
 }
 
 /**
@@ -200,13 +194,6 @@ void frsky_update_topics()
 
 	if (updated) {
 		orb_copy(ORB_ID(vehicle_global_position), vehicle_global_position_sub, global_pos);
-	}
-
-	/* get a local copy of the vehicle status data */
-	orb_check(vehicle_status_sub, &updated);
-
-	if (updated) {
-		orb_copy(ORB_ID(vehicle_status), vehicle_status_sub, vehicle_status);
 	}
 }
 


### PR DESCRIPTION
As mentioned [here](https://github.com/PX4/Firmware/issues/4408), FrSky D-Port Telemetry seems broken. I think this is because I forgot a ```== NULL``` here: https://github.com/PX4/Firmware/pull/4349/files#diff-9575f7679f3a9e8589bccdb130c400d3R115.

This PR corrects this, and removes the unnecessary reference to vehicle_status.