### PR TITLE
Only add DriverFramework for targets using it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,13 +333,16 @@ execute_process(COMMAND cmake -E make_directory ${ep_base}/Install/include)
 #=============================================================================
 # DriverFramework Drivers
 #
-#message("ADDING DRIVERS")
 set(df_driver_libs)
-foreach(driver ${config_df_driver_list})
-	add_subdirectory(src/lib/DriverFramework/drivers/${driver})
-	list(APPEND df_driver_libs df_${driver})
-	message("adding driver: ${driver}")
-endforeach()
+if(NOT "${config_df_driver_list}" STREQUAL "")
+	add_subdirectory(src/lib/DriverFramework/framework/src)
+
+	foreach(driver ${config_df_driver_list})
+		add_subdirectory(src/lib/DriverFramework/drivers/${driver})
+		list(APPEND df_driver_libs df_${driver})
+		message("Adding DF driver: ${driver}")
+	endforeach()
+endif()
 
 #=============================================================================
 # subdirectories
@@ -360,8 +363,6 @@ foreach(module ${config_module_list})
 endforeach()
 
 add_subdirectory(src/firmware/${OS})
-
-add_subdirectory(src/lib/DriverFramework/framework/src)
 
 #add_dependencies(df_driver_framework nuttx_export_${CONFIG}.stamp)
 if (NOT "${OS}" STREQUAL "nuttx")


### PR DESCRIPTION
DriverFramework is not a PX4 module so it cannot be included
as a lib in the config.

Not all targets use DriverFramework so it should not be included
for all targets. This change only adds the DriverFramework dir
if DF drivers are specified in the config file of the target
being built.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>