### PR TITLE
Set EKF2 as default estimator

### DIFF
--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -103,7 +103,7 @@ PARAM_DEFINE_INT32(SYS_RESTART_TYPE, 2);
  * @reboot_required true
  * @group System
  */
-PARAM_DEFINE_INT32(SYS_MC_EST_GROUP, 1);
+PARAM_DEFINE_INT32(SYS_MC_EST_GROUP, 2);
 
 /**
  * TELEM2 as companion computer link


### PR DESCRIPTION
This needs more discussion and coordination. But we need to focus our maintenance efforts and also discuss how we can pull the EKF and LPE estimator implementations closer together.