### PR TITLE
UAVCAN Memory optimizations

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -196,6 +196,7 @@ then
 	set MAV_TYPE none
 	set FAILSAFE none
 	set USE_IO yes
+	set LOGGER_BUF 16
 
 	#
 	# Set USE_IO flag
@@ -738,6 +739,7 @@ then
 	then
 		if uavcan start
 		then
+			set LOGGER_BUF 7
 			uavcan start fw
 		else
 			tone_alarm ${TUNE_ERR}
@@ -875,9 +877,10 @@ then
 			then
 				set LOGGER_ARGS "-m mavlink"
 			fi
-			if logger start -b 16 -t ${LOGGER_ARGS}
+			if logger start -b ${LOGGER_BUF} -t ${LOGGER_ARGS}
 			then
 			fi
+			unset LOGGER_BUF
 			unset LOGGER_ARGS
 		fi
 	fi

--- a/src/modules/uavcan/uavcan_params.c
+++ b/src/modules/uavcan/uavcan_params.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2014 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2014-2017 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,8 +49,9 @@
  * @min 0
  * @max 3
  * @value 0 Disabled
- * @value 2 Sensors Enabled
+ * @value 2 Only Sensors
  * @value 3 Sensors and Motors
+ * @reboot_required true
  * @group UAVCAN
  */
 PARAM_DEFINE_INT32(UAVCAN_ENABLE, 0);
@@ -62,6 +63,7 @@ PARAM_DEFINE_INT32(UAVCAN_ENABLE, 0);
  *
  * @min 1
  * @max 125
+ * @reboot_required true
  * @group UAVCAN
  */
 PARAM_DEFINE_INT32(UAVCAN_NODE_ID, 1);
@@ -72,6 +74,7 @@ PARAM_DEFINE_INT32(UAVCAN_NODE_ID, 1);
  * @unit bit/s
  * @min 20000
  * @max 1000000
+ * @reboot_required true
  * @group UAVCAN
  */
 PARAM_DEFINE_INT32(UAVCAN_BITRATE, 1000000);


### PR DESCRIPTION
This should bring UAVCAN back to life - but not for a VTOL setup. For this V4 or V5 hardware is advised.