### PR TITLE
test_mixer: use memmove instead of memcpy

### DIFF
--- a/src/modules/px4iofirmware/mixer.cpp
+++ b/src/modules/px4iofirmware/mixer.cpp
@@ -532,7 +532,7 @@ mixer_handle_text(const void *buffer, size_t length)
 
 			/* copy any leftover text to the base of the buffer for re-use */
 			if (resid > 0) {
-				memcpy(&mixer_text[0], &mixer_text[mixer_text_length - resid], resid);
+				memmove(&mixer_text[0], &mixer_text[mixer_text_length - resid], resid);
 				/* enforce null termination */
 				mixer_text[resid] = '\0';
 			}

--- a/src/systemcmds/tests/test_mixer.cpp
+++ b/src/systemcmds/tests/test_mixer.cpp
@@ -334,7 +334,7 @@ bool MixerTest::load_mixer(const char *filename, const char *buf, unsigned loade
 
 			/* copy any leftover text to the base of the buffer for re-use */
 			if (resid > 0) {
-				memcpy(&mixer_text[0], &mixer_text[mixer_text_length - resid], resid);
+				memmove(&mixer_text[0], &mixer_text[mixer_text_length - resid], resid);
 				/* enforce null termination */
 				mixer_text[resid] = '\0';
 			}


### PR DESCRIPTION
Both, src & dst use the same array, thus potentially overlapping.
Behavior of memcpy in that case is undefined.