### PR TITLE
WIP: Position control landing and takeoff

### DIFF
--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -239,14 +239,21 @@ bool MulticopterLandDetector::_get_landed_state()
 
 float MulticopterLandDetector::get_takeoff_throttle()
 {
+	/* Position mode */
 	if (_control_mode.flag_control_manual_enabled && _control_mode.flag_control_position_enabled) {
+		/* Should be above 0.5 because below that we do not gain altitude and won't take off.
+		 * Also it should be quite high such that we don't accidentally take off when using
+		 * a spring loaded throttle and have a useful vertical speed to start with. */
 		return 0.75f;
 	}
 
+	/* Manual/attitude mode */
 	if (_control_mode.flag_control_manual_enabled && _control_mode.flag_control_attitude_enabled) {
+		/* Should be quite low and certainly below hover throttle because pilot controls throttle manually. */
 		return 0.15f;
 	}
 
+	/* As default for example in acro mode we do not want to stay landed. */
 	return 0.0f;
 }
 

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -141,7 +141,7 @@ bool MulticopterLandDetector::_get_landed_state()
 	// Time base for this function
 	const uint64_t now = hrt_absolute_time();
 
-	float sys_min_throttle = (_params.minThrottle + 0.01f);
+	float sys_min_throttle = (_params.minThrottle + 0.2f);
 
 	// Determine the system min throttle based on flight mode
 	if (!_control_mode.flag_control_altitude_enabled) {

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -65,7 +65,7 @@ MulticopterLandDetector::MulticopterLandDetector() : LandDetector(),
 	_vehicleAttitude{},
 	_manual{},
 	_ctrl_state{},
-	_ctrl_mode{},
+	_control_mode{},
 	_min_trust_start(0),
 	_arming_time(0)
 {
@@ -99,7 +99,7 @@ void MulticopterLandDetector::_update_topics()
 	_orb_update(ORB_ID(actuator_armed), _armingSub, &_arming);
 	_orb_update(ORB_ID(manual_control_setpoint), _manualSub, &_manual);
 	_orb_update(ORB_ID(control_state), _ctrl_state_sub, &_ctrl_state);
-	_orb_update(ORB_ID(vehicle_control_mode), _vehicle_control_mode_sub, &_ctrl_mode);
+	_orb_update(ORB_ID(vehicle_control_mode), _vehicle_control_mode_sub, &_control_mode);
 }
 
 void MulticopterLandDetector::_update_params()
@@ -144,7 +144,7 @@ bool MulticopterLandDetector::_get_landed_state()
 	float sys_min_throttle = (_params.minThrottle + 0.01f);
 
 	// Determine the system min throttle based on flight mode
-	if (!_ctrl_mode.flag_control_altitude_enabled) {
+	if (!_control_mode.flag_control_altitude_enabled) {
 		sys_min_throttle = (_params.minManThrottle + 0.01f);
 	}
 
@@ -169,11 +169,18 @@ bool MulticopterLandDetector::_get_landed_state()
 		_arming_time = now;
 	}
 
+	const bool manual_control_present = _control_mode.flag_control_manual_enabled && _manual.timestamp > 0;
+
+	// If we control manually and are still landed, we want to stay idle until the pilot rises the throttle
+	if (_state == LandDetectionState::LANDED && manual_control_present && _manual.z < get_takeoff_throttle()) {
+		return true;
+	}
+
 	// If in manual flight mode never report landed if the user has more than idle throttle
 	// Check if user commands throttle and if so, report not landed based on
 	// the user intent to take off (even if the system might physically still have
 	// ground contact at this point).
-	if (_manual.timestamp > 0 && _manual.z > 0.15f && _ctrl_mode.flag_control_manual_enabled) {
+	if (manual_control_present && _manual.z > 0.15f) {
 		return false;
 	}
 
@@ -228,6 +235,19 @@ bool MulticopterLandDetector::_get_landed_state()
 	}
 
 	return true;
+}
+
+float MulticopterLandDetector::get_takeoff_throttle()
+{
+	if (_control_mode.flag_control_manual_enabled && _control_mode.flag_control_position_enabled) {
+		return 0.75f;
+	}
+
+	if (_control_mode.flag_control_manual_enabled && _control_mode.flag_control_attitude_enabled) {
+		return 0.15f;
+	}
+
+	return 0.0f;
 }
 
 

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -116,7 +116,7 @@ private:
 	uint64_t _min_trust_start;		///< timestamp when minimum trust was applied first
 	uint64_t _arming_time;
 
-	// get pilot throttle threshold with which we should quit landed state and take off
+	/* get control mode dependent pilot throttle threshold with which we should quit landed state and take off */
 	float get_takeoff_throttle();
 };
 

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -111,10 +111,13 @@ private:
 	struct vehicle_attitude_s		_vehicleAttitude;
 	struct manual_control_setpoint_s	_manual;
 	struct control_state_s			_ctrl_state;
-	struct vehicle_control_mode_s		_ctrl_mode;
+	struct vehicle_control_mode_s		_control_mode;
 
 	uint64_t _min_trust_start;		///< timestamp when minimum trust was applied first
 	uint64_t _arming_time;
+
+	// get pilot throttle threshold with which we should quit landed state and take off
+	float get_takeoff_throttle();
 };
 
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1040,14 +1040,6 @@ MulticopterPositionControl::control_manual(float dt)
 
 		_att_sp.timestamp = hrt_absolute_time();
 
-		/* publish attitude setpoint */
-		if (_att_sp_pub != nullptr) {
-			orb_publish(_attitude_setpoint_id, _att_sp_pub, &_att_sp);
-
-		} else if (_attitude_setpoint_id) {
-			_att_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp);
-		}
-
 	} else {
 		control_position(dt);
 	}
@@ -1181,14 +1173,6 @@ MulticopterPositionControl::control_non_manual(float dt)
 		_att_sp.thrust = 0.0f;
 
 		_att_sp.timestamp = hrt_absolute_time();
-
-		/* publish attitude setpoint */
-		if (_att_sp_pub != nullptr) {
-			orb_publish(_attitude_setpoint_id, _att_sp_pub, &_att_sp);
-
-		} else if (_attitude_setpoint_id) {
-			_att_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp);
-		}
 
 	} else {
 		control_position(dt);

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1759,7 +1759,7 @@ MulticopterPositionControl::control_position(float dt)
 
 		} else {
 			thrust_sp = vel_err.emult(_params.vel_p) + _vel_err_d.emult(_params.vel_d)
-				    + _thrust_int - math::Vector<3>(0, 0, _params.thr_hover);
+				    + _thrust_int - math::Vector<3>(0.0f, 0.0f, _params.thr_hover);
 		}
 
 		if (_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF
@@ -1905,9 +1905,10 @@ MulticopterPositionControl::control_position(float dt)
 			thrust_sp(2) *= att_comp;
 		}
 
-		/* Calculate desired total thrust amount in body z direction
-		 * Project the desired thrust force vector F onto the vehicles thrust axis -R_z
-		 * to compensate for excess thrust during attitude tracking errors */
+		/* Calculate desired total thrust amount in body z direction. */
+		/* To compensate for excess thrust during attitude tracking errors we
+		 * project the desired thrust force vector F onto the real vehicle's thrust axis in NED:
+		 * body thrust axis [0,0,-1]' rotated by R is: R*[0,0,-1]' = -R_z */
 		matrix::Vector3f R_z(_R(0, 2), _R(1, 2), _R(2, 2));
 		matrix::Vector3f F(thrust_sp.data);
 		float thrust_body_z = F.dot(-R_z); /* recalculate because it might have changed */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1790,7 +1790,6 @@ MulticopterPositionControl::control_position(float dt)
 			thr_min = 0.0f;
 		}
 
-		float thrust_abs = thrust_sp.length();
 		float tilt_max = _params.tilt_max_air;
 		float thr_max = _params.thr_max;
 		/* filter vel_z over 1/8sec */
@@ -1906,10 +1905,15 @@ MulticopterPositionControl::control_position(float dt)
 			thrust_sp(2) *= att_comp;
 		}
 
-		/* limit max thrust */
-		thrust_abs = thrust_sp.length(); /* recalculate because it might have changed */
+		/* Calculate desired total thrust amount in body z direction
+		 * Project the desired thrust force vector F onto the vehicles thrust axis -R_z
+		 * to compensate for excess thrust during attitude tracking errors */
+		matrix::Vector3f R_z(_R(0, 2), _R(1, 2), _R(2, 2));
+		matrix::Vector3f F(thrust_sp.data);
+		float thrust_body_z = F.dot(-R_z); /* recalculate because it might have changed */
 
-		if (thrust_abs > thr_max) {
+		/* limit max thrust */
+		if (thrust_body_z > thr_max) {
 			if (thrust_sp(2) < 0.0f) {
 				if (-thrust_sp(2) > thr_max) {
 					/* thrust Z component is too large, limit it */
@@ -1933,14 +1937,16 @@ MulticopterPositionControl::control_position(float dt)
 
 			} else {
 				/* Z component is negative, going down, simply limit thrust vector */
-				float k = thr_max / thrust_abs;
+				float k = thr_max / thrust_body_z;
 				thrust_sp *= k;
 				saturation_xy = true;
 				saturation_z = true;
 			}
 
-			thrust_abs = thr_max;
+			thrust_body_z = thr_max;
 		}
+
+		_att_sp.thrust = thrust_body_z;
 
 		/* update integrals */
 		if (_control_mode.flag_control_velocity_enabled && !saturation_xy) {
@@ -1959,8 +1965,8 @@ MulticopterPositionControl::control_position(float dt)
 			math::Vector<3> body_y;
 			math::Vector<3> body_z;
 
-			if (thrust_abs > SIGMA) {
-				body_z = -thrust_sp / thrust_abs;
+			if (thrust_sp.length() > SIGMA) {
+				body_z = -thrust_sp.normalized();
 
 			} else {
 				/* no thrust, set Z axis to safe value */
@@ -2023,8 +2029,6 @@ MulticopterPositionControl::control_position(float dt)
 			_att_sp.roll_body = 0.0f;
 			_att_sp.pitch_body = 0.0f;
 		}
-
-		_att_sp.thrust = thrust_abs;
 
 		/* save thrust setpoint for logging */
 		_local_pos_sp.acc_x = thrust_sp(0) * ONE_G;


### PR DESCRIPTION
This pull request suggests subtle but fundamental changes to the position controller and landing detector to achieve an intuitive all the time manual controlled takeoff and landing of a multicopter.

Summary:
- hover throttle is used as feed forward term against constant gravitational force
  (misusing the thrust integration control for this purpose caused problems)
- land detector keeps vehicle landed until a mode dependent manual throttle input is exceeded
  (this unlocks position control takeoff with spring loaded throttle sticks)
- good refactor commit by @julianoes 
- thrust amount calculation in position control takes 3D projection onto the real vehicle thrust direction
  (useful in general but added here especially because horizontal position control corrections while landing produced vertical thrust and didn't allow proper landing)

Foremost the last point still needs real world testing.
