### PR TITLE
px4fmu-v3:Add ICM20608 aliased to the PX4_SPIDEV_ACCEL_MAG to the v3 …

### DIFF
--- a/src/drivers/boards/px4fmu-v3/board_config.h
+++ b/src/drivers/boards/px4fmu-v3/board_config.h
@@ -44,3 +44,4 @@
  ****************************************************************************************************/
 
 #include "../px4fmu-v2/board_config.h"
+#define PX4_SPIDEV_ICM_20608  PX4_SPIDEV_ACCEL_MAG // PixhawkMini has ICM_20608 on GPIO_SPI_CS_ACCEL_MAG


### PR DESCRIPTION
…build

   The Pixkhawk mini was not chip selecting the ICM20608 as it did
   not define PX4_SPIDEV_ICM_20608. This allow the fmu V2 rc code
   to init the ICM20608.