### PR TITLE
Mavlink: fix flight information

### DIFF
--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -44,7 +44,7 @@ set(config_module_list
 	drivers/vmount
 	drivers/pwm_input
 	drivers/camera_trigger
-	drivers/bst
+	#drivers/bst
 	#drivers/snapdragon_rc_pwm
 	drivers/lis3mdl
 	#drivers/iridiumsbd

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1336,6 +1336,7 @@ int commander_thread_main(int argc, char *argv[])
 	param_t _param_arm_switch_is_button = param_find("COM_ARM_SWISBTN");
 	param_t _param_rc_override = param_find("COM_RC_OVERRIDE");
 	param_t _param_arm_mission_required = param_find("COM_ARM_MIS_REQ");
+	param_t _param_flight_uuid = param_find("COM_FLIGHT_UUID");
 
 	param_t _param_fmode_1 = param_find("COM_FLTMODE1");
 	param_t _param_fmode_2 = param_find("COM_FLTMODE2");
@@ -1744,6 +1745,8 @@ int commander_thread_main(int argc, char *argv[])
 
 	int32_t geofence_action = 0;
 
+	int32_t flight_uuid = 0;
+
 	/* RC override auto modes */
 	int32_t rc_override = 0;
 
@@ -1846,6 +1849,7 @@ int commander_thread_main(int argc, char *argv[])
 			param_get(_param_ef_time_thres, &ef_time_thres);
 			param_get(_param_geofence_action, &geofence_action);
 			param_get(_param_disarm_land, &disarm_when_landed);
+			param_get(_param_flight_uuid, &flight_uuid);
 
 			// If we update parameters the first time
 			// make sure the hysteresis time gets set.
@@ -3040,6 +3044,12 @@ int commander_thread_main(int argc, char *argv[])
 		// check for arming state change
 		if (was_armed != armed.armed) {
 			status_changed = true;
+
+			if (!armed.armed) { // increase the flight uuid upon disarming
+				++flight_uuid;
+				// no need for param notification: the only user is mavlink which reads the param upon request
+				param_set_no_notification(_param_flight_uuid, &flight_uuid);
+			}
 		}
 
 		was_armed = armed.armed;

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -687,3 +687,15 @@ PARAM_DEFINE_INT32(COM_POS_FS_PROB, 30);
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_POS_FS_GAIN, 10);
+
+/**
+ * Next flight UUID
+ *
+ * This number is incremented automatically after every flight on
+ * disarming in order to remember the next flight UUID.
+ * The first flight is 0.
+ *
+ * @group Commander
+ * @min 0
+ */
+PARAM_DEFINE_INT32(COM_FLIGHT_UUID, 0);

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -207,7 +207,6 @@ private:
 	struct vehicle_local_position_s _hil_local_pos;
 	struct vehicle_land_detected_s _hil_land_detector;
 	struct vehicle_control_mode_s _control_mode;
-	struct actuator_armed_s _actuator_armed;
 	orb_advert_t _global_pos_pub;
 	orb_advert_t _local_pos_pub;
 	orb_advert_t _attitude_pub;


### PR DESCRIPTION
The flight information was implemented wrong (https://github.com/PX4/Firmware/pull/7881), it used the board ID as flight ID. This adds a separate flight ID param that is increased on every disarm.