### PR TITLE
simulator: Do not kill every process with string 'px4' in the name

### DIFF
--- a/Tools/sitl_multiple_run.sh
+++ b/Tools/sitl_multiple_run.sh
@@ -20,7 +20,8 @@ rc_script="posix-configs/SITL/init/ekf2/multiple_iris"
 build_path=${src_path}/build_posix_sitl_default
 
 echo "killing running instances"
-pkill px4
+pkill -x px4 || true
+
 sleep 1
 
 cd $build_path

--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -57,8 +57,10 @@ fi
 
 # kill process names that might stil
 # be running from last time
-pgrep gazebo && pkill gazebo
-pgrep px4 && pkill px4
+pkill -x gazebo || true
+pkill -x px4 || true
+pkill -x px4_$model || true
+
 jmavsim_pid=`ps aux | grep java | grep Simulator | cut -d" " -f1`
 if [ -n "$jmavsim_pid" ]
 then


### PR DESCRIPTION
This is a follow-up PR from https://github.com/PX4/Firmware/pull/6319