### PR TITLE
vmount: refactor to auto-select between all inputs

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -1111,6 +1111,13 @@ then
 	fi
 	unset TEMP_CALIB_ARGS
 
+	# vmount to control mounts such as gimbals, disabled by default.
+	if param compare MNT_MODE_IN -1
+	then
+	else
+		vmount start
+	fi
+
 # End of autostart
 fi
 

--- a/src/drivers/vmount/input.cpp
+++ b/src/drivers/vmount/input.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *
-*   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+*   Copyright (c) 2016-2017 PX4 Development Team. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
@@ -43,7 +43,7 @@
 namespace vmount
 {
 
-int InputBase::update(unsigned int timeout_ms, ControlData **control_data)
+int InputBase::update(unsigned int timeout_ms, ControlData **control_data, bool already_active)
 {
 	if (!_initialized) {
 		int ret = initialize();
@@ -60,7 +60,7 @@ int InputBase::update(unsigned int timeout_ms, ControlData **control_data)
 		return 0;
 	}
 
-	return update_impl(timeout_ms, control_data);
+	return update_impl(timeout_ms, control_data, already_active);
 }
 
 void InputBase::control_data_set_lon_lat(double lon, double lat, float altitude, float roll_angle,

--- a/src/drivers/vmount/input.h
+++ b/src/drivers/vmount/input.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *
-*   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+*   Copyright (c) 2016-2017 PX4 Development Team. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
@@ -63,15 +63,17 @@ public:
 	 *                     subsequent calls to update() that return no new data
 	 *                     (in other words: if (some) control_data values change,
 	 *                     non-null will be returned).
+	 * @param already_active true if the mode was already active last time, false if it was not and "major"
+	 *                       change is necessary such as big stick movement for RC.
 	 * @return 0 on success, <0 otherwise
 	 */
-	virtual int update(unsigned int timeout_ms, ControlData **control_data);
+	virtual int update(unsigned int timeout_ms, ControlData **control_data, bool already_active);
 
 	/** report status to stdout */
 	virtual void print_status() = 0;
 
 protected:
-	virtual int update_impl(unsigned int timeout_ms, ControlData **control_data) = 0;
+	virtual int update_impl(unsigned int timeout_ms, ControlData **control_data, bool already_active) = 0;
 
 	virtual int initialize() { return 0; }
 

--- a/src/drivers/vmount/input_mavlink.cpp
+++ b/src/drivers/vmount/input_mavlink.cpp
@@ -121,6 +121,9 @@ int InputMavlinkROI::update_impl(unsigned int timeout_ms, ControlData **control_
 
 			if (vehicle_roi.mode == vehicle_roi_s::VEHICLE_ROI_NONE) {
 
+				_control_data.type = ControlData::Type::Neutral;
+				*control_data = &_control_data;
+
 			} else if (vehicle_roi.mode == vehicle_roi_s::VEHICLE_ROI_WPNEXT) {
 				_read_control_data_from_position_setpoint_sub();
 				_control_data.type_data.lonlat.roll_angle = 0.f;

--- a/src/drivers/vmount/input_mavlink.h
+++ b/src/drivers/vmount/input_mavlink.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *
-*   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+*   Copyright (c) 2016-2017 PX4 Development Team. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
@@ -54,18 +54,13 @@ namespace vmount
 class InputMavlinkROI : public InputBase
 {
 public:
-
-	/**
-	 * @param manual_control if non-null allow manual input as long as we have not received any mavlink
-	 * command yet or ROI mode is set to NONE.
-	 */
-	InputMavlinkROI(InputRC *manual_control = nullptr);
+	InputMavlinkROI();
 	virtual ~InputMavlinkROI();
 
 	virtual void print_status();
 
 protected:
-	virtual int update_impl(unsigned int timeout_ms, ControlData **control_data);
+	virtual int update_impl(unsigned int timeout_ms, ControlData **control_data, bool already_active);
 	virtual int initialize();
 
 private:
@@ -73,8 +68,6 @@ private:
 
 	int _vehicle_roi_sub = -1;
 	int _position_setpoint_triplet_sub = -1;
-	bool _allow_manual_control = true;
-	InputRC *_manual_control;
 	uint8_t _cur_roi_mode = vehicle_roi_s::VEHICLE_ROI_NONE;
 };
 
@@ -86,26 +79,19 @@ private:
 class InputMavlinkCmdMount : public InputBase
 {
 public:
-
-	/**
-	 * @param manual_control if non-null allow manual input as long as we have not received any mavlink
-	 * command yet.
-	 */
-	InputMavlinkCmdMount(InputRC *manual_control = nullptr);
+	InputMavlinkCmdMount();
 	virtual ~InputMavlinkCmdMount();
 
 	virtual void print_status();
 
 protected:
-	virtual int update_impl(unsigned int timeout_ms, ControlData **control_data);
+	virtual int update_impl(unsigned int timeout_ms, ControlData **control_data, bool already_active);
 	virtual int initialize();
 
 private:
 	void _ack_vehicle_command(uint16_t command);
 
 	int _vehicle_command_sub = -1;
-	bool _allow_manual_control = true;
-	InputRC *_manual_control;
 	orb_advert_t _vehicle_command_ack_pub = nullptr;
 	bool _stabilize[3] = { false, false, false };
 };

--- a/src/drivers/vmount/input_rc.cpp
+++ b/src/drivers/vmount/input_rc.cpp
@@ -120,7 +120,7 @@ bool InputRC::_read_control_data_from_subscription(ControlData &control_data, bo
 
 	// Detect a big stick movement
 	for (int i = 0; i < 3; ++i) {
-		if (fabs(_last_set_aux_values[i] - new_aux_values[i]) > 0.25f) {
+		if (fabsf(_last_set_aux_values[i] - new_aux_values[i]) > 0.25f) {
 			major_movement = true;
 		}
 	}

--- a/src/drivers/vmount/input_rc.cpp
+++ b/src/drivers/vmount/input_rc.cpp
@@ -120,7 +120,7 @@ bool InputRC::_read_control_data_from_subscription(ControlData &control_data, bo
 
 	// Detect a big stick movement
 	for (int i = 0; i < 3; ++i) {
-		if (fabs(_last_set_aux_values[i] - new_aux_values[i]) > 0.25) {
+		if (fabs(_last_set_aux_values[i] - new_aux_values[i]) > 0.25f) {
 			major_movement = true;
 		}
 	}

--- a/src/drivers/vmount/input_rc.cpp
+++ b/src/drivers/vmount/input_rc.cpp
@@ -127,6 +127,8 @@ bool InputRC::_read_control_data_from_subscription(ControlData &control_data, bo
 
 	if (already_active || major_movement || _first_time) {
 
+		_first_time = false;
+
 		for (int i = 0; i < 3; ++i) {
 			control_data.type_data.angle.is_speed[i] = false;
 			control_data.type_data.angle.angles[i] = new_aux_values[i] * M_PI_F;

--- a/src/drivers/vmount/input_rc.h
+++ b/src/drivers/vmount/input_rc.h
@@ -82,8 +82,8 @@ private:
 
 	int _aux_channels[3];
 	int _manual_control_setpoint_sub = -1;
-	bool _first_time = true;
 
+	bool _first_time = true;
 	float _last_set_aux_values[3] = {};
 };
 

--- a/src/drivers/vmount/input_rc.h
+++ b/src/drivers/vmount/input_rc.h
@@ -77,9 +77,9 @@ protected:
 
 	int _get_subscription_fd() const { return _manual_control_setpoint_sub; }
 
-private:
 	float _get_aux_value(const manual_control_setpoint_s &manual_control_setpoint, int channel_idx);
 
+private:
 	int _aux_channels[3];
 	int _manual_control_setpoint_sub = -1;
 

--- a/src/drivers/vmount/input_rc.h
+++ b/src/drivers/vmount/input_rc.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *
-*   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+*   Copyright (c) 2016-2017 PX4 Development Team. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
@@ -67,10 +67,13 @@ public:
 	virtual void print_status();
 
 protected:
-	virtual int update_impl(unsigned int timeout_ms, ControlData **control_data);
+	virtual int update_impl(unsigned int timeout_ms, ControlData **control_data, bool already_active);
 	virtual int initialize();
 
-	virtual void _read_control_data_from_subscription(ControlData &control_data);
+	/**
+	 * @return true if there was a change in control data
+	 */
+	virtual bool _read_control_data_from_subscription(ControlData &control_data, bool already_active);
 
 	int _get_subscription_fd() const { return _manual_control_setpoint_sub; }
 
@@ -79,9 +82,9 @@ private:
 
 	int _aux_channels[3];
 	int _manual_control_setpoint_sub = -1;
+	bool _first_time = true;
 
-	friend class InputMavlinkROI;
-	friend class InputMavlinkCmdMount;
+	float _last_set_aux_values[3] = {};
 };
 
 

--- a/src/drivers/vmount/input_test.cpp
+++ b/src/drivers/vmount/input_test.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *
-*   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+*   Copyright (c) 2016-2017 PX4 Development Team. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
@@ -57,7 +57,7 @@ bool InputTest::finished()
 	return true; /* only a single-shot test (for now) */
 }
 
-int InputTest::update(unsigned int timeout_ms, ControlData **control_data)
+int InputTest::update(unsigned int timeout_ms, ControlData **control_data, bool already_active)
 {
 	//we directly override the update() here, since we don't need the initialization from the base class
 

--- a/src/drivers/vmount/input_test.h
+++ b/src/drivers/vmount/input_test.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *
-*   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+*   Copyright (c) 2016-2017 PX4 Development Team. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
@@ -61,10 +61,10 @@ public:
 	/** check whether the test finished, and thus the main thread can quit */
 	bool finished();
 
-	virtual int update(unsigned int timeout_ms, ControlData **control_data);
+	virtual int update(unsigned int timeout_ms, ControlData **control_data, bool already_active);
 
 protected:
-	virtual int update_impl(unsigned int timeout_ms, ControlData **control_data) { return 0; } //not needed
+	virtual int update_impl(unsigned int timeout_ms, ControlData **control_data, bool already_active) { return 0; } //not needed
 
 	virtual int initialize();
 

--- a/src/drivers/vmount/output.cpp
+++ b/src/drivers/vmount/output.cpp
@@ -92,6 +92,11 @@ void OutputBase::publish()
 		mount_orientation.attitude_euler_angle[i] = _angle_outputs[i];
 	}
 
+	//PX4_INFO("roll: %.2f, pitch: %.2f, yaw: %.2f",
+	//		(double)_angle_outputs[0],
+	//		(double)_angle_outputs[1],
+	//		(double)_angle_outputs[2]);
+
 	orb_publish_auto(ORB_ID(mount_orientation), &_mount_orientation_pub, &mount_orientation, &instance, ORB_PRIO_DEFAULT);
 }
 

--- a/src/drivers/vmount/vmount.cpp
+++ b/src/drivers/vmount/vmount.cpp
@@ -220,60 +220,38 @@ static int vmount_thread_main(int argc, char *argv[])
 				case 0:
 
 					// Automatic
-					if (!thread_data.input_objs[0]) {
-						thread_data.input_objs[0] = new InputMavlinkCmdMount();
-
-						if (!thread_data.input_objs[0]) { alloc_failed = true; }
-					}
-
-					if (!thread_data.input_objs[1]) {
-						thread_data.input_objs[1] = new InputMavlinkROI();
-
-						if (!thread_data.input_objs[1]) { alloc_failed = true; }
-					}
+					thread_data.input_objs[0] = new InputMavlinkCmdMount();
+					thread_data.input_objs[1] = new InputMavlinkROI();
 
 					// RC is on purpose last here so that if there are any mavlink
 					// messages, they will take precedence over RC.
 					// This logic is done further below while update() is called.
-					if (!thread_data.input_objs[2]) {
-						thread_data.input_objs[2] = new InputRC(params.mnt_man_roll, params.mnt_man_pitch, params.mnt_man_yaw);
-
-						if (!thread_data.input_objs[2]) { alloc_failed = true; }
-					}
+					thread_data.input_objs[2] = new InputRC(params.mnt_man_roll, params.mnt_man_pitch, params.mnt_man_yaw);
 					thread_data.input_objs_len = 3;
 
 					break;
 
 				case 1: //RC
-					if (!thread_data.input_objs[0]) {
-						thread_data.input_objs[0] = new InputRC(params.mnt_man_roll, params.mnt_man_pitch, params.mnt_man_yaw);
-
-						if (!thread_data.input_objs[0]) { alloc_failed = true; }
-					}
-
+					thread_data.input_objs[0] = new InputRC(params.mnt_man_roll, params.mnt_man_pitch, params.mnt_man_yaw);
 					break;
 
 				case 2: //MAVLINK_ROI
-					if (!thread_data.input_objs[0]) {
-						thread_data.input_objs[0] = new InputMavlinkROI();
-
-						if (!thread_data.input_objs[0]) { alloc_failed = true; }
-					}
-
+					thread_data.input_objs[0] = new InputMavlinkROI();
 					break;
 
 				case 3: //MAVLINK_DO_MOUNT
-					if (!thread_data.input_objs[0]) {
-						thread_data.input_objs[0] = new InputMavlinkCmdMount();
-
-						if (!thread_data.input_objs[0]) { alloc_failed = true; }
-					}
-
+					thread_data.input_objs[0] = new InputMavlinkCmdMount();
 					break;
 
 				default:
 					PX4_ERR("invalid input mode %i", params.mnt_mode_in);
 					break;
+				}
+			}
+
+			for (int i = 0; i < thread_data.input_objs_len; ++i) {
+				if (!thread_data.input_objs[i]) {
+					alloc_failed = true;
 				}
 			}
 

--- a/src/drivers/vmount/vmount.cpp
+++ b/src/drivers/vmount/vmount.cpp
@@ -198,7 +198,7 @@ static int vmount_thread_main(int argc, char *argv[])
 	ControlData *control_data = nullptr;
 	g_thread_data = &thread_data;
 
-	int last_active = -1;
+	int last_active = 0;
 
 	while (!thread_should_exit) {
 
@@ -301,7 +301,8 @@ static int vmount_thread_main(int argc, char *argv[])
 				bool already_active = (last_active == i);
 
 				ControlData *control_data_to_check = nullptr;
-				int ret = thread_data.input_objs[i]->update(50, &control_data_to_check, already_active);
+				unsigned int poll_timeout = already_active ? 50 : 0; // poll only on active input to reduce latency
+				int ret = thread_data.input_objs[i]->update(poll_timeout, &control_data_to_check, already_active);
 
 				if (ret) {
 					PX4_ERR("failed to read input %i (ret: %i)", i, ret);
@@ -351,9 +352,10 @@ static int vmount_thread_main(int argc, char *argv[])
 						thread_data.input_objs[i] = nullptr;
 					}
 				}
+
 				thread_data.input_objs_len = 0;
 
-				last_active = -1;
+				last_active = 0;
 
 				if (thread_data.output_obj) {
 					delete (thread_data.output_obj);

--- a/src/drivers/vmount/vmount.cpp
+++ b/src/drivers/vmount/vmount.cpp
@@ -319,7 +319,7 @@ static int vmount_thread_main(int argc, char *argv[])
 				bool already_active = (last_active == i);
 
 				ControlData *control_data_to_check = nullptr;
-				int ret = thread_data.input_objs[i]->update(50, &control_data, already_active);
+				int ret = thread_data.input_objs[i]->update(50, &control_data_to_check, already_active);
 
 				if (ret) {
 					PX4_ERR("failed to read input %i (ret: %i)", i, ret);

--- a/src/drivers/vmount/vmount.cpp
+++ b/src/drivers/vmount/vmount.cpp
@@ -202,7 +202,7 @@ static int vmount_thread_main(int argc, char *argv[])
 
 	while (!thread_should_exit) {
 
-		if (!thread_data.input_objs[0] || test_input) { //need to initialize
+		if (!thread_data.input_objs[0] && (params.mnt_mode_in >= 0 || test_input)) { //need to initialize
 
 			output_config.gimbal_normal_mode_value = params.mnt_ob_norm_mode;
 			output_config.gimbal_retracted_mode_value = params.mnt_ob_lock_mode;

--- a/src/drivers/vmount/vmount.cpp
+++ b/src/drivers/vmount/vmount.cpp
@@ -201,7 +201,7 @@ static int vmount_thread_main(int argc, char *argv[])
 
 	while (!thread_should_exit) {
 
-		if (!thread_data.input_objs[0] && (params.mnt_mode_in != 0 || test_input)) { //need to initialize
+		if (!thread_data.input_objs[0] || test_input) { //need to initialize
 
 			output_config.gimbal_normal_mode_value = params.mnt_ob_norm_mode;
 			output_config.gimbal_retracted_mode_value = params.mnt_ob_lock_mode;

--- a/src/drivers/vmount/vmount.cpp
+++ b/src/drivers/vmount/vmount.cpp
@@ -234,7 +234,7 @@ static int vmount_thread_main(int argc, char *argv[])
 					// messages, they will take precedence over RC.
 					// This logic is done further below while update() is called.
 					if (!thread_data.input_objs[2]) {
-						thread_data.input_objs[0] = new InputRC(params.mnt_man_roll, params.mnt_man_pitch, params.mnt_man_yaw);
+						thread_data.input_objs[2] = new InputRC(params.mnt_man_roll, params.mnt_man_pitch, params.mnt_man_yaw);
 
 						if (!thread_data.input_objs[2]) { alloc_failed = true; }
 					}

--- a/src/drivers/vmount/vmount_params.c
+++ b/src/drivers/vmount/vmount_params.c
@@ -42,15 +42,17 @@
 * RC uses the AUX input channels (see MNT_MAN_* parameters),
 * MAVLINK_ROI uses the MAV_CMD_DO_SET_ROI Mavlink message, and MAVLINK_DO_MOUNT the
 * MAV_CMD_DO_MOUNT_CONFIGURE and MAV_CMD_DO_MOUNT_CONTROL messages to control a mount.
+* @value -1 DISABLED
 * @value 0 AUTO
 * @value 1 RC
 * @value 2 MAVLINK_ROI
 * @value 3 MAVLINK_DO_MOUNT
-* @min 0
+* @min -1
 * @max 3
 * @group Mount
+* @reboot_required true
 */
-PARAM_DEFINE_INT32(MNT_MODE_IN, 0);
+PARAM_DEFINE_INT32(MNT_MODE_IN, -1);
 
 /**
 * Mount output mode

--- a/src/drivers/vmount/vmount_params.c
+++ b/src/drivers/vmount/vmount_params.c
@@ -1,6 +1,6 @@
 /****************************************************************************
 *
-*   Copyright (c) 2013-2016 PX4 Development Team. All rights reserved.
+*   Copyright (c) 2013-2017 PX4 Development Team. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
@@ -42,7 +42,7 @@
 * RC uses the AUX input channels (see MNT_MAN_* parameters),
 * MAVLINK_ROI uses the MAV_CMD_DO_SET_ROI Mavlink message, and MAVLINK_DO_MOUNT the
 * MAV_CMD_DO_MOUNT_CONFIGURE and MAV_CMD_DO_MOUNT_CONTROL messages to control a mount.
-* @value 0 DISABLE
+* @value 0 AUTO
 * @value 1 RC
 * @value 2 MAVLINK_ROI
 * @value 3 MAVLINK_DO_MOUNT
@@ -98,18 +98,6 @@ PARAM_DEFINE_FLOAT(MNT_OB_NORM_MODE, -1.0f);
 * @group Mount
 */
 PARAM_DEFINE_FLOAT(MNT_OB_LOCK_MODE, 0.0f);
-
-
-/**
-* This enables the mount to be manually controlled when no ROI is set.
-*
-* If set to 1, the mount will be controlled by the AUX channels below
-* when no ROI is set.
-*
-* @boolean
-* @group Mount
-*/
-PARAM_DEFINE_INT32(MNT_MAN_CONTROL, 0);
 
 /**
 * Auxiliary channel to control roll (in AUX input or manual mode).


### PR DESCRIPTION
It is not convenient having to change a parameter to change a gimbal
from RC input to mavlink input mode or back. This refactor changes the
behaviour to use whatever is available, RC or mavlink commands.

Once a mavlink command is followed, control can be taken back using RC,
however, this requires a clear stick change.

Needs reviewing and testing.

As discussed with @bkueng.