### PR TITLE
[WIP] Camera triggering with MultiPort adapter

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -537,7 +537,7 @@ then
 			# Get FMU driver out of the way
 			set MIXER_AUX none
 			set AUX_MODE none
-			camera_trigger start
+			camera_trigger start --pwm
 		fi
 	fi
 
@@ -606,7 +606,7 @@ then
 		# Try to get an USB console
 		nshterm /dev/ttyACM0 &
 	else
-		mavlink start -r 800000 -d /dev/ttyACM0 -m config -x
+		mavlink start -r 80000 -d /dev/ttyACM0 -m config -x
 	fi
 
 	#

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -537,7 +537,7 @@ then
 			# Get FMU driver out of the way
 			set MIXER_AUX none
 			set AUX_MODE none
-			camera_trigger start --pwm
+			camera_trigger start
 		fi
 	fi
 
@@ -606,7 +606,7 @@ then
 		# Try to get an USB console
 		nshterm /dev/ttyACM0 &
 	else
-		mavlink start -r 80000 -d /dev/ttyACM0 -m config -x
+		mavlink start -r 800000 -d /dev/ttyACM0 -m config -x
 	fi
 
 	#

--- a/src/drivers/camera_trigger/CMakeLists.txt
+++ b/src/drivers/camera_trigger/CMakeLists.txt
@@ -39,6 +39,9 @@ px4_add_module(
 	SRCS
 		camera_trigger.cpp
 		camera_trigger_params.c
+                interfaces/src/camera_interface.cpp
+                interfaces/src/pwm.cpp
+                interfaces/src/relay.cpp
 	DEPENDS
 		platforms__common
 	)

--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -426,7 +426,11 @@ CameraTrigger::engage(void *arg)
 	/* set timestamp the instant before the trigger goes off */
 	report.timestamp = hrt_absolute_time();
 
+<<<<<<< HEAD
 	CameraTrigger::trigger(trig, trig->_polarity);
+=======
+	trig->_camera_interface->trigger(true);
+>>>>>>> fb669fc... fixed the triggering function logic
 
 	report.seq = trig->_trigger_seq++;
 
@@ -436,10 +440,16 @@ CameraTrigger::engage(void *arg)
 void
 CameraTrigger::disengage(void *arg)
 {
+<<<<<<< HEAD
 
 	CameraTrigger *trig = reinterpret_cast<CameraTrigger *>(arg);
 
 	CameraTrigger::trigger(trig, !(trig->_polarity));
+=======
+	CameraTrigger *trig = reinterpret_cast<CameraTrigger *>(arg);
+
+	trig->_camera_interface->trigger(false);
+>>>>>>> fb669fc... fixed the triggering function logic
 }
 
 void

--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -472,6 +472,7 @@ CameraTrigger::info()
 	warnx("mode : %i", _mode);
 	warnx("interval : %.2f", (double)_interval);
 	warnx("distance : %.2f", (double)_distance);
+	_camera_interface->info();
 }
 
 static void usage()

--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -236,6 +236,8 @@ CameraTrigger::CameraTrigger() :
 
 CameraTrigger::~CameraTrigger()
 {
+	delete(_camera_interface);
+
 	camera_trigger::g_camera_trigger = nullptr;
 }
 

--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -482,9 +482,11 @@ int camera_trigger_main(int argc, char *argv[])
 		if (argc >= 3) {
 			if (!strcmp(argv[2], "--relay")) {
 				camera_trigger::g_camera_trigger = new CameraTrigger(CAMERA_INTERFACE_MODE_RELAY);
+				warnx("started with camera interface mode : relay");
 
 			} else if (!strcmp(argv[2], "--pwm")) {
 				camera_trigger::g_camera_trigger = new CameraTrigger(CAMERA_INTERFACE_MODE_PWM);
+				warnx("started with camera interface mode : pwm");
 
 			} else {
 				usage();

--- a/src/drivers/camera_trigger/interfaces/src/camera_interface.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/camera_interface.cpp
@@ -1,0 +1,14 @@
+#include "camera_interface.h"
+
+/**
+ * @file camera_interface.cpp
+ *
+ */
+
+CameraInterface::CameraInterface()
+{
+}
+
+CameraInterface::~CameraInterface()
+{
+}

--- a/src/drivers/camera_trigger/interfaces/src/camera_interface.h
+++ b/src/drivers/camera_trigger/interfaces/src/camera_interface.h
@@ -1,0 +1,54 @@
+/**
+ * @file camera_interface.h
+ */
+
+#pragma once
+
+class CameraInterface
+{
+public:
+
+	/**
+	 * Constructor
+	 */
+	CameraInterface();
+
+	/**
+	 * Destructor.
+	 */
+	virtual ~CameraInterface();
+
+	/**
+	 * setup the interface
+	 */
+	virtual void setup() {};
+
+	/**
+	 * trigger the camera
+	 * @param trigger:
+	 */
+	virtual void trigger(bool enable) {};
+
+
+	/**
+	 * Display info.
+	 */
+	virtual void info() {};
+
+	/**
+	 * Power on the camera
+	 * @return 0 on success, <0 on error
+	 */
+	virtual int powerOn() { return -1; }
+
+	/**
+	 * Power off the camera
+	 * @return 0 on success, <0 on error
+	 */
+	virtual int powerOff() { return -1; }
+
+
+protected:
+
+
+};

--- a/src/drivers/camera_trigger/interfaces/src/camera_interface.h
+++ b/src/drivers/camera_trigger/interfaces/src/camera_interface.h
@@ -19,11 +19,6 @@ public:
 	virtual ~CameraInterface();
 
 	/**
-	 * setup the interface
-	 */
-	virtual void setup() {};
-
-	/**
 	 * trigger the camera
 	 * @param trigger:
 	 */
@@ -50,5 +45,9 @@ public:
 
 protected:
 
+	/**
+	 * setup the interface
+	 */
+	virtual void setup() {};
 
 };

--- a/src/drivers/camera_trigger/interfaces/src/pwm.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.cpp
@@ -1,7 +1,8 @@
 #include <px4.h>
 #include <sys/ioctl.h>
-#include <lib/helpfuncs/helpfuncs.h>
+#include <lib/mathlib/mathlib.h>
 
+#include "drivers/drv_pwm_output.h"
 #include "pwm.h"
 
 // PWM levels of the interface to seagull MAP converter to
@@ -41,6 +42,7 @@ CameraInterfacePWM::CameraInterfacePWM():
 		pin_list /= 10;
 		i++;
 	}
+
 	setup();
 }
 
@@ -118,7 +120,7 @@ int CameraInterfacePWM::powerOff()
 	return 0;
 }
 
-void CameraInterfaceRelay::info()
+void CameraInterfacePWM::info()
 {
 	warnx("PWM - camera triggering, pins 1-3 : %d,%d,%d", _pins[0], _pins[1], _pins[2]);
 }

--- a/src/drivers/camera_trigger/interfaces/src/pwm.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.cpp
@@ -1,8 +1,33 @@
 #include "pwm.h"
 
 CameraInterfacePWM::CameraInterfacePWM():
-	CameraInterface()
+	CameraInterface(),
+	_camera_is_on(false)
 {
+	_p_pin = param_find("TRIG_PINS");
+	int pin_list;
+	param_get(_p_pin, &pin_list);
+
+	// Set all pins as invalid
+	for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
+		_pins[i] = -1;
+	}
+
+	// Convert number to individual channels
+	unsigned i = 0;
+	int single_pin;
+
+	while ((single_pin = pin_list % 10)) {
+
+		_pins[i] = single_pin - 1;
+
+		if (_pins[i] < 0 || _pins[i] >= static_cast<int>(sizeof(_gpios) / sizeof(_gpios[0]))) {
+			_pins[i] = -1;
+		}
+
+		pin_list /= 10;
+		i++;
+	}
 }
 
 CameraInterfacePWM::~CameraInterfacePWM()
@@ -11,20 +36,100 @@ CameraInterfacePWM::~CameraInterfacePWM()
 
 void CameraInterfacePWM::setup()
 {
+	_pwm_dev = PWM_DEVICE_PATH;  // Used for direct pwm output without mixer
+	_pwm_fd = open(_pwm_dev, 0);  // open pwm device
 
+	if (_pwm_fd < 0) {
+		err(1, "can't open %s", _pwm_dev);
+	}
+
+	for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
+		if (_pin[i] >= 0) {
+			int ret_camera_pwm = px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pin[i]), math::constrain(PWM_CAMERA_DISARMED, 1000, 2000));
+		}
+	}
 }
 
 void CameraInterfacePWM::trigger(bool enable)
 {
+	// Check if armed, otherwise don't send high PWM values
+	if (_disarmed) {
+		for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
+			if (_pin[i] >= 0) {
+				int ret_camera_pwm = px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pin[i]), math::constrain(PWM_CAMERA_DISARMED, 1000, 2000));
+			}
+		}
 
+	} else {
+		if (!_camera_is_on) {
+			// Turn camera on and give time to start up
+			powerOn();
+			return;
+		}
+
+		if (trig) {
+			// Set all valid pins to shoot level
+			for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
+				if (_pin[i] >= 0) {
+					int ret_camera_pwm = px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pin[i]), math::constrain(PWM_CAMERA_INSTANT_SHOOT, 1000, 2000));
+				}
+			}
+
+		} else {
+			// Set all valid pins back to neutral level
+			for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
+				if (_pin[i] >= 0) {
+					int ret_camera_pwm = px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pin[i]), math::constrain(PWM_CAMERA_NEUTRAL, 1000, 2000));
+				}
+			}
+		}
+	}
 }
 
 int CameraInterfacePWM::powerOn()
 {
+	// Check if armed, otherwise don't send high PWM values
+	if (_disarmed) {
+		for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
+			if (_pin[i] >= 0) {
+				int ret_camera_pwm = px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pin[i]), math::constrain(PWM_CAMERA_DISARMED, 1000, 2000));
+			}
+		}
+
+	} else {
+		// Set all valid pins to turn on level
+		for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
+			if (_pin[i] >= 0) {
+				int ret_camera_pwm = px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pin[i]), math::constrain(PWM_CAMERA_ON, 1000, 2000));
+			}
+		}
+
+		_camera_is_on = true;
+	}
+
 	return 0;
 }
 
 int CameraInterfacePWM::powerOff()
 {
+	// Check if armed, otherwise don't send high PWM values
+	if (_disarmed) {
+		for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
+			if (_pin[i] >= 0) {
+				int ret_camera_pwm = px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pin[i]), math::constrain(PWM_CAMERA_DISARMED, 1000, 2000));
+			}
+		}
+
+	} else {
+		// Set all valid pins to turn off level
+		for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
+			if (_pin[i] >= 0) {
+				int ret_camera_pwm = px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pin[i]), math::constrain(PWM_CAMERA_OFF, 1000, 2000));
+			}
+		}
+
+		_camera_is_on = false;
+	}
+
 	return 0;
 }

--- a/src/drivers/camera_trigger/interfaces/src/pwm.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.cpp
@@ -33,6 +33,7 @@ CameraInterfacePWM::CameraInterfacePWM():
 		pin_list /= 10;
 		i++;
 	}
+	setup();
 }
 
 CameraInterfacePWM::~CameraInterfacePWM()

--- a/src/drivers/camera_trigger/interfaces/src/pwm.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.cpp
@@ -1,0 +1,30 @@
+#include "pwm.h"
+
+CameraInterfacePWM::CameraInterfacePWM():
+	CameraInterface()
+{
+}
+
+CameraInterfacePWM::~CameraInterfacePWM()
+{
+}
+
+void CameraInterfacePWM::setup()
+{
+
+}
+
+void CameraInterfacePWM::trigger(bool enable)
+{
+
+}
+
+int CameraInterfacePWM::powerOn()
+{
+	return 0;
+}
+
+int CameraInterfacePWM::powerOff()
+{
+	return 0;
+}

--- a/src/drivers/camera_trigger/interfaces/src/pwm.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.cpp
@@ -117,3 +117,8 @@ int CameraInterfacePWM::powerOff()
 
 	return 0;
 }
+
+void CameraInterfaceRelay::info()
+{
+	warnx("PWM - camera triggering, pins 1-3 : %d,%d,%d", _pins[0], _pins[1], _pins[2]);
+}

--- a/src/drivers/camera_trigger/interfaces/src/pwm.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.cpp
@@ -1,7 +1,12 @@
+#include <px4.h>
+#include <sys/ioctl.h>
+#include <lib/helpfuncs/helpfuncs.h>
+
 #include "pwm.h"
 
 CameraInterfacePWM::CameraInterfacePWM():
 	CameraInterface(),
+	_vehicle_status_sub(-1),
 	_camera_is_on(false)
 {
 	_p_pin = param_find("TRIG_PINS");
@@ -21,7 +26,7 @@ CameraInterfacePWM::CameraInterfacePWM():
 
 		_pins[i] = single_pin - 1;
 
-		if (_pins[i] < 0 || _pins[i] >= static_cast<int>(sizeof(_gpios) / sizeof(_gpios[0]))) {
+		if (_pins[i] < 0) {
 			_pins[i] = -1;
 		}
 
@@ -44,8 +49,9 @@ void CameraInterfacePWM::setup()
 	}
 
 	for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
-		if (_pin[i] >= 0) {
-			int ret_camera_pwm = px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pin[i]), math::constrain(PWM_CAMERA_DISARMED, 1000, 2000));
+		if (_pins[i] >= 0) {
+			px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pins[i]), math::constrain(PWM_CAMERA_DISARMED, 1000,
+					2000)); // TODO(birchera): use return value to make sure everything is fine
 		}
 	}
 }
@@ -53,10 +59,17 @@ void CameraInterfacePWM::setup()
 void CameraInterfacePWM::trigger(bool enable)
 {
 	// Check if armed, otherwise don't send high PWM values
-	if (_disarmed) {
+	if (_vehicle_status_sub < 0) {
+		_vehicle_status_sub = orb_subscribe(ORB_ID(vehicle_status));
+	}
+
+	orb_copy(ORB_ID(vehicle_status), _vehicle_status_sub, &_vehicle_status);
+
+	if (_vehicle_status.arming_state != _vehicle_status.ARMING_STATE_ARMED
+	    || !_vehicle_status.no_pwm) {
 		for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
-			if (_pin[i] >= 0) {
-				int ret_camera_pwm = px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pin[i]), math::constrain(PWM_CAMERA_DISARMED, 1000, 2000));
+			if (_pins[i] >= 0) {
+				px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pins[i]), math::constrain(PWM_CAMERA_DISARMED, 1000, 2000));
 			}
 		}
 
@@ -70,16 +83,16 @@ void CameraInterfacePWM::trigger(bool enable)
 		if (trig) {
 			// Set all valid pins to shoot level
 			for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
-				if (_pin[i] >= 0) {
-					int ret_camera_pwm = px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pin[i]), math::constrain(PWM_CAMERA_INSTANT_SHOOT, 1000, 2000));
+				if (_pins[i] >= 0) {
+					px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pins[i]), math::constrain(PWM_CAMERA_INSTANT_SHOOT, 1000, 2000));
 				}
 			}
 
 		} else {
 			// Set all valid pins back to neutral level
 			for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
-				if (_pin[i] >= 0) {
-					int ret_camera_pwm = px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pin[i]), math::constrain(PWM_CAMERA_NEUTRAL, 1000, 2000));
+				if (_pins[i] >= 0) {
+					px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pins[i]), math::constrain(PWM_CAMERA_NEUTRAL, 1000, 2000));
 				}
 			}
 		}
@@ -89,18 +102,25 @@ void CameraInterfacePWM::trigger(bool enable)
 int CameraInterfacePWM::powerOn()
 {
 	// Check if armed, otherwise don't send high PWM values
-	if (_disarmed) {
+	if (_vehicle_status_sub < 0) {
+		_vehicle_status_sub = orb_subscribe(ORB_ID(vehicle_status));
+	}
+
+	orb_copy(ORB_ID(vehicle_status), _vehicle_status_sub, &_vehicle_status);
+
+	if (_vehicle_status.arming_state != _vehicle_status.ARMING_STATE_ARMED
+	    || !_vehicle_status.no_pwm) {
 		for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
-			if (_pin[i] >= 0) {
-				int ret_camera_pwm = px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pin[i]), math::constrain(PWM_CAMERA_DISARMED, 1000, 2000));
+			if (_pins[i] >= 0) {
+				px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pins[i]), math::constrain(PWM_CAMERA_DISARMED, 1000, 2000));
 			}
 		}
 
 	} else {
 		// Set all valid pins to turn on level
 		for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
-			if (_pin[i] >= 0) {
-				int ret_camera_pwm = px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pin[i]), math::constrain(PWM_CAMERA_ON, 1000, 2000));
+			if (_pins[i] >= 0) {
+				px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pins[i]), math::constrain(PWM_CAMERA_ON, 1000, 2000));
 			}
 		}
 
@@ -113,18 +133,25 @@ int CameraInterfacePWM::powerOn()
 int CameraInterfacePWM::powerOff()
 {
 	// Check if armed, otherwise don't send high PWM values
-	if (_disarmed) {
+	if (_vehicle_status_sub < 0) {
+		_vehicle_status_sub = orb_subscribe(ORB_ID(vehicle_status));
+	}
+
+	orb_copy(ORB_ID(vehicle_status), _vehicle_status_sub, &_vehicle_status);
+
+	if (_vehicle_status.arming_state != _vehicle_status.ARMING_STATE_ARMED
+	    || !_vehicle_status.no_pwm) {
 		for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
-			if (_pin[i] >= 0) {
-				int ret_camera_pwm = px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pin[i]), math::constrain(PWM_CAMERA_DISARMED, 1000, 2000));
+			if (_pins[i] >= 0) {
+				px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pins[i]), math::constrain(PWM_CAMERA_DISARMED, 1000, 2000));
 			}
 		}
 
 	} else {
 		// Set all valid pins to turn off level
 		for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
-			if (_pin[i] >= 0) {
-				int ret_camera_pwm = px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pin[i]), math::constrain(PWM_CAMERA_OFF, 1000, 2000));
+			if (_pins[i] >= 0) {
+				px4_ioctl(_pwm_fd, PWM_CAMERA_SET(_pins[i]), math::constrain(PWM_CAMERA_OFF, 1000, 2000));
 			}
 		}
 

--- a/src/drivers/camera_trigger/interfaces/src/pwm.h
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.h
@@ -40,18 +40,7 @@ public:
 private:
 	void setup();
 
-	int _vehicle_status_sub;
-	struct vehicle_status_s _vehicle_status;
-
-	int _vehicle_status_sub;
-	struct vehicle_status_s _vehicle_status;
-
-	int _vehicle_status_sub;
-	struct vehicle_status_s _vehicle_status;
-
 	param_t _p_pin;
-	const char *_pwm_dev;
-	int _pwm_fd;
 	bool _camera_is_on;
 
 };

--- a/src/drivers/camera_trigger/interfaces/src/pwm.h
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.h
@@ -1,0 +1,27 @@
+/**
+ * @file pwm.h
+ *
+ * Interface with cameras via pwm.
+ *
+ */
+#pragma once
+
+#include "camera_interface.h"
+
+
+class CameraInterfacePWM : public CameraInterface
+{
+public:
+	CameraInterfacePWM();
+	virtual ~CameraInterfacePWM();
+
+	void setup();
+
+	void trigger(bool enable);
+
+	int powerOn();
+	int powerOff();
+
+private:
+
+};

--- a/src/drivers/camera_trigger/interfaces/src/pwm.h
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.h
@@ -11,20 +11,6 @@
 #include <uORB/topics/vehicle_status.h>
 #include "camera_interface.h"
 
-// TODO(birchera): check if this is the right device and addresses
-#define PWM_DEVICE_PATH			"/dev/pwm_output0"
-#define PWM_CAMERA_BASE			0x2a00
-#define PWM_CAMERA_SET(_pin)	_PX4_IOC(PWM_CAMERA_BASE, 0x30 + _pin)
-// PWM levels of the interface to seagull MAP converter to
-// Multiport (http://www.seagulluav.com/manuals/Seagull_MAP2-Manual.pdf)
-#define PWM_CAMERA_DISARMED			90 // TODO(birchera): check here value
-#define PWM_CAMERA_ON				1100
-#define PWM_CAMERA_AUTOFOCUS_SHOOT	1300
-#define PWM_CAMERA_NEUTRAL			1500
-#define PWM_CAMERA_INSTANT_SHOOT	1700
-#define PWM_CAMERA_OFF				1900
-
-
 class CameraInterfacePWM : public CameraInterface
 {
 public:

--- a/src/drivers/camera_trigger/interfaces/src/pwm.h
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.h
@@ -43,6 +43,9 @@ private:
 	int _vehicle_status_sub;
 	struct vehicle_status_s _vehicle_status;
 
+	int _vehicle_status_sub;
+	struct vehicle_status_s _vehicle_status;
+
 	param_t _p_pin;
 	const char *_pwm_dev;
 	int _pwm_fd;

--- a/src/drivers/camera_trigger/interfaces/src/pwm.h
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.h
@@ -6,20 +6,23 @@
  */
 #pragma once
 
+#include <systemlib/param/param.h>
+
+#include <uORB/topics/vehicle_status.h>
 #include "camera_interface.h"
 
 // TODO(birchera): check if this is the right device and addresses
-#define PWM_DEVICE_PATH /dev/pwm_output0
-#define PWM_CAMERA_BASE		0x2a00
-#define PWM_CAMERA_SET(_pin)	_PX4_IOC(_PWM_CAMERA_BASE, 0x30 + _pin)
+#define PWM_DEVICE_PATH			"/dev/pwm_output0"
+#define PWM_CAMERA_BASE			0x2a00
+#define PWM_CAMERA_SET(_pin)	_PX4_IOC(PWM_CAMERA_BASE, 0x30 + _pin)
 // PWM levels of the interface to seagull MAP converter to
 // Multiport (http://www.seagulluav.com/manuals/Seagull_MAP2-Manual.pdf)
-#define PWM_CAMERA_DISARMED 90 // TODO(birchera): check here value
-#define PWM_CAMERA_ON 1100
-#define PWM_CAMERA_AUTOFOCUS_SHOOT 1300
-#define PWM_CAMERA_NEUTRAL 1500
-#define PWM_CAMERA_INSTANT_SHOOT 1700
-#define PWM_CAMERA_OFF 1900
+#define PWM_CAMERA_DISARMED			90 // TODO(birchera): check here value
+#define PWM_CAMERA_ON				1100
+#define PWM_CAMERA_AUTOFOCUS_SHOOT	1300
+#define PWM_CAMERA_NEUTRAL			1500
+#define PWM_CAMERA_INSTANT_SHOOT	1700
+#define PWM_CAMERA_OFF				1900
 
 
 class CameraInterfacePWM : public CameraInterface
@@ -37,6 +40,9 @@ public:
 
 	int _pins[6];
 private:
+
+	int _vehicle_status_sub;
+	struct vehicle_status_s _vehicle_status;
 
 	param_t _p_pin;
 	const char *_pwm_dev;

--- a/src/drivers/camera_trigger/interfaces/src/pwm.h
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.h
@@ -31,8 +31,6 @@ public:
 	CameraInterfacePWM();
 	virtual ~CameraInterfacePWM();
 
-	void setup();
-
 	void trigger(bool enable);
 
 	int powerOn();
@@ -40,6 +38,7 @@ public:
 
 	int _pins[6];
 private:
+	void setup();
 
 	int _vehicle_status_sub;
 	struct vehicle_status_s _vehicle_status;

--- a/src/drivers/camera_trigger/interfaces/src/pwm.h
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.h
@@ -36,6 +36,8 @@ public:
 	int powerOn();
 	int powerOff();
 
+	void info();
+
 	int _pins[6];
 private:
 	void setup();

--- a/src/drivers/camera_trigger/interfaces/src/pwm.h
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.h
@@ -46,6 +46,9 @@ private:
 	int _vehicle_status_sub;
 	struct vehicle_status_s _vehicle_status;
 
+	int _vehicle_status_sub;
+	struct vehicle_status_s _vehicle_status;
+
 	param_t _p_pin;
 	const char *_pwm_dev;
 	int _pwm_fd;

--- a/src/drivers/camera_trigger/interfaces/src/pwm.h
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.h
@@ -8,6 +8,19 @@
 
 #include "camera_interface.h"
 
+// TODO(birchera): check if this is the right device and addresses
+#define PWM_DEVICE_PATH /dev/pwm_output0
+#define PWM_CAMERA_BASE		0x2a00
+#define PWM_CAMERA_SET(_pin)	_PX4_IOC(_PWM_CAMERA_BASE, 0x30 + _pin)
+// PWM levels of the interface to seagull MAP converter to
+// Multiport (http://www.seagulluav.com/manuals/Seagull_MAP2-Manual.pdf)
+#define PWM_CAMERA_DISARMED 90 // TODO(birchera): check here value
+#define PWM_CAMERA_ON 1100
+#define PWM_CAMERA_AUTOFOCUS_SHOOT 1300
+#define PWM_CAMERA_NEUTRAL 1500
+#define PWM_CAMERA_INSTANT_SHOOT 1700
+#define PWM_CAMERA_OFF 1900
+
 
 class CameraInterfacePWM : public CameraInterface
 {
@@ -22,6 +35,12 @@ public:
 	int powerOn();
 	int powerOff();
 
+	int _pins[6];
 private:
+
+	param_t _p_pin;
+	const char *_pwm_dev;
+	int _pwm_fd;
+	bool _camera_is_on;
 
 };

--- a/src/drivers/camera_trigger/interfaces/src/relay.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/relay.cpp
@@ -72,6 +72,6 @@ void CameraInterfaceRelay::trigger(bool enable)
 
 void CameraInterfaceRelay::info()
 {
-	warnx("pins 1-3 : %d,%d,%d polarity : %s", _pins[0], _pins[1], _pins[2],
+	warnx("Relay - camera triggering, pins 1-3 : %d,%d,%d polarity : %s", _pins[0], _pins[1], _pins[2],
 	      _polarity ? "ACTIVE_HIGH" : "ACTIVE_LOW");
 }

--- a/src/drivers/camera_trigger/interfaces/src/relay.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/relay.cpp
@@ -1,0 +1,75 @@
+#include "relay.h"
+
+constexpr uint32_t CameraInterfaceRelay::_gpios[6];
+
+CameraInterfaceRelay::CameraInterfaceRelay():
+	CameraInterface(),
+	_pins{},
+	_polarity(0)
+{
+	_p_pin = param_find("TRIG_PINS");
+	_p_polarity = param_find("TRIG_POLARITY");
+
+	int pin_list;
+	param_get(_p_pin, &pin_list);
+	param_get(_p_polarity, &_polarity);
+
+	// Set all pins as invalid
+	for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
+		_pins[i] = -1;
+	}
+
+	// Convert number to individual channels
+	unsigned i = 0;
+	int single_pin;
+
+	while ((single_pin = pin_list % 10)) {
+
+		_pins[i] = single_pin - 1;
+
+		if (_pins[i] < 0 || _pins[i] >= static_cast<int>(sizeof(_gpios) / sizeof(_gpios[0]))) {
+			_pins[i] = -1;
+		}
+
+		pin_list /= 10;
+		i++;
+	}
+}
+
+CameraInterfaceRelay::~CameraInterfaceRelay()
+{
+}
+
+void CameraInterfaceRelay::setup()
+{
+	for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
+		stm32_configgpio(_gpios[_pins[i]]);
+		stm32_gpiowrite(_gpios[_pins[i]], !_polarity);
+	}
+}
+
+void CameraInterfaceRelay::trigger(bool enable)
+{
+	if (enable) {
+		for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
+			if (_pins[i] >= 0) {
+				// ACTIVE_LOW == 1
+				stm32_gpiowrite(_gpios[_pins[i]], _polarity);
+			}
+		}
+
+	} else {
+		for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
+			if (_pins[i] >= 0) {
+				// ACTIVE_LOW == 1
+				stm32_gpiowrite(_gpios[_pins[i]], !_polarity);
+			}
+		}
+	}
+}
+
+void CameraInterfaceRelay::info()
+{
+	warnx("pins 1-3 : %d,%d,%d polarity : %s", _pins[0], _pins[1], _pins[2],
+	      _polarity ? "ACTIVE_HIGH" : "ACTIVE_LOW");
+}

--- a/src/drivers/camera_trigger/interfaces/src/relay.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/relay.cpp
@@ -34,6 +34,8 @@ CameraInterfaceRelay::CameraInterfaceRelay():
 		pin_list /= 10;
 		i++;
 	}
+
+	setup();
 }
 
 CameraInterfaceRelay::~CameraInterfaceRelay()

--- a/src/drivers/camera_trigger/interfaces/src/relay.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/relay.cpp
@@ -45,8 +45,8 @@ CameraInterfaceRelay::~CameraInterfaceRelay()
 void CameraInterfaceRelay::setup()
 {
 	for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
-		stm32_configgpio(_gpios[_pins[i]]);
-		stm32_gpiowrite(_gpios[_pins[i]], !_polarity);
+		px4_arch_configgpio(_gpios[_pins[i]]);
+		px4_arch_gpiowrite(_gpios[_pins[i]], !_polarity);
 	}
 }
 
@@ -56,7 +56,7 @@ void CameraInterfaceRelay::trigger(bool enable)
 		for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
 			if (_pins[i] >= 0) {
 				// ACTIVE_LOW == 1
-				stm32_gpiowrite(_gpios[_pins[i]], _polarity);
+				px4_arch_gpiowrite(_gpios[_pins[i]], _polarity);
 			}
 		}
 
@@ -64,7 +64,7 @@ void CameraInterfaceRelay::trigger(bool enable)
 		for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i++) {
 			if (_pins[i] >= 0) {
 				// ACTIVE_LOW == 1
-				stm32_gpiowrite(_gpios[_pins[i]], !_polarity);
+				px4_arch_gpiowrite(_gpios[_pins[i]], !_polarity);
 			}
 		}
 	}

--- a/src/drivers/camera_trigger/interfaces/src/relay.h
+++ b/src/drivers/camera_trigger/interfaces/src/relay.h
@@ -19,8 +19,6 @@ public:
 	CameraInterfaceRelay();
 	virtual ~CameraInterfaceRelay();
 
-	void setup();
-
 	void trigger(bool enable);
 
 	void info();
@@ -29,6 +27,9 @@ public:
 	int _polarity;
 
 private:
+
+	void setup();
+
 	param_t _p_pin;
 	param_t _p_polarity;
 

--- a/src/drivers/camera_trigger/interfaces/src/relay.h
+++ b/src/drivers/camera_trigger/interfaces/src/relay.h
@@ -1,0 +1,44 @@
+/**
+ * @file relay.h
+ *
+ * Interface with cameras via FMU auxiliary pins.
+ *
+ */
+#pragma once
+
+#include <systemlib/err.h>
+#include <systemlib/param/param.h>
+#include <board_config.h>
+
+#include "camera_interface.h"
+
+
+class CameraInterfaceRelay : public CameraInterface
+{
+public:
+	CameraInterfaceRelay();
+	virtual ~CameraInterfaceRelay();
+
+	void setup();
+
+	void trigger(bool enable);
+
+	void info();
+
+	int _pins[6];
+	int _polarity;
+
+private:
+	param_t _p_pin;
+	param_t _p_polarity;
+
+	static constexpr uint32_t _gpios[6] = {
+		GPIO_GPIO0_OUTPUT,
+		GPIO_GPIO1_OUTPUT,
+		GPIO_GPIO2_OUTPUT,
+		GPIO_GPIO3_OUTPUT,
+		GPIO_GPIO4_OUTPUT,
+		GPIO_GPIO5_OUTPUT
+	};
+
+};


### PR DESCRIPTION
This implements the interface to manipulate payload cameras via PWM signals. To this end, the actual interfaces are factored out from the triggering class.

The interface is designed to communicate with a Seagull MAP MultiPort adapter chip. The supported functions are:
* Instant shoot
* Camera turn on/off

We are still waiting for the camera to arrive, so the interface is as anticipated and will be tested. This is to get early feedback.