### PR TITLE
Fix some pthread related linker stuff (px4_os_add_flags)

### DIFF
--- a/cmake/nuttx/px4_impl_nuttx.cmake
+++ b/cmake/nuttx/px4_impl_nuttx.cmake
@@ -389,6 +389,10 @@ endfunction()
 #		LINK_DIRS				: link directories
 #		DEFINITIONS				: definitions
 #
+#	Note that EXE_LINKER_FLAGS is not suitable for adding libraries because
+#	these flags are added before any of the object files and static libraries.
+#	Add libraries in src/firmware/nuttx/CMakeLists.txt.
+#
 #	Example:
 #		px4_os_add_flags(
 #			C_FLAGS CMAKE_C_FLAGS

--- a/cmake/qurt/px4_impl_qurt.cmake
+++ b/cmake/qurt/px4_impl_qurt.cmake
@@ -126,6 +126,10 @@ endfunction()
 #		LINK_DIRS				: link directories
 #		DEFINITIONS				: definitions
 #
+#	Note that EXE_LINKER_FLAGS is not suitable for adding libraries because
+#	these flags are added before any of the object files and static libraries.
+#	Add libraries in src/firmware/qurt/CMakeLists.txt.
+#
 #	Example:
 #		px4_os_add_flags(
 #			C_FLAGS CMAKE_C_FLAGS


### PR DESCRIPTION
The px4_os_add_flags defined in cmake/posix/px4_impl_posix.cmake did
add (threading) libraries to added_exe_linker_flags, which subsequently
end up in CMAKE_EXE_LINKER_FLAGS and then have no effect because those
flags are passed to the linker before any of the object files and static
libraries.

Those libraries are already added correctly in the corresponding
src/firmware/*/CMakeLists.txt files (for qurt, nuttx AND posix).

I left in the non-library linker flag '-pthread' for the bebop board,
although it seems very weird to me that this is needed (is it?).
If that is needed then it seems weird to link manually (that is,
src/firmware/*/CMakeLists.txt) with -lpthread.

For linux/g++ -pthread is added to the CXXFLAGS as it should be:
this causes the compiler to define _REENTRANT which is needed
for (the interface of) certain libraries to become thread-safe.
Offically one also can just pass -pthread to the linker, which then
causes the right libraries to be linked, but just linking with
-lpthread -lm -lrt works too.

I ran into this while adding support for libcwd, which explicitly
complains that _REENTRANT isn't defined when trying to link with
the thread-safe version of libcwd (-lcwd_r) and then tells you
to use -pthread.