### PR TITLE
Proposal to check code style a bit earlier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ env:
 script:
   - ccache -M 1GB; ccache -z
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
-      docker run --rm -v `pwd`:`pwd`:rw -v $HOME/.ccache:$HOME/.ccache:rw -e CCACHE_DIR=$HOME/.ccache -e GIT_SUBMODULES_ARE_EVIL=1 -w=`pwd` --user=$UID -it ${DOCKER_REPO} /bin/bash -c "make check_qgc_firmware VECTORCONTROL=1";
+      docker run --rm -v `pwd`:`pwd`:rw -v $HOME/.ccache:$HOME/.ccache:rw -e CCACHE_DIR=$HOME/.ccache -e CI=true -e GIT_SUBMODULES_ARE_EVIL=1 -w=`pwd` --user=$UID -it ${DOCKER_REPO} /bin/bash -c "make check_qgc_firmware VECTORCONTROL=1";
     elif [ "${TRAVIS_OS_NAME}" = "osx" ]; then
       make tests;
     fi

--- a/Makefile
+++ b/Makefile
@@ -283,12 +283,10 @@ quick_check: check_px4fmu-v2_default check_px4fmu-v4_default check_posix_sitl_de
 
 check_format:
 	$(call colorecho,"Checking formatting with astyle")
-	@./Tools/fix_code_style.sh
 	@./Tools/check_code_style_all.sh
 
 format:
 	$(call colorecho,"Formatting with astyle")
-	@./Tools/fix_code_style.sh
 	@./Tools/check_code_style_all.sh --fix
 
 check_%:

--- a/Tools/check_code_style.sh
+++ b/Tools/check_code_style.sh
@@ -1,29 +1,23 @@
 #!/usr/bin/env bash
 
-file=$1
-
+FILE=$1
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-if [ -f "$file" ];
-then
-	${DIR}/fix_code_style.sh --dry-run $file | grep --quiet Formatted
-	if [[ $? -eq 0 ]]
-	then
-		${DIR}/fix_code_style.sh --quiet < $file > $file.pretty
+if [ -f "$FILE" ]; then
+	${DIR}/fix_code_style.sh --dry-run $FILE | grep --quiet Formatted
+	if [[ $? -eq 0 ]]; then
+		${DIR}/fix_code_style.sh --quiet < $FILE > $FILE.pretty
 
 		echo
-		git --no-pager diff --no-index --minimal --histogram --color=always  $file $file.pretty
+		git --no-pager diff --no-index --minimal --histogram --color=always $FILE $FILE.pretty
+		rm -f $FILE.pretty
 		echo
 
-		rm -f $file.pretty
-
-		if [[ $PX4_ASTYLE_FIX -eq 1 ]]
-		then
-			${DIR}/fix_code_style.sh $file
+		if [[ $PX4_ASTYLE_FIX -eq 1 ]]; then
+			${DIR}/fix_code_style.sh $FILE
 		else
-			echo $file 'bad formatting, please run "./Tools/fix_code_style.sh' $file'"'
+			echo $FILE 'bad formatting, please run "make format" or "./Tools/fix_code_style.sh' $FILE'"'
 			exit 1
 		fi
 	fi
 fi
-

--- a/Tools/check_code_style_all.sh
+++ b/Tools/check_code_style_all.sh
@@ -1,35 +1,55 @@
 #!/usr/bin/env bash
 set -eu
 
+ASTYLE_VER_REQUIRED="Artistic Style Version 2.05.1"
+astyle_ver() {
+	echo "PX4 requires ${ASTYLE_VER_REQUIRED}"
+	echo "You can get the correct version here: https://github.com/PX4/astyle/releases/tag/2.05.1"
+}
+
+# check if astyle is installed
+condition=$(which astyle 2>/dev/null | grep -v "not found" | wc -l)
+if [ $condition -eq 0 ]; then
+	echo "astyle is not installed"
+	astyle_ver
+	exit 1
+else
+	ASTYLE_VER=`astyle --version`
+
+	if [ "$ASTYLE_VER" != "$ASTYLE_VER_REQUIRED" ]; then
+		echo "Error: you're using ${ASTYLE_VER}"
+		astyle_ver
+		exit 1
+	fi
+fi
+
+CI="${CI:-false}"
+DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+
 if [[ "$@" == "--fix" ]]
 then
     export PX4_ASTYLE_FIX=1
 fi
 
-DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-find src \
-    -path src/lib/DriverFramework -prune -o \
-    -path src/lib/ecl -prune -o \
-    -path src/lib/external_lgpl -prune -o \
-    -path src/lib/mathlib -prune -o \
-    -path src/lib/matrix -prune -o \
-    -path src/modules/attitude_estimator_ekf -prune -o \
-    -path src/modules/commander -prune -o \
-    -path src/examples/ekf_att_pos_estimator -prune -o \
-    -path src/examples/attitude_estimator_ekf -prune -o \
-    -path src/modules/navigator -prune -o \
-    -path src/modules/sdlog2 -prune -o \
-    -path src/modules/uavcan -prune -o \
-    -path src/modules/uavcan/libuavcan -prune -o \
-    -type f \( -name "*.c" -o -name "*.h" -o -name "*.cpp" -o -name "*.hpp" \) \
-    -not -name '*generated.h' \
-    -not -name '*uthash.h' \
-    -not -name '*utstring.h' \
-    -not -name '*utlist.h' \
-    -not -name '*utarray.h' \
-    -print0 | xargs -0 -n 1 -P 8 -I % ${DIR}/check_code_style.sh %
+# install git pre-commit hook
+HOOK_FILE="$DIR/../.git/hooks/pre-commit"
+if [ ! -f $HOOK_FILE ] && [ "$CI" != "true" ]; then
+	echo ""
+	echo -e "\033[31mNinja tip: add a git pre-commit hook to automatically check code style\033[0m"
+	echo -e "Would you like to install one now? (\033[94mcp ./Tools/pre-commit .git/hooks/pre-commit\033[0m): [y/\033[1mN\033[0m]"
 
+	read user_cmd
+	if [ "$user_cmd" == "y" ]; then
+		echo -e "copying ./Tools/pre-commit -> .git/hooks/pre-commit"
+		cp $DIR/pre-commit $HOOK_FILE
+		echo -e "\033[94mGreat, hook installed!\033[0m (checking style now)"
+	else
+		echo -e "\033[94mOk, I will remind you again later!\033[0m (checking style now)"
+	fi
+fi
+
+${DIR}/files_to_check_code_style.sh | xargs -n 1 -P 8 -I % ${DIR}/check_code_style.sh %
 
 if [ $? -eq 0 ]; then
     echo "Format checks passed"

--- a/Tools/files_to_check_code_style.sh
+++ b/Tools/files_to_check_code_style.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -eu
+
+PATTERN="-e ."
+
+if [ $# -gt 0 ]
+then
+    PATTERN="$1"
+fi
+
+exec find src \
+    -path src/examples/attitude_estimator_ekf -prune -o \
+    -path src/examples/ekf_att_pos_estimator -prune -o \
+    -path src/lib/DriverFramework -prune -o \
+    -path src/lib/ecl -prune -o \
+    -path src/lib/external_lgpl -prune -o \
+    -path src/lib/mathlib -prune -o \
+    -path src/lib/matrix -prune -o \
+    -path src/modules/attitude_estimator_ekf -prune -o \
+    -path src/modules/commander -prune -o \
+    -path src/modules/mavlink -prune -o \
+    -path src/modules/navigator -prune -o \
+    -path src/modules/sdlog2 -prune -o \
+    -path src/modules/systemlib/uthash -prune -o \
+    -path src/modules/uavcan -prune -o \
+    -path src/modules/uavcan/libuavcan -prune -o \
+    -type f \( -name "*.c" -o -name "*.h" -o -name "*.cpp" -o -name "*.hpp" \) | grep $PATTERN
+

--- a/Tools/fix_code_style.sh
+++ b/Tools/fix_code_style.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-ASTYLE_VER=`astyle --version`
-ASTYLE_VER_REQUIRED="Artistic Style Version 2.05.1"
-
-if [ "$ASTYLE_VER" != "$ASTYLE_VER_REQUIRED" ]; then
-  echo "Error: you're using ${ASTYLE_VER}, but PX4 requires ${ASTYLE_VER_REQUIRED}"
-  echo "You can get the correct version here: https://github.com/PX4/astyle/releases/tag/2.05.1"
-  exit 1
-fi
-
 if [[ $# -eq 0 ]] ; then
   exit 0
 fi

--- a/Tools/pre-commit
+++ b/Tools/pre-commit
@@ -1,26 +1,64 @@
 #!/bin/sh
+#
+# An example hook script to verify what is about to be committed.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#
+# To enable this hook, rename this file to "pre-commit".
+
 if git rev-parse --verify HEAD >/dev/null 2>&1
 then
-  against=HEAD
+	against=HEAD
 else
-  # Initial commit: diff against an empty tree object
-  against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+	# Initial commit: diff against an empty tree object
+	against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
 fi
+
+# If you want to allow non-ascii filenames set this variable to true.
+allownonascii=$(git config hooks.allownonascii)
 
 # Redirect output to stderr.
 exec 1>&2
 
-CHANGED_FILES=`git diff --cached --name-only --diff-filter=ACM $against | grep '\.c\|\.cpp\|\.h\|\.hpp'`
-FAILED=0
-if [ ! -z "$CHANGED_FILES" -a "$CHANGED_FILES" != " " ]; then
-  for FILE in $CHANGED_FILES; do
-    ./Tools/fix_code_style.sh --quiet < $FILE > $FILE.pretty
-    diff -u $FILE $FILE.pretty || FAILED=1
-    rm -f $FILE.pretty
-    if [ $FAILED -ne 0 ]; then
-      echo "There are code formatting errors. Please fix them by running ./Tools/fix_code_style.sh $FILE"
-      exit $FAILED
-    fi
-  done
+# Cross platform projects tend to avoid non-ascii filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+	# Note that the use of brackets around a tr range is ok here, (it's
+	# even required, for portability to Solaris 10's /usr/bin/tr), since
+	# the square bracket bytes happen to fall in the designated range.
+	test $(git diff --cached --name-only --diff-filter=A -z $against |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+	echo "Error: Attempt to add a non-ascii file name."
+	echo
+	echo "This can cause problems if you want to work"
+	echo "with people on other platforms."
+	echo
+	echo "To be portable it is advisable to rename the file ..."
+	echo
+	echo "If you know what you are doing you can disable this"
+	echo "check using:"
+	echo
+	echo "  git config hooks.allownonascii true"
+	echo
+	exit 1
 fi
-exit 0
+
+# If there are whitespace errors, print the offending file names and fail.
+git diff-index --check --cached $against --
+if [ $? -ne 0 ]
+then
+        exit 1
+fi
+
+# Check for code style, only in changed files
+for i in `git diff --cached --name-only --diff-filter=ACM`
+do
+        ./Tools/files_to_check_code_style.sh $i | xargs -n 1 -P 8 -I % ./Tools/check_code_style.sh %
+        if [ $? -ne 0 ]
+        then
+                exit 1
+        fi
+done

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ dependencies:
 
 test:
   override:
-    - docker run --rm -v `pwd`:`pwd`:rw -w=`pwd` --user=$UID -it px4io/px4-dev-nuttx-gcc4.9 /bin/bash -c "make quick_check"
+    - docker run --rm -v `pwd`:`pwd`:rw -e CI=true -w=`pwd` --user=$UID -it px4io/px4-dev-nuttx-gcc4.9 /bin/bash -c "make quick_check"
 
 general:
   artifacts:


### PR DESCRIPTION
I've separated the list of included modules to check code style so everyone can include it in their git pre-commit hook and run it for changed files only before the commit. This should get rid of these unnecessary "code style" commits at the end of a pull request.

Had to remove `-print0` from find, which should be fine as long as we don't have spaces in the paths.. Maybe a linux guru can suggest a way to keep `-print0` (and test this :)).

Once this is good I can followup with a quick doc in the devguide.

How-to, in your repositories:
```
mv .git/hooks/pre-commit.sample .git/hooks/pre-commit
chmod 755 .git/hooks/pre-commit
```

Then edit `.git/hooks/pre-commit` and replace the white-space check (yes, it also does that 👍 ) at the end to:
```
# If there are whitespace errors, print the offending file names and fail.
git diff-index --check --cached $against --
if [ $? -ne 0 ]
then
        exit 1
fi

# Check for code style, only in changed files
for i in `git diff --cached --name-only --diff-filter=ACM`
do
        ./Tools/files_to_check_code_style.sh $i | xargs -n 1 -P 8 -I % ./Tools/check_code_style.sh %
        if [ $? -ne 0 ]
        then
                exit 1
        fi
done
```

(see my complete pre-commit file: https://gist.github.com/AndreasAntener/0f9cc67cd4d4eb321f935297d9c268bd)