### PR TITLE
[WIP] use local coordinates for position control (Global to local)

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -84,7 +84,7 @@
 #include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_control_mode.h>
-#include <uORB/topics/vehicle_global_position.h>
+#include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/uORB.h>
@@ -151,7 +151,7 @@ private:
 	bool		_task_should_exit{false};		///< if true, sensor task should exit */
 	bool		_task_running{false};			///< if true, task is running in its mainloop */
 
-	int		_global_pos_sub{-1};
+	int		_local_pos_sub{-1};
 	int		_pos_sp_triplet_sub{-1};
 	int		_control_mode_sub{-1};			///< control mode subscription */
 	int		_vehicle_attitude_sub{-1};		///< vehicle attitude subscription */
@@ -174,7 +174,7 @@ private:
 	vehicle_attitude_setpoint_s	_att_sp {};			///< vehicle attitude setpoint */
 	vehicle_command_s		_vehicle_command {};		///< vehicle commands */
 	vehicle_control_mode_s		_control_mode {};		///< control mode */
-	vehicle_global_position_s	_global_pos {};			///< global vehicle position */
+	vehicle_local_position_s	_local_pos {};			///< local vehicle position */
 	vehicle_land_detected_s		_vehicle_land_detected {};	///< vehicle land detected */
 	vehicle_status_s		_vehicle_status {};		///< vehicle status */
 
@@ -410,7 +410,7 @@ private:
 	/**
 	 * Return the terrain estimate during takeoff or takeoff_alt if terrain estimate is not available
 	 */
-	float		get_terrain_altitude_takeoff(float takeoff_alt, const vehicle_global_position_s &global_pos);
+	float		get_terrain_altitude_takeoff(float takeoff_alt);
 
 	/**
 	 * Check if we are in a takeoff situation

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1766,35 +1766,32 @@ void MulticopterPositionControl::control_auto(float dt)
 
 		math::Vector<3> curr_pos_sp = _curr_pos_sp;
 
-		//only project setpoints if they are finite, else use current position
-		if (PX4_ISFINITE(_pos_sp_triplet.current.lat) &&
-		    PX4_ISFINITE(_pos_sp_triplet.current.lon)) {
-			/* project setpoint to local frame */
-			map_projection_project(&_ref_pos,
-					       _pos_sp_triplet.current.lat, _pos_sp_triplet.current.lon,
-					       &curr_pos_sp.data[0], &curr_pos_sp.data[1]);
+		//check if finite in x and y
+		if (PX4_ISFINITE(_pos_sp_triplet.current.x) &&
+		    PX4_ISFINITE(_pos_sp_triplet.current.y)) {
 
+			curr_pos_sp(0) =  _pos_sp_triplet.current.x;
+			curr_pos_sp(1) =  _pos_sp_triplet.current.y;
 			_triplet_lat_lon_finite = true;
 
 		} else { // use current position if NAN -> e.g. land
 			if (_triplet_lat_lon_finite) {
-				curr_pos_sp.data[0] = _pos(0);
-				curr_pos_sp.data[1] = _pos(1);
+				curr_pos_sp(0) = _pos(0);
+				curr_pos_sp(1) = _pos(1);
 				_triplet_lat_lon_finite = false;
 			}
 		}
 
 		// only project setpoints if they are finite, else use current position
-		if (PX4_ISFINITE(_pos_sp_triplet.current.alt)) {
-			curr_pos_sp(2) = -(_pos_sp_triplet.current.alt - _ref_alt);
+		if (PX4_ISFINITE(_pos_sp_triplet.current.z)) {
+			curr_pos_sp(2) = _pos_sp_triplet.current.z;
 
 		}
 
-
 		/* sanity check */
-		if (PX4_ISFINITE(_curr_pos_sp(0)) &&
-		    PX4_ISFINITE(_curr_pos_sp(1)) &&
-		    PX4_ISFINITE(_curr_pos_sp(2))) {
+		if (PX4_ISFINITE(curr_pos_sp(0)) &&
+		    PX4_ISFINITE(curr_pos_sp(1)) &&
+		    PX4_ISFINITE(curr_pos_sp(2))) {
 			current_setpoint_valid = true;
 		}
 
@@ -1817,16 +1814,16 @@ void MulticopterPositionControl::control_auto(float dt)
 		_curr_pos_sp = curr_pos_sp;
 	}
 
-	if (_pos_sp_triplet.previous.valid) {
-		map_projection_project(&_ref_pos,
-				       _pos_sp_triplet.previous.lat, _pos_sp_triplet.previous.lon,
-				       &prev_sp.data[0], &prev_sp.data[1]);
-		prev_sp(2) = -(_pos_sp_triplet.previous.alt - _ref_alt);
 
-		if (PX4_ISFINITE(prev_sp(0)) &&
-		    PX4_ISFINITE(prev_sp(1)) &&
-		    PX4_ISFINITE(prev_sp(2))) {
-			_prev_pos_sp = prev_sp;
+	if (_pos_sp_triplet.previous.valid) {
+
+		if (PX4_ISFINITE(_pos_sp_triplet.previous.x) &&
+			PX4_ISFINITE(_pos_sp_triplet.previous.y) &&
+			PX4_ISFINITE(_pos_sp_triplet.previous.z)) {
+
+			prev_sp(0) =  _pos_sp_triplet.previous.x;
+			prev_sp(1) =  _pos_sp_triplet.previous.y;
+			prev_sp(2) =  _pos_sp_triplet.previous.z;
 			previous_setpoint_valid = true;
 		}
 	}
@@ -1838,16 +1835,10 @@ void MulticopterPositionControl::control_auto(float dt)
 	}
 
 	if (_pos_sp_triplet.next.valid) {
-		map_projection_project(&_ref_pos,
-				       _pos_sp_triplet.next.lat, _pos_sp_triplet.next.lon,
-				       &next_sp.data[0], &next_sp.data[1]);
-		next_sp(2) = -(_pos_sp_triplet.next.alt - _ref_alt);
-
-		if (PX4_ISFINITE(next_sp(0)) &&
-		    PX4_ISFINITE(next_sp(1)) &&
-		    PX4_ISFINITE(next_sp(2))) {
-			next_setpoint_valid = true;
-		}
+		next_sp(0) =  _pos_sp_triplet.next.x;
+		next_sp(1) =  _pos_sp_triplet.next.y;
+		next_sp(2) =  _pos_sp_triplet.next.z;
+		next_setpoint_valid = true;
 	}
 
 	/* Auto logic:

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1766,8 +1766,8 @@ void MulticopterPositionControl::control_auto(float dt)
 	if (_pos_sp_triplet.previous.valid) {
 
 		if (PX4_ISFINITE(_pos_sp_triplet.previous.x) &&
-			PX4_ISFINITE(_pos_sp_triplet.previous.y) &&
-			PX4_ISFINITE(_pos_sp_triplet.previous.z)) {
+		    PX4_ISFINITE(_pos_sp_triplet.previous.y) &&
+		    PX4_ISFINITE(_pos_sp_triplet.previous.z)) {
 
 			prev_sp(0) =  _pos_sp_triplet.previous.x;
 			prev_sp(1) =  _pos_sp_triplet.previous.y;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -316,11 +316,6 @@ private:
 	float		throttle_curve(float ctl, float ctr);
 
 	/**
-	 * Update reference for local position projection
-	 */
-	void		update_ref();
-
-	/**
 	 * Reset position setpoint to current position.
 	 *
 	 * This reset will only occur if the _reset_pos_sp flag has been set.
@@ -850,43 +845,6 @@ void
 MulticopterPositionControl::task_main_trampoline(int argc, char *argv[])
 {
 	pos_control::g_control->task_main();
-}
-
-void
-MulticopterPositionControl::update_ref()
-{
-	// The reference point is only allowed to change when the vehicle is in standby state which is the
-	// normal state when the estimator origin is set. Changing reference point in flight causes large controller
-	// setpoint changes. Changing reference point in other arming states is untested and shoud not be performed.
-	if ((_local_pos.ref_timestamp != _ref_timestamp)
-	    && (_vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_STANDBY)) {
-		double lat_sp, lon_sp;
-		float alt_sp = 0.0f;
-
-		if (_ref_timestamp != 0) {
-			// calculate current position setpoint in global frame
-			map_projection_reproject(&_ref_pos, _pos_sp(0), _pos_sp(1), &lat_sp, &lon_sp);
-			// the altitude setpoint is the reference altitude (Z up) plus the (Z down)
-			// NED setpoint, multiplied out to minus
-			alt_sp = _ref_alt - _pos_sp(2);
-		}
-
-		// update local projection reference including altitude
-		map_projection_init(&_ref_pos, _local_pos.ref_lat, _local_pos.ref_lon);
-		_ref_alt = _local_pos.ref_alt;
-
-		if (_ref_timestamp != 0) {
-			// reproject position setpoint to new reference
-			// this effectively adjusts the position setpoint to keep the vehicle
-			// in its current local position. It would only change its
-			// global position on the next setpoint update.
-			map_projection_project(&_ref_pos, lat_sp, lon_sp, &_pos_sp.data[0], &_pos_sp.data[1]);
-			_pos_sp(2) = -(alt_sp - _ref_alt);
-		}
-
-		_ref_timestamp = _local_pos.ref_timestamp;
-
-	}
 }
 
 void
@@ -2487,6 +2445,7 @@ MulticopterPositionControl::calculate_velocity_setpoint(float dt)
 	}
 
 	_vel_sp(2) = math::constrain(_vel_sp(2), -_params.vel_max_up, _params.vel_max_down);
+
 }
 
 void
@@ -3082,8 +3041,6 @@ MulticopterPositionControl::task_main()
 		}
 
 		was_landed = _vehicle_land_detected.landed;
-
-		update_ref();
 
 		update_velocity_derivative();
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1707,7 +1707,6 @@ void MulticopterPositionControl::control_auto(float dt)
 	bool next_setpoint_valid = false;
 	bool triplet_updated = false;
 
-	math::Vector<3> prev_sp;
 	math::Vector<3> next_sp;
 
 	if (_pos_sp_triplet.current.valid) {
@@ -1769,9 +1768,9 @@ void MulticopterPositionControl::control_auto(float dt)
 		    PX4_ISFINITE(_pos_sp_triplet.previous.y) &&
 		    PX4_ISFINITE(_pos_sp_triplet.previous.z)) {
 
-			prev_sp(0) =  _pos_sp_triplet.previous.x;
-			prev_sp(1) =  _pos_sp_triplet.previous.y;
-			prev_sp(2) =  _pos_sp_triplet.previous.z;
+			_prev_pos_sp(0) =  _pos_sp_triplet.previous.x;
+			_prev_pos_sp(1) =  _pos_sp_triplet.previous.y;
+			_prev_pos_sp(2) =  _pos_sp_triplet.previous.z;
 			previous_setpoint_valid = true;
 		}
 	}

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -265,29 +265,8 @@ private:
 		math::Vector<3> vel_d;
 	} _params{};
 
-<<<<<<< ead4bee84a27777aca22459d95ec9f1b52c9b891
-	struct map_projection_reference_s _ref_pos;
 	hrt_abstime _ref_timestamp;
 	hrt_abstime _last_warn;
-=======
-	bool _reset_sp_xy;
-	bool _reset_sp_z;
-	bool _do_reset_alt_pos_flag;
-	bool _mode_auto;
-	bool _pos_hold_engaged;
-	bool _alt_hold_engaged;
-	bool _run_pos_control;
-	bool _run_alt_control;
-
-	bool _reset_int_z = true;
-	bool _reset_int_xy = true;
-	bool _reset_int_z_manual = false;
-	bool _reset_yaw_sp = true;
-
-	bool _hold_offboard_xy = false;
-	bool _hold_offboard_z = false;
-	bool _limit_vel_xy = false;
->>>>>>> remove unused variables
 
 	math::Vector<3> _thrust_int;
 	math::Vector<3> _pos;
@@ -467,7 +446,6 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_vel_x_deriv(this, "VELD"),
 	_vel_y_deriv(this, "VELD"),
 	_vel_z_deriv(this, "VELD"),
-<<<<<<< ead4bee84a27777aca22459d95ec9f1b52c9b891
 	_manual_direction_change_hysteresis(false),
 	_filter_manual_pitch(50.0f, 10.0f),
 	_filter_manual_roll(50.0f, 10.0f),
@@ -475,16 +453,6 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_user_intention_z(brake),
 	_ref_timestamp(0),
 	_last_warn(0),
-=======
-	_reset_sp_xy(true),
-	_reset_sp_z(true),
-	_do_reset_alt_pos_flag(true),
-	_mode_auto(false),
-	_pos_hold_engaged(false),
-	_alt_hold_engaged(false),
-	_run_pos_control(true),
-	_run_alt_control(true),
->>>>>>> remove unused variables
 	_yaw(0.0f),
 	_yaw_takeoff(0.0f),
 	_man_yaw_offset(0.0f),
@@ -503,14 +471,9 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	/* Make the attitude quaternion valid */
 	_att.q[0] = 1.0f;
 
-<<<<<<< ead4bee84a27777aca22459d95ec9f1b52c9b891
-	_ref_pos = {};
-
 	/* set trigger time for manual direction change detection */
 	_manual_direction_change_hysteresis.set_hysteresis_time_from(false, DIRECTION_CHANGE_TRIGGER_TIME_US);
 
-=======
->>>>>>> remove unused variables
 	_params.pos_p.zero();
 	_params.vel_p.zero();
 	_params.vel_i.zero();

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -265,7 +265,6 @@ private:
 		math::Vector<3> vel_d;
 	} _params{};
 
-	hrt_abstime _ref_timestamp;
 	hrt_abstime _last_warn;
 
 	math::Vector<3> _thrust_int;
@@ -451,7 +450,6 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_filter_manual_roll(50.0f, 10.0f),
 	_user_intention_xy(brake),
 	_user_intention_z(brake),
-	_ref_timestamp(0),
 	_last_warn(0),
 	_yaw(0.0f),
 	_yaw_takeoff(0.0f),

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -158,7 +158,7 @@ private:
 	struct manual_control_setpoint_s		_manual;		/**< r/c channel data */
 	struct vehicle_control_mode_s			_control_mode;		/**< vehicle control mode */
 	struct vehicle_local_position_s			_local_pos;		/**< vehicle local position */
-	struct position_setpoint_triplet_s		_pos_sp_triplet;	/**< vehicle global position setpoint triplet */
+	struct position_setpoint_triplet_s		_pos_sp_triplet;	/**< vehicle  position setpoint triplet */
 	struct vehicle_local_position_setpoint_s	_local_pos_sp;		/**< vehicle local position setpoint */
 	struct home_position_s				_home_pos; 				/**< home position */
 
@@ -2771,7 +2771,7 @@ MulticopterPositionControl::generate_attitude_setpoint(float dt)
 
 		/* do not move yaw while sitting on the ground */
 
-		/* we want to know the real constraint, and global overrides manual */
+		/* we want to know the real constraint */
 		const float yaw_rate_max = (_params.man_yaw_max < _params.yaw_rate_max) ? _params.man_yaw_max :
 					   _params.yaw_rate_max;
 		const float yaw_offset_max = yaw_rate_max / _params.mc_att_yaw_p;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -265,9 +265,29 @@ private:
 		math::Vector<3> vel_d;
 	} _params{};
 
+<<<<<<< ead4bee84a27777aca22459d95ec9f1b52c9b891
 	struct map_projection_reference_s _ref_pos;
 	hrt_abstime _ref_timestamp;
 	hrt_abstime _last_warn;
+=======
+	bool _reset_sp_xy;
+	bool _reset_sp_z;
+	bool _do_reset_alt_pos_flag;
+	bool _mode_auto;
+	bool _pos_hold_engaged;
+	bool _alt_hold_engaged;
+	bool _run_pos_control;
+	bool _run_alt_control;
+
+	bool _reset_int_z = true;
+	bool _reset_int_xy = true;
+	bool _reset_int_z_manual = false;
+	bool _reset_yaw_sp = true;
+
+	bool _hold_offboard_xy = false;
+	bool _hold_offboard_z = false;
+	bool _limit_vel_xy = false;
+>>>>>>> remove unused variables
 
 	math::Vector<3> _thrust_int;
 	math::Vector<3> _pos;
@@ -447,6 +467,7 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_vel_x_deriv(this, "VELD"),
 	_vel_y_deriv(this, "VELD"),
 	_vel_z_deriv(this, "VELD"),
+<<<<<<< ead4bee84a27777aca22459d95ec9f1b52c9b891
 	_manual_direction_change_hysteresis(false),
 	_filter_manual_pitch(50.0f, 10.0f),
 	_filter_manual_roll(50.0f, 10.0f),
@@ -454,6 +475,16 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_user_intention_z(brake),
 	_ref_timestamp(0),
 	_last_warn(0),
+=======
+	_reset_sp_xy(true),
+	_reset_sp_z(true),
+	_do_reset_alt_pos_flag(true),
+	_mode_auto(false),
+	_pos_hold_engaged(false),
+	_alt_hold_engaged(false),
+	_run_pos_control(true),
+	_run_alt_control(true),
+>>>>>>> remove unused variables
 	_yaw(0.0f),
 	_yaw_takeoff(0.0f),
 	_man_yaw_offset(0.0f),
@@ -472,11 +503,14 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	/* Make the attitude quaternion valid */
 	_att.q[0] = 1.0f;
 
+<<<<<<< ead4bee84a27777aca22459d95ec9f1b52c9b891
 	_ref_pos = {};
 
 	/* set trigger time for manual direction change detection */
 	_manual_direction_change_hysteresis.set_hysteresis_time_from(false, DIRECTION_CHANGE_TRIGGER_TIME_US);
 
+=======
+>>>>>>> remove unused variables
 	_params.pos_p.zero();
 	_params.vel_p.zero();
 	_params.vel_i.zero();

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -132,7 +132,7 @@ private:
 	bool 		_in_smooth_takeoff = false; 				/**<true if takeoff ramp is applied */
 	bool 		_in_landing = false;				/**<true if landing descent (only used in auto) */
 	bool 		_lnd_reached_ground = false; 		/**<true if controller assumes the vehicle has reached the ground after landing */
-	bool 		_triplet_lat_lon_finite = true; 		/**<true if triplets current is non-finite */
+	bool 		_triplet_xy_finite = true; 		/**<true if triplets current is non-finite */
 
 	int		_control_task;			/**< task handle for task */
 	orb_advert_t	_mavlink_log_pub;		/**< mavlink log advert */
@@ -1691,8 +1691,7 @@ void MulticopterPositionControl::control_auto(float dt)
 	if (!_mode_auto || !_vehicle_status.is_rotary_wing) {
 		if (!_mode_auto) {
 			_mode_auto = true;
-			//set _triplet_lat_lon_finite true once switch to AUTO(e.g. LAND)
-			_triplet_lat_lon_finite = true;
+			_triplet_xy_finite = true;
 		}
 
 		_reset_sp_xy = true;
@@ -1721,13 +1720,13 @@ void MulticopterPositionControl::control_auto(float dt)
 
 			curr_pos_sp(0) =  _pos_sp_triplet.current.x;
 			curr_pos_sp(1) =  _pos_sp_triplet.current.y;
-			_triplet_lat_lon_finite = true;
+			_triplet_xy_finite = true;
 
 		} else { // use current position if NAN -> e.g. land
-			if (_triplet_lat_lon_finite) {
+			if (_triplet_xy_finite) {
 				curr_pos_sp(0) = _pos(0);
 				curr_pos_sp(1) = _pos(1);
-				_triplet_lat_lon_finite = false;
+				_triplet_xy_finite = false;
 			}
 		}
 
@@ -1748,7 +1747,7 @@ void MulticopterPositionControl::control_auto(float dt)
 		 * note: we only can look at xy since navigator applies slewrate to z */
 		float  diff;
 
-		if (_triplet_lat_lon_finite) {
+		if (_triplet_xy_finite) {
 			diff = matrix::Vector2f((_curr_pos_sp(0) - curr_pos_sp(0)), (_curr_pos_sp(1) - curr_pos_sp(1))).length();
 
 		} else {

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -223,7 +223,7 @@ private:
 		param_t tilt_max_land;
 		param_t man_tilt_max;
 		param_t man_yaw_max;
-		param_t global_yaw_max;
+		param_t yaw_rate_max;
 		param_t mc_att_yaw_p;
 		param_t hold_max_xy;
 		param_t hold_max_z;
@@ -243,7 +243,7 @@ private:
 		float tilt_max_land;
 		float man_tilt_max;
 		float man_yaw_max;
-		float global_yaw_max;
+		float yaw_rate_max;
 		float mc_att_yaw_p;
 		float hold_max_xy;
 		float hold_max_z;
@@ -522,7 +522,12 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_params_handles.tilt_max_land	= param_find("MPC_TILTMAX_LND");
 	_params_handles.man_tilt_max = param_find("MPC_MAN_TILT_MAX");
 	_params_handles.man_yaw_max = param_find("MPC_MAN_Y_MAX");
+<<<<<<< 2d46b4bf34b11c1095bd8ccc067953bca6e04cf7
 	_params_handles.global_yaw_max = param_find("MC_YAWRATE_MAX");
+=======
+
+	_params_handles.yaw_rate_max = param_find("MC_YAWRATE_MAX");
+>>>>>>> mc_pos_control: better parameter name for yaw_rate_max
 	_params_handles.mc_att_yaw_p = param_find("MC_YAW_P");
 	_params_handles.hold_max_xy = param_find("MPC_HOLD_MAX_XY");
 	_params_handles.hold_max_z = param_find("MPC_HOLD_MAX_Z");
@@ -660,10 +665,10 @@ MulticopterPositionControl::parameters_update(bool force)
 		/* manual control scale */
 		param_get(_params_handles.man_tilt_max, &_params.man_tilt_max);
 		param_get(_params_handles.man_yaw_max, &_params.man_yaw_max);
-		param_get(_params_handles.global_yaw_max, &_params.global_yaw_max);
+		param_get(_params_handles.yaw_rate_max, &_params.yaw_rate_max);
 		_params.man_tilt_max = math::radians(_params.man_tilt_max);
 		_params.man_yaw_max = math::radians(_params.man_yaw_max);
-		_params.global_yaw_max = math::radians(_params.global_yaw_max);
+		_params.yaw_rate_max = math::radians(_params.yaw_rate_max);
 
 		param_get(_params_handles.mc_att_yaw_p, &v);
 		_params.mc_att_yaw_p = v;
@@ -2767,8 +2772,8 @@ MulticopterPositionControl::generate_attitude_setpoint(float dt)
 		/* do not move yaw while sitting on the ground */
 
 		/* we want to know the real constraint, and global overrides manual */
-		const float yaw_rate_max = (_params.man_yaw_max < _params.global_yaw_max) ? _params.man_yaw_max :
-					   _params.global_yaw_max;
+		const float yaw_rate_max = (_params.man_yaw_max < _params.yaw_rate_max) ? _params.man_yaw_max :
+					   _params.yaw_rate_max;
 		const float yaw_offset_max = yaw_rate_max / _params.mc_att_yaw_p;
 
 		_att_sp.yaw_sp_move_rate = _manual.r * yaw_rate_max;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -114,7 +114,6 @@ private:
 	static constexpr uint64_t DIRECTION_CHANGE_TRIGGER_TIME_US = 100000;
 
 	bool		_task_should_exit = false;			/**<true if task should exit */
-	bool		_gear_state_initialized = false;		/**<true if the gear state has been initialized */
 	bool		_gear_state_initialized = false;	/**<true if the gear state has been initialized */
 	bool 		_reset_sp_xy = true;  				/**<true if position setpoint needs a reset */
 	bool 		_reset_sp_z = true; 				/**<true if z setpoint needs a reset */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -266,7 +266,6 @@ private:
 	} _params{};
 
 	struct map_projection_reference_s _ref_pos;
-	float _ref_alt;
 	hrt_abstime _ref_timestamp;
 	hrt_abstime _last_warn;
 
@@ -453,7 +452,6 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_filter_manual_roll(50.0f, 10.0f),
 	_user_intention_xy(brake),
 	_user_intention_z(brake),
-	_ref_alt(0.0f),
 	_ref_timestamp(0),
 	_last_warn(0),
 	_yaw(0.0f),

--- a/src/modules/navigator/datalinkloss.cpp
+++ b/src/modules/navigator/datalinkloss.cpp
@@ -100,7 +100,7 @@ DataLinkLoss::on_activation()
 void
 DataLinkLoss::on_active()
 {
-	if (is_mission_item_reached()) {
+	if (is_navigator_item_reached()) {
 		advance_dll();
 		set_dll_item();
 	}
@@ -153,7 +153,7 @@ DataLinkLoss::set_dll_item()
 			/* Request flight termination from the commander */
 			_navigator->get_mission_result()->flight_termination = true;
 			_navigator->set_mission_result_updated();
-			reset_mission_item_reached();
+			reset_navigator_item_reached();
 			warnx("not switched to manual: request flight termination");
 			pos_sp_triplet->previous.valid = false;
 			pos_sp_triplet->current.valid = false;
@@ -165,10 +165,10 @@ DataLinkLoss::set_dll_item()
 		break;
 	}
 
-	reset_mission_item_reached();
+	reset_navigator_item_reached();
 
 	/* convert mission item to current position setpoint and make it valid */
-	mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
+	navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 	pos_sp_triplet->next.valid = false;
 
 	_navigator->set_position_setpoint_triplet_updated();
@@ -188,7 +188,7 @@ DataLinkLoss::advance_dll()
 			mavlink_log_critical(_navigator->get_mavlink_log_pub(), "too many DL losses, fly to airfield home");
 			_navigator->get_mission_result()->stay_in_failsafe = true;
 			_navigator->set_mission_result_updated();
-			reset_mission_item_reached();
+			reset_navigator_item_reached();
 			_dll_state = DLL_STATE_FLYTOAIRFIELDHOMEWP;
 
 		} else {
@@ -213,7 +213,7 @@ DataLinkLoss::advance_dll()
 		_dll_state = DLL_STATE_FLYTOAIRFIELDHOMEWP;
 		_navigator->get_mission_result()->stay_in_failsafe = true;
 		_navigator->set_mission_result_updated();
-		reset_mission_item_reached();
+		reset_navigator_item_reached();
 		break;
 
 	case DLL_STATE_FLYTOAIRFIELDHOMEWP:
@@ -222,7 +222,7 @@ DataLinkLoss::advance_dll()
 		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "no manual control, terminating");
 		_navigator->get_mission_result()->stay_in_failsafe = true;
 		_navigator->set_mission_result_updated();
-		reset_mission_item_reached();
+		reset_navigator_item_reached();
 		break;
 
 	case DLL_STATE_TERMINATE:

--- a/src/modules/navigator/enginefailure.cpp
+++ b/src/modules/navigator/enginefailure.cpp
@@ -103,10 +103,7 @@ EngineFailure::set_ef_item()
 	case EF_STATE_LOITERDOWN: {
 			//XXX create mission item at ground (below?) here
 
-			_navigator_item.lat = _navigator->get_global_position()->lat;
-			_navigator_item.lon = _navigator->get_global_position()->lon;
 			//XXX setting altitude to a very low value, evaluate other options
-			_navigator_item.altitude = _navigator->get_home_position()->alt - 1000.0f;
 			_navigator_item.x = _navigator->get_local_position()->x;
 			_navigator_item.y = _navigator->get_local_position()->y;
 			_navigator_item.z = _navigator->get_home_position()->z - 1000.0f;

--- a/src/modules/navigator/enginefailure.cpp
+++ b/src/modules/navigator/enginefailure.cpp
@@ -85,7 +85,7 @@ EngineFailure::on_activation()
 void
 EngineFailure::on_active()
 {
-	if (is_mission_item_reached()) {
+	if (is_navigator_item_reached()) {
 		advance_ef();
 		set_ef_item();
 	}
@@ -103,17 +103,19 @@ EngineFailure::set_ef_item()
 	case EF_STATE_LOITERDOWN: {
 			//XXX create mission item at ground (below?) here
 
-			_mission_item.lat = _navigator->get_global_position()->lat;
-			_mission_item.lon = _navigator->get_global_position()->lon;
-			_mission_item.altitude_is_relative = false;
+			_navigator_item.lat = _navigator->get_global_position()->lat;
+			_navigator_item.lon = _navigator->get_global_position()->lon;
 			//XXX setting altitude to a very low value, evaluate other options
-			_mission_item.altitude = _navigator->get_home_position()->alt - 1000.0f;
-			_mission_item.yaw = NAN;
-			_mission_item.loiter_radius = _navigator->get_loiter_radius();
-			_mission_item.nav_cmd = NAV_CMD_LOITER_UNLIMITED;
-			_mission_item.acceptance_radius = _navigator->get_acceptance_radius();
-			_mission_item.autocontinue = true;
-			_mission_item.origin = ORIGIN_ONBOARD;
+			_navigator_item.altitude = _navigator->get_home_position()->alt - 1000.0f;
+			_navigator_item.x = _navigator->get_local_position()->x;
+			_navigator_item.y = _navigator->get_local_position()->y;
+			_navigator_item.z = _navigator->get_home_position()->z - 1000.0f;
+			_navigator_item.yaw = NAN;
+			_navigator_item.loiter_radius = _navigator->get_loiter_radius();
+			_navigator_item.nav_cmd = NAV_CMD_LOITER_UNLIMITED;
+			_navigator_item.acceptance_radius = _navigator->get_acceptance_radius();
+			_navigator_item.autocontinue = true;
+			_navigator_item.origin = ORIGIN_ONBOARD;
 
 			_navigator->set_can_loiter_at_sp(true);
 			break;
@@ -123,11 +125,11 @@ EngineFailure::set_ef_item()
 		break;
 	}
 
-	reset_mission_item_reached();
+	reset_navigator_item_reached();
 
 	/* convert mission item to current position setpoint and make it valid */
-	mission_apply_limitation(_mission_item);
-	mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
+	navigator_apply_limitation(_navigation_item);
+	navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 	pos_sp_triplet->next.valid = false;
 
 	_navigator->set_position_setpoint_triplet_updated();

--- a/src/modules/navigator/enginefailure.cpp
+++ b/src/modules/navigator/enginefailure.cpp
@@ -125,7 +125,7 @@ EngineFailure::set_ef_item()
 	reset_navigator_item_reached();
 
 	/* convert mission item to current position setpoint and make it valid */
-	navigator_apply_limitation(_navigation_item);
+	navigator_apply_limitation(_navigator_item);
 	navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 	pos_sp_triplet->next.valid = false;
 

--- a/src/modules/navigator/enginefailure.cpp
+++ b/src/modules/navigator/enginefailure.cpp
@@ -106,7 +106,7 @@ EngineFailure::set_ef_item()
 			//XXX setting altitude to a very low value, evaluate other options
 			_navigator_item.x = _navigator->get_local_position()->x;
 			_navigator_item.y = _navigator->get_local_position()->y;
-			_navigator_item.z = _navigator->get_home_position()->z - 1000.0f;
+			_navigator_item.z = _navigator->get_home_position()->z + 1000.0f;
 			_navigator_item.yaw = NAN;
 			_navigator_item.loiter_radius = _navigator->get_loiter_radius();
 			_navigator_item.nav_cmd = NAV_CMD_LOITER_UNLIMITED;

--- a/src/modules/navigator/follow_target.cpp
+++ b/src/modules/navigator/follow_target.cpp
@@ -281,7 +281,7 @@ void FollowTarget::on_active()
 				_follow_target_state = TRACK_VELOCITY;
 
 			} else if (target_velocity_valid()) {
-				set_follow_target_item(&_mission_item, _param_min_alt.get(), target_motion_with_offset, _yaw_angle);
+				set_follow_target_item(&_navigator_item, _param_min_alt.get(), target_motion_with_offset, _yaw_angle);
 				// keep the current velocity updated with the target velocity for when it's needed
 				_current_vel = _est_target_vel;
 
@@ -306,7 +306,7 @@ void FollowTarget::on_active()
 					_last_update_time = current_time;
 				}
 
-				set_follow_target_item(&_mission_item, _param_min_alt.get(), target_motion_with_offset, _yaw_angle);
+				set_follow_target_item(&_navigator_item, _param_min_alt.get(), target_motion_with_offset, _yaw_angle);
 
 				update_position_sp(true, false, _yaw_rate);
 
@@ -330,7 +330,7 @@ void FollowTarget::on_active()
 			target.lon = _navigator->get_global_position()->lon;
 			target.alt = 0.0F;
 
-			set_follow_target_item(&_mission_item, _param_min_alt.get(), target, _yaw_angle);
+			set_follow_target_item(&_navigator_item, _param_min_alt.get(), target, _yaw_angle);
 
 			update_position_sp(false, false, _yaw_rate);
 
@@ -341,7 +341,7 @@ void FollowTarget::on_active()
 
 	case WAIT_FOR_TARGET_POSITION: {
 
-			if (is_mission_item_reached() && target_velocity_valid()) {
+			if (is_navigator_item_reached() && target_velocity_valid()) {
 				_target_position_offset(0) = _follow_offset;
 				_follow_target_state = TRACK_POSITION;
 			}
@@ -361,8 +361,8 @@ void FollowTarget::update_position_sp(bool use_velocity, bool use_position, floa
 
 	pos_sp_triplet->previous.valid = use_position;
 	pos_sp_triplet->previous = pos_sp_triplet->current;
-	mission_apply_limitation(_mission_item);
-	mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
+	navigator_apply_limitation(_navigation_item);
+	navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 	pos_sp_triplet->current.type = position_setpoint_s::SETPOINT_TYPE_FOLLOW_TARGET;
 	pos_sp_triplet->current.position_valid = use_position;
 	pos_sp_triplet->current.velocity_valid = use_velocity;
@@ -385,7 +385,7 @@ void FollowTarget::reset_target_validity()
 	_est_target_vel.zero();
 	_target_distance.zero();
 	_target_position_offset.zero();
-	reset_mission_item_reached();
+	reset_navigator_item_reached();
 	_follow_target_state = SET_WAIT_FOR_TARGET_POSITION;
 }
 

--- a/src/modules/navigator/follow_target.cpp
+++ b/src/modules/navigator/follow_target.cpp
@@ -361,7 +361,7 @@ void FollowTarget::update_position_sp(bool use_velocity, bool use_position, floa
 
 	pos_sp_triplet->previous.valid = use_position;
 	pos_sp_triplet->previous = pos_sp_triplet->current;
-	navigator_apply_limitation(_navigation_item);
+	navigator_apply_limitation(_navigator_item);
 	navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 	pos_sp_triplet->current.type = position_setpoint_s::SETPOINT_TYPE_FOLLOW_TARGET;
 	pos_sp_triplet->current.position_valid = use_position;

--- a/src/modules/navigator/gpsfailure.cpp
+++ b/src/modules/navigator/gpsfailure.cpp
@@ -157,6 +157,8 @@ GpsFailure::set_gpsf_item()
 		break;
 	}
 
+	reset_navigator_item_reached();
+
 	_navigator->set_position_setpoint_triplet_updated();
 }
 

--- a/src/modules/navigator/gpsfailure.cpp
+++ b/src/modules/navigator/gpsfailure.cpp
@@ -157,8 +157,6 @@ GpsFailure::set_gpsf_item()
 		break;
 	}
 
-	reset_navigator_item_reached();
-
 	_navigator->set_position_setpoint_triplet_updated();
 }
 

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -82,7 +82,7 @@ Land::on_activation()
 	/* convert mission item to current setpoint */
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 	pos_sp_triplet->previous.valid = false;
-	navigator_apply_limitation(_navigation_item);
+	navigator_apply_limitation(_navigator_item);
 	navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 	pos_sp_triplet->next.valid = false;
 

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -73,17 +73,17 @@ void
 Land::on_activation()
 {
 	/* set current mission item to Land */
-	set_land_item(&_mission_item, true);
+	set_land_item(&_navigator_item, true);
 	_navigator->get_mission_result()->reached = false;
 	_navigator->get_mission_result()->finished = false;
 	_navigator->set_mission_result_updated();
-	reset_mission_item_reached();
+	reset_navigator_item_reached();
 
 	/* convert mission item to current setpoint */
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 	pos_sp_triplet->previous.valid = false;
-	mission_apply_limitation(_mission_item);
-	mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
+	navigator_apply_limitation(_navigation_item);
+	navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 	pos_sp_triplet->next.valid = false;
 
 	_navigator->set_can_loiter_at_sp(false);
@@ -94,13 +94,13 @@ Land::on_activation()
 void
 Land::on_active()
 {
-	if (is_mission_item_reached() && !_navigator->get_mission_result()->finished) {
+	if (is_navigator_item_reached() && !_navigator->get_mission_result()->finished) {
 		_navigator->get_mission_result()->finished = true;
 		_navigator->set_mission_result_updated();
-		set_idle_item(&_mission_item);
+		set_idle_item(&_navigator_item);
 
 		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-		mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
+		navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 		_navigator->set_position_setpoint_triplet_updated();
 	}
 }

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -155,9 +155,6 @@ Loiter::reposition()
 		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 		pos_sp_triplet->current.velocity_valid = false;
 		pos_sp_triplet->previous.yaw = _navigator->get_local_position()->yaw;
-		pos_sp_triplet->previous.lat = _navigator->get_global_position()->lat;
-		pos_sp_triplet->previous.lon = _navigator->get_global_position()->lon;
-		pos_sp_triplet->previous.alt = _navigator->get_global_position()->alt;
 		pos_sp_triplet->previous.x = _navigator->get_local_position()->x;
 		pos_sp_triplet->previous.y = _navigator->get_local_position()->y;
 		pos_sp_triplet->previous.z = _navigator->get_local_position()->z;
@@ -168,17 +165,13 @@ Loiter::reposition()
 		// MISSION_YAWMODE_NONE: do not change yaw setpoint
 		// MISSION_YAWMODE_FRONT_TO_WAYPOINT: point to next waypoint
 		if (_param_yawmode.get() != MISSION_YAWMODE_NONE) {
-			float travel_dist = get_distance_to_next_waypoint(_navigator->get_global_position()->lat,
-					    _navigator->get_global_position()->lon,
-					    pos_sp_triplet->current.lat, pos_sp_triplet->current.lon);
+			float travel_dist = matrix::Vector2f(pos_sp_triplet->current.x - _navigator->get_local_position()->x,
+							     pos_sp_triplet->current.y - _navigator->get_local_position()->y).length();
 
 			if (travel_dist > 1.0f) {
 				// calculate direction the vehicle should point to.
-				pos_sp_triplet->current.yaw = get_bearing_to_next_waypoint(
-								      _navigator->get_global_position()->lat,
-								      _navigator->get_global_position()->lon,
-								      pos_sp_triplet->current.lat,
-								      pos_sp_triplet->current.lon);
+				pos_sp_triplet->current.yaw = _navigator->get_heading_to_target(matrix::Vector2f(pos_sp_triplet->current.x,
+							      pos_sp_triplet->current.y));
 			}
 		}
 

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -123,14 +123,14 @@ Loiter::set_loiter_position()
 	_loiter_pos_set = true;
 
 	// set current mission item to loiter
-	set_loiter_item(&_mission_item, _param_min_alt.get());
+	set_loiter_item(&_navigator_item, _param_min_alt.get());
 
 	// convert mission item to current setpoint
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 	pos_sp_triplet->current.velocity_valid = false;
 	pos_sp_triplet->previous.valid = false;
-	mission_apply_limitation(_mission_item);
-	mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
+	navigator_apply_limitation(_navigation_item);
+	navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 	pos_sp_triplet->next.valid = false;
 
 	_navigator->set_can_loiter_at_sp(pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER);

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -154,10 +154,13 @@ Loiter::reposition()
 		// convert mission item to current setpoint
 		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 		pos_sp_triplet->current.velocity_valid = false;
-		pos_sp_triplet->previous.yaw = _navigator->get_global_position()->yaw;
+		pos_sp_triplet->previous.yaw = _navigator->get_local_position()->yaw;
 		pos_sp_triplet->previous.lat = _navigator->get_global_position()->lat;
 		pos_sp_triplet->previous.lon = _navigator->get_global_position()->lon;
 		pos_sp_triplet->previous.alt = _navigator->get_global_position()->alt;
+		pos_sp_triplet->previous.x = _navigator->get_local_position()->x;
+		pos_sp_triplet->previous.y = _navigator->get_local_position()->y;
+		pos_sp_triplet->previous.z = _navigator->get_local_position()->z;
 		memcpy(&pos_sp_triplet->current, &rep->current, sizeof(rep->current));
 		pos_sp_triplet->next.valid = false;
 

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -129,7 +129,7 @@ Loiter::set_loiter_position()
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 	pos_sp_triplet->current.velocity_valid = false;
 	pos_sp_triplet->previous.valid = false;
-	navigator_apply_limitation(_navigation_item);
+	navigator_apply_limitation(_navigator_item);
 	navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 	pos_sp_triplet->next.valid = false;
 

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -636,6 +636,7 @@ Mission::set_mission_items()
 			}
 
 			_navigator_item.nav_cmd = NAV_CMD_DO_VTOL_TRANSITION;
+			_navigator_item.params[0] = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW;
 			_navigator_item.yaw = _navigator->get_local_position()->yaw;
 
 			/* set position setpoint to target during the transition */
@@ -692,6 +693,7 @@ Mission::set_mission_items()
 		    && !_navigator->get_land_detected()->landed) {
 
 			_navigator_item.nav_cmd = NAV_CMD_DO_VTOL_TRANSITION;
+			_navigator_item.params[0] = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC;
 			_navigator_item.autocontinue = true;
 			new_work_item_type = WORK_ITEM_TYPE_MOVE_TO_LAND_AFTER_TRANSITION;
 		}
@@ -967,7 +969,7 @@ Mission::set_align_navigator_item(struct navigator_item_s *item, struct navigato
 void
 Mission::check_for_takeoff_altitude(struct navigator_item_s *item)
 {
-	/* at this point the alitude should alwasy be either absolute for global
+	/* at this point the alitude should always be either absolute for global
 	 * and relative for local
 	 */
 

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -498,7 +498,7 @@ Mission::set_mission_items()
 
 		/* update position setpoint triplet  */
 		pos_sp_triplet->previous.valid = false;
-		navigator_apply_limitation(_navigation_item);
+		navigator_apply_limitation(_navigator_item);
 		navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 		pos_sp_triplet->next.valid = false;
 
@@ -757,7 +757,7 @@ Mission::set_mission_items()
 			set_align_navigator_item(&_navigator_item, &navigator_item_next_position);
 
 			/* set position setpoint to target during the transition */
-			navigator_apply_limitation(_navigation_item);
+			navigator_apply_limitation(_navigator_item);
 			navigator_item_to_position_setpoint(navigator_item_next_position, &pos_sp_triplet->current);
 		}
 
@@ -798,7 +798,7 @@ Mission::set_mission_items()
 
 	/*********************************** set setpoints and check next *********************************************/
 	/* set current position setpoint from mission item (is protected against non-position items) */
-	navigator_apply_limitation(_navigation_item);
+	navigator_apply_limitation(_navigator_item);
 	navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 
 	/* issue command if ready (will do nothing for position mission items) */
@@ -825,7 +825,7 @@ Mission::set_mission_items()
 		/* try to process next mission item */
 		if (has_next_position_item) {
 			/* got next mission item, update setpoint triplet */
-			navigator_apply_limitation(_navigation_item);
+			navigator_apply_limitation(_navigator_item);
 			navigator_item_to_position_setpoint(navigator_item_next_position, &pos_sp_triplet->next);
 
 		} else {
@@ -1160,7 +1160,7 @@ Mission::do_abort_landing()
 	_navigator_item.origin = ORIGIN_ONBOARD;
 
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-	navigator_apply_limitation(_navigation_item);
+	navigator_apply_limitation(_navigator_item);
 	navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 
 	_navigator->set_position_setpoint_triplet_updated();

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1003,8 +1003,12 @@ Mission::heading_sp_update()
 		} else if (_param_yawmode.get() == MISSION_YAWMODE_TO_ROI
 			   && _navigator->get_vroi().mode == vehicle_roi_s::ROI_LOCATION) {
 			/* target location is ROI */
-			point_to_latlon[0] = _navigator->get_vroi().lat;
-			point_to_latlon[1] = _navigator->get_vroi().lon;
+
+			/* TODO : switch ROI to local as well
+			 * point_to_latlon[0] = _navigator->get_vroi()->lat;
+			 * point_to_latlon[1] = _navigator->get_vroi()->lon;
+			 *
+			 */
 
 		} else {
 			/* target location is next (current) waypoint */
@@ -1181,9 +1185,9 @@ Mission::do_abort_landing()
 	vcmd.command = vehicle_command_s::VEHICLE_CMD_DO_REPOSITION;
 	vcmd.param1 = -1;
 	vcmd.param2 = 1;
-	vcmd.param5 = _navigator_item.lat;
-	vcmd.param6 = _navigator_item.lon;
-	vcmd.param7 = alt_sp;
+	vcmd.param5 = _navigator_item.x; //TODO: check if that makes sense to set param5/6/7 to local
+	vcmd.param6 = _navigator_item.z;
+	vcmd.param7 = z_sp;
 
 	_navigator->publish_vehicle_cmd(&vcmd);
 }

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1194,9 +1194,8 @@ Mission::do_abort_landing()
 
 	// loiter at the larger of MIS_LTRMIN_ALT above the landing point
 	//  or 2 * FW_CLMBOUT_DIFF above the current altitude
-	float alt_landing = get_absolute_altitude_for_item(_mission_item);
-	float min_climbout = _navigator->get_global_position()->alt + (2 * _param_fw_climbout_diff.get());
-	float alt_sp = math::max(alt_landing + _param_loiter_min_alt.get(), min_climbout);
+	float alt_landing = _navigator_item.altitude;
+
 
 	// ignore _param_loiter_min_alt if smaller then 0 (-1)
 	float alt_sp;

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -540,7 +540,9 @@ Mission::set_mission_items()
 
 	/*********************************** handle mission item *********************************************/
 
-	// convert mission item to local navigation item
+	// convert mission_item to local navigator_item
+	//TODO use _navigator_item instead of _mission_item
+	_navigator->mission_item_to_navigator_item(&_navigator_item, &_mission_item);
 	_navigator->global_to_local(&_mission_item);
 
 	/* handle position mission items */

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1246,12 +1246,12 @@ Mission::do_abort_landing()
 
 	// send reposition cmd to get out of mission
 	vehicle_command_s vcmd = {};
-
+	vcmd.timestamp = hrt_absolute_time();
 	vcmd.command = vehicle_command_s::VEHICLE_CMD_DO_REPOSITION;
 	vcmd.param1 = -1;
 	vcmd.param2 = 1;
-	vcmd.param5 = _mission_item.lat;
-	vcmd.param6 = _mission_item.lon;
+	vcmd.param5 = _navigator_item.lat;
+	vcmd.param6 = _navigator_item.lon;
 	vcmd.param7 = alt_sp;
 
 	_navigator->publish_vehicle_cmd(&vcmd);

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -536,7 +536,7 @@ Mission::set_mission_items()
 	_navigator->mission_item_to_navigator_item(&navigator_item_next_position, &mission_item_next_position);
 
 	/* handle position navigator items */
-	if (item_contains_position(&_navigator_item)) {
+	if (item_contains_position(_navigator_item)) {
 
 		/* force vtol land */
 		if (_navigator_item.nav_cmd == NAV_CMD_LAND && _param_force_vtol.get() == 1
@@ -802,7 +802,7 @@ Mission::set_mission_items()
 	navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 
 	/* issue command if ready (will do nothing for position mission items) */
-	issue_command(&_navigator_item);
+	issue_command(_navigator_item);
 
 	/* set current work item type */
 	_work_item_type = new_work_item_type;

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -986,8 +986,6 @@ Mission::check_for_takeoff_altitude(struct navigator_item_s *item)
 		mavlink_log_info(_navigator->get_mavlink_log_pub(), "Takeoff to %.1f meters above home",
 				 (double)(item->altitude - _navigator->get_global_position()->alt));
 	}
-
-	return;
 }
 
 void

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -134,17 +134,17 @@ private:
 	/**
 	 * Copies position from setpoint if valid, otherwise copies current position
 	 */
-	void copy_positon_if_valid(struct mission_item_s *mission_item, struct position_setpoint_s *setpoint);
+	void copy_positon_if_valid(struct navigator_item_s *mission_item, struct position_setpoint_s *setpoint);
 
 	/**
 	 * Create mission item to align towards next waypoint
 	 */
-	void set_align_mission_item(struct mission_item_s *mission_item, struct mission_item_s *mission_item_next);
+	void set_align_navigator_item(struct navigator_item_s *item, struct navigator_item_s *item_next);
 
 	/**
 	 * Calculate takeoff height for mission item considering ground clearance
 	 */
-	float calculate_takeoff_altitude(struct mission_item_s *mission_item);
+	void check_for_takeoff_altitude(struct navigator_item_s *item);
 
 	/**
 	 * Updates the heading of the vehicle. Rotary wings only.
@@ -171,7 +171,6 @@ private:
 	 */
 	void do_abort_landing();
 
-	float get_absolute_altitude_for_item(struct mission_item_s &mission_item);
 
 	/**
 	 * Read the current and the next mission item. The next mission item read is the
@@ -247,8 +246,8 @@ private:
 	struct mission_s _onboard_mission {};
 	struct mission_s _offboard_mission {};
 
-	int _current_onboard_mission_index{-1};
-	int _current_offboard_mission_index{-1};
+	int _current_onboard_mission_index{ -1};
+	int _current_offboard_mission_index{ -1};
 	bool _need_takeoff{true};					/**< if true, then takeoff must be performed before going to the first waypoint (if needed) */
 
 	enum {

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -246,8 +246,8 @@ private:
 	struct mission_s _onboard_mission {};
 	struct mission_s _offboard_mission {};
 
-	int _current_onboard_mission_index{ -1};
-	int _current_offboard_mission_index{ -1};
+	int _current_onboard_mission_index{-1};
+	int _current_offboard_mission_index{-1};
 	bool _need_takeoff{true};					/**< if true, then takeoff must be performed before going to the first waypoint (if needed) */
 
 	enum {

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -504,7 +504,7 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 	sp->cruising_throttle = _navigator->get_cruising_throttle();
 
 	/* TODO: adjust mc_pos_control to use local setpoint only */
-	if (!_navigator->get_vstatus()->is_rotary_wing) {
+	if (_navigator->get_vstatus()->is_rotary_wing) {
 		global_to_local(item, sp);
 	}
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -294,8 +294,9 @@ MissionBlock::is_navigator_item_reached()
 						       _navigator->get_local_position()->vy * _navigator->get_local_position()->vy);
 
 				if (_param_back_trans_dec_mss.get() > FLT_EPSILON && velocity > FLT_EPSILON) {
-					navigator_acceptance_radius = ((velocity / _param_back_trans_dec_mss.get() / 2) * velocity) + _param_reverse_delay.get() *
-								    velocity;
+					navigator_acceptance_radius = ((velocity / _param_back_trans_dec_mss.get() / 2) * velocity) + _param_reverse_delay.get()
+								      *
+								      velocity;
 				}
 
 			}

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -492,6 +492,20 @@ MissionBlock::item_contains_position(const struct navigator_item_s *item)
 }
 
 bool
+MissionBlock::item_contains_position(const struct mission_item_s *item)
+{
+	return item->nav_cmd == NAV_CMD_WAYPOINT ||
+	       item->nav_cmd == NAV_CMD_LOITER_UNLIMITED ||
+	       item->nav_cmd == NAV_CMD_LOITER_TIME_LIMIT ||
+	       item->nav_cmd == NAV_CMD_LAND ||
+	       item->nav_cmd == NAV_CMD_TAKEOFF ||
+	       item->nav_cmd == NAV_CMD_LOITER_TO_ALT ||
+	       item->nav_cmd == NAV_CMD_VTOL_TAKEOFF ||
+	       item->nav_cmd == NAV_CMD_VTOL_LAND;
+
+}
+
+bool
 MissionBlock::navigator_item_to_position_setpoint(const struct navigator_item_s *item, struct position_setpoint_s *sp)
 {
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -393,7 +393,7 @@ MissionBlock::reset_navigator_item_reached()
 }
 
 void
-MissionBlock::issue_command(const struct navigator_item_s *item)
+MissionBlock::issue_command(const struct navigator_item_s &item)
 {
 	if (item_contains_position(item)) {
 		return;
@@ -452,7 +452,7 @@ MissionBlock::get_time_inside(const struct navigator_item_s &item)
 }
 
 bool
-MissionBlock::item_contains_position(const mission_item_s &item)
+MissionBlock::item_contains_position(const struct navigator_item_s &item)
 {
 	return item.nav_cmd == NAV_CMD_WAYPOINT ||
 	       item.nav_cmd == NAV_CMD_LOITER_UNLIMITED ||
@@ -462,46 +462,33 @@ MissionBlock::item_contains_position(const mission_item_s &item)
 	       item.nav_cmd == NAV_CMD_LOITER_TO_ALT ||
 	       item.nav_cmd == NAV_CMD_VTOL_TAKEOFF ||
 	       item.nav_cmd == NAV_CMD_VTOL_LAND;
-}
-
-bool
-MissionBlock::item_contains_position(const struct navigator_item_s *item)
-{
-	return item->nav_cmd == NAV_CMD_WAYPOINT ||
-	       item->nav_cmd == NAV_CMD_LOITER_UNLIMITED ||
-	       item->nav_cmd == NAV_CMD_LOITER_TIME_LIMIT ||
-	       item->nav_cmd == NAV_CMD_LAND ||
-	       item->nav_cmd == NAV_CMD_TAKEOFF ||
-	       item->nav_cmd == NAV_CMD_LOITER_TO_ALT ||
-	       item->nav_cmd == NAV_CMD_VTOL_TAKEOFF ||
-	       item->nav_cmd == NAV_CMD_VTOL_LAND;
 
 }
 
 bool
-MissionBlock::item_contains_position(const struct mission_item_s *item)
+MissionBlock::item_contains_position(const struct mission_item_s &item)
 {
-	return item->nav_cmd == NAV_CMD_WAYPOINT ||
-	       item->nav_cmd == NAV_CMD_LOITER_UNLIMITED ||
-	       item->nav_cmd == NAV_CMD_LOITER_TIME_LIMIT ||
-	       item->nav_cmd == NAV_CMD_LAND ||
-	       item->nav_cmd == NAV_CMD_TAKEOFF ||
-	       item->nav_cmd == NAV_CMD_LOITER_TO_ALT ||
-	       item->nav_cmd == NAV_CMD_VTOL_TAKEOFF ||
-	       item->nav_cmd == NAV_CMD_VTOL_LAND;
+	return item.nav_cmd == NAV_CMD_WAYPOINT ||
+	       item.nav_cmd == NAV_CMD_LOITER_UNLIMITED ||
+	       item.nav_cmd == NAV_CMD_LOITER_TIME_LIMIT ||
+	       item.nav_cmd == NAV_CMD_LAND ||
+	       item.nav_cmd == NAV_CMD_TAKEOFF ||
+	       item.nav_cmd == NAV_CMD_LOITER_TO_ALT ||
+	       item.nav_cmd == NAV_CMD_VTOL_TAKEOFF ||
+	       item.nav_cmd == NAV_CMD_VTOL_LAND;
 
 }
 
 bool
-MissionBlock::navigator_item_to_position_setpoint(const struct navigator_item_s *item, struct position_setpoint_s *sp)
+MissionBlock::navigator_item_to_position_setpoint(const struct navigator_item_s &item, struct position_setpoint_s *sp)
 {
 
-	sp->x = item->x;
-	sp->y = item->y;
-	sp->z = item->z;
-	sp->yaw = item->yaw;
-	sp->yaw_valid = PX4_ISFINITE(item->yaw);
-	sp->loiter_radius = (fabsf(item->loiter_radius) > NAV_EPSILON_POSITION) ? fabsf(item->loiter_radius) :
+	sp->x = item.x;
+	sp->y = item.y;
+	sp->z = item.z;
+	sp->yaw = item.yaw;
+	sp->yaw_valid = PX4_ISFINITE(item.yaw);
+	sp->loiter_radius = (fabsf(item.loiter_radius) > NAV_EPSILON_POSITION) ? fabsf(item.loiter_radius) :
 			    _navigator->get_loiter_radius();
 	sp->loiter_direction = (item.loiter_radius > 0) ? 1 : -1;
 	sp->acceptance_radius = item.acceptance_radius;
@@ -510,7 +497,7 @@ MissionBlock::navigator_item_to_position_setpoint(const struct navigator_item_s 
 	sp->cruising_speed = _navigator->get_cruising_speed();
 	sp->cruising_throttle = _navigator->get_cruising_throttle();
 
-	switch (item->nav_cmd) {
+	switch (item.nav_cmd) {
 	case NAV_CMD_IDLE:
 		sp->type = position_setpoint_s::SETPOINT_TYPE_IDLE;
 		break;

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -737,7 +737,8 @@ MissionBlock::set_land_item(struct navigator_item_s *item, bool at_current_locat
 
 	}
 
-	item->altitude = 0;
+	item->altitude = 0; // not used -> position controller uses descend velocity
+	item->z = 100; // not used -> position controller uses descend velocity
 	item->loiter_radius = _navigator->get_loiter_radius();
 	item->acceptance_radius = _navigator->get_acceptance_radius();
 	item->time_inside = 0.0f;

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -733,9 +733,9 @@ MissionBlock::set_land_item(struct mission_item_s *item, bool at_current_locatio
 		item->lat = _navigator->get_home_position()->lat;
 		item->lon = _navigator->get_home_position()->lon;
 		item->yaw = _navigator->get_home_position()->yaw;
+		item->x = _navigator->get_home_position()->x;
+		item->y = _navigator->get_home_position()->y;
 
-		// convert to local coordinates
-		_navigator->global_to_local(item);
 	}
 
 	item->altitude = 0;
@@ -772,6 +772,9 @@ MissionBlock::set_idle_item(struct mission_item_s *item)
 	item->nav_cmd = NAV_CMD_IDLE;
 	item->lat = _navigator->get_home_position()->lat;
 	item->lon = _navigator->get_home_position()->lon;
+	item->x = _navigator->get_home_position()->x;
+	item->y = _navigator->get_home_position()->y;
+	item->z = _navigator->get_home_position()->z;
 	item->altitude_is_relative = false;
 	item->altitude = _navigator->get_home_position()->alt;
 	item->yaw = NAN;
@@ -780,9 +783,6 @@ MissionBlock::set_idle_item(struct mission_item_s *item)
 	item->time_inside = 0.0f;
 	item->autocontinue = true;
 	item->origin = ORIGIN_ONBOARD;
-
-	// convert to local coordinates
-	_navigator->global_to_local(item);
 }
 
 void

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -484,6 +484,7 @@ MissionBlock::item_contains_position(const mission_item_s &item)
 bool
 MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, position_setpoint_s *sp)
 {
+
 	/* don't change the setpoint for non-position items */
 	if (!item_contains_position(item)) {
 		return false;
@@ -505,7 +506,7 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 
 	/* TODO: adjust mc_pos_control to use local setpoint only */
 	if (_navigator->get_vstatus()->is_rotary_wing) {
-		global_to_local(item, sp);
+		_navigator->global_to_local(sp);
 	}
 
 	switch (item->nav_cmd) {
@@ -579,16 +580,6 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 	sp->valid = true;
 
 	return sp->valid;
-}
-
-void
-MissionBlock::global_to_local(const struct mission_item_s *item, struct position_setpoint_s *sp)
-{
-
-	map_projection_project(_navigator->get_local_reference_pos(), item->lat, item->lon,
-			       &sp->x, &sp->y);
-	sp->z = -(sp->alt - _navigator->get_local_reference_alt());
-
 }
 
 void

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -741,7 +741,7 @@ MissionBlock::set_idle_item(struct navigator_item_s *item)
 
 
 void
-MissionBlock::navigator_apply_limitation(naviator_item_s &item)
+MissionBlock::navigator_apply_limitation(navigator_item_s &item)
 {
 	/*
 	 * Limit altitude
@@ -750,16 +750,9 @@ MissionBlock::navigator_apply_limitation(naviator_item_s &item)
 	/* do nothing if altitude max is negative */
 	if (_navigator->get_land_detected()->alt_max > 0.0f) {
 
-		/* absolute altitude */
-		float altitude_abs = item.altitude_is_relative
-				     ? item.altitude + _navigator->get_home_position()->alt
-				     : item.altitude;
-
 		/* limit altitude to maximum allowed altitude */
-		if ((_navigator->get_land_detected()->alt_max + _navigator->get_home_position()->alt) < altitude_abs) {
-			item.altitude = item.altitude_is_relative ?
-					_navigator->get_land_detected()->alt_max :
-					_navigator->get_land_detected()->alt_max + _navigator->get_home_position()->alt;
+		if (_navigator->get_land_detected()->alt_max  < -(item.z - _navigator->get_home_position()->z)) {
+			item.z = -_navigator->get_land_detected()->alt_max + _navigator->get_home_position()->z;
 
 		}
 	}
@@ -767,6 +760,7 @@ MissionBlock::navigator_apply_limitation(naviator_item_s &item)
 	/*
 	 * Add other limitations here
 	 */
+}
 
 float
 MissionBlock::get_horizontal_distance_to_target(const struct navigator_item_s &item)

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -504,10 +504,8 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 	sp->cruising_speed = _navigator->get_cruising_speed();
 	sp->cruising_throttle = _navigator->get_cruising_throttle();
 
-	/* TODO: adjust mc_pos_control to use local setpoint only */
-	if (_navigator->get_vstatus()->is_rotary_wing) {
-		_navigator->global_to_local(sp);
-	}
+	/* compute local setpoint */
+	_navigator->global_to_local(sp);
 
 	switch (item->nav_cmd) {
 	case NAV_CMD_IDLE:

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -101,7 +101,7 @@ protected:
 	/**
 	 * Set a takeoff mission item
 	 */
-	void set_takeoff_item(struct mission_item_s *item, float abs_altitude, float min_pitch = 0.0f);
+	void set_takeoff_item(struct mission_item_s *item, float abs_altitude, float lpos_z, float min_pitch = 0.0f);
 
 	/**
 	 * Set a land mission item

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -129,6 +129,8 @@ protected:
 
 	float get_time_inside(const struct mission_item_s &item);
 
+	void global_to_local(const struct mission_item_s *item, struct position_setpoint_s *sp);
+
 	mission_item_s _mission_item{};
 
 	bool _waypoint_position_reached{false};

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -129,8 +129,6 @@ protected:
 
 	float get_time_inside(const struct mission_item_s &item);
 
-	void global_to_local(const struct mission_item_s *item, struct position_setpoint_s *sp);
-
 	mission_item_s _mission_item{};
 
 	bool _waypoint_position_reached{false};

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -130,6 +130,7 @@ protected:
 	float get_time_inside(const struct mission_item_s &item);
 
 	mission_item_s _mission_item{};
+	navigator_item_s _navigator_item{};
 
 	bool _waypoint_position_reached{false};
 	bool _waypoint_yaw_reached{false};

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -126,7 +126,7 @@ protected:
 	/**
 	 * General function used to adjust the mission item based on vehicle specific limitations
 	 */
-	void	navigator_apply_limitation(naviator_item_s &item);
+	void	navigator_apply_limitation(navigator_item_s &item);
 
 
 	void issue_command(const struct navigator_item_s &item);

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -104,7 +104,7 @@ protected:
 	/**
 	 * Set a takeoff mission item
 	 */
-	void set_takeoff_item(struct navigator_item_s *item, float abs_altitude, float lpos_z, float min_pitch = 0.0f);
+	void set_takeoff_item(struct navigator_item_s *item, float lpos_z, float min_pitch = 0.0f);
 
 	/**
 	 * Set a land mission item
@@ -132,6 +132,8 @@ protected:
 	void issue_command(const struct navigator_item_s &item);
 
 	float get_time_inside(const struct navigator_item_s &item);
+
+	float get_horizontal_distance_to_target(const struct navigator_item_s &item);
 
 	mission_item_s _mission_item{};
 	navigator_item_s _navigator_item{};

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -66,19 +66,21 @@ public:
 	MissionBlock(const MissionBlock &) = delete;
 	MissionBlock &operator=(const MissionBlock &) = delete;
 
-	static bool item_contains_position(const mission_item_s &item);
+	static bool item_contains_position(const struct navigator_item_s *item);
+
+	static bool item_contains_position(const struct mission_item_s *item);
 
 protected:
 	/**
 	 * Check if mission item has been reached
 	 * @return true if successfully reached
 	 */
-	bool is_mission_item_reached();
+	bool is_navigator_item_reached();
 
 	/**
 	 * Reset all reached flags
 	 */
-	void reset_mission_item_reached();
+	void reset_navigator_item_reached();
 
 	/**
 	 * Convert a mission item to a position setpoint
@@ -86,7 +88,8 @@ protected:
 	 * @param the mission item to convert
 	 * @param the position setpoint that needs to be set
 	 */
-	bool mission_item_to_position_setpoint(const mission_item_s &item, position_setpoint_s *sp);
+
+	bool navigator_item_to_position_setpoint(const navigator_item_s &item, position_setpoint_s *sp);
 
 	/**
 	 * Set previous position setpoint to current setpoint
@@ -96,38 +99,39 @@ protected:
 	/**
 	 * Set a loiter mission item, if possible reuse the position setpoint, otherwise take the current position
 	 */
-	void set_loiter_item(struct mission_item_s *item, float min_clearance = -1.0f);
+	void set_loiter_item(struct navigator_item_s *item, float min_clearance = -1.0f);
 
 	/**
 	 * Set a takeoff mission item
 	 */
-	void set_takeoff_item(struct mission_item_s *item, float abs_altitude, float lpos_z, float min_pitch = 0.0f);
+	void set_takeoff_item(struct navigator_item_s *item, float abs_altitude, float lpos_z, float min_pitch = 0.0f);
 
 	/**
 	 * Set a land mission item
 	 */
-	void set_land_item(struct mission_item_s *item, bool at_current_location);
+	void set_land_item(struct navigator_item_s *item, bool at_current_location);
 
-	void set_current_position_item(struct mission_item_s *item);
+	void set_current_position_item(struct navigator_item_s *item);
 
 	/**
 	 * Set idle mission item
 	 */
-	void set_idle_item(struct mission_item_s *item);
+	void set_idle_item(struct navigator_item_s *item);
 
 	/**
 	 * Set follow_target item
 	 */
-	void set_follow_target_item(struct mission_item_s *item, float min_clearance, follow_target_s &target, float yaw);
+	void set_follow_target_item(struct navigator_item_s *item, float min_clearance, follow_target_s &target, float yaw);
+
 
 	/**
 	 * General function used to adjust the mission item based on vehicle specific limitations
 	 */
-	void	mission_apply_limitation(mission_item_s &item);
+	void	navigator_apply_limitation(naviator_item_s &item);
 
-	void issue_command(const mission_item_s &item);
+	void issue_command(const struct navigator_item_s &item);
 
-	float get_time_inside(const struct mission_item_s &item);
+	float get_time_inside(const struct navigator_item_s &item);
 
 	mission_item_s _mission_item{};
 	navigator_item_s _navigator_item{};

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -66,9 +66,9 @@ public:
 	MissionBlock(const MissionBlock &) = delete;
 	MissionBlock &operator=(const MissionBlock &) = delete;
 
-	static bool item_contains_position(const struct navigator_item_s *item);
+	static bool item_contains_position(const struct navigator_item_s &item);
 
-	static bool item_contains_position(const struct mission_item_s *item);
+	static bool item_contains_position(const struct mission_item_s &item);
 
 protected:
 	/**
@@ -123,11 +123,11 @@ protected:
 	 */
 	void set_follow_target_item(struct navigator_item_s *item, float min_clearance, follow_target_s &target, float yaw);
 
-
 	/**
 	 * General function used to adjust the mission item based on vehicle specific limitations
 	 */
 	void	navigator_apply_limitation(naviator_item_s &item);
+
 
 	void issue_command(const struct navigator_item_s &item);
 

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -100,6 +100,35 @@ enum ORIGIN {
  */
 
 /**
+ * Position setpoint in local coordinates.
+ *
+ * This is the position the MAV is heading towards. If it is of type loiter,
+ * the MAV is circling around it with the given loiter radius in meters.
+ */
+struct navigator_item_s {
+	float x; /**< local position x in meters */
+	float y; /**< local position y in meters */
+	float z; /**< local position z in meters */
+	float yaw; /**< in radians NED -PI..+PI, NAN means don't change yaw		*/
+	float acceptance_radius; /**< default radius in which the mission is accepted as reached in meters */
+	float loiter_radius; /**< loiter radius in meters, 0 for a VTOL to hover, negative for counter-clockwise */
+	uint16_t nav_cmd; /**< navigation command					*/
+	int16_t do_jump_mission_index; /**< index where the do jump will go to                 */
+	uint16_t do_jump_repeat_count; /**< how many times do jump needs to be done            */
+	uint16_t do_jump_current_count; /**< count how many times the jump has been done	*/
+	struct {
+		uint16_t frame : 4, /**< mission frame ***/
+			 origin : 3, /**< how the mission item was generated */
+			 loiter_exit_xtrack : 1, /**< exit xtrack location: 0 for center of loiter wp, 1 for exit location */
+			 force_heading : 1, /**< heading needs to be reached ***/
+			 autocontinue : 1, /**< true if next waypoint should follow after this one */
+			 disable_mc_yaw : 1, /**< weathervane mode */
+			 vtol_back_transition : 1; /**< part of the vtol back transition sequence */
+	};
+	//TODO what else is needed? VTOL?
+};
+
+/**
  * Global position setpoint in WGS84 coordinates.
  *
  * This is the position the MAV is heading towards. If it of type loiter,

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -112,10 +112,22 @@ struct navigator_item_s {
 	float x; /**< local position x in meters */
 	float y; /**< local position y in meters */
 	float z; /**< local position z in meters */
-	float yaw; /**< in radians NED -PI..+PI, NAN means don't change yaw		*/
-	float acceptance_radius; /**< default radius in which the mission is accepted as reached in meters */
-	float loiter_radius; /**< loiter radius in meters, 0 for a VTOL to hover, negative for counter-clockwise */
-	uint16_t nav_cmd; /**< navigation command					*/
+	union {
+		struct {
+			union {
+				float time_inside; /**< time that the MAV should stay inside the radius before advancing in seconds */
+				float pitch_min; /**< minimal pitch angle for fixed wing takeoff waypoints */
+			};
+			float acceptance_radius; /**< default radius in which the mission is accepted as reached in meters */
+			float loiter_radius; /**< loiter radius in meters, 0 for a VTOL to hover, negative for counter-clockwise */
+			float yaw; /**< in radians NED -PI..+PI, NAN means don't change yaw		*/
+			float _x; /**< padding */
+			float _y; /**< padding */
+			float _z; /**< padding */
+		};
+		float params[7];				/**< array to store mission command values for MAV_FRAME_MISSION ***/
+	};
+	uint16_t nav_cmd; /**< navigation command	*/
 	int16_t do_jump_mission_index; /**< index where the do jump will go to                 */
 	uint16_t do_jump_repeat_count; /**< how many times do jump needs to be done            */
 	uint16_t do_jump_current_count; /**< count how many times the jump has been done	*/

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -108,6 +108,7 @@ enum ORIGIN {
 struct navigator_item_s {
 	double lat;			/**< latitude in degrees				*/
 	double lon;			/**< longitude in degrees				*/
+	float altitude;				/**< altitude in meters	(AMSL)			*/
 	float x; /**< local position x in meters */
 	float y; /**< local position y in meters */
 	float z; /**< local position z in meters */

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -106,6 +106,8 @@ enum ORIGIN {
  * the MAV is circling around it with the given loiter radius in meters.
  */
 struct navigator_item_s {
+	double lat;			/**< latitude in degrees				*/
+	double lon;			/**< longitude in degrees				*/
 	float x; /**< local position x in meters */
 	float y; /**< local position y in meters */
 	float z; /**< local position z in meters */

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -106,9 +106,7 @@ enum ORIGIN {
  * the MAV is circling around it with the given loiter radius in meters.
  */
 struct navigator_item_s {
-	double lat;			/**< latitude in degrees				*/
-	double lon;			/**< longitude in degrees				*/
-	float altitude;				/**< altitude in meters	(AMSL)			*/
+
 	float x; /**< local position x in meters */
 	float y; /**< local position y in meters */
 	float z; /**< local position z in meters */

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -111,6 +111,9 @@ enum ORIGIN {
 struct mission_item_s {
 	double lat;			/**< latitude in degrees				*/
 	double lon;			/**< longitude in degrees				*/
+	float x;			/**< local position x in meters */
+	float y;			/**< local position y in meters */
+	float z;			/**< local position z in meters */
 	union {
 		struct {
 			union {

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -153,9 +153,6 @@ struct navigator_item_s {
 struct mission_item_s {
 	double lat;			/**< latitude in degrees				*/
 	double lon;			/**< longitude in degrees				*/
-	float x;			/**< local position x in meters */
-	float y;			/**< local position y in meters */
-	float z;			/**< local position z in meters */
 	union {
 		struct {
 			union {

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -170,6 +170,21 @@ public:
 	 */
 	float		get_cruising_speed();
 
+	/**
+	 *  Get heading to target from current position
+	 *
+	 *  @return desired heading such that body x points towards target
+	 */
+	float 		get_heading_to_target(const matrix::Vector2f &target);
+
+
+	/**
+	 *  Get heading to target from any arbitrary point
+	 *
+	 *  @return desired heading such that body x points towards target from start point
+	 */
+	float 		get_heading_to_target(const matrix::Vector2f &start, const matrix::Vector2f &target);
+
 
 	/**
 	 * Set the cruising speed

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -129,15 +129,9 @@ public:
 	struct vehicle_land_detected_s *get_land_detected() { return &_land_detected; }
 	struct vehicle_local_position_s *get_local_position() { return &_local_pos; }
 	struct vehicle_status_s *get_vstatus() { return &_vstatus; }
-<<<<<<< 0d7d6e59f549e50e45611d19f339b1201e6139d6
-
 	const vehicle_roi_s &get_vroi() { return _vroi; }
-
-=======
-	struct vehicle_roi_s *get_vroi() { return &_vroi; }
 	struct map_projection_reference_s *get_local_reference_pos() {return &_ref_pos;}
 	float 		get_local_reference_alt() {return _ref_alt;}
->>>>>>> copy update_ref logic from mc_pos_ctr to navigator
 	bool home_position_valid() { return (_home_pos.timestamp > 0); }
 
 	int		get_onboard_mission_sub() { return _onboard_mission_sub; }
@@ -233,16 +227,12 @@ public:
 
 	bool		abort_landing();
 
-	void 		global_to_local(struct position_setpoint_s *sp);
-
-	void 		global_to_local(struct mission_item_s *item);
-
 	void 		mission_item_to_navigator_item(struct navigator_item_s *nav_item, struct mission_item_s *mission_item);
 
 private:
 
 	bool		_task_should_exit{false};	/**< if true, sensor task should exit */
-	int		_navigator_task{-1};		/**< task handle for sensor task */
+	int		_navigator_task{ -1};		/**< task handle for sensor task */
 
 	int		_fw_pos_ctrl_status_sub{-1};	/**< notification of vehicle capabilities updates */
 	int		_global_pos_sub{-1};		/**< global position subscription */
@@ -286,7 +276,7 @@ private:
 	hrt_abstime _ref_timestamp{0}; /** time stamp when reference for local frame has been updated */
 	float _ref_alt{0.0f}; /** local reference altitude */
 
-	int		_mission_instance_count{-1};	/**< instance count for the current mission */
+	int		_mission_instance_count{ -1};	/**< instance count for the current mission */
 
 	perf_counter_t	_loop_perf;			/**< loop performance counter */
 
@@ -318,9 +308,9 @@ private:
 	control::BlockParamFloat _param_fw_alt_acceptance_radius;	/**< acceptance radius for fixedwing altitude */
 	control::BlockParamFloat _param_mc_alt_acceptance_radius;	/**< acceptance radius for multicopter altitude */
 
-	float _mission_cruising_speed_mc{-1.0f};
-	float _mission_cruising_speed_fw{-1.0f};
-	float _mission_throttle{-1.0f};
+	float _mission_cruising_speed_mc{ -1.0f};
+	float _mission_cruising_speed_fw{ -1.0f};
+	float _mission_throttle{ -1.0f};
 
 	// update subscriptions
 	void		fw_pos_ctrl_status_update(bool force = false);
@@ -356,10 +346,8 @@ private:
 	 */
 	void		publish_mission_result();
 
-<<<<<<< 0d7d6e59f549e50e45611d19f339b1201e6139d6
-	void		publish_vehicle_command_ack(const vehicle_command_s &cmd, uint8_t result);
-=======
 
->>>>>>> copy update_ref logic from mc_pos_ctr to navigator
+	void		publish_vehicle_command_ack(const vehicle_command_s &cmd, uint8_t result);
+
 };
 #endif

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -176,6 +176,7 @@ public:
 	 */
 	float		get_cruising_speed();
 
+
 	/**
 	 * Set the cruising speed
 	 *
@@ -231,6 +232,8 @@ public:
 	bool		is_planned_mission() { return _navigation_mode == &_mission; }
 
 	bool		abort_landing();
+
+	void 		global_to_local(struct position_setpoint_s *sp);
 
 private:
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -237,6 +237,8 @@ public:
 
 	void 		global_to_local(struct mission_item_s *item);
 
+	void 		mission_item_to_navigator_item(struct navigator_item_s *nav_item, struct mission_item_s *mission_item);
+
 private:
 
 	bool		_task_should_exit{false};	/**< if true, sensor task should exit */

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -235,6 +235,8 @@ public:
 
 	void 		global_to_local(struct position_setpoint_s *sp);
 
+	void 		global_to_local(struct mission_item_s *item);
+
 private:
 
 	bool		_task_should_exit{false};	/**< if true, sensor task should exit */

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -58,6 +58,7 @@
 #include <controllib/blocks.hpp>
 #include <navigator/navigation.h>
 #include <systemlib/perf_counter.h>
+#include <lib/geo/geo.h>
 #include <uORB/topics/fw_pos_ctrl_status.h>
 #include <uORB/topics/geofence_result.h>
 #include <uORB/topics/mission.h>
@@ -128,9 +129,15 @@ public:
 	struct vehicle_land_detected_s *get_land_detected() { return &_land_detected; }
 	struct vehicle_local_position_s *get_local_position() { return &_local_pos; }
 	struct vehicle_status_s *get_vstatus() { return &_vstatus; }
+<<<<<<< 0d7d6e59f549e50e45611d19f339b1201e6139d6
 
 	const vehicle_roi_s &get_vroi() { return _vroi; }
 
+=======
+	struct vehicle_roi_s *get_vroi() { return &_vroi; }
+	struct map_projection_reference_s *get_local_reference_pos() {return &_ref_pos;}
+	float 		get_local_reference_alt() {return _ref_alt;}
+>>>>>>> copy update_ref logic from mc_pos_ctr to navigator
 	bool home_position_valid() { return (_home_pos.timestamp > 0); }
 
 	int		get_onboard_mission_sub() { return _onboard_mission_sub; }
@@ -140,6 +147,8 @@ public:
 
 	bool		get_can_loiter_at_sp() { return _can_loiter_at_sp; }
 	float		get_loiter_radius() { return _param_loiter_radius.get(); }
+
+
 
 	/**
 	 * Returns the default acceptance radius defined by the parameter
@@ -203,6 +212,7 @@ public:
 	 */
 	void		set_cruising_throttle(float throttle = -1.0f) { _mission_throttle = throttle; }
 
+
 	/**
 	 * Get the acceptance radius given the mission item preset radius
 	 *
@@ -265,6 +275,9 @@ private:
 	position_setpoint_triplet_s			_reposition_triplet{};	/**< triplet for non-mission direct position command */
 	position_setpoint_triplet_s			_takeoff_triplet{};	/**< triplet for non-mission direct takeoff command */
 	vehicle_roi_s					_vroi{};		/**< vehicle ROI */
+	map_projection_reference_s _ref_pos{}; /** local reference position */
+	hrt_abstime _ref_timestamp{0}; /** time stamp when reference for local frame has been updated */
+	float _ref_alt{0.0f}; /** local reference altitude */
 
 	int		_mission_instance_count{-1};	/**< instance count for the current mission */
 
@@ -312,6 +325,9 @@ private:
 	void		sensor_combined_update();
 	void		vehicle_land_detected_update();
 	void		vehicle_status_update();
+	void		vehicle_roi_update();
+	void 		local_reference_update();
+
 
 	/**
 	 * Shim for calling task_main from task_create.
@@ -333,6 +349,10 @@ private:
 	 */
 	void		publish_mission_result();
 
+<<<<<<< 0d7d6e59f549e50e45611d19f339b1201e6139d6
 	void		publish_vehicle_command_ack(const vehicle_command_s &cmd, uint8_t result);
+=======
+
+>>>>>>> copy update_ref logic from mc_pos_ctr to navigator
 };
 #endif

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -222,7 +222,6 @@ public:
 	 */
 	void		set_cruising_throttle(float throttle = -1.0f) { _mission_throttle = throttle; }
 
-
 	/**
 	 * Get the acceptance radius given the mission item preset radius
 	 *
@@ -247,7 +246,7 @@ public:
 private:
 
 	bool		_task_should_exit{false};	/**< if true, sensor task should exit */
-	int		_navigator_task{ -1};		/**< task handle for sensor task */
+	int		_navigator_task{-1};		/**< task handle for sensor task */
 
 	int		_fw_pos_ctrl_status_sub{-1};	/**< notification of vehicle capabilities updates */
 	int		_global_pos_sub{-1};		/**< global position subscription */
@@ -323,9 +322,9 @@ private:
 	control::BlockParamFloat _param_fw_alt_acceptance_radius;	/**< acceptance radius for fixedwing altitude */
 	control::BlockParamFloat _param_mc_alt_acceptance_radius;	/**< acceptance radius for multicopter altitude */
 
-	float _mission_cruising_speed_mc{ -1.0f};
-	float _mission_cruising_speed_fw{ -1.0f};
-	float _mission_throttle{ -1.0f};
+	float _mission_cruising_speed_mc{-1.0f};
+	float _mission_cruising_speed_fw{-1.0f};
+	float _mission_throttle{-1.0f};
 
 	// update subscriptions
 	void		fw_pos_ctrl_status_update(bool force = false);
@@ -337,9 +336,7 @@ private:
 	void		sensor_combined_update();
 	void		vehicle_land_detected_update();
 	void		vehicle_status_update();
-	void		vehicle_roi_update();
 	void 		local_reference_update();
-
 
 	/**
 	 * Shim for calling task_main from task_create.
@@ -361,8 +358,6 @@ private:
 	 */
 	void		publish_mission_result();
 
-
 	void		publish_vehicle_command_ack(const vehicle_command_s &cmd, uint8_t result);
-
 };
 #endif

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -319,6 +319,7 @@ Navigator::task_main()
 			if (fds[0].revents & POLLIN) {
 				/* success, local pos is available */
 				local_position_update();
+				local_reference_update();
 			}
 		}
 
@@ -347,15 +348,6 @@ Navigator::task_main()
 				have_geofence_position_data = true;
 			}
 		}
-
-		/* local position updated */
-		orb_check(_local_pos_sub, &updated);
-
-		if (updated) {
-			local_position_update();
-			local_reference_update();
-		}
-
 
 		/* sensors combined updated */
 		orb_check(_sensor_combined_sub, &updated);

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -156,33 +156,58 @@ Navigator::local_position_update()
 void
 Navigator::local_reference_update()
 {
-	if (_local_pos.ref_timestamp != _ref_timestamp) {
 
-		// update local projection reference including altitude
-		map_projection_init(&_ref_pos, _local_pos.ref_lat, _local_pos.ref_lon);
-		_ref_alt = _local_pos.ref_alt;
+	if ((_local_pos.ref_timestamp == _ref_timestamp)
+	    && (_vstatus.arming_state != vehicle_status_s::ARMING_STATE_STANDBY)) {
+		// we don't have to update reference frame
+		return;
 
-		if (_ref_timestamp != 0) {
-			// TODO: get a global septoint
-			// reproject position setpoint to new reference
-			// this effectively adjusts the position setpoint to keep the vehicle
-			// in its current local position. It would only change its
-			//// global position on the next setpoint update.
-			//map_projection_project(&_ref_pos, _pos_sp_triplet.current.lat, _pos_sp_triplet.current.lon, &_pos_sp_triplet.current.x,
-			//		       &_pos_sp_triplet.current.y);
-			//_pos_sp_triplet.current.z = (-_pos_sp_triplet.current.alt - _ref_alt);
-			//
-			//map_projection_project(&_ref_pos, _pos_sp_triplet.previous.lat, _pos_sp_triplet.previous.lon,
-			//		       &_pos_sp_triplet.previous.x, &_pos_sp_triplet.previous.y);
-			//_pos_sp_triplet.previous.z = (-_pos_sp_triplet.previous.alt - _ref_alt);
-			//
-			//map_projection_project(&_ref_pos, _pos_sp_triplet.next.lat, _pos_sp_triplet.next.lon, &_pos_sp_triplet.next.x,
-			//		       &_pos_sp_triplet.next.y);
-			//_pos_sp_triplet.next.z = (-_pos_sp_triplet.next.alt - _ref_alt);
-		}
-
-		_ref_timestamp = _local_pos.ref_timestamp;
 	}
+
+	double lat_current_sp, lon_current_sp;
+	double lat_previous_sp, lon_previous_sp;
+	double lat_next_sp, lon_next_sp;
+	float alt_current_sp{0.0f}, alt_previous_sp{0.0f}, alt_next_sp{0.0f};
+
+	bool new_reference = _ref_timestamp != 0;
+
+	if (new_reference) {
+		// calculate current position setpoint in global frame
+		map_projection_reproject(&_ref_pos, _pos_sp_triplet.current.x, _pos_sp_triplet.current.y, &lat_current_sp,
+					 &lon_current_sp);
+		map_projection_reproject(&_ref_pos, _pos_sp_triplet.previous.x, _pos_sp_triplet.previous.y, &lat_previous_sp,
+					 &lon_previous_sp);
+		map_projection_reproject(&_ref_pos, _pos_sp_triplet.next.x, _pos_sp_triplet.next.y, &lat_next_sp, &lon_next_sp);
+
+		// the altitude setpoint is the reference altitude (Z up) plus the (Z down)
+		// NED setpoint, multiplied out to minus
+		alt_current_sp = _ref_alt - _pos_sp_triplet.current.z;
+		alt_previous_sp = _ref_alt - _pos_sp_triplet.previous.z;
+		alt_next_sp = _ref_alt - _pos_sp_triplet.next.z;
+	}
+
+	// update local projection reference including altitude
+	map_projection_init(&_ref_pos, _local_pos.ref_lat, _local_pos.ref_lon);
+	_ref_alt = _local_pos.ref_alt;
+
+	if (new_reference) {
+		// reproject position setpoint to new reference
+		// this effectively adjusts the position setpoint to keep the vehicle
+		// in its current local position. It would only change its
+		// global position on the next setpoint update.
+		map_projection_project(&_ref_pos, lat_current_sp, lon_current_sp, &_pos_sp_triplet.current.x,
+				       &_pos_sp_triplet.current.y);
+		map_projection_project(&_ref_pos, lat_previous_sp, lon_previous_sp, &_pos_sp_triplet.previous.x,
+				       &_pos_sp_triplet.previous.y);
+		map_projection_project(&_ref_pos, lat_next_sp, lon_next_sp, &_pos_sp_triplet.next.x, &_pos_sp_triplet.next.y);
+		_pos_sp_triplet.current.z = -(alt_current_sp - _ref_alt);
+		_pos_sp_triplet.previous.z = -(alt_previous_sp - _ref_alt);
+		_pos_sp_triplet.next.z = -(alt_next_sp - _ref_alt);
+
+	}
+
+	// we update the timestamp because the reference gets updated only if timestamps are different
+	_ref_timestamp = _local_pos.ref_timestamp;
 }
 
 void

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -163,21 +163,22 @@ Navigator::local_reference_update()
 		_ref_alt = _local_pos.ref_alt;
 
 		if (_ref_timestamp != 0) {
+			// TODO: get a global septoint
 			// reproject position setpoint to new reference
 			// this effectively adjusts the position setpoint to keep the vehicle
 			// in its current local position. It would only change its
-			// global position on the next setpoint update.
-			map_projection_project(&_ref_pos, _pos_sp_triplet.current.lat, _pos_sp_triplet.current.lon, &_pos_sp_triplet.current.x,
-					       &_pos_sp_triplet.current.y);
-			_pos_sp_triplet.current.z = (-_pos_sp_triplet.current.alt - _ref_alt);
-
-			map_projection_project(&_ref_pos, _pos_sp_triplet.previous.lat, _pos_sp_triplet.previous.lon,
-					       &_pos_sp_triplet.previous.x, &_pos_sp_triplet.previous.y);
-			_pos_sp_triplet.previous.z = (-_pos_sp_triplet.previous.alt - _ref_alt);
-
-			map_projection_project(&_ref_pos, _pos_sp_triplet.next.lat, _pos_sp_triplet.next.lon, &_pos_sp_triplet.next.x,
-					       &_pos_sp_triplet.next.y);
-			_pos_sp_triplet.next.z = (-_pos_sp_triplet.next.alt - _ref_alt);
+			//// global position on the next setpoint update.
+			//map_projection_project(&_ref_pos, _pos_sp_triplet.current.lat, _pos_sp_triplet.current.lon, &_pos_sp_triplet.current.x,
+			//		       &_pos_sp_triplet.current.y);
+			//_pos_sp_triplet.current.z = (-_pos_sp_triplet.current.alt - _ref_alt);
+			//
+			//map_projection_project(&_ref_pos, _pos_sp_triplet.previous.lat, _pos_sp_triplet.previous.lon,
+			//		       &_pos_sp_triplet.previous.x, &_pos_sp_triplet.previous.y);
+			//_pos_sp_triplet.previous.z = (-_pos_sp_triplet.previous.alt - _ref_alt);
+			//
+			//map_projection_project(&_ref_pos, _pos_sp_triplet.next.lat, _pos_sp_triplet.next.lon, &_pos_sp_triplet.next.x,
+			//		       &_pos_sp_triplet.next.y);
+			//_pos_sp_triplet.next.z = (-_pos_sp_triplet.next.alt - _ref_alt);
 		}
 
 		_ref_timestamp = _local_pos.ref_timestamp;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -920,8 +920,7 @@ void
 Navigator::global_to_local(struct position_setpoint_s *sp)
 {
 
-	map_projection_project(get_local_reference_pos(), sp->lat, sp->lon,
-			       &sp->x, &sp->y);
+	map_projection_project(get_local_reference_pos(), sp->lat, sp->lon, &sp->x, &sp->y);
 	sp->z = -(sp->alt - get_local_reference_alt());
 
 }

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -418,10 +418,13 @@ Navigator::task_main()
 				position_setpoint_triplet_s *curr = get_position_setpoint_triplet();
 
 				// store current position as previous position and goal as next
-				rep->previous.yaw = get_global_position()->yaw;
 				rep->previous.lat = get_global_position()->lat;
 				rep->previous.lon = get_global_position()->lon;
 				rep->previous.alt = get_global_position()->alt;
+				rep->previous.x = get_local_position()->x;
+				rep->previous.y = get_local_position()->y;
+				rep->previous.z = get_local_position()->z;
+				rep->previous.yaw = get_local_position()->yaw;
 
 				rep->current.loiter_radius = get_loiter_radius();
 				rep->current.loiter_direction = 1;
@@ -466,6 +469,9 @@ Navigator::task_main()
 					rep->current.alt = get_global_position()->alt;
 				}
 
+				map_projection_project(get_local_reference_pos(), rep->current.lat, rep->current.lon, &rep->current.x, &rep->current.y);
+				rep->current.z = - (rep->current.alt - get_local_reference_alt());
+				rep->current.yaw = get_local_position()->yaw;
 				rep->previous.valid = true;
 				rep->current.valid = true;
 				rep->next.valid = false;
@@ -476,10 +482,14 @@ Navigator::task_main()
 				position_setpoint_triplet_s *rep = get_takeoff_triplet();
 
 				// store current position as previous position and goal as next
-				rep->previous.yaw = get_global_position()->yaw;
 				rep->previous.lat = get_global_position()->lat;
 				rep->previous.lon = get_global_position()->lon;
 				rep->previous.alt = get_global_position()->alt;
+
+				rep->previous.x = get_local_position()->x;
+				rep->previous.y = get_local_position()->y;
+				rep->previous.z = get_local_position()->z;
+				rep->previous.yaw = get_local_position()->yaw;
 
 				rep->current.loiter_radius = get_loiter_radius();
 				rep->current.loiter_direction = 1;
@@ -505,6 +515,10 @@ Navigator::task_main()
 				}
 
 				rep->current.alt = cmd.param7;
+
+				map_projection_project(get_local_reference_pos(), rep->current.lat, rep->current.lon, &rep->current.x, &rep->current.y);
+				rep->current.z = - (rep->current.alt - get_local_reference_alt());
+				rep->previous.yaw = get_local_position()->yaw;
 
 				rep->current.valid = true;
 				rep->next.valid = false;
@@ -732,6 +746,7 @@ Navigator::task_main()
 		if (_navigation_mode == nullptr && !_pos_sp_triplet_published_invalid_once) {
 			_pos_sp_triplet_published_invalid_once = true;
 			reset_triplets();
+
 		}
 
 		if (_pos_sp_triplet_updated) {

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -457,8 +457,8 @@ Navigator::task_main()
 
 				if (PX4_ISFINITE(cmd.param5) && PX4_ISFINITE(cmd.param6)) {
 
-					float lat = (cmd.param5 < 1000) ? cmd.param5 : cmd.param5 / (double)1e7;
-					float lon = (cmd.param6 < 1000) ? cmd.param6 : cmd.param6 / (double)1e7;
+					double lat = (cmd.param5 < 1000) ? cmd.param5 : cmd.param5 / (double)1e7;
+					double lon = (cmd.param6 < 1000) ? cmd.param6 : cmd.param6 / (double)1e7;
 
 					if (PX4_ISFINITE(cmd.param7)) {
 						rep->current.z =  -(cmd.param7 - get_local_reference_alt());
@@ -485,7 +485,6 @@ Navigator::task_main()
 					rep->current.z = get_local_position()->z;
 				}
 
-				rep->current.yaw = get_local_position()->yaw;
 				rep->previous.valid = true;
 				rep->current.valid = true;
 				rep->next.valid = false;
@@ -516,8 +515,8 @@ Navigator::task_main()
 
 				if (PX4_ISFINITE(cmd.param5) && PX4_ISFINITE(cmd.param6)) {
 
-					float lat = (cmd.param5 < 1000) ? cmd.param5 : cmd.param5 / (double)1e7;
-					float lon = (cmd.param6 < 1000) ? cmd.param6 : cmd.param6 / (double)1e7;
+					double lat = (cmd.param5 < 1000) ? cmd.param5 : cmd.param5 / (double)1e7;
+					double lon = (cmd.param6 < 1000) ? cmd.param6 : cmd.param6 / (double)1e7;
 
 					map_projection_project(get_local_reference_pos(), lat, lon, &rep->current.x, &rep->current.y);
 
@@ -756,7 +755,6 @@ Navigator::task_main()
 		if (_navigation_mode == nullptr && !_pos_sp_triplet_published_invalid_once) {
 			_pos_sp_triplet_published_invalid_once = true;
 			reset_triplets();
-
 		}
 
 		if (_pos_sp_triplet_updated) {
@@ -884,23 +882,16 @@ Navigator::get_cruising_speed()
 float
 Navigator::get_heading_to_target(const matrix::Vector2f &target)
 {
-
-	matrix::Vector2f unit_to_target = target - matrix::Vector2f(get_local_position()->x, get_local_position()->y);
-
-	if (unit_to_target.length() > FLT_EPSILON) {
-		unit_to_target.normalize();
-	}
-
-	// compute yaw from dot product; the sign is given by cross product
-	return acosf(matrix::Vector2f(1.0f, 0.0f) * unit_to_target) * (unit_to_target(1) / fabsf(unit_to_target(1)));
+	const matrix::Vector2f pose(get_local_position()->x, get_local_position()->y);
+	return get_heading_to_target(pose, target);
 }
 
 
 float
-Navigator::get_heading_to_target(const matrix::Vector2f &start, const matrix::Vector2f &target)
+Navigator::get_heading_to_target(const matrix::Vector2f &pose, const matrix::Vector2f &target)
 {
 
-	matrix::Vector2f unit_to_target = target - start;
+	matrix::Vector2f unit_to_target = target - pose;
 
 	if (unit_to_target.length() > FLT_EPSILON) {
 		unit_to_target.normalize();

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -466,9 +466,6 @@ Navigator::task_main()
 					rep->current.alt = get_global_position()->alt;
 				}
 
-				global_to_local(&rep->current);
-				global_to_local(&rep->previous);
-
 				rep->previous.valid = true;
 				rep->current.valid = true;
 				rep->next.valid = false;
@@ -917,30 +914,6 @@ Navigator::get_acceptance_radius(float mission_item_radius)
 }
 
 void
-Navigator::global_to_local(struct position_setpoint_s *sp)
-{
-
-	map_projection_project(get_local_reference_pos(), sp->lat, sp->lon, &sp->x, &sp->y);
-	sp->z = -(sp->alt - get_local_reference_alt());
-
-}
-
-void
-Navigator::global_to_local(struct mission_item_s *item)
-{
-
-	map_projection_project(get_local_reference_pos(), item->lat, item->lon, &item->x, &item->y);
-
-	if (item->altitude_is_relative) {
-		item->z = - item->altitude;
-
-	} else {
-		item->z = - (item->altitude - get_local_reference_alt());
-	}
-
-}
-
-void
 Navigator::mission_item_to_navigator_item(struct navigator_item_s *nav_item, struct mission_item_s *mission_item)
 {
 
@@ -948,9 +921,11 @@ Navigator::mission_item_to_navigator_item(struct navigator_item_s *nav_item, str
 
 	if (mission_item->altitude_is_relative) {
 		nav_item->z = - mission_item->altitude;
+		nav_item->altitude = mission_item->altitude;
 
 	} else {
 		nav_item->z = - (mission_item->altitude - get_local_reference_alt());
+		nav_item->altitude = mission_item->altitude + get_home_position()->alt;
 	}
 
 	nav_item->yaw = mission_item->yaw;
@@ -967,6 +942,7 @@ Navigator::mission_item_to_navigator_item(struct navigator_item_s *nav_item, str
 	nav_item->autocontinue = mission_item->autocontinue;
 	nav_item->disable_mc_yaw = mission_item->disable_mc_yaw;
 	nav_item->vtol_back_transition = mission_item->vtol_back_transition;
+	nav_item->time_inside = mission_item->time_inside;
 
 }
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -919,13 +919,16 @@ Navigator::mission_item_to_navigator_item(struct navigator_item_s *nav_item, str
 
 	map_projection_project(get_local_reference_pos(), mission_item->lat, mission_item->lon, &nav_item->x, &nav_item->y);
 
+	nav_item->lat = mission_item->lat;
+	nav_item->lon = mission_item->lon;
+
 	if (mission_item->altitude_is_relative) {
 		nav_item->z = - mission_item->altitude;
-		nav_item->altitude = mission_item->altitude;
+		nav_item->altitude = mission_item->altitude + get_home_position()->alt;
 
 	} else {
 		nav_item->z = - (mission_item->altitude - get_local_reference_alt());
-		nav_item->altitude = mission_item->altitude + get_home_position()->alt;
+		nav_item->altitude = mission_item->altitude;
 	}
 
 	nav_item->yaw = mission_item->yaw;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -926,6 +926,51 @@ Navigator::global_to_local(struct position_setpoint_s *sp)
 }
 
 void
+Navigator::global_to_local(struct mission_item_s *item)
+{
+
+	map_projection_project(get_local_reference_pos(), item->lat, item->lon, &item->x, &item->y);
+
+	if (item->altitude_is_relative) {
+		item->z = - item->altitude;
+
+	} else {
+		item->z = - (item->altitude - get_local_reference_alt());
+	}
+
+}
+
+void
+Navigator::mission_item_to_navigator_item(struct navigator_item_s *nav_item, struct mission_item_s *mission_item)
+{
+
+	map_projection_project(get_local_reference_pos(), mission_item->lat, mission_item->lon, &nav_item->x, &nav_item->y);
+
+	if (mission_item->altitude_is_relative) {
+		nav_item->z = - mission_item->altitude;
+
+	} else {
+		nav_item->z = - (mission_item->altitude - get_local_reference_alt());
+	}
+
+	nav_item->yaw = mission_item->yaw;
+	nav_item->acceptance_radius = mission_item->acceptance_radius;
+	nav_item->loiter_radius = mission_item->loiter_radius;
+	nav_item->nav_cmd = mission_item->nav_cmd;
+	nav_item->do_jump_mission_index = mission_item->do_jump_mission_index;
+	nav_item->do_jump_repeat_count = mission_item->do_jump_repeat_count;
+	nav_item->do_jump_current_count = mission_item->do_jump_current_count;
+	nav_item->frame = mission_item->frame;
+	nav_item->origin = mission_item->origin;
+	nav_item->loiter_exit_xtrack = mission_item->loiter_exit_xtrack;
+	nav_item->force_heading = mission_item->force_heading;
+	nav_item->autocontinue = mission_item->autocontinue;
+	nav_item->disable_mc_yaw = mission_item->disable_mc_yaw;
+	nav_item->vtol_back_transition = mission_item->vtol_back_transition;
+
+}
+
+void
 Navigator::load_fence_from_file(const char *filename)
 {
 	_geofence.loadFromFile(filename);

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -348,6 +348,15 @@ Navigator::task_main()
 			}
 		}
 
+		/* local position updated */
+		orb_check(_local_pos_sub, &updated);
+
+		if (updated) {
+			local_position_update();
+			local_reference_update();
+		}
+
+
 		/* sensors combined updated */
 		orb_check(_sensor_combined_sub, &updated);
 
@@ -456,6 +465,9 @@ Navigator::task_main()
 					rep->current.lon = get_global_position()->lon;
 					rep->current.alt = get_global_position()->alt;
 				}
+
+				global_to_local(&rep->current);
+				global_to_local(&rep->previous);
 
 				rep->previous.valid = true;
 				rep->current.valid = true;
@@ -902,6 +914,16 @@ Navigator::get_acceptance_radius(float mission_item_radius)
 	}
 
 	return radius;
+}
+
+void
+Navigator::global_to_local(struct position_setpoint_s *sp)
+{
+
+	map_projection_project(get_local_reference_pos(), sp->lat, sp->lon,
+			       &sp->x, &sp->y);
+	sp->z = -(sp->alt - get_local_reference_alt());
+
 }
 
 void

--- a/src/modules/navigator/rcloss.cpp
+++ b/src/modules/navigator/rcloss.cpp
@@ -106,9 +106,6 @@ RCLoss::set_rcl_item()
 
 	switch (_rcl_state) {
 	case RCL_STATE_LOITER: {
-			_navigator_item.lat = _navigator->get_global_position()->lat;
-			_navigator_item.lon = _navigator->get_global_position()->lon;
-			_navigator_item.altitude = _navigator->get_global_position()->alt;
 			_navigator_item.x = _navigator->get_local_position()->x;
 			_navigator_item.y = _navigator->get_local_position()->y;
 			_navigator_item.z = _navigator->get_local_position()->z;

--- a/src/modules/navigator/rcloss.cpp
+++ b/src/modules/navigator/rcloss.cpp
@@ -139,7 +139,7 @@ RCLoss::set_rcl_item()
 	reset_navigator_item_reached();
 
 	/* convert mission item to current position setpoint and make it valid */
-	navigator_apply_limitation(_navigation_item);
+	navigator_apply_limitation(_navigator_item);
 	navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 	pos_sp_triplet->next.valid = false;
 

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -168,8 +168,8 @@ RTL::set_rtl_item()
 	case RTL_STATE_RETURN: {
 			_mission_item.lat = _navigator->get_home_position()->lat;
 			_mission_item.lon = _navigator->get_home_position()->lon;
-			//TODO use local coordinates
-			_navigator->global_to_local(&_mission_item);
+			_mission_item.x = _navigator->get_home_position()->x;
+			_mission_item.y = _navigator->get_home_position()->y;
 			// don't change altitude
 
 			// use home yaw if close to home
@@ -210,10 +210,11 @@ RTL::set_rtl_item()
 	case RTL_STATE_DESCEND: {
 			_mission_item.lat = _navigator->get_home_position()->lat;
 			_mission_item.lon = _navigator->get_home_position()->lon;
+			_mission_item.x = _navigator->get_home_position()->x;
+			_mission_item.y = _navigator->get_home_position()->y;
+			_mission_item.z = _navigator->get_home_position()->z;
 			_mission_item.altitude_is_relative = false;
 			_mission_item.altitude = _navigator->get_home_position()->alt + _param_descend_alt.get();
-			//TODO use local coordinates
-			_navigator->global_to_local(&_mission_item);
 
 			// check if we are already lower - then we will just stay there
 			if (_mission_item.altitude > _navigator->get_global_position()->alt) {
@@ -255,8 +256,8 @@ RTL::set_rtl_item()
 
 			_mission_item.lat = _navigator->get_home_position()->lat;
 			_mission_item.lon = _navigator->get_home_position()->lon;
-			//TODO use local coordinates
-			_navigator->global_to_local(&_mission_item);
+			_mission_item.x = _navigator->get_home_position()->x;
+			_mission_item.y = _navigator->get_home_position()->y;
 
 			// don't change altitude
 			_mission_item.yaw = _navigator->get_home_position()->yaw;

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -136,16 +136,21 @@ RTL::set_rtl_item()
 
 			// if we are close to home we do not climb as high, otherwise we climb to return alt
 			float climb_alt = _navigator->get_home_position()->alt + get_rtl_altitude();
+			float climb_z = - get_rtl_altitude();
 
 			// we are close to home, limit climb to min
 			if (home_dist < _param_rtl_min_dist.get()) {
 				climb_alt = _navigator->get_home_position()->alt + _param_descend_alt.get();
+				climb_z = - _param_descend_alt.get();
 			}
 
 			_mission_item.lat = _navigator->get_global_position()->lat;
 			_mission_item.lon = _navigator->get_global_position()->lon;
+			_mission_item.x = _navigator->get_local_position()->x;
+			_mission_item.y = _navigator->get_local_position()->y;
 			_mission_item.altitude_is_relative = false;
 			_mission_item.altitude = climb_alt;
+			_mission_item.z = climb_z;
 			_mission_item.yaw = NAN;
 			_mission_item.loiter_radius = _navigator->get_loiter_radius();
 			_mission_item.nav_cmd = NAV_CMD_WAYPOINT;
@@ -163,6 +168,8 @@ RTL::set_rtl_item()
 	case RTL_STATE_RETURN: {
 			_mission_item.lat = _navigator->get_home_position()->lat;
 			_mission_item.lon = _navigator->get_home_position()->lon;
+			//TODO use local coordinates
+			_navigator->global_to_local(&_mission_item);
 			// don't change altitude
 
 			// use home yaw if close to home
@@ -205,10 +212,13 @@ RTL::set_rtl_item()
 			_mission_item.lon = _navigator->get_home_position()->lon;
 			_mission_item.altitude_is_relative = false;
 			_mission_item.altitude = _navigator->get_home_position()->alt + _param_descend_alt.get();
+			//TODO use local coordinates
+			_navigator->global_to_local(&_mission_item);
 
 			// check if we are already lower - then we will just stay there
 			if (_mission_item.altitude > _navigator->get_global_position()->alt) {
 				_mission_item.altitude = _navigator->get_global_position()->alt;
+				_mission_item.z = _navigator->get_local_position()->z;
 			}
 
 			_mission_item.yaw = _navigator->get_home_position()->yaw;
@@ -245,6 +255,9 @@ RTL::set_rtl_item()
 
 			_mission_item.lat = _navigator->get_home_position()->lat;
 			_mission_item.lon = _navigator->get_home_position()->lon;
+			//TODO use local coordinates
+			_navigator->global_to_local(&_mission_item);
+
 			// don't change altitude
 			_mission_item.yaw = _navigator->get_home_position()->yaw;
 			_mission_item.loiter_radius = _navigator->get_loiter_radius();

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -210,7 +210,7 @@ RTL::set_rtl_item()
 			_navigator_item.lon = _navigator->get_home_position()->lon;
 			_navigator_item.x = _navigator->get_home_position()->x;
 			_navigator_item.y = _navigator->get_home_position()->y;
-			_navigator_item.z = _navigator->get_home_position()->z;
+			_navigator_item.z = _navigator->get_home_position()->z - _param_descend_alt.get();
 			_navigator_item.altitude = _navigator->get_home_position()->alt + _param_descend_alt.get();
 
 			// check if we are already lower - then we will just stay there

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -282,8 +282,8 @@ RTL::set_rtl_item()
 	reset_navigator_item_reached();
 
 	/* execute command if set. This is required for commands like VTOL transition */
-	if (!item_contains_position(&_navigator_item)) {
-		issue_command(&_navigator_item);
+	if (!item_contains_position(_navigator_item)) {
+		issue_command(_navigator_item);
 	}
 
 	/* convert mission item to current position setpoint and make it valid */

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -84,7 +84,7 @@ RTL::on_activation()
 {
 	set_current_position_item(&_navigator_item);
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-	navigator_apply_limitation(_navigation_item);
+	navigator_apply_limitation(_navigator_item);
 	navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 	pos_sp_triplet->previous.valid = false;
 	pos_sp_triplet->next.valid = false;
@@ -287,7 +287,7 @@ RTL::set_rtl_item()
 	}
 
 	/* convert mission item to current position setpoint and make it valid */
-	navigator_apply_limitation(_navigation_item);
+	navigator_apply_limitation(_navigator_item);
 	navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 	pos_sp_triplet->next.valid = false;
 

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -140,8 +140,10 @@ Takeoff::set_takeoff_position()
 				     "Already higher than takeoff altitude");
 	}
 
+	float lpos_z = - (abs_altitude - _navigator->get_local_reference_alt());
+
 	// set current mission item to takeoff
-	set_takeoff_item(&_mission_item, abs_altitude);
+	set_takeoff_item(&_mission_item, abs_altitude, lpos_z);
 	_navigator->get_mission_result()->reached = false;
 	_navigator->get_mission_result()->finished = false;
 	_navigator->set_mission_result_updated();

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -85,15 +85,15 @@ Takeoff::on_active()
 		// reset the position
 		set_takeoff_position();
 
-	} else if (is_mission_item_reached() && !_navigator->get_mission_result()->finished) {
+	} else if (is_navigator_item_reached() && !_navigator->get_mission_result()->finished) {
 		_navigator->get_mission_result()->finished = true;
 		_navigator->set_mission_result_updated();
 
 		// set loiter item so position controllers stop doing takeoff logic
-		set_loiter_item(&_mission_item);
+		set_loiter_item(&_navigator_item);
 		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-		mission_apply_limitation(_mission_item);
-		mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
+		navigator_apply_limitation(_navigation_item);
+		navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 		_navigator->set_position_setpoint_triplet_updated();
 	}
 }
@@ -143,16 +143,16 @@ Takeoff::set_takeoff_position()
 	float lpos_z = - (abs_altitude - _navigator->get_local_reference_alt());
 
 	// set current mission item to takeoff
-	set_takeoff_item(&_mission_item, abs_altitude, lpos_z);
+	set_takeoff_item(&_navigator_item, abs_altitude, lpos_z);
 	_navigator->get_mission_result()->reached = false;
 	_navigator->get_mission_result()->finished = false;
 	_navigator->set_mission_result_updated();
-	reset_mission_item_reached();
+	reset_navigator_item_reached();
 
 	// convert mission item to current setpoint
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-	mission_apply_limitation(_mission_item);
-	mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
+	navigator_apply_limitation(_navigation_item);
+	navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 	pos_sp_triplet->previous.valid = false;
 	pos_sp_triplet->current.yaw_valid = true;
 	pos_sp_triplet->next.valid = false;

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -92,7 +92,7 @@ Takeoff::on_active()
 		// set loiter item so position controllers stop doing takeoff logic
 		set_loiter_item(&_navigator_item);
 		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-		navigator_apply_limitation(_navigation_item);
+		navigator_apply_limitation(_navigator_item);
 		navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 		_navigator->set_position_setpoint_triplet_updated();
 	}
@@ -147,7 +147,7 @@ Takeoff::set_takeoff_position()
 
 	// convert mission item to current setpoint
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-	navigator_apply_limitation(_navigation_item);
+	navigator_apply_limitation(_navigator_item);
 	navigator_item_to_position_setpoint(_navigator_item, &pos_sp_triplet->current);
 	pos_sp_triplet->previous.valid = false;
 	pos_sp_triplet->current.yaw_valid = true;


### PR DESCRIPTION
We thought it makes sense to create this PR to get an overview of the current state

What has been done:
* mission_item will be handed over to navigator_item (which still has lat/lon/alt, but we wanted to get rid of it -> needs to be checked with fixed wing). That means mission_item is only being used for reading mission information from the dataman. Since the mission_item are being stored, they need to be small whearas the size of the navigator_item does not matter. 
* mc_pos_controller uses local coordinates


What needs to be done:
- [ ] General flight testing (only SITL so far)
- [ ] Fixed wing @dagar can you maybe have a look at that and test?
- [ ] Offboard maybe @mhkabir or @Stifael?
- [ ] LPE needs more testing
- [ ] Check capability for long missions (remains the same so far for MC)
- [ ] Global coordinate functions to local

Anything else?