### PR TITLE
Use wild card *_PX4_* for upload

### DIFF
--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -510,6 +510,7 @@ function(px4_add_upload)
 	set(serial_ports)
 	if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Linux")
 		list(APPEND serial_ports
+			/dev/serial/by-id/*_PX4_*
 			/dev/serial/by-id/usb-3D_Robotics*
 			/dev/serial/by-id/usb-The_Autopilot*
 			/dev/serial/by-id/usb-Bitcraze*


### PR DESCRIPTION
Compliments the Bootloader change to simplify the ripple effect on the tools, we will be using  /dev/serial/by-id/*_PX4_* to locate PX4 devices. Therefore  moving forward all Bootloaders must contain the prefix "PX4 BL "  in the USBDEVICESTRING