### PR TITLE
EKF2: Robustness Improvements

### DIFF
--- a/msg/estimator_status.msg
+++ b/msg/estimator_status.msg
@@ -1,4 +1,4 @@
-float32[32] states		# Internal filter states
+float32[24] states		# Internal filter states
 float32 n_states		# Number of states effectively used
 float32[3] vibe			# IMU vibration metrics in the following array locations
 # 0 : Gyro delta angle coning metric = filtered length of (delta_angle x prev_delta_angle)
@@ -7,7 +7,7 @@ float32[3] vibe			# IMU vibration metrics in the following array locations
 uint8 nan_flags			# Bitmask to indicate NaN states
 uint8 health_flags		# Bitmask to indicate sensor health states (vel, pos, hgt)
 uint8 timeout_flags		# Bitmask to indicate timeout flags (vel, pos, hgt)
-float32[28] covariances	# Diagonal Elements of Covariance Matrix
+float32[24] covariances	# Diagonal Elements of Covariance Matrix
 uint16 gps_check_fail_flags     # Bitmask to indicate status of GPS checks - see definition below
 # bits are true when corresponding test has failed
 uint16 GPS_CHECK_FAIL_MIN_SAT_COUNT = 0			# 0 : minimum required sat count fail
@@ -84,4 +84,4 @@ uint16 solution_status_flags # Bitmask indicating which filter kinematic state o
 # 8 - True if the EKF has sufficient data to enter a mode that will provide a (relative) position estimate
 # 9 - True if the EKF has sufficient data to enter a mode that will provide a (absolute) position estimate
 # 10 - True if the EKF has detected a GPS glitch
-
+float32 time_slip # cumulative amount of time in seconds that the EKF inertial calculation has slipped relative to system time

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1070,6 +1070,7 @@ void Ekf2::task_main()
 
 					// Declare all bias estimates invalid if any variances are out of range
 					bool all_estimates_invalid = false;
+
 					for (uint8_t axis_index = 0; axis_index <= 2; axis_index++) {
 						if (status.covariances[axis_index + 19] < min_var_allowed
 						    || status.covariances[axis_index + 19] > max_var_allowed) {

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -447,7 +447,7 @@ PARAM_DEFINE_INT32(EKF2_DECL_TYPE, 7);
  * Type of magnetometer fusion
  *
  * Integer controlling the type of magnetometer fusion used - magnetic heading or 3-axis magnetometer.
- * If set to automatic: heading fusion on-ground and 3-axis fusion in-flight
+ * If set to automatic: heading fusion on-ground and 3-axis fusion in-flight with fallback to heading fusion if there is insufficient motion to make yaw or mag biases observable.
  *
  * @group EKF2
  * @value 0 Automatic
@@ -456,6 +456,30 @@ PARAM_DEFINE_INT32(EKF2_DECL_TYPE, 7);
  * @value 3 None
  */
 PARAM_DEFINE_INT32(EKF2_MAG_TYPE, 0);
+
+/**
+ * Horizontal acceleration threshold used by automatic selection of magnetometer fusion method.
+ * This parameter is used when the magnetometer fusion method is set automatically (EKF2_MAG_TYPE = 0). If the filtered horizontal acceleration is greater than this parameter value, then the EKF will use 3-axis magnetomer fusion.
+ *
+ * @group EKF2
+ * @min 0.0
+ * @max 5.0
+ * @unit m/s**2
+ * @decimal 2
+ */
+PARAM_DEFINE_FLOAT(EKF2_MAG_ACCLIM, 0.5f);
+
+/**
+ * Yaw rate threshold used by automatic selection of magnetometer fusion method.
+ * This parameter is used when the magnetometer fusion method is set automatically (EKF2_MAG_TYPE = 0). If the filtered yaw rate is greater than this parameter value, then the EKF will use 3-axis magnetomer fusion.
+ *
+ * @group EKF2
+ * @min 0.0
+ * @max 0.5
+ * @unit rad/s
+ * @decimal 2
+ */
+PARAM_DEFINE_FLOAT(EKF2_MAG_YAWLIM, 0.25f);
 
 /**
  * Gate size for barometric height fusion


### PR DESCRIPTION
Partially replaces https://github.com/PX4/Firmware/pull/7252

1.  Removes un-used state indexes from the estimator status message and adds a time slip variable that enables dropping of ekf2 updates to be detected. The time slip is the difference between the system time and the time obtained by integrating the IMU delta time messages received by the EKF. Time slips have been a likely cause of previous estimation problems, but were hard to determine with previous logging.

2. Adds pre-flight checking of velocity and height innovations to prevent takeoff if velocity errors are large enough to prevent the vehicle being able to descend. This is necessary until the vulnerability of the height controller to small vertical velocity offsets is fixed.

3. Fixes a vulnerability to heading drift during extended periods of extremely stable hover. This updates EKF2 version to one with improved selection criteria for in-flight selection of the magnetometer fusion method, adds parameters required to tune the selection criteria and modifies the checking of learned magnetometer biases for compatibility with the new selection method. See https://github.com/PX4/ecl/pull/275 for details .

Test reports added below.