### PR TITLE
Don't forward heartbeat packets, confuses QGC.

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1155,7 +1155,9 @@ Mavlink::handle_message(const mavlink_message_t *msg)
 
 	if (get_forwarding_on()) {
 		/* forward any messages to other mavlink instances */
-		Mavlink::forward_message(msg, this);
+		if (msg->msgid != MAVLINK_MSG_ID_HEARTBEAT) {
+			Mavlink::forward_message(msg, this);
+		}
 	}
 }
 


### PR DESCRIPTION
Without this change I was getting a heartbeat forwarded from an onboard odroid with type 18 (onboard computer) as well as a heartbeat from the vehicle (quadrotor type). This wasn't handled well on QGC, so I just avoided the forwarding. I'm not sure if this is the proper approach or not.