### PR TITLE
Drone yaw set to destination waypoint yaw in LOITER mode if MIS_YAWMODE=0

### DIFF
--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -164,18 +164,18 @@ Loiter::reposition()
 		// MISSION_YAWMODE_NONE: do not change yaw setpoint
 		// MISSION_YAWMODE_FRONT_TO_WAYPOINT: point to next waypoint
 		if (_param_yawmode.get() != MISSION_YAWMODE_NONE){
-				float travel_dist = get_distance_to_next_waypoint(_navigator->get_global_position()->lat,
-						    _navigator->get_global_position()->lon,
-						    pos_sp_triplet->current.lat, pos_sp_triplet->current.lon);
+			float travel_dist = get_distance_to_next_waypoint(_navigator->get_global_position()->lat,
+					    _navigator->get_global_position()->lon,
+					    pos_sp_triplet->current.lat, pos_sp_triplet->current.lon);
 
-				if (travel_dist > 1.0f) {
-					// calculate direction the vehicle should point to.
-					pos_sp_triplet->current.yaw = get_bearing_to_next_waypoint(
-									      _navigator->get_global_position()->lat,
-									      _navigator->get_global_position()->lon,
-									      pos_sp_triplet->current.lat,
-									      pos_sp_triplet->current.lon);
-				}
+			if (travel_dist > 1.0f) {
+				// calculate direction the vehicle should point to.
+				pos_sp_triplet->current.yaw = get_bearing_to_next_waypoint(
+								      _navigator->get_global_position()->lat,
+								      _navigator->get_global_position()->lon,
+								      pos_sp_triplet->current.lat,
+								      pos_sp_triplet->current.lon);
+			}
 		}
 		_navigator->set_can_loiter_at_sp(pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER);
 

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -177,6 +177,7 @@ Loiter::reposition()
 								      pos_sp_triplet->current.lon);
 			}
 		}
+
 		_navigator->set_can_loiter_at_sp(pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER);
 
 		_navigator->set_position_setpoint_triplet_updated();

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -163,7 +163,7 @@ Loiter::reposition()
 		// set yaw (depends on the value of parameter MIS_YAWMODE):
 		// MISSION_YAWMODE_NONE: do not change yaw setpoint
 		// MISSION_YAWMODE_FRONT_TO_WAYPOINT: point to next waypoint
-		if (_param_yawmode.get() != MISSION_YAWMODE_NONE){
+		if (_param_yawmode.get() != MISSION_YAWMODE_NONE) {
 			float travel_dist = get_distance_to_next_waypoint(_navigator->get_global_position()->lat,
 					    _navigator->get_global_position()->lon,
 					    pos_sp_triplet->current.lat, pos_sp_triplet->current.lon);

--- a/src/modules/navigator/loiter.h
+++ b/src/modules/navigator/loiter.h
@@ -60,6 +60,14 @@ public:
 
 	virtual void on_active();
 
+	enum mission_yaw_mode {
+		MISSION_YAWMODE_NONE = 0,
+		MISSION_YAWMODE_FRONT_TO_WAYPOINT = 1,
+		MISSION_YAWMODE_FRONT_TO_HOME = 2,
+		MISSION_YAWMODE_BACK_TO_HOME = 3,
+		MISSION_YAWMODE_MAX = 4
+	};
+
 private:
 	/**
 	 * Use the stored reposition location of the navigator
@@ -73,6 +81,7 @@ private:
 	void set_loiter_position();
 
 	control::BlockParamFloat _param_min_alt;
+	control::BlockParamInt _param_yawmode;
 	bool _loiter_pos_set;
 };
 


### PR DESCRIPTION
When in LOITER mode, there is a possibility of sending new target locations to the drone via the [`MAV_CMD_DO_REPOSITION `](https://pixhawk.ethz.ch/mavlink/) MAVLink command. In this command, there is an entry for setting the yaw angle of the drone while reaching the new waypoint. Nevertheless this does not work with the current firmware version.

This PR adds the possibility for the drone to point in the desired direction set in the `MAV_CMD_DO_REPOSITION ` message.

The parameter that switches the drone behavior is `MIS_YAWMODE ` as follows:
 *  **`MIS_YAWMODE = 0 `** (MISSION_YAWMODE_NONE): the drone will follow the yaw set in `MAV_CMD_DO_REPOSITION` command.
*  **`MIS_YAWMODE = 1 `** (MISSION_YAWMODE_FRONT_TO_WAYPOINT): the drone will point in the waypoint direction.

This parameter has been selected because it has the same function in MISSION mode, nevertheless the modes MISSION_YAWMODE_FRONT_TO_HOME and MISSION_YAWMODE_BACK_TO_HOME won't work in LOITER mode because the drone yaw setpoint has to be updated constantly in these cases and in LOITER mode it is only set once. So perhaps we should add a new parameter for the yaw behavior in LOITER?

I have tested this with the jMAVSim SITL simulator and by sending commands with QGroundControl, it works. QGroundControl will send `NaN` in the yaw entry of the `MAV_CMD_DO_REPOSITION`, thus the drone does not change its orientation when traveling to a new waypoint in LOITER mode when `MIS_YAWMODE = 0 `.
I have as well written a small piece of code that sends the `MAV_CMD_DO_REPOSITION ` message with different yaw setpoints and the drone behaves as expected (i.e. it follows the yaw setpoints when `MIS_YAWMODE = 0 ` and points towards the next waypoint when `MIS_YAWMODE = 1`).