### PR TITLE
EKF: Let the EKF know if the vehicle is operating as a fixed wing type.

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -732,6 +732,9 @@ void Ekf2::run()
 		bool fuse_beta = !vehicle_status.is_rotary_wing && _fuseBeta.get();
 		_ekf.set_fuse_beta_flag(fuse_beta);
 
+		// let the EKF know if the vehicle motion is that of a fixed wing (forward flight only relative to wind)
+		_ekf.set_is_fixed_wing(!vehicle_status.is_rotary_wing);
+
 		if (optical_flow_updated) {
 			flow_message flow;
 			flow.flowdata(0) = optical_flow.pixel_flow_x_integral;


### PR DESCRIPTION
Allows fixed wing aircraft to recover from bad compass at launch using https://github.com/PX4/ecl/pull/294.

Will improve reduce incidence of loss of navigation at start of flight such as seen here: http://logs.px4.io/plot_app?log=833a9742-1e37-4741-aaf4-2dbee246246e