### PR TITLE
Fix version dependency

### DIFF
--- a/cmake/templates/build_git_version.h.in
+++ b/cmake/templates/build_git_version.h.in
@@ -1,5 +1,0 @@
-/* Auto Magically Generated file */
-/* Do not edit! */
-#define PX4_GIT_VERSION_STR  "@git_version@"
-#define PX4_GIT_VERSION_BINARY 0x@git_version_short@
-#define PX4_GIT_TAG_STR  "@git_tag@"

--- a/src/lib/version/CMakeLists.txt
+++ b/src/lib/version/CMakeLists.txt
@@ -36,6 +36,7 @@ px4_add_module(
 	SRCS
 		version.c
 	DEPENDS
+		ver_gen
 		platforms__common
 	)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix :


### PR DESCRIPTION
Should fix the error:
```
../src/lib/version/version.c:152:31: error: 'PX4_GIT_TAG_STR' undeclared (first use in this function)
  return version_tag_to_number(PX4_GIT_TAG_STR);
```

Fixes #6118