### PR TITLE
Do not merge - baro FRAM v4 buss lock  - for testing only

### DIFF
--- a/src/drivers/ms5611/ms5611_spi.cpp
+++ b/src/drivers/ms5611/ms5611_spi.cpp
@@ -145,6 +145,11 @@ MS5611_SPI::init()
 {
 	int ret;
 
+#if defined(PX4_SPI_BUS_RAMTRON) && \
+	(PX4_SPI_BUS_BARO == PX4_SPI_BUS_RAMTRON)
+	SPI::set_lockmode(LOCK_THREADS);
+#endif
+
 	ret = SPI::init();
 
 	if (ret != OK) {


### PR DESCRIPTION
@LorenzMeier @bkueng 

The ramtron driver already calls SPI_LOCK when accessing the FRAM.
Removed the interrupt lockout and enabled the SPI_LOCK in the ms5611 driver on any HW where the  PX4_SPI_BUS_BARO == PX4_SPI_BUS_RAMTRON

This is the moral equivalent to what was mentioned in params.c: 

```
 XXX this would be the preferred locking method
	// if (dev == nullptr) {
	// 	dev = px4_spibus_initialize(PX4_SPI_BUS_BARO);
	// }
```

The issue I see with it is: It will block the HPWORK queue thread, while FRAM is busy.  Arguably this is less evil than the having the interrupts off for that same period.

I also think that the original bus locking might not have bracketed all the the FRAM access. So this may have better baro noise performance. A gentler approach would be to raise an event that just tells the 5611 to publish the last result and skip this publication until the event is lowered. In that case we would need to check that all the FRAM access is bracketed.

The 2 tests that need to be done are: 1) looking at the noise on the barro and 2) the [bug reported](https://github.com/PX4/Firmware/issues/6902) 

