### PR TITLE
SDlog2 log format fix

### DIFF
--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -641,7 +641,7 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT(CAMT, "QI", "timestamp,seq"),
 	LOG_FORMAT(LAND, "B", "Landed"),
 	LOG_FORMAT(LOAD, "f", "CPU"),
-	LOG_FORMAT(DPRS, "Qffff", "errors,DPRESraw,DPRES,DPRESmax,Temp"),
+	LOG_FORMAT(DPRS, "Qfff", "errors,DPRESraw,DPRES,Temp"),
 	LOG_FORMAT(STCK, "NH", "Task,Free"),
 	/* system-level messages, ID >= 0x80 */
 	/* FMT: don't write format of format message, it's useless */


### PR DESCRIPTION
Fix the log format for the differential pressure message.

Only one uint64_t and 3 floats are written to the log file: https://github.com/acfloria/Firmware/blob/master/src/modules/sdlog2/sdlog2.c#L1885

Therefore it is not possible to convert and process log files logged by SDlog2 and display the data. 

