### PR TITLE
make tests use px4 instead of mainapp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ run_tests_posix: posix_sitl_default
 	@mkdir -p build_posix_sitl_default/src/firmware/posix/rootfs/fs/microsd
 	@mkdir -p build_posix_sitl_default/src/firmware/posix/rootfs/eeprom
 	@touch build_posix_sitl_default/src/firmware/posix/rootfs/eeprom/parameters
-	@(cd build_posix_sitl_default/src/firmware/posix && ./mainapp -d ../../../../posix-configs/SITL/init/rcS_tests | tee test_output)
+	@(cd build_posix_sitl_default/src/firmware/posix && ./px4 -d ../../../../posix-configs/SITL/init/rcS_tests | tee test_output)
 	@(cd build_posix_sitl_default/src/firmware/posix && grep --color=always "All tests passed" test_output)
 
 tests: check_unittest run_tests_posix

--- a/src/modules/commander/commander_tests/state_machine_helper_test.cpp
+++ b/src/modules/commander/commander_tests/state_machine_helper_test.cpp
@@ -370,7 +370,7 @@ bool StateMachineHelperTest::mainStateTransitionTest(void)
 			commander_state_s::MAIN_STATE_AUTO_RTL, commander_state_s::MAIN_STATE_MANUAL, TRANSITION_CHANGED },
 
 		{ "transition: MANUAL to ALTCTL - not rotary",
-			MTT_ALL_NOT_VALID,
+			MTT_LOC_ALT_VALID,
 			commander_state_s::MAIN_STATE_MANUAL, commander_state_s::MAIN_STATE_ALTCTL, TRANSITION_CHANGED },
 
 		{ "transition: MANUAL to ALTCTL - rotary, global position not valid, local altitude valid",
@@ -422,6 +422,10 @@ bool StateMachineHelperTest::mainStateTransitionTest(void)
 		{ "no transition: MANUAL to AUTO_RTL - global position valid, home position not valid",
 			MTT_GLOBAL_POS_VALID,
 			commander_state_s::MAIN_STATE_MANUAL, commander_state_s::MAIN_STATE_AUTO_RTL, TRANSITION_DENIED },
+
+		{ "transition: MANUAL to ALTCTL - not rotary",
+			MTT_ALL_NOT_VALID,
+			commander_state_s::MAIN_STATE_MANUAL, commander_state_s::MAIN_STATE_ALTCTL, TRANSITION_DENIED },
 
 		{ "no transition: MANUAL to ALTCTL - rotary, global position not valid, local altitude not valid",
 			MTT_ROTARY_WING,


### PR DESCRIPTION
Semaphoreci runs `make check` which includes running the tests. Don't merge until that's passing.