### PR TITLE
uORBFastRpcChannel: fixed include for snapdragon

### DIFF
--- a/src/modules/muorb/adsp/uORBFastRpcChannel.hpp
+++ b/src/modules/muorb/adsp/uORBFastRpcChannel.hpp
@@ -39,6 +39,7 @@
 #include "uORB/uORBCommunicator.hpp"
 #include <semaphore.h>
 #include <set>
+#include <px4_sem.h>
 
 namespace uORB
 {


### PR DESCRIPTION
SEM_PRIO_NONE not found