### PR TITLE
[WIP] Improved Navio PWM out: use external mixer

### DIFF
--- a/posix-configs/rpi/px4_fw.config
+++ b/posix-configs/rpi/px4_fw.config
@@ -1,0 +1,24 @@
+uorb start
+param load
+param set MAV_BROADCAST 1
+#param set SYS_AUTOSTART 2104
+param set MAV_TYPE 1
+df_lsm9ds1_wrapper start -R 4
+df_ms5611_wrapper start
+#navio_rgbled start
+gps start -d /dev/spidev0.0 -i spi -p ubx
+sensors start
+commander start
+ekf2 start
+fw_att_control start
+fw_pos_control_l1
+mavlink start -u 14556 -r 1000000
+sleep 1
+mavlink stream -u 14556 -s HIGHRES_IMU -r 20
+mavlink stream -u 14556 -s ATTITUDE -r 20
+mavlink stream -u 14556 -s MANUAL_CONTROL -r 10
+
+
+navio_sysfs_rc_in start
+navio_sysfs_pwm_out start
+mavlink boot_complete

--- a/src/drivers/navio_sysfs_pwm_out/navio_sysfs_pwm_out.cpp
+++ b/src/drivers/navio_sysfs_pwm_out/navio_sysfs_pwm_out.cpp
@@ -48,7 +48,6 @@
 #include <drivers/drv_mixer.h>
 #include <systemlib/mixer/mixer.h>
 #include <systemlib/mixer/mixer_load.h>
-#include <systemlib/mixer/mixer_multirotor.generated.h>
 #include <systemlib/param/param.h>
 #include <systemlib/pwm_limit/pwm_limit.h>
 
@@ -155,22 +154,6 @@ int initialize_mixer(const char *mixer_filename)
 	} else {
 		PX4_ERR("Unable to load config file.");
 	}
-
-	PX4_WARN("Using default mixer.");
-
-	/* Mixer file loading failed, fall back to default mixer configuration for
-	* QUAD_X airframe. */
-	float roll_scale = 1;
-	float pitch_scale = 1;
-	float yaw_scale = 1;
-	float deadband = 0;
-	MultirotorMixer *mixer = new MultirotorMixer(mixer_control_callback, (uintptr_t)&_controls,
-			MultirotorGeometry::QUAD_X,
-			roll_scale, pitch_scale, yaw_scale, deadband);
-	_mixer_group->add_mixer(mixer);
-
-	// TODO: temporary hack to make this compile
-	(void)_config_index[0];
 
 	if (_mixer_group->count() <= 0) {
 		PX4_ERR("Mixer initialization failed");


### PR DESCRIPTION
As stated in #5695, the output support on the RPi2/Navio2 is still very basic.

In order tackle this a little, I propose to use external mixers instead of the default multicopter mixer, such that Navio can also be used on other plattforms.
As I'm new to IO related things on PX4, I would be glad if I could already get some feedback on the changes.

Improvements/Changes:
- [x] uses default px4 mixer files
- [x] all actuator groups may be used in mixer file
- [x] baseline config for fw platforms
- [x] make command line option for mixer file

What still needs to be done
- [ ] use more of the existing params
- [ ] probably some more error handling
