### PR TITLE
Fix boot process on Pixhawk 2

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -74,7 +74,13 @@ then
 	then
 		set BOARD_FMUV3 true
 	else
-		set BOARD_FMUV3 false
+	  # Check for Pixhawk 2 board
+    if mpu9250 -S -R 4 start
+    then
+      set BOARD_FMUV3 true
+    else
+      set BOARD_FMUV3 false
+    fi
 	fi
 
 	if [ $BOARD_FMUV3 == true ]
@@ -92,6 +98,10 @@ then
 		# internal MPU6000 is rotated 180 deg roll, 270 deg yaw
 		if mpu6000 -R 14 start
 		then
+		else
+		  if mpu9250 -R 14 start
+		  then
+		  fi
 		fi
 
 		if hmc5883 -C -T -S -R 8 start

--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -74,13 +74,13 @@ then
 	then
 		set BOARD_FMUV3 true
 	else
-	  # Check for Pixhawk 2 board
-    if mpu9250 -S -R 4 start
-    then
-      set BOARD_FMUV3 true
-    else
-      set BOARD_FMUV3 false
-    fi
+		# Check for Pixhawk 2 board
+		if mpu9250 -S -R 4 start
+		then
+			set BOARD_FMUV3 true
+		else
+			set BOARD_FMUV3 false
+		fi
 	fi
 
 	if [ $BOARD_FMUV3 == true ]
@@ -99,9 +99,9 @@ then
 		if mpu6000 -R 14 start
 		then
 		else
-		  if mpu9250 -R 14 start
-		  then
-		  fi
+			if mpu9250 -R 14 start
+			then
+			fi
 		fi
 
 		if hmc5883 -C -T -S -R 8 start


### PR DESCRIPTION
The boot process on the Pixhawk 2 got stuck because of an insufficient check for MPU6000. We now check also for MPU9250 to detect boards with FMU version 3. 