### PR TITLE
FMU/Camera trigger: initialize all FMU pins from FMU

### DIFF
--- a/src/drivers/camera_trigger/interfaces/src/pwm.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.cpp
@@ -59,8 +59,6 @@ void CameraInterfacePWM::setup()
 {
 	for (unsigned i = 0; i < sizeof(_pins) / sizeof(_pins[0]); i = i + 2) {
 		if (_pins[i] >= 0 && _pins[i + 1] >= 0) {
-			uint8_t pin_bitmask = (1 << _pins[i + 1]) | (1 << _pins[i]);
-			up_pwm_servo_init(pin_bitmask);
 			up_pwm_servo_set(_pins[i + 1], math::constrain(PWM_CAMERA_DISARMED, PWM_CAMERA_DISARMED, 2000));
 			up_pwm_servo_set(_pins[i], math::constrain(PWM_CAMERA_DISARMED, PWM_CAMERA_DISARMED, 2000));
 		}

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -948,7 +948,8 @@ void
 PX4FMU::update_pwm_out_state(bool on)
 {
 	if (on && !_pwm_initialized && _pwm_mask != 0) {
-		up_pwm_servo_init(_pwm_mask);
+		// always initialize all channels
+		up_pwm_servo_init(0xff);
 		set_pwm_rate(_pwm_alt_rate_channels, _pwm_default_rate, _pwm_alt_rate);
 		_pwm_initialized = true;
 	}


### PR DESCRIPTION
@LorenzMeier I'm not sure if this is a good fix. The reason for it not currently working is that `up_pwm_servo_init` de-initializes everything first, so `fmu` was overriding the init from `camera_trigger`. We still need to modify the startup sequence so camera trigger comes after FMU to make the initial values work that it sets.

Potentially resolves #6092