### PR TITLE
param import: don't fail on type mismatch

### DIFF
--- a/cmake/configs/nuttx_px4fmu-v1_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v1_default.cmake
@@ -28,7 +28,7 @@ set(config_module_list
 	#drivers/ll40ls
 	drivers/trone
 	drivers/gps
-	drivers/pwm_out_sim
+	#drivers/pwm_out_sim
 	#drivers/hott
 	#drivers/hott/hott_telemetry
 	#drivers/hott/hott_sensors

--- a/src/modules/systemlib/flashparams/flashparams.c
+++ b/src/modules/systemlib/flashparams/flashparams.c
@@ -231,7 +231,8 @@ param_import_callback(bson_decoder_t decoder, void *private, bson_node_t node)
 	switch (node->type) {
 	case BSON_INT32:
 		if (param_type(param) != PARAM_TYPE_INT32) {
-			debug("unexpected type for '%s", node->name);
+			PX4_WARN("unexpected type for %s", node->name);
+			result = 1; // just skip this entry
 			goto out;
 		}
 
@@ -241,7 +242,8 @@ param_import_callback(bson_decoder_t decoder, void *private, bson_node_t node)
 
 	case BSON_DOUBLE:
 		if (param_type(param) != PARAM_TYPE_FLOAT) {
-			debug("unexpected type for '%s", node->name);
+			PX4_WARN("unexpected type for %s", node->name);
+			result = 1; // just skip this entry
 			goto out;
 		}
 
@@ -251,12 +253,14 @@ param_import_callback(bson_decoder_t decoder, void *private, bson_node_t node)
 
 	case BSON_BINDATA:
 		if (node->subtype != BSON_BIN_BINARY) {
-			debug("unexpected subtype for '%s", node->name);
+			PX4_WARN("unexpected type for %s", node->name);
+			result = 1; // just skip this entry
 			goto out;
 		}
 
 		if (bson_decoder_data_pending(decoder) != param_size(param)) {
-			debug("bad size for '%s'", node->name);
+			PX4_WARN("bad size for '%s'", node->name);
+			result = 1; // just skip this entry
 			goto out;
 		}
 

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -1137,7 +1137,8 @@ param_import_callback(bson_decoder_t decoder, void *private, bson_node_t node)
 	switch (node->type) {
 	case BSON_INT32:
 		if (param_type(param) != PARAM_TYPE_INT32) {
-			debug("unexpected type for '%s", node->name);
+			PX4_WARN("unexpected type for %s", node->name);
+			result = 1; // just skip this entry
 			goto out;
 		}
 
@@ -1147,7 +1148,8 @@ param_import_callback(bson_decoder_t decoder, void *private, bson_node_t node)
 
 	case BSON_DOUBLE:
 		if (param_type(param) != PARAM_TYPE_FLOAT) {
-			debug("unexpected type for '%s", node->name);
+			PX4_WARN("unexpected type for %s", node->name);
+			result = 1; // just skip this entry
 			goto out;
 		}
 
@@ -1157,12 +1159,14 @@ param_import_callback(bson_decoder_t decoder, void *private, bson_node_t node)
 
 	case BSON_BINDATA:
 		if (node->subtype != BSON_BIN_BINARY) {
-			debug("unexpected subtype for '%s", node->name);
+			PX4_WARN("unexpected subtype for %s", node->name);
+			result = 1; // just skip this entry
 			goto out;
 		}
 
 		if (bson_decoder_data_pending(decoder) != param_size(param)) {
-			debug("bad size for '%s'", node->name);
+			PX4_WARN("bad size for '%s'", node->name);
+			result = 1; // just skip this entry
 			goto out;
 		}
 

--- a/src/modules/systemlib/param/param_shmem.c
+++ b/src/modules/systemlib/param/param_shmem.c
@@ -1170,7 +1170,8 @@ param_import_callback(bson_decoder_t decoder, void *private, bson_node_t node)
 	switch (node->type) {
 	case BSON_INT32:
 		if (param_type(param) != PARAM_TYPE_INT32) {
-			PX4_DEBUG("unexpected type for '%s", node->name);
+			PX4_WARN("unexpected type for %s", node->name);
+			result = 1; // just skip this entry
 			goto out;
 		}
 
@@ -1181,7 +1182,8 @@ param_import_callback(bson_decoder_t decoder, void *private, bson_node_t node)
 
 	case BSON_DOUBLE:
 		if (param_type(param) != PARAM_TYPE_FLOAT) {
-			PX4_DEBUG("unexpected type for '%s", node->name);
+			PX4_WARN("unexpected type for %s", node->name);
+			result = 1; // just skip this entry
 			goto out;
 		}
 
@@ -1192,12 +1194,14 @@ param_import_callback(bson_decoder_t decoder, void *private, bson_node_t node)
 
 	case BSON_BINDATA:
 		if (node->subtype != BSON_BIN_BINARY) {
-			PX4_DEBUG("unexpected subtype for '%s", node->name);
+			PX4_WARN("unexpected type for %s", node->name);
+			result = 1; // just skip this entry
 			goto out;
 		}
 
 		if (bson_decoder_data_pending(decoder) != param_size(param)) {
-			PX4_DEBUG("bad size for '%s'", node->name);
+			PX4_WARN("bad size for '%s'", node->name);
+			result = 1; // just skip this entry
 			goto out;
 		}
 


### PR DESCRIPTION
This can happen for example when a param type is changed from int32 to
float. The type check will then fail if the param is stored and the param
import will be aborted completely.
Now we just skip the entry and continue loading the rest.