### PR TITLE
WIP RTL use mission landing

### DIFF
--- a/msg/mission_result.msg
+++ b/msg/mission_result.msg
@@ -9,6 +9,7 @@ bool warning			# true if mission is valid, but has potentially problematic items
 bool reached			# true if mission has been reached
 bool finished			# true if mission has been completed
 bool failure			# true if the mission cannot continue or be completed for some reason
+bool landing			# true if mission is currently landing
 
 bool stay_in_failsafe		# true if the commander should not switch out of the failsafe mode
 bool flight_termination		# true if the navigator demands a flight termination from the commander app

--- a/msg/mission_result.msg
+++ b/msg/mission_result.msg
@@ -4,7 +4,7 @@ uint32 seq_reached		# Sequence of the mission item which has been reached
 uint32 seq_current		# Sequence of the current mission item
 uint32 seq_total		# Total number of mission items
 
-bool valid			# true if mission is valid
+bool valid				# true if mission is valid
 bool warning			# true if mission is valid, but has potentially problematic items leading to safety warnings
 bool reached			# true if mission has been reached
 bool finished			# true if mission has been completed

--- a/src/modules/dataman/dataman.h
+++ b/src/modules/dataman/dataman.h
@@ -54,7 +54,7 @@ typedef enum {
 	DM_KEY_SAFE_POINTS = 0,		/* Safe points coordinates, safe point 0 is home point */
 	DM_KEY_FENCE_POINTS,		/* Fence vertex coordinates */
 	DM_KEY_WAYPOINTS_OFFBOARD_0,	/* Mission way point coordinates sent over mavlink */
-	DM_KEY_WAYPOINTS_OFFBOARD_1,	/* (alernate between 0 and 1) */
+	DM_KEY_WAYPOINTS_OFFBOARD_1,	/* (alternate between 0 and 1) */
 	DM_KEY_WAYPOINTS_ONBOARD,	/* Mission way point coordinates generated onboard */
 	DM_KEY_MISSION_STATE,		/* Persistent mission state */
 	DM_KEY_COMPAT,

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -60,7 +60,6 @@
 #include <drivers/device/ringbuffer.h>
 
 #include <uORB/uORB.h>
-#include <uORB/topics/mission.h>
 #include <uORB/topics/mission_result.h>
 #include <uORB/topics/telemetry_status.h>
 

--- a/src/modules/navigator/datalinkloss.cpp
+++ b/src/modules/navigator/datalinkloss.cpp
@@ -48,7 +48,6 @@
 #include <navigator/navigation.h>
 
 #include <uORB/uORB.h>
-#include <uORB/topics/mission.h>
 #include <uORB/topics/home_position.h>
 
 #include "navigator.h"

--- a/src/modules/navigator/enginefailure.cpp
+++ b/src/modules/navigator/enginefailure.cpp
@@ -47,7 +47,6 @@
 #include <navigator/navigation.h>
 
 #include <uORB/uORB.h>
-#include <uORB/topics/mission.h>
 
 #include "navigator.h"
 #include "enginefailure.h"

--- a/src/modules/navigator/gpsfailure.cpp
+++ b/src/modules/navigator/gpsfailure.cpp
@@ -48,7 +48,6 @@
 #include <navigator/navigation.h>
 
 #include <uORB/uORB.h>
-#include <uORB/topics/mission.h>
 #include <uORB/topics/home_position.h>
 
 #include "navigator.h"

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -92,6 +92,8 @@ public:
 
 	int find_offboard_land_start();
 
+	bool land();
+
 private:
 	/**
 	 * Update onboard mission topic
@@ -240,6 +242,7 @@ private:
 	control::BlockParamInt _param_yawmode;
 	control::BlockParamInt _param_force_vtol;
 	control::BlockParamFloat _param_fw_climbout_diff;
+	control::BlockParamInt _param_rtl_land_type;
 
 	struct mission_s _onboard_mission {};
 	struct mission_s _offboard_mission {};
@@ -247,6 +250,8 @@ private:
 	int _current_onboard_mission_index{-1};
 	int _current_offboard_mission_index{-1};
 	bool _need_takeoff{true};					/**< if true, then takeoff must be performed before going to the first waypoint (if needed) */
+
+	int _land_start_index{INT16_MAX};
 
 	enum {
 		MISSION_TYPE_NONE,

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -69,7 +69,7 @@ class Mission : public MissionBlock
 {
 public:
 	Mission(Navigator *navigator, const char *name);
-	~Mission() override = default;
+	~Mission() override;
 
 	void on_inactive() override;
 	void on_activation() override;
@@ -88,22 +88,19 @@ public:
 		MISSION_YAWMODE_MAX = 4
 	};
 
-	bool set_current_offboard_mission_index(unsigned index);
+	bool set_current_mission_index(unsigned index);
 
 	int find_offboard_land_start();
 
 	bool land();
 
-private:
-	/**
-	 * Update onboard mission topic
-	 */
-	void update_onboard_mission();
+	void abort_landing();
 
+private:
 	/**
 	 * Update offboard mission topic
 	 */
-	void update_offboard_mission();
+	bool update_mission();
 
 	/**
 	 * Move on to next mission item or switch to loiter
@@ -165,11 +162,6 @@ private:
 	 */
 	void cruising_speed_sp_update();
 
-	/**
-	 * Abort landing
-	 */
-	void do_abort_landing();
-
 	float get_absolute_altitude_for_item(struct mission_item_s &mission_item);
 
 	/**
@@ -178,7 +170,7 @@ private:
 	 *
 	 * @return true if current mission item available
 	 */
-	bool prepare_mission_items(bool onboard, struct mission_item_s *mission_item,
+	bool prepare_mission_items(struct mission_item_s *mission_item,
 				   struct mission_item_s *next_position_mission_item, bool *has_next_position_item);
 
 	/**
@@ -187,12 +179,12 @@ private:
 	 *
 	 * @return true if successful
 	 */
-	bool read_mission_item(bool onboard, int offset, struct mission_item_s *mission_item);
+	bool read_mission_item(int offset, mission_item_s *mission_item);
 
 	/**
 	 * Save current offboard mission state to dataman
 	 */
-	void save_offboard_mission_state();
+	void save_mission_state();
 
 	/**
 	 * Inform about a changed mission item after a DO_JUMP
@@ -207,7 +199,7 @@ private:
 	/**
 	 * Set the current offboard mission item
 	 */
-	void set_current_offboard_mission_item();
+	void set_current_mission_item();
 
 	/**
 	 * Set that the mission is finished if one exists or that none exists
@@ -217,13 +209,12 @@ private:
 	/**
 	 * Check whether a mission is ready to go
 	 */
-	void check_mission_valid(bool force);
-
+	bool mission_valid(const mission_s &mission);
 
 	/**
 	 * Reset offboard mission
 	 */
-	void reset_offboard_mission(struct mission_s &mission);
+	void reset_mission(struct mission_s &mission);
 
 	/**
 	 * Returns true if we need to reset the mission
@@ -244,26 +235,23 @@ private:
 	control::BlockParamFloat _param_fw_climbout_diff;
 	control::BlockParamInt _param_rtl_land_type;
 
-	struct mission_s _onboard_mission {};
-	struct mission_s _offboard_mission {};
+	int		_onboard_mission_sub{-1};	/**< onboard mission subscription */
+	int		_offboard_mission_sub{-1};	/**< offboard mission subscription */
 
-	int _current_onboard_mission_index{-1};
-	int _current_offboard_mission_index{-1};
+	mission_s _mission{};
+
+	unsigned _current_mission_index{0};
+
 	bool _need_takeoff{true};					/**< if true, then takeoff must be performed before going to the first waypoint (if needed) */
 
 	int _land_start_index{INT16_MAX};
 
 	enum {
 		MISSION_TYPE_NONE,
-		MISSION_TYPE_ONBOARD,
 		MISSION_TYPE_OFFBOARD
 	} _mission_type{MISSION_TYPE_NONE};
 
-	bool _inited{false};
-	bool _home_inited{false};
 	bool _need_mission_reset{false};
-
-	MissionFeasibilityChecker _missionFeasibilityChecker; /**< class that checks if a mission is feasible */
 
 	float _min_current_sp_distance_xy{FLT_MAX}; /**< minimum distance which was achieved to the current waypoint  */
 

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -46,7 +46,6 @@
 #include <navigator/navigation.h>
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/follow_target.h>
-#include <uORB/topics/mission.h>
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_global_position.h>

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -68,8 +68,6 @@ MissionFeasibilityChecker::checkMissionFeasible(const mission_s &mission, float 
 	const float home_alt = _navigator->get_home_position()->alt;
 	const bool home_valid = _navigator->home_position_valid();
 
-
-
 	bool &warning_issued = _navigator->get_mission_result()->warning;
 	const float default_acceptance_rad  = _navigator->get_default_acceptance_radius();
 	const bool landed = _navigator->get_land_detected()->landed;

--- a/src/modules/navigator/mission_feasibility_checker.h
+++ b/src/modules/navigator/mission_feasibility_checker.h
@@ -43,7 +43,6 @@
 #define MISSION_FEASIBILITY_CHECKER_H_
 
 #include <dataman/dataman.h>
-#include <uORB/topics/mission.h>
 #include <uORB/topics/fw_pos_ctrl_status.h>
 
 class Geofence;

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -141,7 +141,6 @@ struct mission_item_s {
 	};
 };
 #pragma pack(pop)
-#include <uORB/topics/mission.h>
 
 /**
  * @}

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -220,6 +220,7 @@ public:
 	void 		set_mission_failure(const char *reason);
 
 	bool		is_planned_mission() { return _navigation_mode == &_mission; }
+	bool		planned_mission_landing() { return is_planned_mission() && _mission_result.landing; }
 
 	bool		abort_landing();
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -131,9 +131,11 @@ public:
 	struct fw_pos_ctrl_status_s *get_fw_pos_ctrl_status() { return &_fw_pos_ctrl_status; }
 	struct home_position_s *get_home_position() { return &_home_pos; }
 	struct mission_result_s *get_mission_result() { return &_mission_result; }
+
 	struct position_setpoint_triplet_s *get_position_setpoint_triplet() { return &_pos_sp_triplet; }
 	struct position_setpoint_triplet_s *get_reposition_triplet() { return &_reposition_triplet; }
 	struct position_setpoint_triplet_s *get_takeoff_triplet() { return &_takeoff_triplet; }
+
 	struct vehicle_attitude_setpoint_s *get_att_sp() { return &_att_sp; }
 	struct vehicle_global_position_s *get_global_position() { return &_global_pos; }
 	struct vehicle_gps_position_s *get_gps_position() { return &_gps_pos; }
@@ -143,8 +145,6 @@ public:
 
 	bool home_position_valid() { return (_home_pos.timestamp > 0); }
 
-	int		get_onboard_mission_sub() { return _onboard_mission_sub; }
-	int		get_offboard_mission_sub() { return _offboard_mission_sub; }
 	Geofence	&get_geofence() { return _geofence; }
 	bool		get_can_loiter_at_sp() { return _can_loiter_at_sp; }
 	float		get_loiter_radius() { return _param_loiter_radius.get(); }
@@ -215,14 +215,10 @@ public:
 	float		get_acceptance_radius(float mission_item_radius);
 	orb_advert_t	*get_mavlink_log_pub() { return &_mavlink_log_pub; }
 
-	void		increment_mission_instance_count() { _mission_instance_count++; }
-
 	void 		set_mission_failure(const char *reason);
 
 	bool		is_planned_mission() { return _navigation_mode == &_mission; }
 	bool		planned_mission_landing() { return is_planned_mission() && _mission_result.landing; }
-
-	bool		abort_landing();
 
 private:
 
@@ -237,8 +233,6 @@ private:
 	int		_home_pos_sub{-1};		/**< home position subscription */
 	int		_land_detected_sub{-1};		/**< vehicle land detected subscription */
 	int		_local_pos_sub{-1};		/**< local position subscription */
-	int		_offboard_mission_sub{-1};	/**< offboard mission subscription */
-	int		_onboard_mission_sub{-1};	/**< onboard mission subscription */
 	int		_param_update_sub{-1};		/**< param update subscription */
 	int		_sensor_combined_sub{-1};	/**< sensor combined subscription */
 	int		_vehicle_command_sub{-1};	/**< vehicle commands (onboard and offboard) */
@@ -265,8 +259,6 @@ private:
 	vehicle_local_position_s			_local_pos;		/**< local vehicle position */
 	vehicle_status_s				_vstatus{};		/**< vehicle status */
 
-	int		_mission_instance_count{-1};	/**< instance count for the current mission */
-
 	perf_counter_t	_loop_perf;			/**< loop performance counter */
 
 	Geofence	_geofence;			/**< class that handles the geofence */
@@ -274,10 +266,10 @@ private:
 
 	bool		_can_loiter_at_sp{false};			/**< flags if current position SP can be used to loiter */
 	bool		_pos_sp_triplet_updated{false};		/**< flags if position SP triplet needs to be published */
-	bool 		_pos_sp_triplet_published_invalid_once{false};	/**< flags if position SP triplet has been published once to UORB */
 	bool		_mission_result_updated{false};		/**< flags if mission result has seen an update */
 
 	NavigatorMode	*_navigation_mode{nullptr};		/**< abstract pointer to current navigation mode class */
+
 	Mission		_mission;			/**< class that handles the missions */
 	Loiter		_loiter;			/**< class that handles loiter */
 	Takeoff		_takeoff;			/**< class for handling takeoff commands */

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -579,8 +579,15 @@ Navigator::task_main()
 			break;
 
 		case vehicle_status_s::NAVIGATION_STATE_AUTO_RTL:
-			_pos_sp_triplet_published_invalid_once = false;
 			_navigation_mode = &_rtl;
+
+			if (_rtl.mission_landing()) {
+				if (_mission.land()) {
+					_navigation_mode = &_mission;
+				}
+			}
+
+			_pos_sp_triplet_published_invalid_once = false;
 			break;
 
 		case vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF:

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -63,7 +63,6 @@
 #include <uORB/topics/fence.h>
 #include <uORB/topics/fw_pos_ctrl_status.h>
 #include <uORB/topics/home_position.h>
-#include <uORB/topics/mission.h>
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/uORB.h>
@@ -114,6 +113,8 @@ Navigator::Navigator() :
 	_navigation_mode_array[9] = &_follow_target;
 
 	updateParams();
+
+	_mission_result.instance_count = -1;
 }
 
 Navigator::~Navigator()
@@ -184,6 +185,10 @@ Navigator::fw_pos_ctrl_status_update(bool force)
 
 	if (updated || force) {
 		orb_copy(ORB_ID(fw_pos_ctrl_status), _fw_pos_ctrl_status_sub, &_fw_pos_ctrl_status);
+
+		if (is_planned_mission() && _fw_pos_ctrl_status.abort_landing) {
+			_mission.abort_landing();
+		}
 	}
 }
 
@@ -249,8 +254,6 @@ Navigator::task_main()
 	_vstatus_sub = orb_subscribe(ORB_ID(vehicle_status));
 	_land_detected_sub = orb_subscribe(ORB_ID(vehicle_land_detected));
 	_home_pos_sub = orb_subscribe(ORB_ID(home_position));
-	_onboard_mission_sub = orb_subscribe(ORB_ID(onboard_mission));
-	_offboard_mission_sub = orb_subscribe(ORB_ID(offboard_mission));
 	_param_update_sub = orb_subscribe(ORB_ID(parameter_update));
 	_vehicle_command_sub = orb_subscribe(ORB_ID(vehicle_command));
 
@@ -403,11 +406,11 @@ Navigator::task_main()
 					rep->current.yaw = NAN;
 				}
 
-				// Position change with optional altitude change
 				if (PX4_ISFINITE(cmd.param5) && PX4_ISFINITE(cmd.param6)) {
 					rep->current.lat = (cmd.param5 < 1000) ? cmd.param5 : cmd.param5 / (double)1e7;
 					rep->current.lon = (cmd.param6 < 1000) ? cmd.param6 : cmd.param6 / (double)1e7;
 
+					// Position change with optional altitude change
 					if (PX4_ISFINITE(cmd.param7)) {
 						rep->current.alt = cmd.param7;
 
@@ -415,18 +418,17 @@ Navigator::task_main()
 						rep->current.alt = get_global_position()->alt;
 					}
 
-					// Altitude without position change
-
 				} else if (PX4_ISFINITE(cmd.param7) && curr->current.valid
 					   && PX4_ISFINITE(curr->current.lat)
 					   && PX4_ISFINITE(curr->current.lon)) {
+
+					// Altitude without position change
 					rep->current.lat = curr->current.lat;
 					rep->current.lon = curr->current.lon;
 					rep->current.alt = cmd.param7;
 
-					// All three set to NaN - hold in current position
-
 				} else {
+					// All three set to NaN - hold in current position
 					rep->current.lat = get_global_position()->lat;
 					rep->current.lon = get_global_position()->lon;
 					rep->current.alt = get_global_position()->alt;
@@ -500,11 +502,8 @@ Navigator::task_main()
 				if (get_mission_result()->valid &&
 				    PX4_ISFINITE(cmd.param1) && (cmd.param1 >= 0) && (cmd.param1 < _mission_result.seq_total)) {
 
-					_mission.set_current_offboard_mission_index(cmd.param1);
+					_mission.set_current_mission_index(cmd.param1);
 				}
-
-			} else if (cmd.command == vehicle_command_s::VEHICLE_CMD_DO_PAUSE_CONTINUE) {
-				warnx("navigator: got pause/continue command");
 
 			} else if (cmd.command == vehicle_command_s::VEHICLE_CMD_DO_CHANGE_SPEED) {
 				if (cmd.param2 > FLT_EPSILON) {
@@ -536,10 +535,6 @@ Navigator::task_main()
 			last_geofence_check = hrt_absolute_time();
 			have_geofence_position_data = false;
 
-			_geofence_result.timestamp = hrt_absolute_time();
-			_geofence_result.geofence_action = _geofence.getGeofenceAction();
-			_geofence_result.home_required = _geofence.isHomeRequired();
-
 			if (!inside) {
 				/* inform other apps via the mission result */
 				_geofence_result.geofence_violated = true;
@@ -562,66 +557,50 @@ Navigator::task_main()
 		}
 
 		/* Do stuff according to navigation state set by commander */
+		const NavigatorMode *navigation_mode_prev = _navigation_mode;
+
 		switch (_vstatus.nav_state) {
 		case vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION:
-			_pos_sp_triplet_published_invalid_once = false;
 			_navigation_mode = &_mission;
 			break;
 
 		case vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER:
-			_pos_sp_triplet_published_invalid_once = false;
 			_navigation_mode = &_loiter;
 			break;
 
 		case vehicle_status_s::NAVIGATION_STATE_AUTO_RCRECOVER:
-			_pos_sp_triplet_published_invalid_once = false;
 			_navigation_mode = &_rcLoss;
 			break;
 
 		case vehicle_status_s::NAVIGATION_STATE_AUTO_RTL:
 			_navigation_mode = &_rtl;
-
-			if (_rtl.mission_landing()) {
-				if (_mission.land()) {
-					_navigation_mode = &_mission;
-				}
-			}
-
-			_pos_sp_triplet_published_invalid_once = false;
 			break;
 
 		case vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF:
-			_pos_sp_triplet_published_invalid_once = false;
 			_navigation_mode = &_takeoff;
 			break;
 
 		case vehicle_status_s::NAVIGATION_STATE_AUTO_LAND:
-			_pos_sp_triplet_published_invalid_once = false;
 			_navigation_mode = &_land;
 			break;
 
 		case vehicle_status_s::NAVIGATION_STATE_DESCEND:
-			_pos_sp_triplet_published_invalid_once = false;
 			_navigation_mode = &_land;
 			break;
 
 		case vehicle_status_s::NAVIGATION_STATE_AUTO_RTGS:
-			_pos_sp_triplet_published_invalid_once = false;
 			_navigation_mode = &_dataLinkLoss;
 			break;
 
 		case vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL:
-			_pos_sp_triplet_published_invalid_once = false;
 			_navigation_mode = &_engineFailure;
 			break;
 
 		case vehicle_status_s::NAVIGATION_STATE_AUTO_LANDGPSFAIL:
-			_pos_sp_triplet_published_invalid_once = false;
 			_navigation_mode = &_gpsFailure;
 			break;
 
 		case vehicle_status_s::NAVIGATION_STATE_AUTO_FOLLOW_TARGET:
-			_pos_sp_triplet_published_invalid_once = false;
 			_navigation_mode = &_follow_target;
 			break;
 
@@ -633,14 +612,18 @@ Navigator::task_main()
 		case vehicle_status_s::NAVIGATION_STATE_OFFBOARD:
 		case vehicle_status_s::NAVIGATION_STATE_STAB:
 		default:
-			_pos_sp_triplet_published_invalid_once = false;
 			_navigation_mode = nullptr;
+
+			_pos_sp_triplet.previous.valid = false;
+			_pos_sp_triplet.current.valid = false;
+			_pos_sp_triplet.next.valid = false;
+
 			_can_loiter_at_sp = false;
 			break;
 		}
 
 		/* iterate through navigation modes and set active/inactive for each */
-		for (unsigned int i = 0; i < NAVIGATOR_MODE_ARRAY_SIZE; i++) {
+		for (unsigned i = 0; i < NAVIGATOR_MODE_ARRAY_SIZE; i++) {
 			_navigation_mode_array[i]->run(_navigation_mode == _navigation_mode_array[i]);
 		}
 
@@ -654,26 +637,18 @@ Navigator::task_main()
 			_pos_sp_triplet.previous.valid = false;
 			_pos_sp_triplet.next.valid = false;
 
-		}
-
-		/* if nothing is running, set position setpoint triplet invalid once */
-		if (_navigation_mode == nullptr && !_pos_sp_triplet_published_invalid_once) {
-			_pos_sp_triplet_published_invalid_once = true;
-			_pos_sp_triplet.previous.valid = false;
-			_pos_sp_triplet.current.valid = false;
-			_pos_sp_triplet.next.valid = false;
 			_pos_sp_triplet_updated = true;
+
 		}
 
-		if (_pos_sp_triplet_updated) {
-			_pos_sp_triplet.timestamp = hrt_absolute_time();
+		const bool nav_mode_changed = (navigation_mode_prev != _navigation_mode);
+
+		if (_pos_sp_triplet_updated || nav_mode_changed) {
 			publish_position_setpoint_triplet();
-			_pos_sp_triplet_updated = false;
 		}
 
-		if (_mission_result_updated) {
+		if (_mission_result_updated || nav_mode_changed) {
 			publish_mission_result();
-			_mission_result_updated = false;
 		}
 
 		perf_end(_loop_perf);
@@ -698,7 +673,7 @@ Navigator::start()
 					     nullptr);
 
 	if (_navigator_task < 0) {
-		warn("task start failed");
+		PX4_WARN("task start failed");
 		return -errno;
 	}
 
@@ -708,6 +683,10 @@ Navigator::start()
 void
 Navigator::status()
 {
+	PX4_INFO("Mission valid: %d", _mission_result.valid);
+	PX4_INFO("Mission finished: %d", _mission_result.finished);
+	PX4_INFO("Mission failure: %d", _mission_result.failure);
+
 	if (_geofence.valid()) {
 		PX4_INFO("Geofence is valid");
 
@@ -719,10 +698,14 @@ Navigator::status()
 void
 Navigator::publish_position_setpoint_triplet()
 {
+	_pos_sp_triplet_updated = false;
+
 	/* do not publish an empty triplet */
 	if (!_pos_sp_triplet.current.valid) {
 		return;
 	}
+
+	_pos_sp_triplet.timestamp = hrt_absolute_time();
 
 	/* lazily publish the position setpoint triplet only once available */
 	if (_pos_sp_triplet_pub != nullptr) {
@@ -838,25 +821,6 @@ Navigator::load_fence_from_file(const char *filename)
 	_geofence.loadFromFile(filename);
 }
 
-bool
-Navigator::abort_landing()
-{
-	bool should_abort = false;
-
-	if (!_vstatus.is_rotary_wing && !_vstatus.in_transition_mode) {
-		if (hrt_elapsed_time(&_fw_pos_ctrl_status.timestamp) < 1000000) {
-
-			if (get_position_setpoint_triplet()->current.valid
-			    && get_position_setpoint_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
-
-				should_abort = _fw_pos_ctrl_status.abort_landing;
-			}
-		}
-	}
-
-	return should_abort;
-}
-
 static void usage()
 {
 	PX4_INFO("usage: navigator {start|stop|status|fence|fencefile}");
@@ -923,7 +887,6 @@ void
 Navigator::publish_mission_result()
 {
 	_mission_result.timestamp = hrt_absolute_time();
-	_mission_result.instance_count = _mission_instance_count;
 
 	/* lazily publish the mission result only once available */
 	if (_mission_result_pub != nullptr) {
@@ -945,11 +908,17 @@ Navigator::publish_mission_result()
 	_mission_result.item_changed_index = 0;
 	_mission_result.item_do_jump_remaining = 0;
 	_mission_result.valid = true;
+
+	_mission_result_updated = false;
 }
 
 void
 Navigator::publish_geofence_result()
 {
+	_geofence_result.timestamp = hrt_absolute_time();
+	_geofence_result.geofence_action = _geofence.getGeofenceAction();
+	_geofence_result.home_required = _geofence.isHomeRequired();
+
 	/* lazily publish the geofence result only once available */
 	if (_geofence_result_pub != nullptr) {
 		/* publish mission result */

--- a/src/modules/navigator/navigator_mode.cpp
+++ b/src/modules/navigator/navigator_mode.cpp
@@ -63,6 +63,7 @@ NavigatorMode::run(bool active)
 			/* Reset stay in failsafe flag */
 			_navigator->get_mission_result()->stay_in_failsafe = false;
 			_navigator->set_mission_result_updated();
+
 			on_activation();
 
 		} else {

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -176,9 +176,9 @@ RTL::set_rtl_item()
 			_mission_item.autocontinue = true;
 			_mission_item.origin = ORIGIN_ONBOARD;
 
-			mavlink_log_info(_navigator->get_mavlink_log_pub(), "RTL: climb to %d m (%d m above home)",
-					 (int)(climb_alt),
-					 (int)(climb_alt - _navigator->get_home_position()->alt));
+			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: climb to %d m (%d m above home)",
+						     (int)(climb_alt),
+						     (int)(climb_alt - _navigator->get_home_position()->alt));
 			break;
 		}
 
@@ -187,7 +187,7 @@ RTL::set_rtl_item()
 			if (_param_rtl_land_type.get() == 1) {
 				// landing using planned mission landing, fly to DO_LAND_START instead of returning HOME
 				// do nothing, wait for navigator to takeover with mission
-				mavlink_log_info(_navigator->get_mavlink_log_pub(), "RTL: using mission landing");
+				mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: using mission landing");
 
 			} else {
 				_mission_item.lat = home.lat;
@@ -213,9 +213,9 @@ RTL::set_rtl_item()
 				_mission_item.autocontinue = true;
 				_mission_item.origin = ORIGIN_ONBOARD;
 
-				mavlink_log_info(_navigator->get_mavlink_log_pub(), "RTL: return at %d m (%d m above home)",
-						 (int)(_mission_item.altitude),
-						 (int)(_mission_item.altitude - home.alt));
+				mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: return at %d m (%d m above home)",
+							     (int)(_mission_item.altitude),
+							     (int)(_mission_item.altitude - home.alt));
 			}
 
 			break;
@@ -257,9 +257,9 @@ RTL::set_rtl_item()
 			/* disable previous setpoint to prevent drift */
 			pos_sp_triplet->previous.valid = false;
 
-			mavlink_log_info(_navigator->get_mavlink_log_pub(), "RTL: descend to %d m (%d m above home)",
-					 (int)(_mission_item.altitude),
-					 (int)(_mission_item.altitude - home.alt));
+			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: descend to %d m (%d m above home)",
+						     (int)(_mission_item.altitude),
+						     (int)(_mission_item.altitude - home.alt));
 			break;
 		}
 
@@ -280,11 +280,12 @@ RTL::set_rtl_item()
 
 			if (autoland && (get_time_inside(_mission_item) > FLT_EPSILON)) {
 				_mission_item.nav_cmd = NAV_CMD_LOITER_TIME_LIMIT;
-				mavlink_log_info(_navigator->get_mavlink_log_pub(), "RTL: loiter %.1fs", (double)get_time_inside(_mission_item));
+				mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: loiter %.1fs",
+							     (double)get_time_inside(_mission_item));
 
 			} else {
 				_mission_item.nav_cmd = NAV_CMD_LOITER_UNLIMITED;
-				mavlink_log_info(_navigator->get_mavlink_log_pub(), "RTL: completed, loiter");
+				mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: completed, loiter");
 			}
 
 			break;
@@ -297,13 +298,11 @@ RTL::set_rtl_item()
 				// do nothing, navigator is landing with Mission
 
 			} else {
-
 				// land at home position
 				_mission_item.yaw = home.yaw;
 				set_land_item(&_mission_item, false);
 
-				mavlink_log_info(_navigator->get_mavlink_log_pub(), "RTL: land at home");
-
+				mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: land at home");
 			}
 		}
 		break;

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -41,15 +41,12 @@
 #ifndef NAVIGATOR_RTL_H
 #define NAVIGATOR_RTL_H
 
+#include "mission_block.h"
+
 #include <controllib/blocks.hpp>
 #include <controllib/block/BlockParam.hpp>
-
-#include <navigator/navigation.h>
 #include <uORB/topics/home_position.h>
 #include <uORB/topics/vehicle_global_position.h>
-
-#include "navigator_mode.h"
-#include "mission_block.h"
 
 class Navigator;
 
@@ -62,6 +59,8 @@ public:
 	void on_inactive() override;
 	void on_activation() override;
 	void on_active() override;
+
+	bool mission_landing();
 
 private:
 	/**
@@ -96,6 +95,7 @@ private:
 	control::BlockParamFloat _param_descend_alt;
 	control::BlockParamFloat _param_land_delay;
 	control::BlockParamFloat _param_rtl_min_dist;
+	control::BlockParamInt _param_rtl_land_type;
 };
 
 #endif

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -96,6 +96,9 @@ private:
 	control::BlockParamFloat _param_land_delay;
 	control::BlockParamFloat _param_rtl_min_dist;
 	control::BlockParamInt _param_rtl_land_type;
+
+
+	//const Mission&	_mission;
 };
 
 #endif

--- a/src/modules/navigator/rtl_params.c
+++ b/src/modules/navigator/rtl_params.c
@@ -103,3 +103,14 @@ PARAM_DEFINE_FLOAT(RTL_LAND_DELAY, -1.0f);
  * @group Return To Land
  */
 PARAM_DEFINE_FLOAT(RTL_MIN_DIST, 5.0f);
+
+/**
+ * RTL land location
+ *
+ * Land at the home location or planned mission landing
+ *
+ * @value 0 Home Position
+ * @value 1 Planned Landing (Mission)
+ * @group Return To Land
+ */
+PARAM_DEFINE_INT32(RTL_LAND_TYPE, 0);


### PR DESCRIPTION
Planes often need a planned landing (both the location and approach) to land safely. This PR adds the ability for RTL to jump into mission mode at the beginning of a planned landing (DO_LAND_START).

Opening this now to discuss how to optimally fit it into the current navigator and state machine logic. 

**Questions**

 - do we want to still preserve existing RTL behaviour? Maybe called RTH. Is it RTLand or RTLaunch?
 - what about the LAND mode? If you had a planned landing in place would you ever want to command a landing in place? That could still be preserved for failsafe triggers.
 - Smart RTL will hopefully make its way to PX4 soon (PX4/Firmware#6464). How do these fit together?