### PR TITLE
MindPX: Fix for hmc5883 rotation

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -249,7 +249,7 @@ then
 	fi
 
 	# Internal I2C bus
-	if hmc5883 -C -T -I -R 8 start
+	if hmc5883 -C -T -I -R 12 start
 	then
 	fi
 


### PR DESCRIPTION
Make this change according to #5991--hmc5883: fix MAGIOCGEXTERNAL ioctl for non fmuv1 boards