### PR TITLE
Check builds ID compiler and sizes, with option to keep build dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ coverage-html/
 coverage.info
 
 posix-configs/SITL/init/test/*_generated
+check_build_sizes.txt

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ endif
 check_px4fmu-v4_default: uavcan_firmware
 
 check_px4fmu-v4_default_and_uavcan: check_px4fmu-v4_default
-	@echo VECTORCONTROL=$VECTORCONTROL
+	@echo VECTORCONTROL=${VECTORCONTROL}
 ifeq ($(VECTORCONTROL),1)
 	@echo "Cleaning up vectorcontrol firmware"
 	@rm -rf vectorcontrol


### PR DESCRIPTION
   Pass KEEP_BUILD_DIRS=1 on command line to keep build_* dirs

   Print the version of the ARM compiler on check builds so
   we see it on CI build.

   Accumulate the sizes of the fimware files and display them
   at the end og the check builds.