### PR TITLE
Add support for mavlink debug messages

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -48,6 +48,7 @@ set(msg_file_names
 	cpuload.msg
 	debug_key_value.msg
 	debug_value.msg
+	debug_vect.msg
 	differential_pressure.msg
 	distance_sensor.msg
 	ekf2_innovations.msg

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -47,6 +47,7 @@ set(msg_file_names
 	control_state.msg
 	cpuload.msg
 	debug_key_value.msg
+	debug_value.msg
 	differential_pressure.msg
 	distance_sensor.msg
 	ekf2_innovations.msg

--- a/msg/debug_key_value.msg
+++ b/msg/debug_key_value.msg
@@ -1,3 +1,3 @@
 uint32 timestamp_ms		# in milliseconds since system start
-int8[10] key			# max. 10 characters as key / name
+char[10] key			# max. 10 characters as key / name
 float32 value			# the value to send as debug output

--- a/msg/debug_value.msg
+++ b/msg/debug_value.msg
@@ -1,0 +1,3 @@
+uint32 timestamp_ms		# in milliseconds since system start
+int8 ind			    # index of debug variable
+float32 value			# the value to send as debug output

--- a/msg/debug_value.msg
+++ b/msg/debug_value.msg
@@ -1,3 +1,3 @@
-uint32 timestamp_ms		# in milliseconds since system start
-int8 ind			    # index of debug variable
-float32 value			# the value to send as debug output
+uint32 timestamp_ms     # in milliseconds since system start
+int8 ind                # index of debug variable
+float32 value           # the value to send as debug output

--- a/msg/debug_vect.msg
+++ b/msg/debug_vect.msg
@@ -1,5 +1,5 @@
 uint64 timestamp_us     # in microseconds since system start
-int8[10] name           # max. 10 characters as key / name
+char[10] name           # max. 10 characters as key / name
 float32 x               # x value
 float32 y               # y value
 float32 z               # z value

--- a/msg/debug_vect.msg
+++ b/msg/debug_vect.msg
@@ -1,0 +1,5 @@
+uint64 timestamp_us     # in microseconds since system start
+int8[10] name           # max. 10 characters as key / name
+float32 x               # x value
+float32 y               # y value
+float32 z               # z value

--- a/src/examples/px4_mavlink_debug/px4_mavlink_debug.c
+++ b/src/examples/px4_mavlink_debug/px4_mavlink_debug.c
@@ -44,9 +44,12 @@
 #include <poll.h>
 
 #include <systemlib/err.h>
+#include <drivers/drv_hrt.h>
 
 #include <uORB/uORB.h>
 #include <uORB/topics/debug_key_value.h>
+#include <uORB/topics/debug_value.h>
+#include <uORB/topics/debug_vect.h>
 
 __EXPORT int px4_mavlink_debug_main(int argc, char *argv[]);
 
@@ -54,16 +57,40 @@ int px4_mavlink_debug_main(int argc, char *argv[])
 {
 	printf("Hello Debug!\n");
 
-	/* advertise debug value */
-	struct debug_key_value_s dbg = { .key = "velx", .value = 0.0f };
-	orb_advert_t pub_dbg = orb_advertise(ORB_ID(debug_key_value), &dbg);
+	/* advertise named debug value */
+	struct debug_key_value_s dbg_key = { .key = "velx", .value = 0.0f };
+	orb_advert_t pub_dbg_key = orb_advertise(ORB_ID(debug_key_value), &dbg_key);
+
+	/* advertise indexed debug value */
+	struct debug_value_s dbg_ind = { .ind = 42, .value = 0.5f };
+	orb_advert_t pub_dbg_ind = orb_advertise(ORB_ID(debug_value), &dbg_ind);
+
+	/* advertise debug vect */
+	struct debug_vect_s dbg_vect = { .name = "vel3D", .x = 1.0f, .y = 2.0f, .z = 3.0f };
+	orb_advert_t pub_dbg_vect = orb_advertise(ORB_ID(debug_vect), &dbg_vect);
 
 	int value_counter = 0;
 
 	while (value_counter < 100) {
-		/* send one value */
-		dbg.value = value_counter;
-		orb_publish(ORB_ID(debug_key_value), pub_dbg, &dbg);
+		uint64_t timestamp_us = hrt_absolute_time();
+		uint32_t timestamp_ms = timestamp_us / 1000;
+
+		/* send one named value */
+		dbg_key.value = value_counter;
+		dbg_key.timestamp_ms = timestamp_ms;
+		orb_publish(ORB_ID(debug_key_value), pub_dbg_key, &dbg_key);
+
+		/* send one indexed value */
+		dbg_ind.value = 0.5f * value_counter;
+		dbg_ind.timestamp_ms = timestamp_ms;
+		orb_publish(ORB_ID(debug_value), pub_dbg_ind, &dbg_ind);
+
+		/* send one vector */
+		dbg_vect.x = 1.0f * value_counter;
+		dbg_vect.y = 2.0f * value_counter;
+		dbg_vect.z = 3.0f * value_counter;
+		dbg_vect.timestamp_us = timestamp_us;
+		orb_publish(ORB_ID(debug_vect), pub_dbg_vect, &dbg_vect);
 
 		warnx("sent one more value..");
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -544,6 +544,9 @@ void Logger::add_common_topics()
 	add_topic("commander_state", 100);
 	add_topic("control_state", 100);
 	add_topic("cpuload");
+	add_topic("debug_key_value");
+	add_topic("debug_value");
+	add_topic("debug_vect");
 	add_topic("differential_pressure", 50);
 	add_topic("distance_sensor");
 	add_topic("ekf2_innovations", 50);

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2045,6 +2045,7 @@ Mavlink::task_main(int argc, char *argv[])
 		configure_stream("ATTITUDE_TARGET", 2.0f);
 		configure_stream("HOME_POSITION", 0.5f);
 		configure_stream("NAMED_VALUE_FLOAT", 1.0f);
+		configure_stream("DEBUG", 1.0f);
 		configure_stream("VFR_HUD", 4.0f);
 		configure_stream("WIND_COV", 1.0f);
 		configure_stream("CAMERA_IMAGE_CAPTURED");
@@ -2073,6 +2074,7 @@ Mavlink::task_main(int argc, char *argv[])
 		configure_stream("ATTITUDE_TARGET", 10.0f);
 		configure_stream("HOME_POSITION", 0.5f);
 		configure_stream("NAMED_VALUE_FLOAT", 10.0f);
+		configure_stream("DEBUG", 10.0f);
 		configure_stream("VFR_HUD", 10.0f);
 		configure_stream("WIND_COV", 10.0f);
 		configure_stream("POSITION_TARGET_LOCAL_NED", 10.0f);
@@ -2132,6 +2134,7 @@ Mavlink::task_main(int argc, char *argv[])
 		configure_stream("ATTITUDE_TARGET", 8.0f);
 		configure_stream("HOME_POSITION", 0.5f);
 		configure_stream("NAMED_VALUE_FLOAT", 50.0f);
+		configure_stream("DEBUG", 50.0f);
 		configure_stream("VFR_HUD", 20.0f);
 		configure_stream("WIND_COV", 10.0f);
 		configure_stream("CAMERA_TRIGGER");

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2046,6 +2046,7 @@ Mavlink::task_main(int argc, char *argv[])
 		configure_stream("HOME_POSITION", 0.5f);
 		configure_stream("NAMED_VALUE_FLOAT", 1.0f);
 		configure_stream("DEBUG", 1.0f);
+		configure_stream("DEBUG_VECT", 1.0f);
 		configure_stream("VFR_HUD", 4.0f);
 		configure_stream("WIND_COV", 1.0f);
 		configure_stream("CAMERA_IMAGE_CAPTURED");
@@ -2075,6 +2076,7 @@ Mavlink::task_main(int argc, char *argv[])
 		configure_stream("HOME_POSITION", 0.5f);
 		configure_stream("NAMED_VALUE_FLOAT", 10.0f);
 		configure_stream("DEBUG", 10.0f);
+		configure_stream("DEBUG_VECT", 10.0f);
 		configure_stream("VFR_HUD", 10.0f);
 		configure_stream("WIND_COV", 10.0f);
 		configure_stream("POSITION_TARGET_LOCAL_NED", 10.0f);
@@ -2135,6 +2137,7 @@ Mavlink::task_main(int argc, char *argv[])
 		configure_stream("HOME_POSITION", 0.5f);
 		configure_stream("NAMED_VALUE_FLOAT", 50.0f);
 		configure_stream("DEBUG", 50.0f);
+		configure_stream("DEBUG_VECT", 50.0f);
 		configure_stream("VFR_HUD", 20.0f);
 		configure_stream("WIND_COV", 10.0f);
 		configure_stream("CAMERA_TRIGGER");

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -3220,7 +3220,7 @@ protected:
 		_debug_time(0)
 	{}
 
-	void send(const hrt_abstime t)
+	bool send(const hrt_abstime t)
 	{
 		struct debug_value_s debug = {};
 
@@ -3232,7 +3232,11 @@ protected:
 			msg.value = debug.value;
 
 			mavlink_msg_debug_send_struct(_mavlink->get_channel(), &msg);
+
+			return true;
 		}
+
+		return false;
 	}
 };
 
@@ -3283,7 +3287,7 @@ protected:
 		_debug_time(0)
 	{}
 
-	void send(const hrt_abstime t)
+	bool send(const hrt_abstime t)
 	{
 		struct debug_vect_s debug = {};
 
@@ -3299,7 +3303,11 @@ protected:
 			msg.z = debug.z;
 
 			mavlink_msg_debug_vect_send_struct(_mavlink->get_channel(), &msg);
+
+			return true;
 		}
+
+		return false;
 	}
 };
 

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -65,6 +65,7 @@
 #include <uORB/topics/camera_capture.h>
 #include <uORB/topics/cpuload.h>
 #include <uORB/topics/debug_key_value.h>
+#include <uORB/topics/debug_value.h>
 #include <uORB/topics/differential_pressure.h>
 #include <uORB/topics/distance_sensor.h>
 #include <uORB/topics/estimator_status.h>
@@ -3171,6 +3172,69 @@ protected:
 	}
 };
 
+class MavlinkStreamDebug : public MavlinkStream
+{
+public:
+	const char *get_name() const
+	{
+		return MavlinkStreamDebug::get_name_static();
+	}
+
+	static const char *get_name_static()
+	{
+		return "DEBUG";
+	}
+
+	static uint16_t get_id_static()
+	{
+		return MAVLINK_MSG_ID_DEBUG;
+	}
+
+	uint16_t get_id()
+	{
+		return get_id_static();
+	}
+
+	static MavlinkStream *new_instance(Mavlink *mavlink)
+	{
+		return new MavlinkStreamDebug(mavlink);
+	}
+
+	unsigned get_size()
+	{
+		return (_debug_time > 0) ? MAVLINK_MSG_ID_DEBUG_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES : 0;
+	}
+
+private:
+	MavlinkOrbSubscription *_debug_sub;
+	uint64_t _debug_time;
+
+	/* do not allow top copying this class */
+	MavlinkStreamDebug(MavlinkStreamDebug &);
+	MavlinkStreamDebug &operator = (const MavlinkStreamDebug &);
+
+protected:
+	explicit MavlinkStreamDebug(Mavlink *mavlink) : MavlinkStream(mavlink),
+		_debug_sub(_mavlink->add_orb_subscription(ORB_ID(debug_value))),
+		_debug_time(0)
+	{}
+
+	void send(const hrt_abstime t)
+	{
+		struct debug_value_s debug = {};
+
+		if (_debug_sub->update(&_debug_time, &debug)) {
+			mavlink_debug_t msg = {};
+
+			msg.time_boot_ms = debug.timestamp_ms;
+			msg.ind = debug.ind;
+			msg.value = debug.value;
+
+			mavlink_msg_debug_send_struct(_mavlink->get_channel(), &msg);
+		}
+	}
+};
+
 class MavlinkStreamNavControllerOutput : public MavlinkStream
 {
 public:
@@ -4168,6 +4232,7 @@ const StreamListItem *streams_list[] = {
 	new StreamListItem(&MavlinkStreamActuatorControlTarget<2>::new_instance, &MavlinkStreamActuatorControlTarget<2>::get_name_static, &MavlinkStreamActuatorControlTarget<2>::get_id_static),
 	new StreamListItem(&MavlinkStreamActuatorControlTarget<3>::new_instance, &MavlinkStreamActuatorControlTarget<3>::get_name_static, &MavlinkStreamActuatorControlTarget<3>::get_id_static),
 	new StreamListItem(&MavlinkStreamNamedValueFloat::new_instance, &MavlinkStreamNamedValueFloat::get_name_static, &MavlinkStreamNamedValueFloat::get_id_static),
+	new StreamListItem(&MavlinkStreamDebug::new_instance, &MavlinkStreamDebug::get_name_static, &MavlinkStreamDebug::get_id_static),
 	new StreamListItem(&MavlinkStreamNavControllerOutput::new_instance, &MavlinkStreamNavControllerOutput::get_name_static, &MavlinkStreamNavControllerOutput::get_id_static),
 	new StreamListItem(&MavlinkStreamCameraCapture::new_instance, &MavlinkStreamCameraCapture::get_name_static, &MavlinkStreamCameraCapture::get_id_static),
 	new StreamListItem(&MavlinkStreamCameraTrigger::new_instance, &MavlinkStreamCameraTrigger::get_name_static, &MavlinkStreamCameraTrigger::get_id_static),

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -151,6 +151,7 @@ private:
 	void handle_message_serial_control(mavlink_message_t *msg);
 	void handle_message_logging_ack(mavlink_message_t *msg);
 	void handle_message_play_tune(mavlink_message_t *msg);
+	void handle_message_named_value_float(mavlink_message_t *msg);
 
 	void *receive_thread(void *arg);
 
@@ -236,6 +237,7 @@ private:
 	orb_advert_t _transponder_report_pub;
 	orb_advert_t _collision_report_pub;
 	orb_advert_t _control_state_pub;
+	orb_advert_t _debug_key_value_pub;
 	static const int _gps_inject_data_queue_size = 6;
 	orb_advert_t _gps_inject_data_pub;
 	orb_advert_t _command_ack_pub;

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -67,6 +67,7 @@
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/telemetry_status.h>
 #include <uORB/topics/debug_key_value.h>
+#include <uORB/topics/debug_value.h>
 #include <uORB/topics/airspeed.h>
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/vehicle_force_setpoint.h>
@@ -152,6 +153,7 @@ private:
 	void handle_message_logging_ack(mavlink_message_t *msg);
 	void handle_message_play_tune(mavlink_message_t *msg);
 	void handle_message_named_value_float(mavlink_message_t *msg);
+	void handle_message_debug(mavlink_message_t *msg);
 
 	void *receive_thread(void *arg);
 
@@ -238,6 +240,7 @@ private:
 	orb_advert_t _collision_report_pub;
 	orb_advert_t _control_state_pub;
 	orb_advert_t _debug_key_value_pub;
+	orb_advert_t _debug_value_pub;
 	static const int _gps_inject_data_queue_size = 6;
 	orb_advert_t _gps_inject_data_pub;
 	orb_advert_t _command_ack_pub;

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -68,6 +68,7 @@
 #include <uORB/topics/telemetry_status.h>
 #include <uORB/topics/debug_key_value.h>
 #include <uORB/topics/debug_value.h>
+#include <uORB/topics/debug_vect.h>
 #include <uORB/topics/airspeed.h>
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/vehicle_force_setpoint.h>
@@ -154,6 +155,7 @@ private:
 	void handle_message_play_tune(mavlink_message_t *msg);
 	void handle_message_named_value_float(mavlink_message_t *msg);
 	void handle_message_debug(mavlink_message_t *msg);
+	void handle_message_debug_vect(mavlink_message_t *msg);
 
 	void *receive_thread(void *arg);
 
@@ -241,6 +243,7 @@ private:
 	orb_advert_t _control_state_pub;
 	orb_advert_t _debug_key_value_pub;
 	orb_advert_t _debug_value_pub;
+	orb_advert_t _debug_vect_pub;
 	static const int _gps_inject_data_queue_size = 6;
 	orb_advert_t _gps_inject_data_pub;
 	orb_advert_t _command_ack_pub;


### PR DESCRIPTION
Add support for the following messages: 
- NAMED_VALUE_FLOAT: messages are now handled in mavlink_receiver and converted to the existing uORB msg `debug_key_value`
- DEBUG: added uORB msg `debug_value`, with conversions to/from mavlink
- DEBUG_VECT: added uORB msg `debug_vect`, with conversions to/from mavlink
- DEBUG_ARRAY: to be done. @LorenzMeier should I hold this PR until https://github.com/mavlink/mavlink/pull/734 is merged, or create another pull request?