### PR TITLE
WIP: Move RX and frame buffers out of individual drivers

### DIFF
--- a/src/lib/rc/dsm.h
+++ b/src/lib/rc/dsm.h
@@ -51,16 +51,18 @@ __BEGIN_DECLS
 #define DSM_FRAME_SIZE		16		/**< DSM frame size in bytes */
 #define DSM_FRAME_CHANNELS	7		/**< Max supported DSM channels per frame */
 #define DSM_MAX_CHANNEL_COUNT   18  /**< Max channel count of any DSM RC */
-#define DSM_BUFFER_SIZE		(DSM_FRAME_SIZE + DSM_FRAME_SIZE / 2)
+#define DSM_RX_BUFFER_SIZE		(DSM_FRAME_SIZE + DSM_FRAME_SIZE / 2)
+#define DSM_DECODE_BUFFER_SIZE	(DSM_FRAME_SIZE * 2)
 
 __EXPORT int	dsm_init(const char *device);
 __EXPORT void	dsm_deinit(void);
 __EXPORT void	dsm_proto_init(void);
 __EXPORT int	dsm_config(int dsm_fd);
-__EXPORT bool	dsm_input(int dsm_fd, uint16_t *values, uint16_t *num_values, bool *dsm_11_bit, uint8_t *n_bytes,
+__EXPORT bool	dsm_input(int dsm_fd, uint8_t *decode_buf, uint16_t *values, uint16_t *num_values, bool *dsm_11_bit,
+			  uint8_t *n_bytes,
 			  uint8_t **bytes, unsigned max_values);
 
-__EXPORT bool	dsm_parse(uint64_t now, uint8_t *frame, unsigned len, uint16_t *values,
+__EXPORT bool	dsm_parse(uint8_t *decode_buf, uint64_t now, uint8_t *frame, unsigned len, uint16_t *values,
 			  uint16_t *num_values, bool *dsm_11_bit, unsigned *frame_drops, uint16_t max_channels);
 
 #ifdef GPIO_SPEKTRUM_PWR_EN

--- a/src/lib/rc/sbus.c
+++ b/src/lib/rc/sbus.c
@@ -225,7 +225,8 @@ sbus2_output(int sbus_fd, uint16_t *values, uint16_t num_values)
 }
 
 bool
-sbus_input(int sbus_fd, uint16_t *values, uint16_t *num_values, bool *sbus_failsafe, bool *sbus_frame_drop,
+sbus_input(int sbus_fd, uint8_t *decode_buf, uint16_t *values, uint16_t *num_values, bool *sbus_failsafe,
+	   bool *sbus_frame_drop,
 	   uint16_t max_channels)
 {
 	int		ret = 1;
@@ -265,7 +266,7 @@ sbus_input(int sbus_fd, uint16_t *values, uint16_t *num_values, bool *sbus_fails
 	/*
 	 * Try to decode something with what we got
 	 */
-	if (sbus_parse(now, &buf[0], ret, values, num_values, sbus_failsafe,
+	if (sbus_parse(uint8_t *decode_buf, now, &buf[0], ret, values, num_values, sbus_failsafe,
 		       sbus_frame_drop, &sbus_frame_drops, max_channels)) {
 
 		sbus_decoded = true;
@@ -275,10 +276,11 @@ sbus_input(int sbus_fd, uint16_t *values, uint16_t *num_values, bool *sbus_fails
 }
 
 bool
-sbus_parse(uint64_t now, uint8_t *frame, unsigned len, uint16_t *values,
+sbus_parse(uint8_t *decode_buf, uint64_t now, uint8_t *frame, unsigned len, uint16_t *values,
 	   uint16_t *num_values, bool *sbus_failsafe, bool *sbus_frame_drop, unsigned *frame_drops, uint16_t max_channels)
 {
 
+	sbus_frame = decode_buf;
 	last_rx_time = now;
 
 	/* this is set by the decoding state machine and will default to false

--- a/src/lib/rc/st24.c
+++ b/src/lib/rc/st24.c
@@ -74,7 +74,7 @@ const char *decode_states[] = {"UNSYNCED",
 static enum ST24_DECODE_STATE _decode_state = ST24_DECODE_STATE_UNSYNCED;
 static uint8_t _rxlen;
 
-static ReceiverFcPacket _rxpacket;
+static ReceiverFcPacket *_rxpacket;
 
 uint8_t st24_common_crc8(uint8_t *ptr, uint8_t len)
 {
@@ -103,9 +103,11 @@ uint8_t st24_common_crc8(uint8_t *ptr, uint8_t len)
 }
 
 
-int st24_decode(uint8_t byte, uint8_t *rssi, uint8_t *lost_count, uint16_t *channel_count, uint16_t *channels,
+int st24_decode(uint8_t *decode_buf, uint8_t byte, uint8_t *rssi, uint8_t *lost_count, uint16_t *channel_count,
+		uint16_t *channels,
 		uint16_t max_chan_count)
 {
+	_rxpacket = decode_buf;
 	int ret = 1;
 
 	switch (_decode_state) {

--- a/src/lib/rc/st24.h
+++ b/src/lib/rc/st24.h
@@ -138,6 +138,8 @@ typedef struct {
 
 #pragma pack(pop)
 
+#define ST24_DECODE_BUFFER_SIZE sizeof(ReceiverFcPacket)
+
 /**
  * CRC8 implementation for ST24 protocol
  *
@@ -157,7 +159,7 @@ uint8_t st24_common_crc8(uint8_t *ptr, uint8_t len);
  * @param max_chan_count maximum channels to decode - if more channels are decoded, the last n are skipped and success (0) is returned
  * @return 0 for success (a decoded packet), 1 for no packet yet (accumulating), 2 for unknown packet, 3 for out of sync, 4 for checksum error
  */
-__EXPORT int st24_decode(uint8_t byte, uint8_t *rssi, uint8_t *lost_count, uint16_t *channel_count,
+__EXPORT int st24_decode(uint8_t *decode_buf, uint8_t byte, uint8_t *rssi, uint8_t *lost_count, uint16_t *channel_count,
 			 uint16_t *channels, uint16_t max_chan_count);
 
 __END_DECLS

--- a/src/lib/rc/sumd.c
+++ b/src/lib/rc/sumd.c
@@ -88,8 +88,7 @@ bool		_debug		= false;
 static enum SUMD_DECODE_STATE _decode_state = SUMD_DECODE_STATE_UNSYNCED;
 static uint8_t _rxlen;
 
-static ReceiverFcPacketHoTT _rxpacket;
-
+static ReceiverFcPacketHoTT *_rxpacket;
 
 uint16_t sumd_crc16(uint16_t crc, uint8_t value)
 {
@@ -109,9 +108,11 @@ uint8_t sumd_crc8(uint8_t crc, uint8_t value)
 	return crc;
 }
 
-int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channel_count, uint16_t *channels,
+int sumd_decode(uint8_t *decode_buf, uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channel_count,
+		uint16_t *channels,
 		uint16_t max_chan_count, bool *failsafe)
 {
+	_rxpacket = decode_buf;
 
 	int ret = 1;
 
@@ -122,7 +123,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 		}
 
 		if (byte == SUMD_HEADER_ID) {
-			_rxpacket.header = byte;
+			_rxpacket->header = byte;
 			_sumd = true;
 			_rxlen = 0;
 			_crc16 = 0x0000;
@@ -144,7 +145,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 
 	case SUMD_DECODE_STATE_GOT_HEADER:
 		if (byte == SUMD_ID_SUMD || byte == SUMD_ID_FAILSAFE || byte == SUMD_ID_SUMH) {
-			_rxpacket.status = byte;
+			_rxpacket->status = byte;
 
 			if (byte == SUMD_ID_SUMH) {
 				_sumd = false;
@@ -171,7 +172,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 
 	case SUMD_DECODE_STATE_GOT_STATE:
 		if (byte >= 2 && byte <= SUMD_MAX_CHANNELS) {
-			_rxpacket.length = byte;
+			_rxpacket->length = byte;
 
 			if (_sumd) {
 				_crc16 = sumd_crc16(_crc16, byte);
@@ -194,7 +195,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 		break;
 
 	case SUMD_DECODE_STATE_GOT_LEN:
-		_rxpacket.sumd_data[_rxlen] = byte;
+		_rxpacket->sumd_data[_rxlen] = byte;
 
 		if (_sumd) {
 			_crc16 = sumd_crc16(_crc16, byte);
@@ -205,7 +206,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 
 		_rxlen++;
 
-		if (_rxlen <= ((_rxpacket.length * 2))) {
+		if (_rxlen <= ((_rxpacket->length * 2))) {
 			if (_debug) {
 				printf(" SUMD_DECODE_STATE_GOT_DATA[%d]: %x\n", _rxlen - 2, byte) ;
 			}
@@ -222,7 +223,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 		break;
 
 	case SUMD_DECODE_STATE_GOT_DATA:
-		_rxpacket.crc16_high = byte;
+		_rxpacket->crc16_high = byte;
 
 		if (_debug) {
 			printf(" SUMD_DECODE_STATE_GOT_CRC16[1]: %x   [%x]\n", byte, ((_crc16 >> 8) & 0xff)) ;
@@ -238,7 +239,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 		break;
 
 	case SUMD_DECODE_STATE_GOT_CRC16_BYTE_1:
-		_rxpacket.crc16_low = byte;
+		_rxpacket->crc16_low = byte;
 
 		if (_debug) {
 			printf(" SUMD_DECODE_STATE_GOT_CRC16[2]: %x   [%x]\n", byte, (_crc16 & 0xff)) ;
@@ -249,7 +250,7 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 		break;
 
 	case SUMD_DECODE_STATE_GOT_CRC16_BYTE_2:
-		_rxpacket.telemetry = byte;
+		_rxpacket->telemetry = byte;
 
 		if (_debug) {
 			printf(" SUMD_DECODE_STATE_GOT_SUMH_TELEMETRY: %x\n", byte) ;
@@ -261,24 +262,24 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 
 	case SUMD_DECODE_STATE_GOT_CRC:
 		if (_sumd) {
-			_rxpacket.crc16_low = byte;
+			_rxpacket->crc16_low = byte;
 
 			if (_debug) {
 				printf(" SUMD_DECODE_STATE_GOT_CRC[2]: %x   [%x]\n\n", byte, (_crc16 & 0xff)) ;
 			}
 
-			if (_crc16 == (uint16_t)(_rxpacket.crc16_high << 8) + _rxpacket.crc16_low) {
+			if (_crc16 == (uint16_t)(_rxpacket->crc16_high << 8) + _rxpacket->crc16_low) {
 				_crcOK = true;
 			}
 
 		} else {
-			_rxpacket.crc8 = byte;
+			_rxpacket->crc8 = byte;
 
 			if (_debug) {
 				printf(" SUMD_DECODE_STATE_GOT_CRC8_SUMH: %x   [%x]\n\n", byte, _crc8) ;
 			}
 
-			if (_crc8 == _rxpacket.crc8) {
+			if (_crc8 == _rxpacket->crc8) {
 				_crcOK = true;
 			}
 		}
@@ -312,38 +313,38 @@ int sumd_decode(uint8_t byte, uint8_t *rssi, uint8_t *rx_count, uint16_t *channe
 			*rssi = 100;
 
 			/* failsafe flag */
-			*failsafe = (_rxpacket.status == SUMD_ID_FAILSAFE);
+			*failsafe = (_rxpacket->status == SUMD_ID_FAILSAFE);
 
 			/* received Channels */
-			if ((uint16_t)_rxpacket.length > max_chan_count) {
+			if ((uint16_t)_rxpacket->length > max_chan_count) {
 				_rxpacket.length = (uint8_t) max_chan_count;
 			}
 
-			*channel_count = (uint16_t)_rxpacket.length;
+			*channel_count = (uint16_t)_rxpacket->length;
 
 			/* decode the actual packet */
 			/* reorder first 4 channels */
 
 			/* ch1 = roll -> sumd = ch2 */
-			channels[0] = (uint16_t)((_rxpacket.sumd_data[1 * 2 + 1] << 8) | _rxpacket.sumd_data[1 * 2 + 2]) >> 3;
+			channels[0] = (uint16_t)((_rxpacket->sumd_data[1 * 2 + 1] << 8) | _rxpacket->sumd_data[1 * 2 + 2]) >> 3;
 			/* ch2 = pitch -> sumd = ch2 */
-			channels[1] = (uint16_t)((_rxpacket.sumd_data[2 * 2 + 1] << 8) | _rxpacket.sumd_data[2 * 2 + 2]) >> 3;
+			channels[1] = (uint16_t)((_rxpacket->sumd_data[2 * 2 + 1] << 8) | _rxpacket->sumd_data[2 * 2 + 2]) >> 3;
 			/* ch3 = throttle -> sumd = ch2 */
-			channels[2] = (uint16_t)((_rxpacket.sumd_data[0 * 2 + 1] << 8) | _rxpacket.sumd_data[0 * 2 + 2]) >> 3;
+			channels[2] = (uint16_t)((_rxpacket->sumd_data[0 * 2 + 1] << 8) | _rxpacket->sumd_data[0 * 2 + 2]) >> 3;
 			/* ch4 = yaw -> sumd = ch2 */
-			channels[3] = (uint16_t)((_rxpacket.sumd_data[3 * 2 + 1] << 8) | _rxpacket.sumd_data[3 * 2 + 2]) >> 3;
+			channels[3] = (uint16_t)((_rxpacket->sumd_data[3 * 2 + 1] << 8) | _rxpacket->sumd_data[3 * 2 + 2]) >> 3;
 
 			/* we start at channel 5(index 4) */
 			unsigned chan_index = 4;
 
-			for (i = 4; i < _rxpacket.length; i++) {
+			for (i = 4; i < _rxpacket->length; i++) {
 				if (_debug) {
-					printf("ch[%d] : %x %x [ %x    %d ]\n", i + 1, _rxpacket.sumd_data[i * 2 + 1], _rxpacket.sumd_data[i * 2 + 2],
-					       ((_rxpacket.sumd_data[i * 2 + 1] << 8) | _rxpacket.sumd_data[i * 2 + 2]) >> 3,
-					       ((_rxpacket.sumd_data[i * 2 + 1] << 8) | _rxpacket.sumd_data[i * 2 + 2]) >> 3);
+					printf("ch[%d] : %x %x [ %x    %d ]\n", i + 1, _rxpacket->sumd_data[i * 2 + 1], _rxpacket->sumd_data[i * 2 + 2],
+					       ((_rxpacket->sumd_data[i * 2 + 1] << 8) | _rxpacket->sumd_data[i * 2 + 2]) >> 3,
+					       ((_rxpacket->sumd_data[i * 2 + 1] << 8) | _rxpacket->sumd_data[i * 2 + 2]) >> 3);
 				}
 
-				channels[chan_index] = (uint16_t)((_rxpacket.sumd_data[i * 2 + 1] << 8) | _rxpacket.sumd_data[i * 2 + 2]) >> 3;
+				channels[chan_index] = (uint16_t)((_rxpacket->sumd_data[i * 2 + 1] << 8) | _rxpacket->sumd_data[i * 2 + 2]) >> 3;
 				/* convert values to 1000-2000 ppm encoding in a not too sloppy fashion */
 				//channels[chan_index] = (uint16_t)(channels[chan_index] * SUMD_SCALE_FACTOR + .5f) + SUMD_SCALE_OFFSET;
 

--- a/src/lib/rc/sumd.h
+++ b/src/lib/rc/sumd.h
@@ -68,6 +68,7 @@ typedef struct {
 } ReceiverFcPacketHoTT;
 #pragma pack(pop)
 
+#define SUMD_DECODE_BUFFER_SIZE sizeof(ReceiverFcPacketHoTT)
 
 /**
  * CRC16 implementation for SUMD protocol

--- a/src/modules/px4iofirmware/controls.c
+++ b/src/modules/px4iofirmware/controls.c
@@ -44,10 +44,7 @@
 #include <drivers/drv_rc_input.h>
 #include <systemlib/perf_counter.h>
 #include <systemlib/ppm_decode.h>
-#include <rc/st24.h>
-#include <rc/sumd.h>
-#include <rc/sbus.h>
-#include <rc/dsm.h>
+#include <rc/rc.h>
 
 #include "px4io.h"
 
@@ -60,6 +57,9 @@ static bool	dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated
 static perf_counter_t c_gather_dsm;
 static perf_counter_t c_gather_sbus;
 static perf_counter_t c_gather_ppm;
+
+static uint8_t rx_buf[rc_rx_buf_size()];
+static uint8_t decode_buf[rc_decode_buf_size()];
 
 static int _dsm_fd = -1;
 int _sbus_fd = -1;
@@ -104,7 +104,7 @@ bool dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool 
 	for (unsigned i = 0; i < n_bytes; i++) {
 		/* set updated flag if one complete packet was parsed */
 		st24_rssi = RC_INPUT_RSSI_MAX;
-		*st24_updated |= (OK == st24_decode(bytes[i], &st24_rssi, &lost_count,
+		*st24_updated |= (OK == st24_decode(&decode_buf[0], bytes[i], &st24_rssi, &lost_count,
 						    &st24_channel_count, r_raw_rc_values, PX4IO_RC_INPUT_CHANNELS));
 	}
 


### PR DESCRIPTION
This is not finished and not compiling yet, but should show how we need to rework the RC parsers to consume a couple hundred bytes less RAM on IO.