### PR TITLE
commander: raise stack size

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -323,7 +323,7 @@ int commander_main(int argc, char *argv[])
 		daemon_task = px4_task_spawn_cmd("commander",
 					     SCHED_DEFAULT,
 					     SCHED_PRIORITY_DEFAULT + 40,
-					     3200,
+					     3600,
 					     commander_thread_main,
 					     (char * const *)&argv[0]);
 


### PR DESCRIPTION
A stack usage of 3000 bytes was observed, therefore it's safer to raise
the commander's stack size by 400 bytes.

Observed with `top`:
```
  36 commander                    2956  1.879  3000/ 3148 140 (140)  w:sig
```