### PR TITLE
ULog over Mavlink streaming

### DIFF
--- a/Tools/mavlink_ulog_streaming.py
+++ b/Tools/mavlink_ulog_streaming.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python
+
+"""
+Stream ULog data over MAVLink.
+
+@author: Beat Kueng (beat-kueng@gmx.net)
+"""
+
+
+from __future__ import print_function
+import sys, select, os
+import datetime
+from timeit import default_timer as timer
+os.environ['MAVLINK20'] = '1' # The commands require mavlink 2
+
+try:
+    from pymavlink import mavutil
+except:
+    print("Failed to import pymavlink.")
+    print("You may need to install it with 'pip install pymavlink'")
+    exit(-1)
+from argparse import ArgumentParser
+
+
+class MavlinkLogStreaming():
+    '''Streams log data via MAVLink'''
+    def __init__(self, portname, baudrate, output_filename, debug=0):
+        self.baudrate = 0
+        self._debug = debug
+        self.buf = ''
+        self.debug("Connecting with MAVLink to %s ..." % portname)
+        self.mav = mavutil.mavlink_connection(portname, autoreconnect=True, baud=baudrate)
+        self.mav.wait_heartbeat()
+        self.debug("HEARTBEAT OK\n")
+        self.debug("Locked serial device\n")
+
+        self.got_ulog_header = False
+        self.got_header_section = False
+        self.ulog_message = []
+        self.file = open(output_filename,'wb')
+        self.start_time = timer()
+        self.last_sequence = -1
+        self.logging_started = False
+        self.num_dropouts = 0
+
+    def debug(self, s, level=1):
+        '''write some debug text'''
+        if self._debug >= level:
+            print(s)
+
+    def start_log(self):
+        self.mav.mav.command_long_send(self.mav.target_system,
+                self.mav.target_component,
+                mavutil.mavlink.MAV_CMD_LOGGING_START, 0,
+                0, 0, 0, 0, 0, 0, 0)
+
+    def stop_log(self):
+        self.mav.mav.command_long_send(self.mav.target_system,
+                self.mav.target_component,
+                mavutil.mavlink.MAV_CMD_LOGGING_STOP, 0,
+                0, 0, 0, 0, 0, 0, 0)
+
+    def read_messages(self):
+        ''' main loop reading messages '''
+        measure_time_start = timer()
+        measured_data = 0
+        while True:
+            m, first_msg_start, num_drops = self.read_message()
+            if m is not None:
+                self.process_streamed_ulog_data(m, first_msg_start, num_drops)
+
+                # status output
+                if self.logging_started:
+                    measured_data += len(m)
+                    measure_time_cur = timer()
+                    dt = measure_time_cur - measure_time_start
+                    if dt > 1:
+                        sys.stdout.write('\rData Rate: {:0.1f} KB/s  Drops: {:} \033[K'.format(
+                            measured_data / dt / 1024, self.num_dropouts))
+                        sys.stdout.flush()
+                        measure_time_start = measure_time_cur
+                        measured_data = 0
+
+            if not self.logging_started and timer()-self.start_time > 4:
+                raise Exception('Start timed out. Is the logger running in MAVLink mode?')
+
+
+    def read_message(self):
+        ''' read a single mavlink message, handle ACK & return a tuple of (data, first
+        message start, num dropouts) '''
+        m = self.mav.recv_match(type=['LOGGING_DATA_ACKED',
+                            'LOGGING_DATA', 'COMMAND_ACK'], blocking=True,
+                            timeout=0.05)
+        if m is not None:
+            self.debug(m, 3)
+
+            if m.get_type() == 'COMMAND_ACK':
+                if m.command == mavutil.mavlink.MAV_CMD_LOGGING_START and \
+                        not self.got_header_section:
+                    if m.result == 0:
+                        self.logging_started = True
+                        print('Logging started. Waiting for Header...')
+                    else:
+                        raise Exception('Logging start failed', m.result)
+                return None, 0, 0
+
+            # m is either 'LOGGING_DATA_ACKED' or 'LOGGING_DATA':
+            is_newer, num_drops = self.check_sequence(m.sequence)
+
+            if is_newer:
+                if num_drops > 0:
+                    self.num_dropouts += num_drops
+
+                if m.get_type() == 'LOGGING_DATA_ACKED':
+                    self.mav.mav.logging_ack_send(m.sequence)
+                else:
+                    if not self.got_header_section:
+                        print('Header received in {:0.2f}s'.format(timer()-self.start_time))
+                        self.logging_started = True
+                        self.got_header_section = True
+                self.last_sequence = m.sequence
+                return m.data[:m.length], m.first_message_offset, num_drops
+
+            else:
+                self.debug('dup/reordered message '+str(m.sequence))
+
+        return None, 0, 0
+
+
+    def check_sequence(self, seq):
+        ''' check if a sequence is newer than the previously received one & if
+        there were dropped messages between the last and this '''
+        if self.last_sequence == -1:
+            return True, 0
+        if seq == self.last_sequence: # duplicate
+            return False, 0
+        if seq > self.last_sequence:
+            # account for wrap-arounds, sequence is 2 bytes
+            if seq - self.last_sequence > (1<<15): # assume reordered
+                return False, 0
+            return True, seq - self.last_sequence - 1
+        else:
+            if self.last_sequence - seq > (1<<15):
+                return True, (1<<16) - self.last_sequence - 1 + seq
+            return False, 0
+
+
+    def process_streamed_ulog_data(self, data, first_msg_start, num_drops):
+        ''' write streamed data to a file '''
+        if not self.got_ulog_header: # the first 16 bytes need special treatment
+            if len(data) < 16: # that's never the case anyway
+                raise Exception('first received message too short')
+            self.file.write(bytearray(data[0:16]))
+            data = data[16:]
+            self.got_ulog_header = True
+
+        if self.got_header_section and num_drops > 0:
+            if num_drops > 25: num_drops = 25
+            # write a dropout message. We don't really know the actual duration,
+            # so just use the number of drops * 10 ms
+            self.file.write(bytearray([ 2, 0, 79, num_drops*10, 0 ]))
+
+        if num_drops > 0:
+            self.write_ulog_messages(self.ulog_message)
+            self.ulog_message = []
+            if first_msg_start == 255:
+                return # no useful information in this message: drop it
+            data = data[first_msg_start:]
+            first_msg_start = 0
+
+        if first_msg_start == 255 and len(self.ulog_message) > 0:
+            self.ulog_message.extend(data)
+            return
+
+        if len(self.ulog_message) > 0:
+            self.file.write(bytearray(self.ulog_message + data[:first_msg_start]))
+            self.ulog_message = []
+
+        data = self.write_ulog_messages(data[first_msg_start:])
+        self.ulog_message = data # store the rest for the next message
+
+
+    def write_ulog_messages(self, data):
+        ''' write ulog data w/o integrity checking, assuming data starts with a
+        valid ulog message. returns the remaining data at the end. '''
+        while len(data) > 2:
+            message_length = data[0] + data[1] * 256 + 3 # 3=ULog msg header
+            if message_length > len(data):
+                break
+            self.file.write(bytearray(data[:message_length]))
+            data = data[message_length:]
+        return data
+
+
+
+def main():
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument('port', metavar='PORT', nargs='?', default = None,
+            help='Mavlink port name: serial: DEVICE[,BAUD], udp: IP:PORT, tcp: tcp:IP:PORT. Eg: \
+/dev/ttyUSB0 or 0.0.0.0:14550. Auto-detect serial if not given.')
+    parser.add_argument("--baudrate", "-b", dest="baudrate", type=int,
+                      help="Mavlink port baud rate (default=115200)", default=115200)
+    parser.add_argument("--output", "-o", dest="output", default = '.',
+                      help="output file or directory (default=CWD)")
+    args = parser.parse_args()
+
+    if os.path.isdir(args.output):
+        filename = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S.ulg")
+        filename = os.path.join(args.output, filename)
+    else:
+        filename = args.output
+    print('Output file name: {:}'.format(filename))
+
+    if args.port == None:
+        serial_list = mavutil.auto_detect_serial(preferred_list=['*FTDI*',
+            "*Arduino_Mega_2560*", "*3D_Robotics*", "*USB_to_UART*", '*PX4*', '*FMU*'])
+
+        if len(serial_list) == 0:
+            print("Error: no serial connection found")
+            return
+
+        if len(serial_list) > 1:
+            print('Auto-detected serial ports are:')
+            for port in serial_list:
+                print(" {:}".format(port))
+        print('Using port {:}'.format(serial_list[0]))
+        args.port = serial_list[0].device
+
+
+    print("Connecting to MAVLINK...")
+    mav_log_streaming = MavlinkLogStreaming(args.port, args.baudrate, filename)
+
+    try:
+        print('Starting log...')
+        mav_log_streaming.start_log()
+        mav_log_streaming.read_messages()
+
+        print('Stopping log')
+        mav_log_streaming.stop_log()
+
+    except KeyboardInterrupt:
+        print('Stopping log')
+        mav_log_streaming.stop_log()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -101,6 +101,8 @@ set(msg_file_names
 	transponder_report.msg
 	uavcan_parameter_request.msg
 	uavcan_parameter_value.msg
+	ulog_stream.msg
+	ulog_stream_ack.msg
 	vehicle_attitude.msg
 	vehicle_attitude_setpoint.msg
 	vehicle_command_ack.msg

--- a/msg/ulog_stream.msg
+++ b/msg/ulog_stream.msg
@@ -12,5 +12,5 @@ uint8 first_message_offset   # offset into data where first message starts. This
                              # can be used for recovery, when a previous message got lost
 uint16 sequence              # allows determine drops
 uint8 flags                  # see FLAGS_*
-uint8[251] data              # ulog data
+uint8[249] data              # ulog data
 

--- a/msg/ulog_stream.msg
+++ b/msg/ulog_stream.msg
@@ -1,0 +1,16 @@
+# Message to stream ULog data from the logger. Corresponds to the LOGGING_DATA
+# mavlink message
+
+# flags bitmasks
+uint8 FLAGS_NEED_ACK = 1     # if set, this message requires to be acked.
+                             # Acked messages are published synchronous: a
+                             # publisher waits for an ack before sending the
+                             # next message
+
+uint8 length                 # length of data
+uint8 first_message_offset   # offset into data where first message starts. This
+                             # can be used for recovery, when a previous message got lost
+uint16 sequence              # allows determine drops
+uint8 flags                  # see FLAGS_*
+uint8[251] data              # ulog data
+

--- a/msg/ulog_stream_ack.msg
+++ b/msg/ulog_stream_ack.msg
@@ -1,0 +1,7 @@
+# Ack a previously sent ulog_stream message that had
+# the NEED_ACK flag set
+
+int32 ACK_TIMEOUT = 300         # timeout waiting for an ack until we retry to send the message [ms]
+int32 ACK_MAX_TRIES = 9         # maximum amount of tries to (re-)send a message, each time waiting ACK_TIMEOUT ms
+
+uint16 sequence

--- a/msg/vehicle_command.msg
+++ b/msg/vehicle_command.msg
@@ -61,6 +61,8 @@ uint32 VEHICLE_CMD_DO_VTOL_TRANSITION = 3000    # Command VTOL transition
 uint32 VEHICLE_CMD_PAYLOAD_PREPARE_DEPLOY = 30001	# Prepare a payload deployment in the flight plan
 uint32 VEHICLE_CMD_PAYLOAD_CONTROL_DEPLOY = 30002	# Control a pre-programmed payload deployment
 uint32 VEHICLE_CMD_PREFLIGHT_UAVCAN = 243		# UAVCAN configuration. If param 1 == 1 actuator mapping and direction assignment should be started
+uint32 VEHICLE_CMD_LOGGING_START = 2510		# start streaming ULog data
+uint32 VEHICLE_CMD_LOGGING_STOP = 2511			# stop streaming ULog data
 
 uint32 VEHICLE_CMD_RESULT_ACCEPTED = 0			# Command ACCEPTED and EXECUTED |
 uint32 VEHICLE_CMD_RESULT_TEMPORARILY_REJECTED = 1	# Command TEMPORARY REJECTED/DENIED |

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1122,6 +1122,8 @@ bool handle_command(struct vehicle_status_s *status_local, const struct safety_s
 	case vehicle_command_s::VEHICLE_CMD_DO_CHANGE_SPEED:
 	case vehicle_command_s::VEHICLE_CMD_DO_GO_AROUND:
 	case vehicle_command_s::VEHICLE_CMD_START_RX_PAIR:
+	case vehicle_command_s::VEHICLE_CMD_LOGGING_START:
+	case vehicle_command_s::VEHICLE_CMD_LOGGING_STOP:
 		/* ignore commands that handled in low prio loop */
 		break;
 

--- a/src/modules/logger/CMakeLists.txt
+++ b/src/modules/logger/CMakeLists.txt
@@ -41,6 +41,7 @@ px4_add_module(
 		logger.cpp
 		log_writer.cpp
 		log_writer_file.cpp
+		log_writer_mavlink.cpp
 	DEPENDS
 		platforms__common
 		modules__uORB

--- a/src/modules/logger/CMakeLists.txt
+++ b/src/modules/logger/CMakeLists.txt
@@ -40,6 +40,7 @@ px4_add_module(
 	SRCS
 		logger.cpp
 		log_writer.cpp
+		log_writer_file.cpp
 	DEPENDS
 		platforms__common
 		modules__uORB

--- a/src/modules/logger/log_writer.cpp
+++ b/src/modules/logger/log_writer.cpp
@@ -38,10 +38,10 @@ namespace px4
 namespace logger
 {
 
-LogWriter::LogWriter(Backend backend, size_t file_buffer_size, unsigned int queue_size)
-	: _backend(backend)
+LogWriter::LogWriter(Backend configured_backend, size_t file_buffer_size, unsigned int queue_size)
+	: _backend(configured_backend)
 {
-	if (backend & BackendFile) {
+	if (configured_backend & BackendFile) {
 		_log_writer_file_for_write = _log_writer_file = new LogWriterFile(file_buffer_size);
 
 		if (!_log_writer_file) {
@@ -49,7 +49,7 @@ LogWriter::LogWriter(Backend backend, size_t file_buffer_size, unsigned int queu
 		}
 	}
 
-	if (backend & BackendMavlink) {
+	if (configured_backend & BackendMavlink) {
 		_log_writer_mavlink_for_write = _log_writer_mavlink = new LogWriterMavlink(queue_size);
 
 		if (!_log_writer_mavlink) {
@@ -110,13 +110,13 @@ bool LogWriter::is_started() const
 	return ret;
 }
 
-bool LogWriter::is_started(Backend backend) const
+bool LogWriter::is_started(Backend query_backend) const
 {
-	if (backend == BackendFile && _log_writer_file) {
+	if (query_backend == BackendFile && _log_writer_file) {
 		return _log_writer_file->is_started();
 	}
 
-	if (backend == BackendMavlink && _log_writer_mavlink) {
+	if (query_backend == BackendMavlink && _log_writer_mavlink) {
 		return _log_writer_mavlink->is_started();
 	}
 
@@ -178,16 +178,16 @@ int LogWriter::write_message(void *ptr, size_t size, uint64_t dropout_start)
 	return ret_mavlink;
 }
 
-void LogWriter::select_write_backend(Backend backend)
+void LogWriter::select_write_backend(Backend sel_backend)
 {
-	if (backend & BackendFile) {
+	if (sel_backend & BackendFile) {
 		_log_writer_file_for_write = _log_writer_file;
 
 	} else {
 		_log_writer_file_for_write = nullptr;
 	}
 
-	if (backend & BackendMavlink) {
+	if (sel_backend & BackendMavlink) {
 		_log_writer_mavlink_for_write = _log_writer_mavlink;
 
 	} else {

--- a/src/modules/logger/log_writer.cpp
+++ b/src/modules/logger/log_writer.cpp
@@ -38,7 +38,7 @@ namespace px4
 namespace logger
 {
 
-LogWriter::LogWriter(Backend backend, size_t file_buffer_size)
+LogWriter::LogWriter(Backend backend, size_t file_buffer_size, unsigned int queue_size)
 	: _backend(backend)
 {
 	if (backend & BackendFile) {
@@ -88,9 +88,9 @@ bool LogWriter::is_started() const
 	return ret;
 }
 
-bool LogWriter::is_started_file() const
+bool LogWriter::is_started(Backend backend) const
 {
-	if (_log_writer_file) {
+	if (backend == BackendFile && _log_writer_file) {
 		return _log_writer_file->is_started();
 	}
 

--- a/src/modules/logger/log_writer.cpp
+++ b/src/modules/logger/log_writer.cpp
@@ -54,8 +54,17 @@ bool LogWriter::init()
 {
 	if (_log_writer_file) {
 		if (!_log_writer_file->init()) {
+			PX4_ERR("alloc failed");
 			return false;
 		}
+
+		int ret = _log_writer_file->thread_start();
+
+		if (ret) {
+			PX4_ERR("failed to create writer thread (%i)", ret);
+			return false;
+		}
+
 	}
 
 	return true;
@@ -100,15 +109,6 @@ void LogWriter::stop_log_file()
 	if (_log_writer_file) {
 		_log_writer_file->stop_log();
 	}
-}
-
-int LogWriter::thread_start(pthread_t &thread)
-{
-	if (_log_writer_file) {
-		return _log_writer_file->thread_start(thread);
-	}
-
-	return 0;
 }
 
 void LogWriter::thread_stop()

--- a/src/modules/logger/log_writer.cpp
+++ b/src/modules/logger/log_writer.cpp
@@ -32,280 +32,99 @@
  ****************************************************************************/
 
 #include "log_writer.h"
-#include "messages.h"
-#include <fcntl.h>
-#include <string.h>
-
-#include <mathlib/mathlib.h>
 
 namespace px4
 {
 namespace logger
 {
-constexpr size_t LogWriter::_min_write_chunk;
 
-
-LogWriter::LogWriter(size_t buffer_size) :
-	//We always write larger chunks (orb messages) to the buffer, so the buffer
-	//needs to be larger than the minimum write chunk (300 is somewhat arbitrary)
-	_buffer_size(math::max(buffer_size, _min_write_chunk + 300))
+LogWriter::LogWriter(Backend backend, size_t file_buffer_size)
+	: _backend(backend)
 {
-	pthread_mutex_init(&_mtx, nullptr);
-	pthread_cond_init(&_cv, nullptr);
-	/* allocate write performance counters */
-	_perf_write = perf_alloc(PC_ELAPSED, "sd write");
-	_perf_fsync = perf_alloc(PC_ELAPSED, "sd fsync");
+	if (backend & BackendFile) {
+		_log_writer_file = new LogWriterFile(file_buffer_size);
+
+		if (!_log_writer_file) {
+			PX4_ERR("LogWriterFile allocation failed");
+		}
+	}
 }
 
 bool LogWriter::init()
 {
-	if (_buffer) {
-		return true;
+	if (_log_writer_file) {
+		if (!_log_writer_file->init()) {
+			return false;
+		}
 	}
 
-	_buffer = new uint8_t[_buffer_size];
-
-	return _buffer;
+	return true;
 }
 
 LogWriter::~LogWriter()
 {
-	pthread_mutex_destroy(&_mtx);
-	pthread_cond_destroy(&_cv);
-	perf_free(_perf_write);
-	perf_free(_perf_fsync);
-
-	if (_buffer) {
-		delete[] _buffer;
+	if (_log_writer_file) {
+		delete(_log_writer_file);
 	}
 }
 
-void LogWriter::start_log(const char *filename)
+bool LogWriter::is_started() const
 {
-	_fd = ::open(filename, O_CREAT | O_WRONLY, PX4_O_MODE_666);
+	bool ret = false;
 
-	if (_fd < 0) {
-		PX4_ERR("Can't open log file %s", filename);
-		_should_run = false;
-		return;
-
-	} else {
-		PX4_INFO("Opened log file: %s", filename);
-		_should_run = true;
-		_running = true;
+	if (_log_writer_file) {
+		ret = _log_writer_file->is_started();
 	}
-
-	// Clear buffer and counters
-	_head = 0;
-	_count = 0;
-	_total_written = 0;
-	notify();
-}
-
-void LogWriter::stop_log()
-{
-	_should_run = false;
-	notify();
-}
-
-int LogWriter::thread_start(pthread_t &thread)
-{
-	pthread_attr_t thr_attr;
-	pthread_attr_init(&thr_attr);
-
-	sched_param param;
-	/* low priority, as this is expensive disk I/O */
-	param.sched_priority = SCHED_PRIORITY_DEFAULT - 40;
-	(void)pthread_attr_setschedparam(&thr_attr, &param);
-
-	pthread_attr_setstacksize(&thr_attr, PX4_STACK_ADJUSTED(1024));
-
-	int ret = pthread_create(&thread, &thr_attr, &LogWriter::run_helper, this);
-	pthread_attr_destroy(&thr_attr);
 
 	return ret;
 }
 
+bool LogWriter::is_started_file() const
+{
+	if (_log_writer_file) {
+		return _log_writer_file->is_started();
+	}
+
+	return false;
+}
+
+void LogWriter::start_log_file(const char *filename)
+{
+	if (_log_writer_file) {
+		_log_writer_file->start_log(filename);
+	}
+}
+
+void LogWriter::stop_log_file()
+{
+	if (_log_writer_file) {
+		_log_writer_file->stop_log();
+	}
+}
+
+int LogWriter::thread_start(pthread_t &thread)
+{
+	if (_log_writer_file) {
+		return _log_writer_file->thread_start(thread);
+	}
+
+	return 0;
+}
+
 void LogWriter::thread_stop()
 {
-	// this will terminate the main loop of the writer thread
-	_exit_thread = true;
-	_should_run = false;
-}
-
-void *LogWriter::run_helper(void *context)
-{
-	px4_prctl(PR_SET_NAME, "log_writer", px4_getpid());
-
-	reinterpret_cast<LogWriter *>(context)->run();
-	return nullptr;
-}
-
-void LogWriter::run()
-{
-	while (!_exit_thread) {
-		// Outer endless loop
-		// Wait for _should_run flag
-		while (!_exit_thread) {
-			bool start = false;
-			pthread_mutex_lock(&_mtx);
-			pthread_cond_wait(&_cv, &_mtx);
-			start = _should_run;
-			pthread_mutex_unlock(&_mtx);
-
-			if (start) {
-				break;
-			}
-		}
-
-		int poll_count = 0;
-		int written = 0;
-
-		while (true) {
-			size_t available = 0;
-			void *read_ptr = nullptr;
-			bool is_part = false;
-
-			/* lock _buffer
-			 * wait for sufficient data, cycle on notify()
-			 */
-			pthread_mutex_lock(&_mtx);
-
-			while (true) {
-				available = get_read_ptr(&read_ptr, &is_part);
-
-				/* if sufficient data available or partial read or terminating, exit this wait loop */
-				if ((available >= _min_write_chunk) || is_part || !_should_run) {
-					/* GOTO end of block */
-					break;
-				}
-
-				/* wait for a call to notify()
-				 * this call unlocks the mutex while waiting, and returns with the mutex locked
-				 */
-				pthread_cond_wait(&_cv, &_mtx);
-			}
-
-			pthread_mutex_unlock(&_mtx);
-			written = 0;
-
-			if (available > 0) {
-				perf_begin(_perf_write);
-				written = ::write(_fd, read_ptr, available);
-				perf_end(_perf_write);
-
-				/* call fsync periodically to minimize potential loss of data */
-				if (++poll_count >= 100) {
-					perf_begin(_perf_fsync);
-					::fsync(_fd);
-					perf_end(_perf_fsync);
-					poll_count = 0;
-				}
-
-				if (written < 0) {
-					PX4_WARN("error writing log file");
-					_should_run = false;
-					/* GOTO end of block */
-					break;
-				}
-
-				pthread_mutex_lock(&_mtx);
-				/* subtract bytes written from number in _buffer (_count -= written) */
-				mark_read(written);
-				pthread_mutex_unlock(&_mtx);
-
-				_total_written += written;
-			}
-
-			if (!_should_run && written == static_cast<int>(available) && !is_part) {
-				// Stop only when all data written
-				_running = false;
-				_head = 0;
-				_count = 0;
-
-				if (_fd >= 0) {
-					int res = ::close(_fd);
-					_fd = -1;
-
-					if (res) {
-						PX4_WARN("error closing log file");
-
-					} else {
-						PX4_INFO("closed logfile, bytes written: %zu", _total_written);
-					}
-				}
-
-				break;
-			}
-		}
+	if (_log_writer_file) {
+		_log_writer_file->thread_stop();
 	}
 }
 
 bool LogWriter::write(void *ptr, size_t size, uint64_t dropout_start)
 {
-
-	// Bytes available to write
-	size_t available = _buffer_size - _count;
-	size_t dropout_size = 0;
-
-	if (dropout_start) {
-		dropout_size = sizeof(ulog_message_dropout_s);
+	if (_log_writer_file) {
+		return _log_writer_file->write(ptr, size, dropout_start);
 	}
 
-	if (size + dropout_size > available) {
-		// buffer overflow
-		return false;
-	}
-
-	if (dropout_start) {
-		//write dropout msg
-		ulog_message_dropout_s dropout_msg;
-		dropout_msg.duration = (uint16_t)(hrt_elapsed_time(&dropout_start) / 1000);
-		write_no_check(&dropout_msg, sizeof(dropout_msg));
-	}
-
-	write_no_check(ptr, size);
 	return true;
-}
-
-void LogWriter::write_no_check(void *ptr, size_t size)
-{
-	size_t n = _buffer_size - _head;	// bytes to end of the buffer
-
-	uint8_t *buffer_c = reinterpret_cast<uint8_t *>(ptr);
-
-	if (size > n) {
-		// Message goes over the end of the buffer
-		memcpy(&(_buffer[_head]), buffer_c, n);
-		_head = 0;
-
-	} else {
-		n = 0;
-	}
-
-	// now: n = bytes already written
-	size_t p = size - n;	// number of bytes to write
-	memcpy(&(_buffer[_head]), &(buffer_c[n]), p);
-	_head = (_head + p) % _buffer_size;
-	_count += size;
-}
-
-size_t LogWriter::get_read_ptr(void **ptr, bool *is_part)
-{
-	// bytes available to read
-	int read_ptr = _head - _count;
-
-	if (read_ptr < 0) {
-		read_ptr += _buffer_size;
-		*ptr = &_buffer[read_ptr];
-		*is_part = true;
-		return _buffer_size - read_ptr;
-
-	} else {
-		*ptr = &_buffer[read_ptr];
-		*is_part = false;
-		return _count;
-	}
 }
 
 }

--- a/src/modules/logger/log_writer.cpp
+++ b/src/modules/logger/log_writer.cpp
@@ -118,13 +118,20 @@ void LogWriter::thread_stop()
 	}
 }
 
-bool LogWriter::write(void *ptr, size_t size, uint64_t dropout_start)
+int LogWriter::write_message(void *ptr, size_t size, uint64_t dropout_start)
 {
+	int ret_file = 0, ret_mavlink = 0;
+
 	if (_log_writer_file) {
-		return _log_writer_file->write(ptr, size, dropout_start);
+		ret_file = _log_writer_file->write_message(ptr, size, dropout_start);
 	}
 
-	return true;
+	// file backend errors takes precedence
+	if (ret_file != 0) {
+		return ret_file;
+	}
+
+	return ret_mavlink;
 }
 
 }

--- a/src/modules/logger/log_writer.h
+++ b/src/modules/logger/log_writer.h
@@ -55,7 +55,7 @@ public:
 	static constexpr Backend BackendMavlink = 1 << 1;
 	static constexpr Backend BackendAll = BackendFile | BackendMavlink;
 
-	LogWriter(Backend backend, size_t file_buffer_size, unsigned int queue_size);
+	LogWriter(Backend configured_backend, size_t file_buffer_size, unsigned int queue_size);
 	~LogWriter();
 
 	bool init();
@@ -81,7 +81,7 @@ public:
 	/**
 	 * whether logging is currently active or not for a specific backend.
 	 */
-	bool is_started(Backend backend) const;
+	bool is_started(Backend query_backend) const;
 
 	/**
 	 * Write a single ulog message (including header). The caller must call lock() before calling this.
@@ -93,10 +93,10 @@ public:
 
 	/**
 	 * Select a backend, so that future calls to write_message() only write to the selected
-	 * backend, until unselect_write_backend() is called.
+	 * sel_backend, until unselect_write_backend() is called.
 	 * @param backend
 	 */
-	void select_write_backend(Backend backend);
+	void select_write_backend(Backend sel_backend);
 	void unselect_write_backend() { select_write_backend(BackendAll); }
 
 	/* file logging methods */

--- a/src/modules/logger/log_writer.h
+++ b/src/modules/logger/log_writer.h
@@ -51,9 +51,10 @@ public:
 	/** bitfield to specify a backend */
 	typedef uint8_t Backend;
 	static constexpr Backend BackendFile = 1 << 0;
-	static constexpr Backend BackendAll = BackendFile;
+	static constexpr Backend BackendMavlink = 1 << 1;
+	static constexpr Backend BackendAll = BackendFile | BackendMavlink;
 
-	LogWriter(Backend backend, size_t file_buffer_size);
+	LogWriter(Backend backend, size_t file_buffer_size, unsigned int queue_size);
 	~LogWriter();
 
 	bool init();
@@ -68,14 +69,14 @@ public:
 	void stop_log_file();
 
 	/**
-	 * whether logging is currently active or not.
+	 * whether logging is currently active or not (any of the selected backends).
 	 */
 	bool is_started() const;
 
 	/**
-	 * whether file logging is currently active or not.
+	 * whether logging is currently active or not for a specific backend.
 	 */
-	bool is_started_file() const;
+	bool is_started(Backend backend) const;
 
 	/**
 	 * Write data to be logged. The caller must call lock() before calling this.

--- a/src/modules/logger/log_writer.h
+++ b/src/modules/logger/log_writer.h
@@ -60,13 +60,7 @@ public:
 
 	Backend backend() const { return _backend; }
 
-	/**
-	 * start the thread
-	 * @param thread will be set to the created thread on success
-	 * @return 0 on success, error number otherwise (@see pthread_create)
-	 */
-	int thread_start(pthread_t &thread);
-
+	/** stop all running threads and wait for them to exit */
 	void thread_stop();
 
 	void start_log_file(const char *filename);

--- a/src/modules/logger/log_writer.h
+++ b/src/modules/logger/log_writer.h
@@ -66,6 +66,11 @@ public:
 	void stop_log();
 
 	/**
+	 * whether logging is currently active or not.
+	 */
+	bool is_started() const { return _should_run; }
+
+	/**
 	 * Write data to be logged. The caller must call lock() before calling this.
 	 * @param dropout_start timestamp when lastest dropout occured. 0 if no dropout at the moment.
 	 * @return true on success, false if not enough space in the buffer left

--- a/src/modules/logger/log_writer_file.cpp
+++ b/src/modules/logger/log_writer_file.cpp
@@ -1,0 +1,312 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "log_writer_file.h"
+#include "messages.h"
+#include <fcntl.h>
+#include <string.h>
+
+#include <mathlib/mathlib.h>
+
+namespace px4
+{
+namespace logger
+{
+constexpr size_t LogWriterFile::_min_write_chunk;
+
+
+LogWriterFile::LogWriterFile(size_t buffer_size) :
+	//We always write larger chunks (orb messages) to the buffer, so the buffer
+	//needs to be larger than the minimum write chunk (300 is somewhat arbitrary)
+	_buffer_size(math::max(buffer_size, _min_write_chunk + 300))
+{
+	pthread_mutex_init(&_mtx, nullptr);
+	pthread_cond_init(&_cv, nullptr);
+	/* allocate write performance counters */
+	_perf_write = perf_alloc(PC_ELAPSED, "sd write");
+	_perf_fsync = perf_alloc(PC_ELAPSED, "sd fsync");
+}
+
+bool LogWriterFile::init()
+{
+	if (_buffer) {
+		return true;
+	}
+
+	_buffer = new uint8_t[_buffer_size];
+
+	return _buffer;
+}
+
+LogWriterFile::~LogWriterFile()
+{
+	pthread_mutex_destroy(&_mtx);
+	pthread_cond_destroy(&_cv);
+	perf_free(_perf_write);
+	perf_free(_perf_fsync);
+
+	if (_buffer) {
+		delete[] _buffer;
+	}
+}
+
+void LogWriterFile::start_log(const char *filename)
+{
+	_fd = ::open(filename, O_CREAT | O_WRONLY, PX4_O_MODE_666);
+
+	if (_fd < 0) {
+		PX4_ERR("Can't open log file %s", filename);
+		_should_run = false;
+		return;
+
+	} else {
+		PX4_INFO("Opened log file: %s", filename);
+		_should_run = true;
+		_running = true;
+	}
+
+	// Clear buffer and counters
+	_head = 0;
+	_count = 0;
+	_total_written = 0;
+	notify();
+}
+
+void LogWriterFile::stop_log()
+{
+	_should_run = false;
+	notify();
+}
+
+int LogWriterFile::thread_start(pthread_t &thread)
+{
+	pthread_attr_t thr_attr;
+	pthread_attr_init(&thr_attr);
+
+	sched_param param;
+	/* low priority, as this is expensive disk I/O */
+	param.sched_priority = SCHED_PRIORITY_DEFAULT - 40;
+	(void)pthread_attr_setschedparam(&thr_attr, &param);
+
+	pthread_attr_setstacksize(&thr_attr, PX4_STACK_ADJUSTED(1024));
+
+	int ret = pthread_create(&thread, &thr_attr, &LogWriterFile::run_helper, this);
+	pthread_attr_destroy(&thr_attr);
+
+	return ret;
+}
+
+void LogWriterFile::thread_stop()
+{
+	// this will terminate the main loop of the writer thread
+	_exit_thread = true;
+	_should_run = false;
+}
+
+void *LogWriterFile::run_helper(void *context)
+{
+	px4_prctl(PR_SET_NAME, "log_writer_file", px4_getpid());
+
+	reinterpret_cast<LogWriterFile *>(context)->run();
+	return nullptr;
+}
+
+void LogWriterFile::run()
+{
+	while (!_exit_thread) {
+		// Outer endless loop
+		// Wait for _should_run flag
+		while (!_exit_thread) {
+			bool start = false;
+			pthread_mutex_lock(&_mtx);
+			pthread_cond_wait(&_cv, &_mtx);
+			start = _should_run;
+			pthread_mutex_unlock(&_mtx);
+
+			if (start) {
+				break;
+			}
+		}
+
+		int poll_count = 0;
+		int written = 0;
+
+		while (true) {
+			size_t available = 0;
+			void *read_ptr = nullptr;
+			bool is_part = false;
+
+			/* lock _buffer
+			 * wait for sufficient data, cycle on notify()
+			 */
+			pthread_mutex_lock(&_mtx);
+
+			while (true) {
+				available = get_read_ptr(&read_ptr, &is_part);
+
+				/* if sufficient data available or partial read or terminating, exit this wait loop */
+				if ((available >= _min_write_chunk) || is_part || !_should_run) {
+					/* GOTO end of block */
+					break;
+				}
+
+				/* wait for a call to notify()
+				 * this call unlocks the mutex while waiting, and returns with the mutex locked
+				 */
+				pthread_cond_wait(&_cv, &_mtx);
+			}
+
+			pthread_mutex_unlock(&_mtx);
+			written = 0;
+
+			if (available > 0) {
+				perf_begin(_perf_write);
+				written = ::write(_fd, read_ptr, available);
+				perf_end(_perf_write);
+
+				/* call fsync periodically to minimize potential loss of data */
+				if (++poll_count >= 100) {
+					perf_begin(_perf_fsync);
+					::fsync(_fd);
+					perf_end(_perf_fsync);
+					poll_count = 0;
+				}
+
+				if (written < 0) {
+					PX4_WARN("error writing log file");
+					_should_run = false;
+					/* GOTO end of block */
+					break;
+				}
+
+				pthread_mutex_lock(&_mtx);
+				/* subtract bytes written from number in _buffer (_count -= written) */
+				mark_read(written);
+				pthread_mutex_unlock(&_mtx);
+
+				_total_written += written;
+			}
+
+			if (!_should_run && written == static_cast<int>(available) && !is_part) {
+				// Stop only when all data written
+				_running = false;
+				_head = 0;
+				_count = 0;
+
+				if (_fd >= 0) {
+					int res = ::close(_fd);
+					_fd = -1;
+
+					if (res) {
+						PX4_WARN("error closing log file");
+
+					} else {
+						PX4_INFO("closed logfile, bytes written: %zu", _total_written);
+					}
+				}
+
+				break;
+			}
+		}
+	}
+}
+
+bool LogWriterFile::write(void *ptr, size_t size, uint64_t dropout_start)
+{
+
+	// Bytes available to write
+	size_t available = _buffer_size - _count;
+	size_t dropout_size = 0;
+
+	if (dropout_start) {
+		dropout_size = sizeof(ulog_message_dropout_s);
+	}
+
+	if (size + dropout_size > available) {
+		// buffer overflow
+		return false;
+	}
+
+	if (dropout_start) {
+		//write dropout msg
+		ulog_message_dropout_s dropout_msg;
+		dropout_msg.duration = (uint16_t)(hrt_elapsed_time(&dropout_start) / 1000);
+		write_no_check(&dropout_msg, sizeof(dropout_msg));
+	}
+
+	write_no_check(ptr, size);
+	return true;
+}
+
+void LogWriterFile::write_no_check(void *ptr, size_t size)
+{
+	size_t n = _buffer_size - _head;	// bytes to end of the buffer
+
+	uint8_t *buffer_c = reinterpret_cast<uint8_t *>(ptr);
+
+	if (size > n) {
+		// Message goes over the end of the buffer
+		memcpy(&(_buffer[_head]), buffer_c, n);
+		_head = 0;
+
+	} else {
+		n = 0;
+	}
+
+	// now: n = bytes already written
+	size_t p = size - n;	// number of bytes to write
+	memcpy(&(_buffer[_head]), &(buffer_c[n]), p);
+	_head = (_head + p) % _buffer_size;
+	_count += size;
+}
+
+size_t LogWriterFile::get_read_ptr(void **ptr, bool *is_part)
+{
+	// bytes available to read
+	int read_ptr = _head - _count;
+
+	if (read_ptr < 0) {
+		read_ptr += _buffer_size;
+		*ptr = &_buffer[read_ptr];
+		*is_part = true;
+		return _buffer_size - read_ptr;
+
+	} else {
+		*ptr = &_buffer[read_ptr];
+		*is_part = false;
+		return _count;
+	}
+}
+
+}
+}

--- a/src/modules/logger/log_writer_file.h
+++ b/src/modules/logger/log_writer_file.h
@@ -58,10 +58,9 @@ public:
 
 	/**
 	 * start the thread
-	 * @param thread will be set to the created thread on success
 	 * @return 0 on success, error number otherwise (@see pthread_create)
 	 */
-	int thread_start(pthread_t &thread);
+	int thread_start();
 
 	void thread_stop();
 
@@ -144,6 +143,7 @@ private:
 	pthread_cond_t		_cv;
 	perf_counter_t _perf_write;
 	perf_counter_t _perf_fsync;
+	pthread_t _thread = 0;
 };
 
 }

--- a/src/modules/logger/log_writer_mavlink.cpp
+++ b/src/modules/logger/log_writer_mavlink.cpp
@@ -1,0 +1,196 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "log_writer_mavlink.h"
+#include "messages.h"
+
+#include <drivers/drv_hrt.h>
+#include <mathlib/mathlib.h>
+#include <px4_log.h>
+#include <px4_posix.h>
+
+namespace px4
+{
+namespace logger
+{
+
+
+LogWriterMavlink::LogWriterMavlink(unsigned int queue_size) :
+	_queue_size(queue_size)
+{
+	_ulog_stream_data.length = 0;
+}
+
+bool LogWriterMavlink::init()
+{
+	return true;
+}
+
+LogWriterMavlink::~LogWriterMavlink()
+{
+	if (_ulog_stream_ack_sub >= 0) {
+		orb_unsubscribe(_ulog_stream_ack_sub);
+	}
+
+	if (_ulog_stream_pub) {
+		orb_unadvertise(_ulog_stream_pub);
+	}
+}
+
+void LogWriterMavlink::start_log()
+{
+	if (_ulog_stream_ack_sub == -1) {
+		_ulog_stream_ack_sub = orb_subscribe(ORB_ID(ulog_stream_ack));
+	}
+
+	// make sure we don't get any stale ack's by doing an orb_copy
+	ulog_stream_ack_s ack;
+	orb_copy(ORB_ID(ulog_stream_ack), _ulog_stream_ack_sub, &ack);
+	_ulog_stream_data.sequence = 0;
+	_ulog_stream_data.length = 0;
+	_ulog_stream_data.first_message_offset = 0;
+	_is_started = true;
+}
+
+void LogWriterMavlink::stop_log()
+{
+	_ulog_stream_data.length = 0;
+	_is_started = false;
+}
+
+int LogWriterMavlink::write_message(void *ptr, size_t size)
+{
+	if (!is_started()) {
+		return 0;
+	}
+
+	const uint8_t data_len = (uint8_t)sizeof(_ulog_stream_data.data);
+	uint8_t *ptr_data = (uint8_t *)ptr;
+
+	if (_ulog_stream_data.first_message_offset == 255) {
+		_ulog_stream_data.first_message_offset = _ulog_stream_data.length;
+	}
+
+	while (size > 0) {
+		size_t send_len = math::min((size_t)data_len - _ulog_stream_data.length, size);
+		memcpy(_ulog_stream_data.data + _ulog_stream_data.length, ptr_data, send_len);
+		_ulog_stream_data.length += send_len;
+		ptr_data += send_len;
+		size -= send_len;
+
+		if (_ulog_stream_data.length >= data_len) {
+			if (publish_message()) {
+				return -2;
+			}
+		}
+	}
+
+	return 0;
+}
+
+void LogWriterMavlink::set_need_reliable_transfer(bool need_reliable)
+{
+	if (!need_reliable && _need_reliable_transfer) {
+		if (_ulog_stream_data.length > 0) {
+			// make sure to send previous data using reliable transfer
+			publish_message();
+		}
+	}
+
+	_need_reliable_transfer = need_reliable;
+}
+
+int LogWriterMavlink::publish_message()
+{
+	_ulog_stream_data.timestamp = hrt_absolute_time();
+	_ulog_stream_data.flags = 0;
+
+	if (_need_reliable_transfer) {
+		_ulog_stream_data.flags = _ulog_stream_data.FLAGS_NEED_ACK;
+	}
+
+	if (_ulog_stream_pub == nullptr) {
+		_ulog_stream_pub = orb_advertise_queue(ORB_ID(ulog_stream), &_ulog_stream_data, _queue_size);
+
+	} else {
+		orb_publish(ORB_ID(ulog_stream), _ulog_stream_pub, &_ulog_stream_data);
+	}
+
+	if (_need_reliable_transfer) {
+		// we need to wait for an ack. Note that this blocks the main logger thread, so if a file logging
+		// is already running, it will miss samples.
+		px4_pollfd_struct_t fds[1];
+		fds[0].fd = _ulog_stream_ack_sub;
+		fds[0].events = POLLIN;
+		bool got_ack = false;
+		const int timeout_ms = ulog_stream_ack_s::ACK_TIMEOUT * ulog_stream_ack_s::ACK_MAX_TRIES;
+
+		hrt_abstime started = hrt_absolute_time();
+
+		do {
+			int ret = px4_poll(fds, sizeof(fds) / sizeof(fds[0]), timeout_ms);
+
+			if (ret <= 0) {
+				break;
+			}
+
+			if (fds[0].revents & POLLIN) {
+				ulog_stream_ack_s ack;
+				orb_copy(ORB_ID(ulog_stream_ack), _ulog_stream_ack_sub, &ack);
+
+				if (ack.sequence == _ulog_stream_data.sequence) {
+					got_ack = true;
+				}
+
+			} else {
+				break;
+			}
+		} while (!got_ack && hrt_elapsed_time(&started) / 1000 < timeout_ms);
+
+		if (!got_ack) {
+			PX4_ERR("Ack timeout. Stopping mavlink log");
+			stop_log();
+			return -2;
+		}
+
+		PX4_DEBUG("got ack in %i ms", (int)(hrt_elapsed_time(&started) / 1000));
+	}
+
+	_ulog_stream_data.sequence++;
+	_ulog_stream_data.length = 0;
+	_ulog_stream_data.first_message_offset = 255;
+	return 0;
+}
+
+}
+}

--- a/src/modules/logger/log_writer_mavlink.h
+++ b/src/modules/logger/log_writer_mavlink.h
@@ -1,0 +1,87 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <stdint.h>
+#include <uORB/topics/ulog_stream.h>
+#include <uORB/topics/ulog_stream_ack.h>
+
+namespace px4
+{
+namespace logger
+{
+
+/**
+ * @class LogWriterMavlink
+ * Writes logging data to uORB, and then sent via mavlink
+ */
+class LogWriterMavlink
+{
+public:
+	LogWriterMavlink(unsigned int queue_size);
+	~LogWriterMavlink();
+
+	bool init();
+
+	void start_log();
+
+	void stop_log();
+
+	bool is_started() const { return _is_started; }
+
+	/** @see LogWriter::write_message() */
+	int write_message(void *ptr, size_t size);
+
+	void set_need_reliable_transfer(bool need_reliable);
+
+	bool need_reliable_transfer() const
+	{
+		return _need_reliable_transfer;
+	}
+
+private:
+
+	/** publish message, wait for ack if needed & reset message */
+	int publish_message();
+
+	ulog_stream_s _ulog_stream_data;
+	orb_advert_t _ulog_stream_pub = nullptr;
+	int _ulog_stream_ack_sub = -1;
+	bool _need_reliable_transfer = false;
+	bool _is_started = false;
+	const unsigned int _queue_size;
+};
+
+}
+}

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -215,7 +215,7 @@ int Logger::start(char *const *argv)
 
 void Logger::status()
 {
-	if (!_enabled) {
+	if (!_writer.is_started()) {
 		PX4_INFO("Running, but not logging");
 
 	} else {
@@ -225,7 +225,7 @@ void Logger::status()
 }
 void Logger::print_statistics()
 {
-	if (!_enabled) {
+	if (!_writer.is_started()) {
 		return;
 	}
 
@@ -637,6 +637,7 @@ void Logger::run()
 		PX4_ERR("init of writer failed (alloc failed)");
 		return;
 	}
+
 	pthread_t writer_thread;
 
 	int ret = _writer.thread_start(writer_thread);
@@ -693,7 +694,7 @@ void Logger::run()
 			}
 		}
 
-		if (_enabled) {
+		if (_writer.is_started()) {
 
 			bool data_written = false;
 
@@ -1048,7 +1049,7 @@ bool Logger::get_log_time(struct tm *tt, bool boot_time)
 
 void Logger::start_log()
 {
-	if (_enabled) {
+	if (_writer.is_started()) {
 		return;
 	}
 
@@ -1072,17 +1073,15 @@ void Logger::start_log()
 	write_parameters();
 	write_all_add_logged_msg();
 	_writer.notify();
-	_enabled = true;
 	_start_time = hrt_absolute_time();
 }
 
 void Logger::stop_log()
 {
-	if (!_enabled) {
+	if (!_writer.is_started()) {
 		return;
 	}
 
-	_enabled = false;
 	_writer.stop_log();
 }
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -635,16 +635,7 @@ void Logger::run()
 
 
 	if (!_writer.init()) {
-		PX4_ERR("init of writer failed (alloc failed)");
-		return;
-	}
-
-	pthread_t writer_thread;
-
-	int ret = _writer.thread_start(writer_thread);
-
-	if (ret) {
-		PX4_ERR("failed to create writer thread (%i)", ret);
+		PX4_ERR("writer init failed");
 		return;
 	}
 
@@ -813,15 +804,6 @@ void Logger::run()
 
 	// stop the writer thread
 	_writer.thread_stop();
-
-	_writer.notify();
-
-	// wait for thread to complete
-	ret = pthread_join(writer_thread, NULL);
-
-	if (ret) {
-		PX4_WARN("join failed: %d", ret);
-	}
 
 	//unsubscribe
 	for (LoggerSubscription &sub : _subscriptions) {

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -204,7 +204,7 @@ int Logger::start(char *const *argv)
 	logger_task = px4_task_spawn_cmd("logger",
 					 SCHED_DEFAULT,
 					 SCHED_PRIORITY_MAX - 5,
-					 3200,
+					 3800,
 					 (px4_main_t)&Logger::run_trampoline,
 					 (char *const *)argv);
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -259,7 +259,8 @@ void Logger::run_trampoline(int argc, char *argv[])
 	bool log_until_shutdown = false;
 	bool error_flag = false;
 	bool log_name_timestamp = false;
-	unsigned int queue_size = 5;
+	unsigned int queue_size = 14; //TODO: we might be able to reduce this if mavlink polled on the topic and/or
+	// topic sizes get reduced
 	LogWriter::Backend backend = LogWriter::BackendFile;
 
 	int myoptind = 1;

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1086,7 +1086,6 @@ void Logger::start_log_file()
 
 	/* print logging path, important to find log file later */
 	mavlink_log_info(&_mavlink_log_pub, "[logger] file: %s", file_name);
-	_next_topic_id = 0;
 
 	_writer.start_log_file(file_name);
 	_writer.set_need_reliable_transfer(true);
@@ -1142,9 +1141,12 @@ void Logger::write_add_logged_msg(LoggerSubscription &subscription, int instance
 {
 	ulog_message_add_logged_s msg;
 
+	if (subscription.msg_ids[instance] == (uint16_t) - 1) {
+		subscription.msg_ids[instance] = _next_topic_id++;
+	}
+
+	msg.msg_id = subscription.msg_ids[instance];
 	msg.multi_id = instance;
-	subscription.msg_ids[instance] = _next_topic_id;
-	msg.msg_id = _next_topic_id;
 
 	int message_name_len = strlen(subscription.metadata->o_name);
 
@@ -1157,8 +1159,6 @@ void Logger::write_add_logged_msg(LoggerSubscription &subscription, int instance
 	_writer.set_need_reliable_transfer(true);
 	write_message(&msg, msg_size);
 	_writer.set_need_reliable_transfer(prev_reliable);
-
-	++_next_topic_id;
 }
 
 /* write info message */

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -631,7 +631,10 @@ void Logger::run()
 
 		} else if (errno != EEXIST) {
 			PX4_ERR("failed creating log root dir: %s", LOG_ROOT);
-			return;
+
+			if ((_writer.backend() & ~LogWriter::BackendFile) == 0) {
+				return;
+			}
 		}
 
 		if (check_free_space() == 1) {

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -83,7 +83,6 @@ using namespace px4::logger;
 
 static Logger *logger_ptr = nullptr;
 static int logger_task = -1;
-static pthread_t writer_thread;
 
 /* This is used to schedule work for the logger (periodic scan for updated topics) */
 static void timer_callback(void *arg)
@@ -638,6 +637,7 @@ void Logger::run()
 		PX4_ERR("init of writer failed (alloc failed)");
 		return;
 	}
+	pthread_t writer_thread;
 
 	int ret = _writer.thread_start(writer_thread);
 

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -81,7 +81,7 @@ struct LoggerSubscription {
 class Logger
 {
 public:
-	Logger(size_t buffer_size, uint32_t log_interval, bool log_on_start,
+	Logger(LogWriter::Backend backend, size_t buffer_size, uint32_t log_interval, bool log_on_start,
 	       bool log_until_shutdown, bool log_name_timestamp);
 
 	~Logger();
@@ -152,9 +152,9 @@ private:
 	 */
 	int check_free_space();
 
-	void start_log();
+	void start_log_file();
 
-	void stop_log();
+	void stop_log_file();
 
 	/**
 	 * write the file header with file magic and timestamp.

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -160,6 +160,15 @@ private:
 
 	void stop_log_file();
 
+	void start_log_mavlink();
+
+	void stop_log_mavlink();
+
+	/** check if mavlink logging can be started */
+	bool can_start_mavlink_log() const
+	{
+		return !_writer.is_started(LogWriter::BackendMavlink) && (_writer.backend() & LogWriter::BackendMavlink) != 0;
+	}
 
 	/** get the configured backend as string */
 	const char *configured_backend_mode() const;
@@ -205,6 +214,8 @@ private:
 	int add_topics_from_file(const char *fname);
 
 	void add_default_topics();
+
+	void ack_vehicle_command(orb_advert_t &vehicle_command_ack_pub, uint16_t command, uint32_t result);
 
 	static constexpr size_t 	MAX_TOPICS_NUM = 64; /**< Maximum number of logged topics */
 	static constexpr unsigned	MAX_NO_LOGFOLDER = 999;	/**< Maximum number of log dirs */

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -160,6 +160,10 @@ private:
 
 	void stop_log_file();
 
+
+	/** get the configured backend as string */
+	const char *configured_backend_mode() const;
+
 	/**
 	 * write the file header with file magic and timestamp.
 	 */
@@ -222,7 +226,7 @@ private:
 
 
 	// statistics
-	hrt_abstime					_start_time; ///< Time when logging started (not the logger thread)
+	hrt_abstime					_start_time_file; ///< Time when logging started, file backend (not the logger thread)
 	hrt_abstime					_dropout_start = 0; ///< start of current dropout (0 = no dropout)
 	float						_max_dropout_duration = 0.f; ///< max duration of dropout [s]
 	size_t						_write_dropouts = 0; ///< failed buffer writes due to buffer overflow

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -219,7 +219,6 @@ private:
 	char 						_log_dir[LOG_DIR_LEN];
 	char 						_log_file_name[32];
 	bool						_has_log_dir = false;
-	bool						_enabled = false;
 	bool						_was_armed = false;
 	bool						_arm_override;
 

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -82,7 +82,7 @@ class Logger
 {
 public:
 	Logger(LogWriter::Backend backend, size_t buffer_size, uint32_t log_interval, bool log_on_start,
-	       bool log_until_shutdown, bool log_name_timestamp);
+	       bool log_until_shutdown, bool log_name_timestamp, unsigned int queue_size);
 
 	~Logger();
 

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -75,6 +75,10 @@ struct LoggerSubscription {
 		for (int i = 1; i < ORB_MULTI_MAX_INSTANCES; i++) {
 			fd[i] = -1;
 		}
+
+		for (int i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
+			msg_ids[i] = (uint16_t) - 1;
+		}
 	}
 };
 
@@ -232,7 +236,7 @@ private:
 	uint32_t					_log_interval;
 	param_t						_log_utc_offset;
 	orb_advert_t					_mavlink_log_pub = nullptr;
-	uint16_t					_next_topic_id; ///< id of next subscribed topic
+	uint16_t					_next_topic_id = 0; ///< id of next subscribed ulog topic
 	char						*_replay_file_name = nullptr;
 };
 

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -175,17 +175,11 @@ private:
 	bool copy_if_updated_multi(LoggerSubscription &sub, int multi_instance, void *buffer);
 
 	/**
-	 * Write data to the logger. Waits if buffer is full until all data is written.
-	 * Must be called with _writer.lock() held.
-	 */
-	bool write_wait(void *ptr, size_t size);
-
-	/**
-	 * Write data to the logger and handle dropouts.
+	 * Write exactly one ulog message to the logger and handle dropouts.
 	 * Must be called with _writer.lock() held.
 	 * @return true if data written, false otherwise (on overflow)
 	 */
-	bool write(void *ptr, size_t size);
+	bool write_message(void *ptr, size_t size);
 
 	/**
 	 * Get the time for log file name

--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -49,6 +49,7 @@ px4_add_module(
 		mavlink_ftp.cpp
 		mavlink_log_handler.cpp
 		mavlink_shell.cpp
+		mavlink_ulog.cpp
 	DEPENDS
 		platforms__common
 	)

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1601,8 +1601,13 @@ Mavlink::update_rate_mult()
 		}
 	}
 
+	float mavlink_ulog_streaming_rate_inv = 1.0f;
+	if (_mavlink_ulog) {
+		mavlink_ulog_streaming_rate_inv = 1.f - _mavlink_ulog->current_data_rate();
+	}
+
 	/* scale up and down as the link permits */
-	float bandwidth_mult = (float)(_datarate - const_rate) / rate;
+	float bandwidth_mult = (float)(_datarate * mavlink_ulog_streaming_rate_inv - const_rate) / rate;
 
 	/* if we do not have flow control, limit to the set data rate */
 	if (!get_flow_control_enabled()) {
@@ -2480,6 +2485,10 @@ Mavlink::display_status()
 	printf("\ttxerr: %.3f kB/s\n", (double)_rate_txerr);
 	printf("\trx: %.3f kB/s\n", (double)_rate_rx);
 	printf("\trate mult: %.3f\n", (double)_rate_mult);
+	if (_mavlink_ulog) {
+		printf("\tULog rate: %.1f%% of max %.1f%%\n", (double)_mavlink_ulog->current_data_rate()*100.,
+				(double)_mavlink_ulog->maximum_data_rate()*100.);
+	}
 	printf("\taccepting commands: %s\n", (accepting_commands()) ? "YES" : "NO");
 	printf("\tMAVLink version: %i\n", _protocol_version);
 

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -440,7 +440,7 @@ public:
 	MavlinkULog		*get_ulog_streaming() { return _mavlink_ulog; }
 	void			try_start_ulog_streaming(uint8_t target_system, uint8_t target_component) {
 		if (_mavlink_ulog) { return; }
-		_mavlink_ulog = MavlinkULog::try_start(target_system, target_component);
+		_mavlink_ulog = MavlinkULog::try_start(_datarate, 0.7f, target_system, target_component);
 	}
 	void			request_stop_ulog_streaming() {
 		if (_mavlink_ulog) { _mavlink_ulog_stop_requested = true; }

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -438,9 +438,9 @@ public:
 
 	/** get ulog streaming if active, nullptr otherwise */
 	MavlinkULog		*get_ulog_streaming() { return _mavlink_ulog; }
-	void			try_start_ulog_streaming() {
+	void			try_start_ulog_streaming(uint8_t target_system, uint8_t target_component) {
 		if (_mavlink_ulog) { return; }
-		_mavlink_ulog = MavlinkULog::try_start();
+		_mavlink_ulog = MavlinkULog::try_start(target_system, target_component);
 	}
 	void			request_stop_ulog_streaming() {
 		if (_mavlink_ulog) { _mavlink_ulog_stop_requested = true; }

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -70,6 +70,7 @@
 #include "mavlink_ftp.h"
 #include "mavlink_log_handler.h"
 #include "mavlink_shell.h"
+#include "mavlink_ulog.h"
 
 enum Protocol {
 	SERIAL = 0,
@@ -435,6 +436,16 @@ public:
 	/** close the Mavlink shell if it is open */
 	void			close_shell();
 
+	/** get ulog streaming if active, nullptr otherwise */
+	MavlinkULog		*get_ulog_streaming() { return _mavlink_ulog; }
+	void			try_start_ulog_streaming() {
+		if (_mavlink_ulog) { return; }
+		_mavlink_ulog = MavlinkULog::try_start();
+	}
+	void			request_stop_ulog_streaming() {
+		if (_mavlink_ulog) { _mavlink_ulog_stop_requested = true; }
+	}
+
 protected:
 	Mavlink			*next;
 
@@ -467,6 +478,8 @@ private:
 	MavlinkFTP			*_mavlink_ftp;
 	MavlinkLogHandler		*_mavlink_log_handler;
 	MavlinkShell			*_mavlink_shell;
+	MavlinkULog			*_mavlink_ulog;
+	volatile bool			_mavlink_ulog_stop_requested;
 
 	MAVLINK_MODE 		_mode;
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -389,7 +389,7 @@ MavlinkReceiver::handle_message_command_long(mavlink_message_t *msg)
 				// mavlink channel streaming was requested. But in fact it's possible that the logger is
 				// not even running. The main mavlink thread takes care of this by waiting for an ack
 				// from the logger.
-				_mavlink->try_start_ulog_streaming();
+				_mavlink->try_start_ulog_streaming(msg->sysid, msg->compid);
 			} else if (cmd_mavlink.command == MAV_CMD_LOGGING_STOP) {
 				_mavlink->request_stop_ulog_streaming();
 			}

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -144,6 +144,7 @@ private:
 	void handle_message_gps_rtcm_data(mavlink_message_t *msg);
 	void handle_message_battery_status(mavlink_message_t *msg);
 	void handle_message_serial_control(mavlink_message_t *msg);
+	void handle_message_logging_ack(mavlink_message_t *msg);
 
 	void *receive_thread(void *arg);
 

--- a/src/modules/mavlink/mavlink_ulog.cpp
+++ b/src/modules/mavlink/mavlink_ulog.cpp
@@ -47,7 +47,8 @@ MavlinkULog *MavlinkULog::_instance = nullptr;
 sem_t MavlinkULog::_lock;
 
 
-MavlinkULog::MavlinkULog()
+MavlinkULog::MavlinkULog(uint8_t target_system, uint8_t target_component)
+	: _target_system(target_system), _target_component(target_component)
 {
 	_ulog_stream_sub = orb_subscribe(ORB_ID(ulog_stream));
 
@@ -107,6 +108,8 @@ int MavlinkULog::handle_update(mavlink_channel_t channel)
 					msg.sequence = _ulog_data.sequence;
 					msg.length = _ulog_data.length;
 					msg.first_message_offset = _ulog_data.first_message_offset;
+					msg.target_system = _target_system;
+					msg.target_component = _target_component;
 					memcpy(msg.data, _ulog_data.data, sizeof(msg.data));
 					mavlink_msg_logging_data_acked_send_struct(channel, &msg);
 				}
@@ -134,6 +137,8 @@ int MavlinkULog::handle_update(mavlink_channel_t channel)
 			msg.sequence = _ulog_data.sequence;
 			msg.length = _ulog_data.length;
 			msg.first_message_offset = _ulog_data.first_message_offset;
+			msg.target_system = _target_system;
+			msg.target_component = _target_component;
 			memcpy(msg.data, _ulog_data.data, sizeof(msg.data));
 			mavlink_msg_logging_data_acked_send_struct(channel, &msg);
 
@@ -142,6 +147,8 @@ int MavlinkULog::handle_update(mavlink_channel_t channel)
 			msg.sequence = _ulog_data.sequence;
 			msg.length = _ulog_data.length;
 			msg.first_message_offset = _ulog_data.first_message_offset;
+			msg.target_system = _target_system;
+			msg.target_component = _target_component;
 			memcpy(msg.data, _ulog_data.data, sizeof(msg.data));
 			mavlink_msg_logging_data_send_struct(channel, &msg);
 		}
@@ -160,13 +167,13 @@ void MavlinkULog::initialize()
 	_init = true;
 }
 
-MavlinkULog* MavlinkULog::try_start()
+MavlinkULog* MavlinkULog::try_start(uint8_t target_system, uint8_t target_component)
 {
 	MavlinkULog *ret = nullptr;
 	bool failed = false;
 	lock();
 	if (!_instance) {
-		ret = _instance = new MavlinkULog();
+		ret = _instance = new MavlinkULog(target_system, target_component);
 		if (!_instance) {
 			failed = true;
 		}

--- a/src/modules/mavlink/mavlink_ulog.cpp
+++ b/src/modules/mavlink/mavlink_ulog.cpp
@@ -1,0 +1,216 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file mavlink_ulog.cpp
+ * ULog data streaming via MAVLink
+ *
+ * @author Beat Küng <beat-kueng@gmx.net>
+ */
+
+#include "mavlink_ulog.h"
+#include <px4_log.h>
+#include <errno.h>
+
+bool MavlinkULog::_init = false;
+MavlinkULog *MavlinkULog::_instance = nullptr;
+sem_t MavlinkULog::_lock;
+
+
+MavlinkULog::MavlinkULog()
+{
+	_ulog_stream_sub = orb_subscribe(ORB_ID(ulog_stream));
+
+	if (_ulog_stream_sub < 0) {
+		PX4_ERR("orb_subscribe failed (%i)", errno);
+	}
+	_waiting_for_initial_ack = true;
+	_last_sent_time = hrt_absolute_time(); //(ab)use this timestamp during initialization
+}
+
+MavlinkULog::~MavlinkULog()
+{
+	if (_ulog_stream_ack_pub) {
+		orb_unadvertise(_ulog_stream_ack_pub);
+	}
+	if (_ulog_stream_sub >= 0) {
+		orb_unsubscribe(_ulog_stream_sub);
+	}
+}
+
+void MavlinkULog::start_ack_received()
+{
+	if (_waiting_for_initial_ack) {
+		_last_sent_time = 0;
+		_waiting_for_initial_ack = false;
+		PX4_DEBUG("got logger ack");
+	}
+}
+
+int MavlinkULog::handle_update(mavlink_channel_t channel)
+{
+	static_assert(sizeof(ulog_stream_s::data) == MAVLINK_MSG_LOGGING_DATA_FIELD_DATA_LEN, "Invalid uorb ulog_stream.data length");
+	static_assert(sizeof(ulog_stream_s::data) == MAVLINK_MSG_LOGGING_DATA_ACKED_FIELD_DATA_LEN, "Invalid uorb ulog_stream.data length");
+
+	if (_waiting_for_initial_ack) {
+		if (hrt_elapsed_time(&_last_sent_time) > 3e5) {
+			PX4_WARN("no ack from logger (is it running?)");
+			return -1;
+		}
+	}
+
+	// check if we're waiting for an ACK
+	if (_last_sent_time) {
+		bool check_for_updates = false;
+		if (_ack_received) {
+			_last_sent_time = 0;
+			check_for_updates = true;
+		} else {
+
+			if (hrt_elapsed_time(&_last_sent_time) > ulog_stream_ack_s::ACK_TIMEOUT * 1000) {
+				if (++_sent_tries > ulog_stream_ack_s::ACK_MAX_TRIES) {
+					return -ETIMEDOUT;
+				} else {
+					PX4_DEBUG("re-sending ulog mavlink message (try=%i)", _sent_tries);
+					_last_sent_time = hrt_absolute_time();
+					mavlink_logging_data_acked_t msg;
+					msg.sequence = _ulog_data.sequence;
+					msg.length = _ulog_data.length;
+					msg.first_message_offset = _ulog_data.first_message_offset;
+					memcpy(msg.data, _ulog_data.data, sizeof(msg.data));
+					mavlink_msg_logging_data_acked_send_struct(channel, &msg);
+				}
+			}
+		}
+
+		if (!check_for_updates) {
+			return 0;
+		}
+	}
+
+	bool updated = false;
+	int ret = orb_check(_ulog_stream_sub, &updated);
+	while (updated && !ret) {
+		orb_copy(ORB_ID(ulog_stream), _ulog_stream_sub, &_ulog_data);
+		if (_ulog_data.flags & ulog_stream_s::FLAGS_NEED_ACK) {
+			_sent_tries = 1;
+			_last_sent_time = hrt_absolute_time();
+			lock();
+			_wait_for_ack_sequence = _ulog_data.sequence;
+			_ack_received = false;
+			unlock();
+
+			mavlink_logging_data_acked_t msg;
+			msg.sequence = _ulog_data.sequence;
+			msg.length = _ulog_data.length;
+			msg.first_message_offset = _ulog_data.first_message_offset;
+			memcpy(msg.data, _ulog_data.data, sizeof(msg.data));
+			mavlink_msg_logging_data_acked_send_struct(channel, &msg);
+
+		} else {
+			mavlink_logging_data_t msg;
+			msg.sequence = _ulog_data.sequence;
+			msg.length = _ulog_data.length;
+			msg.first_message_offset = _ulog_data.first_message_offset;
+			memcpy(msg.data, _ulog_data.data, sizeof(msg.data));
+			mavlink_msg_logging_data_send_struct(channel, &msg);
+		}
+		ret = orb_check(_ulog_stream_sub, &updated);
+	}
+
+	return 0;
+}
+
+void MavlinkULog::initialize()
+{
+	if (_init) {
+		return;
+	}
+	sem_init(&_lock, 1, 1);
+	_init = true;
+}
+
+MavlinkULog* MavlinkULog::try_start()
+{
+	MavlinkULog *ret = nullptr;
+	bool failed = false;
+	lock();
+	if (!_instance) {
+		ret = _instance = new MavlinkULog();
+		if (!_instance) {
+			failed = true;
+		}
+	}
+	unlock();
+
+	if (failed) {
+		PX4_ERR("alloc failed");
+	}
+	return ret;
+}
+
+void MavlinkULog::stop()
+{
+	lock();
+	if (_instance) {
+		delete _instance;
+		_instance = nullptr;
+	}
+	unlock();
+}
+
+void MavlinkULog::handle_ack(mavlink_logging_ack_t ack)
+{
+	lock();
+	if (_instance) { // make sure stop() was not called right before
+		if (_wait_for_ack_sequence == ack.sequence) {
+			_ack_received = true;
+			publish_ack(ack.sequence);
+		}
+	}
+	unlock();
+}
+
+void MavlinkULog::publish_ack(uint16_t sequence)
+{
+	ulog_stream_ack_s ack;
+	ack.timestamp = hrt_absolute_time();
+	ack.sequence = sequence;
+
+	if (_ulog_stream_ack_pub == nullptr) {
+		_ulog_stream_ack_pub = orb_advertise_queue(ORB_ID(ulog_stream_ack), &ack, 3);
+
+	} else {
+		orb_publish(ORB_ID(ulog_stream_ack), _ulog_stream_ack_pub, &ack);
+	}
+}

--- a/src/modules/mavlink/mavlink_ulog.cpp
+++ b/src/modules/mavlink/mavlink_ulog.cpp
@@ -45,7 +45,7 @@
 
 bool MavlinkULog::_init = false;
 MavlinkULog *MavlinkULog::_instance = nullptr;
-sem_t MavlinkULog::_lock;
+px4_sem_t MavlinkULog::_lock;
 const float MavlinkULog::_rate_calculation_delta_t = 0.1f;
 
 
@@ -185,7 +185,7 @@ void MavlinkULog::initialize()
 	if (_init) {
 		return;
 	}
-	sem_init(&_lock, 1, 1);
+	px4_sem_init(&_lock, 1, 1);
 	_init = true;
 }
 

--- a/src/modules/mavlink/mavlink_ulog.h
+++ b/src/modules/mavlink/mavlink_ulog.h
@@ -68,7 +68,7 @@ public:
 	 * thread-safe
 	 * @return instance, or nullptr
 	 */
-	static MavlinkULog *try_start();
+	static MavlinkULog *try_start(uint8_t target_system, uint8_t target_component);
 
 	/**
 	 * stop the stream. It also deletes the singleton object, so make sure cleanup
@@ -91,7 +91,7 @@ public:
 
 private:
 
-	MavlinkULog();
+	MavlinkULog(uint8_t target_system, uint8_t target_component);
 
 	~MavlinkULog();
 
@@ -119,6 +119,9 @@ private:
 	hrt_abstime _last_sent_time = 0; ///< last time we sent a message that requires an ack
 	ulog_stream_s _ulog_data;
 	bool _waiting_for_initial_ack = false;
+	const uint8_t _target_system;
+	const uint8_t _target_component;
+
 
 	/* do not allow copying this class */
 	MavlinkULog(const MavlinkULog &) = delete;

--- a/src/modules/mavlink/mavlink_ulog.h
+++ b/src/modules/mavlink/mavlink_ulog.h
@@ -1,0 +1,126 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file mavlink_ulog.h
+ * ULog data streaming via MAVLink
+ *
+ * @author Beat Küng <beat-kueng@gmx.net>
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <px4_tasks.h>
+#include <px4_sem.h>
+#include <drivers/drv_hrt.h>
+
+#include <uORB/topics/ulog_stream.h>
+#include <uORB/topics/ulog_stream_ack.h>
+
+#include "mavlink_bridge_header.h"
+
+/**
+ * @class MavlinkULog
+ * ULog streaming class. At most one instance (stream) can exist, assigned to a specific mavlink channel.
+ */
+class MavlinkULog
+{
+public:
+	/**
+	 * initialize: call this once on startup (this function is not thread-safe!)
+	 */
+	static void initialize();
+
+	/**
+	 * try to start a new stream. This fails if a stream is already running.
+	 * thread-safe
+	 * @return instance, or nullptr
+	 */
+	static MavlinkULog *try_start();
+
+	/**
+	 * stop the stream. It also deletes the singleton object, so make sure cleanup
+	 * all pointers to it.
+	 * thread-safe
+	 */
+	void stop();
+
+	/**
+	 * periodic update method: check for ulog stream messages and handle retransmission.
+	 * @return 0 on success, <0 otherwise
+	 */
+	int handle_update(mavlink_channel_t channel);
+
+	/** ack from mavlink for a data message */
+	void handle_ack(mavlink_logging_ack_t ack);
+
+	/** this is called when we got an vehicle_command_ack from the logger */
+	void start_ack_received();
+
+private:
+
+	MavlinkULog();
+
+	~MavlinkULog();
+
+	static void lock()
+	{
+		do {} while (sem_wait(&_lock) != 0);
+	}
+
+	static void unlock()
+	{
+		sem_post(&_lock);
+	}
+
+	void publish_ack(uint16_t sequence);
+
+	static sem_t _lock;
+	static bool _init;
+	static MavlinkULog *_instance;
+
+	int _ulog_stream_sub = -1;
+	orb_advert_t _ulog_stream_ack_pub = nullptr;
+	uint16_t _wait_for_ack_sequence;
+	uint8_t _sent_tries = 0;
+	volatile bool _ack_received = false; ///< set to true if a matching ack received
+	hrt_abstime _last_sent_time = 0; ///< last time we sent a message that requires an ack
+	ulog_stream_s _ulog_data;
+	bool _waiting_for_initial_ack = false;
+
+	/* do not allow copying this class */
+	MavlinkULog(const MavlinkULog &) = delete;
+	MavlinkULog operator=(const MavlinkULog &) = delete;
+};

--- a/src/modules/mavlink/mavlink_ulog.h
+++ b/src/modules/mavlink/mavlink_ulog.h
@@ -105,17 +105,17 @@ private:
 
 	static void lock()
 	{
-		do {} while (sem_wait(&_lock) != 0);
+		do {} while (px4_sem_wait(&_lock) != 0);
 	}
 
 	static void unlock()
 	{
-		sem_post(&_lock);
+		px4_sem_post(&_lock);
 	}
 
 	void publish_ack(uint16_t sequence);
 
-	static sem_t _lock;
+	static px4_sem_t _lock;
 	static bool _init;
 	static MavlinkULog *_instance;
 	static const float _rate_calculation_delta_t; ///< rate update interval

--- a/src/modules/replay/replay_main.cpp
+++ b/src/modules/replay/replay_main.cpp
@@ -40,6 +40,7 @@
  * @author Beat Kueng
 */
 
+#include <drivers/drv_hrt.h>
 #include <px4_defines.h>
 #include <px4_posix.h>
 #include <px4_tasks.h>
@@ -56,7 +57,6 @@
 #include <stdlib.h>
 #include <string>
 
-#include <logger/logger.h>
 #include <logger/messages.h>
 
 #include "replay.hpp"

--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -114,6 +114,7 @@ PARAM_DEFINE_INT32(SYS_MC_EST_GROUP, 1);
  *
  * @value 0 Disabled
  * @value 10 FrSky Telemetry
+ * @value 20 Crazyflie (Syslink)
  * @value 921600 Companion Link (921600 baud, 8N1)
  * @value 57600 Companion Link (57600 baud, 8N1)
  * @value 157600 OSD (57600 baud, 8N1)


### PR DESCRIPTION
This adds a new backend to the logger, such that ULog's can be streamed over mavlink to a companion computer or a GCS. Use cases include:
- enable logging for devices without a micro SD card
- avoid having to cope with SD cards
- enable real-time plotting (we could add messages to dynamically add and remove topic subscriptions)
- ...

It's even possible to use the SD logging and mavlink logging independently, both at the same time. To use it, start the logger in mavlink mode `logger start -m mavlink` or `logger start -m all`. The client side is implemented in the `mavlink_ulog_streaming.py` script.

Depends on https://github.com/mavlink/mavlink/pull/636

fyi @dogmaphobic 

Tested and works in SITL and Pixracer over USB connection.

CPU usage: mavlink needs ~14% CPU with mavlink streaming.

Left todo: resource optimizations, especially RAM/stack usage of the logger.