### PR TITLE
Fix fmu running as task

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -157,7 +157,7 @@ then
 
 	if [ $MIXER_AUX_FILE != none ]
 	then
-		if fmu mode_${AUX_MODE}
+		if fmu mode_${AUX_MODE} $FMU_ARGS
 		then
 			# Append aux mixer to main device
 			if [ $OUTPUT_MODE == hil ]

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -190,6 +190,7 @@ then
 	set MK_MODE none
 	set FMU_MODE pwm
 	set AUX_MODE pwm
+	set FMU_ARGS ""
 	set MAVLINK_F default
 	set MAVLINK_COMPANION_DEVICE /dev/ttyS2
 	set EXIT_ON_END no
@@ -197,6 +198,11 @@ then
 	set FAILSAFE none
 	set USE_IO yes
 	set LOGGER_BUF 16
+
+	if param compare SYS_FMU_TASK 1
+	then
+		set FMU_ARGS "-t"
+	fi
 
 	#
 	# Set USE_IO flag
@@ -535,7 +541,7 @@ then
 
 		if [ $OUTPUT_MODE == fmu -o $OUTPUT_MODE == ardrone ]
 		then
-			if fmu mode_$FMU_MODE
+			if fmu mode_$FMU_MODE $FMU_ARGS
 			then
 			else
 				echo "FMU start failed" >> $LOG_FILE
@@ -604,7 +610,7 @@ then
 		else
 			if [ $OUTPUT_MODE != fmu -a $OUTPUT_MODE != ardrone ]
 			then
-				if fmu mode_${FMU_MODE}
+				if fmu mode_${FMU_MODE} $FMU_ARGS
 				then
 				else
 					echo "FMU mode_${FMU_MODE} start failed" >> $LOG_FILE
@@ -1034,7 +1040,7 @@ then
 		then
 			# On Pixracer use Telem 2 port (TL2).
 			snapdragon_rc_pwm start -d /dev/ttyS2
-			fmu mode_pwm4
+			fmu mode_pwm4 $FMU_ARGS
 		fi
 
 		pwm failsafe -c 1234 -p 900

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1210,7 +1210,7 @@ PX4FMU::cycle()
 			_current_update_rate = 0;
 		}
 
-		int poll_timeout = 20;
+		int poll_timeout = 5; // needs to be small enough so that we don't miss RC input data
 
 		if (!_run_as_task) {
 			/*

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -470,6 +470,8 @@ PX4FMU::~PX4FMU()
 	/* make sure servos are off */
 	up_pwm_servo_deinit();
 
+	dsm_deinit();
+
 	/* note - someone else is responsible for restoring the GPIO config */
 
 	/* clean up the alternate device node */

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -171,6 +171,11 @@ public:
 	/** @see ModuleBase::run() */
 	void run() override;
 
+	/**
+	 * run the main loop: if running as task, continuously iterate, otherwise execute only one single cycle
+	 */
+	void cycle();
+
 	/** @see ModuleBase::print_status() */
 	int print_status() override;
 
@@ -1062,7 +1067,7 @@ PX4FMU::cycle_trampoline(void *arg)
 		_object = dev;
 	}
 
-	dev->run();
+	dev->cycle();
 }
 
 void
@@ -1181,6 +1186,18 @@ PX4FMU::update_pwm_out_state(bool on)
 
 void
 PX4FMU::run()
+{
+	if (init() != 0) {
+		PX4_ERR("init failed");
+		exit_and_cleanup();
+		return;
+	}
+
+	cycle();
+}
+
+void
+PX4FMU::cycle()
 {
 	while (true) {
 
@@ -3355,15 +3372,7 @@ PX4FMU::fake(int argc, char *argv[])
 PX4FMU *PX4FMU::instantiate(int argc, char *argv[])
 {
 	// No arguments to parse. We also know that we should run as task
-	PX4FMU *dev = new PX4FMU(true);
-
-	if (dev && dev->init() != 0) {
-		PX4_ERR("init failed");
-		delete dev;
-		dev = nullptr;
-	}
-
-	return dev;
+	return new PX4FMU(true);
 }
 
 int PX4FMU::custom_command(int argc, char *argv[])

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -470,7 +470,9 @@ PX4FMU::~PX4FMU()
 	/* make sure servos are off */
 	up_pwm_servo_deinit();
 
+#ifdef RC_SERIAL_PORT
 	dsm_deinit();
+#endif
 
 	/* note - someone else is responsible for restoring the GPIO config */
 

--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -72,9 +72,26 @@ PARAM_DEFINE_INT32(SYS_AUTOCONFIG, 0);
  * @boolean
  * @min 0
  * @max 1
+ * @reboot_required true
  * @group System
  */
 PARAM_DEFINE_INT32(SYS_USE_IO, 1);
+
+/**
+ * Run the FMU as a task to reduce latency
+ *
+ * If true, the FMU will run in a separate task instead of on the work queue.
+ * Set this if low latency is required, for example for racing.
+ *
+ * This is a trade-off between RAM usage and latency: running as a task, it
+ * requires a separate stack and directly polls on the control topics, whereas
+ * running on the work queue, it runs at a fixed update rate.
+ *
+ * @boolean
+ * @reboot_required true
+ * @group System
+ */
+PARAM_DEFINE_INT32(SYS_FMU_TASK, 0);
 
 /**
  * Set restart type


### PR DESCRIPTION
There were several problems when the fmu was running as a task, see individual commit messages. 
Note that these issues already existed before the modules base class PR https://github.com/PX4/Firmware/pull/7616.

Bench tested & test flown with a Pixracer.

TODO: I'll add a config param to start the fmu as task.