### PR TITLE
RC st24: change channel input range

### DIFF
--- a/src/lib/rc/st24.c
+++ b/src/lib/rc/st24.c
@@ -61,8 +61,8 @@ const char *decode_states[] = {"UNSYNCED",
 			      };
 
 /* define range mapping here, -+100% -> 1000..2000 */
-#define ST24_RANGE_MIN 0.0f
-#define ST24_RANGE_MAX 4096.0f
+#define ST24_RANGE_MIN 500.0f
+#define ST24_RANGE_MAX 3500.0f
 
 #define ST24_TARGET_MIN 1000.0f
 #define ST24_TARGET_MAX 2000.0f


### PR DESCRIPTION
QGC failed to calibrate RC with the old range.

@LorenzMeier fyi