### PR TITLE
Fix va_arg calls (always call va_end)

### DIFF
--- a/src/examples/ekf_att_pos_estimator/estimator_utilities.cpp
+++ b/src/examples/ekf_att_pos_estimator/estimator_utilities.cpp
@@ -64,6 +64,7 @@ ekf_debug(const char *fmt, ...)
 
     va_start(args, fmt);
     ekf_debug_print(fmt, args);
+    va_end(args);
 }
 
 #else

--- a/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp
+++ b/src/modules/fw_pos_control_l1/mtecs/mTecs.cpp
@@ -336,6 +336,7 @@ void mTecs::debug(const char *fmt, ...)
 
 	va_start(args, fmt);
 	debug_print(fmt, args);
+	va_end(args);
 }
 
 } /* namespace fwPosctrl */

--- a/src/modules/systemlib/err.c
+++ b/src/modules/systemlib/err.c
@@ -102,7 +102,9 @@ err(int exitcode, const char *fmt, ...)
 	va_list	args;
 
 	va_start(args, fmt);
-	verr(exitcode, fmt, args);
+	warnerr_core(errno, fmt, args);
+	va_end(args);
+	exit(exitcode);
 }
 
 void
@@ -118,7 +120,9 @@ errc(int exitcode, int errcode, const char *fmt, ...)
 	va_list args;
 
 	va_start(args, fmt);
-	verrc(exitcode, errcode, fmt, args);
+	warnerr_core(errcode, fmt, args);
+	va_end(args);
+	exit(exitcode);
 }
 
 void
@@ -134,7 +138,9 @@ errx(int exitcode, const char *fmt, ...)
 	va_list args;
 
 	va_start(args, fmt);
-	verrx(exitcode, fmt, args);
+	warnerr_core(NOCODE, fmt, args);
+	va_end(args);
+	exit(exitcode);
 }
 
 void

--- a/src/platforms/qurt/px4_layer/px4_qurt_impl.cpp
+++ b/src/platforms/qurt/px4_layer/px4_qurt_impl.cpp
@@ -80,6 +80,7 @@ void qurt_log(const char *fmt, ...)
 	va_start(args, fmt);
 	printf(fmt, args);
 	printf("n");
+	va_end(args);
 }
 #endif
 


### PR DESCRIPTION
From the manpage: "Each invocation of va_start() must be matched by a
corresponding invocation of va_end() in the same function."