### PR TITLE
UAVCAN diagnostics

### DIFF
--- a/src/modules/uavcan/uavcan_main.hpp
+++ b/src/modules/uavcan/uavcan_main.hpp
@@ -48,6 +48,7 @@
 #include <uavcan/helpers/heap_based_pool_allocator.hpp>
 #include <uavcan/protocol/global_time_sync_master.hpp>
 #include <uavcan/protocol/global_time_sync_slave.hpp>
+#include <uavcan/protocol/node_status_monitor.hpp>
 #include <uavcan/protocol/param/GetSet.hpp>
 #include <uavcan/protocol/param/ExecuteOpcode.hpp>
 #include <uavcan/protocol/RestartNode.hpp>
@@ -140,8 +141,6 @@ public:
 	int			 get_param(int remote_node_id, const char *name);
 	int			 reset_node(int remote_node_id);
 
-
-
 private:
 	void		fill_node_info();
 	int		init(uavcan::NodeID node_id);
@@ -187,6 +186,7 @@ private:
 	UavcanHardpointController	_hardpoint_controller;
 	uavcan::GlobalTimeSyncMaster	_time_sync_master;
 	uavcan::GlobalTimeSyncSlave	_time_sync_slave;
+	uavcan::NodeStatusMonitor	_node_status_monitor;
 
 	List<IUavcanSensorBridge *>	_sensor_bridges;		///< List of active sensor bridges
 

--- a/src/modules/uavcan/uavcan_servers.cpp
+++ b/src/modules/uavcan/uavcan_servers.cpp
@@ -64,11 +64,6 @@
 
 #include <v1.0/common/mavlink.h>
 
-//todo:The Inclusion of file_server_backend is killing
-// #include <sys/types.h> and leaving OK undefined
-# define OK 0
-
-
 
 /**
  * @file uavcan_servers.cpp
@@ -283,7 +278,7 @@ int UavcanServers::init()
 
 	/*  Start the Node   */
 
-	return OK;
+	return 0;
 }
 
 pthread_addr_t UavcanServers::run(pthread_addr_t)

--- a/src/modules/uavcan/uavcan_servers.cpp
+++ b/src/modules/uavcan/uavcan_servers.cpp
@@ -403,7 +403,7 @@ pthread_addr_t UavcanServers::run(pthread_addr_t)
 					 */
 					_param_index = 0;
 					_param_list_in_progress = true;
-					_param_list_node_id = get_next_active_node_id(1);
+					_param_list_node_id = get_next_active_node_id(0);
 					_param_list_all_nodes = true;
 
 					warnx("UAVCAN command bridge: starting global param list with node %hhu", _param_list_node_id);
@@ -491,7 +491,7 @@ pthread_addr_t UavcanServers::run(pthread_addr_t)
 						//       Leaving it as-is to avoid breaking compatibility with non-compliant nodes.
 						req.parameter_name = "esc_index";
 						req.timeout_sec = _esc_enumeration_active ? 65535 : 0;
-						call_res = _enumeration_client.call(get_next_active_node_id(1), req);
+						call_res = _enumeration_client.call(get_next_active_node_id(0), req);
 						if (call_res < 0) {
 							warnx("UAVCAN ESC enumeration: couldn't send initial Begin request: %d", call_res);
 							beep(BeepFrequencyError);
@@ -864,7 +864,7 @@ void UavcanServers::cb_enumeration_save(const uavcan::ServiceCallResult<uavcan::
 		//       Leaving it as-is to avoid breaking compatibility with non-compliant nodes.
 		req.parameter_name = "esc_index";
 		req.timeout_sec = 0;
-		int call_res = _enumeration_client.call(get_next_active_node_id(1), req);
+		int call_res = _enumeration_client.call(get_next_active_node_id(0), req);
 		if (call_res < 0) {
 			warnx("UAVCAN ESC enumeration: couldn't send Begin request to stop enumeration: %d", call_res);
 		} else {


### PR DESCRIPTION
Hey @DonLakeFlyer, 

I attempted to reproduce your issues locally, and failed. I based my attempts with the current master, and found out that everything works as expected. In order to help with the investigation on your end, I added a useful diagnostic that prints the list of all online nodes with the status output (`uavcan status`). It looks like that:

```
Online nodes (Node ID, Health, Mode):
        115 OK         OPERAT    
        116 OK         OPERAT    
        117 OK         OPERAT    
        118 OK         OPERAT  
```

Please merge or cherry-pick this change and show what status output you get.

You can also verify whether your PX4 has access to the configuration parameters via CLI as follows: `uavcan param list 115` (the last number is the node ID, adjust as necessary). You should get back a list of configuration parameters of the specified node:

```
name: esc_index 2
name: cmd_ttl_ms 200
name: cmd_start_dc 0.2500
name: uavcan_node_id 0
name: light_index 0
name: pwm_max_usec 2000
name: pwm_min_usec 1000
(...snip)
```

If the above works for you, then the configuration management module is working well, and the issue should be within the MAVLink part of the system, rather than UAVCAN.

Finally, this is what I get when loading configuration parameters via QGC:

![image](https://cloud.githubusercontent.com/assets/3298404/19618935/1edf5354-9861-11e6-8e16-7aa7f5d0d554.png)

Please let me know how else I can assist.