### PR TITLE
fix qgc flow takeoff -> use min takeoff alt if no home position

### DIFF
--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -104,10 +104,17 @@ Takeoff::set_takeoff_position()
 
 	float abs_altitude = 0.0f;
 
-	const float min_abs_altitude = _navigator->get_home_position()->alt + _param_min_alt.get();
+	float min_abs_altitude;
 
-	// Use altitude if it has been set.
-	if (rep->current.valid && PX4_ISFINITE(rep->current.alt)) {
+	if (_navigator->home_position_valid()) { //only use home position if it is valid
+		min_abs_altitude = _navigator->get_global_position()->alt + _param_min_alt.get();
+
+	} else { //e.g. flow
+		min_abs_altitude = _param_min_alt.get();
+	}
+
+	// Use altitude if it has been set. If home position is invalid use min_abs_altitude
+	if (rep->current.valid && PX4_ISFINITE(rep->current.alt) && _navigator->home_position_valid()) {
 		abs_altitude = rep->current.alt;
 
 		// If the altitude suggestion is lower than home + minimum clearance, raise it and complain.


### PR DESCRIPTION
This fixes flow takeoff with QGC. For GPS, it still works the same way.
If using `commander takeoff` in the shell `param7` is NAN. But when using QGC `param7` is the absolute altitude (~490m). https://github.com/PX4/Firmware/blob/981dac8e955b3a4194421605dda7a09b7c16bbc5/src/modules/navigator/navigator_main.cpp#L458 
So this is valid, but `ref_alt` https://github.com/PX4/Firmware/blob/29795fa95fb07c7e383e73cb725aec60fb88d948/src/modules/mc_pos_control/mc_pos_control_main.cpp#L1428 is zero...
The fix is now to use the minimum takeoff altitude if there is no home position/gps.