### PR TITLE
implemented slew-rate

### DIFF
--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1075,8 +1075,12 @@ PX4FMU::cycle()
 				dt = 0.02f;
 			}
 
-			float slew_max = 2.0f * 1000.0f * dt / (_max_pwm[0] - _min_pwm[0]) / _mot_t_max;
-			_mixers->update_slew_rate(slew_max);
+			if (_mot_t_max > FLT_EPSILON) {
+				// maximum value the ouputs of the multirotor mixer are allowed to change in this cycle
+				// factor 2 is needed because actuator ouputs are in the range [-1,1]
+				float delta_out_max = 2.0f * 1000.0f * dt / (_max_pwm[0] - _min_pwm[0]) / _mot_t_max;
+				_mixers->set_max_delta_out_once(delta_out_max);
+			}
 
 			/* do mixing */
 			float outputs[_max_actuators];

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1245,6 +1245,14 @@ PX4IO::task_main()
 					}
 				}
 
+				/* maximum motor pwm slew rate */
+				parm_handle = param_find("MOT_SLEW_MAX");
+
+				if (parm_handle != PARAM_INVALID) {
+					param_get(parm_handle, &param_val);
+					(void)io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_MOTOR_SLEW_MAX, FLOAT_TO_REG(param_val));
+				}
+
 				// Also trigger param update in Battery instance.
 				_battery.updateParams();
 			}

--- a/src/modules/px4iofirmware/mixer.cpp
+++ b/src/modules/px4iofirmware/mixer.cpp
@@ -232,10 +232,13 @@ mixer_tick(void)
 		float	outputs[PX4IO_SERVO_COUNT];
 		unsigned mixed;
 
-		// update slew rate value
-		float slew_max = 2.0f * 1000.0f * dt / (r_page_servo_control_max[0] - r_page_servo_control_min[0]) / REG_TO_FLOAT(
-					 r_setup_slew_max);
-		mixer_group.update_slew_rate(slew_max);
+		if (REG_TO_FLOAT(r_setup_slew_max) > FLT_EPSILON) {
+			// maximum value the ouputs of the multirotor mixer are allowed to change in this cycle
+			// factor 2 is needed because actuator ouputs are in the range [-1,1]
+			float delta_out_max = 2.0f * 1000.0f * dt / (r_page_servo_control_max[0] - r_page_servo_control_min[0]) / REG_TO_FLOAT(
+						      r_setup_slew_max);
+			mixer_group.set_max_delta_out_once(delta_out_max);
+		}
 
 		/* mix */
 
@@ -518,10 +521,13 @@ mixer_set_failsafe()
 	float	outputs[PX4IO_SERVO_COUNT];
 	unsigned mixed;
 
-	// update slew rate value
-	float slew_max = 2.0f * 1000.0f * dt / (r_page_servo_control_max[0] - r_page_servo_control_min[0]) / REG_TO_FLOAT(
-				 r_setup_slew_max);
-	mixer_group.update_slew_rate(slew_max);
+	if (REG_TO_FLOAT(r_setup_slew_max) > FLT_EPSILON) {
+		// maximum value the ouputs of the multirotor mixer are allowed to change in this cycle
+		// factor 2 is needed because actuator ouputs are in the range [-1,1]
+		float delta_out_max = 2.0f * 1000.0f * dt / (r_page_servo_control_max[0] - r_page_servo_control_min[0]) / REG_TO_FLOAT(
+					      r_setup_slew_max);
+		mixer_group.set_max_delta_out_once(delta_out_max);
+	}
 
 	/* mix */
 	mixed = mixer_group.mix(&outputs[0], PX4IO_SERVO_COUNT, &r_mixer_limits);

--- a/src/modules/px4iofirmware/protocol.h
+++ b/src/modules/px4iofirmware/protocol.h
@@ -242,6 +242,8 @@ enum {							/* DSM bind states */
 
 #define PX4IO_P_SETUP_SBUS_RATE			22	/* frame rate of SBUS1 output in Hz */
 
+#define PX4IO_P_SETUP_MOTOR_SLEW_MAX 	24 	/* max motor slew rate */
+
 /* autopilot control values, -10000..10000 */
 #define PX4IO_PAGE_CONTROLS			51	/**< actuator control groups, one after the other, 8 wide */
 #define PX4IO_P_CONTROLS_GROUP_0		(PX4IO_PROTOCOL_MAX_CONTROL_COUNT * 0)	/**< 0..PX4IO_PROTOCOL_MAX_CONTROL_COUNT - 1 */

--- a/src/modules/px4iofirmware/px4io.c
+++ b/src/modules/px4iofirmware/px4io.c
@@ -69,6 +69,8 @@ static struct hrt_call serial_dma_call;
 
 pwm_limit_t pwm_limit;
 
+float dt;
+
 /*
  * a set of debug buffers to allow us to send debug information from ISRs
  */
@@ -347,8 +349,18 @@ user_start(int argc, char *argv[])
 
 	uint64_t last_debug_time = 0;
 	uint64_t last_heartbeat_time = 0;
+	uint64_t last_loop_time = 0;
 
 	for (;;) {
+		dt = (hrt_absolute_time() - last_loop_time) / 1000000.0f;
+		last_loop_time = hrt_absolute_time();
+
+		if (dt < 0.0001f) {
+			dt = 0.0001f;
+
+		} else if (dt > 0.02f) {
+			dt = 0.02f;
+		}
 
 		/* track the rate at which the loop is running */
 		perf_count(loop_perf);

--- a/src/modules/px4iofirmware/px4io.h
+++ b/src/modules/px4iofirmware/px4io.h
@@ -126,6 +126,7 @@ extern uint16_t			r_page_servo_disarmed[];	/* PX4IO_PAGE_DISARMED_PWM */
 #define r_setup_scale_pitch	r_page_setup[PX4IO_P_SETUP_SCALE_PITCH]
 #define r_setup_scale_yaw	r_page_setup[PX4IO_P_SETUP_SCALE_YAW]
 #define r_setup_sbus_rate	r_page_setup[PX4IO_P_SETUP_SBUS_RATE]
+#define r_setup_slew_max	r_page_setup[PX4IO_P_SETUP_MOTOR_SLEW_MAX]
 
 #define r_control_values	(&r_page_controls[0])
 
@@ -145,6 +146,7 @@ struct sys_state_s {
 };
 
 extern struct sys_state_s system_state;
+extern float dt;
 
 /*
  * PWM limit structure

--- a/src/modules/px4iofirmware/registers.c
+++ b/src/modules/px4iofirmware/registers.c
@@ -180,7 +180,8 @@ volatile uint16_t	r_page_setup[] = {
 	[PX4IO_P_SETUP_TRIM_YAW] = 0,
 	[PX4IO_P_SETUP_SCALE_ROLL] = 10000,
 	[PX4IO_P_SETUP_SCALE_PITCH] = 10000,
-	[PX4IO_P_SETUP_SCALE_YAW] = 10000
+	[PX4IO_P_SETUP_SCALE_YAW] = 10000,
+	[PX4IO_P_SETUP_MOTOR_SLEW_MAX] = 0
 };
 
 #ifdef CONFIG_ARCH_BOARD_PX4IO_V2
@@ -685,6 +686,8 @@ registers_set_one(uint8_t page, uint8_t offset, uint16_t value)
 		case PX4IO_P_SETUP_SCALE_ROLL:
 		case PX4IO_P_SETUP_SCALE_PITCH:
 		case PX4IO_P_SETUP_SCALE_YAW:
+		case PX4IO_P_SETUP_MOTOR_SLEW_MAX:
+
 			r_page_setup[offset] = value;
 			break;
 

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -3198,3 +3198,18 @@ PARAM_DEFINE_INT32(PWM_AUX_MAX, 2000);
  * @group PWM Outputs
  */
 PARAM_DEFINE_INT32(PWM_AUX_DISARMED, 1000);
+
+/**
+ * Minimum motor rise time (slew rate limit).
+ *
+ * Minimum time allowed for the motor input signal to pass through
+ * a range of 1000 PWM units. A value x means that the motor signal
+ * can only go from 1000 to 2000 PWM in maximum x seconds.
+ *
+ * Zero means that slew rate limiting is disabled.
+ *
+ * @min 0.0
+ * @unit s/(1000*PWM)
+ * @group PWM Outputs
+ */
+PARAM_DEFINE_FLOAT(MOT_SLEW_MAX, 0.0f);

--- a/src/modules/systemlib/mixer/mixer.h
+++ b/src/modules/systemlib/mixer/mixer.h
@@ -187,10 +187,14 @@ public:
 	/**
 	 * @brief      Update slew rate parameter. This tells the multicopter mixer
 	 *             the maximum allowed change of the output values per cycle.
+	 *             The value is only valid for one cycle, in order to have continuous
+	 *             slew rate limiting this function needs to be called before every call
+	 *             to mix().
 	 *
-	 * @param[in]  slew_rate_max  The maximum slew rate.
+	 * @param[in]  delta_out_max  Maximum delta output.
+	 *
 	 */
-	virtual void 			update_slew_rate(float slew_rate_max) {};
+	virtual void 			set_max_delta_out_once(float delta_out_max) {};
 
 
 protected:
@@ -324,10 +328,14 @@ public:
 	/**
 	 * @brief      Update slew rate parameter. This tells the multicopter mixer
 	 *             the maximum allowed change of the output values per cycle.
+	 *             The value is only valid for one cycle, in order to have continuous
+	 *             slew rate limiting this function needs to be called before every call
+	 *             to mix().
 	 *
-	 * @param[in]  slew_rate_max  The maximum slew rate.
+	 * @param[in]  delta_out_max  Maximum delta output.
+	 *
 	 */
-	virtual void 			update_slew_rate(float slew_rate_max);
+	virtual void 			set_max_delta_out_once(float delta_out_max);
 
 private:
 	Mixer				*_first;	/**< linked list of mixers */
@@ -538,10 +546,14 @@ public:
 	/**
 	 * @brief      Update slew rate parameter. This tells the multicopter mixer
 	 *             the maximum allowed change of the output values per cycle.
+	 *             The value is only valid for one cycle, in order to have continuous
+	 *             slew rate limiting this function needs to be called before every call
+	 *             to mix().
 	 *
-	 * @param[in]  slew_rate_max  The maximum slew rate.
+	 * @param[in]  delta_out_max  Maximum delta output.
+	 *
 	 */
-	virtual void		update_slew_rate(float slew_rate_max) {_slew_rate_max = slew_rate_max;}
+	virtual void 			set_max_delta_out_once(float delta_out_max) {_delta_out_max = delta_out_max;}
 
 private:
 	float				_roll_scale;
@@ -549,7 +561,7 @@ private:
 	float				_yaw_scale;
 	float				_idle_speed;
 
-	float 				_slew_rate_max;
+	float 				_delta_out_max;
 
 	orb_advert_t			_limits_pub;
 	multirotor_motor_limits_s 	_limits;

--- a/src/modules/systemlib/mixer/mixer.h
+++ b/src/modules/systemlib/mixer/mixer.h
@@ -184,6 +184,15 @@ public:
 	 */
 	virtual void			groups_required(uint32_t &groups) = 0;
 
+	/**
+	 * @brief      Update slew rate parameter. This tells the multicopter mixer
+	 *             the maximum allowed change of the output values per cycle.
+	 *
+	 * @param[in]  slew_rate_max  The maximum slew rate.
+	 */
+	virtual void 			update_slew_rate(float slew_rate_max) {};
+
+
 protected:
 	/** client-supplied callback used when fetching control values */
 	ControlCallback			_control_cb;
@@ -311,6 +320,14 @@ public:
 	 * @return			Zero on successful load, nonzero otherwise.
 	 */
 	int				load_from_buf(const char *buf, unsigned &buflen);
+
+	/**
+	 * @brief      Update slew rate parameter. This tells the multicopter mixer
+	 *             the maximum allowed change of the output values per cycle.
+	 *
+	 * @param[in]  slew_rate_max  The maximum slew rate.
+	 */
+	virtual void 			update_slew_rate(float slew_rate_max);
 
 private:
 	Mixer				*_first;	/**< linked list of mixers */
@@ -518,17 +535,29 @@ public:
 	virtual unsigned		mix(float *outputs, unsigned space, uint16_t *status_reg);
 	virtual void			groups_required(uint32_t &groups);
 
+	/**
+	 * @brief      Update slew rate parameter. This tells the multicopter mixer
+	 *             the maximum allowed change of the output values per cycle.
+	 *
+	 * @param[in]  slew_rate_max  The maximum slew rate.
+	 */
+	virtual void		update_slew_rate(float slew_rate_max) {_slew_rate_max = slew_rate_max;}
+
 private:
 	float				_roll_scale;
 	float				_pitch_scale;
 	float				_yaw_scale;
 	float				_idle_speed;
 
+	float 				_slew_rate_max;
+
 	orb_advert_t			_limits_pub;
 	multirotor_motor_limits_s 	_limits;
 
 	unsigned			_rotor_count;
 	const Rotor			*_rotors;
+
+	float 				*_outputs_prev = nullptr;
 
 	/* do not allow to copy due to ptr data members */
 	MultirotorMixer(const MultirotorMixer &);

--- a/src/modules/systemlib/mixer/mixer.h
+++ b/src/modules/systemlib/mixer/mixer.h
@@ -185,11 +185,7 @@ public:
 	virtual void			groups_required(uint32_t &groups) = 0;
 
 	/**
-	 * @brief      Update slew rate parameter. This tells the multicopter mixer
-	 *             the maximum allowed change of the output values per cycle.
-	 *             The value is only valid for one cycle, in order to have continuous
-	 *             slew rate limiting this function needs to be called before every call
-	 *             to mix().
+	 * @brief      Empty method, only implemented for MultirotorMixer and MixerGroup class.
 	 *
 	 * @param[in]  delta_out_max  Maximum delta output.
 	 *
@@ -326,7 +322,7 @@ public:
 	int				load_from_buf(const char *buf, unsigned &buflen);
 
 	/**
-	 * @brief      Update slew rate parameter. This tells the multicopter mixer
+	 * @brief      Update slew rate parameter. This tells instances of the class MultirotorMixer
 	 *             the maximum allowed change of the output values per cycle.
 	 *             The value is only valid for one cycle, in order to have continuous
 	 *             slew rate limiting this function needs to be called before every call

--- a/src/modules/systemlib/mixer/mixer_group.cpp
+++ b/src/modules/systemlib/mixer/mixer_group.cpp
@@ -200,3 +200,13 @@ MixerGroup::load_from_buf(const char *buf, unsigned &buflen)
 	/* nothing more in the buffer for us now */
 	return ret;
 }
+
+void MixerGroup::update_slew_rate(float slew_rate_max)
+{
+	Mixer	*mixer = _first;
+
+	while (mixer != nullptr) {
+		mixer->update_slew_rate(slew_rate_max);
+		mixer = mixer->_next;
+	}
+}

--- a/src/modules/systemlib/mixer/mixer_group.cpp
+++ b/src/modules/systemlib/mixer/mixer_group.cpp
@@ -201,12 +201,12 @@ MixerGroup::load_from_buf(const char *buf, unsigned &buflen)
 	return ret;
 }
 
-void MixerGroup::update_slew_rate(float slew_rate_max)
+void MixerGroup::set_max_delta_out_once(float delta_out_max)
 {
 	Mixer	*mixer = _first;
 
 	while (mixer != nullptr) {
-		mixer->update_slew_rate(slew_rate_max);
+		mixer->set_max_delta_out_once(delta_out_max);
 		mixer = mixer->_next;
 	}
 }

--- a/src/modules/systemlib/mixer/mixer_multirotor.cpp
+++ b/src/modules/systemlib/mixer/mixer_multirotor.cpp
@@ -102,7 +102,7 @@ MultirotorMixer::MultirotorMixer(ControlCallback control_cb,
 MultirotorMixer::~MultirotorMixer()
 {
 	if (_outputs_prev != nullptr) {
-		delete _outputs_prev;
+		delete[] _outputs_prev;
 	}
 }
 

--- a/src/modules/systemlib/mixer/mixer_multirotor.cpp
+++ b/src/modules/systemlib/mixer/mixer_multirotor.cpp
@@ -90,7 +90,7 @@ MultirotorMixer::MultirotorMixer(ControlCallback control_cb,
 	_pitch_scale(pitch_scale),
 	_yaw_scale(yaw_scale),
 	_idle_speed(-1.0f + idle_speed * 2.0f),	/* shift to output range here to avoid runtime calculation */
-	_slew_rate_max(0.0f),
+	_delta_out_max(0.0f),
 	_limits_pub(),
 	_rotor_count(_config_rotor_count[(MultirotorGeometryUnderlyingType)geometry]),
 	_rotors(_config_index[(MultirotorGeometryUnderlyingType)geometry]),
@@ -375,14 +375,14 @@ MultirotorMixer::mix(float *outputs, unsigned space, uint16_t *status_reg)
 		outputs[i] = constrain(_idle_speed + (outputs[i] * (1.0f - _idle_speed)), _idle_speed, 1.0f);
 
 		// slew rate limiting
-		if (_slew_rate_max > 0.0f) {
+		if (_delta_out_max > 0.0f) {
 			float delta_out = outputs[i] - _outputs_prev[i];
 
-			if (delta_out > _slew_rate_max) {
-				outputs[i] = _outputs_prev[i] + _slew_rate_max;
+			if (delta_out > _delta_out_max) {
+				outputs[i] = _outputs_prev[i] + _delta_out_max;
 
-			} else if (delta_out < -_slew_rate_max) {
-				outputs[i] = _outputs_prev[i] - _slew_rate_max;
+			} else if (delta_out < -_delta_out_max) {
+				outputs[i] = _outputs_prev[i] - _delta_out_max;
 			}
 		}
 
@@ -391,7 +391,7 @@ MultirotorMixer::mix(float *outputs, unsigned space, uint16_t *status_reg)
 	}
 
 	// this will force the caller of the mixer to always supply new slew rate values, otherwise no slew rate limiting will happen
-	_slew_rate_max = 0.0f;
+	_delta_out_max = 0.0f;
 
 	return _rotor_count;
 }

--- a/src/modules/systemlib/mixer/mixer_multirotor.cpp
+++ b/src/modules/systemlib/mixer/mixer_multirotor.cpp
@@ -51,6 +51,7 @@
 #include <math.h>
 
 #include <px4iofirmware/protocol.h>
+#include <drivers/drv_pwm_output.h>
 
 #include "mixer.h"
 
@@ -366,6 +367,7 @@ MultirotorMixer::mix(float *outputs, unsigned space, uint16_t *status_reg)
 			     thrust + boost;
 
 		outputs[i] = constrain(_idle_speed + (outputs[i] * (1.0f - _idle_speed)), _idle_speed, 1.0f);
+
 	}
 
 	return _rotor_count;


### PR DESCRIPTION
@LorenzMeier @julianoes @jgoppert @dagar 
I've implemented simple slew rate limiting of the motor outputs. We've tested the branch on the TBS Discovery and even after upping the attitude gains very much we were not able to make a motor lose sync (happens very quickly without the slew rate limiting). Furthermore, for a decent tuning the pilot was not able to differentiate between no slew rate limiting and slew rate limiting by the attitude control performance and also the two logs show no visible difference. 

Now I would like to sync up on how to integrate this into the firmware.
The main question is where in the code the slew rate limiting should be happening and here are the options:

1) Inside multirotor mixer
2) Inside px4iofirmware / fmu driver

Putting it into the multirotor mixer is easy in one way because there we know the number of outputs for which we have to apply the limiting. However, we have to provide the mixer with the loop time (delta t) and also with the mapping between outputs between in the range [-1,1] and effective pwm outputs. 
Having the slew rate limiting happening outside of the mixer (e.g after the mixer call here https://github.com/PX4/Firmware/blob/master/src/modules/px4iofirmware/mixer.cpp#L239) would bring the advantage that it could be applied to any output. However, this means that we would probably need to implement an IOCTL option for this, which specifies which outputs of the device should be slew rate limited.
What are your thoughts on this?