### PR TITLE
DriverFramework wrappers shouldn't publish garbage

### DIFF
--- a/src/platforms/posix/drivers/df_bmp280_wrapper/df_bmp280_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_bmp280_wrapper/df_bmp280_wrapper.cpp
@@ -115,16 +115,6 @@ DfBmp280Wrapper::~DfBmp280Wrapper()
 
 int DfBmp280Wrapper::start()
 {
-	// TODO: don't publish garbage here
-	baro_report baro_report = {};
-	_baro_topic = orb_advertise_multi(ORB_ID(sensor_baro), &baro_report,
-					  &_baro_orb_class_instance, ORB_PRIO_DEFAULT);
-
-	if (_baro_topic == nullptr) {
-		PX4_ERR("sensor_baro advert fail");
-		return -1;
-	}
-
 	/* Init device and start sensor. */
 	int ret = init();
 
@@ -197,7 +187,10 @@ int DfBmp280Wrapper::_publish(struct baro_sensor_data &data)
 	// TODO: when is this ever blocked?
 	if (!(m_pub_blocked)) {
 
-		if (_baro_topic != nullptr) {
+		if (_baro_topic == nullptr) {
+			_baro_topic = orb_advertise_multi(ORB_ID(sensor_baro), &baro_report,
+							  &_baro_orb_class_instance, ORB_PRIO_DEFAULT);
+		} else {
 			orb_publish(ORB_ID(sensor_baro), _baro_topic, &baro_report);
 		}
 	}

--- a/src/platforms/posix/drivers/df_bmp280_wrapper/df_bmp280_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_bmp280_wrapper/df_bmp280_wrapper.cpp
@@ -190,6 +190,7 @@ int DfBmp280Wrapper::_publish(struct baro_sensor_data &data)
 		if (_baro_topic == nullptr) {
 			_baro_topic = orb_advertise_multi(ORB_ID(sensor_baro), &baro_report,
 							  &_baro_orb_class_instance, ORB_PRIO_DEFAULT);
+
 		} else {
 			orb_publish(ORB_ID(sensor_baro), _baro_topic, &baro_report);
 		}

--- a/src/platforms/posix/drivers/df_isl29501_wrapper/df_isl29501_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_isl29501_wrapper/df_isl29501_wrapper.cpp
@@ -118,11 +118,6 @@ DfISL29501Wrapper::~DfISL29501Wrapper()
 
 int DfISL29501Wrapper::start()
 {
-
-	struct distance_sensor_s d;
-	_range_topic = orb_advertise_multi(ORB_ID(distance_sensor), &d,
-					   &_orb_class_instance, ORB_PRIO_DEFAULT);
-
 	int ret;
 	ret = ISL29501::init();
 
@@ -156,10 +151,6 @@ int DfISL29501Wrapper::stop()
 
 int DfISL29501Wrapper::_publish(struct range_sensor_data &data)
 {
-	if (!_range_topic) {
-		return 1;
-	}
-
 	struct distance_sensor_s d;
 
 	memset(&d, 0, sizeof(d));
@@ -178,7 +169,12 @@ int DfISL29501Wrapper::_publish(struct range_sensor_data &data)
 
 	d.covariance = 0.0f;
 
-	orb_publish(ORB_ID(distance_sensor), _range_topic, &d);
+	if (_range_topic == nullptr) {
+		_range_topic = orb_advertise_multi(ORB_ID(distance_sensor), &d,
+						   &_orb_class_instance, ORB_PRIO_DEFAULT);
+	} else {
+		orb_publish(ORB_ID(distance_sensor), _range_topic, &d);
+	}
 
 	/* Notify anyone waiting for data. */
 	DevMgr::updateNotify(*this);

--- a/src/platforms/posix/drivers/df_isl29501_wrapper/df_isl29501_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_isl29501_wrapper/df_isl29501_wrapper.cpp
@@ -172,6 +172,7 @@ int DfISL29501Wrapper::_publish(struct range_sensor_data &data)
 	if (_range_topic == nullptr) {
 		_range_topic = orb_advertise_multi(ORB_ID(distance_sensor), &d,
 						   &_orb_class_instance, ORB_PRIO_DEFAULT);
+
 	} else {
 		orb_publish(ORB_ID(distance_sensor), _range_topic, &d);
 	}

--- a/src/platforms/posix/drivers/df_trone_wrapper/df_trone_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_trone_wrapper/df_trone_wrapper.cpp
@@ -117,10 +117,6 @@ DfTROneWrapper::~DfTROneWrapper()
 
 int DfTROneWrapper::start()
 {
-	struct distance_sensor_s d;
-	_range_topic = orb_advertise_multi(ORB_ID(distance_sensor), &d,
-					   &_orb_class_instance, ORB_PRIO_DEFAULT);
-
 	int ret;
 
 	/* Init device and start sensor. */
@@ -156,10 +152,6 @@ int DfTROneWrapper::stop()
 
 int DfTROneWrapper::_publish(struct range_sensor_data &data)
 {
-	if (!_range_topic) {
-		return 1;
-	}
-
 	struct distance_sensor_s d;
 
 	memset(&d, 0, sizeof(d));
@@ -180,7 +172,12 @@ int DfTROneWrapper::_publish(struct range_sensor_data &data)
 
 	d.covariance = 0.0f;
 
-	orb_publish(ORB_ID(distance_sensor), _range_topic, &d);
+	if (_range_topic == nullptr) {
+		_range_topic = orb_advertise_multi(ORB_ID(distance_sensor), &d,
+						   &_orb_class_instance, ORB_PRIO_DEFAULT);
+	} else {
+		orb_publish(ORB_ID(distance_sensor), _range_topic, &d);
+	}
 
 	/* Notify anyone waiting for data. */
 	DevMgr::updateNotify(*this);

--- a/src/platforms/posix/drivers/df_trone_wrapper/df_trone_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_trone_wrapper/df_trone_wrapper.cpp
@@ -175,6 +175,7 @@ int DfTROneWrapper::_publish(struct range_sensor_data &data)
 	if (_range_topic == nullptr) {
 		_range_topic = orb_advertise_multi(ORB_ID(distance_sensor), &d,
 						   &_orb_class_instance, ORB_PRIO_DEFAULT);
+
 	} else {
 		orb_publish(ORB_ID(distance_sensor), _range_topic, &d);
 	}


### PR DESCRIPTION
It didn't make sense to do the orb_advertise calls with 0 data instead of later with real data. Presumably, this had the potential to throw off estimators.

Snappy still compiles and runs.

FYI: @eyeam3 