### PR TITLE
meas_airspeed status aspd_com_err

### DIFF
--- a/src/drivers/meas_airspeed/meas_airspeed.cpp
+++ b/src/drivers/meas_airspeed/meas_airspeed.cpp
@@ -186,15 +186,19 @@ MEASAirspeed::collect()
 
 	switch (status) {
 	case 0:
+		// Normal Operation. Good Data Packet
 		break;
 
 	case 1:
+		// Reserved
+		return -EAGAIN;
 
-	/* fallthrough */
 	case 2:
+		// Stale Data. Data has been fetched since last measurement cycle.
+		return -EAGAIN;
 
-	/* fallthrough */
 	case 3:
+		// Fault Detected
 		perf_count(_comms_errors);
 		perf_end(_sample_perf);
 		return -EAGAIN;


### PR DESCRIPTION
Since we updated the airspeed calibration to fail if the airspeed driver has a non zero comms error count I've seen several people struggling to calibrate. After working with someone and going through the usual suggestions, use a short i2c run, 3.3V sensor, etc they were still getting low single digit error counts. 

A took a look at the current driver and it's counting a comms error every time there's an i2c read failure, or the status flag from the sensor is non zero. According to the MEAS i2c guide only status 3 indicates a fault detected. 

![image](https://cloud.githubusercontent.com/assets/84712/22578333/eb8a8330-e995-11e6-8304-666524d5bb87.png)


It's not clear yet if this explains some of the calibration difficultly, but it seems wrong to me. Bench tested so far, but more testing coming.