### PR TITLE
Param bsearch

### DIFF
--- a/Tools/px_generate_params.py
+++ b/Tools/px_generate_params.py
@@ -45,12 +45,9 @@ struct px4_parameters_t {
 start_name = ""
 end_name = ""
 
+params = []
 for group in root:
 	if group.tag == "group" and "no_code_generation" not in group.attrib:
-		section = """
-	/*****************************************************************
-	 * %s
-	 ****************************************************************/""" % group.attrib["name"]
 		for param in group:
 			scope_ = param.find('scope').text
 			if not cmake_scope.Has(scope_):
@@ -58,10 +55,13 @@ for group in root:
 			if not start_name:
 				start_name = param.attrib["name"]
 			end_name = param.attrib["name"]
-			header += section
-			section =""
-			header += """
+			params.append(param)
+
+params = sorted(params, key=lambda name: name.attrib["name"])
+for param in params:
+	header += """
 	const struct param_info_s __param__%s;""" % param.attrib["name"]
+
 header += """
 	const unsigned int param_count;
 };
@@ -83,28 +83,14 @@ __attribute__((used, section("__param")))
 struct px4_parameters_t px4_parameters = {
 """
 i=0
-for group in root:
-	if group.tag == "group" and "no_code_generation" not in group.attrib:
-		section = """
-	/*****************************************************************
-	 * %s
-	 ****************************************************************/""" % group.attrib["name"]
-		for param in group:
-			scope_ = param.find('scope').text
-			if not cmake_scope.Has(scope_):
-				continue
-			if not start_name:
-				start_name = param.attrib["name"]
-			end_name = param.attrib["name"]
-			val_str = "#error UNKNOWN PARAM TYPE, FIX px_generate_params.py"
-			if (param.attrib["type"] == "FLOAT"):
-				val_str = ".val.f = "
-			elif (param.attrib["type"] == "INT32"):
-				val_str = ".val.i = "
-			i+=1
-			src += section
-			section =""
-			src += """
+for param in params:
+	val_str = "#error UNKNOWN PARAM TYPE, FIX px_generate_params.py"
+	if (param.attrib["type"] == "FLOAT"):
+		val_str = ".val.f = "
+	elif (param.attrib["type"] == "INT32"):
+		val_str = ".val.i = "
+	i+=1
+	src += """
 	{
 		"%s",
 		PARAM_TYPE_%s,

--- a/Tools/px_generate_params.py
+++ b/Tools/px_generate_params.py
@@ -42,9 +42,6 @@ __BEGIN_DECLS
 
 struct px4_parameters_t {
 """
-start_name = ""
-end_name = ""
-
 params = []
 for group in root:
 	if group.tag == "group" and "no_code_generation" not in group.attrib:
@@ -52,9 +49,6 @@ for group in root:
 			scope_ = param.find('scope').text
 			if not cmake_scope.Has(scope_):
 				continue
-			if not start_name:
-				start_name = param.attrib["name"]
-			end_name = param.attrib["name"]
 			params.append(param)
 
 params = sorted(params, key=lambda name: name.attrib["name"])

--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -1024,7 +1024,8 @@ function(px4_generate_parameters_xml)
 	add_custom_command(OUTPUT ${OUT}
 		COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/px_process_params.py
 			-s ${path} --board CONFIG_ARCH_${BOARD} --xml --inject-xml --scope ${SCOPE}
-		DEPENDS ${param_src_files}
+		DEPENDS ${param_src_files} ${PX4_SOURCE_DIR}/Tools/px_process_params.py
+			${PX4_SOURCE_DIR}/Tools/px_generate_params.py
 		)
 	set(${OUT} ${${OUT}} PARENT_SCOPE)
 endfunction()

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -263,25 +263,30 @@ param_find_internal(const char *name, bool notification)
 {
 	param_t middle;
 	param_t front = 0;
-	param_t last = get_param_info_count()-1;
+	param_t last = get_param_info_count() - 1;
 
 	/* perform a binary search of the known parameters */
 
 	while (front <= last) {
-		middle = front + (last-front) / 2;
+		middle = front + (last - front) / 2;
 		int ret = strcmp(name, param_info_base[middle].name);
+
 		if (ret == 0) {
 			if (notification) {
 				param_set_used_internal(middle);
 			}
+
 			return middle;
+
 		} else if (middle == front || middle == last) {
 			/* An end point has been hit, but there has been no match */
 			break;
+
 		} else if (ret < 0) {
 			last = middle - 1;
+
 		} else {
-			front = middle + 1;
+			front = middle;
 		}
 	}
 

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -227,19 +227,9 @@ param_find_changed(param_t param)
 	param_assert_locked();
 
 	if (param_values != NULL) {
-#if 0	/* utarray_find requires bsearch, not available */
 		struct param_wbuf_s key;
 		key.param = param;
 		s = utarray_find(param_values, &key, param_compare_values);
-#else
-
-		while ((s = (struct param_wbuf_s *)utarray_next(param_values, s)) != NULL) {
-			if (s->param == param) {
-				break;
-			}
-		}
-
-#endif
 	}
 
 	return s;
@@ -271,17 +261,27 @@ param_notify_changes(bool is_saved)
 param_t
 param_find_internal(const char *name, bool notification)
 {
-	param_t param;
+	param_t middle;
+	param_t front = 0;
+	param_t last = get_param_info_count()-1;
 
-	/* perform a linear search of the known parameters */
+	/* perform a binary search of the known parameters */
 
-	for (param = 0; handle_in_range(param); param++) {
-		if (!strcmp(param_info_base[param].name, name)) {
+	while (front <= last) {
+		middle = front + (last-front) / 2;
+		int ret = strcmp(name, param_info_base[middle].name);
+		if (ret == 0) {
 			if (notification) {
-				param_set_used_internal(param);
+				param_set_used_internal(middle);
 			}
-
-			return param;
+			return middle;
+		} else if (middle == front || middle == last) {
+			/* An end point has been hit, but there has been no match */
+			break;
+		} else if (ret < 0) {
+			last = middle - 1;
+		} else {
+			front = middle + 1;
 		}
 	}
 

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -283,7 +283,7 @@ param_find_internal(const char *name, bool notification)
 			break;
 
 		} else if (ret < 0) {
-			last = middle - 1;
+			last = middle;
 
 		} else {
 			front = middle;

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -263,7 +263,7 @@ param_find_internal(const char *name, bool notification)
 {
 	param_t middle;
 	param_t front = 0;
-	param_t last = get_param_info_count() - 1;
+	param_t last = get_param_info_count();
 
 	/* perform a binary search of the known parameters */
 
@@ -278,7 +278,7 @@ param_find_internal(const char *name, bool notification)
 
 			return middle;
 
-		} else if (middle == front || middle == last) {
+		} else if (middle == front) {
 			/* An end point has been hit, but there has been no match */
 			break;
 

--- a/src/systemcmds/param/param.c
+++ b/src/systemcmds/param/param.c
@@ -351,7 +351,7 @@ do_find(const char *name)
 		return 1;
 	}
 
-	printf("Found param %s at index %lu\n", name, ret);
+	printf("Found param %s at index %"PRIxPTR"\n", name, ret);
 	return 0;
 }
 

--- a/src/systemcmds/param/param.c
+++ b/src/systemcmds/param/param.c
@@ -49,6 +49,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <math.h>
+#include <inttypes.h>
 #include <sys/stat.h>
 
 #include <arch/board/board.h>

--- a/src/systemcmds/param/param.c
+++ b/src/systemcmds/param/param.c
@@ -216,6 +216,7 @@ param_main(int argc, char *argv[])
 		if (!strcmp(argv[1], "find")) {
 			if (argc >= 3) {
 				return do_find(argv[2]);
+
 			} else {
 				warnx("not enough arguments.\nTry 'param find PARAM_NAME'");
 				return 1;
@@ -341,13 +342,15 @@ do_show(const char *search_string)
 }
 
 static int
-do_find(const char* name)
+do_find(const char *name)
 {
 	param_t ret = param_find_no_notification(name);
+
 	if (ret == PARAM_INVALID) {
 		warnx("Parameter %s not found", name);
 		return 1;
 	}
+
 	printf("Found param %s at index %d\n", name, ret);
 	return 0;
 }

--- a/src/systemcmds/param/param.c
+++ b/src/systemcmds/param/param.c
@@ -78,6 +78,7 @@ static int	do_set(const char *name, const char *val, bool fail_on_not_found);
 static int	do_compare(const char *name, char *vals[], unsigned comparisons, enum COMPARE_OPERATOR cmd_op);
 static int 	do_reset(const char *excludes[], int num_excludes);
 static int	do_reset_nostart(const char *excludes[], int num_excludes);
+static int	do_find(const char *name);
 
 int
 param_main(int argc, char *argv[])
@@ -211,9 +212,18 @@ param_main(int argc, char *argv[])
 				return 1;
 			}
 		}
+
+		if (!strcmp(argv[1], "find")) {
+			if (argc >= 3) {
+				return do_find(argv[2]);
+			} else {
+				warnx("not enough arguments.\nTry 'param find PARAM_NAME'");
+				return 1;
+			}
+		}
 	}
 
-	warnx("expected a command, try 'load', 'import', 'show', 'set', 'compare',\n'index', 'index_used', 'greater', 'select', 'save', or 'reset' ");
+	warnx("expected a command, try 'load', 'import', 'show', 'set', 'compare',\n'index', 'index_used', 'find', 'greater', 'select', 'save', or 'reset' ");
 	return 1;
 }
 
@@ -327,6 +337,18 @@ do_show(const char *search_string)
 	param_foreach(do_show_print, (char *)search_string, false, false);
 	printf("\n %u parameters total, %u used.\n", param_count(), param_count_used());
 
+	return 0;
+}
+
+static int
+do_find(const char* name)
+{
+	param_t ret = param_find_no_notification(name);
+	if (ret == PARAM_INVALID) {
+		warnx("Parameter %s not found", name);
+		return 1;
+	}
+	printf("Found param %s at index %d\n", name, ret);
 	return 0;
 }
 

--- a/src/systemcmds/param/param.c
+++ b/src/systemcmds/param/param.c
@@ -351,7 +351,7 @@ do_find(const char *name)
 		return 1;
 	}
 
-	printf("Found param %s at index %"PRIxPTR"\n", name, ret);
+	printf("Found param %s at index %" PRIxPTR "\n", name, ret);
 	return 0;
 }
 

--- a/src/systemcmds/param/param.c
+++ b/src/systemcmds/param/param.c
@@ -351,7 +351,7 @@ do_find(const char *name)
 		return 1;
 	}
 
-	printf("Found param %s at index %d\n", name, ret);
+	printf("Found param %s at index %lu\n", name, ret);
 	return 0;
 }
 

--- a/unittests/param_test.cpp
+++ b/unittests/param_test.cpp
@@ -39,10 +39,10 @@ void _add_parameters()
 	};
 	rc2_x.val.i = 16;
 
-	param_array[0] = test_1;
-	param_array[1] = test_2;
-	param_array[2] = rc_x;
-	param_array[3] = rc2_x;
+	param_array[0] = rc_x;
+	param_array[1] = rc2_x;
+	param_array[2] = test_1;
+	param_array[3] = test_2;
 	param_info_base = (struct param_info_s *) &param_array[0];
 	// needs to point at the end of the data,
 	//  therefore number of params + 1
@@ -91,10 +91,10 @@ TEST(ParamTest, ResetAll)
 
 	param_reset_all();
 
-	_assert_parameter_int_value((param_t)0, 2);
-	_assert_parameter_int_value((param_t)1, 4);
-	_assert_parameter_int_value((param_t)2, 8);
-	_assert_parameter_int_value((param_t)3, 16);
+	_assert_parameter_int_value((param_t)0, 8);
+	_assert_parameter_int_value((param_t)1, 16);
+	_assert_parameter_int_value((param_t)2, 2);
+	_assert_parameter_int_value((param_t)3, 4);
 }
 
 TEST(ParamTest, ResetAllExcludesOne)
@@ -105,10 +105,10 @@ TEST(ParamTest, ResetAllExcludesOne)
 	const char *excludes[] = {"RC_X"};
 	param_reset_excludes(excludes, 1);
 
-	_assert_parameter_int_value((param_t)0, 2);
-	_assert_parameter_int_value((param_t)1, 4);
-	_assert_parameter_int_value((param_t)2, 50);
-	_assert_parameter_int_value((param_t)3, 16);
+	_assert_parameter_int_value((param_t)0, 50);
+	_assert_parameter_int_value((param_t)1, 16);
+	_assert_parameter_int_value((param_t)2, 2);
+	_assert_parameter_int_value((param_t)3, 4);
 }
 
 TEST(ParamTest, ResetAllExcludesTwo)
@@ -120,9 +120,9 @@ TEST(ParamTest, ResetAllExcludesTwo)
 	param_reset_excludes(excludes, 2);
 
 	_assert_parameter_int_value((param_t)0, 50);
-	_assert_parameter_int_value((param_t)1, 4);
+	_assert_parameter_int_value((param_t)1, 16);
 	_assert_parameter_int_value((param_t)2, 50);
-	_assert_parameter_int_value((param_t)3, 16);
+	_assert_parameter_int_value((param_t)3, 4);
 }
 
 TEST(ParamTest, ResetAllExcludesBoundaryCheck)
@@ -133,10 +133,10 @@ TEST(ParamTest, ResetAllExcludesBoundaryCheck)
 	const char *excludes[] = {"RC_X", "TEST_1"};
 	param_reset_excludes(excludes, 1);
 
-	_assert_parameter_int_value((param_t)0, 2);
-	_assert_parameter_int_value((param_t)1, 4);
-	_assert_parameter_int_value((param_t)2, 50);
-	_assert_parameter_int_value((param_t)3, 16);
+	_assert_parameter_int_value((param_t)0, 50);
+	_assert_parameter_int_value((param_t)1, 16);
+	_assert_parameter_int_value((param_t)2, 2);
+	_assert_parameter_int_value((param_t)3, 4);
 }
 
 TEST(ParamTest, ResetAllExcludesWildcard)
@@ -147,8 +147,8 @@ TEST(ParamTest, ResetAllExcludesWildcard)
 	const char *excludes[] = {"RC*"};
 	param_reset_excludes(excludes, 1);
 
-	_assert_parameter_int_value((param_t)0, 2);
-	_assert_parameter_int_value((param_t)1, 4);
-	_assert_parameter_int_value((param_t)2, 50);
-	_assert_parameter_int_value((param_t)3, 50);
+	_assert_parameter_int_value((param_t)0, 50);
+	_assert_parameter_int_value((param_t)1, 50);
+	_assert_parameter_int_value((param_t)2, 2);
+	_assert_parameter_int_value((param_t)3, 4);
 }


### PR DESCRIPTION
* When parsing the parameter XML file, the parameters are sorted by name when written to the generated parameter files
* Do a binary search of parameters when looking up by string
* Use the utarray_find function for changed parameters now the bsearch is implemented in NuttX
* Add a system command for param find

The drawback of this PR is that saved parameter values will be lost because the handles are no longer the same.

See (#6096)