### PR TITLE
Bind Spektrum satellite using only recommended mode

### DIFF
--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -2426,19 +2426,16 @@ void
 PX4FMU::dsm_bind_ioctl(int dsmMode)
 {
 	if (!_armed.armed) {
-//      mavlink_log_info(&_mavlink_log_pub, "[FMU] binding DSM%s RX", (dsmMode == 0) ? "2" : ((dsmMode == 1) ? "-X" : "-X8"));
-		warnx("[FMU] binding DSM%s RX", (dsmMode == 0) ? "2" : ((dsmMode == 1) ? "-X" : "-X8"));
-		int ret = ioctl(nullptr, DSM_BIND_START,
-				(dsmMode == 0) ? DSM2_BIND_PULSES : ((dsmMode == 1) ? DSMX_BIND_PULSES : DSMX8_BIND_PULSES));
+		PX4_INFO("[FMU] binding Spektrum RX");
+		/* specify 11ms DSMX. RX will automatically fall back to 22ms or DSM2 if necessary */
+		int ret = ioctl(nullptr, DSM_BIND_START, DSMX8_BIND_PULSES);
 
 		if (ret) {
-//            mavlink_log_critical(&_mavlink_log_pub, "binding failed.");
-			warnx("binding failed.");
+			PX4_INFO("binding failed.");
 		}
 
 	} else {
-//        mavlink_log_info(&_mavlink_log_pub, "[FMU] system armed, bind request rejected");
-		warnx("[FMU] system armed, bind request rejected");
+		PX4_INFO("[FMU] system armed, bind request rejected");
 	}
 }
 

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -2465,6 +2465,7 @@ bind_spektrum()
 
 	if (true) {
 		PX4_INFO("bind_Spektrum RX");
+
 		/* specify 11ms DSMX. RX will automatically fall back to 22ms or DSM2 if necessary */
 		if (ioctl(fd, DSM_BIND_START, DSMX8_BIND_PULSES)) {
 			PX4_ERR("binding failed.");

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1992,7 +1992,7 @@ PX4FMU::pwm_ioctl(file *filp, int cmd, unsigned long arg)
 
 	case DSM_BIND_START:
 		/* only allow DSM2, DSM-X and DSM-X with more than 7 channels */
-		PX4_DEBUG("pwm_ioctl: DSM_BIND_START, arg: %lu", arg);
+		PX4_INFO("pwm_ioctl: DSM_BIND_START, arg: %lu", arg);
 
 		if (arg == DSM2_BIND_PULSES ||
 		    arg == DSMX_BIND_PULSES ||
@@ -2455,8 +2455,26 @@ namespace
 void
 bind_spektrum()
 {
-	/* specify 11ms DSMX. RX will automatically fall back to 22ms or DSM2 if necessary */
-	g_fmu->dsm_bind_ioctl();
+	int	 fd;
+
+	fd = open(PX4FMU_DEVICE_PATH, O_RDWR);
+
+	if (fd < 0) {
+		errx(1, "open fail");
+	}
+
+	if (true) {
+		PX4_INFO("bind_Spektrum RX");
+		/* specify 11ms DSMX. RX will automatically fall back to 22ms or DSM2 if necessary */
+		if (ioctl(fd, DSM_BIND_START, DSMX8_BIND_PULSES)) {
+			PX4_ERR("binding failed.");
+		}
+
+	} else {
+		PX4_WARN("system armed, bind request rejected");
+	}
+
+	close(fd);
 
 }
 

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -3266,27 +3266,8 @@ bind(int argc, char *argv[])
 
 #endif
 
-	if (argc < 3) {
-		errx(0, "needs argument, use dsm2, dsmx or dsmx8");
-	}
-
-	if (!strcmp(argv[2], "dsm2")) {
-		pulses = DSM2_BIND_PULSES;
-
-	} else if (!strcmp(argv[2], "dsmx")) {
-		pulses = DSMX_BIND_PULSES;
-
-	} else if (!strcmp(argv[2], "dsmx8")) {
-		pulses = DSMX8_BIND_PULSES;
-
-	} else {
-		errx(1, "unknown parameter %s, use dsm2, dsmx or dsmx8", argv[2]);
-	}
-
-	// Test for custom pulse parameter
-	if (argc > 3) {
-		pulses = atoi(argv[3]);
-	}
+	/* specify 11ms DSMX. RX will automatically fall back to 22ms or DSM2 if necessary */
+	pulses = DSMX8_BIND_PULSES;
 
 	if (g_dev->system_status() & PX4IO_P_STATUS_FLAGS_SAFETY_OFF) {
 		errx(1, "system must not be armed");

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1074,18 +1074,6 @@ PX4IO::task_main()
 				parameter_update_s pupdate;
 				orb_copy(ORB_ID(parameter_update), _t_param, &pupdate);
 
-				int32_t dsm_bind_val;
-				param_t dsm_bind_param;
-
-				/* see if bind parameter has been set, and reset it to -1 */
-				param_get(dsm_bind_param = param_find("RC_DSM_BIND"), &dsm_bind_val);
-
-				if (dsm_bind_val > -1) {
-					dsm_bind_ioctl(dsm_bind_val);
-					dsm_bind_val = -1;
-					param_set(dsm_bind_param, &dsm_bind_val);
-				}
-
 				if (!_rc_handling_disabled) {
 					/* re-upload RC input config as it may have changed */
 					io_set_rc_config();

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -1943,17 +1943,6 @@ PARAM_DEFINE_FLOAT(RC18_DZ, 0.0f);
 PARAM_DEFINE_INT32(RC_RL1_DSM_VCC, 0); /* Relay 1 controls DSM VCC */
 
 /**
- * DSM binding trigger.
- *
- * @value -1 Inactive
- * @value 1 Start DSM bind
- * @min -1
- * @max 1
- * @group Radio Calibration
- */
-PARAM_DEFINE_INT32(RC_DSM_BIND, -1);
-
-/**
  * Scaling factor for battery voltage sensor on PX4IO.
  *
  * @min 1

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -1946,8 +1946,7 @@ PARAM_DEFINE_INT32(RC_RL1_DSM_VCC, 0); /* Relay 1 controls DSM VCC */
  * DSM binding trigger.
  *
  * @value -1 Inactive
- * @value 0 Start DSM2 bind
- * @value 1 Start DSMX bind
+ * @value 1 Start DSM bind
  * @min -1
  * @max 1
  * @group Radio Calibration


### PR DESCRIPTION
Always select "internal" 11msec DSMX mode. This provides automatic fallback by RX to DSM2 and/or 22msec frame rate if necessary.

This change ignores the value of parameter RC_DSM_BIND,  any value >= 0 will result in 9 pulses being sent during the bind operation.

Also change from warnx to PX4_x for logging