### PR TITLE
ROMFS startup: Fix variable expansion for new NuttX scheme

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.fw_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.fw_apps
@@ -18,7 +18,3 @@ fw_pos_control_l1 start
 # Start Land Detector
 #
 land_detector start fixedwing
-
-#
-# Misc apps
-#

--- a/ROMFS/px4fmu_common/init.d/rc.fw_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.fw_defaults
@@ -11,10 +11,10 @@ then
 	param set RTL_DESCEND_ALT 100
 	param set RTL_LAND_DELAY -1
 
-	# FW uses L1 distance for acceptance radius 
+	# FW uses L1 distance for acceptance radius
 	#  set a smaller NAV_ACC_RAD for vertical acceptance distance
 	param set NAV_ACC_RAD 10
-	
+
 	param set MIS_LTRMIN_ALT 25
 	param set MIS_TAKEOFF_ALT 25
 fi

--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -19,7 +19,7 @@ then
 
 	if [ $MIXER_AUX == none -a $USE_IO == yes ]
 	then
-		set MIXER_AUX $MIXER.aux
+		set MIXER_AUX ${MIXER}.aux
 	fi
 
 	# Use the mixer file from the SD-card if it exists
@@ -54,13 +54,13 @@ then
 		set OUTPUT_DEV /dev/tap_esc
 	fi
 
-	if mixer load $OUTPUT_DEV $MIXER_FILE
+	if mixer load ${OUTPUT_DEV} ${MIXER_FILE}
 	then
 		echo "INFO  [init] Mixer: ${MIXER_FILE} on ${OUTPUT_DEV}"
 	else
 		echo "ERROR  [init] Failed loading mixer: ${MIXER_FILE}"
 		echo "ERROR  [init] Failed loading mixer: ${MIXER_FILE}" >> $LOG_FILE
-		tone_alarm $TUNE_ERR
+		tone_alarm ${TUNE_ERR}
 	fi
 
 	unset MIXER_FILE
@@ -69,7 +69,7 @@ else
 	then
 		echo "ERROR  [init] Mixer undefined"
 		echo "ERROR  [init] Mixer undefined" >> $LOG_FILE
-		tone_alarm $TUNE_ERR
+		tone_alarm ${TUNE_ERR}
 	fi
 fi
 
@@ -82,7 +82,7 @@ then
 		#
 		if [ $PWM_RATE != none ]
 		then
-			pwm rate -c $PWM_OUT -r $PWM_RATE
+			pwm rate -c ${PWM_OUT} -r ${PWM_RATE}
 		fi
 
 		#
@@ -90,21 +90,21 @@ then
 		#
 		if [ $PWM_DISARMED != none ]
 		then
-			pwm disarmed -c $PWM_OUT -p $PWM_DISARMED
+			pwm disarmed -c ${PWM_OUT} -p ${PWM_DISARMED}
 		fi
 		if [ $PWM_MIN != none ]
 		then
-			pwm min -c $PWM_OUT -p $PWM_MIN
+			pwm min -c ${PWM_OUT} -p ${PWM_MIN}
 		fi
 		if [ $PWM_MAX != none ]
 		then
-			pwm max -c $PWM_OUT -p $PWM_MAX
+			pwm max -c ${PWM_OUT} -p ${PWM_MAX}
 		fi
 	fi
 
 	if [ $FAILSAFE != none ]
 	then
-		pwm failsafe -d $OUTPUT_DEV $FAILSAFE
+		pwm failsafe -d ${OUTPUT_DEV} ${FAILSAFE}
 	fi
 fi
 
@@ -157,7 +157,7 @@ then
 			# Append aux mixer to main device
 			if [ $OUTPUT_MODE == hil ]
 			then
-				if mixer append $OUTPUT_DEV $MIXER_AUX_FILE
+				if mixer append ${OUTPUT_DEV} ${MIXER_AUX_FILE}
 				then
 					echo "INFO  [init] Mixer: ${MIXER_AUX_FILE} appended to ${OUTPUT_DEV}"
 				else
@@ -167,7 +167,7 @@ then
 			fi
 			if [ -e $OUTPUT_AUX_DEV -a $OUTPUT_MODE != hil ]
 			then
-				if mixer load $OUTPUT_AUX_DEV $MIXER_AUX_FILE
+				if mixer load ${OUTPUT_AUX_DEV} ${MIXER_AUX_FILE}
 				then
 					echo "INFO  [init] Mixer: ${MIXER_AUX_FILE} on ${OUTPUT_AUX_DEV}"
 				else
@@ -180,7 +180,7 @@ then
 			fi
 		else
 			echo "ERROR: Could not start: fmu mode_pwm" >> $LOG_FILE
-			tone_alarm $TUNE_ERR
+			tone_alarm ${TUNE_ERR}
 			set PWM_AUX_OUT none
 			set FAILSAFE_AUX none
 		fi
@@ -193,16 +193,16 @@ then
 			#
 			if [ $PWM_AUX_RATE != none ]
 			then
-				pwm rate -c $PWM_AUX_OUT -r $PWM_AUX_RATE -d $OUTPUT_AUX_DEV
+				pwm rate -c ${PWM_AUX_OUT} -r ${PWM_AUX_RATE} -d ${OUTPUT_AUX_DEV}
 			fi
 
 			if [ $PWM_AUX_MIN != none ]
 			then
-				pwm min -c $PWM_AUX_OUT -p $PWM_AUX_MIN -d $OUTPUT_AUX_DEV
+				pwm min -c ${PWM_AUX_OUT} -p ${PWM_AUX_MIN} -d ${OUTPUT_AUX_DEV}
 			fi
 			if [ $PWM_AUX_MAX != none ]
 			then
-				pwm max -c $PWM_AUX_OUT -p $PWM_AUX_MAX -d $OUTPUT_AUX_DEV
+				pwm max -c ${PWM_AUX_OUT} -p ${PWM_AUX_MAX} -d ${OUTPUT_AUX_DEV}
 			fi
 		fi
 
@@ -225,7 +225,7 @@ then
 
 		if [ $FAILSAFE_AUX != none ]
 		then
-			pwm failsafe -d $OUTPUT_AUX_DEV $FAILSAFE
+			pwm failsafe -d ${OUTPUT_AUX_DEV} ${FAILSAFE}
 		fi
 
 	fi

--- a/ROMFS/px4fmu_common/init.d/rc.io
+++ b/ROMFS/px4fmu_common/init.d/rc.io
@@ -16,6 +16,6 @@ then
 	set PX4IO_LIMIT 200
 fi
 
-if px4io limit $PX4IO_LIMIT
+if px4io limit ${PX4IO_LIMIT}
 then
 fi

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -2,7 +2,13 @@
 #
 # PX4FMU startup script.
 #
-#  NOTE: COMMENT LINES ARE REMOVED BEFORE STORED IN ROMFS.
+# NOTE: environment variable references:
+#    If the dollar sign ('$') is followed by a left bracket ('{') then the
+#    variable name is terminated with the right bracket character ('}').
+#    Otherwise, the variable name goes to the end of the argument.
+#
+#
+# NOTE: COMMENT LINES ARE REMOVED BEFORE STORED IN ROMFS.
 #
 # UART mapping on FMUv1/2/3/4:
 #
@@ -85,7 +91,7 @@ fi
 set FRC /fs/microsd/etc/rc.txt
 if [ -f $FRC ]
 then
-	echo "INFO  [init] Executing script: $FRC"
+	echo "INFO  [init] Executing script: ${FRC}"
 	sh $FRC
 	set MODE custom
 fi
@@ -271,7 +277,7 @@ then
 	set FCONFIG /fs/microsd/etc/config.txt
 	if [ -f $FCONFIG ]
 	then
-		echo "Custom: $FCONFIG"
+		echo "Custom: ${FCONFIG}"
 		sh $FCONFIG
 	fi
 	unset FCONFIG
@@ -322,7 +328,7 @@ then
 			if px4io forceupdate 14662 ${IO_FILE}
 			then
 				usleep 10000
-				if px4io checkcrc $IO_FILE
+				if px4io checkcrc ${IO_FILE}
 				then
 					echo "PX4IO CRC OK after updating" >> $LOG_FILE
 					tone_alarm MLL8CDE
@@ -330,11 +336,11 @@ then
 					set IO_PRESENT yes
 				else
 					echo "PX4IO update failed" >> $LOG_FILE
-					tone_alarm $TUNE_ERR
+					tone_alarm ${TUNE_ERR}
 				fi
 			else
 				echo "PX4IO update failed" >> $LOG_FILE
-				tone_alarm $TUNE_ERR
+				tone_alarm ${TUNE_ERR}
 			fi
 		fi
 		unset IO_FILE
@@ -342,7 +348,7 @@ then
 		if [ $IO_PRESENT == no ]
 		then
 			echo "PX4IO not found" >> $LOG_FILE
-			tone_alarm $TUNE_ERR
+			tone_alarm ${TUNE_ERR}
 		fi
 	fi
 
@@ -539,10 +545,10 @@ then
 		else
 			if [ $OUTPUT_MODE != fmu -a $OUTPUT_MODE != ardrone ]
 			then
-				if fmu mode_$FMU_MODE
+				if fmu mode_${FMU_MODE}
 				then
 				else
-					echo "FMU mode_$FMU_MODE start failed" >> $LOG_FILE
+					echo "FMU mode_${FMU_MODE} start failed" >> $LOG_FILE
 					tone_alarm $TUNE_ERR
 				fi
 
@@ -597,7 +603,7 @@ then
 	if [ "x$MAVLINK_F" == xnone ]
 	then
 	else
-		mavlink start $MAVLINK_F
+		mavlink start ${MAVLINK_F}
 	fi
 	unset MAVLINK_F
 
@@ -611,7 +617,7 @@ then
 		# but this works for now
 		if param compare SYS_COMPANION 10
 		then
-			frsky_telemetry start -d $MAVLINK_COMPANION_DEVICE
+			frsky_telemetry start -d ${MAVLINK_COMPANION_DEVICE}
 		fi
 		if param compare SYS_COMPANION 20
 		then
@@ -620,31 +626,31 @@ then
 		fi
 		if param compare SYS_COMPANION 921600
 		then
-			mavlink start -d $MAVLINK_COMPANION_DEVICE -b 921600 -m onboard -r 80000 -x
+			mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 921600 -m onboard -r 80000 -x
 		fi
 		if param compare SYS_COMPANION 57600
 		then
-			mavlink start -d $MAVLINK_COMPANION_DEVICE -b 57600 -m onboard -r 5000 -x
+			mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 57600 -m onboard -r 5000 -x
 		fi
 		if param compare SYS_COMPANION 157600
 		then
-			mavlink start -d $MAVLINK_COMPANION_DEVICE -b 57600 -m osd -r 1000
+			mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 57600 -m osd -r 1000
 		fi
 		if param compare SYS_COMPANION 257600
 		then
-			mavlink start -d $MAVLINK_COMPANION_DEVICE -b 57600 -m magic -r 5000 -x
+			mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 57600 -m magic -r 5000 -x
 		fi
 		if param compare SYS_COMPANION 319200
 		then
-			mavlink start -d $MAVLINK_COMPANION_DEVICE -b 19200 -r 1000
+			mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 19200 -r 1000
 		fi
 		if param compare SYS_COMPANION 338400
 		then
-			mavlink start -d $MAVLINK_COMPANION_DEVICE -b 38400 -r 1000
+			mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 38400 -r 1000
 		fi
 		if param compare SYS_COMPANION 357600
 		then
-			mavlink start -d $MAVLINK_COMPANION_DEVICE -b 57600 -r 1000
+			mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 57600 -r 1000
 		fi
 		if param compare SYS_COMPANION 419200
 		then
@@ -653,11 +659,11 @@ then
 		fi
 		if param compare SYS_COMPANION 1921600
 		then
-			mavlink start -d $MAVLINK_COMPANION_DEVICE -b 921600 -r 20000
+			mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 921600 -r 20000
 		fi
 		if param compare SYS_COMPANION 1500000
 		then
-			mavlink start -d $MAVLINK_COMPANION_DEVICE -b 1500000 -m onboard -r 10000 -x
+			mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 1500000 -m onboard -r 10000 -x
 		fi
 	fi
 
@@ -672,7 +678,7 @@ then
 		then
 			uavcan start fw
 		else
-			tone_alarm $TUNE_ERR
+			tone_alarm ${TUNE_ERR}
 		fi
 	fi
 
@@ -780,7 +786,7 @@ then
 				set LOGGER_ARGS "-f"
 			fi
 
-			if logger start -b 12 -t $LOGGER_ARGS
+			if logger start -b 12 -t ${LOGGER_ARGS}
 			then
 			fi
 			unset LOGGER_ARGS
@@ -812,7 +818,7 @@ then
 			set MAV_TYPE 1
 		fi
 
-		param set MAV_TYPE $MAV_TYPE
+		param set MAV_TYPE ${MAV_TYPE}
 
 		# Load mixer and configure outputs
 		sh /etc/init.d/rc.interface
@@ -878,7 +884,7 @@ then
 			echo "Unknown MAV_TYPE"
 			param set MAV_TYPE 2
 		else
-			param set MAV_TYPE $MAV_TYPE
+			param set MAV_TYPE ${MAV_TYPE}
 		fi
 
 		# Load mixer and configure outputs
@@ -921,7 +927,7 @@ then
 			echo "Unknown MAV_TYPE"
 			param set MAV_TYPE 19
 		else
-			param set MAV_TYPE $MAV_TYPE
+			param set MAV_TYPE ${MAV_TYPE}
 		fi
 
 		# Load mixer and configure outputs
@@ -1009,7 +1015,7 @@ then
 	set FEXTRAS /fs/microsd/etc/extras.txt
 	if [ -f $FEXTRAS ]
 	then
-		echo "Addons script: $FEXTRAS"
+		echo "Addons script: ${FEXTRAS}"
 		sh $FEXTRAS
 	fi
 	unset FEXTRAS


### PR DESCRIPTION
@bkueng Please review. The rule is like the following: Without braces a variable extends to the end of the line for function arguments. For shell syntax like if statements the variable extends to the first space (which is why I only escaped the function call / task start arguments).