### PR TITLE
MPC: Separate XY control gains

### DIFF
--- a/src/lib/mathlib/math/Vector.hpp
+++ b/src/lib/mathlib/math/Vector.hpp
@@ -298,6 +298,18 @@ public:
 	}
 
 	/**
+	 * element by element inversion
+	 */
+	const Vector<N> einv() const {
+		Vector<N> res;
+
+		for (unsigned int i = 0; i < N; i++)
+			res.data[i] = 1 / (data[i] + FLT_EPSILON);
+
+		return res;
+	}
+
+	/**
 	 * gets the length of this vector squared
 	 */
 	float length_squared() const {

--- a/src/lib/mathlib/math/Vector.hpp
+++ b/src/lib/mathlib/math/Vector.hpp
@@ -304,7 +304,7 @@ public:
 		Vector<N> res;
 
 		for (unsigned int i = 0; i < N; i++)
-			res.data[i] = 1 / (data[i] + FLT_EPSILON);
+			res.data[i] = 1 / data[i];
 
 		return res;
 	}

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -650,7 +650,7 @@ void
 MulticopterPositionControl::scale_with_body_fixed_gains(math::Vector<3> &setpoint, const math::Vector<3> errors,
 		const math::Vector<3> &gains, const bool set_z)
 {
-	float z_setpoint;
+	float z_setpoint = 0.0f;
 
 	if (!set_z) {
 		// Preserve z-component

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1521,19 +1521,15 @@ MulticopterPositionControl::task_main()
 				if (_run_pos_control) {
 					/* Separate Gains */
 					float vel_sp_bx, vel_sp_by;
-					float k_bx, k_by;
 					float pos_err_bx, pos_err_by;
-
-					k_bx = _params.pos_p(0);
-					k_by = _params.pos_p(1);
 
 					/* Project error on body axis */
 					pos_err_bx = (_pos_sp(0) - _pos(0)) * cosf(_yaw) + (_pos_sp(1) - _pos(1)) * sinf(_yaw);
 					pos_err_by = (_pos_sp(1) - _pos(1)) * cosf(_yaw) - (_pos_sp(0) - _pos(0)) * sinf(_yaw);
 
 					/* Use separate position gains Gains */
-					vel_sp_bx = pos_err_bx * k_bx;
-					vel_sp_by = pos_err_by * k_by;
+					vel_sp_bx = pos_err_bx * _params.pos_p(0);
+					vel_sp_by = pos_err_by * _params.pos_p(1);
 
 					/* Project setpoint back on world frame */
 					_vel_sp(0) = vel_sp_bx * cosf(_yaw) - vel_sp_by * sinf(_yaw);

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -354,8 +354,9 @@ private:
 	/**
 	 * Function to scale lateral errors(world xy plane) in world frame by gains in body frame
 	 */
-	void 		scale_with_body_fixed_gains(math::Vector<3> &setpoint, const math::Vector<3> errors, const math::Vector<3> &gains,
-				       const bool set_z);
+	void 		scale_with_body_fixed_gains(math::Vector<3> &setpoint, const math::Vector<3> errors,
+			const math::Vector<3> &gains,
+			const bool set_z);
 };
 
 namespace pos_control

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -239,27 +239,47 @@ PARAM_DEFINE_FLOAT(MPC_Z_VEL_MAX_DN, 1.0f);
 PARAM_DEFINE_FLOAT(MPC_Z_FF, 0.5f);
 
 /**
- * Proportional gain for horizontal position error
+ * Proportional gain for horizontal position error in body_x axis
  *
  * @min 0.0
  * @max 2.0
  * @decimal 2
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_XY_P, 0.95f);
+PARAM_DEFINE_FLOAT(MPC_X_P, 0.95f);
 
 /**
- * Proportional gain for horizontal velocity error
+ * Proportional gain for horizontal position error in body_y axis
+ *
+ * @min 0.0
+ * @max 2.0
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_Y_P, 0.95f);
+
+/**
+ * Proportional gain for horizontal velocity error in body_x axis
  *
  * @min 0.06
  * @max 0.15
  * @decimal 2
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_XY_VEL_P, 0.09f);
+PARAM_DEFINE_FLOAT(MPC_X_VEL_P, 0.09f);
 
 /**
- * Integral gain for horizontal velocity error
+ * Proportional gain for horizontal velocity error in body_y axis
+ *
+ * @min 0.06
+ * @max 0.15
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_Y_VEL_P, 0.09f);
+
+/**
+ * Integral gain for horizontal velocity error in body_x axis
  *
  * Non-zero value allows to resist wind.
  *
@@ -268,17 +288,39 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_P, 0.09f);
  * @decimal 3
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_XY_VEL_I, 0.02f);
+PARAM_DEFINE_FLOAT(MPC_X_VEL_I, 0.02f);
 
 /**
- * Differential gain for horizontal velocity error. Small values help reduce fast oscillations. If value is too big oscillations will appear again.
+ * Integral gain for horizontal velocity error in body_y axis
+ *
+ * Non-zero value allows to resist wind.
+ *
+ * @min 0.0
+ * @max 0.1
+ * @decimal 3
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_Y_VEL_I, 0.02f);
+
+/**
+ * Differential gain for horizontal velocity error in body_x axis. Small values help reduce fast oscillations. If value is too big oscillations will appear again.
  *
  * @min 0.005
  * @max 0.1
  * @decimal 3
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_XY_VEL_D, 0.01f);
+PARAM_DEFINE_FLOAT(MPC_X_VEL_D, 0.01f);
+
+/**
+ * Differential gain for horizontal velocity error in body_y axis. Small values help reduce fast oscillations. If value is too big oscillations will appear again.
+ *
+ * @min 0.005
+ * @max 0.1
+ * @decimal 3
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_Y_VEL_D, 0.01f);
 
 /**
  * Nominal horizontal velocity

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -327,7 +327,7 @@ PARAM_DEFINE_FLOAT(MPC_Y_VEL_D, 0.01f);
  *
  * Normal horizontal velocity in AUTO modes (includes
  * also RTL / hold / etc.) and endpoint for
- * position stabilized mode (POSCTRL).
+ * position stabilized mode (POSCTRL) in body x.
  *
  * @unit m/s
  * @min 3.0
@@ -336,7 +336,23 @@ PARAM_DEFINE_FLOAT(MPC_Y_VEL_D, 0.01f);
  * @decimal 2
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_XY_CRUISE, 5.0f);
+PARAM_DEFINE_FLOAT(MPC_X_CRUISE, 5.0f);
+
+/**
+ * Nominal horizontal velocity
+ *
+ * Normal horizontal velocity in AUTO modes (includes
+ * also RTL / hold / etc.) and endpoint for
+ * position stabilized mode (POSCTRL) in body y.
+ *
+ * @unit m/s
+ * @min 3.0
+ * @max 20.0
+ * @increment 1
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_Y_CRUISE, 5.0f);
 
 /**
  * Maximum horizontal velocity

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -239,7 +239,7 @@ PARAM_DEFINE_FLOAT(MPC_Z_VEL_MAX_DN, 1.0f);
 PARAM_DEFINE_FLOAT(MPC_Z_FF, 0.5f);
 
 /**
- * Proportional gain for horizontal position error in body_x axis
+ * Proportional gain for horizontal position error in body x axis
  *
  * @min 0.0
  * @max 2.0


### PR DESCRIPTION
@LorenzMeier,

As promised, separate multicopter control gains for x and y body frame axes.

Replacing the following params:
-  `MPC_XY_P`
-  `MPC_XY_VEL_P`
-  `MPC_XY_VEL_I`
-  `MPC_XY_VEL_D`
-  `MPC_XY_CRUISE`
