### PR TITLE
Fixes frsky telemetry stack warning

### DIFF
--- a/src/drivers/frsky_telemetry/frsky_telemetry.c
+++ b/src/drivers/frsky_telemetry/frsky_telemetry.c
@@ -589,7 +589,7 @@ int frsky_telemetry_main(int argc, char *argv[])
 		frsky_task = px4_task_spawn_cmd("frsky_telemetry",
 						SCHED_DEFAULT,
 						200,
-						1100,
+						1268,
 						frsky_telemetry_thread_main,
 						(char *const *)argv);
 


### PR DESCRIPTION
WARN  [load_mon] frsky_telemetry low on stack! (164 bytes left)

Added 168 bytes = 160 needed + 8 bytes for head room