### PR TITLE
Fix inconsistencies in handling of optical flow data

### DIFF
--- a/msg/optical_flow.msg
+++ b/msg/optical_flow.msg
@@ -1,16 +1,15 @@
-# Optical flow in NED body frame in SI units.
+# Optical flow in XYZ body frame in SI units.
 # @see http://en.wikipedia.org/wiki/International_System_of_Units
- 
+
 uint8 sensor_id			# id of the sensor emitting the flow value
-float32 pixel_flow_x_integral	# accumulated optical flow in radians around x axis
-float32 pixel_flow_y_integral	# accumulated optical flow in radians around y axis
-float32 gyro_x_rate_integral	# accumulated gyro value in radians around x axis
-float32 gyro_y_rate_integral	# accumulated gyro value in radians around y axis
-float32 gyro_z_rate_integral	# accumulated gyro value in radians around z axis
+float32 pixel_flow_x_integral	# accumulated optical flow in radians where a positive value is produced by a RH rotation about the X body axis
+float32 pixel_flow_y_integral	# accumulated optical flow in radians where a positive value is produced by a RH rotation about the Y body axis
+float32 gyro_x_rate_integral	# accumulated gyro value in radians where a positive value is produced by a RH rotation about the X body axis
+float32 gyro_y_rate_integral	# accumulated gyro value in radians where a positive value is produced by a RH rotation about the Y body axis
+float32 gyro_z_rate_integral	# accumulated gyro value in radians where a positive value is produced by a RH rotation about the Z body axis
 float32 ground_distance_m	# Altitude / distance to ground in meters
 uint32 integration_timespan	# accumulation timespan in microseconds
 uint32 time_since_last_sonar_update	# time since last sonar update in microseconds
 uint16 frame_count_since_last_readout	# number of accumulated frames in timespan
 int16 gyro_temperature	# Temperature * 100 in centi-degrees Celsius
 uint8 quality	# Average of quality of accumulated frames, 0: bad quality, 255: maximum quality
-

--- a/src/drivers/px4flow/px4flow.cpp
+++ b/src/drivers/px4flow/px4flow.cpp
@@ -256,12 +256,12 @@ PX4FLOW::init()
 	/* sensor is ok, but we don't really know if it is within range */
 	_sensor_ok = true;
 
-	/* get rotation */
+	/* get yaw rotation from sensor frame to body frame */
 	param_t rot = param_find("SENS_FLOW_ROT");
 
 	/* only set it if the parameter exists */
 	if (rot != PARAM_INVALID) {
-		int32_t val = 0;
+		int32_t val = 6; // the recommended installation for the flow sensor is with the Y sensor axis forward
 		param_get(rot, &val);
 
 		_sensor_rotation = (enum Rotation)val;
@@ -538,7 +538,7 @@ PX4FLOW::collect()
 
 	report.sensor_id = 0;
 
-	/* rotate measurements according to parameter */
+	/* rotate measurements in yaw from sensor frame to body frame according to parameter SENS_FLOW_ROT */
 	float zeroval = 0.0f;
 
 	rotate_3f(_sensor_rotation, report.pixel_flow_x_integral, report.pixel_flow_y_integral, zeroval);

--- a/src/modules/local_position_estimator/sensors/flow.cpp
+++ b/src/modules/local_position_estimator/sensors/flow.cpp
@@ -86,11 +86,11 @@ int BlockLocalPositionEstimator::flowMeasure(Vector<float, n_y_flow> &y)
 	//warnx("flow x: %10.4f y: %10.4f gyro_x: %10.4f gyro_y: %10.4f d: %10.4f",
 	//double(flow_x_rad), double(flow_y_rad), double(gyro_x_rad), double(gyro_y_rad), double(d));
 
-	// compute velocities in camera frame using ground distance
-	// assume camera frame is body frame
+	// compute velocities in body frame using ground distance
+	// note that the integral rates in the optical_flow uORB topic are RH rotations about body axes
 	Vector3f delta_b(
+		+(flow_y_rad - gyro_y_rad)*d,
 		-(flow_x_rad - gyro_x_rad)*d,
-		-(flow_y_rad - gyro_y_rad)*d,
 		0);
 
 	// rotation of flow from body to nav frame

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -786,8 +786,9 @@ PARAM_DEFINE_INT32(SENS_BOARD_ROT, 0);
 /**
  * PX4Flow board rotation
  *
- * This parameter defines the rotation of the PX4FLOW board relative to the platform.
- * Zero rotation is defined as Y on flow board pointing towards front of vehicle
+ * This parameter defines the yaw rotation of the PX4FLOW board relative to the vehicle body frame.
+ * Zero rotation is defined as X on flow board pointing towards front of vehicle.
+ * The recommneded installation default for the PX4FLOW board is with the Y axis forward (270 deg yaw).
  *
  * @value 0 No rotation
  * @value 1 Yaw 45°
@@ -802,7 +803,7 @@ PARAM_DEFINE_INT32(SENS_BOARD_ROT, 0);
  *
  * @group Sensor Calibration
  */
-PARAM_DEFINE_INT32(SENS_FLOW_ROT, 0);
+PARAM_DEFINE_INT32(SENS_FLOW_ROT, 6);
 
 /**
  * Board rotation Y (Pitch) offset


### PR DESCRIPTION
This makes the firmware usage of optical flow consistent with the uORB and Mavlink definition in https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/common.xml#L3266

Some simulators may not be compliant with the Mavlink interface definition 
