### PR TITLE
POSIX: use up to 20 command line arguments

### DIFF
--- a/src/platforms/posix/main.cpp
+++ b/src/platforms/posix/main.cpp
@@ -252,10 +252,11 @@ static void usage()
 
 static void process_line(string &line, bool exit_on_fail)
 {
-	vector<string> appargs(10);
+	vector<string> appargs(20);
 
 	stringstream(line) >> appargs[0] >> appargs[1] >> appargs[2] >> appargs[3] >> appargs[4] >> appargs[5] >> appargs[6] >>
-			   appargs[7] >> appargs[8] >> appargs[9];
+			   appargs[7] >> appargs[8] >> appargs[9] >> appargs[10] >> appargs[11] >> appargs[12] >> appargs[13] >>
+			   appargs[14] >> appargs[15] >> appargs[16] >> appargs[17] >> appargs[18] >> appargs[19];
 	run_cmd(appargs, exit_on_fail);
 }
 


### PR DESCRIPTION
This fixes the case where more than 10 args were needed for instance
when starting mavlink with all its options.

Tested in SITL. This is still ugly but going to be properly fixed in #5162.