### PR TITLE
fix param interface

### DIFF
--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -543,6 +543,7 @@ param_set_internal(param_t param, const void *val, bool mark_saved, bool notify_
 				.val.p = NULL,
 				.unsaved = false
 			};
+			params_changed = true;
 
 			/* add it to the array and sort */
 			utarray_push_back(param_values, &buf);
@@ -556,12 +557,12 @@ param_set_internal(param_t param, const void *val, bool mark_saved, bool notify_
 		switch (param_type(param)) {
 
 		case PARAM_TYPE_INT32:
-			params_changed = s->val.i != *(int32_t *)val;
+			params_changed = params_changed || s->val.i != *(int32_t *)val;
 			s->val.i = *(int32_t *)val;
 			break;
 
 		case PARAM_TYPE_FLOAT:
-			params_changed = fabsf(s->val.f - * (float *)val) > FLT_EPSILON;
+			params_changed = params_changed || fabsf(s->val.f - * (float *)val) > FLT_EPSILON;
 			s->val.f = *(float *)val;
 			break;
 
@@ -576,7 +577,6 @@ param_set_internal(param_t param, const void *val, bool mark_saved, bool notify_
 			}
 
 			memcpy(s->val.p, val, param_size(param));
-			params_changed = true;
 			break;
 
 		default:

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -577,6 +577,7 @@ param_set_internal(param_t param, const void *val, bool mark_saved, bool notify_
 			}
 
 			memcpy(s->val.p, val, param_size(param));
+			params_changed = true;
 			break;
 
 		default:


### PR DESCRIPTION
When param value is changed to 'zero' for the first time, it won't be saved. 

This should be fix the issue #5330 .