### PR TITLE
Translate MC actuators to FW actuators

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -368,6 +368,12 @@ void Standard::fill_actuator_outputs()
 
 	_actuators_out_1->control[actuator_controls_s::INDEX_THROTTLE] = _pusher_throttle;
 
+	/* translate MC actuators to FW actuators */
+	if (_vtol_schedule.flight_mode == TRANSITION_TO_FW || _vtol_schedule.flight_mode == TRANSITION_TO_MC) {
+		_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] = -_actuators_mc_in->control[actuator_controls_s::INDEX_YAW];
+		_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] = _actuators_mc_in->control[actuator_controls_s::INDEX_THROTTLE] - 0.5f;
+	}
+
 	// set the fixed wing throttle control
 	if (_vtol_schedule.flight_mode == FW_MODE && _armed->armed) {
 		// take the throttle value commanded by the fw controller

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -370,7 +370,6 @@ void Standard::fill_actuator_outputs()
 
 	/* translate MC actuators to FW actuators */
 	if (_vtol_schedule.flight_mode == TRANSITION_TO_FW || _vtol_schedule.flight_mode == TRANSITION_TO_MC) {
-		_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] = -_actuators_mc_in->control[actuator_controls_s::INDEX_YAW];
 		_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] = _actuators_mc_in->control[actuator_controls_s::INDEX_THROTTLE] - 0.5f;
 	}
 


### PR DESCRIPTION
Initial solution to altitude gain problem during vtol front transition.
Replaces https://github.com/PX4/Firmware/pull/4091

The altitude gain is still present during vtol front transitions, after changing to a less powerful pusher motor this problem manifested in such a way that transition never occurred as transition airspeed could not be reached while the plane was climbing 2.5m/s.

http://logs.uaventure.com/view/jVPDgZ7JiS7KxSFV6oP9UH

When tecs has been adapted to cope with vtol transitions this patch can be replaced.