### PR TITLE
Use the value of nuttx CONFIG_ARMV7M_STACKCHECK to configure PX4 build

### DIFF
--- a/cmake/nuttx/px4_impl_nuttx.cmake
+++ b/cmake/nuttx/px4_impl_nuttx.cmake
@@ -293,6 +293,15 @@ function(px4_nuttx_add_export)
 		add_dependencies(__nuttx_patch_${CONFIG} ${patch_name})
 	endforeach()
 
+	# Read defconfig to see if CONFIG_ARMV7M_STACKCHECK is yes 
+	# note: CONFIG will be BOARD in the future evaluation of ${hw_stack_check_${CONFIG}
+	file(STRINGS "${CMAKE_SOURCE_DIR}/nuttx-configs/${CONFIG}/${config_nuttx_config}/defconfig"
+		hw_stack_check_${CONFIG}
+		REGEX "CONFIG_ARMV7M_STACKCHECK=y"
+		)
+	if ("${hw_stack_check_${CONFIG}}" STREQUAL "CONFIG_ARMV7M_STACKCHECK=y")
+		set(config_nuttx_hw_stack_check_${CONFIG} y CACHE INTERNAL "" FORCE)
+	endif()
 
 	# export
 	file(GLOB_RECURSE config_files ${CMAKE_SOURCE_DIR}/nuttx-configs/${CONFIG}/*)
@@ -522,6 +531,17 @@ function(px4_os_add_flags)
 		)
 
 	set(added_exe_linker_flags) # none currently
+
+
+	set(instrument_flags)
+	if ("${config_nuttx_hw_stack_check_${BOARD}}" STREQUAL "y")
+		set(instrument_flags
+			-finstrument-functions
+			-ffixed-r10
+			)
+		list(APPEND c_flags ${instrument_flags})
+		list(APPEND cxx_flags ${instrument_flags})
+	endif()
 
 	set(cpu_flags)
 	if (${config_nuttx_hw} STREQUAL "m4")


### PR DESCRIPTION
Since there is a register (R10) that must be preserved for the hardware stack checking to work. Both builds: Nuttx and the Flight code must be built with consistent instrumentation flags. 

This PR use the value of CONFIG_ARMV7M_STACKCHECK from the board's defconfig to set the Flight code's instrumentation flags.

