### PR TITLE
ver all Nuttx reported incorrectly

### DIFF
--- a/Tools/px_update_git_header.py
+++ b/Tools/px_update_git_header.py
@@ -23,7 +23,7 @@ try:
 except:
     git_branch_name = ''
 git_version_short = git_version[0:16]
-nuttx_git_tag = subprocess.check_output('git describe --always --tags --dirty'.split(),
+nuttx_git_tag = subprocess.check_output('git describe --always --tags --match nuttx-*  --dirty'.split(),
                                   cwd='NuttX/nuttx', stderr=subprocess.STDOUT).decode('utf-8').strip().replace("nuttx-","v")
 nuttx_git_tag = re.sub('-.*','.0',nuttx_git_tag)
 nuttx_git_version = subprocess.check_output('git rev-parse --verify HEAD'.split(),

--- a/src/systemcmds/ver/ver.c
+++ b/src/systemcmds/ver/ver.c
@@ -128,10 +128,10 @@ int ver_main(int argc, char *argv[])
 				unsigned type = (fwver >> (8 * 0)) & 0xFF;
 
 				if (type == 255) {
-					printf("FW version: Release %x.%x.%x (%u)\n", major, minor, patch, fwver);
+					printf("FW version: Release %u.%u.%u (%u)\n", major, minor, patch, fwver);
 
 				} else {
-					printf("FW version: %x.%x.%x %x (%u)\n", major, minor, patch, type, fwver);
+					printf("FW version: %u.%u.%u %x (%u)\n", major, minor, patch, type, fwver);
 				}
 
 
@@ -143,10 +143,10 @@ int ver_main(int argc, char *argv[])
 				printf("OS: %s\n", px4_os_name());
 
 				if (type == 255) {
-					printf("OS version: Release %x.%x.%x (%u)\n", major, minor, patch, fwver);
+					printf("OS version: Release %u.%u.%u (%u)\n", major, minor, patch, fwver);
 
 				} else {
-					printf("OS version: %x.%x.%x %x (%u)\n", major, minor, patch, type, fwver);
+					printf("OS version: %u.%u.%u %u (%u)\n", major, minor, patch, type, fwver);
 				}
 
 				const char *os_git_hash = px4_os_version_string();


### PR DESCRIPTION
The recent changes to version.c (Fixed the version naming #7531) return values in base10
The tool that extracts the nuttx git tag was broken by a new tag added the did not match  the form nuttx-M.mm. 

So the value was printed as
```
   OS: NuttX
   OS version: 0.0.0 c0 (192)
```
  Once that issue was fixed, it was apparent that recent  changes to version.c return the values as base 10, before it was hex. This fixes the formatting.

