### PR TITLE
Bugfix: corrects the ARR calculation for the PWM timer

### DIFF
--- a/src/drivers/stm32/drv_io_timer.c
+++ b/src/drivers/stm32/drv_io_timer.c
@@ -457,7 +457,7 @@ static int timer_set_rate(unsigned timer, unsigned rate)
 {
 
 	/* configure the timer to update at the desired rate */
-	rARR(timer) = BOARD_PWM_FREQ / rate;
+	rARR(timer) = (BOARD_PWM_FREQ / rate) - 1;
 
 	/* generate an update event; reloads the counter and all registers */
 	rEGR(timer) = GTIM_EGR_UG;


### PR DESCRIPTION
The calculation of the ARR on the PWM timer did not subtract 1 from the timer period calculation to get the ARR value.

If I am not mistaken, the ARR calculation also requires the -1.