### PR TITLE
Airspeed: preflight check for bad offset, fixed calls to preflight ch…

### DIFF
--- a/msg/airspeed.msg
+++ b/msg/airspeed.msg
@@ -3,3 +3,4 @@ float32 true_airspeed_m_s		# true filtered airspeed in meters per second, -1 if 
 float32 true_airspeed_unfiltered_m_s	# true airspeed in meters per second, -1 if unknown
 float32 air_temperature_celsius		# air temperature in degrees celsius, -1000 if unknown
 float32 confidence			# confidence value from 0 to 1 for this sensor
+float32 differential_pressure_filtered_pa # filtered differential pressure, can be negative

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -402,7 +402,7 @@ static bool airspeedCheck(orb_advert_t *mavlink_log_pub, bool optional, bool rep
 
 	if (fabsf(airspeed.differential_pressure_filtered_pa) > 15.0f && !prearm) {
 		if (report_fail) {
-			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: AIRSPEED CALIBRATION ISSUE");
+			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: HIGH AIRSPEED, CHECK CALIBRATION");
 		}
 		success = false;
 		goto out;

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -363,7 +363,7 @@ static bool baroCheck(orb_advert_t *mavlink_log_pub, unsigned instance, bool opt
 	return success;
 }
 
-static bool airspeedCheck(orb_advert_t *mavlink_log_pub, bool optional, bool report_fail)
+static bool airspeedCheck(orb_advert_t *mavlink_log_pub, bool optional, bool report_fail, bool prearm, hrt_abstime time_since_boot)
 {
 	bool success = true;
 	int ret;
@@ -388,11 +388,24 @@ static bool airspeedCheck(orb_advert_t *mavlink_log_pub, bool optional, bool rep
 		goto out;
 	}
 
-	if (fabsf(airspeed.indicated_airspeed_m_s) > 6.0f) {
+	/**
+	 * Check if differential pressure is off by more than 15Pa which equals to 5m/s when measuring no airspeed.
+	 * Negative and positive offsets are considered. Do not check anymore while arming because pitot cover
+	 * might have been removed.
+	 */
+
+	if (time_since_boot < 1e6) {
+		// the airspeed driver filter doesn't deliver the actual value yet
+		success = false;
+		goto out;
+	}
+
+	if (fabsf(airspeed.differential_pressure_filtered_pa) > 15.0f && !prearm) {
 		if (report_fail) {
-			mavlink_log_critical(mavlink_log_pub, "AIRSPEED WARNING: WIND OR CALIBRATION ISSUE");
+			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: AIRSPEED CALIBRATION ISSUE");
 		}
-		// XXX do not make this fatal yet
+		success = false;
+		goto out;
 	}
 
 out:
@@ -511,7 +524,8 @@ out:
 }
 
 bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkMag, bool checkAcc, bool checkGyro,
-		    bool checkBaro, bool checkAirspeed, bool checkRC, bool checkGNSS, bool checkDynamic, bool isVTOL, bool reportFailures)
+		    bool checkBaro, bool checkAirspeed, bool checkRC, bool checkGNSS,
+		    bool checkDynamic, bool isVTOL, bool reportFailures, bool prearm, hrt_abstime time_since_boot)
 {
 
 #ifdef __PX4_QURT
@@ -651,7 +665,7 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkMag, bool checkAcc,
 
 	/* ---- AIRSPEED ---- */
 	if (checkAirspeed) {
-		if (!airspeedCheck(mavlink_log_pub, true, reportFailures)) {
+		if (!airspeedCheck(mavlink_log_pub, true, reportFailures, prearm, time_since_boot)) {
 			failed = true;
 		}
 	}

--- a/src/modules/commander/PreflightCheck.h
+++ b/src/modules/commander/PreflightCheck.h
@@ -39,6 +39,8 @@
  * @author Johan Jansen <jnsn.johan@gmail.com>
  */
 
+#include <drivers/drv_hrt.h>
+
 #pragma once
 
 namespace Commander
@@ -67,7 +69,8 @@ namespace Commander
 *   true if the GNSS receiver should be checked
 **/
 bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkMag, bool checkAcc,
-    bool checkGyro, bool checkBaro, bool checkAirspeed, bool checkRC, bool checkGNSS, bool checkDynamic, bool isVTOL, bool reportFailures = false);
+    bool checkGyro, bool checkBaro, bool checkAirspeed, bool checkRC, bool checkGNSS,
+    bool checkDynamic, bool isVTOL, bool reportFailures, bool prearm, hrt_abstime time_since_boot);
 
 const unsigned max_mandatory_gyro_count = 1;
 const unsigned max_optional_gyro_count = 3;

--- a/src/modules/commander/airspeed_calibration.cpp
+++ b/src/modules/commander/airspeed_calibration.cpp
@@ -249,6 +249,7 @@ int do_airspeed_calibration(orb_advert_t *mavlink_log_pub)
 
 				feedback_calibration_failed(mavlink_log_pub);
 				goto error_return;
+
 			} else {
 				calibration_log_info(mavlink_log_pub, "[cal] Positive pressure: OK (%d Pa)",
 					(int)diff_pres.differential_pressure_raw_pa);
@@ -271,6 +272,10 @@ int do_airspeed_calibration(orb_advert_t *mavlink_log_pub)
 
 	calibration_log_info(mavlink_log_pub, CAL_QGC_DONE_MSG, sensor_name);
 	tune_neutral(true);
+
+	/* Wait 2sec for the airflow to stop and ensure the driver filter has caught up, otherwise
+	 * the followup preflight checks might fail. */
+	usleep(2e6);
 
 normal_return:
 	calibrate_cancel_unsubscribe(cancel_sub);

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1631,6 +1631,7 @@ int commander_thread_main(int argc, char *argv[])
 	/* update vehicle status to find out vehicle type (required for preflight checks) */
 	param_get(_param_sys_type, &(status.system_type)); // get system type
 	status.is_rotary_wing = is_rotary_wing(&status) || is_vtol(&status);
+	status.is_vtol = is_vtol(&status);
 
 	bool checkAirspeed = false;
 	/* Perform airspeed check only if circuit breaker is not

--- a/src/modules/commander/commander_tests/state_machine_helper_test.cpp
+++ b/src/modules/commander/commander_tests/state_machine_helper_test.cpp
@@ -293,10 +293,10 @@ bool StateMachineHelperTest::armingStateTransitionTest(void)
 
         // Attempt transition
         transition_result_t result = arming_state_transition(&status, &battery, &safety, test->requested_state, &armed,
-        		false /* no pre-arm checks */,
-        		nullptr /* no mavlink_log_pub */,
-        		&status_flags,
-        		5.0f, check_gps);
+				false /* no pre-arm checks */,
+				nullptr /* no mavlink_log_pub */,
+				&status_flags,
+				5.0f, check_gps, 2e6);
 
         // Validate result of transition
         ut_compare(test->assertMsg, test->expected_transition_result, result);

--- a/src/modules/commander/commander_tests/state_machine_helper_test.cpp
+++ b/src/modules/commander/commander_tests/state_machine_helper_test.cpp
@@ -296,7 +296,10 @@ bool StateMachineHelperTest::armingStateTransitionTest(void)
 				false /* no pre-arm checks */,
 				nullptr /* no mavlink_log_pub */,
 				&status_flags,
-				5.0f, check_gps, 2e6);
+				5.0f, /* avionics rail voltage */
+                check_gps,
+                2e6 /* 2 seconds after boot, everything should be checked */
+                );
 
         // Validate result of transition
         ut_compare(test->assertMsg, test->expected_transition_result, result);

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -126,7 +126,8 @@ transition_result_t arming_state_transition(struct vehicle_status_s *status,
 		orb_advert_t *mavlink_log_pub,	///< uORB handle for mavlink log
 		status_flags_s *status_flags,
 		float avionics_power_rail_voltage,
-		bool can_arm_without_gps)
+		bool can_arm_without_gps,
+		hrt_abstime time_since_boot)
 {
 	// Double check that our static arrays are still valid
 	ASSERT(vehicle_status_s::ARMING_STATE_INIT == 0);
@@ -152,7 +153,7 @@ transition_result_t arming_state_transition(struct vehicle_status_s *status,
 		    && status->hil_state == vehicle_status_s::HIL_STATE_OFF) {
 
 			prearm_ret = preflight_check(status, mavlink_log_pub, true /* pre-arm */, false /* force_report */,
-						     status_flags, battery, can_arm_without_gps);
+						     status_flags, battery, can_arm_without_gps, time_since_boot);
 		}
 
 		/* re-run the pre-flight check as long as sensors are failing */
@@ -163,7 +164,7 @@ transition_result_t arming_state_transition(struct vehicle_status_s *status,
 
 			if (last_preflight_check == 0 || hrt_absolute_time() - last_preflight_check > 1000 * 1000) {
 				prearm_ret = preflight_check(status, mavlink_log_pub, false /* pre-flight */, false /* force_report */,
-							     status_flags, battery, can_arm_without_gps);
+							     status_flags, battery, can_arm_without_gps, time_since_boot);
 				status_flags->condition_system_sensors_initialized = !prearm_ret;
 				last_preflight_check = hrt_absolute_time();
 				last_prearm_ret = prearm_ret;
@@ -1102,7 +1103,7 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 }
 
 int preflight_check(struct vehicle_status_s *status, orb_advert_t *mavlink_log_pub, bool prearm, bool force_report,
-		    status_flags_s *status_flags, battery_status_s *battery, bool can_arm_without_gps)
+		    status_flags_s *status_flags, battery_status_s *battery, bool can_arm_without_gps, hrt_abstime time_since_boot)
 {
 	/*
 	 */
@@ -1119,7 +1120,7 @@ int preflight_check(struct vehicle_status_s *status, orb_advert_t *mavlink_log_p
 
 	bool preflight_ok = Commander::preflightCheck(mavlink_log_pub, true, true, true, true,
 			    checkAirspeed, (status->rc_input_mode == vehicle_status_s::RC_IN_MODE_DEFAULT),
-			    !can_arm_without_gps, true, status->is_vtol, reportFailures);
+			    !can_arm_without_gps, true, status->is_vtol, reportFailures, prearm, time_since_boot);
 
 	if (!status_flags->circuit_breaker_engaged_usb_check && status_flags->usb_connected && prearm) {
 		preflight_ok = false;

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -1105,8 +1105,6 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 int preflight_check(struct vehicle_status_s *status, orb_advert_t *mavlink_log_pub, bool prearm, bool force_report,
 		    status_flags_s *status_flags, battery_status_s *battery, bool can_arm_without_gps, hrt_abstime time_since_boot)
 {
-	/*
-	 */
 	bool reportFailures = force_report || (!status_flags->condition_system_prearm_error_reported &&
 					       status_flags->condition_system_hotplug_timeout);
 

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -42,6 +42,8 @@
 #ifndef STATE_MACHINE_HELPER_H_
 #define STATE_MACHINE_HELPER_H_
 
+#include <drivers/drv_hrt.h>
+
 #include <uORB/uORB.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/battery_status.h>
@@ -106,7 +108,8 @@ transition_result_t arming_state_transition(struct vehicle_status_s *status,
 					    orb_advert_t *mavlink_log_pub,	///< uORB handle for mavlink log
 					    status_flags_s *status_flags,
 					    float avionics_power_rail_voltage,
-					    bool can_arm_without_gps);
+					    bool can_arm_without_gps,
+					    hrt_abstime time_since_boot);
 
 transition_result_t
 main_state_transition(struct vehicle_status_s *status, main_state_t new_main_state, uint8_t &main_state_prev,
@@ -124,6 +127,8 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 		   const bool stay_in_failsafe, status_flags_s *status_flags, bool landed,
 		   const bool rc_loss_enabled, const int offb_loss_act, const int offb_loss_rc_act);
 
-int preflight_check(struct vehicle_status_s *status, orb_advert_t *mavlink_log_pub, bool prearm, bool force_report, status_flags_s *status_flags, battery_status_s *battery, bool can_arm_without_gps);
+int preflight_check(struct vehicle_status_s *status, orb_advert_t *mavlink_log_pub, bool prearm,
+	bool force_report, status_flags_s *status_flags, battery_status_s *battery,
+	bool can_arm_without_gps, hrt_abstime time_since_boot);
 
 #endif /* STATE_MACHINE_HELPER_H_ */

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -1409,6 +1409,7 @@ Sensors::diff_pres_poll(struct sensor_combined_s &raw)
 						   _last_best_baro_pressure * 1e2f, air_temperature_celsius));
 
 		_airspeed.air_temperature_celsius = air_temperature_celsius;
+		_airspeed.differential_pressure_filtered_pa = _diff_pres.differential_pressure_filtered_pa;
 
 		/* announce the airspeed if needed, just publish else */
 		if (_airspeed_pub != nullptr) {


### PR DESCRIPTION
…ecks (vtol & airspeed)

This is best used with a pitot tube cover. Without a cover and lots of wind on the ground the check will report a calibration issue. Although it's annoying to do more airspeed calibrations, this effectively got rid of all offset issues for us.

Fixes #5059 (I think)
Fixes #5631

@dagar @julianoes please have a look