### PR TITLE
Fix: disable power valid checks

### DIFF
--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -1039,7 +1039,7 @@ int preflight_check(struct vehicle_status_s *status, orb_advert_t *mavlink_log_p
 		}
 	}
 
-	if (battery->warning >= battery_status_s::BATTERY_WARNING_LOW) {
+	if (!status_flags->circuit_breaker_engaged_power_check && battery->warning >= battery_status_s::BATTERY_WARNING_LOW) {
 		preflight_ok = false;
 
 		if (reportFailures) {


### PR DESCRIPTION
This commit allows to ignore the battery prearm checks when CBRK_SUPPLY_CHK is disabled