### PR TITLE
DMA heap usage instrumentation

### DIFF
--- a/src/drivers/boards/aerocore/board_config.h
+++ b/src/drivers/boards/aerocore/board_config.h
@@ -235,6 +235,8 @@ extern void stm32_spiinitialize(void);
 int nsh_archinitialize(void);
 #endif
 
+#include "../common/board_common.h"
+
 #endif /* __ASSEMBLY__ */
 
 __END_DECLS

--- a/src/drivers/boards/common/board_common.h
+++ b/src/drivers/boards/common/board_common.h
@@ -1,0 +1,101 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2016 PX4 Development Team. All rights reserved.
+ *                 Author: David Sidrane <david_s5@nscdg.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file board_common.h
+ *
+ * Provide the the common board interfaces
+ */
+
+#pragma once
+
+/************************************************************************************
+ * Included Files
+ ************************************************************************************/
+#include <errno.h>
+/************************************************************************************
+ * Definitions
+ ************************************************************************************/
+
+/************************************************************************************
+ * Private Functions
+ ************************************************************************************/
+
+/************************************************************************************
+ * Public Functions
+ ************************************************************************************/
+
+/************************************************************************************
+ * Name: board_name
+ *
+ * Description:
+ *   All boards must provide this API to return the board name.
+ *
+ ************************************************************************************/
+
+__EXPORT const char *board_name(void);
+
+/************************************************************************************
+ * Name: board_dma_alloc_init
+ *
+ * Description:
+ *   All boards may optionally provide this API to instantiate a pool of
+ *   memory for uses with FAST FS DMA operations.
+ *
+ *   Provision is controlled by declaring BOARD_DMA_ALLOC_POOL_SIZE in board_config.h
+ *
+ *
+ ************************************************************************************/
+#if defined(BOARD_DMA_ALLOC_POOL_SIZE)
+__EXPORT int board_dma_alloc_init(void);
+#else
+#define board_dma_alloc_init() (-EPERM)
+#endif
+
+/************************************************************************************
+ * Name: board_get_dma_usage
+ *
+ * Description:
+ *   All boards may optionally provide this API to supply instrumentation for a pool of
+ *   memory used for DMA operations.
+ *
+ *   Provision is controlled by declaring BOARD_DMA_ALLOC_POOL_SIZE in board_config.h
+ *
+ *
+ ************************************************************************************/
+#if defined(BOARD_DMA_ALLOC_POOL_SIZE)
+__EXPORT int board_get_dma_usage(uint16_t *dma_total, uint16_t *dma_used, uint16_t *dma_peek_used);
+#else
+#define board_get_dma_usage(dma_total,dma_used, dma_peek_used) (-ENOMEM)
+#endif

--- a/src/drivers/boards/common/board_dma_alloc.c
+++ b/src/drivers/boards/common/board_dma_alloc.c
@@ -1,0 +1,156 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file board_dma_alloc.c
+ *
+ * Provide the board dma allocator interface.
+ */
+
+/************************************************************************************
+ * Included Files
+ ************************************************************************************/
+
+#include <px4_config.h>
+#include "board_config.h"
+
+#include <stdint.h>
+#include <errno.h>
+#include <nuttx/gran.h>
+
+#include <systemlib/perf_counter.h>
+
+/************************************************************************************
+ * Definitions
+ ************************************************************************************/
+
+/************************************************************************************
+ * Private Functions
+ ************************************************************************************/
+
+/************************************************************************************
+ * Public Functions
+ ************************************************************************************/
+
+/************************************************************************************
+ * Name: board_dma_alloc_init
+ *
+ * Description:
+ *   All boards may optionally provide this API to instantiate a pool of
+ *   memory for uses with FAST FS DMA operations.
+ *
+ ************************************************************************************/
+#if defined(BOARD_DMA_ALLOC_POOL_SIZE)
+
+#  if !defined(CONFIG_GRAN) || !defined(CONFIG_FAT_DMAMEMORY)
+#    error microSD DMA support requires CONFIG_GRAN
+#  endif
+
+static GRAN_HANDLE dma_allocator;
+
+/*
+ * The DMA heap size constrains the total number of things that can be
+ * ready to do DMA at a time.
+ *
+ * For example, FAT DMA depends on one sector-sized buffer per filesystem plus
+ * one sector-sized buffer per file.
+ *
+ * We use a fundamental alignment / granule size of 64B; this is sufficient
+ * to guarantee alignment for the largest STM32 DMA burst (16 beats x 32bits).
+ */
+static uint8_t g_dma_heap[BOARD_DMA_ALLOC_POOL_SIZE] __attribute__((aligned(64)));
+static perf_counter_t g_dma_perf;
+static uint16_t dma_heap_inuse;
+static uint16_t dma_heap_peek_use;
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+__EXPORT int board_dma_alloc_init(void)
+{
+	dma_allocator = gran_initialize(g_dma_heap,
+					sizeof(g_dma_heap),
+					7,  /* 128B granule - must be > alignment (XXX bug?) */
+					6); /* 64B alignment */
+
+	if (dma_allocator == NULL) {
+		return -ENOMEM;
+
+	} else {
+		dma_heap_inuse = 0;
+		dma_heap_peek_use = 0;
+		g_dma_perf = perf_alloc(PC_COUNT, "dma_alloc");
+	}
+
+	return OK;
+}
+
+__EXPORT int board_get_dma_usage(uint16_t *dma_total, uint16_t *dma_used, uint16_t *dma_peek_used)
+{
+	*dma_total = sizeof(g_dma_heap);
+	*dma_used = dma_heap_inuse;
+	*dma_peek_used = dma_heap_peek_use;
+
+	return OK;
+}
+/*
+ * DMA-aware allocator stubs for the FAT filesystem.
+ */
+
+__EXPORT void *fat_dma_alloc(size_t size);
+__EXPORT void fat_dma_free(FAR void *memory, size_t size);
+
+void *
+fat_dma_alloc(size_t size)
+{
+	void *rv = NULL;
+	perf_count(g_dma_perf);
+	rv = gran_alloc(dma_allocator, size);
+
+	if (rv != NULL) {
+		dma_heap_inuse += size;
+
+		if (dma_heap_inuse > dma_heap_peek_use) {
+			dma_heap_peek_use = dma_heap_inuse;
+		}
+	}
+
+	return rv;
+}
+
+void
+fat_dma_free(FAR void *memory, size_t size)
+{
+	gran_free(dma_allocator, memory, size);
+	dma_heap_inuse -= size;
+}
+#endif /* defined(BOARD_DMA_ALLOC_POOL_SIZE) */

--- a/src/drivers/boards/mindpx-v2/CMakeLists.txt
+++ b/src/drivers/boards/mindpx-v2/CMakeLists.txt
@@ -35,6 +35,7 @@ px4_add_module(
 	COMPILE_FLAGS
 		-Os
 	SRCS
+		../common/board_dma_alloc.c
 		../common/board_name.c
 		mindpx_can.c
 		mindpx2_init.c

--- a/src/drivers/boards/mindpx-v2/board_config.h
+++ b/src/drivers/boards/mindpx-v2/board_config.h
@@ -319,6 +319,9 @@ __BEGIN_DECLS
 		{GPIO_GPIO11_INPUT,      GPIO_GPIO11_OUTPUT,      0}, \
 		{GPIO_GPIO12_INPUT,      GPIO_GPIO12_OUTPUT,      0}, }
 
+/* This board provides a DMA pool and APIs */
+
+#define BOARD_DMA_ALLOC_POOL_SIZE 8192
 
 /****************************************************************************************************
  * Public Types
@@ -368,6 +371,8 @@ extern void stm32_usbinitialize(void);
 #ifdef CONFIG_NSH_LIBRARY
 int nsh_archinitialize(void);
 #endif
+
+#include "../common/board_common.h"
 
 #endif /* __ASSEMBLY__ */
 

--- a/src/drivers/boards/mindpx-v2/mindpx2_init.c
+++ b/src/drivers/boards/mindpx-v2/mindpx2_init.c
@@ -110,73 +110,9 @@ __END_DECLS
 /****************************************************************************
  * Protected Functions
  ****************************************************************************/
-
-#if defined(CONFIG_FAT_DMAMEMORY)
-# if !defined(CONFIG_GRAN) || !defined(CONFIG_FAT_DMAMEMORY)
-#  error microSD DMA support requires CONFIG_GRAN
-# endif
-
-static GRAN_HANDLE dma_allocator;
-
-/*
- * The DMA heap size constrains the total number of things that can be
- * ready to do DMA at a time.
- *
- * For example, FAT DMA depends on one sector-sized buffer per filesystem plus
- * one sector-sized buffer per file.
- *
- * We use a fundamental alignment / granule size of 64B; this is sufficient
- * to guarantee alignment for the largest STM32 DMA burst (16 beats x 32bits).
- */
-static uint8_t g_dma_heap[8192] __attribute__((aligned(64)));
-static perf_counter_t g_dma_perf;
-
-static void
-dma_alloc_init(void)
-{
-	dma_allocator = gran_initialize(g_dma_heap,
-					sizeof(g_dma_heap),
-					7,  /* 128B granule - must be > alignment (XXX bug?) */
-					6); /* 64B alignment */
-
-	if (dma_allocator == NULL) {
-		message("DMA alloc FAILED");
-
-	} else {
-		g_dma_perf = perf_alloc(PC_COUNT, "dma_alloc");
-	}
-}
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
-
-/*
- * DMA-aware allocator stubs for the FAT filesystem.
- */
-
-__EXPORT void *fat_dma_alloc(size_t size);
-__EXPORT void fat_dma_free(FAR void *memory, size_t size);
-
-void *
-fat_dma_alloc(size_t size)
-{
-	perf_count(g_dma_perf);
-	return gran_alloc(dma_allocator, size);
-}
-
-void
-fat_dma_free(FAR void *memory, size_t size)
-{
-	gran_free(dma_allocator, memory, size);
-}
-
-#else
-
-# define dma_alloc_init()
-
-#endif
-
 /************************************************************************************
  * Name: stm32_boardinitialize
  *
@@ -252,7 +188,10 @@ __EXPORT int nsh_archinitialize(void)
 	hrt_init();
 
 	/* configure the DMA allocator */
-	dma_alloc_init();
+
+	if (board_dma_alloc_init() < 0) {
+		message("DMA alloc FAILED");
+	}
 
 	/* configure CPU load estimation */
 #ifdef CONFIG_SCHED_INSTRUMENTATION

--- a/src/drivers/boards/px4-stm32f4discovery/board_config.h
+++ b/src/drivers/boards/px4-stm32f4discovery/board_config.h
@@ -134,6 +134,8 @@ extern void stm32_usbinitialize(void);
 int nsh_archinitialize(void);
 #endif
 
+#include "../common/board_common.h"
+
 #endif /* __ASSEMBLY__ */
 
 __END_DECLS

--- a/src/drivers/boards/px4fmu-v1/board_config.h
+++ b/src/drivers/boards/px4fmu-v1/board_config.h
@@ -272,6 +272,8 @@ extern void stm32_usbinitialize(void);
 int nsh_archinitialize(void);
 #endif
 
+#include "../common/board_common.h"
+
 #endif /* __ASSEMBLY__ */
 
 __END_DECLS

--- a/src/drivers/boards/px4fmu-v2/CMakeLists.txt
+++ b/src/drivers/boards/px4fmu-v2/CMakeLists.txt
@@ -36,6 +36,7 @@ px4_add_module(
 		-Os
 	SRCS
 		../common/board_name.c
+		../common/board_dma_alloc.c
 		px4fmu_can.c
 		px4fmu2_init.c
 		px4fmu_timer_config.c

--- a/src/drivers/boards/px4fmu-v2/board_config.h
+++ b/src/drivers/boards/px4fmu-v2/board_config.h
@@ -270,6 +270,9 @@ __BEGIN_DECLS
 		{GPIO_VDD_5V_HIPOWER_OC, 0,                       0}, \
 		{GPIO_VDD_5V_PERIPH_OC,  0,                       0}, }
 
+/* This board provides a DMA pool and APIs */
+
+#define BOARD_DMA_ALLOC_POOL_SIZE 8192
 /****************************************************************************************************
  * Public Types
  ****************************************************************************************************/
@@ -317,6 +320,8 @@ extern void board_peripheral_reset(int ms);
 #ifdef CONFIG_NSH_LIBRARY
 int nsh_archinitialize(void);
 #endif
+
+#include "../common/board_common.h"
 
 #endif /* __ASSEMBLY__ */
 

--- a/src/drivers/boards/px4fmu-v2/px4fmu2_init.c
+++ b/src/drivers/boards/px4fmu-v2/px4fmu2_init.c
@@ -58,7 +58,6 @@
 #include <nuttx/sdio.h>
 #include <nuttx/mmcsd.h>
 #include <nuttx/analog/adc.h>
-#include <nuttx/gran.h>
 
 #include <stm32.h>
 #include "board_config.h"
@@ -111,73 +110,9 @@ __END_DECLS
 /****************************************************************************
  * Protected Functions
  ****************************************************************************/
-
-#if defined(CONFIG_FAT_DMAMEMORY)
-# if !defined(CONFIG_GRAN) || !defined(CONFIG_FAT_DMAMEMORY)
-#  error microSD DMA support requires CONFIG_GRAN
-# endif
-
-static GRAN_HANDLE dma_allocator;
-
-/*
- * The DMA heap size constrains the total number of things that can be
- * ready to do DMA at a time.
- *
- * For example, FAT DMA depends on one sector-sized buffer per filesystem plus
- * one sector-sized buffer per file.
- *
- * We use a fundamental alignment / granule size of 64B; this is sufficient
- * to guarantee alignment for the largest STM32 DMA burst (16 beats x 32bits).
- */
-static uint8_t g_dma_heap[8192] __attribute__((aligned(64)));
-static perf_counter_t g_dma_perf;
-
-static void
-dma_alloc_init(void)
-{
-	dma_allocator = gran_initialize(g_dma_heap,
-					sizeof(g_dma_heap),
-					7,  /* 128B granule - must be > alignment (XXX bug?) */
-					6); /* 64B alignment */
-
-	if (dma_allocator == NULL) {
-		message("DMA alloc FAILED");
-
-	} else {
-		g_dma_perf = perf_alloc(PC_COUNT, "dma_alloc");
-	}
-}
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
-
-/*
- * DMA-aware allocator stubs for the FAT filesystem.
- */
-
-__EXPORT void *fat_dma_alloc(size_t size);
-__EXPORT void fat_dma_free(FAR void *memory, size_t size);
-
-void *
-fat_dma_alloc(size_t size)
-{
-	perf_count(g_dma_perf);
-	return gran_alloc(dma_allocator, size);
-}
-
-void
-fat_dma_free(FAR void *memory, size_t size)
-{
-	gran_free(dma_allocator, memory, size);
-}
-
-#else
-
-# define dma_alloc_init()
-
-#endif
-
 /************************************************************************************
  * Name: board_peripheral_reset
  *
@@ -269,7 +204,10 @@ __EXPORT int nsh_archinitialize(void)
 	hrt_init();
 
 	/* configure the DMA allocator */
-	dma_alloc_init();
+
+	if (board_dma_alloc_init() < 0) {
+		message("DMA alloc FAILED");
+	}
 
 	/* configure CPU load estimation */
 #ifdef CONFIG_SCHED_INSTRUMENTATION

--- a/src/drivers/boards/px4fmu-v4/CMakeLists.txt
+++ b/src/drivers/boards/px4fmu-v4/CMakeLists.txt
@@ -36,6 +36,7 @@ px4_add_module(
 		-Os
 	SRCS
 		../common/board_name.c
+		../common/board_dma_alloc.c
 		px4fmu_can.c
 		px4fmu_init.c
 		px4fmu_timer_config.c

--- a/src/drivers/boards/px4fmu-v4/board_config.h
+++ b/src/drivers/boards/px4fmu-v4/board_config.h
@@ -297,6 +297,9 @@ __BEGIN_DECLS
 		{0,                      GPIO_VDD_3V3_SENSORS_EN, 0}, \
 		{GPIO_VDD_BRICK_VALID,   0,                       0}, }
 
+/* This board provides a DMA pool and APIs */
+
+#define BOARD_DMA_ALLOC_POOL_SIZE 8192
 
 /****************************************************************************************************
  * Public Types
@@ -346,6 +349,8 @@ extern void board_peripheral_reset(int ms);
 #ifdef CONFIG_NSH_LIBRARY
 int nsh_archinitialize(void);
 #endif
+
+#include "../common/board_common.h"
 
 #endif /* __ASSEMBLY__ */
 

--- a/src/drivers/boards/px4fmu-v4/px4fmu_init.c
+++ b/src/drivers/boards/px4fmu-v4/px4fmu_init.c
@@ -111,73 +111,9 @@ __END_DECLS
 /****************************************************************************
  * Protected Functions
  ****************************************************************************/
-
-#if defined(CONFIG_FAT_DMAMEMORY)
-# if !defined(CONFIG_GRAN) || !defined(CONFIG_FAT_DMAMEMORY)
-#  error microSD DMA support requires CONFIG_GRAN
-# endif
-
-static GRAN_HANDLE dma_allocator;
-
-/*
- * The DMA heap size constrains the total number of things that can be
- * ready to do DMA at a time.
- *
- * For example, FAT DMA depends on one sector-sized buffer per filesystem plus
- * one sector-sized buffer per file.
- *
- * We use a fundamental alignment / granule size of 64B; this is sufficient
- * to guarantee alignment for the largest STM32 DMA burst (16 beats x 32bits).
- */
-static uint8_t g_dma_heap[8192] __attribute__((aligned(64)));
-static perf_counter_t g_dma_perf;
-
-static void
-dma_alloc_init(void)
-{
-	dma_allocator = gran_initialize(g_dma_heap,
-					sizeof(g_dma_heap),
-					7,  /* 128B granule - must be > alignment (XXX bug?) */
-					6); /* 64B alignment */
-
-	if (dma_allocator == NULL) {
-		message("DMA alloc FAILED");
-
-	} else {
-		g_dma_perf = perf_alloc(PC_COUNT, "dma_alloc");
-	}
-}
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
-
-/*
- * DMA-aware allocator stubs for the FAT filesystem.
- */
-
-__EXPORT void *fat_dma_alloc(size_t size);
-__EXPORT void fat_dma_free(FAR void *memory, size_t size);
-
-void *
-fat_dma_alloc(size_t size)
-{
-	perf_count(g_dma_perf);
-	return gran_alloc(dma_allocator, size);
-}
-
-void
-fat_dma_free(FAR void *memory, size_t size)
-{
-	gran_free(dma_allocator, memory, size);
-}
-
-#else
-
-# define dma_alloc_init()
-
-#endif
-
 /************************************************************************************
  * Name: board_peripheral_reset
  *
@@ -278,7 +214,10 @@ __EXPORT int nsh_archinitialize(void)
 	hrt_init();
 
 	/* configure the DMA allocator */
-	dma_alloc_init();
+
+	if (board_dma_alloc_init() < 0) {
+		message("DMA alloc FAILED");
+	}
 
 	/* configure CPU load estimation */
 #ifdef CONFIG_SCHED_INSTRUMENTATION

--- a/src/modules/systemlib/printload.c
+++ b/src/modules/systemlib/printload.c
@@ -215,12 +215,25 @@ void print_load(uint64_t t, int fd, struct print_load_s *print_state)
 					(double)(task_load * 100.f),
 					(double)(sched_load * 100.f),
 					(double)(idle * 100.f));
+#if defined(BOARD_DMA_ALLOC_POOL_SIZE)
+				uint16_t dma_total;
+				uint16_t dma_used;
+				uint16_t dma_peek_used;
+
+				if (board_get_dma_usage(&dma_total, &dma_used, &dma_peek_used) >= 0) {
+					dprintf(fd, "%sDMA Memory: %d total, %d used %d peek\n",
+						clear_line,
+						dma_total,
+						dma_used,
+						dma_peek_used);
+				}
+
+#endif
 				dprintf(fd, "%sUptime: %.3fs total, %.3fs idle\n%s\n",
 					clear_line,
 					(double)curr_time_us / 1000000.d,
 					(double)idle_time_us / 1000000.d,
 					clear_line);
-
 				/* header for task list */
 				dprintf(fd, "%s%4s %*-s %8s %6s %11s %10s %-6s\n",
 					clear_line,


### PR DESCRIPTION
@LorenzMeier

This PR moves the DMA allocation to a common file and adds an API to get the DMA heap usage.
```
Processes: 23 total, 2 running, 21 sleeping
CPU usage: 35.48% tasks, 0.67% sched, 63.85% idle
DMA Memory: 8192 total, 1024 used 1536 peek
Uptime: 127.342s total, 82.374s idle

 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE
   0 Idle Task                   82374 63.847     0/    0   0 (  0)  READY
   1 hpwork                       3373  2.619   764/ 1592 192 (192)  w:sig
   2 lpwork                        659  0.523   572/ 1592  50 ( 50)  w:sig
   3 init                         1750  0.000  1168/ 2496 100 (100)  w:sem
 251 top                          2207  3.293  1220/ 1696 100 (100)  RUN
  90 gps                           142  0.074   900/ 1192 220 (220)  w:sem
  92 dataman                        29  0.000   660/ 1192  90 ( 90)  w:sem
 118 sensors                      3885  3.068  1596/ 1992 250 (250)  w:sem
 120 commander                    2752  2.095  3076/ 3592 140 (140)  w:sig
 121 commander_low_prio            265  0.000   780/ 2992  50 ( 50)  w:sem
 127 px4io                        3944  3.068  1060/ 1392 240 (240)  w:sem
 137 mavlink_if0                  1238  0.973  2348/ 2792 100 (100)  w:sig
 138 mavlink_rcv_if0                10  0.000   988/ 2096 175 (175)  w:sem
 145 mavlink_if1                   984  0.748  2356/ 2792 100 (100)  w:sig
 146 mavlink_rcv_if1               517  0.374   988/ 2096 175 (175)  w:sem
 173 mavlink_if2                  4460  3.443  2356/ 2792 100 (100)  w:sig
 174 mavlink_rcv_if2                10  0.000   988/ 2096 175 (175)  w:sem
 181 sdlog2                       1542  1.272  2084/ 3392 177 (177)  w:sem
 221 attitude_estimator_q         7937  6.511  2004/ 2496 250 (250)  w:sem
 228 position_estimator_inav      3178  2.694  4828/ 5296 250 (250)  w:sem
 235 mc_att_control               4236  3.443  1228/ 1496 250 (250)  w:sem
 239 mc_pos_control               1400  1.272  1140/ 1896 250 (250)  w:sem
 244 navigator                       7  0.000   828/ 1296 105 (105)  w:sem
```
I think @kd0aij and @bkueng should stress test FAT FS on the card then run top to see what kind of use we have. If the max usages is only 3 X 512 Bytes then the 8K allocations size is 13 * 512 overkill.