### PR TITLE
CF2: Syslink properly working address params

### DIFF
--- a/src/modules/syslink/syslink_main.cpp
+++ b/src/modules/syslink/syslink_main.cpp
@@ -254,13 +254,15 @@ Syslink::task_main()
 	param_t _param_radio_addr1 = param_find("SLNK_RADIO_ADDR1");
 	param_t _param_radio_addr2 = param_find("SLNK_RADIO_ADDR2");
 
-	uint32_t channel, rate;
+	uint32_t channel, rate, addr1, addr2;
 	uint64_t addr = 0;
 
 	param_get(_param_radio_channel, &channel);
 	param_get(_param_radio_rate, &rate);
-	param_get(_param_radio_addr1, &addr + 4);
-	param_get(_param_radio_addr2, &addr);
+	param_get(_param_radio_addr1, &addr1);
+	param_get(_param_radio_addr2, &addr2);
+
+	memcpy(&addr, &addr2, 4); memcpy(((char *)&addr) + 4, &addr1, 4);
 
 	_bridge = new SyslinkBridge(this);
 	_bridge->init();
@@ -291,10 +293,8 @@ Syslink::task_main()
 
 	px4_arch_configgpio(GPIO_NRF_TXEN);
 
-	set_datarate(rate);
-	usleep(1000);
 	set_channel(channel);
-	usleep(1000);
+	set_datarate(rate);
 	set_address(addr);
 
 

--- a/src/modules/syslink/syslink_params.c
+++ b/src/modules/syslink/syslink_params.c
@@ -66,11 +66,11 @@ PARAM_DEFINE_INT32(SLNK_RADIO_RATE, 2);
  *
  * @group Syslink
  */
-PARAM_DEFINE_INT32(SLNK_RADIO_ADDR1, (uint32_t) 0xE7);
+PARAM_DEFINE_INT32(SLNK_RADIO_ADDR1, 231); // 0xE7
 
 /**
  * Operating address of the NRF51 (least significant 4 bytes)
  *
  * @group Syslink
  */
-PARAM_DEFINE_INT32(SLNK_RADIO_ADDR2, (uint32_t) 0xE7E7E7E7);
+PARAM_DEFINE_INT32(SLNK_RADIO_ADDR2, 3890735079); // 0xE7E7E7E7


### PR DESCRIPTION
Fixes an issue affecting newly purchases CF2s (http://discuss.px4.io/t/crazyflie-cannot-upload-firmware/1262)