### PR TITLE
Hgw add anchor airframe vehicles

### DIFF
--- a/ROMFS/px4fmu_common/init.d/3033_wingwing
+++ b/ROMFS/px4fmu_common/init.d/3033_wingwing
@@ -2,7 +2,7 @@
 #
 # @name Wing Wing (aka Z-84) Flying Wing
 #
-# @url https://pixhawk.org/platforms/planes/z-84_wing_wing
+# @url https://docs.px4.io/en/framebuild_plane/wing_wing_z84.html
 #
 # @type Flying Wing
 # @class Plane

--- a/ROMFS/px4fmu_common/init.d/4051_s250aq
+++ b/ROMFS/px4fmu_common/init.d/4051_s250aq
@@ -1,6 +1,7 @@
 #!nsh
 #
 # @name Spedix S250AQ
+# @url https://docs.px4.io/en/framebuild_multicopter/spedix_s250_pixracer.html
 #
 # @board px4fmu-v1 exclude
 # @board px4fmu-v2 exclude

--- a/Tools/px4airframes/markdownout.py
+++ b/Tools/px4airframes/markdownout.py
@@ -19,7 +19,6 @@ class MarkdownTablesOutput():
 
         for group in groups:
             if group.GetClass() not in type_set:
-               #result += '\n<span id="type_%s"></span>\n' % group.GetType().lower()
                result += '## %s\n\n' % group.GetClass()
                type_set.add(group.GetClass())
 
@@ -88,6 +87,8 @@ class MarkdownTablesOutput():
                     if maintainer != '':
                         maintainer_entry = '<p>Maintainer: %s</p>' % (maintainer)
                     url = param.GetFieldValue('url')
+                    name_anchor='id="%s_%s_%s"' % (group.GetClass(),group.GetName(),name)
+                    name_anchor=name_anchor.replace(' ','_').lower()
                     name_entry = name
                     if url != '':
                         name_entry = '<a href="%s">%s</a>' % (url, name)
@@ -114,8 +115,8 @@ class MarkdownTablesOutput():
                     else:
                         outputs_entry = ''
 
-                    result += ('<tr>\n <td style="vertical-align: top;">%s</td>\n <td style="vertical-align: top;">%s%s%s</td>\n\n</tr>\n' %
-                        (name_entry, maintainer_entry, airframe_id_entry,
+                    result += ('<tr %s>\n <td style="vertical-align: top;">%s</td>\n <td style="vertical-align: top;">%s%s%s</td>\n\n</tr>\n' %
+                        (name_anchor, name_entry, maintainer_entry, airframe_id_entry,
                         outputs_entry))
 
 

--- a/Tools/px4airframes/markdownout.py
+++ b/Tools/px4airframes/markdownout.py
@@ -28,7 +28,7 @@ class MarkdownTablesOutput():
             image_name = group.GetImageName()
             result += '<div>\n'
             if image_name != 'AirframeUnknown':
-                result += '<img src="../images/airframes/types/%s.svg" width="29%%" style="max-height: 180px;"/>\n' % (image_name)
+                result += '<img src="../../assets/airframes/types/%s.svg" width="29%%" style="max-height: 180px;"/>\n' % (image_name)
 
             # check if all outputs are equal for the group: if so, show them
             # only once

--- a/Tools/px_process_airframes.py
+++ b/Tools/px_process_airframes.py
@@ -63,7 +63,7 @@ def main():
                              " (default FILENAME: airframes.xml)")
     parser.add_argument("-m", "--markdown",
                         nargs='?',
-                        const="airframes.md",
+                        const="airframe_reference.md",
                         metavar="FILENAME",
                         help="Create Markdown file"
                              " (default FILENAME: airframes_reference.md)")

--- a/Tools/px_process_airframes.py
+++ b/Tools/px_process_airframes.py
@@ -66,7 +66,7 @@ def main():
                         const="airframes.md",
                         metavar="FILENAME",
                         help="Create Markdown file"
-                             " (default FILENAME: airframes.md)")
+                             " (default FILENAME: airframes_reference.md)")
     parser.add_argument("-s", "--start-script",
                         nargs='?',
                         const="rc.autostart",


### PR DESCRIPTION
Adds an anchor to every single vehicle, making it possible to link to any vehicle we want, not just vehicle class or group.

Also fixed a couple of vehicles to point to build logs in the docs.px4.io rather than pixhawk.org.