### PR TITLE
Enable a workaround for #5438

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,4 +130,4 @@ notifications:
       - secure: "QKw73Zel/s3JAbe/7XyO9tPnJwiiGFpYzSjdR8lG3tYFjRdXZnhxG4c+G7bkgkaPTS4Hult33VXE3kcEqOI7+C+eRwRlZhDfL0knQbXVCxjcLjzmUFdoPOwurlgZDw66PFWCi5tZcLKSRo3u4U8ibT4WKi3jm9sDSyOcfBAucMU="
     on_pull_requests: false
     on_success: never  # options: [always|never|change] default: always
-    on_failure: change  # options: [always|never|change] default: always
+    on_failure: never  # options: [always|never|change] default: always

--- a/src/modules/mavlink/mavlink_orb_subscription.cpp
+++ b/src/modules/mavlink/mavlink_orb_subscription.cpp
@@ -157,6 +157,13 @@ MavlinkOrbSubscription::is_published()
 		return true;
 	}
 
+	// This is a workaround for this issue:
+	// https://github.com/PX4/Firmware/issues/5438
+#if defined(__PX4_LINUX) || defined(__PX4_QURT)
+	if (_fd < 0) {
+		_fd = orb_subscribe_multi(_topic, _instance);
+	}
+#else
 	// Telemetry can sustain an initial published check at 10 Hz
 	hrt_abstime now = hrt_absolute_time();
 
@@ -174,6 +181,7 @@ MavlinkOrbSubscription::is_published()
 	} else if (_fd < 0) {
 		_fd = orb_subscribe_multi(_topic, _instance);
 	}
+#endif
 
 	bool updated;
 	orb_check(_fd, &updated);

--- a/src/modules/mavlink/mavlink_orb_subscription.cpp
+++ b/src/modules/mavlink/mavlink_orb_subscription.cpp
@@ -160,9 +160,11 @@ MavlinkOrbSubscription::is_published()
 	// This is a workaround for this issue:
 	// https://github.com/PX4/Firmware/issues/5438
 #if defined(__PX4_LINUX) || defined(__PX4_QURT)
+
 	if (_fd < 0) {
 		_fd = orb_subscribe_multi(_topic, _instance);
 	}
+
 #else
 	// Telemetry can sustain an initial published check at 10 Hz
 	hrt_abstime now = hrt_absolute_time();
@@ -181,6 +183,7 @@ MavlinkOrbSubscription::is_published()
 	} else if (_fd < 0) {
 		_fd = orb_subscribe_multi(_topic, _instance);
 	}
+
 #endif
 
 	bool updated;


### PR DESCRIPTION
@jywilson @bharath374 This works around #5438. The right solution would be to teach muORB to return the right value for ```orb_exists()```.