### PR TITLE
vmount: multiple fixes

### DIFF
--- a/src/drivers/vmount/input_mavlink.cpp
+++ b/src/drivers/vmount/input_mavlink.cpp
@@ -87,8 +87,6 @@ int InputMavlinkROI::initialize()
 	return 0;
 }
 
-
-
 int InputMavlinkROI::update_impl(unsigned int timeout_ms, ControlData **control_data, bool already_active)
 {
 	// already_active is unused, we don't care what happened previously.
@@ -174,6 +172,7 @@ void InputMavlinkROI::print_status()
 {
 	PX4_INFO("Input: Mavlink (ROI)");
 }
+
 
 InputMavlinkCmdMount::InputMavlinkCmdMount()
 {

--- a/src/drivers/vmount/input_mavlink.h
+++ b/src/drivers/vmount/input_mavlink.h
@@ -42,6 +42,7 @@
 #include "input.h"
 #include "input_rc.h"
 #include <uORB/topics/vehicle_roi.h>
+#include <cstdint>
 
 namespace vmount
 {
@@ -94,6 +95,9 @@ private:
 	int _vehicle_command_sub = -1;
 	orb_advert_t _vehicle_command_ack_pub = nullptr;
 	bool _stabilize[3] = { false, false, false };
+
+	int32_t _mav_sys_id; ///< our mavlink system id
+	int32_t _mav_comp_id; ///< our mavlink component id
 };
 
 

--- a/src/drivers/vmount/output.cpp
+++ b/src/drivers/vmount/output.cpp
@@ -68,6 +68,10 @@ OutputBase::~OutputBase()
 	if (_vehicle_global_position_sub >= 0) {
 		orb_unsubscribe(_vehicle_global_position_sub);
 	}
+
+	if (_mount_orientation_pub) {
+		orb_unadvertise(_mount_orientation_pub);
+	}
 }
 
 int OutputBase::initialize()

--- a/src/drivers/vmount/output_mavlink.cpp
+++ b/src/drivers/vmount/output_mavlink.cpp
@@ -104,9 +104,11 @@ int OutputMavlink::update(const ControlData *control_data)
 	vehicle_command.timestamp = t;
 	vehicle_command.command = vehicle_command_s::VEHICLE_CMD_DO_MOUNT_CONTROL;
 
-	vehicle_command.param1 = _angle_outputs[0];
-	vehicle_command.param2 = _angle_outputs[1];
-	vehicle_command.param3 = _angle_outputs[2];
+	// vmount spec has roll, pitch on channels 0, 1, respectively; MAVLink spec has roll, pitch on channels 1, 0, respectively
+	// vmount uses radians, MAVLink uses degrees
+	vehicle_command.param1 = _angle_outputs[1] * M_RAD_TO_DEG_F;
+	vehicle_command.param2 = _angle_outputs[0] * M_RAD_TO_DEG_F;
+	vehicle_command.param3 = _angle_outputs[2] * M_RAD_TO_DEG_F;
 
 	orb_publish(ORB_ID(vehicle_command), _vehicle_command_pub, &vehicle_command);
 

--- a/src/drivers/vmount/output_mavlink.cpp
+++ b/src/drivers/vmount/output_mavlink.cpp
@@ -52,6 +52,13 @@ OutputMavlink::OutputMavlink(const OutputConfig &output_config)
 {
 }
 
+OutputMavlink::~OutputMavlink()
+{
+	if (_vehicle_command_pub) {
+		orb_unadvertise(_vehicle_command_pub);
+	}
+}
+
 int OutputMavlink::update(const ControlData *control_data)
 {
 	vehicle_command_s vehicle_command = {

--- a/src/drivers/vmount/output_mavlink.h
+++ b/src/drivers/vmount/output_mavlink.h
@@ -56,7 +56,7 @@ class OutputMavlink : public OutputBase
 {
 public:
 	OutputMavlink(const OutputConfig &output_config);
-	virtual ~OutputMavlink() { }
+	~OutputMavlink();
 
 	virtual int update(const ControlData *control_data);
 

--- a/src/drivers/vmount/output_mavlink.h
+++ b/src/drivers/vmount/output_mavlink.h
@@ -56,7 +56,7 @@ class OutputMavlink : public OutputBase
 {
 public:
 	OutputMavlink(const OutputConfig &output_config);
-	~OutputMavlink();
+	virtual ~OutputMavlink();
 
 	virtual int update(const ControlData *control_data);
 

--- a/src/drivers/vmount/vmount.cpp
+++ b/src/drivers/vmount/vmount.cpp
@@ -222,6 +222,7 @@ static int vmount_thread_main(int argc, char *argv[])
 	g_thread_data = &thread_data;
 
 	int last_active = 0;
+	hrt_abstime last_output_update = 0;
 
 	while (!thread_should_exit) {
 
@@ -342,15 +343,20 @@ static int vmount_thread_main(int argc, char *argv[])
 				}
 			}
 
-			//update output
-			int ret = thread_data.output_obj->update(control_data);
+			hrt_abstime now = hrt_absolute_time();
+			if (now - last_output_update > 10000) { // rate-limit the update of outputs
+				last_output_update = now;
 
-			if (ret) {
-				PX4_ERR("failed to write output (%i)", ret);
-				break;
+				//update output
+				int ret = thread_data.output_obj->update(control_data);
+
+				if (ret) {
+					PX4_ERR("failed to write output (%i)", ret);
+					break;
+				}
+
+				thread_data.output_obj->publish();
 			}
-
-			thread_data.output_obj->publish();
 
 		} else {
 			//wait for parameter changes. We still need to wake up regularily to check for thread exit requests

--- a/src/drivers/vmount/vmount.cpp
+++ b/src/drivers/vmount/vmount.cpp
@@ -444,7 +444,7 @@ int vmount_main(int argc, char *argv[])
 		int vmount_task = px4_task_spawn_cmd("vmount",
 						     SCHED_DEFAULT,
 						     SCHED_PRIORITY_DEFAULT + 40,
-						     1500,
+						     2000,
 						     vmount_thread_main,
 						     (char *const *)argv + 1);
 

--- a/src/drivers/vmount/vmount.cpp
+++ b/src/drivers/vmount/vmount.cpp
@@ -444,7 +444,7 @@ int vmount_main(int argc, char *argv[])
 		int vmount_task = px4_task_spawn_cmd("vmount",
 						     SCHED_DEFAULT,
 						     SCHED_PRIORITY_DEFAULT + 40,
-						     2000,
+						     1900,
 						     vmount_thread_main,
 						     (char *const *)argv + 1);
 

--- a/src/drivers/vmount/vmount.cpp
+++ b/src/drivers/vmount/vmount.cpp
@@ -81,15 +81,15 @@ struct ThreadData {
 static volatile ThreadData *g_thread_data = nullptr;
 
 struct Parameters {
-	int mnt_mode_in;
-	int mnt_mode_out;
-	int mnt_mav_sysid;
-	int mnt_mav_compid;
-	int mnt_ob_lock_mode;
-	int mnt_ob_norm_mode;
-	int mnt_man_pitch;
-	int mnt_man_roll;
-	int mnt_man_yaw;
+	int32_t mnt_mode_in;
+	int32_t mnt_mode_out;
+	int32_t mnt_mav_sysid;
+	int32_t mnt_mav_compid;
+	int32_t mnt_ob_lock_mode;
+	int32_t mnt_ob_norm_mode;
+	int32_t mnt_man_pitch;
+	int32_t mnt_man_roll;
+	int32_t mnt_man_yaw;
 
 	bool operator!=(const Parameters &p)
 	{

--- a/src/drivers/vmount/vmount.cpp
+++ b/src/drivers/vmount/vmount.cpp
@@ -337,7 +337,7 @@ static int vmount_thread_main(int argc, char *argv[])
 					continue;
 				}
 
-				if (control_data_to_check != nullptr) {
+				if (control_data_to_check != nullptr || already_active) {
 					control_data = control_data_to_check;
 					last_active = i;
 				}

--- a/src/drivers/vmount/vmount_params.c
+++ b/src/drivers/vmount/vmount_params.c
@@ -39,9 +39,11 @@
 
 /**
 * Mount input mode
+*
 * RC uses the AUX input channels (see MNT_MAN_* parameters),
 * MAVLINK_ROI uses the MAV_CMD_DO_SET_ROI Mavlink message, and MAVLINK_DO_MOUNT the
 * MAV_CMD_DO_MOUNT_CONFIGURE and MAV_CMD_DO_MOUNT_CONTROL messages to control a mount.
+*
 * @value -1 DISABLED
 * @value 0 AUTO
 * @value 1 RC
@@ -56,9 +58,11 @@ PARAM_DEFINE_INT32(MNT_MODE_IN, -1);
 
 /**
 * Mount output mode
+*
 * AUX uses the mixer output Control Group #2.
 * MAVLINK uses the MAV_CMD_DO_MOUNT_CONFIGURE and MAV_CMD_DO_MOUNT_CONTROL MavLink messages
 * to control a mount (set MNT_MAV_SYSID & MNT_MAV_COMPID)
+*
 * @value 0 AUX
 * @value 1 MAVLINK
 * @min 0
@@ -68,14 +72,18 @@ PARAM_DEFINE_INT32(MNT_MODE_IN, -1);
 PARAM_DEFINE_INT32(MNT_MODE_OUT, 0);
 
 /**
-* Mavlink System ID (if MNT_MODE_OUT is MAVLINK)
+* Mavlink System ID of the mount
+*
+* If MNT_MODE_OUT is MAVLINK, mount configure/control commands will be sent with this target ID.
 *
 * @group Mount
 */
 PARAM_DEFINE_INT32(MNT_MAV_SYSID, 1);
 
 /**
-* Mavlink Component ID (if MNT_MODE_OUT is MAVLINK)
+* Mavlink Component ID of the mount
+*
+* If MNT_MODE_OUT is MAVLINK, mount configure/control commands will be sent with this component ID.
 *
 * @group Mount
 */
@@ -84,6 +92,7 @@ PARAM_DEFINE_INT32(MNT_MAV_COMPID, 154);
 /**
 * Mixer value for selecting normal mode
 * if required by the gimbal (only in AUX output mode)
+*
 * @min -1.0
 * @max 1.0
 * @decimal 3
@@ -94,6 +103,7 @@ PARAM_DEFINE_FLOAT(MNT_OB_NORM_MODE, -1.0f);
 /**
 * Mixer value for selecting a locking mode
 * if required for the gimbal (only in AUX output mode)
+*
 * @min -1.0
 * @max 1.0
 * @decimal 3

--- a/src/drivers/vmount/vmount_params.c
+++ b/src/drivers/vmount/vmount_params.c
@@ -72,14 +72,14 @@ PARAM_DEFINE_INT32(MNT_MODE_OUT, 0);
 *
 * @group Mount
 */
-PARAM_DEFINE_INT32(MNT_MAV_SYSID, 71);
+PARAM_DEFINE_INT32(MNT_MAV_SYSID, 1);
 
 /**
 * Mavlink Component ID (if MNT_MODE_OUT is MAVLINK)
 *
 * @group Mount
 */
-PARAM_DEFINE_INT32(MNT_MAV_COMPID, 67);
+PARAM_DEFINE_INT32(MNT_MAV_COMPID, 154);
 
 /**
 * Mixer value for selecting normal mode


### PR DESCRIPTION
This addresses multiple issues with `vmount`:

1. The `vmount` module was outputting angle setpoints in radians instead of degrees (which is what mavlink specifies) and in the order "roll, pitch, yaw", instead of the mavlink-specified "pitch, roll, yaw".

2. This sets more sensible default parameters for the mount target `system_id` and `component_id`: They default to being a sub-component of PX4 (`system_id = 1`) with `component_id = MAV_COMP_ID_GIMBAL`. Also made parameter descriptions a bit more descriptive.

3. Properly unadvertise uORB topics in destructors. When restarting `vmount` or re-configuring it multiple times, uORB advertise calls eventually started failing (only ever actually witnessed with [this](https://github.com/PX4/Firmware/blob/6b3dabc9874331651b683cea20eef46427542245/src/drivers/vmount/output.cpp#L104) `orb_publish_auto` call.

4. Increase stack size from 1500 to 2000. I witnessed stack overflows to about 1552. I am able to cause these with `MNT_MODE_IN 2` and `MNT_MODE_OUT 1` and sending ROI commands through QGC by very rapidly clicking around on [this](https://pastebin.com/Eb9s4Mdq) custom command widget. I don't know if increasing the stack size to 2000 is actually safe, or if the cause of the increased memory usage (from normally < 1000) should be investigated further.

This currently also contains the fixes from https://github.com/PX4/Firmware/pull/7766. I'll rebase this on master once that's in or we just use this PR.