### PR TITLE
total system flight time update & fix

### DIFF
--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -103,7 +103,8 @@ void LandDetector::_cycle()
 		_landDetected.freefall = false;
 		_landDetected.landed = false;
 		_landDetected.ground_contact = false;
-		_p_total_flight_time = param_find("LND_FLIGHT_TIME");
+		_p_total_flight_time_high = param_find("LND_FLIGHT_T_HI");
+		_p_total_flight_time_low = param_find("LND_FLIGHT_T_LO");
 
 		// Initialize uORB topics.
 		_initialize_topics();
@@ -141,7 +142,10 @@ void LandDetector::_cycle()
 			// We landed
 			_total_flight_time += now - _takeoff_time;
 			_takeoff_time = 0;
-			param_set(_p_total_flight_time, &_total_flight_time);
+			int32_t flight_time = (_total_flight_time >> 32) & 0xffffffff;
+			param_set_no_notification(_p_total_flight_time_high, &flight_time);
+			flight_time = _total_flight_time & 0xffffffff;
+			param_set_no_notification(_p_total_flight_time_low, &flight_time);
 		}
 
 		_landDetected.timestamp = hrt_absolute_time();
@@ -178,7 +182,11 @@ void LandDetector::_check_params(const bool force)
 
 	if (updated || force) {
 		_update_params();
-		param_get(_p_total_flight_time, &_total_flight_time);
+		int32_t flight_time;
+		param_get(_p_total_flight_time_high, &flight_time);
+		_total_flight_time = ((uint64_t)flight_time) << 32;
+		param_get(_p_total_flight_time_low, &flight_time);
+		_total_flight_time |= flight_time;
 	}
 }
 

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -133,20 +133,21 @@ void LandDetector::_cycle()
 	    (_landDetected.landed != landDetected) ||
 	    (_landDetected.ground_contact != ground_contactDetected)) {
 
-		_landDetected.timestamp = hrt_absolute_time();
-		_landDetected.freefall = (_state == LandDetectionState::FREEFALL);
-		_landDetected.landed = (_state == LandDetectionState::LANDED);
-		_landDetected.ground_contact = (_state == LandDetectionState::GROUND_CONTACT);
-
-		// We did take off
-		if (landDetected && !_landDetected.landed) {
+		if (!landDetected && _landDetected.landed) {
+			// We did take off
 			_takeoff_time = now;
 
-		} else if (_takeoff_time != 0 && !landDetected && _landDetected.landed) {
+		} else if (_takeoff_time != 0 && landDetected && !_landDetected.landed) {
+			// We landed
 			_total_flight_time += now - _takeoff_time;
 			_takeoff_time = 0;
 			param_set(_p_total_flight_time, &_total_flight_time);
 		}
+
+		_landDetected.timestamp = hrt_absolute_time();
+		_landDetected.freefall = (_state == LandDetectionState::FREEFALL);
+		_landDetected.landed = (_state == LandDetectionState::LANDED);
+		_landDetected.ground_contact = (_state == LandDetectionState::GROUND_CONTACT);
 
 		int instance;
 		orb_publish_auto(ORB_ID(vehicle_land_detected), &_landDetectedPub, &_landDetected,

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -166,8 +166,9 @@ private:
 	bool _taskShouldExit;
 	bool _taskIsRunning;
 
-	param_t _p_total_flight_time;
-	int32_t _total_flight_time;
+	param_t _p_total_flight_time_high;
+	param_t _p_total_flight_time_low;
+	uint64_t _total_flight_time; ///< in microseconds
 	hrt_abstime _takeoff_time;
 
 	struct work_s	_work;

--- a/src/modules/land_detector/land_detector_params.c
+++ b/src/modules/land_detector/land_detector_params.c
@@ -178,10 +178,23 @@ PARAM_DEFINE_FLOAT(LNDFW_AIRSPD_MAX, 8.00f);
 /**
  * Total flight time in microseconds
  *
- * Total flight time of this autopilot.
+ * Total flight time of this autopilot. Higher 32 bits of the value.
+ * Flight time in microseconds = (LND_FLIGHT_T_HI << 32) | LND_FLIGHT_T_LO.
  *
  * @min 0
  * @group Land Detector
  *
  */
-PARAM_DEFINE_INT32(LND_FLIGHT_TIME, 0);
+PARAM_DEFINE_INT32(LND_FLIGHT_T_HI, 0);
+
+/**
+ * Total flight time in microseconds
+ *
+ * Total flight time of this autopilot. Lower 32 bits of the value.
+ * Flight time in microseconds = (LND_FLIGHT_T_HI << 32) | LND_FLIGHT_T_LO.
+ *
+ * @min 0
+ * @group Land Detector
+ *
+ */
+PARAM_DEFINE_INT32(LND_FLIGHT_T_LO, 0);


### PR DESCRIPTION
- fix landed & takeoff logic
- use a 64bit counter for total system flight time
    
The previous 32bit counter wrapped in ~1.19h, this switches to 2 32bit counters, wrapping in 584942 years.

Follow-up to #6466
