### PR TITLE
ekf2: don't ignore function argument

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -116,7 +116,7 @@ public:
 	 */
 	int		start();
 
-	void 	set_replay_mode(bool replay) {_replay_mode = true;};
+	void 	set_replay_mode(bool replay) {_replay_mode = replay;};
 
 	static void	task_main_trampoline(int argc, char *argv[]);
 


### PR DESCRIPTION
This looks like a bug but the function was never actually wrongly used.