### PR TITLE
add pci-Bitcraze to px4_base.cmake

### DIFF
--- a/Tools/upload.sh
+++ b/Tools/upload.sh
@@ -17,7 +17,7 @@ fi
 
 if [ $SYSTYPE = "Linux" ];
 then
-SERIAL_PORTS="/dev/serial/by-id/usb-3D_Robotics*,/dev/serial/by-id/usb-The_Autopilot*,/dev/serial/by-id/usb-Bitcraze*"
+SERIAL_PORTS="/dev/serial/by-id/usb-3D_Robotics*,/dev/serial/by-id/usb-The_Autopilot*,/dev/serial/by-id/usb-Bitcraze*,/dev/serial/by-id/pci-Bitcraze*,"
 fi
 
 if [ $SYSTYPE = "" ];

--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -501,6 +501,7 @@ function(px4_add_upload)
 			/dev/serial/by-id/usb-The_Autopilot*
 			/dev/serial/by-id/usb-Bitcraze*
 			/dev/serial/by-id/pci-3D_Robotics*
+			/dev/serial/by-id/pci-Bitcraze*
 			)
 	elseif(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin")
 		list(APPEND serial_ports


### PR DESCRIPTION
Fix problem that pci can't upload :
Found board c,0 bootloader rev 5 on /dev/serial/by-id/pci-Bitcraze_AB_Crazyflie_BL_0-if00