### PR TITLE
Logger: add high-rate profile & change profile param into a bitset

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -580,6 +580,24 @@ void Logger::add_common_topics()
 	add_topic("wind_estimate", 200);
 }
 
+void Logger::add_high_rate_topics()
+{
+	// maximum rate to analyze fast maneuvers (e.g. for racing)
+	add_topic("actuator_controls_0");
+	add_topic("actuator_outputs");
+	add_topic("manual_control_setpoint");
+	add_topic("vehicle_attitude");
+	add_topic("vehicle_attitude_setpoint");
+	add_topic("vehicle_rates_setpoint");
+}
+
+void Logger::add_debug_topics()
+{
+	add_topic("debug_key_value");
+	add_topic("debug_value");
+	add_topic("debug_vect");
+}
+
 void Logger::add_estimator_replay_topics()
 {
 	// for estimator replay (need to be at full rate)
@@ -601,7 +619,6 @@ void Logger::add_estimator_replay_topics()
 
 void Logger::add_thermal_calibration_topics()
 {
-	// Note: try to avoid setting the interval where possible, as it increases RAM usage
 	add_topic("sensor_accel", 100);
 	add_topic("sensor_baro", 100);
 	add_topic("sensor_gyro", 100);
@@ -740,6 +757,15 @@ void Logger::run()
 		} else if (sdlog_profile == SDLogProfile::SYSTEM_IDENTIFICATION) {
 			add_common_topics();
 			add_system_identification_topics();
+
+		} else if (sdlog_profile == SDLogProfile::HIGH_RATE) {
+			add_common_topics();
+			add_estimator_replay_topics();
+			add_high_rate_topics();
+
+		} else if (sdlog_profile == SDLogProfile::DEBUG_TOPICS) {
+			add_common_topics();
+			add_debug_topics();
 
 		} else {
 			add_common_topics();

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -65,6 +65,8 @@ enum class SDLogProfile : int32_t {
 	DEFAULT = 0,
 	THERMAL_CALIBRATION,
 	SYSTEM_IDENTIFICATION,
+	HIGH_RATE,
+	DEBUG_TOPICS,
 	N_PROFILES
 };
 
@@ -270,6 +272,8 @@ private:
 	void add_estimator_replay_topics();
 	void add_thermal_calibration_topics();
 	void add_system_identification_topics();
+	void add_high_rate_topics();
+	void add_debug_topics();
 
 	void ack_vehicle_command(orb_advert_t &vehicle_command_ack_pub, vehicle_command_s *cmd, uint32_t result);
 

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -61,14 +61,19 @@ namespace px4
 namespace logger
 {
 
-enum class SDLogProfile : int32_t {
-	DEFAULT = 0,
-	THERMAL_CALIBRATION,
-	SYSTEM_IDENTIFICATION,
-	HIGH_RATE,
-	DEBUG_TOPICS,
-	N_PROFILES
+enum class SDLogProfileMask : int32_t {
+	DEFAULT =               1 << 0,
+	ESTIMATOR_REPLAY =      1 << 1,
+	THERMAL_CALIBRATION =   1 << 2,
+	SYSTEM_IDENTIFICATION = 1 << 3,
+	HIGH_RATE =             1 << 4,
+	DEBUG_TOPICS =          1 << 5
 };
+
+inline bool operator&(SDLogProfileMask a, SDLogProfileMask b)
+{
+	return static_cast<int32_t>(a) & static_cast<int32_t>(b);
+}
 
 struct LoggerSubscription {
 	int fd[ORB_MULTI_MAX_INSTANCES];
@@ -268,7 +273,7 @@ private:
 	 */
 	int add_topics_from_file(const char *fname);
 
-	void add_common_topics();
+	void add_default_topics();
 	void add_estimator_replay_topics();
 	void add_thermal_calibration_topics();
 	void add_system_identification_topics();

--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -71,22 +71,33 @@ PARAM_DEFINE_INT32(SDLOG_MODE, 0);
 /**
  * Logging Topic Profile
  *
- * Selects a set of topics appropriate for specific tasks.
+ * This is an integer bitmask controlling the set and rates of logged topics.
+ * The default allows for general log analysis and estimator replay, while
+ * keeping the log file size reasonably small.
  *
- * This parameter is only for the new logger (SYS_LOGGER=1).
+ * Enabling multiple sets leads to higher bandwidth requirements and larger log
+ * files.
  *
- * @value 0 default
- * @value 1 thermal calibration
- * @value 2 system identification
- * @value 3 high rate
- * @value 4 debug topics
+ * Set bits in the following positions to enable:
+ * 0 : Set to true to use the default set (used for general log analysis)
+ * 1 : Set to true to enable estimator (EKF2) replay topics
+ * 2 : Set to true to enable topics for thermal calibration (raw IMU sensor data)
+ * 3 : Set to true to enable topics for system identification (high rate actuator control and IMU data)
+ * 4 : Set to true to enable full rates for analysis of fast maneuvers (RC, attitude, rates and actuators)
+ * 5 : Set to true to enable debugging topics (debug_*.msg topics, for custom code)
  *
  * @min 0
- * @max 4
+ * @max 63
+ * @bit 0 default set (log analysis)
+ * @bit 1 estimator replay (EKF2)
+ * @bit 2 thermal calibration
+ * @bit 3 system identification
+ * @bit 4 high rate
+ * @bit 5 debug
  * @reboot_required true
  * @group SD Logging
  */
-PARAM_DEFINE_INT32(SDLOG_PROFILE, 0);
+PARAM_DEFINE_INT32(SDLOG_PROFILE, 3);
 
 /**
  * Maximum number of log directories to keep

--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -78,9 +78,11 @@ PARAM_DEFINE_INT32(SDLOG_MODE, 0);
  * @value 0 default
  * @value 1 thermal calibration
  * @value 2 system identification
+ * @value 3 high rate
+ * @value 4 debug topics
  *
  * @min 0
- * @max 2
+ * @max 4
  * @reboot_required true
  * @group SD Logging
  */


### PR DESCRIPTION
The high-rate profile allows to analyze fast maneuvers. It logs RC input, actuators, rates and attitude at full rate:
![pixracer_high_rate_test_pitch_rate](https://user-images.githubusercontent.com/281593/31574114-d492f1d0-b0c8-11e7-842b-66ca2684a9e2.png)
![pixracer_high_rate_test_actuator_outputs](https://user-images.githubusercontent.com/281593/31574117-d6b79470-b0c8-11e7-9af4-e07e258663a7.png)
I would have expected a bit a smoother curve, but then again, the vehicle is not really tuned.

Enabling high-rate increases the logging rate from 38kb/s to 90kb/s.