### PR TITLE
Navigator: Fix RTL command lnd logic for missions

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -858,8 +858,7 @@ Mission::do_need_vertical_takeoff()
 			    _mission_item.nav_cmd == NAV_CMD_WAYPOINT ||
 			    _mission_item.nav_cmd == NAV_CMD_VTOL_TAKEOFF ||
 			    _mission_item.nav_cmd == NAV_CMD_LOITER_TIME_LIMIT ||
-			    _mission_item.nav_cmd == NAV_CMD_LOITER_UNLIMITED ||
-			    _mission_item.nav_cmd == NAV_CMD_RETURN_TO_LAUNCH)) {
+			    _mission_item.nav_cmd == NAV_CMD_LOITER_UNLIMITED)) {
 
 			_need_takeoff = false;
 			return true;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -481,16 +481,6 @@ Navigator::task_main()
 					PX4_WARN("planned landing not available");
 				}
 
-			} else if (cmd.command == vehicle_command_s::VEHICLE_CMD_NAV_RETURN_TO_LAUNCH) {
-
-				vehicle_command_s vcmd = {};
-				vcmd.target_system = get_vstatus()->system_id;
-				vcmd.target_component = get_vstatus()->component_id;
-				vcmd.command = vehicle_command_s::VEHICLE_CMD_NAV_RETURN_TO_LAUNCH;
-
-				orb_advert_t pub = orb_advertise_queue(ORB_ID(vehicle_command), &vcmd, vehicle_command_s::ORB_QUEUE_LENGTH);
-				(void)orb_unadvertise(pub);
-
 			} else if (cmd.command == vehicle_command_s::VEHICLE_CMD_MISSION_START) {
 
 				if (get_mission_result()->valid &&

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -300,11 +300,6 @@ RTL::set_rtl_item()
 
 	reset_mission_item_reached();
 
-	/* execute command if set */
-	if (!item_contains_position(&_mission_item)) {
-		issue_command(&_mission_item);
-	}
-
 	/* convert mission item to current position setpoint and make it valid */
 	mission_item_to_position_setpoint(&_mission_item, &pos_sp_triplet->current);
 	pos_sp_triplet->next.valid = false;


### PR DESCRIPTION
The navigator was sending RTL commands in the wrong circumstances leading to a cycle between Navigator and Commander.