### PR TITLE
Increase navigator stack

### DIFF
--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -396,7 +396,8 @@ MissionFeasibilityChecker::check_dist_1wp(dm_item_t dm_current, size_t nMissionI
 
 					} else {
 						/* item is too far from home */
-						mavlink_log_critical(_mavlink_log_pub, "First waypoint too far: %d m,refusing mission", (int)dist_to_1wp, (int)dist_first_wp);
+						mavlink_log_critical(_mavlink_log_pub, "First waypoint too far: %d m > %d, refusing mission",
+								     (int)dist_to_1wp, (int)dist_first_wp);
 						warning_issued = true;
 						return false;
 					}

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -673,7 +673,7 @@ Navigator::start()
 	_navigator_task = px4_task_spawn_cmd("navigator",
 					 SCHED_DEFAULT,
 					 SCHED_PRIORITY_DEFAULT + 5,
-					 1300,
+					 1400,
 					 (px4_main_t)&Navigator::task_main_trampoline,
 					 nullptr);
 


### PR DESCRIPTION
The stack size was generally ok but seemed to get exhausted in the case
of a waypoint which is too far away and therefore exercises some more
code in the mission feasability checker.

Generally, we should have more margin in the navigator stack size
because there are a bunch of different code paths that can happen.

The new stack situation for the case of a mission which is too far away is:
```
  74 navigator                     785  1.891  1276/ 1392 105 (105)  w:sem 
```

This PR also fixes a printf in the mission feasablity checker.