### PR TITLE
VTOL standard preserve PWM_MIN and PWM_MAX

### DIFF
--- a/msg/vtol_vehicle_status.msg
+++ b/msg/vtol_vehicle_status.msg
@@ -8,5 +8,7 @@ uint8 VEHICLE_VTOL_STATE_FW = 4
 bool vtol_in_rw_mode			# true: vtol vehicle is in rotating wing mode
 bool vtol_in_trans_mode
 bool in_transition_to_fw		# True if VTOL is doing a transition from MC to FW
+
 bool vtol_transition_failsafe	# vtol in transition failsafe mode
+
 bool fw_permanent_stab			# In fw mode stabilize attitude even if in manual mode

--- a/src/drivers/pwm_out_sim/pwm_out_sim.cpp
+++ b/src/drivers/pwm_out_sim/pwm_out_sim.cpp
@@ -661,6 +661,11 @@ PWMSim::pwm_ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			break;
 		}
 
+	case PWM_SERVO_SET_MIN_PWM: {
+			// accept message, but do nothing
+			break;
+		}
+
 	case PWM_SERVO_GET_MIN_PWM: {
 			struct pwm_output_values *pwm = (struct pwm_output_values *)arg;
 
@@ -680,6 +685,11 @@ PWMSim::pwm_ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			}
 
 			pwm->channel_count = _num_outputs;
+			break;
+		}
+
+	case PWM_SERVO_SET_MAX_PWM: {
+			// accept message, but do nothing
 			break;
 		}
 

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -600,7 +600,7 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT_S(ATTC, ATTC, "ffff",		"Roll,Pitch,Yaw,Thrust"),
 	LOG_FORMAT_S(ATC1, ATTC, "ffff",		"Roll,Pitch,Yaw,Thrust"),
 	LOG_FORMAT(STAT, "BBBBB",		"MainState,NavState,ArmS,Failsafe,IsRotWing"),
-	LOG_FORMAT(VTOL, "fBBB",		"Arsp,RwMode,TransMode,Failsafe"),
+	LOG_FORMAT(VTOL, "BBB",		"RwMode,TransMode,Failsafe"),
 	LOG_FORMAT(CTS, "fffffff", "Vx_b,Vy_b,Vz_b,Vinf,P,Q,R"),
 	LOG_FORMAT(RC, "ffffffffffffBBBL",		"C0,C1,C2,C3,C4,C5,C6,C7,C8,C9,C10,C11,RSSI,CNT,Lost,Drop"),
 	LOG_FORMAT_S(OUT0, OUT, "ffffffff",		"Out0,Out1,Out2,Out3,Out4,Out5,Out6,Out7"),

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -284,7 +284,7 @@ void Standard::update_transition_state()
 		_airbrakes_output = 0.0f;
 
 		const float as_blend_region = _params_standard.airspeed_trans - _params_standard.airspeed_blend;
-		const float as_above_blend = _airspeed->indicated_airspeed_m_s >= _params_standard.airspeed_blend;
+		const float as_above_blend = _airspeed->indicated_airspeed_m_s - _params_standard.airspeed_blend;
 
 		// do blending of mc and fw controls if a blending airspeed has been provided and the minimum transition time has passed
 		if (_params_standard.airspeed_enabled && (as_blend_region > 0.0f) && (as_above_blend > 0.0f) &&
@@ -491,12 +491,14 @@ void Standard::fill_actuator_outputs()
 			fw_out[actuator_controls_s::INDEX_PITCH] = 0.0f;
 			fw_out[actuator_controls_s::INDEX_YAW] = 0.0f;
 			fw_out[actuator_controls_s::INDEX_THROTTLE] = _pusher_throttle;
+			fw_out[actuator_controls_s::INDEX_AIRBRAKES] = _airbrakes_output;
 
 		} else {
 			fw_out[actuator_controls_s::INDEX_ROLL] = -fw_in[actuator_controls_s::INDEX_ROLL];
 			fw_out[actuator_controls_s::INDEX_PITCH] = fw_in[actuator_controls_s::INDEX_PITCH];
 			fw_out[actuator_controls_s::INDEX_YAW] = fw_in[actuator_controls_s::INDEX_YAW];
 			fw_out[actuator_controls_s::INDEX_THROTTLE] = _pusher_throttle;
+			fw_out[actuator_controls_s::INDEX_AIRBRAKES] = _airbrakes_output;
 		}
 
 		break;
@@ -512,6 +514,7 @@ void Standard::fill_actuator_outputs()
 		fw_out[actuator_controls_s::INDEX_PITCH] = fw_in[actuator_controls_s::INDEX_PITCH];
 		fw_out[actuator_controls_s::INDEX_YAW] = fw_in[actuator_controls_s::INDEX_YAW];
 		fw_out[actuator_controls_s::INDEX_THROTTLE] = _pusher_throttle;
+		fw_out[actuator_controls_s::INDEX_AIRBRAKES] = _airbrakes_output;
 
 		break;
 
@@ -525,6 +528,7 @@ void Standard::fill_actuator_outputs()
 		fw_out[actuator_controls_s::INDEX_PITCH] = fw_in[actuator_controls_s::INDEX_PITCH];
 		fw_out[actuator_controls_s::INDEX_YAW] = fw_in[actuator_controls_s::INDEX_YAW];
 		fw_out[actuator_controls_s::INDEX_THROTTLE] = fw_in[actuator_controls_s::INDEX_THROTTLE];
+		fw_out[actuator_controls_s::INDEX_AIRBRAKES] = fw_in[actuator_controls_s::INDEX_AIRBRAKES];
 
 		break;
 	}

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -47,42 +47,40 @@
 #include <float.h>
 
 Standard::Standard(VtolAttitudeControl *attc) :
-	VtolType(attc),
-	_flag_enable_mc_motors(true),
-	_pusher_throttle(0.0f),
-	_reverse_output(0.0f),
-	_airspeed_trans_blend_margin(0.0f)
+	VtolType(attc)
 {
 	_vtol_schedule.flight_mode = MC_MODE;
 	_vtol_schedule.transition_start = 0;
+
 	_pusher_active = false;
 
-	_mc_roll_weight = 1.0f;
-	_mc_pitch_weight = 1.0f;
-	_mc_yaw_weight = 1.0f;
 	_mc_throttle_weight = 1.0f;
 
+	// forward transition
 	_params_handles_standard.front_trans_dur = param_find("VT_F_TRANS_DUR");
-	_params_handles_standard.back_trans_dur = param_find("VT_B_TRANS_DUR");
-	_params_handles_standard.back_trans_ramp = param_find("VT_B_TRANS_RAMP");
 	_params_handles_standard.pusher_trans = param_find("VT_TRANS_THR");
 	_params_handles_standard.airspeed_blend = param_find("VT_ARSP_BLEND");
 	_params_handles_standard.airspeed_trans = param_find("VT_ARSP_TRANS");
 	_params_handles_standard.front_trans_timeout = param_find("VT_TRANS_TIMEOUT");
 	_params_handles_standard.front_trans_time_min = param_find("VT_TRANS_MIN_TM");
+
+	// pusher assist
 	_params_handles_standard.down_pitch_max = param_find("VT_DWN_PITCH_MAX");
 	_params_handles_standard.forward_thrust_scale = param_find("VT_FWD_THRUST_SC");
-	_params_handles_standard.airspeed_disabled = param_find("FW_ARSP_MODE");
-	_params_handles_standard.pitch_setpoint_offset = param_find("FW_PSP_OFF");
+
+	// back transition
+	_params_handles_standard.back_trans_dur = param_find("VT_B_TRANS_DUR");
+	_params_handles_standard.back_trans_ramp = param_find("VT_B_TRANS_RAMP");
 	_params_handles_standard.reverse_output = param_find("VT_B_REV_OUT");
 	_params_handles_standard.reverse_delay = param_find("VT_B_REV_DEL");
 	_params_handles_standard.back_trans_throttle = param_find("VT_B_TRANS_THR");
+
+	// FW parameters
+	_params_handles_standard.airspeed_mode = param_find("FW_ARSP_MODE");
+	_params_handles_standard.pitch_setpoint_offset = param_find("FW_PSP_OFF");
+
+	// MC parameters
 	_params_handles_standard.mpc_xy_cruise = param_find("MPC_XY_CRUISE");
-
-}
-
-Standard::~Standard()
-{
 }
 
 void
@@ -115,8 +113,6 @@ Standard::parameters_update()
 	param_get(_params_handles_standard.airspeed_blend, &v);
 	_params_standard.airspeed_blend = math::constrain(v, 0.0f, 20.0f);
 
-	_airspeed_trans_blend_margin = _params_standard.airspeed_trans - _params_standard.airspeed_blend;
-
 	/* timeout for transition to fw mode */
 	param_get(_params_handles_standard.front_trans_timeout, &_params_standard.front_trans_timeout);
 
@@ -130,29 +126,32 @@ Standard::parameters_update()
 	/* scale for fixed wing thrust used for forward acceleration in multirotor mode */
 	param_get(_params_handles_standard.forward_thrust_scale, &_params_standard.forward_thrust_scale);
 
+	/* airbrakes value during back transition (often used to control ESC direction) */
+	param_get(_params_handles_standard.reverse_output, &v);
+	_params_standard.reverse_output = math::constrain(v, 0.0f, 1.0f);
+
+	/* delay before applying back transition throttle */
+	param_get(_params_handles_standard.reverse_delay, &v);
+	_params_standard.reverse_delay = math::constrain(v, 0.0f, 10.0f);
+
+	/* back transition throttle (usually reverse throttle) */
+	param_get(_params_handles_standard.back_trans_throttle, &v);
+	_params_standard.back_trans_throttle = math::constrain(v, -1.0f, 1.0f);
+
+
+	// FW paramaters
+
 	/* airspeed mode */
-	param_get(_params_handles_standard.airspeed_disabled, &i);
-	_params_standard.airspeed_disabled = math::constrain(i, 0, 1);
+	param_get(_params_handles_standard.airspeed_mode, &i);
+	_params_standard.airspeed_enabled = (i == 0);
 
 	/* pitch setpoint offset */
 	param_get(_params_handles_standard.pitch_setpoint_offset, &v);
 	_params_standard.pitch_setpoint_offset = math::radians(v);
 
-	/* reverse output */
-	param_get(_params_handles_standard.reverse_output, &v);
-	_params_standard.reverse_output = math::constrain(v, 0.0f, 1.0f);
 
-	/* reverse output */
-	param_get(_params_handles_standard.reverse_delay, &v);
-	_params_standard.reverse_delay = math::constrain(v, 0.0f, 10.0f);
-
-	/* reverse throttle */
-	param_get(_params_handles_standard.back_trans_throttle, &v);
-	_params_standard.back_trans_throttle = math::constrain(v, -1.0f, 1.0f);
-
-	/* mpc cruise speed */
+	// MC parameters
 	param_get(_params_handles_standard.mpc_xy_cruise, &_params_standard.mpc_xy_cruise);
-
 }
 
 void Standard::update_vtol_state()
@@ -162,126 +161,112 @@ void Standard::update_vtol_state()
 	 * For the back transition the pusher motor is immediately stopped and rotors reactivated.
 	 */
 
-	float mc_weight = _mc_roll_weight;
-
 	if (!_attc->is_fixed_wing_requested()) {
 
 		// the transition to fw mode switch is off
-		if (_vtol_schedule.flight_mode == MC_MODE) {
-			// in mc mode
-			_vtol_schedule.flight_mode = MC_MODE;
-			mc_weight = 1.0f;
-			_pusher_throttle = 0.0f;
-			_reverse_output = 0.0f;
 
-		} else if (_vtol_schedule.flight_mode == FW_MODE) {
+		if (_vtol_schedule.flight_mode == FW_MODE) {
 			// transition to mc mode
-			if (_vtol_vehicle_status->vtol_transition_failsafe == true) {
+			if (_vtol_vehicle_status->vtol_transition_failsafe) {
 				// Failsafe event, engage mc motors immediately
 				_vtol_schedule.flight_mode = MC_MODE;
 				_flag_enable_mc_motors = true;
-				_pusher_throttle = 0.0f;
-				_reverse_output = 0.0f;
-
 
 			} else {
 				// Regular backtransition
+				_vtol_schedule.transition_start = hrt_absolute_time();
 				_vtol_schedule.flight_mode = TRANSITION_TO_MC;
 				_flag_enable_mc_motors = true;
-				_vtol_schedule.transition_start = hrt_absolute_time();
-				_reverse_output = _params_standard.reverse_output;
-
+				_transition_achieved = false;
 			}
 
 		} else if (_vtol_schedule.flight_mode == TRANSITION_TO_FW) {
 			// failsafe back to mc mode
 			_vtol_schedule.flight_mode = MC_MODE;
-			mc_weight = 1.0f;
-			_pusher_throttle = 0.0f;
-			_reverse_output = 0.0f;
-
 
 		} else if (_vtol_schedule.flight_mode == TRANSITION_TO_MC) {
 			// transition to MC mode if transition time has passed or forward velocity drops below MPC cruise speed
-
 			const matrix::Dcmf R_to_body(matrix::Quatf(_v_att->q).inversed());
 			const matrix::Vector3f vel = R_to_body * matrix::Vector3f(_local_pos->vx, _local_pos->vy, _local_pos->vz);
 
-			float x_vel = vel(0);
+			const bool mc_speed_limit = _local_pos->v_xy_valid && (vel(0) <= _params_standard.mpc_xy_cruise);
 
-			if (hrt_elapsed_time(&_vtol_schedule.transition_start) >
-			    (_params_standard.back_trans_dur * 1000000.0f) ||
-			    (_local_pos->v_xy_valid && x_vel <= _params_standard.mpc_xy_cruise)) {
-				_vtol_schedule.flight_mode = MC_MODE;
+			const bool back_trans_timeout = (hrt_elapsed_time(&_vtol_schedule.transition_start) >
+							 (_params_standard.back_trans_dur * 1e6f));
+
+			if (back_trans_timeout || mc_speed_limit || can_transition_on_ground()) {
+				if (!_transition_achieved) {
+					// first time transition achieved, begin transition timer
+					_trans_finished_ts = hrt_absolute_time();
+				}
+
+				_transition_achieved = true;
+
+			} else {
+				_transition_achieved = false;
+				_trans_finished_ts = 0;
 			}
 
+			// all conditions must be continuously satisfied for > 1s to complete transition
+			if (_transition_achieved && (hrt_elapsed_time(&_trans_finished_ts) > 1e6f)) {
+				_vtol_schedule.flight_mode = MC_MODE;
+			}
 		}
 
 	} else {
 		// the transition to fw mode switch is on
 		if (_vtol_schedule.flight_mode == MC_MODE || _vtol_schedule.flight_mode == TRANSITION_TO_MC) {
 			// start transition to fw mode
-			/* NOTE: The failsafe transition to fixed-wing was removed because it can result in an
-			 * unsafe flying state. */
-			_vtol_schedule.flight_mode = TRANSITION_TO_FW;
-			_vtol_schedule.transition_start = hrt_absolute_time();
 
-		} else if (_vtol_schedule.flight_mode == FW_MODE) {
-			// in fw mode
-			_vtol_schedule.flight_mode = FW_MODE;
-			mc_weight = 0.0f;
+			_vtol_schedule.transition_start = hrt_absolute_time();
+			_vtol_schedule.flight_mode = TRANSITION_TO_FW;
+			_transition_achieved = false;
 
 		} else if (_vtol_schedule.flight_mode == TRANSITION_TO_FW) {
-			// continue the transition to fw mode while monitoring airspeed for a final switch to fw mode
-			if (((_params_standard.airspeed_disabled == 1 ||
-			      _airspeed->indicated_airspeed_m_s >= _params_standard.airspeed_trans) &&
-			     (float)hrt_elapsed_time(&_vtol_schedule.transition_start)
-			     > (_params_standard.front_trans_time_min * 1000000.0f)) ||
-			    can_transition_on_ground()) {
+			// continue the transition to FW mode while monitoring airspeed and MC throttle
 
-				_vtol_schedule.flight_mode = FW_MODE;
-				// we can turn off the multirotor motors now
-				_flag_enable_mc_motors = false;
-				// don't set pusher throttle here as it's being ramped up elsewhere
-				_trans_finished_ts = hrt_absolute_time();
+			const bool airspeed = (_airspeed->indicated_airspeed_m_s >= _params_standard.airspeed_trans)
+					      || !_params_standard.airspeed_enabled;
+			const bool min_trans_time = (hrt_elapsed_time(&_vtol_schedule.transition_start) > (_params_standard.front_trans_time_min
+						     * 1e6f));
+
+			if ((airspeed && min_trans_time) || can_transition_on_ground()) {
+				if (!_transition_achieved) {
+					// first time transition achieved, begin transition timer
+					_trans_finished_ts = hrt_absolute_time();
+				}
+
+				_transition_achieved = true;
+
+			} else {
+				_transition_achieved = false;
+				_trans_finished_ts = 0;
 			}
 
+			// all conditions must be continuously satisfied for > 1s to complete transition
+			if (_transition_achieved && (hrt_elapsed_time(&_trans_finished_ts) > 1e6f)) {
+				_vtol_schedule.flight_mode = FW_MODE;
+
+				// we can turn off the multirotor motors now
+				_flag_enable_mc_motors = false;
+
+				// update final transition finished time
+				_trans_finished_ts = hrt_absolute_time();
+			}
 		}
 	}
 
-	_mc_roll_weight = mc_weight;
-	_mc_pitch_weight = mc_weight;
-	_mc_yaw_weight = mc_weight;
-	_mc_throttle_weight = mc_weight;
-
-	// map specific control phases to simple control modes
-	switch (_vtol_schedule.flight_mode) {
-	case MC_MODE:
-		_vtol_mode = mode::ROTARY_WING;
-		break;
-
-	case FW_MODE:
-		_vtol_mode = mode::FIXED_WING;
-		break;
-
-	case TRANSITION_TO_FW:
-		_vtol_mode = mode::TRANSITION_TO_FW;
-		break;
-
-	case TRANSITION_TO_MC:
-		_vtol_mode = mode::TRANSITION_TO_MC;
-		break;
-	}
+	_vtol_mode = (mode)_vtol_schedule.flight_mode;
 }
 
 void Standard::update_transition_state()
 {
-	float mc_weight = 1.0f;
-
 	VtolType::update_transition_state();
 
 	// copy virtual attitude setpoint to real attitude setpoint
 	memcpy(_v_att_sp, _mc_virtual_att_sp, sizeof(vehicle_attitude_setpoint_s));
+
+	const float trans_elapsed = hrt_elapsed_time(&_vtol_schedule.transition_start) / 1e6f;
 
 	if (_vtol_schedule.flight_mode == TRANSITION_TO_FW) {
 		if (_params_standard.front_trans_dur <= 0.0f) {
@@ -289,40 +274,50 @@ void Standard::update_transition_state()
 			_pusher_throttle = _params_standard.pusher_trans;
 
 		} else if (_pusher_throttle <= _params_standard.pusher_trans) {
+			const float progress = math::constrain(trans_elapsed / _params_standard.front_trans_dur, 0.0f, 1.0f);
+
 			// ramp up throttle to the target throttle value
-			_pusher_throttle = _params_standard.pusher_trans *
-					   (float)hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params_standard.front_trans_dur * 1000000.0f);
+			_pusher_throttle = _params_standard.pusher_trans * progress;
 		}
 
+		// disable airbrakes output
+		_airbrakes_output = 0.0f;
+
+		const float as_blend_region = _params_standard.airspeed_trans - _params_standard.airspeed_blend;
+		const float as_above_blend = _airspeed->indicated_airspeed_m_s >= _params_standard.airspeed_blend;
+
 		// do blending of mc and fw controls if a blending airspeed has been provided and the minimum transition time has passed
-		if (_airspeed_trans_blend_margin > 0.0f &&
-		    _airspeed->indicated_airspeed_m_s >= _params_standard.airspeed_blend &&
-		    (float)hrt_elapsed_time(&_vtol_schedule.transition_start) > (_params_standard.front_trans_time_min * 1000000.0f)
-		   ) {
-			mc_weight = 1.0f - fabsf(_airspeed->indicated_airspeed_m_s - _params_standard.airspeed_blend) /
-				    _airspeed_trans_blend_margin;
+		if (_params_standard.airspeed_enabled && (as_blend_region > 0.0f) && (as_above_blend > 0.0f) &&
+		    (trans_elapsed > _params_standard.front_trans_time_min)) {
+
+			_mc_throttle_weight = math::constrain(1.0f - as_above_blend / as_blend_region, 0.0f, 1.0f);
+
+		} else if (!_params_standard.airspeed_enabled &&
+			   (trans_elapsed > (_params_standard.front_trans_time_min / 2.0f) &&
+			    (trans_elapsed < _params_standard.front_trans_time_min))) {
+
 			// time based blending when no airspeed sensor is set
+			const float weight = 1.0f - (trans_elapsed / _params_standard.front_trans_time_min);
 
-		} else if (_params_standard.airspeed_disabled &&
-			   hrt_elapsed_time(&_vtol_schedule.transition_start) < (_params_standard.front_trans_time_min * 1e6f) &&
-			   hrt_elapsed_time(&_vtol_schedule.transition_start) > ((_params_standard.front_trans_time_min / 2.0f) * 1e6f)
-			  ) {
-			mc_weight = 1.0f - ((float)(hrt_elapsed_time(&_vtol_schedule.transition_start) - ((
-							    _params_standard.front_trans_time_min / 2.0f) * 1000000.0f)) /
-					    ((_params_standard.front_trans_time_min / 2.0f) * 1000000.0f));
+			// weight is doubled to blend over the 2nd half of the interval
+			_mc_throttle_weight = math::constrain(2.0f * weight, 0.0f, 1.0f);
 
+		} else {
+			// at low speeds give full weight to mc
+			_mc_throttle_weight = 1.0f;
 		}
 
 		// ramp up FW_PSP_OFF
-		_v_att_sp->pitch_body = _params_standard.pitch_setpoint_offset * (1.0f - mc_weight);
+		_v_att_sp->pitch_body = _params_standard.pitch_setpoint_offset * (1.0f - _mc_pitch_weight);
 		matrix::Quatf q_sp(matrix::Eulerf(_v_att_sp->roll_body, _v_att_sp->pitch_body, _v_att_sp->yaw_body));
 		q_sp.copyTo(_v_att_sp->q_d);
 		_v_att_sp->q_d_valid = true;
 
 		// check front transition timeout
 		if (_params_standard.front_trans_timeout > FLT_EPSILON) {
-			if (hrt_elapsed_time(&_vtol_schedule.transition_start) > (_params_standard.front_trans_timeout * 1e6f)) {
-				// transition timeout occured, abort transition
+			if (trans_elapsed > _params_standard.front_trans_timeout) {
+
+				// transition timeout occurred, abort transition
 				_attc->abort_front_transition("Transition timeout");
 			}
 		}
@@ -335,56 +330,56 @@ void Standard::update_transition_state()
 		q_sp.copyTo(_v_att_sp->q_d);
 		_v_att_sp->q_d_valid = true;
 
-		hrt_abstime btrans_start;
-		btrans_start = _vtol_schedule.transition_start + uint64_t(_params_standard.reverse_delay) * 1000000.0f;
-		_pusher_throttle = 0.0f;
+		// enable airbrakes output during back transition (if configured)
+		_airbrakes_output = _params_standard.reverse_output;
 
-		if (hrt_absolute_time() >= btrans_start) {
-			// Handle throttle reversal for active breaking
-			float thrscale = (float)hrt_elapsed_time(&btrans_start) / (_params_standard.front_trans_dur *
-					 1000000.0f);
-			thrscale = math::constrain(thrscale, 0.0f, 1.0f);
+		// desired throttle during back transition (usually reverse throttle)
+		const float btrans_elapsed = hrt_elapsed_time(&_vtol_schedule.transition_start) / 1e6f;
+
+		if (btrans_elapsed >= _params_standard.reverse_delay) {
+			const float thrscale = math::constrain(btrans_elapsed / _params_standard.front_trans_dur, -1.0f, 1.0f);
 			_pusher_throttle = thrscale * _params_standard.back_trans_throttle;
+
+		} else {
+			_pusher_throttle = 0.0f;
 		}
 
-		// continually increase mc attitude control as we transition back to mc mode
 		if (_params_standard.back_trans_ramp > FLT_EPSILON) {
-			mc_weight = (float)hrt_elapsed_time(&_vtol_schedule.transition_start) /
-				    ((_params_standard.back_trans_ramp) * 1000000.0f);
+			// continually increase control as we transition back to mc mode
+			_mc_throttle_weight = math::constrain(trans_elapsed / _params_standard.back_trans_ramp, 0.0f, 1.0f);
 
+		} else {
+			_mc_throttle_weight = 1.0f;
 		}
 
-		// in fw mode we need the multirotor motors to stop spinning, in backtransition mode we let them spin up again
+		// in back transition mode we need to start the MC motors again
 		if (_flag_enable_mc_motors) {
-			set_max_mc(2000);
-			set_idle_mc();
-			_flag_enable_mc_motors = false;
+			_flag_enable_mc_motors = !enable_mc_motors();
 		}
 	}
-
-	mc_weight = math::constrain(mc_weight, 0.0f, 1.0f);
-
-	_mc_roll_weight = mc_weight;
-	_mc_pitch_weight = mc_weight;
-	_mc_yaw_weight = mc_weight;
-	_mc_throttle_weight = mc_weight;
 }
 
 void Standard::update_mc_state()
 {
 	VtolType::update_mc_state();
 
+	// disable pusher and airbrakes
+	_pusher_throttle = 0.0f;
+	_airbrakes_output = 0.0f;
+
+	// full MC weight
+	_mc_throttle_weight = 1.0f;
+
 	// enable MC motors here in case we transitioned directly to MC mode
 	if (_flag_enable_mc_motors) {
-		set_max_mc(2000);
-		set_idle_mc();
-		_flag_enable_mc_motors = false;
+		_flag_enable_mc_motors = !enable_mc_motors();
 	}
 
 	// if the thrust scale param is zero or the drone is on manual mode,
 	// then the pusher-for-pitch strategy is disabled and we can return
 	if (_params_standard.forward_thrust_scale < FLT_EPSILON ||
 	    !_v_control_mode->flag_control_position_enabled) {
+
 		return;
 	}
 
@@ -395,8 +390,9 @@ void Standard::update_mc_state()
 	}
 
 	// disable pusher assist during landing
-	if (_attc->get_pos_sp_triplet()->current.valid
-	    && _attc->get_pos_sp_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
+	if (_attc->get_pos_sp_triplet()->current.valid &&
+	    (_attc->get_pos_sp_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_LAND)) {
+
 		return;
 	}
 
@@ -404,7 +400,6 @@ void Standard::update_mc_state()
 	matrix::Dcmf R_sp(matrix::Quatf(_v_att_sp->q_d));
 	matrix::Eulerf euler(R);
 	matrix::Eulerf euler_sp(R_sp);
-	_pusher_throttle = 0.0f;
 
 	// direction of desired body z axis represented in earth frame
 	matrix::Vector3f body_z_sp(R_sp(0, 2), R_sp(1, 2), R_sp(2, 2));
@@ -428,6 +423,8 @@ void Standard::update_mc_state()
 		_pusher_throttle = (sinf(-pitch_forward) - sinf(_params_standard.down_pitch_max))
 				   * _params_standard.forward_thrust_scale;
 
+		_pusher_throttle = math::constrain(_pusher_throttle, 0.0f, 1.0f);
+
 		// return the vehicle to level position
 		float pitch_new = 0.0f;
 
@@ -436,7 +433,7 @@ void Standard::update_mc_state()
 		matrix::Vector3f tilt_new(R_tmp(0, 2), R_tmp(1, 2), R_tmp(2, 2));
 
 		// rotate the vector into a new frame which is rotated in z by the desired heading
-		// with respect to the earh frame.
+		// with respect to the earth frame.
 		float yaw_error = _wrap_pi(euler_sp(2) - euler(2));
 		matrix::Dcmf R_yaw_correction = matrix::Eulerf(0.0f, 0.0f, -yaw_error);
 		tilt_new = R_yaw_correction * tilt_new;
@@ -448,99 +445,89 @@ void Standard::update_mc_state()
 		matrix::Quatf q_sp(R_sp);
 		q_sp.copyTo(_v_att_sp->q_d);
 	}
-
-	_pusher_throttle = _pusher_throttle < 0.0f ? 0.0f : _pusher_throttle;
-
 }
 
 void Standard::update_fw_state()
 {
 	VtolType::update_fw_state();
 
-	// in fw mode we need the multirotor motors to stop spinning, in backtransition mode we let them spin up again
+	// zero pusher and airbrakes
+	_pusher_throttle = 0.0f;
+	_airbrakes_output = 0.0f;
+
+	// MC off
+	_mc_throttle_weight = 0.0f;
+
+	// stop MC motors in FW mode
 	if (!_flag_enable_mc_motors) {
-		set_max_mc(950);
-		set_idle_fw();  // force them to stop, not just idle
-		_flag_enable_mc_motors = true;
+		_flag_enable_mc_motors = disable_mc_motors();
 	}
 }
 
 /**
- * Prepare message to acutators with data from mc and fw attitude controllers. An mc attitude weighting will determine
+ * Prepare message to actuators with data from mc and fw attitude controllers. An mc attitude weighting will determine
  * what proportion of control should be applied to each of the control groups (mc and fw).
  */
 void Standard::fill_actuator_outputs()
 {
-	// multirotor controls
 	_actuators_out_0->timestamp = _actuators_mc_in->timestamp;
-
-	// roll
-	_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] =
-		_actuators_mc_in->control[actuator_controls_s::INDEX_ROLL] * _mc_roll_weight;
-	// pitch
-	_actuators_out_0->control[actuator_controls_s::INDEX_PITCH] =
-		_actuators_mc_in->control[actuator_controls_s::INDEX_PITCH] * _mc_pitch_weight;
-	// yaw
-	_actuators_out_0->control[actuator_controls_s::INDEX_YAW] =
-		_actuators_mc_in->control[actuator_controls_s::INDEX_YAW] * _mc_yaw_weight;
-	// throttle
-	_actuators_out_0->control[actuator_controls_s::INDEX_THROTTLE] =
-		_actuators_mc_in->control[actuator_controls_s::INDEX_THROTTLE] * _mc_throttle_weight;
-
-
-	// fixed wing controls
 	_actuators_out_1->timestamp = _actuators_fw_in->timestamp;
 
-	if (_vtol_schedule.flight_mode != MC_MODE) {
-		// roll
-		_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] =
-			-_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL];
+	const auto &mc_in = _actuators_mc_in->control; // MC input: mc_att_control
+	const auto &fw_in = _actuators_fw_in->control; // FW input: fw_att_control
 
-		// pitch
-		_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =
-			_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH];
-		// yaw
-		_actuators_out_1->control[actuator_controls_s::INDEX_YAW] =
-			_actuators_fw_in->control[actuator_controls_s::INDEX_YAW];
+	auto &mc_out = _actuators_out_0->control; // MC output: actuator controls 0
+	auto &fw_out = _actuators_out_1->control; // FW output: actuator controls 1
 
-		_actuators_out_1->control[actuator_controls_s::INDEX_AIRBRAKES] = _reverse_output;
-
-	} else {
+	switch (_vtol_schedule.flight_mode) {
+	case MC_MODE:
+		mc_out[actuator_controls_s::INDEX_ROLL] = mc_in[actuator_controls_s::INDEX_ROLL];
+		mc_out[actuator_controls_s::INDEX_PITCH] = mc_in[actuator_controls_s::INDEX_PITCH];
+		mc_out[actuator_controls_s::INDEX_YAW] = mc_in[actuator_controls_s::INDEX_YAW];
+		mc_out[actuator_controls_s::INDEX_THROTTLE] = mc_in[actuator_controls_s::INDEX_THROTTLE];
 
 		if (_params->elevons_mc_lock) {
-			// zero outputs when inactive
-			_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] = 0.0f;
-			_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] = 0.0f;
-			_actuators_out_1->control[actuator_controls_s::INDEX_YAW] = 0.0f;
-			_actuators_out_1->control[actuator_controls_s::INDEX_AIRBRAKES] = 0.0f;
+			fw_out[actuator_controls_s::INDEX_ROLL] = 0.0f;
+			fw_out[actuator_controls_s::INDEX_PITCH] = 0.0f;
+			fw_out[actuator_controls_s::INDEX_YAW] = 0.0f;
+			fw_out[actuator_controls_s::INDEX_THROTTLE] = _pusher_throttle;
 
 		} else {
-			// roll
-			_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] =
-				-_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL];
-
-			// pitch
-			_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =
-				_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH];
-
-			_actuators_out_1->control[actuator_controls_s::INDEX_YAW] = 0.0f;
-			_actuators_out_1->control[actuator_controls_s::INDEX_AIRBRAKES] = 0.0f;
+			fw_out[actuator_controls_s::INDEX_ROLL] = -fw_in[actuator_controls_s::INDEX_ROLL];
+			fw_out[actuator_controls_s::INDEX_PITCH] = fw_in[actuator_controls_s::INDEX_PITCH];
+			fw_out[actuator_controls_s::INDEX_YAW] = fw_in[actuator_controls_s::INDEX_YAW];
+			fw_out[actuator_controls_s::INDEX_THROTTLE] = _pusher_throttle;
 		}
+
+		break;
+
+	case TRANSITION_TO_FW:
+	case TRANSITION_TO_MC:
+		mc_out[actuator_controls_s::INDEX_ROLL] = mc_in[actuator_controls_s::INDEX_ROLL] * _mc_throttle_weight;
+		mc_out[actuator_controls_s::INDEX_PITCH] = mc_in[actuator_controls_s::INDEX_PITCH] * _mc_throttle_weight;
+		mc_out[actuator_controls_s::INDEX_YAW] = mc_in[actuator_controls_s::INDEX_YAW] * _mc_throttle_weight;
+		mc_out[actuator_controls_s::INDEX_THROTTLE] = mc_in[actuator_controls_s::INDEX_THROTTLE] * _mc_throttle_weight;
+
+		fw_out[actuator_controls_s::INDEX_ROLL] = -fw_in[actuator_controls_s::INDEX_ROLL];
+		fw_out[actuator_controls_s::INDEX_PITCH] = fw_in[actuator_controls_s::INDEX_PITCH];
+		fw_out[actuator_controls_s::INDEX_YAW] = fw_in[actuator_controls_s::INDEX_YAW];
+		fw_out[actuator_controls_s::INDEX_THROTTLE] = _pusher_throttle;
+
+		break;
+
+	case FW_MODE:
+		mc_out[actuator_controls_s::INDEX_ROLL] = 0.0f;
+		mc_out[actuator_controls_s::INDEX_PITCH] = 0.0f;
+		mc_out[actuator_controls_s::INDEX_YAW] = 0.0f;
+		mc_out[actuator_controls_s::INDEX_THROTTLE] = 0.0f;
+
+		fw_out[actuator_controls_s::INDEX_ROLL] = -fw_in[actuator_controls_s::INDEX_ROLL];
+		fw_out[actuator_controls_s::INDEX_PITCH] = fw_in[actuator_controls_s::INDEX_PITCH];
+		fw_out[actuator_controls_s::INDEX_YAW] = fw_in[actuator_controls_s::INDEX_YAW];
+		fw_out[actuator_controls_s::INDEX_THROTTLE] = fw_in[actuator_controls_s::INDEX_THROTTLE];
+
+		break;
 	}
-
-	// set the fixed wing throttle control
-	if (_vtol_schedule.flight_mode == FW_MODE) {
-
-		// take the throttle value commanded by the fw controller
-		_actuators_out_1->control[actuator_controls_s::INDEX_THROTTLE] =
-			_actuators_fw_in->control[actuator_controls_s::INDEX_THROTTLE];
-
-	} else {
-		// otherwise we may be ramping up the throttle during the transition to fw mode
-		_actuators_out_1->control[actuator_controls_s::INDEX_THROTTLE] = _pusher_throttle;
-	}
-
-
 }
 
 void
@@ -549,36 +536,3 @@ Standard::waiting_on_tecs()
 	// keep thrust from transition
 	_v_att_sp->thrust = _pusher_throttle;
 };
-
-/**
-* Disable all multirotor motors when in fw mode.
-*/
-void
-Standard::set_max_mc(unsigned pwm_value)
-{
-	int ret;
-	unsigned servo_count;
-	const char *dev = PWM_OUTPUT0_DEVICE_PATH;
-	int fd = px4_open(dev, 0);
-
-	if (fd < 0) {
-		PX4_WARN("can't open %s", dev);
-	}
-
-	ret = px4_ioctl(fd, PWM_SERVO_GET_COUNT, (unsigned long)&servo_count);
-	struct pwm_output_values pwm_values;
-	memset(&pwm_values, 0, sizeof(pwm_values));
-
-	for (int i = 0; i < _params->vtol_motor_count; i++) {
-		pwm_values.values[i] = pwm_value;
-		pwm_values.channel_count = _params->vtol_motor_count;
-	}
-
-	ret = px4_ioctl(fd, PWM_SERVO_SET_MAX_PWM, (long unsigned int)&pwm_values);
-
-	if (ret != OK) {
-		PX4_WARN("failed setting max values");
-	}
-
-	px4_close(fd);
-}

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -123,6 +123,6 @@ private:
 	float _pusher_throttle{0.0f};
 	float _airbrakes_output{0.0f};
 
-	virtual void parameters_update();
+	void parameters_update() override;
 };
 #endif

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -45,24 +45,24 @@
 
 #ifndef STANDARD_H
 #define STANDARD_H
+
 #include "vtol_type.h"
 #include <systemlib/param/param.h>
 #include <drivers/drv_hrt.h>
 
-class Standard : public VtolType
+class Standard final : public VtolType
 {
-
 public:
 
 	Standard(VtolAttitudeControl *_att_controller);
-	~Standard();
+	~Standard() override = default;
 
-	virtual void update_vtol_state();
-	virtual void update_transition_state();
-	virtual void update_fw_state();
-	virtual void update_mc_state();
-	virtual void fill_actuator_outputs();
-	virtual void waiting_on_tecs();
+	void update_vtol_state() override;
+	void update_transition_state() override;
+	void update_fw_state() override;
+	void update_mc_state() override;
+	void fill_actuator_outputs() override;
+	void waiting_on_tecs() override;
 
 private:
 
@@ -77,13 +77,13 @@ private:
 		float front_trans_time_min;
 		float down_pitch_max;
 		float forward_thrust_scale;
-		int32_t airspeed_disabled;
+		bool airspeed_enabled;
 		float pitch_setpoint_offset;
 		float reverse_output;
 		float reverse_delay;
 		float back_trans_throttle;
 		float mpc_xy_cruise;
-	} _params_standard;
+	} _params_standard{};
 
 	struct {
 		param_t front_trans_dur;
@@ -96,32 +96,32 @@ private:
 		param_t front_trans_time_min;
 		param_t down_pitch_max;
 		param_t forward_thrust_scale;
-		param_t airspeed_disabled;
+		param_t airspeed_mode;
 		param_t pitch_setpoint_offset;
 		param_t reverse_output;
 		param_t reverse_delay;
 		param_t back_trans_throttle;
 		param_t mpc_xy_cruise;
-	} _params_handles_standard;
+	} _params_handles_standard{};
 
 	enum vtol_mode {
-		MC_MODE = 0,
-		TRANSITION_TO_FW,
-		TRANSITION_TO_MC,
-		FW_MODE
+		MC_MODE = mode::ROTARY_WING,
+		TRANSITION_TO_FW = mode::TRANSITION_TO_FW,
+		TRANSITION_TO_MC = mode::TRANSITION_TO_MC,
+		FW_MODE = mode::FIXED_WING
 	};
 
 	struct {
 		vtol_mode flight_mode;			// indicates in which mode the vehicle is in
 		hrt_abstime transition_start;	// at what time did we start a transition (front- or backtransition)
-	} _vtol_schedule;
+	} _vtol_schedule{};
 
-	bool _flag_enable_mc_motors;
-	float _pusher_throttle;
-	float _reverse_output;
-	float _airspeed_trans_blend_margin;
+	bool _flag_enable_mc_motors{true};
 
-	void set_max_mc(unsigned pwm_value);
+	bool _transition_achieved{false}; // transition achieved flag
+
+	float _pusher_throttle{0.0f};
+	float _airbrakes_output{0.0f};
 
 	virtual void parameters_update();
 };

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -47,7 +47,6 @@
 #define STANDARD_H
 
 #include "vtol_type.h"
-#include <systemlib/param/param.h>
 #include <drivers/drv_hrt.h>
 
 class Standard final : public VtolType
@@ -66,43 +65,21 @@ public:
 
 private:
 
-	struct {
-		float front_trans_dur;
-		float back_trans_dur;
-		float back_trans_ramp;
-		float pusher_trans;
-		float airspeed_blend;
-		float airspeed_trans;
-		float front_trans_timeout;
-		float front_trans_time_min;
-		float down_pitch_max;
-		float forward_thrust_scale;
-		bool airspeed_enabled;
-		float pitch_setpoint_offset;
-		float reverse_output;
-		float reverse_delay;
-		float back_trans_throttle;
-		float mpc_xy_cruise;
-	} _params_standard{};
+	BlockParamFloat _param_pusher_trans;
+	BlockParamFloat	_param_front_trans_timeout;
 
-	struct {
-		param_t front_trans_dur;
-		param_t back_trans_dur;
-		param_t back_trans_ramp;
-		param_t pusher_trans;
-		param_t airspeed_blend;
-		param_t airspeed_trans;
-		param_t front_trans_timeout;
-		param_t front_trans_time_min;
-		param_t down_pitch_max;
-		param_t forward_thrust_scale;
-		param_t airspeed_mode;
-		param_t pitch_setpoint_offset;
-		param_t reverse_output;
-		param_t reverse_delay;
-		param_t back_trans_throttle;
-		param_t mpc_xy_cruise;
-	} _params_handles_standard{};
+	BlockParamFloat	_param_back_trans_throttle;	// back transition throttle (usually reverse throttle)
+	BlockParamFloat	_param_back_trans_ramp;
+	BlockParamFloat _param_back_reverse_output;	// airbrakes value during back transition (eg ESC direction)
+	BlockParamFloat	_param_back_reverse_delay;	// delay before applying back transition throttle
+
+	// VTOL standard pusher assist
+	BlockParamFloat	_param_down_pitch_max;
+	BlockParamFloat	_param_forward_thrust_scale;
+
+	// non VTOL parameters
+	BlockParamFloat	_param_fw_pitch_setpoint_offset;
+	BlockParamFloat	_param_mc_xy_cruise_velocity;
 
 	enum vtol_mode {
 		MC_MODE = mode::ROTARY_WING,
@@ -116,13 +93,12 @@ private:
 		hrt_abstime transition_start;	// at what time did we start a transition (front- or backtransition)
 	} _vtol_schedule{};
 
+	// TODO: replace with vtol_type's flag_idle_mc
 	bool _flag_enable_mc_motors{true};
 
 	bool _transition_achieved{false}; // transition achieved flag
 
 	float _pusher_throttle{0.0f};
 	float _airbrakes_output{0.0f};
-
-	void parameters_update() override;
 };
 #endif

--- a/src/modules/vtol_att_control/standard_params.c
+++ b/src/modules/vtol_att_control/standard_params.c
@@ -124,3 +124,17 @@ PARAM_DEFINE_FLOAT(VT_B_REV_DEL, 0.0f);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_FLOAT(VT_B_TRANS_THR, 0.0f);
+
+/**
+ * Front transition timeout
+ *
+ * Time in seconds after which transition will be cancelled. Disabled if set to 0.
+ *
+ * @unit s
+ * @min 0.00
+ * @max 30.00
+ * @increment 1
+ * @decimal 2
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_TRANS_TIMEOUT, 15.0f);

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -42,71 +42,20 @@
 #include "tailsitter.h"
 #include "vtol_att_control_main.h"
 
-#define ARSP_YAW_CTRL_DISABLE 4.0f	// airspeed at which we stop controlling yaw during a front transition
-#define THROTTLE_TRANSITION_MAX 0.25f	// maximum added thrust above last value in transition
-#define PITCH_TRANSITION_FRONT_P1 -1.1f	// pitch angle to switch to TRANSITION_P2
-#define PITCH_TRANSITION_FRONT_P2 -1.2f	// pitch angle to switch to FW
-#define PITCH_TRANSITION_BACK -0.25f	// pitch angle to switch to MC
+static constexpr float ARSP_YAW_CTRL_DISABLE = 4.0f; // when to stop controlling yaw during a front transition
+static constexpr float THROTTLE_TRANSITION_MAX = 0.25f;	// maximum added thrust above last value in transition
+static constexpr float PITCH_TRANSITION_FRONT_P1 = -1.1f;	// pitch angle to switch to TRANSITION_P2
+static constexpr float PITCH_TRANSITION_FRONT_P2 = -1.2f;	// pitch angle to switch to FW
+static constexpr float PITCH_TRANSITION_BACK = -0.25f;	// pitch angle to switch to MC
 
 Tailsitter::Tailsitter(VtolAttitudeControl *attc) :
 	VtolType(attc),
-	_min_front_trans_dur(0.5f),
-	_thrust_transition_start(0.0f),
-	_yaw_transition(0.0f),
-	_pitch_transition_start(0.0f)
+	_param_front_trans_dur_p2(this, "TRANS_P2_DUR")
 {
-	_vtol_schedule.flight_mode = MC_MODE;
-	_vtol_schedule.transition_start = 0;
-
-	_mc_roll_weight = 1.0f;
-	_mc_pitch_weight = 1.0f;
-	_mc_yaw_weight = 1.0f;
-
-	_flag_was_in_trans_mode = false;
-
-	_params_handles_tailsitter.front_trans_dur = param_find("VT_F_TRANS_DUR");
-	_params_handles_tailsitter.front_trans_dur_p2 = param_find("VT_TRANS_P2_DUR");
-	_params_handles_tailsitter.back_trans_dur = param_find("VT_B_TRANS_DUR");
-	_params_handles_tailsitter.airspeed_trans = param_find("VT_ARSP_TRANS");
-	_params_handles_tailsitter.airspeed_blend_start = param_find("VT_ARSP_BLEND");
-}
-
-void
-Tailsitter::parameters_update()
-{
-	float v;
-
-	/* vtol duration of a front transition */
-	param_get(_params_handles_tailsitter.front_trans_dur, &v);
-	_params_tailsitter.front_trans_dur = math::constrain(v, 1.0f, 5.0f);
-
-	/* vtol front transition phase 2 duration */
-	param_get(_params_handles_tailsitter.front_trans_dur_p2, &v);
-	_params_tailsitter.front_trans_dur_p2 = v;
-
-	/* vtol duration of a back transition */
-	param_get(_params_handles_tailsitter.back_trans_dur, &v);
-	_params_tailsitter.back_trans_dur = math::constrain(v, 0.0f, 5.0f);
-
-	/* vtol airspeed at which it is ok to switch to fw mode */
-	param_get(_params_handles_tailsitter.airspeed_trans, &v);
-	_params_tailsitter.airspeed_trans = v;
-
-	/* vtol airspeed at which we start blending mc/fw controls */
-	param_get(_params_handles_tailsitter.airspeed_blend_start, &v);
-	_params_tailsitter.airspeed_blend_start = v;
-
-	/* avoid parameters which will lead to zero division in the transition code */
-	_params_tailsitter.front_trans_dur = math::max(_params_tailsitter.front_trans_dur, _min_front_trans_dur);
-
-	if (_params_tailsitter.airspeed_trans < _params_tailsitter.airspeed_blend_start + 1.0f) {
-		_params_tailsitter.airspeed_trans = _params_tailsitter.airspeed_blend_start + 1.0f;
-	}
 }
 
 void Tailsitter::update_vtol_state()
 {
-
 	/* simple logic using a two way switch to perform transitions.
 	 * after flipping the switch the vehicle will start tilting in MC control mode, picking up
 	 * forward speed. After the vehicle has picked up enough and sufficient pitch angle the uav will go into FW mode.
@@ -163,7 +112,7 @@ void Tailsitter::update_vtol_state()
 		case TRANSITION_FRONT_P1:
 
 			// check if we have reached airspeed  and pitch angle to switch to TRANSITION P2 mode
-			if ((_airspeed->indicated_airspeed_m_s >= _params_tailsitter.airspeed_trans
+			if ((_airspeed->indicated_airspeed_m_s >= _param_airspeed_trans.get()
 			     && pitch <= PITCH_TRANSITION_FRONT_P1) || can_transition_on_ground()) {
 				_vtol_schedule.flight_mode = FW_MODE;
 				//_vtol_schedule.transition_start = hrt_absolute_time();
@@ -226,16 +175,19 @@ void Tailsitter::update_transition_state()
 
 		/** create time dependant pitch angle set point + 0.2 rad overlap over the switch value*/
 		_v_att_sp->pitch_body = _pitch_transition_start	- (fabsf(PITCH_TRANSITION_FRONT_P1 - _pitch_transition_start) *
-					(float)hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params_tailsitter.front_trans_dur * 1000000.0f));
-		_v_att_sp->pitch_body = math::constrain(_v_att_sp->pitch_body, PITCH_TRANSITION_FRONT_P1 - 0.2f,
-							_pitch_transition_start);
+					hrt_elapsed_time(&_vtol_schedule.transition_start) / (_param_front_trans_dur.get() * 1e6f));
+
+		_v_att_sp->pitch_body = constrain(_v_att_sp->pitch_body, PITCH_TRANSITION_FRONT_P1 - 0.2f, _pitch_transition_start);
 
 		/** create time dependant throttle signal higher than  in MC and growing untill  P2 switch speed reached */
-		if (_airspeed->indicated_airspeed_m_s <= _params_tailsitter.airspeed_trans) {
+		if (_airspeed->indicated_airspeed_m_s <= _param_airspeed_trans.get()) {
+
 			_thrust_transition = _thrust_transition_start + (fabsf(THROTTLE_TRANSITION_MAX * _thrust_transition_start) *
-					     (float)hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params_tailsitter.front_trans_dur * 1000000.0f));
-			_thrust_transition = math::constrain(_thrust_transition, _thrust_transition_start,
-							     (1.0f + THROTTLE_TRANSITION_MAX) * _thrust_transition_start);
+					     hrt_elapsed_time(&_vtol_schedule.transition_start) / (_param_front_trans_dur.get() * 1e6f));
+
+			_thrust_transition = constrain(_thrust_transition, _thrust_transition_start,
+						       (1.0f + THROTTLE_TRANSITION_MAX) * _thrust_transition_start);
+
 			_v_att_sp->thrust = _thrust_transition;
 		}
 
@@ -256,15 +208,14 @@ void Tailsitter::update_transition_state()
 		/** no motor  switching */
 
 		if (flag_idle_mc) {
-			set_idle_fw();
-			flag_idle_mc = false;
+			flag_idle_mc = !disable_mc_motors();
 		}
 
 		/** create time dependant pitch angle set point  + 0.2 rad overlap over the switch value*/
 		if (_v_att_sp->pitch_body >= (PITCH_TRANSITION_FRONT_P2 - 0.2f)) {
-			_v_att_sp->pitch_body = PITCH_TRANSITION_FRONT_P1 -
-						(fabsf(PITCH_TRANSITION_FRONT_P2 - PITCH_TRANSITION_FRONT_P1) * (float)hrt_elapsed_time(
-							 &_vtol_schedule.transition_start) / (_params_tailsitter.front_trans_dur_p2 * 1000000.0f));
+
+			_v_att_sp->pitch_body = PITCH_TRANSITION_FRONT_P1 - (fabsf(PITCH_TRANSITION_FRONT_P2 - PITCH_TRANSITION_FRONT_P1) *
+						hrt_elapsed_time(&_vtol_schedule.transition_start) / (_param_front_trans_dur_p2.get() * 1e6f));
 
 			if (_v_att_sp->pitch_body <= (PITCH_TRANSITION_FRONT_P2 - 0.2f)) {
 				_v_att_sp->pitch_body = PITCH_TRANSITION_FRONT_P2 - 0.2f;
@@ -290,13 +241,13 @@ void Tailsitter::update_transition_state()
 	} else if (_vtol_schedule.flight_mode == TRANSITION_BACK) {
 
 		if (!flag_idle_mc) {
-			set_idle_mc();
-			flag_idle_mc = true;
+			flag_idle_mc = enable_mc_motors();
 		}
 
 		/** create time dependant pitch angle set point stating at -pi/2 + 0.2 rad overlap over the switch value*/
 		_v_att_sp->pitch_body = M_PI_2_F + _pitch_transition_start + fabsf(PITCH_TRANSITION_BACK + 1.57f) *
-					(float)hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params_tailsitter.back_trans_dur * 1000000.0f);
+					hrt_elapsed_time(&_vtol_schedule.transition_start) / (_param_back_trans_dur.get() * 1e6f);
+
 		_v_att_sp->pitch_body = math::constrain(_v_att_sp->pitch_body, -2.0f, PITCH_TRANSITION_BACK + 0.2f);
 
 		//  throttle value is decreesed
@@ -306,11 +257,8 @@ void Tailsitter::update_transition_state()
 		_mc_yaw_weight = 0.0f;
 
 		/** smoothly move control weight to MC */
-		_mc_roll_weight = 1.0f * (float)hrt_elapsed_time(&_vtol_schedule.transition_start) /
-				  (_params_tailsitter.back_trans_dur * 1000000.0f);
-		_mc_pitch_weight = 1.0f * (float)hrt_elapsed_time(&_vtol_schedule.transition_start) /
-				   (_params_tailsitter.back_trans_dur * 1000000.0f);
-
+		_mc_roll_weight = hrt_elapsed_time(&_vtol_schedule.transition_start) / (_param_back_trans_dur.get() * 1e6f);
+		_mc_pitch_weight = hrt_elapsed_time(&_vtol_schedule.transition_start) / (_param_back_trans_dur.get() * 1e6f);
 	}
 
 	_mc_roll_weight = math::constrain(_mc_roll_weight, 0.0f, 1.0f);
@@ -340,8 +288,7 @@ void Tailsitter::update_mc_state()
 
 	// set idle speed for rotary wing mode
 	if (!flag_idle_mc) {
-		set_idle_mc();
-		flag_idle_mc = true;
+		flag_idle_mc = enable_mc_motors();
 	}
 }
 
@@ -350,8 +297,7 @@ void Tailsitter::update_fw_state()
 	VtolType::update_fw_state();
 
 	if (flag_idle_mc) {
-		set_idle_fw();
-		flag_idle_mc = false;
+		flag_idle_mc = !disable_mc_motors();
 	}
 }
 
@@ -372,7 +318,7 @@ void Tailsitter::fill_actuator_outputs()
 
 		_actuators_out_1->timestamp = _actuators_mc_in->timestamp;
 
-		if (_params->elevons_mc_lock) {
+		if (_param_elevons_mc_lock.get()) {
 			_actuators_out_1->control[0] = 0;
 			_actuators_out_1->control[1] = 0;
 
@@ -395,14 +341,21 @@ void Tailsitter::fill_actuator_outputs()
 		_actuators_out_0->control[actuator_controls_s::INDEX_THROTTLE] =
 			_actuators_fw_in->control[actuator_controls_s::INDEX_THROTTLE];
 
+		// roll elevon
 		_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] =
-			-_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL];	// roll elevon
+			-_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL];
+
+		// pitch elevon
 		_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =
-			_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH] + _params->fw_pitch_trim;	// pitch elevon
+			_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH] + _param_fw_pitch_trim.get();
+
+		// yaw
 		_actuators_out_1->control[actuator_controls_s::INDEX_YAW] =
-			_actuators_fw_in->control[actuator_controls_s::INDEX_YAW];	// yaw
+			_actuators_fw_in->control[actuator_controls_s::INDEX_YAW];
+
+		// throttle
 		_actuators_out_1->control[actuator_controls_s::INDEX_THROTTLE] =
-			_actuators_fw_in->control[actuator_controls_s::INDEX_THROTTLE];	// throttle
+			_actuators_fw_in->control[actuator_controls_s::INDEX_THROTTLE];
 		break;
 
 	case TRANSITION_TO_FW:

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -71,11 +71,6 @@ Tailsitter::Tailsitter(VtolAttitudeControl *attc) :
 	_params_handles_tailsitter.airspeed_blend_start = param_find("VT_ARSP_BLEND");
 }
 
-Tailsitter::~Tailsitter()
-{
-
-}
-
 void
 Tailsitter::parameters_update()
 {
@@ -193,29 +188,24 @@ void Tailsitter::update_vtol_state()
 	switch (_vtol_schedule.flight_mode) {
 	case MC_MODE:
 		_vtol_mode = ROTARY_WING;
-		_vtol_vehicle_status->vtol_in_trans_mode = false;
 		_flag_was_in_trans_mode = false;
 		break;
 
 	case FW_MODE:
 		_vtol_mode = FIXED_WING;
-		_vtol_vehicle_status->vtol_in_trans_mode = false;
 		_flag_was_in_trans_mode = false;
 		break;
 
 	case TRANSITION_FRONT_P1:
 		_vtol_mode = TRANSITION_TO_FW;
-		_vtol_vehicle_status->vtol_in_trans_mode = true;
 		break;
 
 	case TRANSITION_FRONT_P2:
 		_vtol_mode = TRANSITION_TO_FW;
-		_vtol_vehicle_status->vtol_in_trans_mode = true;
 		break;
 
 	case TRANSITION_BACK:
 		_vtol_mode = TRANSITION_TO_MC;
-		_vtol_vehicle_status->vtol_in_trans_mode = true;
 		break;
 	}
 }

--- a/src/modules/vtol_att_control/tailsitter.h
+++ b/src/modules/vtol_att_control/tailsitter.h
@@ -43,16 +43,15 @@
 #define TAILSITTER_H
 
 #include "vtol_type.h"
-#include <systemlib/perf_counter.h>  /** is it necsacery? **/
 #include <systemlib/param/param.h>
 #include <drivers/drv_hrt.h>
 
-class Tailsitter : public VtolType
+class Tailsitter final : public VtolType
 {
 
 public:
 	Tailsitter(VtolAttitudeControl *_att_controller);
-	~Tailsitter();
+	~Tailsitter() = default;
 
 	virtual void update_vtol_state();
 	virtual void update_transition_state();
@@ -69,7 +68,7 @@ private:
 		float back_trans_dur;			/**< duration of back transition */
 		float airspeed_trans;			/**< airspeed at which we switch to fw mode after transition */
 		float airspeed_blend_start;		/**< airspeed at which we start blending mc/fw controls */
-	} _params_tailsitter;
+	} _params_tailsitter{};
 
 	struct {
 		param_t front_trans_dur;
@@ -77,8 +76,7 @@ private:
 		param_t back_trans_dur;
 		param_t airspeed_trans;
 		param_t airspeed_blend_start;
-
-	} _params_handles_tailsitter;
+	} _params_handles_tailsitter{};
 
 	enum vtol_mode {
 		MC_MODE = 0,			/**< vtol is in multicopter mode */

--- a/src/modules/vtol_att_control/tailsitter.h
+++ b/src/modules/vtol_att_control/tailsitter.h
@@ -62,21 +62,7 @@ public:
 
 private:
 
-	struct {
-		float front_trans_dur;			/**< duration of first part of front transition */
-		float front_trans_dur_p2;
-		float back_trans_dur;			/**< duration of back transition */
-		float airspeed_trans;			/**< airspeed at which we switch to fw mode after transition */
-		float airspeed_blend_start;		/**< airspeed at which we start blending mc/fw controls */
-	} _params_tailsitter{};
-
-	struct {
-		param_t front_trans_dur;
-		param_t front_trans_dur_p2;
-		param_t back_trans_dur;
-		param_t airspeed_trans;
-		param_t airspeed_blend_start;
-	} _params_handles_tailsitter{};
+	BlockParamFloat	_param_front_trans_dur_p2;
 
 	enum vtol_mode {
 		MC_MODE = 0,			/**< vtol is in multicopter mode */
@@ -89,19 +75,11 @@ private:
 	struct {
 		vtol_mode flight_mode;			/**< vtol flight mode, defined by enum vtol_mode */
 		hrt_abstime transition_start;	/**< absoulte time at which front transition started */
-	} _vtol_schedule;
+	} _vtol_schedule{};
 
-	/** not sure about it yet ?! **/
-	float _min_front_trans_dur;	/**< min possible time in which rotors are rotated into the first position */
-
-	float _thrust_transition_start; // throttle value when we start the front transition
-	float _yaw_transition;	// yaw angle in which transition will take place
-	float _pitch_transition_start;  // pitch angle at the start of transition (tailsitter)
-
-	/**
-	 * Update parameters.
-	 */
-	virtual void parameters_update();
+	float _thrust_transition_start{0.0f}; // throttle value when we start the front transition
+	float _yaw_transition{0.0f};	// yaw angle in which transition will take place
+	float _pitch_transition_start{0.0f};  // pitch angle at the start of transition (tailsitter)
 
 };
 #endif

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -42,106 +42,37 @@
 #include "tiltrotor.h"
 #include "vtol_att_control_main.h"
 
-#define ARSP_YAW_CTRL_DISABLE 7.0f	// airspeed at which we stop controlling yaw during a front transition
+static constexpr float ARSP_YAW_CTRL_DISABLE =
+	7.0f;	// airspeed at which we stop controlling yaw during a front transition
 
 Tiltrotor::Tiltrotor(VtolAttitudeControl *attc) :
 	VtolType(attc),
-	_rear_motors(ENABLED),
-	_tilt_control(0.0f),
-	_min_front_trans_dur(0.5f)
+	_param_tilt_mc(this, "TILT_MC"),
+	_param_tilt_transition(this, "TILT_TRANS"),
+	_param_tilt_fw(this, "TILT_FW"),
+	_param_front_trans_time_openloop(this, "F_TR_OL_TM"),
+	_param_front_trans_dur_p2(this, "TRANS_P2_DUR"),
+	_param_fw_motors_off(this, "FW_MOT_OFFID"),
+	_param_diff_thrust(this, "FW_DIFTHR_EN"),
+	_param_diff_thrust_scale(this, "FW_DIFTHR_SC")
 {
-	_vtol_schedule.flight_mode = MC_MODE;
-	_vtol_schedule.transition_start = 0;
-
-	_mc_roll_weight = 1.0f;
-	_mc_pitch_weight = 1.0f;
-	_mc_yaw_weight = 1.0f;
-
-	_flag_was_in_trans_mode = false;
-
-	_params_handles_tiltrotor.front_trans_dur = param_find("VT_F_TRANS_DUR");
-	_params_handles_tiltrotor.back_trans_dur = param_find("VT_B_TRANS_DUR");
-	_params_handles_tiltrotor.tilt_mc = param_find("VT_TILT_MC");
-	_params_handles_tiltrotor.tilt_transition = param_find("VT_TILT_TRANS");
-	_params_handles_tiltrotor.tilt_fw = param_find("VT_TILT_FW");
-	_params_handles_tiltrotor.airspeed_trans = param_find("VT_ARSP_TRANS");
-	_params_handles_tiltrotor.airspeed_blend_start = param_find("VT_ARSP_BLEND");
-	_params_handles_tiltrotor.front_trans_dur_p2 = param_find("VT_TRANS_P2_DUR");
-	_params_handles_tiltrotor.fw_motors_off = param_find("VT_FW_MOT_OFFID");
-	_params_handles_tiltrotor.airspeed_disabled = param_find("FW_ARSP_MODE");
-	_params_handles_tiltrotor.diff_thrust = param_find("VT_FW_DIFTHR_EN");
-	_params_handles_tiltrotor.diff_thrust_scale = param_find("VT_FW_DIFTHR_SC");
-
-	set_idle_mc();
 }
 
 void
 Tiltrotor::parameters_update()
 {
-	float v;
-	int l;
+	updateParams();
 
 	/* motors that must be turned off when in fixed wing mode */
-	param_get(_params_handles_tiltrotor.fw_motors_off, &l);
-	_params_tiltrotor.fw_motors_off = get_motor_off_channels(l);
-
-	/* vtol duration of a front transition */
-	param_get(_params_handles_tiltrotor.front_trans_dur, &v);
-	_params_tiltrotor.front_trans_dur = math::constrain(v, 1.0f, 5.0f);
-
-	/* vtol duration of a back transition */
-	param_get(_params_handles_tiltrotor.back_trans_dur, &v);
-	_params_tiltrotor.back_trans_dur = math::constrain(v, 0.0f, 5.0f);
-
-	/* vtol tilt mechanism position in mc mode */
-	param_get(_params_handles_tiltrotor.tilt_mc, &v);
-	_params_tiltrotor.tilt_mc = v;
-
-	/* vtol tilt mechanism position in transition mode */
-	param_get(_params_handles_tiltrotor.tilt_transition, &v);
-	_params_tiltrotor.tilt_transition = v;
-
-	/* vtol tilt mechanism position in fw mode */
-	param_get(_params_handles_tiltrotor.tilt_fw, &v);
-	_params_tiltrotor.tilt_fw = v;
-
-	/* vtol airspeed at which it is ok to switch to fw mode */
-	param_get(_params_handles_tiltrotor.airspeed_trans, &v);
-	_params_tiltrotor.airspeed_trans = v;
-
-	/* vtol airspeed at which we start blending mc/fw controls */
-	param_get(_params_handles_tiltrotor.airspeed_blend_start, &v);
-	_params_tiltrotor.airspeed_blend_start = v;
-
-	/* vtol front transition phase 2 duration */
-	param_get(_params_handles_tiltrotor.front_trans_dur_p2, &v);
-	_params_tiltrotor.front_trans_dur_p2 = v;
-
-	/* avoid parameters which will lead to zero division in the transition code */
-	_params_tiltrotor.front_trans_dur = math::max(_params_tiltrotor.front_trans_dur, _min_front_trans_dur);
-
-	if (_params_tiltrotor.airspeed_trans < _params_tiltrotor.airspeed_blend_start + 1.0f) {
-		_params_tiltrotor.airspeed_trans = _params_tiltrotor.airspeed_blend_start + 1.0f;
-	}
-
-	/* airspeed mode */
-	param_get(_params_handles_tiltrotor.airspeed_disabled, &l);
-	_params_tiltrotor.airspeed_disabled = math::constrain(l, 0, 1);
-
-	param_get(_params_handles_tiltrotor.diff_thrust, &_params_tiltrotor.diff_thrust);
-
-	param_get(_params_handles_tiltrotor.diff_thrust_scale, &v);
-	_params_tiltrotor.diff_thrust_scale = math::constrain(v, -1.0f, 1.0f);
+	_fw_motors_off = get_motor_off_channels(_param_fw_motors_off.get());
 }
 
-int Tiltrotor::get_motor_off_channels(int channels)
+uint32_t Tiltrotor::get_motor_off_channels(int channels)
 {
-	int channel_bitmap = 0;
+	uint32_t channel_bitmap = 0;
 
-	int channel;
-
-	for (int i = 0; i < _params->vtol_motor_count; ++i) {
-		channel = channels % 10;
+	for (int i = 0; i < _param_vtol_motor_count.get(); ++i) {
+		uint32_t channel = channels % 10;
 
 		if (channel == 0) {
 			break;
@@ -186,7 +117,7 @@ void Tiltrotor::update_vtol_state()
 			break;
 
 		case TRANSITION_BACK:
-			if (_tilt_control <= _params_tiltrotor.tilt_mc) {
+			if (_tilt_control <= _param_tilt_mc.get()) {
 				_vtol_schedule.flight_mode = MC_MODE;
 			}
 
@@ -209,15 +140,17 @@ void Tiltrotor::update_vtol_state()
 				// allow switch if we are not armed for the sake of bench testing
 				bool transition_to_p2 = can_transition_on_ground();
 
+				const bool airspeed_enabled = (_param_airspeed_mode.get() == 0);
+
 				// check if we have reached airspeed to switch to fw mode
-				transition_to_p2 |= !_params_tiltrotor.airspeed_disabled &&
-						    _airspeed->indicated_airspeed_m_s >= _params_tiltrotor.airspeed_trans &&
-						    (float)hrt_elapsed_time(&_vtol_schedule.transition_start) > (_params->front_trans_time_min * 1e6f);
+				transition_to_p2 |= airspeed_enabled &&
+						    (_airspeed->indicated_airspeed_m_s >= _param_airspeed_trans.get()) &&
+						    (hrt_elapsed_time(&_vtol_schedule.transition_start) > (_param_front_trans_time_min.get() * 1e6f));
 
 				// check if airspeed is invalid and transition by time
-				transition_to_p2 |= _params_tiltrotor.airspeed_disabled &&
-						    _tilt_control > _params_tiltrotor.tilt_transition &&
-						    (float)hrt_elapsed_time(&_vtol_schedule.transition_start) > (_params->front_trans_time_openloop * 1e6f);
+				transition_to_p2 |= !airspeed_enabled &&
+						    (_tilt_control > _param_tilt_transition.get()) &&
+						    (hrt_elapsed_time(&_vtol_schedule.transition_start) > (_param_front_trans_time_openloop.get() * 1e6f));
 
 				if (transition_to_p2) {
 					_vtol_schedule.flight_mode = TRANSITION_FRONT_P2;
@@ -230,9 +163,9 @@ void Tiltrotor::update_vtol_state()
 		case TRANSITION_FRONT_P2:
 
 			// if the rotors have been tilted completely we switch to fw mode
-			if (_tilt_control >= _params_tiltrotor.tilt_fw) {
+			if (_tilt_control >= _param_tilt_fw.get()) {
 				_vtol_schedule.flight_mode = FW_MODE;
-				_tilt_control = _params_tiltrotor.tilt_fw;
+				_tilt_control = _param_tilt_fw.get();
 			}
 
 			break;
@@ -270,7 +203,7 @@ void Tiltrotor::update_mc_state()
 	VtolType::update_mc_state();
 
 	// make sure motors are not tilted
-	_tilt_control = _params_tiltrotor.tilt_mc;
+	_tilt_control = _param_tilt_mc.get();
 
 	// enable rear motors
 	if (_rear_motors != ENABLED) {
@@ -279,8 +212,7 @@ void Tiltrotor::update_mc_state()
 
 	// set idle speed for rotary wing mode
 	if (!flag_idle_mc) {
-		set_idle_mc();
-		flag_idle_mc = true;
+		flag_idle_mc = enable_mc_motors();
 	}
 }
 
@@ -289,7 +221,7 @@ void Tiltrotor::update_fw_state()
 	VtolType::update_fw_state();
 
 	// make sure motors are tilted forward
-	_tilt_control = _params_tiltrotor.tilt_fw;
+	_tilt_control = _param_tilt_fw.get();
 
 	// disable rear motors
 	if (_rear_motors != DISABLED) {
@@ -298,8 +230,7 @@ void Tiltrotor::update_fw_state()
 
 	// adjust idle for fixed wing flight
 	if (flag_idle_mc) {
-		set_idle_fw();
-		flag_idle_mc = false;
+		flag_idle_mc = !disable_mc_motors();
 	}
 }
 
@@ -319,13 +250,14 @@ void Tiltrotor::update_transition_state()
 		}
 
 		// tilt rotors forward up to certain angle
-		if (_tilt_control <= _params_tiltrotor.tilt_transition) {
-			_tilt_control = _params_tiltrotor.tilt_mc +
-					fabsf(_params_tiltrotor.tilt_transition - _params_tiltrotor.tilt_mc) * (float)hrt_elapsed_time(
-						&_vtol_schedule.transition_start) / (_params_tiltrotor.front_trans_dur * 1000000.0f);
+		if (_tilt_control <= _param_tilt_transition.get()) {
+
+			_tilt_control = _param_tilt_mc.get() +
+					fabsf(_param_tilt_transition.get() - _param_tilt_mc.get())
+					* hrt_elapsed_time(&_vtol_schedule.transition_start) / (_param_front_trans_dur.get() * 1e6f);
 		}
 
-		bool use_airspeed = !_params_tiltrotor.airspeed_disabled;
+		bool use_airspeed = (_param_airspeed_mode.get() == 0);
 
 		// at low speeds give full weight to MC
 		_mc_roll_weight = 1.0f;
@@ -336,16 +268,16 @@ void Tiltrotor::update_transition_state()
 			_mc_yaw_weight = 0.0f;
 		}
 
-		if (use_airspeed && _airspeed->indicated_airspeed_m_s >= _params_tiltrotor.airspeed_blend_start) {
-			_mc_roll_weight = 1.0f - (_airspeed->indicated_airspeed_m_s - _params_tiltrotor.airspeed_blend_start) /
-					  (_params_tiltrotor.airspeed_trans - _params_tiltrotor.airspeed_blend_start);
+		if (use_airspeed && _airspeed->indicated_airspeed_m_s >= _param_airspeed_blend_start.get()) {
+			_mc_roll_weight = 1.0f - (_airspeed->indicated_airspeed_m_s - _param_airspeed_blend_start.get()) /
+					  (_param_airspeed_trans.get() - _param_airspeed_blend_start.get());
 		}
 
 		// without airspeed do timed weight changes
 		if (!use_airspeed
-		    && (float)hrt_elapsed_time(&_vtol_schedule.transition_start) > (_params->front_trans_time_min * 1e6f)) {
-			_mc_roll_weight = 1.0f - ((float)hrt_elapsed_time(&_vtol_schedule.transition_start) - _params->front_trans_time_min *
-						  1e6f) / (_params->front_trans_time_openloop * 1e6f - _params->front_trans_time_min * 1e6f);
+		    && hrt_elapsed_time(&_vtol_schedule.transition_start) > (_param_front_trans_time_min.get() * 1e6f)) {
+			_mc_roll_weight = 1.0f - (hrt_elapsed_time(&_vtol_schedule.transition_start) - _param_front_trans_time_min.get() *
+						  1e6f) / (_param_front_trans_time_openloop.get() * 1e6f - _param_front_trans_time_min.get() * 1e6f);
 			_mc_yaw_weight = _mc_roll_weight;
 		}
 
@@ -353,17 +285,15 @@ void Tiltrotor::update_transition_state()
 
 	} else if (_vtol_schedule.flight_mode == TRANSITION_FRONT_P2) {
 		// the plane is ready to go into fixed wing mode, tilt the rotors forward completely
-		_tilt_control = _params_tiltrotor.tilt_transition +
-				fabsf(_params_tiltrotor.tilt_fw - _params_tiltrotor.tilt_transition) * (float)hrt_elapsed_time(
-					&_vtol_schedule.transition_start) / (_params_tiltrotor.front_trans_dur_p2 * 1000000.0f);
+		_tilt_control = _param_tilt_transition.get() + fabsf(_param_tilt_fw.get() - _param_tilt_transition.get()) *
+				hrt_elapsed_time(&_vtol_schedule.transition_start) / (_param_front_trans_dur_p2.get() * 1e6f);
 
 		_mc_roll_weight = 0.0f;
 		_mc_yaw_weight = 0.0f;
 
 		// ramp down rear motors (setting MAX_PWM down scales the given output into the new range)
-		int rear_value = (1.0f - (float)hrt_elapsed_time(&_vtol_schedule.transition_start) /
-				  (_params_tiltrotor.front_trans_dur_p2 *
-				   1000000.0f)) * (float)(PWM_DEFAULT_MAX - PWM_DEFAULT_MIN) + (float)PWM_DEFAULT_MIN;
+		int rear_value = (1.0f - hrt_elapsed_time(&_vtol_schedule.transition_start) / (_param_front_trans_dur_p2.get() * 1e6f))
+				 * (float)(PWM_DEFAULT_MAX - PWM_DEFAULT_MIN) + (float)PWM_DEFAULT_MIN;
 
 		set_rear_motor_state(VALUE, rear_value);
 
@@ -375,15 +305,14 @@ void Tiltrotor::update_transition_state()
 		}
 
 		if (!flag_idle_mc) {
-			set_idle_mc();
-			flag_idle_mc = true;
+			flag_idle_mc = enable_mc_motors();
 		}
 
 		// tilt rotors back
-		if (_tilt_control > _params_tiltrotor.tilt_mc) {
-			_tilt_control = _params_tiltrotor.tilt_fw -
-					fabsf(_params_tiltrotor.tilt_fw - _params_tiltrotor.tilt_mc) * (float)hrt_elapsed_time(
-						&_vtol_schedule.transition_start) / (_params_tiltrotor.back_trans_dur * 1000000.0f);
+		if (_tilt_control > _param_tilt_mc.get()) {
+
+			_tilt_control = _param_tilt_fw.get() - fabsf(_param_tilt_fw.get() - _param_tilt_mc.get()) *
+					hrt_elapsed_time(&_vtol_schedule.transition_start) / (_param_back_trans_dur.get() * 1e6f);
 		}
 
 		// set zero throttle for backtransition otherwise unwanted moments will be created
@@ -424,9 +353,9 @@ void Tiltrotor::fill_actuator_outputs()
 			_actuators_fw_in->control[actuator_controls_s::INDEX_THROTTLE];
 
 		/* allow differential thrust if enabled */
-		if (_params_tiltrotor.diff_thrust == 1) {
+		if (_param_diff_thrust.get() == 1) {
 			_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] =
-				_actuators_fw_in->control[actuator_controls_s::INDEX_YAW] * _params_tiltrotor.diff_thrust_scale;
+				_actuators_fw_in->control[actuator_controls_s::INDEX_YAW] * _param_diff_thrust_scale.get();
 		}
 
 	} else {
@@ -438,7 +367,7 @@ void Tiltrotor::fill_actuator_outputs()
 	_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] =
 		-_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL];
 	_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =
-		(_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH] + _params->fw_pitch_trim);
+		(_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH] + _param_fw_pitch_trim.get());
 	_actuators_out_1->control[actuator_controls_s::INDEX_YAW] =
 		_actuators_fw_in->control[actuator_controls_s::INDEX_YAW];	// yaw
 	_actuators_out_1->control[4] = _tilt_control;
@@ -466,7 +395,7 @@ void Tiltrotor::set_rear_motor_state(rear_motor_state state, int value)
 		break;
 
 	case IDLE:
-		pwm_value = _params->idle_pwm_mc;
+		pwm_value = _param_idle_pwm_mc.get();
 		_rear_motors = IDLE;
 		break;
 
@@ -485,7 +414,7 @@ void Tiltrotor::set_rear_motor_state(rear_motor_state state, int value)
 
 	struct pwm_output_values pwm_max_values = {};
 
-	for (int i = 0; i < _params->vtol_motor_count; i++) {
+	for (int i = 0; i < _param_vtol_motor_count.get(); i++) {
 		if (is_motor_off_channel(i)) {
 			pwm_max_values.values[i] = pwm_value;
 
@@ -493,7 +422,7 @@ void Tiltrotor::set_rear_motor_state(rear_motor_state state, int value)
 			pwm_max_values.values[i] = PWM_DEFAULT_MAX;
 		}
 
-		pwm_max_values.channel_count = _params->vtol_motor_count;
+		pwm_max_values.channel_count = _param_vtol_motor_count.get();
 	}
 
 	int ret = px4_ioctl(fd, PWM_SERVO_SET_MAX_PWM, (long unsigned int)&pwm_max_values);
@@ -507,5 +436,5 @@ void Tiltrotor::set_rear_motor_state(rear_motor_state state, int value)
 
 bool Tiltrotor::is_motor_off_channel(const int channel)
 {
-	return (_params_tiltrotor.fw_motors_off >> channel) & 1;
+	return (_fw_motors_off >> channel) & 1;
 }

--- a/src/modules/vtol_att_control/tiltrotor.h
+++ b/src/modules/vtol_att_control/tiltrotor.h
@@ -44,13 +44,13 @@
 #include <systemlib/param/param.h>
 #include <drivers/drv_hrt.h>
 
-class Tiltrotor : public VtolType
+class Tiltrotor final : public VtolType
 {
 
 public:
 
 	Tiltrotor(VtolAttitudeControl *_att_controller);
-	~Tiltrotor();
+	virtual ~Tiltrotor() = default;
 
 	virtual void update_vtol_state();
 	virtual void update_transition_state();

--- a/src/modules/vtol_att_control/tiltrotor.h
+++ b/src/modules/vtol_att_control/tiltrotor.h
@@ -40,13 +40,12 @@
 
 #ifndef TILTROTOR_H
 #define TILTROTOR_H
+
 #include "vtol_type.h"
-#include <systemlib/param/param.h>
 #include <drivers/drv_hrt.h>
 
 class Tiltrotor final : public VtolType
 {
-
 public:
 
 	Tiltrotor(VtolAttitudeControl *_att_controller);
@@ -61,35 +60,15 @@ public:
 
 private:
 
-	struct {
-		float front_trans_dur;			/**< duration of first part of front transition */
-		float back_trans_dur;			/**< duration of back transition */
-		float tilt_mc;					/**< actuator value corresponding to mc tilt */
-		float tilt_transition;			/**< actuator value corresponding to transition tilt (e.g 45 degrees) */
-		float tilt_fw;					/**< actuator value corresponding to fw tilt */
-		float airspeed_trans;			/**< airspeed at which we switch to fw mode after transition */
-		float airspeed_blend_start;		/**< airspeed at which we start blending mc/fw controls */
-		float front_trans_dur_p2;
-		int32_t fw_motors_off;			/**< bitmask of all motors that should be off in fixed wing mode */
-		int32_t airspeed_disabled;
-		int32_t diff_thrust;
-		float diff_thrust_scale;
-	} _params_tiltrotor;
+	BlockParamFloat	_param_tilt_mc;					/**< actuator value corresponding to mc tilt */
+	BlockParamFloat	_param_tilt_transition;			/**< actuator value corresponding to transition tilt (e.g 45 degrees) */
+	BlockParamFloat	_param_tilt_fw;					/**< actuator value corresponding to fw tilt */
+	BlockParamFloat	_param_front_trans_time_openloop;
+	BlockParamFloat	_param_front_trans_dur_p2;
 
-	struct {
-		param_t front_trans_dur;
-		param_t back_trans_dur;
-		param_t tilt_mc;
-		param_t tilt_transition;
-		param_t tilt_fw;
-		param_t airspeed_trans;
-		param_t airspeed_blend_start;
-		param_t front_trans_dur_p2;
-		param_t fw_motors_off;
-		param_t airspeed_disabled;
-		param_t diff_thrust;
-		param_t diff_thrust_scale;
-	} _params_handles_tiltrotor;
+	BlockParamInt	_param_fw_motors_off;			/**< bitmask of all motors that should be off in fixed wing mode */
+	BlockParamInt	_param_diff_thrust;
+	BlockParamFloat	_param_diff_thrust_scale;
 
 	enum vtol_mode {
 		MC_MODE = 0,			/**< vtol is in multicopter mode */
@@ -109,21 +88,21 @@ private:
 		DISABLED,
 		IDLE,
 		VALUE
-	} _rear_motors;
+	} _rear_motors{ENABLED};
 
 	struct {
 		vtol_mode flight_mode;			/**< vtol flight mode, defined by enum vtol_mode */
 		hrt_abstime transition_start;	/**< absoulte time at which front transition started */
 	} _vtol_schedule;
 
-	float _tilt_control;		/**< actuator value for the tilt servo */
+	float _tilt_control{0.0f};		/**< actuator value for the tilt servo */
 
-	const float _min_front_trans_dur;	/**< min possible time in which rotors are rotated into the first position */
+	uint32_t _fw_motors_off{0};
 
 	/**
 	 * Return a bitmap of channels that should be turned off in fixed wing mode.
 	 */
-	int get_motor_off_channels(const int channels);
+	uint32_t get_motor_off_channels(const int channels);
 
 	/**
 	 * Return true if the motor channel is off in fixed wing mode.

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -549,8 +549,6 @@ VtolAttitudeControl::task_main_trampoline(int argc, char *argv[])
 
 void VtolAttitudeControl::task_main()
 {
-	fflush(stdout);
-
 	/* do subscriptions */
 	_v_att_sp_sub          = orb_subscribe(ORB_ID(vehicle_attitude_setpoint));
 	_mc_virtual_att_sp_sub = orb_subscribe(ORB_ID(mc_virtual_attitude_setpoint));

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -61,41 +61,25 @@ VtolAttitudeControl::VtolAttitudeControl()
 {
 	_vtol_vehicle_status.vtol_in_rw_mode = true;	/* start vtol in rotary wing mode*/
 
-	_params.idle_pwm_mc = PWM_DEFAULT_MIN;
-	_params.vtol_motor_count = 0;
+	int32_t vtol_type_param = -1;
+	param_get(param_find("VT_TYPE"), &vtol_type_param);
 
-	_params_handles.idle_pwm_mc = param_find("VT_IDLE_PWM_MC");
-	_params_handles.vtol_motor_count = param_find("VT_MOT_COUNT");
-	_params_handles.vtol_fw_permanent_stab = param_find("VT_FW_PERM_STAB");
-	_params_handles.fw_pitch_trim = param_find("VT_FW_PITCH_TRIM");
-	_params_handles.vtol_type = param_find("VT_TYPE");
-	_params_handles.elevons_mc_lock = param_find("VT_ELEV_MC_LOCK");
-	_params_handles.fw_min_alt = param_find("VT_FW_MIN_ALT");
-	_params_handles.fw_alt_err = param_find("VT_FW_ALT_ERR");
-	_params_handles.fw_qc_max_pitch = param_find("VT_FW_QC_P");
-	_params_handles.fw_qc_max_roll = param_find("VT_FW_QC_R");
-	_params_handles.front_trans_time_openloop = param_find("VT_F_TR_OL_TM");
-	_params_handles.front_trans_time_min = param_find("VT_TRANS_MIN_TM");
-
-	_params_handles.wv_takeoff = param_find("VT_WV_TKO_EN");
-	_params_handles.wv_land = param_find("VT_WV_LND_EN");
-	_params_handles.wv_loiter = param_find("VT_WV_LTR_EN");
-
-	/* fetch initial parameter values */
-	parameters_update();
-
-	if (_params.vtol_type == vtol_type::TAILSITTER) {
+	if (vtol_type_param == vtol_type::TAILSITTER) {
 		_vtol_type = new Tailsitter(this);
 
-	} else if (_params.vtol_type == vtol_type::TILTROTOR) {
+	} else if (vtol_type_param == vtol_type::TILTROTOR) {
 		_vtol_type = new Tiltrotor(this);
 
-	} else if (_params.vtol_type == vtol_type::STANDARD) {
+	} else if (vtol_type_param == vtol_type::STANDARD) {
 		_vtol_type = new Standard(this);
 
 	} else {
+		PX4_ERR("invalid vtol_type %d", vtol_type_param);
 		_task_should_exit = true;
 	}
+
+	/* fetch initial parameter values */
+	parameters_update();
 }
 
 /**
@@ -228,7 +212,6 @@ VtolAttitudeControl::vehicle_local_pos_poll()
 	if (updated) {
 		orb_copy(ORB_ID(vehicle_local_position), _local_pos_sub, &_local_pos);
 	}
-
 }
 
 /**
@@ -424,75 +407,18 @@ VtolAttitudeControl::abort_front_transition(const char *reason)
 /**
 * Update parameters.
 */
-int
+void
 VtolAttitudeControl::parameters_update()
 {
-	float v;
-	int32_t l;
-	/* idle pwm for mc mode */
-	param_get(_params_handles.idle_pwm_mc, &_params.idle_pwm_mc);
-
-	/* vtol motor count */
-	param_get(_params_handles.vtol_motor_count, &_params.vtol_motor_count);
-
 	/* vtol fw permanent stabilization */
-	param_get(_params_handles.vtol_fw_permanent_stab, &l);
-	_vtol_vehicle_status.fw_permanent_stab = (l == 1);
-
-	/* vtol pitch trim for fw mode */
-	param_get(_params_handles.fw_pitch_trim, &v);
-	_params.fw_pitch_trim = v;
-
-	param_get(_params_handles.vtol_type, &l);
-	_params.vtol_type = l;
-
-	/* vtol lock elevons in multicopter */
-	param_get(_params_handles.elevons_mc_lock, &l);
-	_params.elevons_mc_lock = (l == 1);
-
-	/* minimum relative altitude for FW mode (QuadChute) */
-	param_get(_params_handles.fw_min_alt, &v);
-	_params.fw_min_alt = v;
-
-	/* maximum negative altitude error for FW mode (Adaptive QuadChute) */
-	param_get(_params_handles.fw_alt_err, &v);
-	_params.fw_alt_err = v;
-
-	/* maximum pitch angle (QuadChute) */
-	param_get(_params_handles.fw_qc_max_pitch, &l);
-	_params.fw_qc_max_pitch = l;
-
-	/* maximum roll angle (QuadChute) */
-	param_get(_params_handles.fw_qc_max_roll, &l);
-	_params.fw_qc_max_roll = l;
-
-	param_get(_params_handles.front_trans_time_openloop, &_params.front_trans_time_openloop);
-
-	param_get(_params_handles.front_trans_time_min, &_params.front_trans_time_min);
-
-	/*
-	 * Minimum transition time can be maximum 90 percent of the open loop transition time,
-	 * anything else makes no sense and can potentially lead to numerical problems.
-	 */
-	_params.front_trans_time_min = math::min(_params.front_trans_time_openloop * 0.9f,
-				       _params.front_trans_time_min);
-
-	/* weathervane */
-	param_get(_params_handles.wv_takeoff, &l);
-	_params.wv_takeoff = (l == 1);
-
-	param_get(_params_handles.wv_loiter, &l);
-	_params.wv_loiter = (l == 1);
-
-	param_get(_params_handles.wv_land, &l);
-	_params.wv_land = (l == 1);
+	int32_t vtol_fw_permanent_stab = 0;
+	param_get(_param_vtol_fw_permanent_stab, &vtol_fw_permanent_stab);
+	_vtol_vehicle_status.fw_permanent_stab = (_param_vtol_fw_permanent_stab == 1);
 
 	// update the parameters of the instances of base VtolType
 	if (_vtol_type != nullptr) {
 		_vtol_type->parameters_update();
 	}
-
-	return OK;
 }
 
 /**
@@ -571,9 +497,6 @@ void VtolAttitudeControl::task_main()
 	_actuator_inputs_fw    = orb_subscribe(ORB_ID(actuator_controls_virtual_fw));
 
 	parameters_update();  // initialize parameter cache
-
-	// make sure we start with idle in mc mode
-	_vtol_type->set_idle_mc();
 
 	/* wakeup source*/
 	px4_pollfd_struct_t fds[1] = {};
@@ -748,7 +671,7 @@ VtolAttitudeControl::start()
 	_control_task = px4_task_spawn_cmd("vtol_att_control",
 					   SCHED_DEFAULT,
 					   SCHED_PRIORITY_ATTITUDE_CONTROL + 1,
-					   1230,
+					   1200,
 					   (px4_main_t)&VtolAttitudeControl::task_main_trampoline,
 					   nullptr);
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -114,11 +114,8 @@ public:
 	struct vehicle_local_position_setpoint_s	*get_local_pos_sp() {return &_local_pos_sp;}
 	struct vtol_vehicle_status_s			*get_vtol_vehicle_status() {return &_vtol_vehicle_status;}
 
-	struct Params 					*get_params() {return &_params;}
-
-
 private:
-//******************flags & handlers******************************************************
+
 	bool	_task_should_exit{false};
 	int	_control_task{-1};		//task handle for VTOL attitude controller
 
@@ -142,7 +139,7 @@ private:
 	int	_v_control_mode_sub{-1};	//vehicle control mode subscription
 	int	_vehicle_cmd_sub{-1};
 
-	//handlers for publishers
+	// handlers for publishers
 	orb_advert_t	_actuators_0_pub{nullptr};		//input for the mixer (roll,pitch,yaw,thrust)
 	orb_advert_t	_mavlink_log_pub{nullptr};	// mavlink log uORB handle
 	orb_advert_t	_v_att_sp_pub{nullptr};
@@ -151,7 +148,6 @@ private:
 	orb_advert_t	_vtol_vehicle_status_pub{nullptr};
 	orb_advert_t 	_actuators_1_pub{nullptr};
 
-//*******************data containers***********************************************************
 
 	vehicle_attitude_setpoint_s		_v_att_sp{};			//vehicle attitude setpoint
 	vehicle_attitude_setpoint_s 		_fw_virtual_att_sp{};	// virtual fw attitude setpoint
@@ -174,25 +170,7 @@ private:
 	vehicle_local_position_setpoint_s	_local_pos_sp{};
 	vtol_vehicle_status_s 			_vtol_vehicle_status{};
 
-	Params _params{};	// struct holding the parameters
-
-	struct {
-		param_t idle_pwm_mc;
-		param_t vtol_motor_count;
-		param_t vtol_fw_permanent_stab;
-		param_t fw_pitch_trim;
-		param_t vtol_type;
-		param_t elevons_mc_lock;
-		param_t fw_min_alt;
-		param_t fw_alt_err;
-		param_t fw_qc_max_pitch;
-		param_t fw_qc_max_roll;
-		param_t front_trans_time_openloop;
-		param_t front_trans_time_min;
-		param_t wv_takeoff;
-		param_t wv_loiter;
-		param_t wv_land;
-	} _params_handles{};
+	param_t _param_vtol_fw_permanent_stab{PARAM_INVALID};
 
 	/* for multicopters it is usual to have a non-zero idle speed of the engines
 	 * for fixed wings we want to have an idle speed of zero since we do not want
@@ -202,7 +180,6 @@ private:
 
 	VtolType *_vtol_type{nullptr};	// base class for different vtol types
 
-//*****************Member functions***********************************************************************
 
 	void 		task_main();	//main task
 	static void	task_main_trampoline(int argc, char *argv[]);	//Shim for calling task_main from task_create.
@@ -222,7 +199,7 @@ private:
 	void 		vehicle_local_pos_poll();		// Check for changes in sensor values
 	void 		vehicle_local_pos_sp_poll();		// Check for changes in setpoint values
 
-	int 		parameters_update();			//Update local paraemter cache
+	void 		parameters_update();			//Update local paraemter cache
 
 	void 		fill_mc_att_rates_sp();
 	void 		fill_fw_att_rates_sp();

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -189,20 +189,6 @@ PARAM_DEFINE_FLOAT(VT_ARSP_TRANS, 10.0f);
 PARAM_DEFINE_INT32(VT_OPT_RECOV_EN, 0);
 
 /**
- * Front transition timeout
- *
- * Time in seconds after which transition will be cancelled. Disabled if set to 0.
- *
- * @unit s
- * @min 0.00
- * @max 30.00
- * @increment 1
- * @decimal 2
- * @group VTOL Attitude Control
- */
-PARAM_DEFINE_FLOAT(VT_TRANS_TIMEOUT, 15.0f);
-
-/**
  * Front transition minimum time
  *
  * Minimum time in seconds for front transition.

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -82,18 +82,15 @@ void VtolType::set_idle_mc()
 		PX4_WARN("can't open %s", dev);
 	}
 
-	unsigned servo_count;
-	int ret = px4_ioctl(fd, PWM_SERVO_GET_COUNT, (unsigned long)&servo_count);
 	unsigned pwm_value = _params->idle_pwm_mc;
-	struct pwm_output_values pwm_values;
-	memset(&pwm_values, 0, sizeof(pwm_values));
+	struct pwm_output_values pwm_values = {};
 
 	for (int i = 0; i < _params->vtol_motor_count; i++) {
 		pwm_values.values[i] = pwm_value;
 		pwm_values.channel_count++;
 	}
 
-	ret = px4_ioctl(fd, PWM_SERVO_SET_MIN_PWM, (long unsigned int)&pwm_values);
+	int ret = px4_ioctl(fd, PWM_SERVO_SET_MIN_PWM, (long unsigned int)&pwm_values);
 
 	if (ret != OK) {
 		PX4_WARN("failed setting min values");

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -40,6 +40,7 @@
 */
 
 #include "vtol_type.h"
+
 #include "vtol_att_control_main.h"
 
 #include <cfloat>
@@ -47,15 +48,36 @@
 #include <matrix/math.hpp>
 
 VtolType::VtolType(VtolAttitudeControl *att_controller) :
+	SuperBlock(nullptr, "VT"),
 	_attc(att_controller),
-	_vtol_mode(ROTARY_WING)
+	_param_idle_pwm_mc(this, "IDLE_PWM_MC"),
+	_param_vtol_motor_count(this, "MOT_COUNT"),
+	_param_fw_pitch_trim(this, "FW_PITCH_TRIM"),
+	_param_elevons_mc_lock(this, "ELEV_MC_LOCK"),
+	_param_front_trans_dur(this, "F_TRANS_DUR"),
+	_param_front_trans_time_min(this, "TRANS_MIN_TM"),
+	_param_airspeed_blend_start(this, "ARSP_BLEND"),
+	_param_airspeed_trans(this, "ARSP_TRANS"),
+	_param_back_trans_dur(this, "B_TRANS_DUR"),
+	_param_qc_fw_min_alt(this, "FW_MIN_ALT"),
+	_param_qc_fw_alt_err(this, "FW_ALT_ERR"),
+	_param_qc_fw_max_pitch(this, "FW_QC_P"),
+	_param_qc_fw_max_roll(this, "FW_QC_R"),
+	_param_wv_takeoff(this, "WV_TKO_EN"),
+	_param_wv_loiter(this, "WV_LTR_EN"),
+	_param_wv_land(this, "WV_LND_EN"),
+	// non-vtol params
+	_param_airspeed_mode(this, "FW_ARSP_MODE", false)
 {
+	for (auto &pwm_max : _max_mc_pwm_values.values) {
+		pwm_max = PWM_DEFAULT_MAX;
+	}
+
 	_v_att = _attc->get_att();
 	_v_att_sp = _attc->get_att_sp();
 	_mc_virtual_att_sp = _attc->get_mc_virtual_att_sp();
 	_fw_virtual_att_sp = _attc->get_fw_virtual_att_sp();
 	_v_control_mode = _attc->get_control_mode();
-	_vtol_vehicle_status = _attc->get_vtol_vehicle_status();
 	_actuators_out_0 = _attc->get_actuators_out0();
 	_actuators_out_1 = _attc->get_actuators_out1();
 	_actuators_mc_in = _attc->get_actuators_mc_in();
@@ -65,71 +87,6 @@ VtolType::VtolType(VtolAttitudeControl *att_controller) :
 	_airspeed = _attc->get_airspeed();
 	_tecs_status = _attc->get_tecs_status();
 	_land_detected = _attc->get_land_detected();
-	_params = _attc->get_params();
-
-	flag_idle_mc = true;
-}
-
-/**
-* Adjust idle speed for mc mode.
-*/
-void VtolType::set_idle_mc()
-{
-	const char *dev = PWM_OUTPUT0_DEVICE_PATH;
-	int fd = px4_open(dev, 0);
-
-	if (fd < 0) {
-		PX4_WARN("can't open %s", dev);
-	}
-
-	unsigned pwm_value = _params->idle_pwm_mc;
-	struct pwm_output_values pwm_values = {};
-
-	for (int i = 0; i < _params->vtol_motor_count; i++) {
-		pwm_values.values[i] = pwm_value;
-		pwm_values.channel_count++;
-	}
-
-	int ret = px4_ioctl(fd, PWM_SERVO_SET_MIN_PWM, (long unsigned int)&pwm_values);
-
-	if (ret != OK) {
-		PX4_WARN("failed setting min values");
-	}
-
-	px4_close(fd);
-
-	flag_idle_mc = true;
-}
-
-/**
-* Adjust idle speed for fw mode.
-*/
-void VtolType::set_idle_fw()
-{
-	const char *dev = PWM_OUTPUT0_DEVICE_PATH;
-	int fd = px4_open(dev, 0);
-
-	if (fd < 0) {
-		PX4_WARN("can't open %s", dev);
-	}
-
-	struct pwm_output_values pwm_values;
-
-	memset(&pwm_values, 0, sizeof(pwm_values));
-
-	for (int i = 0; i < _params->vtol_motor_count; i++) {
-
-		pwm_values.values[i] = PWM_MOTOR_OFF;
-		pwm_values.channel_count++;
-	}
-
-	int ret = px4_ioctl(fd, PWM_SERVO_SET_MIN_PWM, (long unsigned int)&pwm_values);
-
-	if (ret != OK) {
-		PX4_WARN("failed setting min values");
-	}
-
-	px4_close(fd);
 }
 
 void VtolType::update_mc_state()
@@ -147,14 +104,19 @@ void VtolType::update_mc_state()
 	if (_attc->get_pos_sp_triplet()->current.valid &&
 	    !_v_control_mode->flag_control_manual_enabled) {
 
-		if (_params->wv_takeoff && _attc->get_pos_sp_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF) {
+		if (_param_wv_takeoff.get()
+		    && _attc->get_pos_sp_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF) {
+
 			_v_att_sp->disable_mc_yaw_control = true;
 
-		} else if (_params->wv_loiter
+		} else if (_param_wv_loiter.get()
 			   && _attc->get_pos_sp_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER) {
+
 			_v_att_sp->disable_mc_yaw_control = true;
 
-		} else if (_params->wv_land && _attc->get_pos_sp_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
+		} else if (_param_wv_land.get()
+			   && _attc->get_pos_sp_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
+
 			_v_att_sp->disable_mc_yaw_control = true;
 		}
 	}
@@ -206,15 +168,15 @@ void VtolType::check_quadchute_condition()
 		matrix::Eulerf euler = matrix::Quatf(_v_att->q);
 
 		// fixed-wing minimum altitude
-		if (_params->fw_min_alt > FLT_EPSILON) {
+		if (_param_qc_fw_min_alt.get() > FLT_EPSILON) {
 
-			if (-(_local_pos->z) < _params->fw_min_alt) {
+			if (-(_local_pos->z) < _param_qc_fw_min_alt.get()) {
 				_attc->abort_front_transition("QuadChute: Minimum altitude breached");
 			}
 		}
 
 		// adaptive quadchute
-		if (_params->fw_alt_err > FLT_EPSILON && _v_control_mode->flag_control_altitude_enabled) {
+		if (_param_qc_fw_alt_err.get() > FLT_EPSILON && _v_control_mode->flag_control_altitude_enabled) {
 
 			// We use tecs for tracking in FW and local_pos_sp during transitions
 			if (_tecs_running) {
@@ -223,7 +185,7 @@ void VtolType::check_quadchute_condition()
 				_ra_hrate_sp = (49 * _ra_hrate_sp + _tecs_status->flightPathAngleSp) / 50;
 
 				// are we dropping while requesting significant ascend?
-				if (((_tecs_status->altitudeSp - _tecs_status->altitude_filtered) > _params->fw_alt_err) &&
+				if (((_tecs_status->altitudeSp - _tecs_status->altitude_filtered) > _param_qc_fw_alt_err.get()) &&
 				    (_ra_hrate < -1.0f) &&
 				    (_ra_hrate_sp > 1.0f)) {
 
@@ -231,7 +193,7 @@ void VtolType::check_quadchute_condition()
 				}
 
 			} else {
-				const bool height_error = _local_pos->z_valid && ((-_local_pos_sp->z - -_local_pos->z) > _params->fw_alt_err);
+				const bool height_error = _local_pos->z_valid && ((-_local_pos_sp->z - -_local_pos->z) > _param_qc_fw_alt_err.get());
 				const bool height_rate_error = _local_pos->v_z_valid && (_local_pos->vz > 1.0f) && (_local_pos->z_deriv > 1.0f);
 
 				if (height_error && height_rate_error) {
@@ -241,17 +203,15 @@ void VtolType::check_quadchute_condition()
 		}
 
 		// fixed-wing maximum pitch angle
-		if (_params->fw_qc_max_pitch > 0) {
-
-			if (fabsf(euler.theta()) > fabsf(math::radians(_params->fw_qc_max_pitch))) {
+		if (_param_qc_fw_max_pitch.get() > 0) {
+			if (fabsf(math::degrees(euler.theta())) > _param_qc_fw_max_pitch.get()) {
 				_attc->abort_front_transition("Maximum pitch angle exceeded");
 			}
 		}
 
 		// fixed-wing maximum roll angle
-		if (_params->fw_qc_max_roll > 0) {
-
-			if (fabsf(euler.phi()) > fabsf(math::radians(_params->fw_qc_max_roll))) {
+		if (_param_qc_fw_max_roll.get() > 0) {
+			if (fabsf(math::degrees(euler.phi())) > _param_qc_fw_max_roll.get()) {
 				_attc->abort_front_transition("Maximum roll angle exceeded");
 			}
 		}
@@ -284,15 +244,15 @@ VtolType::disable_mc_motors()
 	}
 
 	// now get the disarmed PWM values
-	output_pwm_s disarmed_pwm_values = {};
+	pwm_output_values disarmed_pwm_values = {};
 	ret = px4_ioctl(fd, PWM_SERVO_GET_DISARMED_PWM, (long unsigned int)&disarmed_pwm_values);
 
 	if (ret == OK) {
 
 		// finally disable by setting the MC motors max to the disarmed value
-		for (int i = 0; i < _params->vtol_motor_count; i++) {
+		for (int i = 0; i < _param_vtol_motor_count.get(); i++) {
 			max_pwm_values.values[i] = disarmed_pwm_values.values[i];
-			max_pwm_values.channel_count = _params->vtol_motor_count;
+			max_pwm_values.channel_count = _param_vtol_motor_count.get();
 		}
 
 		ret = px4_ioctl(fd, PWM_SERVO_SET_MAX_PWM, (long unsigned int)&max_pwm_values);
@@ -323,9 +283,9 @@ VtolType::enable_mc_motors()
 
 	struct pwm_output_values pwm_values = {};
 
-	for (int i = 0; i < _params->vtol_motor_count; i++) {
+	for (int i = 0; i < _param_vtol_motor_count.get(); i++) {
 		pwm_values.values[i] = _max_mc_pwm_values.values[i];
-		pwm_values.channel_count = _params->vtol_motor_count;
+		pwm_values.channel_count = _param_vtol_motor_count.get();
 	}
 
 	int ret = px4_ioctl(fd, PWM_SERVO_SET_MAX_PWM, (long unsigned int)&pwm_values);

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -45,6 +45,8 @@
 
 #include <lib/mathlib/mathlib.h>
 #include <drivers/drv_hrt.h>
+#include <drivers/drv_pwm_output.h>
+#include <uORB/topics/vtol_vehicle_status.h>
 
 struct Params {
 	int32_t idle_pwm_mc;			// pwm value for idle in mc mode
@@ -65,10 +67,10 @@ struct Params {
 
 // Has to match 1:1 msg/vtol_vehicle_status.msg
 enum mode {
-	TRANSITION_TO_FW = 1,
-	TRANSITION_TO_MC = 2,
-	ROTARY_WING = 3,
-	FIXED_WING = 4
+	TRANSITION_TO_FW = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_TRANSITION_TO_FW,
+	TRANSITION_TO_MC = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_TRANSITION_TO_MC,
+	ROTARY_WING = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC,
+	FIXED_WING = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW
 };
 
 enum vtol_type {
@@ -87,7 +89,7 @@ public:
 	VtolType(const VtolType &) = delete;
 	VtolType &operator=(const VtolType &) = delete;
 
-	virtual ~VtolType();
+	virtual ~VtolType() = default;
 
 	/**
 	 * Update vtol state.

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -178,6 +178,11 @@ protected:
 	bool _tecs_running = false;
 	hrt_abstime _tecs_running_ts = 0;
 
+	struct pwm_output_values _max_mc_pwm_values {};
+
+	bool enable_mc_motors();
+	bool disable_mc_motors();
+
 };
 
 #endif


### PR DESCRIPTION
VTOL standard was disabling multicopter motors by setting the PWM_MAX to 900us, and then re-enabling by setting back to 2000us. This PR preserves the motors PWM_MIN and PWM_MAX.

Longer term it would be better to have an API to do this without directly dealing with PWM.

The PWM changes have been bench tested and the other misc changes have been tested in SITL. 

This was split out of some larger changes I've been playing with and needs careful review and more testing.