### PR TITLE
Update the Crazyflie config metadata and gains after some tuning flights.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/4900_crazyflie
+++ b/ROMFS/px4fmu_common/init.d/4900_crazyflie
@@ -1,6 +1,6 @@
 #!nsh
 #
-# @name Crazyflie config
+# @name Crazyflie 2.0
 #
 # @type Quadrotor x
 #
@@ -21,12 +21,15 @@ then
 
 	param set SYS_COMPANION 20
 
-	param set MC_PITCHRATE_D 0.0028
-	param set MC_PITCHRATE_P 0.075
-	param set MC_PITCH_P 4.0
-	param set MC_ROLLRATE_D 0.0028
-	param set MC_ROLLRATE_P 0.075
-	param set MC_ROLL_P 4.0
+	param set MC_PITCHRATE_D 0.0015
+	param set MC_PITCHRATE_I 0.05
+	param set MC_PITCHRATE_P 0.045
+	param set MC_PITCH_P 6.5
+	param set MC_ROLLRATE_D 0.0015
+	param set MC_ROLLRATE_I 0.05
+	param set MC_ROLLRATE_P 0.045
+	param set MC_ROLL_P 6.5
+	param set MC_YAW_P 3.0
 
 	param set CBRK_SUPPLY_CHK 894281
 	param set CBRK_USB_CHK 197848


### PR DESCRIPTION
Video: https://youtu.be/GSetauDQU9M

Flown with the mobile app with the following advanced flight control settings:
- max roll/pitch angle: 50
- max yaw angle: 300
- max thrust: 85%
- min thrust: 10%

@dennisss perhaps you want to try these gains and see if they work for you before we merge this?