### PR TITLE
fix NAV_TRAFF_AVOID param definition: needs a ;

### DIFF
--- a/src/modules/navigator/navigator_params.c
+++ b/src/modules/navigator/navigator_params.c
@@ -152,7 +152,7 @@ PARAM_DEFINE_INT32(NAV_RCL_ACT, 2);
  *
  * @group Mission
  */
-PARAM_DEFINE_INT32(NAV_TRAFF_AVOID, 1)
+PARAM_DEFINE_INT32(NAV_TRAFF_AVOID, 1);
 
 /**
  * Airfield home Lat


### PR DESCRIPTION
Without that the parameter was not in parameters.xml, producing the error:
```
ERROR [lib__controllib] error finding param: NAV_TRAFF_AVOID
```