### PR TITLE
mavlink_main: add POSITION_TARGET_LOCAL_NED to mavlink stream

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2002,6 +2002,7 @@ Mavlink::task_main(int argc, char *argv[])
 		configure_stream("NAV_CONTROLLER_OUTPUT", 1.5f);
 		configure_stream("GLOBAL_POSITION_INT", 5.0f);
 		configure_stream("LOCAL_POSITION_NED", 1.0f);
+		configure_stream("POSITION_TARGET_LOCAL_NED", 1.5f);
 		configure_stream("POSITION_TARGET_GLOBAL_INT", 1.5f);
 		configure_stream("ATTITUDE_TARGET", 2.0f);
 		configure_stream("HOME_POSITION", 0.5f);


### PR DESCRIPTION
I think the normal mavlink stream needs to have the setpoint included as well since it helps to observe the velocity controller performance in real time to ease the tuning of the velocity controller.