### PR TITLE
Add wrapper for DF driver AK8963

### DIFF
--- a/cmake/configs/posix_bebop_default.cmake
+++ b/cmake/configs/posix_bebop_default.cmake
@@ -23,7 +23,11 @@ set(config_module_list
 	drivers/device
 	modules/sensors
 	platforms/posix/drivers/df_ms5607_wrapper
+<<<<<<< c4eb65862f307de4b679e24f44fab0c565d7c2a3
 	platforms/posix/drivers/df_mpu6050_wrapper
+=======
+	platforms/posix/drivers/df_ak8963_wrapper
+>>>>>>> Add DF wrapper for AK8963
 
 	#
 	# System commands

--- a/cmake/configs/posix_bebop_default.cmake
+++ b/cmake/configs/posix_bebop_default.cmake
@@ -23,11 +23,8 @@ set(config_module_list
 	drivers/device
 	modules/sensors
 	platforms/posix/drivers/df_ms5607_wrapper
-<<<<<<< c4eb65862f307de4b679e24f44fab0c565d7c2a3
 	platforms/posix/drivers/df_mpu6050_wrapper
-=======
 	platforms/posix/drivers/df_ak8963_wrapper
->>>>>>> Add DF wrapper for AK8963
 
 	#
 	# System commands
@@ -105,4 +102,5 @@ set(config_module_list
 set(config_df_driver_list
 	ms5607
 	mpu6050
+	ak8963
 )

--- a/posix-configs/bebop/px4.config
+++ b/posix-configs/bebop/px4.config
@@ -5,10 +5,14 @@ param set SYS_AUTOSTART 4001
 param set MAV_BROADCAST 1
 df_ms5607_wrapper start
 df_mpu6050_wrapper start -R 8
-df_ak8963_wrapper start
+df_ak8963_wrapper start -R 4
 sensors start
+attitude_estimator_q start
+position_estimator_inav start
+commander start
 sleep 1
 mavlink start -u 14556 -r 1000000
 sleep 1
 mavlink stream -u 14556 -s HIGHRES_IMU -r 50
+mavlink stream -u 14556 -s ATTITUDE -r 50
 mavlink boot_complete

--- a/posix-configs/bebop/px4.config
+++ b/posix-configs/bebop/px4.config
@@ -5,6 +5,7 @@ param set SYS_AUTOSTART 4001
 param set MAV_BROADCAST 1
 df_ms5607_wrapper start
 df_mpu6050_wrapper start -R 8
+df_ak8963_wrapper start
 sensors start
 sleep 1
 mavlink start -u 14556 -r 1000000

--- a/src/modules/commander/accelerometer_calibration.cpp
+++ b/src/modules/commander/accelerometer_calibration.cpp
@@ -175,7 +175,7 @@ typedef struct  {
 
 int do_accel_calibration(orb_advert_t *mavlink_log_pub)
 {
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_EAGLE) && !defined(__PX4_POSIX_RPI)
+#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_EAGLE) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
 	int fd;
 #endif
 
@@ -195,7 +195,7 @@ int do_accel_calibration(orb_advert_t *mavlink_log_pub)
 
 	/* reset all sensors */
 	for (unsigned s = 0; s < max_accel_sens; s++) {
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_EAGLE) && !defined(__PX4_POSIX_RPI)
+#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_EAGLE) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
 		sprintf(str, "%s%u", ACCEL_BASE_DEVICE_PATH, s);
 		/* reset all offsets to zero and all scales to one */
 		fd = px4_open(str, 0);
@@ -329,7 +329,7 @@ int do_accel_calibration(orb_advert_t *mavlink_log_pub)
 			return ERROR;
 		}
 
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_EAGLE) && !defined(__PX4_POSIX_RPI)
+#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_EAGLE) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
 		sprintf(str, "%s%u", ACCEL_BASE_DEVICE_PATH, i);
 		fd = px4_open(str, 0);
 
@@ -419,7 +419,7 @@ calibrate_return do_accel_calibration_measurements(orb_advert_t *mavlink_log_pub
 			break;
 		}
 
-#if defined(__PX4_QURT) || defined(__PX4_POSIX_EAGLE) || defined(__PX4_POSIX_RPI)
+#if defined(__PX4_QURT) || defined(__PX4_POSIX_EAGLE) || defined(__PX4_POSIX_RPI) || defined(__PX4_POSIX_BEBOP)
 		// For QURT respectively the driver framework, we need to get the device ID by copying one report.
 		struct accel_report	accel_report;
 		orb_copy(ORB_ID(sensor_accel), worker_data.subs[i], &accel_report);

--- a/src/modules/commander/gyro_calibration.cpp
+++ b/src/modules/commander/gyro_calibration.cpp
@@ -185,7 +185,7 @@ int do_gyro_calibration(orb_advert_t *mavlink_log_pub)
 
 		// Reset all offsets to 0 and scales to 1
 		(void)memcpy(&worker_data.gyro_scale[s], &gyro_scale_zero, sizeof(gyro_scale_zero));
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_EAGLE) && !defined(__PX4_POSIX_RPI)
+#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_EAGLE) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
 		sprintf(str, "%s%u", GYRO_BASE_DEVICE_PATH, s);
 		int fd = px4_open(str, 0);
 		if (fd >= 0) {
@@ -238,7 +238,7 @@ int do_gyro_calibration(orb_advert_t *mavlink_log_pub)
 	for (unsigned s = 0; s < gyro_count; s++) {
 
 		worker_data.gyro_sensor_sub[s] = orb_subscribe_multi(ORB_ID(sensor_gyro), s);
-#if defined(__PX4_QURT) || defined(__PX4_POSIX_EAGLE) || defined(__PX4_POSIX_RPI)
+#if defined(__PX4_QURT) || defined(__PX4_POSIX_EAGLE) || defined(__PX4_POSIX_RPI) || defined(__PX4_POSIX_BEBOP)
 		// For QURT respectively the driver framework, we need to get the device ID by copying one report.
 		struct gyro_report gyro_report;
 		orb_copy(ORB_ID(sensor_gyro), worker_data.gyro_sensor_sub[s], &gyro_report);
@@ -336,7 +336,7 @@ int do_gyro_calibration(orb_advert_t *mavlink_log_pub)
 				(void)sprintf(str, "CAL_GYRO%u_ID", s);
 				failed |= (OK != param_set_no_notification(param_find(str), &(worker_data.device_id[s])));
 
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_EAGLE) && !defined(__PX4_POSIX_RPI)
+#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_EAGLE) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
 				/* apply new scaling and offsets */
 				(void)sprintf(str, "%s%u", GYRO_BASE_DEVICE_PATH, s);
 				int fd = px4_open(str, 0);

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -664,6 +664,10 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 		for (unsigned cur_mag=0; cur_mag<max_mags; cur_mag++) {
 			if (device_ids[cur_mag] != 0) {
 				struct mag_calibration_s mscale;
+				mscale.x_scale = 1.0;
+				mscale.y_scale = 1.0;
+				mscale.z_scale = 1.0;
+
 #if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
 				int fd_mag = -1;
 

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -124,7 +124,7 @@ int do_mag_calibration(orb_advert_t *mavlink_log_pub)
 	_last_mag_progress = 0;
 
 	for (unsigned cur_mag = 0; cur_mag < max_mags; cur_mag++) {
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI)
+#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
 		// Reset mag id to mag not available
 		(void)sprintf(str, "CAL_MAG%u_ID", cur_mag);
 		result = param_set_no_notification(param_find(str), &(device_ids[cur_mag]));
@@ -166,7 +166,7 @@ int do_mag_calibration(orb_advert_t *mavlink_log_pub)
 #endif
 
 /* for calibration, commander will run on apps, so orb messages are used to get info from dsp */
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI)
+#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
 		// Attempt to open mag
 		(void)sprintf(str, "%s%u", MAG_BASE_DEVICE_PATH, cur_mag);
 		int fd = px4_open(str, O_RDONLY);
@@ -508,7 +508,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 			// Mag in this slot is available
 			worker_data.sub_mag[cur_mag] = orb_subscribe_multi(ORB_ID(sensor_mag), cur_mag);
 
-#if defined(__PX4_QURT) || defined(__PX4_POSIX_RPI)
+#if defined(__PX4_QURT) || defined(__PX4_POSIX_RPI) || defined(__PX4_POSIX_BEBOP)
 			// For QURT respectively the driver framework, we need to get the device ID by copying one report.
 			struct mag_report	mag_report;
 			orb_copy(ORB_ID(sensor_mag), worker_data.sub_mag[cur_mag], &mag_report);
@@ -664,7 +664,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 		for (unsigned cur_mag=0; cur_mag<max_mags; cur_mag++) {
 			if (device_ids[cur_mag] != 0) {
 				struct mag_calibration_s mscale;
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI)
+#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
 				int fd_mag = -1;
 
 				// Set new scale
@@ -688,7 +688,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 					mscale.y_offset = sphere_y[cur_mag];
 					mscale.z_offset = sphere_z[cur_mag];
 
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI)
+#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
 					if (px4_ioctl(fd_mag, MAGIOCSSCALE, (long unsigned int)&mscale) != OK) {
 						calibration_log_critical(mavlink_log_pub, CAL_ERROR_APPLY_CAL_MSG, cur_mag);
 						result = calibrate_return_error;
@@ -696,7 +696,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 #endif
 				}
 
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI)
+#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
 				// Mag device no longer needed
 				if (fd_mag >= 0) {
 					px4_close(fd_mag);

--- a/src/platforms/posix/drivers/df_ak8963_wrapper/CMakeLists.txt
+++ b/src/platforms/posix/drivers/df_ak8963_wrapper/CMakeLists.txt
@@ -1,0 +1,46 @@
+############################################################################
+#
+#   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+include_directories(../../../../lib/DriverFramework/drivers)
+
+px4_add_module(
+	MODULE platforms__posix__drivers__df_ak8963_wrapper
+	MAIN df_ak8963_wrapper
+	SRCS
+		df_ak8963_wrapper.cpp
+	DEPENDS
+		platforms__common
+		df_driver_framework
+		df_ak8963
+	)
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/posix/drivers/df_ak8963_wrapper/df_ak8963_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_ak8963_wrapper/df_ak8963_wrapper.cpp
@@ -1,0 +1,459 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file df_ak8963_wrapper.cpp
+ * Lightweight driver to access the AK8963 of the DriverFramework.
+ */
+
+#include <px4_config.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <unistd.h>
+#include <px4_getopt.h>
+#include <errno.h>
+
+#include <systemlib/perf_counter.h>
+#include <systemlib/err.h>
+
+#include <drivers/drv_mag.h>
+
+#include <uORB/topics/parameter_update.h>
+
+#include <board_config.h>
+
+#include <lib/conversion/rotation.h>
+
+#include <ak8963/AK8963.hpp>
+#include <DevMgr.hpp>
+
+
+extern "C" { __EXPORT int df_ak8963_wrapper_main(int argc, char *argv[]); }
+
+using namespace DriverFramework;
+
+
+class DfAK8963Wrapper : public AK8963
+{
+public:
+	DfAK8963Wrapper(enum Rotation rotation);
+	~DfAK8963Wrapper();
+
+
+	/**
+	 * Start automatic measurement.
+	 *
+	 * @return 0 on success
+	 */
+	int		start();
+
+	/**
+	 * Stop automatic measurement.
+	 *
+	 * @return 0 on success
+	 */
+	int		stop();
+
+private:
+	int _publish(struct mag_sensor_data &data);
+
+	void _update_mag_calibration();
+
+	orb_advert_t		_mag_topic;
+
+	int			_param_update_sub;
+
+	struct mag_calibration_s {
+		float x_offset;
+		float x_scale;
+		float y_offset;
+		float y_scale;
+		float z_offset;
+		float z_scale;
+	} _mag_calibration;
+
+	math::Matrix<3, 3>      _rotation_matrix;
+
+	int			_mag_orb_class_instance;
+
+	perf_counter_t		_mag_sample_perf;
+
+};
+
+DfAK8963Wrapper::DfAK8963Wrapper(enum Rotation rotation) :
+	AK8963(MAG_DEVICE_PATH),
+	_mag_topic(nullptr),
+	_param_update_sub(-1),
+	_mag_calibration{},
+	_mag_orb_class_instance(-1),
+	_mag_sample_perf(perf_alloc(PC_ELAPSED, "df_mag_read"))
+{
+	// Set sane default calibration values
+	_mag_calibration.x_scale = 1.0f;
+	_mag_calibration.y_scale = 1.0f;
+	_mag_calibration.z_scale = 1.0f;
+	_mag_calibration.x_offset = 0.0f;
+	_mag_calibration.y_offset = 0.0f;
+	_mag_calibration.z_offset = 0.0f;
+
+	// Get sensor rotation matrix
+	get_rot_matrix(rotation, &_rotation_matrix);
+}
+
+DfAK8963Wrapper::~DfAK8963Wrapper()
+{
+	perf_free(_mag_sample_perf);
+}
+
+int DfAK8963Wrapper::start()
+{
+	/* Subscribe to param update topic. */
+	if (_param_update_sub < 0) {
+		_param_update_sub = orb_subscribe(ORB_ID(parameter_update));
+	}
+
+	/* Init device and start sensor. */
+	int ret = init();
+
+	if (ret != 0) {
+		PX4_ERR("AK8963 init fail: %d", ret);
+		return ret;
+	}
+
+	ret = AK8963::start();
+
+	if (ret != 0) {
+		PX4_ERR("AK8963 start fail: %d", ret);
+		return ret;
+	}
+
+	/* Force getting the calibration values. */
+	_update_mag_calibration();
+
+	return 0;
+}
+
+int DfAK8963Wrapper::stop()
+{
+	/* Stop sensor. */
+	int ret = AK8963::stop();
+
+	if (ret != 0) {
+		PX4_ERR("AK8963 stop fail: %d", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+void DfAK8963Wrapper::_update_mag_calibration()
+{
+	// TODO: replace magic number
+	for (unsigned i = 0; i < 3; ++i) {
+
+		// TODO: remove printfs and add error counter
+
+		char str[30];
+		(void)sprintf(str, "CAL_MAG%u_ID", i);
+		int32_t device_id;
+		int res = param_get(param_find(str), &device_id);
+
+		if (res != OK) {
+			PX4_ERR("Could not access param %s", str);
+			continue;
+		}
+
+		if ((uint32_t)device_id != m_id.dev_id) {
+			continue;
+		}
+
+		(void)sprintf(str, "CAL_MAG%u_XSCALE", i);
+		res = param_get(param_find(str), &_mag_calibration.x_scale);
+
+		if (res != OK) {
+			PX4_ERR("Could not access param %s", str);
+		}
+
+		(void)sprintf(str, "CAL_MAG%u_YSCALE", i);
+		res = param_get(param_find(str), &_mag_calibration.y_scale);
+
+		if (res != OK) {
+			PX4_ERR("Could not access param %s", str);
+		}
+
+		(void)sprintf(str, "CAL_MAG%u_ZSCALE", i);
+		res = param_get(param_find(str), &_mag_calibration.z_scale);
+
+		if (res != OK) {
+			PX4_ERR("Could not access param %s", str);
+		}
+
+		(void)sprintf(str, "CAL_MAG%u_XOFF", i);
+		res = param_get(param_find(str), &_mag_calibration.x_offset);
+
+		if (res != OK) {
+			PX4_ERR("Could not access param %s", str);
+		}
+
+		(void)sprintf(str, "CAL_MAG%u_YOFF", i);
+		res = param_get(param_find(str), &_mag_calibration.y_offset);
+
+		if (res != OK) {
+			PX4_ERR("Could not access param %s", str);
+		}
+
+		(void)sprintf(str, "CAL_MAG%u_ZOFF", i);
+		res = param_get(param_find(str), &_mag_calibration.z_offset);
+
+		if (res != OK) {
+			PX4_ERR("Could not access param %s", str);
+		}
+	}
+}
+
+
+int DfAK8963Wrapper::_publish(struct mag_sensor_data &data)
+{
+	/* Check if calibration values are still up-to-date. */
+	bool updated;
+	orb_check(_param_update_sub, &updated);
+
+	if (updated) {
+		parameter_update_s parameter_update;
+		orb_copy(ORB_ID(parameter_update), _param_update_sub, &parameter_update);
+
+		_update_mag_calibration();
+	}
+
+	/* Publish mag first. */
+	perf_begin(_mag_sample_perf);
+
+	mag_report mag_report = {};
+	mag_report.timestamp = hrt_absolute_time();
+
+  // TODO: check sensor orientation
+	/* The standard external mag by 3DR has x pointing to the
+	 * right, y pointing backwards, and z down, therefore switch x
+	 * and y and invert y. */
+	const float tmp = data.field_x_ga;
+	data.field_x_ga = -data.field_y_ga;
+	data.field_y_ga = tmp;
+
+	// TODO: remove these (or get the values)
+	mag_report.x_raw = NAN;
+	mag_report.y_raw = NAN;
+	mag_report.z_raw = NAN;
+
+
+	math::Vector<3> mag_val((data.field_x_ga - _mag_calibration.x_offset) * _mag_calibration.x_scale,
+				(data.field_y_ga - _mag_calibration.y_offset) * _mag_calibration.y_scale,
+				(data.field_z_ga - _mag_calibration.z_offset) * _mag_calibration.z_scale);
+
+	// apply sensor rotation on the accel measurement
+	mag_val = _rotation_matrix * mag_val;
+
+	mag_report.x = mag_val(0);
+	mag_report.y = mag_val(1);
+	mag_report.z = mag_val(2);
+
+
+	// TODO: get these right
+	//mag_report.scaling = -1.0f;
+	//mag_report.range_m_s2 = -1.0f;
+
+	mag_report.device_id = m_id.dev_id;
+
+	// TODO: when is this ever blocked?
+	if (!(m_pub_blocked)) {
+
+		if (_mag_topic == nullptr) {
+			_mag_topic = orb_advertise_multi(ORB_ID(sensor_mag), &mag_report,
+							 &_mag_orb_class_instance, ORB_PRIO_HIGH);
+
+		} else {
+			orb_publish(ORB_ID(sensor_mag), _mag_topic, &mag_report);
+		}
+
+	}
+
+	perf_end(_mag_sample_perf);
+
+	/* Notify anyone waiting for data. */
+	DevMgr::updateNotify(*this);
+
+	return 0;
+};
+
+
+namespace df_ak8963_wrapper
+{
+
+DfAK8963Wrapper *g_dev = nullptr;
+
+int start(enum Rotation rotation);
+int stop();
+int info();
+void usage();
+
+int start(enum Rotation rotation)
+{
+	g_dev = new DfAK8963Wrapper(rotation);
+
+	if (g_dev == nullptr) {
+		PX4_ERR("failed instantiating DfAK8963Wrapper object");
+		return -1;
+	}
+
+	int ret = g_dev->start();
+
+	if (ret != 0) {
+		PX4_ERR("DfAK8963Wrapper start failed");
+		return ret;
+	}
+
+	// Open the MAG sensor
+	DevHandle h;
+	DevMgr::getHandle(MAG_DEVICE_PATH, h);
+
+	if (!h.isValid()) {
+		DF_LOG_INFO("Error: unable to obtain a valid handle for the receiver at: %s (%d)",
+			    MAG_DEVICE_PATH, h.getError());
+		return -1;
+	}
+
+	DevMgr::releaseHandle(h);
+
+	return 0;
+}
+
+int stop()
+{
+	if (g_dev == nullptr) {
+		PX4_ERR("driver not running");
+		return 1;
+	}
+
+	int ret = g_dev->stop();
+
+	if (ret != 0) {
+		PX4_ERR("driver could not be stopped");
+		return ret;
+	}
+
+	delete g_dev;
+	g_dev = nullptr;
+	return 0;
+}
+
+/**
+ * Print a little info about the driver.
+ */
+int
+info()
+{
+	if (g_dev == nullptr) {
+		PX4_ERR("driver not running");
+		return 1;
+	}
+
+	PX4_DEBUG("state @ %p", g_dev);
+
+	return 0;
+}
+
+void
+usage()
+{
+	PX4_INFO("Usage: df_ak8963_wrapper 'start', 'info', 'stop'");
+	PX4_INFO("options:");
+	PX4_INFO("    -R rotation");
+}
+
+} // namespace df_ak8963_wrapper
+
+
+int
+df_ak8963_wrapper_main(int argc, char *argv[])
+{
+	int ch;
+	enum Rotation rotation = ROTATION_NONE;
+	int ret = 0;
+	int myoptind = 1;
+	const char *myoptarg = NULL;
+
+	/* jump over start/off/etc and look at options first */
+	while ((ch = px4_getopt(argc, argv, "R:", &myoptind, &myoptarg)) != EOF) {
+		switch (ch) {
+		case 'R':
+			rotation = (enum Rotation)atoi(myoptarg);
+			break;
+
+		default:
+			df_ak8963_wrapper::usage();
+			return 0;
+		}
+	}
+
+	if (argc <= 1) {
+		df_ak8963_wrapper::usage();
+		return 1;
+	}
+
+	const char *verb = argv[myoptind];
+
+
+	if (!strcmp(verb, "start")) {
+		ret = df_ak8963_wrapper::start(rotation);
+	}
+
+	else if (!strcmp(verb, "stop")) {
+		ret = df_ak8963_wrapper::stop();
+	}
+
+	else if (!strcmp(verb, "info")) {
+		ret = df_ak8963_wrapper::info();
+	}
+
+	else {
+		df_ak8963_wrapper::usage();
+		return 1;
+	}
+
+	return ret;
+}

--- a/src/platforms/posix/drivers/df_ak8963_wrapper/df_ak8963_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_ak8963_wrapper/df_ak8963_wrapper.cpp
@@ -288,9 +288,9 @@ int DfAK8963Wrapper::_publish(struct mag_sensor_data &data)
 	// apply sensor rotation on the accel measurement
 	mag_val = _rotation_matrix * mag_val;
 
-	mag_report.x = (mag_val(0) - _mag_calibration.x_offset) * _mag_calibration.x_scale;;
-	mag_report.y = (mag_val(1) - _mag_calibration.y_offset) * _mag_calibration.y_scale;;
-	mag_report.z = (mag_val(2) - _mag_calibration.z_offset) * _mag_calibration.z_scale;;
+	mag_report.x = (mag_val(0) - _mag_calibration.x_offset) * _mag_calibration.x_scale;
+	mag_report.y = (mag_val(1) - _mag_calibration.y_offset) * _mag_calibration.y_scale;
+	mag_report.z = (mag_val(2) - _mag_calibration.z_offset) * _mag_calibration.z_scale;
 
 
 	// TODO: get these right
@@ -394,7 +394,7 @@ info()
 
 	PX4_DEBUG("state @ %p", g_dev);
 
-  g_dev->print_calibration();
+	g_dev->print_calibration();
 
 	return 0;
 }


### PR DESCRIPTION
Add the DF wrapper for the AK8963 driver used on the Parrot Bebop. It also includes some adaptations to use the sensor calibration and the attitude estimation on the Bebop.

However, during testing there have been some problems with the precision of the compass calibration, resulting in a drifting yaw estimation. This needs some further improvements.