### PR TITLE
LPE fault relaxation and sitl fix

### DIFF
--- a/posix-configs/SITL/init/lpe/iris
+++ b/posix-configs/SITL/init/lpe/iris
@@ -42,6 +42,9 @@ param set MPC_Z_VEL_P 0.6
 param set MPC_Z_VEL_I 0.15
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01
+param set LPE_FUSION 247
+# 11110111 no vis yaw (1 << 3)
+
 replay tryapplyparams
 simulator start -s
 rgbledsim start

--- a/posix-configs/SITL/init/lpe/iris_opt_flow
+++ b/posix-configs/SITL/init/lpe/iris_opt_flow
@@ -61,7 +61,7 @@ param set MIS_TAKEOFF_ALT 2
 param set NAV_ACC_RAD 1.0
 param set CBRK_GPSFAIL 240024
 param set LPE_FUSION 246
-# 11110110 no vis (1 << 3) yaw and no gps (1 << 0)
+# 11110110 no vis yaw (1 << 3) and no gps (1 << 0)
 
 replay tryapplyparams
 simulator start -s

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -872,7 +872,6 @@ void BlockLocalPositionEstimator::predict()
 	}
 
 	_P += dP;
-
 	_xLowPass.update(_x);
 	_aglLowPass.update(agl());
 }

--- a/src/modules/local_position_estimator/sensors/baro.cpp
+++ b/src/modules/local_position_estimator/sensors/baro.cpp
@@ -85,13 +85,11 @@ void BlockLocalPositionEstimator::baroCorrect()
 		mavlink_and_console_log_info(&mavlink_log_pub, "[lpe] baro OK");
 	}
 
-	// kalman filter correction if no fault
-	if (!(_sensorFault & SENSOR_BARO)) {
-		Matrix<float, n_x, n_y_baro> K = _P * C.transpose() * S_I;
-		Vector<float, n_x> dx = K * r;
-		_x += dx;
-		_P -= K * C * _P;
-	}
+	// kalman filter correction always
+	Matrix<float, n_x, n_y_baro> K = _P * C.transpose() * S_I;
+	Vector<float, n_x> dx = K * r;
+	_x += dx;
+	_P -= K * C * _P;
 }
 
 void BlockLocalPositionEstimator::baroCheckTimeout()

--- a/src/modules/local_position_estimator/sensors/land.cpp
+++ b/src/modules/local_position_estimator/sensors/land.cpp
@@ -67,7 +67,10 @@ void BlockLocalPositionEstimator::landCorrect()
 	// fault detection
 	float beta = (r.transpose() * (S_I * r))(0, 0);
 
-	if (beta > BETA_TABLE[n_y_land]) {
+	// artifically increase beta threshhold to prevent fault during landing
+	float beta_thresh = 1e2f;
+
+	if (beta / BETA_TABLE[n_y_land] > beta_thresh) {
 		if (!(_sensorFault & SENSOR_LAND)) {
 			_sensorFault |= SENSOR_LAND;
 			mavlink_and_console_log_info(&mavlink_log_pub, "[lpe] land fault,  beta %5.2f", double(beta));
@@ -81,13 +84,11 @@ void BlockLocalPositionEstimator::landCorrect()
 		mavlink_and_console_log_info(&mavlink_log_pub, "[lpe] land OK");
 	}
 
-	// kalman filter correction if no fault
-	if (!(_sensorFault & SENSOR_LAND)) {
-		Matrix<float, n_x, n_y_land> K = _P * C.transpose() * S_I;
-		Vector<float, n_x> dx = K * r;
-		_x += dx;
-		_P -= K * C * _P;
-	}
+	// kalman filter correction always for land detector
+	Matrix<float, n_x, n_y_land> K = _P * C.transpose() * S_I;
+	Vector<float, n_x> dx = K * r;
+	_x += dx;
+	_P -= K * C * _P;
 }
 
 void BlockLocalPositionEstimator::landCheckTimeout()

--- a/src/modules/local_position_estimator/sensors/lidar.cpp
+++ b/src/modules/local_position_estimator/sensors/lidar.cpp
@@ -113,7 +113,7 @@ void BlockLocalPositionEstimator::lidarCorrect()
 		mavlink_and_console_log_info(&mavlink_log_pub, "[lpe] lidar OK");
 	}
 
-	// kalman filter correction if no fault
+	// kalman filter correction always
 	if (!(_sensorFault & SENSOR_LIDAR)) {
 		Matrix<float, n_x, n_y_lidar> K = _P * C.transpose() * S_I;
 		Vector<float, n_x> dx = K * r;

--- a/src/modules/local_position_estimator/sensors/lidar.cpp
+++ b/src/modules/local_position_estimator/sensors/lidar.cpp
@@ -114,12 +114,10 @@ void BlockLocalPositionEstimator::lidarCorrect()
 	}
 
 	// kalman filter correction always
-	if (!(_sensorFault & SENSOR_LIDAR)) {
-		Matrix<float, n_x, n_y_lidar> K = _P * C.transpose() * S_I;
-		Vector<float, n_x> dx = K * r;
-		_x += dx;
-		_P -= K * C * _P;
-	}
+	Matrix<float, n_x, n_y_lidar> K = _P * C.transpose() * S_I;
+	Vector<float, n_x> dx = K * r;
+	_x += dx;
+	_P -= K * C * _P;
 }
 
 void BlockLocalPositionEstimator::lidarCheckTimeout()

--- a/src/modules/local_position_estimator/sensors/mocap.cpp
+++ b/src/modules/local_position_estimator/sensors/mocap.cpp
@@ -91,13 +91,11 @@ void BlockLocalPositionEstimator::mocapCorrect()
 		//mavlink_and_console_log_info(&mavlink_log_pub, "[lpe] mocap OK");
 	}
 
-	// kalman filter correction if no fault
-	if (!(_sensorFault & SENSOR_MOCAP)) {
-		Matrix<float, n_x, n_y_mocap> K = _P * C.transpose() * S_I;
-		Vector<float, n_x> dx = K * r;
-		_x += dx;
-		_P -= K * C * _P;
-	}
+	// kalman filter correction always
+	Matrix<float, n_x, n_y_mocap> K = _P * C.transpose() * S_I;
+	Vector<float, n_x> dx = K * r;
+	_x += dx;
+	_P -= K * C * _P;
 }
 
 void BlockLocalPositionEstimator::mocapCheckTimeout()

--- a/src/modules/local_position_estimator/sensors/sonar.cpp
+++ b/src/modules/local_position_estimator/sensors/sonar.cpp
@@ -137,7 +137,6 @@ void BlockLocalPositionEstimator::sonarCorrect()
 		_x += dx;
 		_P -= K * C * _P;
 	}
-
 }
 
 void BlockLocalPositionEstimator::sonarCheckTimeout()


### PR DESCRIPTION
Closes #6140.

@Stifael please test.

I was able to reproduce drift when the fuse gps flag was set to off. This occurred since the standard iris config for LPE didn't set the param and if you run the  "make posix_sitl_default gazebo_iris_opt_flow" followed by "make posix_sitl_default gazebo_iris" Then the iris without flow and with gps will have flow enabled and gps disabled. It will still take off due to the land detector correction, but then drift since it doesn't have a valid position measurement anymore.