### PR TITLE
Adds Navio Kill Switch Logic

### DIFF
--- a/src/drivers/navio_sysfs_pwm_out/navio_sysfs_pwm_out.cpp
+++ b/src/drivers/navio_sysfs_pwm_out/navio_sysfs_pwm_out.cpp
@@ -360,7 +360,13 @@ void task_main(int argc, char *argv[])
 				       pwm,
 				       &_pwm_limit);
 
-			send_outputs_pwm(pwm);
+
+			if (_armed.lockdown) {
+				send_outputs_pwm(disarmed_pwm);
+
+			} else {
+				send_outputs_pwm(pwm);
+			}
 
 			if (_outputs_pub != nullptr) {
 				orb_publish(ORB_ID(actuator_outputs), _outputs_pub, &_outputs);


### PR DESCRIPTION
Navio PWM driver was previously ignoring lockdown mode.