### PR TITLE
Boot cleanup

### DIFF
--- a/src/drivers/hmc5883/hmc5883.cpp
+++ b/src/drivers/hmc5883/hmc5883.cpp
@@ -1281,8 +1281,12 @@ int HMC5883::check_calibration()
 	bool scale_valid  = (check_scale() == OK);
 
 	if (_calibrated != (offset_valid && scale_valid)) {
-		warnx("mag cal status changed %s%s", (scale_valid) ? "" : "scale invalid ",
-		      (offset_valid) ? "" : "offset invalid");
+		// too verbose for normal operation
+		if (!offset_valid || !scale_valid) {
+			warnx("mag cal status changed %s%s", (scale_valid) ? "" : "scale invalid ",
+			      (offset_valid) ? "" : "offset invalid");
+		}
+
 		_calibrated = (offset_valid && scale_valid);
 	}
 

--- a/src/drivers/lis3mdl/lis3mdl.cpp
+++ b/src/drivers/lis3mdl/lis3mdl.cpp
@@ -79,9 +79,6 @@
 
 #include "lis3mdl.h"
 
-#undef DEVICE_DEBUG
-#define DEVICE_DEBUG printf
-
 /*
  * LIS3MDL internal constants and data structures.
  */

--- a/src/drivers/lis3mdl/lis3mdl_i2c.cpp
+++ b/src/drivers/lis3mdl/lis3mdl_i2c.cpp
@@ -58,9 +58,6 @@
 #include "lis3mdl.h"
 #include "board_config.h"
 
-#undef DEVICE_DEBUG
-#define DEVICE_DEBUG printf
-
 #ifdef PX4_I2C_OBDEV_LIS3MDL
 
 #define LIS3MDLL_ADDRESS		PX4_I2C_OBDEV_LIS3MDL

--- a/src/drivers/lis3mdl/lis3mdl_spi.cpp
+++ b/src/drivers/lis3mdl/lis3mdl_spi.cpp
@@ -58,9 +58,6 @@
 #include "lis3mdl.h"
 #include "board_config.h"
 
-#undef DEVICE_DEBUG
-#define DEVICE_DEBUG printf
-
 #ifdef PX4_SPIDEV_LIS
 
 /* SPI protocol address bits */

--- a/src/drivers/ms5611/ms5611.cpp
+++ b/src/drivers/ms5611/ms5611.cpp
@@ -1004,7 +1004,7 @@ start(enum MS5611_BUS busid, enum MS56XX_DEVICE_TYPES device_type)
 	}
 
 	if (!started) {
-		errx(1, "driver start failed");
+		exit(1);
 	}
 
 	// one or more drivers started OK

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -3396,7 +3396,6 @@ checkcrc(int argc, char *argv[])
 		exit(1);
 	}
 
-	warnx("CRCs match");
 	exit(0);
 }
 

--- a/src/modules/load_mon/load_mon.cpp
+++ b/src/modules/load_mon/load_mon.cpp
@@ -136,13 +136,19 @@ LoadMon::LoadMon() :
 	_stack_perf(perf_alloc(PC_ELAPSED, "stack_check")),
 	_stack_check_enabled(false)
 {
-	/* Parameter for stack checking */
-	param_t _param_stack_check = param_find("SYS_STCK_EN");
-	int ret_val = 0;
-	param_get(_param_stack_check, &ret_val);
-	_stack_check_enabled = ret_val > 0;
+	// Enable stack checking by param
+	param_t param_stack_check = param_find("SYS_STCK_EN");
 
-	PX4_INFO("stack check enabled: %s", _stack_check_enabled ? "yes" : "no");
+	if (param_stack_check != PARAM_INVALID) {
+		int ret_val = 0;
+		param_get(param_stack_check, &ret_val);
+		_stack_check_enabled = ret_val > 0;
+
+		// Only be verbose if enabled
+		if (_stack_check_enabled) {
+			PX4_INFO("stack check enabled");
+		}
+	}
 }
 
 LoadMon::~LoadMon()

--- a/src/modules/uavcan/uavcan_main.cpp
+++ b/src/modules/uavcan/uavcan_main.cpp
@@ -558,7 +558,6 @@ int UavcanNode::start(uavcan::NodeID node_id, uint32_t bitrate)
 	static CanInitHelper* can = nullptr;
 
 	if (can == nullptr) {
-		warnx("CAN driver init...");
 
 		can = new CanInitHelper();
 
@@ -627,7 +626,8 @@ void UavcanNode::fill_node_info()
 	swver.vcs_commit = std::strtol(fw_git_short, &end, 16);
 	swver.optional_field_flags |= swver.OPTIONAL_FIELD_FLAG_VCS_COMMIT;
 
-	warnx("SW version vcs_commit: 0x%08x", unsigned(swver.vcs_commit));
+	// Too verbose for normal operation
+	//warnx("SW version vcs_commit: 0x%08x", unsigned(swver.vcs_commit));
 
 	_node.setSoftwareVersion(swver);
 


### PR DESCRIPTION
@bkueng @julianoes Please review. This just removes text output from the boot which is distracting from real error messages. It also fixes the LIS3MDL driver (not yet widely used) which had incorrect printfs (supposedly leftovers from bringup).