### PR TITLE
[wip] Battery throttle replacement

### DIFF
--- a/src/modules/sensors/parameters.cpp
+++ b/src/modules/sensors/parameters.cpp
@@ -144,6 +144,10 @@ int initialize_parameter_handles(ParameterHandles &parameter_handles)
 	parameter_handles.battery_a_per_v = param_find("BAT_A_PER_V");
 	parameter_handles.battery_source = param_find("BAT_SOURCE");
 
+	/* pwm max/min for main actuator output */
+	parameter_handles.pwm_max = param_find("PWM_MAX");
+	parameter_handles.pwm_min = param_find("PWM_MIN");
+
 	/* rotations */
 	parameter_handles.board_rotation = param_find("SENS_BOARD_ROT");
 
@@ -227,8 +231,6 @@ int initialize_parameter_handles(ParameterHandles &parameter_handles)
 	(void)param_find("SYS_AUTOCONFIG");
 	(void)param_find("SYS_HITL");
 	(void)param_find("PWM_RATE");
-	(void)param_find("PWM_MIN");
-	(void)param_find("PWM_MAX");
 	(void)param_find("PWM_DISARMED");
 	(void)param_find("PWM_AUX_MIN");
 	(void)param_find("PWM_AUX_MAX");
@@ -477,6 +479,16 @@ int update_parameters(const ParameterHandles &parameter_handles, Parameters &par
 	}
 
 	param_get(parameter_handles.battery_source, &(parameters.battery_source));
+
+	if (param_get(parameter_handles.pwm_max, &(parameters.pwm_max)) != OK) {
+		PX4_WARN("%s", paramerr);
+		parameters.pwm_max = 0;
+	}
+
+	if (param_get(parameter_handles.pwm_min, &(parameters.pwm_min)) != OK) {
+		PX4_WARN("%s", paramerr);
+		parameters.pwm_min = 0;
+	}
 
 	param_get(parameter_handles.board_rotation, &(parameters.board_rotation));
 

--- a/src/modules/sensors/parameters.h
+++ b/src/modules/sensors/parameters.h
@@ -142,6 +142,9 @@ struct Parameters {
 	float battery_a_per_v;
 	int32_t battery_source;
 
+	int32_t pwm_max;
+	int32_t pwm_min;
+
 	float baro_qnh;
 
 	float vibration_warning_threshold;
@@ -218,6 +221,9 @@ struct ParameterHandles {
 	param_t battery_v_div;
 	param_t battery_a_per_v;
 	param_t battery_source;
+
+	param_t pwm_max;
+	param_t pwm_min;
 
 	param_t board_rotation;
 

--- a/src/modules/systemlib/battery.cpp
+++ b/src/modules/systemlib/battery.cpp
@@ -86,7 +86,7 @@ Battery::reset(battery_status_s *battery_status)
 void
 Battery::updateBatteryStatus(hrt_abstime timestamp, float voltage_v, float current_a,
 			     bool connected, bool selected_source, int priority,
-			     float throttle_normalized,
+			     float actuators_outputs_normalized,
 			     bool armed, battery_status_s *battery_status)
 {
 	reset(battery_status);
@@ -94,7 +94,7 @@ Battery::updateBatteryStatus(hrt_abstime timestamp, float voltage_v, float curre
 	filterVoltage(voltage_v);
 	filterCurrent(current_a);
 	sumDischarged(timestamp, current_a);
-	estimateRemaining(voltage_v, current_a, throttle_normalized, armed);
+	estimateRemaining(voltage_v, current_a, actuators_outputs_normalized, armed);
 	determineWarning();
 	computeScale();
 
@@ -164,7 +164,7 @@ Battery::sumDischarged(hrt_abstime timestamp, float current_a)
 }
 
 void
-Battery::estimateRemaining(float voltage_v, float current_a, float throttle_normalized, bool armed)
+Battery::estimateRemaining(float voltage_v, float current_a, float actuators_outputs_normalized, bool armed)
 {
 	const float bat_r = _param_r_internal.get();
 
@@ -176,7 +176,7 @@ Battery::estimateRemaining(float voltage_v, float current_a, float throttle_norm
 
 	} else {
 		// assume 10% voltage drop of the full drop range with motors idle
-		const float thr = (armed) ? ((fabsf(throttle_normalized) + 0.1f) / 1.1f) : 0.0f;
+		const float thr = (armed) ? ((fabsf(actuators_outputs_normalized) + 0.1f) / 1.1f) : 0.0f;
 
 		bat_v_empty_dynamic -= _param_v_load_drop.get() * thr;
 	}


### PR DESCRIPTION
if no current measurement is available, then throttle input is used  to compensate for voltage drop due to current consumption. However, current consumption also depends on the direction the vehicle is flying. For instance, flying straight up with full throttle will result in a lower voltage drop than flying sideways and full throttle. Consequently, a better replacement for current measurement is the normalized actuator outputs.

