### PR TITLE
Feature arm switch with the option to also use a button

### DIFF
--- a/msg/manual_control_setpoint.msg
+++ b/msg/manual_control_setpoint.msg
@@ -51,6 +51,7 @@ uint8 loiter_switch		 # loiter 2 position switch (optional): _MISSION_, LOITER
 uint8 acro_switch		 # acro 2 position switch (optional): _MANUAL_, ACRO
 uint8 offboard_switch	 # offboard 2 position switch (optional): _NORMAL_, OFFBOARD
 uint8 kill_switch		 # throttle kill: _NORMAL_, KILL
+uint8 arm_switch		 # arm/disarm switch: _DISARMED_, ARMED
 uint8 transition_switch	 # VTOL transition switch: _HOVER, FORWARD_FLIGHT
 uint8 gear_switch	 # landing gear switch: _DOWN_, UP
 int8 mode_slot			 # the slot a specific model selector is in

--- a/msg/rc_channels.msg
+++ b/msg/rc_channels.msg
@@ -22,11 +22,12 @@ uint8 RC_CHANNELS_FUNCTION_RATTITUDE=19
 uint8 RC_CHANNELS_FUNCTION_KILLSWITCH=20
 uint8 RC_CHANNELS_FUNCTION_TRANSITION=21
 uint8 RC_CHANNELS_FUNCTION_GEAR=22
+uint8 RC_CHANNELS_FUNCTION_ARMSWITCH=23
 
 uint64 timestamp_last_valid					# Timestamp of last valid RC signal
 float32[18] channels						# Scaled to -1..1 (throttle: 0..1)
 uint8 channel_count						# Number of valid channels
-int8[23] function						# Functions mapping
+int8[24] function						# Functions mapping
 uint8 rssi							# Receive signal strength indicator (0-100)
 bool signal_lost						# Control signal lost, should be checked together with topic timeout
 uint32 frame_drop_count						# Number of dropped frames

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -53,7 +53,7 @@ uint32 component_id			# subsystem / component id, contains MAVLink's component I
 
 bool is_rotary_wing			# True if system is in rotary wing configuration, so for a VTOL this is only true while flying as a multicopter
 bool is_vtol				# True if the system is VTOL capable
-bool vtol_fw_permanent_stab		# True if vtol should stabilize attitude for fw in manual mode
+bool vtol_fw_permanent_stab		# True if VTOL should stabilize attitude for fw in manual mode
 bool in_transition_mode			# True if VTOL is doing a transition
 bool in_transition_to_fw		# True if VTOL is doing a transition from MC to FW
 

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2571,7 +2571,7 @@ int commander_thread_main(int argc, char *argv[])
 			    	land_detector.landed) &&
 			    ((sp_man.r < -STICK_ON_OFF_LIMIT && sp_man.z < 0.1f) || (arm_switch_is_button == 1 && sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_ON)) ) {
 
-				if (stick_off_counter > rc_arm_hyst) {
+				if (stick_off_counter == rc_arm_hyst && stick_on_counter < rc_arm_hyst) {
 					/* disarm to STANDBY if ARMED or to STANDBY_ERROR if ARMED_ERROR */
 					arming_state_t new_arming_state = (status.arming_state == vehicle_status_s::ARMING_STATE_ARMED ? vehicle_status_s::ARMING_STATE_STANDBY :
 									   vehicle_status_s::ARMING_STATE_STANDBY_ERROR);
@@ -2590,14 +2590,10 @@ int commander_thread_main(int argc, char *argv[])
 					if (arming_ret == TRANSITION_CHANGED) {
 						arming_state_changed = true;
 					}
-
-					stick_off_counter = 0;
-
-				} else {
-					stick_off_counter++;
 				}
+				stick_off_counter++;
 
-			} else {
+			} else if (arm_switch_is_button == 1 && sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_OFF) {
 				stick_off_counter = 0;
 			}
 
@@ -2605,7 +2601,7 @@ int commander_thread_main(int argc, char *argv[])
 			if (status.rc_input_mode != vehicle_status_s::RC_IN_MODE_OFF &&
 					(status.arming_state != vehicle_status_s::ARMING_STATE_ARMED && status.arming_state != vehicle_status_s::ARMING_STATE_ARMED_ERROR) &&
 					((sp_man.r > STICK_ON_OFF_LIMIT && sp_man.z < 0.1f) || (arm_switch_is_button == 1 && sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_ON)) ) {
-				if (stick_on_counter > rc_arm_hyst) {
+				if (stick_on_counter == rc_arm_hyst && stick_off_counter < rc_arm_hyst) {
 
 					/* we check outside of the transition function here because the requirement
 					 * for being in manual mode only applies to manual arming actions.
@@ -2645,13 +2641,10 @@ int commander_thread_main(int argc, char *argv[])
 							print_reject_arm("NOT ARMING: Preflight checks failed");
 						}
 					}
-					stick_on_counter = 0;
-
-				} else {
-					stick_on_counter++;
 				}
+				stick_on_counter++;
 
-			} else {
+			} else if (arm_switch_is_button == 1 && sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_OFF) {
 				stick_on_counter = 0;
 			}
 

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -280,7 +280,7 @@ PARAM_DEFINE_INT32(COM_DISARM_LAND, 0);
 PARAM_DEFINE_INT32(COM_ARM_WO_GPS, 1);
 
 /**
- * Use arm switch is only a button
+ * Arm switch is only a button
  *
  * The default uses the arm switch as real switch.
  * If parameter set button gets handled like stick arming.
@@ -289,7 +289,7 @@ PARAM_DEFINE_INT32(COM_ARM_WO_GPS, 1);
  * @min 0
  * @max 1
  * @value 0 Arm switch is a switch that stays on when armed
- * @value 1 Arm switch is a button that only triggers arming
+ * @value 1 Arm switch is a button that only triggers arming and disarming
  */
 PARAM_DEFINE_INT32(COM_ARM_SWISBTN, 0);
 

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -280,6 +280,20 @@ PARAM_DEFINE_INT32(COM_DISARM_LAND, 0);
 PARAM_DEFINE_INT32(COM_ARM_WO_GPS, 1);
 
 /**
+ * Use arm switch is only a button
+ *
+ * The default uses the arm switch as real switch.
+ * If parameter set button gets handled like stick arming.
+ *
+ * @group Commander
+ * @min 0
+ * @max 1
+ * @value 0 Arm switch is a switch that stays on when armed
+ * @value 1 Arm switch is a button that only triggers arming
+ */
+PARAM_DEFINE_INT32(COM_ARM_SWISBTN, 0);
+
+/**
  * Battery failsafe mode
  *
  * Action the system takes on low battery. Defaults to off

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -75,7 +75,6 @@
 #include <uORB/topics/wind_estimate.h>
 #include <uORB/topics/estimator_status.h>
 #include <uORB/topics/ekf2_innovations.h>
-#include <uORB/topics/actuator_armed.h>
 #include <uORB/topics/ekf2_replay.h>
 #include <uORB/topics/optical_flow.h>
 #include <uORB/topics/distance_sensor.h>

--- a/src/modules/sensors/parameters.cpp
+++ b/src/modules/sensors/parameters.cpp
@@ -90,6 +90,7 @@ int initialize_parameter_handles(ParameterHandles &parameter_handles)
 	parameter_handles.rc_map_acro_sw = param_find("RC_MAP_ACRO_SW");
 	parameter_handles.rc_map_offboard_sw = param_find("RC_MAP_OFFB_SW");
 	parameter_handles.rc_map_kill_sw = param_find("RC_MAP_KILL_SW");
+	parameter_handles.rc_map_arm_sw = param_find("RC_MAP_ARM_SW");
 	parameter_handles.rc_map_trans_sw = param_find("RC_MAP_TRANS_SW");
 	parameter_handles.rc_map_gear_sw = param_find("RC_MAP_GEAR_SW");
 
@@ -120,6 +121,7 @@ int initialize_parameter_handles(ParameterHandles &parameter_handles)
 	parameter_handles.rc_acro_th = param_find("RC_ACRO_TH");
 	parameter_handles.rc_offboard_th = param_find("RC_OFFB_TH");
 	parameter_handles.rc_killswitch_th = param_find("RC_KILLSWITCH_TH");
+	parameter_handles.rc_armswitch_th = param_find("RC_ARMSWITCH_TH");
 	parameter_handles.rc_trans_th = param_find("RC_TRANS_TH");
 	parameter_handles.rc_gear_th = param_find("RC_GEAR_TH");
 
@@ -313,6 +315,10 @@ int update_parameters(const ParameterHandles &parameter_handles, Parameters &par
 		PX4_WARN("%s", paramerr);
 	}
 
+	if (param_get(parameter_handles.rc_map_arm_sw, &(parameters.rc_map_arm_sw)) != OK) {
+		PX4_WARN("%s", paramerr);
+	}
+
 	if (param_get(parameter_handles.rc_map_trans_sw, &(parameters.rc_map_trans_sw)) != OK) {
 		PX4_WARN("%s", paramerr);
 	}
@@ -365,6 +371,9 @@ int update_parameters(const ParameterHandles &parameter_handles, Parameters &par
 	param_get(parameter_handles.rc_killswitch_th, &(parameters.rc_killswitch_th));
 	parameters.rc_killswitch_inv = (parameters.rc_killswitch_th < 0);
 	parameters.rc_killswitch_th = fabs(parameters.rc_killswitch_th);
+	param_get(parameter_handles.rc_armswitch_th, &(parameters.rc_armswitch_th));
+	parameters.rc_armswitch_inv = (parameters.rc_armswitch_th < 0);
+	parameters.rc_armswitch_th = fabs(parameters.rc_armswitch_th);
 	param_get(parameter_handles.rc_trans_th, &(parameters.rc_trans_th));
 	parameters.rc_trans_inv = (parameters.rc_trans_th < 0);
 	parameters.rc_trans_th = fabs(parameters.rc_trans_th);

--- a/src/modules/sensors/parameters.h
+++ b/src/modules/sensors/parameters.h
@@ -83,6 +83,7 @@ struct Parameters {
 	int rc_map_acro_sw;
 	int rc_map_offboard_sw;
 	int rc_map_kill_sw;
+	int rc_map_arm_sw;
 	int rc_map_trans_sw;
 	int rc_map_gear_sw;
 
@@ -108,6 +109,7 @@ struct Parameters {
 	float rc_acro_th;
 	float rc_offboard_th;
 	float rc_killswitch_th;
+	float rc_armswitch_th;
 	float rc_trans_th;
 	float rc_gear_th;
 	bool rc_assist_inv;
@@ -119,6 +121,7 @@ struct Parameters {
 	bool rc_acro_inv;
 	bool rc_offboard_inv;
 	bool rc_killswitch_inv;
+	bool rc_armswitch_inv;
 	bool rc_trans_inv;
 	bool rc_gear_inv;
 
@@ -159,6 +162,7 @@ struct ParameterHandles {
 	param_t rc_map_acro_sw;
 	param_t rc_map_offboard_sw;
 	param_t rc_map_kill_sw;
+	param_t rc_map_arm_sw;
 	param_t rc_map_trans_sw;
 	param_t rc_map_gear_sw;
 
@@ -188,6 +192,7 @@ struct ParameterHandles {
 	param_t rc_acro_th;
 	param_t rc_offboard_th;
 	param_t rc_killswitch_th;
+	param_t rc_armswitch_th;
 	param_t rc_trans_th;
 	param_t rc_gear_th;
 

--- a/src/modules/sensors/rc_update.cpp
+++ b/src/modules/sensors/rc_update.cpp
@@ -95,6 +95,7 @@ void RCUpdate::update_rc_functions()
 	_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_ACRO] = _parameters.rc_map_acro_sw - 1;
 	_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_OFFBOARD] = _parameters.rc_map_offboard_sw - 1;
 	_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_KILLSWITCH] = _parameters.rc_map_kill_sw - 1;
+	_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_ARMSWITCH] = _parameters.rc_map_arm_sw - 1;
 	_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_TRANSITION] = _parameters.rc_map_trans_sw - 1;
 	_rc.function[rc_channels_s::RC_CHANNELS_FUNCTION_GEAR] = _parameters.rc_map_gear_sw - 1;
 
@@ -414,7 +415,7 @@ RCUpdate::rc_poll(const ParameterHandles &parameter_handles)
 						 _parameters.rc_offboard_th, _parameters.rc_offboard_inv);
 			manual.kill_switch = get_rc_sw2pos_position(rc_channels_s::RC_CHANNELS_FUNCTION_KILLSWITCH,
 					     _parameters.rc_killswitch_th, _parameters.rc_killswitch_inv);
-			manual.arm_switch = get_rc_sw2pos_position(rc_channels_s::RC_CHANNELS_FUNCTION_KILLSWITCH,
+			manual.arm_switch = get_rc_sw2pos_position(rc_channels_s::RC_CHANNELS_FUNCTION_ARMSWITCH,
 					    _parameters.rc_armswitch_th, _parameters.rc_armswitch_inv);
 			manual.transition_switch = get_rc_sw2pos_position(rc_channels_s::RC_CHANNELS_FUNCTION_TRANSITION,
 						   _parameters.rc_trans_th, _parameters.rc_trans_inv);

--- a/src/modules/sensors/rc_update.cpp
+++ b/src/modules/sensors/rc_update.cpp
@@ -414,6 +414,8 @@ RCUpdate::rc_poll(const ParameterHandles &parameter_handles)
 						 _parameters.rc_offboard_th, _parameters.rc_offboard_inv);
 			manual.kill_switch = get_rc_sw2pos_position(rc_channels_s::RC_CHANNELS_FUNCTION_KILLSWITCH,
 					     _parameters.rc_killswitch_th, _parameters.rc_killswitch_inv);
+			manual.arm_switch = get_rc_sw2pos_position(rc_channels_s::RC_CHANNELS_FUNCTION_KILLSWITCH,
+					    _parameters.rc_armswitch_th, _parameters.rc_armswitch_inv);
 			manual.transition_switch = get_rc_sw2pos_position(rc_channels_s::RC_CHANNELS_FUNCTION_TRANSITION,
 						   _parameters.rc_trans_th, _parameters.rc_trans_inv);
 			manual.gear_switch = get_rc_sw2pos_position(rc_channels_s::RC_CHANNELS_FUNCTION_GEAR,

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -2489,6 +2489,34 @@ PARAM_DEFINE_INT32(RC_MAP_OFFB_SW, 0);
 PARAM_DEFINE_INT32(RC_MAP_KILL_SW, 0);
 
 /**
+ * Arm switch channel
+ *
+ * @min 0
+ * @max 18
+ * @group Radio Switches
+ * @value 0 Unassigned
+ * @value 1 Channel 1
+ * @value 2 Channel 2
+ * @value 3 Channel 3
+ * @value 4 Channel 4
+ * @value 5 Channel 5
+ * @value 6 Channel 6
+ * @value 7 Channel 7
+ * @value 8 Channel 8
+ * @value 9 Channel 9
+ * @value 10 Channel 10
+ * @value 11 Channel 11
+ * @value 12 Channel 12
+ * @value 13 Channel 13
+ * @value 14 Channel 14
+ * @value 15 Channel 15
+ * @value 16 Channel 16
+ * @value 17 Channel 17
+ * @value 18 Channel 18
+ */
+PARAM_DEFINE_INT32(RC_MAP_ARM_SW, 0);
+
+/**
  * Flaps channel
  *
  * @min 0
@@ -2984,6 +3012,24 @@ PARAM_DEFINE_FLOAT(RC_OFFB_TH, 0.5f);
  *
  */
 PARAM_DEFINE_FLOAT(RC_KILLSWITCH_TH, 0.25f);
+
+/**
+ * Threshold for the arm switch
+ *
+ * 0-1 indicate where in the full channel range the threshold sits
+ * 		0 : min
+ * 		1 : max
+ * sign indicates polarity of comparison
+ * 		positive : true when channel>th
+ * 		negative : true when channel<th
+ *
+ * @min -1
+ * @max 1
+ * @group Radio Switches
+ *
+ *
+ */
+PARAM_DEFINE_FLOAT(RC_ARMSWITCH_TH, 0.25f);
 
 /**
  * Threshold for the VTOL transition switch


### PR DESCRIPTION
An RC arm switch channel can be mapped with `RC_MAP_ARM_SW`.

The switch arms when a transition to "on" happens and disarms when a transition to "off" happens.
Disarming/arming through other mechanisms is still possible.

There is an option `COM_ARM_SWISBTN` for the commander to use the arm switch as a button: pressing the button for 2 secs arms and pressing it again for 2 secs disarms.

Open for review.