### PR TITLE
Simulator: configure ground truth message

### DIFF
--- a/Tools/jmavsim_run.sh
+++ b/Tools/jmavsim_run.sh
@@ -4,10 +4,22 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR/jMAVSim"
 
 udp_port=14560
-while getopts ":p:" opt; do
+extra_args=
+baudrate=921600
+device=
+while getopts ":b:d:p:q" opt; do
 	case $opt in
+		b)
+			baudrate=$OPTARG
+			;;
+		d)
+			device="$OPTARG"
+			;;
 		p)
 			udp_port=$OPTARG
+			;;
+		q)
+			extra_args="$extra_args -qgc"
 			;;
 		\?)
 			echo "Invalid option: -$OPTARG" >&2
@@ -16,6 +28,12 @@ while getopts ":p:" opt; do
 	esac
 done
 
+if [ "$device" == "" ]; then
+	device="-udp 127.0.0.1:$udp_port"
+else
+	device="-serial $device $baudrate"
+fi
+
 ant create_run_jar copy_res
 cd out/production
-java -Djava.ext.dirs= -jar jmavsim_run.jar -udp 127.0.0.1:$udp_port
+java -Djava.ext.dirs= -jar jmavsim_run.jar $device $extra_args

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -849,14 +849,12 @@ Mavlink::set_hil_enabled(bool hil_enabled)
 	if (hil_enabled && !_hil_enabled) {
 		_hil_enabled = true;
 		configure_stream("HIL_ACTUATOR_CONTROLS", 200.0f);
-		configure_stream("HIL_CONTROLS", 200.0f); //for compatibility, publish the old message as well
 	}
 
 	/* disable HIL */
 	if (!hil_enabled && _hil_enabled) {
 		_hil_enabled = false;
 		configure_stream("HIL_ACTUATOR_CONTROLS", 0.0f);
-		configure_stream("HIL_CONTROLS", 0.0f);
 
 	} else {
 		ret = PX4_ERROR;

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -610,6 +610,13 @@ void Simulator::pollForMAVLinkMessages(bool publish, int udp_port)
 
 	const unsigned max_wait_ms = 6;
 
+	//send MAV_CMD_SET_MESSAGE_INTERVAL for HIL_STATE_QUATERNION ground truth
+	mavlink_command_long_t cmd_long = {};
+	cmd_long.command = MAV_CMD_SET_MESSAGE_INTERVAL;
+	cmd_long.param1 = MAVLINK_MSG_ID_HIL_STATE_QUATERNION;
+	cmd_long.param2 = 5e3;
+	send_mavlink_message(MAVLINK_MSG_ID_COMMAND_LONG, &cmd_long, 200);
+
 	// wait for new mavlink messages to arrive
 	while (true) {
 


### PR DESCRIPTION
Send MAV_CMD_SET_MESSAGE_INTERVAL to enable ground truth on startup.

@kd0aij 

Requires https://github.com/PX4/jMAVSim/pull/44