### PR TITLE
Intel Aero: Set correct ESC mode

### DIFF
--- a/ROMFS/px4fmu_common/init.d/4070_aerofc
+++ b/ROMFS/px4fmu_common/init.d/4070_aerofc
@@ -37,6 +37,9 @@ then
 	param set MPC_XY_CRUISE 8
 
 	param set SYS_LOGGER 1
+
+	# ULog streaming requires Mavlink 2
+	param set MAV_PROTO_VER 2
 fi
 
 tap_esc start -d /dev/ttyS0 -n 4

--- a/posix-configs/SITL/init/ekf2/iris
+++ b/posix-configs/SITL/init/ekf2/iris
@@ -4,6 +4,7 @@ param set MAV_TYPE 2
 param set SYS_AUTOSTART 4010
 param set SYS_RESTART_TYPE 2
 param set SYS_MC_EST_GROUP 2
+param set MAV_PROTO_VER 2
 dataman start
 param set BAT_N_CELLS 3
 param set CAL_GYRO0_ID 2293768

--- a/posix-configs/SITL/init/ekf2/iris_opt_flow
+++ b/posix-configs/SITL/init/ekf2/iris_opt_flow
@@ -4,6 +4,7 @@ param set MAV_TYPE 2
 param set SYS_AUTOSTART 4010
 param set SYS_RESTART_TYPE 2
 param set SYS_MC_EST_GROUP 2
+param set MAV_PROTO_VER 2
 dataman start
 param set BAT_N_CELLS 3
 param set CAL_GYRO0_ID 2293768

--- a/posix-configs/SITL/init/ekf2/multiple_iris
+++ b/posix-configs/SITL/init/ekf2/multiple_iris
@@ -4,6 +4,7 @@ param set MAV_TYPE 2
 param set SYS_AUTOSTART 4010
 param set SYS_RESTART_TYPE 2
 param set SYS_MC_EST_GROUP 2
+param set MAV_PROTO_VER 2
 dataman start
 param set BAT_N_CELLS 3
 param set CAL_GYRO0_ID 2293768

--- a/posix-configs/SITL/init/ekf2/plane
+++ b/posix-configs/SITL/init/ekf2/plane
@@ -4,6 +4,7 @@ param set MAV_TYPE 1
 param set SYS_AUTOSTART 3033
 param set SYS_RESTART_TYPE 2
 param set SYS_MC_EST_GROUP 2
+param set MAV_PROTO_VER 2
 dataman start
 param set BAT_N_CELLS 3
 param set CAL_GYRO0_ID 2293768

--- a/posix-configs/SITL/init/ekf2/solo
+++ b/posix-configs/SITL/init/ekf2/solo
@@ -4,6 +4,7 @@ param set MAV_TYPE 2
 param set SYS_AUTOSTART 4010
 param set SYS_RESTART_TYPE 2
 param set SYS_MC_EST_GROUP 2
+param set MAV_PROTO_VER 2
 dataman start
 param set BAT_N_CELLS 3
 param set CAL_GYRO0_ID 2293768

--- a/posix-configs/SITL/init/ekf2/standard_vtol
+++ b/posix-configs/SITL/init/ekf2/standard_vtol
@@ -7,6 +7,7 @@ param set VT_TRANS_THR 0.75
 param set SYS_AUTOSTART 13006
 param set SYS_RESTART_TYPE 2
 param set SYS_MC_EST_GROUP 2
+param set MAV_PROTO_VER 2
 dataman start
 param set BAT_N_CELLS 3
 param set CAL_GYRO0_ID 2293768

--- a/posix-configs/SITL/init/ekf2/tailsitter
+++ b/posix-configs/SITL/init/ekf2/tailsitter
@@ -5,6 +5,7 @@ param set VT_TYPE 0
 param set SYS_AUTOSTART 4010
 param set SYS_RESTART_TYPE 2
 param set SYS_MC_EST_GROUP 2
+param set MAV_PROTO_VER 2
 dataman start
 param set BAT_N_CELLS 3
 param set CAL_GYRO0_ID 2293768

--- a/posix-configs/SITL/init/ekf2/typhoon_h480
+++ b/posix-configs/SITL/init/ekf2/typhoon_h480
@@ -4,6 +4,7 @@ param set MAV_TYPE 13
 param set SYS_AUTOSTART 6001
 param set SYS_RESTART_TYPE 2
 param set SYS_MC_EST_GROUP 2
+param set MAV_PROTO_VER 2
 dataman start
 param set BAT_N_CELLS 3
 param set CAL_GYRO0_ID 2293768

--- a/posix-configs/SITL/init/lpe/iris
+++ b/posix-configs/SITL/init/lpe/iris
@@ -4,6 +4,7 @@ param set MAV_TYPE 2
 param set SYS_AUTOSTART 4010
 param set SYS_RESTART_TYPE 2
 param set SYS_MC_EST_GROUP 1
+param set MAV_PROTO_VER 2
 dataman start
 param set BAT_N_CELLS 3
 param set CAL_GYRO0_ID 2293768

--- a/posix-configs/SITL/init/lpe/iris_opt_flow
+++ b/posix-configs/SITL/init/lpe/iris_opt_flow
@@ -4,6 +4,7 @@ param set MAV_TYPE 2
 param set SYS_AUTOSTART 4010
 param set SYS_RESTART_TYPE 2
 param set SYS_MC_EST_GROUP 1
+param set MAV_PROTO_VER 2
 dataman start
 param set BAT_N_CELLS 3
 param set CAL_GYRO0_ID 2293768

--- a/posix-configs/SITL/init/lpe/plane
+++ b/posix-configs/SITL/init/lpe/plane
@@ -4,6 +4,7 @@ param set MAV_TYPE 1
 param set SYS_AUTOSTART 3033
 param set SYS_RESTART_TYPE 2
 param set SYS_MC_EST_GROUP 1
+param set MAV_PROTO_VER 2
 dataman start
 param set BAT_N_CELLS 3
 param set CAL_GYRO0_ID 2293768

--- a/posix-configs/SITL/init/lpe/solo
+++ b/posix-configs/SITL/init/lpe/solo
@@ -4,6 +4,7 @@ param set MAV_TYPE 2
 param set SYS_AUTOSTART 4010
 param set SYS_RESTART_TYPE 2
 param set SYS_MC_EST_GROUP 1
+param set MAV_PROTO_VER 2
 dataman start
 param set BAT_N_CELLS 3
 param set CAL_GYRO0_ID 2293768

--- a/posix-configs/SITL/init/lpe/standard_vtol
+++ b/posix-configs/SITL/init/lpe/standard_vtol
@@ -7,6 +7,7 @@ param set VT_TRANS_THR 0.75
 param set SYS_AUTOSTART 13006
 param set SYS_RESTART_TYPE 2
 param set SYS_MC_EST_GROUP 1
+param set MAV_PROTO_VER 2
 dataman start
 param set BAT_N_CELLS 3
 param set CAL_GYRO0_ID 2293768

--- a/posix-configs/SITL/init/lpe/typhoon_h480
+++ b/posix-configs/SITL/init/lpe/typhoon_h480
@@ -4,6 +4,7 @@ param set MAV_TYPE 13
 param set SYS_AUTOSTART 6001
 param set SYS_RESTART_TYPE 2
 param set SYS_MC_EST_GROUP 1
+param set MAV_PROTO_VER 2
 dataman start
 param set BAT_N_CELLS 3
 param set CAL_GYRO0_ID 2293768

--- a/posix-configs/bebop/px4.config
+++ b/posix-configs/bebop/px4.config
@@ -5,6 +5,8 @@ param set SYS_AUTOSTART 4013
 param set MAV_BROADCAST 1
 param set MAV_TYPE 3
 
+param set MAV_PROTO_VER 2
+
 param set MPC_XY_VEL_P 0.12
 param set MPC_XY_P 1.3
 param set MPC_XY_VEL_D 0.006

--- a/posix-configs/rpi/px4.config
+++ b/posix-configs/rpi/px4.config
@@ -2,6 +2,7 @@ uorb start
 param load
 param set SYS_AUTOSTART 4001
 param set MAV_BROADCAST 1
+param set MAV_PROTO_VER 2
 sleep 1
 param set MAV_TYPE 2
 param set SYS_MC_EST_GROUP 0

--- a/posix-configs/rpi/px4_fw.config
+++ b/posix-configs/rpi/px4_fw.config
@@ -3,6 +3,7 @@ param load
 param set MAV_BROADCAST 1
 #param set SYS_AUTOSTART 2104
 param set MAV_TYPE 1
+param set MAV_PROTO_VER 2
 df_lsm9ds1_wrapper start -R 4
 df_ms5611_wrapper start
 #navio_rgbled start

--- a/src/drivers/tap_esc/tap_esc.cpp
+++ b/src/drivers/tap_esc/tap_esc.cpp
@@ -257,6 +257,7 @@ TAP_ESC::init()
 				ESC_CHANNEL_MAP_RUNNING_DIRECTION;
 	}
 
+	config.controlMode = 2;
 	config.maxChannelValue = RPMMAX;
 	config.minChannelValue = RPMMIN;
 


### PR DESCRIPTION
@ChristophTobler @bkueng I've set the correct ESC mode here and we should test this Monday including some position control tuning. @zehortigoza @lucasdemarchi Here is what I expect a final tune should get close to:

```
# pitch angle & rate setting
param set MC_PITCHRATE_P 0.142
param set MC_PITCHRATE_I 0.05
param set MC_PITCHRATE_D 0.001
param set MC_PITCHRATE_MAX 360.0
param set MC_PITCH_P 6

# roll angle & rate setting
param set MC_ROLLRATE_P 0.142
param set MC_ROLLRATE_I 0.05
param set MC_ROLLRATE_D 0.001
param set MC_ROLLRATE_MAX 360.0
param set MC_ROLL_P 6

# yaw angle & rate setting close to defaults

# hover thrust
param set MPC_THR_HOVER 0.5

# Position control parameters
param set MPC_XY_VEL_P 0.14
param set MPC_Z_VEL_P 0.39
param set MPC_XY_P 1.2
param set MPC_Z_P 1.5

# Position control velocity
param set MPC_XY_CRUISE 8.0
param set MPC_XY_VEL_MAX 12.0
param set MPC_Z_VEL_MAX_UP 3.0
param set MPC_Z_VEL_MAX 2.0
param set MPC_Z_VEL_MAX_DN 2.0
param set MPC_LAND_SPEED 0.8

# throttle pid attenuation
param set MC_TPA_RATE_P 0.4
param set MC_TPA_RATE_I 0.5
param set MC_TPA_RATE_D 0.2
param set MC_TPA_BREAK_P 0.65
param set MC_TPA_BREAK_I 0.6
param set MC_TPA_BREAK_D 0.65
```
