### PR TITLE
Fix px4_getopt

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1701,7 +1701,6 @@ Mavlink::task_main(int argc, char *argv[])
 		case 'o':
 			temp_int_arg = strtoul(myoptarg, &eptr, 10);
 			if ( *eptr == '\0' ) {
-				warnx("set remote port %d", temp_int_arg);
 				_remote_port = temp_int_arg;
 				set_protocol(UDP);
 			} else {
@@ -1822,8 +1821,8 @@ Mavlink::task_main(int argc, char *argv[])
 			return ERROR;
 		}
 
-		PX4_INFO("mode: %s, data rate: %d B/s on udp port %hu",
-			 mavlink_mode_str(_mode), _datarate, _network_port);
+		PX4_INFO("mode: %s, data rate: %d B/s on udp port %hu remote port %hu",
+			 mavlink_mode_str(_mode), _datarate, _network_port, _remote_port);
 	}
 
 	/* initialize send mutex */

--- a/src/platforms/common/px4_getopt.c
+++ b/src/platforms/common/px4_getopt.c
@@ -143,10 +143,12 @@ __EXPORT int px4_getopt(int argc, char *argv[], const char *options, int *myopti
 	char c;
 	int takesarg;
 
-	if (*myoptind == 1)
+	if (*myoptind == 1) {
 		if (reorder(argc, argv, options) != 0) {
+			*myoptind += 1;
 			return (int)'?';
 		}
+	}
 
 	p = argv[*myoptind];
 
@@ -158,6 +160,7 @@ __EXPORT int px4_getopt(int argc, char *argv[], const char *options, int *myopti
 		c = isvalidopt(p[1], options, &takesarg);
 
 		if (c == '?') {
+			*myoptind += 1;
 			return (int)c;
 		}
 

--- a/src/platforms/common/px4_getopt.c
+++ b/src/platforms/common/px4_getopt.c
@@ -165,6 +165,9 @@ __EXPORT int px4_getopt(int argc, char *argv[], const char *options, int *myopti
 
 		if (takesarg) {
 			*myoptarg = argv[*myoptind];
+			if (!*myoptarg) { //Error: option takes an argument, but there is no more argument
+				return -1;
+			}
 			*myoptind += 1;
 		}
 


### PR DESCRIPTION
This fixes https://github.com/PX4/Firmware/issues/4462 and another segfault in `px4_getopt`. Also removes an unnecessary warning in mavlink