### PR TITLE
WIP: Gazebo 8 support and Mac OS SITL clock skew fixes

### DIFF
--- a/posix-configs/SITL/init/ekf2/standard_vtol
+++ b/posix-configs/SITL/init/ekf2/standard_vtol
@@ -36,7 +36,6 @@ param set MIS_YAW_TMT 10
 param set MPC_ACC_HOR_MAX 2
 param set MPC_ACC_HOR_MAX 2.0
 param set MPC_TKO_SPEED 1.0
-param set MPC_XY_FF 0.1
 param set MPC_XY_P 0.8
 param set MPC_XY_VEL_D 0.005
 param set MPC_XY_VEL_I 0.2


### PR DESCRIPTION
This is work in progress. Gazebo 8 is already supported, Mac OS X timing is not yet entirely resolved.