### PR TITLE
syslink_bridge: return state instead of 0

### DIFF
--- a/src/modules/syslink/syslink_bridge.cpp
+++ b/src/modules/syslink/syslink_bridge.cpp
@@ -85,7 +85,7 @@ SyslinkBridge::poll_state(struct file *filp)
 		state |= POLLOUT;
 	}
 
-	return 0;
+	return state;
 }
 
 ssize_t


### PR DESCRIPTION
This looked like a mistake, @dennisss can you test this please?