### PR TITLE
Battery Scaling & Explicit Internal Resistance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.px4log
 *.dSYM
 *.o
+*.gch
 *.pyc
 *~
 .*.swp

--- a/msg/battery_status.msg
+++ b/msg/battery_status.msg
@@ -4,6 +4,7 @@ float32 current_a		# Battery current in amperes, -1 if unknown
 float32 current_filtered_a	# Battery current in amperes, filtered, 0 if unknown
 float32 discharged_mah		# Discharged amount in mAh, -1 if unknown
 float32 remaining		# From 1 to 0, -1 if unknown
+float32 scale		# Power scaling factor with >= 1, or -1 if unknown
 int32 cell_count		# Number of cells
 bool connected			# Wether or not a battery is connected
 #bool is_powering_off		# Power off event imminent indication, false if unknown

--- a/msg/battery_status.msg
+++ b/msg/battery_status.msg
@@ -4,7 +4,7 @@ float32 current_a		# Battery current in amperes, -1 if unknown
 float32 current_filtered_a	# Battery current in amperes, filtered, 0 if unknown
 float32 discharged_mah		# Discharged amount in mAh, -1 if unknown
 float32 remaining		# From 1 to 0, -1 if unknown
-float32 scale		# Power scaling factor with >= 1, or -1 if unknown
+float32 scale		# Power scaling factor, >= 1, or -1 if unknown
 int32 cell_count		# Number of cells
 bool connected			# Wether or not a battery is connected
 #bool is_powering_off		# Power off event imminent indication, false if unknown

--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -403,3 +403,19 @@ PARAM_DEFINE_FLOAT(MC_TPA_BREAK, 1.0f);
  * @group Multicopter Attitude Control
  */
 PARAM_DEFINE_FLOAT(MC_TPA_SLOPE, 1.0f);
+
+
+/**
+ * Whether to scale outputs by battery power level
+ *
+ * This compensates for voltage drop of the battery over time by attempting to
+ * normalize performance across the operating range of the battery. The copter
+ * should constantly behave as if it was fully charged with reduced max acceleration
+ * at lower battery percentages. i.e. if hover is at 0.5 throttle at 100% battery,
+ * it will still be 0.5 at 60% battery.
+ *
+ * @min 0
+ * @max 1
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_INT32(MC_BAT_SCALE_EN, 0);

--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -414,8 +414,7 @@ PARAM_DEFINE_FLOAT(MC_TPA_SLOPE, 1.0f);
  * at lower battery percentages. i.e. if hover is at 0.5 throttle at 100% battery,
  * it will still be 0.5 at 60% battery.
  *
- * @min 0
- * @max 1
+ * @boolean
  * @group Multicopter Attitude Control
  */
 PARAM_DEFINE_INT32(MC_BAT_SCALE_EN, 0);

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1956,6 +1956,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 				log_msg.body.log_BATT.current_filtered = buf.battery.current_filtered_a;
 				log_msg.body.log_BATT.discharged = buf.battery.discharged_mah;
 				log_msg.body.log_BATT.remaining = buf.battery.remaining;
+				log_msg.body.log_BATT.scale = buf.battery.scale;
 				log_msg.body.log_BATT.warning = buf.battery.warning;
 				LOGBUFFER_WRITE_AND_COUNT(BATT);
 			}

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -293,6 +293,7 @@ struct log_BATT_s {
 	float current_filtered;
 	float discharged;
 	float remaining;
+	float scale;
 	uint8_t warning;
 };
 
@@ -678,7 +679,7 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT(GPSP, "BLLffBfbf",		"NavState,Lat,Lon,Alt,Yaw,Type,LoitR,LoitDir,PitMin"),
 	LOG_FORMAT(ESC, "HBBBHHffiffH",		"count,nESC,Conn,N,Ver,Adr,Volt,Amp,RPM,Temp,SetP,SetPRAW"),
 	LOG_FORMAT(GVSP, "fff",			"VX,VY,VZ"),
-	LOG_FORMAT(BATT, "ffffffB",		"V,VFilt,C,CFilt,Discharged,Remaining,Warning"),
+	LOG_FORMAT(BATT, "fffffffB",		"V,VFilt,C,CFilt,Discharged,Remaining,Scale,Warning"),
 	LOG_FORMAT(DIST, "BBBff",			"Id,Type,Orientation,Distance,Covariance"),
 	LOG_FORMAT_S(TEL0, TEL, "BBBBHHBQ",		"RSSI,RemRSSI,Noise,RemNoise,RXErr,Fixed,TXBuf,HbTime"),
 	LOG_FORMAT_S(TEL1, TEL, "BBBBHHBQ",		"RSSI,RemRSSI,Noise,RemNoise,RXErr,Fixed,TXBuf,HbTime"),

--- a/src/modules/systemlib/battery.h
+++ b/src/modules/systemlib/battery.h
@@ -94,7 +94,7 @@ private:
 	void filterVoltage(float voltage_v);
 	void filterCurrent(float current_a);
 	void sumDischarged(hrt_abstime timestamp, float current_a);
-	void estimateRemaining(float voltage_v, float throttle_normalized, bool armed);
+	void estimateRemaining(float voltage_v, float current_a, float throttle_normalized, bool armed);
 	void determineWarning();
 	void computeScale();
 

--- a/src/modules/systemlib/battery.h
+++ b/src/modules/systemlib/battery.h
@@ -96,12 +96,14 @@ private:
 	void sumDischarged(hrt_abstime timestamp, float current_a);
 	void estimateRemaining(float voltage_v, float throttle_normalized, bool armed);
 	void determineWarning();
+	void computeScale();
 
 	control::BlockParamFloat _param_v_empty;
 	control::BlockParamFloat _param_v_full;
 	control::BlockParamInt _param_n_cells;
 	control::BlockParamFloat _param_capacity;
 	control::BlockParamFloat _param_v_load_drop;
+	control::BlockParamFloat _param_r_internal;
 	control::BlockParamFloat _param_low_thr;
 	control::BlockParamFloat _param_crit_thr;
 
@@ -111,7 +113,7 @@ private:
 	float _remaining_voltage;		///< normalized battery charge level remaining based on voltage
 	float _remaining_capacity;		///< normalized battery charge level remaining based on capacity
 	float _remaining;			///< normalized battery charge level, selected based on config param
+	float _scale;
 	uint8_t _warning;
 	hrt_abstime _last_timestamp;
 };
-

--- a/src/modules/systemlib/battery_params.c
+++ b/src/modules/systemlib/battery_params.c
@@ -107,7 +107,8 @@ PARAM_DEFINE_FLOAT(BAT_CRIT_THR, 0.07f);
  * This implicitely defines the internal resistance
  * to maximum current ratio and assumes linearity.
  * A good value to use is the difference between the
- * 5C and 20-25C load.
+ * 5C and 20-25C load. Not used if BAT_R_INTERNAL is
+ * set.
  *
  * @group Battery Calibration
  * @unit V
@@ -117,6 +118,19 @@ PARAM_DEFINE_FLOAT(BAT_CRIT_THR, 0.07f);
  * @increment 0.01
  */
 PARAM_DEFINE_FLOAT(BAT_V_LOAD_DROP, 0.3f);
+
+/**
+ * Explicitly defines the per cell internal resistance
+ *
+ * If non-negative, then this will be used in place of
+ * BAT_V_LOAD_DROP for all calculations.
+ *
+ * @group Battery Calibration
+ * @unit Ohms
+ * @min -1.0
+ * @max 0.2
+ */
+PARAM_DEFINE_FLOAT(BAT_R_INTERNAL, -1.0f);
 
 /**
  * Number of cells.


### PR DESCRIPTION
- MC throttle and rate scaling based on current battery level
  - Added MC_BAT_SCALE_EN to turn the scaling feature on
  - It uses the internal battery voltage over the terminal voltage to avoid any potential issues of voltage drop (increased throttle/current -> decreased voltage loop). Although this makes it somewhat sensitive to the battery calibration being correct.
  - @jgoppert , can you please test and verify this?
- Explicit battery internal resistance parameters
  - Allows specifying the resistance in Ohms. Optional and backwards compatible with the V_DROP parameters
  - I'm pretty sure that V_DROP will change over the duration of a flight as more current is needed at lower battery levels. The explicit parameters should be more precise, and less confusing to calibrate.
- Also adds '*.gch' to the gitignore. It's a GCC compiled header format generated by some IDEs

Results for a 10 minute flight with mocap in position lock. Note the divergence between the red and purple lines. Set throttle stays constant while actuator commands are increased. (full log here: http://logs.uaventure.com/view/uSKDwTAY8WdQvKfWnAhEhc). 
![batt-scale-graph-1](https://cloud.githubusercontent.com/assets/1341104/19833092/1faafc18-9e04-11e6-8a87-51dbd9a8241a.png)
