### PR TITLE
HOTFIX:Backport Memory corruption due to stack coloring overreach  As discovered by dcabecinhas

### DIFF
--- a/nuttx-patches/stack_coloration_overreach_fix.patch
+++ b/nuttx-patches/stack_coloration_overreach_fix.patch
@@ -1,0 +1,20 @@
+diff --git NuttX/nuttx/arch/arm/src/common/up_initialize.c NuttX/nuttx/arch/arm/src/common/up_initialize.c
+index a97cd40..b151728 100644
+--- NuttX/nuttx/arch/arm/src/common/up_initialize.c
++++ NuttX/nuttx/arch/arm/src/common/up_initialize.c
+@@ -100,13 +100,13 @@ static void up_calibratedelay(void)
+  *
+  ****************************************************************************/
+ 
+-#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
++#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 7
+ static inline void up_color_intstack(void)
+ {
+   uint32_t *ptr = (uint32_t *)&g_intstackalloc;
+   ssize_t size;
+ 
+-  for (size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
++  for (size = (CONFIG_ARCH_INTERRUPTSTACK & ~7);
+        size > 0;
+        size -= sizeof(uint32_t))
+     {


### PR DESCRIPTION
   Backport of upstream NuttX PR 264

   As discovered by dcabecinhas. This fix assume the 8 byte
   alignment options for size stack size or this will overwrite
   the first word after TOS
   See https://github.com/PX4/Firmware/issues/6613#issuecomment-285869778