### PR TITLE
Get ligit Nuttx Version info from git

### DIFF
--- a/Tools/px_update_git_header.py
+++ b/Tools/px_update_git_header.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import sys
 import subprocess
+import re
 
 filename = sys.argv[1]
 
@@ -16,6 +17,11 @@ git_tag = subprocess.check_output('git describe --always --tags'.split(),
                                   stderr=subprocess.STDOUT).decode('utf-8').strip()
 git_version = subprocess.check_output('git rev-parse --verify HEAD'.split(),
                                       stderr=subprocess.STDOUT).decode('utf-8').strip()
+nuttx_git_tag = subprocess.check_output('git describe --always --tags'.split(),
+                                  cwd='NuttX/nuttx', stderr=subprocess.STDOUT).decode('utf-8').strip().replace("nuttx-","v")
+nuttx_git_tag = re.sub('-.*','.0',nuttx_git_tag)
+nuttx_git_version = subprocess.check_output('git rev-parse --verify HEAD'.split(),
+                                      cwd='NuttX/nuttx', stderr=subprocess.STDOUT).decode('utf-8').strip()
 git_version_short = git_version[0:16]
 
 # Generate the header file content
@@ -26,9 +32,13 @@ header = """
 #define PX4_GIT_VERSION_STR  "{git_version}"
 #define PX4_GIT_VERSION_BINARY 0x{git_version_short}
 #define PX4_GIT_TAG_STR  "{git_tag}"
+#define NUTTX_GIT_VERSION_STR  "{nuttx_git_version}"
+#define NUTTX_GIT_TAG_STR  "{nuttx_git_tag}"
 """.format(git_tag=git_tag,
            git_version=git_version,
-           git_version_short=git_version_short)
+           git_version_short=git_version_short,
+           nuttx_git_version=nuttx_git_version,
+           nuttx_git_tag=nuttx_git_tag)
 
 if old_header != header:
     print('Updating header {}'.format(sys.argv[1]))

--- a/src/lib/version/version.c
+++ b/src/lib/version/version.c
@@ -83,13 +83,17 @@ static uint32_t version_tag_to_number(const char *tag)
 
 		if (tag[i] >= '0' && tag[i] <= '9') {
 			if (mag < 32) {
-				unsigned number = tag[i] - '0';
+				char number = tag[i] - '0';
 
 				ver += (number << mag);
-				mag += 8;
+				mag += 4;
 			}
 
 		} else if (tag[i] == '.') {
+			if (mag % 8) {
+				mag += 4;
+			}
+
 			continue;
 
 		} else if (i > 3 && type == -1) {

--- a/src/lib/version/version.c
+++ b/src/lib/version/version.c
@@ -190,7 +190,7 @@ uint32_t px4_os_version(void)
 #elif defined(__PX4_QURT)
 	return 0; //TODO: implement version for QuRT
 #elif defined(__PX4_NUTTX)
-	return version_tag_to_number("v7.18.0"); //TODO: get correct version
+	return version_tag_to_number(NUTTX_GIT_TAG_STR);
 #else
 # error "px4_os_version not implemented for current OS"
 #endif
@@ -199,7 +199,7 @@ uint32_t px4_os_version(void)
 const char *px4_os_version_string(void)
 {
 #if defined(__PX4_NUTTX)
-	return NULL; //TODO: get NuttX git tag as string
+	return NUTTX_GIT_VERSION_STR;
 #else
 	return NULL;
 #endif

--- a/src/systemcmds/ver/ver.c
+++ b/src/systemcmds/ver/ver.c
@@ -128,10 +128,10 @@ int ver_main(int argc, char *argv[])
 				unsigned type = (fwver >> (8 * 0)) & 0xFF;
 
 				if (type == 255) {
-					printf("FW version: Release %u.%u.%u (%u)\n", major, minor, patch, fwver);
+					printf("FW version: Release %x.%x.%x (%u)\n", major, minor, patch, fwver);
 
 				} else {
-					printf("FW version: %u.%u.%u %u (%u)\n", major, minor, patch, type, fwver);
+					printf("FW version: %x.%x.%x %x (%u)\n", major, minor, patch, type, fwver);
 				}
 
 
@@ -143,10 +143,10 @@ int ver_main(int argc, char *argv[])
 				printf("OS: %s\n", px4_os_name());
 
 				if (type == 255) {
-					printf("OS version: Release %u.%u.%u (%u)\n", major, minor, patch, fwver);
+					printf("OS version: Release %x.%x.%x (%u)\n", major, minor, patch, fwver);
 
 				} else {
-					printf("OS version: %u.%u.%u %u (%u)\n", major, minor, patch, type, fwver);
+					printf("OS version: %x.%x.%x %x (%u)\n", major, minor, patch, type, fwver);
 				}
 
 				const char *os_git_hash = px4_os_version_string();


### PR DESCRIPTION
Nuttx version was incorrect. We would have found this on release 1.10.0 of PX4 :)
Parser now can parse v99.99.99  and return the correct values.

was:
```
nsh> ver all
HW arch: PX4FMU_V4
FW git-hash: 00efbc804973f7f257869b19de3564d251cd62f5
FW version: 1.6.0 0 (17170432)
OS: NuttX
OS version: Release 1.8.0 (17301759)
Build datetime: May  2 2017 11:48:44
Build uri: localhost
Toolchain: GNU GCC, 5.4.1 20160609 (release) [ARM/embedded-5-branch revision 237715]
MFGUID: 303833363335510d00320041
MCU: STM32F42x, rev. 3
UID: 320041:3335510D:30383336
```
is:
```
nsh>  ver all
HW arch: PX4FMU_V4
FW git-hash: 00efbc804973f7f257869b19de3564d251cd62f5
FW version: 1.6.0 0 (17170432)
OS: NuttX
OS version: Release 7.18.0 (119013631)
OS git-hash: 8b81cf5c7ece0c228eaaea3e9d8e667fc4d21a06
Build datetime: May  2 2017 16:41:33
Build uri: localhost
Toolchain: GNU GCC, 5.4.1 20160609 (release) [ARM/embedded-5-branch revision 237715]
MFGUID: 303833363335510d00320041
MCU: STM32F42x, rev. 3
UID: 320041:3335510D:30383336
```