### PR TITLE
Navigator fix vehicle_command_ack (and landing abort improvements)

### DIFF
--- a/src/modules/commander/calibration_routines.cpp
+++ b/src/modules/commander/calibration_routines.cpp
@@ -839,7 +839,8 @@ bool calibrate_cancel_check(orb_advert_t *mavlink_log_pub, int cancel_sub)
 
 		orb_copy(ORB_ID(vehicle_command), cancel_sub, &cmd);
 
-		if (cmd.from_external) { // ignore internal commands, such as VEHICLE_CMD_DO_MOUNT_CONTROL from vmount
+		// ignore internal commands, such as VEHICLE_CMD_DO_MOUNT_CONTROL from vmount
+		if (cmd.from_external) {
 			if (cmd.command == vehicle_command_s::VEHICLE_CMD_PREFLIGHT_CALIBRATION &&
 					(int)cmd.param1 == 0 &&
 					(int)cmd.param2 == 0 &&

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1206,7 +1206,7 @@ bool handle_command(struct vehicle_status_s *status_local, const struct safety_s
 	case vehicle_command_s::VEHICLE_CMD_LOGGING_START:
 	case vehicle_command_s::VEHICLE_CMD_LOGGING_STOP:
 	case vehicle_command_s::VEHICLE_CMD_NAV_DELAY:
-            /* ignore commands that handled in low prio loop */
+		/* ignore commands that are handled by other parts of the system */
 		break;
 
 	default:

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1502,7 +1502,7 @@ FixedwingPositionControl::handle_command()
 		    _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
 
 			_fw_pos_ctrl_status.abort_landing = true;
-			mavlink_log_critical(&_mavlink_log_pub, "Landing, aborted");
+			mavlink_log_critical(&_mavlink_log_pub, "Landing aborted");
 		}
 	}
 }


### PR DESCRIPTION
Navigator was copying the vehicle_command from_external flag to the vehicle_command_ack, which prevented QGC from getting the ACK. 