### PR TITLE
travis ci update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - env: BUILD_TARGET=check_format
     - env: BUILD_TARGET=check_stack
     - env: BUILD_TARGET=clang-tidy-quiet
     - env: BUILD_TARGET=cppcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
   fast_finish: true
   include:
     - env: BUILD_TARGET=clang-tidy-quiet
-    - env: BUILD_TARGET=scan-build
     - env: BUILD_TARGET=tests
     - env: BUILD_TARGET=tests PX4_ASAN=1
     - env: BUILD_TARGET=tests PX4_UBSAN=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,12 @@ matrix:
   include:
     - env: BUILD_TARGET=clang-tidy-quiet
     - env: BUILD_TARGET=tests
-    - env: BUILD_TARGET=tests PX4_ASAN=1
     - env: BUILD_TARGET=tests PX4_UBSAN=1
     - env: BUILD_TARGET=tests_coverage
     - env: BUILD_TARGET=coverity_scan
       dist: trusty
       if: branch = coverity_scan
   allow_failures:
-    - env: BUILD_TARGET=tests PX4_ASAN=1
     - env: BUILD_TARGET=tests PX4_UBSAN=1
     - env: BUILD_TARGET=tests_coverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,11 @@ matrix:
   include:
     - env: BUILD_TARGET=clang-tidy-quiet
     - env: BUILD_TARGET=tests
-    - env: BUILD_TARGET=tests PX4_UBSAN=1
     - env: BUILD_TARGET=tests_coverage
     - env: BUILD_TARGET=coverity_scan
       dist: trusty
       if: branch = coverity_scan
   allow_failures:
-    - env: BUILD_TARGET=tests PX4_UBSAN=1
     - env: BUILD_TARGET=tests_coverage
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
   fast_finish: true
   include:
     - env: BUILD_TARGET=clang-tidy-quiet
-    - env: BUILD_TARGET=cppcheck
     - env: BUILD_TARGET=scan-build
     - env: BUILD_TARGET=tests
     - env: BUILD_TARGET=tests PX4_ASAN=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - env: BUILD_TARGET=check_stack
     - env: BUILD_TARGET=clang-tidy-quiet
     - env: BUILD_TARGET=cppcheck
     - env: BUILD_TARGET=scan-build

--- a/circle.yml
+++ b/circle.yml
@@ -27,4 +27,4 @@ dependencies:
 
 test:
   override:
-    - NO_NINJA_BUILD=1 make quick_check
+    - NO_NINJA_BUILD=1 make -j2 quick_check


### PR DESCRIPTION
Travis has been unstable and unusably slow lately. I'm removing all extraneous parts of the build. All of these are either informational and can't cause the build to fail, or already moved to jenkins.

Plans for migrating these to the new Jenkins server (http://ci.px4.io:8080/) are in this project board. 
https://github.com/PX4/Firmware/projects/16