### PR TITLE
Fix usage of CRTSCTS define from termios.h

### DIFF
--- a/nuttx-patches/fix_CRTSCTS-define.patch
+++ b/nuttx-patches/fix_CRTSCTS-define.patch
@@ -1,0 +1,12 @@
+diff -ruN NuttX/nuttx/include/termios.h NuttX/nuttx/include/termios.h
+--- NuttX/nuttx/include/termios.h	1969-12-31 14:00:00.000000000 -1000
++++ NuttX/nuttx/include/termios.h	2014-12-25 17:33:53.404950574 -1000
+@@ -110,8 +110,8 @@
+ #define HUPCL     (1 << 6)  /* Bit 6: Hang up on last close */
+ #define CLOCAL    (1 << 7)  /* Bit 7: Ignore modem status lines */
+ #define CCTS_OFLOW (1 << 8) /* Bit 8: CTS flow control of output */
+-#define CRTSCTS   CCTS_OFLOW
+ #define CRTS_IFLOW (1 << 9) /* Bit 9: RTS flow control of input */
++#define CRTSCTS   (CRTS_IFLOW | CCTS_OFLOW)
+ 
+ /* Local Modes (c_lflag in the termios structure) */


### PR DESCRIPTION
NuttX had the CRTSCTS define incorrectly set for only output flow control, which broke our flow control logic. This commit patches NuttX and puts in addition a guard in place to prevent any future issue with the non-POSIX define being incorrect.

@ecmnet Could you quickly test this and provide the output of `mavlink status`? Give it 15 seconds or so to auto-disable flow control if your link does not support flow control. Do you have the flow control lines connected and does your radio link support flow control?