### PR TITLE
calibration small improvements

### DIFF
--- a/msg/airspeed.msg
+++ b/msg/airspeed.msg
@@ -3,4 +3,3 @@ float32 true_airspeed_m_s		# true filtered airspeed in meters per second, -1 if 
 float32 true_airspeed_unfiltered_m_s	# true airspeed in meters per second, -1 if unknown
 float32 air_temperature_celsius		# air temperature in degrees celsius, -1000 if unknown
 float32 confidence			# confidence value from 0 to 1 for this sensor
-float32 differential_pressure_filtered_pa # filtered differential pressure, can be negative

--- a/src/drivers/ets_airspeed/ets_airspeed.cpp
+++ b/src/drivers/ets_airspeed/ets_airspeed.cpp
@@ -154,12 +154,12 @@ ETSAirspeed::collect()
 		return ret;
 	}
 
-	uint16_t diff_pres_pa_raw = val[1] << 8 | val[0];
+	float diff_pres_pa_raw = (float)(val[1] << 8 | val[0]);
 
 	differential_pressure_s report;
 	report.timestamp = hrt_absolute_time();
 
-	if (diff_pres_pa_raw == 0) {
+	if (diff_pres_pa_raw < FLT_EPSILON) {
 		// a zero value indicates no measurement
 		// since the noise floor has been arbitrarily killed
 		// it defeats our stuck sensor detection - the best we

--- a/src/modules/commander/PreflightCheck.h
+++ b/src/modules/commander/PreflightCheck.h
@@ -72,16 +72,16 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkMag, bool checkAcc,
     bool checkGyro, bool checkBaro, bool checkAirspeed, bool checkRC, bool checkGNSS,
     bool checkDynamic, bool isVTOL, bool reportFailures, bool prearm, hrt_abstime time_since_boot);
 
-const unsigned max_mandatory_gyro_count = 1;
-const unsigned max_optional_gyro_count = 3;
+static constexpr unsigned max_mandatory_gyro_count = 1;
+static constexpr unsigned max_optional_gyro_count = 3;
 
-const unsigned max_mandatory_accel_count = 1;
-const unsigned max_optional_accel_count = 3;
+static constexpr unsigned max_mandatory_accel_count = 1;
+static constexpr unsigned max_optional_accel_count = 3;
 
-const unsigned max_mandatory_mag_count = 1;
-const unsigned max_optional_mag_count = 4;
+static constexpr unsigned max_mandatory_mag_count = 1;
+static constexpr unsigned max_optional_mag_count = 4;
 
-const unsigned max_mandatory_baro_count = 1;
-const unsigned max_optional_baro_count = 1;
+static constexpr unsigned max_mandatory_baro_count = 1;
+static constexpr unsigned max_optional_baro_count = 1;
 
 }

--- a/src/modules/commander/airspeed_calibration.cpp
+++ b/src/modules/commander/airspeed_calibration.cpp
@@ -167,7 +167,7 @@ int do_airspeed_calibration(orb_advert_t *mavlink_log_pub)
 
 	if (PX4_ISFINITE(diff_pres_offset)) {
 
-		int  fd_scale = px4_open(AIRSPEED0_DEVICE_PATH, 0);
+		int fd_scale = px4_open(AIRSPEED0_DEVICE_PATH, 0);
 		airscale.offset_pa = diff_pres_offset;
 		if (fd_scale > 0) {
 			if (PX4_OK != px4_ioctl(fd_scale, AIRSPEEDIOCSSCALE, (long unsigned int)&airscale)) {

--- a/src/modules/commander/calibration_routines.cpp
+++ b/src/modules/commander/calibration_routines.cpp
@@ -759,6 +759,7 @@ calibrate_return calibrate_from_orientation(orb_advert_t *mavlink_log_pub,
 		/* inform user about already handled side */
 		if (side_data_collected[orient]) {
 			orientation_failures++;
+			set_tune(TONE_NOTIFY_NEGATIVE_TUNE);
 			calibration_log_info(mavlink_log_pub, "[cal] %s side already completed", detect_orientation_str(orient));
 			usleep(20000);
 			continue;
@@ -784,8 +785,10 @@ calibrate_return calibrate_from_orientation(orb_advert_t *mavlink_log_pub,
 
 		// Note that this side is complete
 		side_data_collected[orient] = true;
+
 		// output neutral tune
 		set_tune(TONE_NOTIFY_NEUTRAL_TUNE);
+
 		// temporary priority boost for the white blinking led to come trough
 		rgbled_set_color_and_mode(led_control_s::COLOR_WHITE, led_control_s::MODE_BLINK_FAST, 3, 1);
 		usleep(200000);

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1686,6 +1686,8 @@ int commander_thread_main(int argc, char *argv[])
 		checkAirspeed = true;
 	}
 
+	commander_boot_timestamp = hrt_absolute_time();
+
 	// Run preflight check
 	int32_t rc_in_off = 0;
 	bool hotplug_timeout = hrt_elapsed_time(&commander_boot_timestamp) > HOTPLUG_SENS_TIMEOUT;
@@ -1721,8 +1723,6 @@ int commander_thread_main(int argc, char *argv[])
 	int32_t rc_arm_hyst = 100;
 	param_get(_param_rc_arm_hyst, &rc_arm_hyst);
 	rc_arm_hyst *= COMMANDER_MONITORING_LOOPSPERMSEC;
-
-	commander_boot_timestamp = hrt_absolute_time();
 
 	transition_result_t arming_ret;
 

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -55,11 +55,12 @@
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_accel.h>
 #include <drivers/drv_gyro.h>
-#include <uORB/topics/sensor_combined.h>
 #include <drivers/drv_mag.h>
+#include <drivers/drv_tone_alarm.h>
 #include <systemlib/mavlink_log.h>
 #include <systemlib/param/param.h>
 #include <systemlib/err.h>
+#include <uORB/topics/sensor_combined.h>
 
 static const char *sensor_name = "mag";
 static constexpr unsigned max_mags = 4;
@@ -116,17 +117,17 @@ int do_mag_calibration(orb_advert_t *mavlink_log_pub)
 	// reset the learned EKF mag in-flight bias offsets which have been learned for the previous
 	//  sensor calibration and will be invalidated by a new sensor calibration
 	(void)sprintf(str, "EKF2_MAGBIAS_X");
-	result = param_set(param_find(str), &mscale_null.x_offset);
+	result = param_set_no_notification(param_find(str), &mscale_null.x_offset);
 	if (result != PX4_OK) {
 		PX4_ERR("unable to reset %s", str);
 	}
 	(void)sprintf(str, "EKF2_MAGBIAS_Y");
-	result = param_set(param_find(str), &mscale_null.y_offset);
+	result = param_set_no_notification(param_find(str), &mscale_null.y_offset);
 	if (result != PX4_OK) {
 		PX4_ERR("unable to reset %s", str);
 	}
 	(void)sprintf(str, "EKF2_MAGBIAS_Z");
-	result = param_set(param_find(str), &mscale_null.z_offset);
+	result = param_set_no_notification(param_find(str), &mscale_null.z_offset);
 	if (result != PX4_OK) {
 		PX4_ERR("unable to reset %s", str);
 	}
@@ -150,48 +151,50 @@ int do_mag_calibration(orb_advert_t *mavlink_log_pub)
 
 #else
 		(void)sprintf(str, "CAL_MAG%u_XOFF", cur_mag);
-		result = param_set(param_find(str), &mscale_null.x_offset);
+		result = param_set_no_notification(param_find(str), &mscale_null.x_offset);
 
 		if (result != PX4_OK) {
 			PX4_ERR("unable to reset %s", str);
 		}
 
 		(void)sprintf(str, "CAL_MAG%u_YOFF", cur_mag);
-		result = param_set(param_find(str), &mscale_null.y_offset);
+		result = param_set_no_notification(param_find(str), &mscale_null.y_offset);
 
 		if (result != PX4_OK) {
 			PX4_ERR("unable to reset %s", str);
 		}
 
 		(void)sprintf(str, "CAL_MAG%u_ZOFF", cur_mag);
-		result = param_set(param_find(str), &mscale_null.z_offset);
+		result = param_set_no_notification(param_find(str), &mscale_null.z_offset);
 
 		if (result != PX4_OK) {
 			PX4_ERR("unable to reset %s", str);
 		}
 
 		(void)sprintf(str, "CAL_MAG%u_XSCALE", cur_mag);
-		result = param_set(param_find(str), &mscale_null.x_scale);
+		result = param_set_no_notification(param_find(str), &mscale_null.x_scale);
 
 		if (result != PX4_OK) {
 			PX4_ERR("unable to reset %s", str);
 		}
 
 		(void)sprintf(str, "CAL_MAG%u_YSCALE", cur_mag);
-		result = param_set(param_find(str), &mscale_null.y_scale);
+		result = param_set_no_notification(param_find(str), &mscale_null.y_scale);
 
 		if (result != PX4_OK) {
 			PX4_ERR("unable to reset %s", str);
 		}
 
 		(void)sprintf(str, "CAL_MAG%u_ZSCALE", cur_mag);
-		result = param_set(param_find(str), &mscale_null.z_scale);
+		result = param_set_no_notification(param_find(str), &mscale_null.z_scale);
 
 		if (result != PX4_OK) {
 			PX4_ERR("unable to reset %s", str);
 		}
 
 #endif
+
+		param_notify_changes();
 
 #ifdef __PX4_NUTTX
 		// Attempt to open mag
@@ -339,6 +342,9 @@ static calibrate_return mag_calibration_worker(detect_orientation_return orienta
 	unsigned int calibration_counter_side;
 
 	mag_worker_data_t *worker_data = (mag_worker_data_t *)(data);
+
+	// notify user to start rotating
+	set_tune(TONE_SINGLE_BEEP_TUNE);
 
 	calibration_log_info(worker_data->mavlink_log_pub, "[cal] Rotate vehicle around the detected orientation");
 	calibration_log_info(worker_data->mavlink_log_pub, "[cal] Continue rotation for %s %u s",
@@ -530,8 +536,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 
 	calibration_sides = 0;
 
-	for (unsigned i = 0; i < (sizeof(worker_data.side_data_collected) /
-				  sizeof(worker_data.side_data_collected[0])); i++) {
+	for (unsigned i = 0; i < (sizeof(worker_data.side_data_collected) / sizeof(worker_data.side_data_collected[0])); i++) {
 
 		if ((cal_mask & (1 << i)) > 0) {
 			// mark as missing
@@ -869,12 +874,10 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 
 					} else {
 						calibration_log_info(mavlink_log_pub, "[cal] mag #%u off: x:%.2f y:%.2f z:%.2f Ga",
-								     cur_mag,
-								     (double)mscale.x_offset, (double)mscale.y_offset, (double)mscale.z_offset);
+								     cur_mag, (double)mscale.x_offset, (double)mscale.y_offset, (double)mscale.z_offset);
 #ifndef __PX4_QURT
 						calibration_log_info(mavlink_log_pub, "[cal] mag #%u scale: x:%.2f y:%.2f z:%.2f",
-								     cur_mag,
-								     (double)mscale.x_scale, (double)mscale.y_scale, (double)mscale.z_scale);
+								     cur_mag, (double)mscale.x_scale, (double)mscale.y_scale, (double)mscale.z_scale);
 #endif
 						usleep(200000);
 					}

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -286,14 +286,13 @@ Navigator::task_main()
 			/* timed out - periodic check for _task_should_exit, etc. */
 			if (global_pos_available_once) {
 				global_pos_available_once = false;
-				PX4_WARN("global position timeout");
 			}
 
 			/* Let the loop run anyway, don't do `continue` here. */
 
 		} else if (pret < 0) {
 			/* this is undesirable but not much we can do - might want to flag unhappy status */
-			PX4_ERR("nav: poll error %d, %d", pret, errno);
+			PX4_ERR("poll error %d, %d", pret, errno);
 			usleep(10000);
 			continue;
 

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -102,7 +102,7 @@ RTL::on_activation()
 	/* for safety reasons don't go into RTL if landed */
 	if (_navigator->get_land_detected()->landed) {
 		_rtl_state = RTL_STATE_LANDED;
-		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Already landed, not executing RTL");
+		mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "Already landed, not executing RTL");
 
 		/* if lower than return altitude, climb up first */
 
@@ -166,9 +166,9 @@ RTL::set_rtl_item()
 			_mission_item.autocontinue = true;
 			_mission_item.origin = ORIGIN_ONBOARD;
 
-			mavlink_log_info(_navigator->get_mavlink_log_pub(), "RTL: climb to %d m (%d m above home)",
-					 (int)(climb_alt),
-					 (int)(climb_alt - _navigator->get_home_position()->alt));
+			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: climb to %d m (%d m above home)",
+						     (int)(climb_alt),
+						     (int)(climb_alt - _navigator->get_home_position()->alt));
 			break;
 		}
 
@@ -200,9 +200,9 @@ RTL::set_rtl_item()
 			_mission_item.autocontinue = true;
 			_mission_item.origin = ORIGIN_ONBOARD;
 
-			mavlink_log_info(_navigator->get_mavlink_log_pub(), "RTL: return at %d m (%d m above home)",
-					 (int)(_mission_item.altitude),
-					 (int)(_mission_item.altitude - _navigator->get_home_position()->alt));
+			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: return at %d m (%d m above home)",
+						     (int)(_mission_item.altitude),
+						     (int)(_mission_item.altitude - _navigator->get_home_position()->alt));
 			break;
 		}
 
@@ -246,9 +246,9 @@ RTL::set_rtl_item()
 			/* disable previous setpoint to prevent drift */
 			pos_sp_triplet->previous.valid = false;
 
-			mavlink_log_info(_navigator->get_mavlink_log_pub(), "RTL: descend to %d m (%d m above home)",
-					 (int)(_mission_item.altitude),
-					 (int)(_mission_item.altitude - _navigator->get_home_position()->alt));
+			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: descend to %d m (%d m above home)",
+						     (int)(_mission_item.altitude),
+						     (int)(_mission_item.altitude - _navigator->get_home_position()->alt));
 			break;
 		}
 
@@ -269,11 +269,11 @@ RTL::set_rtl_item()
 			_navigator->set_can_loiter_at_sp(true);
 
 			if (autoland && (get_time_inside(_mission_item) > FLT_EPSILON)) {
-				mavlink_log_info(_navigator->get_mavlink_log_pub(), "RTL: loiter %.1fs",
-						 (double)get_time_inside(_mission_item));
+				mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: loiter %.1fs",
+							     (double)get_time_inside(_mission_item));
 
 			} else {
-				mavlink_log_info(_navigator->get_mavlink_log_pub(), "RTL: completed, loiter");
+				mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: completed, loiter");
 			}
 
 			break;
@@ -283,14 +283,14 @@ RTL::set_rtl_item()
 			set_land_item(&_mission_item, false);
 			_mission_item.yaw = _navigator->get_home_position()->yaw;
 
-			mavlink_log_info(_navigator->get_mavlink_log_pub(), "RTL: land at home");
+			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: land at home");
 			break;
 		}
 
 	case RTL_STATE_LANDED: {
 			set_idle_item(&_mission_item);
 
-			mavlink_log_info(_navigator->get_mavlink_log_pub(), "RTL: completed, landed");
+			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: completed, landed");
 			break;
 		}
 

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -37,25 +37,18 @@
  * @author Anton Babushkin <anton.babushkin@me.com>
  */
 
-#include <string.h>
-#include <stdlib.h>
-#include <math.h>
-#include <fcntl.h>
-#include <float.h>
+#include "rtl.h"
+#include "navigator.h"
 
-#include <systemlib/mavlink_log.h>
-#include <systemlib/err.h>
 #include <geo/geo.h>
-
-#include <uORB/uORB.h>
-#include <navigator/navigation.h>
+#include <mathlib/mathlib.h>
+#include <systemlib/err.h>
+#include <systemlib/mavlink_log.h>
 #include <uORB/topics/home_position.h>
 #include <uORB/topics/vtol_vehicle_status.h>
+#include <uORB/uORB.h>
 
-#include "navigator.h"
-#include "rtl.h"
-
-#define DELAY_SIGMA	0.01f
+static constexpr float DELAY_SIGMA = 0.01f;
 
 RTL::RTL(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name),
@@ -68,12 +61,9 @@ RTL::RTL(Navigator *navigator, const char *name) :
 {
 	/* load initial params */
 	updateParams();
+
 	/* initial reset */
 	on_inactive();
-}
-
-RTL::~RTL()
-{
 }
 
 void
@@ -86,8 +76,7 @@ RTL::on_inactive()
 float
 RTL::get_rtl_altitude()
 {
-	return (_param_return_alt.get() < _navigator->get_land_detected()->alt_max) ? _param_return_alt.get() :
-	       _navigator->get_land_detected()->alt_max;
+	return math::min(_param_return_alt.get(), _navigator->get_land_detected()->alt_max);
 }
 
 void
@@ -102,19 +91,17 @@ RTL::on_activation()
 	/* for safety reasons don't go into RTL if landed */
 	if (_navigator->get_land_detected()->landed) {
 		_rtl_state = RTL_STATE_LANDED;
-		mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "Already landed, not executing RTL");
+
+	} else if (_navigator->get_global_position()->alt < (_navigator->get_home_position()->alt + get_rtl_altitude())) {
 
 		/* if lower than return altitude, climb up first */
-
-	} else if (_navigator->get_global_position()->alt < (_navigator->get_home_position()->alt
-			+ get_rtl_altitude())) {
 		_rtl_state = RTL_STATE_CLIMB;
 
-		/* otherwise go straight to return */
-
 	} else {
-		/* set altitude setpoint to current altitude */
+		/* otherwise go straight to return */
 		_rtl_state = RTL_STATE_RETURN;
+
+		/* set altitude setpoint to current altitude */
 		_mission_item.altitude_is_relative = false;
 		_mission_item.altitude = _navigator->get_global_position()->alt;
 	}
@@ -289,8 +276,6 @@ RTL::set_rtl_item()
 
 	case RTL_STATE_LANDED: {
 			set_idle_item(&_mission_item);
-
-			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: completed, landed");
 			break;
 		}
 

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -57,14 +57,11 @@ class RTL : public MissionBlock
 {
 public:
 	RTL(Navigator *navigator, const char *name);
+	~RTL() = default;
 
-	~RTL();
-
-	virtual void on_inactive();
-
-	virtual void on_activation();
-
-	virtual void on_active();
+	void on_inactive() override;
+	void on_activation() override;
+	void on_active() override;
 
 private:
 	/**

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -395,7 +395,6 @@ Sensors::diff_pres_poll(struct sensor_combined_s &raw)
 						   _voted_sensors_update.baro_pressure(), air_temperature_celsius));
 
 		_airspeed.air_temperature_celsius = air_temperature_celsius;
-		_airspeed.differential_pressure_filtered_pa = _diff_pres.differential_pressure_filtered_pa;
 
 		int instance;
 		orb_publish_auto(ORB_ID(airspeed), &_airspeed_pub, &_airspeed, &instance, ORB_PRIO_DEFAULT);


### PR DESCRIPTION
 - allow eagle tree differential pressure to be negative (for tube swap)
 - don't copy differential_pressure into airspeed when we can check it directly (both are logged)
 - fix commander timestamp bug (causes incorrect SENSORS NOT READY message at boot)
 - calibration add additional tunes for rotation start (single beep) and repeated side (negative) to make it easier to calibrate without watching QGC
 - navigator add RTL mavlink messages to log and don't report global position timeout (this is a different timeout than the rest of the system and confuses people)