### PR TITLE
Fix python 3 compatibility in px_uploader.py

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -615,8 +615,8 @@ def main():
     portnum = 14550
 
     # COMMAND_LONG in MAVLink 1
-    heartbeatpacket = 'fe097001010000000100020c5103033c8a'.decode('hex')
-    commandpacket = 'fe210101014c00000000000000000000000000000000000000000000803f00000000f6000000008459'.decode('hex')
+    heartbeatpacket = bytearray.fromhex('fe097001010000000100020c5103033c8a')
+    commandpacket = bytearray.fromhex('fe210101014c00000000000000000000000000000000000000000000803f00000000f6000000008459')
 
     # initialize an UDP socket
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)


### PR DESCRIPTION
Quickfix for a recent commit https://github.com/PX4/Firmware/commit/5f4fb744caf30ee3f86fe37ab5651bf17dfba738 that broke py3 compatibility of the px_uploader.py script.