### PR TITLE
BMP280 fix /dev/baroX unregister

### DIFF
--- a/src/drivers/bmp280/bmp280.cpp
+++ b/src/drivers/bmp280/bmp280.cpp
@@ -90,7 +90,7 @@ class BMP280 : public device::CDev
 {
 public:
 	BMP280(bmp280::IBMP280 *interface, const char *path);
-	~BMP280();
+	virtual ~BMP280();
 
 	virtual int		init();
 
@@ -175,7 +175,7 @@ BMP280::~BMP280()
 	stop_cycle();
 
 	if (_class_instance != -1) {
-		unregister_class_devname(get_devname(), _class_instance);
+		unregister_class_devname(BARO_BASE_DEVICE_PATH, _class_instance);
 	}
 
 	/* free any existing reports */
@@ -187,15 +187,12 @@ BMP280::~BMP280()
 		orb_unadvertise(_baro_topic);
 	}
 
-
 	// free perf counters
 	perf_free(_sample_perf);
 	perf_free(_measure_perf);
 	perf_free(_comms_errors);
 
 	delete _interface;
-
-
 }
 
 int
@@ -696,7 +693,6 @@ start_bus(struct bmp280_bus_option &bus)
 		exit(1);
 	}
 
-
 	close(fd);
 	return true;
 }
@@ -978,13 +974,6 @@ usage()
 }
 
 } // namespace
-
-
-bmp280::IBMP280::~IBMP280()
-{
-
-}
-
 
 int
 bmp280_main(int argc, char *argv[])

--- a/src/drivers/bmp280/bmp280.h
+++ b/src/drivers/bmp280/bmp280.h
@@ -131,21 +131,26 @@ struct fcalibration_s {
 class IBMP280
 {
 public:
-	virtual ~IBMP280() = 0;
+	virtual ~IBMP280() = default;
 
 	virtual bool is_external() = 0;
 	virtual int init() = 0;
 
-	virtual uint8_t get_reg(uint8_t addr) = 0; //read reg value
-	virtual int set_reg(uint8_t value, uint8_t addr) = 0; //write reg value
-	virtual bmp280::data_s *get_data(uint8_t addr) = 0; //bulk read of data into buffer, return same pointer
-	virtual bmp280::calibration_s *get_calibration(uint8_t addr) =
-		0; //bulk read of calibration data into buffer, return same pointer
+	// read reg value
+	virtual uint8_t get_reg(uint8_t addr) = 0;
+
+	// write reg value
+	virtual int set_reg(uint8_t value, uint8_t addr) = 0;
+
+	// bulk read of data into buffer, return same pointer
+	virtual bmp280::data_s *get_data(uint8_t addr) = 0;
+
+	// bulk read of calibration data into buffer, return same pointer
+	virtual bmp280::calibration_s *get_calibration(uint8_t addr) = 0;
 
 };
 
 } /* namespace */
-
 
 
 /* interface factories */

--- a/src/drivers/bmp280/bmp280_i2c.cpp
+++ b/src/drivers/bmp280/bmp280_i2c.cpp
@@ -44,15 +44,13 @@
 
 #include "board_config.h"
 
-
 #if defined(PX4_I2C_OBDEV_BMP280) || defined(PX4_I2C_EXT_OBDEV_BMP280)
-
 
 class BMP280_I2C: public device::I2C, public bmp280::IBMP280
 {
 public:
 	BMP280_I2C(uint8_t bus, uint8_t device, bool external);
-	~BMP280_I2C();
+	virtual ~BMP280_I2C() = default;
 
 	bool is_external();
 	int init();
@@ -79,12 +77,6 @@ BMP280_I2C::BMP280_I2C(uint8_t bus, uint8_t device, bool external) :
 	_external = external;
 }
 
-
-BMP280_I2C::~BMP280_I2C()
-{
-}
-
-
 bool BMP280_I2C::is_external()
 {
 	return _external;
@@ -101,14 +93,12 @@ uint8_t BMP280_I2C::get_reg(uint8_t addr)
 	transfer(&cmd[0], 1, &cmd[1], 1);
 
 	return cmd[1];
-
 }
 
 int BMP280_I2C::set_reg(uint8_t value, uint8_t addr)
 {
 	uint8_t cmd[2] = { (uint8_t)(addr), value};
 	return transfer(cmd, sizeof(cmd), nullptr, 0);
-
 }
 
 bmp280::data_s *BMP280_I2C::get_data(uint8_t addr)
@@ -121,8 +111,6 @@ bmp280::data_s *BMP280_I2C::get_data(uint8_t addr)
 	} else {
 		return nullptr;
 	}
-
-
 }
 
 bmp280::calibration_s *BMP280_I2C::get_calibration(uint8_t addr)
@@ -136,7 +124,5 @@ bmp280::calibration_s *BMP280_I2C::get_calibration(uint8_t addr)
 		return nullptr;
 	}
 }
-
-
 
 #endif /* PX4_I2C_OBDEV_BMP280 || PX4_I2C_EXT_OBDEV_BMP280 */

--- a/src/drivers/bmp280/bmp280_spi.cpp
+++ b/src/drivers/bmp280/bmp280_spi.cpp
@@ -66,7 +66,7 @@ class BMP280_SPI: public device::SPI, public bmp280::IBMP280
 {
 public:
 	BMP280_SPI(uint8_t bus, spi_dev_e device, bool external);
-	~BMP280_SPI();
+	virtual ~BMP280_SPI() = default;
 
 	bool is_external();
 	int init();
@@ -92,12 +92,6 @@ BMP280_SPI::BMP280_SPI(uint8_t bus, spi_dev_e device, bool external) :
 {
 	_external = external;
 }
-
-
-BMP280_SPI::~BMP280_SPI()
-{
-}
-
 
 bool BMP280_SPI::is_external()
 {
@@ -133,8 +127,6 @@ bmp280::data_s *BMP280_SPI::get_data(uint8_t addr)
 	} else {
 		return nullptr;
 	}
-
-
 }
 
 bmp280::calibration_s *BMP280_SPI::get_calibration(uint8_t addr)
@@ -148,7 +140,5 @@ bmp280::calibration_s *BMP280_SPI::get_calibration(uint8_t addr)
 		return nullptr;
 	}
 }
-
-
 
 #endif /* PX4_SPIDEV_BARO || PX4_SPIDEV_EXT_BARO */


### PR DESCRIPTION
A failed BMP280 start was leaving behind /dev/baro1.