### PR TITLE
mavlink_shell.py: default to 57600 baudrate

### DIFF
--- a/Tools/mavlink_shell.py
+++ b/Tools/mavlink_shell.py
@@ -94,7 +94,7 @@ def main():
             help='Mavlink port name: serial: DEVICE[,BAUD], udp: IP:PORT, tcp: tcp:IP:PORT. Eg: \
 /dev/ttyUSB0 or 0.0.0.0:14550. Auto-detect serial if not given.')
     parser.add_argument("--baudrate", "-b", dest="baudrate", type=int,
-                      help="Mavlink port baud rate (default=115200)", default=115200)
+                      help="Mavlink port baud rate (default=57600)", default=57600)
     args = parser.parse_args()
 
 


### PR DESCRIPTION
I think it makes more sense to use 57600 by default because it works straight out of the box with 3DR radios.

@bkueng objections?

Fixes #5728.