### PR TITLE
UAVCAN: Always enable dynamic node ID allocation

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -378,8 +378,8 @@ then
 		then
 			if param compare UAVCAN_ENABLE 0
 			then
-				echo "OVERRIDING UAVCAN_ENABLE = 1" >> $LOG_FILE
-				param set UAVCAN_ENABLE 1
+				echo "OVERRIDING UAVCAN_ENABLE = 3" >> $LOG_FILE
+				param set UAVCAN_ENABLE 3
 			fi
 		fi
 
@@ -578,15 +578,6 @@ then
 	# Starting stuff according to UAVCAN_ENABLE value
 	#
 	if param greater UAVCAN_ENABLE 0
-	then
-		if uavcan start
-		then
-		else
-			tone_alarm $TUNE_ERR
-		fi
-	fi
-
-	if param greater UAVCAN_ENABLE 1
 	then
 		if uavcan start fw
 		then

--- a/src/modules/uavcan/uavcan_params.c
+++ b/src/modules/uavcan/uavcan_params.c
@@ -42,16 +42,15 @@
  * UAVCAN mode
  *
  *  0 - UAVCAN disabled.
- *  1 - Enabled support for UAVCAN actuators and sensors.
- *  2 - Enabled support for dynamic node ID allocation and firmware update.
+ *  1 - Basic support for UAVCAN actuators and sensors.
+ *  2 - Full support for dynamic node ID allocation and firmware update.
  *  3 - Sets the motor control outputs to UAVCAN and enables support for dynamic node ID allocation and firmware update.
  *
  * @min 0
  * @max 3
  * @value 0 Disabled
- * @value 1 Enabled
- * @value 2 Dynamic ID/Update
- * @value 3 Motors/Update
+ * @value 2 Sensors Enabled
+ * @value 3 Sensors and Motors
  * @group UAVCAN
  */
 PARAM_DEFINE_INT32(UAVCAN_ENABLE, 0);


### PR DESCRIPTION
This fixes an usability issue where users didn't have the Zubax devices working.