### PR TITLE
Improve failsafe response to loss of position and velocity accuracy

### DIFF
--- a/integrationtests/python_src/px4_it/mavros/mission_test.py
+++ b/integrationtests/python_src/px4_it/mavros/mission_test.py
@@ -229,7 +229,10 @@ class MavrosMissionTest(unittest.TestCase):
             (self.mission_name, lat, lon, alt, xy_radius, z_radius, timeout, index, self.last_pos_d, self.last_alt_d, vtol_state_string)))
 
     def run_mission(self):
-        """switch mode: auto and arm"""
+	# Hack to wait until vehicle is ready
+	# TODO better integration with pre-flight status reporting
+	time.sleep(5)
+	"""switch mode: auto and arm"""
         self._srv_cmd_long(False, 176, False,
                            # custom, auto, mission
                            1, 4, 4, 0, 0, 0, 0)

--- a/msg/estimator_status.msg
+++ b/msg/estimator_status.msg
@@ -10,15 +10,16 @@ uint8 timeout_flags		# Bitmask to indicate timeout flags (vel, pos, hgt)
 float32[28] covariances	# Diagonal Elements of Covariance Matrix
 uint16 gps_check_fail_flags     # Bitmask to indicate status of GPS checks - see definition below
 # bits are true when corresponding test has failed
-# 0 : minimum required sat count fail
-# 1 : minimum required GDoP fail
-# 2 : maximum allowed horizontal position error fail
-# 3 : maximum allowed vertical position error fail
-# 4 : maximum allowed speed error fail
-# 5 : maximum allowed horizontal position drift fail
-# 6 : maximum allowed vertical position drift fail
-# 7 : maximum allowed horizontal speed fail
-# 8 : maximum allowed vertical velocity discrepancy fail
+uint8 GPS_CHECK_FAIL_MIN_SAT_COUNT = 0			# 0 : minimum required sat count fail
+uint8 GPS_CHECK_FAIL_MIN_GDOP = 1				# 1 : minimum required GDoP fail
+uint8 GPS_CHECK_FAIL_MAX_HORZ_ERR = 2			# 2 : maximum allowed horizontal position error fail
+uint8 GPS_CHECK_FAIL_MAX_VERT_ERR = 3			# 3 : maximum allowed vertical position error fail
+uint8 GPS_CHECK_FAIL_MAX_SPD_ERR = 4			# 4 : maximum allowed speed error fail
+uint8 GPS_CHECK_FAIL_MAX_HORZ_DRIFT = 5			# 5 : maximum allowed horizontal position drift fail
+uint8 GPS_CHECK_FAIL_MAX_VERT_DRIFT = 6			# 6 : maximum allowed vertical position drift fail
+uint8 GPS_CHECK_FAIL_MAX_HORZ_SPD_ERR = 7		# 7 : maximum allowed horizontal velocity discrepancy fail
+uint8 GPS_CHECK_FAIL_MAX_VERT_SPD_ERR = 8		# 8 : maximum allowed vertical velocity discrepancy fail
+
 uint16 control_mode_flags	# Bitmask to indicate EKF logic state
 # 0 - true if the filter tilt alignment is complete
 # 1 - true if the filter yaw alignment is complete

--- a/msg/vehicle_global_position.msg
+++ b/msg/vehicle_global_position.msg
@@ -18,6 +18,8 @@ float32 vel_d			# Down velocity in NED earth-fixed frame, (metres/sec)
 float32 yaw 			# Euler yaw angle relative to NED earth-fixed frame, -PI..+PI, (radians)
 float32 eph			# Standard deviation of horizontal position error, (metres)
 float32 epv			# Standard deviation of vertical position error, (metres)
+float32 evh			# Standard deviation of horizontal velocity error, (metres/sec)
+float32 evv			# Standard deviation of horizontal velocity error, (metres/sec)
 float32 terrain_alt		# Terrain altitude WGS84, (metres)
 bool terrain_alt_valid		# Terrain altitude estimate is valid
 bool dead_reckoning		# True if this position is estimated through dead-reckoning

--- a/msg/vehicle_local_position.msg
+++ b/msg/vehicle_local_position.msg
@@ -59,5 +59,7 @@ uint64 surface_bottom_timestamp		# Time when new bottom surface found since syst
 bool dist_bottom_valid			# true if distance to bottom surface is valid
 float32 eph				# Standard deviation of horizontal position error, (metres)
 float32 epv				# Standard deviation of vertical position error, (metres)
+float32 evh				# Standard deviation of horizontal velocity error, (metres/sec)
+float32 evv				# Standard deviation of horizontal velocity error, (metres/sec)
 
 # TOPICS vehicle_local_position vehicle_local_position_groundtruth vehicle_vision_position

--- a/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
+++ b/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
@@ -955,6 +955,12 @@ void AttitudePositionEstimatorEKF::publishLocalPosition()
 	_local_pos.v_z_valid = true;
 	_local_pos.xy_global = _gps_initialized; //TODO: Handle optical flow mode here
 
+	// TODO provide calculated values for these
+	_local_pos.eph = 0.0f;
+	_local_pos.epv = 0.0f;
+	_local_pos.evh = 0.0f;
+	_local_pos.evv = 0.0f;
+
 	_local_pos.z_global = false;
 	matrix::Eulerf euler = matrix::Quatf(_ekf->states[0], _ekf->states[1], _ekf->states[2], _ekf->states[3]);
 	_local_pos.yaw = euler.psi();
@@ -1054,6 +1060,10 @@ void AttitudePositionEstimatorEKF::publishGlobalPosition()
 		// bad data, abort publication
 		return;
 	}
+
+	// TODO provide calculated values for these
+	_global_pos.evh = 0.0f;
+	_global_pos.evv = 0.0f;
 
 	/* lazily publish the global position only once available */
 	if (_global_pos_pub != nullptr) {

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -448,7 +448,7 @@ static bool gnssCheck(orb_advert_t *mavlink_log_pub, bool report_fail)
 	return success;
 }
 
-static bool ekf2Check(orb_advert_t *mavlink_log_pub, bool optional, bool report_fail)
+static bool ekf2Check(orb_advert_t *mavlink_log_pub, bool optional, bool report_fail, bool enforce_gps_required)
 {
 	// Get estimator status data if available and exit with a fail recorded if not
 	int sub = orb_subscribe(ORB_ID(estimator_status));
@@ -489,6 +489,31 @@ static bool ekf2Check(orb_advert_t *mavlink_log_pub, bool optional, bool report_
 		}
 		success = false;
 		goto out;
+	}
+
+	// If GPS aiding is required, declare fault condition if the EKF is not using GPS
+	if (enforce_gps_required) {
+		if (!(status.control_mode_flags & 2)) {
+			if (report_fail) {
+				mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: EKF NOT USING GPS");
+			}
+			success = false;
+			goto out;
+		}
+	}
+
+	// If GPS aiding is required, declare fault condition if the required GPS quality checks are failing
+	if (enforce_gps_required) {
+		if ((status.gps_check_fail_flags & (estimator_status_s::GPS_CHECK_FAIL_MIN_SAT_COUNT
+						    | estimator_status_s::GPS_CHECK_FAIL_MIN_GDOP
+						    | estimator_status_s::GPS_CHECK_FAIL_MAX_HORZ_ERR
+						    | estimator_status_s::GPS_CHECK_FAIL_MAX_VERT_ERR)) > 0) {
+			if (report_fail) {
+				mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: GPS QUALITY CHECKS");
+			}
+			success = false;
+			goto out;
+		}
 	}
 
 	// check magnetometer innovation test ratio
@@ -694,7 +719,7 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkMag, bool checkAcc,
 	int32_t estimator_type;
 	param_get(param_find("SYS_MC_EST_GROUP"), &estimator_type);
 	if (estimator_type == 2 && checkGNSS) {
-		if (!ekf2Check(mavlink_log_pub, true, reportFailures)) {
+		if (!ekf2Check(mavlink_log_pub, true, reportFailures, checkGNSS)) {
 			failed = true;
 		}
 	}

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -158,6 +158,18 @@ static constexpr uint8_t COMMANDER_MAX_GPS_NOISE = 60;		/**< Maximum percentage 
 #define HIL_ID_MIN 1000
 #define HIL_ID_MAX 1999
 
+/* Controls the probation period which is the amount of time required for position and velocity checks to pass before the validity can be changed from false to true*/
+#define POSVEL_PROBATION_TAKEOFF 30E6		/**< probation duration set at takeoff (usec) */
+#define POSVEL_PROBATION_MIN 1E6		/**< minimum probation duration (usec) */
+#define POSVEL_PROBATION_MAX 100E6		/**< maximum probation duration (usec) */
+#define POSVEL_VALID_PROBATION_FACTOR 10	/**< the rate at which the probation duration is increased while checks are failing */
+
+/* Probation times for position and velocity validity checks to pass if failed */
+static int64_t gpos_probation_time_us = POSVEL_PROBATION_TAKEOFF;
+static int64_t gvel_probation_time_us = POSVEL_PROBATION_TAKEOFF;
+static int64_t lpos_probation_time_us = POSVEL_PROBATION_TAKEOFF;
+static int64_t lvel_probation_time_us = POSVEL_PROBATION_TAKEOFF;
+
 /* Mavlink log uORB handle */
 static orb_advert_t mavlink_log_pub = nullptr;
 
@@ -178,8 +190,14 @@ static uint64_t last_print_mode_reject_time = 0;
 
 static systemlib::Hysteresis auto_disarm_hysteresis(false);
 
-static float eph_threshold = 5.0f;
-static float epv_threshold = 10.0f;
+static float eph_threshold = 5.0f;	// Horizontal position error threshold (m)
+static float epv_threshold = 10.0f;	// Vertivcal position error threshold (m)
+static float evh_threshold = 1.0f;	// Horizontal velocity error threshold (m)
+
+static uint64_t last_lpos_fail_time_us = 0;	// Last time that the local position validity recovery check failed (usec)
+static uint64_t last_gpos_fail_time_us = 0;	// Last time that the global position validity recovery check failed (usec)
+static uint64_t last_lvel_fail_time_us = 0;	// Last time that the local velocity validity recovery check failed (usec)
+static uint64_t last_gvel_fail_time_us = 0;	// Last time that the global velocity validity recovery check failed (usec)
 
 /* pre-flight EKF checks */
 static float max_ekf_pos_ratio = 0.5f;
@@ -230,6 +248,7 @@ static float avionics_power_rail_voltage;		// voltage of the avionics power rail
 static bool can_arm_without_gps = false;
 static bool _last_condition_global_position_valid = false;
 
+static struct vehicle_land_detected_s land_detector = {};
 
 /**
  * The daemon app only briefly exists to start
@@ -255,7 +274,8 @@ bool handle_command(struct vehicle_status_s *status, const struct safety_s *safe
 		    struct actuator_armed_s *armed, struct home_position_s *home, struct vehicle_global_position_s *global_pos,
 		    struct vehicle_local_position_s *local_pos, struct vehicle_attitude_s *attitude, orb_advert_t *home_pub,
 		    orb_advert_t *command_ack_pub, struct vehicle_command_ack_s *command_ack, struct vehicle_roi_s *roi,
-			orb_advert_t *roi_pub);
+			orb_advert_t *roi_pub,
+		    bool *changed);
 
 /**
  * Mainloop of commander.
@@ -269,7 +289,13 @@ void get_circuit_breaker_params();
 
 void check_valid(hrt_abstime timestamp, hrt_abstime timeout, bool valid_in, bool *valid_out, bool *changed);
 
-transition_result_t set_main_state_rc(struct vehicle_status_s *status);
+transition_result_t set_main_state_rc(struct vehicle_status_s *status, vehicle_global_position_s *global_position, vehicle_local_position_s *local_position, bool *changed);
+
+void reset_posvel_validity(vehicle_global_position_s *global_position, vehicle_local_position_s *local_position, bool *changed);
+
+void check_global_posvel_validity(vehicle_global_position_s *global_position, bool *changed);
+
+void check_local_posvel_validity(vehicle_local_position_s *local_position, bool *changed);
 
 void set_control_mode();
 
@@ -329,7 +355,7 @@ int commander_main(int argc, char *argv[])
 		daemon_task = px4_task_spawn_cmd("commander",
 					     SCHED_DEFAULT,
 					     SCHED_PRIORITY_DEFAULT + 40,
-					     3600,
+					     3700,
 					     commander_thread_main,
 					     (char * const *)&argv[0]);
 
@@ -689,7 +715,7 @@ bool handle_command(struct vehicle_status_s *status_local, const struct safety_s
 		    struct home_position_s *home, struct vehicle_global_position_s *global_pos,
 		    struct vehicle_local_position_s *local_pos, struct vehicle_attitude_s *attitude, orb_advert_t *home_pub,
 		    orb_advert_t *command_ack_pub, struct vehicle_command_ack_s *command_ack,
-			struct vehicle_roi_s *roi, orb_advert_t *roi_pub)
+			struct vehicle_roi_s *roi, orb_advert_t *roi_pub, bool *changed)
 {
 	/* only handle commands that are meant to be handled by this system and component */
 	if (cmd->target_system != status_local->system_id || ((cmd->target_component != status_local->component_id)
@@ -754,11 +780,13 @@ bool handle_command(struct vehicle_status_s *status_local, const struct safety_s
 
 				} else if (custom_main_mode == PX4_CUSTOM_MAIN_MODE_POSCTL) {
 					/* POSCTL */
+					reset_posvel_validity(global_pos, local_pos, changed);
 					main_ret = main_state_transition(status_local, commander_state_s::MAIN_STATE_POSCTL, main_state_prev, &status_flags, &internal_state);
 
 				} else if (custom_main_mode == PX4_CUSTOM_MAIN_MODE_AUTO) {
 					/* AUTO */
 					if (custom_sub_mode > 0) {
+						reset_posvel_validity(global_pos, local_pos, changed);
 						switch(custom_sub_mode) {
 						case PX4_CUSTOM_SUB_MODE_AUTO_LOITER:
 							main_ret = main_state_transition(status_local, commander_state_s::MAIN_STATE_AUTO_LOITER, main_state_prev, &status_flags, &internal_state);
@@ -802,6 +830,7 @@ bool handle_command(struct vehicle_status_s *status_local, const struct safety_s
 					main_ret = main_state_transition(status_local, commander_state_s::MAIN_STATE_STAB, main_state_prev, &status_flags, &internal_state);
 
 				} else if (custom_main_mode == PX4_CUSTOM_MAIN_MODE_OFFBOARD) {
+					reset_posvel_validity(global_pos, local_pos, changed);
 					/* OFFBOARD */
 					main_ret = main_state_transition(status_local, commander_state_s::MAIN_STATE_OFFBOARD, main_state_prev, &status_flags, &internal_state);
 				}
@@ -1424,6 +1453,13 @@ int commander_thread_main(int argc, char *argv[])
 	status_flags.circuit_breaker_engaged_gpsfailure_check = false;
 	get_circuit_breaker_params();
 
+	/* Set position and velocity validty to false */
+	status_flags.condition_global_position_valid = false;
+	status_flags.condition_global_velocity_valid = false;
+	status_flags.condition_local_position_valid = false;
+	status_flags.condition_local_velocity_valid = false;
+	status_flags.condition_local_altitude_valid = false;
+
 	// initialize gps failure to false if circuit breaker enabled
 	if (status_flags.circuit_breaker_engaged_gpsfailure_check) {
 		status_flags.gps_failure = false;
@@ -1564,7 +1600,6 @@ int commander_thread_main(int argc, char *argv[])
 
 	/* Subscribe to land detector */
 	int land_detector_sub = orb_subscribe(ORB_ID(vehicle_land_detected));
-	struct vehicle_land_detected_s land_detector = {};
 	land_detector.landed = true;
 
 	/*
@@ -2072,85 +2107,44 @@ int commander_thread_main(int argc, char *argv[])
 			status_changed = true;
 		}
 
+		// Check if quality checking of position accuracy and consistency is to be performed
+		bool run_quality_checks = !status_flags.circuit_breaker_engaged_posfailure_check;
+
 		/* update global position estimate */
-		orb_check(global_position_sub, &updated);
+		bool gpos_updated =  false;
+		orb_check(global_position_sub, &gpos_updated);
 
-		if (updated) {
+		if (gpos_updated) {
 			/* position changed */
-			vehicle_global_position_s gpos;
-			orb_copy(ORB_ID(vehicle_global_position), global_position_sub, &gpos);
+			orb_copy(ORB_ID(vehicle_global_position), global_position_sub, &global_position);
 
-			/* copy to global struct if valid, with hysteresis */
-
-			// XXX consolidate this with local position handling and timeouts after release
-			// but we want a low-risk change now.
-			if (status_flags.condition_global_position_valid) {
-				if (gpos.eph < eph_threshold * 2.5f) {
-					orb_copy(ORB_ID(vehicle_global_position), global_position_sub, &global_position);
-				}
-			} else {
-				if (gpos.eph < eph_threshold) {
-					orb_copy(ORB_ID(vehicle_global_position), global_position_sub, &global_position);
-				}
+			if (run_quality_checks) {
+				check_global_posvel_validity(&global_position, &status_changed);
 			}
 		}
 
 		/* update local position estimate */
-		orb_check(local_position_sub, &updated);
+		bool lpos_updated = false;
+		orb_check(local_position_sub, &lpos_updated);
 
-		if (updated) {
+		if (lpos_updated) {
 			/* position changed */
 			orb_copy(ORB_ID(vehicle_local_position), local_position_sub, &local_position);
+
+			if (run_quality_checks) {
+				check_local_posvel_validity(&local_position, &status_changed);
+			}
 		}
 
 		/* update attitude estimate */
 		orb_check(attitude_sub, &updated);
 
 		if (updated) {
-			/* position changed */
+			/* attitude changed */
 			orb_copy(ORB_ID(vehicle_attitude), attitude_sub, &attitude);
 		}
 
-		//update condition_global_position_valid
-		//Global positions are only published by the estimators if they are valid
-		if (hrt_absolute_time() - global_position.timestamp > POSITION_TIMEOUT) {
-			//We have had no good fix for POSITION_TIMEOUT amount of time
-			if (status_flags.condition_global_position_valid) {
-				set_tune_override(TONE_GPS_WARNING_TUNE);
-				status_changed = true;
-				status_flags.condition_global_position_valid = false;
-			}
-		} else if (global_position.timestamp != 0) {
-			// Got good global position estimate
-			if (!status_flags.condition_global_position_valid) {
-				status_changed = true;
-				status_flags.condition_global_position_valid = true;
-			}
-		}
-
-		/* update condition_local_position_valid and condition_local_altitude_valid */
-		/* hysteresis for EPH */
-		bool local_eph_good;
-
-		if (status_flags.condition_local_position_valid) {
-			if (local_position.eph > eph_threshold * 2.5f) {
-				local_eph_good = false;
-
-			} else {
-				local_eph_good = true;
-			}
-
-		} else {
-			if (local_position.eph < eph_threshold) {
-				local_eph_good = true;
-
-			} else {
-				local_eph_good = false;
-			}
-		}
-
-		check_valid(local_position.timestamp, POSITION_TIMEOUT, local_position.xy_valid
-			    && local_eph_good, &(status_flags.condition_local_position_valid), &status_changed);
+		/* update condition_local_altitude_valid */
 		check_valid(local_position.timestamp, POSITION_TIMEOUT, local_position.z_valid,
 			    &(status_flags.condition_local_altitude_valid), &status_changed);
 
@@ -2165,6 +2159,14 @@ int commander_thread_main(int argc, char *argv[])
 				} else {
 					mavlink_and_console_log_info(&mavlink_log_pub, "Takeoff detected");
 					have_taken_off_since_arming = true;
+
+					// Set all position and velocity test probation durations to takeoff value
+					// This is a larger value to give the vehicle time to complete a failsafe landing
+					// if faulty sensors cause loss of navigatio shortly after takeoff.
+					gpos_probation_time_us = POSVEL_PROBATION_TAKEOFF;
+					gvel_probation_time_us = POSVEL_PROBATION_TAKEOFF;
+					lpos_probation_time_us = POSVEL_PROBATION_TAKEOFF;
+					lvel_probation_time_us = POSVEL_PROBATION_TAKEOFF;
 				}
 			}
 
@@ -2374,12 +2376,8 @@ int commander_thread_main(int argc, char *argv[])
 
 
 		/*
-		 * Check for valid position information.
-		 *
-		 * If the system has a valid position source from an onboard
-		 * position estimator, it is safe to operate it autonomously.
-		 * The flag_vector_flight_mode_ok flag indicates that a minimum
-		 * set of position measurements is available.
+		 * Check GPS fix quality. Note that this check augments the position validity
+		 * checks and adds an additional level of protection.
 		 */
 
 		orb_check(gps_sub, &updated);
@@ -2414,6 +2412,7 @@ int commander_thread_main(int argc, char *argv[])
 				}
 			}
 
+			// Check fix type and data freshness
 			if (gps_position.fix_type >= 3 && hrt_elapsed_time(&gps_position.timestamp) < FAILSAFE_DEFAULT_TIMEOUT) {
 				/* handle the case where gps was regained */
 				if (status_flags.gps_failure && !gpsIsNoisy) {
@@ -2429,6 +2428,7 @@ int commander_thread_main(int argc, char *argv[])
 				status_changed = true;
 				mavlink_log_critical(&mavlink_log_pub, "GPS fix lost");
 			}
+
 		}
 
 		/* start mission result check */
@@ -2752,7 +2752,7 @@ int commander_thread_main(int argc, char *argv[])
 
 			/* evaluate the main state machine according to mode switches */
 			bool first_rc_eval = (_last_sp_man.timestamp == 0) && (sp_man.timestamp > 0);
-			transition_result_t main_res = set_main_state_rc(&status);
+			transition_result_t main_res = set_main_state_rc(&status, &global_position, &local_position, &status_changed);
 
 			/* store last position lock state */
 			_last_condition_global_position_valid = status_flags.condition_global_position_valid;
@@ -2923,7 +2923,7 @@ int commander_thread_main(int argc, char *argv[])
 
 			/* handle it */
 			if (handle_command(&status, &safety, &cmd, &armed, &_home, &global_position, &local_position,
-					&attitude, &home_pub, &command_ack_pub, &command_ack, &_roi, &roi_pub)) {
+					&attitude, &home_pub, &command_ack_pub, &command_ack, &_roi, &roi_pub, &status_changed)) {
 				status_changed = true;
 			}
 		}
@@ -3192,6 +3192,7 @@ get_circuit_breaker_params()
 	status_flags.circuit_breaker_engaged_enginefailure_check = circuit_breaker_enabled("CBRK_ENGINEFAIL", CBRK_ENGINEFAIL_KEY);
 	status_flags.circuit_breaker_engaged_gpsfailure_check = circuit_breaker_enabled("CBRK_GPSFAIL", CBRK_GPSFAIL_KEY);
 	status_flags.circuit_breaker_flight_termination_disabled = circuit_breaker_enabled("CBRK_FLIGHTTERM", CBRK_FLIGHTTERM_KEY);
+	status_flags.circuit_breaker_engaged_posfailure_check = circuit_breaker_enabled("CBRK_VELPOSERR", CBRK_VELPOSERR_KEY);
 }
 
 void
@@ -3332,7 +3333,7 @@ control_status_leds(vehicle_status_s *status_local, const actuator_armed_s *actu
 }
 
 transition_result_t
-set_main_state_rc(struct vehicle_status_s *status_local)
+set_main_state_rc(struct vehicle_status_s *status_local, vehicle_global_position_s *global_position, vehicle_local_position_s *local_position, bool *changed)
 {
 	/* set main state according to RC switches */
 	transition_result_t res = TRANSITION_DENIED;
@@ -3380,6 +3381,10 @@ set_main_state_rc(struct vehicle_status_s *status_local)
 	}
 
 	_last_sp_man = sp_man;
+
+	// reset the position and velocity validity calculation to give the best change of being able to select
+	// the desired mode
+	reset_posvel_validity(global_position, local_position, changed);
 
 	/* offboard switch overrides main switch */
 	if (sp_man.offboard_switch == manual_control_setpoint_s::SWITCH_POS_ON) {
@@ -3704,6 +3709,216 @@ set_main_state_rc(struct vehicle_status_s *status_local)
 	}
 
 	return res;
+}
+
+void
+reset_posvel_validity(vehicle_global_position_s *global_position, vehicle_local_position_s *local_position, bool *changed)
+{
+	// reset all the check probation times back to the minimum value
+	gpos_probation_time_us = POSVEL_PROBATION_MIN;
+	gvel_probation_time_us = POSVEL_PROBATION_MIN;
+	lpos_probation_time_us = POSVEL_PROBATION_MIN;
+	lvel_probation_time_us = POSVEL_PROBATION_MIN;
+
+	// recheck validity
+	check_global_posvel_validity(global_position, changed);
+	check_local_posvel_validity(local_position, changed);
+}
+
+void
+check_global_posvel_validity(vehicle_global_position_s *global_position, bool *changed)
+{
+	bool global_pos_inaccurate = false;
+	bool global_vel_inaccurate = false;
+	bool hold_fail_state = false;
+
+	// Check position accuracy with hysteresis in both test level and time
+	bool pos_status_changed = false;
+	if (status_flags.condition_global_position_valid && global_position->eph > eph_threshold * 2.5f) {
+		global_pos_inaccurate = true;
+		pos_status_changed = true;
+		last_gpos_fail_time_us = hrt_absolute_time();
+	} else if (!status_flags.condition_global_position_valid) {
+		bool level_check_pass = global_position->eph < eph_threshold;
+		if (!level_check_pass || hold_fail_state) {
+			gpos_probation_time_us += (hrt_absolute_time() - last_gpos_fail_time_us) * POSVEL_VALID_PROBATION_FACTOR;
+			last_gpos_fail_time_us = hrt_absolute_time();
+		} else if (hrt_absolute_time() - last_gpos_fail_time_us > gpos_probation_time_us) {
+			global_pos_inaccurate = false;
+			pos_status_changed = true;
+			last_gpos_fail_time_us = 0;
+		}
+	} else {
+		gpos_probation_time_us -= (hrt_absolute_time() - last_gpos_fail_time_us);
+		last_gpos_fail_time_us = hrt_absolute_time();
+	}
+
+	// check global velocity accuracy with hysteresis in both test level and time
+	bool vel_status_changed = false;
+	if (status_flags.condition_global_velocity_valid && global_position->evh > evh_threshold * 2.5f) {
+		global_vel_inaccurate = true;
+		vel_status_changed = true;
+		last_gvel_fail_time_us = hrt_absolute_time();
+	} else if (!status_flags.condition_global_velocity_valid) {
+		bool check_level_pass = global_position->evh < evh_threshold;
+		if (!check_level_pass || hold_fail_state) {
+			gvel_probation_time_us += (hrt_absolute_time() - last_gvel_fail_time_us) * POSVEL_VALID_PROBATION_FACTOR;
+			last_gvel_fail_time_us = hrt_absolute_time();
+		} else if (hrt_absolute_time() - last_gvel_fail_time_us > gvel_probation_time_us) {
+			global_vel_inaccurate = false;
+			vel_status_changed = true;
+			last_gvel_fail_time_us = 0;
+		}
+	} else {
+		gvel_probation_time_us -= (hrt_absolute_time() - last_gvel_fail_time_us);
+		last_gvel_fail_time_us = hrt_absolute_time();
+	}
+
+	bool global_data_stale = (hrt_absolute_time() - global_position->timestamp > POSITION_TIMEOUT);
+
+	// Set global velocity validity
+	if (vel_status_changed) {
+		if (status_flags.condition_global_velocity_valid
+			   && (global_data_stale || global_vel_inaccurate)) {
+			status_flags.condition_global_position_valid = false;
+			*changed = true;
+		} else if (!status_flags.condition_global_velocity_valid
+			   && !global_data_stale
+			   && !global_vel_inaccurate) {
+			status_flags.condition_global_velocity_valid = true;
+			*changed = true;
+		}
+	}
+
+	// Set global position validity
+	if (pos_status_changed) {
+		if (status_flags.condition_global_position_valid
+			   && (global_data_stale || global_pos_inaccurate)) {
+			status_flags.condition_global_position_valid = false;
+			set_tune_override(TONE_GPS_WARNING_TUNE);
+			*changed = true;
+		} else if (!status_flags.condition_global_position_valid
+			   && !global_data_stale
+			   && !global_pos_inaccurate) {
+			status_flags.condition_global_position_valid = true;
+			*changed = true;
+		}
+	}
+
+	// constrain probation times
+	if (land_detector.landed) {
+		gpos_probation_time_us = POSVEL_PROBATION_MIN;
+		gvel_probation_time_us = POSVEL_PROBATION_MIN;
+	} else {
+		if (gpos_probation_time_us < POSVEL_PROBATION_MIN) {
+			gpos_probation_time_us = POSVEL_PROBATION_MIN;
+		} else if  (gpos_probation_time_us > POSVEL_PROBATION_MAX) {
+			gpos_probation_time_us = POSVEL_PROBATION_MAX;
+		}
+		if (gvel_probation_time_us < POSVEL_PROBATION_MIN) {
+			gvel_probation_time_us = POSVEL_PROBATION_MIN;
+		} else if  (gvel_probation_time_us > POSVEL_PROBATION_MAX) {
+			gvel_probation_time_us = POSVEL_PROBATION_MAX;
+		}
+	}
+}
+
+void
+check_local_posvel_validity(struct vehicle_local_position_s *local_position, bool *changed)
+{
+	bool local_pos_inaccurate = false;
+	bool local_vel_inaccurate = false;
+	bool hold_fail_state = false;
+
+	// Check local position accuracy with hysteresis in both test level and time
+	bool pos_status_changed = false;
+	if (status_flags.condition_local_position_valid && local_position->eph > eph_threshold * 2.5f) {
+		local_pos_inaccurate = true;
+		pos_status_changed = true;
+		last_lpos_fail_time_us = hrt_absolute_time();
+	} else if (!status_flags.condition_local_position_valid) {
+		bool level_check_pass = local_position->xy_valid && local_position->eph < eph_threshold;
+		if (!level_check_pass || hold_fail_state) {
+			lpos_probation_time_us += (hrt_absolute_time() - last_lpos_fail_time_us) * POSVEL_VALID_PROBATION_FACTOR;
+			last_lpos_fail_time_us = hrt_absolute_time();
+		} else if (hrt_absolute_time() - last_lpos_fail_time_us > lpos_probation_time_us) {
+			local_pos_inaccurate = false;
+			pos_status_changed = true;
+			last_lpos_fail_time_us = 0;
+		}
+	} else {
+		lpos_probation_time_us -= (hrt_absolute_time() - last_lpos_fail_time_us);
+		last_lpos_fail_time_us = hrt_absolute_time();
+	}
+
+	// Check local velocity accuracy with hysteresis
+	bool vel_status_changed = false;
+	if (status_flags.condition_local_velocity_valid && local_position->evh > evh_threshold * 2.5f) {
+		local_vel_inaccurate = true;
+		vel_status_changed = true;
+		last_lvel_fail_time_us =  hrt_absolute_time();
+	} else if (!status_flags.condition_local_velocity_valid) {
+		bool level_check_pass = local_position->v_xy_valid && local_position->evh < evh_threshold;
+		if (!level_check_pass || hold_fail_state) {
+			lvel_probation_time_us += (hrt_absolute_time() - last_lvel_fail_time_us) * POSVEL_VALID_PROBATION_FACTOR;
+			last_lvel_fail_time_us =  hrt_absolute_time();
+		} else if (hrt_absolute_time() - last_lvel_fail_time_us > lvel_probation_time_us) {
+			local_vel_inaccurate = false;
+			vel_status_changed = true;
+			last_lvel_fail_time_us = 0;
+		}
+	} else {
+		lvel_probation_time_us -= (hrt_absolute_time() - last_lvel_fail_time_us);
+		last_lvel_fail_time_us =  hrt_absolute_time();
+	}
+
+	bool local_data_stale = (hrt_absolute_time() - local_position->timestamp > POSITION_TIMEOUT);
+
+	// Set local velocity validity
+	if (vel_status_changed) {
+		if (status_flags.condition_local_velocity_valid
+			   && (local_data_stale || local_vel_inaccurate)) {
+			status_flags.condition_local_velocity_valid = false;
+			*changed = true;
+		} else if (!status_flags.condition_local_velocity_valid
+			   && !local_data_stale
+			   && !local_vel_inaccurate) {
+			status_flags.condition_local_velocity_valid = true;
+			*changed = true;
+		}
+	}
+
+	// Set local position validity
+	if (pos_status_changed) {
+		if (status_flags.condition_local_position_valid
+			   && (local_data_stale || !local_position->xy_valid || local_pos_inaccurate)) {
+			status_flags.condition_local_position_valid = false;
+			*changed = true;
+		} else if (!status_flags.condition_local_position_valid
+			   && !local_data_stale
+			   && !local_pos_inaccurate
+			   && local_position->xy_valid) {
+			status_flags.condition_local_position_valid = true;
+			*changed = true;
+		}
+	}
+
+	// constrain probation times
+	if (land_detector.landed) {
+		lpos_probation_time_us = POSVEL_PROBATION_MIN;
+		lvel_probation_time_us = POSVEL_PROBATION_MIN;
+	} else {
+		if (lpos_probation_time_us < POSVEL_PROBATION_MIN) {
+			lpos_probation_time_us = POSVEL_PROBATION_MIN;
+		} else if  (lpos_probation_time_us > POSVEL_PROBATION_MAX) {
+			lpos_probation_time_us = POSVEL_PROBATION_MAX;
+		}
+		if (lvel_probation_time_us < POSVEL_PROBATION_MIN) {
+			lvel_probation_time_us = POSVEL_PROBATION_MIN;
+		} else if  (lvel_probation_time_us > POSVEL_PROBATION_MAX) {
+			lvel_probation_time_us = POSVEL_PROBATION_MAX;
+		}
+	}
 }
 
 void

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -71,13 +71,15 @@ enum class link_loss_actions_t {
 struct status_flags_s {
     bool condition_calibration_enabled;
     bool condition_system_sensors_initialized;
-    bool condition_system_prearm_error_reported;        // true if errors have already been reported
-    bool condition_system_hotplug_timeout;                // true if the hotplug sensor search is over
+    bool condition_system_prearm_error_reported;	// true if errors have already been reported
+    bool condition_system_hotplug_timeout;		// true if the hotplug sensor search is over
     bool condition_system_returned_to_home;
     bool condition_auto_mission_available;
-    bool condition_global_position_valid;                // set to true by the commander app if the quality of the position estimate is good enough to use it for navigation
-    bool condition_home_position_valid;                // indicates a valid home position (a valid home position is not always a valid launch)
-    bool condition_local_position_valid;
+    bool condition_global_position_valid;		// set to true by the commander app if the quality of the global position estimate is good enough to use for navigation
+    bool condition_global_velocity_valid;		// set to true by the commander app if the quality of the global horizontal velocity data is good enough to use for navigation
+    bool condition_home_position_valid;			// indicates a valid home position (a valid home position is not always a valid launch)
+    bool condition_local_position_valid;		// set to true by the commander app if the quality of the local position estimate is good enough to use for navigation
+    bool condition_local_velocity_valid;		// set to true by the commander app if the quality of the local horizontal velocity data is good enough to use for navigation
     bool condition_local_altitude_valid;
     bool condition_airspeed_valid;                        // set to true by the commander app if there is a valid airspeed measurement available
     bool condition_power_input_valid;                // set if input power is valid
@@ -88,6 +90,7 @@ struct status_flags_s {
     bool circuit_breaker_engaged_gpsfailure_check;
     bool circuit_breaker_flight_termination_disabled;
     bool circuit_breaker_engaged_usb_check;
+    bool circuit_breaker_engaged_posfailure_check;	// set to true when the position valid checks have been disabled
     bool offboard_control_signal_found_once;
     bool offboard_control_signal_lost;
     bool offboard_control_signal_weak;
@@ -145,6 +148,16 @@ void set_rc_loss_nav_state(struct vehicle_status_s *status,
 			   struct actuator_armed_s *armed,
 			   status_flags_s *status_flags,
 			   const link_loss_actions_t link_loss_act);
+/*
+ * Checks the validty of position data aaainst the requirements of the current navigation
+ * mode and switches mode if position data required is not available.
+ */
+bool check_invalid_pos_nav_state(struct vehicle_status_s *status,
+			       bool old_failsafe,
+			       orb_advert_t *mavlink_log_pub,
+			       status_flags_s *status_flags,
+			       const bool use_rc, // true if a mode using RC control can be used as a fallback
+			       const bool using_global_pos); // true when the current mode requires a global position estimate
 
 void set_data_link_loss_nav_state(struct vehicle_status_s *status,
 				  struct actuator_armed_s *armed,

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -917,6 +917,79 @@ void Ekf2::task_main()
 				}
 			}
 
+			// publish estimator status
+			{
+				struct estimator_status_s status = {};
+				status.timestamp = hrt_absolute_time();
+				_ekf.get_state_delayed(status.states);
+				_ekf.get_covariances(status.covariances);
+				_ekf.get_gps_check_status(&status.gps_check_fail_flags);
+				_ekf.get_control_mode(&status.control_mode_flags);
+				_ekf.get_filter_fault_status(&status.filter_fault_flags);
+				_ekf.get_innovation_test_status(&status.innovation_check_flags, &status.mag_test_ratio,
+								&status.vel_test_ratio, &status.pos_test_ratio,
+								&status.hgt_test_ratio, &status.tas_test_ratio,
+								&status.hagl_test_ratio);
+
+				status.pos_horiz_accuracy = lpos.eph;
+				status.pos_vert_accuracy = lpos.epv;
+				_ekf.get_ekf_soln_status(&status.solution_status_flags);
+				_ekf.get_imu_vibe_metrics(status.vibe);
+
+				if (_estimator_status_pub == nullptr) {
+					_estimator_status_pub = orb_advertise(ORB_ID(estimator_status), &status);
+
+				} else {
+					orb_publish(ORB_ID(estimator_status), _estimator_status_pub, &status);
+				}
+
+				// Publish wind estimate
+				struct wind_estimate_s wind_estimate = {};
+				wind_estimate.timestamp = hrt_absolute_time();
+				wind_estimate.windspeed_north = status.states[22];
+				wind_estimate.windspeed_east = status.states[23];
+				wind_estimate.covariance_north = status.covariances[22];
+				wind_estimate.covariance_east = status.covariances[23];
+
+				if (_wind_pub == nullptr) {
+					_wind_pub = orb_advertise(ORB_ID(wind_estimate), &wind_estimate);
+
+				} else {
+					orb_publish(ORB_ID(wind_estimate), _wind_pub, &wind_estimate);
+				}
+			}
+
+			// publish estimator innovation data
+			{
+				struct ekf2_innovations_s innovations = {};
+				innovations.timestamp = hrt_absolute_time();
+				_ekf.get_vel_pos_innov(&innovations.vel_pos_innov[0]);
+				_ekf.get_mag_innov(&innovations.mag_innov[0]);
+				_ekf.get_heading_innov(&innovations.heading_innov);
+				_ekf.get_airspeed_innov(&innovations.airspeed_innov);
+				_ekf.get_beta_innov(&innovations.beta_innov);
+				_ekf.get_flow_innov(&innovations.flow_innov[0]);
+				_ekf.get_hagl_innov(&innovations.hagl_innov);
+
+				_ekf.get_vel_pos_innov_var(&innovations.vel_pos_innov_var[0]);
+				_ekf.get_mag_innov_var(&innovations.mag_innov_var[0]);
+				_ekf.get_heading_innov_var(&innovations.heading_innov_var);
+				_ekf.get_airspeed_innov_var(&innovations.airspeed_innov_var);
+				_ekf.get_beta_innov_var(&innovations.beta_innov_var);
+				_ekf.get_flow_innov_var(&innovations.flow_innov_var[0]);
+				_ekf.get_hagl_innov_var(&innovations.hagl_innov_var);
+
+				_ekf.get_output_tracking_error(&innovations.output_tracking_error[0]);
+
+				if (_estimator_innovations_pub == nullptr) {
+					_estimator_innovations_pub = orb_advertise(ORB_ID(ekf2_innovations), &innovations);
+
+				} else {
+					orb_publish(ORB_ID(ekf2_innovations), _estimator_innovations_pub, &innovations);
+				}
+
+			}
+
 		} else if (_replay_mode) {
 			// in replay mode we have to tell the replay module not to wait for an update
 			// we do this by publishing an attitude with zero timestamp
@@ -929,76 +1002,6 @@ void Ekf2::task_main()
 			} else {
 				orb_publish(ORB_ID(vehicle_attitude), _att_pub, &att);
 			}
-		}
-
-		// publish estimator status
-		struct estimator_status_s status = {};
-		status.timestamp = _replay_mode ? now : hrt_absolute_time();
-		_ekf.get_state_delayed(status.states);
-		_ekf.get_covariances(status.covariances);
-		_ekf.get_gps_check_status(&status.gps_check_fail_flags);
-		_ekf.get_control_mode(&status.control_mode_flags);
-		_ekf.get_filter_fault_status(&status.filter_fault_flags);
-		_ekf.get_innovation_test_status(&status.innovation_check_flags, &status.mag_test_ratio,
-						&status.vel_test_ratio, &status.pos_test_ratio,
-						&status.hgt_test_ratio, &status.tas_test_ratio,
-						&status.hagl_test_ratio);
-		bool dead_reckoning;
-		_ekf.get_ekf_accuracy(&status.pos_horiz_accuracy, &status.pos_vert_accuracy, &dead_reckoning);
-		_ekf.get_ekf_soln_status(&status.solution_status_flags);
-		_ekf.get_imu_vibe_metrics(status.vibe);
-
-		if (_estimator_status_pub == nullptr) {
-			_estimator_status_pub = orb_advertise(ORB_ID(estimator_status), &status);
-
-		} else {
-			orb_publish(ORB_ID(estimator_status), _estimator_status_pub, &status);
-		}
-
-		// Publish wind estimate
-		struct wind_estimate_s wind_estimate = {};
-		wind_estimate.timestamp = _replay_mode ? now : hrt_absolute_time();
-		wind_estimate.windspeed_north = status.states[22];
-		wind_estimate.windspeed_east = status.states[23];
-		wind_estimate.covariance_north = status.covariances[22];
-		wind_estimate.covariance_east = status.covariances[23];
-
-		if (_wind_pub == nullptr) {
-			_wind_pub = orb_advertise(ORB_ID(wind_estimate), &wind_estimate);
-
-		} else {
-			orb_publish(ORB_ID(wind_estimate), _wind_pub, &wind_estimate);
-		}
-
-		// publish estimator innovation data
-		{
-			struct ekf2_innovations_s innovations = {};
-			innovations.timestamp = _replay_mode ? now : hrt_absolute_time();
-			_ekf.get_vel_pos_innov(&innovations.vel_pos_innov[0]);
-			_ekf.get_mag_innov(&innovations.mag_innov[0]);
-			_ekf.get_heading_innov(&innovations.heading_innov);
-			_ekf.get_airspeed_innov(&innovations.airspeed_innov);
-			_ekf.get_beta_innov(&innovations.beta_innov);
-			_ekf.get_flow_innov(&innovations.flow_innov[0]);
-			_ekf.get_hagl_innov(&innovations.hagl_innov);
-
-			_ekf.get_vel_pos_innov_var(&innovations.vel_pos_innov_var[0]);
-			_ekf.get_mag_innov_var(&innovations.mag_innov_var[0]);
-			_ekf.get_heading_innov_var(&innovations.heading_innov_var);
-			_ekf.get_airspeed_innov_var(&innovations.airspeed_innov_var);
-			_ekf.get_beta_innov_var(&innovations.beta_innov_var);
-			_ekf.get_flow_innov_var(&innovations.flow_innov_var[0]);
-			_ekf.get_hagl_innov_var(&innovations.hagl_innov_var);
-
-			_ekf.get_output_tracking_error(&innovations.output_tracking_error[0]);
-
-			if (_estimator_innovations_pub == nullptr) {
-				_estimator_innovations_pub = orb_advertise(ORB_ID(ekf2_innovations), &innovations);
-
-			} else {
-				orb_publish(ORB_ID(ekf2_innovations), _estimator_innovations_pub, &innovations);
-			}
-
 		}
 
 		// save the declination to the EKF2_MAG_DECL parameter when a land event is detected

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -846,12 +846,9 @@ void Ekf2::task_main()
 			lpos.dist_bottom_rate = -velocity[2]; // Distance to bottom surface (ground) change rate
 			lpos.surface_bottom_timestamp	= hrt_absolute_time(); // Time when new bottom surface found
 
-			// TODO: uORB definition does not define what these variables are. We have assumed them to be horizontal and vertical 1-std dev accuracy in metres
-			Vector3f pos_var, vel_var;
-			_ekf.get_pos_var(pos_var);
-			_ekf.get_vel_var(vel_var);
-			lpos.eph = sqrtf(pos_var(0) + pos_var(1));
-			lpos.epv = sqrtf(pos_var(2));
+			bool dead_reckoning;
+			_ekf.get_ekf_lpos_accuracy(&lpos.eph, &lpos.epv, &dead_reckoning);
+			_ekf.get_ekf_vel_accuracy(&lpos.evh, &lpos.evv, &dead_reckoning);
 
 			// get state reset information of position and velocity
 			_ekf.get_posD_reset(&lpos.delta_z, &lpos.z_reset_counter);
@@ -895,8 +892,9 @@ void Ekf2::task_main()
 
 				global_pos.yaw = euler.psi(); // Yaw in radians -PI..+PI.
 
-				global_pos.eph = sqrtf(pos_var(0) + pos_var(1));; // Standard deviation of position estimate horizontally
-				global_pos.epv = sqrtf(pos_var(2)); // Standard deviation of position vertically
+				_ekf.get_ekf_gpos_accuracy(&global_pos.eph, &global_pos.epv, &global_pos.dead_reckoning);
+				global_pos.evh = lpos.evh;
+				global_pos.evv = lpos.evv;
 
 				if (lpos.dist_bottom_valid) {
 					global_pos.terrain_alt = lpos.ref_alt - terrain_vpos; // Terrain altitude in m, WGS84
@@ -907,8 +905,7 @@ void Ekf2::task_main()
 					global_pos.terrain_alt_valid = false; // Terrain altitude estimate is valid
 				}
 
-				// TODO use innovatun consistency check timouts to set this
-				global_pos.dead_reckoning = false; // True if this position is estimated through dead-reckoning
+				global_pos.dead_reckoning = _ekf.inertial_dead_reckoning(); // True if this position is estimated through dead-reckoning
 
 				global_pos.pressure_alt = sensors.baro_alt_meter; // Pressure altitude AMSL (m)
 

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -632,6 +632,9 @@ void BlockLocalPositionEstimator::publishLocalPos()
 		_pub_lpos.get().eph = eph;
 		_pub_lpos.get().epv = epv;
 		_pub_lpos.update();
+		//TODO provide calculated values for these
+		_pub_lpos.get().evh = 0.0f;
+		_pub_lpos.get().evv = 0.0f;
 	}
 }
 
@@ -699,6 +702,9 @@ void BlockLocalPositionEstimator::publishGlobalPos()
 		_pub_gpos.get().dead_reckoning = !(_estimatorInitialized & EST_XY);
 		_pub_gpos.get().pressure_alt = _sub_sensor.get().baro_alt_meter;
 		_pub_gpos.update();
+		// TODO provide calculated values for these
+		_pub_gpos.get().evh = 0.0f;
+		_pub_gpos.get().evv = 0.0f;
 	}
 }
 

--- a/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
@@ -1342,6 +1342,9 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 			local_pos.dist_bottom_valid = dist_bottom_valid;
 			local_pos.eph = eph;
 			local_pos.epv = epv;
+			// TODO provide calculated values for these
+			local_pos.evh = 0.0f;
+			local_pos.evv = 0.0f;
 
 			if (local_pos.dist_bottom_valid) {
 				local_pos.dist_bottom = dist_ground;
@@ -1372,6 +1375,10 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 
 				global_pos.eph = eph;
 				global_pos.epv = epv;
+
+				// TODO provide calculated values for these
+				global_pos.evh = 0.0f;
+				global_pos.evv = 0.0f;
 
 				if (terrain_estimator.is_valid()) {
 					global_pos.terrain_alt = global_pos.alt - terrain_estimator.get_distance_to_ground();

--- a/src/modules/systemlib/circuit_breaker.h
+++ b/src/modules/systemlib/circuit_breaker.h
@@ -57,6 +57,7 @@
 #define CBRK_ENGINEFAIL_KEY	284953
 #define CBRK_GPSFAIL_KEY	240024
 #define CBRK_USB_CHK_KEY	197848
+#define CBRK_VELPOSERR_KEY	201607
 
 #include <stdbool.h>
 

--- a/src/modules/systemlib/circuit_breaker_params.c
+++ b/src/modules/systemlib/circuit_breaker_params.c
@@ -169,3 +169,17 @@ PARAM_DEFINE_INT32(CBRK_BUZZER, 0);
  * @group Circuit Breaker
  */
 PARAM_DEFINE_INT32(CBRK_USB_CHK, 0);
+
+/**
+ * Circuit breaker for position error check
+ *
+ * Setting this parameter to 201607 will disable the position and velocity
+ * accuracy checks in the commander.
+ * WARNING: ENABLING THIS CIRCUIT BREAKER IS AT OWN RISK
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 201607
+ * @group Circuit Breaker
+ */
+PARAM_DEFINE_INT32(CBRK_VELPOSERR, 0);


### PR DESCRIPTION
Addresses a significant vulnerability to bad compass alignment or calibration that can cause a high speed flyaway on copters.

Replaces #6656 

Submitted for initial review and feedback.

TESTING

SITL testing performed with fallback from POSCTL and auto takeoff.
Loss of position estimation after takeoff in testing was induced by a 90 degree magnetic declination error added to the ecl EKF code.

