### PR TITLE
aerofc: revert the use of logger by default

### DIFF
--- a/ROMFS/px4fmu_common/init.d/4070_aerofc
+++ b/ROMFS/px4fmu_common/init.d/4070_aerofc
@@ -28,8 +28,6 @@ then
 	param set MC_YAWRATE_D 0.0
 	param set MC_YAW_FF 0.5
 	param set MPC_XY_CRUISE 8
-
-	param set SYS_LOGGER 1
 fi
 
 tap_esc start -d /dev/ttyS0 -n 4

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -630,7 +630,7 @@ then
 		fi
 		if param compare SYS_COMPANION 1500000
 		then
-			mavlink start -d $MAVLINK_COMPANION_DEVICE -b 1500000 -m onboard -r 100000 -x
+			mavlink start -d $MAVLINK_COMPANION_DEVICE -b 1500000 -m onboard -r 10000 -x
 		fi
 	fi
 


### PR DESCRIPTION
This increases the rate of the mavlink channel which will need changes on the Linux side.