### PR TITLE
Add EKF consistency checking to commander failsafe response

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2148,7 +2148,7 @@ int commander_thread_main(int argc, char *argv[])
 		bool optical_flow_data_good = !(estimator_status.innovation_check_flags & (1<<9)) // X axis flow data has been accepted
 				&& !(estimator_status.innovation_check_flags & (1<<10)); // Y axis flow data has been accepted
 		if (using_optical_flow && (optical_flow_data_good || !run_quality_checks)) {
-			last_velpos_pass_time = hrt_absolute_time();
+			last_optflow_fail_time = hrt_absolute_time();
 		} else {
 			last_optflow_fail_time = hrt_absolute_time();
 		}

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -120,6 +120,7 @@
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_status_flags.h>
 #include <uORB/topics/vtol_vehicle_status.h>
+#include <uORB/topics/estimator_status.h>
 
 typedef enum VEHICLE_MODE_FLAG
 {
@@ -190,6 +191,12 @@ static float max_ekf_hgt_ratio = 0.5f;
 static float max_ekf_yaw_ratio = 0.5f;
 static float max_ekf_dvel_bias = 2.0e-3f;
 static float max_ekf_dang_bias = 3.5e-4f;
+
+/* in-flight EKF consistency checks */
+static hrt_abstime last_velpos_pass_time = 0;
+static hrt_abstime last_velpos_fail_time = 0;
+static hrt_abstime last_optflow_pass_time = 0;
+static hrt_abstime last_optflow_fail_time = 0;
 
 /* pre-flight IMU consistency checks */
 static float max_imu_acc_diff = 0.7f;
@@ -1632,6 +1639,10 @@ int commander_thread_main(int argc, char *argv[])
 	int cpuload_sub = orb_subscribe(ORB_ID(cpuload));
 	memset(&cpuload, 0, sizeof(cpuload));
 
+	/* Subscribe to estimator status topic */
+	int estimator_status_sub = orb_subscribe(ORB_ID(estimator_status));
+	struct estimator_status_s estimator_status;
+	memset(&estimator_status, 0, sizeof(estimator_status));
 	control_status_leds(&status, &armed, true, &battery, &cpuload);
 
 	/* now initialized */
@@ -2084,22 +2095,7 @@ int commander_thread_main(int argc, char *argv[])
 
 		if (updated) {
 			/* position changed */
-			vehicle_global_position_s gpos;
-			orb_copy(ORB_ID(vehicle_global_position), global_position_sub, &gpos);
-
-			/* copy to global struct if valid, with hysteresis */
-
-			// XXX consolidate this with local position handling and timeouts after release
-			// but we want a low-risk change now.
-			if (status_flags.condition_global_position_valid) {
-				if (gpos.eph < eph_threshold * 2.5f) {
-					orb_copy(ORB_ID(vehicle_global_position), global_position_sub, &global_position);
-				}
-			} else {
-				if (gpos.eph < eph_threshold) {
-					orb_copy(ORB_ID(vehicle_global_position), global_position_sub, &global_position);
-				}
-			}
+			orb_copy(ORB_ID(vehicle_global_position), global_position_sub, &global_position);
 		}
 
 		/* update local position estimate */
@@ -2114,50 +2110,112 @@ int commander_thread_main(int argc, char *argv[])
 		orb_check(attitude_sub, &updated);
 
 		if (updated) {
-			/* position changed */
+			/* attitude changed */
 			orb_copy(ORB_ID(vehicle_attitude), attitude_sub, &attitude);
 		}
 
-		//update condition_global_position_valid
-		//Global positions are only published by the estimators if they are valid
-		if (hrt_absolute_time() - global_position.timestamp > POSITION_TIMEOUT) {
-			//We have had no good fix for POSITION_TIMEOUT amount of time
-			if (status_flags.condition_global_position_valid) {
-				set_tune_override(TONE_GPS_WARNING_TUNE);
-				status_changed = true;
-				status_flags.condition_global_position_valid = false;
-			}
-		} else if (global_position.timestamp != 0) {
-			// Got good global position estimate
-			if (!status_flags.condition_global_position_valid) {
-				status_changed = true;
-				status_flags.condition_global_position_valid = true;
-			}
+		/* Check validity of global and local position data */
+
+		// Check if quality checking of position accuracy and consistency is to be performed
+		bool run_quality_checks = !status_flags.circuit_breaker_engaged_posfailure_check;
+
+		// Get estimator status data
+		bool estimator_status_updated;
+		orb_check(estimator_status_sub, &estimator_status_updated);
+		if (estimator_status_updated) {
+			orb_copy(ORB_ID(estimator_status), estimator_status_sub, &estimator_status);
 		}
 
-		/* update condition_local_position_valid and condition_local_altitude_valid */
-		/* hysteresis for EPH */
-		bool local_eph_good;
-
-		if (status_flags.condition_local_position_valid) {
-			if (local_position.eph > eph_threshold * 2.5f) {
-				local_eph_good = false;
-
-			} else {
-				local_eph_good = true;
-			}
-
+		// record pass/fail of position and velocity consistency checks
+		bool gps_is_inconsistent = (estimator_status.control_mode_flags & (1<<2)) // the EKF is using GPS
+				&& (estimator_status.pos_test_ratio > 1.0f) // position innovations are excessive
+				&& (estimator_status.vel_test_ratio > 1.0f); // velocity innovations are excessive
+		if (gps_is_inconsistent && run_quality_checks) {
+			last_velpos_fail_time = hrt_absolute_time();
 		} else {
-			if (local_position.eph < eph_threshold) {
-				local_eph_good = true;
-
-			} else {
-				local_eph_good = false;
-			}
+			last_velpos_pass_time = hrt_absolute_time();
 		}
 
-		check_valid(local_position.timestamp, POSITION_TIMEOUT, local_position.xy_valid
-			    && local_eph_good, &(status_flags.condition_local_position_valid), &status_changed);
+		// record pass/fail of optical flow consistency checks
+		bool using_optical_flow = (estimator_status.control_mode_flags & (1<<3));
+		bool optical_flow_data_good = !(estimator_status.innovation_check_flags & (1<<9)) // X axis flow data has been accepted
+				&& !(estimator_status.innovation_check_flags & (1<<10)); // Y axis flow data has been accepted
+		if (using_optical_flow && (optical_flow_data_good || !run_quality_checks)) {
+			last_velpos_pass_time = hrt_absolute_time();
+		} else {
+			last_optflow_fail_time = hrt_absolute_time();
+		}
+
+		// Check position accuracy with hysteresis
+		bool global_pos_inaccurate = true;
+		bool local_pos_inaccurate = true;
+		if (run_quality_checks) {
+			// Check global position accuracy
+			if (status_flags.condition_global_position_valid) {
+				if (global_position.eph < eph_threshold * 2.5f) {
+					global_pos_inaccurate = false;
+				}
+			} else {
+				if (global_position.eph < eph_threshold) {
+					global_pos_inaccurate = false;
+				}
+			}
+
+			// Check local position accuracy
+			if (status_flags.condition_local_position_valid) {
+				if (local_position.eph < eph_threshold * 2.5f) {
+					local_pos_inaccurate = false;
+				}
+			} else {
+				if (local_position.eph < eph_threshold) {
+					local_pos_inaccurate = false;
+				}
+			}
+		} else {
+			global_pos_inaccurate = false;
+			local_pos_inaccurate = false;
+		}
+
+		// Set global position validity
+		bool no_aiding = ((hrt_absolute_time() - last_velpos_pass_time) > 1E6) && ((hrt_absolute_time() - last_optflow_pass_time) > 1E6);
+		bool global_aiding_resumed = ((hrt_absolute_time() - last_velpos_fail_time) > 5E6);
+		bool ekf_reports_valid_global_pos = (estimator_status.solution_status_flags & (1<<4));
+		bool global_pos_stale = (hrt_absolute_time() - global_position.timestamp > POSITION_TIMEOUT);
+		if (status_flags.condition_global_position_valid
+			   && (global_pos_stale || no_aiding || !ekf_reports_valid_global_pos || global_pos_inaccurate)) {
+			// Require 1 second continuous loss of all aiding sources to declare global position invalid
+			status_flags.condition_global_position_valid = false;
+			set_tune_override(TONE_GPS_WARNING_TUNE);
+			status_changed = true;
+		} else if (!status_flags.condition_global_position_valid
+			   && global_aiding_resumed
+			   && ekf_reports_valid_global_pos
+			   && !global_pos_stale
+			   && !global_pos_inaccurate) {
+			// Require 5 seconds continuous position fusion to declare global position valid again
+			status_flags.condition_global_position_valid = true;
+			status_changed = true;
+		}
+
+		// Set local position validity
+		bool flow_aiding_resumed = ((hrt_absolute_time() - last_optflow_fail_time) > 5E6);
+		bool local_pos_stale = (hrt_absolute_time() - local_position.timestamp > POSITION_TIMEOUT);
+		if (status_flags.condition_local_position_valid
+			   && (local_pos_stale || no_aiding || !local_position.xy_valid || local_pos_inaccurate)) {
+			// Require 1 second continuous rejection of all aiding sources to declare local position invalid
+			status_flags.condition_local_position_valid = false;
+			status_changed = true;
+		} else if (!status_flags.condition_local_position_valid
+			   && (global_aiding_resumed || flow_aiding_resumed)
+			   && !local_pos_stale
+			   && !local_pos_inaccurate
+			   && local_position.xy_valid) {
+			// Require 5 seconds continuous fusion of either GPS or optical flow to declare local position valid again
+			status_flags.condition_local_position_valid = true;
+			status_changed = true;
+		}
+
+		/* update condition_local_altitude_valid */
 		check_valid(local_position.timestamp, POSITION_TIMEOUT, local_position.z_valid,
 			    &(status_flags.condition_local_altitude_valid), &status_changed);
 
@@ -2396,6 +2454,7 @@ int commander_thread_main(int argc, char *argv[])
 				}
 			}
 
+			// Check fix type and data freshness
 			if (gps_position.fix_type >= 3 && hrt_elapsed_time(&gps_position.timestamp) < FAILSAFE_DEFAULT_TIMEOUT) {
 				/* handle the case where gps was regained */
 				if (status_flags.gps_failure && !gpsIsNoisy) {
@@ -2411,6 +2470,7 @@ int commander_thread_main(int argc, char *argv[])
 				status_changed = true;
 				mavlink_log_critical(&mavlink_log_pub, "GPS fix lost");
 			}
+
 		}
 
 		/* start mission result check */
@@ -3156,6 +3216,7 @@ int commander_thread_main(int argc, char *argv[])
 	px4_close(param_changed_sub);
 	px4_close(battery_sub);
 	px4_close(land_detector_sub);
+	px4_close (estimator_status_sub);
 
 	thread_running = false;
 
@@ -3171,6 +3232,7 @@ get_circuit_breaker_params()
 	status_flags.circuit_breaker_engaged_enginefailure_check = circuit_breaker_enabled("CBRK_ENGINEFAIL", CBRK_ENGINEFAIL_KEY);
 	status_flags.circuit_breaker_engaged_gpsfailure_check = circuit_breaker_enabled("CBRK_GPSFAIL", CBRK_GPSFAIL_KEY);
 	status_flags.circuit_breaker_flight_termination_disabled = circuit_breaker_enabled("CBRK_FLIGHTTERM", CBRK_FLIGHTTERM_KEY);
+	status_flags.circuit_breaker_engaged_posfailure_check = circuit_breaker_enabled("CBRK_POS_CHK", CBRK_POS_CHK_KEY);
 }
 
 void

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -338,7 +338,7 @@ int commander_main(int argc, char *argv[])
 		daemon_task = px4_task_spawn_cmd("commander",
 					     SCHED_DEFAULT,
 					     SCHED_PRIORITY_DEFAULT + 40,
-					     3600,
+					     3700,
 					     commander_thread_main,
 					     (char * const *)&argv[0]);
 

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -78,6 +78,7 @@ static const char reason_no_gps[] = "no gps";
 static const char reason_no_gps_cmd[] = "no gps cmd";
 static const char reason_no_home[] = "no home";
 static const char reason_no_local_position[] = "no local position";
+static const char reason_no_global_position[] = "no global position";
 static const char reason_no_datalink[] = "no datalink";
 
 // This array defines the arming state transitions. The rows are the new state, and the columns
@@ -749,18 +750,10 @@ bool set_nav_state(struct vehicle_status_s *status,
 				 * this enables POSCTL using e.g. flow.
 				 * For fixedwing, a global position is needed. */
 
-			} else if (((status->is_rotary_wing && !status_flags->condition_local_position_valid) ||
-				    (!status->is_rotary_wing && !status_flags->condition_global_position_valid))
-				   && is_armed) {
-				enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_rc);
-
-				if (status_flags->condition_local_altitude_valid) {
-					status->nav_state = vehicle_status_s::NAVIGATION_STATE_ALTCTL;
-
-				} else {
-					status->nav_state = vehicle_status_s::NAVIGATION_STATE_STAB;
-				}
-
+			} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, true, !status->is_rotary_wing)) {
+				// nothing to do - everything done in check_invalid_pos_nav_state
+			} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, true, status->is_rotary_wing)) {
+				// nothing to do - everything done in check_invalid_pos_nav_state
 			} else {
 				status->nav_state = vehicle_status_s::NAVIGATION_STATE_POSCTL;
 			}
@@ -798,6 +791,8 @@ bool set_nav_state(struct vehicle_status_s *status,
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_gps);
 
+		} else if (check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true)) {
+			// nothing to do - everything done in check_invalid_pos_nav_state
 		} else if (status->engine_failure) {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
@@ -846,6 +841,8 @@ bool set_nav_state(struct vehicle_status_s *status,
 
 			/* also go into failsafe if just datalink is lost */
 
+		} else if (check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true)) {
+			// nothing to do - everything done in check_invalid_pos_nav_state
 		} else if (status->data_link_lost && data_link_loss_act_configured) {
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_datalink);
 
@@ -883,20 +880,8 @@ bool set_nav_state(struct vehicle_status_s *status,
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_gps);
 
-		} else if ((!status_flags->condition_global_position_valid ||
-			    !status_flags->condition_home_position_valid)) {
-			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_home);
-
-			if (status_flags->condition_local_position_valid) {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;
-
-			} else if (status_flags->condition_local_altitude_valid) {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
-
-			} else {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_TERMINATION;
-			}
-
+		} else if (check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true)) {
+			// nothing to do - everything done in check_invalid_pos_nav_state
 		} else {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_RTL;
 		}
@@ -910,18 +895,8 @@ bool set_nav_state(struct vehicle_status_s *status,
 		if (status->engine_failure) {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
-		} else if (!status_flags->condition_global_position_valid) {
-			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_gps);
-
-			if (status_flags->condition_local_position_valid) {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;
-
-			} else if (status_flags->condition_local_altitude_valid) {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
-
-			} else {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_TERMINATION;
-			}
+		} else if (check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true)) {
+			// nothing to do - everything done in check_invalid_pos_nav_state
 
 		} else {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_FOLLOW_TARGET;
@@ -936,18 +911,8 @@ bool set_nav_state(struct vehicle_status_s *status,
 		if (status->engine_failure) {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
-		} else if (!status_flags->condition_local_position_valid) {
-			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_local_position);
-
-			if (status_flags->condition_local_position_valid) {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;
-
-			} else if (status_flags->condition_local_altitude_valid) {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
-
-			} else {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_TERMINATION;
-			}
+		} else if (check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, false)) {
+			// nothing to do - everything done in check_invalid_pos_nav_state
 
 		} else {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF;
@@ -962,15 +927,8 @@ bool set_nav_state(struct vehicle_status_s *status,
 		if (status->engine_failure) {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
-		} else if (!status_flags->condition_local_position_valid) {
-			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_local_position);
-
-			if (status_flags->condition_local_altitude_valid) {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
-
-			} else {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_TERMINATION;
-			}
+		} else if (check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, false)) {
+			// nothing to do - everything done in check_invalid_pos_nav_state
 
 		} else {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;
@@ -1070,6 +1028,49 @@ void set_rc_loss_nav_state(struct vehicle_status_s *status,
 			   const link_loss_actions_t link_loss_act)
 {
 	set_link_loss_nav_state(status, armed, status_flags, link_loss_act, vehicle_status_s::NAVIGATION_STATE_AUTO_RCRECOVER);
+}
+
+bool check_invalid_pos_nav_state(struct vehicle_status_s *status,
+			       bool old_failsafe,
+			       orb_advert_t *mavlink_log_pub,
+			       status_flags_s *status_flags,
+			       const bool use_rc, // true if we can fallback to a mode that uses RC inputs
+			       const bool using_global_pos) // true if the current flight mode requires a global position
+{
+	bool fallback_required = false;
+
+	if (using_global_pos && !status_flags->condition_global_position_valid) {
+		enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_global_position);
+		fallback_required = true;
+	} else if (!using_global_pos && !status_flags->condition_local_position_valid) {
+		enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_local_position);
+		fallback_required = true;
+	}
+
+	if (fallback_required) {
+		if (use_rc) {
+			// fallback to a mode that gives the operator stick control
+			if (status->is_rotary_wing && status_flags->condition_local_position_valid) {
+				status->nav_state = vehicle_status_s::NAVIGATION_STATE_POSCTL;
+			} else if (status_flags->condition_local_altitude_valid) {
+				status->nav_state = vehicle_status_s::NAVIGATION_STATE_ALTCTL;
+			} else {
+				status->nav_state = vehicle_status_s::NAVIGATION_STATE_STAB;
+			}
+		} else {
+			// go into a descent that does not require stick control
+			if (status_flags->condition_local_position_valid) {
+				status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;
+			} else  if (status_flags->condition_local_altitude_valid) {
+				status->nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
+			} else {
+				status->nav_state = vehicle_status_s::NAVIGATION_STATE_TERMINATION;
+			}
+		}
+	}
+
+	return fallback_required;
+
 }
 
 void set_data_link_loss_nav_state(struct vehicle_status_s *status,

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -71,13 +71,13 @@ enum class link_loss_actions_t {
 struct status_flags_s {
     bool condition_calibration_enabled;
     bool condition_system_sensors_initialized;
-    bool condition_system_prearm_error_reported;        // true if errors have already been reported
-    bool condition_system_hotplug_timeout;                // true if the hotplug sensor search is over
+    bool condition_system_prearm_error_reported;	// true if errors have already been reported
+    bool condition_system_hotplug_timeout;		// true if the hotplug sensor search is over
     bool condition_system_returned_to_home;
     bool condition_auto_mission_available;
-    bool condition_global_position_valid;                // set to true by the commander app if the quality of the position estimate is good enough to use it for navigation
-    bool condition_home_position_valid;                // indicates a valid home position (a valid home position is not always a valid launch)
-    bool condition_local_position_valid;
+    bool condition_global_position_valid;		// set to true by the commander app if the quality of the global position estimate is good enough to use for navigation
+    bool condition_home_position_valid;			// indicates a valid home position (a valid home position is not always a valid launch)
+    bool condition_local_position_valid;		// set to true by the commander app if the quality of the local position estimate is good enough to use for navigation
     bool condition_local_altitude_valid;
     bool condition_airspeed_valid;                        // set to true by the commander app if there is a valid airspeed measurement available
     bool condition_power_input_valid;                // set if input power is valid
@@ -88,6 +88,7 @@ struct status_flags_s {
     bool circuit_breaker_engaged_gpsfailure_check;
     bool circuit_breaker_flight_termination_disabled;
     bool circuit_breaker_engaged_usb_check;
+    bool circuit_breaker_engaged_posfailure_check;	// set to true when the position valid checks have been disabled
     bool offboard_control_signal_found_once;
     bool offboard_control_signal_lost;
     bool offboard_control_signal_weak;

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -146,6 +146,16 @@ void set_rc_loss_nav_state(struct vehicle_status_s *status,
 			   struct actuator_armed_s *armed,
 			   status_flags_s *status_flags,
 			   const link_loss_actions_t link_loss_act);
+/*
+ * Checks the validty of position data aaainst the requirements of the current navigation
+ * mode and switches mode if position data required is not available.
+ */
+bool check_invalid_pos_nav_state(struct vehicle_status_s *status,
+			       bool old_failsafe,
+			       orb_advert_t *mavlink_log_pub,
+			       status_flags_s *status_flags,
+			       const bool use_rc, // true if a mode using RC control can be used as a fallback
+			       const bool using_global_pos); // true when the current mode requires a global position estimate
 
 void set_data_link_loss_nav_state(struct vehicle_status_s *status,
 				  struct actuator_armed_s *armed,

--- a/src/modules/systemlib/circuit_breaker.h
+++ b/src/modules/systemlib/circuit_breaker.h
@@ -57,6 +57,7 @@
 #define CBRK_ENGINEFAIL_KEY	284953
 #define CBRK_GPSFAIL_KEY	240024
 #define CBRK_USB_CHK_KEY	197848
+#define CBRK_POS_CHK_KEY	201607
 
 #include <stdbool.h>
 

--- a/src/modules/systemlib/circuit_breaker_params.c
+++ b/src/modules/systemlib/circuit_breaker_params.c
@@ -169,3 +169,18 @@ PARAM_DEFINE_INT32(CBRK_BUZZER, 0);
  * @group Circuit Breaker
  */
 PARAM_DEFINE_INT32(CBRK_USB_CHK, 0);
+
+/**
+ * Circuit breaker for position quality checks
+ *
+ * Setting this parameter to 201607 will disable the local and global
+ * position quality checks in the commander that use accuracy and
+ * innovation data from the EKF.
+ * WARNING: ENABLING THIS CIRCUIT BREAKER IS AT OWN RISK
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 201607
+ * @group Circuit Breaker
+ */
+PARAM_DEFINE_INT32(CBRK_POS_CHK, 0);


### PR DESCRIPTION
This PR consolidates the exisiting checking of valid global and local position in the commander that checks for the following:

1) EKF reported position validity
2) EKF reported position accuracy
3) Stale data

It also adds checking of EKF position and velocity innovation levels and declares position invalid if both position and velocity have been rejected for more than 1 second and there is no optical flow data available to constrain drift. The position is declared valid if both position and velocity have been accepted for more than 5 seconds.

The invalid position failsafe logic in state_machine_helper.cpp has been consolidated to provide consistency in response and reporting. The MAIN_STATE_OFFBOARD failsafe logic is more complex and has not been updated in this PR.

**TODO**

This has had only limited bench and flight testing. Problems with running SITL on OSX Sierra are holding up further testing. This PR will be updated when this issue is resolved and correct position invalid failsafe response all affected nav states has been checked.