### PR TITLE
[WIP] replace for auto logic

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1021,6 +1021,9 @@ MulticopterPositionControl::set_manual_acceleration(matrix::Vector2f &stick_xy, 
 
 		if (jerk > _jerk_hor_max.get()) {
 			_acceleration_state_dependent_xy = _jerk_hor_max.get() * dt + _acceleration_state_dependent_xy;
+
+		} else {
+			_acceleration_state_dependent_xy = _acceleration_hor_max.get();
 		}
 
 		/* check if stop condition still true */
@@ -1182,11 +1185,13 @@ MulticopterPositionControl::control_manual(float dt)
 
 		/* check if we switch to pos_hold_engaged */
 		float vel_xy_mag = sqrtf(_vel(0) * _vel(0) + _vel(1) * _vel(1));
-		bool smooth_pos_transition = pos_hold_desired &&
+		bool smooth_pos_transition = pos_hold_desired
+					     && (fabsf(_acceleration_hor_max.get() - _acceleration_state_dependent_xy) < FLT_EPSILON) &&
 					     (_params.hold_max_xy < FLT_EPSILON || vel_xy_mag < _params.hold_max_xy);
 
 		/* during transition predict setpoint forward */
 		if (smooth_pos_transition) {
+
 			/* time to travel from current velocity to zero velocity */
 			float delta_t = sqrtf(_vel(0) * _vel(0) + _vel(1) * _vel(1)) / _acceleration_hor_max.get();
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1309,11 +1309,11 @@ MulticopterPositionControl::vel_sp_slewrate(float dt)
 
 	float acc_limit = _acceleration_hor_max.get();
 
-	/* deceleration but no direction change */
-	bool slow_deceleration = ((acc_xy * vel_xy) < 0.0f) && ((vel_sp_xy * vel_xy) > 0.0f);
+	/* deceleration but no direction change and not position control*/
+	bool slow_deceleration = ((acc_xy * vel_xy) < 0.0f) && ((vel_sp_xy * vel_xy) > 0.0f) && !_run_pos_control;
 
-	/* deceleration with direction change */
-	bool fast_deceleration = ((acc_xy * vel_xy) < 0.0f) && ((vel_sp_xy * vel_xy) <= 0.0f);
+	/* deceleration with direction change and not position control*/
+	bool fast_deceleration = ((acc_xy * vel_xy) < 0.0f) && ((vel_sp_xy * vel_xy) <= 0.0f) && !_run_pos_control;
 
 	if (slow_deceleration) {
 		acc_limit = _deceleration_hor_slow.get();

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1317,7 +1317,7 @@ MulticopterPositionControl::vel_sp_slewrate(float dt)
 		acc_limit = _acceleration_hor_manual.get();
 
 		/* get normalized direction */
-		matrix::Vector2f vel_sp_xy_norm = (vel_sp_xy.length() > 0.0f) ? vel_sp_xy.normalized() : vel_sp_xy_norm;
+		matrix::Vector2f vel_sp_xy_norm = (vel_sp_xy.length() > 0.0f) ? vel_sp_xy.normalized() : vel_sp_xy;
 		matrix::Vector2f vel_xy_norm = (vel_xy.length() > 0.0f) ? vel_xy.normalized() : vel_xy;
 
 		/* check if deceleration is required */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -2523,6 +2523,7 @@ MulticopterPositionControl::calculate_thrust_setpoint(float dt)
 	for (int i = 0; i < 3; ++i) {
 		if (!PX4_ISFINITE(thrust_sp(i))) {
 			warn_rate_limited("Thrust setpoint not finite");
+			break;
 		}
 	}
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -145,6 +145,7 @@ private:
 	control::BlockParamFloat _hold_dz; /**< deadzone around the center for the sticks when flying in position mode */
 	control::BlockParamFloat _acceleration_hor_max; /**< maximum velocity setpoint slewrate while decelerating */
 	control::BlockParamFloat _deceleration_hor_max; /**< maximum velocity setpoint slewrate while decelerating */
+	control::BlockParamFloat _deceleration_hor_slow; /**< slow velocity setpoint slewrate while decelerating */
 	control::BlockParamFloat _target_threshold_xy; /**< distance threshold for slowdown close to target during mission */
 	control::BlockParamFloat _velocity_hor_manual; /**< target velocity in manual controlled mode at full speed*/
 	control::BlockParamFloat _takeoff_ramp_time; /**< time contant for smooth takeoff ramp */
@@ -417,6 +418,7 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_hold_dz(this, "HOLD_DZ"),
 	_acceleration_hor_max(this, "ACC_HOR_MAX", true),
 	_deceleration_hor_max(this, "DEC_HOR_MAX", true),
+	_deceleration_hor_slow(this, "DEC_HOR_SLOW", true),
 	_target_threshold_xy(this, "TARGET_THRE"),
 	_velocity_hor_manual(this, "VEL_MAN_MAX", true),
 	_takeoff_ramp_time(this, "TKO_RAMP_T", true),
@@ -1300,26 +1302,40 @@ MulticopterPositionControl::control_offboard(float dt)
 void
 MulticopterPositionControl::vel_sp_slewrate(float dt)
 {
-	math::Vector<3> acc = (_vel_sp - _vel_sp_prev) / dt;
-	float acc_xy_mag = sqrtf(acc(0) * acc(0) + acc(1) * acc(1));
+	matrix::Vector2f vel_sp_xy(_vel_sp(0), _vel_sp(1));
+	matrix::Vector2f vel_sp_prev_xy(_vel_sp_prev(0), _vel_sp_prev(1));
+	matrix::Vector2f vel_xy(_vel(0), _vel(1));
+	matrix::Vector2f acc_xy = (vel_sp_xy - vel_sp_prev_xy) / dt;
 
 	float acc_limit = _acceleration_hor_max.get();
 
-	/* adapt slew rate if we are decelerating */
-	if (_vel * acc < 0) {
+	/* deceleration but no direction change */
+	bool slow_deceleration = ((vel_xy * acc_xy) < 0.0f) && ((vel_sp_xy * vel_xy) > 0.0f);
+
+	/* deceleration with direction change */
+	bool fast_deceleration = ((vel_xy * acc_xy) < 0.0f) && ((vel_sp_xy * vel_xy) <= 0.0f);
+
+	if (slow_deceleration) {
+		acc_limit = _deceleration_hor_slow.get();
+	}
+
+	if (fast_deceleration) {
 		acc_limit = _deceleration_hor_max.get();
 	}
 
 	/* limit total horizontal acceleration */
-	if (acc_xy_mag > acc_limit) {
-		_vel_sp(0) = acc_limit * acc(0) / acc_xy_mag * dt + _vel_sp_prev(0);
-		_vel_sp(1) = acc_limit * acc(1) / acc_xy_mag * dt + _vel_sp_prev(1);
+	if (acc_xy.length() > acc_limit) {
+		vel_sp_xy = acc_limit * acc_xy.normalized() * dt + vel_sp_prev_xy;
+		_vel_sp(0) = vel_sp_xy(0);
+		_vel_sp(1) = vel_sp_xy(1);
 	}
 
 	/* limit vertical acceleration */
-	float max_acc_z = acc(2) < 0.0f ? -_params.acc_up_max : _params.acc_down_max;
 
-	if (fabsf(acc(2)) > fabsf(max_acc_z)) {
+	float acc_z = (_vel_sp(2) - _vel_sp_prev(2)) / dt;
+	float max_acc_z = acc_z < 0.0f ? -_params.acc_up_max : _params.acc_down_max;
+
+	if (fabsf(acc_z) > fabsf(max_acc_z)) {
 		_vel_sp(2) = max_acc_z * dt + _vel_sp_prev(2);
 	}
 }

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -271,6 +271,7 @@ private:
 	struct map_projection_reference_s _ref_pos;
 	float _ref_alt;
 	hrt_abstime _ref_timestamp;
+	hrt_abstime _last_warn;
 
 	math::Vector<3> _thrust_int;
 	math::Vector<3> _pos;
@@ -389,6 +390,8 @@ private:
 	 */
 	void limit_altitude();
 
+	void warn_rate_limited(const char* str);
+
 	/**
 	 * Shim for calling task_main from task_create.
 	 */
@@ -463,6 +466,7 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_user_intention_z(brake),
 	_ref_alt(0.0f),
 	_ref_timestamp(0),
+	_last_warn(0),
 	_yaw(0.0f),
 	_yaw_takeoff(0.0f),
 	_vel_z_lp(0),
@@ -593,6 +597,16 @@ MulticopterPositionControl::~MulticopterPositionControl()
 	}
 
 	pos_control::g_control = nullptr;
+}
+
+void
+MulticopterPositionControl::warn_rate_limited(const char* string)
+{
+	hrt_abstime now = hrt_absolute_time();
+	if (now - _last_warn > 50000) {
+		PX4_WARN(string);
+		_last_warn = now;
+	}
 }
 
 int
@@ -1203,7 +1217,7 @@ MulticopterPositionControl::set_manual_acceleration_xy(matrix::Vector2f &stick_x
 		}
 
 	default :
-		PX4_WARN("User intention not recognized");
+		warn_rate_limited("User intention not recognized");
 		_acceleration_state_dependent_xy = _acceleration_hor_max.get();
 
 	}
@@ -1538,7 +1552,7 @@ MulticopterPositionControl::control_offboard(float dt)
 					_vel_sp(1) = sinf(_yaw) * _pos_sp_triplet.current.vx + cosf(_yaw) * _pos_sp_triplet.current.vy;
 
 				} else {
-					PX4_WARN("Unknown velocity offboard coordinate frame");
+					warn_rate_limited("Unknown velocity offboard coordinate frame");
 				}
 
 				_run_pos_control = false;
@@ -1995,7 +2009,7 @@ void MulticopterPositionControl::control_auto(float dt)
 		if (!(PX4_ISFINITE(_pos_sp(0)) && PX4_ISFINITE(_pos_sp(1)) &&
 		      PX4_ISFINITE(_pos_sp(2)))) {
 
-			PX4_WARN("Auto: Position setpoint not finite");
+			warn_rate_limited("Auto: Position setpoint not finite");
 			_pos_sp = _curr_pos_sp;
 		}
 
@@ -2163,7 +2177,7 @@ MulticopterPositionControl::calculate_velocity_setpoint(float dt)
 		} else {
 			_vel_sp(0) = 0.0f;
 			_vel_sp(1) = 0.0f;
-			PX4_WARN("Caught invalid pos_sp in x and y");
+			warn_rate_limited("Caught invalid pos_sp in x and y");
 
 		}
 	}
@@ -2176,7 +2190,7 @@ MulticopterPositionControl::calculate_velocity_setpoint(float dt)
 
 		} else {
 			_vel_sp(2) = 0.0f;
-			PX4_WARN("Caught invalid pos_sp in z");
+			warn_rate_limited("Caught invalid pos_sp in z");
 		}
 
 	}

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1931,8 +1931,8 @@ void MulticopterPositionControl::control_auto(float dt)
 						 * the velocity at target should be 1/5 * cruising speed;
 						 * angle = 2 -> vel_close = min_cruising_speed */
 
-						/* middle cruise speed is a number between maximum cruising speed and minimum cruising speed and corresponds to speed at angle = 1.0 */
-						float middle_cruise_speed = get_cruising_speed_xy() / 5.0f;
+						/* middle cruise speed is a number between maximum cruising speed and minimum cruising speed and corresponds to speed at angle = 1.0 = 90degrees */
+						float middle_cruise_speed = 1.0f;
 
 						/* make sure min cruise speed is always smaller than middle cruise speed but larger than 0*/
 						float min_cruise_speed = (_min_cruise_speed.get() < middle_cruise_speed) ? _min_cruise_speed.get() : middle_cruise_speed

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -135,9 +135,6 @@ private:
 	bool 		_in_takeoff = false; 				/**<true if takeoff ramp is applied */
 	bool 		_in_landing = false;				/**<true if landing descent (only used in auto) */
 	bool 		_lnd_reached_ground = false; 		/**<true if controller assumes the vehicle has reached the ground after landing */
-	bool 		_limit_vel_xy = false;				/**<true if velocity in xy should be farther limited */
-	bool 		_transition_to_non_manual = false;  /**<true if transition from manual to auto */
-
 
 	int		_control_task;			/**< task handle for task */
 	orb_advert_t	_mavlink_log_pub;		/**< mavlink log advert */
@@ -295,7 +292,6 @@ private:
 	math::Vector<3> _curr_pos_sp;  /**< current setpoint of the triplets */
 	math::Vector<3> _prev_pos_sp; /**< previous setpoint of the triples */
 	matrix::Vector2f _stick_input_xy_prev; /*for manual controlled mode to detect direction change */
-
 
 	math::Matrix<3, 3> _R;			/**< rotation matrix from attitude quaternions */
 	float _yaw;				/**< yaw angle (euler) */
@@ -2982,7 +2978,6 @@ MulticopterPositionControl::task_main()
 			_mode_auto = false;
 			_reset_int_z = true;
 			_reset_int_xy = true;
-			_limit_vel_xy = false;
 
 			/* store last velocity in case a mode switch to position control occurs */
 			_vel_sp_prev = _vel;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1746,6 +1746,9 @@ void MulticopterPositionControl::control_auto(float dt)
 			triplet_updated = true;
 		}
 
+		/* we need to update _curr_pos_sp always since navigator applies slew rate on z */
+		_curr_pos_sp = curr_pos_sp;
+
 	}
 
 	if (_pos_sp_triplet.previous.valid) {

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -110,27 +110,26 @@ private:
 	/** Time in us that direction change condition has to be true for direction change state */
 	static constexpr uint64_t DIRECTION_CHANGE_TRIGGER_TIME_US = 100000;
 
-
-	bool		_task_should_exit;		/**< if true, task should exit */
-	bool		_gear_state_initialized; /**< true if the gear state has been initialized */
-	bool    	 _was_armed;        /**< record the pre state armed or disarmed. */
-	bool 		_reset_pos_sp;
-	bool 		_reset_alt_sp;
-	bool 		_do_reset_alt_pos_flag; /**< flag that indicates if both pos_sp and alt_sp needs a reset: TODO: check if we need this */
-	bool		 _mode_auto;  /**< true if in auot mode */
-	bool 		_pos_hold_engaged; /**< true if hold positon in xy desired */
-	bool 		_alt_hold_engaged; /**< true if hold in z desired */
-	bool 		_run_pos_control;  /**< true if position controller should be used */
-	bool 		_run_alt_control; /**< true if altitude controller should be used */
-	bool 		_reset_int_z; /**< true if reset integral in z */
-	bool 		_reset_int_xy; /**< true if reset integral in xy */
-	bool		 _reset_yaw_sp; /**< true if reset yaw setpoint */
-	bool 		_hold_offboard_xy; /**<TODO : check if we need this extra hold_offboard flag */
-	bool 		_hold_offboard_z;
-	bool 		_in_takeoff; /**< true if takeoff ramp is applied */
-	bool 		_in_landing;	/**< true if landing descent (only used in auto) */
-	bool 		_lnd_reached_ground; /**< true if controller assumes the vehicle has reached the ground after landing */
-	bool 		_state_updn_revert; /* true if vehicle is upside down (used such that gears can be controlled independent of vehicle state) */
+	bool		_task_should_exit = false;			/**<true if task should exit */
+	bool		_gear_state_initialized = false;	/**<true if the gear state has been initialized */
+	bool    	 _was_armed = false;        		/**< true if the pre state was armed */
+	bool 		_reset_pos_sp = true;  				/**<true if position setpoint needs a reset */
+	bool 		_reset_alt_sp = true; 				/**<true if altitude setpoint needs a reset */
+	bool 		_do_reset_alt_pos_flag = true; 		/**< TODO: check if we need this */
+	bool		_mode_auto = false ;  				/**<true if in auot mode */
+	bool 		_pos_hold_engaged = false; 			/**<true if hold positon in xy desired */
+	bool 		_alt_hold_engaged = false; 			/**<true if hold in z desired */
+	bool 		_run_pos_control = true;  			/**< true if position controller should be used */
+	bool 		_run_alt_control = true; 			/**<true if altitude controller should be used */
+	bool 		_reset_int_z = true; 				/**<true if reset integral in z */
+	bool 		_reset_int_xy = true; 				/**<true if reset integral in xy */
+	bool		 _reset_yaw_sp = true; 				/**<true if reset yaw setpoint */
+	bool 		_hold_offboard_xy = false; 			/**<TODO : check if we need this extra hold_offboard flag */
+	bool 		_hold_offboard_z = false;
+	bool 		_in_takeoff = false; 				/**<true if takeoff ramp is applied */
+	bool 		_in_landing = false;				/**<true if landing descent (only used in auto) */
+	bool 		_lnd_reached_ground = false; 		/**<true if controller assumes the vehicle has reached the ground after landing */
+	bool 		_state_updn_revert = false; 		/**<true if vehicle is upside down */
 
 	int		_control_task;			/**< task handle for task */
 	orb_advert_t	_mavlink_log_pub;		/**< mavlink log advert */
@@ -411,26 +410,6 @@ MulticopterPositionControl	*g_control;
 
 MulticopterPositionControl::MulticopterPositionControl() :
 	SuperBlock(nullptr, "MPC"),
-	_task_should_exit(false),
-	_gear_state_initialized(false),
-	_was_armed(false),
-	_reset_pos_sp(true),
-	_reset_alt_sp(true),
-	_do_reset_alt_pos_flag(true),
-	_mode_auto(false),
-	_pos_hold_engaged(false),
-	_alt_hold_engaged(false),
-	_run_pos_control(true),
-	_run_alt_control(true),
-	_reset_int_z(true),
-	_reset_int_xy(true),
-	_reset_yaw_sp(true),
-	_hold_offboard_xy(false),
-	_hold_offboard_z(false),
-	_in_takeoff(false),
-	_in_landing(false),
-	_lnd_reached_ground(false),
-	_state_updn_revert(false),
 	_control_task(-1),
 	_mavlink_log_pub(nullptr),
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1307,20 +1307,26 @@ MulticopterPositionControl::vel_sp_slewrate(float dt)
 	matrix::Vector2f vel_xy(_vel(0), _vel(1));
 	matrix::Vector2f acc_xy = (vel_sp_xy - vel_sp_prev_xy) / dt;
 
-	float acc_limit = _acceleration_hor_max.get();
+	/* as default we use max deceleration as acc limit */
+	float acc_limit = _deceleration_hor_max.get();
 
-	/* deceleration but no direction change and not position control*/
-	bool slow_deceleration = ((acc_xy * vel_xy) < 0.0f) && ((vel_sp_xy * vel_xy) > 0.0f) && !_run_pos_control;
+	if (_control_mode.flag_control_manual_enabled) {
+		/* default for manual */
+		acc_limit = _acceleration_hor_max.get();
 
-	/* deceleration with direction change and not position control*/
-	bool fast_deceleration = ((acc_xy * vel_xy) < 0.0f) && ((vel_sp_xy * vel_xy) <= 0.0f) && !_run_pos_control;
+		/* deceleration but no direction change and not position control*/
+		bool slow_deceleration = ((acc_xy * vel_xy) < 0.0f) && ((vel_sp_xy * vel_xy) > 0.0f) && !_run_pos_control;
 
-	if (slow_deceleration) {
-		acc_limit = _deceleration_hor_slow.get();
-	}
+		/* deceleration with direction change and not position control*/
+		bool fast_deceleration = ((acc_xy * vel_xy) < 0.0f) && ((vel_sp_xy * vel_xy) <= 0.0f) && !_run_pos_control;
 
-	if (fast_deceleration) {
-		acc_limit = _deceleration_hor_max.get();
+		if (slow_deceleration) {
+			acc_limit = _deceleration_hor_slow.get();
+		}
+
+		if (fast_deceleration) {
+			acc_limit = _deceleration_hor_max.get();
+		}
 	}
 
 	/* limit total horizontal acceleration */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1090,11 +1090,10 @@ MulticopterPositionControl::set_manual_acceleration(matrix::Vector2f &stick_xy, 
 			} else if (_manual_direction_change_hysteresis.get_state()) {
 
 				/* TODO: find conditions which are always continuous
-				 * only  sick input greater than half*/
+				 * only if stick input is large*/
 				if (stick_xy.length() > 0.6f) {
 					_acceleration_state_dependent_xy = _acceleration_hor_max.get();
 				}
-
 			}
 
 			break;
@@ -1141,8 +1140,7 @@ MulticopterPositionControl::set_manual_acceleration(matrix::Vector2f &stick_xy, 
 	case acceleration: {
 			/* limit acceleration linearly on stick input*/
 			float acc_limit  = (_acceleration_hor_manual.get() - _deceleration_hor_slow.get()) * stick_xy.length()
-					   +
-					   _deceleration_hor_slow.get();
+					   + _deceleration_hor_slow.get();
 
 			if (_acceleration_state_dependent_xy > acc_limit) {
 				acc_limit = _acceleration_state_dependent_xy;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1314,11 +1314,15 @@ MulticopterPositionControl::vel_sp_slewrate(float dt)
 		/* default for manual */
 		acc_limit = _acceleration_hor_max.get();
 
-		/* deceleration but no direction change and not position control*/
-		bool slow_deceleration = ((acc_xy * vel_xy) < 0.0f) && ((vel_sp_xy * vel_xy) > 0.0f) && !_run_pos_control;
+		/* get normalized direction */
+		matrix::Vector2f vel_sp_xy_norm = (vel_sp_xy.length() > 0.0f) ? vel_sp_xy.normalized() : vel_sp_xy_norm;
+		matrix::Vector2f vel_xy_norm = (vel_xy.length() > 0.0f) ? vel_xy.normalized() : vel_xy;
 
-		/* deceleration with direction change and not position control*/
-		bool fast_deceleration = ((acc_xy * vel_xy) < 0.0f) && ((vel_sp_xy * vel_xy) <= 0.0f) && !_run_pos_control;
+		/* deceleration but direction change does not exceed 60degrees (= 0.5)*/
+		bool slow_deceleration = ((acc_xy * vel_xy) < 0.0f) && ((vel_sp_xy_norm * vel_xy_norm) > 0.5f) && !_run_pos_control;
+
+		/* deceleration but direction change does exceed 60degrees (= 0.5)*/
+		bool fast_deceleration = ((acc_xy * vel_xy) < 0.0f) && ((vel_sp_xy_norm * vel_xy_norm) <= 0.5f) && !_run_pos_control;
 
 		if (slow_deceleration) {
 			acc_limit = _deceleration_hor_slow.get();

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -2457,17 +2457,6 @@ MulticopterPositionControl::calculate_thrust_setpoint(float dt)
 		thrust_sp(2) *= att_comp;
 	}
 
-	/* if any of thrust sp is not finite, it is safest to send out hover thrust*/
-	for (int i = 0; i < 3; ++i) {
-		if (!PX4_ISFINITE(thrust_sp(i))) {
-			thrust_sp(0) = 0.0f;
-			thrust_sp(1) = 0.0f;
-			thrust_sp(2) = -_params.thr_hover;
-			PX4_WARN("Caught invalid thrust setpoint");
-			break;
-		}
-	}
-
 	/* Calculate desired total thrust amount in body z direction. */
 	/* To compensate for excess thrust during attitude tracking errors we
 	 * project the desired thrust force vector F onto the real vehicle's thrust axis in NED:

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -112,7 +112,6 @@ private:
 
 	bool		_task_should_exit = false;			/**<true if task should exit */
 	bool		_gear_state_initialized = false;	/**<true if the gear state has been initialized */
-	bool    	 _was_armed = false;        		/**< true if the pre state was armed */
 	bool 		_reset_pos_sp = true;  				/**<true if position setpoint needs a reset */
 	bool 		_reset_alt_sp = true; 				/**<true if altitude setpoint needs a reset */
 	bool 		_do_reset_alt_pos_flag = true; 		/**< TODO: check if we need this */
@@ -129,7 +128,9 @@ private:
 	bool 		_in_takeoff = false; 				/**<true if takeoff ramp is applied */
 	bool 		_in_landing = false;				/**<true if landing descent (only used in auto) */
 	bool 		_lnd_reached_ground = false; 		/**<true if controller assumes the vehicle has reached the ground after landing */
-	bool 		_state_updn_revert = false; 		/**<true if vehicle is upside down */
+	bool 		_limit_vel_xy = false;				/**<true if velocity in xy should be farther limited */
+	bool 		_transition_to_non_manual = false;  /**<true if transition from manual to auto */
+
 
 	int		_control_task;			/**< task handle for task */
 	orb_advert_t	_mavlink_log_pub;		/**< mavlink log advert */
@@ -2661,7 +2662,6 @@ MulticopterPositionControl::task_main()
 			_in_takeoff  = false;
 			_in_landing = false;
 			_lnd_reached_ground = false;
-			_state_updn_revert = false;
 
 			/* also reset previous setpoints */
 			_yaw_takeoff = _yaw;
@@ -2737,6 +2737,7 @@ MulticopterPositionControl::task_main()
 			_mode_auto = false;
 			_reset_int_z = true;
 			_reset_int_xy = true;
+			_limit_vel_xy = false;
 
 			/* store last velocity in case a mode switch to position control occurs */
 			_vel_sp_prev = _vel;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1179,7 +1179,12 @@ MulticopterPositionControl::control_manual(float dt)
 
 	/* check horizontal hold engaged flag */
 	if (_pos_hold_engaged) {
+
+		/* check if contition still true */
 		_pos_hold_engaged = pos_hold_desired;
+
+		/* use max acceleration */
+		_acceleration_state_dependent_xy = _acceleration_hor_max.get();
 
 	} else {
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1030,9 +1030,12 @@ MulticopterPositionControl::set_manual_acceleration(matrix::Vector2f &stick_xy, 
 
 	/* we always want to break starting with slow deceleration */
 	if ((_user_intention != brake) && (intention  == brake)) {
-		_acceleration_state_dependent_xy = _deceleration_hor_slow.get();
 		_manual_jerk_limit = (_jerk_hor_max.get() - _jerk_hor_min.get()) / _velocity_hor_manual.get() * sqrtf(_vel(0) * _vel(
+
 					     0) + _vel(1) * _vel(1)) + _jerk_hor_min.get();
+
+		/* we start braking with lowest accleration */
+		_acceleration_state_dependent_xy = _deceleration_hor_slow.get();
 
 	}
 
@@ -1111,7 +1114,6 @@ MulticopterPositionControl::set_manual_acceleration(matrix::Vector2f &stick_xy, 
 
 	case deceleration: {
 			_acceleration_state_dependent_xy = _deceleration_hor_slow.get();
-
 			break;
 		}
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -112,7 +112,26 @@ private:
 
 
 	bool		_task_should_exit;		/**< if true, task should exit */
-	bool		_gear_state_initialized;	///< true if the gear state has been initialized
+	bool		_gear_state_initialized; /**< true if the gear state has been initialized */
+	bool    	 _armed_last;        /**< record the pre state armed or disarmed. */
+	bool 		_reset_pos_sp;
+	bool 		_reset_alt_sp;
+	bool 		_do_reset_alt_pos_flag; /**< flag that indicates if both pos_sp and alt_sp needs a reset: TODO: check if we need this */
+	bool		 _mode_auto;  /**< true if in auot mode */
+	bool 		_pos_hold_engaged; /**< true if hold positon in xy desired */
+	bool 		_alt_hold_engaged; /**< true if hold in z desired */
+	bool 		_run_pos_control;  /**< true if position controller should be used */
+	bool 		_run_alt_control; /**< true if altitude controller should be used */
+	bool 		_reset_int_z; /**< true if reset integral in z */
+	bool 		_reset_int_xy; /**< true if reset integral in xy */
+	bool		 _reset_yaw_sp; /**< true if reset yaw setpoint */
+	bool 		_hold_offboard_xy; /**<TODO : check if we need this extra hold_offboard flag */
+	bool 		_hold_offboard_z;
+	bool 		_in_takeoff; /**< true if takeoff ramp is applied */
+	bool 		_in_landing;	/**< true if landing descent (only used in auto) */
+	bool 		_lnd_reached_ground; /**< true if controller assumes the vehicle has reached the ground after landing */
+	bool 		_state_updn_revert; /* true if vehicle is upside down (used such that gears can be controlled independent of vehicle state) */
+
 	int		_control_task;			/**< task handle for task */
 	orb_advert_t	_mavlink_log_pub;		/**< mavlink log advert */
 
@@ -252,28 +271,7 @@ private:
 	float _ref_alt;
 	hrt_abstime _ref_timestamp;
 
-	bool _reset_pos_sp;
-	bool _reset_alt_sp;
-	bool _do_reset_alt_pos_flag;
-	bool _mode_auto;
-	bool _pos_hold_engaged;
-	bool _alt_hold_engaged;
-	bool _run_pos_control;
-	bool _run_alt_control;
-
-	bool _reset_int_z = true;
-	bool _reset_int_xy = true;
-	bool _reset_int_z_manual = false;
-	bool _reset_yaw_sp = true;
-
-	bool _hold_offboard_xy = false;
-	bool _hold_offboard_z = false;
-	bool _limit_vel_xy = false;
-
-	bool _transition_to_non_manual = false;
-
 	math::Vector<3> _thrust_int;
-
 	math::Vector<3> _pos;
 	math::Vector<3> _pos_sp;
 	math::Vector<3> _vel;
@@ -289,8 +287,6 @@ private:
 	math::Matrix<3, 3> _R;			/**< rotation matrix from attitude quaternions */
 	float _yaw;				/**< yaw angle (euler) */
 	float _yaw_takeoff;	/**< home yaw angle present when vehicle was taking off (euler) */
-	bool _in_landing;	/**< the vehicle is in the landing descent */
-	bool _lnd_reached_ground; /**< controller assumes the vehicle has reached the ground after landing */
 	float _vel_z_lp;
 	float _acc_z_lp;
 	float _vel_max_xy;  /**< equal to vel_max except in auto mode when close to target */
@@ -299,7 +295,6 @@ private:
 	float _manual_jerk_limit_xy; /**< jerk limit in manual mode dependent on stick input */
 	float _manual_jerk_limit_z; /**< jerk limit in manual mode in z */
 
-	bool _in_takeoff; /**< flag for smooth velocity setpoint takeoff ramp */
 	float _takeoff_vel_limit; /**< velocity limit value which gets ramped up */
 
 	// counters for reset events on position and velocity states
@@ -413,10 +408,29 @@ namespace pos_control
 MulticopterPositionControl	*g_control;
 }
 
+
 MulticopterPositionControl::MulticopterPositionControl() :
 	SuperBlock(nullptr, "MPC"),
 	_task_should_exit(false),
 	_gear_state_initialized(false),
+	_armed_last(false),
+	_reset_pos_sp(true),
+	_reset_alt_sp(true),
+	_do_reset_alt_pos_flag(true),
+	_mode_auto(false),
+	_pos_hold_engaged(false),
+	_alt_hold_engaged(false),
+	_run_pos_control(true),
+	_run_alt_control(true),
+	_reset_int_z(true),
+	_reset_int_xy(true),
+	_reset_yaw_sp(true),
+	_hold_offboard_xy(false),
+	_hold_offboard_z(false),
+	_in_takeoff(false),
+	_in_landing(false),
+	_lnd_reached_ground(false),
+	_state_updn_revert(false),
 	_control_task(-1),
 	_mavlink_log_pub(nullptr),
 
@@ -471,18 +485,8 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_user_intention_z(brake),
 	_ref_alt(0.0f),
 	_ref_timestamp(0),
-	_reset_pos_sp(true),
-	_reset_alt_sp(true),
-	_do_reset_alt_pos_flag(true),
-	_mode_auto(false),
-	_pos_hold_engaged(false),
-	_alt_hold_engaged(false),
-	_run_pos_control(true),
-	_run_alt_control(true),
 	_yaw(0.0f),
 	_yaw_takeoff(0.0f),
-	_in_landing(false),
-	_lnd_reached_ground(false),
 	_vel_z_lp(0),
 	_acc_z_lp(0),
 	_vel_max_xy(0.0f),
@@ -490,7 +494,6 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_acceleration_state_dependent_z(0.0f),
 	_manual_jerk_limit_xy(1.0f),
 	_manual_jerk_limit_z(1.0f),
-	_in_takeoff(false),
 	_takeoff_vel_limit(0.0f),
 	_z_reset_counter(0),
 	_xy_reset_counter(0),
@@ -2754,7 +2757,6 @@ MulticopterPositionControl::task_main()
 			_mode_auto = false;
 			_reset_int_z = true;
 			_reset_int_xy = true;
-			_limit_vel_xy = false;
 
 			/* store last velocity in case a mode switch to position control occurs */
 			_vel_sp_prev = _vel;
@@ -2791,10 +2793,6 @@ MulticopterPositionControl::task_main()
 				_att_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp);
 			}
 		}
-
-		/* reset altitude controller integral (hovering throttle) to manual throttle after manual throttle control */
-		_reset_int_z_manual = _control_mode.flag_armed && _control_mode.flag_control_manual_enabled
-				      && !_control_mode.flag_control_climb_rate_enabled;
 	}
 
 	mavlink_log_info(&_mavlink_log_pub, "[mpc] stopped");

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1964,7 +1964,10 @@ void MulticopterPositionControl::control_auto(float dt)
 		}
 
 	} else {
-		/* idle or triplet not valid, do nothing */
+		/* idle or triplet not valid, set velocity setpoint to zero */
+		_vel_sp.zero();
+		_run_pos_control = false;
+		_run_alt_control = false;
 	}
 }
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -143,8 +143,7 @@ private:
 	control::BlockParamFloat _xy_vel_man_expo; /**< ratio of exponential curve for stick input in xy direction pos mode */
 	control::BlockParamFloat _z_vel_man_expo; /**< ratio of exponential curve for stick input in xy direction pos mode */
 	control::BlockParamFloat _hold_dz; /**< deadzone around the center for the sticks when flying in position mode */
-	control::BlockParamFloat
-	_acceleration_hor_max; /**< maximum velocity setpoint slewrate for auto acceleration and manual deceleration */
+	control::BlockParamFloat _acceleration_hor_max; /**< maximum velocity setpoint slewrate for auto & fast manual brake */
 	control::BlockParamFloat _acceleration_hor_manual; /**< maximum velocity setpoint slewrate for manual acceleration */
 	control::BlockParamFloat _deceleration_hor_slow; /**< slow velocity setpoint slewrate for manual deceleration*/
 	control::BlockParamFloat _target_threshold_xy; /**< distance threshold for slowdown close to target during mission */
@@ -1311,7 +1310,7 @@ MulticopterPositionControl::vel_sp_slewrate(float dt)
 	/* as default we use max acceleration as acc limit */
 	float acc_limit = _acceleration_hor_max.get();
 
-	/*In manual mode but not position control, we apply acceleration limit depending on direction*/
+	/* In manual mode but not position control, we apply acceleration limit depending on direction */
 	if (_control_mode.flag_control_manual_enabled && !_run_pos_control) {
 
 		/* default for manual */
@@ -1324,7 +1323,7 @@ MulticopterPositionControl::vel_sp_slewrate(float dt)
 		/* check if deceleration is required */
 		bool deceleration = (acc_xy * vel_xy) < 0.0f;
 
-		/* check if velocity setpoint direction differs more than 60degrees (= 0.5) from current velocity direction*/
+		/* check if velocity setpoint direction differs more than 60° (cos(60°) = 0.5) from current velocity direction*/
 		bool direction_change_60 = (vel_sp_xy_norm * vel_xy_norm) <= 0.5f;
 
 		/* slow deceleration*/

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1960,6 +1960,9 @@ void MulticopterPositionControl::control_auto(float dt)
 						float slope = (get_cruising_speed_xy() - vel_close) / (_target_threshold_xy.get() - _nav_rad.get()) ;
 						vel_sp_along_track = slope  * (vec_closest_to_current.length()) + vel_close;
 
+						/* make sure vel_sp_along_track is positive */
+						vel_sp_along_track = (vel_sp_along_track < 0.0f) ? SIGMA_SINGLE_OP : vel_sp_along_track;
+
 						/* since we want to slow down take over previous velocity setpoint along track if it was lower */
 						if ((vel_sp_along_track_prev < vel_sp_along_track) && (vel_sp_along_track * vel_sp_along_track_prev > 0.0f)) {
 							vel_sp_along_track = vel_sp_along_track_prev;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -824,13 +824,6 @@ MulticopterPositionControl::poll_subscriptions()
 		    !PX4_ISFINITE(_pos_sp_triplet.current.alt)) {
 			_pos_sp_triplet.current.valid = false;
 		}
-
-		/* to avoid time scheduling issue that occurs when the navigator has not updated the triplet
-		 * but the mc_pos_control already received a non-manual control flag
-		 */
-		if (_transition_to_non_manual && !_control_mode.flag_control_manual_enabled) {
-			_transition_to_non_manual = false;
-		}
 	}
 
 	orb_check(_home_pos_sub, &updated);
@@ -1971,7 +1964,7 @@ void MulticopterPositionControl::control_auto(float dt)
 		}
 
 	} else {
-		/* no waypoint, do nothing, setpoint was already reset */
+		/* idle or triplet not valid, do nothing */
 	}
 }
 
@@ -2036,14 +2029,14 @@ MulticopterPositionControl::do_control(float dt)
 		control_manual(dt);
 		_mode_auto = false;
 
-		_transition_to_non_manual = true;
+		/* we set tiplets to false
+		 * this ensures that when switching to auto, the position
+		 * controller will not use the old triplets but waits until triplets
+		 * have been updated */
+		_pos_sp_triplet.current.valid = false;
 
 		_hold_offboard_xy = false;
 		_hold_offboard_z = false;
-
-	} else if (_transition_to_non_manual) {
-		/* we reuse the previous setpoints */
-		calculate_thrust_setpoint(dt);
 
 	} else {
 		/* reset acceleration to default */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1310,10 +1310,10 @@ MulticopterPositionControl::vel_sp_slewrate(float dt)
 	float acc_limit = _acceleration_hor_max.get();
 
 	/* deceleration but no direction change */
-	bool slow_deceleration = ((vel_xy * acc_xy) < 0.0f) && ((vel_sp_xy * vel_xy) > 0.0f);
+	bool slow_deceleration = ((acc_xy * vel_xy) < 0.0f) && ((vel_sp_xy * vel_xy) > 0.0f);
 
 	/* deceleration with direction change */
-	bool fast_deceleration = ((vel_xy * acc_xy) < 0.0f) && ((vel_sp_xy * vel_xy) <= 0.0f);
+	bool fast_deceleration = ((acc_xy * vel_xy) < 0.0f) && ((vel_sp_xy * vel_xy) <= 0.0f);
 
 	if (slow_deceleration) {
 		acc_limit = _deceleration_hor_slow.get();

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -264,13 +264,13 @@ PARAM_DEFINE_FLOAT(MPC_XY_CRUISE, 5.0f);
  * position stabilized mode (POSCTRL).
  *
  * @unit m/s
- * @min 0.5
- * @max 8.0
+ * @min 0.05
+ * @max 1.0
  * @increment 1
  * @decimal 2
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_CRUISE_MIN, 1.0f);
+PARAM_DEFINE_FLOAT(MPC_CRUISE_MIN, 0.5f);
 
 /**
  * Maximum horizontal velocity setpoint for manual controlled mode

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -424,7 +424,7 @@ PARAM_DEFINE_FLOAT(MPC_HOLD_MAX_Z, 0.6f);
 PARAM_DEFINE_FLOAT(MPC_VELD_LP, 5.0f);
 
 /**
- * Maximum horizonal acceleration in velocity controlled modes
+ * Maximum horizontal acceleration for auto mode and maximum deceleration for manual mode
  *
  * @unit m/s/s
  * @min 2.0
@@ -433,10 +433,10 @@ PARAM_DEFINE_FLOAT(MPC_VELD_LP, 5.0f);
  * @decimal 2
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_ACC_HOR_MAX, 5.0f);
+PARAM_DEFINE_FLOAT(MPC_ACC_HOR_MAX, 10.0f);
 
 /**
- * Maximum horizontal braking deceleration in velocity controlled modes
+ * Maximum horizontal manual acceleration
  *
  * @unit m/s/s
  * @min 2.0
@@ -445,10 +445,10 @@ PARAM_DEFINE_FLOAT(MPC_ACC_HOR_MAX, 5.0f);
  * @decimal 2
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_DEC_HOR_MAX, 10.0f);
+PARAM_DEFINE_FLOAT(MPC_ACC_HOR_MAN, 5.0f);
 
 /**
- * Slow horizontal braking deceleration in velocity controlled modes
+ * Slow horizontal manual deceleration for manual mode
  *
  * @unit m/s/s
  * @min 0.5

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -436,7 +436,7 @@ PARAM_DEFINE_FLOAT(MPC_VELD_LP, 5.0f);
 PARAM_DEFINE_FLOAT(MPC_ACC_HOR_MAX, 5.0f);
 
 /**
- * Maximum horizonal braking deceleration in velocity controlled modes
+ * Maximum horizontal braking deceleration in velocity controlled modes
  *
  * @unit m/s/s
  * @min 2.0
@@ -446,6 +446,18 @@ PARAM_DEFINE_FLOAT(MPC_ACC_HOR_MAX, 5.0f);
  * @group Multicopter Position Control
  */
 PARAM_DEFINE_FLOAT(MPC_DEC_HOR_MAX, 10.0f);
+
+/**
+ * Slow horizontal braking deceleration in velocity controlled modes
+ *
+ * @unit m/s/s
+ * @min 0.5
+ * @max 10.0
+ * @increment 1
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_DEC_HOR_SLOW, 2.0f);
 
 /**
  * Maximum vertical acceleration in velocity controlled modes upward

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -257,7 +257,7 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_D, 0.01f);
 PARAM_DEFINE_FLOAT(MPC_XY_CRUISE, 5.0f);
 
 /**
- * Nominal horizontal velocity for manual controlled mode
+ * Maximum horizontal velocity setpoint for manual controlled mode
  *
  * @unit m/s
  * @min 3.0
@@ -493,7 +493,19 @@ PARAM_DEFINE_FLOAT(MPC_ACC_DOWN_MAX, 5.0f);
  * @decimal 2
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_JERK_MAX, 6.6f);
+PARAM_DEFINE_FLOAT(MPC_JERK_MAX, 9.6f);
+
+/**
+ * Minimum jerk in manual controlled mode for braking to zero
+ *
+ * @unit m/s/s/s
+ * @min 1.0
+ * @max 15.0
+ * @increment 1
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_JERK_MIN, 2.6f);
 
 /**
  * Altitude control mode, note mode 1 only tested with LPE

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -241,7 +241,7 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_I, 0.02f);
 PARAM_DEFINE_FLOAT(MPC_XY_VEL_D, 0.01f);
 
 /**
- * Nominal horizontal velocity in mission
+ * Maximum horizontal velocity in mission
  *
  * Normal horizontal velocity in AUTO modes (includes
  * also RTL / hold / etc.) and endpoint for
@@ -255,6 +255,22 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_D, 0.01f);
  * @group Multicopter Position Control
  */
 PARAM_DEFINE_FLOAT(MPC_XY_CRUISE, 5.0f);
+
+/**
+ * Minimum horizontal velocity in mission
+ *
+ * Normal horizontal velocity in AUTO modes (includes
+ * also RTL / hold / etc.) and endpoint for
+ * position stabilized mode (POSCTRL).
+ *
+ * @unit m/s
+ * @min 0.5
+ * @max 8.0
+ * @increment 1
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_CRUISE_MIN, 1.0f);
 
 /**
  * Maximum horizontal velocity setpoint for manual controlled mode

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -274,6 +274,8 @@ PARAM_DEFINE_FLOAT(MPC_CRUISE_MIN, 0.5f);
 
 /**
  * Maximum horizontal velocity setpoint for manual controlled mode
+ * If velocity setpoint larger than MPC_XY_VEL_MAX is set, then
+ * the setpoint will be capped to MPC_XY_VEL_MAX
  *
  * @unit m/s
  * @min 3.0
@@ -303,8 +305,8 @@ PARAM_DEFINE_FLOAT(MPC_TARGET_THRE, 15.0f);
 /**
  * Maximum horizontal velocity
  *
- * Maximum horizontal velocity in AUTO mode. If higher speeds
- * are commanded in a mission they will be capped to this velocity.
+ * Maximum horizontal velocity. If higher speeds
+ * are commanded they will be capped to this velocity.
  *
  * @unit m/s
  * @min 0.0
@@ -313,7 +315,7 @@ PARAM_DEFINE_FLOAT(MPC_TARGET_THRE, 15.0f);
  * @decimal 2
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_XY_VEL_MAX, 8.0f);
+PARAM_DEFINE_FLOAT(MPC_XY_VEL_MAX, 12.0f);
 
 /**
  * Horizontal velocity feed forward

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -481,7 +481,7 @@ PARAM_DEFINE_FLOAT(MPC_ACC_UP_MAX, 5.0f);
  * @decimal 2
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_ACC_DOWN_MAX, 5.0f);
+PARAM_DEFINE_FLOAT(MPC_ACC_DOWN_MAX, 2.0f);
 
 /**
  * Maximum jerk in manual controlled mode for braking to zero

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -484,6 +484,18 @@ PARAM_DEFINE_FLOAT(MPC_ACC_UP_MAX, 5.0f);
 PARAM_DEFINE_FLOAT(MPC_ACC_DOWN_MAX, 5.0f);
 
 /**
+ * Maximum jerk in manual controlled mode for braking to zero
+ *
+ * @unit m/s/s/s
+ * @min 2.0
+ * @max 15.0
+ * @increment 1
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_JERK_MAX, 6.6f);
+
+/**
  * Altitude control mode, note mode 1 only tested with LPE
  *
  * @min 0

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -493,7 +493,7 @@ PARAM_DEFINE_FLOAT(MPC_ACC_DOWN_MAX, 5.0f);
  * @decimal 2
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_JERK_MAX, 9.6f);
+PARAM_DEFINE_FLOAT(MPC_JERK_MAX, 5.0f);
 
 /**
  * Minimum jerk in manual controlled mode for braking to zero
@@ -505,7 +505,7 @@ PARAM_DEFINE_FLOAT(MPC_JERK_MAX, 9.6f);
  * @decimal 2
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_JERK_MIN, 2.6f);
+PARAM_DEFINE_FLOAT(MPC_JERK_MIN, 1.0f);
 
 /**
  * Altitude control mode, note mode 1 only tested with LPE

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -691,11 +691,11 @@ MissionBlock::set_takeoff_item(struct mission_item_s *item, float abs_altitude, 
 	/* use current position */
 	item->lat = _navigator->get_global_position()->lat;
 	item->lon = _navigator->get_global_position()->lon;
+	item->yaw = _navigator->get_global_position()->yaw;
 
 	item->altitude = abs_altitude;
 	item->altitude_is_relative = false;
 
-	item->yaw = NAN;
 	item->loiter_radius = _navigator->get_loiter_radius();
 	item->pitch_min = min_pitch;
 	item->autocontinue = false;

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -141,9 +141,8 @@ Takeoff::set_takeoff_position()
 
 	// convert mission item to current setpoint
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-	pos_sp_triplet->previous.valid = false;
 	mission_item_to_position_setpoint(&_mission_item, &pos_sp_triplet->current);
-	pos_sp_triplet->current.yaw = _navigator->get_home_position()->yaw;
+	pos_sp_triplet->previous.valid = false;
 	pos_sp_triplet->current.yaw_valid = true;
 	pos_sp_triplet->next.valid = false;
 


### PR DESCRIPTION
This logic is a replacement for the current auto logic. 
It is to note that a trajectory module independent of the position controller is desired/planned.
The changes can be summarized as follow:

- get rid of scale
- get rid of smoothing along the corners since the update of the triplets happens before the smoothing can be completed anyway
- accelerate/decelerate at waypoints depending on angle previous-current-next setpoint

the logic already has several hours of flight test. However, I still need to check for rebase errors. 

NOTE:
It is on top of this PR:
https://github.com/PX4/Firmware/pull/7242