### PR TITLE
Assist pilot to respect max speed and min height when relying on optical flow

### DIFF
--- a/msg/vehicle_local_position.msg
+++ b/msg/vehicle_local_position.msg
@@ -55,4 +55,8 @@ float32 epv				# Standard deviation of vertical position error, (metres)
 float32 evh				# Standard deviation of horizontal velocity error, (metres/sec)
 float32 evv				# Standard deviation of horizontal velocity error, (metres/sec)
 
+# estimator specified vehicle limits
+float32 vxy_max				# maximum horizontal speed - set to 0 when not applicable (metres/sec)
+bool limit_hagl				# true when the height above ground needs to be limited to observe optical flow focus and range finder limits
+
 # TOPICS vehicle_local_position vehicle_local_position_groundtruth vehicle_vision_position

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1022,6 +1022,14 @@ void Ekf2::run()
 			_ekf.get_posNE_reset(&lpos.delta_xy[0], &lpos.xy_reset_counter);
 			_ekf.get_velNE_reset(&lpos.delta_vxy[0], &lpos.vxy_reset_counter);
 
+			// get control limit information
+			_ekf.get_ekf_ctrl_limits(&lpos.vxy_max, &lpos.limit_hagl);
+
+			// convert NaN to zero
+			if (!PX4_ISFINITE(lpos.vxy_max)) {
+				lpos.vxy_max = 0.0f;
+			}
+
 			// publish vehicle local position data
 			_vehicle_local_position_pub.update();
 

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -895,7 +895,9 @@ PARAM_DEFINE_FLOAT(EKF2_EV_POS_Z, 0.0f);
 
 /**
 * Airspeed fusion threshold. A value of zero will deactivate airspeed fusion. Any other positive
-* value will determine the minimum airspeed which will still be fused.
+* value will determine the minimum airspeed which will still be fused. Set to about 90% of the vehicles stall speed.
+* Both airspeed fusion and sideslip fusion must be active for the EKF to continue navigating after loss of GPS.
+* Use EKF2_FUSE_BETA to activate sideslip fusion.
 *
 * @group EKF2
 * @min 0.0
@@ -908,6 +910,8 @@ PARAM_DEFINE_FLOAT(EKF2_ARSP_THR, 0.0f);
 * Boolean determining if synthetic sideslip measurements should fused.
 *
 * A value of 1 indicates that fusion is active
+* Both  sideslip fusion and airspeed fusion must be active for the EKF to continue navigating after loss of GPS.
+* Use EKF2_ARSP_THR to activate airspeed fusion.
 *
 * @group EKF2
 * @boolean

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -728,7 +728,8 @@ PARAM_DEFINE_INT32(EKF2_OF_QMIN, 1);
 PARAM_DEFINE_FLOAT(EKF2_OF_GATE, 3.0f);
 
 /**
- * Optical Flow data will not fused if the magnitude of the flow rate > EKF2_OF_RMAX
+ * Optical Flow data will not fused if the magnitude of the flow rate > EKF2_OF_RMAX.
+ * Control loops will be instructed to limit ground speed such that the flow rate produced by movement over ground is less than 50% of EKF2_OF_RMAX.
  *
  * @group EKF2
  * @min 1.0

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -660,6 +660,8 @@ void BlockLocalPositionEstimator::publishLocalPos()
 		//TODO provide calculated values for these
 		_pub_lpos.get().evh = 0.0f;
 		_pub_lpos.get().evv = 0.0f;
+		_pub_lpos.get().vxy_max = 0.0f;
+		_pub_lpos.get().limit_hagl = false;
 	}
 }
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2206,6 +2206,8 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 		_hil_local_pos.yaw = euler.psi();
 		_hil_local_pos.xy_global = true;
 		_hil_local_pos.z_global = true;
+		_hil_local_pos.vxy_max = 0.0f;
+		_hil_local_pos.limit_hagl = false;
 
 		if (_local_pos_pub == nullptr) {
 			_local_pos_pub = orb_advertise(ORB_ID(vehicle_local_position), &_hil_local_pos);

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -231,6 +231,7 @@ private:
 		param_t opt_recover;
 		param_t rc_flt_smp_rate;
 		param_t rc_flt_cutoff;
+		param_t acc_max_flow_xy;
 	}		_params_handles;		/**< handles for interesting parameters */
 
 	struct {
@@ -259,6 +260,7 @@ private:
 
 		float rc_flt_smp_rate;
 		float rc_flt_cutoff;
+		float acc_max_flow_xy;
 
 		math::Vector<3> pos_p;
 		math::Vector<3> vel_p;
@@ -297,6 +299,8 @@ private:
 	float _z_derivative; /**< velocity in z that agrees with position rate */
 
 	float _takeoff_vel_limit; /**< velocity limit value which gets ramped up */
+
+	float _min_hagl_limit; /**< minimum continuous height above ground (m) */
 
 	// counters for reset events on position and velocity states
 	// they are used to identify a reset event
@@ -474,6 +478,7 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_manual_jerk_limit_z(1.0f),
 	_z_derivative(0.0f),
 	_takeoff_vel_limit(0.0f),
+	_min_hagl_limit(0.0f),
 	_z_reset_counter(0),
 	_xy_reset_counter(0),
 	_heading_reset_counter(0)
@@ -537,6 +542,7 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_params_handles.alt_mode = param_find("MPC_ALT_MODE");
 	_params_handles.rc_flt_cutoff = param_find("RC_FLT_CUTOFF");
 	_params_handles.rc_flt_smp_rate = param_find("RC_FLT_SMP_RATE");
+	_params_handles.acc_max_flow_xy = param_find("MPC_ACC_HOR_FLOW");
 
 	/* fetch initial parameter values */
 	parameters_update(true);
@@ -703,6 +709,16 @@ MulticopterPositionControl::parameters_update(bool force)
 		/* we only use jerk for braking if jerk_hor_max > jerk_hor_min; otherwise just set jerk very large */
 		_manual_jerk_limit_z = (_jerk_hor_max.get() > _jerk_hor_min.get()) ? _jerk_hor_max.get() : 1000000.f;
 
+		/* Get parameter values used to fly within optical flow sensor limits */
+		param_t handle = param_find("SENS_FLOW_MINRNG");
+
+		if (handle != PARAM_INVALID) {
+			param_get(handle, &_min_hagl_limit);
+		}
+
+		if (_params_handles.acc_max_flow_xy != PARAM_INVALID) {
+			param_get(handle, &_params.acc_max_flow_xy);
+		}
 
 	}
 
@@ -1357,6 +1373,7 @@ MulticopterPositionControl::control_manual()
 
 		/* reset position setpoint to current position if needed */
 		reset_pos_sp();
+
 	}
 
 	/* prepare yaw to rotate into NED frame */
@@ -2482,6 +2499,18 @@ MulticopterPositionControl::calculate_velocity_setpoint()
 		_vel_sp(2) = math::max(_vel_sp(2), -vel_limit);
 	}
 
+	// encourage pilot to respect respect flow sensor minimum height limitations
+	if (_local_pos.limit_hagl && _local_pos.dist_bottom_valid && _control_mode.flag_control_manual_enabled
+	    && _control_mode.flag_control_altitude_enabled) {
+		// If distance to ground is less than limit, increment set point upwards at up to the landing descent rate
+		if (_local_pos.dist_bottom < _min_hagl_limit) {
+			float climb_rate_bias = fminf(1.5f * _params.pos_p(2) * (_min_hagl_limit - _local_pos.dist_bottom), _params.land_speed);
+			_vel_sp(2) -= climb_rate_bias;
+			_pos_sp(2) -= climb_rate_bias * dt;
+
+		}
+	}
+
 	/* limit vertical downwards speed (positive z) close to ground
 	 * for now we use the altitude above home and assume that we want to land at same height as we took off */
 	float vel_limit = math::gradual(altitude_above_home,
@@ -3048,8 +3077,23 @@ MulticopterPositionControl::task_main()
 		/* set dt for control blocks */
 		setDt(dt);
 
-		/* set default max velocity in xy to vel_max */
-		_vel_max_xy = _params.vel_max_xy;
+		/* set default max velocity in xy to vel_max
+		 * Apply estimator limits if applicable */
+		if (_local_pos.vxy_max > 0.0f) {
+			// use the minimum of the estimator and user specified limit
+			_vel_max_xy = fminf(_params.vel_max_xy, _local_pos.vxy_max);
+			// Allow for a minimum of 0.3 m/s for repositioning
+			_vel_max_xy = fmaxf(_vel_max_xy, 0.3f);
+
+		} else {
+			// raise the limit at a constant rate up to the user specified value
+			if (_vel_max_xy >= _params.vel_max_xy) {
+				_vel_max_xy = _params.vel_max_xy;
+
+			} else {
+				_vel_max_xy += dt * _params.acc_max_flow_xy;
+			}
+		}
 
 		/* reset flags when landed */
 		if (_vehicle_land_detected.landed) {

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -2506,7 +2506,7 @@ MulticopterPositionControl::calculate_velocity_setpoint()
 		if (_local_pos.dist_bottom < _min_hagl_limit) {
 			float climb_rate_bias = fminf(1.5f * _params.pos_p(2) * (_min_hagl_limit - _local_pos.dist_bottom), _params.land_speed);
 			_vel_sp(2) -= climb_rate_bias;
-			_pos_sp(2) -= climb_rate_bias * dt;
+			_pos_sp(2) -= climb_rate_bias * _dt;
 
 		}
 	}

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -438,6 +438,20 @@ PARAM_DEFINE_FLOAT(MPC_ACC_HOR, 5.0f);
 PARAM_DEFINE_FLOAT(MPC_DEC_HOR_SLOW, 5.0f);
 
 /**
+ * Horizontal acceleration in manual modes when optical flow ground speed limit is removed.
+ * If full stick is being applied and the EKF starts using GPS whilst using optical flow,
+ * the vehicle will accelerate at this rate until the normal position control speed is achieved.
+ *
+ * @unit m/s/s
+ * @min 0.2
+ * @max 2.0
+ * @increment 0.1
+ * @decimal 1
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_ACC_HOR_FLOW, 0.5f);
+
+/**
  * Maximum vertical acceleration in velocity controlled modes upward
  *
  * @unit m/s/s

--- a/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
@@ -1362,6 +1362,8 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 			// TODO provide calculated values for these
 			local_pos.evh = 0.0f;
 			local_pos.evv = 0.0f;
+			local_pos.vxy_max = 0.0f;
+			local_pos.limit_hagl = false;
 
 			// this estimator does not provide a separate vertical position time derivative estimate, so use the vertical velocity
 			local_pos.z_deriv = z_est[1];

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -176,6 +176,15 @@ PARAM_DEFINE_INT32(SENS_BOARD_ROT, 0);
 PARAM_DEFINE_INT32(SENS_FLOW_ROT, 6);
 
 /**
+ * Optical Flow minimum focus distance
+ *
+ * This parameter defines the minimum distance from ground required for the optical flow sensor to operate reliably. The sensor may be usable below this height, but accuracy will progressively reduce to loss of focus.
+ * *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(SENS_FLOW_MINRNG, 0.7f);
+
+/**
  * Board rotation Y (Pitch) offset
  *
  * This parameter defines a rotational offset in degrees around the Y (Pitch) axis. It allows the user

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -529,6 +529,8 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 			hil_lpos.ref_lon = _hil_ref_lon;
 			hil_lpos.ref_alt = _hil_ref_alt;
 			hil_lpos.ref_timestamp = _hil_ref_timestamp;
+			hil_lpos.vxy_max = 0.0f;
+			hil_lpos.limit_hagl = false;
 
 			// always publish ground truth attitude message
 			int hil_lpos_multi;

--- a/src/platforms/ros/nodes/position_estimator/position_estimator.cpp
+++ b/src/platforms/ros/nodes/position_estimator/position_estimator.cpp
@@ -94,6 +94,8 @@ void PositionEstimator::ModelStatesCallback(const gazebo_msgs::ModelStatesConstP
 	msg_v_l_pos.ref_lon = 8.538777;
 	msg_v_l_pos.ref_alt = 1200.0f;
 
+	msg_v_l_pos.vxy_max = 0.0f;
+	msg_v_l_pos.limit_hagl = false;
 
 	msg_v_l_pos.timestamp = px4::get_time_micros();
 	_vehicle_position_pub.publish(msg_v_l_pos);


### PR DESCRIPTION
Replaces https://github.com/PX4/Firmware/pull/8157.

This PR limits the max ground speed and minimum height above to respect limits published by the estimator during optical flow operation. The methods making these limits available were added to the ecl/EKF here: https://github.com/PX4/ecl/pull/339

These limits are only applied during manual controlled flight using the position controller.

The height control biases the vertical velocity demand to push the vehicle back up if below the minimum height. This bias is limited to be no more than the landing sink rate and can be easily over-powered by the pilot if required. It is intended to discourage sustained operation below a height where the flow sensor is in focus.

The position control limits the max speed to the value published by the estimator. This limit is released gradually if the estimator starts using GPS and is no longer reliant on the optical flow sensor to prevent sudden acceleration if GPS use commences while stick inputs are non-zero.

Flight test log here with GPS use commencing during flight: https://logs.px4.io/plot_app?log=2a18e88c-4068-4c76-967b-911f05993a94

SITL test log here with optical flow only operation : https://logs.px4.io/plot_app?log=fb4729b7-212e-4ef8-9144-d80e99c8ab00