### PR TITLE
navio_sysfs_rc_in: Fixing logical expression

### DIFF
--- a/src/drivers/navio_sysfs_rc_in/navio_sysfs_rc_in.cpp
+++ b/src/drivers/navio_sysfs_rc_in/navio_sysfs_rc_in.cpp
@@ -261,7 +261,7 @@ int navio_sysfs_rc_in_main(int argc, char *argv[])
 
 	if (!strcmp(argv[1], "stop")) {
 
-		if (rc_input == nullptr || rc_input->isRunning()) {
+		if (rc_input == nullptr || !rc_input->isRunning()) {
 			PX4_WARN("not running");
 			/* this is not an error */
 			return 0;


### PR DESCRIPTION
command `navio_sysfs_rc_in stop` works now.

The app navio_sysfs_rc_in couldn't be stopped as there was a small mistake in [navio_sysfs_rc_in.cpp](https://github.com/PX4/Firmware/blob/master/src/drivers/navio_sysfs_rc_in/navio_sysfs_rc_in.cpp#L264): 
```
	if (!strcmp(argv[1], "stop")) {

		if (rc_input == nullptr || rc_input->isRunning()) {
			PX4_WARN("not running");
			/* this is not an error */
			return 0;
		}

```
is now:
```
	if (!strcmp(argv[1], "stop")) {

		if (rc_input == nullptr || !rc_input->isRunning()) {
			PX4_WARN("not running");
			/* this is not an error */
			return 0;
		}

```