### PR TITLE
uavcan build enable c++11

### DIFF
--- a/src/modules/uavcan/CMakeLists.txt
+++ b/src/modules/uavcan/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ############################################################################
 
-set(UAVCAN_USE_CPP03 ON CACHE BOOL "uavcan cpp03")
+set(UAVCAN_USE_CPP03 OFF CACHE BOOL "uavcan cpp03")
 set(UAVCAN_PLATFORM stm32 CACHE STRING "uavcan platform")
 
 string(TOUPPER "${OS}" OS_UPPER)


### PR DESCRIPTION
Any reason we shouldn't enable c++11 for uavcan builds? I was just wondering where the c++03 message was coming from at configure time and found it's coming from uavcan.
Firmware is built with -std=c++0x which is actually c++11 + gnu extensions on our current compilers.