### PR TITLE
add null check for param_get

### DIFF
--- a/src/modules/attitude_estimator_q/attitude_estimator_q_params.c
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_params.c
@@ -134,13 +134,3 @@ PARAM_DEFINE_INT32(ATT_ACC_COMP, 1);
  * @decimal 3
  */
 PARAM_DEFINE_FLOAT(ATT_BIAS_MAX, 0.05f);
-
-/**
- * Threshold (of RMS) to warn about high vibration levels
- *
- * @group Attitude Q estimator
- * @min 0.01
- * @max 10
- * @decimal 2
- */
-PARAM_DEFINE_FLOAT(ATT_VIBE_THRESH, 0.2f);

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -884,6 +884,16 @@ PARAM_DEFINE_INT32(SENS_EXT_MAG_ROT, 0);
  */
 PARAM_DEFINE_INT32(SENS_EXT_MAG, 0);
 
+/**
+ * Threshold (of RMS) to warn about high vibration levels
+ *
+ * @group Sensor Calibration
+ * @min 0.01
+ * @max 10
+ * @decimal 2
+ */
+PARAM_DEFINE_FLOAT(ATT_VIBE_THRESH, 0.2f);
+
 
 /**
  * RC Channel 1 Minimum

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -531,7 +531,7 @@ param_get(param_t param, void *val)
 
 	const void *v = param_get_value_ptr(param);
 
-	if (val != NULL) {
+	if (val && v) {
 		memcpy(val, v, param_size(param));
 		result = 0;
 	}

--- a/src/modules/systemlib/param/param_shmem.c
+++ b/src/modules/systemlib/param/param_shmem.c
@@ -548,7 +548,7 @@ param_get(param_t param, void *val)
 
 	const void *v = param_get_value_ptr(param);
 
-	if (val != NULL) {
+	if (val && v) {
 		memcpy(val, v, param_size(param));
 		result = 0;
 	}

--- a/src/systemcmds/param/param.c
+++ b/src/systemcmds/param/param.c
@@ -42,6 +42,7 @@
 #include <px4_config.h>
 #include <px4_posix.h>
 
+#include <errno.h>
 #include <stdio.h>
 #include <ctype.h>
 #include <stdlib.h>
@@ -97,8 +98,10 @@ param_main(int argc, char *argv[])
 				return do_save(argv[2]);
 
 			} else {
-				if (do_save_default()) {
-					warnx("Param export failed.");
+				int ret = do_save_default();
+
+				if (ret) {
+					PX4_ERR("Param save failed (%i)", ret);
 					return 1;
 
 				} else {
@@ -133,7 +136,7 @@ param_main(int argc, char *argv[])
 				param_set_default_file(NULL);
 			}
 
-			warnx("selected parameter default file %s", param_get_default_file());
+			PX4_INFO("selected parameter default file %s", param_get_default_file());
 			return 0;
 		}
 
@@ -169,7 +172,7 @@ param_main(int argc, char *argv[])
 				return do_set(argv[2], argv[3], false);
 
 			} else {
-				warnx("not enough arguments.\nTry 'param set PARAM_NAME 3 [fail]'");
+				PX4_ERR("not enough arguments.\nTry 'param set PARAM_NAME 3 [fail]'");
 				return 1;
 			}
 		}
@@ -179,7 +182,7 @@ param_main(int argc, char *argv[])
 				return do_compare(argv[2], &argv[3], argc - 3, COMPARE_OPERATOR_EQUAL);
 
 			} else {
-				warnx("not enough arguments.\nTry 'param compare PARAM_NAME 3'");
+				PX4_ERR("not enough arguments.\nTry 'param compare PARAM_NAME 3'");
 				return 1;
 			}
 		}
@@ -189,7 +192,7 @@ param_main(int argc, char *argv[])
 				return do_compare(argv[2], &argv[3], argc - 3, COMPARE_OPERATOR_GREATER);
 
 			} else {
-				warnx("not enough arguments.\nTry 'param greater PARAM_NAME 3'");
+				PX4_ERR("not enough arguments.\nTry 'param greater PARAM_NAME 3'");
 				return 1;
 			}
 		}
@@ -217,7 +220,7 @@ param_main(int argc, char *argv[])
 				return do_show_index(argv[2], true);
 
 			} else {
-				warnx("no index provided");
+				PX4_ERR("no index provided");
 				return 1;
 			}
 		}
@@ -227,7 +230,7 @@ param_main(int argc, char *argv[])
 				return do_show_index(argv[2], false);
 
 			} else {
-				warnx("no index provided");
+				PX4_ERR("no index provided");
 				return 1;
 			}
 		}
@@ -237,7 +240,7 @@ param_main(int argc, char *argv[])
 				return do_find(argv[2]);
 
 			} else {
-				warnx("not enough arguments.\nTry 'param find PARAM_NAME'");
+				PX4_ERR("not enough arguments.\nTry 'param find PARAM_NAME'");
 				return 1;
 			}
 		}
@@ -278,7 +281,7 @@ do_save(const char *param_file_name)
 	int fd = open(param_file_name, O_WRONLY | O_CREAT, PX4_O_MODE_666);
 
 	if (fd < 0) {
-		warn("opening '%s' failed", param_file_name);
+		PX4_ERR("open '%s' failed (%i)", param_file_name, errno);
 		return 1;
 	}
 
@@ -289,7 +292,7 @@ do_save(const char *param_file_name)
 #ifndef __PX4_QURT
 		(void)unlink(param_file_name);
 #endif
-		warnx("error exporting to '%s'", param_file_name);
+		PX4_ERR("exporting to '%s' failed (%i)", param_file_name, result);
 		return 1;
 	}
 
@@ -302,7 +305,7 @@ do_load(const char *param_file_name)
 	int fd = open(param_file_name, O_RDONLY);
 
 	if (fd < 0) {
-		warn("open failed '%s'", param_file_name);
+		PX4_ERR("open '%s' failed (%i)", param_file_name, errno);
 		return 1;
 	}
 
@@ -310,7 +313,7 @@ do_load(const char *param_file_name)
 	close(fd);
 
 	if (result < 0) {
-		warnx("error importing from '%s'", param_file_name);
+		PX4_ERR("importing from '%s' failed (%i)", param_file_name, result);
 		return 1;
 	}
 
@@ -323,7 +326,7 @@ do_import(const char *param_file_name)
 	int fd = open(param_file_name, O_RDONLY);
 
 	if (fd < 0) {
-		warn("open '%s'", param_file_name);
+		PX4_ERR("open '%s' failed (%i)", param_file_name, errno);
 		return 1;
 	}
 
@@ -331,7 +334,7 @@ do_import(const char *param_file_name)
 	close(fd);
 
 	if (result < 0) {
-		warnx("error importing from '%s'", param_file_name);
+		PX4_ERR("importing from '%s' failed (%i)", param_file_name, result);
 		return 1;
 	}
 
@@ -361,7 +364,7 @@ do_find(const char *name)
 	param_t ret = param_find_no_notification(name);
 
 	if (ret == PARAM_INVALID) {
-		warnx("Parameter %s not found", name);
+		PX4_ERR("Parameter %s not found", name);
 		return 1;
 	}
 
@@ -386,7 +389,7 @@ do_show_index(const char *index, bool used_index)
 	}
 
 	if (param == PARAM_INVALID) {
-		warnx("param not found for index %u", i);
+		PX4_ERR("param not found for index %u", i);
 		return 1;
 	}
 
@@ -441,7 +444,7 @@ do_show_print(void *arg, param_t param)
 
 			} else if (*ss == '*') {
 				if (*(ss + 1) != '\0') {
-					warnx("* symbol only allowed at end of search string.");
+					PX4_WARN("* symbol only allowed at end of search string");
 					// FIXME - should exit
 					return;
 				}
@@ -507,7 +510,7 @@ do_set(const char *name, const char *val, bool fail_on_not_found)
 	/* set nothing if parameter cannot be found */
 	if (param == PARAM_INVALID) {
 		/* param not found - fail silenty in scripts as it prevents booting */
-		warnx("Error: Parameter %s not found.", name);
+		PX4_ERR("Parameter %s not found.", name);
 		return (fail_on_not_found) ? 1 : 0;
 	}
 
@@ -559,12 +562,14 @@ do_set(const char *name, const char *val, bool fail_on_not_found)
 		break;
 
 	default:
-		warnx("<unknown / unsupported type %d>\n", 0 + param_type(param));
+		PX4_ERR("<unknown / unsupported type %d>\n", 0 + param_type(param));
 		return 1;
 	}
 
-	if (param_save_default()) {
-		warnx("Param export failed.");
+	int ret = param_save_default();
+
+	if (ret) {
+		PX4_ERR("Param save failed (%i)", ret);
 		return 1;
 
 	} else {
@@ -582,7 +587,7 @@ do_compare(const char *name, char *vals[], unsigned comparisons, enum COMPARE_OP
 	/* set nothing if parameter cannot be found */
 	if (param == PARAM_INVALID) {
 		/* param not found */
-		warnx("Error: Parameter %s not found.", name);
+		PX4_ERR("Parameter %s not found", name);
 		return 1;
 	}
 
@@ -634,7 +639,7 @@ do_compare(const char *name, char *vals[], unsigned comparisons, enum COMPARE_OP
 		break;
 
 	default:
-		warnx("<unknown / unsupported type %d>\n", 0 + param_type(param));
+		PX4_ERR("<unknown / unsupported type %d>", 0 + param_type(param));
 		return 1;
 	}
 
@@ -657,8 +662,10 @@ do_reset(const char *excludes[], int num_excludes)
 		param_reset_all();
 	}
 
-	if (param_save_default()) {
-		warnx("Param export failed.");
+	int ret = param_save_default();
+
+	if (ret) {
+		PX4_ERR("Param save failed (%i)", ret);
 		return 1;
 	}
 
@@ -684,8 +691,10 @@ do_reset_nostart(const char *excludes[], int num_excludes)
 	(void)param_set(param_find("SYS_AUTOSTART"), &autostart);
 	(void)param_set(param_find("SYS_AUTOCONFIG"), &autoconfig);
 
-	if (param_save_default()) {
-		warnx("Param export failed.");
+	int ret = param_save_default();
+
+	if (ret) {
+		PX4_ERR("Param save failed (%i)", ret);
 		return 1;
 
 	}


### PR DESCRIPTION
If param_find() returned PARAM_INVALID, and this was directly passed to param_get(), param_get_value_ptr() returned null and we read garbage data on NuttX (but no invalid writes).
On px4fmu-v2, this happened for the param ATT_VIBE_THRESH in sensors (where garbage data did not lead to misbehavior).
Because of the recently added parameter scoping, this param got pruned, as it's defined in attitude_estimator_q.
This also moves the definition of ATT_VIBE_THRES into the sensors module, since it's only used there.

Depending on configuration and runtime config, more params can be affected (a quick check with a VTOL config did not reveal any more). In any case a caller should make sure not to pass an invalid handle, or at least check the returned value of param_get, because if it fails, the value will not be set.

Credits for finding this go to @jeyong, thanks!

Fixes #6659