### PR TITLE
Added set [{+|-}{e|x|xe|ex}] [<name> <value>]  to nsh

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -1,5 +1,8 @@
 #!nsh
-#
+# Un comment and use set +e to ignore and set -e to enable 'exit on error control'
+#set +e
+# Un comment the line below to help debug scripts by printing a trace of the script commands
+#set -x
 # PX4FMU startup script.
 #
 # NOTE: environment variable references:

--- a/nuttx-patches/00003-PENDING-add-set-ex-to-nsh.patch
+++ b/nuttx-patches/00003-PENDING-add-set-ex-to-nsh.patch
@@ -65,7 +65,7 @@ index eef16ed..013357a 100644
  
 +#ifndef CONFIG_NSH_DISABLESCRIPT
 +#  define NSH_NP_SET_OPTIONS "ex"    /* Maintain order see nsh_npflags_e */
-+#  define NSH_NP_SET_OPTIONS_INIT    (NSH_PFALG_SILENT)
++#  define NSH_NP_SET_OPTIONS_INIT    (NSH_PFLAG_SILENT)
 +#endif
 +
 +#if defined(CONFIG_DISABLE_ENVIRON) && defined(CONFIG_NSH_DISABLESCRIPT)
@@ -87,9 +87,9 @@ index eef16ed..013357a 100644
 +
 +enum nsh_npflags_e
 +{
-+	NSH_PFALG_IGNORE = 1,      /*  set for +e no exit on errors,
++	NSH_PFLAG_IGNORE = 1,      /*  set for +e no exit on errors,
 +	                            *  cleared -e exit on error */
-+	NSH_PFALG_SILENT = 2,      /*  cleared -x  print a trace of commands
++	NSH_PFLAG_SILENT = 2,      /*  cleared -x  print a trace of commands
 +	                            *  when parsing.
 +	                            *  set +x no print a trace of commands */
 +};
@@ -283,7 +283,7 @@ index 97c2d04..4bc6794 100644
  
            envstr = nsh_envexpand(vtbl, ptr);
  
-+          if ((vtbl->np.np_flags & NSH_PFALG_SILENT) == 0)
++          if ((vtbl->np.np_flags & NSH_PFLAG_SILENT) == 0)
 +            {
 +              nsh_output(vtbl,"  %s=%s\n", ptr, envstr ? envstr :"(null)");
 +            }
@@ -299,7 +299,7 @@ index 2c4a369..cc20a82 100644
                 * considerable amount of stack may be used.
                 */
  
-+              if ((vtbl->np.np_flags & NSH_PFALG_SILENT) == 0)
++              if ((vtbl->np.np_flags & NSH_PFLAG_SILENT) == 0)
 +                {
 +                  nsh_output(vtbl,"%s", buffer);
 +                }
@@ -308,7 +308,7 @@ index 2c4a369..cc20a82 100644
              }
          }
 -      while (pret && ret == OK);
-+      while (pret && (ret == OK || (vtbl->np.np_flags & NSH_PFALG_IGNORE)));
++      while (pret && (ret == OK || (vtbl->np.np_flags & NSH_PFLAG_IGNORE)));
  
        /* Close the script file */
  

--- a/nuttx-patches/00003-PENDING-add-set-ex-to-nsh.patch
+++ b/nuttx-patches/00003-PENDING-add-set-ex-to-nsh.patch
@@ -1,0 +1,314 @@
+diff --git NuttX/apps/nshlib/README.txt NuttX/apps/nshlib/README.txt
+index 151387a..28e1247 100644
+--- NuttX/apps/nshlib/README.txt
++++ NuttX/apps/nshlib/README.txt
+@@ -1000,10 +1000,10 @@ o rmmod <module-name>
+     NAME                 INIT   UNINIT      ARG     TEXT     SIZE     DATA     SIZE
+     nsh>
+ 
+-o set <name> <value>
++o set [{+|-}{e|x|xe|ex}] [<name> <value>]
+ 
+-  Set the environment variable <name> to the sting <value>.
+-  For example,
++  Set the environment variable <name> to the sting <value> and or set NSH
++  parser control options. For example,
+ 
+     nsh> echo $foobar
+ 
+@@ -1012,6 +1012,38 @@ o set <name> <value>
+     foovalue
+     nsh>
+ 
++  Set the 'exit on error control' and/or 'print a trace' of commands when parsing
++  scripts in NSH.  The settinngs are in effect from the point of exection, until
++  they are changed again, or in the case of the init script, the settings are
++  returned to the default settings when it exits. Included child scripts will run
++  with the parents settings and changes made in the child script will effect the
++  parent on return.
++
++    Use 'set -e' to enable and 'set +e' to disable (ignore) the exit condition on commands.
++    The default is -e. Errors cause script to exit.
++
++    Use 'set -x' to enable and 'set +x' to disable (silence) printing a trace of the script
++    commands as they are ececuted.
++    The default is +x. No printing of a trace of script commands as they are executed.
++
++  Example 1 - no exit on command not found
++    set +e
++    notacommand
++
++  Example 2 - will exit on command not found
++    set -e
++    notacommand
++
++  Example 3 - will exit on command not found, and print a trace of the script commmands
++    set -ex
++
++  Example 4 - will exit on command not found, and print a trace of the script commmands
++              and set foobar to foovalue.
++    set -ex foobar foovalue
++    nsh> echo $foobar
++    foovalue
++
++
+ o sh <script-path>
+ 
+   Execute the sequence of NSH commands in the file referred
+diff --git NuttX/apps/nshlib/nsh.h NuttX/apps/nshlib/nsh.h
+index eef16ed..013357a 100644
+--- NuttX/apps/nshlib/nsh.h
++++ NuttX/apps/nshlib/nsh.h
+@@ -690,6 +690,15 @@
+ #  undef NSH_HAVE_TRIMSPACES
+ #endif
+ 
++#ifndef CONFIG_NSH_DISABLESCRIPT
++#  define NSH_NP_SET_OPTIONS "ex"    /* Maintain order see nsh_npflags_e */
++#  define NSH_NP_SET_OPTIONS_INIT    (NSH_PFALG_SILENT)
++#endif
++
++#if defined(CONFIG_DISABLE_ENVIRON) && defined(CONFIG_NSH_DISABLESCRIPT)
++#  define CONFIG_NSH_DISABLE_SET
++#endif
++
+ /****************************************************************************
+  * Public Types
+  ****************************************************************************/
+@@ -741,6 +750,22 @@ struct nsh_loop_s
+ };
+ #endif
+ 
++#ifndef CONFIG_NSH_DISABLESCRIPT
++/* Define the bits that correspond to the option defined in
++ * NSH_NP_SET_OPTIONS. The bit value is 1 shifted left the offset
++ * of the char in NSH_NP_SET_OPTIONS string.
++ */
++
++enum nsh_npflags_e
++{
++	NSH_PFALG_IGNORE = 1,      /*  set for +e no exit on errors,
++	                            *  cleared -e exit on error */
++	NSH_PFALG_SILENT = 2,      /*  cleared -x  print a trace of commands
++	                            *  when parsing.
++	                            *  set +x no print a trace of commands */
++};
++#endif
++
+ /* These structure provides the overall state of the parser */
+ 
+ struct nsh_parser_s
+@@ -752,6 +777,9 @@ struct nsh_parser_s
+   bool     np_redirect; /* true: Output from the last command was re-directed */
+ #endif
+   bool     np_fail;     /* true: The last command failed */
++#ifndef CONFIG_NSH_DISABLESCRIPT
++  uint8_t  np_flags;    /* See nsh_npflags_e above */
++#endif
+ #ifndef CONFIG_NSH_DISABLEBG
+   int      np_nice;     /* "nice" value applied to last background cmd */
+ #endif
+@@ -1169,10 +1197,10 @@ int cmd_lsmod(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+    int cmd_uname(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+ #endif
+ 
+-#ifndef CONFIG_DISABLE_ENVIRON
+-#  ifndef CONFIG_NSH_DISABLE_SET
++#ifndef CONFIG_NSH_DISABLE_SET
+       int cmd_set(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+-#  endif
++#endif
++#ifndef CONFIG_DISABLE_ENVIRON
+ #  ifndef CONFIG_NSH_DISABLE_UNSET
+       int cmd_unset(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv);
+ #  endif
+diff --git NuttX/apps/nshlib/nsh_command.c NuttX/apps/nshlib/nsh_command.c
+index d466fbf..d507845 100644
+--- NuttX/apps/nshlib/nsh_command.c
++++ NuttX/apps/nshlib/nsh_command.c
+@@ -424,10 +424,14 @@ static const struct cmdmap_s g_cmdmap[] =
+   { "rmmod",    cmd_rmmod,    2, 2, "<module-name>" },
+ #endif
+ 
+-#ifndef CONFIG_DISABLE_ENVIRON
+-# ifndef CONFIG_NSH_DISABLE_SET
++#ifndef CONFIG_NSH_DISABLE_SET
++#  if !defined(CONFIG_DISABLE_ENVIRON) && !defined(CONFIG_NSH_DISABLESCRIPT)
++  { "set",      cmd_set,      2, 4, "[{+|-}{e|x|xe|ex}] [<name> <value>]" },
++#  elif !defined(CONFIG_DISABLE_ENVIRON) && defined(CONFIG_NSH_DISABLESCRIPT)
+   { "set",      cmd_set,      3, 3, "<name> <value>" },
+-# endif
++#  elif defined(CONFIG_DISABLE_ENVIRON) && !defined(CONFIG_NSH_DISABLESCRIPT)
++  { "set",      cmd_set,      2, 2, "{+|-}{e|x|xe|ex}" },
++#  endif
+ #endif
+ 
+ #if  CONFIG_NFILE_DESCRIPTORS > 0 && CONFIG_NFILE_STREAMS > 0 && !defined(CONFIG_NSH_DISABLESCRIPT)
+diff --git NuttX/apps/nshlib/nsh_console.c NuttX/apps/nshlib/nsh_console.c
+index 6d68e3a..2c52409 100644
+--- NuttX/apps/nshlib/nsh_console.c
++++ NuttX/apps/nshlib/nsh_console.c
+@@ -479,6 +479,10 @@ FAR struct console_stdio_s *nsh_newconsole(void)
+       pstate->cn_outstream       = OUTSTREAM(pstate);
+ #endif
+     }
++#ifndef CONFIG_NSH_DISABLESCRIPT
++  /* Set the initial option flags */
+ 
++  pstate->cn_vtbl.np.np_flags = NSH_NP_SET_OPTIONS_INIT;
++#endif
+   return pstate;
+ }
+diff --git NuttX/apps/nshlib/nsh_consolemain.c NuttX/apps/nshlib/nsh_consolemain.c
+index f89944f..2797610 100644
+--- NuttX/apps/nshlib/nsh_consolemain.c
++++ NuttX/apps/nshlib/nsh_consolemain.c
+@@ -85,6 +85,11 @@ int nsh_consolemain(int argc, char *argv[])
+   /* Execute the start-up script */
+ 
+   (void)nsh_initscript(&pstate->cn_vtbl);
++#ifndef CONFIG_NSH_DISABLESCRIPT
++  /* Reset the option flags */
++
++  pstate->cn_vtbl.np.np_flags = NSH_NP_SET_OPTIONS_INIT;
++#endif
+ #endif
+ 
+ #ifdef CONFIG_NSH_USBDEV_TRACE
+diff --git NuttX/apps/nshlib/nsh_envcmds.c NuttX/apps/nshlib/nsh_envcmds.c
+index cbda78b..277665b 100644
+--- NuttX/apps/nshlib/nsh_envcmds.c
++++ NuttX/apps/nshlib/nsh_envcmds.c
+@@ -311,29 +311,84 @@ int cmd_pwd(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+  * Name: cmd_set
+  ****************************************************************************/
+ 
+-#ifndef CONFIG_DISABLE_ENVIRON
+ #ifndef CONFIG_NSH_DISABLE_SET
+ int cmd_set(FAR struct nsh_vtbl_s *vtbl, int argc, char **argv)
+ {
+   FAR char *value;
+-  int ret;
++  int ret = OK;
++  int ndx = 1;
++#ifndef CONFIG_NSH_DISABLESCRIPT
++  FAR char *popt;
++  const char opts[] = NSH_NP_SET_OPTIONS;
++  int op;
+ 
+-  /* Trim whitespace from the value */
++  /* Support set [{+|-}{e|x|xe|ex}] [<name> <value>] */
+ 
+-  value = nsh_trimspaces(argv[2]);
++  if (argc == 2 || argc == 4)
++    {
++      if (strlen(argv[1]) < 2)
++        {
++          ret = -EINVAL;
++          nsh_output(vtbl, g_fmtargrequired, argv[0], "set", NSH_ERRNO);
++        }
++      else
++        {
++          op = argv[1][0];
++          if (op != '-' && op != '+')
++            {
++              ret = -EINVAL;
++              nsh_output(vtbl, g_fmtarginvalid, argv[0], "set", NSH_ERRNO);
++            }
++          else
++            {
++              value = &argv[1][1];
++              while(*value && *value != ' ')
++                {
++                  popt = strchr(opts, *value++);
++                  if (popt == NULL)
++                    {
++                      nsh_output(vtbl, g_fmtarginvalid, argv[0], "set", NSH_ERRNO);
++                      ret = -EINVAL;
++                      break;
++                    }
++                  if (op == '+')
++                    {
++                      vtbl->np.np_flags |= 1 << (popt-opts);
++                    }
++                  else
++                    {
++                      vtbl->np.np_flags &= ~(1 << (popt-opts));
++                    }
++                }
++              if (ret == OK)
++                {
++                  ndx = 2;
++                }
++            }
++         }
++      }
++#  ifndef CONFIG_DISABLE_ENVIRON
++  if (ret == OK && (argc == 3 || argc == 4))
++#  endif
++#endif
++#ifndef CONFIG_DISABLE_ENVIRON
++    {
++      /* Trim whitespace from the value */
+ 
+-  /* Set the environment variable */
++      value = nsh_trimspaces(argv[ndx+1]);
+ 
+-  ret = setenv(argv[1], value, TRUE);
+-  if (ret < 0)
+-    {
+-      nsh_output(vtbl, g_fmtcmdfailed, argv[0], "setenv", NSH_ERRNO);
+-    }
++      /* Set the environment variable */
+ 
++      ret = setenv(argv[ndx], value, TRUE);
++      if (ret < 0)
++        {
++          nsh_output(vtbl, g_fmtcmdfailed, argv[0], "setenv", NSH_ERRNO);
++        }
++    }
++#endif
+   return ret;
+ }
+ #endif
+-#endif
+ 
+ /****************************************************************************
+  * Name: cmd_unset
+diff --git NuttX/apps/nshlib/nsh_parse.c NuttX/apps/nshlib/nsh_parse.c
+index 97c2d04..4bc6794 100644
+--- NuttX/apps/nshlib/nsh_parse.c
++++ NuttX/apps/nshlib/nsh_parse.c
+@@ -1169,6 +1169,11 @@ static FAR char *nsh_argexpand(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline,
+ 
+           envstr = nsh_envexpand(vtbl, ptr);
+ 
++          if ((vtbl->np.np_flags & NSH_PFALG_SILENT) == 0)
++            {
++              nsh_output(vtbl,"  %s=%s\n", ptr, envstr ? envstr :"(null)");
++            }
++
+           /* Concatenate the result of the operation with the accumulated
+            * string.  On failures to allocation memory, nsh_strcat will
+            * just return value value of argument
+diff --git NuttX/apps/nshlib/nsh_script.c NuttX/apps/nshlib/nsh_script.c
+index 2c4a369..cc20a82 100644
+--- NuttX/apps/nshlib/nsh_script.c
++++ NuttX/apps/nshlib/nsh_script.c
+@@ -136,10 +136,15 @@ int nsh_script(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
+                * considerable amount of stack may be used.
+                */
+ 
++              if ((vtbl->np.np_flags & NSH_PFALG_SILENT) == 0)
++                {
++                  nsh_output(vtbl,"%s", buffer);
++                }
++
+               ret = nsh_parse(vtbl, buffer);
+             }
+         }
+-      while (pret && ret == OK);
++      while (pret && (ret == OK || (vtbl->np.np_flags & NSH_PFALG_IGNORE)));
+ 
+       /* Close the script file */
+ 


### PR DESCRIPTION
@LorenzMeier 

I know you asked for a -e  option for nsh - I have added that and -x

   Set the 'exit on error control' and/or 'print a trace' of
   commands when parsing scripts in NSH.

   Use 'set -e' to enable and 'set +e' to disable (ignore) the exit
   condition on commands. The default is -e. Errors cause script to
   exit.

   Use 'set -x' to enable and 'set +x' to disable (silence) printing
   a trace of the script commands as they are executed. The default
   is +x. No printing of a trace of script commands as they are
   executed.

  Print expanded variables if -x

   The settings are in effect from the point of execution,
   until they are changed again, or in the case of the init
   script, the settings are returned to the default settings
   when it exits.

   Included child scripts will run with the parents settings
   and changes made in the child script will effect the parent
   on return.
