### PR TITLE
Fixes #6484: Bug in Offboard mode incorrect use of type_mask

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -926,7 +926,7 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 					} else {
 						pos_sp_triplet.current.type = position_setpoint_s::SETPOINT_TYPE_POSITION;
 					}
-                    
+
 					/* set the local pos values */
 					if (!offboard_control_mode.ignore_position) {
 						pos_sp_triplet.current.position_valid = true;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -909,14 +909,16 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 					pos_sp_triplet.next.valid = false;
 					pos_sp_triplet.current.valid = true;
 
-					if (is_takeoff_sp) {
+					/* Order of statements matters. Takeoff can override loiter.
+					 * See https://github.com/mavlink/mavlink/pull/670 for a broader conversation. */
+					if (is_loiter_sp) {
+						pos_sp_triplet.current.type = position_setpoint_s::SETPOINT_TYPE_LOITER;
+
+					} else if (is_takeoff_sp) {
 						pos_sp_triplet.current.type = position_setpoint_s::SETPOINT_TYPE_TAKEOFF;
 
 					} else if (is_land_sp) {
 						pos_sp_triplet.current.type = position_setpoint_s::SETPOINT_TYPE_LAND;
-
-					} else if (is_loiter_sp) {
-						pos_sp_triplet.current.type = position_setpoint_s::SETPOINT_TYPE_LOITER;
 
 					} else if (is_idle_sp) {
 						pos_sp_triplet.current.type = position_setpoint_s::SETPOINT_TYPE_IDLE;
@@ -924,7 +926,7 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 					} else {
 						pos_sp_triplet.current.type = position_setpoint_s::SETPOINT_TYPE_POSITION;
 					}
-
+                    
 					/* set the local pos values */
 					if (!offboard_control_mode.ignore_position) {
 						pos_sp_triplet.current.position_valid = true;


### PR DESCRIPTION
The reordering of mode checks fixes this particular bug. For a broader discussion of mask bit enumerations, which falls under the jurisdiction of the [mavlink repo](https://github.com/mavlink/mavlink), see [mavlink/mavlink/pull/670](https://github.com/mavlink/mavlink/pull/670).