### PR TITLE
Do not apply back transition duration for QuadChute

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -146,7 +146,7 @@ void Standard::update_vtol_state()
 
 		} else if (_vtol_schedule.flight_mode == FW_MODE) {
 			// transition to mc mode
-			if (_vtol_vehicle_status->vtol_transition_failsafe == true){
+			if (_vtol_vehicle_status->vtol_transition_failsafe == true) {
 				// Failsafe event, engage mc motors immediately
 				_vtol_schedule.flight_mode = MC_MODE;
 				_flag_enable_mc_motors = true;

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -146,9 +146,17 @@ void Standard::update_vtol_state()
 
 		} else if (_vtol_schedule.flight_mode == FW_MODE) {
 			// transition to mc mode
-			_vtol_schedule.flight_mode = TRANSITION_TO_MC;
-			_flag_enable_mc_motors = true;
-			_vtol_schedule.transition_start = hrt_absolute_time();
+			if (_vtol_vehicle_status->vtol_transition_failsafe == true){
+				// Failsafe event, engage mc motors immediately
+				_vtol_schedule.flight_mode = MC_MODE;
+				_flag_enable_mc_motors = true;
+
+			} else {
+				// Regular backtransition
+				_vtol_schedule.flight_mode = TRANSITION_TO_MC;
+				_flag_enable_mc_motors = true;
+				_vtol_schedule.transition_start = hrt_absolute_time();
+			}
 
 		} else if (_vtol_schedule.flight_mode == TRANSITION_TO_FW) {
 			// failsafe back to mc mode


### PR DESCRIPTION
QuadChute during FW flight would apply back transition duration
@AndreasAntener and reality have shown me this is not a good idea