### PR TITLE
Fix strange land detector init

### DIFF
--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -135,6 +135,11 @@ bool MulticopterLandDetector::get_freefall_state()
 
 	const uint64_t now = hrt_absolute_time();
 
+	if (_ctrl_state.timestamp == 0) {
+		// _ctrl_state is not valid yet, we have to assume we're not falling.
+		return false;
+	}
+
 	float acc_norm = _ctrl_state.x_acc * _ctrl_state.x_acc
 			 + _ctrl_state.y_acc * _ctrl_state.y_acc
 			 + _ctrl_state.z_acc * _ctrl_state.z_acc;


### PR DESCRIPTION
The land detector showed erratic behaviour at startup. This should now be fixed. Also, the info in commander should be more consistent.

Bench tested on Snapdragon and flown in SITL.