### PR TITLE
add possibility to change params in gpssim

### DIFF
--- a/src/platforms/posix/drivers/accelsim/accelsim.cpp
+++ b/src/platforms/posix/drivers/accelsim/accelsim.cpp
@@ -1168,7 +1168,7 @@ accelsim_main(int argc, char *argv[])
 		}
 	}
 
-	if (argc <= 1) {
+	if (myoptind >= argc) {
 		accelsim::usage();
 		return 1;
 	}

--- a/src/platforms/posix/drivers/gpssim/gpssim.cpp
+++ b/src/platforms/posix/drivers/gpssim/gpssim.cpp
@@ -558,11 +558,6 @@ usage(const char *reason)
 int
 gpssim_main(int argc, char *argv[])
 {
-	if (argc < 2) {
-		gpssim::usage("not enough arguments supplied");
-		return 1;
-	}
-
 	// set to default
 	const char *device_name = GPS_DEFAULT_UART_PORT;
 	bool fake_gps = false;
@@ -593,6 +588,11 @@ gpssim_main(int argc, char *argv[])
 		default:
 			PX4_WARN("Unknown option!");
 		}
+	}
+
+	if (myoptind >= argc) {
+		gpssim::usage("not enough arguments supplied");
+		return 1;
 	}
 
 	/*

--- a/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
+++ b/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
@@ -1482,6 +1482,11 @@ gyrosim_main(int argc, char *argv[])
 		}
 	}
 
+	if (myoptind >= argc) {
+		gyrosim::usage();
+		return 1;
+	}
+
 	const char *verb = argv[myoptind];
 
 	/*


### PR DESCRIPTION
This PR changes 3 things:

- use px4_getopt for gpssim
- add possibility to change fix_type, satellites_used and a noise parameter during simulation for testing purposes
- fix a seg fault that happens when you run the drivers with options only (e.g. `gpssim -f`)

@priseborough This should hopefully help testing with bad GPS