### PR TITLE
Fix conflict in OcPoC Ubuntu configuration

### DIFF
--- a/cmake/configs/posix_ocpoc_ubuntu.cmake
+++ b/cmake/configs/posix_ocpoc_ubuntu.cmake
@@ -92,6 +92,7 @@ set(config_module_list
 	lib/DriverFramework/framework
 	lib/rc
 	lib/led
+	lib/micro-CDR
 
 	#
 	# POSIX


### PR DESCRIPTION
Adds 'lib/micro-CDR' to posix_ocpoc_ubuntu cmake config file; mirrors changes in 39eeebd from PR #7685.