### PR TITLE
SITL unit tests don't run perf

### DIFF
--- a/posix-configs/SITL/init/test/test_template.in
+++ b/posix-configs/SITL/init/test/test_template.in
@@ -32,6 +32,4 @@ tests @test_name@
 dataman status
 dataman stop
 
-perf
-
 shutdown


### PR DESCRIPTION
Perf seems to be clobbering stdout causing intermittent SITL test failures.