### PR TITLE
DF wrappers: apply calibration after rotation

### DIFF
--- a/src/platforms/posix/drivers/df_hmc5883_wrapper/df_hmc5883_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_hmc5883_wrapper/df_hmc5883_wrapper.cpp
@@ -281,18 +281,17 @@ int DfHmc9250Wrapper::_publish(struct mag_sensor_data &data)
 	mag_report.y_raw = NAN;
 	mag_report.z_raw = NAN;
 
-
-	math::Vector<3> mag_val((data.field_x_ga - _mag_calibration.x_offset) * _mag_calibration.x_scale,
-				(data.field_y_ga - _mag_calibration.y_offset) * _mag_calibration.y_scale,
-				(data.field_z_ga - _mag_calibration.z_offset) * _mag_calibration.z_scale);
+	math::Vector<3> mag_val(data.field_x_ga,
+				data.field_y_ga,
+				data.field_z_ga);
 
 	// apply sensor rotation on the accel measurement
 	mag_val = _rotation_matrix * mag_val;
 
-	mag_report.x = mag_val(0);
-	mag_report.y = mag_val(1);
-	mag_report.z = mag_val(2);
-
+	// Apply calibration after rotation.
+	mag_report.x = (mag_val(0) - _mag_calibration.x_offset) * _mag_calibration.x_scale;
+	mag_report.y = (mag_val(1) - _mag_calibration.y_offset) * _mag_calibration.y_scale;
+	mag_report.z = (mag_val(2) - _mag_calibration.z_offset) * _mag_calibration.z_scale;
 
 	// TODO: get these right
 	//mag_report.scaling = -1.0f;

--- a/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
@@ -588,12 +588,17 @@ int DfMpu9250Wrapper::_publish(struct imu_sensor_data &data)
 				     vec_integrated_unused,
 				     integral_dt_unused);
 
-	math::Vector<3> gyro_val((data.gyro_rad_s_x - _gyro_calibration.x_offset) * _gyro_calibration.x_scale,
-				 (data.gyro_rad_s_y - _gyro_calibration.y_offset) * _gyro_calibration.y_scale,
-				 (data.gyro_rad_s_z - _gyro_calibration.z_offset) * _gyro_calibration.z_scale);
+	math::Vector<3> gyro_val(data.gyro_rad_s_x,
+				 data.gyro_rad_s_y,
+				 data.gyro_rad_s_z);
 
 	// apply sensor rotation on the gyro measurement
 	gyro_val = _rotation_matrix * gyro_val;
+
+	// Apply calibration after rotation.
+	gyro_val(0) = (gyro_val(0) - _gyro_calibration.x_offset) * _gyro_calibration.x_scale;
+	gyro_val(1) = (gyro_val(1) - _gyro_calibration.y_offset) * _gyro_calibration.y_scale;
+	gyro_val(2) = (gyro_val(2) - _gyro_calibration.z_offset) * _gyro_calibration.z_scale;
 
 	_gyro_int.put_with_interval(data.fifo_sample_interval_us,
 				    gyro_val,


### PR DESCRIPTION
The calibration was applied wrongly for DriverFramework sensors that were not used with the default rotation.

Thanks to @eyeam3 for finding this (see: ae66085f89ea6197b2c469c63f9c6d5d70c62f3c).

FYI: @mayanez, @ericye16, @HidenoriKobayashi 