### PR TITLE
Makefile add additional_targets for testing

### DIFF
--- a/additional_targets.mk
+++ b/additional_targets.mk
@@ -1,0 +1,6 @@
+
+# For build testing convenience place additional targets here.
+#  additional_targets is currently built in the "px4-dev-base: check" job on https://semaphoreci.com/px4/firmware
+
+additional_targets: \
+		


### PR DESCRIPTION
-closes #5298 

@davids5 is this what you had in mind? Personally I'd find it just as easy to do it within the Makefile, but I haven't experienced your merge pain.

**check**: the build everything we care about target, although doesn't contain snappy, and anything else with a complex environment. Can now be extended with additional_targets.mk. Builds on semaphore-ci
**qgc_firmware**: the set of firmware uploaded for QGC. Builds on travis-ci
**quick_check**: Easy way to check the main stuff for developers. Builds 1 nuttx, posix, test, and check formatting. I use this locally all the time.