### PR TITLE
commander: fix the issue that UAV can't be armed when COM_DISARM_LAND > 0 

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1198,7 +1198,7 @@ int commander_thread_main(int argc, char *argv[])
 	bool was_armed = false;
 
 	bool startup_in_hil = false;
-    bool start_disarm = false;
+	bool auto_disarm_enable = false; //the flag indicate enable auto disarm when the vehicle state from inair to land
 
 	// XXX for now just set sensors as initialized
 	status_flags.condition_system_sensors_initialized = true;
@@ -2044,15 +2044,15 @@ int commander_thread_main(int argc, char *argv[])
 
 			if (was_landed != land_detector.landed) {
 				if (land_detector.landed) {
-                    // Check for auto-disarm
-                    if (disarm_when_landed > 0) {
-                        start_disarm = true;
-                        auto_disarm_hysteresis.set_state_and_update(true);
-                    }
+					// Check for auto-disarm
+					if (disarm_when_landed > 0) {
+						auto_disarm_enable = true;
+						auto_disarm_hysteresis.set_state_and_update(true);
+					}
 					mavlink_and_console_log_info(&mavlink_log_pub, "Landing detected");
 				} else {
-                    start_disarm = false;
-                    auto_disarm_hysteresis.set_state_and_update(false);
+					auto_disarm_enable = false;
+					auto_disarm_hysteresis.set_state_and_update(false);
 					mavlink_and_console_log_info(&mavlink_log_pub, "Takeoff detected");
 				}
 			}
@@ -2066,14 +2066,14 @@ int commander_thread_main(int argc, char *argv[])
 			was_falling = land_detector.freefall;
 		}
 
-        if (start_disarm && land_detector.landed) {
-            auto_disarm_hysteresis.update();
-        }
+		if (auto_disarm_enable && land_detector.landed) {
+			auto_disarm_hysteresis.update();
+		}
 
 		if (auto_disarm_hysteresis.get_state()) {
 			arm_disarm(false, &mavlink_log_pub, "auto disarm on land");
-            start_disarm = false;
-            auto_disarm_hysteresis.set_state_and_update(false);
+			auto_disarm_enable = false;
+			auto_disarm_hysteresis.set_state_and_update(false);
 		}
 
 		if (!warning_action_on) {
@@ -2786,7 +2786,7 @@ int commander_thread_main(int argc, char *argv[])
 		}
 
 		was_armed = armed.armed;
-        was_landed = land_detector.landed;
+		was_landed = land_detector.landed;
 
 		/* print new state */
 		if (arming_state_changed) {


### PR DESCRIPTION
when parameter "COM_DISARM_LAND" > 0(disarm_when_landed > 0, assume it equal to 1), auto disarm will be enabled if landed, when you arm by RC, armed, because the UAV is still landed, after 1 second, the UAV disarmed. the issue code like below:
if (armed.armed && land_detector.landed && disarm_when_landed > 0) {
auto_disarm_hysteresis.set_state_and_update(true);
}
@dagar I fix it again, and verify it through fly