### PR TITLE
PX4IO Firmware: Fix usage of new operator in IRQ

### DIFF
--- a/src/modules/px4iofirmware/px4io.h
+++ b/src/modules/px4iofirmware/px4io.h
@@ -191,6 +191,7 @@ extern pwm_limit_t pwm_limit;
  * Mixer
  */
 extern void	mixer_tick(void);
+extern int	mixer_handle_text_create_mixer(void);
 extern int	mixer_handle_text(const void *buffer, size_t length);
 /* Set the failsafe values of all mixed channels (based on zero throttle, controls centered) */
 extern void	mixer_set_failsafe(void);


### PR DESCRIPTION
The mixer was creating a new class in interrupt context, which is not valid use in NuttX. This change copies the mixer into the buffer and runs the mixer management section of the code outside of interrupt context in the normal task.

@PX4TestFlights Please bench-test on a plane and flight-test with a quad.