### PR TITLE
WIP: Add baro bias state to LPE

### DIFF
--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -86,6 +86,7 @@ BlockLocalPositionEstimator::BlockLocalPositionEstimator() :
 	_pn_p_noise_density(this, "PN_P"),
 	_pn_v_noise_density(this, "PN_V"),
 	_pn_b_noise_density(this, "PN_B"),
+	_pn_bb_noise_density(this, "PN_BB"),
 	_pn_t_noise_density(this, "PN_T"),
 	_t_max_grade(this, "T_MAX_GRADE"),
 
@@ -773,6 +774,7 @@ void BlockLocalPositionEstimator::initP()
 	_P(X_by, X_by) = 1e-6;
 	_P(X_bz, X_bz) = 1e-6;
 	_P(X_tz, X_tz) = 2 * EST_STDDEV_TZ_VALID;
+	_P(X_bb, X_bb) = 1e-6;
 }
 
 void BlockLocalPositionEstimator::initSS()
@@ -848,6 +850,8 @@ void BlockLocalPositionEstimator::updateSSParams()
 		(_t_max_grade.get() / 100.0f) * sqrtf(_x(X_vx) * _x(X_vx) + _x(X_vy) * _x(X_vy));
 	_Q(X_tz, X_tz) = pn_t_noise_density * pn_t_noise_density;
 
+	// baro random walk noise
+	_Q(X_bb, X_bb) = _pn_bb_noise_density.get() * _pn_bb_noise_density.get();
 }
 
 void BlockLocalPositionEstimator::predict()

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -102,6 +102,7 @@ class BlockLocalPositionEstimator : public control::SuperBlock
 // 	vx, vy, vz ( vel NED, m/s),
 // 	bx, by, bz ( accel bias, m/s^2)
 // 	tz (terrain altitude, ASL, m)
+// 	bb (baro bias, m)
 //
 // measurements:
 //
@@ -122,7 +123,7 @@ class BlockLocalPositionEstimator : public control::SuperBlock
 public:
 
 	// constants
-	enum {X_x = 0, X_y, X_z, X_vx, X_vy, X_vz, X_bx, X_by, X_bz, X_tz, n_x};
+	enum {X_x = 0, X_y, X_z, X_vx, X_vy, X_vz, X_bx, X_by, X_bz, X_tz, X_bb, n_x};
 	enum {U_ax = 0, U_ay, U_az, n_u};
 	enum {Y_baro_z = 0, n_y_baro};
 	enum {Y_lidar_z = 0, n_y_lidar};
@@ -292,6 +293,7 @@ private:
 	BlockParamFloat  _pn_p_noise_density;
 	BlockParamFloat  _pn_v_noise_density;
 	BlockParamFloat  _pn_b_noise_density;
+	BlockParamFloat  _pn_bb_noise_density;
 	BlockParamFloat  _pn_t_noise_density;
 	BlockParamFloat  _t_max_grade;
 

--- a/src/modules/local_position_estimator/params.c
+++ b/src/modules/local_position_estimator/params.c
@@ -297,6 +297,17 @@ PARAM_DEFINE_FLOAT(LPE_PN_V, 0.1f);
 PARAM_DEFINE_FLOAT(LPE_PN_B, 1e-3f);
 
 /**
+ * Barometric pressure bias propgation noise density
+ *
+ * @group Local Position Estimator
+ * @unit (m)/s/sqrt(hz)
+ * @min 0.01
+ * @max 0.5
+ * @decimal 2
+ */
+PARAM_DEFINE_FLOAT(LPE_PN_BB, 0.1f);
+
+/**
  * Terrain random walk noise density, hilly/outdoor (0.1), flat/Indoor (0.001)
  *
  * @group Local Position Estimator

--- a/src/modules/local_position_estimator/sensors/baro.cpp
+++ b/src/modules/local_position_estimator/sensors/baro.cpp
@@ -60,6 +60,7 @@ void BlockLocalPositionEstimator::baroCorrect()
 	Matrix<float, n_y_baro, n_x> C;
 	C.setZero();
 	C(Y_baro_z, X_z) = -1; // measured altitude, negative down dir.
+	C(Y_baro_z, X_bb) = 1; // baro bias
 
 	Matrix<float, n_y_baro, n_y_baro> R;
 	R.setZero();


### PR DESCRIPTION
This adds a state for baro bias random walk. This allows us to lower baro noise since the low frequency offset is a state.
