### PR TITLE
mavlink main return main loop delay proper size

### DIFF
--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -452,7 +452,7 @@ public:
 	int			get_data_rate()		{ return _datarate; }
 	void			set_data_rate(int rate) { if (rate > 0) { _datarate = rate; } }
 
-	uint64_t		get_main_loop_delay() { return _main_loop_delay; }
+	unsigned		get_main_loop_delay() const { return _main_loop_delay; }
 
 	/** get the Mavlink shell. Create a new one if there isn't one. It is *always* created via MavlinkReceiver thread.
 	 *  Returns nullptr if shell cannot be created */


### PR DESCRIPTION
Going back to @pavel-kirienko's NuttX profiling one thing he found was > 1% of total system time was spent on this line in mavlink. https://github.com/PX4/Firmware/pull/6829#issuecomment-287369858
![image](https://user-images.githubusercontent.com/84712/29498499-d12a62da-85cb-11e7-94b5-b707ddf92949.png)

This turned out to be get_main_loop_delay() returning a 64 bit integer, although the loop delay itself is an unsigned int. Simply fixing the return type to match the data reduces cpu by 1-2%.

Before

	 185 mavlink_if0                 19839 10.658  1736/ 2380 100 (100)  w:sig 
	 186 mavlink_rcv_if0               763  0.429  1608/ 2140 175 (175)  w:sem 
	 190 mavlink_if1                  4878  2.646  1656/ 2420 100 (100)  READY 
	 191 mavlink_rcv_if1               757  0.429  1320/ 2140 175 (175)  w:sem 
	 206 mavlink_if2                 13381  7.081  1720/ 2364 100 (100)  w:sig 
	 207 mavlink_rcv_if2               769  0.357  1504/ 2140 175 (175)  w:sem 
	 247 mavlink_if3                 12008  6.151  1648/ 2388 100 (100)  READY 
	 248 mavlink_rcv_if3               777  0.429  1320/ 2140 175 (175)  w:sem 

After

	 185 mavlink_if0                 10836  9.942  1736/ 2380 100 (100)  READY 
	 186 mavlink_rcv_if0               449  0.432  1496/ 2140 175 (175)  w:sem 
	 190 mavlink_if1                  2623  2.377  1656/ 2420 100 (100)  w:sig 
	 191 mavlink_rcv_if1               443  0.432  1320/ 2140 175 (175)  w:sem 
	 206 mavlink_if2                  7237  6.556  1720/ 2364 100 (100)  w:sig 
	 207 mavlink_rcv_if2               451  0.432  1320/ 2140 175 (175)  w:sem 
	 247 mavlink_if3                  6264  5.475  1664/ 2388 100 (100)  w:sig 
	 248 mavlink_rcv_if3               447  0.432  1464/ 2140 175 (175)  w:sem 