### PR TITLE
Fix takeoff edge case 

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1567,7 +1567,7 @@ MulticopterPositionControl::task_main()
 					if (!_takeoff_jumped) {
 						// ramp thrust setpoint up
 						if (_vel(2) > -(_params.tko_speed / 2.0f)) {
-							_takeoff_thrust_sp += 1.0f * dt;
+							_takeoff_thrust_sp += 0.5f * dt;
 							_vel_sp.zero();
 							_vel_prev.zero();
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1567,7 +1567,7 @@ MulticopterPositionControl::task_main()
 					if (!_takeoff_jumped) {
 						// ramp thrust setpoint up
 						if (_vel(2) > -(_params.tko_speed / 2.0f)) {
-							_takeoff_thrust_sp += 0.5f * dt;
+							_takeoff_thrust_sp += 1.0f * dt;
 							_vel_sp.zero();
 							_vel_prev.zero();
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1244,6 +1244,9 @@ MulticopterPositionControl::task_main()
 	/* get an initial update for all sensor and status data */
 	poll_subscriptions();
 
+	/* We really need to know from the beginning if we're landed or in-air. */
+	orb_copy(ORB_ID(vehicle_land_detected), _vehicle_land_detected_sub, &_vehicle_land_detected);
+
 	bool reset_int_z = true;
 	bool reset_int_z_manual = false;
 	bool reset_int_xy = true;

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -618,25 +618,17 @@ MissionBlock::set_follow_target_item(struct mission_item_s *item, float min_clea
 }
 
 void
-MissionBlock::set_takeoff_item(struct mission_item_s *item, float min_clearance, float min_pitch)
+MissionBlock::set_takeoff_item(struct mission_item_s *item, float abs_altitude, float min_pitch)
 {
 	item->nav_cmd = NAV_CMD_TAKEOFF;
 
-	/* use current position and use return altitude as clearance */
+	/* use current position */
 	item->lat = _navigator->get_global_position()->lat;
 	item->lon = _navigator->get_global_position()->lon;
-	item->altitude = _navigator->get_global_position()->alt;
 
-	if (min_clearance > 0.0f) {
-		item->altitude += min_clearance;
-
-		/* we must takeoff to a point further above ground than the acceptance radius */
-		if (_navigator->get_acceptance_radius() > min_clearance) {
-			item->altitude += _navigator->get_acceptance_radius();
-		}
-	}
-
+	item->altitude = abs_altitude;
 	item->altitude_is_relative = false;
+
 	item->yaw = NAN;
 	item->loiter_radius = _navigator->get_loiter_radius();
 	item->loiter_direction = 1;

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -182,7 +182,7 @@ MissionBlock::is_mission_item_reached()
 
 			float altitude_acceptance_radius = _navigator->get_altitude_acceptance_radius();
 
-			/* It should be safe to juse use half of the takoeff_alt as an acceptance radius. */
+			/* It should be safe to just use half of the takoeff_alt as an acceptance radius. */
 			if (takeoff_alt > 0 && takeoff_alt < altitude_acceptance_radius) {
 				altitude_acceptance_radius = takeoff_alt / 2.0f;
 			}

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -107,7 +107,7 @@ protected:
 	/**
 	 * Set a takeoff mission item
 	 */
-	void set_takeoff_item(struct mission_item_s *item, float min_clearance = -1.0f, float min_pitch = 0.0f);
+	void set_takeoff_item(struct mission_item_s *item, float abs_altitude, float min_pitch = 0.0f);
 
 	/**
 	 * Set a land mission item

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -55,7 +55,7 @@
  * @increment 0.5
  * @group Mission
  */
-PARAM_DEFINE_FLOAT(MIS_TAKEOFF_ALT, 10.0f);
+PARAM_DEFINE_FLOAT(MIS_TAKEOFF_ALT, 2.5f);
 
 /**
  * Minimum Loiter altitude

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -99,8 +99,39 @@ Takeoff::on_active()
 void
 Takeoff::set_takeoff_position()
 {
+	struct position_setpoint_triplet_s *rep = _navigator->get_takeoff_triplet();
+
+	float abs_altitude = 0.0f;
+
+	const float min_abs_altitude = _navigator->get_home_position()->alt + _param_min_alt.get();
+
+	// Use altitude if it has been set.
+	if (rep->current.valid && PX4_ISFINITE(rep->current.alt)) {
+		abs_altitude = rep->current.alt;
+
+		// If the altitude suggestion is lower than home + minimum clearance, raise it and complain.
+		if (abs_altitude < min_abs_altitude) {
+			abs_altitude = min_abs_altitude;
+			mavlink_log_critical(_navigator->get_mavlink_log_pub(),
+					     "Using minimum takeoff altitude: %.2f m", (double)_param_min_alt.get());
+		}
+	} else {
+		// Use home + minimum clearance but only notify.
+		abs_altitude = min_abs_altitude;
+		mavlink_log_info(_navigator->get_mavlink_log_pub(),
+				 "Using minimum takeoff altitude: %.2f m", (double)_param_min_alt.get());
+	}
+
+
+	if (abs_altitude < _navigator->get_global_position()->alt) {
+		// If the suggestion is lower than our current alt, let's not go down.
+		abs_altitude = _navigator->get_global_position()->alt;
+		mavlink_log_critical(_navigator->get_mavlink_log_pub(),
+				     "Already higher than takeoff altitude");
+	}
+
 	// set current mission item to takeoff
-	set_takeoff_item(&_mission_item, _param_min_alt.get());
+	set_takeoff_item(&_mission_item, abs_altitude);
 	_navigator->get_mission_result()->reached = false;
 	_navigator->get_mission_result()->finished = false;
 	_navigator->set_mission_result_updated();
@@ -114,12 +145,7 @@ Takeoff::set_takeoff_position()
 	pos_sp_triplet->current.yaw_valid = true;
 	pos_sp_triplet->next.valid = false;
 
-	// check if a specific target altitude has been set
-	struct position_setpoint_triplet_s *rep = _navigator->get_takeoff_triplet();
 	if (rep->current.valid) {
-		if (PX4_ISFINITE(rep->current.alt)) {
-			pos_sp_triplet->current.alt = rep->current.alt;
-		}
 
 		// Go on and check which changes had been requested
 		if (PX4_ISFINITE(rep->current.yaw)) {


### PR DESCRIPTION
In the normal sitl `commander takeoff` case, the takeoff jump was never
actually carried out because the default altitude radius is set to 3m
and the takeoff altitude to ~2m which means that the takeoff waypoint is
"reached" immediately.

This works around this edge case by using the altitude between the home
altitude and takeoff altitude divided by 2 as a acceptance radius.

@bkueng, @LorenzMeier please review.