### PR TITLE
Fixed hardfault on fast proc

### DIFF
--- a/src/drivers/ms5611/ms5611.cpp
+++ b/src/drivers/ms5611/ms5611.cpp
@@ -800,7 +800,7 @@ MS5611::collect()
 		report.altitude = (((pow((p / p1), (-(a * R) / g))) * T1) - T1) / a;
 
 		/* publish it */
-		if (!(_pub_blocked)) {
+		if (!(_pub_blocked) && _baro_topic != nullptr) {
 			/* publish it */
 			orb_publish(ORB_ID(sensor_baro), _baro_topic, &report);
 		}


### PR DESCRIPTION
_baro_topic can be null in init sequence
   init call collect before the topic is inited.

I think this pattern is repeated in other drivers. I would suggest
allowing null in orb_publish to just return.