### PR TITLE
Manual position control continuous setpoint around deadzone

### DIFF
--- a/src/lib/mathlib/math/Expo.hpp
+++ b/src/lib/mathlib/math/Expo.hpp
@@ -35,7 +35,7 @@
  * @file Expo.hpp
  *
  * So called exponential curve function implementation.
- * It's essentially a linear combination between a linear and a cubic function.
+ * It is essentially a linear combination between a linear and a cubic function.
  */
 
 #pragma once
@@ -46,11 +46,33 @@
 namespace math
 {
 
+// Type-safe signum function
+template<typename T> int sign(T val) {
+	return (T(0) < val) - (val < T(0));
+}
+
 template<typename _Tp>
 inline const _Tp expo(const _Tp &value, const _Tp &e)
 {
 	_Tp x = constrain(value ,(_Tp)-1, (_Tp)1);
 	return (1-e)*x + e*x*x*x;
+}
+
+template<typename _Tp>
+inline const _Tp deadzone(const _Tp &value, const _Tp &dz)
+{
+	_Tp x = constrain(value ,(_Tp)-1, (_Tp)1);
+	// Rescale the input such that we get a piecewise linear function that will be continuous with applied deadzone
+	_Tp out = (x-sign(x)*dz)/(1-dz);
+	// apply the deadzone (values zero around the middle)
+	return out * (fabsf(x) > dz);
+}
+
+template<typename _Tp>
+inline const _Tp expo_deadzone(const _Tp &value, const _Tp &e, const _Tp &dz)
+{
+	_Tp x = constrain(value ,(_Tp)-1, (_Tp)1);
+	return expo(deadzone(x, dz),e);
 }
 
 }

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -928,8 +928,8 @@ MulticopterPositionControl::control_manual(float dt)
 
 	if (_control_mode.flag_control_position_enabled) {
 		/* set horizontal velocity setpoint with roll/pitch stick */
-		req_vel_sp_xy(0) = math::expo(_manual.x, _params.xy_vel_man_expo);
-		req_vel_sp_xy(1) = math::expo(_manual.y, _params.xy_vel_man_expo);
+		req_vel_sp_xy(0) = math::expo_deadzone(_manual.x, _params.xy_vel_man_expo, _params.hold_xy_dz);
+		req_vel_sp_xy(1) = math::expo_deadzone(_manual.y, _params.xy_vel_man_expo, _params.hold_xy_dz);
 
 		/* reset position setpoint to current position if needed */
 		reset_pos_sp();
@@ -962,7 +962,7 @@ MulticopterPositionControl::control_manual(float dt)
 	/* horizontal axes */
 	float vel_xy_mag = sqrtf(_vel(0) * _vel(0) + _vel(1) * _vel(1));
 	bool do_pos_hold = _control_mode.flag_control_position_enabled &&
-			   (fabsf(req_vel_sp_xy(0)) < _params.hold_xy_dz && fabsf(req_vel_sp_xy(1)) < _params.hold_xy_dz) &&
+			   (fabsf(req_vel_sp_xy(0)) < FLT_EPSILON && fabsf(req_vel_sp_xy(1)) < FLT_EPSILON) &&
 			   (_params.hold_max_xy < FLT_EPSILON || vel_xy_mag < _params.hold_max_xy);
 
 	bool smooth_pos_transition = do_pos_hold && !_pos_hold_engaged;


### PR DESCRIPTION
mc_pos_control: moved responsibility of the x,y stick deadzone to a mathematical function

to prevent a setpoint step when moving the stick over the border of the deadzone
and to enable very small inputs even from a control stick that needs a big deadzone


The problem of using the deadzone as a velocity setpoint threshold to switch between position and velocity controlled mode was a total resulting stick input function similar to this one (expo was applied here but it's the same for the linear case):
![expo_deadzone](https://cloud.githubusercontent.com/assets/4668506/23160758/f535b27e-f827-11e6-8ec9-602c5bf0e0d2.PNG)

My change here aims to keep the desired deadzone but then allow the pilot to command very small velocities and certainly not have a step or discontiuity in his input range. So the resulting stick input function should look like this:
![expo_deadzone_sol](https://cloud.githubusercontent.com/assets/4668506/23160838/42e13002-f828-11e6-8df8-8c45ed463885.PNG)

