### PR TITLE
Sensors: Clean up boot output

### DIFF
--- a/src/drivers/bmi055/bmi055_accel.cpp
+++ b/src/drivers/bmi055/bmi055_accel.cpp
@@ -79,7 +79,6 @@ BMI055_accel::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		warnx("SPI error");
 		DEVICE_DEBUG("SPI setup failed");
 		return ret;
 	}

--- a/src/drivers/bmi055/bmi055_gyro.cpp
+++ b/src/drivers/bmi055/bmi055_gyro.cpp
@@ -184,7 +184,7 @@ BMI055_gyro::probe()
 		return OK;
 	}
 
-	PX4_ERR("unexpected whoami 0x%02x", _whoami);
+	DEVICE_DEBUG("unexpected whoami 0x%02x", _whoami);
 	return -EIO;
 }
 

--- a/src/drivers/bmi055/bmi055_main.cpp
+++ b/src/drivers/bmi055/bmi055_main.cpp
@@ -133,7 +133,7 @@ start(bool external_bus, enum Rotation rotation, enum sensor_type sensor)
 		close(fd_gyr);
 	}
 
-	exit(0);
+	exit(PX4_OK);
 
 fail_accel:
 
@@ -142,7 +142,8 @@ fail_accel:
 		*g_dev_acc_ptr = nullptr;
 	}
 
-	errx(1, "bmi055 accel driver start failed");
+	PX4_WARN("No BMI055 accel found");
+	exit(PX4_ERROR);
 
 fail_gyro:
 
@@ -151,7 +152,8 @@ fail_gyro:
 		*g_dev_gyr_ptr = nullptr;
 	}
 
-	errx(1, "bmi055 gyro driver start failed");
+	PX4_WARN("No BMI055 gyro found");
+	exit(PX4_ERROR);
 
 }
 

--- a/src/drivers/ms5525_airspeed/MS5525_main.cpp
+++ b/src/drivers/ms5525_airspeed/MS5525_main.cpp
@@ -41,15 +41,15 @@ namespace ms5525_airspeed
 {
 MS5525 *g_dev = nullptr;
 
-void start(uint8_t i2c_bus);
-void stop();
-void test();
-void reset();
+int start(uint8_t i2c_bus);
+int stop();
+int test();
+int reset();
 
 // Start the driver.
 // This function call only returns once the driver is up and running
 // or failed to detect the sensor.
-void
+int
 start(uint8_t i2c_bus)
 {
 	int fd = -1;
@@ -70,8 +70,6 @@ start(uint8_t i2c_bus)
 	if (OK != g_dev->Airspeed::init()) {
 		delete g_dev;
 
-		PX4_WARN("trying MS5525 address 2");
-
 		g_dev = new MS5525(i2c_bus, I2C_ADDRESS_2_MS5525DSO, PATH_MS5525);
 
 		/* check if the MS5525DSO was instantiated */
@@ -82,7 +80,6 @@ start(uint8_t i2c_bus)
 
 		/* both versions failed if the init for the MS5525DSO fails, give up */
 		if (OK != g_dev->Airspeed::init()) {
-			PX4_WARN("MS5525 init fail");
 			goto fail;
 		}
 	}
@@ -98,7 +95,7 @@ start(uint8_t i2c_bus)
 		goto fail;
 	}
 
-	return;
+	return PX4_OK;
 
 fail:
 
@@ -107,11 +104,12 @@ fail:
 		g_dev = nullptr;
 	}
 
-	PX4_WARN("no MS5525 airspeed sensor connected");
+	PX4_WARN("no MS5525 airspeed sensor connected on bus %d", i2c_bus);
+	return PX4_ERROR;
 }
 
 // stop the driver
-void stop()
+int stop()
 {
 	if (g_dev != nullptr) {
 		delete g_dev;
@@ -119,19 +117,22 @@ void stop()
 
 	} else {
 		PX4_ERR("driver not running");
+		return PX4_ERROR;
 	}
+
+	return PX4_OK;
 }
 
 // perform some basic functional tests on the driver;
 // make sure we can collect data from the sensor in polled
 // and automatic modes.
-void test()
+int test()
 {
 	int fd = px4_open(PATH_MS5525, O_RDONLY);
 
 	if (fd < 0) {
 		PX4_WARN("%s open failed (try 'ms5525_airspeed start' if the driver is not running", PATH_MS5525);
-		return;
+		return PX4_ERROR;
 	}
 
 	// do a simple demand read
@@ -140,7 +141,7 @@ void test()
 
 	if (sz != sizeof(report)) {
 		PX4_WARN("immediate read failed");
-		return;
+		return PX4_ERROR;
 	}
 
 	PX4_WARN("single read");
@@ -149,7 +150,7 @@ void test()
 	/* start the sensor polling at 2Hz */
 	if (OK != px4_ioctl(fd, SENSORIOCSPOLLRATE, 2)) {
 		PX4_WARN("failed to set 2Hz poll rate");
-		return;
+		return PX4_ERROR;
 	}
 
 	/* read the sensor 5x and report each value */
@@ -163,6 +164,7 @@ void test()
 
 		if (ret != 1) {
 			PX4_ERR("timed out");
+			return PX4_ERROR;
 		}
 
 		/* now go get it */
@@ -170,6 +172,7 @@ void test()
 
 		if (sz != sizeof(report)) {
 			PX4_ERR("periodic read failed");
+			return PX4_ERROR;
 		}
 
 		PX4_WARN("periodic read %u", i);
@@ -180,28 +183,33 @@ void test()
 	/* reset the sensor polling to its default rate */
 	if (PX4_OK != px4_ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT)) {
 		PX4_WARN("failed to set default rate");
+		return PX4_ERROR;
 	}
+
+	return PX4_OK;
 }
 
 // reset the driver
-void reset()
+int reset()
 {
 	int fd = px4_open(PATH_MS5525, O_RDONLY);
 
 	if (fd < 0) {
 		PX4_ERR("failed ");
-		return;
+		return PX4_ERROR;
 	}
 
 	if (px4_ioctl(fd, SENSORIOCRESET, 0) < 0) {
 		PX4_ERR("driver reset failed");
-		return;
+		return PX4_ERROR;
 	}
 
 	if (px4_ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT) < 0) {
 		PX4_ERR("driver poll restart failed");
-		return;
+		return PX4_ERROR;
 	}
+
+	return PX4_OK;
 }
 
 } // namespace ms5525_airspeed
@@ -234,28 +242,28 @@ ms5525_airspeed_main(int argc, char *argv[])
 	 * Start/load the driver.
 	 */
 	if (!strcmp(argv[1], "start")) {
-		ms5525_airspeed::start(i2c_bus);
+		return ms5525_airspeed::start(i2c_bus);
 	}
 
 	/*
 	 * Stop the driver
 	 */
 	if (!strcmp(argv[1], "stop")) {
-		ms5525_airspeed::stop();
+		return ms5525_airspeed::stop();
 	}
 
 	/*
 	 * Test the driver/device.
 	 */
 	if (!strcmp(argv[1], "test")) {
-		ms5525_airspeed::test();
+		return ms5525_airspeed::test();
 	}
 
 	/*
 	 * Reset the driver.
 	 */
 	if (!strcmp(argv[1], "reset")) {
-		ms5525_airspeed::reset();
+		return ms5525_airspeed::reset();
 	}
 
 	ms5525_airspeed_usage();

--- a/src/drivers/sdp3x_airspeed/SDP3X.cpp
+++ b/src/drivers/sdp3x_airspeed/SDP3X.cpp
@@ -66,7 +66,6 @@ SDP3X::init_sdp3x()
 
 	if (ret != PX4_OK) {
 		perf_count(_comms_errors);
-		PX4_ERR("reset failed");
 		return false;
 	}
 

--- a/src/drivers/sdp3x_airspeed/SDP3X_main.cpp
+++ b/src/drivers/sdp3x_airspeed/SDP3X_main.cpp
@@ -41,22 +41,23 @@ namespace sdp3x_airspeed
 {
 SDP3X *g_dev = nullptr;
 
-void start(int i2c_bus);
-void stop();
-void test();
-void reset();
-void info();
+int start(int i2c_bus);
+int stop();
+int test();
+int reset();
+int info();
 
 // Start the driver.
 // This function call only returns once the driver is up and running
 // or failed to detect the sensor.
-void
+int
 start(int i2c_bus)
 {
 	int fd = -1;
 
 	if (g_dev != nullptr) {
-		errx(1, "already started");
+		PX4_WARN("driver already started");
+		return PX4_ERROR;
 	}
 
 	g_dev = new SDP3X(i2c_bus, I2C_ADDRESS_1_SDP3X, PATH_SDP3X);
@@ -70,19 +71,16 @@ start(int i2c_bus)
 	if (OK != g_dev->Airspeed::init()) {
 		delete g_dev;
 
-		PX4_WARN("trying SDP3X 2");
-
 		g_dev = new SDP3X(i2c_bus, I2C_ADDRESS_2_SDP3X, PATH_SDP3X);
 
 		/* check if the SDP3XDSO was instantiated */
 		if (g_dev == nullptr) {
-			PX4_WARN("SDP3X was not instantiated");
+			PX4_ERR("SDP3X was not instantiated (RAM)");
 			goto fail;
 		}
 
 		/* both versions failed if the init for the SDP3XDSO fails, give up */
 		if (OK != g_dev->Airspeed::init()) {
-			PX4_WARN("SDP3X init fail");
 			goto fail;
 		}
 	}
@@ -98,7 +96,7 @@ start(int i2c_bus)
 		goto fail;
 	}
 
-	return;
+	return PX4_OK;
 
 fail:
 
@@ -107,11 +105,12 @@ fail:
 		g_dev = nullptr;
 	}
 
-	PX4_WARN("no SDP3X airspeed sensor connected");
+	PX4_WARN("no SDP3X airspeed sensor connected on bus %d", i2c_bus);
+	return PX4_ERROR;
 }
 
 // stop the driver
-void stop()
+int stop()
 {
 	if (g_dev != nullptr) {
 		delete g_dev;
@@ -119,19 +118,22 @@ void stop()
 
 	} else {
 		PX4_ERR("driver not running");
+		return PX4_ERROR;
 	}
+
+	return PX4_OK;
 }
 
 // perform some basic functional tests on the driver;
 // make sure we can collect data from the sensor in polled
 // and automatic modes.
-void test()
+int test()
 {
 	int fd = px4_open(PATH_SDP3X, O_RDONLY);
 
 	if (fd < 0) {
 		PX4_WARN("%s open failed (try 'sdp3x_airspeed start' if the driver is not running", PATH_SDP3X);
-		return;
+		return PX4_ERROR;
 	}
 
 	// do a simple demand read
@@ -140,7 +142,7 @@ void test()
 
 	if (sz != sizeof(report)) {
 		PX4_WARN("immediate read failed");
-		return;
+		return PX4_ERROR;
 	}
 
 	PX4_WARN("single read");
@@ -149,7 +151,7 @@ void test()
 	/* start the sensor polling at 2Hz */
 	if (OK != px4_ioctl(fd, SENSORIOCSPOLLRATE, 2)) {
 		PX4_WARN("failed to set 2Hz poll rate");
-		return;
+		return PX4_ERROR;
 	}
 
 	/* read the sensor 5x and report each value */
@@ -163,6 +165,7 @@ void test()
 
 		if (ret != 1) {
 			PX4_ERR("timed out");
+			return PX4_ERROR;
 		}
 
 		/* now go get it */
@@ -170,6 +173,7 @@ void test()
 
 		if (sz != sizeof(report)) {
 			PX4_ERR("periodic read failed");
+			return PX4_ERROR;
 		}
 
 		PX4_WARN("periodic read %u", i);
@@ -180,41 +184,47 @@ void test()
 	/* reset the sensor polling to its default rate */
 	if (PX4_OK != px4_ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT)) {
 		PX4_WARN("failed to set default rate");
-		return;
+		return PX4_ERROR;
 	}
+
+	return PX4_OK;
 }
 
 // reset the driver
-void reset()
+int reset()
 {
 	int fd = px4_open(PATH_SDP3X, O_RDONLY);
 
 	if (fd < 0) {
 		PX4_ERR("failed ");
-		return;
+		return PX4_ERROR;
 	}
 
 	if (px4_ioctl(fd, SENSORIOCRESET, 0) < 0) {
 		PX4_ERR("driver reset failed");
-		return;
+		return PX4_ERROR;
 	}
 
 	if (px4_ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT) < 0) {
 		PX4_ERR("driver poll restart failed");
-		return;
+		return PX4_ERROR;
 	}
+
+	return PX4_OK;
 }
 
 // print a little info about the driver
-void
+int
 info()
 {
 	if (g_dev == nullptr) {
 		PX4_ERR("driver not running");
+		return PX4_ERROR;
 	}
 
 	PX4_INFO("state @ %p", g_dev);
 	g_dev->print_info();
+	return PX4_OK;
 }
 
 } // namespace sdp3x_airspeed
@@ -247,35 +257,35 @@ sdp3x_airspeed_main(int argc, char *argv[])
 	 * Start/load the driver.
 	 */
 	if (!strcmp(argv[1], "start")) {
-		sdp3x_airspeed::start(i2c_bus);
+		return sdp3x_airspeed::start(i2c_bus);
 	}
 
 	/*
 	 * Stop the driver
 	 */
 	if (!strcmp(argv[1], "stop")) {
-		sdp3x_airspeed::stop();
+		return sdp3x_airspeed::stop();
 	}
 
 	/*
 	 * Test the driver/device.
 	 */
 	if (!strcmp(argv[1], "test")) {
-		sdp3x_airspeed::test();
+		return sdp3x_airspeed::test();
 	}
 
 	/*
 	 * Reset the driver.
 	 */
 	if (!strcmp(argv[1], "reset")) {
-		sdp3x_airspeed::reset();
+		return sdp3x_airspeed::reset();
 	}
 
 	/*
 	 * Print driver information.
 	 */
 	if (!strcmp(argv[1], "info") || !strcmp(argv[1], "status")) {
-		sdp3x_airspeed::info();
+		return sdp3x_airspeed::info();
 	}
 
 	sdp3x_airspeed_usage();


### PR DESCRIPTION
Various sensors had too verbose or confusing boot output that would make the boot log hard to read. This patch ensures all output is consistently indicating if there is a real error or an optional sensor just not present. It also removed redundant error messages and adds an indication on which bus the sensor was probed.

@dagar Quick review would be appreciated.