### PR TITLE
voted_sensors_update: fix mag rotation

### DIFF
--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -942,7 +942,8 @@ PARAM_DEFINE_FLOAT(SENS_BOARD_X_OFF, 0.0f);
 PARAM_DEFINE_FLOAT(SENS_BOARD_Z_OFF, 0.0f);
 
 /**
- * Select primary magnetometer
+ * Select primary magnetometer.
+ * DEPRECATED, only used on V1 hardware
  *
  * @min 0
  * @max 2

--- a/src/modules/sensors/voted_sensors_update.h
+++ b/src/modules/sensors/voted_sensors_update.h
@@ -274,7 +274,7 @@ private:
 	struct sensor_selection_s _selection = {}; /**< struct containing the sensor selection to be published to the uORB*/
 	orb_advert_t _sensor_selection_pub = nullptr; /**< handle to the sensor selection uORB topic */
 	bool _selection_changed = false; /**< true when a sensor selection has changed and not been published */
-	uint32_t _accel_device_id[SENSOR_COUNT_MAX] = {};
+	uint32_t _accel_device_id[SENSOR_COUNT_MAX] = {}; /**< accel driver device id for each uorb instance */
 	uint32_t _baro_device_id[SENSOR_COUNT_MAX] = {};
 	uint32_t _gyro_device_id[SENSOR_COUNT_MAX] = {};
 	uint32_t _mag_device_id[SENSOR_COUNT_MAX] = {};


### PR DESCRIPTION
Yet another fix for mag rotations...

fixes a wrong index for _mag_device_id: previously, driver_index was used
(the CAL_MAG param index), but the correct index is the uorb topic
instance.

Tested on a setup where the board is 180deg rotated, but the external mag faces forward direction.
@mhkabir 