### PR TITLE
posix-configs: conflicting sdlog2 arguments

### DIFF
--- a/posix-configs/SITL/init/rc.fixed_wing
+++ b/posix-configs/SITL/init/rc.fixed_wing
@@ -48,4 +48,4 @@ mavlink stream -r 50 -s ATTITUDE -u 14556
 mavlink stream -r 80 -s ATTITUDE_QUATERNION -u 14556
 mavlink stream -r 50 -s ATTITUDE_TARGET -u 14556
 mavlink boot_complete
-sdlog2 start -r 100 -e -t -a
+sdlog2 start -r 100 -e -t

--- a/posix-configs/SITL/init/rcS_ekf2_jmavsim_iris
+++ b/posix-configs/SITL/init/rcS_ekf2_jmavsim_iris
@@ -61,5 +61,5 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 mavlink boot_complete
-sdlog2 start -r 100 -e -t -a
+sdlog2 start -r 100 -e -t
 ekf2 start

--- a/posix-configs/SITL/init/rcS_gazebo_iris
+++ b/posix-configs/SITL/init/rcS_gazebo_iris
@@ -64,4 +64,4 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 mavlink boot_complete
-sdlog2 start -r 100 -e -t -a
+sdlog2 start -r 100 -e -t

--- a/posix-configs/SITL/init/rcS_gazebo_iris_opt_flow
+++ b/posix-configs/SITL/init/rcS_gazebo_iris_opt_flow
@@ -64,4 +64,4 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 mavlink boot_complete
-sdlog2 start -r 100 -e -t -a
+sdlog2 start -r 100 -e -t

--- a/posix-configs/SITL/init/rcS_gazebo_plane
+++ b/posix-configs/SITL/init/rcS_gazebo_plane
@@ -55,4 +55,4 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 mavlink boot_complete
-sdlog2 start -r 200 -e -t -a
+sdlog2 start -r 200 -e -t

--- a/posix-configs/SITL/init/rcS_gazebo_standard_vtol
+++ b/posix-configs/SITL/init/rcS_gazebo_standard_vtol
@@ -71,4 +71,4 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 mavlink boot_complete
-sdlog2 start -r 200 -e -t -a
+sdlog2 start -r 200 -e -t

--- a/posix-configs/SITL/init/rcS_gazebo_tailsitter
+++ b/posix-configs/SITL/init/rcS_gazebo_tailsitter
@@ -68,4 +68,4 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 mavlink boot_complete
-sdlog2 start -r 200 -e -t -a
+sdlog2 start -r 200 -e -t

--- a/posix-configs/SITL/init/rcS_jmavsim_iris
+++ b/posix-configs/SITL/init/rcS_jmavsim_iris
@@ -71,4 +71,4 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 mavlink stream -r 20 -s MANUAL_CONTROL -u 14556
 mavlink boot_complete
-sdlog2 start -r 100 -e -t -a
+sdlog2 start -r 100 -e -t

--- a/posix-configs/SITL/init/rcS_lpe_gazebo_iris
+++ b/posix-configs/SITL/init/rcS_lpe_gazebo_iris
@@ -62,7 +62,7 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 mavlink boot_complete
-sdlog2 start -r 100 -e -t -a
+sdlog2 start -r 100 -e -t
 
 # start LPE at end, when we know it is ok to init sensors
 sleep 5

--- a/posix-configs/SITL/init/rcS_lpe_gazebo_iris_opt_flow
+++ b/posix-configs/SITL/init/rcS_lpe_gazebo_iris_opt_flow
@@ -66,7 +66,7 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 mavlink boot_complete
-sdlog2 start -r 100 -e -t -a
+sdlog2 start -r 100 -e -t
 
 # start LPE at end, when we know it is ok to init sensors
 sleep 5

--- a/posix-configs/SITL/init/rcS_lpe_jmavsim_iris
+++ b/posix-configs/SITL/init/rcS_lpe_jmavsim_iris
@@ -62,6 +62,6 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 mavlink boot_complete
-sdlog2 start -r 100 -e -t -a
+sdlog2 start -r 100 -e -t
 attitude_estimator_q start
 local_position_estimator start

--- a/posix-configs/eagle/flight/mainapp.config
+++ b/posix-configs/eagle/flight/mainapp.config
@@ -5,4 +5,4 @@ sleep 1
 mavlink stream -u 14556 -s HIGHRES_IMU -r 50
 mavlink stream -u 14556 -s ATTITUDE -r 50
 mavlink boot_complete
-sdlog2 start -r 100 -e -t -a
+sdlog2 start -r 100 -e -t

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1023,8 +1023,14 @@ int sdlog2_thread_main(int argc, char *argv[])
 		}
 	}
 
+	if (log_on_start && log_when_armed) {
+		sdlog2_usage("conflicting arguments -e and -a supplied");
+		return 1;
+	}
+
 	if (err_flag) {
 		sdlog2_usage(NULL);
+		return 1;
 	}
 
 	gps_time_sec = 0;


### PR DESCRIPTION
The argument "log only when armed" was supplied but at the same time the
argument "log from startup" which were conflicting each other.

The result was that the logging started on startup but ended with
disarming. It is now changed to always on until the process is shut
down.

Tested on Snapdragon.
Needs quick testing in SITL.