### PR TITLE
cmake: add -fcheck-new to cxx_compile_flags

### DIFF
--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -643,6 +643,7 @@ function(px4_add_common_flags)
 	set(cxx_compile_flags
 		-g
 		-fno-exceptions
+		-fcheck-new
 		-fno-rtti
 		-std=gnu++0x
 		-fno-threadsafe-statics


### PR DESCRIPTION
GCC assumes that operator new never returns null, but throws an exception
instead. This is defined by the C++ standard, and thus ok. But we disable
exceptions with -fno-exceptions, so we break this assumption. GCC then goes
ahead and removes some of our nullptr checks. This flag removes the
assumption.

This adds ~1.4kB to the binary size of the px4fmu-v4 target.

Fixes #4493 