### PR TITLE
Speedup param loading

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1962,7 +1962,7 @@ Mavlink::task_main(int argc, char *argv[])
 
 	/* PARAM_VALUE stream */
 	_parameters_manager = (MavlinkParametersManager *) MavlinkParametersManager::new_instance(this);
-	_parameters_manager->set_interval(interval_from_rate(120.0f));
+	_parameters_manager->set_interval(interval_from_rate(300.0f));
 	LL_APPEND(_streams, _parameters_manager);
 
 	/* MAVLINK_FTP stream */

--- a/src/modules/mavlink/mavlink_parameters.h
+++ b/src/modules/mavlink/mavlink_parameters.h
@@ -91,6 +91,10 @@ protected:
 
 	void send(const hrt_abstime t);
 
+	/// send a single param if a PARAM_REQUEST_LIST is in progress
+	/// @return true if a parameter was sent
+	bool send_one();
+
 	int send_param(param_t param, int component_id = -1);
 
 	// Item of a single-linked list to store requested uavcan parameters


### PR DESCRIPTION
It currently takes more than 5 seconds with SITL to load the parameters in QGC. And there is really no reason why it should take that long.

This PR speeds things up in 2 ways:
- increase the mavlink parameter update rate. Slower links, like telemetry will be unaffected, because mavlink will only run with an update rate of around 100Hz.
- Try to send 5 params at once when connected via USB or UDP.

Tested on various configurations, like telemetry, SITL, Pixracer WiFi, Pixracer USB.