### PR TITLE
SDP3x Airspeed Correction

### DIFF
--- a/Tools/models/sdp3x_pitot_model.py
+++ b/Tools/models/sdp3x_pitot_model.py
@@ -30,18 +30,29 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
+# formula for metal pitot tube with round tip as here: https://drotek.com/shop/2986-large_default/sdp3x-airspeed-sensor-kit-sdp31.jpg
+# and tubing as provided by px4/drotek (1.5 mm diameter)
+
+
+
 import numpy as np
 import matplotlib.pyplot as plt
 
+P_cal=96600. #Pa
+P_amb=96600. #dummy-value, use absolute pressure sensor!!
 
 
 ## differential pressure, sensor values in Pascal
-dp_SDP33=np.linspace(0,800,100)
+dp_SDP33_raw=np.linspace(0,80,100)
 
+
+
+
+dp_SDP33=dp_SDP33_raw*P_cal/P_amb
 
 
 ## total length tube in mm = length dynamic port+ length static port; compensation only valid for inner diameter of 1.5mm
-l_tube=400
+l_tube=450
 
 ## densitiy air in kg/m3
 rho_air=1.29
@@ -50,18 +61,20 @@ rho_air=1.29
 ## flow through sensor
 flow_SDP33=(300.805 - 300.878/(0.00344205*dp_SDP33**0.68698 + 1))*1.29/rho_air
 
-## additional dp through pitot tube
-dp_Pitot=28557670. - 28557670./(1 + (flow_SDP33/5027611)**1.227924)
 
+
+## additional dp through pitot tube
+dp_Pitot=(0.0032*flow_SDP33**2 + 0.0123*flow_SDP33+1.)*1.29/rho_air
 
 ## pressure drop through tube
-dp_Tube=flow_SDP33*0.000746124*l_tube*rho_air
+dp_Tube=(flow_SDP33*0.674)/450*l_tube*rho_air/1.29
 
 ## speed at pitot-tube tip due to flow through sensor
-dv=0.0331582*flow_SDP33
+dv=0.125*flow_SDP33
 
 ## sum of all pressure drops
 dp_tot=dp_SDP33+dp_Tube+dp_Pitot
+
 
 ## computed airspeed without correction for inflow-speed at tip of pitot-tube
 airspeed_uncorrected=np.sqrt(2*dp_tot/rho_air)
@@ -74,18 +87,24 @@ airspeed_corrected=airspeed_uncorrected+dv
 airspeed_raw=np.sqrt(2*dp_SDP33/rho_air)
 
 
-
-
 plt.figure()
-plt.plot(dp_SDP33,airspeed_corrected/airspeed_raw)
+plt.plot(dp_SDP33,airspeed_corrected)
 plt.xlabel('differential pressure raw value [Pa]')
-plt.ylabel('correction factor [-]')
+plt.ylabel('airspeed_corrected [m/s]')
 plt.show()
 
 
 
-plt.figure()
-plt.plot(airspeed_corrected,(airspeed_corrected-airspeed_raw)/airspeed_corrected)
-plt.xlabel('airspeed [m/s]')
-plt.ylabel('relative error [-]')
-plt.show()
+##plt.figure()
+##plt.plot(dp_SDP33,airspeed_corrected/airspeed_raw)
+##plt.xlabel('differential pressure raw value [Pa]')
+##plt.ylabel('correction factor [-]')
+##plt.show()
+##
+##
+##
+##plt.figure()
+##plt.plot(airspeed_corrected,(airspeed_corrected-airspeed_raw)/airspeed_corrected)
+##plt.xlabel('airspeed [m/s]')
+##plt.ylabel('relative error [-]')
+##plt.show()

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -32,7 +32,7 @@ set(config_module_list
 	#drivers/hott/hott_sensors
 	#drivers/blinkm
 	drivers/airspeed
-	drivers/ets_airspeed
+	#drivers/ets_airspeed
 	drivers/ms4525_airspeed
 	drivers/ms5525_airspeed
 	drivers/sdp3x_airspeed

--- a/src/modules/sensors/parameters.cpp
+++ b/src/modules/sensors/parameters.cpp
@@ -157,8 +157,9 @@ int initialize_parameter_handles(ParameterHandles &parameter_handles)
 
 	parameter_handles.vibe_thresh = param_find("ATT_VIBE_THRESH");
 
-	parameter_handles.air_pmodel = param_find("CAL_AIR_PMODEL");
+	parameter_handles.air_cmodel = param_find("CAL_AIR_CMODEL");
 	parameter_handles.air_tube_length = param_find("CAL_AIR_TUBELEN");
+	parameter_handles.air_tube_diameter_mm = param_find("CAL_AIR_TUBED_MM");
 
 	// These are parameters for which QGroundControl always expects to be returned in a list request.
 	// We do a param_find here to force them into the list.
@@ -491,8 +492,9 @@ int update_parameters(const ParameterHandles &parameter_handles, Parameters &par
 
 	param_get(parameter_handles.vibe_thresh, &parameters.vibration_warning_threshold);
 
-	param_get(parameter_handles.air_pmodel, &parameters.air_pmodel);
+	param_get(parameter_handles.air_cmodel, &parameters.air_cmodel);
 	param_get(parameter_handles.air_tube_length, &parameters.air_tube_length);
+	param_get(parameter_handles.air_tube_diameter_mm, &parameters.air_tube_diameter_mm);
 
 	return ret;
 }

--- a/src/modules/sensors/parameters.h
+++ b/src/modules/sensors/parameters.h
@@ -146,9 +146,9 @@ struct Parameters {
 
 	float vibration_warning_threshold;
 
-	int32_t air_pmodel;
+	int32_t air_cmodel;
 	float air_tube_length;
-
+	float air_tube_diameter_mm;
 };
 
 struct ParameterHandles {
@@ -230,8 +230,9 @@ struct ParameterHandles {
 
 	param_t vibe_thresh; /**< vibration threshold */
 
-	param_t air_pmodel;
+	param_t air_cmodel;
 	param_t air_tube_length;
+	param_t air_tube_diameter_mm;
 
 };
 

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -818,17 +818,25 @@ PARAM_DEFINE_INT32(CAL_BARO_PRIME, 0);
  * Airspeed sensor compensation model for the SDP3x
  *
  * @value 0 Model with Pitot
- * @value 1 Model without Pitot
+ * 		CAL_AIR_TUBED_MM: Not used, 1.5 mm tubes assumed.
+ * 		CAL_AIR_TUBELEN: Length of the tubes connecting the pitot to the sensor.
+ * @value 1 Model without Pitot (1.5 mm tubes)
+ * 		CAL_AIR_TUBED_MM: Not used, 1.5 mm tubes assumed.
+ * 		CAL_AIR_TUBELEN: Length of the tubes connecting the pitot to the sensor.
  * @value 2 Tube Pressure Drop
- *
+ * 		CAL_AIR_TUBED_MM: Diameter in mm of the pitot and tubes, must have the same diameter.
+ * 		CAL_AIR_TUBELEN: Length of the tubes connecting the pitot to the sensor and the static + dynamic port length of the pitot.
  * @group Sensor Calibration
  */
 PARAM_DEFINE_INT32(CAL_AIR_CMODEL, 0);
 
 /**
- * Airspeed sensor tube length
+ * Airspeed sensor tube length.
+ *
+ * See the CAL_AIR_CMODEL explanation on how this parameter should be set.
+ *
  * @min 0.01
- * @max 0.5
+ * @max 2.00
  * @unit meter
  *
  * @group Sensor Calibration
@@ -840,7 +848,7 @@ PARAM_DEFINE_FLOAT(CAL_AIR_TUBELEN, 0.2f);
  *
  * @min 0.1
  * @max 100
- * @unit meter
+ * @unit millimeter
  *
  * @group Sensor Calibration
  */

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -815,13 +815,15 @@ PARAM_DEFINE_INT32(CAL_MAG_SIDES, 63);
 PARAM_DEFINE_INT32(CAL_BARO_PRIME, 0);
 
 /**
- * Airspeed sensor pitot model
+ * Airspeed sensor compensation model for the SDP3x
  *
- * @value 0 HB Pitot
+ * @value 0 Model with Pitot
+ * @value 1 Model without Pitot
+ * @value 2 Tube Pressure Drop
  *
  * @group Sensor Calibration
  */
-PARAM_DEFINE_INT32(CAL_AIR_PMODEL, 0);
+PARAM_DEFINE_INT32(CAL_AIR_CMODEL, 0);
 
 /**
  * Airspeed sensor tube length
@@ -832,6 +834,17 @@ PARAM_DEFINE_INT32(CAL_AIR_PMODEL, 0);
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(CAL_AIR_TUBELEN, 0.2f);
+
+/**
+ * Airspeed sensor tube diameter. Only used for the Tube Pressure Drop Compensation.
+ *
+ * @min 0.1
+ * @max 100
+ * @unit meter
+ *
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(CAL_AIR_TUBED_MM, 1.5f);
 
 /**
  * Differential pressure sensor offset

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -817,15 +817,19 @@ PARAM_DEFINE_INT32(CAL_BARO_PRIME, 0);
 /**
  * Airspeed sensor compensation model for the SDP3x
  *
- * @value 0 Model with Pitot
+ * Model with Pitot
  * 		CAL_AIR_TUBED_MM: Not used, 1.5 mm tubes assumed.
  * 		CAL_AIR_TUBELEN: Length of the tubes connecting the pitot to the sensor.
- * @value 1 Model without Pitot (1.5 mm tubes)
+ * Model without Pitot (1.5 mm tubes)
  * 		CAL_AIR_TUBED_MM: Not used, 1.5 mm tubes assumed.
  * 		CAL_AIR_TUBELEN: Length of the tubes connecting the pitot to the sensor.
- * @value 2 Tube Pressure Drop
+ * Tube Pressure Drop
  * 		CAL_AIR_TUBED_MM: Diameter in mm of the pitot and tubes, must have the same diameter.
  * 		CAL_AIR_TUBELEN: Length of the tubes connecting the pitot to the sensor and the static + dynamic port length of the pitot.
+ *
+ * @value 0 Model with Pitot
+ * @value 1 Model without Pitot (1.5 mm tubes)
+ * @value 2 Tube Pressure Drop
  * @group Sensor Calibration
  */
 PARAM_DEFINE_INT32(CAL_AIR_CMODEL, 0);

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -345,8 +345,8 @@ Sensors::diff_pres_poll(struct sensor_combined_s &raw)
 
 		/* don't risk to feed negative airspeed into the system */
 		_airspeed.indicated_airspeed_m_s = math::max(0.0f,
-						   calc_indicated_airspeed_corrected((enum AIRSPEED_PITOT_MODEL)_parameters.air_pmodel,
-								   smodel, _parameters.air_tube_length,
+						   calc_indicated_airspeed_corrected((enum AIRSPEED_COMPENSATION_MODEL)_parameters.air_cmodel,
+								   smodel, _parameters.air_tube_length, _parameters.air_tube_diameter_mm,
 								   _diff_pres.differential_pressure_filtered_pa, _voted_sensors_update.baro_pressure(),
 								   air_temperature_celsius));
 

--- a/src/modules/systemlib/airspeed.c
+++ b/src/modules/systemlib/airspeed.c
@@ -75,6 +75,9 @@ float calc_indicated_airspeed_corrected(enum AIRSPEED_COMPENSATION_MODEL pmodel,
     break;
 
     case AIRSPEED_SENSOR_MODEL_SDP3X: {
+        // assumes a metal pitot tube with round tip as here: https://drotek.com/shop/2986-large_default/sdp3x-airspeed-sensor-kit-sdp31.jpg
+        // and tubing as provided by px4/drotek (1.5 mm diameter)
+        // The tube_len represents the length of the tubes connecting the pitot to the sensor.
         switch (pmodel) {
         case AIRSPEED_COMPENSATION_MODEL_PITOT:
         case AIRSPEED_COMPENSATION_MODEL_NO_PITOT: {
@@ -109,6 +112,10 @@ float calc_indicated_airspeed_corrected(enum AIRSPEED_COMPENSATION_MODEL pmodel,
         }
         break;
         case AIRSPEED_COMPENSATION_TUBE_PRESSURE_LOSS: {
+            // Pressure loss compensation as defined in https://goo.gl/UHV1Vv.
+            // tube_dia_mm: Diameter in mm of the pitot and tubes, must have the same diameter.
+            // tube_len: Length of the tubes connecting the pitot to the sensor and the static + dynamic port length of the pitot.
+
             // check if the tube diameter and dp is nonzero to avoid division by 0
             if ((tube_dia_mm > 0.0f) && (dp > 0.0f)) {
                 const double d_tubePow4 = pow((double)tube_dia_mm * 1e-3, 4);

--- a/src/modules/systemlib/airspeed.c
+++ b/src/modules/systemlib/airspeed.c
@@ -55,86 +55,119 @@
  * @param differential_pressure total_ pressure - static pressure
  * @return indicated airspeed in m/s
  */
-float calc_indicated_airspeed_corrected(enum AIRSPEED_PITOT_MODEL pmodel, enum AIRSPEED_SENSOR_MODEL smodel,
-					float tube_len, float differential_pressure, float pressure_ambient, float temperature_celsius)
+float calc_indicated_airspeed_corrected(enum AIRSPEED_COMPENSATION_MODEL pmodel, enum AIRSPEED_SENSOR_MODEL smodel,
+                                        float tube_len, float tube_dia_mm, float differential_pressure, float pressure_ambient, float temperature_celsius)
 {
 
-	// air density in kg/m3
-	double rho_air = get_air_density(pressure_ambient, temperature_celsius);
+    // air density in kg/m3
+    const double rho_air = get_air_density(pressure_ambient, temperature_celsius);
 
-	double dp = fabsf(differential_pressure);
-	// additional dp through pitot tube
-	float dp_pitot;
-	float dp_tube;
-	float dv;
+    const float dp = fabsf(differential_pressure);
+    float dp_tot = dp;
 
-	switch (smodel) {
+    float dv = 0.0f;
 
-	case AIRSPEED_SENSOR_MODEL_MEMBRANE: {
-			dp_pitot = 0.0f;
-			dp_tube = 0.0f;
-			dv = 0.0f;
-		}
-		break;
+    switch (smodel) {
 
-	case AIRSPEED_SENSOR_MODEL_SDP3X: {
-			// flow through sensor
-			double flow_SDP33 = (300.805 - 300.878 / (0.00344205 * pow(dp, 0.68698) + 1)) * 1.29 / rho_air;
+    case AIRSPEED_SENSOR_MODEL_MEMBRANE: {
+        // do nothing
+    }
+    break;
 
-			// for too small readings the compensation might result in a negative flow which causes numerical issues
-			if (flow_SDP33 < 0.0) {
-				flow_SDP33 = 0.0;
-			}
+    case AIRSPEED_SENSOR_MODEL_SDP3X: {
+        switch (pmodel) {
+        case AIRSPEED_COMPENSATION_MODEL_PITOT:
+        case AIRSPEED_COMPENSATION_MODEL_NO_PITOT: {
+            const double dp_corr = (double)dp * 96600.0 / (double)pressure_ambient;
+            // flow through sensor
+            double flow_SDP33 = (300.805 - 300.878 / (0.00344205 * pow(dp_corr, 0.68698) + 1)) * 1.29 / rho_air;
 
-			switch (pmodel) {
-			case AIRSPEED_PITOT_MODEL_HB:
-				dp_pitot = 28557670.0 - 28557670.0 / (1 + pow((flow_SDP33 / 5027611.0), 1.227924));
-				break;
+            // for too small readings the compensation might result in a negative flow which causes numerical issues
+            if (flow_SDP33 < 0.0) {
+                flow_SDP33 = 0.0;
+            }
 
-			default:
-				dp_pitot = 0.0f;
-				break;
-			}
+            float dp_pitot = 0.0f;
+            switch (pmodel) {
+            case AIRSPEED_COMPENSATION_MODEL_PITOT:
+                dp_pitot = (0.0032 * flow_SDP33 * flow_SDP33 + 0.0123 * flow_SDP33 + 1.0) * 1.29 / rho_air;
+                break;
 
-			// pressure drop through tube
-			dp_tube = flow_SDP33 * 0.000746124 * (double)tube_len * rho_air;
+            default:
+                // do nothing
+                break;
+            }
 
-			// speed at pitot-tube tip due to flow through sensor
-			dv = 0.0331582 * flow_SDP33;
-		}
-		break;
+            // pressure drop through tube
+            const float dp_tube = (flow_SDP33 * 0.674) / 450.0 * (double)tube_len * rho_air / 1.29;
 
-	default: {
-			dp_pitot = 0.0f;
-			dp_tube = 0.0f;
-			dv = 0.0f;
-		}
-		break;
-	}
+            // speed at pitot-tube tip due to flow through sensor
+            dv = 0.125 * flow_SDP33;
 
-	// if (!PX4_ISFINITE(dp_tube)) {
-	// 	dp_tube = 0.0f;
-	// }
+            // sum of all pressure drops
+            dp_tot = (float)dp_corr + dp_tube + dp_pitot;
+        }
+        break;
+        case AIRSPEED_COMPENSATION_TUBE_PRESSURE_LOSS: {
+            // check if the tube diameter and dp is nonzero to avoid division by 0
+            if ((tube_dia_mm > 0.0f) && (dp > 0.0f)) {
+                const double d_tubePow4 = pow((double)tube_dia_mm * 1e-3, 4);
+                const double denominator = M_PI * d_tubePow4 * rho_air * (double)dp;
 
-	// if (!PX4_ISFINITE(dp_pitot)) {
-	// 	dp_pitot = 0.0f;
-	// }
+                // avoid division by 0
+                double eps = 0.0f;
+                if (fabs(denominator)> 1e-32) {
+                    const double viscosity = (18.205 + 0.0484 * ((double)temperature_celsius - 20.0)) * 1e-6;
 
-	// if (!PX4_ISFINITE(dv)) {
-	// 	dv = 0.0f;
-	// }
+                    // 4.79 * 1e-7 -> mass flow through sensor
+                    // 59.5 -> dp sensor constant where linear and quadratic contribution to dp vs flow is equal
+                    eps = -64.0 * (double)tube_len * viscosity * 4.79 * 1e-7 * (sqrt(1.0 + 8.0 * (double)dp / 59.3319) - 1.0) / denominator;
+                }
 
-	// sum of all pressure drops
-	float dp_tot = (float)dp + dp_tube + dp_pitot;
+                // range check on eps
+                if (fabs(eps) >= 1.0)
+                    eps = 0.0;
 
-	// computed airspeed without correction for inflow-speed at tip of pitot-tube
-	float airspeed_uncorrected = sqrtf(2 * dp_tot / CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C);
+                // pressure correction
+                dp_tot = dp / (1.0f + (float)eps);
+            }
+        }
+        break;
+        default: {
+            // do nothing
+        }
+        break;
+        }
 
-	// corrected airspeed
-	float airspeed_corrected = airspeed_uncorrected + dv;
+    }
+    break;
 
-	// return result with correct sign
-	return (differential_pressure > 0.0f) ? airspeed_corrected : -airspeed_corrected;
+    default: {
+        // do nothing
+    }
+    break;
+    }
+
+    // if (!PX4_ISFINITE(dp_tube)) {
+    // 	dp_tube = 0.0f;
+    // }
+
+    // if (!PX4_ISFINITE(dp_pitot)) {
+    // 	dp_pitot = 0.0f;
+    // }
+
+    // if (!PX4_ISFINITE(dv)) {
+    // 	dv = 0.0f;
+    // }
+
+    // computed airspeed without correction for inflow-speed at tip of pitot-tube
+    const float airspeed_uncorrected = sqrtf(2 * dp_tot / CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C);
+
+    // corrected airspeed
+    const float airspeed_corrected = airspeed_uncorrected + dv;
+
+    // return result with correct sign
+    return (differential_pressure > 0.0f) ? airspeed_corrected : -airspeed_corrected;
 }
 
 
@@ -152,12 +185,12 @@ float calc_indicated_airspeed(float differential_pressure)
 {
 
 
-	if (differential_pressure > 0.0f) {
-		return sqrtf((2.0f * differential_pressure) / CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C);
+    if (differential_pressure > 0.0f) {
+        return sqrtf((2.0f * differential_pressure) / CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C);
 
-	} else {
-		return -sqrtf((2.0f * fabsf(differential_pressure)) / CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C);
-	}
+    } else {
+        return -sqrtf((2.0f * fabsf(differential_pressure)) / CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C);
+    }
 
 }
 
@@ -173,8 +206,8 @@ float calc_indicated_airspeed(float differential_pressure)
  */
 float calc_true_airspeed_from_indicated(float speed_indicated, float pressure_ambient, float temperature_celsius)
 {
-	return speed_indicated * sqrtf(CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C / get_air_density(pressure_ambient,
-				       temperature_celsius));
+    return speed_indicated * sqrtf(CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C / get_air_density(pressure_ambient,
+                                   temperature_celsius));
 }
 
 /**
@@ -189,23 +222,23 @@ float calc_true_airspeed_from_indicated(float speed_indicated, float pressure_am
  */
 float calc_true_airspeed(float total_pressure, float static_pressure, float temperature_celsius)
 {
-	float density = get_air_density(static_pressure, temperature_celsius);
+    float density = get_air_density(static_pressure, temperature_celsius);
 
-	if (density < 0.0001f || !isfinite(density)) {
-		density = CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C;
-	}
+    if (density < 0.0001f || !isfinite(density)) {
+        density = CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C;
+    }
 
-	float pressure_difference = total_pressure - static_pressure;
+    float pressure_difference = total_pressure - static_pressure;
 
-	if (pressure_difference > 0) {
-		return sqrtf((2.0f * (pressure_difference)) / density);
+    if (pressure_difference > 0) {
+        return sqrtf((2.0f * (pressure_difference)) / density);
 
-	} else {
-		return -sqrtf((2.0f * fabsf(pressure_difference)) / density);
-	}
+    } else {
+        return -sqrtf((2.0f * fabsf(pressure_difference)) / density);
+    }
 }
 
 float get_air_density(float static_pressure, float temperature_celsius)
 {
-	return static_pressure / (CONSTANTS_AIR_GAS_CONST * (temperature_celsius - CONSTANTS_ABSOLUTE_NULL_CELSIUS));
+    return static_pressure / (CONSTANTS_AIR_GAS_CONST * (temperature_celsius - CONSTANTS_ABSOLUTE_NULL_CELSIUS));
 }

--- a/src/modules/systemlib/airspeed.h
+++ b/src/modules/systemlib/airspeed.h
@@ -69,7 +69,8 @@ enum AIRSPEED_COMPENSATION_MODEL {
  * @param static_pressure pressure at the side of the tube/airplane
  * @return indicated airspeed in m/s
  */
-__EXPORT float calc_indicated_airspeed_corrected(enum AIRSPEED_COMPENSATION_MODEL pmodel, enum AIRSPEED_SENSOR_MODEL smodel,
+__EXPORT float calc_indicated_airspeed_corrected(enum AIRSPEED_COMPENSATION_MODEL pmodel,
+		enum AIRSPEED_SENSOR_MODEL smodel,
 		float tube_len, float tube_dia_mm, float differential_pressure, float pressure_ambient, float temperature_celsius);
 
 /**

--- a/src/modules/systemlib/airspeed.h
+++ b/src/modules/systemlib/airspeed.h
@@ -52,8 +52,10 @@ enum AIRSPEED_SENSOR_MODEL {
 	AIRSPEED_SENSOR_MODEL_SDP3X,
 };
 
-enum AIRSPEED_PITOT_MODEL {
-	AIRSPEED_PITOT_MODEL_HB = 0
+enum AIRSPEED_COMPENSATION_MODEL {
+	AIRSPEED_COMPENSATION_MODEL_PITOT = 0,
+	AIRSPEED_COMPENSATION_MODEL_NO_PITOT = 1,
+	AIRSPEED_COMPENSATION_TUBE_PRESSURE_LOSS = 2
 };
 
 /**
@@ -67,8 +69,8 @@ enum AIRSPEED_PITOT_MODEL {
  * @param static_pressure pressure at the side of the tube/airplane
  * @return indicated airspeed in m/s
  */
-__EXPORT float calc_indicated_airspeed_corrected(enum AIRSPEED_PITOT_MODEL pmodel, enum AIRSPEED_SENSOR_MODEL smodel,
-		float tube_len, float differential_pressure, float pressure_ambient, float temperature_celsius);
+__EXPORT float calc_indicated_airspeed_corrected(enum AIRSPEED_COMPENSATION_MODEL pmodel, enum AIRSPEED_SENSOR_MODEL smodel,
+		float tube_len, float tube_dia_mm, float differential_pressure, float pressure_ambient, float temperature_celsius);
 
 /**
  * Calculate indicated airspeed.


### PR DESCRIPTION
- Update the model for the airspeed correction provided by [sensirion](https://github.com/PX4/Firmware/issues/8140).

- Add a pressure drop compensation which can be used for other pitot configurations than the standard drotek one.

- Remove the ets_airspeed driver from px4fmu-v2_default

I did test flights with a membrane based sensor, our custom pitot tube and the drotek pitot tube. During the flights I mainly did loitering with different airspeeds. If the airspeed has an offset then the wind will have an oscillation with the loitering frequency.

Wind estimate for the membrane based sensor:
![membrane](https://user-images.githubusercontent.com/6713722/32442439-bcb7fd7c-c2fb-11e7-821c-295baee2641b.png)

Wind estimate for the drotek pitot tube:
![drotek](https://user-images.githubusercontent.com/6713722/32442448-c3dcc9c0-c2fb-11e7-91a6-bd2076f6d1b2.png)

Wind estimate for our custom pitot tube:
![custom](https://user-images.githubusercontent.com/6713722/32442510-fa7b6752-c2fb-11e7-891b-84433b225abe.png)

Based on the wind plots I would say the airspeed is still by about 0.2 to 0.4 m/s off but this can be compensated by fine tuning the parameters.
