### PR TITLE
fix altitude setpoint bug

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -893,13 +893,13 @@ MulticopterPositionControl::control_manual(float dt)
 
 		} else {
 			_alt_hold_engaged = false;
+			_pos_sp(2) = _pos(2);
 		}
 
 		/* set requested velocity setpoint */
 		if (!_alt_hold_engaged) {
 			_run_alt_control = false; /* request velocity setpoint to be used, instead of altitude setpoint */
 			_vel_sp(2) = req_vel_sp_scaled(2);
-			_pos_sp(2) = _pos(2);
 		}
 	}
 }


### PR DESCRIPTION
@tumbili Please take a look at this, since it partially reverts your earlier bugfix: https://github.com/PX4/Firmware/commit/ff5db6b1be3c0fdd27eced5f29e51b5c58b8fbb4

flight tested outdoors on Pixracer with no GPS; altitude hold accuracy much better than +/-1m in forward/backward flight (no case on Pixracer, just foam over baro)