### PR TITLE
PixHawk3 v4pro - Start mpu6000 driver with a +/-16g range

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -335,12 +335,12 @@ if ver hwcmp PX4FMU_V4PRO
 then
 
 	# Internal SPI bus ICM-20608-G
-	if mpu6000 -R 2 -T 20608 start
+	if mpu6000 -R 2 -T 20608 -a 16 start
 	then
 	fi
 
 	# Internal SPI bus ICM-20602
-	if mpu6000 -R 2 -T 20602 start
+	if mpu6000 -R 2 -T 20602 -a 16 start
 	then
 	fi
 


### PR DESCRIPTION
Default range when the MPU600 is started is +/-8g. 
On the PixHawk3 (v4Pro target), we need both MPU9k and ICM-20602 at +/-16g.