### PR TITLE
PX4Flow: Add command line options for address and sampling rate

### DIFF
--- a/src/drivers/px4flow/px4flow.cpp
+++ b/src/drivers/px4flow/px4flow.cpp
@@ -833,6 +833,8 @@ start(int argc, char *argv[])
 void
 stop()
 {
+	start_in_progress = false;
+
 	if (g_dev != nullptr) {
 		delete g_dev;
 		g_dev = nullptr;


### PR DESCRIPTION
PX4Flow boards have 3 solder jumpers to set the I2C address from 0x42 to 0x49. But in the driver the address is hard-coded to 0x42.

This adds command line options to the px4flow app. While I was at it I also added an option for the conversion interval.

Example usage
```shell
px4flow start                  # address=0x42, conversion_interval=100ms (default)
px4flow stop
px4flow start -a 0x43          # address=0x43, conversion_interval=100ms
px4flow stop
px4flow start -i 10000 -a 0x44 # address=0x44, conversion_interval=10ms
```