### PR TITLE
Reverse pusher delay

### DIFF
--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -80,6 +80,7 @@ private:
 		int airspeed_mode;
 		float pitch_setpoint_offset;
 		float reverse_output;
+		float reverse_delay;
 		float back_trans_throttle;
 		float mpc_xy_cruise;
 	} _params_standard;
@@ -98,6 +99,7 @@ private:
 		param_t airspeed_mode;
 		param_t pitch_setpoint_offset;
 		param_t reverse_output;
+		param_t reverse_delay;
 		param_t back_trans_throttle;
 		param_t mpc_xy_cruise;
 	} _params_handles_standard;

--- a/src/modules/vtol_att_control/standard_params.c
+++ b/src/modules/vtol_att_control/standard_params.c
@@ -98,6 +98,20 @@ PARAM_DEFINE_FLOAT(VT_B_TRANS_RAMP, 3.0f);
  */
 PARAM_DEFINE_FLOAT(VT_B_REV_OUT, 0.0f);
 
+
+/**
+ * Delay in seconds before applying back transition throttle
+ * Set this to a value greater than 0 to give the motor time to spin down.
+ *
+ * unit s
+ * @min 0
+ * @max 10
+ * @increment 1
+ * @decimal 2
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_B_REV_DEL, 0.0f);
+
 /**
  * Thottle output during back transition
  * For ESCs and mixers that support reverse thrust on low PWM values set this to a negative value to apply active breaking


### PR DESCRIPTION
This adds a delay for the reverse thrust to allow the motor to brake and avoid sync issues.

SITL tested:

![image](https://user-images.githubusercontent.com/14801663/29847387-be5e435e-8d1b-11e7-99d0-ef5317183577.png)

