### PR TITLE
FW att ctrl - Fix vehicle_attitude_setpoint timestamp logging when in stabilized

### DIFF
--- a/src/modules/fw_att_control/fw_att_control_main.cpp
+++ b/src/modules/fw_att_control/fw_att_control_main.cpp
@@ -989,6 +989,7 @@ FixedwingAttitudeControl::task_main()
 				// in STABILIZED mode we need to generate the attitude setpoint
 				// from manual user inputs
 				if (!_vcontrol_mode.flag_control_climb_rate_enabled && !_vcontrol_mode.flag_control_offboard_enabled) {
+					_att_sp.timestamp = hrt_absolute_time();
 					_att_sp.roll_body = _manual.y * _parameters.man_roll_max + _parameters.rollsp_offset_rad;
 					_att_sp.roll_body = math::constrain(_att_sp.roll_body, -_parameters.man_roll_max, _parameters.man_roll_max);
 					_att_sp.pitch_body = -_manual.x * _parameters.man_pitch_max + _parameters.pitchsp_offset_rad;


### PR DESCRIPTION
In FW stabilized mode, the `timestamp` field `vehicle_attitude_setpoint` wasn't updated. As a result, it was impossible to check the accuracy of the attitude controller when in stabilized mode only.

Before the fix:
![before_att_sp_fix](https://user-images.githubusercontent.com/14822839/29368642-9fe4538a-82a0-11e7-8ac8-619c17ee03f3.png)

After the fix:
![after_att_sp_fix](https://user-images.githubusercontent.com/14822839/29368649-a7902a96-82a0-11e7-91d2-f0a69ce41762.png)

