### PR TITLE
Fix lat/lon conversions of HIL_STATE_QUATERNION in simulator_mavlink.cpp

### DIFF
--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -404,9 +404,9 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 			hil_gpos.timestamp = timestamp;
 
 			hil_gpos.time_utc_usec = timestamp;
-			hil_gpos.lat = hil_state.lat;
-			hil_gpos.lon = hil_state.lon;
-			hil_gpos.alt = hil_state.alt / 1000.0f;
+			hil_gpos.lat = hil_state.lat / 10000000.0f;//1E7
+			hil_gpos.lon = hil_state.lon / 10000000.0f;//1E7
+			hil_gpos.alt = hil_state.alt / 1000.0f;//1E3
 
 			hil_gpos.vel_n = hil_state.vx / 100.0f;
 			hil_gpos.vel_e = hil_state.vy / 100.0f;

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -404,9 +404,9 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 			hil_gpos.timestamp = timestamp;
 
 			hil_gpos.time_utc_usec = timestamp;
-			hil_gpos.lat = hil_state.lat / 10000000.0f;//1E7
-			hil_gpos.lon = hil_state.lon / 10000000.0f;//1E7
-			hil_gpos.alt = hil_state.alt / 1000.0f;//1E3
+			hil_gpos.lat = hil_state.lat / 1E7;//1E7
+			hil_gpos.lon = hil_state.lon / 1E7;//1E7
+			hil_gpos.alt = hil_state.alt / 1E3;//1E3
 
 			hil_gpos.vel_n = hil_state.vx / 100.0f;
 			hil_gpos.vel_e = hil_state.vy / 100.0f;


### PR DESCRIPTION
This PR is to fix the conversion of latitude/longitude in 
https://github.com/PX4/Firmware/blob/ecb2511a7bbad094bff23dd95036eda0656778f0/src/modules/simulator/simulator_mavlink.cpp#L407-L409

According to the MAVLink msg definition of [HIL_STATE_QUATERNION](https://pixhawk.ethz.ch/mavlink/#HIL_STATE_QUATERNION), lat/lon should be ```deg*1E7```.

And, according to msg defifnion of [vehicle_global_position](https://github.com/PX4/Firmware/blob/912ed98a28022504ef3ec4bf1bce0fe041f83ac4/msg/vehicle_global_position.msg), on PX4 side, it should be in ```degrees```. 

So, they should be divided by ```1E7``` in,
https://github.com/PX4/Firmware/blob/ecb2511a7bbad094bff23dd95036eda0656778f0/src/modules/simulator/simulator_mavlink.cpp#L407-L408

Thanks.