### PR TITLE
sitl_run.sh: env variable NO_PXH for deamon mode

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -35,6 +35,13 @@ else
 	sudo_enabled=""
 fi
 
+# To disable user input
+if [[ -n "$NO_PXH" ]]; then
+	no_pxh=-d
+else
+	no_pxh=""
+fi
+
 if [ "$model" == "" ] || [ "$model" == "none" ]
 then
 	echo "empty model, setting iris as default"
@@ -111,7 +118,7 @@ fi
 # Do not exit on failure now from here on because we want the complete cleanup
 set +e
 
-sitl_command="$sudo_enabled $sitl_bin $chroot_enabled $src_path $src_path/${rcS_dir}/${model}"
+sitl_command="$sudo_enabled $sitl_bin $no_pxh $chroot_enabled $src_path $src_path/${rcS_dir}/${model}"
 
 echo SITL COMMAND: $sitl_command
 


### PR DESCRIPTION
This allows to set the environment variable NO_PXH to start SITL without
the interactive pxh> shell. For this, px4 is called with the -d arg
which sets it to deamon mode.

This feature is handy to script sitl_run.sh.

@bkueng please review.