### PR TITLE
Bugfix:MPU6000 Driver accept unknown ICM20xxx product IDs

### DIFF
--- a/src/drivers/mpu6000/mpu6000.h
+++ b/src/drivers/mpu6000/mpu6000.h
@@ -174,7 +174,7 @@
 
 // Product ID Description for ICM2608
 
-#define ICM20608_REV_00		0xff // In the past, was thought to be not returning a value. But seem repeatable.
+#define ICM20608_REV_FF		0xff // In the past, was thought to be not returning a value. But seem repeatable.
 
 // Product ID Description for ICM2689
 


### PR DESCRIPTION
   This allows a ICM20xxxx with an unkown product ID to be used
   with the mpu6000 driver.

   This change will issues a warning for any part with an unknown product ID.
   For mpu6000 parts (-T 6000 or not specified) it will then exit.
   For any ICM20xxxx part with an unknown product ID it will accept the ID
   and run with it.

   N.B. This fix expecte the value in the product ID register to be
   a per chip constant. (Not changing during operations)