### PR TITLE
Fix a possible delete null.

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -982,6 +982,7 @@ stop()
 		delete g_dev[0];
 		g_dev[0] = nullptr;
 	}
+
 	if (g_dev[1] != nullptr) {
 		delete g_dev[1];
 	}

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -977,9 +977,11 @@ start(const char *uart_path, bool fake_gps, bool enable_sat_info, int gps_num)
 void
 stop()
 {
-	delete g_dev[0];
-	g_dev[0] = nullptr;
-
+	// if start fails g_dev[0] could be null.
+	if (g_dev[0] != nullptr) {
+		delete g_dev[0];
+		g_dev[0] = nullptr;
+	}
 	if (g_dev[1] != nullptr) {
 		delete g_dev[1];
 	}

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -855,7 +855,8 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 				status->nav_state = vehicle_status_s::NAVIGATION_STATE_TERMINATION;
 			}
 
-		/* go into failsafe if RC is lost and datalink loss is not set up */
+			/* go into failsafe if RC is lost and datalink loss is not set up */
+
 		} else if (status->rc_signal_lost && rc_loss_enabled && !data_link_loss_enabled) {
 			status->failsafe = true;
 
@@ -872,7 +873,8 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 				status->nav_state = vehicle_status_s::NAVIGATION_STATE_TERMINATION;
 			}
 
-		/* don't bother if RC is lost if datalink is connected */
+			/* don't bother if RC is lost if datalink is connected */
+
 		} else if (status->rc_signal_lost && rc_loss_enabled) {
 
 			/* this mode is ok, we don't need RC for loitering */

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -855,9 +855,8 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 				status->nav_state = vehicle_status_s::NAVIGATION_STATE_TERMINATION;
 			}
 
-			/* go into failsafe if RC is lost and datalink loss is not set up */
-
-		} else if (status->rc_signal_lost && !data_link_loss_enabled) {
+		/* go into failsafe if RC is lost and datalink loss is not set up */
+		} else if (status->rc_signal_lost && rc_loss_enabled && !data_link_loss_enabled) {
 			status->failsafe = true;
 
 			if (status_flags->condition_global_position_valid && status_flags->condition_home_position_valid) {
@@ -873,9 +872,8 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 				status->nav_state = vehicle_status_s::NAVIGATION_STATE_TERMINATION;
 			}
 
-			/* don't bother if RC is lost if datalink is connected */
-
-		} else if (status->rc_signal_lost) {
+		/* don't bother if RC is lost if datalink is connected */
+		} else if (status->rc_signal_lost && rc_loss_enabled) {
 
 			/* this mode is ok, we don't need RC for loitering */
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER;

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -638,10 +638,6 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 
 	bool armed = (status->arming_state == vehicle_status_s::ARMING_STATE_ARMED
 		      || status->arming_state == vehicle_status_s::ARMING_STATE_ARMED_ERROR);
-
-	const bool rc_lost = rc_loss_enabled && (status->rc_signal_lost || status_flags->rc_signal_lost_cmd);
-	const bool data_lost = data_link_loss_enabled && (status->data_link_lost || status_flags->data_link_lost_cmd);
-
 	status->failsafe = false;
 
 	/* evaluate main state to decide in normal (non-failsafe) mode */
@@ -653,7 +649,7 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 	case commander_state_s::MAIN_STATE_ALTCTL:
 
 		/* require RC for all manual modes */
-		if (rc_lost && armed) {
+		if (rc_loss_enabled && (status->rc_signal_lost || status_flags->rc_signal_lost_cmd) && armed) {
 			status->failsafe = true;
 
 			if (status_flags->condition_global_position_valid && status_flags->condition_home_position_valid) {
@@ -700,6 +696,7 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 		break;
 
 	case commander_state_s::MAIN_STATE_POSCTL: {
+			const bool rc_lost = rc_loss_enabled && (status->rc_signal_lost || status_flags->rc_signal_lost_cmd);
 
 			if (rc_lost && armed) {
 				status->failsafe = true;
@@ -755,14 +752,14 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 		if (status->engine_failure_cmd) {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
-		} else if (data_lost) {
+		} else if (status_flags->data_link_lost_cmd) {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_RTGS;
 
 		} else if (status_flags->gps_failure_cmd) {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
 			status->failsafe = true;
 
-		} else if (rc_lost) {
+		} else if (status_flags->rc_signal_lost_cmd) {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_RCRECOVER;
 
 		} else if (status_flags->vtol_transition_failure_cmd) {
@@ -786,7 +783,7 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 			/* datalink loss enabled:
 			 * check for datalink lost: this should always trigger RTGS */
 
-		} else if (data_lost) {
+		} else if (data_link_loss_enabled && status->data_link_lost) {
 			status->failsafe = true;
 
 			if (status_flags->condition_global_position_valid && status_flags->condition_home_position_valid) {
@@ -804,11 +801,9 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 
 			/* datalink loss disabled:
 			 * check if both, RC and datalink are lost during the mission
-			 * or all links are lost after the mission finishes in air: this should always trigger RCRECOVER
-			 * NOTE: it is inconisistent that we are even looking at data_link_lost when !data_link_loss_enabled.
-			 */
+			 * or all links are lost after the mission finishes in air: this should always trigger RCRECOVER */
 
-		} else if (!data_link_loss_enabled && rc_lost && status->data_link_lost && !landed && mission_finished) {
+		} else if (!data_link_loss_enabled && status->rc_signal_lost && status->data_link_lost && !landed && mission_finished) {
 			status->failsafe = true;
 
 			if (status_flags->condition_global_position_valid && status_flags->condition_home_position_valid) {
@@ -844,7 +839,7 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 
 			/* also go into failsafe if just datalink is lost */
 
-		} else if (data_lost) {
+		} else if (status->data_link_lost && data_link_loss_enabled) {
 			status->failsafe = true;
 
 			if (status_flags->condition_global_position_valid && status_flags->condition_home_position_valid) {
@@ -862,7 +857,7 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 
 			/* go into failsafe if RC is lost and datalink loss is not set up */
 
-		} else if (rc_lost && !data_link_loss_enabled) {
+		} else if (status->rc_signal_lost && rc_loss_enabled && !data_link_loss_enabled) {
 			status->failsafe = true;
 
 			if (status_flags->condition_global_position_valid && status_flags->condition_home_position_valid) {
@@ -880,7 +875,7 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 
 			/* don't bother if RC is lost if datalink is connected */
 
-		} else if (rc_lost) {
+		} else if (status->rc_signal_lost && rc_loss_enabled) {
 
 			/* this mode is ok, we don't need RC for loitering */
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER;
@@ -1003,7 +998,7 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 	case commander_state_s::MAIN_STATE_OFFBOARD:
 
 		/* require offboard control, otherwise stay where you are */
-		if (status_flags->offboard_control_signal_lost && !rc_lost) {
+		if (status_flags->offboard_control_signal_lost && !status->rc_signal_lost) {
 			status->failsafe = true;
 
 			if (status_flags->offboard_control_loss_timeout && offb_loss_rc_act < 5 && offb_loss_rc_act >= 0) {
@@ -1042,7 +1037,7 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 				}
 			}
 
-		} else if (status_flags->offboard_control_signal_lost && rc_lost) {
+		} else if (status_flags->offboard_control_signal_lost && status->rc_signal_lost) {
 			status->failsafe = true;
 
 			if (status_flags->offboard_control_loss_timeout && offb_loss_act < 3 && offb_loss_act >= 0) {


### PR DESCRIPTION
I also added check for the case when both rc_loss_enabled and data_link_loss_enabled are false (which is handy in jmavsim simulation when no radio is attached).  Without this fix the px4 will not respond to the MAV_CMD_DO_REPOSITION command - instead it just flips the failsafe on and lands.  With this fix it flies to the new position.