### PR TITLE
Potentially infinite and deleted loops found by PVS-Studio

### DIFF
--- a/src/drivers/device/vdev_posix.cpp
+++ b/src/drivers/device/vdev_posix.cpp
@@ -55,7 +55,7 @@ using namespace device;
 pthread_mutex_t filemutex = PTHREAD_MUTEX_INITIALIZER;
 px4_sem_t lockstep_sem;
 bool sim_lockstep = false;
-bool sim_delay = false;
+volatile bool sim_delay = false;
 
 extern "C" {
 

--- a/src/platforms/posix/main.cpp
+++ b/src/platforms/posix/main.cpp
@@ -71,7 +71,7 @@ const unsigned path_max_len = PATH_MAX;
 const unsigned path_max_len = 1024;
 #endif
 
-static bool _ExitFlag = false;
+static volatile bool _ExitFlag = false;
 
 static struct termios orig_term;
 


### PR DESCRIPTION
Hello,
I have found and fixed bug using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

Analyzer warning:

* [V712](https://www.viva64.com/en/w/V712/) Be advised that compiler may delete this cycle or make it infinity. Use volatile variable(s) or synchronization primitives to avoid this. [src/platforms/posix/main.cpp 519](https://github.com/PX4/Firmware/blob/master/src/platforms/posix/main.cpp#L519), [603](https://github.com/PX4/Firmware/blob/master/src/platforms/posix/main.cpp#L603)
* [V712](https://www.viva64.com/en/w/V712/) Be advised that compiler may delete this cycle or make it infinity. Use volatile variable(s) or synchronization primitives to avoid this. [src/drivers/device/vdev_posix.cpp 281](https://github.com/PX4/Firmware/blob/master/src/drivers/device/vdev_posix.cpp#L281)

In addition, I suggest having a look at the emails, sent from @pvs-studio.com.

Best regards,
Phillip Khandeliants