### PR TITLE
Add gps epv/eph minimum to prevent gps from self reporting bad values.

### DIFF
--- a/src/modules/local_position_estimator/sensors/gps.cpp
+++ b/src/modules/local_position_estimator/sensors/gps.cpp
@@ -8,6 +8,8 @@ extern orb_advert_t mavlink_log_pub;
 // to initialize
 static const uint32_t 		REQ_GPS_INIT_COUNT = 10;
 static const uint32_t 		GPS_TIMEOUT =      1000000; // 1.0 s
+static const float 			GPS_EPH_MIN =      2.0; // m, min allowed by gps self reporting
+static const float 			GPS_EPV_MIN =      2.0; // m, min allowed by gps self reporting
 
 void BlockLocalPositionEstimator::gpsInit()
 {
@@ -122,12 +124,12 @@ void BlockLocalPositionEstimator::gpsCorrect()
 	float var_vxy = _gps_vxy_stddev.get() * _gps_vxy_stddev.get();
 	float var_vz = _gps_vz_stddev.get() * _gps_vz_stddev.get();
 
-	// if field is not zero, set it to the value provided
-	if (_sub_gps.get().eph > 1e-3f) {
+	// if field is not below minimum, set it to the value provided
+	if (_sub_gps.get().eph > GPS_EPH_MIN) {
 		var_xy = _sub_gps.get().eph * _sub_gps.get().eph;
 	}
 
-	if (_sub_gps.get().epv > 1e-3f) {
+	if (_sub_gps.get().epv > GPS_EPV_MIN) {
 		var_z = _sub_gps.get().epv * _sub_gps.get().epv;
 	}
 


### PR DESCRIPTION
This prevents gps units from reporting eph/ epv values below a minimum, set to 2.0 m. In a log, one GPS unit was reporting EPH of 60 cm instead of 200 cm, which caused very jittery estimation.

Here is the plot where the estimator is doing better than the GPS but is trusting the GPS too much and causing jiiter.

![image](https://cloud.githubusercontent.com/assets/473772/16368808/d7b50da0-3c00-11e6-86db-0d55529144fb.png)

You can see here that the EPH is significantly lower than in a normal flight.

![image](https://cloud.githubusercontent.com/assets/473772/16368797/b66242da-3c00-11e6-8442-660336e60c77.png)

Here you can see the resulting jitter.

![image](https://cloud.githubusercontent.com/assets/473772/16368805/cc6a84f2-3c00-11e6-8780-0b215b190911.png)

It is clearly present in the power spectrum:

![image](https://cloud.githubusercontent.com/assets/473772/16368848/388740ee-3c01-11e6-87af-05b00c40b1eb.png)


You can also see that with GPS reporting this accuracy the estimator is predicting a standard deviation of 15 cm, when 30 cm is more accurate with reasonable GPS values:

![image](https://cloud.githubusercontent.com/assets/473772/16368915/f37784cc-3c01-11e6-8af2-b141dcdc2b7a.png)
