### PR TITLE
Check mag sensor for consistency before flight

### DIFF
--- a/msg/sensor_preflight.msg
+++ b/msg/sensor_preflight.msg
@@ -4,3 +4,4 @@
 #
 float32 accel_inconsistency_m_s_s  # magnitude of maximum acceleration difference between IMU instances in (m/s/s).
 float32 gyro_inconsistency_rad_s   # magnitude of maximum angular rate difference between IMU instances in (rad/s).
+float32 mag_inconsistency_ga       # magnitude of maximum difference between Mag instances in (Gauss).

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -591,6 +591,18 @@ PARAM_DEFINE_FLOAT(COM_ARM_IMU_ACC, 0.7f);
 PARAM_DEFINE_FLOAT(COM_ARM_IMU_GYR, 0.25f);
 
 /**
+ * Maximum magnetic field inconsistency between units that will allow arming
+ *
+ * @group Commander
+ * @unit Gauss
+ * @min 0.05
+ * @max 0.5
+ * @decimal 2
+ * @increment 0.05
+ */
+PARAM_DEFINE_FLOAT(COM_ARM_MAG, 0.15f);
+
+/**
  * Enable RC stick override of auto modes
  *
  * @boolean

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -614,8 +614,8 @@ Sensors::run()
 
 	/* advertise the sensor_preflight topic and make the initial publication */
 	preflt.accel_inconsistency_m_s_s = 0.0f;
-
 	preflt.gyro_inconsistency_rad_s = 0.0f;
+	preflt.mag_inconsistency_ga = 0.0f;
 
 	_sensor_preflight = orb_advertise(ORB_ID(sensor_preflight), &preflt);
 
@@ -679,6 +679,7 @@ Sensors::run()
 			if (!_armed) {
 				_voted_sensors_update.calc_accel_inconsistency(preflt);
 				_voted_sensors_update.calc_gyro_inconsistency(preflt);
+				_voted_sensors_update.calc_mag_inconsistency(preflt);
 				orb_publish(ORB_ID(sensor_preflight), _sensor_preflight, &preflt);
 
 			}

--- a/src/modules/sensors/voted_sensors_update.h
+++ b/src/modules/sensors/voted_sensors_update.h
@@ -142,7 +142,12 @@ public:
 	/**
 	 * Calculates the magnitude in rad/s of the largest difference between the primary and any other gyro sensor
 	 */
-	void calc_gyro_inconsistency(struct sensor_preflight_s &preflt);
+	void calc_gyro_inconsistency(sensor_preflight_s &preflt);
+
+	/**
+	 * Calculates the magnitude in Gauss of the largest difference between the primary and any other magnetometers
+	 */
+	void calc_mag_inconsistency(sensor_preflight_s &preflt);
 
 private:
 
@@ -263,6 +268,7 @@ private:
 
 	float _accel_diff[3][2];	/**< filtered accel differences between IMU units (m/s/s) */
 	float _gyro_diff[3][2];		/**< filtered gyro differences between IMU uinits (rad/s) */
+	float _mag_diff[3][2];		/**< filtered mag differences between sensor instances (Ga) */
 
 	/* sensor thermal compensation */
 	TemperatureCompensation _temperature_compensation;


### PR DESCRIPTION
Many vehicle have multiple magnetometers fitted which are all calibrated by default and which can all be used by the sensor selection logic. Checking the sensors for consistency will prevent takeoff if one of the sensors has an invalid calibration or if the orientation is set incorrectly.

Potential issues with this solution that need resolving are:

1) Ground based magnetic anomalies will cause this check to fail when sensors are not co-located. We need a way to inform the user that the first cation is to pick up the vehicle to clear the check. This will require the pass to latch.

2) One sensor may have issues that prevent it being successfully calibrated or used. We need to provide a way that users can prevent a problem sensor being used by this and the selection algorithm.