### PR TITLE
pixhawk 2 init and cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,9 +261,10 @@ tests: check_unittest run_tests_posix
 qgc_firmware: \
 	check_px4fmu-v1_default \
 	check_px4fmu-v2_default \
+	check_px4fmu-v3_default \
+	check_px4fmu-v4_default_and_uavcan \
 	check_mindpx-v2_default \
 	check_tap-v1_default \
-	check_px4fmu-v4_default_and_uavcan \
 	check_format
 
 package_firmware:

--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -38,6 +38,10 @@ else
 		fmu sensor_reset 50
 	fi
 
+	if ms5611 -S start
+	then
+	fi
+
 	if ms5611 -s start
 	then
 	fi

--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -102,11 +102,11 @@ then
 	fi
 
 	# external MPU6K is rotated 180 degrees yaw
-	if mpu6000 -X -R 4 start
+	if mpu6000 -S -R 4 start
 	then
 		set BOARD_FMUV3 true
 	else
-		# Check for Pixhawk 2 board
+		# Check for Pixhawk 2.1 board
 		if mpu9250 -S -R 4 start
 		then
 			set BOARD_FMUV3 true

--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -11,46 +11,44 @@ then
 
 else
 	if ver hwcmp AEROFC_V1
-	# Aero FC uses separate driver
 	then
+		# Aero FC uses separate driver
 	else
+		if ver hwcmp CRAZYFLIE
+		then
+			# Crazyflie uses separate driver
+		else
+			# Configure all I2C buses to 100 KHz as they
+			# are all external or slow
+			fmu i2c 1 100000
+			fmu i2c 2 100000
+		fi
 
-	if ver hwcmp CRAZYFLIE
-	then
-	# Crazyflie uses separate driver
-	else
+		if ver hwcmp PX4FMU_V4
+		then
+			# We know there are sketchy boards out there
+			# as chinese companies produce Pixracers without
+			# fully understanding the critical parts of the
+			# schematic and BOM, leading to sensor brownouts
+			# on boot. Original Pixracers following the
+			# open hardware design do not require this.
+			fmu sensor_reset 50
+		fi
 
-	# Configure all I2C buses to 100 KHz as they
-	# are all external or slow
-	fmu i2c 1 100000
-	fmu i2c 2 100000
+		# External SPI
+		if ms5611 -S start
+		then
+		fi
 
-	fi
+		# Internal SPI
+		if ms5611 -s start
+		then
+		fi
 
-	if ver hwcmp PX4FMU_V4
-	then
-		# We know there are sketchy boards out there
-		# as chinese companies produce Pixracers without
-		# fully understanding the critical parts of the
-		# schematic and BOM, leading to sensor brownouts
-		# on boot. Original Pixracers following the
-		# open hardware design do not require this.
-		fmu sensor_reset 50
-	fi
-
-	if ms5611 -S start
-	then
-	fi
-
-	if ms5611 -s start
-	then
-	fi
-
-	# Blacksheep telemetry
-	if bst start
-	then
-	fi
-
+		# Blacksheep telemetry
+		if bst start
+		then
+		fi
 	fi
 fi
 

--- a/cmake/configs/nuttx_px4fmu-v1_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v1_default.cmake
@@ -6,82 +6,98 @@ set(config_module_list
 	#
 	# Board support modules
 	#
+	drivers/airspeed
+	drivers/ardrone_interface
+	drivers/blinkm
+	drivers/boards/px4fmu-v1
+	drivers/camera_trigger
 	drivers/device
+	drivers/ets_airspeed
+	drivers/frsky_telemetry
+	drivers/gps
+	drivers/hmc5883
+	#drivers/hott
+	#drivers/hott/hott_sensors
+	#drivers/hott/hott_telemetry
+	drivers/l3gd20
+	drivers/led
+	#drivers/ll40ls
+	drivers/lsm303d
+	drivers/mb12xx
+	drivers/meas_airspeed
+	drivers/mkblctrl
+	drivers/mpu6000
+	drivers/ms5611
+	drivers/pwm_out_sim
+	drivers/px4flow
+	drivers/px4fmu
+	drivers/px4io
+	drivers/rgbled
+	drivers/sf0x
 	drivers/stm32
 	drivers/stm32/adc
 	drivers/stm32/tone_alarm
-	drivers/led
-	drivers/px4fmu
-	drivers/px4io
-	drivers/boards/px4fmu-v1
-	drivers/ardrone_interface
-	drivers/rgbled
-	drivers/mpu6000
-	drivers/lsm303d
-	drivers/l3gd20
-	drivers/hmc5883
-	drivers/ms5611
-	drivers/mb12xx
-	drivers/sf0x
-	#drivers/ll40ls
 	drivers/trone
-	drivers/gps
-	drivers/pwm_out_sim
-	#drivers/hott
-	#drivers/hott/hott_telemetry
-	#drivers/hott/hott_sensors
-	drivers/blinkm
-	drivers/airspeed
-	drivers/ets_airspeed
-	drivers/meas_airspeed
-	drivers/frsky_telemetry
-	modules/sensors
 	drivers/vmount
-	drivers/camera_trigger
-	drivers/mkblctrl
-	drivers/px4flow
+	modules/sensors
 
 	#
 	# System commands
 	#
 	systemcmds/bl_update
+	systemcmds/config
+	systemcmds/dumpfile
+	systemcmds/esc_calib
 	systemcmds/mixer
+	#systemcmds/motor_ramp
+	systemcmds/mtd
+	systemcmds/nshterm
 	systemcmds/param
 	systemcmds/perf
 	systemcmds/pwm
-	systemcmds/esc_calib
 	systemcmds/reboot
+	#systemcmds/sd_bench
 	systemcmds/top
-	systemcmds/config
-	systemcmds/nshterm
-	systemcmds/mtd
-	systemcmds/dumpfile
+	#systemcmds/topic_listener
 	systemcmds/ver
+
+	#
+	# Testing
+	#
+	#drivers/sf0x/sf0x_tests
+	#drivers/test_ppm
+	#lib/rc/rc_tests
+	#modules/commander/commander_tests
+	#modules/controllib_test
+	#modules/mavlink/mavlink_tests
+	#modules/mc_pos_control/mc_pos_control_tests
+	#modules/unit_test
+	#modules/uORB/uORB_tests
+	#systemcmds/tests
 
 	#
 	# General system control
 	#
 	modules/commander
-	modules/load_mon
-	modules/navigator
-	modules/mavlink
 	modules/gpio_led
 	modules/land_detector
+	modules/load_mon
+	modules/mavlink
+	modules/navigator
 
 	#
 	# Estimation modules
 	#
 	modules/attitude_estimator_q
-	#modules/position_estimator_inav
-	modules/local_position_estimator
 	modules/ekf2
+	modules/local_position_estimator
+	#modules/position_estimator_inav
 
 	#
 	# Vehicle Control
 	#
-	# modules/segway # XXX Needs GCC 4.7 fix
-	modules/fw_pos_control_l1
 	modules/fw_att_control
+	modules/fw_pos_control_l1
 	modules/mc_att_control
 	modules/mc_pos_control
 	modules/vtol_att_control
@@ -89,34 +105,34 @@ set(config_module_list
 	#
 	# Logging
 	#
-	modules/sdlog2
 	modules/logger
+	modules/sdlog2
 
 	#
 	# Library modules
 	#
+	modules/dataman
 	modules/param
 	modules/systemlib
 	modules/systemlib/mixer
 	modules/uORB
-	modules/dataman
 
 	#
 	# Libraries
 	#
 	lib/controllib
-	lib/mathlib
-	lib/mathlib/math/filter
+	lib/conversion
+	lib/DriverFramework/framework
 	lib/ecl
 	lib/external_lgpl
 	lib/geo
 	lib/geo_lookup
-	lib/conversion
 	lib/launchdetection
-	lib/terrain_estimation
+	lib/mathlib
+	lib/mathlib/math/filter
 	lib/runway_takeoff
 	lib/tailsitter_recovery
-	lib/DriverFramework/framework
+	lib/terrain_estimation
 	platforms/nuttx
 
 	# had to add for cmake, not sure why wasn't in original config
@@ -126,12 +142,12 @@ set(config_module_list
 	#
 	# OBC challenge
 	#
-	# modules/bottle_drop
+	#modules/bottle_drop
 
 	#
 	# Rover apps
 	#
-	# examples/rover_steering_control
+	#examples/rover_steering_control
 
 	#
 	# Demo apps
@@ -175,13 +191,11 @@ set(config_io_extra_libs
 add_custom_target(sercon)
 set_target_properties(sercon PROPERTIES
 	PRIORITY "SCHED_PRIORITY_DEFAULT"
-	MAIN "sercon"
-	STACK_MAIN "2048"
+	MAIN "sercon" STACK_MAIN "2048"
 	COMPILE_FLAGS "-Os")
 
 add_custom_target(serdis)
 set_target_properties(serdis PROPERTIES
 	PRIORITY "SCHED_PRIORITY_DEFAULT"
-	MAIN "serdis"
-	STACK_MAIN "2048"
+	MAIN "serdis" STACK_MAIN "2048"
 	COMPILE_FLAGS "-Os")

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -8,46 +8,51 @@ set(config_module_list
 	#
 	# Board support modules
 	#
+	drivers/airspeed
+	#drivers/blinkm
+	#drivers/bma180
+	#drivers/bmi160
+	#drivers/bmp280
+	drivers/boards/px4fmu-v2
+	drivers/bst
+	drivers/camera_trigger
 	drivers/device
+	drivers/ets_airspeed
+	#drivers/frsky_telemetry
+	drivers/gps
+	drivers/hmc5883
+	#drivers/hott
+	#drivers/hott/hott_sensors
+	#drivers/hott/hott_telemetry
+	drivers/l3gd20
+	drivers/led
+	drivers/lis3mdl
+	#drivers/ll40ls
+	drivers/lsm303d
+	#drivers/mb12xx
+	drivers/meas_airspeed
+	#drivers/mkblctrl
+	drivers/mpu6000
+	drivers/mpu9250
+	drivers/ms5611
+	#drivers/oreoled
+	drivers/pwm_input
+	drivers/pwm_out_sim
+	drivers/px4flow
+	drivers/px4fmu
+	drivers/px4io
+	drivers/rgbled
+	drivers/sf0x
+	#drivers/sf1xx
+	#drivers/snapdragon_rc_pwm
+	#drivers/srf02
 	drivers/stm32
 	drivers/stm32/adc
 	drivers/stm32/tone_alarm
-	drivers/led
-	drivers/px4fmu
-	drivers/px4io
-	drivers/boards/px4fmu-v2
-	drivers/rgbled
-	drivers/mpu6000
-	drivers/mpu9250
-	drivers/lsm303d
-	drivers/l3gd20
-	drivers/hmc5883
-	drivers/ms5611
-	#drivers/mb12xx
-	#drivers/srf02
-	drivers/sf0x
-	#drivers/ll40ls
+	#drivers/tap_esc
 	drivers/trone
-	drivers/gps
-	drivers/pwm_out_sim
-	#drivers/hott
-	#drivers/hott/hott_telemetry
-	#drivers/hott/hott_sensors
-	#drivers/blinkm
-	drivers/airspeed
-	drivers/ets_airspeed
-	drivers/meas_airspeed
-	#drivers/frsky_telemetry
-	modules/sensors
-	#drivers/mkblctrl
-	drivers/px4flow
-	#drivers/oreoled
 	#drivers/vmount
-	drivers/pwm_input
-	drivers/camera_trigger
-	drivers/bst
-	#drivers/snapdragon_rc_pwm
-	drivers/lis3mdl
+	modules/sensors
 
 	#
 	# System commands
@@ -78,6 +83,7 @@ set(config_module_list
 	#modules/commander/commander_tests
 	#modules/controllib_test
 	#modules/mavlink/mavlink_tests
+	#modules/mc_pos_control/mc_pos_control_tests
 	#modules/unit_test
 	#modules/uORB/uORB_tests
 	#systemcmds/tests
@@ -86,26 +92,26 @@ set(config_module_list
 	# General system control
 	#
 	modules/commander
-	modules/load_mon
-	modules/navigator
-	modules/mavlink
 	modules/gpio_led
-	modules/uavcan
 	modules/land_detector
+	modules/load_mon
+	modules/mavlink
+	modules/navigator
+	modules/uavcan
 
 	#
 	# Estimation modules
 	#
 	modules/attitude_estimator_q
-	#modules/position_estimator_inav
-	modules/local_position_estimator
 	modules/ekf2
+	modules/local_position_estimator
+	#modules/position_estimator_inav
 
 	#
 	# Vehicle Control
 	#
-	modules/fw_pos_control_l1
 	modules/fw_att_control
+	modules/fw_pos_control_l1
 	modules/mc_att_control
 	modules/mc_pos_control
 	modules/vtol_att_control
@@ -119,28 +125,28 @@ set(config_module_list
 	#
 	# Library modules
 	#
+	modules/dataman
 	modules/param
 	modules/systemlib
 	modules/systemlib/mixer
 	modules/uORB
-	modules/dataman
 
 	#
 	# Libraries
 	#
 	lib/controllib
-	lib/mathlib
-	lib/mathlib/math/filter
+	lib/conversion
+	lib/DriverFramework/framework
 	lib/ecl
 	lib/external_lgpl
 	lib/geo
 	lib/geo_lookup
-	lib/conversion
 	lib/launchdetection
-	lib/terrain_estimation
+	lib/mathlib
+	lib/mathlib/math/filter
 	lib/runway_takeoff
 	lib/tailsitter_recovery
-	lib/DriverFramework/framework
+	lib/terrain_estimation
 	platforms/nuttx
 
 	# had to add for cmake, not sure why wasn't in original config
@@ -179,6 +185,9 @@ set(config_module_list
 
 	# Hardware test
 	#examples/hwtest
+
+	# EKF
+	#examples/ekf_att_pos_estimator
 )
 
 set(config_extra_builtin_cmds

--- a/cmake/configs/nuttx_px4fmu-v2_test.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_test.cmake
@@ -8,46 +8,51 @@ set(config_module_list
 	#
 	# Board support modules
 	#
+	drivers/airspeed
+	#drivers/blinkm
+	#drivers/bma180
+	#drivers/bmi160
+	#drivers/bmp280
+	drivers/boards/px4fmu-v2
+	#drivers/bst
+	drivers/camera_trigger
 	drivers/device
+	drivers/ets_airspeed
+	#drivers/frsky_telemetry
+	drivers/gps
+	drivers/hmc5883
+	#drivers/hott
+	#drivers/hott/hott_sensors
+	#drivers/hott/hott_telemetry
+	drivers/l3gd20
+	drivers/led
+	#drivers/lis3mdl
+	#drivers/ll40ls
+	drivers/lsm303d
+	#drivers/mb12xx
+	drivers/meas_airspeed
+	#drivers/mkblctrl
+	drivers/mpu6000
+	#drivers/mpu9250
+	drivers/ms5611
+	#drivers/oreoled
+	drivers/pwm_input
+	#drivers/pwm_out_sim
+	drivers/px4flow
+	drivers/px4fmu
+	drivers/px4io
+	drivers/rgbled
+	drivers/sf0x
+	#drivers/sf1xx
+	#drivers/snapdragon_rc_pwm
+	#drivers/srf02
 	drivers/stm32
 	drivers/stm32/adc
 	drivers/stm32/tone_alarm
-	drivers/led
-	drivers/px4fmu
-	drivers/px4io
-	drivers/boards/px4fmu-v2
-	drivers/rgbled
-	drivers/mpu6000
-	drivers/mpu9250
-	drivers/lsm303d
-	drivers/l3gd20
-	drivers/hmc5883
-	drivers/ms5611
-	#drivers/mb12xx
-	#drivers/srf02
-	#drivers/sf0x
-	#drivers/ll40ls
-	#drivers/trone
-	drivers/gps
-	#drivers/pwm_out_sim
-	#drivers/hott
-	#drivers/hott/hott_telemetry
-	#drivers/hott/hott_sensors
-	drivers/blinkm
-	drivers/airspeed
-	drivers/ets_airspeed
-	drivers/meas_airspeed
-	drivers/frsky_telemetry
-	modules/sensors
-	#drivers/mkblctrl
-	drivers/px4flow
-	#drivers/oreoled
+	#drivers/tap_esc
+	drivers/trone
 	#drivers/vmount
-	drivers/pwm_input
-	drivers/camera_trigger
-	#drivers/bst
-	#drivers/snapdragon_rc_pwm
-	#drivers/lis3mdl
+	modules/sensors
 
 	#
 	# System commands
@@ -76,9 +81,9 @@ set(config_module_list
 	drivers/test_ppm
 	#lib/rc/rc_tests
 	modules/commander/commander_tests
-	modules/mc_pos_control/mc_pos_control_tests
 	modules/controllib_test
 	modules/mavlink/mavlink_tests
+	modules/mc_pos_control/mc_pos_control_tests
 	modules/unit_test
 	modules/uORB/uORB_tests
 	systemcmds/tests
@@ -87,26 +92,26 @@ set(config_module_list
 	# General system control
 	#
 	modules/commander
-	modules/load_mon
-	modules/navigator
-	modules/mavlink
 	#modules/gpio_led
-	modules/uavcan
 	modules/land_detector
+	modules/load_mon
+	modules/mavlink
+	modules/navigator
+	modules/uavcan
 
 	#
 	# Estimation modules
 	#
 	modules/attitude_estimator_q
-	#modules/position_estimator_inav
-	modules/local_position_estimator
 	modules/ekf2
+	modules/local_position_estimator
+	#modules/position_estimator_inav
 
 	#
 	# Vehicle Control
 	#
-	modules/fw_pos_control_l1
 	modules/fw_att_control
+	modules/fw_pos_control_l1
 	modules/mc_att_control
 	modules/mc_pos_control
 	modules/vtol_att_control
@@ -120,28 +125,28 @@ set(config_module_list
 	#
 	# Library modules
 	#
+	modules/dataman
 	modules/param
 	modules/systemlib
 	modules/systemlib/mixer
 	modules/uORB
-	modules/dataman
 
 	#
 	# Libraries
 	#
 	lib/controllib
-	lib/mathlib
-	lib/mathlib/math/filter
+	lib/conversion
+	lib/DriverFramework/framework
 	lib/ecl
 	lib/external_lgpl
 	lib/geo
 	lib/geo_lookup
-	lib/conversion
 	lib/launchdetection
-	lib/terrain_estimation
+	lib/mathlib
+	lib/mathlib/math/filter
 	lib/runway_takeoff
 	lib/tailsitter_recovery
-	lib/DriverFramework/framework
+	lib/terrain_estimation
 	platforms/nuttx
 
 	# had to add for cmake, not sure why wasn't in original config
@@ -180,6 +185,9 @@ set(config_module_list
 
 	# Hardware test
 	#examples/hwtest
+
+	# EKF
+	#examples/ekf_att_pos_estimator
 )
 
 set(config_extra_builtin_cmds
@@ -202,9 +210,11 @@ set(config_io_extra_libs
 add_custom_target(sercon)
 set_target_properties(sercon PROPERTIES
 	PRIORITY "SCHED_PRIORITY_DEFAULT"
-	MAIN "sercon" STACK_MAIN "2048")
+	MAIN "sercon" STACK_MAIN "2048"
+	COMPILE_FLAGS "-Os")
 
 add_custom_target(serdis)
 set_target_properties(serdis PROPERTIES
 	PRIORITY "SCHED_PRIORITY_DEFAULT"
-	MAIN "serdis" STACK_MAIN "2048")
+	MAIN "serdis" STACK_MAIN "2048"
+	COMPILE_FLAGS "-Os")

--- a/cmake/configs/nuttx_px4fmu-v3_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v3_default.cmake
@@ -8,46 +8,50 @@ set(config_module_list
 	#
 	# Board support modules
 	#
+	drivers/airspeed
+	drivers/blinkm
+	drivers/bmi160
+	drivers/bmp280
+	drivers/boards/px4fmu-v2
+	drivers/bst
+	drivers/camera_trigger
 	drivers/device
+	drivers/ets_airspeed
+	drivers/frsky_telemetry
+	drivers/gps
+	drivers/hmc5883
+	drivers/hott
+	drivers/hott/hott_sensors
+	drivers/hott/hott_telemetry
+	drivers/l3gd20
+	drivers/led
+	drivers/lis3mdl
+	drivers/ll40ls
+	drivers/lsm303d
+	drivers/mb12xx
+	drivers/meas_airspeed
+	drivers/mkblctrl
+	drivers/mpu6000
+	drivers/mpu9250
+	drivers/ms5611
+	drivers/oreoled
+	drivers/pwm_input
+	drivers/pwm_out_sim
+	drivers/px4flow
+	drivers/px4fmu
+	drivers/px4io
+	drivers/rgbled
+	drivers/sf0x
+	drivers/sf1xx
+	drivers/snapdragon_rc_pwm
+	drivers/srf02
 	drivers/stm32
 	drivers/stm32/adc
 	drivers/stm32/tone_alarm
-	drivers/led
-	drivers/px4fmu
-	drivers/px4io
-	drivers/boards/px4fmu-v2
-	drivers/rgbled
-	drivers/mpu6000
-	drivers/mpu9250
-	drivers/lsm303d
-	drivers/l3gd20
-	drivers/hmc5883
-	drivers/ms5611
-	#drivers/mb12xx
-	#drivers/srf02
-	drivers/sf0x
-	drivers/ll40ls
+	drivers/tap_esc
 	drivers/trone
-	drivers/gps
-	drivers/pwm_out_sim
-	#drivers/hott
-	#drivers/hott/hott_telemetry
-	#drivers/hott/hott_sensors
-	#drivers/blinkm
-	drivers/airspeed
-	drivers/ets_airspeed
-	drivers/meas_airspeed
-	drivers/frsky_telemetry
+	drivers/vmount
 	modules/sensors
-	#drivers/mkblctrl
-	drivers/px4flow
-	#drivers/oreoled
-	#drivers/vmount
-	drivers/pwm_input
-	drivers/camera_trigger
-	drivers/bst
-	drivers/snapdragon_rc_pwm
-	drivers/lis3mdl
 
 	#
 	# System commands
@@ -72,40 +76,41 @@ set(config_module_list
 	#
 	# Testing
 	#
-	#drivers/sf0x/sf0x_tests
-	#drivers/test_ppm
+	drivers/sf0x/sf0x_tests
+	drivers/test_ppm
 	#lib/rc/rc_tests
-	#modules/commander/commander_tests
-	#modules/controllib_test
-	#modules/mavlink/mavlink_tests
-	#modules/unit_test
-	#modules/uORB/uORB_tests
-	#systemcmds/tests
+	modules/commander/commander_tests
+	modules/controllib_test
+	modules/mavlink/mavlink_tests
+	modules/mc_pos_control/mc_pos_control_tests
+	modules/unit_test
+	modules/uORB/uORB_tests
+	systemcmds/tests
 
 	#
 	# General system control
 	#
 	modules/commander
-	modules/load_mon
-	modules/navigator
-	modules/mavlink
 	modules/gpio_led
-	modules/uavcan
 	modules/land_detector
+	modules/load_mon
+	modules/mavlink
+	modules/navigator
+	modules/uavcan
 
 	#
 	# Estimation modules
 	#
 	modules/attitude_estimator_q
-	modules/position_estimator_inav
-	modules/local_position_estimator
 	modules/ekf2
+	modules/local_position_estimator
+	modules/position_estimator_inav
 
 	#
 	# Vehicle Control
 	#
-	modules/fw_pos_control_l1
 	modules/fw_att_control
+	modules/fw_pos_control_l1
 	modules/mc_att_control
 	modules/mc_pos_control
 	modules/vtol_att_control
@@ -119,28 +124,28 @@ set(config_module_list
 	#
 	# Library modules
 	#
+	modules/dataman
 	modules/param
 	modules/systemlib
 	modules/systemlib/mixer
 	modules/uORB
-	modules/dataman
 
 	#
 	# Libraries
 	#
 	lib/controllib
-	lib/mathlib
-	lib/mathlib/math/filter
+	lib/conversion
+	lib/DriverFramework/framework
 	lib/ecl
 	lib/external_lgpl
 	lib/geo
 	lib/geo_lookup
-	lib/conversion
 	lib/launchdetection
-	lib/terrain_estimation
+	lib/mathlib
+	lib/mathlib/math/filter
 	lib/runway_takeoff
 	lib/tailsitter_recovery
-	lib/DriverFramework/framework
+	lib/terrain_estimation
 	platforms/nuttx
 
 	# had to add for cmake, not sure why wasn't in original config
@@ -150,12 +155,12 @@ set(config_module_list
 	#
 	# OBC challenge
 	#
-	#modules/bottle_drop
+	modules/bottle_drop
 
 	#
 	# Rover apps
 	#
-	#examples/rover_steering_control
+	examples/rover_steering_control
 
 	#
 	# Demo apps
@@ -163,7 +168,7 @@ set(config_module_list
 	#examples/math_demo
 	# Tutorial code from
 	# https://px4.io/dev/px4_simple_app
-	#examples/px4_simple_app
+	examples/px4_simple_app
 
 	# Tutorial code from
 	# https://px4.io/dev/daemon
@@ -179,6 +184,9 @@ set(config_module_list
 
 	# Hardware test
 	#examples/hwtest
+
+	# EKF
+	examples/ekf_att_pos_estimator
 )
 
 set(config_extra_builtin_cmds

--- a/cmake/configs/nuttx_px4fmu-v4_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v4_default.cmake
@@ -8,78 +8,79 @@ set(config_module_list
 	#
 	# Board support modules
 	#
+	drivers/airspeed
+	drivers/blinkm
+	drivers/bma180
+	drivers/bmi160
+	drivers/bmp280
+	drivers/boards/px4fmu-v4
+	drivers/bst
+	drivers/camera_trigger
 	drivers/device
+	drivers/ets_airspeed
+	drivers/frsky_telemetry
+	drivers/gps
+	drivers/hmc5883
+	drivers/hott
+	drivers/hott/hott_sensors
+	drivers/hott/hott_telemetry
+	drivers/led
+	drivers/lis3mdl
+	drivers/ll40ls
+	drivers/mb12xx
+	drivers/meas_airspeed
+	drivers/mkblctrl
+	drivers/mpu6000
+	drivers/mpu9250
+	drivers/ms5611
+	drivers/oreoled
+	drivers/pwm_input
+	drivers/pwm_out_sim
+	drivers/px4flow
+	drivers/px4fmu
+	drivers/rgbled
+	drivers/sf0x
+	drivers/sf1xx
+	drivers/snapdragon_rc_pwm
+	drivers/srf02
 	drivers/stm32
 	drivers/stm32/adc
 	drivers/stm32/tone_alarm
-	drivers/led
-	drivers/px4fmu
-	drivers/boards/px4fmu-v4
-	drivers/rgbled
-	drivers/mpu6000
-	drivers/mpu9250
-	drivers/hmc5883
-	drivers/ms5611
-	drivers/mb12xx
-	drivers/srf02
-	drivers/sf0x
-	drivers/sf1xx
-	drivers/ll40ls
-	drivers/trone
-	drivers/gps
-	drivers/pwm_out_sim
-	drivers/hott
-	drivers/hott/hott_telemetry
-	drivers/hott/hott_sensors
-	drivers/blinkm
-	drivers/airspeed
-	drivers/ets_airspeed
-	drivers/meas_airspeed
-	drivers/frsky_telemetry
-	modules/sensors
-	drivers/mkblctrl
-	drivers/px4flow
-	drivers/oreoled
-	drivers/vmount
-	drivers/pwm_input
-	drivers/camera_trigger
-	drivers/bst
-	drivers/snapdragon_rc_pwm
-	drivers/lis3mdl
-	drivers/bmp280
-	drivers/bma180
-	drivers/bmi160
 	drivers/tap_esc
+	drivers/trone
+	drivers/vmount
+	modules/sensors
 
 	#
 	# System commands
 	#
 	systemcmds/bl_update
+	systemcmds/config
+	systemcmds/dumpfile
+	systemcmds/esc_calib
 	systemcmds/mixer
+	systemcmds/motor_ramp
+	systemcmds/mtd
+	systemcmds/nshterm
 	systemcmds/param
 	systemcmds/perf
 	systemcmds/pwm
-	systemcmds/esc_calib
 	systemcmds/reboot
-	systemcmds/topic_listener
-	systemcmds/top
-	systemcmds/config
-	systemcmds/nshterm
-	systemcmds/mtd
-	systemcmds/dumpfile
-	systemcmds/ver
 	systemcmds/sd_bench
-	systemcmds/motor_ramp
+	systemcmds/top
+	systemcmds/topic_listener
+	systemcmds/ver
 
 	#
 	# Testing
 	#
 	drivers/sf0x/sf0x_tests
 	drivers/test_ppm
+	#lib/rc/rc_tests
 	modules/commander/commander_tests
-	modules/mc_pos_control/mc_pos_control_tests
 	modules/controllib_test
 	modules/mavlink/mavlink_tests
+	modules/mc_pos_control/mc_pos_control_tests
 	modules/unit_test
 	modules/uORB/uORB_tests
 	systemcmds/tests
@@ -88,27 +89,26 @@ set(config_module_list
 	# General system control
 	#
 	modules/commander
-	modules/load_mon
-	modules/navigator
-	modules/mavlink
 	modules/gpio_led
-	modules/uavcan
 	modules/land_detector
+	modules/load_mon
+	modules/mavlink
+	modules/navigator
+	modules/uavcan
 
 	#
-	# Estimation modules (EKF/ SO3 / other filters)
+	# Estimation modules
 	#
 	modules/attitude_estimator_q
-	modules/position_estimator_inav
 	modules/ekf2
 	modules/local_position_estimator
+	modules/position_estimator_inav
 
 	#
 	# Vehicle Control
 	#
-	# modules/segway # XXX Needs GCC 4.7 fix
-	modules/fw_pos_control_l1
 	modules/fw_att_control
+	modules/fw_pos_control_l1
 	modules/mc_att_control
 	modules/mc_pos_control
 	modules/vtol_att_control
@@ -116,35 +116,35 @@ set(config_module_list
 	#
 	# Logging
 	#
-	modules/sdlog2
 	modules/logger
+	modules/sdlog2
 
 	#
 	# Library modules
 	#
+	modules/dataman
 	modules/param
 	modules/systemlib
 	modules/systemlib/mixer
 	modules/uORB
-	modules/dataman
 
 	#
 	# Libraries
 	#
 	lib/controllib
-	lib/mathlib
-	lib/mathlib/math/filter
-	lib/rc
+	lib/conversion
+	lib/DriverFramework/framework
 	lib/ecl
 	lib/external_lgpl
 	lib/geo
 	lib/geo_lookup
-	lib/conversion
 	lib/launchdetection
-	lib/terrain_estimation
+	lib/mathlib
+	lib/mathlib/math/filter
+	lib/rc
 	lib/runway_takeoff
 	lib/tailsitter_recovery
-	lib/DriverFramework/framework
+	lib/terrain_estimation
 	platforms/nuttx
 
 	# had to add for cmake, not sure why wasn't in original config
@@ -204,13 +204,11 @@ set(config_io_extra_libs
 add_custom_target(sercon)
 set_target_properties(sercon PROPERTIES
 	PRIORITY "SCHED_PRIORITY_DEFAULT"
-	MAIN "sercon"
-	STACK_MAIN "2048"
+	MAIN "sercon" STACK_MAIN "2048"
 	COMPILE_FLAGS "-Os")
 
 add_custom_target(serdis)
 set_target_properties(serdis PROPERTIES
 	PRIORITY "SCHED_PRIORITY_DEFAULT"
-	MAIN "serdis"
-	STACK_MAIN "2048"
+	MAIN "serdis" STACK_MAIN "2048"
 	COMPILE_FLAGS "-Os")

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -619,6 +619,7 @@ Sensors::Sensors() :
 	_vibration_warning_timestamp(0),
 	_vibration_warning(false)
 {
+	_baro.voter.set_timeout(300000);
 	_mag.voter.set_timeout(300000);
 
 	memset(&_rc, 0, sizeof(_rc));


### PR DESCRIPTION
 - pixhawk 2.1 start 2nd ms5611 and adjust baro voter timeout
 - fix pixhawk 2 (solo) init detect
 - travis-ci upload px4fmu-v3 binary to s3
 - rc.sensors indentation fix
 - sync and sort px4fmu-v1,2,3,4 configs, it was becoming quite difficult to keep track of the differences

Pixhawk 2.1 imu heater is still a problem. The sensors were in the mid 70s after bench testing. https://github.com/PX4/Firmware/issues/5963