### PR TITLE
Add I2C option for Lidar Lite v3

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -471,12 +471,6 @@ then
 	fi
 
 	# Sensors on the PWM interface bank
-	if param compare SENS_EN_LL40LS 1
-	then
-		# clear pins 5 and 6
-		set FMU_MODE pwm4
-		set AUX_MODE pwm4
-	fi
 	if param greater TRIG_MODE 0
 	then
 		# We ONLY support trigger on pins 5 and 6 when simultanously using AUX for actuator output
@@ -740,7 +734,7 @@ then
 	then
 		if pwm_input start
 		then
-			if ll40ls start pwm
+			if ll40ls start i2c
 			then
 			fi
 		fi

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -471,6 +471,12 @@ then
 	fi
 
 	# Sensors on the PWM interface bank
+	if param compare SENS_EN_LL40LS 1
+	then
+		# clear pins 5 and 6
+		set FMU_MODE pwm4
+		set AUX_MODE pwm4
+	fi
 	if param greater TRIG_MODE 0
 	then
 		# We ONLY support trigger on pins 5 and 6 when simultanously using AUX for actuator output
@@ -731,6 +737,17 @@ then
 
 	# Sensors on the PWM interface bank
 	if param compare SENS_EN_LL40LS 1
+	then
+		if pwm_input start
+		then
+			if ll40ls start pwm
+			then
+			fi
+		fi
+	fi
+
+	# Lidar-Lite on I2C
+	if param compare SENS_EN_LL40LS 2
 	then
 		if pwm_input start
 		then

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -749,11 +749,8 @@ then
 	# Lidar-Lite on I2C
 	if param compare SENS_EN_LL40LS 2
 	then
-		if pwm_input start
+		if ll40ls start i2c
 		then
-			if ll40ls start i2c
-			then
-			fi
 		fi
 	fi
 

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -3230,7 +3230,7 @@ PARAM_DEFINE_INT32(RC_RSSI_PWM_MAX, 1000);
 PARAM_DEFINE_INT32(RC_RSSI_PWM_MIN, 2000);
 
 /**
- * Lidar-Lite (LL40LS) PWM
+ * Lidar-Lite (LL40LS) I2C
  *
  * @reboot_required true
  *

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -3230,12 +3230,15 @@ PARAM_DEFINE_INT32(RC_RSSI_PWM_MAX, 1000);
 PARAM_DEFINE_INT32(RC_RSSI_PWM_MIN, 2000);
 
 /**
- * Lidar-Lite (LL40LS) I2C
+ * Lidar-Lite (LL40LS)
  *
  * @reboot_required true
- *
- * @boolean
+ * @min 0
+ * @max 2
  * @group Sensor Enable
+ * @value 0 Disabled
+ * @value 1 PWM
+ * @value 2 I2C
  */
 PARAM_DEFINE_INT32(SENS_EN_LL40LS, 0);
 


### PR DESCRIPTION
This pull request adds the option of starting Lidar Lite on I2C