### PR TITLE
WIP: LPE/Q config for racers with no GPS or compass

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,7 +28,7 @@
 	ignore = untracked
 [submodule "src/lib/matrix"]
 	path = src/lib/matrix
-	url = https://github.com/PX4/Matrix.git
+	url = https://github.com/kd0aij/Matrix.git
 [submodule "src/lib/DriverFramework"]
 	path = src/lib/DriverFramework
 	url = https://github.com/PX4/DriverFramework.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,7 +28,7 @@
 	ignore = untracked
 [submodule "src/lib/matrix"]
 	path = src/lib/matrix
-	url = https://github.com/kd0aij/Matrix.git
+	url = https://github.com/PX4/Matrix.git
 [submodule "src/lib/DriverFramework"]
 	path = src/lib/DriverFramework
 	url = https://github.com/PX4/DriverFramework.git

--- a/ROMFS/px4fmu_common/init.d/4052_s250_noGPS_noMAG
+++ b/ROMFS/px4fmu_common/init.d/4052_s250_noGPS_noMAG
@@ -1,0 +1,65 @@
+#!nsh
+#
+# @name Spedix S250AQ
+#
+# @type Quadrotor asymmetric
+#
+# @output MAIN1 motor1 (front right: CCW)
+# @output MAIN2 motor2 (back left: CCW)
+# @output MAIN3 motor3 (front left: CW)
+# @output MAIN4 motor4 (back right: CW)
+#
+# @output MAIN5 feed-through of RC AUX1 channel
+# @output MAIN6 feed-through of RC AUX2 channel
+#
+# @maintainer Mark Whitehorn <kd0aij@gmail.com>
+#
+
+sh /etc/init.d/rc.mc_defaults
+
+set MIXER quad_s250aq
+set MAV_TYPE 2
+
+set PWM_OUT 1234
+
+if [ $AUTOCNF == yes ]
+then
+	param set MC_ROLL_P 8.0
+	param set MC_ROLLRATE_P 0.19
+	param set MC_ROLLRATE_I 0.1
+	param set MC_ROLLRATE_D 0.0055
+	param set MC_PITCH_P 8.0
+	param set MC_PITCHRATE_P 0.19
+	param set MC_PITCHRATE_I 0.1
+	param set MC_PITCHRATE_D 0.0055
+	param set MC_YAW_P 4.0
+	param set MC_YAWRATE_P 0.2
+	param set MC_YAWRATE_I 0.1
+	param set MC_YAWRATE_D 0.0
+	param set MC_YAW_FF 0.5
+	param set MC_ROLLRATE_MAX 720.0
+	param set MC_PITCHRATE_MAX 720.0
+	param set MC_YAWRATE_MAX 400.0
+	param set MC_ACRO_R_MAX 360.0
+	param set MC_ACRO_P_MAX 360.0
+	param set MC_TPA_BREAK_D 0.3
+	param set MC_TPA_BREAK_I 1.0
+	param set MC_TPA_BREAK_P 0.3
+	param set MC_TPA_RATE_D 1.0
+	param set MC_TPA_RATE_I 0.0
+	param set MC_TPA_RATE_P 1.0
+	
+	param set PWM_MIN 1075
+
+	param set MPC_THR_MIN 0.06
+	param set MPC_MANTHR_MIN 0.06
+
+# disable magnetometer and GPS accel compensation
+	param set ACRO_ATT 1
+	param set ATT_ACC_COMP 0
+	param set ATT_BIAS_MAX 0.0
+	param set ATT_W_ACC 0.02
+	param set ATT_W_MAG 0.0
+
+	param set CBRK_IO_SAFETY 22027
+fi

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -113,8 +113,8 @@ set(config_module_list
 	#
 	# Logging
 	#
-	#modules/logger
-	modules/sdlog2
+	modules/logger
+	#modules/sdlog2
 
 	#
 	# Library modules

--- a/msg/manual_control_setpoint.msg
+++ b/msg/manual_control_setpoint.msg
@@ -49,6 +49,7 @@ uint8 rattitude_switch	 # rattitude control 2 position switch (optional): _MANUA
 uint8 posctl_switch		 # position control 2 position switch (optional): _ALTCTL_, POSCTL
 uint8 loiter_switch		 # loiter 2 position switch (optional): _MISSION_, LOITER
 uint8 acro_switch		 # acro 2 position switch (optional): _MANUAL_, ACRO
+uint8 seq_switch		 # sequence 2 position switch (optional): start, abort
 uint8 offboard_switch	 # offboard 2 position switch (optional): _NORMAL_, OFFBOARD
 uint8 kill_switch		 # throttle kill: _NORMAL_, KILL
 uint8 transition_switch	 # VTOL transition switch: _HOVER, FORWARD_FLIGHT

--- a/msg/rc_channels.msg
+++ b/msg/rc_channels.msg
@@ -22,11 +22,12 @@ uint8 RC_CHANNELS_FUNCTION_RATTITUDE=19
 uint8 RC_CHANNELS_FUNCTION_KILLSWITCH=20
 uint8 RC_CHANNELS_FUNCTION_TRANSITION=21
 uint8 RC_CHANNELS_FUNCTION_GEAR=22
+uint8 RC_CHANNELS_FUNCTION_SEQ=23
 
 uint64 timestamp_last_valid					# Timestamp of last valid RC signal
 float32[18] channels						# Scaled to -1..1 (throttle: 0..1)
 uint8 channel_count						# Number of valid channels
-int8[23] function						# Functions mapping
+int8[24] function						# Functions mapping
 uint8 rssi							# Receive signal strength indicator (0-100)
 bool signal_lost						# Control signal lost, should be checked together with topic timeout
 uint32 frame_drop_count						# Number of dropped frames

--- a/posix-configs/SITL/init/lpe/iris
+++ b/posix-configs/SITL/init/lpe/iris
@@ -42,7 +42,7 @@ param set MPC_Z_VEL_I 0.15
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01
 replay tryapplyparams
-simulator start -p
+simulator start -s
 rgbledsim start
 tone_alarm start
 gyrosim start

--- a/posix-configs/SITL/init/lpe/iris
+++ b/posix-configs/SITL/init/lpe/iris
@@ -42,7 +42,7 @@ param set MPC_Z_VEL_I 0.15
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01
 replay tryapplyparams
-simulator start -s
+simulator start -p
 rgbledsim start
 tone_alarm start
 gyrosim start

--- a/src/drivers/boards/px4fmu-v4/board_config.h
+++ b/src/drivers/boards/px4fmu-v4/board_config.h
@@ -34,7 +34,7 @@
 /**
  * @file board_config.h
  *
- * PX4FMUv2 internal definitions
+ * PX4FMUv4 internal definitions
  */
 
 #pragma once

--- a/src/lib/mathlib/math/Matrix.hpp
+++ b/src/lib/mathlib/math/Matrix.hpp
@@ -344,7 +344,8 @@ public:
 			printf("[ ");
 
 			for (unsigned int j = 0; j < N; j++)
-				printf("%.3f\t", (double)data[i][j]);
+				/* make rotation matrices look nice */
+				printf("% 8.3f ", (double)data[i][j]);
 
 			printf(" ]\n");
 		}
@@ -456,11 +457,11 @@ public:
 	}
 
 	/**
-	 * get euler angles from rotation matrix
+	 * get XYZ-fixed euler angles (gamma, beta, alpha) from rotation matrix
 	 */
 	Vector<3> to_euler(void) const {
 		Vector<3> euler;
-		euler.data[1] = asinf(-data[2][0]);
+		euler.data[1] = asinf(-data[2][0]);	/* beta */
 
 		if (fabsf(euler.data[1] - M_PI_2_F) < 1.0e-3f) {
 			euler.data[0] = 0.0f;
@@ -471,8 +472,8 @@ public:
 			euler.data[2] = atan2f(data[1][2] - data[0][1], data[0][2] + data[1][1]) - euler.data[0];
 
 		} else {
-			euler.data[0] = atan2f(data[2][1], data[2][2]);
-			euler.data[2] = atan2f(data[1][0], data[0][0]);
+			euler.data[0] = atan2f(data[2][1], data[2][2]);	/* gamma */
+			euler.data[2] = atan2f(data[1][0], data[0][0]);	/* alpha */
 		}
 
 		return euler;

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -202,6 +202,7 @@ static struct offboard_control_mode_s offboard_control_mode = {};
 static struct home_position_s _home = {};
 static int32_t _flight_mode_slots[manual_control_setpoint_s::MODE_SLOT_MAX];
 static struct commander_state_s internal_state = {};
+static bool acro_att = false;
 
 struct mission_result_s _mission_result;
 
@@ -1305,6 +1306,7 @@ int commander_thread_main(int argc, char *argv[])
 	param_t _param_low_bat_act = param_find("COM_LOW_BAT_ACT");
 	param_t _param_offboard_loss_timeout = param_find("COM_OF_LOSS_T");
 	param_t _param_arm_without_gps = param_find("COM_ARM_WO_GPS");
+	param_t _param_acro_att = param_find("ACRO_ATT");
 
 	param_t _param_fmode_1 = param_find("COM_FLTMODE1");
 	param_t _param_fmode_2 = param_find("COM_FLTMODE2");
@@ -1785,6 +1787,9 @@ int commander_thread_main(int argc, char *argv[])
 									(hrt_abstime)disarm_when_landed * 1000000);
 			}
 
+			int32_t v;
+			param_get(_param_acro_att, &v);
+			acro_att = (v != 0);
 			param_get(_param_low_bat_act, &low_bat_action);
 			param_get(_param_offboard_loss_timeout, &offboard_loss_timeout);
 			param_get(_param_offboard_loss_act, &offboard_loss_act);
@@ -3656,7 +3661,7 @@ set_control_mode()
 		control_mode.flag_control_manual_enabled = true;
 		control_mode.flag_control_auto_enabled = false;
 		control_mode.flag_control_rates_enabled = true;
-		control_mode.flag_control_attitude_enabled = false;
+		control_mode.flag_control_attitude_enabled = acro_att;
 		control_mode.flag_control_rattitude_enabled = false;
 		control_mode.flag_control_altitude_enabled = false;
 		control_mode.flag_control_climb_rate_enabled = false;

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -93,6 +93,20 @@ PARAM_DEFINE_FLOAT(TRIM_PITCH, 0.0f);
 PARAM_DEFINE_FLOAT(TRIM_YAW, 0.0f);
 
 /**
+ * ACRO control method
+ *
+ * Set this parameter to 0 for gyro-only rate control
+ * or to 1 for full attitude control in ACRO mode.
+ *
+ * @group Multicopter Attitude Control
+ * @min 0
+ * @max 1
+ * @decimal 1
+ * @increment 1
+ */
+PARAM_DEFINE_INT32(ACRO_ATT, 0);
+
+/**
  * Datalink loss time threshold
  *
  * After this amount of seconds without datalink the data link lost mode triggers

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -96,13 +96,10 @@ PARAM_DEFINE_FLOAT(TRIM_YAW, 0.0f);
  * ACRO control method
  *
  * Set this parameter to 0 for gyro-only rate control
- * or to 1 for full attitude control in ACRO mode.
+ * or non-zero for full attitude control in ACRO mode.
  *
  * @group Multicopter Attitude Control
- * @min 0
- * @max 1
- * @decimal 1
- * @increment 1
+ * @boolean
  */
 PARAM_DEFINE_INT32(ACRO_ATT, 0);
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -517,6 +517,7 @@ void Logger::add_default_topics()
 	// Note: try to avoid setting the interval where possible, as it increases RAM usage
 
 	add_topic("vehicle_attitude", 10);
+	add_topic("vehicle_attitude_groundtruth", 10);
 	add_topic("actuator_outputs", 50);
 	add_topic("telemetry_status");
 	add_topic("vehicle_command");

--- a/src/modules/mc_pos_control/CMakeLists.txt
+++ b/src/modules/mc_pos_control/CMakeLists.txt
@@ -33,7 +33,7 @@
 px4_add_module(
 	MODULE modules__mc_pos_control
 	MAIN mc_pos_control
-	COMPILE_FLAGS
+	COMPILE_FLAGS -DDEBUG_BUILD
 	STACK_MAIN 1200
 	SRCS
 		mc_sequencer.cpp

--- a/src/modules/mc_pos_control/CMakeLists.txt
+++ b/src/modules/mc_pos_control/CMakeLists.txt
@@ -36,7 +36,8 @@ px4_add_module(
 	COMPILE_FLAGS
 	STACK_MAIN 1200
 	SRCS
-		mc_pos_control_main.cpp
+		mc_sequencer.cpp
+		mc_pos_control_main.cpp 
 	DEPENDS
 		platforms__common
 	)

--- a/src/modules/mc_pos_control/CMakeLists.txt
+++ b/src/modules/mc_pos_control/CMakeLists.txt
@@ -33,7 +33,8 @@
 px4_add_module(
 	MODULE modules__mc_pos_control
 	MAIN mc_pos_control
-	COMPILE_FLAGS -DDEBUG_BUILD
+#	COMPILE_FLAGS -DDEBUG_BUILD
+	COMPILE_FLAGS
 	STACK_MAIN 1200
 	SRCS
 		mc_sequencer.cpp

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -2159,7 +2159,7 @@ MulticopterPositionControl::task_main()
 					 */
 					if (!_sequencer_initialized) {
 						_sequencer_initialized = true;
-						prog_sequence_init(sequence_set::coord_turn, 5.0f);
+						prog_sequence_init(sequence_set::coord_turn, 25.0f);
 					}
 
 					prog_sequence(_ctrl_state, _att_sp, _manual, R_sp, rollRate, pitchRate, yawRate);

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -278,14 +278,7 @@ private:
 	float _acc_z_lp;
 	float _takeoff_thrust_sp;
 	bool control_vel_enabled_prev;	/**< previous loop was in velocity controlled mode (control_state.flag_control_velocity_enabled) */
-
-	// counters for reset events on position and velocity states
-	// they are used to identify a reset event
-	uint8_t _z_reset_counter;
-	uint8_t _xy_reset_counter;
-	uint8_t _vz_reset_counter;
-	uint8_t _vxy_reset_counter;
-	uint8_t _heading_reset_counter;
+	bool _sequencer_initialized;
 
 	/**
 	 * Update our local parameter cache.
@@ -427,6 +420,7 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_acc_z_lp(0),
 	_takeoff_thrust_sp(0.0f),
 	control_vel_enabled_prev(false),
+	_sequencer_initialized(false)
 	_z_reset_counter(0),
 	_xy_reset_counter(0),
 	_vz_reset_counter(0),
@@ -2163,6 +2157,11 @@ MulticopterPositionControl::task_main()
 					/* the control sequencer overrides manual inputs
 					 * by setting values for roll/pitch/yawRate and modifying R_sp as needed
 					 */
+					if (!_sequencer_initialized) {
+						_sequencer_initialized = true;
+						prog_sequence_init(sequence_set::pitch_flip, 5.0f);
+					}
+
 					prog_sequence(_ctrl_state, _att_sp, _manual, R_sp, rollRate, pitchRate, yawRate);
 
 					float tilt_error = 0.0f;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -280,6 +280,14 @@ private:
 	bool control_vel_enabled_prev;	/**< previous loop was in velocity controlled mode (control_state.flag_control_velocity_enabled) */
 	bool _sequencer_initialized;
 
+	// counters for reset events on position and velocity states
+	// they are used to identify a reset event
+	uint8_t _z_reset_counter;
+	uint8_t _xy_reset_counter;
+	uint8_t _vz_reset_counter;
+	uint8_t _vxy_reset_counter;
+	uint8_t _heading_reset_counter;
+
 	/**
 	 * Update our local parameter cache.
 	 */
@@ -420,7 +428,7 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_acc_z_lp(0),
 	_takeoff_thrust_sp(0.0f),
 	control_vel_enabled_prev(false),
-	_sequencer_initialized(false)
+	_sequencer_initialized(false),
 	_z_reset_counter(0),
 	_xy_reset_counter(0),
 	_vz_reset_counter(0),

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -2159,7 +2159,7 @@ MulticopterPositionControl::task_main()
 					 */
 					if (!_sequencer_initialized) {
 						_sequencer_initialized = true;
-						prog_sequence_init(sequence_set::pitch_flip, 5.0f);
+						prog_sequence_init(sequence_set::coord_turn, 5.0f);
 					}
 
 					prog_sequence(_ctrl_state, _att_sp, _manual, R_sp, rollRate, pitchRate, yawRate);

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -87,9 +87,9 @@
 #include <controllib/blocks.hpp>
 #include <controllib/block/BlockParam.hpp>
 
-#if defined CONFIG_ARCH_BOARD_SITL || defined CONFIG_ARCH_BOARD_PX4FMU_V3 || defined CONFIG_ARCH_BOARD_PX4FMU_V4
+//#if defined CONFIG_ARCH_BOARD_SITL || defined CONFIG_ARCH_BOARD_PX4FMU_V3 || defined CONFIG_ARCH_BOARD_PX4FMU_V4
 #include "mc_sequencer.h"
-#endif
+//#endif
 
 #define TILT_COS_MAX	0.7f
 #define SIGMA			0.000001f
@@ -2136,25 +2136,22 @@ MulticopterPositionControl::task_main()
 				}
 			}
 
-			/* control roll and pitch directly if no aiding velocity controller is active */
-			if (!_control_mode.flag_control_velocity_enabled) {
+			/* control throttle directly if no climb rate controller is active */
+			if (!_control_mode.flag_control_climb_rate_enabled) {
+				float thr_val = throttle_curve(_manual.z, _params.thr_hover);
+				_att_sp.thrust = math::min(thr_val, _manual_thr_max.get());
 
-				/* control throttle directly if no climb rate controller is active */
-				if (!_control_mode.flag_control_climb_rate_enabled) {
-					float thr_val = throttle_curve(_manual.z, _params.thr_hover);
-					_att_sp.thrust = math::min(thr_val, _manual_thr_max.get());
-
-					/* enforce minimum throttle if not landed */
-					if (!_vehicle_land_detected.landed) {
-						_att_sp.thrust = math::max(_att_sp.thrust, _manual_thr_min.get());
-					}
+				/* enforce minimum throttle if not landed */
+				if (!_vehicle_land_detected.landed) {
+					_att_sp.thrust = math::max(_att_sp.thrust, _manual_thr_min.get());
 				}
 			}
 
-#if defined CONFIG_ARCH_BOARD_SITL || defined CONFIG_ARCH_BOARD_PX4FMU_V3 || defined CONFIG_ARCH_BOARD_PX4FMU_V4
-				// attitude setpoint rotation matrix
-				math::Matrix<3, 3> R_sp;
+			if (!_control_mode.flag_control_velocity_enabled) {
+				_att_sp.roll_body = _manual.y * _params.man_roll_max;
+				_att_sp.pitch_body = -_manual.x * _params.man_pitch_max;
 
+//#if defined CONFIG_ARCH_BOARD_SITL || defined CONFIG_ARCH_BOARD_PX4FMU_V3 || defined CONFIG_ARCH_BOARD_PX4FMU_V4
 				/* If ACRO attitude control mode */
 				if (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_ACRO) {
 
@@ -2162,17 +2159,9 @@ MulticopterPositionControl::task_main()
 					float pitchRate = -_manual.x * _params.acro_pitchRate_max;
 					float yawRate = _manual.r * _params.acro_yawRate_max;
 
-					if (!_att_sp.R_valid) {
-						/* initialize to current orientation */
-						math::Quaternion q_sp(_ctrl_state.q);
-						R_sp = q_sp.to_dcm();
-						memcpy(&_att_sp.R_body[0], R_sp.data, sizeof(_att_sp.R_body));
-						_att_sp.R_valid = true;
+					// attitude setpoint rotation matrix
+					matrix::Dcm<float> R_sp(matrix::Quatf(_att_sp.q_d));
 
-					} else {
-						/* copy current setpoint */
-						R_sp.set(_att_sp.R_body);
-					}
 
 					/* the control sequencer overrides manual inputs
 					 * by setting values for roll/pitch/yawRate and modifying R_sp as needed
@@ -2181,6 +2170,7 @@ MulticopterPositionControl::task_main()
 					flip_sequence(_ctrl_state, _att_sp, _manual, R_sp, rollRate, pitchRate, yawRate);
 #else
 					prog_sequence(_ctrl_state, _att_sp, _manual, R_sp, rollRate, pitchRate, yawRate);
+
 #endif
 
 					/* limit setpoint lead angle */
@@ -2210,30 +2200,17 @@ MulticopterPositionControl::task_main()
 						dYaw = yawRate * dt;
 					}
 
-					math::Matrix<3, 3> R_xy;
-					R_xy.from_euler(dRoll, dPitch, 0.0f);
-
-					math::Matrix<3, 3> R_z;
-					R_z.from_euler(0.0f, 0.0f, dYaw);
+					matrix::Dcmf R_xy(matrix::Eulerf(dRoll, dPitch, 0.0f));
+					matrix::Dcmf R_z(matrix::Eulerf(0.0f, 0.0f, dYaw));
 
 					R_sp = R_z * R_sp;
-
 					R_sp = R_sp * R_xy;
+					R_sp.renormalize();
 
-					/* renormalize rows */
-					for (int row = 0; row < 3; row++) {
-						math::Vector<3> rvec(R_sp.data[row]);
-						R_sp.set_row(row, rvec.normalized());
-					}
-
-					// this block is not necessary for attitude control
-					{
-						memcpy(&_att_sp.R_body[0], R_sp.data, sizeof(_att_sp.R_body));
-						math::Vector<3> eulerAngles = R_sp.to_euler();
-						_att_sp.roll_body = eulerAngles.data[0];
-						_att_sp.pitch_body = eulerAngles.data[1];
-						_att_sp.yaw_body = eulerAngles.data[2];
-					}
+					matrix::Eulerf eulerAngles(R_sp);
+					_att_sp.roll_body = eulerAngles.phi();
+					_att_sp.pitch_body = eulerAngles.theta();
+					_att_sp.yaw_body = eulerAngles.psi();
 
 				} else if (_params.opt_recover <= 0) {
 					/* not in ACRO mode and optimal recovery is not in use */
@@ -2289,63 +2266,8 @@ MulticopterPositionControl::task_main()
 
 
 			_att_sp.timestamp = hrt_absolute_time();
-#else
-
-				// attitude setpoint rotation matrix
-				math::Matrix<3, 3> R_sp;
-
-				if (_params.opt_recover <= 0) {
-					/* not in ACRO mode and optimal recovery is not in use */
-					_att_sp.roll_body = _manual.y * _params.man_roll_max;
-					_att_sp.pitch_body = -_manual.x * _params.man_pitch_max;
-
-					// construct attitude setpoint rotation matrix. modify the setpoints for roll
-					// and pitch such that they reflect the user's intention even if a yaw error
-					// (yaw_sp - yaw) is present. In the presence of a yaw error constructing a rotation matrix
-					// from the pure euler angle setpoints will lead to unexpected attitude behaviour from
-					// the user's view as the euler angle sequence uses the  yaw setpoint and not the current
-					// heading of the vehicle.
-
-					// calculate our current yaw error
-					float yaw_error = _wrap_pi(_att_sp.yaw_body - _yaw);
-
-					// compute the vector obtained by rotating a z unit vector by the rotation
-					// given by the roll and pitch commands of the user
-					math::Vector<3> zB = {0, 0, 1};
-					math::Matrix<3, 3> R_sp_roll_pitch;
-					R_sp_roll_pitch.from_euler(_att_sp.roll_body, _att_sp.pitch_body, 0);
-					math::Vector<3> z_roll_pitch_sp = R_sp_roll_pitch * zB;
-
-
-					// transform the vector into a new frame which is rotated around the z axis
-					// by the current yaw error. this vector defines the desired tilt when we look
-					// into the direction of the desired heading
-					math::Matrix<3, 3> R_yaw_correction;
-					R_yaw_correction.from_euler(0.0f, 0.0f, -yaw_error);
-					z_roll_pitch_sp = R_yaw_correction * z_roll_pitch_sp;
-
-					// use the formula z_roll_pitch_sp = R_tilt * [0;0;1]
-					// to calculate the new desired roll and pitch angles
-					// R_tilt can be written as a function of the new desired roll and pitch
-					// angles. we get three equations and have to solve for 2 unknowns
-					float pitch_new = asinf(z_roll_pitch_sp(0));
-					float roll_new = -atan2f(z_roll_pitch_sp(1), z_roll_pitch_sp(2));
-
-					R_sp.from_euler(roll_new, pitch_new, _att_sp.yaw_body);
-					memcpy(&_att_sp.R_body[0], R_sp.data, sizeof(_att_sp.R_body));
-				}
-
-				/* copy quaternion setpoint to attitude setpoint topic */
-				math::Quaternion q_sp;
-				q_sp.from_dcm(R_sp);
-				memcpy(&_att_sp.q_d[0], &q_sp.data[0], sizeof(_att_sp.q_d));
-			}
-
-			_att_sp.timestamp = hrt_absolute_time();
-#endif
 
 		} else {
-
 			reset_yaw_sp = true;
 			_att_sp.yaw_sp_move_rate = 0.0f;
 		}

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -65,6 +65,7 @@
 #include <arch/board/board.h>
 
 #include <uORB/topics/manual_control_setpoint.h>
+#include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/vehicle_rates_setpoint.h>
 #include <uORB/topics/control_state.h>
 #include <uORB/topics/mc_virtual_attitude_setpoint.h>
@@ -85,6 +86,8 @@
 
 #include <controllib/blocks.hpp>
 #include <controllib/block/BlockParam.hpp>
+
+#include "mc_sequencer.h"
 
 #define TILT_COS_MAX	0.7f
 #define SIGMA			0.000001f
@@ -198,6 +201,9 @@ private:
 		param_t hold_max_xy;
 		param_t hold_max_z;
 		param_t acc_hor_max;
+		param_t acro_rollRate_max;
+		param_t acro_pitchRate_max;
+		param_t acro_yawRate_max;
 		param_t alt_mode;
 		param_t opt_recover;
 
@@ -222,6 +228,9 @@ private:
 		float hold_max_xy;
 		float hold_max_z;
 		float acc_hor_max;
+		float acro_rollRate_max;
+		float acro_pitchRate_max;
+		float acro_yawRate_max;
 		float vel_max_up;
 		float vel_max_down;
 		uint32_t alt_mode;
@@ -489,6 +498,9 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_params_handles.hold_max_xy = param_find("MPC_HOLD_MAX_XY");
 	_params_handles.hold_max_z = param_find("MPC_HOLD_MAX_Z");
 	_params_handles.acc_hor_max = param_find("MPC_ACC_HOR_MAX");
+	_params_handles.acro_rollRate_max	= 	param_find("MC_ACRO_R_MAX");
+	_params_handles.acro_pitchRate_max	= 	param_find("MC_ACRO_P_MAX");
+	_params_handles.acro_yawRate_max	= 	param_find("MC_ACRO_Y_MAX");
 	_params_handles.alt_mode = param_find("MPC_ALT_MODE");
 	_params_handles.opt_recover = param_find("VT_OPT_RECOV_EN");
 
@@ -621,10 +633,16 @@ MulticopterPositionControl::parameters_update(bool force)
 		param_get(_params_handles.man_pitch_max, &_params.man_pitch_max);
 		param_get(_params_handles.man_yaw_max, &_params.man_yaw_max);
 		param_get(_params_handles.global_yaw_max, &_params.global_yaw_max);
+		param_get(_params_handles.acro_rollRate_max, &_params.acro_rollRate_max);
+		param_get(_params_handles.acro_pitchRate_max, &_params.acro_pitchRate_max);
+		param_get(_params_handles.acro_yawRate_max, &_params.acro_yawRate_max);
 		_params.man_roll_max = math::radians(_params.man_roll_max);
 		_params.man_pitch_max = math::radians(_params.man_pitch_max);
 		_params.man_yaw_max = math::radians(_params.man_yaw_max);
 		_params.global_yaw_max = math::radians(_params.global_yaw_max);
+		_params.acro_rollRate_max = math::radians(_params.acro_rollRate_max);
+		_params.acro_pitchRate_max = math::radians(_params.acro_pitchRate_max);
+		_params.acro_yawRate_max = math::radians(_params.acro_yawRate_max);
 
 		param_get(_params_handles.mc_att_yaw_p, &v);
 		_params.mc_att_yaw_p = v;
@@ -2116,24 +2134,109 @@ MulticopterPositionControl::task_main()
 				}
 			}
 
-			/* control throttle directly if no climb rate controller is active */
-			if (!_control_mode.flag_control_climb_rate_enabled) {
-				float thr_val = throttle_curve(_manual.z, _params.thr_hover);
-				_att_sp.thrust = math::min(thr_val, _manual_thr_max.get());
+			/* control roll and pitch directly if no aiding velocity controller is active */
+			if (!_control_mode.flag_control_velocity_enabled) {
 
-				/* enforce minimum throttle if not landed */
-				if (!_vehicle_land_detected.landed) {
-					_att_sp.thrust = math::max(_att_sp.thrust, _manual_thr_min.get());
+				/* control throttle directly if no climb rate controller is active */
+				if (!_control_mode.flag_control_climb_rate_enabled) {
+					float thr_val = throttle_curve(_manual.z, _params.thr_hover);
+					_att_sp.thrust = math::min(thr_val, _manual_thr_max.get());
+
+					/* enforce minimum throttle if not landed */
+					if (!_vehicle_land_detected.landed) {
+						_att_sp.thrust = math::max(_att_sp.thrust, _manual_thr_min.get());
+					}
 				}
 			}
 
-			/* control roll and pitch directly if no aiding velocity controller is active */
-			if (!_control_mode.flag_control_velocity_enabled) {
-				_att_sp.roll_body = _manual.y * _params.man_roll_max;
-				_att_sp.pitch_body = -_manual.x * _params.man_pitch_max;
+				// attitude setpoint rotation matrix
+				math::Matrix<3, 3> R_sp;
 
-				/* only if optimal recovery is not used, modify roll/pitch */
-				if (_params.opt_recover <= 0) {
+				/* If ACRO attitude control mode */
+				if (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_ACRO) {
+
+					float rollRate = _manual.y * _params.acro_rollRate_max;
+					float pitchRate = -_manual.x * _params.acro_pitchRate_max;
+					float yawRate = _manual.r * _params.acro_yawRate_max;
+
+					if (!_att_sp.R_valid) {
+						/* initialize to current orientation */
+						math::Quaternion q_sp(_ctrl_state.q);
+						R_sp = q_sp.to_dcm();
+						memcpy(&_att_sp.R_body[0], R_sp.data, sizeof(_att_sp.R_body));
+						_att_sp.R_valid = true;
+
+					} else {
+						/* copy current setpoint */
+						R_sp.set(_att_sp.R_body);
+					}
+
+					/* the control sequencer overrides manual inputs
+					 * by setting values for roll/pitch/yawRate and modifying R_sp as needed
+					 */
+#ifdef JUST_FLIPS
+					flip_sequence(_ctrl_state, _att_sp, _manual, R_sp, rollRate, pitchRate, yawRate);
+#else
+					prog_sequence(_ctrl_state, _att_sp, _manual, R_sp, rollRate, pitchRate, yawRate);
+#endif
+
+					/* limit setpoint lead angle */
+					float tilt_error = 0.0f;
+					float yaw_error = 0.0f;
+//					math::Quaternion q_cur(_ctrl_state.q);
+//					math::Matrix<3, 3> R_cur = q_cur.to_dcm();
+//					math::Vector<3> zb(R_cur.data[2]);
+//					math::Vector<3> zsp(R_sp.data[2]);
+//					tilt_error = acosf(zb * zsp);
+//					math::Vector<3> xb(R_cur.data[0]);
+//					math::Vector<3> xsp(R_sp.data[0]);
+//					yaw_error = acosf(xb * xsp);
+
+					/* update attitude setpoint rotation matrix */
+					/* interpret roll/pitch/yaw inputs as rate demands */
+					float dRoll = 0.0f;
+					float dPitch = 0.0f;
+					float dYaw = 0.0f;
+
+					if (tilt_error < M_PI_4_F) {
+						dRoll = rollRate * dt;
+						dPitch = pitchRate * dt;
+					}
+
+					if (yaw_error < M_PI_4_F) {
+						dYaw = yawRate * dt;
+					}
+
+					math::Matrix<3, 3> R_xy;
+					R_xy.from_euler(dRoll, dPitch, 0.0f);
+
+					math::Matrix<3, 3> R_z;
+					R_z.from_euler(0.0f, 0.0f, dYaw);
+
+					R_sp = R_z * R_sp;
+
+					R_sp = R_sp * R_xy;
+
+					/* renormalize rows */
+					for (int row = 0; row < 3; row++) {
+						math::Vector<3> rvec(R_sp.data[row]);
+						R_sp.set_row(row, rvec.normalized());
+					}
+
+					// this block is not necessary for attitude control
+					{
+						memcpy(&_att_sp.R_body[0], R_sp.data, sizeof(_att_sp.R_body));
+						math::Vector<3> eulerAngles = R_sp.to_euler();
+						_att_sp.roll_body = eulerAngles.data[0];
+						_att_sp.pitch_body = eulerAngles.data[1];
+						_att_sp.yaw_body = eulerAngles.data[2];
+					}
+
+				} else if (_params.opt_recover <= 0) {
+					/* not in ACRO mode and optimal recovery is not in use */
+					_att_sp.roll_body = _manual.y * _params.man_roll_max;
+					_att_sp.pitch_body = -_manual.x * _params.man_pitch_max;
+
 					// construct attitude setpoint rotation matrix. modify the setpoints for roll
 					// and pitch such that they reflect the user's intention even if a yaw error
 					// (yaw_sp - yaw) is present. In the presence of a yaw error constructing a rotation matrix

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -87,7 +87,9 @@
 #include <controllib/blocks.hpp>
 #include <controllib/block/BlockParam.hpp>
 
+#if defined CONFIG_ARCH_BOARD_SITL || defined CONFIG_ARCH_BOARD_PX4FMU_V3 || defined CONFIG_ARCH_BOARD_PX4FMU_V4
 #include "mc_sequencer.h"
+#endif
 
 #define TILT_COS_MAX	0.7f
 #define SIGMA			0.000001f
@@ -2149,6 +2151,7 @@ MulticopterPositionControl::task_main()
 				}
 			}
 
+#if defined CONFIG_ARCH_BOARD_SITL || defined CONFIG_ARCH_BOARD_PX4FMU_V3 || defined CONFIG_ARCH_BOARD_PX4FMU_V4
 				// attitude setpoint rotation matrix
 				math::Matrix<3, 3> R_sp;
 
@@ -2286,8 +2289,63 @@ MulticopterPositionControl::task_main()
 
 
 			_att_sp.timestamp = hrt_absolute_time();
+#else
+
+				// attitude setpoint rotation matrix
+				math::Matrix<3, 3> R_sp;
+
+				if (_params.opt_recover <= 0) {
+					/* not in ACRO mode and optimal recovery is not in use */
+					_att_sp.roll_body = _manual.y * _params.man_roll_max;
+					_att_sp.pitch_body = -_manual.x * _params.man_pitch_max;
+
+					// construct attitude setpoint rotation matrix. modify the setpoints for roll
+					// and pitch such that they reflect the user's intention even if a yaw error
+					// (yaw_sp - yaw) is present. In the presence of a yaw error constructing a rotation matrix
+					// from the pure euler angle setpoints will lead to unexpected attitude behaviour from
+					// the user's view as the euler angle sequence uses the  yaw setpoint and not the current
+					// heading of the vehicle.
+
+					// calculate our current yaw error
+					float yaw_error = _wrap_pi(_att_sp.yaw_body - _yaw);
+
+					// compute the vector obtained by rotating a z unit vector by the rotation
+					// given by the roll and pitch commands of the user
+					math::Vector<3> zB = {0, 0, 1};
+					math::Matrix<3, 3> R_sp_roll_pitch;
+					R_sp_roll_pitch.from_euler(_att_sp.roll_body, _att_sp.pitch_body, 0);
+					math::Vector<3> z_roll_pitch_sp = R_sp_roll_pitch * zB;
+
+
+					// transform the vector into a new frame which is rotated around the z axis
+					// by the current yaw error. this vector defines the desired tilt when we look
+					// into the direction of the desired heading
+					math::Matrix<3, 3> R_yaw_correction;
+					R_yaw_correction.from_euler(0.0f, 0.0f, -yaw_error);
+					z_roll_pitch_sp = R_yaw_correction * z_roll_pitch_sp;
+
+					// use the formula z_roll_pitch_sp = R_tilt * [0;0;1]
+					// to calculate the new desired roll and pitch angles
+					// R_tilt can be written as a function of the new desired roll and pitch
+					// angles. we get three equations and have to solve for 2 unknowns
+					float pitch_new = asinf(z_roll_pitch_sp(0));
+					float roll_new = -atan2f(z_roll_pitch_sp(1), z_roll_pitch_sp(2));
+
+					R_sp.from_euler(roll_new, pitch_new, _att_sp.yaw_body);
+					memcpy(&_att_sp.R_body[0], R_sp.data, sizeof(_att_sp.R_body));
+				}
+
+				/* copy quaternion setpoint to attitude setpoint topic */
+				math::Quaternion q_sp;
+				q_sp.from_dcm(R_sp);
+				memcpy(&_att_sp.q_d[0], &q_sp.data[0], sizeof(_att_sp.q_d));
+			}
+
+			_att_sp.timestamp = hrt_absolute_time();
+#endif
 
 		} else {
+
 			reset_yaw_sp = true;
 			_att_sp.yaw_sp_move_rate = 0.0f;
 		}

--- a/src/modules/mc_pos_control/mc_sequencer.cpp
+++ b/src/modules/mc_pos_control/mc_sequencer.cpp
@@ -1,0 +1,440 @@
+#include "mc_sequencer.h"
+
+
+#ifdef JUST_FLIPS
+/*
+ * Perform a 360 degree roll or pitch flip starting and ending at current attitude
+ *
+ * Inputs:
+ * ctrl_state: for current attitude quaternion
+ * manual: sequence trigger switch
+ *
+ * Outputs:
+ * att_sp: thrust and rotation angle setpoints
+ * R_sp: attitude setpoint
+ * rollRate, pitchRate, yawRate: rotation rate commands
+ */
+void flip_sequence(
+	struct control_state_s &ctrl_state,
+	struct vehicle_attitude_setpoint_s &att_sp,
+	struct manual_control_setpoint_s &manual,
+	math::Matrix<3, 3> &R_sp,
+	float &rollRate, float &pitchRate, float &yawRate)
+{
+
+	enum Flip_state {
+		IDLE, CLIMB, ROLL, PITCH, FINISH
+	};
+	static Flip_state cur_state = IDLE;
+	static Flip_state last_state = FINISH;
+
+	static math::Quaternion q_end;
+	static math::Quaternion q_cur;
+	static math::Vector<3> euler_end;
+	static uint64_t start_finish = 0;
+	const uint64_t climb_dur = 1.0f;
+
+	float cur_time = hrt_absolute_time() / 1e6f;
+	static float start_time = cur_time;
+
+	/* if seq_switch just transitioned from off to on, begin substituting sequencer
+	 * controls for manual controls. The sequencer could be a separate module publishing
+	 * manual_control_setpoint messages, or a smaller message containing only
+	 * x, y, z, r
+	 */
+//						uint8_t seq_switch = _manual.seq_switch;
+
+	// for SITL, simulate seq_switch activation every 5 seconds
+	static uint8_t seq_switch = manual_control_setpoint_s::SWITCH_POS_OFF;
+
+	if ((cur_time - start_time) > 10.0f) {
+		if (seq_switch == manual_control_setpoint_s::SWITCH_POS_OFF) {
+			seq_switch = manual_control_setpoint_s::SWITCH_POS_ON;
+			PX4_INFO("seq_switch on: at %f", (double) cur_time);
+		}
+
+		start_time = cur_time;
+	}
+
+	// reduce thrust when inverted (Earth z points down in body frame)
+	// TODO: use ctrl_state instead
+	bool inversion = (att_sp.R_body[8] > 0.0f);
+	static bool inverted = false;
+
+	if (inversion != inverted) {
+		inverted = inversion;
+
+		PX4_INFO("inversion at %6.3f, roll: %6.3f, pitch: %6.3f",
+			 (double) cur_time, (double) att_sp.roll_body,
+			 (double) att_sp.pitch_body);
+	}
+
+	/* substitute attitude sequence for _manual_control_setpoint */
+	if (cur_state != last_state) {
+		PX4_INFO("state: %d at %6.3f", cur_state, (double) cur_time);
+		last_state = cur_state;
+	}
+
+	switch (cur_state) {
+
+	case CLIMB: {
+
+			rollRate = 0.0f;
+			pitchRate = 0.0f;
+			yawRate = 0.0f;
+			att_sp.thrust = 0.9f;
+
+			if ((cur_time - start_time) > climb_dur) {
+//				cur_state = ROLL;
+				cur_state = PITCH;
+			}
+
+			break;
+		}
+
+	case ROLL: {
+			rollRate = M_TWOPI_F;
+			pitchRate = 0.0f;
+			yawRate = 0.0f;
+
+			if (att_sp.R_body[8] > 0.0f) {
+				att_sp.thrust = 0.5f;
+
+			} else {
+				att_sp.thrust = 0.2f;
+			}
+
+			q_cur.set(ctrl_state.q);
+			math::Quaternion q_err = q_cur * q_end.conjugated();
+			float error = acosf(fabsf(q_err.data[0]));
+
+			if ((cur_time - start_time) > (climb_dur + 0.25f) && (error < 0.24f)) {
+				rollRate = 0.0f;
+				R_sp.from_euler(euler_end.data[0], euler_end.data[1],
+						euler_end.data[2]);
+				memcpy(&att_sp.R_body[0], R_sp.data, sizeof(att_sp.R_body));
+				cur_state = FINISH;
+				start_finish = cur_time;
+
+				printf("finish roll: q_cur: "); q_cur.print();
+				printf("q_end: "); q_end.print();
+				printf("q_err: "); q_err.print();
+				PX4_INFO("error %6.3f", (double) error);
+			}
+
+			break;
+		}
+
+	case PITCH: {
+			rollRate = 0.0f;
+			pitchRate = M_TWOPI_F;
+			yawRate = 0.0f;
+
+			if (att_sp.R_body[8] > 0.0f) {
+				att_sp.thrust = 0.5f;
+
+			} else {
+				att_sp.thrust = 0.2f;
+			}
+
+			q_cur.set(ctrl_state.q);
+			math::Quaternion q_err = q_cur * q_end.conjugated();
+			float error = acosf(fabsf(q_err.data[0]));
+
+			if ((cur_time - start_time) > (climb_dur + 0.5f) && (error < 0.24f)) {
+				pitchRate = 0.0f;
+				R_sp.from_euler(euler_end.data[0], euler_end.data[1],
+						euler_end.data[2]);
+				memcpy(&att_sp.R_body[0], R_sp.data, sizeof(att_sp.R_body));
+				cur_state = FINISH;
+				start_finish = cur_time;
+
+				printf("finish pitch: q_cur: ");
+				q_cur.print(); printf("q_end: ");
+				q_end.print(); printf("q_err: ");
+				q_err.print(); PX4_INFO("error %6.3f", (double) error);
+			}
+
+			break;
+		}
+
+	case FINISH: {
+			// return to starting orientation
+			q_cur.set(ctrl_state.q);
+			math::Quaternion q_err = q_cur * q_end.conjugated();
+			float error = acosf(fabsf(q_err.data[0]));
+
+			// exit once error is small, or timeout
+			if (error < 0.005f || (cur_time - start_finish) > 5.0f) {
+				cur_state = IDLE;
+				seq_switch = manual_control_setpoint_s::SWITCH_POS_OFF;
+				PX4_INFO("sequence end at %6.3f, duration: %6.3f",
+					 (double) cur_time,
+					 (double)(cur_time - start_time));
+				printf("q_cur: "); q_cur.print();
+				printf("q_end: "); q_end.print();
+				printf("q_err: "); q_err.print();
+				PX4_INFO("error %6.3f", (double) error);
+				printf("final Euler angles: "); q_cur.to_euler().print();
+			}
+
+			break;
+		}
+
+	case IDLE: {
+
+			if (seq_switch == manual_control_setpoint_s::SWITCH_POS_ON) {
+				cur_state = CLIMB;
+
+				// initialize sequencer
+				q_end.set(ctrl_state.q);
+				euler_end = q_end.to_euler();
+				// set roll and pitch to zero
+				euler_end.data[0] = 0.0f;
+				euler_end.data[1] = 0.0f;
+				q_end.from_euler(euler_end.data[0], euler_end.data[1],
+						 euler_end.data[2]);
+				printf("starting Euler angles: "); q_end.to_euler().print();
+				printf("q_end: "); q_end.print();
+			}
+
+			break;
+		}
+	}
+
+}
+#else
+
+// TODO: make sure this gets stored in codespace ROM to avoid wasting RAM
+static const struct seq_entry_s coord_turn[] {
+	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.5f, -0.25f, 0.0f}, 0.0f},
+	{Seq_state::RATE, 0.8f, 0.0f, 0.0f, 0.9f, { -0.707f, 0.0f, 0.0f}, 30.0f},
+	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
+};
+static const struct seq_entry_s tilt_lr[] {
+	{Seq_state::ATTITUDE, 0.6f, 0.0f, 0.0f, 0.0f, {0.707f, 0.0f, 0.0f}, 1.0f},
+	{Seq_state::ATTITUDE, 0.6f, 0.0f, 0.0f, 0.0f, { -0.707f, 0.0f, 0.0f}, 1.0f},
+	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
+};
+static const struct seq_entry_s pitch_flip[] {
+	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+	{Seq_state::RATE, 0.2f, 0.0f, M_TWOPI_F, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f},
+	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f},
+	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
+};
+static const struct seq_entry_s roll_flip[] {
+	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+	{Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f},
+	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f},
+	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
+};
+static const struct seq_entry_s two_point_roll[] {
+	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+
+	{Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+
+	{Seq_state::RATE, 0.2f, 0.0F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+
+	{Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+
+	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f},
+	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
+};
+static const struct sequence coord_turn_seq {
+	sizeof(coord_turn) / sizeof(seq_entry_s), coord_turn
+};
+static const struct sequence tilt_lr_seq {
+	sizeof(tilt_lr) / sizeof(seq_entry_s), tilt_lr
+};
+static const struct sequence pitch_flip_seq {
+	sizeof(pitch_flip) / sizeof(seq_entry_s), pitch_flip
+};
+static const struct sequence roll_flip_seq {
+	sizeof(roll_flip) / sizeof(seq_entry_s), roll_flip
+};
+static const struct sequence two_point_roll_seq {
+	sizeof(two_point_roll) / sizeof(seq_entry_s), two_point_roll
+};
+static const struct sequence *cur_sequence = &coord_turn_seq;
+
+/*
+ * Execute a sequence of commands: each command is a seq_entry_s struct specifying
+ * 	type: attitude, rate, or delay
+ * 	roll/pitch/yaw rates
+ * 	target attitude (fixed xyz Euler angles)
+ * 	delay
+ *
+ * Inputs:
+ * ctrl_state: for current attitude quaternion
+ * manual: sequence trigger switch
+ *
+ * Outputs:
+ * att_sp: thrust and rotation angle setpoints
+ * R_sp: attitude setpoint
+ * rollRate, pitchRate, yawRate: rotation rate commands
+ */
+void prog_sequence(
+	struct control_state_s &ctrl_state,
+	struct vehicle_attitude_setpoint_s &att_sp,
+	struct manual_control_setpoint_s &manual,
+	math::Matrix<3, 3> &R_sp,
+	float &rollRate, float &pitchRate, float &yawRate)
+{
+
+	static Seq_state cur_state = IDLE;
+	static Seq_state last_state = IDLE;
+	static seq_entry_s seq_entry;
+	static int seq_index = 0;
+
+	static math::Quaternion q_end;
+	static math::Quaternion q_cur;
+	static math::Vector<3> euler_end;
+
+	float cur_time = (double)hrt_absolute_time() / 1e6;
+	static float start_sequence = -1.0f;
+	static float start_time = cur_time;
+
+	static uint8_t seq_switch = manual_control_setpoint_s::SWITCH_POS_OFF;
+
+	/* if seq_switch is on, begin substituting sequencer
+	 * controls for manual controls.
+	 */
+//						uint8_t seq_switch = _manual.seq_switch;
+
+	// for SITL, simulate seq_switch activation
+
+//	if ((cur_time - start_sequence) > 10.0f) {
+	if (start_sequence < 0.0f) {
+		seq_switch = manual_control_setpoint_s::SWITCH_POS_ON;
+		PX4_INFO("seq_switch on: at %f", (double) cur_time);
+
+		start_sequence = cur_time;
+	}
+
+	// perform state transitions
+	switch (cur_state) {
+
+	case IDLE: {
+
+			if (seq_switch == manual_control_setpoint_s::SWITCH_POS_ON) {
+				seq_switch = manual_control_setpoint_s::SWITCH_POS_OFF;
+				seq_index = -1;
+				cur_state = NEXT_ENTRY;
+			}
+
+			break;
+		}
+
+	case RATE: {
+			// immediate transition to delay state
+			cur_state = DELAY;
+			break;
+		}
+
+	case ATTITUDE: {
+			// wait for target attitude
+			att_sp.thrust = seq_entry.thrust;	// this does not persist across calls
+
+			q_cur.set(ctrl_state.q);
+			math::Quaternion q_err = q_cur * q_end.conjugated();
+			float error = acosf(fabsf(q_err.data[0]));
+
+			// once attitude is reached (or timeout), transition to DELAY
+			if (error < 0.005f || (cur_time - start_time) > 5.0f) {
+				cur_state = DELAY;
+				printf("q_err: "); q_err.print();
+				PX4_INFO("error %6.3f", (double) error);
+				printf("final Euler angles: "); q_cur.to_euler().print();
+			}
+
+			break;
+		}
+
+	case DELAY: {
+			// set rates
+			att_sp.thrust = seq_entry.thrust;	// this does not persist across calls
+			rollRate = seq_entry.rollRate;
+			pitchRate = seq_entry.pitchRate;
+			yawRate = seq_entry.yawRate;
+
+			// delay
+			if (cur_time >= (start_time + seq_entry.delay)) {
+				// then perform next sequence entry
+				cur_state = NEXT_ENTRY;
+			}
+
+			break;
+		}
+
+	case NEXT_ENTRY:
+		att_sp.thrust = seq_entry.thrust;	// this does not persist across calls
+		cur_state = seq_entry.type;
+		break;
+	}
+
+	// perform state entry actions
+	if (cur_state != last_state) {
+		start_time = cur_time;
+
+		switch (cur_state) {
+		case IDLE:
+			// initialize sequencer
+			seq_index = 0;
+			seq_switch = manual_control_setpoint_s::SWITCH_POS_OFF;
+			PX4_INFO("sequence end at %6.3f, duration: %6.3f",
+				 (double) cur_time,
+				 (double)(cur_time - start_sequence));
+			PX4_INFO("IDLE state: %d at %6.3f, thrust: %6.3f", cur_state, (double) cur_time, (double)att_sp.thrust);
+			break;
+
+		case RATE:
+			// set rates
+			rollRate = seq_entry.rollRate;
+			pitchRate = seq_entry.pitchRate;
+			yawRate = seq_entry.yawRate;
+			PX4_INFO("RATE state: %d at %6.3f, thrust: %6.3f", cur_state, (double) cur_time, (double)att_sp.thrust);
+			break;
+
+		case ATTITUDE:
+			att_sp.thrust = seq_entry.thrust;	// this does not persist across calls
+			// set target attitude
+			R_sp.from_euler(seq_entry.target_euler[0], seq_entry.target_euler[1],
+					seq_entry.target_euler[2]);
+			memcpy(&att_sp.R_body[0], R_sp.data, sizeof(att_sp.R_body));
+			q_end.from_euler(seq_entry.target_euler[0], seq_entry.target_euler[1],
+					 seq_entry.target_euler[2]);
+			PX4_INFO("ATTITUDE state: %d at %6.3f, thrust: %6.3f", cur_state, (double) cur_time, (double)att_sp.thrust);
+//			printf("R_sp:\n"); R_sp.print();
+//			printf("q_end: "); q_end.print();
+//			printf("target Euler angles: "); q_end.to_euler().print();
+			break;
+
+		case DELAY:
+			PX4_INFO("DELAY duration: %6.3f at %6.3f, thrust: %6.3f", (double)seq_entry.delay, (double) cur_time,
+				 (double)att_sp.thrust);
+			break;
+
+		case NEXT_ENTRY:
+			seq_index++;
+			PX4_INFO("NEXT_ENTRY seq_index: %d at %6.3f, thrust: %6.3f", seq_index, (double) cur_time, (double)att_sp.thrust);
+
+			if (seq_index < cur_sequence->N_entries) {
+				seq_entry = cur_sequence->entries[seq_index];
+				PX4_INFO("seq_entry: type: %d, \nrates: (%6.3f, %6.3f, %6.3f), \ntarget_euler: (%6.3f, %6.3f, %6.3f), \nthrust: %6.3f delay: %6.3f",
+					 seq_entry.type,
+					 (double)seq_entry.rollRate, (double)seq_entry.pitchRate, (double)seq_entry.yawRate,
+					 (double)seq_entry.target_euler[0], (double)seq_entry.target_euler[1], (double)seq_entry.target_euler[2],
+					 (double)seq_entry.thrust, (double)seq_entry.delay);
+
+			} else {
+				cur_state = IDLE;
+			}
+
+		default:
+			break;
+		}
+
+		last_state = cur_state;
+	}
+}
+#endif

--- a/src/modules/mc_pos_control/mc_sequencer.cpp
+++ b/src/modules/mc_pos_control/mc_sequencer.cpp
@@ -2,7 +2,7 @@
 
 #include "mc_sequencer.h"
 
-// TODO: make sure this gets stored in codespace ROM to avoid wasting RAM
+#define SEQ_ENTRY(type, thrust, delay, r, p, y) (seq_entry_s {Seq_state::type, thrust, {r,p,y}, delay})
 
 sequence *get_sequence(sequence_set entry)
 {
@@ -11,48 +11,52 @@ sequence *get_sequence(sequence_set entry)
 	switch (entry) {
 	case coord_turn:
 		result = (sequence *) new sequence(3);
-		result->entries[0] = seq_entry_s {Seq_state::RATE, 0.6f, {0.7f, -0.25f, 0.4f}, 1.0f};
-		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.7f, {0.0f, 0.0f, 0.73f}, 26.0f};
-		result->entries[2] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, {0.0f, 0.0f, NAN}, 0.0f};
+		result->entries[0] = SEQ_ENTRY(RATE, 0.6f, 1.0f, 0.7f, -0.25f, 0.4f);
+		result->entries[1] = SEQ_ENTRY(RATE, 0.7f, 26.0f, 0.0f, 0.0f, 0.73f);
+		result->entries[2] = SEQ_ENTRY(ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, NAN);
 		break;
 
-//	case roll_flip:
-//		result = (sequence *) new sequence(4);
-//		result->entries[0] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
-//		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f};
-//		result->entries[2] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f};
-//		result->entries[3] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
-//		break;
-//
-//	case hover:
-//		result = (sequence *) new sequence(1);
-//		result->entries[0] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
-//		break;
-//
-//	case pitch_flip:
-//		result = (sequence *) new sequence(4);
-//		result->entries[0] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.8f};
-//		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.2f, 0.0f, M_TWOPI_F, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f};
-//		result->entries[2] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.6f};
-//		result->entries[3] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
-//		break;
-//
-//	case two_point_roll:
-//		result = (sequence *) new sequence(6);
-//		result->entries[0] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
-//		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
-//		result->entries[2] = seq_entry_s {Seq_state::RATE, 0.2f, 0.0F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
-//		result->entries[3] = seq_entry_s {Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
-//		result->entries[4] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f};
-//		result->entries[5] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
-//		break;
-//
-//	case tilt_lr:
-//		result = (sequence *) new sequence(3);
-//		result->entries[0] = seq_entry_s {Seq_state::RATE, 0.4f, 1.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
-//		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.4f, -1.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f};
-//		result->entries[2] = seq_entry_s {Seq_state::RATE, 0.4f, 1.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
-//		break;
+#if defined (CONFIG_ARCH_BOARD_PX4FMU_V4) || defined (CONFIG_ARCH_BOARD_SITL)
+
+	case roll_flip:
+		result = (sequence *) new sequence(4);
+		result->entries[0] = SEQ_ENTRY(ATTITUDE, 0.9f, 0.6f, 0.0f, 0.3f, NAN);
+		result->entries[1] = SEQ_ENTRY(RATE, 0.2f, 1.0f, M_TWOPI_F, 0.0f, 0.0f);
+		result->entries[2] = SEQ_ENTRY(RATE, 0.9f, 0.5f, 0.0f, 0.0f, 0.0f);
+		result->entries[3] = SEQ_ENTRY(ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, NAN);
+		break;
+
+	case hover:
+		result = (sequence *) new sequence(1);
+		result->entries[0] = SEQ_ENTRY(ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, 0.0f);
+		break;
+
+	case pitch_flip:
+		result = (sequence *) new sequence(4);
+		result->entries[0] = SEQ_ENTRY(ATTITUDE, 0.8f, 0.8f, 0.0f, 0.0f, 0.0f);
+		result->entries[1] = SEQ_ENTRY(RATE, 0.2f, 1.0f, 0.0f, M_TWOPI_F, 0.0f);
+		result->entries[2] = SEQ_ENTRY(ATTITUDE, 0.8f, 0.6f, 0.0f, 0.0f, 0.0f);
+		result->entries[3] = SEQ_ENTRY(ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, 0.0f);
+		break;
+
+	case two_point_roll:
+		result = (sequence *) new sequence(6);
+		result->entries[0] = SEQ_ENTRY(ATTITUDE, 0.8f, 0.5f, 0.0f, 0.0f, 0.0f);
+		result->entries[1] = SEQ_ENTRY(RATE, 0.2f, 0.5f, M_TWOPI_F, 0.0f, 0.0f);
+		result->entries[2] = SEQ_ENTRY(RATE, 0.2f, 0.5f, 0.0F, 0.0f, 0.0f);
+		result->entries[3] = SEQ_ENTRY(RATE, 0.2f, 0.5f, M_TWOPI_F, 0.0f, 0.0f);
+		result->entries[4] = SEQ_ENTRY(ATTITUDE, 0.8f, 0.25f, 0.0f, 0.0f, 0.0f);
+		result->entries[5] = SEQ_ENTRY(ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, 0.0f);
+		break;
+
+	case tilt_lr:
+		result = (sequence *) new sequence(3);
+		result->entries[0] = SEQ_ENTRY(RATE, 0.4f, 0.5f, 1.0f, 0.0f, 0.0f);
+		result->entries[1] = SEQ_ENTRY(RATE, 0.4f, 1.0f, -1.0f, 0.0f, 0.0f);
+		result->entries[2] = SEQ_ENTRY(RATE, 0.4f, 1.0f, 0.5f, 0.0f, 0.0f);
+		break;
+
+#endif
 	}
 
 	return result;

--- a/src/modules/mc_pos_control/mc_sequencer.cpp
+++ b/src/modules/mc_pos_control/mc_sequencer.cpp
@@ -3,70 +3,70 @@
 #include "mc_sequencer.h"
 
 // TODO: make sure this gets stored in codespace ROM to avoid wasting RAM
-static const struct seq_entry_s hover[] {
-	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
-};
-static const struct sequence hover_seq {
-	sizeof(hover) / sizeof(seq_entry_s), hover
-};
 
-static const struct seq_entry_s coord_turn[] {
-	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.5f, -0.25f, 0.0f}, 0.0f},
-	{Seq_state::RATE, 0.8f, 0.0f, 0.0f, 0.785f, { -0.707f, 0.0f, 0.0f}, 26.0f},
-	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
-};
-static const struct sequence coord_turn_seq {
-	sizeof(coord_turn) / sizeof(seq_entry_s), coord_turn
-};
+sequence *get_sequence(sequence_set entry)
+{
+	struct sequence *result = nullptr;
 
-static const struct seq_entry_s pitch_flip[] {
-	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
-	{Seq_state::RATE, 0.2f, 0.0f, M_TWOPI_F, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f},
-	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f},
-	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
-};
-static const struct sequence pitch_flip_seq {
-	sizeof(pitch_flip) / sizeof(seq_entry_s), pitch_flip
-};
+	switch (entry) {
+	case hover:
+		result = (sequence *) new sequence(1);
+		result->entries[0] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
+		break;
 
-static const struct seq_entry_s roll_flip[] {
-	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
-	{Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f},
-	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f},
-	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
-};
-static const struct sequence roll_flip_seq {
-	sizeof(roll_flip) / sizeof(seq_entry_s), roll_flip
-};
+	case coord_turn:
+		result = (sequence *) new sequence(3);
+		result->entries[0] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.5f, -0.25f, 0.0f}, 0.0f};
+		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.8f, 0.0f, 0.0f, 0.785f, { -0.707f, 0.0f, 0.0f}, 26.0f};
+		result->entries[2] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
+		break;
 
-static const struct seq_entry_s two_point_roll[] {
-	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+	case pitch_flip:
+		result = (sequence *) new sequence(4);
+		result->entries[0] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.8f};
+		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.2f, 0.0f, M_TWOPI_F, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f};
+		result->entries[2] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.6f};
+		result->entries[3] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
+		break;
 
-	{Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+	case roll_flip:
+		result = (sequence *) new sequence(4);
+		result->entries[0] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
+		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f};
+		result->entries[2] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f};
+		result->entries[3] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
+		break;
 
-	{Seq_state::RATE, 0.2f, 0.0F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+	case two_point_roll:
+		result = (sequence *) new sequence(6);
+		result->entries[0] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
+		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
+		result->entries[2] = seq_entry_s {Seq_state::RATE, 0.2f, 0.0F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
+		result->entries[3] = seq_entry_s {Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
+		result->entries[4] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f};
+		result->entries[5] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
+		break;
 
-	{Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+	case tilt_lr:
+		result = (sequence *) new sequence(3);
+		result->entries[0] = seq_entry_s {Seq_state::RATE, 0.4f, 1.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
+		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.4f, -1.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f};
+		result->entries[2] = seq_entry_s {Seq_state::RATE, 0.4f, 1.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
+		break;
+	}
 
-	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f},
-	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
-};
-static const struct sequence two_point_roll_seq {
-	sizeof(two_point_roll) / sizeof(seq_entry_s), two_point_roll
-};
+	return result;
+}
 
-static const struct seq_entry_s tilt_lr[] {
-	{Seq_state::RATE, 0.4f, 1.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
-	{Seq_state::RATE, 0.4f, -1.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f},
-	{Seq_state::RATE, 0.4f, 1.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f}
-};
-static const struct sequence tilt_lr_seq {
-	sizeof(tilt_lr) / sizeof(seq_entry_s), tilt_lr
-};
+// runtime selection of sequence to be executed and SITL repetition interval
+static struct sequence *cur_sequence = nullptr;
+static float trigger_interval = 10.0f;
 
-// compile-time selection of sequence to be executed and SITL repetition interval
-static const struct sequence *cur_sequence = &coord_turn_seq;
-#define TRIG_INTVL 30.0F
+void prog_sequence_init(enum sequence_set seq, float intvl)
+{
+	cur_sequence = get_sequence(seq);
+	trigger_interval = intvl;
+}
 
 /*
  * Execute a sequence of commands: each command is a seq_entry_s struct specifying
@@ -108,6 +108,8 @@ void prog_sequence(
 
 	static uint8_t seq_switch_last = manual_control_setpoint_s::SWITCH_POS_OFF;
 
+	if (cur_sequence == nullptr) { return; }
+
 #if !defined CONFIG_ARCH_BOARD_SITL
 
 	/* if seq_switch is on, begin substituting sequencer
@@ -127,12 +129,12 @@ void prog_sequence(
 	static uint8_t seq_switch = manual_control_setpoint_s::SWITCH_POS_OFF;
 
 	if (seq_switch == manual_control_setpoint_s::SWITCH_POS_OFF) {
-		if ((cur_time - end_sequence) > TRIG_INTVL) {
+		if ((cur_time - end_sequence) > trigger_interval) {
 			seq_switch = manual_control_setpoint_s::SWITCH_POS_ON;
 			PX4_DEBUG("seq_switch on: at %f", (double) cur_time);
 
 		} else if (fmodf((cur_time - start_sequence), 2.0f) < 0.015f) {
-			PX4_DEBUG("seq countdown: %5.3f", (double)(TRIG_INTVL - (cur_time - end_sequence)));
+			PX4_DEBUG("seq countdown: %5.3f", (double)(trigger_interval - (cur_time - end_sequence)));
 		}
 	}
 
@@ -255,7 +257,7 @@ void prog_sequence(
 							    att_sp.yaw_body)); //seq_entry.target_euler[2]));
 
 			q_end.from_euler(seq_entry.target_euler[0], seq_entry.target_euler[1],
-					 seq_entry.target_euler[2]);
+					 att_sp.yaw_body); //seq_entry.target_euler[2]));
 
 			PX4_DEBUG("enter ATTITUDE state: %d at %6.3f, thrust: %6.3f", cur_state, (double) cur_time, (double)att_sp.thrust);
 //			printf("R_sp:\n"); R_sp.print();

--- a/src/modules/mc_pos_control/mc_sequencer.cpp
+++ b/src/modules/mc_pos_control/mc_sequencer.cpp
@@ -1,212 +1,6 @@
 #include <px4_config.h>
-//#if defined CONFIG_ARCH_BOARD_SITL || defined CONFIG_ARCH_BOARD_PX4FMU_V3 || defined CONFIG_ARCH_BOARD_PX4FMU_V4
 
 #include "mc_sequencer.h"
-
-
-#ifdef JUST_FLIPS
-/*
- * Perform a 360 degree roll or pitch flip starting and ending at current attitude
- *
- * Inputs:
- * ctrl_state: for current attitude quaternion
- * manual: sequence trigger switch
- *
- * Outputs:
- * att_sp: thrust and rotation angle setpoints
- * R_sp: attitude setpoint
- * rollRate, pitchRate, yawRate: rotation rate commands
- */
-void flip_sequence(
-	struct control_state_s &ctrl_state,
-	struct vehicle_attitude_setpoint_s &att_sp,
-	struct manual_control_setpoint_s &manual,
-	matrix::Dcmf &R_sp,
-	float &rollRate, float &pitchRate, float &yawRate)
-{
-
-	enum Flip_state {
-		IDLE, CLIMB, ROLL, PITCH, FINISH
-	};
-	static Flip_state cur_state = IDLE;
-	static Flip_state last_state = FINISH;
-
-	static math::Quaternion q_end;
-	static math::Quaternion q_cur;
-	static math::Vector<3> euler_end;
-	static uint64_t start_finish = 0;
-	const uint64_t climb_dur = 1.0f;
-
-	float cur_time = hrt_absolute_time() / 1e6f;
-	static float start_time = cur_time;
-
-	/* if seq_switch just transitioned from off to on, begin substituting sequencer
-	 * controls for manual controls. The sequencer could be a separate module publishing
-	 * manual_control_setpoint messages, or a smaller message containing only
-	 * x, y, z, r
-	 */
-//						uint8_t seq_switch = _manual.seq_switch;
-
-	// for SITL, simulate seq_switch activation every 5 seconds
-	static uint8_t seq_switch = manual_control_setpoint_s::SWITCH_POS_OFF;
-
-	if ((cur_time - start_time) > 10.0f) {
-		if (seq_switch == manual_control_setpoint_s::SWITCH_POS_OFF) {
-			seq_switch = manual_control_setpoint_s::SWITCH_POS_ON;
-			PX4_DEBUG("seq_switch on: at %f", (double) cur_time);
-		}
-
-		start_time = cur_time;
-	}
-
-	// reduce thrust when inverted (Earth z points down in body frame)
-	// TODO: use ctrl_state instead
-	bool inversion = (att_sp.R_body[8] > 0.0f);
-	static bool inverted = false;
-
-	if (inversion != inverted) {
-		inverted = inversion;
-
-		PX4_DEBUG("inversion at %6.3f, roll: %6.3f, pitch: %6.3f",
-			  (double) cur_time, (double) att_sp.roll_body,
-			  (double) att_sp.pitch_body);
-	}
-
-	/* substitute attitude sequence for _manual_control_setpoint */
-	if (cur_state != last_state) {
-		PX4_DEBUG("state: %d at %6.3f", cur_state, (double) cur_time);
-		last_state = cur_state;
-	}
-
-	switch (cur_state) {
-
-	case CLIMB: {
-
-			rollRate = 0.0f;
-			pitchRate = 0.0f;
-			yawRate = 0.0f;
-			att_sp.thrust = 0.9f;
-
-			if ((cur_time - start_time) > climb_dur) {
-//				cur_state = ROLL;
-				cur_state = PITCH;
-			}
-
-			break;
-		}
-
-	case ROLL: {
-			rollRate = M_TWOPI_F;
-			pitchRate = 0.0f;
-			yawRate = 0.0f;
-
-			if (att_sp.R_body[8] > 0.0f) {
-				att_sp.thrust = 0.5f;
-
-			} else {
-				att_sp.thrust = 0.2f;
-			}
-
-			q_cur.set(ctrl_state.q);
-			math::Quaternion q_err = q_cur * q_end.conjugated();
-			float error = acosf(fabsf(q_err.data[0]));
-
-			if ((cur_time - start_time) > (climb_dur + 0.25f) && (error < 0.24f)) {
-				rollRate = 0.0f;
-				R_sp.from_euler(euler_end.data[0], euler_end.data[1],
-						euler_end.data[2]);
-				memcpy(&att_sp.R_body[0], R_sp.data, sizeof(att_sp.R_body));
-				cur_state = FINISH;
-				start_finish = cur_time;
-
-				printf("finish roll: q_cur: "); q_cur.print();
-				printf("q_end: "); q_end.print();
-				printf("q_err: "); q_err.print();
-				PX4_DEBUG("error %6.3f", (double) error);
-			}
-
-			break;
-		}
-
-	case PITCH: {
-			rollRate = 0.0f;
-			pitchRate = M_TWOPI_F;
-			yawRate = 0.0f;
-
-			if (att_sp.R_body[8] > 0.0f) {
-				att_sp.thrust = 0.5f;
-
-			} else {
-				att_sp.thrust = 0.2f;
-			}
-
-			q_cur.set(ctrl_state.q);
-			math::Quaternion q_err = q_cur * q_end.conjugated();
-			float error = acosf(fabsf(q_err.data[0]));
-
-			if ((cur_time - start_time) > (climb_dur + 0.5f) && (error < 0.24f)) {
-				pitchRate = 0.0f;
-				R_sp.from_euler(euler_end.data[0], euler_end.data[1],
-						euler_end.data[2]);
-				memcpy(&att_sp.R_body[0], R_sp.data, sizeof(att_sp.R_body));
-				cur_state = FINISH;
-				start_finish = cur_time;
-
-				printf("finish pitch: q_cur: ");
-				q_cur.print(); printf("q_end: ");
-				q_end.print(); printf("q_err: ");
-				q_err.print(); PX4_DEBUG("error %6.3f", (double) error);
-			}
-
-			break;
-		}
-
-	case FINISH: {
-			// return to starting orientation
-			q_cur.set(ctrl_state.q);
-			math::Quaternion q_err = q_cur * q_end.conjugated();
-			float error = acosf(fabsf(q_err.data[0]));
-
-			// exit once error is small, or timeout
-			if (error < 0.005f || (cur_time - start_finish) > 5.0f) {
-				cur_state = IDLE;
-				seq_switch = manual_control_setpoint_s::SWITCH_POS_OFF;
-				PX4_DEBUG("sequence end at %6.3f, duration: %6.3f",
-					  (double) cur_time,
-					  (double)(cur_time - start_time));
-				printf("q_cur: "); q_cur.print();
-				printf("q_end: "); q_end.print();
-				printf("q_err: "); q_err.print();
-				PX4_DEBUG("error %6.3f", (double) error);
-				printf("final Euler angles: "); q_cur.to_euler().print();
-			}
-
-			break;
-		}
-
-	case IDLE: {
-
-			if (seq_switch == manual_control_setpoint_s::SWITCH_POS_ON) {
-				cur_state = CLIMB;
-
-				// initialize sequencer
-				q_end.set(ctrl_state.q);
-				euler_end = q_end.to_euler();
-				// set roll and pitch to zero
-				euler_end.data[0] = 0.0f;
-				euler_end.data[1] = 0.0f;
-				q_end.from_euler(euler_end.data[0], euler_end.data[1],
-						 euler_end.data[2]);
-				printf("starting Euler angles: "); q_end.to_euler().print();
-				printf("q_end: "); q_end.print();
-			}
-
-			break;
-		}
-	}
-
-}
-#else
 
 // TODO: make sure this gets stored in codespace ROM to avoid wasting RAM
 static const struct seq_entry_s hover[] {
@@ -266,7 +60,7 @@ static const struct seq_entry_s tilt_lr[] {
 static const struct sequence tilt_lr_seq {
 	sizeof(tilt_lr) / sizeof(seq_entry_s), tilt_lr
 };
-static const struct sequence *cur_sequence = &coord_turn_seq;
+static const struct sequence *cur_sequence = &two_point_roll_seq;
 
 /*
  * Execute a sequence of commands: each command is a seq_entry_s struct specifying
@@ -288,7 +82,7 @@ void prog_sequence(
 	struct control_state_s &ctrl_state,
 	struct vehicle_attitude_setpoint_s &att_sp,
 	struct manual_control_setpoint_s &manual,
-	matrix::Dcmf &R_sp,
+	matrix::Quatf &R_sp,
 	float &rollRate, float &pitchRate, float &yawRate)
 {
 
@@ -323,7 +117,7 @@ void prog_sequence(
 
 #else
 	// for SITL, simulate seq_switch activation
-#define TRIG_INTVL 60.0F
+#define TRIG_INTVL 10.0F
 	static uint8_t seq_switch = manual_control_setpoint_s::SWITCH_POS_OFF;
 
 	if (seq_switch == manual_control_setpoint_s::SWITCH_POS_OFF) {
@@ -450,8 +244,8 @@ void prog_sequence(
 			att_sp.thrust = seq_entry.thrust;	// this does not persist across calls
 
 			// set target attitude
-			R_sp = matrix::Dcmf(matrix::Eulerf(seq_entry.target_euler[0], seq_entry.target_euler[1],
-							   att_sp.yaw_body)); //seq_entry.target_euler[2]));
+			R_sp = matrix::Quatf(matrix::Eulerf(seq_entry.target_euler[0], seq_entry.target_euler[1],
+							    att_sp.yaw_body)); //seq_entry.target_euler[2]));
 
 			q_end.from_euler(seq_entry.target_euler[0], seq_entry.target_euler[1],
 					 seq_entry.target_euler[2]);
@@ -478,6 +272,3 @@ void prog_sequence(
 		last_state = cur_state;
 	}
 }
-//#endif
-
-#endif

--- a/src/modules/mc_pos_control/mc_sequencer.cpp
+++ b/src/modules/mc_pos_control/mc_sequencer.cpp
@@ -11,9 +11,9 @@ sequence *get_sequence(sequence_set entry)
 	switch (entry) {
 	case coord_turn:
 		result = (sequence *) new sequence(3);
-		result->entries[0] = seq_entry_s {Seq_state::RATE, 0.6f, 0.65f, -0.25f, 0.4f, {0.0f, 0.0f, 0.0f}, 1.0f};
-		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.7f, 0.0f, 0.0f, 0.73f, {0.0f, 0.0f, 0.0f}, 26.0f};
-		result->entries[2] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
+		result->entries[0] = seq_entry_s {Seq_state::RATE, 0.6f, {0.7f, -0.25f, 0.4f}, 1.0f};
+		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.7f, {0.0f, 0.0f, 0.73f}, 26.0f};
+		result->entries[2] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, {0.0f, 0.0f, 0.0f}, 0.0f};
 		break;
 
 //	case roll_flip:
@@ -190,9 +190,9 @@ void prog_sequence(
 	case DELAY: {
 			// set rates
 			att_sp.thrust = seq_entry.thrust;	// this does not persist across calls
-			rollRate = seq_entry.rollRate;
-			pitchRate = seq_entry.pitchRate;
-			yawRate = seq_entry.yawRate;
+			rollRate = seq_entry.rpy_vals[0];
+			pitchRate = seq_entry.rpy_vals[1];
+			yawRate = seq_entry.rpy_vals[2];
 
 			// delay
 			if (cur_time >= (start_time + seq_entry.delay)) {
@@ -212,10 +212,9 @@ void prog_sequence(
 			att_sp.thrust = seq_entry.thrust;	// this does not persist across calls
 			cur_state = seq_entry.type;
 
-			PX4_DEBUG("seq_entry: type: %d, \nrates: (%6.3f, %6.3f, %6.3f), \ntarget_euler: (%6.3f, %6.3f, %6.3f), \nthrust: %6.3f delay: %6.3f",
+			PX4_DEBUG("seq_entry: type: %d, \nrpy_vals: (%6.3f, %6.3f, %6.3f), \nthrust: %6.3f delay: %6.3f",
 				  seq_entry.type,
-				  (double)seq_entry.rollRate, (double)seq_entry.pitchRate, (double)seq_entry.yawRate,
-				  (double)seq_entry.target_euler[0], (double)seq_entry.target_euler[1], (double)seq_entry.target_euler[2],
+				  (double)seq_entry.rpy_vals[0], (double)seq_entry.rpy_vals[1], (double)seq_entry.rpy_vals[2],
 				  (double)seq_entry.thrust, (double)seq_entry.delay);
 
 		} else {
@@ -243,9 +242,9 @@ void prog_sequence(
 
 		case RATE:
 			// set rates
-			rollRate = seq_entry.rollRate;
-			pitchRate = seq_entry.pitchRate;
-			yawRate = seq_entry.yawRate;
+			rollRate = seq_entry.rpy_vals[0];
+			pitchRate = seq_entry.rpy_vals[1];
+			yawRate = seq_entry.rpy_vals[2];
 			PX4_DEBUG("enter RATE state: %d at %6.3f, thrust: %6.3f", cur_state, (double) cur_time, (double)att_sp.thrust);
 			break;
 
@@ -253,11 +252,11 @@ void prog_sequence(
 			att_sp.thrust = seq_entry.thrust;	// this does not persist across calls
 
 			// set target attitude
-			R_sp = matrix::Quatf(matrix::Eulerf(seq_entry.target_euler[0], seq_entry.target_euler[1],
-							    att_sp.yaw_body)); //seq_entry.target_euler[2]));
+			R_sp = matrix::Quatf(matrix::Eulerf(seq_entry.rpy_vals[0], seq_entry.rpy_vals[1],
+							    att_sp.yaw_body)); //seq_entry.rpy_vals[2]));
 
-			q_end.from_euler(seq_entry.target_euler[0], seq_entry.target_euler[1],
-					 att_sp.yaw_body); //seq_entry.target_euler[2]));
+			q_end.from_euler(seq_entry.rpy_vals[0], seq_entry.rpy_vals[1],
+					 att_sp.yaw_body); //seq_entry.rpy_vals[2]));
 
 			PX4_DEBUG("enter ATTITUDE state: %d at %6.3f, thrust: %6.3f", cur_state, (double) cur_time, (double)att_sp.thrust);
 //			printf("R_sp:\n"); R_sp.print();

--- a/src/modules/mc_pos_control/mc_sequencer.cpp
+++ b/src/modules/mc_pos_control/mc_sequencer.cpp
@@ -140,7 +140,7 @@ void prog_sequence(
 
 #endif
 
-	// perform state transitions
+	// perform state actions
 	switch (cur_state) {
 
 	case IDLE: {
@@ -162,6 +162,7 @@ void prog_sequence(
 	case RATE: {
 			// immediate transition to delay state
 			cur_state = DELAY;
+			att_sp.thrust = seq_entry.thrust;	// this does not persist across calls
 			break;
 		}
 
@@ -241,6 +242,7 @@ void prog_sequence(
 			break;
 
 		case RATE:
+			att_sp.thrust = seq_entry.thrust;	// this does not persist across calls
 			// set rates
 			rollRate = seq_entry.rpy_vals[0];
 			pitchRate = seq_entry.rpy_vals[1];
@@ -266,7 +268,7 @@ void prog_sequence(
 
 		case DELAY:
 			PX4_DEBUG("enter DELAY state, duration: %6.3f at %6.3f, thrust: %6.3f", (double)seq_entry.delay, (double) cur_time,
-				  (double)att_sp.thrust);
+				  (double)seq_entry.thrust);
 			break;
 
 		case NEXT_ENTRY:

--- a/src/modules/mc_pos_control/mc_sequencer.cpp
+++ b/src/modules/mc_pos_control/mc_sequencer.cpp
@@ -1,5 +1,5 @@
 #include <px4_config.h>
-#if defined CONFIG_ARCH_BOARD_SITL || defined CONFIG_ARCH_BOARD_PX4FMU_V3 || defined CONFIG_ARCH_BOARD_PX4FMU_V4
+//#if defined CONFIG_ARCH_BOARD_SITL || defined CONFIG_ARCH_BOARD_PX4FMU_V3 || defined CONFIG_ARCH_BOARD_PX4FMU_V4
 
 #include "mc_sequencer.h"
 
@@ -21,7 +21,7 @@ void flip_sequence(
 	struct control_state_s &ctrl_state,
 	struct vehicle_attitude_setpoint_s &att_sp,
 	struct manual_control_setpoint_s &manual,
-	math::Matrix<3, 3> &R_sp,
+	matrix::Dcmf &R_sp,
 	float &rollRate, float &pitchRate, float &yawRate)
 {
 
@@ -209,57 +209,54 @@ void flip_sequence(
 #else
 
 // TODO: make sure this gets stored in codespace ROM to avoid wasting RAM
-//static const struct seq_entry_s hover[] {
-//	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
-//};
+static const struct seq_entry_s hover[] {
+	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
+};
 
-//static const struct seq_entry_s coord_turn[] {
-//	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.5f, -0.25f, 0.0f}, 0.0f},
-//	{Seq_state::RATE, 0.8f, 0.0f, 0.0f, 0.9f, { -0.707f, 0.0f, 0.0f}, 30.0f},
-//	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
-//};
-//static const struct sequence coord_turn_seq {
-//	sizeof(coord_turn) / sizeof(seq_entry_s), coord_turn
-//};
-//
-//static const struct seq_entry_s pitch_flip[] {
-//	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
-//	{Seq_state::RATE, 0.2f, 0.0f, M_TWOPI_F, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f},
-//	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f},
-//	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
-//};
-//static const struct sequence pitch_flip_seq {
-//	sizeof(pitch_flip) / sizeof(seq_entry_s), pitch_flip
-//};
-//static const struct sequence *cur_sequence = &pitch_flip_seq;
-//
-//static const struct seq_entry_s roll_flip[] {
-//	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
-//	{Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f},
-//	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f},
-//	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
-//};
-//static const struct sequence roll_flip_seq {
-//	sizeof(roll_flip) / sizeof(seq_entry_s), roll_flip
-//};
-//static const struct sequence *cur_sequence = &roll_flip_seq;
-//
-//static const struct seq_entry_s two_point_roll[] {
-//	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
-//
-//	{Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
-//
-//	{Seq_state::RATE, 0.2f, 0.0F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
-//
-//	{Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
-//
-//	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f},
-//	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
-//};
-//static const struct sequence two_point_roll_seq {
-//	sizeof(two_point_roll) / sizeof(seq_entry_s), two_point_roll
-//};
-//static const struct sequence *cur_sequence = &two_point_roll_seq;
+static const struct seq_entry_s coord_turn[] {
+	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.5f, -0.25f, 0.0f}, 0.0f},
+	{Seq_state::RATE, 0.8f, 0.0f, 0.0f, 0.5f, { -0.707f, 0.0f, 0.0f}, 30.0f},
+	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
+};
+static const struct sequence coord_turn_seq {
+	sizeof(coord_turn) / sizeof(seq_entry_s), coord_turn
+};
+
+static const struct seq_entry_s pitch_flip[] {
+	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+	{Seq_state::RATE, 0.2f, 0.0f, M_TWOPI_F, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f},
+	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f},
+	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
+};
+static const struct sequence pitch_flip_seq {
+	sizeof(pitch_flip) / sizeof(seq_entry_s), pitch_flip
+};
+
+static const struct seq_entry_s roll_flip[] {
+	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+	{Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f},
+	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f},
+	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
+};
+static const struct sequence roll_flip_seq {
+	sizeof(roll_flip) / sizeof(seq_entry_s), roll_flip
+};
+
+static const struct seq_entry_s two_point_roll[] {
+	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+
+	{Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+
+	{Seq_state::RATE, 0.2f, 0.0F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+
+	{Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+
+	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f},
+	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
+};
+static const struct sequence two_point_roll_seq {
+	sizeof(two_point_roll) / sizeof(seq_entry_s), two_point_roll
+};
 
 static const struct seq_entry_s tilt_lr[] {
 	{Seq_state::RATE, 0.4f, 1.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
@@ -269,7 +266,7 @@ static const struct seq_entry_s tilt_lr[] {
 static const struct sequence tilt_lr_seq {
 	sizeof(tilt_lr) / sizeof(seq_entry_s), tilt_lr
 };
-static const struct sequence *cur_sequence = &tilt_lr_seq;
+static const struct sequence *cur_sequence = &coord_turn_seq;
 
 /*
  * Execute a sequence of commands: each command is a seq_entry_s struct specifying
@@ -291,7 +288,7 @@ void prog_sequence(
 	struct control_state_s &ctrl_state,
 	struct vehicle_attitude_setpoint_s &att_sp,
 	struct manual_control_setpoint_s &manual,
-	math::Matrix<3, 3> &R_sp,
+	matrix::Dcmf &R_sp,
 	float &rollRate, float &pitchRate, float &yawRate)
 {
 
@@ -326,13 +323,17 @@ void prog_sequence(
 
 #else
 	// for SITL, simulate seq_switch activation
-
+#define TRIG_INTVL 60.0F
 	static uint8_t seq_switch = manual_control_setpoint_s::SWITCH_POS_OFF;
 
-	if ((cur_time - start_sequence) > 10.0f) {
-		seq_switch = manual_control_setpoint_s::SWITCH_POS_ON;
-		PX4_DEBUG("seq_switch on: at %f", (double) cur_time);
+	if (seq_switch == manual_control_setpoint_s::SWITCH_POS_OFF) {
+		if ((cur_time - start_sequence) > TRIG_INTVL) {
+			seq_switch = manual_control_setpoint_s::SWITCH_POS_ON;
+			PX4_DEBUG("seq_switch on: at %f", (double) cur_time);
 
+		} else if (fmodf((cur_time - start_sequence), 2.0f) < 0.015f) {
+			PX4_DEBUG("seq countdown: %5.3f", (double)(TRIG_INTVL - (cur_time - start_sequence)));
+		}
 	}
 
 #endif
@@ -371,11 +372,14 @@ void prog_sequence(
 			float error = acosf(fabsf(q_err.data[0]));
 
 			// once attitude is reached (or timeout), transition to DELAY
-			if (error < 0.005f || (cur_time - start_time) > 5.0f) {
+			if (error < 0.005f || (cur_time - start_time) > 2.0f) {
 				cur_state = DELAY;
-				printf("q_err: "); q_err.print();
+
+				if (error > .005f) { PX4_DEBUG("ATTITUDE state timeout"); }
+
+				PX4_DEBUG("q_err: "); q_err.print();
 				PX4_DEBUG("error %6.3f", (double) error);
-				printf("final Euler angles: "); q_cur.to_euler().print();
+				PX4_DEBUG("final Euler angles: "); q_cur.to_euler().print();
 			}
 
 			break;
@@ -431,7 +435,7 @@ void prog_sequence(
 			PX4_DEBUG("sequence end at %6.3f, duration: %6.3f",
 				  (double) cur_time,
 				  (double)(cur_time - start_sequence));
-			PX4_DEBUG("IDLE state: %d at %6.3f, thrust: %6.3f", cur_state, (double) cur_time, (double)att_sp.thrust);
+			PX4_DEBUG("enter IDLE state: %d at %6.3f, thrust: %6.3f", cur_state, (double) cur_time, (double)att_sp.thrust);
 			break;
 
 		case RATE:
@@ -439,25 +443,27 @@ void prog_sequence(
 			rollRate = seq_entry.rollRate;
 			pitchRate = seq_entry.pitchRate;
 			yawRate = seq_entry.yawRate;
-			PX4_DEBUG("RATE state: %d at %6.3f, thrust: %6.3f", cur_state, (double) cur_time, (double)att_sp.thrust);
+			PX4_DEBUG("enter RATE state: %d at %6.3f, thrust: %6.3f", cur_state, (double) cur_time, (double)att_sp.thrust);
 			break;
 
 		case ATTITUDE:
 			att_sp.thrust = seq_entry.thrust;	// this does not persist across calls
+
 			// set target attitude
-			R_sp.from_euler(seq_entry.target_euler[0], seq_entry.target_euler[1],
-					seq_entry.target_euler[2]);
-			memcpy(&att_sp.R_body[0], R_sp.data, sizeof(att_sp.R_body));
+			R_sp = matrix::Dcmf(matrix::Eulerf(seq_entry.target_euler[0], seq_entry.target_euler[1],
+							   seq_entry.target_euler[2]));
+
 			q_end.from_euler(seq_entry.target_euler[0], seq_entry.target_euler[1],
 					 seq_entry.target_euler[2]);
-			PX4_DEBUG("ATTITUDE state: %d at %6.3f, thrust: %6.3f", cur_state, (double) cur_time, (double)att_sp.thrust);
+
+			PX4_DEBUG("enter ATTITUDE state: %d at %6.3f, thrust: %6.3f", cur_state, (double) cur_time, (double)att_sp.thrust);
 //			printf("R_sp:\n"); R_sp.print();
 //			printf("q_end: "); q_end.print();
 //			printf("target Euler angles: "); q_end.to_euler().print();
 			break;
 
 		case DELAY:
-			PX4_DEBUG("DELAY duration: %6.3f at %6.3f, thrust: %6.3f", (double)seq_entry.delay, (double) cur_time,
+			PX4_DEBUG("enter DELAY state, duration: %6.3f at %6.3f, thrust: %6.3f", (double)seq_entry.delay, (double) cur_time,
 				  (double)att_sp.thrust);
 			break;
 
@@ -472,6 +478,6 @@ void prog_sequence(
 		last_state = cur_state;
 	}
 }
-#endif
+//#endif
 
 #endif

--- a/src/modules/mc_pos_control/mc_sequencer.cpp
+++ b/src/modules/mc_pos_control/mc_sequencer.cpp
@@ -9,11 +9,6 @@ sequence *get_sequence(sequence_set entry)
 	struct sequence *result = nullptr;
 
 	switch (entry) {
-	case hover:
-		result = (sequence *) new sequence(1);
-		result->entries[0] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
-		break;
-
 	case coord_turn:
 		result = (sequence *) new sequence(3);
 		result->entries[0] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.5f, -0.25f, 0.0f}, 0.0f};
@@ -21,38 +16,43 @@ sequence *get_sequence(sequence_set entry)
 		result->entries[2] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
 		break;
 
-	case pitch_flip:
-		result = (sequence *) new sequence(4);
-		result->entries[0] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.8f};
-		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.2f, 0.0f, M_TWOPI_F, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f};
-		result->entries[2] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.6f};
-		result->entries[3] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
-		break;
-
-	case roll_flip:
-		result = (sequence *) new sequence(4);
-		result->entries[0] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
-		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f};
-		result->entries[2] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f};
-		result->entries[3] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
-		break;
-
-	case two_point_roll:
-		result = (sequence *) new sequence(6);
-		result->entries[0] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
-		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
-		result->entries[2] = seq_entry_s {Seq_state::RATE, 0.2f, 0.0F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
-		result->entries[3] = seq_entry_s {Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
-		result->entries[4] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f};
-		result->entries[5] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
-		break;
-
-	case tilt_lr:
-		result = (sequence *) new sequence(3);
-		result->entries[0] = seq_entry_s {Seq_state::RATE, 0.4f, 1.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
-		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.4f, -1.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f};
-		result->entries[2] = seq_entry_s {Seq_state::RATE, 0.4f, 1.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
-		break;
+//	case roll_flip:
+//		result = (sequence *) new sequence(4);
+//		result->entries[0] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
+//		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f};
+//		result->entries[2] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f};
+//		result->entries[3] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
+//		break;
+//
+//	case hover:
+//		result = (sequence *) new sequence(1);
+//		result->entries[0] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
+//		break;
+//
+//	case pitch_flip:
+//		result = (sequence *) new sequence(4);
+//		result->entries[0] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.8f};
+//		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.2f, 0.0f, M_TWOPI_F, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f};
+//		result->entries[2] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.6f};
+//		result->entries[3] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
+//		break;
+//
+//	case two_point_roll:
+//		result = (sequence *) new sequence(6);
+//		result->entries[0] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
+//		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
+//		result->entries[2] = seq_entry_s {Seq_state::RATE, 0.2f, 0.0F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
+//		result->entries[3] = seq_entry_s {Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
+//		result->entries[4] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f};
+//		result->entries[5] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
+//		break;
+//
+//	case tilt_lr:
+//		result = (sequence *) new sequence(3);
+//		result->entries[0] = seq_entry_s {Seq_state::RATE, 0.4f, 1.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
+//		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.4f, -1.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f};
+//		result->entries[2] = seq_entry_s {Seq_state::RATE, 0.4f, 1.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f};
+//		break;
 	}
 
 	return result;

--- a/src/modules/mc_pos_control/mc_sequencer.cpp
+++ b/src/modules/mc_pos_control/mc_sequencer.cpp
@@ -215,7 +215,7 @@ static const struct seq_entry_s hover[] {
 
 static const struct seq_entry_s coord_turn[] {
 	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.5f, -0.25f, 0.0f}, 0.0f},
-	{Seq_state::RATE, 0.8f, 0.0f, 0.0f, 0.5f, { -0.707f, 0.0f, 0.0f}, 30.0f},
+	{Seq_state::RATE, 0.8f, 0.0f, 0.0f, 0.785f, { -0.707f, 0.0f, 0.0f}, 26.0f},
 	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
 };
 static const struct sequence coord_turn_seq {
@@ -451,7 +451,7 @@ void prog_sequence(
 
 			// set target attitude
 			R_sp = matrix::Dcmf(matrix::Eulerf(seq_entry.target_euler[0], seq_entry.target_euler[1],
-							   seq_entry.target_euler[2]));
+							   att_sp.yaw_body)); //seq_entry.target_euler[2]));
 
 			q_end.from_euler(seq_entry.target_euler[0], seq_entry.target_euler[1],
 					 seq_entry.target_euler[2]);

--- a/src/modules/mc_pos_control/mc_sequencer.cpp
+++ b/src/modules/mc_pos_control/mc_sequencer.cpp
@@ -11,8 +11,8 @@ sequence *get_sequence(sequence_set entry)
 	switch (entry) {
 	case coord_turn:
 		result = (sequence *) new sequence(3);
-		result->entries[0] = seq_entry_s {Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.5f, -0.25f, 0.0f}, 0.0f};
-		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.8f, 0.0f, 0.0f, 0.785f, { -0.707f, 0.0f, 0.0f}, 26.0f};
+		result->entries[0] = seq_entry_s {Seq_state::RATE, 0.6f, 0.65f, -0.25f, 0.4f, {0.0f, 0.0f, 0.0f}, 1.0f};
+		result->entries[1] = seq_entry_s {Seq_state::RATE, 0.7f, 0.0f, 0.0f, 0.73f, {0.0f, 0.0f, 0.0f}, 26.0f};
 		result->entries[2] = seq_entry_s {Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f};
 		break;
 

--- a/src/modules/mc_pos_control/mc_sequencer.cpp
+++ b/src/modules/mc_pos_control/mc_sequencer.cpp
@@ -1,3 +1,6 @@
+#include <px4_config.h>
+#if defined CONFIG_ARCH_BOARD_SITL || defined CONFIG_ARCH_BOARD_PX4FMU_V3 || defined CONFIG_ARCH_BOARD_PX4FMU_V4
+
 #include "mc_sequencer.h"
 
 
@@ -50,7 +53,7 @@ void flip_sequence(
 	if ((cur_time - start_time) > 10.0f) {
 		if (seq_switch == manual_control_setpoint_s::SWITCH_POS_OFF) {
 			seq_switch = manual_control_setpoint_s::SWITCH_POS_ON;
-			PX4_INFO("seq_switch on: at %f", (double) cur_time);
+			PX4_DEBUG("seq_switch on: at %f", (double) cur_time);
 		}
 
 		start_time = cur_time;
@@ -64,14 +67,14 @@ void flip_sequence(
 	if (inversion != inverted) {
 		inverted = inversion;
 
-		PX4_INFO("inversion at %6.3f, roll: %6.3f, pitch: %6.3f",
-			 (double) cur_time, (double) att_sp.roll_body,
-			 (double) att_sp.pitch_body);
+		PX4_DEBUG("inversion at %6.3f, roll: %6.3f, pitch: %6.3f",
+			  (double) cur_time, (double) att_sp.roll_body,
+			  (double) att_sp.pitch_body);
 	}
 
 	/* substitute attitude sequence for _manual_control_setpoint */
 	if (cur_state != last_state) {
-		PX4_INFO("state: %d at %6.3f", cur_state, (double) cur_time);
+		PX4_DEBUG("state: %d at %6.3f", cur_state, (double) cur_time);
 		last_state = cur_state;
 	}
 
@@ -119,7 +122,7 @@ void flip_sequence(
 				printf("finish roll: q_cur: "); q_cur.print();
 				printf("q_end: "); q_end.print();
 				printf("q_err: "); q_err.print();
-				PX4_INFO("error %6.3f", (double) error);
+				PX4_DEBUG("error %6.3f", (double) error);
 			}
 
 			break;
@@ -152,7 +155,7 @@ void flip_sequence(
 				printf("finish pitch: q_cur: ");
 				q_cur.print(); printf("q_end: ");
 				q_end.print(); printf("q_err: ");
-				q_err.print(); PX4_INFO("error %6.3f", (double) error);
+				q_err.print(); PX4_DEBUG("error %6.3f", (double) error);
 			}
 
 			break;
@@ -168,13 +171,13 @@ void flip_sequence(
 			if (error < 0.005f || (cur_time - start_finish) > 5.0f) {
 				cur_state = IDLE;
 				seq_switch = manual_control_setpoint_s::SWITCH_POS_OFF;
-				PX4_INFO("sequence end at %6.3f, duration: %6.3f",
-					 (double) cur_time,
-					 (double)(cur_time - start_time));
+				PX4_DEBUG("sequence end at %6.3f, duration: %6.3f",
+					  (double) cur_time,
+					  (double)(cur_time - start_time));
 				printf("q_cur: "); q_cur.print();
 				printf("q_end: "); q_end.print();
 				printf("q_err: "); q_err.print();
-				PX4_INFO("error %6.3f", (double) error);
+				PX4_DEBUG("error %6.3f", (double) error);
 				printf("final Euler angles: "); q_cur.to_euler().print();
 			}
 
@@ -206,56 +209,67 @@ void flip_sequence(
 #else
 
 // TODO: make sure this gets stored in codespace ROM to avoid wasting RAM
-static const struct seq_entry_s coord_turn[] {
-	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.5f, -0.25f, 0.0f}, 0.0f},
-	{Seq_state::RATE, 0.8f, 0.0f, 0.0f, 0.9f, { -0.707f, 0.0f, 0.0f}, 30.0f},
-	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
-};
+//static const struct seq_entry_s hover[] {
+//	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
+//};
+
+//static const struct seq_entry_s coord_turn[] {
+//	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.5f, -0.25f, 0.0f}, 0.0f},
+//	{Seq_state::RATE, 0.8f, 0.0f, 0.0f, 0.9f, { -0.707f, 0.0f, 0.0f}, 30.0f},
+//	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
+//};
+//static const struct sequence coord_turn_seq {
+//	sizeof(coord_turn) / sizeof(seq_entry_s), coord_turn
+//};
+//
+//static const struct seq_entry_s pitch_flip[] {
+//	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+//	{Seq_state::RATE, 0.2f, 0.0f, M_TWOPI_F, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f},
+//	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f},
+//	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
+//};
+//static const struct sequence pitch_flip_seq {
+//	sizeof(pitch_flip) / sizeof(seq_entry_s), pitch_flip
+//};
+//static const struct sequence *cur_sequence = &pitch_flip_seq;
+//
+//static const struct seq_entry_s roll_flip[] {
+//	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+//	{Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f},
+//	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f},
+//	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
+//};
+//static const struct sequence roll_flip_seq {
+//	sizeof(roll_flip) / sizeof(seq_entry_s), roll_flip
+//};
+//static const struct sequence *cur_sequence = &roll_flip_seq;
+//
+//static const struct seq_entry_s two_point_roll[] {
+//	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+//
+//	{Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+//
+//	{Seq_state::RATE, 0.2f, 0.0F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+//
+//	{Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+//
+//	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f},
+//	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
+//};
+//static const struct sequence two_point_roll_seq {
+//	sizeof(two_point_roll) / sizeof(seq_entry_s), two_point_roll
+//};
+//static const struct sequence *cur_sequence = &two_point_roll_seq;
+
 static const struct seq_entry_s tilt_lr[] {
-	{Seq_state::ATTITUDE, 0.6f, 0.0f, 0.0f, 0.0f, {0.707f, 0.0f, 0.0f}, 1.0f},
-	{Seq_state::ATTITUDE, 0.6f, 0.0f, 0.0f, 0.0f, { -0.707f, 0.0f, 0.0f}, 1.0f},
-	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
-};
-static const struct seq_entry_s pitch_flip[] {
-	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
-	{Seq_state::RATE, 0.2f, 0.0f, M_TWOPI_F, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f},
-	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f},
-	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
-};
-static const struct seq_entry_s roll_flip[] {
-	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
-	{Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f},
-	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f},
-	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
-};
-static const struct seq_entry_s two_point_roll[] {
-	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
-
-	{Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
-
-	{Seq_state::RATE, 0.2f, 0.0F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
-
-	{Seq_state::RATE, 0.2f, M_TWOPI_F, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
-
-	{Seq_state::ATTITUDE, 0.8f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.25f},
-	{Seq_state::ATTITUDE, 0.5f, 0.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.0f}
-};
-static const struct sequence coord_turn_seq {
-	sizeof(coord_turn) / sizeof(seq_entry_s), coord_turn
+	{Seq_state::RATE, 0.4f, 1.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f},
+	{Seq_state::RATE, 0.4f, -1.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 1.0f},
+	{Seq_state::RATE, 0.4f, 1.0f, 0.0f, 0.0f, {0.0f, 0.0f, 0.0f}, 0.5f}
 };
 static const struct sequence tilt_lr_seq {
 	sizeof(tilt_lr) / sizeof(seq_entry_s), tilt_lr
 };
-static const struct sequence pitch_flip_seq {
-	sizeof(pitch_flip) / sizeof(seq_entry_s), pitch_flip
-};
-static const struct sequence roll_flip_seq {
-	sizeof(roll_flip) / sizeof(seq_entry_s), roll_flip
-};
-static const struct sequence two_point_roll_seq {
-	sizeof(two_point_roll) / sizeof(seq_entry_s), two_point_roll
-};
-static const struct sequence *cur_sequence = &coord_turn_seq;
+static const struct sequence *cur_sequence = &tilt_lr_seq;
 
 /*
  * Execute a sequence of commands: each command is a seq_entry_s struct specifying
@@ -294,33 +308,50 @@ void prog_sequence(
 	static float start_sequence = -1.0f;
 	static float start_time = cur_time;
 
-	static uint8_t seq_switch = manual_control_setpoint_s::SWITCH_POS_OFF;
+	static uint8_t seq_switch_last = manual_control_setpoint_s::SWITCH_POS_OFF;
+
+#if !defined CONFIG_ARCH_BOARD_SITL
 
 	/* if seq_switch is on, begin substituting sequencer
 	 * controls for manual controls.
 	 */
-//						uint8_t seq_switch = _manual.seq_switch;
+	uint8_t seq_switch = manual.seq_switch;
 
+	// force IDLE if switch transitions to off during a sequence
+	if (seq_switch == manual_control_setpoint_s::SWITCH_POS_OFF &&
+	    seq_switch != seq_switch_last) {
+
+		cur_state = IDLE;
+	}
+
+#else
 	// for SITL, simulate seq_switch activation
 
-//	if ((cur_time - start_sequence) > 10.0f) {
-	if (start_sequence < 0.0f) {
-		seq_switch = manual_control_setpoint_s::SWITCH_POS_ON;
-		PX4_INFO("seq_switch on: at %f", (double) cur_time);
+	static uint8_t seq_switch = manual_control_setpoint_s::SWITCH_POS_OFF;
 
-		start_sequence = cur_time;
+	if ((cur_time - start_sequence) > 10.0f) {
+		seq_switch = manual_control_setpoint_s::SWITCH_POS_ON;
+		PX4_DEBUG("seq_switch on: at %f", (double) cur_time);
+
 	}
+
+#endif
 
 	// perform state transitions
 	switch (cur_state) {
 
 	case IDLE: {
 
-			if (seq_switch == manual_control_setpoint_s::SWITCH_POS_ON) {
-				seq_switch = manual_control_setpoint_s::SWITCH_POS_OFF;
+			// only the rising edge of seq_switch triggers a sequence
+			if (seq_switch == manual_control_setpoint_s::SWITCH_POS_ON &&
+			    seq_switch != seq_switch_last) {
+
 				seq_index = -1;
+				start_sequence = cur_time;
 				cur_state = NEXT_ENTRY;
 			}
+
+			seq_switch_last = seq_switch;
 
 			break;
 		}
@@ -343,7 +374,7 @@ void prog_sequence(
 			if (error < 0.005f || (cur_time - start_time) > 5.0f) {
 				cur_state = DELAY;
 				printf("q_err: "); q_err.print();
-				PX4_INFO("error %6.3f", (double) error);
+				PX4_DEBUG("error %6.3f", (double) error);
 				printf("final Euler angles: "); q_cur.to_euler().print();
 			}
 
@@ -367,8 +398,24 @@ void prog_sequence(
 		}
 
 	case NEXT_ENTRY:
-		att_sp.thrust = seq_entry.thrust;	// this does not persist across calls
-		cur_state = seq_entry.type;
+		PX4_DEBUG("NEXT_ENTRY seq_index: %d at %6.3f, thrust: %6.3f", seq_index, (double) cur_time, (double)att_sp.thrust);
+
+		if (seq_index < cur_sequence->N_entries) {
+			seq_entry = cur_sequence->entries[seq_index];
+
+			att_sp.thrust = seq_entry.thrust;	// this does not persist across calls
+			cur_state = seq_entry.type;
+
+			PX4_DEBUG("seq_entry: type: %d, \nrates: (%6.3f, %6.3f, %6.3f), \ntarget_euler: (%6.3f, %6.3f, %6.3f), \nthrust: %6.3f delay: %6.3f",
+				  seq_entry.type,
+				  (double)seq_entry.rollRate, (double)seq_entry.pitchRate, (double)seq_entry.yawRate,
+				  (double)seq_entry.target_euler[0], (double)seq_entry.target_euler[1], (double)seq_entry.target_euler[2],
+				  (double)seq_entry.thrust, (double)seq_entry.delay);
+
+		} else {
+			cur_state = IDLE;
+		}
+
 		break;
 	}
 
@@ -379,12 +426,12 @@ void prog_sequence(
 		switch (cur_state) {
 		case IDLE:
 			// initialize sequencer
-			seq_index = 0;
+			seq_index = -1;
 			seq_switch = manual_control_setpoint_s::SWITCH_POS_OFF;
-			PX4_INFO("sequence end at %6.3f, duration: %6.3f",
-				 (double) cur_time,
-				 (double)(cur_time - start_sequence));
-			PX4_INFO("IDLE state: %d at %6.3f, thrust: %6.3f", cur_state, (double) cur_time, (double)att_sp.thrust);
+			PX4_DEBUG("sequence end at %6.3f, duration: %6.3f",
+				  (double) cur_time,
+				  (double)(cur_time - start_sequence));
+			PX4_DEBUG("IDLE state: %d at %6.3f, thrust: %6.3f", cur_state, (double) cur_time, (double)att_sp.thrust);
 			break;
 
 		case RATE:
@@ -392,7 +439,7 @@ void prog_sequence(
 			rollRate = seq_entry.rollRate;
 			pitchRate = seq_entry.pitchRate;
 			yawRate = seq_entry.yawRate;
-			PX4_INFO("RATE state: %d at %6.3f, thrust: %6.3f", cur_state, (double) cur_time, (double)att_sp.thrust);
+			PX4_DEBUG("RATE state: %d at %6.3f, thrust: %6.3f", cur_state, (double) cur_time, (double)att_sp.thrust);
 			break;
 
 		case ATTITUDE:
@@ -403,32 +450,20 @@ void prog_sequence(
 			memcpy(&att_sp.R_body[0], R_sp.data, sizeof(att_sp.R_body));
 			q_end.from_euler(seq_entry.target_euler[0], seq_entry.target_euler[1],
 					 seq_entry.target_euler[2]);
-			PX4_INFO("ATTITUDE state: %d at %6.3f, thrust: %6.3f", cur_state, (double) cur_time, (double)att_sp.thrust);
+			PX4_DEBUG("ATTITUDE state: %d at %6.3f, thrust: %6.3f", cur_state, (double) cur_time, (double)att_sp.thrust);
 //			printf("R_sp:\n"); R_sp.print();
 //			printf("q_end: "); q_end.print();
 //			printf("target Euler angles: "); q_end.to_euler().print();
 			break;
 
 		case DELAY:
-			PX4_INFO("DELAY duration: %6.3f at %6.3f, thrust: %6.3f", (double)seq_entry.delay, (double) cur_time,
-				 (double)att_sp.thrust);
+			PX4_DEBUG("DELAY duration: %6.3f at %6.3f, thrust: %6.3f", (double)seq_entry.delay, (double) cur_time,
+				  (double)att_sp.thrust);
 			break;
 
 		case NEXT_ENTRY:
 			seq_index++;
-			PX4_INFO("NEXT_ENTRY seq_index: %d at %6.3f, thrust: %6.3f", seq_index, (double) cur_time, (double)att_sp.thrust);
-
-			if (seq_index < cur_sequence->N_entries) {
-				seq_entry = cur_sequence->entries[seq_index];
-				PX4_INFO("seq_entry: type: %d, \nrates: (%6.3f, %6.3f, %6.3f), \ntarget_euler: (%6.3f, %6.3f, %6.3f), \nthrust: %6.3f delay: %6.3f",
-					 seq_entry.type,
-					 (double)seq_entry.rollRate, (double)seq_entry.pitchRate, (double)seq_entry.yawRate,
-					 (double)seq_entry.target_euler[0], (double)seq_entry.target_euler[1], (double)seq_entry.target_euler[2],
-					 (double)seq_entry.thrust, (double)seq_entry.delay);
-
-			} else {
-				cur_state = IDLE;
-			}
+			break;
 
 		default:
 			break;
@@ -437,4 +472,6 @@ void prog_sequence(
 		last_state = cur_state;
 	}
 }
+#endif
+
 #endif

--- a/src/modules/mc_pos_control/mc_sequencer.h
+++ b/src/modules/mc_pos_control/mc_sequencer.h
@@ -1,0 +1,84 @@
+#ifndef MC_SEQUENCER_H
+#define MC_SEQUENCER_H
+
+#include <px4_defines.h>
+#include <math.h>
+#include <drivers/drv_hrt.h>
+
+#include <uORB/topics/manual_control_setpoint.h>
+#include <uORB/topics/control_state.h>
+
+#include <mathlib/mathlib.h>
+#include <platforms/px4_defines.h>
+
+#undef JUST_FLIPS
+//#define JUST_FLIPS
+
+#ifdef JUST_FLIPS
+/*
+ * Perform a 360 degree roll or pitch flip starting and ending at current attitude
+ *
+ * Inputs:
+ * ctrl_state: for current attitude quaternion
+ * manual: sequence trigger switch
+ *
+ * Outputs:
+ * att_sp: thrust and rotation angle setpoints
+ * R_sp: attitude setpoint
+ * rollRate, pitchRate, yawRate: rotation rate commands
+ */
+void flip_sequence(
+	struct control_state_s &ctrl_state,
+	struct vehicle_attitude_setpoint_s &att_sp,
+	struct manual_control_setpoint_s &manual,
+	math::Matrix<3, 3> &R_sp,
+	float &rollRate, float &pitchRate, float &yawRate);
+
+#else
+
+/*
+ * Perform a programmed sequence with specified target attitudes
+ *
+ * Inputs:
+ * sequence: array of seq_entry items
+ * ctrl_state: for current attitude quaternion
+ * manual: sequence trigger switch
+ *
+ * Outputs:
+ * att_sp: thrust and rotation angle setpoints
+ * R_sp: attitude setpoint
+ * rollRate, pitchRate, yawRate: rotation rate commands
+ */
+void prog_sequence(
+	struct control_state_s &ctrl_state,
+	struct vehicle_attitude_setpoint_s &att_sp,
+	struct manual_control_setpoint_s &manual,
+	math::Matrix<3, 3> &R_sp,
+	float &rollRate, float &pitchRate, float &yawRate);
+
+enum Seq_state {
+	IDLE, RATE, ATTITUDE, DELAY, NEXT_ENTRY
+};
+
+struct seq_entry_s {
+	Seq_state type;
+	float thrust;
+
+	// rates are in radians/second (independent of parameter values)
+	float rollRate;
+	float pitchRate;
+	float yawRate;
+
+	float target_euler[3];
+
+	float delay;
+};
+
+struct sequence {
+	const int N_entries;
+	const struct seq_entry_s *entries;
+};
+
+#endif
+
+#endif

--- a/src/modules/mc_pos_control/mc_sequencer.h
+++ b/src/modules/mc_pos_control/mc_sequencer.h
@@ -11,8 +11,6 @@
 #include <mathlib/mathlib.h>
 #include <platforms/px4_defines.h>
 
-//#define NOT_FMU_V2 1
-
 /*
  * Perform a programmed sequence with specified target attitudes
  *

--- a/src/modules/mc_pos_control/mc_sequencer.h
+++ b/src/modules/mc_pos_control/mc_sequencer.h
@@ -63,7 +63,9 @@ struct sequence {
 	}
 };
 
-enum sequence_set { hover, coord_turn, pitch_flip, roll_flip, two_point_roll, tilt_lr };
+enum sequence_set { coord_turn
+//	, roll_flip, hover, pitch_flip, two_point_roll, tilt_lr
+		  };
 
 sequence *get_sequence(sequence_set entry);
 

--- a/src/modules/mc_pos_control/mc_sequencer.h
+++ b/src/modules/mc_pos_control/mc_sequencer.h
@@ -50,8 +50,23 @@ struct seq_entry_s {
 };
 
 struct sequence {
-	const int N_entries;
-	const struct seq_entry_s *entries;
+	int N_entries;
+	struct seq_entry_s *entries;
+
+	sequence(int n) : N_entries(n)
+	{
+		entries = (seq_entry_s *) malloc(sizeof(seq_entry_s) * N_entries);
+	}
+	~sequence()
+	{
+		free((void *)entries);
+	}
 };
+
+enum sequence_set { hover, coord_turn, pitch_flip, roll_flip, two_point_roll, tilt_lr };
+
+sequence *get_sequence(sequence_set entry);
+
+void prog_sequence_init(enum sequence_set seq, float trigger_interval);
 
 #endif

--- a/src/modules/mc_pos_control/mc_sequencer.h
+++ b/src/modules/mc_pos_control/mc_sequencer.h
@@ -11,31 +11,6 @@
 #include <mathlib/mathlib.h>
 #include <platforms/px4_defines.h>
 
-#undef JUST_FLIPS
-//#define JUST_FLIPS
-
-#ifdef JUST_FLIPS
-/*
- * Perform a 360 degree roll or pitch flip starting and ending at current attitude
- *
- * Inputs:
- * ctrl_state: for current attitude quaternion
- * manual: sequence trigger switch
- *
- * Outputs:
- * att_sp: thrust and rotation angle setpoints
- * R_sp: attitude setpoint
- * rollRate, pitchRate, yawRate: rotation rate commands
- */
-void flip_sequence(
-	struct control_state_s &ctrl_state,
-	struct vehicle_attitude_setpoint_s &att_sp,
-	struct manual_control_setpoint_s &manual,
-	matrix::Dcmf &R_sp,
-	float &rollRate, float &pitchRate, float &yawRate);
-
-#else
-
 /*
  * Perform a programmed sequence with specified target attitudes
  *
@@ -53,7 +28,7 @@ void prog_sequence(
 	struct control_state_s &ctrl_state,
 	struct vehicle_attitude_setpoint_s &att_sp,
 	struct manual_control_setpoint_s &manual,
-	matrix::Dcmf &R_sp,
+	matrix::Quatf &R_sp,
 	float &rollRate, float &pitchRate, float &yawRate);
 
 enum Seq_state {
@@ -78,7 +53,5 @@ struct sequence {
 	const int N_entries;
 	const struct seq_entry_s *entries;
 };
-
-#endif
 
 #endif

--- a/src/modules/mc_pos_control/mc_sequencer.h
+++ b/src/modules/mc_pos_control/mc_sequencer.h
@@ -39,12 +39,9 @@ struct seq_entry_s {
 	Seq_state type;
 	float thrust;
 
-	// rates are in radians/second (independent of parameter values)
-	float rollRate;
-	float pitchRate;
-	float yawRate;
-
-	float target_euler[3];
+	// rate values are in radians/second (independent of parameter values)
+	// attitude values are in radians
+	float rpy_vals[3];
 
 	float delay;
 };

--- a/src/modules/mc_pos_control/mc_sequencer.h
+++ b/src/modules/mc_pos_control/mc_sequencer.h
@@ -31,7 +31,7 @@ void flip_sequence(
 	struct control_state_s &ctrl_state,
 	struct vehicle_attitude_setpoint_s &att_sp,
 	struct manual_control_setpoint_s &manual,
-	math::Matrix<3, 3> &R_sp,
+	matrix::Dcmf &R_sp,
 	float &rollRate, float &pitchRate, float &yawRate);
 
 #else
@@ -53,7 +53,7 @@ void prog_sequence(
 	struct control_state_s &ctrl_state,
 	struct vehicle_attitude_setpoint_s &att_sp,
 	struct manual_control_setpoint_s &manual,
-	math::Matrix<3, 3> &R_sp,
+	matrix::Dcmf &R_sp,
 	float &rollRate, float &pitchRate, float &yawRate);
 
 enum Seq_state {

--- a/src/modules/mc_pos_control/mc_sequencer.h
+++ b/src/modules/mc_pos_control/mc_sequencer.h
@@ -11,6 +11,8 @@
 #include <mathlib/mathlib.h>
 #include <platforms/px4_defines.h>
 
+//#define NOT_FMU_V2 1
+
 /*
  * Perform a programmed sequence with specified target attitudes
  *
@@ -61,7 +63,9 @@ struct sequence {
 };
 
 enum sequence_set { coord_turn
-//	, roll_flip, hover, pitch_flip, two_point_roll, tilt_lr
+#if defined (CONFIG_ARCH_BOARD_PX4FMU_V4) || defined (CONFIG_ARCH_BOARD_SITL)
+, roll_flip, hover, pitch_flip, two_point_roll, tilt_lr
+#endif
 		  };
 
 sequence *get_sequence(sequence_set entry);

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -2433,6 +2433,34 @@ PARAM_DEFINE_INT32(RC_MAP_LOITER_SW, 0);
 PARAM_DEFINE_INT32(RC_MAP_ACRO_SW, 0);
 
 /**
+ * Sequence switch channel
+ *
+ * @min 0
+ * @max 18
+ * @group Radio Switches
+ * @value 0 Unassigned
+ * @value 1 Channel 1
+ * @value 2 Channel 2
+ * @value 3 Channel 3
+ * @value 4 Channel 4
+ * @value 5 Channel 5
+ * @value 6 Channel 6
+ * @value 7 Channel 7
+ * @value 8 Channel 8
+ * @value 9 Channel 9
+ * @value 10 Channel 10
+ * @value 11 Channel 11
+ * @value 12 Channel 12
+ * @value 13 Channel 13
+ * @value 14 Channel 14
+ * @value 15 Channel 15
+ * @value 16 Channel 16
+ * @value 17 Channel 17
+ * @value 18 Channel 18
+ */
+PARAM_DEFINE_INT32(RC_MAP_SEQ_SW, 0);
+
+/**
  * Offboard switch channel
  *
  * @min 0
@@ -2946,6 +2974,24 @@ PARAM_DEFINE_FLOAT(RC_LOITER_TH, 0.5f);
  *
  */
 PARAM_DEFINE_FLOAT(RC_ACRO_TH, 0.5f);
+
+/**
+ * Threshold for selecting sequence mode
+ *
+ * 0-1 indicate where in the full channel range the threshold sits
+ * 		0 : min
+ * 		1 : max
+ * sign indicates polarity of comparison
+ * 		positive : true when channel>th
+ * 		negative : true when channel<th
+ *
+ * @min -1
+ * @max 1
+ * @group Radio Switches
+ *
+ *
+ */
+PARAM_DEFINE_FLOAT(RC_SEQ_TH, 0.5f);
 
 
 /**

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -308,6 +308,7 @@ private:
 		int rc_map_posctl_sw;
 		int rc_map_loiter_sw;
 		int rc_map_acro_sw;
+		int rc_map_seq_sw;
 		int rc_map_offboard_sw;
 		int rc_map_kill_sw;
 		int rc_map_trans_sw;
@@ -333,6 +334,7 @@ private:
 		float rc_return_th;
 		float rc_loiter_th;
 		float rc_acro_th;
+		float rc_seq_th;
 		float rc_offboard_th;
 		float rc_killswitch_th;
 		float rc_trans_th;
@@ -384,6 +386,7 @@ private:
 		param_t rc_map_posctl_sw;
 		param_t rc_map_loiter_sw;
 		param_t rc_map_acro_sw;
+		param_t rc_map_seq_sw;
 		param_t rc_map_offboard_sw;
 		param_t rc_map_kill_sw;
 		param_t rc_map_trans_sw;
@@ -413,6 +416,7 @@ private:
 		param_t rc_return_th;
 		param_t rc_loiter_th;
 		param_t rc_acro_th;
+		param_t rc_seq_th;
 		param_t rc_offboard_th;
 		param_t rc_killswitch_th;
 		param_t rc_trans_th;
@@ -677,6 +681,7 @@ Sensors::Sensors() :
 	_parameter_handles.rc_map_posctl_sw = param_find("RC_MAP_POSCTL_SW");
 	_parameter_handles.rc_map_loiter_sw = param_find("RC_MAP_LOITER_SW");
 	_parameter_handles.rc_map_acro_sw = param_find("RC_MAP_ACRO_SW");
+	_parameter_handles.rc_map_seq_sw = param_find("RC_MAP_SEQ_SW");
 	_parameter_handles.rc_map_offboard_sw = param_find("RC_MAP_OFFB_SW");
 	_parameter_handles.rc_map_kill_sw = param_find("RC_MAP_KILL_SW");
 	_parameter_handles.rc_map_trans_sw = param_find("RC_MAP_TRANS_SW");
@@ -707,6 +712,7 @@ Sensors::Sensors() :
 	_parameter_handles.rc_return_th = param_find("RC_RETURN_TH");
 	_parameter_handles.rc_loiter_th = param_find("RC_LOITER_TH");
 	_parameter_handles.rc_acro_th = param_find("RC_ACRO_TH");
+	_parameter_handles.rc_seq_th = param_find("RC_SEQ_TH");
 	_parameter_handles.rc_offboard_th = param_find("RC_OFFB_TH");
 	_parameter_handles.rc_killswitch_th = param_find("RC_KILLSWITCH_TH");
 	_parameter_handles.rc_trans_th = param_find("RC_TRANS_TH");
@@ -920,6 +926,10 @@ Sensors::parameters_update()
 		PX4_WARN("%s", paramerr);
 	}
 
+	if (param_get(_parameter_handles.rc_map_seq_sw, &(_parameters.rc_map_seq_sw)) != OK) {
+		PX4_WARN("%s", paramerr);
+	}
+
 	if (param_get(_parameter_handles.rc_map_offboard_sw, &(_parameters.rc_map_offboard_sw)) != OK) {
 		PX4_WARN("%s", paramerr);
 	}
@@ -974,6 +984,8 @@ Sensors::parameters_update()
 	param_get(_parameter_handles.rc_acro_th, &(_parameters.rc_acro_th));
 	_parameters.rc_acro_inv = (_parameters.rc_acro_th < 0);
 	_parameters.rc_acro_th = fabs(_parameters.rc_acro_th);
+	param_get(_parameter_handles.rc_seq_th, &(_parameters.rc_seq_th));
+	_parameters.rc_seq_th = fabs(_parameters.rc_seq_th);
 	param_get(_parameter_handles.rc_offboard_th, &(_parameters.rc_offboard_th));
 	_parameters.rc_offboard_inv = (_parameters.rc_offboard_th < 0);
 	_parameters.rc_offboard_th = fabs(_parameters.rc_offboard_th);
@@ -999,6 +1011,7 @@ Sensors::parameters_update()
 	_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_POSCTL] = _parameters.rc_map_posctl_sw - 1;
 	_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_LOITER] = _parameters.rc_map_loiter_sw - 1;
 	_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_ACRO] = _parameters.rc_map_acro_sw - 1;
+	_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_SEQ] = _parameters.rc_map_seq_sw - 1;
 	_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_OFFBOARD] = _parameters.rc_map_offboard_sw - 1;
 	_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_KILLSWITCH] = _parameters.rc_map_kill_sw - 1;
 	_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_TRANSITION] = _parameters.rc_map_trans_sw - 1;
@@ -2204,6 +2217,7 @@ Sensors::rc_poll()
 					       _parameters.rc_loiter_inv);
 			manual.acro_switch = get_rc_sw2pos_position(rc_channels_s::RC_CHANNELS_FUNCTION_ACRO, _parameters.rc_acro_th,
 					     _parameters.rc_acro_inv);
+			manual.seq_switch = get_rc_sw2pos_position(rc_channels_s::RC_CHANNELS_FUNCTION_SEQ, _parameters.rc_seq_th, false);
 			manual.offboard_switch = get_rc_sw2pos_position(rc_channels_s::RC_CHANNELS_FUNCTION_OFFBOARD,
 						 _parameters.rc_offboard_th, _parameters.rc_offboard_inv);
 			manual.kill_switch = get_rc_sw2pos_position(rc_channels_s::RC_CHANNELS_FUNCTION_KILLSWITCH,


### PR DESCRIPTION
This is the 6DOF acro PR https://github.com/PX4/Firmware/pull/5498 rebased onto release 1.5.2
with a new config for SITL and flight performance testing.

SITL results are looking very good with reduced accel weight, but the simulated gyros probably don't exhibit drift or noise, so flight testing (and perhaps simulator enhancement) is still required.