### PR TITLE
Move uORB::Subscription template implementation to header

### DIFF
--- a/src/modules/uORB/Publication.cpp
+++ b/src/modules/uORB/Publication.cpp
@@ -107,20 +107,4 @@ PublicationNode::PublicationNode(const struct orb_metadata *meta,
 	if (list != nullptr) { list->add(this); }
 }
 
-// explicit template instantiation
-template class __EXPORT Publication<actuator_controls_s>;
-template class __EXPORT Publication<actuator_direct_s>;
-template class __EXPORT Publication<actuator_outputs_s>;
-template class __EXPORT Publication<debug_key_value_s>;
-template class __EXPORT Publication<ekf2_innovations_s>;
-template class __EXPORT Publication<filtered_bottom_flow_s>;
-template class __EXPORT Publication<rc_channels_s>;
-template class __EXPORT Publication<tecs_status_s>;
-template class __EXPORT Publication<vehicle_attitude_s>;
-template class __EXPORT Publication<vehicle_attitude_setpoint_s>;
-template class __EXPORT Publication<vehicle_global_position_s>;
-template class __EXPORT Publication<vehicle_global_velocity_setpoint_s>;
-template class __EXPORT Publication<vehicle_local_position_s>;
-template class __EXPORT Publication<vehicle_rates_setpoint_s>;
-
 }

--- a/src/modules/uORB/Publication.cpp
+++ b/src/modules/uORB/Publication.cpp
@@ -37,21 +37,6 @@
  */
 
 #include "Publication.hpp"
-#include "topics/actuator_controls.h"
-#include "topics/actuator_direct.h"
-#include "topics/actuator_outputs.h"
-#include "topics/debug_key_value.h"
-#include "topics/ekf2_innovations.h"
-#include "topics/filtered_bottom_flow.h"
-#include "topics/rc_channels.h"
-#include "topics/tecs_status.h"
-#include "topics/vehicle_attitude.h"
-#include "topics/vehicle_attitude_setpoint.h"
-#include "topics/vehicle_global_position.h"
-#include "topics/vehicle_global_velocity_setpoint.h"
-#include "topics/vehicle_local_position.h"
-#include "topics/vehicle_rates_setpoint.h"
-
 #include <px4_defines.h>
 
 namespace uORB

--- a/src/modules/uORB/Subscription.cpp
+++ b/src/modules/uORB/Subscription.cpp
@@ -37,34 +37,6 @@
  */
 
 #include "Subscription.hpp"
-#include "topics/actuator_armed.h"
-#include "topics/actuator_controls.h"
-#include "topics/att_pos_mocap.h"
-#include "topics/battery_status.h"
-#include "topics/control_state.h"
-#include "topics/distance_sensor.h"
-#include "topics/hil_sensor.h"
-#include "topics/home_position.h"
-#include "topics/log_message.h"
-#include "topics/manual_control_setpoint.h"
-#include "topics/mavlink_log.h"
-#include "topics/optical_flow.h"
-#include "topics/parameter_update.h"
-#include "topics/position_setpoint_triplet.h"
-#include "topics/rc_channels.h"
-#include "topics/satellite_info.h"
-#include "topics/sensor_combined.h"
-#include "topics/vehicle_attitude.h"
-#include "topics/vehicle_attitude_setpoint.h"
-#include "topics/vehicle_control_mode.h"
-#include "topics/vehicle_global_position.h"
-#include "topics/vehicle_gps_position.h"
-#include "topics/vehicle_land_detected.h"
-#include "topics/vehicle_local_position.h"
-#include "topics/vehicle_local_position_setpoint.h"
-#include "topics/vehicle_rates_setpoint.h"
-#include "topics/vehicle_status.h"
-
 #include <px4_defines.h>
 
 namespace uORB

--- a/src/modules/uORB/Subscription.cpp
+++ b/src/modules/uORB/Subscription.cpp
@@ -117,40 +117,6 @@ SubscriptionBase::~SubscriptionBase()
 	if (ret != PX4_OK) { PX4_ERR("orb unsubscribe failed"); }
 }
 
-template <class T>
-Subscription<T>::Subscription(const struct orb_metadata *meta,
-			      unsigned interval,
-			      int instance,
-			      List<SubscriptionNode *> *list) :
-	SubscriptionNode(meta, interval, instance, list),
-	_data() // initialize data structure to zero
-{
-}
-
-template <class T>
-Subscription<T>::Subscription(const Subscription &other) :
-	SubscriptionNode(other._meta, other.getInterval(), other._instance, nullptr),
-	_data() // initialize data structure to zero
-{
-}
-
-template <class T>
-Subscription<T>::~Subscription()
-{
-}
-
-template <class T>
-void Subscription<T>::update()
-{
-	SubscriptionBase::update((void *)(&_data));
-}
-
-template <class T>
-bool Subscription<T>::check_updated()
-{
-	return SubscriptionBase::updated();
-}
-
 template class __EXPORT Subscription<actuator_armed_s>;
 template class __EXPORT Subscription<actuator_controls_s>;
 template class __EXPORT Subscription<att_pos_mocap_s>;

--- a/src/modules/uORB/Subscription.cpp
+++ b/src/modules/uORB/Subscription.cpp
@@ -117,32 +117,4 @@ SubscriptionBase::~SubscriptionBase()
 	if (ret != PX4_OK) { PX4_ERR("orb unsubscribe failed"); }
 }
 
-template class __EXPORT Subscription<actuator_armed_s>;
-template class __EXPORT Subscription<actuator_controls_s>;
-template class __EXPORT Subscription<att_pos_mocap_s>;
-template class __EXPORT Subscription<battery_status_s>;
-template class __EXPORT Subscription<control_state_s>;
-template class __EXPORT Subscription<distance_sensor_s>;
-template class __EXPORT Subscription<hil_sensor_s>;
-template class __EXPORT Subscription<home_position_s>;
-template class __EXPORT Subscription<log_message_s>;
-template class __EXPORT Subscription<manual_control_setpoint_s>;
-template class __EXPORT Subscription<mavlink_log_s>;
-template class __EXPORT Subscription<optical_flow_s>;
-template class __EXPORT Subscription<parameter_update_s>;
-template class __EXPORT Subscription<position_setpoint_triplet_s>;
-template class __EXPORT Subscription<rc_channels_s>;
-template class __EXPORT Subscription<satellite_info_s>;
-template class __EXPORT Subscription<sensor_combined_s>;
-template class __EXPORT Subscription<vehicle_attitude_s>;
-template class __EXPORT Subscription<vehicle_attitude_setpoint_s>;
-template class __EXPORT Subscription<vehicle_control_mode_s>;
-template class __EXPORT Subscription<vehicle_global_position_s>;
-template class __EXPORT Subscription<vehicle_gps_position_s>;
-template class __EXPORT Subscription<vehicle_land_detected_s>;
-template class __EXPORT Subscription<vehicle_local_position_s>;
-template class __EXPORT Subscription<vehicle_local_position_setpoint_s>;
-template class __EXPORT Subscription<vehicle_rates_setpoint_s>;
-template class __EXPORT Subscription<vehicle_status_s>;
-
 } // namespace uORB

--- a/src/modules/uORB/Subscription.hpp
+++ b/src/modules/uORB/Subscription.hpp
@@ -171,29 +171,50 @@ public:
 	Subscription(const struct orb_metadata *meta,
 		     unsigned interval = 0,
 		     int instance = 0,
-		     List<SubscriptionNode *> *list = nullptr);
+		     List<SubscriptionNode *> *list = nullptr):
+		SubscriptionNode(meta, interval, instance, list),
+		_data() // initialize data structure to zero
+	{}
 
-	Subscription(const Subscription & /*other*/);
+
+	Subscription(const Subscription &other):
+		SubscriptionNode(other._meta, other.getInterval(), other._instance, nullptr),
+		_data() // initialize data structure to zero
+	{}
+
 
 	/**
 	 * Deconstructor
 	 */
-	virtual ~Subscription();
+	virtual ~Subscription()
+	{}
 
 
 	/**
 	 * Create an update function that uses the embedded struct.
 	 */
-	void update();
+	void update()
+	{
+		SubscriptionBase::update((void *)(&_data));
+	}
+
 
 	/**
 	 * Create an update function that uses the embedded struct.
 	 */
-	bool check_updated();
+	bool check_updated()
+	{
+		return SubscriptionBase::updated();
+	}
+
 	/*
 	 * This function gets the T struct data
 	 * */
-	const T &get() const { return _data; }
+	const T &get() const
+	{
+		return _data;
+	}
+
 private:
 	T _data;
 };


### PR DESCRIPTION
The C++ interface for uORB is much shorter and less error prone than the C interface. However its implementation requires manual modifications for new uORB messages.
  
The implementation of class template `uORB::Subscription<T>` is currently in a cpp file. That means that any specialization of the template (ex `uORB::Subscription<actuator_armed_s>`) has to be explicitely defined in that cpp file. 
This is fine for standard messages, but less so for custom uORB messages because it increases the number of files that have to be maintained with changes from master.

By moving the implementation to the header, it is not required to modify `src/modules/uORB/Subscription.cpp` for new uORB messages.

`uORB::Publication<T>` is already implemented in the header and does not have the same issue.