### PR TITLE
Camera trigger: Support triggering one image immediately.

### DIFF
--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -601,6 +601,12 @@ CameraTrigger::cycle_trampoline(void *arg)
 				}
 			}
 
+			// Trigger once immediately if param is set
+			if (cmd.param3 > 0.0f) {
+				// Schedule shot
+				trig->_one_shot = true;
+			}
+
 			cmd_result = vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED;
 
 		} else if (cmd.command == vehicle_command_s::VEHICLE_CMD_DO_SET_CAM_TRIGG_INTERVAL) {


### PR DESCRIPTION
This allows to re-enable the distance trigger and immediately take a picture. This is helpful to ensure survey areas are covered on entry and exit.

@DonLakeFlyer I will try to add this to SITL in the weekend so it becomes easy to test.