### PR TITLE
[WIP] Add basic Rally/Safe Points in RTL

### DIFF
--- a/msg/vehicle_control_mode.msg
+++ b/msg/vehicle_control_mode.msg
@@ -1,6 +1,4 @@
 
-						# is set whenever the writing thread stores new data
-
 bool flag_armed
 
 bool flag_external_manual_override_ok		# external override non-fatal for system. Only true for fixed wing

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2549,7 +2549,6 @@ int commander_thread_main(int argc, char *argv[])
 							break;
 						}
 						case (geofence_result_s::GF_ACTION_TERMINATE) : {
-							warnx("Flight termination because of geofence");
 							mavlink_log_critical(&mavlink_log_pub, "Geofence violation: flight termination");
 							armed.force_failsafe = true;
 							status_changed = true;

--- a/src/modules/dataman/dataman.cpp
+++ b/src/modules/dataman/dataman.cpp
@@ -228,7 +228,7 @@ static const unsigned g_per_item_max_index[DM_KEY_NUM_KEYS] = {
 
 /* Table of the len of each item type */
 static const unsigned g_per_item_size[DM_KEY_NUM_KEYS] = {
-	sizeof(struct mission_save_point_s) + DM_SECTOR_HDR_SIZE,
+	sizeof(struct mission_safe_point_s) + DM_SECTOR_HDR_SIZE,
 	sizeof(struct mission_fence_point_s) + DM_SECTOR_HDR_SIZE,
 	sizeof(struct mission_item_s) + DM_SECTOR_HDR_SIZE,
 	sizeof(struct mission_item_s) + DM_SECTOR_HDR_SIZE,

--- a/src/modules/dataman/dataman.h
+++ b/src/modules/dataman/dataman.h
@@ -105,7 +105,7 @@ struct dataman_compat_s {
 
 #define DM_COMPAT_KEY ((DM_COMPAT_VERSION << 32) + (sizeof(struct mission_item_s) << 24) + \
 		       (sizeof(struct mission_s) << 16) + (sizeof(struct mission_stats_entry_s) << 12) + \
-		       (sizeof(struct mission_fence_point_s) << 8) + (sizeof(struct mission_save_point_s) << 4) + \
+		       (sizeof(struct mission_fence_point_s) << 8) + (sizeof(struct mission_safe_point_s) << 4) + \
 		       sizeof(struct dataman_compat_s))
 
 /** Retrieve from the data manager store */

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -348,14 +348,14 @@ MavlinkMissionManager::send_mission_item(uint8_t sysid, uint8_t compid, uint16_t
 		break;
 
 	case MAV_MISSION_TYPE_RALLY: { // Read a safe point / rally point
-			mission_save_point_s mission_save_point;
-			read_success = dm_read(DM_KEY_SAFE_POINTS, seq + 1, &mission_save_point, sizeof(mission_save_point_s)) ==
-				       sizeof(mission_save_point_s);
+			mission_safe_point_s mission_safe_point;
+			read_success = dm_read(DM_KEY_SAFE_POINTS, seq + 1, &mission_safe_point, sizeof(mission_safe_point_s)) ==
+				       sizeof(mission_safe_point_s);
 			mission_item.nav_cmd = MAV_CMD_NAV_RALLY_POINT;
-			mission_item.frame = mission_save_point.frame;
-			mission_item.lat = mission_save_point.lat;
-			mission_item.lon = mission_save_point.lon;
-			mission_item.altitude = mission_save_point.alt;
+			mission_item.frame = mission_safe_point.frame;
+			mission_item.lat = mission_safe_point.lat;
+			mission_item.lon = mission_safe_point.lon;
+			mission_item.altitude = mission_safe_point.alt;
 		}
 		break;
 
@@ -1107,13 +1107,13 @@ MavlinkMissionManager::handle_mission_item_both(const mavlink_message_t *msg)
 			break;
 
 		case MAV_MISSION_TYPE_RALLY: { // Write a safe point / rally point
-				mission_save_point_s mission_save_point;
-				mission_save_point.lat = mission_item.lat;
-				mission_save_point.lon = mission_item.lon;
-				mission_save_point.alt = mission_item.altitude;
-				mission_save_point.frame = mission_item.frame;
-				write_failed = dm_write(DM_KEY_SAFE_POINTS, wp.seq + 1, DM_PERSIST_POWER_ON_RESET, &mission_save_point,
-							sizeof(mission_save_point_s)) != sizeof(mission_save_point_s);
+				mission_safe_point_s mission_safe_point;
+				mission_safe_point.lat = mission_item.lat;
+				mission_safe_point.lon = mission_item.lon;
+				mission_safe_point.alt = mission_item.altitude;
+				mission_safe_point.frame = mission_item.frame;
+				write_failed = dm_write(DM_KEY_SAFE_POINTS, wp.seq + 1, DM_PERSIST_POWER_ON_RESET, &mission_safe_point,
+							sizeof(mission_safe_point_s)) != sizeof(mission_safe_point_s);
 			}
 			break;
 

--- a/src/modules/mavlink/mavlink_mission.h
+++ b/src/modules/mavlink/mavlink_mission.h
@@ -143,7 +143,7 @@ private:
 		DM_KEY_FENCE_POINTS_MAX - 1,
 		DM_KEY_SAFE_POINTS_MAX - 1
 	};	/**< Maximum number of mission items for each type
-					(fence & save points use the first item for the stats) */
+					(fence & safe points use the first item for the stats) */
 
 	/** get the maximum number of item count for the current _mission_type */
 	inline unsigned current_max_item_count();

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -172,10 +172,10 @@ struct mission_fence_point_s {
 };
 
 /**
- * Save Point (Rally Point).
+ * Safe Point (Rally Point).
  * Corresponds to the DM_KEY_SAFE_POINTS dataman item
  */
-struct mission_save_point_s {
+struct mission_safe_point_s {
 	double lat;
 	double lon;
 	float alt;

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -91,6 +91,25 @@ private:
 		RTL_STATE_LANDED,
 	} _rtl_state{RTL_STATE_NONE};
 
+	struct RTLPosition {
+		double lat;
+		double lon;
+		float alt;
+		float yaw;
+		uint8_t safe_point_index; ///< 0 = home position
+
+		void set(const home_position_s &home_position)
+		{
+			lat = home_position.lat;
+			lon = home_position.lon;
+			alt = home_position.alt;
+			yaw = home_position.yaw;
+			safe_point_index = 0;
+		}
+	};
+
+	RTLPosition _destination; ///< the RTL position to fly to (typically the home position or a safe point)
+
 	control::BlockParamFloat _param_return_alt;
 	control::BlockParamFloat _param_min_loiter_alt;
 	control::BlockParamFloat _param_descend_alt;

--- a/src/modules/navigator/rtl_params.c
+++ b/src/modules/navigator/rtl_params.c
@@ -97,7 +97,7 @@ PARAM_DEFINE_FLOAT(RTL_LAND_DELAY, -1.0f);
  *
  * @unit m
  * @min 0.5
- * @max 20
+ * @max 100
  * @decimal 1
  * @increment 0.5
  * @group Return To Land


### PR DESCRIPTION
This adds a basic implementation for Safe Points in RTL. If there are Safe Points, the vehicle will fly to the closest one (including the home position).

I decided to add it to RTL (versus the Landing mode in navigator), because the Landing is also used in failure cases such as GPS or global position loss.

@DonLakeFlyer I'll need QGC support to test this. From what I see the point upload is not enabled in https://github.com/mavlink/qgroundcontrol/pull/5474 due to https://github.com/mavlink/qgroundcontrol/blob/master/src/MissionManager/RallyPointManager.cc#L42.

@dagar @sanderux