### PR TITLE
Fixes dead aux channels introduce in oneshot

### DIFF
--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1151,6 +1151,7 @@ PX4FMU::cycle()
 		}
 
 		/* wait for an update */
+		unsigned n_updates = 0;
 		int ret = ::poll(_poll_fds, _poll_fds_num, poll_timeout);
 
 		/* this would be bad... */
@@ -1166,7 +1167,6 @@ PX4FMU::cycle()
 
 			/* get controls for required topics */
 			unsigned poll_id = 0;
-			unsigned n_updates = 0;
 
 			for (unsigned i = 0; i < actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS; i++) {
 				if (_control_subs[i] > 0) {
@@ -1218,9 +1218,12 @@ PX4FMU::cycle()
 					_pwm_limit.state = PWM_LIMIT_STATE_ON;
 				}
 			}
+		} // poll_fds
 
-			// only mix if we have a new actuator_controls message
-			if ((n_updates > 0) && (_mixers != nullptr)) {
+		/* run the mixers on every cycle */
+		{
+			/* can we mix? */
+			if (_mixers != nullptr) {
 
 				size_t num_outputs;
 
@@ -1334,13 +1337,14 @@ PX4FMU::cycle()
 				 * the oneshots with updated values.
 				 */
 
-				up_pwm_update();
+				if (n_updates > 0) {
+					up_pwm_update();
+				}
 
 				publish_pwm_outputs(pwm_limited, num_outputs);
 				perf_end(_ctl_latency);
-			} // new actuator_controls message
-
-		} // poll_fds
+			}
+		}
 
 		_cycle_timestamp = hrt_absolute_time();
 


### PR DESCRIPTION
@sanderux 

Sorry for the delay I has cascading HW issue to be able to get to a point to test. Would you be able to test this commit.

@LorenzMeier, @kd0aij 

Please see if this makes sense

   Returned the fmu mixer code to where it updated the HW once
   it has a mixer. But  only signals a up_pwm_update() for
   onshots on actual control update.

   Before this change the hw outpuse were not updated.