### PR TITLE
Command sender printfs improvements

### DIFF
--- a/src/modules/mavlink/mavlink_command_sender.cpp
+++ b/src/modules/mavlink/mavlink_command_sender.cpp
@@ -40,7 +40,6 @@
 
 #include "mavlink_command_sender.h"
 #include <px4_log.h>
-#include <cassert>
 
 #define CMD_DEBUG(FMT, ...) PX4_LOG_NAMED_COND("cmd sender", _debug_enabled, FMT, ##__VA_ARGS__)
 

--- a/src/modules/mavlink/mavlink_command_sender.h
+++ b/src/modules/mavlink/mavlink_command_sender.h
@@ -108,7 +108,7 @@ private:
 		mavlink_command_long_t command = {};
 		hrt_abstime timestamp_us = 0;
 		hrt_abstime last_time_sent_us = 0;
-		int8_t num_sent_per_channel[MAX_MAVLINK_CHANNEL] = {-1, -1, -1, -1};
+		int8_t num_sent_per_channel[MAX_MAVLINK_CHANNEL] = { -1, -1, -1, -1};
 	} command_item_t;
 
 	TimestampedList<command_item_t> _commands;


### PR DESCRIPTION
This improves the printfs which will be logged. This should improve to
debug the camera triggering. The debug printfs are disabled by default.