### PR TITLE
[wip] landdetector mc: widen acceptance threshold after landing 

### DIFF
--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -155,8 +155,8 @@ protected:
 	/** Time in us that ground contact condition have to hold before triggering contact ground */
 	static constexpr uint64_t GROUND_CONTACT_TRIGGER_TIME_US = 350000;
 
-	/** Time interval in us in which wider acceptance thresholds are used after arming. */
-	static constexpr uint64_t LAND_DETECTOR_ARM_PHASE_TIME_US = 2000000;
+	/** Time interval in us in which wider acceptance thresholds are used after landed. */
+	static constexpr uint64_t LAND_DETECTOR_LAND_PHASE_TIME_US = 2000000;
 
 	orb_advert_t _landDetectedPub;
 	struct vehicle_land_detected_s _landDetected;

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -138,7 +138,7 @@ private:
 	struct battery_status_s						_battery;
 
 	uint64_t _min_trust_start;		///< timestamp when minimum trust was applied first
-	uint64_t _arming_time;
+	uint64_t _landed_time;
 
 	/* get control mode dependent pilot throttle threshold with which we should quit landed state and take off */
 	float _get_takeoff_throttle();


### PR DESCRIPTION
Related to the issue here: https://github.com/PX4/Firmware/issues/7768.

Instead of widen acceptance threshold right after arming, the threshold has been widened right after landed was detected. 

@sanderux, can you please retest? 