### PR TITLE
hmc5883: fix MAGIOCGEXTERNAL ioctl for non fmuv1 boards

### DIFF
--- a/src/drivers/hmc5883/hmc5883_i2c.cpp
+++ b/src/drivers/hmc5883/hmc5883_i2c.cpp
@@ -113,17 +113,16 @@ HMC5883_I2C::ioctl(unsigned operation, unsigned &arg)
 	switch (operation) {
 
 	case MAGIOCGEXTERNAL:
-// On PX4v1 the MAG can be on an internal I2C
-// On everything else its always external
-#ifdef CONFIG_ARCH_BOARD_PX4FMU_V1
-		if (_bus == PX4_I2C_BUS_EXPANSION) {
-			return 1;
+#ifdef PX4_I2C_BUS_ONBOARD
+		if (_bus == PX4_I2C_BUS_ONBOARD) {
+			return 0;
 
 		} else {
-			return 0;
+			return 1;
 		}
 
 #else
+		/* assume external for all boards that don't define PX4_I2C_BUS_ONBOARD */
 		return 1;
 #endif
 


### PR DESCRIPTION
This makes the onboard check consistent with hmc5883_bus_option
initialization. If the current bus is the onboard bus, return !external.

It fixes the onboard mag (HMC5883) for AeroFC. Its priority is now 100,
previously it was 255, so that if an external mag is attached, it will be
preferred.

![mag_thrust](https://cloud.githubusercontent.com/assets/281593/20962717/c030ea7e-bc6a-11e6-8dfd-72108c5a9f92.png)


Fixes #5978