### PR TITLE
range finder: reject if min/max value

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -554,8 +554,8 @@ void Ekf2::run()
 		if (range_finder_updated) {
 			orb_copy(ORB_ID(distance_sensor), range_finder_sub, &range_finder);
 
-			if (range_finder.min_distance > range_finder.current_distance
-			    || range_finder.max_distance < range_finder.current_distance) {
+			if (range_finder.min_distance >= range_finder.current_distance
+			    || range_finder.max_distance <= range_finder.current_distance) {
 				range_finder_updated = false;
 			}
 		}


### PR DESCRIPTION
Revert the change from https://github.com/PX4/Firmware/pull/7135 as this got fixed in https://github.com/PX4/ecl/pull/292. 
This avoids the ekf range fusion if a distance sensor outputs the maximum range if out of range (vehicle would increase altitude).