### PR TITLE
reset position setpoints once altitude/position condition is reached

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -925,7 +925,10 @@ MulticopterPositionControl::control_manual(float dt)
 		/* check for pos. hold */
 		if (fabsf(req_vel_sp(0)) < _params.hold_xy_dz && fabsf(req_vel_sp(1)) < _params.hold_xy_dz) {
 			if (!_pos_hold_engaged) {
-				if (_params.hold_max_xy < FLT_EPSILON || (sqrtf(_vel(0)*_vel(0) + _vel(1)*_vel(1)) < _params.hold_max_xy)) {
+
+				float vel_xy_mag = sqrtf(_vel(0)*_vel(0) + _vel(1)*_vel(1));
+				if (_params.hold_max_xy < FLT_EPSILON || vel_xy_mag < _params.hold_max_xy) {
+					/* reset position setpoint to have smooth transition from velocity control to position control */
 					_pos_hold_engaged = true;
 					_pos_sp(0) = _pos(0);
 					_pos_sp(1) = _pos(1);
@@ -955,6 +958,7 @@ MulticopterPositionControl::control_manual(float dt)
 		if (fabsf(req_vel_sp(2)) < FLT_EPSILON) {
 			if (!_alt_hold_engaged) {
 				if (_params.hold_max_z < FLT_EPSILON || fabsf(_vel(2)) < _params.hold_max_z) {
+					/* reset position setpoint to have smooth transition from velocity control to position control */
 					_alt_hold_engaged = true;
 					_pos_sp(2) = _pos(2);
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -926,7 +926,8 @@ MulticopterPositionControl::control_manual(float dt)
 		if (fabsf(req_vel_sp(0)) < _params.hold_xy_dz && fabsf(req_vel_sp(1)) < _params.hold_xy_dz) {
 			if (!_pos_hold_engaged) {
 
-				float vel_xy_mag = sqrtf(_vel(0)*_vel(0) + _vel(1)*_vel(1));
+				float vel_xy_mag = sqrtf(_vel(0) * _vel(0) + _vel(1) * _vel(1));
+
 				if (_params.hold_max_xy < FLT_EPSILON || vel_xy_mag < _params.hold_max_xy) {
 					/* reset position setpoint to have smooth transition from velocity control to position control */
 					_pos_hold_engaged = true;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -925,9 +925,10 @@ MulticopterPositionControl::control_manual(float dt)
 		/* check for pos. hold */
 		if (fabsf(req_vel_sp(0)) < _params.hold_xy_dz && fabsf(req_vel_sp(1)) < _params.hold_xy_dz) {
 			if (!_pos_hold_engaged) {
-				if (_params.hold_max_xy < FLT_EPSILON || (fabsf(_vel(0)) < _params.hold_max_xy
-						&& fabsf(_vel(1)) < _params.hold_max_xy)) {
+				if (_params.hold_max_xy < FLT_EPSILON || (sqrtf(_vel(0)*_vel(0) + _vel(1)*_vel(1)) < _params.hold_max_xy)) {
 					_pos_hold_engaged = true;
+					_pos_sp(0) = _pos(0);
+					_pos_sp(1) = _pos(1);
 
 				} else {
 					_pos_hold_engaged = false;
@@ -955,6 +956,7 @@ MulticopterPositionControl::control_manual(float dt)
 			if (!_alt_hold_engaged) {
 				if (_params.hold_max_z < FLT_EPSILON || fabsf(_vel(2)) < _params.hold_max_z) {
 					_alt_hold_engaged = true;
+					_pos_sp(2) = _pos(2);
 
 				} else {
 					_alt_hold_engaged = false;


### PR DESCRIPTION
Currently if one is in the manual position control mode and accelerates upwards (or horizontally), the vehicle skips the altitude controller until the velocity is below some threshold. The position set-point reset occurs before the vehicle's velocity is below the threshold, which leads to an overshoot.
Resetting the position set-point once the vehicle is below that threshold leads to a smoother transition to position control without overshoot, but undergoes a breaking distance.