### PR TITLE
mavlink_mission: support INT altitude frames

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -927,10 +927,12 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 
 		mission_item->altitude = mavlink_mission_item->z;
 
-		if (mavlink_mission_item->frame == MAV_FRAME_GLOBAL) {
+		if (mavlink_mission_item->frame == MAV_FRAME_GLOBAL ||
+		    mavlink_mission_item->frame == MAV_FRAME_GLOBAL_INT) {
 			mission_item->altitude_is_relative = false;
 
-		} else if (mavlink_mission_item->frame == MAV_FRAME_GLOBAL_RELATIVE_ALT) {
+		} else if (mavlink_mission_item->frame == MAV_FRAME_GLOBAL_RELATIVE_ALT ||
+			   mavlink_mission_item->frame == MAV_FRAME_GLOBAL_RELATIVE_ALT_INT) {
 			mission_item->altitude_is_relative = true;
 		}
 

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1138,10 +1138,20 @@ MavlinkMissionManager::format_mavlink_mission_item(const struct mission_item_s *
 		mavlink_mission_item->z = mission_item->altitude;
 
 		if (mission_item->altitude_is_relative) {
-			mavlink_mission_item->frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
+			if (_int_mode) {
+				mavlink_mission_item->frame = MAV_FRAME_GLOBAL_RELATIVE_ALT_INT;
+
+			} else {
+				mavlink_mission_item->frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
+			}
 
 		} else {
-			mavlink_mission_item->frame = MAV_FRAME_GLOBAL;
+			if (_int_mode) {
+				mavlink_mission_item->frame = MAV_FRAME_GLOBAL_INT;
+
+			} else {
+				mavlink_mission_item->frame = MAV_FRAME_GLOBAL;
+			}
 		}
 
 		switch (mission_item->nav_cmd) {


### PR DESCRIPTION
The relative altitude flag was not set correclty when waypoints are sent
using the INT protocol.

Tested in SITL.