### PR TITLE
Improvements in UAVCAN GNSS bridge

### DIFF
--- a/src/modules/uavcan/sensors/gnss.cpp
+++ b/src/modules/uavcan/sensors/gnss.cpp
@@ -43,7 +43,6 @@
 #include <drivers/drv_hrt.h>
 #include <systemlib/err.h>
 #include <mathlib/mathlib.h>
-#include <algorithm>
 
 const char *const UavcanGnssBridge::NAME = "gnss";
 
@@ -424,7 +423,7 @@ void UavcanGnssBridge::broadcast_from_orb(const uavcan::TimerEvent &)
 	msg.covariance.resize(3, orb_msg.epv * orb_msg.epv);
 	msg.covariance.resize(6, orb_msg.s_variance_m_s * orb_msg.s_variance_m_s);
 
-	msg.pdop = std::max(orb_msg.hdop, orb_msg.vdop);  // this is a hack :(
+	msg.pdop = (orb_msg.hdop > orb_msg.vdop) ? orb_msg.hdop : orb_msg.vdop;  // this is a hack :(
 
 	// Publishing now
 	(void) _pub_fix2.broadcast(msg);

--- a/src/modules/uavcan/sensors/gnss.cpp
+++ b/src/modules/uavcan/sensors/gnss.cpp
@@ -65,19 +65,19 @@ int UavcanGnssBridge::init()
 {
 	int res = _pub_fix2.init(uavcan::TransferPriority::MiddleLower);
 	if (res < 0) {
-		warnx("GNSS fix2 pub failed %i", res);
+		PX4_WARN("GNSS fix2 pub failed %i", res);
 		return res;
 	}
 
 	res = _sub_fix.start(FixCbBinder(this, &UavcanGnssBridge::gnss_fix_sub_cb));
 	if (res < 0) {
-		warnx("GNSS fix sub failed %i", res);
+		PX4_WARN("GNSS fix sub failed %i", res);
 		return res;
 	}
 
 	res = _sub_fix2.start(Fix2CbBinder(this, &UavcanGnssBridge::gnss_fix2_sub_cb));
 	if (res < 0) {
-		warnx("GNSS fix2 sub failed %i", res);
+		PX4_WARN("GNSS fix2 sub failed %i", res);
 		return res;
 	}
 
@@ -122,7 +122,7 @@ void UavcanGnssBridge::gnss_fix_sub_cb(const uavcan::ReceivedDataStructure<uavca
 void UavcanGnssBridge::gnss_fix2_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Fix2> &msg)
 {
 	if (_old_fix_subscriber_active) {
-		warnx("GNSS Fix2 message detected, disabling support for the old Fix message");
+		PX4_WARN("GNSS Fix2 message detected, disabling support for the old Fix message");
 		_sub_fix.stop();
 		_old_fix_subscriber_active = false;
 		_receiver_node_id = -1;
@@ -241,7 +241,7 @@ void UavcanGnssBridge::process_fixx(const uavcan::ReceivedDataStructure<FixType>
 	// This bridge does not support redundant GNSS receivers yet.
 	if (_receiver_node_id < 0) {
 		_receiver_node_id = msg.getSrcNodeID().get();
-		warnx("GNSS receiver node ID: %d", _receiver_node_id);
+		PX4_WARN("GNSS receiver node ID: %d", _receiver_node_id);
 
 	} else {
 		if (_receiver_node_id != msg.getSrcNodeID().get()) {
@@ -361,7 +361,7 @@ void UavcanGnssBridge::process_fixx(const uavcan::ReceivedDataStructure<FixType>
 	// Doing less time critical stuff here
 	if (_orb_to_uavcan_pub_timer.isRunning()) {
 		_orb_to_uavcan_pub_timer.stop();
-		warnx("GNSS ORB->UAVCAN bridge stopped, because there are other GNSS publishers");
+		PX4_WARN("GNSS ORB->UAVCAN bridge stopped, because there are other GNSS publishers");
 	}
 }
 
@@ -371,17 +371,17 @@ void UavcanGnssBridge::broadcast_from_orb(const uavcan::TimerEvent &)
 		// ORB subscription stops working if this is relocated into init()
 		_orb_sub_gnss = orb_subscribe(ORB_ID(vehicle_gps_position));
 		if (_orb_sub_gnss < 0) {
-			warnx("GNSS ORB sub errno %d", errno);
+			PX4_WARN("GNSS ORB sub errno %d", errno);
 			return;
 		}
-		warnx("GNSS ORB fd %d", _orb_sub_gnss);
+		PX4_WARN("GNSS ORB fd %d", _orb_sub_gnss);
 	}
 
 	{
 		bool updated = false;
 		const int res = orb_check(_orb_sub_gnss, &updated);
 		if (res < 0) {
-			warnx("GNSS ORB check err %d %d", res, errno);
+			PX4_WARN("GNSS ORB check err %d %d", res, errno);
 			return;
 		}
 
@@ -393,7 +393,7 @@ void UavcanGnssBridge::broadcast_from_orb(const uavcan::TimerEvent &)
 	auto orb_msg = ::vehicle_gps_position_s();
 	const int res = orb_copy(ORB_ID(vehicle_gps_position), _orb_sub_gnss, &orb_msg);
 	if (res < 0) {
-		warnx("GNSS ORB read errno %d", errno);
+		PX4_WARN("GNSS ORB read errno %d", errno);
 		return;
 	}
 

--- a/src/modules/uavcan/sensors/gnss.cpp
+++ b/src/modules/uavcan/sensors/gnss.cpp
@@ -78,7 +78,8 @@ unsigned UavcanGnssBridge::get_num_redundant_channels() const
 
 void UavcanGnssBridge::print_status() const
 {
-	printf("RX errors: %d, receiver node id: ", _sub_fix.getFailureCount());
+	printf("RX errors: %d, using old Fix: %d, receiver node id: ",
+		_sub_fix.getFailureCount(), int(_old_fix_subscriber_active));
 
 	if (_receiver_node_id < 0) {
 		printf("N/A\n");

--- a/src/modules/uavcan/sensors/gnss.hpp
+++ b/src/modules/uavcan/sensors/gnss.hpp
@@ -34,8 +34,9 @@
 /**
  * @file gnss.hpp
  *
- * UAVCAN --> ORB bridge for GNSS messages:
- *     uavcan.equipment.gnss.Fix
+ * UAVCAN <--> ORB bridge for GNSS messages:
+ *     uavcan.equipment.gnss.Fix (deprecated, but still supported for backward compatibility)
+ *     uavcan.equipment.gnss.Fix2
  *
  * @author Pavel Kirienko <pavel.kirienko@gmail.com>
  * @author Andrew Chambers <achamber@gmail.com>
@@ -48,6 +49,7 @@
 
 #include <uavcan/uavcan.hpp>
 #include <uavcan/equipment/gnss/Fix.hpp>
+#include <uavcan/equipment/gnss/Fix2.hpp>
 
 #include "sensor_bridge.hpp"
 
@@ -71,15 +73,29 @@ private:
 	 * GNSS fix message will be reported via this callback.
 	 */
 	void gnss_fix_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Fix> &msg);
+	void gnss_fix2_sub_cb(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Fix2> &msg);
+
+	template <typename FixType>
+	void process_fixx(const uavcan::ReceivedDataStructure<FixType> &msg,
+	                  const float (&pos_cov)[9],
+	                  const float (&vel_cov)[9],
+	                  const bool valid_pos_cov,
+	                  const bool valid_vel_cov);
 
 	typedef uavcan::MethodBinder < UavcanGnssBridge *,
 		void (UavcanGnssBridge::*)(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Fix> &) >
 		FixCbBinder;
 
+	typedef uavcan::MethodBinder < UavcanGnssBridge *,
+		void (UavcanGnssBridge::*)(const uavcan::ReceivedDataStructure<uavcan::equipment::gnss::Fix2> &) >
+		Fix2CbBinder;
+
 	uavcan::INode &_node;
 	uavcan::Subscriber<uavcan::equipment::gnss::Fix, FixCbBinder> _sub_fix;
+	uavcan::Subscriber<uavcan::equipment::gnss::Fix2, Fix2CbBinder> _sub_fix2;
 	int _receiver_node_id = -1;
 
-	orb_advert_t _report_pub;                ///< uORB pub for gnss position
+	bool _old_fix_subscriber_active = true;
 
+	orb_advert_t _report_pub;                ///< uORB pub for gnss position
 };


### PR DESCRIPTION
- Added support for the [new Fix2 data type](https://github.com/UAVCAN/dsdl/pull/10). The bridge automatically switches from Fix to Fix2 depending on what is available on the bus.

- Fixed time base conversion. PX4 uses UTC internally, whereas UAVCAN GNSS fix message may contain either UTC, GPS, or TAI time. Necessary conversion code has been added.

- If there are no UAVCAN nodes that provide GNSS position data, the bridge will be broadcasting this data itself. Broadcasting stops automatically if another node that provides GNSS data is detected.

Changes have been tested on Pixracer.