### PR TITLE
WIP: mc_pos_control: triplet handling for mc

### DIFF
--- a/cmake/configs/posix_sitl_default.cmake
+++ b/cmake/configs/posix_sitl_default.cmake
@@ -120,6 +120,8 @@ set(config_module_list
 	lib/tailsitter_recovery
 	lib/terrain_estimation
 	lib/version
+	lib/bezier
+
 
 	#
 	# Platform

--- a/src/lib/bezier/BezierQuad.cpp
+++ b/src/lib/bezier/BezierQuad.cpp
@@ -1,0 +1,144 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2013, 2014 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file BezierQuad.cpp
+ * Bezier function
+ *
+ * @author Dennis Mannhart <dennis.mannhart@gmail.com>
+ *
+ */
+
+#include "BezierQuad.hpp"
+
+namespace bezier{
+
+#define GOLDEN_RATIO 1.61803398f //(sqrt(5)-1)/2
+#define RESOLUTION 0.0001f  //represents resolution; end criterion for golden section search
+
+
+void
+BezierQuad::setBezier(const matrix::Vector3f &pt0, const matrix::Vector3f &ctrl, const matrix::Vector3f &pt1, float duration){
+	_pt0 = pt0;
+	_ctrl = ctrl;
+	_pt1 = pt1;
+	_duration = duration;
+
+}
+
+void
+BezierQuad::getBezier(matrix::Vector3f &pt0, matrix::Vector3f &ctrl, matrix::Vector3f &pt1){
+	pt0 = _pt0;
+	ctrl = _ctrl;
+	pt1 = _pt1;
+}
+
+void
+BezierQuad::getPoint(matrix::Vector3f &point, const float t){
+	point = _pt0 * (1 - t/_duration) * (1 - t/_duration) + _ctrl * 2.0f * (1- t/_duration)*t/_duration +   _pt1*t/_duration * t/_duration;
+}
+
+void
+BezierQuad::getVelocity(matrix::Vector3f &vel, const float t){
+	vel = ((_ctrl - _pt0)*_duration + (_pt0 - _ctrl *2.0f + _pt1 )*t )*2.0f/(_duration*_duration);
+}
+
+void
+BezierQuad::getAcceleration(matrix::Vector3f &acc){
+	acc = (_pt0 - _ctrl * 2.0f + _pt1) * 2.0f/(_duration * _duration);
+}
+
+void
+BezierQuad::getStates(matrix::Vector3f &point, matrix::Vector3f &vel, matrix::Vector3f &acc, const float time){
+	getPoint(point, time);
+	getVelocity(vel, time);
+	getAcceleration(acc);
+}
+
+float
+BezierQuad::getDistanceSquared(const float t, const matrix::Vector3f &pose){
+	/* get point on bezier */
+	matrix::Vector3f vec;
+	getPoint(vec, t);
+
+	/* get vector from point to pose */
+	vec = vec - pose;
+
+	/* norm squared */
+	return (vec * vec);
+
+}
+
+void
+BezierQuad::getStatesClosest(matrix::Vector3f &point,matrix::Vector3f &vel,matrix::Vector3f &acc, const matrix::Vector3f pose){
+	/* get t that corresponds to point closest on bezier point */
+	float t = goldenSectionSearch(pose);
+
+	/* get states corresponding to t */
+	getStates(point, vel, acc, t);
+
+}
+
+void
+BezierQuad::computeBezFromVel(const matrix::Vector3f &ctrl, const matrix::Vector3f &vel0, const matrix::Vector3f &vel1, const float duration){
+
+	/* update bezier points */
+	_ctrl = ctrl;
+	_duration = duration;
+	_pt0 = _ctrl - vel0 * _duration/2.0f;
+	_pt1 = _ctrl + vel1 * _duration/2.0f;
+}
+
+float
+BezierQuad::goldenSectionSearch(const matrix::Vector3f &pose){
+	float a, b, c, d;
+	a = 0.0f; //represents most left point
+	b = _duration * 1.0f; //represents most right point
+
+	c = b - (b - a) / GOLDEN_RATIO;
+	d = a + (b - a) / GOLDEN_RATIO;
+
+	while(fabsf(c - d) > RESOLUTION){
+			if( getDistanceSquared(c, pose) < getDistanceSquared(d, pose)){
+				b = d;
+			}else{
+				a = c;
+			}
+
+			c = b - (b -a)/GOLDEN_RATIO;
+			d = a + (b -a)/GOLDEN_RATIO;
+
+	}
+	return (b+a)/2.0f;
+}
+
+}

--- a/src/lib/bezier/BezierQuad.hpp
+++ b/src/lib/bezier/BezierQuad.hpp
@@ -105,7 +105,7 @@ public:
 	/*
 	* set duration
 	*/
-	void setDuraiont(const float time) {_duration = time;}
+	void setDuration(const float time) {_duration = time;}
 
 	/**
 	 * get point on bezier point corresponding to t

--- a/src/lib/bezier/BezierQuad.hpp
+++ b/src/lib/bezier/BezierQuad.hpp
@@ -1,0 +1,152 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2012 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file BerzierQuad.hpp
+ *
+ * Quadratic bezier lib
+ */
+
+
+#pragma once
+
+#include <px4_defines.h>
+#include <stdlib.h>
+
+//#include <mathlib/math/Vector.hpp>
+#include <matrix/math.hpp>
+
+
+namespace bezier{
+
+
+class __EXPORT BezierQuad
+{
+public:
+
+	/**
+	 * empty constructor
+	 */
+	BezierQuad(void) :
+	_pt0(matrix::Vector3f()), _ctrl(matrix::Vector3f()), _pt1(matrix::Vector3f()), _duration(1.0f){}
+
+
+	/**
+	 * constructor from array
+	 */
+	BezierQuad(const float pt0[3], const float ctrl[3], const float pt2[3], float duration = 1.0f) :
+		_pt0(matrix::Vector3f(pt0)), _ctrl(matrix::Vector3f(pt0)), _pt1(matrix::Vector3f(pt0)), _duration(duration) {}
+
+	/**
+	 * constructor from vector
+	 */
+	BezierQuad(const matrix::Vector3f &pt0, const matrix::Vector3f &ctrl, const matrix::Vector3f &pt1, float duration = 1.0f ):
+		_pt0(pt0), _ctrl(ctrl), _pt1(pt1), _duration(1.0f){}
+
+
+	/*
+	 * return bezier points
+	 */
+	void getBezier(matrix::Vector3f &pt0, matrix::Vector3f &ctrl, matrix::Vector3f &pt1);
+
+	/**
+	 * set new bezier points
+	 */
+	void setBezier(const matrix::Vector3f &pt0, const matrix::Vector3f &ctrl, const matrix::Vector3f &pt1, float duration = 1.0f );
+
+	/**
+	 * get point on bezier point corresponding to t
+	 */
+	void getPoint(matrix::Vector3f &point, const float t);
+
+	/*
+	 * get velocity on bezier corresponding to t
+	 */
+	void getVelocity(matrix::Vector3f &vel, const float t);
+
+	/*
+	 * get acceleration on bezier corresponding to t
+	 */
+	void getAcceleration(matrix::Vector3f &acc);
+
+	/*
+	 * get states on bezier corresponding to t
+	 */
+	void getStates(matrix::Vector3f &point,matrix::Vector3f &vel,matrix::Vector3f &acc, const float t);
+
+	/*
+	 * get states on bezier which are closest to pose
+	 */
+	void getStatesClosest(matrix::Vector3f &point,matrix::Vector3f &vel,matrix::Vector3f &acc, const matrix::Vector3f pose);
+
+	/*
+	 * get distance to point on bezier
+	 */
+	float getDistanceSquared(const float t, const matrix::Vector3f &pose);
+
+	/*
+	 * compute bezier from velocity at bezier end points and ctrl point
+	 */
+	void computeBezFromVel(const matrix::Vector3f &ctrl, const matrix::Vector3f &vel0, const matrix::Vector3f &vel1, const float duration = 1.0f);
+
+
+private:
+
+	/* control points */
+	matrix::Vector3f _pt0;
+	matrix::Vector3f _ctrl;
+	matrix::Vector3f _pt1;
+	float _duration;
+
+
+	/*
+	 * Helper functions
+	 */
+
+	/* golden section search */
+	float goldenSectionSearch(const matrix::Vector3f &pose);
+
+
+
+
+
+
+
+
+
+
+
+
+};
+}
+

--- a/src/lib/bezier/BezierQuad.hpp
+++ b/src/lib/bezier/BezierQuad.hpp
@@ -47,7 +47,8 @@
 #include <matrix/math.hpp>
 
 
-namespace bezier{
+namespace bezier
+{
 
 
 class __EXPORT BezierQuad
@@ -58,7 +59,7 @@ public:
 	 * empty constructor
 	 */
 	BezierQuad(void) :
-	_pt0(matrix::Vector3f()), _ctrl(matrix::Vector3f()), _pt1(matrix::Vector3f()), _duration(1.0f){}
+		_pt0(matrix::Vector3f()), _ctrl(matrix::Vector3f()), _pt1(matrix::Vector3f()), _duration(1.0f) {}
 
 
 	/**
@@ -70,8 +71,9 @@ public:
 	/**
 	 * constructor from vector
 	 */
-	BezierQuad(const matrix::Vector3f &pt0, const matrix::Vector3f &ctrl, const matrix::Vector3f &pt1, float duration = 1.0f ):
-		_pt0(pt0), _ctrl(ctrl), _pt1(pt1), _duration(1.0f){}
+	BezierQuad(const matrix::Vector3f &pt0, const matrix::Vector3f &ctrl, const matrix::Vector3f &pt1,
+		   float duration = 1.0f):
+		_pt0(pt0), _ctrl(ctrl), _pt1(pt1), _duration(1.0f) {}
 
 
 	/*
@@ -79,46 +81,73 @@ public:
 	 */
 	void getBezier(matrix::Vector3f &pt0, matrix::Vector3f &ctrl, matrix::Vector3f &pt1);
 
+	/*
+	 * get pt0
+	 */
+	matrix::Vector3f getPt0() {return _pt0;}
+
+	/*
+	 * get ctrl
+	 */
+	matrix::Vector3f getCtrl() {return _ctrl;}
+
+	/*
+	 * get pt1
+	 */
+	matrix::Vector3f getPt1() {return _pt1;}
+
 	/**
 	 * set new bezier points
 	 */
-	void setBezier(const matrix::Vector3f &pt0, const matrix::Vector3f &ctrl, const matrix::Vector3f &pt1, float duration = 1.0f );
+	void setBezier(const matrix::Vector3f &pt0, const matrix::Vector3f &ctrl, const matrix::Vector3f &pt1,
+		       float duration = 1.0f);
+
+	/*
+	* set duration
+	*/
+	void setDuraiont(const float time) {_duration = time;}
 
 	/**
 	 * get point on bezier point corresponding to t
 	 */
-	void getPoint(matrix::Vector3f &point, const float t);
+	matrix::Vector3f getPoint(const float t);
+
+	/*
+	 * Distance to closest point given a position
+	 */
+	float getDistToClosestPoint(const matrix::Vector3f &pose);
 
 	/*
 	 * get velocity on bezier corresponding to t
 	 */
-	void getVelocity(matrix::Vector3f &vel, const float t);
+	matrix::Vector3f getVelocity(const float t);
 
 	/*
 	 * get acceleration on bezier corresponding to t
 	 */
-	void getAcceleration(matrix::Vector3f &acc);
+	matrix::Vector3f getAcceleration();
 
 	/*
 	 * get states on bezier corresponding to t
 	 */
-	void getStates(matrix::Vector3f &point,matrix::Vector3f &vel,matrix::Vector3f &acc, const float t);
+	void getStates(matrix::Vector3f &point, matrix::Vector3f &vel, matrix::Vector3f &acc, const float t);
 
 	/*
 	 * get states on bezier which are closest to pose
 	 */
-	void getStatesClosest(matrix::Vector3f &point,matrix::Vector3f &vel,matrix::Vector3f &acc, const matrix::Vector3f pose);
-
-	/*
-	 * get distance to point on bezier
-	 */
-	float getDistanceSquared(const float t, const matrix::Vector3f &pose);
+	void getStatesClosest(matrix::Vector3f &point, matrix::Vector3f &vel, matrix::Vector3f &acc,
+			      const matrix::Vector3f pose);
 
 	/*
 	 * compute bezier from velocity at bezier end points and ctrl point
 	 */
-	void computeBezFromVel(const matrix::Vector3f &ctrl, const matrix::Vector3f &vel0, const matrix::Vector3f &vel1, const float duration = 1.0f);
+	void setBezFromVel(const matrix::Vector3f &ctrl, const matrix::Vector3f &vel0, const matrix::Vector3f &vel1,
+			   const float duration = 1.0f);
 
+	/*
+	 * simpsons inegrattion applied to velocity
+	 */
+	float getArcLength(const float resolution);
 
 private:
 
@@ -134,17 +163,12 @@ private:
 	 */
 
 	/* golden section search */
-	float goldenSectionSearch(const matrix::Vector3f &pose);
+	float _goldenSectionSearch(const matrix::Vector3f &pose);
 
-
-
-
-
-
-
-
-
-
+	/*
+	 * get distance to point on bezier
+	 */
+	float _getDistanceSquared(const float t, const matrix::Vector3f &pose);
 
 
 };

--- a/src/lib/bezier/CMakeLists.txt
+++ b/src/lib/bezier/CMakeLists.txt
@@ -1,0 +1,41 @@
+############################################################################
+#
+#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+px4_add_module(
+	MODULE lib__bezier
+	COMPILE_FLAGS
+	SRCS
+		BezierQuad.cpp
+	DEPENDS
+		platforms__common
+	)
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -86,6 +86,7 @@
 
 #include <controllib/blocks.hpp>
 #include <controllib/block/BlockParam.hpp>
+#include <bezier/BezierQuad.hpp>
 
 #define TILT_COS_MAX	0.7f
 #define SIGMA			0.000001f
@@ -168,6 +169,8 @@ private:
 	control::BlockDerivative _vel_x_deriv;
 	control::BlockDerivative _vel_y_deriv;
 	control::BlockDerivative _vel_z_deriv;
+
+	bezier::BezierQuad _bez;
 
 	struct {
 		param_t thr_min;
@@ -437,6 +440,7 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_vel_x_deriv(this, "VELD"),
 	_vel_y_deriv(this, "VELD"),
 	_vel_z_deriv(this, "VELD"),
+	_bez(),
 	_ref_alt(0.0f),
 	_ref_timestamp(0),
 
@@ -1483,7 +1487,6 @@ void MulticopterPositionControl::control_auto(float dt)
 
 			/* default is current setpoint */
 			_pos_sp = curr_sp;
-
 
 			if ((_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_POSITION  ||
 			     _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_FOLLOW_TARGET) &&


### PR DESCRIPTION
currently the handling of the triplet setpoint in mc_pos_control_main is rather confusing. In addition, the coupling of vtol to mc makes it also hard to distinguish what is important for vtol and what not. Following the discussion from here #6681, the triplet handling for simple point to point motions are implemented too complicated. Setting the desired current setpoint as the desired position is enough. There should not be any additional slewrate applied to the position. It is completely fine to have a position setpoint step. The velocity limit is applied  already at the output of the position controller. 
For the handling of waypoints, I can see the benefit of incorporating the previous and next setpoint, but I would completely split the implementation depending on vtol and normal mc (maybe that is already the case, but it is not obvious to me). Also, instead of having this position setpoint adjustment, I suggest to apply normal position control perpendicular to the line between previous and current setpoint and velocity feedforward in the velocity controller. the velocity feedforward vector can be computed from bezier curve which also incorporates max acceleration. I know how to do trajectory based on bezier curve for mc, but not for vtol and that is another reason why I would split the implementation entirely. obviously with vtol I mean when in fixedwing mode.
