### PR TITLE
cmake minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,17 +107,6 @@ else
 	BUILD_DIR_SUFFIX :=
 endif
 
-# NuttX verbose output
-ifdef VN
-	export PX4_NUTTX_BUILD_VERBOSE=1
-	export V=1
-endif
-
-# NuttX verbose patches output
-ifdef VNP
-	export PX4_NUTTX_PATCHES_VERBOSE=1
-endif
-
 # additional config parameters passed to cmake
 CMAKE_ARGS := -Wno-deprecated
 

--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -53,7 +53,7 @@ add_custom_command(OUTPUT apps_copy.stamp
 	DEPENDS ${copy_apps_files}
 	COMMENT "Copying NuttX/apps to ${CMAKE_CURRENT_BINARY_DIR}"
 	)
-set(APPS_DIR ${CMAKE_CURRENT_BINARY_DIR}/apps)
+set(APPS_DIR ${PX4_BINARY_DIR}/NuttX/apps)
 
 # copy PX4 board config into nuttx
 file(GLOB_RECURSE board_config_files ${NUTTX_CONFIG_DIR}/${BOARD})
@@ -74,7 +74,8 @@ add_custom_command(OUTPUT
 		${NUTTX_CONFIG_DIR}/${BOARD}/${nuttx_config_type}/defconfig
 		${NUTTX_CONFIG_DIR}/${BOARD}/${nuttx_config_type}/Make.defs
 		${board_config_files}
-		nuttx_copy.stamp apps_copy.stamp
+		nuttx_copy.stamp
+		apps_copy.stamp
 	WORKING_DIRECTORY ${NUTTX_DIR}/tools
 	COMMENT "Copying NuttX config ${BOARD} and configuring"
 	)
@@ -109,12 +110,11 @@ add_custom_target(nuttx_context DEPENDS ${NUTTX_DIR}/include/nuttx/version.h)
 
 # library of NuttX libraries
 add_library(nuttx_build INTERFACE)
+add_dependencies(nuttx_build nuttx_context)
 
 # builtins
-set(nuttx_builtin_list)
-if ("${BOARD}" MATCHES "px4io")
-	# no apps for px4io
-else()
+add_custom_target(nuttx_builtins)
+if (CONFIG_NSH_LIBRARY)
 	# add additional commands to nuttx builtins
 	set(builtin_registry ${APPS_DIR}/builtin/registry)
 	foreach(module ${module_libraries})
@@ -125,26 +125,30 @@ else()
 		if(MAIN)
 			add_custom_command(OUTPUT ${builtin_registry}/${MAIN}_main.bdat
 				COMMAND echo "{ \"${MAIN}\", ${PRIORITY}, ${STACK_MAIN}, ${MAIN}_main }," > ${builtin_registry}/${MAIN}_main.bdat
+				DEPENDS nuttx_context
 				VERBATIM
 				)
-			list(APPEND nuttx_builtin_list ${builtin_registry}/${MAIN}_main.bdat)
 
 			add_custom_command(OUTPUT ${builtin_registry}/${MAIN}_main.pdat
 				COMMAND echo "int ${MAIN}_main(int argc, char *argv[]);" > ${builtin_registry}/${MAIN}_main.pdat
+				DEPENDS nuttx_context
 				VERBATIM
 				)
-			list(APPEND nuttx_builtin_list ${builtin_registry}/${MAIN}_main.pdat)
+
+			add_custom_target(nuttx_builtins_${MAIN} DEPENDS ${builtin_registry}/${MAIN}_main.bdat ${builtin_registry}/${MAIN}_main.pdat)
+			add_dependencies(nuttx_builtins nuttx_builtins_${MAIN})
 		endif()
 	endforeach()
 endif()
+add_dependencies(nuttx_build nuttx_builtins)
 
 # APPS
 
 # libapps.a
 add_custom_command(OUTPUT ${APPS_DIR}/libapps.a ${APPS_DIR}/platform/.built
-	COMMAND find ${APPS_DIR} -name \*.o -o -name \*.built -delete
+	COMMAND find ${APPS_DIR} -name \*.o -delete
 	COMMAND make ${nuttx_build_options} --no-print-directory -C ../apps TOPDIR="${NUTTX_DIR}" libapps.a ${nuttx_build_output}
-	DEPENDS nuttx_context ${nuttx_builtin_list}
+	DEPENDS nuttx_context nuttx_builtins
 	WORKING_DIRECTORY ${NUTTX_DIR}
 	${nuttx_build_uses_terminal}
 	)

--- a/src/firmware/nuttx/CMakeLists.txt
+++ b/src/firmware/nuttx/CMakeLists.txt
@@ -42,7 +42,7 @@ if (config_romfs_root)
 endif()
 
 # create px4 file (combined firmware and metadata)
-set(fw_file ${PX4_BINARY_DIR}/${CONFIG}.px4)
+set(fw_file ${PX4_BINARY_DIR}/${BOARD}_${LABEL}.px4)
 
 add_custom_command(OUTPUT ${BOARD}.bin
 	COMMAND ${OBJCOPY} -O binary ${PX4_BINARY_DIR}/${fw_name} ${BOARD}.bin
@@ -50,7 +50,7 @@ add_custom_command(OUTPUT ${BOARD}.bin
 	)
 
 if (TARGET parameters_xml AND TARGET airframes_xml)
-	add_custom_command(OUTPUT ${PX4_BINARY_DIR}/${CONFIG}.px4
+	add_custom_command(OUTPUT ${fw_file}
 		COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/px_mkfw.py
 			--prototype ${PX4_SOURCE_DIR}/Images/${BOARD}.prototype
 			--git_identity ${PX4_SOURCE_DIR}
@@ -58,10 +58,10 @@ if (TARGET parameters_xml AND TARGET airframes_xml)
 			--airframe_xml ${PX4_BINARY_DIR}/airframes.xml
 			--image ${BOARD}.bin > ${fw_file}
 		DEPENDS ${BOARD}.bin parameters_xml airframes_xml
-		COMMENT "Creating ${CONFIG}.px4"
+		COMMENT "Creating ${fw_file}"
 		)
 
-	add_custom_target(px4 ALL DEPENDS ${PX4_BINARY_DIR}/${CONFIG}.px4)
+	add_custom_target(px4 ALL DEPENDS ${fw_file})
 
 	# upload helper
 	if (${BOARD} STREQUAL "aerofc-v1")

--- a/src/firmware/nuttx/CMakeLists.txt
+++ b/src/firmware/nuttx/CMakeLists.txt
@@ -3,7 +3,7 @@ include(common/px4_upload)
 # add executable
 set(fw_name ${CONFIG}.elf)
 add_executable(${fw_name} ${PX4_SOURCE_DIR}/src/platforms/empty.c)
-add_dependencies(${fw_name} git_nuttx)
+add_dependencies(${fw_name} git_nuttx nuttx_build)
 
 get_property(module_libraries GLOBAL PROPERTY PX4_LIBRARIES)
 

--- a/src/firmware/posix/CMakeLists.txt
+++ b/src/firmware/posix/CMakeLists.txt
@@ -40,7 +40,7 @@ if ("${BOARD}" STREQUAL "eagle" OR ("${BOARD}" STREQUAL "excelsior"))
 	px4_add_adb_push(OUT ${UPLOAD_NAME}
 				OS ${OS}
 				BOARD ${BOARD}
-				FILES ${CMAKE_CURRENT_BINARY_DIR}/${APP_NAME}
+				FILES $<TARGET_FILE:${APP_NAME}>
 				${PX4_SOURCE_DIR}/posix-configs/eagle/flight/mainapp.config
 				DEPENDS ${APP_NAME}
 				DEST /home/linaro)
@@ -65,7 +65,7 @@ elseif ("${BOARD}" STREQUAL "rpi")
 	px4_add_scp_push(OUT ${UPLOAD_NAME}
 				OS ${OS}
 				BOARD ${BOARD}
-				FILES ${CMAKE_CURRENT_BINARY_DIR}/${APP_NAME}
+				FILES $<TARGET_FILE:${APP_NAME}>
 				${RPI_CONFIG_FILES}
 				${PX4_SOURCE_DIR}/ROMFS
 				DEPENDS ${APP_NAME}
@@ -101,7 +101,7 @@ elseif ("${BOARD}" STREQUAL "bebop")
 				OS ${OS}
 				BOARD ${BOARD}
 				FILES $<TARGET_FILE:px4>.stripped
-				DEPENDS ${APP_NAME}.stripped
+				DEPENDS px4
 				DEST /usr/bin)
 
 elseif ("${BOARD}" STREQUAL "sitl")
@@ -141,9 +141,8 @@ install(TARGETS px4 DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/ROMFS DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/posix-configs DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
 
-add_custom_target(strip DEPENDS "${APP_NAME}.stripped")
-
 add_custom_command(OUTPUT ${APP_NAME}.stripped
 			COMMAND ${STRIP_TOOL} -R .comment -R .gnu.version -o $<TARGET_FILE:px4>.stripped $<TARGET_FILE:px4>
 			DEPENDS px4
 			)
+add_custom_target(strip DEPENDS "${APP_NAME}.stripped")

--- a/src/lib/version/CMakeLists.txt
+++ b/src/lib/version/CMakeLists.txt
@@ -56,6 +56,7 @@ add_custom_command(OUTPUT ${px4_git_ver_header}
 	DEPENDS
 		${CMAKE_CURRENT_SOURCE_DIR}/px_update_git_header.py
 		${git_dir_path}/HEAD
+		${git_dir_path}/index
 	WORKING_DIRECTORY ${PX4_SOURCE_DIR}
 	COMMENT "Generating git hash header"
 	)

--- a/src/modules/uavcanesc/commands/cfg/CMakeLists.txt
+++ b/src/modules/uavcanesc/commands/cfg/CMakeLists.txt
@@ -39,7 +39,7 @@ px4_add_module(
 		-Wno-deprecated-declarations
 		-O3
 	SRCS
-	 esc_cfg.cpp
+		esc_cfg.cpp
 
 	DEPENDS
 		platforms__common

--- a/src/modules/uavcanesc/commands/stat/CMakeLists.txt
+++ b/src/modules/uavcanesc/commands/stat/CMakeLists.txt
@@ -33,17 +33,15 @@
 
 px4_add_module(
 	MODULE modules__uavcanesc__commands__stat
-	MAIN cfg
+	MAIN stat
 	STACK_MAIN 1024
 	COMPILE_FLAGS
 		-Wno-deprecated-declarations
 		-O3
 	SRCS
-	 esc_stat.cpp
-
+		esc_stat.cpp
 	DEPENDS
 		platforms__common
-
 	)
 
 ## vim: set noet ft=cmake fenc=utf-8 ff=unix :


### PR DESCRIPTION
 - restore output binary naming for s3 (and QGC compatibility) eg nuttx_px4fmu-v2_default.px4 -> px4fmu-v2_default.px4
 - nuttx cmake improved dependencies (#7999)
 - snapdragon 'upload' dependencies fix (remove hardcoded paths)