### PR TITLE
perf: remove unused event_overruns, reduce type of delta times to 32bits

### DIFF
--- a/src/drivers/airspeed/airspeed.cpp
+++ b/src/drivers/airspeed/airspeed.cpp
@@ -80,7 +80,6 @@
 Airspeed::Airspeed(int bus, int address, unsigned conversion_interval, const char *path) :
 	I2C("Airspeed", path, bus, address, 100000),
 	_reports(nullptr),
-	_buffer_overflows(perf_alloc(PC_COUNT, "aspd_buf_of")),
 	_max_differential_pressure_pa(0),
 	_sensor_ok(false),
 	_last_published_sensor_ok(true), /* initialize differently to force publication */
@@ -118,7 +117,6 @@ Airspeed::~Airspeed()
 	// free perf counters
 	perf_free(_sample_perf);
 	perf_free(_comms_errors);
-	perf_free(_buffer_overflows);
 }
 
 int
@@ -409,7 +407,6 @@ Airspeed::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	perf_print_counter(_buffer_overflows);
 	warnx("poll interval:  %u ticks", _measure_ticks);
 	_reports->print_info("report queue");
 }
@@ -417,7 +414,5 @@ Airspeed::print_info()
 void
 Airspeed::new_report(const differential_pressure_s &report)
 {
-	if (!_reports->force(&report)) {
-		perf_count(_buffer_overflows);
-	}
+	_reports->force(&report);
 }

--- a/src/drivers/airspeed/airspeed.h
+++ b/src/drivers/airspeed/airspeed.h
@@ -105,7 +105,6 @@ public:
 
 private:
 	ringbuffer::RingBuffer		*_reports;
-	perf_counter_t		_buffer_overflows;
 
 	/* this class has pointer data members and should not be copied */
 	Airspeed(const Airspeed &);

--- a/src/drivers/hc_sr04/hc_sr04.cpp
+++ b/src/drivers/hc_sr04/hc_sr04.cpp
@@ -128,7 +128,6 @@ private:
 
 	perf_counter_t		_sample_perf;
 	perf_counter_t		_comms_errors;
-	perf_counter_t		_buffer_overflows;
 
 	uint8_t				_cycle_counter;	/* counter in cycle to change i2c adresses */
 	int					_cycling_rate;	/* */
@@ -224,7 +223,6 @@ HC_SR04::HC_SR04(unsigned sonars) :
 	_distance_sensor_topic(nullptr),
 	_sample_perf(perf_alloc(PC_ELAPSED, "hc_sr04_read")),
 	_comms_errors(perf_alloc(PC_COUNT, "hc_sr04_comms_errors")),
-	_buffer_overflows(perf_alloc(PC_COUNT, "hc_sr04_buffer_overflows")),
 	_cycle_counter(0),	/* initialising counter for cycling function to zero */
 	_cycling_rate(0),	/* initialising cycling rate (which can differ depending on one sonar or multiple) */
 	_index_counter(0), 	/* initialising temp sonar i2c address to zero */
@@ -258,7 +256,6 @@ HC_SR04::~HC_SR04()
 	/* free perf counters */
 	perf_free(_sample_perf);
 	perf_free(_comms_errors);
-	perf_free(_buffer_overflows);
 }
 
 int
@@ -620,9 +617,7 @@ HC_SR04::collect()
 		orb_publish(ORB_ID(distance_sensor), _distance_sensor_topic, &report);
 	}
 
-	if (_reports->force(&report)) {
-		perf_count(_buffer_overflows);
-	}
+	_reports->force(&report);
 
 	/* notify anyone waiting for data */
 	poll_notify(POLLIN);
@@ -723,7 +718,6 @@ HC_SR04::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	perf_print_counter(_buffer_overflows);
 	printf("poll interval:  %u ticks\n", _measure_ticks);
 	_reports->print_info("report queue");
 }

--- a/src/drivers/hmc5883/hmc5883.cpp
+++ b/src/drivers/hmc5883/hmc5883.cpp
@@ -168,7 +168,6 @@ private:
 
 	perf_counter_t		_sample_perf;
 	perf_counter_t		_comms_errors;
-	perf_counter_t		_buffer_overflows;
 	perf_counter_t		_range_errors;
 	perf_counter_t		_conf_errors;
 
@@ -358,7 +357,6 @@ HMC5883::HMC5883(device::Device *interface, const char *path, enum Rotation rota
 	_mag_topic(nullptr),
 	_sample_perf(perf_alloc(PC_ELAPSED, "hmc5883_read")),
 	_comms_errors(perf_alloc(PC_COUNT, "hmc5883_com_err")),
-	_buffer_overflows(perf_alloc(PC_COUNT, "hmc5883_buf_of")),
 	_range_errors(perf_alloc(PC_COUNT, "hmc5883_rng_err")),
 	_conf_errors(perf_alloc(PC_COUNT, "hmc5883_conf_err")),
 	_sensor_ok(false),
@@ -407,7 +405,6 @@ HMC5883::~HMC5883()
 	// free perf counters
 	perf_free(_sample_perf);
 	perf_free(_comms_errors);
-	perf_free(_buffer_overflows);
 	perf_free(_range_errors);
 	perf_free(_conf_errors);
 }
@@ -1043,9 +1040,7 @@ HMC5883::collect()
 	_last_report = new_report;
 
 	/* post a report to the ring */
-	if (_reports->force(&new_report)) {
-		perf_count(_buffer_overflows);
-	}
+	_reports->force(&new_report);
 
 	/* notify anyone waiting for data */
 	poll_notify(POLLIN);
@@ -1426,7 +1421,6 @@ HMC5883::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	perf_print_counter(_buffer_overflows);
 	printf("poll interval:  %u ticks\n", _measure_ticks);
 	printf("output  (%.2f %.2f %.2f)\n", (double)_last_report.x, (double)_last_report.y, (double)_last_report.z);
 	printf("offsets (%.2f %.2f %.2f)\n", (double)_scale.x_offset, (double)_scale.y_offset, (double)_scale.z_offset);

--- a/src/drivers/ist8310/ist8310.cpp
+++ b/src/drivers/ist8310/ist8310.cpp
@@ -218,7 +218,6 @@ private:
 
 	perf_counter_t      _sample_perf;
 	perf_counter_t      _comms_errors;
-	perf_counter_t      _buffer_overflows;
 	perf_counter_t      _range_errors;
 	perf_counter_t      _conf_errors;
 
@@ -430,7 +429,6 @@ IST8310::IST8310(int bus_number, int address, const char *path, enum Rotation ro
 	_mag_topic(nullptr),
 	_sample_perf(perf_alloc(PC_ELAPSED, "ist8310_read")),
 	_comms_errors(perf_alloc(PC_COUNT, "ist8310_com_err")),
-	_buffer_overflows(perf_alloc(PC_COUNT, "ist8310_buf_of")),
 	_range_errors(perf_alloc(PC_COUNT, "ist8310_rng_err")),
 	_conf_errors(perf_alloc(PC_COUNT, "ist8310_conf_err")),
 	_sensor_ok(false),
@@ -474,7 +472,6 @@ IST8310::~IST8310()
 	// free perf counters
 	perf_free(_sample_perf);
 	perf_free(_comms_errors);
-	perf_free(_buffer_overflows);
 	perf_free(_range_errors);
 	perf_free(_conf_errors);
 }
@@ -1031,9 +1028,7 @@ IST8310::collect()
 	_last_report = new_report;
 
 	/* post a report to the ring */
-	if (_reports->force(&new_report)) {
-		perf_count(_buffer_overflows);
-	}
+	_reports->force(&new_report);
 
 	/* notify anyone waiting for data */
 	poll_notify(POLLIN);
@@ -1447,7 +1442,6 @@ IST8310::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	perf_print_counter(_buffer_overflows);
 	printf("poll interval:  %u ticks\n", _measure_ticks);
 	printf("output  (%.2f %.2f %.2f)\n", (double)_last_report.x, (double)_last_report.y, (double)_last_report.z);
 	printf("offsets (%.2f %.2f %.2f)\n", (double)_scale.x_offset, (double)_scale.y_offset, (double)_scale.z_offset);

--- a/src/drivers/lis3mdl/lis3mdl.cpp
+++ b/src/drivers/lis3mdl/lis3mdl.cpp
@@ -157,7 +157,6 @@ private:
 
 	perf_counter_t		_sample_perf;
 	perf_counter_t		_comms_errors;
-	perf_counter_t		_buffer_overflows;
 	perf_counter_t		_range_errors;
 	perf_counter_t		_conf_errors;
 
@@ -337,7 +336,6 @@ LIS3MDL::LIS3MDL(device::Device *interface, const char *path, enum Rotation rota
 	_mag_topic(nullptr),
 	_sample_perf(perf_alloc(PC_ELAPSED, "lis3mdl_read")),
 	_comms_errors(perf_alloc(PC_COUNT, "lis3mdl_comms_errors")),
-	_buffer_overflows(perf_alloc(PC_COUNT, "lis3mdl_buffer_overflows")),
 	_range_errors(perf_alloc(PC_COUNT, "lis3mdl_range_errors")),
 	_conf_errors(perf_alloc(PC_COUNT, "lis3mdl_conf_errors")),
 	_sensor_ok(false),
@@ -394,7 +392,6 @@ LIS3MDL::~LIS3MDL()
 	// free perf counters
 	perf_free(_sample_perf);
 	perf_free(_comms_errors);
-	perf_free(_buffer_overflows);
 	perf_free(_range_errors);
 	perf_free(_conf_errors);
 }
@@ -991,9 +988,7 @@ LIS3MDL::collect()
 	_last_report = new_report;
 
 	/* post a report to the ring */
-	if (_reports->force(&new_report)) {
-		perf_count(_buffer_overflows);
-	}
+	_reports->force(&new_report);
 
 	/* notify anyone waiting for data */
 	poll_notify(POLLIN);
@@ -1306,7 +1301,6 @@ LIS3MDL::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	perf_print_counter(_buffer_overflows);
 	printf("poll interval:  %u ticks\n", _measure_ticks);
 	printf("output  (%.2f %.2f %.2f)\n", (double)_last_report.x, (double)_last_report.y, (double)_last_report.z);
 	printf("offsets (%.2f %.2f %.2f)\n", (double)_scale.x_offset, (double)_scale.y_offset, (double)_scale.z_offset);

--- a/src/drivers/ll40ls/LidarLiteI2C.cpp
+++ b/src/drivers/ll40ls/LidarLiteI2C.cpp
@@ -60,7 +60,6 @@ LidarLiteI2C::LidarLiteI2C(int bus, const char *path, int address) :
 	_distance_sensor_topic(nullptr),
 	_sample_perf(perf_alloc(PC_ELAPSED, "ll40ls_i2c_read")),
 	_comms_errors(perf_alloc(PC_COUNT, "ll40ls_i2c_comms_errors")),
-	_buffer_overflows(perf_alloc(PC_COUNT, "ll40ls_buffer_i2c_overflows")),
 	_sensor_resets(perf_alloc(PC_COUNT, "ll40ls_i2c_resets")),
 	_sensor_zero_resets(perf_alloc(PC_COUNT, "ll40ls_i2c_zero_resets")),
 	_last_distance(0),
@@ -98,7 +97,6 @@ LidarLiteI2C::~LidarLiteI2C()
 	// free perf counters
 	perf_free(_sample_perf);
 	perf_free(_comms_errors);
-	perf_free(_buffer_overflows);
 	perf_free(_sensor_resets);
 	perf_free(_sensor_zero_resets);
 }
@@ -465,9 +463,7 @@ int LidarLiteI2C::collect()
 		orb_publish(ORB_ID(distance_sensor), _distance_sensor_topic, &report);
 	}
 
-	if (_reports->force(&report)) {
-		perf_count(_buffer_overflows);
-	}
+	_reports->force(&report);
 
 	/* notify anyone waiting for data */
 	poll_notify(POLLIN);
@@ -561,7 +557,6 @@ void LidarLiteI2C::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	perf_print_counter(_buffer_overflows);
 	perf_print_counter(_sensor_resets);
 	perf_print_counter(_sensor_zero_resets);
 	printf("poll interval:  %u ticks\n", getMeasureTicks());

--- a/src/drivers/ll40ls/LidarLiteI2C.h
+++ b/src/drivers/ll40ls/LidarLiteI2C.h
@@ -110,7 +110,6 @@ private:
 
 	perf_counter_t      _sample_perf;
 	perf_counter_t      _comms_errors;
-	perf_counter_t      _buffer_overflows;
 	perf_counter_t      _sensor_resets;
 	perf_counter_t      _sensor_zero_resets;
 	uint16_t        _last_distance;

--- a/src/drivers/ll40ls/LidarLitePWM.cpp
+++ b/src/drivers/ll40ls/LidarLitePWM.cpp
@@ -61,7 +61,6 @@ LidarLitePWM::LidarLitePWM(const char *path) :
 	_range{},
 	_sample_perf(perf_alloc(PC_ELAPSED, "ll40ls_pwm_read")),
 	_read_errors(perf_alloc(PC_COUNT, "ll40ls_pwm_read_errors")),
-	_buffer_overflows(perf_alloc(PC_COUNT, "ll40ls_pwm_buffer_overflows")),
 	_sensor_zero_resets(perf_alloc(PC_COUNT, "ll40ls_pwm_zero_resets"))
 {
 }
@@ -81,7 +80,6 @@ LidarLitePWM::~LidarLitePWM()
 
 	/* free perf counters */
 	perf_free(_sample_perf);
-	perf_free(_buffer_overflows);
 	perf_free(_sensor_zero_resets);
 }
 
@@ -122,7 +120,6 @@ void LidarLitePWM::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_read_errors);
-	perf_print_counter(_buffer_overflows);
 	perf_print_counter(_sensor_zero_resets);
 	warnx("poll interval:  %u ticks", getMeasureTicks());
 	warnx("distance: %.3fm", (double)_range.current_distance);
@@ -196,9 +193,7 @@ int LidarLitePWM::measure()
 		orb_publish(ORB_ID(distance_sensor), _distance_sensor_topic, &_range);
 	}
 
-	if (_reports->force(&_range)) {
-		perf_count(_buffer_overflows);
-	}
+	_reports->force(&_range);
 
 	poll_notify(POLLIN);
 	perf_end(_sample_perf);

--- a/src/drivers/ll40ls/LidarLitePWM.h
+++ b/src/drivers/ll40ls/LidarLitePWM.h
@@ -116,6 +116,5 @@ private:
 
 	perf_counter_t	        _sample_perf;
 	perf_counter_t	        _read_errors;
-	perf_counter_t	        _buffer_overflows;
 	perf_counter_t	        _sensor_zero_resets;
 };

--- a/src/drivers/lps25h/lps25h.cpp
+++ b/src/drivers/lps25h/lps25h.cpp
@@ -226,7 +226,6 @@ private:
 
 	perf_counter_t		_sample_perf;
 	perf_counter_t		_comms_errors;
-	perf_counter_t		_buffer_overflows;
 
 	struct baro_report	_last_report;           /**< used for info() */
 
@@ -336,7 +335,6 @@ LPS25H::LPS25H(device::Device *interface, const char *path) :
 	_class_instance(-1),
 	_sample_perf(perf_alloc(PC_ELAPSED, "lps25h_read")),
 	_comms_errors(perf_alloc(PC_COUNT, "lps25h_comms_errors")),
-	_buffer_overflows(perf_alloc(PC_COUNT, "lps25h_buffer_overflows")),
 	_last_report{0}
 {
 	// set the device type from the interface
@@ -368,7 +366,6 @@ LPS25H::~LPS25H()
 	// free perf counters
 	perf_free(_sample_perf);
 	perf_free(_comms_errors);
-	perf_free(_buffer_overflows);
 
 	delete _interface;
 }
@@ -771,9 +768,7 @@ LPS25H::collect()
 	_last_report = new_report;
 
 	/* post a report to the ring */
-	if (_reports->force(&new_report)) {
-		perf_count(_buffer_overflows);
-	}
+	_reports->force(&new_report);
 
 	/* notify anyone waiting for data */
 	poll_notify(POLLIN);
@@ -806,7 +801,6 @@ LPS25H::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	perf_print_counter(_buffer_overflows);
 	printf("poll interval:  %u ticks\n", _measure_ticks);
 	printf("pressure    %.2f\n", (double)_last_report.pressure);
 	printf("altitude:    %.2f\n", (double)_last_report.altitude);

--- a/src/drivers/mb12xx/mb12xx.cpp
+++ b/src/drivers/mb12xx/mb12xx.cpp
@@ -130,7 +130,6 @@ private:
 
 	perf_counter_t		_sample_perf;
 	perf_counter_t		_comms_errors;
-	perf_counter_t		_buffer_overflows;
 
 	uint8_t				_cycle_counter;	/* counter in cycle to change i2c adresses */
 	int					_cycling_rate;	/* */
@@ -208,7 +207,6 @@ MB12XX::MB12XX(int bus, int address) :
 	_distance_sensor_topic(nullptr),
 	_sample_perf(perf_alloc(PC_ELAPSED, "mb12xx_read")),
 	_comms_errors(perf_alloc(PC_COUNT, "mb12xx_com_err")),
-	_buffer_overflows(perf_alloc(PC_COUNT, "mb12xx_buf_of")),
 	_cycle_counter(0),	/* initialising counter for cycling function to zero */
 	_cycling_rate(0),	/* initialising cycling rate (which can differ depending on one sonar or multiple) */
 	_index_counter(0) 	/* initialising temp sonar i2c address to zero */
@@ -238,7 +236,6 @@ MB12XX::~MB12XX()
 	/* free perf counters */
 	perf_free(_sample_perf);
 	perf_free(_comms_errors);
-	perf_free(_buffer_overflows);
 }
 
 int
@@ -584,9 +581,7 @@ MB12XX::collect()
 		orb_publish(ORB_ID(distance_sensor), _distance_sensor_topic, &report);
 	}
 
-	if (_reports->force(&report)) {
-		perf_count(_buffer_overflows);
-	}
+	_reports->force(&report);
 
 	/* notify anyone waiting for data */
 	poll_notify(POLLIN);
@@ -711,7 +706,6 @@ MB12XX::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	perf_print_counter(_buffer_overflows);
 	printf("poll interval:  %u ticks\n", _measure_ticks);
 	_reports->print_info("report queue");
 }

--- a/src/drivers/px4flow/px4flow.cpp
+++ b/src/drivers/px4flow/px4flow.cpp
@@ -133,7 +133,6 @@ private:
 
 	perf_counter_t		_sample_perf;
 	perf_counter_t		_comms_errors;
-	perf_counter_t		_buffer_overflows;
 
 	enum Rotation				_sensor_rotation;
 
@@ -193,7 +192,6 @@ PX4FLOW::PX4FLOW(int bus, int address, enum Rotation rotation) :
 	_distance_sensor_topic(nullptr),
 	_sample_perf(perf_alloc(PC_ELAPSED, "px4f_read")),
 	_comms_errors(perf_alloc(PC_COUNT, "px4f_com_err")),
-	_buffer_overflows(perf_alloc(PC_COUNT, "px4f_buf_of")),
 	_sensor_rotation(rotation)
 {
 	// disable debug() calls
@@ -215,7 +213,6 @@ PX4FLOW::~PX4FLOW()
 
 	perf_free(_sample_perf);
 	perf_free(_comms_errors);
-	perf_free(_buffer_overflows);
 }
 
 int
@@ -568,9 +565,7 @@ PX4FLOW::collect()
 	orb_publish(ORB_ID(distance_sensor), _distance_sensor_topic, &distance_report);
 
 	/* post a report to the ring */
-	if (_reports->force(&report)) {
-		perf_count(_buffer_overflows);
-	}
+	_reports->force(&report);
 
 	/* notify anyone waiting for data */
 	poll_notify(POLLIN);
@@ -647,7 +642,6 @@ PX4FLOW::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	perf_print_counter(_buffer_overflows);
 	printf("poll interval:  %u ticks\n", _measure_ticks);
 	_reports->print_info("report queue");
 }

--- a/src/drivers/sf0x/sf0x.cpp
+++ b/src/drivers/sf0x/sf0x.cpp
@@ -130,7 +130,6 @@ private:
 
 	perf_counter_t			_sample_perf;
 	perf_counter_t			_comms_errors;
-	perf_counter_t			_buffer_overflows;
 
 	/**
 	* Initialise the automatic measurement state machine and start it.
@@ -196,8 +195,7 @@ SF0X::SF0X(const char *port) :
 	_distance_sensor_topic(nullptr),
 	_consecutive_fail_count(0),
 	_sample_perf(perf_alloc(PC_ELAPSED, "sf0x_read")),
-	_comms_errors(perf_alloc(PC_COUNT, "sf0x_com_err")),
-	_buffer_overflows(perf_alloc(PC_COUNT, "sf0x_buf_of"))
+	_comms_errors(perf_alloc(PC_COUNT, "sf0x_com_err"))
 {
 	/* store port name */
 	strncpy(_port, port, sizeof(_port));
@@ -262,7 +260,6 @@ SF0X::~SF0X()
 
 	perf_free(_sample_perf);
 	perf_free(_comms_errors);
-	perf_free(_buffer_overflows);
 }
 
 int
@@ -645,9 +642,7 @@ SF0X::collect()
 	/* publish it */
 	orb_publish(ORB_ID(distance_sensor), _distance_sensor_topic, &report);
 
-	if (_reports->force(&report)) {
-		perf_count(_buffer_overflows);
-	}
+	_reports->force(&report);
 
 	/* notify anyone waiting for data */
 	poll_notify(POLLIN);
@@ -782,7 +777,6 @@ SF0X::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	perf_print_counter(_buffer_overflows);
 	printf("poll interval:  %d ticks\n", _measure_ticks);
 	_reports->print_info("report queue");
 }

--- a/src/drivers/sf1xx/sf1xx.cpp
+++ b/src/drivers/sf1xx/sf1xx.cpp
@@ -120,7 +120,6 @@ private:
 
 	perf_counter_t		_sample_perf;
 	perf_counter_t		_comms_errors;
-	perf_counter_t		_buffer_overflows;
 
 
 
@@ -191,8 +190,7 @@ SF1XX::SF1XX(int bus, int address) :
 	_orb_class_instance(-1),
 	_distance_sensor_topic(nullptr),
 	_sample_perf(perf_alloc(PC_ELAPSED, "sf1xx_read")),
-	_comms_errors(perf_alloc(PC_COUNT, "sf1xx_com_err")),
-	_buffer_overflows(perf_alloc(PC_COUNT, "sf1xx_buf_of"))
+	_comms_errors(perf_alloc(PC_COUNT, "sf1xx_com_err"))
 
 {
 	/* enable debug() calls */
@@ -223,7 +221,6 @@ SF1XX::~SF1XX()
 	/* free perf counters */
 	perf_free(_sample_perf);
 	perf_free(_comms_errors);
-	perf_free(_buffer_overflows);
 }
 
 int
@@ -572,9 +569,7 @@ SF1XX::collect()
 		orb_publish(ORB_ID(distance_sensor), _distance_sensor_topic, &report);
 	}
 
-	if (_reports->force(&report)) {
-		perf_count(_buffer_overflows);
-	}
+	_reports->force(&report);
 
 	/* notify anyone waiting for data */
 	poll_notify(POLLIN);
@@ -637,7 +632,6 @@ SF1XX::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	perf_print_counter(_buffer_overflows);
 	printf("poll interval:  %u ticks\n", _measure_ticks);
 	_reports->print_info("report queue");
 }

--- a/src/drivers/srf02/srf02.cpp
+++ b/src/drivers/srf02/srf02.cpp
@@ -131,7 +131,6 @@ private:
 
 	perf_counter_t		_sample_perf;
 	perf_counter_t		_comms_errors;
-	perf_counter_t		_buffer_overflows;
 
 	uint8_t				_cycle_counter;	/* counter in cycle to change i2c adresses */
 	int					_cycling_rate;	/* */
@@ -209,7 +208,6 @@ SRF02::SRF02(int bus, int address) :
 	_distance_sensor_topic(nullptr),
 	_sample_perf(perf_alloc(PC_ELAPSED, "srf02_read")),
 	_comms_errors(perf_alloc(PC_COUNT, "srf02_com_err")),
-	_buffer_overflows(perf_alloc(PC_COUNT, "srf02_buf_of")),
 	_cycle_counter(0),	/* initialising counter for cycling function to zero */
 	_cycling_rate(0),	/* initialising cycling rate (which can differ depending on one sonar or multiple) */
 	_index_counter(0) 	/* initialising temp sonar i2c address to zero */
@@ -239,7 +237,6 @@ SRF02::~SRF02()
 	/* free perf counters */
 	perf_free(_sample_perf);
 	perf_free(_comms_errors);
-	perf_free(_buffer_overflows);
 }
 
 int
@@ -588,9 +585,7 @@ SRF02::collect()
 		orb_publish(ORB_ID(distance_sensor), _distance_sensor_topic, &report);
 	}
 
-	if (_reports->force(&report)) {
-		perf_count(_buffer_overflows);
-	}
+	_reports->force(&report);
 
 	/* notify anyone waiting for data */
 	poll_notify(POLLIN);
@@ -715,7 +710,6 @@ SRF02::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	perf_print_counter(_buffer_overflows);
 	printf("poll interval:  %u ticks\n", _measure_ticks);
 	_reports->print_info("report queue");
 }

--- a/src/drivers/srf02_i2c/srf02_i2c.cpp
+++ b/src/drivers/srf02_i2c/srf02_i2c.cpp
@@ -132,7 +132,6 @@ private:
 
 	perf_counter_t		_sample_perf;
 	perf_counter_t		_comms_errors;
-	perf_counter_t		_buffer_overflows;
 
 	uint8_t				_cycle_counter;	/* counter in cycle to change i2c adresses */
 	int					_cycling_rate;	/* */
@@ -210,7 +209,6 @@ SRF02_I2C::SRF02_I2C(int bus, int address) :
 	_distance_sensor_topic(nullptr),
 	_sample_perf(perf_alloc(PC_ELAPSED, "srf02_i2c_read")),
 	_comms_errors(perf_alloc(PC_COUNT, "srf02_i2c_comms_errors")),
-	_buffer_overflows(perf_alloc(PC_COUNT, "srf02_i2c_buffer_overflows")),
 	_cycle_counter(0),	/* initialising counter for cycling function to zero */
 	_cycling_rate(0),	/* initialising cycling rate (which can differ depending on one sonar or multiple) */
 	_index_counter(0) 	/* initialising temp sonar i2c address to zero */
@@ -240,7 +238,6 @@ SRF02_I2C::~SRF02_I2C()
 	/* free perf counters */
 	perf_free(_sample_perf);
 	perf_free(_comms_errors);
-	perf_free(_buffer_overflows);
 }
 
 int
@@ -589,9 +586,7 @@ SRF02_I2C::collect()
 		orb_publish(ORB_ID(distance_sensor), _distance_sensor_topic, &report);
 	}
 
-	if (_reports->force(&report)) {
-		perf_count(_buffer_overflows);
-	}
+	_reports->force(&report);
 
 	/* notify anyone waiting for data */
 	poll_notify(POLLIN);
@@ -715,7 +710,6 @@ SRF02_I2C::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	perf_print_counter(_buffer_overflows);
 	printf("poll interval:  %u ticks\n", _measure_ticks);
 	_reports->print_info("report queue");
 }

--- a/src/drivers/trone/trone.cpp
+++ b/src/drivers/trone/trone.cpp
@@ -130,7 +130,6 @@ private:
 
 	perf_counter_t		_sample_perf;
 	perf_counter_t		_comms_errors;
-	perf_counter_t		_buffer_overflows;
 
 	/**
 	* Test whether the device supported by the driver is present at a
@@ -238,8 +237,7 @@ TRONE::TRONE(int bus, int address) :
 	_orb_class_instance(-1),
 	_distance_sensor_topic(nullptr),
 	_sample_perf(perf_alloc(PC_ELAPSED, "tr1_read")),
-	_comms_errors(perf_alloc(PC_COUNT, "tr1_com_err")),
-	_buffer_overflows(perf_alloc(PC_COUNT, "tr1_buf_of"))
+	_comms_errors(perf_alloc(PC_COUNT, "tr1_com_err"))
 {
 	// up the retries since the device misses the first measure attempts
 	I2C::_retries = 3;
@@ -268,7 +266,6 @@ TRONE::~TRONE()
 	// free perf counters
 	perf_free(_sample_perf);
 	perf_free(_comms_errors);
-	perf_free(_buffer_overflows);
 }
 
 int
@@ -599,9 +596,7 @@ TRONE::collect()
 		orb_publish(ORB_ID(distance_sensor), _distance_sensor_topic, &report);
 	}
 
-	if (_reports->force(&report)) {
-		perf_count(_buffer_overflows);
-	}
+	_reports->force(&report);
 
 	/* notify anyone waiting for data */
 	poll_notify(POLLIN);
@@ -706,7 +701,6 @@ TRONE::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	perf_print_counter(_buffer_overflows);
 	printf("poll interval:  %u ticks\n", _measure_ticks);
 	_reports->print_info("report queue");
 }

--- a/src/platforms/posix/drivers/airspeedsim/airspeedsim.cpp
+++ b/src/platforms/posix/drivers/airspeedsim/airspeedsim.cpp
@@ -74,7 +74,6 @@
 AirspeedSim::AirspeedSim(int bus, int address, unsigned conversion_interval, const char *path) :
 	VDev("AIRSPEEDSIM", path),
 	_reports(nullptr),
-	_buffer_overflows(perf_alloc(PC_COUNT, "airspeed_buffer_overflows")),
 	_retries(0),
 	_max_differential_pressure_pa(0),
 	_sensor_ok(false),
@@ -113,7 +112,6 @@ AirspeedSim::~AirspeedSim()
 	// free perf counters
 	perf_free(_sample_perf);
 	perf_free(_comms_errors);
-	perf_free(_buffer_overflows);
 }
 
 int
@@ -405,7 +403,6 @@ AirspeedSim::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	perf_print_counter(_buffer_overflows);
 	PX4_INFO("poll interval:  %u ticks", _measure_ticks);
 	_reports->print_info("report queue");
 }
@@ -413,9 +410,7 @@ AirspeedSim::print_info()
 void
 AirspeedSim::new_report(const differential_pressure_s &report)
 {
-	if (!_reports->force(&report)) {
-		perf_count(_buffer_overflows);
-	}
+	_reports->force(&report);
 }
 
 int

--- a/src/platforms/posix/drivers/airspeedsim/airspeedsim.h
+++ b/src/platforms/posix/drivers/airspeedsim/airspeedsim.h
@@ -96,7 +96,6 @@ public:
 
 private:
 	ringbuffer::RingBuffer		*_reports;
-	perf_counter_t		_buffer_overflows;
 
 	unsigned _retries;	// XXX this should come from the SIM class
 

--- a/src/platforms/posix/drivers/barosim/baro.cpp
+++ b/src/platforms/posix/drivers/barosim/baro.cpp
@@ -122,7 +122,6 @@ protected:
 	perf_counter_t		_sample_perf;
 	perf_counter_t		_measure_perf;
 	perf_counter_t		_comms_errors;
-	perf_counter_t		_buffer_overflows;
 
 	/**
 	 * Initialize the automatic measurement state machine and start it.
@@ -203,8 +202,7 @@ BAROSIM::BAROSIM(const char *path) :
 	_orb_class_instance(-1),
 	_sample_perf(perf_alloc(PC_ELAPSED, "barosim_read")),
 	_measure_perf(perf_alloc(PC_ELAPSED, "barosim_measure")),
-	_comms_errors(perf_alloc(PC_COUNT, "barosim_comms_errors")),
-	_buffer_overflows(perf_alloc(PC_COUNT, "barosim_buffer_overflows"))
+	_comms_errors(perf_alloc(PC_COUNT, "barosim_comms_errors"))
 {
 
 }
@@ -223,7 +221,6 @@ BAROSIM::~BAROSIM()
 	perf_free(_sample_perf);
 	perf_free(_measure_perf);
 	perf_free(_comms_errors);
-	perf_free(_buffer_overflows);
 
 }
 
@@ -694,9 +691,7 @@ BAROSIM::collect()
 			}
 		}
 
-		if (_reports->force(&report)) {
-			perf_count(_buffer_overflows);
-		}
+		_reports->force(&report);
 
 		/* notify anyone waiting for data */
 		//DevMgr::updateNotify(*this);
@@ -716,7 +711,6 @@ BAROSIM::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	perf_print_counter(_buffer_overflows);
 	PX4_INFO("poll interval:  %u usec", m_sample_interval_usecs);
 	_reports->print_info("report queue");
 	PX4_INFO("TEMP:           %f", (double)report.temperature);


### PR DESCRIPTION
32 bits are still enough to measure elapsed times up to 1 hour.

Testing on Pixracer: I counted 73 allocations and 39 frees during bootup,
resulting in 2kB RAM usage after boot. This patch reduces this by ~0.5kB.

Fixes #6801