### PR TITLE
cmake remove -fno-math-errno and -fmerge-all-constants

### DIFF
--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -371,7 +371,6 @@ function(px4_add_common_flags)
 		-funsafe-math-optimizations
 		-ffunction-sections
 		-fdata-sections
-		-fmerge-all-constants
 		${PIC_FLAG}
 		)
 

--- a/cmake/nuttx/px4_impl_nuttx.cmake
+++ b/cmake/nuttx/px4_impl_nuttx.cmake
@@ -579,9 +579,7 @@ function(px4_os_add_flags)
 		-nostdlib
 		)
 
-	set(added_optimization_flags
-		-fno-math-errno
-		)
+	set(added_optimization_flags)
 
 	set(added_exe_linker_flags) # none currently
 


### PR DESCRIPTION
Removing these optimization flags entirely for now.

https://github.com/PX4/Firmware/pull/7460