### PR TITLE
Add missing vibration data to estimator-status uORB topic

### DIFF
--- a/msg/estimator_status.msg
+++ b/msg/estimator_status.msg
@@ -1,6 +1,9 @@
 float32[32] states		# Internal filter states
 float32 n_states		# Number of states effectively used
-float32[3] vibe			# Vibration levels in X, Y and Z
+float32[3] vibe			# IMU vibration metrics in the following array locations
+# 0 : Gyro delta angle coning metric = filtered length of (delta_angle x prev_delta_angle)
+# 1 : Gyro high frequency vibe = filtered length of (delta_angle - prev_delta_angle)
+# 2 : Accel high frequency vibe = filtered length of (delta_velocity - prev_delta_velocity)
 uint8 nan_flags			# Bitmask to indicate NaN states
 uint8 health_flags		# Bitmask to indicate sensor health states (vel, pos, hgt)
 uint8 timeout_flags		# Bitmask to indicate timeout flags (vel, pos, hgt)

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -870,6 +870,7 @@ void Ekf2::task_main()
 		bool dead_reckoning;
 		_ekf.get_ekf_accuracy(&status.pos_horiz_accuracy, &status.pos_vert_accuracy, &dead_reckoning);
 		_ekf.get_ekf_soln_status(&status.solution_status_flags);
+		_ekf.get_imu_vibe_metrics(status.vibe);
 
 		if (_estimator_status_pub == nullptr) {
 			_estimator_status_pub = orb_advertise(ORB_ID(estimator_status), &status);


### PR DESCRIPTION
Required for  https://github.com/PX4/ecl/pull/203

Flight data was logged using the new ulog format and analysed using the following script https://github.com/priseborough/pyulog/commit/149671fdf8ec1a8192350f5737ec5074a42f8134

Here are the vibe levels.

<img width="1229" alt="screen shot 2016-10-18 at 5 31 10 pm" src="https://cloud.githubusercontent.com/assets/3596952/19466875/b0b13776-9559-11e6-9667-76ced82f8f4e.png">

Threshold test limits will be added to the analysis script  when more log data is available to set them.