### PR TITLE
Prevent takeoff in fixed-wing mode for VTOL vehicles

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -856,6 +856,13 @@ bool handle_command(struct vehicle_status_s *status_local, const struct safety_s
 						break;
 					}
 
+                    // Make sure we do not takeoff as a fixed wing when the vehicle type is VTOL
+                    if (status_local->is_vtol && !status_local->is_rotary_wing) {
+                    	mavlink_log_critical(&mavlink_log_pub, "Arming DENIED. Cannot Takeoff as a Fixed-Wing when vehicle type is VTOL");
+                    	cmd_result = vehicle_command_s::VEHICLE_CMD_RESULT_DENIED;
+                    	break;
+                    }
+
 					// Refuse to arm if in manual with non-zero throttle
 					if (cmd_arms
 						&& (status_local->nav_state == vehicle_status_s::NAVIGATION_STATE_MANUAL

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -1129,6 +1129,14 @@ int preflight_check(struct vehicle_status_s *status, orb_advert_t *mavlink_log_p
 		}
 	}
 
+	if (status->is_vtol && !status->is_rotary_wing) {
+		preflight_ok = false;
+
+		if (reportFailures) {
+			mavlink_log_critical(mavlink_log_pub, "ARMING DENIED: Cannot Takeoff as a Fixed-Wing when vehicle type is VTOL");
+		}
+	}
+
 	if (battery->warning == battery_status_s::BATTERY_WARNING_CRITICAL) {
 		preflight_ok = false;
 


### PR DESCRIPTION
Interlock added to prevent takeoff in fixed-wing mode when the vehicle type is VTOL. This is a safety feature and is especially handy for tailsitters. 