### PR TITLE
mavlink: don't send uninitialized bytes

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -1479,8 +1479,8 @@ protected:
 
 	void send(const hrt_abstime t)
 	{
-		struct vehicle_global_position_s pos;
-		struct home_position_s home;
+		struct vehicle_global_position_s pos = {};
+		struct home_position_s home = {};
 
 		bool updated = _pos_sub->update(&_pos_time, &pos);
 		updated |= _home_sub->update(&_home_time, &home);


### PR DESCRIPTION
Valgrind did not approve uninitialized bytes from either home or
vehicle global position to be sent.