### PR TITLE
Snapdragon: use navigator 

### DIFF
--- a/cmake/configs/posix_sdflight_default.cmake
+++ b/cmake/configs/posix_sdflight_default.cmake
@@ -40,6 +40,7 @@ set(config_module_list
 	modules/sdlog2
 	modules/simulator
 	modules/commander
+	modules/navigator
 	modules/load_mon
 
 	lib/controllib

--- a/posix-configs/eagle/flight/mainapp.config
+++ b/posix-configs/eagle/flight/mainapp.config
@@ -1,5 +1,7 @@
 uorb start
 muorb start
+dataman start
+navigator start
 mavlink start -u 14556 -r 1000000
 sleep 1
 mavlink stream -u 14556 -s HIGHRES_IMU -r 50

--- a/src/modules/dataman/dataman.c
+++ b/src/modules/dataman/dataman.c
@@ -134,7 +134,11 @@ static px4_sem_t g_sys_state_mutex;
 
 /* The data manager store file handle and file name */
 static int g_fd = -1, g_task_fd = -1;
+#ifdef __PX4_POSIX_EAGLE
+static const char *default_device_path = PX4_ROOTFSDIR"/dataman";
+#else
 static const char *default_device_path = PX4_ROOTFSDIR"/fs/microsd/dataman";
+#endif
 static char *k_data_manager_device_path = NULL;
 
 /* The data manager work queues */

--- a/src/platforms/px4_defines.h
+++ b/src/platforms/px4_defines.h
@@ -160,6 +160,8 @@ __END_DECLS
 
 #if defined(__PX4_QURT)
 #define PX4_ROOTFSDIR
+#elif defined(__PX4_POSIX_EAGLE)
+#define PX4_ROOTFSDIR "/home/linaro"
 #else
 #define PX4_ROOTFSDIR "rootfs"
 #endif


### PR DESCRIPTION
This adds the navigator (and dataman) on the Linux side. We can't use the DSP side because the dataman needs `lseek()` which is not available on QURT.

Note that without this change, RTL and missions won't actually do anything.

I have tested this on the bench but it needs proper testing outdoors.
@tumbili it would be great if you could flight test this next week, otherwise I'll do it next week when I'm back.

I would suggest to first make sure POSCTL works, then try RTL, and finally a mission.

Resolves #4157.