### PR TITLE
integrationtests: use Python2 for dependencies

### DIFF
--- a/integrationtests/python_src/px4_it/mavros/mavros_offboard_attctl_test.py
+++ b/integrationtests/python_src/px4_it/mavros/mavros_offboard_attctl_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #***************************************************************************
 #
 #   Copyright (c) 2015 PX4 Development Team. All rights reserved.
@@ -35,6 +35,9 @@
 #
 # @author Andreas Antener <andreas@uaventure.com>
 #
+# The shebang of this file is currently Python2 because some
+# dependencies such as pymavlink don't play well with Python3 yet.
+
 PKG = 'px4'
 
 import unittest

--- a/integrationtests/python_src/px4_it/mavros/mavros_offboard_posctl_test.py
+++ b/integrationtests/python_src/px4_it/mavros/mavros_offboard_posctl_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #***************************************************************************
 #
 #   Copyright (c) 2015 PX4 Development Team. All rights reserved.
@@ -35,6 +35,9 @@
 #
 # @author Andreas Antener <andreas@uaventure.com>
 #
+# The shebang of this file is currently Python2 because some
+# dependencies such as pymavlink don't play well with Python3 yet.
+
 PKG = 'px4'
 
 import unittest

--- a/integrationtests/python_src/px4_it/mavros/mission_test.py
+++ b/integrationtests/python_src/px4_it/mavros/mission_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #***************************************************************************
 #
 #   Copyright (c) 2015 PX4 Development Team. All rights reserved.
@@ -35,6 +35,10 @@
 #
 # @author Andreas Antener <andreas@uaventure.com>
 #
+
+# The shebang of this file is currently Python2 because some
+# dependencies such as pymavlink don't play well with Python3 yet.
+
 PKG = 'px4'
 
 import unittest


### PR DESCRIPTION
This changes the shebang of the integration test files to python2
because the scripts fail on systems with Python 3 as the default.

Even though ROS has been ported to Python 3, there are still some
dependencies not playing along.

The error that comes up when starting with Python 3 is:
> No module named 'mavexpression'

Tested on Arch Linux.