### PR TITLE
tag_to_version.py: fix Python3 error

### DIFF
--- a/Tools/tag_to_version.py
+++ b/Tools/tag_to_version.py
@@ -12,6 +12,8 @@ p= subprocess.Popen(
     'git describe --always --tags'.split(),
     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 stdout, stderr = p.communicate()
+# Python3 needs this decode step.
+stdout = stdout.decode('ascii')
 res = stdout.split('-')[0].split('.')
 major = res[0].replace('v','')
 minor = res[1]


### PR DESCRIPTION
`subprocess.communicate` returns `bytes` instead of a `str` which is not the
same for Python3. Therefore, we need to decode the bytes.

The error was:
```
Traceback (most recent call last):
  File "Tools/tag_to_version.py", line 15, in <module>
    res = stdout.split('-')[0].split('.')
TypeError: a bytes-like object is required, not 'str'
```
Tested with Python 2 and 3.