### PR TITLE
Fix zmr250 bricking

### DIFF
--- a/ROMFS/px4fmu_common/init.d/4080_zmr250
+++ b/ROMFS/px4fmu_common/init.d/4080_zmr250
@@ -20,7 +20,7 @@ then
 	param set MC_ROLL_P 2.0
 	param set MC_ROLLRATE_P 0.05
 	param set MC_ROLLRATE_I 0.2
-	param set MC_ROLLRATE_D	0.0015
+	param set MC_ROLLRATE_D 0.0015
 	param set MC_ROLL_TC 0.18
 
 	param set MC_PITCH_P 2.0

--- a/ROMFS/px4fmu_common/init.d/4080_zmr250
+++ b/ROMFS/px4fmu_common/init.d/4080_zmr250
@@ -35,9 +35,9 @@ then
 	param set MC_YAWRATE_D 0.0
 	param set MC_YAW_FF 0.5
 
-	param set MC_ACRO_R_MAX 1080.0
-	param set MC_ACRO_P_MAX 1080.0
-	param set MC_ACRO_Y_MAX 1080.0
+	param set MC_ACRO_R_MAX 1000.0
+	param set MC_ACRO_P_MAX 1000.0
+	param set MC_ACRO_Y_MAX 1000.0
 
 	param set MC_TPA_BREAK_P 0.5
 	param set MC_TPA_BREAK_D 0.7


### PR DESCRIPTION
Thanks to stlfatboy who reported bricking of the pixracer if zmr250 config is used.

The issue was in tab instead of space between `MC_ROLLRATE_D` and `0.0015`
