### PR TITLE
Battery Estimation Corrections

### DIFF
--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -367,14 +367,16 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 					batt_sim_start = now;
 				}
 
-				float ibatt = -1.0f;
+				float ibatt = -1.0f; // no current sensor in simulation
+				const float minimum_percentage = 0.5f; // change this value if you want to simulate low battery reaction
 
-				const float battery_time = (now - batt_sim_start) / discharge_interval_us;
-				float vbatt = math::gradual(battery_time, 0.f, 1.f, _battery.full_cell_voltage(), _battery.empty_cell_voltage());
+				/* Simulate the voltage of a linearly draining battery but stop at the minimum percentage */
+				float battery_percentage = (now - batt_sim_start) / discharge_interval_us;
+				battery_percentage = math::min(battery_percentage, minimum_percentage);
+				float vbatt = math::gradual(battery_percentage, 0.f, 1.f, _battery.full_cell_voltage(), _battery.empty_cell_voltage());
 				vbatt *= _battery.cell_count();
 
-				// TODO: don't hard-code throttle.
-				const float throttle = 0.5f;
+				const float throttle = 0.0f; // simulate no throttle compensation to make the estimate predictable
 				_battery.updateBatteryStatus(now, vbatt, ibatt, true, true, 0, throttle, armed, &_battery_status);
 
 				// publish the battery voltage

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -367,20 +367,11 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 					batt_sim_start = now;
 				}
 
-				unsigned cellcount = _battery.cell_count();
-
-				float vbatt = _battery.full_cell_voltage() ;
 				float ibatt = -1.0f;
 
-				float discharge_v = _battery.full_cell_voltage() - _battery.empty_cell_voltage();
-
-				vbatt = (_battery.full_cell_voltage() - (discharge_v * ((now - batt_sim_start) / discharge_interval_us)))  * cellcount;
-
-				float batt_voltage_loaded = _battery.empty_cell_voltage() - 0.05f;
-
-				if (!PX4_ISFINITE(vbatt) || (vbatt < (cellcount * batt_voltage_loaded))) {
-					vbatt = cellcount * batt_voltage_loaded;
-				}
+				const float battery_time = (now - batt_sim_start) / discharge_interval_us;
+				float vbatt = math::gradual(battery_time, 0.f, 1.f, _battery.full_cell_voltage(), _battery.empty_cell_voltage());
+				vbatt *= _battery.cell_count();
 
 				// TODO: don't hard-code throttle.
 				const float throttle = 0.5f;

--- a/src/modules/systemlib/battery.cpp
+++ b/src/modules/systemlib/battery.cpp
@@ -183,18 +183,11 @@ Battery::estimateRemaining(float voltage_v, float current_a, float throttle_norm
 	const float cell_voltage = voltage_v / _n_cells.get();
 	_remaining_voltage = math::gradual(cell_voltage, _v_empty.get(), _v_charged.get(), 0.f, 1.f);
 
-	// remaining battery capacity based on used current integrated time
-	_remaining_capacity = 1.f - _discharged_mah / _capacity.get();
-
-	// limit to sane values
-	_remaining_voltage = (_remaining_voltage < 0.f) ? 0.f : _remaining_voltage;
-	_remaining_voltage = (_remaining_voltage > 1.f) ? 1.f : _remaining_voltage;
-
-	_remaining_capacity = (_remaining_capacity < 0.f) ? 0.f : _remaining_capacity;
-	_remaining_capacity = (_remaining_capacity > 1.f) ? 1.f : _remaining_capacity;
-
 	// choose which quantity we're using for final reporting
 	if (_capacity.get() > 0.f) {
+		// remaining battery capacity based on used current integrated time
+		_remaining_capacity = math::max(1.f - _discharged_mah / _capacity.get(), 0.f);
+
 		// if battery capacity is known, use discharged current for estimate,
 		// but don't show more than voltage estimate
 		_remaining = fminf(_remaining_voltage, _remaining_capacity);

--- a/src/modules/systemlib/battery.cpp
+++ b/src/modules/systemlib/battery.cpp
@@ -58,7 +58,6 @@ Battery::Battery() :
 	_discharged_mah(0.f),
 	_discharged_mah_loop(0.f),
 	_remaining_voltage(1.f),
-	_remaining_capacity(1.f),
 	_remaining(2.f),
 	_scale(1.f),
 	_warning(battery_status_s::BATTERY_WARNING_NONE),
@@ -187,16 +186,16 @@ Battery::estimateRemaining(float voltage_v, float current_a, float throttle_norm
 
 	// choose which quantity we're using for final reporting
 	if (_capacity.get() > 0.f) {
-		// remaining battery capacity based on used current integrated time
-		_remaining_capacity = math::max(1.f - _discharged_mah / _capacity.get(), 0.f);
-
 		// if battery capacity is known, fuse voltage measurement with used capacity
 		if (_remaining > 1.f) {
-			// initialization of the state
+			// initialization of the estimation state
 			_remaining = _remaining_voltage;
 
 		} else {
-			_remaining = 0.9995f * _remaining + 0.0005f * _remaining_voltage;
+			// The lower the voltage the more adjust the estimate with it to avoid deep discharge
+			const float weight_v = 3e-4f * (1 - _remaining_voltage);
+			_remaining = (1 - weight_v) * _remaining + weight_v * _remaining_voltage;
+			// directly apply current capacity slope calculated using current
 			_remaining -= _discharged_mah_loop / _capacity.get();
 			_remaining = math::max(_remaining, 0.f);
 		}

--- a/src/modules/systemlib/battery.cpp
+++ b/src/modules/systemlib/battery.cpp
@@ -156,9 +156,11 @@ Battery::sumDischarged(hrt_abstime timestamp, float current_a)
 		return;
 	}
 
-	// Ignore first update because we don't know dT.
+	// Ignore first update because we don't know dt.
 	if (_last_timestamp != 0) {
-		_discharged_mah += current_a * ((float)(timestamp - _last_timestamp)) / 1e3f / 3600.f;
+		const float dt = (timestamp - _last_timestamp) / 1e6;
+		// current[A] * 1000 = [mA]; dt[s] / 3600 = [h]
+		_discharged_mah += (current_a * 1e3f) * (dt / 3600.f);
 	}
 
 	_last_timestamp = timestamp;

--- a/src/modules/systemlib/battery.cpp
+++ b/src/modules/systemlib/battery.cpp
@@ -59,7 +59,7 @@ Battery::Battery() :
 	_discharged_mah_loop(0.f),
 	_remaining_voltage(1.f),
 	_remaining_capacity(1.f),
-	_remaining(1.f),
+	_remaining(2.f),
 	_scale(1.f),
 	_warning(battery_status_s::BATTERY_WARNING_NONE),
 	_last_timestamp(0)
@@ -191,9 +191,15 @@ Battery::estimateRemaining(float voltage_v, float current_a, float throttle_norm
 		_remaining_capacity = math::max(1.f - _discharged_mah / _capacity.get(), 0.f);
 
 		// if battery capacity is known, fuse voltage measurement with used capacity
-		_remaining = 0.999f * _remaining + 0.001f * _remaining_voltage;
-		_remaining -= _discharged_mah_loop / _capacity.get();
-		_remaining = math::max(_remaining, 0.f);
+		if (_remaining > 1.f) {
+			// initialization of the state
+			_remaining = _remaining_voltage;
+
+		} else {
+			_remaining = 0.9995f * _remaining + 0.0005f * _remaining_voltage;
+			_remaining -= _discharged_mah_loop / _capacity.get();
+			_remaining = math::max(_remaining, 0.f);
+		}
 
 	} else {
 		// else use voltage

--- a/src/modules/systemlib/battery.h
+++ b/src/modules/systemlib/battery.h
@@ -118,7 +118,6 @@ private:
 	float _discharged_mah;
 	float _discharged_mah_loop;
 	float _remaining_voltage;		///< normalized battery charge level remaining based on voltage
-	float _remaining_capacity;		///< normalized battery charge level remaining based on capacity
 	float _remaining;			///< normalized battery charge level, selected based on config param
 	float _scale;
 	uint8_t _warning;

--- a/src/modules/systemlib/battery.h
+++ b/src/modules/systemlib/battery.h
@@ -116,6 +116,7 @@ private:
 	float _voltage_filtered_v;
 	float _current_filtered_a;
 	float _discharged_mah;
+	float _discharged_mah_loop;
 	float _remaining_voltage;		///< normalized battery charge level remaining based on voltage
 	float _remaining_capacity;		///< normalized battery charge level remaining based on capacity
 	float _remaining;			///< normalized battery charge level, selected based on config param

--- a/src/modules/systemlib/battery.h
+++ b/src/modules/systemlib/battery.h
@@ -68,17 +68,17 @@ public:
 	/**
 	 * Get the battery cell count
 	 */
-	int cell_count() { return _param_n_cells.get(); }
+	int cell_count() { return _n_cells.get(); }
 
 	/**
 	 * Get the empty voltage per cell
 	 */
-	float empty_cell_voltage() { return _param_v_empty.get(); }
+	float empty_cell_voltage() { return _v_empty.get(); }
 
 	/**
 	 * Get the full voltage per cell
 	 */
-	float full_cell_voltage() { return _param_v_full.get(); }
+	float full_cell_voltage() { return _v_charged.get(); }
 
 	/**
 	 * Update current battery status message.
@@ -103,15 +103,15 @@ private:
 	void determineWarning(bool connected);
 	void computeScale();
 
-	control::BlockParamFloat _param_v_empty;
-	control::BlockParamFloat _param_v_full;
-	control::BlockParamInt _param_n_cells;
-	control::BlockParamFloat _param_capacity;
-	control::BlockParamFloat _param_v_load_drop;
-	control::BlockParamFloat _param_r_internal;
-	control::BlockParamFloat _param_low_thr;
-	control::BlockParamFloat _param_crit_thr;
-	control::BlockParamFloat _param_emergency_thr;
+	control::BlockParamFloat _v_empty;
+	control::BlockParamFloat _v_charged;
+	control::BlockParamInt _n_cells;
+	control::BlockParamFloat _capacity;
+	control::BlockParamFloat _v_load_drop;
+	control::BlockParamFloat _r_internal;
+	control::BlockParamFloat _low_thr;
+	control::BlockParamFloat _crit_thr;
+	control::BlockParamFloat _emergency_thr;
 
 	float _voltage_filtered_v;
 	float _current_filtered_a;

--- a/src/modules/systemlib/battery_params.c
+++ b/src/modules/systemlib/battery_params.c
@@ -56,7 +56,7 @@
  * @increment 0.01
  * @reboot_required true
  */
-PARAM_DEFINE_FLOAT(BAT_V_EMPTY, 3.4f);
+PARAM_DEFINE_FLOAT(BAT_V_EMPTY, 3.5f);
 
 /**
  * Full cell voltage (5C load)


### PR DESCRIPTION
The battery percentage like it is right now is unpredictable jumping around and far from accurate.

- [x] totally empty battery is not 0%
also this is not really tunable because parameters do not meet invariants
- [x] ~low pass filter for battery state in there does not have time abstraction nor is it tunable~
it's dependent on execution frequency and unpredicatable
- [x] there's no fusion with current integrated to capacity it's just `min(estimate_v, estimate_a)`
- [x] thrust gets used to compensate voltage drop on load linearly
but in reality this relation is not linear but rather quadratic in my experience.
- [x] ~generally known the voltage to remaining capacity function for li-po batteries is non-linear~
**EDIT**: While I was testing I found out that a big part of that nonlinearity comes from the load and can be corrected with the internal resisatnce model for the battery and total current measurements. So still non-linear but less severe.

**EDIT:** Crossed out points are moved to the next improvement step.

Let's change it, that's my take on the problem.

---

I noticed this pr is lacking a clear description for what it does:
- It makes shure the parameters `BAT_V_CHARGED` and `BAT_V_EMPTY` set the voltages where the estimate using the voltage shows 100% or 0% respectively. This is achieved by correcting the voltage measurement **only** internally for the estimation to correct for voltage sag caused by the battery load.
- It assumes the impact of the thrust onto the voltage is quadratic. This depends on the ESCs and sadly the thrust compensation is by far less usable/acurate than the current compensation.
- It kicks out duplicate lowpass filtering of voltage and current.
- It refactors to make the battery estimation more readable with more comments and clearer unit conversions.
- If you have current measurement and battery capacity set it uses a simple fusion algorithm to incorporate voltage and capacity estimation:
Description: On bootup it initially takes the estimate calculated from voltage. While consuming energy it directly reduces the estimate with the integrated current. The voltage estimate gets encorporated with a very strong low pass filter. The lower (emptier) the estimate produced from voltage is, the stronger it gets encorporated to avoid deep discharging in case of wrong parameters or faulty battery.

Here's an example for how it should usually work:
![battery_curve2](https://user-images.githubusercontent.com/4668506/32224455-cb97536a-be41-11e7-861d-9b5ecbbc8e62.PNG)

Here's a theoretical reaction to a battery that would suddenly have a very low voltage (because it's faulty or the initial estimation was wrong or the parameters are not correct):
![battery_curve_faulty](https://user-images.githubusercontent.com/4668506/32224813-314a0332-be43-11e7-8b94-f758b5eebfd0.PNG)
green: capacity based estimation
red: voltage based estimation
blue: resulting estimation from the fusion

