### PR TITLE
fix bug of landing not to the current location

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1744,6 +1744,8 @@ void MulticopterPositionControl::control_auto(float dt)
 	if (!_mode_auto || !_vehicle_status.is_rotary_wing) {
 		if (!_mode_auto) {
 			_mode_auto = true;
+			//set _triplet_lat_lon_finite true once switch to AUTO(e.g. LAND)
+			_triplet_lat_lon_finite = true;
 		}
 
 		_reset_pos_sp = true;


### PR DESCRIPTION
set _triplet_lat_lon_finite true to avoid landing to not the current location, see https://github.com/PX4/Firmware/issues/7990