### PR TITLE
Stick to velocity fix 

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -232,6 +232,8 @@ private:
 		float acc_hor_max;
 		float acc_up_max;
 		float acc_down_max;
+		float vel_max_xy;
+		float vel_cruise_xy;
 		float vel_max_up;
 		float vel_max_down;
 		float xy_vel_man_expo;
@@ -244,8 +246,6 @@ private:
 		math::Vector<3> vel_i;
 		math::Vector<3> vel_d;
 		math::Vector<3> vel_ff;
-		math::Vector<3> vel_max;
-		math::Vector<2> vel_cruise;
 	}		_params;
 
 	struct map_projection_reference_s _ref_pos;
@@ -471,8 +471,6 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_params.vel_p.zero();
 	_params.vel_i.zero();
 	_params.vel_d.zero();
-	_params.vel_max.zero();
-	_params.vel_cruise.zero();
 	_params.vel_ff.zero();
 
 	_pos.zero();
@@ -610,16 +608,13 @@ MulticopterPositionControl::parameters_update(bool force)
 		param_get(_params_handles.z_vel_d, &v);
 		_params.vel_d(2) = v;
 		param_get(_params_handles.xy_vel_max, &v);
-		_params.vel_max(0) = v;
-		_params.vel_max(1) = v;
+		_params.vel_max_xy = v;
 		param_get(_params_handles.z_vel_max_up, &v);
 		_params.vel_max_up = v;
-		_params.vel_max(2) = v;
 		param_get(_params_handles.z_vel_max_down, &v);
 		_params.vel_max_down = v;
 		param_get(_params_handles.xy_vel_cruise, &v);
-		_params.vel_cruise(0) = v;
-		_params.vel_cruise(1) = v;
+		_params.vel_cruise_xy = v;
 		param_get(_params_handles.xy_ff, &v);
 		v = math::constrain(v, 0.0f, 1.0f);
 		_params.vel_ff(0) = v;
@@ -652,7 +647,7 @@ MulticopterPositionControl::parameters_update(bool force)
 		 * increase the maximum horizontal acceleration such that stopping
 		 * within 1 s from full speed is feasible
 		 */
-		_params.acc_hor_max = math::max(_params.vel_cruise(0), _params.acc_hor_max);
+		_params.acc_hor_max = math::max(_params.vel_cruise_xy, _params.acc_hor_max);
 		param_get(_params_handles.alt_mode, &v_i);
 		_params.alt_mode = v_i;
 
@@ -983,8 +978,8 @@ MulticopterPositionControl::control_manual(float dt)
 	}
 
 	/* scale requested velocity setpoint to cruisespeed and rotate around yaw */
-	math::Vector<3> vel_cruise(_params.vel_cruise(0),
-				   _params.vel_cruise(1),
+	math::Vector<3> vel_cruise(_params.vel_cruise_xy,
+				   _params.vel_cruise_xy,
 				   (req_vel_sp_z > 0.0f) ? _params.vel_max_down : _params.vel_max_up);
 	math::Vector<3> req_vel_sp_scaled(req_vel_sp_xy(0), req_vel_sp_xy(1), req_vel_sp_z);
 
@@ -1458,8 +1453,8 @@ void MulticopterPositionControl::control_auto(float dt)
 
 		/* scaled space: 1 == position error resulting max allowed speed */
 
-		math::Vector<3> cruising_speed(_params.vel_cruise(0),
-					       _params.vel_cruise(1),
+		math::Vector<3> cruising_speed(_params.vel_cruise_xy,
+					       _params.vel_cruise_xy,
 					       _params.vel_max_up);
 
 		if (PX4_ISFINITE(_pos_sp_triplet.current.cruising_speed) &&
@@ -1703,10 +1698,9 @@ MulticopterPositionControl::control_position(float dt)
 	float vel_norm_xy = sqrtf(_vel_sp(0) * _vel_sp(0) +
 				  _vel_sp(1) * _vel_sp(1));
 
-	if (vel_norm_xy > _params.vel_max(0)) {
-		/* note assumes vel_max(0) == vel_max(1) */
-		_vel_sp(0) = _vel_sp(0) * _params.vel_max(0) / vel_norm_xy;
-		_vel_sp(1) = _vel_sp(1) * _params.vel_max(1) / vel_norm_xy;
+	if (vel_norm_xy > _params.vel_max_xy) {
+		_vel_sp(0) = _vel_sp(0) * _params.vel_max_xy / vel_norm_xy;
+		_vel_sp(1) = _vel_sp(1) * _params.vel_max_xy / vel_norm_xy;
 	}
 
 	/* make sure velocity setpoint is saturated in z*/

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1459,7 +1459,8 @@ void MulticopterPositionControl::control_auto(float dt)
 	if (current_setpoint_valid &&
 	    (_pos_sp_triplet.current.type != position_setpoint_s::SETPOINT_TYPE_IDLE)) {
 
-		float cruising_speed_xy = (_pos_sp_triplet.current.cruising_speed > 0.1f) ?
+		float cruising_speed_xy = (PX4_ISFINITE(_pos_sp_triplet.current.cruising_speed)
+					   && (_pos_sp_triplet.current.cruising_speed > 0.1f)) ?
 					  _pos_sp_triplet.current.cruising_speed : _params.vel_cruise_xy ;
 		float cruising_speed_z = (curr_sp(2) > _pos(2)) ? _params.vel_max_down : _params.vel_max_up;
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1459,9 +1459,8 @@ void MulticopterPositionControl::control_auto(float dt)
 	if (current_setpoint_valid &&
 	    (_pos_sp_triplet.current.type != position_setpoint_s::SETPOINT_TYPE_IDLE)) {
 
-
-		float cruising_speed_xy = (_pos_sp_triplet.current.cruising_speed > 0.1f) ? math::min(
-						  _pos_sp_triplet.current.cruising_speed, _params.vel_cruise_xy) : _params.vel_cruise_xy ;
+		float cruising_speed_xy = (_pos_sp_triplet.current.cruising_speed > 0.1f) ?
+					  _pos_sp_triplet.current.cruising_speed : _params.vel_cruise_xy ;
 		float cruising_speed_z = (curr_sp(2) > _pos(2)) ? _params.vel_max_down : _params.vel_max_up;
 
 		/* scaled space: 1 == position error resulting max allowed speed */


### PR DESCRIPTION
This pr cleans up issues related to velocity.
1.) use just float for xy instead of carrying around vector
the vel_max vector was a 3d vector with x and y set to vel_max and z to vel_max_up. I deleted the vector and just used a float for xy. same for cruise_vector
2.)
for manual the map from stick input to unscaled requested velocity allowed to have a sqrt(2) * cruise_velocity. I saturated the requested_vel_sp magnitude to be not more than 1. It is to note that in the near future we should try to have a 2d stick to requested_velocity map.

