### PR TITLE
Move uORB Subscription getter to header file

### DIFF
--- a/src/modules/uORB/Subscription.cpp
+++ b/src/modules/uORB/Subscription.cpp
@@ -151,9 +151,6 @@ bool Subscription<T>::check_updated()
 	return SubscriptionBase::updated();
 }
 
-template <class T>
-const T &Subscription<T>::get() { return _data; }
-
 template class __EXPORT Subscription<actuator_armed_s>;
 template class __EXPORT Subscription<actuator_controls_s>;
 template class __EXPORT Subscription<att_pos_mocap_s>;

--- a/src/modules/uORB/Subscription.hpp
+++ b/src/modules/uORB/Subscription.hpp
@@ -193,7 +193,7 @@ public:
 	/*
 	 * This function gets the T struct data
 	 * */
-	const T &get();
+	const T &get() const { return _data; }
 private:
 	T _data;
 };


### PR DESCRIPTION
Another micro optimization that saves a few 100 bytes of flash and cuts a couple of unneeded branches. 