### PR TITLE
Improve robustness of pre-flight checking

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -667,30 +667,34 @@ then
 		then
 		fi
 	else
-		# check if we should increase logging rate for ekf2 replay message logging
-		if param greater EKF2_REC_RPL 0
+		if param compare SYS_LOGGER 0
 		then
-			if param compare SYS_LOGGER 0
+			# check if we should increase logging rate for ekf2 replay message logging
+			if param greater EKF2_REC_RPL 0
 			then
 				if sdlog2 start -r 500 -e -b 18 -t
 				then
 				fi
 			else
-				if logger start -r 500
+				if sdlog2 start -r 100 -a -b 9 -t
 				then
 				fi
 			fi
 		else
-			if param compare SYS_LOGGER 0
+			set LOGGER_ARGS ""
+			if param compare SDLOG_MODE 1
 			then
-				if sdlog2 start -r 100 -a -b 9 -t
-				then
-				fi
-			else
-				if logger start -b 12 -t
-				then
-				fi
+				set LOGGER_ARGS "-e"
 			fi
+			if param compare SDLOG_MODE 2
+			then
+				set LOGGER_ARGS "-f"
+			fi
+
+			if logger start -b 12 -t $LOGGER_ARGS
+			then
+			fi
+			unset LOGGER_ARGS
 		fi
 	fi
 

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -91,6 +91,7 @@ set(msg_file_names
 	sensor_combined.msg
 	sensor_gyro.msg
 	sensor_mag.msg
+	sensor_preflight.msg
 	servorail_status.msg
 	subsystem_info.msg
 	system_power.msg

--- a/msg/sensor_combined.msg
+++ b/msg/sensor_combined.msg
@@ -22,7 +22,3 @@ float32[3] magnetometer_ga		# Magnetic field in NED body frame, in Gauss
 int32 baro_timestamp_relative		# timestamp + baro_timestamp_relative = Barometer timestamp
 float32 baro_alt_meter			# Altitude, already temp. comp.
 float32 baro_temp_celcius		# Temperature in degrees celsius
-
-# Pre-flight consistency check metrics. These will be zero if the vehicle only has one IMU sensor or is armed.
-float32 accel_inconsistency_m_s_s  # magnitude of maximum acceleration difference between IMU instances in (m/s/s).
-float32 gyro_inconsistency_rad_s   # magnitude of maximum angular rate difference between IMU instances in (rad/s).

--- a/msg/sensor_combined.msg
+++ b/msg/sensor_combined.msg
@@ -23,3 +23,6 @@ int32 baro_timestamp_relative		# timestamp + baro_timestamp_relative = Barometer
 float32 baro_alt_meter			# Altitude, already temp. comp.
 float32 baro_temp_celcius		# Temperature in degrees celsius
 
+# Pre-flight consistency check metrics. These will be zero if the vehicle only has one IMU sensor or is armed.
+float32 accel_inconsistency_m_s_s  # magnitude of maximum acceleration difference between IMU instances in (m/s/s).
+float32 gyro_inconsistency_rad_s   # magnitude of maximum angular rate difference between IMU instances in (rad/s).

--- a/msg/sensor_preflight.msg
+++ b/msg/sensor_preflight.msg
@@ -1,0 +1,6 @@
+#
+# Pre-flight sensor check metrics. These will be zero if the vehicle only has one sensor.
+# The topic will not be updated when the vehicle is armed
+#
+float32 accel_inconsistency_m_s_s  # magnitude of maximum acceleration difference between IMU instances in (m/s/s).
+float32 gyro_inconsistency_rad_s   # magnitude of maximum angular rate difference between IMU instances in (rad/s).

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -67,7 +67,7 @@
 #include <uORB/topics/vehicle_gps_position.h>
 #include <uORB/topics/ekf2_innovations.h>
 #include <uORB/topics/estimator_status.h>
-#include <uORB/topics/sensor_combined.h>
+#include <uORB/topics/sensor_preflight.h>
 
 #include "PreflightCheck.h"
 
@@ -164,10 +164,10 @@ out:
 
 static bool imuConsistencyCheck(orb_advert_t *mavlink_log_pub, bool checkAcc, bool checkGyro, bool report_status)
 {
-	// get the sensor combined data
-	int sensors_sub = orb_subscribe(ORB_ID(sensor_combined));
-	struct sensor_combined_s sensors = {};
-	orb_copy(ORB_ID(sensor_combined), sensors_sub, &sensors);
+	// get the sensor preflight data
+	int sensors_sub = orb_subscribe(ORB_ID(sensor_preflight));
+	struct sensor_preflight_s sensors = {};
+	orb_copy(ORB_ID(sensor_preflight), sensors_sub, &sensors);
 	px4_close(sensors_sub);
 
 	// Use the difference between IMU's to detect a bad calibration. If a single IMU is fitted, the value being checked will be zero so this check will always pass.

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -435,7 +435,7 @@ static bool gnssCheck(orb_advert_t *mavlink_log_pub, bool report_fail)
 
 static bool ekf2Check(orb_advert_t *mavlink_log_pub, bool optional, bool report_fail)
 {
-	// Get EKF2 innovation data if available and exit wiht a fail recorded if not
+	// Get EKF2 innovation data if available and exit with a fail recorded if not
 	bool updated;
 	int sub1 = orb_subscribe(ORB_ID(ekf2_innovations));
 	struct ekf2_innovations_s innovations;

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -181,11 +181,10 @@ static float eph_threshold = 5.0f;
 static float epv_threshold = 10.0f;
 
 /* pre-flight EKF checks */
-static float max_ekf_vpos_innov = 1.0f;
-static float max_ekf_vvel_innov = 0.5f;
-static float max_ekf_hpos_innov = 1.0f;
-static float max_ekf_hvel_innov = 0.5f;
-static float max_ekf_yaw_innov = 0.25f;
+static float max_ekf_pos_ratio = 0.5f;
+static float max_ekf_vel_ratio = 0.5f;
+static float max_ekf_hgt_ratio = 0.5f;
+static float max_ekf_yaw_ratio = 0.5f;
 static float max_ekf_dvel_bias = 2.0e-3f;
 static float max_ekf_dang_bias = 3.5e-4f;
 
@@ -1313,11 +1312,10 @@ int commander_thread_main(int argc, char *argv[])
 	param_t _param_fmode_6 = param_find("COM_FLTMODE6");
 
 	/* pre-flight EKF checks */
-	param_t _param_max_ekf_vpos_innov = param_find("COM_ARM_EKF_PD");
-	param_t _param_max_ekf_vvel_innov = param_find("COM_ARM_EKF_VD");
-	param_t _param_max_ekf_hpos_innov = param_find("COM_ARM_EKF_PH");
-	param_t _param_max_ekf_hvel_innov = param_find("COM_ARM_EKF_VH");
-	param_t _param_max_ekf_yaw_innov = param_find("COM_ARM_EKF_YAW");
+	param_t _param_max_ekf_pos_ratio = param_find("COM_ARM_EKF_POS");
+	param_t _param_max_ekf_vel_ratio = param_find("COM_ARM_EKF_VEL");
+	param_t _param_max_ekf_hgt_ratio = param_find("COM_ARM_EKF_HGT");
+	param_t _param_max_ekf_yaw_ratio = param_find("COM_ARM_EKF_YAW");
 	param_t _param_max_ekf_dvel_bias = param_find("COM_ARM_EKF_AB");
 	param_t _param_max_ekf_dang_bias = param_find("COM_ARM_EKF_GB");
 
@@ -1807,11 +1805,10 @@ int commander_thread_main(int argc, char *argv[])
 			param_get(_param_fmode_6, &_flight_mode_slots[5]);
 
 			/* pre-flight EKF checks */
-			param_get(_param_max_ekf_vpos_innov, &max_ekf_vpos_innov);
-			param_get(_param_max_ekf_vvel_innov, &max_ekf_vvel_innov);
-			param_get(_param_max_ekf_hpos_innov, &max_ekf_hpos_innov);
-			param_get(_param_max_ekf_hvel_innov, &max_ekf_hvel_innov);
-			param_get(_param_max_ekf_yaw_innov, &max_ekf_yaw_innov);
+			param_get(_param_max_ekf_pos_ratio, &max_ekf_pos_ratio);
+			param_get(_param_max_ekf_vel_ratio, &max_ekf_vel_ratio);
+			param_get(_param_max_ekf_hgt_ratio, &max_ekf_hgt_ratio);
+			param_get(_param_max_ekf_yaw_ratio, &max_ekf_yaw_ratio);
 			param_get(_param_max_ekf_dvel_bias, &max_ekf_dvel_bias);
 			param_get(_param_max_ekf_dang_bias, &max_ekf_dang_bias);
 

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -180,6 +180,19 @@ static systemlib::Hysteresis auto_disarm_hysteresis(false);
 static float eph_threshold = 5.0f;
 static float epv_threshold = 10.0f;
 
+/* pre-flight EKF checks */
+static float max_ekf_vpos_innov = 1.0f;
+static float max_ekf_vvel_innov = 0.5f;
+static float max_ekf_hpos_innov = 1.0f;
+static float max_ekf_hvel_innov = 0.5f;
+static float max_ekf_yaw_innov = 0.25f;
+static float max_ekf_dvel_bias = 2.0e-3f;
+static float max_ekf_dang_bias = 3.5e-4f;
+
+/* pre-flight IMU consistency checks */
+static float max_imu_acc_diff = 0.7f;
+static float max_imu_gyr_diff = 0.09f;
+
 static struct vehicle_status_s status = {};
 static struct vehicle_roi_s _roi = {};
 static struct battery_status_s battery = {};
@@ -1299,6 +1312,19 @@ int commander_thread_main(int argc, char *argv[])
 	param_t _param_fmode_5 = param_find("COM_FLTMODE5");
 	param_t _param_fmode_6 = param_find("COM_FLTMODE6");
 
+	/* pre-flight EKF checks */
+	param_t _param_max_ekf_vpos_innov = param_find("COM_ARM_EKF_PD");
+	param_t _param_max_ekf_vvel_innov = param_find("COM_ARM_EKF_VD");
+	param_t _param_max_ekf_hpos_innov = param_find("COM_ARM_EKF_PH");
+	param_t _param_max_ekf_hvel_innov = param_find("COM_ARM_EKF_VH");
+	param_t _param_max_ekf_yaw_innov = param_find("COM_ARM_EKF_YAW");
+	param_t _param_max_ekf_dvel_bias = param_find("COM_ARM_EKF_AB");
+	param_t _param_max_ekf_dang_bias = param_find("COM_ARM_EKF_GB");
+
+	/* pre-flight IMU consistency checks */
+	param_t _param_max_imu_acc_diff = param_find("COM_ARM_IMU_ACC");
+	param_t _param_max_imu_gyr_diff = param_find("COM_ARM_IMU_GYR");
+
 	// These are too verbose, but we will retain them a little longer
 	// until we are sure we really don't need them.
 
@@ -1779,6 +1805,19 @@ int commander_thread_main(int argc, char *argv[])
 			param_get(_param_fmode_4, &_flight_mode_slots[3]);
 			param_get(_param_fmode_5, &_flight_mode_slots[4]);
 			param_get(_param_fmode_6, &_flight_mode_slots[5]);
+
+			/* pre-flight EKF checks */
+			param_get(_param_max_ekf_vpos_innov, &max_ekf_vpos_innov);
+			param_get(_param_max_ekf_vvel_innov, &max_ekf_vvel_innov);
+			param_get(_param_max_ekf_hpos_innov, &max_ekf_hpos_innov);
+			param_get(_param_max_ekf_hvel_innov, &max_ekf_hvel_innov);
+			param_get(_param_max_ekf_yaw_innov, &max_ekf_yaw_innov);
+			param_get(_param_max_ekf_dvel_bias, &max_ekf_dvel_bias);
+			param_get(_param_max_ekf_dang_bias, &max_ekf_dang_bias);
+
+			/* pre-flight IMU consistency checks */
+			param_get(_param_max_imu_acc_diff, &max_imu_acc_diff);
+			param_get(_param_max_imu_gyr_diff, &max_imu_gyr_diff);
 
 			param_init_forced = false;
 

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -322,7 +322,7 @@ int commander_main(int argc, char *argv[])
 		daemon_task = px4_task_spawn_cmd("commander",
 					     SCHED_DEFAULT,
 					     SCHED_PRIORITY_DEFAULT + 40,
-					     3100,
+					     3200,
 					     commander_thread_main,
 					     (char * const *)&argv[0]);
 

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -474,19 +474,19 @@ PARAM_DEFINE_INT32(COM_FLTMODE5, -1);
 PARAM_DEFINE_INT32(COM_FLTMODE6, -1);
 
 /**
- * Maximum EKF vertical position innovation that will allow arming
+ * Maximum EKF position innovation test ratio that will allow arming
  *
  * @group Commander
  * @unit m
- * @min 0.5
- * @max 2.0
+ * @min 0.1
+ * @max 1.0
  * @decimal 2
  * @increment 0.05
  */
-PARAM_DEFINE_FLOAT(COM_ARM_EKF_PD, 1.0f);
+PARAM_DEFINE_FLOAT(COM_ARM_EKF_POS, 0.5f);
 
 /**
- * Maximum EKF vertical velocity innovation that will allow arming
+ * Maximum EKF velocity innovation test ratio that will allow arming
  *
  * @group Commander
  * @unit m/s
@@ -495,43 +495,31 @@ PARAM_DEFINE_FLOAT(COM_ARM_EKF_PD, 1.0f);
  * @decimal 2
  * @increment 0.05
  */
-PARAM_DEFINE_FLOAT(COM_ARM_EKF_VD, 0.5f);
+PARAM_DEFINE_FLOAT(COM_ARM_EKF_VEL, 0.5f);
 
 /**
- * Maximum EKF horizontal position innovation that will allow arming
+ * Maximum EKF height innovation test ratio that will allow arming
  *
  * @group Commander
  * @unit m
- * @min 0.5
- * @max 2.0
- * @decimal 2
- * @increment 0.05
- */
-PARAM_DEFINE_FLOAT(COM_ARM_EKF_PH, 1.0f);
-
-/**
- * Maximum EKF horizontal velocity innovation that will allow arming
- *
- * @group Commander
- * @unit m/s
  * @min 0.1
  * @max 1.0
  * @decimal 2
  * @increment 0.05
  */
-PARAM_DEFINE_FLOAT(COM_ARM_EKF_VH, 0.5f);
+PARAM_DEFINE_FLOAT(COM_ARM_EKF_HGT, 1.0f);
 
 /**
- * Maximum EKF yaw innovation that will allow arming
+ * Maximum EKF yaw innovation test ratio that will allow arming
  *
  * @group Commander
  * @unit rad
- * @min 0.05
- * @max 0.5
+ * @min 0.1
+ * @max 1.0
  * @decimal 2
  * @increment 0.05
  */
-PARAM_DEFINE_FLOAT(COM_ARM_EKF_YAW, 0.25f);
+PARAM_DEFINE_FLOAT(COM_ARM_EKF_YAW, 0.5f);
 
 /**
  * Maximum value of EKF accelerometer delta velocity bias estimate that will allow arming

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -472,3 +472,111 @@ PARAM_DEFINE_INT32(COM_FLTMODE5, -1);
  * @value 12 Follow Me
  */
 PARAM_DEFINE_INT32(COM_FLTMODE6, -1);
+
+/**
+ * Maximum EKF vertical position innovation that will allow arming
+ *
+ * @group Commander
+ * @unit m
+ * @min 0.5
+ * @max 2.0
+ * @decimal 2
+ * @increment 0.05
+ */
+PARAM_DEFINE_FLOAT(COM_ARM_EKF_PD, 1.0f);
+
+/**
+ * Maximum EKF vertical velocity innovation that will allow arming
+ *
+ * @group Commander
+ * @unit m/s
+ * @min 0.1
+ * @max 1.0
+ * @decimal 2
+ * @increment 0.05
+ */
+PARAM_DEFINE_FLOAT(COM_ARM_EKF_VD, 0.5f);
+
+/**
+ * Maximum EKF horizontal position innovation that will allow arming
+ *
+ * @group Commander
+ * @unit m
+ * @min 0.5
+ * @max 2.0
+ * @decimal 2
+ * @increment 0.05
+ */
+PARAM_DEFINE_FLOAT(COM_ARM_EKF_PH, 1.0f);
+
+/**
+ * Maximum EKF horizontal velocity innovation that will allow arming
+ *
+ * @group Commander
+ * @unit m/s
+ * @min 0.1
+ * @max 1.0
+ * @decimal 2
+ * @increment 0.05
+ */
+PARAM_DEFINE_FLOAT(COM_ARM_EKF_VH, 0.5f);
+
+/**
+ * Maximum EKF yaw innovation that will allow arming
+ *
+ * @group Commander
+ * @unit rad
+ * @min 0.05
+ * @max 0.5
+ * @decimal 2
+ * @increment 0.05
+ */
+PARAM_DEFINE_FLOAT(COM_ARM_EKF_YAW, 0.25f);
+
+/**
+ * Maximum value of EKF accelerometer delta velocity bias estimate that will allow arming
+ *
+ * @group Commander
+ * @unit m/s
+ * @min 0.001
+ * @max 0.004
+ * @decimal 4
+ * @increment 0.0005
+ */
+PARAM_DEFINE_FLOAT(COM_ARM_EKF_AB, 2.0e-3f);
+
+/**
+ * Maximum value of EKF gyro delta angle bias estimate that will allow arming
+ *
+ * @group Commander
+ * @unit rad
+ * @min 0.0001
+ * @max 0.0007
+ * @decimal 5
+ * @increment 0.00005
+ */
+PARAM_DEFINE_FLOAT(COM_ARM_EKF_GB, 3.5e-4f);
+
+/**
+ * Maximum accelerometer inconsistency between IMU units that will allow arming
+ *
+ * @group Commander
+ * @unit m/s/s
+ * @min 0.1
+ * @max 1.0
+ * @decimal 2
+ * @increment 0.05
+ */
+PARAM_DEFINE_FLOAT(COM_ARM_IMU_ACC, 0.7f);
+
+/**
+ * Maximum rate gyro inconsistency between IMU units that will allow arming
+ *
+ * @group Commander
+ * @unit rad/s
+ * @min 0.02
+ * @max 0.2
+ * @decimal 3
+ * @increment 0.01
+ */
+PARAM_DEFINE_FLOAT(COM_ARM_IMU_GYR, 0.09f);

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -552,6 +552,7 @@ void Logger::add_default_topics()
 	add_topic("camera_trigger");
 	add_topic("cpuload");
 	add_topic("gps_dump"); //this will only be published if GPS_DUMP_COMM is set
+	add_topic("sensor_preflight");
 
 	/* for estimator replay (need to be at full rate) */
 	add_topic("sensor_combined");

--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -48,3 +48,22 @@
  * @group SD Logging
  */
 PARAM_DEFINE_INT32(SDLOG_UTC_OFFSET, 0);
+
+/**
+ * Logging Mode
+ *
+ * Determines when to start and stop logging. By default, logging is started
+ * when arming the system, and stopped when disarming.
+ *
+ * This parameter is only for the new logger (SYS_LOGGER=1).
+ *
+ * @value 0 when armed until disarm (default)
+ * @value 1 from boot until disarm
+ * @value 2 from boot until shutdown
+ *
+ * @min 0
+ * @max 2
+ * @reboot_required true
+ * @group SD Logging
+ */
+PARAM_DEFINE_INT32(SDLOG_MODE, 0);

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -277,8 +277,6 @@ private:
 
 	float _accel_diff[3][2];	/**< filtered accel differences between IMU units (m/s/s) */
 	float _gyro_diff[3][2];		/**< filtered gyro differences between IMU uinits (rad/s) */
-	float _accel_diff_max_mag;	/**< magnitude of the maximum accel difference between different IMU units (m/s/s)*/
-	float _gyro_diff_max_mag;	/**< magnitude of the maximum gyro difference between different IMU units (rad/s)*/
 
 	hrt_abstime _vibration_warning_timestamp;
 	bool _vibration_warning;


### PR DESCRIPTION
Addresses #5842 

Adds checking of EKF innovation levels and inconsistencies between multiple IMU sensors if fitted.

Needs https://github.com/PX4/Firmware/issues/5790 fixed to avoid frustrating users as it is hard to diagnose pre-start sensor calibration issues at the moment.