### PR TITLE
Pr mag cal fix

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -343,6 +343,7 @@ fi
 
 if ver hwcmp PX4FMU_V4PRO
 then
+
 	# Internal SPI bus ICM-20608-G
 	if mpu6000 -R 2 -T 20608 start
 	then
@@ -364,7 +365,7 @@ then
 	fi
 
 	# Possible external compasses
-	if hmc5883 -X start
+	if hmc5883 -C -T -X start
 	then
 	fi
 
@@ -372,6 +373,7 @@ fi
 
 if ver hwcmp PX4FMU_V5
 then
+
 	# Internal SPI bus ICM-20602
 	if mpu6000 -R 8 -s -T 20602 start
 	then
@@ -393,7 +395,7 @@ then
 	fi
 
 	# Possible external compasses
-	if hmc5883 -X start
+	if hmc5883 -C -T -X start
 	then
 	fi
 
@@ -401,6 +403,7 @@ then
 	if meas_airspeed start -b 2
 	then
 	fi
+
 fi
 
 if ver hwcmp AEROCORE2

--- a/src/drivers/lis3mdl/lis3mdl.cpp
+++ b/src/drivers/lis3mdl/lis3mdl.cpp
@@ -911,6 +911,9 @@ LIS3MDL::collect()
 	/* this should be fairly close to the end of the measurement, so the best approximation of the time */
 	new_report.timestamp = hrt_absolute_time();
 	new_report.error_count = perf_event_count(_comms_errors);
+	new_report.range_ga = _range_ga;
+	new_report.scaling = _range_scale;
+	new_report.device_id = _device_id.devid;
 
 	/*
 	 * @note  We could read the status register here, which could tell us that

--- a/src/drivers/mpu9250/mag.cpp
+++ b/src/drivers/mpu9250/mag.cpp
@@ -227,7 +227,7 @@ MPU9250_mag::_measure(struct ak8963_regs data)
 	mrb.range_ga = 48.0f;
 	mrb.scaling = _mag_range_scale;
 	mrb.temperature = _parent->_last_temperature;
-	mrb.device_id = _parent->get_device_id().devid;
+	mrb.device_id = _parent->_mag->_device_id.devid;
 
 	mrb.error_count = perf_event_count(_mag_errors);
 

--- a/src/modules/commander/accelerometer_calibration.cpp
+++ b/src/modules/commander/accelerometer_calibration.cpp
@@ -171,7 +171,7 @@ typedef struct  {
 
 int do_accel_calibration(orb_advert_t *mavlink_log_pub)
 {
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_EAGLE) && !defined(__PX4_POSIX_EXCELSIOR) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
+#ifdef __PX4_NUTTX
 	int fd;
 #endif
 
@@ -191,7 +191,7 @@ int do_accel_calibration(orb_advert_t *mavlink_log_pub)
 
 	/* reset all sensors */
 	for (unsigned s = 0; s < max_accel_sens; s++) {
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_EAGLE) && !defined(__PX4_POSIX_EXCELSIOR) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
+#ifdef __PX4_NUTTX
 		sprintf(str, "%s%u", ACCEL_BASE_DEVICE_PATH, s);
 		/* reset all offsets to zero and all scales to one */
 		fd = px4_open(str, 0);
@@ -387,7 +387,7 @@ int do_accel_calibration(orb_advert_t *mavlink_log_pub)
 			return PX4_ERROR;
 		}
 
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_EAGLE) && !defined(__PX4_POSIX_EXCELSIOR) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
+#ifdef __PX4_NUTTX
 		sprintf(str, "%s%u", ACCEL_BASE_DEVICE_PATH, uorb_index);
 		fd = px4_open(str, 0);
 
@@ -482,7 +482,7 @@ calibrate_return do_accel_calibration_measurements(orb_advert_t *mavlink_log_pub
 			struct accel_report report = {};
 			orb_copy(ORB_ID(sensor_accel), worker_data.subs[cur_accel], &report);
 
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
+#ifdef __PX4_NUTTX
 
 			// For NuttX, we get the UNIQUE device ID from the sensor driver via an IOCTL
 			// and match it up with the one from the uORB subscription, because the
@@ -497,7 +497,7 @@ calibrate_return do_accel_calibration_measurements(orb_advert_t *mavlink_log_pub
 				orb_unsubscribe(worker_data.subs[cur_accel]);
 			}
 
-#elif defined(__PX4_QURT) || defined(__PX4_POSIX_RPI) || defined(__PX4_POSIX_BEBOP)
+#else
 
 			// For the DriverFramework drivers, we fill device ID (this is the first time) by copying one report.
 			device_id[cur_accel] = report.device_id;

--- a/src/modules/commander/accelerometer_calibration.cpp
+++ b/src/modules/commander/accelerometer_calibration.cpp
@@ -466,9 +466,17 @@ calibrate_return do_accel_calibration_measurements(orb_advert_t *mavlink_log_pub
 
 	// We should not try to subscribe if the topic doesn't actually exist and can be counted.
 	const unsigned accel_count = orb_group_count(ORB_ID(sensor_accel));
+
+	// Warn that we will not calibrate more than max_accels accelerometers
+	if (accel_count > max_accel_sens) {
+		calibration_log_critical(mavlink_log_pub, "[cal] Detected %u accels, but will calibrate only %u", accel_count, max_accel_sens);
+	}
+
 	for (unsigned i = 0; i < accel_count; i++) {
 		worker_data.subs[i] = orb_subscribe_multi(ORB_ID(sensor_accel), i);
+
 		if (worker_data.subs[i] < 0) {
+			calibration_log_critical(mavlink_log_pub, "[cal] Accel #%u not found, abort", i);
 			result = calibrate_return_error;
 			break;
 		}

--- a/src/modules/commander/gyro_calibration.cpp
+++ b/src/modules/commander/gyro_calibration.cpp
@@ -243,7 +243,7 @@ int do_gyro_calibration(orb_advert_t *mavlink_log_pub)
 
 		// Reset all offsets to 0 and scales to 1
 		(void)memcpy(&worker_data.gyro_scale[s], &gyro_scale_zero, sizeof(gyro_scale_zero));
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_EAGLE) && !defined(__PX4_POSIX_EXCELSIOR) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
+#ifdef __PX4_NUTTX
 		sprintf(str, "%s%u", GYRO_BASE_DEVICE_PATH, s);
 		int fd = px4_open(str, 0);
 		if (fd >= 0) {
@@ -310,7 +310,7 @@ int do_gyro_calibration(orb_advert_t *mavlink_log_pub)
 			struct gyro_report report;
 			orb_copy(ORB_ID(sensor_gyro), worker_data.gyro_sensor_sub[cur_gyro], &report);
 
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
+#ifdef __PX4_NUTTX
 
 			// For NuttX, we get the UNIQUE device ID from the sensor driver via an IOCTL
 			// and match it up with the one from the uORB subscription, because the
@@ -323,7 +323,7 @@ int do_gyro_calibration(orb_advert_t *mavlink_log_pub)
 				orb_unsubscribe(worker_data.gyro_sensor_sub[cur_gyro]);
 			}
 
-#elif defined(__PX4_QURT) || defined(__PX4_POSIX_RPI) || defined(__PX4_POSIX_BEBOP)
+#else
 
 			// For the DriverFramework drivers, we fill device ID (this is the first time) by copying one report.
 			worker_data.device_id[cur_gyro] = report.device_id;
@@ -473,7 +473,7 @@ int do_gyro_calibration(orb_advert_t *mavlink_log_pub)
 				(void)sprintf(str, "CAL_GYRO%u_ID", uorb_index);
 				failed |= (PX4_OK != param_set_no_notification(param_find(str), &(worker_data.device_id[uorb_index])));
 
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_EAGLE) && !defined(__PX4_POSIX_EXCELSIOR) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
+#ifdef __PX4_NUTTX
 				/* apply new scaling and offsets */
 				(void)sprintf(str, "%s%u", GYRO_BASE_DEVICE_PATH, uorb_index);
 				int fd = px4_open(str, 0);

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -138,7 +138,7 @@ int do_mag_calibration(orb_advert_t *mavlink_log_pub)
 	_last_mag_progress = 0;
 
 	for (unsigned cur_mag = 0; cur_mag < max_mags; cur_mag++) {
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
+#ifdef __PX4_NUTTX
 		// Reset mag id to mag not available
 		(void)sprintf(str, "CAL_MAG%u_ID", cur_mag);
 		result = param_set_no_notification(param_find(str), &(device_ids[cur_mag]));
@@ -193,8 +193,7 @@ int do_mag_calibration(orb_advert_t *mavlink_log_pub)
 
 #endif
 
-		/* for calibration, commander will run on apps, so orb messages are used to get info from dsp */
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
+#ifdef __PX4_NUTTX
 		// Attempt to open mag
 		(void)sprintf(str, "%s%u", MAG_BASE_DEVICE_PATH, cur_mag);
 		int fd = px4_open(str, O_RDONLY);
@@ -598,7 +597,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 				struct mag_report report;
 				orb_copy(ORB_ID(sensor_mag), worker_data.sub_mag[cur_mag], &report);
 
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
+#ifdef __PX4_NUTTX
 
 				// For NuttX, we get the UNIQUE device ID from the sensor driver via an IOCTL
 				// and match it up with the one from the uORB subscription, because the
@@ -611,7 +610,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 					orb_unsubscribe(worker_data.sub_mag[cur_mag]);
 				}
 
-#elif defined(__PX4_QURT) || defined(__PX4_POSIX_RPI) || defined(__PX4_POSIX_BEBOP)
+#else
 
 				// For the DriverFramework drivers, we fill device ID (this is the first time) by copying one report.
 				device_ids[cur_mag] = report.device_id;
@@ -792,7 +791,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 				mscale.y_scale = 1.0;
 				mscale.z_scale = 1.0;
 
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
+#ifdef __PX4_NUTTX
 				int fd_mag = -1;
 
 				// Set new scale
@@ -821,7 +820,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 					mscale.y_scale = diag_y[cur_mag];
 					mscale.z_scale = diag_z[cur_mag];
 
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
+#ifdef __PX4_NUTTX
 
 					if (px4_ioctl(fd_mag, MAGIOCSSCALE, (long unsigned int)&mscale) != PX4_OK) {
 						calibration_log_critical(mavlink_log_pub, CAL_ERROR_APPLY_CAL_MSG, cur_mag);
@@ -831,7 +830,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 #endif
 				}
 
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
+#ifdef __PX4_NUTTX
 
 				// Mag device no longer needed
 				if (fd_mag >= 0) {

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -592,14 +592,8 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 
 			// Lock in to correct ORB instance
 			bool found_cur_mag = false;
-			for(unsigned i = 0; i < orb_mag_count; i++) {
-				worker_data.sub_mag[cur_mag] = orb_subscribe_multi(ORB_ID(sensor_mag), cur_mag);
-
-				if (worker_data.sub_mag[cur_mag] < 0) {
-					calibration_log_critical(mavlink_log_pub, "[cal] Mag #%u not found, abort", cur_mag);
-					result = calibrate_return_error;
-					break;
-				}
+			for(unsigned i = 0; i < orb_mag_count && !found_cur_mag; i++) {
+				worker_data.sub_mag[cur_mag] = orb_subscribe_multi(ORB_ID(sensor_mag), i);
 
 				struct mag_report report;
 				orb_copy(ORB_ID(sensor_mag), worker_data.sub_mag[cur_mag], &report);
@@ -613,7 +607,6 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 				if(report.device_id == device_ids[cur_mag]) {
 					// Device IDs match, correct ORB instance for this mag
 					found_cur_mag = true;
-					break;
 				} else {
 					orb_unsubscribe(worker_data.sub_mag[cur_mag]);
 				}

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -153,6 +153,7 @@ PARAM_DEFINE_INT32(CAL_MAG0_ID, 0);
  *
  * @min -1
  * @max 30
+ * @reboot_required true
  * @group Sensor Calibration
  */
 PARAM_DEFINE_INT32(CAL_MAG0_ROT, -1);
@@ -359,6 +360,7 @@ PARAM_DEFINE_INT32(CAL_MAG1_ID, 0);
  *
  * @min -1
  * @max 30
+ * @reboot_required true
  * @group Sensor Calibration
  */
 PARAM_DEFINE_INT32(CAL_MAG1_ROT, -1);
@@ -565,6 +567,7 @@ PARAM_DEFINE_INT32(CAL_MAG2_ID, 0);
  *
  * @min -1
  * @max 30
+ * @reboot_required true
  * @group Sensor Calibration
  */
 PARAM_DEFINE_INT32(CAL_MAG2_ROT, -1);
@@ -710,6 +713,7 @@ PARAM_DEFINE_INT32(CAL_MAG3_ID, 0);
  *
  * @min -1
  * @max 30
+ * @reboot_required true
  * @group Sensor Calibration
  */
 PARAM_DEFINE_INT32(CAL_MAG3_ROT, -1);
@@ -875,6 +879,8 @@ PARAM_DEFINE_FLOAT(SENS_BARO_QNH, 1013.25f);
  * @value 23 Roll 270°, Yaw 135°
  * @value 24 Pitch 90°
  * @value 25 Pitch 270°
+ *
+ * @reboot_required true
  *
  * @group Sensor Calibration
  */

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -936,40 +936,6 @@ PARAM_DEFINE_FLOAT(SENS_BOARD_X_OFF, 0.0f);
 PARAM_DEFINE_FLOAT(SENS_BOARD_Z_OFF, 0.0f);
 
 /**
- * External magnetometer rotation
- *
- * @value 0 No rotation
- * @value 1 Yaw 45°
- * @value 2 Yaw 90°
- * @value 3 Yaw 135°
- * @value 4 Yaw 180°
- * @value 5 Yaw 225°
- * @value 6 Yaw 270°
- * @value 7 Yaw 315°
- * @value 8 Roll 180°
- * @value 9 Roll 180°, Yaw 45°
- * @value 10 Roll 180°, Yaw 90°
- * @value 11 Roll 180°, Yaw 135°
- * @value 12 Pitch 180°
- * @value 13 Roll 180°, Yaw 225°
- * @value 14 Roll 180°, Yaw 270°
- * @value 15 Roll 180°, Yaw 315°
- * @value 16 Roll 90°
- * @value 17 Roll 90°, Yaw 45°
- * @value 18 Roll 90°, Yaw 90°
- * @value 19 Roll 90°, Yaw 135°
- * @value 20 Roll 270°
- * @value 21 Roll 270°, Yaw 45°
- * @value 22 Roll 270°, Yaw 90°
- * @value 23 Roll 270°, Yaw 135°
- * @value 24 Pitch 90°
- * @value 25 Pitch 270°
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(SENS_EXT_MAG_ROT, 0);
-
-/**
  * Select primary magnetometer
  *
  * @min 0

--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -474,28 +474,6 @@ void VotedSensorsUpdate::parameters_update()
 						mag_rot = 0;
 						param_set_no_notification(param_find(str), &mag_rot);
 					}
-
-					/* handling of old setups, will be removed later (noted Feb 2015) */
-					int32_t deprecated_mag_rot = 0;
-					param_get(param_find("SENS_EXT_MAG_ROT"), &deprecated_mag_rot);
-
-					/*
-					 * If the deprecated parameter is non-default (is != 0),
-					 * and the new parameter is default (is == 0), then this board
-					 * was configured already and we need to copy the old value
-					 * to the new parameter.
-					 * The < 0 case is special: It means that this param slot was
-					 * used previously by an internal sensor, but the the call above
-					 * proved that it is currently occupied by an external sensor.
-					 * In that case we consider the orientation to be default as well.
-					 */
-					if ((deprecated_mag_rot != 0) && (mag_rot <= 0)) {
-						mag_rot = deprecated_mag_rot;
-						param_set_no_notification(param_find(str), &mag_rot);
-						/* clear the old param, not supported in GUI anyway */
-						deprecated_mag_rot = 0;
-						param_set_no_notification(param_find("SENS_EXT_MAG_ROT"), &deprecated_mag_rot);
-					}
 				}
 
 				if (failed) {


### PR DESCRIPTION
This PR : 

- Fixes a bad assumption in sensor calibration code, which assumed that uORB instance ID == the ID of the file descriptor (e.g /dev/sensor_gyroX) for a sensor. This would lead to offsets being applied to the wrong sensor depending on the race between driver instantiation and uORB advertisement. This was hidden so far because of the startup order of sensors on non-v4Pro and non-v5 boards.
- Enables temperature compensation and boot-calibration for HMC5x83 mags running on v4Pro and v5 hardware, which should improve performance in general.
- Fixes MPU9250 mag driver to properly publish it's device ID. 
- Fixes LIS3MDL mag driver to properly publish it's device ID. 
- Adds checks to the sensor calibration code which will fail the calibration if there are inconsistencies in device IDs (usually pointing to a buggy sensor driver) so that we can catch them out and fix them. These problems have remained hidden so far because nothing was forcing a sanity check.

This needs : 

- Test flights on Pixhawk 1 / Pixhawk Mini, Pixhawk 2.1, Pixracer and Pixhawk Pro. Full parameter reset and redo all calibrations before flying.
- Bench tests on Snapdragon Flight / Bebop / RPi to make sure that calibration still works as normal.
