### PR TITLE
Wip - DO NOT MERGE

### DIFF
--- a/src/drivers/boards/mindpx-v2/board_config.h
+++ b/src/drivers/boards/mindpx-v2/board_config.h
@@ -146,14 +146,14 @@ __BEGIN_DECLS
 #define PX4_SPI_BUS_BARO	PX4_SPI_BUS_SENSORS
 
 /* Use these in place of the spi_dev_e enumeration to select a specific SPI device on SPI1 */
-#define PX4_SPIDEV_GYRO		1
-#define PX4_SPIDEV_ACCEL_MAG	2
-#define PX4_SPIDEV_BARO		3
-#define PX4_SPIDEV_MPU		4
+#define PX4_SPIDEV_GYRO      1
+#define PX4_SPIDEV_ACCEL_MAG 2
+#define PX4_SPIDEV_BARO      3
+#define PX4_SPIDEV_MPU       4
 
 
 #define PX4_SPIDEV_FLASH        5
-
+#define PX4_BOARD_HAS_MPU6500   1
 
 /* External bus */
 #define PX4_SPIDEV_EXT0		1
@@ -168,16 +168,17 @@ __BEGIN_DECLS
 //#define PX4_SPIDEV_EXT_GYRO		PX4_SPIDEV_EXT3
 
 /* I2C busses */
-#define PX4_I2C_BUS_EXPANSION	2
-#define PX4_I2C_BUS_ONBOARD	1
+#define PX4_I2C_BUS_ONBOARD   1
+#define PX4_I2C_BUS_EXPANSION 2
 
-/* Devices on the onboard bus.
+/*
+ * i2c Devices on the onboard bus.
  *
- * Note that these are unshifted addresses.
+ * Note that these are unshifted addresses. If the address
+ * is strapped different than the device default, it should be
+ * listed here.
  */
-//#define PX4_I2C_OBDEV_LED	0x55
-#define PX4_I2C_OBDEV_HMC5883	0x1e
-//#define PX4_I2C_OBDEV_MPU6050	0x68
+#define PX4_BOARD_HAS_I2C_HMC5883 1
 
 /*
  * ADC channels

--- a/src/drivers/boards/px4fmu-v1/board_config.h
+++ b/src/drivers/boards/px4fmu-v1/board_config.h
@@ -103,17 +103,20 @@ __BEGIN_DECLS
 /*
  * I2C busses
  */
-#define PX4_I2C_BUS_ESC		1
-#define PX4_I2C_BUS_ONBOARD	2
-#define PX4_I2C_BUS_EXPANSION	3
-#define PX4_I2C_BUS_LED		3
+#define PX4_I2C_BUS_ESC         1
+#define PX4_I2C_BUS_ONBOARD     2
+#define PX4_I2C_BUS_EXPANSION   3
+#define PX4_I2C_BUS_LED         3
 
 /*
- * Devices on the onboard bus.
+ * i2c Devices on the onboard bus.
  *
- * Note that these are unshifted addresses.
+ * Note that these are unshifted addresses. If the address
+ * is strapped different than the device default, it should be
+ * listed here.
  */
-#define PX4_I2C_OBDEV_HMC5883	0x1e
+#define PX4_BOARD_HAS_I2C_HMC5883 1
+
 #define PX4_I2C_OBDEV_EEPROM	NOTDEFINED
 #define PX4_I2C_OBDEV_LED	0x55
 

--- a/src/drivers/boards/px4fmu-v2/board_config.h
+++ b/src/drivers/boards/px4fmu-v2/board_config.h
@@ -146,13 +146,14 @@ __BEGIN_DECLS
 #define PX4_I2C_BUS_ONBOARD	2
 #define PX4_I2C_BUS_LED		PX4_I2C_BUS_ONBOARD
 
-/* Devices on the onboard bus.
+/*
+ * Devices on the onboard bus.
  *
- * Note that these are unshifted addresses.
+ * Note that these are unshifted addresses. If the address
+ * is strapped different than the device default, it should be
+ * listed here.
  */
 #define PX4_I2C_OBDEV_LED	0x55
-#define PX4_I2C_OBDEV_HMC5883	0x1e
-#define PX4_I2C_OBDEV_LIS3MDL	0x1e
 
 /*
  * ADC channels

--- a/src/drivers/boards/px4fmu-v4/board_config.h
+++ b/src/drivers/boards/px4fmu-v4/board_config.h
@@ -147,13 +147,13 @@ __BEGIN_DECLS
 #define PX4_I2C_BUS_EXPANSION	1
 #define PX4_I2C_BUS_LED			PX4_I2C_BUS_EXPANSION
 
-/* Devices on the external bus.
+/*
+ * 12c Devices on the onboard bus.
  *
- * Note that these are unshifted addresses.
+ * Note that these are unshifted addresses. If the address
+ * is strapped different than the device default, it should be
+ * listed here.
  */
-#define PX4_I2C_OBDEV_LED	0x55
-#define PX4_I2C_OBDEV_HMC5883	0x1e
-#define PX4_I2C_OBDEV_LIS3MDL	0x1e
 
 /*
  * ADC channels

--- a/src/drivers/hmc5883/hmc5883_i2c.cpp
+++ b/src/drivers/hmc5883/hmc5883_i2c.cpp
@@ -58,10 +58,11 @@
 #include "hmc5883.h"
 
 #include "board_config.h"
+#if defined(PX4_I2C_BUS_ONBOARD) || defined(PX4_I2C_BUS_EXPANSION)
 
-#ifdef PX4_I2C_OBDEV_HMC5883
+/* The unshifted i2c address of this device */
 
-#define HMC5883L_ADDRESS		PX4_I2C_OBDEV_HMC5883
+#define HMC5883L_ADDRESS		0x1e
 
 device::Device *HMC5883_I2C_interface(int bus);
 
@@ -113,16 +114,14 @@ HMC5883_I2C::ioctl(unsigned operation, unsigned &arg)
 	switch (operation) {
 
 	case MAGIOCGEXTERNAL:
-// On PX4v1 the MAG can be on an internal I2C
-// On everything else its always external
-#ifdef CONFIG_ARCH_BOARD_PX4FMU_V1
+
+#if	defined(PX4_BOARD_HAS_I2C_HMC5883)
 		if (_bus == PX4_I2C_BUS_EXPANSION) {
 			return 1;
 
 		} else {
 			return 0;
 		}
-
 #else
 		return 1;
 #endif
@@ -184,5 +183,4 @@ HMC5883_I2C::read(unsigned address, void *data, unsigned count)
 	uint8_t cmd = address;
 	return transfer(&cmd, 1, (uint8_t *)data, count);
 }
-
-#endif /* PX4_I2C_OBDEV_HMC5883 */
+#endif //  defined(PX4_I2C_BUS_ONBOARD) || defined(PX4_I2C_BUS_EXPANSION)

--- a/src/systemcmds/ver/ver.c
+++ b/src/systemcmds/ver/ver.c
@@ -163,7 +163,7 @@ int ver_main(int argc, char *argv[])
 				unsigned patch = (fwver >> (8 * 1)) & 0xFF;
 				unsigned type = (fwver >> (8 * 0)) & 0xFF;
 				printf("FW version: %s (%u.%u.%u %s)\n", px4_git_tag, major, minor, patch,
-					(type == 0) ? "stable" : "beta");
+				       (type == 0) ? "stable" : "beta");
 				/* middleware is currently the same thing as firmware, so not printing yet */
 				printf("OS version: %s (%u)\n", os_git_tag, version_tag_to_number(os_git_tag));
 				ret = 0;


### PR DESCRIPTION
  This is an interuppted dev of a fix for  #defines of  PX4_I2C_OBDEV_{HMC5883} in board_configs.h that do not have that device on board but need the driver.

It will also  address mods that were done to drv_sensor.h for mindpx-v2 so support a component model where a board has components. Therefor the construct of #ifdef  CONFIG_ARCH_BOARD_xxxx should be #ifdef PX4_BOARD_HAS_MPU6500  then any new board with an MPU6500 sets  PX4_BOARD_HAS_MPU6500  and the code in drv_sensor will not change