### PR TITLE
EKF: pull in miscellaneous bug fixes

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1393,7 +1393,7 @@ int Ekf2::start()
 	_control_task = px4_task_spawn_cmd("ekf2",
 					   SCHED_DEFAULT,
 					   SCHED_PRIORITY_MAX - 5,
-					   5800,
+					   5900,
 					   (px4_main_t)&Ekf2::task_main_trampoline,
 					   nullptr);
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -763,7 +763,7 @@ void Ekf2::task_main()
 			ev_data.posNED(0) = ev_pos.x;
 			ev_data.posNED(1) = ev_pos.y;
 			ev_data.posNED(2) = ev_pos.z;
-			Quaternion q(ev_att.q);
+			Quatf q(ev_att.q);
 			ev_data.quat = q;
 
 			// position measurement error from parameters. TODO : use covariances from topic


### PR DESCRIPTION
Incorporates the following changes.

Fixes failure to switch between baro and GPS height sources after a primary height sensor timeout:
https://github.com/PX4/ecl/pull/289

Fixes failure to properly estimate wind for planes that was inadvertently introduced with the copter wind estimation feature :
https://github.com/PX4/ecl/pull/291

Enables EKF to use baro height on startup if range finder height use is specified, but sensor is out of range:
https://github.com/PX4/ecl/pull/292

Change to use of typedefs compatible with the Matrix library
https://github.com/PX4/ecl/pull/283

Prevents the possibility of IMU delta velocity bias states variances from collapsing to a value that can cause estimation failures and baro and/or GPS resets.
https://github.com/PX4/ecl/pull/288