### PR TITLE
fix posix_rpi_native.cmake: add __DF_RPI define

### DIFF
--- a/cmake/configs/posix_rpi_native.cmake
+++ b/cmake/configs/posix_rpi_native.cmake
@@ -1,3 +1,7 @@
 include(configs/posix_rpi_common)
 
+add_definitions(
+	-D __DF_RPI
+	)
+
 set(CMAKE_TOOLCHAIN_FILE ${PX4_SOURCE_DIR}/cmake/toolchains/Toolchain-native.cmake)


### PR DESCRIPTION
Needed for the DriverFramework. Fixes the error:
```
15050 SPIDevObj start failed
15142 DevObj start failed
15185 Unable to open the device path:
ERROR [df_lsm9ds1_wrapper] LSM9DS1 start fail: -1
ERROR [df_lsm9ds1_wrapper] DfLsm9ds1Wrapper start failed
Command 'df_lsm9ds1_wrapper' failed, returned -1
```