### PR TITLE
Leave some pins available for camera trigger GPIO.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -298,6 +298,17 @@ then
 		set FMU_MODE gpio_serial
 	fi
 
+	if param greater TRIG_MODE 0
+	then
+		if [ $PWM_OUT == 1234 ]
+		then
+			if ver hwcmp PX4FMU_V4
+			then
+				set FMU_MODE pwm4
+			fi
+		fi
+	fi
+
 	if [ $HIL == yes ]
 	then
 		set OUTPUT_MODE hil


### PR DESCRIPTION
Currently, all pins are configured as PWMs and as a result the camera trigger does not work.

This fix is limited to frames with 4 motors, because of using pwm4. Btw, same limitation seems to apply to the lidar setup (`SENS_EN_LL40LS`).

I also limited it to PX4FMU_V4, because there is some setup for PX4FMU_V1 depending on `$FMU_MODE == pwm`.