### PR TITLE
Fix mavlink forwarding issue.

### DIFF
--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -280,7 +280,7 @@ public:
 	/**
 	 * Resend message as is, don't change sequence number and CRC.
 	 */
-	void			resend_message(mavlink_message_t *msg);
+	void			resend_message(mavlink_message_t *msg) { _mavlink_resend_uart(_channel, msg); }
 
 	void			handle_message(const mavlink_message_t *msg);
 


### PR DESCRIPTION
Fix #4816 Mavlink forwarding not working on master.

PX4 master introduce mavlink v2.0 from v1.3.2, but mavros still use mavlink v1.0. 
It will cause compatibility problem when forwarding mavlink v1.0 message.
[MAVLINK_NUM_HEADER_BYTES](https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_main.cpp#L1025) always represents mavlink v2.0 header bytes regardless of mavlink v1.0 or v2.0 message to forward.

[mavlink api _mavlink_resend_uart](https://github.com/mavlink/c_library_v2/blob/master/mavlink_helpers.h#L355) can distinguish v2.0 from v1.0.

