### PR TITLE
VTOL standard cleanup

### DIFF
--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -498,7 +498,7 @@ void Standard::fill_actuator_outputs()
 
 		// pitch
 		_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =
-			_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH] + _params->fw_pitch_trim;
+			_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH];
 		// yaw
 		_actuators_out_1->control[actuator_controls_s::INDEX_YAW] =
 			_actuators_fw_in->control[actuator_controls_s::INDEX_YAW];
@@ -510,7 +510,7 @@ void Standard::fill_actuator_outputs()
 		if (_params->elevons_mc_lock) {
 			// zero outputs when inactive
 			_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] = 0.0f;
-			_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] = _params->fw_pitch_trim;
+			_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] = 0.0f;
 			_actuators_out_1->control[actuator_controls_s::INDEX_YAW] = 0.0f;
 			_actuators_out_1->control[actuator_controls_s::INDEX_AIRBRAKES] = 0.0f;
 
@@ -521,7 +521,7 @@ void Standard::fill_actuator_outputs()
 
 			// pitch
 			_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =
-				_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH] + _params->fw_pitch_trim;
+				_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH];
 
 			_actuators_out_1->control[actuator_controls_s::INDEX_YAW] = 0.0f;
 			_actuators_out_1->control[actuator_controls_s::INDEX_AIRBRAKES] = 0.0f;

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -162,16 +162,15 @@ void Standard::update_vtol_state()
 	 * For the back transition the pusher motor is immediately stopped and rotors reactivated.
 	 */
 
+	float mc_weight = _mc_roll_weight;
+
 	if (!_attc->is_fixed_wing_requested()) {
 
 		// the transition to fw mode switch is off
 		if (_vtol_schedule.flight_mode == MC_MODE) {
 			// in mc mode
 			_vtol_schedule.flight_mode = MC_MODE;
-			_mc_roll_weight = 1.0f;
-			_mc_pitch_weight = 1.0f;
-			_mc_yaw_weight = 1.0f;
-			_mc_throttle_weight = 1.0f;
+			mc_weight = 1.0f;
 			_pusher_throttle = 0.0f;
 			_reverse_output = 0.0f;
 
@@ -197,10 +196,7 @@ void Standard::update_vtol_state()
 		} else if (_vtol_schedule.flight_mode == TRANSITION_TO_FW) {
 			// failsafe back to mc mode
 			_vtol_schedule.flight_mode = MC_MODE;
-			_mc_roll_weight = 1.0f;
-			_mc_pitch_weight = 1.0f;
-			_mc_yaw_weight = 1.0f;
-			_mc_throttle_weight = 1.0f;
+			mc_weight = 1.0f;
 			_pusher_throttle = 0.0f;
 			_reverse_output = 0.0f;
 
@@ -233,10 +229,7 @@ void Standard::update_vtol_state()
 		} else if (_vtol_schedule.flight_mode == FW_MODE) {
 			// in fw mode
 			_vtol_schedule.flight_mode = FW_MODE;
-			_mc_roll_weight = 0.0f;
-			_mc_pitch_weight = 0.0f;
-			_mc_yaw_weight = 0.0f;
-			_mc_throttle_weight = 0.0f;
+			mc_weight = 0.0f;
 
 		} else if (_vtol_schedule.flight_mode == TRANSITION_TO_FW) {
 			// continue the transition to fw mode while monitoring airspeed for a final switch to fw mode
@@ -255,6 +248,11 @@ void Standard::update_vtol_state()
 
 		}
 	}
+
+	_mc_roll_weight = mc_weight;
+	_mc_pitch_weight = mc_weight;
+	_mc_yaw_weight = mc_weight;
+	_mc_throttle_weight = mc_weight;
 
 	// map specific control phases to simple control modes
 	switch (_vtol_schedule.flight_mode) {


### PR DESCRIPTION
Dear standard VTOL developers....

I made a quick pass in the `standard.cpp` file and modify two things:

1. Since the multicopter weight used for blending was redundant (several times applied to all weights and constrained), I decided to put it in a single variable and only apply the constraint at the end. I wanted to completely replace the `_mc_roll/pitch/yaw/throttle_weight` variable by a `_mc_weight` but I wanted to ask you if you need four different weights (I can revert this and just keep the saturation change if needed). If you agree with the changes, I'll make further changes and fuse all those variables in a single one.

2. In my opinion, the `VT_FW_PITCH_TRIM` is normally only useful on a tailsitter/tiltrotor since the elevators are used for hovering and flying. On a standard VTOL, the mechanical linkages should be modified and the pitch offset is changed via `FW_PSP_OFF`.

Thanks for reviewing!