### PR TITLE
Backport Upstream SDIO 1-bit and 16G Size Fixes

### DIFF
--- a/nuttx-patches/00027-BACKPORT-stm32-sdio-1-bit-and-16G-fix.patch
+++ b/nuttx-patches/00027-BACKPORT-stm32-sdio-1-bit-and-16G-fix.patch
@@ -1,3 +1,24 @@
+diff --git NuttX/nuttx/arch/arm/src/stm32/stm32_sdio.c NuttX/nuttx/arch/arm/src/stm32/stm32_sdio.c
+index 9d93a43..737f42f 100644
+--- NuttX/nuttx/arch/arm/src/stm32/stm32_sdio.c
++++ NuttX/nuttx/arch/arm/src/stm32/stm32_sdio.c
+@@ -2573,6 +2573,7 @@ static bool stm32_dmasupported(FAR struct sdio_dev_s *dev)
+ static int stm32_dmapreflight(FAR struct sdio_dev_s *dev,
+                               FAR const uint8_t *buffer, size_t buflen)
+ {
++#if !defined(CONFIG_STM32_STM32F40XX)
+   struct stm32_dev_s *priv = (struct stm32_dev_s *)dev;
+ 
+   DEBUGASSERT(priv != NULL && buffer != NULL && buflen > 0);
+@@ -2583,7 +2584,7 @@ static int stm32_dmapreflight(FAR struct sdio_dev_s *dev,
+     {
+       return -EINVAL;
+     }
+-
++#endif
+   /* DMA must be possible to the buffer */
+ 
+   if (!stm32_dmacapable((uintptr_t)buffer, (buflen + 3) >> 2, SDIO_RXDMA32_CONFIG))
 diff --git NuttX/nuttx/drivers/mmcsd/mmcsd_sdio.c NuttX/nuttx/drivers/mmcsd/mmcsd_sdio.c
 index dbdf4e9..9c93cef 100644
 --- NuttX/nuttx/drivers/mmcsd/mmcsd_sdio.c
@@ -33,24 +54,3 @@ index dbdf4e9..9c93cef 100644
  
            priv->mediachanged = false;
            ret = OK;
-diff --git NuttX/nuttx/arch/arm/src/stm32/stm32_sdio.c NuttX/nuttx/arch/arm/src/stm32/stm32_sdio.c
-index 9d93a43..9fb9001 100644
---- NuttX/nuttx/arch/arm/src/stm32/stm32_sdio.c
-+++ NuttX/nuttx/arch/arm/src/stm32/stm32_sdio.c
-@@ -2577,13 +2577,15 @@ static int stm32_dmapreflight(FAR struct sdio_dev_s *dev,
- 
-   DEBUGASSERT(priv != NULL && buffer != NULL && buflen > 0);
- 
-+#if !defined(CONFIG_STM32_STM32F40XX)
-+
-   /* Wide bus operation is required for DMA */
- 
-   if (!priv->widebus)
-     {
-       return -EINVAL;
-     }
--
-+#endif
-   /* DMA must be possible to the buffer */
- 
-   if (!stm32_dmacapable((uintptr_t)buffer, (buflen + 3) >> 2, SDIO_RXDMA32_CONFIG))

--- a/nuttx-patches/CMakeLists.txt
+++ b/nuttx-patches/CMakeLists.txt
@@ -58,7 +58,7 @@ set(nuttx_patches
 	00024-BACKPORT-stm32f7-serial-dma-hotfix.patch
 	00025-BACKPORT-add-set-ex-to-nsh.patch
 	00026-BACKPORT-stm32fX-serial-fix-freezing.patch
-        00027-BACKPORT-stm32-sdio-1-bit-and-16G-fix.patch
+	00027-BACKPORT-stm32-sdio-1-bit-and-16G-fix.patch
 	90000-PENDING-wip-inflight-to-upstream.patch
 	)
 

--- a/nuttx-patches/CMakeLists.txt
+++ b/nuttx-patches/CMakeLists.txt
@@ -58,6 +58,7 @@ set(nuttx_patches
 	00024-BACKPORT-stm32f7-serial-dma-hotfix.patch
 	00025-BACKPORT-add-set-ex-to-nsh.patch
 	00026-BACKPORT-stm32fX-serial-fix-freezing.patch
+        00027-BACKPORT-stm32-sdio-1-bit-and-16G-fix.patch
 	90000-PENDING-wip-inflight-to-upstream.patch
 	)
 


### PR DESCRIPTION
@LorenzMeier - 

I forgot to commit the CMake file in the first PR. Once added the warning was killing the build.  @PX4TestFlights This just needs bench testing to verify the logs created OK.

 This backports upstrem NuttX
    ea7b673 - Allow dma in 1 bit mode in STM32F4xxx
    17cbec1 - fix warning from ea7b673
    4795d58 - Only the decoded.oid    = (cid[0] >> 8) change.