### PR TITLE
Enable FW without airspeed sensor

### DIFF
--- a/msg/control_state.msg
+++ b/msg/control_state.msg
@@ -1,4 +1,8 @@
 # This is similar to the mavlink message CONTROL_SYSTEM_STATE, but for onboard use */
+uint8 AIRSPD_MODE_MEAS = 0	# airspeed is measured airspeed from sensor
+uint8 AIRSPD_MODE_EST = 1	# airspeed is estimated by body velocity
+uint8 AIRSPD_MODE_DISABLED = 2	# airspeed is disabled
+
 float32 x_acc			# X acceleration in body frame
 float32 y_acc			# Y acceleration in body frame
 float32 z_acc			# Z acceleration in body frame

--- a/msg/position_setpoint.msg
+++ b/msg/position_setpoint.msg
@@ -37,3 +37,4 @@ bool acceleration_valid		# true if acceleration setpoint is valid/should be used
 bool acceleration_is_force	# interprete acceleration as force
 float32 acceptance_radius   # navigation acceptance_radius if we're doing waypoint navigation
 float32 cruising_speed		# the generally desired cruising speed (not a hard constraint)
+float32 cruising_throttle	# the generally desired cruising throttle (not a hard constraint)

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -141,6 +141,7 @@ private:
 		param_t	bias_max;
 		param_t vibe_thresh;
 		param_t	ext_hdg_mode;
+		param_t airspeed_mode;
 	}		_params_handles;		/**< handles for interesting parameters */
 
 	float		_w_accel = 0.0f;
@@ -154,6 +155,7 @@ private:
 	float		_vibration_warning_threshold = 2.0f;
 	hrt_abstime	_vibration_warning_timestamp = 0;
 	int		_ext_hdg_mode = 0;
+	int 	_airspeed_mode = 0;
 
 	Vector<3>	_gyro;
 	Vector<3>	_accel;
@@ -232,6 +234,7 @@ AttitudeEstimatorQ::AttitudeEstimatorQ() :
 	_params_handles.bias_max	= param_find("ATT_BIAS_MAX");
 	_params_handles.vibe_thresh	= param_find("ATT_VIBE_THRESH");
 	_params_handles.ext_hdg_mode	= param_find("ATT_EXT_HDG_M");
+	_params_handles.airspeed_mode = param_find("FW_ARSP_MODE");
 }
 
 /**
@@ -626,14 +629,25 @@ void AttitudeEstimatorQ::task_main()
 
 			ctrl_state.yaw_rate = _lp_yaw_rate.apply(_rates(2));
 
-			/* Airspeed - take airspeed measurement directly here as no wind is estimated */
-			if (PX4_ISFINITE(_airspeed.indicated_airspeed_m_s) && hrt_absolute_time() - _airspeed.timestamp < 1e6
-			    && _airspeed.timestamp > 0) {
-				ctrl_state.airspeed = _airspeed.indicated_airspeed_m_s;
-				ctrl_state.airspeed_valid = true;
+			ctrl_state.airspeed_valid = false;
 
+			// use estimated velocity for airspeed estimate
+			if (_airspeed_mode == 1) {
+				if (hrt_absolute_time() - _gpos.timestamp < 1e6) {
+					ctrl_state.airspeed = sqrtf(_gpos.vel_n * _gpos.vel_n + _gpos.vel_e * _gpos.vel_e +_gpos.vel_d * _gpos.vel_d);
+				}
+			// do nothing, airspeed has been declared as non-valid above, controllers will handle this assuming always trim airspeed	
+			} else if (_airspeed_mode == 2) {
+
+			// use the measured airspeed
 			} else {
-				ctrl_state.airspeed_valid = false;
+				/* Airspeed - take airspeed measurement directly here as no wind is estimated */
+				if (PX4_ISFINITE(_airspeed.indicated_airspeed_m_s) && hrt_absolute_time() - _airspeed.timestamp < 1e6
+				    && _airspeed.timestamp > 0) {
+					ctrl_state.airspeed = _airspeed.indicated_airspeed_m_s;
+					ctrl_state.airspeed_valid = true;
+
+				}
 			}
 
 			/* the instance count is not used here */
@@ -688,6 +702,7 @@ void AttitudeEstimatorQ::update_parameters(bool force)
 		param_get(_params_handles.bias_max, &_bias_max);
 		param_get(_params_handles.vibe_thresh, &_vibration_warning_threshold);
 		param_get(_params_handles.ext_hdg_mode, &_ext_hdg_mode);
+		param_get(_params_handles.airspeed_mode, &_airspeed_mode);
 	}
 }
 

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -634,12 +634,14 @@ void AttitudeEstimatorQ::task_main()
 			// use estimated velocity for airspeed estimate
 			if (_airspeed_mode == 1) {
 				if (hrt_absolute_time() - _gpos.timestamp < 1e6) {
-					ctrl_state.airspeed = sqrtf(_gpos.vel_n * _gpos.vel_n + _gpos.vel_e * _gpos.vel_e +_gpos.vel_d * _gpos.vel_d);
+					ctrl_state.airspeed = sqrtf(_gpos.vel_n * _gpos.vel_n + _gpos.vel_e * _gpos.vel_e + _gpos.vel_d * _gpos.vel_d);
 				}
-			// do nothing, airspeed has been declared as non-valid above, controllers will handle this assuming always trim airspeed	
+
+				// do nothing, airspeed has been declared as non-valid above, controllers will handle this assuming always trim airspeed
+
 			} else if (_airspeed_mode == 2) {
 
-			// use the measured airspeed
+				// use the measured airspeed
 			} else {
 				/* Airspeed - take airspeed measurement directly here as no wind is estimated */
 				if (PX4_ISFINITE(_airspeed.indicated_airspeed_m_s) && hrt_absolute_time() - _airspeed.timestamp < 1e6

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -631,25 +631,25 @@ void AttitudeEstimatorQ::task_main()
 
 			ctrl_state.airspeed_valid = false;
 
-			// use estimated velocity for airspeed estimate
-			if (_airspeed_mode == 1) {
-				if (hrt_absolute_time() - _gpos.timestamp < 1e6) {
-					ctrl_state.airspeed = sqrtf(_gpos.vel_n * _gpos.vel_n + _gpos.vel_e * _gpos.vel_e + _gpos.vel_d * _gpos.vel_d);
-				}
-
-				// do nothing, airspeed has been declared as non-valid above, controllers will handle this assuming always trim airspeed
-
-			} else if (_airspeed_mode == 2) {
-
-				// use the measured airspeed
-			} else {
-				/* Airspeed - take airspeed measurement directly here as no wind is estimated */
+			if (_airspeed_mode == control_state_s::AIRSPD_MODE_MEAS) {
+				// use measured airspeed
 				if (PX4_ISFINITE(_airspeed.indicated_airspeed_m_s) && hrt_absolute_time() - _airspeed.timestamp < 1e6
 				    && _airspeed.timestamp > 0) {
 					ctrl_state.airspeed = _airspeed.indicated_airspeed_m_s;
 					ctrl_state.airspeed_valid = true;
-
 				}
+			}
+
+			else if (_airspeed_mode == control_state_s::AIRSPD_MODE_EST) {
+				// use estimated body velocity as airspeed estimate
+				if (hrt_absolute_time() - _gpos.timestamp < 1e6) {
+					ctrl_state.airspeed = sqrtf(_gpos.vel_n * _gpos.vel_n + _gpos.vel_e * _gpos.vel_e + _gpos.vel_d * _gpos.vel_d);
+					ctrl_state.airspeed_valid = true;
+				}
+
+			} else if (_airspeed_mode == control_state_s::AIRSPD_MODE_DISABLED) {
+				// do nothing, airspeed has been declared as non-valid above, controllers
+				// will handle this assuming always trim airspeed
 			}
 
 			/* the instance count is not used here */

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -672,8 +672,8 @@ void Ekf2::task_main()
 					ctrl_state.airspeed = airspeed.indicated_airspeed_m_s;
 					ctrl_state.airspeed_valid = true;
 				}
-			}
-			if (_airspeed_mode.get() == control_state_s::AIRSPD_MODE_EST) {
+
+			} else if (_airspeed_mode.get() == control_state_s::AIRSPD_MODE_EST) {
 				if (_ekf.local_position_is_valid()) {
 					ctrl_state.airspeed = sqrtf(vel[0] * vel[0] + vel[1] * vel[1] + vel[2] * vel[2]);
 					ctrl_state.airspeed_valid = true;

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -667,12 +667,14 @@ void Ekf2::task_main()
 			// use estimated velocity for airspeed estimate
 			if (_airspeed_mode.get() == 1) {
 				if (_ekf.local_position_is_valid()) {
-					ctrl_state.airspeed = sqrtf(vel[0] * vel[0] + vel[1] * vel[1] +vel[2] * vel[2]);
+					ctrl_state.airspeed = sqrtf(vel[0] * vel[0] + vel[1] * vel[1] + vel[2] * vel[2]);
 				}
-			// do nothing, airspeed has been declared as non-valid above, controllers will handle this assuming always trim airspeed	
+
+				// do nothing, airspeed has been declared as non-valid above, controllers will handle this assuming always trim airspeed
+
 			} else if (_airspeed_mode.get() == 2) {
 
-			// use the measured airspeed
+				// use the measured airspeed
 			} else {
 				/* Airspeed - take airspeed measurement directly here as no wind is estimated */
 				if (PX4_ISFINITE(airspeed.indicated_airspeed_m_s) && hrt_absolute_time() - airspeed.timestamp < 1e6

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -665,23 +665,23 @@ void Ekf2::task_main()
 			ctrl_state.airspeed_valid = false;
 
 			// use estimated velocity for airspeed estimate
-			if (_airspeed_mode.get() == 1) {
-				if (_ekf.local_position_is_valid()) {
-					ctrl_state.airspeed = sqrtf(vel[0] * vel[0] + vel[1] * vel[1] + vel[2] * vel[2]);
-				}
-
-				// do nothing, airspeed has been declared as non-valid above, controllers will handle this assuming always trim airspeed
-
-			} else if (_airspeed_mode.get() == 2) {
-
-				// use the measured airspeed
-			} else {
-				/* Airspeed - take airspeed measurement directly here as no wind is estimated */
+			if (_airspeed_mode.get() == control_state_s::AIRSPD_MODE_MEAS) {
+				// use measured airspeed
 				if (PX4_ISFINITE(airspeed.indicated_airspeed_m_s) && hrt_absolute_time() - airspeed.timestamp < 1e6
 				    && airspeed.timestamp > 0) {
 					ctrl_state.airspeed = airspeed.indicated_airspeed_m_s;
 					ctrl_state.airspeed_valid = true;
 				}
+			}
+			if (_airspeed_mode.get() == control_state_s::AIRSPD_MODE_EST) {
+				if (_ekf.local_position_is_valid()) {
+					ctrl_state.airspeed = sqrtf(vel[0] * vel[0] + vel[1] * vel[1] + vel[2] * vel[2]);
+					ctrl_state.airspeed_valid = true;
+				}
+
+			} else if (_airspeed_mode.get() == control_state_s::AIRSPD_MODE_DISABLED) {
+				// do nothing, airspeed has been declared as non-valid above, controllers
+				// will handle this assuming always trim airspeed
 			}
 
 			// publish control state data

--- a/src/modules/ekf_att_pos_estimator/AttitudePositionEstimatorEKF.h
+++ b/src/modules/ekf_att_pos_estimator/AttitudePositionEstimatorEKF.h
@@ -255,6 +255,7 @@ private:
         float magb_pnoise;
         float eas_noise;
         float pos_stddev_threshold;
+        int32_t airspeed_mode;
     }       _parameters;            /**< local copies of interesting parameters */
 
     struct {
@@ -276,6 +277,7 @@ private:
         param_t magb_pnoise;
         param_t eas_noise;
         param_t pos_stddev_threshold;
+        param_t airspeed_mode;
     }       _parameter_handles;     /**< handles for interesting parameters */
 
     AttPosEKF                   *_ekf;

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -502,3 +502,19 @@ PARAM_DEFINE_FLOAT(FW_FLAPS_SCL, 1.0f);
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_FLAPERON_SCL, 0.0f);
+
+/**
+ * Airspeed mode
+ *
+ * The param value sets the method used to publish the control state airspeed.
+ * For small wings or VTOL without airspeed sensor this parameter can be used to
+ * enable flying without an airspeed reading
+ *
+ * @min 0
+ * @max 2
+ * @value 0 use measured airspeed
+ * @value 1 use vehicle ground velocity as airspeed
+ * @value 2 declare airspeed invalid
+ * @group FW Attitude Control
+ */
+PARAM_DEFINE_INT32(FW_ARSP_MODE, 0);

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
@@ -1326,7 +1326,7 @@ FixedwingPositionControl::control_position(const math::Vector<2> &current_positi
 		float mission_throttle = _parameters.throttle_cruise;
 
 		if (PX4_ISFINITE(_pos_sp_triplet.current.cruising_throttle) &&
-			_pos_sp_triplet.current.cruising_throttle > 0.1f) {
+			_pos_sp_triplet.current.cruising_throttle > 0.01f) {
 			mission_throttle = _pos_sp_triplet.current.cruising_throttle;
 		}
 

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
@@ -1330,8 +1330,6 @@ FixedwingPositionControl::control_position(const math::Vector<2> &current_positi
 			mission_throttle = _pos_sp_triplet.current.cruising_throttle;
 		}
 
-		printf("%f \n", (double)mission_throttle);
-
 		if (pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_IDLE) {
 			_att_sp.thrust = 0.0f;
 			_att_sp.roll_body = 0.0f;

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
@@ -1323,6 +1323,15 @@ FixedwingPositionControl::control_position(const math::Vector<2> &current_positi
 			mission_airspeed = _pos_sp_triplet.current.cruising_speed;
 		}
 
+		float mission_throttle = _parameters.throttle_cruise;
+
+		if (PX4_ISFINITE(_pos_sp_triplet.current.cruising_throttle) &&
+			_pos_sp_triplet.current.cruising_throttle > 0.1f) {
+			mission_throttle = _pos_sp_triplet.current.cruising_throttle;
+		}
+
+		printf("%f \n", (double)mission_throttle);
+
 		if (pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_IDLE) {
 			_att_sp.thrust = 0.0f;
 			_att_sp.roll_body = 0.0f;
@@ -1336,7 +1345,7 @@ FixedwingPositionControl::control_position(const math::Vector<2> &current_positi
 
 			tecs_update_pitch_throttle(pos_sp_triplet.current.alt, calculate_target_airspeed(mission_airspeed), eas2tas,
 						   math::radians(_parameters.pitch_limit_min), math::radians(_parameters.pitch_limit_max),
-						   _parameters.throttle_min, _parameters.throttle_max, _parameters.throttle_cruise,
+						   _parameters.throttle_min, _parameters.throttle_max, mission_throttle,
 						   false, math::radians(_parameters.pitch_limit_min), _global_pos.alt, ground_speed);
 
 		} else if (pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LOITER) {

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -127,7 +127,14 @@ MissionBlock::is_mission_item_reached()
 				_navigator->set_cruising_speed(_mission_item.params[1]);
 			} else {
 				_navigator->set_cruising_speed();
+				/* if no speed target was given try to set throttle */
+				if (_mission_item.params[2] > 0.0f) {
+					_navigator->set_cruising_throttle(_mission_item.params[2] / 100);
+				} else {
+					_navigator->set_cruising_throttle();
+				}
 			}
+
 			return true;
 
 		default:
@@ -367,6 +374,7 @@ MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *ite
 	sp->acceptance_radius = item->acceptance_radius;
 	sp->disable_mc_yaw_control = false;
 	sp->cruising_speed = _navigator->get_cruising_speed();
+	sp->cruising_throttle = _navigator->get_cruising_throttle();
 
 	switch (item->nav_cmd) {
 	case NAV_CMD_IDLE:

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -178,6 +178,19 @@ public:
 	 */
 	void		set_cruising_speed(float speed=-1.0f) { _mission_cruising_speed = speed; }
 
+
+	/**
+	 * Get the target throttle
+	 *
+	 * @return the desired throttle for this mission
+	 */
+	float		get_cruising_throttle();
+
+	/**
+	 * Set the target throttle
+	 */
+	void		set_cruising_throttle(float percent=-1.0f) { _mission_throttle = percent; }
+
 	/**
 	 * Get the acceptance radius given the mission item preset radius
 	 *
@@ -277,8 +290,10 @@ private:
 	
 	control::BlockParamFloat _param_cruising_speed_hover;
 	control::BlockParamFloat _param_cruising_speed_plane;
+	control::BlockParamFloat _param_cruising_throttle_plane;
 
 	float _mission_cruising_speed;
+	float _mission_throttle;
 
 	/**
 	 * Retrieve global position

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -189,7 +189,7 @@ public:
 	/**
 	 * Set the target throttle
 	 */
-	void		set_cruising_throttle(float percent=-1.0f) { _mission_throttle = percent; }
+	void		set_cruising_throttle(float throttle=-1.0f) { _mission_throttle = throttle; }
 
 	/**
 	 * Get the acceptance radius given the mission item preset radius

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -159,6 +159,7 @@ Navigator::Navigator() :
 	_param_rcloss_act(this, "RCL_ACT"),
 	_param_cruising_speed_hover(this, "MPC_XY_CRUISE", false),
 	_param_cruising_speed_plane(this, "FW_AIRSPD_TRIM", false),
+	_param_cruising_throttle_plane(this, "FW_THR_CRUISE", false),
 	_mission_cruising_speed(-1.0f)
 {
 	/* Create a list of our possible navigation types */
@@ -722,6 +723,17 @@ Navigator::get_cruising_speed()
 		return _param_cruising_speed_hover.get();
 	} else {
 		return _param_cruising_speed_plane.get();
+	}
+}
+
+float
+Navigator::get_cruising_throttle()
+{
+	/* Return the mission-requested cruise speed, or -1 */
+	if (_mission_throttle > 0.0f) {
+		return _mission_throttle;
+	} else {
+		return _param_cruising_throttle_plane.get();
 	}
 }
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -729,7 +729,7 @@ Navigator::get_cruising_speed()
 float
 Navigator::get_cruising_throttle()
 {
-	/* Return the mission-requested cruise speed, or -1 */
+	/* Return the mission-requested cruise speed, or default FW_THR_CRUISE value */
 	if (_mission_throttle > 0.0f) {
 		return _mission_throttle;
 	} else {

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -187,7 +187,8 @@ void Standard::update_vtol_state()
 
 		} else if (_vtol_schedule.flight_mode == TRANSITION_TO_FW) {
 			// continue the transition to fw mode while monitoring airspeed for a final switch to fw mode
-			if (((_params_standard.airspeed_mode == 2 || _airspeed->indicated_airspeed_m_s >= _params_standard.airspeed_trans) &&
+			if (((_params_standard.airspeed_mode == control_state_s::AIRSPD_MODE_DISABLED ||
+				_airspeed->indicated_airspeed_m_s >= _params_standard.airspeed_trans) &&
 			     (float)hrt_elapsed_time(&_vtol_schedule.transition_start)
 			     > (_params_standard.front_trans_time_min * 1000000.0f)) ||
 			    can_transition_on_ground()) {
@@ -250,7 +251,7 @@ void Standard::update_transition_state()
 			_mc_throttle_weight = weight;
 
 		// time based blending when no airspeed sensor is set
-		} else if (_params_standard.airspeed_mode == 2 &&
+		} else if (_params_standard.airspeed_mode == control_state_s::AIRSPD_MODE_DISABLED &&
 				  (float)hrt_elapsed_time(&_vtol_schedule.transition_start) < (_params_standard.front_trans_time_min * 1000000.0f)
 				  ) {
 			float weight = 1.0f - (float)(hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params_standard.front_trans_time_min * 1000000.0f));

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -249,6 +249,18 @@ void Standard::update_transition_state()
 			_mc_yaw_weight = weight;
 			_mc_throttle_weight = weight;
 
+		// time based blending when no airspeed sensor is set
+		} else if (_params_standard.airspeed_mode == 2 &&
+				  (float)hrt_elapsed_time(&_vtol_schedule.transition_start) < (_params_standard.front_trans_time_min * 1000000.0f)
+				  ) {
+			float weight = 1.0f - (float)(hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params_standard.front_trans_time_min * 1000000.0f));
+			printf("weight: %f \n", (double)weight);
+			_mc_roll_weight = weight;
+			_mc_pitch_weight = weight;
+			_mc_yaw_weight = weight;
+			_mc_throttle_weight = weight;
+
+
 		} else {
 			// at low speeds give full weight to mc
 			_mc_roll_weight = 1.0f;

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -67,7 +67,8 @@ Standard::Standard(VtolAttitudeControl *attc) :
 	_params_handles_standard.front_trans_timeout = param_find("VT_TRANS_TIMEOUT");
 	_params_handles_standard.front_trans_time_min = param_find("VT_TRANS_MIN_TM");
 	_params_handles_standard.down_pitch_max = param_find("VT_DWN_PITCH_MAX");
-	_params_handles_standard.forward_thurst_scale = param_find("VT_FWD_THRUST_SC");
+	_params_handles_standard.forward_thrust_scale = param_find("VT_FWD_THRUST_SC");
+	_params_handles_standard.airspeed_mode = param_find("FW_ARSP_MODE");
 }
 
 Standard::~Standard()
@@ -78,6 +79,7 @@ int
 Standard::parameters_update()
 {
 	float v;
+	int i;
 
 	/* duration of a forwards transition to fw mode */
 	param_get(_params_handles_standard.front_trans_dur, &v);
@@ -112,7 +114,12 @@ Standard::parameters_update()
 	_params_standard.down_pitch_max = math::radians(v);
 
 	/* scale for fixed wing thrust used for forward acceleration in multirotor mode */
-	param_get(_params_handles_standard.forward_thurst_scale, &_params_standard.forward_thurst_scale);
+	param_get(_params_handles_standard.forward_thrust_scale, &_params_standard.forward_thrust_scale);
+
+	/* airspeed mode */
+	param_get(_params_handles_standard.airspeed_mode, &i);
+	_params_standard.airspeed_mode = math::constrain(i, 0, 2);
+
 
 
 	return OK;
@@ -180,7 +187,7 @@ void Standard::update_vtol_state()
 
 		} else if (_vtol_schedule.flight_mode == TRANSITION_TO_FW) {
 			// continue the transition to fw mode while monitoring airspeed for a final switch to fw mode
-			if ((_airspeed->indicated_airspeed_m_s >= _params_standard.airspeed_trans &&
+			if (((_params_standard.airspeed_mode == 2 || _airspeed->indicated_airspeed_m_s >= _params_standard.airspeed_trans) &&
 			     (float)hrt_elapsed_time(&_vtol_schedule.transition_start)
 			     > (_params_standard.front_trans_time_min * 1000000.0f)) ||
 			    can_transition_on_ground()) {
@@ -294,7 +301,7 @@ void Standard::update_mc_state()
 	VtolType::update_mc_state();
 
 	// if the thrust scale param is zero then the pusher-for-pitch strategy is disabled and we can return
-	if (_params_standard.forward_thurst_scale < FLT_EPSILON) {
+	if (_params_standard.forward_thrust_scale < FLT_EPSILON) {
 		return;
 	}
 

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -254,7 +254,6 @@ void Standard::update_transition_state()
 				  (float)hrt_elapsed_time(&_vtol_schedule.transition_start) < (_params_standard.front_trans_time_min * 1000000.0f)
 				  ) {
 			float weight = 1.0f - (float)(hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params_standard.front_trans_time_min * 1000000.0f));
-			printf("weight: %f \n", (double)weight);
 			_mc_roll_weight = weight;
 			_mc_pitch_weight = weight;
 			_mc_yaw_weight = weight;

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -188,7 +188,7 @@ void Standard::update_vtol_state()
 		} else if (_vtol_schedule.flight_mode == TRANSITION_TO_FW) {
 			// continue the transition to fw mode while monitoring airspeed for a final switch to fw mode
 			if (((_params_standard.airspeed_mode == control_state_s::AIRSPD_MODE_DISABLED ||
-				_airspeed->indicated_airspeed_m_s >= _params_standard.airspeed_trans) &&
+			      _airspeed->indicated_airspeed_m_s >= _params_standard.airspeed_trans) &&
 			     (float)hrt_elapsed_time(&_vtol_schedule.transition_start)
 			     > (_params_standard.front_trans_time_min * 1000000.0f)) ||
 			    can_transition_on_ground()) {
@@ -250,11 +250,13 @@ void Standard::update_transition_state()
 			_mc_yaw_weight = weight;
 			_mc_throttle_weight = weight;
 
-		// time based blending when no airspeed sensor is set
+			// time based blending when no airspeed sensor is set
+
 		} else if (_params_standard.airspeed_mode == control_state_s::AIRSPD_MODE_DISABLED &&
-				  (float)hrt_elapsed_time(&_vtol_schedule.transition_start) < (_params_standard.front_trans_time_min * 1000000.0f)
-				  ) {
-			float weight = 1.0f - (float)(hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params_standard.front_trans_time_min * 1000000.0f));
+			   (float)hrt_elapsed_time(&_vtol_schedule.transition_start) < (_params_standard.front_trans_time_min * 1000000.0f)
+			  ) {
+			float weight = 1.0f - (float)(hrt_elapsed_time(&_vtol_schedule.transition_start) /
+						      (_params_standard.front_trans_time_min * 1000000.0f));
 			_mc_roll_weight = weight;
 			_mc_pitch_weight = weight;
 			_mc_yaw_weight = weight;

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -75,7 +75,8 @@ private:
 		float front_trans_timeout;
 		float front_trans_time_min;
 		float down_pitch_max;
-		float forward_thurst_scale;
+		float forward_thrust_scale;
+		int airspeed_mode;
 	} _params_standard;
 
 	struct {
@@ -87,7 +88,8 @@ private:
 		param_t front_trans_timeout;
 		param_t front_trans_time_min;
 		param_t down_pitch_max;
-		param_t forward_thurst_scale;
+		param_t forward_thrust_scale;
+		param_t airspeed_mode;
 	} _params_handles_standard;
 
 	enum vtol_mode {

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -84,6 +84,7 @@
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/tecs_status.h>
 #include <uORB/topics/vehicle_land_detected.h>
+#include <uORB/topics/control_state.h>
 #include <systemlib/param/param.h>
 #include <systemlib/err.h>
 #include <systemlib/systemlib.h>


### PR DESCRIPTION
Enables flying a fw / vtol without an airspeed sensor.
The new mode parameter enables 3 different modes:

1) Use values from airspeed sensor
2) Approximate airspeed with ground velocity (good if wind-still, e.g indoors with VICON )
3) Declare airspeed invalid, controllers will assume trim speed (e.g. TECS or fw attitude controller)