### PR TITLE
Mavlink statustext relaying

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1924,6 +1924,9 @@ Mavlink::task_main(int argc, char *argv[])
 	/* initialize send mutex */
 	pthread_mutex_init(&_send_mutex, nullptr);
 
+	/* Initialize system properties */
+	mavlink_update_system();
+
 	/* if we are passing on mavlink messages, we need to prepare a buffer for this instance */
 	if (_forwarding_on || _ftp_on || _forward_statustext_on) {
 		/* initialize message buffer if multiplexing is on or its needed for FTP.
@@ -1938,9 +1941,6 @@ Mavlink::task_main(int argc, char *argv[])
 		/* initialize message buffer mutex */
 		pthread_mutex_init(&_message_buffer_mutex, nullptr);
 	}
-
-	/* Initialize system properties */
-	mavlink_update_system();
 
 	/* start the MAVLink receiver */
 	MavlinkReceiver::receive_start(&_receive_thread, this);

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -221,7 +221,7 @@ Mavlink::Mavlink() :
 	_receive_thread{},
 	_verbose(false),
 	_forwarding_on(false),
-	_forward_statustext_on(true),
+	_forward_statustext_on(false),
 	_ftp_on(false),
 	_uart_fd(-1),
 	_baudrate(57600),

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -210,6 +210,8 @@ public:
 
 	bool			get_forwarding_on() { return _forwarding_on; }
 
+	bool			get_forwarding_statustext_on() { return _forward_statustext_on; }
+
 	bool			get_config_link_on() { return _config_link_on; }
 
 	void			set_config_link_on(bool on) { _config_link_on = on; }
@@ -498,6 +500,7 @@ private:
 
 	bool			_verbose;
 	bool			_forwarding_on;
+	bool			_forward_statustext_on;
 	bool			_ftp_on;
 #ifndef __PX4_QURT
 	int			_uart_fd;
@@ -577,6 +580,7 @@ private:
 	param_t			_param_use_hil_gps;
 	param_t			_param_forward_externalsp;
 	param_t			_param_broadcast;
+	param_t			_param_statustext_forward;
 
 	unsigned		_system_type;
 	static bool		_config_link_on;

--- a/src/modules/mavlink/mavlink_params.c
+++ b/src/modules/mavlink/mavlink_params.c
@@ -124,3 +124,14 @@ PARAM_DEFINE_INT32(MAV_BROADCAST, 0);
  * @max 1000
  */
 PARAM_DEFINE_INT32(MAV_TEST_PAR, 1);
+
+/**
+ * Forward statustext messages to other links
+ *
+ * This parameter allows links to send statustext messages
+ * the messages will be relayed by the flight controller
+ *
+ * @boolean
+ * @group MAVLink
+ */
+PARAM_DEFINE_INT32(MAV_FWD_STATUS, 0);


### PR DESCRIPTION
This enables onboard computers to send statustext messages to connected GCS's
Tested both in SITL and with radio telemetry modules

/cc @AndreasAntener 