### PR TITLE
Fix check_stack target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,19 +357,14 @@ cppcheck: posix_sitl_default
 	@cppcheck-htmlreport --source-encoding=ascii --file=cppcheck-result.xml --report-dir=cppcheck --source-dir=$(SRC_DIR)/src/
 
 check_stack: px4fmu-v3_default
-	@echo "Checking worst case stack usage with avstack.pl ..."
-	@echo " "
-	@cd build_px4fmu-v3_default/ && mkdir -p stack_usage && $(SRC_DIR)/Tools/stack_usage/avstack.pl `find . -name *.obj` > stack_usage/avstack_output.txt 2> stack_usage/avstack_errors.txt
-	@head -n 10 build_px4fmu-v3_default/stack_usage/avstack_output.txt | c++filt
-	@echo " "
 	@echo "Checking worst case stack usage with checkstack.pl ..."
 	@echo " "
 	@echo "Top 10:"
-	@cd build_px4fmu-v3_default/ && mkdir -p stack_usage && arm-none-eabi-objdump -d src/firmware/nuttx/firmware_nuttx | $(SRC_DIR)/Tools/stack_usage/checkstack.pl arm 0 > stack_usage/checkstack_output.txt 2> stack_usage/checkstack_errors.txt
-	@head -n 10 build_px4fmu-v3_default/stack_usage/checkstack_output.txt | c++filt
+	@cd build/px4fmu-v3_default/ && mkdir -p stack_usage && arm-none-eabi-objdump -d nuttx_px4fmu-v3_default.elf | $(SRC_DIR)/Tools/stack_usage/checkstack.pl arm 0 > stack_usage/checkstack_output.txt 2> stack_usage/checkstack_errors.txt
+	@head -n 10 build/px4fmu-v3_default/stack_usage/checkstack_output.txt | c++filt
 	@echo " "
 	@echo "Symbols with 'main', 'thread' or 'task':"
-	@cat build_px4fmu-v3_default/stack_usage/checkstack_output.txt | c++filt | grep -E 'thread|main|task'
+	@cat build/px4fmu-v3_default/stack_usage/checkstack_output.txt | c++filt | grep -E 'thread|main|task'
 
 # Cleanup
 # --------------------------------------------------------------------


### PR DESCRIPTION
Fix the Makefile target "check_stack" to match the new build directories (https://github.com/PX4/Firmware/pull/7873).

note: as the compile flag "-fstack-usage" was removed, I removed calls to the first script that needs *.su files (which are only generated when -fstack-usage is passed to the compiler)