### PR TITLE
Optical flow preparation for Parrot Bebop 2

### DIFF
--- a/cmake/configs/posix_bebop_default.cmake
+++ b/cmake/configs/posix_bebop_default.cmake
@@ -106,4 +106,5 @@ set(config_df_driver_list
 	mpu6050
 	ak8963
 	bebop_bus
+	mt9v117
 )

--- a/cmake/configs/posix_bebop_default.cmake
+++ b/cmake/configs/posix_bebop_default.cmake
@@ -26,6 +26,7 @@ set(config_module_list
 	platforms/posix/drivers/df_mpu6050_wrapper
 	platforms/posix/drivers/df_ak8963_wrapper
 	platforms/posix/drivers/df_bebop_bus_wrapper
+	platforms/posix/drivers/bebop_flow
 
 	#
 	# System commands

--- a/posix-configs/bebop/px4.config
+++ b/posix-configs/bebop/px4.config
@@ -31,6 +31,7 @@ df_ms5607_wrapper start
 df_mpu6050_wrapper start -R 8
 df_ak8963_wrapper start -R 32
 gps start -d /dev/ttyPA1
+bebop_flow start
 sensors start
 commander start
 ekf2 start

--- a/src/platforms/posix/drivers/bebop_flow/CMakeLists.txt
+++ b/src/platforms/posix/drivers/bebop_flow/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2017 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,8 +39,10 @@ px4_add_module(
 	SRCS
 		bebop_flow.cpp
 		video_device.cpp
+		dump_pgm.cpp
 	DEPENDS
 		platforms__common
 		df_driver_framework
+		df_mt9v117
 	)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/posix/drivers/bebop_flow/CMakeLists.txt
+++ b/src/platforms/posix/drivers/bebop_flow/CMakeLists.txt
@@ -1,0 +1,46 @@
+############################################################################
+#
+#   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+include_directories(../../../../lib/DriverFramework/drivers)
+
+px4_add_module(
+	MODULE platforms__posix__drivers__bebop_flow
+	MAIN bebop_flow
+	SRCS
+		bebop_flow.cpp
+		video_device.cpp
+	DEPENDS
+		platforms__common
+		df_driver_framework
+	)
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/posix/drivers/bebop_flow/bebop_flow.cpp
+++ b/src/platforms/posix/drivers/bebop_flow/bebop_flow.cpp
@@ -1,0 +1,208 @@
+
+/****************************************************************************
+ *
+ *   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+
+/**
+ * @file bebop_flow.cpp
+ *
+ * This is a wrapper around the Parrot Bebop's downward-facing camera and integrates
+ * an optical flow computation.
+ */
+
+#include <stdint.h>
+
+#include <px4_tasks.h>
+#include <px4_getopt.h>
+#include <px4_posix.h>
+
+#include "video_device.h"
+
+extern "C" { __EXPORT int bebop_flow_main(int argc, char *argv[]); }
+
+namespace bebop_flow
+{
+VideoDevice *g_dev = nullptr;            // interface to the video device
+volatile bool _task_should_exit = false; // flag indicating if bebop flow task should exit
+static bool _is_running = false;         // flag indicating if bebop flow  app is running
+static px4_task_t _task_handle = -1;     // handle to the task main thread
+
+static char *dev_name = "/dev/video0";
+
+int start();
+int stop();
+int info();
+int clear_errors();
+void usage();
+void task_main(int argc, char *argv[]);
+
+
+void task_main(int argc, char *argv[])
+{
+	_is_running = true;
+
+	// Main loop
+	while (!_task_should_exit) {
+
+	}
+
+	_is_running = false;
+
+}
+
+int start()
+{
+	g_dev = new VideoDevice();
+
+	if (g_dev == nullptr) {
+		PX4_ERR("failed instantiating video device object");
+		return -1;
+	}
+
+	int ret = g_dev->start();
+
+	if (ret != 0) {
+		PX4_ERR("Video device start failed");
+		return ret;
+	}
+
+	/* start the task */
+	_task_handle = px4_task_spawn_cmd("bebop_flow",
+					  SCHED_DEFAULT,
+					  SCHED_PRIORITY_DEFAULT,
+					  2000,
+					  (px4_main_t)&task_main,
+					  nullptr);
+
+	if (_task_handle < 0) {
+		warn("task start failed");
+		return -1;
+	}
+
+	return 0;
+}
+
+int stop()
+{
+	// Stop bebop flow task
+	_task_should_exit = true;
+
+	while (_is_running) {
+		usleep(200000);
+		PX4_INFO(".");
+	}
+
+	_task_handle = -1;
+
+	if (g_dev == nullptr) {
+		PX4_ERR("driver not running");
+		return 1;
+	}
+
+	// Stop DF device
+	int ret = g_dev->stop();
+
+	if (ret != 0) {
+		PX4_ERR("driver could not be stopped");
+		return ret;
+	}
+
+	delete g_dev;
+	g_dev = nullptr;
+	return 0;
+}
+
+/**
+ * Print a little info about the driver.
+ */
+int
+info()
+{
+	if (g_dev == nullptr) {
+		PX4_ERR("driver not running");
+		return 1;
+	}
+
+	PX4_DEBUG("state @ %p", g_dev);
+
+	int ret = g_dev->print_info();
+
+	if (ret != 0) {
+		PX4_ERR("Unable to print info");
+		return ret;
+	}
+
+	return 0;
+}
+
+void
+usage()
+{
+	PX4_INFO("Usage: bebop_flow 'start', 'info', 'stop'");
+}
+
+} /* bebop flow namespace*/
+
+int
+bebop_flow_main(int argc, char *argv[])
+{
+	int ret = 0;
+	int myoptind = 1;
+
+	if (argc <= 1) {
+		bebop_flow::usage();
+		return 1;
+	}
+
+	const char *verb = argv[myoptind];
+
+
+	if (!strcmp(verb, "start")) {
+		ret = bebop_flow::start();
+	}
+
+	else if (!strcmp(verb, "stop")) {
+		ret = bebop_flow::stop();
+	}
+
+	else if (!strcmp(verb, "info")) {
+		ret = bebop_flow::info();
+	}
+
+	else {
+		bebop_flow::usage();
+		return 1;
+	}
+
+	return ret;
+}

--- a/src/platforms/posix/drivers/bebop_flow/dump_pgm.h
+++ b/src/platforms/posix/drivers/bebop_flow/dump_pgm.h
@@ -31,63 +31,16 @@
  *
  ****************************************************************************/
 
+
+/**
+ * @file dump_pgm.h
+ *
+ * This is a simple implementation to write an image into a pgm file.
+ *
+ */
+
 #pragma once
 
 #include <stdint.h>
-#include <unistd.h>
 
-#define VIDEO_DEVICE_IMAGE_WIDTH 320
-#define VIDEO_DEVICE_IMAGE_HEIGHT 240
-
-struct frame_data {
-	uint32_t timestamp;
-	uint32_t seq;
-	uint32_t bytes;
-	uint32_t index;
-	void *data;
-};
-
-struct buffer {
-	void *start;
-	size_t length;
-};
-
-class VideoDevice
-{
-public:
-	VideoDevice(char const *dev_name, uint32_t n_buffers) :
-		_fd(-1), _dev_name(dev_name), _n_buffers(n_buffers), _buffers(nullptr) {};
-
-	~VideoDevice() = default;
-
-	/// Start the device
-	int start();
-
-	/// Stop the device
-	int stop();
-
-	/// Print various infos
-	int print_info();
-
-	/// Non-blocking call to fetch an image. Returns 0 if the images was read, -1 on error
-	/// and 1 no new image is ready.
-	int get_frame(struct frame_data &frame);
-
-	/// Return a frame when the data is not needed any more.
-	int put_frame(struct frame_data &frame);
-
-private:
-	int _fd;
-	const char *_dev_name;
-	uint32_t _n_buffers;
-	struct buffer *_buffers;
-
-	int open_device();
-	int close_device();
-	int init_device();
-	int init_buffers();
-	int init_crop();
-	int init_format();
-	int start_capturing();
-	int stop_capturing();
-};
+void dump_pgm(const void *data, uint32_t size, uint32_t seq, uint32_t timestamp);

--- a/src/platforms/posix/drivers/bebop_flow/video_device.cpp
+++ b/src/platforms/posix/drivers/bebop_flow/video_device.cpp
@@ -1,26 +1,401 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file video_device.cpp
+ *
+ * Wrapper for a V4L2 device using the memory mapped interface.
+ *
+ */
+
 #include "video_device.h"
+
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <errno.h>
+#include <string.h>
+
+#include <linux/videodev2.h>
+
+#include <px4_posix.h>
 
 int VideoDevice::start()
 {
-	return -1;
+	int ret = open_device();
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	ret = init_device();
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	return start_capturing();
 }
 
 int VideoDevice::stop()
 {
-	return -1;
+
+	int result = stop_capturing();
+
+	if (result < 0) {
+		PX4_ERR("Error stop stream");
+	}
+
+	// Unmap buffers
+	for (unsigned int i = 0; i < _n_buffers; ++i) {
+		result = munmap(_buffers[i].start, _buffers[i].length);
+
+		if (result < 0) {
+			PX4_ERR("Error: Unmapping buffer");
+		}
+	}
+
+	free(_buffers);
+
+	result = close_device();
+
+	if (result < 0) {
+		return result;
+	}
+
+	return OK;
 }
 
 int VideoDevice::print_info()
 {
-	return -1;
+	PX4_INFO("Device: %s", _dev_name);
+	return 0;
 }
 
 int VideoDevice::open_device()
 {
-	return -1;
+	struct stat st;
+
+	// Check if device is usable
+	int ret = stat(_dev_name, &st);
+
+	if (ret < 0) {
+		PX4_ERR("Cannot identify %s: %d", _dev_name, errno);
+		return -EIO;
+	}
+
+	if (!S_ISCHR(st.st_mode)) {
+		PX4_ERR("%s is no device", _dev_name);
+		return -EIO;
+	}
+
+	// Open V4L2 device nonblocking
+	_fd = open(_dev_name, O_RDWR | O_NONBLOCK);
+
+	if (_fd < 0) {
+		PX4_ERR("Unable to open %s", _dev_name);
+		return -EIO;
+	}
+
+	return OK;
 }
 
 int VideoDevice::close_device()
 {
-	return -1;
+	int ret = close(_fd);
+
+	if (ret < 0) {
+		PX4_ERR("Error closing %s", _dev_name);
+		return -EIO;
+	}
+
+	return OK;
+}
+
+int VideoDevice::init_device()
+{
+	struct v4l2_capability cap;
+	memset(&cap, 0, sizeof(cap));
+
+	int ret = ioctl(_fd, VIDIOC_QUERYCAP, &cap);
+
+	if (ret < 0) {
+		if (EINVAL == errno) {
+			PX4_ERR("No V4L2 device: %s", _dev_name);
+			return -EINVAL;
+
+		} else {
+			PX4_ERR("VIDIOC_QUERYCAP failed: %s", _dev_name);
+			return -1;
+		}
+	}
+
+	if (!(cap.capabilities & V4L2_CAP_VIDEO_CAPTURE)) {
+		PX4_ERR("Device is no video capture device: %s", _dev_name);
+		return -EIO;
+	}
+
+	ret = init_crop();
+
+	if (ret < 0) {
+		PX4_ERR("Error when setting image crop");
+		return -1;
+	}
+
+	return init_buffers();
+}
+
+int VideoDevice::init_crop()
+{
+	struct v4l2_cropcap cropcap;
+	struct v4l2_crop crop;
+
+	memset(&cropcap, 0, sizeof(cropcap));
+	memset(&crop, 0, sizeof(crop));
+
+	cropcap.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	int ret = ioctl(_fd, VIDIOC_CROPCAP, &cropcap);
+
+	if (ret < 0) {
+		PX4_WARN("CROPCAP failed");
+	}
+
+	crop.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	crop.c = cropcap.defrect; // reset to default
+	ret = ioctl(_fd, VIDIOC_S_CROP, &crop);
+
+	if (ret < 0) {
+		PX4_WARN("S_CROP failed");
+	}
+
+	return init_format();
+}
+
+int VideoDevice::init_format()
+{
+	usleep(10000);
+	struct v4l2_format fmt;
+
+	memset(&fmt, 0, sizeof(fmt));
+
+	fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	fmt.fmt.pix.width = VIDEO_DEVICE_IMAGE_WIDTH;
+	fmt.fmt.pix.height = VIDEO_DEVICE_IMAGE_HEIGHT;
+	fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_NV12;
+	fmt.fmt.pix.colorspace = V4L2_COLORSPACE_REC709;
+
+	int ret = ioctl(_fd, VIDIOC_S_FMT, &fmt);
+
+	if (ret < 0) {
+		PX4_ERR("Unable to set format");
+		return -1;
+	}
+
+	const char *format_string;
+
+	switch (fmt.fmt.pix.pixelformat) {
+	case V4L2_PIX_FMT_YUYV:
+		format_string = "YUYV";
+		break;
+
+	case V4L2_PIX_FMT_YVYU:
+		format_string = "YVYU";
+		break;
+
+	case V4L2_PIX_FMT_NV12:
+		format_string = "NV12";
+		break;
+
+	default:
+		format_string = "None";
+	}
+
+	PX4_INFO("Set image format: %ux%u\n    Format: %s\n    Size: %u",
+		 fmt.fmt.pix.width,
+		 fmt.fmt.pix.height,
+		 format_string,
+		 fmt.fmt.pix.sizeimage);
+
+	return OK;
+}
+
+int VideoDevice::init_buffers()
+{
+	struct v4l2_requestbuffers req;
+
+	memset(&req, 0, sizeof(req));
+
+	req.count = _n_buffers;
+	req.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	req.memory = V4L2_MEMORY_MMAP;
+
+	int ret = ioctl(_fd, VIDIOC_REQBUFS, &req);
+
+	if (ret < 0) {
+		PX4_ERR("Unable to request buffers: %s", _dev_name);
+		return -1;
+	}
+
+	_buffers = (struct buffer *) malloc(_n_buffers * sizeof(_buffers[0]));
+
+	if (_buffers == nullptr) {
+		PX4_ERR("Unable to allocate buffers");
+		return -1;
+	}
+
+	for (unsigned int i = 0; i < _n_buffers; ++i) {
+		struct v4l2_buffer buf;
+		memset(&buf, 0, sizeof(buf));
+
+		buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+		buf.memory = V4L2_MEMORY_MMAP;
+		buf.index = i;
+
+		ret = ioctl(_fd, VIDIOC_QUERYBUF, &buf);
+
+		if (ret < 0) {
+			PX4_ERR("Error QUERYBUF");
+			return -1;
+		}
+
+		_buffers[i].length = buf.length;
+		_buffers[i].start = mmap(nullptr, buf.length, PROT_READ | PROT_WRITE,
+					 MAP_SHARED, _fd, buf.m.offset);
+
+		if (_buffers[i].start == MAP_FAILED) {
+			PX4_ERR("Out of memory");
+			return -1;
+		}
+	}
+
+	return OK;
+}
+
+int VideoDevice::start_capturing()
+{
+	for (unsigned int i = 0; i < _n_buffers; ++i) {
+		struct v4l2_buffer buf;
+
+		memset(&buf, 0, sizeof(buf));
+
+		buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+		buf.memory = V4L2_MEMORY_MMAP;
+		buf.index = i;
+
+		int ret = ioctl(_fd, VIDIOC_QBUF, &buf);
+
+		if (ret < 0) {
+			PX4_ERR("Unable to queue buffer: %d", i);
+			return -1;
+		}
+	}
+
+	enum v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	int ret = ioctl(_fd, VIDIOC_STREAMON, &type);
+
+	if (ret < 0) {
+		PX4_ERR("Unable to start streaming");
+		return -1;
+	}
+
+	PX4_INFO("Streaming started: %s", _dev_name);
+	return OK;
+}
+
+int VideoDevice::stop_capturing()
+{
+	enum v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	int ret = ioctl(_fd, VIDIOC_STREAMOFF, &type);
+
+	if (ret < 0) {
+		PX4_ERR("Unable to stop streaming");
+		return -1;
+	}
+
+	PX4_INFO("Streaming stopped: %s", _dev_name);
+	return OK;
+}
+
+int VideoDevice::get_frame(struct frame_data &frame)
+{
+	struct v4l2_buffer buf;
+	memset(&buf, 0, sizeof(buf));
+
+	buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	buf.memory = V4L2_MEMORY_MMAP;
+
+	int ret = ioctl(_fd, VIDIOC_DQBUF, &buf);
+
+	if (ret < 0) {
+		if (errno == EAGAIN) {
+			//PX4_INFO("No frame ready");
+			return 1;
+
+		} else if (errno == EIO) {
+			PX4_INFO("EIO");
+			return 1;
+
+		} else {
+			PX4_ERR("Buffer deque error");
+			return -1;
+		}
+	}
+
+	frame.data = _buffers[buf.index].start;
+	frame.seq = buf.sequence;
+	frame.timestamp = buf.timestamp.tv_sec * 1000000 + buf.timestamp.tv_usec;
+	frame.bytes = buf.bytesused;
+	frame.index = buf.index;
+
+	return 0;
+}
+
+int VideoDevice::put_frame(struct frame_data &frame)
+{
+	struct v4l2_buffer buf;
+	memset(&buf, 0, sizeof(buf));
+
+	buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+	buf.memory = V4L2_MEMORY_MMAP;
+	buf.index = frame.index;
+	buf.length = _buffers[frame.index].length;
+
+	int ret = ioctl(_fd, VIDIOC_QBUF, &buf);
+
+	if (ret < 0) {
+		PX4_ERR("Buffer deque error");
+		return -1;
+	}
+
+	return OK;
 }

--- a/src/platforms/posix/drivers/bebop_flow/video_device.cpp
+++ b/src/platforms/posix/drivers/bebop_flow/video_device.cpp
@@ -1,0 +1,26 @@
+#include "video_device.h"
+
+int VideoDevice::start()
+{
+	return -1;
+}
+
+int VideoDevice::stop()
+{
+	return -1;
+}
+
+int VideoDevice::print_info()
+{
+	return -1;
+}
+
+int VideoDevice::open_device()
+{
+	return -1;
+}
+
+int VideoDevice::close_device()
+{
+	return -1;
+}

--- a/src/platforms/posix/drivers/bebop_flow/video_device.h
+++ b/src/platforms/posix/drivers/bebop_flow/video_device.h
@@ -1,0 +1,58 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+class VideoDevice
+{
+public:
+	VideoDevice(const char *dev_name) :
+		_dev_name(dev_name) {};
+
+	~VideoDevice() = default;
+
+	/// Start the device
+	int start();
+
+	/// Stop the device
+	int stop();
+
+	/// Print various infos
+	int print_info();
+
+private:
+	char *_dev_name;
+
+	int open_device();
+	int close_device();
+};


### PR DESCRIPTION
This PR adds the camera interface for an optical flow computation on Parrot Bebop 2. The module wraps the MT9V117 image sensor (see PX4/DriverFramework#175) and adds a V4L2 interface. 

The driver can be tested with: `bebop_flow trigger -n 10`. The command saves the next 10 frames as pgm files in `/home/root/images`. The camera runs at 90 fps and has a frame size of 320x240.