### PR TITLE
px4fmu_common rcS: fix MAVLINK_F test

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -511,7 +511,7 @@ then
 		fi
 	fi
 
-	if [ $MAVLINK_F == "none" ]
+	if [ "x$MAVLINK_F" == xnone ]
 	then
 	else
 		mavlink start $MAVLINK_F


### PR DESCRIPTION
fixes a 'test: syntax error' message on startup. There were two problems:
- the expansion of $MAVLINK_F lead to multiple arguments in the test
  when the variable contained spaces. Fixed with ""
- the x prevents interpretation as a unary expression, if $MAVLINK_F starts
  with a - character (in that case the expansion would be:
  if [ -r 1200 ... and nsh interprets - as unary expression)