### PR TITLE
navigator: reset cruise speed when out of mission

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -101,6 +101,11 @@ Mission::~Mission()
 void
 Mission::on_inactive()
 {
+	/* We need to reset the mission cruising speed, otherwise the
+	 * mission velocity which might have been set using mission items
+	 * is used for missions such as RTL. */
+	_navigator->set_cruising_speed();
+
 	/* Without home a mission can't be valid yet anyway, let's wait. */
 	if (!_navigator->home_position_valid()) {
 		return;


### PR DESCRIPTION
This reset the cruise speed which can be set by mission items/waypoints
to set a custom speed. Once, switched out of mission, it makes sense to
use the speed set by the param again.

FYI @LorenzMeier as discussed.

Tested in SITL.