### PR TITLE
add tests code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,7 @@ vectorcontrol/
 
 # CLion ignores
 .idea
+
+# gcov code coverage
+coverage-html/
+coverage.info

--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,13 @@ run_tests_posix: posix_sitl_default
 
 tests: check_unittest run_tests_posix
 
+tests_coverage:
+	@(PX4_CODE_COVERAGE=1 CCACHE_DISABLE=1 ${MAKE} tests)
+	@(lcov --directory . --capture --quiet --output-file coverage.info)
+	@(lcov --remove coverage.info '/usr/*' --quiet --output-file coverage.info)
+	#@(lcov --list coverage.info)
+	@(genhtml coverage.info --quiet --output-directory coverage-html)
+
 # QGroundControl flashable firmware (currently built by travis-ci)
 qgc_firmware: \
 	check_px4fmu-v1_default \

--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -827,6 +827,7 @@ function(px4_add_common_flags)
 		)
 
 	set(added_link_dirs) # none used currently
+	set(added_exe_linker_flags)
 
 	string(TOUPPER ${BOARD} board_upper)
 	string(REPLACE "-" "_" board_config ${board_upper})
@@ -846,6 +847,20 @@ function(px4_add_common_flags)
 			-Wl,--gc-sections
 			#,--print-gc-sections
 			)
+	endif()
+
+	# code coverage
+	if ($ENV{PX4_CODE_COVERAGE} MATCHES "1")
+		message(STATUS "Code coverage build flags enabled")
+		list(APPEND added_cxx_flags
+			-fprofile-arcs -ftest-coverage --coverage -g3 -O0 -fno-elide-constructors -Wno-invalid-offsetof -fno-default-inline -fno-inline
+		)
+		list(APPEND added_c_flags
+			-fprofile-arcs -ftest-coverage --coverage -g3 -O0 -fno-default-inline -fno-inline
+		)
+		list(APPEND added_exe_linker_flags
+			-ftest-coverage --coverage -lgcov
+		)
 	endif()
 
 	# output

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -13,10 +13,16 @@ enable_testing()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror -std=gnu99 -g")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -std=gnu++0x -g -fno-exceptions -fno-rtti -fno-threadsafe-statics -DCONFIG_WCHAR_BUILTIN -D__CUSTOM_FILE_IO__")
 
+# code coverage
+if ($ENV{PX4_CODE_COVERAGE} MATCHES "1")
+	message(STATUS "Code coverage build flags enabled")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage --coverage")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage --coverage")
+endif()
+
 if (NOT PX4_SOURCE_DIR)
 	set(PX4_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
 endif()
-
 
 set(GTEST_DIR ${PX4_SOURCE_DIR}/unittests/googletest)
 add_subdirectory(${GTEST_DIR})


### PR DESCRIPTION
 - closes #5862 

Run with `make tests_coverage` and then open coverage-html/index.html in a browser. I'll be adding this to the builds and post output to https://coveralls.io/ soon, and then try to bring in the mission tests.

@mkschreder please review