### PR TITLE
Filter accel/gyro for q estimator

### DIFF
--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -173,11 +173,6 @@ private:
 	Vector<3>	_vel_prev;
 	Vector<3>	_pos_acc;
 
-	/* Low pass filter for attitude rates */
-	math::LowPassFilter2p _lp_roll_rate;
-	math::LowPassFilter2p _lp_pitch_rate;
-	math::LowPassFilter2p _lp_yaw_rate;
-
 	/* Low pass filter for accel/gyro */
 	math::LowPassFilter2p _lp_accel_x;
 	math::LowPassFilter2p _lp_accel_y;
@@ -213,9 +208,6 @@ private:
 AttitudeEstimatorQ::AttitudeEstimatorQ() :
 	_vel_prev(0, 0, 0),
 	_pos_acc(0, 0, 0),
-	_lp_roll_rate(250.0f, 30.0f),
-	_lp_pitch_rate(250.0f, 30.0f),
-	_lp_yaw_rate(250.0f, 20.0f),
 	_lp_accel_x(250.0f, 30.0f),
 	_lp_accel_y(250.0f, 30.0f),
 	_lp_accel_z(250.0f, 30.0f),
@@ -519,11 +511,11 @@ void AttitudeEstimatorQ::task_main()
 			ctrl_state.z_acc = _accel(2);
 
 			/* attitude rates for control state */
-			ctrl_state.roll_rate = _lp_roll_rate.apply(_rates(0));
+			ctrl_state.roll_rate = _rates(0);
 
-			ctrl_state.pitch_rate = _lp_pitch_rate.apply(_rates(1));
+			ctrl_state.pitch_rate = _rates(1);
 
-			ctrl_state.yaw_rate = _lp_yaw_rate.apply(_rates(2));
+			ctrl_state.yaw_rate = _rates(2);
 
 			ctrl_state.airspeed_valid = false;
 

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -355,7 +355,7 @@ void AttitudeEstimatorQ::task_main()
 				_accel(2) = _lp_accel_z.apply(sensors.accelerometer_m_s2[2]);
 
 				if (_accel.length() < 0.01f) {
-					warnx("WARNING: degenerate accel!");
+					PX4_DEBUG("WARNING: degenerate accel!");
 					continue;
 				}
 			}
@@ -366,7 +366,7 @@ void AttitudeEstimatorQ::task_main()
 				_mag(2) = sensors.magnetometer_ga[2];
 
 				if (_mag.length() < 0.01f) {
-					warnx("WARNING: degenerate mag!");
+					PX4_DEBUG("WARNING: degenerate mag!");
 					continue;
 				}
 			}


### PR DESCRIPTION
This is an attempt to fix #5060.

It pre-filters accel and gyro data before it's used in the attitude_estimator_q.

@bkueng please have a look through, thanks.