### PR TITLE
Update URL in airspeed calibration error message

### DIFF
--- a/src/modules/commander/airspeed_calibration.cpp
+++ b/src/modules/commander/airspeed_calibration.cpp
@@ -109,7 +109,9 @@ int do_airspeed_calibration(orb_advert_t *mavlink_log_pub)
 		float analog_scaling = 0.0f;
 		param_get(param_find("SENS_DPRES_ANSC"), &(analog_scaling));
 		if (fabsf(analog_scaling) < 0.1f) {
-			calibration_log_critical(mavlink_log_pub, "[cal] No airspeed sensor, see http://px4.io/help/aspd");
+			calibration_log_critical(mavlink_log_pub, "[cal] No airspeed sensor, refer to the following:");
+			calibration_log_critical(mavlink_log_pub, "http://px4.io/docs/sensor-selection/");
+			calibration_log_critical(mavlink_log_pub, "http://px4.io/docs/vtols-without-airspeed-sensor/");
 			goto error_return;
 		}
 


### PR DESCRIPTION
When a FW/VTOL system detects a missing airspeed sensor, it produces an error message.
This patch uses the new relevant URLs in the PX4 documentation.

Fixes #4549