### PR TITLE
mc_pos_control: have same acceleration max for xy and z

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -468,7 +468,7 @@ PARAM_DEFINE_FLOAT(MPC_ACC_HOR_MAX, 5.0f);
  * @decimal 2
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_ACC_UP_MAX, 10.0f);
+PARAM_DEFINE_FLOAT(MPC_ACC_UP_MAX, 5.0f);
 
 /**
  * Maximum vertical acceleration in velocity controlled modes down


### PR DESCRIPTION
During transition from fast forward flight to fast forward + upward flight, the vehicle's velocity setpoint favors the motion upward due to the slewrate limits. This especially happens during saturation