### PR TITLE
add constraint to ground distance to avoid values below rng_gnd_clear…

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -942,6 +942,12 @@ void Ekf2::run()
 			lpos.dist_bottom_valid = _ekf.get_terrain_valid();
 			_ekf.get_terrain_vert_pos(&terrain_vpos);
 			lpos.dist_bottom = terrain_vpos - pos[2]; // Distance to bottom surface (ground) in meters
+
+			// constrain the distance to ground to _params->rng_gnd_clearance
+			if (lpos.dist_bottom < _params->rng_gnd_clearance) {
+				lpos.dist_bottom = _params->rng_gnd_clearance;
+			}
+
 			lpos.dist_bottom_rate = -velocity[2]; // Distance to bottom surface (ground) change rate
 			lpos.surface_bottom_timestamp = now; // Time when new bottom surface found
 


### PR DESCRIPTION
…ance

I added the constraint to avoid negative values (or smaller than rng_gnd_clearance) which could lead do issues in control loops. There already is a constraint in the terrain estimator but as it runs on delayed time horizon it can still happen that `dist_bottom` will become neagive/small than clearance.

So far only tested in SITL. 