### PR TITLE
navigator simpler cruising speed handling

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -774,7 +774,8 @@ FixedwingPositionControl::control_position(const math::Vector<2> &curr_pos, cons
 		float mission_airspeed = _parameters.airspeed_trim;
 
 		if (PX4_ISFINITE(pos_sp_curr.cruising_speed) &&
-		    pos_sp_curr.cruising_speed > 0.1f) {
+		    pos_sp_curr.cruising_speed >= _parameters.airspeed_min &&
+		    pos_sp_curr.cruising_speed <= _parameters.airspeed_max) {
 
 			mission_airspeed = pos_sp_curr.cruising_speed;
 		}
@@ -782,7 +783,8 @@ FixedwingPositionControl::control_position(const math::Vector<2> &curr_pos, cons
 		float mission_throttle = _parameters.throttle_cruise;
 
 		if (PX4_ISFINITE(pos_sp_curr.cruising_throttle) &&
-		    pos_sp_curr.cruising_throttle > 0.01f) {
+		    pos_sp_curr.cruising_throttle >= 0.0f &&
+		    pos_sp_curr.cruising_throttle <= 1.0f) {
 
 			mission_throttle = pos_sp_curr.cruising_throttle;
 		}

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -383,6 +383,20 @@ PARAM_DEFINE_FLOAT(FW_AIRSPD_MIN, 10.0f);
 PARAM_DEFINE_FLOAT(FW_AIRSPD_MAX, 20.0f);
 
 /**
+ * Cruise Airspeed
+ *
+ * The fixed wing controller tries to fly at this airspeed.
+ *
+ * @unit m/s
+ * @min 0.0
+ * @max 40
+ * @decimal 1
+ * @increment 0.5
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_AIRSPD_TRIM, 15.0f);
+
+/**
  * Maximum climb rate
  *
  * This is the best climb rate that the aircraft can achieve with

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1036,8 +1036,14 @@ MulticopterPositionControl::get_cruising_speed_xy()
 	/*
 	 * in mission the user can choose cruising speed different to default
 	 */
-	return ((PX4_ISFINITE(_pos_sp_triplet.current.cruising_speed) && (_pos_sp_triplet.current.cruising_speed > 0.1f)) ?
-		_pos_sp_triplet.current.cruising_speed : _params.vel_cruise_xy);
+	const float &cruising_speed = _pos_sp_triplet.current.cruising_speed;
+
+	if (PX4_ISFINITE(cruising_speed) && cruising_speed >= 0.0f && cruising_speed <= _params.vel_max_xy) {
+		return cruising_speed;
+
+	} else {
+		return _params.vel_cruise_xy;
+	}
 }
 
 void

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -105,7 +105,7 @@ Mission::on_inactive()
 		if (need_to_reset_mission(false)) {
 			reset_offboard_mission(_offboard_mission);
 			update_offboard_mission();
-			_navigator->reset_cruising_speed();
+			_navigator->set_cruising_speed();
 		}
 
 	} else {
@@ -191,7 +191,7 @@ Mission::on_active()
 	if (need_to_reset_mission(true)) {
 		reset_offboard_mission(_offboard_mission);
 		update_offboard_mission();
-		_navigator->reset_cruising_speed();
+		_navigator->set_cruising_speed();
 		offboard_updated = true;
 	}
 

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -182,17 +182,3 @@ PARAM_DEFINE_INT32(VT_WV_TKO_EN, 0);
  * @group Mission
  */
 PARAM_DEFINE_INT32(VT_WV_LTR_EN, 0);
-
-/**
- * Cruise Airspeed
- *
- * The fixed wing controller tries to fly at this airspeed.
- *
- * @unit m/s
- * @min 0.0
- * @max 40
- * @decimal 1
- * @increment 0.5
- * @group FW TECS
- */
-PARAM_DEFINE_FLOAT(FW_AIRSPD_TRIM, 15.0f);

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -296,8 +296,7 @@ private:
 	control::BlockParamFloat _param_fw_alt_acceptance_radius;	/**< acceptance radius for fixedwing altitude */
 	control::BlockParamFloat _param_mc_alt_acceptance_radius;	/**< acceptance radius for multicopter altitude */
 
-	float _mission_cruising_speed_mc{-1.0f};
-	float _mission_cruising_speed_fw{-1.0f};
+	float _mission_cruising_speed{-1.0f};
 	float _mission_throttle{-1.0f};
 
 	// update subscriptions


### PR DESCRIPTION
We don't need to store separate cruising speeds for MC/FW. The custom speed/throttle only applies within a mission session after the command is executed.