### PR TITLE
fw_att_control_main: fix implicit float to double conversion issue

### DIFF
--- a/src/modules/fw_att_control/fw_att_control_main.cpp
+++ b/src/modules/fw_att_control/fw_att_control_main.cpp
@@ -881,11 +881,11 @@ FixedwingAttitudeControl::task_main()
 
 			/* map flaps by default to manual if valid */
 			if (PX4_ISFINITE(_manual.flaps) && _vcontrol_mode.flag_control_manual_enabled
-			    && fabs(_parameters.flaps_scale) > 0.01) {
+			    && fabsf(_parameters.flaps_scale) > 0.01f) {
 				flap_control = 0.5f * (_manual.flaps + 1.0f) * _parameters.flaps_scale;
 
 			} else if (_vcontrol_mode.flag_control_auto_enabled
-				   && fabs(_parameters.flaps_scale) > 0.01) {
+				   && fabsf(_parameters.flaps_scale) > 0.01f) {
 				flap_control = _att_sp.apply_flaps ? 1.0f * _parameters.flaps_scale : 0.0f;
 			}
 
@@ -902,11 +902,11 @@ FixedwingAttitudeControl::task_main()
 
 			/* map flaperons by default to manual if valid */
 			if (PX4_ISFINITE(_manual.aux2) && _vcontrol_mode.flag_control_manual_enabled
-			    && fabs(_parameters.flaperon_scale) > 0.01) {
+			    && fabsf(_parameters.flaperon_scale) > 0.01f) {
 				flaperon_control = 0.5f * (_manual.aux2 + 1.0f) * _parameters.flaperon_scale;
 
 			} else if (_vcontrol_mode.flag_control_auto_enabled
-				   && fabs(_parameters.flaperon_scale) > 0.01) {
+				   && fabsf(_parameters.flaperon_scale) > 0.01f) {
 				flaperon_control = _att_sp.apply_flaps ? 1.0f * _parameters.flaperon_scale : 0.0f;
 			}
 


### PR DESCRIPTION
GCC 6.1.1 output:
../src/modules/fw_att_control/fw_att_control_main.cpp:884:41: error:
implicit conversion from ‘float’ to ‘double’ to match other operand of
binary expression [-Werror=double-promotion]