### PR TITLE
compile with -fno-math-errno

### DIFF
--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -371,6 +371,7 @@ function(px4_add_common_flags)
 		-funsafe-math-optimizations
 		-ffunction-sections
 		-fdata-sections
+		-fno-math-errno
 		${PIC_FLAG}
 		)
 

--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -372,6 +372,7 @@ function(px4_add_common_flags)
 		-ffunction-sections
 		-fdata-sections
 		-fno-math-errno
+		-fmerge-all-constants
 		${PIC_FLAG}
 		)
 


### PR DESCRIPTION
Safer than going straight to -ffast-math (https://github.com/PX4/Firmware/pull/6863). Reduces EKF2 cpu utilization by ~ 1.5%. 


baseline

	   text    data     bss     dec     hex filename
	1394004    4116   24116 1422236  15b39c build_px4fmu-v4_default/src/firmware/nuttx/firmware_nuttx

	 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE 
	   0 Idle Task                  126653 41.310   604/  748   0 (  0)  READY 
	   1 hpwork                      14211  5.301   968/ 1780 192 (192)  w:sig 
	   2 lpwork                       1603  0.515   692/ 1780  50 ( 50)  READY 
	   3 init                        20863  0.000  1672/ 2580 100 (100)  w:sem 
	 346 top                            43  3.092  1288/ 1684 100 (100)  RUN   
	 103 gps                           864  0.294  1024/ 1524 220 (220)  w:sig 
	 150 sensors                     13330  5.007  1464/ 1980 250 (250)  w:sem 
	 152 commander                    5235  1.914  2736/ 3652 140 (140)  w:sig 
	 166 camera_feedback               545  0.147   656/ 1572 115 (115)  w:sem 
	 172 mavlink_if0                 16443  5.964  1720/ 2380 100 (100)  w:sig 
	 173 mavlink_rcv_if0              1160  0.441  1496/ 2140 175 (175)  w:sem 
	 177 mavlink_if1                  4186  1.620  1720/ 2420 100 (100)  READY 
	 178 mavlink_rcv_if1              1207  0.441  1320/ 2140 175 (175)  w:sem 
	 187 mavlink_if2                 11763  4.270  1656/ 2372 100 (100)  w:sig 
	 188 mavlink_rcv_if2              1221  0.662  1320/ 2140 175 (175)  w:sem 
	 222 frsky_telemetry                 5  0.000   560/ 1188 200 (200)  w:sem 
	 345 commander_low_prio             10  0.000   656/ 2996  50 ( 50)  w:sem 
	 238 mavlink_if3                 11232  3.902  1648/ 2388 100 (100)  w:sig 
	 239 mavlink_rcv_if3              1304  0.368  1424/ 2140 175 (175)  w:sem 
	 255 logger                       1418  0.515  3016/ 3532 250 (250)  w:sem 
	 260 log_writer_file                 0  0.000   344/ 1060  60 ( 60)  w:sem 
	 297 ekf2                        44938 17.157  5056/ 5780 250 (250)  w:sem 
	 299 fw_att_control              11454  4.418  1016/ 1476 250 (250)  w:sem 
	 307 fw_pos_ctrl_l1               2924  1.325   992/ 1676 250 (250)  w:sem 
	 311 navigator                     592  0.220   904/ 1772 105 (105)  w:sem 

	Processes: 25 total, 4 running, 21 sleeping
	CPU usage: 57.58% tasks, 1.10% sched, 41.31% idle
	DMA Memory: 5120 total, 0 used 0 peak
	Uptime: 276.368s total, 126.653s idle

	nsh> free
		     total       used       free    largest
	Mem:        233424     202864      30560      26576


-fno-math-errno

	   text    data     bss     dec     hex filename
	1392556    4116   24116 1420788  15adf4 build_px4fmu-v4_default/src/firmware/nuttx/firmware_nuttx

	 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE 
	   0 Idle Task                   29596 43.237   604/  748   0 (  0)  READY 
	   1 hpwork                       3098  5.617   960/ 1780 192 (192)  w:sig 
	   2 lpwork                        442  0.739   692/ 1780  50 ( 50)  w:sig 
	   3 init                        20216  0.000  1672/ 2580 100 (100)  w:sem 
	 360 top                           752  2.956  1296/ 1684 100 (100)  RUN   
	 103 gps                           293  0.295   976/ 1524 220 (220)  w:sem 
	 150 sensors                      2332  4.286  1456/ 1980 250 (250)  w:sem 
	 152 commander                    1104  1.847  2768/ 3652 140 (140)  w:sig 
	 166 camera_feedback               117  0.221   656/ 1572 115 (115)  w:sem 
	 172 mavlink_if0                  3510  6.208  1696/ 2380 100 (100)  w:sig 
	 173 mavlink_rcv_if0               228  0.369  1608/ 2140 175 (175)  w:sem 
	 177 mavlink_if1                   890  1.478  1672/ 2420 100 (100)  READY 
	 178 mavlink_rcv_if1               266  0.443  1320/ 2140 175 (175)  w:sem 
	 187 mavlink_if2                  2556  4.434  1648/ 2372 100 (100)  READY 
	 188 mavlink_rcv_if2               265  0.443  1504/ 2140 175 (175)  w:sem 
	 222 frsky_telemetry                 1  0.000   552/ 1188 200 (200)  w:sem 
	 345 commander_low_prio              2  0.000   592/ 2996  50 ( 50)  w:sem 
	 238 mavlink_if3                  2466  4.434  1648/ 2388 100 (100)  READY 
	 239 mavlink_rcv_if3               259  0.369  1408/ 2140 175 (175)  w:sem 
	 255 logger                        397  0.739  3024/ 3532 250 (250)  w:sem 
	 260 log_writer_file                 0  0.000   344/ 1060  60 ( 60)  w:sem 
	 297 ekf2                         7954 15.521  5056/ 5780 250 (250)  w:sem 
	 299 fw_att_control               1639  3.473   872/ 1476 250 (250)  w:sem 
	 307 fw_pos_ctrl_l1                468  1.182   984/ 1676 250 (250)  w:sem 
	 311 navigator                     101  0.295   784/ 1772 105 (105)  w:sem 

	Processes: 25 total, 5 running, 20 sleeping
	CPU usage: 55.36% tasks, 1.40% sched, 43.24% idle
	DMA Memory: 5120 total, 0 used 0 peak
	Uptime: 60.712s total, 29.597s idle

	nsh> free
		     total       used       free    largest
	Mem:        233424     202864      30560      26704

