### PR TITLE
set cruising speed for reposition

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -385,6 +385,8 @@ Navigator::task_main()
 				rep->current.loiter_radius = get_loiter_radius();
 				rep->current.loiter_direction = 1;
 				rep->current.type = position_setpoint_s::SETPOINT_TYPE_LOITER;
+				rep->current.cruising_speed = get_cruising_speed();
+				rep->current.cruising_throttle = get_cruising_throttle();
 
 				// Go on and check which changes had been requested
 				if (PX4_ISFINITE(cmd.param4)) {


### PR DESCRIPTION
in mission the cruise speed is set by this function [here](https://github.com/PX4/Firmware/blob/master/src/modules/navigator/navigator_main.cpp#L803), where the cruise speed is set to -1 if triple.cruise_speed is not larger than 0. This function is, however, only called during missions, but not during reposition, where triplet.cruise_speed is set to 0 (default). If I accept -1 as the default for having no specific cruise speed set, then we also need to set that for reposition. 
In general, it would be great if mission, reposition and so on would follow the same code path instead of having two different paths. 