### PR TITLE
fix 10020_3dr_quad script: load proper mixer file

### DIFF
--- a/ROMFS/px4fmu_common/init.d/10020_3dr_quad
+++ b/ROMFS/px4fmu_common/init.d/10020_3dr_quad
@@ -7,7 +7,7 @@
 # @maintainer Lorenz Meier <lorenz@px4.io>
 #
 
-sh /etc/init.d/rc.mc_defaults
+sh /etc/init.d/4001_quad_x
 
 if [ $AUTOCNF == yes ]
 then


### PR DESCRIPTION
fixes regression from 85245471c05a7453ffa50e2e74dbf8f48c01982b