### PR TITLE
Add __PX4_POSIX_BEBOP define to PreflightCheck.cpp

### DIFF
--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -394,6 +394,9 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkMag, bool checkAcc,
 #elif defined(__PX4_POSIX_RPI)
 	PX4_WARN("Preflight checks always pass on RPI.");
 	return true;
+#elif defined(__PX4_POSIX_BEBOP)
+	PX4_WARN("Preflight checks always pass on Bebop.");
+	return true;
 #endif
 
 	bool failed = false;


### PR DESCRIPTION
This fixes the error:
`WARN  [commander] Not ready to fly: Sensors not set up correctly`
that prevents the Bebop from initializing successfully. The quadcopter cannot be armed or flown without this.

There was a commit c606554 which made the change for the RPi.