### PR TITLE
Remove fake config targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ define colorecho
 endef
 
 # Get a list of all config targets.
-ALL_CONFIG_TARGETS := $(basename $(shell find "$(SRC_DIR)/cmake/configs" -name '*.cmake' -print | sed  -e 's:^.*/::' | sort))
+ALL_CONFIG_TARGETS := $(basename $(shell find "$(SRC_DIR)/cmake/configs" ! -name '*_common*' ! -name '*_sdflight_*' -name '*.cmake' -print | sed  -e 's:^.*/::' | sort))
 # Strip off leading nuttx_
 NUTTX_CONFIG_TARGETS := $(patsubst nuttx_%,%,$(filter nuttx_%,$(ALL_CONFIG_TARGETS)))
 


### PR DESCRIPTION
The "targets" posix_rpi_common, qurt_sdflight_default and
posix_sdflight_default are not real targets; they are
just files in cmake/configs that are included by other
targets.