### PR TITLE
Support for synthetic sideslip measurements in EKF2

### DIFF
--- a/msg/ekf2_innovations.msg
+++ b/msg/ekf2_innovations.msg
@@ -2,12 +2,14 @@ float32[6] vel_pos_innov  # velocity and position innovations
 float32[3] mag_innov 	# earth magnetic field innovations
 float32 heading_innov 	# heading innovation
 float32 airspeed_innov	# airspeed innovation
+float32 beta_innov	# synthetic sideslip innovation
 float32[2] flow_innov   # flow innovation
 float32 hagl_innov      # innovation from the terrain estimator for the height above ground level measurement  (m)
 float32[6] vel_pos_innov_var 	# velocity and position innovation variances
 float32[3] mag_innov_var	# earth magnetic field innovation variance
 float32 heading_innov_var 	# heading innovation variance
 float32 airspeed_innov_var	# Airspeed innovation variance
+float32 beta_innov_var		# synthetic sideslip innovation variance
 float32[2] flow_innov_var	# flow innovation variance
 float32 hagl_innov_var          # innovation variance from the terrain estimator for the height above ground level measurement (m^2)
 float32[3] output_tracking_error # return a vector containing the output predictor angular, velocity and position tracking error magnitudes (rad), (m/s), (m)

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -208,7 +208,7 @@ private:
 	control::BlockParamExtFloat _mag_heading_noise;	// measurement noise used for simple heading fusion
 	control::BlockParamExtFloat _mag_noise;		// measurement noise used for 3-axis magnetoemter fusion (Gauss)
 	control::BlockParamExtFloat _eas_noise;		// measurement noise used for airspeed fusion (std m/s)
-	control::BlockParamFloat _beta_noise;		// synthetic sideslip noise (m/s)
+	control::BlockParamExtFloat _beta_noise;		// synthetic sideslip noise (m/s)
 	control::BlockParamExtFloat _mag_declination_deg;// magnetic declination in degrees
 	control::BlockParamExtFloat _heading_innov_gate;// innovation gate for heading innovation test
 	control::BlockParamExtFloat _mag_innov_gate;	// innovation gate for magnetometer innovation test
@@ -333,7 +333,7 @@ Ekf2::Ekf2():
 	_mag_heading_noise(this, "EKF2_HEAD_NOISE", false, _params->mag_heading_noise),
 	_mag_noise(this, "EKF2_MAG_NOISE", false, _params->mag_noise),
 	_eas_noise(this, "EKF2_EAS_NOISE", false, _params->eas_noise),
-	_beta_noise(this, "EKF2_BETA_NOISE", false, &_params->beta_noise),
+	_beta_noise(this, "EKF2_BETA_NOISE", false, _params->beta_noise),
 	_mag_declination_deg(this, "EKF2_MAG_DECL", false, _params->mag_declination_deg),
 	_heading_innov_gate(this, "EKF2_HDG_GATE", false, _params->heading_innov_gate),
 	_mag_innov_gate(this, "EKF2_MAG_GATE", false, _params->mag_innov_gate),
@@ -377,7 +377,7 @@ Ekf2::Ekf2():
 	_ev_pos_y(this, "EKF2_EV_POS_Y", false, _params->ev_pos_body(1)),
 	_ev_pos_z(this, "EKF2_EV_POS_Z", false, _params->ev_pos_body(2)),
 	_arspFusionThreshold(this, "EKF2_ARSP_THR", false),
-	_fuseBeta(this, "EKF2_FUSE_BETA",false),
+	_fuseBeta(this, "EKF2_FUSE_BETA", false),
 	_tau_vel(this, "EKF2_TAU_VEL", false, _params->vel_Tau),
 	_tau_pos(this, "EKF2_TAU_POS", false, _params->pos_Tau),
 	_gyr_bias_init(this, "EKF2_GBIAS_INIT", false, _params->switch_on_gyro_bias),

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -962,31 +962,31 @@ void Ekf2::task_main()
 
 		// publish estimator innovation data
 		{
-		struct ekf2_innovations_s innovations = {};
-		innovations.timestamp = hrt_absolute_time();
-		_ekf.get_vel_pos_innov(&innovations.vel_pos_innov[0]);
-		_ekf.get_mag_innov(&innovations.mag_innov[0]);
-		_ekf.get_heading_innov(&innovations.heading_innov);
-		_ekf.get_airspeed_innov(&innovations.airspeed_innov);
-		_ekf.get_beta_innov(&innovations.beta_innov);
-		_ekf.get_flow_innov(&innovations.flow_innov[0]);
-		_ekf.get_hagl_innov(&innovations.hagl_innov);
+			struct ekf2_innovations_s innovations = {};
+			innovations.timestamp = hrt_absolute_time();
+			_ekf.get_vel_pos_innov(&innovations.vel_pos_innov[0]);
+			_ekf.get_mag_innov(&innovations.mag_innov[0]);
+			_ekf.get_heading_innov(&innovations.heading_innov);
+			_ekf.get_airspeed_innov(&innovations.airspeed_innov);
+			_ekf.get_beta_innov(&innovations.beta_innov);
+			_ekf.get_flow_innov(&innovations.flow_innov[0]);
+			_ekf.get_hagl_innov(&innovations.hagl_innov);
 
-		_ekf.get_vel_pos_innov_var(&innovations.vel_pos_innov_var[0]);
-		_ekf.get_mag_innov_var(&innovations.mag_innov_var[0]);
-		_ekf.get_heading_innov_var(&innovations.heading_innov_var);
-		_ekf.get_airspeed_innov_var(&innovations.airspeed_innov_var);
-		_ekf.get_beta_innov_var(&innovations.beta_innov_var);
-		_ekf.get_flow_innov_var(&innovations.flow_innov_var[0]);
-		_ekf.get_hagl_innov_var(&innovations.hagl_innov_var);
+			_ekf.get_vel_pos_innov_var(&innovations.vel_pos_innov_var[0]);
+			_ekf.get_mag_innov_var(&innovations.mag_innov_var[0]);
+			_ekf.get_heading_innov_var(&innovations.heading_innov_var);
+			_ekf.get_airspeed_innov_var(&innovations.airspeed_innov_var);
+			_ekf.get_beta_innov_var(&innovations.beta_innov_var);
+			_ekf.get_flow_innov_var(&innovations.flow_innov_var[0]);
+			_ekf.get_hagl_innov_var(&innovations.hagl_innov_var);
 
-		_ekf.get_output_tracking_error(&innovations.output_tracking_error[0]);
+			_ekf.get_output_tracking_error(&innovations.output_tracking_error[0]);
 
-		if (_estimator_innovations_pub == nullptr) {
-			_estimator_innovations_pub = orb_advertise(ORB_ID(ekf2_innovations), &innovations);
+			if (_estimator_innovations_pub == nullptr) {
+				_estimator_innovations_pub = orb_advertise(ORB_ID(ekf2_innovations), &innovations);
 
-		} else {
-			orb_publish(ORB_ID(ekf2_innovations), _estimator_innovations_pub, &innovations);
+			} else {
+				orb_publish(ORB_ID(ekf2_innovations), _estimator_innovations_pub, &innovations);
 			}
 
 		}

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -208,7 +208,7 @@ private:
 	control::BlockParamExtFloat _mag_heading_noise;	// measurement noise used for simple heading fusion
 	control::BlockParamExtFloat _mag_noise;		// measurement noise used for 3-axis magnetoemter fusion (Gauss)
 	control::BlockParamExtFloat _eas_noise;		// measurement noise used for airspeed fusion (std m/s)
-	control::BlockParamExtFloat _beta_noise;		// synthetic sideslip noise (m/s)
+	control::BlockParamExtFloat _beta_noise;	// synthetic sideslip noise (m/s)
 	control::BlockParamExtFloat _mag_declination_deg;// magnetic declination in degrees
 	control::BlockParamExtFloat _heading_innov_gate;// innovation gate for heading innovation test
 	control::BlockParamExtFloat _mag_innov_gate;	// innovation gate for magnetometer innovation test

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -270,6 +270,7 @@ private:
 	control::BlockParamFloat
 	_arspFusionThreshold; 	// a value of zero will disabled airspeed fusion. Any another positive value will determine
 	// the minimum airspeed which will still be fused
+	control::BlockParamInt _fuseBeta; // 0 disables synthetic sideslip fusion, 1 activates it
 
 	// output predictor filter time constants
 	control::BlockParamExtFloat _tau_vel;	// time constant used by the output velocity complementary filter (s)
@@ -376,6 +377,7 @@ Ekf2::Ekf2():
 	_ev_pos_y(this, "EKF2_EV_POS_Y", false, _params->ev_pos_body(1)),
 	_ev_pos_z(this, "EKF2_EV_POS_Z", false, _params->ev_pos_body(2)),
 	_arspFusionThreshold(this, "EKF2_ARSP_THR", false),
+	_fuseBeta(this, "EKF2_FUSE_BETA",false),
 	_tau_vel(this, "EKF2_TAU_VEL", false, _params->vel_Tau),
 	_tau_pos(this, "EKF2_TAU_POS", false, _params->pos_Tau),
 	_gyr_bias_init(this, "EKF2_GBIAS_INIT", false, _params->switch_on_gyro_bias),

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -628,6 +628,10 @@ void Ekf2::task_main()
 			_ekf.setAirspeedData(airspeed.timestamp, &airspeed.true_airspeed_m_s, &eas2tas);
 		}
 
+		// only fuse synthetic sideslip measurements if conditions are met
+		bool fuse_beta = !vehicle_status.is_rotary_wing && _fuseBeta.get();
+		_ekf.set_fuse_beta_flag(fuse_beta);
+
 		if (optical_flow_updated) {
 			flow_message flow;
 			flow.flowdata(0) = optical_flow.pixel_flow_x_integral;

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -820,6 +820,16 @@ PARAM_DEFINE_FLOAT(EKF2_EV_POS_Z, 0.0f);
 */
 PARAM_DEFINE_FLOAT(EKF2_ARSP_THR, 0.0f);
 
+ /**
+ * Boolean determining if synthetic sideslip measurements should fused.
+ *
+ * A value of 1 indicates that fusion is active
+ *
+ * @group EKF2
+ * @boolean
+ */
+PARAM_DEFINE_INT32(EKF2_FUSE_BETA, 0);
+
 /**
 
  * Time constant of the velocity output prediction and smoothing filter

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -387,15 +387,16 @@ PARAM_DEFINE_FLOAT(EKF2_MAG_NOISE, 5.0e-2f);
 PARAM_DEFINE_FLOAT(EKF2_EAS_NOISE, 1.4f);
 
 /**
- * Noise for syntetic sideslip fusion.
+ * Noise for synthetic sideslip fusion.
  *
  * @group EKF2
- * @min 0.5
- * @max 5.0
+ * @min 0.1
+ * @max 1.0
  * @unit m/s
- * @decimal 1
+ * @decimal 2
  */
-PARAM_DEFINE_FLOAT(EKF2_BETA_NOISE, 5.0f);
+PARAM_DEFINE_FLOAT(EKF2_BETA_NOISE, 0.3f);
+
 /**
  * Magnetic declination
  *

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -395,7 +395,7 @@ PARAM_DEFINE_FLOAT(EKF2_EAS_NOISE, 1.4f);
  * @unit m/s
  * @decimal 1
  */
- PARAM_DEFINE_FLOAT(EKF2_BETA_NOISE, 5.0f);
+PARAM_DEFINE_FLOAT(EKF2_BETA_NOISE, 5.0f);
 /**
  * Magnetic declination
  *
@@ -830,14 +830,14 @@ PARAM_DEFINE_FLOAT(EKF2_EV_POS_Z, 0.0f);
 */
 PARAM_DEFINE_FLOAT(EKF2_ARSP_THR, 0.0f);
 
- /**
- * Boolean determining if synthetic sideslip measurements should fused.
- *
- * A value of 1 indicates that fusion is active
- *
- * @group EKF2
- * @boolean
- */
+/**
+* Boolean determining if synthetic sideslip measurements should fused.
+*
+* A value of 1 indicates that fusion is active
+*
+* @group EKF2
+* @boolean
+*/
 PARAM_DEFINE_INT32(EKF2_FUSE_BETA, 0);
 
 /**

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -387,6 +387,16 @@ PARAM_DEFINE_FLOAT(EKF2_MAG_NOISE, 5.0e-2f);
 PARAM_DEFINE_FLOAT(EKF2_EAS_NOISE, 1.4f);
 
 /**
+ * Noise for syntetic sideslip fusion.
+ *
+ * @group EKF2
+ * @min 0.5
+ * @max 5.0
+ * @unit m/s
+ * @decimal 1
+ */
+ PARAM_DEFINE_FLOAT(EKF2_BETA_NOISE, 5.0f);
+/**
  * Magnetic declination
  *
  * @group EKF2

--- a/src/modules/ekf2_replay/ekf2_replay_main.cpp
+++ b/src/modules/ekf2_replay/ekf2_replay_main.cpp
@@ -693,6 +693,8 @@ void Ekf2Replay::logIfUpdated()
 		log_message.body.innov2.s[7] = innov.heading_innov_var;
 		log_message.body.innov2.s[8] = innov.airspeed_innov;
 		log_message.body.innov2.s[9] = innov.airspeed_innov_var;
+		log_message.body.innov2.s[10] = innov.beta_innov;
+		log_message.body.innov2.s[11] = innov.beta_innov_var;
 
 		writeMessage(_write_fd, (void *)&log_message.head1, _formats[LOG_EST5_MSG].length);
 

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -2188,6 +2188,8 @@ int sdlog2_thread_main(int argc, char *argv[])
 				log_msg.body.log_INO2.s[7] = buf.innovations.heading_innov_var;
 				log_msg.body.log_INO2.s[8] = buf.innovations.airspeed_innov;
 				log_msg.body.log_INO2.s[9] = buf.innovations.airspeed_innov_var;
+				log_msg.body.log_INO2.s[10] = buf.innovations.beta_innov;
+ 				log_msg.body.log_INO2.s[11] = buf.innovations.beta_innov_var;
 				LOGBUFFER_WRITE_AND_COUNT(EST5);
 
 				log_msg.msg_type = LOG_EST6_MSG;

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -509,7 +509,7 @@ struct log_EST4_s {
 /* --- EST5 - ESTIMATOR INNOVATIONS --- */
 #define LOG_EST5_MSG 49
 struct log_EST5_s {
-    float s[10];
+    float s[12];
 };
 
 #define LOG_OUT1_MSG 50
@@ -689,8 +689,8 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT(EST2, "ffffffffffffHHBH",     "P0,P1,P2,P3,P4,P5,P6,P7,P8,P9,P10,P11,GCHK,CTRL,fHealth,IC"),
 	LOG_FORMAT(EST3, "ffffffffffffffff",    "P12,P13,P14,P15,P16,P17,P18,P19,P20,P21,P22,P23,P24,P25,P26,P27"),
 	LOG_FORMAT(EST4, "fffffffffffffff",     "VxI,VyI,VzI,PxI,PyI,PzI,VxIV,VyIV,VzIV,PxIV,PyIV,PzIV,e1,e2,e3"),
-	LOG_FORMAT(EST5, "ffffffffff",          "MAGxI,MAGyI,MAGzI,MAGxIV,MAGyIV,MAGzIV,HeadI,HeadIV,AirI,AirIV"),
-	LOG_FORMAT(EST6, "ffffff",              "FxI,FyI,FxIV,FyIV,HAGLI,HAGLIV"),
+	LOG_FORMAT(EST5, "ffffffffffff", "MaxI,MayI,MazI,MaxIV,MayIV,MazIV,HeI,HeIV,AiI,AiIV,BeI,BeIV"),
+	LOG_FORMAT(EST6, "ffffff", "FxI,FyI,FxIV,FyIV,HAGLI,HAGLIV"),
 	LOG_FORMAT(PWR, "fffBBBBB",		"Periph5V,Servo5V,RSSI,UsbOk,BrickOk,ServoOk,PeriphOC,HipwrOC"),
 	LOG_FORMAT(MOCP, "fffffff",		"QuatW,QuatX,QuatY,QuatZ,X,Y,Z"),
 	LOG_FORMAT(VISN, "ffffffffff",		"X,Y,Z,VX,VY,VZ,QuatW,QuatX,QuatY,QuatZ"),


### PR DESCRIPTION
Adds the ability to do wind estimation for fixed wing aircraft in EKF2 without using the airspeed sensor. Reduces position drift for fixed win g planes if GPS is lost.

Replaces https://github.com/PX4/Firmware/pull/5367

Requires https://github.com/PX4/ecl/pull/207

See https://github.com/PX4/ecl/pull/207 for test results.
