### PR TITLE
Change prefix construction to allow correct building of scope tag in …

### DIFF
--- a/Tools/px4params/srcscanner.py
+++ b/Tools/px4params/srcscanner.py
@@ -33,7 +33,7 @@ class SourceScanner(object):
         Scans provided file and passes its contents to the parser using
         parser.Parse method.
         """
-        prefix = ".." + os.path.sep + "src" + os.path.sep
+        prefix = "^.*" + os.path.sep + "src" + os.path.sep
         scope = re.sub(prefix.replace("\\", "/"), "", os.path.dirname(os.path.relpath(path)).replace("\\", "/"))
 
         with codecs.open(path, 'r', 'utf-8') as f:


### PR DESCRIPTION
Change prefix construction to allow correct building of scope tag in parameters.xml when building out-of-tree
    
Fixes issue #4767
