### PR TITLE
mc_pos_control: fix position setpoint overshoot

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -2453,20 +2453,8 @@ MulticopterPositionControl::calculate_velocity_setpoint(float dt)
 	_vel_sp(2) = math::min(_vel_sp(2), vel_limit);
 
 	/* apply slewrate (aka acceleration limit) for smooth flying */
-
 	if (!_control_mode.flag_control_auto_enabled) {
 		vel_sp_slewrate(dt);
-	}
-
-	_vel_sp_prev = _vel_sp;
-
-	/* special velocity setpoint limitation for smooth takeoff (after slewrate!) */
-	if (_in_smooth_takeoff) {
-		_in_smooth_takeoff = _takeoff_vel_limit < -_vel_sp(2);
-		/* ramp vertical velocity limit up to takeoff speed */
-		_takeoff_vel_limit += -_vel_sp(2) * dt / _takeoff_ramp_time.get();
-		/* limit vertical velocity to the current ramp value */
-		_vel_sp(2) = math::max(_vel_sp(2), -_takeoff_vel_limit);
 	}
 
 	/* make sure velocity setpoint is constrained in all directions (xyz) */
@@ -2478,6 +2466,20 @@ MulticopterPositionControl::calculate_velocity_setpoint(float dt)
 	}
 
 	_vel_sp(2) = math::constrain(_vel_sp(2), -_params.vel_max_up, _params.vel_max_down);
+
+	/* previous velocity must be updated before smooth takeoff ramping because
+	 * otherwise in the beginning of takeoff it can make _vel_sp_prev positive
+	 * and slewrate limit will not allow to take off */
+	_vel_sp_prev = _vel_sp;
+
+	/* special velocity setpoint limitation for smooth takeoff (after slewrate!) */
+	if (_in_smooth_takeoff) {
+		_in_smooth_takeoff = _takeoff_vel_limit < -_vel_sp(2);
+		/* ramp vertical velocity limit up to takeoff speed */
+		_takeoff_vel_limit += -_vel_sp(2) * dt / _takeoff_ramp_time.get();
+		/* limit vertical velocity to the current ramp value */
+		_vel_sp(2) = math::max(_vel_sp(2), -_takeoff_vel_limit);
+	}
 }
 
 void


### PR DESCRIPTION
This PR addresses massive position setpoint overshoot caused by `_vel_sp_prev` windup. The bug is critical for offboard mode usage.

Flying in offboard mode we had constantly observed position setpoint overshoots in case of flight to distant setpoint. E.g., here we are flying back and forth in offboard mode: https://review.px4.io/plot_app?log=61a675f6-020a-462f-b1cf-b58974460d44. Overshoots really stand out:

![Overshoots](https://user-images.githubusercontent.com/20798956/32437968-ff23a816-c2f9-11e7-8745-67fef6ea073d.png)

Here is plot of y, vy and corresponding setpoints for 1000 m flight in offboard in SITL on current master (https://logs.px4.io/plot_app?log=92b7ba3c-e2f7-4094-98a3-05e8b5a8493f):

![master](https://user-images.githubusercontent.com/20798956/32437865-b5007b24-c2f9-11e7-9580-2f456f57f81b.png)

As can be seen on the plot, copter have overshooted setpoint for over 60 m because velocity setpoint started to drop from max forward velocity when copter already was 50 m ahead of setpoint.

After debugging of mc_pos_control_main.cpp it became clear that cause of overshoots is windup of `_vel_sp_prev(0)` and `(1)`. The reason is [this fragment](https://github.com/PX4/Firmware/blob/aa699cf4b7e63d9bf17dc2ba2b95e2e02224a6ab/src/modules/mc_pos_control/mc_pos_control_main.cpp#L2455) of `calculate_velocity_setpoint()`: 

```c++
if (!_control_mode.flag_control_auto_enabled) {
	vel_sp_slewrate(dt);
}

_vel_sp_prev = _vel_sp;

/* ... */

/* make sure velocity setpoint is constrained in all directions (xyz) */
float vel_norm_xy = sqrtf(_vel_sp(0) * _vel_sp(0) + _vel_sp(1) * _vel_sp(1));

if (vel_norm_xy > _vel_max_xy) {
	_vel_sp(0) = _vel_sp(0) * _vel_max_xy / vel_norm_xy;
	_vel_sp(1) = _vel_sp(1) * _vel_max_xy / vel_norm_xy;
}
```
So `vel_sp_slewrate()` never see constrained velocity and `_vel_sp_prev` continues to rise to hunders and thousands m/s. When copter approaches the setpoint, `_vel_sp_prev` drops, but it's change rate is limited by `vel_sp_slewrate()`. Because of this windup `_vel_sp` can't begin to lower at time and vehicle overshoots. Overshoots are negligible in AUTO mode because mc_pos_control moves position setpoint so it is always close to the vehicle.

It would be more correct to address this moving `_vel_sp_prev = _vel_sp` to the end of control cycle, but this change causes incorrect behavior of smooth takeoff limiter so I had to move velocity constraining before `_vel_sp_prev` assignment, leaving smooth takeoff limit after it.

This is the same 1000 m flight in SITL after fix (https://logs.px4.io/plot_app?log=d5bd2519-432c-446a-b8c9-fd021c2fdab6):

![fix](https://user-images.githubusercontent.com/20798956/32439298-21fcc03e-c2ff-11e7-963c-92051e217d9e.png)

@MaEtUgR, @Stifael, please review.