### PR TITLE
Changes required to support Hexagon SDK 3.0

### DIFF
--- a/cmake/configs/qurt_eagle_travis.cmake
+++ b/cmake/configs/qurt_eagle_travis.cmake
@@ -8,6 +8,7 @@ set(QURT_ENABLE_STUBS "1")
 set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/cmake/cmake_hexagon/toolchain/Toolchain-qurt.cmake)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/cmake_hexagon")
+include(hexagon_sdk)
 
 if ("$ENV{HEXAGON_SDK_ROOT}" STREQUAL "")
 	message(FATAL_ERROR "Enviroment variable HEXAGON_SDK_ROOT must be set")

--- a/cmake/configs/qurt_eagle_travis.cmake
+++ b/cmake/configs/qurt_eagle_travis.cmake
@@ -15,7 +15,7 @@ else()
 	set(HEXAGON_SDK_ROOT $ENV{HEXAGON_SDK_ROOT})
 endif()
 
-include_directories(${HEXAGON_SDK_ROOT}/libs/common/qurt/ADSPv5MP/include)
+include_directories(${HEXAGON_8074_INCLUDES})
 
 set(config_generate_parameters_scope ALL)
 

--- a/cmake/configs/qurt_eagle_travis.cmake
+++ b/cmake/configs/qurt_eagle_travis.cmake
@@ -15,7 +15,7 @@ else()
 	set(HEXAGON_SDK_ROOT $ENV{HEXAGON_SDK_ROOT})
 endif()
 
-include_directories(${HEXAGON_SDK_ROOT}/lib/common/qurt/ADSPv5MP/include)
+include_directories(${HEXAGON_SDK_ROOT}/libs/common/qurt/ADSPv5MP/include)
 
 set(config_generate_parameters_scope ALL)
 

--- a/src/modules/muorb/krait/CMakeLists.txt
+++ b/src/modules/muorb/krait/CMakeLists.txt
@@ -30,11 +30,11 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/cmake_hexagon")
+include(hexagon_sdk)
+
 include_directories(${CMAKE_BINARY_DIR}/src/firmware/posix)
-include_directories(
-	${HEXAGON_SDK_ROOT}/inc/stddef
-	${HEXAGON_SDK_ROOT}/lib/common/rpcmem
-	)
+include_directories(${HEXAGON_SDK_INCLUDES})
 
 px4_add_module(
 	MODULE modules__muorb__krait

--- a/src/platforms/qurt/px4_layer/CMakeLists.txt
+++ b/src/platforms/qurt/px4_layer/CMakeLists.txt
@@ -30,8 +30,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/cmake_hexagon")
+include(hexagon_sdk)
 
-include_directories(${HEXAGON_SDK_ROOT}/libs/common/qurt/ADSPv5MP/include)
+include_directories(${HEXAGON_8074_INCLUDES})
 
 set(QURT_LAYER_SRCS
 	px4_qurt_impl.cpp

--- a/src/platforms/qurt/px4_layer/CMakeLists.txt
+++ b/src/platforms/qurt/px4_layer/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-include_directories(${HEXAGON_SDK_ROOT}/lib/common/qurt/ADSPv5MP/include)
+include_directories(${HEXAGON_SDK_ROOT}/libs/common/qurt/ADSPv5MP/include)
 
 set(QURT_LAYER_SRCS
 	px4_qurt_impl.cpp

--- a/src/platforms/qurt/stubs/stubs_posix.c
+++ b/src/platforms/qurt/stubs/stubs_posix.c
@@ -148,6 +148,11 @@ int pthread_mutexattr_settype(pthread_mutexattr_t *attr, int type)
 	return -1;
 }
 
+int pthread_condattr_init(pthread_condattr_t *attr)
+{
+	return -1;
+}
+
 int fsync(int fd)
 {
 	return -1;


### PR DESCRIPTION
The inc and lib directories were renamed to incs and libs in Hexagon SDK 3.0.

This requires an updated cmake_hexagon and some changes to
PX4. Both Hexagon SDK 2.0 and 3.0 are supported with this patch.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>