### PR TITLE
Clang tidy config

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,46 @@
+# clang-tidy checks http://clang.llvm.org/extra/clang-tidy/checks/list.html
+
+Checks:          '-*,
+                  cert-flp30-c,
+                  clang-analyzer-cplusplus,
+                  clang-analyzer-unix*,
+                  google-readability-casting,
+                  google-readability-todo,
+                  misc-redundant-expression,
+                  misc-sizeof-container,
+                  misc-sizeof-expression,
+                  misc-string-compare,
+                  misc-suspicious-semicolon,
+                  misc-suspicious-string-compare,
+                  misc-swapped-arguments,
+                  misc-undelegated-constructor,
+                  misc-unused-alias-decls,
+                  misc-unused-parameters,
+                  misc-unused-raii,
+                  misc-unused-using-decls,
+                  misc-virtual-near-miss,
+                  performance-*,
+                  readability-braces-around-statements,
+                  readability-container-size-empty,
+                  readability-else-after-return,
+                  readability-function-size,
+                  readability-identifier-naming,
+                  readability-inconsistent-declaration-parameter-name,
+                  readability-named-parameter,
+                  readability-redundant-smartptr-get,
+                  readability-redundant-string-cstr,
+                  readability-simplify-boolean-expr,
+                  readability-uniqueptr-delete-release,
+                  '
+AnalyzeTemporaryDtors: false
+CheckOptions:
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+
+#WarningsAsErrors:

--- a/Tools/clang-tool.sh
+++ b/Tools/clang-tool.sh
@@ -41,6 +41,7 @@ case "${tool}" in
     ;;
   "clang-tidy")
     command=clang-tidy
+    option=-header-filter=.*
     ;;
 esac
 
@@ -49,6 +50,7 @@ awk '{ print $2; }' |
 sed 's/\"//g' |
 while read FILE; do
     (cd $(dirname ${FILE});
-    ${command} ${option} -p ${COMPILE_DB} ${extra_args} $(basename ${FILE})
-    );
+    echo ${FILE}
+    ${command} ${option} -p ${COMPILE_DB} ${extra_args} $(basename ${FILE}));
+    echo
   done


### PR DESCRIPTION
This adds a clang-tidy config file .clang-tidy which lists checks to use and ignore. You can run the checks with `make clang-tidy` which builds posix_sitl_default under clang and then runs clang-tidy.

@LorenzMeier I'm not sure yet if this will be useful, but if we find valuable checks we can turn them on as errors and set this to run in the builds.
Full list of checks here - http://clang.llvm.org/extra/clang-tidy/checks/list.html