### PR TITLE
Allow inflight updates of cruise throttle during missions

### DIFF
--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -291,13 +291,10 @@ private:
 	NavigatorMode *_navigation_mode_array[NAVIGATOR_MODE_ARRAY_SIZE];	/**< array of navigation modes */
 
 	control::BlockParamFloat _param_loiter_radius;	/**< loiter radius for fixedwing */
+
 	control::BlockParamFloat _param_acceptance_radius;	/**< acceptance for takeoff */
 	control::BlockParamFloat _param_fw_alt_acceptance_radius;	/**< acceptance radius for fixedwing altitude */
 	control::BlockParamFloat _param_mc_alt_acceptance_radius;	/**< acceptance radius for multicopter altitude */
-
-	control::BlockParamFloat _param_cruising_speed_hover;
-	control::BlockParamFloat _param_cruising_speed_plane;
-	control::BlockParamFloat _param_cruising_throttle_plane;
 
 	float _mission_cruising_speed_mc{-1.0f};
 	float _mission_cruising_speed_fw{-1.0f};

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -99,10 +99,7 @@ Navigator::Navigator() :
 	_param_loiter_radius(this, "LOITER_RAD"),
 	_param_acceptance_radius(this, "ACC_RAD"),
 	_param_fw_alt_acceptance_radius(this, "FW_ALT_RAD"),
-	_param_mc_alt_acceptance_radius(this, "MC_ALT_RAD"),
-	_param_cruising_speed_hover(this, "MPC_XY_CRUISE", false),
-	_param_cruising_speed_plane(this, "FW_AIRSPD_TRIM", false),
-	_param_cruising_throttle_plane(this, "FW_THR_CRUISE", false)
+	_param_mc_alt_acceptance_radius(this, "MC_ALT_RAD")
 {
 	/* Create a list of our possible navigation types */
 	_navigation_mode_array[0] = &_mission;
@@ -745,7 +742,7 @@ Navigator::get_cruising_speed()
 			return _mission_cruising_speed_mc;
 
 		} else {
-			return _param_cruising_speed_hover.get();
+			return -1.0f;
 		}
 
 	} else {
@@ -753,7 +750,7 @@ Navigator::get_cruising_speed()
 			return _mission_cruising_speed_fw;
 
 		} else {
-			return _param_cruising_speed_plane.get();
+			return -1.0f;
 		}
 	}
 }

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -784,7 +784,7 @@ Navigator::get_cruising_throttle()
 		return _mission_throttle;
 
 	} else {
-		return _param_cruising_throttle_plane.get();
+		return -1.0f;
 	}
 }
 


### PR DESCRIPTION
Currently changing the throttle_cruise param during mission flight will only be applied at the next waypoint. This is because the position setpoint is given this param as cruise throttle when non was set. The position setpoint only gets updated at the next waypoint.

The intended behavior is for the position setpoint to use the last value set from a DO_CHANGE_SPEED command and if not present use the throttle_cruise param. By invalidating the value on a position setpoint level the FW position controller will use the FW_THR_CRUISE directly and thus it will apply updates to this param directly.

SITL tested, working as expected