### PR TITLE
Navio gps on SPI

### DIFF
--- a/posix-configs/rpi/px4.config
+++ b/posix-configs/rpi/px4.config
@@ -7,7 +7,7 @@ df_lsm9ds1_wrapper start -R 4
 #df_mpu9250_wrapper start -R 10
 #df_hmc5883_wrapper start
 df_ms5611_wrapper start
-gps start -d /dev/spidev0.0
+gps start -d /dev/spidev0.0 -i spi -p ubx
 sensors start
 commander start
 attitude_estimator_q start

--- a/posix-configs/rpi/px4.config
+++ b/posix-configs/rpi/px4.config
@@ -7,7 +7,7 @@ df_lsm9ds1_wrapper start -R 4
 #df_mpu9250_wrapper start -R 10
 #df_hmc5883_wrapper start
 df_ms5611_wrapper start
-gps start -d /dev/pts/0
+gps start -d /dev/spidev0.0
 sensors start
 commander start
 attitude_estimator_q start

--- a/src/drivers/drv_gps.h
+++ b/src/drivers/drv_gps.h
@@ -58,3 +58,7 @@ typedef enum {
 	GPS_DRIVER_MODE_ASHTECH
 } gps_driver_mode_t;
 
+typedef enum {
+	GPS_DRIVER_UART = 0,
+	GPS_DRIVER_SPI
+} gps_driver_interface_t;

--- a/src/drivers/gps/definitions.h
+++ b/src/drivers/gps/definitions.h
@@ -51,6 +51,7 @@
 #include <unistd.h> //this is POSIX, used for usleep
 
 #include <drivers/drv_hrt.h>
+#include <drivers/drv_gps.h>
 
 /**
  * Get the current time in us. Function signature:
@@ -59,6 +60,9 @@
 #define gps_absolute_time hrt_absolute_time
 typedef hrt_abstime gps_abstime;
 
+#define INTERFACE_UART GPS_DRIVER_UART
+#define INTERFACE_SPI GPS_DRIVER_SPI
+typedef gps_driver_interface_t gps_interface;
 
 // TODO: this functionality is not available on the Snapdragon yet
 #ifdef __PX4_QURT

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -124,8 +124,9 @@ private:
 	bool				_healthy;					///< flag to signal if the GPS is ok
 	bool				_baudrate_changed;				///< flag to signal that the baudrate with the GPS has changed
 	bool				_mode_changed;					///< flag that the GPS mode has changed
+	bool        _mode_auto;
 	gps_driver_mode_t		_mode;						///< current mode
-	gps_driver_interface_t  _interface;
+	gps_driver_interface_t  _interface;   ///< interface
 	GPSHelper			*_helper;					///< instance of GPS parser
 	GPS_Sat_Info			*_sat_info;					///< instance of GPS sat info data object
 	struct vehicle_gps_position_s	_report_gps_pos;				///< uORB topic for gps position
@@ -278,6 +279,10 @@ GPS::GPS(const char *path, gps_driver_mode_t mode, gps_driver_interface_t interf
 		_sat_info = new GPS_Sat_Info();
 		_p_report_sat_info = &_sat_info->_data;
 		memset(_p_report_sat_info, 0, sizeof(*_p_report_sat_info));
+	}
+
+	if (mode == GPS_DRIVER_MODE_NONE) {
+		_mode_auto = true;
 	}
 }
 
@@ -707,6 +712,9 @@ GPS::task_main()
 			}
 
 			switch (_mode) {
+			case GPS_DRIVER_MODE_NONE:
+				_mode = GPS_DRIVER_MODE_UBX;
+
 			case GPS_DRIVER_MODE_UBX:
 				_helper = new GPSDriverUBX(helper_interface, &GPS::callback, this, &_report_gps_pos, _p_report_sat_info);
 				break;
@@ -813,6 +821,26 @@ GPS::task_main()
 					_rate_rtcm_injection = 0.0f;
 				}
 			}
+
+			if (_mode_auto) {
+				switch (_mode) {
+				case GPS_DRIVER_MODE_UBX:
+					_mode = GPS_DRIVER_MODE_MTK;
+					break;
+
+				case GPS_DRIVER_MODE_MTK:
+					_mode = GPS_DRIVER_MODE_ASHTECH;
+					break;
+
+				case GPS_DRIVER_MODE_ASHTECH:
+					_mode = GPS_DRIVER_MODE_UBX;
+					break;
+
+				default:
+					break;
+				}
+			}
+
 		}
 	}
 
@@ -1037,7 +1065,7 @@ gps_main(int argc, char *argv[])
 	bool fake_gps = false;
 	bool enable_sat_info = false;
 	gps_driver_interface_t interface = GPS_DRIVER_UART;
-	gps_driver_mode_t mode = GPS_DRIVER_MODE_UBX;
+	gps_driver_mode_t mode = GPS_DRIVER_MODE_NONE;
 
 	if (argc < 2) {
 		goto out;

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -696,27 +696,12 @@ GPS::task_main()
 				_helper = nullptr;
 			}
 
-			GPSHelper::Interface helper_interface = GPSHelper::Interface::UART;
-
-			switch (_interface) {
-			case GPS_DRIVER_UART:
-				helper_interface = GPSHelper::Interface::UART;
-				break;
-
-			case GPS_DRIVER_SPI:
-				helper_interface = GPSHelper::Interface::SPI;
-				break;
-
-			default:
-				break;
-			}
-
 			switch (_mode) {
 			case GPS_DRIVER_MODE_NONE:
 				_mode = GPS_DRIVER_MODE_UBX;
 
 			case GPS_DRIVER_MODE_UBX:
-				_helper = new GPSDriverUBX(helper_interface, &GPS::callback, this, &_report_gps_pos, _p_report_sat_info);
+				_helper = new GPSDriverUBX(_interface, &GPS::callback, this, &_report_gps_pos, _p_report_sat_info);
 				break;
 
 			case GPS_DRIVER_MODE_MTK:

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -796,6 +796,7 @@ GPS::task_main()
 			}
 
 #if !defined(__PX4_POSIX_RPI)
+
 			/* select next mode */
 			switch (_mode) {
 			case GPS_DRIVER_MODE_UBX:
@@ -813,6 +814,7 @@ GPS::task_main()
 			default:
 				break;
 			}
+
 #endif
 		}
 

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -374,7 +374,7 @@ int GPS::pollOrRead(uint8_t *buf, size_t buf_length, int timeout)
 {
 	handleInjectDataTopic();
 
-#ifndef __PX4_QURT
+#if !defined(__PX4_QURT) || !defined(__PX4_POSIX_RPI)
 
 	/* For non QURT, use the usual polling. */
 
@@ -795,6 +795,7 @@ GPS::task_main()
 				}
 			}
 
+#if !defined(__PX4_POSIX_RPI)
 			/* select next mode */
 			switch (_mode) {
 			case GPS_DRIVER_MODE_UBX:
@@ -812,6 +813,7 @@ GPS::task_main()
 			default:
 				break;
 			}
+#endif
 		}
 
 	}

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -103,7 +103,8 @@ public:
 class GPS
 {
 public:
-	GPS(const char *uart_path, bool fake_gps, bool enable_sat_info, int gps_num);
+	GPS(const char *path, gps_driver_mode_t mode, gps_driver_interface_t interface, bool fake_gps, bool enable_sat_info,
+	    int gps_num);
 	virtual ~GPS();
 
 	virtual int			init();
@@ -124,6 +125,7 @@ private:
 	bool				_baudrate_changed;				///< flag to signal that the baudrate with the GPS has changed
 	bool				_mode_changed;					///< flag that the GPS mode has changed
 	gps_driver_mode_t		_mode;						///< current mode
+	gps_driver_interface_t  _interface;
 	GPSHelper			*_helper;					///< instance of GPS parser
 	GPS_Sat_Info			*_sat_info;					///< instance of GPS sat info data object
 	struct vehicle_gps_position_s	_report_gps_pos;				///< uORB topic for gps position
@@ -241,11 +243,13 @@ volatile bool is_gps1_advertised = false; ///< for the second gps we want to mak
 }
 
 
-GPS::GPS(const char *uart_path, bool fake_gps, bool enable_sat_info, int gps_num) :
+GPS::GPS(const char *path, gps_driver_mode_t mode, gps_driver_interface_t interface, bool fake_gps,
+	 bool enable_sat_info, int gps_num) :
 	_task_should_exit(false),
 	_healthy(false),
 	_mode_changed(false),
-	_mode(GPS_DRIVER_MODE_UBX),
+	_mode(mode),
+	_interface(interface),
 	_helper(nullptr),
 	_sat_info(nullptr),
 	_report_gps_pos_pub{nullptr},
@@ -263,7 +267,7 @@ GPS::GPS(const char *uart_path, bool fake_gps, bool enable_sat_info, int gps_num
 	_dump_from_device(nullptr)
 {
 	/* store port name */
-	strncpy(_port, uart_path, sizeof(_port));
+	strncpy(_port, path, sizeof(_port));
 	/* enforce null termination */
 	_port[sizeof(_port) - 1] = '\0';
 
@@ -687,13 +691,24 @@ GPS::task_main()
 				_helper = nullptr;
 			}
 
+			GPSHelper::Interface helper_interface = GPSHelper::Interface::UART;
+
+			switch (_interface) {
+			case GPS_DRIVER_UART:
+				helper_interface = GPSHelper::Interface::UART;
+				break;
+
+			case GPS_DRIVER_SPI:
+				helper_interface = GPSHelper::Interface::SPI;
+				break;
+
+			default:
+				break;
+			}
+
 			switch (_mode) {
 			case GPS_DRIVER_MODE_UBX:
-#ifndef __PX4_POSIX_RPI
-				_helper = new GPSDriverUBX(GPSHelper::Interface::UART, &GPS::callback, this, &_report_gps_pos, _p_report_sat_info);
-#else
-				_helper = new GPSDriverUBX(GPSHelper::Interface::SPI, &GPS::callback, this, &_report_gps_pos, _p_report_sat_info);
-#endif
+				_helper = new GPSDriverUBX(helper_interface, &GPS::callback, this, &_report_gps_pos, _p_report_sat_info);
 				break;
 
 			case GPS_DRIVER_MODE_MTK:
@@ -798,30 +813,7 @@ GPS::task_main()
 					_rate_rtcm_injection = 0.0f;
 				}
 			}
-
-#if !defined(__PX4_POSIX_RPI)
-
-			/* select next mode */
-			switch (_mode) {
-			case GPS_DRIVER_MODE_UBX:
-				_mode = GPS_DRIVER_MODE_MTK;
-				break;
-
-			case GPS_DRIVER_MODE_MTK:
-				_mode = GPS_DRIVER_MODE_ASHTECH;
-				break;
-
-			case GPS_DRIVER_MODE_ASHTECH:
-				_mode = GPS_DRIVER_MODE_UBX;
-				break;
-
-			default:
-				break;
-			}
-
-#endif
 		}
-
 	}
 
 	PX4_INFO("exiting");
@@ -943,7 +935,8 @@ namespace gps
 {
 
 
-void	start(const char *uart_path, bool fake_gps, bool enable_sat_info, int gps_num);
+void	start(const char *path, gps_driver_mode_t mode, gps_driver_interface_t interface, bool fake_gps,
+	      bool enable_sat_info, int gps_num);
 void	stop();
 void	test();
 void	reset();
@@ -953,7 +946,8 @@ void	info();
  * Start the driver.
  */
 void
-start(const char *uart_path, bool fake_gps, bool enable_sat_info, int gps_num)
+start(const char *path, gps_driver_mode_t mode, gps_driver_interface_t interface, bool fake_gps, bool enable_sat_info,
+      int gps_num)
 {
 	if (g_dev[gps_num - 1] != nullptr) {
 		PX4_WARN("GPS %i already started", gps_num);
@@ -961,7 +955,7 @@ start(const char *uart_path, bool fake_gps, bool enable_sat_info, int gps_num)
 	}
 
 	/* create the driver */
-	g_dev[gps_num - 1] = new GPS(uart_path, fake_gps, enable_sat_info, gps_num);
+	g_dev[gps_num - 1] = new GPS(path, mode, interface, fake_gps, enable_sat_info, gps_num);
 
 	if (!g_dev[gps_num - 1] || OK != g_dev[gps_num - 1]->init()) {
 		if (g_dev[gps_num - 1] != nullptr) {
@@ -1042,6 +1036,8 @@ gps_main(int argc, char *argv[])
 	const char *device_name2 = nullptr;
 	bool fake_gps = false;
 	bool enable_sat_info = false;
+	gps_driver_interface_t interface = GPS_DRIVER_UART;
+	gps_driver_mode_t mode = GPS_DRIVER_MODE_UBX;
 
 	if (argc < 2) {
 		goto out;
@@ -1076,6 +1072,43 @@ gps_main(int argc, char *argv[])
 			}
 		}
 
+		/* Detect interface option */
+		for (int i = 2; i < argc; i++) {
+			if (!strcmp(argv[i], "-i")) {
+
+				int interface_arg = i + 1;
+
+				if (interface_arg < argc) {
+					if (!strcmp(argv[interface_arg], "spi")) {
+						interface = GPS_DRIVER_SPI;
+
+					} else if (!strcmp(argv[interface_arg], "uart")) {
+						interface = GPS_DRIVER_UART;
+					}
+				}
+			}
+		}
+
+		/* Detect mode/protocol option */
+		for (int i = 2; i < argc; i++) {
+			if (!strcmp(argv[i], "-p")) {
+
+				int mode_arg = i + 1;
+
+				if (mode_arg < argc) {
+					if (!strcmp(argv[mode_arg], "ubx")) {
+						mode = GPS_DRIVER_MODE_UBX;
+
+					} else if (!strcmp(argv[mode_arg], "mtk")) {
+						mode = GPS_DRIVER_MODE_MTK;
+
+					} else if (!strcmp(argv[mode_arg], "ash")) {
+						mode = GPS_DRIVER_MODE_ASHTECH;
+					}
+				}
+			}
+		}
+
 		/* Allow to use a second gps device */
 		for (int i = 2; i < argc; i++) {
 			if (!strcmp(argv[i], "-dualgps")) {
@@ -1088,10 +1121,10 @@ gps_main(int argc, char *argv[])
 			}
 		}
 
-		gps::start(device_name, fake_gps, enable_sat_info, 1);
+		gps::start(device_name, mode, interface, fake_gps, enable_sat_info, 1);
 
 		if (device_name2) {
-			gps::start(device_name2, fake_gps, enable_sat_info, 2);
+			gps::start(device_name2, mode, interface, fake_gps, enable_sat_info, 2);
 		}
 
 	}

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -374,7 +374,7 @@ int GPS::pollOrRead(uint8_t *buf, size_t buf_length, int timeout)
 {
 	handleInjectDataTopic();
 
-#if !defined(__PX4_QURT) || !defined(__PX4_POSIX_RPI)
+#if !defined(__PX4_QURT)
 
 	/* For non QURT, use the usual polling. */
 
@@ -689,7 +689,11 @@ GPS::task_main()
 
 			switch (_mode) {
 			case GPS_DRIVER_MODE_UBX:
-				_helper = new GPSDriverUBX(&GPS::callback, this, &_report_gps_pos, _p_report_sat_info);
+#ifndef __PX4_POSIX_RPI
+				_helper = new GPSDriverUBX(GPSHelper::Interface::UART, &GPS::callback, this, &_report_gps_pos, _p_report_sat_info);
+#else
+				_helper = new GPSDriverUBX(GPSHelper::Interface::SPI, &GPS::callback, this, &_report_gps_pos, _p_report_sat_info);
+#endif
 				break;
 
 			case GPS_DRIVER_MODE_MTK:

--- a/src/drivers/navio_gpio/navio_gpio.cpp
+++ b/src/drivers/navio_gpio/navio_gpio.cpp
@@ -108,7 +108,7 @@ int Gpio::configgpio(uint32_t pinset)
 	addr = (uintptr_t)_gpio_map + GPIO_GPFSEL0_OFFSET + pin / 10;
 	shift = (pin % 10) * 3;
 
-	atomic_modify(addr, shift, GPIO_CNF_MASK, cnf);
+	atomic_modify(addr, shift, GPIO_CNF_MASK >> GPIO_CNF_SHIFT, cnf);
 
 	return 0;
 }


### PR DESCRIPTION
This adds support for SPI-connected U-blox GPS on Navio2. It also fixes a bug in GPIO driver that caused GPS on SPI not to work. This PR needs another PR for GpsDrivers. Together with the other PR, we were able to verify GPS functionality through 'gps status' command.