### PR TITLE
System identification maneuvers

### DIFF
--- a/msg/manual_control_setpoint.msg
+++ b/msg/manual_control_setpoint.msg
@@ -54,3 +54,4 @@ uint8 kill_switch		 # throttle kill: _NORMAL_, KILL
 uint8 transition_switch	 # VTOL transition switch: _HOVER, FORWARD_FLIGHT
 uint8 gear_switch	 # landing gear switch: _DOWN_, UP
 int8 mode_slot			 # the slot a specific model selector is in
+uint8 sysid_switch		# spring back switch to activate system identification maneuver

--- a/msg/rc_channels.msg
+++ b/msg/rc_channels.msg
@@ -22,11 +22,12 @@ uint8 RC_CHANNELS_FUNCTION_RATTITUDE=19
 uint8 RC_CHANNELS_FUNCTION_KILLSWITCH=20
 uint8 RC_CHANNELS_FUNCTION_TRANSITION=21
 uint8 RC_CHANNELS_FUNCTION_GEAR=22
+uint8 RC_CHANNELS_FUNCTION_SYSIDSWITCH=23
 
 uint64 timestamp_last_valid					# Timestamp of last valid RC signal
 float32[18] channels						# Scaled to -1..1 (throttle: 0..1)
 uint8 channel_count						# Number of valid channels
-int8[23] function						# Functions mapping
+int8[24] function						# Functions mapping
 uint8 rssi							# Receive signal strength indicator (0-100)
 bool signal_lost						# Control signal lost, should be checked together with topic timeout
 uint32 frame_drop_count						# Number of dropped frames

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -2571,6 +2571,35 @@ PARAM_DEFINE_INT32(RC_MAP_TRANS_SW, 0);
  * @value 18 Channel 18
  */
 PARAM_DEFINE_INT32(RC_MAP_GEAR_SW, 0);
+
+/**
+ * System identification switch channel mapping
+ *
+ * @min 0
+ * @max 18
+ * @group Radio Switches
+ * @value 0 Unassigned
+ * @value 1 Channel 1
+ * @value 2 Channel 2
+ * @value 3 Channel 3
+ * @value 4 Channel 4
+ * @value 5 Channel 5
+ * @value 6 Channel 6
+ * @value 7 Channel 7
+ * @value 8 Channel 8
+ * @value 9 Channel 9
+ * @value 10 Channel 10
+ * @value 11 Channel 11
+ * @value 12 Channel 12
+ * @value 13 Channel 13
+ * @value 14 Channel 14
+ * @value 15 Channel 15
+ * @value 16 Channel 16
+ * @value 17 Channel 17
+ * @value 18 Channel 18
+ */
+PARAM_DEFINE_INT32(RC_MAP_SYSID_SW, 0);
+
 /**
  * AUX1 Passthrough RC Channel
  *
@@ -3022,6 +3051,24 @@ PARAM_DEFINE_FLOAT(RC_TRANS_TH, 0.25f);
 PARAM_DEFINE_FLOAT(RC_GEAR_TH, 0.25f);
 
 /**
+ * Threshold for the system identification transition switch
+ *
+ * 0-1 indicate where in the full channel range the threshold sits
+ * 		0 : min
+ * 		1 : max
+ * sign indicates polarity of comparison
+ * 		positive : true when channel>th
+ * 		negative : true when channel<th
+ *
+ * @min -1
+ * @max 1
+ * @group Radio Switches
+ *
+ *
+ */
+PARAM_DEFINE_FLOAT(RC_SYSID_TH, 0.25f);
+
+/**
  * PWM input channel that provides RSSI.
  *
  * 0: do not read RSSI from input channel
@@ -3276,3 +3323,108 @@ PARAM_DEFINE_INT32(PWM_AUX_DISARMED, 1000);
  * @group PWM Outputs
  */
 PARAM_DEFINE_FLOAT(MOT_SLEW_MAX, 0.0f);
+
+/**
+ * Define the sysID manoeuvre
+ *
+ * @min 0
+ * @max 7
+ * @value 0 Disabled
+ * @value 1 Step/Ramp in roll
+ * @value 2 Step/Ramp in pitch
+ * @value 3 Step/Ramp in yaw
+ * @value 4 Step in throttle
+ * @value 5 Chirp in roll
+ * @value 6 Chirp in pitch
+ * @value 7 Chirp in yaw
+ * @value 8 2-1-1 in roll
+ * @value 9 2-1-1 in pitch
+ * @value 10 2-1-1 in yaw
+ * @group SysID
+ */
+PARAM_DEFINE_INT32(SID_MANOEUVRE, 0);
+
+/**
+ * Define the amplitude of the sysID manoeuvre
+ *
+ * @min -1
+ * @max 1
+ * @decimal 1
+ * @group SysID
+ */
+PARAM_DEFINE_FLOAT(SID_AMPLITUDE, 0.3f);
+
+/**
+ * Define the active time of the sysID manoeuvre
+ *
+ * @min 0
+ * @max 15
+ * @unit seconds
+ * @decimal 1
+ * @group SysID
+ */
+PARAM_DEFINE_FLOAT(SID_ON_TIME, 3.0f);
+
+/**
+ * Define the trim time before the sysID manoeuvre
+ *
+ * The input signal will be zero before the sid manoeuvre
+ * for this specified time
+ *
+ * @min 0
+ * @max 60
+ * @unit seconds
+ * @decimal 1
+ * @group SysID
+ */
+PARAM_DEFINE_FLOAT(SID_TRIM_TIME_B, 1.0f);
+
+/**
+ * Define the trim time after the sysID manoeuvre
+ *
+ * The input signal will be zero after the sid manoeuvre
+ * for this specified time
+ *
+ * @min 0
+ * @max 60
+ * @unit seconds
+ * @decimal 1
+ * @group SysID
+ */
+PARAM_DEFINE_FLOAT(SID_TRIM_TIME_A, 1.0f);
+
+/**
+ * Define the start frequency of the sysID manoeuvre
+ *
+ * @min 0.1
+ * @max 5
+ * @unit Hz
+ * @decimal 1
+ * @group SysID
+ */
+PARAM_DEFINE_FLOAT(SID_START_FREQ, 1.0f);
+
+/**
+ * Define the Stop frequency of the sysID manoeuvre
+ *
+ * @min 0.1
+ * @max 5
+ * @unit Hz
+ * @decimal 1
+ * @group SysID
+ */
+PARAM_DEFINE_FLOAT(SID_STOP_FREQ, 1.0f);
+
+/**
+ * Define the ramp slope. (1/rate)
+ *
+ * This corresponds to the time [s] it takes to go from 0 to 1 (max. stick input)
+ *
+ * @min 0
+ * @max 5
+ * @decimal 1
+ * @unit seconds
+ * @group SysID
+ */
+PARAM_DEFINE_FLOAT(SID_RAMP_SLOPE, 0.0f);
+

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -3328,7 +3328,7 @@ PARAM_DEFINE_FLOAT(MOT_SLEW_MAX, 0.0f);
  * Define the sysID manoeuvre
  *
  * @min 0
- * @max 7
+ * @max 10
  * @value 0 Disabled
  * @value 1 Step/Ramp in roll
  * @value 2 Step/Ramp in pitch

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -261,6 +261,7 @@ private:
 	struct differential_pressure_s _diff_pres;
 	struct airspeed_s _airspeed;
 	struct rc_parameter_map_s _rc_parameter_map;
+	struct vehicle_control_mode_s vcontrol_mode;
 	float _param_rc_values[rc_parameter_map_s::RC_PARAM_MAP_NCHAN];	/**< parameter values for RC control */
 
 	math::Matrix<3, 3>	_board_rotation;	/**< rotation matrix for the orientation that the board is mounted */
@@ -1480,7 +1481,6 @@ Sensors::diff_pres_poll(struct sensor_combined_s &raw)
 void
 Sensors::vehicle_control_mode_poll()
 {
-	struct vehicle_control_mode_s vcontrol_mode;
 	bool vcontrol_mode_updated;
 
 	/* Check HIL state if vehicle control mode has changed */
@@ -2747,7 +2747,7 @@ Sensors::check_sysid_manoeuvre(manual_control_setpoint_s *manual)
 	    && (manual->sysid_switch != _prev_sysid_sw_pos)) {
 		is_doing_manoeuvre = !is_doing_manoeuvre;
 		starting_time = hrt_absolute_time();
-		mavlink_and_console_log_info(&_mavlink_log_pub, "sid manoeuvre: %i\n", static_cast<double>_parameters.sid_manoeuvre);
+		mavlink_and_console_log_info(&_mavlink_log_pub, "sid manoeuvre started");
 	}
 
 	if (!vcontrol_mode.flag_control_manual_enabled) {

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -2747,6 +2747,7 @@ Sensors::check_sysid_manoeuvre(manual_control_setpoint_s *manual)
 	    && (manual->sysid_switch != _prev_sysid_sw_pos)) {
 		is_doing_manoeuvre = !is_doing_manoeuvre;
 		starting_time = hrt_absolute_time();
+		mavlink_and_console_log_info(&_mavlink_log_pub, "sid manoeuvre: %i\n", static_cast<double>_parameters.sid_manoeuvre);
 	}
 
 	if (!vcontrol_mode.flag_control_manual_enabled) {

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -2747,7 +2747,10 @@ Sensors::check_sysid_manoeuvre(manual_control_setpoint_s *manual)
 	    && (manual->sysid_switch != _prev_sysid_sw_pos)) {
 		is_doing_manoeuvre = !is_doing_manoeuvre;
 		starting_time = hrt_absolute_time();
-		//warnx("pressed");
+	}
+
+	if (!vcontrol_mode.flag_control_manual_enabled) {
+		is_doing_manoeuvre = false;
 	}
 
 	if (is_doing_manoeuvre) {


### PR DESCRIPTION
This lets the user flick a switch and activate system identification maneuvers by letting the autopilot overwrite the stick with a predefined function. This has the advantage that the user still has control over all other channels than the one active for the maneuver, e.g. if you want to do a step in pitch you still have control over throttle, roll and yaw. Since the manual setpoints are overwritten in sensors.cpp this works in any mode (except auto) so you can use it for identifying the physical system if in pure manual, identifying/tuning the attitude controller if in stabilized, identifying/tuning the position controller if in position mode. The maneuver is aborted if the switch is pressed again during the maneuver. 

Currently the following maneuvers are supported:
- Step in roll, pitch, yaw, throttle
- Ramp in roll, pitch, yaw, throttle
- Chrip in roll, pitch, yaw
- 2 1 1 in roll, pitch, yaw

The parameters are:
**SID_MANOEUVRE** defines which maneuver to perform 
**SID_AMPLITUDE** defines the amplitude (in stick value) of the manuever, set to minus if you want to reverse the direction
**SID_ON_TIME** defines the duration of the maneuver in seconds
**SID_TRIM_TIME_B** defines the time the setpoint is set to zero before the maneuver
**SID_TRIM_TIME_A** defines the time the setpoint is set to zero after the maneuver
**SID_START_FREQ** defines the start frequency (in revolutions per second) of the chirp maneuver
**SID_STOP_FREQ** defines the stop frequency (in revolutions per second) of the chirp maneuver
**SID_RAMP_SLOPE** defines the slope of the ramp in time it would take from zero to 100% input signal. So if sid_ramp_slope = 2 and sid_amplitude = 0.5 the ramp will actually take 1 s in the maneuver. 

Step
![selection_140](https://cloud.githubusercontent.com/assets/7795133/19697999/e05c269a-9aed-11e6-8dd0-e0db1bd5f050.png)

Ramp
![selection_141](https://cloud.githubusercontent.com/assets/7795133/19697995/e0585e8e-9aed-11e6-91d4-8ac89cc401ae.png)

Sinus (start and stop freq the same)
![selection_142](https://cloud.githubusercontent.com/assets/7795133/19697997/e05a7dea-9aed-11e6-98da-072c2ac39eaf.png)

Chirp
![selection_143](https://cloud.githubusercontent.com/assets/7795133/19697996/e05831d4-9aed-11e6-8685-e53e1055cdbc.png)

2 - 1 - 1
![selection_144](https://cloud.githubusercontent.com/assets/7795133/19697998/e05b84ba-9aed-11e6-8873-d25204c53ad9.png)
