### PR TITLE
position_estimator_inav: fix compiler issue for GCC 6.1.1

### DIFF
--- a/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
@@ -657,9 +657,9 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 					if (updated)
 						orb_copy(ORB_ID(vehicle_rates_setpoint), vehicle_rate_sp_sub, &rates_setpoint);
 
-					double rate_threshold = 0.15f;
+					float rate_threshold = 0.15f;
 
-					if (fabs(rates_setpoint.pitch) < rate_threshold) {
+					if (fabsf(rates_setpoint.pitch) < rate_threshold) {
 						//warnx("[inav] test ohne comp");
 						flow_ang[0] = (flow.pixel_flow_x_integral / (float)flow.integration_timespan * 1000000.0f) * params.flow_k;//for now the flow has to be scaled (to small)
 					}
@@ -670,7 +670,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 							       + gyro_offset_filtered[0]) * params.flow_k;//for now the flow has to be scaled (to small)
 					}
 
-					if (fabs(rates_setpoint.roll) < rate_threshold) {
+					if (fabsf(rates_setpoint.roll) < rate_threshold) {
 						flow_ang[1] = (flow.pixel_flow_y_integral / (float)flow.integration_timespan * 1000000.0f) * params.flow_k;//for now the flow has to be scaled (to small)
 					}
 					else {
@@ -681,7 +681,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 
 					/* flow measurements vector */
 					float flow_m[3];
-					if (fabs(rates_setpoint.yaw) < rate_threshold) {
+					if (fabsf(rates_setpoint.yaw) < rate_threshold) {
 						flow_m[0] = -flow_ang[0] * flow_dist;
 						flow_m[1] = -flow_ang[1] * flow_dist;
 					} else {


### PR DESCRIPTION
GCC output:
implicit conversion from ‘float’ to ‘double’ to match other operand of
binary expression [-Werror=double-promotion]

It seems gcc 6.1.1 uses the float variant of fabs, whereas older gcc's
use the double version. This makes it compile for both.