### PR TITLE
HOTFIX:Backport Memory corruption due to stack coloring overreach com…

### DIFF
--- a/nuttx-patches/stack_coloration_overreach_fix.patch
+++ b/nuttx-patches/stack_coloration_overreach_fix.patch
@@ -1,20 +1,494 @@
-diff --git NuttX/nuttx/arch/arm/src/common/up_initialize.c NuttX/nuttx/arch/arm/src/common/up_initialize.c
-index a97cd40..b151728 100644
---- NuttX/nuttx/arch/arm/src/common/up_initialize.c
-+++ NuttX/nuttx/arch/arm/src/common/up_initialize.c
-@@ -100,13 +100,13 @@ static void up_calibratedelay(void)
-  *
+diff --git NuttX/nuttx/arch/arm/src/a1x/a1x_irq.c NuttX/nuttx/arch/arm/src/a1x/a1x_irq.c
+index ecabb5f..21c074d 100644
+--- NuttX/nuttx/arch/arm/src/a1x/a1x_irq.c
++++ NuttX/nuttx/arch/arm/src/a1x/a1x_irq.c
+@@ -159,16 +159,6 @@ void up_irqinitialize(void)
+       (void)getreg32(A1X_INTC_IRQ_PEND(i));   /* Reading status clears pending interrupts */
+     }
+ 
+-  /* Colorize the interrupt stack for debug purposes */
+-
+-#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
+-  {
+-    size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
+-    up_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
+-                   intstack_size);
+-  }
+-#endif
+-
+   /* Set the interrupt base address to zero.  We do not use the vectored
+    * interrupts.
+    */
+diff --git NuttX/nuttx/arch/arm/src/armv7-m/gnu/up_exception.S NuttX/nuttx/arch/arm/src/armv7-m/gnu/up_exception.S
+index 0010136..4f2927b 100644
+--- NuttX/nuttx/arch/arm/src/armv7-m/gnu/up_exception.S
++++ NuttX/nuttx/arch/arm/src/armv7-m/gnu/up_exception.S
+@@ -323,7 +323,7 @@ exception_common:
+ 	.global	g_intstackbase
+ 	.align	8
+ g_intstackalloc:
+-	.skip	(CONFIG_ARCH_INTERRUPTSTACK & ~7)
++	.skip	((CONFIG_ARCH_INTERRUPTSTACK + 4) & ~7)
+ g_intstackbase:
+ 	.size	g_intstackalloc, .-g_intstackalloc
+ #endif
+diff --git NuttX/nuttx/arch/arm/src/armv7-m/gnu/up_lazyexception.S NuttX/nuttx/arch/arm/src/armv7-m/gnu/up_lazyexception.S
+index 08ce8be..eb3e270 100644
+--- NuttX/nuttx/arch/arm/src/armv7-m/gnu/up_lazyexception.S
++++ NuttX/nuttx/arch/arm/src/armv7-m/gnu/up_lazyexception.S
+@@ -235,7 +235,7 @@ exception_common:
+ 	 *
+ 	 * Here:
+ 	 *   r0 = Address of the register save area
+-	
++
+ 	 * NOTE: It is a requirement that up_restorefpu() preserve the value of
+ 	 * r0!
+ 	 */
+@@ -355,7 +355,7 @@ exception_common:
+ 	.global	g_intstackbase
+ 	.align	8
+ g_intstackalloc:
+-	.skip	(CONFIG_ARCH_INTERRUPTSTACK & ~7)
++	.skip	((CONFIG_ARCH_INTERRUPTSTACK + 4) & ~7)
+ g_intstackbase:
+ 	.size	g_intstackalloc, .-g_intstackalloc
+ #endif
+diff --git NuttX/nuttx/arch/arm/src/common/up_createstack.c NuttX/nuttx/arch/arm/src/common/up_createstack.c
+index 70d83a8..4503e15 100644
+--- NuttX/nuttx/arch/arm/src/common/up_createstack.c
++++ NuttX/nuttx/arch/arm/src/common/up_createstack.c
+@@ -66,22 +66,11 @@
+ #  define HAVE_KERNEL_HEAP 1
+ #endif
+ 
+-/* ARM requires at least a 4-byte stack alignment.  For use with EABI and
+- * floating point, the stack must be aligned to 8-byte addresses.
++/* For use with EABI and floating point, the stack must be aligned to 8-byte
++ * addresses.
+  */
+ 
+-#ifndef CONFIG_STACK_ALIGNMENT
+-
+-/* The symbol  __ARM_EABI__ is defined by GCC if EABI is being used.  If you
+- * are not using GCC, make sure that CONFIG_STACK_ALIGNMENT is set correctly!
+- */
+-
+-#  ifdef __ARM_EABI__
+-#    define CONFIG_STACK_ALIGNMENT 8
+-#  else
+-#    define CONFIG_STACK_ALIGNMENT 4
+-#  endif
+-#endif
++#define CONFIG_STACK_ALIGNMENT 8
+ 
+ /* Stack alignment macros */
+ 
+@@ -233,9 +222,9 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
+ 
+       top_of_stack = (uint32_t)tcb->stack_alloc_ptr + stack_size - 4;
+ 
+-      /* The ARM stack must be aligned; 4 byte alignment for OABI and
+-       * 8-byte alignment for EABI. If necessary top_of_stack must be
+-       * rounded down to the next boundary
++      /* The ARM stack must be aligned to 8-byte alignment for EABI.
++       * If necessary top_of_stack must be rounded down to the next 
++       * boundary
+        */
+ 
+       top_of_stack = STACK_ALIGN_DOWN(top_of_stack);
+diff --git NuttX/nuttx/arch/arm/src/common/up_stackframe.c NuttX/nuttx/arch/arm/src/common/up_stackframe.c
+index b5712b2..dace2e9 100644
+--- NuttX/nuttx/arch/arm/src/common/up_stackframe.c
++++ NuttX/nuttx/arch/arm/src/common/up_stackframe.c
+@@ -53,22 +53,11 @@
+  * Pre-processor Macros
   ****************************************************************************/
  
--#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
-+#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 7
- static inline void up_color_intstack(void)
- {
-   uint32_t *ptr = (uint32_t *)&g_intstackalloc;
-   ssize_t size;
+-/* ARM requires at least a 4-byte stack alignment.  For use with EABI and
+- * floating point, the stack must be aligned to 8-byte addresses.
++/* For use with EABI and floating point, the stack must be aligned to 8-byte
++ * addresses.
+  */
  
--  for (size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
-+  for (size = (CONFIG_ARCH_INTERRUPTSTACK & ~7);
-        size > 0;
-        size -= sizeof(uint32_t))
-     {
+-#ifndef CONFIG_STACK_ALIGNMENT
+-
+-/* The symbol  __ARM_EABI__ is defined by GCC if EABI is being used.  If you
+- * are not using GCC, make sure that CONFIG_STACK_ALIGNMENT is set correctly!
+- */
+-
+-#  ifdef __ARM_EABI__
+-#    define CONFIG_STACK_ALIGNMENT 8
+-#  else
+-#    define CONFIG_STACK_ALIGNMENT 4
+-#  endif
+-#endif
++#define CONFIG_STACK_ALIGNMENT 8
+ 
+ /* Stack alignment macros */
+ 
+diff --git NuttX/nuttx/arch/arm/src/common/up_usestack.c NuttX/nuttx/arch/arm/src/common/up_usestack.c
+index 8873879..f8072a6 100644
+--- NuttX/nuttx/arch/arm/src/common/up_usestack.c
++++ NuttX/nuttx/arch/arm/src/common/up_usestack.c
+@@ -56,22 +56,11 @@
+  * Pre-processor Macros
+  ****************************************************************************/
+ 
+-/* ARM requires at least a 4-byte stack alignment.  For use with EABI and
+- * floating point, the stack must be aligned to 8-byte addresses.
++/* For use with EABI and floating point, the stack must be aligned to 8-byte
++ * addresses.
+  */
+ 
+-#ifndef CONFIG_STACK_ALIGNMENT
+-
+-/* The symbol  __ARM_EABI__ is defined by GCC if EABI is being used.  If you
+- * are not using GCC, make sure that CONFIG_STACK_ALIGNMENT is set correctly!
+- */
+-
+-#  ifdef __ARM_EABI__
+-#    define CONFIG_STACK_ALIGNMENT 8
+-#  else
+-#    define CONFIG_STACK_ALIGNMENT 4
+-#  endif
+-#endif
++#define CONFIG_STACK_ALIGNMENT 8
+ 
+ /* Stack alignment macros */
+ 
+@@ -143,9 +132,9 @@ int up_use_stack(struct tcb_s *tcb, void *stack, size_t stack_size)
+ 
+   top_of_stack = (uint32_t)tcb->stack_alloc_ptr + stack_size - 4;
+ 
+-  /* The ARM stack must be aligned; 4 byte alignment for OABI and 8-byte
+-   * alignment for EABI. If necessary top_of_stack must be rounded down
+-   * to the next boundary
++  /* The ARM stack must be aligned to 8-byte alignment for EABI.
++   * If necessary top_of_stack must be rounded down to the next 
++   * boundary
+    */
+ 
+   top_of_stack = STACK_ALIGN_DOWN(top_of_stack);
+diff --git NuttX/nuttx/arch/arm/src/common/up_vfork.c NuttX/nuttx/arch/arm/src/common/up_vfork.c
+index e655ab1..5a69e31 100644
+--- NuttX/nuttx/arch/arm/src/common/up_vfork.c
++++ NuttX/nuttx/arch/arm/src/common/up_vfork.c
+@@ -56,22 +56,11 @@
+  * Pre-processor Definitions
+  ****************************************************************************/
+ 
+-/* ARM requires at least a 4-byte stack alignment.  For use with EABI and
+- * floating point, the stack must be aligned to 8-byte addresses.
++/* For use with EABI and floating point, the stack must be aligned to 8-byte
++ * addresses.
+  */
+ 
+-#ifndef CONFIG_STACK_ALIGNMENT
+-
+-/* The symbol  __ARM_EABI__ is defined by GCC if EABI is being used.  If you
+- * are not using GCC, make sure that CONFIG_STACK_ALIGNMENT is set correctly!
+- */
+-
+-#  ifdef __ARM_EABI__
+-#    define CONFIG_STACK_ALIGNMENT 8
+-#  else
+-#    define CONFIG_STACK_ALIGNMENT 4
+-#  endif
+-#endif
++#define CONFIG_STACK_ALIGNMENT 8
+ 
+ /****************************************************************************
+  * Public Functions
+diff --git NuttX/nuttx/arch/arm/src/efm32/efm32_irq.c NuttX/nuttx/arch/arm/src/efm32/efm32_irq.c
+index db5992d..db31e68 100644
+--- NuttX/nuttx/arch/arm/src/efm32/efm32_irq.c
++++ NuttX/nuttx/arch/arm/src/efm32/efm32_irq.c
+@@ -319,16 +319,6 @@ void up_irqinitialize(void)
+       putreg32(0xffffffff, NVIC_IRQ_CLEAR(i));
+     }
+ 
+-#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
+-  /* Colorize the interrupt stack for debug purposes */
+-
+-  {
+-    size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
+-    up_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
+-                   intstack_size);
+-  }
+-#endif
+-
+   /* Make sure that we are using the correct vector table.  The default
+    * vector address is 0x0000:0000 but if we are executing code that is
+    * positioned in SRAM or in external FLASH, then we may need to reset
+diff --git NuttX/nuttx/arch/arm/src/imx6/imx_irq.c NuttX/nuttx/arch/arm/src/imx6/imx_irq.c
+index b15a9a4..d5248ef 100644
+--- NuttX/nuttx/arch/arm/src/imx6/imx_irq.c
++++ NuttX/nuttx/arch/arm/src/imx6/imx_irq.c
+@@ -93,16 +93,6 @@ void up_irqinitialize(void)
+    * access to the GIC.
+    */
+ 
+-  /* Colorize the interrupt stack for debug purposes */
+-
+-#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
+-  {
+-    size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
+-    up_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
+-                   intstack_size);
+-  }
+-#endif
+-
+   /* Initialize the Generic Interrupt Controller (GIC) for CPU0 */
+ 
+   arm_gic0_initialize();  /* Initialization unique to CPU0 */
+diff --git NuttX/nuttx/arch/arm/src/kinetis/kinetis_vectors.S NuttX/nuttx/arch/arm/src/kinetis/kinetis_vectors.S
+index 48c74c7..3094019 100644
+--- NuttX/nuttx/arch/arm/src/kinetis/kinetis_vectors.S
++++ NuttX/nuttx/arch/arm/src/kinetis/kinetis_vectors.S
+@@ -484,7 +484,7 @@ exception_common:
+ 	.global	g_intstackbase
+ 	.align	8
+ g_intstackalloc:
+-	.skip	(CONFIG_ARCH_INTERRUPTSTACK & ~7)
++	.skip	((CONFIG_ARCH_INTERRUPTSTACK + 4) & ~7)
+ g_intstackbase:
+ 	.size	g_intstackalloc, .-g_intstackalloc
+ #endif
+diff --git NuttX/nuttx/arch/arm/src/lpc17xx/lpc17_vectors.S NuttX/nuttx/arch/arm/src/lpc17xx/lpc17_vectors.S
+index 6cee7d9..9881472 100644
+--- NuttX/nuttx/arch/arm/src/lpc17xx/lpc17_vectors.S
++++ NuttX/nuttx/arch/arm/src/lpc17xx/lpc17_vectors.S
+@@ -348,7 +348,7 @@ exception_common:
+ 	 *
+ 	 * Here:
+ 	 *   r0 = Address of the register save area
+-	
++
+ 	 * NOTE: It is a requirement that up_restorefpu() preserve the value of
+ 	 * r0!
+ 	 */
+@@ -468,7 +468,7 @@ exception_common:
+ 	.global	g_intstackbase
+ 	.align	8
+ g_intstackalloc:
+-	.skip	(CONFIG_ARCH_INTERRUPTSTACK & ~7)
++	.skip	((CONFIG_ARCH_INTERRUPTSTACK + 4) & ~7)
+ g_intstackbase:
+ 	.size	g_intstackalloc, .-g_intstackalloc
+ #endif
+diff --git NuttX/nuttx/arch/arm/src/sam34/sam_irq.c NuttX/nuttx/arch/arm/src/sam34/sam_irq.c
+index 0b3286d..a75caaf 100644
+--- NuttX/nuttx/arch/arm/src/sam34/sam_irq.c
++++ NuttX/nuttx/arch/arm/src/sam34/sam_irq.c
+@@ -385,16 +385,6 @@ void up_irqinitialize(void)
+       putreg32(0, regaddr);
+     }
+ 
+-  /* Colorize the interrupt stack for debug purposes */
+-
+-#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
+-  {
+-    size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
+-    up_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
+-                   intstack_size);
+-  }
+-#endif
+-
+   /* Make sure that we are using the correct vector table.  The default
+    * vector address is 0x0000:0000 but if we are executing code that is
+    * positioned in SRAM or in external FLASH, then we may need to reset
+diff --git NuttX/nuttx/arch/arm/src/sam34/sam_vectors.S NuttX/nuttx/arch/arm/src/sam34/sam_vectors.S
+index 9765f61..9de7d24 100644
+--- NuttX/nuttx/arch/arm/src/sam34/sam_vectors.S
++++ NuttX/nuttx/arch/arm/src/sam34/sam_vectors.S
+@@ -362,7 +362,7 @@ exception_common:
+ 	 *
+ 	 * Here:
+ 	 *   r0 = Address of the register save area
+-	
++
+ 	 * NOTE: It is a requirement that up_restorefpu() preserve the value of
+ 	 * r0!
+ 	 */
+@@ -482,7 +482,7 @@ exception_common:
+ 	.global	g_intstackbase
+ 	.align	8
+ g_intstackalloc:
+-	.skip	(CONFIG_ARCH_INTERRUPTSTACK & ~7)
++	.skip	((CONFIG_ARCH_INTERRUPTSTACK + 4) & ~7)
+ g_intstackbase:
+ 	.size	g_intstackalloc, .-g_intstackalloc
+ #endif
+diff --git NuttX/nuttx/arch/arm/src/sama5/sam_irq.c NuttX/nuttx/arch/arm/src/sama5/sam_irq.c
+index c8cf1f5..fd4dfd8 100644
+--- NuttX/nuttx/arch/arm/src/sama5/sam_irq.c
++++ NuttX/nuttx/arch/arm/src/sama5/sam_irq.c
+@@ -431,16 +431,6 @@ void up_irqinitialize(void)
+    * access to the AIC.
+    */
+ 
+-  /* Colorize the interrupt stack for debug purposes */
+-
+-#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
+-  {
+-    size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
+-    up_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
+-                   intstack_size);
+-  }
+-#endif
+-
+   /* Redirect all interrupts to the AIC if so configured */
+ 
+   sam_aic_redirection();
+diff --git NuttX/nuttx/arch/arm/src/samv7/sam_irq.c NuttX/nuttx/arch/arm/src/samv7/sam_irq.c
+index 08537f6..74d73d9 100644
+--- NuttX/nuttx/arch/arm/src/samv7/sam_irq.c
++++ NuttX/nuttx/arch/arm/src/samv7/sam_irq.c
+@@ -381,16 +381,6 @@ void up_irqinitialize(void)
+       putreg32(0, regaddr);
+     }
+ 
+-  /* Colorize the interrupt stack for debug purposes */
+-
+-#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
+-  {
+-    size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
+-    up_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
+-                   intstack_size);
+-  }
+-#endif
+-
+   /* Make sure that we are using the correct vector table.  The default
+    * vector address is 0x0000:0000 but if we are executing code that is
+    * positioned in SRAM or in external FLASH, then we may need to reset
+diff --git NuttX/nuttx/arch/arm/src/stm32/gnu/stm32_vectors.S NuttX/nuttx/arch/arm/src/stm32/gnu/stm32_vectors.S
+index a1a39df..6d2d193 100644
+--- NuttX/nuttx/arch/arm/src/stm32/gnu/stm32_vectors.S
++++ NuttX/nuttx/arch/arm/src/stm32/gnu/stm32_vectors.S
+@@ -493,7 +493,7 @@ exception_common:
+ 	.global	g_intstackbase
+ 	.align	8
+ g_intstackalloc:
+-	.skip	(CONFIG_ARCH_INTERRUPTSTACK & ~7)
++	.skip	((CONFIG_ARCH_INTERRUPTSTACK + 4) & ~7)
+ g_intstackbase:
+ 	.size	g_intstackalloc, .-g_intstackalloc
+ #endif
+diff --git NuttX/nuttx/arch/arm/src/stm32/iar/stm32_vectors.S NuttX/nuttx/arch/arm/src/stm32/iar/stm32_vectors.S
+index cb9069d..450a9bc 100644
+--- NuttX/nuttx/arch/arm/src/stm32/iar/stm32_vectors.S
++++ NuttX/nuttx/arch/arm/src/stm32/iar/stm32_vectors.S
+@@ -1051,7 +1051,7 @@ l5:
+ 	.global	g_intstackbase
+ 	.align	8
+ g_intstackalloc:
+-	.skip	(CONFIG_ARCH_INTERRUPTSTACK & ~7)
++	.skip	((CONFIG_ARCH_INTERRUPTSTACK + 4) & ~7)
+ g_intstackbase:
+ 	.size	g_intstackalloc, .-g_intstackalloc
+ #endif
+diff --git NuttX/nuttx/arch/arm/src/stm32/stm32_irq.c NuttX/nuttx/arch/arm/src/stm32/stm32_irq.c
+index ff40bf8..23313f5 100644
+--- NuttX/nuttx/arch/arm/src/stm32/stm32_irq.c
++++ NuttX/nuttx/arch/arm/src/stm32/stm32_irq.c
+@@ -310,16 +310,6 @@ void up_irqinitialize(void)
+       putreg32(0xffffffff, NVIC_IRQ_CLEAR(i));
+     }
+ 
+-  /* Colorize the interrupt stack for debug purposes */
+-
+-#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
+-  {
+-    size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
+-    up_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
+-                   intstack_size);
+-  }
+-#endif
+-
+   /* The standard location for the vector table is at the beginning of FLASH
+    * at address 0x0800:0000.  If we are using the STMicro DFU bootloader, then
+    * the vector table will be offset to a different location in FLASH and we
+diff --git NuttX/nuttx/arch/arm/src/stm32f7/stm32_irq.c NuttX/nuttx/arch/arm/src/stm32f7/stm32_irq.c
+index 758f32b..2a61490 100644
+--- NuttX/nuttx/arch/arm/src/stm32f7/stm32_irq.c
++++ NuttX/nuttx/arch/arm/src/stm32f7/stm32_irq.c
+@@ -415,16 +415,6 @@ void up_irqinitialize(void)
+       putreg32(0, regaddr);
+     }
+ 
+-  /* Colorize the interrupt stack for debug purposes */
+-
+-#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
+-  {
+-    size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
+-    up_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
+-                   intstack_size);
+-  }
+-#endif
+-
+   /* Make sure that we are using the correct vector table.  The default
+    * vector address is 0x0000:0000 but if we are executing code that is
+    * positioned in SRAM or in external FLASH, then we may need to reset
+diff --git NuttX/nuttx/arch/arm/src/stm32l4/stm32l4_irq.c NuttX/nuttx/arch/arm/src/stm32l4/stm32l4_irq.c
+index 720c05e..d9aeffd 100644
+--- NuttX/nuttx/arch/arm/src/stm32l4/stm32l4_irq.c
++++ NuttX/nuttx/arch/arm/src/stm32l4/stm32l4_irq.c
+@@ -304,16 +304,6 @@ void up_irqinitialize(void)
+       putreg32(0xffffffff, NVIC_IRQ_CLEAR(i));
+     }
+ 
+-  /* Colorize the interrupt stack for debug purposes */
+-
+-#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
+-  {
+-    size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
+-    up_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
+-                   intstack_size);
+-  }
+-#endif
+-
+   /* The standard location for the vector table is at the beginning of FLASH
+    * at address 0x0800:0000.  If we are using the STMicro DFU bootloader, then
+    * the vector table will be offset to a different location in FLASH and we
+diff --git NuttX/nuttx/arch/arm/src/tiva/tiva_vectors.S NuttX/nuttx/arch/arm/src/tiva/tiva_vectors.S
+index 4f56269..943581c 100644
+--- NuttX/nuttx/arch/arm/src/tiva/tiva_vectors.S
++++ NuttX/nuttx/arch/arm/src/tiva/tiva_vectors.S
+@@ -339,7 +339,7 @@ exception_common:
+ 	 *
+ 	 * Here:
+ 	 *   r0 = Address of the register save area
+-	
++
+ 	 * NOTE: It is a requirement that up_restorefpu() preserve the value of
+ 	 * r0!
+ 	 */
+@@ -459,7 +459,7 @@ exception_common:
+ 	.global	g_intstackbase
+ 	.align	8
+ g_intstackalloc:
+-	.skip	(CONFIG_ARCH_INTERRUPTSTACK & ~7)
++	.skip	((CONFIG_ARCH_INTERRUPTSTACK + 4) & ~7)
+ g_intstackbase:
+ 	.size	g_intstackalloc, .-g_intstackalloc
+ #endif
+diff --git NuttX/nuttx/arch/arm/src/tms570/tms570_irq.c NuttX/nuttx/arch/arm/src/tms570/tms570_irq.c
+index da9f8c5..be7cb05 100644
+--- NuttX/nuttx/arch/arm/src/tms570/tms570_irq.c
++++ NuttX/nuttx/arch/arm/src/tms570/tms570_irq.c
+@@ -115,14 +115,6 @@ void up_irqinitialize(void)
+   FAR uintptr_t *vimram;
+   int i;
+ 
+-  /* Colorize the interrupt stack for debug purposes */
+-
+-#if defined(CONFIG_STACK_COLORATION) && CONFIG_ARCH_INTERRUPTSTACK > 3
+-  size_t intstack_size = (CONFIG_ARCH_INTERRUPTSTACK & ~3);
+-  up_stack_color((FAR void *)((uintptr_t)&g_intstackbase - intstack_size),
+-                 intstack_size);
+-#endif
+-
+   /* Initialize VIM RAM vectors.  These vectors are not used in the current
+    * interrupt handler logic.
+    */


### PR DESCRIPTION
…plete

       Backport of upstream NuttX

       86400a252dcbe6e4aef3ecca000b469a0fe96b67
       08e92abb0ba744927ed0b32294859b0f47726f82
       4b65817e99cbdf04fefad883eca0e7c8a9add63c

       Improper rounding in redundant stack coloring
       routines could overwriting the TOS+1 and BOS-1
       depending on the value of CONFIG_ARCH_INTERRUPTSTACK

       This applies the complete upstream set of fixes from
       David Cabecinhas <david.cab+bitbucket@gmail.com>

       Improper rounding in redundant stack coloring
       routines was overwriting the TOS+1 and BOS-1

       The legacy OABI 4 byte stack alignment was removed
       Only the EABI 8 byte alignment is supported
       The redundant interrupt stack coloring. up_initalize
       had the correct implementation (last version of patch)
       and the redundant version in the
       arch/arm/src/stmxxx/stmxx_irq.c was calculating the size
       wrong.

       This is fixed by rounding up CONFIG_ARCH_INTERRUPTSTACK
       by 4 bytes when allocated and aligning on a 8 byte boundary