### PR TITLE
Snapdragon MPU9250 rotation support

### DIFF
--- a/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
@@ -60,6 +60,8 @@
 #include <drivers/drv_gyro.h>
 #include <drivers/device/integrator.h>
 
+#include <lib/conversion/rotation.h>
+
 #include <uORB/topics/parameter_update.h>
 
 #include <mpu9250/MPU9250.hpp>
@@ -77,7 +79,7 @@ using namespace DriverFramework;
 class DfMpu9250Wrapper : public MPU9250
 {
 public:
-	DfMpu9250Wrapper(/*enum Rotation rotation*/);
+	DfMpu9250Wrapper(enum Rotation rotation);
 	~DfMpu9250Wrapper();
 
 
@@ -106,8 +108,6 @@ private:
 	void _update_accel_calibration();
 	void _update_gyro_calibration();
 
-	//enum Rotation		_rotation;
-
 	orb_advert_t		    _accel_topic;
 	orb_advert_t		    _gyro_topic;
 
@@ -132,6 +132,8 @@ private:
 		float z_offset;
 		float z_scale;
 	} _gyro_calibration;
+	
+	math::Matrix<3, 3>	    _rotation_matrix;
 
 	int			    _accel_orb_class_instance;
 	int			    _gyro_orb_class_instance;
@@ -153,7 +155,7 @@ private:
 	uint64_t		    _last_accel_range_hit_count;
 };
 
-DfMpu9250Wrapper::DfMpu9250Wrapper(/*enum Rotation rotation*/) :
+DfMpu9250Wrapper::DfMpu9250Wrapper(enum Rotation rotation) :
 	MPU9250(IMU_DEVICE_PATH),
 	_accel_topic(nullptr),
 	_gyro_topic(nullptr),
@@ -165,7 +167,6 @@ DfMpu9250Wrapper::DfMpu9250Wrapper(/*enum Rotation rotation*/) :
 	_gyro_orb_class_instance(-1),
 	_accel_int(MPU9250_NEVER_AUTOPUBLISH_US, false),
 	_gyro_int(MPU9250_NEVER_AUTOPUBLISH_US, true),
-	/*_rotation(rotation)*/
 	_publish_count(0),
 	_read_counter(perf_alloc(PC_COUNT, "mpu9250_reads")),
 	_error_counter(perf_alloc(PC_COUNT, "mpu9250_errors")),
@@ -191,6 +192,9 @@ DfMpu9250Wrapper::DfMpu9250Wrapper(/*enum Rotation rotation*/) :
 	_gyro_calibration.x_offset = 0.0f;
 	_gyro_calibration.y_offset = 0.0f;
 	_gyro_calibration.z_offset = 0.0f;
+	
+	// Get sensor rotation matrix
+	get_rot_matrix(rotation, &_rotation_matrix);
 }
 
 DfMpu9250Wrapper::~DfMpu9250Wrapper()
@@ -450,7 +454,9 @@ int DfMpu9250Wrapper::_publish(struct imu_sensor_data &data)
 	math::Vector<3> accel_val((data.accel_m_s2_x - _accel_calibration.x_offset) * _accel_calibration.x_scale,
 				  (data.accel_m_s2_y - _accel_calibration.y_offset) * _accel_calibration.y_scale,
 				  (data.accel_m_s2_z - _accel_calibration.z_offset) * _accel_calibration.z_scale);
-
+				  
+	// apply sensor rotation on the accel measurement
+	accel_val = _rotation_matrix * accel_val;
 
 	_accel_int.put_with_interval(data.fifo_sample_interval_us,
 				     accel_val,
@@ -460,8 +466,9 @@ int DfMpu9250Wrapper::_publish(struct imu_sensor_data &data)
 	math::Vector<3> gyro_val((data.gyro_rad_s_x - _gyro_calibration.x_offset) * _gyro_calibration.x_scale,
 				 (data.gyro_rad_s_y - _gyro_calibration.y_offset) * _gyro_calibration.y_scale,
 				 (data.gyro_rad_s_z - _gyro_calibration.z_offset) * _gyro_calibration.z_scale);
-
-	math::Vector<3> gyro_val_integrated_unused;
+	
+	// apply sensor rotation on the gyro measurement
+	gyro_val = _rotation_matrix * gyro_val;
 
 	_gyro_int.put_with_interval(data.fifo_sample_interval_us,
 				    gyro_val,
@@ -583,14 +590,14 @@ namespace df_mpu9250_wrapper
 
 DfMpu9250Wrapper *g_dev = nullptr;
 
-int start(/* enum Rotation rotation */);
+int start(enum Rotation rotation);
 int stop();
 int info();
 void usage();
 
-int start(/*enum Rotation rotation*/)
+int start(enum Rotation rotation)
 {
-	g_dev = new DfMpu9250Wrapper(/*rotation*/);
+	g_dev = new DfMpu9250Wrapper(rotation);
 
 	if (g_dev == nullptr) {
 		PX4_ERR("failed instantiating DfMpu9250Wrapper object");
@@ -660,7 +667,7 @@ usage()
 {
 	PX4_WARN("Usage: df_mpu9250_wrapper 'start', 'info', 'stop'");
 	PX4_WARN("options:");
-	//PX4_WARN("    -R rotation");
+	PX4_WARN("    -R rotation");
 }
 
 } // namespace df_mpu9250_wrapper
@@ -670,7 +677,7 @@ int
 df_mpu9250_wrapper_main(int argc, char *argv[])
 {
 	int ch;
-	// enum Rotation rotation = ROTATION_NONE;
+	enum Rotation rotation = ROTATION_NONE;
 	int ret = 0;
 	int myoptind = 1;
 	const char *myoptarg = NULL;
@@ -678,9 +685,9 @@ df_mpu9250_wrapper_main(int argc, char *argv[])
 	/* jump over start/off/etc and look at options first */
 	while ((ch = px4_getopt(argc, argv, "R:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
-		//case 'R':
-		//	rotation = (enum Rotation)atoi(myoptarg);
-		//	break;
+		case 'R':
+			rotation = (enum Rotation)atoi(myoptarg);
+			break;
 
 		default:
 			df_mpu9250_wrapper::usage();
@@ -697,7 +704,7 @@ df_mpu9250_wrapper_main(int argc, char *argv[])
 
 
 	if (!strcmp(verb, "start")) {
-		ret = df_mpu9250_wrapper::start(/*rotation*/);
+		ret = df_mpu9250_wrapper::start(rotation);
 	}
 
 	else if (!strcmp(verb, "stop")) {


### PR DESCRIPTION
@julianoes @LorenzMeier 

This PR : 
* Fixes Snapdragon build after a slew of changes from this week broke it.
* Renames ```rc_in_pwm_out``` to ```snapdragon_io``` (I prefer the more concise name). Also fixes broken build due to incomplete renaming in the last PR.
* Works around missing dprintf in QuRT. Fixes build.
* Adds sensor rotation support to MPU9250 wrapper to make supporting P1/P2 Flight boards possible. ( #4652 )

TODO : 
* Mag rotation support (for HMC5883 and AK mag in MPU9250)
* Automagically detect P1/P2 boards and set rotations. (@mcharleb @jywilson Any suggestions?)

I haven't added rotations support to the mag driver yet. I can do this if required, but there are hacks in the driver to make it consistent with the 3dr gps, and I'd need to check how we can deal with transitional support. Let me know if we need rotation support in the mag driver at this stage. 

I was planning to add it for the AK mag in the 9250 after #4651 is merged. Please merge this PR before #4651.