### PR TITLE
Added parameter for position control manual stick takeoff threshold

### DIFF
--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -82,6 +82,7 @@ MulticopterLandDetector::MulticopterLandDetector() : LandDetector(),
 	_paramHandle.freefall_trigger_time = param_find("LNDMC_FFALL_TTRI");
 	_paramHandle.manual_stick_down_threshold = param_find("LNDMC_MAN_DWNTHR");
 	_paramHandle.altitude_max = param_find("LNDMC_ALT_MAX");
+	_paramHandle.manual_stick_up_position_takeoff_threshold = param_find("LNDMC_POS_UPTHR");
 }
 
 void MulticopterLandDetector::_initialize_topics()
@@ -125,7 +126,7 @@ void MulticopterLandDetector::_update_params()
 	_freefall_hysteresis.set_hysteresis_time_from(false, (hrt_abstime)(1e6f * _params.freefall_trigger_time));
 	param_get(_paramHandle.manual_stick_down_threshold, &_params.manual_stick_down_threshold);
 	param_get(_paramHandle.altitude_max, &_params.altitude_max);
-
+	param_get(_paramHandle.manual_stick_up_position_takeoff_threshold, &_params.manual_stick_up_position_takeoff_threshold);
 }
 
 
@@ -273,7 +274,7 @@ float MulticopterLandDetector::_get_takeoff_throttle()
 		/* Should be above 0.5 because below that we do not gain altitude and won't take off.
 		 * Also it should be quite high such that we don't accidentally take off when using
 		 * a spring loaded throttle and have a useful vertical speed to start with. */
-		return 0.75f;
+		return _params.manual_stick_up_position_takeoff_threshold;
 	}
 
 	/* Manual/attitude mode */

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -94,6 +94,7 @@ private:
 		param_t freefall_trigger_time;
 		param_t manual_stick_down_threshold;
 		param_t altitude_max;
+		param_t manual_stick_up_position_takeoff_threshold;
 	} _paramHandle;
 
 	struct {
@@ -108,6 +109,7 @@ private:
 		float freefall_trigger_time;
 		float manual_stick_down_threshold;
 		float altitude_max;
+		float manual_stick_up_position_takeoff_threshold;
 	} _params;
 
 	int _vehicleLocalPositionSub;

--- a/src/modules/land_detector/land_detector_params.c
+++ b/src/modules/land_detector/land_detector_params.c
@@ -135,6 +135,20 @@ PARAM_DEFINE_FLOAT(LNDMC_FFALL_TTRI, 0.3);
 PARAM_DEFINE_FLOAT(LNDMC_MAN_DWNTHR, 0.15f);
 
 /**
+ * Manual position flight stick up threshold for taking off
+ *
+ * When controlling manually in position mode the throttle stick value (0 to 1)
+ * has to get above this threshold after arming in order to take off.
+ *
+ * @min 0
+ * @max 1
+ * @decimal 2
+ *
+ * @group Land Detector
+ */
+PARAM_DEFINE_FLOAT(LNDMC_POS_UPTHR, 0.65f);
+
+/**
  * Fixedwing max horizontal velocity
  *
  * Maximum horizontal velocity allowed in the landed state (m/s)


### PR DESCRIPTION
There was mentioned multiple times that the takeoff can sound  a bit aggressive depending on the vehicle.
This is not a full-fledged solution but changing the thershold for the manual takeoff is anyways good to be tunable by parameter and it can be used to achieve a more gentle takeoff according to the users taste.