### PR TITLE
Fix version generation for release builds, #5308

### DIFF
--- a/src/systemcmds/ver/ver.c
+++ b/src/systemcmds/ver/ver.c
@@ -162,6 +162,11 @@ uint32_t version_tag_to_number(const char *tag)
 		type = FIRMWARE_TYPE_DEV;
 	}
 
+	/* looks like a release */
+	if (type == -1) {
+		type = FIRMWARE_TYPE_RELEASE;
+	}
+
 	ver = (ver << 8);
 
 	return ver | type;


### PR DESCRIPTION
In the case of a release build tag (ex "v1.5.0") the branch to decode version type is never triggered and int32_t type = -1 is bitwise OR'd to the version.

This fix ensures that we catch the release case and never return version number with -1 OR'd to the ver unsigned. 