### PR TITLE
Param: add locking

### DIFF
--- a/src/drivers/boards/aerocore/aerocore_init.c
+++ b/src/drivers/boards/aerocore/aerocore_init.c
@@ -70,6 +70,7 @@
 
 #include <systemlib/cpuload.h>
 #include <systemlib/perf_counter.h>
+#include <systemlib/param/param.h>
 
 #if defined(CONFIG_HAVE_CXX) && defined(CONFIG_HAVE_CXXINITIALIZE)
 #include <systemlib/systemlib.h>
@@ -193,6 +194,8 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	/* configure the high-resolution time/callout interface */
 	hrt_init();
+
+	param_init();
 
 	/* configure the DMA allocator */
 	dma_alloc_init();

--- a/src/drivers/boards/aerofc-v1/aerofc_init.c
+++ b/src/drivers/boards/aerofc-v1/aerofc_init.c
@@ -72,6 +72,7 @@
 #include <systemlib/err.h>
 #include <systemlib/hardfault_log.h>
 #include <systemlib/systemlib.h>
+#include <systemlib/param/param.h>
 
 # if defined(FLASH_BASED_PARAMS)
 #  include <systemlib/flashparams/flashfs.h>
@@ -172,6 +173,8 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	/* configure the high-resolution time/callout interface */
 	hrt_init();
+
+	param_init();
 
 	/* configure CPU load estimation */
 #ifdef CONFIG_SCHED_INSTRUMENTATION

--- a/src/drivers/boards/auav-x21/auav_init.c
+++ b/src/drivers/boards/auav-x21/auav_init.c
@@ -79,6 +79,7 @@
 #include <systemlib/hardfault_log.h>
 
 #include <systemlib/systemlib.h>
+#include <systemlib/param/param.h>
 
 /****************************************************************************
  * Pre-Processor Definitions
@@ -241,6 +242,8 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	/* configure the high-resolution time/callout interface */
 	hrt_init();
+
+	param_init();
 
 	/* configure the DMA allocator */
 

--- a/src/drivers/boards/crazyflie/crazyflie_init.c
+++ b/src/drivers/boards/crazyflie/crazyflie_init.c
@@ -71,6 +71,7 @@
 #include <systemlib/err.h>
 #include <systemlib/hardfault_log.h>
 #include <systemlib/systemlib.h>
+#include <systemlib/param/param.h>
 
 /****************************************************************************
  * Pre-Processor Definitions
@@ -163,6 +164,8 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	/* configure the high-resolution time/callout interface */
 	hrt_init();
+
+	param_init();
 
 	/* configure CPU load estimation */
 #ifdef CONFIG_SCHED_INSTRUMENTATION

--- a/src/drivers/boards/esc35-v1/esc35_init.c
+++ b/src/drivers/boards/esc35-v1/esc35_init.c
@@ -69,6 +69,7 @@
 #include <drivers/drv_led.h>
 
 #include <systemlib/cpuload.h>
+#include <systemlib/param/param.h>
 
 #if defined(CONFIG_HAVE_CXX) && defined(CONFIG_HAVE_CXXINITIALIZE)
 #include <systemlib/systemlib.h>
@@ -178,6 +179,8 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	/* configure the high-resolution time/callout interface */
 	hrt_init();
+
+	param_init();
 
 	/* set up the serial DMA polling */
 	static struct hrt_call serial_dma_call;

--- a/src/drivers/boards/mindpx-v2/mindpx2_init.c
+++ b/src/drivers/boards/mindpx-v2/mindpx2_init.c
@@ -79,6 +79,7 @@
 #include <systemlib/hardfault_log.h>
 
 #include <systemlib/systemlib.h>
+#include <systemlib/param/param.h>
 
 /****************************************************************************
  * Pre-Processor Definitions
@@ -227,6 +228,8 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	/* configure the high-resolution time/callout interface */
 
 	hrt_init();
+
+	param_init();
 
 	/* configure the DMA allocator */
 

--- a/src/drivers/boards/px4-stm32f4discovery/px4discovery_init.c
+++ b/src/drivers/boards/px4-stm32f4discovery/px4discovery_init.c
@@ -72,6 +72,7 @@
 
 #include <systemlib/cpuload.h>
 #include <systemlib/perf_counter.h>
+#include <systemlib/param/param.h>
 
 /****************************************************************************
  * Pre-Processor Definitions
@@ -164,6 +165,8 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	/* configure the high-resolution time/callout interface */
 	hrt_init();
+
+	param_init();
 
 	/* configure CPU load estimation */
 #ifdef CONFIG_SCHED_INSTRUMENTATION

--- a/src/drivers/boards/px4cannode-v1/px4cannode_init.c
+++ b/src/drivers/boards/px4cannode-v1/px4cannode_init.c
@@ -69,6 +69,7 @@
 #include <drivers/drv_led.h>
 
 #include <systemlib/cpuload.h>
+#include <systemlib/param/param.h>
 
 #if defined(CONFIG_HAVE_CXX) && defined(CONFIG_HAVE_CXXINITIALIZE)
 #include <systemlib/systemlib.h>
@@ -171,6 +172,8 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	/* configure the high-resolution time/callout interface */
 	hrt_init();
+
+	param_init();
 
 	/* set up the serial DMA polling */
 	static struct hrt_call serial_dma_call;

--- a/src/drivers/boards/px4esc-v1/px4esc_init.c
+++ b/src/drivers/boards/px4esc-v1/px4esc_init.c
@@ -69,6 +69,7 @@
 #include <drivers/drv_led.h>
 
 #include <systemlib/cpuload.h>
+#include <systemlib/param/param.h>
 
 #if defined(CONFIG_HAVE_CXX) && defined(CONFIG_HAVE_CXXINITIALIZE)
 #include <systemlib/systemlib.h>
@@ -172,6 +173,8 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	/* configure the high-resolution time/callout interface */
 	hrt_init();
+
+	param_init();
 
 	/* set up the serial DMA polling */
 	static struct hrt_call serial_dma_call;

--- a/src/drivers/boards/px4fmu-v1/px4fmu_init.c
+++ b/src/drivers/boards/px4fmu-v1/px4fmu_init.c
@@ -69,6 +69,7 @@
 #include <drivers/drv_led.h>
 
 #include <systemlib/cpuload.h>
+#include <systemlib/param/param.h>
 
 /****************************************************************************
  * Pre-Processor Definitions
@@ -188,6 +189,8 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	/* configure the high-resolution time/callout interface */
 	hrt_init();
+
+	param_init();
 
 	/* configure CPU load estimation */
 #ifdef CONFIG_SCHED_INSTRUMENTATION

--- a/src/drivers/boards/px4fmu-v2/px4fmu2_init.c
+++ b/src/drivers/boards/px4fmu-v2/px4fmu2_init.c
@@ -79,6 +79,7 @@
 #include <systemlib/hardfault_log.h>
 
 #include <systemlib/systemlib.h>
+#include <systemlib/param/param.h>
 
 /****************************************************************************
  * Pre-Processor Definitions
@@ -236,6 +237,8 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	/* configure the high-resolution time/callout interface */
 	hrt_init();
+
+	param_init();
 
 	/* configure the DMA allocator */
 

--- a/src/drivers/boards/px4fmu-v4/px4fmu_init.c
+++ b/src/drivers/boards/px4fmu-v4/px4fmu_init.c
@@ -80,6 +80,7 @@
 #include <systemlib/hardfault_log.h>
 
 #include <systemlib/systemlib.h>
+#include <systemlib/param/param.h>
 
 /****************************************************************************
  * Pre-Processor Definitions
@@ -249,6 +250,8 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	/* configure the high-resolution time/callout interface */
 	hrt_init();
+
+	param_init();
 
 	/* configure the DMA allocator */
 

--- a/src/drivers/boards/px4fmu-v4pro/px4fmu_init.c
+++ b/src/drivers/boards/px4fmu-v4pro/px4fmu_init.c
@@ -80,6 +80,7 @@
 #include <systemlib/hardfault_log.h>
 
 #include <systemlib/systemlib.h>
+#include <systemlib/param/param.h>
 
 /****************************************************************************
  * Pre-Processor Definitions
@@ -265,6 +266,8 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	/* configure the high-resolution time/callout interface */
 	hrt_init();
+
+	param_init();
 
 	/* configure the DMA allocator */
 

--- a/src/drivers/boards/px4fmu-v5/px4fmu_init.c
+++ b/src/drivers/boards/px4fmu-v5/px4fmu_init.c
@@ -80,6 +80,7 @@
 #include <systemlib/hardfault_log.h>
 
 #include <systemlib/systemlib.h>
+#include <systemlib/param/param.h>
 
 #include "up_internal.h"
 /****************************************************************************
@@ -310,6 +311,8 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	/* configure the high-resolution time/callout interface */
 	hrt_init();
+
+	param_init();
 
 	/* configure the DMA allocator */
 

--- a/src/drivers/boards/px4nucleoF767ZI-v1/px4nucleo_init.c
+++ b/src/drivers/boards/px4nucleoF767ZI-v1/px4nucleo_init.c
@@ -80,6 +80,7 @@
 #include <systemlib/hardfault_log.h>
 
 #include <systemlib/systemlib.h>
+#include <systemlib/param/param.h>
 
 #include "up_internal.h"
 /****************************************************************************
@@ -249,6 +250,8 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	/* configure the high-resolution time/callout interface */
 	hrt_init();
+
+	param_init();
 
 	/* configure the DMA allocator */
 

--- a/src/drivers/boards/s2740vc-v1/s2740vc_init.c
+++ b/src/drivers/boards/s2740vc-v1/s2740vc_init.c
@@ -69,6 +69,7 @@
 #include <drivers/drv_led.h>
 
 #include <systemlib/cpuload.h>
+#include <systemlib/param/param.h>
 
 #if defined(CONFIG_HAVE_CXX) && defined(CONFIG_HAVE_CXXINITIALIZE)
 #include <systemlib/systemlib.h>
@@ -164,6 +165,8 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	/* configure the high-resolution time/callout interface */
 	hrt_init();
+
+	param_init();
 
 	/* set up the serial DMA polling */
 	static struct hrt_call serial_dma_call;

--- a/src/drivers/boards/tap-v1/tap_init.c
+++ b/src/drivers/boards/tap-v1/tap_init.c
@@ -72,6 +72,7 @@
 #include <systemlib/err.h>
 #include <systemlib/hardfault_log.h>
 #include <systemlib/systemlib.h>
+#include <systemlib/param/param.h>
 
 # if defined(FLASH_BASED_PARAMS)
 #  include <systemlib/flashparams/flashfs.h>
@@ -199,6 +200,8 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	/* configure the high-resolution time/callout interface */
 	hrt_init();
+
+	param_init();
 
 	/* configure the DMA allocator */
 

--- a/src/modules/systemlib/flashparams/flashparams.c
+++ b/src/modules/systemlib/flashparams/flashparams.c
@@ -342,11 +342,6 @@ int flash_param_save(void)
 }
 
 
-int flash_param_save_default(void)
-{
-	return param_export_internal(false);
-}
-
 
 int flash_param_load(void)
 {
@@ -356,5 +351,5 @@ int flash_param_load(void)
 
 int flash_param_import(void)
 {
-	return 0;
+	return -1;
 }

--- a/src/modules/systemlib/flashparams/flashparams.c
+++ b/src/modules/systemlib/flashparams/flashparams.c
@@ -70,30 +70,12 @@ struct param_wbuf_s {
 	bool                    unsaved;
 };
 
-
-/** lock the parameter store */
-static void
-param_lock(void)
-{
-	//do {} while (sem_wait(&param_sem) != 0);
-}
-
-/** unlock the parameter store */
-static void
-param_unlock(void)
-{
-	//sem_post(&param_sem);
-}
-
-
 static int
 param_export_internal(bool only_unsaved)
 {
 	struct param_wbuf_s *s = NULL;
 	struct bson_encoder_s encoder;
 	int     result = -1;
-
-	param_lock();
 
 	/* Use realloc */
 
@@ -165,7 +147,6 @@ param_export_internal(bool only_unsaved)
 	result = 0;
 
 out:
-	param_unlock();
 
 	if (result == 0) {
 

--- a/src/modules/systemlib/flashparams/flashparams.c
+++ b/src/modules/systemlib/flashparams/flashparams.c
@@ -107,7 +107,7 @@ param_export_internal(bool only_unsaved)
 		switch (param_type(s->param)) {
 
 		case PARAM_TYPE_INT32:
-			param_get(s->param, &i);
+			i = s->val.i;
 
 			if (bson_encoder_append_int(&encoder, param_name(s->param), i)) {
 				debug("BSON append failed for '%s'", param_name(s->param));
@@ -117,7 +117,7 @@ param_export_internal(bool only_unsaved)
 			break;
 
 		case PARAM_TYPE_FLOAT:
-			param_get(s->param, &f);
+			f = s->val.f;
 
 			if (bson_encoder_append_double(&encoder, param_name(s->param), f)) {
 				debug("BSON append failed for '%s'", param_name(s->param));

--- a/src/modules/systemlib/flashparams/flashparams.h
+++ b/src/modules/systemlib/flashparams/flashparams.h
@@ -64,9 +64,8 @@ __EXPORT extern UT_array        *param_values;
 __EXPORT int param_set_external(param_t param, const void *val, bool mark_saved, bool notify_changes, bool is_saved);
 __EXPORT const void *param_get_value_ptr_external(param_t param);
 
-/* The interface hooks to the Flash based storage */
+/* The interface hooks to the Flash based storage. The caller is responsible for locking */
 __EXPORT int flash_param_save(void);
-__EXPORT int flash_param_save_default(void);
 __EXPORT int flash_param_load(void);
 __EXPORT int flash_param_import(void);
 __END_DECLS

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -803,7 +803,9 @@ param_save_default(void)
 
 	PARAM_CLOSE(fd);
 #else
+	param_lock();
 	res = flash_param_save();
+	param_unlock();
 #endif
 	return res;
 }
@@ -814,7 +816,8 @@ param_save_default(void)
 int
 param_load_default(void)
 {
-	warnx("param_load_default\n");
+	int res = 0;
+#if !defined(FLASH_BASED_PARAMS)
 	int fd_load = PARAM_OPEN(param_get_default_file(), O_RDONLY);
 
 	if (fd_load < 0) {
@@ -835,7 +838,11 @@ param_load_default(void)
 		return -2;
 	}
 
-	return 0;
+#else
+	// no need for locking
+	res = flash_param_load();
+#endif
+	return res;
 }
 
 static void
@@ -1134,7 +1141,13 @@ out:
 int
 param_import(int fd)
 {
+#if !defined(FLASH_BASED_PARAMS)
 	return param_import_internal(fd, false);
+#else
+	(void)fd; // unused
+	// no need for locking here
+	return flash_param_import();
+#endif
 }
 
 int

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -916,7 +916,7 @@ param_export(int fd, bool only_unsaved)
 		switch (param_type(s->param)) {
 
 		case PARAM_TYPE_INT32: {
-				param_get(s->param, &i);
+				i = s->val.i;
 				const char *name = param_name(s->param);
 
 				/* lock as short as possible */
@@ -932,7 +932,7 @@ param_export(int fd, bool only_unsaved)
 
 		case PARAM_TYPE_FLOAT: {
 
-				param_get(s->param, &f);
+				f = s->val.f;
 				const char *name = param_name(s->param);
 
 				/* lock as short as possible */

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -157,7 +157,7 @@ static void param_set_used_internal(param_t param);
 
 static param_t param_find_internal(const char *name, bool notification);
 
-static px4_sem_t param_sem;
+static px4_sem_t param_sem; ///< this protects against concurrent access to param_values and param save
 
 /** lock the parameter store */
 static void

--- a/src/modules/systemlib/param/param.h
+++ b/src/modules/systemlib/param/param.h
@@ -88,6 +88,11 @@ typedef uintptr_t	param_t;
 #define PARAM_HASH      ((uintptr_t)INT32_MAX)
 
 /**
+ * Initialize the param backend. Call this on startup before calling any other methods.
+ */
+__EXPORT void		param_init(void);
+
+/**
  * Look up a parameter by name.
  *
  * @param name		The canonical name of the parameter being looked up.

--- a/src/modules/systemlib/param/param_shmem.c
+++ b/src/modules/systemlib/param/param_shmem.c
@@ -51,7 +51,7 @@
 #include <unistd.h>
 #include <systemlib/err.h>
 #include <errno.h>
-#include <semaphore.h>
+#include <px4_sem.h>
 
 #include <sys/stat.h>
 
@@ -165,18 +165,20 @@ static void param_set_used_internal(param_t param);
 
 static param_t param_find_internal(const char *name, bool notification);
 
+static px4_sem_t param_sem;
+
 /** lock the parameter store */
 static void
 param_lock(void)
 {
-	//do {} while (px4_sem_wait(&param_sem) != 0);
+	do {} while (px4_sem_wait(&param_sem) != 0);
 }
 
 /** unlock the parameter store */
 static void
 param_unlock(void)
 {
-	//px4_sem_post(&param_sem);
+	px4_sem_post(&param_sem);
 }
 
 /** assert that the parameter store is locked */
@@ -184,6 +186,12 @@ static void
 param_assert_locked(void)
 {
 	/* TODO */
+}
+
+void
+param_init(void)
+{
+	px4_sem_init(&param_sem, 0, 1);
 }
 
 /**
@@ -431,15 +439,22 @@ param_name(param_t param)
 bool
 param_value_is_default(param_t param)
 {
-	return param_find_changed(param) ? false : true;
+	struct param_wbuf_s *s;
+	param_lock();
+	s = param_find_changed(param);
+	param_unlock();
+	return s ? false : true;
 }
 
 bool
 param_value_unsaved(param_t param)
 {
-	static struct param_wbuf_s *s;
+	struct param_wbuf_s *s;
+	param_lock();
 	s = param_find_changed(param);
-	return (s && s->unsaved) ? true : false;
+	bool ret = s && s->unsaved;
+	param_unlock();
+	return ret;
 }
 
 enum param_type_e
@@ -773,8 +788,6 @@ param_reset_all(void)
 void
 param_reset_excludes(const char *excludes[], int num_excludes)
 {
-	param_lock();
-
 	param_t	param;
 
 	for (param = 0; handle_in_range(param); param++) {
@@ -797,8 +810,6 @@ param_reset_excludes(const char *excludes[], int num_excludes)
 		}
 	}
 
-	param_unlock();
-
 	_param_notify_changes(false);
 }
 
@@ -813,6 +824,7 @@ int
 param_set_default_file(const char *filename)
 {
 	if (param_user_file != NULL) {
+		// we assume this is not in use by some other thread
 		free(param_user_file);
 		param_user_file = NULL;
 	}

--- a/src/modules/systemlib/param/param_shmem.c
+++ b/src/modules/systemlib/param/param_shmem.c
@@ -165,7 +165,7 @@ static void param_set_used_internal(param_t param);
 
 static param_t param_find_internal(const char *name, bool notification);
 
-static px4_sem_t param_sem;
+static px4_sem_t param_sem; ///< this protects against concurrent access to param_values and param save
 
 /** lock the parameter store */
 static void

--- a/src/platforms/posix/px4_layer/px4_posix_impl.cpp
+++ b/src/platforms/posix/px4_layer/px4_posix_impl.cpp
@@ -46,7 +46,7 @@
 #include <signal.h>
 #include <errno.h>
 #include <unistd.h>
-#include "systemlib/param/param.h"
+#include <systemlib/param/param.h>
 #include "hrt_work.h"
 #include <drivers/drv_hrt.h>
 #include "px4_time.h"
@@ -76,6 +76,7 @@ void init_once()
 	work_queues_init();
 	hrt_work_queue_init();
 	hrt_init();
+	param_init();
 
 #ifdef CONFIG_SHMEM
 	PX4_DEBUG("Syncing params to shared memory\n");

--- a/src/platforms/qurt/px4_layer/px4_qurt_impl.cpp
+++ b/src/platforms/qurt/px4_layer/px4_qurt_impl.cpp
@@ -48,7 +48,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <semaphore.h>
-#include "systemlib/param/param.h"
+#include <systemlib/param/param.h>
 #include "hrt_work.h"
 #include "px4_log.h"
 
@@ -106,6 +106,7 @@ void init_once(void)
 	work_queues_init();
 	hrt_work_queue_init();
 	hrt_init();
+	param_init();
 
 	/* Shared memory param sync*/
 	init_params();

--- a/src/systemcmds/param/param.c
+++ b/src/systemcmds/param/param.c
@@ -236,31 +236,26 @@ param_main(int argc, char *argv[])
 }
 
 #if defined(FLASH_BASED_PARAMS)
-/* If flash based parameters are uses we call out
- * to the following set of flash routines
+/* If flash based parameters are uses we have to change some of the calls to the
+ * default param calls, which will in turn take care of locking and calling to the
+ * flash backend.
  */
 static int
-
 do_save(const char *param_file_name)
 {
-	return flash_param_save();
-}
-static int
-do_save_default(void)
-{
-	return flash_param_save_default();
+	return param_save_default();
 }
 
 static int
 do_load(const char *param_file_name)
 {
-	return flash_param_load();
+	return param_load_default();
 }
 
 static int
 do_import(const char *param_file_name)
 {
-	return flash_param_import();
+	return param_import(-1);
 }
 #else
 
@@ -287,12 +282,6 @@ do_save(const char *param_file_name)
 	}
 
 	return 0;
-}
-
-static int
-do_save_default(void)
-{
-	return param_save_default();
 }
 
 static int
@@ -337,6 +326,12 @@ do_import(const char *param_file_name)
 	return 0;
 }
 #endif
+
+static int
+do_save_default(void)
+{
+	return param_save_default();
+}
 
 static int
 do_show(const char *search_string)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -105,7 +105,7 @@ endfunction()
 #    add_gtest(example_test)
 
 # param_test
-add_executable(param_test param_test.cpp uorb_stub.cpp
+add_executable(param_test setup.cpp param_test.cpp uorb_stub.cpp
 						${PX4_SRC}/modules/systemlib/bson/tinybson.c
 						${PX4_SRC}/modules/systemlib/param/param.c)
 target_link_libraries(param_test ${PX4_PLATFORM})

--- a/unittests/setup.cpp
+++ b/unittests/setup.cpp
@@ -1,0 +1,23 @@
+#include <systemlib/param/param.h>
+
+#include "gtest/gtest.h"
+
+
+class TestEnvironment: public ::testing::Environment {
+public:
+	/**
+	 * Testing setup: this is called before the actual tests are executed.
+	 */
+	virtual void SetUp()
+	{
+		param_init();
+	}
+};
+
+int main(int argc, char* argv[])
+{
+	::testing::InitGoogleTest(&argc, argv);
+	// gtest takes ownership of the TestEnvironment ptr - we don't delete it.
+	::testing::AddGlobalTestEnvironment(new TestEnvironment);
+	return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This adds locking to the param module.

We need to protect access to the param_values array. This is dynamically
allocated and resized (utarray_reserve() calls realloc). If some thread
was iterating the array while another was resizing the array, the first one
would iterate on a freed array, thus accessing invalid memory.

On NuttX this could lead to hardfaults in rare conditions.

@davids5 This also adds locking to the flash-based params. Can you please test that I called `param_init` everywhere where needed? I checked where `hrt_init` was called and compared that against the cmake config's that enable the `param` module.

@Stifael can you please test this on Snappy?

I tested on Posix & Pixracer.

This could be implemented more efficiently if we had atomic variables.