### PR TITLE
Fix VTOL status in forward transition for tiltrotor models

### DIFF
--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -244,7 +244,7 @@ void Tiltrotor::update_vtol_state()
 
 	case TRANSITION_FRONT_P1:
 	case TRANSITION_FRONT_P2:
-		_vtol_mode = TRANSITION_TO_MC;
+		_vtol_mode = TRANSITION_TO_FW;
 		break;
 
 	case TRANSITION_BACK:


### PR DESCRIPTION
Sets the correct mode for tiltrotors when in transition from multicopter to fixed-wing mode. 

In this kind of vehicles `TRANSITION_FRONT_P1` and `TRANSITION_FRONT_P2` stand for two different phases of the transition from MC to FW, and not of the transition from FW to MC as it was coded.