### PR TITLE
version: add support for vendor version 

### DIFF
--- a/src/firmware/posix/sitl_tests.cmake
+++ b/src/firmware/posix/sitl_tests.cmake
@@ -29,6 +29,7 @@ set(tests
 	sf0x
 	sleep
 	uorb
+	versioning
 	)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/src/lib/version/version.c
+++ b/src/lib/version/version.c
@@ -58,147 +58,144 @@ enum FIRMWARE_TYPE {
 	FIRMWARE_TYPE_RELEASE = 255
 };
 
-typedef enum {
-	PATCH = 0,
-	MINOR = 8,
-	MAJOR = 16
-} version_type_t;
-
-/**
- * Convert a version number from string to int
- * @param version tag
- * @param start index of the fist char
- * @param end index of the last char
- * @return version number as int
- */
-static uint32_t string_to_int(const char *tag, int start, int end)
+uint32_t version_tag_to_number(const char *tag)
 {
-	const char *curr = &tag[start];
-	uint32_t temp_ver = 0;
+	uint32_t version_number = 0;
 
-	while (curr <= &tag[end]) {
-		temp_ver = (temp_ver * 10)  + (*curr - '0');
+	int16_t buffer = -1;
+	size_t buffer_counter = 0;
+	size_t dash_count = 0;
+	size_t point_count = 0;
+	char version[3] = {0, 0, 0};
+	int firmware_type = FIRMWARE_TYPE_RELEASE;
 
-		curr++;
+	for (size_t i = 0; i < strlen(tag); i++) {
+		if (tag[i] == '-') {
+			dash_count++;
+
+		} else if (tag[i] == '.') {
+			point_count++;
+		}
+
+		if (tag[i] == 'r' && i < strlen(tag) - 1 && tag[i + 1] == 'c') {
+			firmware_type = FIRMWARE_TYPE_RC;
+
+		} else if (tag[i] == 'p') {
+			firmware_type = FIRMWARE_TYPE_ALPHA;
+
+		} else if (tag[i] == 't') {
+			firmware_type = FIRMWARE_TYPE_BETA;
+
+		} else if (tag[i] == 'v' && i > 0) {
+			firmware_type = FIRMWARE_TYPE_DEV;
+		}
 	}
 
-	return temp_ver;
-}
+	if ((dash_count == 1 && point_count == 2 && firmware_type == FIRMWARE_TYPE_RELEASE) ||
+	    (dash_count == 2 && point_count == 2) ||
+	    (dash_count == 3 && point_count == 4)) {
+		firmware_type = FIRMWARE_TYPE_DEV;
+	}
 
-/**
- * Convert a version tag string to a number
- * @param tag version tag in one of the following forms:
- *            - dev: v1.4.0rc3-7-g7e282f57
- *            - dev: v1.4.0rc3-7-g7e282f57-dirty
- *            - dev: v1.4.0-dirty
- *            - rc: v1.4.0rc4
- *            - release: v1.4.0
- *            - linux: 7.9.3
- * @return version in the form 0xAABBCCTT (AA: Major, BB: Minor, CC: Patch, TT Type @see FIRMWARE_TYPE)
- */
-static uint32_t version_tag_to_number(const char *tag)
-{
-	uint32_t ver = 0;
-	unsigned len = strlen(tag);
-	int end = 0;
-	int32_t type = -1;
-	unsigned dashcount = 0;
-	version_type_t v_type = PATCH;
-
-	for (int i = len - 1; i >= 0; i--) {
-
-		if (tag[i] == '-') {
-			dashcount++;
+	for (size_t i = 0; i < strlen(tag); i++) {
+		if (buffer_counter > 2) {
+			continue;
 		}
 
 		if (tag[i] >= '0' && tag[i] <= '9') {
-			if (!end) {
-				end = i;
+			buffer = (buffer == -1) ? 0 : buffer;
+			buffer = buffer * 10 + (tag[i] - '0');
+
+		} else {
+			if (buffer >= 0) {
+				version[buffer_counter] = buffer;
+				buffer_counter++;
 			}
 
-			if (i == 0) {
-				uint32_t temp_ver = string_to_int(tag, i, end);
-				ver = (temp_ver << v_type) + ver;
-			}
-
-		} else if ((tag[i] == '.') || (i == 0)) {
-			uint32_t temp_ver = string_to_int(tag, (i + 1), end);
-			ver = (temp_ver << v_type) + ver;
-
-			end = 0;
-
-			switch (v_type) {
-			case PATCH:
-				v_type = MINOR;
-				break;
-
-			case MINOR:
-				v_type = MAJOR;
-				break;
-
-			case MAJOR:
-			default:
-				break;
-			}
-
-		} else if (i > 3 && type == -1) {
-			/* scan and look for signature characters for each type */
-			const char *curr = &tag[i - 1];
-
-			while (curr > &tag[0]) {
-				if (*curr == 'v') {
-					type = FIRMWARE_TYPE_DEV;
-					break;
-
-				} else if (*curr == 'p') {
-					type = FIRMWARE_TYPE_ALPHA;
-					break;
-
-				} else if (*curr == 't') {
-					type = FIRMWARE_TYPE_BETA;
-					break;
-
-				} else if (*curr == 'r') {
-					type = FIRMWARE_TYPE_RC;
-					break;
-				}
-
-				curr--;
-			}
-
-			/* looks like a release */
-			if (type == -1) {
-				type = FIRMWARE_TYPE_RELEASE;
-			}
-
-		} else if (tag[i] != 'v') {
-			/* reset, because we don't have a full tag but
-			 * are seeing non-numeric characters (eg. '-')
-			 */
-			ver = 0;
-			end = 0;
+			buffer = -1;
 		}
 	}
 
-	/* if git describe contains dashes this is not a real tag */
-	if (dashcount > 0) {
-		type = FIRMWARE_TYPE_DEV;
+	if (buffer >= 0) {
+		version[buffer_counter] = buffer;
+		buffer_counter++;
 	}
 
-	/* looks like a release */
-	if (type == -1) {
-		type = FIRMWARE_TYPE_RELEASE;
-	}
+	version_number = ((uint8_t)version[0] << 8 * 3) |
+			 ((uint8_t)version[1] << 8 * 2) |
+			 ((uint8_t)version[2] << 8 * 1) | firmware_type;
 
-	ver = (ver << 8);
-
-	return ver | type;
+	return version_number;
 }
-
 
 uint32_t px4_firmware_version(void)
 {
 	return version_tag_to_number(PX4_GIT_TAG_STR);
+}
+
+uint32_t version_tag_to_vendor_version_number(const char *tag)
+{
+	uint32_t version_number = 0;
+
+	int16_t buffer = -1;
+	size_t buffer_counter = 0;
+	char version[6] = {0, 0, 0, 0, 0, 0};
+
+	size_t dash_count = 0;
+	size_t point_count = 0;
+
+	for (size_t i = 0; i < strlen(tag); i++) {
+		if (tag[i] == '-') {
+			dash_count++;
+
+		} else if (tag[i] == '.') {
+			point_count++;
+		}
+	}
+
+	for (size_t i = 0; i < strlen(tag); i++) {
+		if (buffer_counter > 5) {
+			continue;
+		}
+
+		if (tag[i] >= '0' && tag[i] <= '9') {
+			buffer = (buffer == -1) ? 0 : buffer;
+			buffer = buffer * 10 + (tag[i] - '0');
+
+		} else {
+			if (buffer >= 0) {
+				if (buffer_counter + 1 == 4 && tag[i] == '-') {
+					break;
+				}
+
+				version[buffer_counter] = buffer;
+				buffer_counter++;
+			}
+
+			buffer = -1;
+		}
+	}
+
+	if (buffer >= 0 && (buffer_counter + 1 == 3 || buffer_counter + 1 == 6)) {
+		version[buffer_counter] = buffer;
+		buffer_counter++;
+	}
+
+	if (buffer_counter == 6) {
+		version_number = ((uint8_t)version[3] << 8 * 2) |
+				 ((uint8_t)version[4] << 8 * 1) |
+				 ((uint8_t)version[5] << 8 * 0);
+
+	} else {
+		version_number = 0;
+	}
+
+	return version_number;
+}
+
+uint32_t px4_firmware_vendor_version(void)
+{
+	return version_tag_to_vendor_version_number(PX4_GIT_TAG_STR);
 }
 
 const char *px4_firmware_git_branch(void)

--- a/src/lib/version/version.c
+++ b/src/lib/version/version.c
@@ -119,11 +119,19 @@ uint32_t version_tag_to_number(const char *tag)
 	if (buffer >= 0) {
 		version[buffer_counter] = buffer;
 		buffer_counter++;
+	} 
+	
+	if (buffer_counter <= 0) {
+		firmware_type = 0x00;
 	}
 
-	version_number = ((uint8_t)version[0] << 8 * 3) |
-			 ((uint8_t)version[1] << 8 * 2) |
-			 ((uint8_t)version[2] << 8 * 1) | firmware_type;
+	if (buffer_counter == 3 || buffer_counter == 6) {
+		version_number = ((uint8_t)version[0] << 8 * 3) |
+				 ((uint8_t)version[1] << 8 * 2) |
+				 ((uint8_t)version[2] << 8 * 1) | firmware_type;
+	} else {
+		version_number = 0;
+	}
 
 	return version_number;
 }

--- a/src/lib/version/version.c
+++ b/src/lib/version/version.c
@@ -119,8 +119,8 @@ uint32_t version_tag_to_number(const char *tag)
 	if (buffer >= 0) {
 		version[buffer_counter] = buffer;
 		buffer_counter++;
-	} 
-	
+	}
+
 	if (buffer_counter <= 0) {
 		firmware_type = 0x00;
 	}
@@ -129,6 +129,7 @@ uint32_t version_tag_to_number(const char *tag)
 		version_number = ((uint8_t)version[0] << 8 * 3) |
 				 ((uint8_t)version[1] << 8 * 2) |
 				 ((uint8_t)version[2] << 8 * 1) | firmware_type;
+
 	} else {
 		version_number = 0;
 	}
@@ -175,10 +176,10 @@ uint32_t version_tag_to_vendor_version_number(const char *tag)
 	}
 
 	if ((dash_count == 1 && point_count == 2 && firmware_type == FIRMWARE_TYPE_RELEASE) ||
-	(dash_count == 2 && point_count == 2) ||
-	(dash_count == 3 && point_count == 4)) {
-	firmware_type = FIRMWARE_TYPE_DEV;
-}
+	    (dash_count == 2 && point_count == 2) ||
+	    (dash_count == 3 && point_count == 4)) {
+		firmware_type = FIRMWARE_TYPE_DEV;
+	}
 
 	for (size_t i = 0; i < strlen(tag); i++) {
 		if (buffer_counter > 5) {
@@ -215,6 +216,7 @@ uint32_t version_tag_to_vendor_version_number(const char *tag)
 
 	} else if (buffer_counter == 3) {
 		version_number = firmware_type;
+
 	} else {
 		version_number = 0;
 	}

--- a/src/lib/version/version.h
+++ b/src/lib/version/version.h
@@ -101,6 +101,7 @@ static inline const char *px4_build_uri(void)
 /**
  * Convert a version tag string to a number
  * @param tag version tag in one of the following forms:
+ *            - vendor: v1.4.0-0.2.0
  *            - dev: v1.4.0rc3-7-g7e282f57
  *            - rc: v1.4.0rc4
  *            - release: v1.4.0
@@ -123,13 +124,13 @@ __EXPORT uint32_t px4_firmware_version(void);
  *            - rc: v1.4.0rc4
  *            - release: v1.4.0
  *            - linux: 7.9.3
- * @return version in the form 0xAABBCC (AA: Major, BB: Minor, CC: Patch)
+ * @return version in the form 0xAABBCCTT (AA: Major, BB: Minor, CC: Patch, TT Type @see FIRMWARE_TYPE)
  */
 __EXPORT uint32_t version_tag_to_vendor_version_number(const char *tag);
 
 /**
  * get the PX4 Firmware vendor version
- * @return version in the form 0xAABBCC (AA: Major, BB: Minor, CC: Patch)
+ * @return version in the form 0xAABBCCTT (AA: Major, BB: Minor, CC: Patch, TT Type @see FIRMWARE_TYPE)
  */
 __EXPORT uint32_t px4_firmware_vendor_version(void);
 

--- a/src/lib/version/version.h
+++ b/src/lib/version/version.h
@@ -99,10 +99,39 @@ static inline const char *px4_build_uri(void)
 }
 
 /**
+ * Convert a version tag string to a number
+ * @param tag version tag in one of the following forms:
+ *            - dev: v1.4.0rc3-7-g7e282f57
+ *            - rc: v1.4.0rc4
+ *            - release: v1.4.0
+ *            - linux: 7.9.3
+ * @return version in the form 0xAABBCCTT (AA: Major, BB: Minor, CC: Patch, TT Type @see FIRMWARE_TYPE)
+ */
+__EXPORT uint32_t version_tag_to_number(const char *tag);
+
+/**
  * get the PX4 Firmware version
  * @return version in the form 0xAABBCCTT (AA: Major, BB: Minor, CC: Patch, TT Type @see FIRMWARE_TYPE)
  */
 __EXPORT uint32_t px4_firmware_version(void);
+
+/**
+ * Convert a version tag string to a vendor version number
+ * @param tag version tag in one of the following forms:
+ *            - vendor: v1.4.0-0.2.0
+ *            - dev: v1.4.0rc3-7-g7e282f57
+ *            - rc: v1.4.0rc4
+ *            - release: v1.4.0
+ *            - linux: 7.9.3
+ * @return version in the form 0xAABBCC (AA: Major, BB: Minor, CC: Patch)
+ */
+__EXPORT uint32_t version_tag_to_vendor_version_number(const char *tag);
+
+/**
+ * get the PX4 Firmware vendor version
+ * @return version in the form 0xAABBCC (AA: Major, BB: Minor, CC: Patch)
+ */
+__EXPORT uint32_t px4_firmware_vendor_version(void);
 
 /**
  * get the board version (last 8 bytes should be silicon ID, if any)

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1652,12 +1652,10 @@ void Logger::write_version()
 {
 	write_info("ver_sw", px4_firmware_version_string());
 	write_info("ver_sw_release", px4_firmware_version());
-	// FIXME: px4_firmware_vendor_version() needs be converted to return the same format as px4_firmware_version().
-	// This now just assumes we're on a release
 	uint32_t vendor_version = px4_firmware_vendor_version();
 
 	if (vendor_version > 0) {
-		write_info("ver_vendor_sw_release", (vendor_version << 8) | 0xff);
+		write_info("ver_vendor_sw_release", vendor_version);
 	}
 
 	write_info("ver_hw", px4_board_name());

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1652,6 +1652,14 @@ void Logger::write_version()
 {
 	write_info("ver_sw", px4_firmware_version_string());
 	write_info("ver_sw_release", px4_firmware_version());
+	// FIXME: px4_firmware_vendor_version() needs be converted to return the same format as px4_firmware_version().
+	// This now just assumes we're on a release
+	uint32_t vendor_version = px4_firmware_vendor_version();
+
+	if (vendor_version > 0) {
+		write_info("ver_vendor_sw_release", (vendor_version << 8) | 0xff);
+	}
+
 	write_info("ver_hw", px4_board_name());
 	write_info("sys_name", "PX4");
 	write_info("sys_os_name", px4_os_name());

--- a/src/systemcmds/tests/CMakeLists.txt
+++ b/src/systemcmds/tests/CMakeLists.txt
@@ -63,6 +63,7 @@ set(srcs
 	test_uart_console.c
 	test_uart_loopback.c
 	test_uart_send.c
+	test_versioning.cpp
 	tests_main.c
 	)
 

--- a/src/systemcmds/tests/test_versioning.cpp
+++ b/src/systemcmds/tests/test_versioning.cpp
@@ -7,10 +7,12 @@ public:
 	virtual bool run_tests();
 
 private:
-	bool _test_tag_to_version_number(const char *version_tag, uint32_t flight_version_target, uint32_t vendor_version_target);
+	bool _test_tag_to_version_number(const char *version_tag, uint32_t flight_version_target,
+					 uint32_t vendor_version_target);
 };
 
-bool VersioningTest::_test_tag_to_version_number(const char *version_tag, uint32_t flight_version_target, uint32_t vendor_version_target) 
+bool VersioningTest::_test_tag_to_version_number(const char *version_tag, uint32_t flight_version_target,
+		uint32_t vendor_version_target)
 {
 	uint32_t flight_version_result = version_tag_to_number(version_tag);
 	uint32_t vendor_version_result = version_tag_to_vendor_version_number(version_tag);
@@ -18,12 +20,16 @@ bool VersioningTest::_test_tag_to_version_number(const char *version_tag, uint32
 	if (flight_version_target == flight_version_result) {
 		if (vendor_version_target == vendor_version_result) {
 			return true;
+
 		} else {
-			PX4_ERR("Wrong vendor version: tag: %s, got: 0x%x, expected: 0x%x", version_tag, vendor_version_result, vendor_version_target);
+			PX4_ERR("Wrong vendor version: tag: %s, got: 0x%x, expected: 0x%x", version_tag, vendor_version_result,
+				vendor_version_target);
 			return false;
 		}
+
 	} else {
-		PX4_ERR("Wrong flight version: tag: %s, got: 0x%x, expected: 0x%x", version_tag, flight_version_result, flight_version_target);
+		PX4_ERR("Wrong flight version: tag: %s, got: 0x%x, expected: 0x%x", version_tag, flight_version_result,
+			flight_version_target);
 		return false;
 	}
 }
@@ -31,9 +37,9 @@ bool VersioningTest::_test_tag_to_version_number(const char *version_tag, uint32
 bool VersioningTest::run_tests()
 {
 	ut_assert_true(_test_tag_to_version_number("v11.45.99-1.2.3", 					0x0B2D63FF, 0x010203FF));
-	ut_assert_true(_test_tag_to_version_number("v11.45.99-01.02.03", 				0x0B2D63FF, 0x010203FF));	
-	ut_assert_true(_test_tag_to_version_number("v011.045.099-001.002.003", 			0x0B2D63FF, 0x010203FF));	
-	ut_assert_true(_test_tag_to_version_number("v011.045.099-1.2.3",	 			0x0B2D63FF, 0x010203FF));		
+	ut_assert_true(_test_tag_to_version_number("v11.45.99-01.02.03", 				0x0B2D63FF, 0x010203FF));
+	ut_assert_true(_test_tag_to_version_number("v011.045.099-001.002.003", 			0x0B2D63FF, 0x010203FF));
+	ut_assert_true(_test_tag_to_version_number("v011.045.099-1.2.3",	 			0x0B2D63FF, 0x010203FF));
 	ut_assert_true(_test_tag_to_version_number("v1.2.3", 							0x010203FF, 0x000000FF));
 	ut_assert_true(_test_tag_to_version_number("v255.255.255", 						0xFFFFFFFF, 0x000000FF));
 	ut_assert_true(_test_tag_to_version_number("v255.255.255-11", 					0xFFFFFF00, 0x00000000));
@@ -62,7 +68,7 @@ bool VersioningTest::run_tests()
 	ut_assert_true(_test_tag_to_version_number("v1.6.2-rc2", 						0x010602C0, 0x000000C0));
 	ut_assert_true(_test_tag_to_version_number("v1.6.2rc1", 						0x010602C0, 0x000000C0));
 	ut_assert_true(_test_tag_to_version_number("v1.6.10-100-g890c415", 				0x01060A00, 0x00000000));
-	ut_assert_true(_test_tag_to_version_number("v1.6.10-99999999999999-g890c415",	0x01060A00, 0x00000000));	
+	ut_assert_true(_test_tag_to_version_number("v1.6.10-99999999999999-g890c415",	0x01060A00, 0x00000000));
 	ut_assert_true(_test_tag_to_version_number("v1.6.2-0.8.7-67-g1d5e979", 			0x01060200, 0x00080700));
 	ut_assert_true(_test_tag_to_version_number("randomtext", 						0x00000000, 0x00000000));
 	ut_assert_true(_test_tag_to_version_number("randomtextwithnumber12", 			0x00000000, 0x00000000));
@@ -71,7 +77,7 @@ bool VersioningTest::run_tests()
 	ut_assert_true(_test_tag_to_version_number("v12.12-randomtextwithnumber", 		0x00000000, 0x00000000));
 	ut_assert_true(_test_tag_to_version_number("...-...", 							0x00000000, 0x00000000));
 	ut_assert_true(_test_tag_to_version_number("v...-...", 							0x00000000, 0x00000000));
-	
+
 	return (_tests_failed == 0);
 }
 

--- a/src/systemcmds/tests/test_versioning.cpp
+++ b/src/systemcmds/tests/test_versioning.cpp
@@ -82,34 +82,34 @@ bool VersioningTest::_test_flight_version()
 
 bool VersioningTest::_test_vendor_version()
 {
-	ut_assert_true(_is_correct_version_tag_vendor("alpha", 0x000000));
-	ut_assert_true(_is_correct_version_tag_vendor("alpha23", 0x000000));
-	ut_assert_true(_is_correct_version_tag_vendor("v11.45.99-34.56.88", 0x223858));
-	ut_assert_true(_is_correct_version_tag_vendor("v11.45.99-1.2.3", 0x010203));
-	ut_assert_true(_is_correct_version_tag_vendor("1.2.3-11.45.99", 0x0B2D63));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-1.0.0", 0x010000));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-255.255.255", 0xFFFFFF));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-255.255.255-11", 0xFFFFFF));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3", 0x000000));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-rc2", 0x000000));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11", 0x000000));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45", 0x000000));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11-abababab", 0x000000));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99rc3-7-g7e282f57", 0x0B2D63));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99rc4", 0x0B2D63));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99alpha3-7-g7e282f57", 0x0B2D63));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99alpha4", 0x0B2D63));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99beta3-7-g7e282f57", 0x0B2D63));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99beta4", 0x0B2D63));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99dev4", 0x0B2D63));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99dev3-7-g7e282f57", 0x0B2D63));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-1.0.0-rc2-abababab", 0x010000));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-1.0.0-rc2-23-abababab", 0x010000));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-0.8.7-67-g1d5e979", 0x000807));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.6.0-100-g890c415", 0x000000));
-	ut_assert_true(_is_correct_version_tag_vendor("1.2.3-0.45.99beta4", 0x002D63));
-	ut_assert_true(_is_correct_version_tag_vendor("1.2.3-0.0.0beta4", 0x000000));
-	ut_assert_true(_is_correct_version_tag_vendor("1.2.3-0.0.0dev4", 0x000000));
+	ut_assert_true(_is_correct_version_tag_vendor("alpha", 0x00000000));
+	ut_assert_true(_is_correct_version_tag_vendor("alpha23", 0x00000000));
+	ut_assert_true(_is_correct_version_tag_vendor("v11.45.99-34.56.88", 0x223858FF));
+	ut_assert_true(_is_correct_version_tag_vendor("v11.45.99-1.2.3", 0x010203FF));
+	ut_assert_true(_is_correct_version_tag_vendor("1.2.3-11.45.99", 0x0B2D63FF));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-1.0.0", 0x010000FF));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-255.255.255", 0xFFFFFFFF));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-255.255.255-11", 0xFFFFFFFF));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3", 0x000000FF));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-rc2", 0x000000C0));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11", 0x00000000));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45", 0x00000000));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11-abababab", 0x00000000));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99rc3-7-g7e282f57", 0x0B2D6300));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99rc4", 0x0B2D63C0));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99alpha3-7-g7e282f57", 0x0B2D6300));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99alpha4", 0x0B2D6340));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99beta3-7-g7e282f57", 0x0B2D6300));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99beta4", 0x0B2D6380));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99dev4", 0x0B2D6300));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99dev3-7-g7e282f57", 0x0B2D6300));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-1.0.0-rc2-abababab", 0x01000000));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-1.0.0-rc2-23-abababab", 0x010000C0));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-0.8.7-67-g1d5e979", 0x00080700));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.6.0-100-g890c415", 0x00000000));
+	ut_assert_true(_is_correct_version_tag_vendor("1.2.3-0.45.99beta4", 0x002D6380));
+	ut_assert_true(_is_correct_version_tag_vendor("1.2.3-0.0.0beta4", 0x00000080));
+	ut_assert_true(_is_correct_version_tag_vendor("1.2.3-0.0.0dev4", 0x00000000));
 
 	return true;
 }

--- a/src/systemcmds/tests/test_versioning.cpp
+++ b/src/systemcmds/tests/test_versioning.cpp
@@ -1,0 +1,117 @@
+#include <unit_test.h>
+#include <version/version.h>
+
+class VersioningTest : public UnitTest
+{
+public:
+	virtual bool run_tests();
+
+private:
+	bool _is_correct_version_tag(const char *version_tag, uint32_t result_goal);
+	bool _is_correct_version_tag_vendor(const char *version_tag, uint32_t result_goal);
+
+	bool _test_flight_version();
+	bool _test_vendor_version();
+};
+
+bool VersioningTest::_is_correct_version_tag(const char *version_tag, uint32_t result_goal)
+{
+	uint32_t result = version_tag_to_number(version_tag);
+
+	if (result == result_goal) {
+		return true;
+
+	} else {
+		PX4_ERR("Wrong version: tag: %s, got: 0x%x, expected: 0x%x", version_tag, result, result_goal);
+		return false;
+	}
+}
+
+bool VersioningTest::_is_correct_version_tag_vendor(const char *version_tag, uint32_t result_goal)
+{
+	uint32_t result = version_tag_to_vendor_version_number(version_tag);
+
+	if (result == result_goal) {
+		return true;
+
+	} else {
+		PX4_ERR("Wrong version: tag: %s, got: 0x%x, expected: 0x%x", version_tag, result, result_goal);
+		return false;
+	}
+}
+
+bool VersioningTest::run_tests()
+{
+	ut_run_test(_test_flight_version);
+	ut_run_test(_test_vendor_version);
+
+	return (_tests_failed == 0);
+}
+
+bool VersioningTest::_test_flight_version()
+{
+	ut_assert_true(_is_correct_version_tag("v11.45.99-1.2.3", 0xB2D63ff));
+	ut_assert_true(_is_correct_version_tag("v1.2.3", 0x010203ff));
+	ut_assert_true(_is_correct_version_tag("v255.255.255", 0xffffffff));
+	ut_assert_true(_is_correct_version_tag("v255.255.255-11", 0xffffff00));
+	ut_assert_true(_is_correct_version_tag("v1.2.3-111", 0x01020300));
+	ut_assert_true(_is_correct_version_tag("v1.2.3-11-abababab", 0x01020300));
+	ut_assert_true(_is_correct_version_tag("11.45.99-1.2.3", 0x0B2D63ff));
+	ut_assert_true(_is_correct_version_tag("v11.45.99-1.2.3rc3-7-g7e282f57", 0x0B2D6300));
+	ut_assert_true(_is_correct_version_tag("v11.45.99-1.2.3rc4", 0x0B2D63C0));
+	ut_assert_true(_is_correct_version_tag("v11.45.99-1.2.3alpha3-7-g7e282f57", 0x0B2D6300));
+	ut_assert_true(_is_correct_version_tag("v11.45.99-1.2.3alpha4", 0x0B2D6340));
+	ut_assert_true(_is_correct_version_tag("v11.45.99-1.2.3beta3-7-g7e282f57", 0x0B2D6300));
+	ut_assert_true(_is_correct_version_tag("v11.45.99-1.2.3beta4", 0x0B2D6380));
+	ut_assert_true(_is_correct_version_tag("v11.45.99-1.2.3dev4", 0x0B2D6300));
+	ut_assert_true(_is_correct_version_tag("v11.45.99-1.2.3dev3-7-g7e282f57", 0xB2D6300));
+	ut_assert_true(_is_correct_version_tag("0.45.99-1.2.3beta4", 0x002D6380));
+	ut_assert_true(_is_correct_version_tag("0.0.0-1.2.3beta4", 0x00000080));
+	ut_assert_true(_is_correct_version_tag("0.0.0-1.2.3dev4", 0x00000000));
+	ut_assert_true(_is_correct_version_tag("v1.6.2-1.0.0", 0x010602ff));
+	ut_assert_true(_is_correct_version_tag("v1.6.2-1.0.0rc2", 0x010602C0));
+	ut_assert_true(_is_correct_version_tag("v1.6.2-1.0.0-rc2", 0x010602C0));
+	ut_assert_true(_is_correct_version_tag("v1.6.2-1.0.0-rc2-abababab", 0x01060200));
+	ut_assert_true(_is_correct_version_tag("v1.6.2-rc2", 0x010602C0));
+	ut_assert_true(_is_correct_version_tag("v1.6.2rc1", 0x010602C0));
+	ut_assert_true(_is_correct_version_tag("v1.6.10-100-g890c415", 0x01060A00));
+	ut_assert_true(_is_correct_version_tag("v1.6.2-0.8.7-67-g1d5e979", 0x01060200));
+
+	return true;
+}
+
+bool VersioningTest::_test_vendor_version()
+{
+	ut_assert_true(_is_correct_version_tag_vendor("alpha", 0x000000));
+	ut_assert_true(_is_correct_version_tag_vendor("alpha23", 0x000000));
+	ut_assert_true(_is_correct_version_tag_vendor("v11.45.99-34.56.88", 0x223858));
+	ut_assert_true(_is_correct_version_tag_vendor("v11.45.99-1.2.3", 0x010203));
+	ut_assert_true(_is_correct_version_tag_vendor("1.2.3-11.45.99", 0x0B2D63));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-1.0.0", 0x010000));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-255.255.255", 0xFFFFFF));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-255.255.255-11", 0xFFFFFF));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3", 0x000000));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-rc2", 0x000000));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11", 0x000000));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45", 0x000000));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11-abababab", 0x000000));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99rc3-7-g7e282f57", 0x0B2D63));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99rc4", 0x0B2D63));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99alpha3-7-g7e282f57", 0x0B2D63));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99alpha4", 0x0B2D63));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99beta3-7-g7e282f57", 0x0B2D63));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99beta4", 0x0B2D63));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99dev4", 0x0B2D63));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99dev3-7-g7e282f57", 0x0B2D63));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-1.0.0-rc2-abababab", 0x010000));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-1.0.0-rc2-23-abababab", 0x010000));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-0.8.7-67-g1d5e979", 0x000807));
+	ut_assert_true(_is_correct_version_tag_vendor("v1.6.0-100-g890c415", 0x000000));
+	ut_assert_true(_is_correct_version_tag_vendor("1.2.3-0.45.99beta4", 0x002D63));
+	ut_assert_true(_is_correct_version_tag_vendor("1.2.3-0.0.0beta4", 0x000000));
+	ut_assert_true(_is_correct_version_tag_vendor("1.2.3-0.0.0dev4", 0x000000));
+
+	return true;
+}
+
+ut_declare_test_c(test_versioning, VersioningTest);

--- a/src/systemcmds/tests/test_versioning.cpp
+++ b/src/systemcmds/tests/test_versioning.cpp
@@ -7,111 +7,72 @@ public:
 	virtual bool run_tests();
 
 private:
-	bool _is_correct_version_tag(const char *version_tag, uint32_t result_goal);
-	bool _is_correct_version_tag_vendor(const char *version_tag, uint32_t result_goal);
-
-	bool _test_flight_version();
-	bool _test_vendor_version();
+	bool _test_tag_to_version_number(const char *version_tag, uint32_t flight_version_target, uint32_t vendor_version_target);
 };
 
-bool VersioningTest::_is_correct_version_tag(const char *version_tag, uint32_t result_goal)
+bool VersioningTest::_test_tag_to_version_number(const char *version_tag, uint32_t flight_version_target, uint32_t vendor_version_target) 
 {
-	uint32_t result = version_tag_to_number(version_tag);
+	uint32_t flight_version_result = version_tag_to_number(version_tag);
+	uint32_t vendor_version_result = version_tag_to_vendor_version_number(version_tag);
 
-	if (result == result_goal) {
-		return true;
-
+	if (flight_version_target == flight_version_result) {
+		if (vendor_version_target == vendor_version_result) {
+			return true;
+		} else {
+			PX4_ERR("Wrong vendor version: tag: %s, got: 0x%x, expected: 0x%x", version_tag, vendor_version_result, vendor_version_target);
+			return false;
+		}
 	} else {
-		PX4_ERR("Wrong version: tag: %s, got: 0x%x, expected: 0x%x", version_tag, result, result_goal);
-		return false;
-	}
-}
-
-bool VersioningTest::_is_correct_version_tag_vendor(const char *version_tag, uint32_t result_goal)
-{
-	uint32_t result = version_tag_to_vendor_version_number(version_tag);
-
-	if (result == result_goal) {
-		return true;
-
-	} else {
-		PX4_ERR("Wrong version: tag: %s, got: 0x%x, expected: 0x%x", version_tag, result, result_goal);
+		PX4_ERR("Wrong flight version: tag: %s, got: 0x%x, expected: 0x%x", version_tag, flight_version_result, flight_version_target);
 		return false;
 	}
 }
 
 bool VersioningTest::run_tests()
 {
-	ut_run_test(_test_flight_version);
-	ut_run_test(_test_vendor_version);
-
+	ut_assert_true(_test_tag_to_version_number("v11.45.99-1.2.3", 					0x0B2D63FF, 0x010203FF));
+	ut_assert_true(_test_tag_to_version_number("v11.45.99-01.02.03", 				0x0B2D63FF, 0x010203FF));	
+	ut_assert_true(_test_tag_to_version_number("v011.045.099-001.002.003", 			0x0B2D63FF, 0x010203FF));	
+	ut_assert_true(_test_tag_to_version_number("v011.045.099-1.2.3",	 			0x0B2D63FF, 0x010203FF));		
+	ut_assert_true(_test_tag_to_version_number("v1.2.3", 							0x010203FF, 0x000000FF));
+	ut_assert_true(_test_tag_to_version_number("v255.255.255", 						0xFFFFFFFF, 0x000000FF));
+	ut_assert_true(_test_tag_to_version_number("v255.255.255-11", 					0xFFFFFF00, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("v255.255.255-255.255.255", 			0xFFFFFFFF, 0xFFFFFFFF));
+	ut_assert_true(_test_tag_to_version_number("v255.255.255-0.0.0", 				0xFFFFFFFF, 0x000000FF));
+	ut_assert_true(_test_tag_to_version_number("v0.0.0-0.0.0", 						0x000000FF, 0x000000FF));
+	ut_assert_true(_test_tag_to_version_number("v0.0.0-255.255.255", 				0x000000FF, 0xFFFFFFFF));
+	ut_assert_true(_test_tag_to_version_number("v1.2.3-111", 						0x01020300, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("v1.2.3-11-gabababab", 				0x01020300, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("11.45.99-1.2.3", 					0x0B2D63FF, 0x010203FF));
+	ut_assert_true(_test_tag_to_version_number("v11.45.99-1.2.3rc3-7-g7e282f57", 	0x0B2D6300, 0x01020300));
+	ut_assert_true(_test_tag_to_version_number("v11.45.99-1.2.3rc4", 				0x0B2D63C0, 0x010203C0));
+	ut_assert_true(_test_tag_to_version_number("v11.45.99-1.2.3alpha3-7-g7e282f57", 0x0B2D6300, 0x01020300));
+	ut_assert_true(_test_tag_to_version_number("v11.45.99-1.2.3alpha4", 			0x0B2D6340, 0x01020340));
+	ut_assert_true(_test_tag_to_version_number("v11.45.99-1.2.3beta3-7-g7e282f57", 	0x0B2D6300, 0x01020300));
+	ut_assert_true(_test_tag_to_version_number("v11.45.99-1.2.3beta4", 				0x0B2D6380, 0x01020380));
+	ut_assert_true(_test_tag_to_version_number("v11.45.99-1.2.3dev4", 				0x0B2D6300, 0x01020300));
+	ut_assert_true(_test_tag_to_version_number("v11.45.99-1.2.3dev3-7-g7e282f57", 	0x0B2D6300, 0x01020300));
+	ut_assert_true(_test_tag_to_version_number("0.45.99-1.2.3beta4", 				0x002D6380, 0x01020380));
+	ut_assert_true(_test_tag_to_version_number("0.0.0-1.2.3beta4", 					0x00000080, 0x01020380));
+	ut_assert_true(_test_tag_to_version_number("0.0.0-1.2.3dev4", 					0x00000000, 0x01020300));
+	ut_assert_true(_test_tag_to_version_number("v1.6.2-1.0.0", 						0x010602FF, 0x010000FF));
+	ut_assert_true(_test_tag_to_version_number("v1.6.2-1.0.0rc2", 					0x010602C0, 0x010000C0));
+	ut_assert_true(_test_tag_to_version_number("v1.6.2-1.0.0-rc2", 					0x010602C0, 0x010000C0));
+	ut_assert_true(_test_tag_to_version_number("v1.6.2-1.0.0-rc2-gabababab", 		0x01060200, 0x01000000));
+	ut_assert_true(_test_tag_to_version_number("v1.6.2-rc2", 						0x010602C0, 0x000000C0));
+	ut_assert_true(_test_tag_to_version_number("v1.6.2rc1", 						0x010602C0, 0x000000C0));
+	ut_assert_true(_test_tag_to_version_number("v1.6.10-100-g890c415", 				0x01060A00, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("v1.6.10-99999999999999-g890c415",	0x01060A00, 0x00000000));	
+	ut_assert_true(_test_tag_to_version_number("v1.6.2-0.8.7-67-g1d5e979", 			0x01060200, 0x00080700));
+	ut_assert_true(_test_tag_to_version_number("randomtext", 						0x00000000, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("randomtextwithnumber12", 			0x00000000, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("12randomtextwithnumber", 			0x00000000, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("12.12-randomtextwithnumber", 		0x00000000, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("v12.12-randomtextwithnumber", 		0x00000000, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("...-...", 							0x00000000, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("v...-...", 							0x00000000, 0x00000000));
+	
 	return (_tests_failed == 0);
-}
-
-bool VersioningTest::_test_flight_version()
-{
-	ut_assert_true(_is_correct_version_tag("v11.45.99-1.2.3", 0xB2D63ff));
-	ut_assert_true(_is_correct_version_tag("v1.2.3", 0x010203ff));
-	ut_assert_true(_is_correct_version_tag("v255.255.255", 0xffffffff));
-	ut_assert_true(_is_correct_version_tag("v255.255.255-11", 0xffffff00));
-	ut_assert_true(_is_correct_version_tag("v1.2.3-111", 0x01020300));
-	ut_assert_true(_is_correct_version_tag("v1.2.3-11-abababab", 0x01020300));
-	ut_assert_true(_is_correct_version_tag("11.45.99-1.2.3", 0x0B2D63ff));
-	ut_assert_true(_is_correct_version_tag("v11.45.99-1.2.3rc3-7-g7e282f57", 0x0B2D6300));
-	ut_assert_true(_is_correct_version_tag("v11.45.99-1.2.3rc4", 0x0B2D63C0));
-	ut_assert_true(_is_correct_version_tag("v11.45.99-1.2.3alpha3-7-g7e282f57", 0x0B2D6300));
-	ut_assert_true(_is_correct_version_tag("v11.45.99-1.2.3alpha4", 0x0B2D6340));
-	ut_assert_true(_is_correct_version_tag("v11.45.99-1.2.3beta3-7-g7e282f57", 0x0B2D6300));
-	ut_assert_true(_is_correct_version_tag("v11.45.99-1.2.3beta4", 0x0B2D6380));
-	ut_assert_true(_is_correct_version_tag("v11.45.99-1.2.3dev4", 0x0B2D6300));
-	ut_assert_true(_is_correct_version_tag("v11.45.99-1.2.3dev3-7-g7e282f57", 0xB2D6300));
-	ut_assert_true(_is_correct_version_tag("0.45.99-1.2.3beta4", 0x002D6380));
-	ut_assert_true(_is_correct_version_tag("0.0.0-1.2.3beta4", 0x00000080));
-	ut_assert_true(_is_correct_version_tag("0.0.0-1.2.3dev4", 0x00000000));
-	ut_assert_true(_is_correct_version_tag("v1.6.2-1.0.0", 0x010602ff));
-	ut_assert_true(_is_correct_version_tag("v1.6.2-1.0.0rc2", 0x010602C0));
-	ut_assert_true(_is_correct_version_tag("v1.6.2-1.0.0-rc2", 0x010602C0));
-	ut_assert_true(_is_correct_version_tag("v1.6.2-1.0.0-rc2-abababab", 0x01060200));
-	ut_assert_true(_is_correct_version_tag("v1.6.2-rc2", 0x010602C0));
-	ut_assert_true(_is_correct_version_tag("v1.6.2rc1", 0x010602C0));
-	ut_assert_true(_is_correct_version_tag("v1.6.10-100-g890c415", 0x01060A00));
-	ut_assert_true(_is_correct_version_tag("v1.6.2-0.8.7-67-g1d5e979", 0x01060200));
-
-	return true;
-}
-
-bool VersioningTest::_test_vendor_version()
-{
-	ut_assert_true(_is_correct_version_tag_vendor("alpha", 0x00000000));
-	ut_assert_true(_is_correct_version_tag_vendor("alpha23", 0x00000000));
-	ut_assert_true(_is_correct_version_tag_vendor("v11.45.99-34.56.88", 0x223858FF));
-	ut_assert_true(_is_correct_version_tag_vendor("v11.45.99-1.2.3", 0x010203FF));
-	ut_assert_true(_is_correct_version_tag_vendor("1.2.3-11.45.99", 0x0B2D63FF));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-1.0.0", 0x010000FF));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-255.255.255", 0xFFFFFFFF));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-255.255.255-11", 0xFFFFFFFF));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3", 0x000000FF));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-rc2", 0x000000C0));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11", 0x00000000));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45", 0x00000000));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11-abababab", 0x00000000));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99rc3-7-g7e282f57", 0x0B2D6300));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99rc4", 0x0B2D63C0));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99alpha3-7-g7e282f57", 0x0B2D6300));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99alpha4", 0x0B2D6340));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99beta3-7-g7e282f57", 0x0B2D6300));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99beta4", 0x0B2D6380));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99dev4", 0x0B2D6300));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.2.3-11.45.99dev3-7-g7e282f57", 0x0B2D6300));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-1.0.0-rc2-abababab", 0x01000000));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-1.0.0-rc2-23-abababab", 0x010000C0));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.6.2-0.8.7-67-g1d5e979", 0x00080700));
-	ut_assert_true(_is_correct_version_tag_vendor("v1.6.0-100-g890c415", 0x00000000));
-	ut_assert_true(_is_correct_version_tag_vendor("1.2.3-0.45.99beta4", 0x002D6380));
-	ut_assert_true(_is_correct_version_tag_vendor("1.2.3-0.0.0beta4", 0x00000080));
-	ut_assert_true(_is_correct_version_tag_vendor("1.2.3-0.0.0dev4", 0x00000000));
-
-	return true;
 }
 
 ut_declare_test_c(test_versioning, VersioningTest);

--- a/src/systemcmds/tests/tests_main.c
+++ b/src/systemcmds/tests/tests_main.c
@@ -125,6 +125,7 @@ const struct {
 	{"tone",		test_tone,	0},
 	{"uart_loopback",	test_uart_loopback,	OPT_NOJIGTEST | OPT_NOALLTEST},
 	{"uart_send",		test_uart_send,	OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"versioning",		test_versioning,	0},
 	{NULL,			NULL, 		0}
 };
 

--- a/src/systemcmds/tests/tests_main.h
+++ b/src/systemcmds/tests/tests_main.h
@@ -87,6 +87,7 @@ extern int	test_uart_console(int argc, char *argv[]);
 extern int	test_uart_loopback(int argc, char *argv[]);
 extern int	test_uart_send(int argc, char *argv[]);
 extern int	test_parameters(int argc, char *argv[]);
+extern int	test_versioning(int argc, char *argv[]);
 
 /* external */
 extern int commander_tests_main(int argc, char *argv[]);


### PR DESCRIPTION
This adds support for parsing git tags which include a vendor version. E.g. `vX.Y.Z-A.B.Crc1`, whereas `X.Y.Z` are numbers defining the upstream version and `A.B.C` is the vendor version.

A new unittest ensures its functionality: `test_versioning`, run `make tests`