### PR TITLE
Fixes Function signature MPU9250

### DIFF
--- a/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
@@ -760,7 +760,7 @@ namespace df_mpu9250_wrapper
 
 DfMpu9250Wrapper *g_dev = nullptr;
 
-int start(enum Rotation rotation);
+int start(bool mag_enabled, enum Rotation rotation);
 int stop();
 int info();
 void usage();


### PR DESCRIPTION
Build was failing due to incorrect function signature for MPU9250 wrapper.

Related to https://github.com/PX4/DriverFramework/pull/102