### PR TITLE
Inline BlockParam getter

### DIFF
--- a/src/lib/controllib/block/BlockParam.cpp
+++ b/src/lib/controllib/block/BlockParam.cpp
@@ -94,9 +94,6 @@ BlockParam<T>::BlockParam(Block *block, const char *name,
 }
 
 template <class T>
-T BlockParam<T>::get() { return _val; }
-
-template <class T>
 void BlockParam<T>::set(T val)
 {
 	_val = val;

--- a/src/lib/controllib/block/BlockParam.hpp
+++ b/src/lib/controllib/block/BlockParam.hpp
@@ -82,7 +82,7 @@ public:
 	BlockParam(const BlockParam &) = delete;
 	BlockParam &operator=(const BlockParam &) = delete;
 
-	T get();
+	inline T get() const { return _val; }
 	void commit();
 	void set(T val);
 	void update() override;


### PR DESCRIPTION
This is a small optimization to inline the get method on BlockParams. Should save some bytes of flash because the compiler doesn't have to generate the method and insert a bunch of unnecessary branches to load what is very likely to be nearby in memory. 