### PR TITLE
Fix threading problem in mavlink_parameters.cpp

### DIFF
--- a/src/modules/mavlink/mavlink_bridge_header.h
+++ b/src/modules/mavlink/mavlink_bridge_header.h
@@ -47,12 +47,12 @@
 /* use efficient approach, see mavlink_helpers.h */
 #define MAVLINK_SEND_UART_BYTES mavlink_send_uart_bytes
 
+#define MAVLINK_START_UART_SEND mavlink_start_uart_send
 #define MAVLINK_END_UART_SEND mavlink_end_uart_send
 
 #define MAVLINK_GET_CHANNEL_BUFFER mavlink_get_channel_buffer
 #define MAVLINK_GET_CHANNEL_STATUS mavlink_get_channel_status
 
-#include <stdbool.h>			// Needs to be included before v2.0/mavlink_types.h until https://github.com/ArduPilot/pymavlink/pull/22 makes it through.
 #include <v2.0/mavlink_types.h>
 #include <unistd.h>
 
@@ -78,6 +78,7 @@ extern mavlink_system_t mavlink_system;
  */
 void mavlink_send_uart_bytes(mavlink_channel_t chan, const uint8_t *ch, int length);
 
+void mavlink_start_uart_send(mavlink_channel_t chan, int length);
 void mavlink_end_uart_send(mavlink_channel_t chan, int length);
 
 extern mavlink_status_t *mavlink_get_channel_status(uint8_t chan);

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -171,11 +171,10 @@ public:
 		BROADCAST_MODE_ON
 	};
 
-	static const char *mavlink_mode_str(enum MAVLINK_MODE mode)
-	{
+	static const char *mavlink_mode_str(enum MAVLINK_MODE mode) {
 		switch (mode) {
 		case MAVLINK_MODE_NORMAL:
-			return "Normal";
+				return "Normal";
 
 		case MAVLINK_MODE_CUSTOM:
 			return "Custom";
@@ -273,6 +272,12 @@ public:
 	 */
 	bool			get_manual_input_mode_generation() { return _generate_rc; }
 
+
+	/**
+	 * This is the beginning of a MAVLINK_START_UART_SEND/MAVLINK_END_UART_SEND transaction
+	 */
+	void 			begin_send();
+
 	/**
 	 * Send bytes out on the link.
 	 *
@@ -285,7 +290,7 @@ public:
 	 *
 	 * @return the number of bytes sent or -1 in case of error
 	 */
-	int			send_packet();
+	int             send_packet();
 
 	/**
 	 * Resend message as is, don't change sequence number and CRC.
@@ -440,6 +445,7 @@ public:
 	MavlinkULog		*get_ulog_streaming() { return _mavlink_ulog; }
 	void			try_start_ulog_streaming(uint8_t target_system, uint8_t target_component) {
 		if (_mavlink_ulog) { return; }
+
 		_mavlink_ulog = MavlinkULog::try_start(_datarate, 0.7f, target_system, target_component);
 	}
 	void			request_stop_ulog_streaming() {


### PR DESCRIPTION
The mavlink_parameters::handle_message method was trying to send responses back immediately from the mavlink_receiver::receive_thread.  This conflicts with messages already being sent on the main thread, resulting in random CRC failures, and flakey results from PARAM_REQUEST_READ and PARAM_SET.  The following shows a log of the attempts to read a parameter before this fix:

param get SENS_EN_SF1XX
SENS_EN_SF1XX=4
param get SENS_EN_SF1XX
MavLink message 147, seqno 8c has bad CRC 19 received, expecting 1a6d!
Exception: Parameter 'SENS_EN_SF1XX' not found' 
param get SENS_EN_SF1XX
SENS_EN_SF1XX=4
param get SENS_EN_SF1XX
SENS_EN_SF1XX=4
param get SENS_EN_SF1XX
MavLink message 30, seqno bb has bad CRC 19 received, expecting a7c5!
MavLink message 21, seqno c5 has bad CRC 15 received, expecting ec5f!
Exception: Parameter 'SENS_EN_SF1XX' not found
param get SENS_EN_SF1XX
SENS_EN_SF1XX=4
param get SENS_EN_SF1XX
MavLink message 105, seqno 96 has bad CRC 19 received, expecting 346b!
Exception: Parameter 'SENS_EN_SF1XX' not found
param get SENS_EN_SF1XX
MavLink message 105, seqno 5d has bad CRC 19 received, expecting f1a4!
Exception: Parameter 'SENS_EN_SF1XX' not found
param get SENS_EN_SF1XX
SENS_EN_SF1XX=4

The following shows the result of the fix:

param get SENS_EN_SF1XX
SENS_EN_SF1XX=4
param get SENS_EN_SF1XX
SENS_EN_SF1XX=4
param get SENS_EN_SF1XX
SENS_EN_SF1XX=4
param get SENS_EN_SF1XX
SENS_EN_SF1XX=4
param get SENS_EN_SF1XX
SENS_EN_SF1XX=4
param get SENS_EN_SF1XX
SENS_EN_SF1XX=4
param get SENS_EN_SF1XX
SENS_EN_SF1XX=4
param get SENS_EN_SF1XX
SENS_EN_SF1XX=4
param get SENS_EN_SF1XX
SENS_EN_SF1XX=4
param set SENS_EN_SF1XX 12
setting param SENS_EN_SF1XX to new value 12.000000
success
param get SENS_EN_SF1XX
SENS_EN_SF1XX=12
param get SENS_EN_SF1XX
SENS_EN_SF1XX=12
param get SENS_EN_SF1XX
SENS_EN_SF1XX=12
param set SENS_EN_SF1XX 4
setting param SENS_EN_SF1XX to new value 4.000000
success
param get SENS_EN_SF1XX
SENS_EN_SF1XX=4
param get SENS_EN_SF1XX
SENS_EN_SF1XX=4
param get SENS_EN_SF1XX
SENS_EN_SF1XX=4
