### PR TITLE
cmake: use default Python version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,6 @@ else()
 	message(STATUS "catkin DISABLED")
 endif()
 
-set(Python_ADDITIONAL_VERSIONS "3"; "2.7")
 find_package(PythonInterp REQUIRED)
 
 #=============================================================================


### PR DESCRIPTION
If the Python versions are specified, this breaks the build on Ubuntu systems
where Python3 is also installed but the extensions such as python-empy
are not installed. One could, of course, install python3-empy to fix
this but that's not in the instructions or error messages and therefore
not straightforward.

It is therefore probably better to just use the system default which
ends up being 2.7 on Ubuntu.

Fixes build issues introduced with #5886.

@eyeam3 please cross-test again. I expect it to still work on Arch.