### PR TITLE
Fix compilation errors with GCC 7

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -684,8 +684,8 @@ GPS::task_main()
 			switch (_mode) {
 			case GPS_DRIVER_MODE_NONE:
 				_mode = GPS_DRIVER_MODE_UBX;
+				/* FALLTHROUGH */
 
-			//no break
 			case GPS_DRIVER_MODE_UBX:
 				_helper = new GPSDriverUBX(_interface, &GPS::callback, this, &_report_gps_pos, _p_report_sat_info);
 				break;

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -684,7 +684,8 @@ GPS::task_main()
 			switch (_mode) {
 			case GPS_DRIVER_MODE_NONE:
 				_mode = GPS_DRIVER_MODE_UBX;
-				/* FALLTHROUGH */
+
+			/* FALLTHROUGH */
 
 			case GPS_DRIVER_MODE_UBX:
 				_helper = new GPSDriverUBX(_interface, &GPS::callback, this, &_report_gps_pos, _p_report_sat_info);

--- a/src/drivers/pwm_out_sim/pwm_out_sim.cpp
+++ b/src/drivers/pwm_out_sim/pwm_out_sim.cpp
@@ -718,8 +718,8 @@ PWMSim::pwm_ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			ret = -EINVAL;
 			break;
 		}
+		/* FALLTHROUGH */
 
-	/* FALLTHROUGH */
 	case PWM_SERVO_SET(0):
 	case PWM_SERVO_SET(1):
 		if (arg < 2100) {
@@ -740,6 +740,7 @@ PWMSim::pwm_ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			ret = -EINVAL;
 			break;
 		}
+		/* FALLTHROUGH */
 
 	case PWM_SERVO_GET(3):
 	case PWM_SERVO_GET(2):
@@ -747,8 +748,8 @@ PWMSim::pwm_ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			ret = -EINVAL;
 			break;
 		}
-
-	/* FALLTHROUGH */
+		/* FALLTHROUGH */
+		
 	case PWM_SERVO_GET(1):
 	case PWM_SERVO_GET(0): {
 			*(servo_position_t *)arg = 1500;

--- a/src/drivers/pwm_out_sim/pwm_out_sim.cpp
+++ b/src/drivers/pwm_out_sim/pwm_out_sim.cpp
@@ -718,7 +718,8 @@ PWMSim::pwm_ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			ret = -EINVAL;
 			break;
 		}
-		/* FALLTHROUGH */
+
+	/* FALLTHROUGH */
 
 	case PWM_SERVO_SET(0):
 	case PWM_SERVO_SET(1):
@@ -740,7 +741,8 @@ PWMSim::pwm_ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			ret = -EINVAL;
 			break;
 		}
-		/* FALLTHROUGH */
+
+	/* FALLTHROUGH */
 
 	case PWM_SERVO_GET(3):
 	case PWM_SERVO_GET(2):
@@ -748,8 +750,9 @@ PWMSim::pwm_ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			ret = -EINVAL;
 			break;
 		}
-		/* FALLTHROUGH */
-		
+
+	/* FALLTHROUGH */
+
 	case PWM_SERVO_GET(1):
 	case PWM_SERVO_GET(0): {
 			*(servo_position_t *)arg = 1500;

--- a/src/drivers/vmount/input_mavlink.cpp
+++ b/src/drivers/vmount/input_mavlink.cpp
@@ -231,8 +231,8 @@ int InputMavlinkCmdMount::update_impl(unsigned int timeout_ms, ControlData **con
 				switch ((int)vehicle_command.param7) {
 				case vehicle_command_s::VEHICLE_MOUNT_MODE_RETRACT:
 					_control_data.gimbal_shutter_retract = true;
+					/* FALLTHROUGH */
 
-				//no break
 				case vehicle_command_s::VEHICLE_MOUNT_MODE_NEUTRAL:
 					_control_data.type = ControlData::Type::Neutral;
 
@@ -306,4 +306,3 @@ void InputMavlinkCmdMount::print_status()
 
 
 } /* namespace vmount */
-

--- a/src/drivers/vmount/input_mavlink.cpp
+++ b/src/drivers/vmount/input_mavlink.cpp
@@ -231,7 +231,8 @@ int InputMavlinkCmdMount::update_impl(unsigned int timeout_ms, ControlData **con
 				switch ((int)vehicle_command.param7) {
 				case vehicle_command_s::VEHICLE_MOUNT_MODE_RETRACT:
 					_control_data.gimbal_shutter_retract = true;
-					/* FALLTHROUGH */
+
+				/* FALLTHROUGH */
 
 				case vehicle_command_s::VEHICLE_MOUNT_MODE_NEUTRAL:
 					_control_data.type = ControlData::Type::Neutral;

--- a/src/modules/commander/accelerometer_calibration.cpp
+++ b/src/modules/commander/accelerometer_calibration.cpp
@@ -462,7 +462,7 @@ calibrate_return do_accel_calibration_measurements(orb_advert_t *mavlink_log_pub
 		worker_data.subs[i] = -1;
 	}
 
-	uint64_t timestamps[max_accel_sens];
+	uint64_t timestamps[max_accel_sens] = {};
 
 	// We should not try to subscribe if the topic doesn't actually exist and can be counted.
 	const unsigned orb_accel_count = orb_group_count(ORB_ID(sensor_accel));

--- a/src/modules/mavlink/mavlink_log_handler.cpp
+++ b/src/modules/mavlink/mavlink_log_handler.cpp
@@ -475,10 +475,13 @@ LogListHelper::_init()
 		if (result->d_type == PX4LOG_DIRECTORY) {
 			time_t tt = 0;
 			char log_path[128];
-			snprintf(log_path, sizeof(log_path), "%s/%s", kLogRoot, result->d_name);
+			int ret = snprintf(log_path, sizeof(log_path), "%s/%s", kLogRoot, result->d_name);
+			bool path_is_ok = (ret > 0) && (ret < sizeof(log_path));
 
-			if (_get_session_date(log_path, result->d_name, tt)) {
-				_scan_logs(f, log_path, tt);
+			if (path_is_ok) {
+				if (_get_session_date(log_path, result->d_name, tt)) {
+					_scan_logs(f, log_path, tt);
+				}
 			}
 		}
 	}
@@ -534,12 +537,15 @@ LogListHelper::_scan_logs(FILE *f, const char *dir, time_t &date)
 				time_t  ldate = date;
 				uint32_t size = 0;
 				char log_file_path[128];
-				snprintf(log_file_path, sizeof(log_file_path), "%s/%s", dir, result->d_name);
+				int ret = snprintf(log_file_path, sizeof(log_file_path), "%s/%s", dir, result->d_name);
+				bool path_is_ok = (ret > 0) && (ret < sizeof(log_file_path));
 
-				if (_get_log_time_size(log_file_path, result->d_name, ldate, size)) {
-					//-- Write result->out to list file
-					fprintf(f, "%u %u %s\n", (unsigned)ldate, (unsigned)size, log_file_path);
-					log_count++;
+				if (path_is_ok) {
+					if (_get_log_time_size(log_file_path, result->d_name, ldate, size)) {
+						//-- Write result->out to list file
+						fprintf(f, "%u %u %s\n", (unsigned)ldate, (unsigned)size, log_file_path);
+						log_count++;
+					}
 				}
 			}
 		}
@@ -601,20 +607,27 @@ LogListHelper::delete_all(const char *dir)
 
 		if (result->d_type == PX4LOG_DIRECTORY && result->d_name[0] != '.') {
 			char log_path[128];
-			snprintf(log_path, sizeof(log_path), "%s/%s", dir, result->d_name);
-			LogListHelper::delete_all(log_path);
+			int ret = snprintf(log_path, sizeof(log_path), "%s/%s", dir, result->d_name);
+			bool path_is_ok = (ret > 0) && (ret < sizeof(log_path));
 
-			if (rmdir(log_path)) {
-				PX4LOG_WARN("MavlinkLogHandler::delete_all Error removing %s\n", log_path);
+			if (path_is_ok) {
+				LogListHelper::delete_all(log_path);
+
+				if (rmdir(log_path)) {
+					PX4LOG_WARN("MavlinkLogHandler::delete_all Error removing %s\n", log_path);
+				}
 			}
 		}
 
 		if (result->d_type == PX4LOG_REGULAR_FILE) {
 			char log_path[128];
-			snprintf(log_path, sizeof(log_path), "%s/%s", dir, result->d_name);
+			int ret = snprintf(log_path, sizeof(log_path), "%s/%s", dir, result->d_name);
+			bool path_is_ok = (ret > 0) && (ret < sizeof(log_path));
 
-			if (unlink(log_path)) {
-				PX4LOG_WARN("MavlinkLogHandler::delete_all Error deleting %s\n", log_path);
+			if (path_is_ok) {
+				if (unlink(log_path)) {
+					PX4LOG_WARN("MavlinkLogHandler::delete_all Error deleting %s\n", log_path);
+				}
 			}
 		}
 	}

--- a/src/modules/navigator/follow_target.cpp
+++ b/src/modules/navigator/follow_target.cpp
@@ -344,7 +344,8 @@ void FollowTarget::on_active()
 
 			_follow_target_state = WAIT_FOR_TARGET_POSITION;
 		}
-		/* FALLTHROUGH */
+
+	/* FALLTHROUGH */
 
 	case WAIT_FOR_TARGET_POSITION: {
 

--- a/src/modules/navigator/follow_target.cpp
+++ b/src/modules/navigator/follow_target.cpp
@@ -344,6 +344,7 @@ void FollowTarget::on_active()
 
 			_follow_target_state = WAIT_FOR_TARGET_POSITION;
 		}
+		/* FALLTHROUGH */
 
 	case WAIT_FOR_TARGET_POSITION: {
 

--- a/src/systemcmds/tests/test_matrix.cpp
+++ b/src/systemcmds/tests/test_matrix.cpp
@@ -624,7 +624,9 @@ bool MatrixTest::vector2Tests()
 	ut_test(fabs(c(0) - 0) < 1e-5);
 	ut_test(fabs(c(1) - 0) < 1e-5);
 
-	Matrix<float, 2, 1> d(a);
+	static Matrix<float, 2, 1> d(a);
+	// the static keywork is a workaround for an internal bug of GCC
+	// "internal compiler error: in trunc_int_for_mode, at explow.c:55"
 	ut_test(fabs(d(0, 0) - 1) < 1e-5);
 	ut_test(fabs(d(1, 0) - 0) < 1e-5);
 


### PR DESCRIPTION
With newer versions of GCC, new warnings are emitted and prevent building the posix target on master.

You can find the compiler errors [here](https://gist.github.com/jlecoeur/2aef4f397b5e564e231929195db84742) (I use GCC 7.1.1 on archlinux).

I also had to fix an error in the ecl submodule. I temporarily changed the submodule URL for the tests, but this has to be reverted.