### PR TITLE
Geofence: use correct types for float params

### DIFF
--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -132,8 +132,8 @@ private:
 	control::BlockParamInt _param_altitude_mode;
 	control::BlockParamInt _param_source;
 	control::BlockParamInt _param_counter_threshold;
-	control::BlockParamInt _param_max_hor_distance;
-	control::BlockParamInt _param_max_ver_distance;
+	control::BlockParamFloat _param_max_hor_distance;
+	control::BlockParamFloat _param_max_ver_distance;
 
 	int _outside_counter;
 


### PR DESCRIPTION
@NaterGator I believe this was missing from your #5435 PR, could you have a look?