### PR TITLE
Removed unsupported mag from DSP init script

### DIFF
--- a/posix-configs/eagle/flight/px4.config
+++ b/posix-configs/eagle/flight/px4.config
@@ -4,7 +4,6 @@ param set SYS_AUTOSTART 4001
 sleep 1
 gps start -d /dev/tty-4
 param set MAV_TYPE 2
-df_hmc5883_wrapper start
 df_mpu9250_wrapper start
 df_bmp280_wrapper start
 df_trone_wrapper start


### PR DESCRIPTION
The IMU provides a mag device. The standalone mag is not supported on Snapdragon flight.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>