### PR TITLE
navigator/mavlink: fixes for mission item reached message

### DIFF
--- a/src/modules/mavlink/mavlink_mission.h
+++ b/src/modules/mavlink/mavlink_mission.h
@@ -118,6 +118,8 @@ private:
 	static unsigned		_count;					///< Count of items in active mission
 	static int		_current_seq;				///< Current item sequence in active mission
 
+	static int		_last_reached;				///< Last reached waypoint in active mission (-1 means nothing reached)
+
 	int			_transfer_dataman_id;			///< Dataman storage ID for current transmission
 	unsigned		_transfer_count;			///< Items count in current transmission
 	unsigned		_transfer_seq;				///< Item sequence in current transmission

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -204,7 +204,12 @@ Mission::on_active()
 
 	/* lets check if we reached the current mission item */
 	if (_mission_type != MISSION_TYPE_NONE && is_mission_item_reached()) {
-		set_mission_item_reached();
+
+		/* If we just completed a takeoff which was inserted before the right waypoint,
+		   there is no need to report that we reached it because we didn't. */
+		if (_work_item_type != WORK_ITEM_TYPE_TAKEOFF) {
+			set_mission_item_reached();
+		}
 
 		if (_mission_item.autocontinue) {
 			/* switch to next waypoint if 'autocontinue' flag set */

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -266,6 +266,11 @@ Mission::update_onboard_mission()
 		_navigator->get_mission_result()->valid = true;
 		/* reset mission failure if we have an updated valid mission */
 		_navigator->get_mission_result()->mission_failure = false;
+
+		/* reset reached info as well */
+		_navigator->get_mission_result()->reached = false;
+		_navigator->get_mission_result()->seq_reached = 0;
+
 		_navigator->increment_mission_instance_count();
 		_navigator->set_mission_result_updated();
 
@@ -310,6 +315,10 @@ Mission::update_offboard_mission()
 		if (!failed) {
 			/* reset mission failure if we have an updated valid mission */
 			_navigator->get_mission_result()->mission_failure = false;
+
+			/* reset reached info as well */
+			_navigator->get_mission_result()->reached = false;
+			_navigator->get_mission_result()->seq_reached = 0;
 		}
 
 	} else {
@@ -1206,7 +1215,6 @@ Mission::set_mission_item_reached()
 void
 Mission::set_current_offboard_mission_item()
 {
-	_navigator->get_mission_result()->reached = false;
 	_navigator->get_mission_result()->finished = false;
 	_navigator->get_mission_result()->seq_current = _current_offboard_mission_index;
 	_navigator->set_mission_result_updated();

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -878,7 +878,6 @@ Navigator::publish_mission_result()
 	}
 
 	/* reset some of the flags */
-	_mission_result.seq_reached = false;
 	_mission_result.seq_current = 0;
 	_mission_result.item_do_jump_changed = false;
 	_mission_result.item_changed_index = 0;


### PR DESCRIPTION
Since we can't rely on mavlink that every message arrives, it makes
sense to continuously send the last reached waypoint.

If a new mission is uploaded via QGC, there won't be any new reached message until the first waypoint has been reached again. This can be confusing for a ground station if it doesn't take into account when the last reached message has been sent.

To avoid this, we could consider sending UINT16_MAX to signal "nothing reached".

Tested in SITL.

Additionally, don't report a takeoff which was inserted as reached.