### PR TITLE
EKF2: Add support for external vision observations

### DIFF
--- a/msg/ekf2_replay.msg
+++ b/msg/ekf2_replay.msg
@@ -7,6 +7,7 @@ uint64 baro_timestamp			# timestamp of barometer measurement in us
 uint64 rng_timestamp			# timestamp of range finder measurement in us
 uint64 flow_timestamp			# timestamp of optical flow measurement in us
 uint64 asp_timestamp			# timestamp of airspeed measurement in us
+uint64 ev_timestamp			# timestamp of external vision measurement in us
 
 float32[3] gyro_integral_rad		# integrated gyro vector in rad
 float32[3] accelerometer_integral_m_s  	# integrated accelerometer vector in m/s
@@ -46,3 +47,8 @@ float32 true_airspeed_unfiltered_m_s	# true airspeed in meters per second, -1 if
 float32 air_temperature_celsius		# air temperature in degrees celsius, -1000 if unknown
 float32 confidence			# confidence value from 0 to 1 for this sensor
 
+# external vision measurements
+float32[3] pos_ev			# position in earth (NED) frame (metres)
+float32[4] quat_ev			# quaternion rotation from earth (NED) to body (XYZ) frame
+float32 pos_err				# position error 1-std for each axis (metres)
+float32 ang_err				# angular error 1-std for each axis (rad)

--- a/msg/vision_position_estimate.msg
+++ b/msg/vision_position_estimate.msg
@@ -12,3 +12,6 @@ float32 vy			# Y velocity in meters per second in NED earth-fixed frame
 float32 vz			# Z velocity in meters per second in NED earth-fixed frame
 
 float32[4] q			# Estimated attitude as quaternion
+
+float32 pos_err			# position error 1-std for each axis (metres)
+float32 ang_err			# angular error 1-std for each axis (rad)

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -168,6 +168,7 @@ private:
 	control::BlockParamFloat _flow_delay_ms;
 	control::BlockParamFloat _rng_delay_ms;
 	control::BlockParamFloat _airspeed_delay_ms;
+	control::BlockParamFloat _ev_delay_ms;
 
 	control::BlockParamFloat _gyro_noise;
 	control::BlockParamFloat _accel_noise;
@@ -220,6 +221,11 @@ private:
 	control::BlockParamFloat _range_innov_gate;	// range finder fusion innovation consistency gate size (STD)
 	control::BlockParamFloat _rng_gnd_clearance;	// minimum valid value for range when on ground (m)
 
+	// vision estimate fusion
+	control::BlockParamFloat _ev_noise;		// observation noise for range finder measurements (m)
+	control::BlockParamFloat _ev_innov_gate;	// range finder fusion innovation consistency gate size (STD)
+	control::BlockParamFloat _ev_gnd_clearance;	// minimum valid value for range when on ground (m)
+
 	// optical flow fusion
 	control::BlockParamFloat
 	_flow_noise;		// best quality observation noise for optical flow LOS rate measurements (rad/sec)
@@ -242,6 +248,9 @@ private:
 	control::BlockParamFloat _flow_pos_x;	// X position of optical flow sensor focal point in body frame (m)
 	control::BlockParamFloat _flow_pos_y;	// Y position of optical flow sensor focal point in body frame (m)
 	control::BlockParamFloat _flow_pos_z;	// Z position of optical flow sensor focal point in body frame (m)
+	control::BlockParamFloat _ev_pos_x;	// X position of VI sensor focal point in body frame (m)
+	control::BlockParamFloat _ev_pos_y;	// Y position of VI sensor focal point in body frame (m)
+	control::BlockParamFloat _ev_pos_z;	// Z position of VI sensor focal point in body frame (m)
 
 	// output predictor filter time constants
 	control::BlockParamFloat _tau_vel;	// time constant used by the output velocity complementary filter (s)
@@ -279,6 +288,7 @@ Ekf2::Ekf2():
 	_flow_delay_ms(this, "EKF2_OF_DELAY", false, &_params->flow_delay_ms),
 	_rng_delay_ms(this, "EKF2_RNG_DELAY", false, &_params->range_delay_ms),
 	_airspeed_delay_ms(this, "EKF2_ASP_DELAY", false, &_params->airspeed_delay_ms),
+	_ev_delay_ms(this, "EKF2_EV_DELAY", false, &_params->ev_delay_ms),
 	_gyro_noise(this, "EKF2_GYR_NOISE", false, &_params->gyro_noise),
 	_accel_noise(this, "EKF2_ACC_NOISE", false, &_params->accel_noise),
 	_gyro_bias_p_noise(this, "EKF2_GYR_B_NOISE", false, &_params->gyro_bias_p_noise),
@@ -318,6 +328,9 @@ Ekf2::Ekf2():
 	_range_noise(this, "EKF2_RNG_NOISE", false, &_params->range_noise),
 	_range_innov_gate(this, "EKF2_RNG_GATE", false, &_params->range_innov_gate),
 	_rng_gnd_clearance(this, "EKF2_MIN_RNG", false, &_params->rng_gnd_clearance),
+	_ev_noise(this, "EKF2_EV_NOISE", false, &_params->ev_noise),
+	_ev_innov_gate(this, "EKF2_EV_GATE", false, &_params->ev_innov_gate),
+	_ev_gnd_clearance(this, "EKF2_MIN_EV", false, &_params->ev_gnd_clearance),
 	_flow_noise(this, "EKF2_OF_N_MIN", false, &_params->flow_noise),
 	_flow_noise_qual_min(this, "EKF2_OF_N_MAX", false, &_params->flow_noise_qual_min),
 	_flow_qual_min(this, "EKF2_OF_QMIN", false, &_params->flow_qual_min),
@@ -335,6 +348,9 @@ Ekf2::Ekf2():
 	_flow_pos_x(this, "EKF2_OF_POS_X", false, &_params->flow_pos_body(0)),
 	_flow_pos_y(this, "EKF2_OF_POS_Y", false, &_params->flow_pos_body(1)),
 	_flow_pos_z(this, "EKF2_OF_POS_Z", false, &_params->flow_pos_body(2)),
+	_ev_pos_x(this, "EKF2_EV_POS_X", false, &_params->ev_pos_body(0)),
+	_ev_pos_y(this, "EKF2_EV_POS_Y", false, &_params->ev_pos_body(1)),
+	_ev_pos_z(this, "EKF2_EV_POS_Z", false, &_params->ev_pos_body(2)),
 	_tau_vel(this, "EKF2_TAU_VEL", false, &_params->vel_Tau),
 	_tau_pos(this, "EKF2_TAU_POS", false, &_params->pos_Tau),
 	_gyr_bias_init(this, "EKF2_GBIAS_INIT", false, &_params->switch_on_gyro_bias),

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -498,8 +498,10 @@ PARAM_DEFINE_INT32(EKF2_AID_MASK, 1);
  *
  * @group EKF2
  * @value 0 Barometric pressure
- * @value 1 Reserved (GPS)
+ * @value 1 GPS
  * @value 2 Range sensor
+ * @value 3 Vision
+ *
  */
 PARAM_DEFINE_INT32(EKF2_HGT_MODE, 0);
 

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -535,14 +535,24 @@ PARAM_DEFINE_FLOAT(EKF2_MIN_RNG, 0.1f);
 
 
 /**
- * Measurement noise for vision estimate fusion
+ * Measurement noise for vision position observations used when the vision system does not supply error estimates
  *
  * @group EKF2
  * @min 0.01
  * @unit m
  * @decimal 2
  */
-PARAM_DEFINE_FLOAT(EKF2_EV_NOISE, 0.05f);
+PARAM_DEFINE_FLOAT(EKF2_EVP_NOISE, 0.05f);
+
+/**
+ * Measurement noise for vision angle observations used when the vision system does not supply error estimates
+ *
+ * @group EKF2
+ * @min 0.01
+ * @unit rad
+ * @decimal 2
+ */
+PARAM_DEFINE_FLOAT(EKF2_EVA_NOISE, 0.05f);
 
 /**
  * Gate size for vision estimate fusion

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -109,6 +109,17 @@ PARAM_DEFINE_FLOAT(EKF2_RNG_DELAY, 5);
 PARAM_DEFINE_FLOAT(EKF2_ASP_DELAY, 200);
 
 /**
+ * Vision Position Estimator delay relative to IMU measurements
+ *
+ * @group EKF2
+ * @min 0
+ * @max 300
+ * @unit ms
+ * @decimal 1
+ */
+PARAM_DEFINE_FLOAT(EKF2_EV_DELAY, 175);
+
+/**
  * Integer bitmask controlling GPS checks.
  * 
  * Set bits to 1 to enable checks. Checks enabled by the following bit positions
@@ -471,10 +482,12 @@ PARAM_DEFINE_INT32(EKF2_REC_RPL, 0);
  * 0 : Set to true to use GPS data if available
  * 1 : Set to true to use optical flow data if available
  * 2 : Set to true to inhibit IMU bias estimation
- *
+ * 3 : Set to true to enable vision position fusion
+ * 4 : Set to true to enable vision yaw fusion
+ * *
  * @group EKF2
  * @min 0
- * @max 15
+ * @max 28
  */
 PARAM_DEFINE_INT32(EKF2_AID_MASK, 1);
 
@@ -520,6 +533,36 @@ PARAM_DEFINE_FLOAT(EKF2_RNG_GATE, 5.0f);
  */
 PARAM_DEFINE_FLOAT(EKF2_MIN_RNG, 0.1f);
 
+
+/**
+ * Measurement noise for vision estimate fusion
+ *
+ * @group EKF2
+ * @min 0.01
+ * @unit m
+ * @decimal 2
+ */
+PARAM_DEFINE_FLOAT(EKF2_EV_NOISE, 0.05f);
+
+/**
+ * Gate size for vision estimate fusion
+ *
+ * @group EKF2
+ * @min 1.0
+ * @unit SD
+ * @decimal 1
+ */
+PARAM_DEFINE_FLOAT(EKF2_EV_GATE, 5.0f);
+
+/**
+ * Minimum valid range for the vision estimate
+ *
+ * @group EKF2
+ * @min 0.01
+ * @unit m
+ * @decimal 2
+ */
+PARAM_DEFINE_FLOAT(EKF2_MIN_EV, 0.01f);
 /**
  * Measurement noise for the optical flow sensor when it's reported quality metric is at the maximum
  *
@@ -701,7 +744,35 @@ PARAM_DEFINE_FLOAT(EKF2_OF_POS_Y, 0.0f);
 PARAM_DEFINE_FLOAT(EKF2_OF_POS_Z, 0.0f);
 
 /**
- * Time constant of the velocity output prediction and smoothing filter. Controls how tightly the velocity output tracks the EKF states. Set to a negative number to disable the EKF velocity state tracking. This will cause the output velocity to track the output position time derivative.
+* X position of VI sensor focal point in body frame
+ *
+ * @group EKF2
+ * @unit m
+ * @decimal 3
+ */
+PARAM_DEFINE_FLOAT(EKF2_EV_POS_X, 0.0f);
+
+/**
+ * Y position of VI sensor focal point in body frame
+ *
+ * @group EKF2
+ * @unit m
+ * @decimal 3
+ */
+PARAM_DEFINE_FLOAT(EKF2_EV_POS_Y, 0.0f);
+
+/**
+ * Z position of VI sensor focal point in body frame
+ *
+ * @group EKF2
+ * @unit m
+ * @decimal 3
+ */
+PARAM_DEFINE_FLOAT(EKF2_EV_POS_Z, 0.0f);
+
+/**
+
+ * Time constant of the velocity output prediction and smoothing filter
  *
  * @group EKF2
  * @max 1.0

--- a/src/modules/ekf2_replay/ekf2_replay_main.cpp
+++ b/src/modules/ekf2_replay/ekf2_replay_main.cpp
@@ -70,6 +70,7 @@
 #include <uORB/topics/optical_flow.h>
 #include <uORB/topics/distance_sensor.h>
 #include <uORB/topics/airspeed.h>
+#include <uORB/topics/vision_position_estimate.h>
 
 #include <sdlog2/sdlog2_messages.h>
 
@@ -135,6 +136,7 @@ private:
 	orb_advert_t _flow_pub;
 	orb_advert_t _range_pub;
 	orb_advert_t _airspeed_pub;
+	orb_advert_t _ev_pub;
 
 	int _att_sub;
 	int _estimator_status_sub;
@@ -151,6 +153,7 @@ private:
 	struct optical_flow_s _flow;
 	struct distance_sensor_s _range;
 	struct airspeed_s _airspeed;
+	struct vision_position_estimate_s _ev;
 
 	unsigned _message_counter; // counter which will increase with every message read from the log
 	unsigned _part1_counter_ref;		// this is the value of _message_counter when the part1 of the replay message is read (imu data)
@@ -158,6 +161,7 @@ private:
 	bool _read_part3;
 	bool _read_part4;
 	bool _read_part6;
+	bool _read_part5;
 
 	int _write_fd = -1;
 	px4_pollfd_struct_t _fds[1];
@@ -206,6 +210,7 @@ Ekf2Replay::Ekf2Replay(char *logfile) :
 	_flow_pub(nullptr),
 	_range_pub(nullptr),
 	_airspeed_pub(nullptr),
+	_ev_pub(nullptr),
 	_att_sub(-1),
 	_estimator_status_sub(-1),
 	_innov_sub(-1),
@@ -223,6 +228,7 @@ Ekf2Replay::Ekf2Replay(char *logfile) :
 	_read_part3(false),
 	_read_part4(false),
 	_read_part6(false),
+	_read_part5(false),
 	_write_fd(-1)
 {
 	// build the path to the log
@@ -269,6 +275,15 @@ void Ekf2Replay::publishEstimatorInput()
 	}
 
 	_read_part4 = false;
+
+	if (_ev_pub == nullptr && _read_part5) {
+		_ev_pub = orb_advertise(ORB_ID(vision_position_estimate), &_ev);
+
+	} else if (_ev_pub != nullptr && _read_part5) {
+		orb_publish(ORB_ID(vision_position_estimate), _ev_pub, &_ev);
+	}
+
+	_read_part5 = false;
 
 	if (_sensors_pub == nullptr) {
 		_sensors_pub = orb_advertise(ORB_ID(sensor_combined), &_sensors);
@@ -347,6 +362,7 @@ void Ekf2Replay::setEstimatorInput(uint8_t *data, uint8_t type)
 	struct log_RPL3_s replay_part3 = {};
 	struct log_RPL4_s replay_part4 = {};
 	struct log_RPL6_s replay_part6 = {};
+	struct log_RPL5_s replay_part5 = {};
 	struct log_LAND_s vehicle_landed = {};
 
 	if (type == LOG_RPL1_MSG) {
@@ -409,9 +425,7 @@ void Ekf2Replay::setEstimatorInput(uint8_t *data, uint8_t type)
 		_range.current_distance = replay_part4.range_to_ground;
 		_read_part4 = true;
 
-	} 
-
-	else if (type == LOG_RPL6_MSG){
+	} else if (type == LOG_RPL6_MSG){
 		uint8_t *dest_ptr = (uint8_t *)&replay_part6.time_airs_usec;
 		parseMessage(data, dest_ptr, type);
 		_airspeed.timestamp = replay_part6.time_airs_usec;
@@ -422,9 +436,23 @@ void Ekf2Replay::setEstimatorInput(uint8_t *data, uint8_t type)
 		_airspeed.confidence = replay_part6.confidence;
 		_read_part6 = true;
 
-	}
+	} else if (type == LOG_RPL5_MSG) {
+		uint8_t *dest_ptr = (uint8_t *)&replay_part5.time_ev_usec;
+		parseMessage(data, dest_ptr, type);
+		_ev.timestamp = replay_part5.time_ev_usec;
+		_ev.timestamp_computer = replay_part5.time_ev_usec; // fake this timestamp
+		_ev.x = replay_part5.x;
+		_ev.y = replay_part5.y;
+		_ev.z = replay_part5.z;
+		_ev.q[0] = replay_part5.q0;
+		_ev.q[1] = replay_part5.q1;
+		_ev.q[2] = replay_part5.q2;
+		_ev.q[3] = replay_part5.q3;
+		_ev.pos_err = replay_part5.pos_err;
+		_ev.ang_err = replay_part5.pos_err;
+		_read_part5 = true;
 
-	else if (type == LOG_LAND_MSG) {
+	} else if (type == LOG_LAND_MSG) {
 		uint8_t *dest_ptr = (uint8_t *)&vehicle_landed.landed;
 		parseMessage(data, dest_ptr, type);
 		_land_detected.landed =  vehicle_landed.landed;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -967,6 +967,10 @@ MavlinkReceiver::handle_message_vision_position_estimate(mavlink_message_t *msg)
 	vision_position.q[2] = q(2);
 	vision_position.q[3] = q(3);
 
+	// TODO fix this
+	vision_position.pos_err = 0.0f;
+	vision_position.ang_err = 0.0f;
+
 	if (_vision_position_pub == nullptr) {
 		_vision_position_pub = orb_advertise(ORB_ID(vision_position_estimate), &vision_position);
 

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1251,8 +1251,9 @@ int sdlog2_thread_main(int argc, char *argv[])
 			struct log_EST6_s log_INO3;
 			struct log_RPL3_s log_RPL3;
 			struct log_RPL4_s log_RPL4;
-			struct log_RPL6_s log_RPL6;
+			struct log_RPL5_s log_RPL5;
 			struct log_LAND_s log_LAND;
+			struct log_RPL6_s log_RPL6;
 			struct log_LOAD_s log_LOAD;
 		} body;
 	} log_msg = {
@@ -1604,6 +1605,21 @@ int sdlog2_thread_main(int argc, char *argv[])
 					log_msg.body.log_RPL6.air_temperature_celsius = buf.replay.air_temperature_celsius;
 					log_msg.body.log_RPL6.confidence = buf.replay.confidence;
 					LOGBUFFER_WRITE_AND_COUNT(RPL6);
+				}
+
+				if (buf.replay.ev_timestamp > 0) {
+					log_msg.msg_type = LOG_RPL5_MSG;
+					log_msg.body.log_RPL5.time_ev_usec = buf.replay.ev_timestamp;
+					log_msg.body.log_RPL5.x = buf.replay.pos_ev[0];
+					log_msg.body.log_RPL5.y = buf.replay.pos_ev[1];
+					log_msg.body.log_RPL5.z = buf.replay.pos_ev[2];
+					log_msg.body.log_RPL5.q0 = buf.replay.quat_ev[0];
+					log_msg.body.log_RPL5.q1 = buf.replay.quat_ev[1];
+					log_msg.body.log_RPL5.q2 = buf.replay.quat_ev[2];
+					log_msg.body.log_RPL5.q3 = buf.replay.quat_ev[3];
+					log_msg.body.log_RPL5.pos_err = buf.replay.pos_err;
+					log_msg.body.log_RPL5.ang_err = buf.replay.ang_err;
+					LOGBUFFER_WRITE_AND_COUNT(RPL5);
 				}
 			}
 		}

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -420,24 +420,6 @@ struct log_EST3_s {
     float cov[16];
 };
 
-/* --- EST4 - ESTIMATOR INNOVATIONS --- */
-#define LOG_EST4_MSG 48
-struct log_EST4_s {
-    float s[12];
-};
-
-/* --- EST5 - ESTIMATOR INNOVATIONS --- */
-#define LOG_EST5_MSG 49
-struct log_EST5_s {
-    float s[10];
-};
-
-/* --- EST6 - ESTIMATOR INNOVATIONS --- */
-#define LOG_EST6_MSG 53
-struct log_EST6_s {
-    float s[6];
-};
-
 /* --- TEL0..3 - TELEMETRY STATUS --- */
 #define LOG_TEL0_MSG 36
 #define LOG_TEL1_MSG 37
@@ -518,6 +500,18 @@ struct log_CTS_s {
 	float yaw_rate;
 };
 
+/* --- EST4 - ESTIMATOR INNOVATIONS --- */
+#define LOG_EST4_MSG 48
+struct log_EST4_s {
+    float s[12];
+};
+
+/* --- EST5 - ESTIMATOR INNOVATIONS --- */
+#define LOG_EST5_MSG 49
+struct log_EST5_s {
+    float s[10];
+};
+
 #define LOG_OUT1_MSG 50
 
 /* --- EKF2 REPLAY Part 1 --- */
@@ -558,6 +552,13 @@ struct log_RPL2_s {
 	float vel_d_m_s;
 	bool vel_ned_valid;
 };
+
+/* --- EST6 - ESTIMATOR INNOVATIONS --- */
+#define LOG_EST6_MSG 53
+struct log_EST6_s {
+    float s[6];
+};
+
 /* --- EKF2 REPLAY Part 3 --- */
 #define LOG_RPL3_MSG 54
 struct log_RPL3_s {
@@ -570,6 +571,13 @@ struct log_RPL3_s {
 	uint8_t flow_quality;
 };
 
+/* --- CAMERA TRIGGER --- */
+#define LOG_CAMT_MSG 55
+struct log_CAMT_s {
+	uint64_t timestamp;
+	uint32_t seq;
+};
+
 /* --- EKF2 REPLAY Part 4 --- */
 #define LOG_RPL4_MSG 56
 struct log_RPL4_s {
@@ -577,7 +585,16 @@ struct log_RPL4_s {
 	float range_to_ground;
 };
 
-/* --- EKF2 REPLAY Part 4 --- */
+/* --- LAND DETECTOR --- */
+#define LOG_LAND_MSG 57
+struct log_LAND_s {
+	uint8_t landed;
+};
+
+/* 58 used for DGPS message
+ shares struct with GPS MSG 8*/
+
+/* --- EKF2 REPLAY Part 6 --- */
 #define LOG_RPL6_MSG 59
 struct log_RPL6_s {
 	uint64_t time_airs_usec;
@@ -588,23 +605,23 @@ struct log_RPL6_s {
 	float confidence;
 };
 
-
-
-/* --- CAMERA TRIGGER --- */
-#define LOG_CAMT_MSG 55
-struct log_CAMT_s {
-	uint64_t timestamp;
-	uint32_t seq;
-};
-
-/* --- LAND DETECTOR --- */
-#define LOG_LAND_MSG 57
-struct log_LAND_s {
-	uint8_t landed;
+/* --- EKF2 REPLAY Part 5 --- */
+#define LOG_RPL5_MSG 60
+struct log_RPL5_s {
+	uint64_t time_ev_usec;
+	float x;
+	float y;
+	float z;
+	float q0;
+	float q1;
+	float q2;
+	float q3;
+	float pos_err;
+	float ang_err;
 };
 
 /* --- SYSTEM LOAD --- */
-#define LOG_LOAD_MSG 58
+#define LOG_LOAD_MSG 61
 struct log_LOAD_s {
 	float cpu_load;
 };
@@ -694,6 +711,7 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT(RPL2, "QQLLiMMfffffffM", "Tpos,Tvel,lat,lon,alt,fix,nsats,eph,epv,sacc,v,vN,vE,vD,v_val"),
 	LOG_FORMAT(RPL3, "QffffIB", "Tflow,fx,fy,gx,gy,delT,qual"),
 	LOG_FORMAT(RPL4, "Qf", "Trng,rng"),
+	LOG_FORMAT(RPL5, "Qfffffffff", "Tev,x,y,z,q0,q1,q2,q3,posErr,angErr"),
 	LOG_FORMAT(RPL6, "Qfffff", "Tasp,inAsp,trAsp,ufAsp,tpAsp,confAsp"),
 	LOG_FORMAT(LAND, "B", "Landed"),
 	LOG_FORMAT(LOAD, "f", "CPU"),


### PR DESCRIPTION
Replaces https://github.com/PX4/Firmware/pull/4382

Required for https://github.com/PX4/ecl/pull/153 - see that PR for test results.

Has been rebased and commits consolidated. See https://github.com/PX4/Firmware/pull/4382 and https://github.com/PX4/ecl/issues/141 for reference.

No further work required.