### PR TITLE
[BACKPORT] stm32:stm32f40xxx I2C ensure proper error handling.

### DIFF
--- a/nuttx-patches/00034-BACKPORT-stm32f4-I2C-fix.patch
+++ b/nuttx-patches/00034-BACKPORT-stm32f4-I2C-fix.patch
@@ -1,0 +1,41 @@
+diff --git NuttX/nuttx/arch/arm/src/stm32/stm32f40xxx_i2c.c NuttX/nuttx/arch/arm/src/stm32/stm32f40xxx_i2c.c
+index 2bb715c..481b851 100644
+--- NuttX/nuttx/arch/arm/src/stm32/stm32f40xxx_i2c.c
++++ NuttX/nuttx/arch/arm/src/stm32/stm32f40xxx_i2c.c
+@@ -1828,6 +1828,20 @@ static int stm32_i2c_isr(struct stm32_i2c_priv_s *priv)
+    * the ISR cycle to handle the sending/receiving of the messages.
+    */
+ 
++  /* First check for errors */
++
++  if ((status & I2C_SR1_ERRORMASK) != 0)
++    {
++         stm32_i2c_traceevent(priv, I2CEVENT_ERROR, status & I2C_SR1_ERRORMASK);
++
++         /* Clear interrupt flags */
++
++         stm32_i2c_putreg(priv, STM32_I2C_SR1_OFFSET, 0);
++
++         priv->dcnt = -1;
++         priv->msgc = 0;
++    }
++
+   if (priv->dcnt == -1 && priv->msgc == 0)
+     {
+       i2cinfo("Shutting down I2C ISR\n");
+@@ -2027,7 +2041,6 @@ static int stm32_i2c_transfer(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s
+                               int count)
+ {
+   FAR struct stm32_i2c_priv_s *priv = (struct stm32_i2c_priv_s *)dev;
+-  stm32_i2c_sem_wait(priv);   /* Ensure that address or flags don't change meanwhile */
+   uint32_t status = 0;
+ #ifdef I2C1_FSMC_CONFLICT
+   uint32_t ahbenr;
+@@ -2035,6 +2048,7 @@ static int stm32_i2c_transfer(FAR struct i2c_master_s *dev, FAR struct i2c_msg_s
+   int ret = 0;
+ 
+   ASSERT(count);
++  stm32_i2c_sem_wait(priv);   /* Ensure that address or flags don't change meanwhile */
+ 
+ #ifdef I2C1_FSMC_CONFLICT
+   /* Disable FSMC that shares a pin with I2C1 (LBAR) */

--- a/nuttx-patches/CMakeLists.txt
+++ b/nuttx-patches/CMakeLists.txt
@@ -62,6 +62,7 @@ set(nuttx_patches
 	00031-BACKPORT-fix-arm-none-eabi-gcc-7-warnings-apps.patch
 	00032-BACKPORT-stm32f7-pinmap-FMC-I2C4-fixes.patch
 	00033-BACKPORT-stm32f7-sdmmc-dcache-fix.patch
+	00034-BACKPORT-stm32f4-I2C-fix.patch
 	90000-PENDING-wip-inflight-to-upstream.patch
 	)
 


### PR DESCRIPTION
  Injecting data errors would cause the driver to continually re enter the isr with BERR an RxNE.
  This fix allows the error to be cleared and  propagated to the waiting task.