### PR TITLE
[VTOL Standard] Disable pusher-for-pitch strategy in manual control mode

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -356,8 +356,10 @@ void Standard::update_mc_state()
 		_flag_enable_mc_motors = false;
 	}
 
-	// if the thrust scale param is zero then the pusher-for-pitch strategy is disabled and we can return
-	if (_params_standard.forward_thrust_scale < FLT_EPSILON) {
+	// if the thrust scale param is zero or the drone is on manual mode,
+	// then the pusher-for-pitch strategy is disabled and we can return
+	if (_params_standard.forward_thrust_scale < FLT_EPSILON ||
+		!_v_control_mode->flag_control_position_enabled) {
 		return;
 	}
 


### PR DESCRIPTION
This modification disables the "pusher-for-pitch" strategy when in manual control mode. This is helpful when testing a new setup or tuning the gain of this strategy for example.