### PR TITLE
mc_pos_control: manual input temporary yaw fix

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1015,7 +1015,7 @@ MulticopterPositionControl::control_manual(float dt)
 	}
 
 	/* prepare yaw to rotate into NED frame */
-	float yaw_input_fame = _control_mode.flag_control_fixed_hdg_enabled ? _yaw_takeoff : _local_pos.yaw;
+	float yaw_input_fame = _control_mode.flag_control_fixed_hdg_enabled ? _yaw_takeoff : _att_sp.yaw_body;
 
 	/* prepare cruise speed (m/s) vector to scale the velocity setpoint */
 	matrix::Vector3f vel_cruise_scale(_params.vel_cruise_xy,


### PR DESCRIPTION
We encountered some issue when flying in manual due to the setpoint rotation using the current yaw. this should be correct, but there is most likely some transformation issue. 
As a consequence, we change it back to yaw_sp to prevent any unexpected flight performance during manual flight. 