### PR TITLE
Always update armed flag in Sensors

### DIFF
--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -1355,19 +1355,18 @@ Sensors::vehicle_control_mode_poll()
 	if (vcontrol_mode_updated) {
 
 		orb_copy(ORB_ID(vehicle_control_mode), _vcontrol_mode_sub, &vcontrol_mode);
+		_armed = vcontrol_mode.flag_armed;
 
 		/* switching from non-HIL to HIL mode */
 		if (vcontrol_mode.flag_system_hil_enabled && !_hil_enabled) {
 			_hil_enabled = true;
 			_publishing = false;
-			_armed = vcontrol_mode.flag_armed;
 
 			/* switching from HIL to non-HIL mode */
 
 		} else if (!_publishing && !_hil_enabled) {
 			_hil_enabled = false;
 			_publishing = true;
-			_armed = vcontrol_mode.flag_armed;
 		}
 	}
 }


### PR DESCRIPTION
Otherwise the battery estimator does not compute `bat_v_empty_dynamic` correctly.

I noticed that the battery estimator was performing terribly. Tracked it down to the fact that armed is always false [here](https://github.com/PX4/Firmware/blob/master/src/modules/systemlib/battery.cpp#L159), which renders the parameter `BAT_V_LOAD_DROP` useless.

Tested on PixFalcon.