### PR TITLE
uORB queuing

### DIFF
--- a/src/drivers/airspeed/airspeed.cpp
+++ b/src/drivers/airspeed/airspeed.cpp
@@ -150,7 +150,7 @@ Airspeed::init()
 		_reports->get(&arp);
 
 		/* measurement will have generated a report, publish */
-		_airspeed_pub = orb_advertise(ORB_ID(differential_pressure), &arp);
+		_airspeed_pub = orb_advertise(ORB_ID(differential_pressure), &arp, ORB_DEFAULT_QUEUE_SIZE);
 
 		if (_airspeed_pub == nullptr) {
 			warnx("uORB started?");
@@ -385,7 +385,7 @@ Airspeed::update_status()
 			orb_publish(ORB_ID(subsystem_info), _subsys_pub, &info);
 
 		} else {
-			_subsys_pub = orb_advertise(ORB_ID(subsystem_info), &info);
+			_subsys_pub = orb_advertise(ORB_ID(subsystem_info), &info, ORB_DEFAULT_QUEUE_SIZE);
 		}
 
 		_last_published_sensor_ok = _sensor_ok;

--- a/src/drivers/ardrone_interface/ardrone_motor_control.c
+++ b/src/drivers/ardrone_interface/ardrone_motor_control.c
@@ -346,7 +346,7 @@ int ardrone_write_motor_commands(int ardrone_fd, uint16_t motor1, uint16_t motor
 
 	if (pub == 0) {
 		/* advertise to channel 0 / primary */
-		pub = orb_advertise(ORB_ID(actuator_outputs), &outputs);
+		pub = orb_advertise(ORB_ID(actuator_outputs), &outputs, ORB_DEFAULT_QUEUE_SIZE);
 	}
 
 	if (hrt_absolute_time() - last_motor_time > min_motor_interval) {

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -710,7 +710,7 @@ BATT_SMBUS::cycle()
 			orb_publish(_batt_orb_id, _batt_topic, &new_report);
 
 		} else {
-			_batt_topic = orb_advertise(_batt_orb_id, &new_report);
+			_batt_topic = orb_advertise(_batt_orb_id, &new_report, ORB_DEFAULT_QUEUE_SIZE);
 
 			if (_batt_topic == nullptr) {
 				errx(1, "ADVERT FAIL");

--- a/src/drivers/bma180/bma180.cpp
+++ b/src/drivers/bma180/bma180.cpp
@@ -334,7 +334,7 @@ BMA180::init()
 		_reports->get(&arp);
 
 		/* measurement will have generated a report, publish */
-		_accel_topic = orb_advertise(ORB_ID(sensor_accel), &arp);
+		_accel_topic = orb_advertise(ORB_ID(sensor_accel), &arp, ORB_DEFAULT_QUEUE_SIZE);
 	}
 
 out:

--- a/src/drivers/bmi160/bmi160.cpp
+++ b/src/drivers/bmi160/bmi160.cpp
@@ -190,7 +190,7 @@ BMI160::init()
 
 	/* measurement will have generated a report, publish */
 	_accel_topic = orb_advertise_multi(ORB_ID(sensor_accel), &arp,
-					   &_accel_orb_class_instance, (is_external()) ? ORB_PRIO_MAX - 1 : ORB_PRIO_HIGH - 1);
+					   &_accel_orb_class_instance, (is_external()) ? ORB_PRIO_MAX - 1 : ORB_PRIO_HIGH - 1, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_accel_topic == nullptr) {
 		warnx("ADVERT FAIL");
@@ -202,7 +202,7 @@ BMI160::init()
 	_gyro_reports->get(&grp);
 
 	_gyro->_gyro_topic = orb_advertise_multi(ORB_ID(sensor_gyro), &grp,
-			     &_gyro->_gyro_orb_class_instance, (is_external()) ? ORB_PRIO_MAX - 1 : ORB_PRIO_HIGH - 1);
+			     &_gyro->_gyro_orb_class_instance, (is_external()) ? ORB_PRIO_MAX - 1 : ORB_PRIO_HIGH - 1, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_gyro->_gyro_topic == nullptr) {
 		warnx("ADVERT FAIL");

--- a/src/drivers/bmp280/bmp280.cpp
+++ b/src/drivers/bmp280/bmp280.cpp
@@ -268,7 +268,7 @@ BMP280::init()
 	_reports->get(&brp);
 
 	_baro_topic = orb_advertise_multi(ORB_ID(sensor_baro), &brp,
-					  &_orb_class_instance, _interface->is_external() ? ORB_PRIO_HIGH : ORB_PRIO_DEFAULT);
+					  &_orb_class_instance, _interface->is_external() ? ORB_PRIO_HIGH : ORB_PRIO_DEFAULT, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_baro_topic == nullptr) {
 		warnx("failed to create sensor_baro publication");

--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -231,7 +231,7 @@ CameraTrigger::CameraTrigger() :
 
 	struct camera_trigger_s	camera_trigger = {};
 
-	_trigger_pub = orb_advertise(ORB_ID(camera_trigger), &camera_trigger);
+	_trigger_pub = orb_advertise(ORB_ID(camera_trigger), &camera_trigger, ORB_DEFAULT_QUEUE_SIZE);
 }
 
 CameraTrigger::~CameraTrigger()

--- a/src/drivers/gimbal/gimbal.cpp
+++ b/src/drivers/gimbal/gimbal.cpp
@@ -312,7 +312,7 @@ Gimbal::cycle()
 		struct actuator_controls_s zero_report;
 		memset(&zero_report, 0, sizeof(zero_report));
 		zero_report.timestamp = hrt_absolute_time();
-		_actuator_controls_2_topic = orb_advertise(ORB_ID(actuator_controls_2), &zero_report);
+		_actuator_controls_2_topic = orb_advertise(ORB_ID(actuator_controls_2), &zero_report, ORB_DEFAULT_QUEUE_SIZE);
 
 		if (_actuator_controls_2_topic == nullptr) {
 			warnx("advert err");

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -983,12 +983,12 @@ GPS::publish()
 {
 	if (_gps_num == 1) {
 		orb_publish_auto(ORB_ID(vehicle_gps_position), &_report_gps_pos_pub, &_report_gps_pos, &_gps_orb_instance,
-				 ORB_PRIO_DEFAULT);
+				 ORB_PRIO_DEFAULT, ORB_DEFAULT_QUEUE_SIZE);
 		is_gps1_advertised = true;
 
 	} else if (is_gps1_advertised) {
 		orb_publish_auto(ORB_ID(vehicle_gps_position), &_report_gps_pos_pub, &_report_gps_pos, &_gps_orb_instance,
-				 ORB_PRIO_DEFAULT);
+				 ORB_PRIO_DEFAULT, ORB_DEFAULT_QUEUE_SIZE);
 	}
 
 }
@@ -997,7 +997,7 @@ GPS::publishSatelliteInfo()
 {
 	if (_gps_num == 1) {
 		orb_publish_auto(ORB_ID(satellite_info), &_report_sat_info_pub, _p_report_sat_info, &_gps_sat_orb_instance,
-				 ORB_PRIO_DEFAULT);
+				 ORB_PRIO_DEFAULT, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		//we don't publish satellite info for the secondary gps

--- a/src/drivers/hc_sr04/hc_sr04.cpp
+++ b/src/drivers/hc_sr04/hc_sr04.cpp
@@ -289,7 +289,7 @@ HC_SR04::init()
 	struct distance_sensor_s ds_report = {};
 
 	_distance_sensor_topic = orb_advertise_multi(ORB_ID(distance_sensor), &ds_report,
-				 &_orb_class_instance, ORB_PRIO_LOW);
+				 &_orb_class_instance, ORB_PRIO_LOW, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_distance_sensor_topic == nullptr) {
 		DEVICE_LOG("failed to create distance_sensor object. Did you start uOrb?");
@@ -672,7 +672,7 @@ HC_SR04::start()
 
 
 	} else {
-		pub = orb_advertise(ORB_ID(subsystem_info), &info);
+		pub = orb_advertise(ORB_ID(subsystem_info), &info, ORB_DEFAULT_QUEUE_SIZE);
 
 	}
 }

--- a/src/drivers/hmc5883/hmc5883.cpp
+++ b/src/drivers/hmc5883/hmc5883.cpp
@@ -1023,7 +1023,7 @@ HMC5883::collect()
 
 		} else {
 			_mag_topic = orb_advertise_multi(ORB_ID(sensor_mag), &new_report,
-							 &_orb_class_instance, (sensor_is_onboard) ? ORB_PRIO_HIGH : ORB_PRIO_MAX);
+							 &_orb_class_instance, (sensor_is_onboard) ? ORB_PRIO_HIGH : ORB_PRIO_MAX, ORB_DEFAULT_QUEUE_SIZE);
 
 			if (_mag_topic == nullptr) {
 				DEVICE_DEBUG("ADVERT FAIL");

--- a/src/drivers/hott/messages.cpp
+++ b/src/drivers/hott/messages.cpp
@@ -124,7 +124,7 @@ publish_gam_message(const uint8_t *buffer)
 		orb_publish(ORB_ID(esc_status), _esc_pub, &esc);
 
 	} else {
-		_esc_pub = orb_advertise(ORB_ID(esc_status), &esc);
+		_esc_pub = orb_advertise(ORB_ID(esc_status), &esc, ORB_DEFAULT_QUEUE_SIZE);
 	}
 }
 

--- a/src/drivers/l3gd20/l3gd20.cpp
+++ b/src/drivers/l3gd20/l3gd20.cpp
@@ -501,7 +501,7 @@ L3GD20::init()
 	_reports->get(&grp);
 
 	_gyro_topic = orb_advertise_multi(ORB_ID(sensor_gyro), &grp,
-					  &_orb_class_instance, (is_external()) ? ORB_PRIO_VERY_HIGH : ORB_PRIO_DEFAULT);
+					  &_orb_class_instance, (is_external()) ? ORB_PRIO_VERY_HIGH : ORB_PRIO_DEFAULT, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_gyro_topic == nullptr) {
 		DEVICE_DEBUG("failed to create sensor_gyro publication");

--- a/src/drivers/lis3mdl/lis3mdl.cpp
+++ b/src/drivers/lis3mdl/lis3mdl.cpp
@@ -983,7 +983,7 @@ LIS3MDL::collect()
 
 		} else {
 			_mag_topic = orb_advertise_multi(ORB_ID(sensor_mag), &new_report,
-							 &_orb_class_instance, (sensor_is_onboard) ? ORB_PRIO_HIGH : ORB_PRIO_MAX);
+							 &_orb_class_instance, (sensor_is_onboard) ? ORB_PRIO_HIGH : ORB_PRIO_MAX, ORB_DEFAULT_QUEUE_SIZE);
 
 			if (_mag_topic == nullptr) {
 				DEVICE_DEBUG("ADVERT FAIL");

--- a/src/drivers/ll40ls/LidarLiteI2C.cpp
+++ b/src/drivers/ll40ls/LidarLiteI2C.cpp
@@ -131,7 +131,7 @@ int LidarLiteI2C::init()
 	measure();
 	_reports->get(&ds_report);
 	_distance_sensor_topic = orb_advertise_multi(ORB_ID(distance_sensor), &ds_report,
-				 &_orb_class_instance, ORB_PRIO_LOW);
+				 &_orb_class_instance, ORB_PRIO_LOW, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_distance_sensor_topic == nullptr) {
 		DEVICE_DEBUG("failed to create distance_sensor object. Did you start uOrb?");

--- a/src/drivers/ll40ls/LidarLitePWM.cpp
+++ b/src/drivers/ll40ls/LidarLitePWM.cpp
@@ -113,7 +113,7 @@ int LidarLitePWM::init()
 	measure();
 	_reports->get(&ds_report);
 	_distance_sensor_topic = orb_advertise_multi(ORB_ID(distance_sensor), &ds_report,
-				 &_orb_class_instance, ORB_PRIO_LOW);
+				 &_orb_class_instance, ORB_PRIO_LOW, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_distance_sensor_topic == nullptr) {
 		DEVICE_DEBUG("failed to create distance_sensor object. Did you start uOrb?");

--- a/src/drivers/lsm303d/lsm303d.cpp
+++ b/src/drivers/lsm303d/lsm303d.cpp
@@ -687,7 +687,7 @@ LSM303D::init()
 
 	/* measurement will have generated a report, publish */
 	_mag->_mag_topic = orb_advertise_multi(ORB_ID(sensor_mag), &mrp,
-					       &_mag->_mag_orb_class_instance, ORB_PRIO_LOW);
+					       &_mag->_mag_orb_class_instance, ORB_PRIO_LOW, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_mag->_mag_topic == nullptr) {
 		warnx("ADVERT ERR");
@@ -702,7 +702,7 @@ LSM303D::init()
 
 	/* measurement will have generated a report, publish */
 	_accel_topic = orb_advertise_multi(ORB_ID(sensor_accel), &arp,
-					   &_accel_orb_class_instance, (is_external()) ? ORB_PRIO_VERY_HIGH : ORB_PRIO_DEFAULT);
+					   &_accel_orb_class_instance, (is_external()) ? ORB_PRIO_VERY_HIGH : ORB_PRIO_DEFAULT, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_accel_topic == nullptr) {
 		warnx("ADVERT ERR");

--- a/src/drivers/mb12xx/mb12xx.cpp
+++ b/src/drivers/mb12xx/mb12xx.cpp
@@ -274,7 +274,7 @@ MB12XX::init()
 	struct distance_sensor_s ds_report = {};
 
 	_distance_sensor_topic = orb_advertise_multi(ORB_ID(distance_sensor), &ds_report,
-				 &_orb_class_instance, ORB_PRIO_LOW);
+				 &_orb_class_instance, ORB_PRIO_LOW, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_distance_sensor_topic == nullptr) {
 		DEVICE_LOG("failed to create distance_sensor object. Did you start uOrb?");
@@ -629,7 +629,7 @@ MB12XX::start()
 
 
 	} else {
-		pub = orb_advertise(ORB_ID(subsystem_info), &info);
+		pub = orb_advertise(ORB_ID(subsystem_info), &info, ORB_DEFAULT_QUEUE_SIZE);
 
 	}
 }

--- a/src/drivers/mkblctrl/mkblctrl.cpp
+++ b/src/drivers/mkblctrl/mkblctrl.cpp
@@ -481,14 +481,14 @@ MK::task_main()
 	memset(&outputs, 0, sizeof(outputs));
 	int dummy;
 	_t_outputs = orb_advertise_multi(ORB_ID(actuator_outputs),
-					 &outputs, &dummy, ORB_PRIO_HIGH);
+					 &outputs, &dummy, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 
 	/*
 	 * advertise the blctrl status.
 	 */
 	esc_status_s esc;
 	memset(&esc, 0, sizeof(esc));
-	_t_esc_status = orb_advertise(ORB_ID(esc_status), &esc);
+	_t_esc_status = orb_advertise(ORB_ID(esc_status), &esc, ORB_DEFAULT_QUEUE_SIZE);
 
 
 	pollfd fds[2];

--- a/src/drivers/mpu6000/mpu6000.cpp
+++ b/src/drivers/mpu6000/mpu6000.cpp
@@ -705,7 +705,7 @@ MPU6000::init()
 
 	/* measurement will have generated a report, publish */
 	_accel_topic = orb_advertise_multi(ORB_ID(sensor_accel), &arp,
-					   &_accel_orb_class_instance, (is_external()) ? ORB_PRIO_MAX : ORB_PRIO_HIGH);
+					   &_accel_orb_class_instance, (is_external()) ? ORB_PRIO_MAX : ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_accel_topic == nullptr) {
 		warnx("ADVERT FAIL");
@@ -717,7 +717,7 @@ MPU6000::init()
 	_gyro_reports->get(&grp);
 
 	_gyro->_gyro_topic = orb_advertise_multi(ORB_ID(sensor_gyro), &grp,
-			     &_gyro->_gyro_orb_class_instance, (is_external()) ? ORB_PRIO_MAX : ORB_PRIO_HIGH);
+			     &_gyro->_gyro_orb_class_instance, (is_external()) ? ORB_PRIO_MAX : ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_gyro->_gyro_topic == nullptr) {
 		warnx("ADVERT FAIL");

--- a/src/drivers/mpu6500/mpu6500.cpp
+++ b/src/drivers/mpu6500/mpu6500.cpp
@@ -671,7 +671,7 @@ MPU6500::init()
 
 	/* measurement will have generated a report, publish */
 	_accel_topic = orb_advertise_multi(ORB_ID(sensor_accel), &arp,
-					   &_accel_orb_class_instance, (is_external()) ? ORB_PRIO_MAX : ORB_PRIO_HIGH);
+					   &_accel_orb_class_instance, (is_external()) ? ORB_PRIO_MAX : ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_accel_topic == nullptr) {
 		warnx("ADVERT FAIL");
@@ -683,7 +683,7 @@ MPU6500::init()
 	_gyro_reports->get(&grp);
 
 	_gyro->_gyro_topic = orb_advertise_multi(ORB_ID(sensor_gyro), &grp,
-			     &_gyro->_gyro_orb_class_instance, (is_external()) ? ORB_PRIO_MAX : ORB_PRIO_HIGH);
+			     &_gyro->_gyro_orb_class_instance, (is_external()) ? ORB_PRIO_MAX : ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_gyro->_gyro_topic == nullptr) {
 		warnx("ADVERT FAIL");

--- a/src/drivers/mpu9250/mag.cpp
+++ b/src/drivers/mpu9250/mag.cpp
@@ -225,7 +225,7 @@ MPU9250_mag::init()
 	_mag_reports->get(&mrp);
 
 	_mag_topic = orb_advertise_multi(ORB_ID(sensor_mag), &mrp,
-					 &_mag_orb_class_instance, ORB_PRIO_LOW);
+					 &_mag_orb_class_instance, ORB_PRIO_LOW, ORB_DEFAULT_QUEUE_SIZE);
 //			   &_mag_orb_class_instance, (is_external()) ? ORB_PRIO_MAX - 1 : ORB_PRIO_HIGH - 1);
 
 	if (_mag_topic == nullptr) {

--- a/src/drivers/mpu9250/mpu9250.cpp
+++ b/src/drivers/mpu9250/mpu9250.cpp
@@ -407,7 +407,7 @@ MPU9250::init()
 
 	/* measurement will have generated a report, publish */
 	_accel_topic = orb_advertise_multi(ORB_ID(sensor_accel), &arp,
-					   &_accel_orb_class_instance, (is_external()) ? ORB_PRIO_MAX - 1 : ORB_PRIO_HIGH - 1);
+					   &_accel_orb_class_instance, (is_external()) ? ORB_PRIO_MAX - 1 : ORB_PRIO_HIGH - 1, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_accel_topic == nullptr) {
 		warnx("ADVERT FAIL");
@@ -418,7 +418,7 @@ MPU9250::init()
 	_gyro_reports->get(&grp);
 
 	_gyro->_gyro_topic = orb_advertise_multi(ORB_ID(sensor_gyro), &grp,
-			     &_gyro->_gyro_orb_class_instance, (is_external()) ? ORB_PRIO_MAX - 1 : ORB_PRIO_HIGH - 1);
+			     &_gyro->_gyro_orb_class_instance, (is_external()) ? ORB_PRIO_MAX - 1 : ORB_PRIO_HIGH - 1, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_gyro->_gyro_topic == nullptr) {
 		warnx("ADVERT FAIL");

--- a/src/drivers/ms5611/ms5611_nuttx.cpp
+++ b/src/drivers/ms5611/ms5611_nuttx.cpp
@@ -324,7 +324,7 @@ MS5611::init()
 		ret = OK;
 
 		_baro_topic = orb_advertise_multi(ORB_ID(sensor_baro), &brp,
-						  &_orb_class_instance, (is_external()) ? ORB_PRIO_HIGH : ORB_PRIO_DEFAULT);
+						  &_orb_class_instance, (is_external()) ? ORB_PRIO_HIGH : ORB_PRIO_DEFAULT, ORB_DEFAULT_QUEUE_SIZE);
 
 
 		if (_baro_topic == nullptr) {

--- a/src/drivers/ms5611/ms5611_posix.cpp
+++ b/src/drivers/ms5611/ms5611_posix.cpp
@@ -326,7 +326,7 @@ MS5611::init()
 		ret = OK;
 
 		_baro_topic = orb_advertise_multi(ORB_ID(sensor_baro), &brp,
-						  &_orb_class_instance, (is_external()) ? ORB_PRIO_HIGH : ORB_PRIO_DEFAULT);
+						  &_orb_class_instance, (is_external()) ? ORB_PRIO_HIGH : ORB_PRIO_DEFAULT, ORB_DEFAULT_QUEUE_SIZE);
 
 		if (_baro_topic == nullptr) {
 			warnx("failed to create sensor_baro publication");

--- a/src/drivers/pwm_out_rc_in/pwm_out_rc_in.cpp
+++ b/src/drivers/pwm_out_rc_in/pwm_out_rc_in.cpp
@@ -353,7 +353,7 @@ void handle_message(mavlink_message_t *rc_message)
 		orb_publish(ORB_ID(input_rc), _rc_pub, &_rc);
 
 	} else {
-		_rc_pub = orb_advertise(ORB_ID(input_rc), &_rc);
+		_rc_pub = orb_advertise(ORB_ID(input_rc), &_rc, ORB_DEFAULT_QUEUE_SIZE);
 	}
 }
 
@@ -390,7 +390,7 @@ void task_main(int argc, char *argv[])
 	pwm_limit_init(&_pwm_limit);
 
 	// TODO XXX: this is needed otherwise we crash in the callback context.
-	_rc_pub = orb_advertise(ORB_ID(input_rc), &_rc);
+	_rc_pub = orb_advertise(ORB_ID(input_rc), &_rc, ORB_DEFAULT_QUEUE_SIZE);
 
 	// Main loop
 	while (!_task_should_exit) {
@@ -447,7 +447,7 @@ void task_main(int argc, char *argv[])
 				orb_publish(ORB_ID(actuator_outputs), _outputs_pub, &_outputs);
 
 			} else {
-				_outputs_pub = orb_advertise(ORB_ID(actuator_outputs), &_outputs);
+				_outputs_pub = orb_advertise(ORB_ID(actuator_outputs), &_outputs, ORB_DEFAULT_QUEUE_SIZE);
 			}
 		}
 

--- a/src/drivers/pwm_out_sim/pwm_out_sim.cpp
+++ b/src/drivers/pwm_out_sim/pwm_out_sim.cpp
@@ -382,7 +382,7 @@ PWMSim::task_main()
 	actuator_outputs_s outputs = {};
 
 	/* advertise the mixed control outputs, insist on the first group output */
-	_outputs_pub = orb_advertise(ORB_ID(actuator_outputs), &outputs);
+	_outputs_pub = orb_advertise(ORB_ID(actuator_outputs), &outputs, ORB_DEFAULT_QUEUE_SIZE);
 
 
 	/* loop until killed */
@@ -936,7 +936,7 @@ fake(int argc, char *argv[])
 
 	ac.control[3] = strtol(argv[4], 0, 0) / 100.0f;
 
-	orb_advert_t handle = orb_advertise(ORB_ID_VEHICLE_ATTITUDE_CONTROLS, &ac);
+	orb_advert_t handle = orb_advertise(ORB_ID_VEHICLE_ATTITUDE_CONTROLS, &ac, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (handle == nullptr) {
 		puts("advertise failed");

--- a/src/drivers/px4flow/px4flow.cpp
+++ b/src/drivers/px4flow/px4flow.cpp
@@ -246,7 +246,7 @@ PX4FLOW::init()
 	struct distance_sensor_s ds_report = {};
 
 	_distance_sensor_topic = orb_advertise_multi(ORB_ID(distance_sensor), &ds_report,
-				 &_orb_class_instance, ORB_PRIO_HIGH);
+				 &_orb_class_instance, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_distance_sensor_topic == nullptr) {
 		DEVICE_LOG("failed to create distance_sensor object. Did you start uOrb?");
@@ -546,7 +546,7 @@ PX4FLOW::collect()
 	rotate_3f(_sensor_rotation, report.gyro_x_rate_integral, report.gyro_y_rate_integral, report.gyro_z_rate_integral);
 
 	if (_px4flow_topic == nullptr) {
-		_px4flow_topic = orb_advertise(ORB_ID(optical_flow), &report);
+		_px4flow_topic = orb_advertise(ORB_ID(optical_flow), &report, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		/* publish it */
@@ -604,7 +604,7 @@ PX4FLOW::start()
 		orb_publish(ORB_ID(subsystem_info), pub, &info);
 
 	} else {
-		pub = orb_advertise(ORB_ID(subsystem_info), &info);
+		pub = orb_advertise(ORB_ID(subsystem_info), &info, ORB_DEFAULT_QUEUE_SIZE);
 	}
 }
 

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -727,7 +727,8 @@ PX4FMU::publish_pwm_outputs(uint16_t *values, size_t numvalues)
 
 	if (_outputs_pub == nullptr) {
 		int instance = -1;
-		_outputs_pub = orb_advertise_multi(ORB_ID(actuator_outputs), &outputs, &instance, ORB_PRIO_DEFAULT, ORB_DEFAULT_QUEUE_SIZE);
+		_outputs_pub = orb_advertise_multi(ORB_ID(actuator_outputs), &outputs, &instance, ORB_PRIO_DEFAULT,
+						   ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(actuator_outputs), _outputs_pub, &outputs);

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -727,7 +727,7 @@ PX4FMU::publish_pwm_outputs(uint16_t *values, size_t numvalues)
 
 	if (_outputs_pub == nullptr) {
 		int instance = -1;
-		_outputs_pub = orb_advertise_multi(ORB_ID(actuator_outputs), &outputs, &instance, ORB_PRIO_DEFAULT);
+		_outputs_pub = orb_advertise_multi(ORB_ID(actuator_outputs), &outputs, &instance, ORB_PRIO_DEFAULT, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(actuator_outputs), _outputs_pub, &outputs);
@@ -1086,7 +1086,7 @@ PX4FMU::cycle()
 			orb_publish(ORB_ID(safety), _to_safety, &safety);
 
 		} else {
-			_to_safety = orb_advertise(ORB_ID(safety), &safety);
+			_to_safety = orb_advertise(ORB_ID(safety), &safety, ORB_DEFAULT_QUEUE_SIZE);
 		}
 	}
 
@@ -1383,7 +1383,7 @@ PX4FMU::cycle()
 	if (rc_updated) {
 		/* lazily advertise on first publication */
 		if (_to_input_rc == nullptr) {
-			_to_input_rc = orb_advertise(ORB_ID(input_rc), &_rc_in);
+			_to_input_rc = orb_advertise(ORB_ID(input_rc), &_rc_in, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(input_rc), _to_input_rc, &_rc_in);
@@ -2849,7 +2849,7 @@ fake(int argc, char *argv[])
 
 	ac.control[3] = strtol(argv[4], 0, 0) / 100.0f;
 
-	orb_advert_t handle = orb_advertise(ORB_ID_VEHICLE_ATTITUDE_CONTROLS, &ac);
+	orb_advert_t handle = orb_advertise(ORB_ID_VEHICLE_ATTITUDE_CONTROLS, &ac, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (handle == nullptr) {
 		errx(1, "advertise failed");
@@ -2860,7 +2860,7 @@ fake(int argc, char *argv[])
 	aa.armed = true;
 	aa.lockdown = false;
 
-	handle = orb_advertise(ORB_ID(actuator_armed), &aa);
+	handle = orb_advertise(ORB_ID(actuator_armed), &aa, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (handle == nullptr) {
 		errx(1, "advertise failed 2");

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -807,7 +807,7 @@ PX4IO::init()
 		cmd.confirmation =  1;
 
 		/* send command once */
-		orb_advert_t pub = orb_advertise(ORB_ID(vehicle_command), &cmd);
+		orb_advert_t pub = orb_advertise(ORB_ID(vehicle_command), &cmd, ORB_DEFAULT_QUEUE_SIZE);
 
 		/* spin here until IO's state has propagated into the system */
 		do {
@@ -1629,7 +1629,7 @@ PX4IO::io_handle_status(uint16_t status)
 		orb_publish(ORB_ID(safety), _to_safety, &safety);
 
 	} else {
-		_to_safety = orb_advertise(ORB_ID(safety), &safety);
+		_to_safety = orb_advertise(ORB_ID(safety), &safety, ORB_DEFAULT_QUEUE_SIZE);
 	}
 
 	return ret;
@@ -1696,7 +1696,7 @@ PX4IO::io_handle_battery(uint16_t vbatt, uint16_t ibatt)
 			orb_publish(ORB_ID(battery_status), _to_battery, &battery_status);
 
 		} else {
-			_to_battery = orb_advertise(ORB_ID(battery_status), &battery_status);
+			_to_battery = orb_advertise(ORB_ID(battery_status), &battery_status, ORB_DEFAULT_QUEUE_SIZE);
 		}
 	}
 }
@@ -1725,7 +1725,7 @@ PX4IO::io_handle_vservo(uint16_t vservo, uint16_t vrssi)
 		orb_publish(ORB_ID(servorail_status), _to_servorail, &_servorail_status);
 
 	} else {
-		_to_servorail = orb_advertise(ORB_ID(servorail_status), &_servorail_status);
+		_to_servorail = orb_advertise(ORB_ID(servorail_status), &_servorail_status, ORB_DEFAULT_QUEUE_SIZE);
 	}
 }
 
@@ -1898,7 +1898,7 @@ PX4IO::io_publish_raw_rc()
 
 	/* lazily advertise on first publication */
 	if (_to_input_rc == nullptr) {
-		_to_input_rc = orb_advertise(ORB_ID(input_rc), &rc_val);
+		_to_input_rc = orb_advertise(ORB_ID(input_rc), &rc_val, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(input_rc), _to_input_rc, &rc_val);
@@ -1935,7 +1935,7 @@ PX4IO::io_publish_pwm_outputs()
 	if (_to_outputs == nullptr) {
 		int instance;
 		_to_outputs = orb_advertise_multi(ORB_ID(actuator_outputs),
-						  &outputs, &instance, ORB_PRIO_MAX);
+						  &outputs, &instance, ORB_PRIO_MAX, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(actuator_outputs), _to_outputs, &outputs);
@@ -1952,7 +1952,7 @@ PX4IO::io_publish_pwm_outputs()
 
 	/* publish mixer status */
 	if (_to_mixer_status == nullptr) {
-		_to_mixer_status = orb_advertise(ORB_ID(multirotor_motor_limits), &motor_limits);
+		_to_mixer_status = orb_advertise(ORB_ID(multirotor_motor_limits), &motor_limits, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(multirotor_motor_limits), _to_mixer_status, &motor_limits);

--- a/src/drivers/qshell/posix/qshell.cpp
+++ b/src/drivers/qshell/posix/qshell.cpp
@@ -70,7 +70,7 @@ int QShell::main(std::vector<std::string> argList)
 
 	PX4_DEBUG("Requesting %s", cmd.c_str());
 
-	orb_advert_t pub_id_qshell_req = orb_advertise(ORB_ID(qshell_req), & m_qshell_req);
+	orb_advert_t pub_id_qshell_req = orb_advertise(ORB_ID(qshell_req), & m_qshell_req, ORB_DEFAULT_QUEUE_SIZE);
 
 	m_qshell_req.strlen = cmd.size();
 

--- a/src/drivers/sf0x/sf0x.cpp
+++ b/src/drivers/sf0x/sf0x.cpp
@@ -300,7 +300,7 @@ SF0X::init()
 		struct distance_sensor_s ds_report = {};
 
 		_distance_sensor_topic = orb_advertise_multi(ORB_ID(distance_sensor), &ds_report,
-					 &_orb_class_instance, ORB_PRIO_HIGH);
+					 &_orb_class_instance, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 
 		if (_distance_sensor_topic == nullptr) {
 			DEVICE_LOG("failed to create distance_sensor object. Did you start uOrb?");
@@ -644,7 +644,7 @@ SF0X::start()
 	// 	orb_publish(ORB_ID(subsystem_info), pub, &info);
 
 	// } else {
-	// 	pub = orb_advertise(ORB_ID(subsystem_info), &info);
+	// 	pub = orb_advertise(ORB_ID(subsystem_info), &info, ORB_DEFAULT_QUEUE_SIZE);
 	// }
 }
 

--- a/src/drivers/sf10a/sf10a.cpp
+++ b/src/drivers/sf10a/sf10a.cpp
@@ -260,7 +260,7 @@ SF10A::init()
 	struct distance_sensor_s ds_report = {};
 
 	_distance_sensor_topic = orb_advertise_multi(ORB_ID(distance_sensor), &ds_report,
-				 &_orb_class_instance, ORB_PRIO_HIGH);
+				 &_orb_class_instance, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_distance_sensor_topic == nullptr) {
 		DEVICE_LOG("failed to create distance_sensor object. Did you start uOrb?");
@@ -585,7 +585,7 @@ SF10A::start()
 
 
 	} else {
-		pub = orb_advertise(ORB_ID(subsystem_info), &info);
+		pub = orb_advertise(ORB_ID(subsystem_info), &info, ORB_DEFAULT_QUEUE_SIZE);
 
 	}
 }

--- a/src/drivers/srf02/srf02.cpp
+++ b/src/drivers/srf02/srf02.cpp
@@ -273,7 +273,7 @@ SRF02::init()
 	struct distance_sensor_s ds_report = {};
 
 	_distance_sensor_topic = orb_advertise_multi(ORB_ID(distance_sensor), &ds_report,
-				 &_orb_class_instance, ORB_PRIO_LOW);
+				 &_orb_class_instance, ORB_PRIO_LOW, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_distance_sensor_topic == nullptr) {
 		DEVICE_LOG("failed to create distance_sensor object. Did you start uOrb?");
@@ -631,7 +631,7 @@ SRF02::start()
 
 
 	} else {
-		pub = orb_advertise(ORB_ID(subsystem_info), &info);
+		pub = orb_advertise(ORB_ID(subsystem_info), &info, ORB_DEFAULT_QUEUE_SIZE);
 
 	}
 }

--- a/src/drivers/srf02_i2c/srf02_i2c.cpp
+++ b/src/drivers/srf02_i2c/srf02_i2c.cpp
@@ -275,7 +275,7 @@ SRF02_I2C::init()
 	struct distance_sensor_s ds_report = {};
 
 	_distance_sensor_topic = orb_advertise_multi(ORB_ID(distance_sensor), &ds_report,
-				 &_orb_class_instance, ORB_PRIO_LOW);
+				 &_orb_class_instance, ORB_PRIO_LOW, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_distance_sensor_topic == nullptr) {
 		DEVICE_LOG("failed to create distance_sensor object. Did you start uOrb?");
@@ -632,7 +632,7 @@ SRF02_I2C::start()
 		orb_publish(ORB_ID(subsystem_info), pub, &info);
 
 	} else {
-		pub = orb_advertise(ORB_ID(subsystem_info), &info);
+		pub = orb_advertise(ORB_ID(subsystem_info), &info, ORB_DEFAULT_QUEUE_SIZE);
 
 	}
 }

--- a/src/drivers/stm32/adc/adc.cpp
+++ b/src/drivers/stm32/adc/adc.cpp
@@ -337,7 +337,7 @@ ADC::update_adc_report(hrt_abstime now)
 	}
 
 	int instance;
-	orb_publish_auto(ORB_ID(adc_report), &_to_adc_report, &adc, &instance, ORB_PRIO_HIGH);
+	orb_publish_auto(ORB_ID(adc_report), &_to_adc_report, &adc, &instance, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 }
 
 void
@@ -379,7 +379,7 @@ ADC::update_system_power(hrt_abstime now)
 		orb_publish(ORB_ID(system_power), _to_system_power, &system_power);
 
 	} else {
-		_to_system_power = orb_advertise(ORB_ID(system_power), &system_power);
+		_to_system_power = orb_advertise(ORB_ID(system_power), &system_power, ORB_DEFAULT_QUEUE_SIZE);
 	}
 
 #endif // BOARD_ADC_USB_CONNECTED

--- a/src/drivers/trone/trone.cpp
+++ b/src/drivers/trone/trone.cpp
@@ -302,7 +302,7 @@ TRONE::init()
 		_reports->get(&ds_report);
 
 		_distance_sensor_topic = orb_advertise_multi(ORB_ID(distance_sensor), &ds_report,
-					 &_orb_class_instance, ORB_PRIO_LOW);
+					 &_orb_class_instance, ORB_PRIO_LOW, ORB_DEFAULT_QUEUE_SIZE);
 
 		if (_distance_sensor_topic == nullptr) {
 			DEVICE_LOG("failed to create distance_sensor object. Did you start uOrb?");
@@ -640,7 +640,7 @@ TRONE::start()
 		orb_publish(ORB_ID(subsystem_info), pub, &info);
 
 	} else {
-		pub = orb_advertise(ORB_ID(subsystem_info), &info);
+		pub = orb_advertise(ORB_ID(subsystem_info), &info, ORB_DEFAULT_QUEUE_SIZE);
 	}
 }
 

--- a/src/examples/fixedwing_control/main.c
+++ b/src/examples/fixedwing_control/main.c
@@ -270,8 +270,8 @@ int fixedwing_control_thread_main(int argc, char *argv[])
 	 * Advertise that this controller will publish actuator
 	 * control values and the rate setpoint
 	 */
-	orb_advert_t actuator_pub = orb_advertise(ORB_ID_VEHICLE_ATTITUDE_CONTROLS, &actuators);
-	orb_advert_t rates_pub = orb_advertise(ORB_ID(vehicle_rates_setpoint), &rates_sp);
+	orb_advert_t actuator_pub = orb_advertise(ORB_ID_VEHICLE_ATTITUDE_CONTROLS, &actuators, ORB_DEFAULT_QUEUE_SIZE);
+	orb_advert_t rates_pub = orb_advertise(ORB_ID(vehicle_rates_setpoint), &rates_sp, ORB_DEFAULT_QUEUE_SIZE);
 
 	/* subscribe to topics. */
 	int att_sub = orb_subscribe(ORB_ID(vehicle_attitude));

--- a/src/examples/hwtest/hwtest.c
+++ b/src/examples/hwtest/hwtest.c
@@ -61,7 +61,7 @@ int ex_hwtest_main(int argc, char *argv[])
 
 	struct actuator_controls_s actuators;
 	memset(&actuators, 0, sizeof(actuators));
-	orb_advert_t actuator_pub_ptr = orb_advertise(ORB_ID(actuator_controls_0), &actuators);
+	orb_advert_t actuator_pub_ptr = orb_advertise(ORB_ID(actuator_controls_0), &actuators, ORB_DEFAULT_QUEUE_SIZE);
 
 	struct actuator_armed_s arm;
 	memset(&arm, 0 , sizeof(arm));
@@ -69,7 +69,7 @@ int ex_hwtest_main(int argc, char *argv[])
 	arm.timestamp = hrt_absolute_time();
 	arm.ready_to_arm = true;
 	arm.armed = true;
-	orb_advert_t arm_pub_ptr = orb_advertise(ORB_ID(actuator_armed), &arm);
+	orb_advert_t arm_pub_ptr = orb_advertise(ORB_ID(actuator_armed), &arm, ORB_DEFAULT_QUEUE_SIZE);
 	orb_publish(ORB_ID(actuator_armed), arm_pub_ptr, &arm);
 
 	/* read back values to validate */

--- a/src/examples/px4_mavlink_debug/px4_mavlink_debug.c
+++ b/src/examples/px4_mavlink_debug/px4_mavlink_debug.c
@@ -56,7 +56,7 @@ int px4_mavlink_debug_main(int argc, char *argv[])
 
 	/* advertise debug value */
 	struct debug_key_value_s dbg = { .key = "velx", .value = 0.0f };
-	orb_advert_t pub_dbg = orb_advertise(ORB_ID(debug_key_value), &dbg);
+	orb_advert_t pub_dbg = orb_advertise(ORB_ID(debug_key_value), &dbg, ORB_DEFAULT_QUEUE_SIZE);
 
 	int value_counter = 0;
 

--- a/src/examples/px4_simple_app/px4_simple_app.c
+++ b/src/examples/px4_simple_app/px4_simple_app.c
@@ -63,7 +63,7 @@ int px4_simple_app_main(int argc, char *argv[])
 	/* advertise attitude topic */
 	struct vehicle_attitude_s att;
 	memset(&att, 0, sizeof(att));
-	orb_advert_t att_pub = orb_advertise(ORB_ID(vehicle_attitude), &att);
+	orb_advert_t att_pub = orb_advertise(ORB_ID(vehicle_attitude), &att, ORB_DEFAULT_QUEUE_SIZE);
 
 	/* one could wait for multiple topics with this technique, just using one here */
 	px4_pollfd_struct_t fds[] = {

--- a/src/examples/rover_steering_control/main.cpp
+++ b/src/examples/rover_steering_control/main.cpp
@@ -258,7 +258,7 @@ int rover_steering_control_thread_main(int argc, char *argv[])
 	 * Advertise that this controller will publish actuator
 	 * control values and the rate setpoint
 	 */
-	orb_advert_t actuator_pub = orb_advertise(ORB_ID_VEHICLE_ATTITUDE_CONTROLS, &actuators);
+	orb_advert_t actuator_pub = orb_advertise(ORB_ID_VEHICLE_ATTITUDE_CONTROLS, &actuators, ORB_DEFAULT_QUEUE_SIZE);
 
 	/* subscribe to topics. */
 	int att_sub = orb_subscribe(ORB_ID(vehicle_attitude));

--- a/src/modules/attitude_estimator_ekf/attitude_estimator_ekf_main.cpp
+++ b/src/modules/attitude_estimator_ekf/attitude_estimator_ekf_main.cpp
@@ -304,7 +304,7 @@ int attitude_estimator_ekf_thread_main(int argc, char *argv[])
 	int mocap_sub = orb_subscribe(ORB_ID(att_pos_mocap));
 
 	/* advertise attitude */
-	orb_advert_t pub_att = orb_advertise(ORB_ID(vehicle_attitude), &att);
+	orb_advert_t pub_att = orb_advertise(ORB_ID(vehicle_attitude), &att, ORB_DEFAULT_QUEUE_SIZE);
 
 	int loopcounter = 0;
 

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -639,7 +639,8 @@ void AttitudeEstimatorQ::task_main()
 			/* the instance count is not used here */
 			int ctrl_inst;
 			/* publish to control state topic */
-			orb_publish_auto(ORB_ID(control_state), &_ctrl_state_pub, &ctrl_state, &ctrl_inst, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
+			orb_publish_auto(ORB_ID(control_state), &_ctrl_state_pub, &ctrl_state, &ctrl_inst, ORB_PRIO_HIGH,
+					 ORB_DEFAULT_QUEUE_SIZE);
 		}
 
 		{

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -602,7 +602,7 @@ void AttitudeEstimatorQ::task_main()
 
 		/* the instance count is not used here */
 		int att_inst;
-		orb_publish_auto(ORB_ID(vehicle_attitude), &_att_pub, &att, &att_inst, ORB_PRIO_HIGH);
+		orb_publish_auto(ORB_ID(vehicle_attitude), &_att_pub, &att, &att_inst, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 
 		{
 			struct control_state_s ctrl_state = {};
@@ -639,7 +639,7 @@ void AttitudeEstimatorQ::task_main()
 			/* the instance count is not used here */
 			int ctrl_inst;
 			/* publish to control state topic */
-			orb_publish_auto(ORB_ID(control_state), &_ctrl_state_pub, &ctrl_state, &ctrl_inst, ORB_PRIO_HIGH);
+			orb_publish_auto(ORB_ID(control_state), &_ctrl_state_pub, &ctrl_state, &ctrl_inst, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 		}
 
 		{
@@ -655,7 +655,7 @@ void AttitudeEstimatorQ::task_main()
 			/* publish to control state topic */
 			// TODO handle attitude states in position estimators instead so we can publish all data at once
 			// or we need to enable more thatn just one estimator_status topic
-			// orb_publish_auto(ORB_ID(estimator_status), &_est_state_pub, &est, &est_inst, ORB_PRIO_HIGH);
+			// orb_publish_auto(ORB_ID(estimator_status), &_est_state_pub, &est, &est_inst, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 		}
 	}
 }

--- a/src/modules/bottle_drop/bottle_drop.cpp
+++ b/src/modules/bottle_drop/bottle_drop.cpp
@@ -322,7 +322,7 @@ BottleDrop::actuators_publish()
 		return orb_publish(ORB_ID(actuator_controls_2), _actuator_pub, &_actuators);
 
 	} else {
-		_actuator_pub = orb_advertise(ORB_ID(actuator_controls_2), &_actuators);
+		_actuator_pub = orb_advertise(ORB_ID(actuator_controls_2), &_actuators, ORB_DEFAULT_QUEUE_SIZE);
 
 		if (_actuator_pub != nullptr) {
 			return OK;
@@ -628,7 +628,7 @@ BottleDrop::task_main()
 						orb_publish(ORB_ID(onboard_mission), _onboard_mission_pub, &_onboard_mission);
 
 					} else {
-						_onboard_mission_pub = orb_advertise(ORB_ID(onboard_mission), &_onboard_mission);
+						_onboard_mission_pub = orb_advertise(ORB_ID(onboard_mission), &_onboard_mission, ORB_DEFAULT_QUEUE_SIZE);
 					}
 
 					float approach_direction = get_bearing_to_next_waypoint(flight_vector_s.lat, flight_vector_s.lon, flight_vector_e.lat,

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -440,7 +440,7 @@ int commander_main(int argc, char *argv[])
 				cmd.param6 = NAN;
 				cmd.param7 = NAN;
 
-				orb_advert_t h = orb_advertise(ORB_ID(vehicle_command), &cmd);
+				orb_advert_t h = orb_advertise(ORB_ID(vehicle_command), &cmd, ORB_DEFAULT_QUEUE_SIZE);
 				(void)orb_unadvertise(h);
 
 			} else {
@@ -469,7 +469,7 @@ int commander_main(int argc, char *argv[])
 		cmd.param6 = NAN;
 		cmd.param7 = NAN;
 
-		orb_advert_t h = orb_advertise(ORB_ID(vehicle_command), &cmd);
+		orb_advert_t h = orb_advertise(ORB_ID(vehicle_command), &cmd, ORB_DEFAULT_QUEUE_SIZE);
 		(void)orb_unadvertise(h);
 
 		return 0;
@@ -532,7 +532,7 @@ int commander_main(int argc, char *argv[])
 		cmd.param1 = strcmp(argv[2], "off") ? 2.0f : 0.0f; /* lockdown */
 
 		// XXX inspect use of publication handle
-		(void)orb_advertise(ORB_ID(vehicle_command), &cmd);
+		(void)orb_advertise(ORB_ID(vehicle_command), &cmd, ORB_DEFAULT_QUEUE_SIZE);
 
 		return 0;
 	}
@@ -990,7 +990,7 @@ bool handle_command(struct vehicle_status_s *status_local, const struct safety_s
 					orb_publish(ORB_ID(home_position), *home_pub, home);
 
 				} else {
-					*home_pub = orb_advertise(ORB_ID(home_position), home);
+					*home_pub = orb_advertise(ORB_ID(home_position), home, ORB_DEFAULT_QUEUE_SIZE);
 				}
 
 				/* mark home position as set */
@@ -1123,7 +1123,7 @@ static void commander_set_home_position(orb_advert_t &homePub, home_position_s &
 		orb_publish(ORB_ID(home_position), homePub, &home);
 
 	} else {
-		homePub = orb_advertise(ORB_ID(home_position), &home);
+		homePub = orb_advertise(ORB_ID(home_position), &home, ORB_DEFAULT_QUEUE_SIZE);
 	}
 
 	//Play tune first time we initialize HOME
@@ -1294,10 +1294,10 @@ int commander_thread_main(int argc, char *argv[])
 	get_circuit_breaker_params();
 
 	/* publish initial state */
-	status_pub = orb_advertise(ORB_ID(vehicle_status), &status);
+	status_pub = orb_advertise(ORB_ID(vehicle_status), &status, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (status_pub == nullptr) {
-		warnx("ERROR: orb_advertise for topic vehicle_status failed (uorb app running?).\n");
+		warnx("ERROR: orb_advertise for topic vehicle_status failed (uorb app running?, ORB_DEFAULT_QUEUE_SIZE).\n");
 		warnx("exiting.");
 		px4_task_exit(ERROR);
 	}
@@ -1305,11 +1305,11 @@ int commander_thread_main(int argc, char *argv[])
 	/* Initialize armed with all false */
 	memset(&armed, 0, sizeof(armed));
 	/* armed topic */
-	orb_advert_t armed_pub = orb_advertise(ORB_ID(actuator_armed), &armed);
+	orb_advert_t armed_pub = orb_advertise(ORB_ID(actuator_armed), &armed, ORB_DEFAULT_QUEUE_SIZE);
 
 	/* vehicle control mode topic */
 	memset(&control_mode, 0, sizeof(control_mode));
-	orb_advert_t control_mode_pub = orb_advertise(ORB_ID(vehicle_control_mode), &control_mode);
+	orb_advert_t control_mode_pub = orb_advertise(ORB_ID(vehicle_control_mode), &control_mode, ORB_DEFAULT_QUEUE_SIZE);
 
 	/* home position */
 	orb_advert_t home_pub = nullptr;
@@ -1345,7 +1345,7 @@ int commander_thread_main(int argc, char *argv[])
 			dm_write(DM_KEY_MISSION_STATE, 0, DM_PERSIST_POWER_ON_RESET, &mission, sizeof(mission_s));
 		}
 
-		mission_pub = orb_advertise(ORB_ID(offboard_mission), &mission);
+		mission_pub = orb_advertise(ORB_ID(offboard_mission), &mission, ORB_DEFAULT_QUEUE_SIZE);
 		orb_publish(ORB_ID(offboard_mission), mission_pub, &mission);
 	}
 
@@ -2815,7 +2815,7 @@ int commander_thread_main(int argc, char *argv[])
 			orb_publish(ORB_ID(commander_state), commander_state_pub, &internal_state);
 
 		} else {
-			commander_state_pub = orb_advertise(ORB_ID(commander_state), &internal_state);
+			commander_state_pub = orb_advertise(ORB_ID(commander_state), &internal_state, ORB_DEFAULT_QUEUE_SIZE);
 		}
 
 		usleep(COMMANDER_MONITORING_INTERVAL);
@@ -3570,7 +3570,7 @@ void answer_command(struct vehicle_command_s &cmd, unsigned result,
 		orb_publish(ORB_ID(vehicle_command_ack), command_ack_pub, &command_ack);
 
 	} else {
-		command_ack_pub = orb_advertise(ORB_ID(vehicle_command_ack), &command_ack);
+		command_ack_pub = orb_advertise(ORB_ID(vehicle_command_ack), &command_ack, ORB_DEFAULT_QUEUE_SIZE);
 	}
 }
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -641,7 +641,7 @@ void Ekf2::task_main()
 
 			// publish control state data
 			if (_control_state_pub == nullptr) {
-				_control_state_pub = orb_advertise(ORB_ID(control_state), &ctrl_state);
+				_control_state_pub = orb_advertise(ORB_ID(control_state), &ctrl_state, ORB_DEFAULT_QUEUE_SIZE);
 
 			} else {
 				orb_publish(ORB_ID(control_state), _control_state_pub, &ctrl_state);
@@ -667,7 +667,7 @@ void Ekf2::task_main()
 
 			// publish vehicle attitude data
 			if (_att_pub == nullptr) {
-				_att_pub = orb_advertise(ORB_ID(vehicle_attitude), &att);
+				_att_pub = orb_advertise(ORB_ID(vehicle_attitude), &att, ORB_DEFAULT_QUEUE_SIZE);
 
 			} else {
 				orb_publish(ORB_ID(vehicle_attitude), _att_pub, &att);
@@ -725,7 +725,7 @@ void Ekf2::task_main()
 
 			// publish vehicle local position data
 			if (_lpos_pub == nullptr) {
-				_lpos_pub = orb_advertise(ORB_ID(vehicle_local_position), &lpos);
+				_lpos_pub = orb_advertise(ORB_ID(vehicle_local_position), &lpos, ORB_DEFAULT_QUEUE_SIZE);
 
 			} else {
 				orb_publish(ORB_ID(vehicle_local_position), _lpos_pub, &lpos);
@@ -763,7 +763,7 @@ void Ekf2::task_main()
 				global_pos.pressure_alt = sensors.baro_alt_meter[0]; // Pressure altitude AMSL (m)
 
 				if (_vehicle_global_position_pub == nullptr) {
-					_vehicle_global_position_pub = orb_advertise(ORB_ID(vehicle_global_position), &global_pos);
+					_vehicle_global_position_pub = orb_advertise(ORB_ID(vehicle_global_position), &global_pos, ORB_DEFAULT_QUEUE_SIZE);
 
 				} else {
 					orb_publish(ORB_ID(vehicle_global_position), _vehicle_global_position_pub, &global_pos);
@@ -777,7 +777,7 @@ void Ekf2::task_main()
 			att.timestamp = 0;
 
 			if (_att_pub == nullptr) {
-				_att_pub = orb_advertise(ORB_ID(vehicle_attitude), &att);
+				_att_pub = orb_advertise(ORB_ID(vehicle_attitude), &att, ORB_DEFAULT_QUEUE_SIZE);
 
 			} else {
 				orb_publish(ORB_ID(vehicle_attitude), _att_pub, &att);
@@ -794,7 +794,7 @@ void Ekf2::task_main()
 		_ekf.get_filter_fault_status(&status.filter_fault_flags);
 
 		if (_estimator_status_pub == nullptr) {
-			_estimator_status_pub = orb_advertise(ORB_ID(estimator_status), &status);
+			_estimator_status_pub = orb_advertise(ORB_ID(estimator_status), &status, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(estimator_status), _estimator_status_pub, &status);
@@ -809,7 +809,7 @@ void Ekf2::task_main()
 		wind_estimate.covariance_east = status.covariances[23];
 
 		if (_wind_pub == nullptr) {
-			_wind_pub = orb_advertise(ORB_ID(wind_estimate), &wind_estimate);
+			_wind_pub = orb_advertise(ORB_ID(wind_estimate), &wind_estimate, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(wind_estimate), _wind_pub, &wind_estimate);
@@ -833,7 +833,7 @@ void Ekf2::task_main()
 		_ekf.get_hagl_innov_var(&innovations.hagl_innov_var);
 
 		if (_estimator_innovations_pub == nullptr) {
-			_estimator_innovations_pub = orb_advertise(ORB_ID(ekf2_innovations), &innovations);
+			_estimator_innovations_pub = orb_advertise(ORB_ID(ekf2_innovations), &innovations, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(ekf2_innovations), _estimator_innovations_pub, &innovations);
@@ -936,7 +936,7 @@ void Ekf2::task_main()
 			}
 
 			if (_replay_pub == nullptr) {
-				_replay_pub = orb_advertise(ORB_ID(ekf2_replay), &replay);
+				_replay_pub = orb_advertise(ORB_ID(ekf2_replay), &replay, ORB_DEFAULT_QUEUE_SIZE);
 
 			} else {
 				orb_publish(ORB_ID(ekf2_replay), _replay_pub, &replay);

--- a/src/modules/ekf2_replay/ekf2_replay_main.cpp
+++ b/src/modules/ekf2_replay/ekf2_replay_main.cpp
@@ -250,7 +250,7 @@ Ekf2Replay::~Ekf2Replay()
 void Ekf2Replay::publishEstimatorInput()
 {
 	if (_gps_pub == nullptr && _read_part2) {
-		_gps_pub = orb_advertise(ORB_ID(vehicle_gps_position), &_gps);
+		_gps_pub = orb_advertise(ORB_ID(vehicle_gps_position), &_gps, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else if (_gps_pub != nullptr && _read_part2) {
 		orb_publish(ORB_ID(vehicle_gps_position), _gps_pub, &_gps);
@@ -259,7 +259,7 @@ void Ekf2Replay::publishEstimatorInput()
 	_read_part2 = false;
 
 	if (_flow_pub == nullptr && _read_part3) {
-		_flow_pub = orb_advertise(ORB_ID(optical_flow), &_flow);
+		_flow_pub = orb_advertise(ORB_ID(optical_flow), &_flow, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else if (_flow_pub != nullptr && _read_part3) {
 		orb_publish(ORB_ID(optical_flow), _flow_pub, &_flow);
@@ -268,7 +268,7 @@ void Ekf2Replay::publishEstimatorInput()
 	_read_part3 = false;
 
 	if (_range_pub == nullptr && _read_part4) {
-		_range_pub = orb_advertise(ORB_ID(distance_sensor), &_range);
+		_range_pub = orb_advertise(ORB_ID(distance_sensor), &_range, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else if (_range_pub != nullptr && _read_part4) {
 		orb_publish(ORB_ID(distance_sensor), _range_pub, &_range);
@@ -277,7 +277,7 @@ void Ekf2Replay::publishEstimatorInput()
 	_read_part4 = false;
 
 	if (_ev_pub == nullptr && _read_part5) {
-		_ev_pub = orb_advertise(ORB_ID(vision_position_estimate), &_ev);
+		_ev_pub = orb_advertise(ORB_ID(vision_position_estimate), &_ev, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else if (_ev_pub != nullptr && _read_part5) {
 		orb_publish(ORB_ID(vision_position_estimate), _ev_pub, &_ev);
@@ -286,14 +286,14 @@ void Ekf2Replay::publishEstimatorInput()
 	_read_part5 = false;
 
 	if (_sensors_pub == nullptr) {
-		_sensors_pub = orb_advertise(ORB_ID(sensor_combined), &_sensors);
+		_sensors_pub = orb_advertise(ORB_ID(sensor_combined), &_sensors, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else if (_sensors_pub != nullptr) {
 		orb_publish(ORB_ID(sensor_combined), _sensors_pub, &_sensors);
 	}
 
 	if (_airspeed_pub == nullptr && _read_part6) {
-		_airspeed_pub = orb_advertise(ORB_ID(airspeed), &_airspeed);
+		_airspeed_pub = orb_advertise(ORB_ID(airspeed), &_airspeed, ORB_DEFAULT_QUEUE_SIZE);
 	} else if (_airspeed_pub != nullptr) {
 		orb_publish(ORB_ID(airspeed), _airspeed_pub, &_airspeed);
 	}
@@ -458,7 +458,7 @@ void Ekf2Replay::setEstimatorInput(uint8_t *data, uint8_t type)
 		_land_detected.landed =  vehicle_landed.landed;
 
 		if (_landed_pub == nullptr) {
-			_landed_pub = orb_advertise(ORB_ID(vehicle_land_detected), &_land_detected);
+			_landed_pub = orb_advertise(ORB_ID(vehicle_land_detected), &_land_detected, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else if (_landed_pub != nullptr) {
 			orb_publish(ORB_ID(vehicle_land_detected), _landed_pub, &_land_detected);

--- a/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
+++ b/src/modules/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
@@ -514,7 +514,7 @@ int AttitudePositionEstimatorEKF::check_filter_state()
 			orb_publish(ORB_ID(estimator_status), _estimator_status_pub, &rep);
 
 		} else {
-			_estimator_status_pub = orb_advertise(ORB_ID(estimator_status), &rep);
+			_estimator_status_pub = orb_advertise(ORB_ID(estimator_status), &rep, ORB_DEFAULT_QUEUE_SIZE);
 		}
 	}
 
@@ -872,7 +872,7 @@ void AttitudePositionEstimatorEKF::publishAttitude()
 
 	} else {
 		/* advertise and publish */
-		_att_pub = orb_advertise(ORB_ID(vehicle_attitude), &_att);
+		_att_pub = orb_advertise(ORB_ID(vehicle_attitude), &_att, ORB_DEFAULT_QUEUE_SIZE);
 	}
 }
 
@@ -953,7 +953,7 @@ void AttitudePositionEstimatorEKF::publishControlState()
 
 	} else {
 		/* advertise and publish */
-		_ctrl_state_pub = orb_advertise(ORB_ID(control_state), &_ctrl_state);
+		_ctrl_state_pub = orb_advertise(ORB_ID(control_state), &_ctrl_state, ORB_DEFAULT_QUEUE_SIZE);
 	}
 }
 
@@ -997,7 +997,7 @@ void AttitudePositionEstimatorEKF::publishLocalPosition()
 
 	} else {
 		/* advertise and publish */
-		_local_pos_pub = orb_advertise(ORB_ID(vehicle_local_position), &_local_pos);
+		_local_pos_pub = orb_advertise(ORB_ID(vehicle_local_position), &_local_pos, ORB_DEFAULT_QUEUE_SIZE);
 	}
 }
 
@@ -1083,7 +1083,7 @@ void AttitudePositionEstimatorEKF::publishGlobalPosition()
 
 	} else {
 		/* advertise and publish */
-		_global_pos_pub = orb_advertise(ORB_ID(vehicle_global_position), &_global_pos);
+		_global_pos_pub = orb_advertise(ORB_ID(vehicle_global_position), &_global_pos, ORB_DEFAULT_QUEUE_SIZE);
 	}
 }
 
@@ -1105,7 +1105,7 @@ void AttitudePositionEstimatorEKF::publishWindEstimate()
 
 	} else {
 		/* advertise and publish */
-		_wind_pub = orb_advertise(ORB_ID(wind_estimate), &_wind);
+		_wind_pub = orb_advertise(ORB_ID(wind_estimate), &_wind, ORB_DEFAULT_QUEUE_SIZE);
 	}
 
 }

--- a/src/modules/fw_att_control/fw_att_control_main.cpp
+++ b/src/modules/fw_att_control/fw_att_control_main.cpp
@@ -1084,7 +1084,7 @@ FixedwingAttitudeControl::task_main()
 
 					} else if (_attitude_setpoint_id) {
 						/* advertise and publish */
-						_attitude_sp_pub = orb_advertise(_attitude_setpoint_id, &att_sp);
+						_attitude_sp_pub = orb_advertise(_attitude_setpoint_id, &att_sp, ORB_DEFAULT_QUEUE_SIZE);
 					}
 				}
 
@@ -1238,7 +1238,7 @@ FixedwingAttitudeControl::task_main()
 
 				} else if (_rates_sp_id) {
 					/* advertise the attitude rates setpoint */
-					_rate_sp_pub = orb_advertise(_rates_sp_id, &_rates_sp);
+					_rate_sp_pub = orb_advertise(_rates_sp_id, &_rates_sp, ORB_DEFAULT_QUEUE_SIZE);
 				}
 
 			} else {
@@ -1269,7 +1269,7 @@ FixedwingAttitudeControl::task_main()
 					orb_publish(_actuators_id, _actuators_0_pub, &_actuators);
 
 				} else if (_actuators_id) {
-					_actuators_0_pub = orb_advertise(_actuators_id, &_actuators);
+					_actuators_0_pub = orb_advertise(_actuators_id, &_actuators, ORB_DEFAULT_QUEUE_SIZE);
 				}
 
 				if (_actuators_2_pub != nullptr) {
@@ -1278,7 +1278,7 @@ FixedwingAttitudeControl::task_main()
 
 				} else {
 					/* advertise and publish */
-					_actuators_2_pub = orb_advertise(ORB_ID(actuator_controls_2), &_actuators_airframe);
+					_actuators_2_pub = orb_advertise(ORB_ID(actuator_controls_2), &_actuators_airframe, ORB_DEFAULT_QUEUE_SIZE);
 				}
 			}
 		}

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
@@ -1024,7 +1024,7 @@ void FixedwingPositionControl::fw_pos_ctrl_status_publish()
 		orb_publish(ORB_ID(fw_pos_ctrl_status), _fw_pos_ctrl_status_pub, &_fw_pos_ctrl_status);
 
 	} else {
-		_fw_pos_ctrl_status_pub = orb_advertise(ORB_ID(fw_pos_ctrl_status), &_fw_pos_ctrl_status);
+		_fw_pos_ctrl_status_pub = orb_advertise(ORB_ID(fw_pos_ctrl_status), &_fw_pos_ctrl_status, ORB_DEFAULT_QUEUE_SIZE);
 	}
 }
 
@@ -2162,7 +2162,7 @@ FixedwingPositionControl::task_main()
 
 				} else if (_attitude_setpoint_id) {
 					/* advertise and publish */
-					_attitude_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp);
+					_attitude_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp, ORB_DEFAULT_QUEUE_SIZE);
 				}
 
 				/* XXX check if radius makes sense here */
@@ -2356,7 +2356,7 @@ void FixedwingPositionControl::tecs_update_pitch_throttle(float alt_sp, float v_
 		orb_publish(ORB_ID(tecs_status), _tecs_status_pub, &t);
 
 	} else {
-		_tecs_status_pub = orb_advertise(ORB_ID(tecs_status), &t);
+		_tecs_status_pub = orb_advertise(ORB_ID(tecs_status), &t, ORB_DEFAULT_QUEUE_SIZE);
 	}
 }
 

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -93,7 +93,7 @@ void LandDetector::cycle()
 		_landDetected.timestamp = hrt_absolute_time();
 		_landDetected.landed = false;
 		_landDetected.freefall = false;
-		_landDetectedPub = orb_advertise(ORB_ID(vehicle_land_detected), &_landDetected);
+		_landDetectedPub = orb_advertise(ORB_ID(vehicle_land_detected), &_landDetected, ORB_DEFAULT_QUEUE_SIZE);
 
 		// initialize land detection algorithm
 		initialize();

--- a/src/modules/load_mon/load_mon.cpp
+++ b/src/modules/load_mon/load_mon.cpp
@@ -165,7 +165,7 @@ void LoadMon::_compute()
 	_cpuload.load = 1.0f - (float)interval_idletime / (float)LOAD_MON_INTERVAL_US;
 
 	if (_cpuload_pub == nullptr) {
-		_cpuload_pub = orb_advertise(ORB_ID(cpuload), &_cpuload);
+		_cpuload_pub = orb_advertise(ORB_ID(cpuload), &_cpuload, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(cpuload), _cpuload_pub, &_cpuload);

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -161,7 +161,7 @@ MavlinkMissionManager::update_active_mission(int dataman_id, unsigned count, int
 
 		/* mission state saved successfully, publish offboard_mission topic */
 		if (_offboard_mission_pub == nullptr) {
-			_offboard_mission_pub = orb_advertise(ORB_ID(offboard_mission), &mission);
+			_offboard_mission_pub = orb_advertise(ORB_ID(offboard_mission), &mission, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(offboard_mission), _offboard_mission_pub, &mission);

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -92,7 +92,7 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 				req.param_index = 0;
 
 				if (_uavcan_parameter_request_pub == nullptr) {
-					_uavcan_parameter_request_pub = orb_advertise(ORB_ID(uavcan_parameter_request), &req);
+					_uavcan_parameter_request_pub = orb_advertise(ORB_ID(uavcan_parameter_request), &req, ORB_DEFAULT_QUEUE_SIZE);
 				} else {
 					orb_publish(ORB_ID(uavcan_parameter_request), _uavcan_parameter_request_pub, &req);
 				}
@@ -156,7 +156,7 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 				}
 
 				if (_uavcan_parameter_request_pub == nullptr) {
-					_uavcan_parameter_request_pub = orb_advertise(ORB_ID(uavcan_parameter_request), &req);
+					_uavcan_parameter_request_pub = orb_advertise(ORB_ID(uavcan_parameter_request), &req, ORB_DEFAULT_QUEUE_SIZE);
 				} else {
 					orb_publish(ORB_ID(uavcan_parameter_request), _uavcan_parameter_request_pub, &req);
 				}
@@ -223,7 +223,7 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 				req.param_id[MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN] = '\0';
 
 				if (_uavcan_parameter_request_pub == nullptr) {
-					_uavcan_parameter_request_pub = orb_advertise(ORB_ID(uavcan_parameter_request), &req);
+					_uavcan_parameter_request_pub = orb_advertise(ORB_ID(uavcan_parameter_request), &req, ORB_DEFAULT_QUEUE_SIZE);
 				} else {
 					orb_publish(ORB_ID(uavcan_parameter_request), _uavcan_parameter_request_pub, &req);
 				}
@@ -258,7 +258,7 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 				_rc_param_map.timestamp = hrt_absolute_time();
 
 				if (_rc_param_map_pub == nullptr) {
-					_rc_param_map_pub = orb_advertise(ORB_ID(rc_parameter_map), &_rc_param_map);
+					_rc_param_map_pub = orb_advertise(ORB_ID(rc_parameter_map), &_rc_param_map, ORB_DEFAULT_QUEUE_SIZE);
 
 				} else {
 					orb_publish(ORB_ID(rc_parameter_map), _rc_param_map_pub, &_rc_param_map);

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -395,7 +395,7 @@ MavlinkReceiver::handle_message_command_long(mavlink_message_t *msg)
 			vcmd.confirmation =  cmd_mavlink.confirmation;
 
 			if (_cmd_pub == nullptr) {
-				_cmd_pub = orb_advertise(ORB_ID(vehicle_command), &vcmd);
+				_cmd_pub = orb_advertise(ORB_ID(vehicle_command), &vcmd, ORB_DEFAULT_QUEUE_SIZE);
 
 			} else {
 				orb_publish(ORB_ID(vehicle_command), _cmd_pub, &vcmd);
@@ -471,7 +471,7 @@ MavlinkReceiver::handle_message_command_int(mavlink_message_t *msg)
 			vcmd.source_component = msg->compid;
 
 			if (_cmd_pub == nullptr) {
-				_cmd_pub = orb_advertise(ORB_ID(vehicle_command), &vcmd);
+				_cmd_pub = orb_advertise(ORB_ID(vehicle_command), &vcmd, ORB_DEFAULT_QUEUE_SIZE);
 
 			} else {
 				orb_publish(ORB_ID(vehicle_command), _cmd_pub, &vcmd);
@@ -511,7 +511,7 @@ MavlinkReceiver::handle_message_optical_flow_rad(mavlink_message_t *msg)
 	rotate_3f(flow_rot, f.gyro_x_rate_integral, f.gyro_y_rate_integral, f.gyro_z_rate_integral);
 
 	if (_flow_pub == nullptr) {
-		_flow_pub = orb_advertise(ORB_ID(optical_flow), &f);
+		_flow_pub = orb_advertise(ORB_ID(optical_flow), &f, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(optical_flow), _flow_pub, &f);
@@ -532,7 +532,7 @@ MavlinkReceiver::handle_message_optical_flow_rad(mavlink_message_t *msg)
 
 		if (_flow_distance_sensor_pub == nullptr) {
 			_flow_distance_sensor_pub = orb_advertise_multi(ORB_ID(distance_sensor), &d,
-						   &_orb_class_instance, ORB_PRIO_HIGH);
+						   &_orb_class_instance, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(distance_sensor), _flow_distance_sensor_pub, &d);
@@ -564,7 +564,7 @@ MavlinkReceiver::handle_message_hil_optical_flow(mavlink_message_t *msg)
 	f.gyro_temperature = flow.temperature;
 
 	if (_flow_pub == nullptr) {
-		_flow_pub = orb_advertise(ORB_ID(optical_flow), &f);
+		_flow_pub = orb_advertise(ORB_ID(optical_flow), &f, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(optical_flow), _flow_pub, &f);
@@ -585,7 +585,7 @@ MavlinkReceiver::handle_message_hil_optical_flow(mavlink_message_t *msg)
 
 	if (_hil_distance_sensor_pub == nullptr) {
 		_hil_distance_sensor_pub = orb_advertise_multi(ORB_ID(distance_sensor), &d,
-					   &_orb_class_instance, ORB_PRIO_HIGH);
+					   &_orb_class_instance, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(distance_sensor), _hil_distance_sensor_pub, &d);
@@ -619,7 +619,7 @@ MavlinkReceiver::handle_message_set_mode(mavlink_message_t *msg)
 	vcmd.confirmation = 1;
 
 	if (_cmd_pub == nullptr) {
-		_cmd_pub = orb_advertise(ORB_ID(vehicle_command), &vcmd);
+		_cmd_pub = orb_advertise(ORB_ID(vehicle_command), &vcmd, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(vehicle_command), _cmd_pub, &vcmd);
@@ -649,7 +649,7 @@ MavlinkReceiver::handle_message_distance_sensor(mavlink_message_t *msg)
 
 	if (_distance_sensor_pub == nullptr) {
 		_distance_sensor_pub = orb_advertise_multi(ORB_ID(distance_sensor), &d,
-				       &_orb_class_instance, ORB_PRIO_HIGH);
+				       &_orb_class_instance, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(distance_sensor), _distance_sensor_pub, &d);
@@ -681,7 +681,7 @@ MavlinkReceiver::handle_message_att_pos_mocap(mavlink_message_t *msg)
 	att_pos_mocap.z = mocap.z;
 
 	if (_att_pos_mocap_pub == nullptr) {
-		_att_pos_mocap_pub = orb_advertise(ORB_ID(att_pos_mocap), &att_pos_mocap);
+		_att_pos_mocap_pub = orb_advertise(ORB_ID(att_pos_mocap), &att_pos_mocap, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(att_pos_mocap), _att_pos_mocap_pub, &att_pos_mocap);
@@ -734,7 +734,7 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 		offboard_control_mode.timestamp = hrt_absolute_time();
 
 		if (_offboard_control_mode_pub == nullptr) {
-			_offboard_control_mode_pub = orb_advertise(ORB_ID(offboard_control_mode), &offboard_control_mode);
+			_offboard_control_mode_pub = orb_advertise(ORB_ID(offboard_control_mode), &offboard_control_mode, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(offboard_control_mode), _offboard_control_mode_pub, &offboard_control_mode);
@@ -762,7 +762,7 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 
 					//XXX: yaw
 					if (_force_sp_pub == nullptr) {
-						_force_sp_pub = orb_advertise(ORB_ID(vehicle_force_setpoint), &force_sp);
+						_force_sp_pub = orb_advertise(ORB_ID(vehicle_force_setpoint), &force_sp, ORB_DEFAULT_QUEUE_SIZE);
 
 					} else {
 						orb_publish(ORB_ID(vehicle_force_setpoint), _force_sp_pub, &force_sp);
@@ -849,7 +849,7 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 
 					if (_pos_sp_triplet_pub == nullptr) {
 						_pos_sp_triplet_pub = orb_advertise(ORB_ID(position_setpoint_triplet),
-										    &pos_sp_triplet);
+										    &pos_sp_triplet, ORB_DEFAULT_QUEUE_SIZE);
 
 					} else {
 						orb_publish(ORB_ID(position_setpoint_triplet), _pos_sp_triplet_pub,
@@ -901,7 +901,7 @@ MavlinkReceiver::handle_message_set_actuator_control_target(mavlink_message_t *m
 		offboard_control_mode.timestamp = hrt_absolute_time();
 
 		if (_offboard_control_mode_pub == nullptr) {
-			_offboard_control_mode_pub = orb_advertise(ORB_ID(offboard_control_mode), &offboard_control_mode);
+			_offboard_control_mode_pub = orb_advertise(ORB_ID(offboard_control_mode), &offboard_control_mode, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(offboard_control_mode), _offboard_control_mode_pub, &offboard_control_mode);
@@ -926,7 +926,7 @@ MavlinkReceiver::handle_message_set_actuator_control_target(mavlink_message_t *m
 			}
 
 			if (_actuator_controls_pub == nullptr) {
-				_actuator_controls_pub = orb_advertise(ORB_ID(actuator_controls_0), &actuator_controls);
+				_actuator_controls_pub = orb_advertise(ORB_ID(actuator_controls_0), &actuator_controls, ORB_DEFAULT_QUEUE_SIZE);
 
 			} else {
 				orb_publish(ORB_ID(actuator_controls_0), _actuator_controls_pub, &actuator_controls);
@@ -972,7 +972,7 @@ MavlinkReceiver::handle_message_vision_position_estimate(mavlink_message_t *msg)
 	vision_position.ang_err = 0.0f;
 
 	if (_vision_position_pub == nullptr) {
-		_vision_position_pub = orb_advertise(ORB_ID(vision_position_estimate), &vision_position);
+		_vision_position_pub = orb_advertise(ORB_ID(vision_position_estimate), &vision_position, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(vision_position_estimate), _vision_position_pub, &vision_position);
@@ -1037,7 +1037,7 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 		_offboard_control_mode.timestamp = hrt_absolute_time();
 
 		if (_offboard_control_mode_pub == nullptr) {
-			_offboard_control_mode_pub = orb_advertise(ORB_ID(offboard_control_mode), &_offboard_control_mode);
+			_offboard_control_mode_pub = orb_advertise(ORB_ID(offboard_control_mode), &_offboard_control_mode, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(offboard_control_mode), _offboard_control_mode_pub, &_offboard_control_mode);
@@ -1074,7 +1074,7 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 					}
 
 					if (_att_sp_pub == nullptr) {
-						_att_sp_pub = orb_advertise(ORB_ID(vehicle_attitude_setpoint), &_att_sp);
+						_att_sp_pub = orb_advertise(ORB_ID(vehicle_attitude_setpoint), &_att_sp, ORB_DEFAULT_QUEUE_SIZE);
 
 					} else {
 						orb_publish(ORB_ID(vehicle_attitude_setpoint), _att_sp_pub, &_att_sp);
@@ -1097,7 +1097,7 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 					}
 
 					if (_rates_sp_pub == nullptr) {
-						_rates_sp_pub = orb_advertise(ORB_ID(vehicle_rates_setpoint), &_rates_sp);
+						_rates_sp_pub = orb_advertise(ORB_ID(vehicle_rates_setpoint), &_rates_sp, ORB_DEFAULT_QUEUE_SIZE);
 
 					} else {
 						orb_publish(ORB_ID(vehicle_rates_setpoint), _rates_sp_pub, &_rates_sp);
@@ -1135,7 +1135,7 @@ MavlinkReceiver::handle_message_radio_status(mavlink_message_t *msg)
 
 		if (_telemetry_status_pub == nullptr) {
 			int multi_instance;
-			_telemetry_status_pub = orb_advertise_multi(ORB_ID(telemetry_status), &tstatus, &multi_instance, ORB_PRIO_HIGH);
+			_telemetry_status_pub = orb_advertise_multi(ORB_ID(telemetry_status), &tstatus, &multi_instance, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(telemetry_status), _telemetry_status_pub, &tstatus);
@@ -1237,7 +1237,7 @@ MavlinkReceiver::handle_message_rc_channels_override(mavlink_message_t *msg)
 	rc.values[7] = man.chan8_raw;
 
 	if (_rc_pub == nullptr) {
-		_rc_pub = orb_advertise(ORB_ID(input_rc), &rc);
+		_rc_pub = orb_advertise(ORB_ID(input_rc), &rc, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(input_rc), _rc_pub, &rc);
@@ -1295,7 +1295,7 @@ MavlinkReceiver::handle_message_manual_control(mavlink_message_t *msg)
 		_mom_switch_state = man.buttons;
 
 		if (_rc_pub == nullptr) {
-			_rc_pub = orb_advertise(ORB_ID(input_rc), &rc);
+			_rc_pub = orb_advertise(ORB_ID(input_rc), &rc, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(input_rc), _rc_pub, &rc);
@@ -1311,7 +1311,7 @@ MavlinkReceiver::handle_message_manual_control(mavlink_message_t *msg)
 		manual.z = man.z / 1000.0f;
 
 		if (_manual_pub == nullptr) {
-			_manual_pub = orb_advertise(ORB_ID(manual_control_setpoint), &manual);
+			_manual_pub = orb_advertise(ORB_ID(manual_control_setpoint), &manual, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(manual_control_setpoint), _manual_pub, &manual);
@@ -1340,7 +1340,7 @@ MavlinkReceiver::handle_message_heartbeat(mavlink_message_t *msg)
 
 			if (_telemetry_status_pub == nullptr) {
 				int multi_instance;
-				_telemetry_status_pub = orb_advertise_multi(ORB_ID(telemetry_status), &tstatus, &multi_instance, ORB_PRIO_HIGH);
+				_telemetry_status_pub = orb_advertise_multi(ORB_ID(telemetry_status), &tstatus, &multi_instance, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 
 			} else {
 				orb_publish(ORB_ID(telemetry_status), _telemetry_status_pub, &tstatus);
@@ -1446,7 +1446,7 @@ MavlinkReceiver::handle_message_timesync(mavlink_message_t *msg)
 	tsync_offset.offset_ns = _time_offset ;
 
 	if (_time_offset_pub == nullptr) {
-		_time_offset_pub = orb_advertise(ORB_ID(time_offset), &tsync_offset);
+		_time_offset_pub = orb_advertise(ORB_ID(time_offset), &tsync_offset, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(time_offset), _time_offset_pub, &tsync_offset);
@@ -1492,7 +1492,7 @@ MavlinkReceiver::handle_message_hil_sensor(mavlink_message_t *msg)
 		airspeed.true_airspeed_m_s = tas;
 
 		if (_airspeed_pub == nullptr) {
-			_airspeed_pub = orb_advertise(ORB_ID(airspeed), &airspeed);
+			_airspeed_pub = orb_advertise(ORB_ID(airspeed), &airspeed, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(airspeed), _airspeed_pub, &airspeed);
@@ -1513,7 +1513,7 @@ MavlinkReceiver::handle_message_hil_sensor(mavlink_message_t *msg)
 		gyro.temperature = imu.temperature;
 
 		if (_gyro_pub == nullptr) {
-			_gyro_pub = orb_advertise(ORB_ID(sensor_gyro), &gyro);
+			_gyro_pub = orb_advertise(ORB_ID(sensor_gyro), &gyro, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(sensor_gyro), _gyro_pub, &gyro);
@@ -1534,7 +1534,7 @@ MavlinkReceiver::handle_message_hil_sensor(mavlink_message_t *msg)
 		accel.temperature = imu.temperature;
 
 		if (_accel_pub == nullptr) {
-			_accel_pub = orb_advertise(ORB_ID(sensor_accel), &accel);
+			_accel_pub = orb_advertise(ORB_ID(sensor_accel), &accel, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(sensor_accel), _accel_pub, &accel);
@@ -1555,7 +1555,7 @@ MavlinkReceiver::handle_message_hil_sensor(mavlink_message_t *msg)
 
 		if (_mag_pub == nullptr) {
 			/* publish to the first mag topic */
-			_mag_pub = orb_advertise(ORB_ID(sensor_mag), &mag);
+			_mag_pub = orb_advertise(ORB_ID(sensor_mag), &mag, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(sensor_mag), _mag_pub, &mag);
@@ -1572,7 +1572,7 @@ MavlinkReceiver::handle_message_hil_sensor(mavlink_message_t *msg)
 		baro.temperature = imu.temperature;
 
 		if (_baro_pub == nullptr) {
-			_baro_pub = orb_advertise(ORB_ID(sensor_baro), &baro);
+			_baro_pub = orb_advertise(ORB_ID(sensor_baro), &baro, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(sensor_baro), _baro_pub, &baro);
@@ -1642,7 +1642,7 @@ MavlinkReceiver::handle_message_hil_sensor(mavlink_message_t *msg)
 
 		/* publish combined sensor topic */
 		if (_sensors_pub == nullptr) {
-			_sensors_pub = orb_advertise(ORB_ID(sensor_combined), &hil_sensors);
+			_sensors_pub = orb_advertise(ORB_ID(sensor_combined), &hil_sensors, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(sensor_combined), _sensors_pub, &hil_sensors);
@@ -1660,7 +1660,7 @@ MavlinkReceiver::handle_message_hil_sensor(mavlink_message_t *msg)
 		hil_battery_status.discharged_mah = -1.0f;
 
 		if (_battery_pub == nullptr) {
-			_battery_pub = orb_advertise(ORB_ID(battery_status), &hil_battery_status);
+			_battery_pub = orb_advertise(ORB_ID(battery_status), &hil_battery_status, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(battery_status), _battery_pub, &hil_battery_status);
@@ -1714,7 +1714,7 @@ MavlinkReceiver::handle_message_hil_gps(mavlink_message_t *msg)
 	hil_gps.satellites_used = gps.satellites_visible;  //TODO: rename mavlink_hil_gps_t sats visible to used?
 
 	if (_gps_pub == nullptr) {
-		_gps_pub = orb_advertise(ORB_ID(vehicle_gps_position), &hil_gps);
+		_gps_pub = orb_advertise(ORB_ID(vehicle_gps_position), &hil_gps, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(vehicle_gps_position), _gps_pub, &hil_gps);
@@ -1735,7 +1735,7 @@ void MavlinkReceiver::handle_message_follow_target(mavlink_message_t *msg)
 	follow_target_topic.alt = follow_target_msg.alt;
 
 	if (_follow_target_pub == nullptr) {
-		_follow_target_pub = orb_advertise(ORB_ID(follow_target), &follow_target_topic);
+		_follow_target_pub = orb_advertise(ORB_ID(follow_target), &follow_target_topic, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(follow_target), _follow_target_pub, &follow_target_topic);
@@ -1768,7 +1768,7 @@ void MavlinkReceiver::handle_message_adsb_vehicle(mavlink_message_t *msg)
 	//warnx("code: %d callsign: %s, vel: %8.4f", (int)t.ICAO_address, t.callsign, (double)t.hor_velocity);
 
 	if (_transponder_report_pub == nullptr) {
-		_transponder_report_pub = orb_advertise(ORB_ID(transponder_report), &t);
+		_transponder_report_pub = orb_advertise(ORB_ID(transponder_report), &t, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(transponder_report), _transponder_report_pub, &t);
@@ -1792,7 +1792,7 @@ void MavlinkReceiver::handle_message_gps_rtcm_data(mavlink_message_t *msg)
 	if (pub == nullptr) {
 		int idx = _gps_inject_data_next_idx;
 		pub = orb_advertise_multi(ORB_ID(gps_inject_data), &gps_inject_data_topic,
-					  &idx, ORB_PRIO_DEFAULT);
+					  &idx, ORB_PRIO_DEFAULT, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(gps_inject_data), pub, &gps_inject_data_topic);
@@ -1820,7 +1820,7 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 		airspeed.true_airspeed_m_s = hil_state.true_airspeed * 1e-2f;
 
 		if (_airspeed_pub == nullptr) {
-			_airspeed_pub = orb_advertise(ORB_ID(airspeed), &airspeed);
+			_airspeed_pub = orb_advertise(ORB_ID(airspeed), &airspeed, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(airspeed), _airspeed_pub, &airspeed);
@@ -1853,7 +1853,7 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 		hil_attitude.yawspeed = hil_state.yawspeed;
 
 		if (_attitude_pub == nullptr) {
-			_attitude_pub = orb_advertise(ORB_ID(vehicle_attitude), &hil_attitude);
+			_attitude_pub = orb_advertise(ORB_ID(vehicle_attitude), &hil_attitude, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(vehicle_attitude), _attitude_pub, &hil_attitude);
@@ -1877,7 +1877,7 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 		hil_global_pos.epv = 4.0f;
 
 		if (_global_pos_pub == nullptr) {
-			_global_pos_pub = orb_advertise(ORB_ID(vehicle_global_position), &hil_global_pos);
+			_global_pos_pub = orb_advertise(ORB_ID(vehicle_global_position), &hil_global_pos, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(vehicle_global_position), _global_pos_pub, &hil_global_pos);
@@ -1918,7 +1918,7 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 		hil_local_pos.z_global = true;
 
 		if (_local_pos_pub == nullptr) {
-			_local_pos_pub = orb_advertise(ORB_ID(vehicle_local_position), &hil_local_pos);
+			_local_pos_pub = orb_advertise(ORB_ID(vehicle_local_position), &hil_local_pos, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(vehicle_local_position), _local_pos_pub, &hil_local_pos);
@@ -1934,7 +1934,7 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 			hil_land_detector.timestamp = hrt_absolute_time();
 
 			if (_land_detector_pub == nullptr) {
-				_land_detector_pub = orb_advertise(ORB_ID(vehicle_land_detected), &hil_land_detector);
+				_land_detector_pub = orb_advertise(ORB_ID(vehicle_land_detected), &hil_land_detector, ORB_DEFAULT_QUEUE_SIZE);
 
 			} else {
 				orb_publish(ORB_ID(vehicle_land_detected), _land_detector_pub, &hil_land_detector);
@@ -1957,7 +1957,7 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 		accel.temperature = 25.0f;
 
 		if (_accel_pub == nullptr) {
-			_accel_pub = orb_advertise(ORB_ID(sensor_accel), &accel);
+			_accel_pub = orb_advertise(ORB_ID(sensor_accel), &accel, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(sensor_accel), _accel_pub, &accel);
@@ -1976,7 +1976,7 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 		hil_battery_status.discharged_mah = -1.0f;
 
 		if (_battery_pub == nullptr) {
-			_battery_pub = orb_advertise(ORB_ID(battery_status), &hil_battery_status);
+			_battery_pub = orb_advertise(ORB_ID(battery_status), &hil_battery_status, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(battery_status), _battery_pub, &hil_battery_status);

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -912,7 +912,7 @@ MulticopterAttitudeControl::task_main()
 					orb_publish(_rates_sp_id, _v_rates_sp_pub, &_v_rates_sp);
 
 				} else if (_rates_sp_id) {
-					_v_rates_sp_pub = orb_advertise(_rates_sp_id, &_v_rates_sp);
+					_v_rates_sp_pub = orb_advertise(_rates_sp_id, &_v_rates_sp, ORB_DEFAULT_QUEUE_SIZE);
 				}
 
 				//}
@@ -936,7 +936,7 @@ MulticopterAttitudeControl::task_main()
 						orb_publish(_rates_sp_id, _v_rates_sp_pub, &_v_rates_sp);
 
 					} else if (_rates_sp_id) {
-						_v_rates_sp_pub = orb_advertise(_rates_sp_id, &_v_rates_sp);
+						_v_rates_sp_pub = orb_advertise(_rates_sp_id, &_v_rates_sp, ORB_DEFAULT_QUEUE_SIZE);
 					}
 
 				} else {
@@ -972,7 +972,7 @@ MulticopterAttitudeControl::task_main()
 						perf_end(_controller_latency_perf);
 
 					} else if (_actuators_id) {
-						_actuators_0_pub = orb_advertise(_actuators_id, &_actuators);
+						_actuators_0_pub = orb_advertise(_actuators_id, &_actuators, ORB_DEFAULT_QUEUE_SIZE);
 					}
 
 				}
@@ -982,7 +982,7 @@ MulticopterAttitudeControl::task_main()
 					orb_publish(ORB_ID(mc_att_ctrl_status), _controller_status_pub, &_controller_status);
 
 				} else {
-					_controller_status_pub = orb_advertise(ORB_ID(mc_att_ctrl_status), &_controller_status);
+					_controller_status_pub = orb_advertise(ORB_ID(mc_att_ctrl_status), &_controller_status, ORB_DEFAULT_QUEUE_SIZE);
 				}
 			}
 		}

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1382,7 +1382,7 @@ MulticopterPositionControl::task_main()
 					orb_publish(_attitude_setpoint_id, _att_sp_pub, &_att_sp);
 
 				} else if (_attitude_setpoint_id) {
-					_att_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp);
+					_att_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp, ORB_DEFAULT_QUEUE_SIZE);
 				}
 
 			} else if (_control_mode.flag_control_manual_enabled
@@ -1410,7 +1410,7 @@ MulticopterPositionControl::task_main()
 					orb_publish(_attitude_setpoint_id, _att_sp_pub, &_att_sp);
 
 				} else if (_attitude_setpoint_id) {
-					_att_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp);
+					_att_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp, ORB_DEFAULT_QUEUE_SIZE);
 				}
 
 			} else {
@@ -1578,7 +1578,7 @@ MulticopterPositionControl::task_main()
 					orb_publish(ORB_ID(vehicle_global_velocity_setpoint), _global_vel_sp_pub, &_global_vel_sp);
 
 				} else {
-					_global_vel_sp_pub = orb_advertise(ORB_ID(vehicle_global_velocity_setpoint), &_global_vel_sp);
+					_global_vel_sp_pub = orb_advertise(ORB_ID(vehicle_global_velocity_setpoint), &_global_vel_sp, ORB_DEFAULT_QUEUE_SIZE);
 				}
 
 				if (_control_mode.flag_control_climb_rate_enabled || _control_mode.flag_control_velocity_enabled ||
@@ -1936,7 +1936,7 @@ MulticopterPositionControl::task_main()
 				orb_publish(ORB_ID(vehicle_local_position_setpoint), _local_pos_sp_pub, &_local_pos_sp);
 
 			} else {
-				_local_pos_sp_pub = orb_advertise(ORB_ID(vehicle_local_position_setpoint), &_local_pos_sp);
+				_local_pos_sp_pub = orb_advertise(ORB_ID(vehicle_local_position_setpoint), &_local_pos_sp, ORB_DEFAULT_QUEUE_SIZE);
 			}
 
 		} else {
@@ -2074,7 +2074,7 @@ MulticopterPositionControl::task_main()
 				orb_publish(_attitude_setpoint_id, _att_sp_pub, &_att_sp);
 
 			} else if (_attitude_setpoint_id) {
-				_att_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp);
+				_att_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp, ORB_DEFAULT_QUEUE_SIZE);
 			}
 		}
 

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -308,7 +308,7 @@ void
 Geofence::publishFence(unsigned vertices)
 {
 	if (_fence_pub == nullptr) {
-		_fence_pub = orb_advertise(ORB_ID(fence), &vertices);
+		_fence_pub = orb_advertise(ORB_ID(fence), &vertices, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(fence), _fence_pub, &vertices);

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -297,7 +297,7 @@ MissionBlock::issue_command(const struct mission_item_s *item)
 			orb_publish(ORB_ID(actuator_controls_2), _actuator_pub, &actuators);
 
 		} else {
-			_actuator_pub = orb_advertise(ORB_ID(actuator_controls_2), &actuators);
+			_actuator_pub = orb_advertise(ORB_ID(actuator_controls_2), &actuators, ORB_DEFAULT_QUEUE_SIZE);
 		}
 
 	} else {
@@ -310,7 +310,7 @@ MissionBlock::issue_command(const struct mission_item_s *item)
 			orb_publish(ORB_ID(vehicle_command), _cmd_pub, &cmd);
 
 		} else {
-			_cmd_pub = orb_advertise(ORB_ID(vehicle_command), &cmd);
+			_cmd_pub = orb_advertise(ORB_ID(vehicle_command), &cmd, ORB_DEFAULT_QUEUE_SIZE);
 		}
 	}
 }
@@ -528,7 +528,7 @@ MissionBlock::set_land_item(struct mission_item_s *item, bool at_current_locatio
 		if (_cmd_pub != nullptr) {
 			orb_publish(ORB_ID(vehicle_command), _cmd_pub, &cmd);
 		} else {
-			_cmd_pub = orb_advertise(ORB_ID(vehicle_command), &cmd);
+			_cmd_pub = orb_advertise(ORB_ID(vehicle_command), &cmd, ORB_DEFAULT_QUEUE_SIZE);
 		}
 	}
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -695,7 +695,7 @@ Navigator::publish_position_setpoint_triplet()
 		orb_publish(ORB_ID(position_setpoint_triplet), _pos_sp_triplet_pub, &_pos_sp_triplet);
 
 	} else {
-		_pos_sp_triplet_pub = orb_advertise(ORB_ID(position_setpoint_triplet), &_pos_sp_triplet);
+		_pos_sp_triplet_pub = orb_advertise(ORB_ID(position_setpoint_triplet), &_pos_sp_triplet, ORB_DEFAULT_QUEUE_SIZE);
 	}
 }
 
@@ -823,7 +823,7 @@ Navigator::publish_mission_result()
 
 	} else {
 		/* advertise and publish */
-		_mission_result_pub = orb_advertise(ORB_ID(mission_result), &_mission_result);
+		_mission_result_pub = orb_advertise(ORB_ID(mission_result), &_mission_result, ORB_DEFAULT_QUEUE_SIZE);
 	}
 
 	/* reset some of the flags */
@@ -846,7 +846,7 @@ Navigator::publish_geofence_result()
 
 	} else {
 		/* advertise and publish */
-		_geofence_result_pub = orb_advertise(ORB_ID(geofence_result), &_geofence_result);
+		_geofence_result_pub = orb_advertise(ORB_ID(geofence_result), &_geofence_result, ORB_DEFAULT_QUEUE_SIZE);
 	}
 }
 
@@ -860,7 +860,7 @@ Navigator::publish_att_sp()
 
 	} else {
 		/* advertise and publish */
-		_att_sp_pub = orb_advertise(ORB_ID(vehicle_attitude_setpoint), &_att_sp);
+		_att_sp_pub = orb_advertise(ORB_ID(vehicle_attitude_setpoint), &_att_sp, ORB_DEFAULT_QUEUE_SIZE);
 	}
 }
 

--- a/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
@@ -384,7 +384,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 	int vehicle_rate_sp_sub = orb_subscribe(ORB_ID(vehicle_rates_setpoint));
 
 	/* advertise */
-	orb_advert_t vehicle_local_position_pub = orb_advertise(ORB_ID(vehicle_local_position), &local_pos);
+	orb_advert_t vehicle_local_position_pub = orb_advertise(ORB_ID(vehicle_local_position), &local_pos, ORB_DEFAULT_QUEUE_SIZE);
 	orb_advert_t vehicle_global_position_pub = NULL;
 
 	struct position_estimator_inav_params params;
@@ -1365,7 +1365,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 				global_pos.pressure_alt = sensor.baro_alt_meter[0];
 
 				if (vehicle_global_position_pub == NULL) {
-					vehicle_global_position_pub = orb_advertise(ORB_ID(vehicle_global_position), &global_pos);
+					vehicle_global_position_pub = orb_advertise(ORB_ID(vehicle_global_position), &global_pos, ORB_DEFAULT_QUEUE_SIZE);
 
 				} else {
 					orb_publish(ORB_ID(vehicle_global_position), vehicle_global_position_pub, &global_pos);

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -386,7 +386,7 @@ int sdlog2_main(int argc, char *argv[])
 		cmd.param1 = -1;
 		cmd.param2 = -1;
 		cmd.param3 = 1;
-		orb_advertise(ORB_ID(vehicle_command), &cmd);
+		orb_advertise(ORB_ID(vehicle_command), &cmd, ORB_DEFAULT_QUEUE_SIZE);
 		return 0;
 	}
 
@@ -396,7 +396,7 @@ int sdlog2_main(int argc, char *argv[])
 		cmd.param1 = -1;
 		cmd.param2 = -1;
 		cmd.param3 = 2;
-		orb_advertise(ORB_ID(vehicle_command), &cmd);
+		orb_advertise(ORB_ID(vehicle_command), &cmd, ORB_DEFAULT_QUEUE_SIZE);
 		return 0;
 	}
 

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -1165,7 +1165,7 @@ Sensors::diff_pres_poll(struct sensor_combined_s &raw)
 			orb_publish(ORB_ID(airspeed), _airspeed_pub, &_airspeed);
 
 		} else {
-			_airspeed_pub = orb_advertise(ORB_ID(airspeed), &_airspeed);
+			_airspeed_pub = orb_advertise(ORB_ID(airspeed), &_airspeed, ORB_DEFAULT_QUEUE_SIZE);
 		}
 	}
 }
@@ -1691,7 +1691,7 @@ Sensors::adc_poll(struct sensor_combined_s &raw)
 							orb_publish(ORB_ID(differential_pressure), _diff_pres_pub, &_diff_pres);
 
 						} else {
-							_diff_pres_pub = orb_advertise(ORB_ID(differential_pressure), &_diff_pres);
+							_diff_pres_pub = orb_advertise(ORB_ID(differential_pressure), &_diff_pres, ORB_DEFAULT_QUEUE_SIZE);
 						}
 					}
 
@@ -1710,7 +1710,7 @@ Sensors::adc_poll(struct sensor_combined_s &raw)
 					orb_publish(ORB_ID(battery_status), _battery_pub, &_battery_status);
 
 				} else {
-					_battery_pub = orb_advertise(ORB_ID(battery_status), &_battery_status);
+					_battery_pub = orb_advertise(ORB_ID(battery_status), &_battery_status, ORB_DEFAULT_QUEUE_SIZE);
 				}
 			}
 
@@ -1914,7 +1914,7 @@ Sensors::rc_poll()
 			orb_publish(ORB_ID(rc_channels), _rc_pub, &_rc);
 
 		} else {
-			_rc_pub = orb_advertise(ORB_ID(rc_channels), &_rc);
+			_rc_pub = orb_advertise(ORB_ID(rc_channels), &_rc, ORB_DEFAULT_QUEUE_SIZE);
 		}
 
 		/* only publish manual control if the signal is still present */
@@ -1990,7 +1990,7 @@ Sensors::rc_poll()
 				orb_publish(ORB_ID(manual_control_setpoint), _manual_control_pub, &manual);
 
 			} else {
-				_manual_control_pub = orb_advertise(ORB_ID(manual_control_setpoint), &manual);
+				_manual_control_pub = orb_advertise(ORB_ID(manual_control_setpoint), &manual, ORB_DEFAULT_QUEUE_SIZE);
 			}
 
 			/* copy from mapped manual control to control group 3 */
@@ -2012,7 +2012,7 @@ Sensors::rc_poll()
 				orb_publish(ORB_ID(actuator_controls_3), _actuator_group_3_pub, &actuator_group_3);
 
 			} else {
-				_actuator_group_3_pub = orb_advertise(ORB_ID(actuator_controls_3), &actuator_group_3);
+				_actuator_group_3_pub = orb_advertise(ORB_ID(actuator_controls_3), &actuator_group_3, ORB_DEFAULT_QUEUE_SIZE);
 			}
 
 			/* Update parameters from RC Channels (tuning with RC) if activated */
@@ -2145,7 +2145,7 @@ Sensors::task_main()
 	rc_parameter_map_poll(true /* forced */);
 
 	/* advertise the sensor_combined topic and make the initial publication */
-	_sensor_pub = orb_advertise(ORB_ID(sensor_combined), &raw);
+	_sensor_pub = orb_advertise(ORB_ID(sensor_combined), &raw, ORB_DEFAULT_QUEUE_SIZE);
 
 	/* wakeup source(s) */
 	px4_pollfd_struct_t fds[1] = {};

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -295,7 +295,8 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 
 			// publish the battery voltage
 			int batt_multi;
-			orb_publish_auto(ORB_ID(battery_status), &_battery_pub, &battery_status, &batt_multi, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
+			orb_publish_auto(ORB_ID(battery_status), &_battery_pub, &battery_status, &batt_multi, ORB_PRIO_HIGH,
+					 ORB_DEFAULT_QUEUE_SIZE);
 		}
 		break;
 

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -295,7 +295,7 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 
 			// publish the battery voltage
 			int batt_multi;
-			orb_publish_auto(ORB_ID(battery_status), &_battery_pub, &battery_status, &batt_multi, ORB_PRIO_HIGH);
+			orb_publish_auto(ORB_ID(battery_status), &_battery_pub, &battery_status, &batt_multi, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 		}
 		break;
 
@@ -324,7 +324,7 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 		// publish message
 		if (publish) {
 			int rc_multi;
-			orb_publish_auto(ORB_ID(input_rc), &_rc_channels_pub, &_rc_input, &rc_multi, ORB_PRIO_HIGH);
+			orb_publish_auto(ORB_ID(input_rc), &_rc_channels_pub, &_rc_input, &rc_multi, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 		}
 
 		break;
@@ -802,7 +802,7 @@ int Simulator::publish_sensor_topics(mavlink_hil_sensor_t *imu)
 		gyro.temperature = imu->temperature;
 
 		int gyro_multi;
-		orb_publish_auto(ORB_ID(sensor_gyro), &_gyro_pub, &gyro, &gyro_multi, ORB_PRIO_HIGH);
+		orb_publish_auto(ORB_ID(sensor_gyro), &_gyro_pub, &gyro, &gyro_multi, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 	}
 
 	/* accelerometer */
@@ -820,7 +820,7 @@ int Simulator::publish_sensor_topics(mavlink_hil_sensor_t *imu)
 		accel.temperature = imu->temperature;
 
 		int accel_multi;
-		orb_publish_auto(ORB_ID(sensor_accel), &_accel_pub, &accel, &accel_multi, ORB_PRIO_HIGH);
+		orb_publish_auto(ORB_ID(sensor_accel), &_accel_pub, &accel, &accel_multi, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 	}
 
 	/* magnetometer */
@@ -838,7 +838,7 @@ int Simulator::publish_sensor_topics(mavlink_hil_sensor_t *imu)
 		mag.temperature = imu->temperature;
 
 		int mag_multi;
-		orb_publish_auto(ORB_ID(sensor_mag), &_mag_pub, &mag, &mag_multi, ORB_PRIO_HIGH);
+		orb_publish_auto(ORB_ID(sensor_mag), &_mag_pub, &mag, &mag_multi, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 	}
 
 	/* baro */
@@ -851,7 +851,7 @@ int Simulator::publish_sensor_topics(mavlink_hil_sensor_t *imu)
 		baro.temperature = imu->temperature;
 
 		int baro_multi;
-		orb_publish_auto(ORB_ID(sensor_baro), &_baro_pub, &baro, &baro_multi, ORB_PRIO_HIGH);
+		orb_publish_auto(ORB_ID(sensor_baro), &_baro_pub, &baro, &baro_multi, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 	}
 
 	return OK;
@@ -880,7 +880,7 @@ int Simulator::publish_flow_topic(mavlink_hil_optical_flow_t *flow_mavlink)
 	flow.quality = flow_mavlink->quality;
 
 	int flow_multi;
-	orb_publish_auto(ORB_ID(optical_flow), &_flow_pub, &flow, &flow_multi, ORB_PRIO_HIGH);
+	orb_publish_auto(ORB_ID(optical_flow), &_flow_pub, &flow, &flow_multi, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 
 	return OK;
 }

--- a/src/modules/systemlib/mavlink_log.c
+++ b/src/modules/systemlib/mavlink_log.c
@@ -79,7 +79,7 @@ __EXPORT void mavlink_vasprintf(int severity, orb_advert_t *mavlink_log_pub, con
 		orb_publish(ORB_ID(mavlink_log), *mavlink_log_pub, &log_msg);
 
 	} else {
-		*mavlink_log_pub = orb_advertise(ORB_ID(mavlink_log), &log_msg);
+		*mavlink_log_pub = orb_advertise(ORB_ID(mavlink_log), &log_msg, ORB_DEFAULT_QUEUE_SIZE);
 	}
 }
 

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -244,7 +244,7 @@ param_notify_changes(bool is_saved)
 	 * just publish.
 	 */
 	if (param_topic == NULL) {
-		param_topic = orb_advertise(ORB_ID(parameter_update), &pup);
+		param_topic = orb_advertise(ORB_ID(parameter_update), &pup, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(parameter_update), param_topic, &pup);

--- a/src/modules/systemlib/param/param_shmem.c
+++ b/src/modules/systemlib/param/param_shmem.c
@@ -256,7 +256,7 @@ param_notify_changes(bool is_saved)
 	 * just publish.
 	 */
 	if (param_topic == NULL) {
-		param_topic = orb_advertise(ORB_ID(parameter_update), &pup);
+		param_topic = orb_advertise(ORB_ID(parameter_update), &pup, ORB_DEFAULT_QUEUE_SIZE);
 
 	} else {
 		orb_publish(ORB_ID(parameter_update), param_topic, &pup);

--- a/src/modules/uORB/ORBMap.hpp
+++ b/src/modules/uORB/ORBMap.hpp
@@ -139,6 +139,11 @@ public:
 		}
 	}
 
+	Node *top() const
+	{
+		return _top;
+	}
+
 private:
 	Node *_top;
 	Node *_end;

--- a/src/modules/uORB/Publication.cpp
+++ b/src/modules/uORB/Publication.cpp
@@ -79,10 +79,10 @@ void PublicationBase::update(void *data)
 		if (_priority > 0) {
 			handle = orb_advertise_multi(
 					 getMeta(), data,
-					 &_instance, _priority);
+					 &_instance, _priority, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
-			handle = orb_advertise(getMeta(), data);
+			handle = orb_advertise(getMeta(), data, ORB_DEFAULT_QUEUE_SIZE);
 		}
 
 		if (int64_t(handle) != PX4_ERROR) {

--- a/src/modules/uORB/uORB.cpp
+++ b/src/modules/uORB/uORB.cpp
@@ -40,23 +40,12 @@
 #include "uORBManager.hpp"
 #include "uORBCommon.hpp"
 
-orb_advert_t orb_advertise(const struct orb_metadata *meta, const void *data)
-{
-	return uORB::Manager::get_instance()->orb_advertise(meta, data);
-}
-
-orb_advert_t orb_advertise_queue(const struct orb_metadata *meta, const void *data, unsigned int queue_size)
+orb_advert_t orb_advertise(const struct orb_metadata *meta, const void *data, unsigned int queue_size)
 {
 	return uORB::Manager::get_instance()->orb_advertise(meta, data, queue_size);
 }
 
 orb_advert_t orb_advertise_multi(const struct orb_metadata *meta, const void *data, int *instance,
-				 int priority)
-{
-	return uORB::Manager::get_instance()->orb_advertise_multi(meta, data, instance, priority);
-}
-
-orb_advert_t orb_advertise_multi_queue(const struct orb_metadata *meta, const void *data, int *instance,
 				       int priority, unsigned int queue_size)
 {
 	return uORB::Manager::get_instance()->orb_advertise_multi(meta, data, instance, priority, queue_size);
@@ -68,10 +57,10 @@ int orb_unadvertise(orb_advert_t handle)
 }
 
 int orb_publish_auto(const struct orb_metadata *meta, orb_advert_t *handle, const void *data, int *instance,
-		     int priority)
+		     int priority, unsigned int queue_size)
 {
 	if (*handle == nullptr) {
-		*handle = orb_advertise_multi(meta, data, instance, priority);
+		*handle = orb_advertise_multi(meta, data, instance, priority, queue_size);
 
 		if (*handle != nullptr) {
 			return 0;

--- a/src/modules/uORB/uORB.cpp
+++ b/src/modules/uORB/uORB.cpp
@@ -46,7 +46,7 @@ orb_advert_t orb_advertise(const struct orb_metadata *meta, const void *data, un
 }
 
 orb_advert_t orb_advertise_multi(const struct orb_metadata *meta, const void *data, int *instance,
-				       int priority, unsigned int queue_size)
+				 int priority, unsigned int queue_size)
 {
 	return uORB::Manager::get_instance()->orb_advertise_multi(meta, data, instance, priority, queue_size);
 }

--- a/src/modules/uORB/uORB.h
+++ b/src/modules/uORB/uORB.h
@@ -46,6 +46,8 @@
 // Hack until everything is using this header
 #include <systemlib/visibility.h>
 
+#define ORB_DEFAULT_QUEUE_SIZE 1
+
 /**
  * Object metadata.
  */

--- a/src/modules/uORB/uORB.h
+++ b/src/modules/uORB/uORB.h
@@ -141,13 +141,13 @@ typedef void 	*orb_advert_t;
  * @see uORB::Manager::orb_advertise()
  */
 extern orb_advert_t orb_advertise(const struct orb_metadata *meta, const void *data,
-					unsigned int queue_size) __EXPORT;
+				  unsigned int queue_size) __EXPORT;
 
 /**
  * @see uORB::Manager::orb_advertise_multi()
  */
 extern orb_advert_t orb_advertise_multi(const struct orb_metadata *meta, const void *data, int *instance,
-		int priority, unsigned int queue_size) __EXPORT;
+					int priority, unsigned int queue_size) __EXPORT;
 
 /**
  * @see uORB::Manager::orb_unadvertise()

--- a/src/modules/uORB/uORB.h
+++ b/src/modules/uORB/uORB.h
@@ -140,24 +140,13 @@ typedef void 	*orb_advert_t;
 /**
  * @see uORB::Manager::orb_advertise()
  */
-extern orb_advert_t orb_advertise(const struct orb_metadata *meta, const void *data) __EXPORT;
-
-/**
- * @see uORB::Manager::orb_advertise()
- */
-extern orb_advert_t orb_advertise_queue(const struct orb_metadata *meta, const void *data,
+extern orb_advert_t orb_advertise(const struct orb_metadata *meta, const void *data,
 					unsigned int queue_size) __EXPORT;
 
 /**
  * @see uORB::Manager::orb_advertise_multi()
  */
 extern orb_advert_t orb_advertise_multi(const struct orb_metadata *meta, const void *data, int *instance,
-					int priority) __EXPORT;
-
-/**
- * @see uORB::Manager::orb_advertise_multi()
- */
-extern orb_advert_t orb_advertise_multi_queue(const struct orb_metadata *meta, const void *data, int *instance,
 		int priority, unsigned int queue_size) __EXPORT;
 
 /**
@@ -174,7 +163,7 @@ extern int orb_unadvertise(orb_advert_t handle) __EXPORT;
  * @see uORB::Manager::orb_advertise_multi() for meaning of the individual parameters
  */
 extern int orb_publish_auto(const struct orb_metadata *meta, orb_advert_t *handle, const void *data, int *instance,
-			    int priority);
+			    int priority, unsigned int queue_size);
 
 /**
  * @see uORB::Manager::orb_publish()

--- a/src/modules/uORB/uORBCommon.hpp
+++ b/src/modules/uORB/uORBCommon.hpp
@@ -52,8 +52,10 @@ static const unsigned orb_maxpath = 64;
 const int ERROR = -1;
 
 enum Flavor {
-	PUBSUB,
-	PARAM
+	PUBSUB = 0,
+	PARAM,
+
+	Flavor_count
 };
 
 struct orb_advertdata {

--- a/src/modules/uORB/uORBDevices_nuttx.cpp
+++ b/src/modules/uORB/uORBDevices_nuttx.cpp
@@ -535,11 +535,17 @@ uORB::DeviceNode::print_statistics(bool reset)
 //-----------------------------------------------------------------------------
 void uORB::DeviceNode::add_internal_subscriber()
 {
-	_subscriber_count++;
 	uORBCommunicator::IChannel *ch = uORB::Manager::get_instance()->get_uorb_communicator();
 
+	lock();
+	_subscriber_count++;
+
 	if (ch != nullptr && _subscriber_count > 0) {
+		unlock(); //make sure we cannot deadlock if add_subscription calls back into DeviceNode
 		ch->add_subscription(_meta->o_name, 1);
+
+	} else {
+		unlock();
 	}
 }
 
@@ -547,11 +553,17 @@ void uORB::DeviceNode::add_internal_subscriber()
 //-----------------------------------------------------------------------------
 void uORB::DeviceNode::remove_internal_subscriber()
 {
-	_subscriber_count--;
 	uORBCommunicator::IChannel *ch = uORB::Manager::get_instance()->get_uorb_communicator();
 
+	lock();
+	_subscriber_count--;
+
 	if (ch != nullptr && _subscriber_count == 0) {
+		unlock(); //make sure we cannot deadlock if remove_subscription calls back into DeviceNode
 		ch->remove_subscription(_meta->o_name);
+
+	} else {
+		unlock();
 	}
 }
 

--- a/src/modules/uORB/uORBDevices_nuttx.cpp
+++ b/src/modules/uORB/uORBDevices_nuttx.cpp
@@ -187,6 +187,7 @@ uORB::DeviceNode::read(struct file *filp, char *buffer, size_t buflen)
 
 	if (_generation > sd->generation + _queue_size) {
 		/* Reader is too far behind: some messages are lost */
+		_lost_messages += _generation - (sd->generation + _queue_size);
 		sd->generation = _generation - _queue_size;
 	}
 
@@ -509,6 +510,27 @@ uORB::DeviceNode::update_deferred_trampoline(void *arg)
 	node->update_deferred();
 }
 
+bool
+uORB::DeviceNode::print_statistics(bool reset)
+{
+	if (!_lost_messages) {
+		return false;
+	}
+
+	lock();
+	//This can be wrong: if a reader never reads, _lost_messages will not be increased either
+	uint32_t lost_messages = _lost_messages;
+
+	if (reset) {
+		_lost_messages = 0;
+	}
+
+	unlock();
+
+	PX4_INFO("%s: %i", _meta->o_name, lost_messages);
+	return true;
+}
+
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 void uORB::DeviceNode::add_internal_subscriber()
@@ -612,7 +634,7 @@ uORB::DeviceMaster::DeviceMaster(Flavor f) :
 {
 	// enable debug() calls
 	_debug_enabled = true;
-
+	_last_statistics_output = hrt_absolute_time();
 }
 
 uORB::DeviceMaster::~DeviceMaster()
@@ -738,6 +760,35 @@ uORB::DeviceMaster::ioctl(struct file *filp, int cmd, unsigned long arg)
 		return CDev::ioctl(filp, cmd, arg);
 	}
 }
+
+void uORB::DeviceMaster::printStatistics(bool reset)
+{
+	hrt_abstime current_time = hrt_absolute_time();
+	PX4_INFO("Statistics, since last output (%i ms):",
+		 (int)((current_time - _last_statistics_output) / 1000));
+	_last_statistics_output = current_time;
+
+	PX4_INFO("TOPIC, NR LOST MSGS");
+	bool had_print = false;
+
+	lock();
+	ORBMap::Node *node = _node_map.top();
+
+	while (node) {
+		if (node->node->print_statistics(reset)) {
+			had_print = true;
+		}
+
+		node = node->next;
+	}
+
+	unlock();
+
+	if (!had_print) {
+		PX4_INFO("No lost messages");
+	}
+}
+
 
 uORB::DeviceNode *uORB::DeviceMaster::getDeviceNode(const char *nodepath)
 {

--- a/src/modules/uORB/uORBDevices_nuttx.cpp
+++ b/src/modules/uORB/uORBDevices_nuttx.cpp
@@ -43,8 +43,6 @@
 #include <px4_sem.hpp>
 #include <stdlib.h>
 
-uORB::ORBMap uORB::DeviceMaster::_node_map;
-
 uORB::DeviceNode::DeviceNode
 (
 	const struct orb_metadata *meta,
@@ -704,7 +702,7 @@ uORB::DeviceMaster::ioctl(struct file *filp, int cmd, unsigned long arg)
 					if (ret == -EEXIST) {
 						/* if the node exists already, get the existing one and check if
 						 * something has been published yet. */
-						uORB::DeviceNode *existing_node = GetDeviceNode(devpath);
+						uORB::DeviceNode *existing_node = getDeviceNodeLocked(devpath);
 
 						if ((existing_node != nullptr) && !(existing_node->is_published())) {
 							/* nothing has been published yet, lets claim it */
@@ -741,7 +739,17 @@ uORB::DeviceMaster::ioctl(struct file *filp, int cmd, unsigned long arg)
 	}
 }
 
-uORB::DeviceNode *uORB::DeviceMaster::GetDeviceNode(const char *nodepath)
+uORB::DeviceNode *uORB::DeviceMaster::getDeviceNode(const char *nodepath)
+{
+	lock();
+	uORB::DeviceNode *node = getDeviceNodeLocked(nodepath);
+	unlock();
+	//We can safely return the node that can be used by any thread, because
+	//a DeviceNode never gets deleted.
+	return node;
+}
+
+uORB::DeviceNode *uORB::DeviceMaster::getDeviceNodeLocked(const char *nodepath)
 {
 	uORB::DeviceNode *rc = nullptr;
 

--- a/src/modules/uORB/uORBDevices_nuttx.hpp
+++ b/src/modules/uORB/uORBDevices_nuttx.hpp
@@ -248,16 +248,30 @@ private: // private class methods.
 class uORB::DeviceMaster : public device::CDev
 {
 public:
+	virtual int   ioctl(struct file *filp, int cmd, unsigned long arg);
+
+	/**
+	 * Public interface for getDeviceNodeLocked(). Takes care of synchronization.
+	 * @return node if exists, nullptr otherwise
+	 */
+	uORB::DeviceNode *getDeviceNode(const char *node_name);
+
+private:
+	// Private constructor, uORB::Manager takes care of its creation
 	DeviceMaster(Flavor f);
 	virtual ~DeviceMaster();
 
 	friend class uORB::Manager;
 
-	static uORB::DeviceNode *GetDeviceNode(const char *node_name);
-	virtual int   ioctl(struct file *filp, int cmd, unsigned long arg);
-private:
+	/**
+	 * Find a node give its name.
+	 * _lock must already be held when calling this.
+	 * @return node if exists, nullptr otherwise
+	 */
+	uORB::DeviceNode *getDeviceNodeLocked(const char *node_name);
+
 	const Flavor  _flavor;
-	static ORBMap _node_map;
+	ORBMap _node_map;
 };
 
 

--- a/src/modules/uORB/uORBDevices_nuttx.hpp
+++ b/src/modules/uORB/uORBDevices_nuttx.hpp
@@ -179,6 +179,13 @@ public:
 	 */
 	int update_queue_size(unsigned int queue_size);
 
+	/**
+	 * Print statistics (nr of lost messages)
+	 * @param reset if true, reset statistics afterwards
+	 * @return true if printed something, false otherwise (if no lost messages)
+	 */
+	bool print_statistics(bool reset);
+
 protected:
 	virtual pollevent_t poll_state(struct file *filp);
 	virtual void poll_notify_one(struct pollfd *fds, pollevent_t events);
@@ -203,8 +210,6 @@ private:
 	bool _published;  /**< has ever data been published */
 	unsigned int _queue_size; /**< maximum number of elements in the queue */
 
-private: // private class methods.
-
 	static SubscriberData    *filp_to_sd(struct file *filp)
 	{
 		SubscriberData *sd = (SubscriberData *)(filp->f_priv);
@@ -213,6 +218,10 @@ private: // private class methods.
 
 	bool    _IsRemoteSubscriberPresent;
 	int32_t _subscriber_count;
+
+	//statistics
+	uint32_t _lost_messages = 0; ///< nr of lost messages for all subscribers. If two subscribers lose the same
+	///message, it is counted as two.
 
 	/**
 	 * Perform a deferred update for a rate-limited subscriber.
@@ -256,6 +265,12 @@ public:
 	 */
 	uORB::DeviceNode *getDeviceNode(const char *node_name);
 
+	/**
+	 * Print statistics for each existing topic.
+	 * @param reset if true, reset statistics afterwards
+	 */
+	void printStatistics(bool reset);
+
 private:
 	// Private constructor, uORB::Manager takes care of its creation
 	DeviceMaster(Flavor f);
@@ -272,6 +287,7 @@ private:
 
 	const Flavor  _flavor;
 	ORBMap _node_map;
+	hrt_abstime       _last_statistics_output;
 };
 
 

--- a/src/modules/uORB/uORBDevices_nuttx.hpp
+++ b/src/modules/uORB/uORBDevices_nuttx.hpp
@@ -45,6 +45,7 @@ namespace uORB
 {
 class DeviceNode;
 class DeviceMaster;
+class Manager;
 }
 
 /**
@@ -249,6 +250,8 @@ class uORB::DeviceMaster : public device::CDev
 public:
 	DeviceMaster(Flavor f);
 	virtual ~DeviceMaster();
+
+	friend class uORB::Manager;
 
 	static uORB::DeviceNode *GetDeviceNode(const char *node_name);
 	virtual int   ioctl(struct file *filp, int cmd, unsigned long arg);

--- a/src/modules/uORB/uORBDevices_posix.cpp
+++ b/src/modules/uORB/uORBDevices_posix.cpp
@@ -540,11 +540,17 @@ uORB::DeviceNode::print_statistics(bool reset)
 //-----------------------------------------------------------------------------
 void uORB::DeviceNode::add_internal_subscriber()
 {
-	_subscriber_count++;
 	uORBCommunicator::IChannel *ch = uORB::Manager::get_instance()->get_uorb_communicator();
 
+	lock();
+	_subscriber_count++;
+
 	if (ch != nullptr && _subscriber_count > 0) {
+		unlock(); //make sure we cannot deadlock if add_subscription calls back into DeviceNode
 		ch->add_subscription(_meta->o_name, 1);
+
+	} else {
+		unlock();
 	}
 }
 
@@ -552,11 +558,17 @@ void uORB::DeviceNode::add_internal_subscriber()
 //-----------------------------------------------------------------------------
 void uORB::DeviceNode::remove_internal_subscriber()
 {
-	_subscriber_count--;
 	uORBCommunicator::IChannel *ch = uORB::Manager::get_instance()->get_uorb_communicator();
 
+	lock();
+	_subscriber_count--;
+
 	if (ch != nullptr && _subscriber_count == 0) {
+		unlock(); //make sure we cannot deadlock if remove_subscription calls back into DeviceNode
 		ch->remove_subscription(_meta->o_name);
+
+	} else {
+		unlock();
 	}
 }
 

--- a/src/modules/uORB/uORBDevices_posix.cpp
+++ b/src/modules/uORB/uORBDevices_posix.cpp
@@ -44,8 +44,6 @@
 #include <px4_sem.hpp>
 #include <stdlib.h>
 
-std::map<std::string, uORB::DeviceNode *> uORB::DeviceMaster::_node_map;
-
 
 uORB::DeviceNode::SubscriberData  *uORB::DeviceNode::filp_to_sd(device::file_t *filp)
 {
@@ -710,7 +708,7 @@ uORB::DeviceMaster::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 					if (ret == -EEXIST) {
 						/* if the node exists already, get the existing one and check if
 						 * something has been published yet. */
-						uORB::DeviceNode *existing_node = GetDeviceNode(devpath);
+						uORB::DeviceNode *existing_node = getDeviceNodeLocked(devpath);
 
 						if ((existing_node != nullptr) && !(existing_node->is_published())) {
 							/* nothing has been published yet, lets claim it */
@@ -748,7 +746,17 @@ uORB::DeviceMaster::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 	}
 }
 
-uORB::DeviceNode *uORB::DeviceMaster::GetDeviceNode(const char *nodepath)
+uORB::DeviceNode *uORB::DeviceMaster::getDeviceNode(const char *nodepath)
+{
+	lock();
+	uORB::DeviceNode *node = getDeviceNodeLocked(nodepath);
+	unlock();
+	//We can safely return the node that can be used by any thread, because
+	//a DeviceNode never gets deleted.
+	return node;
+}
+
+uORB::DeviceNode *uORB::DeviceMaster::getDeviceNodeLocked(const char *nodepath)
 {
 	uORB::DeviceNode *rc = nullptr;
 	std::string np(nodepath);

--- a/src/modules/uORB/uORBDevices_posix.cpp
+++ b/src/modules/uORB/uORBDevices_posix.cpp
@@ -200,6 +200,7 @@ uORB::DeviceNode::read(device::file_t *filp, char *buffer, size_t buflen)
 
 	if (_generation > sd->generation + _queue_size) {
 		/* Reader is too far behind: some messages are lost */
+		_lost_messages += _generation - (sd->generation + _queue_size);
 		sd->generation = _generation - _queue_size;
 	}
 
@@ -514,6 +515,27 @@ uORB::DeviceNode::update_deferred_trampoline(void *arg)
 	node->update_deferred();
 }
 
+bool
+uORB::DeviceNode::print_statistics(bool reset)
+{
+	if (!_lost_messages) {
+		return false;
+	}
+
+	lock();
+	//This can be wrong: if a reader never reads, _lost_messages will not be increased either
+	uint32_t lost_messages = _lost_messages;
+
+	if (reset) {
+		_lost_messages = 0;
+	}
+
+	unlock();
+
+	PX4_INFO("%s: %i", _meta->o_name, lost_messages);
+	return true;
+}
+
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 void uORB::DeviceNode::add_internal_subscriber()
@@ -618,7 +640,7 @@ uORB::DeviceMaster::DeviceMaster(Flavor f) :
 {
 	// enable debug() calls
 	//_debug_enabled = true;
-
+	_last_statistics_output = hrt_absolute_time();
 }
 
 uORB::DeviceMaster::~DeviceMaster()
@@ -743,6 +765,31 @@ uORB::DeviceMaster::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 	default:
 		/* give it to the superclass */
 		return VDev::ioctl(filp, cmd, arg);
+	}
+}
+
+void uORB::DeviceMaster::printStatistics(bool reset)
+{
+	hrt_abstime current_time = hrt_absolute_time();
+	PX4_INFO("Statistics, since last output (%i ms):",
+		 (int)((current_time - _last_statistics_output) / 1000));
+	_last_statistics_output = current_time;
+
+	PX4_INFO("TOPIC, NR LOST MSGS");
+
+	lock();
+	bool had_print = false;
+
+	for (const auto &node : _node_map) {
+		if (node.second->print_statistics(reset)) {
+			had_print = true;
+		}
+	}
+
+	unlock();
+
+	if (!had_print) {
+		PX4_INFO("No lost messages");
 	}
 }
 

--- a/src/modules/uORB/uORBDevices_posix.hpp
+++ b/src/modules/uORB/uORBDevices_posix.hpp
@@ -43,6 +43,7 @@ namespace uORB
 {
 class DeviceNode;
 class DeviceMaster;
+class Manager;
 }
 
 class uORB::DeviceNode : public device::VDev
@@ -183,6 +184,8 @@ class uORB::DeviceMaster : public device::VDev
 public:
 	DeviceMaster(Flavor f);
 	virtual ~DeviceMaster();
+
+	friend class uORB::Manager;
 
 	static uORB::DeviceNode *GetDeviceNode(const char *node_name);
 

--- a/src/modules/uORB/uORBDevices_posix.hpp
+++ b/src/modules/uORB/uORBDevices_posix.hpp
@@ -116,6 +116,13 @@ public:
 	 */
 	int update_queue_size(unsigned int queue_size);
 
+	/**
+	 * Print statistics (nr of lost messages)
+	 * @param reset if true, reset statistics afterwards
+	 * @return true if printed something, false otherwise (if no lost messages)
+	 */
+	bool print_statistics(bool reset);
+
 protected:
 	virtual pollevent_t poll_state(device::file_t *filp);
 	virtual void    poll_notify_one(px4_pollfd_struct_t *fds, pollevent_t events);
@@ -144,6 +151,10 @@ private:
 	static SubscriberData    *filp_to_sd(device::file_t *filp);
 
 	int32_t _subscriber_count;
+
+	//statistics
+	uint32_t _lost_messages = 0; ///< nr of lost messages for all subscribers. If two subscribers lose the same
+	///message, it is counted as two.
 
 	/**
 	 * Perform a deferred update for a rate-limited subscriber.
@@ -190,6 +201,12 @@ public:
 	 */
 	uORB::DeviceNode *getDeviceNode(const char *node_name);
 
+	/**
+	 * Print statistics for each existing topic.
+	 * @param reset if true, reset statistics afterwards
+	 */
+	void printStatistics(bool reset);
+
 private:
 	// Private constructor, uORB::Manager takes care of its creation
 	DeviceMaster(Flavor f);
@@ -206,6 +223,7 @@ private:
 
 	const Flavor      _flavor;
 	std::map<std::string, uORB::DeviceNode *> _node_map;
+	hrt_abstime       _last_statistics_output;
 };
 
 #endif /* _uORBDeviceNode_posix.hpp */

--- a/src/modules/uORB/uORBDevices_posix.hpp
+++ b/src/modules/uORB/uORBDevices_posix.hpp
@@ -182,17 +182,30 @@ private:
 class uORB::DeviceMaster : public device::VDev
 {
 public:
+	virtual int   ioctl(device::file_t *filp, int cmd, unsigned long arg);
+
+	/**
+	 * Public interface for getDeviceNodeLocked(). Takes care of synchronization.
+	 * @return node if exists, nullptr otherwise
+	 */
+	uORB::DeviceNode *getDeviceNode(const char *node_name);
+
+private:
+	// Private constructor, uORB::Manager takes care of its creation
 	DeviceMaster(Flavor f);
 	virtual ~DeviceMaster();
 
 	friend class uORB::Manager;
 
-	static uORB::DeviceNode *GetDeviceNode(const char *node_name);
+	/**
+	 * Find a node give its name.
+	 * _lock must already be held when calling this.
+	 * @return node if exists, nullptr otherwise
+	 */
+	uORB::DeviceNode *getDeviceNodeLocked(const char *node_name);
 
-	virtual int   ioctl(device::file_t *filp, int cmd, unsigned long arg);
-private:
 	const Flavor      _flavor;
-	static std::map<std::string, uORB::DeviceNode *> _node_map;
+	std::map<std::string, uORB::DeviceNode *> _node_map;
 };
 
 #endif /* _uORBDeviceNode_posix.hpp */

--- a/src/modules/uORB/uORBMain.cpp
+++ b/src/modules/uORB/uORBMain.cpp
@@ -72,18 +72,10 @@ uorb_main(int argc, char *argv[])
 		}
 
 		/* create the driver */
-		g_dev = new uORB::DeviceMaster(uORB::PUBSUB);
+		g_dev = uORB::Manager::get_instance()->get_device_master(uORB::PUBSUB);
 
 		if (g_dev == nullptr) {
-			PX4_ERR("driver alloc failed");
-			return -ENOMEM;
-		}
-
-		if (OK != g_dev->init()) {
-			PX4_ERR("driver init failed");
-			delete g_dev;
-			g_dev = nullptr;
-			return -EIO;
+			return -errno;
 		}
 
 		return OK;

--- a/src/modules/uORB/uORBMain.cpp
+++ b/src/modules/uORB/uORBMain.cpp
@@ -86,7 +86,7 @@ uorb_main(int argc, char *argv[])
 	 */
 	if (!strcmp(argv[1], "status")) {
 		if (g_dev != nullptr) {
-			PX4_INFO("uorb is running");
+			g_dev->printStatistics(true);
 
 		} else {
 			PX4_INFO("uorb is not running");

--- a/src/modules/uORB/uORBManager.cpp
+++ b/src/modules/uORB/uORBManager.cpp
@@ -385,10 +385,10 @@ int16_t uORB::Manager::process_add_subscription(const char *messageName,
 	_remote_subscriber_topics.insert(messageName);
 	char nodepath[orb_maxpath];
 	int ret = uORB::Utils::node_mkpath(nodepath, PUBSUB, messageName);
+	DeviceMaster *device_master = get_device_master(PUBSUB);
 
-	if (ret == OK) {
-		// get the node name.
-		uORB::DeviceNode *node = uORB::DeviceMaster::GetDeviceNode(nodepath);
+	if (ret == OK && device_master) {
+		uORB::DeviceNode *node = device_master->getDeviceNode(nodepath);
 
 		if (node == nullptr) {
 			warnx("[posix-uORB::Manager::process_add_subscription(%d)]DeviceNode(%s) not created yet",
@@ -417,9 +417,10 @@ int16_t uORB::Manager::process_remove_subscription(
 	_remote_subscriber_topics.erase(messageName);
 	char nodepath[orb_maxpath];
 	int ret = uORB::Utils::node_mkpath(nodepath, PUBSUB, messageName);
+	DeviceMaster *device_master = get_device_master(PUBSUB);
 
-	if (ret == OK) {
-		uORB::DeviceNode *node = uORB::DeviceMaster::GetDeviceNode(nodepath);
+	if (ret == OK && device_master) {
+		uORB::DeviceNode *node = device_master->getDeviceNode(nodepath);
 
 		// get the node name.
 		if (node == nullptr) {
@@ -446,9 +447,10 @@ int16_t uORB::Manager::process_received_message(const char *messageName,
 	int16_t rc = -1;
 	char nodepath[orb_maxpath];
 	int ret = uORB::Utils::node_mkpath(nodepath, PUBSUB, messageName);
+	DeviceMaster *device_master = get_device_master(PUBSUB);
 
-	if (ret == OK) {
-		uORB::DeviceNode *node = uORB::DeviceMaster::GetDeviceNode(nodepath);
+	if (ret == OK && device_master) {
+		uORB::DeviceNode *node = device_master->getDeviceNode(nodepath);
 
 		// get the node name.
 		if (node == nullptr) {

--- a/src/modules/uORB/uORBManager.cpp
+++ b/src/modules/uORB/uORBManager.cpp
@@ -63,6 +63,41 @@ bool uORB::Manager::initialize()
 uORB::Manager::Manager()
 	: _comm_channel(nullptr)
 {
+	for (int i = 0; i < Flavor_count; ++i) {
+		_device_masters[i] = nullptr;
+	}
+}
+uORB::Manager::~Manager()
+{
+	for (int i = 0; i < Flavor_count; ++i) {
+		if (_device_masters[i]) {
+			delete _device_masters[i];
+		}
+	}
+}
+
+uORB::DeviceMaster *uORB::Manager::get_device_master(Flavor flavor)
+{
+	if (!_device_masters[flavor]) {
+		_device_masters[flavor] = new DeviceMaster(flavor);
+
+		if (_device_masters[flavor]) {
+			int ret = _device_masters[flavor]->init();
+
+			if (ret != PX4_OK) {
+				PX4_ERR("Initialization of DeviceMaster failed (%i)", ret);
+				errno = -ret;
+				delete _device_masters[flavor];
+				_device_masters[flavor] = nullptr;
+			}
+
+		} else {
+			PX4_ERR("Failed to allocate DeviceMaster");
+			errno = ENOMEM;
+		}
+	}
+
+	return _device_masters[flavor];
 }
 
 int uORB::Manager::orb_exists(const struct orb_metadata *meta, int instance)

--- a/src/modules/uORB/uORBManager.hpp
+++ b/src/modules/uORB/uORBManager.hpp
@@ -78,6 +78,14 @@ public:
 		return _Instance;
 	}
 
+	/**
+	 * Get the DeviceMaster for a given Flavor. If it does not exist,
+	 * it will be created and initialized.
+	 * Note: the first call to this is not thread-safe.
+	 * @return nullptr if initialization failed (and errno will be set)
+	 */
+	uORB::DeviceMaster *get_device_master(Flavor flavor);
+
 	// ==== uORB interface methods ====
 	/**
 	 * Advertise as the publisher of a topic.
@@ -387,8 +395,11 @@ private: // data members
 	uORBCommunicator::IChannel *_comm_channel;
 	ORBSet _remote_subscriber_topics;
 
+	DeviceMaster *_device_masters[Flavor_count]; ///< Allow at most one DeviceMaster per Flavor
+
 private: //class methods
 	Manager();
+	~Manager();
 
 	/**
 	   * Interface to process a received AddSubscription from remote.

--- a/src/modules/uORB/uORB_tests/uORBTest_UnitTest.cpp
+++ b/src/modules/uORB/uORB_tests/uORBTest_UnitTest.cpp
@@ -199,7 +199,7 @@ int uORBTest::UnitTest::test_unadvertise()
 	struct orb_test t;
 
 	for (int i = 0; i < 4; ++i) {
-		_pfd[i] = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance_test[i], ORB_PRIO_MAX);
+		_pfd[i] = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance_test[i], ORB_PRIO_MAX, 1);
 
 		if (instance_test[i] != i) {
 			return test_fail("got wrong instance (should be %i, is %i)", i, instance_test[i]);
@@ -229,7 +229,7 @@ int uORBTest::UnitTest::test_single()
 	bool updated;
 
 	t.val = 0;
-	ptopic = orb_advertise(ORB_ID(orb_test), &t);
+	ptopic = orb_advertise(ORB_ID(orb_test), &t, 1);
 
 	if (ptopic == nullptr) {
 		return test_fail("advertise failed: %d", errno);
@@ -303,12 +303,12 @@ int uORBTest::UnitTest::test_multi()
 	struct orb_test t, u;
 	t.val = 0;
 	int instance0;
-	_pfd[0] = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance0, ORB_PRIO_MAX);
+	_pfd[0] = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance0, ORB_PRIO_MAX, 1);
 
 	test_note("advertised");
 
 	int instance1;
-	_pfd[1] = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance1, ORB_PRIO_MIN);
+	_pfd[1] = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance1, ORB_PRIO_MIN, 1);
 
 	if (instance0 != 0) {
 		return test_fail("mult. id0: %d", instance0);
@@ -401,7 +401,7 @@ int uORBTest::UnitTest::pub_test_multi2_main()
 		orb_advert_t &pub = orb_pub[i];
 		int idx = i;
 //		PX4_WARN("advertise %i, t=%" PRIu64, i, hrt_absolute_time());
-		pub = orb_advertise_multi(ORB_ID(orb_test_medium_multi), &data_topic, &idx, ORB_PRIO_DEFAULT);
+		pub = orb_advertise_multi(ORB_ID(orb_test_medium_multi), &data_topic, &idx, ORB_PRIO_DEFAULT, 1);
 
 		if (idx != i) {
 			_thread_should_exit = true;
@@ -519,11 +519,11 @@ int uORBTest::UnitTest::test_multi_reversed()
 
 	int instance2;
 
-	_pfd[2] = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance2, ORB_PRIO_MAX);
+	_pfd[2] = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance2, ORB_PRIO_MAX, 1);
 
 	int instance3;
 
-	_pfd[3] = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance3, ORB_PRIO_MIN);
+	_pfd[3] = orb_advertise_multi(ORB_ID(orb_multitest), &t, &instance3, ORB_PRIO_MIN, 1);
 
 	test_note("advertised");
 
@@ -589,7 +589,7 @@ int uORBTest::UnitTest::test_queue()
 
 	const unsigned int queue_size = 11;
 	t.val = 0;
-	ptopic = orb_advertise_queue(ORB_ID(orb_test_medium_queue), &t, queue_size);
+	ptopic = orb_advertise(ORB_ID(orb_test_medium_queue), &t, queue_size);
 
 	if (ptopic == nullptr) {
 		return test_fail("advertise failed: %d", errno);
@@ -697,7 +697,7 @@ int uORBTest::UnitTest::pub_test_queue_main()
 	const unsigned int queue_size = 50;
 	t.val = 0;
 
-	if ((ptopic = orb_advertise_queue(ORB_ID(orb_test_medium_queue_poll), &t, queue_size)) == nullptr) {
+	if ((ptopic = orb_advertise(ORB_ID(orb_test_medium_queue_poll), &t, queue_size)) == nullptr) {
 		_thread_should_exit = true;
 		return test_fail("advertise failed: %d", errno);
 	}

--- a/src/modules/uORB/uORB_tests/uORBTest_UnitTest.hpp
+++ b/src/modules/uORB/uORB_tests/uORBTest_UnitTest.hpp
@@ -131,7 +131,7 @@ int uORBTest::UnitTest::latency_test(orb_id_t T, bool print)
 	t.val = 308;
 	t.time = hrt_absolute_time();
 
-	orb_advert_t pfd0 = orb_advertise(T, &t);
+	orb_advert_t pfd0 = orb_advertise(T, &t, 1);
 
 	char *const args[1] = { NULL };
 

--- a/src/modules/uavcan/actuators/esc.cpp
+++ b/src/modules/uavcan/actuators/esc.cpp
@@ -194,6 +194,6 @@ void UavcanEscController::orb_pub_timer_cb(const uavcan::TimerEvent &)
 		(void)orb_publish(ORB_ID(esc_status), _esc_status_pub, &_esc_status);
 
 	} else {
-		_esc_status_pub = orb_advertise(ORB_ID(esc_status), &_esc_status);
+		_esc_status_pub = orb_advertise(ORB_ID(esc_status), &_esc_status, ORB_DEFAULT_QUEUE_SIZE);
 	}
 }

--- a/src/modules/uavcan/sensors/gnss.cpp
+++ b/src/modules/uavcan/sensors/gnss.cpp
@@ -181,7 +181,7 @@ void UavcanGnssBridge::gnss_fix_sub_cb(const uavcan::ReceivedDataStructure<uavca
 		orb_publish(ORB_ID(vehicle_gps_position), _report_pub, &report);
 
 	} else {
-		_report_pub = orb_advertise(ORB_ID(vehicle_gps_position), &report);
+		_report_pub = orb_advertise(ORB_ID(vehicle_gps_position), &report, ORB_DEFAULT_QUEUE_SIZE);
 	}
 
 }

--- a/src/modules/uavcan/sensors/sensor_bridge.cpp
+++ b/src/modules/uavcan/sensors/sensor_bridge.cpp
@@ -120,7 +120,7 @@ void UavcanCDevSensorBridgeBase::publish(const int node_id, const void *report)
 		channel->node_id        = node_id;
 		channel->class_instance = class_instance;
 
-		channel->orb_advert = orb_advertise_multi(_orb_topic, report, &channel->orb_instance, ORB_PRIO_HIGH);
+		channel->orb_advert = orb_advertise_multi(_orb_topic, report, &channel->orb_instance, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 		if (channel->orb_advert == nullptr) {
 			DEVICE_LOG("ADVERTISE FAILED");
 			(void)unregister_class_devname(_class_devname, class_instance);

--- a/src/modules/uavcan/uavcan_servers.cpp
+++ b/src/modules/uavcan/uavcan_servers.cpp
@@ -633,7 +633,7 @@ void UavcanServers::cb_getset(const uavcan::ServiceCallResult<uavcan::protocol::
 			}
 
 			if (_param_response_pub == nullptr) {
-				_param_response_pub = orb_advertise(ORB_ID(uavcan_parameter_value), &response);
+				_param_response_pub = orb_advertise(ORB_ID(uavcan_parameter_value), &response, ORB_DEFAULT_QUEUE_SIZE);
 			} else {
 				orb_publish(ORB_ID(uavcan_parameter_value), _param_response_pub, &response);
 			}

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -600,7 +600,7 @@ void VtolAttitudeControl::publish_att_sp()
 
 	} else {
 		/* advertise and publish */
-		_v_att_sp_pub = orb_advertise(ORB_ID(vehicle_attitude_setpoint), &_v_att_sp);
+		_v_att_sp_pub = orb_advertise(ORB_ID(vehicle_attitude_setpoint), &_v_att_sp, ORB_DEFAULT_QUEUE_SIZE);
 	}
 }
 
@@ -662,7 +662,7 @@ void VtolAttitudeControl::task_main()
 
 		} else {
 			_vtol_vehicle_status.timestamp = hrt_absolute_time();
-			_vtol_vehicle_status_pub = orb_advertise(ORB_ID(vtol_vehicle_status), &_vtol_vehicle_status);
+			_vtol_vehicle_status_pub = orb_advertise(ORB_ID(vtol_vehicle_status), &_vtol_vehicle_status, ORB_DEFAULT_QUEUE_SIZE);
 		}
 
 		/* wait for up to 100ms for data */
@@ -796,14 +796,14 @@ void VtolAttitudeControl::task_main()
 				orb_publish(ORB_ID(actuator_controls_0), _actuators_0_pub, &_actuators_out_0);
 
 			} else {
-				_actuators_0_pub = orb_advertise(ORB_ID(actuator_controls_0), &_actuators_out_0);
+				_actuators_0_pub = orb_advertise(ORB_ID(actuator_controls_0), &_actuators_out_0, ORB_DEFAULT_QUEUE_SIZE);
 			}
 
 			if (_actuators_1_pub != nullptr) {
 				orb_publish(ORB_ID(actuator_controls_1), _actuators_1_pub, &_actuators_out_1);
 
 			} else {
-				_actuators_1_pub = orb_advertise(ORB_ID(actuator_controls_1), &_actuators_out_1);
+				_actuators_1_pub = orb_advertise(ORB_ID(actuator_controls_1), &_actuators_out_1, ORB_DEFAULT_QUEUE_SIZE);
 			}
 		}
 
@@ -812,7 +812,7 @@ void VtolAttitudeControl::task_main()
 			orb_publish(ORB_ID(vehicle_rates_setpoint), _v_rates_sp_pub, &_v_rates_sp);
 
 		} else {
-			_v_rates_sp_pub = orb_advertise(ORB_ID(vehicle_rates_setpoint), &_v_rates_sp);
+			_v_rates_sp_pub = orb_advertise(ORB_ID(vehicle_rates_setpoint), &_v_rates_sp, ORB_DEFAULT_QUEUE_SIZE);
 		}
 	}
 

--- a/src/platforms/posix/drivers/accelsim/accelsim.cpp
+++ b/src/platforms/posix/drivers/accelsim/accelsim.cpp
@@ -358,7 +358,7 @@ ACCELSIM::init()
 
 	/* measurement will have generated a report, publish */
 	_mag->_mag_topic = orb_advertise_multi(ORB_ID(sensor_mag), &mrp,
-					       &_mag->_mag_orb_class_instance, ORB_PRIO_LOW);
+					       &_mag->_mag_orb_class_instance, ORB_PRIO_LOW, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_mag->_mag_topic == nullptr) {
 		PX4_WARN("ADVERT ERR");
@@ -369,7 +369,7 @@ ACCELSIM::init()
 
 	/* measurement will have generated a report, publish */
 	_accel_topic = orb_advertise_multi(ORB_ID(sensor_accel), &arp,
-					   &_accel_orb_class_instance, ORB_PRIO_DEFAULT);
+					   &_accel_orb_class_instance, ORB_PRIO_DEFAULT, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_accel_topic == nullptr) {
 		PX4_WARN("ADVERT ERR");

--- a/src/platforms/posix/drivers/airspeedsim/airspeedsim.cpp
+++ b/src/platforms/posix/drivers/airspeedsim/airspeedsim.cpp
@@ -146,7 +146,7 @@ AirspeedSim::init()
 		_reports->get(&arp);
 
 		/* measurement will have generated a report, publish */
-		_airspeed_pub = orb_advertise(ORB_ID(differential_pressure), &arp);
+		_airspeed_pub = orb_advertise(ORB_ID(differential_pressure), &arp, ORB_DEFAULT_QUEUE_SIZE);
 
 		if (_airspeed_pub == nullptr) {
 			PX4_WARN("uORB started?");
@@ -381,7 +381,7 @@ AirspeedSim::update_status()
 			orb_publish(ORB_ID(subsystem_info), _subsys_pub, &info);
 
 		} else {
-			_subsys_pub = orb_advertise(ORB_ID(subsystem_info), &info);
+			_subsys_pub = orb_advertise(ORB_ID(subsystem_info), &info, ORB_DEFAULT_QUEUE_SIZE);
 		}
 
 		_last_published_sensor_ok = _sensor_ok;

--- a/src/platforms/posix/drivers/barosim/baro.cpp
+++ b/src/platforms/posix/drivers/barosim/baro.cpp
@@ -257,7 +257,7 @@ BAROSIM::init()
 	_reports->flush();
 
 	_baro_topic = orb_advertise_multi(ORB_ID(sensor_baro), &brp,
-					  &_orb_class_instance, (is_external()) ? ORB_PRIO_HIGH : ORB_PRIO_DEFAULT);
+					  &_orb_class_instance, (is_external()) ? ORB_PRIO_HIGH : ORB_PRIO_DEFAULT, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_baro_topic == nullptr) {
 		PX4_ERR("failed to create sensor_baro publication");

--- a/src/platforms/posix/drivers/df_bmp280_wrapper/df_bmp280_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_bmp280_wrapper/df_bmp280_wrapper.cpp
@@ -118,7 +118,7 @@ int DfBmp280Wrapper::start()
 	// TODO: don't publish garbage here
 	baro_report baro_report = {};
 	_baro_topic = orb_advertise_multi(ORB_ID(sensor_baro), &baro_report,
-					  &_baro_orb_class_instance, ORB_PRIO_DEFAULT);
+					  &_baro_orb_class_instance, ORB_PRIO_DEFAULT, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_baro_topic == nullptr) {
 		PX4_ERR("sensor_baro advert fail");

--- a/src/platforms/posix/drivers/df_hmc5883_wrapper/df_hmc5883_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_hmc5883_wrapper/df_hmc5883_wrapper.cpp
@@ -305,7 +305,7 @@ int DfHmc9250Wrapper::_publish(struct mag_sensor_data &data)
 
 		if (_mag_topic == nullptr) {
 			_mag_topic = orb_advertise_multi(ORB_ID(sensor_mag), &mag_report,
-							 &_mag_orb_class_instance, ORB_PRIO_HIGH);
+							 &_mag_orb_class_instance, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 
 		} else {
 			orb_publish(ORB_ID(sensor_mag), _mag_topic, &mag_report);

--- a/src/platforms/posix/drivers/df_isl29501_wrapper/df_isl29501_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_isl29501_wrapper/df_isl29501_wrapper.cpp
@@ -121,7 +121,7 @@ int DfISL29501Wrapper::start()
 
 	struct distance_sensor_s d;
 	_range_topic = orb_advertise_multi(ORB_ID(distance_sensor), &d,
-					   &_orb_class_instance, ORB_PRIO_DEFAULT);
+					   &_orb_class_instance, ORB_PRIO_DEFAULT, ORB_DEFAULT_QUEUE_SIZE);
 
 	int ret;
 	ret = ISL29501::init();

--- a/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
@@ -248,7 +248,7 @@ int DfMpu9250Wrapper::start()
 	// TODO: don't publish garbage here
 	accel_report accel_report = {};
 	_accel_topic = orb_advertise_multi(ORB_ID(sensor_accel), &accel_report,
-					   &_accel_orb_class_instance, ORB_PRIO_DEFAULT);
+					   &_accel_orb_class_instance, ORB_PRIO_DEFAULT, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_accel_topic == nullptr) {
 		PX4_ERR("sensor_accel advert fail");
@@ -258,7 +258,7 @@ int DfMpu9250Wrapper::start()
 	// TODO: don't publish garbage here
 	gyro_report gyro_report = {};
 	_gyro_topic = orb_advertise_multi(ORB_ID(sensor_gyro), &gyro_report,
-					  &_gyro_orb_class_instance, ORB_PRIO_DEFAULT);
+					  &_gyro_orb_class_instance, ORB_PRIO_DEFAULT, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_gyro_topic == nullptr) {
 		PX4_ERR("sensor_gyro advert fail");
@@ -722,7 +722,7 @@ int DfMpu9250Wrapper::_publish(struct imu_sensor_data &data)
 
 			if (_mag_topic == nullptr) {
 				_mag_topic = orb_advertise_multi(ORB_ID(sensor_mag), &mag_report,
-								 &_mag_orb_class_instance, ORB_PRIO_LOW);
+								 &_mag_orb_class_instance, ORB_PRIO_LOW, ORB_DEFAULT_QUEUE_SIZE);
 
 			} else {
 				orb_publish(ORB_ID(sensor_mag), _mag_topic, &mag_report);

--- a/src/platforms/posix/drivers/df_trone_wrapper/df_trone_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_trone_wrapper/df_trone_wrapper.cpp
@@ -119,7 +119,7 @@ int DfTROneWrapper::start()
 {
 	struct distance_sensor_s d;
 	_range_topic = orb_advertise_multi(ORB_ID(distance_sensor), &d,
-					   &_orb_class_instance, ORB_PRIO_DEFAULT);
+					   &_orb_class_instance, ORB_PRIO_DEFAULT, ORB_DEFAULT_QUEUE_SIZE);
 
 	int ret;
 

--- a/src/platforms/posix/drivers/gpssim/gpssim.cpp
+++ b/src/platforms/posix/drivers/gpssim/gpssim.cpp
@@ -332,7 +332,7 @@ GPSSIM::task_main()
 					orb_publish(ORB_ID(vehicle_gps_position), _report_gps_pos_pub, &_report_gps_pos);
 
 				} else {
-					_report_gps_pos_pub = orb_advertise(ORB_ID(vehicle_gps_position), &_report_gps_pos);
+					_report_gps_pos_pub = orb_advertise(ORB_ID(vehicle_gps_position), &_report_gps_pos, ORB_DEFAULT_QUEUE_SIZE);
 				}
 			}
 
@@ -352,7 +352,7 @@ GPSSIM::task_main()
 					orb_publish(ORB_ID(vehicle_gps_position), _report_gps_pos_pub, &_report_gps_pos);
 
 				} else {
-					_report_gps_pos_pub = orb_advertise(ORB_ID(vehicle_gps_position), &_report_gps_pos);
+					_report_gps_pos_pub = orb_advertise(ORB_ID(vehicle_gps_position), &_report_gps_pos, ORB_DEFAULT_QUEUE_SIZE);
 				}
 			}
 
@@ -370,7 +370,7 @@ GPSSIM::task_main()
 							orb_publish(ORB_ID(satellite_info), _report_sat_info_pub, _p_report_sat_info);
 
 						} else {
-							_report_sat_info_pub = orb_advertise(ORB_ID(satellite_info), _p_report_sat_info);
+							_report_sat_info_pub = orb_advertise(ORB_ID(satellite_info), _p_report_sat_info, ORB_DEFAULT_QUEUE_SIZE);
 						}
 					}
 				}

--- a/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
+++ b/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
@@ -464,7 +464,7 @@ GYROSIM::init()
 
 	/* measurement will have generated a report, publish */
 	_accel_topic = orb_advertise_multi(ORB_ID(sensor_accel), &arp,
-					   &_accel_orb_class_instance, ORB_PRIO_HIGH);
+					   &_accel_orb_class_instance, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_accel_topic == nullptr) {
 		PX4_WARN("ADVERT FAIL");
@@ -478,7 +478,7 @@ GYROSIM::init()
 	_gyro_reports->get(&grp);
 
 	_gyro->_gyro_topic = orb_advertise_multi(ORB_ID(sensor_gyro), &grp,
-			     &_gyro->_gyro_orb_class_instance, ORB_PRIO_HIGH);
+			     &_gyro->_gyro_orb_class_instance, ORB_PRIO_HIGH, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_gyro->_gyro_topic == nullptr) {
 		PX4_WARN("ADVERT FAIL");

--- a/src/platforms/posix/tests/muorb/muorb_test_example.cpp
+++ b/src/platforms/posix/tests/muorb/muorb_test_example.cpp
@@ -58,14 +58,14 @@ int MuorbTestExample::main()
 int  MuorbTestExample::DefaultTest()
 {
 	int i = 0;
-	orb_advert_t pub_id = orb_advertise(ORB_ID(esc_status), & m_esc_status);
+	orb_advert_t pub_id = orb_advertise(ORB_ID(esc_status), & m_esc_status, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (pub_id == 0) {
 		PX4_ERR("error publishing esc_status");
 		return -1;
 	}
 
-	orb_advert_t pub_id_vc = orb_advertise(ORB_ID(vehicle_command), & m_vc);
+	orb_advert_t pub_id_vc = orb_advertise(ORB_ID(vehicle_command), & m_vc, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (pub_id_vc == 0) {
 		PX4_ERR("error publishing vehicle_command");
@@ -127,7 +127,7 @@ int  MuorbTestExample::DefaultTest()
 int MuorbTestExample::PingPongTest()
 {
 	int i = 0;
-	orb_advert_t pub_id_vc = orb_advertise(ORB_ID(vehicle_command), & m_vc);
+	orb_advert_t pub_id_vc = orb_advertise(ORB_ID(vehicle_command), & m_vc, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (pub_id_vc == 0) {
 		PX4_ERR("error publishing vehicle_command");

--- a/src/platforms/qurt/fc_addon/mpu_spi/mpu9x50_main.cpp
+++ b/src/platforms/qurt/fc_addon/mpu_spi/mpu9x50_main.cpp
@@ -372,7 +372,7 @@ bool create_pubs()
 	memset(&_mag, 0, sizeof(struct mag_report));
 
 	_gyro_pub = orb_advertise_multi(ORB_ID(sensor_gyro), &_gyro,
-					&_gyro_orb_class_instance, ORB_PRIO_HIGH - 1);
+					&_gyro_orb_class_instance, ORB_PRIO_HIGH - 1, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_gyro_pub == nullptr) {
 		PX4_ERR("sensor_gyro advert fail");
@@ -380,7 +380,7 @@ bool create_pubs()
 	}
 
 	_accel_pub = orb_advertise_multi(ORB_ID(sensor_accel), &_accel,
-					 &_accel_orb_class_instance, ORB_PRIO_HIGH - 1);
+					 &_accel_orb_class_instance, ORB_PRIO_HIGH - 1, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_accel_pub == nullptr) {
 		PX4_ERR("sensor_accel advert fail");
@@ -388,7 +388,7 @@ bool create_pubs()
 	}
 
 	_mag_pub = orb_advertise_multi(ORB_ID(sensor_mag), &_mag,
-				       &_mag_orb_class_instance, ORB_PRIO_HIGH - 1);
+				       &_mag_orb_class_instance, ORB_PRIO_HIGH - 1, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_mag_pub == nullptr) {
 		PX4_ERR("sensor_mag advert fail");

--- a/src/platforms/qurt/fc_addon/rc_receiver/rc_receiver_main.cpp
+++ b/src/platforms/qurt/fc_addon/rc_receiver/rc_receiver_main.cpp
@@ -187,7 +187,7 @@ void task_main(int argc, char *argv[])
 	// clear the rc_input report for topic advertise
 	memset(&_rc_in, 0, sizeof(struct input_rc_s));
 
-	_input_rc_pub = orb_advertise(ORB_ID(input_rc), &_rc_in);
+	_input_rc_pub = orb_advertise(ORB_ID(input_rc), &_rc_in, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (_input_rc_pub == nullptr) {
 		PX4_WARN("failed to advertise input_rc uorb topic. Quit!");

--- a/src/platforms/qurt/fc_addon/uart_esc/uart_esc_main.cpp
+++ b/src/platforms/qurt/fc_addon/uart_esc/uart_esc_main.cpp
@@ -386,7 +386,7 @@ void task_main(int argc, char *argv[])
 					orb_publish(ORB_ID(actuator_outputs), _outputs_pub, &_outputs);
 
 				} else {
-					_outputs_pub = orb_advertise(ORB_ID(actuator_outputs), &_outputs);
+					_outputs_pub = orb_advertise(ORB_ID(actuator_outputs), &_outputs, ORB_DEFAULT_QUEUE_SIZE);
 				}
 			}
 

--- a/src/platforms/qurt/tests/muorb/muorb_test_example.cpp
+++ b/src/platforms/qurt/tests/muorb/muorb_test_example.cpp
@@ -72,14 +72,14 @@ int MuorbTestExample::DefaultTest()
 	memset(&pwm, 0, sizeof(pwm_input_s));
 	memset(&sc, 0, sizeof(sensor_combined_s));
 	PX4_WARN("Successful after memset... ");
-	orb_advert_t pub_fd = orb_advertise(ORB_ID(pwm_input), &pwm);
+	orb_advert_t pub_fd = orb_advertise(ORB_ID(pwm_input), &pwm, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (pub_fd == nullptr) {
 		PX4_WARN("Error: advertizing  pwm_input topic");
 		return -1;
 	}
 
-	orb_advert_t pub_sc = orb_advertise(ORB_ID(sensor_combined), &sc);
+	orb_advert_t pub_sc = orb_advertise(ORB_ID(sensor_combined), &sc, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (pub_sc == nullptr) {
 		PX4_WARN("Error: advertizing  sensor_combined topic");
@@ -106,7 +106,7 @@ int MuorbTestExample::DefaultTest()
 int MuorbTestExample::PingPongTest()
 {
 	int i = 0;
-	orb_advert_t pub_id_esc_status = orb_advertise(ORB_ID(esc_status), & m_esc_status);
+	orb_advert_t pub_id_esc_status = orb_advertise(ORB_ID(esc_status), & m_esc_status, ORB_DEFAULT_QUEUE_SIZE);
 
 	if (pub_id_esc_status == 0) {
 		PX4_ERR("error publishing esc_status");

--- a/src/systemcmds/motor_test/motor_test.c
+++ b/src/systemcmds/motor_test/motor_test.c
@@ -75,7 +75,7 @@ void motor_test(unsigned channel, float value)
 
 	} else {
 		/* advertise and publish */
-		_test_motor_pub = orb_advertise(ORB_ID(test_motor), &_test_motor);
+		_test_motor_pub = orb_advertise(ORB_ID(test_motor), &_test_motor, ORB_DEFAULT_QUEUE_SIZE);
 	}
 }
 

--- a/unittests/uorb_stub.cpp
+++ b/unittests/uorb_stub.cpp
@@ -10,7 +10,7 @@
  * TODO: use googlemock
 ******************************************/
 
-orb_advert_t orb_advertise(const struct orb_metadata *meta, const void *data)
+orb_advert_t orb_advertise(const struct orb_metadata *meta, const void *data, unsigned int queue_size)
 {
 	return (orb_advert_t)0;
 }


### PR DESCRIPTION
This brings the second part of uORB queuing.

`uorb status` now outputs information about number of lost/dropped messages (as the sum from all subscribers).
It adds a macro `ORB_DEFAULT_QUEUE_SIZE` in `uORB.h` that can be changed to test different queue sizes (it currently applies to all publishers). I think we could add classes with different queue sizes, like `ORB_SENSORS_QUEUE_SIZE`, `ORB_COMMANDS_QUEUE_SIZE` etc.

I got the following test results on Pixracer, QGC connected:
```
- queue length=1:
  - free mem: 24288
INFO  Statistics, since last output (2690 ms):
INFO  TOPIC, NR LOST MSGS
INFO  sensor_mag: 20
INFO  system_power: 36
INFO  actuator_controls_0: 3447
INFO  sensor_combined: 2894
INFO  actuator_armed: 20
INFO  vehicle_local_position: 4695
INFO  vehicle_attitude: 3388
INFO  cpuload: 2
INFO  vehicle_attitude_setpoint: 2453
INFO  vehicle_rates_setpoint: 2453
INFO  actuator_outputs: 3314
INFO  estimator_status: 3618
INFO  control_state: 536

- queue length=3:
  - free mem: 19456
INFO  Statistics, since last output (2797 ms):
INFO  TOPIC, NR LOST MSGS
INFO  system_power: 40
INFO  actuator_controls_0: 3717
INFO  sensor_combined: 3091
INFO  actuator_armed: 18
INFO  vehicle_local_position: 5295
INFO  vehicle_attitude: 3549
INFO  cpuload: 9
INFO  vehicle_attitude_setpoint: 2896
INFO  vehicle_rates_setpoint: 2896
INFO  actuator_outputs: 4657
INFO  estimator_status: 3622
INFO  control_state: 564

- queue length=6:
  - free mem: 12576
INFO  Statistics, since last output (2698 ms):
INFO  TOPIC, NR LOST MSGS
INFO  system_power: 36
INFO  actuator_controls_0: 3464
INFO  sensor_combined: 2842
INFO  actuator_armed: 17
INFO  vehicle_local_position: 4853
INFO  vehicle_attitude: 3440
INFO  cpuload: 7
INFO  vehicle_attitude_setpoint: 2641
INFO  vehicle_rates_setpoint: 2641
INFO  actuator_outputs: 4634
INFO  estimator_status: 3620
INFO  control_state: 549
```
So increasing the queue size by 1 adds about 2.3 kB RAM. But the numbers about lost messages are not really conclusive. They indicate that a subscriber constantly reads with a lower rate than the publisher (and queuing does not help for this). For some topics, the numbers are really high, so it might be worth investigating on these.