### PR TITLE
Needed to avoid name collsion in  upcomming Nuttx logger changes

### DIFF
--- a/src/modules/systemlib/mixer/mixer.h
+++ b/src/modules/systemlib/mixer/mixer.h
@@ -427,7 +427,7 @@ public:
 protected:
 
 private:
-	mixer_simple_s			*_info;
+	mixer_simple_s			*_pinfo;
 
 	static int			parse_output_scaler(const char *buf, unsigned &buflen, mixer_scaler_s &scaler);
 	static int			parse_control_scaler(const char *buf,


### PR DESCRIPTION
@LorenzMeier 

This is the only change we will need moving to nuttx_v3 new logging.