### PR TITLE
vmount fixes

### DIFF
--- a/src/drivers/vmount/input_mavlink.h
+++ b/src/drivers/vmount/input_mavlink.h
@@ -42,6 +42,7 @@
 #include "input.h"
 #include "input_rc.h"
 #include <uORB/topics/vehicle_roi.h>
+#include <cstdint>
 
 namespace vmount
 {
@@ -94,6 +95,9 @@ private:
 	int _vehicle_command_sub = -1;
 	orb_advert_t _vehicle_command_ack_pub = nullptr;
 	bool _stabilize[3] = { false, false, false };
+
+	int32_t _mav_sys_id; ///< our mavlink system id
+	int32_t _mav_comp_id; ///< our mavlink component id
 };
 
 

--- a/src/drivers/vmount/vmount.cpp
+++ b/src/drivers/vmount/vmount.cpp
@@ -222,6 +222,7 @@ static int vmount_thread_main(int argc, char *argv[])
 	g_thread_data = &thread_data;
 
 	int last_active = 0;
+	hrt_abstime last_output_update = 0;
 
 	while (!thread_should_exit) {
 
@@ -342,15 +343,20 @@ static int vmount_thread_main(int argc, char *argv[])
 				}
 			}
 
-			//update output
-			int ret = thread_data.output_obj->update(control_data);
+			hrt_abstime now = hrt_absolute_time();
+			if (now - last_output_update > 10000) { // rate-limit the update of outputs
+				last_output_update = now;
 
-			if (ret) {
-				PX4_ERR("failed to write output (%i)", ret);
-				break;
+				//update output
+				int ret = thread_data.output_obj->update(control_data);
+
+				if (ret) {
+					PX4_ERR("failed to write output (%i)", ret);
+					break;
+				}
+
+				thread_data.output_obj->publish();
 			}
-
-			thread_data.output_obj->publish();
 
 		} else {
 			//wait for parameter changes. We still need to wake up regularily to check for thread exit requests

--- a/src/drivers/vmount/vmount.cpp
+++ b/src/drivers/vmount/vmount.cpp
@@ -81,15 +81,15 @@ struct ThreadData {
 static volatile ThreadData *g_thread_data = nullptr;
 
 struct Parameters {
-	int mnt_mode_in;
-	int mnt_mode_out;
-	int mnt_mav_sysid;
-	int mnt_mav_compid;
-	int mnt_ob_lock_mode;
-	int mnt_ob_norm_mode;
-	int mnt_man_pitch;
-	int mnt_man_roll;
-	int mnt_man_yaw;
+	int32_t mnt_mode_in;
+	int32_t mnt_mode_out;
+	int32_t mnt_mav_sysid;
+	int32_t mnt_mav_compid;
+	int32_t mnt_ob_lock_mode;
+	int32_t mnt_ob_norm_mode;
+	int32_t mnt_man_pitch;
+	int32_t mnt_man_roll;
+	int32_t mnt_man_yaw;
 
 	bool operator!=(const Parameters &p)
 	{

--- a/src/drivers/vmount/vmount.cpp
+++ b/src/drivers/vmount/vmount.cpp
@@ -337,7 +337,7 @@ static int vmount_thread_main(int argc, char *argv[])
 					continue;
 				}
 
-				if (control_data_to_check != nullptr) {
+				if (control_data_to_check != nullptr || already_active) {
 					control_data = control_data_to_check;
 					last_active = i;
 				}


### PR DESCRIPTION
Several fixes for vmount:
- rate-limit the update of the outputs to avoid busy-loops (credits to @ndepal for finding this)
- only handle mavlink input commands that match our system & component id
- make sure outputs don't continously reset their state

@ndepal can you test this please?

Fixes https://github.com/PX4/Firmware/issues/7755