### PR TITLE
ORB_PRIO: set ORB_PRIO_MIN to 1

### DIFF
--- a/src/modules/uORB/uORB.h
+++ b/src/modules/uORB/uORB.h
@@ -68,7 +68,7 @@ typedef const struct orb_metadata *orb_id_t;
  * Relevant for multi-topics / topic groups
  */
 enum ORB_PRIO {
-	ORB_PRIO_MIN = 0,
+	ORB_PRIO_MIN = 1, // leave 0 free for other purposes, eg. marking an uninitialized value
 	ORB_PRIO_VERY_LOW = 25,
 	ORB_PRIO_LOW = 50,
 	ORB_PRIO_DEFAULT = 75,


### PR DESCRIPTION
This is needed as the sensors app assumes a value of 0 means uninitialized.

Follow-up to 'Sensors app: Fix consistency checks', a6696d339d, https://github.com/PX4/Firmware/pull/6213
