### PR TITLE
mc_pos_control: run the loop without position data

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1231,12 +1231,12 @@ MulticopterPositionControl::task_main()
 	fds[0].events = POLLIN;
 
 	while (!_task_should_exit) {
-		/* wait for up to 500ms for data */
-		int pret = px4_poll(&fds[0], (sizeof(fds) / sizeof(fds[0])), 500);
+		/* wait for up to 20ms for data */
+		int pret = px4_poll(&fds[0], (sizeof(fds) / sizeof(fds[0])), 20);
 
 		/* timed out - periodic check for _task_should_exit */
 		if (pret == 0) {
-			continue;
+			// Go through the loop anyway to copy manual input at 50 Hz.
 		}
 
 		/* this is undesirable but not much we can do */


### PR DESCRIPTION
By running the loop in mc_pos_control without successfully polling on
position data, we still copy the manual input over so that
mc_att_control can consume it. This allows to fly in manual mode without
GPS and no position estimate.

This should fix #4766.