### PR TITLE
aerofc: Use baud of 921600 for Aero

### DIFF
--- a/ROMFS/px4fmu_common/init.d/4070_aerofc
+++ b/ROMFS/px4fmu_common/init.d/4070_aerofc
@@ -78,5 +78,5 @@ set OUTPUT_MODE tap_esc
 set MIXER quad_x
 set USE_IO no
 
-param set SYS_COMPANION 460800
+param set SYS_COMPANION 921600
 set MAVLINK_COMPANION_DEVICE /dev/ttyS1

--- a/Tools/aero_upload.sh
+++ b/Tools/aero_upload.sh
@@ -62,7 +62,7 @@ ssh $target /bin/bash <<EOF
     echo -e "Updating firmware on AeroFC"
     ~/px_uploader.py \
         --port /dev/ttyS1 \
-        --baud-flightstack 1500000,460800,115200 \
+        --baud-flightstack 921600,460800,1500000,115200 \
         $(basename $firmware)
     echo "Firmware updated"
     if [ \$router_running -eq 1 ]; then


### PR DESCRIPTION
This changes the baudrate that communicates with Aero to 921600. In order to get a reliable communication there are some changes on the Linux side that's done here and will be part of a new version in future: https://github.com/intel-aero/meta-intel-aero/pull/272 and https://github.com/intel-aero/meta-intel-aero-base/pull/18

Without upgrading the distro/packages these are the equivalent instructions:

- Add this line to the `/lib/systemd/system/mavlink-router.service` under `[Service]` section:
`ExecStartPre=/bin/bash -c 'echo 4 > /sys/class/tty/ttyS1/rx_trig_bytes'`
- Change baudrate of the uart port for mavlink-router in `/etc/mavlink-router/main.conf`
- Change baudrate of the update script in `/usr/sbin/aerofc-update.sh`
