### PR TITLE
Revert to using __builtin_isfinite for QuRT.

### DIFF
--- a/src/platforms/px4_defines.h
+++ b/src/platforms/px4_defines.h
@@ -180,9 +180,11 @@ using ::isfinite;
 #  define PX4_TICKS_PER_SEC 1000L
 #  define SIOCDEVPRIVATE 999999
 
-// HEXAGON defines isfinite() erroneously as a macro even for C++.
+// HEXAGON's isfinite() is erroneously defined as a macro even for C++,
+// using std::isfinite (using ::isfinite) which is a function, but which
+// appears to be broken because of undefined symbols (ie, _Dtest (C linkage)).
 #  undef PX4_ISFINITE
-#  define PX4_ISFINITE(x) isfinite(x)
+#  define PX4_ISFINITE(x) __builtin_isfinite(x)
 
 #else // __PX4_QURT
 


### PR DESCRIPTION
See discussion in https://github.com/PX4/Firmware/issues/5756

Me blames the testsuite for not even catching linking errors for supported targets...
