### PR TITLE
Add missing log messages to EKF2 replay

### DIFF
--- a/src/modules/ekf2_replay/ekf2_replay_main.cpp
+++ b/src/modules/ekf2_replay/ekf2_replay_main.cpp
@@ -643,6 +643,10 @@ void Ekf2Replay::logIfUpdated()
 					    est_status.covariances) : sizeof(log_message.body.est2.cov);
 		memset(&(log_message.body.est2.cov), 0, sizeof(log_message.body.est2.cov));
 		memcpy(&(log_message.body.est2.cov), est_status.covariances, maxcopy2);
+		log_message.body.est2.gps_check_fail_flags = est_status.gps_check_fail_flags;
+		log_message.body.est2.control_mode_flags = est_status.control_mode_flags;
+		log_message.body.est2.health_flags = est_status.health_flags;
+		log_message.body.est2.innov_test_flags = est_status.innovation_check_flags;
 		writeMessage(_write_fd, (void *)&log_message.head1, _formats[LOG_EST2_MSG].length);
 
 		log_message.type = LOG_EST3_MSG;


### PR DESCRIPTION
These messages are logged in sdlog2, but were not being logged by the replay program.

Question: Would it be possible for the logging program (sdlog2 or logger) to do the logging instead of Ekf2Replay::logIfUpdated() ? It would reduce bugs and maintenance effort.