### PR TITLE
Prevents the possibility of buffer overflow in mixer parsing as noted by chungkim

### DIFF
--- a/src/modules/systemlib/mixer/mixer_multirotor.cpp
+++ b/src/modules/systemlib/mixer/mixer_multirotor.cpp
@@ -132,7 +132,7 @@ MultirotorMixer::from_text(Mixer::ControlCallback control_cb, uintptr_t cb_handl
 
 	}
 
-	if (sscanf(buf, "R: %s %d %d %d %d%n", geomname, &s[0], &s[1], &s[2], &s[3], &used) != 5) {
+	if (sscanf(buf, "R: %7s %d %d %d %d%n", geomname, &s[0], &s[1], &s[2], &s[3], &used) != 5) {
 		debug("multirotor parse failed on '%s'", buf);
 		return nullptr;
 	}


### PR DESCRIPTION
Closes https://github.com/PX4/Firmware/issues/5643 
The fix limits scanf from overwriting the geomname buffer local variable. Thus preventing stack corruption as noted by @chungkim. 