### PR TITLE
sensors: use interpolation to set param from RC input

### DIFF
--- a/src/modules/sensors/rc_update.cpp
+++ b/src/modules/sensors/rc_update.cpp
@@ -240,9 +240,11 @@ RCUpdate::set_params_from_rc(const ParameterHandles &parameter_handles)
 		 * maybe we need to introduce a more aggressive limit here */
 		if (rc_val > _param_rc_values[i] + FLT_EPSILON || rc_val < _param_rc_values[i] - FLT_EPSILON) {
 			_param_rc_values[i] = rc_val;
-			float param_val = math::constrain(
-						  _rc_parameter_map.value0[i] + _rc_parameter_map.scale[i] * rc_val,
-						  _rc_parameter_map.value_min[i], _rc_parameter_map.value_max[i]);
+
+			float param_val = rc_val >= 0.0f ?
+					  _rc_parameter_map.value0[i] + rc_val * (_rc_parameter_map.value_max[i] - _rc_parameter_map.value0[i]) :
+					  _rc_parameter_map.value0[i] + rc_val * (_rc_parameter_map.value0[i] - _rc_parameter_map.value_min[i]);
+
 			param_set(parameter_handles.rc_param[i], &param_val);
 		}
 	}


### PR DESCRIPTION
This PR changes the set_params_from_rc() function to use linear interpolation between the user-defined min, center, and max values based on the RC Input value. Since rc_val is essentially a percentage, and constrained from -1.0 to +1.0, all that's required to implement this is a small change to the "param_val" calculation as such:

- if rc_val is positive (or 0.0): param_val = [center value] + rc_val * ([max value] - [center value])
- if rc_val is negative: param_val = [center value] + rc_val * ([center value] - [min value])

Of course, this will be a change of philosophy in parameter tuning via RC input. In my personal case, while gain tuning a new airframe I set some values for MC_PITCHRATE_D assuming the parameter would interpolate between min, center, and max values. Since I left the "Scale" value to 1.0 and the derivative gains are so small, any small change in the RC Input away from the center input would immediately change the parameter from center to min or center to max. So the derivative gain didn't do anything as I increased the transmitter knob from min to its center, then just past half-way on the knob, the derivative gain immediately went from my min to my max value, causing some pretty wild behavior.

All that said, in my opinion, the presented change is a simpler approach to parameter tuning via RC input such that the end user doesn't need to figure out a "Scale" value for appropriate interpolation, rather the end user only needs to set min, center, and max values and the software will set the parameter accordingly.