### PR TITLE
px4fmu-v2_default: save more flash

### DIFF
--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -18,7 +18,7 @@ set(config_module_list
 	drivers/boards/px4fmu-v2
 	drivers/rgbled
 	drivers/mpu6000
-	drivers/mpu9250
+	#drivers/mpu9250
 	drivers/lsm303d
 	drivers/l3gd20
 	drivers/hmc5883
@@ -46,7 +46,7 @@ set(config_module_list
 	drivers/pwm_input
 	drivers/camera_trigger
 	drivers/bst
-	drivers/snapdragon_rc_pwm
+	#drivers/snapdragon_rc_pwm
 	drivers/lis3mdl
 
 	#


### PR DESCRIPTION
This disables the following modules to save flash:
- mpu9250 driver because the MPU9250 is rarely used on Pixhawks
- Snapdragon RC PWM passthrough which is rarely used and definitely a
  special/custom configuration. Also, it will soon be obsolete with the
  upcoming PWM support on Snapdragon.

Flash sizes (with arm-none-eabi-gcc 5.4.1):
```
master: 1027172 bytes
PR:     1012756 bytes
savings:  14416 bytes
```