### PR TITLE
mavlink_main: fix broadcast computation

### DIFF
--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -59,6 +59,10 @@
 #include <systemlib/mavlink_log.h>
 #include <drivers/device/ringbuffer.h>
 
+#ifdef __PX4_POSIX
+#include <net/if.h>
+#endif
+
 #include <uORB/uORB.h>
 #include <uORB/topics/mission.h>
 #include <uORB/topics/mission_result.h>
@@ -417,6 +421,10 @@ public:
 
 	int 			get_socket_fd() { return _socket_fd; };
 #ifdef __PX4_POSIX
+	const in_addr query_netmask_addr(const int socket_fd, const ifreq &ifreq);
+
+	const in_addr compute_broadcast_addr(const in_addr &host_addr, const in_addr &netmask_addr);
+
 	struct sockaddr_in 	*get_client_source_address() { return &_src_addr; }
 
 	void			set_client_source_initialized() { _src_addr_initialized = true; }


### PR DESCRIPTION
The way the broadcast IP is currently fetched is by sending an ioctl()
request. The limitation of this is that the broadcast address may not
be set on the network interface (more specifically, it is usually not
set in docker containers). In those cases, it results in the broadcast
address becoming 0.0.0.0, which is not valid [1].

This fix uses the network IP and the netmask to compute the directed
broadcast address. This should be more reliable, as both of those are
always set on the network interface.

[1]: https://tools.ietf.org/html/rfc1122, section 3.2.1.3 (a)