### PR TITLE
use new logger for all eagle configs

### DIFF
--- a/posix-configs/eagle/200qx/mainapp.config
+++ b/posix-configs/eagle/200qx/mainapp.config
@@ -1,6 +1,6 @@
 uorb start
 muorb start
-sdlog2 start -r 100 -e -t -a -b 200
+logger start -t -b 200
 param set MAV_BROADCAST 1
 param set SDLOG_PRIO_BOOST 3
 dataman start

--- a/posix-configs/eagle/210qc/mainapp.config
+++ b/posix-configs/eagle/210qc/mainapp.config
@@ -1,6 +1,6 @@
 uorb start
 muorb start
-sdlog2 start -r 100 -e -t -a -b 200
+logger start -t -b 200
 param set MAV_BROADCAST 1
 param set SDLOG_PRIO_BOOST 3
 dataman start


### PR DESCRIPTION
As suggested by `rogelion?` (Slack, PX4 general), use the new logger for all eagle configs.