### PR TITLE
/*disable attempted voltage/temp correction?*/

### DIFF
--- a/src/drivers/meas_airspeed/meas_airspeed.cpp
+++ b/src/drivers/meas_airspeed/meas_airspeed.cpp
@@ -236,7 +236,10 @@ MEASAirspeed::collect()
 	float diff_press_pa_raw = diff_press_PSI * PSI_to_Pa;
 
 	// correct for 5V rail voltage if possible
-	voltage_correction(diff_press_pa_raw, temperature);
+	// The stability benefits of the voltage/temp correction are unclear and should be experimentally reconfirmed
+	// The last experimental test of this was in 2014
+	// This voltage/temp correction conflicts with current MS4525DO datasheet 
+	// voltage_correction(diff_press_pa_raw, temperature);
 
 	// the raw value still should be compensated for the known offset
 	diff_press_pa_raw -= _diff_pres_offset;


### PR DESCRIPTION
Back in 2014, through excellent and creative detective work, it was shown that the MS4525DO is somewhat sensitive to VCC and temperature. There was some debate back and forth ("if VCC is sloshing between 4.3 and 5.4V, the airframe has bigger problems etc.") but the correction ended up in the code. Now, three years later, it might be worth revisiting/rethinking this correction.

1/ According to the data sheet, the MS4525DO is temperature compensated throughout -10 ... +85C, and the sensor is also insensitive to +/- 10% VCC changes.

2/ So the code overlaps with what the manufacturer is trying to do inside the device. Are we completely sure that in the intervening 3+ years, MS has not changed their internal V,T compensation code? If they have, we would not know, and all the PX4 code would do would be to _reduce_ the accuracy/stability of the signal, instead of improving it.

3/ The situation is further complicated by the current (2017) airspeed sensor modules, some/many of which have an LDO regulator, so the voltage should be quite stable. This further reduces the need to apply a 2014-era correction, based on three units, to the sensor output of all MS4525DO's that are out there now. 

4/ Anecdotally, for my airframe (so this is not worth much because N = 1), disabling voltage_correction(diff_press_pa_raw, temperature) fixed the "HIGH AIRSPEED" errors I was getting.

5/ If people are sophisticated enough to collect V,T calibration data for _their_ sensor with a thermal chamber, then chances are they will be playing with the firmware anyway, and they can just reenable the correction in the code and use their sensor's actual compensation parameters.

So summarizing, we should either (a) experimentally reconfirm the value of this 2014-era compensation, or (b) work with MS to make sure we really understand the sensor, or (c) simply disable compensation code for now. I vote for (c).