### PR TITLE
Legacy vision interface timestamp hotfix

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1164,6 +1164,8 @@ MavlinkReceiver::handle_message_vision_position_estimate(mavlink_message_t *msg)
 
 	struct vehicle_attitude_s vision_attitude = {};
 
+	vision_attitude.timestamp = sync_stamp(pos.usec);
+
 	math::Quaternion q;
 	q.from_euler(pos.roll, pos.pitch, pos.yaw);
 


### PR DESCRIPTION
The timestamp wasn't being filled for the legacy vision interface attitude messages. 

This fixes it. Please merge @LorenzMeier