### PR TITLE
Remove the notion of legacy from the api and save some FLASH space too

### DIFF
--- a/src/drivers/boards/common/board_common.h
+++ b/src/drivers/boards/common/board_common.h
@@ -198,31 +198,35 @@ typedef enum board_reset_e {
 	board_reset_enter_bootloader = 3   /* Perform a reset to the boot loader */
 } board_reset_e;
 
-/* Defined the types used for board UUID
+/* Defined the types used for board UUID and MFG UID
  *
  * A type suitable for holding the byte format of the UUID
- * The raw format is the result of a memcopy from the lowest address
- * to the highest address of the CPU's serial number
- * Bytes  [00] ,[01], [02], [03], [04], [05], [06], [07], [08], [09], [10], [11]...
- * Bits   00-07,8-15,16-23,24-31,32-39,40-47,48-55,56-63,64-71,72-79,80-87,88-95...
  *
+ * The original PX4 stm32 (legacy) based implementation **displayed** the
+ * UUID as: ABCD EFGH IJKL
+ * Where:
+ *       A was bit 31 and D was bit 0
+ *       E was bit 63 and H was bit 32
+ *       I was bit 95 and L was bit 64
+ *
+ * Since the string was used by some manufactures to identify the units
+ * it must be preserved.
+ *
+ * For new targets moving forward we will use
+ *      IJKL EFGH ABCD
  */
-typedef uint8_t raw_uuid_byte_t[PX4_CPU_UUID_BYTE_LENGTH];
 
-/* A type suitable for holding the reordering array for the byte format of the UUID
+/* A type suitable for defining the 8 bit format of the UUID */
+typedef uint8_t uuid_byte_t[PX4_CPU_UUID_BYTE_LENGTH];
+
+/* A type suitable for defining the 32bit format of the UUID */
+typedef uint32_t uuid_uint32_t[PX4_CPU_UUID_WORD32_LENGTH];
+
+/* A type suitable for defining the 8 bit format of the MFG UID
+ * This is always returned as MSD @ index 0 -LSD @ index PX4_CPU_MFGUID_BYTE_LENGTH-1
  */
-typedef const uint8_t uuid_uint8_reorder_t[PX4_CPU_UUID_BYTE_LENGTH];
+typedef uint8_t mfguid_t[PX4_CPU_MFGUID_BYTE_LENGTH];
 
-/* A type suitable for defining the 32bit format of the UUID and reordering */
-typedef uint32_t raw_uuid_uint32_t[PX4_CPU_UUID_WORD32_LENGTH];
-typedef const uint8_t raw_uuid_uint32_reorder_t[PX4_CPU_UUID_WORD32_LENGTH];
-
-/*
- * The Legacy px4 uint32 ordering
- *   word  [0]    [1]   [2]
- *   bits 31-00, 63-32, 95-64
- */
-extern const raw_uuid_uint32_reorder_t px4_legacy_word32_order;
 /************************************************************************************
  * Private Functions
  ************************************************************************************/
@@ -292,6 +296,10 @@ __EXPORT void board_rc_input(bool invert_on);
 #else
 __EXPORT void board_system_reset(int status) noreturn_function;
 #endif
+
+#if !defined(BOARD_HAS_POWER_CONTROL)
+#define px4_board_pwr(switch_on) { do {} while(0); }
+#endif
 /************************************************************************************
  * Name: board_set_bootload_mode
  *
@@ -309,55 +317,43 @@ __EXPORT int board_set_bootload_mode(board_reset_e mode);
 
 #if !defined(BOARD_OVERRIDE_UUID)
 /************************************************************************************
- * Name: board_get_uuid_raw
- *
- * Description:
- *   All boards either provide a way to read a uuid of PX4_CPU_UUID_BYTE_LENGTH
- *   from PX4_CPU_UUID_ADDRESS in the SoC's address space OR define
- *   BOARD_OVERRIDE_UUID as an array of bytes that is PX4_CPU_UUID_BYTE_LENGTH
- *   The raw format is the result of coping the bytes from the SoC in low memory
- *   to high memory.
- *
- ************************************************************************************/
-__EXPORT void board_get_uuid_raw(raw_uuid_byte_t *raw_uuid_bytes);
-
-/************************************************************************************
  * Name: board_get_uuid
  *
  * Description:
  *   All boards either provide a way to read a uuid of PX4_CPU_UUID_BYTE_LENGTH
  *   from PX4_CPU_UUID_ADDRESS in the SoC's address space OR define
  *   BOARD_OVERRIDE_UUID as an array of bytes that is PX4_CPU_UUID_BYTE_LENGTH
- *   The format is the result of coping the bytes from the SoC in low memory
- *   to high memory and then reordering them based on the reorder.
  *
  ************************************************************************************/
-__EXPORT void board_get_uuid(raw_uuid_byte_t raw_uuid_bytes,
-			     uuid_uint8_reorder_t reorder);
+
+__EXPORT void board_get_uuid(uuid_byte_t uuid_bytes);
 
 /************************************************************************************
- * Name: board_get_uuid_raw32
+ * Name: board_get_uuid32
  *
  * Description:
  *   All boards either provide a way to read a uuid of PX4_CPU_UUID_WORD32_LENGTH
  *   from PX4_CPU_UUID_ADDRESS in the Soc's address space OR define
  *   BOARD_OVERRIDE_UUID as an array of bytes that is PX4_CPU_UUID_BYTE_LENGTH
- *   The raw32 format is the result of coping returning the 32bit words from
- *   low memory to high memory.  But provide an optional to argument to reorder
- *   the output array.
+ *   On Legacy (stm32) targets the raw32 format is the result of coping returning
+ *   the 32bit words from low memory to high memory. On new targets the result
+ *   will be an array of words with the MSW at index 0 and the LSW: at index
+ *   PX4_CPU_UUID_WORD32_LENGTH-1.
+ *
+ *	 The ordering can optionally be set by defining
+ *	 PX4_CPU_UUID_WORD32_FORMAT_ORDER
  *
  ************************************************************************************/
-__EXPORT void board_get_uuid_raw32(raw_uuid_uint32_t raw_uuid_words,
-				   raw_uuid_uint32_reorder_t *optional_reorder);
+__EXPORT void board_get_uuid32(uuid_uint32_t uuid_words);
 
 /************************************************************************************
- * Name: board_get_uuid_formated32
+ * Name: board_get_uuid32_formated
  *
  * Description:
  *   All boards either provide a way to retrieve a uuid and format it
- *   Or define BOARD_OVERRIDE_UUID
- *   The format is the result the optionally reordered raw 32bit word format
- *   printed with the optional separator
+ *   or define BOARD_OVERRIDE_UUID
+ *   The format can optionally be reordered if PX4_CPU_UUID_WORD32_FORMAT_ORDER is
+ *   defined and printed with the optional separator
  *
  *   With seperator = ":"
  *   31-00:63-32:95-64
@@ -370,15 +366,36 @@ __EXPORT void board_get_uuid_raw32(raw_uuid_uint32_t raw_uuid_words,
  *   3238333641203833355110
  *
  ************************************************************************************/
-__EXPORT int board_get_uuid_formated32(char *format_buffer, int size,
+__EXPORT int board_get_uuid32_formated(char *format_buffer, int size,
 				       const char *format,
-				       const char *seperator,
-				       raw_uuid_uint32_reorder_t *optional_reorder);
+				       const char *seperator);
 #endif // !defined(BOARD_OVERRIDE_UUID)
 
-#if !defined(BOARD_HAS_POWER_CONTROL)
-#define px4_board_pwr(switch_on) { do {} while(0); }
-#endif
+#if !defined(BOARD_OVERRIDE_MFGUID)
+/************************************************************************************
+ * Name: board_get_mfguid
+ *
+ * Description:
+ *   All boards either provide a way to retrieve a manafactuers Uniqe ID or
+ *   define BOARD_OVERRIDE_MFGUID.
+ *    The MFGUID is returned as an array of bytes in
+ *    MSD @ index 0 - LSD @ index PX4_CPU_MFGUID_BYTE_LENGTH-1
+ *
+ ************************************************************************************/
+
+int board_get_mfguid(mfguid_t mfgid);
+
+/************************************************************************************
+ * Name: board_get_mfguid_formated
+ *
+ * Description:
+ *   All boards either provide a way to retrieve a formatted string of the
+ *   manafactuers Uniqe ID or define BOARD_OVERRIDE_MFGUID
+ *
+ ************************************************************************************/
+
+int board_get_mfguid_formated(char *format_buffer, int size);
+#endif // !defined(BOARD_OVERRIDE_MFGUID)
 
 /************************************************************************************
  * Name: board_mcu_version

--- a/src/drivers/boards/esc35-v1/bootloader/boot.c
+++ b/src/drivers/boards/esc35-v1/bootloader/boot.c
@@ -172,8 +172,7 @@ size_t board_get_hardware_version(uavcan_HardwareVersion_t *hw_version)
 	hw_version->major = HW_VERSION_MAJOR;
 	hw_version->minor = HW_VERSION_MINOR;
 
-	board_get_uuid_raw((raw_uuid_byte_t *) hw_version->unique_id);
-	return PX4_CPU_UUID_BYTE_LENGTH;
+	return board_get_mfguid(*(mfguid_t *) hw_version->unique_id);
 }
 
 /****************************************************************************

--- a/src/drivers/boards/px4cannode-v1/bootloader/boot.c
+++ b/src/drivers/boards/px4cannode-v1/bootloader/boot.c
@@ -168,8 +168,7 @@ size_t board_get_hardware_version(uavcan_HardwareVersion_t *hw_version)
 	hw_version->major = HW_VERSION_MAJOR;
 	hw_version->minor = HW_VERSION_MINOR;
 
-	board_get_uuid_raw((raw_uuid_byte_t *) hw_version->unique_id);
-	return PX4_CPU_UUID_BYTE_LENGTH;
+	return board_get_mfguid(*(mfguid_t *) hw_version->unique_id);
 }
 
 /****************************************************************************

--- a/src/drivers/boards/px4esc-v1/bootloader/boot.c
+++ b/src/drivers/boards/px4esc-v1/bootloader/boot.c
@@ -167,8 +167,7 @@ size_t board_get_hardware_version(uavcan_HardwareVersion_t *hw_version)
 	hw_version->major = HW_VERSION_MAJOR;
 	hw_version->minor = HW_VERSION_MINOR;
 
-	board_get_uuid_raw((raw_uuid_byte_t *) hw_version->unique_id);
-	return PX4_CPU_UUID_BYTE_LENGTH;
+	return board_get_mfguid(*(mfguid_t *) hw_version->unique_id);
 }
 
 /****************************************************************************

--- a/src/drivers/boards/px4flow-v2/bootloader/boot.c
+++ b/src/drivers/boards/px4flow-v2/bootloader/boot.c
@@ -167,8 +167,7 @@ size_t board_get_hardware_version(uavcan_HardwareVersion_t *hw_version)
 	hw_version->major = HW_VERSION_MAJOR;
 	hw_version->minor = HW_VERSION_MINOR;
 
-	board_get_uuid_raw((raw_uuid_byte_t *) hw_version->unique_id);
-	return PX4_CPU_UUID_BYTE_LENGTH;
+	return board_get_mfguid(*(mfguid_t *) hw_version->unique_id);
 }
 
 /****************************************************************************

--- a/src/drivers/boards/s2740vc-v1/bootloader/boot.c
+++ b/src/drivers/boards/s2740vc-v1/bootloader/boot.c
@@ -170,8 +170,7 @@ size_t board_get_hardware_version(uavcan_HardwareVersion_t *hw_version)
 	hw_version->major = HW_VERSION_MAJOR;
 	hw_version->minor = HW_VERSION_MINOR;
 
-	board_get_uuid_raw((raw_uuid_byte_t *) hw_version->unique_id);
-	return PX4_CPU_UUID_BYTE_LENGTH;
+	return board_get_mfguid(*(mfguid_t *) hw_version->unique_id);
 }
 
 /****************************************************************************

--- a/src/drivers/boards/zubaxgnss-v1/bootloader/boot.c
+++ b/src/drivers/boards/zubaxgnss-v1/bootloader/boot.c
@@ -170,8 +170,7 @@ size_t board_get_hardware_version(uavcan_HardwareVersion_t *hw_version)
 	hw_version->major = HW_VERSION_MAJOR;
 	hw_version->minor = HW_VERSION_MINOR;
 
-	board_get_uuid_raw((raw_uuid_byte_t *) hw_version->unique_id);
-	return PX4_CPU_UUID_BYTE_LENGTH;
+	return board_get_mfguid(*(mfguid_t *) hw_version->unique_id);
 }
 
 /****************************************************************************

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -3302,13 +3302,6 @@ fmu_main(int argc, char *argv[])
 		errx(0, "FMU driver stopped");
 	}
 
-	if (!strcmp(verb, "id")) {
-		char uid_fmt_buffer[PX4_CPU_UUID_WORD32_LEGACY_FORMAT_SIZE];
-		board_get_uuid_formated32(uid_fmt_buffer, sizeof(uid_fmt_buffer), "%0X", " ", &px4_legacy_word32_order);
-		printf("Board serial:\n %s\n", uid_fmt_buffer);
-		exit(0);
-	}
-
 	if (fmu_start() != OK) {
 		errx(1, "failed to start the FMU driver");
 	}

--- a/src/modules/commander/gyro_calibration.cpp
+++ b/src/modules/commander/gyro_calibration.cpp
@@ -450,11 +450,11 @@ int do_gyro_calibration(orb_advert_t *mavlink_log_pub)
 	}
 
 	/* store board ID */
-	raw_uuid_uint32_t mcu_id;
-	board_get_uuid_raw32(mcu_id, NULL);
+	uuid_uint32_t mcu_id;
+	board_get_uuid32(mcu_id);
 
 	/* store last 32bit number - not unique, but unique in a given set */
-	(void)param_set(param_find("CAL_BOARD_ID"), &mcu_id[2]);
+	(void)param_set(param_find("CAL_BOARD_ID"), &mcu_id[PX4_CPU_UUID_WORD32_UNIQUE_H]);
 
 	if (res == PX4_OK) {
 		/* auto-save to EEPROM */

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1438,8 +1438,8 @@ void Logger::write_version()
 		param_get(write_uuid_param, &write_uuid);
 
 		if (write_uuid == 1) {
-			char uuid_string[PX4_CPU_UUID_WORD32_LEGACY_FORMAT_SIZE];
-			board_get_uuid_formated32(uuid_string, sizeof(uuid_string), "%08X", NULL, &px4_legacy_word32_order);
+			char uuid_string[PX4_CPU_UUID_WORD32_FORMAT_SIZE];
+			board_get_uuid32_formated(uuid_string, sizeof(uuid_string), "%08X", NULL);
 			write_info("sys_uuid", uuid_string);
 		}
 	}

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1307,9 +1307,9 @@ void Mavlink::send_autopilot_capabilites()
 #else
 		msg.product_id = 0;
 #endif
-		raw_uuid_uint32_t uid;
-		board_get_uuid_raw32(uid, NULL);
-		msg.uid = (((uint64_t)uid[1]) << 32) | uid[2];
+		uuid_uint32_t uid;
+		board_get_uuid32(uid);
+		msg.uid = (((uint64_t)uid[PX4_CPU_UUID_WORD32_UNIQUE_M]) << 32) | uid[PX4_CPU_UUID_WORD32_UNIQUE_H];
 
 		mavlink_msg_autopilot_version_send_struct(get_channel(), &msg);
 	}

--- a/src/modules/systemlib/board_serial.c
+++ b/src/modules/systemlib/board_serial.c
@@ -44,14 +44,12 @@
 #include <string.h>
 #include "board_serial.h"
 
-int get_board_serial(raw_uuid_byte_t serialid)
+int get_board_serial(uuid_byte_t serialid)
 {
 #if defined(BOARD_OVERRIDE_UUID)
 	memcpy(serialid, BOARD_OVERRIDE_UUID, PX4_CPU_UUID_BYTE_LENGTH);
 #else
-	uuid_uint8_reorder_t odering = {3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8};
-	/* Copy the serial from the chips non-write memory and swap endianess */
-	board_get_uuid(serialid, odering);
+	board_get_uuid(serialid);
 #endif
 	return 0;
 }

--- a/src/modules/systemlib/board_serial.h
+++ b/src/modules/systemlib/board_serial.h
@@ -46,6 +46,6 @@
 
 __BEGIN_DECLS
 
-__EXPORT int get_board_serial(raw_uuid_byte_t serialid);
+__EXPORT int get_board_serial(uuid_byte_t serialid);
 
 __END_DECLS

--- a/src/modules/uavcan/uavcan_main.cpp
+++ b/src/modules/uavcan/uavcan_main.cpp
@@ -191,9 +191,9 @@ int UavcanNode::getHardwareVersion(uavcan::protocol::HardwareVersion &hwver)
 			; // All other values of px4_board_name() resolve to zero
 		}
 
-		raw_uuid_byte_t udid = {};
-		get_board_serial(udid);
-		uavcan::copy(udid, udid + sizeof(udid), hwver.unique_id.begin());
+		mfguid_t mfgid = {};
+		board_get_mfguid(mfgid);
+		uavcan::copy(mfgid, mfgid + sizeof(mfgid), hwver.unique_id.begin());
 		rv = 0;
 	}
 

--- a/src/modules/uavcanesc/uavcanesc_main.cpp
+++ b/src/modules/uavcanesc/uavcanesc_main.cpp
@@ -231,9 +231,9 @@ void UavcanEsc::fill_node_info()
 	hwver.major = HW_VERSION_MAJOR;
 	hwver.minor = HW_VERSION_MINOR;
 
-	raw_uuid_byte_t udid = {};
-	get_board_serial(udid);
-	uavcan::copy(udid, udid + sizeof(udid), hwver.unique_id.begin());
+	mfguid_t mfgid = {};
+	board_get_mfguid(mfgid);
+	uavcan::copy(mfgid, mfgid + sizeof(mfgid), hwver.unique_id.begin());
 
 	_node.setHardwareVersion(hwver);
 }

--- a/src/modules/uavcannode/uavcannode_main.cpp
+++ b/src/modules/uavcannode/uavcannode_main.cpp
@@ -258,9 +258,9 @@ void UavcanNode::fill_node_info()
 	hwver.major = HW_VERSION_MAJOR;
 	hwver.minor = HW_VERSION_MINOR;
 
-	raw_uuid_byte_t udid = {};
-	get_board_serial(udid);
-	uavcan::copy(udid, udid + sizeof(udid), hwver.unique_id.begin());
+	mfguid_t mfgid = {};
+	board_get_mfguid(mfgid);
+	uavcan::copy(mfgid, mfgid + sizeof(mfgid), hwver.unique_id.begin());
 
 	_node.setHardwareVersion(hwver);
 }

--- a/src/platforms/posix/include/system_config.h
+++ b/src/platforms/posix/include/system_config.h
@@ -10,18 +10,24 @@
 #define PX4_I2C_OBDEV_LED	0x55
 
 #define BOARD_OVERRIDE_UUID "SIMULATIONID"
+#define BOARD_OVERRIDE_MFGUID BOARD_OVERRIDE_UUID
 #define SIM_FORMATED_UUID "000000010000000200000003"
 #define PX4_CPU_UUID_BYTE_LENGTH 12
 #define PX4_CPU_UUID_WORD32_LENGTH 3
-#define PX4_CPU_UUID_WORD32_LEGACY_FORMAT_SIZE  (PX4_CPU_UUID_WORD32_LENGTH-1+(2*PX4_CPU_UUID_BYTE_LENGTH))
+#define PX4_CPU_MFGUID_BYTE_LENGTH              PX4_CPU_UUID_BYTE_LENGTH
+#define PX4_CPU_UUID_WORD32_UNIQUE_H            2 /* Most significant digits change the least */
+#define PX4_CPU_UUID_WORD32_UNIQUE_M            1 /* Middle significant digits */
+#define PX4_CPU_UUID_WORD32_UNIQUE_L            0 /* Least significant digits change the most */
+#define PX4_CPU_UUID_WORD32_FORMAT_SIZE         (PX4_CPU_UUID_WORD32_LENGTH-1+(2*PX4_CPU_UUID_BYTE_LENGTH)+1)
+#define PX4_CPU_MFGUID_FORMAT_SIZE              ((2*PX4_CPU_MFGUID_BYTE_LENGTH)+1)
 
 #define BOARD_OVERRIDE_CPU_VERSION (-1)
 #define board_mcu_version(rev, revstr, errata) BOARD_OVERRIDE_CPU_VERSION
-typedef unsigned char raw_uuid_byte_t[PX4_CPU_UUID_BYTE_LENGTH];
-typedef unsigned int raw_uuid_uint32_t[PX4_CPU_UUID_WORD32_LENGTH];
+typedef unsigned char uuid_byte_t[PX4_CPU_UUID_BYTE_LENGTH];
+typedef unsigned int uuid_uint32_t[PX4_CPU_UUID_WORD32_LENGTH];
 
-#define board_get_uuid_raw32(id, null) do {id[0]=0;id[1]=1;id[2]=2;} while(0)
-#define board_get_uuid_formated32(format_buffer, size, format, seperator, optional_reorder) do { strcpy(format_buffer, SIM_FORMATED_UUID); } while(0)
+#define board_get_uuid32(id) do {for(int _idi=0; _idi < PX4_CPU_UUID_WORD32_LENGTH; _idi++) {id[_idi] = _idi;}} while(0)
+#define board_get_uuid32_formated(format_buffer, size, format, seperator) do { strcpy(format_buffer, SIM_FORMATED_UUID); } while(0)
 
 
 #define CONFIG_NFILE_STREAMS 1

--- a/src/systemcmds/ver/ver.c
+++ b/src/systemcmds/ver/ver.c
@@ -57,6 +57,20 @@ static const char sz_ver_gcc_str[] 	= "gcc";
 static const char sz_ver_all_str[] 	= "all";
 static const char mcu_ver_str[]		= "mcu";
 static const char mcu_uid_str[]         = "uid";
+static const char mfg_uid_str[]         = "mfguid";
+
+#if defined(PX4_CPU_UUID_WORD32_FORMAT)
+#  define CPU_UUID_FORMAT PX4_CPU_UUID_WORD32_FORMAT
+#else
+/* This is the legacy format that did not print leading zeros*/
+#  define CPU_UUID_FORMAT "%X"
+#endif
+
+#if defined(PX4_CPU_UUID_WORD32_SEPARATOR)
+#  define CPU_UUID_SEPARATOR PX4_CPU_UUID_WORD32_SEPARATOR
+#else
+#  define CPU_UUID_SEPARATOR ":"
+#endif
 
 static void usage(const char *reason)
 {
@@ -64,7 +78,7 @@ static void usage(const char *reason)
 		printf("%s\n", reason);
 	}
 
-	printf("usage: ver {hw|hwcmp|git|bdate|gcc|all|mcu|uid|uri}\n\n");
+	printf("usage: ver {hw|hwcmp|git|bdate|gcc|all|mcu|mfguid|uid|uri}\n\n");
 }
 
 __EXPORT int ver_main(int argc, char *argv[]);
@@ -164,6 +178,18 @@ int ver_main(int argc, char *argv[])
 
 			}
 
+			if (show_all || !strncmp(argv[1], mfg_uid_str, sizeof(mfg_uid_str))) {
+
+#if defined(BOARD_OVERRIDE_MFGUID)
+				char *mfguid_fmt_buffer = BOARD_OVERRIDE_MFGUID;
+#else
+				char mfguid_fmt_buffer[PX4_CPU_MFGUID_FORMAT_SIZE];
+				board_get_mfguid_formated(mfguid_fmt_buffer, sizeof(mfguid_fmt_buffer));
+#endif
+				printf("MFGUID: %s\n", mfguid_fmt_buffer);
+				ret = 0;
+			}
+
 			if (show_all || !strncmp(argv[1], mcu_ver_str, sizeof(mcu_ver_str))) {
 
 				char rev = ' ';
@@ -194,13 +220,12 @@ int ver_main(int argc, char *argv[])
 #if defined(BOARD_OVERRIDE_UUID)
 				char *uid_fmt_buffer = BOARD_OVERRIDE_UUID;
 #else
-				char uid_fmt_buffer[PX4_CPU_UUID_WORD32_LEGACY_FORMAT_SIZE];
-				board_get_uuid_formated32(uid_fmt_buffer, sizeof(uid_fmt_buffer), "%X", ":", &px4_legacy_word32_order);
+				char uid_fmt_buffer[PX4_CPU_UUID_WORD32_FORMAT_SIZE];
+				board_get_uuid32_formated(uid_fmt_buffer, sizeof(uid_fmt_buffer), CPU_UUID_FORMAT, CPU_UUID_SEPARATOR);
 #endif
 				printf("UID: %s \n", uid_fmt_buffer);
 				ret = 0;
 			}
-
 
 			if (ret == 1) {
 				warn("unknown command.\n");


### PR DESCRIPTION
@LorenzMeier 

This remove the notion of legacy from the api. The board level code  will perform the translation to legacy format on the STM32.  New targets will not need to do this as there is no case where the serial number were used by mfg for tracking.

It maintains the legacy incorrect selection of significant digits of the UUID in the PX4 code base.
This is done to avoid the ripple effects changing the IDs used on STM32 base platforms. [See] (https://github.com/PX4/Firmware/commit/f126668dbd41f10667a8759be7937dd822549828#diff-8da0cce1d272772f52e0d92c6f4343a5R83)