### PR TITLE
Thermal Calibration - improve control over starting conditions

### DIFF
--- a/src/modules/events/temperature_calibration/accel.cpp
+++ b/src/modules/events/temperature_calibration/accel.cpp
@@ -44,8 +44,8 @@
 #include <uORB/topics/sensor_accel.h>
 #include <mathlib/mathlib.h>
 
-TemperatureCalibrationAccel::TemperatureCalibrationAccel(float min_temperature_rise)
-	: TemperatureCalibrationCommon(min_temperature_rise)
+TemperatureCalibrationAccel::TemperatureCalibrationAccel(float min_temperature_rise, float min_start_temperature)
+	: TemperatureCalibrationCommon(min_temperature_rise, min_start_temperature)
 {
 
 	//init subscriptions

--- a/src/modules/events/temperature_calibration/accel.cpp
+++ b/src/modules/events/temperature_calibration/accel.cpp
@@ -44,8 +44,8 @@
 #include <uORB/topics/sensor_accel.h>
 #include <mathlib/mathlib.h>
 
-TemperatureCalibrationAccel::TemperatureCalibrationAccel(float min_temperature_rise, float min_start_temperature)
-	: TemperatureCalibrationCommon(min_temperature_rise, min_start_temperature)
+TemperatureCalibrationAccel::TemperatureCalibrationAccel(float min_temperature_rise, float min_start_temperature, float max_start_temperature)
+	: TemperatureCalibrationCommon(min_temperature_rise, min_start_temperature, max_start_temperature)
 {
 
 	//init subscriptions

--- a/src/modules/events/temperature_calibration/accel.cpp
+++ b/src/modules/events/temperature_calibration/accel.cpp
@@ -45,7 +45,8 @@
 #include <mathlib/mathlib.h>
 #include <drivers/drv_hrt.h>
 
-TemperatureCalibrationAccel::TemperatureCalibrationAccel(float min_temperature_rise, float min_start_temperature, float max_start_temperature)
+TemperatureCalibrationAccel::TemperatureCalibrationAccel(float min_temperature_rise, float min_start_temperature,
+		float max_start_temperature)
 	: TemperatureCalibrationCommon(min_temperature_rise, min_start_temperature, max_start_temperature)
 {
 
@@ -121,6 +122,7 @@ int TemperatureCalibrationAccel::update_sensor_instance(PerSensorData &data, int
 			// If intial temperature exceeds maximum declare an error condition and exit
 			if (data.sensor_sample_filt[3] > _max_start_temperature) {
 				return -110;
+
 			} else {
 				data.cold_soaked = true;
 				data.low_temp = data.sensor_sample_filt[3]; // Record the low temperature
@@ -128,6 +130,7 @@ int TemperatureCalibrationAccel::update_sensor_instance(PerSensorData &data, int
 				data.ref_temp = data.sensor_sample_filt[3] + 0.5f * _min_temperature_rise;
 				return 1;
 			}
+
 		} else {
 			return 1;
 		}

--- a/src/modules/events/temperature_calibration/accel.cpp
+++ b/src/modules/events/temperature_calibration/accel.cpp
@@ -109,6 +109,12 @@ int TemperatureCalibrationAccel::update_sensor_instance(PerSensorData &data, int
 	data.sensor_sample_filt[2] = accel_data.z;
 	data.sensor_sample_filt[3] = accel_data.temperature;
 
+
+	// wait for min start temp to be reached before starting calibration
+	if (data.sensor_sample_filt[3] < _min_start_temperature) {
+		return 1;
+	}
+
 	if (!data.cold_soaked) {
 		data.cold_soaked = true;
 		data.low_temp = data.sensor_sample_filt[3];	//Record the low temperature

--- a/src/modules/events/temperature_calibration/accel.h
+++ b/src/modules/events/temperature_calibration/accel.h
@@ -39,7 +39,7 @@
 class TemperatureCalibrationAccel : public TemperatureCalibrationCommon<3, 3>
 {
 public:
-	TemperatureCalibrationAccel(float min_temperature_rise, float min_start_temperature);
+	TemperatureCalibrationAccel(float min_temperature_rise, float min_start_temperature, float max_start_temperature);
 	virtual ~TemperatureCalibrationAccel();
 
 	/**

--- a/src/modules/events/temperature_calibration/accel.h
+++ b/src/modules/events/temperature_calibration/accel.h
@@ -39,7 +39,7 @@
 class TemperatureCalibrationAccel : public TemperatureCalibrationCommon<3, 3>
 {
 public:
-	TemperatureCalibrationAccel(float min_temperature_rise);
+	TemperatureCalibrationAccel(float min_temperature_rise, float min_start_temperature);
 	virtual ~TemperatureCalibrationAccel();
 
 	/**

--- a/src/modules/events/temperature_calibration/baro.cpp
+++ b/src/modules/events/temperature_calibration/baro.cpp
@@ -43,6 +43,7 @@
 #include "baro.h"
 #include <uORB/topics/sensor_baro.h>
 #include <mathlib/mathlib.h>
+#include <drivers/drv_hrt.h>
 
 TemperatureCalibrationBaro::TemperatureCalibrationBaro(float min_temperature_rise, float min_start_temperature, float max_start_temperature)
 	: TemperatureCalibrationCommon(min_temperature_rise, min_start_temperature, max_start_temperature)
@@ -103,9 +104,21 @@ int TemperatureCalibrationBaro::update_sensor_instance(PerSensorData &data, int 
 	}
 
 	if (!data.cold_soaked) {
-		data.cold_soaked = true;
-		data.low_temp = data.sensor_sample_filt[1];	//Record the low temperature
-		data.ref_temp = data.sensor_sample_filt[1] + 0.5f * _min_temperature_rise;
+		// allow time for sensors and filters to settle
+		if (hrt_absolute_time() > 10E6) {
+			// If intial temperature exceeds maximum declare an error condition and exit
+			if (data.sensor_sample_filt[1] > _max_start_temperature) {
+				return -110;
+			} else {
+				data.cold_soaked = true;
+				data.low_temp = data.sensor_sample_filt[1]; // Record the low temperature
+				data.high_temp = data.low_temp; // Initialise the high temperature to the initial temperature
+				data.ref_temp = data.sensor_sample_filt[1] + 0.5f * _min_temperature_rise;
+				return 1;
+			}
+		} else {
+			return 1;
+		}
 	}
 
 	// check if temperature increased
@@ -129,8 +142,8 @@ int TemperatureCalibrationBaro::update_sensor_instance(PerSensorData &data, int 
 	}
 
 	//update linear fit matrices
-	data.sensor_sample_filt[1] -= data.ref_temp;
-	data.P[0].update((double)data.sensor_sample_filt[1], (double)data.sensor_sample_filt[0]);
+	double relative_temperature = data.sensor_sample_filt[1] - data.ref_temp;
+	data.P[0].update(relative_temperature, (double)data.sensor_sample_filt[0]);
 
 	return 1;
 }

--- a/src/modules/events/temperature_calibration/baro.cpp
+++ b/src/modules/events/temperature_calibration/baro.cpp
@@ -44,8 +44,8 @@
 #include <uORB/topics/sensor_baro.h>
 #include <mathlib/mathlib.h>
 
-TemperatureCalibrationBaro::TemperatureCalibrationBaro(float min_temperature_rise)
-	: TemperatureCalibrationCommon(min_temperature_rise)
+TemperatureCalibrationBaro::TemperatureCalibrationBaro(float min_temperature_rise, float min_start_temperature)
+	: TemperatureCalibrationCommon(min_temperature_rise, min_start_temperature)
 {
 
 	//init subscriptions

--- a/src/modules/events/temperature_calibration/baro.cpp
+++ b/src/modules/events/temperature_calibration/baro.cpp
@@ -44,8 +44,8 @@
 #include <uORB/topics/sensor_baro.h>
 #include <mathlib/mathlib.h>
 
-TemperatureCalibrationBaro::TemperatureCalibrationBaro(float min_temperature_rise, float min_start_temperature)
-	: TemperatureCalibrationCommon(min_temperature_rise, min_start_temperature)
+TemperatureCalibrationBaro::TemperatureCalibrationBaro(float min_temperature_rise, float min_start_temperature, float max_start_temperature)
+	: TemperatureCalibrationCommon(min_temperature_rise, min_start_temperature, max_start_temperature)
 {
 
 	//init subscriptions

--- a/src/modules/events/temperature_calibration/baro.cpp
+++ b/src/modules/events/temperature_calibration/baro.cpp
@@ -96,6 +96,12 @@ int TemperatureCalibrationBaro::update_sensor_instance(PerSensorData &data, int 
 	data.sensor_sample_filt[0] = 100.0f * baro_data.pressure; // convert from hPA to Pa
 	data.sensor_sample_filt[1] = baro_data.temperature;
 
+
+	// wait for min start temp to be reached before starting calibration
+	if (data.sensor_sample_filt[1] < _min_start_temperature) {
+		return 1;
+	}
+
 	if (!data.cold_soaked) {
 		data.cold_soaked = true;
 		data.low_temp = data.sensor_sample_filt[1];	//Record the low temperature

--- a/src/modules/events/temperature_calibration/baro.cpp
+++ b/src/modules/events/temperature_calibration/baro.cpp
@@ -45,7 +45,8 @@
 #include <mathlib/mathlib.h>
 #include <drivers/drv_hrt.h>
 
-TemperatureCalibrationBaro::TemperatureCalibrationBaro(float min_temperature_rise, float min_start_temperature, float max_start_temperature)
+TemperatureCalibrationBaro::TemperatureCalibrationBaro(float min_temperature_rise, float min_start_temperature,
+		float max_start_temperature)
 	: TemperatureCalibrationCommon(min_temperature_rise, min_start_temperature, max_start_temperature)
 {
 
@@ -109,6 +110,7 @@ int TemperatureCalibrationBaro::update_sensor_instance(PerSensorData &data, int 
 			// If intial temperature exceeds maximum declare an error condition and exit
 			if (data.sensor_sample_filt[1] > _max_start_temperature) {
 				return -110;
+
 			} else {
 				data.cold_soaked = true;
 				data.low_temp = data.sensor_sample_filt[1]; // Record the low temperature
@@ -116,6 +118,7 @@ int TemperatureCalibrationBaro::update_sensor_instance(PerSensorData &data, int 
 				data.ref_temp = data.sensor_sample_filt[1] + 0.5f * _min_temperature_rise;
 				return 1;
 			}
+
 		} else {
 			return 1;
 		}

--- a/src/modules/events/temperature_calibration/baro.h
+++ b/src/modules/events/temperature_calibration/baro.h
@@ -42,7 +42,7 @@
 class TemperatureCalibrationBaro : public TemperatureCalibrationCommon<1, POLYFIT_ORDER>
 {
 public:
-	TemperatureCalibrationBaro(float min_temperature_rise, float min_start_temperature);
+	TemperatureCalibrationBaro(float min_temperature_rise, float min_start_temperature, float max_start_temperature);
 	virtual ~TemperatureCalibrationBaro();
 
 	/**

--- a/src/modules/events/temperature_calibration/baro.h
+++ b/src/modules/events/temperature_calibration/baro.h
@@ -42,7 +42,7 @@
 class TemperatureCalibrationBaro : public TemperatureCalibrationCommon<1, POLYFIT_ORDER>
 {
 public:
-	TemperatureCalibrationBaro(float min_temperature_rise);
+	TemperatureCalibrationBaro(float min_temperature_rise, float min_start_temperature);
 	virtual ~TemperatureCalibrationBaro();
 
 	/**

--- a/src/modules/events/temperature_calibration/common.h
+++ b/src/modules/events/temperature_calibration/common.h
@@ -53,8 +53,8 @@
 class TemperatureCalibrationBase
 {
 public:
-	TemperatureCalibrationBase(float min_temperature_rise, float min_start_temperature)
-		: _min_temperature_rise(min_temperature_rise), _min_start_temperature(min_start_temperature) {}
+	TemperatureCalibrationBase(float min_temperature_rise, float min_start_temperature, float max_start_temperature)
+		: _min_temperature_rise(min_temperature_rise), _min_start_temperature(min_start_temperature), _max_start_temperature(max_start_temperature) {}
 
 	virtual ~TemperatureCalibrationBase() {}
 
@@ -86,6 +86,7 @@ protected:
 
 	float _min_temperature_rise; ///< minimum difference in temperature before the process finishes
 	float _min_start_temperature; ///< minimum temperature before the process starts
+	float _max_start_temperature; ///< maximum temperature above which the process does not start and an error is declared
 };
 
 
@@ -111,8 +112,8 @@ template <int Dim, int PolyfitOrder>
 class TemperatureCalibrationCommon : public TemperatureCalibrationBase
 {
 public:
-	TemperatureCalibrationCommon(float min_temperature_rise, float min_start_temperature)
-		: TemperatureCalibrationBase(min_temperature_rise, min_start_temperature) {}
+	TemperatureCalibrationCommon(float min_temperature_rise, float min_start_temperature, float max_start_temperature)
+		: TemperatureCalibrationBase(min_temperature_rise, min_start_temperature, max_start_temperature) {}
 
 	virtual ~TemperatureCalibrationCommon() {}
 
@@ -164,7 +165,7 @@ protected:
 
 	/**
 	 * update a single sensor instance
-	 * @return 0 when done, 1 not finished yet
+	 * @return 0 when done, 1 not finished yet, -1 for an error that requires the test to be repeated
 	 */
 	virtual int update_sensor_instance(PerSensorData &data, int sensor_sub) = 0;
 

--- a/src/modules/events/temperature_calibration/common.h
+++ b/src/modules/events/temperature_calibration/common.h
@@ -53,8 +53,8 @@
 class TemperatureCalibrationBase
 {
 public:
-	TemperatureCalibrationBase(float min_temperature_rise)
-		: _min_temperature_rise(min_temperature_rise) {}
+	TemperatureCalibrationBase(float min_temperature_rise, float min_start_temperature)
+		: _min_temperature_rise(min_temperature_rise), _min_start_temperature(min_start_temperature) {}
 
 	virtual ~TemperatureCalibrationBase() {}
 
@@ -85,6 +85,7 @@ protected:
 	inline int set_parameter(const char *format_str, unsigned index, const void *value);
 
 	float _min_temperature_rise; ///< minimum difference in temperature before the process finishes
+	float _min_start_temperature; ///< minimum temperature before the process starts
 };
 
 
@@ -110,8 +111,8 @@ template <int Dim, int PolyfitOrder>
 class TemperatureCalibrationCommon : public TemperatureCalibrationBase
 {
 public:
-	TemperatureCalibrationCommon(float min_temperature_rise)
-		: TemperatureCalibrationBase(min_temperature_rise) {}
+	TemperatureCalibrationCommon(float min_temperature_rise, float min_start_temperature)
+		: TemperatureCalibrationBase(min_temperature_rise, min_start_temperature) {}
 
 	virtual ~TemperatureCalibrationCommon() {}
 

--- a/src/modules/events/temperature_calibration/common.h
+++ b/src/modules/events/temperature_calibration/common.h
@@ -54,7 +54,8 @@ class TemperatureCalibrationBase
 {
 public:
 	TemperatureCalibrationBase(float min_temperature_rise, float min_start_temperature, float max_start_temperature)
-		: _min_temperature_rise(min_temperature_rise), _min_start_temperature(min_start_temperature), _max_start_temperature(max_start_temperature) {}
+		: _min_temperature_rise(min_temperature_rise), _min_start_temperature(min_start_temperature),
+		  _max_start_temperature(max_start_temperature) {}
 
 	virtual ~TemperatureCalibrationBase() {}
 
@@ -126,11 +127,14 @@ public:
 
 		for (unsigned uorb_index = 0; uorb_index < _num_sensor_instances; uorb_index++) {
 			int status = update_sensor_instance(_data[uorb_index], _sensor_subs[uorb_index]);
+
 			if (status == -1) {
 				return -1;
+
 			} else if (status == -110) {
 				return -110;
 			}
+
 			num_not_complete += status;
 		}
 
@@ -159,12 +163,14 @@ protected:
 		polyfitter < PolyfitOrder + 1 > P[Dim];
 		unsigned hot_soak_sat = 0; // counter that increments every time the sensor temperature reduces from the last reading
 		uint32_t device_id = 0; // ID for the sensor being calibrated
-		bool cold_soaked = false; // true when the sensor cold soak starting temperature condition had been verified and the starting temperature set
+		bool cold_soaked =
+			false; // true when the sensor cold soak starting temperature condition had been verified and the starting temperature set
 		bool hot_soaked = false; // true when the sensor has achieved the specified temperature increase
 		bool tempcal_complete = false; // true when the calibration has been completed
 		float low_temp = 0.f; // low temperature recorded at start of calibration (deg C)
 		float high_temp = 0.f; // highest temperature recorded during calibration (deg C)
-		float ref_temp = 0.f; // calibration reference temperature, nominally in the middle of the calibration temperature range (deg C)
+		float ref_temp =
+			0.f; // calibration reference temperature, nominally in the middle of the calibration temperature range (deg C)
 	};
 
 	PerSensorData _data[SENSOR_COUNT_MAX];

--- a/src/modules/events/temperature_calibration/gyro.cpp
+++ b/src/modules/events/temperature_calibration/gyro.cpp
@@ -96,6 +96,11 @@ int TemperatureCalibrationGyro::update_sensor_instance(PerSensorData &data, int 
 	data.sensor_sample_filt[2] = gyro_data.z;
 	data.sensor_sample_filt[3] = gyro_data.temperature;
 
+	// wait for min start temp to be reached before starting calibration
+	if (data.sensor_sample_filt[3] < _min_start_temperature) {
+		return 1;
+	}
+
 	if (!data.cold_soaked) {
 		data.cold_soaked = true;
 		data.low_temp = data.sensor_sample_filt[3];	//Record the low temperature

--- a/src/modules/events/temperature_calibration/gyro.cpp
+++ b/src/modules/events/temperature_calibration/gyro.cpp
@@ -44,7 +44,8 @@
 #include "gyro.h"
 #include <drivers/drv_hrt.h>
 
-TemperatureCalibrationGyro::TemperatureCalibrationGyro(float min_temperature_rise, float min_start_temperature, float max_start_temperature, int gyro_subs[], int num_gyros)
+TemperatureCalibrationGyro::TemperatureCalibrationGyro(float min_temperature_rise, float min_start_temperature,
+		float max_start_temperature, int gyro_subs[], int num_gyros)
 	: TemperatureCalibrationCommon(min_temperature_rise, min_start_temperature, max_start_temperature)
 {
 	for (int i = 0; i < num_gyros; ++i) {
@@ -108,6 +109,7 @@ int TemperatureCalibrationGyro::update_sensor_instance(PerSensorData &data, int 
 			// If intial temperature exceeds maximum declare an error condition and exit
 			if (data.sensor_sample_filt[3] > _max_start_temperature) {
 				return -110;
+
 			} else {
 				data.cold_soaked = true;
 				data.low_temp = data.sensor_sample_filt[3]; // Record the low temperature
@@ -115,6 +117,7 @@ int TemperatureCalibrationGyro::update_sensor_instance(PerSensorData &data, int 
 				data.ref_temp = data.sensor_sample_filt[3] + 0.5f * _min_temperature_rise;
 				return 1;
 			}
+
 		} else {
 			return 1;
 		}

--- a/src/modules/events/temperature_calibration/gyro.cpp
+++ b/src/modules/events/temperature_calibration/gyro.cpp
@@ -43,8 +43,8 @@
 #include <uORB/topics/sensor_gyro.h>
 #include "gyro.h"
 
-TemperatureCalibrationGyro::TemperatureCalibrationGyro(float min_temperature_rise, float min_start_temperature, int gyro_subs[], int num_gyros)
-	: TemperatureCalibrationCommon(min_temperature_rise, min_start_temperature)
+TemperatureCalibrationGyro::TemperatureCalibrationGyro(float min_temperature_rise, float min_start_temperature, float max_start_temperature, int gyro_subs[], int num_gyros)
+	: TemperatureCalibrationCommon(min_temperature_rise, min_start_temperature, max_start_temperature)
 {
 	for (int i = 0; i < num_gyros; ++i) {
 		_sensor_subs[i] = gyro_subs[i];

--- a/src/modules/events/temperature_calibration/gyro.cpp
+++ b/src/modules/events/temperature_calibration/gyro.cpp
@@ -42,6 +42,7 @@
 #include <mathlib/mathlib.h>
 #include <uORB/topics/sensor_gyro.h>
 #include "gyro.h"
+#include <drivers/drv_hrt.h>
 
 TemperatureCalibrationGyro::TemperatureCalibrationGyro(float min_temperature_rise, float min_start_temperature, float max_start_temperature, int gyro_subs[], int num_gyros)
 	: TemperatureCalibrationCommon(min_temperature_rise, min_start_temperature, max_start_temperature)
@@ -102,9 +103,21 @@ int TemperatureCalibrationGyro::update_sensor_instance(PerSensorData &data, int 
 	}
 
 	if (!data.cold_soaked) {
-		data.cold_soaked = true;
-		data.low_temp = data.sensor_sample_filt[3];	//Record the low temperature
-		data.ref_temp = data.sensor_sample_filt[3] + 0.5f * _min_temperature_rise;
+		// allow time for sensors and filters to settle
+		if (hrt_absolute_time() > 10E6) {
+			// If intial temperature exceeds maximum declare an error condition and exit
+			if (data.sensor_sample_filt[3] > _max_start_temperature) {
+				return -110;
+			} else {
+				data.cold_soaked = true;
+				data.low_temp = data.sensor_sample_filt[3]; // Record the low temperature
+				data.high_temp = data.low_temp; // Initialise the high temperature to the initial temperature
+				data.ref_temp = data.sensor_sample_filt[3] + 0.5f * _min_temperature_rise;
+				return 1;
+			}
+		} else {
+			return 1;
+		}
 	}
 
 	// check if temperature increased
@@ -129,10 +142,10 @@ int TemperatureCalibrationGyro::update_sensor_instance(PerSensorData &data, int 
 	}
 
 	//update linear fit matrices
-	data.sensor_sample_filt[3] -= data.ref_temp;
-	data.P[0].update((double)data.sensor_sample_filt[3], (double)data.sensor_sample_filt[0]);
-	data.P[1].update((double)data.sensor_sample_filt[3], (double)data.sensor_sample_filt[1]);
-	data.P[2].update((double)data.sensor_sample_filt[3], (double)data.sensor_sample_filt[2]);
+	double relative_temperature = data.sensor_sample_filt[3] - data.ref_temp;
+	data.P[0].update(relative_temperature, (double)data.sensor_sample_filt[0]);
+	data.P[1].update(relative_temperature, (double)data.sensor_sample_filt[1]);
+	data.P[2].update(relative_temperature, (double)data.sensor_sample_filt[2]);
 
 	return 1;
 }

--- a/src/modules/events/temperature_calibration/gyro.cpp
+++ b/src/modules/events/temperature_calibration/gyro.cpp
@@ -43,8 +43,8 @@
 #include <uORB/topics/sensor_gyro.h>
 #include "gyro.h"
 
-TemperatureCalibrationGyro::TemperatureCalibrationGyro(float min_temperature_rise, int gyro_subs[], int num_gyros)
-	: TemperatureCalibrationCommon(min_temperature_rise)
+TemperatureCalibrationGyro::TemperatureCalibrationGyro(float min_temperature_rise, float min_start_temperature, int gyro_subs[], int num_gyros)
+	: TemperatureCalibrationCommon(min_temperature_rise, min_start_temperature)
 {
 	for (int i = 0; i < num_gyros; ++i) {
 		_sensor_subs[i] = gyro_subs[i];

--- a/src/modules/events/temperature_calibration/gyro.h
+++ b/src/modules/events/temperature_calibration/gyro.h
@@ -39,7 +39,7 @@
 class TemperatureCalibrationGyro : public TemperatureCalibrationCommon<3, 3>
 {
 public:
-	TemperatureCalibrationGyro(float min_temperature_rise, float min_start_temperature, int gyro_subs[], int num_gyros);
+	TemperatureCalibrationGyro(float min_temperature_rise, float min_start_temperature, float max_start_temperature, int gyro_subs[], int num_gyros);
 	virtual ~TemperatureCalibrationGyro() {}
 
 	/**

--- a/src/modules/events/temperature_calibration/gyro.h
+++ b/src/modules/events/temperature_calibration/gyro.h
@@ -39,7 +39,8 @@
 class TemperatureCalibrationGyro : public TemperatureCalibrationCommon<3, 3>
 {
 public:
-	TemperatureCalibrationGyro(float min_temperature_rise, float min_start_temperature, float max_start_temperature, int gyro_subs[], int num_gyros);
+	TemperatureCalibrationGyro(float min_temperature_rise, float min_start_temperature, float max_start_temperature,
+				   int gyro_subs[], int num_gyros);
 	virtual ~TemperatureCalibrationGyro() {}
 
 	/**

--- a/src/modules/events/temperature_calibration/gyro.h
+++ b/src/modules/events/temperature_calibration/gyro.h
@@ -39,7 +39,7 @@
 class TemperatureCalibrationGyro : public TemperatureCalibrationCommon<3, 3>
 {
 public:
-	TemperatureCalibrationGyro(float min_temperature_rise, int gyro_subs[], int num_gyros);
+	TemperatureCalibrationGyro(float min_temperature_rise, float min_start_temperature, int gyro_subs[], int num_gyros);
 	virtual ~TemperatureCalibrationGyro() {}
 
 	/**

--- a/src/modules/events/temperature_calibration/task.cpp
+++ b/src/modules/events/temperature_calibration/task.cpp
@@ -124,7 +124,7 @@ void TemperatureCalibration::task_main()
 	}
 
 	int32_t min_temp_rise = 24;
-	param_get(param_find("SYS_CAL_TEMP"), &min_temp_rise);
+	param_get(param_find("SYS_CAL_TDEL"), &min_temp_rise);
 	PX4_INFO("Waiting for %i degrees difference in sensor temperature", min_temp_rise);
 
 	//init calibrators

--- a/src/modules/events/temperature_calibration/task.cpp
+++ b/src/modules/events/temperature_calibration/task.cpp
@@ -127,13 +127,16 @@ void TemperatureCalibration::task_main()
 	param_get(param_find("SYS_CAL_TDEL"), &min_temp_rise);
 	PX4_INFO("Waiting for %i degrees difference in sensor temperature", min_temp_rise);
 
+	int32_t min_start_temp = 5;
+	param_get(param_find("SYS_CAL_TMIN"), &min_start_temp);
+
 	//init calibrators
 	TemperatureCalibrationBase *calibrators[3];
 	bool error_reported[3] = {};
 	int num_calibrators = 0;
 
 	if (_accel) {
-		calibrators[num_calibrators] = new TemperatureCalibrationAccel(min_temp_rise);
+		calibrators[num_calibrators] = new TemperatureCalibrationAccel(min_temp_rise,min_start_temp);
 
 		if (calibrators[num_calibrators]) {
 			++num_calibrators;
@@ -144,7 +147,7 @@ void TemperatureCalibration::task_main()
 	}
 
 	if (_baro) {
-		calibrators[num_calibrators] = new TemperatureCalibrationBaro(min_temp_rise);
+		calibrators[num_calibrators] = new TemperatureCalibrationBaro(min_temp_rise, min_start_temp);
 
 		if (calibrators[num_calibrators]) {
 			++num_calibrators;
@@ -155,7 +158,7 @@ void TemperatureCalibration::task_main()
 	}
 
 	if (_gyro) {
-		calibrators[num_calibrators] = new TemperatureCalibrationGyro(min_temp_rise, gyro_sub, num_gyro);
+		calibrators[num_calibrators] = new TemperatureCalibrationGyro(min_temp_rise, min_start_temp, gyro_sub, num_gyro);
 
 		if (calibrators[num_calibrators]) {
 			++num_calibrators;

--- a/src/modules/events/temperature_calibration/task.cpp
+++ b/src/modules/events/temperature_calibration/task.cpp
@@ -130,13 +130,16 @@ void TemperatureCalibration::task_main()
 	int32_t min_start_temp = 5;
 	param_get(param_find("SYS_CAL_TMIN"), &min_start_temp);
 
+	int32_t max_start_temp = 10;
+	param_get(param_find("SYS_CAL_TMAX"), &max_start_temp);
+
 	//init calibrators
 	TemperatureCalibrationBase *calibrators[3];
 	bool error_reported[3] = {};
 	int num_calibrators = 0;
 
 	if (_accel) {
-		calibrators[num_calibrators] = new TemperatureCalibrationAccel(min_temp_rise,min_start_temp);
+		calibrators[num_calibrators] = new TemperatureCalibrationAccel(min_temp_rise, min_start_temp, max_start_temp);
 
 		if (calibrators[num_calibrators]) {
 			++num_calibrators;
@@ -147,7 +150,7 @@ void TemperatureCalibration::task_main()
 	}
 
 	if (_baro) {
-		calibrators[num_calibrators] = new TemperatureCalibrationBaro(min_temp_rise, min_start_temp);
+		calibrators[num_calibrators] = new TemperatureCalibrationBaro(min_temp_rise, min_start_temp, max_start_temp);
 
 		if (calibrators[num_calibrators]) {
 			++num_calibrators;
@@ -158,7 +161,7 @@ void TemperatureCalibration::task_main()
 	}
 
 	if (_gyro) {
-		calibrators[num_calibrators] = new TemperatureCalibrationGyro(min_temp_rise, min_start_temp, gyro_sub, num_gyro);
+		calibrators[num_calibrators] = new TemperatureCalibrationGyro(min_temp_rise, min_start_temp, max_start_temp, gyro_sub, num_gyro);
 
 		if (calibrators[num_calibrators]) {
 			++num_calibrators;

--- a/src/modules/events/temperature_calibration/task.cpp
+++ b/src/modules/events/temperature_calibration/task.cpp
@@ -161,7 +161,8 @@ void TemperatureCalibration::task_main()
 	}
 
 	if (_gyro) {
-		calibrators[num_calibrators] = new TemperatureCalibrationGyro(min_temp_rise, min_start_temp, max_start_temp, gyro_sub, num_gyro);
+		calibrators[num_calibrators] = new TemperatureCalibrationGyro(min_temp_rise, min_start_temp, max_start_temp, gyro_sub,
+				num_gyro);
 
 		if (calibrators[num_calibrators]) {
 			++num_calibrators;
@@ -184,6 +185,7 @@ void TemperatureCalibration::task_main()
 	hrt_abstime next_progress_output = hrt_absolute_time() + 1e6;
 
 	bool abort_calibration = false;
+
 	while (!_force_task_exit) {
 		/* we poll on the gyro(s), since this is the sensor with the highest update rate.
 		 * Each individual sensor will then check on its own if there's new data.
@@ -213,15 +215,18 @@ void TemperatureCalibration::task_main()
 
 		for (int i = 0; i < num_calibrators; ++i) {
 			ret = calibrators[i]->update();
+
 			if (ret == -110) {
 				abort_calibration = true;
 				PX4_ERR("Calibration won't start - sensor temperature too high");
 				_force_task_exit = true;
 				break;
+
 			} else if (ret < 0 && !error_reported[i]) {
 				// temperature has decreased so calibration is not being updated
 				error_reported[i] = true;
 				PX4_ERR("Calibration update step failed (%i)", ret);
+
 			} else if (ret < min_progress) {
 				// temperature is stable or increasing
 				min_progress = ret;

--- a/src/modules/sensors/parameters.cpp
+++ b/src/modules/sensors/parameters.cpp
@@ -221,6 +221,10 @@ int initialize_parameter_handles(ParameterHandles &parameter_handles)
 	(void)param_find("UAVCAN_ENABLE");
 	(void)param_find("SYS_MC_EST_GROUP");
 
+	// Parameters controlling the on-board sensor thermal calibrator
+	(void)param_find("SYS_CAL_TDEL");
+	(void)param_find("SYS_CAL_TMAX");
+	(void)param_find("SYS_CAL_TMIN");
 
 	return 0;
 }

--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -220,7 +220,7 @@ PARAM_DEFINE_INT32(SYS_CAL_BARO, 0);
  * @min 10
  * @group System
  */
-PARAM_DEFINE_INT32(SYS_CAL_DELT, 24);
+PARAM_DEFINE_INT32(SYS_CAL_TDEL, 24);
 
 /**
  * Minimum starting temperature for thermal calibration

--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -221,3 +221,13 @@ PARAM_DEFINE_INT32(SYS_CAL_BARO, 0);
  * @group System
  */
 PARAM_DEFINE_INT32(SYS_CAL_DELT, 24);
+
+/**
+ * Minimum starting temperature for thermal calibration
+ *
+ * Temperature calibration for each sensor will ignore data if the temperature is lower than the value set by SYS_CAL_TMIN.
+ *
+ * @unit deg C
+ * @group System
+ */
+PARAM_DEFINE_INT32(SYS_CAL_TMIN, 5);

--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -231,3 +231,13 @@ PARAM_DEFINE_INT32(SYS_CAL_TDEL, 24);
  * @group System
  */
 PARAM_DEFINE_INT32(SYS_CAL_TMIN, 5);
+
+/**
+ * Maximum starting temperature for thermal calibration
+ *
+ * Temperature calibration will not start if the temperature of any sensor is higher than the value set by SYS_CAL_TMAX.
+ *
+ * @unit deg C
+ * @group System
+ */
+PARAM_DEFINE_INT32(SYS_CAL_TMAX, 10);

--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -212,13 +212,12 @@ PARAM_DEFINE_INT32(SYS_CAL_BARO, 0);
 /**
  * Required temperature rise during thermal calibration
  *
- * A temperature increase greater than this value is required during calibration performed by the setting of SYS_TEMP_CAL.
- * Calibration will complete for each sensor when the temperature increase above the starting temeprature exceeds SYS_TEMP_RISE.
+ * A temperature increase greater than this value is required during calibration.
+ * Calibration will complete for each sensor when the temperature increase above the starting temeprature exceeds the value set by SYS_CAL_TDEL.
  * If the temperature rise is insufficient, the calibration will continue indefinitely and the board will need to be repowered to exit.
  *
  * @unit deg C
  * @min 10
- * @max 50
  * @group System
  */
-PARAM_DEFINE_INT32(SYS_CAL_TEMP, 24);
+PARAM_DEFINE_INT32(SYS_CAL_DELT, 24);


### PR DESCRIPTION
The changes in this PR provide more control over the starting condition for the on-board thermal calibrator.

1) The SYS_CAL_TEMP parameter is renamed SYS_CAL_TDEL better indicate that it is a temperature delta.
2) A SYS_CAL_TMIN parameter is added which sets the minimum temperature that will be accepted by the calibration. This enables a board to be cold soaked to below the required starting temperature so that when hot soak testing starts, a more stable temperature rise is achieved by the sensor when the at the point the calibration starts using the data.
3) A 10 second delay from startup to use of sensor data has been added to allow sensors and filters to stabilise
4) A SYS_CAL_TMAX pareter has been added which specifies the maximum starting temperature accepted by the calibrator. This prevents the calibration starting if a board has not been sufficiently cold soaked.

The SYS_CAL_TMIN and SYS_CAL_TMAX defaults have been set to 5 and 10 deg C respectively to allow use of a domestic refrigerator for cold soaking.