### PR TITLE
Consider FW PSP in pitch limits

### DIFF
--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_main.cpp
@@ -1235,8 +1235,8 @@ FixedwingPositionControl::control_position(const math::Vector<2> &curr_pos, cons
 
 			tecs_update_pitch_throttle(pos_sp_curr.alt,
 						   calculate_target_airspeed(mission_airspeed),
-						   radians(_parameters.pitch_limit_min),
-						   radians(_parameters.pitch_limit_max),
+						   radians(_parameters.pitch_limit_min) - _parameters.pitchsp_offset_rad,
+						   radians(_parameters.pitch_limit_max) - _parameters.pitchsp_offset_rad,
 						   _parameters.throttle_min,
 						   _parameters.throttle_max,
 						   mission_throttle,
@@ -1271,8 +1271,8 @@ FixedwingPositionControl::control_position(const math::Vector<2> &curr_pos, cons
 
 			tecs_update_pitch_throttle(alt_sp,
 						   calculate_target_airspeed(mission_airspeed),
-						   radians(_parameters.pitch_limit_min),
-						   radians(_parameters.pitch_limit_max),
+						   radians(_parameters.pitch_limit_min) - _parameters.pitchsp_offset_rad,
+						   radians(_parameters.pitch_limit_max) - _parameters.pitchsp_offset_rad,
 						   _parameters.throttle_min,
 						   _parameters.throttle_max,
 						   _parameters.throttle_cruise,


### PR DESCRIPTION
Fix for https://github.com/PX4/Firmware/issues/7097

%releasenotes: The FW_PSP_OFF parameter no longer breaches the pitch min/max limits

SITL tested with the following params:
FW_P_LIM_MAX = 10
FW_P_LIM_MIN = -10
FW_PSP_OFF = 5

Before patch:
![image](https://cloud.githubusercontent.com/assets/14801663/25273684/2cae7c52-268d-11e7-8536-2b2adb7fb37f.png)

After patch:
![image](https://cloud.githubusercontent.com/assets/14801663/25273695/3d15bdd0-268d-11e7-9bc6-c54b2fa9e520.png)

