### PR TITLE
New calibration timeout supporting Hobbywing x-rotor series

### DIFF
--- a/src/modules/commander/esc_calibration.cpp
+++ b/src/modules/commander/esc_calibration.cpp
@@ -91,7 +91,7 @@ int do_esc_calibration(orb_advert_t *mavlink_log_pub, struct actuator_armed_s* a
 	bool	batt_connected = false;
 
 	hrt_abstime battery_connect_wait_timeout = 30000000;
-	hrt_abstime pwm_high_timeout = 10000000;
+	hrt_abstime pwm_high_timeout = 4000000;
 	hrt_abstime timeout_start;
 
 	calibration_log_info(mavlink_log_pub, CAL_QGC_STARTED_MSG, "esc");


### PR DESCRIPTION
@LorenzMeier this is required to support calibration for these esc's
A better solution is to augment the QGC calibration interface and list known ESC's or ask for the timeout period