### PR TITLE
[wip] rtl: brake, pre-return and after-return

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1035,7 +1035,7 @@ float
 MulticopterPositionControl::get_cruising_speed_xy()
 {
 	/*
-	 * in mission the user can choose cruising speed different to default
+	 * in mission the cruise-speed can be different to default
 	 */
 	return ((PX4_ISFINITE(_pos_sp_triplet.current.cruising_speed) && !(_pos_sp_triplet.current.cruising_speed < 0.0f)) ?
 		_pos_sp_triplet.current.cruising_speed : _params.vel_cruise_xy);
@@ -2235,6 +2235,7 @@ void MulticopterPositionControl::control_auto(float dt)
 			_pos_sp = pos_sp;
 
 		} else if (_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_VELOCITY) {
+			/* track the cruise-speed of current triplet */
 
 			float vel_xy_mag = sqrtf(_vel(0) * _vel(0) + _vel(1) * _vel(1));
 
@@ -2243,9 +2244,6 @@ void MulticopterPositionControl::control_auto(float dt)
 				_vel_sp(1) = _vel(1) / vel_xy_mag * get_cruising_speed_xy();
 
 			} else {
-				/* TODO: we should go in the direction we are heading
-				 * if current velocity is zero
-				 */
 				_vel_sp(0) = 0.0f;
 				_vel_sp(1) = 0.0f;
 			}

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -86,7 +86,6 @@ Land::on_activation()
 	pos_sp_triplet->next.valid = false;
 
 	_navigator->set_can_loiter_at_sp(false);
-
 	_navigator->set_position_setpoint_triplet_updated();
 }
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -360,7 +360,11 @@ MissionBlock::is_mission_item_reached()
 
 		/* the vehicle has desired velocity */
 		if (fabsf(ground_speed - _mission_item.requested_speed) < 0.5f) {
+
+			// only interested in velocity and therefore reset position and yaw criteria
 			_waypoint_velocity_reached = true;
+			_waypoint_position_reached = false;
+			_waypoint_yaw_reached = false;
 			return true;
 		}
 
@@ -403,11 +407,13 @@ MissionBlock::is_mission_item_reached()
 								   &curr_sp.lat, &curr_sp.lon);
 			}
 
+			// we are not interested in velocity criteria
+			_waypoint_velocity_reached = false;
 			return true;
 		}
 	}
 
-// all acceptance criteria must be met in the same iteration
+	// reset all criteria
 	_waypoint_position_reached = false;
 	_waypoint_yaw_reached = false;
 	_waypoint_velocity_reached = false;

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -120,6 +120,11 @@ protected:
 	 */
 	void set_follow_target_item(struct mission_item_s *item, float min_clearance, follow_target_s &target, float yaw);
 
+	/**
+	* Set brake item
+	*/
+	void set_brake_item(struct mission_item_s *item);
+
 	void issue_command(const mission_item_s &item);
 
 	float get_time_inside(const struct mission_item_s &item);
@@ -128,6 +133,7 @@ protected:
 
 	bool _waypoint_position_reached{false};
 	bool _waypoint_yaw_reached{false};
+	bool _waypoint_velocity_reached{false};
 
 	hrt_abstime _time_first_inside_orbit{0};
 	hrt_abstime _action_start{0};

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -124,6 +124,7 @@ struct mission_item_s {
 			float ___lat_float;			/**< padding */
 			float ___lon_float;			/**< padding */
 			float altitude;				/**< altitude in meters	(AMSL)			*/
+			float requested_speed;     /**< only considered if force_velocity is set */
 		};
 		float params[7];				/**< array to store mission command values for MAV_FRAME_MISSION ***/
 	};
@@ -142,7 +143,8 @@ struct mission_item_s {
 			 altitude_is_relative : 1,		/**< true if altitude is relative from start point	*/
 			 autocontinue : 1,				/**< true if next waypoint should follow after this one */
 			 disable_mc_yaw : 1,				/**< weathervane mode */
-			 vtol_back_transition : 1;		/**< part of the vtol back transition sequence */
+			 vtol_back_transition : 1,		/**< part of the vtol back transition sequence */
+			 force_velocity: 1;				/**< velocity target is set*/
 	};
 };
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -385,6 +385,7 @@ Navigator::task_main()
 				rep->current.loiter_radius = get_loiter_radius();
 				rep->current.loiter_direction = 1;
 				rep->current.type = position_setpoint_s::SETPOINT_TYPE_LOITER;
+				rep->current.cruising_speed = get_cruising_speed();
 
 				// Go on and check which changes had been requested
 				if (PX4_ISFINITE(cmd.param4)) {

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -82,13 +82,18 @@ RTL::on_activation()
 	pos_sp_triplet->previous.valid = false;
 	pos_sp_triplet->next.valid = false;
 
-	/* for safety reasons don't go into RTL if landed */
+	// for safety reasons don't go into RTL if landed
 	if (_navigator->get_land_detected()->landed) {
 		_rtl_state = RTL_STATE_LANDED;
 
 	} else {
-		// otherwise start RTL with braking first
-		_rtl_state = RTL_STATE_BRAKE;
+		// otherwise start with first item of rtl sequence
+		if (_navigator->get_vstatus()->is_rotary_wing) {
+			_rtl_state = RTL_STATE_BRAKE;
+
+		} else {
+			_rtl_state = RTL_STATE_CLIMB;
+		}
 
 	}
 

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -31,7 +31,7 @@
  *
  ****************************************************************************/
 /**
- * @file navigator_rtl.h
+ * @file rtl.h
  * Helper class for RTL
  *
  * @author Julian Oes <julian@oes.ch>
@@ -74,14 +74,10 @@ private:
 	 */
 	void		advance_rtl();
 
-	/**
-	 * Get RTL altitude
-	 */
-	float 		get_rtl_altitude();
-
 
 	enum RTLState {
 		RTL_STATE_NONE = 0,
+		RTL_STATE_BRAKE,
 		RTL_STATE_CLIMB,
 		RTL_STATE_RETURN,
 		RTL_STATE_TRANSITION_TO_MC,
@@ -89,6 +85,8 @@ private:
 		RTL_STATE_LOITER,
 		RTL_STATE_LAND,
 		RTL_STATE_LANDED,
+		RTL_STATE_PRE_RETURN,
+		RTL_STATE_AFTER_RETURN,
 	} _rtl_state{RTL_STATE_NONE};
 
 	control::BlockParamFloat _param_return_alt;


### PR DESCRIPTION
rtl brake (could be used for any mission change)
vehicle slows down before proceeding to next rlt state

rlt pre-return
before returning to home, orient vehicle first

rlt after-return
before descending, orient vehicle to home yaw

@dagar 
how does fixed wing do rtl?