### PR TITLE
VTOL: enable MC motors after instant back transition

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -324,6 +324,13 @@ void Standard::update_mc_state()
 {
 	VtolType::update_mc_state();
 
+	// enable MC motors here in case we transitioned directly to MC mode
+	if (_flag_enable_mc_motors) {
+		set_max_mc(2000);
+		set_idle_mc();
+		_flag_enable_mc_motors = false;
+	}
+
 	// if the thrust scale param is zero then the pusher-for-pitch strategy is disabled and we can return
 	if (_params_standard.forward_thrust_scale < FLT_EPSILON) {
 		return;


### PR DESCRIPTION
In case of an instant back transition (quadchute) we need to enable the MC motors again
@tumbili @sanderux please check