### PR TITLE
WIP: cmake nuttx rsync copy only use relative paths

### DIFF
--- a/cmake/nuttx/px4_impl_nuttx.cmake
+++ b/cmake/nuttx/px4_impl_nuttx.cmake
@@ -255,12 +255,15 @@ function(px4_nuttx_add_export)
 
 	# copy
 	file(GLOB_RECURSE nuttx_all_files ${PX4_SOURCE_DIR}/NuttX/*)
+	file(RELATIVE_PATH nuttx_cp_src ${PX4_BINARY_DIR} ${PX4_SOURCE_DIR}/NuttX)
 	add_custom_command(OUTPUT nuttx_copy_${CONFIG}.stamp
 		COMMAND ${MKDIR} -p ${nuttx_src}
-		COMMAND rsync -a --delete --exclude=.git ${PX4_SOURCE_DIR}/NuttX/ ${nuttx_src}/
+		COMMAND rsync -a --delete --exclude=.git ${nuttx_cp_src}/ ${CONFIG}/NuttX/
 		COMMAND ${TOUCH} nuttx_copy_${CONFIG}.stamp
 		DEPENDS ${DEPENDS} ${nuttx_patches} ${nuttx_all_files}
-		COMMENT "Copying NuttX for ${CONFIG} with ${config_nuttx_config}")
+		COMMENT "Copying NuttX for ${CONFIG} with ${config_nuttx_config}"
+		WORKING_DIRECTORY ${PX4_BINARY_DIR}
+		)
 	add_custom_target(nuttx_copy_${CONFIG} DEPENDS nuttx_copy_${CONFIG}.stamp)
 
 	# patch


### PR DESCRIPTION
 - this is to work around confusion between cygwin and windows native
   paths
 - closes #6332 

Waiting for testing on windows (#6332).