### PR TITLE
Fix data loss in ekf2 and ekf2 replay and enable smaller buffers to reduce RAM

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.mc_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_apps
@@ -8,11 +8,12 @@
 #---------------------------------------
 # Estimator group selction
 #
-# INAV
+# INAV (deprecated)
 if param compare SYS_MC_EST_GROUP 0
 then
-	attitude_estimator_q start
-	position_estimator_inav start
+	echo "ERROR [init] Estimator INAV deprecated. Using LPE"
+	param set SYS_MC_EST_GROUP 1
+	param save
 fi
 
 # LPE

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_apps
@@ -9,11 +9,12 @@
 #---------------------------------------
 # Estimator group selction
 #
-# INAV
+# INAV (deprecated)
 if param compare SYS_MC_EST_GROUP 0
 then
-	attitude_estimator_q start
-	position_estimator_inav start
+	echo "ERROR [init] Estimator INAV deprecated. Using LPE"
+	param set SYS_MC_EST_GROUP 1
+	param save
 fi
 
 # LPE

--- a/cmake/configs/nuttx_px4fmu-v1_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v1_default.cmake
@@ -72,7 +72,7 @@ set(config_module_list
 	# Estimation modules
 	#
 	modules/attitude_estimator_q
-	modules/position_estimator_inav
+	#modules/position_estimator_inav
 	modules/local_position_estimator
 	modules/ekf2
 

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -97,7 +97,7 @@ set(config_module_list
 	# Estimation modules
 	#
 	modules/attitude_estimator_q
-	modules/position_estimator_inav
+	#modules/position_estimator_inav
 	modules/local_position_estimator
 	modules/ekf2
 

--- a/cmake/configs/nuttx_px4fmu-v2_test.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_test.cmake
@@ -98,7 +98,7 @@ set(config_module_list
 	# Estimation modules
 	#
 	modules/attitude_estimator_q
-	modules/position_estimator_inav
+	#modules/position_estimator_inav
 	modules/local_position_estimator
 	modules/ekf2
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -149,7 +149,8 @@ private:
 	float _balt_data_sum;			// summed barometric altitude readings (m)
 	uint64_t _balt_time_sum_ms;		// summed barometric altitude time stamps (msec)
 	uint8_t _balt_sample_count = 0;		// number of barometric altitude measurements summed
-	uint32_t _balt_time_ms_last_used = 0;	// time stamp in msec of the last averaged barometric altitude measurement used by the EKF
+	uint32_t _balt_time_ms_last_used =
+		0;	// time stamp in msec of the last averaged barometric altitude measurement used by the EKF
 
 	int	_sensors_sub = -1;
 	int	_gps_sub = -1;
@@ -549,16 +550,17 @@ void Ekf2::task_main()
 
 				// If the time last used by the EKF is less than 50msec, then accumulate the
 				// data and push the average when the 50msec is reached.
-				_mag_time_sum_ms += _timestamp_mag_us/1000;
+				_mag_time_sum_ms += _timestamp_mag_us / 1000;
 				_mag_sample_count++;
 				_mag_data_sum[0] += sensors.magnetometer_ga[0];
 				_mag_data_sum[1] += sensors.magnetometer_ga[1];
 				_mag_data_sum[2] += sensors.magnetometer_ga[2];
 				uint64_t mag_time_ms = _mag_time_sum_ms / _mag_sample_count;
+
 				if (mag_time_ms - _mag_time_ms_last_used > 50) {
 					float mag_sample_count_inv = 1.0f / (float)_mag_sample_count;
-					float mag_data_avg_ga[3] = {_mag_data_sum[0]*mag_sample_count_inv , _mag_data_sum[1]*mag_sample_count_inv , _mag_data_sum[2]*mag_sample_count_inv};
-					_ekf.setMagData(1000*(uint64_t)mag_time_ms, mag_data_avg_ga);
+					float mag_data_avg_ga[3] = {_mag_data_sum[0] *mag_sample_count_inv , _mag_data_sum[1] *mag_sample_count_inv , _mag_data_sum[2] *mag_sample_count_inv};
+					_ekf.setMagData(1000 * (uint64_t)mag_time_ms, mag_data_avg_ga);
 					_mag_time_ms_last_used = mag_time_ms;
 					_mag_time_sum_ms = 0;
 					_mag_sample_count = 0;
@@ -581,13 +583,14 @@ void Ekf2::task_main()
 
 				// If the time last used by the EKF is less than 50msec, then accumulate the
 				// data and push the average when the 50msec is reached.
-				_balt_time_sum_ms += _timestamp_balt_us/1000;
+				_balt_time_sum_ms += _timestamp_balt_us / 1000;
 				_balt_sample_count++;
 				_balt_data_sum += sensors.baro_alt_meter;
 				uint64_t balt_time_ms = _balt_time_sum_ms / _balt_sample_count;
+
 				if (balt_time_ms - _balt_time_ms_last_used > 50) {
 					float balt_data_avg = _balt_data_sum / (float)_balt_sample_count;
-					_ekf.setBaroData(1000*(uint64_t)balt_time_ms, &balt_data_avg);
+					_ekf.setBaroData(1000 * (uint64_t)balt_time_ms, &balt_data_avg);
 					_balt_time_ms_last_used = balt_time_ms;
 					_balt_time_sum_ms = 0;
 					_balt_sample_count = 0;

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -135,6 +135,27 @@ private:
 	float	_default_ev_pos_noise = 0.05f;	// external vision position noise used when an invalid value is supplied
 	float	_default_ev_ang_noise = 0.05f;	// external vision angle noise used when an invalid value is supplied
 
+	// Initialise time stamps used to send sensor data to the EKF and for logging
+	uint64_t _timestamp_mag_us = 0;
+	uint64_t _timestamp_balt_us = 0;
+
+	// Used to down sample magnetometer data
+	float _mag_data_sum[3];			// summed magnetometer readings (Ga)
+	uint64_t _mag_time_sum_ms;		// summed magnetoemter time stamps (msec)
+	uint8_t _mag_sample_count = 0;		// number of magnetometer measurements summed
+	uint32_t _mag_time_ms_last_used = 0;	// time stamp in msec of the last averaged magnetometer measurement used by the EKF
+
+	int	_sensors_sub = -1;
+	int	_gps_sub = -1;
+	int	_airspeed_sub = -1;
+	int	_params_sub = -1;
+	int 	_optical_flow_sub = -1;
+	int 	_range_finder_sub = -1;
+	int 	_ev_pos_sub = -1;
+	int	_actuator_armed_sub = -1;
+	int	_vehicle_land_detected_sub = -1;
+	int _status_sub = -1;
+
 	bool	_prev_landed = true;	// landed status from the previous frame
 
 	float _acc_hor_filt = 0.0f; 	// low-pass filtered horizontal acceleration
@@ -513,18 +534,47 @@ void Ekf2::task_main()
 
 		// read mag data
 		if (sensors.magnetometer_timestamp_relative == sensor_combined_s::RELATIVE_TIMESTAMP_INVALID) {
-			_ekf.setMagData(0, sensors.magnetometer_ga);
+			// set a zero timestamp to let the ekf replay program know that this data is not valid
+			_timestamp_mag_us = 0;
 
 		} else {
-			_ekf.setMagData(sensors.timestamp + sensors.magnetometer_timestamp_relative, sensors.magnetometer_ga);
+			if ((sensors.timestamp + sensors.magnetometer_timestamp_relative) != _timestamp_mag_us) {
+				_timestamp_mag_us = sensors.timestamp + sensors.magnetometer_timestamp_relative;
+
+				// If the time last used by the EKF is less than 50msec, then accumulate the
+				// data and push the average when the 50msec is reached.
+				_mag_time_sum_ms += _timestamp_mag_us/1000;
+				_mag_sample_count++;
+				_mag_data_sum[0] += sensors.magnetometer_ga[0];
+				_mag_data_sum[1] += sensors.magnetometer_ga[1];
+				_mag_data_sum[2] += sensors.magnetometer_ga[2];
+				uint64_t mag_time_ms = _mag_time_sum_ms / _mag_sample_count;
+				if (mag_time_ms - _mag_time_ms_last_used > 50) {
+					float mag_sample_count_inv = 1.0f / (float)_mag_sample_count;
+					float mag_data_avg_ga[3] = {_mag_data_sum[0]*mag_sample_count_inv , _mag_data_sum[1]*mag_sample_count_inv , _mag_data_sum[2]*mag_sample_count_inv};
+					_ekf.setMagData(1000*(uint64_t)mag_time_ms, mag_data_avg_ga);
+					_mag_time_ms_last_used = mag_time_ms;
+					_mag_time_sum_ms = 0;
+					_mag_sample_count = 0;
+					_mag_data_sum[0] = 0.0f;
+					_mag_data_sum[1] = 0.0f;
+					_mag_data_sum[2] = 0.0f;
+
+				}
+			}
 		}
 
 		// read baro data
 		if (sensors.baro_timestamp_relative == sensor_combined_s::RELATIVE_TIMESTAMP_INVALID) {
-			_ekf.setBaroData(0, &sensors.baro_alt_meter);
+			// set a zero timestamp to let the ekf replay program know that this data is not valid
+			_timestamp_balt_us = 0;
 
 		} else {
-			_ekf.setBaroData(sensors.timestamp + sensors.baro_timestamp_relative, &sensors.baro_alt_meter);
+			if ((sensors.timestamp + sensors.baro_timestamp_relative) != _timestamp_balt_us) {
+			_timestamp_balt_us = sensors.timestamp + sensors.baro_timestamp_relative;
+			_ekf.setBaroData(_timestamp_balt_us, &sensors.baro_alt_meter);
+
+			}
 		}
 
 		// read gps data if available
@@ -548,6 +598,7 @@ void Ekf2::task_main()
 			gps_msg.gdop = 0.0f;
 
 			_ekf.setGpsData(gps.timestamp, &gps_msg);
+
 		}
 
 		// only set airspeed data if condition for airspeed fusion are met
@@ -932,8 +983,8 @@ void Ekf2::task_main()
 			replay.time_ref = now;
 			replay.gyro_integral_dt = sensors.gyro_integral_dt;
 			replay.accelerometer_integral_dt = sensors.accelerometer_integral_dt;
-			replay.magnetometer_timestamp = sensors.timestamp + sensors.magnetometer_timestamp_relative;
-			replay.baro_timestamp = sensors.timestamp + sensors.baro_timestamp_relative;
+			replay.magnetometer_timestamp = _timestamp_mag_us;
+			replay.baro_timestamp = _timestamp_balt_us;
 			memcpy(replay.gyro_rad, sensors.gyro_rad, sizeof(replay.gyro_rad));
 			memcpy(replay.accelerometer_m_s2, sensors.accelerometer_m_s2, sizeof(replay.accelerometer_m_s2));
 			memcpy(replay.magnetometer_ga, sensors.magnetometer_ga, sizeof(replay.magnetometer_ga));

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -152,17 +152,6 @@ private:
 	uint32_t _balt_time_ms_last_used =
 		0;	// time stamp in msec of the last averaged barometric altitude measurement used by the EKF
 
-	int	_sensors_sub = -1;
-	int	_gps_sub = -1;
-	int	_airspeed_sub = -1;
-	int	_params_sub = -1;
-	int 	_optical_flow_sub = -1;
-	int 	_range_finder_sub = -1;
-	int 	_ev_pos_sub = -1;
-	int	_actuator_armed_sub = -1;
-	int	_vehicle_land_detected_sub = -1;
-	int _status_sub = -1;
-
 	bool	_prev_landed = true;	// landed status from the previous frame
 
 	float _acc_hor_filt = 0.0f; 	// low-pass filtered horizontal acceleration

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -39,6 +39,18 @@
  *
  */
 
+
+/**
+ * Minimum time of arrival delta between non-IMU observations before data is downsampled.
+ * Baro and Magnetometer data will be averaged before downsampling, other data will be point sampled resulting in loss of information.
+ *
+ * @group EKF2
+ * @min 10
+ * @max 50
+ * @unit ms
+ */
+PARAM_DEFINE_INT32(EKF2_MIN_OBS_DT, 20);
+
 /**
  * Magnetometer measurement delay relative to IMU measurements
  *

--- a/src/modules/ekf2_replay/ekf2_replay_main.cpp
+++ b/src/modules/ekf2_replay/ekf2_replay_main.cpp
@@ -379,8 +379,18 @@ void Ekf2Replay::setEstimatorInput(uint8_t *data, uint8_t type)
 		_sensors.timestamp = replay_part1.time_ref;
 		_sensors.gyro_integral_dt = replay_part1.gyro_integral_dt;
 		_sensors.accelerometer_integral_dt = replay_part1.accelerometer_integral_dt;
-		_sensors.magnetometer_timestamp_relative = (int32_t)(replay_part1.magnetometer_timestamp - _sensors.timestamp);
-		_sensors.baro_timestamp_relative = (int32_t)(replay_part1.baro_timestamp - _sensors.timestamp);
+		// If the magnetometer timestamp is zero, then there is no valid data
+		if (replay_part1.magnetometer_timestamp == 0) {
+			_sensors.magnetometer_timestamp_relative = (int32_t)sensor_combined_s::RELATIVE_TIMESTAMP_INVALID;
+		} else {
+			_sensors.magnetometer_timestamp_relative = (int32_t)(replay_part1.magnetometer_timestamp - _sensors.timestamp);
+		}
+		// If the barometer timestamp is zero then there is no valid data
+		if (replay_part1.baro_timestamp == 0) {
+			_sensors.baro_timestamp_relative = (int32_t)sensor_combined_s::RELATIVE_TIMESTAMP_INVALID;
+		} else {
+			_sensors.baro_timestamp_relative = (int32_t)(replay_part1.baro_timestamp - _sensors.timestamp);
+		}
 		_sensors.gyro_rad[0] = replay_part1.gyro_x_rad;
 		_sensors.gyro_rad[1] = replay_part1.gyro_y_rad;
 		_sensors.gyro_rad[2] = replay_part1.gyro_z_rad;

--- a/src/modules/ekf2_replay/ekf2_replay_main.cpp
+++ b/src/modules/ekf2_replay/ekf2_replay_main.cpp
@@ -379,18 +379,23 @@ void Ekf2Replay::setEstimatorInput(uint8_t *data, uint8_t type)
 		_sensors.timestamp = replay_part1.time_ref;
 		_sensors.gyro_integral_dt = replay_part1.gyro_integral_dt;
 		_sensors.accelerometer_integral_dt = replay_part1.accelerometer_integral_dt;
+
 		// If the magnetometer timestamp is zero, then there is no valid data
 		if (replay_part1.magnetometer_timestamp == 0) {
 			_sensors.magnetometer_timestamp_relative = (int32_t)sensor_combined_s::RELATIVE_TIMESTAMP_INVALID;
+
 		} else {
 			_sensors.magnetometer_timestamp_relative = (int32_t)(replay_part1.magnetometer_timestamp - _sensors.timestamp);
 		}
+
 		// If the barometer timestamp is zero then there is no valid data
 		if (replay_part1.baro_timestamp == 0) {
 			_sensors.baro_timestamp_relative = (int32_t)sensor_combined_s::RELATIVE_TIMESTAMP_INVALID;
+
 		} else {
 			_sensors.baro_timestamp_relative = (int32_t)(replay_part1.baro_timestamp - _sensors.timestamp);
 		}
+
 		_sensors.gyro_rad[0] = replay_part1.gyro_x_rad;
 		_sensors.gyro_rad[1] = replay_part1.gyro_y_rad;
 		_sensors.gyro_rad[2] = replay_part1.gyro_z_rad;

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -152,6 +152,16 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 					/* set and send parameter */
 					param_set(param, &(set.param_value));
 					send_param(param);
+
+					/* check for deprecated value, coming from an older GCS */
+					if (strcmp(name, "SYS_MC_EST_GROUP") == 0) {
+						uint32_t val = *(uint32_t *)&set.param_value;
+
+						if (val == 0) { //INAV
+							mavlink_log_critical(_mavlink->get_mavlink_log_pub(),
+									     "INAV is deprecated. Using LPE after reboot");
+						}
+					}
 				}
 			}
 

--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -95,11 +95,10 @@ PARAM_DEFINE_INT32(SYS_RESTART_TYPE, 2);
  *
  * Set the group of estimators used for multicopters and vtols
  *
- * @value 0 position_estimator_inav, attitude_estimator_q
  * @value 1 local_position_estimator, attitude_estimator_q
  * @value 2 ekf2
  *
- * @min 0
+ * @min 1
  * @max 2
  * @reboot_required true
  * @group System


### PR DESCRIPTION
Fixes a time stamping bug in the ekf2_replay app that could result in repeated mag and baro data being used.

Allows high rate magnetometer and baro data to be used without data loss by downsampling data using a running average if the data rate is too high. This will allow a smaller observation buffer size to be used on the ekf2 to save RAM by setting the delay parameters for all sensors not required to zero and tuning the remaining delay parameters using replay logs.

This has been tested on replay and flight (copter only) in combination with https://github.com/PX4/ecl/pull/213