### PR TITLE
Find and use Python 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,7 @@ else()
 	message(STATUS "catkin DISABLED")
 endif()
 
-find_package(PythonInterp REQUIRED)
+find_package(PythonInterp 2.7 REQUIRED)
 
 #=============================================================================
 # cmake modules


### PR DESCRIPTION
This will make the build works in distros that have Python 3 as default
and will not break anything in distros that have Python 2 as default.