### PR TITLE
EKF2 limit map reprojection

### DIFF
--- a/msg/vehicle_global_position.msg
+++ b/msg/vehicle_global_position.msg
@@ -8,7 +8,6 @@ uint64 time_utc_usec		# GPS UTC timestamp, (microseconds)
 float64 lat			# Latitude, (degrees)
 float64 lon			# Longitude, (degrees)
 float32 alt			# Altitude AMSL, (meters)
-float64[2] delta_lat_lon # Reset delta for horizontal position coordinates
 float32 delta_alt 	# Reset delta for altitude
 uint8 lat_lon_reset_counter	# Counter for reset events on horizontal position coordinates
 uint8 alt_reset_counter 		# Counter for reset events on altitude


### PR DESCRIPTION
The map projection operations in geo use doubles and are extremely expensive on an STM32F4. For publishing vehicle_global_position EKF2 is doing two reprojections per iteration, one for the main lat/lon and another for delta_lat_lon.

In this PR I've removed the second map projection and deleted vehicle_global_position delta_lat_lon as it wasn't used. I also limited the first map projection call to when the local position x and y change.

On a pixracer this reduces EKF2 cpu usage from ~20% to 13-16% depending on movement. Limiting the vehicle_global_position orb publication rate would reduce it further.



Some other low hanging fruit for EKF2 optimization.
 - remove unnecessary memsetting (eg `struct ekf2_innovations_s innovations = {}` right before manually populating every field)
 - limit uORB publications for unchanged data (wind_estimate, etc), each orb_publish has a cost for locking, setting up poll waiters, and subscribers of course.
 - increase optimization level, `-Os` -> `-O2` significantly decreases cpu usage at the cost of code space. This could be targeted per file.