### PR TITLE
Mavlink threadding fixes

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -49,10 +49,10 @@
 //#define MAVLINK_FTP_DEBUG
 
 MavlinkFTP::MavlinkFTP(Mavlink *mavlink) :
-	MavlinkStream(mavlink),
 	_session_info{},
 	_utRcvMsgFunc{},
-	_worker_data{}
+	_worker_data{},
+	_mavlink(mavlink)
 {
 	// initialize session
 	_session_info.fd = -1;
@@ -61,18 +61,6 @@ MavlinkFTP::MavlinkFTP(Mavlink *mavlink) :
 MavlinkFTP::~MavlinkFTP()
 {
 
-}
-
-const char *
-MavlinkFTP::get_name() const
-{
-	return "MAVLINK_FTP";
-}
-
-uint16_t
-MavlinkFTP::get_id()
-{
-	return MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL;
 }
 
 unsigned
@@ -84,12 +72,6 @@ MavlinkFTP::get_size()
 	} else {
 		return 0;
 	}
-}
-
-MavlinkStream *
-MavlinkFTP::new_instance(Mavlink *mavlink)
-{
-	return new MavlinkFTP(mavlink);
 }
 
 #ifdef MAVLINK_FTP_UNIT_TEST

--- a/src/modules/mavlink/mavlink_log_handler.cpp
+++ b/src/modules/mavlink/mavlink_log_handler.cpp
@@ -80,16 +80,9 @@ stat_file(const char *file, time_t *date = nullptr, uint32_t *size = nullptr)
 }
 
 //-------------------------------------------------------------------
-MavlinkLogHandler *
-MavlinkLogHandler::new_instance(Mavlink *mavlink)
-{
-	return new MavlinkLogHandler(mavlink);
-}
-
-//-------------------------------------------------------------------
 MavlinkLogHandler::MavlinkLogHandler(Mavlink *mavlink)
-	: MavlinkStream(mavlink)
-	, _pLogHandlerHelper(nullptr)
+	: _pLogHandlerHelper(nullptr),
+	  _mavlink(mavlink)
 {
 
 }
@@ -115,20 +108,6 @@ MavlinkLogHandler::handle_message(const mavlink_message_t *msg)
 		_log_request_end(msg);
 		break;
 	}
-}
-
-//-------------------------------------------------------------------
-const char *
-MavlinkLogHandler::get_name() const
-{
-	return "MAVLINK_LOG_HANDLER";
-}
-
-//-------------------------------------------------------------------
-uint16_t
-MavlinkLogHandler::get_id()
-{
-	return MAVLINK_MSG_ID_LOG_ENTRY;
 }
 
 //-------------------------------------------------------------------

--- a/src/modules/mavlink/mavlink_log_handler.cpp
+++ b/src/modules/mavlink/mavlink_log_handler.cpp
@@ -133,7 +133,7 @@ void
 MavlinkLogHandler::send(const hrt_abstime /*t*/)
 {
 	//-- An arbitrary count of max bytes in one go (one of the two below but never both)
-#define MAX_BYTES_SEND 64 * 1024
+#define MAX_BYTES_SEND 256 * 1024
 	size_t count = 0;
 
 	//-- Log Entries

--- a/src/modules/mavlink/mavlink_log_handler.h
+++ b/src/modules/mavlink/mavlink_log_handler.h
@@ -42,7 +42,7 @@
 #include <stdio.h>
 #include <cstdbool>
 #include <v2.0/mavlink_types.h>
-#include "mavlink_stream.h"
+#include <drivers/drv_hrt.h>
 
 class Mavlink;
 
@@ -88,21 +88,21 @@ private:
 };
 
 // MAVLink LOG_* Message Handler
-class MavlinkLogHandler : public MavlinkStream
+class MavlinkLogHandler
 {
 public:
 	MavlinkLogHandler(Mavlink *mavlink);
 
-	static MavlinkLogHandler *new_instance(Mavlink *mavlink);
-
 	// Handle possible LOG message
 	void handle_message(const mavlink_message_t *msg);
 
-	// Overrides from MavlinkStream
-	const char     *get_name(void) const;
-	uint16_t        get_id(void);
-	unsigned        get_size(void);
-	void            send(const hrt_abstime t);
+	/**
+	 * Handle sending of messages. Call this regularly at a fixed frequency.
+	 * @param t current time
+	 */
+	void send(const hrt_abstime t);
+
+	unsigned get_size();
 
 private:
 	void _log_message(const mavlink_message_t *msg);
@@ -114,7 +114,6 @@ private:
 	size_t _log_send_listing();
 	size_t _log_send_data();
 
-private:
 	LogListHelper    *_pLogHandlerHelper;
-
+	Mavlink *_mavlink;
 };

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2061,7 +2061,6 @@ Mavlink::task_main(int argc, char *argv[])
 		configure_stream("WIND_COV", 10.0f);
 		configure_stream("CAMERA_TRIGGER", 500.0f);
 		configure_stream("CAMERA_IMAGE_CAPTURED", 5.0f);
-		configure_stream("MISSION_ITEM", 50.0f);
 		configure_stream("ACTUATOR_CONTROL_TARGET0", 30.0f);
 		configure_stream("MANUAL_CONTROL", 5.0f);
 		break;

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -65,10 +65,6 @@
 #include "mavlink_orb_subscription.h"
 #include "mavlink_stream.h"
 #include "mavlink_messages.h"
-#include "mavlink_mission.h"
-#include "mavlink_parameters.h"
-#include "mavlink_ftp.h"
-#include "mavlink_log_handler.h"
 #include "mavlink_shell.h"
 #include "mavlink_ulog.h"
 
@@ -480,10 +476,6 @@ private:
 	MavlinkOrbSubscription	*_subscriptions;
 	MavlinkStream		*_streams;
 
-	MavlinkMissionManager		*_mission_manager;
-	MavlinkParametersManager	*_parameters_manager;
-	MavlinkFTP			*_mavlink_ftp;
-	MavlinkLogHandler		*_mavlink_log_handler;
 	MavlinkShell			*_mavlink_shell;
 	MavlinkULog			*_mavlink_ulog;
 	volatile bool			_mavlink_ulog_stop_requested;

--- a/src/modules/mavlink/mavlink_mission.h
+++ b/src/modules/mavlink/mavlink_mission.h
@@ -46,7 +46,6 @@
 
 #include "mavlink_bridge_header.h"
 #include "mavlink_rate_limiter.h"
-#include "mavlink_stream.h"
 
 enum MAVLINK_WPM_STATES {
 	MAVLINK_WPM_STATE_IDLE = 0,
@@ -67,32 +66,20 @@ enum MAVLINK_WPM_CODES {
 #define MAVLINK_MISSION_PROTOCOL_TIMEOUT_DEFAULT 5000000    ///< Protocol communication action timeout in useconds
 #define MAVLINK_MISSION_RETRY_TIMEOUT_DEFAULT 500000        ///< Protocol communication retry timeout in useconds
 
-class MavlinkMissionManager : public MavlinkStream
+class Mavlink;
+
+class MavlinkMissionManager
 {
 public:
+	explicit MavlinkMissionManager(Mavlink *mavlink);
+
 	~MavlinkMissionManager();
 
-	const char *get_name() const
-	{
-		return MavlinkMissionManager::get_name_static();
-	}
-
-	static const char *get_name_static()
-	{
-		return "MISSION_ITEM";
-	}
-
-	uint16_t get_id()
-	{
-		return MAVLINK_MSG_ID_MISSION_ITEM;
-	}
-
-	static MavlinkStream *new_instance(Mavlink *mavlink)
-	{
-		return new MavlinkMissionManager(mavlink);
-	}
-
-	unsigned get_size();
+	/**
+	 * Handle sending of messages. Call this regularly at a fixed frequency.
+	 * @param t current time
+	 */
+	void send(const hrt_abstime t);
 
 	void handle_message(const mavlink_message_t *msg);
 
@@ -139,6 +126,8 @@ private:
 	MavlinkRateLimiter	_slow_rate_limiter;
 
 	bool _verbose;
+
+	Mavlink *_mavlink;
 
 	static constexpr unsigned int	FILESYSTEM_ERRCOUNT_NOTIFY_LIMIT =
 		2;	///< Error count limit before stopping to report FS errors
@@ -219,8 +208,4 @@ private:
 	int format_mavlink_mission_item(const struct mission_item_s *mission_item,
 					mavlink_mission_item_t *mavlink_mission_item);
 
-protected:
-	explicit MavlinkMissionManager(Mavlink *mavlink);
-
-	void send(const hrt_abstime t);
 };

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -49,7 +49,7 @@
 
 #define HASH_PARAM "_HASH_CHECK"
 
-MavlinkParametersManager::MavlinkParametersManager(Mavlink *mavlink) : MavlinkStream(mavlink),
+MavlinkParametersManager::MavlinkParametersManager(Mavlink *mavlink) :
 	_send_all_index(-1),
 	_uavcan_open_request_list(nullptr),
 	_uavcan_waiting_for_request_response(false),
@@ -57,7 +57,8 @@ MavlinkParametersManager::MavlinkParametersManager(Mavlink *mavlink) : MavlinkSt
 	_rc_param_map_pub(nullptr),
 	_rc_param_map(),
 	_uavcan_parameter_request_pub(nullptr),
-	_uavcan_parameter_value_sub(-1)
+	_uavcan_parameter_value_sub(-1),
+	_mavlink(mavlink)
 {
 }
 MavlinkParametersManager::~MavlinkParametersManager()
@@ -75,12 +76,6 @@ unsigned
 MavlinkParametersManager::get_size()
 {
 	return MAVLINK_MSG_ID_PARAM_VALUE_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
-}
-
-unsigned
-MavlinkParametersManager::get_size_avg()
-{
-	return 0;
 }
 
 void

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -314,15 +314,19 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 void
 MavlinkParametersManager::send(const hrt_abstime t)
 {
+	int max_num_to_send;
+
 	if (_mavlink->get_protocol() == SERIAL && !_mavlink->is_usb_uart()) {
-		send_one();
+		max_num_to_send = 3;
 
 	} else {
-		// speed up parameter loading via UDP, TCP or USB: try to send 5 at once
-		int i = 0;
-
-		while (i++ < 5 && send_one());
+		// speed up parameter loading via UDP, TCP or USB: try to send 15 at once
+		max_num_to_send = 5 * 3;
 	}
+
+	int i = 0;
+
+	while (i++ < max_num_to_send && send_one());
 }
 
 

--- a/src/modules/mavlink/mavlink_parameters.h
+++ b/src/modules/mavlink/mavlink_parameters.h
@@ -44,37 +44,26 @@
 #include <systemlib/param/param.h>
 
 #include "mavlink_bridge_header.h"
-#include "mavlink_stream.h"
 #include <uORB/uORB.h>
 #include <uORB/topics/rc_parameter_map.h>
 #include <uORB/topics/uavcan_parameter_request.h>
+#include <drivers/drv_hrt.h>
 
-class MavlinkParametersManager : public MavlinkStream
+class Mavlink;
+
+class MavlinkParametersManager
 {
 public:
-	const char *get_name() const
-	{
-		return MavlinkParametersManager::get_name_static();
-	}
+	explicit MavlinkParametersManager(Mavlink *mavlink);
+	~MavlinkParametersManager();
 
-	static const char *get_name_static()
-	{
-		return "PARAM_VALUE";
-	}
-
-	uint16_t get_id()
-	{
-		return MAVLINK_MSG_ID_PARAM_VALUE;
-	}
-
-	static MavlinkStream *new_instance(Mavlink *mavlink)
-	{
-		return new MavlinkParametersManager(mavlink);
-	}
+	/**
+	 * Handle sending of messages. Call this regularly at a fixed frequency.
+	 * @param t current time
+	 */
+	void send(const hrt_abstime t);
 
 	unsigned get_size();
-
-	unsigned get_size_avg();
 
 	void handle_message(const mavlink_message_t *msg);
 
@@ -86,11 +75,6 @@ private:
 	MavlinkParametersManager &operator = (const MavlinkParametersManager &);
 
 protected:
-	explicit MavlinkParametersManager(Mavlink *mavlink);
-	~MavlinkParametersManager();
-
-	void send(const hrt_abstime t);
-
 	/// send a single param if a PARAM_REQUEST_LIST is in progress
 	/// @return true if a parameter was sent
 	bool send_one();
@@ -119,4 +103,6 @@ protected:
 
 	orb_advert_t _uavcan_parameter_request_pub;
 	int _uavcan_parameter_value_sub;
+
+	Mavlink *_mavlink;
 };

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2493,6 +2493,11 @@ void *MavlinkReceiver::start_helper(void *context)
 
 	MavlinkReceiver *rcv = new MavlinkReceiver((Mavlink *)context);
 
+	if (!rcv) {
+		PX4_ERR("alloc failed");
+		return nullptr;
+	}
+
 	void *ret = rcv->receive_thread(nullptr);
 
 	delete rcv;

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -100,13 +100,6 @@ public:
 	~MavlinkReceiver();
 
 	/**
-	* Start the mavlink task.
-	 *
-	 * @return		OK on success.
-	 */
-	int		start();
-
-	/**
 	 * Display the mavlink status.
 	 */
 	void		print_status();

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -80,7 +80,10 @@
 #include <uORB/topics/collision_report.h>
 
 
+#include "mavlink_mission.h"
+#include "mavlink_parameters.h"
 #include "mavlink_ftp.h"
+#include "mavlink_log_handler.h"
 
 #define PX4_EPOCH_SECS 1234567890ULL
 
@@ -188,6 +191,12 @@ private:
 	bool	evaluate_target_ok(int command, int target_system, int target_component);
 
 	Mavlink	*_mavlink;
+
+	MavlinkMissionManager		_mission_manager;
+	MavlinkParametersManager	_parameters_manager;
+	MavlinkFTP			_mavlink_ftp;
+	MavlinkLogHandler		_mavlink_log_handler;
+
 	mavlink_status_t _status; ///< receiver status, used for mavlink_parse_char()
 	struct vehicle_local_position_s _hil_local_pos;
 	struct vehicle_land_detected_s _hil_land_detector;

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -111,6 +111,9 @@ public:
 	 */
 	void		print_status();
 
+	/**
+	 * Start the receiver thread
+	 */
 	static void receive_start(pthread_t *thread, Mavlink *parent);
 
 	static void *start_helper(void *context);
@@ -192,9 +195,9 @@ private:
 	bool	evaluate_target_ok(int command, int target_system, int target_component);
 
 	Mavlink	*_mavlink;
-	mavlink_status_t status;
-	struct vehicle_local_position_s hil_local_pos;
-	struct vehicle_land_detected_s hil_land_detector;
+	mavlink_status_t _status; ///< receiver status, used for mavlink_parse_char()
+	struct vehicle_local_position_s _hil_local_pos;
+	struct vehicle_land_detected_s _hil_land_detector;
 	struct vehicle_control_mode_s _control_mode;
 	orb_advert_t _global_pos_pub;
 	orb_advert_t _local_pos_pub;
@@ -257,7 +260,6 @@ private:
 	param_t _p_bat_crit_thr;
 	param_t _p_bat_low_thr;
 
-	/* do not allow copying this class */
-	MavlinkReceiver(const MavlinkReceiver &);
-	MavlinkReceiver operator=(const MavlinkReceiver &);
+	MavlinkReceiver(const MavlinkReceiver &) = delete;
+	MavlinkReceiver operator=(const MavlinkReceiver &) = delete;
 };

--- a/src/modules/mavlink/mavlink_stream.h
+++ b/src/modules/mavlink/mavlink_stream.h
@@ -44,7 +44,6 @@
 #include <drivers/drv_hrt.h>
 
 class Mavlink;
-class MavlinkStream;
 
 class MavlinkStream
 {

--- a/src/modules/mavlink/mavlink_stream.h
+++ b/src/modules/mavlink/mavlink_stream.h
@@ -98,7 +98,7 @@ public:
 
 protected:
 	Mavlink     *_mavlink;
-	unsigned int _interval;		//<<< if set to zero = unlimited rate
+	unsigned int _interval;		///< if set to zero = unlimited rate
 
 #ifndef __PX4_QURT
 	virtual void send(const hrt_abstime t) = 0;


### PR DESCRIPTION
This fixes point 5 from #7223 by moving the mavlink mission, param manager, ftp & log downloader into the receiver thread.

Tested on:
- SITL
- Pixracer, USB & WiFi
- Pixhawk with 3DR telemetry

Test cases & results:
- Param loading: pretty much the same observable behavior as before
- Large mission upload & download (ca. 400WP): transaction times are roughly the same before and after
- Log download: download speed is a bit faster now via USB, unchanged via telemetry (at 1.5KB/s, not that I think someone would actually do that :). Looking at the mavlink inspector, the attitude rate goes down to ~45Hz from 50Hz during download, which is expected. I get the same numbers on current master.

I also tested ULog streaming + log download in parallel via USB, and it works well, the attitude was still received with ~40Hz.

@lovettchris can you test if you still have FTP issues with this?
@ecmnet @tops4u can you test as well?