### PR TITLE
Modifed the PPM_MIN_CHANNELS check so it accepts a minimum of 5 channels.

### DIFF
--- a/src/drivers/stm32/drv_hrt.c
+++ b/src/drivers/stm32/drv_hrt.c
@@ -462,7 +462,7 @@ hrt_ppm_decode(uint32_t status)
 		goto error;
 	}
 
-	/* how long since the last edge? - this handles counter wrapping implicitely. */
+	/* how long since the last edge? - this handles counter wrapping implicitly. */
 	width = count - ppm.last_edge;
 
 #if PPM_DEBUG
@@ -506,7 +506,7 @@ hrt_ppm_decode(uint32_t status)
 
 		} else {
 			/* frame channel count matches expected, let's use it */
-			if (ppm.next_channel > PPM_MIN_CHANNELS) {
+			if (ppm.next_channel >= PPM_MIN_CHANNELS) {
 				for (i = 0; i < ppm.next_channel; i++) {
 					ppm_buffer[i] = ppm_temp_buffer[i];
 				}


### PR DESCRIPTION
It seems that was the initial intention in the code. 

I actually did this change for myself since I have a hacked up reciever that has 5 PPM channels only. It refuses to work with as many channels, it wants at least 6 although the code seems to be intended for 5 channels, so I modified a check in /src/drivers/stm32/drv_hrt.c and now it works. Does this seem ok?

This is my first open-source contribution so I'm sorry if I broke some convention or if this is a silly PR. I'd love some feedback though.