### PR TITLE
rc.interface missing braces

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -146,7 +146,7 @@ then
 
 	if [ $MIXER_AUX_FILE != none ]
 	then
-		if fmu mode_$AUX_MODE
+		if fmu mode_${AUX_MODE}
 		then
 			# Append aux mixer to main device
 			if [ $OUTPUT_MODE == hil ]


### PR DESCRIPTION
Fixes 
```
FMU: unrecognized command mode_, try:
```