### PR TITLE
WIP: Change for pending termios support in DSPAL.

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -43,14 +43,10 @@
 
 
 #ifndef __PX4_QURT
-#include <termios.h>
 #include <poll.h>
-#else
-#include <sys/ioctl.h>
-#include <dev_fs_lib_serial.h>
 #endif
 
-
+#include <termios.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -456,35 +452,6 @@ bool GPS::injectData(uint8_t *data, size_t len)
 
 int GPS::setBaudrate(unsigned baud)
 {
-
-#if __PX4_QURT
-	// TODO: currently QURT does not support configuration with termios.
-	dspal_serial_ioctl_data_rate data_rate;
-
-	switch (baud) {
-	case 9600: data_rate.bit_rate = DSPAL_SIO_BITRATE_9600; break;
-
-	case 19200: data_rate.bit_rate = DSPAL_SIO_BITRATE_19200; break;
-
-	case 38400: data_rate.bit_rate = DSPAL_SIO_BITRATE_38400; break;
-
-	case 57600: data_rate.bit_rate = DSPAL_SIO_BITRATE_57600; break;
-
-	case 115200: data_rate.bit_rate = DSPAL_SIO_BITRATE_115200; break;
-
-	default:
-		PX4_ERR("ERR: unknown baudrate: %d", baud);
-		return -EINVAL;
-	}
-
-	int ret = ::ioctl(_serial_fd, SERIAL_IOCTL_SET_DATA_RATE, (void *)&data_rate);
-
-	if (ret != 0) {
-
-		return ret;
-	}
-
-#else
 	/* process baud rate */
 	int speed;
 
@@ -562,7 +529,6 @@ int GPS::setBaudrate(unsigned baud)
 		return -1;
 	}
 
-#endif
 	return 0;
 }
 


### PR DESCRIPTION
Removes #ifdef for GPS access within QURT since the termios API is now supported.