### PR TITLE
Solve the problem When lost rc signal, it will rtl repeated.

### DIFF
--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -603,7 +603,7 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 	case commander_state_s::MAIN_STATE_ALTCTL:
 	case commander_state_s::MAIN_STATE_POSCTL:
 		/* require RC for all manual modes */
-		if (rc_loss_enabled && (status->rc_signal_lost || status_flags->rc_signal_lost_cmd) && armed && !landed) {
+		if (rc_loss_enabled && (status->rc_signal_lost || status_flags->rc_signal_lost_cmd) && armed) {
 			status->failsafe = true;
 
 			if (status_flags->condition_global_position_valid && status_flags->condition_home_position_valid) {


### PR DESCRIPTION
I think there is something wrong in lost signal condition "!landed". Because in RTL. When touched the land It is still uncompleted. But it will change to other navigator_mode. So I suggest Delete that condition.