### PR TITLE
aerofc: disable internal compass

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -289,11 +289,6 @@ then
 	then
 	fi
 
-	# Internal compass
-	if hmc5883 -I -R 4 start
-	then
-	fi
-
 	# Possible external compasses
 	if hmc5883 -X start
 	then


### PR DESCRIPTION
It uses a shared I2C bus with MS65611 which causes noise on the baro
reads. This will rely on the external compass instead of the internal
one.