### PR TITLE
MC pos control: realize when we are on the trajectory but passed the target waypoint

### DIFF
--- a/cmake/configs/nuttx_mindpx-v2_default.cmake
+++ b/cmake/configs/nuttx_mindpx-v2_default.cmake
@@ -80,6 +80,7 @@ set(config_module_list
 	drivers/sf0x/sf0x_tests
 	drivers/test_ppm
 	modules/commander/commander_tests
+	modules/mc_pos_control/mc_pos_control_tests
 	modules/controllib_test
 	modules/mavlink/mavlink_tests
 	modules/unit_test

--- a/cmake/configs/nuttx_px4fmu-v2_test.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_test.cmake
@@ -76,6 +76,7 @@ set(config_module_list
 	drivers/test_ppm
 	#lib/rc/rc_tests
 	modules/commander/commander_tests
+	modules/mc_pos_control/mc_pos_control_tests
 	modules/controllib_test
 	modules/mavlink/mavlink_tests
 	modules/unit_test

--- a/cmake/configs/nuttx_px4fmu-v4_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v4_default.cmake
@@ -77,6 +77,7 @@ set(config_module_list
 	drivers/sf0x/sf0x_tests
 	drivers/test_ppm
 	modules/commander/commander_tests
+	modules/mc_pos_control/mc_pos_control_tests
 	modules/controllib_test
 	modules/mavlink/mavlink_tests
 	modules/unit_test

--- a/cmake/configs/posix_sitl_default.cmake
+++ b/cmake/configs/posix_sitl_default.cmake
@@ -84,6 +84,7 @@ set(config_module_list
 	drivers/sf0x/sf0x_tests
 	lib/rc/rc_tests
 	modules/commander/commander_tests
+	modules/mc_pos_control/mc_pos_control_tests
 	modules/controllib_test
 	#modules/mavlink/mavlink_tests #TODO: fix mavlink_tests
 	modules/unit_test

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1127,6 +1127,11 @@ void MulticopterPositionControl::control_auto(float dt)
 
 					if (near) {
 						/* unit sphere crosses trajectory */
+						/* if copter is in front of curr waypoint, go directly to curr waypoint */
+						if ((pos_sp_s - curr_sp_s) * prev_curr_s > 0.0f) {
+							pos_sp_s = curr_sp_s;
+							pos_sp_s = pos_s + (pos_sp_s - pos_s).normalized();
+						}
 
 					} else {
 						/* copter is too far from trajectory */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -976,9 +976,7 @@ MulticopterPositionControl::cross_sphere_line(const math::Vector<3> &sphere_c, f
 
 		if ((sphere_c - line_b) * ab_norm > 0.0f) {
 			/* target waypoint is already behind us */
-			math::Vector<3> ba_norm = line_a - line_b;
-			ba_norm.normalize();
-			res = d + ba_norm * dx_len; // vector B->A on line
+			res = line_b;
 
 		} else {
 			/* target is in front of us */

--- a/src/modules/mc_pos_control/mc_pos_control_tests/CMakeLists.txt
+++ b/src/modules/mc_pos_control/mc_pos_control_tests/CMakeLists.txt
@@ -1,0 +1,42 @@
+############################################################################
+#
+#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+px4_add_module(
+	MODULE modules__mc_pos_control__mc_pos_control_tests
+	MAIN mc_pos_control_tests
+	SRCS
+		mc_pos_control_tests.cpp
+		../mc_pos_control_main.cpp
+	DEPENDS
+		platforms__common
+	)
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/mc_pos_control/mc_pos_control_tests/mc_pos_control_tests.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_tests/mc_pos_control_tests.cpp
@@ -92,79 +92,92 @@ bool McPosControlTests::cross_sphere_line_test(void)
 	 * Near            +              +              +
 	 * On trajectory --+----o---------+---------o----+--
 	 *                    prev                curr
+	 *
+	 * Expected targets (1, 2, 3):
+	 * Far             +              +              +
+	 *
+	 *
+	 * On trajectory -------1---------2---------3-------
+	 *
+	 *
+	 * Near            +              +              +
+	 * On trajectory -------o---1---------2-----3-------
+	 *
+	 *
+	 * On trajectory --+----o----1----+--------2/3---+--
 	 */
 
 	// on line, near, before previous waypoint
 	retval = control->cross_sphere_line(math::Vector<3>(0.0f, 0.0f, -0.5f), 1.0f, prev, curr, res);
 	PX4_WARN("result %.2f, %.2f, %.2f", (double)res(0), (double)res(1), (double)res(2));
 	ut_assert_true(retval);
-	ut_assert_true(res(0) == 0.0f);
-	ut_assert_true(res(1) == 0.0f);
-	ut_assert_true((int)(res(2) * 1e2f + 0.5f) == 50);
+	ut_compare_float("target A 0", res(0), 0.0f, 2);
+	ut_compare_float("target A 1", res(1), 0.0f, 2);
+	ut_compare_float("target A 2", res(2), 0.5f, 2);
 
 	// on line, near, before target waypoint
 	retval = control->cross_sphere_line(math::Vector<3>(0.0f, 0.0f, 1.0f), 1.0f, prev, curr, res);
 	PX4_WARN("result %.2f, %.2f, %.2f", (double)res(0), (double)res(1), (double)res(2));
 	ut_assert_true(retval);
-	ut_assert_true(res(0) == 0.0f);
-	ut_assert_true(res(1) == 0.0f);
-	ut_assert_true((int)(res(2) * 1e2f + 0.5f) == 200);
+	ut_compare_float("target B 0", res(0), 0.0f, 2);
+	ut_compare_float("target B 1", res(1), 0.0f, 2);
+	ut_compare_float("target B 2", res(2), 2.0f, 2);
 
 	// on line, near, after target waypoint
 	retval = control->cross_sphere_line(math::Vector<3>(0.0f, 0.0f, 2.5f), 1.0f, prev, curr, res);
 	PX4_WARN("result %.2f, %.2f, %.2f", (double)res(0), (double)res(1), (double)res(2));
 	ut_assert_true(retval);
-	ut_assert_true(res(0) == 0.0f);
-	ut_assert_true(res(1) == 0.0f);
-	ut_assert_true((int)(res(2) * 1e2f + 0.5f) == 150);
+	ut_compare_float("target C 0", res(0), 0.0f, 2);
+	ut_compare_float("target C 1", res(1), 0.0f, 2);
+	ut_compare_float("target C 2", res(2), 2.0f, 2);
 
 	// near, before previous waypoint
 	retval = control->cross_sphere_line(math::Vector<3>(0.0f, 0.5f, -0.5f), 1.0f, prev, curr, res);
 	PX4_WARN("result %.2f, %.2f, %.2f", (double)res(0), (double)res(1), (double)res(2));
 	ut_assert_true(retval);
-	ut_assert_true(res(0) == 0.0f);
-	ut_assert_true(res(1) == 0.0f);
-	ut_assert_true((int)(res(2) * 1e2f + 0.5f) == 37);
+	ut_compare_float("target D 0", res(0), 0.0f, 2);
+	ut_compare_float("target D 1", res(1), 0.0f, 2);
+	ut_compare_float("target D 2", res(2), 0.37f, 2);
 
 	// near, before target waypoint
 	retval = control->cross_sphere_line(math::Vector<3>(0.0f, 0.5f, 1.0f), 1.0f, prev, curr, res);
 	PX4_WARN("result %.2f, %.2f, %.2f", (double)res(0), (double)res(1), (double)res(2));
 	ut_assert_true(retval);
-	ut_assert_true(res(0) == 0.0f);
-	ut_assert_true(res(1) == 0.0f);
-	ut_assert_true((int)(res(2) * 1e2f + 0.5f) == 187);
+	ut_compare_float("target E 0", res(0), 0.0f, 2);
+	ut_compare_float("target E 1", res(1), 0.0f, 2);
+	ut_compare_float("target E 2", res(2), 1.87f, 2);
 
 	// near, after target waypoint
 	retval = control->cross_sphere_line(math::Vector<3>(0.0f, 0.5f, 2.5f), 1.0f, prev, curr, res);
 	PX4_WARN("result %.2f, %.2f, %.2f", (double)res(0), (double)res(1), (double)res(2));
 	ut_assert_true(retval);
-	ut_assert_true(res(0) == 0.0f);
-	ut_assert_true(res(1) == 0.0f);
-	ut_assert_true((int)(res(2) * 1e2f + 0.5f) == 163);
+	ut_compare_float("target F 0", res(0), 0.0f, 2);
+	ut_compare_float("target F 1", res(1), 0.0f, 2);
+	ut_compare_float("target F 2", res(2), 2.0f, 2);
 
 	// far, before previous waypoint
 	retval = control->cross_sphere_line(math::Vector<3>(0.0f, 2.0f, -0.5f), 1.0f, prev, curr, res);
 	PX4_WARN("result %.2f, %.2f, %.2f", (double)res(0), (double)res(1), (double)res(2));
 	ut_assert_false(retval);
-	ut_assert_true(res(0) == 0.0f);
-	ut_assert_true(res(1) == 0.0f);
-	ut_assert_true(res(2) == 0.0f);
+	ut_compare_float("target G 0", res(0), 0.0f, 2);
+	ut_compare_float("target G 1", res(1), 0.0f, 2);
+	ut_compare_float("target G 2", res(2), 0.0f, 2);
 
 	// far, before target waypoint
 	retval = control->cross_sphere_line(math::Vector<3>(0.0f, 2.0f, 1.0f), 1.0f, prev, curr, res);
 	PX4_WARN("result %.2f, %.2f, %.2f", (double)res(0), (double)res(1), (double)res(2));
 	ut_assert_false(retval);
-	ut_assert_true(res(0) == 0.0f);
-	ut_assert_true(res(1) == 0.0f);
-	ut_assert_true((int)(res(2) * 1e2f + 0.5f) == 100);
+	ut_compare_float("target H 0", res(0), 0.0f, 2);
+	ut_compare_float("target H 1", res(1), 0.0f, 2);
+	ut_compare_float("target H 2", res(2), 1.0f, 2);
 
 	// far, after target waypoint
 	retval = control->cross_sphere_line(math::Vector<3>(0.0f, 2.0f, 2.5f), 1.0f, prev, curr, res);
 	PX4_WARN("result %.2f, %.2f, %.2f", (double)res(0), (double)res(1), (double)res(2));
 	ut_assert_false(retval);
-	ut_assert_true(res(0) == 0.0f);
-	ut_assert_true(res(1) == 0.0f);
-	ut_assert_true((int)(res(2) * 1e2f + 0.5f) == 200);
+	ut_compare_float("target I 0", res(0), 0.0f, 2);
+	ut_compare_float("target I 1", res(1), 0.0f, 2);
+	ut_compare_float("target I 2", res(2), 2.0f, 2);
 
 	return true;
 }

--- a/src/modules/mc_pos_control/mc_pos_control_tests/mc_pos_control_tests.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_tests/mc_pos_control_tests.cpp
@@ -1,0 +1,184 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2013 PX4 Development Team. All rights reserved.
+ *   Author: Simon Wilks <sjwilks@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file mc_pos_control_tests.cpp
+ * Commander unit tests. Run the tests as follows:
+ *   nsh> mc_pos_control_tests
+ *
+ */
+
+#include <systemlib/err.h>
+#include <unit_test/unit_test.h>
+#include <mathlib/mathlib.h>
+
+extern "C" __EXPORT int mc_pos_control_tests_main(int argc, char *argv[]);
+
+bool mcPosControlTests(void);
+
+//#include "../mc_pos_control_main.cpp"
+class MulticopterPositionControl
+{
+public:
+	bool		cross_sphere_line(const math::Vector<3> &sphere_c, float sphere_r,
+					  const math::Vector<3> line_a, const math::Vector<3> line_b, math::Vector<3> &res);
+};
+
+class McPosControlTests : public UnitTest
+{
+public:
+	McPosControlTests();
+	virtual ~McPosControlTests();
+
+	virtual bool run_tests(void);
+
+private:
+	bool cross_sphere_line_test();
+};
+
+McPosControlTests::McPosControlTests()
+{
+}
+
+McPosControlTests::~McPosControlTests()
+{
+}
+
+bool McPosControlTests::cross_sphere_line_test(void)
+{
+	MulticopterPositionControl	*control = {};
+
+	math::Vector<3> prev = math::Vector<3>(0, 0, 0);
+	math::Vector<3> curr = math::Vector<3>(0, 0, 2);
+	math::Vector<3> res;
+	bool retval = false;
+
+	/*
+	 * Testing 9 positions (+) around waypoints (o):
+	 *
+	 * Far             +              +              +
+	 *
+	 * Near            +              +              +
+	 * On trajectory --+----o---------+---------o----+--
+	 *                    prev                curr
+	 */
+
+	// on line, near, before previous waypoint
+	retval = control->cross_sphere_line(math::Vector<3>(0.0f, 0.0f, -0.5f), 1.0f, prev, curr, res);
+	PX4_WARN("result %.2f, %.2f, %.2f", (double)res(0), (double)res(1), (double)res(2));
+	ut_assert_true(retval);
+	ut_assert_true(res(0) == 0.0f);
+	ut_assert_true(res(1) == 0.0f);
+	ut_assert_true((int)(res(2) * 1e2f + 0.5f) == 50);
+
+	// on line, near, before target waypoint
+	retval = control->cross_sphere_line(math::Vector<3>(0.0f, 0.0f, 1.0f), 1.0f, prev, curr, res);
+	PX4_WARN("result %.2f, %.2f, %.2f", (double)res(0), (double)res(1), (double)res(2));
+	ut_assert_true(retval);
+	ut_assert_true(res(0) == 0.0f);
+	ut_assert_true(res(1) == 0.0f);
+	ut_assert_true((int)(res(2) * 1e2f + 0.5f) == 200);
+
+	// on line, near, after target waypoint
+	retval = control->cross_sphere_line(math::Vector<3>(0.0f, 0.0f, 2.5f), 1.0f, prev, curr, res);
+	PX4_WARN("result %.2f, %.2f, %.2f", (double)res(0), (double)res(1), (double)res(2));
+	ut_assert_true(retval);
+	ut_assert_true(res(0) == 0.0f);
+	ut_assert_true(res(1) == 0.0f);
+	ut_assert_true((int)(res(2) * 1e2f + 0.5f) == 150);
+
+	// near, before previous waypoint
+	retval = control->cross_sphere_line(math::Vector<3>(0.0f, 0.5f, -0.5f), 1.0f, prev, curr, res);
+	PX4_WARN("result %.2f, %.2f, %.2f", (double)res(0), (double)res(1), (double)res(2));
+	ut_assert_true(retval);
+	ut_assert_true(res(0) == 0.0f);
+	ut_assert_true(res(1) == 0.0f);
+	ut_assert_true((int)(res(2) * 1e2f + 0.5f) == 37);
+
+	// near, before target waypoint
+	retval = control->cross_sphere_line(math::Vector<3>(0.0f, 0.5f, 1.0f), 1.0f, prev, curr, res);
+	PX4_WARN("result %.2f, %.2f, %.2f", (double)res(0), (double)res(1), (double)res(2));
+	ut_assert_true(retval);
+	ut_assert_true(res(0) == 0.0f);
+	ut_assert_true(res(1) == 0.0f);
+	ut_assert_true((int)(res(2) * 1e2f + 0.5f) == 187);
+
+	// near, after target waypoint
+	retval = control->cross_sphere_line(math::Vector<3>(0.0f, 0.5f, 2.5f), 1.0f, prev, curr, res);
+	PX4_WARN("result %.2f, %.2f, %.2f", (double)res(0), (double)res(1), (double)res(2));
+	ut_assert_true(retval);
+	ut_assert_true(res(0) == 0.0f);
+	ut_assert_true(res(1) == 0.0f);
+	ut_assert_true((int)(res(2) * 1e2f + 0.5f) == 163);
+
+	// far, before previous waypoint
+	retval = control->cross_sphere_line(math::Vector<3>(0.0f, 2.0f, -0.5f), 1.0f, prev, curr, res);
+	PX4_WARN("result %.2f, %.2f, %.2f", (double)res(0), (double)res(1), (double)res(2));
+	ut_assert_false(retval);
+	ut_assert_true(res(0) == 0.0f);
+	ut_assert_true(res(1) == 0.0f);
+	ut_assert_true(res(2) == 0.0f);
+
+	// far, before target waypoint
+	retval = control->cross_sphere_line(math::Vector<3>(0.0f, 2.0f, 1.0f), 1.0f, prev, curr, res);
+	PX4_WARN("result %.2f, %.2f, %.2f", (double)res(0), (double)res(1), (double)res(2));
+	ut_assert_false(retval);
+	ut_assert_true(res(0) == 0.0f);
+	ut_assert_true(res(1) == 0.0f);
+	ut_assert_true((int)(res(2) * 1e2f + 0.5f) == 100);
+
+	// far, after target waypoint
+	retval = control->cross_sphere_line(math::Vector<3>(0.0f, 2.0f, 2.5f), 1.0f, prev, curr, res);
+	PX4_WARN("result %.2f, %.2f, %.2f", (double)res(0), (double)res(1), (double)res(2));
+	ut_assert_false(retval);
+	ut_assert_true(res(0) == 0.0f);
+	ut_assert_true(res(1) == 0.0f);
+	ut_assert_true((int)(res(2) * 1e2f + 0.5f) == 200);
+
+	return true;
+}
+
+bool McPosControlTests::run_tests(void)
+{
+	ut_run_test(cross_sphere_line_test);
+
+	return (_tests_failed == 0);
+}
+
+ut_declare_test(mcPosControlTests, McPosControlTests);
+
+int mc_pos_control_tests_main(int argc, char *argv[])
+{
+	return mcPosControlTests() ? 0 : -1;
+}

--- a/src/modules/unit_test/unit_test.h
+++ b/src/modules/unit_test/unit_test.h
@@ -142,6 +142,21 @@ protected:
 		}										\
 	} while (0)
 
+/// @brief Used to compare two float values within a unit test. If possible use ut_compare_float instead of ut_assert
+/// since it will give you better error reporting of the actual values being compared.
+#define ut_compare_float(message, v1, v2, precision)						\
+	do {											\
+		int _p = pow(10, precision);							\
+		int _v1 = (int)(v1 * _p + 0.5f);						\
+		int _v2 = (int)(v2 * _p + 0.5f);						\
+		if (_v1 != _v2) {								\
+			_print_compare(message, #v1, _v1, #v2, _v2, __FILE__, __LINE__);	\
+			return false;								\
+		} else {									\
+			_assertions++;								\
+		}										\
+	} while (0)
+
 	virtual void _init(void) { };		///< Run before each unit test. Override to provide custom behavior.
 	virtual void _cleanup(void) { };	///< Run after each unit test. Override to provide custom behavior.
 

--- a/src/systemcmds/tests/tests.h
+++ b/src/systemcmds/tests/tests.h
@@ -112,6 +112,7 @@ extern int controllib_test_main(int argc, char *argv[]);
 extern int uorb_tests_main(int argc, char *argv[]);
 extern int rc_tests_main(int argc, char *argv[]);
 extern int sf0x_tests_main(int argc, char *argv[]);
+extern int mc_pos_control_tests_main(int argc, char *argv[]);
 
 
 __END_DECLS

--- a/src/systemcmds/tests/tests_main.c
+++ b/src/systemcmds/tests/tests_main.c
@@ -92,6 +92,7 @@ const struct {
 	/* external tests */
 	{"commander",		commander_tests_main,	0},
 	{"controllib",		controllib_test_main,	0},
+	{"mc_pos_control",	mc_pos_control_tests_main,	0},
 	//{"mavlink",		mavlink_tests_main,	0}, // TODO: fix mavlink_tests
 	{"sf0x",		sf0x_tests_main,	0},
 #ifndef __PX4_DARWIN


### PR DESCRIPTION
In the following mission, https://gist.github.com/AndreasAntener/42eb7d7e777cff4baf0c0c01c3a5de4f, the multicopter manages to fly 180 degrees into the wrong direction. This waypoint combination most likely never occurs for multicopters (discovered while analyzing #5270). However what happens is that the MC controller sees a previous and current setpoint where the previous setpoint is on the further end of the trajectory (viewed from the current position). The outcome is a target position setpoint on the trajectory into the direction from previous to current and therefore into the wrong direction.

Should be investigated further, having a second pair of eyes to look this over would be appreciated.

<img width="316" alt="screen shot 2016-08-12 at 00 10 47" src="https://cloud.githubusercontent.com/assets/5750020/17607603/10037904-6027-11e6-891d-1771af56444d.png">
