### PR TITLE
Camera trigger optimizations

### DIFF
--- a/msg/camera_trigger.msg
+++ b/msg/camera_trigger.msg
@@ -1,3 +1,4 @@
+uint32 seq		# Image sequence number
 
-uint32 seq		# Image sequence
+uint32 ORB_QUEUE_LENGTH = 3
 

--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -631,8 +631,14 @@ CameraTrigger::engage(void *arg)
 
 	report.seq = trig->_trigger_seq++;
 
-	int instance_id = 0;
-	orb_publish_auto(ORB_ID(camera_trigger), &trig->_trigger_pub, &report, &instance_id, ORB_PRIO_DEFAULT);
+	if (trig->_trigger_pub == nullptr) {
+		trig->_trigger_pub = orb_advertise_queue(ORB_ID(camera_trigger), &report,
+				     camera_trigger_s::ORB_QUEUE_LENGTH);
+
+	} else {
+		orb_publish(ORB_ID(camera_trigger), trig->_trigger_pub, &report);
+
+	}
 }
 
 void

--- a/src/drivers/camera_trigger/camera_trigger_params.c
+++ b/src/drivers/camera_trigger/camera_trigger_params.c
@@ -35,7 +35,7 @@
  * @file camera_trigger_params.c
  * Camera trigger parameters
  *
- * @author Mohammed Kabir <mhkabir98@gmail.com>
+ * @author Mohammed Kabir <kabir@uasys.io>
  * @author Andreas Bircher <andreas@wingtra.com>
  */
 

--- a/src/drivers/camera_trigger/interfaces/src/camera_interface.h
+++ b/src/drivers/camera_trigger/interfaces/src/camera_interface.h
@@ -53,6 +53,13 @@ public:
 	 */
 	virtual bool has_power_control() { return false; }
 
+	/**
+	 * Checks if the camera connected to the interface
+	 * is turned on.
+	 * @return true if camera is on
+	 */
+	virtual bool is_powered_on() { return true; }
+
 protected:
 
 	/**

--- a/src/drivers/camera_trigger/interfaces/src/seagull_map2.h
+++ b/src/drivers/camera_trigger/interfaces/src/seagull_map2.h
@@ -28,6 +28,8 @@ public:
 
 	bool has_power_control() { return true; }
 
+	bool is_powered_on() { return _camera_is_on; }
+
 private:
 	void setup();
 


### PR DESCRIPTION
Cleans up trigger command handling and user-feedback. Doesn't look like much, but the user experience while testing this from the GCS will be heavily improved. Also fixes a small bug in distance-based always-on triggering.

@Antiheavy, would be nice if you can give this a go in HIL. For your setup, it isn't any functionally different from master. The new logger already logs `camera_trigger` messages, I realised, so you just need to redo your HIL test using the new logger. Make sure you use the new logger when testing. The `SYS_LOGGER` parameter should be set to "new logger".