### PR TITLE
Tools: add separate jmavsim_run.sh script

### DIFF
--- a/Tools/jmavsim_run.sh
+++ b/Tools/jmavsim_run.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR/jMAVSim"
+
+ant create_run_jar copy_res
+cd out/production
+java -Djava.ext.dirs= -jar jmavsim_run.jar -udp 127.0.0.1:14560

--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -64,10 +64,7 @@ SIM_PID=0
 
 if [ "$program" == "jmavsim" ] && [ ! -n "$no_sim" ]
 then
-	cd $src_path/Tools/jMAVSim
-	ant create_run_jar copy_res
-	cd out/production
-	java -Djava.ext.dirs= -jar jmavsim_run.jar -udp 127.0.0.1:14560 &
+	./Tools/jmavsim_run.sh &
 	SIM_PID=`echo $!`
 	cd ../..
 elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]
@@ -135,6 +132,7 @@ fi
 
 if [ "$program" == "jmavsim" ]
 then
+	pkill -9 -P $SIM_PID
 	kill -9 $SIM_PID
 elif [ "$program" == "gazebo" ]
 then

--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -64,7 +64,7 @@ SIM_PID=0
 
 if [ "$program" == "jmavsim" ] && [ ! -n "$no_sim" ]
 then
-	./Tools/jmavsim_run.sh &
+	$src_path/Tools/jmavsim_run.sh &
 	SIM_PID=`echo $!`
 	cd ../..
 elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]


### PR DESCRIPTION
It is useful to run jmavsim separately, for example when debugging mainapp
separately, or running some other external tool on mainapp (like heap analysis)