### PR TITLE
Corrections on DO_SET_SERVO mission item

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -45,7 +45,7 @@ then
 
 	if mixer load $OUTPUT_DEV $MIXER_FILE
 	then
-		echo "INFO  [init] Mixer: $MIXER_FILE on $OUTPUT_DEV"
+		echo "INFO  [init] Mixer: $MIXER_FILE on $OUTPUT_DEV" >> $LOG_FILE
 	else
 		echo "ERROR [init] Error loading mixer: $MIXER_FILE"
 		echo "ERROR:[init] Could not load mixer: $MIXER_FILE" >> $LOG_FILE
@@ -137,7 +137,7 @@ then
 			then
 				if mixer load $OUTPUT_AUX_DEV $MIXER_AUX_FILE
 				then
-					echo "INFO  [init] Mixer: $MIXER_AUX_FILE on $OUTPUT_AUX_DEV"
+					echo "INFO  [init] Mixer: $MIXER_AUX_FILE on $OUTPUT_AUX_DEV" >> $LOG_FILE
 				else
 					echo "ERROR [init] Error loading mixer: $MIXER_AUX_FILE"
 					echo "ERROR [init] Could not load mixer: $MIXER_AUX_FILE" >> $LOG_FILE

--- a/ROMFS/px4fmu_common/mixers/pass.aux.mix
+++ b/ROMFS/px4fmu_common/mixers/pass.aux.mix
@@ -1,21 +1,36 @@
 # Manual pass through mixer for servo outputs 1-4
 
 # AUX1 channel (select RC channel with RC_MAP_AUX1 param)
-M: 1
+M: 2
 O:      10000  10000      0 -10000  10000
+S: 2 1  10000  10000      0 -10000  10000
 S: 3 5  10000  10000      0 -10000  10000
 
 # AUX2 channel (select RC channel with RC_MAP_AUX2 param)
-M: 1
+M: 2
 O:      10000  10000      0 -10000  10000
+S: 2 2  10000  10000      0 -10000  10000
 S: 3 6  10000  10000      0 -10000  10000
 
 # AUX3 channel (select RC channel with RC_MAP_AUX3 param)
-M: 1
+M: 2
 O:      10000  10000      0 -10000  10000
+S: 2 3  10000  10000      0 -10000  10000
 S: 3 7  10000  10000      0 -10000  10000
 
 # FLAPS channel (select RC channel with RC_MAP_FLAPS param)
+M: 2
+O:      10000  10000      0 -10000  10000
+S: 2 4  10000  10000      0 -10000  10000
+S: 3 4  10000  10000      0 -10000  10000
+
+# AUX5 channel (select servo id 5 in mission item)
 M: 1
 O:      10000  10000      0 -10000  10000
-S: 3 4  10000  10000      0 -10000  10000
+S: 2 5  10000  10000      0 -10000  10000
+
+# AUX6 channel (select servo id 6 in mission item)
+M: 1
+O:      10000  10000      0 -10000  10000
+S: 2 6  10000  10000      0 -10000  10000
+


### PR DESCRIPTION
Hello,
   I have modified default auxiliary mixer to accept input from actuators group 2
Next i added bootlog.txt as output into rc.interface to have more visible mixers loading process when user try to upload own mixer
Last change - adding DO_SET_SERVO mission item check in navigator( before only first mission item are checked) and correction of limits for id of AUX outputs ( from 0...5 to 1...6)
Changes are tested in flight today for all 6 AUX channels.
Regards,
Michail.