### PR TITLE
S port scale fix

### DIFF
--- a/src/drivers/frsky_telemetry/sPort_data.c
+++ b/src/drivers/frsky_telemetry/sPort_data.c
@@ -90,8 +90,8 @@ bool sPort_init()
 	gps_position = malloc(sizeof(struct vehicle_gps_position_s));
 
 
-	if (sensor_combined == NULL || global_pos == NULL || local_pos == NULL || battery_status == NULL || vehicle_status == NULL
-	    || gps_position == NULL) {
+	if (sensor_combined == NULL || global_pos == NULL || local_pos == NULL || battery_status == NULL
+	    || vehicle_status == NULL || gps_position == NULL) {
 		return false;
 	}
 
@@ -318,7 +318,8 @@ void sPort_send_GPS_CRS(int uart)
 
 	/* convert to 30 bit signed magnitude degrees*6E5 with MSb = 1 and bit 30=sign */
 	int32_t iYaw = local_pos->yaw * 18000.0f / M_PI_F;
-	if (iYaw < 0) iYaw += 36000;
+
+	if (iYaw < 0) { iYaw += 36000; }
 
 	sPort_send_data(uart, SMARTPORT_ID_GPS_CRS, iYaw);
 }
@@ -331,14 +332,16 @@ void sPort_send_GPS_TIME(int uart)
 	time_t time_gps = gps_position->time_utc_usec / 1000000ULL;
 	struct tm *tm_gps = gmtime(&time_gps);
 
-	if(date){
+	if (date) {
 
-		sPort_send_data(uart, SMARTPORT_ID_GPS_TIME, (uint32_t) 0xff | (tm_gps->tm_mday << 8 ) | ((tm_gps->tm_mon + 1) << 16 ) | ((tm_gps->tm_year -100) << 24 ) );
+		sPort_send_data(uart, SMARTPORT_ID_GPS_TIME,
+				(uint32_t) 0xff | (tm_gps->tm_mday << 8) | ((tm_gps->tm_mon + 1) << 16) | ((tm_gps->tm_year - 100) << 24));
 		date = 0;
 
 	} else {
 
-		sPort_send_data(uart, SMARTPORT_ID_GPS_TIME, (uint32_t) 0x00 | (tm_gps->tm_sec << 8 ) | (tm_gps->tm_min  << 16 ) | (tm_gps->tm_hour << 24 ));
+		sPort_send_data(uart, SMARTPORT_ID_GPS_TIME,
+				(uint32_t) 0x00 | (tm_gps->tm_sec << 8) | (tm_gps->tm_min  << 16) | (tm_gps->tm_hour << 24));
 		date = 1;
 
 	}

--- a/src/drivers/frsky_telemetry/sPort_data.c
+++ b/src/drivers/frsky_telemetry/sPort_data.c
@@ -270,7 +270,8 @@ void sPort_send_GPS_LON(int uart)
 	/* send longitude */
 	/* convert to 30 bit signed magnitude degrees*6E5 with MSb = 1 and bit 30=sign */
 	/* precision is approximately 0.1m */
-	uint32_t iLon = 6E5 * fabs(gps_position->lon);
+	uint32_t iLon =  6E-2 * fabs(gps_position->lon);
+
 	iLon |= (1 << 31);
 
 	if (gps_position->lon < 0) { iLon |= (1 << 30); }
@@ -282,7 +283,7 @@ void sPort_send_GPS_LAT(int uart)
 {
 	/* send latitude */
 	/* convert to 30 bit signed magnitude degrees*6E5 with MSb = 0 and bit 30=sign */
-	uint32_t iLat = 6E5 * fabs(gps_position->lat);
+	uint32_t iLat = 6E-2 * fabs(gps_position->lat);
 
 	if (gps_position->lat < 0) { iLat |= (1 << 30); }
 
@@ -292,8 +293,7 @@ void sPort_send_GPS_LAT(int uart)
 void sPort_send_GPS_ALT(int uart)
 {
 	/* send altitude */
-	/* convert to 100 * m/sec */
-	uint32_t iAlt = 100 * gps_position->alt;
+	uint32_t iAlt = gps_position->alt / 10;
 	sPort_send_data(uart, SMARTPORT_ID_GPS_ALT, iAlt);
 }
 

--- a/src/drivers/frsky_telemetry/sPort_data.c
+++ b/src/drivers/frsky_telemetry/sPort_data.c
@@ -325,7 +325,23 @@ void sPort_send_GPS_CRS(int uart)
 
 void sPort_send_GPS_TIME(int uart)
 {
-	sPort_send_data(uart, SMARTPORT_ID_GPS_TIME, gps_position->time_utc_usec);
+	static int date = 0;
+
+	/* send formatted frame */
+	time_t time_gps = gps_position->time_utc_usec / 1000000ULL;
+	struct tm *tm_gps = gmtime(&time_gps);
+
+	if(date){
+
+		sPort_send_data(uart, SMARTPORT_ID_GPS_TIME, (uint32_t) 0xff | (tm_gps->tm_mday << 8 ) | ((tm_gps->tm_mon + 1) << 16 ) | ((tm_gps->tm_year -100) << 24 ) );
+		date = 0;
+
+	} else {
+
+		sPort_send_data(uart, SMARTPORT_ID_GPS_TIME, (uint32_t) 0x00 | (tm_gps->tm_sec << 8 ) | (tm_gps->tm_min  << 16 ) | (tm_gps->tm_hour << 24 ));
+		date = 1;
+
+	}
 }
 
 void sPort_send_GPS_SPD(int uart)


### PR DESCRIPTION
Fixed some issues on FrSky S.Port telemetry

1. Fixed scaling on GPS coords and Altitude
2. Fixed heading data
3. Correctly formatted GPS date/time information 

Tested on a Pixracer with Taranis+