### PR TITLE
initialize waypoint transfer sequence with -1

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -82,7 +82,7 @@ MavlinkMissionManager::MavlinkMissionManager(Mavlink *mavlink) : MavlinkStream(m
 	_transfer_dataman_id(0),
 	_transfer_count(0),
 	_transfer_seq(0),
-	_transfer_current_seq(0),
+	_transfer_current_seq(-1),
 	_transfer_partner_sysid(0),
 	_transfer_partner_compid(0),
 	_offboard_mission_sub(-1),


### PR DESCRIPTION
Tiny bug that would prevent the mission to continue at the current waypoint after a mission re-upload. Only relevant once https://github.com/mavlink/qgroundcontrol/issues/3843 is fixed