### PR TITLE
move -fno-math-errno to nuttx only

### DIFF
--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -371,7 +371,6 @@ function(px4_add_common_flags)
 		-funsafe-math-optimizations
 		-ffunction-sections
 		-fdata-sections
-		-fno-math-errno
 		-fmerge-all-constants
 		${PIC_FLAG}
 		)

--- a/cmake/nuttx/px4_impl_nuttx.cmake
+++ b/cmake/nuttx/px4_impl_nuttx.cmake
@@ -579,6 +579,10 @@ function(px4_os_add_flags)
 		-nostdlib
 		)
 
+	set(added_optimization_flags
+		-fno-math-errno
+		)
+
 	set(added_exe_linker_flags) # none currently
 
 	set(instrument_flags)


### PR DESCRIPTION
Causes param errors on Snapdragon for some reason.

@rogelion