### PR TITLE
Intel Aero: Start external mags first

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -284,17 +284,17 @@ then
 	then
 	fi
 
-	# Internal compass
-	if hmc5883 -I -R 4 start
-	then
-	fi
-
 	# Possible external compasses
 	if hmc5883 -X start
 	then
 	fi
 
 	if ist8310 -C -b 1 -R 8 start
+	then
+	fi
+
+	# Internal compass
+	if hmc5883 -I -R 4 start
 	then
 	fi
 fi


### PR DESCRIPTION
In theory the start order shouldn't matter, but this is worth a try @lucasdemarchi @lfelipe.