### PR TITLE
Pr takeoff landing

### DIFF
--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -172,7 +172,8 @@ bool MulticopterLandDetector::_get_landed_state()
 	// Check if user commands throttle and if so, report not landed based on
 	// the user intent to take off (even if the system might physically still have
 	// ground contact at this point).
-	if (_manual.timestamp > 0 && _manual.z > 0.15f && _ctrl_mode.flag_control_manual_enabled) {
+	if (_manual.timestamp > 0 && _manual.z > 0.15f && _ctrl_mode.flag_control_manual_enabled
+	    && !_ctrl_mode.flag_control_altitude_enabled) {
 		return false;
 	}
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1451,6 +1451,7 @@ MulticopterPositionControl::task_main()
 			_do_reset_alt_pos_flag = true;
 			_vel_sp_prev.zero();
 			_reset_int_z = true;
+			_takeoff_thrust_sp = 0.0f;
 			reset_int_xy = true;
 			reset_yaw_sp = true;
 		}

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1623,9 +1623,8 @@ MulticopterPositionControl::task_main()
 
 				_att_sp.roll_body = 0.0f;
 				_att_sp.pitch_body = 0.0f;
-				R = matrix::Eulerf(_att_sp.roll_body, _att_sp.pitch_body, _att_sp.yaw_body);
 				_att_sp.timestamp = hrt_absolute_time();
-				matrix::Quatf q_sp = R;
+				matrix::Quatf q_sp = matrix::Eulerf(_att_sp.roll_body, _att_sp.pitch_body, _att_sp.yaw_body);
 				memcpy(&_att_sp.q_d[0], &q_sp._data, sizeof(_att_sp.q_d));
 				_att_sp.q_d_valid = true;
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1349,7 +1349,7 @@ MulticopterPositionControl::do_ground_takeoff(float dt)
 			_vel_prev.zero();
 
 		} else {
-			// copter has reached half of the takeoff speed
+			// copter has reached takeoff speed
 			// we can assume we are off the ground, set takeoff target velocity
 			// set the integator z value to hover thrust since it's the best guess we have
 			_takeoff_jumped = true;

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -468,3 +468,36 @@ PARAM_DEFINE_FLOAT(MPC_ACC_HOR_MAX, 5.0f);
  * @group Multicopter Position Control
  */
 PARAM_DEFINE_INT32(MPC_ALT_MODE, 0);
+
+/**
+ * Manual landing throttle threshold.
+ *
+ * The minimum throttle value required for a landing to commence in manual, climb-rate controlled modes.
+ *
+ * @min 0.01
+ * @max 0.3
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MPC_LND_T_THRESH, 0.1f);
+
+/**
+ * Manual takeoff throttle threshold.
+ *
+ * The minimum throttle value required for an automated takeoff to commence in manual, climb-rate controlled modes.
+ *
+ * @min 0.5
+ * @max 0.95
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MPC_TK_T_THRESH, 0.6f);
+
+/**
+ * Relative takeoff altitude.
+ *
+ * The altitude relative to the pre-takeoff altitude the drone is going to target after a takeoff.
+ *
+ * @min 0.5
+ * @max 10.0
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MPC_TK_ALT, 1.0f);


### PR DESCRIPTION
@julianoes @Stifael @MaEtUgR This is the code for the automated takeoff and landing in all altitude controlled modes.

I made a fix in the landing detector so that it doesn't check the rc throttle stick when not in full manual mode.
This prevents the landing detector to detect in_air when the throttle stick is raised in altitude controlled modes.
If this works out well then we could remove the _landed_locked flag from this PR. I had to introduce it due to the problem with the landing detector.

