### PR TITLE
ekf2 replay: added magic values for range min/max distance

### DIFF
--- a/src/modules/ekf2_replay/ekf2_replay_main.cpp
+++ b/src/modules/ekf2_replay/ekf2_replay_main.cpp
@@ -429,6 +429,10 @@ void Ekf2Replay::setEstimatorInput(uint8_t *data, uint8_t type)
 		parseMessage(data, dest_ptr, type);
 		_range.timestamp = replay_part4.time_rng_usec;
 		_range.current_distance = replay_part4.range_to_ground;
+		_range.covariance = 0.0f;
+		// magic values
+		_range.min_distance = 0.05f;
+		_range.max_distance = 30.0f;
 		_read_part4 = true;
 
 	} else if (type == LOG_RPL6_MSG) {


### PR DESCRIPTION
- replay was not working without these values as only range measurements
were given to the filter which were between the min/max value

Tested ekf2 outdoors using range sensor as primary height source.

Signed-off-by: Roman <bapstroman@gmail.com>