### PR TITLE
Add the mavlink logging output to the ULog file

### DIFF
--- a/msg/mavlink_log.msg
+++ b/msg/mavlink_log.msg
@@ -1,3 +1,3 @@
 
 uint8[50] text
-uint8 severity
+uint8 severity # log level (same as in the linux kernel, starting with 0)

--- a/src/modules/logger/log_writer.cpp
+++ b/src/modules/logger/log_writer.cpp
@@ -250,7 +250,7 @@ bool LogWriter::write(void *ptr, size_t size, uint64_t dropout_start)
 	size_t dropout_size = 0;
 
 	if (dropout_start) {
-		dropout_size = sizeof(message_dropout_s);
+		dropout_size = sizeof(ulog_message_dropout_s);
 	}
 
 	if (size + dropout_size > available) {
@@ -260,7 +260,7 @@ bool LogWriter::write(void *ptr, size_t size, uint64_t dropout_start)
 
 	if (dropout_start) {
 		//write dropout msg
-		message_dropout_s dropout_msg;
+		ulog_message_dropout_s dropout_msg;
 		dropout_msg.duration = (uint16_t)(hrt_elapsed_time(&dropout_start) / 1000);
 		write_no_check(&dropout_msg, sizeof(dropout_msg));
 	}

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -75,6 +75,10 @@
 
 using namespace px4::logger;
 
+static Logger *logger_ptr = nullptr;
+static int logger_task = -1;
+static pthread_t writer_thread;
+
 int logger_main(int argc, char *argv[])
 {
 	// logger currently assumes little endian
@@ -464,7 +468,7 @@ void Logger::run()
 		return;
 	}
 
-	int ret = _writer.thread_start(_writer_thread);
+	int ret = _writer.thread_start(writer_thread);
 
 	if (ret) {
 		PX4_ERR("logger: failed to create writer thread (%i)", ret);
@@ -616,7 +620,7 @@ void Logger::run()
 	_writer.notify();
 
 	// wait for thread to complete
-	ret = pthread_join(_writer_thread, NULL);
+	ret = pthread_join(writer_thread, NULL);
 
 	if (ret) {
 		PX4_WARN("join failed: %d", ret);

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -165,6 +165,13 @@ private:
 	bool write_wait(void *ptr, size_t size);
 
 	/**
+	 * Write data to the logger and handle dropouts.
+	 * Must be called with _writer.lock() held.
+	 * @return true if data written, false otherwise (on overflow)
+	 */
+	bool write(void *ptr, size_t size);
+
+	/**
 	 * Get the time for log file name
 	 * @param tt returned time
 	 * @param boot_time use time when booted instead of current time

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -81,6 +81,13 @@ public:
 	~Logger();
 
 	/**
+	 * Tell the logger that we're in replay mode. This must be called
+	 * before starting the logger.
+	 * @param file_name file name of the used log replay file. Will be copied.
+	 */
+	static void setReplayFile(const char *file_name);
+
+	/**
 	 * Add a topic to be logged. This must be called before start_log()
 	 * (because it does not write an ADD_LOGGED_MSG message).
 	 * @param name topic name
@@ -211,6 +218,7 @@ private:
 	orb_advert_t					_mavlink_log_pub = nullptr;
 	uint16_t					_next_topic_id; ///< id of next subscribed topic
 
+	static char		*_replay_file_name;
 };
 
 } //namespace logger

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -203,11 +203,8 @@ private:
 	param_t						_log_utc_offset;
 	orb_advert_t					_mavlink_log_pub = nullptr;
 	uint16_t					_next_topic_id; ///< id of next subscribed topic
+
 };
 
-Logger *logger_ptr = nullptr;
-int		logger_task = -1;
-pthread_t _writer_thread;
-
-}
-}
+} //namespace logger
+} //namespace px4

--- a/src/modules/logger/messages.h
+++ b/src/modules/logger/messages.h
@@ -33,7 +33,7 @@
 
 #pragma once
 
-enum class MessageType : uint8_t {
+enum class ULogMessageType : uint8_t {
 	FORMAT = 'F',
 	DATA = 'D',
 	INFO = 'I',
@@ -49,78 +49,78 @@ enum class MessageType : uint8_t {
 /* declare message data structs with byte alignment (no padding) */
 #pragma pack(push, 1)
 
-#define MSG_HEADER_LEN 3 //accounts for msg_size and msg_type
+#define ULOG_MSG_HEADER_LEN 3 //accounts for msg_size and msg_type
 
 /** first bytes of the file */
-struct message_file_header_s {
+struct ulog_file_header_s {
 	uint8_t magic[8];
 	uint64_t timestamp;
 };
 
-struct message_format_s {
-	uint16_t msg_size; //size of message - MSG_HEADER_LEN
-	uint8_t msg_type = static_cast<uint8_t>(MessageType::FORMAT);
+struct ulog_message_format_s {
+	uint16_t msg_size; //size of message - ULOG_MSG_HEADER_LEN
+	uint8_t msg_type = static_cast<uint8_t>(ULogMessageType::FORMAT);
 
 	char format[2096];
 };
 
-struct message_add_logged_s {
-	uint16_t msg_size; //size of message - MSG_HEADER_LEN
-	uint8_t msg_type = static_cast<uint8_t>(MessageType::ADD_LOGGED_MSG);
+struct ulog_message_add_logged_s {
+	uint16_t msg_size; //size of message - ULOG_MSG_HEADER_LEN
+	uint8_t msg_type = static_cast<uint8_t>(ULogMessageType::ADD_LOGGED_MSG);
 
 	uint8_t multi_id;
 	uint16_t msg_id;
 	char message_name[255];
 };
 
-struct message_remove_logged_s {
-	uint16_t msg_size; //size of message - MSG_HEADER_LEN
-	uint8_t msg_type = static_cast<uint8_t>(MessageType::REMOVE_LOGGED_MSG);
+struct ulog_message_remove_logged_s {
+	uint16_t msg_size; //size of message - ULOG_MSG_HEADER_LEN
+	uint8_t msg_type = static_cast<uint8_t>(ULogMessageType::REMOVE_LOGGED_MSG);
 
 	uint16_t msg_id;
 };
 
-struct message_sync_s {
-	uint16_t msg_size; //size of message - MSG_HEADER_LEN
-	uint8_t msg_type = static_cast<uint8_t>(MessageType::SYNC);
+struct ulog_message_sync_s {
+	uint16_t msg_size; //size of message - ULOG_MSG_HEADER_LEN
+	uint8_t msg_type = static_cast<uint8_t>(ULogMessageType::SYNC);
 
 	uint8_t sync_magic[8];
 };
 
-struct message_dropout_s {
-	uint16_t msg_size = sizeof(uint16_t); //size of message - MSG_HEADER_LEN
-	uint8_t msg_type = static_cast<uint8_t>(MessageType::DROPOUT);
+struct ulog_message_dropout_s {
+	uint16_t msg_size = sizeof(uint16_t); //size of message - ULOG_MSG_HEADER_LEN
+	uint8_t msg_type = static_cast<uint8_t>(ULogMessageType::DROPOUT);
 
 	uint16_t duration; //in ms
 };
 
-struct message_data_header_s {
-	uint16_t msg_size; //size of message - MSG_HEADER_LEN
-	uint8_t msg_type = static_cast<uint8_t>(MessageType::DATA);
+struct ulog_message_data_header_s {
+	uint16_t msg_size; //size of message - ULOG_MSG_HEADER_LEN
+	uint8_t msg_type = static_cast<uint8_t>(ULogMessageType::DATA);
 
 	uint16_t msg_id;
 };
 
-struct message_info_header_s {
-	uint16_t msg_size; //size of message - MSG_HEADER_LEN
-	uint8_t msg_type = static_cast<uint8_t>(MessageType::INFO);
+struct ulog_message_info_header_s {
+	uint16_t msg_size; //size of message - ULOG_MSG_HEADER_LEN
+	uint8_t msg_type = static_cast<uint8_t>(ULogMessageType::INFO);
 
 	uint8_t key_len;
 	char key[255];
 };
 
-struct message_logging_s {
-	uint16_t msg_size; //size of message - MSG_HEADER_LEN
-	uint8_t msg_type = static_cast<uint8_t>(MessageType::LOGGING);
+struct ulog_message_logging_s {
+	uint16_t msg_size; //size of message - ULOG_MSG_HEADER_LEN
+	uint8_t msg_type = static_cast<uint8_t>(ULogMessageType::LOGGING);
 
 	uint8_t log_level; //same levels as in the linux kernel
 	uint64_t timestamp;
 	char message[255];
 };
 
-struct message_parameter_header_s {
+struct ulog_message_parameter_header_s {
 	uint16_t msg_size;
-	uint8_t msg_type = static_cast<uint8_t>(MessageType::PARAMETER);
+	uint8_t msg_type = static_cast<uint8_t>(ULogMessageType::PARAMETER);
 
 	uint8_t key_len;
 	char key[255];

--- a/src/modules/logger/messages.h
+++ b/src/modules/logger/messages.h
@@ -42,6 +42,7 @@ enum class MessageType : uint8_t {
 	REMOVE_LOGGED_MSG = 'R',
 	SYNC = 'S',
 	DROPOUT = 'O',
+	LOGGING = 'L',
 };
 
 
@@ -106,6 +107,15 @@ struct message_info_header_s {
 
 	uint8_t key_len;
 	char key[255];
+};
+
+struct message_logging_s {
+	uint16_t msg_size; //size of message - MSG_HEADER_LEN
+	uint8_t msg_type = static_cast<uint8_t>(MessageType::LOGGING);
+
+	uint8_t log_level; //same levels as in the linux kernel
+	uint64_t timestamp;
+	char message[255];
 };
 
 struct message_parameter_header_s {

--- a/src/modules/systemlib/mavlink_log.c
+++ b/src/modules/systemlib/mavlink_log.c
@@ -64,6 +64,7 @@ __EXPORT void mavlink_vasprintf(int severity, orb_advert_t *mavlink_log_pub, con
 	struct mavlink_log_s log_msg;
 
 	log_msg.severity = severity;
+	log_msg.timestamp = hrt_absolute_time();
 
 	va_list ap;
 

--- a/src/modules/systemlib/mavlink_log.c
+++ b/src/modules/systemlib/mavlink_log.c
@@ -64,6 +64,7 @@ __EXPORT void mavlink_vasprintf(int severity, orb_advert_t *mavlink_log_pub, con
 	struct mavlink_log_s log_msg;
 
 	log_msg.severity = severity;
+
 	log_msg.timestamp = hrt_absolute_time();
 
 	va_list ap;

--- a/src/modules/uORB/Subscription.cpp
+++ b/src/modules/uORB/Subscription.cpp
@@ -49,6 +49,7 @@
 #include "topics/position_setpoint_triplet.h"
 #include "topics/vehicle_status.h"
 #include "topics/manual_control_setpoint.h"
+#include "topics/mavlink_log.h"
 #include "topics/vehicle_local_position_setpoint.h"
 #include "topics/vehicle_local_position.h"
 #include "topics/vehicle_attitude_setpoint.h"
@@ -165,6 +166,7 @@ template class __EXPORT Subscription<encoders_s>;
 template class __EXPORT Subscription<position_setpoint_triplet_s>;
 template class __EXPORT Subscription<vehicle_status_s>;
 template class __EXPORT Subscription<manual_control_setpoint_s>;
+template class __EXPORT Subscription<mavlink_log_s>;
 template class __EXPORT Subscription<vehicle_local_position_setpoint_s>;
 template class __EXPORT Subscription<vehicle_local_position_s>;
 template class __EXPORT Subscription<vehicle_attitude_setpoint_s>;


### PR DESCRIPTION
Once the new logger becomes the default, we can remove the current mavlink log files msgs_*.txt

Another goal will be to add the PX4_{WARN,ERR} to the ULog file and replace all warnx/errx with PX4_{WARN,ERR}. But this will require some more refactoring.