### PR TITLE
Mavlink ULog & shell scripts: send heartbeat

### DIFF
--- a/Tools/mavlink_shell.py
+++ b/Tools/mavlink_shell.py
@@ -18,7 +18,8 @@ try:
 except:
     print("Failed to import pymavlink.")
     print("You may need to install it with 'pip install pymavlink pyserial'")
-    exit(-1)
+    print("")
+    raise
 from argparse import ArgumentParser
 
 

--- a/Tools/mavlink_ulog_streaming.py
+++ b/Tools/mavlink_ulog_streaming.py
@@ -68,7 +68,18 @@ class MavlinkLogStreaming():
         ''' main loop reading messages '''
         measure_time_start = timer()
         measured_data = 0
+
+        next_heartbeat_time = timer()
         while True:
+
+            # handle heartbeat sending
+            heartbeat_time = timer()
+            if heartbeat_time > next_heartbeat_time:
+                self.debug('sending heartbeat')
+                self.mav.mav.heartbeat_send(mavutil.mavlink.MAV_TYPE_GCS,
+                        mavutil.mavlink.MAV_AUTOPILOT_GENERIC, 0, 0, 0)
+                next_heartbeat_time = heartbeat_time + 1
+
             m, first_msg_start, num_drops = self.read_message()
             if m is not None:
                 self.process_streamed_ulog_data(m, first_msg_start, num_drops)

--- a/Tools/mavlink_ulog_streaming.py
+++ b/Tools/mavlink_ulog_streaming.py
@@ -17,8 +17,9 @@ try:
     from pymavlink import mavutil
 except:
     print("Failed to import pymavlink.")
-    print("You may need to install it with 'pip install pymavlink'")
-    exit(-1)
+    print("You may need to install it with 'pip install pymavlink pyserial'")
+    print("")
+    raise
 from argparse import ArgumentParser
 
 

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2356,6 +2356,11 @@ Mavlink::task_main(int argc, char *argv[])
 		pthread_mutex_destroy(&_message_buffer_mutex);
 	}
 
+	if (_mavlink_ulog) {
+		_mavlink_ulog->stop();
+		_mavlink_ulog = nullptr;
+	}
+
 	warnx("exiting channel %i", (int)_channel);
 
 	return OK;


### PR DESCRIPTION
and fix a bug when `mavlink stop-all` was called during log streaming