### PR TITLE
Add loiter option to COM_OBL_RC_ACT

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -345,7 +345,7 @@ PARAM_DEFINE_INT32(COM_OBL_ACT, 0);
  * @value 2 Manual
  * @value 3 Return to Land
  * @value 4 Land at current position
- * @value 5 Loter
+ * @value 5 Loiter
  * @group Mission
  */
 PARAM_DEFINE_INT32(COM_OBL_RC_ACT, 0);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -345,7 +345,8 @@ PARAM_DEFINE_INT32(COM_OBL_ACT, 0);
  * @value 2 Manual
  * @value 3 Return to Land
  * @value 4 Land at current position
- *
+ * @value 5 Loter
+ * @
  * @group Mission
  */
 PARAM_DEFINE_INT32(COM_OBL_RC_ACT, 0);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -346,7 +346,6 @@ PARAM_DEFINE_INT32(COM_OBL_ACT, 0);
  * @value 3 Return to Land
  * @value 4 Land at current position
  * @value 5 Loter
- * @
  * @group Mission
  */
 PARAM_DEFINE_INT32(COM_OBL_RC_ACT, 0);

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -874,6 +874,9 @@ bool set_nav_state(struct vehicle_status_s *status,
 				} else if (offb_loss_rc_act == 4 && status_flags->condition_global_position_valid) {
 					status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;
 
+				} else if (offb_loss_rc_act == 5 && status_flags->condition_global_position_valid) {
+					status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER;
+
 				} else if (status_flags->condition_local_altitude_valid) {
 					status->nav_state = vehicle_status_s::NAVIGATION_STATE_DESCEND;
 


### PR DESCRIPTION
COM_OBL_ACT has a loiter option but COM_OBL_RC_ACT does not.  I would really like to have the loiter option in COM_OBL_RC_ACT since it works better than ALTCTRL as a quick layover between sequential offboard control paths.  When moving quickly ALTCTRL just keeps going because of momentum which can crash into things.  Loiter on the other hand safely stops the drone, but isn't as drastic as landing or RTL options.