### PR TITLE
sitl: add possibility to not run gazebo when running make

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -95,20 +95,23 @@ elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]
 then
 	if [ -x "$(command -v gazebo)" ]
 	then
-		# Set the plugin path so Gazebo finds our model and sim
-		source $src_path/Tools/setup_gazebo.bash ${src_path} ${build_path}
+		if  [[ -z "$DONT_RUN" ]]
+		then
+			# Set the plugin path so Gazebo finds our model and sim
+			source $src_path/Tools/setup_gazebo.bash ${src_path} ${build_path}
 
-		gzserver --verbose ${src_path}/Tools/sitl_gazebo/worlds/${model}.world &
-		SIM_PID=`echo $!`
+			gzserver --verbose ${src_path}/Tools/sitl_gazebo/worlds/${model}.world &
+			SIM_PID=`echo $!`
 
-		if [[ -n "$HEADLESS" ]]; then
-			echo "not running gazebo gui"
-		else
-			# gzserver needs to be running to avoid a race. Since the launch
-			# is putting it into the background we need to avoid it by backing off
-			sleep 3
-			nice -n 20 gzclient --verbose &
-			GUI_PID=`echo $!`
+			if [[ -n "$HEADLESS" ]]; then
+				echo "not running gazebo gui"
+			else
+				# gzserver needs to be running to avoid a race. Since the launch
+				# is putting it into the background we need to avoid it by backing off
+				sleep 3
+				nice -n 20 gzclient --verbose &
+				GUI_PID=`echo $!`
+			fi
 		fi
 	else
 		echo "You need to have gazebo simulator installed!"
@@ -141,8 +144,11 @@ sitl_command="$sudo_enabled $sitl_bin $no_pxh $chroot_enabled $src_path $src_pat
 
 echo SITL COMMAND: $sitl_command
 
+if [[ -n "$DONT_RUN" ]]
+then
+    echo "Not running simulation (\$DONT_RUN is set)."
 # Start Java simulator
-if [ "$debugger" == "lldb" ]
+elif [ "$debugger" == "lldb" ]
 then
 	lldb -- $sitl_command
 elif [ "$debugger" == "gdb" ]
@@ -170,14 +176,17 @@ else
 	$sitl_command
 fi
 
-if [ "$program" == "jmavsim" ]
+if [[ -z "$DONT_RUN" ]]
 then
-	pkill -9 -P $SIM_PID
-	kill -9 $SIM_PID
-elif [ "$program" == "gazebo" ]
-then
-	kill -9 $SIM_PID
-	if [[ ! -n "$HEADLESS" ]]; then
-		kill -9 $GUI_PID
+	if [ "$program" == "jmavsim" ]
+	then
+		pkill -9 -P $SIM_PID
+		kill -9 $SIM_PID
+	elif [ "$program" == "gazebo" ]
+	then
+		kill -9 $SIM_PID
+		if [[ ! -n "$HEADLESS" ]]; then
+			kill -9 $GUI_PID
+		fi
 	fi
 fi


### PR DESCRIPTION
Trying to resolve #3961 without changing to much of the scripts, I found that I could just add an environment variable (I called it "DONT_RUN") in `sitl_run.sh` that would disable running for Gazebo (there is already a "HEADLESS" environment variable used there).

I don't know how to edit the cmake target as suggested by @AndreasAntener in #3961, so I'm open to advice.

Of course, that could be extended to other simulators, but for now I wanted to have a feedback on this idea.