### PR TITLE
[WIP] Fix race condition in voted_sensors_update

### DIFF
--- a/src/modules/sensors/parameters.cpp
+++ b/src/modules/sensors/parameters.cpp
@@ -166,9 +166,11 @@ int initialize_parameter_handles(ParameterHandles &parameter_handles)
 	(void)param_find("CAL_MAG0_ID");
 	(void)param_find("CAL_MAG1_ID");
 	(void)param_find("CAL_MAG2_ID");
+	(void)param_find("CAL_MAG3_ID");
 	(void)param_find("CAL_MAG0_ROT");
 	(void)param_find("CAL_MAG1_ROT");
 	(void)param_find("CAL_MAG2_ROT");
+	(void)param_find("CAL_MAG3_ROT");
 	(void)param_find("CAL_MAG_SIDES");
 
 	(void)param_find("CAL_MAG1_XOFF");
@@ -184,6 +186,13 @@ int initialize_parameter_handles(ParameterHandles &parameter_handles)
 	(void)param_find("CAL_MAG2_YSCALE");
 	(void)param_find("CAL_MAG2_ZOFF");
 	(void)param_find("CAL_MAG2_ZSCALE");
+
+	(void)param_find("CAL_MAG3_XOFF");
+	(void)param_find("CAL_MAG3_XSCALE");
+	(void)param_find("CAL_MAG3_YOFF");
+	(void)param_find("CAL_MAG3_YSCALE");
+	(void)param_find("CAL_MAG3_ZOFF");
+	(void)param_find("CAL_MAG3_ZSCALE");
 
 	(void)param_find("CAL_GYRO1_XOFF");
 	(void)param_find("CAL_GYRO1_XSCALE");

--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -722,6 +722,11 @@ void VotedSensorsUpdate::mag_poll(struct sensor_combined_s &raw)
 
 			// First publication with data
 			if (_mag.priority[uorb_index] == 0) {
+
+				// Parameters update to get offsets and scaling loaded (if not already loaded)
+				parameters_update();
+
+				// Set device priority for the voter
 				int32_t priority = 0;
 				orb_priority(_mag.subscription[uorb_index], &priority);
 				_mag.priority[uorb_index] = (uint8_t)priority;


### PR DESCRIPTION
Another race condition, only exposed by the recent refactoring I did. It's triggered by slow external mags.

Tested on Zubax GNSS v2 + Pixhawk 2.1. Do not merge yet till we can ascertain whether something more is needed for POSIX builds.

@tstellanova @nicolaerosia Please test!