### PR TITLE
Disable a set of warnings for NuttX that are new in GCC 6

### DIFF
--- a/nuttx-configs/PX4_Warnings.mk
+++ b/nuttx-configs/PX4_Warnings.mk
@@ -43,7 +43,9 @@ PX4_ARCHWARNINGS = -Wall \
                    -Wpointer-arith \
                    -Wshadow \
                    -Wno-sign-compare \
-                   -Wno-unused-parameter
+                   -Wno-unused-parameter \
+                   -Wno-nonnull-compare \
+                   -Wno-misleading-indentation
 
 #   -Wcast-qual  - generates spurious noreturn attribute warnings, try again later
 #   -Wconversion - would be nice, but too many "risky-but-safe" conversions in the code


### PR DESCRIPTION
This doesn't compile in GCC 6 yet to the end, but its a start.