### PR TITLE
EKF2: Parameterize no_gps_timeout_max

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -339,6 +339,7 @@ private:
 	_K_pstatic_coef_xn;	///< static pressure position error coefficient along the negative X body axis
 	control::BlockParamFloat _K_pstatic_coef_y;	///< static pressure position error coefficient along the Y body axis
 	control::BlockParamFloat _K_pstatic_coef_z;	///< static pressure position error coefficient along the Z body axis
+	control::BlockParamInt _no_gps_timeout_max; ///< maximum time we allow dead reckoning while both gps position and velocity measurements are being rejected before attempting to reset the states to the GPS measurement
 
 };
 
@@ -459,7 +460,8 @@ Ekf2::Ekf2():
 	_K_pstatic_coef_xp(this, "EKF2_PCOEF_XP", false),
 	_K_pstatic_coef_xn(this, "EKF2_PCOEF_XN", false),
 	_K_pstatic_coef_y(this, "EKF2_PCOEF_Y", false),
-	_K_pstatic_coef_z(this, "EKF2_PCOEF_Z", false)
+	_K_pstatic_coef_z(this, "EKF2_PCOEF_Z", false),
+	_no_gps_timeout_max(this, "EKF2_NO_GPS_TOUT",  _params->no_gps_timeout_max)
 {
 
 }

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1152,3 +1152,12 @@ PARAM_DEFINE_FLOAT(EKF2_PCOEF_Y, 0.0f);
  * @decimal 2
  */
 PARAM_DEFINE_FLOAT(EKF2_PCOEF_Z, 0.0f);
+
+/**
+ * Maximum time we allow dead reckoning while both gps position and velocity measurements are being rejected before attempting to reset the states to the GPS measurement (usec). 
+ *
+ * @group EKF2
+ * @min 0
+ * @unit us
+ */
+PARAM_DEFINE_INT32(EKF2_NO_GPS_TOUT, 7000000);


### PR DESCRIPTION
Right now the timeout for when to trigger a reset of the position and velocity (and yaw for fw) is hardcoded to 7 seconds. Fow fw aircrafts this time is unnecessary long and hence should be parameterized. 

@priseborough 
- the ```no_gps_timeout_max``` parameter in ecl is an ```unsigned```, is it an option to have it as a float and convert it to uint64_t in ecl for easier handling of the parameter? 
- If no, this PR should be changed to use BlockParamFloat, if yes this PR should be changed to use BlockParamUInt, which is not yet supported.
- The maximum number of parameters for ekf2 also needs to be increased.