### PR TITLE
Fixes lost RC on px4fmu-v4

### DIFF
--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1764,6 +1764,11 @@ void PX4FMU::stop()
 	orb_unsubscribe(_armed_sub);
 	orb_unsubscribe(_param_sub);
 
+	orb_unadvertise(_to_input_rc);
+	orb_unadvertise(_outputs_pub);
+	orb_unadvertise(_to_safety);
+	orb_unadvertise(_to_mixer_status);
+
 	/* make sure servos are off */
 	up_pwm_servo_deinit();
 


### PR DESCRIPTION
@LorenzMeier 

   As I am unfamiliar with the uOrb publication lifecycle. Please check that this is a proper fix. 
   If this is a proper fix, I think we have to look at the creation pattern used herein and possibly
   use an auto_ptr like pattern to avoid this in many other drivers that can be stopped.

----
   A [recent change](https://github.com/PX4/Firmware/commit/a716b105f545188b79a3e552f23cad864d1c1821) in the fmu code stops the instance when a
   xxxx_reset command is used issued if the fmu was not
   already running.

   That change left publications published and then on the
   next creation, of the fmu created a new publications.

   This change calls orb_unadvertise to mark the publication
   as un published so that on the next instantiations of the
   fmu it resumes publishing on the same publication.