### PR TITLE
Implement the way to run posix simulator directly from IDE without the need to reconfigure command lines, but use runner created via CMake

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -135,6 +135,15 @@ then
 elif [ "$debugger" == "valgrind" ]
 then
 	valgrind $sitl_command
+elif [ "$debugger" == "ide" ]
+then
+	echo "######################################################################"
+	echo
+	echo "PX4 simulator not started, use your IDE to start PX4_${model} target."
+	echo "Hit enter to quit..."
+	echo
+	echo "######################################################################"
+	read
 else
 	$sitl_command
 fi

--- a/src/firmware/posix/CMakeLists.txt
+++ b/src/firmware/posix/CMakeLists.txt
@@ -4,121 +4,136 @@ px4_posix_generate_builtin_commands(
 	OUT apps
 	MODULE_LIST ${module_libraries})
 
-if ("${BOARD}" STREQUAL "eagle" OR ("${BOARD}" STREQUAL "excelsior"))
 
-	include(fastrpc)
-	include(linux_app)
+function(px4_add_sitl_app)
+	px4_parse_function_args(
+			NAME px4_add_sitl_app
+			ONE_VALUE APP_NAME MAIN_SRC UPLOAD_NAME
+			REQUIRED APP_NAME MAIN_SRC
+			ARGN ${ARGN})
 
-	FASTRPC_STUB_GEN(../qurt/px4muorb.idl)
+	if ("${BOARD}" STREQUAL "eagle" OR ("${BOARD}" STREQUAL "excelsior"))
 
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-missing-prototypes -Wno-missing-declarations")
-	LINUX_APP(
-		APP_NAME px4
-		IDL_NAME px4muorb
-		APPS_DEST "/home/linaro"
-		SOURCES
-			px4muorb_stub.c
-			${PX4_SOURCE_DIR}/src/platforms/posix/main.cpp
-			apps.cpp
-		LINK_LIBS
-			-Wl,--start-group
-			${module_libraries}
-			${df_driver_libs}
-			${FASTRPC_ARM_LIBS}
-			pthread m rt
-			-Wl,--end-group
-		)
+		include(fastrpc)
+		include(linux_app)
 
-	px4_add_adb_push(OUT upload
-			 OS ${OS}
-			 BOARD ${BOARD}
-			 FILES ${CMAKE_CURRENT_BINARY_DIR}/px4
+		FASTRPC_STUB_GEN(../qurt/px4muorb.idl)
+
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-missing-prototypes -Wno-missing-declarations")
+		LINUX_APP(
+			APP_NAME ${APP_NAME}
+			IDL_NAME px4muorb
+			APPS_DEST "/home/linaro"
+			SOURCES
+				px4muorb_stub.c
+				${MAIN_SRC}
+				apps.cpp
+			LINK_LIBS
+				-Wl,--start-group
+				${module_libraries}
+				${df_driver_libs}
+				${FASTRPC_ARM_LIBS}
+				pthread m rt
+				-Wl,--end-group
+			)
+
+		px4_add_adb_push(OUT ${UPLOAD_NAME}
+				 OS ${OS}
+				 BOARD ${BOARD}
+				 FILES ${CMAKE_CURRENT_BINARY_DIR}/${APP_NAME}
 				 ${PX4_SOURCE_DIR}/posix-configs/eagle/flight/mainapp.config
-			 DEPENDS px4
-			 DEST /home/linaro)
+				 DEPENDS ${APP_NAME}
+				 DEST /home/linaro)
 
-elseif ("${BOARD}" STREQUAL "rpi")
+	elseif ("${BOARD}" STREQUAL "rpi")
 
-	px4_add_executable(px4
-		${PX4_SOURCE_DIR}/src/platforms/posix/main.cpp
-		apps.cpp
-		)
+		px4_add_executable(${APP_NAME}
+			${MAIN_SRC}
+			apps.cpp
+			)
 
-	target_link_libraries(px4
-		-Wl,--start-group
-		${module_libraries}
-		df_driver_framework
-		${df_driver_libs}
-		pthread m rt
-		-Wl,--end-group
-		)
-
-	file(GLOB RPI_CONFIG_FILES ${PX4_SOURCE_DIR}/posix-configs/rpi/*.config)
-	px4_add_scp_push(OUT upload
-			 OS ${OS}
-			 BOARD ${BOARD}
-			 FILES ${CMAKE_CURRENT_BINARY_DIR}/px4
-				${RPI_CONFIG_FILES}
-				${PX4_SOURCE_DIR}/ROMFS
-			 DEPENDS px4
-			 DEST /home/pi)
-
-elseif ("${BOARD}" STREQUAL "bebop")
-
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static")
-
-	px4_add_executable(px4
-		${PX4_SOURCE_DIR}/src/platforms/posix/main.cpp
-		apps.cpp
-		)
-
-	if (NOT APPLE)
-		target_link_libraries(px4
+		target_link_libraries(${APP_NAME}
 			-Wl,--start-group
 			${module_libraries}
+			df_driver_framework
 			${df_driver_libs}
 			pthread m rt
 			-Wl,--end-group
 			)
-	else()
-		target_link_libraries(px4
-			${module_libraries}
-			${df_driver_libs}
-			pthread m
+
+		file(GLOB RPI_CONFIG_FILES ${PX4_SOURCE_DIR}/posix-configs/rpi/*.config)
+		px4_add_scp_push(OUT ${UPLOAD_NAME}
+				 OS ${OS}
+				 BOARD ${BOARD}
+				 FILES ${CMAKE_CURRENT_BINARY_DIR}/${APP_NAME}
+				 ${RPI_CONFIG_FILES}
+				 ${PX4_SOURCE_DIR}/ROMFS
+				 DEPENDS ${APP_NAME}
+				 DEST /home/pi)
+
+	elseif ("${BOARD}" STREQUAL "bebop")
+
+		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static")
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static")
+
+		px4_add_executable(${APP_NAME}
+			${MAIN_SRC}
+			apps.cpp
 			)
+
+		if (NOT APPLE)
+			target_link_libraries(${APP_NAME}
+				-Wl,--start-group
+				${module_libraries}
+				${df_driver_libs}
+				pthread m rt
+				-Wl,--end-group
+				)
+		else()
+			target_link_libraries(${APP_NAME}
+				${module_libraries}
+				${df_driver_libs}
+				pthread m
+				)
+		endif()
+
+		px4_add_adb_push_to_bebop(OUT ${UPLOAD_NAME}
+				 OS ${OS}
+				 BOARD ${BOARD}
+				 FILES ${CMAKE_CURRENT_BINARY_DIR}/${APP_NAME}
+				 DEPENDS ${APP_NAME}
+				 DEST /usr/bin)
+
+	else()
+
+		px4_add_executable(${APP_NAME}
+			${MAIN_SRC}
+			apps.cpp
+			)
+
+		if (NOT APPLE)
+			target_link_libraries(${APP_NAME}
+				-Wl,--start-group
+				${module_libraries}
+				${df_driver_libs}
+				pthread m rt
+				-Wl,--end-group
+				)
+		else()
+			target_link_libraries(${APP_NAME}
+				${module_libraries}
+				${df_driver_libs}
+				pthread m
+				)
+		endif()
 	endif()
+endfunction()
 
-	px4_add_adb_push_to_bebop(OUT upload
-			 OS ${OS}
-			 BOARD ${BOARD}
-			 FILES ${CMAKE_CURRENT_BINARY_DIR}/px4
-			 DEPENDS px4
-			 DEST /usr/bin)
-
-else()
-
-	px4_add_executable(px4
-		${PX4_SOURCE_DIR}/src/platforms/posix/main.cpp
-		apps.cpp
+SET(SITL_RUNNER_MAIN_CPP ${PX4_SOURCE_DIR}/src/platforms/posix/main.cpp)
+px4_add_sitl_app(APP_NAME px4
+		UPLOAD_NAME upload
+		MAIN_SRC ${SITL_RUNNER_MAIN_CPP}
 		)
-
-	if (NOT APPLE)
-		target_link_libraries(px4
-			-Wl,--start-group
-			${module_libraries}
-			${df_driver_libs}
-			pthread m rt
-			-Wl,--end-group
-			)
-	else()
-		target_link_libraries(px4
-			${module_libraries}
-			${df_driver_libs}
-			pthread m
-			)
-	endif()
-endif()
 
 #=============================================================================
 # sitl run targets
@@ -152,7 +167,7 @@ set_target_properties(sitl_gazebo PROPERTIES EXCLUDE_FROM_ALL TRUE)
 
 # create targets for each viewer/model/debugger combination
 set(viewers none jmavsim gazebo replay)
-set(debuggers none gdb lldb ddd valgrind)
+set(debuggers none ide gdb lldb ddd valgrind)
 set(models none iris iris_opt_flow tailsitter standard_vtol plane solo typhoon_h480)
 set(all_posix_vmd_make_targets)
 foreach(viewer ${viewers})
@@ -171,6 +186,20 @@ foreach(viewer ${viewers})
 					set(_targ_name "${viewer}_${model}_${debugger}")
 				endif()
 			endif()
+
+			if (debugger STREQUAL "ide" AND viewer STREQUAL "gazebo")
+				SET(SITL_RUNNER_SOURCE_DIR ${PX4_SOURCE_DIR})
+				SET(SITL_RUNNER_MODEL_FILE ${PX4_SOURCE_DIR}/${config_sitl_rcS_dir}/${model})
+				SET(SITL_RUNNER_WORKING_DIRECTORY ${SITL_WORKING_DIR})
+
+				CONFIGURE_FILE(${PX4_SOURCE_DIR}/src/platforms/posix/sitl_runner_main.cpp.in sitl_runner_main_${model}.cpp @ONLY)
+
+				px4_add_sitl_app(APP_NAME px4_${model}
+                        UPLOAD_NAME upload_${model}
+						MAIN_SRC ${CMAKE_CURRENT_BINARY_DIR}/sitl_runner_main_${model}.cpp
+						)
+			endif()
+
 			add_custom_target(${_targ_name}
 				COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
 				$<TARGET_FILE:px4>

--- a/src/platforms/posix/main.cpp
+++ b/src/platforms/posix/main.cpp
@@ -286,7 +286,13 @@ static void set_cpu_scaling()
 #endif
 }
 
+#ifdef __PX4_SITL_MAIN_OVERRIDE
+int SITL_MAIN(int argc, char **argv);
+
+int SITL_MAIN(int argc, char **argv)
+#else
 int main(int argc, char **argv)
+#endif
 {
 	bool daemon_mode = false;
 	bool chroot_on = false;

--- a/src/platforms/posix/sitl_runner_main.cpp.in
+++ b/src/platforms/posix/sitl_runner_main.cpp.in
@@ -1,0 +1,53 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2015 Anton Matosov. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file sitl_runner_main.cpp
+ * Basic shell to execute px4 with specific model
+ *
+ * @author Anton Matosov <anton.matosov@gmail.com>
+ */
+
+#include <unistd.h>
+
+#define __PX4_SITL_MAIN_OVERRIDE
+#include "@SITL_RUNNER_MAIN_CPP@"
+
+int main(int argc, const char **argv)
+{
+    if (chdir("@SITL_RUNNER_WORKING_DIRECTORY@") != 0) {
+        PX4_ERR("Failed to change current directory to @SITL_RUNNER_WORKING_DIRECTORY@. error %i", errno);
+        return errno;
+    }
+    const char *argsOverride[] = {argv[0], "@SITL_RUNNER_SOURCE_DIR@", "@SITL_RUNNER_MODEL_FILE@"};
+    return SITL_MAIN(sizeof(argsOverride) / sizeof(argsOverride[0]), (char**)argsOverride);
+}


### PR DESCRIPTION
What these changes do:
In addition to the existing cmake targets that run `sitl_run.sh` with parameters for px4 to load correct model it creates a `launcher` targets named `px4_<mode>` that is a `thin wrapper` around original sitl px4 app. This `thin wrapper` simply embeds app arguments like current working directories and path to the model file.

How to use it:
 * Run gazebo (or any other sim) server and client viewers via the terminal: `make posix_sitl_default gazebo_none_ide`
 * In your IDE select `px4_<mode>` target you want to debug (e.g. `px4_iris`)
 * Start debug session directly from IDE

This approach significantly reduces the debug cycle time because simulator (e.g. gazebo) is always running in background and you only re-run px4 process which is very light.
