### PR TITLE
IO Mixer Fix

### DIFF
--- a/ROMFS/px4fmu_common/mixers/AAERTWF.main.mix
+++ b/ROMFS/px4fmu_common/mixers/AAERTWF.main.mix
@@ -18,13 +18,15 @@ depending on the actual configuration it may be necessary to reverse the scaling
 factors (to reverse the servo movement) and adjust the offset, scaling and
 endpoints to suit.
 
-M: 1
+M: 2
 O:      10000  10000      0 -10000  10000
 S: 0 0  10000  10000      0 -10000  10000
+S: 0 6  10000  10000      0 -10000  10000
 
-M: 1
+M: 2
 O:      10000  10000      0 -10000  10000
 S: 0 0  10000  10000      0 -10000  10000
+S: 0 6 -10000 -10000      0 -10000  10000
 
 Elevator mixer
 ------------

--- a/src/modules/px4iofirmware/mixer.cpp
+++ b/src/modules/px4iofirmware/mixer.cpp
@@ -384,6 +384,8 @@ mixer_callback(uintptr_t handle,
 	       uint8_t control_index,
 	       float &control)
 {
+	control = 0.0f;
+
 	if (control_group >= PX4IO_CONTROL_GROUPS) {
 		return -1;
 	}

--- a/src/modules/systemlib/mixer/mixer_simple.cpp
+++ b/src/modules/systemlib/mixer/mixer_simple.cpp
@@ -299,7 +299,7 @@ SimpleMixer::mix(float *outputs, unsigned space)
 	}
 
 	for (unsigned i = 0; i < _pinfo->control_count; i++) {
-		float input;
+		float input = 0.0f;
 
 		_control_cb(_cb_handle,
 			    _pinfo->controls[i].control_group,

--- a/src/systemcmds/tests/test_mixer.cpp
+++ b/src/systemcmds/tests/test_mixer.cpp
@@ -591,6 +591,7 @@ static int
 mixer_callback(uintptr_t handle, uint8_t control_group, uint8_t control_index, float &control)
 {
 	control = 0.0f;
+
 	if (control_group != 0) {
 		return -1;
 	}

--- a/src/systemcmds/tests/test_mixer.cpp
+++ b/src/systemcmds/tests/test_mixer.cpp
@@ -590,6 +590,7 @@ bool MixerTest::mixerTest()
 static int
 mixer_callback(uintptr_t handle, uint8_t control_group, uint8_t control_index, float &control)
 {
+	control = 0.0f;
 	if (control_group != 0) {
 		return -1;
 	}


### PR DESCRIPTION
This PR provides a clean solution for the issue [#7861](https://github.com/PX4/Firmware/issues/7861). The Flaperons are again added to the mixer as they now do not case any harm anymore.

The problem was caused that [callback](https://github.com/acfloria/Firmware/blob/master/src/modules/px4iofirmware/mixer.cpp#L382) would not modify the `control` value in case that it failed to get an control value. The fact that the `input` value is not initialized with a value in the [mix function of the simple mixer](https://github.com/acfloria/Firmware/blob/fix_io_mixer/src/modules/systemlib/mixer/mixer_simple.cpp#L302) resulted that it kept its value between iterations.

So in case of the right aileron for the AAERTWF mixer in my case the following happened [(L301:310)](https://github.com/acfloria/Firmware/blob/fix_io_mixer/src/modules/systemlib/mixer/mixer_simple.cpp#L301-L310):
1. During the first iteration based on the roll input the `input` would be assigned for example with `0.5` by the control callback.
2. Due to the positive scale of the output it would result in `sum = 5000`.
3. In the next iteration the control callback would not modify the input value as the corresponding input was not defined. So the `input` variable has still the value `0.5`.
4. Due to the negative scale of the flaperons '5000' is subtracted resulting in `sum = 0`.
5. Therefore the output would always be `0` regardless of the roll input.