### PR TITLE
orb_exists: change semantics from (is published or subscribed) to (is published)

### DIFF
--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -44,7 +44,7 @@ set(config_module_list
 	drivers/vmount
 	drivers/pwm_input
 	drivers/camera_trigger
-	drivers/bst
+	#drivers/bst
 	#drivers/snapdragon_rc_pwm
 	drivers/lis3mdl
 	#drivers/iridiumsbd

--- a/src/drivers/device/vdev.h
+++ b/src/drivers/device/vdev.h
@@ -61,14 +61,12 @@ namespace device __EXPORT
 {
 
 struct file_t {
-	int fd;
 	int flags;
-	mode_t mode;
 	void *priv;
 	void *vdev;
 
-	file_t() : fd(-1), flags(0), priv(NULL), vdev(NULL) {}
-	file_t(int f, void *c, int d) : fd(d), flags(f), priv(NULL), vdev(c) {}
+	file_t() : flags(0), priv(NULL), vdev(NULL) {}
+	file_t(int f, void *c) : flags(f), priv(NULL), vdev(c) {}
 };
 
 /**

--- a/src/drivers/device/vdev_posix.cpp
+++ b/src/drivers/device/vdev_posix.cpp
@@ -155,8 +155,8 @@ extern "C" {
 			return -1;
 		}
 
-		PX4_DEBUG("px4_open fd = %d", filemap[i]->fd);
-		return filemap[i]->fd;
+		PX4_DEBUG("px4_open fd = %d", i);
+		return i;
 	}
 
 	int px4_close(int fd)

--- a/src/drivers/drv_orb_dev.h
+++ b/src/drivers/drv_orb_dev.h
@@ -93,4 +93,7 @@
 /** Get the minimum interval at which the topic can be seen to be updated for this subscription */
 #define ORBIOCGETINTERVAL	_ORBIOC(16)
 
+/** Check whether the topic is published, sets *(unsigned long *)arg to 1 if published, 0 otherwise */
+#define ORBIOCISPUBLISHED	_ORBIOC(17)
+
 #endif /* _DRV_UORB_H */

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1010,7 +1010,7 @@ void Logger::run()
 				/* if this topic has been updated, copy the new data into the message buffer
 				 * and write a message to the log
 				 */
-				for (uint8_t instance = 0; instance < ORB_MULTI_MAX_INSTANCES; instance++) {
+				for (int instance = 0; instance < ORB_MULTI_MAX_INSTANCES; instance++) {
 					if (copy_if_updated_multi(sub, instance, _msg_buffer + sizeof(ulog_message_data_header_s),
 								  sub_idx == next_subscribe_topic_index)) {
 
@@ -1113,7 +1113,7 @@ void Logger::run()
 			// - we avoid subscribing to many topics at once, when logging starts
 			// - we'll get the data immediately once we start logging (no need to wait for the next subscribe timeout)
 			if (next_subscribe_topic_index != -1) {
-				for (uint8_t instance = 0; instance < ORB_MULTI_MAX_INSTANCES; instance++) {
+				for (int instance = 0; instance < ORB_MULTI_MAX_INSTANCES; instance++) {
 					if (_subscriptions[next_subscribe_topic_index].fd[instance] < 0) {
 						try_to_subscribe_topic(_subscriptions[next_subscribe_topic_index], instance);
 					}
@@ -1167,7 +1167,7 @@ void Logger::run()
 
 	//unsubscribe
 	for (LoggerSubscription &sub : _subscriptions) {
-		for (uint8_t instance = 0; instance < ORB_MULTI_MAX_INSTANCES; instance++) {
+		for (int instance = 0; instance < ORB_MULTI_MAX_INSTANCES; instance++) {
 			if (sub.fd[instance] >= 0) {
 				orb_unsubscribe(sub.fd[instance]);
 				sub.fd[instance] = -1;

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -586,7 +586,6 @@ void Logger::add_default_topics()
 	add_topic("battery_status", 500);
 	add_topic("camera_capture");
 	add_topic("camera_trigger");
-	add_topic("commander_state", 200);
 	add_topic("cpuload");
 	add_topic("distance_sensor", 100);
 	add_topic("ekf2_innovations", 200);
@@ -596,7 +595,6 @@ void Logger::add_default_topics()
 	add_topic("manual_control_setpoint", 200);
 	add_topic("optical_flow", 50);
 	add_topic("position_setpoint_triplet", 200);
-	add_topic("rc_channels", 200);
 	add_topic("sensor_combined", 100);
 	add_topic("sensor_preflight", 200);
 	add_topic("system_power", 500);

--- a/src/modules/mavlink/mavlink_orb_subscription.cpp
+++ b/src/modules/mavlink/mavlink_orb_subscription.cpp
@@ -160,10 +160,9 @@ MavlinkOrbSubscription::is_published()
 		return true;
 	}
 
-	// Telemetry can sustain an initial published check at 10 Hz
 	hrt_abstime now = hrt_absolute_time();
 
-	if (now - _last_pub_check < 100000) {
+	if (now - _last_pub_check < 300000) {
 		return false;
 	}
 

--- a/src/modules/uORB/uORBDevices.cpp
+++ b/src/modules/uORB/uORBDevices.cpp
@@ -170,6 +170,10 @@ uORB::DeviceNode::open(device::file_t *filp)
 		return ret;
 	}
 
+	if (FILE_FLAGS(filp) == 0) {
+		return CDev::open(filp);
+	}
+
 	/* can only be pub or sub, not both */
 	return -EINVAL;
 }
@@ -402,6 +406,11 @@ uORB::DeviceNode::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 		} else {
 			*(unsigned *)arg = 0;
 		}
+
+		return OK;
+
+	case ORBIOCISPUBLISHED:
+		*(unsigned long *)arg = _published;
 
 		return OK;
 

--- a/src/modules/uORB/uORBManager.hpp
+++ b/src/modules/uORB/uORBManager.hpp
@@ -152,7 +152,7 @@ public:
 	 *      this function will return -1 and set errno to ENOENT.
 	 */
 	orb_advert_t orb_advertise_multi(const struct orb_metadata *meta, const void *data, int *instance,
-					 int priority, unsigned int queue_size = 1) ;
+					 int priority, unsigned int queue_size = 1);
 
 
 	/**
@@ -176,7 +176,7 @@ public:
 	 * @param data    A pointer to the data to be published.
 	 * @return    OK on success, ERROR otherwise with errno set accordingly.
 	 */
-	int  orb_publish(const struct orb_metadata *meta, orb_advert_t handle, const void *data) ;
+	int  orb_publish(const struct orb_metadata *meta, orb_advert_t handle, const void *data);
 
 	/**
 	 * Subscribe to a topic.
@@ -203,7 +203,7 @@ public:
 	 * @return    ERROR on error, otherwise returns a handle
 	 *      that can be used to read and update the topic.
 	 */
-	int  orb_subscribe(const struct orb_metadata *meta) ;
+	int  orb_subscribe(const struct orb_metadata *meta);
 
 	/**
 	 * Subscribe to a multi-instance of a topic.
@@ -238,7 +238,7 @@ public:
 	 *      ORB_DEFINE_OPTIONAL with no corresponding ORB_DECLARE)
 	 *      this function will return -1 and set errno to ENOENT.
 	 */
-	int  orb_subscribe_multi(const struct orb_metadata *meta, unsigned instance) ;
+	int  orb_subscribe_multi(const struct orb_metadata *meta, unsigned instance);
 
 	/**
 	 * Unsubscribe from a topic.
@@ -246,7 +246,7 @@ public:
 	 * @param handle  A handle returned from orb_subscribe.
 	 * @return    OK on success, ERROR otherwise with errno set accordingly.
 	 */
-	int  orb_unsubscribe(int handle) ;
+	int  orb_unsubscribe(int handle);
 
 	/**
 	 * Fetch data from a topic.
@@ -264,7 +264,7 @@ public:
 	 *      using the data.
 	 * @return    OK on success, ERROR otherwise with errno set accordingly.
 	 */
-	int  orb_copy(const struct orb_metadata *meta, int handle, void *buffer) ;
+	int  orb_copy(const struct orb_metadata *meta, int handle, void *buffer);
 
 	/**
 	 * Check whether a topic has been published to since the last orb_copy.
@@ -284,7 +284,7 @@ public:
 	 * @return    OK if the check was successful, ERROR otherwise with
 	 *      errno set accordingly.
 	 */
-	int  orb_check(int handle, bool *updated) ;
+	int  orb_check(int handle, bool *updated);
 
 	/**
 	 * Return the last time that the topic was updated. If a queue is used, it returns
@@ -295,7 +295,7 @@ public:
 	 *      never been updated. Time is measured in microseconds.
 	 * @return    OK on success, ERROR otherwise with errno set accordingly.
 	 */
-	int  orb_stat(int handle, uint64_t *time) ;
+	int  orb_stat(int handle, uint64_t *time);
 
 	/**
 	 * Check if a topic has already been created and published (advertised)
@@ -304,7 +304,7 @@ public:
 	 * @param instance  ORB instance
 	 * @return    OK if the topic exists, ERROR otherwise.
 	 */
-	int  orb_exists(const struct orb_metadata *meta, int instance) ;
+	int  orb_exists(const struct orb_metadata *meta, int instance);
 
 	/**
 	 * Return the priority of the topic
@@ -316,7 +316,7 @@ public:
 	 *      independent of the startup order of the associated publishers.
 	 * @return    OK on success, ERROR otherwise with errno set accordingly.
 	 */
-	int  orb_priority(int handle, int32_t *priority) ;
+	int  orb_priority(int handle, int32_t *priority);
 
 	/**
 	 * Set the minimum interval between which updates are seen for a subscription.
@@ -336,7 +336,7 @@ public:
 	 * @param interval  An interval period in milliseconds.
 	 * @return    OK on success, ERROR otherwise with ERRNO set accordingly.
 	 */
-	int  orb_set_interval(int handle, unsigned interval) ;
+	int  orb_set_interval(int handle, unsigned interval);
 
 
 	/**

--- a/src/modules/uORB/uORBManager.hpp
+++ b/src/modules/uORB/uORBManager.hpp
@@ -298,12 +298,11 @@ public:
 	int  orb_stat(int handle, uint64_t *time) ;
 
 	/**
-	 * Check if a topic has already been created (a publisher or a subscriber exists with
-	 * the given instance).
+	 * Check if a topic has already been created and published (advertised)
 	 *
 	 * @param meta    ORB topic metadata.
 	 * @param instance  ORB instance
-	 * @return    OK if the topic exists, ERROR otherwise with errno set accordingly.
+	 * @return    OK if the topic exists, ERROR otherwise.
 	 */
 	int  orb_exists(const struct orb_metadata *meta, int instance) ;
 


### PR DESCRIPTION
Existing users of `orb_exists`:
- logger (dynamic subscribe to multi-instances)
- mavlink (orb subscription)
- sdlog2
- preflightcheck (check for home_position)
- wait_for_topic shell command (it's not used)
- orb_group_count() (used in sensors: dynamic sensor addition)
    
All use-cases benefit from the changed semantics: they are really only interested if there is a publisher, not another subscriber.

Additional changes:
- logger: do not subscribe to the first instance if the topic is not advertised (but dynamically check if it's published later on)
- logger: remove unused topics commander_state & rc_channels
- avoid dynamic allocations in orb_exists on POSIX
- mavlink_orb_subscription: reduce orb_exists() check from 10Hz to 3Hz

This has deeper impacts on the overall system, hopefully mostly positive!
The following provides some test results.

### Testing
To get representative results, I tested on a fully assembled quad (pixracer) in armed state with RC and an open QGC connection.

#### Used file descriptors
Number of used file descriptors (mavlink instance is the one that is connected to QGC, without b50b0b7):
```
Before:  mavlink: 46, logger: 54
This PR: mavlink: 30, logger: 33
```

#### Memory (Fragmentation)
The additional file operations (open & close) in `orb_exists` do not lead to memory allocations/frees on Nuttx, but did so on POSIX. I changed this in 3b31a03.

My tests showed a considerable **memory reduction of 4.2 KB**. A bit more than half is because of mavlink, the rest is logger. Since pixracer runs more mavlink instances than other boards, it will be slightly less on other boards.

#### CPU usage
Tests showed this is pretty much unchanged (without 191622b). This is the execution time of `orb_exists` before (with locked scheduling):
```
orb_exists: 23174 events, 879696us elapsed, 37us avg, min 20us max 196us 24.192us rms
```
And this PR:
```
orb_exists: 22182 events, 1383130us elapsed, 62us avg, min 20us max 274us 47.743us rms
```
Obviously slower, but I think it's still ok, since it's not called with high frequency or at critical places.

I suggest reviewing each individual commit.

