### PR TITLE
driver: ll40ls: Correctly instantiate with the right parameters

### DIFF
--- a/src/drivers/ll40ls/LidarLiteI2C.cpp
+++ b/src/drivers/ll40ls/LidarLiteI2C.cpp
@@ -49,7 +49,7 @@
 #include <stdio.h>
 #include <drivers/drv_hrt.h>
 
-LidarLiteI2C::LidarLiteI2C(int bus, const char *path, int address, uint8_t rotation) :
+LidarLiteI2C::LidarLiteI2C(int bus, const char *path, uint8_t rotation, int address) :
 	I2C("LL40LS", path, bus, address, 100000),
 	_rotation(rotation),
 	_work{},

--- a/src/drivers/ll40ls/LidarLiteI2C.h
+++ b/src/drivers/ll40ls/LidarLiteI2C.h
@@ -71,8 +71,9 @@
 class LidarLiteI2C : public LidarLite, public device::I2C
 {
 public:
-	LidarLiteI2C(int bus, const char *path, int address = LL40LS_BASEADDR,
-		     uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING);
+	LidarLiteI2C(int bus, const char *path,
+		     uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING,
+		     int address = LL40LS_BASEADDR);
 	virtual ~LidarLiteI2C();
 
 	int         init() override;


### PR DESCRIPTION
It was setting the rotation value to the I2C slave address
causing it to not be successfully probe.

Changing the constructor paramters order instead of
just fix line instantiating to keep consistency with
the other lidars and sonars.