### PR TITLE
mc_pos_control: do not do tilt compensation when hor velocity is cont…

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1891,8 +1891,8 @@ MulticopterPositionControl::task_main()
 						}
 					}
 
-					if (_control_mode.flag_control_altitude_enabled) {
-						/* thrust compensation for altitude only control modes */
+					if (_control_mode.flag_control_climb_rate_enabled && !_control_mode.flag_control_velocity_enabled) {
+						/* thrust compensation when vertical velocity but not horizontal velocity is controlled */
 						float att_comp;
 
 						if (_R(2, 2) > TILT_COS_MAX) {


### PR DESCRIPTION
…rolled

- fixed a bug where tilt compensation was done also when the horizontal
velocity was controlled. This is not needed because in this case
the controller outputs a 3D thrust vector.

Signed-off-by: Roman <bapstroman@gmail.com>