### PR TITLE
Fix build errors

### DIFF
--- a/Tools/px4params/srcparser.py
+++ b/Tools/px4params/srcparser.py
@@ -129,8 +129,7 @@ class Parameter(object):
         Return list of existing bitmask codes in convenient order
         """
         keys = self.bitmask.keys()
-        keys.sort(key=float)
-        return keys
+        return sorted(keys, key=float)
 
     def GetBitmaskBit(self, index):
         """

--- a/src/platforms/posix/drivers/df_ak8963_wrapper/df_ak8963_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_ak8963_wrapper/df_ak8963_wrapper.cpp
@@ -53,6 +53,7 @@
 #include <systemlib/err.h>
 
 #include <drivers/drv_mag.h>
+#include <drivers/drv_hrt.h>
 
 #include <uORB/topics/parameter_update.h>
 

--- a/src/platforms/posix/drivers/df_ms5607_wrapper/df_ms5607_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_ms5607_wrapper/df_ms5607_wrapper.cpp
@@ -53,6 +53,7 @@
 #include <systemlib/err.h>
 
 #include <drivers/drv_baro.h>
+#include <drivers/drv_hrt.h>
 
 #include <board_config.h>
 


### PR DESCRIPTION
When building the firmware, I had the following error:

```
FAILED: parameters.xml 
cd /home/michael/Projects/PX4/Firmware/build_posix_bebop_default && /usr/bin/python /home/michael/Projects/PX4/Firmware/Tools/px_process_params.py -s /home/michael/Projects/PX4/Firmware/src --board CONFIG_ARCH_bebop --xml --inject-xml
Traceback (most recent call last):
  File "/home/michael/Projects/PX4/Firmware/Tools/px_process_params.py", line 155, in <module>
    main()
  File "/home/michael/Projects/PX4/Firmware/Tools/px_process_params.py", line 127, in main
    if not parser.Validate():
  File "/home/michael/Projects/PX4/Firmware/Tools/px4params/srcparser.py", line 361, in Validate
    for index in param.GetBitmaskList():
  File "/home/michael/Projects/PX4/Firmware/Tools/px4params/srcparser.py", line 132, in GetBitmaskList
    keys.sort(key=float)
AttributeError: 'dict_keys' object has no attribute 'sort'
```

I am using Arch Linux which uses Python3 by default. Yet, Python3 returns a view when calling `dict.keys()` and the iterator has no `sort()` function. Python2 returns a `list()` instead. The first commit should fix this error.

The second commit adds a missing header include to drivers used on the Parrot Bebop.