### PR TITLE
Refactor board level RC_IN definitions and useage

### DIFF
--- a/src/drivers/boards/aerofc-v1/board_config.h
+++ b/src/drivers/boards/aerofc-v1/board_config.h
@@ -124,7 +124,7 @@
 /* RC Serial port
  */
 #define RC_SERIAL_PORT		"/dev/ttyS3"
-#define INVERT_RC_INPUT(_s)		while(0)
+#define INVERT_RC_INPUT(_invert_true)		while(0)
 
 /* High-resolution timer
  */

--- a/src/drivers/boards/mindpx-v2/board_config.h
+++ b/src/drivers/boards/mindpx-v2/board_config.h
@@ -276,22 +276,29 @@
 
 #define RC_SERIAL_PORT		"/dev/ttyS0"
 
-// #define GPIO_RSSI_IN		(GPIO_INPUT|GPIO_PULLUP|GPIO_PORTC|GPIO_PIN1)
-#define GPIO_SBUS_INV		(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTA|GPIO_PIN10)
-#define INVERT_RC_INPUT(_s)	px4_arch_gpiowrite(GPIO_SBUS_INV, _s);
+// #define GPIO_RSSI_IN                (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTC|GPIO_PIN1)
+#define GPIO_SBUS_INV                  (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTA|GPIO_PIN10)
+#define INVERT_RC_INPUT(_invert_true)  px4_arch_gpiowrite(GPIO_SBUS_INV, _invert_true);
 
-#define GPIO_FRSKY_INV		(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTB|GPIO_PIN12)
-#define INVERT_FRSKY(_s)	px4_arch_gpiowrite(GPIO_FRSKY_INV, _s);
+#define GPIO_FRSKY_INV                (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTB|GPIO_PIN12)
+#define INVERT_FRSKY(_invert_true)    px4_arch_gpiowrite(GPIO_FRSKY_INV, _invert_true);
 
 /* Power switch controls */
-#define GPIO_SPEKTRUM_PWR_EN
-#define POWER_SPEKTRUM(_s)		do { } while (0)
-#define SPEKTRUM_RX_AS_UART()	px4_arch_configgpio(GPIO_USART1_RX)
+#define SPEKTRUM_POWER(_on_true)      do { } while (0)
 
-/* MindPXv2 has a separate GPIO for serial RC output */
-#define GPIO_RC_OUT		(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN6)
-#define SPEKTRUM_RX_AS_GPIO()	px4_arch_configgpio(GPIO_RC_OUT)
-#define SPEKTRUM_RX_HIGH(_s)	px4_arch_gpiowrite(GPIO_RC_OUT, (_s))
+/*
+ * MindPXv2 has one RC_IN
+ *
+ * GPIO PPM_IN on PC6 T8CH1
+ * SPEKTRUM_RX (it's TX or RX in Bind) on PC6 UART1
+ * Inversion is possible via the 74LVC2G86 controlled by the FMU
+ * The FMU can drive GPIO PPM_IN as an output
+ */
+
+#define GPIO_PPM_IN_AS_OUT            (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN6)
+#define SPEKTRUM_RX_AS_GPIO_OUTPUT()  px4_arch_configgpio(GPIO_PPM_IN_AS_OUT)
+#define SPEKTRUM_RX_AS_UART()         px4_arch_configgpio(GPIO_USART1_RX)
+#define SPEKTRUM_OUT(_one_true)       px4_arch_gpiowrite(GPIO_PPM_IN_AS_OUT, (_one_true))
 
 #define BOARD_NAME "MINDPX_V2"
 

--- a/src/drivers/boards/mindpx-v2/mindpx2_init.c
+++ b/src/drivers/boards/mindpx-v2/mindpx2_init.c
@@ -152,8 +152,6 @@ stm32_boardinitialize(void)
 	/* configure power supply control/sense pins */
 
 	px4_arch_configgpio(GPIO_SBUS_INV);
-	px4_arch_configgpio(GPIO_RC_OUT);	/* Serial RC output pin */
-	px4_arch_gpiowrite(GPIO_RC_OUT, 1);	/* set it high to pull RC input up */
 	px4_arch_configgpio(GPIO_FRSKY_INV);
 
 	/* configure the GPIO pins to outputs and keep them low */

--- a/src/drivers/boards/px4fmu-v4/board_config.h
+++ b/src/drivers/boards/px4fmu-v4/board_config.h
@@ -236,10 +236,10 @@
 #define GPIO_OTGFS_VBUS		(GPIO_INPUT|GPIO_FLOAT|GPIO_SPEED_100MHz|GPIO_OPENDRAIN|GPIO_PORTA|GPIO_PIN9)
 
 /* High-resolution timer */
-#define HRT_TIMER		3	/* use timer8 for the HRT */
-#define HRT_TIMER_CHANNEL	4	/* use capture/compare channel */
+#define HRT_TIMER           3   /* use timer 3 for the HRT */
+#define HRT_TIMER_CHANNEL	4   /* use capture/compare channel 4 */
 
-#define HRT_PPM_CHANNEL		3	/* use capture/compare channel 2 */
+#define HRT_PPM_CHANNEL		3	/* use capture/compare channel 3 */
 #define GPIO_PPM_IN			(GPIO_ALT|GPIO_AF2|GPIO_PULLUP|GPIO_PORTB|GPIO_PIN0)
 
 #define RC_SERIAL_PORT		"/dev/ttyS4"
@@ -255,7 +255,7 @@
 #define GPIO_PERIPH_3V3_EN		(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN5)
 /* for R12, this signal is active high */
 #define GPIO_SBUS_INV			(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN13)
-#define INVERT_RC_INPUT(_s)		px4_arch_gpiowrite(GPIO_SBUS_INV, _s)
+#define INVERT_RC_INPUT(_invert_true) px4_arch_gpiowrite(GPIO_SBUS_INV, _invert_true)
 
 #define GPIO_8266_GPIO0			(GPIO_INPUT|GPIO_PULLUP|GPIO_PORTE|GPIO_PIN2)
 #define GPIO_SPEKTRUM_PWR_EN		(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTE|GPIO_PIN4)
@@ -264,14 +264,21 @@
 
 /* Power switch controls ******************************************************/
 
-#define POWER_SPEKTRUM(_s)			px4_arch_gpiowrite(GPIO_SPEKTRUM_PWR_EN, (1-_s))
-#define SPEKTRUM_RX_AS_UART()		px4_arch_configgpio(GPIO_USART1_RX)
+#define SPEKTRUM_POWER(_on_true)    px4_arch_gpiowrite(GPIO_SPEKTRUM_PWR_EN, (!_on_true))
 
-// FMUv4 has a separate GPIO for serial RC output
-#define GPIO_RC_OUT			(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTB|GPIO_PIN0)
-#define SPEKTRUM_RX_AS_GPIO()		px4_arch_configgpio(GPIO_RC_OUT)
-#define SPEKTRUM_RX_HIGH(_s)		px4_arch_gpiowrite(GPIO_RC_OUT, (_s))
+/*
+ * FMUv4 has separate RC_IN
+ *
+ * GPIO PPM_IN on PB0 T3C3
+ * SPEKTRUM_RX (it's TX or RX in Bind) on UART6 PC7
+ * Inversion is possible via the 74LVC2G86 controlled by the FMU
+ * The FMU can drive  GPIO PPM_IN as an output
+ */
 
+#define GPIO_PPM_IN_AS_OUT             (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTB|GPIO_PIN0)
+#define SPEKTRUM_RX_AS_GPIO_OUTPUT()   px4_arch_configgpio(GPIO_PPM_IN_AS_OUT)
+#define SPEKTRUM_RX_AS_UART()          /* Can be left as uart */
+#define SPEKTRUM_OUT(_one_true)        px4_arch_gpiowrite(GPIO_PPM_IN_AS_OUT, (_one_true))
 
 #define	BOARD_NAME "PX4FMU_V4"
 

--- a/src/drivers/boards/px4fmu-v4/px4fmu_init.c
+++ b/src/drivers/boards/px4fmu-v4/px4fmu_init.c
@@ -182,11 +182,6 @@ stm32_boardinitialize(void)
 	stm32_configgpio(GPIO_8266_RST);
 	stm32_configgpio(GPIO_BTN_SAFETY);
 
-#ifdef GPIO_RC_OUT
-	stm32_configgpio(GPIO_RC_OUT);      /* Serial RC output pin */
-	stm32_gpiowrite(GPIO_RC_OUT, 1);    /* set it high to pull RC input up */
-#endif
-
 	/* configure the GPIO pins to outputs and keep them low */
 	stm32_configgpio(GPIO_GPIO0_OUTPUT);
 	stm32_configgpio(GPIO_GPIO1_OUTPUT);

--- a/src/drivers/boards/px4fmu-v4pro/board_config.h
+++ b/src/drivers/boards/px4fmu-v4pro/board_config.h
@@ -306,23 +306,10 @@ __BEGIN_DECLS
 #define GPIO_8266_PD			(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTE|GPIO_PIN5)
 #define GPIO_8266_RST			(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTE|GPIO_PIN6)
 
-/* Power switch controls ******************************************************/
-
-//#define SPEKTRUM_POWER(_on_true)     px4_arch_gpiowrite(GPIO_SPEKTRUM_PWR_EN, (!_on_true))
-
-/* FMUv4-pro has RC_IN to the FMU and to the PX4IO:
- *
- * GPIO PPM_IN to the FMU on PB0 T3C 3
- * SPEKTRUM_RX (it's TX or RX in Bind) on UART3 on the PX4IO
- * Inversion is possible via the 74LVC2G86 controlled by the FMU
- * The FMU can drive  GPIO PPM_IN as an output
+/* No Power switch controls or binding control *********************************************
+ * V4 Pro does not have control to bind SPEKTRUM - there is only 5V VCC on
+ * the connector interface and Spektrum requires VDD 3v3 to be controllable
  */
-
-#define GPIO_PPM_IN_AS_OUT             (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTB|GPIO_PIN0)
-#define SPEKTRUM_RX_AS_GPIO_OUTPUT()   px4_arch_configgpio(GPIO_PPM_IN_AS_OUT)
-#define SPEKTRUM_RX_AS_UART()          px4_arch_configgpio(GPIO_USART1_RX)
-#define SPEKTRUM_OUT(_one_true)        px4_arch_gpiowrite(GPIO_PPM_IN_AS_OUT, (_one_true))
-
 
 #define	BOARD_NAME "PX4FMU_V4PRO"
 

--- a/src/drivers/boards/px4fmu-v4pro/board_config.h
+++ b/src/drivers/boards/px4fmu-v4pro/board_config.h
@@ -283,38 +283,45 @@ __BEGIN_DECLS
 #define GPIO_OTGFS_VBUS		(GPIO_INPUT|GPIO_FLOAT|GPIO_SPEED_100MHz|GPIO_OPENDRAIN|GPIO_PORTA|GPIO_PIN9)
 
 /* High-resolution timer */
-#define HRT_TIMER		3	/* use timer8 for the HRT */
-#define HRT_TIMER_CHANNEL	4	/* use capture/compare channel */
+#define HRT_TIMER           3 /* use timer 3 for the HRT */
+#define HRT_TIMER_CHANNEL   4 /* use capture/compare channel 4 */
 
-#define HRT_PPM_CHANNEL		3	/* use capture/compare channel 2 */
-#define GPIO_PPM_IN			(GPIO_ALT|GPIO_AF2|GPIO_PULLUP|GPIO_PORTB|GPIO_PIN0)
+#define HRT_PPM_CHANNEL     3	/* use capture/compare channel 3 */
+#define GPIO_PPM_IN         (GPIO_ALT|GPIO_AF2|GPIO_PULLUP|GPIO_PORTB|GPIO_PIN0)
 
 //#define RC_SERIAL_PORT		"/dev/ttyS4"
 
 /* PWM input driver. Use FMU AUX5 pins attached to timer4 channel 2 */
-#define PWMIN_TIMER			4
-#define PWMIN_TIMER_CHANNEL		2
+#define PWMIN_TIMER         4
+#define PWMIN_TIMER_CHANNEL 2
 #define GPIO_PWM_IN			GPIO_TIM4_CH2IN_2
 
 #define GPIO_RSSI_IN 			(GPIO_INPUT|GPIO_PULLUP|GPIO_PORTC|GPIO_PIN1)
 #define GPIO_BTN_SAFETY_FMU		(GPIO_INPUT|GPIO_PULLUP|GPIO_PORTC|GPIO_PIN4)
 #define GPIO_SBUS_INV			(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN13)
-#define INVERT_RC_INPUT(_s)		px4_arch_gpiowrite(GPIO_SBUS_INV, _s)
+#define INVERT_RC_INPUT(_invert_true)  px4_arch_gpiowrite(GPIO_SBUS_INV, _invert_true)
 
 #define GPIO_8266_GPIO0			(GPIO_INPUT|GPIO_PULLUP|GPIO_PORTE|GPIO_PIN2)
-//TODO:VET#define GPIO_SPEKTRUM_PWR_EN		(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTE|GPIO_PIN4)
+//TODO: fo not see on schematic #define GPIO_SPEKTRUM_PWR_EN		(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTE|GPIO_PIN4)
 #define GPIO_8266_PD			(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTE|GPIO_PIN5)
 #define GPIO_8266_RST			(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTE|GPIO_PIN6)
 
 /* Power switch controls ******************************************************/
 
-#define POWER_SPEKTRUM(_s)		px4_arch_gpiowrite(GPIO_SPEKTRUM_PWR_EN, (1-_s))
-#define SPEKTRUM_RX_AS_UART()		px4_arch_configgpio(GPIO_USART1_RX)
+//#define SPEKTRUM_POWER(_on_true)     px4_arch_gpiowrite(GPIO_SPEKTRUM_PWR_EN, (!_on_true))
 
-// FMUv4-pro has a separate GPIO for serial RC output
-#define GPIO_RC_OUT			(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTB|GPIO_PIN0)
-#define SPEKTRUM_RX_AS_GPIO()		px4_arch_configgpio(GPIO_RC_OUT)
-#define SPEKTRUM_RX_HIGH(_s)		px4_arch_gpiowrite(GPIO_RC_OUT, (_s))
+/* FMUv4-pro has RC_IN to the FMU and to the PX4IO:
+ *
+ * GPIO PPM_IN to the FMU on PB0 T3C 3
+ * SPEKTRUM_RX (it's TX or RX in Bind) on UART3 on the PX4IO
+ * Inversion is possible via the 74LVC2G86 controlled by the FMU
+ * The FMU can drive  GPIO PPM_IN as an output
+ */
+
+#define GPIO_PPM_IN_AS_OUT             (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTB|GPIO_PIN0)
+#define SPEKTRUM_RX_AS_GPIO_OUTPUT()   px4_arch_configgpio(GPIO_PPM_IN_AS_OUT)
+#define SPEKTRUM_RX_AS_UART()          px4_arch_configgpio(GPIO_USART1_RX)
+#define SPEKTRUM_OUT(_one_true)        px4_arch_gpiowrite(GPIO_PPM_IN_AS_OUT, (_one_true))
 
 
 #define	BOARD_NAME "PX4FMU_V4PRO"

--- a/src/drivers/boards/px4fmu-v4pro/px4fmu_init.c
+++ b/src/drivers/boards/px4fmu-v4pro/px4fmu_init.c
@@ -196,11 +196,6 @@ stm32_boardinitialize(void)
 	stm32_configgpio(GPIO_8266_RST);
 	stm32_configgpio(GPIO_BTN_SAFETY_FMU);
 
-#ifdef GPIO_RC_OUT
-	stm32_configgpio(GPIO_RC_OUT);      /* Serial RC output pin */
-	stm32_gpiowrite(GPIO_RC_OUT, 1);    /* set it high to pull RC input up */
-#endif
-
 	/* configure the GPIO pins to outputs and keep them low */
 	stm32_configgpio(GPIO_GPIO0_OUTPUT);
 	stm32_configgpio(GPIO_GPIO1_OUTPUT);

--- a/src/drivers/boards/px4fmu-v5/board_config.h
+++ b/src/drivers/boards/px4fmu-v5/board_config.h
@@ -338,18 +338,26 @@ __BEGIN_DECLS
 #define GPIO_LED_SAFETY         /* PE12 */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTE|GPIO_PIN12)
 #define GPIO_BTN_SAFETY         /* PE10 */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTE|GPIO_PIN10)
 
-#define INVERT_RC_INPUT(_s)		board_rc_input(_s);
+#define INVERT_RC_INPUT(_invert_true)      board_rc_input(_invert_true);
 
 
 /* Power switch controls ******************************************************/
 
-#define POWER_SPEKTRUM(_s)      px4_arch_gpiowrite(GPIO_SPEKTRUM_POWER_EN, (1-_s))
-#define SPEKTRUM_RX_AS_UART()   px4_arch_configgpio(GPIO_USART6_RX) /* NOT FMUv5 test HW ONLY*/
+#define SPEKTRUM_POWER(_on_true)           px4_arch_gpiowrite(GPIO_SPEKTRUM_POWER_EN, (_on_true))
 
-// FMUv5 has a separate GPIO for serial RC output
-#define GPIO_RC_OUT            /* PG9 */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTG|GPIO_PIN9)
-#define SPEKTRUM_RX_AS_GPIO()   px4_arch_configgpio(GPIO_RC_OUT)
-#define SPEKTRUM_RX_HIGH(_s)    px4_arch_gpiowrite(GPIO_RC_OUT, (_s))
+/*
+ * FMUv5 has a separate RC_IN
+ *
+ * GPIO PPM_IN on PI5 T8CH1
+ * SPEKTRUM_RX (it's TX or RX in Bind) on UART6 PG9 (NOT FMUv5 test HW ONLY)
+ *   In version is possible in the UART
+ * and can drive  GPIO PPM_IN as an output
+ */
+
+#define GPIO_PPM_IN_AS_OUT             (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTI|GPIO_PIN5)
+#define SPEKTRUM_RX_AS_GPIO_OUTPUT()   px4_arch_configgpio(GPIO_PPM_IN_AS_OUT)
+#define SPEKTRUM_RX_AS_UART()          /* Can be left as uart */
+#define SPEKTRUM_OUT(_one_true)        px4_arch_gpiowrite(GPIO_PPM_IN_AS_OUT, (_one_true))
 
 #define SDIO_SLOTNO             0  /* Only one slot */
 #define SDIO_MINOR              0

--- a/src/drivers/boards/px4fmu-v5/px4fmu_init.c
+++ b/src/drivers/boards/px4fmu-v5/px4fmu_init.c
@@ -257,10 +257,6 @@ stm32_boardinitialize(void)
 	stm32_configgpio(GPIO_LED_SAFETY);
 	stm32_configgpio(GPIO_BTN_SAFETY);
 
-#ifdef GPIO_RC_OUT
-	stm32_configgpio(GPIO_RC_OUT);      /* Serial RC output pin */
-#endif
-
 	/* configure SPI interfaces */
 	stm32_spiinitialize();
 

--- a/src/drivers/boards/px4io-v1/board_config.h
+++ b/src/drivers/boards/px4io-v1/board_config.h
@@ -80,11 +80,11 @@
 #define GPIO_RELAY2_EN (GPIO_OUTPUT|GPIO_CNF_OUTPP|GPIO_MODE_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTA|GPIO_PIN11)
 
 #define GPIO_SPEKTRUM_PWR_EN GPIO_RELAY1_EN
-#define POWER_SPEKTRUM(_s)		px4_arch_gpiowrite(GPIO_RELAY1_EN, (_s))
+#define SPEKTRUM_POWER(_on_true)     px4_arch_gpiowrite(GPIO_RELAY1_EN, (_on_true))
 
-#define SPEKTRUM_RX_HIGH(_s)	px4_arch_gpiowrite(GPIO_USART1_RX_SPEKTRUM, (_s))
-#define SPEKTRUM_RX_AS_UART()		px4_arch_configgpio(GPIO_USART1_RX)
-#define SPEKTRUM_RX_AS_GPIO()		px4_arch_configgpio(GPIO_USART1_RX_SPEKTRUM)
+#define SPEKTRUM_OUT(_one_true)      px4_arch_gpiowrite(GPIO_USART1_RX_SPEKTRUM, (_one_true))
+#define SPEKTRUM_RX_AS_UART()        px4_arch_configgpio(GPIO_USART1_RX)
+#define SPEKTRUM_RX_AS_GPIO_OUTPUT() px4_arch_configgpio(GPIO_USART1_RX_SPEKTRUM)
 
 /* Analog inputs ********************************************************************/
 

--- a/src/drivers/boards/px4io-v2/board_config.h
+++ b/src/drivers/boards/px4io-v2/board_config.h
@@ -83,12 +83,12 @@
 
 /* Power switch controls ******************************************************/
 
-#define GPIO_SPEKTRUM_PWR_EN (GPIO_OUTPUT|GPIO_CNF_OUTPP|GPIO_MODE_50MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN13)
-#define POWER_SPEKTRUM(_s)		px4_arch_gpiowrite(GPIO_SPEKTRUM_PWR_EN, (_s))
+#define GPIO_SPEKTRUM_PWR_EN         (GPIO_OUTPUT|GPIO_CNF_OUTPP|GPIO_MODE_50MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN13)
+#define SPEKTRUM_POWER(_on_true)     px4_arch_gpiowrite(GPIO_SPEKTRUM_PWR_EN, (_on_true))
 
-#define SPEKTRUM_RX_HIGH(_s)	px4_arch_gpiowrite(GPIO_USART1_RX_SPEKTRUM, (_s))
-#define SPEKTRUM_RX_AS_UART()		px4_arch_configgpio(GPIO_USART1_RX)
-#define SPEKTRUM_RX_AS_GPIO()		px4_arch_configgpio(GPIO_USART1_RX_SPEKTRUM)
+#define SPEKTRUM_OUT(_one_true)      px4_arch_gpiowrite(GPIO_USART1_RX_SPEKTRUM, (_one_true))
+#define SPEKTRUM_RX_AS_UART()        px4_arch_configgpio(GPIO_USART1_RX)
+#define SPEKTRUM_RX_AS_GPIO_OUTPUT() px4_arch_configgpio(GPIO_USART1_RX_SPEKTRUM)
 
 #define GPIO_SERVO_FAULT_DETECT (GPIO_INPUT|GPIO_CNF_INPULLUP|GPIO_MODE_INPUT|GPIO_PORTA|GPIO_PIN15)
 

--- a/src/drivers/boards/px4nucleoF767ZI-v1/board_config.h
+++ b/src/drivers/boards/px4nucleoF767ZI-v1/board_config.h
@@ -252,6 +252,7 @@ __BEGIN_DECLS
 #define HRT_TIMER		    8	/* use timer8 for the HRT */
 #define HRT_TIMER_CHANNEL   3	/* use capture/compare channel 3 */
 
+//todo:Needs to be moved to T14C1
 #define HRT_PPM_CHANNEL         /* PA7[CN12-15] */  1	/* use capture/compare channel 1 */
 #define GPIO_PPM_IN             /* PB0[CN11-34] */ GPIO_TIM3_CH3IN_1
 
@@ -268,7 +269,7 @@ __BEGIN_DECLS
 #define GPIO_PERIPH_3V3_EN      /* PG4[CN12-69]  */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTG|GPIO_PIN4)
 
 #define GPIO_SBUS_INV		    /* PD10[CN12-65] */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTD|GPIO_PIN10)
-#define INVERT_RC_INPUT(_s)		px4_arch_gpiowrite(GPIO_SBUS_INV, _s);
+#define INVERT_RC_INPUT(_invert_true)                px4_arch_gpiowrite(GPIO_SBUS_INV, _invert_true);
 
 #define GPIO_8266_GPIO0         /* PD15[CN12-48] */ (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTD|GPIO_PIN15)
 #define GPIO_SPEKTRUM_PWR_EN    /* PE4[CN11-48]  */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTE|GPIO_PIN4)
@@ -279,13 +280,25 @@ __BEGIN_DECLS
 
 /* Power switch controls ******************************************************/
 
-#define POWER_SPEKTRUM(_s)      px4_arch_gpiowrite(GPIO_SPEKTRUM_PWR_EN, (1-_s))
-#define SPEKTRUM_RX_AS_UART()   px4_arch_configgpio(GPIO_USART1_RX)
+#define SPEKTRUM_POWER(_on_true)      px4_arch_gpiowrite(GPIO_SPEKTRUM_PWR_EN, (!_on_true))
 
-// FMUv4 has a separate GPIO for serial RC output
-#define GPIO_RC_OUT			    /* PE5[CN11-50] */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTE|GPIO_PIN5)
-#define SPEKTRUM_RX_AS_GPIO()   px4_arch_configgpio(GPIO_RC_OUT)
-#define SPEKTRUM_RX_HIGH(_s)    px4_arch_gpiowrite(GPIO_RC_OUT, (_s))
+/*
+ * FMUv5 has a separate RC_IN
+ *
+ * N.B.  px4nucleoF767ZI-v1 is Deprecated - for Reference only
+ * These interfaces can not be realized with this HW without
+ * more work.
+ *
+ * GPIO PPM_IN on PA7 T14C1
+ * SPEKTRUM_RX (it's TX or RX in Bind) on UART6 PG9 (NOT FMUv5 test HW ONLY)
+ * Inversion is possible in the UART
+ * FMU can drive  GPIO PPM_IN as an output
+ */
+#define GPIO_PPM_IN_AS_OUT /* PE5[CN11-50] */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTE|GPIO_PIN5)
+#define SPEKTRUM_RX_AS_GPIO_OUTPUT()          px4_arch_configgpio(GPIO_PPM_IN_AS_OUT)
+#define SPEKTRUM_RX_AS_UART()                 px4_arch_configgpio(GPIO_USART1_RX)
+#define SPEKTRUM_OUT(_one_true)               px4_arch_gpiowrite(GPIO_PPM_IN_AS_OUT, (_one_true))
+
 
 #define SDIO_SLOTNO             0  /* Only one slot */
 #define SDIO_MINOR              0

--- a/src/drivers/boards/px4nucleoF767ZI-v1/px4nucleo_init.c
+++ b/src/drivers/boards/px4nucleoF767ZI-v1/px4nucleo_init.c
@@ -187,11 +187,6 @@ stm32_boardinitialize(void)
 	stm32_configgpio(GPIO_8266_RST);
 	stm32_configgpio(GPIO_BTN_SAFETY);
 
-#ifdef GPIO_RC_OUT
-	stm32_configgpio(GPIO_RC_OUT);      /* Serial RC output pin */
-	stm32_gpiowrite(GPIO_RC_OUT, 1);    /* set it high to pull RC input up */
-#endif
-
 	/* configure the GPIO pins to outputs and keep them low */
 	stm32_configgpio(GPIO_GPIO0_OUTPUT);
 	stm32_configgpio(GPIO_GPIO1_OUTPUT);

--- a/src/drivers/boards/tap-v1/board_config.h
+++ b/src/drivers/boards/tap-v1/board_config.h
@@ -200,7 +200,7 @@
 #define GPIO_OTGFS_VBUS (GPIO_INPUT|GPIO_FLOAT|GPIO_PORTA|GPIO_PIN9)
 
 #define RC_SERIAL_PORT		"/dev/ttyS5"
-#define INVERT_RC_INPUT(_s)		while(0)
+#define INVERT_RC_INPUT(_invert_true)		while(0)
 
 /* High-resolution timer
  */

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -941,15 +941,6 @@ void PX4FMU::set_rc_scan_state(RC_SCAN newState)
 void PX4FMU::rc_io_invert(bool invert)
 {
 	INVERT_RC_INPUT(invert);
-
-#ifdef GPIO_RC_OUT
-
-	if (!invert) {
-		// set FMU_RC_OUTPUT high to pull RC_INPUT up
-		px4_arch_gpiowrite(GPIO_RC_OUT, 1);
-	}
-
-#endif
 }
 #endif
 
@@ -2288,7 +2279,7 @@ PX4FMU::pwm_ioctl(file *filp, int cmd, unsigned long arg)
 			break;
 		}
 
-#ifdef GPIO_SPEKTRUM_PWR_EN
+#ifdef SPEKTRUM_POWER
 
 	case DSM_BIND_START:
 		/* only allow DSM2, DSM-X and DSM-X with more than 7 channels */

--- a/src/lib/rc/dsm.c
+++ b/src/lib/rc/dsm.c
@@ -235,9 +235,9 @@ dsm_guess_format(bool reset)
 int
 dsm_config(int fd)
 {
-#ifdef GPIO_SPEKTRUM_PWR_EN
+#ifdef SPEKTRUM_POWER
 	// enable power on DSM connector
-	POWER_SPEKTRUM(true);
+	SPEKTRUM_POWER(true);
 #endif
 
 	int ret = -1;
@@ -315,7 +315,7 @@ dsm_deinit()
 	dsm_fd = -1;
 }
 
-#ifdef GPIO_SPEKTRUM_PWR_EN
+#if defined(SPEKTRUM_POWER)
 /**
  * Handle DSM satellite receiver bind mode handler
  *
@@ -334,20 +334,20 @@ dsm_bind(uint16_t cmd, int pulses)
 	case DSM_CMD_BIND_POWER_DOWN:
 
 		/*power down DSM satellite*/
-		POWER_SPEKTRUM(0);
+		SPEKTRUM_POWER(false);
 		break;
 
 	case DSM_CMD_BIND_POWER_UP:
 
 		/*power up DSM satellite*/
-		POWER_SPEKTRUM(1);
+		SPEKTRUM_POWER(true);
 		dsm_guess_format(true);
 		break;
 
 	case DSM_CMD_BIND_SET_RX_OUT:
 
 		/*Set UART RX pin to active output mode*/
-		SPEKTRUM_RX_AS_GPIO();
+		SPEKTRUM_RX_AS_GPIO_OUTPUT();
 		break;
 
 	case DSM_CMD_BIND_SEND_PULSES:
@@ -355,9 +355,9 @@ dsm_bind(uint16_t cmd, int pulses)
 		/*Pulse RX pin a number of times*/
 		for (int i = 0; i < pulses; i++) {
 			dsm_udelay(120);
-			SPEKTRUM_RX_HIGH(false);
+			SPEKTRUM_OUT(false);
 			dsm_udelay(120);
-			SPEKTRUM_RX_HIGH(true);
+			SPEKTRUM_OUT(true);
 		}
 
 		break;

--- a/src/lib/rc/dsm.h
+++ b/src/lib/rc/dsm.h
@@ -63,7 +63,7 @@ __EXPORT bool	dsm_input(int dsm_fd, uint16_t *values, uint16_t *num_values, bool
 __EXPORT bool	dsm_parse(const uint64_t now, const uint8_t *frame, const unsigned len, uint16_t *values,
 			  uint16_t *num_values, bool *dsm_11_bit, unsigned *frame_drops, uint16_t max_channels);
 
-#ifdef GPIO_SPEKTRUM_PWR_EN
+#ifdef SPEKTRUM_POWER
 __EXPORT void	dsm_bind(uint16_t cmd, int pulses);
 #endif
 


### PR DESCRIPTION
@sirPerna This should resolve the RC_INPUT is pulled to VCC issue. 

Removed the legacy FMUv4 define that was activating a nonexistent
pull up and on some HW driving the PPM_IN aka RC_IN aka SPEKTRUM_RX
to VDD.

Also detailed the connections of this pins for the board.

The simplest connection is RC_IN to a timer capture pin
and a UART.
In this case the UART_RX pin and just be left as is.
While the pin can be configured as the PPM_IN (Timer capture)
or as SPEKTRUM_RX_AS_GPIO_OUTPUT to use it as and GPIO to
facilitate binding.

Renamed the macros and defines to be more explicit as to what
Is being done and the sense of the parameters