### PR TITLE
MPU9250 Reset reorganization (fixes I2C functionality)

### DIFF
--- a/src/drivers/mpu9250/mpu9250.h
+++ b/src/drivers/mpu9250/mpu9250.h
@@ -375,6 +375,11 @@ private:
 	int			reset();
 
 
+	/**
+	 * Resets the main chip (excluding the magnetometer if any).
+	 */
+	int			reset_mpu();
+
 
 #if defined(USE_I2C)
 	/**

--- a/src/modules/syslink/syslink_main.h
+++ b/src/modules/syslink/syslink_main.h
@@ -67,7 +67,7 @@ public:
 	int set_channel(uint8_t channel);
 	int set_address(uint64_t addr);
 
-	int is_good(int i) { return _params_ack != 0; }
+	int is_good(int i) { return _params_ack[i] != 0; }
 
 	int pktrate;
 	int nullrate;


### PR DESCRIPTION
During MPU9250 initialization, depending on passthrough modes, the main chip must be reset() before the magnetometer connection is initialized in order to setup the passthrough to the magnetometer.

Current sequence of events (during init):
---
...
- reset()
    - "MPU6050" reset
    - AK8963 reset <- fails because not yet connected
- Magnetometer init/connect

...

Fixed sequence:
---
...
- reset_mpu()
    - "MPU6050" reset
- magnetometer init
- ak8963_reset()
    - AK8963 reset

...

The functionality of `reset()` is preserved, but for the initialization phase, the reset is split into a two phase reset.

Fixes #7624


Also adds a one liner fix specified in another issue report.