### PR TITLE
Fix led during calibration

### DIFF
--- a/src/modules/commander/calibration_routines.cpp
+++ b/src/modules/commander/calibration_routines.cpp
@@ -55,6 +55,8 @@
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/sensor_combined.h>
 
+#include <drivers/drv_tone_alarm.h>
+
 #include "calibration_routines.h"
 #include "calibration_messages.h"
 #include "commander_helper.h"
@@ -782,7 +784,10 @@ calibrate_return calibrate_from_orientation(orb_advert_t *mavlink_log_pub,
 
 		// Note that this side is complete
 		side_data_collected[orient] = true;
-		tune_neutral(true);
+		// output neutral tune
+		set_tune(TONE_NOTIFY_NEUTRAL_TUNE);
+		// temporary priority boost for the white blinking led to come trough
+		rgbled_set_color_and_mode(led_control_s::COLOR_WHITE, led_control_s::MODE_BLINK_FAST, 3, 1);
 		usleep(200000);
 	}
 

--- a/src/modules/commander/commander_helper.cpp
+++ b/src/modules/commander/commander_helper.cpp
@@ -322,12 +322,16 @@ int led_off(int led)
 	return h_leds.ioctl(LED_OFF, led);
 }
 
-void rgbled_set_color_and_mode(uint8_t color, uint8_t mode)
+void rgbled_set_color_and_mode(uint8_t color, uint8_t mode, uint8_t blinks, uint8_t prio)
 {
 	led_control.mode = mode;
 	led_control.color = color;
-	led_control.num_blinks = 0;
-	led_control.priority = 0;
+	led_control.num_blinks = blinks;
+	led_control.priority = prio;
 	led_control.timestamp = hrt_absolute_time();
 	orb_publish(ORB_ID(led_control), led_control_pub, &led_control);
+}
+
+void rgbled_set_color_and_mode(uint8_t color, uint8_t mode){
+	rgbled_set_color_and_mode(color, mode, 0, 0);
 }

--- a/src/modules/commander/commander_helper.h
+++ b/src/modules/commander/commander_helper.h
@@ -83,4 +83,6 @@ int led_off(int led);
  */
 void rgbled_set_color_and_mode(uint8_t color, uint8_t mode);
 
+void rgbled_set_color_and_mode(uint8_t color, uint8_t mode, uint8_t blinks, uint8_t prio);
+
 #endif /* COMMANDER_HELPER_H_ */


### PR DESCRIPTION
During calibration the LED would continue to blink white after the first side calibration.
This should solve the problem with a small priority boost on the white blinking LED when a side is completed.