### PR TITLE
Fix incorrect MPU9250 device ID

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.mc_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_apps
@@ -19,8 +19,14 @@ fi
 # LPE
 if param compare SYS_MC_EST_GROUP 1
 then
-	attitude_estimator_q start
-	local_position_estimator start
+	# Try to start LPE. If it fails, start EKF2 as a default
+	# Unfortunately we do not build it on px4fmu-v2 duo to a limited flash.
+	if attitude_estimator_q start
+	then
+		local_position_estimator start
+	else
+		ekf2 start
+	fi
 fi
 
 # EKF

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_apps
@@ -20,8 +20,14 @@ fi
 # LPE
 if param compare SYS_MC_EST_GROUP 1
 then
-	attitude_estimator_q start
-	local_position_estimator start
+	# Try to start LPE. If it fails, start EKF2 as a default
+	# Unfortunately we do not build it on px4fmu-v2 duo to a limited flash.
+	if attitude_estimator_q start
+	then
+		local_position_estimator start
+	else
+		ekf2 start
+	fi
 fi
 
 # EKF

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -96,9 +96,9 @@ set(config_module_list
 	#
 	# Estimation modules
 	#
-	modules/attitude_estimator_q
+	#modules/attitude_estimator_q
 	#modules/position_estimator_inav
-	modules/local_position_estimator
+	#modules/local_position_estimator
 	modules/ekf2
 
 	#

--- a/src/drivers/device/device_nuttx.h
+++ b/src/drivers/device/device_nuttx.h
@@ -130,6 +130,20 @@ public:
 	 */
 	virtual int	ioctl(unsigned operation, unsigned &arg);
 
+	/**
+	 * Return the bus ID the device is connected to.
+	 *
+	 * @return The bus ID
+	 */
+	virtual uint8_t get_device_bus() {return _device_id.devid_s.bus;};
+
+	/**
+	 * Return the bus address of the device.
+	 *
+	 * @return The bus address
+	 */
+	virtual uint8_t get_device_address() {return _device_id.devid_s.address;};
+
 	/*
 	  device bus types for DEVID
 	 */

--- a/src/drivers/mpu9250/mpu9250.cpp
+++ b/src/drivers/mpu9250/mpu9250.cpp
@@ -166,11 +166,17 @@ MPU9250::MPU9250(device::Device *interface, device::Device *mag_interface, const
 	// disable debug() calls
 	_debug_enabled = false;
 
+	/* Set device parameters and make sure parameters of the bus device are adopted */
 	_device_id.devid_s.devtype = DRV_ACC_DEVTYPE_MPU9250;
+	_device_id.devid_s.bus = _interface->get_device_bus();;
+	_device_id.devid_s.address = _interface->get_device_address();;
 
 	/* Prime _gyro with parents devid. */
+	/* Set device parameters and make sure parameters of the bus device are adopted */
 	_gyro->_device_id.devid = _device_id.devid;
 	_gyro->_device_id.devid_s.devtype = DRV_GYR_DEVTYPE_MPU9250;
+	_gyro->_device_id.devid_s.bus = _interface->get_device_bus();
+	_gyro->_device_id.devid_s.address = _interface->get_device_address();
 
 	/* Prime _mag with parents devid. */
 	_mag->_device_id.devid = _device_id.devid;


### PR DESCRIPTION
We propagate the bus parameters from the bus (SPI) interface to the sensor devices. Thus, the device ID of the sensor driver is set to the correct bus id and address. Otherwise it would be zero, which is an issue if several MPU9250s are running at the same time.

This fixes #6002. Due to the incorrect ID the calibration of the first sensor was also applied to the second sensor, which in turn caused the inconsistency for the acceleration and gyro sensors.

**Caution**: This will alter the MPU9250 device ID on all boards and lead to errors. The previous device is not found anymore and the calibration is not retrieved.

Please test on Pixhawk 2.1 to make sure that it works now, but also on other boards that use the MPU9250.