### PR TITLE
Helicopter mixer scale throttle to -1 .. +1

### DIFF
--- a/src/modules/systemlib/mixer/mixer_helicopter.cpp
+++ b/src/modules/systemlib/mixer/mixer_helicopter.cpp
@@ -252,7 +252,7 @@ HelicopterMixer::mix(float *outputs, unsigned space)
 	/* Local throttle curve gradient and offset */
 	float tg = (_mixer_info.throttle_curve[idx + 1] - _mixer_info.throttle_curve[idx]) / 0.25f;
 	float to = (_mixer_info.throttle_curve[idx]) - (tg * idx * 0.25f);
-	float throttle = constrain((tg * thrust_cmd + to), 0.0f, 1.0f);
+	float throttle = constrain(2.0f * (tg * thrust_cmd + to) - 1.0f, -1.0f, 1.0f);
 
 	/* Local pitch curve gradient and offset */
 	float pg = (_mixer_info.pitch_curve[idx + 1] - _mixer_info.pitch_curve[idx]) / 0.25f;


### PR DESCRIPTION
Not sure why it worked for me without this change. I cannot test it myself. Should fix https://github.com/PX4/Firmware/issues/8013