### PR TITLE
controllib block use consistent name length

### DIFF
--- a/src/lib/controllib/block/Block.cpp
+++ b/src/lib/controllib/block/Block.cpp
@@ -143,8 +143,8 @@ void SuperBlock::setDt(float dt)
 
 	while (child != NULL) {
 		if (count++ > maxChildrenPerBlock) {
-			char name[40];
-			getName(name, 40);
+			char name[blockNameLengthMax];
+			getName(name, blockNameLengthMax);
 			printf("exceeded max children for block: %s\n", name);
 			break;
 		}
@@ -161,8 +161,8 @@ void SuperBlock::updateChildParams()
 
 	while (child != NULL) {
 		if (count++ > maxChildrenPerBlock) {
-			char name[40];
-			getName(name, 40);
+			char name[blockNameLengthMax];
+			getName(name, blockNameLengthMax);
 			printf("exceeded max children for block: %s\n", name);
 			break;
 		}
@@ -179,8 +179,8 @@ void SuperBlock::updateChildSubscriptions()
 
 	while (child != NULL) {
 		if (count++ > maxChildrenPerBlock) {
-			char name[40];
-			getName(name, 40);
+			char name[blockNameLengthMax];
+			getName(name, blockNameLengthMax);
 			printf("exceeded max children for block: %s\n", name);
 			break;
 		}
@@ -197,8 +197,8 @@ void SuperBlock::updateChildPublications()
 
 	while (child != NULL) {
 		if (count++ > maxChildrenPerBlock) {
-			char name[40];
-			getName(name, 40);
+			char name[blockNameLengthMax];
+			getName(name, blockNameLengthMax);
 			printf("exceeded max children for block: %s\n", name);
 			break;
 		}

--- a/src/lib/controllib/block/Block.hpp
+++ b/src/lib/controllib/block/Block.hpp
@@ -54,7 +54,7 @@ static const uint16_t maxChildrenPerBlock = 100;
 static const uint16_t maxParamsPerBlock = 100;
 static const uint16_t maxSubscriptionsPerBlock = 100;
 static const uint16_t maxPublicationsPerBlock = 100;
-static const uint8_t blockNameLengthMax = 80;
+static const uint8_t blockNameLengthMax = 40;
 
 // forward declaration
 class BlockParamBase;


### PR DESCRIPTION
@jgoppert Is there a reason name is limited to 40 chars here instead of using blockNameLengthMax (80)? getName() does a strncpy into it - https://github.com/PX4/Firmware/blob/master/src/lib/controllib/block/Block.cpp#L75

 - coverity CID 12524, 12542, 12548, 12550