### PR TITLE
Bugfix: corrects orientation of magnetometer raw values

### DIFF
--- a/src/drivers/hmc5883/hmc5883.cpp
+++ b/src/drivers/hmc5883/hmc5883.cpp
@@ -987,8 +987,8 @@ HMC5883::collect()
 	 * to align the sensor axes with the board, x and y need to be flipped
 	 * and y needs to be negated
 	 */
-	new_report.x_raw = report.y;
-	new_report.y_raw = -report.x;
+	new_report.x_raw = -report.y;
+	new_report.y_raw = report.x;
 	/* z remains z */
 	new_report.z_raw = report.z;
 


### PR DESCRIPTION
The magnetomer raw values were not being rotated in the same direction as
the scaled values. This meant that if the rotation was set to ROTATION_NONE,
the raw values and scaled values were off by 180 degrees.

This is commit addresses issue #7929.