### PR TITLE
auav-x21:Delete PX4_I2C_BUS_ONBOARD

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -63,18 +63,8 @@ fi
 
 if ver hwcmp AUAV_X21
 then
-	# I2C bus
-	if hmc5883 -C -T start
-	then
-	fi
-
-	# I2C bus
-	if lis3mdl start
-	then
-	fi
-
-	# Internal SPI bus ICM-20602-G is rotated 90 deg yaw
-	if mpu6000 -R 2 -T 20602 start
+	# External I2C bus
+	if hmc5883 -C -T -X start
 	then
 	fi
 

--- a/src/drivers/boards/auav-x21/board_config.h
+++ b/src/drivers/boards/auav-x21/board_config.h
@@ -111,7 +111,6 @@
 
 /* There is no I2C2 so there is not notion of internal / external*/
 #define PX4_I2C_BUS_EXPANSION 1
-#define PX4_I2C_BUS_ONBOARD   1
 #define PX4_I2C_BUS_LED		PX4_I2C_BUS_EXPANSION
 
 /* Devices not on the onboard bus.


### PR DESCRIPTION
Continuation of https://github.com/PX4/Firmware/pull/7487

I removed the onboard definition. @tubeme Please test this. 