### PR TITLE
remove px4_model targets from all

### DIFF
--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -56,8 +56,8 @@ include(CMakeParseArguments)
 #
 #	px4_parse_function_args
 #
-#	This function simpliies usage of the cmake_parse_arguments module.
-#	It is inteded to be called by other functions.
+#	This function simplifies usage of the cmake_parse_arguments module.
+#	It is intended to be called by other functions.
 #
 #	Usage:
 #		px4_parse_function_args(
@@ -148,7 +148,7 @@ function(px4_add_git_submodule)
 		)
 	add_custom_target(${TARGET}
 		WORKING_DIRECTORY ${PX4_SOURCE_DIR}
-# todo:Not have 2 list of submodues one (see the end of Tools/check_submodules.sh and Firmware/CMakeLists.txt)
+# todo:Not have 2 list of submodules one (see the end of Tools/check_submodules.sh and Firmware/CMakeLists.txt)
 # using the list of submodules from the CMake file to drive the test
 #		COMMAND Tools/check_submodules.sh ${PATH}
 		DEPENDS ${PX4_BINARY_DIR}/git_init_${NAME}.stamp
@@ -165,7 +165,7 @@ endfunction()
 #		px4_prepend_string(OUT <output-list> STR <string> LIST <list>)
 #
 #	Input:
-#		STR			: string to prepend
+#		STR		: string to prepend
 #		LIST		: list to prepend to
 #
 #	Output:

--- a/src/firmware/posix/CMakeLists.txt
+++ b/src/firmware/posix/CMakeLists.txt
@@ -104,6 +104,7 @@ elseif ("${BOARD}" STREQUAL "bebop")
 elseif ("${BOARD}" STREQUAL "sitl")
 
 	include(./sitl_target.cmake)
+	include(./sitl_tests.cmake)
 
 else()
 
@@ -136,81 +137,5 @@ endif()
 install(TARGETS px4 DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/ROMFS DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/posix-configs DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
-
-#=============================================================================
-# tests
-#
-
-# TODO: find a way to keep this in sync with tests_main
-set(tests
-	autodeclination
-	bson
-	commander
-	controllib
-	conv
-	file2
-	float
-	gpio
-	hrt
-	hysteresis
-	int
-	mathlib
-	matrix
-	mavlink
-	mc_pos_control
-	mixer
-	param
-	perf
-	rc
-	servo
-	sf0x
-	sleep
-	uorb
-	)
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-	list(REMOVE_ITEM tests
-		hysteresis
-		mixer
-		uorb
-	)
-endif()
-
-foreach(test_name ${tests})
-	configure_file(${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/test_template.in ${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/${test_name}_generated)
-
-	add_test(NAME ${test_name}
-		COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
-			$<TARGET_FILE:px4>
-			posix-configs/SITL/init/test
-			none
-			none
-			${test_name}_generated
-			${PX4_SOURCE_DIR}
-			${PX4_BINARY_DIR}
-			WORKING_DIRECTORY ${SITL_WORKING_DIR})
-
-	set_tests_properties(${test_name} PROPERTIES PASS_REGULAR_EXPRESSION "${test_name} PASSED")
-endforeach()
-
-add_custom_target(test_results
-		COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -T Test
-		DEPENDS px4
-		USES_TERMINAL
-		COMMENT "Running tests in sitl"
-		WORKING_DIRECTORY ${PX4_BINARY_DIR})
-set_target_properties(test_results PROPERTIES EXCLUDE_FROM_ALL TRUE)
-
-add_custom_target(test_results_junit
-		COMMAND xsltproc ${PX4_SOURCE_DIR}/Tools/CTest2JUnit.xsl Testing/`head -n 1 < Testing/TAG`/Test.xml > JUnitTestResults.xml
-		COMMENT "Converting ctest output to junit xml"
-		WORKING_DIRECTORY ${PX4_BINARY_DIR})
-set_target_properties(test_results_junit PROPERTIES EXCLUDE_FROM_ALL TRUE)
-
-add_custom_target(test_cdash_submit
-		COMMAND ${CMAKE_CTEST_COMMAND} -D Experimental
-		USES_TERMINAL
-		WORKING_DIRECTORY ${PX4_BINARY_DIR})
-set_target_properties(test_cdash_submit PROPERTIES EXCLUDE_FROM_ALL TRUE)
 
 # vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/firmware/posix/sitl_target.cmake
+++ b/src/firmware/posix/sitl_target.cmake
@@ -4,12 +4,13 @@ px4_parse_function_args(
 			NAME px4_add_sitl_app
 			ONE_VALUE APP_NAME MAIN_SRC UPLOAD_NAME
 			REQUIRED APP_NAME MAIN_SRC
-			ARGN ${ARGN})
+			ARGN ${ARGN}
+			)
 
 	px4_add_executable(${APP_NAME}
-		${MAIN_SRC}
-		apps.cpp
-		)
+			${MAIN_SRC}
+			apps.cpp
+			)
 
 	if (NOT APPLE)
 		target_link_libraries(${APP_NAME}
@@ -33,27 +34,27 @@ endfunction()
 # sitl run targets
 #
 
-SET(SITL_RUNNER_MAIN_CPP ${PX4_SOURCE_DIR}/src/platforms/posix/main.cpp)
+set(SITL_RUNNER_MAIN_CPP ${PX4_SOURCE_DIR}/src/platforms/posix/main.cpp)
 px4_add_sitl_app(APP_NAME px4
-								UPLOAD_NAME upload
-								MAIN_SRC ${SITL_RUNNER_MAIN_CPP}
-								)
+		UPLOAD_NAME upload
+		MAIN_SRC ${SITL_RUNNER_MAIN_CPP}
+		)
 
 set(SITL_WORKING_DIR ${PX4_BINARY_DIR}/tmp)
 file(MAKE_DIRECTORY ${SITL_WORKING_DIR})
 
 add_custom_target(run_config
-	COMMAND Tools/sitl_run.sh
-	$<TARGET_FILE:px4>
-	${config_sitl_rcS_dir}
-	${config_sitl_debugger}
-	${config_sitl_viewer}
-	${config_sitl_model}
-	${PX4_SOURCE_DIR}
-	${PX4_BINARY_DIR}
-	WORKING_DIRECTORY ${SITL_WORKING_DIR}
-	USES_TERMINAL
-	)
+		COMMAND Tools/sitl_run.sh
+			$<TARGET_FILE:px4>
+			${config_sitl_rcS_dir}
+			${config_sitl_debugger}
+			${config_sitl_viewer}
+			${config_sitl_model}
+			${PX4_SOURCE_DIR}
+			${PX4_BINARY_DIR}
+			WORKING_DIRECTORY ${SITL_WORKING_DIR}
+			USES_TERMINAL
+		)
 add_dependencies(run_config px4)
 
 # project to build sitl_gazebo if necessary
@@ -68,7 +69,7 @@ set_target_properties(sitl_gazebo PROPERTIES EXCLUDE_FROM_ALL TRUE)
 # create targets for each viewer/model/debugger combination
 set(viewers none jmavsim gazebo replay)
 set(debuggers none ide gdb lldb ddd valgrind)
-set(models none iris iris_opt_flow tailsitter standard_vtol plane solo typhoon_h480)
+set(models none iris iris_opt_flow standard_vtol plane solo tailsitter typhoon_h480)
 set(all_posix_vmd_make_targets)
 foreach(viewer ${viewers})
 	foreach(debugger ${debuggers})
@@ -88,34 +89,37 @@ foreach(viewer ${viewers})
 			endif()
 
 			if (debugger STREQUAL "ide" AND viewer STREQUAL "gazebo")
-				SET(SITL_RUNNER_SOURCE_DIR ${PX4_SOURCE_DIR})
-				SET(SITL_RUNNER_MODEL_FILE ${PX4_SOURCE_DIR}/${config_sitl_rcS_dir}/${model})
-				SET(SITL_RUNNER_WORKING_DIRECTORY ${SITL_WORKING_DIR})
+				set(SITL_RUNNER_SOURCE_DIR ${PX4_SOURCE_DIR})
+				set(SITL_RUNNER_MODEL_FILE ${PX4_SOURCE_DIR}/${config_sitl_rcS_dir}/${model})
+				set(SITL_RUNNER_WORKING_DIRECTORY ${SITL_WORKING_DIR})
 
-				CONFIGURE_FILE(${PX4_SOURCE_DIR}/src/platforms/posix/sitl_runner_main.cpp.in sitl_runner_main_${model}.cpp @ONLY)
+				configure_file(${PX4_SOURCE_DIR}/src/platforms/posix/sitl_runner_main.cpp.in sitl_runner_main_${model}.cpp @ONLY)
 
 				px4_add_sitl_app(APP_NAME px4_${model}
-												UPLOAD_NAME upload_${model}
-												MAIN_SRC ${CMAKE_CURRENT_BINARY_DIR}/sitl_runner_main_${model}.cpp
-												)
-
+						UPLOAD_NAME upload_${model}
+						MAIN_SRC ${CMAKE_CURRENT_BINARY_DIR}/sitl_runner_main_${model}.cpp
+						)
+				set_target_properties(px4_${model} PROPERTIES EXCLUDE_FROM_ALL TRUE)
 			endif()
 
 			add_custom_target(${_targ_name}
-				COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
-				$<TARGET_FILE:px4>
-				${config_sitl_rcS_dir}
-				${debugger}
-				${viewer}
-				${model}
-				${PX4_SOURCE_DIR}
-				${PX4_BINARY_DIR}
-				WORKING_DIRECTORY ${SITL_WORKING_DIR}
-				USES_TERMINAL
-				)
+					COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
+						$<TARGET_FILE:px4>
+						${config_sitl_rcS_dir}
+						${debugger}
+						${viewer}
+						${model}
+						${PX4_SOURCE_DIR}
+						${PX4_BINARY_DIR}
+						WORKING_DIRECTORY ${SITL_WORKING_DIR}
+						USES_TERMINAL
+					)
 			list(APPEND all_posix_vmd_make_targets ${_targ_name})
 			if (viewer STREQUAL "gazebo")
 				add_dependencies(${_targ_name} sitl_gazebo)
+				if (viewer STREQUAL "gazebo")
+					add_dependencies(${_targ_name} px4_${model})
+				endif()
 			endif()
 		endforeach()
 	endforeach()

--- a/src/firmware/posix/sitl_tests.cmake
+++ b/src/firmware/posix/sitl_tests.cmake
@@ -1,0 +1,75 @@
+#=============================================================================
+# tests
+#
+
+# TODO: find a way to keep this in sync with tests_main
+set(tests
+	autodeclination
+	bson
+	commander
+	controllib
+	conv
+	file2
+	float
+	gpio
+	hrt
+	hysteresis
+	int
+	mathlib
+	matrix
+	mavlink
+	mc_pos_control
+	mixer
+	param
+	perf
+	rc
+	servo
+	sf0x
+	sleep
+	uorb
+	)
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+	list(REMOVE_ITEM tests
+		hysteresis
+		mixer
+		uorb
+	)
+endif()
+
+foreach(test_name ${tests})
+	configure_file(${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/test_template.in ${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/${test_name}_generated)
+
+	add_test(NAME ${test_name}
+		COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
+			$<TARGET_FILE:px4>
+			posix-configs/SITL/init/test
+			none
+			none
+			${test_name}_generated
+			${PX4_SOURCE_DIR}
+			${PX4_BINARY_DIR}
+			WORKING_DIRECTORY ${SITL_WORKING_DIR})
+
+	set_tests_properties(${test_name} PROPERTIES PASS_REGULAR_EXPRESSION "${test_name} PASSED")
+endforeach()
+
+add_custom_target(test_results
+		COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -T Test
+		DEPENDS px4
+		USES_TERMINAL
+		COMMENT "Running tests in sitl"
+		WORKING_DIRECTORY ${PX4_BINARY_DIR})
+set_target_properties(test_results PROPERTIES EXCLUDE_FROM_ALL TRUE)
+
+add_custom_target(test_results_junit
+		COMMAND xsltproc ${PX4_SOURCE_DIR}/Tools/CTest2JUnit.xsl Testing/`head -n 1 < Testing/TAG`/Test.xml > JUnitTestResults.xml
+		COMMENT "Converting ctest output to junit xml"
+		WORKING_DIRECTORY ${PX4_BINARY_DIR})
+set_target_properties(test_results_junit PROPERTIES EXCLUDE_FROM_ALL TRUE)
+
+add_custom_target(test_cdash_submit
+		COMMAND ${CMAKE_CTEST_COMMAND} -D Experimental
+		USES_TERMINAL
+		WORKING_DIRECTORY ${PX4_BINARY_DIR})
+set_target_properties(test_cdash_submit PROPERTIES EXCLUDE_FROM_ALL TRUE)


### PR DESCRIPTION
The main purpose of this PR is to limit the additional identical px4 binaries that are currently being built for each model as part of the debugger = ide sitl targets (px4 px4_none px4_iris px4_iris_opt_flow px4_standard_vtol plane px4_solo px4_tailsitter px4_typhoon_h480)  - https://github.com/PX4/Firmware/compare/master...dagar:cmake_sitl?expand=1#diff-28c446586b4565ce2f15cfa3c713c705R102

Now only the dependant binary will be built as part of the appropriate target. eg gazebo_standard_vtol_ide


There's also some cleanup moving sitl tests to a separate cmake file and whitespace cleanup in sitl_target.cmake.