### PR TITLE
modules: dataman: Optimize memory usage

### DIFF
--- a/src/modules/dataman/dataman.h
+++ b/src/modules/dataman/dataman.h
@@ -44,6 +44,7 @@
 #include <uORB/topics/mission.h>
 #include <uORB/topics/fence.h>
 #include <uORB/topics/fence_vertex.h>
+#include <uORB/topics/home_position.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -115,20 +116,6 @@ struct dataman_compat_s {
 #define DM_COMPAT_VERSION	1ULL
 
 #define DM_COMPAT_KEY ((DM_COMPAT_VERSION << 32) + (sizeof(struct mission_item_s) << 24) + (sizeof(struct mission_s) << 16) + (sizeof(struct fence_vertex_s) << 8) + sizeof(struct dataman_compat_s))
-
-/** Maximum size in bytes of a single item instance is
- * defined by adding the structure type to the union below
- */
-
-typedef union dataman_max_size_t {
-	struct mission_item_s		mission_item;
-	struct mission_s			mission;
-	struct fence_vertex_s		vertex;
-	struct dataman_compat_s		compat;
-} dataman_max_size_t;
-
-
-#define DM_MAX_DATA_SIZE sizeof(dataman_max_size_t)
 
 /** Retrieve from the data manager store */
 __EXPORT ssize_t

--- a/src/systemcmds/tests/test_dataman.c
+++ b/src/systemcmds/tests/test_dataman.c
@@ -63,6 +63,8 @@ int test_dataman(int argc, char *argv[]);
 
 #define NUM_MISSIONS_TEST 50
 
+#define DM_MAX_DATA_SIZE sizeof(struct mission_s)
+
 static int
 task_main(int argc, char *argv[])
 {


### PR DESCRIPTION
Use the size of each item type instead of the biggest one.

In AeroFC that runs is constrained mode it was using 7860 bytes
and now it uses 6930 bytes almost 1KB less.