### PR TITLE
Rename uart_esc to pwm_out_rc_in

### DIFF
--- a/cmake/configs/qurt_eagle_legacy_driver_default.cmake
+++ b/cmake/configs/qurt_eagle_legacy_driver_default.cmake
@@ -64,7 +64,7 @@ set(config_module_list
 	# PX4 drivers
 	#
 	drivers/gps
-	drivers/uart_esc
+	drivers/pwm_out_rc_in
 	drivers/qshell/qurt
 
 	#

--- a/cmake/configs/qurt_sdflight_default.cmake
+++ b/cmake/configs/qurt_sdflight_default.cmake
@@ -61,7 +61,7 @@ set(config_module_list
 	# PX4 drivers
 	#
 	drivers/gps
-	drivers/uart_esc
+	drivers/pwm_out_rc_in
 	drivers/qshell/qurt
 
 	#

--- a/posix-configs/eagle/flight/px4.config
+++ b/posix-configs/eagle/flight/px4.config
@@ -15,7 +15,7 @@ ekf2 start
 land_detector start multicopter
 mc_pos_control start
 mc_att_control start
-uart_esc start -d /dev/tty-2
+pwm_out_rc_in start -d /dev/tty-2
 sleep 1
 list_devices
 list_files

--- a/src/drivers/pwm_out_rc_in/CMakeLists.txt
+++ b/src/drivers/pwm_out_rc_in/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2015-2016 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,12 +31,12 @@
 #
 ############################################################################
 px4_add_module(
-	MODULE drivers__uart_esc
-	MAIN uart_esc
+	MODULE drivers__pwm_out_rc_in
+	MAIN pwm_out_rc_in
 	COMPILE_FLAGS
 		-Os
 	SRCS
-		uart_esc.cpp
+		pwm_out_rc_in.cpp
 	DEPENDS
 		platforms__common
 	)

--- a/src/drivers/snapdragon_rc_pwm/snapdragon_rc_pwm.cpp
+++ b/src/drivers/snapdragon_rc_pwm/snapdragon_rc_pwm.cpp
@@ -35,9 +35,10 @@
 /**
  * @file snapdragon_rc_pwm.cpp
  * @author Roman Bapst <roman@px4.io>
+ * @author Julian Oes <julian@oes.ch>
  *
- * This driver sends rc commands to the Snapdragon via UART. On the same UART it receives pwm
- * motor commands from the Snapdragon.
+ * This driver sends RC commands to the Snapdragon via UART. On the same UART
+ * it receives pwm motor commands from the Snapdragon.
  */
 
 
@@ -66,9 +67,9 @@ namespace snapdragon_rc_pwm
 static const uint8_t mavlink_message_lengths[256] = MAVLINK_MESSAGE_LENGTHS;
 static const uint8_t mavlink_message_crcs[256] = MAVLINK_MESSAGE_CRCS;
 
-volatile bool _task_should_exit = false; // flag indicating if uart_esc task should exit
+volatile bool _task_should_exit = false; // flag indicating if snapdragon_rc_pwm task should exit
 static char _device[MAX_LEN_DEV_PATH];
-static bool _is_running = false;         // flag indicating if uart_esc app is running
+static bool _is_running = false;         // flag indicating if snapdragon_rc_pwm app is running
 static px4_task_t _task_handle = -1;     // handle to the task main thread
 static int _uart_fd = -1;
 int _pwm_fd = -1;
@@ -85,7 +86,7 @@ void usage();
 
 void start();
 
-/** uart_esc stop */
+/** snapdragon_rc_pwm stop */
 void stop();
 
 int initialise_uart();
@@ -103,7 +104,7 @@ void set_pwm_output(mavlink_actuator_control_target_t *actuator_controls);
 /** task main trampoline function */
 void task_main_trampoline(int argc, char *argv[]);
 
-/** uart_esc thread primary entry point */
+/** snapdragon_rc_pwm thread primary entry point */
 void task_main(int argc, char *argv[]);
 
 void task_main(int argc, char *argv[])
@@ -365,7 +366,7 @@ int deinitialize_uart()
 	return close(_uart_fd);
 }
 
-// uart_esc main entrance
+// snapdragon_rc_pwm main entrance
 void task_main_trampoline(int argc, char *argv[])
 {
 	task_main(argc, argv);
@@ -450,7 +451,7 @@ int snapdragon_rc_pwm_main(int argc, char *argv[])
 
 
 		if (snapdragon_rc_pwm::_is_running) {
-			PX4_WARN("uart_esc already running");
+			PX4_WARN("snapdragon_rc_pwm already running");
 			return 1;
 		}
 


### PR DESCRIPTION
The name uart_esc was initially taken by Qualcomm's UART ESC driver but
then got changed into the current mavlink ESC/RC helper. Since the
uart_esc is still around, we should prevent the names clashing.

My current suggestion is `pwm_out_rc_in` but if somebody has a better idea, I'm all ears.

This unblocks #4651.

@LorenzMeier thoughts?