### PR TITLE
Logger: add logrotate & reduce CPU load

### DIFF
--- a/src/firmware/posix/sitl_target.cmake
+++ b/src/firmware/posix/sitl_target.cmake
@@ -43,6 +43,12 @@ px4_add_sitl_app(APP_NAME px4
 set(SITL_WORKING_DIR ${PX4_BINARY_DIR}/tmp)
 file(MAKE_DIRECTORY ${SITL_WORKING_DIR})
 
+# add a symlink to the logs dir to make it easier to find them
+add_custom_target(logs_symlink ALL
+                  COMMAND ${CMAKE_COMMAND} -E create_symlink tmp/rootfs/fs/microsd/log logs
+				  WORKING_DIRECTORY ${PX4_BINARY_DIR}
+				  )
+
 add_custom_target(run_config
 		COMMAND Tools/sitl_run.sh
 			$<TARGET_FILE:px4>

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -289,6 +289,7 @@ private:
 	uint32_t					_log_interval;
 	const orb_metadata				*_polling_topic_meta = nullptr; ///< if non-null, poll on this topic instead of sleeping
 	param_t						_log_utc_offset;
+	param_t						_log_dirs_max;
 	orb_advert_t					_mavlink_log_pub = nullptr;
 	uint16_t					_next_topic_id = 0; ///< id of next subscribed ulog topic
 	char						*_replay_file_name = nullptr;

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -215,7 +215,7 @@ private:
 
 	void write_changed_parameters();
 
-	bool copy_if_updated_multi(LoggerSubscription &sub, int multi_instance, void *buffer, bool try_to_subscribe);
+	inline bool copy_if_updated_multi(LoggerSubscription &sub, int multi_instance, void *buffer, bool try_to_subscribe);
 
 	/**
 	 * Write exactly one ulog message to the logger and handle dropouts.

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -141,6 +141,11 @@ private:
 	 */
 	int create_log_dir(tm *tt);
 
+	/** recursively remove a directory
+	 * @return 0 on success, <0 otherwise
+	 */
+	int remove_directory(const char *dir);
+
 	static bool file_exist(const char *filename);
 
 	/**
@@ -149,7 +154,9 @@ private:
 	int get_log_file_name(char *file_name, size_t file_name_size);
 
 	/**
-	 * Check if there is enough free space left on the SD Card
+	 * Check if there is enough free space left on the SD Card.
+	 * It will remove old log files if there is not enough space,
+	 * and if that fails return 1
 	 * @return 0 on success, 1 if not enough space, <0 on error
 	 */
 	int check_free_space();
@@ -249,7 +256,6 @@ private:
 
 
 	static constexpr size_t 	MAX_TOPICS_NUM = 64; /**< Maximum number of logged topics */
-	static constexpr unsigned	MAX_NO_LOGFOLDER = 999;	/**< Maximum number of log dirs */
 	static constexpr unsigned	MAX_NO_LOGFILE = 999;	/**< Maximum number of log files */
 #if defined(__PX4_POSIX_EAGLE) || defined(__PX4_POSIX_EXCELSIOR)
 	static constexpr const char	*LOG_ROOT = PX4_ROOTFSDIR"/log";
@@ -260,6 +266,7 @@ private:
 	uint8_t						*_msg_buffer = nullptr;
 	int						_msg_buffer_len = 0;
 	char 						_log_dir[LOG_DIR_LEN];
+	int						_sess_dir_index = 1; ///< search starting index for 'sess<i>' directory name
 	char 						_log_file_name[32];
 	bool						_task_should_exit = true;
 	bool						_has_log_dir = false;

--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -70,6 +70,25 @@ PARAM_DEFINE_INT32(SDLOG_UTC_OFFSET, 0);
 PARAM_DEFINE_INT32(SDLOG_MODE, 0);
 
 /**
+ * Maximum number of log directories to keep
+ *
+ * If there are more log directories than this value,
+ * the system will delete the oldest directories during startup.
+ *
+ * In addition, the system will delete old logs if there is not enough free space left.
+ * The minimum amount is 300 MB.
+ *
+ * If this is set to 0, old directories will only be removed if the free space falls below
+ * the minimum.
+ *
+ * @min 0
+ * @max 1000
+ * @reboot_required true
+ * @group SD Logging
+ */
+PARAM_DEFINE_INT32(SDLOG_DIRS_MAX, 0);
+
+/**
  * Log UUID
  *
  * If set to 1, add an ID to the log, which uniquely identifies the vehicle


### PR DESCRIPTION
- Imlement a simple logrotate. If free space on the SD card falls below a threshold, old log directories are deleted. The threshold is conservative: 300MB or 10% of the disk capacity if that's less, to make it usable on all architectures (SITL, embedded Linux, Pixhawk & co).
- Reduces the CPU load of the logger by ~1.5% to 5.3%.
- Add a `logs` symlink to the SITL build root directory for more convenient access to the logs.