### PR TITLE
px4fmu-v2:Use simple HW versioning API to differentiate V2 variants at runtime.

### DIFF
--- a/src/drivers/boards/common/board_common.h
+++ b/src/drivers/boards/common/board_common.h
@@ -228,6 +228,17 @@
 #define BOARD_HAS_CAPTURE 1
 #endif
 
+/*
+ * Defined when a supports version and type API.
+ */
+#if defined(BOARD_HAS_SIMPLE_HW_VERSIONING)
+#  define BOARD_HAS_VERSIONING 1
+#  define HW_VER_SIMPLE(s)	     0x90000+(s)
+
+#  define HW_VER_FMUV2           HW_VER_SIMPLE(HW_VER_FMUV2_STATE)
+#  define HW_VER_FMUV3           HW_VER_SIMPLE(HW_VER_FMUV3_STATE)
+#  define HW_VER_FMUV2MINI       HW_VER_SIMPLE(HW_VER_FMUV2MINI_STATE)
+#endif
 
 /************************************************************************************
  * Public Data
@@ -390,6 +401,51 @@ __EXPORT void board_system_reset(int status) noreturn_function;
 #  define board_set_bootload_mode(mode)
 #else
 __EXPORT int board_set_bootload_mode(board_reset_e mode);
+#endif
+
+/************************************************************************************
+ * Name: board_get_hw_type
+ *
+ * Description:
+ *   Optional returns a string defining the HW type
+ *
+ *
+ ************************************************************************************/
+
+#if defined(BOARD_HAS_VERSIONING)
+__EXPORT const char *board_get_hw_type_name(void);
+#else
+#define board_get_hw_type_name() ""
+#endif
+
+/************************************************************************************
+ * Name: board_get_hw_version
+ *
+ * Description:
+ *   Optional returns a integer HW version
+ *
+ *
+ ************************************************************************************/
+
+#if defined(BOARD_HAS_VERSIONING)
+__EXPORT int board_get_hw_version(void);
+#else
+#define board_get_hw_version() 0
+#endif
+
+/************************************************************************************
+ * Name: board_get_hw_revision
+ *
+ * Description:
+ *   Optional returns a integer HW revision
+ *
+ *
+ ************************************************************************************/
+
+#if defined(BOARD_HAS_VERSIONING)
+__EXPORT int board_get_hw_revision(void);
+#else
+#define board_get_hw_revision() 0
 #endif
 
 #if !defined(BOARD_OVERRIDE_UUID)

--- a/src/drivers/boards/px4fmu-v3/board_config.h
+++ b/src/drivers/boards/px4fmu-v3/board_config.h
@@ -43,5 +43,16 @@
  * Included Files
  ****************************************************************************************************/
 
+/* Run time Hardware detection */
+#define BOARD_HAS_SIMPLE_HW_VERSIONING 1
+#define HW_VER_PB4             (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTB|GPIO_PIN4)
+#define HW_VER_PB12            (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTB|GPIO_PIN12)
+#define HW_VER_PB4_INIT        (GPIO_EXTI_ACCEL_DRDY)
+#define HW_VER_PB12_INIT       (GPIO_INPUT|GPIO_FLOAT|GPIO_PORTB|GPIO_PIN12)
+#define HW_VER_FMUV2_STATE     0x8 /* PB12:PU:1 PB12:PD:0 PB4:PU:0 PB4PD:0 */
+#define HW_VER_FMUV3_STATE     0xE /* PB12:PU:1 PB12:PD:1 PB4:PU:1 PB4PD:0 */
+#define HW_VER_FMUV2MINI_STATE 0xA /* PB12:PU:1 PB12:PD:0 PB4:PU:1 PB4PD:0 */
+#define HW_VER_TYPE_INIT {'V','2',0, 0}
+
 #include "../px4fmu-v2/board_config.h"
 #define PX4_SPIDEV_ICM_20608  PX4_SPIDEV_ACCEL_MAG // PixhawkMini has ICM_20608 on GPIO_SPI_CS_ACCEL_MAG

--- a/src/lib/version/version.h
+++ b/src/lib/version/version.h
@@ -67,6 +67,30 @@ static inline const char *px4_board_name(void)
 }
 
 /**
+ * get the board sub type
+ */
+static inline const char *px4_board_sub_type(void)
+{
+	return board_get_hw_type_name();
+}
+
+/**
+ * get the board HW version
+ */
+static inline int px4_board_hw_version(void)
+{
+	return board_get_hw_version();
+}
+
+/**
+ * get the board HW revision
+ */
+static inline int px4_board_hw_revision(void)
+{
+	return board_get_hw_revision();
+}
+
+/**
  * get the build URI (used for crash logging)
  */
 static inline const char *px4_build_uri(void)


### PR DESCRIPTION

   There are several boards that share the px4fmu-v2 build as px4fmu-v3 build.

   It was initially envisioned, that the build would be binary compatable and
   the RC script would probe different sensors and determine at runtime the
   HW type. Unfortunately, a failed sensor, can result in mis-detection
   of the HW and result in an improper start up and not detect the HW
   failure.

   All these boards's bootloader report board type as px4fmu-v2.
   This precludes and automated selection of the correct fw if it
   had been built, by a different build i.e. px4fmu-cube etc.

   We need a way to deal with the slight differences in HW that effect
   the operations of drivers and board level functions that are different
   from the FMUv2 pinout and bus utilization.

   1) FMUv3 AKA Cube 2.0 and Cube 2.1 Bothe I2C busses are external.
      This effected the mag on GPS2 not reporting Internal and
      having the wrong rotation applied.

   2) FMUv3 does not performa a SPI buss reset correctly.
      FMUv2 provides a SPI1 buss reset. But FMUv3 is on
      SPI4. To complicate matters the CS cross bus
      boundries.

   3) PixhawkMini reused a signal that was associated with SPI4
      as a SPI1 ready signal.

   Based on hardware differnce in the use of PB4 and PB12 this code
   detects: FMUv2,  the Cube, and PixhawkMini and provides the
   simple common API for retriving the type, version and revision.

   On FmuV5 this same API will be used.