### PR TITLE
Airspeed sensor check relaxation

### DIFF
--- a/src/drivers/ets_airspeed/ets_airspeed.cpp
+++ b/src/drivers/ets_airspeed/ets_airspeed.cpp
@@ -156,14 +156,16 @@ ETSAirspeed::collect()
 
 	uint16_t diff_pres_pa_raw = val[1] << 8 | val[0];
 
+	differential_pressure_s report;
+	report.timestamp = hrt_absolute_time();
+
 	if (diff_pres_pa_raw == 0) {
-		// a zero value means the pressure sensor cannot give us a
-		// value. We need to return, and not report a value or the
-		// caller could end up using this value as part of an
-		// average
-		perf_count(_comms_errors);
-		DEVICE_LOG("zero value from sensor");
-		return -1;
+		// a zero value indicates no measurement
+		// since the noise floor has been arbitrarily killed
+		// it defeats our stuck sensor detection - the best we
+		// can do is to output some numerical noise to show
+		// that we are still correctly sampling.
+		diff_pres_pa_raw = 0.001f * (report.timestamp & 0x01);
 	}
 
 	// The raw value still should be compensated for the known offset
@@ -174,8 +176,6 @@ ETSAirspeed::collect()
 		_max_differential_pressure_pa = diff_pres_pa_raw;
 	}
 
-	differential_pressure_s report;
-	report.timestamp = hrt_absolute_time();
 	report.error_count = perf_event_count(_comms_errors);
 
 	// XXX we may want to smooth out the readings to remove noise.

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -380,7 +380,7 @@ static bool airspeedCheck(orb_advert_t *mavlink_log_pub, bool optional, bool rep
 		goto out;
 	}
 
-	if (fabsf(airspeed.confidence) < 0.99f) {
+	if (fabsf(airspeed.confidence) < 0.95f) {
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: AIRSPEED SENSOR COMM ERROR");
 		}

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -283,6 +283,9 @@ Sensors::Sensors() :
 	memset(&_parameters, 0, sizeof(_parameters));
 
 	initialize_parameter_handles(_parameter_handles);
+
+	_airspeed_validator.set_timeout(300000);
+	_airspeed_validator.set_equal_value_threshold(100);
 }
 
 Sensors::~Sensors()
@@ -378,13 +381,9 @@ Sensors::diff_pres_poll(struct sensor_combined_s &raw)
 		_airspeed.timestamp = _diff_pres.timestamp;
 
 		/* push data into validator */
-		_airspeed_validator.put(_airspeed.timestamp, _diff_pres.differential_pressure_raw_pa, _diff_pres.error_count, 100);
-
-#ifdef __PX4_POSIX
-		_airspeed.confidence = 1.0f;
-#else
+		_airspeed_validator.put(_airspeed.timestamp, _diff_pres.differential_pressure_raw_pa, _diff_pres.error_count,
+					ORB_PRIO_HIGH);
 		_airspeed.confidence = _airspeed_validator.confidence(hrt_absolute_time());
-#endif
 
 		/* don't risk to feed negative airspeed into the system */
 		_airspeed.indicated_airspeed_m_s = math::max(0.0f,

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -253,7 +253,7 @@ void Simulator::update_sensors(mavlink_hil_sensor_t *imu)
 
 	RawAirspeedData airspeed = {};
 	airspeed.temperature = imu->temperature;
-	airspeed.diff_pressure = imu->diff_pressure;
+	airspeed.diff_pressure = imu->diff_pressure + 0.001f * (hrt_absolute_time() & 0x01);;
 
 	write_airspeed_data(&airspeed);
 }


### PR DESCRIPTION
@tubeme @dagar This relaxes the airspeed checks within reasonable bounds. If anything is failing still now there is a real issue with the sensor setup which needs to be fixed in hardware.

Arming should also now possible without much noise on the sensor.