### PR TITLE
fixed wing offboard attitude setpoint fix

### DIFF
--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -444,7 +444,7 @@ main_state_transition(struct vehicle_status_s *status, main_state_t new_main_sta
 		 * OFFBOARD only implemented in MC
 		 */
 		if (!status_flags->offboard_control_signal_lost
-		    && status->is_rotary_wing) {
+		    && (status->is_rotary_wing || status->is_fixed_wing) {
 
 			ret = TRANSITION_CHANGED;
 		}

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -441,10 +441,8 @@ main_state_transition(struct vehicle_status_s *status, main_state_t new_main_sta
 	case commander_state_s::MAIN_STATE_OFFBOARD:
 
 		/* need offboard signal
-		 * OFFBOARD only implemented in MC
 		 */
-		if (!status_flags->offboard_control_signal_lost
-		    && (status->is_rotary_wing || status->is_fixed_wing) {
+		if (!status_flags->offboard_control_signal_lost) {
 
 			ret = TRANSITION_CHANGED;
 		}

--- a/src/modules/fw_att_control/fw_att_control_main.cpp
+++ b/src/modules/fw_att_control/fw_att_control_main.cpp
@@ -974,7 +974,7 @@ FixedwingAttitudeControl::task_main()
 
 				// in STABILIZED mode we need to generate the attitude setpoint
 				// from manual user inputs
-				if (!_vcontrol_mode.flag_control_climb_rate_enabled) {
+				if (!_vcontrol_mode.flag_control_climb_rate_enabled && !_vcontrol_mode.flag_control_offboard_enabled) {
 					_att_sp.roll_body = _manual.y * _parameters.man_roll_max + _parameters.rollsp_offset_rad;
 					_att_sp.roll_body = math::constrain(_att_sp.roll_body, -_parameters.man_roll_max, _parameters.man_roll_max);
 					_att_sp.pitch_body = -_manual.x * _parameters.man_pitch_max + _parameters.pitchsp_offset_rad;

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
@@ -2346,14 +2346,20 @@ FixedwingPositionControl::task_main()
 				_att_sp.q_d[3] = q(3);
 				_att_sp.q_d_valid = true;
 
-				/* lazily publish the setpoint only once available */
-				if (_attitude_sp_pub != nullptr) {
-					/* publish the attitude setpoint */
-					orb_publish(_attitude_setpoint_id, _attitude_sp_pub, &_att_sp);
+				if (!_control_mode.flag_control_offboard_enabled ||
+				    _control_mode.flag_control_position_enabled ||
+				    _control_mode.flag_control_velocity_enabled ||
+				    _control_mode.flag_control_acceleration_enabled) {
 
-				} else if (_attitude_setpoint_id) {
-					/* advertise and publish */
-					_attitude_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp);
+					/* lazily publish the setpoint only once available */
+					if (_attitude_sp_pub != nullptr) {
+						/* publish the attitude setpoint */
+						orb_publish(_attitude_setpoint_id, _attitude_sp_pub, &_att_sp);
+
+					} else if (_attitude_setpoint_id) {
+						/* advertise and publish */
+						_attitude_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp);
+					}
 				}
 
 				/* XXX check if radius makes sense here */


### PR DESCRIPTION
Fix #5927 where attitude setpoints from offboard were being overwritten by the RC channels due to some missing flags.