### PR TITLE
Vehicle Land detector: use param_notify_changes instead of param_save_default

### DIFF
--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -152,7 +152,7 @@ void LandDetector::_cycle()
 			param_set_no_notification(_p_total_flight_time_high, &flight_time);
 			flight_time = _total_flight_time & 0xffffffff;
 			param_set_no_notification(_p_total_flight_time_low, &flight_time);
-			param_save_default();
+			param_notify_changes(); // this will notify the commander, who will save the params
 		}
 
 		_landDetected.timestamp = hrt_absolute_time();

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -270,7 +270,7 @@ _param_notify_changes(bool is_saved)
 void
 param_notify_changes(void)
 {
-	_param_notify_changes(true);
+	_param_notify_changes(false);
 }
 
 param_t


### PR DESCRIPTION
param_save_default() could take something like 0.5s, and because the
LandDetector is running on the HP work queue, this would block other
tasks, like RC handling or drivers, leading to RC loss timeouts.

I think moving towards an automatic rate-limited param save (on the LP queue) would make sense and would simplify cases like this.