### PR TITLE
Only optimize for size on NuttX

### DIFF
--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -668,7 +668,9 @@ function(px4_add_common_flags)
 
 	if ($ENV{MEMORY_DEBUG} MATCHES "1")
 		message(STATUS "address sanitizer enabled")
-		set(max_optimization -Os)
+		if ("${OS}" STREQUAL "nuttx")
+			set(max_optimization -Os)
+		endif()
 
 		# Do not use optimization_flags (without _) as that is already used.
 		set(_optimization_flags
@@ -680,7 +682,11 @@ function(px4_add_common_flags)
 			-g3 -fsanitize=address
 			)
 	else()
-		set(max_optimization -Os)
+		if ("${OS}" STREQUAL "nuttx")
+			set(max_optimization -Os)
+		else()
+			set(max_optimization -O2)
+		endif()
 
 		if ("${OS}" STREQUAL "qurt")
 			set(PIC_FLAG -fPIC)

--- a/src/drivers/airspeed/CMakeLists.txt
+++ b/src/drivers/airspeed/CMakeLists.txt
@@ -33,10 +33,9 @@
 px4_add_module(
 	MODULE drivers__airspeed
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		airspeed.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/ardrone_interface/CMakeLists.txt
+++ b/src/drivers/ardrone_interface/CMakeLists.txt
@@ -35,11 +35,10 @@ px4_add_module(
 	MAIN ardrone_interface
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		ardrone_interface.c
 		ardrone_motor_control.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/batt_smbus/CMakeLists.txt
+++ b/src/drivers/batt_smbus/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE drivers__batt_smbus
 	MAIN batt_smbus
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		batt_smbus.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/blinkm/CMakeLists.txt
+++ b/src/drivers/blinkm/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE drivers__blinkm
 	MAIN blinkm
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		blinkm.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/bma180/CMakeLists.txt
+++ b/src/drivers/bma180/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE drivers__bma180
 	MAIN bma180
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		bma180.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/bmi160/CMakeLists.txt
+++ b/src/drivers/bmi160/CMakeLists.txt
@@ -36,7 +36,6 @@ px4_add_module(
 	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Weffc++
-		-Os
 	SRCS
 		bmi160.cpp
 		bmi160_gyro.cpp
@@ -44,4 +43,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/bmp280/CMakeLists.txt
+++ b/src/drivers/bmp280/CMakeLists.txt
@@ -35,11 +35,10 @@ px4_add_module(
 	MODULE drivers__bmp280
 	MAIN bmp280
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		bmp280_spi.cpp
 		bmp280.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/boards/aerocore/CMakeLists.txt
+++ b/src/drivers/boards/aerocore/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__boards__aerocore
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		../common/board_name.c
 		aerocore_init.c

--- a/src/drivers/boards/asc-v1/CMakeLists.txt
+++ b/src/drivers/boards/asc-v1/CMakeLists.txt
@@ -34,7 +34,6 @@
 px4_add_module(
 	MODULE drivers__boards__asc-v1
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		../common/board_name.c
 		asc_init.c
@@ -45,4 +44,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/boards/mindpx-v2/CMakeLists.txt
+++ b/src/drivers/boards/mindpx-v2/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__boards__mindpx-v2
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		../common/board_dma_alloc.c
 		../common/board_name.c
@@ -46,4 +45,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/boards/px4fmu-v1/CMakeLists.txt
+++ b/src/drivers/boards/px4fmu-v1/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__boards__px4fmu-v1
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		../common/board_name.c
 		px4fmu_can.c
@@ -45,4 +44,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/boards/px4fmu-v2/CMakeLists.txt
+++ b/src/drivers/boards/px4fmu-v2/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__boards__px4fmu-v2
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		../common/board_name.c
 		../common/board_dma_alloc.c

--- a/src/drivers/boards/px4fmu-v4/CMakeLists.txt
+++ b/src/drivers/boards/px4fmu-v4/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__boards__px4fmu-v4
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		../common/board_name.c
 		../common/board_dma_alloc.c
@@ -46,4 +45,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/boards/px4io-v1/CMakeLists.txt
+++ b/src/drivers/boards/px4io-v1/CMakeLists.txt
@@ -33,11 +33,10 @@
 px4_add_module(
 	MODULE drivers__boards__px4io-v1
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		px4io_init.c
 		px4io_timer_config.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/boards/px4io-v2/CMakeLists.txt
+++ b/src/drivers/boards/px4io-v2/CMakeLists.txt
@@ -33,11 +33,10 @@
 px4_add_module(
 	MODULE drivers__boards__px4io-v2
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		px4iov2_init.c
 		px4iov2_timer_config.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/boards/sitl/CMakeLists.txt
+++ b/src/drivers/boards/sitl/CMakeLists.txt
@@ -33,10 +33,9 @@
 px4_add_module(
 	MODULE drivers__boards__sitl
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		sitl_led.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/boards/tap-v1/CMakeLists.txt
+++ b/src/drivers/boards/tap-v1/CMakeLists.txt
@@ -34,7 +34,6 @@
 px4_add_module(
 	MODULE drivers__boards__tap-v1
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		../common/board_name.c
 		tap_init.c
@@ -48,4 +47,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/bst/CMakeLists.txt
+++ b/src/drivers/bst/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN bst
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		bst.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/camera_trigger/CMakeLists.txt
+++ b/src/drivers/camera_trigger/CMakeLists.txt
@@ -35,7 +35,6 @@ px4_add_module(
 	MAIN camera_trigger
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		camera_trigger.cpp
 		camera_trigger_params.c
@@ -45,4 +44,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/ets_airspeed/CMakeLists.txt
+++ b/src/drivers/ets_airspeed/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN ets_airspeed
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		ets_airspeed.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/frsky_telemetry/CMakeLists.txt
+++ b/src/drivers/frsky_telemetry/CMakeLists.txt
@@ -35,7 +35,6 @@ px4_add_module(
 	MAIN frsky_telemetry
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		frsky_data.c
 		sPort_data.c

--- a/src/drivers/gps/CMakeLists.txt
+++ b/src/drivers/gps/CMakeLists.txt
@@ -35,7 +35,6 @@ px4_add_module(
 	MAIN gps
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		gps.cpp
 		devices/src/gps_helper.cpp

--- a/src/drivers/hc_sr04/CMakeLists.txt
+++ b/src/drivers/hc_sr04/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN hc_sr04
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		hc_sr04.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/hmc5883/CMakeLists.txt
+++ b/src/drivers/hmc5883/CMakeLists.txt
@@ -36,7 +36,6 @@ px4_add_module(
 	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Weffc++
-		-Os
 	SRCS
 		hmc5883_i2c.cpp
 		hmc5883_spi.cpp
@@ -44,4 +43,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/hott/CMakeLists.txt
+++ b/src/drivers/hott/CMakeLists.txt
@@ -30,16 +30,14 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
-set(MODULE_CFLAGS -Os)
 list(APPEND MODULE_CFLAGS -Wframe-larger-than=1100)
 px4_add_module(
 	MODULE drivers__hott
 	COMPILE_FLAGS
-		${MODULE_CFLAGS}
 	SRCS
 		messages.cpp
 		comms.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/hott/hott_sensors/CMakeLists.txt
+++ b/src/drivers/hott/hott_sensors/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE drivers__hott__hott_sensors
 	MAIN hott_sensors
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		hott_sensors.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/hott/hott_telemetry/CMakeLists.txt
+++ b/src/drivers/hott/hott_telemetry/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE drivers__hott__hott_telemetry
 	MAIN hott_telemetry
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		hott_telemetry.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/irlock/CMakeLists.txt
+++ b/src/drivers/irlock/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE drivers__irlock
 	MAIN irlock
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		irlock.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/l3gd20/CMakeLists.txt
+++ b/src/drivers/l3gd20/CMakeLists.txt
@@ -36,10 +36,9 @@ px4_add_module(
 	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Weffc++
-		-Os
 	SRCS
 		l3gd20.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/led/CMakeLists.txt
+++ b/src/drivers/led/CMakeLists.txt
@@ -33,10 +33,9 @@
 px4_add_module(
 	MODULE drivers__led
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		led.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/lis3mdl/CMakeLists.txt
+++ b/src/drivers/lis3mdl/CMakeLists.txt
@@ -36,7 +36,6 @@ px4_add_module(
 	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Weffc++
-		-Os
 	SRCS
 		lis3mdl_i2c.cpp
 		lis3mdl_spi.cpp
@@ -44,4 +43,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/ll40ls/CMakeLists.txt
+++ b/src/drivers/ll40ls/CMakeLists.txt
@@ -34,7 +34,6 @@ px4_add_module(
 	MODULE drivers__ll40ls
 	MAIN ll40ls
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		ll40ls.cpp
 		LidarLite.cpp
@@ -43,4 +42,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/lps25h/CMakeLists.txt
+++ b/src/drivers/lps25h/CMakeLists.txt
@@ -36,7 +36,6 @@ px4_add_module(
 	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Weffc++
-		-Os
 	SRCS
 		lps25h.cpp
 		lps25h_i2c.cpp
@@ -45,4 +44,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/lsm303d/CMakeLists.txt
+++ b/src/drivers/lsm303d/CMakeLists.txt
@@ -36,10 +36,9 @@ px4_add_module(
 	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Weffc++
-		-Os
 	SRCS
 		lsm303d.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/mb12xx/CMakeLists.txt
+++ b/src/drivers/mb12xx/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE drivers__mb12xx
 	MAIN mb12xx
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		mb12xx.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/md25/CMakeLists.txt
+++ b/src/drivers/md25/CMakeLists.txt
@@ -34,11 +34,10 @@ px4_add_module(
 	MODULE drivers__md25
 	MAIN md25
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		md25.cpp
 		md25_main.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/meas_airspeed/CMakeLists.txt
+++ b/src/drivers/meas_airspeed/CMakeLists.txt
@@ -36,10 +36,9 @@ px4_add_module(
 	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Weffc++
-		-Os
 	SRCS
 		meas_airspeed.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/mkblctrl/CMakeLists.txt
+++ b/src/drivers/mkblctrl/CMakeLists.txt
@@ -34,11 +34,10 @@ px4_add_module(
 	MODULE drivers__mkblctrl
 	MAIN mkblctrl
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		mkblctrl.cpp
 		mkblctrl_params.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/mpu6000/CMakeLists.txt
+++ b/src/drivers/mpu6000/CMakeLists.txt
@@ -36,7 +36,6 @@ px4_add_module(
 	STACK_MAIN 1400
 	COMPILE_FLAGS
 		-Weffc++
-		-Os
 	SRCS
 		mpu6000.cpp
 		mpu6000_i2c.cpp
@@ -44,4 +43,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/mpu6500/CMakeLists.txt
+++ b/src/drivers/mpu6500/CMakeLists.txt
@@ -36,10 +36,9 @@ px4_add_module(
 	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Weffc++
-		-Os
 	SRCS
 		mpu6500.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/mpu9250/CMakeLists.txt
+++ b/src/drivers/mpu9250/CMakeLists.txt
@@ -36,7 +36,6 @@ px4_add_module(
 	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Weffc++
-		-Os
 	SRCS
 		mpu9250.cpp
 		mpu9250_i2c.cpp

--- a/src/drivers/ms5611/CMakeLists.txt
+++ b/src/drivers/ms5611/CMakeLists.txt
@@ -41,9 +41,8 @@ px4_add_module(
 	MAIN ms5611
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Os
 	SRCS ${srcs}
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/navio_gpio/CMakeLists.txt
+++ b/src/drivers/navio_gpio/CMakeLists.txt
@@ -34,7 +34,7 @@ px4_add_module(
 	MODULE drivers__navio_gpio
 	MAIN navio_gpio
 	STACK_MAIN 1200
-	COMPILE_FLAGS -Os
+	COMPILE_FLAGS
 	SRCS
 		navio_gpio.cpp
 	DEPENDS

--- a/src/drivers/navio_rgbled/CMakeLists.txt
+++ b/src/drivers/navio_rgbled/CMakeLists.txt
@@ -35,7 +35,7 @@ include_directories(../navio_gpio)
 px4_add_module(
 	MODULE drivers__navio_rgbled
 	MAIN navio_rgbled
-	COMPILE_FLAGS -Os
+	COMPILE_FLAGS
 	SRCS
 		navio_rgbled.cpp
 	DEPENDS

--- a/src/drivers/navio_sysfs_pwm_out/CMakeLists.txt
+++ b/src/drivers/navio_sysfs_pwm_out/CMakeLists.txt
@@ -34,7 +34,6 @@ px4_add_module(
 	MODULE drivers__navio_sysfs_pwm_out
 	MAIN navio_sysfs_pwm_out
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		navio_sysfs_pwm_out.cpp
 	DEPENDS

--- a/src/drivers/navio_sysfs_rc_in/CMakeLists.txt
+++ b/src/drivers/navio_sysfs_rc_in/CMakeLists.txt
@@ -34,7 +34,7 @@ px4_add_module(
 	MODULE drivers__navio_sysfs_rc_in
 	MAIN navio_sysfs_rc_in
 	STACK_MAIN 1200
-	COMPILE_FLAGS -Os
+	COMPILE_FLAGS
 	SRCS
 		navio_sysfs_rc_in.cpp
 	DEPENDS

--- a/src/drivers/oreoled/CMakeLists.txt
+++ b/src/drivers/oreoled/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN oreoled
 	STACK_MAIN 1024
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		oreoled.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/pca8574/CMakeLists.txt
+++ b/src/drivers/pca8574/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE drivers__pca8574
 	MAIN pca8574
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		pca8574.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/pwm_out_rc_in/CMakeLists.txt
+++ b/src/drivers/pwm_out_rc_in/CMakeLists.txt
@@ -34,7 +34,6 @@ px4_add_module(
 	MODULE drivers__pwm_out_rc_in
 	MAIN pwm_out_rc_in
 	COMPILE_FLAGS
-		-Os
 		-DMAVLINK_COMM_NUM_BUFFERS=1
 	SRCS
 		pwm_out_rc_in.cpp

--- a/src/drivers/pwm_out_sim/CMakeLists.txt
+++ b/src/drivers/pwm_out_sim/CMakeLists.txt
@@ -36,10 +36,9 @@ px4_add_module(
 	STACK_MAIN 1200
 	STACK_MAX 1200
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		pwm_out_sim.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/px4flow/CMakeLists.txt
+++ b/src/drivers/px4flow/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN px4flow
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		px4flow.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/px4fmu/CMakeLists.txt
+++ b/src/drivers/px4fmu/CMakeLists.txt
@@ -35,11 +35,10 @@ px4_add_module(
 	MAIN fmu
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		fmu.cpp
 		px4fmu_params.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/px4io/CMakeLists.txt
+++ b/src/drivers/px4io/CMakeLists.txt
@@ -35,7 +35,6 @@ px4_add_module(
 	MAIN px4io
 	STACK_MAIN 1800
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		px4io.cpp
 		px4io_uploader.cpp
@@ -45,4 +44,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/rgbled/CMakeLists.txt
+++ b/src/drivers/rgbled/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE drivers__rgbled
 	MAIN rgbled
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		rgbled.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/rgbled_pwm/CMakeLists.txt
+++ b/src/drivers/rgbled_pwm/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE drivers__rgbled_pwm
 	MAIN rgbled
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		rgbled_pwm.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/roboclaw/CMakeLists.txt
+++ b/src/drivers/roboclaw/CMakeLists.txt
@@ -34,11 +34,10 @@ px4_add_module(
 	MODULE drivers__roboclaw
 	MAIN roboclaw
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		roboclaw_main.cpp
 		RoboClaw.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/sf0x/CMakeLists.txt
+++ b/src/drivers/sf0x/CMakeLists.txt
@@ -34,11 +34,10 @@ px4_add_module(
 	MODULE drivers__sf0x
 	MAIN sf0x
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		sf0x.cpp
 		sf0x_parser.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/sf1xx/CMakeLists.txt
+++ b/src/drivers/sf1xx/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MODULE drivers__sf1xx
 	MAIN sf1xx
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		sf1xx.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/snapdragon_rc_pwm/CMakeLists.txt
+++ b/src/drivers/snapdragon_rc_pwm/CMakeLists.txt
@@ -34,11 +34,10 @@ px4_add_module(
 	MODULE drivers__snapdragon_rc_pwm
 	MAIN snapdragon_rc_pwm
 	COMPILE_FLAGS
-		-Os
 		-DMAVLINK_COMM_NUM_BUFFERS=1
 	SRCS
 		snapdragon_rc_pwm.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/srf02/CMakeLists.txt
+++ b/src/drivers/srf02/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE drivers__srf02
 	MAIN srf02
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		srf02.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/srf02_i2c/CMakeLists.txt
+++ b/src/drivers/srf02_i2c/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE drivers__srf02_i2c
 	MAIN srf02_i2c
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		srf02_i2c.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/stm32/CMakeLists.txt
+++ b/src/drivers/stm32/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE drivers__stm32
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		drv_hrt.c
 		drv_io_timer.c
@@ -43,4 +42,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/stm32/adc/CMakeLists.txt
+++ b/src/drivers/stm32/adc/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE drivers__stm32__adc
 	MAIN adc
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		adc.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/stm32/tone_alarm/CMakeLists.txt
+++ b/src/drivers/stm32/tone_alarm/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE drivers__stm32__tone_alarm
 	MAIN tone_alarm
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		tone_alarm.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/tap_esc/CMakeLists.txt
+++ b/src/drivers/tap_esc/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE drivers__tap_esc
 	MAIN tap_esc
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		tap_esc.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/test_ppm/CMakeLists.txt
+++ b/src/drivers/test_ppm/CMakeLists.txt
@@ -36,10 +36,9 @@ px4_add_module(
 	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Weffc++
-		-Os
 	SRCS
 		test_ppm.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/trone/CMakeLists.txt
+++ b/src/drivers/trone/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN trone
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		trone.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/examples/ekf_att_pos_estimator/CMakeLists.txt
+++ b/src/examples/ekf_att_pos_estimator/CMakeLists.txt
@@ -34,7 +34,7 @@
 px4_add_module(
 	MODULE examples__ekf_att_pos_estimator
 	MAIN ekf_att_pos_estimator
-	COMPILE_FLAGS -Os
+	COMPILE_FLAGS
 	STACK_MAIN 3000
 	STACK_MAX 3400
 	SRCS
@@ -44,4 +44,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/lib/controllib/CMakeLists.txt
+++ b/src/lib/controllib/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE lib__controllib
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		blocks.cpp
 		block/Block.cpp
@@ -42,4 +41,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/lib/conversion/CMakeLists.txt
+++ b/src/lib/conversion/CMakeLists.txt
@@ -33,10 +33,9 @@
 px4_add_module(
 	MODULE lib__conversion
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		rotation.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/lib/external_lgpl/CMakeLists.txt
+++ b/src/lib/external_lgpl/CMakeLists.txt
@@ -33,10 +33,9 @@
 px4_add_module(
 	MODULE lib__external_lgpl
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		tecs/tecs.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/lib/geo_lookup/CMakeLists.txt
+++ b/src/lib/geo_lookup/CMakeLists.txt
@@ -33,10 +33,9 @@
 px4_add_module(
 	MODULE lib__geo_lookup
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		geo_mag_declination.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/lib/launchdetection/CMakeLists.txt
+++ b/src/lib/launchdetection/CMakeLists.txt
@@ -33,11 +33,10 @@
 px4_add_module(
 	MODULE lib__launchdetection
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		LaunchDetector.cpp
 		CatapultLaunchMethod.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/lib/mathlib/CMakeLists.txt
+++ b/src/lib/mathlib/CMakeLists.txt
@@ -33,11 +33,10 @@
 px4_add_module(
 	MODULE lib__mathlib
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		math/test/test.cpp
 		math/Limits.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/lib/rc/CMakeLists.txt
+++ b/src/lib/rc/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE lib__rc
 	COMPILE_FLAGS
-		-Os
 		-Wno-unused-result
 	SRCS
 		st24.c
@@ -43,4 +42,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/lib/runway_takeoff/CMakeLists.txt
+++ b/src/lib/runway_takeoff/CMakeLists.txt
@@ -33,10 +33,9 @@
 px4_add_module(
 	MODULE lib__runway_takeoff
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		RunwayTakeoff.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/lib/tailsitter_recovery/CMakeLists.txt
+++ b/src/lib/tailsitter_recovery/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE lib__tailsitter_recovery
 	STACK_MAIN 400
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		tailsitter_recovery.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/lib/terrain_estimation/CMakeLists.txt
+++ b/src/lib/terrain_estimation/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE lib__terrain_estimation
 	STACK_MAIN 1024
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		terrain_estimator.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/attitude_estimator_q/CMakeLists.txt
+++ b/src/modules/attitude_estimator_q/CMakeLists.txt
@@ -35,7 +35,6 @@ px4_add_module(
 	MODULE modules__attitude_estimator_q
 	MAIN attitude_estimator_q
 	COMPILE_FLAGS
-		-Os
 	STACK_MAIN 1200
 	STACK_MAX 1600
 	SRCS
@@ -43,4 +42,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/bottle_drop/CMakeLists.txt
+++ b/src/modules/bottle_drop/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN bottle_drop
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		bottle_drop.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/commander/CMakeLists.txt
+++ b/src/modules/commander/CMakeLists.txt
@@ -36,7 +36,6 @@ px4_add_module(
 	STACK_MAIN 4096
 	STACK_MAX 2450
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		commander.cpp
 		state_machine_helper.cpp
@@ -53,4 +52,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/controllib_test/CMakeLists.txt
+++ b/src/modules/controllib_test/CMakeLists.txt
@@ -34,11 +34,10 @@ px4_add_module(
 	MODULE modules__controllib_test
 	MAIN controllib_test
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		controllib_test_main.cpp
 	DEPENDS
 		platforms__common
 	)
 
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/dataman/CMakeLists.txt
+++ b/src/modules/dataman/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN dataman
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		dataman.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/dummy/CMakeLists.txt
+++ b/src/modules/dummy/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE modules__dummy
 	MAIN tone_alarm
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		tone_alarm.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/ekf2/CMakeLists.txt
+++ b/src/modules/ekf2/CMakeLists.txt
@@ -33,7 +33,7 @@
 px4_add_module(
 	MODULE modules__ekf2
 	MAIN ekf2
-	COMPILE_FLAGS -Os
+	COMPILE_FLAGS
 	STACK_MAIN 2500
 	STACK_MAX 4000
 	SRCS
@@ -42,4 +42,4 @@ px4_add_module(
 		platforms__common
 		git_ecl
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/fw_att_control/CMakeLists.txt
+++ b/src/modules/fw_att_control/CMakeLists.txt
@@ -35,7 +35,6 @@ px4_add_module(
 	MAIN fw_att_control
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		fw_att_control_main.cpp
 	DEPENDS
@@ -43,4 +42,4 @@ px4_add_module(
 		git_ecl
 		lib__ecl
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/fw_pos_control_l1/CMakeLists.txt
+++ b/src/modules/fw_pos_control_l1/CMakeLists.txt
@@ -35,7 +35,7 @@ px4_add_module(
 	MAIN fw_pos_control_l1
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Os -Weffc++
+		-Weffc++
 	SRCS
 		fw_pos_control_l1_main.cpp
 		landingslope.cpp
@@ -45,4 +45,4 @@ px4_add_module(
 		lib__external_lgpl
 		lib__ecl
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/gpio_led/CMakeLists.txt
+++ b/src/modules/gpio_led/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE modules__gpio_led
 	MAIN gpio_led
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		gpio_led.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/land_detector/CMakeLists.txt
+++ b/src/modules/land_detector/CMakeLists.txt
@@ -35,7 +35,6 @@ px4_add_module(
 	MAIN land_detector
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		land_detector_main.cpp
 		LandDetector.cpp
@@ -45,4 +44,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/load_mon/CMakeLists.txt
+++ b/src/modules/load_mon/CMakeLists.txt
@@ -34,7 +34,7 @@ px4_add_module(
 	MODULE modules__load_mon
 	MAIN load_mon
 	STACK_MAIN 1200
-	COMPILE_FLAGS -Os
+	COMPILE_FLAGS
 	SRCS
 		load_mon.cpp
 	DEPENDS

--- a/src/modules/local_position_estimator/CMakeLists.txt
+++ b/src/modules/local_position_estimator/CMakeLists.txt
@@ -33,7 +33,7 @@
 px4_add_module(
 	MODULE modules__local_position_estimator
 	MAIN local_position_estimator
-	COMPILE_FLAGS -Os
+	COMPILE_FLAGS
 	STACK_MAIN 5700
 	STACK_MAX 13000
 	SRCS
@@ -49,4 +49,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/logger/CMakeLists.txt
+++ b/src/modules/logger/CMakeLists.txt
@@ -36,7 +36,7 @@ px4_add_module(
 	MAIN logger
 	PRIORITY "SCHED_PRIORITY_MAX-30"
 	STACK_MAIN 2200
-	COMPILE_FLAGS -Os
+	COMPILE_FLAGS
 	SRCS
 		logger.cpp
 		log_writer.cpp
@@ -44,4 +44,4 @@ px4_add_module(
 		platforms__common
 		modules__uORB
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -36,7 +36,6 @@ px4_add_module(
 	STACK_MAIN 1200
 	STACK_MAX 1500
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		mavlink.c
 		mavlink_main.cpp
@@ -53,4 +52,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/mavlink/mavlink_tests/CMakeLists.txt
+++ b/src/modules/mavlink/mavlink_tests/CMakeLists.txt
@@ -36,7 +36,6 @@ px4_add_module(
 	STACK_MAIN 5000
 	COMPILE_FLAGS
 		-DMAVLINK_FTP_UNIT_TEST
-		-Os
 	SRCS
 		mavlink_tests.cpp
 		mavlink_ftp_test.cpp
@@ -46,4 +45,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/mc_att_control/CMakeLists.txt
+++ b/src/modules/mc_att_control/CMakeLists.txt
@@ -35,10 +35,10 @@ px4_add_module(
 	MAIN mc_att_control
 	STACK_MAIN 1200
 	STACK_MAX 3500
-	COMPILE_FLAGS -Os
+	COMPILE_FLAGS
 	SRCS
 		mc_att_control_main.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/mc_pos_control/CMakeLists.txt
+++ b/src/modules/mc_pos_control/CMakeLists.txt
@@ -33,11 +33,11 @@
 px4_add_module(
 	MODULE modules__mc_pos_control
 	MAIN mc_pos_control
-	COMPILE_FLAGS -Os
+	COMPILE_FLAGS
 	STACK_MAIN 1200
 	SRCS
 		mc_pos_control_main.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/muorb/adsp/CMakeLists.txt
+++ b/src/modules/muorb/adsp/CMakeLists.txt
@@ -35,11 +35,10 @@ include_directories("../../uORB")
 px4_add_module(
 	MODULE modules__muorb__adsp
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		px4muorb.cpp
 		uORBFastRpcChannel.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/navigator/CMakeLists.txt
+++ b/src/modules/navigator/CMakeLists.txt
@@ -35,7 +35,6 @@ px4_add_module(
 	MAIN navigator
 	STACK_MAIN 1300
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		navigator_main.cpp
 		navigator_mode.cpp
@@ -55,4 +54,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/param/CMakeLists.txt
+++ b/src/modules/param/CMakeLists.txt
@@ -42,9 +42,8 @@ px4_generate_parameters_source(OUT param_files
 px4_add_module(
 	MODULE modules__param
 	COMPILE_FLAGS
-		-Os
 	SRCS ${param_files}
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/position_estimator_inav/CMakeLists.txt
+++ b/src/modules/position_estimator_inav/CMakeLists.txt
@@ -36,7 +36,7 @@ px4_add_module(
 	MAIN position_estimator_inav
 	STACK_MAIN 1200
 	STACK_MAX 4000
-	COMPILE_FLAGS -Os
+	COMPILE_FLAGS
 	SRCS
 		position_estimator_inav_main.cpp
 		position_estimator_inav_params.cpp
@@ -44,4 +44,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/sdlog2/CMakeLists.txt
+++ b/src/modules/sdlog2/CMakeLists.txt
@@ -38,11 +38,10 @@ px4_add_module(
 	STACK_MAX 1600
 	COMPILE_FLAGS
 		${MODULE_CFLAGS}
-		-Os
 	SRCS
 		sdlog2.c
 		logbuffer.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/sensors/CMakeLists.txt
+++ b/src/modules/sensors/CMakeLists.txt
@@ -37,7 +37,6 @@ px4_add_module(
 	PRIORITY "SCHED_PRIORITY_MAX-5"
 	STACK_MAIN 1300
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		sensors.cpp
 		sensors_init.cpp

--- a/src/modules/systemlib/CMakeLists.txt
+++ b/src/modules/systemlib/CMakeLists.txt
@@ -83,7 +83,6 @@ px4_add_module(
 	MODULE modules__systemlib
 	COMPILE_FLAGS
 		-Wno-sign-compare
-		-Os
 	SRCS ${SRCS}
 	DEPENDS
 		platforms__common

--- a/src/modules/uORB/CMakeLists.txt
+++ b/src/modules/uORB/CMakeLists.txt
@@ -70,9 +70,8 @@ px4_add_module(
 	MAIN uorb
 	STACK_MAIN 2100
 	COMPILE_FLAGS
-		-Os
 	SRCS ${SRCS}
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/uORB/uORB_tests/CMakeLists.txt
+++ b/src/modules/uORB/uORB_tests/CMakeLists.txt
@@ -45,9 +45,8 @@ px4_add_module(
 	MAIN uorb_tests
 	STACK_MAIN 2048
 	COMPILE_FLAGS
-		-Os
 	SRCS ${SRCS}
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/uavcan/CMakeLists.txt
+++ b/src/modules/uavcan/CMakeLists.txt
@@ -59,7 +59,6 @@ px4_add_module(
 	STACK_MAIN 3200
 	STACK_MAX 1500
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		# Main
 		uavcan_main.cpp
@@ -81,4 +80,4 @@ px4_add_module(
 		uavcan
 	)
 
-## vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+## vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/unit_test/CMakeLists.txt
+++ b/src/modules/unit_test/CMakeLists.txt
@@ -33,10 +33,9 @@
 px4_add_module(
 	MODULE modules__unit_test
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		unit_test.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/vtol_att_control/CMakeLists.txt
+++ b/src/modules/vtol_att_control/CMakeLists.txt
@@ -34,7 +34,7 @@ px4_add_module(
 	MODULE modules__vtol_att_control
 	MAIN vtol_att_control
 	STACK_MAIN 1300
-	COMPILE_FLAGS -Os
+	COMPILE_FLAGS
 	SRCS
 		vtol_att_control_main.cpp
 		tiltrotor.cpp
@@ -44,4 +44,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/nuttx/CMakeLists.txt
+++ b/src/platforms/nuttx/CMakeLists.txt
@@ -33,10 +33,9 @@
 px4_add_module(
 	MODULE platforms__nuttx
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		px4_nuttx_impl.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/nuttx/px4_layer/CMakeLists.txt
+++ b/src/platforms/nuttx/px4_layer/CMakeLists.txt
@@ -33,11 +33,10 @@
 px4_add_module(
 	MODULE platforms__nuttx__px4_layer
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		px4_nuttx_tasks.c
 		../../posix/px4_layer/px4_log.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/posix/drivers/adcsim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/adcsim/CMakeLists.txt
@@ -34,7 +34,6 @@ px4_add_module(
 	MODULE platforms__posix__drivers__adcsim
 	MAIN adcsim
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		adcsim.cpp
 	DEPENDS
@@ -47,4 +46,4 @@ target_link_libraries(platforms__posix__drivers__adcsim
 	df_driver_framework
 )
 
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/posix/drivers/airspeedsim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/airspeedsim/CMakeLists.txt
@@ -34,11 +34,10 @@ px4_add_module(
 	MODULE platforms__posix__drivers__airspeedsim
 	MAIN measairspeedsim
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		airspeedsim.cpp
 		meas_airspeed_sim.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/posix/drivers/barosim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/barosim/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE platforms__posix__drivers__barosim
 	MAIN barosim
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		baro.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/posix/drivers/gpssim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/gpssim/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE platforms__posix__drivers__gpssim
 	MAIN gpssim
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		gpssim.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/posix/drivers/gyrosim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/gyrosim/CMakeLists.txt
@@ -35,7 +35,6 @@ px4_add_module(
 	MAIN gyrosim
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		gyrosim.cpp
 	DEPENDS
@@ -48,4 +47,4 @@ target_link_libraries(platforms__posix__drivers__gyrosim
 	df_driver_framework
 )
 
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/posix/drivers/ledsim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/ledsim/CMakeLists.txt
@@ -33,10 +33,9 @@
 px4_add_module(
 	MODULE platforms__posix__drivers__ledsim
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		led.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/posix/drivers/rgbledsim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/rgbledsim/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE platforms__posix__drivers__rgbledsim
 	MAIN rgbledsim
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		rgbled.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/posix/drivers/tonealrmsim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/tonealrmsim/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE platforms__posix__drivers__tonealrmsim
 	MAIN tone_alarm
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		tone_alarm.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/posix/px4_layer/CMakeLists.txt
+++ b/src/platforms/posix/px4_layer/CMakeLists.txt
@@ -47,7 +47,6 @@ endif()
 px4_add_module(
 	MODULE platforms__posix__px4_layer
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		px4_posix_impl.cpp
 		px4_posix_tasks.cpp

--- a/src/platforms/posix/work_queue/CMakeLists.txt
+++ b/src/platforms/posix/work_queue/CMakeLists.txt
@@ -33,7 +33,6 @@
 px4_add_module(
 	MODULE platforms__posix__work_queue
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		hrt_thread.c
 		hrt_queue.c
@@ -52,4 +51,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/qurt/fc_addon/mpu_spi/CMakeLists.txt
+++ b/src/platforms/qurt/fc_addon/mpu_spi/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-set(TOOLS_ERROR_MSG 
+set(TOOLS_ERROR_MSG
 		"The FC_ADDON must be installed and the environment variable FC_ADDON must be set"
 		"(e.g. export FC_ADDON=${HOME}/Qualcomm/addon)")
 
@@ -53,7 +53,7 @@ px4_add_module(
 	MAIN mpu9x50
 	STACK_MAIN 1200
 	COMPILE_FLAGS
-		-Os -Weffc++
+		-Weffc++
 	SRCS
 		mpu9x50_main.cpp
 		mpu9x50_params.c
@@ -61,10 +61,10 @@ px4_add_module(
 		platforms__common
 	)
 
-set(module_external_libraries 
+set(module_external_libraries
 	${module_external_libraries}
 	libmpu9x50
 	CACHE INTERNAL "module_external_libraries"
 	)
 
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/qurt/fc_addon/rc_receiver/CMakeLists.txt
+++ b/src/platforms/qurt/fc_addon/rc_receiver/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-set(TOOLS_ERROR_MSG 
+set(TOOLS_ERROR_MSG
 		"The FC_ADDON must be installed and the environment variable FC_ADDON must be set"
 		"(e.g. export FC_ADDON=${HOME}/Qualcomm/addon)")
 
@@ -53,7 +53,7 @@ px4_add_module(
         MAIN rc_receiver
 	STACK_MAIN 1200
         COMPILE_FLAGS
-                -Os -Weffc++
+                -Weffc++
         SRCS
                 rc_receiver_main.cpp
 		rc_receiver_params.c
@@ -62,10 +62,10 @@ px4_add_module(
                 platforms__common
         )
 
-set(module_external_libraries 
+set(module_external_libraries
 	${module_external_libraries}
 	librc_receiver
 	CACHE INTERNAL "module_external_libraries"
 	)
 
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/qurt/fc_addon/uart_esc/CMakeLists.txt
+++ b/src/platforms/qurt/fc_addon/uart_esc/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-set(TOOLS_ERROR_MSG 
+set(TOOLS_ERROR_MSG
 		"The FC_ADDON must be installed and the environment variable FC_ADDON must be set"
 		"(e.g. export FC_ADDON=${HOME}/Qualcomm/addon)")
 
@@ -53,7 +53,7 @@ px4_add_module(
         MAIN uart_esc
 	STACK_MAIN 1200
         COMPILE_FLAGS
-                -Os -Weffc++
+                -Weffc++
         SRCS
                 uart_esc_main.cpp
 		uart_esc_params.c
@@ -62,10 +62,10 @@ px4_add_module(
                 platforms__common
         )
 
-set(module_external_libraries 
+set(module_external_libraries
 	${module_external_libraries}
-	libuart_esc 
+	libuart_esc
 	CACHE INTERNAL "module_external_libraries"
 	)
-	
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/qurt/px4_layer/CMakeLists.txt
+++ b/src/platforms/qurt/px4_layer/CMakeLists.txt
@@ -56,7 +56,6 @@ endif()
 px4_add_module(
 	MODULE platforms__qurt__px4_layer
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		${QURT_LAYER_SRCS}
 		${CONFIG_SRC}

--- a/src/systemcmds/bl_update/CMakeLists.txt
+++ b/src/systemcmds/bl_update/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN bl_update
 	STACK_MAIN 4096
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		bl_update.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/systemcmds/config/CMakeLists.txt
+++ b/src/systemcmds/config/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN config
 	STACK_MAIN 4096
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		config.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/systemcmds/dumpfile/CMakeLists.txt
+++ b/src/systemcmds/dumpfile/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE systemcmds__dumpfile
 	MAIN dumpfile
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		dumpfile.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/systemcmds/esc_calib/CMakeLists.txt
+++ b/src/systemcmds/esc_calib/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN esc_calib
 	STACK_MAIN 4096
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		esc_calib.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/systemcmds/i2c/CMakeLists.txt
+++ b/src/systemcmds/i2c/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE systemcmds__i2c
 	MAIN i2c
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		i2c.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/systemcmds/mixer/CMakeLists.txt
+++ b/src/systemcmds/mixer/CMakeLists.txt
@@ -30,17 +30,16 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
-set(MIXER_CFLAGS -Os)
 
 px4_add_module(
 	MODULE systemcmds__mixer
 	MAIN mixer
 	STACK_MAIN 4096
 	STACK_MAX 2100
-	COMPILE_FLAGS ${MIXER_CFLAGS}
+	COMPILE_FLAGS
 	SRCS
 		mixer.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/systemcmds/motor_test/CMakeLists.txt
+++ b/src/systemcmds/motor_test/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN motor_test
 	STACK_MAIN 4096
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		motor_test.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/systemcmds/mtd/CMakeLists.txt
+++ b/src/systemcmds/mtd/CMakeLists.txt
@@ -34,11 +34,10 @@ px4_add_module(
 	MODULE systemcmds__mtd
 	MAIN mtd
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		mtd.c
 		24xxxx_mtd.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/systemcmds/nshterm/CMakeLists.txt
+++ b/src/systemcmds/nshterm/CMakeLists.txt
@@ -36,10 +36,9 @@ px4_add_module(
 	PRIORITY "SCHED_PRIORITY_DEFAULT-30"
 	STACK_MAIN 1500
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		nshterm.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/systemcmds/param/CMakeLists.txt
+++ b/src/systemcmds/param/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN param
 	STACK_MAIN 2500
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		param.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/systemcmds/perf/CMakeLists.txt
+++ b/src/systemcmds/perf/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN perf
 	STACK_MAIN 1800
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		perf.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/systemcmds/pwm/CMakeLists.txt
+++ b/src/systemcmds/pwm/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN pwm
 	STACK_MAIN 2400
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		pwm.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/systemcmds/reboot/CMakeLists.txt
+++ b/src/systemcmds/reboot/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN reboot
 	STACK_MAIN 800
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		reboot.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/systemcmds/reflect/CMakeLists.txt
+++ b/src/systemcmds/reflect/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE systemcmds__reflect
 	MAIN reflect
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		reflect.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/systemcmds/sd_bench/CMakeLists.txt
+++ b/src/systemcmds/sd_bench/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN sd_bench
 	STACK_MAIN 2500
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		sd_bench.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/systemcmds/tests/CMakeLists.txt
+++ b/src/systemcmds/tests/CMakeLists.txt
@@ -82,7 +82,6 @@ px4_add_module(
 		-Wno-missing-declarations
 		-Wno-double-promotion
 		-Wno-unknown-warning-option
-		-Os
 	SRCS ${srcs}
 	DEPENDS
 		platforms__common

--- a/src/systemcmds/top/CMakeLists.txt
+++ b/src/systemcmds/top/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN top
 	STACK_MAIN 1700
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		top.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/systemcmds/topic_listener/CMakeLists.txt
+++ b/src/systemcmds/topic_listener/CMakeLists.txt
@@ -46,11 +46,10 @@ px4_add_module(
 	MAIN listener
 	STACK_MAIN 1800
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		topic_listener.cpp
 	DEPENDS
 		platforms__common
 		generate_topic_listener
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/systemcmds/usb_connected/CMakeLists.txt
+++ b/src/systemcmds/usb_connected/CMakeLists.txt
@@ -34,10 +34,9 @@ px4_add_module(
 	MODULE systemcmds__usb_connected
 	MAIN usb_connected
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		usb_connected.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/systemcmds/ver/CMakeLists.txt
+++ b/src/systemcmds/ver/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN ver
 	STACK_MAIN 1024
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		ver.c
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :


### PR DESCRIPTION
With this change only builds for NuttX which are very much flash size
constraint are optimized for size. All other builds (e.g. SITL,
Snapdragon, etc.) are left at the default for debugging or -O2 for the
usual use.

This addresses #4759.

## Build times
### POSIX:

-Os:
`make posix 164.70s user 11.82s system 334% cpu 52.833 total`

-O2:
`make posix 187.23s user 12.61s system 351% cpu 56.923 total`

(default no -O2, not in this PR):
`make posix 115.52s user 11.32s system 337% cpu 37.601 total`

### QURT:

with -Os
`make qurt_eagle_default  257.10s user 6.22s system 208% cpu 2:06.03 total`

-O2
`make qurt_eagle_default  245.09s user 5.87s system 221% cpu 1:53.15 total`

(default no -O2, not in this PR):
`make qurt_eagle_default  98.16s user 5.94s system 341% cpu 30.496 total`


## size comparison:

### px4fmu-v2_default

before (-Os):
`1018992 build_px4fmu-v2_default/src/firmware/nuttx/firmware_nuttx.bin`

after (-Os):
`1018992 build_px4fmu-v2_default/src/firmware/nuttx/firmware_nuttx.bin`

Unfortunately, the changes here include the latest ecl submodule, so this can't be merged before the rest of ecl has been merged.