### PR TITLE
Sensors app: Fix consistency checks.

### DIFF
--- a/src/modules/sensors/voted_sensors_update.h
+++ b/src/modules/sensors/voted_sensors_update.h
@@ -152,6 +152,7 @@ private:
 		{
 			for (unsigned i = 0; i < SENSOR_COUNT_MAX; i++) {
 				subscription[i] = -1;
+				priority[i] = 0;
 			}
 		}
 


### PR DESCRIPTION
The sensors app assumed that all topics are published on boot which is not necessarily true and it assumed that all publications had valid data. This change ensures that topics are initialized as they update the first time and that the consistency check only runs on topics which carry valid data.