### PR TITLE
Pr tecs integrator

### DIFF
--- a/src/lib/external_lgpl/tecs/tecs.cpp
+++ b/src/lib/external_lgpl/tecs/tecs.cpp
@@ -475,20 +475,6 @@ void TECS::_update_pitch(void)
 		SEB_correction += _PITCHminf * gainInv;
 	}
 
-	// Apply max and min values for integrator state that will allow for no more than
-	// 10deg of saturation. This allows for some pitch variation due to gusts before the
-	// integrator is clipped. Otherwise the effectiveness of the integrator will be reduced in turbulence
-	float integ7_err_min = (gainInv * (_PITCHminf - math::radians(10.0f))) - SEB_correction;
-	float integ7_err_max = (gainInv * (_PITCHmaxf + math::radians(10.0f))) - SEB_correction;
-	_integ7_state = constrain(_integ7_state, integ7_err_min, integ7_err_max);
-
-	// if the specific engergy balance correction term produces a demanded pitch value which exceeds the aircraft pitch limits
-	// then zero the integrator. Not doing so can lead to the integrator value being shifted to large unwanted values due to the
-	// constraint right above this comment
-	if (SEB_correction / gainInv > (_PITCHmaxf + math::radians(10.0f)) || SEB_correction / gainInv < (_PITCHminf - math::radians(10.0f))) {
-		_integ7_state = 0.0f;
-	}
-
 	// Calculate pitch demand from specific energy balance signals
 	_pitch_dem_unc = (SEB_correction + _integ7_state) / gainInv;
 

--- a/src/lib/external_lgpl/tecs/tecs.cpp
+++ b/src/lib/external_lgpl/tecs/tecs.cpp
@@ -583,14 +583,15 @@ void TECS::update_pitch_throttle(const math::Matrix<3,3> &rotMat, float pitch, f
 	// Calculate Specific Total Energy Rate Limits
 	_update_STE_rate_lim();
 
+	// Detect underspeed condition
+	_detect_underspeed();
+
 	// Calculate the speed demand
 	_update_speed_demand();
 
 	// Calculate the height demand
 	_update_height_demand(hgt_dem, baro_altitude);
 
-	// Detect underspeed condition
-	_detect_underspeed();
 
 	// Calculate specific energy quantitiues
 	_update_energies();

--- a/src/lib/external_lgpl/tecs/tecs.cpp
+++ b/src/lib/external_lgpl/tecs/tecs.cpp
@@ -474,6 +474,13 @@ void TECS::_update_pitch(void)
 	float integ7_err_max = (gainInv * (_PITCHmaxf + math::radians(5.0f))) - temp;
 	_integ7_state = constrain(_integ7_state, integ7_err_min, integ7_err_max);
 
+	// if the specific engergy balance correction term produces a demanded pitch value which exceeds the aircraft pitch limits
+	// then zero the integrator. Not doing so can lead to the integrator value being shifted to large unwanted values due to the
+	// constraint right above this comment
+	if (SEB_correction / gainInv > (_PITCHmaxf + math::radians(10.0f)) || SEB_correction / gainInv < (_PITCHminf - math::radians(10.0f))) {
+		_integ7_state = 0.0f;
+	}
+
 	// Calculate pitch demand from specific energy balance signals
 	_pitch_dem_unc = (temp + _integ7_state) / gainInv;
 
@@ -591,7 +598,6 @@ void TECS::update_pitch_throttle(const math::Matrix<3,3> &rotMat, float pitch, f
 
 	// Calculate the height demand
 	_update_height_demand(hgt_dem, baro_altitude);
-
 
 	// Calculate specific energy quantitiues
 	_update_energies();


### PR DESCRIPTION
Please look at the commit messages for explanation.

First plot shows the problem that occured. Red line jumping from 0 to 100 shows tecs underspeed condition kicking in. The TECS integrator (blue line, scaled) jumps up and compensates for the spike in the
specific energy balance  errors signal (gray line at t > 62,5 seconds).
This spike is also a bug and is fixed by this PR (see first commit message).
![underspeed_integ_bug](https://cloud.githubusercontent.com/assets/7610489/19891652/5bef2124-a041-11e6-8d03-999ed31207e9.png)

This figure shows the results when using this PR.
1) Pitch integrator cannot be shifted arbitrarily anymore and is just zeroed if the pitch demand gets too large.
2) Spike in specific energy balance error signal not visible anymore.
![underspeed_integ_zeroed](https://cloud.githubusercontent.com/assets/7610489/19891944/b2c49faa-a042-11e6-8667-c3988d8b4f4f.png)


