### PR TITLE
landdetector: remove outdated comment

### DIFF
--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -245,7 +245,6 @@ bool MulticopterLandDetector::_get_maybe_landed_state()
 	float landThresholdFactor = 1.0f;
 
 	// Widen acceptance thresholds for landed state right after landed
-	// so that motor spool-up and other effects do not trigger false negatives.
 	if (hrt_elapsed_time(&_landed_time) < LAND_DETECTOR_LAND_PHASE_TIME_US) {
 		landThresholdFactor = 2.5f;
 	}


### PR DESCRIPTION
related to land-detector [PR](https://github.com/PX4/Firmware/pull/7772), where the comment was not in sync with the current state.
I do not want to ignore the concern from @AndreasAntener [here](https://github.com/PX4/Firmware/pull/7772#issuecomment-327107899). However, since there are different ways to address the likelihood of falling out of landdetection during arming, I am currently hesitating to revert the old logic just because it was already in there and most likely not even necessary anymore because of the evolution of the landdetector