### PR TITLE
Feature publish commander status flags

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -119,6 +119,7 @@ set(msg_file_names
 	vehicle_local_position_setpoint.msg
 	vehicle_rates_setpoint.msg
 	vehicle_status.msg
+	vehicle_status_flags.msg
 	vision_position_estimate.msg
 	vtol_vehicle_status.msg
 	wind_estimate.msg

--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -1,0 +1,73 @@
+# define mask for conditions flags
+uint16 CONDITION_CALIBRATION_ENABLE_MASK = 1
+uint16 CONDITION_SYSTEM_SENSORS_INITIALIZED_MASK = 2
+uint16 CONDITION_SYSTEM_PREARM_ERROR_REPORTED_MASK = 4
+uint16 CONDITION_SYSTEM_HOTPLUG_TIMEOUT_MASK = 8
+uint16 CONDITION_SYSTEM_RETURNED_TO_HOME_MASK = 16
+uint16 CONDITION_AUTO_MISSION_AVAILABLE_MASK = 32
+uint16 CONDITION_GLOBAL_POSITION_VALID_MASK = 64
+uint16 CONDITION_HOME_POSITION_VALID_MASK = 128
+uint16 CONDITION_LOCAL_POSITION_VALID_MASK = 256
+uint16 CONDITION_LOCAL_ALTITUDE_VALID_MASK = 512
+uint16 CONDITION_AIRSPEED_VALID_MASK = 1024
+uint16 CONDITION_POWER_INPUT_VALID_MASK = 2048
+# uint16 reserved for future implementation
+# uint16 reserved for future implementation
+# uint16 reserved for future implementation
+# uint16 reserved for future implementation
+
+uint16 conditions
+
+# define mask for circuit breaker flags
+uint8 CIRCUIT_BREAKER_ENGAGED_POWER_CHECK_MASK = 1
+uint8 CIRCUIT_BREAKER_ENGAGED_AIRSPD_CHECK_MASK = 2
+uint8 CIRCUIT_BREAKER_ENGAGED_ENGINEFAILURE_CHECK_MASK = 4
+uint8 CIRCUIT_BREAKER_ENGAGED_GPSFAILURE_CHECK_MASK = 8
+uint8 CIRCUIT_BREAKER_FLIGHT_TERMINATION_DISABLED_MASK = 16
+uint8 CIRCUIT_BREAKER_ENGAGED_USB_CHECK_MASK = 32
+
+# 0x0001 circuit_breaker_engaged_power_check
+# 0x0002 circuit_breaker_engaged_airspd_check
+# 0x0004 circuit_breaker_engaged_enginefailure_check
+# 0x0008 circuit_breaker_engaged_gpsfailure_check
+# 0x0010 circuit_breaker_flight_termination_disabled
+# 0x0020 circuit_breaker_engaged_usb_check
+
+uint8 circuit_breakers
+
+# define mask for other flags
+uint16 USB_CONNECTED_MASK = 1
+uint16 OFFBOARD_CONTROL_SIGNAL_FOUND_ONCE_MASK = 2
+uint16 OFFBOARD_CONTROL_SIGNAL_LOST_MASK = 4
+uint16 OFFBOARD_CONTROL_SIGNAL_WEAK_MASK = 8
+uint16 OFFBOARD_CONTROL_SET_BY_COMMAND_MASK = 16
+uint16 OFFBOARD_CONTROL_LOSS_TIMEOUT_MASK = 32
+uint16 RC_SIGNAL_FOUND_ONCE_MASK = 64
+uint16 RC_SIGNAL_LOST_CMD_MASK = 128
+uint16 RC_INPUT_BLOCKED_MASK = 256
+uint16 DATA_LINK_LOST_CMD_MASK = 512
+uint16 VTOL_TRANSITION_FAILURE_MASK = 1024
+uint16 VTOL_TRANSITION_FAILURE_CMD_MASK = 2048
+uint16 GPS_FAILURE_MASK = 4096
+uint16 GPS_FAILURE_CMD_MASK = 8192
+uint16 BAROMETER_FAILURE_MASK = 16384
+uint16 EVER_HAD_BAROMETER_DATA_MASK = 32768
+
+# 0x0001 usb_connected: status of the USB power supply
+# 0x0002 offboard_control_signal_found_once
+# 0x0004 offboard_control_signal_lost
+# 0x0008 offboard_control_signal_weak
+# 0x0010 offboard_control_set_by_command: true if the offboard mode was set by a mavlink command and should not be overridden by RC
+# 0x0020 offboard_control_loss_timeout: true if offboard is lost for a certain amount of time
+# 0x0040 rc_signal_found_once
+# 0x0080 rc_signal_lost_cmd: true if RC lost mode is commanded
+# 0x0100 rc_input_blocked: set if RC input should be ignored temporarily
+# 0x0200 data_link_lost_cmd: datalink to GCS lost mode commanded
+# 0x0400 vtol_transition_failure: Set to true if vtol transition failed
+# 0x0800 vtol_transition_failure_cmd: Set to true if vtol transition failure mode is commanded
+# 0x1000 gps_failure: Set to true if a gps failure is detected
+# 0x2000 gps_failure_cmd: Set to true if a gps failure mode is commanded
+# 0x4000 barometer_failure: Set to true if a barometer failure is detected
+# 0x8000 ever_had_barometer_data: Set to true if ever had valid barometer data before
+
+uint16 other_flags

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -116,6 +116,7 @@
 #include <uORB/topics/vehicle_gps_position.h>
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_status_flags.h>
 #include <uORB/topics/vtol_vehicle_status.h>
 
 typedef enum VEHICLE_MODE_FLAG
@@ -295,6 +296,9 @@ void *commander_low_prio_loop(void *arg);
 
 void answer_command(struct vehicle_command_s &cmd, unsigned result,
 					orb_advert_t &command_ack_pub, vehicle_command_ack_s &command_ack);
+
+/* publish vehicle status flags from the global variable status_flags*/
+void publish_status_flags(orb_advert_t vehicle_status_flags_pub);
 
 /**
  * check whether autostart ID is in the reserved range for HIL setups
@@ -1458,6 +1462,8 @@ int commander_thread_main(int argc, char *argv[])
 	mission_s mission;
 
 	orb_advert_t commander_state_pub = nullptr;
+
+	orb_advert_t vehicle_status_flags_pub = nullptr;
 
 	if (dm_read(DM_KEY_MISSION_STATE, 0, &mission, sizeof(mission_s)) == sizeof(mission_s)) {
 		if (mission.dataman_id >= 0 && mission.dataman_id <= 1) {
@@ -3062,6 +3068,8 @@ int commander_thread_main(int argc, char *argv[])
 			have_taken_off_since_arming = false;
 		}
 
+		/* publish vehicle_status_flags */
+		publish_status_flags(vehicle_status_flags_pub);
 
 		/* publish internal state for logging purposes */
 		if (commander_state_pub != nullptr) {
@@ -4170,4 +4178,126 @@ void *commander_low_prio_loop(void *arg)
 	px4_close(cmd_sub);
 
 	return NULL;
+}
+
+void publish_status_flags(orb_advert_t vehicle_status_flags_pub){
+	struct vehicle_status_flags_s v_flags;
+	memset(&v_flags, 0, sizeof(v_flags));
+	/* set condition status flags */
+	if (status_flags.condition_calibration_enabled) {
+		v_flags.conditions |= vehicle_status_flags_s::CONDITION_CALIBRATION_ENABLE_MASK;
+	}
+	if (status_flags.condition_system_sensors_initialized) {
+		v_flags.conditions |= vehicle_status_flags_s::CONDITION_SYSTEM_SENSORS_INITIALIZED_MASK;
+	}
+	if (status_flags.condition_system_prearm_error_reported) {
+		v_flags.conditions |= vehicle_status_flags_s::CONDITION_SYSTEM_PREARM_ERROR_REPORTED_MASK;
+	}
+	if (status_flags.condition_system_hotplug_timeout) {
+		v_flags.conditions |= vehicle_status_flags_s::CONDITION_SYSTEM_HOTPLUG_TIMEOUT_MASK;
+	}
+	if (status_flags.condition_system_returned_to_home) {
+		v_flags.conditions |= vehicle_status_flags_s::CONDITION_SYSTEM_RETURNED_TO_HOME_MASK;
+	}
+	if (status_flags.condition_auto_mission_available) {
+		v_flags.conditions |= vehicle_status_flags_s::CONDITION_AUTO_MISSION_AVAILABLE_MASK;
+	}
+	if (status_flags.condition_global_position_valid) {
+		v_flags.conditions |= vehicle_status_flags_s::CONDITION_GLOBAL_POSITION_VALID_MASK;
+	}
+	if (status_flags.condition_home_position_valid) {
+		v_flags.conditions |= vehicle_status_flags_s::CONDITION_HOME_POSITION_VALID_MASK;
+	}
+	if (status_flags.condition_local_position_valid) {
+		v_flags.conditions |= vehicle_status_flags_s::CONDITION_LOCAL_POSITION_VALID_MASK;
+	}
+	if (status_flags.condition_local_altitude_valid) {
+		v_flags.conditions |= vehicle_status_flags_s::CONDITION_LOCAL_ALTITUDE_VALID_MASK;
+	}
+	if (status_flags.condition_local_altitude_valid) {
+		v_flags.conditions |= vehicle_status_flags_s::CONDITION_LOCAL_ALTITUDE_VALID_MASK;
+	}
+	if (status_flags.condition_airspeed_valid) {
+		v_flags.conditions |= vehicle_status_flags_s::CONDITION_AIRSPEED_VALID_MASK;
+	}
+	if (status_flags.condition_power_input_valid) {
+		v_flags.conditions |= vehicle_status_flags_s::CONDITION_POWER_INPUT_VALID_MASK;
+	}
+
+	/* set circuit breaker status flags */
+	if (status_flags.circuit_breaker_engaged_power_check) {
+		v_flags.circuit_breakers |= vehicle_status_flags_s::CIRCUIT_BREAKER_ENGAGED_POWER_CHECK_MASK;
+	}
+	if (status_flags.circuit_breaker_engaged_airspd_check) {
+		v_flags.circuit_breakers |= vehicle_status_flags_s::CIRCUIT_BREAKER_ENGAGED_AIRSPD_CHECK_MASK;
+	}
+	if (status_flags.circuit_breaker_engaged_enginefailure_check) {
+		v_flags.circuit_breakers |= vehicle_status_flags_s::CIRCUIT_BREAKER_ENGAGED_ENGINEFAILURE_CHECK_MASK;
+	}
+	if (status_flags.circuit_breaker_engaged_gpsfailure_check) {
+		v_flags.circuit_breakers |= vehicle_status_flags_s::CIRCUIT_BREAKER_ENGAGED_GPSFAILURE_CHECK_MASK;
+	}
+	if (status_flags.circuit_breaker_flight_termination_disabled) {
+		v_flags.circuit_breakers |= vehicle_status_flags_s::CIRCUIT_BREAKER_FLIGHT_TERMINATION_DISABLED_MASK;
+	}
+	if (status_flags.circuit_breaker_engaged_usb_check) {
+		v_flags.circuit_breakers |= vehicle_status_flags_s::CIRCUIT_BREAKER_ENGAGED_USB_CHECK_MASK;
+	}
+
+	/* set other status flags */
+	if (status_flags.usb_connected) {
+		v_flags.other_flags |= vehicle_status_flags_s::USB_CONNECTED_MASK;
+	}
+	if (status_flags.offboard_control_signal_found_once) {
+		v_flags.other_flags |= vehicle_status_flags_s::OFFBOARD_CONTROL_SIGNAL_FOUND_ONCE_MASK;
+	}
+	if (status_flags.offboard_control_signal_lost) {
+		v_flags.other_flags |= vehicle_status_flags_s::OFFBOARD_CONTROL_SIGNAL_LOST_MASK;
+	}
+	if (status_flags.offboard_control_signal_weak) {
+		v_flags.other_flags |= vehicle_status_flags_s::OFFBOARD_CONTROL_SIGNAL_WEAK_MASK;
+	}
+	if (status_flags.offboard_control_set_by_command) {
+		v_flags.other_flags |= vehicle_status_flags_s::OFFBOARD_CONTROL_SET_BY_COMMAND_MASK;
+	}
+	if (status_flags.offboard_control_loss_timeout) {
+		v_flags.other_flags |= vehicle_status_flags_s::OFFBOARD_CONTROL_LOSS_TIMEOUT_MASK;
+	}
+	if (status_flags.rc_signal_found_once) {
+		v_flags.other_flags |= vehicle_status_flags_s::RC_SIGNAL_FOUND_ONCE_MASK;
+	}
+	if (status_flags.rc_signal_lost_cmd) {
+		v_flags.other_flags |= vehicle_status_flags_s::RC_SIGNAL_LOST_CMD_MASK;
+	}
+	if (status_flags.rc_input_blocked) {
+		v_flags.other_flags |= vehicle_status_flags_s::RC_INPUT_BLOCKED_MASK;
+	}
+	if (status_flags.data_link_lost_cmd) {
+		v_flags.other_flags |= vehicle_status_flags_s::DATA_LINK_LOST_CMD_MASK;
+	}
+	if (status_flags.vtol_transition_failure) {
+		v_flags.other_flags |= vehicle_status_flags_s::VTOL_TRANSITION_FAILURE_MASK;
+	}
+	if (status_flags.vtol_transition_failure_cmd) {
+		v_flags.other_flags |= vehicle_status_flags_s::VTOL_TRANSITION_FAILURE_CMD_MASK;
+	}
+	if (status_flags.gps_failure) {
+		v_flags.other_flags |= vehicle_status_flags_s::GPS_FAILURE_MASK;
+	}
+	if (status_flags.gps_failure_cmd) {
+		v_flags.other_flags |= vehicle_status_flags_s::GPS_FAILURE_CMD_MASK;
+	}
+	if (status_flags.barometer_failure) {
+		v_flags.other_flags |= vehicle_status_flags_s::BAROMETER_FAILURE_MASK;
+	}
+	if (status_flags.ever_had_barometer_data) {
+		v_flags.other_flags |= vehicle_status_flags_s::EVER_HAD_BAROMETER_DATA_MASK;
+	}
+
+	/* publish vehicle_status_flags */
+	if (vehicle_status_flags_pub != nullptr) {
+		orb_publish(ORB_ID(vehicle_status_flags), vehicle_status_flags_pub, &v_flags);
+	}else{
+		vehicle_status_flags_pub = orb_advertise(ORB_ID(vehicle_status_flags), &v_flags);
+	}
 }


### PR DESCRIPTION
With this message is possible to get the internal commander status flags system wide.
This would enable to separate the low priority staff from the commander such as LED or tune logic.