### PR TITLE
adjust stack sizes and cleanup ignored warnings

### DIFF
--- a/Tools/check_code_style_all.sh
+++ b/Tools/check_code_style_all.sh
@@ -37,6 +37,7 @@ find \
     src/modules/systemlib \
     src/modules/unit_test \
     src/modules/uORB \
+    src/modules/vtol_att_control \
     src/platforms \
     src/systemcmds \
     -type f \( -name "*.c" -o -name "*.h" -o -name "*.cpp" -o -name "*.hpp" \) \

--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -597,7 +597,6 @@ function(px4_add_common_flags)
 		-Wall
 		-Werror
 		-Wextra
-		-Wpacked
 		-Wno-sign-compare
 		-Wshadow
 		-Wfloat-equal

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -67,6 +67,8 @@ set(config_module_list
 	systemcmds/mtd
 	systemcmds/dumpfile
 	systemcmds/ver
+	#systemcmds/sd_bench
+	#systemcmds/tests
 
 	#
 	# General system control

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -48,7 +48,7 @@ set(config_module_list
 	drivers/bst
 	drivers/snapdragon_rc_pwm
 	drivers/lis3mdl
-	drivers/bmi160
+	#drivers/bmi160
 
 	#
 	# System commands

--- a/cmake/configs/nuttx_px4fmu-v2_test.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_test.cmake
@@ -67,6 +67,8 @@ set(config_module_list
 	systemcmds/mtd
 	systemcmds/dumpfile
 	systemcmds/ver
+	systemcmds/sd_bench
+	systemcmds/tests
 
 	#
 	# Testing
@@ -77,7 +79,6 @@ set(config_module_list
 	modules/mavlink/mavlink_tests
 	modules/unit_test
 	modules/uORB/uORB_tests
-	systemcmds/tests
 
 	#
 	# General system control
@@ -111,6 +112,7 @@ set(config_module_list
 	#
 	# Logging
 	#
+	#modules/logger
 	#modules/sdlog2
 
 	#

--- a/cmake/configs/nuttx_px4fmu-v4_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v4_default.cmake
@@ -83,12 +83,11 @@ set(config_module_list
 	#
 	# Estimation modules (EKF/ SO3 / other filters)
 	#
-	# Too high RAM usage due to static allocations
-	# modules/attitude_estimator_ekf
 	modules/attitude_estimator_q
 	modules/ekf_att_pos_estimator
 	modules/position_estimator_inav
 	modules/ekf2
+	modules/local_position_estimator
 
 	#
 	# Vehicle Control

--- a/cmake/configs/posix_sitl_default.cmake
+++ b/cmake/configs/posix_sitl_default.cmake
@@ -57,6 +57,7 @@ set(config_module_list
 	modules/systemlib/mixer
 	modules/uORB
 	modules/vtol_att_control
+
 	lib/controllib
 	lib/conversion
 	lib/DriverFramework/framework
@@ -72,6 +73,17 @@ set(config_module_list
 	lib/terrain_estimation
 
 	examples/px4_simple_app
+
+	#
+	# Testing
+	#
+	modules/commander/commander_tests
+	modules/controllib_test
+	#modules/mavlink/mavlink_tests
+	modules/unit_test
+	modules/uORB/uORB_tests
+	systemcmds/tests
+
 	)
 
 set(config_extra_builtin_cmds

--- a/cmake/configs/posix_sitl_test.cmake
+++ b/cmake/configs/posix_sitl_test.cmake
@@ -49,6 +49,7 @@ set(config_module_list
 	modules/navigator
 	modules/param
 	modules/position_estimator_inav
+	modules/local_position_estimator
 	modules/sdlog2
 	modules/sensors
 	modules/simulator
@@ -72,7 +73,7 @@ set(config_module_list
 	lib/terrain_estimation
 
 	examples/px4_simple_app
-	
+
 	#
 	# Testing
 	#

--- a/cmake/nuttx/px4_impl_nuttx.cmake
+++ b/cmake/nuttx/px4_impl_nuttx.cmake
@@ -204,7 +204,7 @@ function(px4_nuttx_add_export)
 
 	# Read defconfig to see if CONFIG_ARMV7M_STACKCHECK is yes 
 	# note: CONFIG will be BOARD in the future evaluation of ${hw_stack_check_${CONFIG}
-	file(STRINGS "${CMAKE_SOURCE_DIR}/nuttx-configs/${CONFIG}/${config_nuttx_config}/defconfig"
+	file(STRINGS "${CMAKE_SOURCE_DIR}/nuttx-configs/${CONFIG}/nsh/defconfig"
 		hw_stack_check_${CONFIG}
 		REGEX "CONFIG_ARMV7M_STACKCHECK=y"
 		)

--- a/cmake/nuttx/px4_impl_nuttx.cmake
+++ b/cmake/nuttx/px4_impl_nuttx.cmake
@@ -213,13 +213,13 @@ function(px4_nuttx_add_export)
 	endif()
 
 	# copy and export
+	file(RELATIVE_PATH nuttx_cp_src ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/NuttX)
 	file(GLOB_RECURSE config_files ${CMAKE_SOURCE_DIR}/nuttx-configs/${CONFIG}/*)
 	add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/${CONFIG}.export
 		COMMAND ${MKDIR} -p ${nuttx_src}
-		COMMAND ${CP} -a ${CMAKE_SOURCE_DIR}/NuttX/. ${nuttx_src}/
-		COMMAND ${RM} -rf ${nuttx_src}/.git
+		COMMAND rsync -a --delete --exclude=.git ${nuttx_cp_src}/ ${CONFIG}/NuttX/
 		#COMMAND ${ECHO} Configuring NuttX for ${CONFIG}
-		COMMAND ${MAKE} --no-print-directory -C${nuttx_src}/nuttx -r --quiet distclean
+		#COMMAND ${MAKE} --no-print-directory -C${nuttx_src}/nuttx -r --quiet distclean
 		COMMAND ${CP} -r ${CMAKE_SOURCE_DIR}/nuttx-configs/PX4_Warnings.mk ${nuttx_src}/nuttx/
 		COMMAND ${CP} -r ${CMAKE_SOURCE_DIR}/nuttx-configs/${CONFIG} ${nuttx_src}/nuttx/configs
 		COMMAND cd ${nuttx_src}/nuttx/tools && ./configure.sh ${CONFIG}/nsh && cd ..
@@ -227,6 +227,7 @@ function(px4_nuttx_add_export)
 		COMMAND ${MAKE} --no-print-directory --quiet -C ${nuttx_src}/nuttx -j${THREADS} -r CONFIG_ARCH_BOARD=${CONFIG} export > nuttx_build.log
 		COMMAND ${CP} -r ${nuttx_src}/nuttx/nuttx-export.zip ${CMAKE_BINARY_DIR}/${CONFIG}.export
 		DEPENDS ${config_files} ${DEPENDS}
+		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 		COMMENT "Building NuttX for ${CONFIG}")
 
 	# extract
@@ -437,16 +438,6 @@ function(px4_os_add_flags)
 		)
 
 	set(added_exe_linker_flags) # none currently
-
-	set(instrument_flags)
-	if ("${config_nuttx_hw_stack_check_${BOARD}}" STREQUAL "y")
-		set(instrument_flags
-			-finstrument-functions
-			-ffixed-r10
-			)
-		list(APPEND c_flags ${instrument_flags})
-		list(APPEND cxx_flags ${instrument_flags})
-	endif()
 
 	set(cpu_flags)
 	if (${BOARD} STREQUAL "px4fmu-v1")

--- a/src/drivers/mpu6000/CMakeLists.txt
+++ b/src/drivers/mpu6000/CMakeLists.txt
@@ -33,7 +33,7 @@
 px4_add_module(
 	MODULE drivers__mpu6000
 	MAIN mpu6000
-	STACK_MAIN 1200
+	STACK_MAIN 1300
 	COMPILE_FLAGS
 		-Weffc++
 		-Os

--- a/src/drivers/ms5611/CMakeLists.txt
+++ b/src/drivers/ms5611/CMakeLists.txt
@@ -50,6 +50,7 @@ endif()
 px4_add_module(
 	MODULE drivers__ms5611
 	MAIN ms5611
+	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Os
 	SRCS ${srcs}

--- a/src/drivers/pwm_out_sim/CMakeLists.txt
+++ b/src/drivers/pwm_out_sim/CMakeLists.txt
@@ -34,6 +34,7 @@ px4_add_module(
 	MODULE drivers__pwm_out_sim
 	MAIN pwm_out_sim
 	STACK_MAIN 1200
+	STACK_MAX 1200
 	COMPILE_FLAGS
 		-Os
 	SRCS

--- a/src/drivers/pwm_out_sim/pwm_out_sim.cpp
+++ b/src/drivers/pwm_out_sim/pwm_out_sim.cpp
@@ -252,7 +252,7 @@ PWMSim::init()
 	_task = px4_task_spawn_cmd("pwm_out_sim",
 				   SCHED_DEFAULT,
 				   SCHED_PRIORITY_DEFAULT,
-				   1000,
+				   1200,
 				   (px4_main_t)&PWMSim::task_main_trampoline,
 				   nullptr);
 

--- a/src/drivers/px4flow/CMakeLists.txt
+++ b/src/drivers/px4flow/CMakeLists.txt
@@ -35,7 +35,6 @@ px4_add_module(
 	MAIN px4flow
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Wno-attributes
 		-Os
 	SRCS
 		px4flow.cpp

--- a/src/drivers/snapdragon_rc_pwm/CMakeLists.txt
+++ b/src/drivers/snapdragon_rc_pwm/CMakeLists.txt
@@ -35,8 +35,6 @@ px4_add_module(
 	MAIN snapdragon_rc_pwm
 	COMPILE_FLAGS
 		-Os
-		-Wno-attributes
-		-Wno-packed
 	SRCS
 		snapdragon_rc_pwm.cpp
 	DEPENDS

--- a/src/drivers/uart_esc/CMakeLists.txt
+++ b/src/drivers/uart_esc/CMakeLists.txt
@@ -35,7 +35,6 @@ px4_add_module(
 	MAIN uart_esc
 	COMPILE_FLAGS
 		-Os
-		-Wno-packed
 	SRCS
 		uart_esc.cpp
 	DEPENDS

--- a/src/firmware/posix/CMakeLists.txt
+++ b/src/firmware/posix/CMakeLists.txt
@@ -11,7 +11,7 @@ if ("${BOARD}" STREQUAL "eagle" OR ("${BOARD}" STREQUAL "excelsior"))
 
 	FASTRPC_STUB_GEN(../qurt/px4muorb.idl)
 
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-missing-prototypes -Wno-missing-declarations")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 	LINUX_APP(
 		APP_NAME mainapp
 		IDL_NAME px4muorb

--- a/src/modules/commander/CMakeLists.txt
+++ b/src/modules/commander/CMakeLists.txt
@@ -36,8 +36,6 @@ px4_add_module(
 	STACK_MAIN 4096
 	STACK_MAX 2450
 	COMPILE_FLAGS
-		-Wno-attributes
-		-Wno-packed
 		-Os
 	SRCS
 		commander.cpp

--- a/src/modules/fw_att_control/fw_att_control_main.cpp
+++ b/src/modules/fw_att_control/fw_att_control_main.cpp
@@ -1302,7 +1302,7 @@ FixedwingAttitudeControl::start()
 	_control_task = px4_task_spawn_cmd("fw_att_control",
 					   SCHED_DEFAULT,
 					   SCHED_PRIORITY_MAX - 5,
-					   1300,
+					   1400,
 					   (px4_main_t)&FixedwingAttitudeControl::task_main_trampoline,
 					   nullptr);
 

--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -36,11 +36,7 @@ px4_add_module(
 	STACK_MAIN 1200
 	STACK_MAX 1500
 	COMPILE_FLAGS
-		-Wno-attributes
-		-Wno-packed
 		-DMAVLINK_COMM_NUM_BUFFERS=4
-		-Wno-packed
-		-Wno-tautological-constant-out-of-range-compare
 		-Os
 	SRCS
 		mavlink.c

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2286,7 +2286,7 @@ Mavlink::start(int argc, char *argv[])
 	px4_task_spawn_cmd(buf,
 			   SCHED_DEFAULT,
 			   SCHED_PRIORITY_DEFAULT,
-			   2800,
+			   3000,
 			   (px4_main_t)&Mavlink::start_helper,
 			   (char *const *)argv);
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1109,7 +1109,7 @@ void
 MavlinkReceiver::handle_message_radio_status(mavlink_message_t *msg)
 {
 	/* telemetry status supported only on first ORB_MULTI_MAX_INSTANCES mavlink channels */
-	if (_mavlink->get_channel() < ORB_MULTI_MAX_INSTANCES) {
+	if (_mavlink->get_channel() < (mavlink_channel_t)ORB_MULTI_MAX_INSTANCES) {
 		mavlink_radio_status_t rstatus;
 		mavlink_msg_radio_status_decode(msg, &rstatus);
 
@@ -1319,7 +1319,7 @@ void
 MavlinkReceiver::handle_message_heartbeat(mavlink_message_t *msg)
 {
 	/* telemetry status supported only on first TELEMETRY_STATUS_ORB_ID_NUM mavlink channels */
-	if (_mavlink->get_channel() < ORB_MULTI_MAX_INSTANCES) {
+	if (_mavlink->get_channel() < (mavlink_channel_t)ORB_MULTI_MAX_INSTANCES) {
 		mavlink_heartbeat_t hb;
 		mavlink_msg_heartbeat_decode(msg, &hb);
 

--- a/src/modules/mavlink/mavlink_tests/CMakeLists.txt
+++ b/src/modules/mavlink/mavlink_tests/CMakeLists.txt
@@ -36,9 +36,6 @@ px4_add_module(
 	STACK_MAIN 5000
 	COMPILE_FLAGS
 		-DMAVLINK_FTP_UNIT_TEST
-		-Wno-attributes
-		-Wno-packed
-		-Wno-packed
 		-Os
 	SRCS
 		mavlink_tests.cpp

--- a/src/modules/navigator/CMakeLists.txt
+++ b/src/modules/navigator/CMakeLists.txt
@@ -35,7 +35,6 @@ px4_add_module(
 	MAIN navigator
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Wno-sign-compare
 		-Os
 	SRCS
 		navigator_main.cpp

--- a/src/modules/navigator/CMakeLists.txt
+++ b/src/modules/navigator/CMakeLists.txt
@@ -33,7 +33,7 @@
 px4_add_module(
 	MODULE modules__navigator
 	MAIN navigator
-	STACK_MAIN 1200
+	STACK_MAIN 1300
 	COMPILE_FLAGS
 		-Os
 	SRCS

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -131,7 +131,7 @@ private:
 	control::BlockParamInt _param_max_hor_distance;
 	control::BlockParamInt _param_max_ver_distance;
 
-	unsigned _outside_counter;
+	int _outside_counter;
 
 	bool inside(double lat, double lon, float altitude);
 	bool inside(const struct vehicle_global_position_s &global_position);

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1149,7 +1149,7 @@ Mission::reset_offboard_mission(struct mission_s &mission)
 			if (mission.count > 0) {
 				dm_item_t dm_current = DM_KEY_WAYPOINTS_OFFBOARD(mission.dataman_id);
 
-				for (int index = 0; index < mission.count; index++) {
+				for (unsigned index = 0; index < mission.count; index++) {
 					struct mission_item_s item;
 					const ssize_t len = sizeof(struct mission_item_s);
 

--- a/src/modules/sensors/CMakeLists.txt
+++ b/src/modules/sensors/CMakeLists.txt
@@ -35,7 +35,7 @@ px4_add_module(
 	MODULE modules__sensors
 	MAIN sensors
 	PRIORITY "SCHED_PRIORITY_MAX-5"
-	STACK_MAIN 1300
+	STACK_MAIN 2000
 	COMPILE_FLAGS
 		-O3
 	SRCS

--- a/src/modules/sensors/CMakeLists.txt
+++ b/src/modules/sensors/CMakeLists.txt
@@ -35,9 +35,8 @@ px4_add_module(
 	MODULE modules__sensors
 	MAIN sensors
 	PRIORITY "SCHED_PRIORITY_MAX-5"
-	STACK_MAIN 1200
+	STACK_MAIN 1300
 	COMPILE_FLAGS
-		-Wno-type-limits
 		-O3
 	SRCS
 		sensors.cpp

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -1945,7 +1945,7 @@ Sensors::rc_poll()
 			if (_parameters.rc_map_flightmode > 0) {
 
 				/* the number of valid slots equals the index of the max marker minus one */
-				const unsigned num_slots = manual_control_setpoint_s::MODE_SLOT_MAX;
+				const int num_slots = manual_control_setpoint_s::MODE_SLOT_MAX;
 
 				/* the half width of the range of a slot is the total range
 				 * divided by the number of slots, again divided by two

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -2276,7 +2276,7 @@ Sensors::start()
 	_sensors_task = px4_task_spawn_cmd("sensors",
 					   SCHED_DEFAULT,
 					   SCHED_PRIORITY_MAX - 5,
-					   2000,
+					   2200,
 					   (px4_main_t)&Sensors::task_main_trampoline,
 					   nullptr);
 

--- a/src/modules/simulator/CMakeLists.txt
+++ b/src/modules/simulator/CMakeLists.txt
@@ -40,9 +40,6 @@ px4_add_module(
 	MODULE modules__simulator
 	MAIN simulator
 	COMPILE_FLAGS
-		-Wno-attributes
-		-Wno-packed
-		-Wno-packed
 	SRCS
 		${SIMULATOR_SRCS}
 	DEPENDS

--- a/src/modules/systemlib/CMakeLists.txt
+++ b/src/modules/systemlib/CMakeLists.txt
@@ -80,8 +80,6 @@ px4_add_module(
 	MODULE modules__systemlib
 	COMPILE_FLAGS
 		-Wno-sign-compare
-		-Wno-attributes
-		-Wno-packed
 		-Os
 	SRCS ${SRCS}
 	DEPENDS

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -173,7 +173,7 @@ param_assert_locked(void)
 static bool
 handle_in_range(param_t param)
 {
-	int count = get_param_info_count();
+	unsigned count = get_param_info_count();
 	return (count && param < count);
 }
 

--- a/src/modules/uORB/CMakeLists.txt
+++ b/src/modules/uORB/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 px4_add_module(
 	MODULE modules__uORB
 	MAIN uorb
-	STACK_MAIN 2048
+	STACK_MAIN 2100
 	COMPILE_FLAGS
 		-Os
 	SRCS ${SRCS}

--- a/src/modules/uavcan/CMakeLists.txt
+++ b/src/modules/uavcan/CMakeLists.txt
@@ -59,9 +59,6 @@ px4_add_module(
 	STACK_MAIN 3200
 	STACK_MAX 1500
 	COMPILE_FLAGS
-		-Wno-attributes
-		-Wno-packed
-		-Wno-deprecated-declarations
 		-Os
 	SRCS
 		# Main

--- a/src/modules/vtol_att_control/CMakeLists.txt
+++ b/src/modules/vtol_att_control/CMakeLists.txt
@@ -34,8 +34,6 @@ px4_add_module(
 	MODULE modules__vtol_att_control
 	MAIN vtol_att_control
 	COMPILE_FLAGS
-		-Wno-write-strings
-		
 	SRCS
 		vtol_att_control_main.cpp
 		tiltrotor.cpp

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -395,10 +395,12 @@ Standard::set_max_mc(unsigned pwm_value)
 {
 	int ret;
 	unsigned servo_count;
-	char *dev = PWM_OUTPUT0_DEVICE_PATH;
+	const char *dev = PWM_OUTPUT0_DEVICE_PATH;
 	int fd = px4_open(dev, 0);
 
-	if (fd < 0) {PX4_WARN("can't open %s", dev);}
+	if (fd < 0) {
+		PX4_WARN("can't open %s", dev);
+	}
 
 	ret = px4_ioctl(fd, PWM_SERVO_GET_COUNT, (unsigned long)&servo_count);
 	struct pwm_output_values pwm_values;
@@ -411,7 +413,9 @@ Standard::set_max_mc(unsigned pwm_value)
 
 	ret = px4_ioctl(fd, PWM_SERVO_SET_MAX_PWM, (long unsigned int)&pwm_values);
 
-	if (ret != OK) {PX4_WARN("failed setting max values");}
+	if (ret != OK) {
+		PX4_WARN("failed setting max values");
+	}
 
 	px4_close(fd);
 }

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -155,7 +155,7 @@ void Standard::update_vtol_state()
 			// transition to MC mode if transition time has passed
 			// XXX: base this on XY hold velocity of MC
 			if (hrt_elapsed_time(&_vtol_schedule.transition_start) >
-				(_params_standard.back_trans_dur * 1000000.0f)) {
+			    (_params_standard.back_trans_dur * 1000000.0f)) {
 				_vtol_schedule.flight_mode = MC_MODE;
 			}
 		}
@@ -236,7 +236,7 @@ void Standard::update_transition_state()
 		    (float)hrt_elapsed_time(&_vtol_schedule.transition_start) > (_params_standard.front_trans_time_min * 1000000.0f)
 		   ) {
 			float weight = 1.0f - fabsf(_airspeed->indicated_airspeed_m_s - _params_standard.airspeed_blend) /
-					   _airspeed_trans_blend_margin;
+				       _airspeed_trans_blend_margin;
 			_mc_roll_weight = weight;
 			_mc_pitch_weight = weight;
 			_mc_yaw_weight = weight;
@@ -300,18 +300,19 @@ void Standard::update_mc_state()
 
 	// get projection of thrust vector on body x axis. This is used to
 	// determine the desired forward acceleration which we want to achieve with the pusher
-	math::Matrix<3,3> R(&_v_att->R[0]);
-	math::Matrix<3,3> R_sp(&_v_att_sp->R_body[0]);
-	math::Vector<3> thrust_sp_axis(-R_sp(0,2), -R_sp(1,2), -R_sp(2,2));
+	math::Matrix<3, 3> R(&_v_att->R[0]);
+	math::Matrix<3, 3> R_sp(&_v_att_sp->R_body[0]);
+	math::Vector<3> thrust_sp_axis(-R_sp(0, 2), -R_sp(1, 2), -R_sp(2, 2));
 	math::Vector<3> euler = R.to_euler();
 	R.from_euler(0, 0, euler(2));
-	math::Vector<3> body_x_zero_tilt(R(0,0), R(1,0), R(2,0));
+	math::Vector<3> body_x_zero_tilt(R(0, 0), R(1, 0), R(2, 0));
 
 	// we are using a parameter to scale the thrust value in order to compensate for highly over/under-powered motors
 	_pusher_throttle = body_x_zero_tilt * thrust_sp_axis * _v_att_sp->thrust * _params_standard.forward_thurst_scale;
 	_pusher_throttle = _pusher_throttle < 0.0f ? 0.0f : _pusher_throttle;
 
-	float pitch_sp_corrected = _v_att_sp->pitch_body < -_params_standard.down_pitch_max ? -_params_standard.down_pitch_max : _v_att_sp->pitch_body;
+	float pitch_sp_corrected = _v_att_sp->pitch_body < -_params_standard.down_pitch_max ? -_params_standard.down_pitch_max :
+				   _v_att_sp->pitch_body;
 
 	// compute new desired rotation matrix with corrected pitch angle
 	// and copy data to attitude setpoint topic

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -103,7 +103,7 @@ private:
 	} _vtol_schedule;
 
 	bool _flag_enable_mc_motors;
-	float _pusher_throttle;	
+	float _pusher_throttle;
 	float _airspeed_trans_blend_margin;
 
 	void set_max_mc(unsigned pwm_value);

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -250,9 +250,9 @@ void Tailsitter::update_transition_state()
 		/** create time dependant throttle signal higher than  in MC and growing untill  P2 switch speed reached */
 		if (_airspeed->indicated_airspeed_m_s <= _params_tailsitter.airspeed_trans) {
 			_thrust_transition = _thrust_transition_start + (fabsf(THROTTLE_TRANSITION_MAX * _thrust_transition_start) *
-					    (float)hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params_tailsitter.front_trans_dur * 1000000.0f));
+					     (float)hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params_tailsitter.front_trans_dur * 1000000.0f));
 			_thrust_transition = math::constrain(_thrust_transition , _thrust_transition_start ,
-							    (1.0f + THROTTLE_TRANSITION_MAX) * _thrust_transition_start);
+							     (1.0f + THROTTLE_TRANSITION_MAX) * _thrust_transition_start);
 			_v_att_sp->thrust = _thrust_transition;
 		}
 

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -433,10 +433,12 @@ void Tiltrotor::set_rear_motor_state(rear_motor_state state)
 
 	int ret;
 	unsigned servo_count;
-	char *dev = PWM_OUTPUT0_DEVICE_PATH;
+	const char *dev = PWM_OUTPUT0_DEVICE_PATH;
 	int fd = px4_open(dev, 0);
 
-	if (fd < 0) {PX4_WARN("can't open %s", dev);}
+	if (fd < 0) {
+		PX4_WARN("can't open %s", dev);
+	}
 
 	ret = px4_ioctl(fd, PWM_SERVO_GET_COUNT, (unsigned long)&servo_count);
 	struct pwm_output_values pwm_max_values;

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -491,6 +491,7 @@ VtolAttitudeControl::is_fixed_wing_requested()
 	if (_abort_front_transition) {
 		if (to_fw) {
 			to_fw = false;
+
 		} else {
 			// the state changed to mc mode, reset the abort request
 			_abort_front_transition = false;
@@ -507,7 +508,7 @@ VtolAttitudeControl::is_fixed_wing_requested()
 void
 VtolAttitudeControl::abort_front_transition()
 {
-	if(!_abort_front_transition) {
+	if (!_abort_front_transition) {
 		mavlink_log_critical(&_mavlink_log_pub, "Front transition timeout occured, aborting");
 		_abort_front_transition = true;
 		_vtol_vehicle_status.vtol_transition_failsafe = true;
@@ -789,8 +790,8 @@ void VtolAttitudeControl::task_main()
 
 		/* Only publish if the proper mode(s) are enabled */
 		if (_v_control_mode.flag_control_attitude_enabled ||
-			_v_control_mode.flag_control_rates_enabled ||
-			_v_control_mode.flag_control_manual_enabled) {
+		    _v_control_mode.flag_control_rates_enabled ||
+		    _v_control_mode.flag_control_manual_enabled) {
 			if (_actuators_0_pub != nullptr) {
 				orb_publish(ORB_ID(actuator_controls_0), _actuators_0_pub, &_actuators_out_0);
 

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -86,10 +86,12 @@ void VtolType::set_idle_mc()
 {
 	int ret;
 	unsigned servo_count;
-	char *dev = PWM_OUTPUT0_DEVICE_PATH;
+	const char *dev = PWM_OUTPUT0_DEVICE_PATH;
 	int fd = px4_open(dev, 0);
 
-	if (fd < 0) {PX4_WARN("can't open %s", dev);}
+	if (fd < 0) {
+		PX4_WARN("can't open %s", dev);
+	}
 
 	ret = px4_ioctl(fd, PWM_SERVO_GET_COUNT, (unsigned long)&servo_count);
 	unsigned pwm_value = _params->idle_pwm_mc;
@@ -103,7 +105,9 @@ void VtolType::set_idle_mc()
 
 	ret = px4_ioctl(fd, PWM_SERVO_SET_MIN_PWM, (long unsigned int)&pwm_values);
 
-	if (ret != OK) {PX4_WARN("failed setting min values");}
+	if (ret != OK) {
+		PX4_WARN("failed setting min values");
+	}
 
 	px4_close(fd);
 
@@ -116,10 +120,12 @@ void VtolType::set_idle_mc()
 void VtolType::set_idle_fw()
 {
 	int ret;
-	char *dev = PWM_OUTPUT0_DEVICE_PATH;
+	const char *dev = PWM_OUTPUT0_DEVICE_PATH;
 	int fd = px4_open(dev, 0);
 
-	if (fd < 0) {PX4_WARN("can't open %s", dev);}
+	if (fd < 0) {
+		PX4_WARN("can't open %s", dev);
+	}
 
 	struct pwm_output_values pwm_values;
 	memset(&pwm_values, 0, sizeof(pwm_values));
@@ -132,7 +138,9 @@ void VtolType::set_idle_fw()
 
 	ret = px4_ioctl(fd, PWM_SERVO_SET_MIN_PWM, (long unsigned int)&pwm_values);
 
-	if (ret != OK) {PX4_WARN("failed setting min values");}
+	if (ret != OK) {
+		PX4_WARN("failed setting min values");
+	}
 
 	px4_close(fd);
 }

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -128,6 +128,7 @@ void VtolType::set_idle_fw()
 	}
 
 	struct pwm_output_values pwm_values;
+
 	memset(&pwm_values, 0, sizeof(pwm_values));
 
 	for (int i = 0; i < _params->vtol_motor_count; i++) {

--- a/src/platforms/posix/drivers/accelsim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/accelsim/CMakeLists.txt
@@ -34,7 +34,6 @@ px4_add_module(
 	MODULE platforms__posix__drivers__accelsim
 	MAIN accelsim
 	COMPILE_FLAGS
-		-Wno-packed
 	SRCS
 		accelsim.cpp
 	DEPENDS

--- a/src/platforms/posix/drivers/airspeedsim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/airspeedsim/CMakeLists.txt
@@ -34,7 +34,6 @@ px4_add_module(
 	MODULE platforms__posix__drivers__airspeedsim
 	MAIN measairspeedsim
 	COMPILE_FLAGS
-		-Wno-packed
 		-Os
 	SRCS
 		airspeedsim.cpp

--- a/src/platforms/posix/drivers/barosim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/barosim/CMakeLists.txt
@@ -34,7 +34,6 @@ px4_add_module(
 	MODULE platforms__posix__drivers__barosim
 	MAIN barosim
 	COMPILE_FLAGS
-		-Wno-packed
 		-Os
 	SRCS
 		baro.cpp

--- a/src/platforms/posix/drivers/gpssim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/gpssim/CMakeLists.txt
@@ -34,7 +34,6 @@ px4_add_module(
 	MODULE platforms__posix__drivers__gpssim
 	MAIN gpssim
 	COMPILE_FLAGS
-		-Wno-packed
 		-Os
 	SRCS
 		gpssim.cpp

--- a/src/platforms/posix/drivers/gyrosim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/gyrosim/CMakeLists.txt
@@ -35,7 +35,6 @@ px4_add_module(
 	MAIN gyrosim
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Wno-packed
 		-Os
 	SRCS
 		gyrosim.cpp

--- a/src/platforms/posix/px4_layer/CMakeLists.txt
+++ b/src/platforms/posix/px4_layer/CMakeLists.txt
@@ -43,8 +43,6 @@ px4_add_module(
 	MODULE platforms__posix__px4_layer
 	COMPILE_FLAGS
 		-Os
-		-Wno-attributes
-		-Wno-packed
 	SRCS
 		px4_posix_impl.cpp
 		px4_posix_tasks.cpp

--- a/src/platforms/qurt/px4_layer/CMakeLists.txt
+++ b/src/platforms/qurt/px4_layer/CMakeLists.txt
@@ -55,7 +55,6 @@ px4_add_module(
 	MODULE platforms__qurt__px4_layer
 	COMPILE_FLAGS
 		-Os
-		-Wno-packed
 	SRCS
 		${QURT_LAYER_SRCS}
 		${CONFIG_SRC}

--- a/src/systemcmds/mtd/CMakeLists.txt
+++ b/src/systemcmds/mtd/CMakeLists.txt
@@ -34,7 +34,6 @@ px4_add_module(
 	MODULE systemcmds__mtd
 	MAIN mtd
 	COMPILE_FLAGS
-		-Wno-error
 		-Os
 	SRCS
 		mtd.c

--- a/src/systemcmds/tests/CMakeLists.txt
+++ b/src/systemcmds/tests/CMakeLists.txt
@@ -70,10 +70,10 @@ px4_add_module(
 	MODULE systemcmds__tests
 	MAIN tests
 	STACK_MAIN 9000
+	STACK_MAX 9000
 	COMPILE_FLAGS
-		-Wframe-larger-than=8000
 		-Wno-float-equal
-		-O0
+		-Os
 	SRCS ${srcs}
 	DEPENDS
 		platforms__common

--- a/src/systemcmds/tests/CMakeLists.txt
+++ b/src/systemcmds/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ px4_add_module(
 	STACK_MAIN 9000
 	STACK_MAX 9000
 	COMPILE_FLAGS
+		-Wno-unused-result
 		-Wno-float-equal
 		-Os
 	SRCS ${srcs}

--- a/src/systemcmds/tests/test_file.c
+++ b/src/systemcmds/tests/test_file.c
@@ -39,13 +39,14 @@
  * @author Lorenz Meier <lm@inf.ethz.ch>
  */
 
+#include <px4_config.h>
+#include <px4_posix.h>
+
 #include <sys/stat.h>
 #include <poll.h>
 #include <dirent.h>
 #include <stdio.h>
 #include <stddef.h>
-#include <unistd.h>
-#include <fcntl.h>
 #include <systemlib/err.h>
 #include <systemlib/perf_counter.h>
 #include <string.h>
@@ -125,7 +126,7 @@ test_file(int argc, char *argv[])
 			uint8_t read_buf[chunk_sizes[c] + alignments] __attribute__((aligned(64)));
 			hrt_abstime start, end;
 
-			int fd = open(PX4_ROOTFSDIR "/fs/microsd/testfile", O_TRUNC | O_WRONLY | O_CREAT);
+			int fd = px4_open(PX4_ROOTFSDIR "/fs/microsd/testfile", O_TRUNC | O_WRONLY | O_CREAT);
 
 			warnx("testing unaligned writes - please wait..");
 
@@ -156,7 +157,7 @@ test_file(int argc, char *argv[])
 
 			warnx("write took %" PRIu64 " us", (end - start));
 
-			close(fd);
+			px4_close(fd);
 			fd = open(PX4_ROOTFSDIR "/fs/microsd/testfile", O_RDONLY);
 
 			/* read back data for validation */
@@ -196,7 +197,7 @@ test_file(int argc, char *argv[])
 
 			close(fd);
 			int ret = unlink(PX4_ROOTFSDIR "/fs/microsd/testfile");
-			fd = open(PX4_ROOTFSDIR "/fs/microsd/testfile", O_TRUNC | O_WRONLY | O_CREAT);
+			fd = px4_open(PX4_ROOTFSDIR "/fs/microsd/testfile", O_TRUNC | O_WRONLY | O_CREAT);
 
 			warnx("testing aligned writes - please wait.. (CTRL^C to abort)");
 
@@ -218,7 +219,7 @@ test_file(int argc, char *argv[])
 
 			warnx("reading data aligned..");
 
-			close(fd);
+			px4_close(fd);
 			fd = open(PX4_ROOTFSDIR "/fs/microsd/testfile", O_RDONLY);
 
 			bool align_read_ok = true;

--- a/src/systemcmds/tests/test_mount.c
+++ b/src/systemcmds/tests/test_mount.c
@@ -39,12 +39,13 @@
  * @author Lorenz Meier <lm@inf.ethz.ch>
  */
 
+#include <px4_config.h>
+#include <px4_posix.h>
+
 #include <sys/stat.h>
 #include <dirent.h>
 #include <stdio.h>
 #include <stddef.h>
-#include <unistd.h>
-#include <fcntl.h>
 #include <systemlib/err.h>
 #include <systemlib/systemlib.h>
 #include <systemlib/perf_counter.h>
@@ -200,7 +201,7 @@ test_mount(int argc, char *argv[])
 
 			uint8_t read_buf[chunk_sizes[c] + alignments] __attribute__((aligned(64)));
 
-			int fd = open(PX4_ROOTFSDIR "/fs/microsd/testfile", O_TRUNC | O_WRONLY | O_CREAT);
+			int fd = px4_open(PX4_ROOTFSDIR "/fs/microsd/testfile", O_TRUNC | O_WRONLY | O_CREAT);
 
 			for (unsigned i = 0; i < iterations; i++) {
 
@@ -236,8 +237,8 @@ test_mount(int argc, char *argv[])
 			fsync(fileno(stderr));
 			usleep(200000);
 
-			close(fd);
-			fd = open(PX4_ROOTFSDIR "/fs/microsd/testfile", O_RDONLY);
+			px4_close(fd);
+			fd = px4_open(PX4_ROOTFSDIR "/fs/microsd/testfile", O_RDONLY);
 
 			/* read back data for validation */
 			for (unsigned i = 0; i < iterations; i++) {
@@ -267,7 +268,7 @@ test_mount(int argc, char *argv[])
 			}
 
 			int ret = unlink(PX4_ROOTFSDIR "/fs/microsd/testfile");
-			close(fd);
+			px4_close(fd);
 
 			if (ret) {
 				PX4_ERR("UNLINKING FILE FAILED");


### PR DESCRIPTION
I enabled 	CONFIG_ARMV7M_STACKCHECK and adjusted some of the insufficient stack sizes I saw. There are still more modules to check and I still did get the system fully running. Once we have a hardware test harness I think we should have a build with stackcheck enabled. Alternatively if the overhead is acceptable we could keep it enabled on px4fmu-v4.