### PR TITLE
Added a parameter for the manual land detection stick throshold

### DIFF
--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -78,6 +78,7 @@ MulticopterLandDetector::MulticopterLandDetector() : LandDetector(),
 	_paramHandle.minManThrottle = param_find("MPC_MANTHR_MIN");
 	_paramHandle.freefall_acc_threshold = param_find("LNDMC_FFALL_THR");
 	_paramHandle.freefall_trigger_time = param_find("LNDMC_FFALL_TTRI");
+	_paramHandle.manual_stick_down_threshold = param_find("LNDMC_MAN_DWNTHR");
 }
 
 void MulticopterLandDetector::_initialize_topics()
@@ -117,6 +118,7 @@ void MulticopterLandDetector::_update_params()
 	param_get(_paramHandle.freefall_acc_threshold, &_params.freefall_acc_threshold);
 	param_get(_paramHandle.freefall_trigger_time, &_params.freefall_trigger_time);
 	_freefall_hysteresis.set_hysteresis_time_from(false, (hrt_abstime)(1e6f * _params.freefall_trigger_time));
+	param_get(_paramHandle.manual_stick_down_threshold, &_params.manual_stick_down_threshold);
 }
 
 
@@ -158,7 +160,7 @@ bool MulticopterLandDetector::_get_ground_contact_state()
 	// Check if user commands throttle and if so, report no ground contact based on
 	// the user intent to take off (even if the system might physically still have
 	// ground contact at this point).
-	const bool manual_control_idle = (_has_manual_control_present() && _manual.z < 0.15f);
+	const bool manual_control_idle = (_has_manual_control_present() && _manual.z < _params.manual_stick_down_threshold);
 	const bool manual_control_idle_or_auto = manual_control_idle || !_control_mode.flag_control_manual_enabled;
 
 	// Widen acceptance thresholds for landed state right after arming

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -89,6 +89,7 @@ private:
 		param_t minManThrottle;
 		param_t freefall_acc_threshold;
 		param_t freefall_trigger_time;
+		param_t manual_stick_down_threshold;
 	} _paramHandle;
 
 	struct {
@@ -101,6 +102,7 @@ private:
 		float minManThrottle;
 		float freefall_acc_threshold;
 		float freefall_trigger_time;
+		float manual_stick_down_threshold;
 	} _params;
 
 	int _vehicleLocalPositionSub;

--- a/src/modules/land_detector/land_detector_params.c
+++ b/src/modules/land_detector/land_detector_params.c
@@ -120,6 +120,21 @@ PARAM_DEFINE_FLOAT(LNDMC_THR_RANGE, 0.1f);
 PARAM_DEFINE_FLOAT(LNDMC_FFALL_TTRI, 0.3);
 
 /**
+ * Manual flight stick down threshold for landing
+ *
+ * When controlling manually the throttle stick value (0 to 1)
+ * has to be bellow this threshold in order to pass the check for landing.
+ * So if set to 1 it's allowed to land with any stick position.
+ *
+ * @min 0
+ * @max 1
+ * @decimal 2
+ *
+ * @group Land Detector
+ */
+PARAM_DEFINE_FLOAT(LNDMC_MAN_DWNTHR, 0.15f);
+
+/**
  * Fixedwing max horizontal velocity
  *
  * Maximum horizontal velocity allowed in the landed state (m/s)


### PR DESCRIPTION
I changed this value multiple times now. It should have been a parameter from the beginning.
The default is now what it was before all the changes.


land_detector: added a parameter for the manual land detection stick throshold

because it is definitely something that needs to be allowed to tune or disable for different application scenarios