### PR TITLE
Provide controller access to a vertical position derivative

### DIFF
--- a/msg/vehicle_global_position.msg
+++ b/msg/vehicle_global_position.msg
@@ -15,6 +15,7 @@ uint8 alt_reset_counter 		# Counter for reset events on altitude
 float32 vel_n			# North velocity in NED earth-fixed frame, (metres/sec)
 float32 vel_e			# East velocity in NED earth-fixed frame, (metres/sec)
 float32 vel_d			# Down velocity in NED earth-fixed frame, (metres/sec)
+float32 pos_d_deriv		# Down position time derivative in NED earth-fixed frame, (metres/sec)
 float32 yaw 			# Euler yaw angle relative to NED earth-fixed frame, -PI..+PI, (radians)
 float32 eph			# Standard deviation of horizontal position error, (metres)
 float32 epv			# Standard deviation of vertical position error, (metres)

--- a/msg/vehicle_local_position.msg
+++ b/msg/vehicle_local_position.msg
@@ -26,6 +26,7 @@ float32 delta_z
 float32 vx 				# North velocity in NED earth-fixed frame, (metres/sec)
 float32 vy				# East velocity in NED earth-fixed frame, (metres/sec)
 float32 vz				# Down velocity in NED earth-fixed frame, (metres/sec)
+float32 z_deriv				# Down position time derivative in NED earth-fixed frame, (metres/sec)
 
 # Velocity reset delta
 float32[2] delta_vxy

--- a/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
+++ b/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
@@ -948,6 +948,9 @@ void AttitudePositionEstimatorEKF::publishLocalPosition()
 	_local_pos.vy = _ekf->states[5];
 	_local_pos.vz = _ekf->states[6];
 
+	// this estimator does not provide a separate vertical position time derivative estimate, so use the vertical velocity
+	_local_pos.z_deriv = _ekf->states[6];
+
 	_local_pos.xy_valid = _gps_initialized && _gpsIsGood;
 	_local_pos.z_valid = true;
 	_local_pos.v_xy_valid = _gps_initialized && _gpsIsGood;
@@ -1016,10 +1019,12 @@ void AttitudePositionEstimatorEKF::publishGlobalPosition()
 
 	if (_local_pos.v_z_valid) {
 		_global_pos.vel_d = _local_pos.vz;
-
 	} else {
 		_global_pos.vel_d = 0.0f;
 	}
+
+	// this estimator does not provide a separate vertical position time derivative estimate, so use the vertical velocity
+	_global_pos.pos_d_deriv = _global_pos.vel_d;
 
 	/* terrain altitude */
 	if (_terrain_estimator->is_valid()) {

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -789,6 +789,9 @@ void Ekf2::task_main()
 			float velocity[3];
 			_ekf.get_velocity(velocity);
 
+			float pos_d_deriv;
+			_ekf.get_pos_d_deriv(&pos_d_deriv);
+
 			float gyro_rad[3];
 
 			{
@@ -911,6 +914,7 @@ void Ekf2::task_main()
 			lpos.vx = velocity[0];
 			lpos.vy = velocity[1];
 			lpos.vz = velocity[2];
+			lpos.z_deriv = pos_d_deriv; // vertical position time derivative (m/s)
 
 			// TODO: better status reporting
 			lpos.xy_valid = _ekf.local_position_is_valid() && !_vel_innov_preflt_fail;
@@ -978,6 +982,7 @@ void Ekf2::task_main()
 				global_pos.vel_n = velocity[0]; // Ground north velocity, m/s
 				global_pos.vel_e = velocity[1]; // Ground east velocity, m/s
 				global_pos.vel_d = velocity[2]; // Ground downside velocity, m/s
+				global_pos.pos_d_deriv = pos_d_deriv; // vertical position time derivative, m/s
 
 				global_pos.yaw = euler.psi(); // Yaw in radians -PI..+PI.
 

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -611,6 +611,9 @@ void BlockLocalPositionEstimator::publishLocalPos()
 		_pub_lpos.get().vy = xLP(X_vy); // east
 		_pub_lpos.get().vz = xLP(X_vz); // down
 
+		// this estimator does not provide a separate vertical position time derivative estimate, so use the vertical velocity
+		_pub_lpos.get().z_deriv = xLP(X_vz);
+
 		_pub_lpos.get().yaw = _eul(2);
 		_pub_lpos.get().xy_global = _estimatorInitialized & EST_XY;
 		_pub_lpos.get().z_global = !(_sensorTimeout & SENSOR_BARO);
@@ -691,6 +694,10 @@ void BlockLocalPositionEstimator::publishGlobalPos()
 		_pub_gpos.get().vel_n = xLP(X_vx);
 		_pub_gpos.get().vel_e = xLP(X_vy);
 		_pub_gpos.get().vel_d = xLP(X_vz);
+
+		// this estimator does not provide a separate vertical position time derivative estimate, so use the vertical velocity
+		_pub_gpos.get().pos_d_deriv = xLP(X_vz);
+
 		_pub_gpos.get().yaw = _eul(2);
 		_pub_gpos.get().eph = eph;
 		_pub_gpos.get().epv = epv;

--- a/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
@@ -1346,6 +1346,9 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 			local_pos.evh = 0.0f;
 			local_pos.evv = 0.0f;
 
+			// this estimator does not provide a separate vertical position time derivative estimate, so use the vertical velocity
+			local_pos.z_deriv = z_est[1];
+
 			if (local_pos.dist_bottom_valid) {
 				local_pos.dist_bottom = dist_ground;
 				local_pos.dist_bottom_rate = - z_est[1];
@@ -1370,6 +1373,9 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 				global_pos.vel_n = local_pos.vx;
 				global_pos.vel_e = local_pos.vy;
 				global_pos.vel_d = local_pos.vz;
+
+				// this estimator does not provide a separate vertical position time derivative estimate, so use the vertical velocity
+				global_pos.pos_d_deriv = local_pos.vz;
 
 				global_pos.yaw = local_pos.yaw;
 


### PR DESCRIPTION
This PR provides controllers with access to a vertical position derivative that is free from steady state offsets that are generated when the EKF is subject to uncorrected  IMU vertical accel and GPS velocity offsets.

This vertical position derivative can be used when the controller is operating in a vertical velocity tracking mode without position feedback.

Modifications to the position controller is required to take advantage of this change.