### PR TITLE
SF10A driver fix

### DIFF
--- a/src/drivers/sf10a/sf10a.cpp
+++ b/src/drivers/sf10a/sf10a.cpp
@@ -572,12 +572,13 @@ SF10A::start()
 	work_queue(HPWORK, &_work, (worker_t)&SF10A::cycle_trampoline, this, 5);
 
 	/* notify about state change */
-	struct subsystem_info_s info = {
-		true,
-		true,
-		true,
-		subsystem_info_s::SUBSYSTEM_TYPE_RANGEFINDER
-	};
+		struct subsystem_info_s info = {};
+		info.present = true;
+		info.enabled = true;
+		info.ok = true;
+		info.subsystem_type = subsystem_info_s::SUBSYSTEM_TYPE_RANGEFINDER;
+
+
 	static orb_advert_t pub = nullptr;
 
 	if (pub != nullptr) {


### PR DESCRIPTION
Fixes compilation error for the SF10a driver. I would like to add the SF10a driver to nuttx_px4fmu-v2_default.cmake as well, but building this returns with flash out of space error. In my own installation, I removed some other unused drivers, which might not be appropriate for other users. Any general procedure to deal with that?