### PR TITLE
drv_hrt: avoid using a mutex on POSIX, it's only needed on SITL

### DIFF
--- a/src/drivers/drv_hrt.h
+++ b/src/drivers/drv_hrt.h
@@ -173,6 +173,7 @@ __EXPORT extern void	hrt_init(void);
 
 #ifdef __PX4_POSIX
 
+#if defined(CONFIG_ARCH_BOARD_SITL)
 /**
  * Start to delay the HRT return value.
  *
@@ -185,6 +186,8 @@ __EXPORT extern	void	hrt_start_delay(void);
  * Stop to delay the HRT.
  */
 __EXPORT extern void	hrt_stop_delay(void);
+
+#endif
 
 #endif
 


### PR DESCRIPTION
Signed-off-by: Nicolae Rosia <nicolae.rosia@gmail.com>