### PR TITLE
Posctl quaternion fixes

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -253,7 +253,6 @@ private:
 	math::Vector<3> _vel_prev;			/**< velocity on previous step */
 	math::Vector<3> _vel_ff;
 	math::Vector<3> _vel_sp_prev;
-	math::Vector<3> _thrust_sp_prev;
 	math::Vector<3> _vel_err_d;		/**< derivative of current velocity */
 
 	math::Matrix<3, 3> _R;			/**< rotation matrix from attitude quaternions */
@@ -2056,14 +2055,6 @@ MulticopterPositionControl::task_main()
 				R_sp.from_euler(roll_new, pitch_new, _att_sp.yaw_body);
 
 				memcpy(&_att_sp.R_body[0], R_sp.data, sizeof(_att_sp.R_body));
-
-				/* reset the acceleration set point for all non-attitude flight modes */
-				if (!(_control_mode.flag_control_offboard_enabled &&
-				      !(_control_mode.flag_control_position_enabled ||
-					_control_mode.flag_control_velocity_enabled))) {
-
-					_thrust_sp_prev = R_sp * math::Vector<3>(0, 0, -_att_sp.thrust);
-				}
 			}
 
 			/* copy quaternion setpoint to attitude setpoint topic */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -2022,7 +2022,7 @@ MulticopterPositionControl::task_main()
 			/* control roll and pitch directly if no aiding velocity controller is active
 			 * and only if optimal recovery is not used */
 			if (!_control_mode.flag_control_velocity_enabled
-				&& !_params.opt_recover > 0) {
+			    && _params.opt_recover <= 0) {
 				math::Matrix<3, 3> R_sp;
 				_att_sp.roll_body = _manual.y * _params.man_roll_max;
 				_att_sp.pitch_body = -_manual.x * _params.man_pitch_max;


### PR DESCRIPTION
- Removes duplicate Q and DCM calculation when in POSCTL, currently happens in the POSCTL loop and then again after resolving manual yaw with Euler angles
- Removes unused code (`_thrust_sp_prev`)
- Disables rotation around actual yaw for tailsitters with optimal recovery since optimal recovery doesn't work otherwise

we should give this a flight test on master (tested on our branch)