### PR TITLE
Refactor mc_pos_control_main and offboard velocity hold

### DIFF
--- a/msg/position_setpoint.msg
+++ b/msg/position_setpoint.msg
@@ -9,6 +9,9 @@ uint8 SETPOINT_TYPE_IDLE=5	# do nothing, switch off motors or keep at idle speed
 uint8 SETPOINT_TYPE_OFFBOARD=6 	# setpoint in NED frame (x, y, z, vx, vy, vz) set by offboard
 uint8 SETPOINT_TYPE_FOLLOW_TARGET=7  # setpoint in NED frame (x, y, z, vx, vy, vz) set by follow target
 
+uint8 VELOCITY_FRAME_LOCAL_NED = 1 # MAV_FRAME_LOCAL_NED
+uint8 VELOCITY_FRAME_BODY_NED = 8 # MAV_FRAME_BODY_NED
+
 bool valid			# true if setpoint is valid
 uint8 type			# setpoint type to adjust behavior of position controller
 float32 x			# local position setpoint in m in NED
@@ -19,6 +22,8 @@ float32 vx			# local velocity setpoint in m/s in NED
 float32 vy			# local velocity setpoint in m/s in NED
 float32 vz			# local velocity setpoint in m/s in NED
 bool velocity_valid		# true if local velocity setpoint valid
+uint8 velocity_frame		# to set velocity setpoints in NED or body
+
 bool alt_valid		# do not set for 3D position control. Set to true if you want z-position control while doing vx,vy velocity control.
 float64 lat			# latitude, in deg
 float64 lon			# longitude, in deg

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -84,7 +84,6 @@ static const char reason_no_rc[] = "no RC";
 static const char reason_no_offboard[] = "no offboard";
 static const char reason_no_rc_and_no_offboard[] = "no RC and no offboard";
 static const char reason_no_gps[] = "no gps";
-static const char reason_no_gpos[] = "no gpos";
 static const char reason_no_gps_cmd[] = "no gps cmd";
 static const char reason_no_home[] = "no home";
 static const char reason_no_datalink[] = "no datalink";

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -80,12 +80,14 @@ using namespace DriverFramework;
 #define AVIONICS_WARN_VOLTAGE	4.9f
 #endif
 
-const char *reason_no_rc = "no rc";
-const char *reason_no_gps = "no gps";
-const char *reason_no_gpos = "no gpos";
-const char *reason_no_gps_cmd = "no gps cmd";
-const char *reason_no_home = "no home";
-const char *reason_no_datalink = "no datalink";
+static const char reason_no_rc[] = "no RC";
+static const char reason_no_offboard[] = "no offboard";
+static const char reason_no_rc_and_no_offboard[] = "no RC and no offboard";
+static const char reason_no_gps[] = "no gps";
+static const char reason_no_gpos[] = "no gpos";
+static const char reason_no_gps_cmd[] = "no gps cmd";
+static const char reason_no_home[] = "no home";
+static const char reason_no_datalink[] = "no datalink";
 
 // This array defines the arming state transitions. The rows are the new state, and the columns
 // are the current state. Using new state and current state you can index into the array which
@@ -1020,7 +1022,7 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 
 		/* require offboard control, otherwise stay where you are */
 		if (status_flags->offboard_control_signal_lost && !status->rc_signal_lost) {
-			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_rc);
+			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_offboard);
 
 			if (status_flags->offboard_control_loss_timeout && offb_loss_rc_act < 5 && offb_loss_rc_act >= 0) {
 				if (offb_loss_rc_act == 3 && status_flags->condition_global_position_valid
@@ -1059,7 +1061,7 @@ bool set_nav_state(struct vehicle_status_s *status, struct commander_state_s *in
 			}
 
 		} else if (status_flags->offboard_control_signal_lost && status->rc_signal_lost) {
-			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_rc);
+			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_rc_and_no_offboard);
 
 			if (status_flags->offboard_control_loss_timeout && offb_loss_act < 3 && offb_loss_act >= 0) {
 				if (offb_loss_act == 2 && status_flags->condition_global_position_valid

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -868,6 +868,8 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 						pos_sp_triplet.current.vy = set_position_target_local_ned.vy;
 						pos_sp_triplet.current.vz = set_position_target_local_ned.vz;
 
+						pos_sp_triplet.current.velocity_frame =
+							set_position_target_local_ned.coordinate_frame;
 					} else {
 						pos_sp_triplet.current.velocity_valid = false;
 					}

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1831,7 +1831,6 @@ MulticopterPositionControl::control_position(float dt)
 						   _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF);
 
 		if (_vehicle_land_detected.landed && !got_takeoff_setpoint) {
-			PX4_INFO("still on ground");
 			// Keep throttle low while still on ground.
 			thr_max = 0.0f;
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1107,8 +1107,8 @@ MulticopterPositionControl::control_non_manual(float dt)
 			ft_vel.zero();
 		}
 
-		_vel_sp(0) = fabs(ft_vel(0)) > fabs(_vel_sp(0)) ? ft_vel(0) : _vel_sp(0);
-		_vel_sp(1) = fabs(ft_vel(1)) > fabs(_vel_sp(1)) ? ft_vel(1) : _vel_sp(1);
+		_vel_sp(0) = fabsf(ft_vel(0)) > fabsf(_vel_sp(0)) ? ft_vel(0) : _vel_sp(0);
+		_vel_sp(1) = fabsf(ft_vel(1)) > fabsf(_vel_sp(1)) ? ft_vel(1) : _vel_sp(1);
 
 		// track target using velocity only
 
@@ -1837,7 +1837,7 @@ MulticopterPositionControl::control_position(float dt)
 
 			/* descend stabilized, we're landing */
 			if (!_in_landing && !_lnd_reached_ground
-			    && (float)fabs(_acc_z_lp) < 0.1f
+			    && (float)fabsf(_acc_z_lp) < 0.1f
 			    && _vel_z_lp > 0.5f * _params.land_speed) {
 				_in_landing = true;
 			}

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -2139,11 +2139,10 @@ MulticopterPositionControl::generate_attitude_setpoint(float dt)
 			z_roll_pitch_sp = R_yaw_correction * z_roll_pitch_sp;
 
 			// use the formula z_roll_pitch_sp = R_tilt * [0;0;1]
-			// to calculate the new desired roll and pitch angles
-			// R_tilt can be written as a function of the new desired roll and pitch
-			// angles. we get three equations and have to solve for 2 unknowns
-			_att_sp.pitch_body = asinf(z_roll_pitch_sp(0));
-			_att_sp.roll_body = -atan2f(z_roll_pitch_sp(1), z_roll_pitch_sp(2));
+			// R_tilt is computed from_euler; only true if cos(roll) not equal zero
+			// -> valid if roll is not +-pi/2;
+			_att_sp.roll_body = -asinf(z_roll_pitch_sp(1));
+			_att_sp.pitch_body = atan2f(z_roll_pitch_sp(0), z_roll_pitch_sp(2));
 		}
 
 		/* copy quaternion setpoint to attitude setpoint topic */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1222,12 +1222,24 @@ MulticopterPositionControl::control_offboard(float dt)
 					_hold_offboard_xy = true;
 				}
 
-				_run_pos_control = false;
+				_run_pos_control = true;
 
 			} else {
-				/* set position setpoint move rate */
-				_vel_sp(0) = _pos_sp_triplet.current.vx;
-				_vel_sp(1) = _pos_sp_triplet.current.vy;
+
+				if (_pos_sp_triplet.current.velocity_frame == position_setpoint_s::VELOCITY_FRAME_LOCAL_NED) {
+					/* set position setpoint move rate */
+					_vel_sp(0) = _pos_sp_triplet.current.vx;
+					_vel_sp(1) = _pos_sp_triplet.current.vy;
+
+				} else if (_pos_sp_triplet.current.velocity_frame == position_setpoint_s::VELOCITY_FRAME_BODY_NED) {
+					// Transform velocity command from body frame to NED frame
+					_vel_sp(0) = cosf(_yaw) * _pos_sp_triplet.current.vx - sinf(_yaw) * _pos_sp_triplet.current.vy;
+					_vel_sp(1) = sinf(_yaw) * _pos_sp_triplet.current.vx + cosf(_yaw) * _pos_sp_triplet.current.vy;
+
+				} else {
+					PX4_WARN("Unknown velocity offboard coordinate frame");
+				}
+
 				_run_pos_control = false;
 
 				_hold_offboard_xy = false;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -338,6 +338,8 @@ private:
 	 */
 	void		control_manual(float dt);
 
+	void control_non_manual(float dt);
+
 	/**
 	 * Set position setpoint using offboard control
 	 */
@@ -348,6 +350,8 @@ private:
 	 */
 	void		control_auto(float dt);
 
+	void control_position(float dt);
+
 	/**
 	 * Select between barometric and global (AMSL) altitudes
 	 */
@@ -355,7 +359,7 @@ private:
 
 	void update_velocity_derivative();
 
-	void do_position_control(float dt);
+	void do_control(float dt);
 
 	void generate_attitude_setpoint(float dt);
 
@@ -1012,6 +1016,89 @@ MulticopterPositionControl::control_manual(float dt)
 			_vel_sp(2) = req_vel_sp_scaled(2);
 		}
 	}
+
+	if (_vehicle_land_detected.landed) {
+		/* don't run controller when landed */
+		_reset_pos_sp = true;
+		_reset_alt_sp = true;
+		_mode_auto = false;
+		_reset_int_z = true;
+		_reset_int_xy = true;
+
+		_R_setpoint.identity();
+
+		_att_sp.roll_body = 0.0f;
+		_att_sp.pitch_body = 0.0f;
+		_att_sp.yaw_body = _yaw;
+		_att_sp.thrust = 0.0f;
+
+		_att_sp.timestamp = hrt_absolute_time();
+
+		/* publish attitude setpoint */
+		if (_att_sp_pub != nullptr) {
+			orb_publish(_attitude_setpoint_id, _att_sp_pub, &_att_sp);
+
+		} else if (_attitude_setpoint_id) {
+			_att_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp);
+		}
+
+	} else {
+		control_position(dt);
+	}
+
+}
+
+void
+MulticopterPositionControl::control_non_manual(float dt)
+{
+	/* select control source */
+	if (_control_mode.flag_control_offboard_enabled) {
+		/* offboard control */
+		control_offboard(dt);
+		_mode_auto = false;
+
+	} else {
+		/* AUTO */
+		control_auto(dt);
+	}
+
+	/* weather-vane mode for vtol: disable yaw control */
+	if (_pos_sp_triplet.current.disable_mc_yaw_control == true) {
+		_att_sp.disable_mc_yaw_control = true;
+
+	} else {
+		/* reset in case of setpoint updates */
+		_att_sp.disable_mc_yaw_control = false;
+	}
+
+	if (_pos_sp_triplet.current.valid
+	    && _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_IDLE) {
+		/* idle state, don't run controller and set zero thrust */
+		_R_setpoint.identity();
+
+
+		matrix::Quatf qd = _R_setpoint;
+		memcpy(&_att_sp.q_d[0], qd.data(), sizeof(_att_sp.q_d));
+		_att_sp.q_d_valid = true;
+
+		_att_sp.roll_body = 0.0f;
+		_att_sp.pitch_body = 0.0f;
+		_att_sp.yaw_body = _yaw;
+		_att_sp.thrust = 0.0f;
+
+		_att_sp.timestamp = hrt_absolute_time();
+
+		/* publish attitude setpoint */
+		if (_att_sp_pub != nullptr) {
+			orb_publish(_attitude_setpoint_id, _att_sp_pub, &_att_sp);
+
+		} else if (_attitude_setpoint_id) {
+			_att_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp);
+		}
+
+	} else {
+		control_position(dt);
+	}
 }
 
 void
@@ -1362,7 +1449,7 @@ MulticopterPositionControl::update_velocity_derivative()
 }
 
 void
-MulticopterPositionControl::do_position_control(float dt)
+MulticopterPositionControl::do_control(float dt)
 {
 
 	_vel_ff.zero();
@@ -1372,608 +1459,524 @@ MulticopterPositionControl::do_position_control(float dt)
 	_run_pos_control = true;
 	_run_alt_control = true;
 
-	/* select control source */
 	if (_control_mode.flag_control_manual_enabled) {
 		/* manual control */
 		control_manual(dt);
 		_mode_auto = false;
 
-	} else if (_control_mode.flag_control_offboard_enabled) {
-		/* offboard control */
-		control_offboard(dt);
-		_mode_auto = false;
-
 	} else {
-		/* AUTO */
-		control_auto(dt);
+		control_non_manual(dt);
+	}
+}
+
+void
+MulticopterPositionControl::control_position(float dt)
+{
+	/* run position & altitude controllers, if enabled (otherwise use already computed velocity setpoints) */
+	if (_run_pos_control) {
+		_vel_sp(0) = (_pos_sp(0) - _pos(0)) * _params.pos_p(0);
+		_vel_sp(1) = (_pos_sp(1) - _pos(1)) * _params.pos_p(1);
 	}
 
-	/* weather-vane mode for vtol: disable yaw control */
-	if (!_control_mode.flag_control_manual_enabled && _pos_sp_triplet.current.disable_mc_yaw_control == true) {
-		_att_sp.disable_mc_yaw_control = true;
+	// guard against any bad velocity values
 
-	} else {
-		/* reset in case of setpoint updates */
-		_att_sp.disable_mc_yaw_control = false;
-	}
+	bool velocity_valid = PX4_ISFINITE(_pos_sp_triplet.current.vx) &&
+			      PX4_ISFINITE(_pos_sp_triplet.current.vy) &&
+			      _pos_sp_triplet.current.velocity_valid;
 
-	if (!_control_mode.flag_control_manual_enabled && _pos_sp_triplet.current.valid
-	    && _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_IDLE) {
-		/* idle state, don't run controller and set zero thrust */
-		_R_setpoint.identity();
+	// do not go slower than the follow target velocity when position tracking is active (set to valid)
 
+	if (_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_FOLLOW_TARGET &&
+	    velocity_valid &&
+	    _pos_sp_triplet.current.position_valid) {
 
-		matrix::Quatf qd = _R_setpoint;
-		memcpy(&_att_sp.q_d[0], qd.data(), sizeof(_att_sp.q_d));
-		_att_sp.q_d_valid = true;
+		math::Vector<3> ft_vel(_pos_sp_triplet.current.vx, _pos_sp_triplet.current.vy, 0);
 
-		_att_sp.roll_body = 0.0f;
-		_att_sp.pitch_body = 0.0f;
-		_att_sp.yaw_body = _yaw;
-		_att_sp.thrust = 0.0f;
+		float cos_ratio = (ft_vel * _vel_sp) / (ft_vel.length() * _vel_sp.length());
 
-		_att_sp.timestamp = hrt_absolute_time();
+		// only override velocity set points when uav is traveling in same direction as target and vector component
+		// is greater than calculated position set point velocity component
 
-		/* publish attitude setpoint */
-		if (_att_sp_pub != nullptr) {
-			orb_publish(_attitude_setpoint_id, _att_sp_pub, &_att_sp);
+		if (cos_ratio > 0) {
+			ft_vel *= (cos_ratio);
+			// min speed a little faster than target vel
+			ft_vel += ft_vel.normalized() * 1.5f;
 
-		} else if (_attitude_setpoint_id) {
-			_att_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp);
+		} else {
+			ft_vel.zero();
 		}
 
-	} else if (_control_mode.flag_control_manual_enabled
-		   && _vehicle_land_detected.landed) {
-		/* don't run controller when landed */
+		_vel_sp(0) = fabs(ft_vel(0)) > fabs(_vel_sp(0)) ? ft_vel(0) : _vel_sp(0);
+		_vel_sp(1) = fabs(ft_vel(1)) > fabs(_vel_sp(1)) ? ft_vel(1) : _vel_sp(1);
+
+		// track target using velocity only
+
+	} else if (_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_FOLLOW_TARGET &&
+		   velocity_valid) {
+
+		_vel_sp(0) = _pos_sp_triplet.current.vx;
+		_vel_sp(1) = _pos_sp_triplet.current.vy;
+	}
+
+	if (_run_alt_control) {
+		_vel_sp(2) = (_pos_sp(2) - _pos(2)) * _params.pos_p(2);
+	}
+
+	/* make sure velocity setpoint is saturated in xy*/
+	float vel_norm_xy = sqrtf(_vel_sp(0) * _vel_sp(0) +
+				  _vel_sp(1) * _vel_sp(1));
+
+	if (vel_norm_xy > _params.vel_max(0)) {
+		/* note assumes vel_max(0) == vel_max(1) */
+		_vel_sp(0) = _vel_sp(0) * _params.vel_max(0) / vel_norm_xy;
+		_vel_sp(1) = _vel_sp(1) * _params.vel_max(1) / vel_norm_xy;
+	}
+
+	/* make sure velocity setpoint is saturated in z*/
+	if (_vel_sp(2) < -1.0f * _params.vel_max_up) {
+		_vel_sp(2) = -1.0f * _params.vel_max_up;
+	}
+
+	if (_vel_sp(2) >  _params.vel_max_down) {
+		_vel_sp(2) = _params.vel_max_down;
+	}
+
+	if (!_control_mode.flag_control_position_enabled) {
 		_reset_pos_sp = true;
+	}
+
+	if (!_control_mode.flag_control_altitude_enabled) {
 		_reset_alt_sp = true;
-		_do_reset_alt_pos_flag = true;
-		_mode_auto = false;
-		_reset_int_z = true;
-		_reset_int_xy = true;
+	}
 
-		_R_setpoint.identity();
+	if (!_control_mode.flag_control_velocity_enabled) {
+		_vel_sp_prev(0) = _vel(0);
+		_vel_sp_prev(1) = _vel(1);
+		_vel_sp(0) = 0.0f;
+		_vel_sp(1) = 0.0f;
+		control_vel_enabled_prev = false;
+	}
 
-		_att_sp.roll_body = 0.0f;
-		_att_sp.pitch_body = 0.0f;
-		_att_sp.yaw_body = _yaw;
-		_att_sp.thrust = 0.0f;
+	if (!_control_mode.flag_control_climb_rate_enabled) {
+		_vel_sp(2) = 0.0f;
+	}
 
-		_att_sp.timestamp = hrt_absolute_time();
+	/* use constant descend rate when landing, ignore altitude setpoint */
+	if (!_control_mode.flag_control_manual_enabled && _pos_sp_triplet.current.valid
+	    && _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
+		_vel_sp(2) = _params.land_speed;
+	}
 
-		/* publish attitude setpoint */
-		if (_att_sp_pub != nullptr) {
-			orb_publish(_attitude_setpoint_id, _att_sp_pub, &_att_sp);
+	/* special thrust setpoint generation for takeoff from ground */
+	if (!_control_mode.flag_control_manual_enabled && _pos_sp_triplet.current.valid
+	    && _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF
+	    && _control_mode.flag_armed) {
 
-		} else if (_attitude_setpoint_id) {
-			_att_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp);
+		// check if we are not already in air.
+		// if yes then we don't need a jumped takeoff anymore
+		if (!_takeoff_jumped && !_vehicle_land_detected.landed && fabsf(_takeoff_thrust_sp) < FLT_EPSILON) {
+			_takeoff_jumped = true;
+		}
+
+		if (!_takeoff_jumped) {
+			// ramp thrust setpoint up
+			if (_vel(2) > -(_params.tko_speed / 2.0f)) {
+				_takeoff_thrust_sp += 0.5f * dt;
+				_vel_sp.zero();
+				_vel_prev.zero();
+
+			} else {
+				// copter has reached our takeoff speed. split the thrust setpoint up
+				// into an integral part and into a P part
+				_thrust_int(2) = _takeoff_thrust_sp - _params.vel_p(2) * fabsf(_vel(2));
+				_thrust_int(2) = -math::constrain(_thrust_int(2), _params.thr_min, _params.thr_max);
+				_vel_sp_prev(2) = -_params.tko_speed;
+				_takeoff_jumped = true;
+				_reset_int_z = false;
+			}
+		}
+
+		if (_takeoff_jumped) {
+			_vel_sp(2) = -_params.tko_speed;
 		}
 
 	} else {
-		/* run position & altitude controllers, if enabled (otherwise use already computed velocity setpoints) */
-		if (_run_pos_control) {
-			_vel_sp(0) = (_pos_sp(0) - _pos(0)) * _params.pos_p(0);
-			_vel_sp(1) = (_pos_sp(1) - _pos(1)) * _params.pos_p(1);
-		}
-
-		// guard against any bad velocity values
-
-		bool velocity_valid = PX4_ISFINITE(_pos_sp_triplet.current.vx) &&
-				      PX4_ISFINITE(_pos_sp_triplet.current.vy) &&
-				      _pos_sp_triplet.current.velocity_valid;
-
-		// do not go slower than the follow target velocity when position tracking is active (set to valid)
-
-		if (_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_FOLLOW_TARGET &&
-		    velocity_valid &&
-		    _pos_sp_triplet.current.position_valid) {
-
-			math::Vector<3> ft_vel(_pos_sp_triplet.current.vx, _pos_sp_triplet.current.vy, 0);
-
-			float cos_ratio = (ft_vel * _vel_sp) / (ft_vel.length() * _vel_sp.length());
-
-			// only override velocity set points when uav is traveling in same direction as target and vector component
-			// is greater than calculated position set point velocity component
-
-			if (cos_ratio > 0) {
-				ft_vel *= (cos_ratio);
-				// min speed a little faster than target vel
-				ft_vel += ft_vel.normalized() * 1.5f;
-
-			} else {
-				ft_vel.zero();
-			}
-
-			_vel_sp(0) = fabs(ft_vel(0)) > fabs(_vel_sp(0)) ? ft_vel(0) : _vel_sp(0);
-			_vel_sp(1) = fabs(ft_vel(1)) > fabs(_vel_sp(1)) ? ft_vel(1) : _vel_sp(1);
-
-			// track target using velocity only
-
-		} else if (_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_FOLLOW_TARGET &&
-			   velocity_valid) {
-
-			_vel_sp(0) = _pos_sp_triplet.current.vx;
-			_vel_sp(1) = _pos_sp_triplet.current.vy;
-		}
-
-		if (_run_alt_control) {
-			_vel_sp(2) = (_pos_sp(2) - _pos(2)) * _params.pos_p(2);
-		}
-
-		/* make sure velocity setpoint is saturated in xy*/
-		float vel_norm_xy = sqrtf(_vel_sp(0) * _vel_sp(0) +
-					  _vel_sp(1) * _vel_sp(1));
-
-		if (vel_norm_xy > _params.vel_max(0)) {
-			/* note assumes vel_max(0) == vel_max(1) */
-			_vel_sp(0) = _vel_sp(0) * _params.vel_max(0) / vel_norm_xy;
-			_vel_sp(1) = _vel_sp(1) * _params.vel_max(1) / vel_norm_xy;
-		}
-
-		/* make sure velocity setpoint is saturated in z*/
-		if (_vel_sp(2) < -1.0f * _params.vel_max_up) {
-			_vel_sp(2) = -1.0f * _params.vel_max_up;
-		}
-
-		if (_vel_sp(2) >  _params.vel_max_down) {
-			_vel_sp(2) = _params.vel_max_down;
-		}
-
-		if (!_control_mode.flag_control_position_enabled) {
-			_reset_pos_sp = true;
-		}
-
-		if (!_control_mode.flag_control_altitude_enabled) {
-			_reset_alt_sp = true;
-		}
-
-		if (!_control_mode.flag_control_velocity_enabled) {
-			_vel_sp_prev(0) = _vel(0);
-			_vel_sp_prev(1) = _vel(1);
-			_vel_sp(0) = 0.0f;
-			_vel_sp(1) = 0.0f;
-			control_vel_enabled_prev = false;
-		}
-
-		if (!_control_mode.flag_control_climb_rate_enabled) {
-			_vel_sp(2) = 0.0f;
-		}
-
-		/* use constant descend rate when landing, ignore altitude setpoint */
-		if (!_control_mode.flag_control_manual_enabled && _pos_sp_triplet.current.valid
-		    && _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
-			_vel_sp(2) = _params.land_speed;
-		}
-
-		/* special thrust setpoint generation for takeoff from ground */
-		if (!_control_mode.flag_control_manual_enabled && _pos_sp_triplet.current.valid
-		    && _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF
-		    && _control_mode.flag_armed) {
-
-			// check if we are not already in air.
-			// if yes then we don't need a jumped takeoff anymore
-			if (!_takeoff_jumped && !_vehicle_land_detected.landed && fabsf(_takeoff_thrust_sp) < FLT_EPSILON) {
-				_takeoff_jumped = true;
-			}
-
-			if (!_takeoff_jumped) {
-				// ramp thrust setpoint up
-				if (_vel(2) > -(_params.tko_speed / 2.0f)) {
-					_takeoff_thrust_sp += 0.5f * dt;
-					_vel_sp.zero();
-					_vel_prev.zero();
-
-				} else {
-					// copter has reached our takeoff speed. split the thrust setpoint up
-					// into an integral part and into a P part
-					_thrust_int(2) = _takeoff_thrust_sp - _params.vel_p(2) * fabsf(_vel(2));
-					_thrust_int(2) = -math::constrain(_thrust_int(2), _params.thr_min, _params.thr_max);
-					_vel_sp_prev(2) = -_params.tko_speed;
-					_takeoff_jumped = true;
-					_reset_int_z = false;
-				}
-			}
-
-			if (_takeoff_jumped) {
-				_vel_sp(2) = -_params.tko_speed;
-			}
-
-		} else {
-			_takeoff_jumped = false;
-			_takeoff_thrust_sp = 0.0f;
-		}
-
-		// limit total horizontal acceleration
-		math::Vector<2> acc_hor;
-		acc_hor(0) = (_vel_sp(0) - _vel_sp_prev(0)) / dt;
-		acc_hor(1) = (_vel_sp(1) - _vel_sp_prev(1)) / dt;
-
-		if ((acc_hor.length() > _params.acc_hor_max) & !_reset_pos_sp) {
-			acc_hor.normalize();
-			acc_hor *= _params.acc_hor_max;
-			math::Vector<2> vel_sp_hor_prev(_vel_sp_prev(0), _vel_sp_prev(1));
-			math::Vector<2> vel_sp_hor = acc_hor * dt + vel_sp_hor_prev;
-			_vel_sp(0) = vel_sp_hor(0);
-			_vel_sp(1) = vel_sp_hor(1);
-		}
-
-		// limit vertical acceleration
-		float acc_v = (_vel_sp(2) - _vel_sp_prev(2)) / dt;
-
-		if ((fabsf(acc_v) > 2 * _params.acc_hor_max) & !_reset_alt_sp) {
-			acc_v /= fabsf(acc_v);
-			_vel_sp(2) = acc_v * 2 * _params.acc_hor_max * dt + _vel_sp_prev(2);
-		}
-
-		_vel_sp_prev = _vel_sp;
-
-		_global_vel_sp.vx = _vel_sp(0);
-		_global_vel_sp.vy = _vel_sp(1);
-		_global_vel_sp.vz = _vel_sp(2);
-
-		/* publish velocity setpoint */
-		if (_global_vel_sp_pub != nullptr) {
-			orb_publish(ORB_ID(vehicle_global_velocity_setpoint), _global_vel_sp_pub, &_global_vel_sp);
-
-		} else {
-			_global_vel_sp_pub = orb_advertise(ORB_ID(vehicle_global_velocity_setpoint), &_global_vel_sp);
-		}
-
-		if (_control_mode.flag_control_climb_rate_enabled || _control_mode.flag_control_velocity_enabled ||
-		    _control_mode.flag_control_acceleration_enabled) {
-			/* reset integrals if needed */
-			if (_control_mode.flag_control_climb_rate_enabled) {
-				if (_reset_int_z) {
-					_reset_int_z = false;
-					float i = _params.thr_min;
-
-					if (_reset_int_z_manual) {
-						i = _params.thr_hover;
-
-						if (i < _params.thr_min) {
-							i = _params.thr_min;
-
-						} else if (i > _params.thr_max) {
-							i = _params.thr_max;
-						}
-					}
-
-					_thrust_int(2) = -i;
-				}
-
-			} else {
-				_reset_int_z = true;
-			}
-
-			if (_control_mode.flag_control_velocity_enabled) {
-				if (_reset_int_xy) {
-					_reset_int_xy = false;
-					_thrust_int(0) = 0.0f;
-					_thrust_int(1) = 0.0f;
-				}
-
-			} else {
-				_reset_int_xy = true;
-			}
-
-			/* velocity error */
-			math::Vector<3> vel_err = _vel_sp - _vel;
-
-			// check if we have switched from a non-velocity controlled mode into a velocity controlled mode
-			// if yes, then correct xy velocity setpoint such that the attitude setpoint is continuous
-			if (!control_vel_enabled_prev && _control_mode.flag_control_velocity_enabled) {
-
-				matrix::Dcmf Rb = matrix::Quatf(_att_sp.q_d[0], _att_sp.q_d[1], _att_sp.q_d[2], _att_sp.q_d[3]);
-
-				// choose velocity xyz setpoint such that the resulting thrust setpoint has the direction
-				// given by the last attitude setpoint
-				_vel_sp(0) = _vel(0) + (-Rb(0,
-							    2) * _att_sp.thrust - _thrust_int(0) - _vel_err_d(0) * _params.vel_d(0)) / _params.vel_p(0);
-				_vel_sp(1) = _vel(1) + (-Rb(1,
-							    2) * _att_sp.thrust - _thrust_int(1) - _vel_err_d(1) * _params.vel_d(1)) / _params.vel_p(1);
-				_vel_sp(2) = _vel(2) + (-Rb(2,
-							    2) * _att_sp.thrust - _thrust_int(2) - _vel_err_d(2) * _params.vel_d(2)) / _params.vel_p(2);
-				_vel_sp_prev(0) = _vel_sp(0);
-				_vel_sp_prev(1) = _vel_sp(1);
-				_vel_sp_prev(2) = _vel_sp(2);
-				control_vel_enabled_prev = true;
-
-				// compute updated velocity error
-				vel_err = _vel_sp - _vel;
-			}
-
-			/* thrust vector in NED frame */
-			math::Vector<3> thrust_sp;
-
-			if (_control_mode.flag_control_acceleration_enabled && _pos_sp_triplet.current.acceleration_valid) {
-				thrust_sp = math::Vector<3>(_pos_sp_triplet.current.a_x, _pos_sp_triplet.current.a_y, _pos_sp_triplet.current.a_z);
-
-			} else {
-				thrust_sp = vel_err.emult(_params.vel_p) + _vel_err_d.emult(_params.vel_d) + _thrust_int;
-			}
-
-			if (_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF
-			    && !_takeoff_jumped && !_control_mode.flag_control_manual_enabled) {
-				// for jumped takeoffs use special thrust setpoint calculated above
-				thrust_sp.zero();
-				thrust_sp(2) = -_takeoff_thrust_sp;
-			}
-
-			if (!_control_mode.flag_control_velocity_enabled && !_control_mode.flag_control_acceleration_enabled) {
-				thrust_sp(0) = 0.0f;
-				thrust_sp(1) = 0.0f;
-			}
-
-			if (!_control_mode.flag_control_climb_rate_enabled && !_control_mode.flag_control_acceleration_enabled) {
-				thrust_sp(2) = 0.0f;
-			}
-
-			/* limit thrust vector and check for saturation */
-			bool saturation_xy = false;
-			bool saturation_z = false;
-
-			/* limit min lift */
-			float thr_min = _params.thr_min;
-
-			if (!_control_mode.flag_control_velocity_enabled && thr_min < 0.0f) {
-				/* don't allow downside thrust direction in manual attitude mode */
-				thr_min = 0.0f;
-			}
-
-			float thrust_abs = thrust_sp.length();
-			float tilt_max = _params.tilt_max_air;
-			float thr_max = _params.thr_max;
-			/* filter vel_z over 1/8sec */
-			_vel_z_lp = _vel_z_lp * (1.0f - dt * 8.0f) + dt * 8.0f * _vel(2);
-			/* filter vel_z change over 1/8sec */
-			float vel_z_change = (_vel(2) - _vel_prev(2)) / dt;
-			_acc_z_lp = _acc_z_lp * (1.0f - dt * 8.0f) + dt * 8.0f * vel_z_change;
-
-			/* adjust limits for landing mode */
-			if (!_control_mode.flag_control_manual_enabled && _pos_sp_triplet.current.valid &&
-			    _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
-				/* limit max tilt and min lift when landing */
-				tilt_max = _params.tilt_max_land;
-
-				if (thr_min < 0.0f) {
-					thr_min = 0.0f;
-				}
-
-				/* descend stabilized, we're landing */
-				if (!_in_landing && !_lnd_reached_ground
-				    && (float)fabs(_acc_z_lp) < 0.1f
-				    && _vel_z_lp > 0.5f * _params.land_speed) {
-					_in_landing = true;
-				}
-
-				/* assume ground, cut thrust */
-				if (_in_landing
-				    && _vel_z_lp < 0.1f) {
-					thr_max = 0.0f;
-					_in_landing = false;
-					_lnd_reached_ground = true;
-				}
-
-				/* once we assumed to have reached the ground always cut the thrust.
-					Only free fall detection below can revoke this
-				*/
-				if (!_in_landing && _lnd_reached_ground) {
-					thr_max = 0.0f;
-				}
-
-				/* if we suddenly fall, reset landing logic and remove thrust limit */
-				if (_lnd_reached_ground
-				    /* XXX: magic value, assuming free fall above 4m/s2 acceleration */
-				    && (_acc_z_lp > 4.0f
-					|| _vel_z_lp > 2.0f * _params.land_speed)) {
-					thr_max = _params.thr_max;
-					_in_landing = false;
-					_lnd_reached_ground = false;
-				}
-
-			} else {
-				_in_landing = false;
-				_lnd_reached_ground = false;
-			}
-
-			/* limit min lift */
-			if (-thrust_sp(2) < thr_min) {
-				thrust_sp(2) = -thr_min;
-				saturation_z = true;
-			}
-
-			if (_control_mode.flag_control_velocity_enabled || _control_mode.flag_control_acceleration_enabled) {
-
-				/* limit max tilt */
-				if (thr_min >= 0.0f && tilt_max < M_PI_F / 2 - 0.05f) {
-					/* absolute horizontal thrust */
-					float thrust_sp_xy_len = math::Vector<2>(thrust_sp(0), thrust_sp(1)).length();
-
-					if (thrust_sp_xy_len > 0.01f) {
-						/* max horizontal thrust for given vertical thrust*/
-						float thrust_xy_max = -thrust_sp(2) * tanf(tilt_max);
-
-						if (thrust_sp_xy_len > thrust_xy_max) {
-							float k = thrust_xy_max / thrust_sp_xy_len;
-							thrust_sp(0) *= k;
-							thrust_sp(1) *= k;
-							saturation_xy = true;
-						}
+		_takeoff_jumped = false;
+		_takeoff_thrust_sp = 0.0f;
+	}
+
+	// limit total horizontal acceleration
+	math::Vector<2> acc_hor;
+	acc_hor(0) = (_vel_sp(0) - _vel_sp_prev(0)) / dt;
+	acc_hor(1) = (_vel_sp(1) - _vel_sp_prev(1)) / dt;
+
+	if (acc_hor.length() > _params.acc_hor_max) {
+		acc_hor.normalize();
+		acc_hor *= _params.acc_hor_max;
+		math::Vector<2> vel_sp_hor_prev(_vel_sp_prev(0), _vel_sp_prev(1));
+		math::Vector<2> vel_sp_hor = acc_hor * dt + vel_sp_hor_prev;
+		_vel_sp(0) = vel_sp_hor(0);
+		_vel_sp(1) = vel_sp_hor(1);
+	}
+
+	// limit vertical acceleration
+	float acc_v = (_vel_sp(2) - _vel_sp_prev(2)) / dt;
+
+	if (fabsf(acc_v) > 2 * _params.acc_hor_max) {
+		acc_v /= fabsf(acc_v);
+		_vel_sp(2) = acc_v * 2 * _params.acc_hor_max * dt + _vel_sp_prev(2);
+	}
+
+	_vel_sp_prev = _vel_sp;
+
+	_global_vel_sp.vx = _vel_sp(0);
+	_global_vel_sp.vy = _vel_sp(1);
+	_global_vel_sp.vz = _vel_sp(2);
+
+	/* publish velocity setpoint */
+	if (_global_vel_sp_pub != nullptr) {
+		orb_publish(ORB_ID(vehicle_global_velocity_setpoint), _global_vel_sp_pub, &_global_vel_sp);
+
+	} else {
+		_global_vel_sp_pub = orb_advertise(ORB_ID(vehicle_global_velocity_setpoint), &_global_vel_sp);
+	}
+
+	if (_control_mode.flag_control_climb_rate_enabled || _control_mode.flag_control_velocity_enabled ||
+	    _control_mode.flag_control_acceleration_enabled) {
+		/* reset integrals if needed */
+		if (_control_mode.flag_control_climb_rate_enabled) {
+			if (_reset_int_z) {
+				_reset_int_z = false;
+				float i = _params.thr_min;
+
+				if (_reset_int_z_manual) {
+					i = _params.thr_hover;
+
+					if (i < _params.thr_min) {
+						i = _params.thr_min;
+
+					} else if (i > _params.thr_max) {
+						i = _params.thr_max;
 					}
 				}
+
+				_thrust_int(2) = -i;
 			}
-
-			if (_control_mode.flag_control_climb_rate_enabled && !_control_mode.flag_control_velocity_enabled) {
-				/* thrust compensation for altitude only control modes */
-				float att_comp;
-
-				if (_R(2, 2) > TILT_COS_MAX) {
-					att_comp = 1.0f / _R(2, 2);
-
-				} else if (_R(2, 2) > 0.0f) {
-					att_comp = ((1.0f / TILT_COS_MAX - 1.0f) / TILT_COS_MAX) * _R(2, 2) + 1.0f;
-					saturation_z = true;
-
-				} else {
-					att_comp = 1.0f;
-					saturation_z = true;
-				}
-
-				thrust_sp(2) *= att_comp;
-			}
-
-			/* limit max thrust */
-			thrust_abs = thrust_sp.length(); /* recalculate because it might have changed */
-
-			if (thrust_abs > thr_max) {
-				if (thrust_sp(2) < 0.0f) {
-					if (-thrust_sp(2) > thr_max) {
-						/* thrust Z component is too large, limit it */
-						thrust_sp(0) = 0.0f;
-						thrust_sp(1) = 0.0f;
-						thrust_sp(2) = -thr_max;
-						saturation_xy = true;
-						saturation_z = true;
-
-					} else {
-						/* preserve thrust Z component and lower XY, keeping altitude is more important than position */
-						float thrust_xy_max = sqrtf(thr_max * thr_max - thrust_sp(2) * thrust_sp(2));
-						float thrust_xy_abs = math::Vector<2>(thrust_sp(0), thrust_sp(1)).length();
-						float k = thrust_xy_max / thrust_xy_abs;
-						thrust_sp(0) *= k;
-						thrust_sp(1) *= k;
-						saturation_xy = true;
-					}
-
-				} else {
-					/* Z component is negative, going down, simply limit thrust vector */
-					float k = thr_max / thrust_abs;
-					thrust_sp *= k;
-					saturation_xy = true;
-					saturation_z = true;
-				}
-
-				thrust_abs = thr_max;
-			}
-
-			/* update integrals */
-			if (_control_mode.flag_control_velocity_enabled && !saturation_xy) {
-				_thrust_int(0) += vel_err(0) * _params.vel_i(0) * dt;
-				_thrust_int(1) += vel_err(1) * _params.vel_i(1) * dt;
-			}
-
-			if (_control_mode.flag_control_climb_rate_enabled && !saturation_z) {
-				_thrust_int(2) += vel_err(2) * _params.vel_i(2) * dt;
-
-				/* protection against flipping on ground when landing */
-				if (_thrust_int(2) > 0.0f) {
-					_thrust_int(2) = 0.0f;
-				}
-			}
-
-			/* calculate attitude setpoint from thrust vector */
-			if (_control_mode.flag_control_velocity_enabled || _control_mode.flag_control_acceleration_enabled) {
-				/* desired body_z axis = -normalize(thrust_vector) */
-				math::Vector<3> body_x;
-				math::Vector<3> body_y;
-				math::Vector<3> body_z;
-
-				if (thrust_abs > SIGMA) {
-					body_z = -thrust_sp / thrust_abs;
-
-				} else {
-					/* no thrust, set Z axis to safe value */
-					body_z.zero();
-					body_z(2) = 1.0f;
-				}
-
-				/* vector of desired yaw direction in XY plane, rotated by PI/2 */
-				math::Vector<3> y_C(-sinf(_att_sp.yaw_body), cosf(_att_sp.yaw_body), 0.0f);
-
-				if (fabsf(body_z(2)) > SIGMA) {
-					/* desired body_x axis, orthogonal to body_z */
-					body_x = y_C % body_z;
-
-					/* keep nose to front while inverted upside down */
-					if (body_z(2) < 0.0f) {
-						body_x = -body_x;
-					}
-
-					body_x.normalize();
-
-				} else {
-					/* desired thrust is in XY plane, set X downside to construct correct matrix,
-					 * but yaw component will not be used actually */
-					body_x.zero();
-					body_x(2) = 1.0f;
-				}
-
-				/* desired body_y axis */
-				body_y = body_z % body_x;
-
-				/* fill rotation matrix */
-				for (int i = 0; i < 3; i++) {
-					_R_setpoint(i, 0) = body_x(i);
-					_R_setpoint(i, 1) = body_y(i);
-					_R_setpoint(i, 2) = body_z(i);
-				}
-
-				/* copy quaternion setpoint to attitude setpoint topic */
-				matrix::Quatf q_sp = _R_setpoint;
-				memcpy(&_att_sp.q_d[0], q_sp.data(), sizeof(_att_sp.q_d));
-				_att_sp.q_d_valid = true;
-
-				/* calculate euler angles, for logging only, must not be used for control */
-				matrix::Eulerf euler = _R_setpoint;
-				_att_sp.roll_body = euler(0);
-				_att_sp.pitch_body = euler(1);
-				/* yaw already used to construct rot matrix, but actual rotation matrix can have different yaw near singularity */
-
-			} else if (!_control_mode.flag_control_manual_enabled) {
-				/* autonomous altitude control without position control (failsafe landing),
-				 * force level attitude, don't change yaw */
-				_R_setpoint = matrix::Eulerf(0.0f, 0.0f, _att_sp.yaw_body);
-
-				/* copy quaternion setpoint to attitude setpoint topic */
-				matrix::Quatf q_sp = _R_setpoint;
-				memcpy(&_att_sp.q_d[0], q_sp.data(), sizeof(_att_sp.q_d));
-				_att_sp.q_d_valid = true;
-
-				_att_sp.roll_body = 0.0f;
-				_att_sp.pitch_body = 0.0f;
-			}
-
-			_att_sp.thrust = thrust_abs;
-
-			/* save thrust setpoint for logging */
-			_local_pos_sp.acc_x = thrust_sp(0) * ONE_G;
-			_local_pos_sp.acc_y = thrust_sp(1) * ONE_G;
-			_local_pos_sp.acc_z = thrust_sp(2) * ONE_G;
-
-			_att_sp.timestamp = hrt_absolute_time();
-
 
 		} else {
 			_reset_int_z = true;
 		}
-	}
 
-	/* fill local position, velocity and thrust setpoint */
-	_local_pos_sp.timestamp = hrt_absolute_time();
-	_local_pos_sp.x = _pos_sp(0);
-	_local_pos_sp.y = _pos_sp(1);
-	_local_pos_sp.z = _pos_sp(2);
-	_local_pos_sp.yaw = _att_sp.yaw_body;
-	_local_pos_sp.vx = _vel_sp(0);
-	_local_pos_sp.vy = _vel_sp(1);
-	_local_pos_sp.vz = _vel_sp(2);
+		if (_control_mode.flag_control_velocity_enabled) {
+			if (_reset_int_xy) {
+				_reset_int_xy = false;
+				_thrust_int(0) = 0.0f;
+				_thrust_int(1) = 0.0f;
+			}
 
-	/* publish local position setpoint */
-	if (_local_pos_sp_pub != nullptr) {
-		orb_publish(ORB_ID(vehicle_local_position_setpoint), _local_pos_sp_pub, &_local_pos_sp);
+		} else {
+			_reset_int_xy = true;
+		}
+
+		/* velocity error */
+		math::Vector<3> vel_err = _vel_sp - _vel;
+
+		// check if we have switched from a non-velocity controlled mode into a velocity controlled mode
+		// if yes, then correct xy velocity setpoint such that the attitude setpoint is continuous
+		if (!control_vel_enabled_prev && _control_mode.flag_control_velocity_enabled) {
+
+			matrix::Dcmf Rb = matrix::Quatf(_att_sp.q_d[0], _att_sp.q_d[1], _att_sp.q_d[2], _att_sp.q_d[3]);
+
+			// choose velocity xyz setpoint such that the resulting thrust setpoint has the direction
+			// given by the last attitude setpoint
+			_vel_sp(0) = _vel(0) + (-Rb(0,
+						    2) * _att_sp.thrust - _thrust_int(0) - _vel_err_d(0) * _params.vel_d(0)) / _params.vel_p(0);
+			_vel_sp(1) = _vel(1) + (-Rb(1,
+						    2) * _att_sp.thrust - _thrust_int(1) - _vel_err_d(1) * _params.vel_d(1)) / _params.vel_p(1);
+			_vel_sp(2) = _vel(2) + (-Rb(2,
+						    2) * _att_sp.thrust - _thrust_int(2) - _vel_err_d(2) * _params.vel_d(2)) / _params.vel_p(2);
+			_vel_sp_prev(0) = _vel_sp(0);
+			_vel_sp_prev(1) = _vel_sp(1);
+			_vel_sp_prev(2) = _vel_sp(2);
+			control_vel_enabled_prev = true;
+
+			// compute updated velocity error
+			vel_err = _vel_sp - _vel;
+		}
+
+		/* thrust vector in NED frame */
+		math::Vector<3> thrust_sp;
+
+		if (_control_mode.flag_control_acceleration_enabled && _pos_sp_triplet.current.acceleration_valid) {
+			thrust_sp = math::Vector<3>(_pos_sp_triplet.current.a_x, _pos_sp_triplet.current.a_y, _pos_sp_triplet.current.a_z);
+
+		} else {
+			thrust_sp = vel_err.emult(_params.vel_p) + _vel_err_d.emult(_params.vel_d) + _thrust_int;
+		}
+
+		if (_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF
+		    && !_takeoff_jumped && !_control_mode.flag_control_manual_enabled) {
+			// for jumped takeoffs use special thrust setpoint calculated above
+			thrust_sp.zero();
+			thrust_sp(2) = -_takeoff_thrust_sp;
+		}
+
+		if (!_control_mode.flag_control_velocity_enabled && !_control_mode.flag_control_acceleration_enabled) {
+			thrust_sp(0) = 0.0f;
+			thrust_sp(1) = 0.0f;
+		}
+
+		if (!_control_mode.flag_control_climb_rate_enabled && !_control_mode.flag_control_acceleration_enabled) {
+			thrust_sp(2) = 0.0f;
+		}
+
+		/* limit thrust vector and check for saturation */
+		bool saturation_xy = false;
+		bool saturation_z = false;
+
+		/* limit min lift */
+		float thr_min = _params.thr_min;
+
+		if (!_control_mode.flag_control_velocity_enabled && thr_min < 0.0f) {
+			/* don't allow downside thrust direction in manual attitude mode */
+			thr_min = 0.0f;
+		}
+
+		float thrust_abs = thrust_sp.length();
+		float tilt_max = _params.tilt_max_air;
+		float thr_max = _params.thr_max;
+		/* filter vel_z over 1/8sec */
+		_vel_z_lp = _vel_z_lp * (1.0f - dt * 8.0f) + dt * 8.0f * _vel(2);
+		/* filter vel_z change over 1/8sec */
+		float vel_z_change = (_vel(2) - _vel_prev(2)) / dt;
+		_acc_z_lp = _acc_z_lp * (1.0f - dt * 8.0f) + dt * 8.0f * vel_z_change;
+
+		/* adjust limits for landing mode */
+		if (!_control_mode.flag_control_manual_enabled && _pos_sp_triplet.current.valid &&
+		    _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
+			/* limit max tilt and min lift when landing */
+			tilt_max = _params.tilt_max_land;
+
+			if (thr_min < 0.0f) {
+				thr_min = 0.0f;
+			}
+
+			/* descend stabilized, we're landing */
+			if (!_in_landing && !_lnd_reached_ground
+			    && (float)fabs(_acc_z_lp) < 0.1f
+			    && _vel_z_lp > 0.5f * _params.land_speed) {
+				_in_landing = true;
+			}
+
+			/* assume ground, cut thrust */
+			if (_in_landing
+			    && _vel_z_lp < 0.1f) {
+				thr_max = 0.0f;
+				_in_landing = false;
+				_lnd_reached_ground = true;
+			}
+
+			/* once we assumed to have reached the ground always cut the thrust.
+				Only free fall detection below can revoke this
+			*/
+			if (!_in_landing && _lnd_reached_ground) {
+				thr_max = 0.0f;
+			}
+
+			/* if we suddenly fall, reset landing logic and remove thrust limit */
+			if (_lnd_reached_ground
+			    /* XXX: magic value, assuming free fall above 4m/s2 acceleration */
+			    && (_acc_z_lp > 4.0f
+				|| _vel_z_lp > 2.0f * _params.land_speed)) {
+				thr_max = _params.thr_max;
+				_in_landing = false;
+				_lnd_reached_ground = false;
+			}
+
+		} else {
+			_in_landing = false;
+			_lnd_reached_ground = false;
+		}
+
+		/* limit min lift */
+		if (-thrust_sp(2) < thr_min) {
+			thrust_sp(2) = -thr_min;
+			saturation_z = true;
+		}
+
+		if (_control_mode.flag_control_velocity_enabled || _control_mode.flag_control_acceleration_enabled) {
+
+			/* limit max tilt */
+			if (thr_min >= 0.0f && tilt_max < M_PI_F / 2 - 0.05f) {
+				/* absolute horizontal thrust */
+				float thrust_sp_xy_len = math::Vector<2>(thrust_sp(0), thrust_sp(1)).length();
+
+				if (thrust_sp_xy_len > 0.01f) {
+					/* max horizontal thrust for given vertical thrust*/
+					float thrust_xy_max = -thrust_sp(2) * tanf(tilt_max);
+
+					if (thrust_sp_xy_len > thrust_xy_max) {
+						float k = thrust_xy_max / thrust_sp_xy_len;
+						thrust_sp(0) *= k;
+						thrust_sp(1) *= k;
+						saturation_xy = true;
+					}
+				}
+			}
+		}
+
+		if (_control_mode.flag_control_climb_rate_enabled && !_control_mode.flag_control_velocity_enabled) {
+			/* thrust compensation when vertical velocity but not horizontal velocity is controlled */
+			float att_comp;
+
+			if (_R(2, 2) > TILT_COS_MAX) {
+				att_comp = 1.0f / _R(2, 2);
+
+			} else if (_R(2, 2) > 0.0f) {
+				att_comp = ((1.0f / TILT_COS_MAX - 1.0f) / TILT_COS_MAX) * _R(2, 2) + 1.0f;
+				saturation_z = true;
+
+			} else {
+				att_comp = 1.0f;
+				saturation_z = true;
+			}
+
+			thrust_sp(2) *= att_comp;
+		}
+
+		/* limit max thrust */
+		thrust_abs = thrust_sp.length(); /* recalculate because it might have changed */
+
+		if (thrust_abs > thr_max) {
+			if (thrust_sp(2) < 0.0f) {
+				if (-thrust_sp(2) > thr_max) {
+					/* thrust Z component is too large, limit it */
+					thrust_sp(0) = 0.0f;
+					thrust_sp(1) = 0.0f;
+					thrust_sp(2) = -thr_max;
+					saturation_xy = true;
+					saturation_z = true;
+
+				} else {
+					/* preserve thrust Z component and lower XY, keeping altitude is more important than position */
+					float thrust_xy_max = sqrtf(thr_max * thr_max - thrust_sp(2) * thrust_sp(2));
+					float thrust_xy_abs = math::Vector<2>(thrust_sp(0), thrust_sp(1)).length();
+					float k = thrust_xy_max / thrust_xy_abs;
+					thrust_sp(0) *= k;
+					thrust_sp(1) *= k;
+					saturation_xy = true;
+				}
+
+			} else {
+				/* Z component is negative, going down, simply limit thrust vector */
+				float k = thr_max / thrust_abs;
+				thrust_sp *= k;
+				saturation_xy = true;
+				saturation_z = true;
+			}
+
+			thrust_abs = thr_max;
+		}
+
+		/* update integrals */
+		if (_control_mode.flag_control_velocity_enabled && !saturation_xy) {
+			_thrust_int(0) += vel_err(0) * _params.vel_i(0) * dt;
+			_thrust_int(1) += vel_err(1) * _params.vel_i(1) * dt;
+		}
+
+		if (_control_mode.flag_control_climb_rate_enabled && !saturation_z) {
+			_thrust_int(2) += vel_err(2) * _params.vel_i(2) * dt;
+
+			/* protection against flipping on ground when landing */
+			if (_thrust_int(2) > 0.0f) {
+				_thrust_int(2) = 0.0f;
+			}
+		}
+
+		/* calculate attitude setpoint from thrust vector */
+		if (_control_mode.flag_control_velocity_enabled || _control_mode.flag_control_acceleration_enabled) {
+			/* desired body_z axis = -normalize(thrust_vector) */
+			math::Vector<3> body_x;
+			math::Vector<3> body_y;
+			math::Vector<3> body_z;
+
+			if (thrust_abs > SIGMA) {
+				body_z = -thrust_sp / thrust_abs;
+
+			} else {
+				/* no thrust, set Z axis to safe value */
+				body_z.zero();
+				body_z(2) = 1.0f;
+			}
+
+			/* vector of desired yaw direction in XY plane, rotated by PI/2 */
+			math::Vector<3> y_C(-sinf(_att_sp.yaw_body), cosf(_att_sp.yaw_body), 0.0f);
+
+			if (fabsf(body_z(2)) > SIGMA) {
+				/* desired body_x axis, orthogonal to body_z */
+				body_x = y_C % body_z;
+
+				/* keep nose to front while inverted upside down */
+				if (body_z(2) < 0.0f) {
+					body_x = -body_x;
+				}
+
+				body_x.normalize();
+
+			} else {
+				/* desired thrust is in XY plane, set X downside to construct correct matrix,
+				 * but yaw component will not be used actually */
+				body_x.zero();
+				body_x(2) = 1.0f;
+			}
+
+			/* desired body_y axis */
+			body_y = body_z % body_x;
+
+			/* fill rotation matrix */
+			for (int i = 0; i < 3; i++) {
+				_R_setpoint(i, 0) = body_x(i);
+				_R_setpoint(i, 1) = body_y(i);
+				_R_setpoint(i, 2) = body_z(i);
+			}
+
+			/* copy quaternion setpoint to attitude setpoint topic */
+			matrix::Quatf q_sp = _R_setpoint;
+			memcpy(&_att_sp.q_d[0], q_sp.data(), sizeof(_att_sp.q_d));
+			_att_sp.q_d_valid = true;
+
+			/* calculate euler angles, for logging only, must not be used for control */
+			matrix::Eulerf euler = _R_setpoint;
+			_att_sp.roll_body = euler(0);
+			_att_sp.pitch_body = euler(1);
+			/* yaw already used to construct rot matrix, but actual rotation matrix can have different yaw near singularity */
+
+		} else if (!_control_mode.flag_control_manual_enabled) {
+			/* autonomous altitude control without position control (failsafe landing),
+			 * force level attitude, don't change yaw */
+			_R_setpoint = matrix::Eulerf(0.0f, 0.0f, _att_sp.yaw_body);
+
+			/* copy quaternion setpoint to attitude setpoint topic */
+			matrix::Quatf q_sp = _R_setpoint;
+			memcpy(&_att_sp.q_d[0], q_sp.data(), sizeof(_att_sp.q_d));
+			_att_sp.q_d_valid = true;
+
+			_att_sp.roll_body = 0.0f;
+			_att_sp.pitch_body = 0.0f;
+		}
+
+		_att_sp.thrust = thrust_abs;
+
+		/* save thrust setpoint for logging */
+		_local_pos_sp.acc_x = thrust_sp(0) * ONE_G;
+		_local_pos_sp.acc_y = thrust_sp(1) * ONE_G;
+		_local_pos_sp.acc_z = thrust_sp(2) * ONE_G;
+
+		_att_sp.timestamp = hrt_absolute_time();
+
 
 	} else {
-		_local_pos_sp_pub = orb_advertise(ORB_ID(vehicle_local_position_setpoint), &_local_pos_sp);
+		_reset_int_z = true;
 	}
 }
 
@@ -2192,7 +2195,25 @@ MulticopterPositionControl::task_main()
 		    _control_mode.flag_control_velocity_enabled ||
 		    _control_mode.flag_control_acceleration_enabled) {
 
-			do_position_control(dt);
+			do_control(dt);
+
+			/* fill local position, velocity and thrust setpoint */
+			_local_pos_sp.timestamp = hrt_absolute_time();
+			_local_pos_sp.x = _pos_sp(0);
+			_local_pos_sp.y = _pos_sp(1);
+			_local_pos_sp.z = _pos_sp(2);
+			_local_pos_sp.yaw = _att_sp.yaw_body;
+			_local_pos_sp.vx = _vel_sp(0);
+			_local_pos_sp.vy = _vel_sp(1);
+			_local_pos_sp.vz = _vel_sp(2);
+
+			/* publish local position setpoint */
+			if (_local_pos_sp_pub != nullptr) {
+				orb_publish(ORB_ID(vehicle_local_position_setpoint), _local_pos_sp_pub, &_local_pos_sp);
+
+			} else {
+				_local_pos_sp_pub = orb_advertise(ORB_ID(vehicle_local_position_setpoint), &_local_pos_sp);
+			}
 
 		} else {
 			/* position controller disabled, reset setpoints */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1875,7 +1875,7 @@ MulticopterPositionControl::control_position(float dt)
 			    && (_acc_z_lp > 4.0f
 				|| _vel_z_lp > 2.0f * _params.land_speed)) {
 				thr_max = _params.thr_max;
-				_in_landing = false;
+				_in_landing = true;
 				_lnd_reached_ground = false;
 			}
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1123,6 +1123,7 @@ MulticopterPositionControl::control_non_manual(float dt)
 	if (_pos_sp_triplet.current.valid
 	    && _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
 		_vel_sp(2) = _params.land_speed;
+		_run_alt_control = false;
 	}
 
 	/* special thrust setpoint generation for takeoff from ground */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1825,10 +1825,12 @@ MulticopterPositionControl::control_position(float dt)
 		float vel_z_change = (_vel(2) - _vel_prev(2)) / dt;
 		_acc_z_lp = _acc_z_lp * (1.0f - dt * 8.0f) + dt * 8.0f * vel_z_change;
 
-		// We can only run the control if we're already in-air or have a takeoff setpoint.
+		// We can only run the control if we're already in-air, have a takeoff setpoint,
+		// or if we're in offboard control.
 		// Otherwise, we should just bail out
 		const bool got_takeoff_setpoint = (_pos_sp_triplet.current.valid &&
-						   _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF);
+						   _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF) ||
+						  _control_mode.flag_control_offboard_enabled;
 
 		if (_vehicle_land_detected.landed && !got_takeoff_setpoint) {
 			// Keep throttle low while still on ground.


### PR DESCRIPTION
This PR contains the following:

- Refactor of mc_pos_control: mainly code is moved around and put into smaller functions, no real functional changes should come from this.
- The state_machine_helper gives better feedback in case of offboard loss (instead of saying "rc lost" it actually informs about offboard lost).
- If velocity offboard control is used, it makes sense to lock/hold
position if the velocity input is 0. If this is not done, we will slowly
drift because nothing is integrating to keep the UAV at its position.

Tested in SITL. @Stifael please review commit by commit.