### PR TITLE
Removing @board tag from the PARAM_DEFINE.  Use of this tag prevents …

### DIFF
--- a/src/platforms/qurt/fc_addon/uart_esc/uart_esc_params.c
+++ b/src/platforms/qurt/fc_addon/uart_esc/uart_esc_params.c
@@ -138,10 +138,3 @@ PARAM_DEFINE_INT32(UART_ESC_MOTOR3, 1);
  */
 PARAM_DEFINE_INT32(UART_ESC_MOTOR4, 3);
 
-/**
- * TODO-JYW: Temporary change until the reason can be determined why this
- * same parameters is not read from src/platforms/px4_layer/params.c
- *
- * @group Snapdragon UART ESC
- */
-PARAM_DEFINE_INT32(MAV_TYPE, 2);

--- a/src/platforms/qurt/px4_layer/params.c
+++ b/src/platforms/qurt/px4_layer/params.c
@@ -37,8 +37,7 @@
 
 // Following is hack to prevent duplicate parameter definition error in param parser
 /**
- * @board QuRT_App
+ * Default MAV type of multirotor for Snapdragon Flight.
  */
-// TODO-JYW: Temporarily removed to remove duplicate definition.
-// PARAM_DEFINE_INT32(MAV_TYPE, 2);
+PARAM_DEFINE_INT32(MAV_TYPE, 2);
 


### PR DESCRIPTION
…the copying of the parameter into the parameters.xml file generated at build time.  I will generate an Issue for this problem.