### PR TITLE
Fix 'stale mag' on POSIX

### DIFF
--- a/msg/sensor_mag.msg
+++ b/msg/sensor_mag.msg
@@ -11,3 +11,5 @@ int16 y_raw
 int16 z_raw
 
 uint32 device_id	# unique device ID for the sensor that does not change between power cycles
+uint8  is_external  # if 1, the mag is external (i.e. not built into the board)
+

--- a/src/drivers/bmm150/bmm150.cpp
+++ b/src/drivers/bmm150/bmm150.cpp
@@ -251,7 +251,6 @@ BMM150 :: BMM150(int bus, const char *path, bool external, enum Rotation rotatio
 	_external(false),
 	_running(false),
 	_call_interval(0),
-	_report{0},
 	_reports(nullptr),
 	_collect_phase(false),
 	_scale{},
@@ -344,7 +343,7 @@ int BMM150::init()
 	}
 
 	/* allocate basic report buffers */
-	_reports = new ringbuffer::RingBuffer(2, sizeof(_report));
+	_reports = new ringbuffer::RingBuffer(2, sizeof(mag_report));
 
 	if (_reports == nullptr) {
 		goto out;
@@ -433,7 +432,7 @@ BMM150::stop()
 ssize_t
 BMM150::read(struct file *filp, char *buffer, size_t buflen)
 {
-	unsigned count = buflen / sizeof(_report);
+	unsigned count = buflen / sizeof(mag_report);
 	struct mag_report *mag_buf = reinterpret_cast<struct mag_report *>(buffer);
 	int ret = 0;
 
@@ -684,6 +683,7 @@ BMM150::collect()
 
 
 	mrb.timestamp = hrt_absolute_time();
+	mrb.is_external = is_external();
 
 	// report the error count as the number of bad transfers.
 	// This allows the higher level code to decide if it

--- a/src/drivers/bmm150/bmm150.hpp
+++ b/src/drivers/bmm150/bmm150.hpp
@@ -228,7 +228,6 @@ private:
 	unsigned        _call_interval;
 
 
-	struct mag_report _report;
 	ringbuffer::RingBuffer  *_reports;
 
 	bool            _collect_phase;

--- a/src/drivers/hmc5883/hmc5883.cpp
+++ b/src/drivers/hmc5883/hmc5883.cpp
@@ -997,6 +997,7 @@ HMC5883::collect()
 	// XXX revisit for SPI part, might require a bus type IOCTL
 	unsigned dummy;
 	sensor_is_onboard = !_interface->ioctl(MAGIOCGEXTERNAL, dummy);
+	new_report.is_external = !sensor_is_onboard;
 
 	if (sensor_is_onboard) {
 		// convert onboard so it matches offboard for the

--- a/src/drivers/ist8310/ist8310.cpp
+++ b/src/drivers/ist8310/ist8310.cpp
@@ -913,6 +913,7 @@ IST8310::collect()
 
 	/* this should be fairly close to the end of the measurement, so the best approximation of the time */
 	new_report.timestamp = hrt_absolute_time();
+	new_report.is_external = !sensor_is_onboard;
 	new_report.error_count = perf_event_count(_comms_errors);
 	new_report.scaling = _range_scale;
 	new_report.device_id = _device_id.devid;

--- a/src/drivers/lis3mdl/lis3mdl.cpp
+++ b/src/drivers/lis3mdl/lis3mdl.cpp
@@ -945,6 +945,7 @@ LIS3MDL::collect()
 
 	unsigned dummy;
 	sensor_is_onboard = !_interface->ioctl(MAGIOCGEXTERNAL, dummy);
+	new_report.is_external = !sensor_is_onboard;
 
 	/*
 	 * RAW outputs

--- a/src/drivers/lps25h/lps25h_spi.cpp
+++ b/src/drivers/lps25h/lps25h_spi.cpp
@@ -135,14 +135,6 @@ LPS25H_SPI::ioctl(unsigned operation, unsigned &arg)
 
 	switch (operation) {
 
-	case MAGIOCGEXTERNAL:
-		/*
-		 * Even if this sensor is on the external SPI
-		 * bus it is still internal to the autopilot
-		 * assembly, so always return 0 for internal.
-		 */
-		return 0;
-
 	case DEVIOCGDEVICEID:
 		return CDev::ioctl(nullptr, operation, arg);
 

--- a/src/drivers/lsm303d/lsm303d.cpp
+++ b/src/drivers/lsm303d/lsm303d.cpp
@@ -1653,8 +1653,7 @@ LSM303D::mag_measure()
 	} raw_mag_report;
 #pragma pack(pop)
 
-	mag_report mag_report;
-	memset(&mag_report, 0, sizeof(mag_report));
+	mag_report mag_report {};
 
 	/* start the performance counter */
 	perf_begin(_mag_sample_perf);
@@ -1680,6 +1679,7 @@ LSM303D::mag_measure()
 	 */
 
 	mag_report.timestamp = hrt_absolute_time();
+	mag_report.is_external = is_external();
 
 	mag_report.x_raw = raw_mag_report.x;
 	mag_report.y_raw = raw_mag_report.y;

--- a/src/drivers/mpu9250/mag.cpp
+++ b/src/drivers/mpu9250/mag.cpp
@@ -205,6 +205,7 @@ MPU9250_mag::_measure(struct ak8963_regs data)
 
 	mag_report	mrb;
 	mrb.timestamp = hrt_absolute_time();
+	mrb.is_external = false;
 
 	/*
 	 * Align axes - note the accel & gryo are also re-aligned so this

--- a/src/drivers/sdp3x_airspeed/SDP3X.cpp
+++ b/src/drivers/sdp3x_airspeed/SDP3X.cpp
@@ -187,22 +187,22 @@ SDP3X::cycle()
 
 bool SDP3X::crc(const uint8_t data[], unsigned size, uint8_t checksum)
 {
-	uint8_t crc = 0xff;
+	uint8_t crc_value = 0xff;
 
 	// calculate 8-bit checksum with polynomial 0x31 (x^8 + x^5 + x^4 + 1)
 	for (unsigned i = 0; i < size; i++) {
-		crc ^= (data[i]);
+		crc_value ^= (data[i]);
 
 		for (int bit = 8; bit > 0; --bit) {
-			if (crc & 0x80) {
-				crc = (crc << 1) ^ 0x31;
+			if (crc_value & 0x80) {
+				crc_value = (crc_value << 1) ^ 0x31;
 
 			} else {
-				crc = (crc << 1);
+				crc_value = (crc_value << 1);
 			}
 		}
 	}
 
 	// verify checksum
-	return (crc == checksum);
+	return (crc_value == checksum);
 }

--- a/src/modules/sensors/parameters.cpp
+++ b/src/modules/sensors/parameters.cpp
@@ -166,9 +166,11 @@ int initialize_parameter_handles(ParameterHandles &parameter_handles)
 	(void)param_find("CAL_MAG0_ID");
 	(void)param_find("CAL_MAG1_ID");
 	(void)param_find("CAL_MAG2_ID");
+	(void)param_find("CAL_MAG3_ID");
 	(void)param_find("CAL_MAG0_ROT");
 	(void)param_find("CAL_MAG1_ROT");
 	(void)param_find("CAL_MAG2_ROT");
+	(void)param_find("CAL_MAG3_ROT");
 	(void)param_find("CAL_MAG_SIDES");
 
 	(void)param_find("CAL_MAG1_XOFF");
@@ -184,6 +186,13 @@ int initialize_parameter_handles(ParameterHandles &parameter_handles)
 	(void)param_find("CAL_MAG2_YSCALE");
 	(void)param_find("CAL_MAG2_ZOFF");
 	(void)param_find("CAL_MAG2_ZSCALE");
+
+	(void)param_find("CAL_MAG3_XOFF");
+	(void)param_find("CAL_MAG3_XSCALE");
+	(void)param_find("CAL_MAG3_YOFF");
+	(void)param_find("CAL_MAG3_YSCALE");
+	(void)param_find("CAL_MAG3_ZOFF");
+	(void)param_find("CAL_MAG3_ZSCALE");
 
 	(void)param_find("CAL_GYRO1_XOFF");
 	(void)param_find("CAL_GYRO1_XSCALE");

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -730,6 +730,8 @@ Sensors::start()
 void Sensors::print_status()
 {
 	_voted_sensors_update.print_status();
+
+	PX4_INFO("Airspeed status:");
 	_airspeed_validator.print();
 }
 

--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -254,7 +254,6 @@ void VotedSensorsUpdate::parameters_update()
 			failed = failed || (OK != param_get(param_find(str), &device_id));
 
 			if (failed) {
-				DevMgr::releaseHandle(h);
 				continue;
 			}
 
@@ -337,7 +336,6 @@ void VotedSensorsUpdate::parameters_update()
 			failed = failed || (OK != param_get(param_find(str), &device_id));
 
 			if (failed) {
-				DevMgr::releaseHandle(h);
 				continue;
 			}
 
@@ -421,7 +419,6 @@ void VotedSensorsUpdate::parameters_update()
 			failed = failed || (OK != param_get(param_find(str), &device_id));
 
 			if (failed) {
-				DevMgr::releaseHandle(h);
 				continue;
 			}
 

--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -250,7 +250,7 @@ void VotedSensorsUpdate::parameters_update()
 			failed = false;
 
 			(void)sprintf(str, "CAL_GYRO%u_ID", i);
-			int device_id;
+			int32_t device_id;
 			failed = failed || (OK != param_get(param_find(str), &device_id));
 
 			if (failed) {
@@ -306,7 +306,7 @@ void VotedSensorsUpdate::parameters_update()
 		// run through all stored calibrations and reset them
 		for (unsigned i = 0; i < GYRO_COUNT_MAX; i++) {
 
-			int device_id = 0;
+			int32_t device_id = 0;
 			(void)sprintf(str, "CAL_GYRO%u_ID", i);
 			(void)param_set(param_find(str), &device_id);
 		}
@@ -333,7 +333,7 @@ void VotedSensorsUpdate::parameters_update()
 			failed = false;
 
 			(void)sprintf(str, "CAL_ACC%u_ID", i);
-			int device_id;
+			int32_t device_id;
 			failed = failed || (OK != param_get(param_find(str), &device_id));
 
 			if (failed) {
@@ -389,7 +389,7 @@ void VotedSensorsUpdate::parameters_update()
 		// run through all stored calibrations and reset them
 		for (unsigned i = 0; i < ACCEL_COUNT_MAX; i++) {
 
-			int device_id = 0;
+			int32_t device_id = 0;
 			(void)sprintf(str, "CAL_ACC%u_ID", i);
 			(void)param_set(param_find(str), &device_id);
 		}
@@ -417,7 +417,7 @@ void VotedSensorsUpdate::parameters_update()
 			failed = false;
 
 			(void)sprintf(str, "CAL_MAG%u_ID", i);
-			int device_id;
+			int32_t device_id;
 			failed = failed || (OK != param_get(param_find(str), &device_id));
 
 			if (failed) {

--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -740,6 +740,11 @@ void VotedSensorsUpdate::mag_poll(struct sensor_combined_s &raw)
 
 			// First publication with data
 			if (_mag.priority[uorb_index] == 0) {
+
+				// Parameters update to get offsets and scaling loaded (if not already loaded)
+				parameters_update();
+
+				// Set device priority for the voter
 				int32_t priority = 0;
 				orb_priority(_mag.subscription[uorb_index], &priority);
 				_mag.priority[uorb_index] = (uint8_t)priority;

--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -223,7 +223,6 @@ void VotedSensorsUpdate::parameters_update()
 	/* set offset parameters to new values */
 	bool failed;
 	char str[30];
-	unsigned mag_count = 0;
 	unsigned gyro_count = 0;
 	unsigned accel_count = 0;
 	unsigned gyro_cal_found_count = 0;
@@ -393,20 +392,46 @@ void VotedSensorsUpdate::parameters_update()
 		}
 	}
 
-	/* run through all mag sensors */
-	for (unsigned driver_index = 0; driver_index < MAG_COUNT_MAX; driver_index++) {
+	/* run through all mag sensors
+	 * Because we store the device id in _mag_device_id, we need to get the id via uorb topic since
+	 * the DevHandle method does not work on POSIX.
+	 */
+	for (unsigned topic_instance = 0; topic_instance < MAG_COUNT_MAX && topic_instance < _mag.subscription_count;
+	     ++topic_instance) {
 
-		(void)sprintf(str, "%s%u", MAG_BASE_DEVICE_PATH, driver_index);
+		struct mag_report report;
 
-		DevHandle h;
-		DevMgr::getHandle(str, h);
-
-		if (!h.isValid()) {
-			/* the driver is not running, abort */
+		if (orb_copy(ORB_ID(sensor_mag), _mag.subscription[topic_instance], &report) != 0) {
 			continue;
 		}
 
-		_mag_device_id[driver_index] = h.ioctl(DEVIOCGDEVICEID, 0);
+		int topic_device_id = report.device_id;
+		_mag_device_id[topic_instance] = topic_device_id;
+
+		// find the driver handle that matches the topic_device_id
+		DevHandle h;
+
+		for (unsigned driver_index = 0; driver_index < MAG_COUNT_MAX; ++driver_index) {
+
+			(void)sprintf(str, "%s%u", MAG_BASE_DEVICE_PATH, driver_index);
+
+			DevMgr::getHandle(str, h);
+
+			if (!h.isValid()) {
+				/* the driver is not running, continue with the next */
+				continue;
+			}
+
+			int driver_device_id = h.ioctl(DEVIOCGDEVICEID, 0);
+
+			if (driver_device_id == topic_device_id) {
+				break; // we found the matching driver
+
+			} else {
+				DevMgr::releaseHandle(h);
+			}
+		}
+
 		bool config_ok = false;
 
 		/* run through all stored calibrations */
@@ -423,7 +448,7 @@ void VotedSensorsUpdate::parameters_update()
 			}
 
 			/* if the calibration is for this device, apply it */
-			if (device_id == _mag_device_id[driver_index]) {
+			if (device_id == _mag_device_id[topic_instance]) {
 				struct mag_calibration_s mscale = {};
 				(void)sprintf(str, "CAL_MAG%u_XOFF", i);
 				failed = failed || (OK != param_get(param_find(str), &mscale.x_offset));
@@ -440,26 +465,28 @@ void VotedSensorsUpdate::parameters_update()
 
 				(void)sprintf(str, "CAL_MAG%u_ROT", i);
 
-				if (h.ioctl(MAGIOCGEXTERNAL, 0) <= 0) {
-					/* mag is internal - reset param to -1 to indicate internal mag */
-					int32_t minus_one;
-					param_get(param_find(str), &minus_one);
+				if (h.isValid()) { //FIXME: get the 'is external' information via uorb topic
+					if (h.ioctl(MAGIOCGEXTERNAL, 0) <= 0) {
+						/* mag is internal - reset param to -1 to indicate internal mag */
+						int32_t minus_one;
+						param_get(param_find(str), &minus_one);
 
-					if (minus_one != MAG_ROT_VAL_INTERNAL) {
-						minus_one = MAG_ROT_VAL_INTERNAL;
-						param_set_no_notification(param_find(str), &minus_one);
-					}
+						if (minus_one != MAG_ROT_VAL_INTERNAL) {
+							minus_one = MAG_ROT_VAL_INTERNAL;
+							param_set_no_notification(param_find(str), &minus_one);
+						}
 
-				} else {
-					/* mag is external */
-					int32_t mag_rot;
-					param_get(param_find(str), &mag_rot);
+					} else {
+						/* mag is external */
+						int32_t mag_rot;
+						param_get(param_find(str), &mag_rot);
 
-					/* check if this mag is still set as internal, otherwise leave untouched */
-					if (mag_rot < 0) {
-						/* it was marked as internal, change to external with no rotation */
-						mag_rot = 0;
-						param_set_no_notification(param_find(str), &mag_rot);
+						/* check if this mag is still set as internal, otherwise leave untouched */
+						if (mag_rot < 0) {
+							/* it was marked as internal, change to external with no rotation */
+							mag_rot = 0;
+							param_set_no_notification(param_find(str), &mag_rot);
+						}
 					}
 				}
 
@@ -478,10 +505,6 @@ void VotedSensorsUpdate::parameters_update()
 
 				break;
 			}
-		}
-
-		if (config_ok) {
-			mag_count++;
 		}
 	}
 
@@ -1017,13 +1040,17 @@ VotedSensorsUpdate::apply_accel_calibration(DevHandle &h, const struct accel_cal
 bool
 VotedSensorsUpdate::apply_mag_calibration(DevHandle &h, const struct mag_calibration_s *mcal, const int device_id)
 {
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_RPI) && !defined(__PX4_POSIX_BEBOP)
+#if !defined(__PX4_QURT) && !defined(__PX4_POSIX)
+
+	if (!h.isValid()) {
+		return false;
+	}
 
 	/* On most systems, we can just use the IOCTL call to set the calibration params. */
 	return !h.ioctl(MAGIOCSSCALE, (long unsigned int)mcal);
 
 #else
-	/* On QURT, the params are read directly in the respective wrappers. */
+	/* On QURT & POSIX, the params are read directly in the respective wrappers. */
 	return true;
 #endif
 }

--- a/src/modules/uavcan/sensors/mag.cpp
+++ b/src/modules/uavcan/sensors/mag.cpp
@@ -156,6 +156,7 @@ void UavcanMagnetometerBridge::mag_sub_cb(const uavcan::ReceivedDataStructure<ua
 	 */
 	_report.timestamp = hrt_absolute_time();
 	_report.device_id = _device_id.devid;
+	_report.is_external = true;
 
 	_report.x = (msg.magnetic_field_ga[0] - _scale.x_offset) * _scale.x_scale;
 	_report.y = (msg.magnetic_field_ga[1] - _scale.y_offset) * _scale.y_scale;

--- a/src/platforms/posix/drivers/accelsim/accelsim.cpp
+++ b/src/platforms/posix/drivers/accelsim/accelsim.cpp
@@ -915,8 +915,7 @@ ACCELSIM::mag_measure()
 	} raw_mag_report;
 #pragma pack(pop)
 
-	mag_report mag_report;
-	memset(&mag_report, 0, sizeof(mag_report));
+	mag_report mag_report = {};
 
 	/* start the performance counter */
 	perf_begin(_mag_sample_perf);
@@ -946,6 +945,7 @@ ACCELSIM::mag_measure()
 
 
 	mag_report.timestamp = hrt_absolute_time();
+	mag_report.is_external = false;
 
 	mag_report.x_raw = (int16_t)(raw_mag_report.x / _mag_range_scale);
 	mag_report.y_raw = (int16_t)(raw_mag_report.y / _mag_range_scale);

--- a/src/platforms/posix/drivers/df_ak8963_wrapper/df_ak8963_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_ak8963_wrapper/df_ak8963_wrapper.cpp
@@ -278,6 +278,7 @@ int DfAK8963Wrapper::_publish(struct mag_sensor_data &data)
 
 	mag_report mag_report = {};
 	mag_report.timestamp = hrt_absolute_time();
+	mag_report.is_external = true;
 
 	// TODO: remove these (or get the values)
 	mag_report.x_raw = 0;

--- a/src/platforms/posix/drivers/df_hmc5883_wrapper/df_hmc5883_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_hmc5883_wrapper/df_hmc5883_wrapper.cpp
@@ -269,6 +269,7 @@ int DfHmc9250Wrapper::_publish(struct mag_sensor_data &data)
 
 	mag_report mag_report = {};
 	mag_report.timestamp = hrt_absolute_time();
+	mag_report.is_external = true;
 
 	/* The standard external mag by 3DR has x pointing to the
 	 * right, y pointing backwards, and z down, therefore switch x

--- a/src/platforms/posix/drivers/df_lsm9ds1_wrapper/df_lsm9ds1_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_lsm9ds1_wrapper/df_lsm9ds1_wrapper.cpp
@@ -624,6 +624,7 @@ int DfLsm9ds1Wrapper::_publish(struct imu_sensor_data &data)
 
 	accel_report.timestamp = gyro_report.timestamp = hrt_absolute_time();
 	mag_report.timestamp = accel_report.timestamp;
+	mag_report.is_external = false;
 
 	// TODO: get these right
 	gyro_report.scaling = -1.0f;

--- a/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
@@ -700,6 +700,7 @@ int DfMpu9250Wrapper::_publish(struct imu_sensor_data &data)
 
 	if (_mag_enabled) {
 		mag_report.timestamp = accel_report.timestamp;
+		mag_report.is_external = false;
 
 		mag_report.scaling = -1.0f;
 		mag_report.range_ga = -1.0f;


### PR DESCRIPTION
- fix 'stale mag' error messages on RPi (& POSIX) (commit fb1d479bbe60e2b2c1573e8e5a54762b7fdb43)
- get the 'is external' information via uORB topic instead of ioctl, which does not work reliably on POSIX

Please see the individual commit messages.

Fixes https://github.com/PX4/Firmware/issues/7395

Tested on Pixracer & Pixhawk Pro (with external sensor) & RPi.
@mhkabir 