### PR TITLE
LPE reverted local z pub change

### DIFF
--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -560,7 +560,7 @@ void BlockLocalPositionEstimator::publishLocalPos()
 		_pub_lpos.get().v_z_valid = _canEstimateZ;
 		_pub_lpos.get().x = _x(X_x); 	// north
 		_pub_lpos.get().y = _x(X_y);  	// east
-		_pub_lpos.get().z = _x(X_z); 	// down
+		_pub_lpos.get().z = -agl(); // - use agl for local z, so vehicle maintains distance above ground level (follows terrain)
 		_pub_lpos.get().vx = _x(X_vx);  // north
 		_pub_lpos.get().vy = _x(X_vy);  // east
 		_pub_lpos.get().vz = _x(X_vz); 	// down


### PR DESCRIPTION
To make end-user experience with logging/alt-hold simpler this makes local z be distance above ground (-agl), instead of the best estimate of -(vehicle asl - altHome) relative to vehicle. This is the typical desired use-case for most people if they have a device to measure terrain altitude (ultrasonic/ lidar). Maybe we can make this a parameter in the future to select what local z means to LPE, but then we should support terrain following for logmuncher etc.. All the plots currently show local z setpoint vs. local z, but if in terrain following mode, this doesn't make sense and was confusing end users.