### PR TITLE
implement rover with manual reverse

### DIFF
--- a/ROMFS/px4fmu_common/init.d/50003_rover_wReverse
+++ b/ROMFS/px4fmu_common/init.d/50003_rover_wReverse
@@ -1,0 +1,57 @@
+#!nsh
+#
+# @name rover wth manual reverse
+#
+# @url https://www.horizonhobby.com/product/storefronts/electric-cars-and-trucks/vaterra-brand/1972-chevrolet-k10-pickup-ascender--1-10th-rtr-vtr03090
+#
+# @type Rover
+# @class Rover
+#
+# @output MAIN1 steering
+# @output MAIN3 throttle
+#
+# @maintainer Bo Liu
+#
+
+sh /etc/init.d/rc.ugv_defaults
+
+if [ $AUTOCNF == yes ]
+then
+        param set NAV_ACC_RAD 2.0
+
+        param set MIS_LTRMIN_ALT 0.01
+        param set MIS_TAKEOFF_ALT 0.01
+
+        param set EKF2_GBIAS_INIT 0.01
+        param set EKF2_ANGERR_INIT 0.01
+        param set EKF2_MAG_TYPE 1
+
+        param set GND_WR_P 0.35
+        param set GND_WR_I 0.5
+        param set GND_WR_IMAX 0.5
+        param set GND_WR_D 0.0
+        param set GND_SP_CTRL_MODE 0
+        param set GND_L1_DIST 1.8
+        param set GND_THR_IDLE 0
+        param set GND_THR_CRUISE 0.5
+        param set GND_THR_MAX 0.8
+        param set GND_THR_MIN 0
+        param set GND_SPEED_P 0.2
+        param set GND_SPEED_I 0.1
+        param set GND_SPEED_D 0.0
+        param set GND_SPEED_IMAX 1.0
+        param set GND_SPEED_THR_SC 10
+
+fi
+
+# Configure this as ugv
+set MAV_TYPE 10
+
+# Set mixer
+set MIXER Rover_wReverse
+
+# Provide ESC a constant 1500 us pulse
+set PWM_DISARMED 1500
+set PWM_MAIN_REV2 1
+set PWM_MAX 2000
+set PWM_MIN 1000

--- a/ROMFS/px4fmu_common/mixers/Rover_wReverse.main.mix
+++ b/ROMFS/px4fmu_common/mixers/Rover_wReverse.main.mix
@@ -1,0 +1,42 @@
+# A rover mixer with reverse:
+# This example uses Vaterra Ascender Chevrolet K10 Pickup RTR Rock Crawler,
+# which has a Dynamite S2210 WP 60A Brushed ESC.
+#
+# The only important part here is the power system of your rover:
+# a reverse-enabled ESC and a motor.
+#
+# You need to adjust the offset of the throttle output in this file to
+# achieve motor neutral/break when your throttle stick is at the mid position (usually 1500us).
+#
+# # board pin connections:
+# To be consistent with ArduRover from Ardupilot,
+# reference: https://docs.emlid.com/navio2/ardupilot/typical-setup-schemes/
+# steering servo should be connected to pwm output pin 1
+# and the ESC should be connected to pwm output pin 3
+#
+# This mixer has be tested on a RPI3/Navio2 board.
+#
+
+board pwm out pin 1:
+Steering = Control Group 0, ouput channel 2 (yaw):
+---------------------------------------
+M: 1
+O:       10000   10000      0 -10000  10000
+S: 0 2   10000   10000      0 -10000  10000
+
+board pwm out pin 2:
+This mixer is empty
+---------------------------------------
+Z:
+
+board pwm out pin 3:
+Throttle = Control Group 0, output channel 3 (throttle):
+---------------------------------------
+M: 1
+O:      10000  10000     0  -10000  10000
+S: 0 3  10000  10000     -5000  -10000  10000
+
+board pwm out pin 4:
+This mixer is empty.
+---------------------------------------
+Z:

--- a/posix-configs/rpi/px4_rover.config
+++ b/posix-configs/rpi/px4_rover.config
@@ -1,0 +1,41 @@
+# navio config for a rover
+uorb start
+param load
+param set SYS_AUTOSTART 50003
+param set SYS_COMPANION 921600
+param set MAV_BROADCAST 0
+param set MAV_TYPE 10
+param set SYS_MC_EST_GROUP 2
+param set SYS_RESTART_TYPE 2
+param set BAT_CNT_V_VOLT 0.001
+param set BAT_V_DIV 10.9176300578
+param set BAT_CNT_V_CURR 0.001
+param set BAT_A_PER_V 15.391030303
+dataman start
+df_lsm9ds1_wrapper start -R 4
+df_mpu9250_wrapper start -R 10
+#df_hmc5883_wrapper start
+df_ms5611_wrapper start
+#navio_rgbled start
+navio_adc start
+gps start -d /dev/spidev0.0 -i spi -p ubx
+sensors start
+commander start
+navigator start
+ekf2 start
+gnd_pos_control start
+gnd_att_control start
+## uncomment the the following line for UDP connection
+mavlink start -u 14556 -r 1000000 -t 192.168.1.11
+mavlink stream -u 14556 -s HIGHRES_IMU -r 50
+mavlink stream -u 14556 -s ATTITUDE -r 50
+## Use a motion capture system to simulate HIL GPS indoors,
+## the following line is for Vicon-simulated GPS UDP datastream
+mavlink start -u 45454 -t 192.168.1.2
+mavlink start -d /dev/ttyUSB1
+mavlink stream -d /dev/ttyUSB1 -s HIGHRES_IMU -r 50
+mavlink stream -d /dev/ttyUSB1 -s ATTITUDE -r 50
+navio_sysfs_rc_in start
+linux_pwm_out start -m Rover_wReverse.main.mix
+logger start -t -b 200
+mavlink boot_complete

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -947,12 +947,15 @@ bool handle_command(struct vehicle_status_s *status_local, const struct safety_s
 						&& (status_local->nav_state == vehicle_status_s::NAVIGATION_STATE_MANUAL
 						|| status_local->nav_state == vehicle_status_s::NAVIGATION_STATE_ACRO
 						|| status_local->nav_state == vehicle_status_s::NAVIGATION_STATE_STAB
-						|| status_local->nav_state == vehicle_status_s::NAVIGATION_STATE_RATTITUDE)
-						&& (sp_man.z > 0.1f)) {
+						|| status_local->nav_state == vehicle_status_s::NAVIGATION_STATE_RATTITUDE)) {
 
-						mavlink_log_critical(&mavlink_log_pub, "Arming DENIED. Manual throttle non-zero.");
-						cmd_result = vehicle_command_s::VEHICLE_CMD_RESULT_DENIED;
-						break;
+						// for rover, mid throttle is required. for other frames zero throttle is required
+						if ( (status_local->system_type == 10 && (sp_man.z > 0.6f || sp_man.z < 0.4f)) ||
+						     (status_local->system_type != 10 && sp_man.z > 0.1f) ) {
+						    mavlink_log_critical(&mavlink_log_pub, "Arming DENIED. Manual throttle non-zero.");
+						    cmd_result = vehicle_command_s::VEHICLE_CMD_RESULT_DENIED;
+						    break;
+						}
 					}
 				}
 
@@ -2682,18 +2685,21 @@ int commander_thread_main(int argc, char *argv[])
 			const bool arm_button_pressed = arm_switch_is_button == 1 && sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_ON;
 
 			/* DISARM
-			 * check if left stick is in lower left position or arm button is pushed or arm switch has transition from arm to disarm
+			 * check if left stick is in lower left position, except for rover which requires a mid left position, or arm button is pushed or arm switch has transition from arm to disarm
 			 * and we are in MANUAL, Rattitude, or AUTO_READY mode or (ASSIST mode and landed)
 			 * do it only for rotary wings in manual mode or fixed wing if landed */
 			const bool stick_in_lower_left = sp_man.r < -STICK_ON_OFF_LIMIT && sp_man.z < 0.1f;
+			const bool stick_in_mid_left = sp_man.r < -STICK_ON_OFF_LIMIT && sp_man.z < 0.6f && sp_man.z > 0.4f;
+
 			const bool arm_switch_to_disarm_transition =  arm_switch_is_button == 0 &&
-					_last_sp_man_arm_switch == manual_control_setpoint_s::SWITCH_POS_ON &&
-					sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_OFF;
+				_last_sp_man_arm_switch == manual_control_setpoint_s::SWITCH_POS_ON &&
+				sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_OFF;
 
 			if (in_armed_state &&
-				status.rc_input_mode != vehicle_status_s::RC_IN_MODE_OFF &&
-				(status.is_rotary_wing || (!status.is_rotary_wing && land_detector.landed)) &&
-				(stick_in_lower_left || arm_button_pressed || arm_switch_to_disarm_transition) ) {
+			    status.rc_input_mode != vehicle_status_s::RC_IN_MODE_OFF &&
+			    (status.is_rotary_wing || (!status.is_rotary_wing && land_detector.landed)) &&
+			    (((stick_in_lower_left && status.system_type != 10) || (stick_in_mid_left && status.system_type == 10))
+			     || arm_button_pressed || arm_switch_to_disarm_transition)) {
 
 				if (internal_state.main_state != commander_state_s::MAIN_STATE_MANUAL &&
 						internal_state.main_state != commander_state_s::MAIN_STATE_ACRO &&
@@ -2729,17 +2735,20 @@ int commander_thread_main(int argc, char *argv[])
 			}
 
 			/* ARM
-			 * check if left stick is in lower right position or arm button is pushed or arm switch has transition from disarm to arm
+			 * check if left stick is in lower right position, except for rover which requires a mid right position, or arm button is pushed or arm switch has transition from disarm to arm
 			 * and we're in MANUAL mode */
 			const bool stick_in_lower_right = (sp_man.r > STICK_ON_OFF_LIMIT && sp_man.z < 0.1f);
+			const bool stick_in_mid_right = (sp_man.r > 0.4f && sp_man.z < 0.6f);
+
 			const bool arm_switch_to_arm_transition = arm_switch_is_button == 0 &&
-					_last_sp_man_arm_switch == manual_control_setpoint_s::SWITCH_POS_OFF &&
-					sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_ON;
+				_last_sp_man_arm_switch == manual_control_setpoint_s::SWITCH_POS_OFF &&
+				sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_ON;
 
 			if (!in_armed_state &&
-				status.rc_input_mode != vehicle_status_s::RC_IN_MODE_OFF &&
-				(stick_in_lower_right || arm_button_pressed || arm_switch_to_arm_transition) ) {
-				if ((stick_on_counter == rc_arm_hyst && stick_off_counter < rc_arm_hyst) || arm_switch_to_arm_transition) {
+			    status.rc_input_mode != vehicle_status_s::RC_IN_MODE_OFF &&
+			    (((stick_in_lower_right && status.system_type != 10) || (stick_in_mid_right && status.system_type == 10))
+			     || arm_button_pressed || arm_switch_to_arm_transition)) {
+			    if ((stick_on_counter == rc_arm_hyst && stick_off_counter < rc_arm_hyst) || arm_switch_to_arm_transition) {
 
 					/* we check outside of the transition function here because the requirement
 					 * for being in manual mode only applies to manual arming actions.

--- a/src/modules/gnd_att_control/GroundRoverAttitudeControl.cpp
+++ b/src/modules/gnd_att_control/GroundRoverAttitudeControl.cpp
@@ -55,6 +55,11 @@ namespace att_gnd_control
 GroundRoverAttitudeControl	*g_control = nullptr;
 }
 
+namespace gnd_throttle
+{
+const double HOLD = 0.5;
+}
+
 GroundRoverAttitudeControl::GroundRoverAttitudeControl() :
 	/* performance counters */
 	_loop_perf(perf_alloc(PC_ELAPSED, "gnda_dt")),
@@ -141,6 +146,17 @@ GroundRoverAttitudeControl::vehicle_control_mode_poll()
 }
 
 void
+GroundRoverAttitudeControl::vehicle_status_poll()
+{
+	bool updated = false;
+	orb_check(_vstatus_sub, &updated);
+
+	if (updated) {
+		orb_copy(ORB_ID(vehicle_status), _vstatus_sub, &_vstatus);
+	}
+}
+
+void
 GroundRoverAttitudeControl::manual_control_setpoint_poll()
 {
 	bool updated = false;
@@ -186,6 +202,7 @@ GroundRoverAttitudeControl::task_main()
 	_att_sp_sub = orb_subscribe(ORB_ID(vehicle_attitude_setpoint));
 	_att_sub = orb_subscribe(ORB_ID(vehicle_attitude));
 	_vcontrol_mode_sub = orb_subscribe(ORB_ID(vehicle_control_mode));
+	_vstatus_sub = orb_subscribe(ORB_ID(vehicle_status));
 	_params_sub = orb_subscribe(ORB_ID(parameter_update));
 	_manual_sub = orb_subscribe(ORB_ID(manual_control_setpoint));
 	_battery_status_sub = orb_subscribe(ORB_ID(battery_status));
@@ -310,6 +327,11 @@ GroundRoverAttitudeControl::task_main()
 
 						_actuators.control[actuator_controls_s::INDEX_THROTTLE] *= _battery_status.scale;
 					}
+				}
+
+				/* When reverse is possible, at HOLD mode, throttle hold pwm should be at the mid position */
+				if (_vstatus.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER) {
+					_actuators.control[actuator_controls_s::INDEX_THROTTLE] = gnd_throttle::HOLD;
 				}
 
 			} else {

--- a/src/modules/gnd_att_control/GroundRoverAttitudeControl.hpp
+++ b/src/modules/gnd_att_control/GroundRoverAttitudeControl.hpp
@@ -59,6 +59,7 @@
 #include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_rates_setpoint.h>
+#include <uORB/topics/vehicle_status.h>
 #include <uORB/uORB.h>
 
 using matrix::Eulerf;
@@ -85,6 +86,7 @@ private:
 	int		_manual_sub{-1};			/**< notification of manual control updates */
 	int		_params_sub{-1};			/**< notification of parameter updates */
 	int		_vcontrol_mode_sub{-1};		/**< vehicle status subscription */
+	int		_vstatus_sub{-1};          /**< vehicle status subscription */
 
 	orb_advert_t	_actuators_0_pub{nullptr};		/**< actuator control group 0 setpoint */
 
@@ -94,6 +96,7 @@ private:
 	vehicle_attitude_s				_att {};	/**< control state */
 	vehicle_attitude_setpoint_s		_att_sp {};		/**< vehicle attitude setpoint */
 	vehicle_control_mode_s			_vcontrol_mode {};		/**< vehicle control mode */
+	vehicle_status_s			_vstatus {};		/**< vehicle status */
 
 	perf_counter_t	_loop_perf;			/**< loop performance counter */
 	perf_counter_t	_nonfinite_input_perf;		/**< performance counter for non finite input */
@@ -132,6 +135,7 @@ private:
 	void		parameters_update();
 
 	void		vehicle_control_mode_poll();
+	void		vehicle_status_poll();
 	void		manual_control_setpoint_poll();
 	void		vehicle_attitude_setpoint_poll();
 	void		battery_status_poll();

--- a/src/modules/gnd_pos_control/GroundRoverPositionControl.cpp
+++ b/src/modules/gnd_pos_control/GroundRoverPositionControl.cpp
@@ -57,6 +57,10 @@ using matrix::Vector3f;
  */
 extern "C" __EXPORT int gnd_pos_control_main(int argc, char *argv[]);
 
+namespace gnd_throttle
+{
+const float HOLD = 0.5;
+}
 
 namespace gnd_control
 {
@@ -204,6 +208,11 @@ void GroundRoverPositionControl::gnd_pos_ctrl_status_publish()
 	}
 }
 
+float GroundRoverPositionControl::map_above(float source, float mid)
+{
+	return (1.0f - mid) * source + mid;
+}
+
 bool
 GroundRoverPositionControl::control_position(const math::Vector<2> &current_position,
 		const math::Vector<3> &ground_speed, const position_setpoint_triplet_s &pos_sp_triplet)
@@ -239,7 +248,8 @@ GroundRoverPositionControl::control_position(const math::Vector<2> &current_posi
 
 		math::Vector<2> ground_speed_2d = {ground_speed(0), ground_speed(1)};
 
-		float mission_throttle = _parameters.throttle_cruise;
+		/* map mission_throttle to the upper half of the throttle range for forward only */
+		float mission_throttle = map_above(_parameters.throttle_cruise, gnd_throttle::HOLD);
 
 		/* Just control the throttle */
 		if (_parameters.speed_control_mode == 1) {
@@ -279,7 +289,7 @@ GroundRoverPositionControl::control_position(const math::Vector<2> &current_posi
 			_att_sp.roll_body = 0.0f;
 			_att_sp.pitch_body = 0.0f;
 			_att_sp.yaw_body = 0.0f;
-			_att_sp.thrust = 0.0f;
+			_att_sp.thrust = gnd_throttle::HOLD;
 
 		} else if ((pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_POSITION)
 			   || (pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF)) {
@@ -302,7 +312,7 @@ GroundRoverPositionControl::control_position(const math::Vector<2> &current_posi
 			_att_sp.pitch_body = 0.0f;
 			_att_sp.yaw_body = _gnd_control.nav_bearing();
 			_att_sp.fw_control_yaw = true;
-			_att_sp.thrust = 0.0f;
+			_att_sp.thrust = gnd_throttle::HOLD;
 		}
 
 		if (was_circle_mode && !_gnd_control.circle_mode()) {
@@ -317,7 +327,7 @@ GroundRoverPositionControl::control_position(const math::Vector<2> &current_posi
 		_att_sp.pitch_body = 0.0f;
 		_att_sp.yaw_body = 0.0f;
 		_att_sp.fw_control_yaw = true;
-		_att_sp.thrust = 0.0f;
+		_att_sp.thrust = gnd_throttle::HOLD;
 
 		/* do not publish the setpoint */
 		setpoint = false;

--- a/src/modules/gnd_pos_control/GroundRoverPositionControl.hpp
+++ b/src/modules/gnd_pos_control/GroundRoverPositionControl.hpp
@@ -178,6 +178,10 @@ private:
 
 	} _parameter_handles{};		/**< handles for interesting parameters */
 
+	/**
+	 * Helper function to map range [0,1] to [mid,1.0]
+	 */
+	float map_above(float source, float mid);
 
 	/**
 	 * Update our local parameter cache.


### PR DESCRIPTION
@TSC21 @dagar This pull request is exactly the same as #7902 except that the mixer is rewritten such that the ESC and steering servo connection is consistent with the case in ~~ArduRover from Ardupilot. i.e. pin 1 connects to ESC, pin 3 connects to the steering servo.~~(it turns out ardurover does not have a consistent wiring setup from version to version) [Navio2 rover setup](https://docs.emlid.com/navio2/ardupilot/typical-setup-schemes/) i.e. pin 1 connects to steering servo, pin 3 connects to the ESC.

This implementation has the following behavior:
* manual mode has reverse if the ESC support reverse.
 * the mid position of throttle channel (typically 1500  us) is the neutral or breaking, the lower half is for revere and the higher half is for going forward.
 * arming requires throttle channel at neutral position when motor is not spinning. 
* auto mission uses only the forward range of the throttle channel. auto hold mode uses neutral/breaking throttle.
* for the users, the behavior of mission cruise settings stay the same. e.g. 50% cruise throttle will be mapped to the correct forward speed, i.e. 50% of full forward speed.
* Other vehicle configurations and behaviors not affected.

This new pull request is re-tested on RPI3 with Navio2.

This pull request is accompanied by https://github.com/PX4/px4_user_guide/pull/69