### PR TITLE
mavlink: fix use of -x flag

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,7 @@ Checks:          '*
 		,-clang-analyzer-core.UndefinedBinaryOperatorResult
 		,-clang-analyzer-core.uninitialized.Assign
 		,-clang-analyzer-core.VLASize
+		,-clang-analyzer-cplusplus.NewDelete
 		,-clang-analyzer-cplusplus.NewDeleteLeaks
 		,-clang-analyzer-deadcode.DeadStores
 		,-clang-analyzer-optin.cplusplus.VirtualCall

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1971,8 +1971,8 @@ Mavlink::task_main(int argc, char *argv[])
 	pthread_mutex_init(&_send_mutex, nullptr);
 
 	/* if we are passing on mavlink messages, we need to prepare a buffer for this instance */
-	if (_forwarding_on || _ftp_on) {
-		/* initialize message buffer if multiplexing is on or its needed for FTP.
+	if (_forwarding_on) {
+		/* initialize message buffer if multiplexing is on.
 		 * make space for two messages plus off-by-one space as we use the empty element
 		 * marker ring buffer approach.
 		 */
@@ -2301,8 +2301,8 @@ Mavlink::task_main(int argc, char *argv[])
 			stream->update(t);
 		}
 
-		/* pass messages from other UARTs or FTP worker */
-		if (_forwarding_on || _ftp_on) {
+		/* pass messages from other UARTs */
+		if (_forwarding_on) {
 
 			bool is_part;
 			uint8_t *read_ptr;
@@ -2410,7 +2410,7 @@ Mavlink::task_main(int argc, char *argv[])
 		_socket_fd = -1;
 	}
 
-	if (_forwarding_on || _ftp_on) {
+	if (_forwarding_on) {
 		message_buffer_destroy();
 		pthread_mutex_destroy(&_message_buffer_mutex);
 	}

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2604,7 +2604,7 @@ Mavlink::display_status()
 		       (double)_mavlink_ulog->maximum_data_rate() * 100.);
 	}
 
-	printf("\taccepting commands: %s\n", (accepting_commands()) ? "YES" : "NO");
+	printf("\taccepting commands: %s, FTP enabled: %s\n", accepting_commands() ? "YES" : "NO", _ftp_on ? "YES" : "NO");
 	printf("\tMAVLink version: %i\n", _protocol_version);
 
 	printf("\ttransport protocol: ");

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -476,6 +476,8 @@ public:
 
 	void set_uorb_main_fd(int fd, unsigned int interval);
 
+	bool ftp_enabled() const { return _ftp_on; }
+
 protected:
 	Mavlink			*next;
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2483,8 +2483,10 @@ MavlinkReceiver::receive_thread(void *arg)
 						/* handle packet with parameter component */
 						_parameters_manager.handle_message(&msg);
 
-						/* handle packet with ftp component */
-						_mavlink_ftp.handle_message(&msg);
+						if (_mavlink->ftp_enabled()) {
+							/* handle packet with ftp component */
+							_mavlink_ftp.handle_message(&msg);
+						}
 
 						/* handle packet with log component */
 						_mavlink_log_handler.handle_message(&msg);
@@ -2507,7 +2509,11 @@ MavlinkReceiver::receive_thread(void *arg)
 			_mission_manager.check_active_mission();
 			_mission_manager.send(t);
 			_parameters_manager.send(t);
-			_mavlink_ftp.send(t);
+
+			if (_mavlink->ftp_enabled()) {
+				_mavlink_ftp.send(t);
+			}
+
 			_mavlink_log_handler.send(t);
 			last_send_update = t;
 


### PR DESCRIPTION
The `-x` flag did not do what it was supposed to do, namely enabling FTP.