### PR TITLE
Fixed param output for QuRT

### DIFF
--- a/src/systemcmds/param/param.c
+++ b/src/systemcmds/param/param.c
@@ -68,6 +68,12 @@ enum COMPARE_OPERATOR {
 	COMPARE_OPERATOR_GREATER = 1,
 };
 
+#ifdef __PX4_QURT
+#define PARAM_PRINT PX4_INFO
+#else
+#define PARAM_PRINT printf
+#endif
+
 static int 	do_save(const char *param_file_name);
 static int	do_save_default(void);
 static int 	do_load(const char *param_file_name);
@@ -335,9 +341,9 @@ do_import(const char *param_file_name)
 static int
 do_show(const char *search_string)
 {
-	printf("Symbols: x = used, + = saved, * = unsaved\n");
+	PARAM_PRINT("Symbols: x = used, + = saved, * = unsaved\n");
 	param_foreach(do_show_print, (char *)search_string, false, false);
-	printf("\n %u parameters total, %u used.\n", param_count(), param_count_used());
+	PARAM_PRINT("\n %u parameters total, %u used.\n", param_count(), param_count_used());
 
 	return 0;
 }
@@ -352,7 +358,7 @@ do_find(const char *name)
 		return 1;
 	}
 
-	printf("Found param %s at index %" PRIxPTR "\n", name, ret);
+	PARAM_PRINT("Found param %s at index %" PRIxPTR "\n", name, ret);
 	return 0;
 }
 
@@ -377,27 +383,27 @@ do_show_index(const char *index, bool used_index)
 		return 1;
 	}
 
-	printf("index %d: %c %c %s [%d,%d] : ", i, (param_used(param) ? 'x' : ' '),
+	PARAM_PRINT("index %d: %c %c %s [%d,%d] : ", i, (param_used(param) ? 'x' : ' '),
 	       param_value_unsaved(param) ? '*' : (param_value_is_default(param) ? ' ' : '+'),
 	       param_name(param), param_get_used_index(param), param_get_index(param));
 
 	switch (param_type(param)) {
 	case PARAM_TYPE_INT32:
 		if (!param_get(param, &ii)) {
-			printf("%ld\n", (long)ii);
+			PARAM_PRINT("%ld\n", (long)ii);
 		}
 
 		break;
 
 	case PARAM_TYPE_FLOAT:
 		if (!param_get(param, &ff)) {
-			printf("%4.4f\n", (double)ff);
+			PARAM_PRINT("%4.4f\n", (double)ff);
 		}
 
 		break;
 
 	default:
-		printf("<unknown type %d>\n", 0 + param_type(param));
+		PARAM_PRINT("<unknown type %d>\n", 0 + param_type(param));
 	}
 
 	return 0;
@@ -446,7 +452,7 @@ do_show_print(void *arg, param_t param)
 		}
 	}
 
-	printf("%c %c %s [%d,%d] : ", (param_used(param) ? 'x' : ' '),
+	PARAM_PRINT("%c %c %s [%d,%d] : ", (param_used(param) ? 'x' : ' '),
 	       param_value_unsaved(param) ? '*' : (param_value_is_default(param) ? ' ' : '+'),
 	       param_name(param), param_get_used_index(param), param_get_index(param));
 
@@ -457,7 +463,7 @@ do_show_print(void *arg, param_t param)
 	switch (param_type(param)) {
 	case PARAM_TYPE_INT32:
 		if (!param_get(param, &i)) {
-			printf("%ld\n", (long)i);
+			PARAM_PRINT("%ld\n", (long)i);
 			return;
 		}
 
@@ -465,22 +471,22 @@ do_show_print(void *arg, param_t param)
 
 	case PARAM_TYPE_FLOAT:
 		if (!param_get(param, &f)) {
-			printf("%4.4f\n", (double)f);
+			PARAM_PRINT("%4.4f\n", (double)f);
 			return;
 		}
 
 		break;
 
 	case PARAM_TYPE_STRUCT ... PARAM_TYPE_STRUCT_MAX:
-		printf("<struct type %d size %zu>\n", 0 + param_type(param), param_size(param));
+		PARAM_PRINT("<struct type %d size %zu>\n", 0 + param_type(param), param_size(param));
 		return;
 
 	default:
-		printf("<unknown type %d>\n", 0 + param_type(param));
+		PARAM_PRINT("<unknown type %d>\n", 0 + param_type(param));
 		return;
 	}
 
-	printf("<error fetching parameter %lu>\n", (unsigned long)param);
+	PARAM_PRINT("<error fetching parameter %lu>\n", (unsigned long)param);
 }
 
 static int
@@ -510,12 +516,12 @@ do_set(const char *name, const char *val, bool fail_on_not_found)
 			int32_t newval = strtol(val, &end, 10);
 
 			if (i != newval) {
-				printf("%c %s: ",
+				PARAM_PRINT("%c %s: ",
 				       param_value_unsaved(param) ? '*' : (param_value_is_default(param) ? ' ' : '+'),
 				       param_name(param));
-				printf("curr: %ld", (long)i);
+				PARAM_PRINT("curr: %ld", (long)i);
 				param_set_no_autosave(param, &newval);
-				printf(" -> new: %ld\n", (long)newval);
+				PARAM_PRINT(" -> new: %ld\n", (long)newval);
 			}
 		}
 
@@ -532,12 +538,12 @@ do_set(const char *name, const char *val, bool fail_on_not_found)
 
 			if (f != newval) {
 #pragma GCC diagnostic pop
-				printf("%c %s: ",
+				PARAM_PRINT("%c %s: ",
 				       param_value_unsaved(param) ? '*' : (param_value_is_default(param) ? ' ' : '+'),
 				       param_name(param));
-				printf("curr: %4.4f", (double)f);
+				PARAM_PRINT("curr: %4.4f", (double)f);
 				param_set_no_autosave(param, &newval);
-				printf(" -> new: %4.4f\n", (double)newval);
+				PARAM_PRINT(" -> new: %4.4f\n", (double)newval);
 			}
 
 		}

--- a/src/systemcmds/param/param.c
+++ b/src/systemcmds/param/param.c
@@ -384,8 +384,8 @@ do_show_index(const char *index, bool used_index)
 	}
 
 	PARAM_PRINT("index %d: %c %c %s [%d,%d] : ", i, (param_used(param) ? 'x' : ' '),
-	       param_value_unsaved(param) ? '*' : (param_value_is_default(param) ? ' ' : '+'),
-	       param_name(param), param_get_used_index(param), param_get_index(param));
+		    param_value_unsaved(param) ? '*' : (param_value_is_default(param) ? ' ' : '+'),
+		    param_name(param), param_get_used_index(param), param_get_index(param));
 
 	switch (param_type(param)) {
 	case PARAM_TYPE_INT32:
@@ -453,8 +453,8 @@ do_show_print(void *arg, param_t param)
 	}
 
 	PARAM_PRINT("%c %c %s [%d,%d] : ", (param_used(param) ? 'x' : ' '),
-	       param_value_unsaved(param) ? '*' : (param_value_is_default(param) ? ' ' : '+'),
-	       param_name(param), param_get_used_index(param), param_get_index(param));
+		    param_value_unsaved(param) ? '*' : (param_value_is_default(param) ? ' ' : '+'),
+		    param_name(param), param_get_used_index(param), param_get_index(param));
 
 	/*
 	 * This case can be expanded to handle printing common structure types.
@@ -517,8 +517,8 @@ do_set(const char *name, const char *val, bool fail_on_not_found)
 
 			if (i != newval) {
 				PARAM_PRINT("%c %s: ",
-				       param_value_unsaved(param) ? '*' : (param_value_is_default(param) ? ' ' : '+'),
-				       param_name(param));
+					    param_value_unsaved(param) ? '*' : (param_value_is_default(param) ? ' ' : '+'),
+					    param_name(param));
 				PARAM_PRINT("curr: %ld", (long)i);
 				param_set_no_autosave(param, &newval);
 				PARAM_PRINT(" -> new: %ld\n", (long)newval);
@@ -539,8 +539,8 @@ do_set(const char *name, const char *val, bool fail_on_not_found)
 			if (f != newval) {
 #pragma GCC diagnostic pop
 				PARAM_PRINT("%c %s: ",
-				       param_value_unsaved(param) ? '*' : (param_value_is_default(param) ? ' ' : '+'),
-				       param_name(param));
+					    param_value_unsaved(param) ? '*' : (param_value_is_default(param) ? ' ' : '+'),
+					    param_name(param));
 				PARAM_PRINT("curr: %4.4f", (double)f);
 				param_set_no_autosave(param, &newval);
 				PARAM_PRINT(" -> new: %4.4f\n", (double)newval);


### PR DESCRIPTION
QuRT doesn't support printf, so the messages don't appeat in mini-dm.

This problem is also present in many other parts of the PX4 code.

Signed-off-by: Mark Charlebois <charlebm@gmail.com>