### PR TITLE
WIP: Standard vtol altitude controlled front transition

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -243,6 +243,21 @@ void Standard::update_transition_state()
 			_mc_yaw_weight = weight;
 			_mc_throttle_weight = weight;
 
+			// simple vertical velocity controller based on integration of vertical velocity error
+			_pitch_sp_transition -= 0.5f * (0.0f - _local_pos->vz) * 0.004f;
+			_pitch_sp_transition = math::constrain(_pitch_sp_transition, -0.4f, 0.4f);
+
+	//		printf("%d\n", (double)_attc->get_dt());
+			math::Matrix<3,3> R_sp(&_v_att_sp->R_body[0]);
+			math::Vector<3> euler_sp = R_sp.to_euler();
+			euler_sp(1) = _pitch_sp_transition;
+			R_sp.from_euler(euler_sp(0), euler_sp(1), euler_sp(2));
+			memcpy(&_v_att_sp->R_body[0], R_sp.data, sizeof(_v_att_sp->R_body));
+			_v_att_sp->pitch_body = _pitch_sp_transition;
+			math::Quaternion q_sp;
+			q_sp.from_dcm(R_sp);
+			memcpy(&_v_att_sp->q_d[0], &q_sp.data[0], sizeof(_v_att_sp->q_d));
+
 		} else {
 			// at low speeds give full weight to mc
 			_mc_roll_weight = 1.0f;
@@ -259,19 +274,7 @@ void Standard::update_transition_state()
 			}
 		}
 
-		// simple vertical velocity controller based on integration of vertical velocity error
-		_pitch_sp_transition -= 0.1f * (0.0f - _local_pos->vz) * _attc->get_dt();
-		_pitch_sp_transition = math::constrain(_pitch_sp_transition, -0.4f, 0.4f);
 
-		math::Matrix<3,3> R_sp(&_v_att_sp->R_body[0]);
-		math::Vector<3> euler_sp = R_sp.to_euler();
-		euler_sp(1) = _pitch_sp_transition;
-		R_sp.from_euler(euler_sp(0), euler_sp(1), euler_sp(2));
-		memcpy(&_v_att_sp->R_body[0], R_sp.data, sizeof(_v_att_sp->R_body));
-		_v_att_sp->pitch_body = _pitch_sp_transition;
-		math::Quaternion q_sp;
-		q_sp.from_dcm(R_sp);
-		memcpy(&_v_att_sp->q_d[0], &q_sp.data[0], sizeof(_v_att_sp->q_d));
 
 	} else if (_vtol_schedule.flight_mode == TRANSITION_TO_MC) {
 		// continually increase mc attitude control as we transition back to mc mode

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -244,19 +244,9 @@ void Standard::update_transition_state()
 			_mc_throttle_weight = weight;
 
 			// simple vertical velocity controller based on integration of vertical velocity error
-			_pitch_sp_transition -= 0.5f * (_local_pos_sp->vz - _local_pos->vz) * 0.004f;
+			_pitch_sp_transition -= 0.1f * (_local_pos_sp->vz - _local_pos->vz) * 0.003f;
 			_pitch_sp_transition = math::constrain(_pitch_sp_transition, -0.4f, 0.4f);
 
-	//		printf("%d\n", (double)_attc->get_dt());
-			math::Matrix<3,3> R_sp(&_v_att_sp->R_body[0]);
-			math::Vector<3> euler_sp = R_sp.to_euler();
-			euler_sp(1) = _pitch_sp_transition;
-			R_sp.from_euler(euler_sp(0), euler_sp(1), euler_sp(2));
-			memcpy(&_v_att_sp->R_body[0], R_sp.data, sizeof(_v_att_sp->R_body));
-			_v_att_sp->pitch_body = _pitch_sp_transition;
-			math::Quaternion q_sp;
-			q_sp.from_dcm(R_sp);
-			memcpy(&_v_att_sp->q_d[0], &q_sp.data[0], sizeof(_v_att_sp->q_d));
 
 		} else {
 			// at low speeds give full weight to mc
@@ -264,7 +254,19 @@ void Standard::update_transition_state()
 			_mc_pitch_weight = 1.0f;
 			_mc_yaw_weight = 1.0f;
 			_mc_throttle_weight = 1.0f;
+
+			_pitch_sp_transition = 0.0f;
 		}
+
+		math::Matrix<3,3> R_sp(&_v_att_sp->R_body[0]);
+		math::Vector<3> euler_sp = R_sp.to_euler();
+		euler_sp(1) = _pitch_sp_transition;
+		R_sp.from_euler(euler_sp(0), euler_sp(1), euler_sp(2));
+		memcpy(&_v_att_sp->R_body[0], R_sp.data, sizeof(_v_att_sp->R_body));
+		_v_att_sp->pitch_body = _pitch_sp_transition;
+		math::Quaternion q_sp;
+		q_sp.from_dcm(R_sp);
+		memcpy(&_v_att_sp->q_d[0], &q_sp.data[0], sizeof(_v_att_sp->q_d));
 
 		// check front transition timeout
 		if (_params_standard.front_trans_timeout > FLT_EPSILON) {

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -244,7 +244,7 @@ void Standard::update_transition_state()
 			_mc_throttle_weight = weight;
 
 			// simple vertical velocity controller based on integration of vertical velocity error
-			_pitch_sp_transition -= 0.5f * (0.0f - _local_pos->vz) * 0.004f;
+			_pitch_sp_transition -= 0.5f * (_local_pos_sp->vz - _local_pos->vz) * 0.004f;
 			_pitch_sp_transition = math::constrain(_pitch_sp_transition, -0.4f, 0.4f);
 
 	//		printf("%d\n", (double)_attc->get_dt());

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -105,6 +105,7 @@ private:
 	bool _flag_enable_mc_motors;
 	float _pusher_throttle;	
 	float _airspeed_trans_blend_margin;
+	float _pitch_sp_transition;		// dynamic pitch setpoint based on vertical velocity integral control
 
 	void set_max_mc(unsigned pwm_value);
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -89,7 +89,8 @@ VtolAttitudeControl::VtolAttitudeControl() :
 	_v_rates_sp_pub(nullptr),
 	_v_att_sp_pub(nullptr),
 
-	_abort_front_transition(false)
+	_abort_front_transition(false),
+	_dt(0.0f)
 
 {
 	memset(& _vtol_vehicle_status, 0, sizeof(_vtol_vehicle_status));
@@ -596,6 +597,8 @@ void VtolAttitudeControl::task_main()
 {
 	fflush(stdout);
 
+	hrt_abstime t_prev = 0;
+
 	/* do subscriptions */
 	_v_att_sp_sub          = orb_subscribe(ORB_ID(vehicle_attitude_setpoint));
 	_mc_virtual_att_sp_sub = orb_subscribe(ORB_ID(mc_virtual_attitude_setpoint));
@@ -671,6 +674,11 @@ void VtolAttitudeControl::task_main()
 			/* update parameters from storage */
 			parameters_update();
 		}
+
+		// get the dt of the control loop
+		hrt_abstime t = hrt_absolute_time();
+		_dt = t_prev != 0 ? (t - t_prev) * 0.000001f : 0.01f;
+		t_prev = t;
 
 		_vtol_vehicle_status.fw_permanent_stab = _params.vtol_fw_permanent_stab == 1 ? true : false;
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -85,6 +85,7 @@
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/tecs_status.h>
+#include <uORB/topics/vehicle_local_position_setpoint.h>
 #include <systemlib/param/param.h>
 #include <systemlib/err.h>
 #include <systemlib/systemlib.h>
@@ -132,6 +133,7 @@ public:
 	struct battery_status_s 			*get_batt_status() {return &_batt_status;}
 	struct vehicle_status_s 			*get_vehicle_status() {return &_vehicle_status;}
 	struct tecs_status_s 				*get_tecs_status() {return &_tecs_status;}
+	struct vehicle_local_position_setpoint_s *get_local_pos_sp() {return &_local_pos_sp;}
 
 	struct Params 					*get_params() {return &_params;}
 
@@ -161,6 +163,7 @@ private:
 	int 	_vehicle_cmd_sub;
 	int 	_vehicle_status_sub;
 	int	_tecs_status_sub;
+	int _local_pos_sp_sub;
 
 	int 	_actuator_inputs_mc;	//topic on which the mc_att_controller publishes actuator inputs
 	int 	_actuator_inputs_fw;	//topic on which the fw_att_controller publishes actuator inputs
@@ -193,6 +196,7 @@ private:
 	struct vehicle_command_s			_vehicle_cmd;
 	struct vehicle_status_s				_vehicle_status;
 	struct tecs_status_s				_tecs_status;
+	struct vehicle_local_position_setpoint_s _local_pos_sp;
 
 	Params _params;	// struct holding the parameters
 
@@ -244,6 +248,7 @@ private:
 	void 		vehicle_battery_poll();			// Check for battery updates
 	void		vehicle_cmd_poll();
 	void		tecs_status_poll();
+	void 		local_pos_sp_poll();
 	void 		parameters_update_poll();		//Check if parameters have changed
 	void 		vehicle_status_poll();
 	int 		parameters_update();			//Update local paraemter cache

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -135,6 +135,8 @@ public:
 
 	struct Params 					*get_params() {return &_params;}
 
+	float get_dt(){return _dt;}
+
 
 private:
 //******************flags & handlers******************************************************
@@ -214,6 +216,7 @@ private:
 	 * to waste energy when gliding. */
 	int _transition_command;
 	bool _abort_front_transition;
+	float _dt;		// delta time at which the control loop runs
 
 	VtolType *_vtol_type;	// base class for different vtol types
 	Tiltrotor *_tiltrotor;	// tailsitter vtol type

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -68,6 +68,7 @@ VtolType::VtolType(VtolAttitudeControl *att_controller) :
 	_batt_status = _attc->get_batt_status();
 	_vehicle_status = _attc->get_vehicle_status();
 	_tecs_status = _attc->get_tecs_status();
+	_local_pos_sp = _attc->get_local_pos_sp();
 	_params = _attc->get_params();
 
 	flag_idle_mc = true;

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -145,6 +145,7 @@ protected:
 	struct actuator_controls_s			*_actuators_fw_in;			//actuator controls from fw_att_control
 	struct actuator_armed_s				*_armed;					//actuator arming status
 	struct vehicle_local_position_s			*_local_pos;
+	struct vehicle_local_position_setpoint_s *_local_pos_sp;
 	struct airspeed_s 				*_airspeed;					// airspeed
 	struct battery_status_s 			*_batt_status; 				// battery status
 	struct vehicle_status_s 			*_vehicle_status;			// vehicle status from commander app


### PR DESCRIPTION
Using vertical velocity to control pitch angle during quadplane vtol transition.

- [x] Flight test
- [ ] Second flight test
- [ ] Parameterize
- [ ] Increment over delta time
- [ ] use correct delta time instead of fixed value
- [ ] how do we tell TECS to start at the integrated pitch value?