### PR TITLE
VTOL pusher assist: return vehicle to level position

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -389,8 +389,8 @@ void Standard::update_mc_state()
 		_pusher_throttle = (sinf(-pitch_forward) - sinf(_params_standard.down_pitch_max))
 				   * _v_att_sp->thrust * _params_standard.forward_thrust_scale;
 
-		// limit desired pitch
-		float pitch_new = -_params_standard.down_pitch_max;
+		// return the vehicle to level position
+		float pitch_new = 0;
 
 		// create corrected desired body z axis in heading frame
 		matrix::Dcmf R_tmp = matrix::Eulerf(roll_new, pitch_new, 0.0f);


### PR DESCRIPTION
This PR reverts the pusher assist behavior to returning level when the pusher activates.
Initially i had changed this to keep the vehicle at the maximum tilt angle so it would have some failsafe behavior if there was no actuation on the pusher. But after more testing it seems that this puts the vehicle in a very awkward position to cruise.

@PX4TestFlights please help me test this on a VTOL in MC mode by setting
VT_DWN_PITCH_MAX: 5
VT_FWD_THRUST_SC: 1.5

@LorenzMeier if this passes review and testing in time i would very much like to get this in 1.6.4

@dagar @MaEtUgR we need to look at failsafing this. currently activating pusher assist and having a reversed spinning pusher could result in a fly-away