### PR TITLE
Set battery warning for MAVLink battery status

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1360,6 +1360,26 @@ MavlinkReceiver::handle_message_battery_status(mavlink_message_t *msg)
 	battery_status.cell_count = cell_count;
 	battery_status.connected = true;
 
+	// Get the battery level thresholds.
+	float bat_emergency_thr;
+	float bat_crit_thr;
+	float bat_low_thr;
+	param_get(param_find("BAT_EMERGEN_THR"), &bat_emergency_thr);
+	param_get(param_find("BAT_CRIT_THR"), &bat_crit_thr);
+	param_get(param_find("BAT_LOW_THR"), &bat_low_thr);
+
+	// Set the battery warning based on remaining charge.
+	//  Note: Smallest values must come first in evaluation.
+	if (battery_status.remaining < bat_emergency_thr) {
+		battery_status.warning = battery_status_s::BATTERY_WARNING_EMERGENCY;
+
+	} else if (battery_status.remaining < bat_crit_thr) {
+		battery_status.warning = battery_status_s::BATTERY_WARNING_CRITICAL;
+
+	} else if (battery_status.remaining < bat_low_thr) {
+		battery_status.warning = battery_status_s::BATTERY_WARNING_LOW;
+	}
+
 	if (_battery_pub == nullptr) {
 		_battery_pub = orb_advertise(ORB_ID(battery_status), &battery_status);
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -147,7 +147,10 @@ MavlinkReceiver::MavlinkReceiver(Mavlink *parent) :
 	_time_offset(0),
 	_orb_class_instance(-1),
 	_mom_switch_pos{},
-	_mom_switch_state(0)
+	_mom_switch_state(0),
+	_p_bat_emergen_thr(param_find("BAT_EMERGEN_THR")),
+	_p_bat_crit_thr(param_find("BAT_CRIT_THR")),
+	_p_bat_low_thr(param_find("BAT_LOW_THR"))
 {
 }
 
@@ -1361,16 +1364,16 @@ MavlinkReceiver::handle_message_battery_status(mavlink_message_t *msg)
 	battery_status.connected = true;
 
 	// Get the battery level thresholds.
-	float bat_emergency_thr;
+	float bat_emergen_thr;
 	float bat_crit_thr;
 	float bat_low_thr;
-	param_get(param_find("BAT_EMERGEN_THR"), &bat_emergency_thr);
-	param_get(param_find("BAT_CRIT_THR"), &bat_crit_thr);
-	param_get(param_find("BAT_LOW_THR"), &bat_low_thr);
+	param_get(_p_bat_emergen_thr, &bat_emergen_thr);
+	param_get(_p_bat_crit_thr, &bat_crit_thr);
+	param_get(_p_bat_low_thr, &bat_low_thr);
 
 	// Set the battery warning based on remaining charge.
 	//  Note: Smallest values must come first in evaluation.
-	if (battery_status.remaining < bat_emergency_thr) {
+	if (battery_status.remaining < bat_emergen_thr) {
 		battery_status.warning = battery_status_s::BATTERY_WARNING_EMERGENCY;
 
 	} else if (battery_status.remaining < bat_crit_thr) {

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -252,6 +252,10 @@ private:
 	uint8_t _mom_switch_pos[MOM_SWITCH_COUNT];
 	uint16_t _mom_switch_state;
 
+	param_t _p_bat_emergen_thr;
+	param_t _p_bat_crit_thr;
+	param_t _p_bat_low_thr;
+
 	/* do not allow copying this class */
 	MavlinkReceiver(const MavlinkReceiver &);
 	MavlinkReceiver operator=(const MavlinkReceiver &);


### PR DESCRIPTION
**Software Modification**
The software is updated to set the battery warning when a MAVLink BATTERY_STATUS
message is received.  The battery warning is set based on emergency/critical/low
thresholds within the parameters.

This modification is consistent with the existing battery [operation](https://github.com/PX4/Firmware/blob/master/src/modules/systemlib/battery.cpp#L220), when the 'Power Module' is enabled.  A common definition of setting the battery warning could ultimately be achieved (independent of the BAT_SOURCE) with an architectural modification.

**Testing**
Desktop testing performed:
QGroundControl Daily Build (HEAD:e5afeae0)
X-Plane 10.51r2
PX4 Sw: https://github.com/SenteraLLC/Firmware/tree/mavlink_batt_warning-HIL_testing
PX4 Hw: px4fmu-v4 (custom variant)
[Log](https://drive.google.com/open?id=0B-yJurEfkd7eRm1kdFZzX1M3ZTQ)
