### PR TITLE
Fixed stack overflow in UAVCAN process

### DIFF
--- a/src/modules/uavcan/uavcan_main.hpp
+++ b/src/modules/uavcan/uavcan_main.hpp
@@ -99,7 +99,7 @@ class UavcanNode : public device::CDev
 	 */
 
 	static constexpr unsigned RxQueueLenPerIface	= FramePerMSecond * PollTimeoutMs; // At
-	static constexpr unsigned StackSize		= 1800;
+	static constexpr unsigned StackSize		= 2400;
 
 public:
 	typedef uavcan_stm32::CanInitHelper<RxQueueLenPerIface> CanInitHelper;

--- a/src/modules/uavcan/uavcan_servers.cpp
+++ b/src/modules/uavcan/uavcan_servers.cpp
@@ -923,7 +923,6 @@ void UavcanServers::unpackFwFromROMFS(const char* sd_path, const char* romfs_pat
 
 	DIR* const romfs_dir = opendir(romfs_path);
 	if (!romfs_dir) {
-		warnx("base: couldn't open %s", romfs_path);
 		return;
 	}
 


### PR DESCRIPTION
Not sure when did this change, but the UAVCAN process now requires ~2100 bytes of stack instead of 1700 (tested with GCC 4.8 and 4.9). This changeset increases the UAVCAN stack to 2400 bytes, which fixes occasional crashes due to stack overflow.

At least f290650646e6b8feaec4e4e03c7b1d67f5100d95 should be cherry-picked into stable.

FYI @Aperture-Laboratories