### PR TITLE
MC attitude controller: fixes for yaw control

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -91,10 +91,8 @@
  */
 extern "C" __EXPORT int mc_att_control_main(int argc, char *argv[]);
 
-#define YAW_DEADZONE	0.05f
 #define MIN_TAKEOFF_THRUST    0.2f
 #define TPA_RATE_LOWER_LIMIT 0.05f
-#define MANUAL_THROTTLE_MAX_MULTICOPTER	0.9f
 #define ATTITUDE_TC_DEFAULT 0.2f
 
 #define AXIS_INDEX_ROLL 0
@@ -624,7 +622,7 @@ MulticopterAttitudeControl::parameters_update()
 	param_get(_params_handles.yaw_auto_max, &_params.yaw_auto_max);
 	_params.auto_rate_max(2) = math::radians(_params.yaw_auto_max);
 
-	/* manual rate control scale and auto mode roll/pitch rate limits */
+	/* manual rate control scale and acro mode roll/pitch rate limits */
 	param_get(_params_handles.acro_roll_max, &v);
 	_params.acro_rate_max(0) = math::radians(v);
 	param_get(_params_handles.acro_pitch_max, &v);
@@ -1196,15 +1194,13 @@ MulticopterAttitudeControl::task_main()
 					_v_rates_sp_pub = orb_advertise(_rates_sp_id, &_v_rates_sp);
 				}
 
-				//}
-
 			} else {
 				/* attitude controller disabled, poll rates setpoint topic */
 				if (_v_control_mode.flag_control_manual_enabled) {
 					/* manual rates control - ACRO mode */
 					_rates_sp = math::Vector<3>(_manual_control_sp.y, -_manual_control_sp.x,
 								    _manual_control_sp.r).emult(_params.acro_rate_max);
-					_thrust_sp = math::min(_manual_control_sp.z, MANUAL_THROTTLE_MAX_MULTICOPTER);
+					_thrust_sp = _manual_control_sp.z;
 
 					/* publish attitude rates setpoint */
 					_v_rates_sp.roll = _rates_sp(0);

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -653,6 +653,17 @@ MulticopterAttitudeControl::parameters_update()
 	param_get(_params_handles.board_offset[1], &(_params.board_offset[1]));
 	param_get(_params_handles.board_offset[2], &(_params.board_offset[2]));
 
+
+	/* get transformation matrix from sensor/board to body frame */
+	get_rot_matrix((enum Rotation)_params.board_rotation, &_board_rotation);
+
+	/* fine tune the rotation */
+	math::Matrix<3, 3> board_rotation_offset;
+	board_rotation_offset.from_euler(M_DEG_TO_RAD_F * _params.board_offset[0],
+					 M_DEG_TO_RAD_F * _params.board_offset[1],
+					 M_DEG_TO_RAD_F * _params.board_offset[2]);
+	_board_rotation = board_rotation_offset * _board_rotation;
+
 	return OK;
 }
 
@@ -954,16 +965,6 @@ MulticopterAttitudeControl::control_attitude_rates(float dt)
 	if (!_armed.armed || !_vehicle_status.is_rotary_wing) {
 		_rates_int.zero();
 	}
-
-	/* get transformation matrix from sensor/board to body frame */
-	get_rot_matrix((enum Rotation)_params.board_rotation, &_board_rotation);
-
-	/* fine tune the rotation */
-	math::Matrix<3, 3> board_rotation_offset;
-	board_rotation_offset.from_euler(M_DEG_TO_RAD_F * _params.board_offset[0],
-					 M_DEG_TO_RAD_F * _params.board_offset[1],
-					 M_DEG_TO_RAD_F * _params.board_offset[2]);
-	_board_rotation = board_rotation_offset * _board_rotation;
 
 	// get the raw gyro data and correct for thermal errors
 	math::Vector<3> rates;

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -858,9 +858,6 @@ MulticopterAttitudeControl::control_attitude(float dt)
 	float e_R_z_sin = e_R.length(); // == sin(tilt angle error)
 	float e_R_z_cos = R_z * R_sp_z; // == cos(tilt angle error) == (R.transposed() * R_sp)(2, 2)
 
-	/* calculate weight for yaw control */
-	float yaw_w = R_sp(2, 2) * R_sp(2, 2);
-
 	/* calculate rotation matrix after roll/pitch only rotation */
 	math::Matrix<3, 3> R_rp;
 
@@ -892,6 +889,14 @@ MulticopterAttitudeControl::control_attitude(float dt)
 	/* R_rp and R_sp have the same Z axis, calculate yaw error */
 	math::Vector<3> R_sp_x(R_sp(0, 0), R_sp(1, 0), R_sp(2, 0));
 	math::Vector<3> R_rp_x(R_rp(0, 0), R_rp(1, 0), R_rp(2, 0));
+
+	/* calculate the weight for yaw control
+	 * Make the weight depend on the tilt angle error: the higher the error of roll and/or pitch, the lower
+	 * the weight that we use to control the yaw. This gives precedence to roll & pitch correction.
+	 * The weight is 1 if there is no tilt error.
+	 */
+	float yaw_w = e_R_z_cos * e_R_z_cos;
+
 	/* calculate the angle between R_rp_x and R_sp_x (yaw angle error), and apply the yaw weight */
 	e_R(2) = atan2f((R_rp_x % R_sp_x) * R_sp_z, R_rp_x * R_sp_x) * yaw_w;
 

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -850,12 +850,13 @@ MulticopterAttitudeControl::control_attitude(float dt)
 	math::Vector<3> R_z(R(0, 2), R(1, 2), R(2, 2));
 	math::Vector<3> R_sp_z(R_sp(0, 2), R_sp(1, 2), R_sp(2, 2));
 
-	/* axis and sin(angle) of desired rotation */
+	/* axis and sin(angle) of desired rotation (indexes: 0=pitch, 1=roll, 2=yaw).
+	 * This is for roll/pitch only (tilt), e_R(2) is 0 */
 	math::Vector<3> e_R = R.transposed() * (R_z % R_sp_z);
 
 	/* calculate angle error */
-	float e_R_z_sin = e_R.length();
-	float e_R_z_cos = R_z * R_sp_z;
+	float e_R_z_sin = e_R.length(); // == sin(tilt angle error)
+	float e_R_z_cos = R_z * R_sp_z; // == cos(tilt angle error) == (R.transposed() * R_sp)(2, 2)
 
 	/* calculate weight for yaw control */
 	float yaw_w = R_sp(2, 2) * R_sp(2, 2);
@@ -888,9 +889,10 @@ MulticopterAttitudeControl::control_attitude(float dt)
 		R_rp = R;
 	}
 
-	/* R_rp and R_sp has the same Z axis, calculate yaw error */
+	/* R_rp and R_sp have the same Z axis, calculate yaw error */
 	math::Vector<3> R_sp_x(R_sp(0, 0), R_sp(1, 0), R_sp(2, 0));
 	math::Vector<3> R_rp_x(R_rp(0, 0), R_rp(1, 0), R_rp(2, 0));
+	/* calculate the angle between R_rp_x and R_sp_x (yaw angle error), and apply the yaw weight */
 	e_R(2) = atan2f((R_rp_x % R_sp_x) * R_sp_z, R_rp_x * R_sp_x) * yaw_w;
 
 	if (e_R_z_cos < 0.0f) {

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -908,6 +908,18 @@ MulticopterAttitudeControl::control_attitude(float dt)
 	/* calculate angular rates setpoint */
 	_rates_sp = _params.att_p.emult(e_R);
 
+
+	/* Feed forward the yaw setpoint rate. We need to transform the yaw from world into body frame.
+	 * The following is a simplification of:
+	 * R.transposed() * math::Vector<3>(0.f, 0.f, _v_att_sp.yaw_sp_move_rate * _params.yaw_ff)
+	 */
+	math::Vector<3> yaw_feedforward_rate(R(2, 0), R(2, 1), R(2, 2));
+	yaw_feedforward_rate *= _v_att_sp.yaw_sp_move_rate * _params.yaw_ff;
+
+	yaw_feedforward_rate(2) *= yaw_w;
+	_rates_sp += yaw_feedforward_rate;
+
+
 	/* limit rates */
 	for (int i = 0; i < 3; i++) {
 		if ((_v_control_mode.flag_control_velocity_enabled || _v_control_mode.flag_control_auto_enabled) &&
@@ -918,9 +930,6 @@ MulticopterAttitudeControl::control_attitude(float dt)
 			_rates_sp(i) = math::constrain(_rates_sp(i), -_params.mc_rate_max(i), _params.mc_rate_max(i));
 		}
 	}
-
-	/* feed forward yaw setpoint rate */
-	_rates_sp(2) += _v_att_sp.yaw_sp_move_rate * yaw_w * _params.yaw_ff;
 
 	/* weather-vane mode, dampen yaw rate */
 	if ((_v_control_mode.flag_control_velocity_enabled || _v_control_mode.flag_control_auto_enabled) &&

--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -307,11 +307,16 @@ PARAM_DEFINE_FLOAT(MC_YAW_FF, 0.5f);
 /**
  * Max roll rate
  *
- * Limit for roll rate, has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation.
+ * Limit for roll rate in manual and auto modes (except acro).
+ * Has effect for large rotations in autonomous mode, to avoid large control
+ * output and mixer saturation.
+ *
+ * This is not only limited by the vehicle's properties, but also by the maximum
+ * measurement rate of the gyro.
  *
  * @unit deg/s
  * @min 0.0
- * @max 360.0
+ * @max 1800.0
  * @decimal 1
  * @increment 5
  * @group Multicopter Attitude Control
@@ -321,11 +326,16 @@ PARAM_DEFINE_FLOAT(MC_ROLLRATE_MAX, 220.0f);
 /**
  * Max pitch rate
  *
- * Limit for pitch rate, has effect for large rotations in autonomous mode, to avoid large control output and mixer saturation.
+ * Limit for pitch rate in manual and auto modes (except acro).
+ * Has effect for large rotations in autonomous mode, to avoid large control
+ * output and mixer saturation.
+ *
+ * This is not only limited by the vehicle's properties, but also by the maximum
+ * measurement rate of the gyro.
  *
  * @unit deg/s
  * @min 0.0
- * @max 360.0
+ * @max 1800.0
  * @decimal 1
  * @increment 5
  * @group Multicopter Attitude Control
@@ -335,11 +345,9 @@ PARAM_DEFINE_FLOAT(MC_PITCHRATE_MAX, 220.0f);
 /**
  * Max yaw rate
  *
- * A value of significantly over 120 degrees per second can already lead to mixer saturation.
- *
  * @unit deg/s
  * @min 0.0
- * @max 360.0
+ * @max 1800.0
  * @decimal 1
  * @increment 5
  * @group Multicopter Attitude Control
@@ -350,13 +358,11 @@ PARAM_DEFINE_FLOAT(MC_YAWRATE_MAX, 200.0f);
  * Max yaw rate in auto mode
  *
  * Limit for yaw rate, has effect for large rotations in autonomous mode,
- * to avoid large control output and mixer saturation. A value of significantly
- * over 60 degrees per second can already lead to mixer saturation.
- * A value of 30 degrees / second is recommended to avoid very audible twitches.
+ * to avoid large control output and mixer saturation.
  *
  * @unit deg/s
  * @min 0.0
- * @max 120.0
+ * @max 360.0
  * @decimal 1
  * @increment 5
  * @group Multicopter Attitude Control

--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -373,7 +373,7 @@ PARAM_DEFINE_FLOAT(MC_YAWRAUTO_MAX, 45.0f);
  * @increment 5
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MC_ACRO_R_MAX, 360.0f);
+PARAM_DEFINE_FLOAT(MC_ACRO_R_MAX, 120.0f);
 
 /**
  * Max acro pitch rate
@@ -385,7 +385,7 @@ PARAM_DEFINE_FLOAT(MC_ACRO_R_MAX, 360.0f);
  * @increment 5
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 360.0f);
+PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 120.0f);
 
 /**
  * Max acro yaw rate
@@ -397,7 +397,7 @@ PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 360.0f);
  * @increment 5
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MC_ACRO_Y_MAX, 360.0f);
+PARAM_DEFINE_FLOAT(MC_ACRO_Y_MAX, 120.0f);
 
 /**
  * Threshold for Rattitude mode

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -341,7 +341,7 @@ PARAM_DEFINE_FLOAT(MPC_TKO_SPEED, 1.5f);
  *
  * @unit deg
  * @min 0.0
- * @max 85.0
+ * @max 90.0
  * @decimal 1
  * @group Multicopter Position Control
  */


### PR DESCRIPTION
This brings some fixes for the MC attitude controller - in particular it fixes the slow yaw convergence from #7949 (there is one more remaining problem and I'll update the issue).

This does:
- fix the yaw feedforwarding (there was a transformation missing from world to body frame)
- fix computation of yaw weight for attitude control. Previously, the yaw weight was based on the tilt angle of the attitude setpoint (R_sp(2, 2) == cos(tilt angle)). This makes no sense, it means the weight is low for high tilt angles even if there is no roll-pitch error at all.
    This PR changes the weight computation to be based on the tilt angle error: the yaw weight is 1 if there is no roll-pitch error (independent from current tilt angle), and is reduced for higher tilt angle errors.
    The weight was added in 05e9a30573f50dd271f10, without any explanation or derivation of how and why the weight is chosen that way.
- remove the hardcoded max throttle limit of 0.9 for ACRO

Further infos are in the commit messages.

Some test flights:
- https://logs.px4.io/plot_app?log=1adf352b-9e6d-4754-8665-5967c87cf00f
- https://logs.px4.io/plot_app?log=58f771d6-0793-482a-afbe-c12ecfdc748d

These tests include the mixer saturation improvements (https://github.com/PX4/Firmware/pull/7920) and I disabled the roll-pitch correction in presence of large yaw errors (see #7949).
I used a maximum tilt angle of 65 degrees and it flies really well. The only thing is that the yaw can go off if you do very fast roll-pitch changes, but this is expected, since the roll & pitch correction take precedence in these cases.

@MaEtUgR plans to implement his attitude controller, then we can compare both.

I'm aware that these are changes at critical places, so careful reviewing and testing is mandatory.