### PR TITLE
Make LPE default estimator.

### DIFF
--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -104,7 +104,7 @@ PARAM_DEFINE_INT32(SYS_RESTART_TYPE, 2);
  * @reboot_required true
  * @group System
  */
-PARAM_DEFINE_INT32(SYS_MC_EST_GROUP, 0);
+PARAM_DEFINE_INT32(SYS_MC_EST_GROUP, 1);
 
 /**
  * TELEM2 as companion computer link


### PR DESCRIPTION
This switches the default estimation group to attitude estimator q + lpe instead of attitude estimator q + inav.
