### PR TITLE
pwm_out_sim sleep if no fds

### DIFF
--- a/src/drivers/pwm_out_sim/pwm_out_sim.cpp
+++ b/src/drivers/pwm_out_sim/pwm_out_sim.cpp
@@ -414,7 +414,10 @@ PWMSim::task_main()
 			_current_update_rate = _update_rate;
 		}
 
+		/* this can happen during boot, but after the sleep its likely resolved */
 		if (_poll_fds_num == 0) {
+			usleep(1000 * 1000);
+
 			PX4_DEBUG("no valid fds");
 			continue;
 		}


### PR DESCRIPTION
-fixes #4828 

@julianoes I think you're familiar with this code. Can you review/comment? I don't fully understand why this is a problem at startup, but restoring the sleep resolves the issue in #4828