### PR TITLE
Fix magnetometer calibration on Pixhawk 2 with external mags

### DIFF
--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -62,7 +62,7 @@
 #include <systemlib/err.h>
 
 static const char *sensor_name = "mag";
-static constexpr unsigned max_mags = 3;
+static constexpr unsigned max_mags = 4;
 static constexpr float mag_sphere_radius = 0.2f;
 static unsigned int calibration_sides = 6;			///< The total number of sides
 static constexpr unsigned int calibration_total_points = 240;		///< The total points per magnetometer
@@ -565,7 +565,12 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 		// We should not try to subscribe if the topic doesn't actually exist and can be counted.
 		const unsigned mag_count = orb_group_count(ORB_ID(sensor_mag));
 
-		for (unsigned cur_mag = 0; cur_mag < mag_count; cur_mag++) {
+		// Warn that we will not calibrate more than max_mags magnetometers
+		if (mag_count > max_mags) {
+			calibration_log_critical(mavlink_log_pub, "[cal] Detected %u mags, but will calibrate only %u", mag_count, max_mags);
+		}
+
+		for (unsigned cur_mag = 0; cur_mag < mag_count && cur_mag < max_mags; cur_mag++) {
 			// Mag in this slot is available
 			worker_data.sub_mag[cur_mag] = orb_subscribe_multi(ORB_ID(sensor_mag), cur_mag);
 


### PR DESCRIPTION
@dagar This fixes https://github.com/PX4/Firmware/issues/6898.

We now will calibrate upto 4 mags, and warn if more are connected. This should be a good enough fix for the v1.6 release.

I do not have an external GPS to test this with, but this should be the correct fix.