### PR TITLE
navigator treat TAKEOFF like POSITION if already flying

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -535,10 +535,22 @@ MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *ite
 		break;
 
 	case NAV_CMD_TAKEOFF:
-		// set pitch and ensure that the hold time is zero
-		sp->pitch_min = item->pitch_min;
 
-	// fall through
+		// if already flying (armed and !landed) treat TAKEOFF like regular POSITION
+		if ((_navigator->get_vstatus()->arming_state == vehicle_status_s::ARMING_STATE_ARMED)
+		    && !_navigator->get_land_detected()->landed) {
+
+			sp->type = position_setpoint_s::SETPOINT_TYPE_POSITION;
+
+		} else {
+			sp->type = position_setpoint_s::SETPOINT_TYPE_TAKEOFF;
+
+			// set pitch and ensure that the hold time is zero
+			sp->pitch_min = item->pitch_min;
+		}
+
+		break;
+
 	case NAV_CMD_VTOL_TAKEOFF:
 		sp->type = position_setpoint_s::SETPOINT_TYPE_TAKEOFF;
 


### PR DESCRIPTION
This PR updates navigator to treat a takeoff position setpoint like a regular position setpoint if you're already flying (armed and !landed when the mission item becomes a position setpoint). 
FW takeoff has logic for launch detection and runway takeoff that can be dangerous if activated while already flying. The FW position controller has been updated to better reset the takeoff logic independently of this.
This also allows regular navigator altitude FOH to be used. 