### PR TITLE
navigator: don't set the MC cruise speed

### DIFF
--- a/msg/position_setpoint.msg
+++ b/msg/position_setpoint.msg
@@ -37,5 +37,5 @@ float32 a_z			# acceleration z setpoint
 bool acceleration_valid		# true if acceleration setpoint is valid/should be used
 bool acceleration_is_force	# interprete acceleration as force
 float32 acceptance_radius   # navigation acceptance_radius if we're doing waypoint navigation
-float32 cruising_speed		# the generally desired cruising speed (not a hard constraint)
+float32 cruising_speed		# the generally desired cruising speed (not a hard constraint), -1 if not set
 float32 cruising_throttle	# the generally desired cruising throttle (not a hard constraint)

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -299,8 +299,7 @@ private:
 	control::BlockParamFloat _param_mc_alt_acceptance_radius;	/**< acceptance radius for multicopter altitude */
 	control::BlockParamInt _param_datalinkloss_act;	/**< select data link loss action */
 	control::BlockParamInt _param_rcloss_act;	/**< select data link loss action */
-	
-	control::BlockParamFloat _param_cruising_speed_hover;
+
 	control::BlockParamFloat _param_cruising_speed_plane;
 	control::BlockParamFloat _param_cruising_throttle_plane;
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -160,7 +160,6 @@ Navigator::Navigator() :
 	_param_mc_alt_acceptance_radius(this, "MC_ALT_RAD"),
 	_param_datalinkloss_act(this, "DLL_ACT"),
 	_param_rcloss_act(this, "RCL_ACT"),
-	_param_cruising_speed_hover(this, "MPC_XY_CRUISE", false),
 	_param_cruising_speed_plane(this, "FW_AIRSPD_TRIM", false),
 	_param_cruising_throttle_plane(this, "FW_THR_CRUISE", false),
 	_mission_cruising_speed(-1.0f),
@@ -761,7 +760,11 @@ Navigator::get_cruising_speed()
 	if (_mission_cruising_speed > 0.0f) {
 		return _mission_cruising_speed;
 	} else if (_vstatus.is_rotary_wing) {
-		return _param_cruising_speed_hover.get();
+		// The position controller should use the param MPC_XY_CRUISE automatically.
+		// If it is set here, we can only change the speed once before a waypoint and then
+		// we're stuck with it until the next time. However, when set in the position
+		// controller, we can adjust it as we go.
+		return -1.0f;
 	} else {
 		return _param_cruising_speed_plane.get();
 	}


### PR DESCRIPTION
Instead, let the multirotor position controller take care of respecting
the cruise velocity. If it is set in the navigator, there is the
drawback that the param value is only respected on a waypoint change
instead of immediately.

I have not looked into the fixedwing implementation and therefore left
it as is.

Tested in SITL.