### PR TITLE
mc_pos_control: change yaw setpoint to yaw

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1003,7 +1003,7 @@ MulticopterPositionControl::control_manual(float dt)
 		R_input_fame.from_euler(0.0f, 0.0f, _yaw_takeoff);
 
 	} else {
-		R_input_fame.from_euler(0.0f, 0.0f, _att_sp.yaw_body);
+		R_input_fame.from_euler(0.0f, 0.0f, _local_pos.yaw);
 
 	}
 


### PR DESCRIPTION
in manual mode, the stick input x and y correspond to the body frame. in order to get them into NED frame, the stick inputs need to be rotated by the current yaw and not by the yaw setpoint.