### PR TITLE
Simulation improvements

### DIFF
--- a/cmake/configs/posix_sitl_default.cmake
+++ b/cmake/configs/posix_sitl_default.cmake
@@ -104,7 +104,7 @@ set(config_extra_builtin_cmds
 # for the config posix_sitl_efk2 and set again, explicitly, for posix_sitl_lpe,
 # which are based on posix_sitl_default.
 set(config_sitl_rcS_dir
-	posix-configs/SITL/init/lpe
+	posix-configs/SITL/init/ekf2
 	CACHE INTERNAL "init script dir for sitl"
 	)
 

--- a/posix-configs/SITL/init/ekf2/typhoon_h480
+++ b/posix-configs/SITL/init/ekf2/typhoon_h480
@@ -29,8 +29,8 @@ param set RTL_RETURN_ALT 30.0
 param set RTL_DESCEND_ALT 10.0
 param set RTL_LAND_DELAY 0
 param set MIS_TAKEOFF_ALT 2.5
-param set MC_ROLLRATE_P 0.15
-param set MC_PITCHRATE_P 0.15
+param set MC_ROLLRATE_P 0.1
+param set MC_PITCHRATE_P 0.1
 param set MC_PITCH_P 6
 param set MC_ROLL_P 6
 param set MPC_HOLD_MAX_Z 2.0

--- a/posix-configs/SITL/init/ekf2/typhoon_h480
+++ b/posix-configs/SITL/init/ekf2/typhoon_h480
@@ -10,15 +10,15 @@ param set CAL_GYRO0_ID 2293768
 param set CAL_ACC0_ID 1376264
 param set CAL_ACC1_ID 1310728
 param set CAL_MAG0_ID 196616
-param set CAL_GYRO0_XOFF 0.01
-param set CAL_ACC0_XOFF 0.01
-param set CAL_ACC0_YOFF -0.01
-param set CAL_ACC0_ZOFF 0.01
-param set CAL_ACC0_XSCALE 1.01
-param set CAL_ACC0_YSCALE 1.01
-param set CAL_ACC0_ZSCALE 1.01
-param set CAL_ACC1_XOFF 0.01
-param set CAL_MAG0_XOFF 0.01
+param set CAL_GYRO0_XOFF 0.001
+param set CAL_ACC0_XOFF 0.001
+param set CAL_ACC0_YOFF -0.001
+param set CAL_ACC0_ZOFF 0.001
+param set CAL_ACC0_XSCALE 1.0001
+param set CAL_ACC0_YSCALE 1.0001
+param set CAL_ACC0_ZSCALE 1.0001
+param set CAL_ACC1_XOFF 0.001
+param set CAL_MAG0_XOFF 0.001
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
@@ -29,8 +29,8 @@ param set RTL_RETURN_ALT 30.0
 param set RTL_DESCEND_ALT 10.0
 param set RTL_LAND_DELAY 0
 param set MIS_TAKEOFF_ALT 2.5
-param set MC_ROLLRATE_P 0.2
-param set MC_PITCHRATE_P 0.2
+param set MC_ROLLRATE_P 0.15
+param set MC_PITCHRATE_P 0.15
 param set MC_PITCH_P 6
 param set MC_ROLL_P 6
 param set MPC_HOLD_MAX_Z 2.0
@@ -74,7 +74,7 @@ mavlink stream -r 50 -s SERVO_OUTPUT_RAW_0 -u 14556
 mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
-sdlog2 start -r 100 -e -t -a
+logger start -e -t
 vmount start
 mavlink boot_complete
 replay trystart

--- a/src/platforms/posix/px4_layer/drv_hrt.c
+++ b/src/platforms/posix/px4_layer/drv_hrt.c
@@ -338,8 +338,8 @@ void	hrt_stop_delay()
 	_delay_interval += delta;
 	_start_delay_time = 0;
 
-	if (delta > 10000) {
-		PX4_INFO("simulator is slow. Delay added: %" PRIu64 " us", delta);
+	if (delta > 100000) {
+		PX4_INFO("Computer load temporarily too high for real-time simulation. (slowdown delay: %" PRIu64 " us)", delta);
 	}
 
 	pthread_mutex_unlock(&_hrt_mutex);


### PR DESCRIPTION
@julianoes I'm currently going through all airframes and checking their simulation performance. This one was pretty off. This also fixes the stale baro warning.

Flight still shows oscillation: Must be tuning or an issue with Gazebo physics:
http://review.px4.io/plot_app?log=c53f2a39-943a-43ec-9deb-7d6dce72ff02