### PR TITLE
mc_pos_control: limit slewrate different in up and down direction

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -459,6 +459,30 @@ PARAM_DEFINE_FLOAT(MPC_VELD_LP, 5.0f);
 PARAM_DEFINE_FLOAT(MPC_ACC_HOR_MAX, 5.0f);
 
 /**
+ * Maximum vertical acceleration in velocity controlled modes upward
+ *
+ * @unit m/s/s
+ * @min 2.0
+ * @max 15.0
+ * @increment 1
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_ACC_UP_MAX, 10.0f);
+
+/**
+ * Maximum vertical acceleration in velocity controlled modes down
+ *
+ * @unit m/s/s
+ * @min 2.0
+ * @max 15.0
+ * @increment 1
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_ACC_DOWN_MAX, 5.0f);
+
+/**
  * Altitude control mode, note mode 1 only tested with LPE
  *
  * @min 0


### PR DESCRIPTION
Fixes dependency of max_acceleration in z direction from max_acceleration in xy direction;
Prevents fast changes in acceleration downwards