### PR TITLE
travis-ci use tagged docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
   include:
     - os: linux
       sudo: required
-      env: GCC_VER=4.8 DOCKER_REPO="px4io/px4-dev-base"
+      env: GCC_VER=4.8 DOCKER_REPO="px4io/px4-dev-base:2016-07-14"
       services:
         - docker
     - os: osx


### PR DESCRIPTION
Tagging all PX4 docker images so we have more control in the builds. This probably won't pass yet.