### PR TITLE
build: get rid of annoying CMake warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,8 @@ ifdef VNP
 endif
 
 # additional config parameters passed to cmake
-CMAKE_ARGS :=
+CMAKE_ARGS := -Wno-deprecated
+
 ifdef EXTERNAL_MODULES_LOCATION
 	CMAKE_ARGS := -DEXTERNAL_MODULES_LOCATION:STRING=$(EXTERNAL_MODULES_LOCATION)
 endif


### PR DESCRIPTION
Depending on the CMake version when we are configuring it emits a
warning about deprecation of CMAKE_FORCE_CXX_COMPILER. However we
rely on this macro and don't want to do what CMAKE_CXX_COMPILER
is doing. Here is what I get with CMake 3.9.1:

	CMake Deprecation Warning at /usr/share/cmake/Modules/CMakeForceCompiler.cmake:83 (message):
	  The CMAKE_FORCE_CXX_COMPILER macro is deprecated.  Instead just set
	  CMAKE_CXX_COMPILER and allow CMake to identify the compiler.
	Call Stack (most recent call first):
	  cmake/toolchains/Toolchain-arm-none-eabi.cmake:37 (cmake_force_cxx_compiler)
	  /usr/share/cmake/Modules/CMakeDetermineSystem.cmake:94 (include)
	  CMakeLists.txt:263 (project)

Avoid the warning by passing -Wno-deprecated to cmake.