### PR TITLE
use snapdragon_pwm_out and change connector for RC

### DIFF
--- a/posix-configs/eagle/flight/px4.config
+++ b/posix-configs/eagle/flight/px4.config
@@ -16,5 +16,5 @@ ekf2 start
 land_detector start multicopter
 mc_pos_control start
 mc_att_control start
-pwm_out_rc_in start -d /dev/tty-2
+snapdragon_pwm_out start
 spektrum_rc start

--- a/src/drivers/spektrum_rc/spektrum_rc.cpp
+++ b/src/drivers/spektrum_rc/spektrum_rc.cpp
@@ -36,7 +36,7 @@
  * @file spektrum_rc.cpp
  *
  * This is a driver for a Spektrum satellite receiver connected to a Snapdragon
- * on the serial port. By default port J15 (next to USB) is used.
+ * on the serial port. By default port J12 (next to J13, power module side) is used.
  */
 
 #include <px4_tasks.h>
@@ -49,8 +49,8 @@
 #include <uORB/uORB.h>
 #include <uORB/topics/input_rc.h>
 
-// Snapdraogon: use J15 (next to USB)
-#define SPEKTRUM_UART_DEVICE_PATH "/dev/tty-1"
+// Snapdraogon: use J12 (next to J13, power module side)
+#define SPEKTRUM_UART_DEVICE_PATH "/dev/tty-3"
 
 #define UNUSED(x) (void)(x)
 


### PR DESCRIPTION
Two changes:
* use snapdragon_pwm_out for ESCs
* change the connector for RC from J15 to J12, since the lidar (trone) needs I2C (which J15 has and J12 not).