### PR TITLE
cmake fix airframes.xml dependency, mavlink include, bad whitespace

### DIFF
--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -458,7 +458,6 @@ function(px4_add_common_flags)
 		${PX4_BINARY_DIR}
 		${PX4_BINARY_DIR}/src
 		${PX4_BINARY_DIR}/src/modules
-		${PX4_SOURCE_DIR}/mavlink/include/mavlink
 		${PX4_SOURCE_DIR}/src
 		${PX4_SOURCE_DIR}/src/drivers/boards/${BOARD}
 		${PX4_SOURCE_DIR}/src/include

--- a/cmake/common/px4_metadata.cmake
+++ b/cmake/common/px4_metadata.cmake
@@ -191,11 +191,12 @@ function(px4_generate_airframes_xml)
 		REQUIRED BOARD
 		ARGN ${ARGN})
 
-	add_custom_command(OUTPUT ${PX4_SOURCE_DIR}/airframes.xml
+	add_custom_command(OUTPUT ${PX4_BINARY_DIR}/airframes.xml
 		COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/px_process_airframes.py
 			-a ${PX4_SOURCE_DIR}/ROMFS/${config_romfs_root}/init.d
 			--board CONFIG_ARCH_BOARD_${BOARD} --xml
 		DEPENDS ${PX4_SOURCE_DIR}/Tools/px_process_airframes.py
+		COMMENT "Creating airframes.xml"
 		)
-	add_custom_target(airframes_xml DEPENDS ${PX4_SOURCE_DIR}/airframes.xml)
+	add_custom_target(airframes_xml DEPENDS ${PX4_BINARY_DIR}/airframes.xml)
 endfunction()

--- a/cmake/posix/px4_impl_posix.cmake
+++ b/cmake/posix/px4_impl_posix.cmake
@@ -167,7 +167,7 @@ function(px4_os_add_flags)
 		LINK_DIRS ${LINK_DIRS}
 		DEFINITIONS ${DEFINITIONS})
 
-        set(added_include_dirs
+	set(added_include_dirs
 		src/platforms/posix/include
 		)
 

--- a/cmake/qurt/px4_impl_qurt.cmake
+++ b/cmake/qurt/px4_impl_qurt.cmake
@@ -160,18 +160,18 @@ function(px4_os_add_flags)
 		LINK_DIRS ${LINK_DIRS}
 		DEFINITIONS ${DEFINITIONS})
 
-        set(DSPAL_ROOT src/lib/DriverFramework/dspal)
-        set(added_include_dirs
-                ${DSPAL_ROOT}/include 
-                ${DSPAL_ROOT}/sys 
-                ${DSPAL_ROOT}/sys/sys 
-                ${DSPAL_ROOT}/mpu_spi/inc
-                ${DSPAL_ROOT}/uart_esc/inc
-                src/platforms/qurt/include
-                src/platforms/posix/include
-                )
+	set(DSPAL_ROOT src/lib/DriverFramework/dspal)
+	set(added_include_dirs
+		${DSPAL_ROOT}/include
+		${DSPAL_ROOT}/sys
+		${DSPAL_ROOT}/sys/sys
+		${DSPAL_ROOT}/mpu_spi/inc
+		${DSPAL_ROOT}/uart_esc/inc
+		src/platforms/qurt/include
+		src/platforms/posix/include
+		)
 
-        set(added_definitions
+	set(added_definitions
 		-D__PX4_QURT
 		-D__DF_QURT # For DriverFramework
 		-D__PX4_POSIX
@@ -179,8 +179,8 @@ function(px4_os_add_flags)
 		)
 
 	# Add the toolchain specific flags
-        set(added_cflags)
-        set(added_cxx_flags)
+	set(added_cflags)
+	set(added_cxx_flags)
 
 	# Clear -rdynamic flag which fails for hexagon
 	set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")

--- a/cmake/qurt/px4_impl_qurt.cmake
+++ b/cmake/qurt/px4_impl_qurt.cmake
@@ -172,11 +172,11 @@ function(px4_os_add_flags)
                 )
 
         set(added_definitions
-                -D__PX4_QURT
+		-D__PX4_QURT
 		-D__DF_QURT # For DriverFramework
 		-D__PX4_POSIX
 		-D__QAIC_SKEL_EXPORT=__EXPORT
-                )
+		)
 
 	# Add the toolchain specific flags
         set(added_cflags)

--- a/src/drivers/pwm_out_rc_in/CMakeLists.txt
+++ b/src/drivers/pwm_out_rc_in/CMakeLists.txt
@@ -30,6 +30,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
+
+include_directories(${PX4_SOURCE_DIR}/mavlink/include/mavlink)
+
 px4_add_module(
 	MODULE drivers__pwm_out_rc_in
 	MAIN pwm_out_rc_in

--- a/src/drivers/snapdragon_rc_pwm/CMakeLists.txt
+++ b/src/drivers/snapdragon_rc_pwm/CMakeLists.txt
@@ -30,6 +30,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
+
+include_directories(${PX4_SOURCE_DIR}/mavlink/include/mavlink)
+
 px4_add_module(
 	MODULE drivers__snapdragon_rc_pwm
 	MAIN snapdragon_rc_pwm

--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -30,6 +30,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
+
+include_directories(${PX4_SOURCE_DIR}/mavlink/include/mavlink)
+
 px4_add_module(
 	MODULE modules__mavlink
 	MAIN mavlink

--- a/src/modules/mavlink/mavlink_tests/CMakeLists.txt
+++ b/src/modules/mavlink/mavlink_tests/CMakeLists.txt
@@ -30,6 +30,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
+
+include_directories(${PX4_SOURCE_DIR}/mavlink/include/mavlink)
+
 px4_add_module(
 	MODULE modules__mavlink__mavlink_tests
 	MAIN mavlink_tests

--- a/src/modules/simulator/CMakeLists.txt
+++ b/src/modules/simulator/CMakeLists.txt
@@ -31,6 +31,8 @@
 #
 ############################################################################
 
+include_directories(${PX4_SOURCE_DIR}/mavlink/include/mavlink)
+
 option(ENABLE_UART_RC_INPUT "Enable RC Input from UART mavlink connection" OFF)
 
 if(ENABLE_UART_RC_INPUT)

--- a/src/modules/systemlib/param/CMakeLists.txt
+++ b/src/modules/systemlib/param/CMakeLists.txt
@@ -80,7 +80,7 @@ add_custom_command(OUTPUT px4_parameters.c px4_parameters.h
 	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/px_generate_params.py
 		--xml ${parameters_xml} --dest ${CMAKE_CURRENT_BINARY_DIR}
 	DEPENDS
-		parameters_xml
+		${PX4_BINARY_DIR}/parameters.xml
 		${CMAKE_CURRENT_SOURCE_DIR}/px_generate_params.py
 		${CMAKE_CURRENT_SOURCE_DIR}/templates/px4_parameters.c.jinja
 		${CMAKE_CURRENT_SOURCE_DIR}/templates/px4_parameters.h.jinja

--- a/src/modules/uavcan/CMakeLists.txt
+++ b/src/modules/uavcan/CMakeLists.txt
@@ -48,6 +48,7 @@ add_definitions(
 add_subdirectory(libuavcan EXCLUDE_FROM_ALL)
 add_dependencies(uavcan platforms__nuttx)
 
+include_directories(${PX4_SOURCE_DIR}/mavlink/include/mavlink)
 include_directories(libuavcan/libuavcan/include)
 include_directories(libuavcan/libuavcan/include/dsdlc_generated)
 include_directories(libuavcan/libuavcan_drivers/posix/include)

--- a/src/platforms/posix/drivers/accelsim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/accelsim/CMakeLists.txt
@@ -30,6 +30,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
+
+include_directories(${PX4_SOURCE_DIR}/mavlink/include/mavlink)
+
 px4_add_module(
 	MODULE platforms__posix__drivers__accelsim
 	MAIN accelsim

--- a/src/platforms/posix/drivers/airspeedsim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/airspeedsim/CMakeLists.txt
@@ -30,6 +30,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
+
+include_directories(${PX4_SOURCE_DIR}/mavlink/include/mavlink)
+
 px4_add_module(
 	MODULE platforms__posix__drivers__airspeedsim
 	MAIN measairspeedsim

--- a/src/platforms/posix/drivers/barosim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/barosim/CMakeLists.txt
@@ -30,6 +30,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
+
+include_directories(${PX4_SOURCE_DIR}/mavlink/include/mavlink)
+
 px4_add_module(
 	MODULE platforms__posix__drivers__barosim
 	MAIN barosim

--- a/src/platforms/posix/drivers/gpssim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/gpssim/CMakeLists.txt
@@ -30,6 +30,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
+
+include_directories(${PX4_SOURCE_DIR}/mavlink/include/mavlink)
+
 px4_add_module(
 	MODULE platforms__posix__drivers__gpssim
 	MAIN gpssim

--- a/src/platforms/posix/drivers/gyrosim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/gyrosim/CMakeLists.txt
@@ -30,6 +30,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
+
+include_directories(${PX4_SOURCE_DIR}/mavlink/include/mavlink)
+
 px4_add_module(
 	MODULE platforms__posix__drivers__gyrosim
 	MAIN gyrosim


### PR DESCRIPTION
A few trivial cmake things I came across. The diff is large because px4_posix_impl.cmake indentation was wrong, but the only thing that changed there is the default includes.