### PR TITLE
LPE firmware creation for px4fmu-v2 and param default overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,9 @@
 Archives/*
 Build/*
 Testing/
-Binaries/*
-Meta/*
+Packages/*
+s3deploy-branch/
+s3deploy-archive/
 build/*
 build_*/
 core

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,9 +78,7 @@ script:
 after_success:
   - if [[ "${TRAVIS_OS_NAME}" = "linux" && "${TRAVIS_BRANCH}" != "coverity" ]]; then
          make package_firmware && mkdir s3deploy-archive && cp Firmware.zip s3deploy-archive/
-      && cp Binaries/* .
-      && find . -maxdepth 1 -mindepth 1 -type f -name 'nuttx-*-default.px4' | sed 's/.\/nuttx-//' | sed 's/-default.px4//' | xargs -I{} mv nuttx-{}-default.px4 {}_default.px4
-      && mkdir s3deploy-branch && mv *_default.px4 Meta/px4fmu-v4_default/parameters.xml Meta/px4fmu-v4_default/airframes.xml s3deploy-branch/;
+      && Tools/s3_deploy.py;
     fi
   - if [[ "${TRAVIS_OS_NAME}" = "linux" && "$GCC_VER" == "5.4" && "${TRAVIS_BRANCH}" != "coverity" ]]; then
       export PX4_S3_DEPLOY=1;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,12 @@ if (NOT ${CMAKE_VERSION} VERSION_LESS 3.1.0)
 	cmake_policy(SET CMP0054 NEW) # don't dereference quoted variables
 endif()
 
+execute_process(
+	COMMAND git describe --always --tags
+	OUTPUT_VARIABLE git_tag
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+	WORKING_DIRECTORY ${PX4_SOURCE_DIR}
+	)
 set(version_major 1)
 set(version_minor 5)
 set(version_patch 0)
@@ -371,6 +377,10 @@ px4_generate_parameters_xml(OUT parameters.xml
 px4_generate_airframes_xml(OUT airframes.xml BOARD ${BOARD})
 add_custom_target(xml_gen
 	DEPENDS parameters.xml airframes.xml)
+install(FILES
+	${CMAKE_CURRENT_BINARY_DIR}/airframes.xml
+	${CMAKE_CURRENT_BINARY_DIR}/parameters.xml
+	DESTINATION .)
 
 #=============================================================================
 # external projects
@@ -468,12 +478,6 @@ px4_create_git_hash_header(OUT ${PX4_BINARY_DIR}/build_git_version.h)
 #
 # Important to having packaging at end of cmake file.
 #
-execute_process(
-	COMMAND git describe --always --tags
-	OUTPUT_VARIABLE git_tag
-	OUTPUT_STRIP_TRAILING_WHITESPACE
-	WORKING_DIRECTORY ${PX4_SOURCE_DIR}
-	)
 set(CPACK_PACKAGE_NAME ${PROJECT_NAME}-${CONFIG})
 set(CPACK_PACKAGE_VERSION ${version})
 set(CPACK_PACKAGE_CONTACT ${package-contact})
@@ -486,7 +490,7 @@ set(CPACK_GENERATOR "ZIP")
 set(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}-${CONFIG}-${git_tag}")
 set(CPACK_SOURCE_PACKAGE_FILE_NAME "${PROJECT_NAME}-${version}")
 set(CPACK_SOURCE_GENERATOR "ZIP;TBZ2")
-set(CPACK_PACKAGING_INSTALL_PREFIX "/usr")
+set(CPACK_PACKAGING_INSTALL_PREFIX "")
 set(CPACK_SET_DESTDIR "OFF")
 if ("${CMAKE_SYSTEM}" MATCHES "Linux")
 	find_program(DPKG_PROGRAM dpkg)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,7 +244,7 @@ endif()
 
 # version info from git
 execute_process(
-	COMMAND Tools/tag_to_version.py ${PX4_SOURCE_DIR}
+	COMMAND Tools/tag_to_version.py --root ${PX4_SOURCE_DIR}
 	OUTPUT_VARIABLE version
 	WORKING_DIRECTORY ${PX4_SOURCE_DIR}
 	)
@@ -255,7 +255,7 @@ execute_process(
 	WORKING_DIRECTORY ${PX4_SOURCE_DIR}
 	)
 set(package-contact "px4users@googlegroups.com")
-message(STATUS "PX4 VERSION: ${version}")
+message(STATUS "VERSION: ${version}")
 
 #=============================================================================
 # find programs and packages

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,17 +242,20 @@ if (NOT ${CMAKE_VERSION} VERSION_LESS 3.1.0)
 	cmake_policy(SET CMP0054 NEW) # don't dereference quoted variables
 endif()
 
+# version info from git
+execute_process(
+	COMMAND Tools/tag_to_version.py ${PX4_SOURCE_DIR}
+	OUTPUT_VARIABLE version
+	WORKING_DIRECTORY ${PX4_SOURCE_DIR}
+	)
 execute_process(
 	COMMAND git describe --always --tags
 	OUTPUT_VARIABLE git_tag
 	OUTPUT_STRIP_TRAILING_WHITESPACE
 	WORKING_DIRECTORY ${PX4_SOURCE_DIR}
 	)
-set(version_major 1)
-set(version_minor 5)
-set(version_patch 0)
-set(version "${version_major}.${version_minor}.${version_patch}")
 set(package-contact "px4users@googlegroups.com")
+message(STATUS "PX4 VERSION: ${version}")
 
 #=============================================================================
 # find programs and packages

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,10 +380,13 @@ px4_generate_parameters_xml(OUT parameters.xml
 px4_generate_airframes_xml(OUT airframes.xml BOARD ${BOARD})
 add_custom_target(xml_gen
 	DEPENDS parameters.xml airframes.xml)
+
+if(NOT "${config_nuttx_config}" STREQUAL "bootloader")
 install(FILES
 	${CMAKE_CURRENT_BINARY_DIR}/airframes.xml
 	${CMAKE_CURRENT_BINARY_DIR}/parameters.xml
 	DESTINATION .)
+endif()
 
 #=============================================================================
 # external projects

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,8 +365,9 @@ px4_generate_messages(TARGET msg_gen
 	DEPENDS git_genmsg git_gencpp prebuild_targets
 	)
 px4_generate_parameters_xml(OUT parameters.xml 
-                            BOARD ${BOARD}
-                            SCOPE ${PX4_SOURCE_DIR}/cmake/configs/${OS}_${BOARD}_${LABEL}.cmake)
+	BOARD ${BOARD}
+	SCOPE ${PX4_SOURCE_DIR}/cmake/configs/${OS}_${BOARD}_${LABEL}.cmake
+	OVERRIDES ${PARAM_DEFAULT_OVERRIDES})
 px4_generate_airframes_xml(OUT airframes.xml BOARD ${BOARD})
 add_custom_target(xml_gen
 	DEPENDS parameters.xml airframes.xml)

--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ clang-tidy:
 	@$(SRC_DIR)/Tools/clang-tool.sh -b build_posix_sitl_default -t clang-tidy
 
 package_firmware:
-	@zip --junk-paths Firmware.zip `find Binaries/. -name \*.px4`
+	@./Tools/package_firmware.py
 
 clean:
 	@rm -rf build_*/

--- a/Makefile
+++ b/Makefile
@@ -260,11 +260,9 @@ format:
 check_%:
 	@echo
 	$(call colorecho,"Building" $(subst check_,,$@))
-	@$(MAKE) --no-print-directory $(subst check_,,$@)
-	@mkdir -p Binaries
-	@mkdir -p Meta/$(subst check_,,$@)
-	@cp build_$(subst check_,,$@)/*.xml Meta/$(subst check_,,$@) 2> /dev/null || :
-	@find build_$(subst check_,,$@)/src/firmware -type f -name 'nuttx-*-default.px4' -exec cp "{}" Binaries \; 2> /dev/null || :
+	@$(MAKE) --no-print-directory $(subst check_,,$@) package
+	@mkdir -p Packages
+	@cp build_$(subst check_,,$@)/*.zip Packages
 	@rm -rf build_$(subst check_,,$@)
 	@echo
 

--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,7 @@ qgc_firmware: \
 	check_mindpx-v2_default \
 	check_px4fmu-v1_default \
 	check_px4fmu-v2_default \
+	check_px4fmu-v2_lpe \
 	check_px4fmu-v3_default \
 	check_px4fmu-v4_default \
 	check_tap-v1_default \

--- a/Tools/package_firmware.py
+++ b/Tools/package_firmware.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import glob
+import zipfile
+import os
+
+FIRMWARE_FILE = 'Firmware.zip'
+
+
+def extract_file_only(filename, dest):
+    """
+    Extract a file without keeping directories.
+    """
+    # extract firmware files without paths
+    f_src = archive.open(filename, 'r')
+    data = f_src.read()
+    dst_name = os.path.join(dest, os.path.basename(filename))
+    with open(dst_name, 'w') as f_dst:
+        f_dst.write(data)
+    f_src.close()
+
+# open destination archive
+with zipfile.ZipFile(FIRMWARE_FILE, 'w') as dest_archive:
+
+    # get all zip files in Packages directory
+    for zip_filename in glob.glob("Packages/*.zip"):
+
+        # open zipfile
+        with zipfile.ZipFile(zip_filename, 'r') as archive:
+
+            # look for interesting names
+            for src_filename in archive.namelist():
+
+                # extract firmware files
+                if os.path.splitext(src_filename)[1] == '.px4':
+                    base_name = os.path.basename(src_filename)
+                    dest_archive.writestr(base_name, archive.read(src_filename))

--- a/Tools/px_process_params.py
+++ b/Tools/px_process_params.py
@@ -53,6 +53,7 @@ import argparse
 from px4params import srcscanner, srcparser, xmlout, dokuwikiout, dokuwikirpc, scope, cmakeparser
 
 import re
+import json
 import codecs
 
 def main():
@@ -112,6 +113,10 @@ def main():
                         help="DokuWiki page edit summary")
     parser.add_argument('-v', '--verbose', action='store_true', help="verbose output")
     parser.add_argument('--scope', default=None, action='store', help="pass the scope (list of compiled modules)")
+    parser.add_argument("-o", "--overrides",
+                        default="{}",
+                        metavar="OVERRIDES",
+                        help="a dict of overrides in the form of a json string")
 
     args = parser.parse_args()
 
@@ -154,6 +159,16 @@ def main():
 
     if len(param_groups) == 0:
         print("Warning: no parameters found")
+
+    override_dict = json.loads(args.overrides)
+    if len(override_dict.keys()) > 0:
+        for group in param_groups:
+            for param in group.GetParams():
+                name = param.GetName()
+                if name in override_dict.keys():
+                    val = str(override_dict[param.GetName()])
+                    param.default = val
+                    print("OVERRIDING {:s} to {:s}!!!!!".format(name, val))
 
     # Output to XML file
     if args.xml:

--- a/Tools/s3_deploy.py
+++ b/Tools/s3_deploy.py
@@ -7,7 +7,7 @@ import re
 import shutil
 
 S3_DIR = 's3deploy-branch'
-S3_ARCHIVE_DIR = 's3deploy-branch'
+S3_ARCHIVE_DIR = 's3deploy-archive'
 
 if not os.path.isdir(S3_DIR):
     os.mkdir(S3_DIR)
@@ -15,7 +15,7 @@ if not os.path.isdir(S3_DIR):
 if not os.path.isdir(S3_ARCHIVE_DIR):
     os.mkdir(S3_ARCHIVE_DIR)
 
-shutil.copyfile(Firmware.zip, S3_ARCHIVE_DIR)
+shutil.copy("Firmware.zip", S3_ARCHIVE_DIR)
 
 def extract_file_only(filename, dest):
     # extract firmware files without paths

--- a/Tools/s3_deploy.py
+++ b/Tools/s3_deploy.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+import glob
+import zipfile
+import os
+import re
+import shutil
+
+S3_DIR = 's3deploy-branch'
+S3_ARCHIVE_DIR = 's3deploy-branch'
+
+if not os.path.isdir(S3_DIR):
+    os.mkdir(S3_DIR)
+
+if not os.path.isdir(S3_ARCHIVE_DIR):
+    os.mkdir(S3_ARCHIVE_DIR)
+
+shutil.copyfile(Firmware.zip, S3_ARCHIVE_DIR)
+
+def extract_file_only(filename, dest):
+    # extract firmware files without paths
+    f_src = archive.open(filename, 'r')
+    data = f_src.read()
+    with open(os.path.join(dest,
+              os.path.basename(filename)), 'w') as f_dst:
+        f_dst.write(data)
+    f_src.close()
+
+# get all zip files in Packages directory
+for zip_filename in glob.glob("Packages/*.zip"):
+
+    # open zipfile
+    with zipfile.ZipFile(zip_filename, 'r') as archive:
+
+        # look for interesting names
+        for filename in archive.namelist():
+
+            # extract firmware files
+            if os.path.splitext(filename)[1] == '.px4':
+                extract_file_only(filename, S3_DIR)
+
+            # copy px4fmu-v4_default xml files for qgroundcontrol
+            if re.match(filename, r'.*px4fmu-v4_default.*\.xml') is not None:
+                extract_file_only(filename, S3_DIR)

--- a/Tools/tag_to_version.py
+++ b/Tools/tag_to_version.py
@@ -1,0 +1,17 @@
+import subprocess
+import os
+import argparse
+
+p = argparse.ArgumentParser('finds major minor patch version from git tag')
+p.add_argument('--root', help="root of git repo", default=".")
+args = p.parse_args()
+os.chdir(args.root)
+p= subprocess.Popen(
+    'git describe --always --tags'.split(),
+    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+stdout, stderr = p.communicate()
+res = stdout.split('-')[0].split('.')
+major = res[0].replace('v','')
+minor = res[1]
+patch = res[2]
+print("{:s}.{:s}.{:s}".format(major, minor, patch))

--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -1014,16 +1014,20 @@ endfunction()
 function(px4_generate_parameters_xml)
 	px4_parse_function_args(
 		NAME px4_generate_parameters_xml
-		ONE_VALUE OUT BOARD SCOPE
+		ONE_VALUE OUT BOARD SCOPE OVERRIDES
 		REQUIRED OUT BOARD
 		ARGN ${ARGN})
 	set(path ${PX4_SOURCE_DIR}/src)
 	file(GLOB_RECURSE param_src_files
 		${PX4_SOURCE_DIR}/src/*params.c
 		)
+	if (NOT OVERRIDES)
+		set(OVERRIDES "{}")
+	endif()
 	add_custom_command(OUTPUT ${OUT}
 		COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/px_process_params.py
 			-s ${path} --board CONFIG_ARCH_${BOARD} --xml --inject-xml --scope ${SCOPE}
+			--overrides ${OVERRIDES}
 		DEPENDS ${param_src_files} ${PX4_SOURCE_DIR}/Tools/px_process_params.py
 			${PX4_SOURCE_DIR}/Tools/px_generate_params.py
 		)

--- a/cmake/configs/nuttx_px4fmu-v2_lpe.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_lpe.cmake
@@ -1,0 +1,12 @@
+include(configs/nuttx_px4fmu-v2_default)
+
+set(PARAM_DEFAULT_OVERRIDES "{\\\"SYS_MC_EST_GROUP\\\": 1}")
+
+list(REMOVE_ITEM config_module_list
+	modules/ekf2
+	)
+
+list(APPEND config_module_list
+	modules/attitude_estimator_q
+	modules/local_position_estimator
+	)

--- a/src/systemcmds/tests/test_servo.c
+++ b/src/systemcmds/tests/test_servo.c
@@ -116,8 +116,10 @@ int test_servo(int argc, char *argv[])
 	printf("Advancing channel 1 to 1800\n");
 	result = ioctl(fd, PWM_SERVO_SET(1), 1800);
 out:
+
 	if (fd >= 0) {
 		close(fd);
 	}
+
 	return 0;
 }


### PR DESCRIPTION
This adds LPE firmware build for px4fmu-v2 and also add a mechanism for param default overrides. Right now a lot of users are struggling to build LPE since it is no-longer default and I'm trying to make it easier for them. It would be great if it could be an option for QGC @dagar @LorenzMeier .

The param default override  is used to make sure the user starts up with LPE as default. I made it a json dict string so it is very easy to add to other configs.

```cmake
set(PARAM_DEFAULT_OVERRIDES "{\\\"SYS_MC_EST_GROUP\\\": 1}")
```