### PR TITLE
Revert "Disable EKF2 3D fusion temporarily in SITL, fix missing fast-…

### DIFF
--- a/posix-configs/SITL/init/rcS_gazebo_iris
+++ b/posix-configs/SITL/init/rcS_gazebo_iris
@@ -41,7 +41,6 @@ param set MPC_Z_VEL_P 0.6
 param set MPC_Z_VEL_I 0.15
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01
-param set EKF2_MAG_TYPE 1
 replay tryapplyparams
 simulator start -s
 rgbledsim start

--- a/posix-configs/SITL/init/rcS_gazebo_plane
+++ b/posix-configs/SITL/init/rcS_gazebo_plane
@@ -25,9 +25,6 @@ param set COM_RC_IN_MODE 1
 param set NAV_DLL_ACT 2
 param set NAV_ACC_RAD 15.0
 param set FW_THR_IDLE 0.8
-param set EKF2_GBIAS_INIT 0.01
-param set EKF2_ANGERR_INIT 0.01
-param set EKF2_MAG_TYPE 1
 replay tryapplyparams
 simulator start -s
 rgbledsim start

--- a/posix-configs/SITL/init/rcS_gazebo_solo
+++ b/posix-configs/SITL/init/rcS_gazebo_solo
@@ -38,7 +38,6 @@ param set MPC_Z_VEL_P 0.6
 param set MPC_Z_VEL_I 0.15
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01
-param set EKF2_MAG_TYPE 1
 replay tryapplyparams
 simulator start -s
 rgbledsim start

--- a/posix-configs/SITL/init/rcS_gazebo_standard_vtol
+++ b/posix-configs/SITL/init/rcS_gazebo_standard_vtol
@@ -44,9 +44,6 @@ param set RTL_LAND_DELAY 0
 param set COM_DISARM_LAND 5
 param set COM_DL_LOSS_EN 1
 param set MPC_ACC_HOR_MAX 2
-param set EKF2_GBIAS_INIT 0.01
-param set EKF2_ANGERR_INIT 0.01
-param set EKF2_MAG_TYPE 1
 replay tryapplyparams
 simulator start -s 
 rgbledsim start

--- a/posix-configs/SITL/init/rcS_gazebo_tailsitter
+++ b/posix-configs/SITL/init/rcS_gazebo_tailsitter
@@ -35,9 +35,6 @@ param set SENS_DPRES_OFF 0.001
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
 param set NAV_DLL_ACT 2
-param set EKF2_GBIAS_INIT 0.01
-param set EKF2_ANGERR_INIT 0.01
-param set EKF2_MAG_TYPE 1
 replay tryapplyparams
 simulator start -s
 rgbledsim start

--- a/posix-configs/SITL/init/rcS_gazebo_typhoon_h480
+++ b/posix-configs/SITL/init/rcS_gazebo_typhoon_h480
@@ -40,7 +40,6 @@ param set MPC_XY_VEL_P 0.15
 param set MPC_XY_VEL_I 0.2
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01
-param set EKF2_MAG_TYPE 1
 replay tryapplyparams
 simulator start -s
 rgbledsim start

--- a/posix-configs/SITL/init/rcS_jmavsim_iris
+++ b/posix-configs/SITL/init/rcS_jmavsim_iris
@@ -41,7 +41,6 @@ param set MPC_Z_VEL_MAX 2.0
 param set MPC_Z_VEL_P 0.4
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01
-param set EKF2_MAG_TYPE 1
 replay tryapplyparams
 simulator start -s
 rgbledsim start

--- a/posix-configs/SITL/init/rcS_multiple_gazebo_iris
+++ b/posix-configs/SITL/init/rcS_multiple_gazebo_iris
@@ -32,9 +32,6 @@ param set COM_RC_IN_MODE 1
 param set NAV_ACC_RAD 2.0
 param set RTL_RETURN_ALT 30.0
 param set RTL_DESCEND_ALT 10.0
-param set EKF2_GBIAS_INIT 0.01
-param set EKF2_ANGERR_INIT 0.01
-param set EKF2_MAG_TYPE 1
 replay tryapplyparams
 rgbledsim start
 tone_alarm start
@@ -49,7 +46,8 @@ sensors start
 commander start
 land_detector start multicopter
 navigator start
-ekf2 start
+attitude_estimator_q start
+position_estimator_inav start
 mc_pos_control start
 mc_att_control start
 mixer load /dev/pwm_output0 quad_w.main.mix


### PR DESCRIPTION
…init params for some configs"

This reverts commit db174cf8b1b108b864724a8448dba80f2440f357.

The intent of this PR is to see if this has any relationship to the recent SITL system failure.