### PR TITLE
Improve new logger update rate

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -482,7 +482,6 @@ void Logger::add_default_topics()
 	add_topic("vehicle_global_velocity_setpoint", 100);
 	add_topic("battery_status", 300);
 	add_topic("system_power", 300);
-	add_topic("servorail_status", 300);
 	add_topic("position_setpoint_triplet", 10);
 	add_topic("att_pos_mocap", 50);
 	add_topic("vision_position_estimate", 50);
@@ -495,9 +494,6 @@ void Logger::add_default_topics()
 	add_topic("ekf2_innovations", 20);
 	add_topic("tecs_status", 20);
 	add_topic("wind_estimate", 100);
-	add_topic("encoders", 50);
-	add_topic("time_offset", 1000);
-	add_topic("mc_att_ctrl_status", 50);
 	add_topic("control_state", 20);
 	add_topic("camera_trigger");
 	add_topic("cpuload");

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -75,7 +75,7 @@ struct LoggerSubscription {
 class Logger
 {
 public:
-	Logger(size_t buffer_size, unsigned log_interval, bool log_on_start,
+	Logger(size_t buffer_size, uint32_t log_interval, bool log_on_start,
 	       bool log_until_shutdown, bool log_name_timestamp);
 
 	~Logger();


### PR DESCRIPTION
As @kd0aij noticed, the new logger dropped every ~4th sample of the sensor_combined, even though the logger update rate was high enough.

I noticed, under NuttX with the default rate of 285Hz, the actual measured rate was only 200Hz while on Linux it was ~280Hz. The reason is that NuttX only uses a usleep() granularity of 1ms, so that the typical sleep time is longer than what we set.

Now the logger waits on a semaphore, which gets activated periodically with a hrt timer. With this the measured rate is exactly the expected one, 285Hz.

Thanks @kd0aij, and @davids5 for the hrt timer tip.

This is a time difference plot of sensor_combined, before:
![rate_default_logged_everything_sess014](https://cloud.githubusercontent.com/assets/281593/16881210/57f3dea8-4ab9-11e6-9b86-55876635ba1d.png)

And after:
![rate_default_logged_everything_hrt_timer](https://cloud.githubusercontent.com/assets/281593/16881227/775ee076-4ab9-11e6-9b6a-0466b5a9c46b.png)

Another irregularity is that some samples have a slightly higher time difference (4800 instead of 4000). This does not come from the logger, but somewhere else. Should be analyzed as well.

@julianoes can you test this on Snappy & possibly RPi, before and after? I instrumented with:
```
	int counter = 0;
	hrt_abstime time_start_hz = hrt_absolute_time();
```
before the logger main loop, and inside:
```
		hrt_abstime elapsed_hz = hrt_elapsed_time(&time_start_hz);
		if (elapsed_hz > 1e6) {
			time_start_hz = hrt_absolute_time();
			PX4_WARN("hz=%.3f", (double)counter / (elapsed_hz / 1.e6));
			counter = 0;
		}
		++counter;
```