### PR TITLE
Fixes in displaying and converting timestamps in Mavlink

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -1459,7 +1459,7 @@ protected:
 
         if (_pos_sub->update(&_pos_time, &vpos)) {
             mavlink_vision_position_estimate_t vmsg;
-            vmsg.usec = vpos.timestamp_boot / 1000;
+            vmsg.usec = vpos.timestamp_boot;
             vmsg.x = vpos.x;
             vmsg.y = vpos.y;
             vmsg.z = vpos.z;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2177,8 +2177,9 @@ void MavlinkReceiver::print_status()
 
 uint64_t MavlinkReceiver::sync_stamp(uint64_t usec)
 {
-	if (_time_offset > 0) {
-		return usec - (_time_offset / 1000) ;
+
+	if (_time_offset != 0) {
+		return usec + (_time_offset / 1000) ;
 
 	} else {
 		return hrt_absolute_time();

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -683,7 +683,7 @@ MavlinkReceiver::handle_message_att_pos_mocap(mavlink_message_t *msg)
 	// Use the component ID to identify the mocap system
 	att_pos_mocap.id = msg->compid;
 
-	att_pos_mocap.timestamp_boot = hrt_absolute_time(); // Monotonic time
+	att_pos_mocap.timestamp_boot = sync_stamp(mocap.time_usec);
 	att_pos_mocap.timestamp_computer = sync_stamp(mocap.time_usec); // Synced time
 
 	att_pos_mocap.q[0] = mocap.q[0];
@@ -963,7 +963,7 @@ MavlinkReceiver::handle_message_vision_position_estimate(mavlink_message_t *msg)
 	// Use the component ID to identify the vision sensor
 	vision_position.id = msg->compid;
 
-	vision_position.timestamp_boot = hrt_absolute_time(); // Monotonic time
+	vision_position.timestamp_boot = sync_stamp(pos.usec);
 	vision_position.timestamp_computer = sync_stamp(pos.usec); // Synced time
 	vision_position.x = pos.x;
 	vision_position.y = pos.y;


### PR DESCRIPTION
I tested this by comparing camera trigger times with video stream timestamps on the remote system sent back in VISION_POSITION_ESTIMATE messages. They matched with accuracy of at least 1ms, so it works.