### PR TITLE
Time saver removed the zipping and un-zipping of the nuttx-export

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ env:
 script:
   - ccache -M 1GB; ccache -z
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
-      docker run --rm -v `pwd`:`pwd`:rw -v $HOME/.ccache:$HOME/.ccache:rw -e CCACHE_DIR=$HOME/.ccache -e CI=true -e GIT_SUBMODULES_ARE_EVIL=1 -w=`pwd` --user=$UID -it ${DOCKER_REPO} /bin/bash -c "make check VECTORCONTROL=1";
+      docker run --rm -v `pwd`:`pwd`:rw -v $HOME/.ccache:$HOME/.ccache:rw -e CCACHE_DIR=$HOME/.ccache -e CI=true -e GIT_SUBMODULES_ARE_EVIL=1 -w=`pwd` --user=$UID -it ${DOCKER_REPO} /bin/bash -c "make check_qgc_firmware VECTORCONTROL=0";
     elif [ "${TRAVIS_OS_NAME}" = "osx" ]; then
       make tests;
     fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,8 +153,6 @@ set(EXTERNAL_MODULES_LOCATION "" CACHE STRING "External modules source location"
 #
 # must come before project to set toolchain
 
-set(nuttx_configure "$ENV{NUTTX_CONFIGURE}")
-
 string(REPLACE "_" ";" config_args ${CONFIG})
 list(GET config_args 0 OS)
 list(GET config_args 1 BOARD)
@@ -426,7 +424,7 @@ set(module_external_libraries "${module_external_libraries}" CACHE INTERNAL "mod
 
 add_subdirectory(src/firmware/${OS})
 
-#add_dependencies(df_driver_framework nuttx_export_${CONFIG}.stamp)
+#add_dependencies(df_driver_framework nuttx_export_${CONFIG})
 if (NOT "${OS}" STREQUAL "nuttx")
 endif()
 

--- a/cmake/nuttx/px4_impl_nuttx.cmake
+++ b/cmake/nuttx/px4_impl_nuttx.cmake
@@ -268,7 +268,7 @@ function(px4_nuttx_add_export)
 		get_filename_component(patch_file_name ${patch} NAME)
 		message(STATUS "NuttX patch: nuttx-patches/${patch_file_name}")
 		string(REPLACE "/" "_" patch_name "nuttx_patch_${patch_file_name}-${CONFIG}")
-		set(patch_stamp ${patch_name}.stamp)
+		set(patch_stamp ${nuttx_src}/${patch_name}.stamp)
 
 		add_custom_command(OUTPUT ${patch_stamp}
 			COMMAND ${PATCH} -d ${nuttx_src} -s -p1 -N < ${patch}
@@ -276,8 +276,8 @@ function(px4_nuttx_add_export)
 			DEPENDS ${DEPENDS} nuttx_copy_${CONFIG}.stamp ${patch}
 			COMMENT "Applying ${patch}")
 
-		#add_custom_target(${patch_name} DEPENDS ${patch_stamp})
-		add_dependencies(nuttx_patch_${CONFIG} ${patch_stamp})
+		add_custom_target(${patch_name} DEPENDS ${patch_stamp})
+		add_dependencies(nuttx_patch_${CONFIG} ${patch_name})
 	endforeach()
 
 	# Read defconfig to see if CONFIG_ARMV7M_STACKCHECK is yes
@@ -313,7 +313,7 @@ function(px4_nuttx_add_export)
 	# build and export
 	add_custom_command(OUTPUT ${nuttx_src}/nuttx/nuttx-export/include/nuttx/config.h
 		COMMAND ${RM} -rf ${nuttx_src}/nuttx/nuttx-export
-		COMMAND ${MAKE} --no-print-directory --quiet -C ${nuttx_src}/nuttx -j${THREADS} -r CONFIG_ARCH_BOARD=${CONFIG} export > nuttx_build.log
+		COMMAND ${MAKE} --no-print-directory --quiet -C ${nuttx_src}/nuttx -r CONFIG_ARCH_BOARD=${CONFIG} export > nuttx_build.log
 		DEPENDS ${DEPENDS} ${nuttx_src}/nuttx/.config
 		WORKING_DIRECTORY ${PX4_BINARY_DIR}
 		COMMENT "Building NuttX for ${CONFIG} with ${config_nuttx_config}")

--- a/nuttx-patches/export_insitu.patch
+++ b/nuttx-patches/export_insitu.patch
@@ -1,0 +1,56 @@
+diff --git NuttX/nuttx/tools/mkexport.sh NuttX/nuttx/tools/mkexport.sh
+index 348a14c..3cc9182 100755
+--- NuttX/nuttx/tools/mkexport.sh
++++ NuttX/nuttx/tools/mkexport.sh
+@@ -34,19 +34,23 @@
+ 
+ # Get the input parameter list
+ 
+-USAGE="USAGE: $0 [-d] [-z] [-u] [-w|wy|wn] -t <top-dir> [-x <lib-ext>] -l \"lib1 [lib2 [lib3 ...]]\""
++USAGE="USAGE: $0 [-d] [-e] [-z] [-u] [-w|wy|wn] -t <top-dir> [-x <lib-ext>] -l \"lib1 [lib2 [lib3 ...]]\""
+ unset TOPDIR
+ unset LIBLIST
+ unset TGZ
+ USRONLY=n
+ WINTOOL=n
+ LIBEXT=.a
++INSITU=y
+ 
+ while [ ! -z "$1" ]; do
+ 	case $1 in
+ 		-d )
+ 			set -x
+ 			;;
++		-e )
++			INSITU=n
++			;;
+ 		-l )
+ 			shift
+ 			LIBLIST=$1
+@@ -373,13 +377,17 @@ done
+ cd "${TOPDIR}" || \
+ 	{ echo "MK: 'cd ${TOPDIR}' failed"; exit 1; }
+ 
+-if [ "X${TGZ}" = "Xy" ]; then
+-	tar cvf "${EXPORTSUBDIR}.tar" "${EXPORTSUBDIR}" 1>/dev/null 2>&1
+-	gzip -f "${EXPORTSUBDIR}.tar"
+-else
+-	zip -r "${EXPORTSUBDIR}.zip" "${EXPORTSUBDIR}" 1>/dev/null 2>&1
+-fi
++# Should we leave the export insitu
++
++if [ "X${INSITU}" = "Xn" ]; then
++    if [ "X${TGZ}" = "Xy" ]; then
++	    tar cvf "${EXPORTSUBDIR}.tar" "${EXPORTSUBDIR}" 1>/dev/null 2>&1
++	    gzip -f "${EXPORTSUBDIR}.tar"
++    else
++	    zip -r "${EXPORTSUBDIR}.zip" "${EXPORTSUBDIR}" 1>/dev/null 2>&1
++    fi
+ 
+-# Clean up after ourselves
++    # Clean up after ourselves
+ 
+-rm -rf "${EXPORTSUBDIR}"
++    rm -rf "${EXPORTSUBDIR}"
++fi
+\ No newline at end of file

--- a/src/firmware/nuttx/CMakeLists.txt
+++ b/src/firmware/nuttx/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(firmware_nuttx
 	builtin_commands.c)
 
 
-set(nuttx_export_dir ${PX4_BINARY_DIR}/${BOARD}/NuttX/nuttx-export)
+set(nuttx_export_dir ${PX4_BINARY_DIR}/${BOARD}/NuttX/nuttx/nuttx-export)
 
 set(link_libs
 	apps nuttx m gcc

--- a/src/modules/px4iofirmware/CMakeLists.txt
+++ b/src/modules/px4iofirmware/CMakeLists.txt
@@ -121,7 +121,7 @@ add_dependencies(${fw_io_name}
 	mixer_gen
 	)
 
-set(nuttx_export_dir ${PX4_BINARY_DIR}/${config_io_board}/NuttX/nuttx-export)
+set(nuttx_export_dir ${PX4_BINARY_DIR}/${config_io_board}/NuttX/nuttx/nuttx-export)
 set(main_link_flags
 	"-T${nuttx_export_dir}/build/ld.script"
 	"-Wl,-Map=${PX4_BINARY_DIR}/${config_io_board}/main.map"


### PR DESCRIPTION
   Since the build is done in build_xxxx there is no reason to zip and unzip the nuttx export to a new location. We simply build insitu.