### PR TITLE
Properly reflect flow control state if IOCTL fails

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -205,7 +205,7 @@ Mavlink::Mavlink() :
 	_subscribe_to_stream(nullptr),
 	_subscribe_to_stream_rate(0.0f),
 	_udp_initialised(false),
-	_flow_control_enabled(true),
+	_flow_control_enabled(false),
 	_last_write_success_time(0),
 	_last_write_try_time(0),
 	_mavlink_start_time(0),


### PR DESCRIPTION
The flow control state is improperly reflected as enabled if the arch/HAL rejects an IOCTL to turn it on. Mavlink::enable_flow_control updates _flow_control_enabled only if the IOCTL call does not fail.