### PR TITLE
fix logger: avoid leaking file descriptor in get_log_time()

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1124,12 +1124,13 @@ bool Logger::get_log_time(struct tm *tt, bool boot_time)
 
 	if (orb_copy(ORB_ID(vehicle_gps_position), vehicle_gps_position_sub, &gps_pos) == 0) {
 		utc_time_sec = gps_pos.time_utc_usec / 1e6;
-		orb_unsubscribe(vehicle_gps_position_sub);
 
 		if (gps_pos.fix_type >= 2 && utc_time_sec >= GPS_EPOCH_SECS) {
 			use_clock_time = false;
 		}
 	}
+
+	orb_unsubscribe(vehicle_gps_position_sub);
 
 	if (use_clock_time) {
 		/* take clock time if there's no fix (yet) */


### PR DESCRIPTION
orb_subscribe can succeed, but if there is no publisher, orb_copy will fail.
We still need to unsubscribe in that case.

fixes #5766