### PR TITLE
Type-safety for param_get()

### DIFF
--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -73,7 +73,7 @@
 
 extern "C" __EXPORT int camera_trigger_main(int argc, char *argv[]);
 
-typedef enum : uint8_t {
+typedef enum : int32_t {
 	CAMERA_INTERFACE_MODE_NONE = 0,
 	CAMERA_INTERFACE_MODE_GPIO,
 	CAMERA_INTERFACE_MODE_SEAGULL_MAP2_PWM,
@@ -81,7 +81,7 @@ typedef enum : uint8_t {
 	CAMERA_INTERFACE_MODE_GENERIC_PWM
 } camera_interface_mode_t;
 
-typedef enum : uint8_t {
+typedef enum : int32_t {
 	TRIGGER_MODE_NONE = 0,
 	TRIGGER_MODE_INTERVAL_ON_CMD,
 	TRIGGER_MODE_INTERVAL_ALWAYS_ON,
@@ -273,8 +273,8 @@ CameraTrigger::CameraTrigger() :
 	param_get(_p_activation_time, &_activation_time);
 	param_get(_p_interval, &_interval);
 	param_get(_p_distance, &_distance);
-	param_get(_p_mode, &_trigger_mode);
-	param_get(_p_interface, &_camera_interface_mode);
+	param_get(_p_mode, (int32_t *)&_trigger_mode);
+	param_get(_p_interface, (int32_t *)&_camera_interface_mode);
 
 	switch (_camera_interface_mode) {
 #ifdef __PX4_NUTTX

--- a/src/modules/camera_feedback/camera_feedback.cpp
+++ b/src/modules/camera_feedback/camera_feedback.cpp
@@ -59,7 +59,7 @@ CameraFeedback::CameraFeedback() :
 	// Parameters
 	_p_feedback = param_find("CAM_FBACK_MODE");
 
-	param_get(_p_feedback, &_camera_feedback_mode);
+	param_get(_p_feedback, (int32_t *)&_camera_feedback_mode);
 
 }
 

--- a/src/modules/camera_feedback/camera_feedback.hpp
+++ b/src/modules/camera_feedback/camera_feedback.hpp
@@ -62,7 +62,7 @@
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_global_position.h>
 
-typedef enum : uint8_t {
+typedef enum : int32_t {
 	CAMERA_FEEDBACK_MODE_NONE = 0,
 	CAMERA_FEEDBACK_MODE_TRIGGER,
 	CAMERA_FEEDBACK_MODE_PWM

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -103,7 +103,7 @@ static int check_calibration(DevHandle &h, const char *param_template, int &devi
 		}
 
 		/* if param get succeeds */
-		int calibration_devid;
+		int32_t calibration_devid;
 
 		if (!param_get(parm, &(calibration_devid))) {
 

--- a/src/modules/commander/arm_auth.cpp
+++ b/src/modules/commander/arm_auth.cpp
@@ -181,7 +181,7 @@ uint8_t arm_auth_check()
 
 void arm_auth_update(hrt_abstime now)
 {
-	param_get(param_arm_parameters, &arm_parameters);
+	param_get(param_arm_parameters, (int32_t*)&arm_parameters);
 
 	switch (state) {
 	case ARM_AUTH_WAITING_AUTH:

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1681,7 +1681,9 @@ int commander_thread_main(int argc, char *argv[])
 	thread_running = true;
 
 	/* update vehicle status to find out vehicle type (required for preflight checks) */
-	param_get(_param_sys_type, &(status.system_type)); // get system type
+	int32_t system_type;
+	param_get(_param_sys_type, &system_type); // get system type
+	status.system_type = (uint8_t)system_type;
 	status.is_rotary_wing = is_rotary_wing(&status) || is_vtol(&status);
 	status.is_vtol = is_vtol(&status);
 
@@ -1801,8 +1803,10 @@ int commander_thread_main(int argc, char *argv[])
 
 			/* update parameters */
 			if (!armed.armed) {
-				if (param_get(_param_sys_type, &(status.system_type)) != OK) {
-					warnx("failed getting new system type");
+				if (param_get(_param_sys_type, &system_type) != OK) {
+					PX4_ERR("failed getting new system type");
+				} else {
+					status.system_type = (uint8_t)system_type;
 				}
 
 				/* disable manual override for all systems that rely on electronic stabilization */

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1754,9 +1754,9 @@ int commander_thread_main(int argc, char *argv[])
 
 
 	/* Thresholds for engine failure detection */
-	int32_t ef_throttle_thres = 1.0f;
-	int32_t ef_current2throttle_thres = 0.0f;
-	int32_t ef_time_thres = 1000.0f;
+	float ef_throttle_thres = 1.0f;
+	float ef_current2throttle_thres = 0.0f;
+	float ef_time_thres = 1000.0f;
 	uint64_t timestamp_engine_healthy = 0; /**< absolute time when engine was healty */
 
 	int32_t disarm_when_landed = 0;
@@ -2918,7 +2918,7 @@ int commander_thread_main(int argc, char *argv[])
 				/* potential failure, measure time */
 				if (timestamp_engine_healthy > 0 &&
 				    hrt_elapsed_time(&timestamp_engine_healthy) >
-				    ef_time_thres * 1e6 &&
+				    ef_time_thres * 1e6f &&
 				    !status.engine_failure) {
 					status.engine_failure = true;
 					status_changed = true;

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -182,9 +182,6 @@ static orb_advert_t mavlink_log_pub = nullptr;
 
 static orb_advert_t power_button_state_pub = nullptr;
 
-/* System autostart ID */
-static int autostart_id;
-
 /* flags */
 static bool commander_initialized = false;
 static volatile bool thread_should_exit = false;	/**< daemon exit flag */
@@ -1322,7 +1319,6 @@ int commander_thread_main(int argc, char *argv[])
 	param_t _param_ef_throttle_thres = param_find("COM_EF_THROT");
 	param_t _param_ef_current2throttle_thres = param_find("COM_EF_C2T");
 	param_t _param_ef_time_thres = param_find("COM_EF_TIME");
-	param_t _param_autostart_id = param_find("SYS_AUTOSTART");
 	param_t _param_rc_in_off = param_find("COM_RC_IN_MODE");
 	param_t _param_rc_arm_hyst = param_find("COM_RC_ARM_HYST");
 	param_t _param_min_stick_change = param_find("COM_RC_STICK_OV");
@@ -1701,7 +1697,6 @@ int commander_thread_main(int argc, char *argv[])
 	int32_t rc_in_off = 0;
 	bool hotplug_timeout = hrt_elapsed_time(&commander_boot_timestamp) > HOTPLUG_SENS_TIMEOUT;
 
-	param_get(_param_autostart_id, &autostart_id);
 	param_get(_param_rc_in_off, &rc_in_off);
 
 	int32_t arm_switch_is_button = 0;
@@ -1874,9 +1869,6 @@ int commander_thread_main(int argc, char *argv[])
 			arm_requirements = (arm_without_gps_param == 1) ? ARM_REQ_NONE : ARM_REQ_GPS_BIT;
 			param_get(_param_arm_mission_required, &arm_mission_required_param);
 			arm_requirements |= (arm_mission_required_param & (ARM_REQ_MISSION_BIT | ARM_REQ_ARM_AUTH_BIT));
-
-			/* Autostart id */
-			param_get(_param_autostart_id, &autostart_id);
 
 			/* EPH / EPV */
 			param_get(_param_eph, &eph_threshold);

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -531,7 +531,7 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 
 	// Collect: As defined by configuration
 	// start with a full mask, all six bits set
-	uint32_t cal_mask = (1 << 6) - 1;
+	int32_t cal_mask = (1 << 6) - 1;
 	param_get(param_find("CAL_MAG_SIDES"), &cal_mask);
 
 	calibration_sides = 0;

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -169,9 +169,9 @@ void LandDetector::_check_params(const bool force)
 	if (updated || force) {
 		_update_params();
 		uint32_t flight_time;
-		param_get(_p_total_flight_time_high, &flight_time);
+		param_get(_p_total_flight_time_high, (int32_t *)&flight_time);
 		_total_flight_time = ((uint64_t)flight_time) << 32;
-		param_get(_p_total_flight_time_low, &flight_time);
+		param_get(_p_total_flight_time_low, (int32_t *)&flight_time);
 		_total_flight_time |= flight_time;
 	}
 }

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -787,7 +787,7 @@ void Logger::run()
 		SDLogProfileMask sdlog_profile = SDLogProfileMask::DEFAULT;
 
 		if (_sdlog_profile_handle != PARAM_INVALID) {
-			param_get(_sdlog_profile_handle, &sdlog_profile);
+			param_get(_sdlog_profile_handle, (int32_t*)&sdlog_profile);
 		}
 		if ((int32_t)sdlog_profile == 0) {
 			PX4_WARN("No logging profile selected. Using default set");
@@ -1797,7 +1797,7 @@ void Logger::write_version()
 	param_t write_uuid_param = param_find("SDLOG_UUID");
 
 	if (write_uuid_param != PARAM_INVALID) {
-		uint32_t write_uuid;
+		int32_t write_uuid;
 		param_get(write_uuid_param, &write_uuid);
 
 		if (write_uuid == 1) {
@@ -1864,7 +1864,18 @@ void Logger::write_parameters()
 			size_t msg_size = sizeof(msg) - sizeof(msg.key) + msg.key_len;
 
 			/* copy parameter value directly to buffer */
-			param_get(param, &buffer[msg_size]);
+			switch (type) {
+			case PARAM_TYPE_INT32:
+				param_get(param, (int32_t*)&buffer[msg_size]);
+				break;
+
+			case PARAM_TYPE_FLOAT:
+				param_get(param, (float*)&buffer[msg_size]);
+				break;
+
+			default:
+				continue;
+			}
 			msg_size += value_size;
 
 			msg.msg_size = msg_size - ULOG_MSG_HEADER_LEN;
@@ -1922,7 +1933,18 @@ void Logger::write_changed_parameters()
 			size_t msg_size = sizeof(msg) - sizeof(msg.key) + msg.key_len;
 
 			/* copy parameter value directly to buffer */
-			param_get(param, &buffer[msg_size]);
+			switch (type) {
+			case PARAM_TYPE_INT32:
+				param_get(param, (int32_t*)&buffer[msg_size]);
+				break;
+
+			case PARAM_TYPE_FLOAT:
+				param_get(param, (float*)&buffer[msg_size]);
+				break;
+
+			default:
+				continue;
+			}
 			msg_size += value_size;
 
 			/* msg_size is now 1 (msg_type) + 2 (msg_size) + 1 (key_len) + key_len + value_size */

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -593,7 +593,7 @@ private:
 	pthread_mutex_t		_send_mutex;
 
 	bool			_param_initialized;
-	uint32_t		_broadcast_mode;
+	int32_t			_broadcast_mode;
 
 	param_t			_param_system_id;
 	param_t			_param_component_id;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -668,8 +668,9 @@ MavlinkReceiver::handle_message_optical_flow_rad(mavlink_message_t *msg)
 	mavlink_optical_flow_rad_t flow;
 	mavlink_msg_optical_flow_rad_decode(msg, &flow);
 
-	enum Rotation flow_rot;
-	param_get(param_find("SENS_FLOW_ROT"), &flow_rot);
+	int32_t flow_rot_int;
+	param_get(param_find("SENS_FLOW_ROT"), &flow_rot_int);
+	const enum Rotation flow_rot = (Rotation)flow_rot_int;
 
 	struct optical_flow_s f = {};
 

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -261,13 +261,13 @@ private:
 		float acro_superexpo;				/**< function parameter for superexpo stick curve shape */
 		float rattitude_thres;
 
-		int32_t vtol_type;						/**< 0 = Tailsitter, 1 = Tiltrotor, 2 = Standard airframe */
+		int32_t vtol_type;					/**< 0 = Tailsitter, 1 = Tiltrotor, 2 = Standard airframe */
 		bool vtol_opt_recovery_enabled;
 		float vtol_wv_yaw_rate_scale;			/**< Scale value [0, 1] for yaw rate setpoint  */
 
-		int bat_scale_en;
+		int32_t bat_scale_en;
 
-		int board_rotation;
+		int32_t board_rotation;
 
 		float board_offset[3];
 

--- a/src/modules/sensors/parameters.h
+++ b/src/modules/sensors/parameters.h
@@ -66,40 +66,40 @@ struct Parameters {
 	float diff_pres_offset_pa;
 	float diff_pres_analog_scale;
 
-	int board_rotation;
+	int32_t board_rotation;
 
 	float board_offset[3];
 
-	int rc_map_roll;
-	int rc_map_pitch;
-	int rc_map_yaw;
-	int rc_map_throttle;
-	int rc_map_failsafe;
+	int32_t rc_map_roll;
+	int32_t rc_map_pitch;
+	int32_t rc_map_yaw;
+	int32_t rc_map_throttle;
+	int32_t rc_map_failsafe;
 
-	int rc_map_mode_sw;
-	int rc_map_return_sw;
-	int rc_map_rattitude_sw;
-	int rc_map_posctl_sw;
-	int rc_map_loiter_sw;
-	int rc_map_acro_sw;
-	int rc_map_offboard_sw;
-	int rc_map_kill_sw;
-	int rc_map_arm_sw;
-	int rc_map_trans_sw;
-	int rc_map_gear_sw;
-	int rc_map_stab_sw;
-	int rc_map_man_sw;
-	int rc_map_flaps;
+	int32_t rc_map_mode_sw;
+	int32_t rc_map_return_sw;
+	int32_t rc_map_rattitude_sw;
+	int32_t rc_map_posctl_sw;
+	int32_t rc_map_loiter_sw;
+	int32_t rc_map_acro_sw;
+	int32_t rc_map_offboard_sw;
+	int32_t rc_map_kill_sw;
+	int32_t rc_map_arm_sw;
+	int32_t rc_map_trans_sw;
+	int32_t rc_map_gear_sw;
+	int32_t rc_map_stab_sw;
+	int32_t rc_map_man_sw;
+	int32_t rc_map_flaps;
 
-	int rc_map_aux1;
-	int rc_map_aux2;
-	int rc_map_aux3;
-	int rc_map_aux4;
-	int rc_map_aux5;
+	int32_t rc_map_aux1;
+	int32_t rc_map_aux2;
+	int32_t rc_map_aux3;
+	int32_t rc_map_aux4;
+	int32_t rc_map_aux5;
 
-	int rc_map_param[rc_parameter_map_s::RC_PARAM_MAP_NCHAN];
+	int32_t rc_map_param[rc_parameter_map_s::RC_PARAM_MAP_NCHAN];
 
-	int rc_map_flightmode;
+	int32_t rc_map_flightmode;
 
 	int32_t rc_fails_thr;
 	float rc_assist_th;

--- a/src/modules/sensors/temperature_compensation.h
+++ b/src/modules/sensors/temperature_compensation.h
@@ -118,7 +118,7 @@ private:
 
 	*/
 	struct SensorCalData1D {
-		int ID;
+		int32_t ID;
 		float x5;
 		float x4;
 		float x3;
@@ -162,7 +162,7 @@ private:
 
 	 */
 	struct SensorCalData3D {
-		int ID;			/**< sensor device ID*/
+		int32_t ID;		/**< sensor device ID*/
 		float x3[3];		/**< x^3 term of polynomial */
 		float x2[3];		/**< x^2 term of polynomial */
 		float x1[3];		/**< x^1 term of polynomial */
@@ -187,11 +187,11 @@ private:
 
 	// create a struct containing all thermal calibration parameters
 	struct Parameters {
-		int gyro_tc_enable;
+		int32_t gyro_tc_enable;
 		SensorCalData3D gyro_cal_data[GYRO_COUNT_MAX];
-		int accel_tc_enable;
+		int32_t accel_tc_enable;
 		SensorCalData3D accel_cal_data[ACCEL_COUNT_MAX];
-		int baro_tc_enable;
+		int32_t baro_tc_enable;
 		SensorCalData1D baro_cal_data[BARO_COUNT_MAX];
 	};
 

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -1106,8 +1106,9 @@ int Simulator::publish_flow_topic(mavlink_hil_optical_flow_t *flow_mavlink)
 	flow.quality = flow_mavlink->quality;
 
 	/* rotate measurements according to parameter */
-	enum Rotation flow_rot;
-	param_get(param_find("SENS_FLOW_ROT"), &flow_rot);
+	int32_t flow_rot_int;
+	param_get(param_find("SENS_FLOW_ROT"), &flow_rot_int);
+	const enum Rotation flow_rot = (Rotation)flow_rot_int;
 
 	float zeroval = 0.0f;
 	rotate_3f(flow_rot, flow.pixel_flow_x_integral, flow.pixel_flow_y_integral, zeroval);

--- a/src/modules/syslink/syslink_main.cpp
+++ b/src/modules/syslink/syslink_main.cpp
@@ -190,7 +190,7 @@ Syslink::update_params(bool force_set)
 
 	// reading parameter values into temp variables
 
-	uint32_t channel, rate, addr1, addr2;
+	int32_t channel, rate, addr1, addr2;
 	uint64_t addr = 0;
 
 	param_get(_param_radio_channel, &channel);
@@ -198,7 +198,8 @@ Syslink::update_params(bool force_set)
 	param_get(_param_radio_addr1, &addr1);
 	param_get(_param_radio_addr2, &addr2);
 
-	memcpy(&addr, &addr2, 4); memcpy(((char *)&addr) + 4, &addr1, 4);
+	memcpy(&addr, &addr2, 4);
+	memcpy(((char *)&addr) + 4, &addr1, 4);
 
 
 	hrt_abstime t = hrt_absolute_time();

--- a/src/modules/syslink/syslink_main.h
+++ b/src/modules/syslink/syslink_main.h
@@ -127,7 +127,7 @@ private:
 	int _params_sub;
 
 	// Current parameter values
-	uint32_t _channel, _rate;
+	int32_t _channel, _rate;
 	uint64_t _addr;
 	hrt_abstime _params_update[3]; // Time at which the parameters were updated
 	hrt_abstime _params_ack[3]; // Time at which the parameters were acknowledged by the nrf module

--- a/src/modules/systemlib/param/param.h
+++ b/src/modules/systemlib/param/param.h
@@ -451,4 +451,35 @@ struct param_info_s {
 
 __END_DECLS
 
+
+
+#ifdef	__cplusplus
+#if 0 // set to 1 to debug param type mismatches
+#include <cstdio>
+#define CHECK_PARAM_TYPE(param, type) \
+	if (param_type(param) != type) { \
+		/* use printf() to avoid having to use more includes */ \
+		printf("wrong type passed to param_get() for param %s\n", param_name(param)); \
+	}
+#else
+#define CHECK_PARAM_TYPE(param, type)
+#endif
+
+// param is a C-interface. This means there is no overloading, and thus no type-safety for param_get().
+// So for C++ code we redefine param_get() to inlined overloaded versions, which gives us type-safety
+// w/o having to use a different interface
+static inline int param_get_cplusplus(param_t param, float *val)
+{
+	CHECK_PARAM_TYPE(param, PARAM_TYPE_FLOAT);
+	return param_get(param, val);
+}
+static inline int param_get_cplusplus(param_t param, int32_t *val)
+{
+	CHECK_PARAM_TYPE(param, PARAM_TYPE_INT32);
+	return param_get(param, val);
+}
+#define param_get(param, val) param_get_cplusplus(param, val)
+
+#endif /* __cplusplus */
+
 #endif

--- a/src/modules/systemlib/param/param.h
+++ b/src/modules/systemlib/param/param.h
@@ -478,6 +478,8 @@ static inline int param_get_cplusplus(param_t param, int32_t *val)
 	CHECK_PARAM_TYPE(param, PARAM_TYPE_INT32);
 	return param_get(param, val);
 }
+#undef CHECK_PARAM_TYPE
+
 #define param_get(param, val) param_get_cplusplus(param, val)
 
 #endif /* __cplusplus */


### PR DESCRIPTION
I found a surprisingly simple way to bring type-safety to `param_get` without runtime overhead: just by redefining & overloading the method when included in C++ code.

There were several wrong usages, and the one in https://github.com/PX4/Firmware/issues/8178 showed up as well.