### PR TITLE
Landdetector additional state

### DIFF
--- a/msg/vehicle_land_detected.msg
+++ b/msg/vehicle_land_detected.msg
@@ -1,4 +1,5 @@
 bool landed		# true if vehicle is currently landed on the ground
 bool freefall	# true if vehicle is currently in free-fall
 bool ground_contact # true if vehicle has ground contact but is not landed
+bool maybe_landed # true if the vehicle might have landed
 float32 alt_max 	# maximum altitude in [m] that can be reached

--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -112,6 +112,13 @@ bool FixedwingLandDetector::_get_ground_contact_state()
 	return false;
 }
 
+bool FixedwingLandDetector::_get_maybe_landed_state()
+{
+
+	// TODO
+	return false;
+}
+
 bool FixedwingLandDetector::_get_landed_state()
 {
 	// only trigger flight conditions if we are armed

--- a/src/modules/land_detector/FixedwingLandDetector.h
+++ b/src/modules/land_detector/FixedwingLandDetector.h
@@ -65,6 +65,8 @@ protected:
 
 	virtual bool _get_landed_state() override;
 
+	virtual bool _get_maybe_landed_state() override;
+
 	virtual bool _get_ground_contact_state() override;
 
 	virtual bool _get_freefall_state() override;

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -195,7 +195,7 @@ void LandDetector::_update_state()
 	_freefall_hysteresis.set_state_and_update(_get_freefall_state());
 	_landed_hysteresis.set_state_and_update(_get_landed_state());
 	_maybe_landed_hysteresis.set_state_and_update(_get_maybe_landed_state());
-	_ground_contact_hysteresis.set_state_and_update(_landed_hysteresis.get_state() || _get_ground_contact_state());
+	_ground_contact_hysteresis.set_state_and_update(_get_ground_contact_state());
 
 	if (_freefall_hysteresis.get_state()) {
 		_state = LandDetectionState::FREEFALL;

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -57,6 +57,7 @@ LandDetector::LandDetector() :
 	_state{},
 	_freefall_hysteresis(false),
 	_landed_hysteresis(true),
+	_maybe_landed_hysteresis(true),
 	_ground_contact_hysteresis(true),
 	_total_flight_time{0},
 	_takeoff_time{0},
@@ -64,6 +65,7 @@ LandDetector::LandDetector() :
 {
 	// Use Trigger time when transitioning from in-air (false) to landed (true) / ground contact (true).
 	_landed_hysteresis.set_hysteresis_time_from(false, LAND_DETECTOR_TRIGGER_TIME_US);
+	_maybe_landed_hysteresis.set_hysteresis_time_from(false, MAYBE_LAND_DETECTOR_TRIGGER_TIME_US);
 	_ground_contact_hysteresis.set_hysteresis_time_from(false, GROUND_CONTACT_TRIGGER_TIME_US);
 }
 
@@ -93,6 +95,7 @@ void LandDetector::_cycle()
 		_landDetected.freefall = false;
 		_landDetected.landed = false;
 		_landDetected.ground_contact = false;
+		_landDetected.maybe_landed = false;
 		_p_total_flight_time_high = param_find("LND_FLIGHT_T_HI");
 		_p_total_flight_time_low = param_find("LND_FLIGHT_T_LO");
 
@@ -117,6 +120,7 @@ void LandDetector::_cycle()
 
 	bool freefallDetected = (_state == LandDetectionState::FREEFALL);
 	bool landDetected = (_state == LandDetectionState::LANDED);
+	bool maybe_landedDetected = (_state == LandDetectionState::MAYBE_LANDED);
 	bool ground_contactDetected = (_state == LandDetectionState::GROUND_CONTACT);
 
 	// Only publish very first time or when the result has changed.
@@ -124,6 +128,7 @@ void LandDetector::_cycle()
 	    (_landDetected.freefall != freefallDetected) ||
 	    (_landDetected.landed != landDetected) ||
 	    (_landDetected.ground_contact != ground_contactDetected) ||
+	    (_landDetected.maybe_landed != maybe_landedDetected) ||
 	    (fabsf(_landDetected.alt_max - alt_max_prev) > FLT_EPSILON)) {
 
 		if (!landDetected && _landDetected.landed) {
@@ -144,6 +149,7 @@ void LandDetector::_cycle()
 		_landDetected.freefall = (_state == LandDetectionState::FREEFALL);
 		_landDetected.landed = (_state == LandDetectionState::LANDED);
 		_landDetected.ground_contact = (_state == LandDetectionState::GROUND_CONTACT);
+		_landDetected.maybe_landed = (_state == LandDetectionState::MAYBE_LANDED);
 		_landDetected.alt_max = _altitude_max;
 
 		int instance;
@@ -188,6 +194,7 @@ void LandDetector::_update_state()
 	 * with higher priority for landed */
 	_freefall_hysteresis.set_state_and_update(_get_freefall_state());
 	_landed_hysteresis.set_state_and_update(_get_landed_state());
+	_maybe_landed_hysteresis.set_state_and_update(_get_maybe_landed_state());
 	_ground_contact_hysteresis.set_state_and_update(_landed_hysteresis.get_state() || _get_ground_contact_state());
 
 	if (_freefall_hysteresis.get_state()) {
@@ -195,6 +202,9 @@ void LandDetector::_update_state()
 
 	} else if (_landed_hysteresis.get_state()) {
 		_state = LandDetectionState::LANDED;
+
+	} else if (_maybe_landed_hysteresis.get_state()) {
+		_state = LandDetectionState::MAYBE_LANDED;
 
 	} else if (_ground_contact_hysteresis.get_state()) {
 		_state = LandDetectionState::GROUND_CONTACT;

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -150,7 +150,7 @@ protected:
 	static constexpr uint64_t LAND_DETECTOR_TRIGGER_TIME_US = 500000;
 
 	/** Time in us that almost landing conditions have to hold before triggering almost landed . */
-	static constexpr uint64_t MAYBE_LAND_DETECTOR_TRIGGER_TIME_US = 1500000;
+	static constexpr uint64_t MAYBE_LAND_DETECTOR_TRIGGER_TIME_US = 1000000;
 
 	/** Time in us that ground contact condition have to hold before triggering contact ground */
 	static constexpr uint64_t GROUND_CONTACT_TRIGGER_TIME_US = 1000000;

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -147,7 +147,7 @@ protected:
 	static constexpr uint32_t LAND_DETECTOR_UPDATE_RATE_HZ = 50;
 
 	/** Time in us that landing conditions have to hold before triggering a land. */
-	static constexpr uint64_t LAND_DETECTOR_TRIGGER_TIME_US = 500000;
+	static constexpr uint64_t LAND_DETECTOR_TRIGGER_TIME_US = 300000;
 
 	/** Time in us that almost landing conditions have to hold before triggering almost landed . */
 	static constexpr uint64_t MAYBE_LAND_DETECTOR_TRIGGER_TIME_US = 250000;

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -60,7 +60,8 @@ public:
 		FLYING = 0,
 		LANDED = 1,
 		FREEFALL = 2,
-		GROUND_CONTACT = 3
+		GROUND_CONTACT = 3,
+		MAYBE_LANDED = 4
 	};
 
 	LandDetector();
@@ -116,6 +117,11 @@ protected:
 	virtual bool _get_landed_state() = 0;
 
 	/**
+	 * @return true if UAV is in almost landed state
+	 */
+	virtual bool _get_maybe_landed_state() = 0;
+
+	/**
 	 * @return true if UAV is touching ground but not landed
 	 */
 	virtual bool _get_ground_contact_state()  = 0;
@@ -141,7 +147,10 @@ protected:
 	static constexpr uint32_t LAND_DETECTOR_UPDATE_RATE_HZ = 50;
 
 	/** Time in us that landing conditions have to hold before triggering a land. */
-	static constexpr uint64_t LAND_DETECTOR_TRIGGER_TIME_US = 1500000;
+	static constexpr uint64_t LAND_DETECTOR_TRIGGER_TIME_US = 500000;
+
+	/** Time in us that almost landing conditions have to hold before triggering almost landed . */
+	static constexpr uint64_t MAYBE_LAND_DETECTOR_TRIGGER_TIME_US = 1500000;
 
 	/** Time in us that ground contact condition have to hold before triggering contact ground */
 	static constexpr uint64_t GROUND_CONTACT_TRIGGER_TIME_US = 1000000;
@@ -158,6 +167,7 @@ protected:
 
 	systemlib::Hysteresis _freefall_hysteresis;
 	systemlib::Hysteresis _landed_hysteresis;
+	systemlib::Hysteresis _maybe_landed_hysteresis;
 	systemlib::Hysteresis _ground_contact_hysteresis;
 
 	float _altitude_max;

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -150,10 +150,10 @@ protected:
 	static constexpr uint64_t LAND_DETECTOR_TRIGGER_TIME_US = 500000;
 
 	/** Time in us that almost landing conditions have to hold before triggering almost landed . */
-	static constexpr uint64_t MAYBE_LAND_DETECTOR_TRIGGER_TIME_US = 1000000;
+	static constexpr uint64_t MAYBE_LAND_DETECTOR_TRIGGER_TIME_US = 250000;
 
 	/** Time in us that ground contact condition have to hold before triggering contact ground */
-	static constexpr uint64_t GROUND_CONTACT_TRIGGER_TIME_US = 1000000;
+	static constexpr uint64_t GROUND_CONTACT_TRIGGER_TIME_US = 350000;
 
 	/** Time interval in us in which wider acceptance thresholds are used after arming. */
 	static constexpr uint64_t LAND_DETECTOR_ARM_PHASE_TIME_US = 2000000;

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -218,9 +218,13 @@ bool MulticopterLandDetector::_get_ground_contact_state()
 			  && (_vehicleLocalPositionSetpoint.vz >= 0.9f * math::max(_params.landSpeed, 0.1f));
 	bool hit_ground = in_descend && !verticalMovement;
 
+	// Check if we are moving horizontally.
+	bool horizontalMovement = sqrtf(_vehicleLocalPosition.vx * _vehicleLocalPosition.vx
+					+ _vehicleLocalPosition.vy * _vehicleLocalPosition.vy) > _params.maxVelocity;
+
 	// If pilots commands down or in auto mode and we are already below minimal thrust and we do not move down we assume ground contact
 	// TODO: we need an accelerometer based check for vertical movement for flying without GPS
-	if (manual_control_idle_or_auto && (_has_low_thrust() || hit_ground) &&
+	if (manual_control_idle_or_auto && _has_low_thrust() && (!horizontalMovement || !_has_position_lock()) &&
 	    (!verticalMovement || !_has_altitude_lock())) {
 		return true;
 	}
@@ -276,10 +280,6 @@ bool MulticopterLandDetector::_get_maybe_landed_state()
 		armThresholdFactor = 2.5f;
 	}
 
-	// Check if we are moving horizontally.
-	bool horizontalMovement = sqrtf(_vehicleLocalPosition.vx * _vehicleLocalPosition.vx
-					+ _vehicleLocalPosition.vy * _vehicleLocalPosition.vy) > _params.maxVelocity;
-
 	// Next look if all rotation angles are not moving.
 	float maxRotationScaled = _params.maxRotation_rad_s * armThresholdFactor;
 
@@ -287,8 +287,7 @@ bool MulticopterLandDetector::_get_maybe_landed_state()
 			(fabsf(_vehicleAttitude.pitchspeed) > maxRotationScaled) ||
 			(fabsf(_vehicleAttitude.yawspeed) > maxRotationScaled);
 
-	if (_ground_contact_hysteresis.get_state() && _has_minimal_thrust() && !rotating &&
-	    (!horizontalMovement || !_has_position_lock())) {
+	if (_ground_contact_hysteresis.get_state() && _has_minimal_thrust() && !rotating) {
 		// Ground contact, no thrust and no movement -> landed
 		return true;
 	}

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -75,6 +75,7 @@ MulticopterLandDetector::MulticopterLandDetector() :
 	_paramHandle(),
 	_params(),
 	_vehicleLocalPositionSub(-1),
+	_vehicleLocalPositionSetpointSub(-1),
 	_actuatorsSub(-1),
 	_armingSub(-1),
 	_attitudeSub(-1),
@@ -83,6 +84,7 @@ MulticopterLandDetector::MulticopterLandDetector() :
 	_vehicle_control_mode_sub(-1),
 	_battery_sub(-1),
 	_vehicleLocalPosition{},
+	_vehicleLocalPositionSetpoint{},
 	_actuators{},
 	_arming{},
 	_vehicleAttitude{},
@@ -105,12 +107,14 @@ MulticopterLandDetector::MulticopterLandDetector() :
 	_paramHandle.manual_stick_down_threshold = param_find("LNDMC_MAN_DWNTHR");
 	_paramHandle.altitude_max = param_find("LNDMC_ALT_MAX");
 	_paramHandle.manual_stick_up_position_takeoff_threshold = param_find("LNDMC_POS_UPTHR");
+	_paramHandle.landSpeed = param_find("MPC_LAND_SPEED");
 }
 
 void MulticopterLandDetector::_initialize_topics()
 {
 	// subscribe to position, attitude, arming and velocity changes
 	_vehicleLocalPositionSub = orb_subscribe(ORB_ID(vehicle_local_position));
+	_vehicleLocalPositionSetpointSub = orb_subscribe(ORB_ID(vehicle_local_position_setpoint));
 	_attitudeSub = orb_subscribe(ORB_ID(vehicle_attitude));
 	_actuatorsSub = orb_subscribe(ORB_ID(actuator_controls_0));
 	_armingSub = orb_subscribe(ORB_ID(actuator_armed));
@@ -124,6 +128,7 @@ void MulticopterLandDetector::_initialize_topics()
 void MulticopterLandDetector::_update_topics()
 {
 	_orb_update(ORB_ID(vehicle_local_position), _vehicleLocalPositionSub, &_vehicleLocalPosition);
+	_orb_update(ORB_ID(vehicle_local_position_setpoint), _vehicleLocalPositionSetpointSub, &_vehicleLocalPositionSetpoint);
 	_orb_update(ORB_ID(vehicle_attitude), _attitudeSub, &_vehicleAttitude);
 	_orb_update(ORB_ID(actuator_controls_0), _actuatorsSub, &_actuators);
 	_orb_update(ORB_ID(actuator_armed), _armingSub, &_arming);
@@ -149,6 +154,7 @@ void MulticopterLandDetector::_update_params()
 	param_get(_paramHandle.manual_stick_down_threshold, &_params.manual_stick_down_threshold);
 	param_get(_paramHandle.altitude_max, &_params.altitude_max);
 	param_get(_paramHandle.manual_stick_up_position_takeoff_threshold, &_params.manual_stick_up_position_takeoff_threshold);
+	param_get(_paramHandle.landSpeed, &_params.landSpeed);
 }
 
 
@@ -206,9 +212,14 @@ bool MulticopterLandDetector::_get_ground_contact_state()
 	// an accurate in-air indication.
 	bool verticalMovement = fabsf(_vehicleLocalPosition.vz) > _params.maxClimbRate * armThresholdFactor;
 
+	// if we have a valid velocity setpoint and the vehicle is demanded to go down but no vertical movement present,
+	// we then can assume that the vehicle hit ground
+	bool in_descend = _is_velocity_control_active() && (_vehicleLocalPositionSetpoint.vz >= 0.9f * _params.landSpeed);
+	bool hit_ground = in_descend && !verticalMovement;
+
 	// If pilots commands down or in auto mode and we are already below minimal thrust and we do not move down we assume ground contact
 	// TODO: we need an accelerometer based check for vertical movement for flying without GPS
-	if (manual_control_idle_or_auto && _has_low_thrust() &&
+	if (manual_control_idle_or_auto && (_has_low_thrust() || hit_ground) &&
 	    (!verticalMovement || !_has_altitude_lock())) {
 		return true;
 	}
@@ -347,6 +358,15 @@ bool MulticopterLandDetector::_has_position_lock()
 bool MulticopterLandDetector::_has_manual_control_present()
 {
 	return _control_mode.flag_control_manual_enabled && _manual.timestamp > 0;
+}
+
+bool MulticopterLandDetector::_is_velocity_control_active()
+{
+	bool is_finite = PX4_ISFINITE(_vehicleLocalPositionSetpoint.vx) && PX4_ISFINITE(_vehicleLocalPositionSetpoint.vy)
+			 && PX4_ISFINITE(_vehicleLocalPositionSetpoint.vz);
+
+	return (_vehicleLocalPositionSetpoint.timestamp != 0) &&
+	       (hrt_elapsed_time(&_vehicleLocalPositionSetpoint.timestamp) < 500000) && is_finite;
 }
 
 bool MulticopterLandDetector::_has_low_thrust()

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -34,6 +34,28 @@
 /**
  * @file MulticopterLandDetector.cpp
  *
+ *The MC land-detector goes through 3 states before it will detect landed:
+ *
+ *State 1 (=ground_contact):
+ *ground_contact is detected once the vehicle is not moving along the NED-z direction and has
+ *a thrust value below 0.3 of the thrust_range (thrust_max - thrust_min). The condition has to be true
+ *for GROUND_CONTACT_TRIGGER_TIME_US in order to detect ground_contact
+ *
+ *State 2 (=maybe_landed):
+ *maybe_landed can only occur if the internal ground_contact hysteresis state is true. maybe_landed criteria requires to have no motion in x and y,
+ *no rotation and a thrust below 0.1 of the thrust_range (thrust_max - thrust_min). In addition, the mc_pos_control turns off the thrust_sp in
+ *body frame along x and y. The criteria for maybe_landed needs to be true for MAYBE_LAND_DETECTOR_TRIGGER_TIME_US.
+ *
+ *State 3 (=landed)
+ *landed can only be detected if maybe_landed is true for LAND_DETECTOR_TRIGGER_TIME_US. No farther criteria is tested, but the mc_pos_control goes into
+ *idle (thrust_sp = 0). By doing this the thrust_criteria of State 2 will always be met, however the remaining criteria of no rotation and no motion still
+ *has to be valid.
+
+ *It is to note that if one criteria is not met, then vehicle exits the state directly without blocking.
+ *
+ *If the land-detector does not detect ground_contact, then the vehicle is either flying or falling, where free fall detection heavily relies
+ *on the acceleration. TODO: verify that free fall is reliable
+ *
  * @author Johan Jansen <jnsn.johan@gmail.com>
  * @author Morten Lysgaard <morten@lysgaard.no>
  * @author Julian Oes <julian@oes.ch>

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -335,11 +335,8 @@ bool MulticopterLandDetector::_has_low_thrust()
 	// 30% of throttle range between min and hover
 	float sys_min_throttle = _params.minThrottle + (_params.hoverThrottle - _params.minThrottle) * 0.3f;
 
-	PX4_INFO("_actuatl control 3: %.5f, sys_min_throttle: %.5f", (double)_actuators.control[3], (double)sys_min_throttle);
-
 	// Check if thrust output is less than the minimum auto throttle param.
 	return _actuators.control[3] <= sys_min_throttle;
-
 }
 
 bool MulticopterLandDetector::_has_minimal_thrust()

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -266,11 +266,8 @@ bool MulticopterLandDetector::_get_landed_state()
 {
 	// if we have maybe_landed, the mc_pos_control goes into idle (thrust_sp = 0.0)
 	// therefore check if all other condition of the landed state remain true
-	if (_maybe_landed_hysteresis.get_state()) {
-		return true;
-	}
+	return _maybe_landed_hysteresis.get_state();
 
-	return false;
 }
 
 float MulticopterLandDetector::_get_takeoff_throttle()

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -224,7 +224,8 @@ bool MulticopterLandDetector::_get_ground_contact_state()
 
 	// If pilots commands down or in auto mode and we are already below minimal thrust and we do not move down we assume ground contact
 	// TODO: we need an accelerometer based check for vertical movement for flying without GPS
-	if (manual_control_idle_or_auto && _has_low_thrust() && (!horizontalMovement || !_has_position_lock()) &&
+	if (manual_control_idle_or_auto && (_has_low_thrust() || hit_ground) && (!horizontalMovement || !_has_position_lock())
+	    &&
 	    (!verticalMovement || !_has_altitude_lock())) {
 		return true;
 	}

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -38,18 +38,18 @@
  *
  *State 1 (=ground_contact):
  *ground_contact is detected once the vehicle is not moving along the NED-z direction and has
- *a thrust value below 0.3 of the thrust_range (thrust_max - thrust_min). The condition has to be true
+ *a thrust value below 0.3 of the thrust_range (thrust_hover - thrust_min). The condition has to be true
  *for GROUND_CONTACT_TRIGGER_TIME_US in order to detect ground_contact
  *
  *State 2 (=maybe_landed):
  *maybe_landed can only occur if the internal ground_contact hysteresis state is true. maybe_landed criteria requires to have no motion in x and y,
- *no rotation and a thrust below 0.1 of the thrust_range (thrust_max - thrust_min). In addition, the mc_pos_control turns off the thrust_sp in
- *body frame along x and y. The criteria for maybe_landed needs to be true for MAYBE_LAND_DETECTOR_TRIGGER_TIME_US.
+ *no rotation and a thrust below 0.1 of the thrust_range (thrust_hover - thrust_min). In addition, the mc_pos_control turns off the thrust_sp in
+ *body frame along x and y which helps to detect maybe_landed. The criteria for maybe_landed needs to be true for MAYBE_LAND_DETECTOR_TRIGGER_TIME_US.
  *
  *State 3 (=landed)
  *landed can only be detected if maybe_landed is true for LAND_DETECTOR_TRIGGER_TIME_US. No farther criteria is tested, but the mc_pos_control goes into
- *idle (thrust_sp = 0). By doing this the thrust_criteria of State 2 will always be met, however the remaining criteria of no rotation and no motion still
- *has to be valid.
+ *idle (thrust_sp = 0) which helps to detect landed. By doing this the thrust-criteria of State 2 will always be met, however the remaining criteria of no rotation and no motion still
+ *have to be valid.
 
  *It is to note that if one criteria is not met, then vehicle exits the state directly without blocking.
  *

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -225,8 +225,7 @@ bool MulticopterLandDetector::_get_ground_contact_state()
 	// If pilots commands down or in auto mode and we are already below minimal thrust and we do not move down we assume ground contact
 	// TODO: we need an accelerometer based check for vertical movement for flying without GPS
 	if (manual_control_idle_or_auto && (_has_low_thrust() || hit_ground) && (!horizontalMovement || !_has_position_lock())
-	    &&
-	    (!verticalMovement || !_has_altitude_lock())) {
+	    && (!verticalMovement || !_has_altitude_lock())) {
 		return true;
 	}
 

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -44,6 +44,7 @@
 
 #include <systemlib/param/param.h>
 #include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_local_position_setpoint.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/actuator_armed.h>
@@ -97,6 +98,7 @@ private:
 		param_t manual_stick_down_threshold;
 		param_t altitude_max;
 		param_t manual_stick_up_position_takeoff_threshold;
+		param_t landSpeed;
 	} _paramHandle;
 
 	struct {
@@ -112,9 +114,11 @@ private:
 		float manual_stick_down_threshold;
 		float altitude_max;
 		float manual_stick_up_position_takeoff_threshold;
+		float landSpeed;
 	} _params;
 
 	int _vehicleLocalPositionSub;
+	int _vehicleLocalPositionSetpointSub;
 	int _actuatorsSub;
 	int _armingSub;
 	int _attitudeSub;
@@ -124,6 +128,7 @@ private:
 	int _battery_sub;
 
 	struct vehicle_local_position_s		_vehicleLocalPosition;
+	struct vehicle_local_position_setpoint_s _vehicleLocalPositionSetpoint;
 	struct actuator_controls_s		_actuators;
 	struct actuator_armed_s			_arming;
 	struct vehicle_attitude_s		_vehicleAttitude;
@@ -142,6 +147,7 @@ private:
 	bool _has_manual_control_present();
 	bool _has_minimal_thrust();
 	bool _has_low_thrust();
+	bool _is_velocity_control_active();
 };
 
 

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -74,6 +74,8 @@ protected:
 
 	virtual bool _get_ground_contact_state() override;
 
+	virtual bool _get_maybe_landed_state() override;
+
 	virtual bool _get_freefall_state() override;
 
 	virtual float _get_max_altitude() override;
@@ -139,6 +141,7 @@ private:
 	bool _has_position_lock();
 	bool _has_manual_control_present();
 	bool _has_minimal_thrust();
+	bool _has_low_thrust();
 };
 
 

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -147,7 +147,7 @@ private:
 	bool _has_manual_control_present();
 	bool _has_minimal_thrust();
 	bool _has_low_thrust();
-	bool _is_velocity_control_active();
+	bool _is_climb_rate_enabled();
 };
 
 

--- a/src/modules/land_detector/RoverLandDetector.cpp
+++ b/src/modules/land_detector/RoverLandDetector.cpp
@@ -67,6 +67,12 @@ bool RoverLandDetector::_get_ground_contact_state()
 	return false;
 }
 
+bool RoverLandDetector::_get_maybe_landed_state()
+{
+	return false;
+}
+
+
 bool RoverLandDetector::_get_landed_state()
 {
 	return false;

--- a/src/modules/land_detector/RoverLandDetector.h
+++ b/src/modules/land_detector/RoverLandDetector.h
@@ -64,6 +64,8 @@ protected:
 
 	virtual bool  _get_ground_contact_state() override;
 
+	virtual bool _get_maybe_landed_state() override;
+
 	virtual bool _get_freefall_state() override;
 
 	virtual float _get_max_altitude() override;

--- a/src/modules/land_detector/VtolLandDetector.cpp
+++ b/src/modules/land_detector/VtolLandDetector.cpp
@@ -76,6 +76,13 @@ bool VtolLandDetector::_get_ground_contact_state()
 	return MulticopterLandDetector::_get_ground_contact_state();
 }
 
+bool VtolLandDetector::_get_maybe_landed_state()
+{
+
+	// TODO
+	return false;
+}
+
 bool VtolLandDetector::_get_landed_state()
 {
 	// this is returned from the mutlicopter land detector

--- a/src/modules/land_detector/VtolLandDetector.h
+++ b/src/modules/land_detector/VtolLandDetector.h
@@ -62,6 +62,8 @@ protected:
 
 	virtual bool _get_landed_state() override;
 
+	virtual bool _get_maybe_landed_state() override;
+
 	virtual bool  _get_ground_contact_state() override;
 
 	virtual bool _get_freefall_state() override;

--- a/src/modules/land_detector/land_detector_params.c
+++ b/src/modules/land_detector/land_detector_params.c
@@ -60,7 +60,7 @@ PARAM_DEFINE_FLOAT(LNDMC_Z_VEL_MAX, 0.50f);
  *
  * @group Land Detector
  */
-PARAM_DEFINE_FLOAT(LNDMC_XY_VEL_MAX, 1.50f);
+PARAM_DEFINE_FLOAT(LNDMC_XY_VEL_MAX, 0.5f);
 
 /**
  * Multicopter max rotation

--- a/src/modules/land_detector/land_detector_params.c
+++ b/src/modules/land_detector/land_detector_params.c
@@ -60,7 +60,7 @@ PARAM_DEFINE_FLOAT(LNDMC_Z_VEL_MAX, 0.50f);
  *
  * @group Land Detector
  */
-PARAM_DEFINE_FLOAT(LNDMC_XY_VEL_MAX, 0.5f);
+PARAM_DEFINE_FLOAT(LNDMC_XY_VEL_MAX, 1.5f);
 
 /**
  * Multicopter max rotation

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1807,7 +1807,7 @@ MulticopterPositionControl::calculate_thrust_setpoint(float dt)
 		thrust_sp(1) = 0.0f;
 	}
 
-	if (!in_auto_takeoff) {
+	if (!in_auto_takeoff()) {
 		if (_vehicle_land_detected.ground_contact) {
 			/* if still or already on ground command zero xy thrust_sp in body
 			 * frame to consider uneven ground */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1807,33 +1807,31 @@ MulticopterPositionControl::calculate_thrust_setpoint(float dt)
 		thrust_sp(1) = 0.0f;
 	}
 
-	/* if still or already on ground command zero xy velcoity and zero xy thrust_sp in body frame to consider uneven ground */
-	if (_vehicle_land_detected.ground_contact && !in_auto_takeoff()) {
+	if (!in_auto_takeoff) {
+		if (_vehicle_land_detected.ground_contact) {
+			/* if still or already on ground command zero xy thrust_sp in body
+			 * frame to consider uneven ground */
 
+			/* thrust setpoint in body frame*/
+			math::Vector<3> thrust_sp_body = _R.transposed() * thrust_sp;
 
-		/* if still or already on ground command zero xy thrust_sp in body
-		 * frame to consider uneven ground */
+			/* we dont want to make any correction in body x and y*/
+			thrust_sp_body(0) = 0.0f;
+			thrust_sp_body(1) = 0.0f;
 
-		/* thrust setpoint in body frame*/
-		math::Vector<3> thrust_sp_body = _R.transposed() * thrust_sp;
+			/* make sure z component of thrust_sp_body is larger than 0 (positive thrust is downward) */
+			thrust_sp_body(2) = thrust_sp(2) > 0.0f ? thrust_sp(2) : 0.0f;
 
-		/* we dont want to make any correction in body x and y*/
-		thrust_sp_body(0) = 0.0f;
-		thrust_sp_body(1) = 0.0f;
+			/* convert back to local frame (NED) */
+			thrust_sp = _R * thrust_sp_body;
+		}
 
-		/* make sure z component of thrust_sp_body is larger than 0 (positive thrust is downward) */
-		thrust_sp_body(2) = thrust_sp(2) > 0.0f ? thrust_sp(2) : 0.0f;
-
-		/* convert back to local frame (NED) */
-		thrust_sp = _R * thrust_sp_body;
-	}
-
-	if (_vehicle_land_detected.maybe_landed
-	    && !(_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF)) {
-		/* we set thrust to zero
-		 * this will help to decide if we are actually landed or not
-		 */
-		thrust_sp.zero();
+		if (_vehicle_land_detected.maybe_landed) {
+			/* we set thrust to zero
+			 * this will help to decide if we are actually landed or not
+			 */
+			thrust_sp.zero();
+		}
 	}
 
 	if (!_control_mode.flag_control_climb_rate_enabled && !_control_mode.flag_control_acceleration_enabled) {

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1834,9 +1834,9 @@ MulticopterPositionControl::calculate_thrust_setpoint(float dt)
 
 		/* convert back to local frame (NED) */
 		thrust_sp = _R * thrust_sp_body;
+	}
 
-
-	} else if (_vehicle_land_detected.maybe_landed) {
+	if (_vehicle_land_detected.maybe_landed) {
 		/* we set thrust to zero
 		 * this will help to decide if we are actually landed or not
 		 */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1818,6 +1818,10 @@ MulticopterPositionControl::calculate_thrust_setpoint(float dt)
 	/* if still or already on ground command zero xy velcoity and zero xy thrust_sp in body frame to consider uneven ground */
 	if (_vehicle_land_detected.ground_contact && !in_auto_takeoff()) {
 
+
+		/* if still or already on ground command zero xy thrust_sp in body
+		 * frame to consider uneven ground */
+
 		/* thrust setpoint in body frame*/
 		math::Vector<3> thrust_sp_body = _R.transposed() * thrust_sp;
 
@@ -1831,11 +1835,12 @@ MulticopterPositionControl::calculate_thrust_setpoint(float dt)
 		/* convert back to local frame (NED) */
 		thrust_sp = _R * thrust_sp_body;
 
-		/* set velocity setpoint to zero and reset position */
-		_vel_sp(0) = 0.0f;
-		_vel_sp(1) = 0.0f;
-		_pos_sp(0) = _pos(0);
-		_pos_sp(1) = _pos(1);
+
+	} else if (_vehicle_land_detected.maybe_landed) {
+		/* we set thrust to zero
+		 * this will help to decide if we are actually landed or not
+		 */
+		thrust_sp.zero();
 	}
 
 	if (!_control_mode.flag_control_climb_rate_enabled && !_control_mode.flag_control_acceleration_enabled) {

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1828,7 +1828,8 @@ MulticopterPositionControl::calculate_thrust_setpoint(float dt)
 		thrust_sp = _R * thrust_sp_body;
 	}
 
-	if (_vehicle_land_detected.maybe_landed) {
+	if (_vehicle_land_detected.maybe_landed
+	    && !(_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF)) {
 		/* we set thrust to zero
 		 * this will help to decide if we are actually landed or not
 		 */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -253,10 +253,6 @@ private:
 	math::Matrix<3, 3> _R;			/**< rotation matrix from attitude quaternions */
 	float _yaw;				/**< yaw angle (euler) */
 	float _yaw_takeoff;	/**< home yaw angle present when vehicle was taking off (euler) */
-	bool _in_landing;	/**< the vehicle is in the landing descent */
-	bool _lnd_reached_ground; /**< controller assumes the vehicle has reached the ground after landing */
-	float _vel_z_lp;
-	float _acc_z_lp;
 	float _vel_max_xy;  /**< equal to vel_max except in auto mode when close to target */
 
 	bool _in_takeoff = false; /**< flag for smooth velocity setpoint takeoff ramp */
@@ -426,10 +422,6 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_pos_first_nonfinite(true),
 	_yaw(0.0f),
 	_yaw_takeoff(0.0f),
-	_in_landing(false),
-	_lnd_reached_ground(false),
-	_vel_z_lp(0),
-	_acc_z_lp(0),
 	_vel_max_xy(0.0f),
 	_takeoff_vel_limit(0.0f),
 	_z_reset_counter(0),
@@ -1862,13 +1854,6 @@ MulticopterPositionControl::calculate_thrust_setpoint(float dt)
 	float tilt_max = _params.tilt_max_air;
 	float thr_max = _params.thr_max;
 
-	/* filter vel_z over 1/8sec */
-	_vel_z_lp = _vel_z_lp * (1.0f - dt * 8.0f) + dt * 8.0f * _vel(2);
-
-	/* filter vel_z change over 1/8sec */
-	float vel_z_change = (_vel(2) - _vel_prev(2)) / dt;
-	_acc_z_lp = _acc_z_lp * (1.0f - dt * 8.0f) + dt * 8.0f * vel_z_change;
-
 	// We can only run the control if we're already in-air, have a takeoff setpoint,
 	// or if we're in offboard control.
 	// Otherwise, we should just bail out
@@ -1882,59 +1867,6 @@ MulticopterPositionControl::calculate_thrust_setpoint(float dt)
 		/* adjust limits for landing mode */
 		/* limit max tilt and min lift when landing */
 		tilt_max = _params.tilt_max_land;
-
-		if (thr_min < 0.0f) {
-			thr_min = 0.0f;
-		}
-
-		/* descend stabilized, we're landing */
-		if (!_in_landing && !_lnd_reached_ground
-		    && (fabsf(_acc_z_lp) < 0.1f)
-		    && _vel_z_lp > 0.6f * _params.land_speed) {
-
-			_in_landing = true;
-		}
-
-		float land_z_threshold = 0.1f;
-
-		/* assume ground, cut thrust */
-		if (_in_landing
-		    && _vel_z_lp < land_z_threshold) {
-			thr_max = 0.0f;
-			_in_landing = false;
-			_lnd_reached_ground = true;
-
-		} else if (_in_landing
-			   && _vel_z_lp < math::min(0.3f * _params.land_speed, 2.5f * land_z_threshold)) {
-			/* not on ground but with ground contact, stop position and velocity control */
-			thrust_sp(0) = 0.0f;
-			thrust_sp(1) = 0.0f;
-			_vel_sp(0) = _vel(0);
-			_vel_sp(1) = _vel(1);
-			_pos_sp(0) = _pos(0);
-			_pos_sp(1) = _pos(1);
-		}
-
-		/* once we assumed to have reached the ground always cut the thrust.
-			Only free fall detection below can revoke this
-		*/
-		if (!_in_landing && _lnd_reached_ground) {
-			thr_max = 0.0f;
-		}
-
-		/* if we suddenly fall, reset landing logic and remove thrust limit */
-		if (_lnd_reached_ground
-		    /* XXX: magic value, assuming free fall above 4 m/s^2 acceleration */
-		    && (_acc_z_lp > 4.0f || _vel_z_lp > 2.0f * _params.land_speed)) {
-
-			thr_max = _params.thr_max;
-			_in_landing = true;
-			_lnd_reached_ground = false;
-		}
-
-	} else {
-		_in_landing = false;
-		_lnd_reached_ground = false;
 	}
 
 	/* limit min lift */


### PR DESCRIPTION
the pr adds a new state to the landdetection: maybe_landed
This new state allows to be less conservative when detecting ground_contact. During ground_contact, only the thrust in body x and y is turned off, and the z component is not farther adjusted like it is in the current firmware. during maybe_landed, the thrust_sp is set to zero: this serves as a test for the landing detection to prevent false-positive for the actual landing_detected state.