### PR TITLE
Snapdragon: MPU9250 accel/gyro filtering for non-ekf2

### DIFF
--- a/src/drivers/device/integrator.cpp
+++ b/src/drivers/device/integrator.cpp
@@ -143,6 +143,20 @@ Integrator::get(bool reset, uint64_t &integral_dt)
 	return val;
 }
 
+math::Vector<3>
+Integrator::get_and_filtered(bool reset, uint64_t &integral_dt, math::Vector<3> &filtered_val)
+{
+	// Do the usual get with reset first but don't return yet.
+	math::Vector<3> ret_integral = get(reset, integral_dt);
+
+	// Because we need both the integral and the integral_dt.
+	filtered_val(0) = ret_integral(0) * 1000000 / integral_dt;
+	filtered_val(1) = ret_integral(1) * 1000000 / integral_dt;
+	filtered_val(2) = ret_integral(2) * 1000000 / integral_dt;
+
+	return ret_integral;
+}
+
 void
 Integrator::_reset(uint64_t &integral_dt)
 {

--- a/src/drivers/device/integrator.h
+++ b/src/drivers/device/integrator.h
@@ -86,6 +86,17 @@ public:
 	 */
 	math::Vector<3>		get(bool reset, uint64_t &integral_dt);
 
+	/**
+	 * Get the current integral and reset the integrator if needed. Additionally give the
+	 * integral over the samples differentiated by the integration time (mean filtered values).
+	 *
+	 * @param reset	    	Reset the integral to zero.
+	 * @param integral_dt	Get the dt in us of the current integration (only if reset).
+	 * @param filtered_val	The integral differentiated by the integration time.
+	 * @return		the integral since the last read-reset
+	 */
+	math::Vector<3>		get_and_filtered(bool reset, uint64_t &integral_dt, math::Vector<3> &filtered_val);
+
 private:
 	uint64_t _auto_reset_interval;			/**< the interval after which the content will be published
 							     and the integrator reset, 0 if no auto-reset */


### PR DESCRIPTION
Use the data which has been filtered by the integrator for the
instantanous values instead of only 1 out of 32 samples.

This is to better support estimators and modules other than ekf2 which
uses the integrated gyro/accel values anyway.

Has been bench tested on Snapdragon. Accel/gyro values are displayed in QGC, and still logged by sdlog2.
The gyro calibration and accel calibration still work.

Please review @tumbili or @bkueng.