### PR TITLE
navigator: don't reset current waypoint

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -928,9 +928,12 @@ Navigator::publish_mission_result()
 		_mission_result_pub = orb_advertise(ORB_ID(mission_result), &_mission_result);
 	}
 
+	// Don't reset current waypoint because it won't be updated e.g. if not in mission mode
+	// however, the current is still valid and therefore helpful for ground stations.
+	//_mission_result.seq_current = 0;
+
 	/* reset some of the flags */
 	_mission_result.seq_reached = false;
-	_mission_result.seq_current = 0;
 	_mission_result.item_do_jump_changed = false;
 	_mission_result.item_changed_index = 0;
 	_mission_result.item_do_jump_remaining = 0;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -933,7 +933,7 @@ Navigator::publish_mission_result()
 	//_mission_result.seq_current = 0;
 
 	/* reset some of the flags */
-	_mission_result.seq_reached = false;
+	_mission_result.reached = false;
 	_mission_result.item_do_jump_changed = false;
 	_mission_result.item_changed_index = 0;
 	_mission_result.item_do_jump_remaining = 0;


### PR DESCRIPTION
We don't want to reset the current waypoint because this means that the
ground stations see a current waypoint of 0 if the current waypoint is
not updated e.g. when we're not in mission mode.

However, it is wrong to send 0 as the current waypoint because if we
switch back to mission mode, it will actually go to the last current
waypoint and not 0.