### PR TITLE
ekf2: accept min/max range

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -506,8 +506,8 @@ void Ekf2::task_main()
 		if (range_finder_updated) {
 			orb_copy(ORB_ID(distance_sensor), range_finder_sub, &range_finder);
 
-			if (range_finder.min_distance >= range_finder.current_distance
-			    || range_finder.max_distance <= range_finder.current_distance) {
+			if (range_finder.min_distance > range_finder.current_distance
+			    || range_finder.max_distance < range_finder.current_distance) {
 				range_finder_updated = false;
 			}
 		}


### PR DESCRIPTION
There are distance sensors that output the minimum distance when on ground. Without this change, ekf never aligns when using range finder as primary height source.