### PR TITLE
land detector start last

### DIFF
--- a/posix-configs/SITL/init/ekf2/iris
+++ b/posix-configs/SITL/init/ekf2/iris
@@ -55,7 +55,6 @@ pwm_out_sim mode_pwm
 sleep 1
 sensors start
 commander start
-land_detector start multicopter
 navigator start
 ekf2 start
 mc_pos_control start
@@ -74,5 +73,6 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 sdlog2 start -r 100 -e -t -a
+land_detector start multicopter
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/ekf2/multiple_iris
+++ b/posix-configs/SITL/init/ekf2/multiple_iris
@@ -55,7 +55,6 @@ pwm_out_sim mode_pwm
 sleep 1
 sensors start
 commander start
-land_detector start multicopter
 navigator start
 ekf2 start
 mc_pos_control start
@@ -73,5 +72,6 @@ mavlink stream -r 20 -s RC_CHANNELS -u _MAVPORT_
 mavlink stream -r 250 -s HIGHRES_IMU -u _MAVPORT_
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u _MAVPORT_
 sdlog2 start -r 100 -e -t -a
+land_detector start multicopter
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/ekf2/plane
+++ b/posix-configs/SITL/init/ekf2/plane
@@ -46,7 +46,6 @@ navigator start
 ekf2 start
 fw_pos_control_l1 start
 fw_att_control start
-land_detector start fixedwing
 mixer load /dev/pwm_output0 ROMFS/sitl/mixers/plane_sitl.main.mix
 mavlink start -u 14556 -r 2000000
 mavlink start -u 14557 -r 2000000 -m onboard -o 14540
@@ -60,5 +59,6 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 sdlog2 start -r 200 -e -t -a
+land_detector start fixedwing
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/ekf2/solo
+++ b/posix-configs/SITL/init/ekf2/solo
@@ -52,7 +52,6 @@ pwm_out_sim mode_pwm
 sleep 1
 sensors start
 commander start
-land_detector start multicopter
 navigator start
 ekf2 start
 mc_pos_control start
@@ -71,5 +70,6 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 sdlog2 start -r 100 -e -t -a
+land_detector start multicopter
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/ekf2/standard_vtol
+++ b/posix-configs/SITL/init/ekf2/standard_vtol
@@ -64,7 +64,6 @@ pwm_out_sim mode_pwm
 sleep 1
 sensors start
 commander start
-land_detector start multicopter
 navigator start
 ekf2 start
 vtol_att_control start
@@ -85,5 +84,6 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 sdlog2 start -r 200 -e -t -a
+land_detector start multicopter
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/ekf2/tailsitter
+++ b/posix-configs/SITL/init/ekf2/tailsitter
@@ -52,7 +52,6 @@ pwm_out_sim mode_pwm
 sleep 1
 sensors start
 commander start
-land_detector start multicopter
 navigator start
 ekf2 start
 vtol_att_control start
@@ -73,5 +72,6 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 sdlog2 start -r 200 -e -t -a
+land_detector start multicopter
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/ekf2/typhoon_h480
+++ b/posix-configs/SITL/init/ekf2/typhoon_h480
@@ -54,7 +54,6 @@ pwm_out_sim mode_pwm16
 sleep 1
 sensors start
 commander start
-land_detector start multicopter
 navigator start
 ekf2 start
 mc_pos_control start
@@ -75,5 +74,6 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 sdlog2 start -r 100 -e -t -a
 vmount start
+land_detector start multicopter
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/inav/iris
+++ b/posix-configs/SITL/init/inav/iris
@@ -55,7 +55,6 @@ pwm_out_sim mode_pwm
 sleep 1
 sensors start
 commander start
-land_detector start multicopter
 navigator start
 attitude_estimator_q start
 position_estimator_inav start
@@ -74,5 +73,6 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
+land_detector start multicopter
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/inav/iris_opt_flow
+++ b/posix-configs/SITL/init/inav/iris_opt_flow
@@ -53,7 +53,6 @@ pwm_out_sim mode_pwm
 sleep 1
 sensors start
 commander start
-land_detector start multicopter
 navigator start
 attitude_estimator_q start
 position_estimator_inav start
@@ -72,5 +71,6 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 sdlog2 start -r 100 -e -t -a
+land_detector start multicopter
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/lpe/iris
+++ b/posix-configs/SITL/init/lpe/iris
@@ -54,7 +54,6 @@ pwm_out_sim mode_pwm
 sleep 1
 sensors start
 commander start
-land_detector start multicopter
 navigator start
 attitude_estimator_q start
 local_position_estimator start
@@ -74,5 +73,6 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
+land_detector start multicopter
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/lpe/iris_opt_flow
+++ b/posix-configs/SITL/init/lpe/iris_opt_flow
@@ -63,7 +63,6 @@ pwm_out_sim mode_pwm
 sleep 1
 sensors start
 commander start
-land_detector start multicopter
 navigator start
 attitude_estimator_q start
 local_position_estimator start
@@ -82,5 +81,6 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 sdlog2 start -r 100 -e -t -a
+land_detector start multicopter
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/lpe/plane
+++ b/posix-configs/SITL/init/lpe/plane
@@ -46,7 +46,6 @@ navigator start
 ekf2 start
 fw_pos_control_l1 start
 fw_att_control start
-land_detector start fixedwing
 mixer load /dev/pwm_output0 ROMFS/sitl/mixers/plane_sitl.main.mix
 mavlink start -u 14556 -r 2000000
 mavlink start -u 14557 -r 2000000 -m onboard -o 14540
@@ -60,5 +59,6 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 sdlog2 start -r 200 -e -t -a
+land_detector start fixedwing
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/lpe/standard_vtol
+++ b/posix-configs/SITL/init/lpe/standard_vtol
@@ -61,7 +61,6 @@ pwm_out_sim mode_pwm
 sleep 1
 sensors start
 commander start
-land_detector start multicopter
 navigator start
 attitude_estimator_q start
 local_position_estimator start
@@ -83,5 +82,6 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 sdlog2 start -r 200 -e -t -a
+land_detector start multicopter
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/lpe/typhoon_h480
+++ b/posix-configs/SITL/init/lpe/typhoon_h480
@@ -54,7 +54,6 @@ pwm_out_sim mode_pwm16
 sleep 1
 sensors start
 commander start
-land_detector start multicopter
 navigator start
 attitude_estimator_q start
 local_position_estimator start
@@ -76,5 +75,6 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 sdlog2 start -r 100 -e -t -a
 vmount start
+land_detector start multicopter
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/rcS_gazebo_delta_wing
+++ b/posix-configs/SITL/init/rcS_gazebo_delta_wing
@@ -44,7 +44,6 @@ navigator start
 ekf2 start
 fw_pos_control_l1 start
 fw_att_control start
-land_detector start fixedwing
 mixer load /dev/pwm_output0 ../../../../ROMFS/sitl/mixers/delta_wing_sitl.main.mix
 mavlink start -u 14556 -r 2000000
 mavlink start -u 14557 -r 2000000 -m onboard -o 14540
@@ -58,5 +57,6 @@ mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 sdlog2 start -r 200 -e -t -a
+land_detector start fixedwing
 mavlink boot_complete
 replay trystart

--- a/posix-configs/eagle/200qx/px4.config
+++ b/posix-configs/eagle/200qx/px4.config
@@ -62,11 +62,11 @@ df_bmp280_wrapper start
 sensors start
 commander start
 ekf2 start
-land_detector start multicopter
 mc_pos_control start
 mc_att_control start
 uart_esc start -D /dev/tty-2
 rc_receiver start -D /dev/tty-1
+land_detector start multicopter
 sleep 1
 list_devices
 list_files

--- a/posix-configs/eagle/210qc/px4.config
+++ b/posix-configs/eagle/210qc/px4.config
@@ -80,11 +80,11 @@ df_bmp280_wrapper start
 sensors start
 commander start
 ekf2 start
-land_detector start multicopter
 mc_pos_control start
 mc_att_control start
 uart_esc start -D /dev/tty-2
 rc_receiver start -D /dev/tty-1
+land_detector start multicopter
 sleep 1
 list_devices
 list_files

--- a/posix-configs/eagle/flight/px4.config
+++ b/posix-configs/eagle/flight/px4.config
@@ -12,7 +12,7 @@ df_trone_wrapper start
 sensors start
 commander start
 ekf2 start
-land_detector start multicopter
 mc_pos_control start
 mc_att_control start
 pwm_out_rc_in start -d /dev/tty-2
+land_detector start multicopter

--- a/posix-configs/rpi/px4.config
+++ b/posix-configs/rpi/px4.config
@@ -12,7 +12,6 @@ sensors start
 commander start
 attitude_estimator_q start
 position_estimator_inav start
-land_detector start multicopter
 mc_pos_control start
 mc_att_control start
 mavlink start -u 14556 -r 1000000
@@ -24,4 +23,5 @@ mavlink stream -d /dev/ttyUSB0 -s HIGHRES_IMU -r 50
 mavlink stream -d /dev/ttyUSB0 -s ATTITUDE -r 50
 navio_sysfs_rc_in start
 navio_sysfs_pwm_out start
+land_detector start multicopter
 mavlink boot_complete


### PR DESCRIPTION
I was getting landed state undefined in QGC using SITL. Apps starting after land detector won't have the initial landed state.

Would it be safer to publish landed state periodically, or do something to make sure it publishes after boot is complete?

The configs using px4.config are probably still not right, but I moved them for consistency.
