### PR TITLE
BAT_V_CHARGED default 4.05V -> 4.2V

### DIFF
--- a/src/modules/systemlib/battery_params.c
+++ b/src/modules/systemlib/battery_params.c
@@ -70,7 +70,7 @@ PARAM_DEFINE_FLOAT(BAT_V_EMPTY, 3.4f);
  * @increment 0.01
  * @reboot_required true
  */
-PARAM_DEFINE_FLOAT(BAT_V_CHARGED, 4.05f);
+PARAM_DEFINE_FLOAT(BAT_V_CHARGED, 4.20f);
 
 /**
  * Low threshold


### PR DESCRIPTION
Is the default of 4.05V intentional? 

http://discuss.px4.io/t/bat-v-charged/3213