### PR TITLE
trivial: fix segmentation fault when running local_position_estimator module without arguments

### DIFF
--- a/src/modules/local_position_estimator/local_position_estimator_main.cpp
+++ b/src/modules/local_position_estimator/local_position_estimator_main.cpp
@@ -97,6 +97,7 @@ int local_position_estimator_main(int argc, char *argv[])
 
 	if (argc < 2) {
 		usage("missing command");
+		return 1;
 	}
 
 	if (!strcmp(argv[1], "start")) {


### PR DESCRIPTION
argv[1] was read even if argc < 2 -> segmentation fault when running without arguments
the return saves this