### PR TITLE
Setup sf0x driver to handle all lightware lidars.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -636,10 +636,18 @@ then
 		fi
 	fi
 
-	# sf0x lidar sensor
-	if param compare SENS_EN_SF0X 1
+	# lightware serial lidar sensor
+	if param compare SENS_EN_SF0X 0
 	then
+	else
 		sf0x start
+	fi
+
+	# lightware i2c lidar sensor
+	if param compare SENS_EN_SF1XX 0
+	then
+	else
+		sf1xx start
 	fi
 
 	# mb12xx sonar sensor

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -3090,12 +3090,18 @@ PARAM_DEFINE_INT32(RC_RSSI_PWM_MIN, 2000);
 PARAM_DEFINE_INT32(SENS_EN_LL40LS, 0);
 
 /**
- * Lightware SF0x laser rangefinder
+ * Lightware laser rangefinder (serial)
  *
  * @reboot_required true
- *
- * @boolean
+ * @min 0
+ * @max 4
  * @group Sensor Enable
+ * @value 0 Disabled
+ * @value 1 SF02
+ * @value 2 SF10/a
+ * @value 3 SF10/b
+ * @value 4 SF10/c
+ * @value 5 SF11/c
  */
 PARAM_DEFINE_INT32(SENS_EN_SF0X, 0);
 
@@ -3120,7 +3126,7 @@ PARAM_DEFINE_INT32(SENS_EN_MB12XX, 0);
 PARAM_DEFINE_INT32(SENS_EN_TRONE, 0);
 
 /**
- * Lightware SF1xx laser rangefinder
+ * Lightware SF1xx laser rangefinder (i2c)
  *
  * @reboot_required true
  * @min 0


### PR DESCRIPTION
Currently the sf0x driver uses serial and the sf1xx driver uses i2c. This sets up the sf0x driver to be able to handle the sf10a on serial. Some renaming would be good, but this is the minimal impact change and will maintain backwards compatibility with the existing param names and their behavior.

I've test flown this with an sf10a on serial.

@ecmnet, @LorenzMeier  Please review.