### PR TITLE
circleci force make distclean before build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ checkout:
     - git submodule sync --recursive
     - git submodule deinit -f . && rm -rf .git/modules
     - git submodule update --init --recursive --force
+    - make distclean
 
 dependencies:
   pre:


### PR DESCRIPTION
This is an attempt to fix the annoying circleci OSX cmake configure loop.

![image](https://user-images.githubusercontent.com/84712/31448444-7899c7d0-ae72-11e7-994a-cb55a9c3639c.png)
