### PR TITLE
add support for out-of-tree modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ set_property(CACHE CONFIG PROPERTY STRINGS ${configs})
 set(THREADS "4" CACHE STRING
 	"number of threads to use for external build processes")
 set(DEBUG_PORT "/dev/ttyACM0" CACHE STRING "debugging port")
+set(EXTERNAL_MODULES_LOCATION "" CACHE STRING "External modules source location")
 
 #=============================================================================
 # configuration
@@ -369,6 +370,24 @@ foreach(driver ${config_df_driver_list})
 	list(APPEND df_driver_libs df_${driver})
 	message("Adding DF driver: ${driver}")
 endforeach()
+
+#=============================================================================
+# external modules
+#
+if(NOT EXTERNAL_MODULES_LOCATION STREQUAL "")
+	message(STATUS "External modules: ${EXTERNAL_MODULES_LOCATION}")
+	add_subdirectory("${EXTERNAL_MODULES_LOCATION}/src" external_modules_src)
+
+	set(config_module_list_external_expanded)
+	foreach(external_module ${config_module_list_external})
+		list(APPEND config_module_list_external_expanded
+			${EXTERNAL_MODULES_LOCATION}/src/${external_module})
+	endforeach()
+	set(config_module_list
+		${config_module_list}
+		${config_module_list_external_expanded}
+		)
+endif()
 
 #=============================================================================
 # subdirectories

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,12 @@ else
 	BUILD_DIR_SUFFIX :=
 endif
 
+# additional config parameters passed to cmake
+CMAKE_ARGS :=
+ifdef EXTERNAL_MODULES_LOCATION
+	CMAKE_ARGS := -DEXTERNAL_MODULES_LOCATION:STRING=$(EXTERNAL_MODULES_LOCATION)
+endif
+
 SRC_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 # Functions
@@ -119,7 +125,7 @@ SRC_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 define cmake-build
 +@$(eval BUILD_DIR = $(SRC_DIR)/build_$@$(BUILD_DIR_SUFFIX))
 +@if [ $(PX4_CMAKE_GENERATOR) = "Ninja" ] && [ -e $(BUILD_DIR)/Makefile ]; then rm -rf $(BUILD_DIR); fi
-+@if [ ! -e $(BUILD_DIR)/CMakeCache.txt ]; then mkdir -p $(BUILD_DIR) && cd $(BUILD_DIR) && cmake .. -G$(PX4_CMAKE_GENERATOR) -DCONFIG=$(1) || (cd .. && rm -rf $(BUILD_DIR)); fi
++@if [ ! -e $(BUILD_DIR)/CMakeCache.txt ]; then mkdir -p $(BUILD_DIR) && cd $(BUILD_DIR) && cmake .. -G$(PX4_CMAKE_GENERATOR) -DCONFIG=$(1) $(CMAKE_ARGS) || (cd .. && rm -rf $(BUILD_DIR)); fi
 +@(echo "PX4 CONFIG: $(BUILD_DIR)" && cd $(BUILD_DIR) && $(PX4_MAKE) $(PX4_MAKE_ARGS) $(ARGS))
 endef
 

--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -231,6 +231,7 @@ endfunction()
 #			[ COMPILE_FLAGS <list> ]
 #			[ INCLUDES <list> ]
 #			[ DEPENDS <string> ]
+#			[ EXTERNAL ]
 #			)
 #
 #	Input:
@@ -244,6 +245,7 @@ endfunction()
 #		SRCS			: source files
 #		INCLUDES		: include directories
 #		DEPENDS			: targets which this module depends on
+#		EXTERNAL		: flag to indicate that this module is out-of-tree
 #
 #	Output:
 #		Static library with name matching MODULE.
@@ -263,8 +265,13 @@ function(px4_add_module)
 		NAME px4_add_module
 		ONE_VALUE MODULE MAIN STACK STACK_MAIN STACK_MAX PRIORITY
 		MULTI_VALUE COMPILE_FLAGS LINK_FLAGS SRCS INCLUDES DEPENDS
+		OPTIONS EXTERNAL
 		REQUIRED MODULE
 		ARGN ${ARGN})
+
+	if(EXTERNAL)
+		px4_mangle_name("${EXTERNAL_MODULES_LOCATION}/src/${MODULE}" MODULE)
+	endif()
 
 	add_library(${MODULE} STATIC EXCLUDE_FROM_ALL ${SRCS})
 


### PR DESCRIPTION
Add the possibility to build out-of-tree src modules via EXTERNAL_MODULES_LOCATION variable.
Usage:
- EXTERNAL_MODULES_LOCATION points to a directory with the same structure as Firmware (and thus contains a directory `src`)
- copy an existing module (eg. examples/px4_simple_app) to the external directory
- rename the module (including MODULE in CMakeLists.txt) or remove it from the existing Firmware cmake config.
- add `$EXTERNAL_MODULES_LOCATION/CMakeLists.txt` with content:
```
set(config_module_list_external
	modules/<new_module>
	PARENT_SCOPE
	)
```
- add a line `EXTERNAL` to the `modules/<new_module>/CMakeLists.txt` within `px4_add_module`
- `make posix EXTERNAL_MODULES_LOCATION=<path>` (or just set the cmake variable in the build folder if a build already exists)