### PR TITLE
px4fmu-v2_default add sf1xx driver

### DIFF
--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -23,6 +23,7 @@ set(config_module_list
 	#drivers/mb12xx
 	#drivers/srf02
 	drivers/sf0x
+	drivers/sf1xx
 	drivers/ll40ls
 	drivers/teraranger
 	drivers/gps


### PR DESCRIPTION
 - closes #8177