### PR TITLE
Small fixes for px_mkfw.py

### DIFF
--- a/Tools/px_mkfw.py
+++ b/Tools/px_mkfw.py
@@ -107,7 +107,7 @@ if args.parameter_xml != None:
 	bytes = f.read()
 	desc['parameter_xml_size'] = len(bytes)
 	desc['parameter_xml'] = base64.b64encode(zlib.compress(bytes,9)).decode('utf-8')
-        desc['mav_autopilot'] = 12 # 12 = MAV_AUTOPILOT_PX4
+	desc['mav_autopilot'] = 12 # 12 = MAV_AUTOPILOT_PX4
 if args.airframe_xml != None:
 	f = open(args.airframe_xml, "rb")
 	bytes = f.read()

--- a/Tools/px_mkfw.py
+++ b/Tools/px_mkfw.py
@@ -39,7 +39,6 @@
 # metadata fields and a zlib-compressed base64-encoded firmware image.
 #
 
-import sys
 import argparse
 import json
 import base64


### PR DESCRIPTION
The Python script had a wrong indent with spaces instead of tabs like the rest of the file.
This should fix distributions such as Arch Linux which default to Python 3 and are more strict about tabs vs. spaces.

Also an import was unused. 