### PR TITLE
px_process_params.py: fix for empty cmake scope

### DIFF
--- a/Tools/px_process_params.py
+++ b/Tools/px_process_params.py
@@ -142,15 +142,18 @@ def main():
             except:
                 use_scope = False
                 pass
-    if use_scope:
+    if use_scope and len(cmake_scope.scope) > 0:
         if not scanner.ScanDir([os.path.join(args.src_path, p) for p in cmake_scope.scope], parser):
             sys.exit(1)
-    else:    
+    else:
         if not scanner.ScanDir([args.src_path], parser):
             sys.exit(1)
     if not parser.Validate():
         sys.exit(1)
     param_groups = parser.GetParamGroups()
+
+    if len(param_groups) == 0:
+        print("Warning: no parameters found")
 
     # Output to XML file
     if args.xml:


### PR DESCRIPTION
Hotfix for cmake configs which use include() for the module list (eg.
posix_sitl_ekf2.cmake or snapdragon). In that case the cmake parser did
not find any modules and thus the param list was empty.

Introduced with 6fe9b8e54351c8fe620f959b62ce1

The proper fix will be to parse the include() statements correctly.