### PR TITLE
sensors: only poll on first gyro for now

### DIFF
--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -2342,7 +2342,7 @@ Sensors::task_main()
 		}
 
 		/* wait for up to 50ms for data */
-		int pret = px4_poll(fds, num_poll_fds, 50);
+		int pret = px4_poll(fds, 1, 50);
 
 		/* if pret == 0 it timed out - periodic check for _task_should_exit, etc. */
 


### PR DESCRIPTION
This fixes a bug with following setup:
- two (or N > 1) connected gyros
- ekf2 enabled

In this case, sensors would publish with the combined rate of the gyros, but with N following messages having the same gyro data & timestamp.
Apparently ekf2 cannot handle this, the other estimators can. Observed behavior is that when rotating by alpha, the output is a rotation of 2 alpha, and then the estimator slowly moves back to alpha.
This was introduced in d846ad5dacfa4ab89

We may want to rethink what the proper solution is here. I see two:
- poll only on the currently voted gyro. This means if it fails, we can have a 50 ms delay from the poll and then voting can switch over.
- poll on all gyros and only publish if something actually changed.

ekf2 might need to be fixed as well, depending on what assumptions should hold.
Related to #5029 

@julianoes can you take a look at this?