### PR TITLE
uORB generation use constexpr

### DIFF
--- a/msg/templates/uorb/msg.cpp.template
+++ b/msg/templates/uorb/msg.cpp.template
@@ -69,7 +69,7 @@ topic_fields = ["uint64_t timestamp"]+["%s %s" % (convert_type(field.type), fiel
 
 @# join all msg files in one line e.g: "float[3] position;float[3] velocity;bool armed"
 @# This is used for the logger
-const char *__orb_@(topic_name)_fields = "@( ";".join(topic_fields) );";
+constexpr char __orb_@(topic_name)_fields[] = "@( ";".join(topic_fields) );";
 
 @[for multi_topic in topics]@
 ORB_DEFINE(@multi_topic, struct @uorb_struct, @(struct_size-padding_end_size),

--- a/msg/templates/uorb/msg.h.template
+++ b/msg/templates/uorb/msg.h.template
@@ -129,7 +129,7 @@ for constant in spec.constants:
     else:
         raise Exception("Type {0} not supported, add to to template file!".format(type_name))
 
-    print('\tstatic const %s %s = %s;'%(type_px4, constant.name, int(constant.val)))
+    print('\tstatic constexpr %s %s = %s;'%(type_px4, constant.name, int(constant.val)))
 }
 #endif
 };


### PR DESCRIPTION
Before:
``` bash
 % make sizes
   text    data     bss     dec     hex filename
1383820    6632   24116 1414568  1595a8 build_px4fmu-v4_default/src/firmware/nuttx/firmware_nuttx
```

``` bash
nsh> free
             total       used       free    largest
Mem:        231120     218384      12736      12096
```

After:
``` bash
 % make sizes
   text    data     bss     dec     hex filename
1383676    4104   24116 1411896  158b38 build_px4fmu-v4_default/src/firmware/nuttx/firmware_nuttx
```

``` bash
nsh> free
             total       used       free    largest
Mem:        233424     218384      15040      14752
```