### PR TITLE
Append AUX mixer for HITL simulation

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -138,7 +138,18 @@ then
 	then
 		if fmu mode_$AUX_MODE
 		then
-			if [ -e $OUTPUT_AUX_DEV ]
+			# Append aux mixer to main device
+			if [ $OUTPUT_MODE == hil ]
+			then
+				if mixer append $OUTPUT_DEV $MIXER_AUX_FILE
+				then
+					echo "INFO  [init] Mixer: $MIXER_AUX_FILE appended to $OUTPUT_DEV"
+				else
+					echo "ERROR [init] Error appending mixer: $MIXER_AUX_FILE"
+					echo "ERROR [init] Could not append mixer: $MIXER_AUX_FILE" >> $LOG_FILE
+				fi
+			fi
+			if [ -e $OUTPUT_AUX_DEV -a $OUTPUT_MODE != hil ]
 			then
 				if mixer load $OUTPUT_AUX_DEV $MIXER_AUX_FILE
 				then

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -438,7 +438,7 @@ then
 
 		if [ $OUTPUT_MODE == hil ]
 		then
-			if pwm_out_sim mode_port2_pwm8
+			if pwm_out_sim mode_pwm16
 			then
 			else
 				tone_alarm $TUNE_ERR

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -2295,7 +2295,8 @@ protected:
 			    system_type == MAV_TYPE_HEXAROTOR ||
 			    system_type == MAV_TYPE_OCTOROTOR ||
 			    system_type == MAV_TYPE_VTOL_DUOROTOR ||
-			    system_type == MAV_TYPE_VTOL_QUADROTOR) {
+			    system_type == MAV_TYPE_VTOL_QUADROTOR ||
+			    system_type == MAV_TYPE_VTOL_RESERVED2) {
 
 				/* multirotors: set number of rotor outputs depending on type */
 
@@ -2316,6 +2317,10 @@ protected:
 
 				case MAV_TYPE_VTOL_QUADROTOR:
 					n = 4;
+					break;
+
+				case MAV_TYPE_VTOL_RESERVED2:
+					n = 8;
 					break;
 
 				default:

--- a/src/systemcmds/mixer/mixer.cpp
+++ b/src/systemcmds/mixer/mixer.cpp
@@ -59,7 +59,7 @@
 extern "C" __EXPORT int mixer_main(int argc, char *argv[]);
 
 static void	usage(const char *reason);
-static int	load(const char *devname, const char *fname);
+static int	load(const char *devname, const char *fname, bool append);
 
 int
 mixer_main(int argc, char *argv[])
@@ -75,10 +75,23 @@ mixer_main(int argc, char *argv[])
 			return 1;
 		}
 
-		int ret = load(argv[2], argv[3]);
+		int ret = load(argv[2], argv[3], false);
 
 		if (ret != 0) {
 			warnx("failed to load mixer");
+			return 1;
+		}
+
+	} else if (!strcmp(argv[1], "append")) {
+		if (argc < 4) {
+			usage("missing device or filename");
+			return 1;
+		}
+
+		int ret = load(argv[2], argv[3], true);
+
+		if (ret != 0) {
+			warnx("failed to append mixer");
 			return 1;
 		}
 
@@ -102,7 +115,7 @@ usage(const char *reason)
 }
 
 static int
-load(const char *devname, const char *fname)
+load(const char *devname, const char *fname, bool append)
 {
 	// sleep a while to ensure device has been set up
 	usleep(20000);
@@ -115,10 +128,12 @@ load(const char *devname, const char *fname)
 		return 1;
 	}
 
-	/* reset mixers on the device */
-	if (px4_ioctl(dev, MIXERIOCRESET, 0)) {
-		warnx("can't reset mixers on %s", devname);
-		return 1;
+	/* reset mixers on the device, but not if appending */
+	if (!append) {
+		if (px4_ioctl(dev, MIXERIOCRESET, 0)) {
+			warnx("can't reset mixers on %s", devname);
+			return 1;
+		}
 	}
 
 	char buf[2048];


### PR DESCRIPTION
For HITL simulation, I need to capture all outputs of the pixhawk, including the AUX ones. With this pull-request, it basically works like this:

1. Main mixer is loaded to pwm_out_sim
2. Aux mixer is *appended* to pwm_out_sim

The append function is basically the same as load, but it does not reset the mixer first.