### PR TITLE
logger: avoid logging the UUID if the system does not provide it

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1674,6 +1674,7 @@ void Logger::write_version()
 		write_info("sys_mcu", mcu_ver);
 	}
 
+#ifndef BOARD_HAS_NO_UUID
 	/* write the UUID if enabled */
 	param_t write_uuid_param = param_find("SDLOG_UUID");
 
@@ -1687,6 +1688,7 @@ void Logger::write_version()
 			write_info("sys_uuid", uuid_string);
 		}
 	}
+#endif /* BOARD_HAS_NO_UUID */
 
 	int32_t utc_offset = 0;
 

--- a/src/platforms/posix/include/system_config.h
+++ b/src/platforms/posix/include/system_config.h
@@ -70,6 +70,7 @@
 #define board_get_uuid32(id) do {for(int _idi=0; _idi < PX4_CPU_UUID_WORD32_LENGTH; _idi++) {id[_idi] = _idi;}} while(0)
 #define board_get_uuid32_formated(format_buffer, size, format, seperator) do { strcpy(format_buffer, SIM_FORMATED_UUID); } while(0)
 
+#define BOARD_HAS_NO_UUID
 
 #define CONFIG_NFILE_STREAMS 1
 #define CONFIG_SCHED_WORKQUEUE 1


### PR DESCRIPTION
The linux targets don't have it and setting a fixed constant causes wrong vehicle associationss in Flight Review.