### PR TITLE
Param: Implement RW locking to reduce lock contention

### DIFF
--- a/src/modules/systemlib/flashparams/flashparams.c
+++ b/src/modules/systemlib/flashparams/flashparams.c
@@ -65,8 +65,8 @@
  * Storage for modified parameters.
  */
 struct param_wbuf_s {
-	param_t                 param;
 	union param_value_u     val;
+	param_t                 param;
 	bool                    unsaved;
 };
 

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -111,8 +111,8 @@ static const struct param_info_s *param_info_base = (const struct param_info_s *
  * Storage for modified parameters.
  */
 struct param_wbuf_s {
-	param_t			param;
 	union param_value_u	val;
+	param_t			param;
 	bool			unsaved;
 };
 

--- a/src/modules/systemlib/param/param.h
+++ b/src/modules/systemlib/param/param.h
@@ -69,23 +69,50 @@ typedef enum param_type_e {
 	PARAM_TYPE_UNKNOWN = 0xffff
 } param_type_t;
 
+
+#ifdef __PX4_NUTTX // on NuttX use 16 bits to save RAM
 /**
  * Parameter handle.
  *
  * Parameters are represented by parameter handles, which can
- * be obtained by looking up (or creating?) parameters.
+ * be obtained by looking up parameters. They are an offset into a global
+ * constant parameter array.
  */
-typedef uintptr_t	param_t;
+typedef uint16_t	param_t;
 
 /**
  * Handle returned when a parameter cannot be found.
  */
-#define PARAM_INVALID	((uintptr_t)0xffffffff)
+#define PARAM_INVALID	((uint16_t)0xffff)
 
 /**
  * Magic handle for hash check param
  */
-#define PARAM_HASH      ((uintptr_t)INT32_MAX)
+#define PARAM_HASH      ((uint16_t)INT16_MAX)
+
+#else // on other platforms use 32 bits for better performance
+
+/**
+ * Parameter handle.
+ *
+ * Parameters are represented by parameter handles, which can
+ * be obtained by looking up parameters. They are an offset into a global
+ * constant parameter array.
+ */
+typedef uint32_t	param_t;
+
+/**
+ * Handle returned when a parameter cannot be found.
+ */
+#define PARAM_INVALID	((uint32_t)0xffffffff)
+
+/**
+ * Magic handle for hash check param
+ */
+#define PARAM_HASH      ((uint32_t)INT32_MAX)
+
+#endif /* __PX4_NUTTX */
+
 
 /**
  * Initialize the param backend. Call this on startup before calling any other methods.

--- a/src/modules/systemlib/param/param_shmem.c
+++ b/src/modules/systemlib/param/param_shmem.c
@@ -96,8 +96,8 @@ static struct param_info_s *param_info_base = (struct param_info_s *) &px4_param
  * Storage for modified parameters.
  */
 struct param_wbuf_s {
-	param_t			param;
 	union param_value_u	val;
+	param_t			param;
 	bool			unsaved;
 };
 

--- a/src/platforms/posix/px4_layer/shmem_posix.c
+++ b/src/platforms/posix/px4_layer/shmem_posix.c
@@ -61,8 +61,8 @@ uint64_t update_from_shmem_prev_time = 0, update_from_shmem_current_time = 0;
 extern unsigned char *adsp_changed_index;
 
 struct param_wbuf_s {
-	param_t param;
 	union param_value_u val;
+	param_t param;
 	bool unsaved;
 };
 

--- a/src/platforms/qurt/px4_layer/shmem_qurt.c
+++ b/src/platforms/qurt/px4_layer/shmem_qurt.c
@@ -77,8 +77,8 @@ static unsigned log2_for_int(unsigned v)
 }
 
 struct param_wbuf_s {
-	param_t param;
 	union param_value_u val;
+	param_t param;
 	bool unsaved;
 };
 extern struct param_wbuf_s *param_find_changed(param_t param);

--- a/src/systemcmds/param/param.c
+++ b/src/systemcmds/param/param.c
@@ -368,7 +368,7 @@ do_find(const char *name)
 		return 1;
 	}
 
-	PARAM_PRINT("Found param %s at index %" PRIxPTR "\n", name, ret);
+	PARAM_PRINT("Found param %s at index %i\n", name, (int)ret);
 	return 0;
 }
 

--- a/unittests/param_test.cpp
+++ b/unittests/param_test.cpp
@@ -54,8 +54,8 @@ void _assert_parameter_int_value(param_t param, int32_t expected)
 {
 	int32_t value;
 	int result = param_get(param, &value);
-	ASSERT_EQ(0, result) << printf("param_get (%lu) did not return parameter\n", param);
-	ASSERT_EQ(expected, value) << printf("value for param (%lu) doesn't match default value\n", param);
+	ASSERT_EQ(0, result) << printf("param_get (%i) did not return parameter\n", (int)param);
+	ASSERT_EQ(expected, value) << printf("value for param (%i) doesn't match default value\n", (int)param);
 }
 
 void _set_all_int_parameters_to(int32_t value)


### PR DESCRIPTION
With the introduction of param locking (https://github.com/PX4/Firmware/pull/6597), reading parameters potentially becomes a bottleneck since the whole system wants to read params, and usually at the same time.

This improves that by allowing multiple readers to enter the critical section concurrently. 

However taking a lock is expensive and it can be made more efficient using an [RCU](https://en.wikipedia.org/wiki/Read-copy-update) synchronization scheme. In that case a reader only needs to increase/decrease an atomic counter.

The PR also reduces the size of `param_t` to 16 bits (since we really only need < 1000), freeing up almost 1 KB of RAM (with around 120 changed params).

While updating it, I discovered another concurrency issue (it is a problem we already had). `param_changed_storage` is updated during a param read using non-atomic read-modify-write (https://github.com/PX4/Firmware/compare/param_rw_locking?expand=1#diff-a953b7046039fd7cd55c5860953df79cR721). If 2 (or more) threads try to set a bit at the same time, it can happen that one of updates gets overwritten by the other, thus a param would not be marked as used even though it is.

Tested on SITL & Pixracer.