### PR TITLE
use current local position for land and not GPS -> e.g. flow

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -755,9 +755,9 @@ MulticopterPositionControl::poll_subscriptions()
 	if (updated) {
 		orb_copy(ORB_ID(position_setpoint_triplet), _pos_sp_triplet_sub, &_pos_sp_triplet);
 
-		//Make sure that the position setpoint is valid
-		if (!PX4_ISFINITE(_pos_sp_triplet.current.lat) ||
-		    !PX4_ISFINITE(_pos_sp_triplet.current.lon) ||
+		//set current position setpoint invalid if none of them (lat, lon and alt) is finite
+		if (!PX4_ISFINITE(_pos_sp_triplet.current.lat) &&
+		    !PX4_ISFINITE(_pos_sp_triplet.current.lon) &&
 		    !PX4_ISFINITE(_pos_sp_triplet.current.alt)) {
 			_pos_sp_triplet.current.valid = false;
 		}
@@ -1384,11 +1384,26 @@ void MulticopterPositionControl::control_auto(float dt)
 
 	if (_pos_sp_triplet.current.valid) {
 
-		/* project setpoint to local frame */
-		map_projection_project(&_ref_pos,
-				       _pos_sp_triplet.current.lat, _pos_sp_triplet.current.lon,
-				       &_curr_pos_sp.data[0], &_curr_pos_sp.data[1]);
-		_curr_pos_sp(2) = -(_pos_sp_triplet.current.alt - _ref_alt);
+		//only project setpoints if they are finite, else use current position
+		if (PX4_ISFINITE(_pos_sp_triplet.current.lat) &&
+		    PX4_ISFINITE(_pos_sp_triplet.current.lon)) {
+			/* project setpoint to local frame */
+			map_projection_project(&_ref_pos,
+					       _pos_sp_triplet.current.lat, _pos_sp_triplet.current.lon,
+					       &_curr_pos_sp.data[0], &_curr_pos_sp.data[1]);
+
+		} else {
+			_curr_pos_sp(0) = _pos(0);
+			_curr_pos_sp(1) = _pos(1);
+		}
+
+		//only project setpoints if they are finite, else use current position
+		if (PX4_ISFINITE(_pos_sp_triplet.current.alt)) {
+			_curr_pos_sp(2) = -(_pos_sp_triplet.current.alt - _ref_alt);
+
+		} else {
+			_curr_pos_sp(2) = _pos(2);
+		}
 
 		if (PX4_ISFINITE(_curr_pos_sp(0)) &&
 		    PX4_ISFINITE(_curr_pos_sp(1)) &&

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -699,8 +699,8 @@ MissionBlock::set_land_item(struct mission_item_s *item, bool at_current_locatio
 
 	/* use current position */
 	if (at_current_location) {
-		item->lat = _navigator->get_global_position()->lat;
-		item->lon = _navigator->get_global_position()->lon;
+		item->lat = NAN; //descend at current position
+		item->lon = NAN; //descend at current position
 		item->yaw = _navigator->get_local_position()->yaw;
 
 	} else {


### PR DESCRIPTION
@Stifael here are the changes as discussed.

When executing land in the old implementation using only flow, the quad used the origin as the setpoint because lat/lon were 0.