### PR TITLE
Add PX4_{WARN,ERR} log messages to the ulog file

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -65,6 +65,7 @@ set(msg_file_names
 	hil_sensor.msg
 	home_position.msg
 	input_rc.msg
+	log_message.msg
 	manual_control_setpoint.msg
 	mavlink_log.msg
 	mc_att_ctrl_status.msg

--- a/msg/log_message.msg
+++ b/msg/log_message.msg
@@ -1,0 +1,5 @@
+# A logging message, output with PX4_{WARN,ERR,INFO}
+
+uint8 severity # log level (same as in the linux kernel, starting with 0)
+uint8[127] text
+

--- a/src/drivers/device/integrator.cpp
+++ b/src/drivers/device/integrator.cpp
@@ -41,6 +41,7 @@
  */
 
 #include "integrator.h"
+#include <drivers/drv_hrt.h>
 
 Integrator::Integrator(uint64_t auto_reset_interval, bool coning_compensation) :
 	_auto_reset_interval(auto_reset_interval),

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -1,4 +1,5 @@
 #include "BlockLocalPositionEstimator.hpp"
+#include <drivers/drv_hrt.h>
 #include <systemlib/mavlink_log.h>
 #include <fcntl.h>
 #include <systemlib/err.h>

--- a/src/modules/local_position_estimator/local_position_estimator_main.cpp
+++ b/src/modules/local_position_estimator/local_position_estimator_main.cpp
@@ -102,7 +102,7 @@ int local_position_estimator_main(int argc, char *argv[])
 	if (!strcmp(argv[1], "start")) {
 
 		if (thread_running) {
-			warnx("already running");
+			PX4_INFO("already running");
 			/* this is not an error */
 			return 0;
 		}
@@ -120,11 +120,11 @@ int local_position_estimator_main(int argc, char *argv[])
 
 	if (!strcmp(argv[1], "stop")) {
 		if (thread_running) {
-			warnx("stop");
+			PX4_DEBUG("stop");
 			thread_should_exit = true;
 
 		} else {
-			warnx("not started");
+			PX4_WARN("not started");
 		}
 
 		return 0;
@@ -132,10 +132,10 @@ int local_position_estimator_main(int argc, char *argv[])
 
 	if (!strcmp(argv[1], "status")) {
 		if (thread_running) {
-			warnx("is running");
+			PX4_INFO("is running");
 
 		} else {
-			warnx("not started");
+			PX4_INFO("not started");
 		}
 
 		return 0;
@@ -148,7 +148,7 @@ int local_position_estimator_main(int argc, char *argv[])
 int local_position_estimator_thread_main(int argc, char *argv[])
 {
 
-	warnx("starting");
+	PX4_DEBUG("starting");
 
 	using namespace control;
 
@@ -160,7 +160,7 @@ int local_position_estimator_thread_main(int argc, char *argv[])
 		est.update();
 	}
 
-	warnx("exiting.");
+	PX4_DEBUG("exiting.");
 
 	thread_running = false;
 

--- a/src/modules/logger/log_writer.cpp
+++ b/src/modules/logger/log_writer.cpp
@@ -82,16 +82,15 @@ LogWriter::~LogWriter()
 
 void LogWriter::start_log(const char *filename)
 {
-	::strncpy(_filename, filename, sizeof(_filename));
-	_fd = ::open(_filename, O_CREAT | O_WRONLY, PX4_O_MODE_666);
+	_fd = ::open(filename, O_CREAT | O_WRONLY, PX4_O_MODE_666);
 
 	if (_fd < 0) {
-		PX4_ERR("Can't open log file %s", _filename);
+		PX4_ERR("Can't open log file %s", filename);
 		_should_run = false;
 		return;
 
 	} else {
-		PX4_INFO("Opened log file: %s", _filename);
+		PX4_INFO("Opened log file: %s", filename);
 		_should_run = true;
 		_running = true;
 	}
@@ -232,7 +231,7 @@ void LogWriter::run()
 						PX4_WARN("error closing log file");
 
 					} else {
-						PX4_INFO("closed logfile: %s, bytes written: %zu", _filename, _total_written);
+						PX4_INFO("closed logfile, bytes written: %zu", _total_written);
 					}
 				}
 

--- a/src/modules/logger/log_writer.h
+++ b/src/modules/logger/log_writer.h
@@ -122,7 +122,6 @@ private:
 	/* 512 didn't seem to work properly, 4096 should match the FAT cluster size */
 	static constexpr size_t	_min_write_chunk = 4096;
 
-	char		_filename[64];
 	int			_fd = -1;
 	uint8_t 	*_buffer = nullptr;
 	const size_t	_buffer_size;

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -234,6 +234,7 @@ void Logger::print_statistics()
 	float mebibytes = kibibytes / 1024.0f;
 	float seconds = ((float)(hrt_absolute_time() - _start_time)) / 1000000.0f;
 
+	PX4_INFO("Log file: %s/%s", _log_dir, _log_file_name);
 	PX4_INFO("Wrote %4.2f MiB (avg %5.2f KiB/s)", (double)mebibytes, (double)(kibibytes / seconds));
 	PX4_INFO("Since last status: dropouts: %zu (max len: %.3f s), max used buffer: %zu / %zu B",
 		 _write_dropouts, (double)_max_dropout_duration, _high_water, _writer.get_buffer_size());
@@ -942,9 +943,10 @@ int Logger::get_log_file_name(char *file_name, size_t file_name_size)
 			return -1;
 		}
 
-		char log_file_name[64] = "";
-		strftime(log_file_name, sizeof(log_file_name), "%H_%M_%S", &tt);
-		snprintf(file_name, file_name_size, "%s/%s%s.ulg", _log_dir, log_file_name, replay_suffix);
+		char log_file_name_time[16] = "";
+		strftime(log_file_name_time, sizeof(log_file_name_time), "%H_%M_%S", &tt);
+		snprintf(_log_file_name, sizeof(_log_file_name), "%s%s.ulg", log_file_name_time, replay_suffix);
+		snprintf(file_name, file_name_size, "%s/%s", _log_dir, _log_file_name);
 
 	} else {
 		if (create_log_dir(nullptr)) {
@@ -956,7 +958,8 @@ int Logger::get_log_file_name(char *file_name, size_t file_name_size)
 		/* look for the next file that does not exist */
 		while (file_number <= MAX_NO_LOGFILE) {
 			/* format log file path: e.g. /fs/microsd/sess001/log001.ulg */
-			snprintf(file_name, file_name_size, "%s/log%03u%s.ulg", _log_dir, file_number, replay_suffix);
+			snprintf(_log_file_name, sizeof(_log_file_name), "log%03u%s.ulg", file_number, replay_suffix);
+			snprintf(file_name, file_name_size, "%s/%s", _log_dir, _log_file_name);
 
 			if (!file_exist(file_name)) {
 				break;

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -441,7 +441,7 @@ bool Logger::copy_if_updated_multi(LoggerSubscription &sub, int multi_instance, 
 		if (OK == orb_exists(sub.metadata, multi_instance)) {
 			handle = orb_subscribe_multi(sub.metadata, multi_instance);
 
-			//PX4_INFO("subscribed to instance %d of topic %s", multi_instance, topic->o_name);
+			//PX4_INFO("subscribed to instance %d of topic %s", multi_instance, sub.metadata->o_name);
 
 			/* copy first data */
 			if (handle >= 0) {
@@ -454,8 +454,11 @@ bool Logger::copy_if_updated_multi(LoggerSubscription &sub, int multi_instance, 
 					orb_set_interval(handle, interval);
 				}
 
-				orb_copy(sub.metadata, handle, buffer);
-				updated = true;
+				/* It can happen that orb_exists returns true, even if there is no publisher (but another subscriber).
+				 * We catch this here, because orb_copy will fail in this case. */
+				if (orb_copy(sub.metadata, handle, buffer) == PX4_OK) {
+					updated = true;
+				}
 			}
 		}
 

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -217,6 +217,7 @@ private:
 	int						_msg_buffer_len = 0;
 	bool						_task_should_exit = true;
 	char 						_log_dir[LOG_DIR_LEN];
+	char 						_log_file_name[32];
 	bool						_has_log_dir = false;
 	bool						_enabled = false;
 	bool						_was_armed = false;

--- a/src/modules/muorb/krait/px4muorb_KraitRpcWrapper.cpp
+++ b/src/modules/muorb/krait/px4muorb_KraitRpcWrapper.cpp
@@ -39,6 +39,7 @@
 #include "px4muorb.h"
 #include "px4_log.h"
 #include <shmem.h>
+#include <drivers/drv_hrt.h>
 
 using namespace px4muorb;
 

--- a/src/modules/systemlib/mavlink_log.c
+++ b/src/modules/systemlib/mavlink_log.c
@@ -38,6 +38,7 @@
  * @author Lorenz Meier <lorenz@px4.io>
  */
 
+#include <drivers/drv_hrt.h>
 #include <px4_posix.h>
 #include <string.h>
 #include <stdlib.h>

--- a/src/modules/uORB/Subscription.cpp
+++ b/src/modules/uORB/Subscription.cpp
@@ -49,6 +49,7 @@
 #include "topics/vehicle_status.h"
 #include "topics/manual_control_setpoint.h"
 #include "topics/mavlink_log.h"
+#include "topics/log_message.h"
 #include "topics/vehicle_local_position_setpoint.h"
 #include "topics/vehicle_local_position.h"
 #include "topics/vehicle_attitude_setpoint.h"
@@ -166,6 +167,7 @@ template class __EXPORT Subscription<position_setpoint_triplet_s>;
 template class __EXPORT Subscription<vehicle_status_s>;
 template class __EXPORT Subscription<manual_control_setpoint_s>;
 template class __EXPORT Subscription<mavlink_log_s>;
+template class __EXPORT Subscription<log_message_s>;
 template class __EXPORT Subscription<vehicle_local_position_setpoint_s>;
 template class __EXPORT Subscription<vehicle_local_position_s>;
 template class __EXPORT Subscription<vehicle_attitude_setpoint_s>;

--- a/src/modules/uORB/Subscription.cpp
+++ b/src/modules/uORB/Subscription.cpp
@@ -84,7 +84,7 @@ SubscriptionBase::SubscriptionBase(const struct orb_metadata *meta,
 		_handle =  orb_subscribe(getMeta());
 	}
 
-	if (_handle < 0) { warnx("sub failed"); }
+	if (_handle < 0) { PX4_ERR("sub failed"); }
 
 	if (interval > 0) {
 		orb_set_interval(getHandle(), interval);
@@ -96,7 +96,7 @@ bool SubscriptionBase::updated()
 	bool isUpdated = false;
 	int ret = orb_check(_handle, &isUpdated);
 
-	if (ret != PX4_OK) { warnx("orb check failed"); }
+	if (ret != PX4_OK) { PX4_ERR("orb check failed"); }
 
 	return isUpdated;
 }
@@ -106,7 +106,7 @@ void SubscriptionBase::update(void *data)
 	if (updated()) {
 		int ret = orb_copy(_meta, _handle, data);
 
-		if (ret != PX4_OK) { warnx("orb copy failed"); }
+		if (ret != PX4_OK) { PX4_ERR("orb copy failed"); }
 	}
 }
 
@@ -114,7 +114,7 @@ SubscriptionBase::~SubscriptionBase()
 {
 	int ret = orb_unsubscribe(_handle);
 
-	if (ret != PX4_OK) { warnx("orb unsubscribe failed"); }
+	if (ret != PX4_OK) { PX4_ERR("orb unsubscribe failed"); }
 }
 
 template <class T>
@@ -129,7 +129,7 @@ Subscription<T>::Subscription(const struct orb_metadata *meta,
 
 template <class T>
 Subscription<T>::Subscription(const Subscription &other) :
-	SubscriptionNode(other._meta, other._interval, other._instance, nullptr),
+	SubscriptionNode(other._meta, other.getInterval(), other._instance, nullptr),
 	_data() // initialize data structure to zero
 {
 }

--- a/src/modules/uORB/Subscription.hpp
+++ b/src/modules/uORB/Subscription.hpp
@@ -86,7 +86,14 @@ public:
 
 // accessors
 	const struct orb_metadata *getMeta() { return _meta; }
-	int getHandle() { return _handle; }
+	int getHandle() const { return _handle; }
+
+	unsigned getInterval() const
+	{
+		unsigned int interval;
+		orb_get_interval(getHandle(), &interval);
+		return interval;
+	}
 protected:
 // accessors
 	void setHandle(int handle) { _handle = handle; }
@@ -130,8 +137,7 @@ public:
 			 unsigned interval = 0,
 			 int instance = 0,
 			 List<SubscriptionNode *> *list = nullptr) :
-		SubscriptionBase(meta, interval, instance),
-		_interval(interval)
+		SubscriptionBase(meta, interval, instance)
 	{
 		if (list != nullptr) { list->add(this); }
 	}
@@ -141,11 +147,6 @@ public:
 	 * updates, a child class must implement it.
 	 */
 	virtual void update() = 0;
-// accessors
-	unsigned getInterval() { return _interval; }
-protected:
-// attributes
-	unsigned _interval;
 
 };
 

--- a/src/modules/uORB/uORBMain.cpp
+++ b/src/modules/uORB/uORBMain.cpp
@@ -36,6 +36,7 @@
 #include "uORBManager.hpp"
 #include "uORB.h"
 #include "uORBCommon.hpp"
+#include <px4_log.h>
 
 extern "C" { __EXPORT int uorb_main(int argc, char *argv[]); }
 
@@ -77,6 +78,8 @@ uorb_main(int argc, char *argv[])
 		if (g_dev == nullptr) {
 			return -errno;
 		}
+
+		px4_log_initialize();
 
 		return OK;
 	}

--- a/src/modules/uORB/uORBManager.hpp
+++ b/src/modules/uORB/uORBManager.hpp
@@ -295,7 +295,8 @@ public:
 	int  orb_stat(int handle, uint64_t *time) ;
 
 	/**
-	 * Check if a topic has already been created.
+	 * Check if a topic has already been created (a publisher or a subscriber exists with
+	 * the given instance).
 	 *
 	 * @param meta    ORB topic metadata.
 	 * @param instance  ORB instance

--- a/src/modules/uavcan/sensors/baro.cpp
+++ b/src/modules/uavcan/sensors/baro.cpp
@@ -35,6 +35,7 @@
  * @author Pavel Kirienko <pavel.kirienko@gmail.com>
  */
 
+#include <drivers/drv_hrt.h>
 #include "baro.hpp"
 #include <cmath>
 

--- a/src/modules/uavcan/sensors/gnss.cpp
+++ b/src/modules/uavcan/sensors/gnss.cpp
@@ -40,6 +40,7 @@
  */
 
 #include "gnss.hpp"
+#include <drivers/drv_hrt.h>
 #include <systemlib/err.h>
 #include <mathlib/mathlib.h>
 

--- a/src/modules/uavcan/sensors/mag.cpp
+++ b/src/modules/uavcan/sensors/mag.cpp
@@ -37,6 +37,7 @@
 
 #include "mag.hpp"
 
+#include <drivers/drv_hrt.h>
 #include <systemlib/err.h>
 
 const char *const UavcanMagnetometerBridge::NAME = "mag";

--- a/src/platforms/posix/px4_layer/px4_log.c
+++ b/src/platforms/posix/px4_layer/px4_log.c
@@ -3,11 +3,33 @@
 #ifdef __PX4_POSIX
 #include <execinfo.h>
 #endif
+#include <uORB/uORB.h>
+#include <uORB/topics/log_message.h>
+#include <drivers/drv_hrt.h>
 
+static orb_advert_t orb_log_message_pub = NULL;
 
 __EXPORT const char *__px4_log_level_str[_PX4_LOG_LEVEL_PANIC + 1] = { "INFO", "DEBUG", "WARN", "ERROR", "PANIC" };
 __EXPORT const char *__px4_log_level_color[_PX4_LOG_LEVEL_PANIC + 1] =
 { PX4_ANSI_COLOR_RESET, PX4_ANSI_COLOR_GREEN, PX4_ANSI_COLOR_YELLOW, PX4_ANSI_COLOR_RED, PX4_ANSI_COLOR_RED };
+
+
+void px4_log_initialize(void)
+{
+	ASSERT(orb_log_message_pub == NULL);
+
+	/* we need to advertise with a valid message */
+	struct log_message_s log_message;
+	log_message.timestamp = hrt_absolute_time();
+	log_message.severity = 6; //info
+	strcpy((char *)log_message.text, "initialized uORB logging");
+
+	orb_log_message_pub = orb_advertise_queue(ORB_ID(log_message), &log_message, 2);
+
+	if (!orb_log_message_pub) {
+		PX4_ERR("failed to advertise log_message");
+	}
+}
 
 void px4_backtrace()
 {
@@ -43,5 +65,33 @@ __EXPORT void px4_log_modulename(int level, const char *moduleName, const char *
 	va_end(argptr);
 	PX4_LOG_COLOR_END
 	printf("\n");
+
+	/* publish an orb log message */
+	if (level >= _PX4_LOG_LEVEL_WARN && orb_log_message_pub) { //only publish important messages
+
+		struct log_message_s log_message;
+		const unsigned max_length = sizeof(log_message.text);
+		log_message.timestamp = hrt_absolute_time();
+
+		const uint8_t log_level_table[] = {
+			6, /* _PX4_LOG_LEVEL_ALWAYS */
+			7, /* _PX4_LOG_LEVEL_DEBUG */
+			4, /* _PX4_LOG_LEVEL_WARN */
+			3, /* _PX4_LOG_LEVEL_ERROR */
+			0  /* _PX4_LOG_LEVEL_PANIC */
+		};
+		log_message.severity = log_level_table[level];
+
+		unsigned pos = 0;
+
+		pos += snprintf((char *)log_message.text + pos, max_length - pos, __px4__log_modulename_pfmt, moduleName);
+		va_start(argptr, fmt);
+		pos += vsnprintf((char *)log_message.text + pos, max_length - pos, fmt, argptr);
+		va_end(argptr);
+		log_message.text[max_length - 1] = 0; //ensure 0-termination
+
+		orb_publish(ORB_ID(log_message), orb_log_message_pub, &log_message);
+
+	}
 }
 

--- a/src/platforms/posix/px4_layer/px4_log.c
+++ b/src/platforms/posix/px4_layer/px4_log.c
@@ -4,7 +4,6 @@
 #include <execinfo.h>
 #endif
 
-__EXPORT int __px4_log_level_current = PX4_LOG_LEVEL_AT_RUN_TIME;
 
 __EXPORT const char *__px4_log_level_str[_PX4_LOG_LEVEL_PANIC + 1] = { "INFO", "DEBUG", "WARN", "ERROR", "PANIC" };
 __EXPORT const char *__px4_log_level_color[_PX4_LOG_LEVEL_PANIC + 1] =
@@ -33,18 +32,16 @@ void px4_backtrace()
 
 __EXPORT void px4_log_modulename(int level, const char *moduleName, const char *fmt, ...)
 {
-	if (level <= __px4_log_level_current) {
-		PX4_LOG_COLOR_START
-		printf(__px4__log_level_fmt __px4__log_level_arg(level));
-		PX4_LOG_COLOR_MODULE
-		printf(__px4__log_modulename_pfmt, moduleName);
-		PX4_LOG_COLOR_MESSAGE
-		va_list argptr;
-		va_start(argptr, fmt);
-		vprintf(fmt, argptr);
-		va_end(argptr);
-		PX4_LOG_COLOR_END
-		printf("\n");
-	}
+	PX4_LOG_COLOR_START
+	printf(__px4__log_level_fmt __px4__log_level_arg(level));
+	PX4_LOG_COLOR_MODULE
+	printf(__px4__log_modulename_pfmt, moduleName);
+	PX4_LOG_COLOR_MESSAGE
+	va_list argptr;
+	va_start(argptr, fmt);
+	vprintf(fmt, argptr);
+	va_end(argptr);
+	PX4_LOG_COLOR_END
+	printf("\n");
 }
 

--- a/src/platforms/px4_log.h
+++ b/src/platforms/px4_log.h
@@ -130,7 +130,6 @@ __BEGIN_DECLS
 
 __EXPORT extern const char *__px4_log_level_str[_PX4_LOG_LEVEL_PANIC + 1];
 __EXPORT extern const char *__px4_log_level_color[_PX4_LOG_LEVEL_PANIC + 1];
-__EXPORT extern int __px4_log_level_current;
 __EXPORT extern void px4_backtrace(void);
 __EXPORT void px4_log_modulename(int level, const char *moduleName, const char *fmt, ...);
 
@@ -138,21 +137,18 @@ __END_DECLS
 
 #define PX4_BACKTRACE() px4_backtrace()
 
-// __px4_log_level_current will be initialized to PX4_LOG_LEVEL_AT_RUN_TIME
-#define PX4_LOG_LEVEL_AT_RUN_TIME	_PX4_LOG_LEVEL_ERROR
-
 /****************************************************************************
  * Implementation of log section formatting based on printf
  *
  * To write to a specific stream for each message type, open the streams and
  * set __px4__log_startline to something like:
- * 	if (level <= __px4_log_level_current) printf(_px4_fd[level],
+ * 	printf(_px4_fd[level],
  *
  * Additional behavior can be added using "{\" for __px4__log_startline and
  * "}" for __px4__log_endline and any other required setup or teardown steps
  ****************************************************************************/
 #define __px4__log_printcond(cond, ...)	    if (cond) printf(__VA_ARGS__)
-#define __px4__log_printline(level, ...)    if (level <= __px4_log_level_current) printf(__VA_ARGS__)
+#define __px4__log_printline(level, ...)    printf(__VA_ARGS__)
 
 
 #ifndef MODULE_NAME

--- a/src/platforms/px4_log.h
+++ b/src/platforms/px4_log.h
@@ -127,7 +127,6 @@ static inline void do_nothing(int level, ...)
 #include <px4_defines.h>
 
 __BEGIN_DECLS
-__EXPORT extern uint64_t hrt_absolute_time(void);
 
 __EXPORT extern const char *__px4_log_level_str[_PX4_LOG_LEVEL_PANIC + 1];
 __EXPORT extern const char *__px4_log_level_color[_PX4_LOG_LEVEL_PANIC + 1];

--- a/src/platforms/px4_log.h
+++ b/src/platforms/px4_log.h
@@ -128,6 +128,11 @@ static inline void do_nothing(int level, ...)
 
 __BEGIN_DECLS
 
+/**
+ * initialize the orb logging. Logging to console still works without or before calling this.
+ */
+__EXPORT extern void px4_log_initialize(void);
+
 __EXPORT extern const char *__px4_log_level_str[_PX4_LOG_LEVEL_PANIC + 1];
 __EXPORT extern const char *__px4_log_level_color[_PX4_LOG_LEVEL_PANIC + 1];
 __EXPORT extern void px4_backtrace(void);

--- a/src/platforms/px4_log.h
+++ b/src/platforms/px4_log.h
@@ -38,6 +38,8 @@
 
 #pragma once
 
+#include <systemlib/visibility.h>
+
 #define _PX4_LOG_LEVEL_ALWAYS		0
 #define _PX4_LOG_LEVEL_DEBUG		1
 #define _PX4_LOG_LEVEL_WARN		2
@@ -50,6 +52,14 @@ static inline void do_nothing(int level, ...)
 	(void)level;
 }
 
+__BEGIN_DECLS
+
+/**
+ * initialize the orb logging. Logging to console still works without or before calling this.
+ */
+__EXPORT extern void px4_log_initialize(void);
+
+__END_DECLS
 
 /****************************************************************************
  * __px4_log_omit:
@@ -127,11 +137,6 @@ static inline void do_nothing(int level, ...)
 #include <px4_defines.h>
 
 __BEGIN_DECLS
-
-/**
- * initialize the orb logging. Logging to console still works without or before calling this.
- */
-__EXPORT extern void px4_log_initialize(void);
 
 __EXPORT extern const char *__px4_log_level_str[_PX4_LOG_LEVEL_PANIC + 1];
 __EXPORT extern const char *__px4_log_level_color[_PX4_LOG_LEVEL_PANIC + 1];

--- a/unittests/uorb_stub.cpp
+++ b/unittests/uorb_stub.cpp
@@ -15,6 +15,11 @@ orb_advert_t orb_advertise(const struct orb_metadata *meta, const void *data)
 	return (orb_advert_t)0;
 }
 
+orb_advert_t orb_advertise_queue(const struct orb_metadata *meta, const void *data, unsigned int queue_size)
+{
+	return (orb_advert_t)0;
+}
+
 int	orb_publish(const struct orb_metadata *meta, orb_advert_t handle, const void *data)
 {
 	return 0;


### PR DESCRIPTION
This removes the mavlink log messages and adds PX4_{WARN,ERR} instead to the ulog. It still includes the important mavlink log messages, since they are logged to console as well.
Messages are rate limited to 50Hz with orb queue size of 2.

I did not add PX4_INFO, if someone has good reasons to add them, we can do that as well.

Also fixes a bug in the new logger, where garbage data was written to the log.