### PR TITLE
Add markdown (HTML) output format for parameters

### DIFF
--- a/Tools/px4params/markdownout.py
+++ b/Tools/px4params/markdownout.py
@@ -1,0 +1,40 @@
+from xml.sax.saxutils import escape
+import codecs
+
+class MarkdownTablesOutput():
+    def __init__(self, groups):
+        result = ("# Parameter Reference\n"
+                  "> **Note** **This list is auto-generated from the source code** and contains the most recent parameter documentation.\n"
+                  "\n")
+        for group in groups:
+            result += '## %s\n\n' % group.GetName()
+            result += '<table style="width: 100%;">\n'
+            result += '<colgroup><col style="width: 25%"><col style="width: 45%"><col style="width: 10%"><col style="width: 10%"><col style="width: 10%"></colgroup>\n'
+            result += '<thead><tr><th class="col0" rowspan="2">Name</th><th class="col1">Description</th><th class="col2 rightalign">Min</th><th class="col3 rightalign">Max</th><th class="col4 rightalign">Default</th></tr>\n'
+            result += '</thead>\n'
+            result += '<tbody>\n'
+
+            for param in group.GetParams():
+                code = param.GetName()
+                def_val = param.GetDefault() or ''
+                name = param.GetFieldValue("short_desc") or ''
+                min_val = param.GetFieldValue("min") or ''
+                max_val = param.GetFieldValue("max") or ''
+                long_desc = param.GetFieldValue("long_desc") or ''
+                if long_desc is not '':
+                    long_desc = '<p><strong>Comment:</strong> %s</p>' % long_desc
+
+                if name == code:
+                    name = ""
+                code='<strong id="%s">%s</strong>' % (code, code)
+                
+                result += '<tr><td class="col0">%s</td><td class="col1"><p>%s</p>%s</td><td class="col2 rightalign">%s</td><td class="col3 rightalign">%s</td><td class="col4 rightalign">%s</td></tr>\n' % (code,name, long_desc, min_val,max_val,def_val)
+
+            #Close the table.
+            result += '</tbody></table>\n\n'
+
+        self.output = result;
+
+    def Save(self, filename):
+        with codecs.open(filename, 'w', 'utf-8') as f:
+            f.write(self.output)

--- a/Tools/px_process_params.py
+++ b/Tools/px_process_params.py
@@ -50,7 +50,7 @@ from __future__ import print_function
 import sys
 import os
 import argparse
-from px4params import srcscanner, srcparser, xmlout, dokuwikiout, dokuwikirpc
+from px4params import srcscanner, srcparser, xmlout, dokuwikiout, dokuwikirpc, markdownout
 
 import re
 import json
@@ -81,6 +81,12 @@ def main():
                          const="",
                          metavar="BOARD",
                          help="Board to create xml parameter xml for")
+    parser.add_argument("-m", "--markdown",
+                        nargs='?',
+                        const="parameters.md",
+                        metavar="FILENAME",
+                        help="Create Markdown file"
+                             " (default FILENAME: parameters.md)")
     parser.add_argument("-w", "--wiki",
                         nargs='?',
                         const="parameters.wiki",
@@ -122,7 +128,7 @@ def main():
     args = parser.parse_args()
 
     # Check for valid command
-    if not (args.xml or args.wiki or args.wiki_update):
+    if not (args.xml or args.wiki or args.wiki_update or args.markdown):
         print("Error: You need to specify at least one output method!\n")
         parser.print_usage()
         sys.exit(1)
@@ -175,6 +181,13 @@ def main():
                 xmlrpc.wiki.putPage(args.wiki_update, out.output, {'sum': args.wiki_summary})
             else:
                 print("Error: You need to specify DokuWiki XML-RPC username and password!")
+
+    # Output to Markdown/HTML tables
+    if args.markdown:
+        out = markdownout.MarkdownTablesOutput(param_groups)
+        if args.markdown:
+            print("Creating markdown file " + args.markdown)
+            out.Save(args.markdown)
 
     #print("All done!")
 


### PR DESCRIPTION
Add Gitbook compatible output format for parameters (HTML tables).

This does not yet provide a mechanism for automating build. 