### PR TITLE
Master additional targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,9 @@ FIRST_ARG := $(firstword $(MAKECMDGOALS))
 ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 j ?= 4
 
+ifndef NO_NINJA_BUILD
 NINJA_BUILD := $(shell ninja --version 2>/dev/null)
+endif
 ifdef NINJA_BUILD
     PX4_CMAKE_GENERATOR ?= "Ninja"
     PX4_MAKE = ninja

--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,8 @@ $(ALL_CONFIG_TARGETS):
 $(NUTTX_CONFIG_TARGETS):
 	$(call cmake-build,nuttx_$@)
 
+all_nuttx_targets: $(NUTTX_CONFIG_TARGETS)
+
 posix: posix_sitl_default
 broadcast: posix_sitl_broadcast
 


### PR DESCRIPTION
@LorenzMeier 

2 small tweaks to make file.

1) First allows ```NO_NINJA_BUILD=1 make <target>``` - for build debugging
2) adds all_nuttx_targets to build all nuttx configs targets - this is useful to build as build checks for nuttx. 

and solves https://github.com/PX4/Firmware/pull/5373#issuecomment-245360623