### PR TITLE
Fix gyro calibration

### DIFF
--- a/src/modules/commander/gyro_calibration.cpp
+++ b/src/modules/commander/gyro_calibration.cpp
@@ -92,7 +92,6 @@ static calibrate_return gyro_calibration_worker(int cancel_sub, void* data)
 	}
 
 	memset(&worker_data->gyro_report_0, 0, sizeof(worker_data->gyro_report_0));
-	memset(&worker_data->gyro_scale, 0, sizeof(worker_data->gyro_scale));
 
 	/* use first gyro to pace, but count correctly per-gyro for statistics */
 	while (calibration_counter[0] < calibration_count) {
@@ -142,9 +141,6 @@ static calibrate_return gyro_calibration_worker(int cancel_sub, void* data)
 			return calibrate_return_error;
 		}
 
-		worker_data->gyro_scale[s].x_scale = 1.0f;
-		worker_data->gyro_scale[s].y_scale = 1.0f;
-		worker_data->gyro_scale[s].z_scale = 1.0f;
 		worker_data->gyro_scale[s].x_offset /= calibration_counter[s];
 		worker_data->gyro_scale[s].y_offset /= calibration_counter[s];
 		worker_data->gyro_scale[s].z_offset /= calibration_counter[s];

--- a/src/modules/commander/gyro_calibration.cpp
+++ b/src/modules/commander/gyro_calibration.cpp
@@ -142,6 +142,9 @@ static calibrate_return gyro_calibration_worker(int cancel_sub, void* data)
 			return calibrate_return_error;
 		}
 
+		worker_data->gyro_scale[s].x_scale = 1.0f;
+		worker_data->gyro_scale[s].y_scale = 1.0f;
+		worker_data->gyro_scale[s].z_scale = 1.0f;
 		worker_data->gyro_scale[s].x_offset /= calibration_counter[s];
 		worker_data->gyro_scale[s].y_offset /= calibration_counter[s];
 		worker_data->gyro_scale[s].z_offset /= calibration_counter[s];


### PR DESCRIPTION
The gyro calibration scale was initialized and set to 0 in a calibration instead of 1.

Tested using Pixhawk.

This fixes #5060 and #5029.

@bkueng please review and merge as soon as travis is ok.