### PR TITLE
AUAV-X2.1 sensors bringup

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -63,18 +63,8 @@ fi
 
 if ver hwcmp AUAV_X21
 then
-	# I2C bus
-	if hmc5883 -C -T start
-	then
-	fi
-
-	# I2C bus
-	if lis3mdl start
-	then
-	fi
-
-	# Internal SPI bus ICM-20602-G is rotated 90 deg yaw
-	if mpu6000 -R 2 -T 20602 start
+	# External I2C bus
+	if hmc5883 -C -T -X start
 	then
 	fi
 


### PR DESCRIPTION
This should only bring up the required sensors for the X2.1. Still needs audit from @pkocmoud to make sure that the correct chip rotation is being set. i.e verify that `-R 2` is the correct chip rotation with respect to the board : `mpu6000 -R 2 -T 20608 start`.

@tubme FYI