### PR TITLE
cmake nuttx binary naming fix

### DIFF
--- a/Tools/s3put.sh
+++ b/Tools/s3put.sh
@@ -13,8 +13,7 @@ filename=${1}
 
 if [ -f ${filename} ]; then
 	base_file_name=`basename $filename`
-	short_file_name=${base_file_name#nuttx-}
-	s3cmd --access_key=${AWS_ACCESS_KEY_ID} --secret_key=${AWS_SECRET_ACCESS_KEY} put ${filename} s3://${AWS_S3_BUCKET}/${short_file_name}
+	s3cmd --access_key=${AWS_ACCESS_KEY_ID} --secret_key=${AWS_SECRET_ACCESS_KEY} put ${filename} s3://${AWS_S3_BUCKET}/${base_file_name}
 else
 	echo "ERROR: ${file} doesn't exist"
 	exit 1

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -48,7 +48,7 @@ set(config_module_list
 	drivers/pwm_input
 	drivers/camera_trigger
 	drivers/bst
-##TO FIT drivers/snapdragon_rc_pwm
+	#drivers/snapdragon_rc_pwm
 	drivers/lis3mdl
 	#drivers/iridiumsbd
 	drivers/ulanding
@@ -98,7 +98,6 @@ set(config_module_list
 	modules/gpio_led
 	#modules/uavcan
 	modules/land_detector
-	#modules/tempcal
 
 	#
 	# Estimation modules
@@ -120,7 +119,7 @@ set(config_module_list
 	#
 	# Logging
 	#
-	#modules/logger
+	modules/logger
 	modules/sdlog2
 
 	#

--- a/src/firmware/nuttx/CMakeLists.txt
+++ b/src/firmware/nuttx/CMakeLists.txt
@@ -96,7 +96,7 @@ if(NOT ${BOARD} STREQUAL "sim")
 	endif()
 
 	set(fw_file
-		${CMAKE_CURRENT_BINARY_DIR}/${OS}-${BOARD}-${LABEL}.px4)
+		${CMAKE_CURRENT_BINARY_DIR}/${BOARD}_${LABEL}.px4)
 
 #
 # Bootloaders do not need .px4 or xml


### PR DESCRIPTION
@LorenzMeier - With this PR the nuttx binaries (.px4) are now named in the same form QGC expects for S3. For example px4fmu-v2_default is now named `px4fmu-v2_default.px4` instead of `nuttx-px4fmu-v2-default.px4` which was then erroneously renamed to `px4fmu-v2-default.px4`.

The naming of the binaries uploaded to S3 for QGC has been wrong for about 2 weeks now. Dashes instead of underscores.