### PR TITLE
uORB Subscription/Publication c++ wrapper improve error messages and minor cleanup

### DIFF
--- a/src/drivers/aerofc_adc/aerofc_adc.cpp
+++ b/src/drivers/aerofc_adc/aerofc_adc.cpp
@@ -34,6 +34,8 @@
 #include <px4_config.h>
 #include <px4_defines.h>
 
+#include <cstring>
+
 #include <arch/board/board.h>
 
 #include <nuttx/arch.h>

--- a/src/drivers/bst/bst.cpp
+++ b/src/drivers/bst/bst.cpp
@@ -49,6 +49,7 @@
 #include <math.h>
 #include <uORB/topics/vehicle_gps_position.h>
 #include <uORB/topics/battery_status.h>
+#include <uORB/topics/vehicle_attitude.h>
 #include <mathlib/math/Quaternion.hpp>
 
 using namespace matrix;

--- a/src/drivers/device/cdev.cpp
+++ b/src/drivers/device/cdev.cpp
@@ -43,8 +43,9 @@
 #include <sys/ioctl.h>
 #include <arch/irq.h>
 
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
 
 #ifdef CONFIG_DISABLE_POLL
 # error This driver is not compatible with CONFIG_DISABLE_POLL

--- a/src/drivers/linux_pwm_out/linux_pwm_out.cpp
+++ b/src/drivers/linux_pwm_out/linux_pwm_out.cpp
@@ -43,6 +43,7 @@
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/actuator_outputs.h>
 #include <uORB/topics/actuator_armed.h>
+#include <uORB/topics/rc_channels.h>
 
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_mixer.h>

--- a/src/drivers/rgbled/rgbled.cpp
+++ b/src/drivers/rgbled/rgbled.cpp
@@ -66,6 +66,8 @@
 #include <drivers/drv_led.h>
 #include <lib/led/led.h>
 
+#include "uORB/topics/parameter_update.h"
+
 #define RGBLED_ONTIME 120
 #define RGBLED_OFFTIME 120
 

--- a/src/drivers/sf0x/sf0x_tests/SF0XTest.cpp
+++ b/src/drivers/sf0x/sf0x_tests/SF0XTest.cpp
@@ -4,7 +4,8 @@
 
 #include <systemlib/err.h>
 
-#include <stdio.h>
+#include <cstdio>
+#include <cstring>
 #include <unistd.h>
 
 extern "C" __EXPORT int sf0x_tests_main(int argc, char *argv[]);

--- a/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
+++ b/src/examples/ekf_att_pos_estimator/ekf_att_pos_estimator_main.cpp
@@ -67,6 +67,7 @@
 #include <mathlib/mathlib.h>
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
 #include <platforms/px4_defines.h>
+#include <uORB/topics/parameter_update.h>
 
 static uint64_t IMUusec = 0;
 

--- a/src/include/containers/List.hpp
+++ b/src/include/containers/List.hpp
@@ -43,45 +43,43 @@ template<class T>
 class __EXPORT ListNode
 {
 public:
-	ListNode() : _sibling(nullptr)
-	{
-	}
-	virtual ~ListNode() {};
+	ListNode() : _sibling() {}
+	virtual ~ListNode() = default;
+
+	// no copy, assignment, move, move assignment
+	ListNode(const ListNode &) = delete;
+	ListNode &operator=(const ListNode &) = delete;
+	ListNode(ListNode &&) = delete;
+	ListNode &operator=(ListNode &&) = delete;
+
 	void setSibling(T sibling) { _sibling = sibling; }
-	T getSibling() { return _sibling; }
-	T get()
-	{
-		return _sibling;
-	}
+	const T getSibling() { return _sibling; }
+
 protected:
 	T _sibling;
-private:
-	// forbid copy
-	ListNode(const ListNode &other);
-	// forbid assignment
-	ListNode &operator = (const ListNode &);
 };
 
 template<class T>
 class __EXPORT List
 {
 public:
-	List() : _head()
-	{
-	}
-	virtual ~List() {};
+	List() : _head() {}
+	virtual ~List() = default;
+
+	// no copy, assignment, move, move assignment
+	List(const List &) = delete;
+	List &operator=(const List &) = delete;
+	List(List &&) = delete;
+	List &operator=(List &&) = delete;
+
 	void add(T newNode)
 	{
 		newNode->setSibling(getHead());
-		setHead(newNode);
+		_head = newNode;
 	}
-	T getHead() { return _head; }
+
+	const T getHead() { return _head; }
+
 protected:
-	void setHead(T &head) { _head = head; }
 	T _head;
-private:
-	// forbid copy
-	List(const List &other);
-	// forbid assignment
-	List &operator = (const List &);
 };

--- a/src/lib/controllib/block/BlockParam.cpp
+++ b/src/lib/controllib/block/BlockParam.cpp
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 /**
- * @file Blockparam.cpp
+ * @file BlockParam.cpp
  *
  * Controller library code
  */

--- a/src/lib/controllib/block/BlockParam.hpp
+++ b/src/lib/controllib/block/BlockParam.hpp
@@ -32,17 +32,18 @@
  ****************************************************************************/
 
 /**
- * @file BlockParam.h
+ * @file BlockParam.hpp
  *
  * Controller library code
  */
 
 #pragma once
 
-#include <systemlib/param/param.h>
-
 #include "Block.hpp"
+
 #include <containers/List.hpp>
+#include <px4_defines.h>
+#include <systemlib/param/param.h>
 
 namespace control
 {
@@ -59,9 +60,9 @@ public:
 	 * @param parent_prefix Set to true to include the parent name in the parameter name
 	 */
 	BlockParamBase(Block *parent, const char *name, bool parent_prefix = true);
-	virtual ~BlockParamBase() {};
+	virtual ~BlockParamBase() = default;
 
-	virtual void update() = 0;
+	virtual bool update() = 0;
 	const char *getName() { return param_name(_handle); }
 
 protected:
@@ -70,13 +71,13 @@ protected:
 
 // Parameters that are tied to blocks for updating and naming.
 template <class T>
-class __EXPORT BlockParam : public BlockParamBase
+class __EXPORT BlockParam final : public BlockParamBase
 {
 public:
 	BlockParam(Block *block, const char *name, bool parent_prefix = true);
 	BlockParam(Block *block, const char *name, bool parent_prefix, T &extern_val);
 
-	~BlockParam() = default;
+	~BlockParam() override = default;
 
 	// no copy, assignment, move, move assignment
 	BlockParam(const BlockParam &) = delete;
@@ -87,13 +88,14 @@ public:
 	T get() const { return _val; }
 
 	// Store the parameter value to the parameter storage (@see param_set())
-	void commit() { param_set(_handle, &_val); };
+	bool commit() { return (param_set(_handle, &_val) == PX4_OK); }
 
 	// Store the parameter value to the parameter storage, w/o notifying the system (@see param_set_no_notification())
-	void commit_no_notification() { param_set_no_notification(_handle, &_val); };
+	bool commit_no_notification() { return (param_set_no_notification(_handle, &_val) == PX4_OK); }
 
-	void set(T val) { _val = val; };
-	void update() override { param_get(_handle, &_val); };
+	void set(T val) { _val = val; }
+
+	bool update() override { return (param_get(_handle, &_val) == PX4_OK); }
 
 protected:
 	T _val;
@@ -103,10 +105,5 @@ typedef BlockParam<float> BlockParamFloat;
 typedef BlockParam<int32_t> BlockParamInt;
 typedef BlockParam<float &> BlockParamExtFloat;
 typedef BlockParam<int32_t &> BlockParamExtInt;
-
-template class __EXPORT BlockParam<float>;
-template class __EXPORT BlockParam<int32_t>;
-template class __EXPORT BlockParam<float &>;
-template class __EXPORT BlockParam<int32_t &>;
 
 } // namespace control

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -83,6 +83,7 @@
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/sensor_selection.h>
 #include <uORB/topics/sensor_baro.h>
+#include <uORB/topics/parameter_update.h>
 
 #include <ecl/EKF/ekf.h>
 

--- a/src/modules/ekf2_replay/ekf2_replay_main.cpp
+++ b/src/modules/ekf2_replay/ekf2_replay_main.cpp
@@ -70,6 +70,8 @@
 #include <uORB/topics/optical_flow.h>
 #include <uORB/topics/distance_sensor.h>
 #include <uORB/topics/airspeed.h>
+#include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_status.h>
 
 #include <sdlog2/sdlog2_messages.h>
 

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -38,12 +38,14 @@
  * @author Julian Oes <julian@oes.ch>
  */
 
+#include "LandDetector.h"
+
+#include <cfloat>
+
 #include <px4_config.h>
 #include <px4_defines.h>
 #include <drivers/drv_hrt.h>
-#include <float.h>
-
-#include "LandDetector.h"
+#include "uORB/topics/parameter_update.h"
 
 
 namespace land_detector

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -912,8 +912,7 @@ void Logger::run()
 
 			/* Check if parameters have changed */
 			// this needs to change to a timestamped record to record a history of parameter changes
-			if (parameter_update_sub.check_updated()) {
-				parameter_update_sub.update();
+			if (parameter_update_sub.update()) {
 				write_changed_parameters();
 			}
 

--- a/src/modules/mavlink/mavlink_command_sender.h
+++ b/src/modules/mavlink/mavlink_command_sender.h
@@ -108,7 +108,7 @@ private:
 		mavlink_command_long_t command = {};
 		hrt_abstime timestamp_us = 0;
 		hrt_abstime last_time_sent_us = 0;
-		int8_t num_sent_per_channel[MAX_MAVLINK_CHANNEL] = { -1, -1, -1, -1};
+		int8_t num_sent_per_channel[MAX_MAVLINK_CHANNEL] = {-1, -1, -1, -1};
 	} command_item_t;
 
 	TimestampedList<command_item_t> _commands;

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -81,6 +81,7 @@
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_command.h>
+#include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_gps_position.h>
 #include <uORB/topics/vehicle_land_detected.h>

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -60,10 +60,12 @@
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/position_setpoint_triplet.h>
+#include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_local_position_setpoint.h>
+#include <uORB/topics/vehicle_status.h>
 
 #include <float.h>
 #include <lib/geo/geo.h>

--- a/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_dummy.cpp
+++ b/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_dummy.cpp
@@ -34,6 +34,8 @@
 #include <px4_posix.h>
 #include <px4_tasks.h>
 
+#include <cstring>
+
 extern "C" __EXPORT int micrortps_client_main(int argc, char *argv[]);
 
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -68,6 +68,7 @@
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_gps_position.h>
 #include <uORB/topics/vehicle_land_detected.h>
+#include <uORB/topics/vehicle_local_position.h>
 #include <uORB/uORB.h>
 
 /**

--- a/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
@@ -59,6 +59,7 @@
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_gps_position.h>
+#include <uORB/topics/vehicle_rates_setpoint.h>
 #include <uORB/topics/att_pos_mocap.h>
 #include <uORB/topics/optical_flow.h>
 #include <uORB/topics/distance_sensor.h>

--- a/src/modules/sensors/rc_update.h
+++ b/src/modules/sensors/rc_update.h
@@ -44,6 +44,7 @@
 #include <drivers/drv_hrt.h>
 #include <mathlib/mathlib.h>
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
+#include <uORB/topics/rc_channels.h>
 
 namespace sensors
 {

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -45,6 +45,7 @@
 #include <pthread.h>
 #include <conversion/rotation.h>
 #include <mathlib/mathlib.h>
+#include <uORB/topics/vehicle_local_position.h>
 
 extern "C" __EXPORT hrt_abstime hrt_reset(void);
 

--- a/src/modules/uORB/Publication.hpp
+++ b/src/modules/uORB/Publication.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2015 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2017 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,13 +32,11 @@
  ****************************************************************************/
 
 /**
- * @file Publication.h
+ * @file Publication.hpp
  *
  */
 
 #pragma once
-
-#include <assert.h>
 
 #include <uORB/uORB.h>
 #include <containers/List.hpp>
@@ -63,35 +61,28 @@ public:
 	 * @param priority The priority for multi pub/sub, 0-based, -1 means
 	 * 	don't publish as multi
 	 */
-	PublicationBase(const struct orb_metadata *meta,
-			int priority = -1);
+	PublicationBase(const struct orb_metadata *meta, int priority = -1);
+
+	virtual ~PublicationBase();
+
+	// no copy, assignment, move, move assignment
+	PublicationBase(const PublicationBase &) = delete;
+	PublicationBase &operator=(const PublicationBase &) = delete;
+	PublicationBase(PublicationBase &&) = delete;
+	PublicationBase &operator=(PublicationBase &&) = delete;
 
 	/**
 	 * Update the struct
 	 * @param data The uORB message struct we are updating.
 	 */
-	void update(void *data);
+	bool update(void *data);
 
-	/**
-	 * Deconstructor
-	 */
-	virtual ~PublicationBase();
-
-// accessors
-	const struct orb_metadata *getMeta() { return _meta; }
-	orb_advert_t getHandle() { return _handle; }
 protected:
-	// disallow copy
-	PublicationBase(const PublicationBase &other);
-	// disallow assignment
-	PublicationBase &operator=(const PublicationBase &other);
-// accessors
-	void setHandle(orb_advert_t handle) { _handle = handle; }
-// attributes
 	const struct orb_metadata *_meta;
-	int _priority;
-	int _instance;
-	orb_advert_t _handle;
+	const int _priority;
+
+	int _instance{0};
+	orb_advert_t _handle{nullptr};
 };
 
 /**
@@ -103,9 +94,7 @@ typedef PublicationBase PublicationTiny;
 /**
  * The publication base class as a list node.
  */
-class __EXPORT PublicationNode :
-	public PublicationBase,
-	public ListNode<PublicationNode *>
+class __EXPORT PublicationNode : public PublicationBase, public ListNode<PublicationNode *>
 {
 public:
 	/**
@@ -118,20 +107,20 @@ public:
 	 * 	list during construction
 	 */
 	PublicationNode(const struct orb_metadata *meta, int priority = -1, List<PublicationNode *> *list = nullptr);
+	virtual ~PublicationNode() override = default;
 
 	/**
 	 * This function is the callback for list traversal
 	 * updates, a child class must implement it.
 	 */
-	virtual void update() = 0;
+	virtual bool update() = 0;
 };
 
 /**
  * Publication wrapper class
  */
 template<class T>
-class __EXPORT Publication :
-	public PublicationNode
+class __EXPORT Publication final : public PublicationNode
 {
 public:
 	/**
@@ -149,10 +138,13 @@ public:
 	{
 	}
 
-	/**
-	 * Deconstructor
-	 **/
-	virtual ~Publication() {};
+	~Publication() override = default;
+
+	// no copy, assignment, move, move assignment
+	Publication(const Publication &) = delete;
+	Publication &operator=(const Publication &) = delete;
+	Publication(Publication &&) = delete;
+	Publication &operator=(Publication &&) = delete;
 
 	/*
 	 * This function gets the T struct
@@ -162,10 +154,11 @@ public:
 	/**
 	 * Create an update function that uses the embedded struct.
 	 */
-	void update()
+	bool update() override
 	{
-		PublicationBase::update((void *)(&_data));
+		return PublicationBase::update((void *)(&_data));
 	}
+
 private:
 	T _data;
 };

--- a/src/modules/uORB/Subscription.hpp
+++ b/src/modules/uORB/Subscription.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2015 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2017 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,13 +32,11 @@
  ****************************************************************************/
 
 /**
- * @file Subscription.h
+ * @file Subscription.hpp
  *
  */
 
 #pragma once
-
-#include <assert.h>
 
 #include <uORB/uORB.h>
 #include <containers/List.hpp>
@@ -48,14 +46,12 @@ namespace uORB
 {
 
 /**
- * Base subscription warapper class, used in list traversal
+ * Base subscription wrapper class, used in list traversal
  * of various subscriptions.
  */
 class __EXPORT SubscriptionBase
 {
 public:
-// methods
-
 	/**
 	 * Constructor
 	 *
@@ -65,8 +61,14 @@ public:
 	 * 	between updates
 	 * @param instance The instance for multi sub.
 	 */
-	SubscriptionBase(const struct orb_metadata *meta,
-			 unsigned interval = 0, unsigned instance = 0);
+	SubscriptionBase(const struct orb_metadata *meta, unsigned interval = 0, unsigned instance = 0);
+	virtual ~SubscriptionBase();
+
+	// no copy, assignment, move, move assignment
+	SubscriptionBase(const SubscriptionBase &) = delete;
+	SubscriptionBase &operator=(const SubscriptionBase &) = delete;
+	SubscriptionBase(SubscriptionBase &&) = delete;
+	SubscriptionBase &operator=(SubscriptionBase &&) = delete;
 
 	/**
 	 * Check if there is a new update.
@@ -77,35 +79,14 @@ public:
 	 * Update the struct
 	 * @param data The uORB message struct we are updating.
 	 */
-	void update(void *data);
+	bool update(void *data);
 
-	/**
-	 * Deconstructor
-	 */
-	virtual ~SubscriptionBase();
-
-// accessors
-	const struct orb_metadata *getMeta() { return _meta; }
 	int getHandle() const { return _handle; }
 
-	unsigned getInterval() const
-	{
-		unsigned int interval;
-		orb_get_interval(getHandle(), &interval);
-		return interval;
-	}
 protected:
-// accessors
-	void setHandle(int handle) { _handle = handle; }
-// attributes
 	const struct orb_metadata *_meta;
-	int _instance;
+	unsigned _instance;
 	int _handle;
-private:
-	// disallow copy
-	SubscriptionBase(const SubscriptionBase &other);
-	// disallow assignment
-	SubscriptionBase &operator=(const SubscriptionBase &other);
 };
 
 /**
@@ -116,10 +97,7 @@ typedef SubscriptionBase SubscriptionTiny;
 /**
  * The subscription base class as a list node.
  */
-class __EXPORT SubscriptionNode :
-
-	public SubscriptionBase,
-	public ListNode<SubscriptionNode *>
+class __EXPORT SubscriptionNode : public SubscriptionBase, public ListNode<SubscriptionNode *>
 {
 public:
 	/**
@@ -133,20 +111,16 @@ public:
 	 * @param list 	A pointer to a list of subscriptions
 	 * 	that this should be appended to.
 	 */
-	SubscriptionNode(const struct orb_metadata *meta,
-			 unsigned interval = 0,
-			 int instance = 0,
-			 List<SubscriptionNode *> *list = nullptr) :
-		SubscriptionBase(meta, interval, instance)
-	{
-		if (list != nullptr) { list->add(this); }
-	}
+	SubscriptionNode(const struct orb_metadata *meta, unsigned interval = 0, unsigned instance = 0,
+			 List<SubscriptionNode *> *list = nullptr);
+
+	virtual ~SubscriptionNode() override = default;
 
 	/**
 	 * This function is the callback for list traversal
 	 * updates, a child class must implement it.
 	 */
-	virtual void update() = 0;
+	virtual bool update() = 0;
 
 };
 
@@ -154,8 +128,7 @@ public:
  * Subscription wrapper class
  */
 template<class T>
-class __EXPORT Subscription :
-	public SubscriptionNode
+class __EXPORT Subscription final : public SubscriptionNode
 {
 public:
 	/**
@@ -168,43 +141,26 @@ public:
 	 * @param list A list interface for adding to
 	 * 	list during construction
 	 */
-	Subscription(const struct orb_metadata *meta,
-		     unsigned interval = 0,
-		     int instance = 0,
+	Subscription(const struct orb_metadata *meta, unsigned interval = 0, unsigned instance = 0,
 		     List<SubscriptionNode *> *list = nullptr):
 		SubscriptionNode(meta, interval, instance, list),
 		_data() // initialize data structure to zero
 	{}
 
+	~Subscription() override final = default;
 
-	Subscription(const Subscription &other):
-		SubscriptionNode(other._meta, other.getInterval(), other._instance, nullptr),
-		_data() // initialize data structure to zero
-	{}
-
-
-	/**
-	 * Deconstructor
-	 */
-	virtual ~Subscription()
-	{}
-
+	// no copy, assignment, move, move assignment
+	Subscription(const Subscription &) = delete;
+	Subscription &operator=(const Subscription &) = delete;
+	Subscription(Subscription &&) = delete;
+	Subscription &operator=(Subscription &&) = delete;
 
 	/**
 	 * Create an update function that uses the embedded struct.
 	 */
-	void update()
+	bool update() override final
 	{
-		SubscriptionBase::update((void *)(&_data));
-	}
-
-
-	/**
-	 * Create an update function that uses the embedded struct.
-	 */
-	bool check_updated()
-	{
-		return SubscriptionBase::updated();
+		return SubscriptionBase::update((void *)(&_data));
 	}
 
 	/*

--- a/src/modules/uORB/uORBManager.cpp
+++ b/src/modules/uORB/uORBManager.cpp
@@ -197,7 +197,7 @@ orb_advert_t uORB::Manager::orb_advertise_multi(const struct orb_metadata *meta,
 	px4_close(fd);
 
 	if (result == ERROR) {
-		PX4_WARN("px4_ioctl ORBIOCGADVERTISER  failed. fd = %d", fd);
+		PX4_WARN("px4_ioctl ORBIOCGADVERTISER failed. fd = %d", fd);
 		return nullptr;
 	}
 

--- a/src/platforms/px4_includes.h
+++ b/src/platforms/px4_includes.h
@@ -39,34 +39,10 @@
 
 #pragma once
 
-#include <stdbool.h>
-
 #if defined(__PX4_ROS)
 /*
  * Building for running within the ROS environment
  */
-
-#ifdef __cplusplus
-#include "ros/ros.h"
-#include <px4_rc_channels.h>
-#include <px4_vehicle_attitude.h>
-#include <px4_vehicle_attitude_setpoint.h>
-#include <px4_manual_control_setpoint.h>
-#include <px4_actuator_controls.h>
-#include <px4_vehicle_rates_setpoint.h>
-#include <px4_mc_virtual_rates_setpoint.h>
-#include <px4_vehicle_attitude.h>
-#include <px4_control_state.h>
-#include <px4_vehicle_control_mode.h>
-#include <px4_actuator_armed.h>
-#include <px4_parameter_update.h>
-#include <px4_vehicle_status.h>
-#include <px4_vehicle_local_position_setpoint.h>
-#include <px4_vehicle_local_position.h>
-#include <px4_position_setpoint_triplet.h>
-#include <px4_offboard_control_mode.h>
-#include <px4_vehicle_force_setpoint.h>
-#endif
 
 #elif defined(__PX4_NUTTX)
 /*
@@ -74,81 +50,39 @@
  */
 #include <nuttx/config.h>
 #include <uORB/uORB.h>
-#ifdef __cplusplus
-#include <platforms/nuttx/px4_messages/px4_rc_channels.h>
-#include <platforms/nuttx/px4_messages/px4_vehicle_attitude_setpoint.h>
-#include <platforms/nuttx/px4_messages/px4_manual_control_setpoint.h>
-#include <platforms/nuttx/px4_messages/px4_actuator_controls.h>
-#include <platforms/nuttx/px4_messages/px4_vehicle_rates_setpoint.h>
-#include <platforms/nuttx/px4_messages/px4_vehicle_attitude.h>
-#include <platforms/nuttx/px4_messages/px4_control_state.h>
-#include <platforms/nuttx/px4_messages/px4_vehicle_control_mode.h>
-#include <platforms/nuttx/px4_messages/px4_actuator_armed.h>
-#include <platforms/nuttx/px4_messages/px4_parameter_update.h>
-#include <platforms/nuttx/px4_messages/px4_vehicle_status.h>
-#include <platforms/nuttx/px4_messages/px4_vehicle_local_position_setpoint.h>
-#include <platforms/nuttx/px4_messages/px4_vehicle_local_position.h>
-#include <platforms/nuttx/px4_messages/px4_position_setpoint_triplet.h>
-#include <platforms/nuttx/px4_messages/px4_offboard_control_mode.h>
-#include <platforms/nuttx/px4_messages/px4_vehicle_force_setpoint.h>
-#include <platforms/nuttx/px4_messages/px4_camera_trigger.h>
-#endif
+
 #include <systemlib/err.h>
 #include <systemlib/param/param.h>
 #include <systemlib/systemlib.h>
 
 #elif defined(__PX4_POSIX) && !defined(__PX4_QURT)
+/*
+ * Building for Posix
+ */
 #include <string.h>
 #include <assert.h>
 #include <uORB/uORB.h>
 
 #define ASSERT(x) assert(x)
 
-#ifdef __cplusplus
-#include <platforms/posix/px4_messages/px4_rc_channels.h>
-#include <platforms/posix/px4_messages/px4_vehicle_attitude_setpoint.h>
-#include <platforms/posix/px4_messages/px4_manual_control_setpoint.h>
-#include <platforms/posix/px4_messages/px4_actuator_controls.h>
-#include <platforms/posix/px4_messages/px4_vehicle_rates_setpoint.h>
-#include <platforms/posix/px4_messages/px4_vehicle_attitude.h>
-#include <platforms/posix/px4_messages/px4_control_state.h>
-#include <platforms/posix/px4_messages/px4_vehicle_control_mode.h>
-#include <platforms/posix/px4_messages/px4_actuator_armed.h>
-#include <platforms/posix/px4_messages/px4_parameter_update.h>
-#include <platforms/posix/px4_messages/px4_vehicle_status.h>
-#include <platforms/posix/px4_messages/px4_vehicle_local_position_setpoint.h>
-#include <platforms/posix/px4_messages/px4_vehicle_local_position.h>
-#include <platforms/posix/px4_messages/px4_position_setpoint_triplet.h>
-#endif
 #include <systemlib/err.h>
 #include <systemlib/param/param.h>
 #include <systemlib/systemlib.h>
+
 #elif defined(__PX4_QURT)
+/*
+ * Building for QuRT
+ */
 #include <string.h>
 #include <assert.h>
 #include <uORB/uORB.h>
 
 #define ASSERT(x) assert(x)
 
-#ifdef __cplusplus
-#include <platforms/qurt/px4_messages/px4_rc_channels.h>
-#include <platforms/qurt/px4_messages/px4_vehicle_attitude_setpoint.h>
-#include <platforms/qurt/px4_messages/px4_manual_control_setpoint.h>
-#include <platforms/qurt/px4_messages/px4_actuator_controls.h>
-#include <platforms/qurt/px4_messages/px4_vehicle_rates_setpoint.h>
-#include <platforms/qurt/px4_messages/px4_vehicle_attitude.h>
-#include <platforms/qurt/px4_messages/px4_control_state.h>
-#include <platforms/qurt/px4_messages/px4_vehicle_control_mode.h>
-#include <platforms/qurt/px4_messages/px4_actuator_armed.h>
-#include <platforms/qurt/px4_messages/px4_parameter_update.h>
-#include <platforms/qurt/px4_messages/px4_vehicle_status.h>
-#include <platforms/qurt/px4_messages/px4_vehicle_local_position_setpoint.h>
-#include <platforms/qurt/px4_messages/px4_vehicle_local_position.h>
-#include <platforms/qurt/px4_messages/px4_position_setpoint_triplet.h>
-#endif
 #include <systemlib/err.h>
 #include <systemlib/param/param.h>
 #include <systemlib/systemlib.h>
+
 #else
 #error "No target platform defined"
 #endif

--- a/src/systemcmds/motor_ramp/motor_ramp.cpp
+++ b/src/systemcmds/motor_ramp/motor_ramp.cpp
@@ -58,6 +58,7 @@
 
 #include "systemlib/systemlib.h"
 #include "systemlib/err.h"
+#include "uORB/topics/actuator_controls.h"
 
 enum RampState {
 	RAMP_INIT,


### PR DESCRIPTION
 - update Subscription/Publication error messages to use PX4_WARN/PX4_ERR and print the topic name
 - Subscription change update() method to return a bool and drop check_update()
 - mark Subscription/Publication final (might remove some virtual calls)
 - cleanup px4_includes.h to remove partial list of uorb messages