### PR TITLE
Fixed order of arguments in px4_task_spawn_cmd.

### DIFF
--- a/src/platforms/px4_tasks.h
+++ b/src/platforms/px4_tasks.h
@@ -108,8 +108,8 @@ __EXPORT void px4_systemreset(bool to_bootloader) noreturn_function;
 
 /** Starts a task and performs any specific accounting, scheduler setup, etc. */
 __EXPORT px4_task_t px4_task_spawn_cmd(const char *name,
-				       int priority,
 				       int scheduler,
+				       int priority,
 				       int stack_size,
 				       px4_main_t entry,
 				       char *const argv[]);


### PR DESCRIPTION
Fixes #5601 
See also forum post http://discuss.px4.io/t/order-of-arguments-of-px4-task-spawn-cmd/1373.