### PR TITLE
MPU6000 driver: change default accelerometer range to +-16g

### DIFF
--- a/src/drivers/mpu6000/mpu6000.cpp
+++ b/src/drivers/mpu6000/mpu6000.cpp
@@ -796,7 +796,7 @@ int MPU6000::reset()
 	_gyro_range_scale = (0.0174532 / 16.4);//1.0f / (32768.0f * (2000.0f / 180.0f) * M_PI_F);
 	_gyro_range_rad_s = (2000.0f / 180.0f) * M_PI_F;
 
-	set_accel_range(8);
+	set_accel_range(16);
 
 	usleep(1000);
 


### PR DESCRIPTION
This range amkes much more sense for MAV applications.
It reduces vibration vulnerability caused by measurement range clipping.