### PR TITLE
Fix bug causing constant publishing of sensor corrections

### DIFF
--- a/src/modules/sensors/temperature_compensation.cpp
+++ b/src/modules/sensors/temperature_compensation.cpp
@@ -378,8 +378,8 @@ int TemperatureCompensation::apply_corrections_gyro(int topic_instance, math::Ve
 
 	int8_t temperaturei = (int8_t)temperature;
 
-	if (temperaturei != _gyro_data.last_temperature) {
-		_gyro_data.last_temperature = temperaturei;
+	if (temperaturei != _gyro_data.last_temperature[topic_instance]) {
+		_gyro_data.last_temperature[topic_instance] = temperaturei;
 		return 2;
 	}
 
@@ -409,8 +409,8 @@ int TemperatureCompensation::apply_corrections_accel(int topic_instance, math::V
 
 	int8_t temperaturei = (int8_t)temperature;
 
-	if (temperaturei != _accel_data.last_temperature) {
-		_accel_data.last_temperature = temperaturei;
+	if (temperaturei != _accel_data.last_temperature[topic_instance]) {
+		_accel_data.last_temperature[topic_instance] = temperaturei;
 		return 2;
 	}
 
@@ -438,8 +438,8 @@ int TemperatureCompensation::apply_corrections_baro(int topic_instance, float &s
 
 	int8_t temperaturei = (int8_t)temperature;
 
-	if (temperaturei != _baro_data.last_temperature) {
-		_baro_data.last_temperature = temperaturei;
+	if (temperaturei != _baro_data.last_temperature[topic_instance]) {
+		_baro_data.last_temperature[topic_instance] = temperaturei;
 		return 2;
 	}
 

--- a/src/modules/sensors/temperature_compensation.h
+++ b/src/modules/sensors/temperature_compensation.h
@@ -252,10 +252,10 @@ private:
 	struct PerSensorData {
 		PerSensorData()
 		{
-			for (int i = 0; i < SENSOR_COUNT_MAX; ++i) { device_mapping[i] = 255; }
+			for (int i = 0; i < SENSOR_COUNT_MAX; ++i) { device_mapping[i] = 255; last_temperature[i] = -100; }
 		}
 		uint8_t device_mapping[SENSOR_COUNT_MAX]; /// map a topic instance to the parameters index
-		int8_t last_temperature = -100;
+		int8_t last_temperature[SENSOR_COUNT_MAX];
 	};
 	PerSensorData _gyro_data;
 	PerSensorData _accel_data;


### PR DESCRIPTION
The exisiting logic used to determine if new sensor corrections should be published used a one degree change in sensor temperature as the trigger. When multiple sensor instances were present, the differences in reported temperature for each instance could cause continuous publishing.

This PR enables the publishing logic to monitor the change in temperature for each instance individually.