### PR TITLE
MC: improve manual stick input handling

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -2854,7 +2854,8 @@ MulticopterPositionControl::generate_attitude_setpoint(float dt)
 		}
 
 		matrix::Quatf q_sp_rpy = matrix::AxisAnglef(v(0), v(1), 0.f);
-		// The axis angle can change the yaw as well (but only at higher tilt angles).
+		// The axis angle can change the yaw as well (but only at higher tilt angles. Note: we're talking
+		// about the world frame here, in terms of body frame the yaw rate will be unaffected).
 		// This the the formula by how much the yaw changes:
 		//   let a := tilt angle, b := atan(y/x) (direction of maximum tilt)
 		//   yaw = atan(-2 * sin(b) * cos(b) * sin^2(a/2) / (1 - 2 * cos^2(b) * sin^2(a/2))).

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -251,8 +251,8 @@ private:
 		float vel_max_down;
 		float slow_land_alt1;
 		float slow_land_alt2;
-		uint32_t alt_mode;
-		int opt_recover;
+		int32_t alt_mode;
+		int32_t opt_recover;
 		float rc_flt_smp_rate;
 		float rc_flt_cutoff;
 
@@ -596,7 +596,7 @@ MulticopterPositionControl::parameters_update(bool force)
 		_params.tilt_max_land = math::radians(_params.tilt_max_land);
 
 		float v;
-		uint32_t v_i;
+		int32_t v_i;
 		param_get(_params_handles.xy_p, &v);
 		_params.pos_p(0) = v;
 		_params.pos_p(1) = v;
@@ -651,9 +651,7 @@ MulticopterPositionControl::parameters_update(bool force)
 		param_get(_params_handles.alt_mode, &v_i);
 		_params.alt_mode = v_i;
 
-		int i;
-		param_get(_params_handles.opt_recover, &i);
-		_params.opt_recover = i;
+		param_get(_params_handles.opt_recover, &_params.opt_recover);
 
 		/* mc attitude control parameters*/
 		/* manual control scale */

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -341,7 +341,7 @@ PARAM_DEFINE_FLOAT(MPC_TKO_SPEED, 1.5f);
  *
  * @unit deg
  * @min 0.0
- * @max 90.0
+ * @max 85.0
  * @decimal 1
  * @group Multicopter Position Control
  */


### PR DESCRIPTION
I was quite surprised when I noticed the following in manual mode:
1. The maximum tilt angle (set via `MPC_MAN_TILT_MAX`) can easily be exceeded just by using a combination of roll & pitch (e.g. by moving the stick to the right upper corner). The formula for the tilt angle is `acos(cos(roll) * cos(pitch))`. By inserting the maximum angle, the limit is exceeded by roughly 15 degrees (with the default maximum tilt of 35 degrees). The full graph can be seen here: https://www.desmos.com/calculator/5zykbcnn93
2. I would have expected the vehicle to move towards 45 degrees when I move the stick towards a corner (equal roll & pitch). However this is not the case. For a maximum tilt angle of 35 degrees, the direction is off by a bit more than 5 degrees. What's worse is that the direction depends on the tilt angle, meaning if you were to move the stick perfectly straight from the center towards a corner, you would fly a curve. The formula for the direction of maximum tilt is `atan(sin(roll) / (sin(pitch) * cos(roll)))`. For `roll == pitch`, this is the graph by how much the direction is off from the diagonal: https://www.desmos.com/calculator/3poijoayhx. With a larger maximum tilt angle, this becomes noticeable as well.

I confirmed both points by looking at logs & doing simulations.

At first I only noticed 1. and implemented a solution for that, when I noticed the second point. They cannot be solved independently, so I propose a completely new approach to handle manual input. x and y input are used to control two (different) angles:
- the tilt angle (given by `sqrt(x*x + y*y)`). This allows a simple limitation of the maximum tilt (it adds a small dead-zone in the corners of the stick range)
- the direction of the tilt in the xy-plane, which defines the (eventual) direction of the motion

Benefits:
- for roll/pitch only inputs (zero pitch/roll) the behavior is exactly the same as before
- maximum tilt is correctly limited in every direction
- the flight direction matches with the direction of the stick input
- changes are linear
- improved flight experience. The vehicle does what you would expect it to do. This is a bit subjective, and I suggest you test it yourself. I made a [test branch manual_input_rework_testing](https://github.com/PX4/Firmware/tree/manual_input_rework_testing). It makes it possible to switch between the old & new behavior in-flight by mapping the aux1 channel.

However there is one point to note: the new behavior changes the yaw as well, when roll & pitch are combined. This can be seen if you pick up an x-quad at 2 diagonal motors, and start rotating it around those 2 motors: the yaw changes a bit.
If `a` is the tilt angle and `b` is the angle of the direction of the tilt angle, then the yaw angle is given by `yaw = atan((-2 * sin(b) * cos(b) * sin^2(a/2)) / (1 - 2 * cos^2(b) * sin^2(a/2)))`, and as a graph (x=tilt angle): https://www.desmos.com/calculator/y2mnebvl0j

Testing
I did extensive testing in HIL, including combinations of yawing and maximum tilt angles up to 90 degrees. I noticed that the yaw becomes very uncontrolled (overshoots and slow convergence) at high angles (around 80+). But this is a separate issue, I had the same behavior before this PR.
Then I tested on 2 different quads. So far, with a maximum tilt angle up to 55 degrees:
- 35 degrees max tilt: https://logs.px4.io/plot_app?log=6c4e8474-63dc-4a54-b2ca-9f9ee05566e0
- 55 degrees max tilt (with in-flight switching between old & new behavior): https://logs.px4.io/plot_app?log=8c1af5f2-f90f-41e9-a42e-83d1af481c6f
- 55 degrees max tilt: https://logs.px4.io/plot_app?log=5b613a54-e4f4-481c-ae78-1bed66e9fd24
  In this log the position estimation is off, not sure why. Also the yaw lost tracking when I quickly changed roll & pitch angles. This happens with both the old & new behavior, it's not a setpoint issue.