### PR TITLE
driver: vdev_posix, increase PX4_MAX_FD

### DIFF
--- a/src/drivers/device/vdev_posix.cpp
+++ b/src/drivers/device/vdev_posix.cpp
@@ -59,7 +59,7 @@ volatile bool sim_delay = false;
 
 extern "C" {
 
-#define PX4_MAX_FD 300
+#define PX4_MAX_FD 350
 	static device::file_t *filemap[PX4_MAX_FD] = {};
 
 	int px4_errno;


### PR DESCRIPTION
According to #7892, avoid "exceeded maximum number of file descriptors" when "make posix gazebo_typhoon_h480"