### PR TITLE
Add compensation for IMU and Barometer thermal drift

### DIFF
--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -50,7 +50,7 @@ set(config_module_list
 	drivers/bst
 ##TO FIT drivers/snapdragon_rc_pwm
 	drivers/lis3mdl
-	drivers/iridiumsbd
+	#drivers/iridiumsbd
 	drivers/ulanding
 
 	#

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -89,6 +89,7 @@ set(msg_file_names
 	sensor_accel.msg
 	sensor_baro.msg
 	sensor_combined.msg
+	sensor_correction.msg
 	sensor_gyro.msg
 	sensor_mag.msg
 	sensor_preflight.msg

--- a/msg/control_state.msg
+++ b/msg/control_state.msg
@@ -19,7 +19,10 @@ float32[3] pos_variance	# Variance in local position estimate
 float32[4] q 			# Attitude Quaternion
 float32[4] delta_q_reset 	# Amount by which quaternion has changed during last reset
 uint8 quat_reset_counter	# Quaternion reset counter
-float32 roll_rate		# Roll body angular rate (rad/s, x forward/y right/z down)
-float32 pitch_rate		# Pitch body angular rate (rad/s, x forward/y right/z down)
-float32 yaw_rate		# Yaw body angular rate (rad/s, x forward/y right/z down)
-float32 horz_acc_mag	# low pass filtered magnitude of the horizontal acceleration
+float32 roll_rate		# Roll body angular rate (rad/s, x forward/y right/z down) - corrected for bias
+float32 pitch_rate		# Pitch body angular rate (rad/s, x forward/y right/z down) - corrected for bias
+float32 yaw_rate		# Yaw body angular rate (rad/s, x forward/y right/z down) - corrected for bias
+float32 horz_acc_mag		# low pass filtered magnitude of the horizontal acceleration
+float32 roll_rate_bias		# Roll body angular rate bias (rad/s, x forward) - subtract from uncorrected gyro data
+float32 pitch_rate_bias		# Pitch body angular rate bias (rad/s, y right) - subtract from uncorrected gyro data
+float32 yaw_rate_bias		# Yaw body angular rate bias (rad/s, z down) - subtract from uncorrected gyro data

--- a/msg/sensor_accel.msg
+++ b/msg/sensor_accel.msg
@@ -15,4 +15,4 @@ int16 y_raw
 int16 z_raw
 int16 temperature_raw
 
-uint32 device_id
+uint32 device_id	# unique device ID for the sensor that does not change between power cycles

--- a/msg/sensor_accel.msg
+++ b/msg/sensor_accel.msg
@@ -15,4 +15,4 @@ int16 y_raw
 int16 z_raw
 int16 temperature_raw
 
-uint32 device_id	# unique device ID for the sensor that does not change between power cycles
+int32 device_id	# unique device ID for the sensor that does not change between power cycles

--- a/msg/sensor_baro.msg
+++ b/msg/sensor_baro.msg
@@ -2,3 +2,4 @@ float32 pressure
 float32 altitude
 float32 temperature
 uint64 error_count
+uint32 device_id	# Sensor ID that must be unique for each baro sensor and must not change

--- a/msg/sensor_baro.msg
+++ b/msg/sensor_baro.msg
@@ -2,4 +2,4 @@ float32 pressure	# static pressure measurement in millibar
 float32 altitude	# ISA pressure altitude in meters
 float32 temperature	# static temperature measurement in deg C
 uint64 error_count
-uint32 device_id	# Sensor ID that must be unique for each baro sensor and must not change
+int32 device_id	# Sensor ID that must be unique for each baro sensor and must not change

--- a/msg/sensor_baro.msg
+++ b/msg/sensor_baro.msg
@@ -1,5 +1,5 @@
-float32 pressure
-float32 altitude
-float32 temperature
+float32 pressure	# static pressure measurement in millibar
+float32 altitude	# ISA pressure altitude in meters
+float32 temperature	# static temperature measurement in deg C
 uint64 error_count
 uint32 device_id	# Sensor ID that must be unique for each baro sensor and must not change

--- a/msg/sensor_combined.msg
+++ b/msg/sensor_combined.msg
@@ -9,12 +9,12 @@ int32 RELATIVE_TIMESTAMP_INVALID = 2147483647 # (0x7fffffff) If one of the relat
 
 
 # gyro timstamp is equal to the timestamp of the message
-float32[3] gyro_rad				# delta angle in the NED body frame in rad
-float32 gyro_integral_dt			# delta time for gyro integral in s
+float32[3] gyro_rad			# average angular rate measured in the XYZ body frame in rad/s over the last gyro sampling period
+float32 gyro_integral_dt		# gyro measurement sampling period in s
 
 int32 accelerometer_timestamp_relative	# timestamp + accelerometer_timestamp_relative = Accelerometer timestamp
-float32[3] accelerometer_m_s2			# velocity in NED body frame, in m/s^2
-float32 accelerometer_integral_dt		# delta time for accel integral in s
+float32[3] accelerometer_m_s2		# average value acceleration measured in the XYZ body frame in m/s/s over the last accelerometer sampling period
+float32 accelerometer_integral_dt	# accelerometer measurement sampling period in s
 
 int32 magnetometer_timestamp_relative	# timestamp + magnetometer_timestamp_relative = Magnetometer timestamp
 float32[3] magnetometer_ga		# Magnetic field in NED body frame, in Gauss

--- a/msg/sensor_correction.msg
+++ b/msg/sensor_correction.msg
@@ -8,8 +8,14 @@ uint8 gyro_select		# gyro uORB index for the voted sensor
 float32[3] gyro_offset		# gyro XYZ offsets in the sensor frame in rad/s
 float32[3] gyro_scale		# gyro XYZ scale factors in the sensor frame
 
-# Corrections for acceleromter acceleration outputs where corrected_accel = raw_aaccel * accel_scale + accel_offset
+# Corrections for acceleromter acceleration outputs where corrected_accel = raw_accel * accel_scale + accel_offset
 # Note the corrections are in the sensor frame and must be applied before the sensor data is rotated into body frame
 uint8 accel_select		# accelerometer uORB index for the voted sensor
 float32[3] accel_offset		# accelerometer XYZ offsets in the sensor frame in m/s/s
 float32[3] accel_scale		# accelerometer XYZ scale factors in the sensor frame
+
+# Corrections for barometric pressure outputs where corrected_pressure = raw_pressure * pressure_scale + pressure_offset
+# Note the corrections are in the sensor frame and must be applied before the sensor data is rotated into body frame
+uint8 baro_select		# barometric pressure uORB index for the voted sensor
+float32 baro_offset		# barometric pressure offsets in the sensor frame in m/s/s
+float32 baro_scale		# barometric pressure scale factors in the sensor frame

--- a/msg/sensor_correction.msg
+++ b/msg/sensor_correction.msg
@@ -1,0 +1,15 @@
+#
+# Sensor corrections in SI-unit form for the voted sensor
+#
+
+# Corrections for gyro angular rate outputs where corrected_rate = raw_rate * gyro_scale + gyro_offset
+# Note the corrections are in the sensor frame and must be applied before the sensor data is rotated into body frame
+uint8 gyro_select		# gyro uORB index for the voted sensor
+float32[3] gyro_offset		# gyro XYZ offsets in the sensor frame in rad/s
+float32[3] gyro_scale		# gyro XYZ scale factors in the sensor frame
+
+# Corrections for acceleromter acceleration outputs where corrected_accel = raw_aaccel * accel_scale + accel_offset
+# Note the corrections are in the sensor frame and must be applied before the sensor data is rotated into body frame
+uint8 accel_select		# accelerometer uORB index for the voted sensor
+float32[3] accel_offset		# accelerometer XYZ offsets in the sensor frame in m/s/s
+float32[3] accel_scale		# accelerometer XYZ scale factors in the sensor frame

--- a/msg/sensor_gyro.msg
+++ b/msg/sensor_gyro.msg
@@ -15,4 +15,4 @@ int16 y_raw
 int16 z_raw
 int16 temperature_raw
 
-uint32 device_id
+uint32 device_id	# unique device ID for the sensor that does not change between power cycles

--- a/msg/sensor_gyro.msg
+++ b/msg/sensor_gyro.msg
@@ -15,4 +15,4 @@ int16 y_raw
 int16 z_raw
 int16 temperature_raw
 
-uint32 device_id	# unique device ID for the sensor that does not change between power cycles
+int32 device_id	# unique device ID for the sensor that does not change between power cycles

--- a/src/drivers/bmi160/bmi160.cpp
+++ b/src/drivers/bmi160/bmi160.cpp
@@ -1288,8 +1288,8 @@ BMI160::measure()
 	arb.temperature_raw = report.temp;
 	arb.temperature = _last_temperature;
 
-	/* TODO return unique hardware ID */
-	arb.device_id = 0;
+	/* Return class instance as a surrogate device ID */
+	arb.device_id = _accel_class_instance;
 
 	grb.x_raw = report.gyro_x;
 	grb.y_raw = report.gyro_y;
@@ -1324,8 +1324,8 @@ BMI160::measure()
 	grb.temperature_raw = report.temp;
 	grb.temperature = _last_temperature;
 
-	/* TODO return unique hardware ID */
-	grb.device_id = 0;
+	/* Use class instance as a surrogate hardware ID */
+	grb.device_id = _gyro->_gyro_class_instance;
 
 	_accel_reports->force(&arb);
 	_gyro_reports->force(&grb);

--- a/src/drivers/bmi160/bmi160.cpp
+++ b/src/drivers/bmi160/bmi160.cpp
@@ -1288,6 +1288,9 @@ BMI160::measure()
 	arb.temperature_raw = report.temp;
 	arb.temperature = _last_temperature;
 
+	/* TODO return unique hardware ID */
+	arb.device_id = 0;
+
 	grb.x_raw = report.gyro_x;
 	grb.y_raw = report.gyro_y;
 	grb.z_raw = report.gyro_z;
@@ -1320,6 +1323,9 @@ BMI160::measure()
 
 	grb.temperature_raw = report.temp;
 	grb.temperature = _last_temperature;
+
+	/* TODO return unique hardware ID */
+	grb.device_id = 0;
 
 	_accel_reports->force(&arb);
 	_gyro_reports->force(&grb);

--- a/src/drivers/bmp280/bmp280.cpp
+++ b/src/drivers/bmp280/bmp280.cpp
@@ -543,6 +543,8 @@ BMP280::collect()
 	report.temperature = _T;
 	report.pressure = _P / 100.0f; // to mbar
 
+	/* TODO get device ID for sensor */
+	report.device_id = 0;
 
 	/* altitude calculations based on http://www.kansasflyer.org/index.asp?nav=Avi&sec=Alti&tab=Theory&pg=1 */
 

--- a/src/drivers/l3gd20/l3gd20.cpp
+++ b/src/drivers/l3gd20/l3gd20.cpp
@@ -1075,6 +1075,9 @@ L3GD20::measure()
 	report.scaling = _gyro_range_scale;
 	report.range_rad_s = _gyro_range_rad_s;
 
+	/* TODO return unique hardware ID */
+	report.device_id = 0;
+
 	_reports->force(&report);
 
 	if (gyro_notify) {

--- a/src/drivers/l3gd20/l3gd20.cpp
+++ b/src/drivers/l3gd20/l3gd20.cpp
@@ -1075,8 +1075,8 @@ L3GD20::measure()
 	report.scaling = _gyro_range_scale;
 	report.range_rad_s = _gyro_range_rad_s;
 
-	/* TODO return unique hardware ID */
-	report.device_id = 0;
+	/* Return class instance as a surrogate device ID */
+	report.device_id = _class_instance;
 
 	_reports->force(&report);
 

--- a/src/drivers/lps25h/lps25h.cpp
+++ b/src/drivers/lps25h/lps25h.cpp
@@ -743,6 +743,9 @@ LPS25H::collect()
 	new_report.pressure = p;
 	new_report.altitude = alt;
 
+	/* TODO get device ID for sensor */
+	new_report.device_id = 0;
+
 	if (!(_pub_blocked)) {
 
 		if (_baro_topic != nullptr) {

--- a/src/drivers/lsm303d/lsm303d.cpp
+++ b/src/drivers/lsm303d/lsm303d.cpp
@@ -1642,8 +1642,8 @@ LSM303D::measure()
 	accel_report.scaling = _accel_range_scale;
 	accel_report.range_m_s2 = _accel_range_m_s2;
 
-	/* TODO return unique hardware ID */
-	accel_report.device_id = 0;
+	/* Return class instance as a surrogate device ID */
+	accel_report.device_id = _accel_class_instance;
 
 	_accel_reports->force(&accel_report);
 

--- a/src/drivers/lsm303d/lsm303d.cpp
+++ b/src/drivers/lsm303d/lsm303d.cpp
@@ -1642,6 +1642,9 @@ LSM303D::measure()
 	accel_report.scaling = _accel_range_scale;
 	accel_report.range_m_s2 = _accel_range_m_s2;
 
+	/* TODO return unique hardware ID */
+	accel_report.device_id = 0;
+
 	_accel_reports->force(&accel_report);
 
 	/* notify anyone waiting for data */

--- a/src/drivers/mpu6000/mpu6000.cpp
+++ b/src/drivers/mpu6000/mpu6000.cpp
@@ -2030,6 +2030,9 @@ MPU6000::measure()
 	arb.temperature_raw = report.temp;
 	arb.temperature = _last_temperature;
 
+	/* TODO return unique hardware ID */
+	arb.device_id = 0;
+
 	grb.x_raw = report.gyro_x;
 	grb.y_raw = report.gyro_y;
 	grb.z_raw = report.gyro_z;
@@ -2062,6 +2065,9 @@ MPU6000::measure()
 
 	grb.temperature_raw = report.temp;
 	grb.temperature = _last_temperature;
+
+	/* TODO return unique hardware ID */
+	grb.device_id = 0;
 
 	_accel_reports->force(&arb);
 	_gyro_reports->force(&grb);

--- a/src/drivers/mpu6000/mpu6000.cpp
+++ b/src/drivers/mpu6000/mpu6000.cpp
@@ -2030,8 +2030,8 @@ MPU6000::measure()
 	arb.temperature_raw = report.temp;
 	arb.temperature = _last_temperature;
 
-	/* TODO return unique hardware ID */
-	arb.device_id = 0;
+	/* Return class instance as a surrogate device ID */
+	arb.device_id = _accel_class_instance;
 
 	grb.x_raw = report.gyro_x;
 	grb.y_raw = report.gyro_y;
@@ -2066,8 +2066,8 @@ MPU6000::measure()
 	grb.temperature_raw = report.temp;
 	grb.temperature = _last_temperature;
 
-	/* TODO return unique hardware ID */
-	grb.device_id = 0;
+	/* Return class instance as a surrogate device ID */
+	grb.device_id = _gyro->_gyro_class_instance;
 
 	_accel_reports->force(&arb);
 	_gyro_reports->force(&grb);

--- a/src/drivers/mpu6500/mpu6500.cpp
+++ b/src/drivers/mpu6500/mpu6500.cpp
@@ -1833,6 +1833,9 @@ MPU6500::measure()
 	arb.temperature_raw = report.temp;
 	arb.temperature = _last_temperature;
 
+	/* TODO return unique hardware ID */
+	arb.device_id = 0;
+
 	grb.x_raw = report.gyro_x;
 	grb.y_raw = report.gyro_y;
 	grb.z_raw = report.gyro_z;
@@ -1865,6 +1868,9 @@ MPU6500::measure()
 
 	grb.temperature_raw = report.temp;
 	grb.temperature = _last_temperature;
+
+	/* TODO return unique hardware ID */
+	grb.device_id = 0;
 
 	_accel_reports->force(&arb);
 	_gyro_reports->force(&grb);

--- a/src/drivers/mpu6500/mpu6500.cpp
+++ b/src/drivers/mpu6500/mpu6500.cpp
@@ -1833,8 +1833,8 @@ MPU6500::measure()
 	arb.temperature_raw = report.temp;
 	arb.temperature = _last_temperature;
 
-	/* TODO return unique hardware ID */
-	arb.device_id = 0;
+	/* Return class instance as a surrogate device ID */
+	arb.device_id = _accel_class_instance;
 
 	grb.x_raw = report.gyro_x;
 	grb.y_raw = report.gyro_y;
@@ -1869,7 +1869,8 @@ MPU6500::measure()
 	grb.temperature_raw = report.temp;
 	grb.temperature = _last_temperature;
 
-	/* TODO return unique hardware ID */
+	/* Use class instance as a surrogate hardware ID */
+	grb.device_id = _gyro->_gyro_class_instance;
 	grb.device_id = 0;
 
 	_accel_reports->force(&arb);

--- a/src/drivers/mpu9250/mpu9250.cpp
+++ b/src/drivers/mpu9250/mpu9250.cpp
@@ -1424,6 +1424,9 @@ MPU9250::measure()
 	arb.temperature_raw = report.temp;
 	arb.temperature = _last_temperature;
 
+	/* TODO return unique hardware ID */
+	arb.device_id = 0;
+
 	grb.x_raw = report.gyro_x;
 	grb.y_raw = report.gyro_y;
 	grb.z_raw = report.gyro_z;
@@ -1456,6 +1459,9 @@ MPU9250::measure()
 
 	grb.temperature_raw = report.temp;
 	grb.temperature = _last_temperature;
+
+	/* TODO return unique hardware ID */
+	grb.device_id = 0;
 
 	_accel_reports->force(&arb);
 	_gyro_reports->force(&grb);

--- a/src/drivers/mpu9250/mpu9250.cpp
+++ b/src/drivers/mpu9250/mpu9250.cpp
@@ -1424,8 +1424,8 @@ MPU9250::measure()
 	arb.temperature_raw = report.temp;
 	arb.temperature = _last_temperature;
 
-	/* TODO return unique hardware ID */
-	arb.device_id = 0;
+	/* Return class instance as a surrogate device ID */
+	arb.device_id = _accel_class_instance;
 
 	grb.x_raw = report.gyro_x;
 	grb.y_raw = report.gyro_y;
@@ -1460,8 +1460,8 @@ MPU9250::measure()
 	grb.temperature_raw = report.temp;
 	grb.temperature = _last_temperature;
 
-	/* TODO return unique hardware ID */
-	grb.device_id = 0;
+	/* Use class instance as a surrogate hardware ID */
+	grb.device_id = _gyro->_gyro_class_instance;
 
 	_accel_reports->force(&arb);
 	_gyro_reports->force(&grb);

--- a/src/drivers/ms5611/ms5611.cpp
+++ b/src/drivers/ms5611/ms5611.cpp
@@ -762,6 +762,9 @@ MS5611::collect()
 		report.temperature = _TEMP / 100.0f;
 		report.pressure = P / 100.0f;		/* convert to millibar */
 
+		/* TODO get device ID for sensor */
+		report.device_id = 0;
+
 		/* altitude calculations based on http://www.kansasflyer.org/index.asp?nav=Avi&sec=Alti&tab=Theory&pg=1 */
 
 		/*

--- a/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
+++ b/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
@@ -909,6 +909,11 @@ void AttitudePositionEstimatorEKF::publishControlState()
 	_ctrl_state.pitch_rate = _LP_att_Q.apply(_ekf->dAngIMU.y / _ekf->dtIMU) - _ekf->states[11] / _ekf->dtIMUfilt;
 	_ctrl_state.yaw_rate = _LP_att_R.apply(_ekf->dAngIMU.z / _ekf->dtIMU) - _ekf->states[12] / _ekf->dtIMUfilt;
 
+	/* Gyro bias estimates */
+	_ctrl_state.roll_rate_bias = _ekf->states[10] / _ekf->dtIMUfilt;
+	_ctrl_state.pitch_rate_bias = _ekf->states[11] / _ekf->dtIMUfilt;
+	_ctrl_state.yaw_rate_bias = _ekf->states[12] / _ekf->dtIMUfilt;
+
 	/* Guard from bad data */
 	if (!PX4_ISFINITE(_ctrl_state.x_vel) ||
 	    !PX4_ISFINITE(_ctrl_state.y_vel) ||

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -492,10 +492,13 @@ void AttitudeEstimatorQ::task_main()
 
 			/* attitude rates for control state */
 			ctrl_state.roll_rate = _rates(0);
-
 			ctrl_state.pitch_rate = _rates(1);
-
 			ctrl_state.yaw_rate = _rates(2);
+
+			/* TODO get bias estimates from estimator */
+			ctrl_state.roll_rate_bias = 0.0f;
+			ctrl_state.pitch_rate_bias = 0.0f;
+			ctrl_state.yaw_rate_bias = 0.0f;
 
 			ctrl_state.airspeed_valid = false;
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -711,6 +711,9 @@ void Ekf2::task_main()
 				ctrl_state.roll_rate = _lp_roll_rate.apply(gyro_rad[0]);
 				ctrl_state.pitch_rate = _lp_pitch_rate.apply(gyro_rad[1]);
 				ctrl_state.yaw_rate = _lp_yaw_rate.apply(gyro_rad[2]);
+				ctrl_state.roll_rate_bias = gyro_bias[0];
+				ctrl_state.pitch_rate_bias = gyro_bias[1];
+				ctrl_state.yaw_rate_bias = gyro_bias[2];
 
 				// Velocity in body frame
 				Vector3f v_n(velocity);

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1802,6 +1802,9 @@ MavlinkReceiver::handle_message_hil_sensor(mavlink_message_t *msg)
 		baro.altitude = imu.pressure_alt;
 		baro.temperature = imu.temperature;
 
+		/* TODO get device ID for sensor */
+		baro.device_id = 0;
+
 		if (_baro_pub == nullptr) {
 			_baro_pub = orb_advertise(ORB_ID(sensor_baro), &baro);
 

--- a/src/modules/sensors/CMakeLists.txt
+++ b/src/modules/sensors/CMakeLists.txt
@@ -43,6 +43,7 @@ px4_add_module(
 		sensors.cpp
 		sensors_init.cpp
 		parameters.cpp
+		temperature_compensation.cpp
 
 	DEPENDS
 		platforms__common

--- a/src/modules/sensors/temp_comp_params_accel.c
+++ b/src/modules/sensors/temp_comp_params_accel.c
@@ -1,0 +1,454 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file temp_comp_params_accel.c
+ *
+ * Parameters required for temperature compensation of rate Accelerometers.
+ *
+ * @author Paul Riseborough <gncsolns@gmail.com>
+ */
+
+/**
+ * Set to 1 to enable thermal compensation for accelerometer sensors. Set to 0 to disable.
+ *
+ * @group Sensor Thermal Compensation
+ * @min 0
+ * @max 1
+ */
+PARAM_DEFINE_INT32(TC_A_ENABLE, 0);
+
+/* Accelerometer 0 */
+
+/**
+ * ID of Accelerometer that the calibration is for.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_INT32(TC_A0_ID, 0);
+
+/**
+ * Accelerometer offset temperature ^3 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A0_X3_0, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^3 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A0_X3_1, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^3 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A0_X3_2, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^2 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A0_X2_0, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^2 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A0_X2_1, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^2 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A0_X2_2, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^1 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A0_X1_0, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^1 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A0_X1_1, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^1 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A0_X1_2, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^0 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A0_X0_0, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^0 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A0_X0_1, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^0 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A0_X0_2, 0.0f);
+
+/**
+ * Accelerometer scale factor - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A0_SCL_0, 1.0f);
+
+/**
+ * Accelerometer scale factor - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A0_SCL_1, 1.0f);
+
+/**
+ * Accelerometer scale factor - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A0_SCL_2, 1.0f);
+
+/**
+ * Accelerometer calibration reference temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A0_TREF, 25.0f);
+
+/**
+ * Accelerometer calibration minimum temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A0_TMIN, 0.0f);
+
+/**
+ * Accelerometer calibration maximum temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A0_TMAX, 100.0f);
+
+/* Accelerometer 1 */
+
+/**
+ * ID of Accelerometer that the calibration is for.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_INT32(TC_A1_ID, 0);
+
+/**
+ * Accelerometer offset temperature ^3 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A1_X3_0, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^3 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A1_X3_1, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^3 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A1_X3_2, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^2 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A1_X2_0, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^2 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A1_X2_1, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^2 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A1_X2_2, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^1 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A1_X1_0, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^1 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A1_X1_1, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^1 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A1_X1_2, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^0 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A1_X0_0, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^0 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A1_X0_1, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^0 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A1_X0_2, 0.0f);
+
+/**
+ * Accelerometer scale factor - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A1_SCL_0, 1.0f);
+
+/**
+ * Accelerometer scale factor - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A1_SCL_1, 1.0f);
+
+/**
+ * Accelerometer scale factor - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A1_SCL_2, 1.0f);
+
+/**
+ * Accelerometer calibration reference temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A1_TREF, 25.0f);
+
+/**
+ * Accelerometer calibration minimum temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A1_TMIN, 0.0f);
+
+/**
+ * Accelerometer calibration maximum temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A1_TMAX, 100.0f);
+
+/* Accelerometer 2 */
+
+/**
+ * ID of Accelerometer that the calibration is for.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_INT32(TC_A2_ID, 0);
+
+/**
+ * Accelerometer offset temperature ^3 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A2_X3_0, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^3 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A2_X3_1, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^3 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A2_X3_2, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^2 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A2_X2_0, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^2 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A2_X2_1, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^2 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A2_X2_2, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^1 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A2_X1_0, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^1 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A2_X1_1, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^1 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A2_X1_2, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^0 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A2_X0_0, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^0 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A2_X0_1, 0.0f);
+
+/**
+ * Accelerometer offset temperature ^0 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A2_X0_2, 0.0f);
+
+/**
+ * Accelerometer scale factor - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A2_SCL_0, 1.0f);
+
+/**
+ * Accelerometer scale factor - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A2_SCL_1, 1.0f);
+
+/**
+ * Accelerometer scale factor - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A2_SCL_2, 1.0f);
+
+/**
+ * Accelerometer calibration reference temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A2_TREF, 25.0f);
+
+/**
+ * Accelerometer calibration minimum temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A2_TMIN, 0.0f);
+
+/**
+ * Accelerometer calibration maximum temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_A2_TMAX, 100.0f);

--- a/src/modules/sensors/temp_comp_params_baro.c
+++ b/src/modules/sensors/temp_comp_params_baro.c
@@ -1,0 +1,286 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file temp_comp_params_baro.c
+ *
+ * Parameters required for temperature compensation of barometers.
+ *
+ * @author Paul Riseborough <gncsolns@gmail.com>
+ */
+
+/**
+ * Set to 1 to enable thermal compensation for barometric pressure sensors. Set to 0 to disable.
+ *
+ * @group Sensor Thermal Compensation
+ * @min 0
+ * @max 1
+ */
+PARAM_DEFINE_INT32(TC_B_ENABLE, 0);
+
+/* Barometer 0 */
+
+/**
+ * ID of Barometer that the calibration is for.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_INT32(TC_B0_ID, 0);
+
+/**
+ * Barometer offset temperature ^5 polynomial coefficient.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B0_X5, 0.0f);
+
+/**
+ * Barometer offset temperature ^4 polynomial coefficient.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B0_X4, 0.0f);
+
+/**
+ * Barometer offset temperature ^3 polynomial coefficient.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B0_X3, 0.0f);
+
+/**
+ * Barometer offset temperature ^2 polynomial coefficient.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B0_X2, 0.0f);
+
+/**
+ * Barometer offset temperature ^1 polynomial coefficients.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B0_X1, 0.0f);
+
+/**
+ * Barometer offset temperature ^0 polynomial coefficient.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B0_X0, 0.0f);
+
+/**
+ * Barometer scale factor - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B0_SCL, 1.0f);
+
+/**
+ * Barometer calibration reference temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B0_TREF, 40.0f);
+
+/**
+ * Barometer calibration minimum temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B0_TMIN, 5.0f);
+
+/**
+ * Barometer calibration maximum temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B0_TMAX, 75.0f);
+
+/* Barometer 1 */
+
+/**
+ * ID of Barometer that the calibration is for.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_INT32(TC_B1_ID, 0);
+
+/**
+ * Barometer offset temperature ^5 polynomial coefficient.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B1_X5, 0.0f);
+
+/**
+ * Barometer offset temperature ^4 polynomial coefficient.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B1_X4, 0.0f);
+
+/**
+ * Barometer offset temperature ^3 polynomial coefficient.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B1_X3, 0.0f);
+
+/**
+ * Barometer offset temperature ^2 polynomial coefficient.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B1_X2, 0.0f);
+
+/**
+ * Barometer offset temperature ^1 polynomial coefficients.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B1_X1, 0.0f);
+
+/**
+ * Barometer offset temperature ^0 polynomial coefficient.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B1_X0, 0.0f);
+
+/**
+ * Barometer scale factor - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B1_SCL, 1.0f);
+
+/**
+ * Barometer calibration reference temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B1_TREF, 40.0f);
+
+/**
+ * Barometer calibration minimum temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B1_TMIN, 5.0f);
+
+/**
+ * Barometer calibration maximum temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B1_TMAX, 75.0f);
+
+/* Barometer 2 */
+
+/**
+ * ID of Barometer that the calibration is for.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_INT32(TC_B2_ID, 0);
+
+/**
+ * Barometer offset temperature ^5 polynomial coefficient.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B2_X5, 0.0f);
+
+/**
+ * Barometer offset temperature ^4 polynomial coefficient.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B2_X4, 0.0f);
+
+/**
+ * Barometer offset temperature ^3 polynomial coefficient.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B2_X3, 0.0f);
+
+/**
+ * Barometer offset temperature ^2 polynomial coefficient.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B2_X2, 0.0f);
+
+/**
+ * Barometer offset temperature ^1 polynomial coefficients.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B2_X1, 0.0f);
+
+/**
+ * Barometer offset temperature ^0 polynomial coefficient.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B2_X0, 0.0f);
+
+/**
+ * Barometer scale factor - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B2_SCL, 1.0f);
+
+/**
+ * Barometer calibration reference temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B2_TREF, 40.0f);
+
+/**
+ * Barometer calibration minimum temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B2_TMIN, 5.0f);
+
+/**
+ * Barometer calibration maximum temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_B2_TMAX, 75.0f);

--- a/src/modules/sensors/temp_comp_params_gyro.c
+++ b/src/modules/sensors/temp_comp_params_gyro.c
@@ -1,0 +1,454 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file temp_comp_params_gyro.c
+ *
+ * Parameters required for temperature compensation of rate gyros.
+ *
+ * @author Paul Riseborough <gncsolns@gmail.com>
+ */
+
+/**
+ * Set to 1 to enable thermal compensation for rate gyro sensors. Set to 0 to disable.
+ *
+ * @group Sensor Thermal Compensation
+ * @min 0
+ * @max 1
+ */
+PARAM_DEFINE_INT32(TC_G_ENABLE, 0);
+
+/* Gyro 0 */
+
+/**
+ * ID of Gyro that the calibration is for.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_INT32(TC_G0_ID, 0);
+
+/**
+ * Gyro rate offset temperature ^3 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G0_X3_0, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^3 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G0_X3_1, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^3 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G0_X3_2, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^2 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G0_X2_0, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^2 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G0_X2_1, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^2 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G0_X2_2, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^1 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G0_X1_0, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^1 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G0_X1_1, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^1 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G0_X1_2, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^0 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G0_X0_0, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^0 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G0_X0_1, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^0 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G0_X0_2, 0.0f);
+
+/**
+ * Gyro scale factor - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G0_SCL_0, 1.0f);
+
+/**
+ * Gyro scale factor - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G0_SCL_1, 1.0f);
+
+/**
+ * Gyro scale factor - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G0_SCL_2, 1.0f);
+
+/**
+ * Gyro calibration reference temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G0_TREF, 25.0f);
+
+/**
+ * Gyro calibration minimum temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G0_TMIN, 0.0f);
+
+/**
+ * Gyro calibration maximum temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G0_TMAX, 100.0f);
+
+/* Gyro 1 */
+
+/**
+ * ID of Gyro that the calibration is for.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_INT32(TC_G1_ID, 0);
+
+/**
+ * Gyro rate offset temperature ^3 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G1_X3_0, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^3 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G1_X3_1, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^3 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G1_X3_2, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^2 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G1_X2_0, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^2 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G1_X2_1, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^2 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G1_X2_2, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^1 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G1_X1_0, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^1 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G1_X1_1, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^1 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G1_X1_2, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^0 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G1_X0_0, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^0 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G1_X0_1, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^0 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G1_X0_2, 0.0f);
+
+/**
+ * Gyro scale factor - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G1_SCL_0, 1.0f);
+
+/**
+ * Gyro scale factor - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G1_SCL_1, 1.0f);
+
+/**
+ * Gyro scale factor - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G1_SCL_2, 1.0f);
+
+/**
+ * Gyro calibration reference temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G1_TREF, 25.0f);
+
+/**
+ * Gyro calibration minimum temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G1_TMIN, 0.0f);
+
+/**
+ * Gyro calibration maximum temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G1_TMAX, 100.0f);
+
+/* Gyro 2 */
+
+/**
+ * ID of Gyro that the calibration is for.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_INT32(TC_G2_ID, 0);
+
+/**
+ * Gyro rate offset temperature ^3 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G2_X3_0, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^3 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G2_X3_1, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^3 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G2_X3_2, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^2 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G2_X2_0, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^2 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G2_X2_1, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^2 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G2_X2_2, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^1 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G2_X1_0, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^1 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G2_X1_1, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^1 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G2_X1_2, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^0 polynomial coefficient - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G2_X0_0, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^0 polynomial coefficient - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G2_X0_1, 0.0f);
+
+/**
+ * Gyro rate offset temperature ^0 polynomial coefficient - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G2_X0_2, 0.0f);
+
+/**
+ * Gyro scale factor - X axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G2_SCL_0, 1.0f);
+
+/**
+ * Gyro scale factor - Y axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G2_SCL_1, 1.0f);
+
+/**
+ * Gyro scale factor - Z axis.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G2_SCL_2, 1.0f);
+
+/**
+ * Gyro calibration reference temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G2_TREF, 25.0f);
+
+/**
+ * Gyro calibration minimum temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G2_TMIN, 0.0f);
+
+/**
+ * Gyro calibration maximum temperature.
+ *
+ * @group Sensor Thermal Compensation
+ */
+PARAM_DEFINE_FLOAT(TC_G2_TMAX, 100.0f);

--- a/src/modules/sensors/temperature_compensation.cpp
+++ b/src/modules/sensors/temperature_compensation.cpp
@@ -181,7 +181,7 @@ int update_parameters(const ParameterHandles &parameter_handles, Parameters &par
 	return ret;
 }
 
-bool correct_data_1D(struct SENSOR_CAL_DATA_1D &coef, const float &measured_temp, float &offset)
+bool calc_thermal_offsets_1D(struct SENSOR_CAL_DATA_1D &coef, const float &measured_temp, float &offset)
 {
 	bool ret = true;
 
@@ -204,8 +204,15 @@ bool correct_data_1D(struct SENSOR_CAL_DATA_1D &coef, const float &measured_temp
 	delta_temp -= coef.ref_temp;
 
 	// calulate the offset
-	offset = coef.x0 + coef.x1 * delta_temp + coef.x2 * delta_temp * delta_temp + coef.x3 * delta_temp * delta_temp *
-		 delta_temp;
+	offset = coef.x0 + coef.x1 * delta_temp;
+	delta_temp *= delta_temp;
+	offset += coef.x2 * delta_temp;
+	delta_temp *= delta_temp;
+	offset += coef.x3 * delta_temp;
+	delta_temp *= delta_temp;
+	offset += coef.x4 * delta_temp;
+	delta_temp *= delta_temp;
+	offset += coef.x5 * delta_temp;
 
 	return ret;
 

--- a/src/modules/sensors/temperature_compensation.cpp
+++ b/src/modules/sensors/temperature_compensation.cpp
@@ -1,0 +1,249 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file temperature_compensation.cpp
+ *
+ * Sensors temperature compensation methods
+ *
+ * @author Paul Riseborough <gncsolns@gmail.com>
+ */
+
+#include "temperature_compensation.h"
+#include <systemlib/param/param.h>
+#include <stdio.h>
+#include <px4_defines.h>
+
+namespace sensors_temp_comp
+{
+
+int initialize_parameter_handles(ParameterHandles &parameter_handles)
+{
+	char nbuf[16];
+
+	/* rate gyro calibration parameters */
+	sprintf(nbuf, "TC_G_ENABLE");
+	parameter_handles.gyro_tc_enable = param_find(nbuf);
+
+	for (unsigned j = 0; j < 3; j++) {
+		sprintf(nbuf, "TC_G%d_ID", j);
+		parameter_handles.gyro_cal_handles[j].ID = param_find(nbuf);
+
+		for (unsigned i = 0; i < 3; i++) {
+			sprintf(nbuf, "TC_G%d_X3_%d", j, i);
+			parameter_handles.gyro_cal_handles[j].x3[i] = param_find(nbuf);
+			sprintf(nbuf, "TC_G%d_X2_%d", j, i);
+			parameter_handles.gyro_cal_handles[j].x2[i] = param_find(nbuf);
+			sprintf(nbuf, "TC_G%d_X1_%d", j, i);
+			parameter_handles.gyro_cal_handles[j].x1[i] = param_find(nbuf);
+			sprintf(nbuf, "TC_G%d_X0_%d", j, i);
+			parameter_handles.gyro_cal_handles[j].x0[i] = param_find(nbuf);
+			sprintf(nbuf, "TC_G%d_SCL_%d", j, i);
+			parameter_handles.gyro_cal_handles[j].scale[i] = param_find(nbuf);
+		}
+
+		sprintf(nbuf, "TC_G%d_TREF", j);
+		parameter_handles.gyro_cal_handles[j].ref_temp = param_find(nbuf);
+		sprintf(nbuf, "TC_G%d_TMIN", j);
+		parameter_handles.gyro_cal_handles[j].min_temp = param_find(nbuf);
+		sprintf(nbuf, "TC_G%d_TMAX", j);
+		parameter_handles.gyro_cal_handles[j].max_temp = param_find(nbuf);
+	}
+
+	/* accelerometer calibration parameters */
+	sprintf(nbuf, "TC_A_ENABLE");
+	parameter_handles.accel_tc_enable = param_find(nbuf);
+
+	for (unsigned j = 0; j < 3; j++) {
+		sprintf(nbuf, "TC_A%d_ID", j);
+		parameter_handles.accel_cal_handles[j].ID = param_find(nbuf);
+
+		for (unsigned i = 0; i < 3; i++) {
+			sprintf(nbuf, "TC_A%d_X3_%d", j, i);
+			parameter_handles.accel_cal_handles[j].x3[i] = param_find(nbuf);
+			sprintf(nbuf, "TC_A%d_X2_%d", j, i);
+			parameter_handles.accel_cal_handles[j].x2[i] = param_find(nbuf);
+			sprintf(nbuf, "TC_A%d_X1_%d", j, i);
+			parameter_handles.accel_cal_handles[j].x1[i] = param_find(nbuf);
+			sprintf(nbuf, "TC_A%d_X0_%d", j, i);
+			parameter_handles.accel_cal_handles[j].x0[i] = param_find(nbuf);
+			sprintf(nbuf, "TC_A%d_SCL_%d", j, i);
+			parameter_handles.accel_cal_handles[j].scale[i] = param_find(nbuf);
+		}
+
+		sprintf(nbuf, "TC_A%d_TREF", j);
+		parameter_handles.accel_cal_handles[j].ref_temp = param_find(nbuf);
+		sprintf(nbuf, "TC_A%d_TMIN", j);
+		parameter_handles.accel_cal_handles[j].min_temp = param_find(nbuf);
+		sprintf(nbuf, "TC_A%d_TMAX", j);
+		parameter_handles.accel_cal_handles[j].max_temp = param_find(nbuf);
+	}
+
+	return PX4_OK;
+}
+
+int update_parameters(const ParameterHandles &parameter_handles, Parameters &parameters)
+{
+	int ret = PX4_OK;
+
+	/* rate gyro calibration parameters */
+	param_get(parameter_handles.gyro_tc_enable, &(parameters.gyro_tc_enable));
+
+	for (unsigned j = 0; j < 3; j++) {
+		if (param_get(parameter_handles.gyro_cal_handles[j].ID, &(parameters.gyro_cal_data[j].ID)) == PX4_OK) {
+			param_get(parameter_handles.gyro_cal_handles[j].ref_temp, &(parameters.gyro_cal_data[j].ref_temp));
+			param_get(parameter_handles.gyro_cal_handles[j].min_temp, &(parameters.gyro_cal_data[j].min_temp));
+			param_get(parameter_handles.gyro_cal_handles[j].min_temp, &(parameters.gyro_cal_data[j].min_temp));
+
+			for (unsigned int i = 0; i < 3; i++) {
+				param_get(parameter_handles.gyro_cal_handles[j].x3[i], &(parameters.gyro_cal_data[j].x3[i]));
+				param_get(parameter_handles.gyro_cal_handles[j].x2[i], &(parameters.gyro_cal_data[j].x2[i]));
+				param_get(parameter_handles.gyro_cal_handles[j].x1[i], &(parameters.gyro_cal_data[j].x1[i]));
+				param_get(parameter_handles.gyro_cal_handles[j].x0[i], &(parameters.gyro_cal_data[j].x0[i]));
+				param_get(parameter_handles.gyro_cal_handles[j].scale[i], &(parameters.gyro_cal_data[j].scale[i]));
+			}
+
+		} else {
+			// Set all cal values to zero and scale factor to unity
+			memset(&parameters.gyro_cal_data[j], 0, sizeof(parameters.gyro_cal_data[j]));
+
+			// Set the scale factor to unity
+			for (unsigned int i = 0; i < 3; i++) {
+				parameters.gyro_cal_data[j].scale[i] = 1.0f;
+			}
+
+			PX4_WARN("FAIL GYRO %d CAL PARAM LOAD - USING DEFAULTS", j);
+			ret = PX4_ERROR;
+		}
+	}
+
+	/* accelerometer calibration parameters */
+	param_get(parameter_handles.accel_tc_enable, &(parameters.accel_tc_enable));
+
+	for (unsigned j = 0; j < 3; j++) {
+		if (param_get(parameter_handles.accel_cal_handles[j].ID, &(parameters.accel_cal_data[j].ID)) == PX4_OK) {
+			param_get(parameter_handles.accel_cal_handles[j].ref_temp, &(parameters.accel_cal_data[j].ref_temp));
+			param_get(parameter_handles.accel_cal_handles[j].min_temp, &(parameters.accel_cal_data[j].min_temp));
+			param_get(parameter_handles.accel_cal_handles[j].min_temp, &(parameters.accel_cal_data[j].min_temp));
+
+			for (unsigned int i = 0; i < 3; i++) {
+				param_get(parameter_handles.accel_cal_handles[j].x3[i], &(parameters.accel_cal_data[j].x3[i]));
+				param_get(parameter_handles.accel_cal_handles[j].x2[i], &(parameters.accel_cal_data[j].x2[i]));
+				param_get(parameter_handles.accel_cal_handles[j].x1[i], &(parameters.accel_cal_data[j].x1[i]));
+				param_get(parameter_handles.accel_cal_handles[j].x0[i], &(parameters.accel_cal_data[j].x0[i]));
+				param_get(parameter_handles.accel_cal_handles[j].scale[i], &(parameters.accel_cal_data[j].scale[i]));
+			}
+
+		} else {
+			// Set all cal values to zero and scale factor to unity
+			memset(&parameters.accel_cal_data[j], 0, sizeof(parameters.accel_cal_data[j]));
+
+			// Set the scale factor to unity
+			for (unsigned int i = 0; i < 3; i++) {
+				parameters.accel_cal_data[j].scale[i] = 1.0f;
+			}
+
+			PX4_WARN("FAIL ACCEL %d CAL PARAM LOAD - USING DEFAULTS", j);
+			ret = PX4_ERROR;
+		}
+	}
+
+	return ret;
+}
+
+bool correct_data_1D(struct SENSOR_CAL_DATA_1D &coef, const float &measured_temp, float &offset)
+{
+	bool ret = true;
+
+	// clip the measured temperature to remain within the calibration range
+	float delta_temp;
+
+	if (measured_temp > coef.max_temp) {
+		delta_temp = coef.max_temp;
+		ret = false;
+
+	} else if (measured_temp < coef.min_temp) {
+		delta_temp = coef.min_temp;
+		ret = false;
+
+	} else {
+		delta_temp = measured_temp;
+
+	}
+
+	delta_temp -= coef.ref_temp;
+
+	// calulate the offset
+	offset = coef.x0 + coef.x1 * delta_temp + coef.x2 * delta_temp * delta_temp + coef.x3 * delta_temp * delta_temp *
+		 delta_temp;
+
+	return ret;
+
+}
+
+bool calc_thermal_offsets_3D(struct SENSOR_CAL_DATA_3D &coef, const float &measured_temp, float offset[])
+{
+	bool ret = true;
+
+	// clip the measured temperature to remain within the calibration range
+	float delta_temp;
+
+	if (measured_temp > coef.max_temp) {
+		delta_temp = coef.max_temp;
+		ret = false;
+
+	} else if (measured_temp < coef.min_temp) {
+		delta_temp = coef.min_temp;
+		ret = false;
+
+	} else {
+		delta_temp = measured_temp;
+
+	}
+
+	delta_temp -= coef.ref_temp;
+
+	// calulate the offsets
+	float delta_temp_2 = delta_temp * delta_temp;
+	float delta_temp_3 = delta_temp_2 * delta_temp;
+
+	for (uint8_t i = 0; i < 3; i++) {
+		offset[i] = coef.x0[i] + coef.x1[i] * delta_temp + coef.x2[i] * delta_temp_2 + coef.x3[i] * delta_temp_3;
+
+	}
+
+	return ret;
+
+}
+
+}

--- a/src/modules/sensors/temperature_compensation.h
+++ b/src/modules/sensors/temperature_compensation.h
@@ -1,0 +1,176 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file temperature_compensation.h
+ *
+ * Sensor correction methods
+ *
+ * @author Paul Riseborough <gncsolns@gmail.com>
+ */
+
+#include <systemlib/param/param.h>
+#include <mathlib/mathlib.h>
+
+/* These structs struct define the parameters used by the temperature compensation algorithm
+
+Input:
+
+measured_temp : temperature measured at the sensor (deg C)
+raw_value : reading from the sensor before compensation
+corrected_value : reading from the sensor after compensation for errors
+
+Compute:
+
+delta_temp = measured_temp - ref_temp
+offset = x3 * delta_temp^3 + x2 * delta_temp^2 + x1 * delta_temp + x0
+corrected_value = raw_value * scale + offset
+
+*/
+namespace sensors_temp_comp
+{
+
+struct SENSOR_CAL_DATA_1D {
+	int ID;			/**< sensor device ID*/
+	float x3;		/**< x^3 term of polynomial */
+	float x2;		/**< x^2 term of polynomial */
+	float x1;		/**< x^1 term of polynomial */
+	float x0;		/**< x^0 / offset term of polynomial */
+	float scale;		/**< scale factor correction */
+	float ref_temp;		/**< reference temperature used by the curve-fit */
+	float min_temp;		/**< minimum temperature with valid compensation data */
+	float max_temp;		/**< maximum temperature with valid compensation data */
+};
+
+struct SENSOR_CAL_DATA_3D {
+	int ID;			/**< sensor device ID*/
+	float x3[3];		/**< x^3 term of polynomial */
+	float x2[3];		/**< x^2 term of polynomial */
+	float x1[3];		/**< x^1 term of polynomial */
+	float x0[3];		/**< x^0 / offset term of polynomial */
+	float scale[3];		/**< scale factor correction */
+	float ref_temp;		/**< reference temperature used by the curve-fit */
+	float min_temp;		/**< minimum temperature with valid compensation data */
+	float max_temp;		/**< maximum temperature with valid compensation data */
+};
+
+struct SENSOR_CAL_HANDLES_1D {
+	param_t ID;
+	param_t x3;
+	param_t x2;
+	param_t x1;
+	param_t x0;
+	param_t scale;
+	param_t ref_temp;
+	param_t min_temp;
+	param_t max_temp;
+};
+
+struct SENSOR_CAL_HANDLES_3D {
+	param_t ID;
+	param_t x3[3];
+	param_t x2[3];
+	param_t x1[3];
+	param_t x0[3];
+	param_t scale[3];
+	param_t ref_temp;
+	param_t min_temp;
+	param_t max_temp;
+};
+
+struct Parameters {
+	int gyro_tc_enable;
+	SENSOR_CAL_DATA_3D gyro_cal_data[3];
+	int accel_tc_enable;
+	SENSOR_CAL_DATA_3D accel_cal_data[3];
+};
+
+struct ParameterHandles {
+	param_t gyro_tc_enable;
+	SENSOR_CAL_HANDLES_3D gyro_cal_handles[3];
+	param_t accel_tc_enable;
+	SENSOR_CAL_HANDLES_3D accel_cal_handles[3];
+};
+
+/**
+ * initialize ParameterHandles struct
+ * @return 0 on succes, <0 on error
+ */
+int initialize_parameter_handles(ParameterHandles &parameter_handles);
+
+
+/**
+ * Read out the parameters using the handles into the parameters struct.
+ * @return 0 on succes, <0 on error
+ */
+int update_parameters(const ParameterHandles &parameter_handles, Parameters &parameters);
+
+/*
+
+Calculate the offset required to compensate the sensor for temperature effects
+If the measured temperature is outside the calibration range, clip the temperature to remain within the range and return false.
+If the measured temperature is within the calibration range, return true.
+
+Arguments:
+
+coef : reference to struct containing calibration coefficients
+measured_temp : temperature measured at the sensor (deg C)
+offset : reference to sensor offset
+
+Returns:
+
+Boolean true if the measured temperature is inside the valid range for the compensation
+
+*/
+bool correct_data_1D(SENSOR_CAL_DATA_1D &coef, const float &measured_temp, float &offset);
+
+/*
+
+Calculate the offsets required to compensate the sensor for temperature effects
+If the measured temperature is outside the calibration range, clip the temperature to remain within the range and return false.
+If the measured temperature is within the calibration range, return true.
+
+Arguments:
+
+coef : reference to struct containing calibration coefficients
+measured_temp : temperature measured at the sensor (deg C)
+offset : reference to sensor offset - array of 3
+
+Returns:
+
+Boolean true if the measured temperature is inside the valid range for the compensation
+
+*/
+bool calc_thermal_offsets_3D(SENSOR_CAL_DATA_3D &coef, const float &measured_temp, float offset[]);
+
+}

--- a/src/modules/sensors/temperature_compensation.h
+++ b/src/modules/sensors/temperature_compensation.h
@@ -134,7 +134,7 @@ struct Parameters {
 	int accel_tc_enable;
 	SENSOR_CAL_DATA_3D accel_cal_data[3];
 	int baro_tc_enable;
-	SENSOR_CAL_DATA_1D baro_cal_data;
+	SENSOR_CAL_DATA_1D baro_cal_data[3];
 };
 
 // create a struct containing the handles required to access all calibration parameters
@@ -144,7 +144,7 @@ struct ParameterHandles {
 	param_t accel_tc_enable;
 	SENSOR_CAL_HANDLES_3D accel_cal_handles[3];
 	param_t baro_tc_enable;
-	SENSOR_CAL_HANDLES_1D baro_cal_handles;
+	SENSOR_CAL_HANDLES_1D baro_cal_handles[3];
 };
 
 /**

--- a/src/modules/sensors/voted_sensors_update.h
+++ b/src/modules/sensors/voted_sensors_update.h
@@ -54,9 +54,11 @@
 
 #include <uORB/topics/sensor_combined.h>
 #include <uORB/topics/sensor_preflight.h>
+#include <uORB/topics/sensor_correction.h>
 
 #include <DevMgr.hpp>
 
+#include "temperature_compensation.h"
 
 namespace sensors
 {
@@ -260,6 +262,16 @@ private:
 
 	float _accel_diff[3][2];	/**< filtered accel differences between IMU units (m/s/s) */
 	float _gyro_diff[3][2];		/**< filtered gyro differences between IMU uinits (rad/s) */
+
+	/* sensor thermal compensation */
+	sensors_temp_comp::Parameters	_thermal_correction_param; /**< copy of the thermal correction parameters*/
+	sensors_temp_comp::ParameterHandles _thermal_correction_param_handles; /**< handles for the thermal correction parameters */
+	struct sensor_correction_s _corrections = {}; /**< struct containing the sensor corrections to be published to the uORB*/
+	orb_advert_t _sensor_correction_pub; /**< handle to the sensor correction uORB topic */
+	float _accel_offset[SENSOR_COUNT_MAX][3]; /**< offsets to be added to the raw accel data after scale factor correction */
+	float _accel_scale[SENSOR_COUNT_MAX][3]; /**< scale factor corrections to be applied to the raw accel data before offsets are added */
+	float _gyro_offset[SENSOR_COUNT_MAX][3]; /**< offsets to be added to the raw angular rate data after scale factor correction */
+	float _gyro_scale[SENSOR_COUNT_MAX][3]; /**< scale factor corrections to be applied to the raw angular rate data before offsets are added */
 
 };
 

--- a/src/modules/sensors/voted_sensors_update.h
+++ b/src/modules/sensors/voted_sensors_update.h
@@ -265,13 +265,19 @@ private:
 
 	/* sensor thermal compensation */
 	sensors_temp_comp::Parameters	_thermal_correction_param; /**< copy of the thermal correction parameters*/
-	sensors_temp_comp::ParameterHandles _thermal_correction_param_handles; /**< handles for the thermal correction parameters */
+	sensors_temp_comp::ParameterHandles
+	_thermal_correction_param_handles; /**< handles for the thermal correction parameters */
 	struct sensor_correction_s _corrections = {}; /**< struct containing the sensor corrections to be published to the uORB*/
 	orb_advert_t _sensor_correction_pub; /**< handle to the sensor correction uORB topic */
 	float _accel_offset[SENSOR_COUNT_MAX][3]; /**< offsets to be added to the raw accel data after scale factor correction */
 	float _accel_scale[SENSOR_COUNT_MAX][3]; /**< scale factor corrections to be applied to the raw accel data before offsets are added */
 	float _gyro_offset[SENSOR_COUNT_MAX][3]; /**< offsets to be added to the raw angular rate data after scale factor correction */
 	float _gyro_scale[SENSOR_COUNT_MAX][3]; /**< scale factor corrections to be applied to the raw angular rate data before offsets are added */
+	float _baro_offset[SENSOR_COUNT_MAX]; /**< offsets to be added to the raw baro pressure data after scale factor correction */
+	float _baro_scale[SENSOR_COUNT_MAX]; /**< scale factor corrections to be applied to the raw barp pressure data before offsets are added */
+
+	/* altitude conversion calibration */
+	unsigned		_msl_pressure;	/* in Pa */
 
 };
 

--- a/src/modules/uavcan/sensors/baro.cpp
+++ b/src/modules/uavcan/sensors/baro.cpp
@@ -165,6 +165,9 @@ void UavcanBarometerBridge::air_pressure_sub_cb(const
 	report.pressure    = msg.static_pressure / 100.0F;  // Convert to millibar
 	report.error_count = 0;
 
+	/* TODO get device ID for sensor */
+	report.device_id = 0;
+
 	/*
 	 * Altitude computation
 	 * Refer to the MS5611 driver for details

--- a/src/platforms/posix/drivers/barosim/baro.cpp
+++ b/src/platforms/posix/drivers/barosim/baro.cpp
@@ -680,6 +680,9 @@ BAROSIM::collect()
 		report.altitude = raw_baro.altitude;
 		report.temperature = raw_baro.temperature;
 
+		/* TODO get device ID for sensor */
+		report.device_id = 0;
+
 		/* publish it */
 		if (!(m_pub_blocked)) {
 			if (_baro_topic != nullptr) {

--- a/src/platforms/posix/drivers/df_bmp280_wrapper/df_bmp280_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_bmp280_wrapper/df_bmp280_wrapper.cpp
@@ -155,8 +155,10 @@ int DfBmp280Wrapper::_publish(struct baro_sensor_data &data)
 
 	baro_report.pressure = data.pressure_pa;
 	baro_report.temperature = data.temperature_c;
-
 	// TODO: verify this, it's just copied from the MS5611 driver.
+
+	/* TODO get device ID for sensor */
+	baro_report.device_id = 0;
 
 	// Constant for now
 	const double MSL_PRESSURE_KPA = 101325.0 / 1000.0;

--- a/src/platforms/posix/drivers/df_lsm9ds1_wrapper/df_lsm9ds1_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_lsm9ds1_wrapper/df_lsm9ds1_wrapper.cpp
@@ -689,9 +689,15 @@ int DfLsm9ds1Wrapper::_publish(struct imu_sensor_data &data)
 	gyro_report.y_integral = gyro_val_integ(1);
 	gyro_report.z_integral = gyro_val_integ(2);
 
+	/* TODO return unique hardware ID */
+	gyro_report.device_id = 0;
+
 	accel_report.x_integral = accel_val_integ(0);
 	accel_report.y_integral = accel_val_integ(1);
 	accel_report.z_integral = accel_val_integ(2);
+
+	/* TODO return unique hardware ID */
+	accel_report.device_id = 0;
 
 	// TODO: when is this ever blocked?
 	if (!(m_pub_blocked)) {

--- a/src/platforms/posix/drivers/df_mpu6050_wrapper/df_mpu6050_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_mpu6050_wrapper/df_mpu6050_wrapper.cpp
@@ -531,9 +531,15 @@ int DfMPU6050Wrapper::_publish(struct imu_sensor_data &data)
 	gyro_report.y_integral = gyro_val_integ(1);
 	gyro_report.z_integral = gyro_val_integ(2);
 
+	/* TODO return unique hardware ID */
+	gyro_report.device_id = 0;
+
 	accel_report.x_integral = accel_val_integ(0);
 	accel_report.y_integral = accel_val_integ(1);
 	accel_report.z_integral = accel_val_integ(2);
+
+	/* TODO return unique hardware ID */
+	accel_report.device_id = 0;
 
 	// TODO: when is this ever blocked?
 	if (!(m_pub_blocked)) {

--- a/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
@@ -708,9 +708,15 @@ int DfMpu9250Wrapper::_publish(struct imu_sensor_data &data)
 	gyro_report.y_integral = gyro_val_integ(1);
 	gyro_report.z_integral = gyro_val_integ(2);
 
+	/* TODO return unique hardware ID */
+	gyro_report.device_id = 0;
+
 	accel_report.x_integral = accel_val_integ(0);
 	accel_report.y_integral = accel_val_integ(1);
 	accel_report.z_integral = accel_val_integ(2);
+
+	/* TODO return unique hardware ID */
+	accel_report.device_id = 0;
 
 	// TODO: when is this ever blocked?
 	if (!(m_pub_blocked)) {

--- a/src/platforms/posix/drivers/df_ms5607_wrapper/df_ms5607_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_ms5607_wrapper/df_ms5607_wrapper.cpp
@@ -156,6 +156,9 @@ int DfMS5607Wrapper::_publish(struct baro_sensor_data &data)
 
 	// TODO: verify this, it's just copied from the MS5611 driver.
 
+	/* TODO get device ID for sensor */
+	baro_report.device_id = 0;
+
 	// Constant for now
 	const double MSL_PRESSURE_KPA = 101325.0 / 1000.0;
 

--- a/src/platforms/posix/drivers/df_ms5611_wrapper/df_ms5611_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_ms5611_wrapper/df_ms5611_wrapper.cpp
@@ -156,6 +156,9 @@ int DfMS5611Wrapper::_publish(struct baro_sensor_data &data)
 
 	// TODO: verify this, it's just copied from the MS5611 driver.
 
+	/* TODO get device ID for sensor */
+	baro_report.device_id = 0;
+
 	// Constant for now
 	const double MSL_PRESSURE_KPA = 101325.0 / 1000.0;
 

--- a/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
+++ b/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
@@ -1107,6 +1107,9 @@ GYROSIM::_measure()
 	arb.y_integral = aval_integrated(1);
 	arb.z_integral = aval_integrated(2);
 
+	/* TODO return unique hardware ID */
+	arb.device_id = 0;
+
 	grb.x_raw = (int16_t)(mpu_report.gyro_x / _gyro_range_scale);
 	grb.y_raw = (int16_t)(mpu_report.gyro_y / _gyro_range_scale);
 	grb.z_raw = (int16_t)(mpu_report.gyro_z / _gyro_range_scale);
@@ -1128,6 +1131,9 @@ GYROSIM::_measure()
 	grb.x_integral = gval_integrated(0);
 	grb.y_integral = gval_integrated(1);
 	grb.z_integral = gval_integrated(2);
+
+	/* TODO return unique hardware ID */
+	grb.device_id = 0;
 
 	_accel_reports->force(&arb);
 	_gyro_reports->force(&grb);

--- a/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
+++ b/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
@@ -1107,8 +1107,8 @@ GYROSIM::_measure()
 	arb.y_integral = aval_integrated(1);
 	arb.z_integral = aval_integrated(2);
 
-	/* TODO return unique hardware ID */
-	arb.device_id = 0;
+	/* Return orb instance as a surrogate device ID */
+	arb.device_id = _accel_orb_class_instance;
 
 	grb.x_raw = (int16_t)(mpu_report.gyro_x / _gyro_range_scale);
 	grb.y_raw = (int16_t)(mpu_report.gyro_y / _gyro_range_scale);
@@ -1132,8 +1132,8 @@ GYROSIM::_measure()
 	grb.y_integral = gval_integrated(1);
 	grb.z_integral = gval_integrated(2);
 
-	/* TODO return unique hardware ID */
-	grb.device_id = 0;
+	/* Return orb instance as a surrogate device ID */
+	grb.device_id = _gyro->_gyro_orb_class_instance;
 
 	_accel_reports->force(&arb);
 	_gyro_reports->force(&grb);


### PR DESCRIPTION
Draft implementation for comment and review.

See https://docs.google.com/document/d/1GHzjsPTfSUAxYGPNlXSL7FYkxFcq76jTfsaquc57Rww for previous discussion.

A separate PR's will be submitted for the on-board logging and calibration function.

TODO:

Assignment of unique ID's to baro sensors to enable multiple Baros to be used with calibration.
Better method of assigning unique ID's to gyro and accel sensors.
