### PR TITLE
adb_upload: try to sync after uploading

### DIFF
--- a/Tools/adb_upload.sh
+++ b/Tools/adb_upload.sh
@@ -23,3 +23,7 @@ do
 	adb push $arg $last
 	((i+=1))
 done
+
+# Make sure they are synced to the file system
+echo "Syncing FS..."
+adb shell sync


### PR DESCRIPTION
I've had cases where I ended up with corrupt files on the Snappy. Mostly this happened when I yanked power right after uploading.

This change should attempt a file system sync, so that changes are saved to "disk". The actual saving still depends on the hardware and filesystem, but chances are probably higher that it survives after this.

@bkueng any other ideas what to do?