### PR TITLE
Finer granularity on battery actions

### DIFF
--- a/msg/battery_status.msg
+++ b/msg/battery_status.msg
@@ -12,6 +12,8 @@ bool connected			# Wether or not a battery is connected
 
 uint8 BATTERY_WARNING_NONE = 0       # no battery low voltage warning active
 uint8 BATTERY_WARNING_LOW = 1        # warning of low voltage
-uint8 BATTERY_WARNING_CRITICAL = 2   # alerting of critical voltage
+uint8 BATTERY_WARNING_CRITICAL = 2   # critical voltage, return / abort immediately
+uint8 BATTERY_WARNING_EMERGENCY = 3   # immediate landing required
+uint8 BATTERY_WARNING_FAILED = 4   # the battery has failed completely
 
 uint8 warning    # current battery warning

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -315,8 +315,9 @@ PARAM_DEFINE_INT32(COM_ARM_SWISBTN, 0);
  *
  * @group Commander
  * @value 0 Warning
- * @value 1 Return to Land
+ * @value 1 Return to land
  * @value 2 Land at current position
+ * @value 3 Return to land at critically low level, land at current position if reaching dangerously low levels
  * @decimal 0
  * @increment 1
  */

--- a/src/modules/systemlib/battery.cpp
+++ b/src/modules/systemlib/battery.cpp
@@ -51,6 +51,7 @@ Battery::Battery() :
 	_param_r_internal(this, "R_INTERNAL"),
 	_param_low_thr(this, "LOW_THR"),
 	_param_crit_thr(this, "CRIT_THR"),
+	_param_emergency_thr(this, "EMERGEN_THR"),
 	_voltage_filtered_v(-1.0f),
 	_discharged_mah(0.0f),
 	_remaining_voltage(1.0f),
@@ -219,7 +220,10 @@ void
 Battery::determineWarning()
 {
 	// Smallest values must come first
-	if (_remaining < _param_crit_thr.get()) {
+	if (_remaining < _param_emergency_thr.get()) {
+		_warning = battery_status_s::BATTERY_WARNING_EMERGENCY;
+
+	} else if (_remaining < _param_crit_thr.get()) {
 		_warning = battery_status_s::BATTERY_WARNING_CRITICAL;
 
 	} else if (_remaining < _param_low_thr.get()) {

--- a/src/modules/systemlib/battery.h
+++ b/src/modules/systemlib/battery.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2016, 2017 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -106,6 +106,7 @@ private:
 	control::BlockParamFloat _param_r_internal;
 	control::BlockParamFloat _param_low_thr;
 	control::BlockParamFloat _param_crit_thr;
+	control::BlockParamFloat _param_emergency_thr;
 
 	float _voltage_filtered_v;
 	float _current_filtered_a;

--- a/src/modules/systemlib/battery_params.c
+++ b/src/modules/systemlib/battery_params.c
@@ -90,7 +90,7 @@ PARAM_DEFINE_FLOAT(BAT_LOW_THR, 0.15f);
  *
  * Sets the threshold when the battery will be reported as critically low.
  * This has to be lower than the low threshold. This threshold commonly
- * will trigger RTL or landing.
+ * will trigger RTL.
  *
  * @group Battery Calibration
  * @unit norm
@@ -100,6 +100,22 @@ PARAM_DEFINE_FLOAT(BAT_LOW_THR, 0.15f);
  * @increment 0.01
  */
 PARAM_DEFINE_FLOAT(BAT_CRIT_THR, 0.07f);
+
+/**
+ * Emergency threshold
+ *
+ * Sets the threshold when the battery will be reported as dangerously low.
+ * This has to be lower than the critical threshold. This threshold commonly
+ * will trigger landing.
+ *
+ * @group Battery Calibration
+ * @unit norm
+ * @min 0.03
+ * @max 0.07
+ * @decimal 2
+ * @increment 0.01
+ */
+PARAM_DEFINE_FLOAT(BAT_EMERGEN_THR, 0.05f);
 
 /**
  * Voltage drop per cell on full throttle


### PR DESCRIPTION
@bkueng @MaEtUgR This brings in finer granularity: We RTL first, then land if we go too low.