### PR TITLE
Allow sending a param with a different component ID

### DIFF
--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -397,7 +397,7 @@ MavlinkParametersManager::send(const hrt_abstime t)
 }
 
 int
-MavlinkParametersManager::send_param(param_t param)
+MavlinkParametersManager::send_param(param_t param, int component_id)
 {
 	if (param == PARAM_INVALID) {
 		return 1;
@@ -436,7 +436,17 @@ MavlinkParametersManager::send_param(param_t param)
 		msg.param_type = MAVLINK_TYPE_FLOAT;
 	}
 
-	mavlink_msg_param_value_send_struct(_mavlink->get_channel(), &msg);
+	/* default component ID */
+	if (component_id < 0) {
+		mavlink_msg_param_value_send_struct(_mavlink->get_channel(), &msg);
+
+	} else {
+
+		// Re-pack the message with a different component ID
+		mavlink_message_t mavlink_packet;
+		mavlink_msg_param_value_encode_chan(mavlink_system.sysid, component_id, _mavlink->get_channel(), &mavlink_packet, &msg);
+		_mavlink_resend_uart(_mavlink->get_channel(), &mavlink_packet);
+	}
 
 	return 0;
 }

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -339,7 +339,10 @@ MavlinkParametersManager::send(const hrt_abstime t)
 			msg.param_type = MAVLINK_TYPE_INT32_T;
 		}
 
-		mavlink_msg_param_value_send_struct(_mavlink->get_channel(), &msg);
+		// Re-pack the message with the UAVCAN node ID
+		mavlink_message_t mavlink_packet;
+		mavlink_msg_param_value_encode_chan(mavlink_system.sysid, value.node_id, _mavlink->get_channel(), &mavlink_packet, &msg);
+		_mavlink_resend_uart(_mavlink->get_channel(), &mavlink_packet);
 
 	} else if (_send_all_index >= 0 && _mavlink->boot_complete()) {
 		/* send all parameters if requested, but only after the system has booted */

--- a/src/modules/mavlink/mavlink_parameters.h
+++ b/src/modules/mavlink/mavlink_parameters.h
@@ -90,7 +90,7 @@ protected:
 
 	void send(const hrt_abstime t);
 
-	int send_param(param_t param);
+	int send_param(param_t param, int component_id=-1);
 
 	orb_advert_t _rc_param_map_pub;
 	struct rc_parameter_map_s _rc_param_map;


### PR DESCRIPTION
@mhkabir @pavel-kirienko This allows to send a param with a different component ID. I already did what I think is required for UAVCAN (in the 2nd commit). Please compare and let me know.

@DonLakeFlyer If its not already the case: I would advise to allow component params without receiving a component heartbeat first. Essentially instantiate the component as soon as you see a PARAM_VALUE message with the same system ID but different component ID.
