### PR TITLE
minor param cleanup, move params into relevant module

### DIFF
--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -310,7 +310,7 @@ CameraTrigger::CameraTrigger() :
 	     _camera_interface_mode == CAMERA_INTERFACE_MODE_SEAGULL_MAP2_PWM)) {
 		_activation_time = 40.0f;
 		PX4_WARN("Trigger interval too low for PWM interface, setting to 40 ms");
-		param_set(_p_activation_time, &(_activation_time));
+		param_set_no_notification(_p_activation_time, &(_activation_time));
 	}
 
 	// Advertise critical publishers here, because we cannot advertise in interrupt context
@@ -588,7 +588,7 @@ CameraTrigger::cycle_trampoline(void *arg)
 
 			if (cmd.param1 > 0.0f) {
 				trig->_distance = cmd.param1;
-				param_set(trig->_p_distance, &(trig->_distance));
+				param_set_no_notification(trig->_p_distance, &(trig->_distance));
 
 				trig->_trigger_enabled = true;
 				trig->_trigger_paused = false;
@@ -604,7 +604,7 @@ CameraTrigger::cycle_trampoline(void *arg)
 			if (cmd.param2 > 0.0f) {
 				if (trig->_camera_interface_mode == CAMERA_INTERFACE_MODE_GPIO) {
 					trig->_activation_time = cmd.param2;
-					param_set(trig->_p_activation_time, &(trig->_activation_time));
+					param_set_no_notification(trig->_p_activation_time, &(trig->_activation_time));
 				}
 			}
 
@@ -622,14 +622,14 @@ CameraTrigger::cycle_trampoline(void *arg)
 
 			if (cmd.param1 > 0.0f) {
 				trig->_interval = cmd.param1;
-				param_set(trig->_p_interval, &(trig->_interval));
+				param_set_no_notification(trig->_p_interval, &(trig->_interval));
 			}
 
 			// We can only control the shutter integration time of the camera in GPIO mode
 			if (cmd.param2 > 0.0f) {
 				if (trig->_camera_interface_mode == CAMERA_INTERFACE_MODE_GPIO) {
 					trig->_activation_time = cmd.param2;
-					param_set(trig->_p_activation_time, &(trig->_activation_time));
+					param_set_no_notification(trig->_p_activation_time, &(trig->_activation_time));
 				}
 			}
 

--- a/src/drivers/ll40ls/parameters.c
+++ b/src/drivers/ll40ls/parameters.c
@@ -1,0 +1,45 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Lidar-Lite (LL40LS)
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 2
+ * @group Sensor Enable
+ * @value 0 Disabled
+ * @value 1 PWM
+ * @value 2 I2C
+ */
+PARAM_DEFINE_INT32(SENS_EN_LL40LS, 0);

--- a/src/drivers/mb12xx/parameters.c
+++ b/src/drivers/mb12xx/parameters.c
@@ -1,0 +1,42 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Maxbotix Sonar (mb12xx)
+ *
+ * @reboot_required true
+ *
+ * @boolean
+ * @group Sensor Enable
+ */
+PARAM_DEFINE_INT32(SENS_EN_MB12XX, 0);

--- a/src/drivers/px4io/px4io_params.c
+++ b/src/drivers/px4io/px4io_params.c
@@ -306,3 +306,12 @@ PARAM_DEFINE_INT32(RC_RSSI_PWM_MAX, 1000);
  *
  */
 PARAM_DEFINE_INT32(RC_RSSI_PWM_MIN, 2000);
+
+/**
+ * Scaling factor for battery voltage sensor on PX4IO.
+ *
+ * @min 1
+ * @max 100000
+ * @group Battery Calibration
+ */
+PARAM_DEFINE_INT32(BAT_V_SCALE_IO, 10000);

--- a/src/drivers/sf0x/parameters.c
+++ b/src/drivers/sf0x/parameters.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Lightware laser rangefinder (serial)
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 4
+ * @group Sensor Enable
+ * @value 0 Disabled
+ * @value 1 SF02
+ * @value 2 SF10/a
+ * @value 3 SF10/b
+ * @value 4 SF10/c
+ * @value 5 SF11/c
+ */
+PARAM_DEFINE_INT32(SENS_EN_SF0X, 0);

--- a/src/drivers/sf1xx/parameters.c
+++ b/src/drivers/sf1xx/parameters.c
@@ -1,0 +1,48 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Lightware SF1xx/SF20/LW20 laser rangefinder (i2c)
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 5
+ * @group Sensor Enable
+ * @value 0 Disabled
+ * @value 1 SF10/a
+ * @value 2 SF10/b
+ * @value 3 SF10/c
+ * @value 4 SF11/c
+ * @value 5 SF/LW20
+ */
+PARAM_DEFINE_INT32(SENS_EN_SF1XX, 0);

--- a/src/drivers/stm32/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/stm32/tone_alarm/tone_alarm.cpp
@@ -402,7 +402,7 @@ ToneAlarm::ToneAlarm() :
 	_user_tune(nullptr),
 	_tune(nullptr),
 	_next(nullptr),
-	_cbrk(CBRK_OFF)
+	_cbrk(CBRK_UNINIT)
 {
 	_default_tunes[TONE_STARTUP_TUNE] = "MFT240L8 O4aO5dc O4aO5dc O4aO5dc L16dcdcdcdc";		// startup tune
 	_default_tunes[TONE_ERROR_TUNE] = "MBT200a8a8a8PaaaP";						// ERROR tone

--- a/src/drivers/teraranger/parameters.c
+++ b/src/drivers/teraranger/parameters.c
@@ -1,0 +1,46 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * TeraRanger Rangefinder (i2c)
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 3
+ * @group Sensor Enable
+ * @value 0 Disabled
+ * @value 1 Autodetect
+ * @value 2 TROne
+ * @value 3 TREvo
+ */
+PARAM_DEFINE_INT32(SENS_EN_TRANGER, 0);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -45,54 +45,6 @@
 #include <systemlib/param/param.h>
 
 /**
- * Roll trim
- *
- * The trim value is the actuator control value the system needs
- * for straight and level flight. It can be calibrated by
- * flying manually straight and level using the RC trims and
- * copying them using the GCS.
- *
- * @group Radio Calibration
- * @min -0.25
- * @max 0.25
- * @decimal 2
- * @increment 0.01
- */
-PARAM_DEFINE_FLOAT(TRIM_ROLL, 0.0f);
-
-/**
- * Pitch trim
- *
- * The trim value is the actuator control value the system needs
- * for straight and level flight. It can be calibrated by
- * flying manually straight and level using the RC trims and
- * copying them using the GCS.
- *
- * @group Radio Calibration
- * @min -0.25
- * @max 0.25
- * @decimal 2
- * @increment 0.01
- */
-PARAM_DEFINE_FLOAT(TRIM_PITCH, 0.0f);
-
-/**
- * Yaw trim
- *
- * The trim value is the actuator control value the system needs
- * for straight and level flight. It can be calibrated by
- * flying manually straight and level using the RC trims and
- * copying them using the GCS.
- *
- * @group Radio Calibration
- * @min -0.25
- * @max 0.25
- * @decimal 2
- * @increment 0.01
- */
-PARAM_DEFINE_FLOAT(TRIM_YAW, 0.0f);
-
-/**
  * Datalink loss time threshold
  *
  * After this amount of seconds without datalink the data link lost mode triggers

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -326,11 +326,10 @@ PARAM_DEFINE_FLOAT(COM_OF_LOSS_T, 0.0f);
  * The offboard loss failsafe will only be entered after a timeout,
  * set by COM_OF_LOSS_T in seconds.
  *
+ * @group Commander
  * @value 0 Land at current position
  * @value 1 Loiter
  * @value 2 Return to Land
- *
- * @group Mission
  */
 PARAM_DEFINE_INT32(COM_OBL_ACT, 0);
 
@@ -340,13 +339,13 @@ PARAM_DEFINE_INT32(COM_OBL_ACT, 0);
  * The offboard loss failsafe will only be entered after a timeout,
  * set by COM_OF_LOSS_T in seconds.
  *
+ * @group Commander
  * @value 0 Position control
  * @value 1 Altitude control
  * @value 2 Manual
  * @value 3 Return to Land
  * @value 4 Land at current position
  * @value 5 Loiter
- * @group Mission
  */
 PARAM_DEFINE_INT32(COM_OBL_RC_ACT, 0);
 
@@ -626,15 +625,14 @@ PARAM_DEFINE_INT32(COM_ARM_MIS_REQ, 0);
  * This sets the flight mode that will be used if navigation accuracy is no longer adequte for position control.
  * Navigation accuracy checks can be disabled using the CBRK_VELPOSERR parameter, but doing so will remove protection for all flight modes.
  *
+ * @group Commander
  * @value 0 Assume use of remote control after fallback. Switch to ALTCTL if a height estimate is available, else switch to MANUAL.
  * @value 1 Assume no use of remote control after fallback. Switch to DESCEND if a height estimate is available, else switch to TERMINATION.
- *
- * @group Mission
  */
 PARAM_DEFINE_INT32(COM_POSCTL_NAVL, 0);
 
 /**
- * Arm authorization parameters, this uint32_t will be splitted between starting from the LSB:
+ * Arm authorization parameters, this uint32_t will be split between starting from the LSB:
  * - 8bits to authorizer system id
  * - 16bits to authentication method parameter, this will be used to store a timeout for the first 2 methods but can be used to another parameter for other new authentication methods.
  * - 7bits to authentication method

--- a/src/modules/commander/gyro_calibration.cpp
+++ b/src/modules/commander/gyro_calibration.cpp
@@ -499,13 +499,6 @@ int do_gyro_calibration(orb_advert_t *mavlink_log_pub)
 		}
 	}
 
-	/* store board ID */
-	uuid_uint32_t mcu_id;
-	board_get_uuid32(mcu_id);
-
-	/* store last 32bit number - not unique, but unique in a given set */
-	(void)param_set(param_find("CAL_BOARD_ID"), &mcu_id[PX4_CPU_UUID_WORD32_UNIQUE_H]);
-
 	/* if there is a any preflight-check system response, let the barrage of messages through */
 	usleep(200000);
 

--- a/src/modules/load_mon/parameters.c
+++ b/src/modules/load_mon/parameters.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Enable stack checking
+ *
+ * @boolean
+ * @group System
+ */
+PARAM_DEFINE_INT32(SYS_STCK_EN, 1);

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2478,7 +2478,7 @@ void Mavlink::check_radio_config()
 
 		/* reset param and save */
 		_radio_id = 0;
-		param_set(_param_radio_id, &_radio_id);
+		param_set_no_notification(_param_radio_id, &_radio_id);
 	}
 }
 

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -608,9 +608,6 @@ void Mavlink::mavlink_update_system()
 		_param_use_hil_gps = param_find("MAV_USEHILGPS");
 		_param_forward_externalsp = param_find("MAV_FWDEXTSP");
 		_param_broadcast = param_find("MAV_BROADCAST");
-
-		/* test param - needs to be referenced, but is unused */
-		(void)param_find("MAV_TEST_PAR");
 	}
 
 	/* update system and component id */

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -150,16 +150,6 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 					/* set and send parameter */
 					param_set(param, &(set.param_value));
 					send_param(param);
-
-					/* check for deprecated value, coming from an older GCS */
-					if (strcmp(name, "SYS_MC_EST_GROUP") == 0) {
-						uint32_t val = *(uint32_t *)&set.param_value;
-
-						if (val == 0) { //INAV
-							mavlink_log_critical(_mavlink->get_mavlink_log_pub(),
-									     "INAV is deprecated. Using LPE after reboot");
-						}
-					}
 				}
 			}
 

--- a/src/modules/mavlink/mavlink_params.c
+++ b/src/modules/mavlink/mavlink_params.c
@@ -112,15 +112,3 @@ PARAM_DEFINE_INT32(MAV_FWDEXTSP, 1);
  * @group MAVLink
  */
 PARAM_DEFINE_INT32(MAV_BROADCAST, 0);
-
-/**
- * Test parameter
- *
- * This parameter is not actively used by the system. Its purpose is to allow
- * testing the parameter interface on the communication level.
- *
- * @group MAVLink
- * @min -1000
- * @max 1000
- */
-PARAM_DEFINE_INT32(MAV_TEST_PAR, 1);

--- a/src/modules/mavlink/mavlink_params.c
+++ b/src/modules/mavlink/mavlink_params.c
@@ -76,6 +76,35 @@ PARAM_DEFINE_INT32(MAV_RADIO_ID, 0);
  * MAVLink airframe type
  *
  * @min 1
+ * @max 27
+ * @value 0 Generic micro air vehicle
+ * @value 1 Fixed wing aircraft
+ * @value 2 Quadrotor
+ * @value 3 Coaxial helicopter
+ * @value 4 Normal helicopter with tail rotor
+ * @value 5 Ground installation
+ * @value 6 Operator control unit / ground control station
+ * @value 7 Airship, controlled
+ * @value 8 Free balloon, uncontrolled
+ * @value 9 Rocket
+ * @value 10 Ground rover
+ * @value 11 Surface vessel, boat, ship
+ * @value 12 Submarine
+ * @value 13 Hexarotor
+ * @value 14 Octorotor
+ * @value 15 Tricopter
+ * @value 16 Flapping wing
+ * @value 17 Kite
+ * @value 18 Onboard companion controller
+ * @value 19 Two-rotor VTOL using control surfaces in vertical operation in addition. Tailsitter.
+ * @value 20 Quad-rotor VTOL using a V-shaped quad config in vertical operation. Tailsitter.
+ * @value 21 Tiltrotor VTOL
+ * @value 22 VTOL reserved 2
+ * @value 23 VTOL reserved 3
+ * @value 24 VTOL reserved 4
+ * @value 25 VTOL reserved 5
+ * @value 26 Onboard gimbal
+ * @value 27 Onboard ADSB peripheral
  * @group MAVLink
  */
 PARAM_DEFINE_INT32(MAV_TYPE, 2);

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -253,6 +253,7 @@ PARAM_DEFINE_FLOAT(MPC_XY_CRUISE, 5.0f);
  *
  * @unit m/s
  * @min 1.0
+ * @max 20.0
  * @increment 1
  * @decimal 2
  * @group Multicopter Position Control

--- a/src/modules/navigator/rcloss_params.c
+++ b/src/modules/navigator/rcloss_params.c
@@ -44,15 +44,16 @@
  */
 
 /**
- * Loiter Time
+ * RC Loss Loiter Time (CASA Outback Challenge rules)
  *
- * The amount of time in seconds the system should loiter at current position before termination
- * Set to -1 to make the system skip loitering
+ * The amount of time in seconds the system should loiter at current position before termination.
+ * Only applies if NAV_RCL_ACT is set to 2 (CASA Outback Challenge rules).
+ * Set to -1 to make the system skip loitering.
  *
  * @unit s
  * @min -1.0
  * @decimal 1
  * @increment 0.1
- * @group Radio Signal Loss
+ * @group Mission
  */
 PARAM_DEFINE_FLOAT(NAV_RCL_LT, 120.0f);

--- a/src/modules/sensors/parameters.cpp
+++ b/src/modules/sensors/parameters.cpp
@@ -42,7 +42,7 @@
 namespace sensors
 {
 
-int initialize_parameter_handles(ParameterHandles &parameter_handles)
+void initialize_parameter_handles(ParameterHandles &parameter_handles)
 {
 	/* basic r/c parameters */
 	for (unsigned i = 0; i < RC_MAX_CHAN_COUNT; i++) {
@@ -164,90 +164,21 @@ int initialize_parameter_handles(ParameterHandles &parameter_handles)
 
 	// These are parameters for which QGroundControl always expects to be returned in a list request.
 	// We do a param_find here to force them into the list.
-	(void)param_find("RC_CHAN_CNT");
-	(void)param_find("RC_TH_USER");
+
 	(void)param_find("CAL_ACC0_ID");
 	(void)param_find("CAL_GYRO0_ID");
 	(void)param_find("CAL_MAG0_ID");
-	(void)param_find("CAL_MAG1_ID");
-	(void)param_find("CAL_MAG2_ID");
-	(void)param_find("CAL_MAG3_ID");
 	(void)param_find("CAL_MAG0_ROT");
+	(void)param_find("CAL_MAG1_ID");
 	(void)param_find("CAL_MAG1_ROT");
+	(void)param_find("CAL_MAG2_ID");
 	(void)param_find("CAL_MAG2_ROT");
+	(void)param_find("CAL_MAG3_ID");
 	(void)param_find("CAL_MAG3_ROT");
 	(void)param_find("CAL_MAG_SIDES");
 
-	(void)param_find("CAL_MAG1_XOFF");
-	(void)param_find("CAL_MAG1_XSCALE");
-	(void)param_find("CAL_MAG1_YOFF");
-	(void)param_find("CAL_MAG1_YSCALE");
-	(void)param_find("CAL_MAG1_ZOFF");
-	(void)param_find("CAL_MAG1_ZSCALE");
-
-	(void)param_find("CAL_MAG2_XOFF");
-	(void)param_find("CAL_MAG2_XSCALE");
-	(void)param_find("CAL_MAG2_YOFF");
-	(void)param_find("CAL_MAG2_YSCALE");
-	(void)param_find("CAL_MAG2_ZOFF");
-	(void)param_find("CAL_MAG2_ZSCALE");
-
-	(void)param_find("CAL_MAG3_XOFF");
-	(void)param_find("CAL_MAG3_XSCALE");
-	(void)param_find("CAL_MAG3_YOFF");
-	(void)param_find("CAL_MAG3_YSCALE");
-	(void)param_find("CAL_MAG3_ZOFF");
-	(void)param_find("CAL_MAG3_ZSCALE");
-
-	(void)param_find("CAL_GYRO1_XOFF");
-	(void)param_find("CAL_GYRO1_XSCALE");
-	(void)param_find("CAL_GYRO1_YOFF");
-	(void)param_find("CAL_GYRO1_YSCALE");
-	(void)param_find("CAL_GYRO1_ZOFF");
-	(void)param_find("CAL_GYRO1_ZSCALE");
-
-	(void)param_find("CAL_GYRO2_XOFF");
-	(void)param_find("CAL_GYRO2_XSCALE");
-	(void)param_find("CAL_GYRO2_YOFF");
-	(void)param_find("CAL_GYRO2_YSCALE");
-	(void)param_find("CAL_GYRO2_ZOFF");
-	(void)param_find("CAL_GYRO2_ZSCALE");
-
-	(void)param_find("CAL_ACC1_XOFF");
-	(void)param_find("CAL_ACC1_XSCALE");
-	(void)param_find("CAL_ACC1_YOFF");
-	(void)param_find("CAL_ACC1_YSCALE");
-	(void)param_find("CAL_ACC1_ZOFF");
-	(void)param_find("CAL_ACC1_ZSCALE");
-
-	(void)param_find("CAL_ACC2_XOFF");
-	(void)param_find("CAL_ACC2_XSCALE");
-	(void)param_find("CAL_ACC2_YOFF");
-	(void)param_find("CAL_ACC2_YSCALE");
-	(void)param_find("CAL_ACC2_ZOFF");
-	(void)param_find("CAL_ACC2_ZSCALE");
-
-	(void)param_find("SYS_PARAM_VER");
-	(void)param_find("SYS_AUTOSTART");
-	(void)param_find("SYS_AUTOCONFIG");
-	(void)param_find("SYS_HITL");
-	(void)param_find("PWM_RATE");
-	(void)param_find("PWM_MIN");
-	(void)param_find("PWM_MAX");
-	(void)param_find("PWM_DISARMED");
-	(void)param_find("PWM_AUX_MIN");
-	(void)param_find("PWM_AUX_MAX");
-	(void)param_find("PWM_AUX_DISARMED");
-	(void)param_find("TRIG_MODE");
-	(void)param_find("UAVCAN_ENABLE");
-	(void)param_find("SYS_MC_EST_GROUP");
-
-	// Parameters controlling the on-board sensor thermal calibrator
-	(void)param_find("SYS_CAL_TDEL");
-	(void)param_find("SYS_CAL_TMAX");
-	(void)param_find("SYS_CAL_TMIN");
-
-	return 0;
+	(void)param_find("RC_CHAN_CNT");
+	(void)param_find("RC_TH_USER");
 }
 
 int update_parameters(const ParameterHandles &parameter_handles, Parameters &parameters)

--- a/src/modules/sensors/parameters.cpp
+++ b/src/modules/sensors/parameters.cpp
@@ -178,6 +178,9 @@ void initialize_parameter_handles(ParameterHandles &parameter_handles)
 	(void)param_find("CAL_MAG_SIDES");
 
 	(void)param_find("RC_CHAN_CNT");
+
+	(void)param_find("SYS_AUTOCONFIG");
+	(void)param_find("SYS_AUTOSTART");
 }
 
 int update_parameters(const ParameterHandles &parameter_handles, Parameters &parameters)

--- a/src/modules/sensors/parameters.cpp
+++ b/src/modules/sensors/parameters.cpp
@@ -178,7 +178,6 @@ void initialize_parameter_handles(ParameterHandles &parameter_handles)
 	(void)param_find("CAL_MAG_SIDES");
 
 	(void)param_find("RC_CHAN_CNT");
-	(void)param_find("RC_TH_USER");
 }
 
 int update_parameters(const ParameterHandles &parameter_handles, Parameters &parameters)

--- a/src/modules/sensors/parameters.cpp
+++ b/src/modules/sensors/parameters.cpp
@@ -135,7 +135,9 @@ int initialize_parameter_handles(ParameterHandles &parameter_handles)
 
 	/* Differential pressure offset */
 	parameter_handles.diff_pres_offset_pa = param_find("SENS_DPRES_OFF");
+#ifdef ADC_AIRSPEED_VOLTAGE_CHANNEL
 	parameter_handles.diff_pres_analog_scale = param_find("SENS_DPRES_ANSC");
+#endif /* ADC_AIRSPEED_VOLTAGE_CHANNEL */
 
 	parameter_handles.battery_voltage_scaling = param_find("BAT_CNT_V_VOLT");
 	parameter_handles.battery_current_scaling = param_find("BAT_CNT_V_CURR");
@@ -430,7 +432,9 @@ int update_parameters(const ParameterHandles &parameter_handles, Parameters &par
 
 	/* Airspeed offset */
 	param_get(parameter_handles.diff_pres_offset_pa, &(parameters.diff_pres_offset_pa));
+#ifdef ADC_AIRSPEED_VOLTAGE_CHANNEL
 	param_get(parameter_handles.diff_pres_analog_scale, &(parameters.diff_pres_analog_scale));
+#endif /* ADC_AIRSPEED_VOLTAGE_CHANNEL */
 
 	/* scaling of ADC ticks to battery voltage */
 	if (param_get(parameter_handles.battery_voltage_scaling, &(parameters.battery_voltage_scaling)) != OK) {

--- a/src/modules/sensors/parameters.cpp
+++ b/src/modules/sensors/parameters.cpp
@@ -181,6 +181,12 @@ void initialize_parameter_handles(ParameterHandles &parameter_handles)
 
 	(void)param_find("SYS_AUTOCONFIG");
 	(void)param_find("SYS_AUTOSTART");
+	(void)param_find("SYS_PARAM_VER");
+
+	// Parameters controlling the on-board sensor thermal calibrator
+	(void)param_find("SYS_CAL_TDEL");
+	(void)param_find("SYS_CAL_TMAX");
+	(void)param_find("SYS_CAL_TMIN");
 }
 
 int update_parameters(const ParameterHandles &parameter_handles, Parameters &parameters)

--- a/src/modules/sensors/parameters.cpp
+++ b/src/modules/sensors/parameters.cpp
@@ -373,7 +373,7 @@ int update_parameters(const ParameterHandles &parameter_handles, Parameters &par
 	} else if (parameters.battery_voltage_scaling < 0.0f) {
 		/* apply scaling according to defaults if set to default */
 		parameters.battery_voltage_scaling = (3.3f / 4096);
-		param_set(parameter_handles.battery_voltage_scaling, &parameters.battery_voltage_scaling);
+		param_set_no_notification(parameter_handles.battery_voltage_scaling, &parameters.battery_voltage_scaling);
 	}
 
 	/* scaling of ADC ticks to battery current */
@@ -383,7 +383,7 @@ int update_parameters(const ParameterHandles &parameter_handles, Parameters &par
 	} else if (parameters.battery_current_scaling < 0.0f) {
 		/* apply scaling according to defaults if set to default */
 		parameters.battery_current_scaling = (3.3f / 4096);
-		param_set(parameter_handles.battery_current_scaling, &parameters.battery_current_scaling);
+		param_set_no_notification(parameter_handles.battery_current_scaling, &parameters.battery_current_scaling);
 	}
 
 	if (param_get(parameter_handles.battery_current_offset, &(parameters.battery_current_offset)) != OK) {
@@ -399,7 +399,7 @@ int update_parameters(const ParameterHandles &parameter_handles, Parameters &par
 		/* apply scaling according to defaults if set to default */
 
 		parameters.battery_v_div = BOARD_BATTERY1_V_DIV;
-		param_set(parameter_handles.battery_v_div, &parameters.battery_v_div);
+		param_set_no_notification(parameter_handles.battery_v_div, &parameters.battery_v_div);
 	}
 
 	if (param_get(parameter_handles.battery_a_per_v, &(parameters.battery_a_per_v)) != OK) {
@@ -410,7 +410,7 @@ int update_parameters(const ParameterHandles &parameter_handles, Parameters &par
 		/* apply scaling according to defaults if set to default */
 
 		parameters.battery_a_per_v = BOARD_BATTERY1_A_PER_V;
-		param_set(parameter_handles.battery_a_per_v, &parameters.battery_a_per_v);
+		param_set_no_notification(parameter_handles.battery_a_per_v, &parameters.battery_a_per_v);
 	}
 
 	param_get(parameter_handles.battery_source, &(parameters.battery_source));

--- a/src/modules/sensors/parameters.h
+++ b/src/modules/sensors/parameters.h
@@ -247,7 +247,7 @@ void initialize_parameter_handles(ParameterHandles &parameter_handles);
 
 /**
  * Read out the parameters using the handles into the parameters struct.
- * @return 0 on succes, <0 on error
+ * @return 0 on success, <0 on error
  */
 int update_parameters(const ParameterHandles &parameter_handles, Parameters &parameters);
 

--- a/src/modules/sensors/parameters.h
+++ b/src/modules/sensors/parameters.h
@@ -241,9 +241,8 @@ struct ParameterHandles {
 
 /**
  * initialize ParameterHandles struct
- * @return 0 on succes, <0 on error
  */
-int initialize_parameter_handles(ParameterHandles &parameter_handles);
+void initialize_parameter_handles(ParameterHandles &parameter_handles);
 
 
 /**

--- a/src/modules/sensors/parameters.h
+++ b/src/modules/sensors/parameters.h
@@ -64,7 +64,9 @@ struct Parameters {
 	float scaling_factor[RC_MAX_CHAN_COUNT];
 
 	float diff_pres_offset_pa;
+#ifdef ADC_AIRSPEED_VOLTAGE_CHANNEL
 	float diff_pres_analog_scale;
+#endif /* ADC_AIRSPEED_VOLTAGE_CHANNEL */
 
 	int board_rotation;
 
@@ -159,7 +161,9 @@ struct ParameterHandles {
 	param_t dz[RC_MAX_CHAN_COUNT];
 
 	param_t diff_pres_offset_pa;
+#ifdef ADC_AIRSPEED_VOLTAGE_CHANNEL
 	param_t diff_pres_analog_scale;
+#endif /* ADC_AIRSPEED_VOLTAGE_CHANNEL */
 
 	param_t rc_map_roll;
 	param_t rc_map_pitch;

--- a/src/modules/sensors/rc_params.c
+++ b/src/modules/sensors/rc_params.c
@@ -1111,21 +1111,6 @@ PARAM_DEFINE_INT32(RC_RL1_DSM_VCC, 0); /* Relay 1 controls DSM VCC */
 PARAM_DEFINE_INT32(RC_CHAN_CNT, 0);
 
 /**
- * RC mode switch threshold automatic distribution
- *
- * This parameter is used by Ground Station software to specify whether
- * the threshold values for flight mode switches were automatically calculated.
- * 0 indicates that the threshold values were set by the user. Any other value
- * indicates that the threshold value where automatically set by the ground
- * station software. It is only meant for ground station use.
- *
- * @boolean
- * @group Radio Calibration
- */
-
-PARAM_DEFINE_INT32(RC_TH_USER, 1);
-
-/**
  * Roll control channel mapping.
  *
  * The channel index (starting from 1 for channel 1) indicates

--- a/src/modules/sensors/rc_params.c
+++ b/src/modules/sensors/rc_params.c
@@ -2220,3 +2220,51 @@ PARAM_DEFINE_FLOAT(RC_FLT_SMP_RATE, 50.0f);
  * @group Radio Calibration
  */
 PARAM_DEFINE_FLOAT(RC_FLT_CUTOFF, 10.0f);
+
+/**
+ * Roll trim
+ *
+ * The trim value is the actuator control value the system needs
+ * for straight and level flight. It can be calibrated by
+ * flying manually straight and level using the RC trims and
+ * copying them using the GCS.
+ *
+ * @group Radio Calibration
+ * @min -0.25
+ * @max 0.25
+ * @decimal 2
+ * @increment 0.01
+ */
+PARAM_DEFINE_FLOAT(TRIM_ROLL, 0.0f);
+
+/**
+ * Pitch trim
+ *
+ * The trim value is the actuator control value the system needs
+ * for straight and level flight. It can be calibrated by
+ * flying manually straight and level using the RC trims and
+ * copying them using the GCS.
+ *
+ * @group Radio Calibration
+ * @min -0.25
+ * @max 0.25
+ * @decimal 2
+ * @increment 0.01
+ */
+PARAM_DEFINE_FLOAT(TRIM_PITCH, 0.0f);
+
+/**
+ * Yaw trim
+ *
+ * The trim value is the actuator control value the system needs
+ * for straight and level flight. It can be calibrated by
+ * flying manually straight and level using the RC trims and
+ * copying them using the GCS.
+ *
+ * @group Radio Calibration
+ * @min -0.25
+ * @max 0.25
+ * @decimal 2
+ * @increment 0.01
+ */
+PARAM_DEFINE_FLOAT(TRIM_YAW, 0.0f);

--- a/src/modules/sensors/rc_params.c
+++ b/src/modules/sensors/rc_params.c
@@ -81,6 +81,8 @@ PARAM_DEFINE_FLOAT(RC1_MAX, 2000.0f);
  *
  * @min -1.0
  * @max 1.0
+ * @value -1.0 Reverse
+ * @value 1.0 Normal
  * @group Radio Calibration
  */
 PARAM_DEFINE_FLOAT(RC1_REV, 1.0f);
@@ -140,6 +142,8 @@ PARAM_DEFINE_FLOAT(RC2_MAX, 2000.0f);
  *
  * @min -1.0
  * @max 1.0
+ * @value -1.0 Reverse
+ * @value 1.0 Normal
  * @group Radio Calibration
  */
 PARAM_DEFINE_FLOAT(RC2_REV, 1.0f);
@@ -199,9 +203,12 @@ PARAM_DEFINE_FLOAT(RC3_MAX, 2000);
  *
  * @min -1.0
  * @max 1.0
+ * @value -1.0 Reverse
+ * @value 1.0 Normal
  * @group Radio Calibration
  */
 PARAM_DEFINE_FLOAT(RC3_REV, 1.0f);
+
 /**
  * RC channel 3 dead zone
  *
@@ -257,6 +264,8 @@ PARAM_DEFINE_FLOAT(RC4_MAX, 2000);
  *
  * @min -1.0
  * @max 1.0
+ * @value -1.0 Reverse
+ * @value 1.0 Normal
  * @group Radio Calibration
  */
 PARAM_DEFINE_FLOAT(RC4_REV, 1.0f);
@@ -316,6 +325,8 @@ PARAM_DEFINE_FLOAT(RC5_MAX, 2000);
  *
  * @min -1.0
  * @max 1.0
+ * @value -1.0 Reverse
+ * @value 1.0 Normal
  * @group Radio Calibration
  */
 PARAM_DEFINE_FLOAT(RC5_REV, 1.0f);
@@ -374,6 +385,8 @@ PARAM_DEFINE_FLOAT(RC6_MAX, 2000);
  *
  * @min -1.0
  * @max 1.0
+ * @value -1.0 Reverse
+ * @value 1.0 Normal
  * @group Radio Calibration
  */
 PARAM_DEFINE_FLOAT(RC6_REV, 1.0f);
@@ -432,6 +445,8 @@ PARAM_DEFINE_FLOAT(RC7_MAX, 2000);
  *
  * @min -1.0
  * @max 1.0
+ * @value -1.0 Reverse
+ * @value 1.0 Normal
  * @group Radio Calibration
  */
 PARAM_DEFINE_FLOAT(RC7_REV, 1.0f);
@@ -490,6 +505,8 @@ PARAM_DEFINE_FLOAT(RC8_MAX, 2000);
  *
  * @min -1.0
  * @max 1.0
+ * @value -1.0 Reverse
+ * @value 1.0 Normal
  * @group Radio Calibration
  */
 PARAM_DEFINE_FLOAT(RC8_REV, 1.0f);
@@ -548,6 +565,8 @@ PARAM_DEFINE_FLOAT(RC9_MAX, 2000);
  *
  * @min -1.0
  * @max 1.0
+ * @value -1.0 Reverse
+ * @value 1.0 Normal
  * @group Radio Calibration
  */
 PARAM_DEFINE_FLOAT(RC9_REV, 1.0f);
@@ -606,6 +625,8 @@ PARAM_DEFINE_FLOAT(RC10_MAX, 2000);
  *
  * @min -1.0
  * @max 1.0
+ * @value -1.0 Reverse
+ * @value 1.0 Normal
  * @group Radio Calibration
  */
 PARAM_DEFINE_FLOAT(RC10_REV, 1.0f);
@@ -664,6 +685,8 @@ PARAM_DEFINE_FLOAT(RC11_MAX, 2000);
  *
  * @min -1.0
  * @max 1.0
+ * @value -1.0 Reverse
+ * @value 1.0 Normal
  * @group Radio Calibration
  */
 PARAM_DEFINE_FLOAT(RC11_REV, 1.0f);
@@ -722,6 +745,8 @@ PARAM_DEFINE_FLOAT(RC12_MAX, 2000);
  *
  * @min -1.0
  * @max 1.0
+ * @value -1.0 Reverse
+ * @value 1.0 Normal
  * @group Radio Calibration
  */
 PARAM_DEFINE_FLOAT(RC12_REV, 1.0f);
@@ -780,6 +805,8 @@ PARAM_DEFINE_FLOAT(RC13_MAX, 2000);
  *
  * @min -1.0
  * @max 1.0
+ * @value -1.0 Reverse
+ * @value 1.0 Normal
  * @group Radio Calibration
  */
 PARAM_DEFINE_FLOAT(RC13_REV, 1.0f);
@@ -838,6 +865,8 @@ PARAM_DEFINE_FLOAT(RC14_MAX, 2000);
  *
  * @min -1.0
  * @max 1.0
+ * @value -1.0 Reverse
+ * @value 1.0 Normal
  * @group Radio Calibration
  */
 PARAM_DEFINE_FLOAT(RC14_REV, 1.0f);
@@ -896,6 +925,8 @@ PARAM_DEFINE_FLOAT(RC15_MAX, 2000);
  *
  * @min -1.0
  * @max 1.0
+ * @value -1.0 Reverse
+ * @value 1.0 Normal
  * @group Radio Calibration
  */
 PARAM_DEFINE_FLOAT(RC15_REV, 1.0f);
@@ -954,6 +985,8 @@ PARAM_DEFINE_FLOAT(RC16_MAX, 2000);
  *
  * @min -1.0
  * @max 1.0
+ * @value -1.0 Reverse
+ * @value 1.0 Normal
  * @group Radio Calibration
  */
 PARAM_DEFINE_FLOAT(RC16_REV, 1.0f);
@@ -1012,6 +1045,8 @@ PARAM_DEFINE_FLOAT(RC17_MAX, 2000);
  *
  * @min -1.0
  * @max 1.0
+ * @value -1.0 Reverse
+ * @value 1.0 Normal
  * @group Radio Calibration
  */
 PARAM_DEFINE_FLOAT(RC17_REV, 1.0f);
@@ -1070,6 +1105,8 @@ PARAM_DEFINE_FLOAT(RC18_MAX, 2000);
  *
  * @min -1.0
  * @max 1.0
+ * @value -1.0 Reverse
+ * @value 1.0 Normal
  * @group Radio Calibration
  */
 PARAM_DEFINE_FLOAT(RC18_REV, 1.0f);
@@ -1107,7 +1144,6 @@ PARAM_DEFINE_INT32(RC_RL1_DSM_VCC, 0); /* Relay 1 controls DSM VCC */
  * @max 18
  * @group Radio Calibration
  */
-
 PARAM_DEFINE_INT32(RC_CHAN_CNT, 0);
 
 /**
@@ -1963,8 +1999,6 @@ PARAM_DEFINE_INT32(RC_FAILS_THR, 0);
  * @min -1
  * @max 1
  * @group Radio Switches
- *
- *
  */
 PARAM_DEFINE_FLOAT(RC_ASSIST_TH, 0.25f);
 
@@ -1981,8 +2015,6 @@ PARAM_DEFINE_FLOAT(RC_ASSIST_TH, 0.25f);
  * @min -1
  * @max 1
  * @group Radio Switches
- *
- *
  */
 PARAM_DEFINE_FLOAT(RC_AUTO_TH, 0.75f);
 
@@ -1999,7 +2031,6 @@ PARAM_DEFINE_FLOAT(RC_AUTO_TH, 0.75f);
  * @min -1
  * @max 1
  * @group Radio Switches
- *
  */
 PARAM_DEFINE_FLOAT(RC_RATT_TH, 0.5f);
 
@@ -2016,7 +2047,6 @@ PARAM_DEFINE_FLOAT(RC_RATT_TH, 0.5f);
  * @min -1
  * @max 1
  * @group Radio Switches
- *
  */
 PARAM_DEFINE_FLOAT(RC_POSCTL_TH, 0.5f);
 
@@ -2033,8 +2063,6 @@ PARAM_DEFINE_FLOAT(RC_POSCTL_TH, 0.5f);
  * @min -1
  * @max 1
  * @group Radio Switches
- *
- *
  */
 PARAM_DEFINE_FLOAT(RC_RETURN_TH, 0.5f);
 
@@ -2051,8 +2079,6 @@ PARAM_DEFINE_FLOAT(RC_RETURN_TH, 0.5f);
  * @min -1
  * @max 1
  * @group Radio Switches
- *
- *
  */
 PARAM_DEFINE_FLOAT(RC_LOITER_TH, 0.5f);
 
@@ -2069,8 +2095,6 @@ PARAM_DEFINE_FLOAT(RC_LOITER_TH, 0.5f);
  * @min -1
  * @max 1
  * @group Radio Switches
- *
- *
  */
 PARAM_DEFINE_FLOAT(RC_ACRO_TH, 0.5f);
 
@@ -2087,8 +2111,6 @@ PARAM_DEFINE_FLOAT(RC_ACRO_TH, 0.5f);
  * @min -1
  * @max 1
  * @group Radio Switches
- *
- *
  */
 PARAM_DEFINE_FLOAT(RC_OFFB_TH, 0.5f);
 
@@ -2105,8 +2127,6 @@ PARAM_DEFINE_FLOAT(RC_OFFB_TH, 0.5f);
  * @min -1
  * @max 1
  * @group Radio Switches
- *
- *
  */
 PARAM_DEFINE_FLOAT(RC_KILLSWITCH_TH, 0.25f);
 
@@ -2123,8 +2143,6 @@ PARAM_DEFINE_FLOAT(RC_KILLSWITCH_TH, 0.25f);
  * @min -1
  * @max 1
  * @group Radio Switches
- *
- *
  */
 PARAM_DEFINE_FLOAT(RC_ARMSWITCH_TH, 0.25f);
 
@@ -2141,8 +2159,6 @@ PARAM_DEFINE_FLOAT(RC_ARMSWITCH_TH, 0.25f);
  * @min -1
  * @max 1
  * @group Radio Switches
- *
- *
  */
 PARAM_DEFINE_FLOAT(RC_TRANS_TH, 0.25f);
 
@@ -2159,8 +2175,6 @@ PARAM_DEFINE_FLOAT(RC_TRANS_TH, 0.25f);
  * @min -1
  * @max 1
  * @group Radio Switches
- *
- *
  */
 PARAM_DEFINE_FLOAT(RC_GEAR_TH, 0.25f);
 
@@ -2177,8 +2191,6 @@ PARAM_DEFINE_FLOAT(RC_GEAR_TH, 0.25f);
  * @min -1
  * @max 1
  * @group Radio Switches
- *
- *
  */
 PARAM_DEFINE_FLOAT(RC_STAB_TH, 0.5f);
 
@@ -2195,13 +2207,11 @@ PARAM_DEFINE_FLOAT(RC_STAB_TH, 0.5f);
  * @min -1
  * @max 1
  * @group Radio Switches
- *
- *
  */
 PARAM_DEFINE_FLOAT(RC_MAN_TH, 0.5f);
 
 /**
- * Sample rate of the remote control values for the low pass filter on roll,pitch, yaw and throttle
+ * Sample rate of the remote control values for the low pass filter on roll, pitch, yaw and throttle
  *
  * Has an influence on the cutoff frequency precision.
  *
@@ -2212,7 +2222,7 @@ PARAM_DEFINE_FLOAT(RC_MAN_TH, 0.5f);
 PARAM_DEFINE_FLOAT(RC_FLT_SMP_RATE, 50.0f);
 
 /**
- * Cutoff frequency for the low pass filter on roll,pitch, yaw and throttle
+ * Cutoff frequency for the low pass filter on roll, pitch, yaw and throttle
  *
  * Does not get set unless below RC_FLT_SMP_RATE/2 because of filter instability characteristics.
  *

--- a/src/modules/sensors/rc_params.c
+++ b/src/modules/sensors/rc_params.c
@@ -1123,17 +1123,6 @@ PARAM_DEFINE_FLOAT(RC18_REV, 1.0f);
 PARAM_DEFINE_FLOAT(RC18_DZ, 0.0f);
 
 /**
- * Relay control of relay 1 mapped to the Spektrum receiver power supply
- *
- * @min 0
- * @max 1
- * @value 0 Disabled
- * @value 1 Relay controls DSM power
- * @group Radio Calibration
- */
-PARAM_DEFINE_INT32(RC_RL1_DSM_VCC, 0); /* Relay 1 controls DSM VCC */
-
-/**
  * RC channel count
  *
  * This parameter is used by Ground Station software to save the number

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -42,13 +42,6 @@
  */
 
 /**
- * ID of the board this parameter set was calibrated on.
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_BOARD_ID, 0);
-
-/**
  * ID of the Gyro that the calibration is for.
  *
  * @group Sensor Calibration

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -1068,19 +1068,6 @@ PARAM_DEFINE_FLOAT(BAT_A_PER_V, -1.0);
 PARAM_DEFINE_INT32(BAT_SOURCE, 0);
 
 /**
- * Lidar-Lite (LL40LS)
- *
- * @reboot_required true
- * @min 0
- * @max 2
- * @group Sensor Enable
- * @value 0 Disabled
- * @value 1 PWM
- * @value 2 I2C
- */
-PARAM_DEFINE_INT32(SENS_EN_LL40LS, 0);
-
-/**
  * Lightware laser rangefinder (serial)
  *
  * @reboot_required true

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -1068,20 +1068,6 @@ PARAM_DEFINE_FLOAT(BAT_A_PER_V, -1.0);
 PARAM_DEFINE_INT32(BAT_SOURCE, 0);
 
 /**
- * TeraRanger Rangefinder (i2c)
- *
- * @reboot_required true
- * @min 0
- * @max 3
- * @group Sensor Enable
- * @value 0 Disabled
- * @value 1 Autodetect
- * @value 2 TROne
- * @value 3 TREvo
- */
-PARAM_DEFINE_INT32(SENS_EN_TRANGER, 0);
-
-/**
  * Lightware SF1xx/SF20/LW20 laser rangefinder (i2c)
  *
  * @reboot_required true

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -1068,22 +1068,6 @@ PARAM_DEFINE_FLOAT(BAT_A_PER_V, -1.0);
 PARAM_DEFINE_INT32(BAT_SOURCE, 0);
 
 /**
- * Lightware SF1xx/SF20/LW20 laser rangefinder (i2c)
- *
- * @reboot_required true
- * @min 0
- * @max 5
- * @group Sensor Enable
- * @value 0 Disabled
- * @value 1 SF10/a
- * @value 2 SF10/b
- * @value 3 SF10/c
- * @value 4 SF11/c
- * @value 5 SF/LW20
- */
-PARAM_DEFINE_INT32(SENS_EN_SF1XX, 0);
-
-/**
  * Thermal control of sensor temperature
  *
  * @value -1 Thermal control unavailable

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -1068,16 +1068,6 @@ PARAM_DEFINE_FLOAT(BAT_A_PER_V, -1.0);
 PARAM_DEFINE_INT32(BAT_SOURCE, 0);
 
 /**
- * Maxbotix Soanr (mb12xx)
- *
- * @reboot_required true
- *
- * @boolean
- * @group Sensor Enable
- */
-PARAM_DEFINE_INT32(SENS_EN_MB12XX, 0);
-
-/**
  * TeraRanger Rangefinder (i2c)
  *
  * @reboot_required true

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -766,7 +766,6 @@ PARAM_DEFINE_FLOAT(CAL_MAG3_YSCALE, 1.0f);
  */
 PARAM_DEFINE_FLOAT(CAL_MAG3_ZSCALE, 1.0f);
 
-
 /**
  * Primary accel ID
  *
@@ -854,7 +853,7 @@ PARAM_DEFINE_FLOAT(SENS_DPRES_OFF, 0.0f);
  *
  * @group Sensor Calibration
  */
-PARAM_DEFINE_FLOAT(SENS_DPRES_ANSC, 0);
+PARAM_DEFINE_FLOAT(SENS_DPRES_ANSC, 0.0f);
 
 /**
  * QNH for barometer
@@ -865,7 +864,6 @@ PARAM_DEFINE_FLOAT(SENS_DPRES_ANSC, 0);
  * @unit hPa
  */
 PARAM_DEFINE_FLOAT(SENS_BARO_QNH, 1013.25f);
-
 
 /**
  * Board rotation

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -984,15 +984,6 @@ PARAM_DEFINE_INT32(SENS_EXT_MAG, 0);
 PARAM_DEFINE_FLOAT(ATT_VIBE_THRESH, 0.2f);
 
 /**
- * Scaling factor for battery voltage sensor on PX4IO.
- *
- * @min 1
- * @max 100000
- * @group Battery Calibration
- */
-PARAM_DEFINE_INT32(BAT_V_SCALE_IO, 10000);
-
-/**
  * Scaling from ADC counts to volt on the ADC input (battery voltage)
  *
  * This is not the battery voltage, but the intermediate ADC voltage.

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -1068,22 +1068,6 @@ PARAM_DEFINE_FLOAT(BAT_A_PER_V, -1.0);
 PARAM_DEFINE_INT32(BAT_SOURCE, 0);
 
 /**
- * Lightware laser rangefinder (serial)
- *
- * @reboot_required true
- * @min 0
- * @max 4
- * @group Sensor Enable
- * @value 0 Disabled
- * @value 1 SF02
- * @value 2 SF10/a
- * @value 3 SF10/b
- * @value 4 SF10/c
- * @value 5 SF11/c
- */
-PARAM_DEFINE_INT32(SENS_EN_SF0X, 0);
-
-/**
  * Maxbotix Soanr (mb12xx)
  *
  * @reboot_required true

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -961,19 +961,6 @@ PARAM_DEFINE_FLOAT(SENS_BOARD_X_OFF, 0.0f);
 PARAM_DEFINE_FLOAT(SENS_BOARD_Z_OFF, 0.0f);
 
 /**
- * Select primary magnetometer.
- * DEPRECATED, only used on V1 hardware
- *
- * @min 0
- * @max 2
- * @value 0 Auto-select Mag
- * @value 1 External is primary Mag
- * @value 2 Internal is primary Mag
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(SENS_EXT_MAG, 0);
-
-/**
  * Threshold (of RMS) to warn about high vibration levels
  *
  * @group Sensor Calibration

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -498,7 +498,7 @@ Sensors::adc_poll(struct sensor_combined_s &raw)
 					}
 
 				} else
-#endif
+#endif /* ADC_AIRSPEED_VOLTAGE_CHANNEL */
 				{
 					for (int b = 0; b < BOARD_NUMBER_BRICKS; b++) {
 

--- a/src/modules/sensors/temp_comp_params_accel.c
+++ b/src/modules/sensors/temp_comp_params_accel.c
@@ -40,11 +40,12 @@
  */
 
 /**
- * Set to 1 to enable thermal compensation for accelerometer sensors. Set to 0 to disable.
+ * Thermal compensation for accelerometer sensors.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  * @min 0
  * @max 1
+ * @boolean
  */
 PARAM_DEFINE_INT32(TC_A_ENABLE, 0);
 
@@ -53,133 +54,133 @@ PARAM_DEFINE_INT32(TC_A_ENABLE, 0);
 /**
  * ID of Accelerometer that the calibration is for.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_INT32(TC_A0_ID, 0);
 
 /**
  * Accelerometer offset temperature ^3 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A0_X3_0, 0.0f);
 
 /**
  * Accelerometer offset temperature ^3 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A0_X3_1, 0.0f);
 
 /**
  * Accelerometer offset temperature ^3 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A0_X3_2, 0.0f);
 
 /**
  * Accelerometer offset temperature ^2 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A0_X2_0, 0.0f);
 
 /**
  * Accelerometer offset temperature ^2 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A0_X2_1, 0.0f);
 
 /**
  * Accelerometer offset temperature ^2 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A0_X2_2, 0.0f);
 
 /**
  * Accelerometer offset temperature ^1 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A0_X1_0, 0.0f);
 
 /**
  * Accelerometer offset temperature ^1 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A0_X1_1, 0.0f);
 
 /**
  * Accelerometer offset temperature ^1 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A0_X1_2, 0.0f);
 
 /**
  * Accelerometer offset temperature ^0 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A0_X0_0, 0.0f);
 
 /**
  * Accelerometer offset temperature ^0 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A0_X0_1, 0.0f);
 
 /**
  * Accelerometer offset temperature ^0 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A0_X0_2, 0.0f);
 
 /**
  * Accelerometer scale factor - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A0_SCL_0, 1.0f);
 
 /**
  * Accelerometer scale factor - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A0_SCL_1, 1.0f);
 
 /**
  * Accelerometer scale factor - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A0_SCL_2, 1.0f);
 
 /**
  * Accelerometer calibration reference temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A0_TREF, 25.0f);
 
 /**
  * Accelerometer calibration minimum temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A0_TMIN, 0.0f);
 
 /**
  * Accelerometer calibration maximum temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A0_TMAX, 100.0f);
 
@@ -188,133 +189,133 @@ PARAM_DEFINE_FLOAT(TC_A0_TMAX, 100.0f);
 /**
  * ID of Accelerometer that the calibration is for.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_INT32(TC_A1_ID, 0);
 
 /**
  * Accelerometer offset temperature ^3 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A1_X3_0, 0.0f);
 
 /**
  * Accelerometer offset temperature ^3 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A1_X3_1, 0.0f);
 
 /**
  * Accelerometer offset temperature ^3 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A1_X3_2, 0.0f);
 
 /**
  * Accelerometer offset temperature ^2 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A1_X2_0, 0.0f);
 
 /**
  * Accelerometer offset temperature ^2 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A1_X2_1, 0.0f);
 
 /**
  * Accelerometer offset temperature ^2 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A1_X2_2, 0.0f);
 
 /**
  * Accelerometer offset temperature ^1 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A1_X1_0, 0.0f);
 
 /**
  * Accelerometer offset temperature ^1 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A1_X1_1, 0.0f);
 
 /**
  * Accelerometer offset temperature ^1 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A1_X1_2, 0.0f);
 
 /**
  * Accelerometer offset temperature ^0 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A1_X0_0, 0.0f);
 
 /**
  * Accelerometer offset temperature ^0 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A1_X0_1, 0.0f);
 
 /**
  * Accelerometer offset temperature ^0 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A1_X0_2, 0.0f);
 
 /**
  * Accelerometer scale factor - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A1_SCL_0, 1.0f);
 
 /**
  * Accelerometer scale factor - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A1_SCL_1, 1.0f);
 
 /**
  * Accelerometer scale factor - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A1_SCL_2, 1.0f);
 
 /**
  * Accelerometer calibration reference temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A1_TREF, 25.0f);
 
 /**
  * Accelerometer calibration minimum temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A1_TMIN, 0.0f);
 
 /**
  * Accelerometer calibration maximum temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A1_TMAX, 100.0f);
 
@@ -323,132 +324,132 @@ PARAM_DEFINE_FLOAT(TC_A1_TMAX, 100.0f);
 /**
  * ID of Accelerometer that the calibration is for.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_INT32(TC_A2_ID, 0);
 
 /**
  * Accelerometer offset temperature ^3 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A2_X3_0, 0.0f);
 
 /**
  * Accelerometer offset temperature ^3 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A2_X3_1, 0.0f);
 
 /**
  * Accelerometer offset temperature ^3 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A2_X3_2, 0.0f);
 
 /**
  * Accelerometer offset temperature ^2 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A2_X2_0, 0.0f);
 
 /**
  * Accelerometer offset temperature ^2 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A2_X2_1, 0.0f);
 
 /**
  * Accelerometer offset temperature ^2 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A2_X2_2, 0.0f);
 
 /**
  * Accelerometer offset temperature ^1 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A2_X1_0, 0.0f);
 
 /**
  * Accelerometer offset temperature ^1 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A2_X1_1, 0.0f);
 
 /**
  * Accelerometer offset temperature ^1 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A2_X1_2, 0.0f);
 
 /**
  * Accelerometer offset temperature ^0 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A2_X0_0, 0.0f);
 
 /**
  * Accelerometer offset temperature ^0 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A2_X0_1, 0.0f);
 
 /**
  * Accelerometer offset temperature ^0 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A2_X0_2, 0.0f);
 
 /**
  * Accelerometer scale factor - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A2_SCL_0, 1.0f);
 
 /**
  * Accelerometer scale factor - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A2_SCL_1, 1.0f);
 
 /**
  * Accelerometer scale factor - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A2_SCL_2, 1.0f);
 
 /**
  * Accelerometer calibration reference temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A2_TREF, 25.0f);
 
 /**
  * Accelerometer calibration minimum temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A2_TMIN, 0.0f);
 
 /**
  * Accelerometer calibration maximum temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_A2_TMAX, 100.0f);

--- a/src/modules/sensors/temp_comp_params_baro.c
+++ b/src/modules/sensors/temp_comp_params_baro.c
@@ -40,11 +40,12 @@
  */
 
 /**
- * Set to 1 to enable thermal compensation for barometric pressure sensors. Set to 0 to disable.
+ * Thermal compensation for barometric pressure sensors.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  * @min 0
  * @max 1
+ * @boolean
  */
 PARAM_DEFINE_INT32(TC_B_ENABLE, 0);
 
@@ -53,77 +54,77 @@ PARAM_DEFINE_INT32(TC_B_ENABLE, 0);
 /**
  * ID of Barometer that the calibration is for.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_INT32(TC_B0_ID, 0);
 
 /**
  * Barometer offset temperature ^5 polynomial coefficient.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B0_X5, 0.0f);
 
 /**
  * Barometer offset temperature ^4 polynomial coefficient.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B0_X4, 0.0f);
 
 /**
  * Barometer offset temperature ^3 polynomial coefficient.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B0_X3, 0.0f);
 
 /**
  * Barometer offset temperature ^2 polynomial coefficient.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B0_X2, 0.0f);
 
 /**
  * Barometer offset temperature ^1 polynomial coefficients.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B0_X1, 0.0f);
 
 /**
  * Barometer offset temperature ^0 polynomial coefficient.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B0_X0, 0.0f);
 
 /**
  * Barometer scale factor - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B0_SCL, 1.0f);
 
 /**
  * Barometer calibration reference temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B0_TREF, 40.0f);
 
 /**
  * Barometer calibration minimum temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B0_TMIN, 5.0f);
 
 /**
  * Barometer calibration maximum temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B0_TMAX, 75.0f);
 
@@ -132,77 +133,77 @@ PARAM_DEFINE_FLOAT(TC_B0_TMAX, 75.0f);
 /**
  * ID of Barometer that the calibration is for.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_INT32(TC_B1_ID, 0);
 
 /**
  * Barometer offset temperature ^5 polynomial coefficient.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B1_X5, 0.0f);
 
 /**
  * Barometer offset temperature ^4 polynomial coefficient.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B1_X4, 0.0f);
 
 /**
  * Barometer offset temperature ^3 polynomial coefficient.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B1_X3, 0.0f);
 
 /**
  * Barometer offset temperature ^2 polynomial coefficient.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B1_X2, 0.0f);
 
 /**
  * Barometer offset temperature ^1 polynomial coefficients.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B1_X1, 0.0f);
 
 /**
  * Barometer offset temperature ^0 polynomial coefficient.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B1_X0, 0.0f);
 
 /**
  * Barometer scale factor - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B1_SCL, 1.0f);
 
 /**
  * Barometer calibration reference temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B1_TREF, 40.0f);
 
 /**
  * Barometer calibration minimum temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B1_TMIN, 5.0f);
 
 /**
  * Barometer calibration maximum temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B1_TMAX, 75.0f);
 
@@ -211,76 +212,76 @@ PARAM_DEFINE_FLOAT(TC_B1_TMAX, 75.0f);
 /**
  * ID of Barometer that the calibration is for.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_INT32(TC_B2_ID, 0);
 
 /**
  * Barometer offset temperature ^5 polynomial coefficient.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B2_X5, 0.0f);
 
 /**
  * Barometer offset temperature ^4 polynomial coefficient.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B2_X4, 0.0f);
 
 /**
  * Barometer offset temperature ^3 polynomial coefficient.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B2_X3, 0.0f);
 
 /**
  * Barometer offset temperature ^2 polynomial coefficient.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B2_X2, 0.0f);
 
 /**
  * Barometer offset temperature ^1 polynomial coefficients.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B2_X1, 0.0f);
 
 /**
  * Barometer offset temperature ^0 polynomial coefficient.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B2_X0, 0.0f);
 
 /**
  * Barometer scale factor - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B2_SCL, 1.0f);
 
 /**
  * Barometer calibration reference temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B2_TREF, 40.0f);
 
 /**
  * Barometer calibration minimum temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B2_TMIN, 5.0f);
 
 /**
  * Barometer calibration maximum temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_B2_TMAX, 75.0f);

--- a/src/modules/sensors/temp_comp_params_gyro.c
+++ b/src/modules/sensors/temp_comp_params_gyro.c
@@ -40,11 +40,12 @@
  */
 
 /**
- * Set to 1 to enable thermal compensation for rate gyro sensors. Set to 0 to disable.
+ * Thermal compensation for rate gyro sensors.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  * @min 0
  * @max 1
+ * @boolean
  */
 PARAM_DEFINE_INT32(TC_G_ENABLE, 0);
 
@@ -53,133 +54,133 @@ PARAM_DEFINE_INT32(TC_G_ENABLE, 0);
 /**
  * ID of Gyro that the calibration is for.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_INT32(TC_G0_ID, 0);
 
 /**
  * Gyro rate offset temperature ^3 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G0_X3_0, 0.0f);
 
 /**
  * Gyro rate offset temperature ^3 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G0_X3_1, 0.0f);
 
 /**
  * Gyro rate offset temperature ^3 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G0_X3_2, 0.0f);
 
 /**
  * Gyro rate offset temperature ^2 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G0_X2_0, 0.0f);
 
 /**
  * Gyro rate offset temperature ^2 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G0_X2_1, 0.0f);
 
 /**
  * Gyro rate offset temperature ^2 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G0_X2_2, 0.0f);
 
 /**
  * Gyro rate offset temperature ^1 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G0_X1_0, 0.0f);
 
 /**
  * Gyro rate offset temperature ^1 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G0_X1_1, 0.0f);
 
 /**
  * Gyro rate offset temperature ^1 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G0_X1_2, 0.0f);
 
 /**
  * Gyro rate offset temperature ^0 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G0_X0_0, 0.0f);
 
 /**
  * Gyro rate offset temperature ^0 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G0_X0_1, 0.0f);
 
 /**
  * Gyro rate offset temperature ^0 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G0_X0_2, 0.0f);
 
 /**
  * Gyro scale factor - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G0_SCL_0, 1.0f);
 
 /**
  * Gyro scale factor - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G0_SCL_1, 1.0f);
 
 /**
  * Gyro scale factor - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G0_SCL_2, 1.0f);
 
 /**
  * Gyro calibration reference temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G0_TREF, 25.0f);
 
 /**
  * Gyro calibration minimum temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G0_TMIN, 0.0f);
 
 /**
  * Gyro calibration maximum temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G0_TMAX, 100.0f);
 
@@ -188,133 +189,133 @@ PARAM_DEFINE_FLOAT(TC_G0_TMAX, 100.0f);
 /**
  * ID of Gyro that the calibration is for.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_INT32(TC_G1_ID, 0);
 
 /**
  * Gyro rate offset temperature ^3 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G1_X3_0, 0.0f);
 
 /**
  * Gyro rate offset temperature ^3 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G1_X3_1, 0.0f);
 
 /**
  * Gyro rate offset temperature ^3 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G1_X3_2, 0.0f);
 
 /**
  * Gyro rate offset temperature ^2 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G1_X2_0, 0.0f);
 
 /**
  * Gyro rate offset temperature ^2 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G1_X2_1, 0.0f);
 
 /**
  * Gyro rate offset temperature ^2 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G1_X2_2, 0.0f);
 
 /**
  * Gyro rate offset temperature ^1 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G1_X1_0, 0.0f);
 
 /**
  * Gyro rate offset temperature ^1 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G1_X1_1, 0.0f);
 
 /**
  * Gyro rate offset temperature ^1 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G1_X1_2, 0.0f);
 
 /**
  * Gyro rate offset temperature ^0 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G1_X0_0, 0.0f);
 
 /**
  * Gyro rate offset temperature ^0 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G1_X0_1, 0.0f);
 
 /**
  * Gyro rate offset temperature ^0 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G1_X0_2, 0.0f);
 
 /**
  * Gyro scale factor - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G1_SCL_0, 1.0f);
 
 /**
  * Gyro scale factor - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G1_SCL_1, 1.0f);
 
 /**
  * Gyro scale factor - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G1_SCL_2, 1.0f);
 
 /**
  * Gyro calibration reference temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G1_TREF, 25.0f);
 
 /**
  * Gyro calibration minimum temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G1_TMIN, 0.0f);
 
 /**
  * Gyro calibration maximum temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G1_TMAX, 100.0f);
 
@@ -323,132 +324,132 @@ PARAM_DEFINE_FLOAT(TC_G1_TMAX, 100.0f);
 /**
  * ID of Gyro that the calibration is for.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_INT32(TC_G2_ID, 0);
 
 /**
  * Gyro rate offset temperature ^3 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G2_X3_0, 0.0f);
 
 /**
  * Gyro rate offset temperature ^3 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G2_X3_1, 0.0f);
 
 /**
  * Gyro rate offset temperature ^3 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G2_X3_2, 0.0f);
 
 /**
  * Gyro rate offset temperature ^2 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G2_X2_0, 0.0f);
 
 /**
  * Gyro rate offset temperature ^2 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G2_X2_1, 0.0f);
 
 /**
  * Gyro rate offset temperature ^2 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G2_X2_2, 0.0f);
 
 /**
  * Gyro rate offset temperature ^1 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G2_X1_0, 0.0f);
 
 /**
  * Gyro rate offset temperature ^1 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G2_X1_1, 0.0f);
 
 /**
  * Gyro rate offset temperature ^1 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G2_X1_2, 0.0f);
 
 /**
  * Gyro rate offset temperature ^0 polynomial coefficient - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G2_X0_0, 0.0f);
 
 /**
  * Gyro rate offset temperature ^0 polynomial coefficient - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G2_X0_1, 0.0f);
 
 /**
  * Gyro rate offset temperature ^0 polynomial coefficient - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G2_X0_2, 0.0f);
 
 /**
  * Gyro scale factor - X axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G2_SCL_0, 1.0f);
 
 /**
  * Gyro scale factor - Y axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G2_SCL_1, 1.0f);
 
 /**
  * Gyro scale factor - Z axis.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G2_SCL_2, 1.0f);
 
 /**
  * Gyro calibration reference temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G2_TREF, 25.0f);
 
 /**
  * Gyro calibration minimum temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G2_TMIN, 0.0f);
 
 /**
  * Gyro calibration maximum temperature.
  *
- * @group Sensor Thermal Compensation
+ * @group Thermal Compensation
  */
 PARAM_DEFINE_FLOAT(TC_G2_TMAX, 100.0f);

--- a/src/modules/sensors/temperature_compensation.cpp
+++ b/src/modules/sensors/temperature_compensation.cpp
@@ -50,89 +50,102 @@ namespace sensors
 int TemperatureCompensation::initialize_parameter_handles(ParameterHandles &parameter_handles)
 {
 	char nbuf[16];
+	int ret = PX4_ERROR;
 
 	/* rate gyro calibration parameters */
 	parameter_handles.gyro_tc_enable = param_find("TC_G_ENABLE");
+	int32_t gyro_tc_enabled = 0;
+	ret = param_get(parameter_handles.gyro_tc_enable, &gyro_tc_enabled);
 
-	for (unsigned j = 0; j < GYRO_COUNT_MAX; j++) {
-		sprintf(nbuf, "TC_G%d_ID", j);
-		parameter_handles.gyro_cal_handles[j].ID = param_find(nbuf);
+	if (ret == PX4_OK && gyro_tc_enabled) {
+		for (unsigned j = 0; j < GYRO_COUNT_MAX; j++) {
+			sprintf(nbuf, "TC_G%d_ID", j);
+			parameter_handles.gyro_cal_handles[j].ID = param_find(nbuf);
 
-		for (unsigned i = 0; i < 3; i++) {
-			sprintf(nbuf, "TC_G%d_X3_%d", j, i);
-			parameter_handles.gyro_cal_handles[j].x3[i] = param_find(nbuf);
-			sprintf(nbuf, "TC_G%d_X2_%d", j, i);
-			parameter_handles.gyro_cal_handles[j].x2[i] = param_find(nbuf);
-			sprintf(nbuf, "TC_G%d_X1_%d", j, i);
-			parameter_handles.gyro_cal_handles[j].x1[i] = param_find(nbuf);
-			sprintf(nbuf, "TC_G%d_X0_%d", j, i);
-			parameter_handles.gyro_cal_handles[j].x0[i] = param_find(nbuf);
-			sprintf(nbuf, "TC_G%d_SCL_%d", j, i);
-			parameter_handles.gyro_cal_handles[j].scale[i] = param_find(nbuf);
+			for (unsigned i = 0; i < 3; i++) {
+				sprintf(nbuf, "TC_G%d_X3_%d", j, i);
+				parameter_handles.gyro_cal_handles[j].x3[i] = param_find(nbuf);
+				sprintf(nbuf, "TC_G%d_X2_%d", j, i);
+				parameter_handles.gyro_cal_handles[j].x2[i] = param_find(nbuf);
+				sprintf(nbuf, "TC_G%d_X1_%d", j, i);
+				parameter_handles.gyro_cal_handles[j].x1[i] = param_find(nbuf);
+				sprintf(nbuf, "TC_G%d_X0_%d", j, i);
+				parameter_handles.gyro_cal_handles[j].x0[i] = param_find(nbuf);
+				sprintf(nbuf, "TC_G%d_SCL_%d", j, i);
+				parameter_handles.gyro_cal_handles[j].scale[i] = param_find(nbuf);
+			}
+
+			sprintf(nbuf, "TC_G%d_TREF", j);
+			parameter_handles.gyro_cal_handles[j].ref_temp = param_find(nbuf);
+			sprintf(nbuf, "TC_G%d_TMIN", j);
+			parameter_handles.gyro_cal_handles[j].min_temp = param_find(nbuf);
+			sprintf(nbuf, "TC_G%d_TMAX", j);
+			parameter_handles.gyro_cal_handles[j].max_temp = param_find(nbuf);
 		}
-
-		sprintf(nbuf, "TC_G%d_TREF", j);
-		parameter_handles.gyro_cal_handles[j].ref_temp = param_find(nbuf);
-		sprintf(nbuf, "TC_G%d_TMIN", j);
-		parameter_handles.gyro_cal_handles[j].min_temp = param_find(nbuf);
-		sprintf(nbuf, "TC_G%d_TMAX", j);
-		parameter_handles.gyro_cal_handles[j].max_temp = param_find(nbuf);
 	}
 
 	/* accelerometer calibration parameters */
 	parameter_handles.accel_tc_enable = param_find("TC_A_ENABLE");
+	int32_t accel_tc_enabled = 0;
+	ret = param_get(parameter_handles.accel_tc_enable, &accel_tc_enabled);
 
-	for (unsigned j = 0; j < ACCEL_COUNT_MAX; j++) {
-		sprintf(nbuf, "TC_A%d_ID", j);
-		parameter_handles.accel_cal_handles[j].ID = param_find(nbuf);
+	if (ret == PX4_OK && accel_tc_enabled) {
+		for (unsigned j = 0; j < ACCEL_COUNT_MAX; j++) {
+			sprintf(nbuf, "TC_A%d_ID", j);
+			parameter_handles.accel_cal_handles[j].ID = param_find(nbuf);
 
-		for (unsigned i = 0; i < 3; i++) {
-			sprintf(nbuf, "TC_A%d_X3_%d", j, i);
-			parameter_handles.accel_cal_handles[j].x3[i] = param_find(nbuf);
-			sprintf(nbuf, "TC_A%d_X2_%d", j, i);
-			parameter_handles.accel_cal_handles[j].x2[i] = param_find(nbuf);
-			sprintf(nbuf, "TC_A%d_X1_%d", j, i);
-			parameter_handles.accel_cal_handles[j].x1[i] = param_find(nbuf);
-			sprintf(nbuf, "TC_A%d_X0_%d", j, i);
-			parameter_handles.accel_cal_handles[j].x0[i] = param_find(nbuf);
-			sprintf(nbuf, "TC_A%d_SCL_%d", j, i);
-			parameter_handles.accel_cal_handles[j].scale[i] = param_find(nbuf);
+			for (unsigned i = 0; i < 3; i++) {
+				sprintf(nbuf, "TC_A%d_X3_%d", j, i);
+				parameter_handles.accel_cal_handles[j].x3[i] = param_find(nbuf);
+				sprintf(nbuf, "TC_A%d_X2_%d", j, i);
+				parameter_handles.accel_cal_handles[j].x2[i] = param_find(nbuf);
+				sprintf(nbuf, "TC_A%d_X1_%d", j, i);
+				parameter_handles.accel_cal_handles[j].x1[i] = param_find(nbuf);
+				sprintf(nbuf, "TC_A%d_X0_%d", j, i);
+				parameter_handles.accel_cal_handles[j].x0[i] = param_find(nbuf);
+				sprintf(nbuf, "TC_A%d_SCL_%d", j, i);
+				parameter_handles.accel_cal_handles[j].scale[i] = param_find(nbuf);
+			}
+
+			sprintf(nbuf, "TC_A%d_TREF", j);
+			parameter_handles.accel_cal_handles[j].ref_temp = param_find(nbuf);
+			sprintf(nbuf, "TC_A%d_TMIN", j);
+			parameter_handles.accel_cal_handles[j].min_temp = param_find(nbuf);
+			sprintf(nbuf, "TC_A%d_TMAX", j);
+			parameter_handles.accel_cal_handles[j].max_temp = param_find(nbuf);
 		}
-
-		sprintf(nbuf, "TC_A%d_TREF", j);
-		parameter_handles.accel_cal_handles[j].ref_temp = param_find(nbuf);
-		sprintf(nbuf, "TC_A%d_TMIN", j);
-		parameter_handles.accel_cal_handles[j].min_temp = param_find(nbuf);
-		sprintf(nbuf, "TC_A%d_TMAX", j);
-		parameter_handles.accel_cal_handles[j].max_temp = param_find(nbuf);
 	}
 
 	/* barometer calibration parameters */
 	parameter_handles.baro_tc_enable = param_find("TC_B_ENABLE");
+	int32_t baro_tc_enabled = 0;
+	ret = param_get(parameter_handles.baro_tc_enable, &baro_tc_enabled);
 
-	for (unsigned j = 0; j < BARO_COUNT_MAX; j++) {
-		sprintf(nbuf, "TC_B%d_ID", j);
-		parameter_handles.baro_cal_handles[j].ID = param_find(nbuf);
-		sprintf(nbuf, "TC_B%d_X5", j);
-		parameter_handles.baro_cal_handles[j].x5 = param_find(nbuf);
-		sprintf(nbuf, "TC_B%d_X4", j);
-		parameter_handles.baro_cal_handles[j].x4 = param_find(nbuf);
-		sprintf(nbuf, "TC_B%d_X3", j);
-		parameter_handles.baro_cal_handles[j].x3 = param_find(nbuf);
-		sprintf(nbuf, "TC_B%d_X2", j);
-		parameter_handles.baro_cal_handles[j].x2 = param_find(nbuf);
-		sprintf(nbuf, "TC_B%d_X1", j);
-		parameter_handles.baro_cal_handles[j].x1 = param_find(nbuf);
-		sprintf(nbuf, "TC_B%d_X0", j);
-		parameter_handles.baro_cal_handles[j].x0 = param_find(nbuf);
-		sprintf(nbuf, "TC_B%d_SCL", j);
-		parameter_handles.baro_cal_handles[j].scale = param_find(nbuf);
-		sprintf(nbuf, "TC_B%d_TREF", j);
-		parameter_handles.baro_cal_handles[j].ref_temp = param_find(nbuf);
-		sprintf(nbuf, "TC_B%d_TMIN", j);
-		parameter_handles.baro_cal_handles[j].min_temp = param_find(nbuf);
-		sprintf(nbuf, "TC_B%d_TMAX", j);
-		parameter_handles.baro_cal_handles[j].max_temp = param_find(nbuf);
+	if (ret == PX4_OK && baro_tc_enabled) {
+		for (unsigned j = 0; j < BARO_COUNT_MAX; j++) {
+			sprintf(nbuf, "TC_B%d_ID", j);
+			parameter_handles.baro_cal_handles[j].ID = param_find(nbuf);
+			sprintf(nbuf, "TC_B%d_X5", j);
+			parameter_handles.baro_cal_handles[j].x5 = param_find(nbuf);
+			sprintf(nbuf, "TC_B%d_X4", j);
+			parameter_handles.baro_cal_handles[j].x4 = param_find(nbuf);
+			sprintf(nbuf, "TC_B%d_X3", j);
+			parameter_handles.baro_cal_handles[j].x3 = param_find(nbuf);
+			sprintf(nbuf, "TC_B%d_X2", j);
+			parameter_handles.baro_cal_handles[j].x2 = param_find(nbuf);
+			sprintf(nbuf, "TC_B%d_X1", j);
+			parameter_handles.baro_cal_handles[j].x1 = param_find(nbuf);
+			sprintf(nbuf, "TC_B%d_X0", j);
+			parameter_handles.baro_cal_handles[j].x0 = param_find(nbuf);
+			sprintf(nbuf, "TC_B%d_SCL", j);
+			parameter_handles.baro_cal_handles[j].scale = param_find(nbuf);
+			sprintf(nbuf, "TC_B%d_TREF", j);
+			parameter_handles.baro_cal_handles[j].ref_temp = param_find(nbuf);
+			sprintf(nbuf, "TC_B%d_TMIN", j);
+			parameter_handles.baro_cal_handles[j].min_temp = param_find(nbuf);
+			sprintf(nbuf, "TC_B%d_TMAX", j);
+			parameter_handles.baro_cal_handles[j].max_temp = param_find(nbuf);
+		}
 	}
 
 	return PX4_OK;
@@ -152,90 +165,96 @@ int TemperatureCompensation::parameters_update()
 	/* rate gyro calibration parameters */
 	param_get(parameter_handles.gyro_tc_enable, &(_parameters.gyro_tc_enable));
 
-	for (unsigned j = 0; j < GYRO_COUNT_MAX; j++) {
-		if (param_get(parameter_handles.gyro_cal_handles[j].ID, &(_parameters.gyro_cal_data[j].ID)) == PX4_OK) {
-			param_get(parameter_handles.gyro_cal_handles[j].ref_temp, &(_parameters.gyro_cal_data[j].ref_temp));
-			param_get(parameter_handles.gyro_cal_handles[j].min_temp, &(_parameters.gyro_cal_data[j].min_temp));
-			param_get(parameter_handles.gyro_cal_handles[j].max_temp, &(_parameters.gyro_cal_data[j].max_temp));
+	if (_parameters.gyro_tc_enable == 1) {
+		for (unsigned j = 0; j < GYRO_COUNT_MAX; j++) {
+			if (param_get(parameter_handles.gyro_cal_handles[j].ID, &(_parameters.gyro_cal_data[j].ID)) == PX4_OK) {
+				param_get(parameter_handles.gyro_cal_handles[j].ref_temp, &(_parameters.gyro_cal_data[j].ref_temp));
+				param_get(parameter_handles.gyro_cal_handles[j].min_temp, &(_parameters.gyro_cal_data[j].min_temp));
+				param_get(parameter_handles.gyro_cal_handles[j].max_temp, &(_parameters.gyro_cal_data[j].max_temp));
 
-			for (unsigned int i = 0; i < 3; i++) {
-				param_get(parameter_handles.gyro_cal_handles[j].x3[i], &(_parameters.gyro_cal_data[j].x3[i]));
-				param_get(parameter_handles.gyro_cal_handles[j].x2[i], &(_parameters.gyro_cal_data[j].x2[i]));
-				param_get(parameter_handles.gyro_cal_handles[j].x1[i], &(_parameters.gyro_cal_data[j].x1[i]));
-				param_get(parameter_handles.gyro_cal_handles[j].x0[i], &(_parameters.gyro_cal_data[j].x0[i]));
-				param_get(parameter_handles.gyro_cal_handles[j].scale[i], &(_parameters.gyro_cal_data[j].scale[i]));
+				for (unsigned int i = 0; i < 3; i++) {
+					param_get(parameter_handles.gyro_cal_handles[j].x3[i], &(_parameters.gyro_cal_data[j].x3[i]));
+					param_get(parameter_handles.gyro_cal_handles[j].x2[i], &(_parameters.gyro_cal_data[j].x2[i]));
+					param_get(parameter_handles.gyro_cal_handles[j].x1[i], &(_parameters.gyro_cal_data[j].x1[i]));
+					param_get(parameter_handles.gyro_cal_handles[j].x0[i], &(_parameters.gyro_cal_data[j].x0[i]));
+					param_get(parameter_handles.gyro_cal_handles[j].scale[i], &(_parameters.gyro_cal_data[j].scale[i]));
+				}
+
+			} else {
+				// Set all cal values to zero and scale factor to unity
+				memset(&_parameters.gyro_cal_data[j], 0, sizeof(_parameters.gyro_cal_data[j]));
+
+				// Set the scale factor to unity
+				for (unsigned int i = 0; i < 3; i++) {
+					_parameters.gyro_cal_data[j].scale[i] = 1.0f;
+				}
+
+				PX4_WARN("FAIL GYRO %d CAL PARAM LOAD - USING DEFAULTS", j);
+				ret = PX4_ERROR;
 			}
-
-		} else {
-			// Set all cal values to zero and scale factor to unity
-			memset(&_parameters.gyro_cal_data[j], 0, sizeof(_parameters.gyro_cal_data[j]));
-
-			// Set the scale factor to unity
-			for (unsigned int i = 0; i < 3; i++) {
-				_parameters.gyro_cal_data[j].scale[i] = 1.0f;
-			}
-
-			PX4_WARN("FAIL GYRO %d CAL PARAM LOAD - USING DEFAULTS", j);
-			ret = PX4_ERROR;
 		}
 	}
 
 	/* accelerometer calibration parameters */
 	param_get(parameter_handles.accel_tc_enable, &(_parameters.accel_tc_enable));
 
-	for (unsigned j = 0; j < ACCEL_COUNT_MAX; j++) {
-		if (param_get(parameter_handles.accel_cal_handles[j].ID, &(_parameters.accel_cal_data[j].ID)) == PX4_OK) {
-			param_get(parameter_handles.accel_cal_handles[j].ref_temp, &(_parameters.accel_cal_data[j].ref_temp));
-			param_get(parameter_handles.accel_cal_handles[j].min_temp, &(_parameters.accel_cal_data[j].min_temp));
-			param_get(parameter_handles.accel_cal_handles[j].max_temp, &(_parameters.accel_cal_data[j].max_temp));
+	if (_parameters.accel_tc_enable == 1) {
+		for (unsigned j = 0; j < ACCEL_COUNT_MAX; j++) {
+			if (param_get(parameter_handles.accel_cal_handles[j].ID, &(_parameters.accel_cal_data[j].ID)) == PX4_OK) {
+				param_get(parameter_handles.accel_cal_handles[j].ref_temp, &(_parameters.accel_cal_data[j].ref_temp));
+				param_get(parameter_handles.accel_cal_handles[j].min_temp, &(_parameters.accel_cal_data[j].min_temp));
+				param_get(parameter_handles.accel_cal_handles[j].max_temp, &(_parameters.accel_cal_data[j].max_temp));
 
-			for (unsigned int i = 0; i < 3; i++) {
-				param_get(parameter_handles.accel_cal_handles[j].x3[i], &(_parameters.accel_cal_data[j].x3[i]));
-				param_get(parameter_handles.accel_cal_handles[j].x2[i], &(_parameters.accel_cal_data[j].x2[i]));
-				param_get(parameter_handles.accel_cal_handles[j].x1[i], &(_parameters.accel_cal_data[j].x1[i]));
-				param_get(parameter_handles.accel_cal_handles[j].x0[i], &(_parameters.accel_cal_data[j].x0[i]));
-				param_get(parameter_handles.accel_cal_handles[j].scale[i], &(_parameters.accel_cal_data[j].scale[i]));
+				for (unsigned int i = 0; i < 3; i++) {
+					param_get(parameter_handles.accel_cal_handles[j].x3[i], &(_parameters.accel_cal_data[j].x3[i]));
+					param_get(parameter_handles.accel_cal_handles[j].x2[i], &(_parameters.accel_cal_data[j].x2[i]));
+					param_get(parameter_handles.accel_cal_handles[j].x1[i], &(_parameters.accel_cal_data[j].x1[i]));
+					param_get(parameter_handles.accel_cal_handles[j].x0[i], &(_parameters.accel_cal_data[j].x0[i]));
+					param_get(parameter_handles.accel_cal_handles[j].scale[i], &(_parameters.accel_cal_data[j].scale[i]));
+				}
+
+			} else {
+				// Set all cal values to zero and scale factor to unity
+				memset(&_parameters.accel_cal_data[j], 0, sizeof(_parameters.accel_cal_data[j]));
+
+				// Set the scale factor to unity
+				for (unsigned int i = 0; i < 3; i++) {
+					_parameters.accel_cal_data[j].scale[i] = 1.0f;
+				}
+
+				PX4_WARN("FAIL ACCEL %d CAL PARAM LOAD - USING DEFAULTS", j);
+				ret = PX4_ERROR;
 			}
-
-		} else {
-			// Set all cal values to zero and scale factor to unity
-			memset(&_parameters.accel_cal_data[j], 0, sizeof(_parameters.accel_cal_data[j]));
-
-			// Set the scale factor to unity
-			for (unsigned int i = 0; i < 3; i++) {
-				_parameters.accel_cal_data[j].scale[i] = 1.0f;
-			}
-
-			PX4_WARN("FAIL ACCEL %d CAL PARAM LOAD - USING DEFAULTS", j);
-			ret = PX4_ERROR;
 		}
 	}
 
 	/* barometer calibration parameters */
 	param_get(parameter_handles.baro_tc_enable, &(_parameters.baro_tc_enable));
 
-	for (unsigned j = 0; j < BARO_COUNT_MAX; j++) {
-		if (param_get(parameter_handles.baro_cal_handles[j].ID, &(_parameters.baro_cal_data[j].ID)) == PX4_OK) {
-			param_get(parameter_handles.baro_cal_handles[j].ref_temp, &(_parameters.baro_cal_data[j].ref_temp));
-			param_get(parameter_handles.baro_cal_handles[j].min_temp, &(_parameters.baro_cal_data[j].min_temp));
-			param_get(parameter_handles.baro_cal_handles[j].max_temp, &(_parameters.baro_cal_data[j].max_temp));
-			param_get(parameter_handles.baro_cal_handles[j].x5, &(_parameters.baro_cal_data[j].x5));
-			param_get(parameter_handles.baro_cal_handles[j].x4, &(_parameters.baro_cal_data[j].x4));
-			param_get(parameter_handles.baro_cal_handles[j].x3, &(_parameters.baro_cal_data[j].x3));
-			param_get(parameter_handles.baro_cal_handles[j].x2, &(_parameters.baro_cal_data[j].x2));
-			param_get(parameter_handles.baro_cal_handles[j].x1, &(_parameters.baro_cal_data[j].x1));
-			param_get(parameter_handles.baro_cal_handles[j].x0, &(_parameters.baro_cal_data[j].x0));
-			param_get(parameter_handles.baro_cal_handles[j].scale, &(_parameters.baro_cal_data[j].scale));
+	if (_parameters.baro_tc_enable == 1) {
+		for (unsigned j = 0; j < BARO_COUNT_MAX; j++) {
+			if (param_get(parameter_handles.baro_cal_handles[j].ID, &(_parameters.baro_cal_data[j].ID)) == PX4_OK) {
+				param_get(parameter_handles.baro_cal_handles[j].ref_temp, &(_parameters.baro_cal_data[j].ref_temp));
+				param_get(parameter_handles.baro_cal_handles[j].min_temp, &(_parameters.baro_cal_data[j].min_temp));
+				param_get(parameter_handles.baro_cal_handles[j].max_temp, &(_parameters.baro_cal_data[j].max_temp));
+				param_get(parameter_handles.baro_cal_handles[j].x5, &(_parameters.baro_cal_data[j].x5));
+				param_get(parameter_handles.baro_cal_handles[j].x4, &(_parameters.baro_cal_data[j].x4));
+				param_get(parameter_handles.baro_cal_handles[j].x3, &(_parameters.baro_cal_data[j].x3));
+				param_get(parameter_handles.baro_cal_handles[j].x2, &(_parameters.baro_cal_data[j].x2));
+				param_get(parameter_handles.baro_cal_handles[j].x1, &(_parameters.baro_cal_data[j].x1));
+				param_get(parameter_handles.baro_cal_handles[j].x0, &(_parameters.baro_cal_data[j].x0));
+				param_get(parameter_handles.baro_cal_handles[j].scale, &(_parameters.baro_cal_data[j].scale));
 
-		} else {
-			// Set all cal values to zero and scale factor to unity
-			memset(&_parameters.baro_cal_data[j], 0, sizeof(_parameters.baro_cal_data[j]));
+			} else {
+				// Set all cal values to zero and scale factor to unity
+				memset(&_parameters.baro_cal_data[j], 0, sizeof(_parameters.baro_cal_data[j]));
 
-			// Set the scale factor to unity
-			_parameters.baro_cal_data[j].scale = 1.0f;
+				// Set the scale factor to unity
+				_parameters.baro_cal_data[j].scale = 1.0f;
 
-			PX4_WARN("FAIL BARO %d CAL PARAM LOAD - USING DEFAULTS", j);
-			ret = PX4_ERROR;
+				PX4_WARN("FAIL BARO %d CAL PARAM LOAD - USING DEFAULTS", j);
+				ret = PX4_ERROR;
+			}
 		}
 	}
 

--- a/src/modules/sensors/temperature_compensation.h
+++ b/src/modules/sensors/temperature_compensation.h
@@ -208,7 +208,7 @@ private:
 
 	/**
 	 * initialize ParameterHandles struct
-	 * @return 0 on succes, <0 on error
+	 * @return 0 on success, <0 on error
 	 */
 	static int initialize_parameter_handles(ParameterHandles &parameter_handles);
 

--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -158,14 +158,6 @@ PARAM_DEFINE_INT32(SYS_PARAM_VER, 1);
 PARAM_DEFINE_INT32(SYS_LOGGER, 1);
 
 /**
- * Enable stack checking
- *
- * @boolean
- * @group System
- */
-PARAM_DEFINE_INT32(SYS_STCK_EN, 1);
-
-/**
  * Enable auto start of rate gyro thermal calibration at the next power up.
  *
  * 0 : Set to 0 to do nothing


### PR DESCRIPTION
Placing the param definition within the relevant module is a better user experience. When a module isn't built for a particular board the option to enable it shouldn't be either.