### PR TITLE
navigator: Takeoff and reposition lat/long already in degrees.

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -436,8 +436,8 @@ Navigator::task_main()
 				}
 
 				if (PX4_ISFINITE(cmd.param5) && PX4_ISFINITE(cmd.param6)) {
-					rep->current.lat = cmd.param5 / (double)1e7;
-					rep->current.lon = cmd.param6 / (double)1e7;
+					rep->current.lat = cmd.param5;
+					rep->current.lon = cmd.param6;
 				} else {
 					rep->current.lat = get_global_position()->lat;
 					rep->current.lon = get_global_position()->lon;
@@ -465,8 +465,8 @@ Navigator::task_main()
 				rep->current.loiter_direction = 1;
 				rep->current.type = position_setpoint_s::SETPOINT_TYPE_TAKEOFF;
 				rep->current.yaw = cmd.param4;
-				rep->current.lat = cmd.param5 / (double)1e7;
-				rep->current.lon = cmd.param6 / (double)1e7;
+				rep->current.lat = cmd.param5;
+				rep->current.lon = cmd.param6;
 				rep->current.alt = cmd.param7;
 
 				rep->previous.valid = true;


### PR DESCRIPTION
Param 5&6 is already scaled in COMMAND_INT handler, so scaling in navigator is bug, which is masked by NAN math. 

Fixes issue #4844.