### PR TITLE
Save more RAM

### DIFF
--- a/src/drivers/device/device_nuttx.cpp
+++ b/src/drivers/device/device_nuttx.cpp
@@ -91,8 +91,7 @@ Device::Device(const char *name,
 	_name(name),
 	_debug_enabled(false),
 	// private
-	_irq(irq),
-	_irq_attached(false)
+	_irq(irq)
 {
 	sem_init(&_lock, 0, 1);
 
@@ -109,7 +108,7 @@ Device::~Device()
 {
 	sem_destroy(&_lock);
 
-	if (_irq_attached) {
+	if (_irq) {
 		unregister_interrupt(_irq);
 	}
 }
@@ -128,20 +127,17 @@ Device::init()
 		ret = register_interrupt(_irq, this);
 
 		if (ret != OK) {
-			goto out;
+			_irq = 0;
 		}
-
-		_irq_attached = true;
 	}
 
-out:
 	return ret;
 }
 
 void
 Device::interrupt_enable()
 {
-	if (_irq_attached) {
+	if (_irq) {
 		up_enable_irq(_irq);
 	}
 }
@@ -149,7 +145,7 @@ Device::interrupt_enable()
 void
 Device::interrupt_disable()
 {
-	if (_irq_attached) {
+	if (_irq) {
 		up_disable_irq(_irq);
 	}
 }

--- a/src/drivers/device/device_nuttx.h
+++ b/src/drivers/device/device_nuttx.h
@@ -209,8 +209,7 @@ protected:
 	sem_t		_lock; /**< lock to protect access to all class members (also for derived classes) */
 
 private:
-	int		_irq;
-	bool		_irq_attached;
+	int		_irq; /**< if non-zero, it's a valid IRQ */
 
 	/** disable copy construction for this and all subclasses */
 	Device(const Device &);

--- a/src/drivers/device/device_nuttx.h
+++ b/src/drivers/device/device_nuttx.h
@@ -455,7 +455,7 @@ private:
 
 	const char	*_devname;		/**< device node name */
 	bool		_registered;		/**< true if device name was registered */
-	unsigned	_open_count;		/**< number of successful opens */
+	uint16_t	_open_count;		/**< number of successful opens */
 
 	struct pollfd	*_pollset[_max_pollwaiters];
 

--- a/src/drivers/device/vdev.cpp
+++ b/src/drivers/device/vdev.cpp
@@ -73,10 +73,6 @@ private:
 static px4_dev_t *devmap[PX4_MAX_DEV];
 pthread_mutex_t devmutex = PTHREAD_MUTEX_INITIALIZER;
 
-/*
- * The standard NuttX operation dispatch table can't call C++ member functions
- * directly, so we have to bounce them through this dispatch table.
- */
 
 VDev::VDev(const char *name,
 	   const char *devname) :

--- a/src/lib/controllib/block/BlockParam.cpp
+++ b/src/lib/controllib/block/BlockParam.cpp
@@ -82,10 +82,9 @@ BlockParamBase::BlockParamBase(Block *parent, const char *name, bool parent_pref
 
 template <class T>
 BlockParam<T>::BlockParam(Block *block, const char *name,
-			  bool parent_prefix, T *extern_address) :
+			  bool parent_prefix) :
 	BlockParamBase(block, name, parent_prefix),
-	_val(),
-	_extern_address(extern_address)
+	_val()
 {
 	update();
 }
@@ -97,10 +96,6 @@ template <class T>
 void BlockParam<T>::set(T val)
 {
 	_val = val;
-
-	if (_extern_address != NULL) {
-		*_extern_address = val;
-	}
 }
 
 template <class T>
@@ -108,10 +103,6 @@ void BlockParam<T>::update()
 {
 	if (_handle != PARAM_INVALID) {
 		param_get(_handle, &_val);
-
-		if (_extern_address != NULL) {
-			*_extern_address = _val;
-		}
 	}
 }
 
@@ -126,5 +117,37 @@ BlockParam<T>::~BlockParam() {};
 
 template class __EXPORT BlockParam<float>;
 template class __EXPORT BlockParam<int>;
+
+
+template <class T>
+BlockParamExt<T>::BlockParamExt(Block *block, const char *name,
+				bool parent_prefix, T &extern_val) :
+	BlockParam<T>(block, name, parent_prefix),
+	_extern_val(extern_val)
+{
+	update();
+}
+
+template <class T>
+void BlockParamExt<T>::set(T val)
+{
+	this->_val = val;
+	_extern_val = val;
+}
+
+template <class T>
+void BlockParamExt<T>::update()
+{
+	if (this->_handle != PARAM_INVALID) {
+		param_get(this->_handle, &this->_val);
+		_extern_val = this->_val;
+	}
+}
+
+template <class T>
+BlockParamExt<T>::~BlockParamExt() {};
+
+template class __EXPORT BlockParamExt<float>;
+template class __EXPORT BlockParamExt<int>;
 
 } // namespace control

--- a/src/lib/controllib/block/BlockParam.hpp
+++ b/src/lib/controllib/block/BlockParam.hpp
@@ -77,21 +77,45 @@ class BlockParam : public BlockParamBase
 {
 public:
 	BlockParam(Block *block, const char *name,
-		   bool parent_prefix = true, T *extern_address = NULL);
+		   bool parent_prefix = true);
 	BlockParam(const BlockParam &) = delete;
 	BlockParam &operator=(const BlockParam &) = delete;
 
 	T get();
 	void commit();
 	void set(T val);
-	void update();
+	void update() override;
 	virtual ~BlockParam();
 protected:
 	T _val;
-	T *_extern_address;
 };
 
 typedef BlockParam<float> BlockParamFloat;
 typedef BlockParam<int> BlockParamInt;
+
+
+/**
+ * Same as BlockParam, but in addition with a pointer to an external field that will be
+ * set to the value of the parameter.
+ * (BlockParam should be prefered over this)
+ */
+template <class T>
+class BlockParamExt : public BlockParam<T>
+{
+public:
+	BlockParamExt(Block *block, const char *name,
+		      bool parent_prefix, T &extern_val);
+	BlockParamExt(const BlockParamExt &) = delete;
+	BlockParamExt &operator=(const BlockParamExt &) = delete;
+
+	void set(T val);
+	void update() override;
+	virtual ~BlockParamExt();
+protected:
+	T &_extern_val;
+};
+
+typedef BlockParamExt<float> BlockParamExtFloat;
+typedef BlockParamExt<int> BlockParamExtInt;
 
 } // namespace control

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -168,108 +168,109 @@ private:
 
 	parameters *_params;	// pointer to ekf parameter struct (located in _ekf class instance)
 
-	control::BlockParamFloat _mag_delay_ms;
-	control::BlockParamFloat _baro_delay_ms;
-	control::BlockParamFloat _gps_delay_ms;
-	control::BlockParamFloat _flow_delay_ms;
-	control::BlockParamFloat _rng_delay_ms;
-	control::BlockParamFloat _airspeed_delay_ms;
-	control::BlockParamFloat _ev_delay_ms;
+	control::BlockParamExtFloat _mag_delay_ms;
+	control::BlockParamExtFloat _baro_delay_ms;
+	control::BlockParamExtFloat _gps_delay_ms;
+	control::BlockParamExtFloat _flow_delay_ms;
+	control::BlockParamExtFloat _rng_delay_ms;
+	control::BlockParamExtFloat _airspeed_delay_ms;
+	control::BlockParamExtFloat _ev_delay_ms;
 
-	control::BlockParamFloat _gyro_noise;
-	control::BlockParamFloat _accel_noise;
+	control::BlockParamExtFloat _gyro_noise;
+	control::BlockParamExtFloat _accel_noise;
 
 	// process noise
-	control::BlockParamFloat _gyro_bias_p_noise;
-	control::BlockParamFloat _accel_bias_p_noise;
-	control::BlockParamFloat _mage_p_noise;
-	control::BlockParamFloat _magb_p_noise;
-	control::BlockParamFloat _wind_vel_p_noise;
-	control::BlockParamFloat _terrain_p_noise;	// terrain offset state random walk (m/s)
-	control::BlockParamFloat _terrain_gradient;	// magnitude of terrain gradient (m/m)
+	control::BlockParamExtFloat _gyro_bias_p_noise;
+	control::BlockParamExtFloat _accel_bias_p_noise;
+	control::BlockParamExtFloat _mage_p_noise;
+	control::BlockParamExtFloat _magb_p_noise;
+	control::BlockParamExtFloat _wind_vel_p_noise;
+	control::BlockParamExtFloat _terrain_p_noise;	// terrain offset state random walk (m/s)
+	control::BlockParamExtFloat _terrain_gradient;	// magnitude of terrain gradient (m/m)
 
-	control::BlockParamFloat _gps_vel_noise;
-	control::BlockParamFloat _gps_pos_noise;
-	control::BlockParamFloat _pos_noaid_noise;
-	control::BlockParamFloat _baro_noise;
-	control::BlockParamFloat _baro_innov_gate;     // innovation gate for barometric height innovation test (std dev)
-	control::BlockParamFloat _posNE_innov_gate;    // innovation gate for GPS horizontal position innovation test (std dev)
-	control::BlockParamFloat _vel_innov_gate;      // innovation gate for GPS velocity innovation test (std dev)
-	control::BlockParamFloat _tas_innov_gate;	   // innovation gate for tas innovation test (std dev)
+	control::BlockParamExtFloat _gps_vel_noise;
+	control::BlockParamExtFloat _gps_pos_noise;
+	control::BlockParamExtFloat _pos_noaid_noise;
+	control::BlockParamExtFloat _baro_noise;
+	control::BlockParamExtFloat _baro_innov_gate;     // innovation gate for barometric height innovation test (std dev)
+	control::BlockParamExtFloat
+	_posNE_innov_gate;    // innovation gate for GPS horizontal position innovation test (std dev)
+	control::BlockParamExtFloat _vel_innov_gate;      // innovation gate for GPS velocity innovation test (std dev)
+	control::BlockParamExtFloat _tas_innov_gate;	   // innovation gate for tas innovation test (std dev)
 
-	control::BlockParamFloat _mag_heading_noise;	// measurement noise used for simple heading fusion
-	control::BlockParamFloat _mag_noise;           // measurement noise used for 3-axis magnetoemter fusion (Gauss)
-	control::BlockParamFloat _eas_noise;			// measurement noise used for airspeed fusion (std m/s)
-	control::BlockParamFloat _mag_declination_deg;	// magnetic declination in degrees
-	control::BlockParamFloat _heading_innov_gate;	// innovation gate for heading innovation test
-	control::BlockParamFloat _mag_innov_gate;	// innovation gate for magnetometer innovation test
-	control::BlockParamInt
+	control::BlockParamExtFloat _mag_heading_noise;	// measurement noise used for simple heading fusion
+	control::BlockParamExtFloat _mag_noise;           // measurement noise used for 3-axis magnetoemter fusion (Gauss)
+	control::BlockParamExtFloat _eas_noise;			// measurement noise used for airspeed fusion (std m/s)
+	control::BlockParamExtFloat _mag_declination_deg;	// magnetic declination in degrees
+	control::BlockParamExtFloat _heading_innov_gate;	// innovation gate for heading innovation test
+	control::BlockParamExtFloat _mag_innov_gate;	// innovation gate for magnetometer innovation test
+	control::BlockParamExtInt
 	_mag_decl_source;       // bitmasked integer used to control the handling of magnetic declination
-	control::BlockParamInt _mag_fuse_type;         // integer ued to control the type of magnetometer fusion used
+	control::BlockParamExtInt _mag_fuse_type;         // integer ued to control the type of magnetometer fusion used
 
-	control::BlockParamInt _gps_check_mask;        // bitmasked integer used to activate the different GPS quality checks
-	control::BlockParamFloat _requiredEph;         // maximum acceptable horiz position error (m)
-	control::BlockParamFloat _requiredEpv;         // maximum acceptable vert position error (m)
-	control::BlockParamFloat _requiredSacc;        // maximum acceptable speed error (m/s)
-	control::BlockParamInt _requiredNsats;         // minimum acceptable satellite count
-	control::BlockParamFloat _requiredGDoP;        // maximum acceptable geometric dilution of precision
-	control::BlockParamFloat _requiredHdrift;      // maximum acceptable horizontal drift speed (m/s)
-	control::BlockParamFloat _requiredVdrift;      // maximum acceptable vertical drift speed (m/s)
-	control::BlockParamInt _param_record_replay_msg; // indicates if we want to record ekf2 replay messages
+	control::BlockParamExtInt _gps_check_mask;        // bitmasked integer used to activate the different GPS quality checks
+	control::BlockParamExtFloat _requiredEph;         // maximum acceptable horiz position error (m)
+	control::BlockParamExtFloat _requiredEpv;         // maximum acceptable vert position error (m)
+	control::BlockParamExtFloat _requiredSacc;        // maximum acceptable speed error (m/s)
+	control::BlockParamExtInt _requiredNsats;         // minimum acceptable satellite count
+	control::BlockParamExtFloat _requiredGDoP;        // maximum acceptable geometric dilution of precision
+	control::BlockParamExtFloat _requiredHdrift;      // maximum acceptable horizontal drift speed (m/s)
+	control::BlockParamExtFloat _requiredVdrift;      // maximum acceptable vertical drift speed (m/s)
+	control::BlockParamExtInt _param_record_replay_msg; // indicates if we want to record ekf2 replay messages
 
 	// measurement source control
-	control::BlockParamInt
+	control::BlockParamExtInt
 	_fusion_mode;		// bitmasked integer that selects which of the GPS and optical flow aiding sources will be used
-	control::BlockParamInt _vdist_sensor_type;	// selects the primary source for height data
+	control::BlockParamExtInt _vdist_sensor_type;	// selects the primary source for height data
 
 	// range finder fusion
-	control::BlockParamFloat _range_noise;		// observation noise for range finder measurements (m)
-	control::BlockParamFloat _range_innov_gate;	// range finder fusion innovation consistency gate size (STD)
-	control::BlockParamFloat _rng_gnd_clearance;	// minimum valid value for range when on ground (m)
+	control::BlockParamExtFloat _range_noise;		// observation noise for range finder measurements (m)
+	control::BlockParamExtFloat _range_innov_gate;	// range finder fusion innovation consistency gate size (STD)
+	control::BlockParamExtFloat _rng_gnd_clearance;	// minimum valid value for range when on ground (m)
 
 	// vision estimate fusion
-	control::BlockParamFloat _ev_pos_noise;		// default position observation noise for exernal vision measurements (m)
-	control::BlockParamFloat _ev_ang_noise;		// default angular observation noise for exernal vision measurements (rad)
-	control::BlockParamFloat _ev_innov_gate;	// external vision position innovation consistency gate size (STD)
+	control::BlockParamExtFloat _ev_pos_noise;		// default position observation noise for exernal vision measurements (m)
+	control::BlockParamExtFloat _ev_ang_noise;		// default angular observation noise for exernal vision measurements (rad)
+	control::BlockParamExtFloat _ev_innov_gate;	// external vision position innovation consistency gate size (STD)
 
 	// optical flow fusion
-	control::BlockParamFloat
+	control::BlockParamExtFloat
 	_flow_noise;		// best quality observation noise for optical flow LOS rate measurements (rad/sec)
-	control::BlockParamFloat
+	control::BlockParamExtFloat
 	_flow_noise_qual_min;	// worst quality observation noise for optical flow LOS rate measurements (rad/sec)
-	control::BlockParamInt _flow_qual_min;		// minimum acceptable quality integer from  the flow sensor
-	control::BlockParamFloat _flow_innov_gate;	// optical flow fusion innovation consistency gate size (STD)
-	control::BlockParamFloat _flow_rate_max;	// maximum valid optical flow rate (rad/sec)
+	control::BlockParamExtInt _flow_qual_min;		// minimum acceptable quality integer from  the flow sensor
+	control::BlockParamExtFloat _flow_innov_gate;	// optical flow fusion innovation consistency gate size (STD)
+	control::BlockParamExtFloat _flow_rate_max;	// maximum valid optical flow rate (rad/sec)
 
 	// sensor positions in body frame
-	control::BlockParamFloat _imu_pos_x;	// X position of IMU in body frame (m)
-	control::BlockParamFloat _imu_pos_y;	// Y position of IMU in body frame (m)
-	control::BlockParamFloat _imu_pos_z;	// Z position of IMU in body frame (m)
-	control::BlockParamFloat _gps_pos_x;	// X position of GPS antenna in body frame (m)
-	control::BlockParamFloat _gps_pos_y;	// Y position of GPS antenna in body frame (m)
-	control::BlockParamFloat _gps_pos_z;	// Z position of GPS antenna in body frame (m)
-	control::BlockParamFloat _rng_pos_x;	// X position of range finder in body frame (m)
-	control::BlockParamFloat _rng_pos_y;	// Y position of range finder in body frame (m)
-	control::BlockParamFloat _rng_pos_z;	// Z position of range finder in body frame (m)
-	control::BlockParamFloat _flow_pos_x;	// X position of optical flow sensor focal point in body frame (m)
-	control::BlockParamFloat _flow_pos_y;	// Y position of optical flow sensor focal point in body frame (m)
-	control::BlockParamFloat _flow_pos_z;	// Z position of optical flow sensor focal point in body frame (m)
-	control::BlockParamFloat _ev_pos_x;	// X position of VI sensor focal point in body frame (m)
-	control::BlockParamFloat _ev_pos_y;	// Y position of VI sensor focal point in body frame (m)
-	control::BlockParamFloat _ev_pos_z;	// Z position of VI sensor focal point in body frame (m)
+	control::BlockParamExtFloat _imu_pos_x;	// X position of IMU in body frame (m)
+	control::BlockParamExtFloat _imu_pos_y;	// Y position of IMU in body frame (m)
+	control::BlockParamExtFloat _imu_pos_z;	// Z position of IMU in body frame (m)
+	control::BlockParamExtFloat _gps_pos_x;	// X position of GPS antenna in body frame (m)
+	control::BlockParamExtFloat _gps_pos_y;	// Y position of GPS antenna in body frame (m)
+	control::BlockParamExtFloat _gps_pos_z;	// Z position of GPS antenna in body frame (m)
+	control::BlockParamExtFloat _rng_pos_x;	// X position of range finder in body frame (m)
+	control::BlockParamExtFloat _rng_pos_y;	// Y position of range finder in body frame (m)
+	control::BlockParamExtFloat _rng_pos_z;	// Z position of range finder in body frame (m)
+	control::BlockParamExtFloat _flow_pos_x;	// X position of optical flow sensor focal point in body frame (m)
+	control::BlockParamExtFloat _flow_pos_y;	// Y position of optical flow sensor focal point in body frame (m)
+	control::BlockParamExtFloat _flow_pos_z;	// Z position of optical flow sensor focal point in body frame (m)
+	control::BlockParamExtFloat _ev_pos_x;	// X position of VI sensor focal point in body frame (m)
+	control::BlockParamExtFloat _ev_pos_y;	// Y position of VI sensor focal point in body frame (m)
+	control::BlockParamExtFloat _ev_pos_z;	// Z position of VI sensor focal point in body frame (m)
 	// control of airspeed and sideslip fusion
 	control::BlockParamFloat
 	_arspFusionThreshold; 	// a value of zero will disabled airspeed fusion. Any another positive value will determine
 	// the minimum airspeed which will still be fused
 
 	// output predictor filter time constants
-	control::BlockParamFloat _tau_vel;	// time constant used by the output velocity complementary filter (s)
-	control::BlockParamFloat _tau_pos;	// time constant used by the output position complementary filter (s)
+	control::BlockParamExtFloat _tau_vel;	// time constant used by the output velocity complementary filter (s)
+	control::BlockParamExtFloat _tau_pos;	// time constant used by the output position complementary filter (s)
 
 	// IMU switch on bias paameters
-	control::BlockParamFloat _gyr_bias_init;	// 1-sigma gyro bias uncertainty at switch-on (rad/sec)
-	control::BlockParamFloat _acc_bias_init;	// 1-sigma accelerometer bias uncertainty at switch-on (m/s**2)
-	control::BlockParamFloat _ang_err_init;		// 1-sigma uncertainty in tilt angle after gravity vector alignment (rad)
+	control::BlockParamExtFloat _gyr_bias_init;	// 1-sigma gyro bias uncertainty at switch-on (rad/sec)
+	control::BlockParamExtFloat _acc_bias_init;	// 1-sigma accelerometer bias uncertainty at switch-on (m/s**2)
+	control::BlockParamExtFloat _ang_err_init;		// 1-sigma uncertainty in tilt angle after gravity vector alignment (rad)
 
 	// airspeed mode parameter
 	control::BlockParamInt _airspeed_mode;
@@ -295,81 +296,81 @@ Ekf2::Ekf2():
 	_lp_yaw_rate(250.0f, 20.0f),
 	_ekf(),
 	_params(_ekf.getParamHandle()),
-	_mag_delay_ms(this, "EKF2_MAG_DELAY", false, &_params->mag_delay_ms),
-	_baro_delay_ms(this, "EKF2_BARO_DELAY", false, &_params->baro_delay_ms),
-	_gps_delay_ms(this, "EKF2_GPS_DELAY", false, &_params->gps_delay_ms),
-	_flow_delay_ms(this, "EKF2_OF_DELAY", false, &_params->flow_delay_ms),
-	_rng_delay_ms(this, "EKF2_RNG_DELAY", false, &_params->range_delay_ms),
-	_airspeed_delay_ms(this, "EKF2_ASP_DELAY", false, &_params->airspeed_delay_ms),
-	_ev_delay_ms(this, "EKF2_EV_DELAY", false, &_params->ev_delay_ms),
-	_gyro_noise(this, "EKF2_GYR_NOISE", false, &_params->gyro_noise),
-	_accel_noise(this, "EKF2_ACC_NOISE", false, &_params->accel_noise),
-	_gyro_bias_p_noise(this, "EKF2_GYR_B_NOISE", false, &_params->gyro_bias_p_noise),
-	_accel_bias_p_noise(this, "EKF2_ACC_B_NOISE", false, &_params->accel_bias_p_noise),
-	_mage_p_noise(this, "EKF2_MAG_E_NOISE", false, &_params->mage_p_noise),
-	_magb_p_noise(this, "EKF2_MAG_B_NOISE", false, &_params->magb_p_noise),
-	_wind_vel_p_noise(this, "EKF2_WIND_NOISE", false, &_params->wind_vel_p_noise),
-	_terrain_p_noise(this, "EKF2_TERR_NOISE", false, &_params->terrain_p_noise),
-	_terrain_gradient(this, "EKF2_TERR_GRAD", false, &_params->terrain_gradient),
-	_gps_vel_noise(this, "EKF2_GPS_V_NOISE", false, &_params->gps_vel_noise),
-	_gps_pos_noise(this, "EKF2_GPS_P_NOISE", false, &_params->gps_pos_noise),
-	_pos_noaid_noise(this, "EKF2_NOAID_NOISE", false, &_params->pos_noaid_noise),
-	_baro_noise(this, "EKF2_BARO_NOISE", false, &_params->baro_noise),
-	_baro_innov_gate(this, "EKF2_BARO_GATE", false, &_params->baro_innov_gate),
-	_posNE_innov_gate(this, "EKF2_GPS_P_GATE", false, &_params->posNE_innov_gate),
-	_vel_innov_gate(this, "EKF2_GPS_V_GATE", false, &_params->vel_innov_gate),
-	_tas_innov_gate(this, "EKF2_TAS_GATE", false, &_params->tas_innov_gate),
-	_mag_heading_noise(this, "EKF2_HEAD_NOISE", false, &_params->mag_heading_noise),
-	_mag_noise(this, "EKF2_MAG_NOISE", false, &_params->mag_noise),
-	_eas_noise(this, "EKF2_EAS_NOISE", false, &_params->eas_noise),
-	_mag_declination_deg(this, "EKF2_MAG_DECL", false, &_params->mag_declination_deg),
-	_heading_innov_gate(this, "EKF2_HDG_GATE", false, &_params->heading_innov_gate),
-	_mag_innov_gate(this, "EKF2_MAG_GATE", false, &_params->mag_innov_gate),
-	_mag_decl_source(this, "EKF2_DECL_TYPE", false, &_params->mag_declination_source),
-	_mag_fuse_type(this, "EKF2_MAG_TYPE", false, &_params->mag_fusion_type),
-	_gps_check_mask(this, "EKF2_GPS_CHECK", false, &_params->gps_check_mask),
-	_requiredEph(this, "EKF2_REQ_EPH", false, &_params->req_hacc),
-	_requiredEpv(this, "EKF2_REQ_EPV", false, &_params->req_vacc),
-	_requiredSacc(this, "EKF2_REQ_SACC", false, &_params->req_sacc),
-	_requiredNsats(this, "EKF2_REQ_NSATS", false, &_params->req_nsats),
-	_requiredGDoP(this, "EKF2_REQ_GDOP", false, &_params->req_gdop),
-	_requiredHdrift(this, "EKF2_REQ_HDRIFT", false, &_params->req_hdrift),
-	_requiredVdrift(this, "EKF2_REQ_VDRIFT", false, &_params->req_vdrift),
-	_param_record_replay_msg(this, "EKF2_REC_RPL", false, &_publish_replay_mode),
-	_fusion_mode(this, "EKF2_AID_MASK", false, &_params->fusion_mode),
-	_vdist_sensor_type(this, "EKF2_HGT_MODE", false, &_params->vdist_sensor_type),
-	_range_noise(this, "EKF2_RNG_NOISE", false, &_params->range_noise),
-	_range_innov_gate(this, "EKF2_RNG_GATE", false, &_params->range_innov_gate),
-	_rng_gnd_clearance(this, "EKF2_MIN_RNG", false, &_params->rng_gnd_clearance),
-	_ev_pos_noise(this, "EKF2_EVP_NOISE", false, &_default_ev_pos_noise),
-	_ev_ang_noise(this, "EKF2_EVA_NOISE", false, &_default_ev_ang_noise),
-	_ev_innov_gate(this, "EKF2_EV_GATE", false, &_params->ev_innov_gate),
-	_flow_noise(this, "EKF2_OF_N_MIN", false, &_params->flow_noise),
-	_flow_noise_qual_min(this, "EKF2_OF_N_MAX", false, &_params->flow_noise_qual_min),
-	_flow_qual_min(this, "EKF2_OF_QMIN", false, &_params->flow_qual_min),
-	_flow_innov_gate(this, "EKF2_OF_GATE", false, &_params->flow_innov_gate),
-	_flow_rate_max(this, "EKF2_OF_RMAX", false, &_params->flow_rate_max),
-	_imu_pos_x(this, "EKF2_IMU_POS_X", false, &_params->imu_pos_body(0)),
-	_imu_pos_y(this, "EKF2_IMU_POS_Y", false, &_params->imu_pos_body(1)),
-	_imu_pos_z(this, "EKF2_IMU_POS_Z", false, &_params->imu_pos_body(2)),
-	_gps_pos_x(this, "EKF2_GPS_POS_X", false, &_params->gps_pos_body(0)),
-	_gps_pos_y(this, "EKF2_GPS_POS_Y", false, &_params->gps_pos_body(1)),
-	_gps_pos_z(this, "EKF2_GPS_POS_Z", false, &_params->gps_pos_body(2)),
-	_rng_pos_x(this, "EKF2_RNG_POS_X", false, &_params->rng_pos_body(0)),
-	_rng_pos_y(this, "EKF2_RNG_POS_Y", false, &_params->rng_pos_body(1)),
-	_rng_pos_z(this, "EKF2_RNG_POS_Z", false, &_params->rng_pos_body(2)),
-	_flow_pos_x(this, "EKF2_OF_POS_X", false, &_params->flow_pos_body(0)),
-	_flow_pos_y(this, "EKF2_OF_POS_Y", false, &_params->flow_pos_body(1)),
-	_flow_pos_z(this, "EKF2_OF_POS_Z", false, &_params->flow_pos_body(2)),
-	_ev_pos_x(this, "EKF2_EV_POS_X", false, &_params->ev_pos_body(0)),
-	_ev_pos_y(this, "EKF2_EV_POS_Y", false, &_params->ev_pos_body(1)),
-	_ev_pos_z(this, "EKF2_EV_POS_Z", false, &_params->ev_pos_body(2)),
+	_mag_delay_ms(this, "EKF2_MAG_DELAY", false, _params->mag_delay_ms),
+	_baro_delay_ms(this, "EKF2_BARO_DELAY", false, _params->baro_delay_ms),
+	_gps_delay_ms(this, "EKF2_GPS_DELAY", false, _params->gps_delay_ms),
+	_flow_delay_ms(this, "EKF2_OF_DELAY", false, _params->flow_delay_ms),
+	_rng_delay_ms(this, "EKF2_RNG_DELAY", false, _params->range_delay_ms),
+	_airspeed_delay_ms(this, "EKF2_ASP_DELAY", false, _params->airspeed_delay_ms),
+	_ev_delay_ms(this, "EKF2_EV_DELAY", false, _params->ev_delay_ms),
+	_gyro_noise(this, "EKF2_GYR_NOISE", false, _params->gyro_noise),
+	_accel_noise(this, "EKF2_ACC_NOISE", false, _params->accel_noise),
+	_gyro_bias_p_noise(this, "EKF2_GYR_B_NOISE", false, _params->gyro_bias_p_noise),
+	_accel_bias_p_noise(this, "EKF2_ACC_B_NOISE", false, _params->accel_bias_p_noise),
+	_mage_p_noise(this, "EKF2_MAG_E_NOISE", false, _params->mage_p_noise),
+	_magb_p_noise(this, "EKF2_MAG_B_NOISE", false, _params->magb_p_noise),
+	_wind_vel_p_noise(this, "EKF2_WIND_NOISE", false, _params->wind_vel_p_noise),
+	_terrain_p_noise(this, "EKF2_TERR_NOISE", false, _params->terrain_p_noise),
+	_terrain_gradient(this, "EKF2_TERR_GRAD", false, _params->terrain_gradient),
+	_gps_vel_noise(this, "EKF2_GPS_V_NOISE", false, _params->gps_vel_noise),
+	_gps_pos_noise(this, "EKF2_GPS_P_NOISE", false, _params->gps_pos_noise),
+	_pos_noaid_noise(this, "EKF2_NOAID_NOISE", false, _params->pos_noaid_noise),
+	_baro_noise(this, "EKF2_BARO_NOISE", false, _params->baro_noise),
+	_baro_innov_gate(this, "EKF2_BARO_GATE", false, _params->baro_innov_gate),
+	_posNE_innov_gate(this, "EKF2_GPS_P_GATE", false, _params->posNE_innov_gate),
+	_vel_innov_gate(this, "EKF2_GPS_V_GATE", false, _params->vel_innov_gate),
+	_tas_innov_gate(this, "EKF2_TAS_GATE", false, _params->tas_innov_gate),
+	_mag_heading_noise(this, "EKF2_HEAD_NOISE", false, _params->mag_heading_noise),
+	_mag_noise(this, "EKF2_MAG_NOISE", false, _params->mag_noise),
+	_eas_noise(this, "EKF2_EAS_NOISE", false, _params->eas_noise),
+	_mag_declination_deg(this, "EKF2_MAG_DECL", false, _params->mag_declination_deg),
+	_heading_innov_gate(this, "EKF2_HDG_GATE", false, _params->heading_innov_gate),
+	_mag_innov_gate(this, "EKF2_MAG_GATE", false, _params->mag_innov_gate),
+	_mag_decl_source(this, "EKF2_DECL_TYPE", false, _params->mag_declination_source),
+	_mag_fuse_type(this, "EKF2_MAG_TYPE", false, _params->mag_fusion_type),
+	_gps_check_mask(this, "EKF2_GPS_CHECK", false, _params->gps_check_mask),
+	_requiredEph(this, "EKF2_REQ_EPH", false, _params->req_hacc),
+	_requiredEpv(this, "EKF2_REQ_EPV", false, _params->req_vacc),
+	_requiredSacc(this, "EKF2_REQ_SACC", false, _params->req_sacc),
+	_requiredNsats(this, "EKF2_REQ_NSATS", false, _params->req_nsats),
+	_requiredGDoP(this, "EKF2_REQ_GDOP", false, _params->req_gdop),
+	_requiredHdrift(this, "EKF2_REQ_HDRIFT", false, _params->req_hdrift),
+	_requiredVdrift(this, "EKF2_REQ_VDRIFT", false, _params->req_vdrift),
+	_param_record_replay_msg(this, "EKF2_REC_RPL", false, _publish_replay_mode),
+	_fusion_mode(this, "EKF2_AID_MASK", false, _params->fusion_mode),
+	_vdist_sensor_type(this, "EKF2_HGT_MODE", false, _params->vdist_sensor_type),
+	_range_noise(this, "EKF2_RNG_NOISE", false, _params->range_noise),
+	_range_innov_gate(this, "EKF2_RNG_GATE", false, _params->range_innov_gate),
+	_rng_gnd_clearance(this, "EKF2_MIN_RNG", false, _params->rng_gnd_clearance),
+	_ev_pos_noise(this, "EKF2_EVP_NOISE", false, _default_ev_pos_noise),
+	_ev_ang_noise(this, "EKF2_EVA_NOISE", false, _default_ev_ang_noise),
+	_ev_innov_gate(this, "EKF2_EV_GATE", false, _params->ev_innov_gate),
+	_flow_noise(this, "EKF2_OF_N_MIN", false, _params->flow_noise),
+	_flow_noise_qual_min(this, "EKF2_OF_N_MAX", false, _params->flow_noise_qual_min),
+	_flow_qual_min(this, "EKF2_OF_QMIN", false, _params->flow_qual_min),
+	_flow_innov_gate(this, "EKF2_OF_GATE", false, _params->flow_innov_gate),
+	_flow_rate_max(this, "EKF2_OF_RMAX", false, _params->flow_rate_max),
+	_imu_pos_x(this, "EKF2_IMU_POS_X", false, _params->imu_pos_body(0)),
+	_imu_pos_y(this, "EKF2_IMU_POS_Y", false, _params->imu_pos_body(1)),
+	_imu_pos_z(this, "EKF2_IMU_POS_Z", false, _params->imu_pos_body(2)),
+	_gps_pos_x(this, "EKF2_GPS_POS_X", false, _params->gps_pos_body(0)),
+	_gps_pos_y(this, "EKF2_GPS_POS_Y", false, _params->gps_pos_body(1)),
+	_gps_pos_z(this, "EKF2_GPS_POS_Z", false, _params->gps_pos_body(2)),
+	_rng_pos_x(this, "EKF2_RNG_POS_X", false, _params->rng_pos_body(0)),
+	_rng_pos_y(this, "EKF2_RNG_POS_Y", false, _params->rng_pos_body(1)),
+	_rng_pos_z(this, "EKF2_RNG_POS_Z", false, _params->rng_pos_body(2)),
+	_flow_pos_x(this, "EKF2_OF_POS_X", false, _params->flow_pos_body(0)),
+	_flow_pos_y(this, "EKF2_OF_POS_Y", false, _params->flow_pos_body(1)),
+	_flow_pos_z(this, "EKF2_OF_POS_Z", false, _params->flow_pos_body(2)),
+	_ev_pos_x(this, "EKF2_EV_POS_X", false, _params->ev_pos_body(0)),
+	_ev_pos_y(this, "EKF2_EV_POS_Y", false, _params->ev_pos_body(1)),
+	_ev_pos_z(this, "EKF2_EV_POS_Z", false, _params->ev_pos_body(2)),
 	_arspFusionThreshold(this, "EKF2_ARSP_THR", false),
-	_tau_vel(this, "EKF2_TAU_VEL", false, &_params->vel_Tau),
-	_tau_pos(this, "EKF2_TAU_POS", false, &_params->pos_Tau),
-	_gyr_bias_init(this, "EKF2_GBIAS_INIT", false, &_params->switch_on_gyro_bias),
-	_acc_bias_init(this, "EKF2_ABIAS_INIT", false, &_params->switch_on_accel_bias),
-	_ang_err_init(this, "EKF2_ANGERR_INIT", false, &_params->initial_tilt_err),
+	_tau_vel(this, "EKF2_TAU_VEL", false, _params->vel_Tau),
+	_tau_pos(this, "EKF2_TAU_POS", false, _params->pos_Tau),
+	_gyr_bias_init(this, "EKF2_GBIAS_INIT", false, _params->switch_on_gyro_bias),
+	_acc_bias_init(this, "EKF2_ABIAS_INIT", false, _params->switch_on_accel_bias),
+	_ang_err_init(this, "EKF2_ANGERR_INIT", false, _params->initial_tilt_err),
 	_airspeed_mode(this, "FW_ARSP_MODE", false)
 {
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -512,14 +512,16 @@ void Logger::add_default_topics()
 	add_topic("vehicle_attitude_groundtruth", 10);
 #endif
 
+	// Note: try to avoid setting the interval where possible, as it increases RAM usage
+
 	add_topic("vehicle_attitude", 10);
 	add_topic("actuator_outputs", 50);
-	add_topic("telemetry_status", 50);
+	add_topic("telemetry_status");
 	add_topic("vehicle_command");
-	add_topic("vehicle_status", 200);
+	add_topic("vehicle_status");
 	add_topic("vtol_vehicle_status", 100);
 	add_topic("commander_state", 100);
-	add_topic("satellite_info", 1000);
+	add_topic("satellite_info");
 	add_topic("vehicle_attitude_setpoint", 20);
 	add_topic("vehicle_rates_setpoint", 10);
 	add_topic("actuator_controls", 20);

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -204,7 +204,7 @@ int Logger::start(char *const *argv)
 	logger_task = px4_task_spawn_cmd("logger",
 					 SCHED_DEFAULT,
 					 SCHED_PRIORITY_MAX - 5,
-					 3800,
+					 3600,
 					 (px4_main_t)&Logger::run_trampoline,
 					 (char *const *)argv);
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1259,21 +1259,21 @@ void Logger::write_add_logged_msg(LoggerSubscription &subscription, int instance
 void Logger::write_info(const char *name, const char *value)
 {
 	_writer.lock();
-	uint8_t buffer[sizeof(ulog_message_info_header_s)];
-	ulog_message_info_header_s *msg = reinterpret_cast<ulog_message_info_header_s *>(buffer);
-	msg->msg_type = static_cast<uint8_t>(ULogMessageType::INFO);
+	ulog_message_info_header_s msg;
+	uint8_t *buffer = reinterpret_cast<uint8_t *>(&msg);
+	msg.msg_type = static_cast<uint8_t>(ULogMessageType::INFO);
 
 	/* construct format key (type and name) */
 	size_t vlen = strlen(value);
-	msg->key_len = snprintf(msg->key, sizeof(msg->key), "char[%zu] %s", vlen, name);
-	size_t msg_size = sizeof(*msg) - sizeof(msg->key) + msg->key_len;
+	msg.key_len = snprintf(msg.key, sizeof(msg.key), "char[%zu] %s", vlen, name);
+	size_t msg_size = sizeof(msg) - sizeof(msg.key) + msg.key_len;
 
 	/* copy string value directly to buffer */
-	if (vlen < (sizeof(*msg) - msg_size)) {
+	if (vlen < (sizeof(msg) - msg_size)) {
 		memcpy(&buffer[msg_size], value, vlen);
 		msg_size += vlen;
 
-		msg->msg_size = msg_size - ULOG_MSG_HEADER_LEN;
+		msg.msg_size = msg_size - ULOG_MSG_HEADER_LEN;
 
 		write_message(buffer, msg_size);
 	}
@@ -1283,19 +1283,19 @@ void Logger::write_info(const char *name, const char *value)
 void Logger::write_info(const char *name, int32_t value)
 {
 	_writer.lock();
-	uint8_t buffer[sizeof(ulog_message_info_header_s)];
-	ulog_message_info_header_s *msg = reinterpret_cast<ulog_message_info_header_s *>(buffer);
-	msg->msg_type = static_cast<uint8_t>(ULogMessageType::INFO);
+	ulog_message_info_header_s msg;
+	uint8_t *buffer = reinterpret_cast<uint8_t *>(&msg);
+	msg.msg_type = static_cast<uint8_t>(ULogMessageType::INFO);
 
 	/* construct format key (type and name) */
-	msg->key_len = snprintf(msg->key, sizeof(msg->key), "int32_t %s", name);
-	size_t msg_size = sizeof(*msg) - sizeof(msg->key) + msg->key_len;
+	msg.key_len = snprintf(msg.key, sizeof(msg.key), "int32_t %s", name);
+	size_t msg_size = sizeof(msg) - sizeof(msg.key) + msg.key_len;
 
 	/* copy string value directly to buffer */
 	memcpy(&buffer[msg_size], &value, sizeof(int32_t));
 	msg_size += sizeof(int32_t);
 
-	msg->msg_size = msg_size - ULOG_MSG_HEADER_LEN;
+	msg.msg_size = msg_size - ULOG_MSG_HEADER_LEN;
 
 	write_message(buffer, msg_size);
 
@@ -1340,10 +1340,10 @@ void Logger::write_version()
 void Logger::write_parameters()
 {
 	_writer.lock();
-	uint8_t buffer[sizeof(ulog_message_parameter_header_s) + sizeof(param_value_u)];
-	ulog_message_parameter_header_s *msg = reinterpret_cast<ulog_message_parameter_header_s *>(buffer);
+	ulog_message_parameter_header_s msg;
+	uint8_t *buffer = reinterpret_cast<uint8_t *>(&msg);
 
-	msg->msg_type = static_cast<uint8_t>(ULogMessageType::PARAMETER);
+	msg.msg_type = static_cast<uint8_t>(ULogMessageType::PARAMETER);
 	int param_idx = 0;
 	param_t param = 0;
 
@@ -1377,14 +1377,14 @@ void Logger::write_parameters()
 			}
 
 			/* format parameter key (type and name) */
-			msg->key_len = snprintf(msg->key, sizeof(msg->key), "%s %s", type_str, param_name(param));
-			size_t msg_size = sizeof(*msg) - sizeof(msg->key) + msg->key_len;
+			msg.key_len = snprintf(msg.key, sizeof(msg.key), "%s %s", type_str, param_name(param));
+			size_t msg_size = sizeof(msg) - sizeof(msg.key) + msg.key_len;
 
 			/* copy parameter value directly to buffer */
 			param_get(param, &buffer[msg_size]);
 			msg_size += value_size;
 
-			msg->msg_size = msg_size - ULOG_MSG_HEADER_LEN;
+			msg.msg_size = msg_size - ULOG_MSG_HEADER_LEN;
 
 			write_message(buffer, msg_size);
 		}
@@ -1397,10 +1397,10 @@ void Logger::write_parameters()
 void Logger::write_changed_parameters()
 {
 	_writer.lock();
-	uint8_t buffer[sizeof(ulog_message_parameter_header_s) + sizeof(param_value_u)];
-	ulog_message_parameter_header_s *msg = reinterpret_cast<ulog_message_parameter_header_s *>(buffer);
+	ulog_message_parameter_header_s msg;
+	uint8_t *buffer = reinterpret_cast<uint8_t *>(&msg);
 
-	msg->msg_type = static_cast<uint8_t>(ULogMessageType::PARAMETER);
+	msg.msg_type = static_cast<uint8_t>(ULogMessageType::PARAMETER);
 	int param_idx = 0;
 	param_t param = 0;
 
@@ -1435,15 +1435,15 @@ void Logger::write_changed_parameters()
 			}
 
 			/* format parameter key (type and name) */
-			msg->key_len = snprintf(msg->key, sizeof(msg->key), "%s %s", type_str, param_name(param));
-			size_t msg_size = sizeof(*msg) - sizeof(msg->key) + msg->key_len;
+			msg.key_len = snprintf(msg.key, sizeof(msg.key), "%s %s", type_str, param_name(param));
+			size_t msg_size = sizeof(msg) - sizeof(msg.key) + msg.key_len;
 
 			/* copy parameter value directly to buffer */
 			param_get(param, &buffer[msg_size]);
 			msg_size += value_size;
 
 			/* msg_size is now 1 (msg_type) + 2 (msg_size) + 1 (key_len) + key_len + value_size */
-			msg->msg_size = msg_size - ULOG_MSG_HEADER_LEN;
+			msg.msg_size = msg_size - ULOG_MSG_HEADER_LEN;
 
 			write_message(buffer, msg_size);
 		}

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -192,7 +192,7 @@ void Logger::usage(const char *reason)
 		 "\t-e\tEnable logging right after start until disarm (otherwise only when armed)\n"
 		 "\t-f\tLog until shutdown (implies -e)\n"
 		 "\t-t\tUse date/time for naming log directories and files\n"
-		 "\t-m\tMode: one of 'file', 'mavlink', 'all' (default=file)\n"
+		 "\t-m\tMode: one of 'file', 'mavlink', 'all' (default=all)\n"
 		 "\t-q\tuORB queue size for mavlink mode");
 }
 
@@ -261,7 +261,7 @@ void Logger::run_trampoline(int argc, char *argv[])
 	bool log_name_timestamp = false;
 	unsigned int queue_size = 14; //TODO: we might be able to reduce this if mavlink polled on the topic and/or
 	// topic sizes get reduced
-	LogWriter::Backend backend = LogWriter::BackendFile;
+	LogWriter::Backend backend = LogWriter::BackendAll;
 
 	int myoptind = 1;
 	int ch;

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -61,7 +61,6 @@ namespace logger
 struct LoggerSubscription {
 	int fd[ORB_MULTI_MAX_INSTANCES];
 	uint16_t msg_ids[ORB_MULTI_MAX_INSTANCES];
-	uint64_t time_tried_subscribe;	// captures the time at which we checked last time if this instance existed
 	const orb_metadata *metadata = nullptr;
 
 	LoggerSubscription() {}
@@ -70,7 +69,6 @@ struct LoggerSubscription {
 		metadata(metadata_)
 	{
 		fd[0] = fd_;
-		time_tried_subscribe = 0;
 
 		for (int i = 1; i < ORB_MULTI_MAX_INSTANCES; i++) {
 			fd[i] = -1;
@@ -189,7 +187,7 @@ private:
 
 	void write_changed_parameters();
 
-	bool copy_if_updated_multi(LoggerSubscription &sub, int multi_instance, void *buffer);
+	bool copy_if_updated_multi(LoggerSubscription &sub, int multi_instance, void *buffer, bool try_to_subscribe);
 
 	/**
 	 * Write exactly one ulog message to the logger and handle dropouts.
@@ -228,9 +226,9 @@ private:
 
 	uint8_t						*_msg_buffer = nullptr;
 	int						_msg_buffer_len = 0;
-	bool						_task_should_exit = true;
 	char 						_log_dir[LOG_DIR_LEN];
 	char 						_log_file_name[32];
+	bool						_task_should_exit = true;
 	bool						_has_log_dir = false;
 	bool						_was_armed = false;
 	bool						_arm_override;

--- a/src/modules/mavlink/mavlink_orb_subscription.cpp
+++ b/src/modules/mavlink/mavlink_orb_subscription.cpp
@@ -50,11 +50,11 @@
 MavlinkOrbSubscription::MavlinkOrbSubscription(const orb_id_t topic, int instance) :
 	next(nullptr),
 	_topic(topic),
-	_instance(instance),
 	_fd(-1),
+	_instance(instance),
 	_published(false),
-	_last_pub_check(0),
-	_subscribe_from_beginning(false)
+	_subscribe_from_beginning(false),
+	_last_pub_check(0)
 {
 }
 

--- a/src/modules/mavlink/mavlink_orb_subscription.h
+++ b/src/modules/mavlink/mavlink_orb_subscription.h
@@ -95,11 +95,11 @@ public:
 
 private:
 	const orb_id_t _topic;		///< topic metadata
-	const int _instance;		///< get topic instance
 	int _fd;			///< subscription handle
+	const uint8_t _instance;		///< get topic instance
 	bool _published;		///< topic was ever published
-	hrt_abstime _last_pub_check;	///< when we checked last
 	bool _subscribe_from_beginning; ///< we need to subscribe from the beginning, e.g. for vehicle_command_acks
+	hrt_abstime _last_pub_check;	///< when we checked last
 
 	/* do not allow copying this class */
 	MavlinkOrbSubscription(const MavlinkOrbSubscription &);

--- a/src/modules/uORB/ORBMap.hpp
+++ b/src/modules/uORB/ORBMap.hpp
@@ -62,13 +62,19 @@ public:
 			unlinkNext(_top);
 
 			if (_top->next == nullptr) {
-				free((void *)_top->node_name);
 				free(_top);
 				_top = nullptr;
 				_end = nullptr;
 			}
 		}
 	}
+
+	/**
+	 * Insert an element with a unique name
+	 * @param node_name name of the node. This will not be copied, so the caller has to ensure
+	 *                  the pointer is valid until the node is removed from ORBMap
+	 * @param node
+	 */
 	void insert(const char *node_name, uORB::DeviceNode *node)
 	{
 		Node **p;
@@ -90,7 +96,7 @@ public:
 		}
 
 		_end->next = nullptr;
-		_end->node_name = strdup(node_name);
+		_end->node_name = node_name;
 		_end->node = node;
 	}
 
@@ -124,21 +130,6 @@ public:
 		return nullptr;
 	}
 
-	void unlinkNext(Node *a)
-	{
-		Node *b = a->next;
-
-		if (b != nullptr) {
-			if (_end == b) {
-				_end = a;
-			}
-
-			a->next = b->next;
-			free((void *)b->node_name);
-			free(b);
-		}
-	}
-
 	Node *top() const
 	{
 		return _top;
@@ -150,6 +141,20 @@ public:
 	}
 
 private:
+	void unlinkNext(Node *a)
+	{
+		Node *b = a->next;
+
+		if (b != nullptr) {
+			if (_end == b) {
+				_end = a;
+			}
+
+			a->next = b->next;
+			free(b);
+		}
+	}
+
 	Node *_top;
 	Node *_end;
 };

--- a/src/modules/uORB/uORBDevices.cpp
+++ b/src/modules/uORB/uORBDevices.cpp
@@ -93,14 +93,11 @@ uORB::DeviceNode::DeviceNode(const struct orb_metadata *meta, const char *name, 
 	_data(nullptr),
 	_last_update(0),
 	_generation(0),
-	_priority(priority),
+	_priority((uint8_t)priority),
 	_published(false),
 	_queue_size(queue_size),
-	_publisher(0),
-#ifdef __PX4_NUTTX
-	_IsRemoteSubscriberPresent(false),
-#endif
-	_subscriber_count(0)
+	_subscriber_count(0),
+	_publisher(0)
 {
 	// enable debug() calls
 	//_debug_enabled = true;
@@ -749,7 +746,8 @@ int uORB::DeviceNode::update_queue_size(unsigned int queue_size)
 		return PX4_OK;
 	}
 
-	if (_data || _queue_size > queue_size) {
+	//queue size is limited to 255 for the single reason that we use uint8 to store it
+	if (_data || _queue_size > queue_size || queue_size > 255) {
 		return ERROR;
 	}
 

--- a/src/modules/uORB/uORBDevices.cpp
+++ b/src/modules/uORB/uORBDevices.cpp
@@ -912,9 +912,9 @@ uORB::DeviceMaster::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 				} else {
 					// add to the node map;.
 #ifdef __PX4_NUTTX
-					_node_map.insert(nodepath, node);
+					_node_map.insert(devpath, node);
 #else
-					_node_map[std::string(nodepath)] = node;
+					_node_map[std::string(devpath)] = node;
 #endif
 				}
 

--- a/src/modules/uORB/uORBDevices.hpp
+++ b/src/modules/uORB/uORBDevices.hpp
@@ -186,7 +186,7 @@ public:
 	bool print_statistics(bool reset);
 
 	unsigned int get_queue_size() const { return _queue_size; }
-	int32_t subscriber_count() const { return _subscriber_count; }
+	int16_t subscriber_count() const { return _subscriber_count; }
 	uint32_t lost_message_count() const { return _lost_messages; }
 	unsigned int published_message_count() const { return _generation; }
 	const struct orb_metadata *get_meta() const { return _meta; }
@@ -221,21 +221,20 @@ private:
 	uint8_t     *_data;   /**< allocated object buffer */
 	hrt_abstime   _last_update; /**< time the object was last updated */
 	volatile unsigned   _generation;  /**< object generation count */
-	const int   _priority;  /**< priority of topic */
+	const uint8_t   _priority;  /**< priority of the topic */
 	bool _published;  /**< has ever data been published */
-	unsigned int _queue_size; /**< maximum number of elements in the queue */
+	uint8_t _queue_size; /**< maximum number of elements in the queue */
+	int16_t _subscriber_count;
 
 	inline static SubscriberData    *filp_to_sd(device::file_t *filp);
 
 #ifdef __PX4_NUTTX
 	pid_t     _publisher; /**< if nonzero, current publisher. Only used inside the advertise call.
 					We allow one publisher to have an open file descriptor at the same time. */
-	bool    _IsRemoteSubscriberPresent;
 #else
 	px4_task_t     _publisher; /**< if nonzero, current publisher. Only used inside the advertise call.
 					We allow one publisher to have an open file descriptor at the same time. */
 #endif
-	int32_t _subscriber_count;
 
 	//statistics
 	uint32_t _lost_messages = 0; ///< nr of lost messages for all subscribers. If two subscribers lose the same


### PR DESCRIPTION
This frees up about 7KB of RAM for pretty much all NuttX configurations (tested on Pixracer). 1KB is in the new logger (plus reduced CPU usage), the rest is distributed at other places.

Also enables mavlink ulog streaming by default (both logger backends are enabled), which uses roughly 270B more RAM.

Please review carefully as these are changes at central places.