### PR TITLE
TAP:Fix build to use correct ROMFS

### DIFF
--- a/src/firmware/nuttx/CMakeLists.txt
+++ b/src/firmware/nuttx/CMakeLists.txt
@@ -47,9 +47,13 @@ if(NOT ${BOARD} STREQUAL "sim")
 	endif()
 	
 	set(romfs_dir "ROMFS/px4fmu_common")
+	if (${BOARD} STREQUAL "tap-v1")
+	set(romfs_dir "ROMFS/tap_common")
+	endif()
 	if (${BOARD} STREQUAL "px4fmu-v2" AND ${LABEL} STREQUAL "test")
 	    set(romfs_dir "ROMFS/px4fmu_test")
 	endif()
+
 
 	px4_nuttx_add_romfs(OUT romfs
 		ROOT ${romfs_dir}


### PR DESCRIPTION
@LorenzMeier. @bkueng 

master - build_tap-v1_default/src/firmware/nuttx/firmware_nuttx
   text    data     bss     dec     hex filename
 662668    4656    9360  676684   a534c 

using correct ROMFS -
   text    data     bss     dec     hex filename
 601228    4656    9360  615244   9634c 

I much prefer the way I handled nuttx configuration this in [nuttx_v3] (https://github.com/PX4/Firmware/blob/nuttx_v3/cmake/configs/nuttx_tap-v1_default.cmake#L2-L4)

So eventual this hack will come out, but it is needed now.
