### PR TITLE
Pr ekf ecl

### DIFF
--- a/msg/estimator_status.msg
+++ b/msg/estimator_status.msg
@@ -20,7 +20,7 @@ uint16 GPS_CHECK_FAIL_MAX_VERT_DRIFT = 6		# 6 : maximum allowed vertical positio
 uint16 GPS_CHECK_FAIL_MAX_HORZ_SPD_ERR = 7		# 7 : maximum allowed horizontal velocity discrepancy fail
 uint16 GPS_CHECK_FAIL_MAX_VERT_SPD_ERR = 8		# 8 : maximum allowed vertical velocity discrepancy fail
 
-uint16 control_mode_flags	# Bitmask to indicate EKF logic state
+uint32 control_mode_flags	# Bitmask to indicate EKF logic state
 # 0 - true if the filter tilt alignment is complete
 # 1 - true if the filter yaw alignment is complete
 # 2 - true if GPS measurements are being fused

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -265,6 +265,8 @@ private:
 	control::BlockParamExtFloat _rng_pitch_offset;	// range sensor pitch offset (rad)
 	control::BlockParamExtInt
 	_rng_aid;              // enables use of a range finder even if primary height source is not range finder (EKF2_HGT_MODE != 2)
+	control::BlockParamExtFloat _rng_aid_hor_vel_max; 	// maximum allowed horizontal velocity for range aid
+	control::BlockParamExtFloat _rng_aid_height_max; 	// maximum allowed absolute altitude (AGL) for range aid
 
 	// vision estimate fusion
 	control::BlockParamExtFloat _ev_pos_noise;		// default position observation noise for exernal vision measurements (m)
@@ -396,6 +398,8 @@ Ekf2::Ekf2():
 	_rng_gnd_clearance(this, "EKF2_MIN_RNG", false, _params->rng_gnd_clearance),
 	_rng_pitch_offset(this, "EKF2_RNG_PITCH", false, _params->rng_sens_pitch),
 	_rng_aid(this, "EKF2_RNG_AID", false, _params->range_aid),
+	_rng_aid_hor_vel_max(this, "EKF2_RNG_A_VMAX", false, _params->max_vel_for_range_aid),
+	_rng_aid_height_max(this, "EKF2_RNG_A_HMAX", false, _params->max_hagl_for_range_aid),
 	_ev_pos_noise(this, "EKF2_EVP_NOISE", false, _default_ev_pos_noise),
 	_ev_ang_noise(this, "EKF2_EVA_NOISE", false, _default_ev_ang_noise),
 	_ev_innov_gate(this, "EKF2_EV_GATE", false, _params->ev_innov_gate),

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -260,6 +260,7 @@ private:
 
 	// range finder fusion
 	control::BlockParamExtFloat _range_noise;		// observation noise for range finder measurements (m)
+	control::BlockParamExtFloat _range_noise_scaler; // scale factor from range to range noise (m/m)
 	control::BlockParamExtFloat _range_innov_gate;	// range finder fusion innovation consistency gate size (STD)
 	control::BlockParamExtFloat _rng_gnd_clearance;	// minimum valid value for range when on ground (m)
 	control::BlockParamExtFloat _rng_pitch_offset;	// range sensor pitch offset (rad)
@@ -394,6 +395,7 @@ Ekf2::Ekf2():
 	_fusion_mode(this, "EKF2_AID_MASK", false, _params->fusion_mode),
 	_vdist_sensor_type(this, "EKF2_HGT_MODE", false, _params->vdist_sensor_type),
 	_range_noise(this, "EKF2_RNG_NOISE", false, _params->range_noise),
+	_range_noise_scaler(this, "EKF2_RNG_SFE", false, _params->range_noise_scaler),
 	_range_innov_gate(this, "EKF2_RNG_GATE", false, _params->range_innov_gate),
 	_rng_gnd_clearance(this, "EKF2_MIN_RNG", false, _params->rng_gnd_clearance),
 	_rng_pitch_offset(this, "EKF2_RNG_PITCH", false, _params->rng_sens_pitch),

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -263,6 +263,8 @@ private:
 	control::BlockParamExtFloat _range_innov_gate;	// range finder fusion innovation consistency gate size (STD)
 	control::BlockParamExtFloat _rng_gnd_clearance;	// minimum valid value for range when on ground (m)
 	control::BlockParamExtFloat _rng_pitch_offset;	// range sensor pitch offset (rad)
+	control::BlockParamExtInt
+	_rng_aid;              // enables use of a range finder even if primary height source is not range finder (EKF2_HGT_MODE != 2)
 
 	// vision estimate fusion
 	control::BlockParamExtFloat _ev_pos_noise;		// default position observation noise for exernal vision measurements (m)
@@ -393,6 +395,7 @@ Ekf2::Ekf2():
 	_range_innov_gate(this, "EKF2_RNG_GATE", false, _params->range_innov_gate),
 	_rng_gnd_clearance(this, "EKF2_MIN_RNG", false, _params->rng_gnd_clearance),
 	_rng_pitch_offset(this, "EKF2_RNG_PITCH", false, _params->rng_sens_pitch),
+	_rng_aid(this, "EKF2_RNG_AID", false, _params->range_aid),
 	_ev_pos_noise(this, "EKF2_EVP_NOISE", false, _default_ev_pos_noise),
 	_ev_ang_noise(this, "EKF2_EVA_NOISE", false, _default_ev_ang_noise),
 	_ev_innov_gate(this, "EKF2_EV_GATE", false, _params->ev_innov_gate),

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -578,6 +578,18 @@ PARAM_DEFINE_INT32(EKF2_HGT_MODE, 0);
 PARAM_DEFINE_FLOAT(EKF2_RNG_NOISE, 0.1f);
 
 /**
+ * Range finder range depednat noise scaler.
+ *
+ * Specifies the increase in range finder noise with range.
+ *
+ * @group EKF2
+ * @min 0.0
+ * @max 0.2
+ * @unit m/m
+ */
+PARAM_DEFINE_FLOAT(EKF2_RNG_SFE, 0.05f);
+
+/**
  * Gate size for range finder fusion
  *
  * @group EKF2

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -578,7 +578,7 @@ PARAM_DEFINE_INT32(EKF2_HGT_MODE, 0);
 PARAM_DEFINE_FLOAT(EKF2_RNG_NOISE, 0.1f);
 
 /**
- * Range finder range depednat noise scaler.
+ * Range finder range dependant noise scaler.
  *
  * Specifies the increase in range finder noise with range.
  *

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1007,3 +1007,27 @@ PARAM_DEFINE_FLOAT(EKF2_MAGB_K, 0.2f);
  * @value 1 Range aid enabled
  */
 PARAM_DEFINE_INT32(EKF2_RNG_AID, 0.0f);
+
+/**
+ * Maximum horizontal velocity allowed for range aid mode.
+ *
+ * If the vehicle horizontal speed exceeds this value then the estimator will not fuse range measurements
+ * to estimate it's height. This only applies when range aid mode is activated (EKF2_RNG_AID = enabled).
+ *
+ * @group EKF2
+ * @min 0.1
+ * @max 2
+ */
+PARAM_DEFINE_FLOAT(EKF2_RNG_A_VMAX, 1.0f);
+
+/**
+ * Maximum absolute altitude (height above ground level) allowed for range aid mode.
+ *
+ * If the vehicle absolute altitude exceeds this value then the estimator will not fuse range measurements
+ * to estimate it's height. This only applies when range aid mode is activated (EKF2_RNG_AID = enabled).
+ *
+ * @group EKF2
+ * @min 1.0
+ * @max 10.0
+ */
+PARAM_DEFINE_FLOAT(EKF2_RNG_A_HMAX, 5.0f);

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1006,7 +1006,7 @@ PARAM_DEFINE_FLOAT(EKF2_MAGB_K, 0.2f);
  * @value 0 Range aid disabled
  * @value 1 Range aid enabled
  */
-PARAM_DEFINE_INT32(EKF2_RNG_AID, 0.0f);
+PARAM_DEFINE_INT32(EKF2_RNG_AID, 0);
 
 /**
  * Maximum horizontal velocity allowed for range aid mode.

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -994,3 +994,16 @@ PARAM_DEFINE_FLOAT(EKF2_MAGB_VREF, 2.5E-7f);
  * @decimal 2
  */
 PARAM_DEFINE_FLOAT(EKF2_MAGB_K, 0.2f);
+
+/**
+ * Range sensor aid.
+ *
+ * If this parameter is enabled then the estimator will make use of the range finder measurements
+ * to estimate it's height even if range sensor is not the primary height source. It will only do so if conditions
+ * for range measurement fusion are met.
+ *
+ * @group EKF2
+ * @value 0 Range aid disabled
+ * @value 1 Range aid enabled
+ */
+PARAM_DEFINE_INT32(EKF2_RNG_AID, 0.0f);


### PR DESCRIPTION
This PR brings in the "range aid feature" for the estimator.

To test is set the parameter "EKF2_RNG_AID" to enabled and make sure to test with a vehicle that has a range finder connected.