### PR TITLE
valgrind initialization fixes

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1784,7 +1784,7 @@ PX4IO::io_handle_battery(uint16_t vbatt, uint16_t ibatt)
 		return;
 	}
 
-	battery_status_s	battery_status;
+	battery_status_s battery_status = {};
 
 	const hrt_abstime timestamp = hrt_absolute_time();
 	/* voltage is scaled to mV */

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -454,7 +454,7 @@ static bool ekf2Check(orb_advert_t *mavlink_log_pub, bool optional, bool report_
 	int sub = orb_subscribe(ORB_ID(estimator_status));
 	bool updated;
 	orb_check(sub,&updated);
-	struct estimator_status_s status;
+	struct estimator_status_s status = {};
 	orb_copy(ORB_ID(estimator_status), sub, &status);
 	orb_unsubscribe(sub);
 

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -3482,7 +3482,7 @@ protected:
 		}
 
 		{
-			struct vehicle_local_position_s local_pos;
+			struct vehicle_local_position_s local_pos = {};
 			updated |= _local_pos_sub->update(&_local_pos_time, &local_pos);
 			msg.altitude_local = (_local_pos_time > 0) ? -local_pos.z : NAN;
 

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -105,7 +105,7 @@ MavlinkMissionManager::~MavlinkMissionManager()
 void
 MavlinkMissionManager::init_offboard_mission()
 {
-	mission_s mission_state;
+	mission_s mission_state = {};
 
 	if (!_dataman_init) {
 		_dataman_init = true;
@@ -138,7 +138,7 @@ MavlinkMissionManager::init_offboard_mission()
 int
 MavlinkMissionManager::update_active_mission(int dataman_id, unsigned count, int seq)
 {
-	struct mission_s mission;
+	struct mission_s mission = {};
 
 	mission.dataman_id = dataman_id;
 	mission.count = count;

--- a/src/modules/systemlib/battery.h
+++ b/src/modules/systemlib/battery.h
@@ -50,15 +50,8 @@
 class Battery : public control::SuperBlock
 {
 public:
-	/**
-	 * Constructor
-	 */
 	Battery();
-
-	/**
-	 * Destructor
-	 */
-	~Battery();
+	~Battery() = default;
 
 	/**
 	 * Reset all battery stats and report invalid/nothing.
@@ -108,13 +101,13 @@ private:
 	control::BlockParamFloat _param_crit_thr;
 	control::BlockParamFloat _param_emergency_thr;
 
-	float _voltage_filtered_v;
-	float _current_filtered_a;
-	float _discharged_mah;
-	float _remaining_voltage;		///< normalized battery charge level remaining based on voltage
-	float _remaining_capacity;		///< normalized battery charge level remaining based on capacity
-	float _remaining;			///< normalized battery charge level, selected based on config param
-	float _scale;
-	uint8_t _warning;
-	hrt_abstime _last_timestamp;
+	float _voltage_filtered_v{-1.0f};
+	float _current_filtered_a{-1.0f};
+	float _discharged_mah{0.0f};
+	float _remaining_voltage{1.0f};		///< normalized battery charge level remaining based on voltage
+	float _remaining_capacity{1.0f};	///< normalized battery charge level remaining based on capacity
+	float _remaining{1.0f};			///< normalized battery charge level, selected based on config param
+	float _scale{1.0f};
+	uint8_t _warning{battery_status_s::BATTERY_WARNING_NONE};
+	hrt_abstime _last_timestamp{0};
 };

--- a/src/platforms/posix/drivers/df_bebop_bus_wrapper/df_bebop_bus_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_bebop_bus_wrapper/df_bebop_bus_wrapper.cpp
@@ -197,7 +197,7 @@ int DfBebopBusWrapper::set_esc_speeds(const float speed_scaled[4])
 int DfBebopBusWrapper::_publish(struct bebop_state_data &data)
 {
 
-	battery_status_s battery_report;
+	battery_status_s battery_report = {};
 	const hrt_abstime timestamp = hrt_absolute_time();
 
 	// TODO Check if this is the right way for the Bebop


### PR DESCRIPTION
Found during (attempted) unrelated Valgrind testing.

https://github.com/PX4/ecl/pull/266

Tonealarmsim was partially resynced with the stm version.

A small sampling.

	==15321== Thread 16 ekf2:
	==15321== Conditional jump or move depends on uninitialised value(s)
	==15321==    at 0x4EED4B: Ekf2::task_main() (ekf2_main.cpp:567)
	==15321==    by 0x573486: entry_adapter(void*) (px4_posix_tasks.cpp:105)
	==15321==    by 0x4E416B9: start_thread (pthread_create.c:333)
	==15321==    by 0x59F082C: clone (clone.S:109)
	==15321==  Uninitialised value was created by a heap allocation
	==15321==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
	==15321==    by 0x4F1718: ekf2_main (ekf2_main.cpp:1224)
	==15321==    by 0x426E12: run_cmd(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, bool) (main.cpp:219)
	==15321==    by 0x4273CD: process_line(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool) [clone .constprop.81] (main.cpp:260)
	==15321==    by 0x4244E2: main (main.cpp:466)
	==15321== 
	==15321== Conditional jump or move depends on uninitialised value(s)
	==15321==    at 0x54F427: EstimatorInterface::setMagData(unsigned long, float (&) [3]) (estimator_interface.cpp:203)
	==15321==    by 0x4F1260: Ekf2::task_main() (ekf2_main.cpp:570)
	==15321==    by 0x573486: entry_adapter(void*) (px4_posix_tasks.cpp:105)
	==15321==    by 0x4E416B9: start_thread (pthread_create.c:333)
	==15321==    by 0x59F082C: clone (clone.S:109)
	==15321==  Uninitialised value was created by a heap allocation
	==15321==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
	==15321==    by 0x4F1718: ekf2_main (ekf2_main.cpp:1224)
	==15321==    by 0x426E12: run_cmd(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, bool) (main.cpp:219)
	==15321==    by 0x4273CD: process_line(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool) [clone .constprop.81] (main.cpp:260)
	==15321==    by 0x4244E2: main (main.cpp:466)
	==15321== 
	==15321== Conditional jump or move depends on uninitialised value(s)
	==15321==    at 0x54F439: EstimatorInterface::setMagData(unsigned long, float (&) [3]) (estimator_interface.cpp:208)
	==15321==    by 0x4F1260: Ekf2::task_main() (ekf2_main.cpp:570)
	==15321==    by 0x573486: entry_adapter(void*) (px4_posix_tasks.cpp:105)
	==15321==    by 0x4E416B9: start_thread (pthread_create.c:333)
	==15321==    by 0x59F082C: clone (clone.S:109)
	==15321==  Uninitialised value was created by a heap allocation
	==15321==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
	==15321==    by 0x4F1718: ekf2_main (ekf2_main.cpp:1224)
	==15321==    by 0x426E12: run_cmd(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, bool) (main.cpp:219)
	==15321==    by 0x4273CD: process_line(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool) [clone .constprop.81] (main.cpp:260)
	==15321==    by 0x4244E2: main (main.cpp:466)
	==15321== 
	==15321== Conditional jump or move depends on uninitialised value(s)
	==15321==    at 0x54F465: EstimatorInterface::setMagData(unsigned long, float (&) [3]) (estimator_interface.cpp:208)
	==15321==    by 0x4F1260: Ekf2::task_main() (ekf2_main.cpp:570)
	==15321==    by 0x573486: entry_adapter(void*) (px4_posix_tasks.cpp:105)
	==15321==    by 0x4E416B9: start_thread (pthread_create.c:333)
	==15321==    by 0x59F082C: clone (clone.S:109)
	==15321==  Uninitialised value was created by a heap allocation
	==15321==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
	==15321==    by 0x4F1718: ekf2_main (ekf2_main.cpp:1224)
	==15321==    by 0x426E12: run_cmd(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, bool) (main.cpp:219)
	==15321==    by 0x4273CD: process_line(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool) [clone .constprop.81] (main.cpp:260)
	==15321==    by 0x4244E2: main (main.cpp:466)
	==15321== 
	==15321== Conditional jump or move depends on uninitialised value(s)
	==15321==    at 0x4EEDEA: Ekf2::task_main() (ekf2_main.cpp:598)
	==15321==    by 0x573486: entry_adapter(void*) (px4_posix_tasks.cpp:105)
	==15321==    by 0x4E416B9: start_thread (pthread_create.c:333)
	==15321==    by 0x59F082C: clone (clone.S:109)
	==15321==  Uninitialised value was created by a heap allocation
	==15321==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
	==15321==    by 0x4F1718: ekf2_main (ekf2_main.cpp:1224)
	==15321==    by 0x426E12: run_cmd(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, bool) (main.cpp:219)
	==15321==    by 0x4273CD: process_line(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool) [clone .constprop.81] (main.cpp:260)
	==15321==    by 0x4244E2: main (main.cpp:466)
	==15321== 
	==15321== Conditional jump or move depends on uninitialised value(s)
	==15321==    at 0x54F910: EstimatorInterface::setBaroData(unsigned long, float) (estimator_interface.cpp:268)
	==15321==    by 0x4F12C8: Ekf2::task_main() (ekf2_main.cpp:600)
	==15321==    by 0x573486: entry_adapter(void*) (px4_posix_tasks.cpp:105)
	==15321==    by 0x4E416B9: start_thread (pthread_create.c:333)
	==15321==    by 0x59F082C: clone (clone.S:109)
	==15321==  Uninitialised value was created by a heap allocation
	==15321==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
	==15321==    by 0x4F1718: ekf2_main (ekf2_main.cpp:1224)
	==15321==    by 0x426E12: run_cmd(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, bool) (main.cpp:219)
	==15321==    by 0x4273CD: process_line(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool) [clone .constprop.81] (main.cpp:260)
	==15321==    by 0x4244E2: main (main.cpp:466)
	==15321== 
	==15321== Conditional jump or move depends on uninitialised value(s)
	==15321==    at 0x54F919: EstimatorInterface::setBaroData(unsigned long, float) (estimator_interface.cpp:272)
	==15321==    by 0x4F12C8: Ekf2::task_main() (ekf2_main.cpp:600)
	==15321==    by 0x573486: entry_adapter(void*) (px4_posix_tasks.cpp:105)
	==15321==    by 0x4E416B9: start_thread (pthread_create.c:333)
	==15321==    by 0x59F082C: clone (clone.S:109)
	==15321==  Uninitialised value was created by a heap allocation
	==15321==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
	==15321==    by 0x4F1718: ekf2_main (ekf2_main.cpp:1224)
	==15321==    by 0x426E12: run_cmd(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, bool) (main.cpp:219)
	==15321==    by 0x4273CD: process_line(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool) [clone .constprop.81] (main.cpp:260)
	==15321==    by 0x4244E2: main (main.cpp:466)
	==15321== 
	==15321== Conditional jump or move depends on uninitialised value(s)
	==15321==    at 0x54F945: EstimatorInterface::setBaroData(unsigned long, float) (estimator_interface.cpp:272)
	==15321==    by 0x4F12C8: Ekf2::task_main() (ekf2_main.cpp:600)
	==15321==    by 0x573486: entry_adapter(void*) (px4_posix_tasks.cpp:105)
	==15321==    by 0x4E416B9: start_thread (pthread_create.c:333)
	==15321==    by 0x59F082C: clone (clone.S:109)
	==15321==  Uninitialised value was created by a heap allocation
	==15321==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
	==15321==    by 0x4F1718: ekf2_main (ekf2_main.cpp:1224)
	==15321==    by 0x426E12: run_cmd(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, bool) (main.cpp:219)
	==15321==    by 0x4273CD: process_line(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool) [clone .constprop.81] (main.cpp:260)
	==15321==    by 0x4244E2: main (main.cpp:466)
	==15321== 
	==15321== Conditional jump or move depends on uninitialised value(s)
	==15321==    at 0x5463E3: pop_first_older_than (RingBuffer.h:128)
	==15321==    by 0x5463E3: Ekf::initialiseFilter() (ekf.cpp:257)
	==15321==    by 0x548F24: Ekf::update() (ekf.cpp:214)
	==15321==    by 0x4EEF68: Ekf2::task_main() (ekf2_main.cpp:693)
	==15321==    by 0x573486: entry_adapter(void*) (px4_posix_tasks.cpp:105)
	==15321==    by 0x4E416B9: start_thread (pthread_create.c:333)
	==15321==    by 0x59F082C: clone (clone.S:109)
	==15321==  Uninitialised value was created by a heap allocation
	==15321==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
	==15321==    by 0x4F1718: ekf2_main (ekf2_main.cpp:1224)
	==15321==    by 0x426E12: run_cmd(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, bool) (main.cpp:219)
	==15321==    by 0x4273CD: process_line(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool) [clone .constprop.81] (main.cpp:260)
	==15321==    by 0x4244E2: main (main.cpp:466)
	==15321== 
	==15321== Conditional jump or move depends on uninitialised value(s)
	==15321==    at 0x5463F2: pop_first_older_than (RingBuffer.h:128)
	==15321==    by 0x5463F2: Ekf::initialiseFilter() (ekf.cpp:257)
	==15321==    by 0x548F24: Ekf::update() (ekf.cpp:214)
	==15321==    by 0x4EEF68: Ekf2::task_main() (ekf2_main.cpp:693)
	==15321==    by 0x573486: entry_adapter(void*) (px4_posix_tasks.cpp:105)
	==15321==    by 0x4E416B9: start_thread (pthread_create.c:333)
	==15321==    by 0x59F082C: clone (clone.S:109)
	==15321==  Uninitialised value was created by a heap allocation
	==15321==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
	==15321==    by 0x4F1718: ekf2_main (ekf2_main.cpp:1224)
	==15321==    by 0x426E12: run_cmd(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, bool) (main.cpp:219)
	==15321==    by 0x4273CD: process_line(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool) [clone .constprop.81] (main.cpp:260)
	==15321==    by 0x4244E2: main (main.cpp:466)
	==15321== 
	==15321== Conditional jump or move depends on uninitialised value(s)
	==15321==    at 0x546B79: pop_first_older_than (RingBuffer.h:128)
	==15321==    by 0x546B79: Ekf::initialiseFilter() (ekf.cpp:325)
	==15321==    by 0x548F24: Ekf::update() (ekf.cpp:214)
	==15321==    by 0x4EEF68: Ekf2::task_main() (ekf2_main.cpp:693)
	==15321==    by 0x573486: entry_adapter(void*) (px4_posix_tasks.cpp:105)
	==15321==    by 0x4E416B9: start_thread (pthread_create.c:333)
	==15321==    by 0x59F082C: clone (clone.S:109)
	==15321==  Uninitialised value was created by a heap allocation
	==15321==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
	==15321==    by 0x4F1718: ekf2_main (ekf2_main.cpp:1224)
	==15321==    by 0x426E12: run_cmd(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, bool) (main.cpp:219)
	==15321==    by 0x4273CD: process_line(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool) [clone .constprop.81] (main.cpp:260)
	==15321==    by 0x4244E2: main (main.cpp:466)
	==15321== 
	==15321== Conditional jump or move depends on uninitialised value(s)
	==15321==    at 0x546B87: pop_first_older_than (RingBuffer.h:128)
	==15321==    by 0x546B87: Ekf::initialiseFilter() (ekf.cpp:325)
	==15321==    by 0x548F24: Ekf::update() (ekf.cpp:214)
	==15321==    by 0x4EEF68: Ekf2::task_main() (ekf2_main.cpp:693)
	==15321==    by 0x573486: entry_adapter(void*) (px4_posix_tasks.cpp:105)
	==15321==    by 0x4E416B9: start_thread (pthread_create.c:333)
	==15321==    by 0x59F082C: clone (clone.S:109)
	==15321==  Uninitialised value was created by a heap allocation
	==15321==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
	==15321==    by 0x4F1718: ekf2_main (ekf2_main.cpp:1224)
	==15321==    by 0x426E12: run_cmd(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, bool) (main.cpp:219)
	==15321==    by 0x4273CD: process_line(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool) [clone .constprop.81] (main.cpp:260)
	==15321==    by 0x4244E2: main (main.cpp:466)
	==15321== 
	==15321== Conditional jump or move depends on uninitialised value(s)
	==15321==    at 0x546D28: Ekf::initialiseFilter() (ekf.cpp:326)
	==15321==    by 0x548F24: Ekf::update() (ekf.cpp:214)
	==15321==    by 0x4EEF68: Ekf2::task_main() (ekf2_main.cpp:693)
	==15321==    by 0x573486: entry_adapter(void*) (px4_posix_tasks.cpp:105)
	==15321==    by 0x4E416B9: start_thread (pthread_create.c:333)
	==15321==    by 0x59F082C: clone (clone.S:109)
	==15321==  Uninitialised value was created by a heap allocation
	==15321==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
	==15321==    by 0x4F1718: ekf2_main (ekf2_main.cpp:1224)
	==15321==    by 0x426E12: run_cmd(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, bool) (main.cpp:219)
	==15321==    by 0x4273CD: process_line(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool) [clone .constprop.81] (main.cpp:260)
	==15321==    by 0x4244E2: main (main.cpp:466)
	==15321== 
