### PR TITLE
Fix follow me position setpoint

### DIFF
--- a/src/modules/navigator/follow_target.cpp
+++ b/src/modules/navigator/follow_target.cpp
@@ -240,7 +240,7 @@ void FollowTarget::on_active()
 			}
 		}
 
-//		warnx(" _step_vel x %3.6f y %3.6f cur vel %3.6f %3.6f tar vel %3.6f %3.6f dist = %3.6f (%3.6f) mode = %d con ratio = %3.6f yaw rate = %3.6f",
+//		warnx(" _step_vel x %3.6f y %3.6f cur vel %3.6f %3.6f tar vel %3.6f %3.6f dist = %3.6f (%3.6f) mode = %d yaw rate = %3.6f",
 //				(double) _step_vel(0),
 //				(double) _step_vel(1),
 //				(double) _current_vel(0),
@@ -250,7 +250,7 @@ void FollowTarget::on_active()
 //				(double) (_target_distance).length(),
 //				(double) (_target_position_offset + _target_distance).length(),
 //				_follow_target_state,
-//				(double)_avg_cos_ratio, (double) _yaw_rate);
+//				(double) _yaw_rate);
 	}
 
 	if (target_position_valid()) {

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -475,7 +475,8 @@ MissionBlock::item_contains_position(const mission_item_s &item)
 	       item.nav_cmd == NAV_CMD_TAKEOFF ||
 	       item.nav_cmd == NAV_CMD_LOITER_TO_ALT ||
 	       item.nav_cmd == NAV_CMD_VTOL_TAKEOFF ||
-	       item.nav_cmd == NAV_CMD_VTOL_LAND;
+	       item.nav_cmd == NAV_CMD_VTOL_LAND ||
+	       item.nav_cmd == NAV_CMD_DO_FOLLOW_REPOSITION;
 }
 
 bool


### PR DESCRIPTION
The function `mission_item_to_position_setpoint()` is called in
`FollowTarget::update_position_sp()`. The nav_cmd is a
`NAV_CMD_DO_FOLLOW_REPOSITION` as set earlier in `set_follow_target_item`.

Since `mission_item_to_position_setpoint` returns early because the item
presumably contains no position, the lat/lon of the mission_item are
not copied over to the position_setpoint and therefore the vehicle will
never move in follow me position mode.

This PR fixes this problem and should unblock the [DroneCore follow me implementation](https://github.com/dronecore/DroneCore/pull/142).