### PR TITLE
/*Airspeed error message clarification*/

### DIFF
--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -411,7 +411,7 @@ static bool airspeedCheck(orb_advert_t *mavlink_log_pub, bool optional, bool rep
 
 	if (fabsf(airspeed.differential_pressure_filtered_pa) > 15.0f && !prearm) {
 		if (report_fail) {
-			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: HIGH AIRSPEED, CHECK CALIBRATION");
+			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: AIRSPEED CALIBRATION BAD OR PITOT UNCOVERED");
 		}
 		success = false;
 		goto out;


### PR DESCRIPTION
In day to day practice, there are two reasons for fabsf(airspeed.differential_pressure_filtered_pa) > 15.0f

1/ The sensor has not been calibrated. In this case, the sensor needs to be calibrated.
2/ It's a windy day, and the operator has powered up the system without covering the pitot tube. In that case, you need to reboot with the pitot cover in place.

The original message ('Check calibration') is ok, but why not be more direct? The user does not have to "check the calibration" - the user has to (a) either calibrate the system in the first place, or (b) not forget the pitot tube cover when powering up the system.