### PR TITLE
CF2: Unique board id

### DIFF
--- a/Images/crazyflie.prototype
+++ b/Images/crazyflie.prototype
@@ -1,5 +1,5 @@
 {
-    "board_id": 5, 
+    "board_id": 12, 
     "magic": "Crazyflie", 
     "description": "Firmware for the Crazyflie 2.0", 
     "image": "", 


### PR DESCRIPTION
The old id seemed to be the same as the one used by the FMUv1

Merge with corresponding Bootloader PR