### PR TITLE
Multicopter mixer: Fix thrust reduction for yaw control

### DIFF
--- a/src/modules/systemlib/mixer/mixer_multirotor.cpp
+++ b/src/modules/systemlib/mixer/mixer_multirotor.cpp
@@ -334,7 +334,7 @@ MultirotorMixer::mix(float *outputs, unsigned space, uint16_t *status_reg)
 
 			} else {
 				yaw = (1.0f - ((roll * _rotors[i].roll_scale + pitch * _rotors[i].pitch_scale) *
-					       roll_pitch_scale + thrust + boost)) / _rotors[i].yaw_scale;
+					       roll_pitch_scale + (thrust - thrust_reduction) + boost)) / _rotors[i].yaw_scale;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes the issue [#7288](https://github.com/PX4/Firmware/issues/7288).
When saturating the outputs, the mixer computes the correct new yaw value when reducing thrust.
You can see the results [here](http://logs.px4.io/plot_app?log=08e124ec-c9d0-4205-a740-9e48006290d9), [here](http://logs.px4.io/plot_app?log=4105252f-3d0b-48a7-9190-93a3e0cc8769) and [here](http://logs.px4.io/plot_app?log=c3a2cb92-66c6-40fd-8a95-8c560f8ac490)