### PR TITLE
Allow POSCTL with local position

### DIFF
--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -674,8 +674,12 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 				}
 
 			/* As long as there is RC, we can fallback to ALTCTL, or STAB. */
-			/* A local position estimate is enough for POSCTL, this enables POSCTL using e.g. flow. */
-			} else if (!status_flags->condition_local_position_valid && armed) {
+			/* A local position estimate is enough for POSCTL for multirotors,
+			 * this enables POSCTL using e.g. flow.
+			 * For fixedwing, a global position is needed. */
+			} else if (((status->is_rotary_wing && !status_flags->condition_local_position_valid) ||
+				   (!status->is_rotary_wing && !status_flags->condition_global_position_valid))
+				   && armed) {
 				status->failsafe = true;
 
 				if (status_flags->condition_local_altitude_valid) {

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -674,7 +674,8 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 				}
 
 			/* As long as there is RC, we can fallback to ALTCTL, or STAB. */
-			} else if (status_flags->gps_failure && armed) {
+			/* A local position estimate is enough for POSCTL, this enables POSCTL using e.g. flow. */
+			} else if (!status_flags->condition_local_position_valid && armed) {
 				status->failsafe = true;
 
 				if (status_flags->condition_local_altitude_valid) {


### PR DESCRIPTION
We want to allow flying POSCTL with optical flow only without GPS.

This should resolve:
https://github.com/PX4/snap_cam/issues/10
https://github.com/PX4/Firmware/issues/4929
https://github.com/PX4/Firmware/issues/4962

I can't test this because I don't have a working flow setup. I tried to use `make posix gazebo_iris_opt_flow` but it didn't report any optical flow. @ChristophTobler Am I doing something wrong?