### PR TITLE
Master px4io ppm fix

### DIFF
--- a/src/drivers/boards/px4io-v1/board_config.h
+++ b/src/drivers/boards/px4io-v1/board_config.h
@@ -96,5 +96,5 @@
  */
 #define HRT_TIMER		1	/* use timer1 for the HRT */
 #define HRT_TIMER_CHANNEL	2	/* use capture/compare channel 2 */
-#define HRT_PPM_CHANNEL		1	/* use capture/compare channel 1 */
-#define GPIO_PPM_IN		(GPIO_ALT|GPIO_CNF_INPULLUP|GPIO_PORTE|GPIO_PIN9)
+#define HRT_PPM_CHANNEL		1	/* use capture/compare channel 1 PA8 */
+#define GPIO_PPM_IN		(GPIO_ALT|GPIO_CNF_INPULLUP|GPIO_PORTA|GPIO_PIN8)

--- a/src/drivers/boards/px4io-v2/board_config.h
+++ b/src/drivers/boards/px4io-v2/board_config.h
@@ -125,8 +125,8 @@
  */
 #define HRT_TIMER		1	/* use timer1 for the HRT */
 #define HRT_TIMER_CHANNEL	2	/* use capture/compare channel 2 */
-#define HRT_PPM_CHANNEL		1	/* use capture/compare channel 1 */
-#define GPIO_PPM_IN		(GPIO_ALT|GPIO_CNF_INPULLUP|GPIO_PORTE|GPIO_PIN9)
+#define HRT_PPM_CHANNEL		1	/* use capture/compare channel 1 PA8 */
+#define GPIO_PPM_IN		(GPIO_ALT|GPIO_CNF_INPULLUP|GPIO_PORTA|GPIO_PIN8)
 
 /* LED definitions ******************************************************************/
 /* PX4 has two LEDs that we will encode as: */


### PR DESCRIPTION
@LorenzMeier 

This was reported by @matanhavi in "Error on px4io-v2/board_config.h ?" #6516

I am surprised this ever worked on the PX4IOs.

Could it be PPM was never tested [since](https://github.com/PX4/Firmware/commit/85651218e28968161890ddcae1c670f08774c285#diff-1f9583407523ce00e27e2754f6800af2) ands subsequent mods to the same line?

I stepped the code on the F1 on master and it does **not** initialize the pin returning -EINVAL:

```
 /* Verify that this hardware supports the select GPIO port */

  port = (cfgset & GPIO_PORT_MASK) >> GPIO_PORT_SHIFT;
  if (port >= STM32_NGPIO_PORTS)
    {
      return -EINVAL;
    }
```

Therefore I want to have this tested to ensure there was not some side effect.