### PR TITLE
Disable the safety switch by default on Pixracer

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -287,6 +287,11 @@ then
 	#
 	if [ $AUTOCNF == yes ]
 	then
+		# Disable safety switch by default on Pixracer
+		if ver hwcmp PX4FMU_V4
+		then
+			param set CBRK_IO_SAFETY 22027
+		fi
 		param set SYS_AUTOCONFIG 0
 	fi
 	unset AUTOCNF


### PR DESCRIPTION
This disables the safety switch when Pixracer is configured. It does not change existing setups and it can be re-enabled after. This might be the more sensible default for a racing board.

@kd0aij @sanderux @dagar @julianoes Comments?