### PR TITLE
sdlog2: fix Segfault on Eagle

### DIFF
--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -917,8 +917,13 @@ bool copy_if_updated_multi(orb_id_t topic, int multi_instance, int *handle, void
 			*handle = orb_subscribe_multi(topic, multi_instance);
 			/* copy first data */
 			if (*handle >= 0) {
-				orb_copy(topic, *handle, buffer);
-				updated = true;
+
+				/* but only if it has really been updated */
+				orb_check(*handle, &updated);
+
+				if (updated) {
+					orb_copy(topic, *handle, buffer);
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
Since orb_exist doesn't work on the Snapdragon Linux side, we need to do
an additional orb_check after the orb_subscribe_multi, otherwise we copy
garbage.

The segfault was triggered by a count/length information about ESC
packets which lead to access outside the struct in the garbage case.

@LorenzMeier or @bkueng please review.

Fixes #4638.