### PR TITLE
px4fmu-v4:SPI and init clean up

### DIFF
--- a/src/drivers/boards/px4fmu-v4/board_config.h
+++ b/src/drivers/boards/px4fmu-v4/board_config.h
@@ -51,55 +51,52 @@
  * Definitions
  ****************************************************************************************************/
 /* Configuration ************************************************************************************/
-//{GPIO_RSSI_IN,           0,                       0}, - pio Analog used as PWM
-//{0,                      GPIO_LED_SAFETY,         0},	pio replacement
-//{GPIO_SAFETY_SWITCH_IN,  0,                       0},   pio replacement
-//{0,                      GPIO_PERIPH_3V3_EN,      0},	Owned by the 8266 driver
-//{0,                      GPIO_SBUS_INV,           0},	https://github.com/PX4/Firmware/blob/master/src/modules/px4iofirmware/sbus.c
-//{GPIO_8266_GPIO0,        0,                       0},   Owned by the 8266 driver
-//{0,                      GPIO_SPEKTRUM_PWR_EN,     0},	Owned Spektum driver input to auto pilot
-//{0,                      GPIO_8266_PD,            0},	Owned by the 8266 driver
-//{0,                      GPIO_8266_RST,           0},	Owned by the 8266 driver
 
 /* PX4FMU GPIOs ***********************************************************************************/
 /* LEDs */
 
-#define GPIO_LED1		(GPIO_OUTPUT|GPIO_OPENDRAIN|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTB|GPIO_PIN11)
-#define GPIO_LED2		(GPIO_OUTPUT|GPIO_OPENDRAIN|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTB|GPIO_PIN1)
-#define GPIO_LED3		(GPIO_OUTPUT|GPIO_OPENDRAIN|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTB|GPIO_PIN3)
+#define GPIO_LED1                    (GPIO_OUTPUT|GPIO_OPENDRAIN|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTB|GPIO_PIN11)
+#define GPIO_LED2                    (GPIO_OUTPUT|GPIO_OPENDRAIN|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTB|GPIO_PIN1)
+#define GPIO_LED3                    (GPIO_OUTPUT|GPIO_OPENDRAIN|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTB|GPIO_PIN3)
 
-#define GPIO_LED_RED 	GPIO_LED1
-#define GPIO_LED_GREEN 	GPIO_LED2
-#define GPIO_LED_BLUE   GPIO_LED3
+#define GPIO_LED_RED                 GPIO_LED1
+#define GPIO_LED_GREEN               GPIO_LED2
+#define GPIO_LED_BLUE                GPIO_LED3
 
-/*  Define the Chip Selects */
-
-#define GPIO_SPI_CS_MPU9250		(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN2)
-#define GPIO_SPI_CS_HMC5983		(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTE|GPIO_PIN15)
-#define GPIO_SPI_CS_LIS3MDL		(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTE|GPIO_PIN15)
-#define GPIO_SPI_CS_MS5611		(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTD|GPIO_PIN7)
-#define GPIO_SPI_CS_ICM_2060X 		(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN15)
-
+/*  Define the Chip Selects for SPI1
+ *  CS           Devices                                 DRDY
+ *  ---- ----------------------------------------------- -----
+    PC2  MPU9250                    BMI160               PD15
+    PC15 ICM, ICM_20602, ICM_20608  BMI055_ACCEL         PC14
+    PE15 HMC5983                    BMI055_GYRO          PE12
+ *  ---- ----------------------------------------------- -----
+*/
 /* The BMI160 sensor replaces the MPU9250 on some boards. Only one is actually present and connected
- * to the second GPIO pin on port C. The wrong driver will fail during start becaus of an incorrect WHO_AM_I register.*/
-#define GPIO_SPI1_CS_PORTC_PIN2		(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN2)
-
-#define GPIO_SPI_CS_FRAM		(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTD|GPIO_PIN10)
+ * to the second GPIO pin on port C. The wrong driver will fail during start because of an incorrect WHO_AM_I register.*/
+#define GPIO_SPI1_CS_PORTC_PIN2      (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN2)
 
 /* The BMI055 acceleration sensor replaces the ICM20608G on some boards. Only one is actually present and connected
- * to the second GPIO pin on port C. The wrong driver will fail during start becaus of an incorrect WHO_AM_I register.*/
-#define GPIO_SPI1_CS_PORTC_PIN15  (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN15)
+ * to the second GPIO pin on port C. The wrong driver will fail during start because of an incorrect WHO_AM_I register.*/
+#define GPIO_SPI1_CS_PORTC_PIN15     (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN15)
 
 /* The BMI055 gyroscope sensor replaces the LIS3MDL, HMC5983 on some boards. Only one is actually present and connected
- * to the second GPIO pin on port E. The wrong driver will fail during start becaus of an incorrect WHO_AM_I register.*/
-#define GPIO_SPI1_CS_PORTE_PIN15  (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTE|GPIO_PIN15)
+ * to the second GPIO pin on port E. The wrong driver will fail during start because of an incorrect WHO_AM_I register.*/
+#define GPIO_SPI1_CS_PORTE_PIN15     (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTE|GPIO_PIN15)
+
+/*  Define the Data Ready interrupts On SPI 1*/
+
+#define GPIO_DRDY_PORTD_PIN15        (GPIO_INPUT|GPIO_FLOAT|GPIO_EXTI|GPIO_PORTD|GPIO_PIN15)
+#define GPIO_DRDY_PORTC_PIN14        (GPIO_INPUT|GPIO_FLOAT|GPIO_EXTI|GPIO_PORTC|GPIO_PIN14)
+#define GPIO_DRDY_PORTE_PIN12        (GPIO_INPUT|GPIO_FLOAT|GPIO_EXTI|GPIO_PORTE|GPIO_PIN12)
 
 
-/*  Define the Ready interrupts */
 
-#define GPIO_DRDY_MPU9250		(GPIO_INPUT|GPIO_FLOAT|GPIO_EXTI|GPIO_PORTD|GPIO_PIN15)
-#define GPIO_DRDY_HMC5983		(GPIO_INPUT|GPIO_FLOAT|GPIO_EXTI|GPIO_PORTE|GPIO_PIN12)
-#define GPIO_DRDY_ICM_2060X		(GPIO_INPUT|GPIO_FLOAT|GPIO_EXTI|GPIO_PORTC|GPIO_PIN14)
+/*  Define the Chip Selects for SPI2 */
+
+#define GPIO_SPI2_CS_MS5611          (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTD|GPIO_PIN7)
+#define GPIO_SPI2_CS_FRAM            (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTD|GPIO_PIN10)
+
+/* There are no DRDY on SPI 2 */
 
 /*
  *  Define the ability to shut off off the sensor signals
@@ -108,64 +105,70 @@
 
 #define _PIN_OFF(def) (((def) & (GPIO_PORT_MASK | GPIO_PIN_MASK)) | (GPIO_INPUT|GPIO_PULLDOWN|GPIO_SPEED_2MHz))
 
-#define GPIO_SPI_CS_OFF_MPU9250		_PIN_OFF(GPIO_SPI_CS_MPU9250)
-#define GPIO_SPI_CS_OFF_HMC5983		_PIN_OFF(GPIO_SPI_CS_HMC5983)
-#define GPIO_SPI_CS_OFF_LIS3MDL		_PIN_OFF(GPIO_SPI_CS_LIS3MDL)
-#define GPIO_SPI_CS_OFF_MS5611		_PIN_OFF(GPIO_SPI_CS_MS5611)
-#define GPIO_SPI_CS_OFF_ICM_2060X 	_PIN_OFF(GPIO_SPI_CS_ICM_2060X)
-#define GPIO_SPI_CS_OFF_BMI160		_PIN_OFF(GPIO_SPI1_CS_PORTC_PIN2)
-#define GPIO_SPI_CS_OFF_BMI055_ACC _PIN_OFF(GPIO_SPI1_CS_PORTC_PIN15)
-#define GPIO_SPI_CS_OFF_BMI055_GYR _PIN_OFF(GPIO_SPI1_CS_PORTE_PIN15)
+/* SPI 1 bus off */
 
-#define GPIO_DRDY_OFF_MPU9250		_PIN_OFF(GPIO_DRDY_MPU9250)
-#define GPIO_DRDY_OFF_ICM_2060X	_PIN_OFF(GPIO_DRDY_ICM_2060X)
+#define GPIO_SPI1_SCK_OFF            _PIN_OFF(GPIO_SPI1_SCK)
+#define GPIO_SPI1_MISO_OFF           _PIN_OFF(GPIO_SPI1_MISO)
+#define GPIO_SPI1_MOSI_OFF           _PIN_OFF(GPIO_SPI1_MOSI)
 
-/* SPI1 off */
-#define GPIO_SPI1_SCK_OFF	_PIN_OFF(GPIO_SPI1_SCK)
-#define GPIO_SPI1_MISO_OFF	_PIN_OFF(GPIO_SPI1_MISO)
-#define GPIO_SPI1_MOSI_OFF	_PIN_OFF(GPIO_SPI1_MOSI)
+/* SPI 1 CS's  off */
 
-#define PX4_SPI_BUS_SENSORS	1
-#define PX4_SPI_BUS_RAMTRON	2
-#define PX4_SPI_BUS_BARO	PX4_SPI_BUS_RAMTRON
+#define GPIO_SPI1_CS_OFF_PORTC_PIN2  _PIN_OFF(GPIO_SPI1_CS_PORTC_PIN2)
+#define GPIO_SPI1_CS_OFF_PORTC_PIN15 _PIN_OFF(GPIO_SPI1_CS_PORTC_PIN15)
+#define GPIO_SPI1_CS_OFF_PORTE_PIN15 _PIN_OFF(GPIO_SPI1_CS_PORTE_PIN15)
+
+/* SPI 1 DRDY's  off */
+
+#define GPIO_DRDY_OFF_PORTD_PIN15    _PIN_OFF(GPIO_DRDY_PORTD_PIN15)
+#define GPIO_DRDY_OFF_PORTC_PIN14    _PIN_OFF(GPIO_DRDY_PORTC_PIN14)
+#define GPIO_DRDY_OFF_PORTE_PIN12    _PIN_OFF(GPIO_DRDY_PORTE_PIN12)
+
+/* N.B we do not have control over the SPI 2 buss powered devices
+ * so the the ms5611 is not resetable.
+ */
+
+
+#define PX4_SPI_BUS_SENSORS          1
+#define PX4_SPI_BUS_RAMTRON          2
+#define PX4_SPI_BUS_BARO             PX4_SPI_BUS_RAMTRON
 
 /* Use these in place of the spi_dev_e enumeration to select a specific SPI device on SPI1 */
-#define PX4_SPIDEV_GYRO			1
-#define PX4_SPIDEV_ACCEL_MAG		2
-#define PX4_SPIDEV_MPU			4
-#define PX4_SPIDEV_HMC			5
-#define PX4_SPIDEV_ICM			6
-#define PX4_SPIDEV_LIS			7
-#define PX4_SPIDEV_BMI			8
-#define PX4_SPIDEV_BMA			9
-#define PX4_SPIDEV_ICM_20608		10
-#define PX4_SPIDEV_ICM_20602		11
-#define PX4_SPIDEV_BMI055_ACC   	12
-#define PX4_SPIDEV_BMI055_GYR   	13
+#define PX4_SPIDEV_GYRO              1
+#define PX4_SPIDEV_ACCEL_MAG         2
+#define PX4_SPIDEV_MPU               4
+#define PX4_SPIDEV_HMC               5
+#define PX4_SPIDEV_ICM               6
+#define PX4_SPIDEV_LIS               7
+#define PX4_SPIDEV_BMI               8
+#define PX4_SPIDEV_BMA               9
+#define PX4_SPIDEV_ICM_20608         10
+#define PX4_SPIDEV_ICM_20602         11
+#define PX4_SPIDEV_BMI055_ACC        12
+#define PX4_SPIDEV_BMI055_GYR        13
 
 /* onboard MS5611 and FRAM are both on bus SPI2
  * spi_dev_e:SPIDEV_FLASH has the value 2 and is used in the NuttX ramtron driver
  * use 3 for the barometer to differentiate
  */
-#define PX4_SPIDEV_BARO			3
+#define PX4_SPIDEV_BARO               3
 #if (PX4_SPIDEV_BARO == SPIDEV_FLASH)
 #error PX4_SPIDEV_BARO must not be equal to SPIDEV_FLASH as they share the same bus
 #endif
 
 /* I2C busses */
-#define PX4_I2C_BUS_EXPANSION	1
-#define PX4_I2C_BUS_LED			PX4_I2C_BUS_EXPANSION
-#define PX4_I2C_BUS_BMM150 		PX4_I2C_BUS_EXPANSION
+#define PX4_I2C_BUS_EXPANSION        1
+#define PX4_I2C_BUS_LED              PX4_I2C_BUS_EXPANSION
+#define PX4_I2C_BUS_BMM150           PX4_I2C_BUS_EXPANSION
 
 /* Devices on the external bus.
  *
  * Note that these are unshifted addresses.
  */
-#define PX4_I2C_OBDEV_LED	0x55
-#define PX4_I2C_OBDEV_HMC5883	0x1e
-#define PX4_I2C_OBDEV_LIS3MDL	0x1e
-#define PX4_I2C_OBDEV_BMM150	0x10
-#define PX4_I2C_OBDEV_BMP280	0x76
+#define PX4_I2C_OBDEV_LED            0x55
+#define PX4_I2C_OBDEV_HMC5883        0x1e
+#define PX4_I2C_OBDEV_LIS3MDL        0x1e
+#define PX4_I2C_OBDEV_BMM150         0x10
+#define PX4_I2C_OBDEV_BMP280         0x76
 
 /*
  * ADC channels
@@ -175,45 +178,45 @@
 #define ADC_CHANNELS (1 << 2) | (1 << 3) | (1 << 4) | (1 << 10) | (1 << 11) | (1 << 12) | (1 << 13) | (1 << 14)
 
 // ADC defines to be used in sensors.cpp to read from a particular channel
-#define ADC_BATTERY_VOLTAGE_CHANNEL		2
-#define ADC_BATTERY_CURRENT_CHANNEL		3
-#define ADC_5V_RAIL_SENSE				4
-#define ADC_RC_RSSI_CHANNEL				11
+#define ADC_BATTERY_VOLTAGE_CHANNEL  2
+#define ADC_BATTERY_CURRENT_CHANNEL  3
+#define ADC_5V_RAIL_SENSE            4
+#define ADC_RC_RSSI_CHANNEL          11
 
 /* Define Battery 1 Voltage Divider and A per V
  */
 
-#define BOARD_BATTERY1_V_DIV (13.653333333f)
-#define BOARD_BATTERY1_A_PER_V (36.367515152f)
+#define BOARD_BATTERY1_V_DIV         (13.653333333f)
+#define BOARD_BATTERY1_A_PER_V       (36.367515152f)
 
 
 /* User GPIOs
  *
  * GPIO0-5 are the PWM servo outputs.
  */
-#define GPIO_GPIO0_INPUT	(GPIO_INPUT|GPIO_PULLUP|GPIO_PORTE|GPIO_PIN14)
-#define GPIO_GPIO1_INPUT	(GPIO_INPUT|GPIO_PULLUP|GPIO_PORTE|GPIO_PIN13)
-#define GPIO_GPIO2_INPUT	(GPIO_INPUT|GPIO_PULLUP|GPIO_PORTE|GPIO_PIN11)
-#define GPIO_GPIO3_INPUT	(GPIO_INPUT|GPIO_PULLUP|GPIO_PORTE|GPIO_PIN9)
-#define GPIO_GPIO4_INPUT	(GPIO_INPUT|GPIO_PULLUP|GPIO_PORTD|GPIO_PIN13)
-#define GPIO_GPIO5_INPUT	(GPIO_INPUT|GPIO_PULLUP|GPIO_PORTD|GPIO_PIN14)
+#define GPIO_GPIO0_INPUT             (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTE|GPIO_PIN14)
+#define GPIO_GPIO1_INPUT             (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTE|GPIO_PIN13)
+#define GPIO_GPIO2_INPUT             (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTE|GPIO_PIN11)
+#define GPIO_GPIO3_INPUT             (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTE|GPIO_PIN9)
+#define GPIO_GPIO4_INPUT             (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTD|GPIO_PIN13)
+#define GPIO_GPIO5_INPUT             (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTD|GPIO_PIN14)
 
-#define GPIO_GPIO0_OUTPUT	(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTE|GPIO_PIN14)
-#define GPIO_GPIO1_OUTPUT	(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTE|GPIO_PIN13)
-#define GPIO_GPIO2_OUTPUT	(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTE|GPIO_PIN11)
-#define GPIO_GPIO3_OUTPUT	(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTE|GPIO_PIN9)
-#define GPIO_GPIO4_OUTPUT	(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTD|GPIO_PIN13)
-#define GPIO_GPIO5_OUTPUT	(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTD|GPIO_PIN14)
+#define GPIO_GPIO0_OUTPUT            (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTE|GPIO_PIN14)
+#define GPIO_GPIO1_OUTPUT            (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTE|GPIO_PIN13)
+#define GPIO_GPIO2_OUTPUT            (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTE|GPIO_PIN11)
+#define GPIO_GPIO3_OUTPUT            (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTE|GPIO_PIN9)
+#define GPIO_GPIO4_OUTPUT            (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTD|GPIO_PIN13)
+#define GPIO_GPIO5_OUTPUT            (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTD|GPIO_PIN14)
 
 /* Power supply control and monitoring GPIOs */
-#define GPIO_VDD_BRICK_VALID	(GPIO_INPUT|GPIO_PULLUP|GPIO_PORTB|GPIO_PIN5)
-#define GPIO_VDD_3V3_SENSORS_EN	(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTE|GPIO_PIN3)
+#define GPIO_VDD_BRICK_VALID         (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTB|GPIO_PIN5)
+#define GPIO_VDD_3V3_SENSORS_EN      (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTE|GPIO_PIN3)
 
 /* Tone alarm output */
-#define TONE_ALARM_TIMER		2	/* timer 2 */
-#define TONE_ALARM_CHANNEL		1	/* channel 1 */
-#define GPIO_TONE_ALARM_IDLE	(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTA|GPIO_PIN15)
-#define GPIO_TONE_ALARM			(GPIO_ALT|GPIO_AF1|GPIO_SPEED_2MHz|GPIO_PUSHPULL|GPIO_PORTA|GPIO_PIN15)
+#define TONE_ALARM_TIMER             2    /* timer 2 */
+#define TONE_ALARM_CHANNEL           1    /* channel 1 */
+#define GPIO_TONE_ALARM_IDLE         (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTA|GPIO_PIN15)
+#define GPIO_TONE_ALARM              (GPIO_ALT|GPIO_AF1|GPIO_SPEED_2MHz|GPIO_PUSHPULL|GPIO_PORTA|GPIO_PIN15)
 
 /* PWM
  *
@@ -228,58 +231,59 @@
  * CH5 : PD13 : TIM4_CH2
  * CH6 : PD14 : TIM4_CH3
  */
-#define GPIO_TIM1_CH1OUT	(GPIO_ALT|GPIO_AF1|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PUSHPULL|GPIO_PORTE|GPIO_PIN9)
-#define GPIO_TIM1_CH2OUT	(GPIO_ALT|GPIO_AF1|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PUSHPULL|GPIO_PORTE|GPIO_PIN11)
-#define GPIO_TIM1_CH3OUT	(GPIO_ALT|GPIO_AF1|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PUSHPULL|GPIO_PORTE|GPIO_PIN13)
-#define GPIO_TIM1_CH4OUT	(GPIO_ALT|GPIO_AF1|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PUSHPULL|GPIO_PORTE|GPIO_PIN14)
-#define GPIO_TIM4_CH2OUT	(GPIO_ALT|GPIO_AF2|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PUSHPULL|GPIO_PORTD|GPIO_PIN13)
-#define GPIO_TIM4_CH3OUT	(GPIO_ALT|GPIO_AF2|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PUSHPULL|GPIO_PORTD|GPIO_PIN14)
-#define DIRECT_PWM_OUTPUT_CHANNELS	6
+#define GPIO_TIM1_CH1OUT             (GPIO_ALT|GPIO_AF1|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PUSHPULL|GPIO_PORTE|GPIO_PIN9)
+#define GPIO_TIM1_CH2OUT             (GPIO_ALT|GPIO_AF1|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PUSHPULL|GPIO_PORTE|GPIO_PIN11)
+#define GPIO_TIM1_CH3OUT             (GPIO_ALT|GPIO_AF1|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PUSHPULL|GPIO_PORTE|GPIO_PIN13)
+#define GPIO_TIM1_CH4OUT             (GPIO_ALT|GPIO_AF1|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PUSHPULL|GPIO_PORTE|GPIO_PIN14)
+#define GPIO_TIM4_CH2OUT             (GPIO_ALT|GPIO_AF2|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PUSHPULL|GPIO_PORTD|GPIO_PIN13)
+#define GPIO_TIM4_CH3OUT             (GPIO_ALT|GPIO_AF2|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PUSHPULL|GPIO_PORTD|GPIO_PIN14)
+#define DIRECT_PWM_OUTPUT_CHANNELS   6
 
-#define GPIO_TIM1_CH1IN		GPIO_TIM1_CH1IN_2
-#define GPIO_TIM1_CH2IN		GPIO_TIM1_CH2IN_2
-#define GPIO_TIM1_CH3IN		GPIO_TIM1_CH3IN_2
-#define GPIO_TIM1_CH4IN		GPIO_TIM1_CH4IN_2
-#define GPIO_TIM4_CH2IN		GPIO_TIM4_CH2IN_2
-#define GPIO_TIM4_CH3IN		GPIO_TIM4_CH3IN_2
+#define GPIO_TIM1_CH1IN              GPIO_TIM1_CH1IN_2
+#define GPIO_TIM1_CH2IN              GPIO_TIM1_CH2IN_2
+#define GPIO_TIM1_CH3IN              GPIO_TIM1_CH3IN_2
+#define GPIO_TIM1_CH4IN              GPIO_TIM1_CH4IN_2
+#define GPIO_TIM4_CH2IN              GPIO_TIM4_CH2IN_2
+#define GPIO_TIM4_CH3IN              GPIO_TIM4_CH3IN_2
 #define DIRECT_INPUT_TIMER_CHANNELS  6
 
 /* USB OTG FS
  *
  * PA9  OTG_FS_VBUS VBUS sensing
  */
-#define GPIO_OTGFS_VBUS		(GPIO_INPUT|GPIO_FLOAT|GPIO_SPEED_100MHz|GPIO_OPENDRAIN|GPIO_PORTA|GPIO_PIN9)
+#define GPIO_OTGFS_VBUS              (GPIO_INPUT|GPIO_FLOAT|GPIO_SPEED_100MHz|GPIO_OPENDRAIN|GPIO_PORTA|GPIO_PIN9)
 
 /* High-resolution timer */
-#define HRT_TIMER           3   /* use timer 3 for the HRT */
-#define HRT_TIMER_CHANNEL	4   /* use capture/compare channel 4 */
+#define HRT_TIMER                    3   /* use timer 3 for the HRT */
+#define HRT_TIMER_CHANNEL            4   /* use capture/compare channel 4 */
 
-#define HRT_PPM_CHANNEL		3	/* use capture/compare channel 3 */
-#define GPIO_PPM_IN			(GPIO_ALT|GPIO_AF2|GPIO_PULLUP|GPIO_PORTB|GPIO_PIN0)
+#define HRT_PPM_CHANNEL              3    /* use capture/compare channel 3 */
+#define GPIO_PPM_IN                  (GPIO_ALT|GPIO_AF2|GPIO_PULLUP|GPIO_PORTB|GPIO_PIN0)
 
-#define RC_SERIAL_PORT		"/dev/ttyS4"
+#define RC_SERIAL_PORT               "/dev/ttyS4"
 
 /* PWM input driver. Use FMU AUX5 pins attached to timer4 channel 2 */
-#define PWMIN_TIMER			4
-#define PWMIN_TIMER_CHANNEL	2
-#define GPIO_PWM_IN			GPIO_TIM4_CH2IN_2
+#define PWMIN_TIMER                  4
+#define PWMIN_TIMER_CHANNEL          2
+#define GPIO_PWM_IN                  GPIO_TIM4_CH2IN_2
 
-#define GPIO_RSSI_IN 			(GPIO_INPUT|GPIO_PULLUP|GPIO_PORTC|GPIO_PIN1)
-#define GPIO_LED_SAFETY			(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN3)
-#define GPIO_BTN_SAFETY			(GPIO_INPUT|GPIO_PULLUP|GPIO_PORTC|GPIO_PIN4)
-#define GPIO_PERIPH_3V3_EN		(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN5)
+#define GPIO_RSSI_IN                 (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTC|GPIO_PIN1)
+#define GPIO_LED_SAFETY              (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN3)
+#define GPIO_BTN_SAFETY              (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTC|GPIO_PIN4)
+#define GPIO_PERIPH_3V3_EN           (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN5)
 /* for R12, this signal is active high */
-#define GPIO_SBUS_INV			(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN13)
+#define GPIO_SBUS_INV                (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN13)
 #define INVERT_RC_INPUT(_invert_true) px4_arch_gpiowrite(GPIO_SBUS_INV, _invert_true)
 
-#define GPIO_8266_GPIO0			(GPIO_INPUT|GPIO_PULLUP|GPIO_PORTE|GPIO_PIN2)
-#define GPIO_SPEKTRUM_PWR_EN		(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTE|GPIO_PIN4)
-#define GPIO_8266_PD			(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTE|GPIO_PIN5)
-#define GPIO_8266_RST			(GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTE|GPIO_PIN6)
+#define GPIO_SPEKTRUM_PWR_EN         (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTE|GPIO_PIN4)
+
+#define GPIO_8266_GPIO0              (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTE|GPIO_PIN2)
+#define GPIO_8266_PD                 (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTE|GPIO_PIN5)
+#define GPIO_8266_RST                (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTE|GPIO_PIN6)
 
 /* Power switch controls ******************************************************/
 
-#define SPEKTRUM_POWER(_on_true)    px4_arch_gpiowrite(GPIO_SPEKTRUM_PWR_EN, (!_on_true))
+#define SPEKTRUM_POWER(_on_true)     px4_arch_gpiowrite(GPIO_SPEKTRUM_PWR_EN, (!_on_true))
 
 /*
  * FMUv4 has separate RC_IN
@@ -290,24 +294,24 @@
  * The FMU can drive  GPIO PPM_IN as an output
  */
 
-#define GPIO_PPM_IN_AS_OUT             (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTB|GPIO_PIN0)
-#define SPEKTRUM_RX_AS_GPIO_OUTPUT()   px4_arch_configgpio(GPIO_PPM_IN_AS_OUT)
-#define SPEKTRUM_RX_AS_UART()          /* Can be left as uart */
-#define SPEKTRUM_OUT(_one_true)        px4_arch_gpiowrite(GPIO_PPM_IN_AS_OUT, (_one_true))
+#define GPIO_PPM_IN_AS_OUT           (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTB|GPIO_PIN0)
+#define SPEKTRUM_RX_AS_GPIO_OUTPUT() px4_arch_configgpio(GPIO_PPM_IN_AS_OUT)
+#define SPEKTRUM_RX_AS_UART()       /* Can be left as uart */
+#define SPEKTRUM_OUT(_one_true)      px4_arch_gpiowrite(GPIO_PPM_IN_AS_OUT, (_one_true))
 
-#define	BOARD_NAME "PX4FMU_V4"
+#define    BOARD_NAME "PX4FMU_V4"
 
 /* By Providing BOARD_ADC_USB_CONNECTED (using the px4_arch abstraction)
  * this board support the ADC system_power interface, and therefore
  * provides the true logic GPIO BOARD_ADC_xxxx macros.
  */
-#define BOARD_ADC_USB_CONNECTED (px4_arch_gpioread(GPIO_OTGFS_VBUS))
-#define BOARD_ADC_BRICK_VALID   (px4_arch_gpioread(GPIO_VDD_BRICK_VALID))
-#define BOARD_ADC_SERVO_VALID   (1)
-#define BOARD_ADC_PERIPH_5V_OC  (0)
-#define BOARD_ADC_HIPOWER_5V_OC (0)
+#define BOARD_ADC_USB_CONNECTED      (px4_arch_gpioread(GPIO_OTGFS_VBUS))
+#define BOARD_ADC_BRICK_VALID        (px4_arch_gpioread(GPIO_VDD_BRICK_VALID))
+#define BOARD_ADC_SERVO_VALID        (1)
+#define BOARD_ADC_PERIPH_5V_OC       (0)
+#define BOARD_ADC_HIPOWER_5V_OC      (0)
 
-#define BOARD_HAS_PWM	DIRECT_PWM_OUTPUT_CHANNELS
+#define BOARD_HAS_PWM    DIRECT_PWM_OUTPUT_CHANNELS
 
 #define BOARD_FMU_GPIO_TAB { \
 		{GPIO_GPIO0_INPUT,       GPIO_GPIO0_OUTPUT,       0}, \
@@ -324,18 +328,18 @@
  *
  * There are no alternate functions on this board.
  */
-#define GPIO_SERVO_1           (1<<0)  /**< servo 1 output */
-#define GPIO_SERVO_2           (1<<1)  /**< servo 2 output */
-#define GPIO_SERVO_3           (1<<2)  /**< servo 3 output */
-#define GPIO_SERVO_4           (1<<3)  /**< servo 4 output */
-#define GPIO_SERVO_5           (1<<4)  /**< servo 5 output */
-#define GPIO_SERVO_6           (1<<5)  /**< servo 6 output */
+#define GPIO_SERVO_1                 (1<<0)  /**< servo 1 output */
+#define GPIO_SERVO_2                 (1<<1)  /**< servo 2 output */
+#define GPIO_SERVO_3                 (1<<2)  /**< servo 3 output */
+#define GPIO_SERVO_4                 (1<<3)  /**< servo 4 output */
+#define GPIO_SERVO_5                 (1<<4)  /**< servo 5 output */
+#define GPIO_SERVO_6                 (1<<5)  /**< servo 6 output */
 
-#define GPIO_3V3_SENSORS_EN    (1<<7)  /**< PE3 - VDD_3V3_SENSORS_EN */
-#define GPIO_BRICK_VALID       (1<<8)  /**< PB5 - !VDD_BRICK_VALID */
+#define GPIO_3V3_SENSORS_EN          (1<<7)  /**< PE3 - VDD_3V3_SENSORS_EN */
+#define GPIO_BRICK_VALID             (1<<8)  /**< PB5 - !VDD_BRICK_VALID */
 
 /* This board provides a DMA pool and APIs */
-#define BOARD_DMA_ALLOC_POOL_SIZE 5120
+#define BOARD_DMA_ALLOC_POOL_SIZE    5120
 
 __BEGIN_DECLS
 
@@ -359,9 +363,13 @@ __BEGIN_DECLS
  * Description:
  *   Called to configure SPI chip select GPIO pins for the PX4FMU board.
  *
+ *   mask - is bus selection
+ *   1 - 1 << 0
+ *   2 - 1 << 1
+ *
  ****************************************************************************************************/
 
-extern void stm32_spiinitialize(void);
+extern void stm32_spiinitialize(int mask);
 void board_spi_reset(int ms);
 
 extern void stm32_usbinitialize(void);

--- a/src/drivers/boards/px4fmu-v4/px4fmu_init.c
+++ b/src/drivers/boards/px4fmu-v4/px4fmu_init.c
@@ -165,6 +165,18 @@ __EXPORT void board_peripheral_reset(int ms)
 __EXPORT void
 stm32_boardinitialize(void)
 {
+	/* configure the GPIO pins to outputs and keep them low */
+	stm32_configgpio(GPIO_GPIO0_OUTPUT);
+	stm32_configgpio(GPIO_GPIO1_OUTPUT);
+	stm32_configgpio(GPIO_GPIO2_OUTPUT);
+	stm32_configgpio(GPIO_GPIO3_OUTPUT);
+	stm32_configgpio(GPIO_GPIO4_OUTPUT);
+	stm32_configgpio(GPIO_GPIO5_OUTPUT);
+
+	/* configure LEDs */
+	board_autoled_initialize();
+
+
 	/* configure ADC pins */
 	stm32_configgpio(GPIO_ADC1_IN2);	/* BATT_VOLTAGE_SENS */
 	stm32_configgpio(GPIO_ADC1_IN3);	/* BATT_CURRENT_SENS */
@@ -175,26 +187,28 @@ stm32_boardinitialize(void)
 	stm32_configgpio(GPIO_PERIPH_3V3_EN);
 	stm32_configgpio(GPIO_VDD_BRICK_VALID);
 
+	/* Start with Sensor voltage off We will enable it
+	 * in board_app_initialize
+	 */
+	stm32_configgpio(GPIO_VDD_3V3_SENSORS_EN);
+
 	stm32_configgpio(GPIO_SBUS_INV);
-	stm32_configgpio(GPIO_8266_GPIO0);
 	stm32_configgpio(GPIO_SPEKTRUM_PWR_EN);
+
+	stm32_configgpio(GPIO_8266_GPIO0);
 	stm32_configgpio(GPIO_8266_PD);
 	stm32_configgpio(GPIO_8266_RST);
+
+	/* Safety - led don in led driver */
+
 	stm32_configgpio(GPIO_BTN_SAFETY);
+	stm32_configgpio(GPIO_RSSI_IN);
+	stm32_configgpio(GPIO_PPM_IN);
 
-	/* configure the GPIO pins to outputs and keep them low */
-	stm32_configgpio(GPIO_GPIO0_OUTPUT);
-	stm32_configgpio(GPIO_GPIO1_OUTPUT);
-	stm32_configgpio(GPIO_GPIO2_OUTPUT);
-	stm32_configgpio(GPIO_GPIO3_OUTPUT);
-	stm32_configgpio(GPIO_GPIO4_OUTPUT);
-	stm32_configgpio(GPIO_GPIO5_OUTPUT);
+	/* configure SPI all interfaces GPIO */
 
-	/* configure SPI interfaces */
-	stm32_spiinitialize();
+	stm32_spiinitialize(PX4_SPI_BUS_RAMTRON | PX4_SPI_BUS_SENSORS);
 
-	/* configure LEDs */
-	board_autoled_initialize();
 }
 
 /****************************************************************************
@@ -414,6 +428,10 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	led_off(LED_GREEN);
 	led_off(LED_BLUE);
 
+	/* Power up there sensors */
+
+	stm32_gpiowrite(GPIO_VDD_3V3_SENSORS_EN, 1);
+
 	/* Configure SPI-based devices */
 
 	spi1 = stm32_spibus_initialize(1);
@@ -423,6 +441,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 		board_autoled_on(LED_RED);
 		return -ENODEV;
 	}
+
 
 	/* Default SPI1 to 1MHz and de-assert the known chip selects. */
 	SPI_SETFREQUENCY(spi1, 10000000);

--- a/src/drivers/boards/px4fmu-v4/px4fmu_spi.c
+++ b/src/drivers/boards/px4fmu-v4/px4fmu_spi.c
@@ -66,39 +66,35 @@
  *
  * Description:
  *   Called to configure SPI chip select GPIO pins for the PX4FMU board.
+ *   mask - is bus selection
+ *   1 - 1 << 0
+ *   2 - 1 << 1
  *
  ************************************************************************************/
 
-__EXPORT void stm32_spiinitialize(void)
+__EXPORT void stm32_spiinitialize(int mask)
 {
 #ifdef CONFIG_STM32_SPI1
-	px4_arch_configgpio(GPIO_SPI_CS_MPU9250);
-	px4_arch_configgpio(GPIO_SPI_CS_HMC5983);
-	px4_arch_configgpio(GPIO_SPI_CS_MS5611);
-	px4_arch_configgpio(GPIO_SPI_CS_ICM_2060X);
-	px4_arch_configgpio(GPIO_SPI1_CS_PORTC_PIN2);   //BMI160
-	px4_arch_configgpio(GPIO_SPI1_CS_PORTC_PIN15);  //BMI055 ACC
-	px4_arch_configgpio(GPIO_SPI1_CS_PORTE_PIN15);  //BMI055 GYRO
 
-	/* De-activate all peripherals,
-	 * required for some peripheral
-	 * state machines
-	 */
-	px4_arch_gpiowrite(GPIO_SPI_CS_MPU9250, 1);
-	px4_arch_gpiowrite(GPIO_SPI_CS_HMC5983, 1);
-	px4_arch_gpiowrite(GPIO_SPI_CS_MS5611, 1);
-	px4_arch_gpiowrite(GPIO_SPI_CS_ICM_2060X, 1);
-	px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN2, 1);
-	px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN15, 1);
-	px4_arch_gpiowrite(GPIO_SPI1_CS_PORTE_PIN15, 1);
+	if (mask & PX4_SPI_BUS_SENSORS) {
+		stm32_configgpio(GPIO_SPI1_CS_PORTC_PIN2);
+		stm32_configgpio(GPIO_SPI1_CS_PORTC_PIN15);
+		stm32_configgpio(GPIO_SPI1_CS_PORTE_PIN15);
 
-	px4_arch_configgpio(GPIO_DRDY_MPU9250);
-	px4_arch_configgpio(GPIO_DRDY_HMC5983);
-	px4_arch_configgpio(GPIO_DRDY_ICM_2060X);
+		stm32_configgpio(GPIO_DRDY_PORTD_PIN15);
+		stm32_configgpio(GPIO_DRDY_PORTC_PIN14);
+		stm32_configgpio(GPIO_DRDY_PORTE_PIN12);
+	}
+
 #endif
 
 #ifdef CONFIG_STM32_SPI2
-	stm32_configgpio(GPIO_SPI_CS_FRAM);
+
+	if (mask & (PX4_SPI_BUS_RAMTRON | PX4_SPI_BUS_BARO)) {
+		stm32_configgpio(GPIO_SPI2_CS_MS5611);
+		stm32_configgpio(GPIO_SPI2_CS_FRAM);
+	}
+
 #endif
 
 }
@@ -108,91 +104,37 @@ __EXPORT void stm32_spi1select(FAR struct spi_dev_s *dev, enum spi_dev_e devid, 
 	/* SPI select is active low, so write !selected to select the device */
 
 	switch (devid) {
+
+	/* Shared PC2 CS devices */
+
+	case PX4_SPIDEV_BMI:
+	case PX4_SPIDEV_MPU:
+		/* Making sure the other peripherals are not selected */
+		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN2,  !selected);
+		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN15, 1);
+		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTE_PIN15, 1);
+		break;
+
+	/* Shared PC15 CS devices */
+
 	case PX4_SPIDEV_ICM:
-
-	/* intended fallthrough */
 	case PX4_SPIDEV_ICM_20602:
-
-	/* intended fallthrough */
 	case PX4_SPIDEV_ICM_20608:
+	case PX4_SPIDEV_BMI055_ACC:
+		/* Making sure the other peripherals are not selected */
+		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN2, 1);
+		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN15, !selected);
+		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTE_PIN15, 1);
+		break;
+
+	/* Shared PE15 CS devices */
+
+	case PX4_SPIDEV_HMC:
+	case PX4_SPIDEV_BMI055_GYR:
 		/* Making sure the other peripherals are not selected */
 		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN2, 1);
 		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN15, 1);
-		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTE_PIN15, 1);
-		px4_arch_gpiowrite(GPIO_SPI_CS_MPU9250, 1);
-		px4_arch_gpiowrite(GPIO_SPI_CS_HMC5983, 1);
-		px4_arch_gpiowrite(GPIO_SPI_CS_MS5611, 1);
-		px4_arch_gpiowrite(GPIO_SPI_CS_ICM_2060X, !selected);
-		break;
-
-	case PX4_SPIDEV_ACCEL_MAG:
-		/* Making sure the other peripherals are not selected */
-		break;
-
-	case PX4_SPIDEV_BARO:
-		/* Making sure the other peripherals are not selected */
-		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN2, 1);     //BMI160
-		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN15, 1);    //BMI055 ACC
-		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTE_PIN15, 1);    //BMI055 GYRO
-		px4_arch_gpiowrite(GPIO_SPI_CS_MPU9250, 1);
-		px4_arch_gpiowrite(GPIO_SPI_CS_HMC5983, 1);
-		px4_arch_gpiowrite(GPIO_SPI_CS_MS5611, !selected);
-		px4_arch_gpiowrite(GPIO_SPI_CS_ICM_2060X, 1);
-		break;
-
-	case PX4_SPIDEV_HMC:
-		/* Making sure the other peripherals are not selected */
-		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN2, 1);     //BMI160
-		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN15, 1);    //BMI055 ACC
-		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTE_PIN15, 1);    //BMI055 GYRO
-		px4_arch_gpiowrite(GPIO_SPI_CS_MPU9250, 1);
-		px4_arch_gpiowrite(GPIO_SPI_CS_HMC5983, !selected);
-		px4_arch_gpiowrite(GPIO_SPI_CS_MS5611, 1);
-		px4_arch_gpiowrite(GPIO_SPI_CS_ICM_2060X, 1);
-		break;
-
-	case PX4_SPIDEV_MPU:
-		/* Making sure the other peripherals are not selected */
-		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN2, 1);     //BMI160
-		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN15, 1);    //BMI055 ACC
-		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTE_PIN15, 1);    //BMI055 GYRO
-		px4_arch_gpiowrite(GPIO_SPI_CS_MPU9250, !selected);
-		px4_arch_gpiowrite(GPIO_SPI_CS_HMC5983, 1);
-		px4_arch_gpiowrite(GPIO_SPI_CS_MS5611, 1);
-		px4_arch_gpiowrite(GPIO_SPI_CS_ICM_2060X, 1);
-		break;
-
-	case PX4_SPIDEV_BMI:
-		/* Making sure the other peripherals are not selected */
-		px4_arch_gpiowrite(GPIO_SPI_CS_MPU9250, 1);
-		px4_arch_gpiowrite(GPIO_SPI_CS_HMC5983, 1);
-		px4_arch_gpiowrite(GPIO_SPI_CS_MS5611, 1);
-		px4_arch_gpiowrite(GPIO_SPI_CS_ICM_2060X, 1);
-		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN15, 1);    //BMI055 ACC
-		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTE_PIN15, 1);    //BMI055 GYRO
-		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN2, !selected); //BMI160
-		break;
-
-	case PX4_SPIDEV_BMI055_ACC:
-		/* Making sure the other peripherals are not selected */
-		px4_arch_gpiowrite(GPIO_SPI_CS_MPU9250, 1);
-		px4_arch_gpiowrite(GPIO_SPI_CS_HMC5983, 1);
-		px4_arch_gpiowrite(GPIO_SPI_CS_MS5611, 1);
-		px4_arch_gpiowrite(GPIO_SPI_CS_ICM_2060X, 1);
-		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN2, 1);     //BMI160
-		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTE_PIN15, 1);    //BMI055 GYRO
-		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN15, !selected); //BMI055 ACC
-		break;
-
-	case PX4_SPIDEV_BMI055_GYR:
-		/* Making sure the other peripherals are not selected */
-		px4_arch_gpiowrite(GPIO_SPI_CS_MPU9250, 1);
-		px4_arch_gpiowrite(GPIO_SPI_CS_HMC5983, 1);
-		px4_arch_gpiowrite(GPIO_SPI_CS_MS5611, 1);
-		px4_arch_gpiowrite(GPIO_SPI_CS_ICM_2060X, 1);
-		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN2, 1);     //BMI160
-		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN15, 1);    //BMI055 ACC
-		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTE_PIN15, !selected);    //BMI055 GYRO
+		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTE_PIN15, !selected);
 		break;
 
 	default:
@@ -214,14 +156,14 @@ __EXPORT void stm32_spi2select(FAR struct spi_dev_s *dev, enum spi_dev_e devid, 
 	switch (devid) {
 	case SPIDEV_FLASH:
 		/* Making sure the other peripherals are not selected */
-		stm32_gpiowrite(GPIO_SPI_CS_MS5611, 1);
-		stm32_gpiowrite(GPIO_SPI_CS_FRAM, !selected);
+		stm32_gpiowrite(GPIO_SPI2_CS_MS5611, 1);
+		stm32_gpiowrite(GPIO_SPI2_CS_FRAM, !selected);
 		break;
 
 	case PX4_SPIDEV_BARO:
 		/* Making sure the other peripherals are not selected */
-		stm32_gpiowrite(GPIO_SPI_CS_FRAM, 1);
-		stm32_gpiowrite(GPIO_SPI_CS_MS5611, !selected);
+		stm32_gpiowrite(GPIO_SPI2_CS_FRAM, 1);
+		stm32_gpiowrite(GPIO_SPI2_CS_MS5611, !selected);
 		break;
 
 	default:
@@ -238,22 +180,27 @@ __EXPORT uint8_t stm32_spi2status(FAR struct spi_dev_s *dev, enum spi_dev_e devi
 
 __EXPORT void board_spi_reset(int ms)
 {
-	/* disable SPI bus */
-	px4_arch_configgpio(GPIO_SPI_CS_OFF_MPU9250);
-	px4_arch_configgpio(GPIO_SPI_CS_OFF_HMC5983);
-	px4_arch_configgpio(GPIO_SPI_CS_OFF_MS5611);
-	px4_arch_configgpio(GPIO_SPI_CS_OFF_ICM_2060X);
-	px4_arch_configgpio(GPIO_SPI_CS_OFF_BMI160);   // BMI160
-	px4_arch_configgpio(GPIO_SPI_CS_OFF_BMI055_ACC);  // BMI055 ACC
-	px4_arch_configgpio(GPIO_SPI_CS_OFF_BMI055_GYR);  // BMI055 GYRO
+	/* disable SPI bus 1  DRDY */
 
-	px4_arch_gpiowrite(GPIO_SPI_CS_OFF_MPU9250, 0);
-	px4_arch_gpiowrite(GPIO_SPI_CS_OFF_HMC5983, 0);
-	px4_arch_gpiowrite(GPIO_SPI_CS_OFF_MS5611, 0);
-	px4_arch_gpiowrite(GPIO_SPI_CS_OFF_ICM_2060X, 0);
-	px4_arch_gpiowrite(GPIO_SPI_CS_OFF_BMI160, 0);     // BMI160
-	px4_arch_gpiowrite(GPIO_SPI_CS_OFF_BMI055_ACC, 0);    // BMI055 ACC
-	px4_arch_gpiowrite(GPIO_SPI_CS_OFF_BMI055_GYR, 0);    // BMI055 GYRO
+	stm32_configgpio(GPIO_DRDY_OFF_PORTD_PIN15);
+	stm32_configgpio(GPIO_DRDY_OFF_PORTC_PIN14);
+	stm32_configgpio(GPIO_DRDY_OFF_PORTE_PIN12);
+
+	stm32_gpiowrite(GPIO_DRDY_OFF_PORTD_PIN15, 0);
+	stm32_gpiowrite(GPIO_DRDY_OFF_PORTC_PIN14, 0);
+	stm32_gpiowrite(GPIO_DRDY_OFF_PORTE_PIN12, 0);
+
+	/* disable SPI bus 1  CS */
+
+	stm32_configgpio(GPIO_SPI1_CS_OFF_PORTC_PIN2);
+	stm32_configgpio(GPIO_SPI1_CS_OFF_PORTC_PIN15);
+	stm32_configgpio(GPIO_SPI1_CS_OFF_PORTE_PIN15);
+
+	stm32_gpiowrite(GPIO_SPI1_CS_OFF_PORTC_PIN2, 0);
+	stm32_gpiowrite(GPIO_SPI1_CS_OFF_PORTC_PIN15, 0);
+	stm32_gpiowrite(GPIO_SPI1_CS_OFF_PORTE_PIN15, 0);
+
+	/* disable SPI bus 1*/
 
 	stm32_configgpio(GPIO_SPI1_SCK_OFF);
 	stm32_configgpio(GPIO_SPI1_MISO_OFF);
@@ -263,15 +210,14 @@ __EXPORT void board_spi_reset(int ms)
 	stm32_gpiowrite(GPIO_SPI1_MISO_OFF, 0);
 	stm32_gpiowrite(GPIO_SPI1_MOSI_OFF, 0);
 
-	stm32_configgpio(GPIO_DRDY_OFF_MPU9250);
-	stm32_configgpio(GPIO_DRDY_OFF_ICM_2060X);
 
-	stm32_gpiowrite(GPIO_DRDY_OFF_MPU9250, 0);
-	stm32_gpiowrite(GPIO_DRDY_OFF_ICM_2060X, 0);
+	/* N.B we do not have control over the SPI 2 buss powered devices
+	 * so the the ms5611 is not resetable.
+	 */
 
-	/* set the sensor rail off */
+
+	/* set the sensor rail off (default) */
 	stm32_configgpio(GPIO_VDD_3V3_SENSORS_EN);
-	stm32_gpiowrite(GPIO_VDD_3V3_SENSORS_EN, 0);
 
 	/* wait for the sensor rail to reach GND */
 	usleep(ms * 1000);
@@ -285,26 +231,10 @@ __EXPORT void board_spi_reset(int ms)
 	/* wait a bit before starting SPI, different times didn't influence results */
 	usleep(100);
 
-	/* reconfigure the SPI pins */
-#ifdef CONFIG_STM32_SPI1
-	px4_arch_configgpio(GPIO_SPI_CS_MPU9250);
-	px4_arch_configgpio(GPIO_SPI_CS_HMC5983);
-	px4_arch_configgpio(GPIO_SPI_CS_MS5611);
-	px4_arch_configgpio(GPIO_SPI_CS_ICM_2060X);
-	px4_arch_configgpio(GPIO_SPI1_CS_PORTC_PIN2);     //BMI160
-	px4_arch_configgpio(GPIO_SPI1_CS_PORTC_PIN15);    //BMI055 ACC
-	px4_arch_configgpio(GPIO_SPI1_CS_PORTE_PIN15);    //BMI055 GYRO
-
+	stm32_spiinitialize(PX4_SPI_BUS_SENSORS);
 	stm32_configgpio(GPIO_SPI1_SCK);
 	stm32_configgpio(GPIO_SPI1_MISO);
 	stm32_configgpio(GPIO_SPI1_MOSI);
 
-	// // XXX bring up the EXTI pins again
-	// stm32_configgpio(GPIO_GYRO_DRDY);
-	// stm32_configgpio(GPIO_MAG_DRDY);
-	// stm32_configgpio(GPIO_ACCEL_DRDY);
-	// stm32_configgpio(GPIO_EXTI_MPU_DRDY);
-
-#endif
 
 }


### PR DESCRIPTION
This is a clean up of the SPI chip select handling. It was very broken.  

When the MS5611 baro was moved to SPI2, the majority of the code was not refactored. The MS5611's CS was still being activated on SPI 1 and it was driven to enabled during sensor_reset on SPI1. 