### PR TITLE
fw_pos_control_l1: fix compiler problem

### DIFF
--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
@@ -1281,7 +1281,7 @@ FixedwingPositionControl::control_position(const math::Vector<2> &current_positi
 	float air_gnd_angle = acosf((air_speed_2d * ground_speed_2d) / (air_speed_2d.length() * ground_speed_2d.length()));
 
 	// if angle > 90 degrees or groundspeed is less than threshold, replace groundspeed with airspeed projection
-	if ((fabs(air_gnd_angle) > M_PI) || (ground_speed_2d.length() < 3.0f)) {
+	if ((fabsf(air_gnd_angle) > (float)M_PI) || (ground_speed_2d.length() < 3.0f)) {
 		nav_speed_2d = air_speed_2d;
 
 	} else {


### PR DESCRIPTION
Issue (GCC 6.1.1):
../src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp:1284:27: error: implicit conversion from ‘float’ to ‘double’ to match other operand of binary expression [-Werror=double-promotion]
  if ((fabs(air_gnd_angle) > M_PI) || (ground_speed_2d.length() < 3.0f)) {