### PR TITLE
mc_position_control: Fix divide by zero in scale_control

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -805,7 +805,11 @@ MulticopterPositionControl::scale_control(float ctl, float end, float dz, float 
 		return -dy + (ctl + dz) * (1.0f - dy) / (end - dz);
 
 	} else {
-		return ctl * (dy / dz);
+		if (dz < FLT_EPSILON) {
+			return 0;
+		} else {
+			return ctl * (dy / dz);
+		}
 	}
 }
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -807,6 +807,7 @@ MulticopterPositionControl::scale_control(float ctl, float end, float dz, float 
 	} else {
 		if (dz < FLT_EPSILON) {
 			return 0;
+
 		} else {
 			return ctl * (dy / dz);
 		}


### PR DESCRIPTION
Fix for divide by zero error if MPC_ALTCTL_DZ is set to zero.