### PR TITLE
Preventing division by zero

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -489,9 +489,9 @@ void Ekf2::task_main()
 		}
 
 		// read airspeed data if available
-		float eas2tas = airspeed.true_airspeed_m_s / airspeed.indicated_airspeed_m_s;
-
 		if (airspeed_updated && airspeed.true_airspeed_m_s > 7.0f) {
+			float eas2tas = airspeed.true_airspeed_m_s / airspeed.indicated_airspeed_m_s;
+
 			_ekf.setAirspeedData(airspeed.timestamp, &airspeed.true_airspeed_m_s, &eas2tas);
 		}
 


### PR DESCRIPTION
In case airspeed is zero, this is division by zero. As true and indicated airspeeds are affine, the check for true_airspeed>7.0f should make sure that also indicated airspeed is non-zero.

Additionally saves some computation time, if airspeed can not be updated.