### PR TITLE
Guard against reboots during param saving

### DIFF
--- a/cmake/configs/nuttx_px4fmu-v1_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v1_default.cmake
@@ -94,7 +94,7 @@ set(config_module_list
 	#
 	# Logging
 	#
-	modules/sdlog2
+	#modules/sdlog2
 	modules/logger
 
 	#

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -125,7 +125,7 @@ set(config_module_list
 	# Logging
 	#
 	modules/logger
-	modules/sdlog2
+	#modules/sdlog2
 
 	#
 	# Library modules

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -81,6 +81,7 @@ set(msg_file_names
 	parameter_update.msg
 	position_setpoint.msg
 	position_setpoint_triplet.msg
+	power_button_state.msg
 	pwm_input.msg
 	qshell_req.msg
 	rc_channels.msg

--- a/msg/power_button_state.msg
+++ b/msg/power_button_state.msg
@@ -1,0 +1,8 @@
+# power button state notification message
+
+uint8 PWR_BUTTON_STATE_IDEL = 0             # Button went up without meeting shutdown button down time (delete event)
+uint8 PWR_BUTTON_STATE_DOWN = 1             # Button went Down
+uint8 PWR_BUTTON_STATE_UP = 2               # Button went Up
+uint8 PWR_BUTTON_STATE_REQUEST_SHUTDOWN = 3 # Button went Up after meeting shutdown button down time
+
+uint8 event                                 # one of PWR_BUTTON_STATE_*

--- a/src/drivers/boards/tap-v1/tap_pwr.c
+++ b/src/drivers/boards/tap-v1/tap_pwr.c
@@ -59,6 +59,9 @@
 extern void led_on(int led);
 extern void led_off(int led);
 
+static struct timespec time_down;
+
+
 /************************************************************************************
  * Private Data
  ************************************************************************************/
@@ -80,6 +83,12 @@ static power_button_state_notification_t power_state_notification = default_powe
 int board_register_power_state_notification_cb(power_button_state_notification_t cb)
 {
 	power_state_notification = cb;
+
+	if (board_pwr_button_down() && (time_down.tv_nsec != 0 || time_down.tv_sec != 0)) {
+		// make sure we don't miss the first event
+		power_state_notification(PWR_BUTTON_DOWN);
+	}
+
 	return OK;
 }
 
@@ -99,8 +108,6 @@ int board_shutdown()
 
 static int board_button_irq(int irq, FAR void *context)
 {
-	static struct timespec time_down;
-
 	if (board_pwr_button_down()) {
 
 		led_on(BOARD_LED_RED);

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -104,6 +104,7 @@
 #include <uORB/topics/mission_result.h>
 #include <uORB/topics/offboard_control_mode.h>
 #include <uORB/topics/position_setpoint_triplet.h>
+#include <uORB/topics/power_button_state.h>
 #include <uORB/topics/vehicle_roi.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/safety.h>
@@ -176,6 +177,8 @@ static int64_t lvel_probation_time_us = POSVEL_PROBATION_TAKEOFF;
 
 /* Mavlink log uORB handle */
 static orb_advert_t mavlink_log_pub = nullptr;
+
+static orb_advert_t power_button_state_pub = nullptr;
 
 /* System autostart ID */
 static int autostart_id;
@@ -337,11 +340,34 @@ static void publish_status_flags(orb_advert_t &vehicle_status_flags_pub);
 
 static int power_button_state_notification_cb(board_power_button_state_notification_e request)
 {
-	// Note: this can be called from IRQ handlers
-	if (request == PWR_BUTTON_REQUEST_SHUT_DOWN) {
-		px4_shutdown_request(false, false);
+	// Note: this can be called from IRQ handlers, so we publish a message that will be handled
+	// on the main thread of commander.
+	power_button_state_s button_state;
+	button_state.timestamp = hrt_absolute_time();
+	int ret = PWR_BUTTON_RESPONSE_SHUT_DOWN_PENDING;
+
+	switch(request) {
+		case PWR_BUTTON_IDEL:
+			button_state.event = power_button_state_s::PWR_BUTTON_STATE_IDEL;
+			break;
+		case PWR_BUTTON_DOWN:
+			button_state.event = power_button_state_s::PWR_BUTTON_STATE_DOWN;
+			break;
+		case PWR_BUTTON_UP:
+			button_state.event = power_button_state_s::PWR_BUTTON_STATE_UP;
+			break;
+		case PWR_BUTTON_REQUEST_SHUT_DOWN:
+			button_state.event = power_button_state_s::PWR_BUTTON_STATE_REQUEST_SHUTDOWN;
+			break;
+		default:
+			PX4_ERR("unhandled power button state: %i", (int)request);
+			return ret;
 	}
-	return PWR_BUTTON_RESPONSE_SHUT_DOWN_PENDING;
+
+	int instance;
+	orb_publish_auto(ORB_ID(power_button_state), &power_button_state_pub, &button_state, &instance, ORB_PRIO_DEFAULT);
+
+	return ret;
 }
 
 /**
@@ -1657,6 +1683,8 @@ int commander_thread_main(int argc, char *argv[])
 	struct system_power_s system_power;
 	memset(&system_power, 0, sizeof(system_power));
 
+	int power_button_state_sub = orb_subscribe(ORB_ID(power_button_state));
+
 	/* Subscribe to actuator controls (outputs) */
 	int actuator_controls_sub = orb_subscribe(ORB_ID_VEHICLE_ATTITUDE_CONTROLS);
 	struct actuator_controls_s actuator_controls;
@@ -1892,6 +1920,17 @@ int commander_thread_main(int argc, char *argv[])
 			param_get(_param_posctl_nav_loss_act, &posctl_nav_loss_act);
 
 			param_init_forced = false;
+		}
+
+		/* handle power button state */
+		orb_check(power_button_state_sub, &updated);
+
+		if (updated) {
+			power_button_state_s button_state;
+			orb_copy(ORB_ID(power_button_state), power_button_state_sub, &button_state);
+			if (button_state.event == power_button_state_s::PWR_BUTTON_STATE_REQUEST_SHUTDOWN) {
+				px4_shutdown_request(false, false);
+			}
 		}
 
 		orb_check(sp_man_sub, &updated);

--- a/src/modules/systemlib/flashparams/flashparams.c
+++ b/src/modules/systemlib/flashparams/flashparams.c
@@ -44,6 +44,7 @@
 
 #include <px4_defines.h>
 #include <px4_posix.h>
+#include <px4_shutdown.h>
 #include <string.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -158,6 +159,12 @@ out:
 
 		size_t buf_size = bson_encoder_buf_size(&encoder);
 
+		int shutdown_lock_ret = px4_shutdown_lock();
+
+		if (shutdown_lock_ret) {
+			PX4_ERR("px4_shutdown_lock() failed (%i)", shutdown_lock_ret);
+		}
+
 		/* Get a buffer from the flash driver with enough space */
 
 		uint8_t *buffer;
@@ -186,6 +193,11 @@ out:
 			free(enc_buff);
 			parameter_flashfs_free();
 		}
+
+		if (shutdown_lock_ret == 0) {
+			px4_shutdown_unlock();
+		}
+
 	}
 
 	return result;

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -947,6 +947,10 @@ param_save_default(void)
 	while (res != OK && attempts > 0) {
 		res = param_export(fd, false);
 		attempts--;
+
+		if (res != OK) {
+			lseek(fd, 0, SEEK_SET); // jump back to the beginning of the file
+		}
 	}
 
 	if (res != OK) {

--- a/src/platforms/common/shutdown.cpp
+++ b/src/platforms/common/shutdown.cpp
@@ -94,6 +94,7 @@ int px4_unregister_shutdown_hook(shutdown_hook_t hook)
 
 int px4_shutdown_request(bool reboot, bool to_bootloader)
 {
+	int ret = 0;
 	pthread_mutex_lock(&shutdown_mutex);
 
 	// FIXME: if shutdown_lock_counter > 0, we should wait, but unfortunately we don't have work queues
@@ -101,12 +102,12 @@ int px4_shutdown_request(bool reboot, bool to_bootloader)
 		px4_systemreset(to_bootloader);
 
 	} else {
-		return board_shutdown();
+		ret = board_shutdown();
 	}
 
 	pthread_mutex_unlock(&shutdown_mutex);
 
-	return 0;
+	return ret;
 }
 
 #else

--- a/src/platforms/common/shutdown.cpp
+++ b/src/platforms/common/shutdown.cpp
@@ -45,6 +45,35 @@
 #include <errno.h>
 #include <pthread.h>
 
+static pthread_mutex_t shutdown_mutex =
+	PTHREAD_MUTEX_INITIALIZER; // protects access to shutdown_hooks & shutdown_lock_counter
+static uint8_t shutdown_lock_counter = 0;
+
+int px4_shutdown_lock()
+{
+	int ret = pthread_mutex_lock(&shutdown_mutex);
+
+	if (ret == 0) {
+		++shutdown_lock_counter;
+		return pthread_mutex_unlock(&shutdown_mutex);
+	}
+
+	return ret;
+}
+
+int px4_shutdown_unlock()
+{
+	int ret = pthread_mutex_lock(&shutdown_mutex);
+
+	if (ret == 0) {
+		--shutdown_lock_counter;
+		return pthread_mutex_unlock(&shutdown_mutex);
+	}
+
+	return ret;
+}
+
+
 #if (defined(__PX4_NUTTX) && !defined(CONFIG_SCHED_WORKQUEUE)) || __PX4_QURT
 // minimal NuttX/QuRT build without work queue support
 
@@ -59,6 +88,9 @@ int px4_unregister_shutdown_hook(shutdown_hook_t hook)
 
 int px4_shutdown_request(bool reboot, bool to_bootloader)
 {
+	pthread_mutex_lock(&shutdown_mutex);
+
+	// FIXME: if shutdown_lock_counter > 0, we should wait, but unfortunately we don't have work queues
 	if (reboot) {
 		px4_systemreset(to_bootloader);
 
@@ -66,13 +98,15 @@ int px4_shutdown_request(bool reboot, bool to_bootloader)
 		return board_shutdown();
 	}
 
+	pthread_mutex_unlock(&shutdown_mutex);
+
 	return 0;
 }
 
 #else
 
 static struct work_s shutdown_work = {};
-static uint8_t shutdown_counter = 0;
+static uint16_t shutdown_counter = 0; ///< count how many times the shutdown worker was executed
 
 #define SHUTDOWN_ARG_IN_PROGRESS (1<<0)
 #define SHUTDOWN_ARG_REBOOT (1<<1)
@@ -80,7 +114,6 @@ static uint8_t shutdown_counter = 0;
 static uint8_t shutdown_args = 0;
 
 
-pthread_mutex_t shutdown_hooks_mutex = PTHREAD_MUTEX_INITIALIZER; // protects access to shutdown_hooks
 static const int max_shutdown_hooks = 1;
 static shutdown_hook_t shutdown_hooks[max_shutdown_hooks] = {};
 
@@ -97,33 +130,33 @@ static void shutdown_worker(void *arg);
 
 int px4_register_shutdown_hook(shutdown_hook_t hook)
 {
-	pthread_mutex_lock(&shutdown_hooks_mutex);
+	pthread_mutex_lock(&shutdown_mutex);
 
 	for (int i = 0; i < max_shutdown_hooks; ++i) {
 		if (!shutdown_hooks[i]) {
 			shutdown_hooks[i] = hook;
-			pthread_mutex_unlock(&shutdown_hooks_mutex);
+			pthread_mutex_unlock(&shutdown_mutex);
 			return 0;
 		}
 	}
 
-	pthread_mutex_unlock(&shutdown_hooks_mutex);
+	pthread_mutex_unlock(&shutdown_mutex);
 	return -ENOMEM;
 }
 
 int px4_unregister_shutdown_hook(shutdown_hook_t hook)
 {
-	pthread_mutex_lock(&shutdown_hooks_mutex);
+	pthread_mutex_lock(&shutdown_mutex);
 
 	for (int i = 0; i < max_shutdown_hooks; ++i) {
 		if (shutdown_hooks[i] == hook) {
 			shutdown_hooks[i] = nullptr;
-			pthread_mutex_unlock(&shutdown_hooks_mutex);
+			pthread_mutex_unlock(&shutdown_mutex);
 			return 0;
 		}
 	}
 
-	pthread_mutex_unlock(&shutdown_hooks_mutex);
+	pthread_mutex_unlock(&shutdown_mutex);
 	return -EINVAL;
 }
 
@@ -134,7 +167,7 @@ void shutdown_worker(void *arg)
 	PX4_DEBUG("shutdown worker (%i)", shutdown_counter);
 	bool done = true;
 
-	pthread_mutex_lock(&shutdown_hooks_mutex);
+	pthread_mutex_lock(&shutdown_mutex);
 
 	for (int i = 0; i < max_shutdown_hooks; ++i) {
 		if (shutdown_hooks[i]) {
@@ -144,9 +177,7 @@ void shutdown_worker(void *arg)
 		}
 	}
 
-	pthread_mutex_unlock(&shutdown_hooks_mutex);
-
-	if (done || ++shutdown_counter > shutdown_timeout_ms / 10) {
+	if ((done && shutdown_lock_counter == 0) || ++shutdown_counter > shutdown_timeout_ms / 10) {
 		if (shutdown_args & SHUTDOWN_ARG_REBOOT) {
 			PX4_WARN("Reboot NOW.");
 			px4_systemreset(shutdown_args & SHUTDOWN_ARG_TO_BOOTLOADER);
@@ -156,7 +187,10 @@ void shutdown_worker(void *arg)
 			board_shutdown();
 		}
 
+		pthread_mutex_unlock(&shutdown_mutex); // must NEVER come here
+
 	} else {
+		pthread_mutex_unlock(&shutdown_mutex);
 		work_queue(HPWORK, &shutdown_work, (worker_t)&shutdown_worker, nullptr, USEC2TICK(10000));
 	}
 }
@@ -192,7 +226,8 @@ int px4_shutdown_request(bool reboot, bool to_bootloader)
 		shutdown_args |= SHUTDOWN_ARG_TO_BOOTLOADER;
 	}
 
-	return work_queue(HPWORK, &shutdown_work, (worker_t)&shutdown_worker, nullptr, USEC2TICK(0));
+	shutdown_worker(nullptr);
+	return 0;
 }
 
 

--- a/src/platforms/common/shutdown.cpp
+++ b/src/platforms/common/shutdown.cpp
@@ -118,7 +118,7 @@ static const int max_shutdown_hooks = 1;
 static shutdown_hook_t shutdown_hooks[max_shutdown_hooks] = {};
 
 
-static const int shutdown_timeout_ms = 300; // force shutdown after this time if modules do not respond in time
+static const int shutdown_timeout_ms = 5000; ///< force shutdown after this time if modules do not respond in time
 
 
 /**

--- a/src/platforms/common/shutdown.cpp
+++ b/src/platforms/common/shutdown.cpp
@@ -66,7 +66,13 @@ int px4_shutdown_unlock()
 	int ret = pthread_mutex_lock(&shutdown_mutex);
 
 	if (ret == 0) {
-		--shutdown_lock_counter;
+		if (shutdown_lock_counter > 0) {
+			--shutdown_lock_counter;
+
+		} else {
+			PX4_ERR("unmatched number of px4_shutdown_unlock() calls");
+		}
+
 		return pthread_mutex_unlock(&shutdown_mutex);
 	}
 

--- a/src/platforms/px4_shutdown.h
+++ b/src/platforms/px4_shutdown.h
@@ -69,8 +69,7 @@ __EXPORT int px4_unregister_shutdown_hook(shutdown_hook_t hook);
 
 
 /**
- * Request the system to shut down. It's save to call this from an IRQ context,
- * but the work queues need to be initialized already.
+ * Request the system to shut down or reboot.
  * Note the following:
  * - The system might not support to shutdown (or reboot). In that case -EINVAL will
  *   be returned.

--- a/src/platforms/px4_shutdown.h
+++ b/src/platforms/px4_shutdown.h
@@ -81,5 +81,19 @@ __EXPORT int px4_unregister_shutdown_hook(shutdown_hook_t hook);
  */
 __EXPORT int px4_shutdown_request(bool reboot, bool to_bootloader);
 
+
+/**
+ * Grab the shutdown lock. It will prevent the system from shutting down until the lock is released.
+ * It is safe to call this recursively.
+ * @return 0 on success, <0 on error
+ */
+__EXPORT int px4_shutdown_lock(void);
+
+/**
+ * Release the shutdown lock.
+ * @return 0 on success, <0 on error
+ */
+__EXPORT int px4_shutdown_unlock(void);
+
 __END_DECLS
 

--- a/src/systemcmds/reboot/reboot.c
+++ b/src/systemcmds/reboot/reboot.c
@@ -43,6 +43,7 @@
 #include <px4_module.h>
 #include <px4_shutdown.h>
 #include <systemlib/systemlib.h>
+#include <string.h>
 
 __EXPORT int reboot_main(int argc, char *argv[]);
 
@@ -52,6 +53,8 @@ static void print_usage(void)
 
 	PRINT_MODULE_USAGE_NAME_SIMPLE("reboot", "command");
 	PRINT_MODULE_USAGE_PARAM_FLAG('b', "Reboot into bootloader", true);
+
+	PRINT_MODULE_USAGE_ARG("lock|unlock", "Take/release the shutdown lock (for testing)", true);
 }
 
 int reboot_main(int argc, char *argv[])
@@ -73,6 +76,28 @@ int reboot_main(int argc, char *argv[])
 			return 1;
 
 		}
+	}
+
+	if (myoptind >= 0 && myoptind < argc) {
+		int ret = -1;
+
+		if (strcmp(argv[myoptind], "lock") == 0) {
+			ret = px4_shutdown_lock();
+
+			if (ret != 0) {
+				PX4_ERR("lock failed (%i)", ret);
+			}
+		}
+
+		if (strcmp(argv[myoptind], "unlock") == 0) {
+			ret = px4_shutdown_unlock();
+
+			if (ret != 0) {
+				PX4_ERR("unlock failed (%i)", ret);
+			}
+		}
+
+		return ret;
 	}
 
 	int ret = px4_shutdown_request(true, to_bootloader);


### PR DESCRIPTION
This adds a shutdown locking API: the lock is aquired during param write, so that all shutdowns & reboots (this includes power button, reboots from shell scripts, FW flashing, low battery poweroff, ...) are deferred (with a maximum timeout of 5sec, after that the system forces shutdown). This avoids corrupt param storage.
It is implemented in a way that the lock is always only held for a very short time, so that the negative effects are avoided (priority inversion, blocking a work queue).

The reboot command adds a `lock` and `unlock` command for testing:

```
reboot lock
reboot &
reboot unlock
```

It can also be tested with `param save & ; reboot`.

---

In addition it changes the work queue call from IRQ context for the power button notification (https://github.com/PX4/Firmware/pull/7038) to an uORB publication. Work queues cannot be used in IRQ context on NuttX because they use semaphores.