### PR TITLE
fix the issue that UAV can't be armed when disarm_when_landed > 0

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2055,13 +2055,11 @@ int commander_thread_main(int argc, char *argv[])
 				}
 			}
 
-
-			was_landed = land_detector.landed;
 			was_falling = land_detector.freefall;
 		}
 
 		// Check for auto-disarm
-		if (armed.armed && land_detector.landed && disarm_when_landed > 0) {
+		if (!was_landed && land_detector.landed && disarm_when_landed > 0) {
 			auto_disarm_hysteresis.set_state_and_update(true);
 		} else {
 			auto_disarm_hysteresis.set_state_and_update(false);
@@ -2780,6 +2778,7 @@ int commander_thread_main(int argc, char *argv[])
 			commander_set_home_position(home_pub, _home, local_position, global_position, attitude);
 		}
 
+		was_landed = land_detector.landed;
 		was_armed = armed.armed;
 
 		/* print new state */


### PR DESCRIPTION
when parameter "COM_DISARM_LAND" > 0(disarm_when_landed > 0, assume it equal to 1), auto disarm will be enabled if landed, when you arm by RC, armed, because the UAV is still landed, after 1 second, the UAV disarmed. the issue code like below:
if (armed.armed && land_detector.landed && disarm_when_landed > 0) {
 		auto_disarm_hysteresis.set_state_and_update(true);
}