### PR TITLE
Make VTOL weathervane when navigating to vtol_land as MC

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -622,6 +622,7 @@ Mission::set_mission_items()
 			_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
 			_mission_item.autocontinue = true;
 			_mission_item.time_inside = 0.0f;
+			_mission_item.disable_mc_yaw = true;
 		}
 
 		/* we just moved to the landing waypoint, now descend */

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -488,7 +488,8 @@ MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *ite
 				_navigator->get_loiter_radius();
 	sp->loiter_direction = (item->loiter_radius > 0) ? 1 : -1;
 	sp->acceptance_radius = item->acceptance_radius;
-	sp->disable_mc_yaw_control = false;
+	sp->disable_mc_yaw_control = item->disable_mc_yaw;
+
 	sp->cruising_speed = _navigator->get_cruising_speed();
 	sp->cruising_throttle = _navigator->get_cruising_throttle();
 

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -127,7 +127,8 @@ struct mission_item_s {
 		loiter_exit_xtrack : 1,			/**< exit xtrack location: 0 for center of loiter wp, 1 for exit location */
 		force_heading : 1,				/**< heading needs to be reached ***/
 		altitude_is_relative : 1,		/**< true if altitude is relative from start point	*/
-		autocontinue : 1;				/**< true if next waypoint should follow after this one */
+		autocontinue : 1,				/**< true if next waypoint should follow after this one */
+		disable_mc_yaw : 1;				/**< weathervane mode */
 	};
 };
 #pragma pack(pop)


### PR DESCRIPTION
vtol_land has the following sequence:
1 navigate to WP as FW
2 transition to MC
3 navigate to WP as MC
4 land

Often when reaching sequence 3 it still has too much velocity, attempting to yaw saturates the actuators. Using weathervane will likely be smoother.
