### PR TITLE
Commander: fix low battery failsafe behavior and messages

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2005,6 +2005,16 @@ Commander::run()
 								mavlink_log_emergency(&mavlink_log_pub, "DANGEROUSLY LOW BATTERY, LANDING FAILED");
 							}
 
+						} else if (low_bat_action == 1 && !critical_battery_voltage_actions_done) {
+							/* In case of transition to BATTERY_WARNING_EMERGENCY bypassing BATTERY_WARNING_CRITICAL */
+							if (TRANSITION_DENIED != main_state_transition(status, commander_state_s::MAIN_STATE_AUTO_RTL, status_flags, &internal_state)) {
+								warning_action_on = true;
+								mavlink_log_emergency(&mavlink_log_pub, "DANGEROUSLY LOW BATTERY, RETURNING TO LAUNCH");
+
+							} else {
+								mavlink_log_emergency(&mavlink_log_pub, "DANGEROUSLY LOW BATTERY, RTL FAILED");
+							}
+
 						} else {
 							mavlink_log_emergency(&mavlink_log_pub, "DANGEROUSLY LOW BATTERY, LANDING ADVISED!");
 						}

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1943,7 +1943,7 @@ Commander::run()
 					low_battery_voltage_actions_done = true;
 
 					if (armed.armed) {
-						mavlink_log_critical(&mavlink_log_pub, "LOW BATTERY, RETURN TO LAND ADVISED");
+						mavlink_log_critical(&mavlink_log_pub, "LOW BATTERY, RETURN TO LAUNCH ADVISED");
 
 					} else {
 						mavlink_log_critical(&mavlink_log_pub, "LOW BATTERY, TAKEOFF DISCOURAGED");
@@ -1964,7 +1964,7 @@ Commander::run()
 							// let us send the critical message even if already in RTL
 							if (TRANSITION_DENIED != main_state_transition(status, commander_state_s::MAIN_STATE_AUTO_RTL, status_flags, &internal_state)) {
 								warning_action_on = true;
-								mavlink_log_emergency(&mavlink_log_pub, "CRITICAL BATTERY, RETURNING TO LAND");
+								mavlink_log_emergency(&mavlink_log_pub, "CRITICAL BATTERY, RETURNING TO LAUNCH");
 
 							} else {
 								mavlink_log_emergency(&mavlink_log_pub, "CRITICAL BATTERY, RTL FAILED");
@@ -1999,14 +1999,14 @@ Commander::run()
 						if (low_bat_action == 2 || low_bat_action == 3) {
 							if (TRANSITION_CHANGED == main_state_transition(status, commander_state_s::MAIN_STATE_AUTO_LAND, status_flags, &internal_state)) {
 								warning_action_on = true;
-								mavlink_log_emergency(&mavlink_log_pub, "DANGEROUS BATTERY LEVEL, LANDING IMMEDIATELY");
+								mavlink_log_emergency(&mavlink_log_pub, "DANGEROUSLY LOW BATTERY, LANDING IMMEDIATELY");
 
 							} else {
-								mavlink_log_emergency(&mavlink_log_pub, "DANGEROUS BATTERY LEVEL, LANDING FAILED");
+								mavlink_log_emergency(&mavlink_log_pub, "DANGEROUSLY LOW BATTERY, LANDING FAILED");
 							}
 
 						} else {
-							mavlink_log_emergency(&mavlink_log_pub, "DANGEROUS BATTERY LEVEL, LANDING ADVISED!");
+							mavlink_log_emergency(&mavlink_log_pub, "DANGEROUSLY LOW BATTERY, LANDING ADVISED!");
 						}
 					}
 

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1997,7 +1997,7 @@ Commander::run()
 						dangerous_battery_level_requests_poweroff = true;
 					} else {
 						if (low_bat_action == 2 || low_bat_action == 3) {
-							if (TRANSITION_CHANGED == main_state_transition(status, commander_state_s::MAIN_STATE_AUTO_LAND, status_flags, &internal_state)) {
+							if (TRANSITION_DENIED != main_state_transition(status, commander_state_s::MAIN_STATE_AUTO_LAND, status_flags, &internal_state)) {
 								warning_action_on = true;
 								mavlink_log_emergency(&mavlink_log_pub, "DANGEROUSLY LOW BATTERY, LANDING IMMEDIATELY");
 


### PR DESCRIPTION
If battery failsafe action set to RTL (`COM_LOW_BAT_ACT = 1`), failsafe is triggered only in `BATTERY_WARNING_CRITICAL` state. If battery drops to `EMERGENCY` state missing `CRITICAL`, failsafe will not be activated. While this transition is unlikely, it is still possible and PR fixes this behavior adding check for `critical_battery_voltage_actions_done` in `BATTERY_WARNING_EMERGENCY` state handler so RTL will be triggered there when battery enters `EMERGENCY` state.

PR makes state transition outcomes' checks consistent, replacing
`TRANSITION_CHANGED == main_state_transition(...)` with
`TRANSITION_DENIED != main_state_transition(...)` in `BATTERY_WARNING_EMERGENCY` `if` branch — commit 263b7ea ("commander battery failsafe only error if TRANSITION_DENIED", 2017-10-06) already did this replacement in `BATTERY_WARNING_CRITICAL` branch. Comparison with `TRANSITION_CHANGED` can lead to "LANDING FAILED" message when the vehicle is actually landing.

Battery failsafe messages were fixed for consistency too.

The code was compiled and tested in SITL.