### PR TITLE
Add ocpoc target to CI

### DIFF
--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -11,6 +11,9 @@ if [ -z ${PX4_DOCKER_REPO+x} ]; then
 	elif [[ $@ =~ .*eagle.* ]] || [[ $@ =~ .*excelsior.* ]]; then
 		# eagle, excelsior
 		PX4_DOCKER_REPO="lorenzmeier/px4-dev-snapdragon:2017-07-28"
+	elif [[ $@ =~ .*ocpoc.* ]]; then
+		# posix_ocpoc_ubuntu
+		PX4_DOCKER_REPO="px4io/px4-dev-armhf:2017-09-26"
 	elif [[ $@ =~ .*clang.* ]] || [[ $@ =~ .*scan-build.* ]]; then
 		# clang tools
 		PX4_DOCKER_REPO="px4io/px4-dev-clang:2017-08-29"

--- a/src/drivers/boards/ocpoc/board_config.h
+++ b/src/drivers/boards/ocpoc/board_config.h
@@ -47,6 +47,12 @@
 #define BOARD_HAS_NO_RESET
 #define BOARD_HAS_NO_BOOTLOADER
 
+#define BOARD_NUMBER_I2C_BUSES 4
+#define BOARD_MAX_LEDS 1 // Number external of LED's this board has
+#define PX4_I2C_BUS_LED 1
+#define PX4_I2C_OBDEV_LED 0x55
+#define PX4_I2C_BUS_EXPANSION 1
+
 // Battery ADC channels
 #define ADC_BATTERY_VOLTAGE_CHANNEL     10
 #define ADC_BATTERY_CURRENT_CHANNEL     ((uint8_t)(-1))
@@ -54,5 +60,3 @@
 
 #include <system_config.h>
 #include "../common/board_common.h"
-
-#define BOARD_MAX_LEDS 1 // Number external of LED's this board has


### PR DESCRIPTION
Adds ocpoc build target to docker_run.sh - in response to PR #7787 - and updates some board_config items that had broken the build target. Docker file and container were added/built in [containers PR #73](https://github.com/PX4/containers/pull/73).

@dagar It seems like semaphoreci is the appropriate place to add ocpoc, since that's where rpi and bebop run their test builds, but I'll reiterate that I'm brand new to the CI side of things. I haven't added the target yet, as I don't really know how to add the target to semaphoreci.