### PR TITLE
Convert geofence distance params to float

### DIFF
--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -134,8 +134,8 @@ bool Geofence::inside(const struct vehicle_global_position_s &global_position,
 
 bool Geofence::inside(double lat, double lon, float altitude)
 {
-		int32_t max_horizontal_distance = _param_max_hor_distance.get();
-		int32_t max_vertical_distance = _param_max_ver_distance.get();
+		float max_horizontal_distance = _param_max_hor_distance.get();
+		float max_vertical_distance = _param_max_ver_distance.get();
 
 		if (max_horizontal_distance > 0 || max_vertical_distance > 0) {
 			if (_home_pos_set) {

--- a/src/modules/navigator/geofence_params.c
+++ b/src/modules/navigator/geofence_params.c
@@ -114,7 +114,7 @@ PARAM_DEFINE_INT32(GF_COUNT, -1);
  * @increment 1
  * @group Geofence
  */
-PARAM_DEFINE_INT32(GF_MAX_HOR_DIST, -1);
+PARAM_DEFINE_FLOAT(GF_MAX_HOR_DIST, -1);
 
 /**
  * Max vertical distance in meters.
@@ -126,4 +126,4 @@ PARAM_DEFINE_INT32(GF_MAX_HOR_DIST, -1);
  * @increment 1
  * @group Geofence
  */
-PARAM_DEFINE_INT32(GF_MAX_VER_DIST, -1);
+PARAM_DEFINE_FLOAT(GF_MAX_VER_DIST, -1);


### PR DESCRIPTION
Identified by https://github.com/mavlink/qgroundcontrol/issues/4008, we should be using a float to store geofence distance parameters. 