### PR TITLE
Support platforms like CF2 without capture ioctl

### DIFF
--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -2899,6 +2899,9 @@ PX4FMU::capture_ioctl(struct file *filp, int cmd, unsigned long arg)
 	}
 
 	unlock();
+
+#else
+	ret = -ENOTTY;
 #endif
 	return ret;
 }


### PR DESCRIPTION
Otherwise it would return EINVAL and stop trying to use one of the other ioctl handlers.