### PR TITLE
sdlog2_dump.py skip unknown message type

### DIFF
--- a/Tools/sdlog2/sdlog2_dump.py
+++ b/Tools/sdlog2/sdlog2_dump.py
@@ -142,9 +142,13 @@ class SDLog2Parser:
                     self.__parseMsgDescr()
                 else:
                     # parse data message
-                    msg_descr = self.__msg_descrs[msg_type]
+                    msg_descr = self.__msg_descrs.get(msg_type, None)
                     if msg_descr == None:
-                        raise Exception("Unknown msg type: %i" % msg_type)
+                        if self.__correct_errors:
+                            self.__ptr += 1
+                            continue
+                        else:
+                            raise Exception("Unknown msg type: %i" % msg_type)
                     msg_length = msg_descr[0]
                     if self.__bytesLeft() < msg_length:
                         break


### PR DESCRIPTION
The parser stopped halfway on an unknown message type (164). Don't know the exact reason, maybe my logfile is corrupt. Anyway, with this modification it just continues with the next message if the "-e" option is used.

Tested in python 3.52 and 2.7.12