### PR TITLE
run px4flow for v4 pro

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -786,6 +786,12 @@ then
 		px4flow start &
 	fi
 
+	if ver hwcmp PX4FMU_V4PRO
+	then
+		# Check for flow sensor - as it is a background task, launch it last
+		px4flow start &
+	fi
+
 	if ver hwcmp MINDPX_V2
 	then
 		px4flow start &


### PR DESCRIPTION
I added a separate if case for the time being since somthing like
```
# compare hardware version with boards and safe the output in IS... variable on the next line
ver hwcmp PX4FMU_V2
set ISPX4FMU_V2 $?
  ver hwcmp PX4FMU_V4
set ISPX4FMU_V4 $?
ver hwcmp PX4FMU_V4PRO
set ISPX4FMU_V4PRO $?
ver hwcmp MINDPX_V2
set ISMINDPX_V2 $?

# launch PX4Flow for any of the above boards  -o $ISPX4FMU_V4 == 0 -o $ISMINDPX_V2 == 0
if [ $ISPX4FMU_V2 == 0 -o $ISPX4FMU_V4 == 0 -o $ISPX4FMU_V4PRO == 0 -o $ISMINDPX_V2 == 0 ]
then
    # Check for flow sensor - as it is a background task, launch it last
    px4flow start &
fi
```
isn't working for more than 2 statements. See https://github.com/PX4/NuttX/issues/90

