### PR TITLE
Updating simulator to mavlink 2.0

### DIFF
--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -56,8 +56,8 @@
 #include <uORB/uORB.h>
 #include <uORB/topics/optical_flow.h>
 #include <uORB/topics/distance_sensor.h>
-#include <v1.0/mavlink_types.h>
-#include <v1.0/common/mavlink.h>
+#include <v2.0/mavlink_types.h>
+#include <v2.0/common/mavlink.h>
 namespace simulator
 {
 
@@ -337,7 +337,7 @@ private:
 	void pollForMAVLinkMessages(bool publish, int udp_port);
 
 	void pack_actuator_message(mavlink_hil_actuator_controls_t &actuator_msg, unsigned index);
-	void send_mavlink_message(const uint8_t msgid, const void *msg, uint8_t component_ID);
+	void send_mavlink_message(mavlink_message_t *msgbuf);
 	void update_sensors(mavlink_hil_sensor_t *imu);
 	void update_gps(mavlink_hil_gps_t *gps_sim);
 	static void *sending_trampoline(void *);

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -177,8 +177,8 @@ void Simulator::send_controls()
 		mavlink_hil_actuator_controls_t msg = {};
 
 		pack_actuator_message(msg, i);
-        mavlink_msg_hil_actuator_controls_encode(0, 200, &mav_msg, &msg);
-        send_mavlink_message(&mav_msg);
+		mavlink_msg_hil_actuator_controls_encode(0, 200, &mav_msg, &msg);
+		send_mavlink_message(&mav_msg);
 	}
 }
 
@@ -405,15 +405,15 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 
 void Simulator::send_mavlink_message(mavlink_message_t *msgbuf)
 {
-    uint8_t buf[MAVLINK_MAX_PACKET_LEN];
+	uint8_t buf[MAVLINK_MAX_PACKET_LEN];
 
-    unsigned packet_len = mavlink_msg_to_send_buffer(buf, msgbuf);
+	unsigned packet_len = mavlink_msg_to_send_buffer(buf, msgbuf);
 
-    ssize_t len = sendto(_fd, buf, packet_len, 0, (struct sockaddr *)&_srcaddr, _addrlen);
+	ssize_t len = sendto(_fd, buf, packet_len, 0, (struct sockaddr *)&_srcaddr, _addrlen);
 
-    if (len <= 0) {
-        PX4_WARN("Failed sending mavlink message");
-    }
+	if (len <= 0) {
+		PX4_WARN("Failed sending mavlink message");
+	}
 }
 
 void Simulator::poll_topics()
@@ -660,12 +660,12 @@ void Simulator::pollForMAVLinkMessages(bool publish, int udp_port)
 
 	//send MAV_CMD_SET_MESSAGE_INTERVAL for HIL_STATE_QUATERNION ground truth
 	mavlink_command_long_t cmd_long = {};
-    mavlink_message_t mav_msg;
+	mavlink_message_t mav_msg;
 	cmd_long.command = MAV_CMD_SET_MESSAGE_INTERVAL;
 	cmd_long.param1 = MAVLINK_MSG_ID_HIL_STATE_QUATERNION;
 	cmd_long.param2 = 5e3;
-    mavlink_msg_command_long_encode(0, 200, &mav_msg, &cmd_long);
-    send_mavlink_message(&mav_msg);
+	mavlink_msg_command_long_encode(0, 200, &mav_msg, &cmd_long);
+	send_mavlink_message(&mav_msg);
 
 	// wait for new mavlink messages to arrive
 	while (true) {

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -61,8 +61,6 @@ extern "C" __EXPORT hrt_abstime hrt_reset(void);
 #define DENSITY 1.2041f
 #define GRAVITY 9.81f
 
-static const uint8_t mavlink_message_lengths[256] = MAVLINK_MESSAGE_LENGTHS;
-static const uint8_t mavlink_message_crcs[256] = MAVLINK_MESSAGE_CRCS;
 static const float mg2ms2 = CONSTANTS_ONE_G / 1000.0f;
 
 static int openUart(const char *uart_name, int baud);
@@ -175,9 +173,12 @@ void Simulator::send_controls()
 			continue;
 		}
 
-		mavlink_hil_actuator_controls_t msg;
+		mavlink_message_t mav_msg;
+		mavlink_hil_actuator_controls_t msg = {};
+
 		pack_actuator_message(msg, i);
-		send_mavlink_message(MAVLINK_MSG_ID_HIL_ACTUATOR_CONTROLS, &msg, 200);
+        mavlink_msg_hil_actuator_controls_encode(0, 200, &mav_msg, &msg);
+        send_mavlink_message(&mav_msg);
 	}
 }
 
@@ -402,40 +403,17 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 
 }
 
-void Simulator::send_mavlink_message(const uint8_t msgid, const void *msg, uint8_t component_ID)
+void Simulator::send_mavlink_message(mavlink_message_t *msgbuf)
 {
-	component_ID = 0;
-	uint8_t payload_len = mavlink_message_lengths[msgid];
-	unsigned packet_len = payload_len + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+    uint8_t buf[MAVLINK_MAX_PACKET_LEN];
 
-	uint8_t buf[MAVLINK_MAX_PACKET_LEN];
+    unsigned packet_len = mavlink_msg_to_send_buffer(buf, msgbuf);
 
-	/* header */
-	buf[0] = MAVLINK_STX;
-	buf[1] = payload_len;
-	/* no idea which numbers should be here*/
-	buf[2] = 100;
-	buf[3] = 0;
-	buf[4] = component_ID;
-	buf[5] = msgid;
+    ssize_t len = sendto(_fd, buf, packet_len, 0, (struct sockaddr *)&_srcaddr, _addrlen);
 
-	/* payload */
-	memcpy(&buf[MAVLINK_NUM_HEADER_BYTES], msg, payload_len);
-
-	/* checksum */
-	uint16_t checksum;
-	crc_init(&checksum);
-	crc_accumulate_buffer(&checksum, (const char *) &buf[1], MAVLINK_CORE_HEADER_LEN + payload_len);
-	crc_accumulate(mavlink_message_crcs[msgid], &checksum);
-
-	buf[MAVLINK_NUM_HEADER_BYTES + payload_len] = (uint8_t)(checksum & 0xFF);
-	buf[MAVLINK_NUM_HEADER_BYTES + payload_len + 1] = (uint8_t)(checksum >> 8);
-
-	ssize_t len = sendto(_fd, buf, packet_len, 0, (struct sockaddr *)&_srcaddr, _addrlen);
-
-	if (len <= 0) {
-		PX4_WARN("Failed sending mavlink message");
-	}
+    if (len <= 0) {
+        PX4_WARN("Failed sending mavlink message");
+    }
 }
 
 void Simulator::poll_topics()
@@ -630,7 +608,10 @@ void Simulator::pollForMAVLinkMessages(bool publish, int udp_port)
 			mavlink_heartbeat_t hb = {};
 			hb.autopilot = 12;
 			hb.base_mode |= (_vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED) ? 128 : 0;
-			send_mavlink_message(MAVLINK_MSG_ID_HEARTBEAT, &hb, 200);
+
+			mavlink_message_t mav_msg;
+			mavlink_msg_heartbeat_encode(0, 200, &mav_msg, &hb);
+			send_mavlink_message(&mav_msg);
 
 			if (len > 0) {
 				mavlink_message_t msg;
@@ -679,10 +660,12 @@ void Simulator::pollForMAVLinkMessages(bool publish, int udp_port)
 
 	//send MAV_CMD_SET_MESSAGE_INTERVAL for HIL_STATE_QUATERNION ground truth
 	mavlink_command_long_t cmd_long = {};
+    mavlink_message_t mav_msg;
 	cmd_long.command = MAV_CMD_SET_MESSAGE_INTERVAL;
 	cmd_long.param1 = MAVLINK_MSG_ID_HIL_STATE_QUATERNION;
 	cmd_long.param2 = 5e3;
-	send_mavlink_message(MAVLINK_MSG_ID_COMMAND_LONG, &cmd_long, 200);
+    mavlink_msg_command_long_encode(0, 200, &mav_msg, &cmd_long);
+    send_mavlink_message(&mav_msg);
 
 	// wait for new mavlink messages to arrive
 	while (true) {

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -619,6 +619,16 @@ void Simulator::pollForMAVLinkMessages(bool publish, int udp_port)
 
 				for (int i = 0; i < len; i++) {
 					if (mavlink_parse_char(MAVLINK_COMM_0, _buf[i], &msg, &udp_status)) {
+
+						// switch mavlink protocol version depending on what's on the other end
+
+						if (mavlink_get_channel_status(MAVLINK_COMM_0)->flags & MAVLINK_STATUS_FLAG_IN_MAVLINK1) {
+							mavlink_get_channel_status(MAVLINK_COMM_0)->flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
+
+						} else  {
+							mavlink_get_channel_status(MAVLINK_COMM_0)->flags &= ~(MAVLINK_STATUS_FLAG_OUT_MAVLINK1);
+						}
+
 						// have a message, handle it
 						handle_message(&msg, publish);
 


### PR DESCRIPTION
This pull request cleans up and, updates the simulator to mavlink 2.0.  Disregard the name of the branch.  I was confused about the naming conventions for the mavlink releases.
