### PR TITLE
Log tasks low on stack

### DIFF
--- a/ROMFS/px4fmu_common/mixers/coax.main.mix
+++ b/ROMFS/px4fmu_common/mixers/coax.main.mix
@@ -1,5 +1,5 @@
 Coaxial helicopter mixer
-- Two servomotors act on the swashplate (90° angle on the swashplate, decoupled effect on roll and pitch).
+- Two servomotors act on the swashplate (90 degree angle on the swashplate, decoupled effect on roll and pitch).
 - No collective pitch.
 - One motor per rotor.
 ===========================

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -124,6 +124,7 @@ set(msg_file_names
 	vehicle_roi.msg
 	mount_orientation.msg
 	collision_report.msg
+	low_stack.msg
 	)
 
 # Get absolute paths

--- a/msg/low_stack.msg
+++ b/msg/low_stack.msg
@@ -1,0 +1,4 @@
+uint8 MAX_REPORT_TASK_NAME_LEN = 16
+
+uint16 stack_free
+uint8[16] task_name

--- a/src/modules/load_mon/load_mon.cpp
+++ b/src/modules/load_mon/load_mon.cpp
@@ -138,6 +138,7 @@ LoadMon::LoadMon() :
 LoadMon::~LoadMon()
 {
 	work_cancel(LPWORK, &_work);
+	perf_free(_stack_perf);
 	_taskIsRunning = false;
 }
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -554,6 +554,7 @@ void Logger::add_default_topics()
 	add_topic("cpuload");
 	add_topic("gps_dump"); //this will only be published if GPS_DUMP_COMM is set
 	add_topic("sensor_preflight");
+	add_topic("low_stack");
 
 	/* for estimator replay (need to be at full rate) */
 	add_topic("sensor_combined");

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -634,6 +634,13 @@ struct log_DPRS_s {
 	float temperature;
 };
 
+/* --- LOW STACK --- */
+#define LOG_STCK_MSG 63
+struct log_STCK_s {
+	char task_name[16];
+	uint16_t stack_free;
+};
+
 /********** SYSTEM MESSAGES, ID > 0x80 **********/
 
 /* --- TIME - TIME STAMP --- */
@@ -724,6 +731,7 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT(LAND, "B", "Landed"),
 	LOG_FORMAT(LOAD, "f", "CPU"),
 	LOG_FORMAT(DPRS, "Qffff", "errors,DPRESraw,DPRES,DPRESmax,Temp"),
+	LOG_FORMAT(STCK, "NH", "Task,Free"),
 	/* system-level messages, ID >= 0x80 */
 	/* FMT: don't write format of format message, it's useless */
 	LOG_FORMAT(TIME, "Q", "StartTime"),

--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -153,3 +153,11 @@ PARAM_DEFINE_INT32(SYS_PARAM_VER, 1);
  * @group System
  */
 PARAM_DEFINE_INT32(SYS_LOGGER, 0);
+
+/**
+ * Enable stack checking
+ *
+ * @min 0
+ * @group System
+ */
+PARAM_DEFINE_INT32(SYS_STCK_EN, 0);


### PR DESCRIPTION
This is trying to be a resource friendly stack monitoring, almost state-less and only looking at one task per cycle. Ideally, it never logs anything. Tasks who breach the hard limit get logged every second (one at a time if there are multiple).

Seems to run out of flash on v2 unfortunately.

It would make sense to look at the stack limit (300 ATM), check it on the main configs and adjust stack sizes accordingly so this doesn't log anything by default.