### PR TITLE
Change lower range limit of SF10a to 0.01m

### DIFF
--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -25,8 +25,9 @@ set(config_module_list
 	drivers/ms5611
 	#drivers/mb12xx
 	drivers/srf02
+	drivers/sf10a
 	drivers/sf0x
-	drivers/ll40ls
+	#drivers/ll40ls
 	drivers/trone
 	drivers/gps
 	drivers/pwm_out_sim
@@ -46,7 +47,7 @@ set(config_module_list
 	drivers/pwm_input
 	drivers/camera_trigger
 	drivers/bst
-	drivers/snapdragon_rc_pwm
+	#drivers/snapdragon_rc_pwm
 	drivers/lis3mdl
 
 	#

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -25,9 +25,8 @@ set(config_module_list
 	drivers/ms5611
 	#drivers/mb12xx
 	drivers/srf02
-	drivers/sf10a
 	drivers/sf0x
-	#drivers/ll40ls
+	drivers/ll40ls
 	drivers/trone
 	drivers/gps
 	drivers/pwm_out_sim
@@ -47,7 +46,7 @@ set(config_module_list
 	drivers/pwm_input
 	drivers/camera_trigger
 	drivers/bst
-	#drivers/snapdragon_rc_pwm
+	drivers/snapdragon_rc_pwm
 	drivers/lis3mdl
 
 	#

--- a/src/drivers/sf10a/sf10a.cpp
+++ b/src/drivers/sf10a/sf10a.cpp
@@ -80,7 +80,7 @@
 #define SF10A_DEVICE_PATH	"/dev/sf10a"
 
 /* Device limits */
-#define SF10A_MIN_DISTANCE 	(0.0f)
+#define SF10A_MIN_DISTANCE 	(0.01f)
 #define SF10A_MAX_DISTANCE 	(25.0f)
 
 


### PR DESCRIPTION
This ensures, that LIDAR is initialized properly in LPE. Refer to [#4878](https://github.com/PX4/Firmware/issues/4878).