### PR TITLE
fix the function of disabling safety switch

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1126,7 +1126,7 @@ PX4IO::task_main()
 				}
 
 				int32_t safety_param_val;
-				param_t safety_param = param_find("RC_FAILS_THR");
+				param_t safety_param = param_find("CBRK_IO_SAFETY");
 
 				if (safety_param != PARAM_INVALID) {
 


### PR DESCRIPTION
the parameter "RC_FAILS_THR" has been checked twice in the loop of px4io, but the parameter "CBRK_IO_SAFETY" is not been checked in the loop, only checked in the initialization.
so, according to the context, this "RC_FAILS_THR" should be "CBRK_IO_SAFETY". and then the safety switch can be disabled really.