### PR TITLE
Add Ubuntu-armhf Build for OcPoC-Zynq-mini

### DIFF
--- a/cmake/configs/posix_ocpoc_ubuntu.cmake
+++ b/cmake/configs/posix_ocpoc_ubuntu.cmake
@@ -1,0 +1,113 @@
+#set toolchain
+set(CMAKE_TOOLCHAIN_FILE ${PX4_SOURCE_DIR}/cmake/toolchains/Toolchain-gcc-arm-linux-gnueabihf.cmake)
+
+set(CMAKE_PROGRAM_PATH
+	${CMAKE_PROGRAM_PATH}
+)
+
+include(posix/px4_impl_posix)
+
+add_definitions(
+  -D__PX4_POSIX_OCPOC
+  -D__DF_LINUX # For DriverFramework
+  -D__DF_OCPOC # For DriverFramework
+  -D__PX4_POSIX
+)
+
+set(config_module_list
+	#
+	# Board support modules
+	#
+	drivers/device
+	modules/sensors
+	platforms/posix/drivers/df_mpu9250_wrapper
+	platforms/posix/drivers/df_ms5611_wrapper
+	platforms/posix/drivers/df_hmc5883_wrapper
+
+	#
+	# System commands
+	#
+	systemcmds/param
+	systemcmds/mixer
+	systemcmds/ver
+	systemcmds/esc_calib
+	systemcmds/reboot
+	systemcmds/topic_listener
+	systemcmds/perf
+
+	#
+	# Estimation modules
+	#
+	modules/attitude_estimator_q
+	modules/position_estimator_inav
+	modules/local_position_estimator
+	modules/ekf2
+
+	#
+	# Vehicle Control
+	#
+	modules/mc_att_control
+	modules/mc_pos_control
+
+	#
+	# Library modules
+	#
+	modules/sdlog2
+	modules/logger
+	modules/commander
+	modules/systemlib/param
+	modules/systemlib
+	modules/systemlib/mixer
+	modules/uORB
+	modules/dataman
+	modules/land_detector
+	modules/navigator
+	modules/mavlink
+
+	#
+	# PX4 drivers
+	#
+	drivers/gps
+	drivers/ocpoc_adc
+	drivers/ocpoc_sbus_rc_in
+	drivers/linux_pwm_out
+	drivers/rgbled
+
+	#
+	# Libraries
+	#
+	lib/controllib
+	lib/mathlib
+	lib/mathlib/math/filter
+	lib/geo
+	lib/ecl
+	lib/geo_lookup
+	lib/launchdetection
+	lib/external_lgpl
+	lib/conversion
+	lib/terrain_estimation
+	lib/runway_takeoff
+	lib/tailsitter_recovery
+	lib/version
+	lib/DriverFramework/framework
+	lib/rc
+	lib/led
+
+	#
+	# POSIX
+	#
+	platforms/common
+	platforms/posix/px4_layer
+	platforms/posix/work_queue
+	
+	examples/px4_simple_app
+)
+
+#
+# DriverFramework driver
+#
+set(config_df_driver_list
+	mpu9250
+	ms5611
+	hmc5883
+)

--- a/cmake/toolchains/Toolchain-gcc-arm-linux-gnueabihf.cmake
+++ b/cmake/toolchains/Toolchain-gcc-arm-linux-gnueabihf.cmake
@@ -1,0 +1,74 @@
+# defines:
+#
+# NM
+# OBJCOPY
+# LD
+# CXX_COMPILER
+# C_COMPILER
+# CMAKE_SYSTEM_NAME
+# CMAKE_SYSTEM_VERSION
+# LINKER_FLAGS
+# CMAKE_EXE_LINKER_FLAGS
+# CMAKE_FIND_ROOT_PATH
+# CMAKE_FIND_ROOT_PATH_MODE_PROGRAM
+# CMAKE_FIND_ROOT_PATH_MODE_LIBRARY
+# CMAKE_FIND_ROOT_PATH_MODE_INCLUDE
+
+include(CMakeForceCompiler)
+
+# this one is important
+set(CMAKE_SYSTEM_NAME Generic)
+
+#this one not so much
+set(CMAKE_SYSTEM_VERSION 1)
+
+# specify the cross compiler
+find_program(C_COMPILER arm-linux-gnueabihf-gcc)
+
+if(NOT C_COMPILER)
+	message(STATUS "Make sure to: apt-get install arm-linux-gnueabihf-gcc")
+	message(FATAL_ERROR "could not find arm-linux-gnueabihf-gcc compiler")
+endif()
+cmake_force_c_compiler(${C_COMPILER} GNU)
+
+find_program(CXX_COMPILER arm-linux-gnueabihf-g++)
+
+if(NOT CXX_COMPILER)
+	message(FATAL_ERROR "could not find arm-linux-gnueabihf-g++ compiler")
+endif()
+cmake_force_cxx_compiler(${CXX_COMPILER} GNU)
+
+# compiler tools
+foreach(tool objcopy nm ld)
+	string(TOUPPER ${tool} TOOL)
+	find_program(${TOOL} arm-linux-gnueabihf-${tool})
+	if(NOT ${TOOL})
+		message(FATAL_ERROR "could not find arm-linux-gnueabihf-${tool}")
+	endif()
+endforeach()
+
+# os tools
+foreach(tool echo grep rm mkdir nm cp touch make unzip)
+	string(TOUPPER ${tool} TOOL)
+	find_program(${TOOL} ${tool})
+	if(NOT ${TOOL})
+		message(FATAL_ERROR "could not find ${TOOL}")
+	endif()
+endforeach()
+
+set(LINKER_FLAGS "-Wl,-gc-sections")
+set(CMAKE_EXE_LINKER_FLAGS ${LINKER_FLAGS})
+set(CMAKE_C_FLAGS ${C_FLAGS})
+set(CMAKE_CXX_LINKER_FLAGS ${C_FLAGS} -mfloat-abi=hard -mcpu=cortex-a9 -mfpu=neon-vfpv3 -O3 -funsafe-math-optimizations -mthumb-interwork -ftree-vectorize)
+
+# where is the target environment
+set(CMAKE_FIND_ROOT_PATH  get_file_component(${C_COMPILER} PATH))
+
+# search for programs in the build host directories
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# for libraries and headers in the target directories
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# enable static linking
+#set(LDFLAGS "--disable-shared")

--- a/src/drivers/ocpoc_adc/ocpoc_adc.cpp
+++ b/src/drivers/ocpoc_adc/ocpoc_adc.cpp
@@ -154,7 +154,12 @@ int OcpocADC::read(px4_adc_msg_t(*buf)[PX4_MAX_ADC_CHANNELS], unsigned int len)
 	FILE *xadc_fd = fopen(ADC_VOLTAGE_PATH, "r");
 
 	if (xadc_fd != NULL) {
-		fscanf(xadc_fd, "%d", buff);
+		int ret_tmp = fscanf(xadc_fd, "%d", buff);
+
+		if (ret_tmp < 0) {
+			ret = ret_tmp;
+		}
+
 		fclose(xadc_fd);
 
 		(*buf)[0].am_data = buff[0];


### PR DESCRIPTION
Adds cmake configuration "posix_ocpoc_ubuntu" to build PX4 for ubuntu-armhf on OcPoC-Zynq-mini.