### PR TITLE
4001_quad_x: use PWM_DISARMED param

### DIFF
--- a/ROMFS/px4fmu_common/init.d/4001_quad_x
+++ b/ROMFS/px4fmu_common/init.d/4001_quad_x
@@ -16,3 +16,5 @@ sh /etc/init.d/rc.mc_defaults
 set MIXER quad_x
 
 set PWM_OUT 1234
+
+set PWM_DISARMED p:PWM_DISARMED


### PR DESCRIPTION
Without this, setting the param `PWM_DISARMED` doesn't have any effect.