### PR TITLE
Log download: try to use file modification date for log list if it ma…

### DIFF
--- a/src/modules/mavlink/mavlink_log_handler.cpp
+++ b/src/modules/mavlink/mavlink_log_handler.cpp
@@ -534,6 +534,14 @@ bool
 LogListHelper::_get_session_date(const char *path, const char *dir, time_t &date)
 {
 	if (strlen(dir) > 4) {
+		// Always try to get file time first
+		if (stat_file(path, &date)) {
+			// Try to prevent taking date if it's around 1970 (use the logic below instead)
+			if (date > 60 * 60 * 24) {
+				return true;
+			}
+		}
+
 		// Convert "sess000" to 00:00 Jan 1 1970 (day per session)
 		if (strncmp(dir, "sess", 4) == 0) {
 			unsigned u;
@@ -542,20 +550,6 @@ LogListHelper::_get_session_date(const char *path, const char *dir, time_t &date
 				date = u * 60 * 60 * 24;
 				return true;
 			}
-
-		} else {
-			if (stat_file(path, &date)) {
-				return true;
-			}
-
-			/* strptime not available for some reason
-			// Get date from directory name
-			struct tm tt;
-			if(strptime(dir, "%Y-%m-%d", &tt)) {
-				date = mktime(&tt);
-				return true;
-			}
-			*/
 		}
 	}
 
@@ -594,6 +588,14 @@ LogListHelper::_get_log_time_size(const char *path, const char *file, time_t &da
 {
 	if (file && file[0]) {
 		if (strstr(file, ".px4log") || strstr(file, ".ulg")) {
+			// Always try to get file time first
+			if (stat_file(path, &date, &size)) {
+				// Try to prevent taking date if it's around 1970 (use the logic below instead)
+				if (date > 60 * 60 * 24) {
+					return true;
+				}
+			}
+
 			// Convert "log000" to 00:00 (minute per flight in session)
 			if (strncmp(file, "log", 3) == 0) {
 				unsigned u;
@@ -605,20 +607,6 @@ LogListHelper::_get_log_time_size(const char *path, const char *file, time_t &da
 						return true;
 					}
 				}
-
-			} else {
-				if (stat_file(path, &date, &size)) {
-					return true;
-				}
-
-				/* strptime not available for some reason
-				// Get time from file name
-				struct tm tt;
-				if(strptime(file, "%H_%M_%S", &tt)) {
-					date += mktime(&tt);
-					return true;
-				}
-				*/
 			}
 		}
 	}


### PR DESCRIPTION
…kes sense

I like to make sure that the log download reports a log date/time even if we start logging already on boot and can't create log files/folders with timestamps yet. The file will have a correct modification time later on so we should use that.

Question: anybody knows why the alternate logic of getting the artificial date from sessXXX/logXXX doesn't work? Can't seem to find the problem..