### PR TITLE
Changes to RCC HSI and FLASH driver

### DIFF
--- a/nuttx-patches/wip_inflight_to_upstream.patch
+++ b/nuttx-patches/wip_inflight_to_upstream.patch
@@ -33,3 +33,70 @@ index 644c810..10919e8 100644
    struct up_dev_s   *priv  = (struct up_dev_s *)dev->priv;
  #endif
    int                ret    = OK;
+diff --git NuttX/nuttx/arch/arm/src/stm32/stm32f40xxx_rcc.c NuttX/nuttx/arch/arm/src/stm32/stm32f40xxx_rcc.c
+index 5e2ba73..adda863 100644
+--- NuttX/nuttx/arch/arm/src/stm32/stm32f40xxx_rcc.c
++++ NuttX/nuttx/arch/arm/src/stm32/stm32f40xxx_rcc.c
+@@ -95,10 +95,10 @@ static inline void rcc_reset(void)
+ 
+   putreg32(0x00000000, STM32_RCC_CFGR);
+ 
+-  /* Reset HSION, HSEON, CSSON and PLLON bits */
++  /* Reset HSEON, CSSON and PLLON bits */
+ 
+   regval  = getreg32(STM32_RCC_CR);
+-  regval &= ~(RCC_CR_HSION | RCC_CR_HSEON | RCC_CR_CSSON | RCC_CR_PLLON);
++  regval &= ~(RCC_CR_HSEON | RCC_CR_CSSON | RCC_CR_PLLON);
+   putreg32(regval, STM32_RCC_CR);
+ 
+   /* Reset PLLCFGR register to reset default */
+@@ -619,11 +619,6 @@ static void stm32_stdclockconfig(void)
+   volatile int32_t timeout;
+ 
+ #ifdef STM32_BOARD_USEHSI
+-  /* Enable Internal High-Speed Clock (HSI) */
+-
+-  regval  = getreg32(STM32_RCC_CR);
+-  regval |= RCC_CR_HSION;           /* Enable HSI */
+-  putreg32(regval, STM32_RCC_CR);
+ 
+   /* Wait until the HSI is ready (or until a timeout elapsed) */
+ 
+diff --git NuttX/nuttx/arch/arm/src/stm32/stm32_flash.c NuttX/nuttx/arch/arm/src/stm32/stm32_flash.c
+index 73f1419..9ac38a1 100644
+--- NuttX/nuttx/arch/arm/src/stm32/stm32_flash.c
++++ NuttX/nuttx/arch/arm/src/stm32/stm32_flash.c
+@@ -231,12 +231,14 @@ ssize_t up_progmem_erasepage(size_t page)
+       return -EFAULT;
+     }
+ 
+-  /* Get flash ready and begin erasing single page */
+-
++#if !defined(CONFIG_STM32_STM32F40XX)
+   if (!(getreg32(STM32_RCC_CR) & RCC_CR_HSION))
+     {
+       return -EPERM;
+     }
++#endif
++
++  /* Get flash ready and begin erasing single page */
+ 
+   stm32_flash_unlock();
+ 
+@@ -318,12 +320,14 @@ ssize_t up_progmem_write(size_t addr, const void *buf, size_t count)
+       return -EFAULT;
+     }
+ 
+-  /* Get flash ready and begin flashing */
+-
++#if !defined(CONFIG_STM32_STM32F40XX)
+   if (!(getreg32(STM32_RCC_CR) & RCC_CR_HSION))
+     {
+       return -EPERM;
+     }
++#endif
++
++  /* Get flash ready and begin flashing */
+ 
+   stm32_flash_unlock();
+ 


### PR DESCRIPTION
FYI @bkueng

   STM32F4 does not require the HSI to erase or program FLASH
   The HSI needs to be left on until a new clock source is chosen.
   (we leave it on all the time)