### PR TITLE
stop spamming console with navigator timeout warnings

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -339,6 +339,7 @@ Navigator::task_main()
 			/* timed out - periodic check for _task_should_exit, etc. */
 			if (global_pos_available_once) {
 				PX4_WARN("navigator timed out");
+				global_pos_available_once = false;
 			}
 			continue;
 


### PR DESCRIPTION
report timeout only once per gps loss (added missing line to clear global_pos_available_once, which isn't referenced anywhere else)