### PR TITLE
make submodulesclean sync recursively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ submodulesclean:
 	@git submodule update --init --recursive --force
 
 distclean: submodulesclean
-	@git clean -ff -x -d
+	@git clean -ff -x -d -e ".project" -e ".cproject"
 
 # targets handled by cmake
 cmake_targets = test upload package package_source debug debug_tui debug_ddd debug_io debug_io_tui debug_io_ddd check_weak \

--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ clean:
 	@(cd NuttX/nuttx && make clean)
 
 submodulesclean:
-	@git submodule sync
+	@git submodule sync --recursive
 	@git submodule deinit -f .
 	@git submodule update --init --recursive --force
 


### PR DESCRIPTION
I somehow got stuck when the nested DriverFramework dspal submodule moved and `make submodulesclean` couldn't fix it because dspal needed to be synced first.