### PR TITLE
System: Set new logger system as the default

### DIFF
--- a/cmake/configs/nuttx_aerocore2_default.cmake
+++ b/cmake/configs/nuttx_aerocore2_default.cmake
@@ -95,8 +95,8 @@ set(config_module_list
 	#
 	# Logging
 	#
-	#modules/logger
-	modules/sdlog2
+	modules/logger
+	#modules/sdlog2
 
 	#
 	# Library modules

--- a/cmake/configs/nuttx_crazyflie_default.cmake
+++ b/cmake/configs/nuttx_crazyflie_default.cmake
@@ -70,7 +70,7 @@ set(config_module_list
 	#
 	# Logging
 	#
-	modules/sdlog2
+	modules/logger
 
 	#
 	# Library modules

--- a/posix-configs/SITL/init/ekf2/multiple_iris
+++ b/posix-configs/SITL/init/ekf2/multiple_iris
@@ -72,6 +72,6 @@ mavlink stream -r 50 -s ATTITUDE_TARGET -u _MAVPORT_
 mavlink stream -r 20 -s RC_CHANNELS -u _MAVPORT_
 mavlink stream -r 250 -s HIGHRES_IMU -u _MAVPORT_
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u _MAVPORT_
-sdlog2 start -r 100 -e -t -a
+logger start -e -t
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/ekf2/rover
+++ b/posix-configs/SITL/init/ekf2/rover
@@ -67,6 +67,6 @@ mavlink stream -r 80 -s ATTITUDE_TARGET -u 14556
 mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
-sdlog2 start -r 200 -e -t -a
+logger start -e -t
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/ekf2/solo
+++ b/posix-configs/SITL/init/ekf2/solo
@@ -70,6 +70,6 @@ mavlink stream -r 50 -s SERVO_OUTPUT_RAW_0 -u 14556
 mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
-sdlog2 start -r 100 -e -t -a
+logger start -e -t
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/ekf2/tailsitter
+++ b/posix-configs/SITL/init/ekf2/tailsitter
@@ -72,6 +72,6 @@ mavlink stream -r 80 -s ATTITUDE_TARGET -u 14556
 mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
-sdlog2 start -r 200 -e -t -a
+logger start -e -t
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/inav/iris_opt_flow
+++ b/posix-configs/SITL/init/inav/iris_opt_flow
@@ -74,6 +74,6 @@ mavlink stream -r 80 -s ATTITUDE_TARGET -u 14556
 mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
-sdlog2 start -r 100 -e -t -a
+logger start -e -t
 mavlink boot_complete
 replay trystart

--- a/posix-configs/SITL/init/rcS_gazebo_delta_wing
+++ b/posix-configs/SITL/init/rcS_gazebo_delta_wing
@@ -55,6 +55,6 @@ mavlink stream -r 80 -s ATTITUDE_TARGET -u 14556
 mavlink stream -r 20 -s RC_CHANNELS -u 14556
 mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
-sdlog2 start -r 200 -e -t -a
+logger start -e -t
 mavlink boot_complete
 replay trystart

--- a/posix-configs/excelsior/mainapp.config
+++ b/posix-configs/excelsior/mainapp.config
@@ -1,8 +1,7 @@
 uorb start
 muorb start
-sdlog2 start -r 100 -e -t -a -b 200
+logger start -e -t
 param set MAV_BROADCAST 1
-param set SDLOG_PRIO_BOOST 3
 dataman start
 navigator start
 sleep 2

--- a/posix-configs/rpi/px4.config
+++ b/posix-configs/rpi/px4.config
@@ -26,5 +26,5 @@ mavlink stream -d /dev/ttyUSB0 -s HIGHRES_IMU -r 50
 mavlink stream -d /dev/ttyUSB0 -s ATTITUDE -r 50
 navio_sysfs_rc_in start
 navio_sysfs_pwm_out start
-logger start -t
+logger start -t -b 200
 mavlink boot_complete

--- a/posix-configs/rpi/px4_fw.config
+++ b/posix-configs/rpi/px4_fw.config
@@ -24,5 +24,5 @@ mavlink stream -u 14556 -s MANUAL_CONTROL -r 10
 
 navio_sysfs_rc_in start
 navio_sysfs_pwm_out start -m ROMFS/px4fmu_common/mixers/AERT.main.mix
-logger start -t
+logger start -t -b 200
 mavlink boot_complete

--- a/posix-configs/rpi/px4_hil.config
+++ b/posix-configs/rpi/px4_hil.config
@@ -20,6 +20,6 @@ mavlink start -u 14577 -r 1000000
 navio_sysfs_rc_in start
 pwm_out_sim mode_pwm16
 mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_x.main.mix
-logger start -t
+logger start -t -b 200
 mavlink boot_complete
 

--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -147,14 +147,14 @@ PARAM_DEFINE_INT32(SYS_PARAM_VER, 1);
 /**
  * SD logger
  *
- * @value 0 sdlog2 (default)
- * @value 1 new logger
+ * @value 0 sdlog2 (legacy)
+ * @value 1 logger (default)
  * @min 0
  * @max 1
  * @reboot_required true
  * @group System
  */
-PARAM_DEFINE_INT32(SYS_LOGGER, 0);
+PARAM_DEFINE_INT32(SYS_LOGGER, 1);
 
 /**
  * Enable stack checking


### PR DESCRIPTION
This will upgrade systems to the new .ulog format used by http://logs.px4.io and supported by Flight Plot.

Please comment in this PR if you have concerns about the ripples for the community and legacy systems.
