### PR TITLE
px4fmu-v4:Insure the discharge of the pins PWM pins on rest.

### DIFF
--- a/src/drivers/boards/px4fmu-v4/px4fmu_init.c
+++ b/src/drivers/boards/px4fmu-v4/px4fmu_init.c
@@ -179,7 +179,7 @@ __EXPORT void board_on_reset(int status)
 	 */
 
 	if (status >= 0) {
-		up_mdelay(6);
+		up_mdelay(400);
 	}
 }
 

--- a/src/drivers/boards/px4fmu-v4/px4fmu_init.c
+++ b/src/drivers/boards/px4fmu-v4/px4fmu_init.c
@@ -165,14 +165,22 @@ __EXPORT void board_peripheral_reset(int ms)
  ************************************************************************************/
 __EXPORT void board_on_reset(int status)
 {
-	UNUSED(status);
 	/* configure the GPIO pins to outputs and keep them low */
+
 	stm32_configgpio(GPIO_GPIO0_OUTPUT);
 	stm32_configgpio(GPIO_GPIO1_OUTPUT);
 	stm32_configgpio(GPIO_GPIO2_OUTPUT);
 	stm32_configgpio(GPIO_GPIO3_OUTPUT);
 	stm32_configgpio(GPIO_GPIO4_OUTPUT);
 	stm32_configgpio(GPIO_GPIO5_OUTPUT);
+
+	/* On resets invoked from system (not boot) insure we establish a low
+	 * output state (discharge the pins) on PWM pins before they become inputs.
+	 */
+
+	if (status >= 0) {
+		up_mdelay(6);
+	}
 }
 
 /************************************************************************************


### PR DESCRIPTION
Addressing https://github.com/PX4/Firmware/issues/7457

On resets invoked from system (not boot) insure we establish a low output state (discharge the pins) on PWM pins before they become inputs.

