### PR TITLE
inav: check for updated baro in baro_offset calculation

### DIFF
--- a/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
@@ -424,7 +424,9 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 			if (fds_init[0].revents & POLLIN) {
 				orb_copy(ORB_ID(sensor_combined), sensor_combined_sub, &sensor);
 
-				if (wait_baro && sensor.timestamp + sensor.baro_timestamp_relative != baro_timestamp) {
+				bool baro_updated = (sensor.baro_timestamp_relative != sensor.RELATIVE_TIMESTAMP_INVALID);
+
+				if (wait_baro && sensor.timestamp + sensor.baro_timestamp_relative != baro_timestamp && baro_updated) {
 					baro_timestamp = sensor.timestamp + sensor.baro_timestamp_relative;
 					baro_wait_for_sample_time = hrt_absolute_time();
 


### PR DESCRIPTION
Adds a check that sensor_combined.baro_alt_meter has valid data before initializing the baro_offset variable. Without the check, the baro_offset summation can include several zeros resulting in an errant baro_offset. This results in a large offset in local_pos.z estimate which interferes with the limit_altitude() function in mc_pos_control.

The check is placed such that the wait_baro loop is still capable of the time out if it never gets valid baro data.