### PR TITLE
Bebop rangefinder: Add signal capture command

### DIFF
--- a/src/platforms/posix/drivers/df_bebop_rangefinder_wrapper/df_bebop_rangefinder_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_bebop_rangefinder_wrapper/df_bebop_rangefinder_wrapper.cpp
@@ -186,6 +186,7 @@ DfBebopRangeFinderWrapper *g_dev = nullptr;
 int start();
 int stop();
 int info();
+int capture_signal();
 void usage();
 
 int start()
@@ -235,6 +236,21 @@ int stop()
 
 	delete g_dev;
 	g_dev = nullptr;
+	return 0;
+}
+
+/**
+ * Capture the recorded sound signal into a .csv file
+ */
+int capture_signal()
+{
+	if (g_dev == nullptr) {
+		PX4_ERR("driver not running");
+		return 1;
+	}
+
+	g_dev->capture_signal();
+
 	return 0;
 }
 
@@ -299,6 +315,10 @@ df_bebop_rangefinder_wrapper_main(int argc, char *argv[])
 
 	else if (!strcmp(verb, "info")) {
 		ret = df_bebop_rangefinder_wrapper::info();
+	}
+
+	else if (!strcmp(verb, "capture")) {
+		ret = df_bebop_rangefinder_wrapper::capture_signal();
 	}
 
 	else {


### PR DESCRIPTION
This PR belongs to PX4/DriverFramework#181and adds the capture command to the DF wrapper.