### PR TITLE
muorb: call `initialize()` before `get_instance()`

### DIFF
--- a/src/modules/muorb/adsp/px4muorb.cpp
+++ b/src/modules/muorb/adsp/px4muorb.cpp
@@ -56,8 +56,7 @@ int px4muorb_orb_initialize()
 	// Register the fastrpc muorb with uORBManager.
 	uORB::Manager::get_instance()->set_uorb_communicator(uORB::FastRpcChannel::GetInstance());
 
-	// Now call the normal startup where uorb, muorb are started, called again but that
-	// doesn't matter.
+	// Now continue with the usual dspal startup.
 	const char *argv[] = {"dspal", "start"};
 	int argc = 2;
 	int rc;

--- a/src/modules/muorb/adsp/px4muorb.cpp
+++ b/src/modules/muorb/adsp/px4muorb.cpp
@@ -51,12 +51,18 @@ int px4muorb_orb_initialize()
 {
 	HAP_power_request(100, 100, 1000);
 
-	// register the fastrpc muorb with uORBManager.
+	// The uORB Manager needs to be initialized first up, otherwise the instance is nullptr.
+	uORB::Manager::initialize();
+	// Register the fastrpc muorb with uORBManager.
 	uORB::Manager::get_instance()->set_uorb_communicator(uORB::FastRpcChannel::GetInstance());
+
+	// Now call the normal startup where uorb, muorb are started, called again but that
+	// doesn't matter.
 	const char *argv[] = {"dspal", "start"};
 	int argc = 2;
 	int rc;
 	rc = dspal_main(argc, (char **)argv);
+
 	return rc;
 }
 


### PR DESCRIPTION
Recent changes to avoid race conditions made this change necessary.

Fixes #4421.