### PR TITLE
Improve fallback behaviour when navigation accuracy is lost

### DIFF
--- a/msg/vehicle_global_position.msg
+++ b/msg/vehicle_global_position.msg
@@ -18,6 +18,8 @@ float32 vel_d			# Down velocity in NED earth-fixed frame, (metres/sec)
 float32 yaw 			# Euler yaw angle relative to NED earth-fixed frame, -PI..+PI, (radians)
 float32 eph			# Standard deviation of horizontal position error, (metres)
 float32 epv			# Standard deviation of vertical position error, (metres)
+float32 evh			# Standard deviation of horizontal velocity error, (metres/sec)
+float32 evv			# Standard deviation of horizontal velocity error, (metres/sec)
 float32 terrain_alt		# Terrain altitude WGS84, (metres)
 bool terrain_alt_valid		# Terrain altitude estimate is valid
 bool dead_reckoning		# True if this position is estimated through dead-reckoning

--- a/msg/vehicle_local_position.msg
+++ b/msg/vehicle_local_position.msg
@@ -59,5 +59,7 @@ uint64 surface_bottom_timestamp		# Time when new bottom surface found since syst
 bool dist_bottom_valid			# true if distance to bottom surface is valid
 float32 eph				# Standard deviation of horizontal position error, (metres)
 float32 epv				# Standard deviation of vertical position error, (metres)
+float32 evh				# Standard deviation of horizontal velocity error, (metres/sec)
+float32 evv				# Standard deviation of horizontal velocity error, (metres/sec)
 
 # TOPICS vehicle_local_position vehicle_local_position_groundtruth vehicle_vision_position

--- a/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
+++ b/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
@@ -955,6 +955,12 @@ void AttitudePositionEstimatorEKF::publishLocalPosition()
 	_local_pos.v_z_valid = true;
 	_local_pos.xy_global = _gps_initialized; //TODO: Handle optical flow mode here
 
+	// TODO provide calculated values for these
+	_local_pos.eph = 0.0f;
+	_local_pos.epv = 0.0f;
+	_local_pos.evh = 0.0f;
+	_local_pos.evv = 0.0f;
+
 	_local_pos.z_global = false;
 	matrix::Eulerf euler = matrix::Quatf(_ekf->states[0], _ekf->states[1], _ekf->states[2], _ekf->states[3]);
 	_local_pos.yaw = euler.psi();
@@ -1054,6 +1060,10 @@ void AttitudePositionEstimatorEKF::publishGlobalPosition()
 		// bad data, abort publication
 		return;
 	}
+
+	// TODO provide calculated values for these
+	_global_pos.evh = 0.0f;
+	_global_pos.evv = 0.0f;
 
 	/* lazily publish the global position only once available */
 	if (_global_pos_pub != nullptr) {

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -331,7 +331,7 @@ int commander_main(int argc, char *argv[])
 		daemon_task = px4_task_spawn_cmd("commander",
 					     SCHED_DEFAULT,
 					     SCHED_PRIORITY_DEFAULT + 40,
-					     3600,
+					     3700,
 					     commander_thread_main,
 					     (char * const *)&argv[0]);
 

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -78,6 +78,7 @@ static const char reason_no_gps[] = "no gps";
 static const char reason_no_gps_cmd[] = "no gps cmd";
 static const char reason_no_home[] = "no home";
 static const char reason_no_local_position[] = "no local position";
+static const char reason_no_global_position[] = "no global position";
 static const char reason_no_datalink[] = "no datalink";
 
 // This array defines the arming state transitions. The rows are the new state, and the columns
@@ -749,18 +750,10 @@ bool set_nav_state(struct vehicle_status_s *status,
 				 * this enables POSCTL using e.g. flow.
 				 * For fixedwing, a global position is needed. */
 
-			} else if (((status->is_rotary_wing && !status_flags->condition_local_position_valid) ||
-				    (!status->is_rotary_wing && !status_flags->condition_global_position_valid))
-				   && is_armed) {
-				enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_rc);
-
-				if (status_flags->condition_local_altitude_valid) {
-					status->nav_state = vehicle_status_s::NAVIGATION_STATE_ALTCTL;
-
-				} else {
-					status->nav_state = vehicle_status_s::NAVIGATION_STATE_STAB;
-				}
-
+			} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, true, !status->is_rotary_wing)) {
+				// nothing to do - everything done in check_invalid_pos_nav_state
+			} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, true, status->is_rotary_wing)) {
+				// nothing to do - everything done in check_invalid_pos_nav_state
 			} else {
 				status->nav_state = vehicle_status_s::NAVIGATION_STATE_POSCTL;
 			}
@@ -798,6 +791,8 @@ bool set_nav_state(struct vehicle_status_s *status,
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_gps);
 
+		} else if (check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true)) {
+			// nothing to do - everything done in check_invalid_pos_nav_state
 		} else if (status->engine_failure) {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
@@ -846,6 +841,8 @@ bool set_nav_state(struct vehicle_status_s *status,
 
 			/* also go into failsafe if just datalink is lost */
 
+		} else if (check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true)) {
+			// nothing to do - everything done in check_invalid_pos_nav_state
 		} else if (status->data_link_lost && data_link_loss_act_configured) {
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_datalink);
 
@@ -883,20 +880,8 @@ bool set_nav_state(struct vehicle_status_s *status,
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_gps);
 
-		} else if ((!status_flags->condition_global_position_valid ||
-			    !status_flags->condition_home_position_valid)) {
-			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_home);
-
-			if (status_flags->condition_local_position_valid) {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;
-
-			} else if (status_flags->condition_local_altitude_valid) {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
-
-			} else {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_TERMINATION;
-			}
-
+		} else if (check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true)) {
+			// nothing to do - everything done in check_invalid_pos_nav_state
 		} else {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_RTL;
 		}
@@ -910,18 +895,8 @@ bool set_nav_state(struct vehicle_status_s *status,
 		if (status->engine_failure) {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
-		} else if (!status_flags->condition_global_position_valid) {
-			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_gps);
-
-			if (status_flags->condition_local_position_valid) {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;
-
-			} else if (status_flags->condition_local_altitude_valid) {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
-
-			} else {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_TERMINATION;
-			}
+		} else if (check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true)) {
+			// nothing to do - everything done in check_invalid_pos_nav_state
 
 		} else {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_FOLLOW_TARGET;
@@ -936,18 +911,8 @@ bool set_nav_state(struct vehicle_status_s *status,
 		if (status->engine_failure) {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
-		} else if (!status_flags->condition_local_position_valid) {
-			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_local_position);
-
-			if (status_flags->condition_local_position_valid) {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;
-
-			} else if (status_flags->condition_local_altitude_valid) {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
-
-			} else {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_TERMINATION;
-			}
+		} else if (check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, false)) {
+			// nothing to do - everything done in check_invalid_pos_nav_state
 
 		} else {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF;
@@ -962,15 +927,8 @@ bool set_nav_state(struct vehicle_status_s *status,
 		if (status->engine_failure) {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
 
-		} else if (!status_flags->condition_local_position_valid) {
-			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_local_position);
-
-			if (status_flags->condition_local_altitude_valid) {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
-
-			} else {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_TERMINATION;
-			}
+		} else if (check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, false)) {
+			// nothing to do - everything done in check_invalid_pos_nav_state
 
 		} else {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;
@@ -1070,6 +1028,49 @@ void set_rc_loss_nav_state(struct vehicle_status_s *status,
 			   const link_loss_actions_t link_loss_act)
 {
 	set_link_loss_nav_state(status, armed, status_flags, link_loss_act, vehicle_status_s::NAVIGATION_STATE_AUTO_RCRECOVER);
+}
+
+bool check_invalid_pos_nav_state(struct vehicle_status_s *status,
+			       bool old_failsafe,
+			       orb_advert_t *mavlink_log_pub,
+			       status_flags_s *status_flags,
+			       const bool use_rc, // true if we can fallback to a mode that uses RC inputs
+			       const bool using_global_pos) // true if the current flight mode requires a global position
+{
+	bool fallback_required = false;
+
+	if (using_global_pos && !status_flags->condition_global_position_valid) {
+		enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_global_position);
+		fallback_required = true;
+	} else if (!using_global_pos && !status_flags->condition_local_position_valid) {
+		enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_local_position);
+		fallback_required = true;
+	}
+
+	if (fallback_required) {
+		if (use_rc) {
+			// fallback to a mode that gives the operator stick control
+			if (status->is_rotary_wing && status_flags->condition_local_position_valid) {
+				status->nav_state = vehicle_status_s::NAVIGATION_STATE_POSCTL;
+			} else if (status_flags->condition_local_altitude_valid) {
+				status->nav_state = vehicle_status_s::NAVIGATION_STATE_ALTCTL;
+			} else {
+				status->nav_state = vehicle_status_s::NAVIGATION_STATE_STAB;
+			}
+		} else {
+			// go into a descent that does not require stick control
+			if (status_flags->condition_local_position_valid) {
+				status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;
+			} else  if (status_flags->condition_local_altitude_valid) {
+				status->nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
+			} else {
+				status->nav_state = vehicle_status_s::NAVIGATION_STATE_TERMINATION;
+			}
+		}
+	}
+
+	return fallback_required;
+
 }
 
 void set_data_link_loss_nav_state(struct vehicle_status_s *status,

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -1039,10 +1039,10 @@ bool check_invalid_pos_nav_state(struct vehicle_status_s *status,
 {
 	bool fallback_required = false;
 
-	if (using_global_pos && !status_flags->condition_global_position_valid) {
+	if (using_global_pos && (!status_flags->condition_global_position_valid || !status_flags->condition_global_velocity_valid)) {
 		enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_global_position);
 		fallback_required = true;
-	} else if (!using_global_pos && !status_flags->condition_local_position_valid) {
+	} else if (!using_global_pos && (!status_flags->condition_local_position_valid || !status_flags->condition_local_velocity_valid)) {
 		enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_local_position);
 		fallback_required = true;
 	}

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -71,13 +71,13 @@ enum class link_loss_actions_t {
 struct status_flags_s {
     bool condition_calibration_enabled;
     bool condition_system_sensors_initialized;
-    bool condition_system_prearm_error_reported;        // true if errors have already been reported
-    bool condition_system_hotplug_timeout;                // true if the hotplug sensor search is over
+    bool condition_system_prearm_error_reported;	// true if errors have already been reported
+    bool condition_system_hotplug_timeout;		// true if the hotplug sensor search is over
     bool condition_system_returned_to_home;
     bool condition_auto_mission_available;
-    bool condition_global_position_valid;                // set to true by the commander app if the quality of the position estimate is good enough to use it for navigation
-    bool condition_home_position_valid;                // indicates a valid home position (a valid home position is not always a valid launch)
-    bool condition_local_position_valid;
+    bool condition_global_position_valid;		// set to true by the commander app if the quality of the global position estimate is good enough to use for navigation
+    bool condition_home_position_valid;			// indicates a valid home position (a valid home position is not always a valid launch)
+    bool condition_local_position_valid;		// set to true by the commander app if the quality of the local position estimate is good enough to use for navigation
     bool condition_local_altitude_valid;
     bool condition_airspeed_valid;                        // set to true by the commander app if there is a valid airspeed measurement available
     bool condition_power_input_valid;                // set if input power is valid
@@ -88,6 +88,7 @@ struct status_flags_s {
     bool circuit_breaker_engaged_gpsfailure_check;
     bool circuit_breaker_flight_termination_disabled;
     bool circuit_breaker_engaged_usb_check;
+    bool circuit_breaker_engaged_posfailure_check;	// set to true when the position valid checks have been disabled
     bool offboard_control_signal_found_once;
     bool offboard_control_signal_lost;
     bool offboard_control_signal_weak;
@@ -145,6 +146,16 @@ void set_rc_loss_nav_state(struct vehicle_status_s *status,
 			   struct actuator_armed_s *armed,
 			   status_flags_s *status_flags,
 			   const link_loss_actions_t link_loss_act);
+/*
+ * Checks the validty of position data aaainst the requirements of the current navigation
+ * mode and switches mode if position data required is not available.
+ */
+bool check_invalid_pos_nav_state(struct vehicle_status_s *status,
+			       bool old_failsafe,
+			       orb_advert_t *mavlink_log_pub,
+			       status_flags_s *status_flags,
+			       const bool use_rc, // true if a mode using RC control can be used as a fallback
+			       const bool using_global_pos); // true when the current mode requires a global position estimate
 
 void set_data_link_loss_nav_state(struct vehicle_status_s *status,
 				  struct actuator_armed_s *armed,

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -76,8 +76,10 @@ struct status_flags_s {
     bool condition_system_returned_to_home;
     bool condition_auto_mission_available;
     bool condition_global_position_valid;		// set to true by the commander app if the quality of the global position estimate is good enough to use for navigation
+    bool condition_global_velocity_valid;		// set to true by the commander app if the quality of the global horizontal velocity data is good enough to use for navigation
     bool condition_home_position_valid;			// indicates a valid home position (a valid home position is not always a valid launch)
     bool condition_local_position_valid;		// set to true by the commander app if the quality of the local position estimate is good enough to use for navigation
+    bool condition_local_velocity_valid;		// set to true by the commander app if the quality of the local horizontal velocity data is good enough to use for navigation
     bool condition_local_altitude_valid;
     bool condition_airspeed_valid;                        // set to true by the commander app if there is a valid airspeed measurement available
     bool condition_power_input_valid;                // set if input power is valid

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -851,6 +851,7 @@ void Ekf2::task_main()
 
 			bool dead_reckoning;
 			_ekf.get_ekf_lpos_accuracy(&lpos.eph, &lpos.epv, &dead_reckoning);
+			_ekf.get_ekf_vel_accuracy(&lpos.evh, &lpos.evv, &dead_reckoning);
 
 			// get state reset information of position and velocity
 			_ekf.get_posD_reset(&lpos.delta_z, &lpos.z_reset_counter);
@@ -895,6 +896,8 @@ void Ekf2::task_main()
 				global_pos.yaw = euler.psi(); // Yaw in radians -PI..+PI.
 
 				_ekf.get_ekf_gpos_accuracy(&global_pos.eph, &global_pos.epv, &global_pos.dead_reckoning);
+				global_pos.evh = lpos.evh;
+				global_pos.evv = lpos.evv;
 
 				if (lpos.dist_bottom_valid) {
 					global_pos.terrain_alt = lpos.ref_alt - terrain_vpos; // Terrain altitude in m, WGS84

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -910,8 +910,7 @@ void Ekf2::task_main()
 					global_pos.terrain_alt_valid = false; // Terrain altitude estimate is valid
 				}
 
-				// TODO use innovatun consistency check timouts to set this
-				global_pos.dead_reckoning = false; // True if this position is estimated through dead-reckoning
+				global_pos.dead_reckoning = _ekf.inertial_dead_reckoning(); // True if this position is estimated through dead-reckoning
 
 				global_pos.pressure_alt = sensors.baro_alt_meter; // Pressure altitude AMSL (m)
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -849,12 +849,8 @@ void Ekf2::task_main()
 			lpos.dist_bottom_rate = -velocity[2]; // Distance to bottom surface (ground) change rate
 			lpos.surface_bottom_timestamp	= hrt_absolute_time(); // Time when new bottom surface found
 
-			// TODO: uORB definition does not define what these variables are. We have assumed them to be horizontal and vertical 1-std dev accuracy in metres
-			Vector3f pos_var, vel_var;
-			_ekf.get_pos_var(pos_var);
-			_ekf.get_vel_var(vel_var);
-			lpos.eph = sqrtf(pos_var(0) + pos_var(1));
-			lpos.epv = sqrtf(pos_var(2));
+			bool dead_reckoning;
+			_ekf.get_ekf_lpos_accuracy(&lpos.eph, &lpos.epv, &dead_reckoning);
 
 			// get state reset information of position and velocity
 			_ekf.get_posD_reset(&lpos.delta_z, &lpos.z_reset_counter);
@@ -898,8 +894,7 @@ void Ekf2::task_main()
 
 				global_pos.yaw = euler.psi(); // Yaw in radians -PI..+PI.
 
-				global_pos.eph = sqrtf(pos_var(0) + pos_var(1));; // Standard deviation of position estimate horizontally
-				global_pos.epv = sqrtf(pos_var(2)); // Standard deviation of position vertically
+				_ekf.get_ekf_gpos_accuracy(&global_pos.eph, &global_pos.epv, &global_pos.dead_reckoning);
 
 				if (lpos.dist_bottom_valid) {
 					global_pos.terrain_alt = lpos.ref_alt - terrain_vpos; // Terrain altitude in m, WGS84
@@ -922,6 +917,78 @@ void Ekf2::task_main()
 				}
 			}
 
+			// publish estimator status
+			{
+				struct estimator_status_s status = {};
+				status.timestamp = hrt_absolute_time();
+				_ekf.get_state_delayed(status.states);
+				_ekf.get_covariances(status.covariances);
+				_ekf.get_gps_check_status(&status.gps_check_fail_flags);
+				_ekf.get_control_mode(&status.control_mode_flags);
+				_ekf.get_filter_fault_status(&status.filter_fault_flags);
+				_ekf.get_innovation_test_status(&status.innovation_check_flags, &status.mag_test_ratio,
+								&status.vel_test_ratio, &status.pos_test_ratio,
+								&status.hgt_test_ratio, &status.tas_test_ratio,
+								&status.hagl_test_ratio);
+				status.pos_horiz_accuracy = lpos.eph;
+				status.pos_vert_accuracy = lpos.epv;
+				_ekf.get_ekf_soln_status(&status.solution_status_flags);
+				_ekf.get_imu_vibe_metrics(status.vibe);
+
+				if (_estimator_status_pub == nullptr) {
+					_estimator_status_pub = orb_advertise(ORB_ID(estimator_status), &status);
+
+				} else {
+					orb_publish(ORB_ID(estimator_status), _estimator_status_pub, &status);
+				}
+
+				// Publish wind estimate
+				struct wind_estimate_s wind_estimate = {};
+				wind_estimate.timestamp = hrt_absolute_time();
+				wind_estimate.windspeed_north = status.states[22];
+				wind_estimate.windspeed_east = status.states[23];
+				wind_estimate.covariance_north = status.covariances[22];
+				wind_estimate.covariance_east = status.covariances[23];
+
+				if (_wind_pub == nullptr) {
+					_wind_pub = orb_advertise(ORB_ID(wind_estimate), &wind_estimate);
+
+				} else {
+					orb_publish(ORB_ID(wind_estimate), _wind_pub, &wind_estimate);
+				}
+			}
+
+			// publish estimator innovation data
+			{
+				struct ekf2_innovations_s innovations = {};
+				innovations.timestamp = hrt_absolute_time();
+				_ekf.get_vel_pos_innov(&innovations.vel_pos_innov[0]);
+				_ekf.get_mag_innov(&innovations.mag_innov[0]);
+				_ekf.get_heading_innov(&innovations.heading_innov);
+				_ekf.get_airspeed_innov(&innovations.airspeed_innov);
+				_ekf.get_beta_innov(&innovations.beta_innov);
+				_ekf.get_flow_innov(&innovations.flow_innov[0]);
+				_ekf.get_hagl_innov(&innovations.hagl_innov);
+
+				_ekf.get_vel_pos_innov_var(&innovations.vel_pos_innov_var[0]);
+				_ekf.get_mag_innov_var(&innovations.mag_innov_var[0]);
+				_ekf.get_heading_innov_var(&innovations.heading_innov_var);
+				_ekf.get_airspeed_innov_var(&innovations.airspeed_innov_var);
+				_ekf.get_beta_innov_var(&innovations.beta_innov_var);
+				_ekf.get_flow_innov_var(&innovations.flow_innov_var[0]);
+				_ekf.get_hagl_innov_var(&innovations.hagl_innov_var);
+
+				_ekf.get_output_tracking_error(&innovations.output_tracking_error[0]);
+
+				if (_estimator_innovations_pub == nullptr) {
+					_estimator_innovations_pub = orb_advertise(ORB_ID(ekf2_innovations), &innovations);
+
+				} else {
+					orb_publish(ORB_ID(ekf2_innovations), _estimator_innovations_pub, &innovations);
+				}
+
+			}
+
 		} else if (_replay_mode) {
 			// in replay mode we have to tell the replay module not to wait for an update
 			// we do this by publishing an attitude with zero timestamp
@@ -934,76 +1001,6 @@ void Ekf2::task_main()
 			} else {
 				orb_publish(ORB_ID(vehicle_attitude), _att_pub, &att);
 			}
-		}
-
-		// publish estimator status
-		struct estimator_status_s status = {};
-		status.timestamp = hrt_absolute_time();
-		_ekf.get_state_delayed(status.states);
-		_ekf.get_covariances(status.covariances);
-		_ekf.get_gps_check_status(&status.gps_check_fail_flags);
-		_ekf.get_control_mode(&status.control_mode_flags);
-		_ekf.get_filter_fault_status(&status.filter_fault_flags);
-		_ekf.get_innovation_test_status(&status.innovation_check_flags, &status.mag_test_ratio,
-						&status.vel_test_ratio, &status.pos_test_ratio,
-						&status.hgt_test_ratio, &status.tas_test_ratio,
-						&status.hagl_test_ratio);
-		bool dead_reckoning;
-		_ekf.get_ekf_accuracy(&status.pos_horiz_accuracy, &status.pos_vert_accuracy, &dead_reckoning);
-		_ekf.get_ekf_soln_status(&status.solution_status_flags);
-		_ekf.get_imu_vibe_metrics(status.vibe);
-
-		if (_estimator_status_pub == nullptr) {
-			_estimator_status_pub = orb_advertise(ORB_ID(estimator_status), &status);
-
-		} else {
-			orb_publish(ORB_ID(estimator_status), _estimator_status_pub, &status);
-		}
-
-		// Publish wind estimate
-		struct wind_estimate_s wind_estimate = {};
-		wind_estimate.timestamp = hrt_absolute_time();
-		wind_estimate.windspeed_north = status.states[22];
-		wind_estimate.windspeed_east = status.states[23];
-		wind_estimate.covariance_north = status.covariances[22];
-		wind_estimate.covariance_east = status.covariances[23];
-
-		if (_wind_pub == nullptr) {
-			_wind_pub = orb_advertise(ORB_ID(wind_estimate), &wind_estimate);
-
-		} else {
-			orb_publish(ORB_ID(wind_estimate), _wind_pub, &wind_estimate);
-		}
-
-		// publish estimator innovation data
-		{
-			struct ekf2_innovations_s innovations = {};
-			innovations.timestamp = hrt_absolute_time();
-			_ekf.get_vel_pos_innov(&innovations.vel_pos_innov[0]);
-			_ekf.get_mag_innov(&innovations.mag_innov[0]);
-			_ekf.get_heading_innov(&innovations.heading_innov);
-			_ekf.get_airspeed_innov(&innovations.airspeed_innov);
-			_ekf.get_beta_innov(&innovations.beta_innov);
-			_ekf.get_flow_innov(&innovations.flow_innov[0]);
-			_ekf.get_hagl_innov(&innovations.hagl_innov);
-
-			_ekf.get_vel_pos_innov_var(&innovations.vel_pos_innov_var[0]);
-			_ekf.get_mag_innov_var(&innovations.mag_innov_var[0]);
-			_ekf.get_heading_innov_var(&innovations.heading_innov_var);
-			_ekf.get_airspeed_innov_var(&innovations.airspeed_innov_var);
-			_ekf.get_beta_innov_var(&innovations.beta_innov_var);
-			_ekf.get_flow_innov_var(&innovations.flow_innov_var[0]);
-			_ekf.get_hagl_innov_var(&innovations.hagl_innov_var);
-
-			_ekf.get_output_tracking_error(&innovations.output_tracking_error[0]);
-
-			if (_estimator_innovations_pub == nullptr) {
-				_estimator_innovations_pub = orb_advertise(ORB_ID(ekf2_innovations), &innovations);
-
-			} else {
-				orb_publish(ORB_ID(ekf2_innovations), _estimator_innovations_pub, &innovations);
-			}
-
 		}
 
 		// save the declination to the EKF2_MAG_DECL parameter when a land event is detected

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -632,6 +632,9 @@ void BlockLocalPositionEstimator::publishLocalPos()
 		_pub_lpos.get().eph = eph;
 		_pub_lpos.get().epv = epv;
 		_pub_lpos.update();
+		//TODO provide calculated values for these
+		_pub_lpos.get().evh = 0.0f;
+		_pub_lpos.get().evv = 0.0f;
 	}
 }
 
@@ -699,6 +702,9 @@ void BlockLocalPositionEstimator::publishGlobalPos()
 		_pub_gpos.get().dead_reckoning = !(_estimatorInitialized & EST_XY);
 		_pub_gpos.get().pressure_alt = _sub_sensor.get().baro_alt_meter;
 		_pub_gpos.update();
+		// TODO provide calculated values for these
+		_pub_gpos.get().evh = 0.0f;
+		_pub_gpos.get().evv = 0.0f;
 	}
 }
 

--- a/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
@@ -1340,6 +1340,9 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 			local_pos.dist_bottom_valid = dist_bottom_valid;
 			local_pos.eph = eph;
 			local_pos.epv = epv;
+			// TODO provide calculated values for these
+			local_pos.evh = 0.0f;
+			local_pos.evv = 0.0f;
 
 			if (local_pos.dist_bottom_valid) {
 				local_pos.dist_bottom = dist_ground;
@@ -1370,6 +1373,10 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 
 				global_pos.eph = eph;
 				global_pos.epv = epv;
+
+				// TODO provide calculated values for these
+				global_pos.evh = 0.0f;
+				global_pos.evv = 0.0f;
 
 				if (terrain_estimator.is_valid()) {
 					global_pos.terrain_alt = global_pos.alt - terrain_estimator.get_distance_to_ground();

--- a/src/modules/systemlib/circuit_breaker.h
+++ b/src/modules/systemlib/circuit_breaker.h
@@ -57,6 +57,7 @@
 #define CBRK_ENGINEFAIL_KEY	284953
 #define CBRK_GPSFAIL_KEY	240024
 #define CBRK_USB_CHK_KEY	197848
+#define CBRK_VELPOSERR_KEY	201607
 
 #include <stdbool.h>
 

--- a/src/modules/systemlib/circuit_breaker_params.c
+++ b/src/modules/systemlib/circuit_breaker_params.c
@@ -169,3 +169,17 @@ PARAM_DEFINE_INT32(CBRK_BUZZER, 0);
  * @group Circuit Breaker
  */
 PARAM_DEFINE_INT32(CBRK_USB_CHK, 0);
+
+/**
+ * Circuit breaker for position error check
+ *
+ * Setting this parameter to 201607 will disable the position and velocity
+ * accuracy checks in the commander.
+ * WARNING: ENABLING THIS CIRCUIT BREAKER IS AT OWN RISK
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 201607
+ * @group Circuit Breaker
+ */
+PARAM_DEFINE_INT32(CBRK_VELPOSERR, 0);


### PR DESCRIPTION
Requires https://github.com/PX4/ecl/pull/241

Consolidates the exisiting commander position validity checks.
Adds checking of velocity validity.
Adds a circuit breaker parameter enabling accuracy checks to be bypassed.
Has had basic bench and flight testing in pos control mode with uncalibrated magnetometer to induce large position and velocity variances.

**TODO**

SITL testing (currently unable to run SITL in OSX Sierra)
Determine reason for rapid toggling in logged nav_state when failsafe activates in POSCTL mode - see below.
![posctl_failsafe_test](https://cloud.githubusercontent.com/assets/3596952/23288915/6eb526ba-fa9a-11e6-9ed7-6f87eeb58b4b.png)
