### PR TITLE
Allow position failsafe sensitivity to be adjusted for different platform types

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -641,8 +641,10 @@ PARAM_DEFINE_INT32(COM_ARM_AUTH, 256010);
 /**
  * Loss of position failsafe activation delay.
  *
- * This sets number of micro seconds that the position checks need to be failed before the failsafe will activate.
+ * This sets number of uSec that the position checks need to be failed before the failsafe will activate.
+ * The default value has been optimised for rotary wing applications. For fixed wing applications, a larger value between 5E6 and 10E6 should be used.
  *
+ * @unit uSec
  * @reboot_required true
  * @group Commander
  */
@@ -651,10 +653,13 @@ PARAM_DEFINE_INT32(COM_POS_FS_DELAY, 1E6);
 /**
  * Loss of position probation delay at takeoff.
  *
- * This sets number of micro seconds at takeoff that the EKF innovation checks need to pass for the positon to be declared good, if it has been declared bad.
- * The probation period reduces by one second for every lapsed second of valid position down to a minimum of one second.
- * When checks fail, the probation period is increased by COM_POS_FS_FACT seconds for every lapsed second up to a maximum of 100 seconds
+ * The probation delay is number of uSec that the EKF innovation checks need to pass for the positon to be declared good once it has been declared bad.
+ * The probation delay will be reset to this parameter value when takeoff is detected.
+ * After takeoff, if position checks are passing, the probation delay will reduce by one uSec for every lapsed uSec of valid position down to a minimum of 1E6 uSec.
+ * If position checks are failing, the probation delay will increase by COM_POS_FS_FACT micro seconds for every lapsed uSec up to a maximum of 100E6 uSec.
+ * The default value has been optimised for rotary wing applications. For fixed wing applications, a value of 1E6 should be used.
  *
+ * @unit uSec
  * @reboot_required true
  * @group Commander
  */
@@ -664,7 +669,9 @@ PARAM_DEFINE_INT32(COM_POS_FS_PROB, 30E6);
  * Loss of position probation gain factor.
  *
  * This sets the rate that the loss of position probation time grows when position checks are failing.
+ * The default value has been optimised for rotary wing applications. For fixed wing applications a value of 2 should be used.
  *
+ * @unit uSec
  * @reboot_required true
  * @group Commander
  */

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -637,3 +637,35 @@ PARAM_DEFINE_INT32(COM_POSCTL_NAVL, 0);
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_ARM_AUTH, 256010);
+
+/**
+ * Loss of position failsafe activation delay.
+ *
+ * This sets number of micro seconds that the position checks need to be failed before the failsafe will activate.
+ *
+ * @reboot_required true
+ * @group Commander
+ */
+PARAM_DEFINE_INT32(COM_POS_FS_DELAY, 1E6);
+
+/**
+ * Loss of position probation delay at takeoff.
+ *
+ * This sets number of micro seconds at takeoff that the EKF innovation checks need to pass for the positon to be declared good, if it has been declared bad.
+ * The probation period reduces by one second for every lapsed second of valid position down to a minimum of one second.
+ * When checks fail, the probation period is increased by COM_POS_FS_FACT seconds for every lapsed second up to a maximum of 100 seconds
+ *
+ * @reboot_required true
+ * @group Commander
+ */
+PARAM_DEFINE_INT32(COM_POS_FS_PROB, 30E6);
+
+/**
+ * Loss of position probation gain factor.
+ *
+ * This sets the rate that the loss of position probation time grows when position checks are failing.
+ *
+ * @reboot_required true
+ * @group Commander
+ */
+PARAM_DEFINE_INT32(COM_POS_FS_GAIN, 10);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -641,37 +641,36 @@ PARAM_DEFINE_INT32(COM_ARM_AUTH, 256010);
 /**
  * Loss of position failsafe activation delay.
  *
- * This sets number of uSec that the position checks need to be failed before the failsafe will activate.
- * The default value has been optimised for rotary wing applications. For fixed wing applications, a larger value between 5E6 and 10E6 should be used.
+ * This sets number of second that the position checks need to be failed before the failsafe will activate.
+ * The default value has been optimised for rotary wing applications. For fixed wing applications, a larger value between 5 and 10 should be used.
  *
- * @unit uSec
+ * @unit sec
  * @reboot_required true
  * @group Commander
  */
-PARAM_DEFINE_INT32(COM_POS_FS_DELAY, 1E6);
+PARAM_DEFINE_INT32(COM_POS_FS_DELAY, 1);
 
 /**
  * Loss of position probation delay at takeoff.
  *
- * The probation delay is number of uSec that the EKF innovation checks need to pass for the positon to be declared good once it has been declared bad.
+ * The probation delay is number of seconds that the EKF innovation checks need to pass for the positon to be declared good after it has been declared bad.
  * The probation delay will be reset to this parameter value when takeoff is detected.
- * After takeoff, if position checks are passing, the probation delay will reduce by one uSec for every lapsed uSec of valid position down to a minimum of 1E6 uSec.
- * If position checks are failing, the probation delay will increase by COM_POS_FS_FACT micro seconds for every lapsed uSec up to a maximum of 100E6 uSec.
- * The default value has been optimised for rotary wing applications. For fixed wing applications, a value of 1E6 should be used.
+ * After takeoff, if position checks are passing, the probation delay will reduce by one second for every lapsed second of valid position down to a minimum of 1 second.
+ * If position checks are failing, the probation delay will increase by COM_POS_FS_GAIN seconds for every lapsed second up to a maximum of 100 seconds.
+ * The default value has been optimised for rotary wing applications. For fixed wing applications, a value of 1 should be used.
  *
- * @unit uSec
+ * @unit sec
  * @reboot_required true
  * @group Commander
  */
-PARAM_DEFINE_INT32(COM_POS_FS_PROB, 30E6);
+PARAM_DEFINE_INT32(COM_POS_FS_PROB, 30);
 
 /**
  * Loss of position probation gain factor.
  *
  * This sets the rate that the loss of position probation time grows when position checks are failing.
- * The default value has been optimised for rotary wing applications. For fixed wing applications a value of 2 should be used.
+ * The default value has been optimised for rotary wing applications. For fixed wing applications a value of 0 should be used.
  *
- * @unit uSec
  * @reboot_required true
  * @group Commander
  */


### PR DESCRIPTION
The description for the parameters created contain recommended values for fixed wing platforms.

Partially addresses https://github.com/PX4/Firmware/issues/7609