### PR TITLE
[WIP] navigator simplify cruising speed handling

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -774,7 +774,8 @@ FixedwingPositionControl::control_position(const math::Vector<2> &curr_pos, cons
 		float mission_airspeed = _parameters.airspeed_trim;
 
 		if (PX4_ISFINITE(pos_sp_curr.cruising_speed) &&
-		    pos_sp_curr.cruising_speed > 0.1f) {
+		    pos_sp_curr.cruising_speed >= _parameters.airspeed_min &&
+		    pos_sp_curr.cruising_speed <= _parameters.airspeed_max) {
 
 			mission_airspeed = pos_sp_curr.cruising_speed;
 		}
@@ -782,7 +783,8 @@ FixedwingPositionControl::control_position(const math::Vector<2> &curr_pos, cons
 		float mission_throttle = _parameters.throttle_cruise;
 
 		if (PX4_ISFINITE(pos_sp_curr.cruising_throttle) &&
-		    pos_sp_curr.cruising_throttle > 0.01f) {
+		    pos_sp_curr.cruising_throttle >= _parameters.throttle_min &&
+		    pos_sp_curr.cruising_throttle <= _parameters.throttle_max) {
 
 			mission_throttle = pos_sp_curr.cruising_throttle;
 		}
@@ -793,6 +795,7 @@ FixedwingPositionControl::control_position(const math::Vector<2> &curr_pos, cons
 			_att_sp.pitch_body = 0.0f;
 
 		} else if (pos_sp_curr.type == position_setpoint_s::SETPOINT_TYPE_POSITION) {
+
 			/* waypoint is a plain navigation waypoint */
 			_l1_control.navigate_waypoints(prev_wp, curr_wp, curr_pos, nav_speed_2d);
 			_att_sp.roll_body = _l1_control.nav_roll();
@@ -840,7 +843,7 @@ FixedwingPositionControl::control_position(const math::Vector<2> &curr_pos, cons
 						   radians(_parameters.pitch_limit_max) - _parameters.pitchsp_offset_rad,
 						   _parameters.throttle_min,
 						   _parameters.throttle_max,
-						   _parameters.throttle_cruise,
+						   mission_throttle,
 						   false,
 						   radians(_parameters.pitch_limit_min));
 

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -383,6 +383,20 @@ PARAM_DEFINE_FLOAT(FW_AIRSPD_MIN, 10.0f);
 PARAM_DEFINE_FLOAT(FW_AIRSPD_MAX, 20.0f);
 
 /**
+ * Cruise Airspeed
+ *
+ * The fixed wing controller tries to fly at this airspeed.
+ *
+ * @unit m/s
+ * @min 0.0
+ * @max 40
+ * @decimal 1
+ * @increment 0.5
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_AIRSPD_TRIM, 15.0f);
+
+/**
  * Maximum climb rate
  *
  * This is the best climb rate that the aircraft can achieve with

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1036,8 +1036,14 @@ MulticopterPositionControl::get_cruising_speed_xy()
 	/*
 	 * in mission the user can choose cruising speed different to default
 	 */
-	return ((PX4_ISFINITE(_pos_sp_triplet.current.cruising_speed) && (_pos_sp_triplet.current.cruising_speed > 0.1f)) ?
-		_pos_sp_triplet.current.cruising_speed : _params.vel_cruise_xy);
+	const float &cruising_speed = _pos_sp_triplet.current.cruising_speed;
+
+	if (PX4_ISFINITE(cruising_speed) && cruising_speed >= 0.0f && cruising_speed <= _params.vel_max_xy) {
+		return cruising_speed;
+
+	} else {
+		return _params.vel_cruise_xy;
+	}
 }
 
 void

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -98,8 +98,7 @@ Land::on_active()
 		_navigator->set_mission_result_updated();
 		set_idle_item(&_mission_item);
 
-		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-		mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
+		mission_item_to_position_setpoint(_mission_item, &_navigator->get_position_setpoint_triplet()->current);
 		_navigator->set_position_setpoint_triplet_updated();
 	}
 }

--- a/src/modules/navigator/loiter.h
+++ b/src/modules/navigator/loiter.h
@@ -46,29 +46,25 @@
 
 #include "navigator_mode.h"
 #include "mission_block.h"
+#include "mission.h"
 
-class Loiter : public MissionBlock
+class Loiter final : public MissionBlock
 {
 public:
 	Loiter(Navigator *navigator, const char *name);
 
-	~Loiter();
+	~Loiter() = default;
 
-	virtual void on_inactive();
+	void on_inactive() override;
+	void on_activation() override;
+	void on_active() override;
 
-	virtual void on_activation();
-
-	virtual void on_active();
-
-	enum mission_yaw_mode {
-		MISSION_YAWMODE_NONE = 0,
-		MISSION_YAWMODE_FRONT_TO_WAYPOINT = 1,
-		MISSION_YAWMODE_FRONT_TO_HOME = 2,
-		MISSION_YAWMODE_BACK_TO_HOME = 3,
-		MISSION_YAWMODE_MAX = 4
-	};
+	position_setpoint_triplet_s *get_reposition_triplet() { return &_reposition_triplet; }
 
 private:
+
+	position_setpoint_triplet_s	_reposition_triplet{};	/**< triplet for non-mission direct position command */
+
 	/**
 	 * Use the stored reposition location of the navigator
 	 * to move to a new location.
@@ -80,8 +76,6 @@ private:
 	 */
 	void set_loiter_position();
 
-	control::BlockParamFloat _param_min_alt;
-	control::BlockParamInt _param_yawmode;
 	bool _loiter_pos_set;
 };
 

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -66,7 +66,7 @@
 
 class Navigator;
 
-class Mission : public MissionBlock
+class Mission final : public MissionBlock
 {
 public:
 	Mission(Navigator *navigator, const char *name);
@@ -80,15 +80,6 @@ public:
 	enum mission_altitude_mode {
 		MISSION_ALTMODE_ZOH = 0,
 		MISSION_ALTMODE_FOH = 1
-	};
-
-	enum mission_yaw_mode {
-		MISSION_YAWMODE_NONE = 0,
-		MISSION_YAWMODE_FRONT_TO_WAYPOINT = 1,
-		MISSION_YAWMODE_FRONT_TO_HOME = 2,
-		MISSION_YAWMODE_BACK_TO_HOME = 3,
-		MISSION_YAWMODE_TO_ROI = 4,
-		MISSION_YAWMODE_MAX = 5
 	};
 
 	bool set_current_offboard_mission_index(unsigned index);
@@ -162,11 +153,6 @@ private:
 	void altitude_sp_foh_reset();
 
 	/**
-	 * Update the cruising speed setpoint.
-	 */
-	void cruising_speed_sp_update();
-
-	/**
 	 * Abort landing
 	 */
 	void do_abort_landing();
@@ -179,8 +165,8 @@ private:
 	 *
 	 * @return true if current mission item available
 	 */
-	bool prepare_mission_items(bool onboard, struct mission_item_s *mission_item,
-				   struct mission_item_s *next_position_mission_item, bool *has_next_position_item);
+	bool prepare_mission_items(bool onboard, mission_item_s *mission_item,
+				   mission_item_s *next_position_mission_item, bool *has_next_position_item);
 
 	/**
 	 * Read current (offset == 0) or a specific (offset > 0) mission item
@@ -236,20 +222,32 @@ private:
 	 */
 	void generate_waypoint_from_heading(struct position_setpoint_s *setpoint, float yaw);
 
+	// Cruising speed
+	float		get_cruising_speed() override { return _cruising_speed; }
+	bool		set_cruising_speed(float speed) override;
+	void		reset_cruising_speed() override { _cruising_speed = -1.0f; }
+
+	// Cruising throttle
+	float		get_cruising_throttle() override { return _cruising_throttle; }
+	bool		set_cruising_throttle(float throttle) override;
+	void		reset_cruising_throttle() override { _cruising_throttle = -1.0f; }
+
 	control::BlockParamInt _param_onboard_enabled;
 	control::BlockParamFloat _param_takeoff_alt;
 	control::BlockParamFloat _param_dist_1wp;
 	control::BlockParamInt _param_altmode;
-	control::BlockParamInt _param_yawmode;
 	control::BlockParamInt _param_force_vtol;
 	control::BlockParamFloat _param_fw_climbout_diff;
 
-	struct mission_s _onboard_mission {};
-	struct mission_s _offboard_mission {};
+	mission_s _onboard_mission {};
+	mission_s _offboard_mission {};
 
 	int _current_onboard_mission_index{-1};
 	int _current_offboard_mission_index{-1};
 	bool _need_takeoff{true};					/**< if true, then takeoff must be performed before going to the first waypoint (if needed) */
+
+	float _cruising_speed{-1.0f};
+	float _cruising_throttle{-1.0f};
 
 	enum {
 		MISSION_TYPE_NONE,

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -56,7 +56,6 @@
 
 MissionBlock::MissionBlock(Navigator *navigator, const char *name) :
 	NavigatorMode(navigator, name),
-	_param_loiter_min_alt(this, "MIS_LTRMIN_ALT", false),
 	_param_yaw_timeout(this, "MIS_YAW_TMT", false),
 	_param_yaw_err(this, "MIS_YAW_ERR", false),
 	_param_vtol_wv_land(this, "VT_WV_LND_EN", false),
@@ -500,8 +499,8 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 	sp->acceptance_radius = item.acceptance_radius;
 	sp->disable_mc_yaw_control = item.disable_mc_yaw;
 
-	sp->cruising_speed = _navigator->get_cruising_speed();
-	sp->cruising_throttle = _navigator->get_cruising_throttle();
+	sp->cruising_speed = get_cruising_speed();
+	sp->cruising_throttle = get_cruising_throttle();
 
 	switch (item.nav_cmd) {
 	case NAV_CMD_IDLE:
@@ -547,9 +546,9 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 	case NAV_CMD_LOITER_TO_ALT:
 
 		// initially use current altitude, and switch to mission item altitude once in loiter position
-		if (_param_loiter_min_alt.get() > 0.0f) { // ignore _param_loiter_min_alt if smaller then 0 (-1)
+		if (_navigator->get_loiter_min_alt() > 0.0f) { // ignore _param_loiter_min_alt if smaller then 0 (-1)
 			sp->alt = math::max(_navigator->get_global_position()->alt,
-					    _navigator->get_home_position()->alt + _param_loiter_min_alt.get());
+					    _navigator->get_home_position()->alt + _navigator->get_loiter_min_alt());
 
 		} else {
 			sp->alt = _navigator->get_global_position()->alt;

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -68,6 +68,20 @@ public:
 
 	static bool item_contains_position(const mission_item_s &item);
 
+	/**
+	 * Cruising speed
+	 */
+	virtual float	get_cruising_speed() { return -1.0f; }
+	virtual bool	set_cruising_speed(float speed) { return false; }
+	virtual void	reset_cruising_speed() {}
+
+	/**
+	 * Cruising throttle
+	 */
+	virtual float	get_cruising_throttle() { return -1.0f; }
+	virtual bool	set_cruising_throttle(float throttle) { return false; }
+	virtual void	reset_cruising_throttle() {}
+
 protected:
 	/**
 	 * Check if mission item has been reached
@@ -136,7 +150,6 @@ protected:
 	actuator_controls_s _actuators{};
 	orb_advert_t    _actuator_pub{nullptr};
 
-	control::BlockParamFloat _param_loiter_min_alt;
 	control::BlockParamFloat _param_yaw_timeout;
 	control::BlockParamFloat _param_yaw_err;
 	control::BlockParamInt _param_vtol_wv_land;

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -182,17 +182,3 @@ PARAM_DEFINE_INT32(VT_WV_TKO_EN, 0);
  * @group Mission
  */
 PARAM_DEFINE_INT32(VT_WV_LTR_EN, 0);
-
-/**
- * Cruise Airspeed
- *
- * The fixed wing controller tries to fly at this airspeed.
- *
- * @unit m/s
- * @min 0.0
- * @max 40
- * @decimal 1
- * @increment 0.5
- * @group FW TECS
- */
-PARAM_DEFINE_FLOAT(FW_AIRSPD_TRIM, 15.0f);

--- a/src/modules/navigator/navigator_mode.cpp
+++ b/src/modules/navigator/navigator_mode.cpp
@@ -44,11 +44,11 @@
 
 NavigatorMode::NavigatorMode(Navigator *navigator, const char *name) :
 	SuperBlock(navigator, name),
-	_navigator(navigator),
-	_active(false)
+	_navigator(navigator)
 {
 	/* load initial params */
 	updateParams();
+
 	/* set initial mission items */
 	on_inactivation();
 	on_inactive();

--- a/src/modules/navigator/navigator_mode.h
+++ b/src/modules/navigator/navigator_mode.h
@@ -86,7 +86,6 @@ public:
 protected:
 	Navigator *_navigator{nullptr};
 
-private:
 	bool _active{false};
 };
 

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -54,7 +54,6 @@ RTL::RTL(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name),
 	_rtl_state(RTL_STATE_NONE),
 	_param_return_alt(this, "RTL_RETURN_ALT", false),
-	_param_min_loiter_alt(this, "MIS_LTRMIN_ALT", false),
 	_param_descend_alt(this, "RTL_DESCEND_ALT", false),
 	_param_land_delay(this, "RTL_LAND_DELAY", false),
 	_param_rtl_min_dist(this, "RTL_MIN_DIST", false)

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -53,7 +53,7 @@
 
 class Navigator;
 
-class RTL : public MissionBlock
+class RTL final : public MissionBlock
 {
 public:
 	RTL(Navigator *navigator, const char *name);
@@ -92,7 +92,6 @@ private:
 	} _rtl_state{RTL_STATE_NONE};
 
 	control::BlockParamFloat _param_return_alt;
-	control::BlockParamFloat _param_min_loiter_alt;
 	control::BlockParamFloat _param_descend_alt;
 	control::BlockParamFloat _param_land_delay;
 	control::BlockParamFloat _param_rtl_min_dist;

--- a/src/modules/navigator/takeoff.h
+++ b/src/modules/navigator/takeoff.h
@@ -47,21 +47,20 @@
 #include "navigator_mode.h"
 #include "mission_block.h"
 
-class Takeoff : public MissionBlock
+class Takeoff final : public MissionBlock
 {
 public:
 	Takeoff(Navigator *navigator, const char *name);
+	~Takeoff() = default;
 
-	~Takeoff();
+	void on_inactive() override;
+	void on_activation() override;
+	void on_active() override;
 
-	virtual void on_inactive();
-
-	virtual void on_activation();
-
-	virtual void on_active();
+	position_setpoint_triplet_s *get_takeoff_triplet() { return &_takeoff_triplet; }
 
 private:
-	control::BlockParamFloat _param_min_alt;
+	position_setpoint_triplet_s	_takeoff_triplet{};	/**< triplet for non-mission direct takeoff command */
 
 	void set_takeoff_position();
 };


### PR DESCRIPTION
This moves cruise speed and throttle handling to the MissionBlock interface. Mission (a MissionBlock) has an implementation, but none of the other navigation modes currently do.

 - closes https://github.com/PX4/Firmware/issues/8073