### PR TITLE
Acknowledge vehicle commands in UAVCAN server

### DIFF
--- a/src/modules/uavcan/uavcan_servers.hpp
+++ b/src/modules/uavcan/uavcan_servers.hpp
@@ -161,6 +161,7 @@ private:
 
 	// uORB topic handle for MAVLink parameter responses
 	orb_advert_t _param_response_pub = nullptr;
+	orb_advert_t _command_ack_pub = nullptr;
 
 	typedef uavcan::MethodBinder<UavcanServers *,
 		void (UavcanServers::*)(const uavcan::ServiceCallResult<uavcan::protocol::param::GetSet> &)> GetSetCallback;


### PR DESCRIPTION
Vehicle commands that are not acknowledged from the UAVCAN server were send several times and lead to an error message in QGS: "vehicle did not respond to command".