### PR TITLE
logger: reduce rate of some topics

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -547,41 +547,41 @@ void Logger::add_default_topics()
 
 	// Note: try to avoid setting the interval where possible, as it increases RAM usage
 
-	add_topic("vehicle_attitude", 10);
-	add_topic("actuator_outputs", 50);
+	add_topic("vehicle_attitude", 30);
+	add_topic("actuator_outputs", 100);
 	add_topic("telemetry_status");
 	add_topic("vehicle_command");
 	add_topic("vtol_vehicle_status", 100);
 	add_topic("commander_state", 100);
 	add_topic("satellite_info");
-	add_topic("vehicle_attitude_setpoint", 20);
-	add_topic("vehicle_rates_setpoint", 10);
-	add_topic("actuator_controls_0", 20);
-	add_topic("actuator_controls_1", 20);
+	add_topic("vehicle_attitude_setpoint", 50);
+	add_topic("vehicle_rates_setpoint", 30);
+	add_topic("actuator_controls_0", 100);
+	add_topic("actuator_controls_1", 100);
 	add_topic("vehicle_local_position", 100);
-	add_topic("vehicle_local_position_setpoint", 50);
-	add_topic("vehicle_global_position", 100);
-	add_topic("vehicle_global_velocity_setpoint", 100);
+	add_topic("vehicle_local_position_setpoint", 200);
+	add_topic("vehicle_global_position", 200);
+	add_topic("vehicle_global_velocity_setpoint", 200);
 	add_topic("vehicle_vision_position");
 	add_topic("vehicle_vision_attitude");
 	add_topic("battery_status", 300);
 	add_topic("system_power", 300);
-	add_topic("position_setpoint_triplet", 10);
+	add_topic("position_setpoint_triplet", 30);
 	add_topic("att_pos_mocap", 50);
 	add_topic("optical_flow", 50);
-	add_topic("rc_channels");
-	add_topic("input_rc");
+	add_topic("rc_channels", 100);
+	add_topic("input_rc", 100);
 	add_topic("differential_pressure", 50);
-	add_topic("esc_status", 20);
-	add_topic("estimator_status", 50); //this one is large
-	add_topic("ekf2_innovations", 20);
+	add_topic("esc_status", 250);
+	add_topic("estimator_status", 200); //this one is large
+	add_topic("ekf2_innovations", 50);
 	add_topic("tecs_status", 20);
 	add_topic("wind_estimate", 100);
-	add_topic("control_state", 20);
+	add_topic("control_state", 100);
 	add_topic("camera_trigger");
 	add_topic("cpuload");
 	add_topic("gps_dump"); //this will only be published if GPS_DUMP_COMM is set
-	add_topic("sensor_preflight");
+	add_topic("sensor_preflight", 50);
 	add_topic("task_stack_info");
 
 	/* for estimator replay (need to be at full rate) */


### PR DESCRIPTION
Reduces dropouts, bandwidth requirements and log file size.

Should some of them be too low, we can adjust them again (@priseborough @tumbili )