### PR TITLE
commander: corrected comment gps check parameter

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -267,9 +267,11 @@ PARAM_DEFINE_INT32(COM_RC_ARM_HYST, 1000);
 PARAM_DEFINE_INT32(COM_DISARM_LAND, 0);
 
 /**
- * Allow arming without GPS
+ * Allow arming without GPS module
  *
- * The default allows to arm the vehicle without GPS signal.
+ * If set to 0 arming without GPS device connected and running is not allowed.
+ * It still arms without GPS lock.
+ * The default allows to arm the vehicle without GPS module.
  *
  * @group Commander
  * @min 0


### PR DESCRIPTION
As I found out the check for GPS is actually for the device and not for GPS lock.

Reference to the actual check: https://github.com/PX4/Firmware/blob/master/src/modules/commander/PreflightCheck.cpp#L416