### PR TITLE
MAVLink app: Do not rate-limit camera trigger feedback

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1412,9 +1412,9 @@ Mavlink::adjust_stream_rates(const float multiplier)
 		unsigned interval = stream->get_interval();
 		interval /= multiplier;
 
-		/* allow max ~2000 Hz */
-		if (interval < 1600) {
-			interval = 500;
+		/* allow max ~1000 Hz */
+		if (interval < 1000) {
+			interval = 1000;
 		}
 
 		/* set new interval */
@@ -2025,8 +2025,9 @@ Mavlink::task_main(int argc, char *argv[])
 		configure_stream("SYSTEM_TIME", 1.0f);
 		configure_stream("TIMESYNC", 10.0f);
 		configure_stream("CAMERA_CAPTURE", 2.0f);
-		//camera trigger is rate limited at the source, do not limit here
-		configure_stream("CAMERA_TRIGGER", 500.0f);
+		// camera trigger is not limited,
+		// 30 Hz is just an estimation for bandwidth required
+		configure_stream("CAMERA_TRIGGER", 30.0f);
 		configure_stream("CAMERA_IMAGE_CAPTURED", 5.0f);
 		configure_stream("ACTUATOR_CONTROL_TARGET0", 10.0f);
 		break;
@@ -2079,8 +2080,12 @@ Mavlink::task_main(int argc, char *argv[])
 		configure_stream("NAMED_VALUE_FLOAT", 50.0f);
 		configure_stream("VFR_HUD", 20.0f);
 		configure_stream("WIND_COV", 10.0f);
-		configure_stream("CAMERA_TRIGGER", 500.0f);
+		// camera trigger is not limited,
+		// 30 Hz is just an estimation for bandwidth required
+		configure_stream("CAMERA_TRIGGER", 30.0f);
 		configure_stream("CAMERA_IMAGE_CAPTURED", 5.0f);
+		configure_stream("CAMERA_TRIGGER", 30.0f);
+		configure_stream("MISSION_ITEM", 50.0f);
 		configure_stream("ACTUATOR_CONTROL_TARGET0", 30.0f);
 		configure_stream("MANUAL_CONTROL", 5.0f);
 		break;
@@ -2096,9 +2101,9 @@ Mavlink::task_main(int argc, char *argv[])
 	/* set main loop delay depending on data rate to minimize CPU overhead */
 	_main_loop_delay = (MAIN_LOOP_DELAY * 1000) / _datarate;
 
-	/* hard limit to 500 Hz at max */
-	if (_main_loop_delay < 2000) {
-		_main_loop_delay = 2000;
+	/* hard limit to ~800 Hz at max */
+	if (_main_loop_delay < 1250) {
+		_main_loop_delay = 1250;
 	}
 
 	/* hard limit to 100 Hz at least */

--- a/src/modules/mavlink/mavlink_stream.cpp
+++ b/src/modules/mavlink/mavlink_stream.cpp
@@ -98,15 +98,15 @@ MavlinkStream::update(const hrt_abstime t)
 
 	// send the message if it is due or
 	// if it will overrun the next scheduled send interval
-	// by 40% of the interval time. This helps to avoid
+	// by 10% of the interval time. This helps to avoid
 	// sending a scheduled message on average slower than
-	// scheduled. Doing this at 50% would risk sending
+	// scheduled. Doing this at more than 10% would risk sending
 	// the message too often as the loop runtime of the app
 	// needs to be accounted for as well.
 	// This method is not theoretically optimal but a suitable
 	// stopgap as it hits its deadlines well (0.5 Hz, 50 Hz and 250 Hz)
 
-	if (dt > (interval - (_mavlink->get_main_loop_delay() / 10) * 4)) {
+	if (dt > (interval - (_mavlink->get_main_loop_delay() / 10) * 1)) {
 		// interval expired, send message
 #ifndef __PX4_QURT
 		send(t);


### PR DESCRIPTION
This is important to ensure no camera trigger messages are being dropped.