### PR TITLE
Snapdragon: start sdlog first to log everything

### DIFF
--- a/posix-configs/eagle/flight/mainapp.config
+++ b/posix-configs/eagle/flight/mainapp.config
@@ -1,5 +1,6 @@
 uorb start
 muorb start
+sdlog2 start -r 100 -e -t -a -b 200
 dataman start
 navigator start
 mavlink start -u 14556 -r 1000000
@@ -7,4 +8,3 @@ sleep 1
 mavlink stream -u 14556 -s HIGHRES_IMU -r 50
 mavlink stream -u 14556 -s ATTITUDE -r 50
 mavlink boot_complete
-sdlog2 start -r 100 -e -t -a -b 200

--- a/posix-configs/eagle/flight/px4.config
+++ b/posix-configs/eagle/flight/px4.config
@@ -1,6 +1,7 @@
 uorb start
 qshell start
 param set SYS_AUTOSTART 4001
+sleep 1
 gps start -d /dev/tty-4
 sleep 1
 param set MAV_TYPE 2


### PR DESCRIPTION
In order to capture everything for replay logs, start sdlog2 at the very
beginning. Also, wait with starting the sensors for a second, to make
sure sdlog2 has started by then.

Fixes #4299.

Tested on Snapdragon.