### PR TITLE
Perf improvements for SITL

### DIFF
--- a/src/drivers/device/vdev.cpp
+++ b/src/drivers/device/vdev.cpp
@@ -44,33 +44,20 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <string>
+#include <map>
 
 #include "DevMgr.hpp"
 
 using namespace DriverFramework;
+using namespace std;
 
 namespace device
 {
 
 int px4_errno;
 
-struct px4_dev_t {
-	char *name;
-	void *cdev;
-
-	px4_dev_t(const char *n, void *c) : cdev(c)
-	{
-		name = strdup(n);
-	}
-
-	~px4_dev_t() { free(name); }
-
-private:
-	px4_dev_t() {}
-};
-
-#define PX4_MAX_DEV 500
-static px4_dev_t *devmap[PX4_MAX_DEV];
+static map<string, void *> devmap;
 pthread_mutex_t devmutex = PTHREAD_MUTEX_INITIALIZER;
 
 
@@ -137,38 +124,26 @@ int
 VDev::register_driver(const char *name, void *data)
 {
 	PX4_DEBUG("VDev::register_driver %s", name);
-	int ret = -ENOSPC;
+	int ret = 0;
 
 	if (name == nullptr || data == nullptr) {
 		return -EINVAL;
 	}
 
-	// Make sure the device does not already exist
-	// FIXME - convert this to a map for efficiency
-
 	pthread_mutex_lock(&devmutex);
 
-	for (int i = 0; i < PX4_MAX_DEV; ++i) {
-		if (devmap[i] && (strcmp(devmap[i]->name, name) == 0)) {
-			pthread_mutex_unlock(&devmutex);
-			return -EEXIST;
-		}
+	// Make sure the device does not already exist
+	auto item = devmap.find(name);
+
+	if (item != devmap.end()) {
+		pthread_mutex_unlock(&devmutex);
+		return -EEXIST;
 	}
 
-	for (int i = 0; i < PX4_MAX_DEV; ++i) {
-		if (devmap[i] == nullptr) {
-			devmap[i] = new px4_dev_t(name, (void *)data);
-			PX4_DEBUG("Registered DEV %s", name);
-			ret = PX4_OK;
-			break;
-		}
-	}
+	devmap[name] = (void *)data;
+	PX4_DEBUG("Registered DEV %s", name);
 
 	pthread_mutex_unlock(&devmutex);
-
-	if (ret != PX4_OK) {
-		PX4_ERR("No free devmap entries - increase PX4_MAX_DEV");
-	}
 
 	return ret;
 }
@@ -185,14 +160,9 @@ VDev::unregister_driver(const char *name)
 
 	pthread_mutex_lock(&devmutex);
 
-	for (int i = 0; i < PX4_MAX_DEV; ++i) {
-		if (devmap[i] && (strcmp(name, devmap[i]->name) == 0)) {
-			delete devmap[i];
-			devmap[i] = nullptr;
-			PX4_DEBUG("Unregistered DEV %s", name);
-			ret = PX4_OK;
-			break;
-		}
+	if (devmap.erase(name) > 0) {
+		PX4_DEBUG("Unregistered DEV %s", name);
+		ret = 0;
 	}
 
 	pthread_mutex_unlock(&devmutex);
@@ -206,22 +176,19 @@ VDev::unregister_class_devname(const char *class_devname, unsigned class_instanc
 	PX4_DEBUG("VDev::unregister_class_devname");
 	char name[32];
 	snprintf(name, sizeof(name), "%s%u", class_devname, class_instance);
+	int ret = -EINVAL;
 
+	PX4_WARN("unregistering class %s", name);
 	pthread_mutex_lock(&devmutex);
 
-	for (int i = 0; i < PX4_MAX_DEV; ++i) {
-		if (devmap[i] && strcmp(devmap[i]->name, name) == 0) {
-			delete devmap[i];
-			PX4_DEBUG("Unregistered class DEV %s", name);
-			devmap[i] = nullptr;
-			pthread_mutex_unlock(&devmutex);
-			return PX4_OK;
-		}
+	if (devmap.erase(name) > 0) {
+		PX4_DEBUG("Unregistered class DEV %s", name);
+		ret = 0;
 	}
 
 	pthread_mutex_unlock(&devmutex);
 
-	return -EINVAL;
+	return ret;
 }
 
 int
@@ -535,18 +502,14 @@ VDev::remove_poll_waiter(px4_pollfd_struct_t *fds)
 VDev *VDev::getDev(const char *path)
 {
 	PX4_DEBUG("VDev::getDev");
-	int i = 0;
 
 	pthread_mutex_lock(&devmutex);
 
-	for (; i < PX4_MAX_DEV; ++i) {
-		//if (devmap[i]) {
-		//	printf("%s %s\n", devmap[i]->name, path);
-		//}
-		if (devmap[i] && (strcmp(devmap[i]->name, path) == 0)) {
-			pthread_mutex_unlock(&devmutex);
-			return (VDev *)(devmap[i]->cdev);
-		}
+	auto item = devmap.find(path);
+
+	if (item != devmap.end()) {
+		pthread_mutex_unlock(&devmutex);
+		return (VDev *)item->second;
 	}
 
 	pthread_mutex_unlock(&devmutex);
@@ -561,9 +524,9 @@ void VDev::showDevices()
 
 	pthread_mutex_lock(&devmutex);
 
-	for (; i < PX4_MAX_DEV; ++i) {
-		if (devmap[i] && strncmp(devmap[i]->name, "/dev/", 5) == 0) {
-			PX4_INFO("   %s", devmap[i]->name);
+	for (const auto &dev : devmap) {
+		if (strncmp(dev.first.c_str(), "/dev/", 5) == 0) {
+			PX4_INFO("   %s", dev.first.c_str());
 		}
 	}
 
@@ -586,14 +549,13 @@ void VDev::showDevices()
 
 void VDev::showTopics()
 {
-	int i = 0;
 	PX4_INFO("Devices:");
 
 	pthread_mutex_lock(&devmutex);
 
-	for (; i < PX4_MAX_DEV; ++i) {
-		if (devmap[i] && strncmp(devmap[i]->name, "/obj/", 5) == 0) {
-			PX4_INFO("   %s", devmap[i]->name);
+	for (const auto &dev : devmap) {
+		if (strncmp(dev.first.c_str(), "/obj/", 5) == 0) {
+			PX4_INFO("   %s", dev.first.c_str());
 		}
 	}
 
@@ -602,15 +564,14 @@ void VDev::showTopics()
 
 void VDev::showFiles()
 {
-	int i = 0;
 	PX4_INFO("Files:");
 
 	pthread_mutex_lock(&devmutex);
 
-	for (; i < PX4_MAX_DEV; ++i) {
-		if (devmap[i] && strncmp(devmap[i]->name, "/obj/", 5) != 0 &&
-		    strncmp(devmap[i]->name, "/dev/", 5) != 0) {
-			PX4_INFO("   %s", devmap[i]->name);
+	for (const auto &dev : devmap) {
+		if (strncmp(dev.first.c_str(), "/obj/", 5) != 0 &&
+		    strncmp(dev.first.c_str(), "/dev/", 5) != 0) {
+			PX4_INFO("   %s", dev.first.c_str());
 		}
 	}
 

--- a/src/drivers/device/vdev.cpp
+++ b/src/drivers/device/vdev.cpp
@@ -617,26 +617,4 @@ void VDev::showFiles()
 	pthread_mutex_unlock(&devmutex);
 }
 
-const char *VDev::topicList(unsigned int *next)
-{
-	for (; *next < PX4_MAX_DEV; (*next)++) {
-		if (devmap[*next] && strncmp(devmap[(*next)]->name, "/obj/", 5) == 0) {
-			return devmap[(*next)++]->name;
-		}
-	}
-
-	return nullptr;
-}
-
-const char *VDev::devList(unsigned int *next)
-{
-	for (; *next < PX4_MAX_DEV; (*next)++) {
-		if (devmap[*next] && strncmp(devmap[(*next)]->name, "/dev/", 5) == 0) {
-			return devmap[(*next)++]->name;
-		}
-	}
-
-	return nullptr;
-}
-
 } // namespace device

--- a/src/drivers/device/vdev.h
+++ b/src/drivers/device/vdev.h
@@ -326,8 +326,6 @@ public:
 	static void showFiles(void);
 	static void showDevices(void);
 	static void showTopics(void);
-	static const char *devList(unsigned int *next);
-	static const char *topicList(unsigned int *next);
 
 	/**
 	 * Get the device name.

--- a/src/drivers/device/vdev_posix.cpp
+++ b/src/drivers/device/vdev_posix.cpp
@@ -442,15 +442,5 @@ extern "C" {
 		return sim_delay;
 	}
 
-	const char *px4_get_device_names(unsigned int *handle)
-	{
-		return VDev::devList(handle);
-	}
-
-	const char *px4_get_topic_names(unsigned int *handle)
-	{
-		return VDev::topicList(handle);
-	}
-
 }
 

--- a/src/drivers/linux_pwm_out/PCA9685.h
+++ b/src/drivers/linux_pwm_out/PCA9685.h
@@ -82,7 +82,7 @@ public:
 	 */
 	PCA9685(int bus, int address);
 
-	int init() override { return _fd >= 0; }
+	int init() override { return _fd >= 0 ? 0 : -1; }
 
 	int send_output_pwm(const uint16_t *pwm, int num_outputs) override;
 

--- a/src/drivers/linux_pwm_out/linux_pwm_out.cpp
+++ b/src/drivers/linux_pwm_out/linux_pwm_out.cpp
@@ -217,13 +217,7 @@ void task_main(int argc, char *argv[])
 		pwm_out = new NavioSysfsPWMOut(_device, _max_num_outputs);
 	}
 
-	/**
-	 * if the _protocol is "pca9685" and the driver is executed correctly，
-	 * the return value of "pwm_out->init()" will be higher than 0.
-	 */
-	bool check_pwm_device = (strcmp(_protocol, "pca9685") == 0) ? (0 > pwm_out->init()) : (pwm_out->init() != 0);
-
-	if (check_pwm_device) {
+	if (pwm_out->init() != 0) {
 		PX4_ERR("PWM output init failed");
 		delete pwm_out;
 		return;

--- a/src/modules/simulator/simulator_params.c
+++ b/src/modules/simulator/simulator_params.c
@@ -53,6 +53,7 @@ PARAM_DEFINE_INT32(SITL_UDP_PRT, 14560);
  * @min 1
  * @max 86400
  * @increment 1
+ * @unit s
  *
  * @group SITL
  */


### PR DESCRIPTION
This shows the CPU cycles used in SITL, master (user-space only):
![perf_improvement_before](https://user-images.githubusercontent.com/281593/29511719-3f192864-8660-11e7-9116-91ae2e722c20.png)

The top one px4_ioctl is called by orb_check. Then the other top contributers come from locking, namely 2 places: `hrt_absolute_time` and the DriverFramework, they all use `pthread_mutex_lock`:
![perf_improvement_locking](https://user-images.githubusercontent.com/281593/29511923-f84bfb2c-8660-11e7-879a-a62a66587382.png)

The VDev::getDev() call is called from px4_access, which is called from orb_exists.

This PR improves the VDev::getDev() call by using a std::map (the following includes https://github.com/PX4/DriverFramework/pull/220 as well):
![perf_improvement_after](https://user-images.githubusercontent.com/281593/29511766-6cd3e2bc-8660-11e7-8dd1-7ea95014cd47.png)

There is still room for improvements, especially in the DriverFramework and `hrt_absolute_time`.