### PR TITLE
FrSky telemetry updates

### DIFF
--- a/src/drivers/frsky_telemetry/common.h
+++ b/src/drivers/frsky_telemetry/common.h
@@ -1,0 +1,81 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file common.h
+ *
+ * common declarations
+ *
+ */
+#pragma once
+
+#include <stdint.h>
+
+/* FrSky sensor hub data IDs */
+#define FRSKY_ID_GPS_ALT_BP     0x01
+#define FRSKY_ID_TEMP1          0x02
+#define FRSKY_ID_RPM            0x03
+#define FRSKY_ID_FUEL           0x04
+#define FRSKY_ID_TEMP2          0x05
+#define FRSKY_ID_VOLTS          0x06
+#define FRSKY_ID_GPS_ALT_AP     0x09
+#define FRSKY_ID_BARO_ALT_BP    0x10
+#define FRSKY_ID_GPS_SPEED_BP   0x11
+#define FRSKY_ID_GPS_LONG_BP    0x12
+#define FRSKY_ID_GPS_LAT_BP     0x13
+#define FRSKY_ID_GPS_COURS_BP   0x14
+#define FRSKY_ID_GPS_DAY_MONTH  0x15
+#define FRSKY_ID_GPS_YEAR       0x16
+#define FRSKY_ID_GPS_HOUR_MIN   0x17
+#define FRSKY_ID_GPS_SEC        0x18
+#define FRSKY_ID_GPS_SPEED_AP   0x19
+#define FRSKY_ID_GPS_LONG_AP    0x1A
+#define FRSKY_ID_GPS_LAT_AP     0x1B
+#define FRSKY_ID_GPS_COURS_AP   0x1C
+#define FRSKY_ID_BARO_ALT_AP    0x21
+#define FRSKY_ID_GPS_LONG_EW    0x22
+#define FRSKY_ID_GPS_LAT_NS     0x23
+#define FRSKY_ID_ACCEL_X        0x24
+#define FRSKY_ID_ACCEL_Y        0x25
+#define FRSKY_ID_ACCEL_Z        0x26
+#define FRSKY_ID_CURRENT        0x28
+#define FRSKY_ID_VARIO          0x30
+#define FRSKY_ID_VFAS           0x39
+#define FRSKY_ID_VOLTS_BP       0x3A
+#define FRSKY_ID_VOLTS_AP       0x3B
+
+
+/**
+ * Map the PX4 flight mode (vehicle_status_s::nav_state) to the telemetry flight mode
+ */
+uint16_t get_telemetry_flight_mode(int px4_flight_mode);

--- a/src/drivers/frsky_telemetry/frsky_data.c
+++ b/src/drivers/frsky_telemetry/frsky_data.c
@@ -41,6 +41,7 @@
  */
 
 #include "frsky_data.h"
+#include "common.h"
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -57,39 +58,6 @@
 #include <uORB/topics/vehicle_status.h>
 
 #include <drivers/drv_hrt.h>
-
-/* FrSky sensor hub data IDs */
-#define FRSKY_ID_GPS_ALT_BP     0x01
-#define FRSKY_ID_TEMP1          0x02
-#define FRSKY_ID_RPM            0x03
-#define FRSKY_ID_FUEL           0x04
-#define FRSKY_ID_TEMP2          0x05
-#define FRSKY_ID_VOLTS          0x06
-#define FRSKY_ID_GPS_ALT_AP     0x09
-#define FRSKY_ID_BARO_ALT_BP    0x10
-#define FRSKY_ID_GPS_SPEED_BP   0x11
-#define FRSKY_ID_GPS_LONG_BP    0x12
-#define FRSKY_ID_GPS_LAT_BP     0x13
-#define FRSKY_ID_GPS_COURS_BP   0x14
-#define FRSKY_ID_GPS_DAY_MONTH  0x15
-#define FRSKY_ID_GPS_YEAR       0x16
-#define FRSKY_ID_GPS_HOUR_MIN   0x17
-#define FRSKY_ID_GPS_SEC        0x18
-#define FRSKY_ID_GPS_SPEED_AP   0x19
-#define FRSKY_ID_GPS_LONG_AP    0x1A
-#define FRSKY_ID_GPS_LAT_AP     0x1B
-#define FRSKY_ID_GPS_COURS_AP   0x1C
-#define FRSKY_ID_BARO_ALT_AP    0x21
-#define FRSKY_ID_GPS_LONG_EW    0x22
-#define FRSKY_ID_GPS_LAT_NS     0x23
-#define FRSKY_ID_ACCEL_X        0x24
-#define FRSKY_ID_ACCEL_Y        0x25
-#define FRSKY_ID_ACCEL_Z        0x26
-#define FRSKY_ID_CURRENT        0x28
-#define FRSKY_ID_VARIO          0x30
-#define FRSKY_ID_VFAS           0x39
-#define FRSKY_ID_VOLTS_BP       0x3A
-#define FRSKY_ID_VOLTS_AP       0x3B
 
 #define frac(f) (f - (int)f)
 
@@ -250,6 +218,12 @@ void frsky_send_frame1(int uart)
 			roundf(subs->battery_status.voltage_v * 10.0f));
 	frsky_send_data(uart, FRSKY_ID_CURRENT,
 			(subs->battery_status.current_a < 0) ? 0 : roundf(subs->battery_status.current_a * 10.0f));
+
+	int16_t telem_flight_mode = get_telemetry_flight_mode(subs->current_flight_mode);
+	frsky_send_data(uart, FRSKY_ID_TEMP1, telem_flight_mode); // send flight mode as TEMP1. This matches with OpenTX & APM
+
+	frsky_send_data(uart, FRSKY_ID_TEMP2, subs->vehicle_gps_position.satellites_used * 10 +
+			subs->vehicle_gps_position.fix_type);
 
 	frsky_send_startstop(uart);
 }

--- a/src/drivers/frsky_telemetry/frsky_data.c
+++ b/src/drivers/frsky_telemetry/frsky_data.c
@@ -53,6 +53,8 @@
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/sensor_combined.h>
 #include <uORB/topics/vehicle_global_position.h>
+#include <uORB/topics/vehicle_gps_position.h>
+#include <uORB/topics/vehicle_status.h>
 
 #include <drivers/drv_hrt.h>
 
@@ -91,38 +93,52 @@
 
 #define frac(f) (f - (int)f)
 
-static struct battery_status_s *battery_status;
-static struct vehicle_global_position_s *global_pos;
-static struct sensor_combined_s *sensor_combined;
+struct frsky_subscription_data_s {
+	struct battery_status_s battery_status;
+	struct vehicle_global_position_s global_pos;
+	struct sensor_combined_s sensor_combined;
+	struct vehicle_gps_position_s vehicle_gps_position;
+	uint8_t current_flight_mode; // == vehicle_status.nav_state
 
-static int battery_status_sub = -1;
-static int vehicle_global_position_sub = -1;
-static int sensor_sub = -1;
+	int battery_status_sub;
+	int vehicle_global_position_sub;
+	int sensor_sub;
+	int vehicle_gps_position_sub;
+	int vehicle_status_sub;
+};
+
+static struct frsky_subscription_data_s *subscription_data = NULL;
 
 /**
  * Initializes the uORB subscriptions.
  */
 bool frsky_init()
 {
-	battery_status = malloc(sizeof(struct battery_status_s));
-	global_pos = malloc(sizeof(struct vehicle_global_position_s));
-	sensor_combined = malloc(sizeof(struct sensor_combined_s));
+	subscription_data = (struct frsky_subscription_data_s *)calloc(1, sizeof(struct frsky_subscription_data_s));
 
-	if (battery_status == NULL || global_pos == NULL || sensor_combined == NULL) {
+	if (!subscription_data) {
 		return false;
 	}
 
-	battery_status_sub = orb_subscribe(ORB_ID(battery_status));
-	vehicle_global_position_sub = orb_subscribe(ORB_ID(vehicle_global_position));
-	sensor_sub = orb_subscribe(ORB_ID(sensor_combined));
+	subscription_data->battery_status_sub = orb_subscribe(ORB_ID(battery_status));
+	subscription_data->vehicle_global_position_sub = orb_subscribe(ORB_ID(vehicle_global_position));
+	subscription_data->sensor_sub = orb_subscribe(ORB_ID(sensor_combined));
+	subscription_data->vehicle_gps_position_sub = orb_subscribe(ORB_ID(vehicle_gps_position));
+	subscription_data->vehicle_status_sub = orb_subscribe(ORB_ID(vehicle_status));
 	return true;
 }
 
 void frsky_deinit()
 {
-	free(battery_status);
-	free(global_pos);
-	free(sensor_combined);
+	if (subscription_data) {
+		orb_unsubscribe(subscription_data->battery_status_sub);
+		orb_unsubscribe(subscription_data->vehicle_global_position_sub);
+		orb_unsubscribe(subscription_data->sensor_sub);
+		orb_unsubscribe(subscription_data->vehicle_gps_position_sub);
+		orb_unsubscribe(subscription_data->vehicle_status_sub);
+		free(subscription_data);
+		subscription_data = NULL;
+	}
 }
 
 /**
@@ -174,26 +190,41 @@ static void frsky_send_data(int uart, uint8_t id, int16_t data)
 
 void frsky_update_topics()
 {
+	struct frsky_subscription_data_s *subs = subscription_data;
 	bool updated;
 	/* get a local copy of the current sensor values */
-	orb_check(sensor_sub, &updated);
+	orb_check(subs->sensor_sub, &updated);
 
 	if (updated) {
-		orb_copy(ORB_ID(sensor_combined), sensor_sub, sensor_combined);
+		orb_copy(ORB_ID(sensor_combined), subs->sensor_sub, &subs->sensor_combined);
+	}
+
+	orb_check(subs->vehicle_gps_position_sub, &updated);
+
+	if (updated) {
+		orb_copy(ORB_ID(vehicle_gps_position), subs->vehicle_gps_position_sub, &subs->vehicle_gps_position);
+	}
+
+	orb_check(subs->vehicle_status_sub, &updated);
+
+	if (updated) {
+		struct vehicle_status_s vehicle_status;
+		orb_copy(ORB_ID(vehicle_status), subs->vehicle_status_sub, &vehicle_status);
+		subs->current_flight_mode = vehicle_status.nav_state;
 	}
 
 	/* get a local copy of the battery data */
-	orb_check(battery_status_sub, &updated);
+	orb_check(subs->battery_status_sub, &updated);
 
 	if (updated) {
-		orb_copy(ORB_ID(battery_status), battery_status_sub, battery_status);
+		orb_copy(ORB_ID(battery_status), subs->battery_status_sub, &subs->battery_status);
 	}
 
 	/* get a local copy of the global position data */
-	orb_check(vehicle_global_position_sub, &updated);
+	orb_check(subs->vehicle_global_position_sub, &updated);
 
 	if (updated) {
-		orb_copy(ORB_ID(vehicle_global_position), vehicle_global_position_sub, global_pos);
+		orb_copy(ORB_ID(vehicle_global_position), subs->vehicle_global_position_sub, &subs->global_pos);
 	}
 }
 
@@ -203,23 +234,22 @@ void frsky_update_topics()
  */
 void frsky_send_frame1(int uart)
 {
+	struct frsky_subscription_data_s *subs = subscription_data;
+
 	/* send formatted frame */
-	frsky_send_data(uart, FRSKY_ID_ACCEL_X, roundf(sensor_combined->accelerometer_m_s2[0] * 1000.0f));
-	frsky_send_data(uart, FRSKY_ID_ACCEL_Y, roundf(sensor_combined->accelerometer_m_s2[1] * 1000.0f));
-	frsky_send_data(uart, FRSKY_ID_ACCEL_Z, roundf(sensor_combined->accelerometer_m_s2[2] * 1000.0f));
+	frsky_send_data(uart, FRSKY_ID_ACCEL_X, roundf(subs->sensor_combined.accelerometer_m_s2[0] * 1000.0f));
+	frsky_send_data(uart, FRSKY_ID_ACCEL_Y, roundf(subs->sensor_combined.accelerometer_m_s2[1] * 1000.0f));
+	frsky_send_data(uart, FRSKY_ID_ACCEL_Z, roundf(subs->sensor_combined.accelerometer_m_s2[2] * 1000.0f));
 
 	frsky_send_data(uart, FRSKY_ID_BARO_ALT_BP,
-			sensor_combined->baro_alt_meter);
+			subs->sensor_combined.baro_alt_meter);
 	frsky_send_data(uart, FRSKY_ID_BARO_ALT_AP,
-			roundf(frac(sensor_combined->baro_alt_meter) * 100.0f));
-
-	frsky_send_data(uart, FRSKY_ID_TEMP1,
-			roundf(sensor_combined->baro_temp_celcius));
+			roundf(frac(subs->sensor_combined.baro_alt_meter) * 100.0f));
 
 	frsky_send_data(uart, FRSKY_ID_VFAS,
-			roundf(battery_status->voltage_v * 10.0f));
+			roundf(subs->battery_status.voltage_v * 10.0f));
 	frsky_send_data(uart, FRSKY_ID_CURRENT,
-			(battery_status->current_a < 0) ? 0 : roundf(battery_status->current_a * 10.0f));
+			(subs->battery_status.current_a < 0) ? 0 : roundf(subs->battery_status.current_a * 10.0f));
 
 	frsky_send_startstop(uart);
 }
@@ -239,6 +269,8 @@ static float frsky_format_gps(float dec)
  */
 void frsky_send_frame2(int uart)
 {
+	struct vehicle_global_position_s *global_pos = &subscription_data->global_pos;
+	struct battery_status_s *battery_status = &subscription_data->battery_status;
 	/* send formatted frame */
 	float course = 0, lat = 0, lon = 0, speed = 0, alt = 0;
 	char lat_ns = 0, lon_ew = 0;
@@ -296,7 +328,7 @@ void frsky_send_frame2(int uart)
 void frsky_send_frame3(int uart)
 {
 	/* send formatted frame */
-	time_t time_gps = global_pos->time_utc_usec / 1000000ULL;
+	time_t time_gps = subscription_data->global_pos.time_utc_usec / 1000000ULL;
 	struct tm *tm_gps = gmtime(&time_gps);
 	uint16_t hour_min = (tm_gps->tm_min << 8) | (tm_gps->tm_hour & 0xff);
 	frsky_send_data(uart, FRSKY_ID_GPS_DAY_MONTH, tm_gps->tm_mday);

--- a/src/drivers/frsky_telemetry/frsky_data.c
+++ b/src/drivers/frsky_telemetry/frsky_data.c
@@ -248,7 +248,12 @@ void frsky_send_frame2(int uart)
 		time_t time_gps = global_pos->time_utc_usec / 1000000ULL;
 		struct tm *tm_gps = gmtime(&time_gps);
 
-		course = (global_pos->yaw + M_PI_F) / M_PI_F * 180.0f;
+		course = global_pos->yaw / M_PI_F * 180.0f;
+
+		if (course < 0.f) { // course is in range [0, 360], 0=north, CW
+			course += 360.f;
+		}
+
 		lat    = frsky_format_gps(fabsf(global_pos->lat));
 		lat_ns = (global_pos->lat < 0) ? 'S' : 'N';
 		lon    = frsky_format_gps(fabsf(global_pos->lon));

--- a/src/drivers/frsky_telemetry/frsky_telemetry.c
+++ b/src/drivers/frsky_telemetry/frsky_telemetry.c
@@ -148,7 +148,7 @@ static int sPort_open_uart(const char *uart_name, struct termios *uart_config, s
 	uart_config->c_oflag &= ~OPOST;
 
 	/* Set baud rate */
-	static const speed_t speed = B9600;
+	const speed_t speed = B9600;
 
 	if (cfsetispeed(uart_config, speed) < 0 || cfsetospeed(uart_config, speed) < 0) {
 		warnx("ERR: %s: %d (cfsetispeed, cfsetospeed)\n", uart_name, termios_state);
@@ -200,7 +200,7 @@ static void usage()
 static int frsky_telemetry_thread_main(int argc, char *argv[])
 {
 	/* Default values for arguments */
-	char *device_name = "/dev/ttyS6"; /* USART8 */
+	const char *device_name = "/dev/ttyS6"; /* USART8 */
 
 	/* Work around some stupidity in task_create's argv handling */
 	argc -= 2;
@@ -325,8 +325,19 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 			err(1, "could not allocate memory");
 		}
 
-		static float filtered_alt = NAN;
+		float filtered_alt = NAN;
+		float last_baro_alt = 0.f;
 		int sensor_sub = orb_subscribe(ORB_ID(sensor_baro));
+
+		uint32_t lastBATV_ms = 0;
+		uint32_t lastCUR_ms = 0;
+		uint32_t lastALT_ms = 0;
+		uint32_t lastSPD_ms = 0;
+		uint32_t lastFUEL_ms = 0;
+		uint32_t lastVSPD_ms = 0;
+		uint32_t lastGPS_ms = 0;
+		uint32_t lastNAV_STATE_ms = 0;
+		uint32_t lastGPS_FIX_ms = 0;
 
 		/* send S.port telemetry */
 		while (!thread_should_exit) {
@@ -350,14 +361,13 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 
 			if (status < 1) { continue; }
 
-			hrt_abstime now = hrt_absolute_time();
+			uint32_t now_ms = hrt_absolute_time() / 1000;
 
 			newBytes = read(uart, &sbuf[1], 1);
 
 			/* get a local copy of the current sensor values
 			 * in order to apply a lowpass filter to baro pressure.
 			 */
-			static float last_baro_alt = 0;
 			bool sensor_updated;
 			orb_check(sensor_sub, &sensor_updated);
 
@@ -377,24 +387,14 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 
 			sPort_update_topics();
 
-			static hrt_abstime lastBATV = 0;
-			static hrt_abstime lastCUR = 0;
-			static hrt_abstime lastALT = 0;
-			static hrt_abstime lastSPD = 0;
-			static hrt_abstime lastFUEL = 0;
-			static hrt_abstime lastVSPD = 0;
-			static hrt_abstime lastGPS = 0;
-			static hrt_abstime lastNAV_STATE = 0;
-			static hrt_abstime lastGPS_FIX = 0;
-
 
 			switch (sbuf[1]) {
 
 			case SMARTPORT_POLL_1:
 
 				/* report BATV at 1Hz */
-				if (now - lastBATV > 1000 * 1000) {
-					lastBATV = now;
+				if (now_ms - lastBATV_ms > 1000) {
+					lastBATV_ms = now_ms;
 					/* send battery voltage */
 					sPort_send_BATV(uart);
 				}
@@ -405,8 +405,8 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 			case SMARTPORT_POLL_2:
 
 				/* report battery current at 5Hz */
-				if (now - lastCUR > 200 * 1000) {
-					lastCUR = now;
+				if (now_ms - lastCUR_ms > 200) {
+					lastCUR_ms = now_ms;
 					/* send battery current */
 					sPort_send_CUR(uart);
 				}
@@ -417,8 +417,8 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 			case SMARTPORT_POLL_3:
 
 				/* report altitude at 5Hz */
-				if (now - lastALT > 200 * 1000) {
-					lastALT = now;
+				if (now_ms - lastALT_ms > 200) {
+					lastALT_ms = now_ms;
 					/* send altitude */
 					sPort_send_ALT(uart);
 				}
@@ -429,8 +429,8 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 			case SMARTPORT_POLL_4:
 
 				/* report speed at 5Hz */
-				if (now - lastSPD > 200 * 1000) {
-					lastSPD = now;
+				if (now_ms - lastSPD_ms > 200) {
+					lastSPD_ms = now_ms;
 					/* send speed */
 					sPort_send_SPD(uart);
 				}
@@ -440,8 +440,8 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 			case SMARTPORT_POLL_5:
 
 				/* report fuel at 1Hz */
-				if (now - lastFUEL > 1000 * 1000) {
-					lastFUEL = now;
+				if (now_ms - lastFUEL_ms > 1000) {
+					lastFUEL_ms = now_ms;
 					/* send fuel */
 					sPort_send_FUEL(uart);
 				}
@@ -451,14 +451,14 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 			case SMARTPORT_POLL_6:
 
 				/* report vertical speed at 10Hz */
-				if (now - lastVSPD > 100 * 1000) {
+				if (now_ms - lastVSPD_ms > 100) {
 					/* estimate vertical speed using first difference and delta t */
-					uint64_t dt = now - lastVSPD;
-					float speed  = (filtered_alt - last_baro_alt) / (1e-6f * (float)dt);
+					uint32_t dt = now_ms - lastVSPD_ms;
+					float speed  = (filtered_alt - last_baro_alt) / (1e-3f * (float)dt);
 
 					/* save current alt and timestamp */
 					last_baro_alt = filtered_alt;
-					lastVSPD = now;
+					lastVSPD_ms = now_ms;
 
 					sPort_send_VSPD(uart, speed);
 				}
@@ -468,7 +468,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 			case SMARTPORT_POLL_7:
 
 				/* report GPS data elements at 5*5Hz */
-				if (now - lastGPS > 100 * 1000) {
+				if (now_ms - lastGPS_ms > 100) {
 					static int elementCount = 0;
 
 					switch (elementCount) {
@@ -511,15 +511,15 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 			case SMARTPORT_POLL_8:
 
 				/* report nav_state as DIY_NAVSTATE 2Hz */
-				if (now - lastNAV_STATE > 500 * 1000) {
-					lastNAV_STATE = now;
+				if (now_ms - lastNAV_STATE_ms > 500) {
+					lastNAV_STATE_ms = now_ms;
 					/* send T1 */
 					sPort_send_NAV_STATE(uart);
 				}
 
 				/* report satcount and fix as DIY_GPSFIX at 2Hz */
-				else if (now - lastGPS_FIX > 500 * 1000) {
-					lastGPS_FIX = now;
+				else if (now_ms - lastGPS_FIX_ms > 500) {
+					lastGPS_FIX_ms = now_ms;
 					/* send T2 */
 					sPort_send_GPS_FIX(uart);
 				}
@@ -585,9 +585,9 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 			bool new_input = frsky_parse_host((uint8_t *)&sbuf[0], nbytes, &host_frame);
 
 			/* the RSSI value could be useful */
-			if (false && new_input) {
-				warnx("host frame: ad1:%u, ad2: %u, rssi: %u",
-				      host_frame.ad1, host_frame.ad2, host_frame.linkq);
+			if (new_input) {
+				PX4_DEBUG("host frame: ad1:%u, ad2: %u, rssi: %u",
+					  host_frame.ad1, host_frame.ad2, host_frame.linkq);
 			}
 
 			frsky_update_topics();
@@ -648,7 +648,7 @@ int frsky_telemetry_main(int argc, char *argv[])
 		thread_should_exit = false;
 		frsky_task = px4_task_spawn_cmd("frsky_telemetry",
 						SCHED_DEFAULT,
-						200,
+						SCHED_PRIORITY_DEFAULT + 4,
 						1268,
 						frsky_telemetry_thread_main,
 						(char *const *)argv);

--- a/src/drivers/frsky_telemetry/frsky_telemetry.c
+++ b/src/drivers/frsky_telemetry/frsky_telemetry.c
@@ -55,6 +55,7 @@
 #include <unistd.h>
 
 #include <px4_tasks.h>
+#include <px4_module.h>
 #include <systemlib/err.h>
 #include <termios.h>
 #include <drivers/drv_hrt.h>
@@ -145,10 +146,13 @@ static int set_uart_speed(int uart, struct termios *uart_config, speed_t speed)
  */
 static void usage()
 {
-	fprintf(stderr,
-		"usage: frsky_telemetry start [-d <devicename>]\n"
-		"       frsky_telemetry stop\n"
-		"       frsky_telemetry status\n");
+	PRINT_MODULE_DESCRIPTION("FrSky Telemetry support. Auto-detects D or S.PORT protocol.");
+
+	PRINT_MODULE_USAGE_NAME("frsky_telemetry", "communication");
+	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_PARAM_STRING('d', "/dev/ttyS6", "<file:dev>", "Select Serial Device", true);
+	PRINT_MODULE_USAGE_COMMAND("stop");
+	PRINT_MODULE_USAGE_COMMAND("status");
 	exit(1);
 }
 

--- a/src/drivers/frsky_telemetry/sPort_data.c
+++ b/src/drivers/frsky_telemetry/sPort_data.c
@@ -61,19 +61,23 @@
 
 #define frac(f) (f - (int)f)
 
-static int sensor_sub = -1;
-static int global_position_sub = -1;
-static int local_position_sub = -1;
-static int battery_status_sub = -1;
-static int vehicle_status_sub = -1;
-static int gps_position_sub = -1;
+struct s_port_subscription_data_s {
+	int sensor_sub;
+	int global_position_sub;
+	int local_position_sub;
+	int battery_status_sub;
+	int vehicle_status_sub;
+	int gps_position_sub;
 
-static struct sensor_combined_s *sensor_combined;
-static struct vehicle_global_position_s *global_pos;
-static struct vehicle_local_position_s *local_pos;
-static struct battery_status_s *battery_status;
-static struct vehicle_status_s *vehicle_status;
-static struct vehicle_gps_position_s *gps_position;
+	struct sensor_combined_s sensor_combined;
+	struct vehicle_global_position_s global_pos;
+	struct vehicle_local_position_s local_pos;
+	struct battery_status_s battery_status;
+	struct vehicle_status_s vehicle_status;
+	struct vehicle_gps_position_s gps_position;
+};
+
+static struct s_port_subscription_data_s *s_port_subscription_data = NULL;
 
 
 /**
@@ -81,84 +85,82 @@ static struct vehicle_gps_position_s *gps_position;
  */
 bool sPort_init()
 {
+	s_port_subscription_data = (struct s_port_subscription_data_s *)calloc(1, sizeof(struct s_port_subscription_data_s));
 
-	sensor_combined = malloc(sizeof(struct sensor_combined_s));
-	global_pos = malloc(sizeof(struct vehicle_global_position_s));
-	local_pos = malloc(sizeof(struct vehicle_local_position_s));
-	battery_status = malloc(sizeof(struct battery_status_s));
-	vehicle_status = malloc(sizeof(struct vehicle_status_s));
-	gps_position = malloc(sizeof(struct vehicle_gps_position_s));
-
-
-	if (sensor_combined == NULL || global_pos == NULL || local_pos == NULL || battery_status == NULL
-	    || vehicle_status == NULL || gps_position == NULL) {
+	if (s_port_subscription_data == NULL) {
 		return false;
 	}
 
 
-	sensor_sub = orb_subscribe(ORB_ID(sensor_combined));
-	global_position_sub = orb_subscribe(ORB_ID(vehicle_global_position));
-	local_position_sub = orb_subscribe(ORB_ID(vehicle_local_position));
-	battery_status_sub = orb_subscribe(ORB_ID(battery_status));
-	vehicle_status_sub = orb_subscribe(ORB_ID(vehicle_status));
-	gps_position_sub = orb_subscribe(ORB_ID(vehicle_gps_position));
+	s_port_subscription_data->sensor_sub = orb_subscribe(ORB_ID(sensor_combined));
+	s_port_subscription_data->global_position_sub = orb_subscribe(ORB_ID(vehicle_global_position));
+	s_port_subscription_data->local_position_sub = orb_subscribe(ORB_ID(vehicle_local_position));
+	s_port_subscription_data->battery_status_sub = orb_subscribe(ORB_ID(battery_status));
+	s_port_subscription_data->vehicle_status_sub = orb_subscribe(ORB_ID(vehicle_status));
+	s_port_subscription_data->gps_position_sub = orb_subscribe(ORB_ID(vehicle_gps_position));
 
 	return true;
 }
 
 void sPort_deinit()
 {
-	free(sensor_combined);
-	free(global_pos);
-	free(local_pos);
-	free(battery_status);
-	free(vehicle_status);
-	free(gps_position);
+	if (s_port_subscription_data) {
+		orb_unsubscribe(s_port_subscription_data->sensor_sub);
+		orb_unsubscribe(s_port_subscription_data->global_position_sub);
+		orb_unsubscribe(s_port_subscription_data->local_position_sub);
+		orb_unsubscribe(s_port_subscription_data->battery_status_sub);
+		orb_unsubscribe(s_port_subscription_data->vehicle_status_sub);
+		orb_unsubscribe(s_port_subscription_data->gps_position_sub);
+		free(s_port_subscription_data);
+		s_port_subscription_data = NULL;
+	}
 }
 
 void sPort_update_topics()
 {
+	struct s_port_subscription_data_s *subs = s_port_subscription_data;
+
 	bool updated;
 	/* get a local copy of the current sensor values */
-	orb_check(sensor_sub, &updated);
+	orb_check(subs->sensor_sub, &updated);
 
 	if (updated) {
-		orb_copy(ORB_ID(sensor_combined), sensor_sub, sensor_combined);
+		orb_copy(ORB_ID(sensor_combined), subs->sensor_sub, &subs->sensor_combined);
 	}
 
 	/* get a local copy of the battery data */
-	orb_check(battery_status_sub, &updated);
+	orb_check(subs->battery_status_sub, &updated);
 
 	if (updated) {
-		orb_copy(ORB_ID(battery_status), battery_status_sub, battery_status);
+		orb_copy(ORB_ID(battery_status), subs->battery_status_sub, &subs->battery_status);
 	}
 
 	/* get a local copy of the global position data */
-	orb_check(global_position_sub, &updated);
+	orb_check(subs->global_position_sub, &updated);
 
 	if (updated) {
-		orb_copy(ORB_ID(vehicle_global_position), global_position_sub, global_pos);
+		orb_copy(ORB_ID(vehicle_global_position), subs->global_position_sub, &subs->global_pos);
 	}
 
 	/* get a local copy of the local position data */
-	orb_check(local_position_sub, &updated);
+	orb_check(subs->local_position_sub, &updated);
 
 	if (updated) {
-		orb_copy(ORB_ID(vehicle_local_position), local_position_sub, local_pos);
+		orb_copy(ORB_ID(vehicle_local_position), subs->local_position_sub, &subs->local_pos);
 	}
 
 	/* get a local copy of the vehicle status data */
-	orb_check(vehicle_status_sub, &updated);
+	orb_check(subs->vehicle_status_sub, &updated);
 
 	if (updated) {
-		orb_copy(ORB_ID(vehicle_status), vehicle_status_sub, vehicle_status);
+		orb_copy(ORB_ID(vehicle_status), subs->vehicle_status_sub, &subs->vehicle_status);
 	}
 
 	/* get a local copy of the gps position data */
-	orb_check(gps_position_sub, &updated);
+	orb_check(subs->gps_position_sub, &updated);
 
 	if (updated) {
-		orb_copy(ORB_ID(vehicle_gps_position), gps_position_sub, gps_position);
+		orb_copy(ORB_ID(vehicle_gps_position), subs->gps_position_sub, &subs->gps_position);
 	}
 
 }
@@ -205,7 +207,7 @@ void sPort_send_data(int uart, uint16_t id, uint32_t data)
 	} buf;
 
 	/* send start byte */
-	static const uint8_t c = 0x10;
+	const uint8_t c = 0x10;
 	write(uart, &c, 1);
 
 	/* init crc */
@@ -233,7 +235,7 @@ void sPort_send_data(int uart, uint16_t id, uint32_t data)
 void sPort_send_BATV(int uart)
 {
 	/* send battery voltage as VFAS */
-	uint32_t voltage = (int)(100 * battery_status->voltage_v);
+	uint32_t voltage = (int)(100 * s_port_subscription_data->battery_status.voltage_v);
 	sPort_send_data(uart, SMARTPORT_ID_VFAS, voltage);
 }
 
@@ -241,7 +243,7 @@ void sPort_send_BATV(int uart)
 void sPort_send_CUR(int uart)
 {
 	/* send data */
-	uint32_t current = (int)(10 * battery_status->current_a);
+	uint32_t current = (int)(10 * s_port_subscription_data->battery_status.current_a);
 	sPort_send_data(uart, SMARTPORT_ID_CURR, current);
 }
 
@@ -251,13 +253,14 @@ void sPort_send_CUR(int uart)
 void sPort_send_ALT(int uart)
 {
 	/* send data */
-	uint32_t alt = (int)(100 * sensor_combined->baro_alt_meter);
+	uint32_t alt = (int)(100 * s_port_subscription_data->sensor_combined.baro_alt_meter);
 	sPort_send_data(uart, SMARTPORT_ID_ALT, alt);
 }
 
 // verified scaling for "calculated" option
 void sPort_send_SPD(int uart)
 {
+	struct vehicle_global_position_s *global_pos = &s_port_subscription_data->global_pos;
 	/* send data for A2 */
 	float speed  = sqrtf(global_pos->vel_n * global_pos->vel_n + global_pos->vel_e * global_pos->vel_e);
 	uint32_t ispeed = (int)(10 * speed);
@@ -276,7 +279,7 @@ void sPort_send_VSPD(int uart, float speed)
 void sPort_send_FUEL(int uart)
 {
 	/* send data */
-	uint32_t fuel = (int)(100 * battery_status->remaining);
+	uint32_t fuel = (int)(100 * s_port_subscription_data->battery_status.remaining);
 	sPort_send_data(uart, SMARTPORT_ID_FUEL, fuel);
 }
 
@@ -285,11 +288,11 @@ void sPort_send_GPS_LON(int uart)
 	/* send longitude */
 	/* convert to 30 bit signed magnitude degrees*6E5 with MSb = 1 and bit 30=sign */
 	/* precision is approximately 0.1m */
-	uint32_t iLon =  6E-2 * fabs(gps_position->lon);
+	uint32_t iLon =  6E-2 * fabs(s_port_subscription_data->gps_position.lon);
 
 	iLon |= (1 << 31);
 
-	if (gps_position->lon < 0) { iLon |= (1 << 30); }
+	if (s_port_subscription_data->gps_position.lon < 0) { iLon |= (1 << 30); }
 
 	sPort_send_data(uart, SMARTPORT_ID_GPS_LON_LAT, iLon);
 }
@@ -298,9 +301,9 @@ void sPort_send_GPS_LAT(int uart)
 {
 	/* send latitude */
 	/* convert to 30 bit signed magnitude degrees*6E5 with MSb = 0 and bit 30=sign */
-	uint32_t iLat = 6E-2 * fabs(gps_position->lat);
+	uint32_t iLat = 6E-2 * fabs(s_port_subscription_data->gps_position.lat);
 
-	if (gps_position->lat < 0) { iLat |= (1 << 30); }
+	if (s_port_subscription_data->gps_position.lat < 0) { iLat |= (1 << 30); }
 
 	sPort_send_data(uart, SMARTPORT_ID_GPS_LON_LAT, iLat);
 }
@@ -308,7 +311,7 @@ void sPort_send_GPS_LAT(int uart)
 void sPort_send_GPS_ALT(int uart)
 {
 	/* send altitude */
-	uint32_t iAlt = gps_position->alt / 10;
+	uint32_t iAlt = s_port_subscription_data->gps_position.alt / 10;
 	sPort_send_data(uart, SMARTPORT_ID_GPS_ALT, iAlt);
 }
 
@@ -317,7 +320,7 @@ void sPort_send_GPS_CRS(int uart)
 	/* send course */
 
 	/* convert to 30 bit signed magnitude degrees*6E5 with MSb = 1 and bit 30=sign */
-	int32_t iYaw = local_pos->yaw * 18000.0f / M_PI_F;
+	int32_t iYaw = s_port_subscription_data->local_pos.yaw * 18000.0f / M_PI_F;
 
 	if (iYaw < 0) { iYaw += 36000; }
 
@@ -329,7 +332,7 @@ void sPort_send_GPS_TIME(int uart)
 	static int date = 0;
 
 	/* send formatted frame */
-	time_t time_gps = gps_position->time_utc_usec / 1000000ULL;
+	time_t time_gps = s_port_subscription_data->gps_position.time_utc_usec / 1000000ULL;
 	struct tm *tm_gps = gmtime(&time_gps);
 
 	if (date) {
@@ -349,6 +352,7 @@ void sPort_send_GPS_TIME(int uart)
 
 void sPort_send_GPS_SPD(int uart)
 {
+	struct vehicle_global_position_s *global_pos = &s_port_subscription_data->global_pos;
 	/* send 100 * knots */
 	float speed  = sqrtf(global_pos->vel_n * global_pos->vel_n + global_pos->vel_e * global_pos->vel_e);
 	uint32_t ispeed = (int)(1944 * speed);
@@ -360,7 +364,7 @@ void sPort_send_GPS_SPD(int uart)
  */
 void sPort_send_NAV_STATE(int uart)
 {
-	uint32_t navstate = (int)(128 + vehicle_status->nav_state);
+	uint32_t navstate = (int)(128 + s_port_subscription_data->vehicle_status.nav_state);
 
 	/* send data */
 	sPort_send_data(uart, SMARTPORT_ID_DIY_NAVSTATE, navstate);
@@ -371,8 +375,8 @@ void sPort_send_NAV_STATE(int uart)
 void sPort_send_GPS_FIX(int uart)
 {
 	/* send data */
-	uint32_t satcount = (int)(gps_position->satellites_used);
-	uint32_t fixtype = (int)(gps_position->fix_type);
+	uint32_t satcount = (int)(s_port_subscription_data->gps_position.satellites_used);
+	uint32_t fixtype = (int)(s_port_subscription_data->gps_position.fix_type);
 	uint32_t t2 = satcount * 10 + fixtype;
 	sPort_send_data(uart, SMARTPORT_ID_DIY_GPSFIX, t2);
 }

--- a/src/drivers/frsky_telemetry/sPort_data.c
+++ b/src/drivers/frsky_telemetry/sPort_data.c
@@ -42,6 +42,7 @@
  */
 
 #include "sPort_data.h"
+#include "common.h"
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -379,4 +380,20 @@ void sPort_send_GPS_FIX(int uart)
 	uint32_t fixtype = (int)(s_port_subscription_data->gps_position.fix_type);
 	uint32_t t2 = satcount * 10 + fixtype;
 	sPort_send_data(uart, SMARTPORT_ID_DIY_GPSFIX, t2);
+}
+
+
+void sPort_send_flight_mode(int uart)
+{
+	struct s_port_subscription_data_s *subs = s_port_subscription_data;
+	int16_t telem_flight_mode = get_telemetry_flight_mode(subs->vehicle_status.nav_state);
+
+	sPort_send_data(uart, FRSKY_ID_TEMP1, telem_flight_mode); // send flight mode as TEMP1. This matches with OpenTX & APM
+
+}
+
+void sPort_send_GPS_info(int uart)
+{
+	struct s_port_subscription_data_s *subs = s_port_subscription_data;
+	sPort_send_data(uart, FRSKY_ID_TEMP2, subs->gps_position.satellites_used * 10 + subs->gps_position.fix_type);
 }

--- a/src/drivers/frsky_telemetry/sPort_data.h
+++ b/src/drivers/frsky_telemetry/sPort_data.h
@@ -54,8 +54,9 @@
 #define SMARTPORT_POLL_6    0x00
 #define SMARTPORT_POLL_7    0x83
 #define SMARTPORT_POLL_8    0xBA
+#define SMARTPORT_SENSOR_ID_SP2UR     0xC6 // Sensor ID  6
 
-/* FrSky SmartPort sensor IDs. See more here: https://github.com/opentx/opentx/blob/master/radio/src/telemetry/frsky.h#L109 */
+/* FrSky SmartPort sensor IDs. See more here: https://github.com/opentx/opentx/blob/2.2/radio/src/telemetry/frsky.h */
 #define SMARTPORT_ID_RSSI          0xf101
 #define SMARTPORT_ID_RXA1          0xf102	// supplied by RX
 #define SMARTPORT_ID_RXA2          0xf103	// supplied by RX
@@ -100,6 +101,8 @@ void sPort_send_GPS_ALT(int uart);
 void sPort_send_GPS_SPD(int uart);
 void sPort_send_GPS_CRS(int uart);
 void sPort_send_GPS_TIME(int uart);
+void sPort_send_flight_mode(int uart);
+void sPort_send_GPS_info(int uart);
 
 void sPort_send_NAV_STATE(int uart);
 void sPort_send_GPS_FIX(int uart);


### PR DESCRIPTION
This brings some updates to the frsky telemetry driver:
- fix the heading information (D protocol)
- send flight mode & gps information
- remove static's, refactor allocations to free up several 100 bytes.

There's a really cool script that can be used on the Taranis: http://ilihack.github.io/LuaPilot_Taranis_Telemetry/
![taranis_telemetry](https://user-images.githubusercontent.com/281593/28781504-936380f6-760a-11e7-85b5-505399e4c8ae.jpg)
It shows:
- gps lock information
- current flight mode (very useful to know whether you actually are in position mode)
- battery fill level
- global heading (if it's there, it means ekf has properly initialized the position)
- signal strength
- and more

This is almost a replacement for QGC :D

Tested on Pixracer with both D and S.Port protocols.