### PR TITLE
Enable parameter selected pre-arm logging start for sdlog2

### DIFF
--- a/src/modules/sdlog2/params.c
+++ b/src/modules/sdlog2/params.c
@@ -95,7 +95,8 @@ PARAM_DEFINE_INT32(SDLOG_GPSTIME, 1);
 PARAM_DEFINE_INT32(SDLOG_PRIO_BOOST, 2);
 
 /**
- * Controls when logging starts.
+ * Controls when the sdlog2 program starts logging data.
+ * The sdlog2 program is used when SYS_LOGGER is set to 0.
  *
  * A value of 0 is the default which starts on arming for normal
  * logging and on startup for ekf2 replay logging. A value of 1

--- a/src/modules/sdlog2/params.c
+++ b/src/modules/sdlog2/params.c
@@ -93,3 +93,19 @@ PARAM_DEFINE_INT32(SDLOG_GPSTIME, 1);
  * @group SD Logging
  */
 PARAM_DEFINE_INT32(SDLOG_PRIO_BOOST, 2);
+
+/**
+ * Controls when logging starts.
+ *
+ * A value of 0 is the default which starts on arming for normal
+ * logging and on startup for ekf2 replay logging. A value of 1
+ * causes all logging to commence on startup and can be used to
+ * help with diagnosis of pre-arm issues.
+ *
+ * @min 0
+ * @max 1
+ * @value 0 Default
+ * @value 1 Startup
+ * @group SD Logging
+ */
+PARAM_DEFINE_INT32(SDLOG_START, 0);

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -973,7 +973,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 	/* enable logging on start (-e option) */
 	bool log_on_start = false;
 
-    /* enable logging when armed (-a option) */
+	/* enable logging when armed (-a option) */
 	bool log_when_armed = false;
 	log_name_timestamp = false;
 

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -969,9 +969,11 @@ int sdlog2_thread_main(int argc, char *argv[])
 	int32_t log_rate = 50;
 	int log_buffer_size = LOG_BUFFER_SIZE_DEFAULT;
 	logging_enabled = false;
+
 	/* enable logging on start (-e option) */
 	bool log_on_start = false;
-	/* enable logging when armed (-a option) */
+
+    /* enable logging when armed (-a option) */
 	bool log_when_armed = false;
 	log_name_timestamp = false;
 
@@ -1056,6 +1058,42 @@ int sdlog2_thread_main(int argc, char *argv[])
 			break;
 		}
 	}
+
+    /* Check if we are gathering data for a replay log for ekf2. */
+    param_t replay_handle = param_find("EKF2_REC_RPL");
+    int32_t tmp = 0;
+    param_get(replay_handle, &tmp);
+    bool record_replay_log = (bool)tmp;
+
+    /* Define the type of logging
+     * There are different log types possible on different platforms. */
+    enum {
+        LOG_TYPE_NORMAL,
+        LOG_TYPE_REPLAY_ONLY,
+        LOG_TYPE_ALL
+    } log_type;
+    if (record_replay_log) {
+#if defined(__PX4_QURT) || defined(__PX4_POSIX)
+        log_type = LOG_TYPE_ALL;
+#else
+        log_type = LOG_TYPE_REPLAY_ONLY;
+#endif
+    } else {
+        log_type = LOG_TYPE_NORMAL;
+    }
+
+    /* Check the sdlog2 start parameter */
+    param_t start_handle = param_find("SDLOG_START");
+    int start_param = 0;
+    param_get(start_handle, &start_param);
+    if (start_param == 1) {
+        log_on_start = true;
+    }
+
+    /* ekf2 replay data needs to be logged from startup */
+    if (record_replay_log) {
+        log_on_start = true;
+    }
 
 	if (err_flag) {
 		sdlog2_usage(NULL);
@@ -1158,29 +1196,6 @@ int sdlog2_thread_main(int argc, char *argv[])
 
 	struct commander_state_s buf_commander_state;
 	memset(&buf_commander_state, 0, sizeof(buf_commander_state));
-
-	/* There are different log types possible on different platforms. */
-	enum {
-		LOG_TYPE_NORMAL,
-		LOG_TYPE_REPLAY_ONLY,
-		LOG_TYPE_ALL
-	} log_type;
-
-	/* Check if we are gathering data for a replay log for ekf2. */
-	param_t replay_handle = param_find("EKF2_REC_RPL");
-	int32_t tmp = 0;
-	param_get(replay_handle, &tmp);
-	bool record_replay_log = (bool)tmp;
-
-	if (record_replay_log) {
-#if defined(__PX4_QURT) || defined(__PX4_POSIX)
-		log_type = LOG_TYPE_ALL;
-#else
-		log_type = LOG_TYPE_REPLAY_ONLY;
-#endif
-	} else {
-		log_type = LOG_TYPE_NORMAL;
-	}
 
 	/* warning! using union here to save memory, elements should be used separately! */
 	union {
@@ -1406,7 +1421,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 	float snr_mean = 0.0f;
 
 	/* enable logging on start if needed */
-	if (log_on_start) {
+    if (log_on_start) {
 		/* check GPS topic to get GPS time */
 		if (log_name_timestamp) {
 			if (!copy_if_updated_multi(ORB_ID(vehicle_gps_position), 0, &subs.gps_pos_sub[0], &buf_gps_pos)) {


### PR DESCRIPTION
This patch fixes the following issues:

1) Pre-arm logging start for diagnosis of pre-arm issues can now be selected using the SDLOG2_START parameter. Addresses https://github.com/PX4/Firmware/issues/5790
2) Pre-arm logging is now guaranteed when ekf2 replay logging via the EKF2_REC_RPL parameter is selected, rather than being dependant on the startup script.