### PR TITLE
correct board rotation is zero for LPE IRIS in jmavsim SITL

### DIFF
--- a/posix-configs/SITL/init/lpe/iris
+++ b/posix-configs/SITL/init/lpe/iris
@@ -18,7 +18,7 @@ param set CAL_ACC0_YSCALE 1.01
 param set CAL_ACC0_ZSCALE 1.01
 param set CAL_ACC1_XOFF 0.01
 param set CAL_MAG0_XOFF 0.01
-param set SENS_BOARD_ROT 8
+param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
 param set NAV_DLL_ACT 2


### PR DESCRIPTION
seems like it should default to zero, but a recent PR changed it to 8