### PR TITLE
land detector revert FW hysteresis constants and cleanup initialization

### DIFF
--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -87,7 +87,7 @@ float FixedwingLandDetector::_get_max_altitude()
 	// TODO
 	// This means no altitude limit as the limit
 	// is always current position plus 1000 meters
-	return -_controlState.z_pos + 1000;
+	return roundf(-_controlState.z_pos + 1000);
 }
 
 bool FixedwingLandDetector::_get_freefall_state()

--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -68,6 +68,9 @@ FixedwingLandDetector::FixedwingLandDetector() :
 	_paramHandle.maxClimbRate = param_find("LNDFW_VEL_Z_MAX");
 	_paramHandle.maxAirSpeed = param_find("LNDFW_AIRSPD_MAX");
 	_paramHandle.maxIntVelocity = param_find("LNDFW_VELI_MAX");
+
+	// Use Trigger time when transitioning from in-air (false) to landed (true) / ground contact (true).
+	_landed_hysteresis.set_hysteresis_time_from(false, LAND_DETECTOR_TRIGGER_TIME_US);
 }
 
 void FixedwingLandDetector::_initialize_topics()
@@ -105,16 +108,15 @@ bool FixedwingLandDetector::_get_freefall_state()
 	// TODO
 	return false;
 }
+
 bool FixedwingLandDetector::_get_ground_contact_state()
 {
-
 	// TODO
 	return false;
 }
 
 bool FixedwingLandDetector::_get_maybe_landed_state()
 {
-
 	// TODO
 	return false;
 }

--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -41,28 +41,15 @@
 
 #include <px4_config.h>
 #include <px4_defines.h>
+
 #include <cmath>
-#include <drivers/drv_hrt.h>
 
 #include "FixedwingLandDetector.h"
-
 
 namespace land_detector
 {
 
-FixedwingLandDetector::FixedwingLandDetector() :
-	_paramHandle(),
-	_params(),
-	_controlStateSub(-1),
-	_armingSub(-1),
-	_airspeedSub(-1),
-	_controlState{},
-	_arming{},
-	_airspeed{},
-	_velocity_xy_filtered(0.0f),
-	_velocity_z_filtered(0.0f),
-	_airspeed_filtered(0.0f),
-	_accel_horz_lp(0.0f)
+FixedwingLandDetector::FixedwingLandDetector()
 {
 	_paramHandle.maxVelocity = param_find("LNDFW_VEL_XY_MAX");
 	_paramHandle.maxClimbRate = param_find("LNDFW_VEL_Z_MAX");

--- a/src/modules/land_detector/FixedwingLandDetector.h
+++ b/src/modules/land_detector/FixedwingLandDetector.h
@@ -73,6 +73,10 @@ protected:
 
 	virtual float _get_max_altitude() override;
 private:
+
+	/** Time in us that landing conditions have to hold before triggering a land. */
+	static constexpr uint64_t LAND_DETECTOR_TRIGGER_TIME_US = 1500000;
+
 	struct {
 		param_t maxVelocity;
 		param_t maxClimbRate;

--- a/src/modules/land_detector/FixedwingLandDetector.h
+++ b/src/modules/land_detector/FixedwingLandDetector.h
@@ -57,21 +57,15 @@ public:
 	FixedwingLandDetector();
 
 protected:
-	virtual void _initialize_topics() override;
+	void _initialize_topics() override;
+	void _update_params() override;
+	void _update_topics() override;
+	bool _get_landed_state() override;
+	bool _get_maybe_landed_state() override;
+	bool _get_ground_contact_state() override;
+	bool _get_freefall_state() override;
+	float _get_max_altitude() override;
 
-	virtual void _update_params() override;
-
-	virtual void _update_topics() override;
-
-	virtual bool _get_landed_state() override;
-
-	virtual bool _get_maybe_landed_state() override;
-
-	virtual bool _get_ground_contact_state() override;
-
-	virtual bool _get_freefall_state() override;
-
-	virtual float _get_max_altitude() override;
 private:
 
 	/** Time in us that landing conditions have to hold before triggering a land. */
@@ -82,27 +76,27 @@ private:
 		param_t maxClimbRate;
 		param_t maxAirSpeed;
 		param_t maxIntVelocity;
-	} _paramHandle;
+	} _paramHandle{};
 
 	struct {
 		float maxVelocity;
 		float maxClimbRate;
 		float maxAirSpeed;
 		float maxIntVelocity;
-	} _params;
+	} _params{};
 
-	int _controlStateSub;
-	int _armingSub;
-	int _airspeedSub;
+	int _controlStateSub{-1};
+	int _armingSub{-1};
+	int _airspeedSub{-1};
 
-	struct control_state_s _controlState;
-	struct actuator_armed_s _arming;
-	struct airspeed_s _airspeed;
+	control_state_s _controlState{};
+	actuator_armed_s _arming{};
+	airspeed_s _airspeed{};
 
-	float _velocity_xy_filtered;
-	float _velocity_z_filtered;
-	float _airspeed_filtered;
-	float _accel_horz_lp;
+	float _velocity_xy_filtered{0.0f};
+	float _velocity_z_filtered{0.0f};
+	float _airspeed_filtered{0.0f};
+	float _accel_horz_lp{0.0f};
 };
 
 } // namespace land_detector

--- a/src/modules/land_detector/FixedwingLandDetector.h
+++ b/src/modules/land_detector/FixedwingLandDetector.h
@@ -51,7 +51,7 @@
 namespace land_detector
 {
 
-class FixedwingLandDetector : public LandDetector
+class FixedwingLandDetector final : public LandDetector
 {
 public:
 	FixedwingLandDetector();

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -65,10 +65,6 @@ LandDetector::LandDetector() :
 	_takeoff_time{0},
 	_work{}
 {
-	// Use Trigger time when transitioning from in-air (false) to landed (true) / ground contact (true).
-	_landed_hysteresis.set_hysteresis_time_from(false, LAND_DETECTOR_TRIGGER_TIME_US);
-	_maybe_landed_hysteresis.set_hysteresis_time_from(false, MAYBE_LAND_DETECTOR_TRIGGER_TIME_US);
-	_ground_contact_hysteresis.set_hysteresis_time_from(false, GROUND_CONTACT_TRIGGER_TIME_US);
 }
 
 LandDetector::~LandDetector()

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -78,7 +78,7 @@ void LandDetector::_cycle()
 {
 	perf_begin(_cycle_perf);
 
-	if (!_object) { // not initialized yet
+	if (_object == nullptr) { // not initialized yet
 		// Advertise the first land detected uORB.
 		_landDetected.timestamp = hrt_absolute_time();
 		_landDetected.freefall = false;

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -146,18 +146,6 @@ protected:
 	/** Run main land detector loop at this rate in Hz. */
 	static constexpr uint32_t LAND_DETECTOR_UPDATE_RATE_HZ = 50;
 
-	/** Time in us that landing conditions have to hold before triggering a land. */
-	static constexpr uint64_t LAND_DETECTOR_TRIGGER_TIME_US = 300000;
-
-	/** Time in us that almost landing conditions have to hold before triggering almost landed . */
-	static constexpr uint64_t MAYBE_LAND_DETECTOR_TRIGGER_TIME_US = 250000;
-
-	/** Time in us that ground contact condition have to hold before triggering contact ground */
-	static constexpr uint64_t GROUND_CONTACT_TRIGGER_TIME_US = 350000;
-
-	/** Time interval in us in which wider acceptance thresholds are used after landed. */
-	static constexpr uint64_t LAND_DETECTOR_LAND_PHASE_TIME_US = 2000000;
-
 	orb_advert_t _landDetectedPub;
 	struct vehicle_land_detected_s _landDetected;
 

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -46,6 +46,7 @@
 #include <px4_module.h>
 #include <systemlib/hysteresis/hysteresis.h>
 #include <systemlib/param/param.h>
+#include <systemlib/perf_counter.h>
 #include <uORB/uORB.h>
 #include <uORB/topics/vehicle_land_detected.h>
 
@@ -175,6 +176,8 @@ private:
 	hrt_abstime _takeoff_time;
 
 	struct work_s	_work;
+
+	perf_counter_t	_cycle_perf;
 };
 
 

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -106,7 +106,6 @@ protected:
 	 */
 	virtual void _update_topics() = 0;
 
-
 	/**
 	 * Update parameters.
 	 */
@@ -147,19 +146,17 @@ protected:
 	/** Run main land detector loop at this rate in Hz. */
 	static constexpr uint32_t LAND_DETECTOR_UPDATE_RATE_HZ = 50;
 
-	orb_advert_t _landDetectedPub;
-	struct vehicle_land_detected_s _landDetected;
+	orb_advert_t _landDetectedPub{nullptr};
+	vehicle_land_detected_s _landDetected{};
 
-	int _parameterSub;
+	int _parameterSub{-1};
 
-	LandDetectionState _state;
+	LandDetectionState _state{LandDetectionState::LANDED};
 
-	systemlib::Hysteresis _freefall_hysteresis;
-	systemlib::Hysteresis _landed_hysteresis;
-	systemlib::Hysteresis _maybe_landed_hysteresis;
-	systemlib::Hysteresis _ground_contact_hysteresis;
-
-	float _altitude_max;
+	systemlib::Hysteresis _freefall_hysteresis{false};
+	systemlib::Hysteresis _landed_hysteresis{true};
+	systemlib::Hysteresis _maybe_landed_hysteresis{true};
+	systemlib::Hysteresis _ground_contact_hysteresis{true};
 
 private:
 	static void _cycle_trampoline(void *arg);
@@ -170,12 +167,12 @@ private:
 
 	void _update_state();
 
-	param_t _p_total_flight_time_high;
-	param_t _p_total_flight_time_low;
-	uint64_t _total_flight_time; ///< in microseconds
-	hrt_abstime _takeoff_time;
+	param_t _p_total_flight_time_high{PARAM_INVALID};
+	param_t _p_total_flight_time_low{PARAM_INVALID};
+	uint64_t _total_flight_time{0}; ///< in microseconds
+	hrt_abstime _takeoff_time{0};
 
-	struct work_s	_work;
+	struct work_s	_work {};
 
 	perf_counter_t	_cycle_perf;
 };

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -108,6 +108,11 @@ MulticopterLandDetector::MulticopterLandDetector() :
 	_paramHandle.altitude_max = param_find("LNDMC_ALT_MAX");
 	_paramHandle.manual_stick_up_position_takeoff_threshold = param_find("LNDMC_POS_UPTHR");
 	_paramHandle.landSpeed = param_find("MPC_LAND_SPEED");
+
+	// Use Trigger time when transitioning from in-air (false) to landed (true) / ground contact (true).
+	_landed_hysteresis.set_hysteresis_time_from(false, LAND_DETECTOR_TRIGGER_TIME_US);
+	_maybe_landed_hysteresis.set_hysteresis_time_from(false, MAYBE_LAND_DETECTOR_TRIGGER_TIME_US);
+	_ground_contact_hysteresis.set_hysteresis_time_from(false, GROUND_CONTACT_TRIGGER_TIME_US);
 }
 
 void MulticopterLandDetector::_initialize_topics()

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -291,14 +291,7 @@ bool MulticopterLandDetector::_get_maybe_landed_state()
 		// if this persists for 8 seconds AND the drone is not
 		// falling consider it to be landed. This should even sustain
 		// quite acrobatic flight.
-		if ((_min_trust_start > 0) &&
-		    (hrt_elapsed_time(&_min_trust_start) > 8000000)) {
-
-			return true;
-
-		} else {
-			return false;
-		}
+		return (_min_trust_start > 0) && (hrt_elapsed_time(&_min_trust_start) > 8000000);
 	}
 
 	if (_ground_contact_hysteresis.get_state() && _has_minimal_thrust() && !rotating) {
@@ -416,4 +409,4 @@ bool MulticopterLandDetector::_has_minimal_thrust()
 	return _actuators.control[3] <= sys_min_throttle;
 }
 
-}
+} // namespace land_detector

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -82,6 +82,18 @@ protected:
 	virtual float _get_max_altitude() override;
 private:
 
+	/** Time in us that landing conditions have to hold before triggering a land. */
+	static constexpr uint64_t LAND_DETECTOR_TRIGGER_TIME_US = 300000;
+
+	/** Time in us that almost landing conditions have to hold before triggering almost landed . */
+	static constexpr uint64_t MAYBE_LAND_DETECTOR_TRIGGER_TIME_US = 250000;
+
+	/** Time in us that ground contact condition have to hold before triggering contact ground */
+	static constexpr uint64_t GROUND_CONTACT_TRIGGER_TIME_US = 350000;
+
+	/** Time interval in us in which wider acceptance thresholds are used after landed. */
+	static constexpr uint64_t LAND_DETECTOR_LAND_PHASE_TIME_US = 2000000;
+
 	/**
 	* @brief Handles for interesting parameters
 	**/

--- a/src/modules/land_detector/RoverLandDetector.cpp
+++ b/src/modules/land_detector/RoverLandDetector.cpp
@@ -46,10 +46,6 @@
 namespace land_detector
 {
 
-RoverLandDetector::RoverLandDetector()
-{
-}
-
 void RoverLandDetector::_initialize_topics()
 {
 }
@@ -88,4 +84,4 @@ float RoverLandDetector::_get_max_altitude()
 	return 0.0f;
 }
 
-}
+} // namespace land_detector

--- a/src/modules/land_detector/RoverLandDetector.h
+++ b/src/modules/land_detector/RoverLandDetector.h
@@ -51,7 +51,7 @@ namespace land_detector
 class RoverLandDetector : public LandDetector
 {
 public:
-	RoverLandDetector();
+	RoverLandDetector() = default;
 
 protected:
 	virtual void _initialize_topics() override;

--- a/src/modules/land_detector/VtolLandDetector.cpp
+++ b/src/modules/land_detector/VtolLandDetector.cpp
@@ -114,4 +114,4 @@ void VtolLandDetector::_update_params()
 	param_get(_paramHandle.maxAirSpeed, &_params.maxAirSpeed);
 }
 
-}
+} // namespace land_detector

--- a/src/modules/land_detector/land_detector_main.cpp
+++ b/src/modules/land_detector/land_detector_main.cpp
@@ -39,22 +39,17 @@
  * @author Lorenz Meier <lorenz@px4.io>
  */
 
+#include <drivers/drv_hrt.h>
 #include <px4_config.h>
 #include <px4_defines.h>
-#include <px4_tasks.h>
 #include <px4_posix.h>
-#include <unistd.h>					//usleep
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <drivers/drv_hrt.h>
-#include <systemlib/systemlib.h>	//Scheduler
+#include <px4_tasks.h>
+#include <systemlib/systemlib.h>
 
 #include "FixedwingLandDetector.h"
 #include "MulticopterLandDetector.h"
-#include "VtolLandDetector.h"
 #include "RoverLandDetector.h"
+#include "VtolLandDetector.h"
 
 
 namespace land_detector
@@ -73,16 +68,16 @@ int LandDetector::task_spawn(int argc, char *argv[])
 
 	LandDetector *obj;
 
-	if (!strcmp(argv[1], "fixedwing")) {
+	if (strcmp(argv[1], "fixedwing") == 0) {
 		obj = new FixedwingLandDetector();
 
-	} else if (!strcmp(argv[1], "multicopter")) {
+	} else if (strcmp(argv[1], "multicopter") == 0) {
 		obj = new MulticopterLandDetector();
 
-	} else if (!strcmp(argv[1], "vtol")) {
+	} else if (strcmp(argv[1], "vtol") == 0) {
 		obj = new VtolLandDetector();
 
-	} else if (!strcmp(argv[1], "ugv")) {
+	} else if (strcmp(argv[1], "ugv") == 0) {
 		obj = new RoverLandDetector();
 
 	} else {
@@ -90,7 +85,7 @@ int LandDetector::task_spawn(int argc, char *argv[])
 		return -1;
 	}
 
-	if (!obj) {
+	if (obj == nullptr) {
 		PX4_ERR("alloc failed");
 		return -1;
 	}
@@ -139,7 +134,7 @@ int LandDetector::print_status()
 
 int LandDetector::print_usage(const char *reason)
 {
-	if (reason) {
+	if (reason != nullptr) {
 		PX4_ERR("%s\n", reason);
 	}
 
@@ -182,4 +177,4 @@ int land_detector_main(int argc, char *argv[])
 	return LandDetector::main(argc, argv);
 }
 
-}
+} // namespace land_detector


### PR DESCRIPTION
The constants for the land detector hysteresis were reduced significantly about 6 weeks ago. The longer times were more appropriate for FW and made things like hand launch easier.

https://github.com/PX4/Firmware/commit/97b5cc77b8763f7198437ac15d86aa982fa7a3c5#diff-921bb7fba625c282568fb2cbfc8dd414
https://github.com/PX4/Firmware/commit/50ef2d0e526fdff4d82b701d70574a078695b71f#diff-921bb7fba625c282568fb2cbfc8dd414
https://github.com/PX4/Firmware/commit/03d86054a48d3ebf1d4a8f21ce5e4d3d4efb4f08#diff-921bb7fba625c282568fb2cbfc8dd414

This PR moves the constants into the per vehicle land detector headers and has some general initialization cleanup for FixedwingLandDetector and LandDetector. I also added a perf counter to the cycle and rounding to FixedwingLandDetector::_get_max_altitude() so that vehicle_land_detected isn't changed and published every single iteration.

@Stifael FYI
