### PR TITLE
EKF2: Improvements to use of non-GPS aiding sources

### DIFF
--- a/msg/vehicle_local_position.msg
+++ b/msg/vehicle_local_position.msg
@@ -55,4 +55,8 @@ float32 epv				# Standard deviation of vertical position error, (metres)
 float32 evh				# Standard deviation of horizontal velocity error, (metres/sec)
 float32 evv				# Standard deviation of horizontal velocity error, (metres/sec)
 
+# estimator specified vehicle limits
+float32 vxy_max				# maximum horizontal speed - set to NaN when not required (metres/sec)
+bool limit_hagl				# true when the height above ground needs to be limited to observe optical flow focus and range finder limits
+
 # TOPICS vehicle_local_position vehicle_local_position_groundtruth vehicle_vision_position

--- a/posix-configs/SITL/init/ekf2/plane
+++ b/posix-configs/SITL/init/ekf2/plane
@@ -33,7 +33,10 @@ param set EKF2_AID_MASK 1
 param set EKF2_ANGERR_INIT 0.01
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_HGT_MODE 0
-param set EKF2_MAG_TYPE 1
+param set EKF2_MAG_TYPE 0
+param set EKF2_FUSE_BETA 1
+param set EKF2_ARSP_THR 10.0
+param set FW_ARSP_MODE 0
 
 param set FW_LND_ANG 8
 param set FW_THR_IDLE 0.15

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -959,6 +959,9 @@ void Ekf2::run()
 			_ekf.get_posNE_reset(&lpos.delta_xy[0], &lpos.xy_reset_counter);
 			_ekf.get_velNE_reset(&lpos.delta_vxy[0], &lpos.vxy_reset_counter);
 
+			// get control limit information
+			_ekf.get_ekf_ctrl_limits(&lpos.vxy_max, &lpos.limit_hagl);
+
 			// publish vehicle local position data
 			_vehicle_local_position_pub.update();
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1404,7 +1404,7 @@ int Ekf2::task_spawn(int argc, char *argv[])
 	_task_id = px4_task_spawn_cmd("ekf2",
 				      SCHED_DEFAULT,
 				      SCHED_PRIORITY_ESTIMATOR,
-				      5720,
+				      5780,
 				      (px4_main_t)&run_trampoline,
 				      (char *const *)argv);
 

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -851,7 +851,9 @@ PARAM_DEFINE_FLOAT(EKF2_EV_POS_Z, 0.0f);
 
 /**
 * Airspeed fusion threshold. A value of zero will deactivate airspeed fusion. Any other positive
-* value will determine the minimum airspeed which will still be fused.
+* value will determine the minimum airspeed which will still be fused. Set to about 90% of the vehicles stall speed.
+* Both airspeed fusion and sideslip fusion must be active for the EKF to continue navigating after loss of GPS.
+* Use EKF2_FUSE_BETA to activate sideslip fusion.
 *
 * @group EKF2
 * @min 0.0
@@ -864,6 +866,8 @@ PARAM_DEFINE_FLOAT(EKF2_ARSP_THR, 0.0f);
 * Boolean determining if synthetic sideslip measurements should fused.
 *
 * A value of 1 indicates that fusion is active
+* Both  sideslip fusion and airspeed fusion must be active for the EKF to continue navigating after loss of GPS.
+* Use EKF2_ARSP_THR to activate airspeed fusion.
 *
 * @group EKF2
 * @boolean

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -684,7 +684,8 @@ PARAM_DEFINE_INT32(EKF2_OF_QMIN, 1);
 PARAM_DEFINE_FLOAT(EKF2_OF_GATE, 3.0f);
 
 /**
- * Optical Flow data will not fused if the magnitude of the flow rate > EKF2_OF_RMAX
+ * Optical Flow data will not fused if the magnitude of the flow rate > EKF2_OF_RMAX.
+ * Control loops will be instructed to limit ground speed such that the flow rate produced by movement over ground is less than 50% of EKF2_OF_RMAX.
  *
  * @group EKF2
  * @min 1.0

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3032,6 +3032,12 @@ MulticopterPositionControl::task_main()
 		/* set default max velocity in xy to vel_max */
 		_vel_max_xy = _params.vel_max_xy;
 
+		/* Apply estimator limits if applicable */
+		if (PX4_ISFINITE(_local_pos.vxy_max)) {
+			_vel_max_xy = fminf(_vel_max_xy , _local_pos.vxy_max);
+			// Allow for a minimum of 0.3 m/s for repositioning
+			_vel_max_xy = fmaxf(_vel_max_xy , 0.3f);
+		}
 
 		/* reset flags when landed */
 		if (_vehicle_land_detected.landed) {

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -438,6 +438,20 @@ PARAM_DEFINE_FLOAT(MPC_ACC_HOR, 5.0f);
 PARAM_DEFINE_FLOAT(MPC_DEC_HOR_SLOW, 5.0f);
 
 /**
+ * Horizontal acceleration in manual modes when optical flow ground speed limit is removed.
+ * If full stick is being applied and the EKF starts using GPS whilst using optical flow,
+ * the vehicle will accelerate at this rate until the normal position control speed is achieved.
+ *
+ * @unit m/s/s
+ * @min 0.2
+ * @max 2.0
+ * @increment 0.1
+ * @decimal 1
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_ACC_HOR_FLOW, 0.5f);
+
+/**
  * Maximum vertical acceleration in velocity controlled modes upward
  *
  * @unit m/s/s

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -928,6 +928,15 @@ PARAM_DEFINE_INT32(SENS_BOARD_ROT, 0);
 PARAM_DEFINE_INT32(SENS_FLOW_ROT, 6);
 
 /**
+ * Optical Flow minimum focus distance
+ *
+ * This parameter defines the minimum distance from ground required for the optical flow sensor to operate reliably. The sensor may be usable below this height, but accuracy will progressively reduce to loss of focus.
+ * *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(SENS_FLOW_MINRNG, 0.7f);
+
+/**
  * Board rotation Y (Pitch) offset
  *
  * This parameter defines a rotational offset in degrees around the Y (Pitch) axis. It allows the user


### PR DESCRIPTION
Requires https://github.com/PX4/ecl/pull/339 to be merged first.

Adds the following capabilities:

1) When navigation is totally reliant on optical flow data, vehicle ground speed is limited in position control modes to respect flow sensor limits.

2) When navigation is totally reliant on optical flow data and the vehicle is in a manual height control mode, the vertical position and velocity set-point is biased if the vehicle is below the flow sensor minimum focal distance to discourage continuous operation below the sensors minimum effective height.

3) Allows for simultaneous use of  intermittent GPS and optical flow provided one or both are working at the same time.

4) Loss of GPS logic in the EKF has been improved so that provided both sideslip and airspeed fusion are active, the EKF can continue to navigate after total loss of GPS. The navigator failsafe logic prevents FW auto modes taking advantage of this, but an operator can now select altitude mode following total GPS loss and fly back to the recovery area using the GCS map and AHRS displays if required.