### PR TITLE
Wip USB serial issue on MAC

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -864,7 +864,7 @@ Mavlink::get_free_tx_buf()
 	} else {
 		// No FIONWRITE on Linux
 #if !defined(__PX4_LINUX) && !defined(__PX4_DARWIN)
-		(void) ioctl(_uart_fd, FIONWRITE, (unsigned long)&buf_free);
+		(void) ioctl(_uart_fd, FIONSPACE, (unsigned long)&buf_free);
 #else
         //Linux cp210x does not support TIOCOUTQ
         buf_free = 256;


### PR DESCRIPTION
@LorenzMeier, 

Nuttx Submodule is pointing to backport of all the serial and CDCACM fixes from upstream.

This is a starting point for testing the USB issue on the MAC. Would you please test it on your machines.
