### PR TITLE
Fix position control parameter description of expo for QGC parsing

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -510,10 +510,11 @@ PARAM_DEFINE_INT32(MPC_ALT_MODE, 0);
  * The higher the value the less sensitivity the stick has around zero
  * while still reaching the maximum value with full stick deflection.
  *
+ * 0 Purely linear input curve (default)
+ * 1 Purely cubic input curve
+ *
  * @min 0
  * @max 1
- * @value 0 Purely linear input curve (default)
- * @value 1 Purely cubic input curve
  * @decimal 2
  * @group Multicopter Position Control
  */


### PR DESCRIPTION
Sadly the wrong description is already in newer build versions of QGC therefore it will take a while to get fixed everywhere... Sorry for making a mess.