### PR TITLE
cmake: Use Python3 if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,8 @@ else()
 	message(STATUS "catkin DISABLED")
 endif()
 
-find_package(PythonInterp 2.7 REQUIRED)
+set(Python_ADDITIONAL_VERSIONS "3"; "2.7")
+find_package(PythonInterp REQUIRED)
 
 #=============================================================================
 # cmake modules


### PR DESCRIPTION
This brings support for Distros that use Python3 by default such as
Arch Linux.

@eyeam3 did you have a better solution for this?