### PR TITLE
tecs: fix limiting of pitch integrator input, better comments and str…

### DIFF
--- a/src/lib/external_lgpl/tecs/tecs.cpp
+++ b/src/lib/external_lgpl/tecs/tecs.cpp
@@ -453,35 +453,37 @@ void TECS::_update_pitch(void)
 	// Calculate integrator state, constraining input if pitch limits are exceeded
 	float integ7_input = _SEB_error * _integGain;
 
+	// constrain the integrator input to prevent it changing in the direction that increases pitch demand saturation
+	// if the pitch demand is saturated, then decay the integrator at the control loop time constant
 	if (_pitch_dem_unc > _PITCHmaxf) {
-		integ7_input = min(integ7_input, 0.0f);
-		// integ7_input = min(integ7_input, (_PITCHmaxf - _pitch_dem_unc) * gainInv / _DT);
+		integ7_input = min(integ7_input, min((_PITCHmaxf - _pitch_dem_unc) * gainInv / _timeConst, 0.0f));
 
 	} else if (_pitch_dem_unc < _PITCHminf) {
-		integ7_input = max(integ7_input, 0.0f);
-		// integ7_input = max(integ7_input, (_PITCHminf - _pitch_dem_unc) * gainInv / _DT);
+		integ7_input = max(integ7_input, max((_PITCHminf - _pitch_dem_unc) * gainInv / _timeConst, 0.0f));
 	}
 
+	// pitch loop integration
 	_integ7_state = _integ7_state + integ7_input * _DT;
 
-	float temp = _SEB_error + _SEBdot_error * _ptchDamp + SEBdot_dem * _timeConst;
+	// Specific Energy Balance correction excluding integrator contribution
+	float SEB_correction = _SEB_error + _SEBdot_error * _ptchDamp + SEBdot_dem * _timeConst;
 
 	// During climbout/takeoff, bias the demanded pitch angle so that zero speed error produces a pitch angle
 	// demand equal to the minimum value (which is )set by the mission plan during this mode). Otherwise the
 	// integrator has to catch up before the nose can be raised to reduce speed during climbout.
 	if (_climbOutDem) {
-		temp += _PITCHminf * gainInv;
+		SEB_correction += _PITCHminf * gainInv;
 	}
 
 	// Apply max and min values for integrator state that will allow for no more than
-	// 5deg of saturation. This allows for some pitch variation due to gusts before the
+	// 10deg of saturation. This allows for some pitch variation due to gusts before the
 	// integrator is clipped. Otherwise the effectiveness of the integrator will be reduced in turbulence
-	float integ7_err_min = (gainInv * (_PITCHminf - math::radians(5.0f))) - temp;
-	float integ7_err_max = (gainInv * (_PITCHmaxf + math::radians(5.0f))) - temp;
+	float integ7_err_min = (gainInv * (_PITCHminf - math::radians(10.0f))) - SEB_correction;
+	float integ7_err_max = (gainInv * (_PITCHmaxf + math::radians(10.0f))) - SEB_correction;
 	_integ7_state = constrain(_integ7_state, integ7_err_min, integ7_err_max);
 
 	// Calculate pitch demand from specific energy balance signals
-	_pitch_dem_unc = (temp + _integ7_state) / gainInv;
+	_pitch_dem_unc = (SEB_correction + _integ7_state) / gainInv;
 
 	// Constrain pitch demand
 	_pitch_dem = constrain(_pitch_dem_unc, _PITCHminf, _PITCHmaxf);


### PR DESCRIPTION
…ucture
- when limiting the pitch integrator input the value was related to
  a quantity with different units (specific energy error rate vs delta pitch)
- once the unconstrained pitch demand is larger / smaller than the max/min
  allowed pitch angle the integrator input should only be allowed to drag
  the integrator into the direction leading to less pitch demand violation

Signed-off-by: Roman bapstroman@gmail.com
