### PR TITLE
[WIP/RFC] FlightTasks basic Architecture

### DIFF
--- a/src/lib/FlightTasks/CMakeLists.txt
+++ b/src/lib/FlightTasks/CMakeLists.txt
@@ -1,0 +1,42 @@
+############################################################################
+#
+#   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+px4_add_module(
+	MODULE lib__flight_tasks
+	SRCS
+		FlightTask.h
+		tasks/FlightTaskOrbit.cpp
+	DEPENDS
+		platforms__common
+		modules__uORB
+	)
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/lib/FlightTasks/CMakeLists.txt
+++ b/src/lib/FlightTasks/CMakeLists.txt
@@ -34,6 +34,7 @@ px4_add_module(
 	MODULE lib__flight_tasks
 	SRCS
 		FlightTask.h
+		tasks/FlightTaskManual.cpp
 		tasks/FlightTaskOrbit.cpp
 	DEPENDS
 		platforms__common

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -77,7 +77,16 @@ public:
 	};
 
 	/**
-	 * Switch to a different task
+	 * Switch to the next task in the available list (for testing)
+	 */
+	void switch_task()
+	{
+		switch_task(_current_task + 1);
+	};
+
+	/**
+	 * Switch to a specific task (for normal usage)
+	 * @param task number to switch to
 	 */
 	void switch_task(int task_number)
 	{
@@ -89,18 +98,27 @@ public:
 
 		if (is_any_task_active()) {
 			_tasks[_current_task]->activate();
+
+		} else {
+			_current_task = -1;
 		}
 	};
 
 	/**
-	 * Call to get result of the task execution
+	 * Get the number of the active task
+	 * @return number of active task, -1 if there is none
+	 */
+	int get_active_task() const { return _current_task; };
+
+	/**
+	 * Get result of the task execution
 	 * @return pointer to the setpoint for the position controller
 	 */
 	const vehicle_local_position_setpoint_s *get_position_setpoint() const { return Orbit.get_position_setpoint(); };
 
 	/**
-	 * Call to get result of the task execution
-	 * @return pointer to
+	 * Check if any task is active
+	 * @return true if a task is active, flase if not
 	 */
 	bool is_any_task_active() const { return _current_task > -1 && _current_task < _task_count; };
 

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -52,10 +52,9 @@ public:
 
 	/**
 	 * Call regularly in the control loop cycle to execute the task
-	 * @param TODO
 	 * @return 0 on success, >0 on error otherwise
 	 */
-	int update() { return Orbit.update(); };
+	int update() { return _tasks[_current_task]->update(); };
 
 	void set_input_pointers(vehicle_local_position_s *vehicle_local_position,
 				manual_control_setpoint_s *manual_control_setpoint)
@@ -74,6 +73,7 @@ public:
 
 private:
 	static const int _task_count = 1;
+	int _current_task = 0;
 
 	FlightTaskOrbit Orbit;
 	FlightTask *_tasks[_task_count] = {&Orbit};

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -45,12 +45,13 @@
 #include "tasks/FlightTaskManual.hpp"
 #include "tasks/FlightTaskOrbit.hpp"
 
-class FlightTasks
+class FlightTasks : control::SuperBlock
 {
 public:
-	FlightTasks(control::SuperBlock *parent) :
-		Manual(parent, "MAN"),
-		Orbit(parent, "ORB")
+	FlightTasks() :
+		SuperBlock(nullptr, "TSK"),
+		Manual(this, "MAN"),
+		Orbit(this, "ORB")
 	{};
 	~FlightTasks() {};
 

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -1,0 +1,70 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file flight_taks.h
+ *
+ * Library class to hold and manage all implemented flight task instances
+ *
+ * @author Matthias Grob <maetugr@gmail.com>
+ */
+
+#pragma once
+
+#include "tasks/FlightTask.hpp"
+#include "tasks/FlightTaskOrbit.hpp"
+
+class FlightTasks
+{
+public:
+	FlightTasks() {};
+	~FlightTasks() {};
+
+	/**
+	 * Call regularly in the control loop cycle to execute the task
+	 * @param TODO
+	 * @return 0 on success, >0 on error otherwise
+	 */
+	int update(manual_control_setpoint_s *manual_control_setpoint, vehicle_local_position_s *vehicle_local_position) { return 0; };
+
+	/**
+	 * Call to get result of the task execution
+	 * @return pointer to
+	 */
+	const vehicle_local_position_setpoint_s *get_local_position_setpoint() const { return Orbit.get_local_position_setpoint(); };
+
+private:
+
+	FlightTaskOrbit Orbit;
+
+};

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -68,12 +68,22 @@ public:
 	/**
 	 * Call this function initially to point all tasks to the general input data
 	 */
-	void set_input_pointers(vehicle_local_position_s *vehicle_local_position,
-				manual_control_setpoint_s *manual_control_setpoint)
+	void set_general_input_pointers(vehicle_local_position_s *vehicle_local_position,
+					manual_control_setpoint_s *manual_control_setpoint)
 	{
 		for (int i = 0; i < _task_count; i++) {
 			_tasks[i]->set_vehicle_local_position_pointer(vehicle_local_position);
 			_tasks[i]->set_manual_control_setpoint_pointer(manual_control_setpoint);
+		}
+	};
+
+	/**
+	 * Call this function initially to point all tasks to the general output data
+	 */
+	void set_general_output_pointers(vehicle_local_position_setpoint_s *vehicle_local_position_setpoint)
+	{
+		for (int i = 0; i < _task_count; i++) {
+			_tasks[i]->set_vehicle_local_position_setpoint_pointer(vehicle_local_position_setpoint);
 		}
 	};
 
@@ -110,17 +120,6 @@ public:
 	 * @return number of active task, -1 if there is none
 	 */
 	int get_active_task() const { return _current_task; };
-
-	/**
-	 * Get result of the task execution
-	 * @return pointer to the setpoint for the position controller
-	 */
-	const vehicle_local_position_setpoint_s *get_position_setpoint() const
-	{
-		//if (is_any_task_active()) {
-		return _tasks[_current_task]->get_position_setpoint();
-		//}
-	};
 
 	/**
 	 * Check if any task is active

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -42,6 +42,7 @@
 #pragma once
 
 #include "tasks/FlightTask.hpp"
+#include "tasks/FlightTaskManual.hpp"
 #include "tasks/FlightTaskOrbit.hpp"
 
 class FlightTasks
@@ -114,7 +115,12 @@ public:
 	 * Get result of the task execution
 	 * @return pointer to the setpoint for the position controller
 	 */
-	const vehicle_local_position_setpoint_s *get_position_setpoint() const { return Orbit.get_position_setpoint(); };
+	const vehicle_local_position_setpoint_s *get_position_setpoint() const
+	{
+		//if (is_any_task_active()) {
+		return _tasks[_current_task]->get_position_setpoint();
+		//}
+	};
 
 	/**
 	 * Check if any task is active
@@ -123,10 +129,11 @@ public:
 	bool is_any_task_active() const { return _current_task > -1 && _current_task < _task_count; };
 
 private:
-	static const int _task_count = 1;
 	int _current_task = -1;
 
+	FlightTaskManual Manual;
 	FlightTaskOrbit Orbit;
-	FlightTask *_tasks[_task_count] = {&Orbit};
+	static const int _task_count = 2;
+	FlightTask *_tasks[_task_count] = {&Manual, &Orbit};
 
 };

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -93,6 +93,7 @@ public:
 
 	/**
 	 * Switch to the next task in the available list (for testing)
+	 * @return 0 on success, >0 on error
 	 */
 	void switch_task()
 	{
@@ -102,9 +103,14 @@ public:
 	/**
 	 * Switch to a specific task (for normal usage)
 	 * @param task number to switch to
+	 * @return 0 on success, >0 on error
 	 */
-	void switch_task(int task_number)
+	int switch_task(int task_number)
 	{
+		if (task_number == _current_task) {
+			return 0;
+		}
+
 		if (is_any_task_active()) {
 			_tasks[_current_task]->disable();
 		}
@@ -113,10 +119,11 @@ public:
 
 		if (is_any_task_active()) {
 			_tasks[_current_task]->activate();
-
-		} else {
-			_current_task = -1;
+			return 0;
 		}
+
+		_current_task = -1;
+		return 1;
 	};
 
 	/**

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -57,6 +57,15 @@ public:
 	 */
 	int update() { return Orbit.update(); };
 
+	void set_input_pointers(vehicle_local_position_s *vehicle_local_position,
+				manual_control_setpoint_s *manual_control_setpoint)
+	{
+		for (int i = 0; i < _task_count; i++) {
+			_tasks[i]->set_vehicle_local_position_pointer(vehicle_local_position);
+			_tasks[i]->set_manual_control_setpoint_pointer(manual_control_setpoint);
+		}
+	};
+
 	/**
 	 * Call to get result of the task execution
 	 * @return pointer to
@@ -64,7 +73,9 @@ public:
 	const vehicle_local_position_setpoint_s *get_position_setpoint() const { return Orbit.get_position_setpoint(); };
 
 private:
+	static const int _task_count = 1;
 
 	FlightTaskOrbit Orbit;
+	FlightTask *_tasks[_task_count] = {&Orbit};
 
 };

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -55,7 +55,7 @@ public:
 	 * @param TODO
 	 * @return 0 on success, >0 on error otherwise
 	 */
-	int update(manual_control_setpoint_s *manual_control_setpoint, vehicle_local_position_s *vehicle_position) { return Orbit.update(NULL, NULL); };
+	int update() { return Orbit.update(); };
 
 	/**
 	 * Call to get result of the task execution

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -55,7 +55,7 @@ public:
 	 * @param TODO
 	 * @return 0 on success, >0 on error otherwise
 	 */
-	int update(manual_control_setpoint_s *manual_control_setpoint, vehicle_local_position_s *vehicle_local_position) { return Orbit.update(NULL, NULL); };
+	int update(manual_control_setpoint_s *manual_control_setpoint, vehicle_local_position_s *vehicle_position) { return Orbit.update(NULL, NULL); };
 
 	/**
 	 * Call to get result of the task execution

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -55,13 +55,13 @@ public:
 	 * @param TODO
 	 * @return 0 on success, >0 on error otherwise
 	 */
-	int update(manual_control_setpoint_s *manual_control_setpoint, vehicle_local_position_s *vehicle_local_position) { return 0; };
+	int update(manual_control_setpoint_s *manual_control_setpoint, vehicle_local_position_s *vehicle_local_position) { return Orbit.update(NULL, NULL); };
 
 	/**
 	 * Call to get result of the task execution
 	 * @return pointer to
 	 */
-	const vehicle_local_position_setpoint_s *get_local_position_setpoint() const { return Orbit.get_local_position_setpoint(); };
+	const vehicle_local_position_setpoint_s *get_position_setpoint() const { return Orbit.get_position_setpoint(); };
 
 private:
 

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -48,7 +48,10 @@
 class FlightTasks
 {
 public:
-	FlightTasks() {};
+	FlightTasks(control::SuperBlock *parent) :
+		Manual(parent, "MAN"),
+		Orbit(parent, "ORB")
+	{};
 	~FlightTasks() {};
 
 	/**

--- a/src/lib/FlightTasks/tasks/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.hpp
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 /**
- * @file FlightTask.h
+ * @file FlightTask.hpp
  *
  * Abstract base class for different advanced flight tasks like orbit, follow me, ...
  *
@@ -67,7 +67,7 @@ public:
 	 * Call once on the event of switching away from the task
 	 * 	@return 0 on success, >0 on error
 	 */
-	virtual int disable() = 0;
+	virtual int disable() { return 0; };
 
 	/**
 	 * To be called regularly in the control loop cycle to execute the task
@@ -167,10 +167,10 @@ private:
 	void _evaluate_sticks()
 	{
 		if (_manual_control_setpoint != NULL && hrt_elapsed_time(&_manual_control_setpoint->timestamp) < _timeout) {
-			_sticks(0) = _manual_control_setpoint->y; /* "roll" [-1,1] */
-			_sticks(1) = _manual_control_setpoint->x; /* "pitch" [-1,1] */
-			_sticks(2) = _manual_control_setpoint->r; /* "yaw" [-1,1] */
-			_sticks(3) = (_manual_control_setpoint->z - 0.5f) * 2.f; /* "thrust" resacaled from [0,1] to [-1,1] */
+			_sticks(0) = _manual_control_setpoint->x; /* NED x, "pitch" [-1,1] */
+			_sticks(1) = _manual_control_setpoint->y; /* NED y, "roll" [-1,1] */
+			_sticks(2) = (_manual_control_setpoint->z - 0.5f) * 2.f; /* NED z, "thrust" resacaled from [0,1] to [-1,1] */
+			_sticks(3) = _manual_control_setpoint->r; /* "yaw" [-1,1] */
 
 		} else {
 			_sticks = matrix::Vector<float, 4>(); /* default is all zero */

--- a/src/lib/FlightTasks/tasks/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.hpp
@@ -41,9 +41,6 @@
 
 #pragma once
 
-#include <uORB/topics/manual_control_setpoint.h>
-#include <uORB/topics/vehicle_local_position_setpoint.h>
-
 class FlightTask
 {
 public:
@@ -83,12 +80,6 @@ public:
 	};
 
 	/**
-	 * Get the resulting setpoints of the task execution via pointer
-	 * @return pointer to setpoint struct
-	 */
-	const vehicle_local_position_setpoint_s *get_position_setpoint() const { return &_vehicle_position_setpoint; };
-
-	/**
 	 * Set vehicle local position data pointer
 	 * @param pointer to vehicle local position
 	 */
@@ -99,6 +90,12 @@ public:
 	 * @param pointer to manual control setpoint
 	 */
 	void set_manual_control_setpoint_pointer(const manual_control_setpoint_s *manual_control_setpoint) { _manual_control_setpoint = manual_control_setpoint; };
+
+	/**
+	 * Get the resulting setpoints of the task execution via pointer
+	 * @return pointer to setpoint struct
+	 */
+	const vehicle_local_position_setpoint_s *get_position_setpoint() const { return &_vehicle_position_setpoint; };
 
 protected:
 

--- a/src/lib/FlightTasks/tasks/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.hpp
@@ -54,7 +54,11 @@ public:
 	 * Call once on the event where you switch to the task
 	 * @return 0 on success, >0 on error otherwise
 	 */
-	virtual int activate() = 0;
+	virtual int activate()
+	{
+		_reset_time();
+		return 0;
+	};
 
 	/**
 	 * Call once on the event of switching away from the task
@@ -67,8 +71,11 @@ public:
 	 * @param TODO
 	 * @return 0 on success, >0 on error otherwise
 	 */
-	virtual int update(manual_control_setpoint_s *manual_control_setpoint,
-			   vehicle_local_position_s *vehicle_local_position) = 0;
+	virtual int update(manual_control_setpoint_s *manual_control_setpoint, vehicle_local_position_s *vehicle_position)
+	{
+		_time = hrt_elapsed_time(&_starting_time_stamp) / 1e6;
+		return 0;
+	};
 
 	/**
 	 * Call to get result of the task execution
@@ -77,6 +84,9 @@ public:
 	const vehicle_local_position_setpoint_s *get_position_setpoint() const { return &_vehicle_position_setpoint; };
 
 protected:
+
+	float _get_time() { return _time; }
+	void _reset_time() { _starting_time_stamp = hrt_absolute_time(); };
 
 	void _set_position_setpoint(const matrix::Vector3f position_setpoint)
 	{
@@ -101,6 +111,8 @@ protected:
 
 private:
 
+	float _time = 0; /*< passed time in seconds since the task was activated */
+	hrt_abstime _starting_time_stamp; /*< time stamp when task was activated */
 	vehicle_local_position_setpoint_s _vehicle_position_setpoint;
 
 };

--- a/src/lib/FlightTasks/tasks/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.hpp
@@ -47,12 +47,7 @@
 class FlightTask
 {
 public:
-	FlightTask()
-	{
-		vehicle_local_position_setpoint.x = 1;
-		vehicle_local_position_setpoint.y = 2;
-		vehicle_local_position_setpoint.z = -3;
-	};
+	FlightTask() {};
 	virtual ~FlightTask() {};
 
 	/**
@@ -79,10 +74,33 @@ public:
 	 * Call to get result of the task execution
 	 * @return pointer to
 	 */
-	const vehicle_local_position_setpoint_s *get_local_position_setpoint() const { return &vehicle_local_position_setpoint; };
+	const vehicle_local_position_setpoint_s *get_position_setpoint() const { return &_vehicle_position_setpoint; };
+
+protected:
+
+	void _set_position_setpoint(const matrix::Vector3f position_setpoint)
+	{
+		_vehicle_position_setpoint.x = position_setpoint(0);
+		_vehicle_position_setpoint.y = position_setpoint(1);
+		_vehicle_position_setpoint.z = position_setpoint(2);
+	};
+
+	void _set_velocity_setpoint(const matrix::Vector3f velocity_setpoint)
+	{
+		_vehicle_position_setpoint.vx = velocity_setpoint(0);
+		_vehicle_position_setpoint.vy = velocity_setpoint(1);
+		_vehicle_position_setpoint.vz = velocity_setpoint(2);
+	};
+
+	void _set_acceleration_setpoint(const matrix::Vector3f acceleration_setpoint)
+	{
+		_vehicle_position_setpoint.acc_x = acceleration_setpoint(0);
+		_vehicle_position_setpoint.acc_y = acceleration_setpoint(1);
+		_vehicle_position_setpoint.acc_z = acceleration_setpoint(2);
+	};
 
 private:
 
-	vehicle_local_position_setpoint_s vehicle_local_position_setpoint;
+	vehicle_local_position_setpoint_s _vehicle_position_setpoint;
 
 };

--- a/src/lib/FlightTasks/tasks/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.hpp
@@ -80,6 +80,7 @@ public:
 		_last_time_stamp = hrt_absolute_time();
 		_evaluate_sticks();
 		_evaluate_position();
+		_evaluate_velocity();
 		return 0;
 	};
 
@@ -107,8 +108,10 @@ protected:
 	float _deltatime = 0; /*< passed time in seconds since the task was last updated */
 	void _reset_time() { _starting_time_stamp = hrt_absolute_time(); };
 
+	/* Prepared general inputs for every task */
 	matrix::Vector<float, 4> _sticks;
 	matrix::Vector3f _position;
+	matrix::Vector3f _velocity;
 
 	void _set_position_setpoint(const matrix::Vector3f position_setpoint)
 	{
@@ -147,14 +150,17 @@ private:
 	void _evaluate_position()
 	{
 		if (_vehicle_local_position != NULL && hrt_elapsed_time(&_vehicle_local_position->timestamp) < _timeout) {
-			_position(0) = _vehicle_local_position->x;
-			_position(1) = _vehicle_local_position->y;
-			_position(2) = _vehicle_local_position->z;
+			_position = matrix::Vector3f(&_vehicle_local_position->x);
+		}
+	}
+
+	void _evaluate_velocity()
+	{
+		if (_vehicle_local_position != NULL && hrt_elapsed_time(&_vehicle_local_position->timestamp) < _timeout) {
+			_velocity = matrix::Vector3f(&_vehicle_local_position->vx);
 
 		} else {
-			for (int i = 0; i < 3; i++) {
-				_position(i) = 0.f;
-			}
+			_velocity = matrix::Vector3f(); /* default is all zero */
 		}
 	}
 
@@ -167,9 +173,7 @@ private:
 			_sticks(3) = (_manual_control_setpoint->z - 0.5f) * 2.f; /* "thrust" resacaled from [0,1] to [-1,1] */
 
 		} else {
-			for (int i = 0; i < 4; i++) {
-				_sticks(i) = 0.f;
-			}
+			_sticks = matrix::Vector<float, 4>(); /* default is all zero */
 		}
 	}
 

--- a/src/lib/FlightTasks/tasks/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.hpp
@@ -81,8 +81,7 @@ public:
 		_last_time_stamp = hrt_absolute_time();
 		updateSubscriptions();
 		_evaluate_sticks();
-		_evaluate_position();
-		_evaluate_velocity();
+		_evaluate_vehicle_position();
 		return 0;
 	};
 
@@ -114,6 +113,7 @@ protected:
 	matrix::Vector<float, 4> _sticks;
 	matrix::Vector3f _position;
 	matrix::Vector3f _velocity;
+	float _yaw;
 
 	/**
 	 * Put the position vector produced by the task into the setpoint message
@@ -169,20 +169,15 @@ private:
 	/* General output that every task has */
 	vehicle_local_position_setpoint_s *_vehicle_position_setpoint;
 
-	void _evaluate_position()
+	void _evaluate_vehicle_position()
 	{
 		if (_vehicle_position != nullptr && hrt_elapsed_time(&_vehicle_position->timestamp) < _timeout) {
 			_position = matrix::Vector3f(&_vehicle_position->x);
-		}
-	}
-
-	void _evaluate_velocity()
-	{
-		if (_vehicle_position != nullptr && hrt_elapsed_time(&_vehicle_position->timestamp) < _timeout) {
 			_velocity = matrix::Vector3f(&_vehicle_position->vx);
+			_yaw = _vehicle_position->yaw;
 
 		} else {
-			_velocity = matrix::Vector3f(); /* default is all zero */
+			_velocity = matrix::Vector3f(); /* default velocity is all zero */
 		}
 	}
 

--- a/src/lib/FlightTasks/tasks/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.hpp
@@ -111,8 +111,8 @@ protected:
 
 	/* Prepared general inputs for every task */
 	matrix::Vector<float, 4> _sticks;
-	matrix::Vector3f _position;
-	matrix::Vector3f _velocity;
+	matrix::Vector3f _position; /*< current vehicle position */
+	matrix::Vector3f _velocity; /*< current vehicle velocity */
 	float _yaw;
 
 	/**

--- a/src/lib/FlightTasks/tasks/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.hpp
@@ -1,0 +1,88 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file FlightTask.h
+ *
+ * Abstract base class for different advanced flight tasks like orbit, follow me, ...
+ *
+ * @author Matthias Grob <maetugr@gmail.com>
+ */
+
+#pragma once
+
+#include <uORB/topics/manual_control_setpoint.h>
+#include <uORB/topics/vehicle_local_position_setpoint.h>
+
+class FlightTask
+{
+public:
+	FlightTask()
+	{
+		vehicle_local_position_setpoint.x = 1;
+		vehicle_local_position_setpoint.y = 2;
+		vehicle_local_position_setpoint.z = -3;
+	};
+	virtual ~FlightTask() {};
+
+	/**
+	 * Call once on the event where you switch to the task
+	 * @return 0 on success, >0 on error otherwise
+	 */
+	virtual int activate() = 0;
+
+	/**
+	 * Call once on the event of switching away from the task
+	 * 	@return 0 on success, >0 on error otherwise
+	 */
+	virtual int disable() = 0;
+
+	/**
+	 * Call regularly in the control loop cycle to execute the task
+	 * @param TODO
+	 * @return 0 on success, >0 on error otherwise
+	 */
+	virtual int update(manual_control_setpoint_s *manual_control_setpoint,
+			   vehicle_local_position_s *vehicle_local_position) = 0;
+
+	/**
+	 * Call to get result of the task execution
+	 * @return pointer to
+	 */
+	const vehicle_local_position_setpoint_s *get_local_position_setpoint() const { return &vehicle_local_position_setpoint; };
+
+private:
+
+	vehicle_local_position_setpoint_s vehicle_local_position_setpoint;
+
+};

--- a/src/lib/FlightTasks/tasks/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.hpp
@@ -41,10 +41,11 @@
 
 #pragma once
 
-class FlightTask
+class FlightTask : public control::SuperBlock
 {
 public:
-	FlightTask()
+	FlightTask(SuperBlock *parent, const char *name) :
+		SuperBlock(parent, name)
 	{
 		_vehicle_position = nullptr;
 		_manual_control_setpoint = nullptr;
@@ -78,6 +79,7 @@ public:
 		_time = hrt_elapsed_time(&_starting_time_stamp) / 1e6f;
 		_deltatime  = math::min(hrt_elapsed_time(&_last_time_stamp) / 1e6f, (float)_timeout);
 		_last_time_stamp = hrt_absolute_time();
+		updateSubscriptions();
 		_evaluate_sticks();
 		_evaluate_position();
 		_evaluate_velocity();

--- a/src/lib/FlightTasks/tasks/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.hpp
@@ -55,7 +55,7 @@ public:
 	/**
 	 * Call once on the event where you switch to the task
 	 * Note: Set the necessary input pointers first!
-	 * @return 0 on success, >0 on error otherwise
+	 * @return 0 on success, >0 on error
 	 */
 	virtual int activate()
 	{
@@ -65,13 +65,13 @@ public:
 
 	/**
 	 * Call once on the event of switching away from the task
-	 * 	@return 0 on success, >0 on error otherwise
+	 * 	@return 0 on success, >0 on error
 	 */
 	virtual int disable() = 0;
 
 	/**
 	 * To be called regularly in the control loop cycle to execute the task
-	 * @return 0 on success, >0 on error otherwise
+	 * @return 0 on success, >0 on error
 	 */
 	virtual int update()
 	{

--- a/src/lib/FlightTasks/tasks/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.hpp
@@ -47,11 +47,17 @@
 class FlightTask
 {
 public:
-	FlightTask() {};
+	FlightTask()
+	{
+		_vehicle_local_position = NULL;
+		_manual_control_setpoint = NULL;
+		_reset_time();
+	};
 	virtual ~FlightTask() {};
 
 	/**
 	 * Call once on the event where you switch to the task
+	 * Note: Set the necessary input pointers first!
 	 * @return 0 on success, >0 on error otherwise
 	 */
 	virtual int activate()
@@ -67,21 +73,32 @@ public:
 	virtual int disable() = 0;
 
 	/**
-	 * Call regularly in the control loop cycle to execute the task
-	 * @param TODO
+	 * To be called regularly in the control loop cycle to execute the task
 	 * @return 0 on success, >0 on error otherwise
 	 */
-	virtual int update(manual_control_setpoint_s *manual_control_setpoint, vehicle_local_position_s *vehicle_position)
+	virtual int update()
 	{
 		_time = hrt_elapsed_time(&_starting_time_stamp) / 1e6;
 		return 0;
 	};
 
 	/**
-	 * Call to get result of the task execution
-	 * @return pointer to
+	 * Get the resulting setpoints of the task execution via pointer
+	 * @return pointer to setpoint struct
 	 */
 	const vehicle_local_position_setpoint_s *get_position_setpoint() const { return &_vehicle_position_setpoint; };
+
+	/**
+	 * Set vehicle local position data pointer
+	 * @param pointer to vehicle local position
+	 */
+	void set_vehicle_local_position_pointer(const vehicle_local_position_s *vehicle_local_position) { _vehicle_local_position = vehicle_local_position; };
+
+	/**
+	 * Set manual control setpoint data pointer if it's needed for the task
+	 * @param pointer to manual control setpoint
+	 */
+	void set_manual_control_setpoint_pointer(const manual_control_setpoint_s *manual_control_setpoint) { _manual_control_setpoint = manual_control_setpoint; };
 
 protected:
 
@@ -111,8 +128,15 @@ protected:
 
 private:
 
+	/* local time for a task */
 	float _time = 0; /*< passed time in seconds since the task was activated */
 	hrt_abstime _starting_time_stamp; /*< time stamp when task was activated */
+
+	/* General Input */
+	const vehicle_local_position_s *_vehicle_local_position;
+	const manual_control_setpoint_s *_manual_control_setpoint;
+
+	/* General Output */
 	vehicle_local_position_setpoint_s _vehicle_position_setpoint;
 
 };

--- a/src/lib/FlightTasks/tasks/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.hpp
@@ -46,15 +46,15 @@ class FlightTask
 public:
 	FlightTask()
 	{
-		_vehicle_local_position = NULL;
-		_manual_control_setpoint = NULL;
+		_vehicle_position = nullptr;
+		_manual_control_setpoint = nullptr;
 		_reset_time();
 	};
 	virtual ~FlightTask() {};
 
 	/**
 	 * Call once on the event where you switch to the task
-	 * Note: Set the necessary input pointers first!
+	 * Note: Set the necessary input and output pointers first!
 	 * @return 0 on success, >0 on error
 	 */
 	virtual int activate()
@@ -85,22 +85,22 @@ public:
 	};
 
 	/**
-	 * Set vehicle local position data pointer
+	 * Set vehicle local position input data pointer
 	 * @param pointer to vehicle local position
 	 */
-	void set_vehicle_local_position_pointer(const vehicle_local_position_s *vehicle_local_position) { _vehicle_local_position = vehicle_local_position; };
+	void set_vehicle_local_position_pointer(const vehicle_local_position_s *vehicle_local_position) { _vehicle_position = vehicle_local_position; };
 
 	/**
-	 * Set manual control setpoint data pointer if it's needed for the task
+	 * Set manual control setpoint input data pointer if it's needed for the task
 	 * @param pointer to manual control setpoint
 	 */
 	void set_manual_control_setpoint_pointer(const manual_control_setpoint_s *manual_control_setpoint) { _manual_control_setpoint = manual_control_setpoint; };
 
 	/**
-	 * Get the resulting setpoints of the task execution via pointer
-	 * @return pointer to setpoint struct
+	 * Set local position setpoint data pointer if it's needed for the task
+	 * @param pointer to manual control setpoint
 	 */
-	const vehicle_local_position_setpoint_s *get_position_setpoint() const { return &_vehicle_position_setpoint; };
+	void set_vehicle_local_position_setpoint_pointer(vehicle_local_position_setpoint_s *vehicle_position_setpoint) { _vehicle_position_setpoint = vehicle_position_setpoint; };
 
 protected:
 
@@ -113,25 +113,45 @@ protected:
 	matrix::Vector3f _position;
 	matrix::Vector3f _velocity;
 
+	/**
+	 * Put the position vector produced by the task into the setpoint message
+	 */
 	void _set_position_setpoint(const matrix::Vector3f position_setpoint)
 	{
-		_vehicle_position_setpoint.x = position_setpoint(0);
-		_vehicle_position_setpoint.y = position_setpoint(1);
-		_vehicle_position_setpoint.z = position_setpoint(2);
+		if (_vehicle_position_setpoint != nullptr) {
+			_vehicle_position_setpoint->x = position_setpoint(0);
+			_vehicle_position_setpoint->y = position_setpoint(1);
+			_vehicle_position_setpoint->z = position_setpoint(2);
+		}
 	};
 
+	/**
+	 * Put the velocity vector produced by the task into the setpoint message
+	 */
 	void _set_velocity_setpoint(const matrix::Vector3f velocity_setpoint)
 	{
-		_vehicle_position_setpoint.vx = velocity_setpoint(0);
-		_vehicle_position_setpoint.vy = velocity_setpoint(1);
-		_vehicle_position_setpoint.vz = velocity_setpoint(2);
+		if (_vehicle_position_setpoint != nullptr) {
+			_vehicle_position_setpoint->vx = velocity_setpoint(0);
+			_vehicle_position_setpoint->vy = velocity_setpoint(1);
+			_vehicle_position_setpoint->vz = velocity_setpoint(2);
+		}
 	};
 
-	void _set_acceleration_setpoint(const matrix::Vector3f acceleration_setpoint)
+	/**
+	 * Put the acceleration vector produced by the task into the setpoint message
+	 * @return 0 on success, >0 on error
+	 */
+	int _set_acceleration_setpoint(const matrix::Vector3f acceleration_setpoint)
 	{
-		_vehicle_position_setpoint.acc_x = acceleration_setpoint(0);
-		_vehicle_position_setpoint.acc_y = acceleration_setpoint(1);
-		_vehicle_position_setpoint.acc_z = acceleration_setpoint(2);
+		if (_vehicle_position_setpoint != nullptr) {
+			_vehicle_position_setpoint->acc_x = acceleration_setpoint(0);
+			_vehicle_position_setpoint->acc_y = acceleration_setpoint(1);
+			_vehicle_position_setpoint->acc_z = acceleration_setpoint(2);
+			return 0;
+
+		} else {
+			return 1;
+		}
 	};
 
 private:
@@ -141,23 +161,23 @@ private:
 	hrt_abstime _last_time_stamp; /*< time stamp when task was last updated */
 
 	/* General input that every task has */
-	const vehicle_local_position_s *_vehicle_local_position;
+	const vehicle_local_position_s *_vehicle_position;
 	const manual_control_setpoint_s *_manual_control_setpoint;
 
 	/* General output that every task has */
-	vehicle_local_position_setpoint_s _vehicle_position_setpoint;
+	vehicle_local_position_setpoint_s *_vehicle_position_setpoint;
 
 	void _evaluate_position()
 	{
-		if (_vehicle_local_position != NULL && hrt_elapsed_time(&_vehicle_local_position->timestamp) < _timeout) {
-			_position = matrix::Vector3f(&_vehicle_local_position->x);
+		if (_vehicle_position != nullptr && hrt_elapsed_time(&_vehicle_position->timestamp) < _timeout) {
+			_position = matrix::Vector3f(&_vehicle_position->x);
 		}
 	}
 
 	void _evaluate_velocity()
 	{
-		if (_vehicle_local_position != NULL && hrt_elapsed_time(&_vehicle_local_position->timestamp) < _timeout) {
-			_velocity = matrix::Vector3f(&_vehicle_local_position->vx);
+		if (_vehicle_position != nullptr && hrt_elapsed_time(&_vehicle_position->timestamp) < _timeout) {
+			_velocity = matrix::Vector3f(&_vehicle_position->vx);
 
 		} else {
 			_velocity = matrix::Vector3f(); /* default is all zero */
@@ -166,7 +186,7 @@ private:
 
 	void _evaluate_sticks()
 	{
-		if (_manual_control_setpoint != NULL && hrt_elapsed_time(&_manual_control_setpoint->timestamp) < _timeout) {
+		if (_manual_control_setpoint != nullptr && hrt_elapsed_time(&_manual_control_setpoint->timestamp) < _timeout) {
 			_sticks(0) = _manual_control_setpoint->x; /* NED x, "pitch" [-1,1] */
 			_sticks(1) = _manual_control_setpoint->y; /* NED y, "roll" [-1,1] */
 			_sticks(2) = (_manual_control_setpoint->z - 0.5f) * 2.f; /* NED z, "thrust" resacaled from [0,1] to [-1,1] */

--- a/src/lib/FlightTasks/tasks/FlightTaskManual.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskManual.hpp
@@ -49,12 +49,12 @@ class FlightTaskManual : public FlightTask
 public:
 	FlightTaskManual(SuperBlock *parent, const char *name) :
 		FlightTask(parent, name),
-		_xy_vel_man_expo(nullptr, "MPC_XY_MAN_EXPO"),
-		_z_vel_man_expo(nullptr, "MPC_Z_MAN_EXPO"),
-		_hold_dz(nullptr, "MPC_HOLD_DZ"),
-		_velocity_hor_manual(nullptr, "MPC_VEL_MANUAL"),
-		_z_vel_max_up(nullptr, "MPC_Z_VEL_MAX_UP"),
-		_z_vel_max_down(nullptr, "MPC_Z_VEL_MAX_DN"),
+		_xy_vel_man_expo(parent, "MPC_XY_MAN_EXPO", false),
+		_z_vel_man_expo(parent, "MPC_Z_MAN_EXPO", false),
+		_hold_dz(parent, "MPC_HOLD_DZ", false),
+		_velocity_hor_manual(parent, "MPC_VEL_MANUAL", false),
+		_z_vel_max_up(parent, "MPC_Z_VEL_MAX_UP", false),
+		_z_vel_max_down(parent, "MPC_Z_VEL_MAX_DN", false),
 		_sub_control_state(ORB_ID(control_state), 0, 0, &getSubscriptions())
 	{};
 	virtual ~FlightTaskManual() {};

--- a/src/lib/FlightTasks/tasks/FlightTaskManual.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskManual.hpp
@@ -202,33 +202,33 @@ private:
 	math::LowPassFilter2p _filter_manual_pitch;
 	math::LowPassFilter2p _filter_manual_roll;
 
-	void vel_sp_slewrate(float dt, matrix::Vector3f &_vel_sp)
+	void vel_sp_slewrate(matrix::Vector3f &_vel_sp)
 	{
 		matrix::Vector2f vel_sp_xy(_vel_sp(0), _vel_sp(1));
 		matrix::Vector2f vel_sp_prev_xy(_vel_sp_prev(0), _vel_sp_prev(1));
 		matrix::Vector2f vel_xy(_velocity(0), _velocity(1));
-		matrix::Vector2f acc_xy = (vel_sp_xy - vel_sp_prev_xy) / dt;
+		matrix::Vector2f acc_xy = (vel_sp_xy - vel_sp_prev_xy) / _deltatime;
 
 		/* limit total horizontal acceleration */
 		if (acc_xy.length() > _acceleration_state_dependent_xy) {
-			vel_sp_xy = _acceleration_state_dependent_xy * acc_xy.normalized() * dt + vel_sp_prev_xy;
+			vel_sp_xy = _acceleration_state_dependent_xy * acc_xy.normalized() * _deltatime + vel_sp_prev_xy;
 			_vel_sp(0) = vel_sp_xy(0);
 			_vel_sp(1) = vel_sp_xy(1);
 		}
 
 		/* limit vertical acceleration */
-		float acc_z = (_vel_sp(2) - _vel_sp_prev(2)) / dt;
+		float acc_z = (_vel_sp(2) - _vel_sp_prev(2)) / _deltatime;
 		float max_acc_z;
 
 		max_acc_z = (acc_z < 0.0f) ? -_acceleration_state_dependent_z : _acceleration_state_dependent_z;
 
 		if (fabsf(acc_z) > fabsf(max_acc_z)) {
-			_vel_sp(2) = max_acc_z * dt + _vel_sp_prev(2);
+			_vel_sp(2) = max_acc_z * _deltatime + _vel_sp_prev(2);
 		}
 
 	}
 
-	void set_manual_acceleration_xy(matrix::Vector2f &stick_xy, const float dt)
+	void set_manual_acceleration_xy(matrix::Vector2f &stick_xy)
 	{
 
 		/*
@@ -383,10 +383,10 @@ private:
 		case brake: {
 
 				/* limit jerk when braking to zero */
-				float jerk = (_acceleration_hor_max.get() - _acceleration_state_dependent_xy) / dt;
+				float jerk = (_acceleration_hor_max.get() - _acceleration_state_dependent_xy) / _deltatime;
 
 				if (jerk > _manual_jerk_limit_xy) {
-					_acceleration_state_dependent_xy = _manual_jerk_limit_xy * dt + _acceleration_state_dependent_xy;
+					_acceleration_state_dependent_xy = _manual_jerk_limit_xy * _deltatime + _acceleration_state_dependent_xy;
 
 				} else {
 					_acceleration_state_dependent_xy = _acceleration_hor_max.get();
@@ -437,7 +437,7 @@ private:
 		}
 	}
 
-	void set_manual_acceleration_z(float &max_acceleration, const float stick_z, const float dt)
+	void set_manual_acceleration_z(float &max_acceleration, const float stick_z)
 	{
 
 		/* in manual altitude control apply acceleration limit based on stick input
@@ -480,10 +480,10 @@ private:
 		if (_user_intention_z == brake) {
 
 			/* limit jerk when braking to zero */
-			float jerk = (_acceleration_z_max_up.get() - _acceleration_state_dependent_z) / dt;
+			float jerk = (_acceleration_z_max_up.get() - _acceleration_state_dependent_z) / _deltatime;
 
 			if (jerk > _manual_jerk_limit_z) {
-				_acceleration_state_dependent_z = _manual_jerk_limit_z * dt + _acceleration_state_dependent_z;
+				_acceleration_state_dependent_z = _manual_jerk_limit_z * _deltatime + _acceleration_state_dependent_z;
 
 			} else {
 				_acceleration_state_dependent_z = _acceleration_z_max_up.get();

--- a/src/lib/FlightTasks/tasks/FlightTaskManual.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskManual.hpp
@@ -162,4 +162,214 @@ private:
 	uORB::Subscription<control_state_s> _sub_control_state;
 
 	matrix::Vector3f _hold_position; /**< position at which the vehicle stays while the input is zero velocity */
+
+	void set_manual_acceleration_xy(matrix::Vector2f &stick_xy, const float dt)
+	{
+
+		/*
+		 * In manual mode we consider four states with different acceleration handling:
+		 * 1. user wants to stop
+		 * 2. user wants to quickly change direction
+		 * 3. user wants to accelerate
+		 * 4. user wants to decelerate
+		 */
+
+		/* get normalized stick input vector */
+		matrix::Vector2f stick_xy_norm = (stick_xy.length() > 0.0f) ? stick_xy.normalized() : stick_xy;
+		matrix::Vector2f stick_xy_prev_norm = (_stick_input_xy_prev.length() > 0.0f) ? _stick_input_xy_prev.normalized() :
+						      _stick_input_xy_prev;
+
+		/* check if stick direction and current velocity are within 60angle */
+		const bool is_aligned = (stick_xy_norm * stick_xy_prev_norm) > 0.5f;
+
+		/* check if zero input stick */
+		const bool is_prev_zero = (fabsf(_stick_input_xy_prev.length()) <= FLT_EPSILON);
+		const bool is_current_zero = (fabsf(stick_xy.length()) <= FLT_EPSILON);
+
+		/* check acceleration */
+		const bool do_acceleration = is_prev_zero || (is_aligned &&
+					     ((stick_xy.length() > _stick_input_xy_prev.length()) || (fabsf(stick_xy.length() - 1.0f) < FLT_EPSILON)));
+
+		const bool do_deceleration = (is_aligned && (stick_xy.length() <= _stick_input_xy_prev.length()));
+
+		const bool do_direction_change = !is_aligned;
+
+		manual_stick_input intention;
+
+		if (is_current_zero) {
+			/* we want to stop */
+			intention = brake;
+
+		} else if (do_acceleration) {
+			/* we do manual acceleration */
+			intention = acceleration;
+
+		} else if (do_deceleration) {
+			/* we do manual deceleration */
+			intention = deceleration;
+
+		} else if (do_direction_change) {
+			/* we have a direction change */
+			intention = direction_change;
+
+		} else {
+			/* catchall: acceleration */
+			intention = acceleration;
+		}
+
+
+		/*
+		 * update user intention
+		 */
+
+		/* we always want to break starting with slow deceleration */
+		if ((_user_intention_xy != brake) && (intention  == brake)) {
+
+			if (_jerk_hor_max.get() > _jerk_hor_min.get()) {
+				_manual_jerk_limit_xy = (_jerk_hor_max.get() - _jerk_hor_min.get()) / _velocity_hor_manual.get() *
+							sqrtf(_vel(0) * _vel(0) + _vel(1) * _vel(1)) + _jerk_hor_min.get();
+
+				/* we start braking with lowest accleration */
+				_acceleration_state_dependent_xy = _deceleration_hor_slow.get();
+
+			} else {
+
+				/* set the jerk limit large since we don't know it better*/
+				_manual_jerk_limit_xy = 1000000.f;
+
+				/* at brake we use max acceleration */
+				_acceleration_state_dependent_xy = _acceleration_hor_max.get();
+
+			}
+
+			/* reset slew rate */
+			_vel_sp_prev(0) = _vel(0);
+			_vel_sp_prev(1) = _vel(1);
+
+		}
+
+		switch (_user_intention_xy) {
+		case brake: {
+				if (intention != brake) {
+					_user_intention_xy = acceleration;
+					/* we initialize with lowest acceleration */
+					_acceleration_state_dependent_xy = _deceleration_hor_slow.get();
+				}
+
+				break;
+			}
+
+		case direction_change: {
+				/* only exit direction change if brake or aligned */
+				matrix::Vector2f vel_xy(_vel(0), _vel(1));
+				matrix::Vector2f vel_xy_norm = (vel_xy.length() > 0.0f) ? vel_xy.normalized() : vel_xy;
+				bool stick_vel_aligned = (vel_xy_norm * stick_xy_norm > 0.0f);
+
+				/* update manual direction change hysteresis */
+				_manual_direction_change_hysteresis.set_state_and_update(!stick_vel_aligned);
+
+
+				/* exit direction change if one of the condition is met */
+				if (intention == brake) {
+					_user_intention_xy = intention;
+
+				} else if (stick_vel_aligned) {
+					_user_intention_xy = acceleration;
+
+				} else if (_manual_direction_change_hysteresis.get_state()) {
+
+					/* TODO: find conditions which are always continuous
+					 * only if stick input is large*/
+					if (stick_xy.length() > 0.6f) {
+						_acceleration_state_dependent_xy = _acceleration_hor_max.get();
+					}
+				}
+
+				break;
+			}
+
+		case acceleration: {
+				_user_intention_xy = intention;
+
+				if (_user_intention_xy == direction_change) {
+					_vel_sp_prev(0) = _vel(0);
+					_vel_sp_prev(1) = _vel(1);
+				}
+
+				break;
+			}
+
+		case deceleration: {
+				_user_intention_xy = intention;
+
+				if (_user_intention_xy == direction_change) {
+					_vel_sp_prev(0) = _vel(0);
+					_vel_sp_prev(1) = _vel(1);
+				}
+
+				break;
+			}
+		}
+
+		/*
+		 * apply acceleration based on state
+		*/
+		switch (_user_intention_xy) {
+		case brake: {
+
+				/* limit jerk when braking to zero */
+				float jerk = (_acceleration_hor_max.get() - _acceleration_state_dependent_xy) / dt;
+
+				if (jerk > _manual_jerk_limit_xy) {
+					_acceleration_state_dependent_xy = _manual_jerk_limit_xy * dt + _acceleration_state_dependent_xy;
+
+				} else {
+					_acceleration_state_dependent_xy = _acceleration_hor_max.get();
+				}
+
+				break;
+			}
+
+		case direction_change: {
+
+				/* limit acceleration linearly on stick input*/
+				_acceleration_state_dependent_xy = (_acceleration_hor_manual.get() - _deceleration_hor_slow.get()) * stick_xy.length() +
+								   _deceleration_hor_slow.get();
+				break;
+			}
+
+		case acceleration: {
+				/* limit acceleration linearly on stick input*/
+				float acc_limit  = (_acceleration_hor_manual.get() - _deceleration_hor_slow.get()) * stick_xy.length()
+						   + _deceleration_hor_slow.get();
+
+				if (_acceleration_state_dependent_xy > acc_limit) {
+					acc_limit = _acceleration_state_dependent_xy;
+				}
+
+				_acceleration_state_dependent_xy = acc_limit;
+				break;
+			}
+
+		case deceleration: {
+				_acceleration_state_dependent_xy = _deceleration_hor_slow.get();
+				break;
+			}
+
+		default :
+			warn_rate_limited("User intention not recognized");
+			_acceleration_state_dependent_xy = _acceleration_hor_max.get();
+
+		}
+
+		/* update previous stick input */
+		_stick_input_xy_prev = matrix::Vector2f(_filter_manual_pitch.apply(stick_xy(0)),
+							_filter_manual_roll.apply(stick_xy(1)));
+
+
+		if (_stick_input_xy_prev.length() > 1.0f) {
+			_stick_input_xy_prev = _stick_input_xy_prev.normalized();
+		}
+	}
+
 };

--- a/src/lib/FlightTasks/tasks/FlightTaskManual.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskManual.hpp
@@ -202,11 +202,11 @@ private:
 	math::LowPassFilter2p _filter_manual_pitch;
 	math::LowPassFilter2p _filter_manual_roll;
 
-	void vel_sp_slewrate(float dt)
+	void vel_sp_slewrate(float dt, matrix::Vector3f &_vel_sp)
 	{
 		matrix::Vector2f vel_sp_xy(_vel_sp(0), _vel_sp(1));
 		matrix::Vector2f vel_sp_prev_xy(_vel_sp_prev(0), _vel_sp_prev(1));
-		matrix::Vector2f vel_xy(_vel(0), _vel(1));
+		matrix::Vector2f vel_xy(_velocity(0), _velocity(1));
 		matrix::Vector2f acc_xy = (vel_sp_xy - vel_sp_prev_xy) / dt;
 
 		/* limit total horizontal acceleration */
@@ -220,12 +220,7 @@ private:
 		float acc_z = (_vel_sp(2) - _vel_sp_prev(2)) / dt;
 		float max_acc_z;
 
-		if (_control_mode.flag_control_manual_enabled) {
-			max_acc_z = (acc_z < 0.0f) ? -_acceleration_state_dependent_z : _acceleration_state_dependent_z;
-
-		} else {
-			max_acc_z = (acc_z < 0.0f) ? -_acceleration_z_max_up.get() : _acceleration_z_max_down.get();
-		}
+		max_acc_z = (acc_z < 0.0f) ? -_acceleration_state_dependent_z : _acceleration_state_dependent_z;
 
 		if (fabsf(acc_z) > fabsf(max_acc_z)) {
 			_vel_sp(2) = max_acc_z * dt + _vel_sp_prev(2);

--- a/src/lib/FlightTasks/tasks/FlightTaskManual.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskManual.hpp
@@ -63,6 +63,8 @@ public:
 		_deceleration_hor_slow(parent, "MPC_DEC_HOR_SLOW", false),
 		_acceleration_hor_max(this, "ACC_HOR_MAX", true),
 		_acceleration_hor_manual(this, "ACC_HOR_MAN", true),
+		_acceleration_z_max_up(this, "ACC_UP_MAX", true),
+		_acceleration_z_max_down(this, "ACC_DOWN_MAX", true),
 		_manual_direction_change_hysteresis(false),
 		_filter_manual_pitch(50.0f, 10.0f),
 		_filter_manual_roll(50.0f, 10.0f)
@@ -180,6 +182,8 @@ private:
 	control::BlockParamFloat _deceleration_hor_slow; /**< slow velocity setpoint slewrate for manual deceleration*/
 	control::BlockParamFloat _acceleration_hor_max; /**< maximum velocity setpoint slewrate for auto & fast manual brake */
 	control::BlockParamFloat _acceleration_hor_manual; /**< maximum velocity setpoint slewrate for manual acceleration */
+	control::BlockParamFloat _acceleration_z_max_up; /**< max acceleration up */
+	control::BlockParamFloat _acceleration_z_max_down; /**< max acceleration down */
 	matrix::Vector2f _stick_input_xy_prev;
 	matrix::Vector3f _vel_sp_prev;
 	enum manual_stick_input {
@@ -438,7 +442,7 @@ private:
 			_acceleration_state_dependent_z = _acceleration_z_max_down.get();
 
 			/* reset slew rate */
-			_vel_sp_prev(2) = _vel(2);
+			_vel_sp_prev(2) = _velocity(2);
 			_user_intention_z = brake;
 		}
 

--- a/src/lib/FlightTasks/tasks/FlightTaskManual.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskManual.hpp
@@ -57,7 +57,6 @@ public:
 		_z_vel_max_down(parent, "MPC_Z_VEL_MAX_DN", false),
 		_hold_max_xy(parent, "MPC_HOLD_MAX_XY", false),
 		_hold_max_z(parent, "MPC_HOLD_MAX_Z", false),
-		_sub_control_state(ORB_ID(control_state), 0, 0, &getSubscriptions()),
 		_jerk_hor_max(parent, "MPC_JERK_MAX", false),
 		_jerk_hor_min(parent, "MPC_JERK_MIN", false),
 		_deceleration_hor_slow(parent, "MPC_DEC_HOR_SLOW", false),
@@ -176,8 +175,6 @@ private:
 	control::BlockParamFloat _z_vel_max_down; /**< maximal vertical velocity when flying downwards with the stick */
 	control::BlockParamFloat _hold_max_xy; /**< velocity threshold to switch into horizontal position hold */
 	control::BlockParamFloat _hold_max_z; /**< velocity threshold to switch into vertical position hold */
-
-	uORB::Subscription<control_state_s> _sub_control_state;
 
 	matrix::Vector3f _hold_position; /**< position at which the vehicle stays while the input is zero velocity */
 

--- a/src/lib/FlightTasks/tasks/FlightTaskManual.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskManual.hpp
@@ -114,8 +114,6 @@ public:
 		velocity_setpoint = velocity_setpoint.emult(vel_scale);
 
 		_set_velocity_setpoint(velocity_setpoint);
-		//printf("------");
-		//velocity_setpoint.print();
 
 		/* handle position and altitude hold */
 		const bool stick_xy_zero = stick_xy_norm <= FLT_EPSILON;
@@ -142,7 +140,6 @@ public:
 		}
 
 		_set_position_setpoint(_hold_position);
-		//_hold_position.print();
 		return 0;
 	};
 
@@ -164,5 +161,5 @@ private:
 
 	uORB::Subscription<control_state_s> _sub_control_state;
 
-	matrix::Vector3f _hold_position;
+	matrix::Vector3f _hold_position; /**< position at which the vehicle stays while the input is zero velocity */
 };

--- a/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
@@ -73,20 +73,30 @@ public:
 	{
 		FlightTask::update();
 		r += _sticks(1) * _deltatime;
-		vu += _sticks(0) * 0.1f * _deltatime;
+		r = math::constrain(r, 0.5f, 4.f);
+
+		v += _sticks(0) * _deltatime; /* angular velocity for orbiting in revolutions per second */
+		v = math::constrain(v, -4.f, 4.f);
 		altitude += _sticks(3) * _deltatime;
-		//printf("%f %f %f\n", (double)altitude, (double)r, (double)vu);
+		altitude = math::constrain(altitude, 2.f, 5.f);
+
+		printf("%f %f %f\n", (double)altitude, (double)r, (double)v);
+
 		//printf("%f %f %f\n", (double)_position(0), (double)_position(1), (double)_position(2));
-		printf("%f %f %f\n", (double)_velocity(0), (double)_velocity(1), (double)_velocity(2));
-		float v = 2 * M_PI_F * vu; /* velocity for orbiting in radians per second */
-		_set_position_setpoint(matrix::Vector3f(r * cosf(v * _time), r * sinf(v * _time), -altitude));
+		//printf("%f %f %f\n", (double)_velocity(0), (double)_velocity(1), (double)_velocity(2));
+		if (fabsf(r) < 0.01f) {
+			r = 0.01;
+		}
+
+		float w = v / r; /* angular velocity for orbiting in radians per second */
+		_set_position_setpoint(matrix::Vector3f(r * cosf(w * _time), r * sinf(w * _time), -altitude));
 		return 0;
 	};
 
 private:
 
-	float r = 2.f; /* radius with which to orbit the target */
-	float vu =  0.1f; /* velocity for orbiting in revolutions per second */
-	float altitude = 2; /* altitude in meters */
+	float r = 1.f; /* radius with which to orbit the target */
+	float v =  0.1f; /* linear velocity for orbiting in m/s */
+	float altitude = 2.f; /* altitude in meters */
 
 };

--- a/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
@@ -53,7 +53,11 @@ public:
 	 * Call once on the event where you switch to the task
 	 * @return 0 on success, >0 on error otherwise
 	 */
-	virtual int activate() { return 0; };
+	virtual int activate()
+	{
+		_set_position_setpoint(matrix::Vector3f());
+		return 0;
+	};
 
 	/**
 	 * Call once on the event of switching away from the task
@@ -66,8 +70,12 @@ public:
 	 * @param TODO
 	 * @return 0 on success, >0 on error otherwise
 	 */
-	virtual int update(manual_control_setpoint_s *manual_control_setpoint,
-			   vehicle_local_position_s *vehicle_local_position) { return 0; };
+	virtual int update(manual_control_setpoint_s *manual_control_setpoint, vehicle_local_position_s *vehicle_position)
+	{
+		float time = hrt_absolute_time() / 1e6;
+		_set_position_setpoint(matrix::Vector3f(0.1f * time, 0.f, -2.f));
+		return 0;
+	};
 
 private:
 

--- a/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
@@ -67,19 +67,23 @@ public:
 
 	/**
 	 * Call regularly in the control loop cycle to execute the task
-	 * @param TODO
 	 * @return 0 on success, >0 on error otherwise
 	 */
 	virtual int update()
 	{
 		FlightTask::update();
-		float v = 2 * M_PI_F * 0.1f; /* velocity for orbiting in radians per second */
+		r += _sticks(1) * _deltatime;
+		vu += _sticks(0) * _deltatime;
+		printf("%f %f %f\n", (double)_deltatime, (double)r, (double)vu);
+		float v = 2 * M_PI_F * vu; /* velocity for orbiting in radians per second */
 		float altitude = 2; /* altitude in meters */
-		_set_position_setpoint(matrix::Vector3f(1.f * cosf(v * _get_time()), 1.f * sinf(v * _get_time()), -altitude));
+		_set_position_setpoint(matrix::Vector3f(r * cosf(v * _time), r * sinf(v * _time), -altitude));
 		return 0;
 	};
 
 private:
 
+	float r = 2.f; /* radius with which to orbit the target */
+	float vu =  0.1f; /* velocity for orbiting in revolutions per second */
 
 };

--- a/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
@@ -73,7 +73,9 @@ public:
 	virtual int update(manual_control_setpoint_s *manual_control_setpoint, vehicle_local_position_s *vehicle_position)
 	{
 		FlightTask::update(NULL, NULL);
-		_set_position_setpoint(matrix::Vector3f(0.1f * _get_time(), 0.f, -2.f));
+		float v = 2 * M_PI_F * 0.1f; /* velocity for orbiting in radians per second */
+		float altitude = 2; /* altitude in meters */
+		_set_position_setpoint(matrix::Vector3f(1.f * cosf(v * _get_time()), 1.f * sinf(v * _get_time()), -altitude));
 		return 0;
 	};
 

--- a/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
@@ -58,6 +58,9 @@ public:
 	virtual int activate()
 	{
 		FlightTask::activate();
+		r = 1.f;
+		v =  0.5f;
+		altitude = 6.f;
 		return 0;
 	};
 
@@ -80,7 +83,7 @@ public:
 		FlightTask::update();
 
 		r += _sticks(0) * _deltatime;
-		r = math::constrain(r, 0.5f, 4.f);
+		r = math::constrain(r, 1.f, 20.f);
 		v -= _sticks(1) * _deltatime;
 		v = math::constrain(v, -7.f, 7.f);
 		altitude += _sticks(2) * _deltatime;

--- a/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
@@ -70,9 +70,9 @@ public:
 	 * @param TODO
 	 * @return 0 on success, >0 on error otherwise
 	 */
-	virtual int update(manual_control_setpoint_s *manual_control_setpoint, vehicle_local_position_s *vehicle_position)
+	virtual int update()
 	{
-		FlightTask::update(NULL, NULL);
+		FlightTask::update();
 		float v = 2 * M_PI_F * 0.1f; /* velocity for orbiting in radians per second */
 		float altitude = 2; /* altitude in meters */
 		_set_position_setpoint(matrix::Vector3f(1.f * cosf(v * _get_time()), 1.f * sinf(v * _get_time()), -altitude));

--- a/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
@@ -55,7 +55,7 @@ public:
 	 */
 	virtual int activate()
 	{
-		_set_position_setpoint(matrix::Vector3f());
+		FlightTask::activate();
 		return 0;
 	};
 
@@ -72,8 +72,8 @@ public:
 	 */
 	virtual int update(manual_control_setpoint_s *manual_control_setpoint, vehicle_local_position_s *vehicle_position)
 	{
-		float time = hrt_absolute_time() / 1e6;
-		_set_position_setpoint(matrix::Vector3f(0.1f * time, 0.f, -2.f));
+		FlightTask::update(NULL, NULL);
+		_set_position_setpoint(matrix::Vector3f(0.1f * _get_time(), 0.f, -2.f));
 		return 0;
 	};
 

--- a/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
@@ -46,7 +46,9 @@
 class FlightTaskOrbit : public FlightTask
 {
 public:
-	FlightTaskOrbit() {};
+	FlightTaskOrbit(SuperBlock *parent, const char *name) :
+		FlightTask(parent, name)
+	{};
 	virtual ~FlightTaskOrbit() {};
 
 	/**

--- a/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
@@ -1,0 +1,75 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file FlightTaskOrbit.h
+ *
+ * Flight task for orbiting in a circle around a target position
+ *
+ * @author Matthias Grob <maetugr@gmail.com>
+ */
+
+#pragma once
+
+#include "FlightTask.hpp"
+
+class FlightTaskOrbit : public FlightTask
+{
+public:
+	FlightTaskOrbit() {};
+	virtual ~FlightTaskOrbit() {};
+
+	/**
+	 * Call once on the event where you switch to the task
+	 * @return 0 on success, >0 on error otherwise
+	 */
+	virtual int activate() { return 0; };
+
+	/**
+	 * Call once on the event of switching away from the task
+	 * 	@return 0 on success, >0 on error otherwise
+	 */
+	virtual int disable() { return 0; };
+
+	/**
+	 * Call regularly in the control loop cycle to execute the task
+	 * @param TODO
+	 * @return 0 on success, >0 on error otherwise
+	 */
+	virtual int update(manual_control_setpoint_s *manual_control_setpoint,
+			   vehicle_local_position_s *vehicle_local_position) { return 0; };
+
+private:
+
+
+};

--- a/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskOrbit.hpp
@@ -73,10 +73,12 @@ public:
 	{
 		FlightTask::update();
 		r += _sticks(1) * _deltatime;
-		vu += _sticks(0) * _deltatime;
-		printf("%f %f %f\n", (double)_deltatime, (double)r, (double)vu);
+		vu += _sticks(0) * 0.1f * _deltatime;
+		altitude += _sticks(3) * _deltatime;
+		//printf("%f %f %f\n", (double)altitude, (double)r, (double)vu);
+		//printf("%f %f %f\n", (double)_position(0), (double)_position(1), (double)_position(2));
+		printf("%f %f %f\n", (double)_velocity(0), (double)_velocity(1), (double)_velocity(2));
 		float v = 2 * M_PI_F * vu; /* velocity for orbiting in radians per second */
-		float altitude = 2; /* altitude in meters */
 		_set_position_setpoint(matrix::Vector3f(r * cosf(v * _time), r * sinf(v * _time), -altitude));
 		return 0;
 	};
@@ -85,5 +87,6 @@ private:
 
 	float r = 2.f; /* radius with which to orbit the target */
 	float vu =  0.1f; /* velocity for orbiting in revolutions per second */
+	float altitude = 2; /* altitude in meters */
 
 };

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -543,7 +543,8 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	/* fetch initial parameter values */
 	parameters_update(true);
 
-	_flight_tasks.set_input_pointers(&_local_pos, &_manual);
+	_flight_tasks.set_general_input_pointers(&_local_pos, &_manual);
+	_flight_tasks.set_general_output_pointers(&_local_pos_sp);
 	_flight_tasks.switch_task(0);
 }
 
@@ -2422,17 +2423,17 @@ MulticopterPositionControl::calculate_velocity_setpoint(float dt)
 	if (_flight_tasks.is_any_task_active()) {
 		if (!_flight_tasks.update()) {
 			/* take over position setpoint from task if there is any */
-			if (PX4_ISFINITE(_flight_tasks.get_position_setpoint()->x) && PX4_ISFINITE(_flight_tasks.get_position_setpoint()->y)) {
-				_pos_sp(0) = _flight_tasks.get_position_setpoint()->x;
-				_pos_sp(1) = _flight_tasks.get_position_setpoint()->y;
+			if (PX4_ISFINITE(_local_pos_sp.x) && PX4_ISFINITE(_local_pos_sp.y)) {
+				_pos_sp(0) = _local_pos_sp.x;
+				_pos_sp(1) = _local_pos_sp.y;
 				_run_pos_control = true;
 
 			} else {
 				_run_pos_control = false;
 			}
 
-			if (PX4_ISFINITE(_flight_tasks.get_position_setpoint()->z)) {
-				_pos_sp(2) = _flight_tasks.get_position_setpoint()->z;
+			if (PX4_ISFINITE(_local_pos_sp.z)) {
+				_pos_sp(2) = _local_pos_sp.z;
 				_run_alt_control = true;
 
 			} else {
@@ -2440,14 +2441,14 @@ MulticopterPositionControl::calculate_velocity_setpoint(float dt)
 			}
 
 			/* take over velocity setpoint from task if there is any */
-			if (PX4_ISFINITE(_flight_tasks.get_position_setpoint()->vx)
-			    && PX4_ISFINITE(_flight_tasks.get_position_setpoint()->vy)) {
-				_vel_sp(0) = _flight_tasks.get_position_setpoint()->vx;
-				_vel_sp(1) = _flight_tasks.get_position_setpoint()->vy;
+			if (PX4_ISFINITE(_local_pos_sp.vx)
+			    && PX4_ISFINITE(_local_pos_sp.vy)) {
+				_vel_sp(0) = _local_pos_sp.vx;
+				_vel_sp(1) = _local_pos_sp.vy;
 			}
 
-			if (PX4_ISFINITE(_flight_tasks.get_position_setpoint()->vz)) {
-				_vel_sp(2) = _flight_tasks.get_position_setpoint()->vz;
+			if (PX4_ISFINITE(_local_pos_sp.vz)) {
+				_vel_sp(2) = _local_pos_sp.vz;
 			}
 
 		} else {

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -2407,9 +2407,10 @@ MulticopterPositionControl::calculate_velocity_setpoint(float dt)
 	/* run position & altitude controllers, if enabled (otherwise use already computed velocity setpoints) */
 	if (_run_pos_control) {
 
-		_pos_sp(0) = _flight_tasks.get_local_position_setpoint()->x;
-		_pos_sp(1) = _flight_tasks.get_local_position_setpoint()->y;
-		_pos_sp(2) = _flight_tasks.get_local_position_setpoint()->z;
+		_flight_tasks.update(NULL, NULL);
+		_pos_sp(0) = _flight_tasks.get_position_setpoint()->x;
+		_pos_sp(1) = _flight_tasks.get_position_setpoint()->y;
+		_pos_sp(2) = _flight_tasks.get_position_setpoint()->z;
 
 		// If for any reason, we get a NaN position setpoint, we better just stay where we are.
 		if (PX4_ISFINITE(_pos_sp(0)) && PX4_ISFINITE(_pos_sp(1))) {

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -2407,6 +2407,18 @@ MulticopterPositionControl::control_position(float dt)
 void
 MulticopterPositionControl::calculate_velocity_setpoint(float dt)
 {
+	/* TODO: this block is for task switch testing only */
+	static int gear_switch_last;
+	const bool gear_transition_to_on = gear_switch_last == manual_control_setpoint_s::SWITCH_POS_OFF
+					   && _manual.gear_switch == manual_control_setpoint_s::SWITCH_POS_ON;
+
+	if (gear_transition_to_on) {
+		_flight_tasks.switch_task();
+	}
+
+	gear_switch_last = _manual.gear_switch;
+
+
 	if (_flight_tasks.is_any_task_active()) {
 		if (!_flight_tasks.update()) {
 			/* take over position setpoint from task if there is any */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -2406,13 +2406,14 @@ MulticopterPositionControl::control_position(float dt)
 void
 MulticopterPositionControl::calculate_velocity_setpoint(float dt)
 {
+	_flight_tasks.update();
+	_pos_sp(0) = _flight_tasks.get_position_setpoint()->x;
+	_pos_sp(1) = _flight_tasks.get_position_setpoint()->y;
+	_pos_sp(2) = _flight_tasks.get_position_setpoint()->z;
+	_run_pos_control = true;
+
 	/* run position & altitude controllers, if enabled (otherwise use already computed velocity setpoints) */
 	if (_run_pos_control) {
-
-		_flight_tasks.update();
-		_pos_sp(0) = _flight_tasks.get_position_setpoint()->x;
-		_pos_sp(1) = _flight_tasks.get_position_setpoint()->y;
-		_pos_sp(2) = _flight_tasks.get_position_setpoint()->z;
 
 		// If for any reason, we get a NaN position setpoint, we better just stay where we are.
 		if (PX4_ISFINITE(_pos_sp(0)) && PX4_ISFINITE(_pos_sp(1))) {

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -2407,7 +2407,7 @@ MulticopterPositionControl::calculate_velocity_setpoint(float dt)
 	/* run position & altitude controllers, if enabled (otherwise use already computed velocity setpoints) */
 	if (_run_pos_control) {
 
-		_flight_tasks.update(NULL, NULL);
+		_flight_tasks.update();
 		_pos_sp(0) = _flight_tasks.get_position_setpoint()->x;
 		_pos_sp(1) = _flight_tasks.get_position_setpoint()->y;
 		_pos_sp(2) = _flight_tasks.get_position_setpoint()->z;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -76,6 +76,8 @@
 #include <controllib/blocks.hpp>
 #include <controllib/block/BlockParam.hpp>
 
+#include <lib/FlightTasks/FlightTasks.hpp>
+
 #define SIGMA_SINGLE_OP			0.000001f
 #define SIGMA_NORM			0.001f
 /**
@@ -182,6 +184,8 @@ private:
 	control::BlockDerivative _vel_x_deriv;
 	control::BlockDerivative _vel_y_deriv;
 	control::BlockDerivative _vel_z_deriv;
+
+	FlightTasks _flight_tasks;
 
 	systemlib::Hysteresis _manual_direction_change_hysteresis;
 
@@ -2402,6 +2406,10 @@ MulticopterPositionControl::calculate_velocity_setpoint(float dt)
 {
 	/* run position & altitude controllers, if enabled (otherwise use already computed velocity setpoints) */
 	if (_run_pos_control) {
+
+		_pos_sp(0) = _flight_tasks.get_local_position_setpoint()->x;
+		_pos_sp(1) = _flight_tasks.get_local_position_setpoint()->y;
+		_pos_sp(2) = _flight_tasks.get_local_position_setpoint()->z;
 
 		// If for any reason, we get a NaN position setpoint, we better just stay where we are.
 		if (PX4_ISFINITE(_pos_sp(0)) && PX4_ISFINITE(_pos_sp(1))) {

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -546,7 +546,7 @@ MulticopterPositionControl::MulticopterPositionControl() :
 
 	_flight_tasks.set_general_input_pointers(&_local_pos, &_manual);
 	_flight_tasks.set_general_output_pointers(&_local_pos_sp);
-	_flight_tasks.switch_task(0);
+	//_flight_tasks.switch_task(0);
 }
 
 MulticopterPositionControl::~MulticopterPositionControl()
@@ -2420,7 +2420,8 @@ MulticopterPositionControl::calculate_velocity_setpoint(float dt)
 
 	gear_switch_last = _manual.gear_switch;
 
-
+	/* get position controller setpoints from the active flight task, this will be through uORB from Trajectory module to position controller module in the future */
+	/* TODO: as soon as legacy stuff gets ported setting velocity and position setpoint at the same time (feed-forward) will be supported through addition of setpoints */
 	if (_flight_tasks.is_any_task_active()) {
 		if (!_flight_tasks.update()) {
 			/* take over position setpoint from task if there is any */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -2460,8 +2460,8 @@ MulticopterPositionControl::calculate_velocity_setpoint(float dt)
 
 		// If for any reason, we get a NaN position setpoint, we better just stay where we are.
 		if (PX4_ISFINITE(_pos_sp(0)) && PX4_ISFINITE(_pos_sp(1))) {
-			_vel_sp(0) += (_pos_sp(0) - _pos(0)) * _params.pos_p(0);
-			_vel_sp(1) += (_pos_sp(1) - _pos(1)) * _params.pos_p(1);
+			_vel_sp(0) = (_pos_sp(0) - _pos(0)) * _params.pos_p(0);
+			_vel_sp(1) = (_pos_sp(1) - _pos(1)) * _params.pos_p(1);
 
 		} else {
 			_vel_sp(0) = 0.0f;
@@ -2478,7 +2478,7 @@ MulticopterPositionControl::calculate_velocity_setpoint(float dt)
 
 	if (_run_alt_control) {
 		if (PX4_ISFINITE(_pos_sp(2))) {
-			_vel_sp(2) += (_pos_sp(2) - _pos(2)) * _params.pos_p(2);
+			_vel_sp(2) = (_pos_sp(2) - _pos(2)) * _params.pos_p(2);
 
 		} else {
 			_vel_sp(2) = 0.0f;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -542,6 +542,8 @@ MulticopterPositionControl::MulticopterPositionControl() :
 
 	/* fetch initial parameter values */
 	parameters_update(true);
+
+	_flight_tasks.set_input_pointers(&_local_pos, &_manual);
 }
 
 MulticopterPositionControl::~MulticopterPositionControl()

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -456,7 +456,7 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_vel_x_deriv(this, "VELD"),
 	_vel_y_deriv(this, "VELD"),
 	_vel_z_deriv(this, "VELD"),
-	_flight_tasks(nullptr),
+	_flight_tasks(),
 	_manual_direction_change_hysteresis(false),
 	_filter_manual_pitch(50.0f, 10.0f),
 	_filter_manual_roll(50.0f, 10.0f),

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -456,6 +456,7 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_vel_x_deriv(this, "VELD"),
 	_vel_y_deriv(this, "VELD"),
 	_vel_z_deriv(this, "VELD"),
+	_flight_tasks(nullptr),
 	_manual_direction_change_hysteresis(false),
 	_filter_manual_pitch(50.0f, 10.0f),
 	_filter_manual_roll(50.0f, 10.0f),


### PR DESCRIPTION
As I already introduced in the flight stack structure goal graph: https://docs.google.com/drawings/d/1Uw1PmU3hqEfWR3et9KT7zWggDX9wqoAiCt5suiWdnlw/edit
and discussed with multiple people related to https://github.com/PX4/Firmware/issues/7318
I'm working on an architecture that should allow easy implementation of any feature that makes the vehicle behave in a certain way in position controlled flight. It could potentially support attitude controlled flight through the acceleration setpoint in the future but not acro mode for sure because this mode requires a different even simpler interface and none of the functionality implemented here is necessary.

Without the current structure such additional features would result in an `if (my_mode) vel_sp = ...;` somwhere in a more or less random location of the position controller which is totally unmaintainable.

It is intended that this library classes are instanciated in a trajectory module and the resulting setpoint passed to the position controller module in the future. The output interface is currently kept as simple as possible with the local_position_setpoint (position, velocity, acceleration and yaw). This interface should also allow further piping through geo fence, obstacle avoidance and so on.

Request for comments and questions :)