### PR TITLE
build: also look for ninja-build in addition to ninja

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,12 +88,20 @@ FIRST_ARG := $(firstword $(MAKECMDGOALS))
 ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 j ?= 4
 
+NINJA_BIN := ninja
 ifndef NO_NINJA_BUILD
-NINJA_BUILD := $(shell ninja --version 2>/dev/null)
+NINJA_BUILD := $(shell $(NINJA_BIN) --version 2>/dev/null)
+
+ifndef NINJA_BUILD
+NINJA_BIN := ninja-build
+NINJA_BUILD := $(shell $(NINJA_BIN) --version 2>/dev/null)
 endif
+
+endif
+
 ifdef NINJA_BUILD
     PX4_CMAKE_GENERATOR ?= "Ninja"
-    PX4_MAKE = ninja
+    PX4_MAKE = $(NINJA_BIN)
     PX4_MAKE_ARGS =
 else
 


### PR DESCRIPTION
The ninja binary may have other names on Linux distributions. On Fedora
it's ninja-build.

For me the build is broken using Makefile generation. Then I discovered I was not using ninja because it was looking for the wrong binary.  This is not a proper fix for the build breakage, but should be applied nonetheless.