### PR TITLE
Fixes for FTP

### DIFF
--- a/src/modules/mavlink/mavlink_ftp.cpp
+++ b/src/modules/mavlink/mavlink_ftp.cpp
@@ -311,7 +311,8 @@ MavlinkFTP::_workList(PayloadHeader *payload, bool list_hidden)
 	struct dirent *result = nullptr;
 
 	// move to the requested offset
-	seekdir(dp, payload->offset);
+	int requested_offset = payload->offset;
+	while (requested_offset-- > 0 && readdir(dp));
 
 	for (;;) {
 		errno = 0;

--- a/src/platforms/px4_defines.h
+++ b/src/platforms/px4_defines.h
@@ -110,7 +110,7 @@ typedef param_t px4_param_t;
  * NuttX specific defines.
  ****************************************************************************/
 
-#define PX4_ROOTFSDIR
+#define PX4_ROOTFSDIR ""
 #define _PX4_IOC(x,y) _IOC(x,y)
 #define px4_statfs_buf_f_bavail_t int
 
@@ -174,7 +174,7 @@ using ::isfinite;
 
 // QURT specific
 #  include "dspal_math.h"
-#  define PX4_ROOTFSDIR
+#  define PX4_ROOTFSDIR ""
 #  define PX4_TICKS_PER_SEC 1000L
 #  define SIOCDEVPRIVATE 999999
 

--- a/src/systemcmds/tests/test_mixer.cpp
+++ b/src/systemcmds/tests/test_mixer.cpp
@@ -176,14 +176,10 @@ bool MixerTest::loadAllTest()
 
 	if (dp == nullptr) {
 		PX4_ERR("File open failed");
-		// this is not an FTP error, abort directory by simulating eof
 		return false;
 	}
 
 	struct dirent *result = nullptr;
-
-	// move to the requested offset
-	//seekdir(dp, payload->offset);
 
 	for (;;) {
 		errno = 0;


### PR DESCRIPTION
- avoid using seekdir()
- fix stack overflow:
      change memory allocation from stack to a malloc'd buffer. This avoids
      increasing the stack size. And since FTP is rarely used, the buffers
      are only allocated upon use and freed after a time of 2s inactivity.
- adds PX4_ROOTFSDIR as root directory prefix. This does not change
      anything on NuttX, but in SITL it will avoid enumerating the whole
      disk tree when using QGC (which enumerates all files recursively).

I tested repeatedly in SITL & on a Pixracer via USB with QGC and it works well, except when a message is dropped. In that case a transaction is immediately aborted, because of this:
https://github.com/mavlink/qgroundcontrol/blob/9af74e972bec5ec7616248e89c37b247e241ba28/src/uas/FileManager.cc#L326. We need to add retransmission to make this more robust.