### PR TITLE
Navigator: Fix RTL backtransition for VTOL. Fixes #7405

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -300,6 +300,11 @@ RTL::set_rtl_item()
 
 	reset_mission_item_reached();
 
+	/* execute command if set. This is required for commands like VTOL transition */
+	if (!item_contains_position(&_mission_item)) {
+		issue_command(&_mission_item);
+	}
+
 	/* convert mission item to current position setpoint and make it valid */
 	mission_item_to_position_setpoint(&_mission_item, &pos_sp_triplet->current);
 	pos_sp_triplet->next.valid = false;


### PR DESCRIPTION
A recent change removed the command forwarding required for VTOL transitions. This change brings this back.

Partially reverts https://github.com/PX4/Firmware/pull/7249