### PR TITLE
Use DriverFramework as a PX4 module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,16 +150,6 @@ list(GET config_args 1 BOARD)
 list(GET config_args 2 LABEL)
 set(target_name "${OS}-${BOARD}-${LABEL}")
 
-if("${OS}" STREQUAL "posix")
-	if (APPLE)
-		set(DF_TARGET darwin)
-	else()
-		set(DF_TARGET linux)
-	endif()
-else()
-	set(DF_TARGET ${OS})
-endif()
-
 message(STATUS "${target_name}")
 
 # switch to ros CMake file if building ros

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,13 +334,11 @@ execute_process(COMMAND cmake -E make_directory ${ep_base}/Install/include)
 # DriverFramework Drivers
 #
 set(df_driver_libs)
-if(NOT "${config_df_driver_list}" STREQUAL "")
-	foreach(driver ${config_df_driver_list})
-		add_subdirectory(src/lib/DriverFramework/drivers/${driver})
-		list(APPEND df_driver_libs df_${driver})
-		message("Adding DF driver: ${driver}")
-	endforeach()
-endif()
+foreach(driver ${config_df_driver_list})
+	add_subdirectory(src/lib/DriverFramework/drivers/${driver})
+	list(APPEND df_driver_libs df_${driver})
+	message("Adding DF driver: ${driver}")
+endforeach()
 
 #=============================================================================
 # subdirectories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,13 +333,14 @@ execute_process(COMMAND cmake -E make_directory ${ep_base}/Install/include)
 #=============================================================================
 # DriverFramework Drivers
 #
-#message("ADDING DRIVERS")
 set(df_driver_libs)
-foreach(driver ${config_df_driver_list})
-	add_subdirectory(src/lib/DriverFramework/drivers/${driver})
-	list(APPEND df_driver_libs df_${driver})
-	message("adding driver: ${driver}")
-endforeach()
+if(NOT "${config_df_driver_list}" STREQUAL "")
+	foreach(driver ${config_df_driver_list})
+		add_subdirectory(src/lib/DriverFramework/drivers/${driver})
+		list(APPEND df_driver_libs df_${driver})
+		message("Adding DF driver: ${driver}")
+	endforeach()
+endif()
 
 #=============================================================================
 # subdirectories
@@ -360,8 +361,6 @@ foreach(module ${config_module_list})
 endforeach()
 
 add_subdirectory(src/firmware/${OS})
-
-add_subdirectory(src/lib/DriverFramework/framework/src)
 
 #add_dependencies(df_driver_framework nuttx_export_${CONFIG}.stamp)
 if (NOT "${OS}" STREQUAL "nuttx")

--- a/cmake/configs/nuttx_mindpx-v2_default.cmake
+++ b/cmake/configs/nuttx_mindpx-v2_default.cmake
@@ -130,6 +130,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/runway_takeoff
 	lib/tailsitter_recovery
+	lib/DriverFramework/framework
 	platforms/nuttx
 
 	# had to add for cmake, not sure why wasn't in original config

--- a/cmake/configs/nuttx_px4-stm32f4discovery_default.cmake
+++ b/cmake/configs/nuttx_px4-stm32f4discovery_default.cmake
@@ -43,6 +43,7 @@ set(config_module_list
 	lib/external_lgpl
 	lib/geo
 	lib/conversion
+	lib/DriverFramework/framework
 	platforms/nuttx
 
 	# had to add for cmake, not sure why wasn't in original config

--- a/cmake/configs/nuttx_px4fmu-v1_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v1_default.cmake
@@ -115,6 +115,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/runway_takeoff
 	lib/tailsitter_recovery
+	lib/DriverFramework/framework
 	platforms/nuttx
 
 	# had to add for cmake, not sure why wasn't in original config

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -124,6 +124,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/runway_takeoff
 	lib/tailsitter_recovery
+	lib/DriverFramework/framework
 	platforms/nuttx
 
 	# had to add for cmake, not sure why wasn't in original config

--- a/cmake/configs/nuttx_px4fmu-v2_ekf2.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_ekf2.cmake
@@ -123,6 +123,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/runway_takeoff
 	lib/tailsitter_recovery
+	lib/DriverFramework/framework
 	platforms/nuttx
 
 	# had to add for cmake, not sure why wasn't in original config

--- a/cmake/configs/nuttx_px4fmu-v4_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v4_default.cmake
@@ -125,6 +125,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/runway_takeoff
 	lib/tailsitter_recovery
+	lib/DriverFramework/framework
 	platforms/nuttx
 
 	# had to add for cmake, not sure why wasn't in original config

--- a/cmake/configs/posix_eagle_default.cmake
+++ b/cmake/configs/posix_eagle_default.cmake
@@ -55,6 +55,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/runway_takeoff
 	lib/tailsitter_recovery
+	lib/DriverFramework/framework
 
 	platforms/common
 	platforms/posix/px4_layer

--- a/cmake/configs/posix_eagle_hil.cmake
+++ b/cmake/configs/posix_eagle_hil.cmake
@@ -33,6 +33,7 @@ set(config_module_list
 	lib/geo
 	lib/geo_lookup
 	lib/conversion
+	lib/DriverFramework/framework
 
 	platforms/common
 	platforms/posix/px4_layer

--- a/cmake/configs/posix_eagle_legacy_driver_default.cmake
+++ b/cmake/configs/posix_eagle_legacy_driver_default.cmake
@@ -56,6 +56,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/runway_takeoff
 	lib/tailsitter_recovery
+	lib/DriverFramework/framework
 
 	platforms/common
 	platforms/posix/px4_layer

--- a/cmake/configs/posix_eagle_legacy_driver_release.cmake
+++ b/cmake/configs/posix_eagle_legacy_driver_release.cmake
@@ -35,6 +35,7 @@ set(config_module_list
 	lib/geo
 	lib/geo_lookup
 	lib/conversion
+	lib/DriverFramework/framework
 
 	platforms/common
 	platforms/posix/px4_layer

--- a/cmake/configs/posix_eagle_muorb.cmake
+++ b/cmake/configs/posix_eagle_muorb.cmake
@@ -9,6 +9,8 @@ set(config_module_list
 
 	modules/uORB
 
+	lib/DriverFramework/framework
+
 	platforms/posix/px4_layer
 	platforms/posix/work_queue
 

--- a/cmake/configs/posix_eagle_release.cmake
+++ b/cmake/configs/posix_eagle_release.cmake
@@ -29,6 +29,7 @@ set(config_module_list
 	lib/geo
 	lib/geo_lookup
 	lib/conversion
+	lib/DriverFramework/framework
 
 	platforms/common
 	platforms/posix/px4_layer

--- a/cmake/configs/posix_rpi2_default.cmake
+++ b/cmake/configs/posix_rpi2_default.cmake
@@ -44,4 +44,5 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/runway_takeoff
 	lib/tailsitter_recovery
+	lib/DriverFramework/framework
 )

--- a/cmake/configs/posix_rpi2_release.cmake
+++ b/cmake/configs/posix_rpi2_release.cmake
@@ -53,4 +53,5 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/runway_takeoff
 	lib/tailsitter_recovery
+	lib/DriverFramework/framework
 )

--- a/cmake/configs/posix_sitl_broadcast.cmake
+++ b/cmake/configs/posix_sitl_broadcast.cmake
@@ -62,6 +62,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/runway_takeoff
 	lib/tailsitter_recovery
+	lib/DriverFramework/framework
 	examples/px4_simple_app
 	)
 

--- a/cmake/configs/posix_sitl_default.cmake
+++ b/cmake/configs/posix_sitl_default.cmake
@@ -62,6 +62,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/runway_takeoff
 	lib/tailsitter_recovery
+	lib/DriverFramework/framework
 	examples/px4_simple_app
 	)
 

--- a/cmake/configs/posix_sitl_ekf2.cmake
+++ b/cmake/configs/posix_sitl_ekf2.cmake
@@ -61,6 +61,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/runway_takeoff
 	lib/tailsitter_recovery
+	lib/DriverFramework/framework
 	examples/px4_simple_app
 	)
 

--- a/cmake/configs/posix_sitl_replay.cmake
+++ b/cmake/configs/posix_sitl_replay.cmake
@@ -25,6 +25,7 @@ set(config_module_list
 	lib/external_lgpl
 	lib/geo
 	lib/geo_lookup
+	lib/DriverFramework/framework
 	)
 
 set(config_extra_builtin_cmds

--- a/cmake/configs/qurt_eagle_default.cmake
+++ b/cmake/configs/qurt_eagle_default.cmake
@@ -74,6 +74,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/runway_takeoff
 	lib/tailsitter_recovery
+	lib/DriverFramework/framework
 
 	#
 	# QuRT port

--- a/cmake/configs/qurt_eagle_hil.cmake
+++ b/cmake/configs/qurt_eagle_hil.cmake
@@ -59,6 +59,7 @@ set(config_module_list
 	lib/runway_takeoff
 	lib/tailsitter_recovery
 	lib/controllib
+	lib/DriverFramework/framework
 
 	#
 	# QuRT port

--- a/cmake/configs/qurt_eagle_legacy_driver_default.cmake
+++ b/cmake/configs/qurt_eagle_legacy_driver_default.cmake
@@ -77,6 +77,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/runway_takeoff
 	lib/tailsitter_recovery
+	lib/DriverFramework/framework
 
 	#
 	# QuRT port

--- a/cmake/configs/qurt_eagle_legacy_driver_release.cmake
+++ b/cmake/configs/qurt_eagle_legacy_driver_release.cmake
@@ -87,6 +87,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/runway_takeoff
 	lib/tailsitter_recovery
+	lib/DriverFramework/framework
 
 	#
 	# QuRT port

--- a/cmake/configs/qurt_eagle_muorb.cmake
+++ b/cmake/configs/qurt_eagle_muorb.cmake
@@ -33,6 +33,7 @@ set(config_module_list
 	lib/geo
 	lib/geo_lookup
 	lib/conversion
+	lib/DriverFramework/framework
 
 	#
 	# QuRT port

--- a/cmake/configs/qurt_eagle_release.cmake
+++ b/cmake/configs/qurt_eagle_release.cmake
@@ -83,6 +83,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/runway_takeoff
 	lib/tailsitter_recovery
+	lib/DriverFramework/framework
 
 	#
 	# QuRT port

--- a/cmake/configs/qurt_eagle_test.cmake
+++ b/cmake/configs/qurt_eagle_test.cmake
@@ -31,6 +31,7 @@ set(config_module_list
 	lib/mathlib
 	lib/mathlib/math/filter
 	lib/conversion
+	lib/DriverFramework/framework
 
 	#
 	# QuRT port

--- a/cmake/configs/qurt_eagle_travis.cmake
+++ b/cmake/configs/qurt_eagle_travis.cmake
@@ -67,6 +67,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/runway_takeoff
 	lib/tailsitter_recovery
+	lib/DriverFramework/framework
 
 	#
 	# QuRT port

--- a/cmake/nuttx/px4_impl_nuttx.cmake
+++ b/cmake/nuttx/px4_impl_nuttx.cmake
@@ -415,7 +415,6 @@ function(px4_os_add_flags)
 		)
 	set(added_definitions
 		-D__PX4_NUTTX
-		-D__DF_NUTTX
 		)
 	set(added_c_flags
 		-nodefaultlibs
@@ -499,8 +498,6 @@ function(px4_os_add_flags)
 		set(${${var}} ${${${var}}} ${added_${lower_var}} PARENT_SCOPE)
 		#message(STATUS "nuttx: set(${${var}} ${${${var}}} ${added_${lower_var}} PARENT_SCOPE)")
 	endforeach()
-
-	set(DF_TARGET "nuttx" PARENT_SCOPE)
 
 endfunction()
 

--- a/cmake/nuttx/px4_impl_nuttx.cmake
+++ b/cmake/nuttx/px4_impl_nuttx.cmake
@@ -415,6 +415,7 @@ function(px4_os_add_flags)
 		)
 	set(added_definitions
 		-D__PX4_NUTTX
+		-D__DF_NUTTX
 		)
 	set(added_c_flags
 		-nodefaultlibs

--- a/cmake/posix/px4_impl_posix.cmake
+++ b/cmake/posix/px4_impl_posix.cmake
@@ -170,7 +170,6 @@ if(UNIX AND APPLE)
         set(added_definitions
 		-D__PX4_POSIX
 		-D__PX4_DARWIN
-		-D__DF_DARWIN
 		-DCLOCK_MONOTONIC=1
 		-Dnoreturn_function=__attribute__\(\(noreturn\)\)
 		-include ${PX4_INCLUDE_DIR}visibility.h
@@ -185,7 +184,6 @@ else()
         set(added_definitions
 		-D__PX4_POSIX
 		-D__PX4_LINUX
-		-D__DF_LINUX
 		-DCLOCK_MONOTONIC=1
 		-Dnoreturn_function=__attribute__\(\(noreturn\)\)
 		-include ${PX4_INCLUDE_DIR}visibility.h

--- a/cmake/posix/px4_impl_posix.cmake
+++ b/cmake/posix/px4_impl_posix.cmake
@@ -170,6 +170,7 @@ if(UNIX AND APPLE)
         set(added_definitions
 		-D__PX4_POSIX
 		-D__PX4_DARWIN
+		-D__DF_DARWIN
 		-DCLOCK_MONOTONIC=1
 		-Dnoreturn_function=__attribute__\(\(noreturn\)\)
 		-include ${PX4_INCLUDE_DIR}visibility.h
@@ -184,6 +185,7 @@ else()
         set(added_definitions
 		-D__PX4_POSIX
 		-D__PX4_LINUX
+		-D__DF_LINUX
 		-DCLOCK_MONOTONIC=1
 		-Dnoreturn_function=__attribute__\(\(noreturn\)\)
 		-include ${PX4_INCLUDE_DIR}visibility.h

--- a/cmake/qurt/px4_impl_qurt.cmake
+++ b/cmake/qurt/px4_impl_qurt.cmake
@@ -177,8 +177,6 @@ function(px4_os_add_flags)
 	set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 	set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 
-	set(DF_TARGET "qurt" PARENT_SCOPE)
-
 	# output
 	foreach(var ${inout_vars})
 		string(TOLOWER ${var} lower_var)

--- a/src/firmware/nuttx/CMakeLists.txt
+++ b/src/firmware/nuttx/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(firmware_nuttx
 set(nuttx_export_dir ${CMAKE_BINARY_DIR}/${BOARD}/NuttX/nuttx-export)
 
 set(link_libs
-	romfs apps nuttx m gcc df_driver_framework
+	romfs apps nuttx m gcc
 	)
 
 if(NOT ${BOARD} STREQUAL "sim")
@@ -29,6 +29,7 @@ endif()
 target_link_libraries(firmware_nuttx
 	-Wl,--start-group
 	${module_libraries}
+	${df_driver_libs}
 	${config_extra_libs}
 	${link_libs}
 	-Wl,--end-group)

--- a/src/firmware/posix/CMakeLists.txt
+++ b/src/firmware/posix/CMakeLists.txt
@@ -17,17 +17,16 @@ if ("${BOARD}" STREQUAL "eagle")
 		IDL_NAME px4muorb
 		APPS_DEST "/home/linaro"
 		SOURCES
-		px4muorb_stub.c
-		${CMAKE_SOURCE_DIR}/src/platforms/posix/main.cpp
-		apps.h
+			px4muorb_stub.c
+			${CMAKE_SOURCE_DIR}/src/platforms/posix/main.cpp
+			apps.h
 		LINK_LIBS
-		-Wl,--start-group
-		${module_libraries}
-		df_driver_framework
-		${df_driver_libs}
-		${FASTRPC_ARM_LIBS}
-		pthread m rt
-		-Wl,--end-group
+			-Wl,--start-group
+			${module_libraries}
+			${df_driver_libs}
+			${FASTRPC_ARM_LIBS}
+			pthread m rt
+			-Wl,--end-group
 		)
 
 	px4_add_adb_push(OUT upload
@@ -47,7 +46,6 @@ else()
 		target_link_libraries(mainapp
 			-Wl,--start-group
 			${module_libraries}
-			df_driver_framework
 			${df_driver_libs}
 			pthread m rt
 			-Wl,--end-group
@@ -55,7 +53,6 @@ else()
 	else()
 		target_link_libraries(mainapp
 			${module_libraries}
-			df_driver_framework
 			${df_driver_libs}
 			pthread m
 			)

--- a/src/firmware/qurt/CMakeLists.txt
+++ b/src/firmware/qurt/CMakeLists.txt
@@ -27,7 +27,6 @@ if ("${QURT_ENABLE_STUBS}" STREQUAL "1")
 		-Wl,--start-group
 		${module_libraries}
                 ${target_libraries}
-                df_driver_framework
                 ${df_driver_libs}
 		-Wl,--end-group
 		)
@@ -44,7 +43,6 @@ else()
 		LINK_LIBS
 			${module_libraries}
 			${target_libraries}
-			df_driver_framework
 			${df_driver_libs}
 			m
 		)


### PR DESCRIPTION
Targets wanting to use DriverFramework must add

   lib/DriverFramework/framework

to their config file.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>