### PR TITLE
cmake nuttx copy dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,7 @@ if (CATKIN_DEVEL_PREFIX)
 		message(FATAL_ERROR "catkin not found")
 	endif()
 else()
-	message(STATUS "catkin DISABLED")
+	#message(STATUS "catkin DISABLED")
 endif()
 
 find_package(PythonInterp 2.7 REQUIRED)


### PR DESCRIPTION
@davids5 FYI this makes nuttx copy depend on all nuttx files.

I haven't made any progress on the intermittent build failures. Logging would definitely help. To me it looks like it must be a race condition within the actual nuttx build. In the PX4 nuttx export step remove ` > nuttx_build.log` to get more output.