### PR TITLE
When switching to land in VTOL, update land target during back trans

### DIFF
--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -94,6 +94,17 @@ Land::on_activation()
 void
 Land::on_active()
 {
+	/* for VTOL update landing location during back transition */
+	if (_navigator->get_vstatus()->is_vtol &&
+		_navigator->get_vstatus()->in_transition_mode)
+	{
+		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
+		pos_sp_triplet->current.lat = _navigator->get_global_position()->lat;
+		pos_sp_triplet->current.lon = _navigator->get_global_position()->lon;
+		_navigator->set_position_setpoint_triplet_updated();
+	}
+
+
 	if (is_mission_item_reached() && !_navigator->get_mission_result()->finished) {
 		_navigator->get_mission_result()->finished = true;
 		_navigator->set_mission_result_updated();

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -96,8 +96,7 @@ Land::on_active()
 {
 	/* for VTOL update landing location during back transition */
 	if (_navigator->get_vstatus()->is_vtol &&
-		_navigator->get_vstatus()->in_transition_mode)
-	{
+	    _navigator->get_vstatus()->in_transition_mode) {
 		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 		pos_sp_triplet->current.lat = _navigator->get_global_position()->lat;
 		pos_sp_triplet->current.lon = _navigator->get_global_position()->lon;


### PR DESCRIPTION
Currently, when switching to LAND mode on a vtol, it will perform a back transition and landing simultaneously. This prevents the vehicle trying to navigate back to where the back transition started during landing as it might result in a landing while tilted.