### PR TITLE
geofence fix combined simple and polygon logic

### DIFF
--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -168,7 +168,7 @@ bool Geofence::inside(double lat, double lon, float altitude)
 		}
 	}
 
-	inside_fence |= inside_polygon(lat, lon, altitude);
+	inside_fence &= inside_polygon(lat, lon, altitude);
 
 	if (inside_fence) {
 		_outside_counter = 0;


### PR DESCRIPTION
 - require being inside both fences, not one or the other

Broken by me after a "trivial" refactor.

TODO: add a mission test that explicitly tests the geofence (cylinder and polygon).

Reported here - http://discuss.px4.io/t/v1-5-1-issue-with-geofence/1936
FYI @pturcotte