### PR TITLE
Fixed app args buffer overrun in qurt px4_layer main.cpp and qshell.cpp

### DIFF
--- a/src/drivers/qshell/qurt/qshell.cpp
+++ b/src/drivers/qshell/qurt/qshell.cpp
@@ -61,6 +61,8 @@
 #include <drivers/drv_hrt.h>
 #include "DriverFramework.hpp"
 
+#define MAX_ARGS 8 // max number of whitespace separated args after app name
+
 extern void init_app_map(std::map<std::string, px4_main_t> &apps);
 extern void list_builtins(std::map<std::string, px4_main_t> &apps);
 
@@ -155,9 +157,15 @@ int QShell::run_cmd(const std::vector<std::string> &appargs)
 	//replaces app.find with iterator code to avoid null pointer exception
 	for (map<string, px4_main_t>::iterator it = apps.begin(); it != apps.end(); ++it) {
 		if (it->first == command) {
-			const char *arg[2 + 1];
+			// one for command name, one for null terminator
+			const char *arg[MAX_ARGS + 2];
 
 			unsigned int i = 0;
+
+			if (appargs.size() > MAX_ARGS + 1) {
+				PX4_ERR("%d too many arguments in run_cmd", appargs.size() - (MAX_ARGS + 1));
+				return 1;
+			}
 
 			while (i < appargs.size() && appargs[i].c_str()[0] != '\0') {
 				arg[i] = (char *)appargs[i].c_str();

--- a/src/platforms/qurt/px4_layer/main.cpp
+++ b/src/platforms/qurt/px4_layer/main.cpp
@@ -51,6 +51,8 @@
 #include "apps.h"
 #include "DriverFramework.hpp"
 
+#define MAX_ARGS 8 // max number of whitespace separated args after app name
+
 using namespace std;
 
 extern void init_app_map(map<string, px4_main_t> &apps);
@@ -76,9 +78,15 @@ static void run_cmd(map<string, px4_main_t> &apps, const vector<string> &appargs
 	//replaces app.find with iterator code to avoid null pointer exception
 	for (map<string, px4_main_t>::iterator it = apps.begin(); it != apps.end(); ++it)
 		if (it->first == command) {
-			const char *arg[2 + 1];
+			// one for command name, one for null terminator
+			const char *arg[MAX_ARGS + 2];
 
 			unsigned int i = 0;
+
+			if (appargs.size() > MAX_ARGS + 1) {
+				PX4_ERR("%d too many arguments in run_cmd", appargs.size() - (MAX_ARGS + 1));
+				return;
+			}
 
 			while (i < appargs.size() && appargs[i].c_str()[0] != '\0') {
 				arg[i] = (char *)appargs[i].c_str();
@@ -202,7 +210,7 @@ const char *get_commands()
 	PX4_ERR("Could not open %s\n", COMMANDS_ADSP_FILE);
 
 	static const char *commands =
-		"uorb start\n"
+		"uorb start\nqshell start\n"
 		;
 
 	return commands;


### PR DESCRIPTION
Fixes [#5603](https://github.com/PX4/Firmware/issues/5603)

Before this fix, module start commands like "pwm_out_rc_in start -d /dev/tty-1" would cause overruns of the arg array at the following lines:

https://github.com/PX4/Firmware/blob/master/src/platforms/qurt/px4_layer/main.cpp#L84
https://github.com/PX4/Firmware/blob/master/src/platforms/qurt/px4_layer/main.cpp#L89

https://github.com/PX4/Firmware/blob/master/src/drivers/qshell/qurt/qshell.cpp#L163
https://github.com/PX4/Firmware/blob/master/src/drivers/qshell/qurt/qshell.cpp#L168

In my case, this manifested as overwriting the px4_main_t function pointer in the apps[] map, leading to a null-pointer exception when 3-argument (or more) commands were run.

I increased the array size by 1 to account for the null terminator, and added checking and a PX4_ERR message to prevent overruns.

Separately, I also added the 'qshell start' command to the default list of commands if px4.config is missing.
https://github.com/PX4/Firmware/blob/master/src/platforms/qurt/px4_layer/main.cpp#L205
This allows actually starting the required px4 tasks via qshell.