### PR TITLE
land_detector: fix uninitialized value

### DIFF
--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -67,7 +67,8 @@ MulticopterLandDetector::MulticopterLandDetector() : LandDetector(),
 	_ctrl_state{},
 	_ctrl_mode{},
 	_landTimer(0),
-	_freefallTimer(0)
+	_freefallTimer(0),
+	_min_trust_start(0)
 {
 	_paramHandle.maxRotation = param_find("LNDMC_ROT_MAX");
 	_paramHandle.maxVelocity = param_find("LNDMC_XY_VEL_MAX");


### PR DESCRIPTION
Found with valgrind in SITL:

```
==6033== Thread 4 hpwork:
==6033== Conditional jump or move depends on uninitialised value(s)
==6033==    at 0x48188F: landdetection::MulticopterLandDetector::get_landed_state() (MulticopterLandDetector.cpp:167)
==6033==    by 0x481A89: landdetection::MulticopterLandDetector::update() (MulticopterLandDetector.cpp:118)
==6033==    by 0x481277: landdetection::LandDetector::cycle() (LandDetector.cpp:106)
==6033==    by 0x43D0FC: work_process (work_thread.c:148)
==6033==    by 0x43D14C: work_hpthread (work_thread.c:269)
==6033==    by 0x43C6EE: entry_adapter(void*) (px4_posix_tasks.cpp:104)
==6033==    by 0x4E3F6A9: start_thread (pthread_create.c:333)
==6033==    by 0x59EF13C: clone (clone.S:109)
==6033== 
```

@tumbili FYI.