### PR TITLE
Param metadata

### DIFF
--- a/src/lib/launchdetection/launchdetection_params.c
+++ b/src/lib/launchdetection/launchdetection_params.c
@@ -61,6 +61,8 @@ PARAM_DEFINE_INT32(LAUN_ALL_ON, 0);
  *
  * @unit m/s/s
  * @min 0
+ * @decimal 1
+ * @increment 0.5
  * @group Launch detection
  */
 PARAM_DEFINE_FLOAT(LAUN_CAT_A, 30.0f);
@@ -71,7 +73,10 @@ PARAM_DEFINE_FLOAT(LAUN_CAT_A, 30.0f);
  * LAUN_CAT_A for LAUN_CAT_T serves as threshold to trigger launch detection.
  *
  * @unit s
- * @min 0
+ * @min 0.0
+ * @max 5.0
+ * @decimal 2
+ * @increment 0.05
  * @group Launch detection
  */
 PARAM_DEFINE_FLOAT(LAUN_CAT_T, 0.05f);
@@ -83,7 +88,10 @@ PARAM_DEFINE_FLOAT(LAUN_CAT_T, 0.05f);
  * Before this timespan is up the throttle will be set to FW_THR_IDLE, set to 0 to deactivate
  *
  * @unit s
- * @min 0
+ * @min 0.0
+ * @max 10.0
+ * @decimal 1
+ * @increment 0.5
  * @group Launch detection
  */
 PARAM_DEFINE_FLOAT(LAUN_CAT_MDEL, 0.0f);
@@ -95,8 +103,10 @@ PARAM_DEFINE_FLOAT(LAUN_CAT_MDEL, 0.0f);
  * This allows to limit the maximum pitch angle during a bungee launch (make the launch less steep).
  *
  * @unit deg
- * @min 0
- * @max 45
+ * @min 0.0
+ * @max 45.0
+ * @decimal 1
+ * @increment 0.5
  * @group Launch detection
  */
 PARAM_DEFINE_FLOAT(LAUN_CAT_PMAX, 30.0f);

--- a/src/lib/runway_takeoff/runway_takeoff_params.c
+++ b/src/lib/runway_takeoff/runway_takeoff_params.c
@@ -42,8 +42,6 @@
 /**
  * Enable or disable runway takeoff with landing gear
  *
- * 0: disabled, 1: enabled
- *
  * @boolean
  * @group Runway Takeoff
  */
@@ -71,6 +69,8 @@ PARAM_DEFINE_INT32(RWTO_HDG, 0);
  * @unit m
  * @min 0.0
  * @max 100.0
+ * @decimal 1
+ * @increment 1
  * @group Runway Takeoff
  */
 PARAM_DEFINE_FLOAT(RWTO_NAV_ALT, 5.0);
@@ -79,8 +79,11 @@ PARAM_DEFINE_FLOAT(RWTO_NAV_ALT, 5.0);
  * Max throttle during runway takeoff.
  * (Can be used to test taxi on runway)
  *
+ * @unit norm
  * @min 0.0
  * @max 1.0
+ * @decimal 2
+ * @increment 0.01
  * @group Runway Takeoff
  */
 PARAM_DEFINE_FLOAT(RWTO_MAX_THR, 1.0);
@@ -94,6 +97,8 @@ PARAM_DEFINE_FLOAT(RWTO_MAX_THR, 1.0);
  * @unit deg
  * @min 0.0
  * @max 20.0
+ * @decimal 1
+ * @increment 0.5
  * @group Runway Takeoff
  */
 PARAM_DEFINE_FLOAT(RWTO_PSP, 0.0);
@@ -106,6 +111,8 @@ PARAM_DEFINE_FLOAT(RWTO_PSP, 0.0);
  * @unit deg
  * @min 0.0
  * @max 60.0
+ * @decimal 1
+ * @increment 0.5
  * @group Runway Takeoff
  */
 PARAM_DEFINE_FLOAT(RWTO_MAX_PITCH, 20.0);
@@ -118,6 +125,8 @@ PARAM_DEFINE_FLOAT(RWTO_MAX_PITCH, 20.0);
  * @unit deg
  * @min 0.0
  * @max 60.0
+ * @decimal 1
+ * @increment 0.5
  * @group Runway Takeoff
  */
 PARAM_DEFINE_FLOAT(RWTO_MAX_ROLL, 25.0);
@@ -127,8 +136,11 @@ PARAM_DEFINE_FLOAT(RWTO_MAX_ROLL, 25.0);
  * Pitch up will be commanded when the following airspeed is reached:
  * FW_AIRSPD_MIN * RWTO_AIRSPD_SCL
  *
+ * @unit norm
  * @min 0.0
  * @max 2.0
+ * @decimal 2
+ * @increment 0.01
  * @group Runway Takeoff
  */
 PARAM_DEFINE_FLOAT(RWTO_AIRSPD_SCL, 1.3);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -127,10 +127,11 @@ PARAM_DEFINE_INT32(COM_DL_REG_T, 0);
  * Engine failure triggers only above this throttle value
  *
  * @group Commander
+ * @unit norm
  * @min 0.0
  * @max 1.0
- * @decimal 1
- * @increment 0.05
+ * @decimal 2
+ * @increment 0.01
  */
 PARAM_DEFINE_FLOAT(COM_EF_THROT, 0.5f);
 
@@ -142,7 +143,7 @@ PARAM_DEFINE_FLOAT(COM_EF_THROT, 0.5f);
  * @group Commander
  * @min 0.0
  * @max 50.0
- * @unit A
+ * @unit A/%
  * @decimal 2
  * @increment 1
  */

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -57,6 +57,8 @@
  * @unit s
  * @min 0.4
  * @max 1.0
+ * @decimal 2
+ * @increment 0.05
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_R_TC, 0.4f);
@@ -73,6 +75,8 @@ PARAM_DEFINE_FLOAT(FW_R_TC, 0.4f);
  * @unit s
  * @min 0.2
  * @max 1.0
+ * @decimal 2
+ * @increment 0.05
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_P_TC, 0.4f);
@@ -86,6 +90,8 @@ PARAM_DEFINE_FLOAT(FW_P_TC, 0.4f);
  * @unit %/rad/s
  * @min 0.005
  * @max 1.0
+ * @decimal 3
+ * @increment 0.005
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_PR_P, 0.08f);
@@ -99,6 +105,8 @@ PARAM_DEFINE_FLOAT(FW_PR_P, 0.08f);
  * @unit %/rad
  * @min 0.005
  * @max 0.5
+ * @decimal 3
+ * @increment 0.005
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_PR_I, 0.02f);
@@ -112,6 +120,8 @@ PARAM_DEFINE_FLOAT(FW_PR_I, 0.02f);
  * @unit deg/s
  * @min 0.0
  * @max 90.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_P_RMAX_POS, 60.0f);
@@ -125,6 +135,8 @@ PARAM_DEFINE_FLOAT(FW_P_RMAX_POS, 60.0f);
  * @unit deg/s
  * @min 0.0
  * @max 90.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_P_RMAX_NEG, 60.0f);
@@ -135,9 +147,10 @@ PARAM_DEFINE_FLOAT(FW_P_RMAX_NEG, 60.0f);
  * The portion of the integrator part in the control surface deflection is
  * limited to this value
  *
- * @unit %
  * @min 0.0
  * @max 1.0
+ * @decimal 2
+ * @increment 0.05
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_PR_IMAX, 0.4f);
@@ -151,6 +164,8 @@ PARAM_DEFINE_FLOAT(FW_PR_IMAX, 0.4f);
  * @unit %/rad/s
  * @min 0.005
  * @max 1.0
+ * @decimal 3
+ * @increment 0.005
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_RR_P, 0.05f);
@@ -164,6 +179,8 @@ PARAM_DEFINE_FLOAT(FW_RR_P, 0.05f);
  * @unit %/rad
  * @min 0.005
  * @max 0.2
+ * @decimal 3
+ * @increment 0.005
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_RR_I, 0.01f);
@@ -173,9 +190,10 @@ PARAM_DEFINE_FLOAT(FW_RR_I, 0.01f);
  *
  * The portion of the integrator part in the control surface deflection is limited to this value.
  *
- * @unit %
  * @min 0.0
  * @max 1.0
+ * @decimal 2
+ * @increment 0.05
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_RR_IMAX, 0.2f);
@@ -189,6 +207,8 @@ PARAM_DEFINE_FLOAT(FW_RR_IMAX, 0.2f);
  * @unit deg/s
  * @min 0.0
  * @max 90.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_R_RMAX, 70.0f);
@@ -202,6 +222,8 @@ PARAM_DEFINE_FLOAT(FW_R_RMAX, 70.0f);
  * @unit %/rad/s
  * @min 0.005
  * @max 1.0
+ * @decimal 3
+ * @increment 0.005
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_YR_P, 0.05f);
@@ -215,6 +237,8 @@ PARAM_DEFINE_FLOAT(FW_YR_P, 0.05f);
  * @unit %/rad
  * @min 0.0
  * @max 50.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_YR_I, 0.0f);
@@ -225,9 +249,10 @@ PARAM_DEFINE_FLOAT(FW_YR_I, 0.0f);
  * The portion of the integrator part in the control surface deflection is
  * limited to this value
  *
- * @unit %
  * @min 0.0
  * @max 1.0
+ * @decimal 2
+ * @increment 0.05
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_YR_IMAX, 0.2f);
@@ -241,6 +266,8 @@ PARAM_DEFINE_FLOAT(FW_YR_IMAX, 0.2f);
  * @unit deg/s
  * @min 0.0
  * @max 90.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_Y_RMAX, 0.0f);
@@ -254,6 +281,8 @@ PARAM_DEFINE_FLOAT(FW_Y_RMAX, 0.0f);
  * @unit %/rad/s
  * @min 0.005
  * @max 1.0
+ * @decimal 3
+ * @increment 0.005
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_WR_P, 0.5f);
@@ -265,8 +294,10 @@ PARAM_DEFINE_FLOAT(FW_WR_P, 0.5f);
  * state error. It trims any constant error.
  *
  * @unit %/rad
- * @min 0.0
- * @max 50.0
+ * @min 0.005
+ * @max 0.5
+ * @decimal 3
+ * @increment 0.005
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_WR_I, 0.1f);
@@ -277,9 +308,10 @@ PARAM_DEFINE_FLOAT(FW_WR_I, 0.1f);
  * The portion of the integrator part in the control surface deflection is
  * limited to this value
  *
- * @unit %
  * @min 0.0
  * @max 1.0
+ * @decimal 2
+ * @increment 0.05
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_WR_IMAX, 1.0f);
@@ -293,6 +325,8 @@ PARAM_DEFINE_FLOAT(FW_WR_IMAX, 1.0f);
  * @unit deg/s
  * @min 0.0
  * @max 90.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_W_RMAX, 0.0f);
@@ -307,6 +341,8 @@ PARAM_DEFINE_FLOAT(FW_W_RMAX, 0.0f);
  * @unit %/rad/s
  * @min 0.0
  * @max 10.0
+ * @decimal 2
+ * @increment 0.05
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_RR_FF, 0.5f);
@@ -319,6 +355,8 @@ PARAM_DEFINE_FLOAT(FW_RR_FF, 0.5f);
  * @unit %/rad/s
  * @min 0.0
  * @max 10.0
+ * @decimal 2
+ * @increment 0.05
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_PR_FF, 0.5f);
@@ -331,6 +369,8 @@ PARAM_DEFINE_FLOAT(FW_PR_FF, 0.5f);
  * @unit %/rad/s
  * @min 0.0
  * @max 10.0
+ * @decimal 2
+ * @increment 0.05
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_YR_FF, 0.3f);
@@ -343,6 +383,8 @@ PARAM_DEFINE_FLOAT(FW_YR_FF, 0.3f);
  * @unit %/rad/s
  * @min 0.0
  * @max 10.0
+ * @decimal 2
+ * @increment 0.05
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_WR_FF, 0.2f);
@@ -354,6 +396,10 @@ PARAM_DEFINE_FLOAT(FW_WR_FF, 0.2f);
  * turn. Set to a very high value to disable.
  *
  * @unit m/s
+ * @min 0.0
+ * @max 1000.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_YCO_VMIN, 1000.0f);
@@ -373,49 +419,6 @@ PARAM_DEFINE_FLOAT(FW_YCO_VMIN, 1000.0f);
  */
 PARAM_DEFINE_INT32(FW_YCO_METHOD, 0);
 
-/* Airspeed parameters:
- * The following parameters about airspeed are used by the attitude and the
- * position controller.
- * */
-
-/**
- * Minimum Airspeed
- *
- * If the airspeed falls below this value, the TECS controller will try to
- * increase airspeed more aggressively.
- *
- * @unit m/s
- * @min 0.0
- * @max 40
- * @group FW Attitude Control
- */
-PARAM_DEFINE_FLOAT(FW_AIRSPD_MIN, 10.0f);
-
-/**
- * Trim Airspeed
- *
- * The TECS controller tries to fly at this airspeed.
- *
- * @unit m/s
- * @min 0.0
- * @max 40
- * @group FW Attitude Control
- */
-PARAM_DEFINE_FLOAT(FW_AIRSPD_TRIM, 15.0f);
-
-/**
- * Maximum Airspeed
- *
- * If the airspeed is above this value, the TECS controller will try to decrease
- * airspeed more aggressively.
- *
- * @unit m/s
- * @min 0.0
- * @max 40
- * @group FW Attitude Control
- */
-PARAM_DEFINE_FLOAT(FW_AIRSPD_MAX, 20.0f);
-
 /**
  * Roll Setpoint Offset
  *
@@ -426,6 +429,8 @@ PARAM_DEFINE_FLOAT(FW_AIRSPD_MAX, 20.0f);
  * @unit deg
  * @min -90.0
  * @max 90.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_RSP_OFF, 0.0f);
@@ -440,6 +445,8 @@ PARAM_DEFINE_FLOAT(FW_RSP_OFF, 0.0f);
  * @unit deg
  * @min -90.0
  * @max 90.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_PSP_OFF, 0.0f);
@@ -452,6 +459,8 @@ PARAM_DEFINE_FLOAT(FW_PSP_OFF, 0.0f);
  * @unit deg
  * @min 0.0
  * @max 90.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_MAN_R_MAX, 45.0f);
@@ -464,6 +473,8 @@ PARAM_DEFINE_FLOAT(FW_MAN_R_MAX, 45.0f);
  * @unit deg
  * @min 0.0
  * @max 90.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_MAN_P_MAX, 45.0f);
@@ -471,8 +482,11 @@ PARAM_DEFINE_FLOAT(FW_MAN_P_MAX, 45.0f);
 /**
  * Scale factor for flaps
  *
+ * @unit norm
  * @min 0.0
  * @max 1.0
+ * @decimal 2
+ * @increment 0.01
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_FLAPS_SCL, 1.0f);
@@ -480,8 +494,11 @@ PARAM_DEFINE_FLOAT(FW_FLAPS_SCL, 1.0f);
 /**
  * Scale factor for flaperons
  *
+ * @unit norm
  * @min 0.0
  * @max 1.0
+ * @decimal 2
+ * @increment 0.01
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_FLAPERON_SCL, 0.0f);

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -54,6 +54,8 @@
  * @unit m
  * @min 12.0
  * @max 50.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW L1 Control
  */
 PARAM_DEFINE_FLOAT(FW_L1_PERIOD, 20.0f);
@@ -65,6 +67,8 @@ PARAM_DEFINE_FLOAT(FW_L1_PERIOD, 20.0f);
  *
  * @min 0.6
  * @max 0.9
+ * @decimal 2
+ * @increment 0.05
  * @group FW L1 Control
  */
 PARAM_DEFINE_FLOAT(FW_L1_DAMPING, 0.75f);
@@ -77,6 +81,8 @@ PARAM_DEFINE_FLOAT(FW_L1_DAMPING, 0.75f);
  * @unit norm
  * @min 0.0
  * @max 1.0
+ * @decimal 2
+ * @increment 0.01
  * @group FW L1 Control
  */
 PARAM_DEFINE_FLOAT(FW_THR_CRUISE, 0.6f);
@@ -100,6 +106,8 @@ PARAM_DEFINE_FLOAT(FW_THR_SLEW_MAX, 0.0f);
  * @unit deg
  * @min -60.0
  * @max 0.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW L1 Control
  */
 PARAM_DEFINE_FLOAT(FW_P_LIM_MIN, -45.0f);
@@ -112,6 +120,8 @@ PARAM_DEFINE_FLOAT(FW_P_LIM_MIN, -45.0f);
  * @unit deg
  * @min 0.0
  * @max 60.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW L1 Control
  */
 PARAM_DEFINE_FLOAT(FW_P_LIM_MAX, 45.0f);
@@ -124,6 +134,8 @@ PARAM_DEFINE_FLOAT(FW_P_LIM_MAX, 45.0f);
  * @unit deg
  * @min 35.0
  * @max 65.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW L1 Control
  */
 PARAM_DEFINE_FLOAT(FW_R_LIM, 50.0f);
@@ -138,6 +150,8 @@ PARAM_DEFINE_FLOAT(FW_R_LIM, 50.0f);
  * @unit norm
  * @min 0.0
  * @max 1.0
+ * @decimal 2
+ * @increment 0.01
  * @group FW L1 Control
  */
 PARAM_DEFINE_FLOAT(FW_THR_MAX, 1.0f);
@@ -157,6 +171,8 @@ PARAM_DEFINE_FLOAT(FW_THR_MAX, 1.0f);
  * @unit norm
  * @min 0.0
  * @max 1.0
+ * @decimal 2
+ * @increment 0.01
  * @group FW L1 Control
  */
 PARAM_DEFINE_FLOAT(FW_THR_MIN, 0.0f);
@@ -172,6 +188,8 @@ PARAM_DEFINE_FLOAT(FW_THR_MIN, 0.0f);
  * @unit norm
  * @min 0.0
  * @max 0.4
+ * @decimal 2
+ * @increment 0.01
  * @group FW L1 Control
  */
 PARAM_DEFINE_FLOAT(FW_THR_IDLE, 0.15f);
@@ -185,6 +203,8 @@ PARAM_DEFINE_FLOAT(FW_THR_IDLE, 0.15f);
  * @unit norm
  * @min 0.0
  * @max 1.0
+ * @decimal 2
+ * @increment 0.01
  * @group FW L1 Control
  */
 PARAM_DEFINE_FLOAT(FW_THR_LND_MAX, 1.0f);
@@ -200,9 +220,180 @@ PARAM_DEFINE_FLOAT(FW_THR_LND_MAX, 1.0f);
  * @unit m
  * @min 0.0
  * @max 150.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW L1 Control
  */
 PARAM_DEFINE_FLOAT(FW_CLMBOUT_DIFF, 10.0f);
+
+/**
+ * Landing slope angle
+ *
+ * @unit deg
+ * @min 1.0
+ * @max 15.0
+ * @decimal 1
+ * @increment 0.5
+ * @group FW L1 Control
+ */
+PARAM_DEFINE_FLOAT(FW_LND_ANG, 5.0f);
+
+/**
+ *
+ *
+ * @unit m
+ * @min 1.0
+ * @max 15.0
+ * @decimal 1
+ * @increment 0.5
+ * @group FW L1 Control
+ */
+PARAM_DEFINE_FLOAT(FW_LND_HVIRT, 10.0f);
+
+/**
+ * Landing flare altitude (relative to landing altitude)
+ *
+ * @unit m
+ * @min 0.0
+ * @max 25.0
+ * @decimal 1
+ * @increment 0.5
+ * @group FW L1 Control
+ */
+PARAM_DEFINE_FLOAT(FW_LND_FLALT, 8.0f);
+
+/**
+ * Landing throttle limit altitude (relative landing altitude)
+ *
+ * Default of -1.0 lets the system default to applying throttle
+ * limiting at 2/3 of the flare altitude.
+ *
+ * @unit m
+ * @min -1.0
+ * @max 30.0
+ * @decimal 1
+ * @increment 0.5
+ * @group FW L1 Control
+ */
+PARAM_DEFINE_FLOAT(FW_LND_TLALT, -1.0f);
+
+/**
+ * Landing heading hold horizontal distance
+ *
+ * @unit m
+ * @min 0
+ * @max 30.0
+ * @decimal 1
+ * @increment 0.5
+ * @group FW L1 Control
+ */
+PARAM_DEFINE_FLOAT(FW_LND_HHDIST, 15.0f);
+
+/**
+ * Enable or disable usage of terrain estimate during landing
+ *
+ * @boolean
+ * @group FW L1 Control
+ */
+PARAM_DEFINE_INT32(FW_LND_USETER, 0);
+
+/**
+ * Flare, minimum pitch
+ *
+ * Minimum pitch during flare, a positive sign means nose up
+ * Applied once FW_LND_TLALT is reached
+ *
+ * @unit deg
+ * @min 0
+ * @max 15.0
+ * @decimal 1
+ * @increment 0.5
+ * @group FW L1 Control
+ */
+PARAM_DEFINE_FLOAT(FW_LND_FL_PMIN, 2.5f);
+
+/**
+ * Flare, maximum pitch
+ *
+ * Maximum pitch during flare, a positive sign means nose up
+ * Applied once FW_LND_TLALT is reached
+ *
+ * @unit deg
+ * @min 0
+ * @max 45.0
+ * @decimal 1
+ * @increment 0.5
+ * @group FW L1 Control
+ */
+PARAM_DEFINE_FLOAT(FW_LND_FL_PMAX, 15.0f);
+
+/**
+ * Min. airspeed scaling factor for landing
+ *
+ * Multiplying this factor with the minimum airspeed of the plane
+ * gives the target airspeed the landing approach.
+ * FW_AIRSPD_MIN * FW_LND_AIRSPD_SC
+ *
+ * @unit norm
+ * @min 1.0
+ * @max 1.5
+ * @decimal 2
+ * @increment 0.01
+ * @group FW L1 Control
+ */
+PARAM_DEFINE_FLOAT(FW_LND_AIRSPD_SC, 1.3f);
+
+
+
+/*
+ * TECS parameters
+ *
+ */
+
+
+/**
+ * Minimum Airspeed
+ *
+ * If the airspeed falls below this value, the TECS controller will try to
+ * increase airspeed more aggressively.
+ *
+ * @unit m/s
+ * @min 0.0
+ * @max 40
+ * @decimal 1
+ * @increment 0.5
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_AIRSPD_MIN, 10.0f);
+
+/**
+ * Trim Airspeed
+ *
+ * The TECS controller tries to fly at this airspeed.
+ *
+ * @unit m/s
+ * @min 0.0
+ * @max 40
+ * @decimal 1
+ * @increment 0.5
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_AIRSPD_TRIM, 15.0f);
+
+/**
+ * Maximum Airspeed
+ *
+ * If the airspeed is above this value, the TECS controller will try to decrease
+ * airspeed more aggressively.
+ *
+ * @unit m/s
+ * @min 0.0
+ * @max 40
+ * @decimal 1
+ * @increment 0.5
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_AIRSPD_MAX, 20.0f);
 
 /**
  * Maximum climb rate
@@ -221,8 +412,10 @@ PARAM_DEFINE_FLOAT(FW_CLMBOUT_DIFF, 10.0f);
  * FW_THR_MAX reduced.
  *
  * @unit m/s
- * @min 2.0
- * @max 10.0
+ * @min 1.0
+ * @max 15.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_T_CLMB_MAX, 5.0f);
@@ -235,6 +428,10 @@ PARAM_DEFINE_FLOAT(FW_T_CLMB_MAX, 5.0f);
  * to measure FW_T_CLMB_MAX.
  *
  * @unit m/s
+ * @min 1.0
+ * @max 5.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_T_SINK_MIN, 2.0f);
@@ -249,6 +446,10 @@ PARAM_DEFINE_FLOAT(FW_T_SINK_MIN, 2.0f);
  * the aircraft.
  *
  * @unit m/s
+ * @min 2.0
+ * @max 15.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_T_SINK_MAX, 5.0f);
@@ -261,6 +462,10 @@ PARAM_DEFINE_FLOAT(FW_T_SINK_MAX, 5.0f);
  * to respond.
  *
  * @unit s
+ * @min 1.0
+ * @max 10.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_T_TIME_CONST, 5.0f);
@@ -273,6 +478,10 @@ PARAM_DEFINE_FLOAT(FW_T_TIME_CONST, 5.0f);
  * to respond.
  *
  * @unit s
+ * @min 1.0
+ * @max 10.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_T_THRO_CONST, 8.0f);
@@ -283,6 +492,10 @@ PARAM_DEFINE_FLOAT(FW_T_THRO_CONST, 8.0f);
  * This is the damping gain for the throttle demand loop.
  * Increase to add damping to correct for oscillations in speed and height.
  *
+ * @min 0.0
+ * @max 2.0
+ * @decimal 1
+ * @increment 0.1
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_T_THR_DAMP, 0.5f);
@@ -295,6 +508,10 @@ PARAM_DEFINE_FLOAT(FW_T_THR_DAMP, 0.5f);
  * and height offsets are trimmed out, but reduces damping and
  * increases overshoot.
  *
+ * @min 0.0
+ * @max 2.0
+ * @decimal 2
+ * @increment 0.05
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_T_INTEG_GAIN, 0.1f);
@@ -309,6 +526,10 @@ PARAM_DEFINE_FLOAT(FW_T_INTEG_GAIN, 0.1f);
  * from under-speed conditions.
  *
  * @unit m/s/s
+ * @min 1.0
+ * @max 10.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_T_VERT_ACC, 7.0f);
@@ -323,6 +544,10 @@ PARAM_DEFINE_FLOAT(FW_T_VERT_ACC, 7.0f);
  * the solution more towards use of the accelerometer data.
  *
  * @unit rad/s
+ * @min 1.0
+ * @max 10.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_T_HGT_OMEGA, 3.0f);
@@ -333,10 +558,14 @@ PARAM_DEFINE_FLOAT(FW_T_HGT_OMEGA, 3.0f);
  * This is the cross-over frequency (in radians/second) of the complementary
  * filter used to fuse longitudinal acceleration and airspeed to obtain an
  * improved airspeed estimate. Increasing this frequency weights the solution
- * more towards use of the arispeed sensor, whilst reducing it weights the
+ * more towards use of the airspeed sensor, whilst reducing it weights the
  * solution more towards use of the accelerometer data.
  *
  * @unit rad/s
+ * @min 1.0
+ * @max 10.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_T_SPD_OMEGA, 2.0f);
@@ -353,6 +582,10 @@ PARAM_DEFINE_FLOAT(FW_T_SPD_OMEGA, 2.0f);
  * aircraft (eg powered sailplanes) can use a lower value, whereas
  * inefficient low aspect-ratio models (eg delta wings) can use a higher value.
  *
+ * @min 0.0
+ * @max 20.0
+ * @decimal 1
+ * @increment 0.5
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_T_RLL2THR, 15.0f);
@@ -373,6 +606,8 @@ PARAM_DEFINE_FLOAT(FW_T_RLL2THR, 15.0f);
  *
  * @min 0.0
  * @max 2.0
+ * @decimal 1
+ * @increment 1.0
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_T_SPDWEIGHT, 1.0f);
@@ -385,6 +620,10 @@ PARAM_DEFINE_FLOAT(FW_T_SPDWEIGHT, 1.0f);
  * will work well provided the pitch to servo controller has been tuned
  * properly.
  *
+ * @min 0.0
+ * @max 2.0
+ * @decimal 1
+ * @increment 0.1
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_T_PTCH_DAMP, 0.0f);
@@ -392,6 +631,10 @@ PARAM_DEFINE_FLOAT(FW_T_PTCH_DAMP, 0.0f);
 /**
  * Height rate P factor
  *
+ * @min 0.0
+ * @max 2.0
+ * @decimal 2
+ * @increment 0.05
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_T_HRATE_P, 0.05f);
@@ -399,6 +642,10 @@ PARAM_DEFINE_FLOAT(FW_T_HRATE_P, 0.05f);
 /**
  * Height rate FF factor
  *
+ * @min 0.0
+ * @max 2.0
+ * @decimal 2
+ * @increment 0.05
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_T_HRATE_FF, 0.0f);
@@ -406,107 +653,10 @@ PARAM_DEFINE_FLOAT(FW_T_HRATE_FF, 0.0f);
 /**
  * Speed rate P factor
  *
+ * @min 0.0
+ * @max 2.0
+ * @decimal 2
+ * @increment 0.01
  * @group FW TECS
  */
 PARAM_DEFINE_FLOAT(FW_T_SRATE_P, 0.02f);
-
-/**
- * Landing slope angle
- *
- * @unit deg
- * @min 1.0
- * @max 15.0
- * @group FW L1 Control
- */
-PARAM_DEFINE_FLOAT(FW_LND_ANG, 5.0f);
-
-/**
- *
- *
- * @unit m
- * @group FW L1 Control
- */
-PARAM_DEFINE_FLOAT(FW_LND_HVIRT, 10.0f);
-
-/**
- * Landing flare altitude (relative to landing altitude)
- *
- * @unit m
- * @min 0.0
- * @max 25.0
- * @group FW L1 Control
- */
-PARAM_DEFINE_FLOAT(FW_LND_FLALT, 8.0f);
-
-/**
- * Landing throttle limit altitude (relative landing altitude)
- *
- * Default of -1.0 lets the system default to applying throttle
- * limiting at 2/3 of the flare altitude.
- *
- * @unit m
- * @min -1.0
- * @max 30.0
- * @group FW L1 Control
- */
-PARAM_DEFINE_FLOAT(FW_LND_TLALT, -1.0f);
-
-/**
- * Landing heading hold horizontal distance
- *
- * @unit m
- * @min 0
- * @max 30.0
- * @group FW L1 Control
- */
-PARAM_DEFINE_FLOAT(FW_LND_HHDIST, 15.0f);
-
-/**
- * Enable or disable usage of terrain estimate during landing
- *
- * 0: disabled, 1: enabled
- *
- * @boolean
- * @group FW L1 Control
- */
-PARAM_DEFINE_INT32(FW_LND_USETER, 0);
-
-/**
- * Flare, minimum pitch
- *
- * Minimum pitch during flare, a positive sign means nose up
- * Applied once FW_LND_TLALT is reached
- *
- * @unit deg
- * @min 0
- * @max 15.0
- * @group FW L1 Control
- *
- */
-PARAM_DEFINE_FLOAT(FW_LND_FL_PMIN, 2.5f);
-
-/**
- * Flare, maximum pitch
- *
- * Maximum pitch during flare, a positive sign means nose up
- * Applied once FW_LND_TLALT is reached
- *
- * @unit deg
- * @min 0
- * @max 45.0
- * @group FW L1 Control
- *
- */
-PARAM_DEFINE_FLOAT(FW_LND_FL_PMAX, 15.0f);
-
-/**
- * Landing airspeed scale factor
- *
- * Multiplying this factor with the minimum airspeed of the plane
- * gives the target airspeed the landing approach.
- *
- * @min 1.0
- * @max 1.5
- * @group FW L1 Control
- */
-PARAM_DEFINE_FLOAT(FW_LND_AIRSPD_SC, 1.3f);

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -47,6 +47,7 @@
  * @min 0.05
  * @max 1.0
  * @decimal 2
+ * @increment 0.01
  * @group Multicopter Position Control
  */
 PARAM_DEFINE_FLOAT(MPC_THR_MIN, 0.12f);
@@ -65,6 +66,7 @@ PARAM_DEFINE_FLOAT(MPC_THR_MIN, 0.12f);
  * @min 0.2
  * @max 0.8
  * @decimal 2
+ * @increment 0.01
  * @group Multicopter Position Control
  */
 PARAM_DEFINE_FLOAT(MPC_THR_HOVER, 0.5f);
@@ -80,6 +82,7 @@ PARAM_DEFINE_FLOAT(MPC_THR_HOVER, 0.5f);
  * @min 0.0
  * @max 0.2
  * @decimal 2
+ * @increment 0.05
  * @group Multicopter Position Control
  */
 PARAM_DEFINE_FLOAT(MPC_ALTCTL_DZ, 0.1f);

--- a/src/modules/navigator/datalinkloss_params.c
+++ b/src/modules/navigator/datalinkloss_params.c
@@ -50,6 +50,9 @@
  *
  * @unit s
  * @min 0.0
+ * @max 3600.0
+ * @decimal 0
+ * @increment 1
  * @group Data Link Loss
  */
 PARAM_DEFINE_FLOAT(NAV_DLL_CH_T, 120.0f);
@@ -86,17 +89,22 @@ PARAM_DEFINE_INT32(NAV_DLL_CH_LON, 1518453890);
  * @unit m
  * @min -50
  * @max 30000
+ * @decimal 1
+ * @increment 0.5
  * @group Data Link Loss
  */
 PARAM_DEFINE_FLOAT(NAV_DLL_CH_ALT, 600.0f);
 
 /**
- * Airfield hole wait time
+ * Airfield home wait time
  *
  * The amount of time in seconds the system should wait at the airfield home waypoint
  *
  * @unit s
  * @min 0.0
+ * @max 3600.0
+ * @decimal 0
+ * @increment 1
  * @group Data Link Loss
  */
 PARAM_DEFINE_FLOAT(NAV_DLL_AH_T, 120.0f);
@@ -106,9 +114,9 @@ PARAM_DEFINE_FLOAT(NAV_DLL_AH_T, 120.0f);
  *
  * After more than this number of data link timeouts the aircraft returns home directly
  *
- * @group Data Link Loss
  * @min 0
  * @max 1000
+ * @group Data Link Loss
  */
 PARAM_DEFINE_INT32(NAV_DLL_N, 2);
 
@@ -118,7 +126,7 @@ PARAM_DEFINE_INT32(NAV_DLL_N, 2);
  * If set to 1 the system will skip the comms hold wp on data link loss and will directly fly to
  * airfield home
  *
- * @group Data Link Loss
  * @boolean
+ * @group Data Link Loss
  */
 PARAM_DEFINE_INT32(NAV_DLL_CHSK, 0);

--- a/src/modules/navigator/gpsfailure_params.c
+++ b/src/modules/navigator/gpsfailure_params.c
@@ -51,6 +51,9 @@
  *
  * @unit s
  * @min 0.0
+ * @max 3600.0
+ * @decimal 0
+ * @increment 1
  * @group GPS Failure Navigation
  */
 PARAM_DEFINE_FLOAT(NAV_GPSF_LT, 30.0f);
@@ -63,6 +66,8 @@ PARAM_DEFINE_FLOAT(NAV_GPSF_LT, 30.0f);
  * @unit deg
  * @min 0.0
  * @max 30.0
+ * @decimal 1
+ * @increment 0.5
  * @group GPS Failure Navigation
  */
 PARAM_DEFINE_FLOAT(NAV_GPSF_R, 15.0f);
@@ -75,6 +80,8 @@ PARAM_DEFINE_FLOAT(NAV_GPSF_R, 15.0f);
  * @unit deg
  * @min -30.0
  * @max 30.0
+ * @decimal 1
+ * @increment 0.5
  * @group GPS Failure Navigation
  */
 PARAM_DEFINE_FLOAT(NAV_GPSF_P, 0.0f);
@@ -84,8 +91,11 @@ PARAM_DEFINE_FLOAT(NAV_GPSF_P, 0.0f);
  *
  * Thrust value which is set during the open loop loiter
  *
+ * @unit norm
  * @min 0.0
  * @max 1.0
+ * @decimal 2
+ * @increment 0.05
  * @group GPS Failure Navigation
  */
 PARAM_DEFINE_FLOAT(NAV_GPSF_TR, 0.7f);

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -51,6 +51,8 @@
  * @unit m
  * @min 0
  * @max 80
+ * @decimal 1
+ * @increment 0.5
  * @group Mission
  */
 PARAM_DEFINE_FLOAT(MIS_TAKEOFF_ALT, 10.0f);
@@ -63,6 +65,8 @@ PARAM_DEFINE_FLOAT(MIS_TAKEOFF_ALT, 10.0f);
  * @unit m
  * @min 0
  * @max 80
+ * @decimal 1
+ * @increment 0.5
  * @group Mission
  */
 PARAM_DEFINE_FLOAT(MIS_LTRMIN_ALT, 1.2f);
@@ -88,6 +92,8 @@ PARAM_DEFINE_INT32(MIS_ONBOARD_EN, 1);
  * @unit m
  * @min 0
  * @max 1000
+ * @decimal 1
+ * @increment 0.5
  * @group Mission
  */
 PARAM_DEFINE_FLOAT(MIS_DIST_1WP, 900);
@@ -133,17 +139,19 @@ PARAM_DEFINE_INT32(MIS_YAWMODE, 1);
  * @unit s
  * @min -1
  * @max 20
+ * @decimal 1
  * @increment 1
  * @group Mission
  */
 PARAM_DEFINE_FLOAT(MIS_YAW_TMT, -1.0f);
 
 /**
- * Max yaw error in degree needed for waypoint heading acceptance.
+ * Max yaw error in degrees needed for waypoint heading acceptance.
  *
  * @unit deg
  * @min 0
  * @max 90
+ * @decimal 1
  * @increment 1
  * @group Mission
  */

--- a/src/modules/navigator/navigator_params.c
+++ b/src/modules/navigator/navigator_params.c
@@ -48,6 +48,8 @@
  * @unit m
  * @min 25
  * @max 1000
+ * @decimal 1
+ * @increment 0.5
  * @group Mission
  */
 PARAM_DEFINE_FLOAT(NAV_LOITER_RAD, 50.0f);
@@ -60,6 +62,8 @@ PARAM_DEFINE_FLOAT(NAV_LOITER_RAD, 50.0f);
  * @unit m
  * @min 0.05
  * @max 200.0
+ * @decimal 1
+ * @increment 0.5
  * @group Mission
  */
 PARAM_DEFINE_FLOAT(NAV_ACC_RAD, 10.0f);
@@ -131,6 +135,8 @@ PARAM_DEFINE_INT32(NAV_AH_LON, 1518423250);
  *
  * @unit m
  * @min -50
+ * @decimal 1
+ * @increment 0.5
  * @group Data Link Loss
  */
 PARAM_DEFINE_FLOAT(NAV_AH_ALT, 600.0f);

--- a/src/modules/systemlib/battery_params.c
+++ b/src/modules/systemlib/battery_params.c
@@ -78,9 +78,9 @@ PARAM_DEFINE_FLOAT(BAT_V_CHARGED, 4.05f);
  *
  * @group Battery Calibration
  * @unit norm
- * @decimal 2
  * @min 0.12
  * @max 0.4
+ * @decimal 2
  * @increment 0.01
  */
 PARAM_DEFINE_FLOAT(BAT_LOW_THR, 0.15f);
@@ -94,9 +94,9 @@ PARAM_DEFINE_FLOAT(BAT_LOW_THR, 0.15f);
  *
  * @group Battery Calibration
  * @unit norm
- * @decimal 2
  * @min 0.05
  * @max 0.1
+ * @decimal 2
  * @increment 0.01
  */
 PARAM_DEFINE_FLOAT(BAT_CRIT_THR, 0.07f);

--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -43,6 +43,8 @@
  * CHANGING THIS VALUE REQUIRES A RESTART. Defines the auto-start script used to bootstrap the system.
  *
  * @reboot_required true
+ * @min 0
+ * @max 99999
  * @group System
  */
 PARAM_DEFINE_INT32(SYS_AUTOSTART, 0);
@@ -56,6 +58,8 @@ PARAM_DEFINE_INT32(SYS_AUTOSTART, 0);
  *
  * @min 0
  * @max 1
+ * @value 0 Keep parameters
+ * @value 1 Reset parameters
  * @group System
  */
 PARAM_DEFINE_INT32(SYS_AUTOCONFIG, 0);
@@ -65,6 +69,7 @@ PARAM_DEFINE_INT32(SYS_AUTOCONFIG, 0);
  *
  * Can be used to use a standard startup script but with a FMU only set-up. Set to 0 to force the FMU only set-up.
  *
+ * @boolean
  * @min 0
  * @max 1
  * @group System
@@ -78,6 +83,9 @@ PARAM_DEFINE_INT32(SYS_USE_IO, 1);
  *
  * @min 0
  * @max 2
+ * @value 0 Data survives resets
+ * @value 1 Data survives in-flight resets only
+ * @value 2 Data does not survive reset
  * @group System
  */
 PARAM_DEFINE_INT32(SYS_RESTART_TYPE, 2);


### PR DESCRIPTION
This mainly adds increment and decimal to fixed wing params.

One thing to note is that increment and decimal for `@unit norm` (0-1.0) is somewhat confusing. Those actually apply to the QGC formatted percent (0-100).