### PR TITLE
Conditionally define __STDC_FORMAT_MACROS

### DIFF
--- a/Tools/generate_listener.py
+++ b/Tools/generate_listener.py
@@ -106,6 +106,10 @@ print("""
  * Tool for listening to topics when running flight stack on linux.
  */
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <drivers/drv_hrt.h>
 #include <px4_middleware.h>
 #include <px4_app.h>
@@ -115,7 +119,6 @@ print("""
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #ifndef PRIu64

--- a/src/drivers/drv_hrt.h
+++ b/src/drivers/drv_hrt.h
@@ -39,9 +39,12 @@
 
 #pragma once
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <sys/types.h>
 #include <stdbool.h>
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #include <px4_time.h>

--- a/src/drivers/px4flow/i2c_frame.h
+++ b/src/drivers/px4flow/i2c_frame.h
@@ -41,7 +41,10 @@
 #ifndef I2C_FRAME_H_
 #define I2C_FRAME_H_
 
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 
 typedef  struct i2c_frame {

--- a/src/lib/controllib/block/Block.hpp
+++ b/src/lib/controllib/block/Block.hpp
@@ -39,7 +39,10 @@
 
 #pragma once
 
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
+
 #include <stdint.h>
 #include <inttypes.h>
 

--- a/src/modules/px4iofirmware/protocol.h
+++ b/src/modules/px4iofirmware/protocol.h
@@ -33,7 +33,10 @@
 
 #pragma once
 
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 
 /**

--- a/src/modules/systemlib/err.c
+++ b/src/modules/systemlib/err.c
@@ -38,9 +38,12 @@
  * the same names.
  */
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <px4_config.h>
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #include <stdlib.h>

--- a/src/modules/systemlib/uthash/uthash.h
+++ b/src/modules/systemlib/uthash/uthash.h
@@ -61,7 +61,9 @@ do {                                                                            
 typedef unsigned int uint32_t;
 typedef unsigned char uint8_t;
 #else
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
 #include <inttypes.h>   /* uint32_t */
 #endif
 

--- a/src/platforms/posix/drivers/barosim/baro.cpp
+++ b/src/platforms/posix/drivers/barosim/baro.cpp
@@ -36,7 +36,10 @@
  * Driver for the simulated barometric pressure sensor
  */
 
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 #include <px4_config.h>
 #include <px4_defines.h>

--- a/src/platforms/posix/drivers/gpssim/gpssim.cpp
+++ b/src/platforms/posix/drivers/gpssim/gpssim.cpp
@@ -36,8 +36,11 @@
  * Simulated GPS driver
  */
 
-#include <sys/types.h>
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
+
+#include <sys/types.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdbool.h>

--- a/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
+++ b/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
@@ -41,7 +41,10 @@
  * @author Mark Charlebois
  */
 
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 
 #include <px4_config.h>

--- a/src/platforms/posix/px4_layer/drv_hrt.c
+++ b/src/platforms/posix/px4_layer/drv_hrt.c
@@ -37,6 +37,10 @@
  * High-resolution timer with callouts and timekeeping.
  */
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <px4_time.h>
 #include <px4_posix.h>
 #include <px4_defines.h>
@@ -45,7 +49,6 @@
 #include <semaphore.h>
 #include <time.h>
 #include <string.h>
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <errno.h>
 #include "hrt_work.h"

--- a/src/platforms/px4_log.h
+++ b/src/platforms/px4_log.h
@@ -118,7 +118,10 @@ static inline void do_nothing(int level, ...)
 
 #else
 
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 #include <stdint.h>
 #include <sys/cdefs.h>

--- a/src/platforms/px4_nodehandle.h
+++ b/src/platforms/px4_nodehandle.h
@@ -45,10 +45,13 @@
 #include "px4_app.h"
 
 #if defined(__PX4_ROS)
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 /* includes when building for ros */
 #include "ros/ros.h"
 #include <list>
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <type_traits>
 #else

--- a/src/systemcmds/tests/test_bson.c
+++ b/src/systemcmds/tests/test_bson.c
@@ -37,7 +37,10 @@
  * Tests for the bson en/decoder
  */
 
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 
 #include <px4_defines.h>

--- a/src/systemcmds/tests/test_int.c
+++ b/src/systemcmds/tests/test_int.c
@@ -36,7 +36,10 @@
  * Included Files
  ****************************************************************************/
 
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
+
 #include <inttypes.h>
 
 #include <px4_config.h>


### PR DESCRIPTION
__STDC_FORMAT_MACROS changes the behavior of inttypes.h to allow
defining format macros for printf-like functions. It needs to be defined
before any include is done, otherwise due to include chains and header
guards it may not take effect.

This does 2 things:
    1) move all the definitions to be done before including anything
       else: when it's defined on a header, it's still not optimal since
       it will depend on the include order by the compilation unit
    2) make the definition conditional so it's possible to delegate the
       definition either to the build system or to the command line
