### PR TITLE
fw_pos_ctrl_l1 initialization, var naming consistency, and Weffc++

### DIFF
--- a/Tools/check_code_style_all.sh
+++ b/Tools/check_code_style_all.sh
@@ -23,6 +23,7 @@ find \
     src/modules/controllib_test \
     src/modules/dataman \
     src/modules/fw_att_control \
+    src/modules/fw_pos_control_l1 \
     src/modules/gpio_led \
     src/modules/land_detector \
     src/modules/local_position_estimator \

--- a/src/lib/controllib/block/BlockParam.hpp
+++ b/src/lib/controllib/block/BlockParam.hpp
@@ -78,6 +78,9 @@ class BlockParam : public BlockParamBase
 public:
 	BlockParam(Block *block, const char *name,
 		   bool parent_prefix = true, T *extern_address = NULL);
+	BlockParam(const BlockParam &) = delete;
+	BlockParam &operator=(const BlockParam &) = delete;
+
 	T get();
 	void commit();
 	void set(T val);

--- a/src/lib/external_lgpl/tecs/tecs.h
+++ b/src/lib/external_lgpl/tecs/tecs.h
@@ -66,6 +66,8 @@ public:
 		_TASmin(3.0f),
 		_TAS_dem(0.0f),
 		_TAS_dem_last(0.0f),
+		_EAS_dem(0.0f),
+		_hgt_dem(0.0f),
 		_hgt_dem_in_old(0.0f),
 		_hgt_dem_adj(0.0f),
 		_hgt_dem_adj_last(0.0f),

--- a/src/lib/launchdetection/LaunchDetector.h
+++ b/src/lib/launchdetection/LaunchDetector.h
@@ -55,7 +55,10 @@ class __EXPORT LaunchDetector : public control::SuperBlock
 {
 public:
 	LaunchDetector();
-	~LaunchDetector();
+	LaunchDetector(const LaunchDetector &) = delete;
+	LaunchDetector operator=(const LaunchDetector &) = delete;
+	virtual ~LaunchDetector();
+
 	void reset();
 
 	void update(float accel_x);
@@ -79,7 +82,6 @@ private:
 	LaunchMethod *launchMethods[1];
 	control::BlockParamInt launchdetection_on;
 	control::BlockParamFloat throttlePreTakeoff;
-
 
 };
 

--- a/src/lib/launchdetection/LaunchMethod.h
+++ b/src/lib/launchdetection/LaunchMethod.h
@@ -58,6 +58,8 @@ enum LaunchDetectionResult {
 class LaunchMethod
 {
 public:
+	virtual ~LaunchMethod() {};
+
 	virtual void update(float accel_x) = 0;
 	virtual LaunchDetectionResult getLaunchDetected() const = 0;
 	virtual void reset() = 0;

--- a/src/modules/fw_pos_control_l1/CMakeLists.txt
+++ b/src/modules/fw_pos_control_l1/CMakeLists.txt
@@ -35,7 +35,7 @@ px4_add_module(
 	MAIN fw_pos_control_l1
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Os
+		-Os -Weffc++
 	SRCS
 		fw_pos_control_l1_main.cpp
 		landingslope.cpp

--- a/src/modules/fw_pos_control_l1/landingslope.cpp
+++ b/src/modules/fw_pos_control_l1/landingslope.cpp
@@ -46,6 +46,19 @@
 #include <unistd.h>
 #include <mathlib/mathlib.h>
 
+Landingslope::Landingslope() :
+	_landing_slope_angle_rad(0.0f),
+	_flare_relative_alt(0.0f),
+	_motor_lim_relative_alt(0.0f),
+	_H1_virt(0.0f),
+	_H0(0.0f),
+	_d1(0.0f),
+	_flare_constant(0.0f),
+	_flare_length(0.0f),
+	_horizontal_slope_displacement(0.0f)
+{
+}
+
 void Landingslope::update(float landing_slope_angle_rad_new,
 			  float flare_relative_alt_new,
 			  float motor_lim_relative_alt_new,
@@ -69,7 +82,7 @@ void Landingslope::calculateSlopeValues()
 	_horizontal_slope_displacement = (_flare_length - _d1);
 }
 
-float  Landingslope::getLandingSlopeRelativeAltitude(float wp_landing_distance)
+float Landingslope::getLandingSlopeRelativeAltitude(float wp_landing_distance)
 {
 	return Landingslope::getLandingSlopeRelativeAltitude(wp_landing_distance, _horizontal_slope_displacement,
 			_landing_slope_angle_rad);

--- a/src/modules/fw_pos_control_l1/landingslope.h
+++ b/src/modules/fw_pos_control_l1/landingslope.h
@@ -60,7 +60,7 @@ private:
 	void calculateSlopeValues();
 
 public:
-	Landingslope() {}
+	Landingslope();
 	~Landingslope() {}
 
 

--- a/src/modules/fw_pos_control_l1/mtecs/limitoverride.cpp
+++ b/src/modules/fw_pos_control_l1/mtecs/limitoverride.cpp
@@ -41,10 +41,11 @@
 
 #include "limitoverride.h"
 
-namespace fwPosctrl {
+namespace fwPosctrl
+{
 
 bool LimitOverride::applyOverride(BlockOutputLimiter &outputLimiterThrottle,
-		BlockOutputLimiter &outputLimiterPitch)
+				  BlockOutputLimiter &outputLimiterPitch)
 {
 	bool ret = false;
 
@@ -52,14 +53,17 @@ bool LimitOverride::applyOverride(BlockOutputLimiter &outputLimiterThrottle,
 		outputLimiterThrottle.setMin(overrideThrottleMin);
 		ret = true;
 	}
+
 	if (overrideThrottleMaxEnabled)	{
 		outputLimiterThrottle.setMax(overrideThrottleMax);
 		ret = true;
 	}
+
 	if (overridePitchMinEnabled)	{
 		outputLimiterPitch.setMin(overridePitchMin);
 		ret = true;
 	}
+
 	if (overridePitchMaxEnabled)	{
 		outputLimiterPitch.setMax(overridePitchMax);
 		ret = true;

--- a/src/modules/fw_pos_control_l1/mtecs/limitoverride.h
+++ b/src/modules/fw_pos_control_l1/mtecs/limitoverride.h
@@ -69,20 +69,32 @@ public:
 	* @return true if the limit was applied
 	*/
 	bool applyOverride(BlockOutputLimiter &outputLimiterThrottle,
-			BlockOutputLimiter &outputLimiterPitch);
+			   BlockOutputLimiter &outputLimiterPitch);
 
 	/* Functions to enable or disable the override */
-	void enableThrottleMinOverride(float value) { enable(&overrideThrottleMinEnabled,
-			&overrideThrottleMin, value); }
+	void enableThrottleMinOverride(float value)
+	{
+		enable(&overrideThrottleMinEnabled,
+		       &overrideThrottleMin, value);
+	}
 	void disableThrottleMinOverride() { disable(&overrideThrottleMinEnabled); }
-	void enableThrottleMaxOverride(float value) { enable(&overrideThrottleMaxEnabled,
-			&overrideThrottleMax, value); }
+	void enableThrottleMaxOverride(float value)
+	{
+		enable(&overrideThrottleMaxEnabled,
+		       &overrideThrottleMax, value);
+	}
 	void disableThrottleMaxOverride() { disable(&overrideThrottleMaxEnabled); }
-	void enablePitchMinOverride(float value) { enable(&overridePitchMinEnabled,
-			&overridePitchMin, value); }
+	void enablePitchMinOverride(float value)
+	{
+		enable(&overridePitchMinEnabled,
+		       &overridePitchMin, value);
+	}
 	void disablePitchMinOverride() { disable(&overridePitchMinEnabled); }
-	void enablePitchMaxOverride(float value) { enable(&overridePitchMaxEnabled,
-			&overridePitchMax, value); }
+	void enablePitchMaxOverride(float value)
+	{
+		enable(&overridePitchMaxEnabled,
+		       &overridePitchMax, value);
+	}
 	void disablePitchMaxOverride() { disable(&overridePitchMaxEnabled); }
 
 protected:

--- a/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp
+++ b/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp
@@ -44,7 +44,8 @@
 #include <lib/geo/geo.h>
 #include <stdio.h>
 
-namespace fwPosctrl {
+namespace fwPosctrl
+{
 
 mTecs::mTecs() :
 	SuperBlock(NULL, "MT"),
@@ -85,11 +86,11 @@ mTecs::~mTecs()
 }
 
 int mTecs::updateAltitudeSpeed(float flightPathAngle, float altitude, float altitudeSp, float airspeed,
-		float airspeedSp, unsigned mode, LimitOverride limitOverride)
+			       float airspeedSp, unsigned mode, LimitOverride limitOverride)
 {
 	/* check if all input arguments are numbers and abort if not so */
 	if (!PX4_ISFINITE(flightPathAngle) || !PX4_ISFINITE(altitude) ||
-			!PX4_ISFINITE(altitudeSp) || !PX4_ISFINITE(airspeed) || !PX4_ISFINITE(airspeedSp) || !PX4_ISFINITE(mode)) {
+	    !PX4_ISFINITE(altitudeSp) || !PX4_ISFINITE(airspeed) || !PX4_ISFINITE(airspeedSp) || !PX4_ISFINITE(mode)) {
 		return -1;
 	}
 
@@ -106,7 +107,8 @@ int mTecs::updateAltitudeSpeed(float flightPathAngle, float altitude, float alti
 	/* Debug output */
 	if (_counter % 10 == 0) {
 		debug("***");
-		debug("updateAltitudeSpeed: altitudeSp %.4f, altitude %.4f, altitude filtered %.4f, flightPathAngleSp %.4f", (double)altitudeSp, (double)altitude, (double)altitudeFiltered, (double)flightPathAngleSp);
+		debug("updateAltitudeSpeed: altitudeSp %.4f, altitude %.4f, altitude filtered %.4f, flightPathAngleSp %.4f",
+		      (double)altitudeSp, (double)altitude, (double)altitudeFiltered, (double)flightPathAngleSp);
 	}
 
 #if defined(__PX4_NUTTX)
@@ -118,15 +120,15 @@ int mTecs::updateAltitudeSpeed(float flightPathAngle, float altitude, float alti
 
 	/* use flightpath angle setpoint for total energy control */
 	return updateFlightPathAngleSpeed(flightPathAngle, flightPathAngleSp, airspeed,
-			airspeedSp, mode, limitOverride);
+					  airspeedSp, mode, limitOverride);
 }
 
 int mTecs::updateFlightPathAngleSpeed(float flightPathAngle, float flightPathAngleSp, float airspeed,
-		float airspeedSp, unsigned mode, LimitOverride limitOverride)
+				      float airspeedSp, unsigned mode, LimitOverride limitOverride)
 {
 	/* check if all input arguments are numbers and abort if not so */
 	if (!PX4_ISFINITE(flightPathAngle) || !PX4_ISFINITE(flightPathAngleSp) ||
-			!PX4_ISFINITE(airspeed) || !PX4_ISFINITE(airspeedSp) || !PX4_ISFINITE(mode)) {
+	    !PX4_ISFINITE(airspeed) || !PX4_ISFINITE(airspeedSp) || !PX4_ISFINITE(mode)) {
 		return -1;
 	}
 
@@ -142,9 +144,9 @@ int mTecs::updateFlightPathAngleSpeed(float flightPathAngle, float flightPathAng
 	/* Debug output */
 	if (_counter % 10 == 0) {
 		debug("updateFlightPathAngleSpeed airspeedSp %.4f, airspeed %.4f airspeedFiltered %.4f,"
-				"accelerationLongitudinalSp%.4f",
-				(double)airspeedSp, (double)airspeed,
-				(double)airspeedFiltered, (double)accelerationLongitudinalSp);
+		      "accelerationLongitudinalSp%.4f",
+		      (double)airspeedSp, (double)airspeed,
+		      (double)airspeedFiltered, (double)accelerationLongitudinalSp);
 	}
 
 #if defined(__PX4_NUTTX)
@@ -164,9 +166,10 @@ int mTecs::updateFlightPathAngleAcceleration(float flightPathAngle, float flight
 {
 	/* check if all input arguments are numbers and abort if not so */
 	if (!PX4_ISFINITE(flightPathAngle) || !PX4_ISFINITE(flightPathAngleSp) ||
-			!PX4_ISFINITE(airspeedFiltered) || !PX4_ISFINITE(accelerationLongitudinalSp) || !PX4_ISFINITE(mode)) {
+	    !PX4_ISFINITE(airspeedFiltered) || !PX4_ISFINITE(accelerationLongitudinalSp) || !PX4_ISFINITE(mode)) {
 		return -1;
 	}
+
 	/* time measurement */
 	updateTimeMeasurement();
 
@@ -179,9 +182,11 @@ int mTecs::updateFlightPathAngleAcceleration(float flightPathAngle, float flight
 	/* calculate values (energies) */
 	float flightPathAngleError = flightPathAngleSp - flightPathAngleFiltered;
 	float airspeedDerivative = 0.0f;
-	if(_airspeedDerivative.getDt() > 0.0f) {
+
+	if (_airspeedDerivative.getDt() > 0.0f) {
 		airspeedDerivative = _airspeedDerivative.update(airspeedFiltered);
 	}
+
 	float airspeedDerivativeNorm = airspeedDerivative / CONSTANTS_ONE_G;
 	float airspeedDerivativeSp = accelerationLongitudinalSp;
 	float airspeedDerivativeNormSp = airspeedDerivativeSp / CONSTANTS_ONE_G;
@@ -200,9 +205,11 @@ int mTecs::updateFlightPathAngleAcceleration(float flightPathAngle, float flight
 	/* Debug output */
 	if (_counter % 10 == 0) {
 		debug("totalEnergyRateSp %.2f, totalEnergyRate %.2f, totalEnergyRateError %.2f totalEnergyRateError2 %.2f airspeedDerivativeNorm %.4f",
-				(double)totalEnergyRateSp, (double)totalEnergyRate, (double)totalEnergyRateError, (double)totalEnergyRateError2, (double)airspeedDerivativeNorm);
+		      (double)totalEnergyRateSp, (double)totalEnergyRate, (double)totalEnergyRateError, (double)totalEnergyRateError2,
+		      (double)airspeedDerivativeNorm);
 		debug("energyDistributionRateSp %.2f, energyDistributionRate %.2f, energyDistributionRateError %.2f energyDistributionRateError2 %.2f",
-				(double)energyDistributionRateSp, (double)energyDistributionRate, (double)energyDistributionRateError, (double)energyDistributionRateError2);
+		      (double)energyDistributionRateSp, (double)energyDistributionRate, (double)energyDistributionRateError,
+		      (double)energyDistributionRateError2);
 	}
 
 	/* Check airspeed: if below safe value switch to underspeed mode (if not in land or takeoff mode) */
@@ -213,15 +220,19 @@ int mTecs::updateFlightPathAngleAcceleration(float flightPathAngle, float flight
 	/* Set special output limiters if we are not in MTECS_MODE_NORMAL */
 	BlockOutputLimiter *outputLimiterThrottle = &_controlTotalEnergy.getOutputLimiter();
 	BlockOutputLimiter *outputLimiterPitch = &_controlEnergyDistribution.getOutputLimiter();
+
 	if (mode == MTECS_MODE_TAKEOFF) {
 		outputLimiterThrottle = &_BlockOutputLimiterTakeoffThrottle;
 		outputLimiterPitch = &_BlockOutputLimiterTakeoffPitch;
+
 	} else if (mode == MTECS_MODE_LAND) {
 		// only limit pitch but do not limit throttle
 		outputLimiterPitch = &_BlockOutputLimiterLandPitch;
+
 	} else if (mode == MTECS_MODE_LAND_THROTTLELIM) {
 		outputLimiterThrottle = &_BlockOutputLimiterLandThrottle;
 		outputLimiterPitch = &_BlockOutputLimiterLandPitch;
+
 	} else if (mode == MTECS_MODE_UNDERSPEED) {
 		outputLimiterThrottle = &_BlockOutputLimiterUnderspeedThrottle;
 		outputLimiterPitch = &_BlockOutputLimiterUnderspeedPitch;
@@ -256,9 +267,9 @@ int mTecs::updateFlightPathAngleAcceleration(float flightPathAngle, float flight
 
 	if (_counter % 10 == 0) {
 		debug("_throttleSp %.1f, _pitchSp %.1f, flightPathAngleSp %.1f, flightPathAngle %.1f accelerationLongitudinalSp %.1f, airspeedDerivative %.1f",
-				(double)_throttleSp, (double)_pitchSp,
-				(double)flightPathAngleSp, (double)flightPathAngle,
-				(double)accelerationLongitudinalSp, (double)airspeedDerivative);
+		      (double)_throttleSp, (double)_pitchSp,
+		      (double)flightPathAngleSp, (double)flightPathAngle,
+		      (double)accelerationLongitudinalSp, (double)airspeedDerivative);
 	}
 
 #if defined(__PX4_NUTTX)
@@ -293,11 +304,13 @@ void mTecs::updateTimeMeasurement()
 {
 	if (!_dtCalculated) {
 		float deltaTSeconds = 0.0f;
+
 		if (!_firstIterationAfterReset) {
 			hrt_abstime timestampNow = hrt_absolute_time();
 			deltaTSeconds = (float)(timestampNow - timestampLastIteration) * 1e-6f;
 			timestampLastIteration = timestampNow;
 		}
+
 		setDt(deltaTSeconds);
 
 		_dtCalculated = true;
@@ -312,7 +325,8 @@ void mTecs::debug_print(const char *fmt, va_list args)
 	fprintf(stderr, "\n");
 }
 
-void mTecs::debug(const char *fmt, ...) {
+void mTecs::debug(const char *fmt, ...)
+{
 
 	if (!_debug) {
 		return;

--- a/src/modules/fw_pos_control_l1/mtecs/mTecs_blocks.h
+++ b/src/modules/fw_pos_control_l1/mtecs/mTecs_blocks.h
@@ -68,21 +68,25 @@ public:
 	 *
 	 * @param value is changed to be on the interval _min to _max
 	 * @param difference if the value is changed this corresponds to the change of value * (-1)
-     * otherwise unchanged
+	* otherwise unchanged
 	 * @return: true if the limit is applied, false otherwise
 	 */
-	bool limit(float& value, float& difference) {
+	bool limit(float &value, float &difference)
+	{
 		float minimum = getIsAngularLimit() ? getMin() * M_DEG_TO_RAD_F : getMin();
 		float maximum = getIsAngularLimit() ? getMax() * M_DEG_TO_RAD_F : getMax();
+
 		if (value < minimum) {
 			difference = value - minimum;
 			value = minimum;
 			return true;
+
 		} else if (value > maximum) {
 			difference = value - maximum;
 			value = maximum;
 			return true;
 		}
+
 		return false;
 	}
 //accessor:
@@ -126,15 +130,18 @@ protected:
 	BlockOutputLimiter _outputLimiter;
 
 	float calcUnlimitedOutput(float inputValue, float inputError) {return getOffset() + getKFF() * inputValue + getKP() * inputError + getKI() * getIntegral().update(inputError);}
-	float calcLimitedOutput(float inputValue, float inputError, BlockOutputLimiter &outputLimiter) {
+	float calcLimitedOutput(float inputValue, float inputError, BlockOutputLimiter &outputLimiter)
+	{
 		float difference = 0.0f;
 		float integralYPrevious = _integral.getY();
 		float output = calcUnlimitedOutput(inputValue, inputError);
-		if(outputLimiter.limit(output, difference) &&
-			(((difference < 0) && (getKI() * getIntegral().getY() < 0)) ||
-			((difference > 0) && (getKI() * getIntegral().getY() > 0)))) {
-				getIntegral().setY(integralYPrevious);
+
+		if (outputLimiter.limit(output, difference) &&
+		    (((difference < 0) && (getKI() * getIntegral().getY() < 0)) ||
+		     ((difference > 0) && (getKI() * getIntegral().getY() > 0)))) {
+			getIntegral().setY(integralYPrevious);
 		}
+
 		return output;
 	}
 private:
@@ -152,9 +159,10 @@ public:
 // methods
 	BlockFFPILimitedCustom(SuperBlock *parent, const char *name, bool isAngularLimit = false) :
 		BlockFFPILimited(parent, name, isAngularLimit)
-		{};
+	{};
 	virtual ~BlockFFPILimitedCustom() {};
-	float update(float inputValue, float inputError, BlockOutputLimiter *outputLimiter = NULL) {
+	float update(float inputValue, float inputError, BlockOutputLimiter *outputLimiter = NULL)
+	{
 		return calcLimitedOutput(inputValue, inputError, outputLimiter == NULL ? _outputLimiter : *outputLimiter);
 	}
 };
@@ -170,7 +178,8 @@ public:
 		_outputLimiter(this, "", isAngularLimit)
 	{};
 	virtual ~BlockPLimited() {};
-	float update(float input) {
+	float update(float input)
+	{
 		float difference = 0.0f;
 		float output = getKP() * input;
 		getOutputLimiter().limit(output, difference);
@@ -197,7 +206,8 @@ public:
 		_outputLimiter(this, "", isAngularLimit)
 	{};
 	virtual ~BlockPDLimited() {};
-	float update(float input) {
+	float update(float input)
+	{
 		float difference = 0.0f;
 		float output = getKP() * input + (getDerivative().getDt() > 0.0f ? getKD() * getDerivative().update(input) : 0.0f);
 		getOutputLimiter().limit(output, difference);

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -121,7 +121,7 @@ MissionBlock::is_mission_item_reached()
 				return false;
 			}
 
-		case vehicle_command_s::VEHICLE_CMD_DO_CHANGE_SPEED:
+		case NAV_CMD_DO_CHANGE_SPEED:
 			// XXX not differentiating ground and airspeed yet
 			if (_mission_item.params[1] > 0.0f) {
 				_navigator->set_cruising_speed(_mission_item.params[1]);

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -82,6 +82,8 @@ class VtolType
 public:
 
 	VtolType(VtolAttitudeControl *att_controller);
+	VtolType(const VtolType &) = delete;
+	VtolType &operator=(const VtolType &) = delete;
 
 	virtual ~VtolType();
 


### PR DESCRIPTION
Pulling out the cosmetic cleanup I couldn't stop myself from doing in https://github.com/PX4/Firmware/pull/5030

fw_pos_control_l1 changes
- name all member variables consistently
- initialize everything and in proper order
- enforces code style going forward

-Weffc++ says we need a copy constructor and operator= with pointer data members, so I disabled them in headers included by fw_pos_control_l1.