### PR TITLE
Multicopter mixer saturation handling strategy

### DIFF
--- a/src/drivers/pwm_out_sim/pwm_out_sim.cpp
+++ b/src/drivers/pwm_out_sim/pwm_out_sim.cpp
@@ -69,7 +69,6 @@
 
 #include <drivers/device/device.h>
 #include <drivers/drv_pwm_output.h>
-#include <drivers/drv_gpio.h>
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_mixer.h>
 
@@ -145,20 +144,6 @@ private:
 	int		pwm_ioctl(device::file_t *filp, int cmd, unsigned long arg);
 	void 	subscribe();
 
-	struct GPIOConfig {
-		uint32_t	input;
-		uint32_t	output;
-		uint32_t	alt;
-	};
-
-	static const GPIOConfig	_gpio_tab[];
-	static const unsigned	_ngpio;
-
-	void		gpio_reset();
-	void		gpio_set_function(uint32_t gpios, int function);
-	void		gpio_write(uint32_t gpios, int function);
-	uint32_t	gpio_read();
-	int		gpio_ioctl(device::file_t *filp, int cmd, unsigned long arg);
 
 };
 
@@ -544,11 +529,6 @@ PWMSim::task_main()
 
 	orb_unsubscribe(_armed_sub);
 
-	/* make sure servos are off */
-	// up_pwm_servo_deinit();
-
-	/* note - someone else is responsible for restoring the GPIO config */
-
 	/* tell the dtor that we are exiting */
 	_task = -1;
 }
@@ -862,13 +842,6 @@ PortMode g_port_mode = PORT_MODE_UNDEFINED;
 int
 hil_new_mode(PortMode new_mode)
 {
-	// uint32_t gpio_bits;
-
-
-//	/* reset to all-inputs */
-//	g_pwm_sim->ioctl(0, GPIO_RESET, 0);
-
-	// gpio_bits = 0;
 
 	PWMSim::Mode servo_mode = PWMSim::MODE_NONE;
 

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1296,7 +1296,6 @@ PX4FMU::cycle()
 					// factor 2 is needed because actuator outputs are in the range [-1,1]
 					const float delta_out_max = 2.0f * 1000.0f * dt / (_max_pwm[0] - _min_pwm[0]) / _mot_t_max;
 					_mixers->set_max_delta_out_once(delta_out_max);
-					_mixers->set_airmode(_airmode);
 				}
 
 				if (_thr_mdl_fac > FLT_EPSILON) {
@@ -1364,6 +1363,8 @@ PX4FMU::cycle()
 					orb_publish_auto(ORB_ID(multirotor_motor_limits), &_to_mixer_status, &motor_limits, &_class_instance,
 							 ORB_PRIO_DEFAULT);
 				}
+
+				_mixers->set_airmode(_airmode);
 
 				perf_end(_ctl_latency);
 			}
@@ -1795,7 +1796,7 @@ void PX4FMU::update_params()
 	param_handle = param_find("MC_AIRMODE");
 
 	if (param_handle != PARAM_INVALID) {
-		int val;
+		int32_t val;
 		param_get(param_handle, &val);
 		_airmode = val > 0;
 		PX4_DEBUG("%s: %d", "MC_AIRMODE", _airmode);

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -276,6 +276,7 @@ private:
 
 	float _mot_t_max;	// maximum rise time for motor (slew rate limiting)
 	float _thr_mdl_fac;	// thrust to pwm modelling factor
+	bool _airmode; 		// multicopter air-mode
 
 	perf_counter_t	_ctl_latency;
 
@@ -386,6 +387,7 @@ PX4FMU::PX4FMU(bool run_as_task) :
 	_to_mixer_status(nullptr),
 	_mot_t_max(0.0f),
 	_thr_mdl_fac(0.0f),
+	_airmode(false),
 	_ctl_latency(perf_alloc(PC_ELAPSED, "ctl_lat"))
 {
 	for (unsigned i = 0; i < _max_actuators; i++) {
@@ -1294,6 +1296,7 @@ PX4FMU::cycle()
 					// factor 2 is needed because actuator outputs are in the range [-1,1]
 					const float delta_out_max = 2.0f * 1000.0f * dt / (_max_pwm[0] - _min_pwm[0]) / _mot_t_max;
 					_mixers->set_max_delta_out_once(delta_out_max);
+					_mixers->set_airmode(_airmode);
 				}
 
 				if (_thr_mdl_fac > FLT_EPSILON) {
@@ -1786,6 +1789,16 @@ void PX4FMU::update_params()
 
 	if (param_handle != PARAM_INVALID) {
 		param_get(param_handle, &_thr_mdl_fac);
+	}
+
+	// multicopter air-mode
+	param_handle = param_find("MC_AIRMODE");
+
+	if (param_handle != PARAM_INVALID) {
+		int val;
+		param_get(param_handle, &val);
+		_airmode = val > 0;
+		PX4_DEBUG("%s: %d", "MC_AIRMODE", _airmode);
 	}
 }
 

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1221,6 +1221,14 @@ PX4IO::task_main()
 					param_get(parm_handle, &param_val);
 					(void)io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_MOTOR_SLEW_MAX, FLOAT_TO_REG(param_val));
 				}
+
+				/* air-mode */
+				parm_handle = param_find("MC_AIRMODE");
+
+				if (parm_handle != PARAM_INVALID) {
+					param_get(parm_handle, &param_val);
+					(void)io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_AIRMODE, SIGNED_TO_REG(param_val));
+				}
 			}
 
 		}

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1226,8 +1226,9 @@ PX4IO::task_main()
 				parm_handle = param_find("MC_AIRMODE");
 
 				if (parm_handle != PARAM_INVALID) {
-					param_get(parm_handle, &param_val);
-					(void)io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_AIRMODE, SIGNED_TO_REG(param_val));
+					int32_t param_val_int;
+					param_get(parm_handle, &param_val_int);
+					(void)io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_AIRMODE, SIGNED_TO_REG(param_val_int));
 				}
 			}
 

--- a/src/lib/mixer/mixer.h
+++ b/src/lib/mixer/mixer.h
@@ -211,6 +211,13 @@ public:
 	 */
 	virtual void 			set_thrust_factor(float val) {}
 
+	/**
+	 * @brief Set airmode. Airmode allows the mixer to increase the total thrust in order to unsaturate the motors.
+	 *
+	 * @param[in]  airmode   Dis/-activate airmode by setting it to false/true
+	 */
+	virtual void set_airmode(bool airmode) {};
+
 protected:
 	/** client-supplied callback used when fetching control values */
 	ControlCallback			_control_cb;
@@ -388,6 +395,8 @@ public:
 	 * @param[in]  val   The value
 	 */
 	virtual void	set_thrust_factor(float val);
+
+	virtual void 	set_airmode(bool airmode);
 
 private:
 	Mixer				*_first;	/**< linked list of mixers */
@@ -624,6 +633,8 @@ public:
 	 */
 	virtual void			set_thrust_factor(float val) {_thrust_factor = val;}
 
+	virtual void 			set_airmode(bool airmode);
+
 	union saturation_status {
 		struct {
 			uint16_t valid		: 1; // 0 - true when the saturation status is used
@@ -648,6 +659,8 @@ private:
 	float				_idle_speed;
 	float 				_delta_out_max;
 	float 				_thrust_factor;
+
+	bool                		_airmode;
 
 	void update_saturation_status(unsigned index, bool clipping_high, bool clipping_low);
 	saturation_status _saturation_status;

--- a/src/lib/mixer/mixer_group.cpp
+++ b/src/lib/mixer/mixer_group.cpp
@@ -154,7 +154,17 @@ MixerGroup::set_thrust_factor(float val)
 		mixer->set_thrust_factor(val);
 		mixer = mixer->_next;
 	}
+}
 
+void
+MixerGroup::set_airmode(bool airmode)
+{
+	Mixer	*mixer = _first;
+
+	while (mixer != nullptr) {
+		mixer->set_airmode(airmode);
+		mixer = mixer->_next;
+	}
 }
 
 uint16_t

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -210,15 +210,7 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 	// TODO: revise the saturation/boosting strategy
 
 	if (min_out < 0.0f && max_out < 1.0f && -min_out <= 1.0f - max_out) {
-		float max_thrust_diff = thrust * thrust_increase_factor - thrust;
-
-		if (max_thrust_diff >= -min_out) {
-			boost = -min_out;
-
-		} else {
-			boost = max_thrust_diff;
-			roll_pitch_scale = (thrust + boost) / (thrust - min_out);
-		}
+		boost = -min_out;
 
 	} else if (max_out > 1.0f && min_out > 0.0f && min_out >= max_out - 1.0f) {
 		float max_thrust_diff = thrust - thrust_decrease_factor * thrust;

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -209,10 +209,10 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 	// which may result in motor saturation after thrust boost is applied
 	// TODO: revise the saturation/boosting strategy
 
-	if (min_out < 0.0f && max_out < 1.0f && -min_out <= 1.0f - max_out) {
+	if (min_out < 0.0f && max_out < 1.0f && max_out - min_out <= 1.0f) {
 		boost = -min_out;
 
-	} else if (max_out > 1.0f && min_out > 0.0f && min_out >= max_out - 1.0f) {
+	} else if (max_out > 1.0f && min_out > 0.0f && max_out - min_out <= 1.0f) {
 		float max_thrust_diff = thrust - thrust_decrease_factor * thrust;
 
 		if (max_thrust_diff >= max_out - 1.0f) {
@@ -223,12 +223,12 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 			roll_pitch_scale = (1 - (thrust + boost)) / (max_out - thrust);
 		}
 
-	} else if (min_out < 0.0f && max_out < 1.0f && -min_out > 1.0f - max_out) {
+	} else if (min_out < 0.0f && max_out < 1.0f && max_out - min_out > 1.0f) {
 		float max_thrust_diff = thrust * thrust_increase_factor - thrust;
 		boost = math::constrain(-min_out - (1.0f - max_out) / 2.0f, 0.0f, max_thrust_diff);
 		roll_pitch_scale = (thrust + boost) / (thrust - min_out);
 
-	} else if (max_out > 1.0f && min_out > 0.0f && min_out < max_out - 1.0f) {
+	} else if (max_out > 1.0f && min_out > 0.0f && max_out - min_out > 1.0f) {
 		float max_thrust_diff = thrust - thrust_decrease_factor * thrust;
 		boost = math::constrain(-(max_out - 1.0f - min_out) / 2.0f, -max_thrust_diff, 0.0f);
 		roll_pitch_scale = (1 - (thrust + boost)) / (max_out - thrust);

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -179,10 +179,6 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 	// clean out class variable used to capture saturation
 	_saturation_status.value = 0;
 
-	// thrust boost parameters
-	float thrust_increase_factor = 1.5f;
-	float thrust_decrease_factor = 0.6f;
-
 	/* perform initial mix pass yielding unbounded outputs, ignore yaw */
 	for (unsigned i = 0; i < _rotor_count; i++) {
 		float out = roll * _rotors[i].roll_scale +
@@ -216,18 +212,15 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 		boost = -(max_out - 1.0f);
 
 	} else if (min_out < 0.0f && max_out < 1.0f && max_out - min_out > 1.0f) {
-		float max_thrust_diff = thrust * thrust_increase_factor - thrust;
-		boost = math::constrain(-min_out - (1.0f - max_out) / 2.0f, 0.0f, max_thrust_diff);
+		boost = -min_out - (1.0f - max_out) / 2.0f;
 		roll_pitch_scale = (thrust + boost) / (thrust - min_out);
 
 	} else if (max_out > 1.0f && min_out > 0.0f && max_out - min_out > 1.0f) {
-		float max_thrust_diff = thrust - thrust_decrease_factor * thrust;
-		boost = math::constrain(-(max_out - 1.0f - min_out) / 2.0f, -max_thrust_diff, 0.0f);
+		boost = -(max_out - min_out - 1.0f) / 2.0f;
 		roll_pitch_scale = (1 - (thrust + boost)) / (max_out - thrust);
 
 	} else if (min_out < 0.0f && max_out > 1.0f) {
-		boost = math::constrain(-(max_out - 1.0f + min_out) / 2.0f, thrust_decrease_factor * thrust - thrust,
-					thrust_increase_factor * thrust - thrust);
+		boost = -(max_out - 1.0f + min_out) / 2.0f;
 		roll_pitch_scale = (thrust + boost) / (thrust - min_out);
 	}
 

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -213,15 +213,7 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 		boost = -min_out;
 
 	} else if (max_out > 1.0f && min_out > 0.0f && max_out - min_out <= 1.0f) {
-		float max_thrust_diff = thrust - thrust_decrease_factor * thrust;
-
-		if (max_thrust_diff >= max_out - 1.0f) {
-			boost = -(max_out - 1.0f);
-
-		} else {
-			boost = -max_thrust_diff;
-			roll_pitch_scale = (1 - (thrust + boost)) / (max_out - thrust);
-		}
+		boost = -(max_out - 1.0f);
 
 	} else if (min_out < 0.0f && max_out < 1.0f && max_out - min_out > 1.0f) {
 		float max_thrust_diff = thrust * thrust_increase_factor - thrust;

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -207,8 +207,8 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 	// Otherwise, a scaler is computed to make the distance between the two extrema exacly 1.0 and the boost
 	// value is computed to maximize the roll-pitch control.
 	//
-	// Note: thrust boost is computed assuming thrust_gain==1 for all motors.
-	// On asymmetric platforms, some motors have thrust_gain<1,
+	// Note: thrust boost is computed assuming thrust_scale==1 for all motors.
+	// On asymmetric platforms, some motors have thrust_scale<1,
 	// which may result in motor saturation after thrust boost is applied
 	// TODO: revise the saturation/boosting strategy
 	if (delta_out_max <= 1.0f) {

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -217,7 +217,6 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 
 		} else if (max_out > 1.0f) {
 			boost = -(max_out - 1.0f);
-
 		}
 
 	} else {
@@ -226,7 +225,13 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 	}
 
 	if (!_airmode) {
-		boost = math::min(boost, 0.0f); // Disable positive boosting if not in air-mode
+		// disable positive boosting if not in air-mode
+		// boosting is positive when min_out < 0.0
+		// roll_pitch_scale is reduced accordingly
+		if (boost > 0.0f) {
+			roll_pitch_scale = thrust / (thrust - min_out);
+			boost = 0.0f;
+		}
 	}
 
 	// capture saturation

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -220,7 +220,7 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 		}
 
 	} else {
-		roll_pitch_scale = 1 / (max_out - min_out);
+		roll_pitch_scale = 1 / (delta_out_max);
 		boost = 1.0f - ((max_out - thrust) * roll_pitch_scale + thrust);
 	}
 

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -84,6 +84,7 @@ MultirotorMixer::MultirotorMixer(ControlCallback control_cb,
 	_idle_speed(-1.0f + idle_speed * 2.0f),	/* shift to output range here to avoid runtime calculation */
 	_delta_out_max(0.0f),
 	_thrust_factor(0.0f),
+	_airmode(false),
 	_rotor_count(_config_rotor_count[(MultirotorGeometryUnderlyingType)geometry]),
 	_rotors(_config_index[(MultirotorGeometryUnderlyingType)geometry]),
 	_outputs_prev(new float[_rotor_count])
@@ -224,6 +225,9 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 		boost = 1.0f - ((max_out - thrust) * roll_pitch_scale + thrust);
 	}
 
+	if (!_airmode) {
+		boost = math::min(boost, 0.0f); // Disable positive boosting if not in air-mode
+	}
 
 	// capture saturation
 	if (min_out < 0.0f) {
@@ -423,6 +427,12 @@ MultirotorMixer::update_saturation_status(unsigned index, bool clipping_high, bo
 	}
 
 	_saturation_status.flags.valid = true;
+}
+
+void
+MultirotorMixer::set_airmode(bool airmode)
+{
+	_airmode = airmode;
 }
 
 void

--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -554,3 +554,16 @@ PARAM_DEFINE_FLOAT(MC_TPA_RATE_I, 0.0f);
  * @group Multicopter Attitude Control
  */
 PARAM_DEFINE_FLOAT(MC_TPA_RATE_D, 0.0f);
+
+/**
+ * Multicopter air-mode
+ *
+ * The air-mode enables the mixer to increase or decrease the total thrust of the multirotor
+ * in order to keep attitude and rate control even at low and high throttle.
+ * This function should be disabled during tuning as it will help the controller
+ * to diverge if the closed-loop is unstable.
+ *
+ * @boolean
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_INT32(MC_AIRMODE, 0);

--- a/src/modules/px4iofirmware/mixer.cpp
+++ b/src/modules/px4iofirmware/mixer.cpp
@@ -254,6 +254,11 @@ mixer_tick(void)
 	 */
 	mixer_group.set_trims(r_page_servo_control_trim, PX4IO_SERVO_COUNT);
 
+	/*
+	 * Update air-mode parameter
+	 */
+	mixer_group.set_airmode(REG_TO_BOOL(r_setup_airmode));
+
 
 	/*
 	 * Run the mixers.

--- a/src/modules/px4iofirmware/protocol.h
+++ b/src/modules/px4iofirmware/protocol.h
@@ -78,6 +78,8 @@
 #define REG_TO_FLOAT(_reg)	((float)REG_TO_SIGNED(_reg) / 10000.0f)
 #define FLOAT_TO_REG(_float)	SIGNED_TO_REG((int16_t)floorf((_float + 0.00005f) * 10000.0f))
 
+#define REG_TO_BOOL(_reg) 	((bool)(_reg))
+
 #define PX4IO_PROTOCOL_VERSION		4
 
 /* maximum allowable sizes on this protocol version */
@@ -231,6 +233,8 @@ enum {							/* DSM bind states */
 #define PX4IO_P_SETUP_SBUS_RATE			22	/* frame rate of SBUS1 output in Hz */
 
 #define PX4IO_P_SETUP_MOTOR_SLEW_MAX		24 	/* max motor slew rate */
+
+#define PX4IO_P_SETUP_AIRMODE 			27 	/* air-mode */
 
 #define PX4IO_P_SETUP_THR_MDL_FAC 		25	/* factor for modelling static pwm output to thrust relationship */
 

--- a/src/modules/px4iofirmware/px4io.h
+++ b/src/modules/px4iofirmware/px4io.h
@@ -132,6 +132,7 @@ extern uint16_t			r_page_servo_disarmed[];	/* PX4IO_PAGE_DISARMED_PWM */
 #define r_setup_sbus_rate	r_page_setup[PX4IO_P_SETUP_SBUS_RATE]
 #define r_setup_thr_fac		r_page_setup[PX4IO_P_SETUP_THR_MDL_FAC]
 #define r_setup_slew_max	r_page_setup[PX4IO_P_SETUP_MOTOR_SLEW_MAX]
+#define r_setup_airmode		r_page_setup[PX4IO_P_SETUP_AIRMODE]
 
 #define r_control_values	(&r_page_controls[0])
 

--- a/src/modules/px4iofirmware/registers.c
+++ b/src/modules/px4iofirmware/registers.c
@@ -178,6 +178,7 @@ volatile uint16_t	r_page_setup[] = {
 	[PX4IO_P_SETUP_SCALE_PITCH] = 10000,
 	[PX4IO_P_SETUP_SCALE_YAW] = 10000,
 	[PX4IO_P_SETUP_MOTOR_SLEW_MAX] = 0,
+	[PX4IO_P_SETUP_AIRMODE] = 0,
 	[PX4IO_P_SETUP_THR_MDL_FAC] = 0,
 	[PX4IO_P_SETUP_THERMAL] = PX4IO_THERMAL_IGNORE
 };
@@ -702,6 +703,10 @@ registers_set_one(uint8_t page, uint8_t offset, uint16_t value)
 		case PX4IO_P_SETUP_SBUS_RATE:
 			r_page_setup[offset] = value;
 			sbus1_set_output_rate_hz(value);
+			break;
+
+		case PX4IO_P_SETUP_AIRMODE:
+			r_page_setup[PX4IO_P_SETUP_AIRMODE] = value;
 			break;
 
 		case PX4IO_P_SETUP_THR_MDL_FAC:

--- a/src/modules/uavcan/uavcan_main.cpp
+++ b/src/modules/uavcan/uavcan_main.cpp
@@ -417,6 +417,20 @@ int  UavcanNode::get_param(int remote_node_id, const char *name)
 	return rv;
 }
 
+void UavcanNode::update_params()
+{
+    param_t param_handle;
+
+    // multicopter air-mode
+    param_handle = param_find("MC_AIRMODE");
+
+    if (param_handle != PARAM_INVALID) {
+	    int val;
+	    param_get(param_handle, &val);
+	    _airmode = val > 0;
+    }
+}
+
 int UavcanNode::start_fw_server()
 {
 	int rv = -1;
@@ -821,6 +835,8 @@ int UavcanNode::run()
 
 	while (!_task_should_exit) {
 
+		update_params();
+
 		switch (_fw_server_action) {
 		case Start:
 			_fw_server_status = start_fw_server();
@@ -907,6 +923,8 @@ int UavcanNode::run()
 				// XXX one output group has 8 outputs max,
 				// but this driver could well serve multiple groups.
 				unsigned num_outputs_max = 8;
+
+				_mixers->set_airmode(_airmode);
 
 				// Do mixing
 				_outputs.noutputs = _mixers->mix(&_outputs.output[0], num_outputs_max);

--- a/src/modules/uavcan/uavcan_main.hpp
+++ b/src/modules/uavcan/uavcan_main.hpp
@@ -152,6 +152,7 @@ private:
 	int		request_fw_check();
 	int		print_params(uavcan::protocol::param::GetSet::Response &resp);
 	int		get_set_param(int nodeid, const char *name, uavcan::protocol::param::GetSet::Request &req);
+	void 		update_params();
 	void		set_setget_response(uavcan::protocol::param::GetSet::Response *resp)
 	{
 		_setget_response = resp;
@@ -206,6 +207,8 @@ private:
 	actuator_direct_s		_actuator_direct = {};
 
 	actuator_outputs_s		_outputs = {};
+
+	bool 				_airmode = false;
 
 	// index into _poll_fds for each _control_subs handle
 	uint8_t				_poll_ids[NUM_ACTUATOR_CONTROL_GROUPS_UAVCAN];


### PR DESCRIPTION
After having some issues just after back-transition with a standard VTOL, I found that the problem came from the multicopter mixer.
Since after back-transition the wings can still produce quite a lot of lift with high AOA and high-lift wings, the multicopter thrust is close to zero and the motors are directly saturated when trying to compensate attitude errors. In this special case, the initial 'boost' technique - a gain applied to the thrust - is ineffective:
- If thrust is close to zero, `thrust * thrust_increase_factor` is also close to zero...

The 2nd issue highlighted by @sanderux in #7871 is that when the altitude control is active, the thrust saturates the outputs and attitude control becomes sloppy. 

I made several passes to first simplify the code and finally rewrite the saturation handling process in order to get rid of the arbitrary boost gains and make the attitude control the highest priority.

Before implementing in PX4, I first made a python script to simulate the different cases, you can try here:
https://gist.github.com/bresch/8ea4232452bc64de1ed780bcfbee3564

Be aware that I never tested this PR in reality and that the mixer code is critical. Be careful when testing!