### PR TITLE
Add missing sdlog and mavlink EKF status data

### DIFF
--- a/msg/estimator_status.msg
+++ b/msg/estimator_status.msg
@@ -45,5 +45,23 @@ uint16 filter_fault_flags	# Bitmask to indicate EKF internal faults
 # 12 - true if fusion of the North position has encountered a numerical error
 # 13 - true if fusion of the East position has encountered a numerical error
 # 14 - true if fusion of the Down position has encountered a numerical error
-float32 pos_horiz_accuracy
-float32 pos_vert_accuracy
+float32 pos_horiz_accuracy # 1-Sigma estimated horizontal position accuracy relative to the estimators origin (m)
+float32 pos_vert_accuracy # 1-Sigma estimated vertical position accuracy relative to the estimators origin (m)
+uint16 innovation_check_flags # Bitmask to indicate pass/fail status of innovation consistency checks
+# 0 - true if velocity observations have been rejected
+# 1 - true if horizontal position observations have been rejected
+# 2 - true if true if vertical position observations have been rejected
+# 3 - true if the X magnetometer observation has been rejected
+# 4 - true if the Y magnetometer observation has been rejected
+# 5 - true if the Z magnetometer observation has been rejected
+# 6 - true if the yaw observation has been rejected
+# 7 - true if the airspeed observation has been rejected
+# 8 - true if the height above ground observation has been rejected
+# 9 - true if the X optical flow observation has been rejected
+# 10 - true if the Y optical flow observation has been rejected
+float32 mag_test_ratio # ratio of the largest magnetometer innovation component to the innovation test limit
+float32 vel_test_ratio # ratio of the largest velocity innovation component to the innovation test limit
+float32 pos_test_ratio # ratio of the largest horizontal position innovation component to the innovation test limit
+float32 hgt_test_ratio # ratio of the vertical position innovation to the innovation test limit
+float32 tas_test_ratio # ratio of the true airspeed innovation to the innovation test limit
+float32 hagl_test_ratio # ratio of the height above ground innovation to the innovation test limit

--- a/msg/estimator_status.msg
+++ b/msg/estimator_status.msg
@@ -65,3 +65,16 @@ float32 pos_test_ratio # ratio of the largest horizontal position innovation com
 float32 hgt_test_ratio # ratio of the vertical position innovation to the innovation test limit
 float32 tas_test_ratio # ratio of the true airspeed innovation to the innovation test limit
 float32 hagl_test_ratio # ratio of the height above ground innovation to the innovation test limit
+uint16 solution_status_flags # Bitmask indicating which filter kinematic state outputs are valid for flight control use.
+# 0 - True if the attitude estimate is good
+# 1 - True if the horizontal velocity estimate is good
+# 2 - True if the vertical velocity estimate is good
+# 3 - True if the horizontal position (relative) estimate is good
+# 4 - True if the horizontal position (absolute) estimate is good
+# 5 - True if the vertical position (absolute) estimate is good
+# 6 - True if the vertical position (above ground) estimate is good
+# 7 - True if the EKF is in a constant position mode and is not using external measurements (eg GPS or optical flow)
+# 8 - True if the EKF has sufficient data to enter a mode that will provide a (relative) position estimate
+# 9 - True if the EKF has sufficient data to enter a mode that will provide a (absolute) position estimate
+# 10 - True if the EKF has detected a GPS glitch
+

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -873,6 +873,7 @@ void Ekf2::task_main()
 							&status.hagl_test_ratio);
 			bool dead_reckoning;
 			_ekf.get_ekf_accuracy(&status.pos_horiz_accuracy, &status.pos_vert_accuracy, &dead_reckoning);
+			_ekf.get_ekf_soln_status(&status.solution_status_flags);
 			if (_estimator_status_pub == nullptr) {
 				_estimator_status_pub = orb_advertise(ORB_ID(estimator_status), &status);
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -859,164 +859,165 @@ void Ekf2::task_main()
 			}
 		}
 
-		// publish estimator status
-		struct estimator_status_s status = {};
-		status.timestamp = hrt_absolute_time();
-		_ekf.get_state_delayed(status.states);
-		_ekf.get_covariances(status.covariances);
-		_ekf.get_gps_check_status(&status.gps_check_fail_flags);
-		_ekf.get_control_mode(&status.control_mode_flags);
-		_ekf.get_filter_fault_status(&status.filter_fault_flags);
-		_ekf.get_innovation_test_status(&status.innovation_check_flags, &status.mag_test_ratio,
-						&status.vel_test_ratio, &status.pos_test_ratio,
-						&status.hgt_test_ratio, &status.tas_test_ratio,
-						&status.hagl_test_ratio);
-		if (_estimator_status_pub == nullptr) {
-			_estimator_status_pub = orb_advertise(ORB_ID(estimator_status), &status);
-
-		} else {
-			orb_publish(ORB_ID(estimator_status), _estimator_status_pub, &status);
-		}
-
-		// Publish wind estimate
-		struct wind_estimate_s wind_estimate = {};
-		wind_estimate.timestamp = hrt_absolute_time();
-		wind_estimate.windspeed_north = status.states[22];
-		wind_estimate.windspeed_east = status.states[23];
-		wind_estimate.covariance_north = status.covariances[22];
-		wind_estimate.covariance_east = status.covariances[23];
-
-		if (_wind_pub == nullptr) {
-			_wind_pub = orb_advertise(ORB_ID(wind_estimate), &wind_estimate);
-
-		} else {
-			orb_publish(ORB_ID(wind_estimate), _wind_pub, &wind_estimate);
-		}
-
-		// publish estimator innovation data
-		struct ekf2_innovations_s innovations = {};
-		innovations.timestamp = hrt_absolute_time();
-		_ekf.get_vel_pos_innov(&innovations.vel_pos_innov[0]);
-		_ekf.get_mag_innov(&innovations.mag_innov[0]);
-		_ekf.get_heading_innov(&innovations.heading_innov);
-		_ekf.get_airspeed_innov(&innovations.airspeed_innov);
-		_ekf.get_flow_innov(&innovations.flow_innov[0]);
-		_ekf.get_hagl_innov(&innovations.hagl_innov);
-
-		_ekf.get_vel_pos_innov_var(&innovations.vel_pos_innov_var[0]);
-		_ekf.get_mag_innov_var(&innovations.mag_innov_var[0]);
-		_ekf.get_heading_innov_var(&innovations.heading_innov_var);
-		_ekf.get_airspeed_innov_var(&innovations.airspeed_innov_var);
-		_ekf.get_flow_innov_var(&innovations.flow_innov_var[0]);
-		_ekf.get_hagl_innov_var(&innovations.hagl_innov_var);
-
-		if (_estimator_innovations_pub == nullptr) {
-			_estimator_innovations_pub = orb_advertise(ORB_ID(ekf2_innovations), &innovations);
-
-		} else {
-			orb_publish(ORB_ID(ekf2_innovations), _estimator_innovations_pub, &innovations);
-		}
-
-		// save the declination to the EKF2_MAG_DECL parameter when a land event is detected
-		if ((_params->mag_declination_source & (1 << 1)) && !_prev_landed && vehicle_land_detected.landed) {
-			float decl_deg;
-			_ekf.copy_mag_decl_deg(&decl_deg);
-			_mag_declination_deg.set(decl_deg);
-		}
-
-		_prev_landed = vehicle_land_detected.landed;
-
-		// publish replay message if in replay mode
-		bool publish_replay_message = (bool)_param_record_replay_msg.get();
-
-		if (publish_replay_message) {
-			struct ekf2_replay_s replay = {};
-			replay.time_ref = now;
-			replay.gyro_integral_dt = sensors.gyro_integral_dt;
-			replay.accelerometer_integral_dt = sensors.accelerometer_integral_dt;
-			replay.magnetometer_timestamp = sensors.timestamp + sensors.magnetometer_timestamp_relative;
-			replay.baro_timestamp = sensors.timestamp + sensors.baro_timestamp_relative;
-			memcpy(replay.gyro_rad, sensors.gyro_rad, sizeof(replay.gyro_rad));
-			memcpy(replay.accelerometer_m_s2, sensors.accelerometer_m_s2, sizeof(replay.accelerometer_m_s2));
-			memcpy(replay.magnetometer_ga, sensors.magnetometer_ga, sizeof(replay.magnetometer_ga));
-			replay.baro_alt_meter = sensors.baro_alt_meter;
-
-			// only write gps data if we had a gps update.
-			if (gps_updated) {
-				replay.time_usec = gps.timestamp;
-				replay.time_usec_vel = gps.timestamp;
-				replay.lat = gps.lat;
-				replay.lon = gps.lon;
-				replay.alt = gps.alt;
-				replay.fix_type = gps.fix_type;
-				replay.nsats = gps.satellites_used;
-				replay.eph = gps.eph;
-				replay.epv = gps.epv;
-				replay.sacc = gps.s_variance_m_s;
-				replay.vel_m_s = gps.vel_m_s;
-				replay.vel_n_m_s = gps.vel_n_m_s;
-				replay.vel_e_m_s = gps.vel_e_m_s;
-				replay.vel_d_m_s = gps.vel_d_m_s;
-				replay.vel_ned_valid = gps.vel_ned_valid;
+			// publish estimator status
+			struct estimator_status_s status = {};
+			status.timestamp = hrt_absolute_time();
+			_ekf.get_state_delayed(status.states);
+			_ekf.get_covariances(status.covariances);
+			_ekf.get_gps_check_status(&status.gps_check_fail_flags);
+			_ekf.get_control_mode(&status.control_mode_flags);
+			_ekf.get_filter_fault_status(&status.filter_fault_flags);
+			_ekf.get_innovation_test_status(&status.innovation_check_flags, &status.mag_test_ratio,
+							&status.vel_test_ratio, &status.pos_test_ratio,
+							&status.hgt_test_ratio, &status.tas_test_ratio,
+							&status.hagl_test_ratio);
+			bool dead_reckoning;
+			_ekf.get_ekf_accuracy(&status.pos_horiz_accuracy, &status.pos_vert_accuracy, &dead_reckoning);
+			if (_estimator_status_pub == nullptr) {
+				_estimator_status_pub = orb_advertise(ORB_ID(estimator_status), &status);
 
 			} else {
-				// this will tell the logging app not to bother logging any gps replay data
-				replay.time_usec = 0;
+				orb_publish(ORB_ID(estimator_status), _estimator_status_pub, &status);
 			}
 
-			if (optical_flow_updated) {
-				replay.flow_timestamp = optical_flow.timestamp;
-				replay.flow_pixel_integral[0] = optical_flow.pixel_flow_x_integral;
-				replay.flow_pixel_integral[1] = optical_flow.pixel_flow_y_integral;
-				replay.flow_gyro_integral[0] = optical_flow.gyro_x_rate_integral;
-				replay.flow_gyro_integral[1] = optical_flow.gyro_y_rate_integral;
-				replay.flow_time_integral = optical_flow.integration_timespan;
-				replay.flow_quality = optical_flow.quality;
+			// Publish wind estimate
+			struct wind_estimate_s wind_estimate = {};
+			wind_estimate.timestamp = hrt_absolute_time();
+			wind_estimate.windspeed_north = status.states[22];
+			wind_estimate.windspeed_east = status.states[23];
+			wind_estimate.covariance_north = status.covariances[22];
+			wind_estimate.covariance_east = status.covariances[23];
+
+			if (_wind_pub == nullptr) {
+				_wind_pub = orb_advertise(ORB_ID(wind_estimate), &wind_estimate);
 
 			} else {
-				replay.flow_timestamp = 0;
+				orb_publish(ORB_ID(wind_estimate), _wind_pub, &wind_estimate);
 			}
 
-			if (range_finder_updated) {
-				replay.rng_timestamp = range_finder.timestamp;
-				replay.range_to_ground = range_finder.current_distance;
+			// publish estimator innovation data
+			struct ekf2_innovations_s innovations = {};
+			innovations.timestamp = hrt_absolute_time();
+			_ekf.get_vel_pos_innov(&innovations.vel_pos_innov[0]);
+			_ekf.get_mag_innov(&innovations.mag_innov[0]);
+			_ekf.get_heading_innov(&innovations.heading_innov);
+			_ekf.get_airspeed_innov(&innovations.airspeed_innov);
+			_ekf.get_flow_innov(&innovations.flow_innov[0]);
+			_ekf.get_hagl_innov(&innovations.hagl_innov);
 
+			_ekf.get_vel_pos_innov_var(&innovations.vel_pos_innov_var[0]);
+			_ekf.get_mag_innov_var(&innovations.mag_innov_var[0]);
+			_ekf.get_heading_innov_var(&innovations.heading_innov_var);
+			_ekf.get_airspeed_innov_var(&innovations.airspeed_innov_var);
+			_ekf.get_flow_innov_var(&innovations.flow_innov_var[0]);
+			_ekf.get_hagl_innov_var(&innovations.hagl_innov_var);
+
+			if (_estimator_innovations_pub == nullptr) {
+				_estimator_innovations_pub = orb_advertise(ORB_ID(ekf2_innovations), &innovations);
 			} else {
-				replay.rng_timestamp = 0;
+				orb_publish(ORB_ID(ekf2_innovations), _estimator_innovations_pub, &innovations);
 			}
 
-			if (airspeed_updated) {
-				replay.asp_timestamp = airspeed.timestamp;
-				replay.indicated_airspeed_m_s = airspeed.indicated_airspeed_m_s;
-				replay.true_airspeed_m_s = airspeed.true_airspeed_m_s;
-
-			} else {
-				replay.asp_timestamp = 0;
+			// save the declination to the EKF2_MAG_DECL parameter when a land event is detected
+			if ((_params->mag_declination_source & (1 << 1)) && !_prev_landed && vehicle_land_detected.landed) {
+				float decl_deg;
+				_ekf.copy_mag_decl_deg(&decl_deg);
+				_mag_declination_deg.set(decl_deg);
 			}
 
-			if (vision_position_updated) {
-				replay.ev_timestamp = ev.timestamp;
-				replay.pos_ev[0] = ev.x;
-				replay.pos_ev[1] = ev.y;
-				replay.pos_ev[2] = ev.z;
-				replay.quat_ev[0] = ev.q[0];
-				replay.quat_ev[1] = ev.q[1];
-				replay.quat_ev[2] = ev.q[2];
-				replay.quat_ev[3] = ev.q[3];
-				replay.pos_err = ev.pos_err;
-				replay.ang_err = ev.ang_err;
+			_prev_landed = vehicle_land_detected.landed;
 
-			} else {
-				replay.ev_timestamp = 0;
+			// publish replay message if in replay mode
+			bool publish_replay_message = (bool)_param_record_replay_msg.get();
+
+			if (publish_replay_message) {
+				struct ekf2_replay_s replay = {};
+				replay.time_ref = now;
+				replay.gyro_integral_dt = sensors.gyro_integral_dt;
+				replay.accelerometer_integral_dt = sensors.accelerometer_integral_dt;
+				replay.magnetometer_timestamp = sensors.timestamp + sensors.magnetometer_timestamp_relative;
+				replay.baro_timestamp = sensors.timestamp + sensors.baro_timestamp_relative;
+				memcpy(replay.gyro_rad, sensors.gyro_rad, sizeof(replay.gyro_rad));
+				memcpy(replay.accelerometer_m_s2, sensors.accelerometer_m_s2, sizeof(replay.accelerometer_m_s2));
+				memcpy(replay.magnetometer_ga, sensors.magnetometer_ga, sizeof(replay.magnetometer_ga));
+				replay.baro_alt_meter = sensors.baro_alt_meter;
+
+				// only write gps data if we had a gps update.
+				if (gps_updated) {
+					replay.time_usec = gps.timestamp;
+					replay.time_usec_vel = gps.timestamp;
+					replay.lat = gps.lat;
+					replay.lon = gps.lon;
+					replay.alt = gps.alt;
+					replay.fix_type = gps.fix_type;
+					replay.nsats = gps.satellites_used;
+					replay.eph = gps.eph;
+					replay.epv = gps.epv;
+					replay.sacc = gps.s_variance_m_s;
+					replay.vel_m_s = gps.vel_m_s;
+					replay.vel_n_m_s = gps.vel_n_m_s;
+					replay.vel_e_m_s = gps.vel_e_m_s;
+					replay.vel_d_m_s = gps.vel_d_m_s;
+					replay.vel_ned_valid = gps.vel_ned_valid;
+
+				} else {
+					// this will tell the logging app not to bother logging any gps replay data
+					replay.time_usec = 0;
+				}
+
+				if (optical_flow_updated) {
+					replay.flow_timestamp = optical_flow.timestamp;
+					replay.flow_pixel_integral[0] = optical_flow.pixel_flow_x_integral;
+					replay.flow_pixel_integral[1] = optical_flow.pixel_flow_y_integral;
+					replay.flow_gyro_integral[0] = optical_flow.gyro_x_rate_integral;
+					replay.flow_gyro_integral[1] = optical_flow.gyro_y_rate_integral;
+					replay.flow_time_integral = optical_flow.integration_timespan;
+					replay.flow_quality = optical_flow.quality;
+
+				} else {
+					replay.flow_timestamp = 0;
+				}
+
+				if (range_finder_updated) {
+					replay.rng_timestamp = range_finder.timestamp;
+					replay.range_to_ground = range_finder.current_distance;
+
+				} else {
+					replay.rng_timestamp = 0;
+				}
+
+				if (airspeed_updated) {
+					replay.asp_timestamp = airspeed.timestamp;
+					replay.indicated_airspeed_m_s = airspeed.indicated_airspeed_m_s;
+					replay.true_airspeed_m_s = airspeed.true_airspeed_m_s;
+
+				} else {
+					replay.asp_timestamp = 0;
+				}
+
+				if (vision_position_updated) {
+					replay.ev_timestamp = ev.timestamp;
+					replay.pos_ev[0] = ev.x;
+					replay.pos_ev[1] = ev.y;
+					replay.pos_ev[2] = ev.z;
+					replay.quat_ev[0] = ev.q[0];
+					replay.quat_ev[1] = ev.q[1];
+					replay.quat_ev[2] = ev.q[2];
+					replay.quat_ev[3] = ev.q[3];
+					replay.pos_err = ev.pos_err;
+					replay.ang_err = ev.ang_err;
+
+				} else {
+					replay.ev_timestamp = 0;
+				}
+
+				if (_replay_pub == nullptr) {
+					_replay_pub = orb_advertise(ORB_ID(ekf2_replay), &replay);
+
+				} else {
+					orb_publish(ORB_ID(ekf2_replay), _replay_pub, &replay);
+				}
 			}
-
-			if (_replay_pub == nullptr) {
-				_replay_pub = orb_advertise(ORB_ID(ekf2_replay), &replay);
-
-			} else {
-				orb_publish(ORB_ID(ekf2_replay), _replay_pub, &replay);
-			}
-		}
 	}
 
 	delete ekf2::instance;

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -867,7 +867,10 @@ void Ekf2::task_main()
 		_ekf.get_gps_check_status(&status.gps_check_fail_flags);
 		_ekf.get_control_mode(&status.control_mode_flags);
 		_ekf.get_filter_fault_status(&status.filter_fault_flags);
-
+		_ekf.get_innovation_test_status(&status.innovation_check_flags, &status.mag_test_ratio,
+						&status.vel_test_ratio, &status.pos_test_ratio,
+						&status.hgt_test_ratio, &status.tas_test_ratio,
+						&status.hagl_test_ratio);
 		if (_estimator_status_pub == nullptr) {
 			_estimator_status_pub = orb_advertise(ORB_ID(estimator_status), &status);
 

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -1715,6 +1715,7 @@ protected:
 			est_msg.tas_ratio = est.tas_test_ratio;
 			est_msg.pos_horiz_accuracy = est.pos_horiz_accuracy;
 			est_msg.pos_vert_accuracy = est.pos_vert_accuracy;
+			est_msg.flags = est.solution_status_flags;
 
 			mavlink_msg_estimator_status_send_struct(_mavlink->get_channel(), &est_msg);
 

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -1707,6 +1707,12 @@ protected:
 			est_msg.time_usec = est.timestamp;
 			est_msg.pos_horiz_accuracy = est.pos_horiz_accuracy;
 			est_msg.pos_vert_accuracy = est.pos_vert_accuracy;
+			est_msg.mag_ratio = est.mag_test_ratio;
+			est_msg.vel_ratio = est.vel_test_ratio;
+			est_msg.pos_horiz_ratio = est.pos_test_ratio;
+			est_msg.pos_vert_ratio = est.hgt_test_ratio;
+			est_msg.hagl_ratio = est.hagl_test_ratio;
+			est_msg.tas_ratio = est.tas_test_ratio;
 
 			mavlink_msg_estimator_status_send_struct(_mavlink->get_channel(), &est_msg);
 

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -1713,6 +1713,8 @@ protected:
 			est_msg.pos_vert_ratio = est.hgt_test_ratio;
 			est_msg.hagl_ratio = est.hagl_test_ratio;
 			est_msg.tas_ratio = est.tas_test_ratio;
+			est_msg.pos_horiz_accuracy = est.pos_horiz_accuracy;
+			est_msg.pos_vert_accuracy = est.pos_vert_accuracy;
 
 			mavlink_msg_estimator_status_send_struct(_mavlink->get_channel(), &est_msg);
 

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -2154,6 +2154,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 				log_msg.body.log_EST2.gps_check_fail_flags = buf.estimator_status.gps_check_fail_flags;
 				log_msg.body.log_EST2.control_mode_flags = buf.estimator_status.control_mode_flags;
 				log_msg.body.log_EST2.health_flags = buf.estimator_status.health_flags;
+				log_msg.body.log_EST2.innov_test_flags = buf.estimator_status.innovation_check_flags;
 				LOGBUFFER_WRITE_AND_COUNT(EST2);
 
 				log_msg.msg_type = LOG_EST3_MSG;

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -414,6 +414,7 @@ struct log_EST2_s {
 	uint16_t gps_check_fail_flags;
 	uint16_t control_mode_flags;
 	uint8_t health_flags;
+	uint16_t innov_test_flags;
 };
 
 /* --- EST3 - ESTIMATOR STATUS --- */
@@ -688,7 +689,7 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT_S(TEL3, TEL, "BBBBHHBQ",		"RSSI,RemRSSI,Noise,RemNoise,RXErr,Fixed,TXBuf,HbTime"),
 	LOG_FORMAT(EST0, "ffffffffffffBBHB",	"s0,s1,s2,s3,s4,s5,s6,s7,s8,s9,s10,s11,nStat,fNaN,fFault,fTOut"),
 	LOG_FORMAT(EST1, "ffffffffffffffff",	"s12,s13,s14,s15,s16,s17,s18,s19,s20,s21,s22,s23,s24,s25,s26,s27"),
-	LOG_FORMAT(EST2, "ffffffffffffHHB",    "P0,P1,P2,P3,P4,P5,P6,P7,P8,P9,P10,P11,GCHK,CTRL,fHealth"),
+	LOG_FORMAT(EST2, "ffffffffffffHHBH",     "P0,P1,P2,P3,P4,P5,P6,P7,P8,P9,P10,P11,GCHK,CTRL,fHealth,IC"),
 	LOG_FORMAT(EST3, "ffffffffffffffff",    "P12,P13,P14,P15,P16,P17,P18,P19,P20,P21,P22,P23,P24,P25,P26,P27"),
 	LOG_FORMAT(EST4, "ffffffffffff", "VxI,VyI,VzI,PxI,PyI,PzI,VxIV,VyIV,VzIV,PxIV,PyIV,PzIV"),
 	LOG_FORMAT(EST5, "ffffffffff", "MAGxI,MAGyI,MAGzI,MAGxIV,MAGyIV,MAGzIV,HeadI,HeadIV,AirI,AirIV"),


### PR DESCRIPTION
Fully populates the mavlink ESTIMATOR_STATUS message when using ekf2.
Requires https://github.com/PX4/ecl/pull/196 to be pulled in first.