### PR TITLE
cmake: don't build load_mon for POSIX/QURT

### DIFF
--- a/cmake/configs/posix_bebop_default.cmake
+++ b/cmake/configs/posix_bebop_default.cmake
@@ -51,7 +51,7 @@ set(config_module_list
 	modules/mc_att_control
 	modules/mc_pos_control
 	modules/fw_att_control
-	modules/fw_pos_control_l1	
+	modules/fw_pos_control_l1
 	modules/vtol_att_control
 
 	#
@@ -60,7 +60,6 @@ set(config_module_list
 	modules/sdlog2
 	modules/logger
 	modules/commander
-	modules/load_mon
 	modules/param
 	modules/systemlib
 	modules/systemlib/mixer

--- a/cmake/configs/posix_eagle_hil.cmake
+++ b/cmake/configs/posix_eagle_hil.cmake
@@ -30,7 +30,6 @@ set(config_module_list
 	modules/logger
 	modules/simulator
 	modules/commander
-	modules/load_mon
 
 	lib/mathlib
 	lib/mathlib/math/filter

--- a/cmake/configs/posix_eagle_legacy_driver_default.cmake
+++ b/cmake/configs/posix_eagle_legacy_driver_default.cmake
@@ -49,7 +49,6 @@ set(config_module_list
 	modules/simulator
 	modules/commander
 	modules/navigator
-	modules/load_mon
 
 	lib/controllib
 	lib/mathlib

--- a/cmake/configs/posix_rpi_common.cmake
+++ b/cmake/configs/posix_rpi_common.cmake
@@ -60,7 +60,6 @@ set(config_module_list
 	modules/sdlog2
 	modules/logger
 	modules/commander
-	modules/load_mon
 	modules/param
 	modules/systemlib
 	modules/systemlib/mixer

--- a/cmake/configs/posix_sdflight_default.cmake
+++ b/cmake/configs/posix_sdflight_default.cmake
@@ -42,7 +42,6 @@ set(config_module_list
 	modules/simulator
 	modules/commander
 	modules/navigator
-	modules/load_mon
 
 	lib/controllib
 	lib/mathlib

--- a/cmake/configs/posix_sitl_default.cmake
+++ b/cmake/configs/posix_sitl_default.cmake
@@ -41,7 +41,6 @@ set(config_module_list
 	modules/fw_att_control
 	modules/fw_pos_control_l1
 	modules/land_detector
-	modules/load_mon
 	modules/logger
 	modules/mavlink
 	modules/mc_att_control

--- a/cmake/configs/posix_sitl_test.cmake
+++ b/cmake/configs/posix_sitl_test.cmake
@@ -39,7 +39,6 @@ set(config_module_list
 	modules/fw_att_control
 	modules/fw_pos_control_l1
 	modules/land_detector
-	modules/load_mon
 	modules/logger
 	modules/mavlink
 	modules/mc_att_control

--- a/cmake/configs/qurt_eagle_hil.cmake
+++ b/cmake/configs/qurt_eagle_hil.cmake
@@ -48,7 +48,6 @@ set(config_module_list
 	modules/systemlib/mixer
 	modules/uORB
 	modules/commander
-	modules/load_mon
 
 	#
 	# Libraries

--- a/cmake/configs/qurt_eagle_legacy_driver_default.cmake
+++ b/cmake/configs/qurt_eagle_legacy_driver_default.cmake
@@ -57,7 +57,6 @@ set(config_module_list
 	modules/uORB
 	modules/commander
 	modules/land_detector
-	modules/load_mon
 
 	#
 	# PX4 drivers

--- a/cmake/configs/qurt_eagle_travis.cmake
+++ b/cmake/configs/qurt_eagle_travis.cmake
@@ -56,7 +56,6 @@ set(config_module_list
 	modules/systemlib/mixer
 	modules/uORB
 	modules/commander
-	modules/load_mon
 
 	#
 	# Libraries


### PR DESCRIPTION
The module `load_mon` is currently only available on NuttX. I have therefore removed it from all the POSIX and QURT builds.

This fixes #5103 brought up by @mcharleb.