### PR TITLE
sensor priority after failure and EKF2 bias reset

### DIFF
--- a/src/modules/commander/gyro_calibration.cpp
+++ b/src/modules/commander/gyro_calibration.cpp
@@ -499,13 +499,6 @@ int do_gyro_calibration(orb_advert_t *mavlink_log_pub)
 		}
 	}
 
-	/* store board ID */
-	uuid_uint32_t mcu_id;
-	board_get_uuid32(mcu_id);
-
-	/* store last 32bit number - not unique, but unique in a given set */
-	(void)param_set(param_find("CAL_BOARD_ID"), &mcu_id[PX4_CPU_UUID_WORD32_UNIQUE_H]);
-
 	/* if there is a any preflight-check system response, let the barrage of messages through */
 	usleep(200000);
 

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -32,775 +32,6 @@
  ****************************************************************************/
 
 /**
- * @file sensor_params.c
- *
- * Parameters defined by the sensors task.
- *
- * @author Lorenz Meier <lorenz@px4.io>
- * @author Julian Oes <julian@px4.io>
- * @author Thomas Gubler <thomas@px4.io>
- */
-
-/**
- * ID of the Gyro that the calibration is for.
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_GYRO0_ID, 0);
-
-/**
- * Gyro X-axis offset
- *
- * @min -10.0
- * @max 10.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_GYRO0_XOFF, 0.0f);
-
-/**
- * Gyro Y-axis offset
- *
- * @min -10.0
- * @max 10.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_GYRO0_YOFF, 0.0f);
-
-/**
- * Gyro Z-axis offset
- *
- * @min -5.0
- * @max 5.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_GYRO0_ZOFF, 0.0f);
-
-/**
- * Gyro X-axis scaling factor
- *
- * @min -1.5
- * @max 1.5
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_GYRO0_XSCALE, 1.0f);
-
-/**
- * Gyro Y-axis scaling factor
- *
- * @min -1.5
- * @max 1.5
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_GYRO0_YSCALE, 1.0f);
-
-/**
- * Gyro Z-axis scaling factor
- *
- * @min -1.5
- * @max 1.5
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_GYRO0_ZSCALE, 1.0f);
-
-/**
- * ID of Magnetometer the calibration is for.
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_MAG0_ID, 0);
-
-/**
- * Rotation of magnetometer 0 relative to airframe.
- *
- * An internal magnetometer will force a value of -1, so a GCS
- * should only attempt to configure the rotation if the value is
- * greater than or equal to zero.
- *
- * @value -1 Internal mag
- * @value 0 No rotation
- * @value 1 Yaw 45°
- * @value 2 Yaw 90°
- * @value 3 Yaw 135°
- * @value 4 Yaw 180°
- * @value 5 Yaw 225°
- * @value 6 Yaw 270°
- * @value 7 Yaw 315°
- * @value 8 Roll 180°
- * @value 9 Roll 180°, Yaw 45°
- * @value 10 Roll 180°, Yaw 90°
- * @value 11 Roll 180°, Yaw 135°
- * @value 12 Pitch 180°
- * @value 13 Roll 180°, Yaw 225°
- * @value 14 Roll 180°, Yaw 270°
- * @value 15 Roll 180°, Yaw 315°
- * @value 16 Roll 90°
- * @value 17 Roll 90°, Yaw 45°
- * @value 18 Roll 90°, Yaw 90°
- * @value 19 Roll 90°, Yaw 135°
- * @value 20 Roll 270°
- * @value 21 Roll 270°, Yaw 45°
- * @value 22 Roll 270°, Yaw 90°
- * @value 23 Roll 270°, Yaw 135°
- * @value 24 Pitch 90°
- * @value 25 Pitch 270°
- *
- * @min -1
- * @max 30
- * @reboot_required true
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_MAG0_ROT, -1);
-
-/**
- * Magnetometer X-axis offset
- *
- * @min -500.0
- * @max 500.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG0_XOFF, 0.0f);
-
-/**
- * Magnetometer Y-axis offset
- *
- * @min -500.0
- * @max 500.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG0_YOFF, 0.0f);
-
-/**
- * Magnetometer Z-axis offset
- *
- * @min -500.0
- * @max 500.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG0_ZOFF, 0.0f);
-
-/**
- * Magnetometer X-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG0_XSCALE, 1.0f);
-
-/**
- * Magnetometer Y-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG0_YSCALE, 1.0f);
-
-/**
- * Magnetometer Z-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG0_ZSCALE, 1.0f);
-
-/**
- * ID of the Accelerometer that the calibration is for.
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_ACC0_ID, 0);
-
-/**
- * Accelerometer X-axis offset
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_ACC0_XOFF, 0.0f);
-
-/**
- * Accelerometer Y-axis offset
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_ACC0_YOFF, 0.0f);
-
-/**
- * Accelerometer Z-axis offset
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_ACC0_ZOFF, 0.0f);
-
-/**
- * Accelerometer X-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_ACC0_XSCALE, 1.0f);
-
-/**
- * Accelerometer Y-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_ACC0_YSCALE, 1.0f);
-
-/**
- * Accelerometer Z-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_ACC0_ZSCALE, 1.0f);
-
-/**
- * ID of the Gyro that the calibration is for.
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_GYRO1_ID, 0);
-
-/**
- * Gyro X-axis offset
- *
- * @min -10.0
- * @max 10.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_GYRO1_XOFF, 0.0f);
-
-/**
- * Gyro Y-axis offset
- *
- * @min -10.0
- * @max 10.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_GYRO1_YOFF, 0.0f);
-
-/**
- * Gyro Z-axis offset
- *
- * @min -5.0
- * @max 5.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_GYRO1_ZOFF, 0.0f);
-
-/**
- * Gyro X-axis scaling factor
- *
- * @min -1.5
- * @max 1.5
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_GYRO1_XSCALE, 1.0f);
-
-/**
- * Gyro Y-axis scaling factor
- *
- * @min -1.5
- * @max 1.5
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_GYRO1_YSCALE, 1.0f);
-
-/**
- * Gyro Z-axis scaling factor
- *
- * @min -1.5
- * @max 1.5
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_GYRO1_ZSCALE, 1.0f);
-
-/**
- * ID of Magnetometer the calibration is for.
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_MAG1_ID, 0);
-
-/**
- * Rotation of magnetometer 1 relative to airframe.
- *
- * An internal magnetometer will force a value of -1, so a GCS
- * should only attempt to configure the rotation if the value is
- * greater than or equal to zero.
- *
- * @value -1 Internal mag
- * @value 0 No rotation
- * @value 1 Yaw 45°
- * @value 2 Yaw 90°
- * @value 3 Yaw 135°
- * @value 4 Yaw 180°
- * @value 5 Yaw 225°
- * @value 6 Yaw 270°
- * @value 7 Yaw 315°
- * @value 8 Roll 180°
- * @value 9 Roll 180°, Yaw 45°
- * @value 10 Roll 180°, Yaw 90°
- * @value 11 Roll 180°, Yaw 135°
- * @value 12 Pitch 180°
- * @value 13 Roll 180°, Yaw 225°
- * @value 14 Roll 180°, Yaw 270°
- * @value 15 Roll 180°, Yaw 315°
- * @value 16 Roll 90°
- * @value 17 Roll 90°, Yaw 45°
- * @value 18 Roll 90°, Yaw 90°
- * @value 19 Roll 90°, Yaw 135°
- * @value 20 Roll 270°
- * @value 21 Roll 270°, Yaw 45°
- * @value 22 Roll 270°, Yaw 90°
- * @value 23 Roll 270°, Yaw 135°
- * @value 24 Pitch 90°
- * @value 25 Pitch 270°
- *
- * @min -1
- * @max 30
- * @reboot_required true
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_MAG1_ROT, -1);
-
-/**
- * Magnetometer X-axis offset
- *
- * @min -500.0
- * @max 500.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG1_XOFF, 0.0f);
-
-/**
- * Magnetometer Y-axis offset
- *
- * @min -500.0
- * @max 500.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG1_YOFF, 0.0f);
-
-/**
- * Magnetometer Z-axis offset
- *
- * @min -500.0
- * @max 500.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG1_ZOFF, 0.0f);
-
-/**
- * Magnetometer X-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG1_XSCALE, 1.0f);
-
-/**
- * Magnetometer Y-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG1_YSCALE, 1.0f);
-
-/**
- * Magnetometer Z-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG1_ZSCALE, 1.0f);
-
-/**
- * ID of the Accelerometer that the calibration is for.
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_ACC1_ID, 0);
-
-/**
- * Accelerometer X-axis offset
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_ACC1_XOFF, 0.0f);
-
-/**
- * Accelerometer Y-axis offset
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_ACC1_YOFF, 0.0f);
-
-/**
- * Accelerometer Z-axis offset
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_ACC1_ZOFF, 0.0f);
-
-/**
- * Accelerometer X-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_ACC1_XSCALE, 1.0f);
-
-/**
- * Accelerometer Y-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_ACC1_YSCALE, 1.0f);
-
-/**
- * Accelerometer Z-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_ACC1_ZSCALE, 1.0f);
-
-/**
- * ID of the Gyro that the calibration is for.
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_GYRO2_ID, 0);
-
-/**
- * Gyro X-axis offset
- *
- * @min -10.0
- * @max 10.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_GYRO2_XOFF, 0.0f);
-
-/**
- * Gyro Y-axis offset
- *
- * @min -10.0
- * @max 10.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_GYRO2_YOFF, 0.0f);
-
-/**
- * Gyro Z-axis offset
- *
- * @min -5.0
- * @max 5.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_GYRO2_ZOFF, 0.0f);
-
-/**
- * Gyro X-axis scaling factor
- *
- * @min -1.5
- * @max 1.5
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_GYRO2_XSCALE, 1.0f);
-
-/**
- * Gyro Y-axis scaling factor
- *
- * @min -1.5
- * @max 1.5
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_GYRO2_YSCALE, 1.0f);
-
-/**
- * Gyro Z-axis scaling factor
- *
- * @min -1.5
- * @max 1.5
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_GYRO2_ZSCALE, 1.0f);
-
-/**
- * ID of Magnetometer the calibration is for.
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_MAG2_ID, 0);
-
-/**
- * Rotation of magnetometer 2 relative to airframe.
- *
- * An internal magnetometer will force a value of -1, so a GCS
- * should only attempt to configure the rotation if the value is
- * greater than or equal to zero.
- *
- * @value -1 Internal mag
- * @value 0 No rotation
- * @value 1 Yaw 45°
- * @value 2 Yaw 90°
- * @value 3 Yaw 135°
- * @value 4 Yaw 180°
- * @value 5 Yaw 225°
- * @value 6 Yaw 270°
- * @value 7 Yaw 315°
- * @value 8 Roll 180°
- * @value 9 Roll 180°, Yaw 45°
- * @value 10 Roll 180°, Yaw 90°
- * @value 11 Roll 180°, Yaw 135°
- * @value 12 Pitch 180°
- * @value 13 Roll 180°, Yaw 225°
- * @value 14 Roll 180°, Yaw 270°
- * @value 15 Roll 180°, Yaw 315°
- * @value 16 Roll 90°
- * @value 17 Roll 90°, Yaw 45°
- * @value 18 Roll 90°, Yaw 90°
- * @value 19 Roll 90°, Yaw 135°
- * @value 20 Roll 270°
- * @value 21 Roll 270°, Yaw 45°
- * @value 22 Roll 270°, Yaw 90°
- * @value 23 Roll 270°, Yaw 135°
- * @value 24 Pitch 90°
- * @value 25 Pitch 270°
- *
- * @min -1
- * @max 30
- * @reboot_required true
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_MAG2_ROT, -1);
-
-/**
- * Magnetometer X-axis offset
- *
- * @min -500.0
- * @max 500.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG2_XOFF, 0.0f);
-
-/**
- * Magnetometer Y-axis offset
- *
- * @min -500.0
- * @max 500.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG2_YOFF, 0.0f);
-
-/**
- * Magnetometer Z-axis offset
- *
- * @min -500.0
- * @max 500.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG2_ZOFF, 0.0f);
-
-/**
- * Magnetometer X-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG2_XSCALE, 1.0f);
-
-/**
- * Magnetometer Y-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG2_YSCALE, 1.0f);
-
-/**
- * Magnetometer Z-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG2_ZSCALE, 1.0f);
-
-/**
- * ID of the Accelerometer that the calibration is for.
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_ACC2_ID, 0);
-
-/**
- * Accelerometer X-axis offset
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_ACC2_XOFF, 0.0f);
-
-/**
- * Accelerometer Y-axis offset
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_ACC2_YOFF, 0.0f);
-
-/**
- * Accelerometer Z-axis offset
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_ACC2_ZOFF, 0.0f);
-
-/**
- * Accelerometer X-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_ACC2_XSCALE, 1.0f);
-
-/**
- * Accelerometer Y-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_ACC2_YSCALE, 1.0f);
-
-/**
- * Accelerometer Z-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_ACC2_ZSCALE, 1.0f);
-
-/**
- * ID of Magnetometer the calibration is for.
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_MAG3_ID, 0);
-
-/**
- * Rotation of magnetometer 2 relative to airframe.
- *
- * An internal magnetometer will force a value of -1, so a GCS
- * should only attempt to configure the rotation if the value is
- * greater than or equal to zero.
- *
- * @value -1 Internal mag
- * @value 0 No rotation
- * @value 1 Yaw 45°
- * @value 2 Yaw 90°
- * @value 3 Yaw 135°
- * @value 4 Yaw 180°
- * @value 5 Yaw 225°
- * @value 6 Yaw 270°
- * @value 7 Yaw 315°
- * @value 8 Roll 180°
- * @value 9 Roll 180°, Yaw 45°
- * @value 10 Roll 180°, Yaw 90°
- * @value 11 Roll 180°, Yaw 135°
- * @value 12 Pitch 180°
- * @value 13 Roll 180°, Yaw 225°
- * @value 14 Roll 180°, Yaw 270°
- * @value 15 Roll 180°, Yaw 315°
- * @value 16 Roll 90°
- * @value 17 Roll 90°, Yaw 45°
- * @value 18 Roll 90°, Yaw 90°
- * @value 19 Roll 90°, Yaw 135°
- * @value 20 Roll 270°
- * @value 21 Roll 270°, Yaw 45°
- * @value 22 Roll 270°, Yaw 90°
- * @value 23 Roll 270°, Yaw 135°
- * @value 24 Pitch 90°
- * @value 25 Pitch 270°
- *
- * @min -1
- * @max 30
- * @reboot_required true
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_MAG3_ROT, -1);
-
-/**
- * Magnetometer X-axis offset
- *
- * @min -500.0
- * @max 500.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG3_XOFF, 0.0f);
-
-/**
- * Magnetometer Y-axis offset
- *
- * @min -500.0
- * @max 500.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG3_YOFF, 0.0f);
-
-/**
- * Magnetometer Z-axis offset
- *
- * @min -500.0
- * @max 500.0
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG3_ZOFF, 0.0f);
-
-/**
- * Magnetometer X-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG3_XSCALE, 1.0f);
-
-/**
- * Magnetometer Y-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG3_YSCALE, 1.0f);
-
-/**
- * Magnetometer Z-axis scaling factor
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(CAL_MAG3_ZSCALE, 1.0f);
-
-
-/**
- * Primary accel ID
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_ACC_PRIME, 0);
-
-/**
- * Primary gyro ID
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_GYRO_PRIME, 0);
-
-/**
- * Primary mag ID
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_MAG_PRIME, 0);
-
-/**
- * Bitfield selecting mag sides for calibration
- *
- * DETECT_ORIENTATION_TAIL_DOWN = 1
- * DETECT_ORIENTATION_NOSE_DOWN = 2
- * DETECT_ORIENTATION_LEFT = 4
- * DETECT_ORIENTATION_RIGHT = 8
- * DETECT_ORIENTATION_UPSIDE_DOWN = 16
- * DETECT_ORIENTATION_RIGHTSIDE_UP = 32
- *
- * @min 34
- * @max 63
- * @value 34 Two side calibration
- * @value 38 Three side calibration
- * @value 63 Six side calibration
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_MAG_SIDES, 63);
-
-/**
  * Primary baro ID
  *
  * @group Sensor Calibration
@@ -854,11 +85,10 @@ PARAM_DEFINE_FLOAT(SENS_DPRES_ANSC, 0);
  *
  * @min 500
  * @max 1500
- * @group Sensor Calibration
+ * @group Sensors
  * @unit hPa
  */
 PARAM_DEFINE_FLOAT(SENS_BARO_QNH, 1013.25f);
-
 
 /**
  * Board rotation
@@ -894,7 +124,7 @@ PARAM_DEFINE_FLOAT(SENS_BARO_QNH, 1013.25f);
  *
  * @reboot_required true
  *
- * @group Sensor Calibration
+ * @group Sensors
  */
 PARAM_DEFINE_INT32(SENS_BOARD_ROT, 0);
 
@@ -916,7 +146,7 @@ PARAM_DEFINE_INT32(SENS_BOARD_ROT, 0);
  *
  * @reboot_required true
  *
- * @group Sensor Calibration
+ * @group Sensors
  */
 PARAM_DEFINE_INT32(SENS_FLOW_ROT, 6);
 
@@ -927,7 +157,7 @@ PARAM_DEFINE_INT32(SENS_FLOW_ROT, 6);
  * to fine tune the board offset in the event of misalignment.
  *
  * @unit deg
- * @group Sensor Calibration
+ * @group Sensors
  */
 PARAM_DEFINE_FLOAT(SENS_BOARD_Y_OFF, 0.0f);
 
@@ -938,7 +168,7 @@ PARAM_DEFINE_FLOAT(SENS_BOARD_Y_OFF, 0.0f);
  * to fine tune the board offset in the event of misalignment.
  *
  * @unit deg
- * @group Sensor Calibration
+ * @group Sensors
  */
 PARAM_DEFINE_FLOAT(SENS_BOARD_X_OFF, 0.0f);
 
@@ -949,27 +179,14 @@ PARAM_DEFINE_FLOAT(SENS_BOARD_X_OFF, 0.0f);
  * to fine tune the board offset in the event of misalignment.
  *
  * @unit deg
- * @group Sensor Calibration
+ * @group Sensors
  */
 PARAM_DEFINE_FLOAT(SENS_BOARD_Z_OFF, 0.0f);
 
 /**
- * Select primary magnetometer.
- * DEPRECATED, only used on V1 hardware
- *
- * @min 0
- * @max 2
- * @value 0 Auto-select Mag
- * @value 1 External is primary Mag
- * @value 2 Internal is primary Mag
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(SENS_EXT_MAG, 0);
-
-/**
  * Threshold (of RMS) to warn about high vibration levels
  *
- * @group Sensor Calibration
+ * @group Sensors
  * @min 0.01
  * @max 10
  * @decimal 2
@@ -977,96 +194,12 @@ PARAM_DEFINE_INT32(SENS_EXT_MAG, 0);
 PARAM_DEFINE_FLOAT(ATT_VIBE_THRESH, 0.2f);
 
 /**
- * Scaling factor for battery voltage sensor on PX4IO.
- *
- * @min 1
- * @max 100000
- * @group Battery Calibration
- */
-PARAM_DEFINE_INT32(BAT_V_SCALE_IO, 10000);
-
-/**
- * Scaling from ADC counts to volt on the ADC input (battery voltage)
- *
- * This is not the battery voltage, but the intermediate ADC voltage.
- * A value of -1 signifies that the board defaults are used, which is
- * highly recommended.
- *
- * @group Battery Calibration
- * @decimal 8
- */
-PARAM_DEFINE_FLOAT(BAT_CNT_V_VOLT, -1.0f);
-
-/**
- * Scaling from ADC counts to volt on the ADC input (battery current)
- *
- * This is not the battery current, but the intermediate ADC voltage.
- * A value of -1 signifies that the board defaults are used, which is
- * highly recommended.
- *
- * @group Battery Calibration
- * @decimal 8
- */
-PARAM_DEFINE_FLOAT(BAT_CNT_V_CURR, -1.0);
-
-/**
- * Offset in volt as seen by the ADC input of the current sensor.
- *
- * This offset will be subtracted before calculating the battery
- * current based on the voltage.
- *
- * @group Battery Calibration
- * @decimal 8
- */
-PARAM_DEFINE_FLOAT(BAT_V_OFFS_CURR, 0.0);
-
-/**
- * Battery voltage divider (V divider)
- *
- * This is the divider from battery voltage to 3.3V ADC voltage.
- * If using e.g. Mauch power modules the value from the datasheet
- * can be applied straight here. A value of -1 means to use
- * the board default.
- *
- * @group Battery Calibration
- * @decimal 8
- */
-PARAM_DEFINE_FLOAT(BAT_V_DIV, -1.0);
-
-/**
- * Battery current per volt (A/V)
- *
- * The voltage seen by the 3.3V ADC multiplied by this factor
- * will determine the battery current. A value of -1 means to use
- * the board default.
- *
- * @group Battery Calibration
- * @decimal 8
- */
-PARAM_DEFINE_FLOAT(BAT_A_PER_V, -1.0);
-
-/**
- * Battery monitoring source.
- *
- * This parameter controls the source of battery data. The value 'Power Module'
- * means that measurements are expected to come from a power module. If the value is set to
- * 'External' then the system expects to receive mavlink battery status messages.
- *
- * @min 0
- * @max 1
- * @value 0 Power Module
- * @value 1 External
- * @group Battery Calibration
- */
-PARAM_DEFINE_INT32(BAT_SOURCE, 0);
-
-/**
  * Lidar-Lite (LL40LS)
  *
  * @reboot_required true
  * @min 0
  * @max 2
- * @group Sensor Enable
+ * @group Sensors
  * @value 0 Disabled
  * @value 1 PWM
  * @value 2 I2C
@@ -1079,7 +212,7 @@ PARAM_DEFINE_INT32(SENS_EN_LL40LS, 0);
  * @reboot_required true
  * @min 0
  * @max 4
- * @group Sensor Enable
+ * @group Sensors
  * @value 0 Disabled
  * @value 1 SF02
  * @value 2 SF10/a
@@ -1095,7 +228,7 @@ PARAM_DEFINE_INT32(SENS_EN_SF0X, 0);
  * @reboot_required true
  *
  * @boolean
- * @group Sensor Enable
+ * @group Sensors
  */
 PARAM_DEFINE_INT32(SENS_EN_MB12XX, 0);
 
@@ -1105,7 +238,7 @@ PARAM_DEFINE_INT32(SENS_EN_MB12XX, 0);
  * @reboot_required true
  * @min 0
  * @max 3
- * @group Sensor Enable
+ * @group Sensors
  * @value 0 Disabled
  * @value 1 Autodetect
  * @value 2 TROne
@@ -1119,7 +252,7 @@ PARAM_DEFINE_INT32(SENS_EN_TRANGER, 0);
  * @reboot_required true
  * @min 0
  * @max 5
- * @group Sensor Enable
+ * @group Sensors
  * @value 0 Disabled
  * @value 1 SF10/a
  * @value 2 SF10/b
@@ -1134,7 +267,7 @@ PARAM_DEFINE_INT32(SENS_EN_SF1XX, 0);
  *
  * @value -1 Thermal control unavailable
  * @value 0 Thermal control off
- * @group Sensor Enable
+ * @group Sensors
  */
 PARAM_DEFINE_INT32(SENS_EN_THERMAL, -1);
 
@@ -1149,7 +282,7 @@ PARAM_DEFINE_INT32(SENS_EN_THERMAL, -1);
 * @max 1000
 * @unit Hz
 * @reboot_required true
-* @group Sensor Calibration
+* @group Sensors
 */
 PARAM_DEFINE_FLOAT(IMU_GYRO_CUTOFF, 30.0f);
 
@@ -1164,6 +297,6 @@ PARAM_DEFINE_FLOAT(IMU_GYRO_CUTOFF, 30.0f);
 * @max 1000
 * @unit Hz
 * @reboot_required true
-* @group Sensor Calibration
+* @group Sensors
 */
 PARAM_DEFINE_FLOAT(IMU_ACCEL_CUTOFF, 30.0f);

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -42,13 +42,6 @@
  */
 
 /**
- * ID of the board this parameter set was calibrated on.
- *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_INT32(CAL_BOARD_ID, 0);
-
-/**
  * ID of the Gyro that the calibration is for.
  *
  * @group Sensor Calibration

--- a/src/modules/sensors/sensor_params_accel.c
+++ b/src/modules/sensors/sensor_params_accel.c
@@ -1,0 +1,186 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Primary accel ID
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_ACC_PRIME, 0);
+
+/**
+ * ID of the Accelerometer that the calibration is for.
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_ACC0_ID, 0);
+
+/**
+ * Accelerometer X-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC0_XOFF, 0.0f);
+
+/**
+ * Accelerometer Y-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC0_YOFF, 0.0f);
+
+/**
+ * Accelerometer Z-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC0_ZOFF, 0.0f);
+
+/**
+ * Accelerometer X-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC0_XSCALE, 1.0f);
+
+/**
+ * Accelerometer Y-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC0_YSCALE, 1.0f);
+
+/**
+ * Accelerometer Z-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC0_ZSCALE, 1.0f);
+
+/**
+ * ID of the Accelerometer that the calibration is for.
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_ACC1_ID, 0);
+
+/**
+ * Accelerometer X-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC1_XOFF, 0.0f);
+
+/**
+ * Accelerometer Y-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC1_YOFF, 0.0f);
+
+/**
+ * Accelerometer Z-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC1_ZOFF, 0.0f);
+
+/**
+ * Accelerometer X-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC1_XSCALE, 1.0f);
+
+/**
+ * Accelerometer Y-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC1_YSCALE, 1.0f);
+
+/**
+ * Accelerometer Z-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC1_ZSCALE, 1.0f);
+
+/**
+ * ID of the Accelerometer that the calibration is for.
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_ACC2_ID, 0);
+
+/**
+ * Accelerometer X-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC2_XOFF, 0.0f);
+
+/**
+ * Accelerometer Y-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC2_YOFF, 0.0f);
+
+/**
+ * Accelerometer Z-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC2_ZOFF, 0.0f);
+
+/**
+ * Accelerometer X-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC2_XSCALE, 1.0f);
+
+/**
+ * Accelerometer Y-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC2_YSCALE, 1.0f);
+
+/**
+ * Accelerometer Z-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_ACC2_ZSCALE, 1.0f);

--- a/src/modules/sensors/sensor_params_accel.c
+++ b/src/modules/sensors/sensor_params_accel.c
@@ -46,6 +46,14 @@ PARAM_DEFINE_INT32(CAL_ACC_PRIME, 0);
 PARAM_DEFINE_INT32(CAL_ACC0_ID, 0);
 
 /**
+ * Accelerometer 0 enabled
+ *
+ * @boolean
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_ACC0_EN, 1);
+
+/**
  * Accelerometer X-axis offset
  *
  * @group Sensor Calibration
@@ -95,6 +103,14 @@ PARAM_DEFINE_FLOAT(CAL_ACC0_ZSCALE, 1.0f);
 PARAM_DEFINE_INT32(CAL_ACC1_ID, 0);
 
 /**
+ * Accelerometer 1 enabled
+ *
+ * @boolean
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_ACC1_EN, 1);
+
+/**
  * Accelerometer X-axis offset
  *
  * @group Sensor Calibration
@@ -142,6 +158,14 @@ PARAM_DEFINE_FLOAT(CAL_ACC1_ZSCALE, 1.0f);
  * @group Sensor Calibration
  */
 PARAM_DEFINE_INT32(CAL_ACC2_ID, 0);
+
+/**
+ * Accelerometer 2 enabled
+ *
+ * @boolean
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_ACC2_EN, 1);
 
 /**
  * Accelerometer X-axis offset

--- a/src/modules/sensors/sensor_params_battery.c
+++ b/src/modules/sensors/sensor_params_battery.c
@@ -1,0 +1,116 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Scaling factor for battery voltage sensor on PX4IO.
+ *
+ * @min 1
+ * @max 100000
+ * @group Battery Calibration
+ */
+PARAM_DEFINE_INT32(BAT_V_SCALE_IO, 10000);
+
+/**
+ * Scaling from ADC counts to volt on the ADC input (battery voltage)
+ *
+ * This is not the battery voltage, but the intermediate ADC voltage.
+ * A value of -1 signifies that the board defaults are used, which is
+ * highly recommended.
+ *
+ * @group Battery Calibration
+ * @decimal 8
+ */
+PARAM_DEFINE_FLOAT(BAT_CNT_V_VOLT, -1.0f);
+
+/**
+ * Scaling from ADC counts to volt on the ADC input (battery current)
+ *
+ * This is not the battery current, but the intermediate ADC voltage.
+ * A value of -1 signifies that the board defaults are used, which is
+ * highly recommended.
+ *
+ * @group Battery Calibration
+ * @decimal 8
+ */
+PARAM_DEFINE_FLOAT(BAT_CNT_V_CURR, -1.0);
+
+/**
+ * Offset in volt as seen by the ADC input of the current sensor.
+ *
+ * This offset will be subtracted before calculating the battery
+ * current based on the voltage.
+ *
+ * @group Battery Calibration
+ * @decimal 8
+ */
+PARAM_DEFINE_FLOAT(BAT_V_OFFS_CURR, 0.0);
+
+/**
+ * Battery voltage divider (V divider)
+ *
+ * This is the divider from battery voltage to 3.3V ADC voltage.
+ * If using e.g. Mauch power modules the value from the datasheet
+ * can be applied straight here. A value of -1 means to use
+ * the board default.
+ *
+ * @group Battery Calibration
+ * @decimal 8
+ */
+PARAM_DEFINE_FLOAT(BAT_V_DIV, -1.0);
+
+/**
+ * Battery current per volt (A/V)
+ *
+ * The voltage seen by the 3.3V ADC multiplied by this factor
+ * will determine the battery current. A value of -1 means to use
+ * the board default.
+ *
+ * @group Battery Calibration
+ * @decimal 8
+ */
+PARAM_DEFINE_FLOAT(BAT_A_PER_V, -1.0);
+
+/**
+ * Battery monitoring source.
+ *
+ * This parameter controls the source of battery data. The value 'Power Module'
+ * means that measurements are expected to come from a power module. If the value is set to
+ * 'External' then the system expects to receive mavlink battery status messages.
+ *
+ * @min 0
+ * @max 1
+ * @value 0 Power Module
+ * @value 1 External
+ * @group Battery Calibration
+ */
+PARAM_DEFINE_INT32(BAT_SOURCE, 0);

--- a/src/modules/sensors/sensor_params_gyro.c
+++ b/src/modules/sensors/sensor_params_gyro.c
@@ -1,0 +1,186 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Primary gyro ID
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_GYRO_PRIME, 0);
+
+/**
+ * ID of the Gyro that the calibration is for.
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_GYRO0_ID, 0);
+
+/**
+ * Gyro X-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO0_XOFF, 0.0f);
+
+/**
+ * Gyro Y-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO0_YOFF, 0.0f);
+
+/**
+ * Gyro Z-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO0_ZOFF, 0.0f);
+
+/**
+ * Gyro X-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO0_XSCALE, 1.0f);
+
+/**
+ * Gyro Y-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO0_YSCALE, 1.0f);
+
+/**
+ * Gyro Z-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO0_ZSCALE, 1.0f);
+
+/**
+ * ID of the Gyro that the calibration is for.
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_GYRO1_ID, 0);
+
+/**
+ * Gyro X-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO1_XOFF, 0.0f);
+
+/**
+ * Gyro Y-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO1_YOFF, 0.0f);
+
+/**
+ * Gyro Z-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO1_ZOFF, 0.0f);
+
+/**
+ * Gyro X-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO1_XSCALE, 1.0f);
+
+/**
+ * Gyro Y-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO1_YSCALE, 1.0f);
+
+/**
+ * Gyro Z-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO1_ZSCALE, 1.0f);
+
+/**
+ * ID of the Gyro that the calibration is for.
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_GYRO2_ID, 0);
+
+/**
+ * Gyro X-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO2_XOFF, 0.0f);
+
+/**
+ * Gyro Y-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO2_YOFF, 0.0f);
+
+/**
+ * Gyro Z-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO2_ZOFF, 0.0f);
+
+/**
+ * Gyro X-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO2_XSCALE, 1.0f);
+
+/**
+ * Gyro Y-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO2_YSCALE, 1.0f);
+
+/**
+ * Gyro Z-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_GYRO2_ZSCALE, 1.0f);

--- a/src/modules/sensors/sensor_params_gyro.c
+++ b/src/modules/sensors/sensor_params_gyro.c
@@ -46,6 +46,14 @@ PARAM_DEFINE_INT32(CAL_GYRO_PRIME, 0);
 PARAM_DEFINE_INT32(CAL_GYRO0_ID, 0);
 
 /**
+ * Gyro 0 enabled
+ *
+ * @boolean
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_GYRO0_EN, 1);
+
+/**
  * Gyro X-axis offset
  *
  * @group Sensor Calibration
@@ -95,6 +103,14 @@ PARAM_DEFINE_FLOAT(CAL_GYRO0_ZSCALE, 1.0f);
 PARAM_DEFINE_INT32(CAL_GYRO1_ID, 0);
 
 /**
+ * Gyro 1 enabled
+ *
+ * @boolean
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_GYRO1_EN, 1);
+
+/**
  * Gyro X-axis offset
  *
  * @group Sensor Calibration
@@ -142,6 +158,14 @@ PARAM_DEFINE_FLOAT(CAL_GYRO1_ZSCALE, 1.0f);
  * @group Sensor Calibration
  */
 PARAM_DEFINE_INT32(CAL_GYRO2_ID, 0);
+
+/**
+ * Gyro 2 enabled
+ *
+ * @boolean
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_GYRO2_EN, 1);
 
 /**
  * Gyro X-axis offset

--- a/src/modules/sensors/sensor_params_mag.c
+++ b/src/modules/sensors/sensor_params_mag.c
@@ -1,0 +1,431 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Primary mag ID
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_MAG_PRIME, 0);
+
+/**
+ * Bitfield selecting mag sides for calibration
+ *
+ * DETECT_ORIENTATION_TAIL_DOWN = 1
+ * DETECT_ORIENTATION_NOSE_DOWN = 2
+ * DETECT_ORIENTATION_LEFT = 4
+ * DETECT_ORIENTATION_RIGHT = 8
+ * DETECT_ORIENTATION_UPSIDE_DOWN = 16
+ * DETECT_ORIENTATION_RIGHTSIDE_UP = 32
+ *
+ * @min 34
+ * @max 63
+ * @value 34 Two side calibration
+ * @value 38 Three side calibration
+ * @value 63 Six side calibration
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_MAG_SIDES, 63);
+
+
+/**
+ * ID of Magnetometer the calibration is for.
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_MAG0_ID, 0);
+
+/**
+ * Rotation of magnetometer 0 relative to airframe.
+ *
+ * An internal magnetometer will force a value of -1, so a GCS
+ * should only attempt to configure the rotation if the value is
+ * greater than or equal to zero.
+ *
+ * @value -1 Internal mag
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ * @value 8 Roll 180°
+ * @value 9 Roll 180°, Yaw 45°
+ * @value 10 Roll 180°, Yaw 90°
+ * @value 11 Roll 180°, Yaw 135°
+ * @value 12 Pitch 180°
+ * @value 13 Roll 180°, Yaw 225°
+ * @value 14 Roll 180°, Yaw 270°
+ * @value 15 Roll 180°, Yaw 315°
+ * @value 16 Roll 90°
+ * @value 17 Roll 90°, Yaw 45°
+ * @value 18 Roll 90°, Yaw 90°
+ * @value 19 Roll 90°, Yaw 135°
+ * @value 20 Roll 270°
+ * @value 21 Roll 270°, Yaw 45°
+ * @value 22 Roll 270°, Yaw 90°
+ * @value 23 Roll 270°, Yaw 135°
+ * @value 24 Pitch 90°
+ * @value 25 Pitch 270°
+ *
+ * @min -1
+ * @max 30
+ * @reboot_required true
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_MAG0_ROT, -1);
+
+/**
+ * Magnetometer X-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG0_XOFF, 0.0f);
+
+/**
+ * Magnetometer Y-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG0_YOFF, 0.0f);
+
+/**
+ * Magnetometer Z-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG0_ZOFF, 0.0f);
+
+/**
+ * Magnetometer X-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG0_XSCALE, 1.0f);
+
+/**
+ * Magnetometer Y-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG0_YSCALE, 1.0f);
+
+/**
+ * Magnetometer Z-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG0_ZSCALE, 1.0f);
+
+/**
+ * ID of Magnetometer the calibration is for.
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_MAG1_ID, 0);
+
+/**
+ * Rotation of magnetometer 1 relative to airframe.
+ *
+ * An internal magnetometer will force a value of -1, so a GCS
+ * should only attempt to configure the rotation if the value is
+ * greater than or equal to zero.
+ *
+ * @value -1 Internal mag
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ * @value 8 Roll 180°
+ * @value 9 Roll 180°, Yaw 45°
+ * @value 10 Roll 180°, Yaw 90°
+ * @value 11 Roll 180°, Yaw 135°
+ * @value 12 Pitch 180°
+ * @value 13 Roll 180°, Yaw 225°
+ * @value 14 Roll 180°, Yaw 270°
+ * @value 15 Roll 180°, Yaw 315°
+ * @value 16 Roll 90°
+ * @value 17 Roll 90°, Yaw 45°
+ * @value 18 Roll 90°, Yaw 90°
+ * @value 19 Roll 90°, Yaw 135°
+ * @value 20 Roll 270°
+ * @value 21 Roll 270°, Yaw 45°
+ * @value 22 Roll 270°, Yaw 90°
+ * @value 23 Roll 270°, Yaw 135°
+ * @value 24 Pitch 90°
+ * @value 25 Pitch 270°
+ *
+ * @min -1
+ * @max 30
+ * @reboot_required true
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_MAG1_ROT, -1);
+
+/**
+ * Magnetometer X-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG1_XOFF, 0.0f);
+
+/**
+ * Magnetometer Y-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG1_YOFF, 0.0f);
+
+/**
+ * Magnetometer Z-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG1_ZOFF, 0.0f);
+
+/**
+ * Magnetometer X-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG1_XSCALE, 1.0f);
+
+/**
+ * Magnetometer Y-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG1_YSCALE, 1.0f);
+
+/**
+ * Magnetometer Z-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG1_ZSCALE, 1.0f);
+
+/**
+ * ID of Magnetometer the calibration is for.
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_MAG2_ID, 0);
+
+/**
+ * Rotation of magnetometer 2 relative to airframe.
+ *
+ * An internal magnetometer will force a value of -1, so a GCS
+ * should only attempt to configure the rotation if the value is
+ * greater than or equal to zero.
+ *
+ * @value -1 Internal mag
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ * @value 8 Roll 180°
+ * @value 9 Roll 180°, Yaw 45°
+ * @value 10 Roll 180°, Yaw 90°
+ * @value 11 Roll 180°, Yaw 135°
+ * @value 12 Pitch 180°
+ * @value 13 Roll 180°, Yaw 225°
+ * @value 14 Roll 180°, Yaw 270°
+ * @value 15 Roll 180°, Yaw 315°
+ * @value 16 Roll 90°
+ * @value 17 Roll 90°, Yaw 45°
+ * @value 18 Roll 90°, Yaw 90°
+ * @value 19 Roll 90°, Yaw 135°
+ * @value 20 Roll 270°
+ * @value 21 Roll 270°, Yaw 45°
+ * @value 22 Roll 270°, Yaw 90°
+ * @value 23 Roll 270°, Yaw 135°
+ * @value 24 Pitch 90°
+ * @value 25 Pitch 270°
+ *
+ * @min -1
+ * @max 30
+ * @reboot_required true
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_MAG2_ROT, -1);
+
+/**
+ * Magnetometer X-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG2_XOFF, 0.0f);
+
+/**
+ * Magnetometer Y-axis offset
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG2_YOFF, 0.0f);
+
+/**
+ * Magnetometer Z-axis offset
+ *
+ * @min -500.0
+ * @max 500.0
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG2_ZOFF, 0.0f);
+
+/**
+ * Magnetometer X-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG2_XSCALE, 1.0f);
+
+/**
+ * Magnetometer Y-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG2_YSCALE, 1.0f);
+
+/**
+ * Magnetometer Z-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG2_ZSCALE, 1.0f);
+
+/**
+ * ID of Magnetometer the calibration is for.
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_MAG3_ID, 0);
+
+/**
+ * Rotation of magnetometer 2 relative to airframe.
+ *
+ * An internal magnetometer will force a value of -1, so a GCS
+ * should only attempt to configure the rotation if the value is
+ * greater than or equal to zero.
+ *
+ * @value -1 Internal mag
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ * @value 8 Roll 180°
+ * @value 9 Roll 180°, Yaw 45°
+ * @value 10 Roll 180°, Yaw 90°
+ * @value 11 Roll 180°, Yaw 135°
+ * @value 12 Pitch 180°
+ * @value 13 Roll 180°, Yaw 225°
+ * @value 14 Roll 180°, Yaw 270°
+ * @value 15 Roll 180°, Yaw 315°
+ * @value 16 Roll 90°
+ * @value 17 Roll 90°, Yaw 45°
+ * @value 18 Roll 90°, Yaw 90°
+ * @value 19 Roll 90°, Yaw 135°
+ * @value 20 Roll 270°
+ * @value 21 Roll 270°, Yaw 45°
+ * @value 22 Roll 270°, Yaw 90°
+ * @value 23 Roll 270°, Yaw 135°
+ * @value 24 Pitch 90°
+ * @value 25 Pitch 270°
+ *
+ * @min -1
+ * @max 30
+ * @reboot_required true
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_MAG3_ROT, -1);
+
+/**
+ * Magnetometer X-axis offset
+ *
+ * @min -500.0
+ * @max 500.0
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG3_XOFF, 0.0f);
+
+/**
+ * Magnetometer Y-axis offset
+ *
+ * @min -500.0
+ * @max 500.0
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG3_YOFF, 0.0f);
+
+/**
+ * Magnetometer Z-axis offset
+ *
+ * @min -500.0
+ * @max 500.0
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG3_ZOFF, 0.0f);
+
+/**
+ * Magnetometer X-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG3_XSCALE, 1.0f);
+
+/**
+ * Magnetometer Y-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG3_YSCALE, 1.0f);
+
+/**
+ * Magnetometer Z-axis scaling factor
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_MAG3_ZSCALE, 1.0f);

--- a/src/modules/sensors/sensor_params_mag.c
+++ b/src/modules/sensors/sensor_params_mag.c
@@ -66,6 +66,14 @@ PARAM_DEFINE_INT32(CAL_MAG_SIDES, 63);
 PARAM_DEFINE_INT32(CAL_MAG0_ID, 0);
 
 /**
+ * Mag 0 enabled
+ *
+ * @boolean
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_MAG0_EN, 1);
+
+/**
  * Rotation of magnetometer 0 relative to airframe.
  *
  * An internal magnetometer will force a value of -1, so a GCS
@@ -155,6 +163,14 @@ PARAM_DEFINE_FLOAT(CAL_MAG0_ZSCALE, 1.0f);
  * @group Sensor Calibration
  */
 PARAM_DEFINE_INT32(CAL_MAG1_ID, 0);
+
+/**
+ * Mag 1 enabled
+ *
+ * @boolean
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_MAG1_EN, 1);
 
 /**
  * Rotation of magnetometer 1 relative to airframe.
@@ -248,6 +264,14 @@ PARAM_DEFINE_FLOAT(CAL_MAG1_ZSCALE, 1.0f);
 PARAM_DEFINE_INT32(CAL_MAG2_ID, 0);
 
 /**
+ * Mag 2 enabled
+ *
+ * @boolean
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_MAG2_EN, 1);
+
+/**
  * Rotation of magnetometer 2 relative to airframe.
  *
  * An internal magnetometer will force a value of -1, so a GCS
@@ -339,6 +363,14 @@ PARAM_DEFINE_FLOAT(CAL_MAG2_ZSCALE, 1.0f);
  * @group Sensor Calibration
  */
 PARAM_DEFINE_INT32(CAL_MAG3_ID, 0);
+
+/**
+ * Mag 3 enabled
+ *
+ * @boolean
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_INT32(CAL_MAG3_EN, 1);
 
 /**
  * Rotation of magnetometer 2 relative to airframe.

--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -920,14 +920,19 @@ bool VotedSensorsUpdate::check_failover(SensorData &sensor, const char *sensor_n
 			}
 
 		} else {
+			int failover_index = sensor.voter.failover_index();
+
 			mavlink_log_emergency(&_mavlink_log_pub, "%s #%i fail: %s%s%s%s%s!",
 					      sensor_name,
-					      sensor.voter.failover_index(),
+					      failover_index,
 					      ((flags & DataValidator::ERROR_FLAG_NO_DATA) ? " OFF" : ""),
 					      ((flags & DataValidator::ERROR_FLAG_STALE_DATA) ? " STALE" : ""),
 					      ((flags & DataValidator::ERROR_FLAG_TIMEOUT) ? " TOUT" : ""),
 					      ((flags & DataValidator::ERROR_FLAG_HIGH_ERRCOUNT) ? " ECNT" : ""),
 					      ((flags & DataValidator::ERROR_FLAG_HIGH_ERRDENSITY) ? " EDNST" : ""));
+
+			// reduce priority of failed sensor to the minimum
+			sensor.priority[failover_index] = 1;
 		}
 
 		sensor.last_failover_count = sensor.voter.failover_count();

--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -168,10 +168,10 @@ void VotedSensorsUpdate::parameters_update()
 				if (temp < 0) {
 					PX4_ERR("gyro temp compensation init: failed to find device ID %u for instance %i",
 						report.device_id, topic_instance);
-					_corrections.gyro_mapping[topic_instance] =  0;
+					_corrections.gyro_mapping[topic_instance] = 0;
 
 				} else {
-					_corrections.gyro_mapping[topic_instance] =  temp;
+					_corrections.gyro_mapping[topic_instance] = temp;
 
 				}
 			}
@@ -192,10 +192,10 @@ void VotedSensorsUpdate::parameters_update()
 				if (temp < 0) {
 					PX4_ERR("accel temp compensation init: failed to find device ID %u for instance %i",
 						report.device_id, topic_instance);
-					_corrections.accel_mapping[topic_instance] =  0;
+					_corrections.accel_mapping[topic_instance] = 0;
 
 				} else {
-					_corrections.accel_mapping[topic_instance] =  temp;
+					_corrections.accel_mapping[topic_instance] = temp;
 
 				}
 			}
@@ -215,10 +215,10 @@ void VotedSensorsUpdate::parameters_update()
 				if (temp < 0) {
 					PX4_ERR("baro temp compensation init: failed to find device ID %u for instance %i",
 						report.device_id, topic_instance);
-					_corrections.baro_mapping[topic_instance] =  0;
+					_corrections.baro_mapping[topic_instance] = 0;
 
 				} else {
-					_corrections.baro_mapping[topic_instance] =  temp;
+					_corrections.baro_mapping[topic_instance] = temp;
 
 				}
 			}
@@ -257,6 +257,12 @@ void VotedSensorsUpdate::parameters_update()
 			(void)sprintf(str, "CAL_GYRO%u_ID", i);
 			int32_t device_id;
 			failed = failed || (OK != param_get(param_find(str), &device_id));
+
+			(void)sprintf(str, "CAL_GYRO%u_EN", i);
+			int32_t device_enabled = 0;
+			failed = failed || (OK != param_get(param_find(str), &device_enabled));
+
+			_gyro.enabled[i] = (device_enabled == 1);
 
 			if (failed) {
 				continue;
@@ -339,6 +345,12 @@ void VotedSensorsUpdate::parameters_update()
 			(void)sprintf(str, "CAL_ACC%u_ID", i);
 			int32_t device_id;
 			failed = failed || (OK != param_get(param_find(str), &device_id));
+
+			(void)sprintf(str, "CAL_ACC%u_EN", i);
+			int32_t device_enabled = 0;
+			failed = failed || (OK != param_get(param_find(str), &device_enabled));
+
+			_accel.enabled[i] = (device_enabled == 1);
 
 			if (failed) {
 				continue;
@@ -450,6 +462,12 @@ void VotedSensorsUpdate::parameters_update()
 			int32_t device_id;
 			failed = failed || (OK != param_get(param_find(str), &device_id));
 
+			(void)sprintf(str, "CAL_MAG%u_EN", i);
+			int32_t device_enabled = 0;
+			failed = failed || (OK != param_get(param_find(str), &device_enabled));
+
+			_mag.enabled[i] = (device_enabled == 1);
+
 			if (failed) {
 				continue;
 			}
@@ -531,7 +549,7 @@ void VotedSensorsUpdate::accel_poll(struct sensor_combined_s &raw)
 		bool accel_updated;
 		orb_check(_accel.subscription[uorb_index], &accel_updated);
 
-		if (accel_updated) {
+		if (accel_updated && _accel.enabled[uorb_index]) {
 			struct accel_report accel_report;
 
 			orb_copy(ORB_ID(sensor_accel), _accel.subscription[uorb_index], &accel_report);
@@ -638,7 +656,7 @@ void VotedSensorsUpdate::gyro_poll(struct sensor_combined_s &raw)
 		bool gyro_updated;
 		orb_check(_gyro.subscription[uorb_index], &gyro_updated);
 
-		if (gyro_updated) {
+		if (gyro_updated && _gyro.enabled[uorb_index]) {
 			struct gyro_report gyro_report;
 
 			orb_copy(ORB_ID(sensor_gyro), _gyro.subscription[uorb_index], &gyro_report);
@@ -743,7 +761,7 @@ void VotedSensorsUpdate::mag_poll(struct sensor_combined_s &raw)
 		bool mag_updated;
 		orb_check(_mag.subscription[uorb_index], &mag_updated);
 
-		if (mag_updated) {
+		if (mag_updated && _mag.enabled[uorb_index]) {
 			struct mag_report mag_report;
 
 			orb_copy(ORB_ID(sensor_mag), _mag.subscription[uorb_index], &mag_report);
@@ -803,7 +821,7 @@ void VotedSensorsUpdate::baro_poll(struct sensor_combined_s &raw)
 		bool baro_updated;
 		orb_check(_baro.subscription[uorb_index], &baro_updated);
 
-		if (baro_updated) {
+		if (baro_updated && _baro.enabled[uorb_index]) {
 			struct baro_report baro_report;
 
 			orb_copy(ORB_ID(sensor_baro), _baro.subscription[uorb_index], &baro_report);

--- a/src/modules/sensors/voted_sensors_update.h
+++ b/src/modules/sensors/voted_sensors_update.h
@@ -164,6 +164,8 @@ private:
 			}
 		}
 
+		bool enabled[SENSOR_COUNT_MAX];
+
 		int subscription[SENSOR_COUNT_MAX]; /**< raw sensor data subscription */
 		uint8_t priority[SENSOR_COUNT_MAX]; /**< sensor priority */
 		uint8_t last_best_vote; /**< index of the latest best vote */


### PR DESCRIPTION
 - if the primary sensor switches due to voting drop the priority to the minimum
 - EKF2 reset IMU bias when the sensor changes
 - add a boolean parameter to each sensor
    -  CAL_ACCX_EN
    -  CAL_GYROX_EN
    -  CAL_MAGX_EN

https://github.com/PX4/Firmware/issues/8186