### PR TITLE
logger: Add logging profile to support comparison of multiple sensors

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -624,6 +624,14 @@ void Logger::add_thermal_calibration_topics()
 	add_topic("sensor_gyro", 100);
 }
 
+void Logger::add_sensor_comparison_topics()
+{
+	add_topic("sensor_accel", 10);
+	add_topic("sensor_baro", 10);
+	add_topic("sensor_gyro", 10);
+	add_topic("sensor_mag", 10);
+}
+
 void Logger::add_system_identification_topics()
 {
 	// for system id need to log imu and controls at full rate
@@ -775,6 +783,11 @@ void Logger::run()
 		if (sdlog_profile & SDLogProfileMask::DEBUG_TOPICS) {
 			add_debug_topics();
 		}
+
+		if (sdlog_profile & SDLogProfileMask::SENSOR_COMPARISON) {
+			add_sensor_comparison_topics();
+		}
+
 	}
 
 	int vehicle_command_sub = -1;

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -626,10 +626,10 @@ void Logger::add_thermal_calibration_topics()
 
 void Logger::add_sensor_comparison_topics()
 {
-	add_topic("sensor_accel", 10);
-	add_topic("sensor_baro", 10);
-	add_topic("sensor_gyro", 10);
-	add_topic("sensor_mag", 10);
+	add_topic("sensor_accel", 100);
+	add_topic("sensor_baro", 100);
+	add_topic("sensor_gyro", 100);
+	add_topic("sensor_mag", 100);
 }
 
 void Logger::add_system_identification_topics()

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -67,7 +67,8 @@ enum class SDLogProfileMask : int32_t {
 	THERMAL_CALIBRATION =   1 << 2,
 	SYSTEM_IDENTIFICATION = 1 << 3,
 	HIGH_RATE =             1 << 4,
-	DEBUG_TOPICS =          1 << 5
+	DEBUG_TOPICS =          1 << 5,
+	SENSOR_COMPARISON =	1 << 6
 };
 
 inline bool operator&(SDLogProfileMask a, SDLogProfileMask b)
@@ -279,6 +280,7 @@ private:
 	void add_system_identification_topics();
 	void add_high_rate_topics();
 	void add_debug_topics();
+	void add_sensor_comparison_topics();
 
 	void ack_vehicle_command(orb_advert_t &vehicle_command_ack_pub, vehicle_command_s *cmd, uint32_t result);
 

--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -80,20 +80,22 @@ PARAM_DEFINE_INT32(SDLOG_MODE, 0);
  *
  * Set bits in the following positions to enable:
  * 0 : Set to true to use the default set (used for general log analysis)
- * 1 : Set to true to enable estimator (EKF2) replay topics
- * 2 : Set to true to enable topics for thermal calibration (raw IMU sensor data)
+ * 1 : Set to true to enable full rate estimator (EKF2) replay topics
+ * 2 : Set to true to enable topics for thermal calibration (high rate raw IMU and Baro sensor data)
  * 3 : Set to true to enable topics for system identification (high rate actuator control and IMU data)
  * 4 : Set to true to enable full rates for analysis of fast maneuvers (RC, attitude, rates and actuators)
  * 5 : Set to true to enable debugging topics (debug_*.msg topics, for custom code)
+ * 6 : Set to true to enable topics for sensor comparison (low rate raw IMU, Baro and Magnetomer data)
  *
  * @min 0
- * @max 63
+ * @max 127
  * @bit 0 default set (log analysis)
  * @bit 1 estimator replay (EKF2)
  * @bit 2 thermal calibration
  * @bit 3 system identification
  * @bit 4 high rate
  * @bit 5 debug
+ * @bit 6 sensor comparison
  * @reboot_required true
  * @group SD Logging
  */


### PR DESCRIPTION
This is required to assist users with diagnosing pre-arm sensor consistency failures.