### PR TITLE
Pixhawk 2 mag fix

### DIFF
--- a/src/lib/mathlib/math/Limits.hpp
+++ b/src/lib/mathlib/math/Limits.hpp
@@ -56,19 +56,19 @@ namespace math
 {
 
 template<typename _Tp>
-inline const _Tp &min(const _Tp &a, const _Tp &b)
+inline constexpr const _Tp &min(const _Tp &a, const _Tp &b)
 {
 	return (a < b) ? a : b;
 }
 
 template<typename _Tp>
-inline const _Tp &max(const _Tp &a, const _Tp &b)
+inline constexpr const _Tp &max(const _Tp &a, const _Tp &b)
 {
 	return (a > b) ? a : b;
 }
 
 template<typename _Tp>
-inline const _Tp &constrain(const _Tp &val, const _Tp &min_val, const _Tp &max_val)
+inline constexpr const _Tp &constrain(const _Tp &val, const _Tp &min_val, const _Tp &max_val)
 {
 	return (val < min_val) ? min_val : ((val > max_val) ? max_val : val);
 }

--- a/src/modules/commander/PreflightCheck.h
+++ b/src/modules/commander/PreflightCheck.h
@@ -79,7 +79,7 @@ const unsigned max_mandatory_accel_count = 1;
 const unsigned max_optional_accel_count = 3;
 
 const unsigned max_mandatory_mag_count = 1;
-const unsigned max_optional_mag_count = 3;
+const unsigned max_optional_mag_count = 4;
 
 const unsigned max_mandatory_baro_count = 1;
 const unsigned max_optional_baro_count = 1;

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -62,7 +62,7 @@
 #include <systemlib/err.h>
 
 static const char *sensor_name = "mag";
-static constexpr unsigned max_mags = 3;
+static constexpr unsigned max_mags = 4;
 static constexpr float mag_sphere_radius = 0.2f;
 static unsigned int calibration_sides = 6;			///< The total number of sides
 static constexpr unsigned int calibration_total_points = 240;		///< The total points per magnetometer

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -565,7 +565,12 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 		// We should not try to subscribe if the topic doesn't actually exist and can be counted.
 		const unsigned mag_count = orb_group_count(ORB_ID(sensor_mag));
 
-		for (unsigned cur_mag = 0; cur_mag < mag_count; cur_mag++) {
+		// Warn that we will not calibrate more than max_mags magnetometers
+		if (mag_count > max_mags) {
+			calibration_log_critical(mavlink_log_pub, "[cal] Detected %u mags, but will calibrate only %u", mag_count, max_mags);
+		}
+
+		for (unsigned cur_mag = 0; cur_mag < mag_count && cur_mag < max_mags; cur_mag++) {
 			// Mag in this slot is available
 			worker_data.sub_mag[cur_mag] = orb_subscribe_multi(ORB_ID(sensor_mag), cur_mag);
 

--- a/src/modules/sensors/common.h
+++ b/src/modules/sensors/common.h
@@ -43,6 +43,14 @@
 namespace sensors
 {
 
-static const int SENSOR_COUNT_MAX = 3;
+constexpr uint8_t MAG_COUNT_MAX = 4;
+constexpr uint8_t GYRO_COUNT_MAX = 3;
+constexpr uint8_t ACCEL_COUNT_MAX = 3;
+constexpr uint8_t BARO_COUNT_MAX = 3;
+
+constexpr uint8_t SENSOR_COUNT_MAX = math::max(MAG_COUNT_MAX,
+				     math::max(GYRO_COUNT_MAX,
+						     math::max(ACCEL_COUNT_MAX,
+								     BARO_COUNT_MAX)));
 
 } /* namespace sensors */

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -667,6 +667,103 @@ PARAM_DEFINE_FLOAT(CAL_ACC2_YSCALE, 1.0f);
 PARAM_DEFINE_FLOAT(CAL_ACC2_ZSCALE, 1.0f);
 
 /**
+ * ID of Magnetometer the calibration is for.
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_MAG3_ID, 0);
+
+/**
+ * Rotation of magnetometer 2 relative to airframe.
+ *
+ * An internal magnetometer will force a value of -1, so a GCS
+ * should only attempt to configure the rotation if the value is
+ * greater than or equal to zero.
+ *
+ * @value -1 Internal mag
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ * @value 8 Roll 180°
+ * @value 9 Roll 180°, Yaw 45°
+ * @value 10 Roll 180°, Yaw 90°
+ * @value 11 Roll 180°, Yaw 135°
+ * @value 12 Pitch 180°
+ * @value 13 Roll 180°, Yaw 225°
+ * @value 14 Roll 180°, Yaw 270°
+ * @value 15 Roll 180°, Yaw 315°
+ * @value 16 Roll 90°
+ * @value 17 Roll 90°, Yaw 45°
+ * @value 18 Roll 90°, Yaw 90°
+ * @value 19 Roll 90°, Yaw 135°
+ * @value 20 Roll 270°
+ * @value 21 Roll 270°, Yaw 45°
+ * @value 22 Roll 270°, Yaw 90°
+ * @value 23 Roll 270°, Yaw 135°
+ * @value 24 Pitch 90°
+ * @value 25 Pitch 270°
+ *
+ * @min -1
+ * @max 30
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_MAG3_ROT, -1);
+
+/**
+ * Magnetometer X-axis offset
+ *
+ * @min -500.0
+ * @max 500.0
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG3_XOFF, 0.0f);
+
+/**
+ * Magnetometer Y-axis offset
+ *
+ * @min -500.0
+ * @max 500.0
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG3_YOFF, 0.0f);
+
+/**
+ * Magnetometer Z-axis offset
+ *
+ * @min -500.0
+ * @max 500.0
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG3_ZOFF, 0.0f);
+
+/**
+ * Magnetometer X-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG3_XSCALE, 1.0f);
+
+/**
+ * Magnetometer Y-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG3_YSCALE, 1.0f);
+
+/**
+ * Magnetometer Z-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG3_ZSCALE, 1.0f);
+
+
+/**
  * Primary accel ID
  *
  * @group Sensor Calibration

--- a/src/modules/sensors/temperature_compensation.h
+++ b/src/modules/sensors/temperature_compensation.h
@@ -49,8 +49,12 @@
 namespace sensors
 {
 
-static_assert(SENSOR_COUNT_MAX == 3,
-	      "SENSOR_COUNT_MAX must be 3 (if changed, add/remove TC_* params to match the count)");
+static_assert(GYRO_COUNT_MAX == 3,
+	      "GYRO_COUNT_MAX must be 3 (if changed, add/remove TC_* params to match the count)");
+static_assert(ACCEL_COUNT_MAX == 3,
+	      "ACCEL_COUNT_MAX must be 3 (if changed, add/remove TC_* params to match the count)");
+static_assert(BARO_COUNT_MAX == 3,
+	      "BARO_COUNT_MAX must be 3 (if changed, add/remove TC_* params to match the count)");
 
 /**
  ** class TemperatureCompensation
@@ -182,21 +186,21 @@ private:
 	// create a struct containing all thermal calibration parameters
 	struct Parameters {
 		int gyro_tc_enable;
-		SensorCalData3D gyro_cal_data[SENSOR_COUNT_MAX];
+		SensorCalData3D gyro_cal_data[GYRO_COUNT_MAX];
 		int accel_tc_enable;
-		SensorCalData3D accel_cal_data[SENSOR_COUNT_MAX];
+		SensorCalData3D accel_cal_data[ACCEL_COUNT_MAX];
 		int baro_tc_enable;
-		SensorCalData1D baro_cal_data[SENSOR_COUNT_MAX];
+		SensorCalData1D baro_cal_data[BARO_COUNT_MAX];
 	};
 
 	// create a struct containing the handles required to access all calibration parameters
 	struct ParameterHandles {
 		param_t gyro_tc_enable;
-		SensorCalHandles3D gyro_cal_handles[SENSOR_COUNT_MAX];
+		SensorCalHandles3D gyro_cal_handles[GYRO_COUNT_MAX];
 		param_t accel_tc_enable;
-		SensorCalHandles3D accel_cal_handles[SENSOR_COUNT_MAX];
+		SensorCalHandles3D accel_cal_handles[ACCEL_COUNT_MAX];
 		param_t baro_tc_enable;
-		SensorCalHandles1D baro_cal_handles[SENSOR_COUNT_MAX];
+		SensorCalHandles1D baro_cal_handles[BARO_COUNT_MAX];
 	};
 
 
@@ -268,7 +272,7 @@ private:
 
 	template<typename T>
 	static inline int set_sensor_id(uint32_t device_id, int topic_instance, PerSensorData &sensor_data,
-					const T *sensor_cal_data);
+					const T *sensor_cal_data, uint8_t sensor_count_max);
 };
 
 }

--- a/src/modules/sensors/voted_sensors_update.h
+++ b/src/modules/sensors/voted_sensors_update.h
@@ -166,7 +166,7 @@ private:
 		unsigned int last_failover_count;
 	};
 
-	void	init_sensor_class(const struct orb_metadata *meta, SensorData &sensor_data);
+	void	init_sensor_class(const struct orb_metadata *meta, SensorData &sensor_data, uint8_t sensor_count_max);
 
 	/**
 	 * Poll the accelerometer for updated data.
@@ -237,7 +237,6 @@ private:
 	 */
 	bool apply_mag_calibration(DriverFramework::DevHandle &h, const struct mag_calibration_s *mcal, const int device_id);
 
-
 	SensorData _gyro;
 	SensorData _accel;
 	SensorData _mag;
@@ -245,18 +244,18 @@ private:
 
 	orb_advert_t	_mavlink_log_pub = nullptr;
 
-	float _last_baro_pressure[SENSOR_COUNT_MAX]; /**< pressure from last baro sensors */
+	float _last_baro_pressure[BARO_COUNT_MAX]; /**< pressure from last baro sensors */
 	float _last_best_baro_pressure = 0.0f; /**< pressure from last best baro */
 	sensor_combined_s _last_sensor_data[SENSOR_COUNT_MAX]; /**< latest sensor data from all sensors instances */
-	uint64_t _last_accel_timestamp[SENSOR_COUNT_MAX]; /**< latest full timestamp */
-	uint64_t _last_mag_timestamp[SENSOR_COUNT_MAX]; /**< latest full timestamp */
-	uint64_t _last_baro_timestamp[SENSOR_COUNT_MAX]; /**< latest full timestamp */
+	uint64_t _last_accel_timestamp[ACCEL_COUNT_MAX]; /**< latest full timestamp */
+	uint64_t _last_mag_timestamp[MAG_COUNT_MAX]; /**< latest full timestamp */
+	uint64_t _last_baro_timestamp[BARO_COUNT_MAX]; /**< latest full timestamp */
 
 	hrt_abstime _vibration_warning_timestamp = 0;
 	bool _vibration_warning = false;
 
 	math::Matrix<3, 3>	_board_rotation = {};	/**< rotation matrix for the orientation that the board is mounted */
-	math::Matrix<3, 3>	_mag_rotation[SENSOR_COUNT_MAX] = {};	/**< rotation matrix for the orientation that the external mag0 is mounted */
+	math::Matrix<3, 3>	_mag_rotation[MAG_COUNT_MAX] = {};	/**< rotation matrix for the orientation that the external mag0 is mounted */
 
 	const Parameters &_parameters;
 	const bool _hil_enabled; /**< is hardware-in-the-loop mode enabled? */


### PR DESCRIPTION
Adds support for a 4th magnetometer (Pixhawk 2 has 3 internal + atleast 1 external in GPS unit)

@dagar Would be great if you could crosstest with Pixhawk 2 + external mag. Wipe everything and recalibrate.