### PR TITLE
Make LPE sonar reading more robust.

### DIFF
--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -113,6 +113,7 @@ BlockLocalPositionEstimator::BlockLocalPositionEstimator() :
 	_time_last_gps(0),
 	_time_last_lidar(0),
 	_time_last_sonar(0),
+	_time_init_sonar(0),
 	_time_last_vision_p(0),
 	_time_last_mocap(0),
 

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -318,6 +318,7 @@ private:
 	uint64_t _time_last_gps;
 	uint64_t _time_last_lidar;
 	uint64_t _time_last_sonar;
+	uint64_t _time_init_sonar;
 	uint64_t _time_last_vision_p;
 	uint64_t _time_last_mocap;
 

--- a/src/modules/local_position_estimator/params.c
+++ b/src/modules/local_position_estimator/params.c
@@ -126,7 +126,7 @@ PARAM_DEFINE_FLOAT(LPE_ACC_Z, 0.0454f);
  * @max 3
  * @decimal 2
  */
-PARAM_DEFINE_FLOAT(LPE_BAR_Z, 1.0f);
+PARAM_DEFINE_FLOAT(LPE_BAR_Z, 3.0f);
 
 /**
  * Enables GPS data, also forces alt init with GPS
@@ -264,7 +264,7 @@ PARAM_DEFINE_FLOAT(LPE_VIC_P, 0.05f);
  * @max 1
  * @decimal 8
  */
-PARAM_DEFINE_FLOAT(LPE_PN_P, 0.1f);
+PARAM_DEFINE_FLOAT(LPE_PN_P, 0.0f);
 
 /**
  * Velocity propagation noise density
@@ -275,7 +275,7 @@ PARAM_DEFINE_FLOAT(LPE_PN_P, 0.1f);
  * @max 1
  * @decimal 8
  */
-PARAM_DEFINE_FLOAT(LPE_PN_V, 0.1f);
+PARAM_DEFINE_FLOAT(LPE_PN_V, 0.0f);
 
 /**
  * Accel bias propagation noise density
@@ -289,7 +289,7 @@ PARAM_DEFINE_FLOAT(LPE_PN_V, 0.1f);
 PARAM_DEFINE_FLOAT(LPE_PN_B, 1e-3f);
 
 /**
- * Terrain random walk noise density
+ * Terrain random walk noise density, hilly/outdoor (1e-1), flat/Indoor (1e-3)
  *
  * @group Local Position Estimator
  * @unit m/s/sqrt(Hz)
@@ -297,7 +297,7 @@ PARAM_DEFINE_FLOAT(LPE_PN_B, 1e-3f);
  * @max 1
  * @decimal 3
  */
-PARAM_DEFINE_FLOAT(LPE_PN_T, 1e-3f);
+PARAM_DEFINE_FLOAT(LPE_PN_T, 1e-1f);
 
 /**
  * Flow gyro high pass filter cut off frequency

--- a/src/modules/local_position_estimator/sensors/flow.cpp
+++ b/src/modules/local_position_estimator/sensors/flow.cpp
@@ -49,20 +49,11 @@ int BlockLocalPositionEstimator::flowMeasure(Vector<float, n_y_flow> &y)
 	}
 
 	// calculate range to center of image for flow
-	float d = 0;
-
-	if (_lidarInitialized && (_lidarFault < fault_lvl_disable)) {
-		d = _sub_lidar->get().current_distance
-		    + (_lidar_z_offset.get() - _flow_z_offset.get());
-
-	} else if (_sonarInitialized && (_sonarFault < fault_lvl_disable)) {
-		d = _sub_sonar->get().current_distance
-		    + (_sonar_z_offset.get() - _flow_z_offset.get());
-
-	} else {
-		// no valid distance data
+	if (!_canEstimateT) {
 		return -1;
 	}
+
+	float d = agl() * cosf(_sub_att.get().roll) * cosf(_sub_att.get().pitch);
 
 	// check for global accuracy
 	if (_gpsInitialized) {


### PR DESCRIPTION
This makes LPE optical flow flight outdoors/indoors rock solid. I defaulted the T_Z (terrain noise) param to the outdoors noise level as more users are flying it outdoors now with a comment about values for typical indoor/outdoor settings. Will include flight logs and video below.