### PR TITLE
commander: don't auto-disarm as fast if not flown

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1641,7 +1641,6 @@ int commander_thread_main(int argc, char *argv[])
 		orb_check(param_changed_sub, &updated);
 
 		if (updated || param_init_forced) {
-			param_init_forced = false;
 
 			/* parameters changed */
 			struct parameter_update_s param_changed;
@@ -1689,6 +1688,15 @@ int commander_thread_main(int argc, char *argv[])
 			param_get(_param_geofence_action, &geofence_action);
 			param_get(_param_disarm_land, &disarm_when_landed);
 
+			// If we update parameters the first time
+			// make sure the hysteresis time gets set.
+			// After that it will be set in the main state
+			// machine based on the arming state.
+			if (param_init_forced) {
+				auto_disarm_hysteresis.set_hysteresis_time_from(false,
+									(hrt_abstime)disarm_when_landed * 1000000);
+			}
+
 			param_get(_param_low_bat_act, &low_bat_action);
 			param_get(_param_offboard_loss_timeout, &offboard_loss_timeout);
 			param_get(_param_offboard_loss_act, &offboard_loss_act);
@@ -1713,6 +1721,8 @@ int commander_thread_main(int argc, char *argv[])
 			param_get(_param_fmode_4, &_flight_mode_slots[3]);
 			param_get(_param_fmode_5, &_flight_mode_slots[4]);
 			param_get(_param_fmode_6, &_flight_mode_slots[5]);
+
+			param_init_forced = false;
 
 			/* Set flag to autosave parameters if necessary */
 			if (updated && autosave_params != 0 && param_changed.saved == false) {

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1612,6 +1612,8 @@ int commander_thread_main(int argc, char *argv[])
 	bool main_state_changed = false;
 	bool failsafe_old = false;
 
+	bool have_taken_off_since_arming = false;
+
 	/* initialize low priority thread */
 	pthread_attr_t commander_low_prio_attr;
 	pthread_attr_init(&commander_low_prio_attr);
@@ -1686,8 +1688,6 @@ int commander_thread_main(int argc, char *argv[])
 			param_get(_param_ef_time_thres, &ef_time_thres);
 			param_get(_param_geofence_action, &geofence_action);
 			param_get(_param_disarm_land, &disarm_when_landed);
-			auto_disarm_hysteresis.set_hysteresis_time_from(false,
-									(hrt_abstime)disarm_when_landed * 1000000);
 
 			param_get(_param_low_bat_act, &low_bat_action);
 			param_get(_param_offboard_loss_timeout, &offboard_loss_timeout);
@@ -2046,6 +2046,7 @@ int commander_thread_main(int argc, char *argv[])
 					mavlink_and_console_log_info(&mavlink_log_pub, "Landing detected");
 				} else {
 					mavlink_and_console_log_info(&mavlink_log_pub, "Takeoff detected");
+					have_taken_off_since_arming = true;
 				}
 			}
 
@@ -2059,6 +2060,17 @@ int commander_thread_main(int argc, char *argv[])
 			was_landed = land_detector.landed;
 			was_falling = land_detector.freefall;
 		}
+
+
+
+		/* Update hysteresis time. Use a time of factor 5 longer if we have not taken off yet. */
+		hrt_abstime timeout_time = disarm_when_landed * 1000000;
+
+		if (!have_taken_off_since_arming) {
+			timeout_time *= 5;
+		}
+
+		auto_disarm_hysteresis.set_hysteresis_time_from(false, timeout_time);
 
 		// Check for auto-disarm
 		if (armed.armed && land_detector.landed && disarm_when_landed > 0) {
@@ -2910,6 +2922,11 @@ int commander_thread_main(int argc, char *argv[])
 		}
 
 		status_changed = false;
+
+		if (!armed.armed) {
+			/* Reset the flag if disarmed. */
+			have_taken_off_since_arming = false;
+		}
 
 
 		/* publish internal state for logging purposes */

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -251,6 +251,10 @@ PARAM_DEFINE_INT32(COM_RC_ARM_HYST, 1000);
  *
  * A non-zero, positive value specifies the time-out period in seconds after which the vehicle will be
  * automatically disarmed in case a landing situation has been detected during this period.
+ *
+ * The vehicle will also auto-disarm right after arming if it has not even flown, however the time
+ * will be longer by a factor of 5.
+ *
  * A value of zero means that automatic disarming is disabled.
  *
  * @group Commander


### PR DESCRIPTION
It was found inconvenient that auto-disarm triggers too quickly right
after arming when the vehicle has not actually taken off yet.

Therefore, the auto-disarm takes now by a factor of 5 longer if the
vehicle has not taken off yet.

Tested in SITL, needs testing on a real vehicle.

Addresses #5565
@xiaoyuLi-China0372 