### PR TITLE
Fix takeoff overshoot (issue 319)

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1230,7 +1230,8 @@ MulticopterPositionControl::control_non_manual(float dt)
 			} else {
 				// copter has reached our takeoff speed. split the thrust setpoint up
 				// into an integral part and into a P part
-				_thrust_int(2) = _takeoff_thrust_sp - _params.vel_p(2) * fabsf(_vel(2));
+				// remembering to remove _params.thr_hover which is added later as a feed-forward in control_position.
+				_thrust_int(2) = _takeoff_thrust_sp - _params.vel_p(2) * fabsf(_vel(2)) - _params.thr_hover;
 				_thrust_int(2) = -math::constrain(_thrust_int(2), _params.thr_min, _params.thr_max);
 				_vel_sp_prev(2) = -_params.tko_speed;
 				_takeoff_jumped = true;


### PR DESCRIPTION
Fix takeoff overshoot using idea by Martin Sollie.   He identified that the problem with takeoff overshoot comes from the hover throttle feedforward added in 5529023 that is not taken into account in the takeoff code.  I tested it on simulator and a real drone flight, the fix seems to work well.  Here's the log from the real drone, notice that before this fix the take of "way" overshoots to 25 meters.  Now it properly hits the target of 5 meters.

![image](https://cloud.githubusercontent.com/assets/18707114/25075576/87fc87b2-22cc-11e7-92b2-25cbef169503.png)
