### PR TITLE
Support for FMUv5 RC00 test HW

### DIFF
--- a/src/drivers/boards/px4fmu-v5/board_config.h
+++ b/src/drivers/boards/px4fmu-v5/board_config.h
@@ -54,10 +54,22 @@
  ****************************************************************************************************/
 /* Configuration ************************************************************************************/
 
-#define BOARD_HAS_LTC44XX_VALIDS      2 // No LTC or N Bricks
-#define BOARD_HAS_USB_VALID           1 // LTC Has No USB valid
-#define BOARD_HAS_NBAT_V              2 // Only one Vbat to ADC
-#define BOARD_HAS_NBAT_I              2 // No Ibat ADC
+/* Un-comment to support some RC00 polarities for test HW */
+//#define PX4_FMUV5_RC00
+#define PX4_FMUV5_RC01
+#define BOARD_HAS_LTC4417
+
+#if defined(BOARD_HAS_LTC4417)
+#  define BOARD_HAS_LTC44XX_VALIDS      2 // No LTC or N Bricks
+#  define BOARD_HAS_USB_VALID           1 // LTC Has No USB valid
+#  define BOARD_HAS_NBAT_V              2 // Only one Vbat to ADC
+#  define BOARD_HAS_NBAT_I              2 // No Ibat ADC
+#else
+#  define BOARD_HAS_LTC44XX_VALIDS      0 // No LTC or N Bricks
+#  define BOARD_HAS_USB_VALID           0 // LTC Has No USB valid
+#  define BOARD_HAS_NBAT_V              1 // Only one Vbat to ADC
+#  define BOARD_HAS_NBAT_I              0 // No Ibat ADC
+#endif
 
 /* PX4FMU GPIOs ***********************************************************************************/
 
@@ -417,7 +429,14 @@
 #define BOARD_NUMBER_BRICKS             2
 #define GPIO_nVDD_USB_VALID             GPIO_nPOWER_IN_C /* USB     Is Chosen */
 
-#define GPIO_nVDD_5V_PERIPH_EN          /* PG4  */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTG|GPIO_PIN4)
+#if defined(PX4_FMUV5_RC00)
+#  define GPIO_VDD_5V_PERIPH_EN         /* PG4  */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTG|GPIO_PIN4)
+#  define GPIO_xVDD_5V_PERIPH_EN                   GPIO_VDD_5V_PERIPH_EN
+#endif
+#if defined(PX4_FMUV5_RC01)
+#  define GPIO_nVDD_5V_PERIPH_EN         /* PG4  */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTG|GPIO_PIN4)
+#  define GPIO_xVDD_5V_PERIPH_EN                    GPIO_nVDD_5V_PERIPH_EN
+#endif
 #define GPIO_nVDD_5V_PERIPH_OC          /* PE15 */ (GPIO_INPUT |GPIO_PULLUP|GPIO_PORTE|GPIO_PIN15)
 #define GPIO_nVDD_5V_HIPOWER_EN         /* PF12 */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTF|GPIO_PIN12)
 #define GPIO_nVDD_5V_HIPOWER_OC         /* PG13 */ (GPIO_INPUT |GPIO_PULLUP|GPIO_PORTF|GPIO_PIN13)
@@ -430,10 +449,16 @@
 
 /* Define True logic Power Control in arch agnostic form */
 
+#if defined(PX4_FMUV5_RC00)
+#define VDD_5V_PERIPH_EN(on_true)          px4_arch_gpiowrite(GPIO_VDD_5V_PERIPH_EN, (on_true))
+#endif
+#if defined(PX4_FMUV5_RC01)
 #define VDD_5V_PERIPH_EN(on_true)          px4_arch_gpiowrite(GPIO_nVDD_5V_PERIPH_EN, !(on_true))
+#endif
 #define VDD_5V_HIPOWER_EN(on_true)         px4_arch_gpiowrite(GPIO_nVDD_5V_HIPOWER_EN, !(on_true))
 #define VDD_3V3_SENSORS_EN(on_true)        px4_arch_gpiowrite(GPIO_VDD_3V3_SENSORS_EN, (on_true))
 #define VDD_3V3_SPEKTRUM_POWER_EN(on_true) px4_arch_gpiowrite(GPIO_VDD_3V3_SPEKTRUM_POWER_EN, (on_true))
+#define READ_VDD_3V3_SPEKTRUM_POWER_EN()   px4_arch_gpioread(GPIO_VDD_3V3_SPEKTRUM_POWER_EN)
 #define VDD_5V_RC_EN(on_true)              px4_arch_gpiowrite(GPIO_VDD_5V_RC_EN, (on_true))
 #define VDD_5V_WIFI_EN(on_true)            px4_arch_gpiowrite(GPIO_VDD_5V_WIFI_EN, (on_true))
 #define VDD_3V3_SD_CARD_EN(on_true)        px4_arch_gpiowrite(GPIO_VDD_3V3_SD_CARD_EN, (on_true))
@@ -575,7 +600,7 @@
 		{GPIO_nPOWER_IN_A,       0,                              0}, \
 		{GPIO_nPOWER_IN_B,       0,                              0}, \
 		{GPIO_nPOWER_IN_C,       0,                              0}, \
-		{0,                      GPIO_nVDD_5V_PERIPH_EN,         0}, \
+		{0,                      GPIO_xVDD_5V_PERIPH_EN,         0}, \
 		{GPIO_nVDD_5V_PERIPH_OC, 0,                              0}, \
 		{0,                      GPIO_nVDD_5V_HIPOWER_EN,        0}, \
 		{GPIO_nVDD_5V_HIPOWER_OC,0,                              0}, \
@@ -650,7 +675,7 @@
 		GPIO_nPOWER_IN_A,                 \
 		GPIO_nPOWER_IN_B,                 \
 		GPIO_nPOWER_IN_C,                 \
-		GPIO_nVDD_5V_PERIPH_EN,           \
+		GPIO_xVDD_5V_PERIPH_EN,           \
 		GPIO_nVDD_5V_PERIPH_OC,           \
 		GPIO_nVDD_5V_HIPOWER_EN,          \
 		GPIO_nVDD_5V_HIPOWER_OC,          \

--- a/src/drivers/boards/px4fmu-v5/px4fmu_init.c
+++ b/src/drivers/boards/px4fmu-v5/px4fmu_init.c
@@ -157,12 +157,12 @@ __EXPORT void board_peripheral_reset(int ms)
 {
 	/* set the peripheral rails off */
 
-	stm32_gpiowrite(GPIO_nVDD_5V_PERIPH_EN, 1);
-	stm32_gpiowrite(GPIO_VDD_3V3_SENSORS_EN, 0);
+	VDD_5V_PERIPH_EN(false);
+	VDD_3V3_SENSORS_EN(false);
 
-	bool last = stm32_gpioread(GPIO_VDD_3V3_SPEKTRUM_POWER_EN);
+	bool last = READ_VDD_3V3_SPEKTRUM_POWER_EN();
 	/* Keep Spektum on to discharge rail*/
-	stm32_gpiowrite(GPIO_VDD_3V3_SPEKTRUM_POWER_EN, 1);
+	VDD_3V3_SPEKTRUM_POWER_EN(false);
 
 	/* wait for the peripheral rail to reach GND */
 	usleep(ms * 1000);
@@ -171,9 +171,9 @@ __EXPORT void board_peripheral_reset(int ms)
 	/* re-enable power */
 
 	/* switch the peripheral rail back on */
-	stm32_gpiowrite(GPIO_VDD_3V3_SPEKTRUM_POWER_EN, last);
-	stm32_gpiowrite(GPIO_VDD_3V3_SENSORS_EN, 1);
-	stm32_gpiowrite(GPIO_nVDD_5V_PERIPH_EN, 0);
+	VDD_3V3_SPEKTRUM_POWER_EN(last);
+	VDD_3V3_SENSORS_EN(true);
+	VDD_5V_PERIPH_EN(true);
 
 }
 


### PR DESCRIPTION
@simonegu 

 RC00 had an active high VDD_5V_PERIPH_EN
 RC01 has an active low  VDD_5V_PERIPH_EN

 RC00 Test hardware did not use an LTC4417

 While RC00 HW is still in circulation you can build with
 PX4_FMUV5_RC00 defined and BOARD_HAS_LTC4417 undefined.

 The default is PX4_FMUV5_RC01 and BOARD_HAS_LTC4417 defined.