### PR TITLE
Airspeed measurement: Add accurate models for dynamic pressure

### DIFF
--- a/src/modules/sensors/parameters.cpp
+++ b/src/modules/sensors/parameters.cpp
@@ -157,6 +157,10 @@ int initialize_parameter_handles(ParameterHandles &parameter_handles)
 
 	parameter_handles.vibe_thresh = param_find("ATT_VIBE_THRESH");
 
+	parameter_handles.air_pmodel = param_find("CAL_AIR_PMODEL");
+	parameter_handles.air_smodel = param_find("CAL_AIR_SMODEL");
+	parameter_handles.air_tube_length = param_find("CAL_AIR_TUBELEN");
+
 	// These are parameters for which QGroundControl always expects to be returned in a list request.
 	// We do a param_find here to force them into the list.
 	(void)param_find("RC_CHAN_CNT");
@@ -487,6 +491,10 @@ int update_parameters(const ParameterHandles &parameter_handles, Parameters &par
 	param_get(parameter_handles.baro_qnh, &(parameters.baro_qnh));
 
 	param_get(parameter_handles.vibe_thresh, &parameters.vibration_warning_threshold);
+
+	param_get(parameter_handles.air_pmodel, &parameters.air_pmodel);
+	param_get(parameter_handles.air_smodel, &parameters.air_smodel);
+	param_get(parameter_handles.air_tube_length, &parameters.air_tube_length);
 
 	return ret;
 }

--- a/src/modules/sensors/parameters.cpp
+++ b/src/modules/sensors/parameters.cpp
@@ -158,7 +158,6 @@ int initialize_parameter_handles(ParameterHandles &parameter_handles)
 	parameter_handles.vibe_thresh = param_find("ATT_VIBE_THRESH");
 
 	parameter_handles.air_pmodel = param_find("CAL_AIR_PMODEL");
-	parameter_handles.air_smodel = param_find("CAL_AIR_SMODEL");
 	parameter_handles.air_tube_length = param_find("CAL_AIR_TUBELEN");
 
 	// These are parameters for which QGroundControl always expects to be returned in a list request.
@@ -493,7 +492,6 @@ int update_parameters(const ParameterHandles &parameter_handles, Parameters &par
 	param_get(parameter_handles.vibe_thresh, &parameters.vibration_warning_threshold);
 
 	param_get(parameter_handles.air_pmodel, &parameters.air_pmodel);
-	param_get(parameter_handles.air_smodel, &parameters.air_smodel);
 	param_get(parameter_handles.air_tube_length, &parameters.air_tube_length);
 
 	return ret;

--- a/src/modules/sensors/parameters.h
+++ b/src/modules/sensors/parameters.h
@@ -147,7 +147,6 @@ struct Parameters {
 	float vibration_warning_threshold;
 
 	int32_t air_pmodel;
-	int32_t air_smodel;
 	float air_tube_length;
 
 };
@@ -232,7 +231,6 @@ struct ParameterHandles {
 	param_t vibe_thresh; /**< vibration threshold */
 
 	param_t air_pmodel;
-	param_t air_smodel;
 	param_t air_tube_length;
 
 };

--- a/src/modules/sensors/parameters.h
+++ b/src/modules/sensors/parameters.h
@@ -146,6 +146,10 @@ struct Parameters {
 
 	float vibration_warning_threshold;
 
+	int32_t air_pmodel;
+	int32_t air_smodel;
+	float air_tube_length;
+
 };
 
 struct ParameterHandles {
@@ -226,6 +230,10 @@ struct ParameterHandles {
 	param_t baro_qnh;
 
 	param_t vibe_thresh; /**< vibration threshold */
+
+	param_t air_pmodel;
+	param_t air_smodel;
+	param_t air_tube_length;
 
 };
 

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -831,7 +831,7 @@ PARAM_DEFINE_INT32(CAL_AIR_PMODEL, 0);
  *
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(CAL_AIR_TUBELEN, 0.15);
+PARAM_DEFINE_FLOAT(CAL_AIR_TUBELEN, 0.2f);
 
 /**
  * Differential pressure sensor offset

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2017 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -813,6 +813,35 @@ PARAM_DEFINE_INT32(CAL_MAG_SIDES, 63);
  * @group Sensor Calibration
  */
 PARAM_DEFINE_INT32(CAL_BARO_PRIME, 0);
+
+/**
+ * Airspeed sensor pitot model
+ *
+ * @value 0 HB Pitot
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_AIR_PMODEL, 0);
+
+/**
+ * Airspeed sensor model
+ *
+ * @value 0 Membrane sensor
+ * @value 1 Sensirion SDP3x
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_AIR_SMODEL, 0);
+
+/**
+ * Airspeed sensor tube length
+ * @min 0.01
+ * @max 0.5
+ * @unit meter
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_AIR_TUBELEN, 0.15);
 
 /**
  * Differential pressure sensor offset

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -824,16 +824,6 @@ PARAM_DEFINE_INT32(CAL_BARO_PRIME, 0);
 PARAM_DEFINE_INT32(CAL_AIR_PMODEL, 0);
 
 /**
- * Airspeed sensor model
- *
- * @value 0 Membrane sensor
- * @value 1 Sensirion SDP3x
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_AIR_SMODEL, 0);
-
-/**
  * Airspeed sensor tube length
  * @min 0.01
  * @max 0.5

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -346,10 +346,13 @@ Sensors::diff_pres_poll(struct sensor_combined_s &raw)
 
 		/* don't risk to feed negative airspeed into the system */
 		_airspeed.indicated_airspeed_m_s = math::max(0.0f,
-						   calc_indicated_airspeed(_diff_pres.differential_pressure_filtered_pa));
+						   calc_indicated_airspeed_corrected((enum AIRSPEED_PITOT_MODEL)_parameters.air_pmodel,
+								   (enum AIRSPEED_SENSOR_MODEL)_parameters.air_smodel, _parameters.air_tube_length,
+								   _diff_pres.differential_pressure_filtered_pa, _voted_sensors_update.baro_pressure(),
+								   air_temperature_celsius));
 
 		_airspeed.true_airspeed_m_s = math::max(0.0f,
-							calc_true_airspeed(_diff_pres.differential_pressure_filtered_pa + _voted_sensors_update.baro_pressure(),
+							calc_true_airspeed_from_indicated(_airspeed.indicated_airspeed_m_s,
 									_voted_sensors_update.baro_pressure(), air_temperature_celsius));
 
 		_airspeed.true_airspeed_unfiltered_m_s = math::max(0.0f,

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -344,10 +344,29 @@ Sensors::diff_pres_poll(struct sensor_combined_s &raw)
 
 		_airspeed.confidence = _airspeed_validator.confidence(hrt_absolute_time());
 
+		enum AIRSPEED_SENSOR_MODEL smodel;
+
+		switch ((_diff_pres.device_id >> 16) & 0xFF) {
+		case DRV_DIFF_PRESS_DEVTYPE_SDP31:
+
+		/* fallthrough */
+		case DRV_DIFF_PRESS_DEVTYPE_SDP32:
+
+		/* fallthrough */
+		case DRV_DIFF_PRESS_DEVTYPE_SDP33:
+			/* fallthrough */
+			smodel = AIRSPEED_SENSOR_MODEL_SDP3X;
+			break;
+
+		default:
+			smodel = AIRSPEED_SENSOR_MODEL_MEMBRANE;
+			break;
+		}
+
 		/* don't risk to feed negative airspeed into the system */
 		_airspeed.indicated_airspeed_m_s = math::max(0.0f,
 						   calc_indicated_airspeed_corrected((enum AIRSPEED_PITOT_MODEL)_parameters.air_pmodel,
-								   (enum AIRSPEED_SENSOR_MODEL)_parameters.air_smodel, _parameters.air_tube_length,
+								   smodel, _parameters.air_tube_length,
 								   _diff_pres.differential_pressure_filtered_pa, _voted_sensors_update.baro_pressure(),
 								   air_temperature_celsius));
 

--- a/src/modules/systemlib/airspeed.c
+++ b/src/modules/systemlib/airspeed.c
@@ -78,12 +78,17 @@ float calc_indicated_airspeed_corrected(enum AIRSPEED_PITOT_MODEL pmodel, enum A
 		break;
 
 	case AIRSPEED_SENSOR_MODEL_SDP3X: {
-			//
-			double flow_SDP33 = (300.805 - 300.878 / (0.00344205 * dp * 0.68698 * 0.68698 + 1)) * 1.29 / rho_air;
+			// flow through sensor
+			double flow_SDP33 = (300.805 - 300.878 / (0.00344205 * pow(dp, 0.68698) + 1)) * 1.29 / rho_air;
+
+			// for too small readings the compensation might result in a negative flow which causes numerical issues
+			if (flow_SDP33 < 0.0) {
+				flow_SDP33 = 0.0;
+			}
 
 			switch (pmodel) {
 			case AIRSPEED_PITOT_MODEL_HB:
-				dp_pitot = 28557670.0 - 28557670.0 / (1 + (flow_SDP33 / 5027611.0) * 1.227924 * 1.227924);
+				dp_pitot = 28557670.0 - 28557670.0 / (1 + pow((flow_SDP33 / 5027611.0), 1.227924));
 				break;
 
 			default:

--- a/src/modules/systemlib/airspeed.h
+++ b/src/modules/systemlib/airspeed.h
@@ -1,7 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2012-2013 PX4 Development Team. All rights reserved.
- *   Author: Lorenz Meier <lm@inf.ethz.ch>
+ *   Copyright (c) 2012-2013, 2017 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,7 +35,7 @@
  * @file airspeed.h
  * Airspeed estimation declarations
  *
- * @author Lorenz Meier <lm@inf.ethz.ch>
+ * @author Lorenz Meier <lorenz@px4.io>
  *
  */
 
@@ -47,6 +46,29 @@
 #include "conversions.h"
 
 __BEGIN_DECLS
+
+enum AIRSPEED_SENSOR_MODEL {
+	AIRSPEED_SENSOR_MODEL_MEMBRANE = 0,
+	AIRSPEED_SENSOR_MODEL_SDP3X,
+};
+
+enum AIRSPEED_PITOT_MODEL {
+	AIRSPEED_PITOT_MODEL_HB = 0
+};
+
+/**
+ * Calculate indicated airspeed.
+ *
+ * Note that the indicated airspeed is not the true airspeed because it
+ * lacks the air density compensation. Use the calc_true_airspeed functions to get
+ * the true airspeed.
+ *
+ * @param total_pressure pressure inside the pitot/prandtl tube
+ * @param static_pressure pressure at the side of the tube/airplane
+ * @return indicated airspeed in m/s
+ */
+__EXPORT float calc_indicated_airspeed_corrected(enum AIRSPEED_PITOT_MODEL pmodel, enum AIRSPEED_SENSOR_MODEL smodel,
+		float tube_len, float differential_pressure, float pressure_ambient, float temperature_celsius);
 
 /**
  * Calculate indicated airspeed.


### PR DESCRIPTION
This allows to get very accurate readings from the SDP3x sensor series from Sensirion using a complete sensor model.

@AndreasAntener Another set of test flights with this in would be great. I've left the unfiltered value uncompensated so that we can compare efficiently.