### PR TITLE
ver.c: fix hwcmp to match exact string

### DIFF
--- a/src/systemcmds/ver/ver.c
+++ b/src/systemcmds/ver/ver.c
@@ -82,7 +82,7 @@ int ver_main(int argc, char *argv[])
 				if (argc >= 3 && argv[2] != NULL) {
 					/* compare 3rd parameter with px4_board_name() string, in case of match, return 0 */
 					const char *board_name = px4_board_name();
-					ret = strncmp(board_name, argv[2], strlen(board_name));
+					ret = strcmp(board_name, argv[2]);
 
 					if (ret == 0) {
 						PX4_INFO("match: %s", board_name);


### PR DESCRIPTION
Previously for example 'ver hwcmp PX4FMU_V4PRO' matched on PX4FMU_V4
hardware too.

Unless this is the desired behavior, in which case this can be closed.

@davids5 