### PR TITLE
Acro: SuperExpo Stick Input

### DIFF
--- a/src/lib/mathlib/math/Functions.hpp
+++ b/src/lib/mathlib/math/Functions.hpp
@@ -54,13 +54,36 @@ int sign(T val)
 /*
  * So called exponential curve function implementation.
  * It is essentially a linear combination between a linear and a cubic function.
- * It's used in the range [-1,1]
+ * @param value [-1,1] input value to function
+ * @param e [0,1] function parameter to set ratio between linear and cubic shape
+ * 		0 - pure linear function
+ * 		1 - pure cubic function
+ * @return result of function output
  */
 template<typename _Tp>
 inline const _Tp expo(const _Tp &value, const _Tp &e)
 {
 	_Tp x = constrain(value, (_Tp) - 1, (_Tp)1);
 	return (1 - e) * x + e * x * x * x;
+}
+
+/*
+ * So called SuperExpo function implementation.
+ * It is a 1/(1-x) function to further shape the rc input curve intuitively.
+ * I enhanced it compared to other implementations to keep the scale between [-1,1].
+ * @param value [-1,1] input value to function
+ * @param e [0,1] function parameter to set ratio between linear and cubic shape (see expo)
+ * @param g [0,1) function parameter to set SuperExpo shape
+ * 		0 - pure expo function
+ * 		0.99 - very strong bent curve, stays zero until maximum stick input
+ * 		1 - DO NOT USE, division by zero on maxima
+ * @return result of function output
+ */
+template<typename _Tp>
+inline const _Tp superexpo(const _Tp &value, const _Tp &e, const _Tp &g)
+{
+	_Tp x = constrain(value, (_Tp) - 1, (_Tp)1);
+	return expo(x, e) * (1 - g) / (1 - fabsf(x) * g);
 }
 
 template<typename _Tp>

--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -371,6 +371,7 @@ PARAM_DEFINE_FLOAT(MC_YAWRAUTO_MAX, 45.0f);
 
 /**
  * Max acro roll rate
+ * default: 2 turns per second
  *
  * @unit deg/s
  * @min 0.0
@@ -379,10 +380,11 @@ PARAM_DEFINE_FLOAT(MC_YAWRAUTO_MAX, 45.0f);
  * @increment 5
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MC_ACRO_R_MAX, 700.0f);
+PARAM_DEFINE_FLOAT(MC_ACRO_R_MAX, 720.0f);
 
 /**
  * Max acro pitch rate
+ * default: 2 turns per second
  *
  * @unit deg/s
  * @min 0.0
@@ -391,10 +393,11 @@ PARAM_DEFINE_FLOAT(MC_ACRO_R_MAX, 700.0f);
  * @increment 5
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 700.0f);
+PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 720.0f);
 
 /**
  * Max acro yaw rate
+ * default 1.5 turns per second
  *
  * @unit deg/s
  * @min 0.0
@@ -403,7 +406,7 @@ PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 700.0f);
  * @increment 5
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MC_ACRO_Y_MAX, 700.0f);
+PARAM_DEFINE_FLOAT(MC_ACRO_Y_MAX, 540.0f);
 
 /**
  * Acro Expo factor

--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -406,7 +406,8 @@ PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 700.0f);
 PARAM_DEFINE_FLOAT(MC_ACRO_Y_MAX, 700.0f);
 
 /**
- * Acro expo factor
+ * Acro Expo factor
+ * applied to input of all axis: roll, pitch, yaw
  *
  * 0 Purely linear input curve
  * 1 Purely cubic input curve
@@ -417,6 +418,21 @@ PARAM_DEFINE_FLOAT(MC_ACRO_Y_MAX, 700.0f);
  * @group Multicopter Attitude Control
  */
 PARAM_DEFINE_FLOAT(MC_ACRO_EXPO, 0.69f);
+
+/**
+ * Acro SuperExpo factor
+ * applied to input of all axis: roll, pitch, yaw
+ *
+ * 0 Pure Expo function
+ * 0.7 resonable shape enhancement for intuitive stick feel
+ * 0.95 very strong bent input curve only near maxima have effect
+ *
+ * @min 0
+ * @max 0.95
+ * @decimal 2
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MC_ACRO_SUPEXPO, 0.7f);
 
 /**
  * Threshold for Rattitude mode

--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -379,7 +379,7 @@ PARAM_DEFINE_FLOAT(MC_YAWRAUTO_MAX, 45.0f);
  * @increment 5
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MC_ACRO_R_MAX, 120.0f);
+PARAM_DEFINE_FLOAT(MC_ACRO_R_MAX, 700.0f);
 
 /**
  * Max acro pitch rate
@@ -391,7 +391,7 @@ PARAM_DEFINE_FLOAT(MC_ACRO_R_MAX, 120.0f);
  * @increment 5
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 120.0f);
+PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 700.0f);
 
 /**
  * Max acro yaw rate
@@ -403,7 +403,20 @@ PARAM_DEFINE_FLOAT(MC_ACRO_P_MAX, 120.0f);
  * @increment 5
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MC_ACRO_Y_MAX, 120.0f);
+PARAM_DEFINE_FLOAT(MC_ACRO_Y_MAX, 700.0f);
+
+/**
+ * Acro expo factor
+ *
+ * 0 Purely linear input curve
+ * 1 Purely cubic input curve
+ *
+ * @min 0
+ * @max 1
+ * @decimal 2
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MC_ACRO_EXPO, 0.69f);
 
 /**
  * Threshold for Rattitude mode


### PR DESCRIPTION
To do actual **acro**batic moves you need to have high rotation rate inputs available which was until now achieved by setting high `MC_ACRO_X_MAX` parameters (X being R,P,Y). The problem with this is that you very fast loose sensitivity around the stick center to keep the vehicle stable and smooth with your small corrections.

That's why people flying model helicopters and race quads like to use a so called exponential curve.
https://librepilot.atlassian.net/wiki/spaces/LPDOC/pages/19890199/Expo+setup
It's nothing else than rescaling your stick input depenting on the stick deflection. What it does mathematically is a linear combination of a linear function and a cubic function between your -1 to 1 stick values.

For more details refer to https://github.com/PX4/Firmware/pull/6440 and https://github.com/PX4/Firmware/pull/6625 where the expo input curve was already introduced for position controlled flight.

My tests so far are using jmavsim on very low resolution to reduce delay and a ***** xbox controller and it seems to work as far as it's possible to tell with bugging sticks and input delay. Looking forward to test this on the racer build https://dev.px4.io/en/airframes_multicopter/qav-r-5-kiss-esc-racer.html tomorrow.

@bkueng I plan to use this for further FPV performance tests.

mc_att_control: use expo input for acro mode to allow for high input rates without loosing input sensitivity