### PR TITLE
dsm rctest num_values return

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,12 @@ matrix:
       sudo: required
       services:
         - docker
-      env: BUILD_TARGET=clang-tidy PX4_DOCKER_REPO=px4io/px4-dev-clang
+      env: BUILD_TARGET=tests_linux
+    - os: linux
+      sudo: required
+      services:
+        - docker
+      env: BUILD_TARGET=clang-tidy
     - os: osx
       sudo: true
       osx_image: xcode8
@@ -50,6 +55,8 @@ script:
       ./Tools/docker_run.sh 'make qgc_firmware';
     elif [[ "${BUILD_TARGET}" = "check_format" && "${TRAVIS_BRANCH}" != "coverity" ]]; then
       ./Tools/docker_run.sh 'make check_format';
+    elif [[ "${BUILD_TARGET}" = "tests_linux" && "${TRAVIS_BRANCH}" != "coverity" ]]; then
+      ./Tools/docker_run.sh 'make tests';
     elif [[ "${BUILD_TARGET}" = "clang-tidy" && "${TRAVIS_BRANCH}" != "coverity" ]]; then
       PX4_DOCKER_REPO=px4io/px4-dev-clang ./Tools/docker_run.sh 'make clang-tidy';
     elif [ "${TRAVIS_OS_NAME}" = "osx" ]; then

--- a/src/lib/rc/dsm.c
+++ b/src/lib/rc/dsm.c
@@ -594,7 +594,7 @@ dsm_input(int fd, uint16_t *values, uint16_t *num_values, bool *dsm_11_bit, uint
 }
 
 bool
-dsm_parse(uint64_t now, uint8_t *frame, unsigned len, uint16_t *values,
+dsm_parse(const uint64_t now, const uint8_t *frame, const unsigned len, uint16_t *values,
 	  uint16_t *num_values, bool *dsm_11_bit, unsigned *frame_drops, uint16_t max_channels)
 {
 
@@ -691,10 +691,7 @@ dsm_parse(uint64_t now, uint8_t *frame, unsigned len, uint16_t *values,
 	}
 
 	if (decode_ret) {
-		/* num values should not decrease, only increase */
-		if (dsm_chan_count > *num_values) {
-			*num_values = dsm_chan_count;
-		}
+		*num_values = dsm_chan_count;
 
 		memcpy(&values[0], &dsm_chan_buf[0], dsm_chan_count * sizeof(dsm_chan_buf[0]));
 #ifdef DSM_DEBUG

--- a/src/lib/rc/dsm.h
+++ b/src/lib/rc/dsm.h
@@ -60,7 +60,7 @@ __EXPORT int	dsm_config(int dsm_fd);
 __EXPORT bool	dsm_input(int dsm_fd, uint16_t *values, uint16_t *num_values, bool *dsm_11_bit, uint8_t *n_bytes,
 			  uint8_t **bytes, unsigned max_values);
 
-__EXPORT bool	dsm_parse(uint64_t now, uint8_t *frame, unsigned len, uint16_t *values,
+__EXPORT bool	dsm_parse(const uint64_t now, const uint8_t *frame, const unsigned len, uint16_t *values,
 			  uint16_t *num_values, bool *dsm_11_bit, unsigned *frame_drops, uint16_t max_channels);
 
 #ifdef GPIO_SPEKTRUM_PWR_EN

--- a/src/lib/rc/rc_tests/RCTest.cpp
+++ b/src/lib/rc/rc_tests/RCTest.cpp
@@ -103,7 +103,7 @@ bool RCTest::dsmTest(const char *filepath, unsigned expected_chancount, unsigned
 					&dsm_11_bit, &dsm_frame_drops, max_channels);
 
 		if (result) {
-			ut_test(num_values == expected_chancount);
+			ut_compare("num_values == expected_chancount", num_values, expected_chancount);
 
 			ut_test(abs((int)chan0 - (int)rc_values[0]) < 30);
 


### PR DESCRIPTION
@smithandrewc @LorenzMeier dsm_parse() was changed here and causes the rc tests to fail if built with optimization - https://github.com/PX4/Firmware/commit/12a34c9fcfd184dac7cdb1e10ae1444274aefba0#diff-a4fb34c61c3e2506bd9bfcf1f7151356

num_values is passed in and not necessarily initialized.
If you run the rc test locally with optimization on it should fail. `make tests`
In the builds the tests are currently only running on OSX and on Linux built for test coverage. Neither were failing.

	INFO  [rc_tests] RUNNING TEST: dsmTest10Ch
	INFO  [rc_tests] frame dropped, now #1
	INFO  [rc_tests] frame dropped, now #2
	INFO  [rc_tests] frame dropped, now #3
	INFO  [rc_tests] frame dropped, now #4
	INFO  [rc_tests] frame dropped, now #5
	ERROR [modules__unit_test] Assertion failed: test - num_values == expected_chancount (../src/lib/rc/rc_tests/RCTest.cpp:106)
	ERROR [rc_tests] TEST FAILED: dsmTest10Ch
	INFO  [rc_tests] RUNNING TEST: dsmTest12Ch
	INFO  [rc_tests] frame dropped, now #1
	INFO  [rc_tests] frame dropped, now #2
	INFO  [rc_tests] frame dropped, now #3
	INFO  [rc_tests] frame dropped, now #4
	INFO  [rc_tests] frame dropped, now #5
	INFO  [rc_tests] frame dropped, now #6
	ERROR [modules__unit_test] Assertion failed: test - num_values == expected_chancount (../src/lib/rc/rc_tests/RCTest.cpp:106)


Can you review and tell me if this is correct? Do we need to initialize for the tests or is the new code in dsm_parse wrong?


