### PR TITLE
commander: ignore arm/disarm in DO_SET_MODE cmd

### DIFF
--- a/integrationtests/python_src/px4_it/mavros/mavros_offboard_attctl_test.py
+++ b/integrationtests/python_src/px4_it/mavros/mavros_offboard_attctl_test.py
@@ -40,6 +40,7 @@ PKG = 'px4'
 import unittest
 import rospy
 import rosbag
+import time
 
 from std_msgs.msg import Header
 from std_msgs.msg import Float64
@@ -122,7 +123,14 @@ class MavrosOffboardAttctlTest(unittest.TestCase):
             # (need to wait the first few rounds until PX4 has the offboard stream)
             if not armed and count > 5:
                 self._srv_cmd_long(False, 176, False,
-                                   128 | 1, 6, 0, 0, 0, 0, 0)
+                                   1, 6, 0, 0, 0, 0, 0)
+                # make sure the first command doesn't get lost
+                time.sleep(1)
+
+                self._srv_cmd_long(False, 400, False,
+                                   # arm
+                                   1, 0, 0, 0, 0, 0, 0)
+
                 armed = True
 
             if (self.local_position.pose.position.x > 5

--- a/integrationtests/python_src/px4_it/mavros/mavros_offboard_posctl_test.py
+++ b/integrationtests/python_src/px4_it/mavros/mavros_offboard_posctl_test.py
@@ -41,6 +41,7 @@ import unittest
 import rospy
 import math
 import rosbag
+import time
 
 from numpy import linalg
 import numpy as np
@@ -131,7 +132,14 @@ class MavrosOffboardPosctlTest(unittest.TestCase):
             # (need to wait the first few rounds until PX4 has the offboard stream)
             if not self.armed and count > 5:
                 self._srv_cmd_long(False, 176, False,
-                                   128 | 1, 6, 0, 0, 0, 0, 0)
+                                   1, 6, 0, 0, 0, 0, 0)
+                # make sure the first command doesn't get lost
+                time.sleep(1)
+
+                self._srv_cmd_long(False, 400, False,
+                                   # arm
+                                   1, 0, 0, 0, 0, 0, 0)
+
                 self.armed = True
 
             if self.is_at_position(pos.pose.position.x, pos.pose.position.y, pos.pose.position.z, 1):

--- a/integrationtests/python_src/px4_it/mavros/mission_test.py
+++ b/integrationtests/python_src/px4_it/mavros/mission_test.py
@@ -43,6 +43,7 @@ import math
 import rosbag
 import sys
 import os
+import time
 
 import mavros
 from pymavlink import mavutil
@@ -174,10 +175,16 @@ class MavrosMissionTest(unittest.TestCase):
             (self.mission_name, lat, lon, alt, xy_radius, z_radius, timeout, index, self.last_pos_d, self.last_alt_d)))
 
     def run_mission(self):
-        """switch mode: armed | auto"""
+        """switch mode: auto and arm"""
         self._srv_cmd_long(False, 176, False,
-                           # arm | custom, auto, mission
-                           128 | 1, 4, 4, 0, 0, 0, 0)
+                           # custom, auto, mission
+                           1, 4, 4, 0, 0, 0, 0)
+        # make sure the first command doesn't get lost
+        time.sleep(1)
+
+        self._srv_cmd_long(False, 400, False,
+                           # arm
+                           1, 0, 0, 0, 0, 0, 0)
 
     def wait_until_ready(self):
         """FIXME: hack to wait for simulation to be ready"""

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -730,17 +730,9 @@ bool handle_command(struct vehicle_status_s *status_local, const struct safety_s
 			hil_state_t new_hil_state = (base_mode & VEHICLE_MODE_FLAG_HIL_ENABLED) ? vehicle_status_s::HIL_STATE_ON : vehicle_status_s::HIL_STATE_OFF;
 			transition_result_t hil_ret = hil_state_transition(new_hil_state, status_pub, status_local, &mavlink_log_pub);
 
-			// Transition the arming state
-			bool cmd_arm = base_mode & VEHICLE_MODE_FLAG_SAFETY_ARMED;
-
-			arming_ret = arm_disarm(cmd_arm, &mavlink_log_pub, "set mode command");
-
-			/* update home position on arming if at least 500 ms from commander start spent to avoid setting home on in-air restart */
-			if (cmd_arm && (arming_ret == TRANSITION_CHANGED) &&
-				(hrt_absolute_time() > (commander_boot_timestamp + INAIR_RESTART_HOLDOFF_INTERVAL))) {
-
-				commander_set_home_position(*home_pub, *home, *local_pos, *global_pos, *attitude);
-			}
+			// We ignore base_mode & VEHICLE_MODE_FLAG_SAFETY_ARMED because
+			// the command VEHICLE_CMD_COMPONENT_ARM_DISARM should be used
+			// instead according to the latest mavlink spec.
 
 			if (base_mode & VEHICLE_MODE_FLAG_CUSTOM_MODE_ENABLED) {
 				/* use autopilot-specific mode */


### PR DESCRIPTION
According to https://github.com/mavlink/mavlink/pull/629 the mavlink
command DO_SET_MODE should only determine the mode but not the
armed/disarmed state, so the MAV_MODE_FLAG_SAFETY_ARMED bit should be
ignored.
Instead the mavlink command COMPONENT_ARM_DISARM should be used instead.

Therefore, the commander now ignores the arm/disarm bit.

Tested in SITL with `commander takeoff` and take off and land using QGC.

Please cross-test, review @dagar.

Fixes #4066.