### PR TITLE
Bugfix: corrects the ARR calculation for the LED PWM timer

### DIFF
--- a/src/drivers/stm32/drv_led_pwm.cpp
+++ b/src/drivers/stm32/drv_led_pwm.cpp
@@ -147,14 +147,14 @@ static void led_pwm_timer_init_timer(unsigned timer)
 
 	/* If the timer clock source provided as clock_freq is the STM32_APBx_TIMx_CLKIN
 	 * then configure the timer to free-run at 1MHz.
-	 * Otherwize, other frequencies are attainable by adjusting .clock_freq accordingly.
+	 * Otherwise, other frequencies are attainable by adjusting .clock_freq accordingly.
 	 */
 
 	rPSC(timer) = (led_pwm_timers[timer].clock_freq / 1000000) - 1;
 
 	/* configure the timer to update at the desired rate */
 
-	rARR(timer) = 1000000 / LED_PWM_RATE;
+	rARR(timer) = (1000000 / LED_PWM_RATE) - 1;
 
 	/* generate an update event; reloads the counter and all registers */
 	rEGR(timer) = GTIM_EGR_UG;


### PR DESCRIPTION
The calculation of the ARR on the LED PWM timer did not subtract 1
from the timer period calculation to get the ARR value.

@davids5: I went and looked for other ARR calculations and found this one in the LED PWM driver - This is the same error that we fixed in the PWM driver (PR #7952).