### PR TITLE
Fix HIL mode

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -399,9 +399,7 @@ then
 		then
 			set FMU_MODE serial
 		fi
-		unset HIL
 	else
-		unset HIL
 		gps start
 	fi
 
@@ -420,7 +418,13 @@ then
 	#
 	# Sensors System (start before Commander so Preflight checks are properly run)
 	#
-	sh /etc/init.d/rc.sensors
+	if [ $HIL == yes ]
+	then
+		sensors start -hil
+	else
+		sh /etc/init.d/rc.sensors
+	fi
+	unset HIL
 
 	# Needs to be this early for in-air-restarts
 	if [ $OUTPUT_MODE == hil ]

--- a/Tools/jmavsim_run.sh
+++ b/Tools/jmavsim_run.sh
@@ -7,7 +7,7 @@ udp_port=14560
 extra_args=
 baudrate=921600
 device=
-while getopts ":b:d:p:q" opt; do
+while getopts ":b:d:p:qr:" opt; do
 	case $opt in
 		b)
 			baudrate=$OPTARG
@@ -20,6 +20,9 @@ while getopts ":b:d:p:q" opt; do
 			;;
 		q)
 			extra_args="$extra_args -qgc"
+			;;
+		r)
+			extra_args="$extra_args -r $OPTARG"
 			;;
 		\?)
 			echo "Invalid option: -$OPTARG" >&2

--- a/src/drivers/pwm_out_sim/pwm_out_sim.cpp
+++ b/src/drivers/pwm_out_sim/pwm_out_sim.cpp
@@ -169,7 +169,7 @@ private:
 namespace
 {
 
-PWMSim	*g_pwm_sim;
+PWMSim	*g_pwm_sim = nullptr;
 
 } // namespace
 

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -237,11 +237,8 @@ private:
 	uint64_t _global_ref_timestamp;
 	int _hil_frames;
 	uint64_t _old_timestamp;
-	uint64_t _hil_last_frame;
 	bool _hil_local_proj_inited;
 	float _hil_local_alt0;
-	float _hil_prev_gyro[3];
-	float _hil_prev_accel[3];
 	struct map_projection_reference_s _hil_local_proj_ref;
 	struct offboard_control_mode_s _offboard_control_mode;
 	struct vehicle_attitude_setpoint_s _att_sp;

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -1124,10 +1124,11 @@ MulticopterAttitudeControl::task_main()
 
 	/* wakeup source: gyro data from sensor selected by the sensor app */
 	px4_pollfd_struct_t poll_fds = {};
-	poll_fds.fd = _sensor_gyro_sub[_selected_gyro];
 	poll_fds.events = POLLIN;
 
 	while (!_task_should_exit) {
+
+		poll_fds.fd = _sensor_gyro_sub[_selected_gyro];
 
 		/* wait for up to 100ms for data */
 		int pret = px4_poll(&poll_fds, 1, 100);

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -835,7 +835,7 @@ MulticopterAttitudeControl::sensor_correction_poll()
 	}
 
 	/* update the latest gyro selection */
-	if (_sensor_correction.selected_gyro_instance < sizeof(_sensor_gyro_sub) / sizeof(_sensor_gyro_sub[0])) {
+	if (_sensor_correction.selected_gyro_instance < _gyro_count) {
 		_selected_gyro = _sensor_correction.selected_gyro_instance;
 	}
 }
@@ -1108,6 +1108,10 @@ MulticopterAttitudeControl::task_main()
 	_battery_status_sub = orb_subscribe(ORB_ID(battery_status));
 
 	_gyro_count = math::min(orb_group_count(ORB_ID(sensor_gyro)), MAX_GYRO_COUNT);
+
+	if (_gyro_count == 0) {
+		_gyro_count = 1;
+	}
 
 	for (unsigned s = 0; s < _gyro_count; s++) {
 		_sensor_gyro_sub[s] = orb_subscribe_multi(ORB_ID(sensor_gyro), s);

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -140,7 +140,7 @@ public:
 	/**
 	 * Constructor
 	 */
-	Sensors();
+	Sensors(bool hil_enabled);
 
 	/**
 	 * Destructor, also kills the sensors task.
@@ -165,8 +165,7 @@ private:
 	bool 		_task_should_exit;		/**< if true, sensor task should exit */
 	int 		_sensors_task;			/**< task handle for sensor task */
 
-	bool		_hil_enabled;			/**< if true, HIL is active */
-	bool		_publishing;			/**< if true, we are publishing sensor data (in HIL mode, we don't) */
+	const bool	_hil_enabled;			/**< if true, HIL is active */
 	bool		_armed;				/**< arming status of the vehicle */
 
 	int		_actuator_ctrl_0_sub;		/**< attitude controls sub */
@@ -250,14 +249,13 @@ namespace sensors
 Sensors	*g_sensors = nullptr;
 }
 
-Sensors::Sensors() :
+Sensors::Sensors(bool hil_enabled) :
 	_h_adc(),
 	_last_adc(0),
 
 	_task_should_exit(true),
 	_sensors_task(-1),
-	_hil_enabled(false),
-	_publishing(true),
+	_hil_enabled(hil_enabled),
 	_armed(false),
 
 	_actuator_ctrl_0_sub(-1),
@@ -277,7 +275,7 @@ Sensors::Sensors() :
 	_airspeed_validator(),
 
 	_rc_update(_parameters),
-	_voted_sensors_update(_parameters)
+	_voted_sensors_update(_parameters, hil_enabled)
 {
 	memset(&_diff_pres, 0, sizeof(_diff_pres));
 	memset(&_parameters, 0, sizeof(_parameters));
@@ -412,25 +410,12 @@ Sensors::vehicle_control_mode_poll()
 	struct vehicle_control_mode_s vcontrol_mode;
 	bool vcontrol_mode_updated;
 
-	/* Check HIL state if vehicle control mode has changed */
 	orb_check(_vcontrol_mode_sub, &vcontrol_mode_updated);
 
 	if (vcontrol_mode_updated) {
 
 		orb_copy(ORB_ID(vehicle_control_mode), _vcontrol_mode_sub, &vcontrol_mode);
 		_armed = vcontrol_mode.flag_armed;
-
-		/* switching from non-HIL to HIL mode */
-		if (vcontrol_mode.flag_system_hil_enabled && !_hil_enabled) {
-			_hil_enabled = true;
-			_publishing = false;
-
-			/* switching from HIL to non-HIL mode */
-
-		} else if (!_publishing && !_hil_enabled) {
-			_hil_enabled = false;
-			_publishing = true;
-		}
 	}
 }
 
@@ -473,8 +458,8 @@ Sensors::parameter_update_poll(bool forced)
 void
 Sensors::adc_poll(struct sensor_combined_s &raw)
 {
-	/* only read if publishing */
-	if (!_publishing) {
+	/* only read if not in HIL mode */
+	if (_hil_enabled) {
 		return;
 	}
 
@@ -569,13 +554,15 @@ Sensors::task_main()
 	/* start individual sensors */
 	int ret = 0;
 
-	/* This calls a sensors_init which can have different implementations on NuttX, POSIX, QURT. */
-	ret = sensors_init();
+	if (!_hil_enabled) {
+		/* This calls a sensors_init which can have different implementations on NuttX, POSIX, QURT. */
+		ret = sensors_init();
 
 #if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
-	// TODO: move adc_init into the sensors_init call.
-	ret = ret || adc_init();
+		// TODO: move adc_init into the sensors_init call.
+		ret = ret || adc_init();
 #endif
+	}
 
 	if (ret) {
 		PX4_ERR("sensor initialization failed");
@@ -670,7 +657,7 @@ Sensors::task_main()
 
 		diff_pres_poll(raw);
 
-		if (_publishing && raw.timestamp > 0) {
+		if (raw.timestamp > 0) {
 
 			_voted_sensors_update.set_relative_timestamps(raw);
 
@@ -771,7 +758,13 @@ int sensors_main(int argc, char *argv[])
 			return 0;
 		}
 
-		sensors::g_sensors = new Sensors;
+		bool hil_enabled = false;
+
+		if (argc > 2 && !strcmp(argv[2], "-hil")) {
+			hil_enabled = true;
+		}
+
+		sensors::g_sensors = new Sensors(hil_enabled);
 
 		if (sensors::g_sensors == nullptr) {
 			PX4_ERR("alloc failed");

--- a/src/modules/sensors/voted_sensors_update.h
+++ b/src/modules/sensors/voted_sensors_update.h
@@ -76,7 +76,7 @@ public:
 	 * @param parameters parameter values. These do not have to be initialized when constructing this object.
 	 * Only when calling init(), they have to be initialized.
 	 */
-	VotedSensorsUpdate(const Parameters &parameters);
+	VotedSensorsUpdate(const Parameters &parameters, bool hil_enabled);
 
 	/**
 	 * initialize subscriptions etc.
@@ -259,6 +259,7 @@ private:
 	math::Matrix<3, 3>	_mag_rotation[SENSOR_COUNT_MAX] = {};	/**< rotation matrix for the orientation that the external mag0 is mounted */
 
 	const Parameters &_parameters;
+	const bool _hil_enabled; /**< is hardware-in-the-loop mode enabled? */
 
 	float _accel_diff[3][2];	/**< filtered accel differences between IMU units (m/s/s) */
 	float _gyro_diff[3][2];		/**< filtered gyro differences between IMU uinits (rad/s) */


### PR DESCRIPTION
HIL mode is currently broken in several ways:
- mc_att_control listened directly to the gyro topic, but in HIL mode, both mavlink and the sensor driver(s) published this topic on the same instance.
- CPU was always at 100% (which explains the purple blinking LED)
- thermal compensation was applied even in HIL mode

This changes the following:
- let mavlink only publish the raw sensors topics, which is then handled in `sensors`, which in turn publishes `sensor_combined` as usual
- make sure no sensor driver starts in HIL mode to avoid publication interference
- don't apply thermal corrections in HIL mode

With these changes the CPU was still >90%, and the drone flew very unstable. It turns out that jMAVSim uses a default update rate of 500Hz, which means the system would run at 500Hz as well. I tested with a rate of 300 and 250 Hz (see command below), and in both cases the drone flies stable. We may need to change the default in jMAVSim.

The CPU usage was still very high, but it may not be representative as I had to use a different mavlink port to run the tests (my USB UART connection on the laptop is flaky).

To test:
`
./Tools/jmavsim_run.sh -q -d /dev/ttyACM0 -b 921600 -r 250
`

@gamoreno can you test this?

@clovett @julianoes  fyi