### PR TITLE
Auto take-off corner case: Reset work item type when landed

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -146,6 +146,11 @@ Mission::on_inactive()
 	/* require takeoff after non-loiter or landing */
 	if (!_navigator->get_can_loiter_at_sp() || _navigator->get_land_detected()->landed) {
 		_need_takeoff = true;
+		/* Reset work item type to default if auto take-off has been paused or aborted,
+		   and we landed in manual mode. */
+		if (_work_item_type == WORK_ITEM_TYPE_TAKEOFF) {
+			_work_item_type = WORK_ITEM_TYPE_DEFAULT;		
+		}
 	}
 }
 


### PR DESCRIPTION
If the auto mission is paused/aborted during take-off and we land in manual mode, then work_item_type needs to be reset unless we re-power. Otherwise, it is set to WORK_ITEM_TYPE_TAKEOFF, and take-off waypoint is treated as normal position waypoint next time mission is launched. Thus, controller does not use take-off logic but position control logic. 