### PR TITLE
Navigator: Fix takeoff handling if already in air

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -621,6 +621,10 @@ Mission::set_mission_items()
 			_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
 			/* ignore yaw here, otherwise it might yaw before heading_sp_update takes over */
 			_mission_item.yaw = NAN;
+			/* since _mission_item.time_inside and and _mission_item.pitch_min build a union, we need to set time_inside to zero
+			 * since in NAV_CMD_TAKEOFF mode there is currently no time_inside.
+			 */
+			_mission_item.time_inside = 0.0f;
 		}
 
 		/* if we just did a VTOL takeoff, prepare transition */


### PR DESCRIPTION
If the vehicle was already in air on takeoff and the waypoint gets converted to a regular waypoint the wait / delay time does not get reset to zero. This change ensures the next mission item is approached immediately.

@MaEtUgR Please add this to the test queue. @PX4TestFlights Please test a mission with a takeoff item by flying in position control, then switching to mission. It should fly to the first waypoint and continue straight to the next.