### PR TITLE
eagle: switch from sdlog2 to logger

### DIFF
--- a/posix-configs/eagle/flight/mainapp.config
+++ b/posix-configs/eagle/flight/mainapp.config
@@ -1,6 +1,7 @@
 uorb start
 muorb start
-sdlog2 start -r 100 -e -t -a -b 200
+#sdlog2 start -r 100 -e -t -a -b 200
+logger start -r 500 -b 24 -e -t
 param set MAV_BROADCAST 1
 param set SDLOG_PRIO_BOOST 3
 dataman start


### PR DESCRIPTION
Bench tested, performance looks ok.

![logger_snappy_2](https://cloud.githubusercontent.com/assets/1419688/16910214/518236a6-4ccf-11e6-8b2b-dbeaf7e73a76.png)
