### PR TITLE
navigator_main: include fix for FLT_EPSILON

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -60,6 +60,7 @@
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <float.h>
 
 #include <drivers/device/device.h>
 #include <drivers/drv_hrt.h>


### PR DESCRIPTION
inorder to use FLT_EPSILON, float.h file has to be included