### PR TITLE
Fix Windows build

### DIFF
--- a/cmake/nuttx/px4_impl_nuttx.cmake
+++ b/cmake/nuttx/px4_impl_nuttx.cmake
@@ -300,7 +300,7 @@ function(px4_nuttx_add_export)
 	add_custom_command(OUTPUT ${nuttx_src}/nuttx/.config
 		COMMAND ${CP} -rp ${PX4_SOURCE_DIR}/nuttx-configs/*.mk ${nuttx_src}/nuttx/
 		COMMAND ${CP} -rp ${PX4_SOURCE_DIR}/nuttx-configs/${CONFIG} ${nuttx_src}/nuttx/configs
-		COMMAND cd ${nuttx_src}/nuttx/tools && ./configure.sh ${CONFIG}/${config_nuttx_config}
+		COMMAND cd ${nuttx_src}/nuttx/tools && sh configure.sh ${CONFIG}/${config_nuttx_config}
 		DEPENDS ${DEPENDS} nuttx_patch_${CONFIG} ${config_files}
 		WORKING_DIRECTORY ${PX4_BINARY_DIR}
 		COMMENT "Configuring NuttX for ${CONFIG} with ${config_nuttx_config}")


### PR DESCRIPTION
As I'm currently trying to get the MSYS/MinGW environment windows toolchain for PX4 back to life I got stuck with having to change this line in the cmake configuration. I hope this will not break any other build but CI will show.

I'm now able to build and upload master px4fmu-v4_default for the pixracer with my toolchain.
The build process takes pretty long **only** because of the NuttX build. The NuttX build takes over 5 minutes and the rest is quite a bit faster than on my ubuntu VM.

cmake: NuttX make shell scirpt call explicit
to enable ninja on windows to find the correct command to execute