### PR TITLE
trying to enable vmount on px4fmu-v2

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -1123,7 +1123,9 @@ then
 	if param compare MNT_MODE_IN -1
 	then
 	else
-		vmount start
+		if vmount start
+		then
+		fi
 	fi
 
 # End of autostart

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -44,7 +44,7 @@ set(config_module_list
 	#drivers/mkblctrl
 	drivers/px4flow
 	#drivers/oreoled
-	#drivers/vmount
+	drivers/vmount
 	drivers/pwm_input
 	drivers/camera_trigger
 	drivers/bst


### PR DESCRIPTION
and make sure that boot is not aborted if `vmount start` fails.

`make sizes` before:
```
977344    6452   18676 1002472   f4be8 build_px4fmu-v2_default/src/firmware/nuttx/firmware_nuttx
```
`make sizes` after:
```
983516    6452   18676 1008644   f6404 build_px4fmu-v2_default/src/firmware/nuttx/firmware_nuttx
```

Fixes #7085