### PR TITLE
commander: no datalink failsafe on ground

### DIFF
--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -844,10 +844,10 @@ bool set_nav_state(struct vehicle_status_s *status,
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_gps);
 
-			/* also go into failsafe if just datalink is lost */
+			/* also go into failsafe if just datalink is lost, and we're actually in air */
 
-		} else if (status->data_link_lost && data_link_loss_act_configured) {
 			enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_datalink);
+		} else if (status->data_link_lost && data_link_loss_act_configured && !landed) {
 
 			set_data_link_loss_nav_state(status, armed, status_flags, data_link_loss_act);
 


### PR DESCRIPTION
On SITL startup we got a datalink lost failsafe message whenever home
was initialized. The reason that in standalone SITL, there is usually no
datalink connected. However, on ground, we shouldn't really failsafe,
therefore it makes sense not to enter the state in the first place.

This always annoyed me in SITL:

```
INFO  [lib__ecl] EKF commencing GPS fusion
INFO  [commander] home: 47.3977421, 8.5455939, 488.00
INFO  [tone_alarm] home_set
INFO  [commander] no datalink
WARN  [commander] failsafe mode on
INFO  [tone_alarm] fast_bat
WARN  [navigator] Already landed, not executing RTL
INFO  [tone_alarm] neutral
INFO  [tone_alarm] fast_bat

pxh> INFO  [tone_alarm] positive
INFO  [commander] home: 47.3977421, 8.5455940, 488.01
WARN  [commander] failsafe mode off
```

@bkueng please review.