### PR TITLE
WIP: mc_pos_control auto handling

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1472,7 +1472,6 @@ void MulticopterPositionControl::control_auto(float dt)
 		}
 	}
 
-
 	if (current_setpoint_valid &&
 	    (_pos_sp_triplet.current.type != position_setpoint_s::SETPOINT_TYPE_IDLE)) {
 
@@ -1485,7 +1484,10 @@ void MulticopterPositionControl::control_auto(float dt)
 		math::Vector<3> cruising_speed(cruising_speed_xy,
 					       cruising_speed_xy,
 					       cruising_speed_z);
-
+		/* if previous is valid, we want to follow line */
+		if (previous_setpoint_valid
+		    && (_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_POSITION  ||
+			_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_FOLLOW_TARGET)) {
 
 			math::Vector<3> scale = _params.pos_p.edivide(cruising_speed);
 
@@ -1505,7 +1507,8 @@ void MulticopterPositionControl::control_auto(float dt)
 			/* we are close to current setpoint */
 			if (curr_pos_s_len < 1.0f) {
 
-				if ((next_sp - curr_sp).length() > MIN_DIST) {
+				/* if next is valid, we want to have smooth transition */
+				if ( next_setpoint_valid && (next_sp - curr_sp).length() > MIN_DIST) {
 
 					math::Vector<3> next_sp_s = next_sp.emult(scale);
 
@@ -1544,8 +1547,23 @@ void MulticopterPositionControl::control_auto(float dt)
 				}
 			}
 
+			/* move setpoint not faster than max allowed speed */
+			math::Vector<3> pos_sp_old_s = _pos_sp.emult(scale);
+
+			/* difference between current and desired position setpoints, 1 = max speed */
+			math::Vector<3> d_pos_m = (pos_sp_s - pos_sp_old_s).edivide(_params.pos_p);
+			float d_pos_m_len = d_pos_m.length();
+
+			if (d_pos_m_len > dt) {
+				pos_sp_s = pos_sp_old_s + (d_pos_m / d_pos_m_len * dt).emult(_params.pos_p);
+			}
+
 			/* scale back */
 			_pos_sp = pos_sp_s.edivide(scale);
+
+		/* default */
+		} else {
+			_pos_sp = curr_sp;
 		}
 
 		/* update yaw setpoint if needed */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1424,9 +1424,11 @@ void MulticopterPositionControl::control_auto(float dt)
 
 	bool current_setpoint_valid = false;
 	bool previous_setpoint_valid = false;
+	bool next_setpoint_valid = false;
 
 	math::Vector<3> prev_sp;
 	math::Vector<3> curr_sp;
+	math::Vector<3> next_sp;
 
 	if (_pos_sp_triplet.current.valid) {
 
@@ -1456,6 +1458,21 @@ void MulticopterPositionControl::control_auto(float dt)
 		}
 	}
 
+
+	if (_pos_sp_triplet.next.valid) {
+		map_projection_project(&_ref_pos,
+				       _pos_sp_triplet.next.lat, _pos_sp_triplet.next.lon,
+				       &next_sp.data[0], &next_sp.data[1]);
+		next_sp(2) = -(_pos_sp_triplet.next.alt - _ref_alt);
+
+		if (PX4_ISFINITE(next_sp(0)) &&
+		    PX4_ISFINITE(next_sp(1)) &&
+		    PX4_ISFINITE(next_sp(2))) {
+			next_setpoint_valid = true;
+		}
+	}
+
+
 	if (current_setpoint_valid &&
 	    (_pos_sp_triplet.current.type != position_setpoint_s::SETPOINT_TYPE_IDLE)) {
 
@@ -1469,67 +1486,52 @@ void MulticopterPositionControl::control_auto(float dt)
 					       cruising_speed_xy,
 					       cruising_speed_z);
 
-		math::Vector<3> scale = _params.pos_p.edivide(cruising_speed);
 
-		/* convert current setpoint to scaled space */
-		math::Vector<3> curr_sp_s = curr_sp.emult(scale);
+			math::Vector<3> scale = _params.pos_p.edivide(cruising_speed);
 
-		/* by default use current setpoint as is */
-		math::Vector<3> pos_sp_s = curr_sp_s;
+			/* convert current setpoint to scaled space */
+			math::Vector<3> curr_sp_s = curr_sp.emult(scale);
 
-		if ((_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_POSITION  ||
-		     _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_FOLLOW_TARGET) &&
-		    previous_setpoint_valid) {
+			/* by default use current setpoint as is */
+			math::Vector<3> pos_sp_s = curr_sp_s;
 
-			/* follow "previous - current" line */
+			/* find X - cross point of unit sphere and trajectory */
+			math::Vector<3> pos_s = _pos.emult(scale);
+			math::Vector<3> prev_sp_s = prev_sp.emult(scale);
+			math::Vector<3> prev_curr_s = curr_sp_s - prev_sp_s;
+			math::Vector<3> curr_pos_s = pos_s - curr_sp_s;
+			float curr_pos_s_len = curr_pos_s.length();
 
-			if ((curr_sp - prev_sp).length() > MIN_DIST) {
+			/* we are close to current setpoint */
+			if (curr_pos_s_len < 1.0f) {
 
-				/* find X - cross point of unit sphere and trajectory */
-				math::Vector<3> pos_s = _pos.emult(scale);
-				math::Vector<3> prev_sp_s = prev_sp.emult(scale);
-				math::Vector<3> prev_curr_s = curr_sp_s - prev_sp_s;
-				math::Vector<3> curr_pos_s = pos_s - curr_sp_s;
-				float curr_pos_s_len = curr_pos_s.length();
+				if ((next_sp - curr_sp).length() > MIN_DIST) {
 
-				if (curr_pos_s_len < 1.0f) {
-					/* copter is closer to waypoint than unit radius */
-					/* check next waypoint and use it to avoid slowing down when passing via waypoint */
-					if (_pos_sp_triplet.next.valid) {
-						math::Vector<3> next_sp;
-						map_projection_project(&_ref_pos,
-								       _pos_sp_triplet.next.lat, _pos_sp_triplet.next.lon,
-								       &next_sp.data[0], &next_sp.data[1]);
-						next_sp(2) = -(_pos_sp_triplet.next.alt - _ref_alt);
+					math::Vector<3> next_sp_s = next_sp.emult(scale);
 
-						if ((next_sp - curr_sp).length() > MIN_DIST) {
-							math::Vector<3> next_sp_s = next_sp.emult(scale);
+					/* calculate angle prev - curr - next */
+					math::Vector<3> curr_next_s = next_sp_s - curr_sp_s;
+					math::Vector<3> prev_curr_s_norm = prev_curr_s.normalized();
 
-							/* calculate angle prev - curr - next */
-							math::Vector<3> curr_next_s = next_sp_s - curr_sp_s;
-							math::Vector<3> prev_curr_s_norm = prev_curr_s.normalized();
+					/* cos(a) * curr_next, a = angle between current and next trajectory segments */
+					float cos_a_curr_next = prev_curr_s_norm * curr_next_s;
 
-							/* cos(a) * curr_next, a = angle between current and next trajectory segments */
-							float cos_a_curr_next = prev_curr_s_norm * curr_next_s;
+					/* cos(b), b = angle pos - curr_sp - prev_sp */
+					float cos_b = -curr_pos_s * prev_curr_s_norm / curr_pos_s_len;
 
-							/* cos(b), b = angle pos - curr_sp - prev_sp */
-							float cos_b = -curr_pos_s * prev_curr_s_norm / curr_pos_s_len;
+					if (cos_a_curr_next > 0.0f && cos_b > 0.0f) {
+						float curr_next_s_len = curr_next_s.length();
 
-							if (cos_a_curr_next > 0.0f && cos_b > 0.0f) {
-								float curr_next_s_len = curr_next_s.length();
-
-								/* if curr - next distance is larger than unit radius, limit it */
-								if (curr_next_s_len > 1.0f) {
-									cos_a_curr_next /= curr_next_s_len;
-								}
-
-								/* feed forward position setpoint offset */
-								math::Vector<3> pos_ff = prev_curr_s_norm *
-											 cos_a_curr_next * cos_b * cos_b * (1.0f - curr_pos_s_len) *
-											 (1.0f - expf(-curr_pos_s_len * curr_pos_s_len * 20.0f));
-								pos_sp_s += pos_ff;
-							}
+						/* if curr - next distance is larger than unit radius, limit it */
+						if (curr_next_s_len > 1.0f) {
+							cos_a_curr_next /= curr_next_s_len;
 						}
+
+						/* feed forward position setpoint offset */
+						math::Vector<3> pos_ff = prev_curr_s_norm *
+									 cos_a_curr_next * cos_b * cos_b * (1.0f - curr_pos_s_len) *
+									 (1.0f - expf(-curr_pos_s_len * curr_pos_s_len * 20.0f));
+						pos_sp_s += pos_ff;
 					}
 
 				} else {
@@ -1541,21 +1543,10 @@ void MulticopterPositionControl::control_auto(float dt)
 					}
 				}
 			}
+
+			/* scale back */
+			_pos_sp = pos_sp_s.edivide(scale);
 		}
-
-		/* move setpoint not faster than max allowed speed */
-		math::Vector<3> pos_sp_old_s = _pos_sp.emult(scale);
-
-		/* difference between current and desired position setpoints, 1 = max speed */
-		math::Vector<3> d_pos_m = (pos_sp_s - pos_sp_old_s).edivide(_params.pos_p);
-		float d_pos_m_len = d_pos_m.length();
-
-		if (d_pos_m_len > dt) {
-			pos_sp_s = pos_sp_old_s + (d_pos_m / d_pos_m_len * dt).emult(_params.pos_p);
-		}
-
-		/* scale result back to normal space */
-		_pos_sp = pos_sp_s.edivide(scale);
 
 		/* update yaw setpoint if needed */
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -169,6 +169,8 @@ private:
 	control::BlockDerivative _vel_y_deriv;
 	control::BlockDerivative _vel_z_deriv;
 
+	control::BlockParamFloat _target_threshold_xy;
+
 	struct {
 		param_t thr_min;
 		param_t thr_max;
@@ -188,7 +190,6 @@ private:
 		param_t xy_vel_d;
 		param_t xy_vel_max;
 		param_t xy_vel_cruise;
-		param_t xy_target_threshold;
 		param_t xy_ff;
 		param_t tilt_max_air;
 		param_t land_speed;
@@ -238,7 +239,6 @@ private:
 		float vel_cruise_xy;
 		float vel_max_up;
 		float vel_max_down;
-		float target_threshold_xy;
 		float xy_vel_man_expo;
 		uint32_t alt_mode;
 
@@ -283,7 +283,7 @@ private:
 	math::Vector<3> _vel_ff;
 	math::Vector<3> _vel_sp_prev;
 	math::Vector<3> _vel_err_d;		/**< derivative of current velocity */
-	math::Vector<3> _curr_sp;  /**< the previous current setpoint of the triplets */
+	math::Vector<3> _curr_pos_sp;  /**< current setpoint of the triplets */
 
 	math::Matrix<3, 3> _R;			/**< rotation matrix from attitude quaternions */
 	float _yaw;				/**< yaw angle (euler) */
@@ -295,7 +295,6 @@ private:
 	float _acc_z_lp;
 	float _takeoff_thrust_sp;
 	float _vel_max_xy;  /**< equal to vel_max except in auto mode when close to target */
-	float _vel_target_entry;  /**< entry velocity in auto mode when close to target */
 
 	// counters for reset events on position and velocity states
 	// they are used to identify a reset event
@@ -451,9 +450,9 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_vel_x_deriv(this, "VELD"),
 	_vel_y_deriv(this, "VELD"),
 	_vel_z_deriv(this, "VELD"),
+	_target_threshold_xy(this, "MPC_TARGET_THRE"),
 	_ref_alt(0.0f),
 	_ref_timestamp(0),
-
 	_reset_pos_sp(true),
 	_reset_alt_sp(true),
 	_do_reset_alt_pos_flag(true),
@@ -471,7 +470,6 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_acc_z_lp(0),
 	_takeoff_thrust_sp(0.0f),
 	_vel_max_xy(0.0f),
-	_vel_target_entry(0.0f),
 	_z_reset_counter(0),
 	_xy_reset_counter(0),
 	_vz_reset_counter(0),
@@ -497,7 +495,7 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_vel_ff.zero();
 	_vel_sp_prev.zero();
 	_vel_err_d.zero();
-	_curr_sp.zero();
+	_curr_pos_sp.zero();
 
 	_R.identity();
 
@@ -523,7 +521,6 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_params_handles.xy_vel_d	= param_find("MPC_XY_VEL_D");
 	_params_handles.xy_vel_max	= param_find("MPC_XY_VEL_MAX");
 	_params_handles.xy_vel_cruise	= param_find("MPC_XY_CRUISE");
-	_params_handles.xy_target_threshold = param_find("MPC_TARGET_THRE");
 	_params_handles.xy_ff		= param_find("MPC_XY_FF");
 	_params_handles.tilt_max_air	= param_find("MPC_TILTMAX_AIR");
 	_params_handles.land_speed	= param_find("MPC_LAND_SPEED");
@@ -634,8 +631,6 @@ MulticopterPositionControl::parameters_update(bool force)
 		_params.vel_max_down = v;
 		param_get(_params_handles.xy_vel_cruise, &v);
 		_params.vel_cruise_xy = v;
-		param_get(_params_handles.xy_target_threshold, &v);
-		_params.target_threshold_xy = v;
 		param_get(_params_handles.xy_ff, &v);
 		v = math::constrain(v, 0.0f, 1.0f);
 		_params.vel_ff(0) = v;
@@ -961,8 +956,8 @@ MulticopterPositionControl::limit_vel_xy_gradually()
 	 * the max velocity is defined by the linear line
 	 * with x= (curr_sp - pos) and y = _vel_sp
 	 */
-	float slope = get_cruising_speed_xy()  / _params.target_threshold_xy;
-	float vel_limit =  slope * (_curr_sp - _pos).length();
+	float slope = get_cruising_speed_xy()  / _target_threshold_xy.get();
+	float vel_limit =  slope * (_curr_pos_sp - _pos).length();
 	float vel_mag_xy = sqrtf(_vel_sp(0) * _vel_sp(0) + _vel_sp(1) * _vel_sp(1));
 	float vel_mag_valid = math::min(vel_mag_xy, vel_limit);
 	_vel_sp(0) = _vel_sp(0) / vel_mag_xy * vel_mag_valid;
@@ -1476,12 +1471,12 @@ void MulticopterPositionControl::control_auto(float dt)
 		/* project setpoint to local frame */
 		map_projection_project(&_ref_pos,
 				       _pos_sp_triplet.current.lat, _pos_sp_triplet.current.lon,
-				       &_curr_sp.data[0], &_curr_sp.data[1]);
-		_curr_sp(2) = -(_pos_sp_triplet.current.alt - _ref_alt);
+				       &_curr_pos_sp.data[0], &_curr_pos_sp.data[1]);
+		_curr_pos_sp(2) = -(_pos_sp_triplet.current.alt - _ref_alt);
 
-		if (PX4_ISFINITE(_curr_sp(0)) &&
-		    PX4_ISFINITE(_curr_sp(1)) &&
-		    PX4_ISFINITE(_curr_sp(2))) {
+		if (PX4_ISFINITE(_curr_pos_sp(0)) &&
+		    PX4_ISFINITE(_curr_pos_sp(1)) &&
+		    PX4_ISFINITE(_curr_pos_sp(2))) {
 			current_setpoint_valid = true;
 		}
 
@@ -1518,13 +1513,13 @@ void MulticopterPositionControl::control_auto(float dt)
 	* no next setpoint available: we only consider updated if xy is updated
 	*/
 	_limit_vel_xy = (!next_setpoint_valid || (_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LOITER))
-			&& ((_curr_sp - _pos).length() <= _params.target_threshold_xy);
+			&& ((_curr_pos_sp - _pos).length() <= _target_threshold_xy.get());
 
 	if (current_setpoint_valid &&
 	    (_pos_sp_triplet.current.type != position_setpoint_s::SETPOINT_TYPE_IDLE)) {
 
 		float cruising_speed_xy = get_cruising_speed_xy();
-		float cruising_speed_z = (_curr_sp(2) > _pos(2)) ? _params.vel_max_down : _params.vel_max_up;
+		float cruising_speed_z = (_curr_pos_sp(2) > _pos(2)) ? _params.vel_max_down : _params.vel_max_up;
 
 		/* scaled space: 1 == position error resulting max allowed speed */
 		math::Vector<3> cruising_speed(cruising_speed_xy,
@@ -1540,12 +1535,12 @@ void MulticopterPositionControl::control_auto(float dt)
 			math::Vector<3> scale = _params.pos_p.edivide(cruising_speed);
 
 			/* convert current setpoint to scaled space */
-			math::Vector<3> curr_sp_s = _curr_sp.emult(scale);
+			math::Vector<3> curr_sp_s = _curr_pos_sp.emult(scale);
 
 			/* by default use current setpoint as is */
 			math::Vector<3> pos_sp_s = curr_sp_s;
 
-			if ((_curr_sp - prev_sp).length() > MIN_DIST) {
+			if ((_curr_pos_sp - prev_sp).length() > MIN_DIST) {
 
 				/* find X - cross point of unit sphere and trajectory */
 				math::Vector<3> pos_s = _pos.emult(scale);
@@ -1558,7 +1553,7 @@ void MulticopterPositionControl::control_auto(float dt)
 				if (curr_pos_s_len < 1.0f) {
 
 					/* if next is valid, we want to have smooth transition */
-					if (next_setpoint_valid && (next_sp - _curr_sp).length() > MIN_DIST) {
+					if (next_setpoint_valid && (next_sp - _curr_pos_sp).length() > MIN_DIST) {
 
 						math::Vector<3> next_sp_s = next_sp.emult(scale);
 
@@ -1569,7 +1564,7 @@ void MulticopterPositionControl::control_auto(float dt)
 						/* cos(a) * curr_next, a = angle between current and next trajectory segments */
 						float cos_a_curr_next = prev_curr_s_norm * curr_next_s;
 
-						/* cos(b), b = angle pos - _curr_sp - prev_sp */
+						/* cos(b), b = angle pos - _curr_pos_sp - prev_sp */
 						float cos_b = -curr_pos_s * prev_curr_s_norm / curr_pos_s_len;
 
 						if (cos_a_curr_next > 0.0f && cos_b > 0.0f) {
@@ -1615,7 +1610,7 @@ void MulticopterPositionControl::control_auto(float dt)
 
 		} else {
 			/* we just have a current setpoint that we want to go to */
-			_pos_sp = _curr_sp;
+			_pos_sp = _curr_pos_sp;
 
 			/* set max velocity to cruise */
 			_vel_max_xy = cruising_speed(0);

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -287,6 +287,38 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_D, 0.01f);
 PARAM_DEFINE_FLOAT(MPC_XY_CRUISE, 5.0f);
 
 /**
+ * Nominal horizontal velocity minimum cruise speed when close to target
+ *
+ * Normal horizontal velocity in AUTO modes (includes
+ * also RTL / hold / etc.) and endpoint for
+ * position stabilized mode (POSCTRL).
+ *
+ * @unit m/s
+ * @min 0.0
+ * @max 10.0
+ * @increment 1
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_CRUISE_MIN, 0.5f);
+
+/**
+ * Distance Threshold Horizontal Auto
+ *
+ * The distance defines at which point the vehicle
+ * has to slow down to reach target if no direct
+ * passing to the next target is desired
+ *
+ * @unit m
+ * @min 1.0
+ * @max 50.0
+ * @increment 1
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_TARGET_THRE, 10.0f);
+
+/**
  * Maximum horizontal velocity
  *
  * Maximum horizontal velocity in AUTO mode. If higher speeds

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -287,22 +287,6 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_D, 0.01f);
 PARAM_DEFINE_FLOAT(MPC_XY_CRUISE, 5.0f);
 
 /**
- * Nominal horizontal velocity minimum cruise speed when close to target
- *
- * Normal horizontal velocity in AUTO modes (includes
- * also RTL / hold / etc.) and endpoint for
- * position stabilized mode (POSCTRL).
- *
- * @unit m/s
- * @min 0.0
- * @max 10.0
- * @increment 1
- * @decimal 2
- * @group Multicopter Position Control
- */
-PARAM_DEFINE_FLOAT(MPC_CRUISE_MIN, 0.0f);
-
-/**
  * Distance Threshold Horizontal Auto
  *
  * The distance defines at which point the vehicle

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -300,7 +300,7 @@ PARAM_DEFINE_FLOAT(MPC_XY_CRUISE, 5.0f);
  * @decimal 2
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_CRUISE_MIN, 0.5f);
+PARAM_DEFINE_FLOAT(MPC_CRUISE_MIN, 0.0f);
 
 /**
  * Distance Threshold Horizontal Auto
@@ -316,7 +316,7 @@ PARAM_DEFINE_FLOAT(MPC_CRUISE_MIN, 0.5f);
  * @decimal 2
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_TARGET_THRE, 10.0f);
+PARAM_DEFINE_FLOAT(MPC_TARGET_THRE, 15.0f);
 
 /**
  * Maximum horizontal velocity


### PR DESCRIPTION
the position setpoint is just set to the current setpoint without positional slewrate. this is just for now, since a better solution is to actually use a trajectory (not slewrate) from which position, velocity and maybe acceleration can be derived from (like here:
https://github.com/PX4/Firmware/pull/6717).

This change covers the issues here:
https://github.com/PX4/Firmware/issues/6681

What it needs: 
- real world testing
- adjust speed (right now it ignores cruise speed and is saturated with max velocity)