### PR TITLE
lis3mdl: Fix check_calibration() output

### DIFF
--- a/src/drivers/lis3mdl/lis3mdl.cpp
+++ b/src/drivers/lis3mdl/lis3mdl.cpp
@@ -1228,12 +1228,7 @@ int LIS3MDL::check_calibration()
 	}
 
 	/* return 0 if calibrated, 1 else */
-	if (!_calibrated) {
-		return 0;
-
-	} else {
-		return 1;
-	}
+	return !_calibrated;
 }
 
 int LIS3MDL::set_excitement(unsigned enable)


### PR DESCRIPTION
The previous implementation returned OK when the sensor was not calibrated and vice
versa. This fixes
```
PREFLIGHT FAIL: MAG 1 SELFTEST FAILED
```
due to failed `check_calibration()`.

@klopezal Can you verify this is correct?