### PR TITLE
multirotor_motor_limits only publish if used

### DIFF
--- a/msg/multirotor_motor_limits.msg
+++ b/msg/multirotor_motor_limits.msg
@@ -1,11 +1,13 @@
 uint16 saturation_status	# Integer bit mask indicating which axes in the control mixer are saturated
-# 0 - True if any motor is saturated at the upper limit
-# 1 - True if any motor is saturated at the lower limit
-# 2 - True if a positive roll increment will increase motor saturation
-# 3 - True if negative roll increment will increase motor saturation
-# 4 - True if positive pitch increment will increase motor saturation
-# 5 - True if negative pitch increment will increase motor saturation
-# 6 - True if positive yaw increment will increase motor saturation
-# 7 - True if negative yaw increment will increase motor saturation
-# 8 - True if positive thrust increment will increase motor saturation
-# 9 - True if negative thrust increment will increase motor saturation
+
+# 0 - True if the saturation status is valid
+# 1 - True if any motor is saturated at the upper limit
+# 2 - True if any motor is saturated at the lower limit
+# 3 - True if a positive roll increment will increase motor saturation
+# 4 - True if negative roll increment will increase motor saturation
+# 5 - True if positive pitch increment will increase motor saturation
+# 6 - True if negative pitch increment will increase motor saturation
+# 7 - True if positive yaw increment will increase motor saturation
+# 8 - True if negative yaw increment will increase motor saturation
+# 9 - True if positive thrust increment will increase motor saturation
+# 10 - True if negative thrust increment will increase motor saturation

--- a/src/drivers/linux_pwm_out/linux_pwm_out.cpp
+++ b/src/drivers/linux_pwm_out/linux_pwm_out.cpp
@@ -299,9 +299,7 @@ void task_main(int argc, char *argv[])
 		if (_mixer_group != nullptr) {
 			_outputs.timestamp = hrt_absolute_time();
 			/* do mixing */
-			_outputs.noutputs = _mixer_group->mix(_outputs.output,
-							      actuator_outputs_s::NUM_ACTUATOR_OUTPUTS,
-							      NULL);
+			_outputs.noutputs = _mixer_group->mix(_outputs.output, actuator_outputs_s::NUM_ACTUATOR_OUTPUTS);
 
 			/* disable unused ports by setting their output to NaN */
 			for (size_t i = _outputs.noutputs; i < _outputs.NUM_ACTUATOR_OUTPUTS; i++) {

--- a/src/drivers/mkblctrl/mkblctrl.cpp
+++ b/src/drivers/mkblctrl/mkblctrl.cpp
@@ -539,7 +539,7 @@ MK::task_main()
 				if (_mixers != nullptr) {
 
 					/* do mixing */
-					outputs.noutputs = _mixers->mix(&outputs.output[0], _num_outputs, NULL);
+					outputs.noutputs = _mixers->mix(&outputs.output[0], _num_outputs);
 					outputs.timestamp = hrt_absolute_time();
 
 					/* iterate actuators */

--- a/src/drivers/pwm_out_rc_in/pwm_out_rc_in.cpp
+++ b/src/drivers/pwm_out_rc_in/pwm_out_rc_in.cpp
@@ -55,7 +55,6 @@
 #include <v1.0/mavlink_types.h>
 #include <v1.0/common/mavlink.h>
 
-
 /*
  * This driver is supposed to run on Snapdragon. It sends actuator_controls (PWM)
  * to a Pixhawk/Pixfalcon/Pixracer over UART (mavlink) and receives RC input.
@@ -415,7 +414,7 @@ void task_main(int argc, char *argv[])
 			_outputs.timestamp = _controls.timestamp;
 
 			/* do mixing */
-			_outputs.noutputs = _mixer->mix(_outputs.output, 0 /* not used */, NULL);
+			_outputs.noutputs = _mixer->mix(_outputs.output, 0);
 
 			/* disable unused ports by setting their output to NaN */
 			for (size_t i = _outputs.noutputs; i < sizeof(_outputs.output) / sizeof(_outputs.output[0]); i++) {

--- a/src/drivers/pwm_out_sim/pwm_out_sim.cpp
+++ b/src/drivers/pwm_out_sim/pwm_out_sim.cpp
@@ -474,7 +474,7 @@ PWMSim::task_main()
 			}
 
 			/* do mixing */
-			num_outputs = _mixers->mix(&outputs.output[0], num_outputs, nullptr);
+			num_outputs = _mixers->mix(&outputs.output[0], num_outputs);
 			outputs.noutputs = num_outputs;
 			outputs.timestamp = hrt_absolute_time();
 

--- a/src/drivers/px4io/CMakeLists.txt
+++ b/src/drivers/px4io/CMakeLists.txt
@@ -40,7 +40,6 @@ px4_add_module(
 		px4io_uploader.cpp
 		px4io_serial.cpp
 		px4io_i2c.cpp
-		px4io_params.c
 	DEPENDS
 		platforms__common
 	)

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1928,12 +1928,6 @@ PX4IO::io_publish_raw_rc()
 int
 PX4IO::io_publish_pwm_outputs()
 {
-	/* data we are going to fetch */
-	actuator_outputs_s outputs = {};
-	multirotor_motor_limits_s motor_limits;
-
-	outputs.timestamp = hrt_absolute_time();
-
 	/* get servo values from IO */
 	uint16_t ctl[_max_actuators];
 	int ret = io_reg_get(PX4IO_PAGE_SERVOS, 0, ctl, _max_actuators);
@@ -1942,38 +1936,33 @@ PX4IO::io_publish_pwm_outputs()
 		return ret;
 	}
 
+	actuator_outputs_s outputs = {};
+	outputs.timestamp = hrt_absolute_time();
+	outputs.noutputs = _max_actuators;
+
 	/* convert from register format to float */
 	for (unsigned i = 0; i < _max_actuators; i++) {
 		outputs.output[i] = ctl[i];
 	}
 
-	outputs.noutputs = _max_actuators;
-
-	/* lazily advertise on first publication */
-	if (_to_outputs == nullptr) {
-		int instance;
-		_to_outputs = orb_advertise_multi(ORB_ID(actuator_outputs),
-						  &outputs, &instance, ORB_PRIO_MAX);
-
-	} else {
-		orb_publish(ORB_ID(actuator_outputs), _to_outputs, &outputs);
-	}
+	int instance;
+	orb_publish_auto(ORB_ID(actuator_outputs), &_to_outputs, &outputs, &instance, ORB_PRIO_DEFAULT);
 
 	/* get mixer status flags from IO */
-	uint16_t mixer_status;
-	ret = io_reg_get(PX4IO_PAGE_STATUS, PX4IO_P_STATUS_MIXER, &mixer_status, sizeof(mixer_status) / sizeof(uint16_t));
-	motor_limits.saturation_status = mixer_status;
+	MultirotorMixer::saturation_status saturation_status;
+	ret = io_reg_get(PX4IO_PAGE_STATUS, PX4IO_P_STATUS_MIXER, &saturation_status.value, 1);
 
 	if (ret != OK) {
 		return ret;
 	}
 
 	/* publish mixer status */
-	if (_to_mixer_status == nullptr) {
-		_to_mixer_status = orb_advertise(ORB_ID(multirotor_motor_limits), &motor_limits);
+	if (saturation_status.flags.valid) {
+		multirotor_motor_limits_s motor_limits;
+		motor_limits.timestamp = hrt_absolute_time();
+		motor_limits.saturation_status = saturation_status.value;
 
-	} else {
-		orb_publish(ORB_ID(multirotor_motor_limits), _to_mixer_status, &motor_limits);
+		orb_publish_auto(ORB_ID(multirotor_motor_limits), &_to_mixer_status, &motor_limits, &instance, ORB_PRIO_DEFAULT);
 	}
 
 	return OK;

--- a/src/drivers/snapdragon_pwm_out/snapdragon_pwm_out.cpp
+++ b/src/drivers/snapdragon_pwm_out/snapdragon_pwm_out.cpp
@@ -402,9 +402,7 @@ void task_main(int argc, char *argv[])
 		_outputs.timestamp = hrt_absolute_time();
 
 		/* do  mixing for virtual control group */
-		_outputs.noutputs = _mixer->mix(_outputs.output,
-						_outputs.NUM_ACTUATOR_OUTPUTS,
-						NULL);
+		_outputs.noutputs = _mixer->mix(_outputs.output, _outputs.NUM_ACTUATOR_OUTPUTS);
 
 		//set max, min and disarmed pwm
 		const uint16_t reverse_mask = 0;

--- a/src/drivers/tap_esc/tap_esc.cpp
+++ b/src/drivers/tap_esc/tap_esc.cpp
@@ -655,7 +655,7 @@ TAP_ESC::cycle()
 		if (_is_armed && _mixers != nullptr) {
 
 			/* do mixing */
-			num_outputs = _mixers->mix(&_outputs.output[0], num_outputs, NULL);
+			num_outputs = _mixers->mix(&_outputs.output[0], num_outputs);
 			_outputs.noutputs = num_outputs;
 			_outputs.timestamp = hrt_absolute_time();
 

--- a/src/modules/px4iofirmware/mixer.cpp
+++ b/src/modules/px4iofirmware/mixer.cpp
@@ -91,11 +91,7 @@ enum mixer_source {
 
 static volatile mixer_source source;
 
-static int	mixer_callback(uintptr_t handle,
-			       uint8_t control_group,
-			       uint8_t control_index,
-			       float &control);
-
+static int mixer_callback(uintptr_t handle, uint8_t control_group, uint8_t control_index, float &control);
 static int mixer_mix_threadsafe(float *outputs, volatile uint16_t *limits);
 
 static MixerGroup mixer_group(mixer_callback, 0);
@@ -107,10 +103,9 @@ int mixer_mix_threadsafe(float *outputs, volatile uint16_t *limits)
 		return 0;
 	}
 
-	uint16_t mixer_limits = 0;
 	in_mixer = true;
-	int mixcount = mixer_group.mix(&outputs[0], PX4IO_SERVO_COUNT, &mixer_limits);
-	*limits = mixer_limits;
+	int mixcount = mixer_group.mix(&outputs[0], PX4IO_SERVO_COUNT);
+	*limits = mixer_group.get_saturation_status();
 	in_mixer = false;
 
 	return mixcount;
@@ -600,7 +595,6 @@ mixer_set_failsafe()
 	}
 
 	/* mix */
-
 	mixed = mixer_mix_threadsafe(&outputs[0], &r_mixer_limits);
 
 	/* scale to PWM and update the servo outputs as required */

--- a/src/modules/systemlib/mixer/mixer.cpp
+++ b/src/modules/systemlib/mixer/mixer.cpp
@@ -184,7 +184,7 @@ NullMixer::NullMixer() :
 }
 
 unsigned
-NullMixer::mix(float *outputs, unsigned space, uint16_t *status_reg)
+NullMixer::mix(float *outputs, unsigned space)
 {
 	if (space > 0) {
 		*outputs = 0.0f;

--- a/src/modules/systemlib/mixer/mixer_group.cpp
+++ b/src/modules/systemlib/mixer/mixer_group.cpp
@@ -103,13 +103,13 @@ MixerGroup::reset()
 }
 
 unsigned
-MixerGroup::mix(float *outputs, unsigned space, uint16_t *status_reg)
+MixerGroup::mix(float *outputs, unsigned space)
 {
 	Mixer	*mixer = _first;
 	unsigned index = 0;
 
 	while ((mixer != nullptr) && (index < space)) {
-		index += mixer->mix(outputs + index, space - index, status_reg);
+		index += mixer->mix(outputs + index, space - index);
 		mixer = mixer->_next;
 	}
 

--- a/src/modules/systemlib/mixer/mixer_helicopter.cpp
+++ b/src/modules/systemlib/mixer/mixer_helicopter.cpp
@@ -234,7 +234,7 @@ HelicopterMixer::from_text(Mixer::ControlCallback control_cb, uintptr_t cb_handl
 }
 
 unsigned
-HelicopterMixer::mix(float *outputs, unsigned space, uint16_t *status_reg)
+HelicopterMixer::mix(float *outputs, unsigned space)
 {
 	/* Find index to use for curves */
 	float thrust_cmd = get_control(0, 3);

--- a/src/modules/systemlib/mixer/mixer_multirotor.cpp
+++ b/src/modules/systemlib/mixer/mixer_multirotor.cpp
@@ -83,7 +83,6 @@ MultirotorMixer::MultirotorMixer(ControlCallback control_cb,
 	_idle_speed(-1.0f + idle_speed * 2.0f),	/* shift to output range here to avoid runtime calculation */
 	_delta_out_max(0.0f),
 	_thrust_factor(0.0f),
-	_limits_pub(),
 	_rotor_count(_config_rotor_count[(MultirotorGeometryUnderlyingType)geometry]),
 	_rotors(_config_index[(MultirotorGeometryUnderlyingType)geometry]),
 	_outputs_prev(new float[_rotor_count])
@@ -178,13 +177,6 @@ MultirotorMixer::from_text(Mixer::ControlCallback control_cb, uintptr_t cb_handl
 	} else if (!strcmp(geomname, "6a")) {
 		geometry = MultirotorGeometry::DODECA_BOTTOM_COX;
 
-
-#if 0
-
-	} else if (!strcmp(geomname, "8cw")) {
-		geometry = MultirotorGeometry::OCTA_COX_WIDE;
-#endif
-
 	} else if (!strcmp(geomname, "2-")) {
 		geometry = MultirotorGeometry::TWIN_ENGINE;
 
@@ -209,7 +201,7 @@ MultirotorMixer::from_text(Mixer::ControlCallback control_cb, uintptr_t cb_handl
 }
 
 unsigned
-MultirotorMixer::mix(float *outputs, unsigned space, uint16_t *status_reg)
+MultirotorMixer::mix(float *outputs, unsigned space)
 {
 	/* Summary of mixing strategy:
 	1) mix roll, pitch and thrust without yaw.
@@ -404,22 +396,16 @@ MultirotorMixer::mix(float *outputs, unsigned space, uint16_t *status_reg)
 
 		// update the saturation status report
 		update_saturation_status(i, clipping_high, clipping_low);
-
 	}
 
 	// this will force the caller of the mixer to always supply new slew rate values, otherwise no slew rate limiting will happen
 	_delta_out_max = 0.0f;
 
-	// Notify saturation status
-	if (status_reg != nullptr) {
-		(*status_reg) = _saturation_status.value;
-	}
-
 	return _rotor_count;
 }
 
 /*
- * This function update the control saturation status report using hte following inputs:
+ * This function update the control saturation status report using the following inputs:
  *
  * index: 0 based index identifying the motor that is saturating
  * clipping_high: true if the motor demand is being limited in the positive direction
@@ -438,7 +424,6 @@ MultirotorMixer::update_saturation_status(unsigned index, bool clipping_high, bo
 		} else if (_rotors[index].roll_scale < 0.0f) {
 			// A negative change in roll will increase saturation
 			_saturation_status.flags.roll_neg = true;
-
 		}
 
 		// check if the pitch input is saturating
@@ -449,7 +434,6 @@ MultirotorMixer::update_saturation_status(unsigned index, bool clipping_high, bo
 		} else if (_rotors[index].pitch_scale < 0.0f) {
 			// A negative change in pitch will increase saturation
 			_saturation_status.flags.pitch_neg = true;
-
 		}
 
 		// check if the yaw input is saturating
@@ -460,7 +444,6 @@ MultirotorMixer::update_saturation_status(unsigned index, bool clipping_high, bo
 		} else if (_rotors[index].yaw_scale < 0.0f) {
 			// A negative change in yaw will increase saturation
 			_saturation_status.flags.yaw_neg = true;
-
 		}
 
 		// A positive change in thrust will increase saturation
@@ -479,7 +462,6 @@ MultirotorMixer::update_saturation_status(unsigned index, bool clipping_high, bo
 		} else if (_rotors[index].roll_scale < 0.0f) {
 			// A positive change in roll will increase saturation
 			_saturation_status.flags.roll_pos = true;
-
 		}
 
 		// check if the pitch input is saturating
@@ -490,7 +472,6 @@ MultirotorMixer::update_saturation_status(unsigned index, bool clipping_high, bo
 		} else if (_rotors[index].pitch_scale < 0.0f) {
 			// A positive change in pitch will increase saturation
 			_saturation_status.flags.pitch_pos = true;
-
 		}
 
 		// check if the yaw input is saturating
@@ -501,13 +482,13 @@ MultirotorMixer::update_saturation_status(unsigned index, bool clipping_high, bo
 		} else if (_rotors[index].yaw_scale < 0.0f) {
 			// A positive change in yaw will increase saturation
 			_saturation_status.flags.yaw_pos = true;
-
 		}
 
 		// A negative change in thrust will increase saturation
 		_saturation_status.flags.thrust_neg = true;
-
 	}
+
+	_saturation_status.flags.valid = true;
 }
 
 void

--- a/src/modules/systemlib/mixer/mixer_simple.cpp
+++ b/src/modules/systemlib/mixer/mixer_simple.cpp
@@ -286,7 +286,7 @@ out:
 }
 
 unsigned
-SimpleMixer::mix(float *outputs, unsigned space, uint16_t *status_reg)
+SimpleMixer::mix(float *outputs, unsigned space)
 {
 	float		sum = 0.0f;
 

--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -78,19 +78,6 @@ PARAM_DEFINE_INT32(SYS_AUTOCONFIG, 0);
 PARAM_DEFINE_INT32(SYS_HITL, 0);
 
 /**
- * Set usage of IO board
- *
- * Can be used to use a standard startup script but with a FMU only set-up. Set to 0 to force the FMU only set-up.
- *
- * @boolean
- * @min 0
- * @max 1
- * @reboot_required true
- * @group System
- */
-PARAM_DEFINE_INT32(SYS_USE_IO, 1);
-
-/**
  * Set restart type
  *
  * Set by px4io to indicate type of restart

--- a/src/modules/uavcan/uavcan_main.cpp
+++ b/src/modules/uavcan/uavcan_main.cpp
@@ -909,7 +909,7 @@ int UavcanNode::run()
 				unsigned num_outputs_max = 8;
 
 				// Do mixing
-				_outputs.noutputs = _mixers->mix(&_outputs.output[0], num_outputs_max, NULL);
+				_outputs.noutputs = _mixers->mix(&_outputs.output[0], num_outputs_max);
 
 				new_output = true;
 			}

--- a/src/platforms/posix/drivers/df_bebop_bus_wrapper/df_bebop_bus_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_bebop_bus_wrapper/df_bebop_bus_wrapper.cpp
@@ -377,9 +377,7 @@ void task_main(int argc, char *argv[])
 
 			if (_mixers != nullptr) {
 				/* do mixing */
-				_outputs.noutputs = _mixers->mix(_outputs.output,
-								 4,
-								 NULL);
+				_outputs.noutputs = _mixers->mix(_outputs.output, 4);
 			}
 
 			// Set last throttle for battery calculations

--- a/src/platforms/qurt/fc_addon/uart_esc/uart_esc_main.cpp
+++ b/src/platforms/qurt/fc_addon/uart_esc/uart_esc_main.cpp
@@ -337,9 +337,7 @@ void task_main(int argc, char *argv[])
 				int16_t motor_rpms[UART_ESC_MAX_MOTORS];
 
 				if (_armed.armed) {
-					_outputs.noutputs = mixer->mix(&_outputs.output[0],
-								       actuator_controls_s::NUM_ACTUATOR_CONTROLS,
-								       NULL);
+					_outputs.noutputs = mixer->mix(&_outputs.output[0], actuator_controls_s::NUM_ACTUATOR_CONTROLS);
 
 					// Make sure we support only up to UART_ESC_MAX_MOTORS motors
 					if (_outputs.noutputs > UART_ESC_MAX_MOTORS) {

--- a/src/systemcmds/tests/test_mixer.cpp
+++ b/src/systemcmds/tests/test_mixer.cpp
@@ -395,7 +395,7 @@ bool MixerTest::mixerTest()
 
 	/* mix */
 	should_prearm = true;
-	mixed = mixer_group.mix(&outputs[0], output_max, nullptr);
+	mixed = mixer_group.mix(&outputs[0], output_max);
 
 	pwm_limit_calc(should_arm, should_prearm, mixed, reverse_pwm_mask, r_page_servo_disarmed, r_page_servo_control_min,
 		       r_page_servo_control_max, outputs, r_page_servos, &pwm_limit);
@@ -436,7 +436,7 @@ bool MixerTest::mixerTest()
 	while (hrt_elapsed_time(&starttime) < INIT_TIME_US + RAMP_TIME_US + 2 * sleep_quantum_us) {
 
 		/* mix */
-		mixed = mixer_group.mix(&outputs[0], output_max, nullptr);
+		mixed = mixer_group.mix(&outputs[0], output_max);
 
 		pwm_limit_calc(should_arm, should_prearm, mixed, reverse_pwm_mask, r_page_servo_disarmed, r_page_servo_control_min,
 			       r_page_servo_control_max, outputs, r_page_servos, &pwm_limit);
@@ -480,7 +480,7 @@ bool MixerTest::mixerTest()
 		}
 
 		/* mix */
-		mixed = mixer_group.mix(&outputs[0], output_max, nullptr);
+		mixed = mixer_group.mix(&outputs[0], output_max);
 
 		pwm_limit_calc(should_arm, should_prearm, mixed, reverse_pwm_mask, r_page_servo_disarmed, r_page_servo_control_min,
 			       r_page_servo_control_max, outputs, r_page_servos, &pwm_limit);
@@ -508,7 +508,7 @@ bool MixerTest::mixerTest()
 	while (hrt_elapsed_time(&starttime) < 600000) {
 
 		/* mix */
-		mixed = mixer_group.mix(&outputs[0], output_max, nullptr);
+		mixed = mixer_group.mix(&outputs[0], output_max);
 
 		pwm_limit_calc(should_arm, should_prearm, mixed, reverse_pwm_mask, r_page_servo_disarmed, r_page_servo_control_min,
 			       r_page_servo_control_max, outputs, r_page_servos, &pwm_limit);
@@ -545,7 +545,7 @@ bool MixerTest::mixerTest()
 	while (hrt_elapsed_time(&starttime) < 600000 + RAMP_TIME_US) {
 
 		/* mix */
-		mixed = mixer_group.mix(&outputs[0], output_max, nullptr);
+		mixed = mixer_group.mix(&outputs[0], output_max);
 
 		pwm_limit_calc(should_arm, should_prearm, mixed, reverse_pwm_mask, r_page_servo_disarmed, r_page_servo_control_min,
 			       r_page_servo_control_max, outputs, r_page_servos, &pwm_limit);


### PR DESCRIPTION
Both the IO and FMU publish multirotor_motor_limits, but were doing so regardless of a multicopter mixer.
In this PR it's only published if a multirotor mixer is used.