### PR TITLE
px4fmu-v4: Fix for HIL Unable to Set Control Surfaces. Fixes #5651

### DIFF
--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -3273,6 +3273,7 @@ fmu_main(int argc, char *argv[])
 {
 	PortMode new_mode = PORT_MODE_UNSET;
 	const char *verb = argv[1];
+	bool fmu_was_running = false;
 
 	if (!strcmp(verb, "bind")) {
 		bind_spektrum();
@@ -3301,6 +3302,8 @@ fmu_main(int argc, char *argv[])
 		fmu_stop();
 		errx(0, "FMU driver stopped");
 	}
+
+	fmu_was_running = (g_fmu != nullptr);
 
 	if (fmu_start() != OK) {
 		errx(1, "failed to start the FMU driver");
@@ -3396,10 +3399,12 @@ fmu_main(int argc, char *argv[])
 			warnx("resettet default time");
 		}
 
-		// When we are done resetting, we should clean up the fmu drivers
-		// Failure to do so prevents other devices (HIL sim driver)
-		// from starting.
-		fmu_stop();
+		// When we are done resetting, we should clean up the fmu drivers if they
+		// weren't active at the beginning of the reset.
+		// Failure to do so prevents other devices (HIL sim driver) from starting
+		if (!fmu_was_running) {
+			fmu_stop();
+		}
 		exit(0);
 	}
 
@@ -3413,10 +3418,12 @@ fmu_main(int argc, char *argv[])
 			warnx("resettet default time");
 		}
 
-		// When we are done resetting, we should clean up the fmu drivers
-		// Failure to do so prevents other devices (HIL sim driver)
-		// from starting.
-		fmu_stop();
+		// When we are done resetting, we should clean up the fmu drivers if they
+		// weren't active at the beginning of the reset.
+		// Failure to do so prevents other devices (HIL sim driver) from starting
+		if (!fmu_was_running) {
+			fmu_stop();
+		}
 		exit(0);
 	}
 

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -3405,6 +3405,7 @@ fmu_main(int argc, char *argv[])
 		if (!fmu_was_running) {
 			fmu_stop();
 		}
+
 		exit(0);
 	}
 
@@ -3424,6 +3425,7 @@ fmu_main(int argc, char *argv[])
 		if (!fmu_was_running) {
 			fmu_stop();
 		}
+
 		exit(0);
 	}
 

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -3396,6 +3396,10 @@ fmu_main(int argc, char *argv[])
 			warnx("resettet default time");
 		}
 
+		// When we are done resetting, we should clean up the fmu drivers
+		// Failure to do so prevents other devices (HIL sim driver)
+		// from starting.
+		fmu_stop();
 		exit(0);
 	}
 
@@ -3409,6 +3413,10 @@ fmu_main(int argc, char *argv[])
 			warnx("resettet default time");
 		}
 
+		// When we are done resetting, we should clean up the fmu drivers
+		// Failure to do so prevents other devices (HIL sim driver)
+		// from starting.
+		fmu_stop();
 		exit(0);
 	}
 


### PR DESCRIPTION
### Issue Description

The sensor_rest command added to the sensors.rc startup script for px4fmu_v4 hardware was leaving the /dev/pwm_output0 driver open.  (See https://github.com/PX4/Firmware/commit/021f0840ae7f724bfdfd317dda3d57362017b835)  This would prevent the pwm_out_sim module from registering as a simulated driver.  The result would cause the system to properly boot in HIL mode, but you would not be able to set any control surfaces.

Since sensor_rest and peripheral_reset are only used on initialization, the drivers can be shut down after they have performed their reset functions.

### Testing

This has been tested and verified in HIL with the following:

**Hardware**
Pixracer Based Board
Only USB Used for Connection (No Sensors)

**Software/Firmware:**
Windows 10
XPlane 10.51r2 (build 105101 64-bit)
XPlane Model: HiLStar17
QGroundControl: 3.1.3
