### PR TITLE
LPE : default fusion flags for GPS-only use

### DIFF
--- a/posix-configs/SITL/init/lpe/iris
+++ b/posix-configs/SITL/init/lpe/iris
@@ -41,8 +41,8 @@ param set MPC_Z_VEL_P 0.6
 param set MPC_Z_VEL_I 0.15
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01
-param set LPE_FUSION 247
-# 11110111 no vis yaw (1 << 3)
+# GPS only mode
+param set LPE_FUSION 145
 
 replay tryapplyparams
 simulator start -s

--- a/posix-configs/SITL/init/lpe/iris_opt_flow
+++ b/posix-configs/SITL/init/lpe/iris_opt_flow
@@ -59,8 +59,9 @@ param set MPC_XY_P 0.5
 param set MIS_TAKEOFF_ALT 2
 param set NAV_ACC_RAD 1.0
 param set CBRK_GPSFAIL 240024
-param set LPE_FUSION 246
-# 11110110 no vis yaw (1 << 3) and no gps (1 << 0)
+# Flow-only mode
+param set LPE_FUSION 242
+param set FAKE_ORIGIN 1
 
 replay tryapplyparams
 simulator start -s

--- a/src/modules/local_position_estimator/params.c
+++ b/src/modules/local_position_estimator/params.c
@@ -345,7 +345,7 @@ PARAM_DEFINE_FLOAT(LPE_FGYRO_HP, 0.001f);
  * @min 0
  * @max 1
  */
-PARAM_DEFINE_INT32(LPE_FAKE_ORIGIN, 1);
+PARAM_DEFINE_INT32(LPE_FAKE_ORIGIN, 0);
 
 /**
  * Local origin latitude for nav w/o GPS
@@ -437,7 +437,7 @@ PARAM_DEFINE_FLOAT(LPE_LAND_VXY, 0.05f);
  * 6 : Set to true to enable flow gyro compensation
  * 7 : Set to true to enable baro fusion
  *
- * default (247, no vision yaw)
+ * default (145 - GPS only)
  *
  * @group Local Position Estimator
  * @min 0
@@ -451,4 +451,4 @@ PARAM_DEFINE_FLOAT(LPE_LAND_VXY, 0.05f);
  * @bit 6 flow gyro compensation
  * @bit 7 fuse baro
  */
-PARAM_DEFINE_INT32(LPE_FUSION, 247);
+PARAM_DEFINE_INT32(LPE_FUSION, 145);


### PR DESCRIPTION
This changes the LPE fusion flags to default to GPS-only mode. For optical flow based nav, I will add a Devguide entry on how to set it up properly : https://github.com/PX4/Devguide/pull/98

Fixes #6823. @lovettchris You will want this :)

