### PR TITLE
Hotfix for vision debug stream

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -1576,7 +1576,10 @@ protected:
 		struct vehicle_local_position_s vpos = {};
 		struct vehicle_attitude_s vatt = {};
 
-		if (_pos_sub->update(&_pos_time, &vpos) || _att_sub->update(&_att_time, &vatt)) {
+		bool att_updated = _att_sub->update(&_att_time, &vatt);
+		bool pos_updated = _pos_sub->update(&_pos_time, &vpos);
+
+		if (pos_updated || att_updated) {
 			mavlink_vision_position_estimate_t vmsg;
 			vmsg.usec = vpos.timestamp;
 			vmsg.x = vpos.x;


### PR DESCRIPTION
I realised that the vision attitude subscription wasn't being updated correctly while testing vision in SITL. If the first condition was true, the second would never get evaluated or executed, and the data would not be updated.

This patch fixes it. Please merge @LorenzMeier. Looks like I can't push to master because its protected.