### PR TITLE
Snapdragon: Fix sdlog2 update misses

### DIFF
--- a/posix-configs/eagle/flight/mainapp.config
+++ b/posix-configs/eagle/flight/mainapp.config
@@ -2,6 +2,7 @@ uorb start
 muorb start
 sdlog2 start -r 100 -e -t -a -b 200
 param set MAV_BROADCAST 1
+param set SDLOG_PRIO_BOOST 3
 dataman start
 navigator start
 mavlink start -u 14556 -r 1000000

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -144,8 +144,14 @@ static bool logwriter_should_exit = false;	/**< Logwriter thread exit flag */
 static const unsigned MAX_NO_LOGFOLDER = 999;	/**< Maximum number of log dirs */
 static const unsigned MAX_NO_LOGFILE = 999;		/**< Maximum number of log files */
 static const int LOG_BUFFER_SIZE_DEFAULT = 8192;
+
+#if defined __PX4_POSIX
+static const int MAX_WRITE_CHUNK = 2048;
+static const int MIN_BYTES_TO_WRITE = 256;
+#else
 static const int MAX_WRITE_CHUNK = 512;
-static const int MIN_BYTES_TO_WRITE = 512;
+static const int MIN_BYTES_TO_WRITE = 256;
+#endif
 
 static bool _extended_logging = false;
 static bool _gpstime_only = false;

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -147,10 +147,10 @@ static const int LOG_BUFFER_SIZE_DEFAULT = 8192;
 
 #if defined __PX4_POSIX
 static const int MAX_WRITE_CHUNK = 2048;
-static const int MIN_BYTES_TO_WRITE = 256;
+static const int MIN_BYTES_TO_WRITE = 512;
 #else
 static const int MAX_WRITE_CHUNK = 512;
-static const int MIN_BYTES_TO_WRITE = 256;
+static const int MIN_BYTES_TO_WRITE = 512;
 #endif
 
 static bool _extended_logging = false;

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1503,7 +1503,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 			continue;
 		}
 
-		if (poll_counter++ >= poll_to_logging_factor) {
+		if ((poll_counter+1) >= poll_to_logging_factor) {
 			poll_counter = 0;
 		} else {
 
@@ -1531,6 +1531,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 					}
 					break;
 			}
+			poll_counter++;
 			continue;
 		}
 

--- a/src/platforms/posix/main.cpp
+++ b/src/platforms/posix/main.cpp
@@ -162,6 +162,21 @@ bool px4_exit_requested(void)
 	return _ExitFlag;
 }
 
+static void set_cpu_scaling()
+{
+#ifdef __PX4_POSIX_EAGLE
+	// On Snapdragon we miss updates in sdlog2 unless all 4 CPUs are run
+	// at the maximum frequency all the time.
+	// Interestingely, cpu0 and cpu3 set the scaling for all 4 CPUs on Snapdragon.
+	system("echo performance > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor");
+	system("echo performance > /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor");
+
+	// Alternatively we could also raise the minimum frequency to save some power,
+	// unfortunately this still lead to some drops.
+	//system("echo 1190400 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq");
+#endif
+}
+
 int main(int argc, char **argv)
 {
 	bool daemon_mode = false;
@@ -183,6 +198,8 @@ int main(int argc, char **argv)
 	sigaction(SIGINT, &sig_int, NULL);
 	//sigaction(SIGTERM, &sig_int, NULL);
 	sigaction(SIGFPE, &sig_fpe, NULL);
+
+	set_cpu_scaling();
 
 	int index = 1;
 	char *commands_file = nullptr;


### PR DESCRIPTION
sdlog2 sometimes missed samples on Snapdragon. This is not the usual drops because of file IO but rather the poll loop doesn't keep up and misses a sample.

The drops still happens with the fixes in this PR every few minutes but generally a lot less frequent than earlier.

The fixes are regression tested on Pixhawk for both normal and replay logging.

FYI: @LorenzMeier, @bkueng 