### PR TITLE
px4.config: add spektrum_rc to startup

### DIFF
--- a/posix-configs/eagle/flight/px4.config
+++ b/posix-configs/eagle/flight/px4.config
@@ -17,3 +17,4 @@ land_detector start multicopter
 mc_pos_control start
 mc_att_control start
 pwm_out_rc_in start -d /dev/tty-2
+spektrum_rc start


### PR DESCRIPTION
In order to use the spektrum driver, it has to be added to the px4 config file.