### PR TITLE
Add preflight & postflight perf counters & process usage to ULog

### DIFF
--- a/src/modules/logger/log_writer_file.cpp
+++ b/src/modules/logger/log_writer_file.cpp
@@ -54,8 +54,8 @@ LogWriterFile::LogWriterFile(size_t buffer_size) :
 	pthread_mutex_init(&_mtx, nullptr);
 	pthread_cond_init(&_cv, nullptr);
 	/* allocate write performance counters */
-	_perf_write = perf_alloc(PC_ELAPSED, "sd write");
-	_perf_fsync = perf_alloc(PC_ELAPSED, "sd fsync");
+	_perf_write = perf_alloc(PC_ELAPSED, "logger_sd_write");
+	_perf_fsync = perf_alloc(PC_ELAPSED, "logger_sd_fsync");
 }
 
 bool LogWriterFile::init()

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -825,6 +825,12 @@ void Logger::run()
 				_was_armed = armed;
 
 				if (armed) {
+
+					if (_should_stop_file_log) { // happens on quick arming after disarm
+						_should_stop_file_log = false;
+						stop_log_file();
+					}
+
 					start_log_file();
 
 #ifdef DBGPRINT
@@ -833,7 +839,9 @@ void Logger::run()
 #endif /* DBGPRINT */
 
 				} else {
-					stop_log_file();
+					// delayed stop: we measure the process loads and then stop
+					initialize_load_output();
+					_should_stop_file_log = true;
 				}
 			}
 		}
@@ -872,6 +880,23 @@ void Logger::run()
 
 
 		if (_writer.is_started()) {
+
+			hrt_abstime loop_time = hrt_absolute_time();
+
+			/* check if we need to output the process load */
+			if (_next_load_print != 0 && loop_time >= _next_load_print) {
+				_next_load_print = 0;
+
+				if (_should_stop_file_log) {
+					_should_stop_file_log = false;
+					write_load_output(false);
+					stop_log_file();
+					continue; // skip to next loop iteration
+
+				} else {
+					write_load_output(true);
+				}
+			}
 
 			bool data_written = false;
 
@@ -967,10 +992,10 @@ void Logger::run()
 			if (next_subscribe_topic_index != -1) {
 				if (++next_subscribe_topic_index >= _subscriptions.size()) {
 					next_subscribe_topic_index = -1;
-					next_subscribe_check = hrt_absolute_time() + TRY_SUBSCRIBE_INTERVAL;
+					next_subscribe_check = loop_time + TRY_SUBSCRIBE_INTERVAL;
 				}
 
-			} else if (hrt_absolute_time() > next_subscribe_check) {
+			} else if (loop_time > next_subscribe_check) {
 				next_subscribe_topic_index = 0;
 			}
 
@@ -1022,6 +1047,8 @@ void Logger::run()
 			while (px4_sem_wait(&timer_semaphore) != 0);
 		}
 	}
+
+	stop_log_file();
 
 	hrt_cancel(&timer_call);
 	px4_sem_destroy(&timer_semaphore);
@@ -1292,16 +1319,29 @@ void Logger::start_log_file()
 	write_version();
 	write_formats();
 	write_parameters();
+	write_perf_data(true);
 	write_all_add_logged_msg();
 	_writer.set_need_reliable_transfer(false);
 	_writer.unselect_write_backend();
 	_writer.notify();
 
+	/* reset performance counters to get in-flight min and max values in post flight log */
+	perf_reset_all();
+
 	_start_time_file = hrt_absolute_time();
+
+	initialize_load_output();
 }
 
 void Logger::stop_log_file()
 {
+	if (!_writer.is_started(LogWriter::BackendFile)) {
+		return;
+	}
+
+	_writer.set_need_reliable_transfer(true);
+	write_perf_data(false);
+	_writer.set_need_reliable_transfer(false);
 	_writer.stop_log_file();
 }
 
@@ -1320,16 +1360,109 @@ void Logger::start_log_mavlink()
 	write_version();
 	write_formats();
 	write_parameters();
+	write_perf_data(true);
 	write_all_add_logged_msg();
 	_writer.set_need_reliable_transfer(false);
 	_writer.unselect_write_backend();
 	_writer.notify();
+
+	initialize_load_output();
 }
 
 void Logger::stop_log_mavlink()
 {
+	// don't write perf data since a client does not expect more data after a stop command
 	PX4_INFO("Stop mavlink log");
 	_writer.stop_log_mavlink();
+}
+
+struct perf_callback_data_t {
+	Logger *logger;
+	int counter;
+	bool preflight;
+	char *buffer;
+};
+
+void Logger::perf_iterate_callback(perf_counter_t handle, void *user)
+{
+	perf_callback_data_t *callback_data = (perf_callback_data_t *)user;
+	const int buffer_length = 256;
+	char buffer[buffer_length];
+	char perf_name[32];
+
+	perf_print_counter_buffer(buffer, buffer_length, handle);
+
+	if (callback_data->preflight) {
+		snprintf(perf_name, 32, "perf_counter_preflight-%02i", callback_data->counter);
+
+	} else {
+		snprintf(perf_name, 32, "perf_counter_postflight-%02i", callback_data->counter);
+	}
+
+	callback_data->logger->write_info(perf_name, buffer);
+	++callback_data->counter;
+}
+
+void Logger::write_perf_data(bool preflight)
+{
+	perf_callback_data_t callback_data;
+	callback_data.logger = this;
+	callback_data.counter = 0;
+	callback_data.preflight = preflight;
+
+	// write the perf counters
+	perf_iterate_all(perf_iterate_callback, &callback_data);
+}
+
+
+void Logger::print_load_callback(void *user)
+{
+	perf_callback_data_t *callback_data = (perf_callback_data_t *)user;
+	char perf_name[32];
+
+	if (!callback_data->buffer) {
+		return;
+	}
+
+	if (callback_data->preflight) {
+		snprintf(perf_name, 32, "perf_top_preflight-%02i", callback_data->counter);
+
+	} else {
+		snprintf(perf_name, 32, "perf_top_postflight-%02i", callback_data->counter);
+	}
+
+	callback_data->logger->write_info(perf_name, callback_data->buffer);
+	++callback_data->counter;
+}
+
+void Logger::initialize_load_output()
+{
+	perf_callback_data_t callback_data;
+	callback_data.logger = this;
+	callback_data.counter = 0;
+	callback_data.buffer = NULL;
+	char buffer[140];
+	hrt_abstime curr_time = hrt_absolute_time();
+	init_print_load_s(curr_time, &_load);
+	// this will not yet print anything
+	print_load_buffer(curr_time, buffer, sizeof(buffer), print_load_callback, &callback_data, &_load);
+	_next_load_print = curr_time + 1000000;
+}
+
+void Logger::write_load_output(bool preflight)
+{
+	perf_callback_data_t callback_data;
+	char buffer[140];
+	callback_data.logger = this;
+	callback_data.counter = 0;
+	callback_data.buffer = buffer;
+	callback_data.preflight = preflight;
+	hrt_abstime curr_time = hrt_absolute_time();
+	_writer.set_need_reliable_transfer(true);
+	// TODO: maybe we should restrict the output to a selected backend (eg. when file logging is running
+	// and mavlink log is started, this will be added to the file as well)
+	print_load_buffer(curr_time, buffer, sizeof(buffer), print_load_callback, &callback_data, &_load);
+	_writer.set_need_reliable_transfer(false);
 }
 
 void Logger::write_formats()

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1440,7 +1440,7 @@ void Logger::initialize_load_output()
 	perf_callback_data_t callback_data;
 	callback_data.logger = this;
 	callback_data.counter = 0;
-	callback_data.buffer = NULL;
+	callback_data.buffer = nullptr;
 	char buffer[140];
 	hrt_abstime curr_time = hrt_absolute_time();
 	init_print_load_s(curr_time, &_load);

--- a/src/modules/systemlib/perf_counter.c
+++ b/src/modules/systemlib/perf_counter.c
@@ -43,7 +43,11 @@
 #include <sys/queue.h>
 #include <drivers/drv_hrt.h>
 #include <math.h>
+#include <pthread.h>
+#include <systemlib/err.h>
+
 #include "perf_counter.h"
+
 
 #ifdef __PX4_QURT
 // There is presumably no dprintf on QURT. Therefore use the usual output to mini-dm.
@@ -100,7 +104,18 @@ struct perf_ctr_interval {
 /**
  * List of all known counters.
  */
-static sq_queue_t	perf_counters;
+static sq_queue_t	perf_counters = { NULL, NULL };
+
+/**
+ * mutex protecting access to the perf_counters linked list (which is read from & written to by different threads)
+ */
+pthread_mutex_t perf_counters_mutex = PTHREAD_MUTEX_INITIALIZER;
+// FIXME: the mutex does **not** protect against access to/from the perf
+// counter's data. It can still happen that a counter is updated while it is
+// printed. This can lead to inconsistent output, or completely bogus values
+// (especially the 64bit values which are in general not atomically updated).
+// The same holds for shared perf counters (perf_alloc_once), that can be updated
+// concurrently (this affects the 'ctrl_latency' counter).
 
 
 perf_counter_t
@@ -129,7 +144,9 @@ perf_alloc(enum perf_counter_type type, const char *name)
 	if (ctr != NULL) {
 		ctr->type = type;
 		ctr->name = name;
+		pthread_mutex_lock(&perf_counters_mutex);
 		sq_addfirst(&ctr->link, &perf_counters);
+		pthread_mutex_unlock(&perf_counters_mutex);
 	}
 
 	return ctr;
@@ -138,22 +155,27 @@ perf_alloc(enum perf_counter_type type, const char *name)
 perf_counter_t
 perf_alloc_once(enum perf_counter_type type, const char *name)
 {
+	pthread_mutex_lock(&perf_counters_mutex);
 	perf_counter_t handle = (perf_counter_t)sq_peek(&perf_counters);
 
 	while (handle != NULL) {
 		if (!strcmp(handle->name, name)) {
 			if (type == handle->type) {
 				/* they are the same counter */
+				pthread_mutex_unlock(&perf_counters_mutex);
 				return handle;
 
 			} else {
 				/* same name but different type, assuming this is an error and not intended */
+				pthread_mutex_unlock(&perf_counters_mutex);
 				return NULL;
 			}
 		}
 
 		handle = (perf_counter_t)sq_next(&handle->link);
 	}
+
+	pthread_mutex_unlock(&perf_counters_mutex);
 
 	/* if the execution reaches here, no existing counter of that name was found */
 	return perf_alloc(type, name);
@@ -166,7 +188,9 @@ perf_free(perf_counter_t handle)
 		return;
 	}
 
+	pthread_mutex_lock(&perf_counters_mutex);
 	sq_rem(&handle->link, &perf_counters);
+	pthread_mutex_unlock(&perf_counters_mutex);
 	free(handle);
 }
 
@@ -293,8 +317,6 @@ perf_end(perf_counter_t handle)
 		break;
 	}
 }
-
-#include "systemlib/err.h"
 
 void
 perf_set_elapsed(perf_counter_t handle, int64_t elapsed)
@@ -505,14 +527,18 @@ perf_event_count(perf_counter_t handle)
 void
 perf_print_all(int fd)
 {
+	pthread_mutex_lock(&perf_counters_mutex);
 	perf_counter_t handle = (perf_counter_t)sq_peek(&perf_counters);
 
 	while (handle != NULL) {
 		perf_print_counter_fd(fd, handle);
 		handle = (perf_counter_t)sq_next(&handle->link);
 	}
+
+	pthread_mutex_unlock(&perf_counters_mutex);
 }
 
+// these are defined in drv_hrt.c
 extern const uint16_t latency_bucket_count;
 extern uint32_t latency_counters[];
 extern const uint16_t latency_buckets[];
@@ -533,12 +559,15 @@ perf_print_latency(int fd)
 void
 perf_reset_all(void)
 {
+	pthread_mutex_lock(&perf_counters_mutex);
 	perf_counter_t handle = (perf_counter_t)sq_peek(&perf_counters);
 
 	while (handle != NULL) {
 		perf_reset(handle);
 		handle = (perf_counter_t)sq_next(&handle->link);
 	}
+
+	pthread_mutex_unlock(&perf_counters_mutex);
 
 	for (int i = 0; i <= latency_bucket_count; i++) {
 		latency_counters[i] = 0;

--- a/src/modules/systemlib/perf_counter.h
+++ b/src/modules/systemlib/perf_counter.h
@@ -171,11 +171,36 @@ __EXPORT extern void		perf_print_counter(perf_counter_t handle);
 __EXPORT extern void		perf_print_counter_fd(int fd, perf_counter_t handle);
 
 /**
+ * Print one performance counter to a buffer.
+ *
+ * @param buffer			buffer to write to
+ * @param length			buffer length
+ * @param handle			The counter to print.
+ * @param return			number of bytes written
+ */
+__EXPORT extern int		perf_print_counter_buffer(char *buffer, int length, perf_counter_t handle);
+
+/**
  * Print all of the performance counters.
  *
  * @param fd			File descriptor to print to - e.g. 0 for stdout
  */
 __EXPORT extern void		perf_print_all(int fd);
+
+
+typedef void (*perf_callback)(perf_counter_t handle, void *user);
+
+/**
+ * Iterate over all performance counters using a callback.
+ *
+ * Caution: This will aquire the mutex, so do not call any other perf_* method
+ * that aquire the mutex as well from the callback (If this is needed, configure
+ * the mutex to be reentrant).
+ *
+ * @param cb callback method
+ * @param user custom argument for the callback
+ */
+__EXPORT extern void	perf_iterate_all(perf_callback cb, void *user);
 
 /**
  * Print hrt latency counters.

--- a/src/modules/systemlib/print_load_posix.c
+++ b/src/modules/systemlib/print_load_posix.c
@@ -180,3 +180,9 @@ void print_load(uint64_t t, int fd, struct print_load_s *print_state)
 #endif
 }
 
+void print_load_buffer(uint64_t t, char *buffer, int buffer_length, print_load_callback_f cb, void *user,
+		       struct print_load_s *print_state)
+{
+
+}
+

--- a/src/modules/systemlib/printload.c
+++ b/src/modules/systemlib/printload.c
@@ -140,159 +140,186 @@ void print_load(uint64_t t, int fd, struct print_load_s *print_state)
 	print_state->total_user_time = 0;
 
 	for (i = 0; i < CONFIG_MAX_TASKS; i++) {
-		uint64_t interval_runtime;
 
-		if (system_load.tasks[i].valid) {
-			switch (system_load.tasks[i].tcb->task_state) {
-			case TSTATE_TASK_PENDING:
-			case TSTATE_TASK_READYTORUN:
-			case TSTATE_TASK_RUNNING:
-				print_state->running_count++;
-				break;
+		sched_lock(); // need to lock the tcb access (but make it as short as possible)
 
-			case TSTATE_TASK_INVALID:
-			case TSTATE_TASK_INACTIVE:
-			case TSTATE_WAIT_SEM:
-#ifndef CONFIG_DISABLE_SIGNALS
-			case TSTATE_WAIT_SIG:
-#endif
-#ifndef CONFIG_DISABLE_MQUEUE
-			case TSTATE_WAIT_MQNOTEMPTY:
-			case TSTATE_WAIT_MQNOTFULL:
-#endif
-#ifdef CONFIG_PAGING
-			case TSTATE_WAIT_PAGEFILL:
-#endif
-				print_state->blocked_count++;
-				break;
-			}
+		if (!system_load.tasks[i].valid) {
+			sched_unlock();
+			continue;
 		}
 
-		interval_runtime = (system_load.tasks[i].valid && print_state->last_times[i] > 0 &&
+		uint64_t interval_runtime;
+		unsigned tcb_pid = system_load.tasks[i].tcb->pid;
+		size_t stack_size = system_load.tasks[i].tcb->adj_stack_size;
+		ssize_t stack_free = 0;
+		char tcb_name[CONFIG_TASK_NAME_SIZE];
+		strncpy(tcb_name, system_load.tasks[i].tcb->name, CONFIG_TASK_NAME_SIZE);
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 3
+
+		if (system_load.tasks[i].tcb->pid == 0) {
+			stack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
+			stack_free = up_check_intstack_remain();
+
+		} else {
+#endif
+			stack_free = up_check_tcbstack_remain(system_load.tasks[i].tcb);
+#if CONFIG_ARCH_INTERRUPTSTACK > 3
+		}
+
+#endif
+
+		unsigned tcb_sched_priority = system_load.tasks[i].tcb->sched_priority;
+#if CONFIG_ARCH_BOARD_SIM || !defined(CONFIG_PRIORITY_INHERITANCE)
+#else
+		unsigned tcb_base_priority = system_load.tasks[i].tcb->base_priority;
+#endif
+
+#if CONFIG_RR_INTERVAL > 0
+		unsigned tcb_timeslice = system_load.tasks[i].tcb->timeslice);
+#endif
+		unsigned tcb_task_state = system_load.tasks[i].tcb->task_state;
+
+
+		sched_unlock();
+
+
+		switch (tcb_task_state) {
+	// astyle formatting bug
+	case TSTATE_TASK_PENDING:
+	case TSTATE_TASK_READYTORUN:
+	case TSTATE_TASK_RUNNING:
+		print_state->running_count++;
+		break;
+
+	case TSTATE_TASK_INVALID:
+	case TSTATE_TASK_INACTIVE:
+	case TSTATE_WAIT_SEM:
+#ifndef CONFIG_DISABLE_SIGNALS
+	case TSTATE_WAIT_SIG:
+#endif
+#ifndef CONFIG_DISABLE_MQUEUE
+	case TSTATE_WAIT_MQNOTEMPTY:
+	case TSTATE_WAIT_MQNOTFULL:
+#endif
+#ifdef CONFIG_PAGING
+	case TSTATE_WAIT_PAGEFILL:
+#endif
+		print_state->blocked_count++;
+		break;
+	}
+
+	interval_runtime = (print_state->last_times[i] > 0 &&
 				    system_load.tasks[i].total_runtime > print_state->last_times[i])
 				   ? (system_load.tasks[i].total_runtime - print_state->last_times[i]) / 1000
 				   : 0;
 
 		print_state->last_times[i] = system_load.tasks[i].total_runtime;
 
-		if (system_load.tasks[i].valid && (print_state->new_time > print_state->interval_start_time)) {
-			print_state->curr_loads[i] = interval_runtime * print_state->interval_time_ms_inv;
+		if (print_state->new_time > print_state->interval_start_time) {
+		print_state->curr_loads[i] = interval_runtime * print_state->interval_time_ms_inv;
 
-			if (i > 0) {
+			if (tcb_pid != 0) {
 				print_state->total_user_time += interval_runtime;
 			}
 
 		} else {
 			print_state->curr_loads[i] = 0;
 		}
+
+
+		if (print_state->new_time <= print_state->interval_start_time) {
+		continue; // not enough data yet
 	}
 
-	for (i = 0; i < CONFIG_MAX_TASKS; i++) {
-		if (system_load.tasks[i].valid && (print_state->new_time > print_state->interval_start_time)) {
-			if (system_load.tasks[i].tcb->pid == 0) {
-				float idle;
-				float task_load;
-				float sched_load;
+	// print output
 
-				idle = print_state->curr_loads[0];
-				task_load = (float)(print_state->total_user_time) * print_state->interval_time_ms_inv;
+	if (tcb_pid == 0) {
+		float idle;
+		float task_load;
+		float sched_load;
 
-				/* this can happen if one tasks total runtime was not computed
-				   correctly by the scheduler instrumentation TODO */
-				if (task_load > (1.f - idle)) {
-					task_load = (1.f - idle);
-				}
+		idle = print_state->curr_loads[i];
+			task_load = (float)(print_state->total_user_time) * print_state->interval_time_ms_inv;
 
-				sched_load = 1.f - idle - task_load;
-
-				dprintf(fd, "%sProcesses: %d total, %d running, %d sleeping\n",
-					clear_line,
-					system_load.total_count,
-					print_state->running_count,
-					print_state->blocked_count);
-				dprintf(fd, "%sCPU usage: %.2f%% tasks, %.2f%% sched, %.2f%% idle\n",
-					clear_line,
-					(double)(task_load * 100.f),
-					(double)(sched_load * 100.f),
-					(double)(idle * 100.f));
-#if defined(BOARD_DMA_ALLOC_POOL_SIZE)
-				uint16_t dma_total;
-				uint16_t dma_used;
-				uint16_t dma_peak_used;
-
-				if (board_get_dma_usage(&dma_total, &dma_used, &dma_peak_used) >= 0) {
-					dprintf(fd, "%sDMA Memory: %d total, %d used %d peak\n",
-						clear_line,
-						dma_total,
-						dma_used,
-						dma_peak_used);
-				}
-
-#endif
-				dprintf(fd, "%sUptime: %.3fs total, %.3fs idle\n%s\n",
-					clear_line,
-					(double)curr_time_us / 1000000.d,
-					(double)idle_time_us / 1000000.d,
-					clear_line);
-				/* header for task list */
-				dprintf(fd, "%s%4s %*-s %8s %6s %11s %10s %-6s\n",
-					clear_line,
-					"PID",
-					CONFIG_TASK_NAME_SIZE, "COMMAND",
-					"CPU(ms)",
-					"CPU(%)",
-					"USED/STACK",
-					"PRIO(BASE)",
-#if CONFIG_RR_INTERVAL > 0
-					"TSLICE"
-#else
-					"STATE"
-#endif
-				       );
+			/* this can happen if one tasks total runtime was not computed
+			   correctly by the scheduler instrumentation TODO */
+			if (task_load > (1.f - idle)) {
+				task_load = (1.f - idle);
 			}
 
-			size_t stack_size = system_load.tasks[i].tcb->adj_stack_size;
-			ssize_t stack_free = 0;
+			sched_load = 1.f - idle - task_load;
 
-#if CONFIG_ARCH_INTERRUPTSTACK > 3
-
-			if (system_load.tasks[i].tcb->pid == 0) {
-				stack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
-				stack_free = up_check_intstack_remain();
-
-			} else {
-#endif
-				stack_free = up_check_tcbstack_remain(system_load.tasks[i].tcb);
-#if CONFIG_ARCH_INTERRUPTSTACK > 3
-			}
-
-#endif
-
-			dprintf(fd, "%s%4d %*-s %8lld %2d.%03d %5u/%5u %3u (%3u) ",
+			dprintf(fd, "%sProcesses: %d total, %d running, %d sleeping\n",
 				clear_line,
-				system_load.tasks[i].tcb->pid,
-				CONFIG_TASK_NAME_SIZE, system_load.tasks[i].tcb->name,
-				(system_load.tasks[i].total_runtime / 1000),
-				(int)(print_state->curr_loads[i] * 100.0f),
-				(int)((print_state->curr_loads[i] * 100.0f - (int)(print_state->curr_loads[i] * 100.0f)) * 1000),
-				stack_size - stack_free,
-				stack_size,
-				system_load.tasks[i].tcb->sched_priority,
-#if CONFIG_ARCH_BOARD_SIM || !defined(CONFIG_PRIORITY_INHERITANCE)
-				0);
+				system_load.total_count,
+				print_state->running_count,
+				print_state->blocked_count);
+			dprintf(fd, "%sCPU usage: %.2f%% tasks, %.2f%% sched, %.2f%% idle\n",
+				clear_line,
+				(double)(task_load * 100.f),
+				(double)(sched_load * 100.f),
+				(double)(idle * 100.f));
+#if defined(BOARD_DMA_ALLOC_POOL_SIZE)
+			uint16_t dma_total;
+			uint16_t dma_used;
+			uint16_t dma_peak_used;
+
+			if (board_get_dma_usage(&dma_total, &dma_used, &dma_peak_used) >= 0) {
+				dprintf(fd, "%sDMA Memory: %d total, %d used %d peak\n",
+					clear_line,
+					dma_total,
+					dma_used,
+					dma_peak_used);
+			}
+
+#endif
+			dprintf(fd, "%sUptime: %.3fs total, %.3fs idle\n%s\n",
+				clear_line,
+				(double)curr_time_us / 1000000.d,
+				(double)idle_time_us / 1000000.d,
+				clear_line);
+			/* header for task list */
+			dprintf(fd, "%s%4s %*-s %8s %6s %11s %10s %-6s\n",
+				clear_line,
+				"PID",
+				CONFIG_TASK_NAME_SIZE, "COMMAND",
+				"CPU(ms)",
+				"CPU(%)",
+				"USED/STACK",
+				"PRIO(BASE)",
+#if CONFIG_RR_INTERVAL > 0
+				"TSLICE"
 #else
-				system_load.tasks[i].tcb->base_priority);
+				"STATE"
+#endif
+			       );
+		}
+
+		dprintf(fd, "%s%4d %*-s %8lld %2d.%03d %5u/%5u %3u (%3u) ",
+			clear_line,
+			tcb_pid,
+			CONFIG_TASK_NAME_SIZE, tcb_name,
+			(system_load.tasks[i].total_runtime / 1000),
+			(int)(print_state->curr_loads[i] * 100.0f),
+			(int)((print_state->curr_loads[i] * 100.0f - (int)(print_state->curr_loads[i] * 100.0f)) * 1000),
+			stack_size - stack_free,
+			stack_size,
+			tcb_sched_priority,
+#if CONFIG_ARCH_BOARD_SIM || !defined(CONFIG_PRIORITY_INHERITANCE)
+			0);
+#else
+			tcb_base_priority);
 #endif
 
 #if CONFIG_RR_INTERVAL > 0
-			/* print scheduling info with RR time slice */
-			dprintf(fd, " %6d\n", system_load.tasks[i].tcb->timeslice);
-			(void)tstate_name(TSTATE_TASK_INVALID); // Stop not used warning
+		/* print scheduling info with RR time slice */
+		dprintf(fd, " %6d\n", tcb_timeslice);
+		(void)tstate_name(TSTATE_TASK_INVALID); // Stop not used warning
 #else
-			// print task state instead
-			dprintf(fd, " %-6s\n", tstate_name(system_load.tasks[i].tcb->task_state));
+		// print task state instead
+		dprintf(fd, " %-6s\n", tstate_name(tcb_task_state));
 #endif
-		}
 	}
 
 	print_state->interval_start_time = print_state->new_time;

--- a/src/modules/systemlib/printload.h
+++ b/src/modules/systemlib/printload.h
@@ -57,8 +57,7 @@ struct print_load_s {
 
 	uint64_t new_time;
 	uint64_t interval_start_time;
-	uint64_t last_times[CONFIG_MAX_TASKS];
-	float curr_loads[CONFIG_MAX_TASKS];
+	uint32_t last_times[CONFIG_MAX_TASKS]; // in [ms]. This wraps if a process needs more than 49 days of CPU
 	float interval_time_ms_inv;
 };
 

--- a/src/modules/systemlib/printload.h
+++ b/src/modules/systemlib/printload.h
@@ -67,4 +67,13 @@ __EXPORT void init_print_load_s(uint64_t t, struct print_load_s *s);
 
 __EXPORT void print_load(uint64_t t, int fd, struct print_load_s *print_state);
 
+
+typedef void (*print_load_callback_f)(void *user);
+
+/**
+ * Print load to a buffer, and call cb after each written line (buffer will not include '\n')
+ */
+void print_load_buffer(uint64_t t, char *buffer, int buffer_length, print_load_callback_f cb, void *user,
+		       struct print_load_s *print_state);
+
 __END_DECLS

--- a/src/platforms/ros/perf_counter.cpp
+++ b/src/platforms/ros/perf_counter.cpp
@@ -144,6 +144,16 @@ void		perf_print_counter_fd(int fd, perf_counter_t handle)
 
 }
 
+int		perf_print_counter_buffer(char *buffer, int length, perf_counter_t handle)
+{
+	return 0;
+}
+
+void	perf_iterate_all(perf_callback cb, void *user)
+{
+
+}
+
 /**
  * Print all of the performance counters.
  *


### PR DESCRIPTION
This adds the perf counters & process usage (output of `top`) to the ulog, when logging starts, and when it ends. For simplicity to read it, the data is added as plain-text.
To reduce buffer size requirements and make it scale to arbitrary number of processes & counters, the data is split up into individual messages.

The data can be shown with `ulog_info -v <file.ulg>`. Later we can show them in flight_review.

Fixes https://github.com/PX4/Firmware/issues/6802

### perf counter concurrency
I found yet another central place with concurrency issues: perf counters use a linked list which is accessed (add, remove, iterate) from different threads. Without synchronization this can lead to invalid memory accesses in the worst case. This PR adds a mutex protecting access to the linked list. It should not cause contention, since the lock only needs to be aquired when allocating, freeing or iterating the counters, but not on each update.

However there are two remaining issues:
- perf counters that are shared and updated from several threads.
- updating perf counters while they are being read out for printing.

Both cases can lead to bogus values, however it will not lead to invalid memory accesses.