### PR TITLE
disable uavcan build to make space for other modules

### DIFF
--- a/cmake/configs/nuttx_px4fmu-v2_test.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_test.cmake
@@ -96,7 +96,7 @@ set(config_module_list
 	modules/navigator
 	modules/mavlink
 	#modules/gpio_led
-	modules/uavcan
+	#modules/uavcan
 	modules/land_detector
 
 	#
@@ -198,10 +198,10 @@ set(config_io_board
 	px4io-v2
 	)
 
-set(config_extra_libs
-	uavcan
-	uavcan_stm32_driver
-	)
+#set(config_extra_libs
+#	uavcan
+#	uavcan_stm32_driver
+#	)
 
 set(config_io_extra_libs
 	)


### PR DESCRIPTION
When I make px4fmu-v2_test, there are some error related to region 'flash' overflow. 
To solve this problem, I disable uavcan build.

```
$make px4fmu-v2_test

~
/bin/ld: region `flash' overflowed by 41144 bytes
collect2: error: ld returned 1 exit status
~
```
