### PR TITLE
For HW with no ADC_5V_RAIL_SENSE 

### DIFF
--- a/src/drivers/stm32/adc/adc.cpp
+++ b/src/drivers/stm32/adc/adc.cpp
@@ -349,12 +349,14 @@ ADC::update_system_power(hrt_abstime now)
 
 	system_power.voltage5V_v = 0;
 
+#if defined(ADC_5V_RAIL_SENSE)
 	for (unsigned i = 0; i < _channel_count; i++) {
 		if (_samples[i].am_channel == ADC_5V_RAIL_SENSE) {
 			// it is 2:1 scaled
 			system_power.voltage5V_v = _samples[i].am_data * (6.6f / 4096);
 		}
 	}
+#endif
 
 	/* Note once the board_config.h provides BOARD_ADC_USB_CONNECTED,
 	 * It must provide the true logic GPIO BOARD_ADC_xxxx macros.

--- a/src/drivers/stm32/adc/adc.cpp
+++ b/src/drivers/stm32/adc/adc.cpp
@@ -350,12 +350,14 @@ ADC::update_system_power(hrt_abstime now)
 	system_power.voltage5V_v = 0;
 
 #if defined(ADC_5V_RAIL_SENSE)
+
 	for (unsigned i = 0; i < _channel_count; i++) {
 		if (_samples[i].am_channel == ADC_5V_RAIL_SENSE) {
 			// it is 2:1 scaled
 			system_power.voltage5V_v = _samples[i].am_data * (6.6f / 4096);
 		}
 	}
+
 #endif
 
 	/* Note once the board_config.h provides BOARD_ADC_USB_CONNECTED,


### PR DESCRIPTION
@LorenzMeier 

This allows a board without ADC_5V_RAIL_SENSE defined