### PR TITLE
WIP: Fix FMU MC failsafe on RC loss

### DIFF
--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1045,6 +1045,10 @@ PX4FMU::cycle()
 			}
 		}
 
+	}
+
+	_cycle_timestamp = hrt_absolute_time();
+
 		/* can we mix? */
 		if (_mixers != nullptr) {
 
@@ -1132,9 +1136,6 @@ PX4FMU::cycle()
 
 			publish_pwm_outputs(pwm_limited, num_outputs);
 		}
-	}
-
-	_cycle_timestamp = hrt_absolute_time();
 
 #ifdef GPIO_BTN_SAFETY
 

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1049,93 +1049,93 @@ PX4FMU::cycle()
 
 	_cycle_timestamp = hrt_absolute_time();
 
-		/* can we mix? */
-		if (_mixers != nullptr) {
+	/* can we mix? */
+	if (_mixers != nullptr) {
 
-			size_t num_outputs;
+		size_t num_outputs;
 
-			switch (_mode) {
-			case MODE_1PWM:
-				num_outputs = 1;
-				break;
+		switch (_mode) {
+		case MODE_1PWM:
+			num_outputs = 1;
+			break;
 
-			case MODE_2PWM:
-			case MODE_2PWM2CAP:
-				num_outputs = 2;
-				break;
+		case MODE_2PWM:
+		case MODE_2PWM2CAP:
+			num_outputs = 2;
+			break;
 
-			case MODE_3PWM:
-			case MODE_3PWM1CAP:
-				num_outputs = 3;
-				break;
+		case MODE_3PWM:
+		case MODE_3PWM1CAP:
+			num_outputs = 3;
+			break;
 
-			case MODE_4PWM:
-				num_outputs = 4;
-				break;
+		case MODE_4PWM:
+			num_outputs = 4;
+			break;
 
-			case MODE_6PWM:
-				num_outputs = 6;
-				break;
+		case MODE_6PWM:
+			num_outputs = 6;
+			break;
 
-			case MODE_8PWM:
-				num_outputs = 8;
-				break;
+		case MODE_8PWM:
+			num_outputs = 8;
+			break;
 
-			default:
-				num_outputs = 0;
-				break;
-			}
-
-			hrt_abstime now = hrt_absolute_time();
-			float dt = (now - _time_last_mix) / 1e6f;
-			_time_last_mix = now;
-
-			if (dt < 0.0001f) {
-				dt = 0.0001f;
-
-			} else if (dt > 0.02f) {
-				dt = 0.02f;
-			}
-
-			if (_mot_t_max > FLT_EPSILON) {
-				// maximum value the ouputs of the multirotor mixer are allowed to change in this cycle
-				// factor 2 is needed because actuator ouputs are in the range [-1,1]
-				float delta_out_max = 2.0f * 1000.0f * dt / (_max_pwm[0] - _min_pwm[0]) / _mot_t_max;
-				_mixers->set_max_delta_out_once(delta_out_max);
-			}
-
-			/* do mixing */
-			float outputs[_max_actuators];
-			num_outputs = _mixers->mix(outputs, num_outputs, NULL);
-
-			/* disable unused ports by setting their output to NaN */
-			for (size_t i = 0; i < sizeof(outputs) / sizeof(outputs[0]); i++) {
-				if (i >= num_outputs) {
-					outputs[i] = NAN_VALUE;
-				}
-			}
-
-			uint16_t pwm_limited[_max_actuators];
-
-			/* the PWM limit call takes care of out of band errors, NaN and constrains */
-			pwm_limit_calc(_throttle_armed, arm_nothrottle(), num_outputs, _reverse_pwm_mask,
-				       _disarmed_pwm, _min_pwm, _max_pwm, outputs, pwm_limited, &_pwm_limit);
-
-
-			/* overwrite outputs in case of lockdown with disarmed PWM values */
-			if (_armed.lockdown) {
-				for (size_t i = 0; i < num_outputs; i++) {
-					pwm_limited[i] = _disarmed_pwm[i];
-				}
-			}
-
-			/* output to the servos */
-			for (size_t i = 0; i < num_outputs; i++) {
-				pwm_output_set(i, pwm_limited[i]);
-			}
-
-			publish_pwm_outputs(pwm_limited, num_outputs);
+		default:
+			num_outputs = 0;
+			break;
 		}
+
+		hrt_abstime now = hrt_absolute_time();
+		float dt = (now - _time_last_mix) / 1e6f;
+		_time_last_mix = now;
+
+		if (dt < 0.0001f) {
+			dt = 0.0001f;
+
+		} else if (dt > 0.02f) {
+			dt = 0.02f;
+		}
+
+		if (_mot_t_max > FLT_EPSILON) {
+			// maximum value the ouputs of the multirotor mixer are allowed to change in this cycle
+			// factor 2 is needed because actuator ouputs are in the range [-1,1]
+			float delta_out_max = 2.0f * 1000.0f * dt / (_max_pwm[0] - _min_pwm[0]) / _mot_t_max;
+			_mixers->set_max_delta_out_once(delta_out_max);
+		}
+
+		/* do mixing */
+		float outputs[_max_actuators];
+		num_outputs = _mixers->mix(outputs, num_outputs, NULL);
+
+		/* disable unused ports by setting their output to NaN */
+		for (size_t i = 0; i < sizeof(outputs) / sizeof(outputs[0]); i++) {
+			if (i >= num_outputs) {
+				outputs[i] = NAN_VALUE;
+			}
+		}
+
+		uint16_t pwm_limited[_max_actuators];
+
+		/* the PWM limit call takes care of out of band errors, NaN and constrains */
+		pwm_limit_calc(_throttle_armed, arm_nothrottle(), num_outputs, _reverse_pwm_mask,
+			       _disarmed_pwm, _min_pwm, _max_pwm, outputs, pwm_limited, &_pwm_limit);
+
+
+		/* overwrite outputs in case of lockdown with disarmed PWM values */
+		if (_armed.lockdown) {
+			for (size_t i = 0; i < num_outputs; i++) {
+				pwm_limited[i] = _disarmed_pwm[i];
+			}
+		}
+
+		/* output to the servos */
+		for (size_t i = 0; i < num_outputs; i++) {
+			pwm_output_set(i, pwm_limited[i]);
+		}
+
+		publish_pwm_outputs(pwm_limited, num_outputs);
+	}
 
 #ifdef GPIO_BTN_SAFETY
 

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2836,6 +2836,7 @@ int commander_thread_main(int argc, char *argv[])
 			    ((status.rc_signal_lost /*&& status_flags.gps_failure*/) ||
 			     (status_flags.rc_signal_lost_cmd && status_flags.gps_failure_cmd))) {
 				armed.force_failsafe = true;
+				armed.lockdown = true;
 				status_changed = true;
 				static bool flight_termination_printed = false;
 

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2833,19 +2833,20 @@ int commander_thread_main(int argc, char *argv[])
 			     internal_state.main_state == commander_state_s::MAIN_STATE_STAB ||
 			     internal_state.main_state == commander_state_s::MAIN_STATE_ALTCTL ||
 			     internal_state.main_state == commander_state_s::MAIN_STATE_POSCTL) &&
-			    ((status.rc_signal_lost && status_flags.gps_failure) ||
+			    ((status.rc_signal_lost /*&& status_flags.gps_failure*/) ||
 			     (status_flags.rc_signal_lost_cmd && status_flags.gps_failure_cmd))) {
 				armed.force_failsafe = true;
 				status_changed = true;
 				static bool flight_termination_printed = false;
 
 				if (!flight_termination_printed) {
-					warnx("Flight termination because of RC signal loss and GPS failure");
+					PX4_WARN("Flight termination because of RC signal loss"); // and GPS failure");
 					flight_termination_printed = true;
 				}
 
 				if (counter % (1000000 / COMMANDER_MONITORING_INTERVAL) == 0) {
-					mavlink_log_critical(&mavlink_log_pub, "RC and GPS lost: flight termination");
+//					mavlink_log_critical(&mavlink_log_pub, "RC and GPS lost: flight termination");
+					mavlink_log_critical(&mavlink_log_pub, "RC lost: flight termination");
 				}
 			}
 		}

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -150,6 +150,7 @@ private:
 	orb_id_t _actuators_id;	/**< pointer to correct actuator controls0 uORB metadata structure */
 
 	bool		_actuators_0_circuit_breaker_enabled;	/**< circuit breaker to suppress output */
+	bool		_termination_enabled;	/**< true if flight termination circuit breaker not set */
 
 	struct control_state_s				_ctrl_state;		/**< control state */
 	struct vehicle_attitude_setpoint_s	_v_att_sp;			/**< vehicle attitude setpoint */
@@ -539,6 +540,7 @@ MulticopterAttitudeControl::parameters_update()
 	param_get(_params_handles.vtol_wv_yaw_rate_scale, &_params.vtol_wv_yaw_rate_scale);
 
 	_actuators_0_circuit_breaker_enabled = circuit_breaker_enabled("CBRK_RATE_CTRL", CBRK_RATE_CTRL_KEY);
+	_termination_enabled = !circuit_breaker_enabled("CBRK_FLIGHTTERM", CBRK_FLIGHTTERM_KEY);
 
 	return OK;
 }
@@ -888,6 +890,12 @@ MulticopterAttitudeControl::task_main()
 			vehicle_manual_poll();
 			vehicle_status_poll();
 			vehicle_motor_limits_poll();
+
+			/* handle flight termination */
+			if (_termination_enabled && _v_control_mode.flag_control_termination_enabled) {
+				// do something
+			}
+
 
 			/* Check if we are in rattitude mode and the pilot is above the threshold on pitch
 			 * or roll (yaw can rotate 360 in normal att control).  If both are true don't


### PR DESCRIPTION
This fixes some problems with RC loss failsafe when in manual modes on fmu-v4, but may break other things since it's not clear to me how it was intended to work.

It appears that failsafe would never be entered if in manual mode with a GPS connected. 
Also, px4fmu quit running the output mixer when RC was lost.
