### PR TITLE
EKF2 HIL gps decrease s_variance_m_s 5.0 -> 1.0

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1789,7 +1789,7 @@ MavlinkReceiver::handle_message_hil_gps(mavlink_message_t *msg)
 	hil_gps.eph = (float)gps.eph * 1e-2f; // from cm to m
 	hil_gps.epv = (float)gps.epv * 1e-2f; // from cm to m
 
-	hil_gps.s_variance_m_s = 5.0f;
+	hil_gps.s_variance_m_s = 1.0f;
 
 	hil_gps.vel_m_s = (float)gps.vel * 1e-2f; // from cm/s to m/s
 	hil_gps.vel_n_m_s = gps.vn * 1e-2f; // from cm to m


### PR DESCRIPTION
Needed for HIL with EKF2 (QGC/XPlane). Alternatively I could adjust the param in the init script for the HIL easystart.