### PR TITLE
MPC controller: Do not initialize to zero dt but a likely default dt

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -2192,7 +2192,7 @@ MulticopterPositionControl::task_main()
 		parameters_update(false);
 
 		hrt_abstime t = hrt_absolute_time();
-		float dt = t_prev != 0 ? (t - t_prev) / 1e6f : 0.0f;
+		float dt = t_prev != 0 ? (t - t_prev) / 1e6f : 0.004f;
 		t_prev = t;
 
 		// set dt for control blocks


### PR DESCRIPTION
@Stifael This should prevent having big jumps in the local position setpoint on log start which we sometimes get.