### PR TITLE
LPE switch to velocity based optical flow

### DIFF
--- a/launch/mavros.launch
+++ b/launch/mavros.launch
@@ -6,11 +6,13 @@
     <arg name="gcs_url" default="udp://:14550@:14555" />
     <arg name="tgt_system" default="1" />
     <arg name="tgt_component" default="1" />
+    <arg name="pluginlists_yaml" default="$(find mavros)/launch/px4_pluginlists.yaml" />
+    <arg name="config_yaml" default="$(find mavros)/launch/px4_config.yaml" />
 
     <group ns="$(arg ns)">
         <include file="$(find mavros)/launch/node.launch">
-            <arg name="pluginlists_yaml" value="$(find mavros)/launch/px4_pluginlists.yaml" />
-            <arg name="config_yaml" value="$(find mavros)/launch/px4_config.yaml" />
+            <arg name="pluginlists_yaml" value="$(arg pluginlists_yaml)" />
+            <arg name="config_yaml" value="$(arg config_yaml)" />
 
             <arg name="fcu_url" value="$(arg fcu_url)" />
             <arg name="gcs_url" value="$(arg gcs_url)" />
@@ -19,3 +21,5 @@
         </include>
     </group>
 </launch>
+
+<!-- vim: set ft=xml et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : -->

--- a/launch/mavros_posix_sitl.launch
+++ b/launch/mavros_posix_sitl.launch
@@ -25,6 +25,9 @@
     <arg name="verbose" default="false"/>
     <arg name="paused" default="false"/>
 
+    <arg name="pluginlists_yaml" default="$(find mavros)/launch/px4_pluginlists.yaml" />
+    <arg name="config_yaml" default="$(find mavros)/launch/px4_config.yaml" />
+
     <include file="$(find px4)/launch/posix_sitl.launch">
         <arg name="x" value="$(arg x)"/>
         <arg name="y" value="$(arg y)"/>
@@ -48,6 +51,8 @@
         <arg name="ns" value="$(arg ns)"/>
         <arg name="gcs_url" value=""/> <!-- GCS link is provided by SITL -->
         <arg name="fcu_url" value="$(arg fcu_url)"/>
+        <arg name="pluginlists_yaml" value="$(arg pluginlists_yaml)" />
+        <arg name="config_yaml" value="$(arg config_yaml)" />
     </include>
 </launch>
 

--- a/launch/posix_sitl.launch
+++ b/launch/posix_sitl.launch
@@ -6,8 +6,7 @@
     <arg name="z" default="0"/>
     <arg name="R" default="0"/>
     <arg name="P" default="0"/>
-    <arg name="Y" default="0"/>
-
+    <arg name="Y" default="0"/> 
     <arg name="est" default="lpe"/>
     <arg name="vehicle" default="iris"/>
     <arg name="world" default="$(find mavlink_sitl_gazebo)/worlds/empty.world"/>

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -126,7 +126,7 @@ public:
 	enum {U_ax = 0, U_ay, U_az, n_u};
 	enum {Y_baro_z = 0, n_y_baro};
 	enum {Y_lidar_z = 0, n_y_lidar};
-	enum {Y_flow_x = 0, Y_flow_y, n_y_flow};
+	enum {Y_flow_vx = 0, Y_flow_vy, n_y_flow};
 	enum {Y_sonar_z = 0, n_y_sonar};
 	enum {Y_gps_x = 0, Y_gps_y, Y_gps_z, Y_gps_vx, Y_gps_vy, Y_gps_vz, n_y_gps};
 	enum {Y_vision_x = 0, Y_vision_y, Y_vision_z, n_y_vision};
@@ -244,7 +244,8 @@ private:
 	struct map_projection_reference_s _map_ref;
 
 	// general parameters
-	BlockParamFloat  _xy_pub_thresh;
+	BlockParamInt  _pub_agl_z;
+	BlockParamFloat  _vxy_pub_thresh;
 	BlockParamFloat  _z_pub_thresh;
 
 	// sonar parameters
@@ -281,9 +282,11 @@ private:
 	BlockParamFloat  _mocap_p_stddev;
 
 	// flow parameters
+	BlockParamInt  _flow_gyro_comp;
 	BlockParamFloat  _flow_z_offset;
-	BlockParamFloat  _flow_xy_stddev;
-	BlockParamFloat  _flow_xy_d_stddev;
+	BlockParamFloat  _flow_vxy_stddev;
+	BlockParamFloat  _flow_vxy_d_stddev;
+	BlockParamFloat  _flow_vxy_r_stddev;
 	//BlockParamFloat  _flow_board_x_offs;
 	//BlockParamFloat  _flow_board_y_offs;
 	BlockParamInt    _flow_min_q;
@@ -351,12 +354,6 @@ private:
 	bool _altOriginInitialized;
 	float _baroAltOrigin;
 	float _gpsAltOrigin;
-	Vector3f _visionOrigin;
-	Vector3f _mocapOrigin;
-
-	// flow integration
-	float _flowX;
-	float _flowY;
 
 	// status
 	bool _validXY;

--- a/src/modules/local_position_estimator/params.c
+++ b/src/modules/local_position_estimator/params.c
@@ -2,6 +2,13 @@
 
 // 16 is max name length
 
+/**
+ * Publish AGL as Z
+ *
+ * @group Local Position Estimator
+ * @boolean
+ */
+PARAM_DEFINE_FLOAT(LPE_PUB_AGL_Z, 0);
 
 /**
  * Optical flow z offset from center
@@ -15,7 +22,18 @@
 PARAM_DEFINE_FLOAT(LPE_FLW_OFF_Z, 0.0f);
 
 /**
- * Optical flow xy standard deviation.
+ * Optical flow gyro compensation
+ *
+ * @group Local Position Estimator
+ * @unit m
+ * @min -1
+ * @max 1
+ * @decimal 3
+ */
+PARAM_DEFINE_INT32(LPE_FLW_GYRO_CMP, 1);
+
+/**
+ * Optical flow xy velocity standard deviation.
  *
  * @group Local Position Estimator
  * @unit m
@@ -23,10 +41,10 @@ PARAM_DEFINE_FLOAT(LPE_FLW_OFF_Z, 0.0f);
  * @max 1
  * @decimal 3
  */
-PARAM_DEFINE_FLOAT(LPE_FLW_XY, 0.01f);
+PARAM_DEFINE_FLOAT(LPE_FLW_VXY, 0.04f);
 
 /**
- * Optical flow xy standard deviation linear factor on distance
+ * Optical flow xy velocity standard deviation linear factor on distance
  *
  * @group Local Position Estimator
  * @unit m / m
@@ -34,7 +52,18 @@ PARAM_DEFINE_FLOAT(LPE_FLW_XY, 0.01f);
  * @max 1
  * @decimal 3
  */
-PARAM_DEFINE_FLOAT(LPE_FLW_XY_D, 0.01f);
+PARAM_DEFINE_FLOAT(LPE_FLW_VXY_D, 0.04f);
+
+/**
+ * Optical flow xy velocity standard deviation linear factor on rotation rate
+ *
+ * @group Local Position Estimator
+ * @unit m / m
+ * @min 0.01
+ * @max 1
+ * @decimal 3
+ */
+PARAM_DEFINE_FLOAT(LPE_FLW_VXY_R, 1.0f);
 
 /**
  * Optical flow minimum quality threshold
@@ -44,7 +73,7 @@ PARAM_DEFINE_FLOAT(LPE_FLW_XY_D, 0.01f);
  * @max 255
  * @decimal 0
  */
-PARAM_DEFINE_INT32(LPE_FLW_QMIN, 75);
+PARAM_DEFINE_INT32(LPE_FLW_QMIN, 150);
 
 /**
  * Sonar z standard deviation.
@@ -225,7 +254,7 @@ PARAM_DEFINE_FLOAT(LPE_EPV_MAX, 5.0f);
  * @max 1
  * @decimal 3
  */
-PARAM_DEFINE_FLOAT(LPE_VIS_XY, 0.5f);
+PARAM_DEFINE_FLOAT(LPE_VIS_XY, 0.1f);
 
 /**
  * Vision z standard deviation.
@@ -328,7 +357,7 @@ PARAM_DEFINE_FLOAT(LPE_T_MAX_GRADE, 1.0f);
  * @max 2
  * @decimal 3
  */
-PARAM_DEFINE_FLOAT(LPE_FGYRO_HP, 0.1f);
+PARAM_DEFINE_FLOAT(LPE_FGYRO_HP, 0.001f);
 
 /**
  * Local origin latitude for nav w/o GPS
@@ -364,15 +393,15 @@ PARAM_DEFINE_FLOAT(LPE_LON, -86.929);
 PARAM_DEFINE_FLOAT(LPE_X_LP, 5.0f);
 
 /**
- * Required xy standard deviation to publish position
+ * Required velocity xy standard deviation to publish position
  *
  * @group Local Position Estimator
- * @unit m
- * @min 0.3
- * @max 5.0
- * @decimal 1
+ * @unit m/s
+ * @min 0.01
+ * @max 1.0
+ * @decimal 3
  */
-PARAM_DEFINE_FLOAT(LPE_XY_PUB, 1.0f);
+PARAM_DEFINE_FLOAT(LPE_VXY_PUB, 0.1f);
 
 /**
  * Required z standard deviation to publish altitude/ terrain

--- a/src/modules/local_position_estimator/sensors/lidar.cpp
+++ b/src/modules/local_position_estimator/sensors/lidar.cpp
@@ -49,10 +49,12 @@ int BlockLocalPositionEstimator::lidarMeasure(Vector<float, n_y_lidar> &y)
 	}
 
 	// update stats
-	_lidarStats.update(Scalarf(d + _lidar_z_offset.get()));
+	_lidarStats.update(Scalarf(d));
 	_time_last_lidar = _timeStamp;
 	y.setZero();
-	y(0) = d;
+	y(0) = (d + _lidar_z_offset.get()) *
+	       cosf(_sub_att.get().roll) *
+	       cosf(_sub_att.get().pitch);
 	return OK;
 }
 
@@ -62,11 +64,6 @@ void BlockLocalPositionEstimator::lidarCorrect()
 	Vector<float, n_y_lidar> y;
 
 	if (lidarMeasure(y) != OK) { return; }
-
-	// account for leaning
-	y(0) = y(0) *
-	       cosf(_sub_att.get().roll) *
-	       cosf(_sub_att.get().pitch);
 
 	// measurement matrix
 	Matrix<float, n_y_lidar, n_x> C;

--- a/src/modules/local_position_estimator/sensors/mocap.cpp
+++ b/src/modules/local_position_estimator/sensors/mocap.cpp
@@ -21,7 +21,6 @@ void BlockLocalPositionEstimator::mocapInit()
 
 	// if finished
 	if (_mocapStats.getCount() > REQ_MOCAP_INIT_COUNT) {
-		_mocapOrigin = _mocapStats.getMean();
 		mavlink_and_console_log_info(&mavlink_log_pub, "[lpe] mocap position init: "
 					     "%5.2f, %5.2f, %5.2f m std %5.2f, %5.2f, %5.2f m",
 					     double(_mocapStats.getMean()(0)),
@@ -35,7 +34,7 @@ void BlockLocalPositionEstimator::mocapInit()
 
 		if (!_altOriginInitialized) {
 			_altOriginInitialized = true;
-			_altOrigin = _mocapOrigin(2);
+			_altOrigin = 0;
 		}
 	}
 }
@@ -57,9 +56,6 @@ void BlockLocalPositionEstimator::mocapCorrect()
 	Vector<float, n_y_mocap> y;
 
 	if (mocapMeasure(y) != OK) { return; }
-
-	// make measurement relative to origin
-	y -= _mocapOrigin;
 
 	// mocap measurement matrix, measures position
 	Matrix<float, n_y_mocap, n_x> C;

--- a/src/modules/local_position_estimator/sensors/vision.cpp
+++ b/src/modules/local_position_estimator/sensors/vision.cpp
@@ -6,8 +6,13 @@ extern orb_advert_t mavlink_log_pub;
 
 // required number of samples for sensor
 // to initialize
-static const uint32_t 		REQ_VISION_INIT_COUNT = 20;
-static const uint32_t 		VISION_TIMEOUT =    500000;	// 0.5 s
+
+// this is a vision based position measurement so we assume as soon as we get one
+// measurement it is initialized, we also don't want to deinitialize it because
+// this will throw away a correction before it starts using the data so we
+// set the timeout to 10 seconds
+static const uint32_t 		REQ_VISION_INIT_COUNT = 1;
+static const uint32_t 		VISION_TIMEOUT =    10000000;	// 10 s
 
 void BlockLocalPositionEstimator::visionInit()
 {
@@ -21,7 +26,6 @@ void BlockLocalPositionEstimator::visionInit()
 
 	// increament sums for mean
 	if (_visionStats.getCount() > REQ_VISION_INIT_COUNT) {
-		_visionOrigin = _visionStats.getMean();
 		mavlink_and_console_log_info(&mavlink_log_pub, "[lpe] vision position init: "
 					     "%5.2f %5.2f %5.2f m std %5.2f %5.2f %5.2f m",
 					     double(_visionStats.getMean()(0)),
@@ -35,7 +39,7 @@ void BlockLocalPositionEstimator::visionInit()
 
 		if (!_altOriginInitialized) {
 			_altOriginInitialized = true;
-			_altOrigin = _visionOrigin(2);
+			_altOrigin = 0;
 		}
 	}
 }
@@ -57,9 +61,6 @@ void BlockLocalPositionEstimator::visionCorrect()
 	Vector<float, n_y_vision> y;
 
 	if (visionMeasure(y) != OK) { return; }
-
-	// make measurement relative to origin
-	y -= _visionOrigin;
 
 	// vision measurement matrix, measures position
 	Matrix<float, n_y_vision, n_x> C;


### PR DESCRIPTION
This switches LPE from treating optical flow as a position measurement and keeping the integrated state to just treating it as a velocity measurement.  This makes it work more easily with external vision measurements. I just flew this in position hold at 100 ft with only sonar, so it is very robust. I also manually increased the px4flow autoexposure maximum to get this kind of performance, for some reason the default is set very low.

I've also been flying this branch in gazebo simulations with external vision measurements and it works well.

@mhkabir probably will be useful to you