### PR TITLE
Fix eagle build

### DIFF
--- a/src/drivers/uart_esc/CMakeLists.txt
+++ b/src/drivers/uart_esc/CMakeLists.txt
@@ -35,6 +35,7 @@ px4_add_module(
 	MAIN uart_esc
 	COMPILE_FLAGS
 		-Os
+		-Wno-packed
 	SRCS
 		uart_esc.cpp
 	DEPENDS

--- a/src/platforms/qurt/px4_layer/CMakeLists.txt
+++ b/src/platforms/qurt/px4_layer/CMakeLists.txt
@@ -55,6 +55,7 @@ px4_add_module(
 	MODULE platforms__qurt__px4_layer
 	COMPILE_FLAGS
 		-Os
+		-Wno-packed
 	SRCS
 		${QURT_LAYER_SRCS}
 		${CONFIG_SRC}


### PR DESCRIPTION
Will fix compile issues after ##4437 together with 084dfb40260eb53f3f48b37a7263e5af1c7c8d02, 192510ee1c9ec34959c2284c3ee4d7cedafcfb42, 34ba80ea9d8d649ba09d328eaaf6e99f168193f9, and 2801a54544eef2d782bae5f99c8e45959c1d8c40.