### PR TITLE
HOTFIX:Backport of upstream NuttX i2c fix

### DIFF
--- a/nuttx-patches/i2c_hotfix.patch
+++ b/nuttx-patches/i2c_hotfix.patch
@@ -1,0 +1,189 @@
+diff --git NuttX/nuttx/arch/arm/src/stm32/stm32_i2c.c NuttX/nuttx/arch/arm/src/stm32/stm32_i2c.c
+index 631ba66..654d18a 100644
+--- NuttX/nuttx/arch/arm/src/stm32/stm32_i2c.c
++++ NuttX/nuttx/arch/arm/src/stm32/stm32_i2c.c
+@@ -7,7 +7,7 @@
+  *
+  * With extensions, modifications by:
+  *
+- *   Copyright (C) 2011-2014, 2016 Gregory Nutt. All rights reserved.
++ *   Copyright (C) 2011-2014, 2016-2017 Gregory Nutt. All rights reserved.
+  *   Author: Gregory Nutt <gnutt@nuttx.org>
+  *
+  * Redistribution and use in source and binary forms, with or without
+@@ -670,15 +670,15 @@ static inline int stm32_i2c_sem_waitdone(FAR struct stm32_i2c_priv_s *priv)
+ 
+   do
+     {
++      /* Calculate the elapsed time */
++
++      elapsed = clock_systimer() - start;
++
+       /* Poll by simply calling the timer interrupt handler until it
+        * reports that it is done.
+        */
+ 
+       stm32_i2c_isr(priv);
+-
+-      /* Calculate the elapsed time */
+-
+-      elapsed = clock_systimer() - start;
+     }
+ 
+   /* Loop until the transfer is complete. */
+diff --git NuttX/nuttx/arch/arm/src/stm32/stm32_i2c_alt.c NuttX/nuttx/arch/arm/src/stm32/stm32_i2c_alt.c
+index 545a647..61cea4e 100644
+--- NuttX/nuttx/arch/arm/src/stm32/stm32_i2c_alt.c
++++ NuttX/nuttx/arch/arm/src/stm32/stm32_i2c_alt.c
+@@ -7,7 +7,7 @@
+  *
+  * With extensions, modifications by:
+  *
+- *   Copyright (C) 2011-2014, 2016 Gregory Nutt. All rights reserved.
++ *   Copyright (C) 2011-2014, 2016-2017 Gregory Nutt. All rights reserved.
+  *   Author: Gregory Nutt <gnutt@nuttx.org>
+  *
+  *   Copyright( C) 2014 Patrizio Simona. All rights reserved.
+@@ -678,15 +678,15 @@ static int stm32_i2c_sem_waitdone(FAR struct stm32_i2c_priv_s *priv)
+ 
+   do
+     {
++      /* Calculate the elapsed time */
++
++      elapsed = clock_systimer() - start;
++
+       /* Poll by simply calling the timer interrupt handler until it
+        * reports that it is done.
+        */
+ 
+       stm32_i2c_isr(priv);
+-
+-      /* Calculate the elapsed time */
+-
+-      elapsed = clock_systimer() - start;
+     }
+ 
+   /* Loop until the transfer is complete. */
+diff --git NuttX/nuttx/arch/arm/src/stm32/stm32f30xxx_i2c.c NuttX/nuttx/arch/arm/src/stm32/stm32f30xxx_i2c.c
+index 312e0b4..193ccb8 100644
+--- NuttX/nuttx/arch/arm/src/stm32/stm32f30xxx_i2c.c
++++ NuttX/nuttx/arch/arm/src/stm32/stm32f30xxx_i2c.c
+@@ -7,7 +7,7 @@
+  *
+  * With extensions and modifications for the F1, F2, and F4 by:
+  *
+- *   Copyright (C) 2011-2013, 2016 Gregory Nutt. All rights reserved.
++ *   Copyright (C) 2011-2013, 2016-2017 Gregory Nutt. All rights reserved.
+  *   Author: Gregroy Nutt <gnutt@nuttx.org>
+  *
+  * And this version for the STM32 F3 by
+@@ -704,15 +704,15 @@ static inline int stm32_i2c_sem_waitdone(FAR struct stm32_i2c_priv_s *priv)
+ 
+   do
+     {
++      /* Calculate the elapsed time */
++
++      elapsed = clock_systimer() - start;
++
+       /* Poll by simply calling the timer interrupt handler until it
+        * reports that it is done.
+        */
+ 
+       stm32_i2c_isr(priv);
+-
+-      /* Calculate the elapsed time */
+-
+-      elapsed = clock_systimer() - start;
+     }
+ 
+   /* Loop until the transfer is complete. */
+diff --git NuttX/nuttx/arch/arm/src/stm32/stm32f40xxx_i2c.c NuttX/nuttx/arch/arm/src/stm32/stm32f40xxx_i2c.c
+index 2bb715c..974fab8 100644
+--- NuttX/nuttx/arch/arm/src/stm32/stm32f40xxx_i2c.c
++++ NuttX/nuttx/arch/arm/src/stm32/stm32f40xxx_i2c.c
+@@ -7,7 +7,7 @@
+  *
+  * With extensions, modifications by:
+  *
+- *   Copyright (C) 2011-2014, 2016 Gregory Nutt. All rights reserved.
++ *   Copyright (C) 2011-2014, 2016-2017 Gregory Nutt. All rights reserved.
+  *   Author: Gregory Nutt <gnutt@nuttx.org>
+  *
+  * Redistribution and use in source and binary forms, with or without
+@@ -672,15 +672,15 @@ static inline int stm32_i2c_sem_waitdone(FAR struct stm32_i2c_priv_s *priv)
+ 
+   do
+     {
++      /* Calculate the elapsed time */
++
++      elapsed = clock_systimer() - start;
++
+       /* Poll by simply calling the timer interrupt handler until it
+        * reports that it is done.
+        */
+ 
+       stm32_i2c_isr(priv);
+-
+-      /* Calculate the elapsed time */
+-
+-      elapsed = clock_systimer() - start;
+     }
+ 
+   /* Loop until the transfer is complete. */
+diff --git NuttX/nuttx/arch/arm/src/stm32f7/stm32_i2c.c NuttX/nuttx/arch/arm/src/stm32f7/stm32_i2c.c
+index d089db9..1b5951d 100644
+--- NuttX/nuttx/arch/arm/src/stm32f7/stm32_i2c.c
++++ NuttX/nuttx/arch/arm/src/stm32f7/stm32_i2c.c
+@@ -897,15 +897,15 @@ static inline int stm32_i2c_sem_waitdone(FAR struct stm32_i2c_priv_s *priv)
+ 
+   do
+     {
++      /* Calculate the elapsed time */
++
++      elapsed = clock_systimer() - start;
++
+       /* Poll by simply calling the timer interrupt handler until it
+        * reports that it is done.
+        */
+ 
+       stm32_i2c_isr(priv);
+-
+-      /* Calculate the elapsed time */
+-
+-      elapsed = clock_systimer() - start;
+     }
+ 
+   /* Loop until the transfer is complete. */
+diff --git NuttX/nuttx/arch/arm/src/stm32l4/stm32l4_i2c.c NuttX/nuttx/arch/arm/src/stm32l4/stm32l4_i2c.c
+index eed199f..d5027bf 100644
+--- NuttX/nuttx/arch/arm/src/stm32l4/stm32l4_i2c.c
++++ NuttX/nuttx/arch/arm/src/stm32l4/stm32l4_i2c.c
+@@ -4,7 +4,7 @@
+  *
+  *   Copyright (C) 2011 Uros Platise. All rights reserved.
+  *   Author: Uros Platise <uros.platise@isotel.eu>
+- *   Copyright (C) 2011-2013, 2016 Gregory Nutt. All rights reserved.
++ *   Copyright (C) 2011-2013, 2016-2017 Gregory Nutt. All rights reserved.
+  *   Author: Gregroy Nutt <gnutt@nuttx.org>
+  *   Author: John Wharington
+  *   Author: Sebastien Lorquet
+@@ -648,15 +648,15 @@ static inline int stm32l4_i2c_sem_waitdone(FAR struct stm32l4_i2c_priv_s *priv)
+ 
+   do
+     {
++      /* Calculate the elapsed time */
++
++      elapsed = clock_systimer() - start;
++
+       /* Poll by simply calling the timer interrupt handler until it
+        * reports that it is done.
+        */
+ 
+       stm32l4_i2c_isr(priv);
+-
+-      /* Calculate the elapsed time */
+-
+-      elapsed = clock_systimer() - start;
+     }
+ 
+   /* Loop until the transfer is complete. */


### PR DESCRIPTION
   5a6d95dd9f051be548a8d2378aaef75f0a1ba5e1 and ee5ae3a57dbbe835584f164c956e0374da1ed2eb

   Thanks to Freddie Chopin

   Applies to STM32F4 and STM32F7

   Save elapsed time before handling I2C in stm32_i2c_sem_waitdone()
   It is possible that a context switch occurs after stm32_i2c_isr() call
   but before elapsed time is saved in stm32_i2c_sem_waitdone(). It is then
   possible that the handling code was executed only once with "elapsed
   time" equal 0. When scheduler resumes this thread it is quite possible
   that now "elapsed time" will be well above timeout threshold. In that
   case the function returns and reports a timeout, even though the
   handling code was not executed "recently".
   Fix this by inverting the order of operations in the loop - save elapsed
  time before handling I2C. This way a context switch anywhere in the loop
  will not cause an erroneous "timeout" error.