### PR TITLE
mavlink: allow heartbeat from onboard controller

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1324,8 +1324,9 @@ MavlinkReceiver::handle_message_heartbeat(mavlink_message_t *msg)
 		mavlink_heartbeat_t hb;
 		mavlink_msg_heartbeat_decode(msg, &hb);
 
-		/* ignore own heartbeats, accept only heartbeats from GCS */
-		if (msg->sysid != mavlink_system.sysid && hb.type == MAV_TYPE_GCS) {
+		/* ignore own heartbeats, accept only heartbeats from GCS and onboard controller */
+		if ((msg->sysid != mavlink_system.sysid && hb.type == MAV_TYPE_GCS) || 
+		    (msg->sysid == mavlink_system.sysid && hb.type == MAV_TYPE_ONBOARD_CONTROLLER)) {
 
 			struct telemetry_status_s &tstatus = _mavlink->get_rx_status();
 


### PR DESCRIPTION
Allows change flight modes and so on from onboard controller (such as mavros)