### PR TITLE
commander: require local position for home

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1264,8 +1264,8 @@ static void commander_set_home_position(orb_advert_t &homePub, home_position_s &
 					const vehicle_local_position_s &localPosition, const vehicle_global_position_s &globalPosition,
 					const vehicle_attitude_s &attitude)
 {
-	//Need global position fix to be able to set home
-	if (!status_flags.condition_global_position_valid) {
+	//Need global and local position fix to be able to set home
+	if (!status_flags.condition_global_position_valid || !status_flags.condition_local_position_valid) {
 		return;
 	}
 


### PR DESCRIPTION
This fixes (or at least works around) a race condition where the
`status_flags.condition_local_position_valid` is still `false` but the
`status_flags.condition_global_position_valid` is already `true`.

The way to reproduce it is t:
1. Poll home position to check if home is initialized
2. Send arm and takeoff command as soon as home is initialized

Then arming will succeed but takeoff will fail because there is a check
for `status_flags.condition_local_position_valid` in
`main_state_transition()` to enter TAKEOFF.

Tested in SITL using [DroneCore takeoff and land example](https://github.com/dronecore/DroneCore/tree/master/example/takeoff_land).

The error case was found by @hamishwillee.