### PR TITLE
Add parameter to enable rc stick override

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1308,6 +1308,7 @@ int commander_thread_main(int argc, char *argv[])
 	param_t _param_offboard_loss_timeout = param_find("COM_OF_LOSS_T");
 	param_t _param_arm_without_gps = param_find("COM_ARM_WO_GPS");
 	param_t _param_arm_switch_is_button = param_find("COM_ARM_SWISBTN");
+	param_t _param_rc_override = param_find("COM_RC_OVERRIDE");
 
 	param_t _param_fmode_1 = param_find("COM_FLTMODE1");
 	param_t _param_fmode_2 = param_find("COM_FLTMODE2");
@@ -1692,6 +1693,10 @@ int commander_thread_main(int argc, char *argv[])
 
 	int32_t geofence_action = 0;
 
+	/* RC override auto modes */
+	int32_t rc_override = 0;
+
+
 	/* Thresholds for engine failure detection */
 	int32_t ef_throttle_thres = 1.0f;
 	int32_t ef_current2throttle_thres = 0.0f;
@@ -1775,6 +1780,7 @@ int commander_thread_main(int argc, char *argv[])
 			status.rc_input_mode = rc_in_off;
 			param_get(_param_rc_arm_hyst, &rc_arm_hyst);
 			param_get(_param_min_stick_change, &min_stick_change);
+			param_get(_param_rc_override, &rc_override);
 			// percentage (* 0.01) needs to be doubled because RC total interval is 2, not 1
 			min_stick_change *= 0.02f;
 			rc_arm_hyst *= COMMANDER_MONITORING_LOOPSPERMSEC;
@@ -2511,7 +2517,7 @@ int commander_thread_main(int argc, char *argv[])
 
 		// revert geofence failsafe transition if sticks are moved and we were previously in a manual mode
 		// but only if not in a low battery handling action
-		if (!critical_battery_voltage_actions_done && (warning_action_on &&
+		if (rc_override != 0 && !critical_battery_voltage_actions_done && (warning_action_on &&
 		   (main_state_before_rtl == commander_state_s::MAIN_STATE_MANUAL ||
 			main_state_before_rtl == commander_state_s::MAIN_STATE_ALTCTL ||
 			main_state_before_rtl == commander_state_s::MAIN_STATE_POSCTL ||
@@ -2534,7 +2540,7 @@ int commander_thread_main(int argc, char *argv[])
 
 		// abort landing or auto or loiter if sticks are moved significantly
 		// but only if not in a low battery handling action
-		if (!critical_battery_voltage_actions_done &&
+		if (rc_override != 0 && !critical_battery_voltage_actions_done &&
 			(internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LAND ||
 			internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_MISSION ||
 			internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LOITER)) {

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -586,3 +586,11 @@ PARAM_DEFINE_FLOAT(COM_ARM_IMU_ACC, 0.7f);
  * @increment 0.01
  */
 PARAM_DEFINE_FLOAT(COM_ARM_IMU_GYR, 0.15f);
+
+/**
+ * Enable RC stick override of auto modes
+ *
+ * @boolean
+ * @group Commander
+ */
+PARAM_DEFINE_INT32(COM_RC_OVERRIDE, 0);


### PR DESCRIPTION
As discussed in dev call, defaults to 0
SITL tested with virtual joystick, works as expected