### PR TITLE
Allow manual override in stabilized mode for a fixed-wing aircraft

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -3873,8 +3873,6 @@ set_control_mode()
 		control_mode.flag_control_velocity_enabled = false;
 		control_mode.flag_control_acceleration_enabled = false;
 		control_mode.flag_control_termination_enabled = false;
-		/* override is not ok in stabilized mode */
-		control_mode.flag_external_manual_override_ok = false;
 		break;
 
 	case vehicle_status_s::NAVIGATION_STATE_RATTITUDE:


### PR DESCRIPTION
Removes explicitly setting the manual override to false in the stabilized mode.

The reason is that the manual override is not allowed for multicopters and vtol platforms anyway: https://github.com/PX4/Firmware/blob/master/src/modules/commander/commander.cpp#L3845
Therefore this change only affects fixed-wing planes.

By allowing the manual override the pilot can try to land the airplane in case of an emergency such as a FMU crash using the manual commands. With the manual override not allowed the constant failsafe commands are sent and the airplane will crash for sure.