### PR TITLE
Add parameter that adds altitude to the VTOL_LAND waypoint after back…

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -74,6 +74,7 @@ Mission::Mission(Navigator *navigator, const char *name) :
 	_param_altmode(this, "MIS_ALTMODE", false),
 	_param_yawmode(this, "MIS_YAWMODE", false),
 	_param_force_vtol(this, "VT_NAV_FORCE_VT", false),
+	_param_vt_b_add_alt(this, "VT_B_ADD_ALT", 0.0f),
 	_onboard_mission{},
 	_offboard_mission{},
 	_current_onboard_mission_index(-1),
@@ -565,7 +566,7 @@ Mission::set_mission_items()
 			 * XXX: We might want to change that at some point if it is clear to the user
 			 * what the altitude means on this waypoint type.
 			 */
-			float altitude = _navigator->get_global_position()->alt;
+			float altitude = _navigator->get_global_position()->alt + _param_vt_b_add_alt.get();
 
 			_mission_item.altitude = altitude;
 			_mission_item.altitude_is_relative = false;

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -229,6 +229,7 @@ private:
 	control::BlockParamInt _param_altmode;
 	control::BlockParamInt _param_yawmode;
 	control::BlockParamInt _param_force_vtol;
+	control::BlockParamFloat _param_vt_b_add_alt;
 
 	struct mission_s _onboard_mission;
 	struct mission_s _offboard_mission;

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -304,3 +304,13 @@ PARAM_DEFINE_FLOAT(VT_TRANS_MIN_TM, 2.0f);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_INT32(VT_NAV_FORCE_VT, 1);
+
+/**
+ * Add altitude after VTOL_LAND back transition to aid stability
+ *
+ * @unit m
+ * @min 0.0
+ * @max 20.0
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_B_ADD_ALT, 0.0f);


### PR DESCRIPTION
…transition to aid quad stability after back transition.

When quadplanes come out of back transition the horizontal velocity is often too high. The quad pitches back to brake and thereby increases altitude due to lift from the wing.

The quad will lower thrust to combat this altitude increase while also attempting to correct velocity and often roll / yaw for navigation purposes. This results in eratic behavior and saturation on the low end of the quad actuators.

Adding altitude to the position setpoint will give the vtol more thrust and will likely make the back transition in missions less erratic.

For safety purposes it defaults to 0.

Currently only tested in SITL, outdoor testing is required.

/cc @LorenzMeier @AndreasAntener @tumbili 
