### PR TITLE
ms4525 treat max temperature as an error

### DIFF
--- a/src/drivers/meas_airspeed/meas_airspeed.cpp
+++ b/src/drivers/meas_airspeed/meas_airspeed.cpp
@@ -210,6 +210,13 @@ MEASAirspeed::collect()
 	dp_raw = 0x3FFF & dp_raw;
 	dT_raw = (val[2] << 8) + val[3];
 	dT_raw = (0xFFE0 & dT_raw) >> 5;
+
+	// dT max is almost certainly an invalid reading
+	if (dT_raw == 2047) {
+		perf_count(_comms_errors);
+		return -EAGAIN;
+	}
+
 	float temperature = ((200.0f * dT_raw) / 2047) - 50;
 
 	// Calculate differential pressure. As its centered around 8000


### PR DESCRIPTION
On a FW flight earlier this week with a relatively new AUAV ms4525 differential pressure sensor I noticed it occasionally returning huge negative differential pressure readings accompanied with max temperature readings. They don't register as i2c transfer errors and the status field from the device is valid.

I don't know how hacky this is (I'd still rather fix any underlying problem), but at a minimum we can stop publishing the bogus data and increment the error count.

![imgpsh_fullsize](https://user-images.githubusercontent.com/84712/27511656-fef2cc30-58f7-11e7-8977-4f7c7f7825f9.png)

FlightPlot doesn't display all of them depending on zoom level.