### PR TITLE
Remove obsolete linker flag for Bebop build

### DIFF
--- a/cmake/posix/px4_impl_posix.cmake
+++ b/cmake/posix/px4_impl_posix.cmake
@@ -174,16 +174,6 @@ function(px4_os_add_flags)
                 mavlink/include/mavlink
                 )
 
-# This block sets added_exe_linker_flags.
-if ("${BOARD}" STREQUAL "bebop")
-	# Use the -pthread if the firmware is build for the parrot bebop.
-	# This resolves some linker errors in DriverFramework, when building
-	# a static target.
-	set(added_exe_linker_flags "-pthread")
-else()
-	set(added_exe_linker_flags)
-endif()
-
 # This block sets added_definitions and added_cxx_flags.
 if(UNIX AND APPLE)
         set(added_definitions
@@ -227,6 +217,8 @@ else()
 		)
 
 endif()
+
+set(added_exe_linker_flags)
 
 # This block sets added_c_flags (appends to others).
 if ("${BOARD}" STREQUAL "eagle" OR "${BOARD}" STREQUAL "excelsior")


### PR DESCRIPTION
The pthread linker flags were changed in c6a2641 and it was questioned in #5504 if the
exception for the Bebop is necessary. It is not, so remove those lines from the cmake
file.