### PR TITLE
Payload camera on off

### DIFF
--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -392,7 +392,6 @@ CameraTrigger::test()
 {
 	struct vehicle_command_s cmd = {};
 	cmd.command = vehicle_command_s::VEHICLE_CMD_DO_DIGICAM_CONTROL;
-
 	cmd.param5 = 1.0f;
 
 	orb_advert_t pub;
@@ -478,7 +477,8 @@ CameraTrigger::cycle_trampoline(void *arg)
 					if (cmd.param1 > 0.0f && !trig->_trigger_enabled) {
 						trig->turnOnOff();
 						trig->keepAlive(true);
-						poll_interval_usec = 2000000;
+						// Give the camera time to turn on, before starting to send trigger signals
+						poll_interval_usec = 5000000;
 						turning_on = true;
 
 					} else if (cmd.param1 <= 0.0f && trig->_trigger_enabled) {

--- a/src/drivers/camera_trigger/camera_trigger_params.c
+++ b/src/drivers/camera_trigger/camera_trigger_params.c
@@ -67,7 +67,7 @@ PARAM_DEFINE_INT32(TRIG_INTERFACE, 2);
  * @decimal 1
  * @group Camera trigger
  */
-PARAM_DEFINE_FLOAT(TRIG_INTERVAL, 40.0f);
+PARAM_DEFINE_FLOAT(TRIG_INTERVAL, 3000.0f);
 
 /**
  * Camera trigger polarity
@@ -93,7 +93,7 @@ PARAM_DEFINE_INT32(TRIG_POLARITY, 0);
  * @decimal 1
  * @group Camera trigger
  */
-PARAM_DEFINE_FLOAT(TRIG_ACT_TIME, 0.5f);
+PARAM_DEFINE_FLOAT(TRIG_ACT_TIME, 500.0f);
 
 /**
  * Camera trigger mode
@@ -123,7 +123,7 @@ PARAM_DEFINE_INT32(TRIG_MODE, 0);
  * @reboot_required true
  * @group Camera trigger
  */
-PARAM_DEFINE_INT32(TRIG_PINS, 6);
+PARAM_DEFINE_INT32(TRIG_PINS, 56);
 
 /**
  * Camera trigger distance

--- a/src/drivers/camera_trigger/camera_trigger_params.c
+++ b/src/drivers/camera_trigger/camera_trigger_params.c
@@ -67,7 +67,7 @@ PARAM_DEFINE_INT32(TRIG_INTERFACE, 2);
  * @decimal 1
  * @group Camera trigger
  */
-PARAM_DEFINE_FLOAT(TRIG_INTERVAL, 3000.0f);
+PARAM_DEFINE_FLOAT(TRIG_INTERVAL, 40.0f);
 
 /**
  * Camera trigger polarity
@@ -93,7 +93,7 @@ PARAM_DEFINE_INT32(TRIG_POLARITY, 0);
  * @decimal 1
  * @group Camera trigger
  */
-PARAM_DEFINE_FLOAT(TRIG_ACT_TIME, 500.0f);
+PARAM_DEFINE_FLOAT(TRIG_ACT_TIME, 0.5f);
 
 /**
  * Camera trigger mode
@@ -115,7 +115,7 @@ PARAM_DEFINE_INT32(TRIG_MODE, 0);
  *
  * Selects which pin is used, ranges from 1 to 6 (AUX1-AUX6 on px4fmu-v2 and the rail
  * pins on px4fmu-v4). The PWM interface takes two pins per camera, while relay
- * triggers on every pin individually. Example: Value 34 would trigger on pins 3 and 4.
+ * triggers on every pin individually. Example: Value 56 would trigger on pins 5 and 6.
  *
  * @min 1
  * @max 123456

--- a/src/drivers/camera_trigger/interfaces/src/camera_interface.h
+++ b/src/drivers/camera_trigger/interfaces/src/camera_interface.h
@@ -25,6 +25,12 @@ public:
 	virtual void trigger(bool enable) {};
 
 	/**
+	 * turn on/off the camera
+	 * @param enable:
+	 */
+	virtual void turn_on_off(bool enable) {};
+
+	/**
 	 * prevent the camera from sleeping
 	 * @param keep alive signal:
 	 */

--- a/src/drivers/camera_trigger/interfaces/src/pwm.h
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.h
@@ -29,10 +29,7 @@ public:
 private:
 	void setup();
 
-	param_t				_p_pin;
-	orb_advert_t		_pwm_pub[2];
-	int					_orb_id[2];
-
-	bool				_camera_is_on;
+	param_t _p_pin;
+	bool _camera_is_on;
 
 };

--- a/src/drivers/camera_trigger/interfaces/src/pwm.h
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.h
@@ -6,6 +6,7 @@
  */
 #pragma once
 
+#include <drivers/drv_hrt.h>
 #include <systemlib/param/param.h>
 
 #include <uORB/topics/vehicle_status.h>
@@ -20,8 +21,7 @@ public:
 	void trigger(bool enable);
 	void keep_alive(bool signal_on);
 
-	int powerOn();
-	int powerOff();
+	void turn_on_off(bool enable);
 
 	void info();
 
@@ -29,7 +29,10 @@ public:
 private:
 	void setup();
 
-	param_t _p_pin;
-	bool _camera_is_on;
+	param_t				_p_pin;
+	orb_advert_t		_pwm_pub[2];
+	int					_orb_id[2];
+
+	bool				_camera_is_on;
 
 };


### PR DESCRIPTION
This PR enables the turning on and off of a camera that is interfaced via a Seagull MAP2 adapter chip.

Whenever trigger mode is set to mission controlled, turn-on signal will be sent once triggering gets enabled. Upon disabling, also the camera is turned off. Does not have an effect on other trigger modes.

Specifically designed for and tested with the Sony QX1.