### PR TITLE
PixHawk Pro: Update mag IDs to have external higher priority

### DIFF
--- a/src/drivers/lis3mdl/lis3mdl.cpp
+++ b/src/drivers/lis3mdl/lis3mdl.cpp
@@ -941,6 +941,11 @@ LIS3MDL::collect()
 	new_report.temperature = report.t;
 	new_report.temperature = 25 + (report.t / (16 * 8.0f));
 
+	// XXX revisit for SPI part, might require a bus type IOCTL
+
+	unsigned dummy;
+	sensor_is_onboard = !_interface->ioctl(MAGIOCGEXTERNAL, dummy);
+
 	/*
 	 * RAW outputs
 	 *

--- a/src/modules/uavcan/sensors/mag.cpp
+++ b/src/modules/uavcan/sensors/mag.cpp
@@ -155,6 +155,7 @@ void UavcanMagnetometerBridge::mag_sub_cb(const uavcan::ReceivedDataStructure<ua
 	 * The proper solution is to be developed.
 	 */
 	_report.timestamp = hrt_absolute_time();
+	_report.device_id = _device_id.devid;
 
 	_report.x = (msg.magnetic_field_ga[0] - _scale.x_offset) * _scale.x_scale;
 	_report.y = (msg.magnetic_field_ga[1] - _scale.y_offset) * _scale.y_scale;

--- a/src/modules/uavcan/sensors/sensor_bridge.cpp
+++ b/src/modules/uavcan/sensors/sensor_bridge.cpp
@@ -120,7 +120,7 @@ void UavcanCDevSensorBridgeBase::publish(const int node_id, const void *report)
 		channel->node_id        = node_id;
 		channel->class_instance = class_instance;
 
-		channel->orb_advert = orb_advertise_multi(_orb_topic, report, &channel->orb_instance, ORB_PRIO_HIGH);
+		channel->orb_advert = orb_advertise_multi(_orb_topic, report, &channel->orb_instance, ORB_PRIO_VERY_HIGH);
 		if (channel->orb_advert == nullptr) {
 			DEVICE_LOG("ADVERTISE FAILED");
 			(void)unregister_class_devname(_class_devname, class_instance);


### PR DESCRIPTION
@LorenzMeier @klopezal @eyeam3 
In order to force the use of the external magnetometer connected through UAVCAN, I had to set its priority to VERY_HIGH. Is it a proper way to do it?