### PR TITLE
Add Parrot Bebop as build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,9 @@ posix_rpi2_default:
 posix_rpi2_release:
 	$(call cmake-build,$@)
 
+posix_bebop_default:
+	$(call cmake-build,$@)
+
 posix: posix_sitl_default
 
 broadcast: posix_sitl_broadcast

--- a/Tools/adb_upload_to_bebop.sh
+++ b/Tools/adb_upload_to_bebop.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+ip=192.168.42.1
+port=9050
+
+echo "Connecting to bebop: $ip:$port"
+
+# adb returns also 0 as exit status if the connection fails
+adb_return=$(adb connect $ip:$port)
+adb_status=$(echo $adb_return | cut -f 1 -d " ")
+
+if [[ $adb_status == "unable" ]]; then
+  
+  echo ""
+  echo "Connection with Parrot Bebop could not be established:"
+  echo "  Make sure you are connected with the Bebop's WiFi and"
+  echo "  enable access to the board by pressing the power button 4 times."
+  echo ""
+  exit 50
+
+fi
+
+echo "Connection successfully established"
+
+sleep 1
+
+adb shell mount -o remount,rw /
+
+../Tools/adb_upload.sh $@
+
+echo "Disconnecting from bebop"
+adb disconnect

--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -528,6 +528,24 @@ function(px4_add_adb_push)
 		)
 endfunction()
 
+function(px4_add_adb_push_to_bebop)
+	px4_parse_function_args(
+		NAME px4_add_upload_to_bebop
+		ONE_VALUE OS BOARD OUT DEST
+		MULTI_VALUE FILES DEPENDS
+		REQUIRED OS BOARD OUT FILES DEPENDS DEST
+		ARGN ${ARGN})
+
+	add_custom_target(${OUT}
+		COMMAND ${CMAKE_SOURCE_DIR}/Tools/adb_upload_to_bebop.sh ${FILES} ${DEST}
+		DEPENDS ${DEPENDS}
+		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+		COMMENT "uploading ${BUNDLE}"
+		VERBATIM
+		USES_TERMINAL
+		)
+endfunction()
+
 function(px4_add_scp_push)
 	px4_parse_function_args(
 		NAME px4_add_upload

--- a/cmake/configs/posix_bebop_default.cmake
+++ b/cmake/configs/posix_bebop_default.cmake
@@ -1,0 +1,35 @@
+include(posix/px4_impl_posix)
+
+set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/cmake/toolchains/Toolchain-arm-linux-gnueabihf-raspbian.cmake)
+
+add_definitions(
+  -D__PX4_POSIX_BEBOP
+	)
+
+set(CMAKE_PROGRAM_PATH
+	"${RPI_TOOLCHAIN_DIR}/gcc-linaro-arm-linux-gnueabihf-raspbian/bin"
+	${CMAKE_PROGRAM_PATH}
+	)
+
+set(config_module_list
+  examples/px4_simple_app
+
+	drivers/device
+
+	#
+	# Library modules
+	#
+	modules/uORB
+
+	#
+	# POSIX
+	#
+	platforms/common
+	platforms/posix/px4_layer
+	platforms/posix/work_queue
+	
+  # 
+  # libraries
+  #
+	lib/DriverFramework/framework
+)

--- a/cmake/configs/posix_bebop_default.cmake
+++ b/cmake/configs/posix_bebop_default.cmake
@@ -12,14 +12,80 @@ set(CMAKE_PROGRAM_PATH
 	)
 
 set(config_module_list
+
   examples/px4_simple_app
 
+	#
+	# Board support modules
+	#
 	drivers/device
+	modules/sensors
+
+	#
+	# System commands
+	#
+	systemcmds/param
+	systemcmds/mixer
+	systemcmds/ver
+	systemcmds/esc_calib
+	systemcmds/topic_listener
+	systemcmds/perf
+
+	#
+	# Estimation modules (EKF/ SO3 / other filters)
+	#
+	#modules/attitude_estimator_ekf
+	modules/ekf_att_pos_estimator
+	modules/attitude_estimator_q
+	modules/position_estimator_inav
+	modules/local_position_estimator
+	modules/ekf2
+
+	#
+	# Vehicle Control
+	#
+	modules/mc_att_control
+	modules/mc_pos_control
+	modules/fw_att_control
+	modules/fw_pos_control_l1	
+	modules/vtol_att_control
 
 	#
 	# Library modules
 	#
+	modules/sdlog2
+	modules/logger
+	modules/commander
+	modules/load_mon
+	modules/param
+	modules/systemlib
+	modules/systemlib/mixer
 	modules/uORB
+	modules/dataman
+	modules/land_detector
+	modules/navigator
+	modules/mavlink
+
+	#
+	# PX4 drivers
+	#
+
+	#
+	# Libraries
+	#
+	lib/controllib
+	lib/mathlib
+	lib/mathlib/math/filter
+	lib/geo
+	lib/ecl
+	lib/geo_lookup
+	lib/launchdetection
+	lib/external_lgpl
+	lib/conversion
+	lib/terrain_estimation
+	lib/runway_takeoff
+	lib/tailsitter_recovery
+	lib/DriverFramework/framework
 
 	#
 	# POSIX
@@ -27,9 +93,4 @@ set(config_module_list
 	platforms/common
 	platforms/posix/px4_layer
 	platforms/posix/work_queue
-	
-  # 
-  # libraries
-  #
-	lib/DriverFramework/framework
 )

--- a/cmake/posix/px4_impl_posix.cmake
+++ b/cmake/posix/px4_impl_posix.cmake
@@ -166,6 +166,15 @@ function(px4_os_add_flags)
                 mavlink/include/mavlink
                 )
 
+# Use the pthread instead of lpthread if the firmware is build for the parrot
+# bebop. This resolves some linker errors in DriverFramework, when building a 
+# static target.
+if ("${BOARD}" STREQUAL "bebop")
+  set(PX4_PTHREAD_BUILD "-pthread")
+else()
+  set(PX4_PTHREAD_BUILD "-lpthread")
+endif()
+
 if(UNIX AND APPLE)
         set(added_definitions
 		-D__PX4_POSIX
@@ -177,7 +186,7 @@ if(UNIX AND APPLE)
                 )
 
         set(added_exe_linker_flags
-		-lpthread
+          ${PX4_PTHREAD_BUILD}
 		)
 
 else()
@@ -192,7 +201,7 @@ else()
                 )
 
         set(added_exe_linker_flags
-		-lpthread -lrt
+		      ${PX4_PTHREAD_BUILD} -lrt
 		)
 
 endif()

--- a/posix-configs/bebop/mainapp.config
+++ b/posix-configs/bebop/mainapp.config
@@ -1,0 +1,15 @@
+uorb start
+param set SYS_AUTOSTART 4001
+sleep 1
+param set MAV_TYPE 2
+sensors start
+commander start
+ekf2 start
+land_detector start multicopter
+mc_pos_control start
+mc_att_control start
+mavlink start -u 14556 -r 1000000
+sleep 1
+mavlink stream -u 14556 -s HIGHRES_IMU -r 50
+mavlink stream -u 14556 -s ATTITUDE -r 50
+mavlink boot_complete

--- a/src/firmware/posix/CMakeLists.txt
+++ b/src/firmware/posix/CMakeLists.txt
@@ -61,7 +61,34 @@ elseif ("${BOARD}" STREQUAL "rpi2")
 			 DEPENDS mainapp
 			 DEST /home/pi)
 
+elseif ("${BOARD}" STREQUAL "bebop")
+
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static")
+
+	add_executable(mainapp
+		${CMAKE_SOURCE_DIR}/src/platforms/posix/main.cpp
+		apps.h
+		)
+
+	if (NOT APPLE)
+		target_link_libraries(mainapp
+			-Wl,--start-group
+			${module_libraries}
+			${df_driver_libs}
+			pthread m rt
+			-Wl,--end-group
+			)
+	else()
+		target_link_libraries(mainapp
+			${module_libraries}
+			${df_driver_libs}
+			pthread m
+			)
+	endif()
+
 else()
+
 	add_executable(mainapp
 		${CMAKE_SOURCE_DIR}/src/platforms/posix/main.cpp
 		apps.h

--- a/src/firmware/posix/CMakeLists.txt
+++ b/src/firmware/posix/CMakeLists.txt
@@ -91,6 +91,7 @@ elseif ("${BOARD}" STREQUAL "bebop")
 			 OS ${OS}
 			 BOARD ${BOARD}
 			 FILES ${CMAKE_CURRENT_BINARY_DIR}/mainapp
+						 ${CMAKE_SOURCE_DIR}/posix-configs/bebop/mainapp.config
 			 DEPENDS mainapp
 			 DEST /usr/bin)
 			 

--- a/src/firmware/posix/CMakeLists.txt
+++ b/src/firmware/posix/CMakeLists.txt
@@ -87,6 +87,13 @@ elseif ("${BOARD}" STREQUAL "bebop")
 			)
 	endif()
 
+	px4_add_adb_push_to_bebop(OUT upload
+			 OS ${OS}
+			 BOARD ${BOARD}
+			 FILES ${CMAKE_CURRENT_BINARY_DIR}/mainapp
+			 DEPENDS mainapp
+			 DEST /usr/bin)
+			 
 else()
 
 	add_executable(mainapp

--- a/src/lib/version/version.h
+++ b/src/lib/version/version.h
@@ -61,6 +61,8 @@ __END_DECLS
 #  define HW_ARCH "LINUXTEST"
 #elif defined(CONFIG_ARCH_BOARD_RPI2)
 #  define	HW_ARCH "LINUXTEST"
+#elif defined(CONFIG_ARCH_BOARD_BEBOP)
+#  define	HW_ARCH "LINUXTEST"
 #else
 #define HW_ARCH (board_name())
 #endif


### PR DESCRIPTION
This request enables the build of basic firmware elements for the Parrot Bebop platform. You can build and upload the binaries using make, yet you have to start the executable by hand on the platform.