### PR TITLE
mavlink: Buffer UAVCAN parameter re-requests

### DIFF
--- a/src/modules/mavlink/mavlink_parameters.h
+++ b/src/modules/mavlink/mavlink_parameters.h
@@ -47,6 +47,7 @@
 #include "mavlink_stream.h"
 #include <uORB/uORB.h>
 #include <uORB/topics/rc_parameter_map.h>
+#include <uORB/topics/uavcan_parameter_request.h>
 
 class MavlinkParametersManager : public MavlinkStream
 {
@@ -91,6 +92,23 @@ protected:
 	void send(const hrt_abstime t);
 
 	int send_param(param_t param, int component_id = -1);
+
+	// Item of a single-linked list to store requested uavcan parameters
+	struct _uavcan_open_request_list_item {
+		uavcan_parameter_request_s req;
+		struct _uavcan_open_request_list_item *next;
+	};
+
+	// Request the next uavcan parameter
+	void request_next_uavcan_parameter();
+	// Enque one uavcan parameter reqest. We store 10 at max.
+	void enque_uavcan_request(uavcan_parameter_request_s *req);
+	// Drop the first reqest from the list
+	void dequeue_uavcan_request();
+
+	_uavcan_open_request_list_item *_uavcan_open_request_list; // Pointer to the first item in the linked list
+	bool _uavcan_waiting_for_request_response; // We have reqested a parameter and wait for the response
+	uint16_t _uavcan_queued_request_items;	// Number of stored parameter requests currently in the list
 
 	orb_advert_t _rc_param_map_pub;
 	struct rc_parameter_map_s _rc_param_map;


### PR DESCRIPTION
We buffer the mavlink messages and don't forward them directly via uORB. This solves an issue where many requests are dropped and QGC does not start properly with UAVCAN devices.