### PR TITLE
Pixhawk 3 Pro : enable external LIS3MDL

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -259,6 +259,9 @@ then
 
 	# Possible external compasses
 	hmc5883 -C -T -X start
+
+	# Possible external compasses
+	lis3mdl -X start
 fi
 
 if ver hwcmp PX4FMU_V5


### PR DESCRIPTION
As HMC5983 is EOL, LIS3MDL is a replacement for external compasses. Checked on hardware with `sensors status`, the device is correctly recognized and prioritized. 

Would it be better to let the two instances of LIS3MDL (internal SPI + external I2C) run together or modify `rc.sensors` so they are mutually exclusive?  