### PR TITLE
Fix front transition for airspeed-less mode

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -166,7 +166,8 @@ MissionBlock::is_mission_item_reached()
 		if ((_mission_item.nav_cmd == NAV_CMD_TAKEOFF || _mission_item.nav_cmd == NAV_CMD_VTOL_TAKEOFF)
 			&& _navigator->get_vstatus()->is_rotary_wing) {
 			/* require only altitude for takeoff for multicopter, do not use waypoint acceptance radius */
-			if (_navigator->get_global_position()->alt >= altitude_amsl) {
+			if (_navigator->get_global_position()->alt >
+					altitude_amsl - _navigator->get_acceptance_radius()) {
 				_waypoint_position_reached = true;
 			}
 		} else if (_mission_item.nav_cmd == NAV_CMD_TAKEOFF) {

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -165,9 +165,9 @@ MissionBlock::is_mission_item_reached()
 
 		if ((_mission_item.nav_cmd == NAV_CMD_TAKEOFF || _mission_item.nav_cmd == NAV_CMD_VTOL_TAKEOFF)
 			&& _navigator->get_vstatus()->is_rotary_wing) {
-			/* require only altitude for takeoff for multicopter, do not use waypoint acceptance radius */
+			/* require only altitude for takeoff for multicopter */
 			if (_navigator->get_global_position()->alt >
-					altitude_amsl - _navigator->get_acceptance_radius()) {
+					altitude_amsl - _navigator->get_altitude_acceptance_radius()) {
 				_waypoint_position_reached = true;
 			}
 		} else if (_mission_item.nav_cmd == NAV_CMD_TAKEOFF) {

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -263,10 +263,14 @@ void Standard::update_transition_state()
 			// time based blending when no airspeed sensor is set
 
 		} else if (_params_standard.airspeed_mode == control_state_s::AIRSPD_MODE_DISABLED &&
-			   (float)hrt_elapsed_time(&_vtol_schedule.transition_start) < (_params_standard.front_trans_time_min * 1000000.0f)
+				(float)hrt_elapsed_time(&_vtol_schedule.transition_start) < (_params_standard.front_trans_time_min * 1000000.0f) &&
+				(float)hrt_elapsed_time(&_vtol_schedule.transition_start) > ((_params_standard.front_trans_time_min / 2.0f) * 1000000.0f)
 			  ) {
-			float weight = 1.0f - (float)(hrt_elapsed_time(&_vtol_schedule.transition_start) /
-						      (_params_standard.front_trans_time_min * 1000000.0f));
+			float weight = 1.0f - ((float)(hrt_elapsed_time(&_vtol_schedule.transition_start) - ((_params_standard.front_trans_time_min / 2.0f) * 1000000.0f)) /
+							  ((_params_standard.front_trans_time_min / 2.0f) * 1000000.0f));
+
+			weight = math::constrain(weight, 0.0f, 1.0f);
+
 			_mc_roll_weight = weight;
 			_mc_pitch_weight = weight;
 			_mc_yaw_weight = weight;

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -263,11 +263,13 @@ void Standard::update_transition_state()
 			// time based blending when no airspeed sensor is set
 
 		} else if (_params_standard.airspeed_mode == control_state_s::AIRSPD_MODE_DISABLED &&
-				(float)hrt_elapsed_time(&_vtol_schedule.transition_start) < (_params_standard.front_trans_time_min * 1000000.0f) &&
-				(float)hrt_elapsed_time(&_vtol_schedule.transition_start) > ((_params_standard.front_trans_time_min / 2.0f) * 1000000.0f)
+			   (float)hrt_elapsed_time(&_vtol_schedule.transition_start) < (_params_standard.front_trans_time_min * 1000000.0f) &&
+			   (float)hrt_elapsed_time(&_vtol_schedule.transition_start) > ((_params_standard.front_trans_time_min / 2.0f) *
+					   1000000.0f)
 			  ) {
-			float weight = 1.0f - ((float)(hrt_elapsed_time(&_vtol_schedule.transition_start) - ((_params_standard.front_trans_time_min / 2.0f) * 1000000.0f)) /
-							  ((_params_standard.front_trans_time_min / 2.0f) * 1000000.0f));
+			float weight = 1.0f - ((float)(hrt_elapsed_time(&_vtol_schedule.transition_start) - ((
+							       _params_standard.front_trans_time_min / 2.0f) * 1000000.0f)) /
+					       ((_params_standard.front_trans_time_min / 2.0f) * 1000000.0f));
 
 			weight = math::constrain(weight, 0.0f, 1.0f);
 


### PR DESCRIPTION
- Re-enabled altitude acceptance radius for vtol-takeoff to combat overshoot (led to too little control for the MC in the first moments of transition)
- Changed  time based blending to start half-way and not directly

SITL tested, going outdoor now

@AndreasAntener 