### PR TITLE
Auto-select mount mixer

### DIFF
--- a/ROMFS/px4fmu_common/init.d/4002_quad_x_mount
+++ b/ROMFS/px4fmu_common/init.d/4002_quad_x_mount
@@ -30,5 +30,3 @@ set MIXER_AUX mount
 set PWM_AUX_OUT 123456
 set PWM_AUX_RATE 50
 
-# Start mount driver
-vmount start

--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -19,7 +19,7 @@ then
 
 	if [ $MIXER_AUX == none -a $USE_IO == yes ]
 	then
-		set MIXER_AUX ${MIXER}.aux
+		set MIXER_AUX ${MIXER}
 	fi
 
 	# Use the mixer file from the SD-card if it exists

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -265,6 +265,19 @@ then
 	unset MODE
 
 	#
+	# If mount (gimbal) control is enabled and output mode is AUX, set the aux
+	# mixer to mount (override the airframe-specific MIXER_AUX setting)
+	#
+	if param compare MNT_MODE_IN -1
+	then
+	else
+		if param compare MNT_MODE_OUT 0
+		then
+			set MIXER_AUX mount
+		fi
+	fi
+
+	#
 	# Wipe incompatible settings for boards not having two outputs
 	if ver hwcmp PX4FMU_V4
 	then


### PR DESCRIPTION
This automatically selects the mount aux mixer if vmount is enabled (overriding the aux mixer specified by the airframe). A user can customize this by adding a file `etc/mixers/mount.aux.mix` to the SD card.
@LorenzMeier Please review, I'm not entirely sure if that's the best way to do it.