### PR TITLE
Integrator: fix comparison

### DIFF
--- a/src/drivers/device/integrator.cpp
+++ b/src/drivers/device/integrator.cpp
@@ -105,7 +105,7 @@ Integrator::put(uint64_t timestamp, math::Vector<3> &val, math::Vector<3> &integ
 	_last_integration_time = timestamp;
 
 	// Only do auto reset if auto reset interval is not 0.
-	if (_auto_reset_interval > 0 && (timestamp - _last_reset_time) > _auto_reset_interval) {
+	if (_auto_reset_interval > 0 && (timestamp - _last_reset_time) >= _auto_reset_interval) {
 
 		// apply coning corrections if required
 		if (_coning_comp_on) {


### PR DESCRIPTION
Hello,

As I'm trying to rework the MPU9250 driver for Linux, I've started using the Integrator and I noticed that it's not working as advertised.

This file, https://github.com/PX4/Firmware/blob/master/src/drivers/device/integrator.h#L50 , advertises that with an `auto_reset_interval` set to `4000` it should run at 250 Hz.

Let's look at the following example where a driver is sampling at 1 KHz and desires to output data at 250 Hz.

Let's image the current time is 0 so now = 0
Functions code: https://github.com/PX4/Firmware/blob/master/src/drivers/device/integrator.cpp#L128-L146

# sample 1
call `put_with_interval(interval = 1000, ...)`
```
_last_integration_time == 0 so:
now = 0
_last_integration_time = now = 0
_last_reset_time = now = 0
timestamp = _last_reset_time + interval (1000) = 0 + 1000 = 1000
```
-> `put(...)`
```
_last_integration_time = timestamp = 1000
if (timestamp - last_reset_time(0) > 4000) - no
```

# sample 2
call `put_with_interval(interval = 1000, ...)`
```
timestamp = _last_integration_time + interval (1000) = 2000
```
-> `put(...)`
```
_last_integration_time = timestamp = 2000
if (timestamp - last_reset_time(0) > 4000) - no
```

# sample 3
call `put_with_interval(interval = 1000, ...)`
```
timestamp = _last_integration_time + interval (1000) = 3000
```
-> `put(...)`:
```
_last_integration_time = timestamp = 3000

if (timestamp - last_reset_time(0) > 4000) - no
```

# sample 4
call `put_with_interval(interval = 1000, ...)`
```
timestamp = _last_integration_time + interval (1000) = 4000
```
-> `put(...)`:
```
_last_integration_time = timestamp = 4000

if (timestamp - last_reset_time(0) > 4000) - no because 4000 is not bigger than 4000
```

It will only output data at the fifth sample.
Is this expected? This drops the publish rate to 200 Hz.

Signed-off-by: Nicolae Rosia <nicolae.rosia@gmail.com>