### PR TITLE
aerofc: default to EKF2

### DIFF
--- a/ROMFS/px4fmu_common/init.d/4070_aerofc
+++ b/ROMFS/px4fmu_common/init.d/4070_aerofc
@@ -25,6 +25,8 @@ then
 	param set MC_YAWRATE_I 0.050000000745058060
 	param set MC_YAWRATE_D 0.0
 	param set MC_YAW_FF 0.5
+
+	param set SYS_MC_EST_GROUP 2
 fi
 
 tap_esc start -d /dev/ttyS0 -n 4


### PR DESCRIPTION
We had much better GPS performance by using EKF2 rather than LPE so that
should be the default. User can still go back to LPE, or we can
re-evaluate this later when LPE has good GPS performance again.