### PR TITLE
Interim fix avoid using params before initialized

### DIFF
--- a/src/drivers/stm32/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/stm32/tone_alarm/tone_alarm.cpp
@@ -410,7 +410,7 @@ ToneAlarm::ToneAlarm() :
 	_user_tune(nullptr),
 	_tune(nullptr),
 	_next(nullptr),
-	_cbrk(CBRK_UNINIT)
+	_cbrk(CBRK_OFF)
 {
 	// enable debug() calls
 	//_debug_enabled = true;


### PR DESCRIPTION
This is a Interim fix to avoid using params before initialized.

The Long term fix will be:
1) Not play the startup tone on start but allow tones to be generated from other invocations (i.e error conditions)
2) Add a command to tone alam to have it read a parameter, after parameter initialization, in the init script. If that parameter is on then sound the startup tone and further tones will be enabled. If it is off, all further tones will be disabled.

The new parameter will not be of the class circuit breaker (not named ) as it is not an absolute control of the tone alarm.