### PR TITLE
add HIL_STATE message handler and publish to uORB

### DIFF
--- a/Tools/px_generate_uorb_topic_files.py
+++ b/Tools/px_generate_uorb_topic_files.py
@@ -259,7 +259,12 @@ def convert_dir_save(format_idx, inputdir, outputdir, templatedir, temporarydir,
 
 def generate_topics_list_file(msgdir, outputdir, templatedir):
         # generate cpp file with topics list
-        tl_globals = {"msgs" : get_msgs_list(msgdir)}
+        msgs = get_msgs_list(msgdir)
+        multi_topics = []
+        for msg in msgs:
+            msg_filename = os.path.join(msgdir, msg)
+            multi_topics.extend(get_multi_topics(msg_filename))
+        tl_globals = {"msgs" : msgs, "multi_topics" : multi_topics}
         tl_template_file = os.path.join(templatedir, TOPICS_LIST_TEMPLATE_FILE)
         tl_out_file = os.path.join(outputdir, TOPICS_LIST_TEMPLATE_FILE.replace(".template", ""))
         generate_by_template(tl_out_file, tl_template_file, tl_globals)
@@ -267,7 +272,10 @@ def generate_topics_list_file(msgdir, outputdir, templatedir):
 def generate_topics_list_file_from_files(files, outputdir, templatedir):
         # generate cpp file with topics list
         filenames = [os.path.basename(p) for p in files if os.path.basename(p).endswith(".msg")]
-        tl_globals = {"msgs" : filenames}
+        multi_topics = []
+        for msg_filename in files:
+            multi_topics.extend(get_multi_topics(msg_filename))
+        tl_globals = {"msgs" : filenames, "multi_topics" : multi_topics}
         tl_template_file = os.path.join(templatedir, TOPICS_LIST_TEMPLATE_FILE)
         tl_out_file = os.path.join(outputdir, TOPICS_LIST_TEMPLATE_FILE.replace(".template", ""))
         generate_by_template(tl_out_file, tl_template_file, tl_globals)

--- a/msg/input_rc.msg
+++ b/msg/input_rc.msg
@@ -15,7 +15,6 @@ uint8 RC_INPUT_SOURCE_PX4IO_SUMD = 13
 
 uint8 RC_INPUT_MAX_CHANNELS = 18 	# Maximum number of R/C input channels in the system. S.Bus has up to 18 channels.
 
-uint64 timestamp_publication		# publication time
 uint64 timestamp_last_signal		# last valid reception time
 uint32 channel_count			# number of channels actually being seen
 int32 rssi				# receive signal strength indicator (RSSI): < 0: Undefined, 0: no signal, 100: full reception

--- a/msg/templates/uorb/uORBTopics.cpp.template
+++ b/msg/templates/uorb/uORBTopics.cpp.template
@@ -8,6 +8,7 @@
 @#
 @# Context:
 @#  - msgs (List) list of all msg files
+@#  - multi_topics (List) list of all multi-topic names
 @###############################################
 /****************************************************************************
  *
@@ -45,17 +46,19 @@
 #include <uORB/uORBTopics.h>
 #include <uORB/uORB.h>
 @{
-msgs_count = len(msgs)
 msg_names = [mn.replace(".msg", "") for mn in msgs]
+msgs_count = len(msg_names)
+msg_names_all = list(set(msg_names + multi_topics)) # set() filters duplicates
+msgs_count_all = len(msg_names_all)
 }@
 @[for msg_name in msg_names]@
 #include <uORB/topics/@(msg_name).h>
 @[end for]
 
-const size_t _uorb_topics_count = @(msgs_count);
+const size_t _uorb_topics_count = @(msgs_count_all);
 const struct orb_metadata* _uorb_topics_list[_uorb_topics_count] = { 
-@[for idx, msg_name in enumerate(msg_names, 1)]@
-    ORB_ID(@(msg_name))@[if idx != msgs_count],@[end if]
+@[for idx, msg_name in enumerate(msg_names_all, 1)]@
+    ORB_ID(@(msg_name))@[if idx != msgs_count_all],@[end if]
 @[end for]
 };
 

--- a/msg/vehicle_attitude.msg
+++ b/msg/vehicle_attitude.msg
@@ -18,3 +18,5 @@ float32[4] q		# Quaternion (NED)
 float32[3] g_comp	# Compensated gravity vector
 bool R_valid		# Rotation matrix valid
 bool q_valid		# Quaternion valid
+
+# TOPICS vehicle_attitude vehicle_attitude_groundtruth

--- a/posix-configs/SITL/init/lpe/iris
+++ b/posix-configs/SITL/init/lpe/iris
@@ -73,6 +73,6 @@ mavlink stream -r 50 -s SERVO_OUTPUT_RAW_0 -u 14556
 mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
-sdlog2 start -r 100 -e -t -a
+logger start -e -t
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/lpe/iris
+++ b/posix-configs/SITL/init/lpe/iris
@@ -42,7 +42,7 @@ param set MPC_Z_VEL_I 0.15
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01
 replay tryapplyparams
-simulator start -p
+simulator start -s
 rgbledsim start
 tone_alarm start
 gyrosim start

--- a/posix-configs/SITL/init/lpe/iris
+++ b/posix-configs/SITL/init/lpe/iris
@@ -42,7 +42,7 @@ param set MPC_Z_VEL_I 0.15
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01
 replay tryapplyparams
-simulator start -s
+simulator start -p
 rgbledsim start
 tone_alarm start
 gyrosim start

--- a/src/drivers/navio_sysfs_rc_in/navio_sysfs_rc_in.cpp
+++ b/src/drivers/navio_sysfs_rc_in/navio_sysfs_rc_in.cpp
@@ -197,7 +197,7 @@ void RcInput::_measure(void)
 	}
 
 	ts = hrt_absolute_time();
-	_data.timestamp_publication = ts;
+	_data.timestamp = ts;
 	_data.timestamp_last_signal = ts;
 	_data.channel_count = _channels;
 	_data.rssi = 100;

--- a/src/drivers/pwm_out_rc_in/pwm_out_rc_in.cpp
+++ b/src/drivers/pwm_out_rc_in/pwm_out_rc_in.cpp
@@ -323,7 +323,7 @@ void handle_message(mavlink_message_t *rc_message)
 {
 	mavlink_rc_channels_t rc;
 	mavlink_msg_rc_channels_decode(rc_message, &rc);
-	_rc.timestamp_publication = hrt_absolute_time();
+	_rc.timestamp = hrt_absolute_time();
 	_rc.timestamp_last_signal = hrt_absolute_time();
 	_rc.channel_count = rc.chancount;
 	_rc.rc_lost = false;

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -810,8 +810,8 @@ PX4FMU::fill_rc_in(uint16_t raw_rc_count,
 		}
 	}
 
-	_rc_in.timestamp_publication = now;
-	_rc_in.timestamp_last_signal = _rc_in.timestamp_publication;
+	_rc_in.timestamp = now;
+	_rc_in.timestamp_last_signal = _rc_in.timestamp;
 	_rc_in.rc_ppm_frame_length = 0;
 
 	/* fake rssi if no value was provided */

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1839,7 +1839,7 @@ PX4IO::io_get_raw_rc_input(rc_input_values &input_rc)
 
 	_rc_chan_count = channel_count;
 
-	input_rc.timestamp_publication = hrt_absolute_time();
+	input_rc.timestamp = hrt_absolute_time();
 
 	input_rc.rc_ppm_frame_length = regs[PX4IO_P_RAW_RC_DATA];
 
@@ -1868,7 +1868,7 @@ PX4IO::io_get_raw_rc_input(rc_input_values &input_rc)
 
 	/* rc_lost has to be set before the call to this function */
 	if (!input_rc.rc_lost && !input_rc.rc_failsafe) {
-		_rc_last_valid = input_rc.timestamp_publication;
+		_rc_last_valid = input_rc.timestamp;
 	}
 
 	input_rc.timestamp_last_signal = _rc_last_valid;

--- a/src/drivers/snapdragon_rc_pwm/snapdragon_rc_pwm.cpp
+++ b/src/drivers/snapdragon_rc_pwm/snapdragon_rc_pwm.cpp
@@ -234,7 +234,7 @@ void set_pwm_output(mavlink_actuator_control_target_t *actuator_controls)
 void send_rc_mavlink()
 {
 	mavlink_rc_channels_t rc_message;
-	rc_message.time_boot_ms = _rc.timestamp_publication / 1000;
+	rc_message.time_boot_ms = _rc.timestamp / 1000;
 	rc_message.chancount = _rc.channel_count;
 	rc_message.chan1_raw = (_rc.channel_count > 0) ? _rc.values[0] : UINT16_MAX;
 	rc_message.chan2_raw = (_rc.channel_count > 1) ? _rc.values[1] : UINT16_MAX;

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -475,8 +475,11 @@ bool Logger::copy_if_updated_multi(LoggerSubscription &sub, int multi_instance, 
 
 void Logger::add_default_topics()
 {
-	add_topic("vehicle_attitude", 10);
+#ifdef CONFIG_ARCH_BOARD_SITL
 	add_topic("vehicle_attitude_groundtruth", 10);
+#endif
+
+	add_topic("vehicle_attitude", 10);
 	add_topic("actuator_outputs", 50);
 	add_topic("telemetry_status", 50);
 	add_topic("vehicle_command");

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -476,6 +476,7 @@ bool Logger::copy_if_updated_multi(LoggerSubscription &sub, int multi_instance, 
 void Logger::add_default_topics()
 {
 	add_topic("vehicle_attitude", 10);
+	add_topic("vehicle_attitude_groundtruth", 10);
 	add_topic("actuator_outputs", 50);
 	add_topic("telemetry_status", 50);
 	add_topic("vehicle_command");
@@ -499,6 +500,7 @@ void Logger::add_default_topics()
 	add_topic("vision_position_estimate", 50);
 	add_topic("optical_flow", 50);
 	add_topic("rc_channels");
+	add_topic("input_rc");
 	add_topic("airspeed", 50);
 	add_topic("distance_sensor", 20);
 	add_topic("esc_status", 20);
@@ -656,6 +658,7 @@ void Logger::run()
 
 	/* init the update timer */
 	struct hrt_call timer_call;
+	memset(&timer_call, 0, sizeof(hrt_call));
 	px4_sem_t timer_semaphore;
 	px4_sem_init(&timer_semaphore, 0, 0);
 	hrt_call_every(&timer_call, _log_interval, _log_interval, timer_callback, &timer_semaphore);

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -2645,7 +2645,7 @@ protected:
 			/* send RC channel data and RSSI */
 			mavlink_rc_channels_t msg;
 
-			msg.time_boot_ms = rc.timestamp_publication / 1000;
+			msg.time_boot_ms = rc.timestamp / 1000;
 			msg.chancount = rc.channel_count;
 			msg.chan1_raw = (rc.channel_count > 0) ? rc.values[0] : UINT16_MAX;
 			msg.chan2_raw = (rc.channel_count > 1) ? rc.values[1] : UINT16_MAX;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -788,6 +788,7 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 				} else {
 					/* It's not a pure force setpoint: publish to setpoint triplet  topic */
 					struct position_setpoint_triplet_s pos_sp_triplet = {};
+					pos_sp_triplet.timestamp = hrt_absolute_time();
 					pos_sp_triplet.previous.valid = false;
 					pos_sp_triplet.next.valid = false;
 					pos_sp_triplet.current.valid = true;
@@ -1277,9 +1278,9 @@ MavlinkReceiver::handle_message_rc_channels_override(mavlink_message_t *msg)
 
 	struct rc_input_values rc = {};
 
-	rc.timestamp_publication = hrt_absolute_time();
+	rc.timestamp = hrt_absolute_time();
 
-	rc.timestamp_last_signal = rc.timestamp_publication;
+	rc.timestamp_last_signal = rc.timestamp;
 
 	rc.channel_count = 8;
 
@@ -1336,8 +1337,8 @@ MavlinkReceiver::handle_message_manual_control(mavlink_message_t *msg)
 	if (_mavlink->get_manual_input_mode_generation()) {
 
 		struct rc_input_values rc = {};
-		rc.timestamp_publication = hrt_absolute_time();
-		rc.timestamp_last_signal = rc.timestamp_publication;
+		rc.timestamp = hrt_absolute_time();
+		rc.timestamp_last_signal = rc.timestamp;
 
 		rc.channel_count = 8;
 		rc.rc_failsafe = false;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -622,6 +622,7 @@ Navigator::task_main()
 		}
 
 		if (_pos_sp_triplet_updated) {
+			_pos_sp_triplet.timestamp = hrt_absolute_time();
 			publish_position_setpoint_triplet();
 			_pos_sp_triplet_updated = false;
 		}

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -245,6 +245,7 @@ private:
 #ifndef __PX4_QURT
 		,
 		_rc_channels_pub(nullptr),
+		_attitude_pub(nullptr),
 		_actuator_outputs_sub{},
 		_vehicle_attitude_sub(-1),
 		_manual_sub(-1),
@@ -306,6 +307,7 @@ private:
 #ifndef __PX4_QURT
 	// uORB publisher handlers
 	orb_advert_t _rc_channels_pub;
+	orb_advert_t _attitude_pub;
 
 	// uORB subscription handlers
 	int _actuator_outputs_sub[ORB_MULTI_MAX_INSTANCES];

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -329,10 +329,9 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 			hil_attitude.pitch = euler(0);
 			hil_attitude.yaw = euler(2);
 
-			if (true) {
-				int hilstate_multi;
-				orb_publish_auto(ORB_ID(vehicle_attitude_groundtruth), &_attitude_pub, &hil_attitude, &hilstate_multi, ORB_PRIO_HIGH);
-			}
+			// always publish ground truth attitude message
+			int hilstate_multi;
+			orb_publish_auto(ORB_ID(vehicle_attitude_groundtruth), &_attitude_pub, &hil_attitude, &hilstate_multi, ORB_PRIO_HIGH);
 		}
 		break;
 	}

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -41,6 +41,8 @@
 #include <netinet/in.h>
 #include <pthread.h>
 
+#include <mathlib/mathlib.h>
+
 extern "C" __EXPORT hrt_abstime hrt_reset(void);
 
 #define SEND_INTERVAL 	20
@@ -114,8 +116,8 @@ void Simulator::send_controls()
 
 static void fill_rc_input_msg(struct rc_input_values *rc, mavlink_rc_channels_t *rc_channels)
 {
-	rc->timestamp_publication = hrt_absolute_time();
-	rc->timestamp_last_signal = hrt_absolute_time();
+	rc->timestamp = hrt_absolute_time();
+	rc->timestamp_last_signal = rc->timestamp;
 	rc->channel_count = rc_channels->chancount;
 	rc->rssi = rc_channels->rssi;
 
@@ -301,7 +303,40 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 		}
 
 		break;
+
+	case MAVLINK_MSG_ID_HIL_STATE_QUATERNION:
+		mavlink_hil_state_quaternion_t hil_state;
+		mavlink_msg_hil_state_quaternion_decode(msg, &hil_state);
+
+		uint64_t timestamp = hrt_absolute_time();
+
+		/* attitude */
+		struct vehicle_attitude_s hil_attitude;
+		{
+			hil_attitude.timestamp = timestamp;
+
+			math::Quaternion q(hil_state.attitude_quaternion);
+			math::Matrix<3, 3> C_nb = q.to_dcm();
+			math::Vector<3> euler = C_nb.to_euler();
+
+			hil_attitude.q[0] = q(0);
+			hil_attitude.q[1] = q(1);
+			hil_attitude.q[2] = q(2);
+			hil_attitude.q[3] = q(3);
+			hil_attitude.q_valid = true;
+
+			hil_attitude.roll = euler(1);
+			hil_attitude.pitch = euler(0);
+			hil_attitude.yaw = euler(2);
+
+			if (true) {
+				int hilstate_multi;
+				orb_publish_auto(ORB_ID(vehicle_attitude_groundtruth), &_attitude_pub, &hil_attitude, &hilstate_multi, ORB_PRIO_HIGH);
+			}
+		}
+		break;
 	}
+
 }
 
 void Simulator::send_mavlink_message(const uint8_t msgid, const void *msg, uint8_t component_ID)

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -329,7 +329,7 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 			hil_attitude.pitch = euler(0);
 			hil_attitude.yaw = euler(2);
 
-			if (true) {
+			if (publish) {
 				int hilstate_multi;
 				orb_publish_auto(ORB_ID(vehicle_attitude_groundtruth), &_attitude_pub, &hil_attitude, &hilstate_multi, ORB_PRIO_HIGH);
 			}

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -329,7 +329,7 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 			hil_attitude.pitch = euler(0);
 			hil_attitude.yaw = euler(2);
 
-			if (publish) {
+			if (true) {
 				int hilstate_multi;
 				orb_publish_auto(ORB_ID(vehicle_attitude_groundtruth), &_attitude_pub, &hil_attitude, &hilstate_multi, ORB_PRIO_HIGH);
 			}

--- a/src/platforms/qurt/fc_addon/rc_receiver/rc_receiver_main.cpp
+++ b/src/platforms/qurt/fc_addon/rc_receiver/rc_receiver_main.cpp
@@ -248,8 +248,8 @@ void task_main(int argc, char *argv[])
 
 		// populate the input_rc_s structure
 		if (ret == 0) {
-			_rc_in.timestamp_publication = ts;
-			_rc_in.timestamp_last_signal = _rc_in.timestamp_publication;
+			_rc_in.timestamp = ts;
+			_rc_in.timestamp_last_signal = _rc_in.timestamp;
 			_rc_in.channel_count = num_channels;
 
 			// TODO - need to add support for RSSI, failsafe mode

--- a/src/systemcmds/mixer/mixer.cpp
+++ b/src/systemcmds/mixer/mixer.cpp
@@ -91,7 +91,7 @@ mixer_main(int argc, char *argv[])
 		int ret = load(argv[2], argv[3], true);
 
 		if (ret != 0) {
-			warnx("failed to append mixer");
+			PX4_ERR("failed to append mixer");
 			return 1;
 		}
 
@@ -124,14 +124,14 @@ load(const char *devname, const char *fname, bool append)
 
 	/* open the device */
 	if ((dev = px4_open(devname, 0)) < 0) {
-		warnx("can't open %s\n", devname);
+		PX4_ERR("can't open %s\n", devname);
 		return 1;
 	}
 
 	/* reset mixers on the device, but not if appending */
 	if (!append) {
 		if (px4_ioctl(dev, MIXERIOCRESET, 0)) {
-			warnx("can't reset mixers on %s", devname);
+			PX4_ERR("can't reset mixers on %s", devname);
 			return 1;
 		}
 	}
@@ -139,7 +139,7 @@ load(const char *devname, const char *fname, bool append)
 	char buf[2048];
 
 	if (load_mixer_file(fname, &buf[0], sizeof(buf)) < 0) {
-		warnx("can't load mixer: %s", fname);
+		PX4_ERR("can't load mixer: %s", fname);
 		return 1;
 	}
 
@@ -147,7 +147,7 @@ load(const char *devname, const char *fname, bool append)
 	int ret = px4_ioctl(dev, MIXERIOCLOADBUF, (unsigned long)buf);
 
 	if (ret < 0) {
-		warnx("error loading mixers from %s", fname);
+		PX4_ERR("error loading mixers from %s", fname);
 		return 1;
 	}
 


### PR DESCRIPTION
@bkueng Incorporates https://github.com/PX4/Firmware/pull/5323

add missing break

uorb topics generator: add multi-topics to the list of all topics

topic names with '# TOPICS <name>' were previously not in orb_get_topics().
This means the logger could not find them.

Affects for example actuator_controls_0.

px_generate_uorb_topic_files.py: add multitopics to generate_topics_list_file_from_files method

switch simulated attitude to new topic: vehicle_attitude_groundtruth

logger: add input_rc topic. needed for web plotting

input_rc.msg: remove timestamp_publication, use timestamp instead

mixer.cpp: warnx -> PX4_ERR

logger: initialize timer_call to 0 (hrt_call_every reads some fields)

position_setpoint_triplet topic: set the timestamp when publishing

px_generate_uorb_topic_files.py: add multitopics to generate_topics_list_file_from_files method

add vehicle_attitude_groundtruth to default topics

change to hil_state_quaternion