### PR TITLE
ekf: change gyro & accel dt from float to uint64.

### DIFF
--- a/msg/ekf2_replay.msg
+++ b/msg/ekf2_replay.msg
@@ -1,6 +1,6 @@
 
-uint64 gyro_integral_dt		# gyro integration period in s
-uint64 accelerometer_integral_dt 	# accelerometer integration period in s
+uint64 gyro_integral_dt		# gyro integration period in us
+uint64 accelerometer_integral_dt 	# accelerometer integration period in us
 uint64 magnetometer_timestamp 		# timestamp of magnetometer measurement in us
 uint64 baro_timestamp			# timestamp of barometer measurement in us
 uint64 rng_timestamp			# timestamp of range finder measurement in us

--- a/msg/ekf2_replay.msg
+++ b/msg/ekf2_replay.msg
@@ -1,6 +1,6 @@
 
-float32 gyro_integral_dt		# gyro integration period in s
-float32 accelerometer_integral_dt 	# accelerometer integration period in s
+uint64 gyro_integral_dt		# gyro integration period in s
+uint64 accelerometer_integral_dt 	# accelerometer integration period in s
 uint64 magnetometer_timestamp 		# timestamp of magnetometer measurement in us
 uint64 baro_timestamp			# timestamp of barometer measurement in us
 uint64 rng_timestamp			# timestamp of range finder measurement in us

--- a/msg/ekf2_replay.msg
+++ b/msg/ekf2_replay.msg
@@ -1,6 +1,6 @@
 
-uint64 gyro_integral_dt		# gyro integration period in us
-uint64 accelerometer_integral_dt 	# accelerometer integration period in us
+uint32 gyro_integral_dt		# gyro integration period in us
+uint32 accelerometer_integral_dt 	# accelerometer integration period in us
 uint64 magnetometer_timestamp 		# timestamp of magnetometer measurement in us
 uint64 baro_timestamp			# timestamp of barometer measurement in us
 uint64 rng_timestamp			# timestamp of range finder measurement in us

--- a/msg/sensor_combined.msg
+++ b/msg/sensor_combined.msg
@@ -10,11 +10,11 @@ int32 RELATIVE_TIMESTAMP_INVALID = 2147483647 # (0x7fffffff) If one of the relat
 
 # gyro timstamp is equal to the timestamp of the message
 float32[3] gyro_rad			# average angular rate measured in the XYZ body frame in rad/s over the last gyro sampling period
-uint64 gyro_integral_dt		# gyro measurement sampling period in us
+uint32 gyro_integral_dt		# gyro measurement sampling period in us
 
 int32 accelerometer_timestamp_relative	# timestamp + accelerometer_timestamp_relative = Accelerometer timestamp
 float32[3] accelerometer_m_s2		# average value acceleration measured in the XYZ body frame in m/s/s over the last accelerometer sampling period
-uint64 accelerometer_integral_dt	# accelerometer measurement sampling period in us
+uint32 accelerometer_integral_dt	# accelerometer measurement sampling period in us
 
 int32 magnetometer_timestamp_relative	# timestamp + magnetometer_timestamp_relative = Magnetometer timestamp
 float32[3] magnetometer_ga		# Magnetic field in NED body frame, in Gauss

--- a/msg/sensor_combined.msg
+++ b/msg/sensor_combined.msg
@@ -10,11 +10,11 @@ int32 RELATIVE_TIMESTAMP_INVALID = 2147483647 # (0x7fffffff) If one of the relat
 
 # gyro timstamp is equal to the timestamp of the message
 float32[3] gyro_rad			# average angular rate measured in the XYZ body frame in rad/s over the last gyro sampling period
-float32 gyro_integral_dt		# gyro measurement sampling period in s
+uint64 gyro_integral_dt		# gyro measurement sampling period in s
 
 int32 accelerometer_timestamp_relative	# timestamp + accelerometer_timestamp_relative = Accelerometer timestamp
 float32[3] accelerometer_m_s2		# average value acceleration measured in the XYZ body frame in m/s/s over the last accelerometer sampling period
-float32 accelerometer_integral_dt	# accelerometer measurement sampling period in s
+uint64 accelerometer_integral_dt	# accelerometer measurement sampling period in s
 
 int32 magnetometer_timestamp_relative	# timestamp + magnetometer_timestamp_relative = Magnetometer timestamp
 float32[3] magnetometer_ga		# Magnetic field in NED body frame, in Gauss

--- a/msg/sensor_combined.msg
+++ b/msg/sensor_combined.msg
@@ -10,11 +10,11 @@ int32 RELATIVE_TIMESTAMP_INVALID = 2147483647 # (0x7fffffff) If one of the relat
 
 # gyro timstamp is equal to the timestamp of the message
 float32[3] gyro_rad			# average angular rate measured in the XYZ body frame in rad/s over the last gyro sampling period
-uint64 gyro_integral_dt		# gyro measurement sampling period in s
+uint64 gyro_integral_dt		# gyro measurement sampling period in us
 
 int32 accelerometer_timestamp_relative	# timestamp + accelerometer_timestamp_relative = Accelerometer timestamp
 float32[3] accelerometer_m_s2		# average value acceleration measured in the XYZ body frame in m/s/s over the last accelerometer sampling period
-uint64 accelerometer_integral_dt	# accelerometer measurement sampling period in s
+uint64 accelerometer_integral_dt	# accelerometer measurement sampling period in us
 
 int32 magnetometer_timestamp_relative	# timestamp + magnetometer_timestamp_relative = Magnetometer timestamp
 float32[3] magnetometer_ga		# Magnetic field in NED body frame, in Gauss

--- a/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
+++ b/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
@@ -1359,7 +1359,7 @@ void AttitudePositionEstimatorEKF::pollData()
 	_ekf->angRate.y = _sensor_combined.gyro_rad[1];
 	_ekf->angRate.z = _sensor_combined.gyro_rad[2];
 
-	float gyro_dt = _sensor_combined.gyro_integral_dt;
+	float gyro_dt = _sensor_combined.gyro_integral_dt / 1.e6f;
 	_ekf->dAngIMU = _ekf->angRate * gyro_dt;
 
 	perf_count(_perf_gyro);
@@ -1370,7 +1370,7 @@ void AttitudePositionEstimatorEKF::pollData()
 		_ekf->accel.y = _sensor_combined.accelerometer_m_s2[1];
 		_ekf->accel.z = _sensor_combined.accelerometer_m_s2[2];
 
-		float accel_dt = _sensor_combined.accelerometer_integral_dt;
+		float accel_dt = _sensor_combined.accelerometer_integral_dt / 1.e6f;
 		_ekf->dVelIMU = _ekf->accel * accel_dt;
 
 		_last_accel = _sensor_combined.timestamp + _sensor_combined.accelerometer_timestamp_relative;
@@ -1394,8 +1394,8 @@ void AttitudePositionEstimatorEKF::pollData()
 	// leave this in as long as larger improvements are still being made.
 #if 0
 
-	float deltaTIntegral = _sensor_combined.gyro_integral_dt;
-	float deltaTIntAcc = _sensor_combined.accelerometer_integral_dt;
+	float deltaTIntegral = _sensor_combined.gyro_integral_dt / 1.e6f;
+	float deltaTIntAcc = _sensor_combined.accelerometer_integral_dt / 1.e6f;
 
 	static unsigned dtoverflow5 = 0;
 	static unsigned dtoverflow10 = 0;

--- a/src/modules/replay/replay.hpp
+++ b/src/modules/replay/replay.hpp
@@ -113,6 +113,16 @@ protected:
 	};
 
 	/**
+	 * Find the offset & field size in bytes for a given field name
+	 * @param format format string, as specified by ULog
+	 * @param field_name search for this field
+	 * @param offset returned offset
+	 * @param field_size returned field size
+	 * @return true if found, false otherwise
+	 */
+	static bool findFieldOffset(const std::string &format, const std::string &field_name, int &offset, int &field_size);
+
+	/**
 	 * publish an orb topic
 	 * @param sub
 	 * @param data

--- a/src/modules/replay/replay.hpp
+++ b/src/modules/replay/replay.hpp
@@ -95,6 +95,36 @@ public:
 
 protected:
 
+	/**
+	 * @class Compatibility base class to convert topics to an updated format
+	 */
+	class CompatBase
+	{
+	public:
+		virtual ~CompatBase() = default;
+
+		/**
+		 * apply compatibility to a topic
+		 * @param data input topic (can be modified in place)
+		 * @return new topic data
+		 */
+		virtual void *apply(void *data) = 0;
+	};
+
+	class CompatSensorCombinedDtType : public CompatBase
+	{
+	public:
+		CompatSensorCombinedDtType(int gyro_integral_dt_offset_log, int gyro_integral_dt_offset_intern,
+					   int accelerometer_integral_dt_offset_log, int accelerometer_integral_dt_offset_intern);
+
+		void *apply(void *data) override;
+	private:
+		int _gyro_integral_dt_offset_log;
+		int _gyro_integral_dt_offset_intern;
+		int _accelerometer_integral_dt_offset_log;
+		int _accelerometer_integral_dt_offset_intern;
+	};
+
 	struct Subscription {
 
 		const orb_metadata *orb_meta = nullptr; ///< if nullptr, this subscription is invalid
@@ -106,6 +136,8 @@ protected:
 
 		std::streampos next_read_pos;
 		uint64_t next_timestamp; ///< timestamp of the file
+
+		CompatBase *compat = nullptr;
 
 		// statistics
 		int error_counter = 0;

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -518,8 +518,8 @@ struct log_EST5_s {
 #define LOG_RPL1_MSG 51
 struct log_RPL1_s {
 	uint64_t time_ref;
-	float gyro_integral_dt;
-	float accelerometer_integral_dt;
+	uint64_t gyro_integral_dt;
+	uint64_t accelerometer_integral_dt;
 	uint64_t magnetometer_timestamp;
 	uint64_t baro_timestamp;
 	float gyro_x_rad;

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -518,8 +518,8 @@ struct log_EST5_s {
 #define LOG_RPL1_MSG 51
 struct log_RPL1_s {
 	uint64_t time_ref;
-	uint64_t gyro_integral_dt;
-	uint64_t accelerometer_integral_dt;
+	uint32_t gyro_integral_dt;
+	uint32_t accelerometer_integral_dt;
 	uint64_t magnetometer_timestamp;
 	uint64_t baro_timestamp;
 	float gyro_x_rad;

--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -563,7 +563,7 @@ void VotedSensorsUpdate::accel_poll(struct sensor_combined_s &raw)
 				accel_data = math::Vector<3>(accel_report.x_integral * dt_inv, accel_report.y_integral * dt_inv,
 							     accel_report.z_integral * dt_inv);
 
-				_last_sensor_data[uorb_index].accelerometer_integral_dt = accel_report.integral_dt / 1.e6f;
+				_last_sensor_data[uorb_index].accelerometer_integral_dt = accel_report.integral_dt;
 
 			} else {
 				// using the value instead of the integral (the integral is the prefered choice)
@@ -579,7 +579,7 @@ void VotedSensorsUpdate::accel_poll(struct sensor_combined_s &raw)
 
 				// approximate the  delta time using the difference in accel data time stamps
 				_last_sensor_data[uorb_index].accelerometer_integral_dt =
-					(accel_report.timestamp - _last_accel_timestamp[uorb_index]) / 1.e6f;
+					(accel_report.timestamp - _last_accel_timestamp[uorb_index]);
 			}
 
 			// handle temperature compensation
@@ -670,7 +670,7 @@ void VotedSensorsUpdate::gyro_poll(struct sensor_combined_s &raw)
 				gyro_rate = math::Vector<3>(gyro_report.x_integral * dt_inv, gyro_report.y_integral * dt_inv,
 							    gyro_report.z_integral * dt_inv);
 
-				_last_sensor_data[uorb_index].gyro_integral_dt = gyro_report.integral_dt / 1.e6f;
+				_last_sensor_data[uorb_index].gyro_integral_dt = gyro_report.integral_dt;
 
 			} else {
 				//using the value instead of the integral (the integral is the prefered choice)
@@ -686,7 +686,7 @@ void VotedSensorsUpdate::gyro_poll(struct sensor_combined_s &raw)
 
 				// approximate the  delta time using the difference in gyro data time stamps
 				_last_sensor_data[uorb_index].gyro_integral_dt =
-					(gyro_report.timestamp - _last_sensor_data[uorb_index].timestamp) / 1.e6f;
+					(gyro_report.timestamp - _last_sensor_data[uorb_index].timestamp);
 			}
 
 			// handle temperature compensation


### PR DESCRIPTION
This has the benefit of calculating the estimator timeslip correctly.

Signed-off-by: Nicolae Rosia <nicolae.rosia@gmail.com>