### PR TITLE
FW landing abort use reposition

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1466,15 +1466,12 @@ FixedwingPositionControl::handle_command()
 {
 	if (_vehicle_command.command == vehicle_command_s::VEHICLE_CMD_DO_GO_AROUND) {
 		// only abort landing before point of no return (horizontal and vertical)
-		if (_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
+		if (_control_mode.flag_control_auto_enabled &&
+		    _pos_sp_triplet.current.valid &&
+		    _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
 
-			if (_land_noreturn_vertical) {
-				mavlink_log_info(&_mavlink_log_pub, "Landing, can't abort after flare");
-
-			} else {
-				_fw_pos_ctrl_status.abort_landing = true;
-				mavlink_log_info(&_mavlink_log_pub, "Landing, aborted");
-			}
+			_fw_pos_ctrl_status.abort_landing = true;
+			mavlink_log_critical(&_mavlink_log_pub, "Landing, aborted");
 		}
 	}
 }

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -510,12 +510,12 @@ MissionBlock::item_contains_position(const struct mission_item_s *item)
 	       item->nav_cmd == NAV_CMD_VTOL_LAND;
 }
 
-void
+bool
 MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *item, struct position_setpoint_s *sp)
 {
 	/* don't change the setpoint for non-position items */
 	if (!item_contains_position(item)) {
-		return;
+		return false;
 	}
 
 	sp->lat = item->lat;
@@ -601,6 +601,8 @@ MissionBlock::mission_item_to_position_setpoint(const struct mission_item_s *ite
 	}
 
 	sp->valid = true;
+
+	return sp->valid;
 }
 
 void

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -86,7 +86,7 @@ protected:
 	 * @param the mission item to convert
 	 * @param the position setpoint that needs to be set
 	 */
-	void mission_item_to_position_setpoint(const mission_item_s *item, position_setpoint_s *sp);
+	bool mission_item_to_position_setpoint(const mission_item_s *item, position_setpoint_s *sp);
 
 	/**
 	 * Set previous position setpoint to current setpoint

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -88,7 +88,7 @@ public:
 	 *
 	 * @return		OK on success.
 	 */
-	int			start();
+	int		start();
 
 	/**
 	 * Display the navigator status.

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -467,15 +467,15 @@ Navigator::task_main()
 				int land_start = _mission.find_offboard_land_start();
 
 				if (land_start != -1) {
-					vehicle_command_s vcmd = {};
-					vcmd.target_system = get_vstatus()->system_id;
-					vcmd.target_component = get_vstatus()->component_id;
-					vcmd.command = vehicle_command_s::VEHICLE_CMD_MISSION_START;
-					vcmd.param1 = land_start;
-					vcmd.param2 = 0;
+					vehicle_command_s cmd_mission_start = {};
+					cmd_mission_start.timestamp = hrt_absolute_time();
+					cmd_mission_start.target_system = get_vstatus()->system_id;
+					cmd_mission_start.target_component = get_vstatus()->component_id;
+					cmd_mission_start.command = vehicle_command_s::VEHICLE_CMD_MISSION_START;
+					cmd_mission_start.param1 = land_start;
+					cmd_mission_start.param2 = 0;
 
-					vcmd.timestamp = hrt_absolute_time();
-					publish_vehicle_cmd(vcmd);
+					publish_vehicle_cmd(cmd_mission_start);
 
 				} else {
 					PX4_WARN("planned landing not available");

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -75,7 +75,7 @@ private:
 	void		advance_rtl();
 
 	/**
-	 * Get rtl altitude
+	 * Get RTL altitude
 	 */
 	float 		get_rtl_altitude();
 
@@ -89,7 +89,7 @@ private:
 		RTL_STATE_LOITER,
 		RTL_STATE_LAND,
 		RTL_STATE_LANDED,
-	} _rtl_state;
+	} _rtl_state{RTL_STATE_NONE};
 
 	control::BlockParamFloat _param_return_alt;
 	control::BlockParamFloat _param_min_loiter_alt;


### PR DESCRIPTION
This places the vehicle in HOLD positioned above the landing waypoint with the mission index reset to the start of landing rather than overriding the current position setpoint, but staying in AUTO MISSION. This makes it safer to modify the existing landing mission without immediately being redirected at mission sync.

Tested as part of a larger change, but will test again in isolation.