### PR TITLE
Reduce CPU load on Pixracer

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -559,7 +559,7 @@ then
 		then
 			set MAVLINK_F "-r 1200 -d /dev/ttyS1"
 			# Start MAVLink on Wifi (ESP8266 port)
-			mavlink start -r 20000 -m config -b 921600 -d /dev/ttyS0
+			mavlink start -r 20000 -b 921600 -d /dev/ttyS0
 		fi
 
 		if ver hwcmp AEROFC_V1


### PR DESCRIPTION
by starting mavlink in normal mode for the WiFi module

The config mode uses high rates for many streams, leading to high CPU usage
(9-10% for the mavlink sender). The normal mode contains almost the same
set of messages but at lower rates.
This reduces the CPU load on a Pixracer by 3-4%.