### PR TITLE
Add ICM20602 to AUAV-x21 sensor startup

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -60,6 +60,9 @@ then
 	# Internal SPI bus ICM-20608-G is rotated 90 deg yaw
 	mpu6000 -R 2 -T 20608 start
 
+	# Internal SPI bus ICM-20602-G is rotated 90 deg yaw
+	mpu6000 -R 2 -T 20602 start
+
 	# Internal SPI bus mpu9250 is rotated 90 deg yaw
 	mpu9250 -R 2 start
 fi

--- a/src/drivers/mpu6000/mpu6000.cpp
+++ b/src/drivers/mpu6000/mpu6000.cpp
@@ -34,7 +34,7 @@
 /**
  * @file mpu6000.cpp
  *
- * Driver for the Invensense MPU6000, MPU6050 and the ICM2608 connected via
+ * Driver for the Invensense MPU6000, MPU6050, ICM20608, and ICM20602 connected via
  * SPI or I2C.
  *
  * When the device is on the SPI bus the hrt is used to provide thread of
@@ -44,11 +44,11 @@
  * execution to the driver.
  *
  * The I2C code is only included in the build if USE_I2C is defined by the
- * existance of any of PX4_I2C_MPU6050_ADDR, PX4_I2C_MPU6000_ADDR or
+ * existance of any of PX4_I2C_MPU6050_ADDR, PX4_I2C_MPU6000_ADDR
  * PX4_I2C_ICM_20608_G_ADDR in the board_config.h file.
  *
- * The command line option -T 6000|20608 (default 6000) selects between
- * MPU60x0 or the ICM20608G;
+ * The command line option -T 6000|20608|20602 (default 6000) selects between
+ * MPU60x0, ICM20608G, or ICM20602G;
  *
  * @author Andrew Tridgell
  * @author Pat Hickey
@@ -101,9 +101,9 @@
   accelerometer values. This time reduction is enough to cope with
   worst case timing jitter due to other timers
 
-  I2C bus is running at 100 kHz Transaction time is 2.163Ms
- I2C bus is running at 400 kHz (304 kHz acutal) Transaction time
- is 583 uS
+  I2C bus is running at 100 kHz Transaction time is 2.163ms
+  I2C bus is running at 400 kHz (304 kHz actual) Transaction time
+  is 583 us
 
  */
 #define MPU6000_TIMER_REDUCTION				200

--- a/src/drivers/mpu6000/mpu6000.h
+++ b/src/drivers/mpu6000/mpu6000.h
@@ -167,17 +167,17 @@
 #define MPUREG_ICM_UNDOC1		0x11
 #define MPUREG_ICM_UNDOC1_VALUE	0xc9
 
-// Product ID Description for ICM2602
+// Product ID Description for ICM20602
 // Read From device
 
 #define ICM20602_REV_01		1
 #define ICM20602_REV_02		2
 
-// Product ID Description for ICM2608
+// Product ID Description for ICM20608
 
 #define ICM20608_REV_FF		0xff // In the past, was thought to be not returning a value. But seem repeatable.
 
-// Product ID Description for ICM2689
+// Product ID Description for ICM20689
 
 #define ICM20689_REV_FE		0xfe
 #define ICM20689_REV_03		0x03


### PR DESCRIPTION
The mRO x21 Rev.2 (https://store.mrobotics.io/mRo-X2-1-Rev-2-p/mro-x2.1rv2-mr.htm)
has an ICM20602 instead of an ICM20608.

Also fixed a few typos in the comments for mpu6000/icm20608/icm20602 driver.