### PR TITLE
HOTFIX:Backport of second round upstream NuttX i2c fix

### DIFF
--- a/nuttx-patches/i2c_hotfix.patch
+++ b/nuttx-patches/i2c_hotfix.patch
@@ -1,5 +1,5 @@
 diff --git NuttX/nuttx/arch/arm/src/stm32/stm32_i2c.c NuttX/nuttx/arch/arm/src/stm32/stm32_i2c.c
-index 631ba66..654d18a 100644
+index 631ba66..669e0db 100644
 --- NuttX/nuttx/arch/arm/src/stm32/stm32_i2c.c
 +++ NuttX/nuttx/arch/arm/src/stm32/stm32_i2c.c
 @@ -7,7 +7,7 @@
@@ -31,8 +31,30 @@ index 631ba66..654d18a 100644
      }
  
    /* Loop until the transfer is complete. */
+@@ -729,6 +729,10 @@ static inline void stm32_i2c_sem_waitstop(FAR struct stm32_i2c_priv_s *priv)
+   start = clock_systimer();
+   do
+     {
++      /* Calculate the elapsed time */
++
++      elapsed = clock_systimer() - start;
++
+       /* Check for STOP condition */
+ 
+       cr1 = stm32_i2c_getreg(priv, STM32_I2C_CR1_OFFSET);
+@@ -744,10 +748,6 @@ static inline void stm32_i2c_sem_waitstop(FAR struct stm32_i2c_priv_s *priv)
+         {
+           return;
+         }
+-
+-      /* Calculate the elapsed time */
+-
+-      elapsed = clock_systimer() - start;
+     }
+ 
+   /* Loop until the stop is complete or a timeout occurs. */
 diff --git NuttX/nuttx/arch/arm/src/stm32/stm32_i2c_alt.c NuttX/nuttx/arch/arm/src/stm32/stm32_i2c_alt.c
-index 545a647..61cea4e 100644
+index 545a647..981edb6 100644
 --- NuttX/nuttx/arch/arm/src/stm32/stm32_i2c_alt.c
 +++ NuttX/nuttx/arch/arm/src/stm32/stm32_i2c_alt.c
 @@ -7,7 +7,7 @@
@@ -64,8 +86,29 @@ index 545a647..61cea4e 100644
      }
  
    /* Loop until the transfer is complete. */
+@@ -737,6 +737,10 @@ static inline void stm32_i2c_sem_waitstop(FAR struct stm32_i2c_priv_s *priv)
+   start = clock_systimer();
+   do
+     {
++      /* Calculate the elapsed time */
++
++      elapsed = clock_systimer() - start;
++
+       /* Check for STOP condition */
+ 
+       cr1 = stm32_i2c_getreg(priv, STM32_I2C_CR1_OFFSET);
+@@ -753,9 +757,6 @@ static inline void stm32_i2c_sem_waitstop(FAR struct stm32_i2c_priv_s *priv)
+           return;
+         }
+ 
+-      /* Calculate the elapsed time */
+-
+-      elapsed = clock_systimer() - start;
+     }
+ 
+   /* Loop until the stop is complete or a timeout occurs. */
 diff --git NuttX/nuttx/arch/arm/src/stm32/stm32f30xxx_i2c.c NuttX/nuttx/arch/arm/src/stm32/stm32f30xxx_i2c.c
-index 312e0b4..193ccb8 100644
+index 312e0b4..b2da861 100644
 --- NuttX/nuttx/arch/arm/src/stm32/stm32f30xxx_i2c.c
 +++ NuttX/nuttx/arch/arm/src/stm32/stm32f30xxx_i2c.c
 @@ -7,7 +7,7 @@
@@ -97,8 +140,29 @@ index 312e0b4..193ccb8 100644
      }
  
    /* Loop until the transfer is complete. */
+@@ -844,6 +844,10 @@ static inline void stm32_i2c_sem_waitstop(FAR struct stm32_i2c_priv_s *priv)
+   start = clock_systimer();
+   do
+     {
++      /* Calculate the elapsed time */
++
++      elapsed = clock_systimer() - start;
++
+       /* Check for STOP condition */
+ 
+       cr = stm32_i2c_getreg32(priv, STM32_I2C_CR2_OFFSET);
+@@ -860,9 +864,6 @@ static inline void stm32_i2c_sem_waitstop(FAR struct stm32_i2c_priv_s *priv)
+           return;
+         }
+ 
+-      /* Calculate the elapsed time */
+-
+-      elapsed = clock_systimer() - start;
+     }
+ 
+   /* Loop until the stop is complete or a timeout occurs. */
 diff --git NuttX/nuttx/arch/arm/src/stm32/stm32f40xxx_i2c.c NuttX/nuttx/arch/arm/src/stm32/stm32f40xxx_i2c.c
-index 2bb715c..974fab8 100644
+index 2bb715c..e91058a 100644
 --- NuttX/nuttx/arch/arm/src/stm32/stm32f40xxx_i2c.c
 +++ NuttX/nuttx/arch/arm/src/stm32/stm32f40xxx_i2c.c
 @@ -7,7 +7,7 @@
@@ -130,10 +194,40 @@ index 2bb715c..974fab8 100644
      }
  
    /* Loop until the transfer is complete. */
+@@ -731,6 +731,10 @@ static inline void stm32_i2c_sem_waitstop(FAR struct stm32_i2c_priv_s *priv)
+   start = clock_systimer();
+   do
+     {
++      /* Calculate the elapsed time */
++
++      elapsed = clock_systimer() - start;
++
+       /* Check for STOP condition */
+ 
+       cr1 = stm32_i2c_getreg(priv, STM32_I2C_CR1_OFFSET);
+@@ -747,9 +751,6 @@ static inline void stm32_i2c_sem_waitstop(FAR struct stm32_i2c_priv_s *priv)
+           return;
+         }
+ 
+-      /* Calculate the elapsed time */
+-
+-      elapsed = clock_systimer() - start;
+     }
+ 
+   /* Loop until the stop is complete or a timeout occurs. */
 diff --git NuttX/nuttx/arch/arm/src/stm32f7/stm32_i2c.c NuttX/nuttx/arch/arm/src/stm32f7/stm32_i2c.c
-index d089db9..1b5951d 100644
+index d089db9..fd73457 100644
 --- NuttX/nuttx/arch/arm/src/stm32f7/stm32_i2c.c
 +++ NuttX/nuttx/arch/arm/src/stm32f7/stm32_i2c.c
+@@ -7,7 +7,7 @@
+  *
+  * With extensions and modifications for the F1, F2, and F4 by:
+  *
+- *   Copyright (C) 2016 Gregory Nutt. All rights reserved.
++ *   Copyright (C) 2016-2017 Gregory Nutt. All rights reserved.
+  *   Authors: Gregroy Nutt <gnutt@nuttx.org>
+  *            John Wharington
+  *            David Sidrane <david_s5@nscdg.com>
 @@ -897,15 +897,15 @@ static inline int stm32_i2c_sem_waitdone(FAR struct stm32_i2c_priv_s *priv)
  
    do
@@ -154,8 +248,29 @@ index d089db9..1b5951d 100644
      }
  
    /* Loop until the transfer is complete. */
+@@ -1034,6 +1034,10 @@ static inline void stm32_i2c_sem_waitstop(FAR struct stm32_i2c_priv_s *priv)
+   start = clock_systimer();
+   do
+     {
++      /* Calculate the elapsed time */
++
++      elapsed = clock_systimer() - start;
++
+       /* Check for STOP condition */
+ 
+       cr = stm32_i2c_getreg32(priv, STM32_I2C_CR2_OFFSET);
+@@ -1050,9 +1054,6 @@ static inline void stm32_i2c_sem_waitstop(FAR struct stm32_i2c_priv_s *priv)
+           return;
+         }
+ 
+-      /* Calculate the elapsed time */
+-
+-      elapsed = clock_systimer() - start;
+     }
+ 
+   /* Loop until the stop is complete or a timeout occurs. */
 diff --git NuttX/nuttx/arch/arm/src/stm32l4/stm32l4_i2c.c NuttX/nuttx/arch/arm/src/stm32l4/stm32l4_i2c.c
-index eed199f..d5027bf 100644
+index eed199f..be46524 100644
 --- NuttX/nuttx/arch/arm/src/stm32l4/stm32l4_i2c.c
 +++ NuttX/nuttx/arch/arm/src/stm32l4/stm32l4_i2c.c
 @@ -4,7 +4,7 @@
@@ -187,3 +302,24 @@ index eed199f..d5027bf 100644
      }
  
    /* Loop until the transfer is complete. */
+@@ -788,6 +788,10 @@ static inline void stm32l4_i2c_sem_waitstop(FAR struct stm32l4_i2c_priv_s *priv)
+   start = clock_systimer();
+   do
+     {
++      /* Calculate the elapsed time */
++
++      elapsed = clock_systimer() - start;
++
+       /* Check for STOP condition */
+ 
+       cr = stm32l4_i2c_getreg32(priv, STM32L4_I2C_CR2_OFFSET);
+@@ -804,9 +808,6 @@ static inline void stm32l4_i2c_sem_waitstop(FAR struct stm32l4_i2c_priv_s *priv)
+           return;
+         }
+ 
+-      /* Calculate the elapsed time */
+-
+-      elapsed = clock_systimer() - start;
+     }
+ 
+   /* Loop until the stop is complete or a timeout occurs. */


### PR DESCRIPTION
   backport 3cd66af889b42b036d6c9d88e067fc3b8abbdb2a and pr 258

   Applies to STM32F4 and STM32F7

   STM32, STM32 F7, and STM32 L4: Clone Freddie Chopin's I2C change to similar STM32 I2C drivers.

   Save elapsed time before handling I2C in stm32_i2c_sem_waitstop()
   This patch follows the same logic as in previous fix to
   stm32_i2c_sem_waitdone().
   It is possible that a context switch occurs after I2C registers are read
   but before elapsed time is saved in stm32_i2c_sem_waitstop(). It is then
   possible that the registers were read only once with "elapsed time"
   equal 0. When scheduler resumes this thread it is quite possible that
   now "elapsed time" will be well above timeout threshold. In that case
   the function returns and reports a timeout, even though the registers
   were not read "recently".
   Fix this by inverting the order of operations in the loop - save elapsed
   time before reading registers. This way a context switch anywhere in the
   loop will not cause an erroneous "timeout" error.