### PR TITLE
Only compile the Messages specified in msg/CMakeLists.txt

### DIFF
--- a/Tools/px_generate_uorb_topic_files.py
+++ b/Tools/px_generate_uorb_topic_files.py
@@ -47,6 +47,7 @@ import sys
 px4_tools_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(px4_tools_dir + "/genmsg/src")
 sys.path.append(px4_tools_dir + "/gencpp/src")
+px4_msg_dir = os.path.join(px4_tools_dir,"../msg")
 
 try:
         import em
@@ -78,7 +79,7 @@ __email__ = "thomasgubler@gmail.com"
 TEMPLATE_FILE = ['msg.h.template', 'msg.cpp.template']
 TOPICS_LIST_TEMPLATE_FILE = 'uORBTopics.cpp.template'
 OUTPUT_FILE_EXT = ['.h', '.cpp']
-INCL_DEFAULT = ['std_msgs:./msg/std_msgs']
+INCL_DEFAULT = ['std_msgs:./msg/std_msgs','px4:%s'%(px4_msg_dir)]
 PACKAGE = 'px4'
 TOPICS_TOKEN = '# TOPICS '
 
@@ -146,6 +147,11 @@ def generate_by_template(output_file, template_file, em_globals):
         Invokes empy intepreter to geneate output_file by the
         given template_file and predefined em_globals dict
         """
+        # check if folder exists:
+        folder_name = os.path.dirname(output_file)
+        if not os.path.exists(folder_name):
+            os.makedirs(folder_name)
+            
         ofile = open(output_file, 'w')
         # todo, reuse interpreter
         interpreter = em.Interpreter(output=ofile, globals=em_globals, options={em.RAW_OPT:True,em.BUFFERED_OPT:True})
@@ -171,7 +177,7 @@ def convert_dir(format_idx, inputdir, outputdir, templatedir):
                 if os.path.isfile(fni):
                     it = os.path.getmtime(fni)
                     if it > maxinputtime:
-                        maxinputtime = it;
+                        maxinputtime = it
 
         # Find the most recent modification time in output dir
         maxouttime = 0
@@ -181,7 +187,7 @@ def convert_dir(format_idx, inputdir, outputdir, templatedir):
                     if os.path.isfile(fni):
                         it = os.path.getmtime(fni)
                         if it > maxouttime:
-                            maxouttime = it;
+                            maxouttime = it
 
         # Do not generate if nothing changed on the input
         if (maxinputtime != 0 and maxouttime != 0 and maxinputtime < maxouttime):
@@ -257,7 +263,15 @@ def generate_topics_list_file(msgdir, outputdir, templatedir):
         tl_template_file = os.path.join(templatedir, TOPICS_LIST_TEMPLATE_FILE)
         tl_out_file = os.path.join(outputdir, TOPICS_LIST_TEMPLATE_FILE.replace(".template", ""))
         generate_by_template(tl_out_file, tl_template_file, tl_globals)
-
+        
+def generate_topics_list_file_from_files(files, outputdir, templatedir):
+        # generate cpp file with topics list
+        filenames = [os.path.basename(p) for p in files if os.path.basename(p).endswith(".msg")]
+        tl_globals = {"msgs" : filenames}
+        tl_template_file = os.path.join(templatedir, TOPICS_LIST_TEMPLATE_FILE)
+        tl_out_file = os.path.join(outputdir, TOPICS_LIST_TEMPLATE_FILE.replace(".template", ""))
+        generate_by_template(tl_out_file, tl_template_file, tl_globals)
+        
 if __name__ == "__main__":
         parser = argparse.ArgumentParser(
             description='Convert msg files to uorb headers/sources')
@@ -290,12 +304,12 @@ if __name__ == "__main__":
         else:
             print('Error: either --headers or --sources must be specified')
             exit(-1)
-
         if args.file is not None:
             for f in args.file:
-                generate_output_from_file(generate_idx, f, args.outputdir, args.templatedir, INCL_DEFAULT)
+                generate_output_from_file(generate_idx, f, args.temporarydir, args.templatedir, INCL_DEFAULT)
             if generate_idx == 1:
-                generate_topics_list_file(args.dir, args.outputdir, args.templatedir)
+                generate_topics_list_file_from_files(args.file, args.outputdir, args.templatedir)
+            copy_changed(args.temporarydir, args.outputdir, args.prefix, args.quiet)
         elif args.dir is not None:
             convert_dir_save(
                     generate_idx,

--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -386,7 +386,7 @@ function(px4_generate_messages)
 			Tools/px_generate_uorb_topic_files.py
 			--headers
 			${QUIET}
-			-d msg
+			-f ${MSG_FILES}
 			-o ${msg_out_path}
 			-e msg/templates/uorb
 			-t ${PX4_BINARY_DIR}/topics_temporary_header
@@ -407,7 +407,7 @@ function(px4_generate_messages)
 			Tools/px_generate_uorb_topic_files.py
 			--sources
 			${QUIET}
-			-d msg
+			-f ${MSG_FILES}
 			-o ${msg_source_out_path}
 			-e msg/templates/uorb
 			-t ${PX4_BINARY_DIR}/topics_temporary_sources
@@ -437,7 +437,7 @@ function(px4_generate_messages)
 			Tools/px_generate_uorb_topic_files.py
 			--headers
 			${QUIET}
-			-d msg
+			-f ${MSG_FILES}
 			-o ${msg_multi_out_path}
 			-e msg/templates/px4/uorb
 			-t ${PX4_BINARY_DIR}/multi_topics_temporary/${OS}


### PR DESCRIPTION
this lets a user select what msgs should be compiled for his project
Care must be taken though, to compile all orb_topcis that are required by the Rest of the Code.
Otherwise many compile errors will occur.

This commits adds by default the ./msg include path to reference to other msgs.
if an exisiting msg is used in another msg.