### PR TITLE
DF_MS5611_Wrapper: convert baro pressure to mbar

### DIFF
--- a/src/platforms/posix/drivers/df_ms5611_wrapper/df_ms5611_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_ms5611_wrapper/df_ms5611_wrapper.cpp
@@ -151,7 +151,7 @@ int DfMS5611Wrapper::_publish(struct baro_sensor_data &data)
 	baro_report baro_report = {};
 	baro_report.timestamp = hrt_absolute_time();
 
-	baro_report.pressure = data.pressure_pa;
+	baro_report.pressure = data.pressure_pa / 100.0f; // convert to mbar
 	baro_report.temperature = data.temperature_c;
 
 	// TODO: verify this, it's just copied from the MS5611 driver.


### PR DESCRIPTION
df_ms5611_wrapper previously reported baro pressure in Pa, as reported from the DriverFramework driver. This didn't cause any issues until the recent addition of temperature compensation in sensors.cpp and the addition of a second calculation of Baro Altitude, which assumes baro pressure is stored as mbar.