### PR TITLE
Add LED signal when boot failed

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -1189,6 +1189,7 @@ unset TUNE_ERR
 
 # Boot is complete, inform MAVLink app(s) that the system is now fully up and running
 mavlink boot_complete
+commander boot_complete
 
 if [ $EXIT_ON_END == yes ]
 then

--- a/posix-configs/SITL/init/ekf2/iris
+++ b/posix-configs/SITL/init/ekf2/iris
@@ -75,4 +75,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/ekf2/iris_1
+++ b/posix-configs/SITL/init/ekf2/iris_1
@@ -77,4 +77,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/ekf2/iris_2
+++ b/posix-configs/SITL/init/ekf2/iris_2
@@ -77,4 +77,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14558
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14558
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/ekf2/iris_opt_flow
+++ b/posix-configs/SITL/init/ekf2/iris_opt_flow
@@ -75,4 +75,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/ekf2/multiple_iris
+++ b/posix-configs/SITL/init/ekf2/multiple_iris
@@ -74,4 +74,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u _MAVPORT_
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u _MAVPORT_
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/ekf2/plane
+++ b/posix-configs/SITL/init/ekf2/plane
@@ -82,4 +82,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/ekf2/rover
+++ b/posix-configs/SITL/init/ekf2/rover
@@ -69,4 +69,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/ekf2/solo
+++ b/posix-configs/SITL/init/ekf2/solo
@@ -72,4 +72,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/ekf2/standard_vtol
+++ b/posix-configs/SITL/init/ekf2/standard_vtol
@@ -94,4 +94,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/ekf2/tailsitter
+++ b/posix-configs/SITL/init/ekf2/tailsitter
@@ -74,4 +74,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/ekf2/typhoon_h480
+++ b/posix-configs/SITL/init/ekf2/typhoon_h480
@@ -76,4 +76,5 @@ mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 vmount start
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/inav/iris
+++ b/posix-configs/SITL/init/inav/iris
@@ -74,4 +74,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/inav/iris_opt_flow
+++ b/posix-configs/SITL/init/inav/iris_opt_flow
@@ -76,4 +76,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/lpe/iris
+++ b/posix-configs/SITL/init/lpe/iris
@@ -76,4 +76,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/lpe/iris_1
+++ b/posix-configs/SITL/init/lpe/iris_1
@@ -78,4 +78,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/lpe/iris_2
+++ b/posix-configs/SITL/init/lpe/iris_2
@@ -78,4 +78,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14558
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14558
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/lpe/iris_opt_flow
+++ b/posix-configs/SITL/init/lpe/iris_opt_flow
@@ -94,4 +94,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/lpe/iris_rplidar
+++ b/posix-configs/SITL/init/lpe/iris_rplidar
@@ -76,4 +76,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/lpe/plane
+++ b/posix-configs/SITL/init/lpe/plane
@@ -80,4 +80,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/lpe/solo
+++ b/posix-configs/SITL/init/lpe/solo
@@ -76,4 +76,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/lpe/standard_vtol
+++ b/posix-configs/SITL/init/lpe/standard_vtol
@@ -90,4 +90,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/lpe/typhoon_h480
+++ b/posix-configs/SITL/init/lpe/typhoon_h480
@@ -75,4 +75,5 @@ mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 vmount start
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/rcS_gazebo_delta_wing
+++ b/posix-configs/SITL/init/rcS_gazebo_delta_wing
@@ -57,4 +57,5 @@ mavlink stream -r 250 -s HIGHRES_IMU -u 14556
 mavlink stream -r 10 -s OPTICAL_FLOW_RAD -u 14556
 logger start -e -t
 mavlink boot_complete
+commander boot_complete
 replay trystart

--- a/posix-configs/SITL/init/test/test_template.in
+++ b/posix-configs/SITL/init/test/test_template.in
@@ -24,6 +24,7 @@ list_files
 
 mavlink start -u 14556 -r 2000000
 mavlink boot_complete
+commander boot_complete
 
 tests @test_name@
 

--- a/posix-configs/bebop/px4.config
+++ b/posix-configs/bebop/px4.config
@@ -48,4 +48,5 @@ mavlink stream -u 14556 -s HIGHRES_IMU -r 50
 mavlink stream -u 14556 -s ATTITUDE -r 50
 df_bebop_bus_wrapper start
 mavlink boot_complete
+commander boot_complete
 logger start -b 200 -e -t

--- a/posix-configs/eagle/200qx/mainapp.config
+++ b/posix-configs/eagle/200qx/mainapp.config
@@ -11,3 +11,4 @@ mavlink stream -u 14556 -s HIGHRES_IMU -r 50
 mavlink stream -u 14556 -s ATTITUDE -r 50
 mavlink stream -u 14556 -s RC_CHANNELS -r 20
 mavlink boot_complete
+commander boot_complete

--- a/posix-configs/eagle/210qc/mainapp.config
+++ b/posix-configs/eagle/210qc/mainapp.config
@@ -11,3 +11,4 @@ mavlink stream -u 14556 -s HIGHRES_IMU -r 50
 mavlink stream -u 14556 -s ATTITUDE -r 50
 mavlink stream -u 14556 -s RC_CHANNELS -r 20
 mavlink boot_complete
+commander boot_complete

--- a/posix-configs/eagle/flight/mainapp.config
+++ b/posix-configs/eagle/flight/mainapp.config
@@ -11,3 +11,4 @@ mavlink stream -u 14556 -s HIGHRES_IMU -r 50
 mavlink stream -u 14556 -s ATTITUDE -r 50
 mavlink stream -u 14556 -s RC_CHANNELS -r 20
 mavlink boot_complete
+commander boot_complete

--- a/posix-configs/eagle/hil/mainapphil.config
+++ b/posix-configs/eagle/hil/mainapphil.config
@@ -6,4 +6,5 @@ sleep 1
 mavlink stream -u 14556 -s HIGHRES_IMU -r 50
 mavlink stream -u 14556 -s ATTITUDE -r 50
 mavlink boot_complete
+commander boot_complete
 simulator start -p

--- a/posix-configs/excelsior/mainapp.config
+++ b/posix-configs/excelsior/mainapp.config
@@ -11,3 +11,4 @@ mavlink stream -u 14556 -s HIGHRES_IMU -r 50
 mavlink stream -u 14556 -s ATTITUDE -r 50
 mavlink stream -u 14556 -s RC_CHANNELS -r 20
 mavlink boot_complete
+commander boot_complete

--- a/posix-configs/rpi/px4.config
+++ b/posix-configs/rpi/px4.config
@@ -33,3 +33,4 @@ navio_sysfs_rc_in start
 navio_sysfs_pwm_out start
 logger start -t -b 200
 mavlink boot_complete
+commander boot_complete

--- a/posix-configs/rpi/px4_fw.config
+++ b/posix-configs/rpi/px4_fw.config
@@ -31,3 +31,4 @@ navio_sysfs_rc_in start
 navio_sysfs_pwm_out start -m ROMFS/px4fmu_common/mixers/AERT.main.mix
 logger start -t -b 200
 mavlink boot_complete
+commander boot_complete

--- a/posix-configs/rpi/px4_hil.config
+++ b/posix-configs/rpi/px4_hil.config
@@ -22,4 +22,5 @@ pwm_out_sim mode_pwm16
 mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_x.main.mix
 logger start -t -b 200
 mavlink boot_complete
+commander boot_complete
 

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -144,6 +144,8 @@ static constexpr uint8_t COMMANDER_MAX_GPS_NOISE = 60;		/**< Maximum percentage 
 
 #define STICK_ON_OFF_LIMIT 0.9f
 
+#define BOOT_TIMEOUT				(5 * 1000 * 1000)	/**< wait for system boot completion for up to 5 seconds */
+
 #define POSITION_TIMEOUT		(1 * 1000 * 1000)	/**< consider the local or global position estimate invalid after 1000ms */
 #define FAILSAFE_DEFAULT_TIMEOUT	(3 * 1000 * 1000)	/**< hysteresis time - the failsafe will trigger after 3 seconds in this state */
 #define OFFBOARD_TIMEOUT		500000
@@ -187,6 +189,7 @@ static volatile bool thread_running = false;		/**< daemon status flag */
 static int daemon_task;					/**< Handle of daemon task / thread */
 static bool _usb_telemetry_active = false;
 static hrt_abstime commander_boot_timestamp = 0;
+static bool boot_complete = false;
 
 static unsigned int leds_counter;
 /* To remember when last notification was sent */
@@ -419,6 +422,11 @@ int commander_main(int argc, char *argv[])
 		return 0;
 	}
 
+	if (!strcmp(argv[1], "boot_complete")) {
+		boot_complete = true;
+		return 0;
+	}
+
 	if (!strcmp(argv[1], "calibrate")) {
 		if (argc > 2) {
 			int calib_ret = OK;
@@ -625,7 +633,7 @@ void usage(const char *reason)
 		PX4_INFO("%s", reason);
 	}
 
-	PX4_INFO("usage: commander {start|stop|status|calibrate|check|arm|disarm|takeoff|land|transition|mode}\n");
+	PX4_INFO("usage: commander {start|stop|status|boot_complete|calibrate|check|arm|disarm|takeoff|land|transition|mode}\n");
 }
 
 void print_status()
@@ -3295,12 +3303,21 @@ control_status_leds(vehicle_status_s *status_local, const actuator_armed_s *actu
 		uint8_t led_mode = led_control_s::MODE_OFF;
 		uint8_t led_color = led_control_s::COLOR_WHITE;
 		bool set_normal_color = false;
+		bool boot_timeout = hrt_elapsed_time(&commander_boot_timestamp) > BOOT_TIMEOUT;
 		bool hotplug_timeout = hrt_elapsed_time(&commander_boot_timestamp) > HOTPLUG_SENS_TIMEOUT;
 
 		int overload_warn_delay = (status_local->arming_state == vehicle_status_s::ARMING_STATE_ARMED) ? 1000 : 250000;
 
 		/* set mode */
-		if (overload && ((hrt_absolute_time() - overload_start) > overload_warn_delay)) {
+		if (!boot_complete) {
+			if (!boot_timeout) {
+				led_mode = led_control_s::MODE_OFF;
+			} else {
+				led_mode = led_control_s::MODE_BLINK_SLOW;
+				led_color = led_control_s::COLOR_RED;
+			}
+
+		} else if (overload && ((hrt_absolute_time() - overload_start) > overload_warn_delay)) {
 			led_mode = led_control_s::MODE_BLINK_FAST;
 			led_color = led_control_s::COLOR_PURPLE;
 


### PR DESCRIPTION
## Problem
When the boot is halted because of an error in the init scripts, the system is left in a half-started state. 

For example in #4846, the boot failed because a command in the SD card file `etc/extras.txt` was unknown. The mavlink stream was blocked, but no error was reported (except in the system console).

## Solution
This adds an LED error signal (red slowly blinking) when the system boot takes too long.

## Implementation
I implemented it in the commander app similarly to the mavlink app: i.e. with a boolean `boot_complete` set to true at the end of the startup script.
Upsides:
- warns user that the boot failed
- does not change the behaviour of the commander app, only the LED pattern

Downsides:
- the startup scripts are modified to add the command `commander boot_complete` after the command `mavlink boot_complete`

## Potential improvements (not included in this PR):
Let me know if I should add these to the PR:
- Add the boolean `boot_complete` in topic `vehicle_status`. 
With this PR, both `commander` and `mavlink` apps need to by notified when the boot is complete. Boot completion could be indicated on the `vehicle_status` topic. This would allow others apps to be notified, and also to remove the command `mavlink boot_complete` from startup scripts. 
- Prevent flight while boot is incomplete
The drone can take off even if the boot failed. For safety reason, it would be nice to prevent flight, for example by preventing mode switching.