### PR TITLE
sitl_run.sh: use ps instead of jps

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -44,7 +44,7 @@ fi
 # be running from last time
 pkill gazebo
 pkill px4
-jmavsim_pid=`jps | grep Simulator | cut -d" " -f1`
+jmavsim_pid=`ps aux | grep java | grep Simulator | cut -d" " -f1`
 if [ -n "$jmavsim_pid" ]
 then
 	kill $jmavsim_pid


### PR DESCRIPTION
The tool jps does not seem to be available on macos Java.