### PR TITLE
orb_exists slow, remove usage

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1975,16 +1975,14 @@ int commander_thread_main(int argc, char *argv[])
 
 		for (int i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
 
-			if (telemetry_subs[i] < 0 && (OK == orb_exists(ORB_ID(telemetry_status), i))) {
+			if (telemetry_subs[i] < 0) {
 				telemetry_subs[i] = orb_subscribe_multi(ORB_ID(telemetry_status), i);
 			}
 
 			orb_check(telemetry_subs[i], &updated);
 
 			if (updated) {
-				struct telemetry_status_s telemetry;
-				memset(&telemetry, 0, sizeof(telemetry));
-
+				telemetry_status_s telemetry = {};
 				orb_copy(ORB_ID(telemetry_status), telemetry_subs[i], &telemetry);
 
 				/* perform system checks when new telemetry link connected */


### PR DESCRIPTION
The orb_exists() call is incredibly slow. In commander no longer checking if a telem instance exists and instead subscribing and checking all (max 4) reduces commander cpu from ~ 2.7% -> 1.3% on a pixracer.

Before

	 167 commander                    4725  2.758  2552/ 3652 140 (140)  w:sig 

After

	 167 commander                    1432  1.299  2344/ 3652 140 (140)  w:sig 


