### PR TITLE
Land detector: Measure total system flight time

### DIFF
--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -143,7 +143,7 @@ void LandDetector::_cycle()
 			_takeoff_time = now;
 
 		} else if (_takeoff_time != 0 && !landDetected && _landDetected.landed) {
-			_total_flight_time = now - _takeoff_time;
+			_total_flight_time += now - _takeoff_time;
 			_takeoff_time = 0;
 			param_set(_p_total_flight_time, &_total_flight_time);
 		}

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -166,6 +166,10 @@ private:
 	bool _taskShouldExit;
 	bool _taskIsRunning;
 
+	param_t _p_total_flight_time;
+	int32_t _total_flight_time;
+	hrt_abstime _takeoff_time;
+
 	struct work_s	_work;
 };
 

--- a/src/modules/land_detector/land_detector_main.cpp
+++ b/src/modules/land_detector/land_detector_main.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2015 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2017 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,6 +36,7 @@
  * Land detection algorithm
  *
  * @author Johan Jansen <jnsn.johan@gmail.com>
+ * @author Lorenz Meier <lorenz@px4.io>
  */
 
 #include <px4_config.h>
@@ -59,7 +60,7 @@
 namespace land_detector
 {
 
-//Function prototypes
+// Function prototypes
 static int land_detector_start(const char *mode);
 static void land_detector_stop();
 
@@ -70,13 +71,13 @@ static void land_detector_stop();
  */
 extern "C" __EXPORT int land_detector_main(int argc, char *argv[]);
 
-//Private variables
+// Private variables
 static LandDetector *land_detector_task = nullptr;
 static char _currentMode[12];
 
 /**
-* Stop the task, force killing it if it doesn't stop by itself
-**/
+ * Stop the task, force killing it if it doesn't stop by itself
+ */
 static void land_detector_stop()
 {
 	if (land_detector_task == nullptr) {
@@ -90,7 +91,7 @@ static void land_detector_stop()
 	int i = 0;
 
 	do {
-		/* wait 20ms */
+		// wait 20ms at a time
 		usleep(20000);
 
 	} while (land_detector_task->is_running() && ++i < 50);
@@ -102,8 +103,8 @@ static void land_detector_stop()
 }
 
 /**
-* Start new task, fails if it is already running. Returns OK if successful
-**/
+ * Start new task, fails if it is already running. Returns OK if successful
+ */
 static int land_detector_start(const char *mode)
 {
 	if (land_detector_task != nullptr) {
@@ -126,13 +127,13 @@ static int land_detector_start(const char *mode)
 		return -1;
 	}
 
-	//Check if alloc worked
+	// Check if alloc worked
 	if (land_detector_task == nullptr) {
 		PX4_WARN("alloc failed");
 		return -1;
 	}
 
-	//Start new thread task
+	// Start new thread task
 	int ret = land_detector_task->start();
 
 	if (ret) {
@@ -140,13 +141,12 @@ static int land_detector_start(const char *mode)
 		return -1;
 	}
 
-	/* avoid memory fragmentation by not exiting start handler until the task has fully started */
-	const uint64_t timeout = hrt_absolute_time() + 5000000; //5 second timeout
+	// Avoid memory fragmentation by not exiting start handler until the task has fully started
+	const uint64_t timeout = hrt_absolute_time() + 5000000; // 5 second timeout
 
-	/* avoid printing dots just yet and do one sleep before the first check */
+	// Do one sleep before the first check
 	usleep(10000);
 
-	/* check if the waiting involving dots and a newline are still needed */
 	if (!land_detector_task->is_running()) {
 		while (!land_detector_task->is_running()) {
 			usleep(50000);
@@ -167,8 +167,8 @@ static int land_detector_start(const char *mode)
 }
 
 /**
-* Main entry point for this module
-**/
+ * Main entry point for this module
+ */
 int land_detector_main(int argc, char *argv[])
 {
 

--- a/src/modules/land_detector/land_detector_params.c
+++ b/src/modules/land_detector/land_detector_params.c
@@ -174,3 +174,14 @@ PARAM_DEFINE_FLOAT(LNDFW_VELI_MAX, 4.0f);
  * @group Land Detector
  */
 PARAM_DEFINE_FLOAT(LNDFW_AIRSPD_MAX, 8.00f);
+
+/**
+ * Total flight time in microseconds
+ *
+ * Total flight time of this autopilot.
+ *
+ * @min 0
+ * @group Land Detector
+ *
+ */
+PARAM_DEFINE_INT32(LND_FLIGHT_TIME, 0);


### PR DESCRIPTION
This implementation is a baseline implementation and makes no attempt to be tamper-proof. A monotonic counter like the W25R64FV or a similar HW facility would be required to achieve this.