### PR TITLE
Transition timeout for tailsitter

### DIFF
--- a/src/modules/vtol_att_control/tailsitter.h
+++ b/src/modules/vtol_att_control/tailsitter.h
@@ -70,6 +70,7 @@ private:
 		float airspeed_trans;			/**< airspeed at which we switch to fw mode after transition */
 		float airspeed_blend_start;		/**< airspeed at which we start blending mc/fw controls */
 		int elevons_mc_lock;			/**< lock elevons in multicopter mode */
+		float front_trans_timeout;		/**< transition timeout */
 
 	} _params_tailsitter;
 
@@ -80,6 +81,7 @@ private:
 		param_t airspeed_trans;
 		param_t airspeed_blend_start;
 		param_t elevons_mc_lock;
+		param_t front_trans_timeout;
 
 	} _params_handles_tailsitter;
 


### PR DESCRIPTION
Added timeout for tailsitter
When setting transition airspeed to 30s sitl goes crazy on gazebo_tailsitter it did eventually timeout but the vehicle had already crashed.

not sure if this is only sitl or if there is something fundamentally wrong with a tailsitter not reaching transition airspeed.

fixes https://github.com/PX4/Firmware/issues/3741

/cc @LorenzMeier 
