### PR TITLE
FW auto land force heading hold at flare

### DIFF
--- a/posix-configs/SITL/init/ekf2/plane
+++ b/posix-configs/SITL/init/ekf2/plane
@@ -28,10 +28,26 @@ param set NAV_ACC_RAD 15.0
 param set NAV_LOITER_RAD 50
 param set MIS_LTRMIN_ALT 30
 param set MIS_TAKEOFF_ALT 30
-param set FW_THR_IDLE 0.8
+
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01
 param set EKF2_MAG_TYPE 1
+
+param set FW_THR_IDLE 0.15
+param set FW_LND_ANG 8
+
+param set FW_R_TC 0.7
+param set FW_RR_FF 0.20
+param set FW_RR_I 0.02
+param set FW_RR_P 0.22
+
+param set FW_P_TC 0.5
+param set FW_PR_FF 0.40
+param set FW_PR_I 0.05
+param set FW_PR_P 0.05
+
+param set RWTO_TKOFF 1
+
 replay tryapplyparams
 simulator start -s
 rgbledsim start
@@ -63,6 +79,6 @@ mavlink stream -r 80 -s ATTITUDE_TARGET -u 14556
 mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
-sdlog2 start -r 200 -e -t -a
+logger start -e -t
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/lpe/plane
+++ b/posix-configs/SITL/init/lpe/plane
@@ -29,10 +29,25 @@ param set NAV_LOITER_RAD 50
 param set MIS_LTRMIN_ALT 30
 param set MIS_TAKEOFF_ALT 30
 
-param set FW_THR_IDLE 0.8
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01
 param set EKF2_MAG_TYPE 1
+
+param set FW_THR_IDLE 0.15
+param set FW_LND_ANG 8
+
+param set FW_R_TC 0.7
+param set FW_RR_FF 0.20
+param set FW_RR_I 0.02
+param set FW_RR_P 0.22
+
+param set FW_P_TC 0.5
+param set FW_PR_FF 0.40
+param set FW_PR_I 0.05
+param set FW_PR_P 0.05
+
+param set RWTO_TKOFF 1
+
 replay tryapplyparams
 simulator start -s
 rgbledsim start
@@ -48,7 +63,7 @@ sleep 1
 sensors start
 commander start
 navigator start
-ekf2 start
+local_position_estimator start
 fw_pos_control_l1 start
 fw_att_control start
 land_detector start fixedwing
@@ -64,6 +79,6 @@ mavlink stream -r 80 -s ATTITUDE_TARGET -u 14556
 mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
-sdlog2 start -r 200 -e -t -a
+logger start -e -t
 mavlink boot_complete
 replay trystart

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
@@ -115,6 +115,9 @@ static int	_control_task = -1;			/**< task handle for sensor task */
 #define MANUAL_THROTTLE_CLIMBOUT_THRESH 0.85f	///< a throttle / pitch input above this value leads to the system switching to climbout mode
 #define ALTHOLD_EPV_RESET_THRESH 5.0f
 
+using matrix::Eulerf;
+using matrix::Quatf;
+
 /**
  * L1 control app start / stop handling function
  *
@@ -2338,6 +2341,13 @@ FixedwingPositionControl::task_main()
 					_att_sp.roll_body = math::constrain(_att_sp.roll_body, -_parameters.man_roll_max_rad, _parameters.man_roll_max_rad);
 					_att_sp.pitch_body = math::constrain(_att_sp.pitch_body, -_parameters.man_pitch_max_rad, _parameters.man_pitch_max_rad);
 				}
+
+				Quatf q(Eulerf(_att_sp.roll_body, _att_sp.pitch_body, _att_sp.yaw_body));
+				_att_sp.q_d[0] = q(0);
+				_att_sp.q_d[1] = q(1);
+				_att_sp.q_d[2] = q(2);
+				_att_sp.q_d[3] = q(3);
+				_att_sp.q_d_valid = true;
 
 				/* lazily publish the setpoint only once available */
 				if (_attitude_sp_pub != nullptr) {


### PR DESCRIPTION
 - fixes #5970

@AndreasAntener or @tumbili would you mind reviewing?

It's possible to not hit the heading hold section of the current auto land, then in flare the uninitialized _target_bearing is used for the yaw setpoint as the wheel controller is enabled.

This PR forces heading hold at flare.