### PR TITLE
remove "transitional support" for PMW_MIN and MAX

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.mc_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_defaults
@@ -34,15 +34,6 @@ set PWM_AUX_DISARMED 1500
 set PWM_AUX_MIN 1000
 set PWM_AUX_MAX 2000
 
-# Transitional support: ensure suitable PWM min/max param values
-if param compare PWM_MIN 1000
-then
-	param set PWM_MIN 1075
-fi
-if param compare PWM_MAX 2000
-then
-	param set PWM_MAX 1950
-fi
 if param compare PWM_DISARMED 0
 then
 	param set PWM_DISARMED 900

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -34,15 +34,6 @@ set PWM_DISARMED p:PWM_DISARMED
 set PWM_MIN p:PWM_MIN
 set PWM_MAX p:PWM_MAX
 
-# Transitional support: ensure suitable PWM min/max param values
-if param compare PWM_MIN 1000
-then
-	param set PWM_MIN 1075
-fi
-if param compare PWM_MAX 2000
-then
-	param set PWM_MAX 1950
-fi
 if param compare PWM_DISARMED 0
 then
 	param set PWM_DISARMED 900


### PR DESCRIPTION
this feature silently prevents a user from setting a parameter to a "magic" number