### PR TITLE
cmake: fix update of git hashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,7 +448,7 @@ endif()
 #=============================================================================
 # generate git version
 #
-px4_create_git_hash_header(HEADER ${PX4_BINARY_DIR}/build_git_version.h)
+px4_create_git_hash_header(OUT ${PX4_BINARY_DIR}/build_git_version.h)
 
 #=============================================================================
 # packaging

--- a/Tools/px_update_git_header.py
+++ b/Tools/px_update_git_header.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import sys
+import subprocess
+
+filename = sys.argv[1]
+
+try:
+    fp_header = open(filename, 'r')
+    old_header = fp_header.read()
+except:
+    old_header = ''
+
+git_tag = subprocess.check_output('git describe --always --tags'.split(),
+                                  stderr=subprocess.STDOUT).decode('utf-8').strip()
+git_version = subprocess.check_output('git rev-parse --verify HEAD'.split(),
+                                      stderr=subprocess.STDOUT).decode('utf-8').strip()
+git_version_short = git_version[0:16]
+
+# Generate the header file content
+header = """
+/* Auto Magically Generated file */
+/* Do not edit! */
+#pragma once
+#define PX4_GIT_VERSION_STR  "{git_version}"
+#define PX4_GIT_VERSION_BINARY 0x{git_version_short}
+#define PX4_GIT_TAG_STR  "{git_tag}"
+""".format(git_tag=git_tag,
+           git_version=git_version,
+           git_version_short=git_version_short)
+
+if old_header != header:
+    print('Updating header {}'.format(sys.argv[1]))
+    fp_header = open(filename, 'w')
+    fp_header.write(header)

--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -932,6 +932,7 @@ function(px4_create_git_hash_header)
 	add_custom_command(
 		OUTPUT __fake
 		COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/px_update_git_header.py ${OUT}
+		WORKING_DIRECTORY ${PX4_SOURCE_DIR}
 		COMMENT "Generating git hash header"
 		)
 	add_custom_target(ver_gen ALL

--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -925,27 +925,17 @@ endfunction()
 function(px4_create_git_hash_header)
 	px4_parse_function_args(
 		NAME px4_create_git_hash_header
-		ONE_VALUE HEADER
-		REQUIRED HEADER
+		ONE_VALUE OUT
+		REQUIRED OUT
 		ARGN ${ARGN})
-	execute_process(
-		COMMAND git describe --always --tags
-		OUTPUT_VARIABLE git_tag
-		OUTPUT_STRIP_TRAILING_WHITESPACE
-		WORKING_DIRECTORY ${PX4_SOURCE_DIR}
+	file(WRITE ${OUT} "")
+	add_custom_command(
+		OUTPUT __fake
+		COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/px_update_git_header.py ${OUT}
+		COMMENT "Generating git hash header"
 		)
-	message(STATUS "GIT_TAG = ${git_tag}")
-	execute_process(
-		COMMAND git rev-parse --verify HEAD
-		OUTPUT_VARIABLE git_version
-		OUTPUT_STRIP_TRAILING_WHITESPACE
-		WORKING_DIRECTORY ${PX4_SOURCE_DIR}
-		)
-	#message(STATUS "GIT_VERSION = ${git_version}")
-	set(git_version_short)
-	# We use the first 16 chars, starting at index 0
-	string(SUBSTRING ${git_version} 0 16 git_version_short)
-	configure_file(${PX4_SOURCE_DIR}/cmake/templates/build_git_version.h.in ${HEADER} @ONLY)
+	add_custom_target(ver_gen ALL
+		DEPENDS ${OUT} __fake)
 endfunction()
 
 #=============================================================================

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -217,7 +217,6 @@ static struct cpuload_s cpuload = {};
 
 static uint8_t main_state_prev = 0;
 static bool warning_action_on = false;
-static bool rtl_on = false;
 static bool last_overload = false;
 
 static struct status_flags_s status_flags = {};


### PR DESCRIPTION
Since the git hashes were being generate by cmake it would only be
generated if the header file was not present. Simple test:

    $ make aerofc-v1_default
    $ touch a
    $ git add a
    $ git commit -m tmp
    $ make aerofc-v1_default

The file build_aerofc-v1_default/build_git_version.h should have the new
hashes and the correspondent .c/c.pp files should be rebuilt, but they
aren't.  The end result is that checking the version with "ver git" in
the nsh console will point to the wrong commit.

This moves the generation of the header to a separate tool and enforces
the command to be executed every time.