### PR TITLE
Fixed version firmware type

### DIFF
--- a/src/lib/version/version.c
+++ b/src/lib/version/version.c
@@ -83,6 +83,9 @@ uint32_t version_tag_to_number(const char *tag)
 		} else if (tag[i] == 'p') {
 			firmware_type = FIRMWARE_TYPE_ALPHA;
 
+		} else if (tag[i] == 't' && i < strlen(tag) - 1 && tag[i + 1] == 'y') {
+			firmware_type = FIRMWARE_TYPE_DEV;
+
 		} else if (tag[i] == 't') {
 			firmware_type = FIRMWARE_TYPE_BETA;
 
@@ -93,7 +96,8 @@ uint32_t version_tag_to_number(const char *tag)
 
 	if ((dash_count == 1 && point_count == 2 && firmware_type == FIRMWARE_TYPE_RELEASE) ||
 	    (dash_count == 2 && point_count == 2) ||
-	    (dash_count == 3 && point_count == 4)) {
+	    (dash_count == 3 && point_count == 4) ||
+		(dash_count == 4 && point_count == 4)) {
 		firmware_type = FIRMWARE_TYPE_DEV;
 	}
 
@@ -167,6 +171,9 @@ uint32_t version_tag_to_vendor_version_number(const char *tag)
 		} else if (tag[i] == 'p') {
 			firmware_type = FIRMWARE_TYPE_ALPHA;
 
+		} else if (tag[i] == 't' && i < strlen(tag) - 1 && tag[i + 1] == 'y') {
+			firmware_type = FIRMWARE_TYPE_DEV;
+
 		} else if (tag[i] == 't') {
 			firmware_type = FIRMWARE_TYPE_BETA;
 
@@ -177,7 +184,8 @@ uint32_t version_tag_to_vendor_version_number(const char *tag)
 
 	if ((dash_count == 1 && point_count == 2 && firmware_type == FIRMWARE_TYPE_RELEASE) ||
 	    (dash_count == 2 && point_count == 2) ||
-	    (dash_count == 3 && point_count == 4)) {
+	    (dash_count == 3 && point_count == 4) ||
+		(dash_count == 4 && point_count == 4)) {
 		firmware_type = FIRMWARE_TYPE_DEV;
 	}
 

--- a/src/lib/version/version.c
+++ b/src/lib/version/version.c
@@ -97,7 +97,7 @@ uint32_t version_tag_to_number(const char *tag)
 	if ((dash_count == 1 && point_count == 2 && firmware_type == FIRMWARE_TYPE_RELEASE) ||
 	    (dash_count == 2 && point_count == 2) ||
 	    (dash_count == 3 && point_count == 4) ||
-		(dash_count == 4 && point_count == 4)) {
+	    (dash_count == 4 && point_count == 4)) {
 		firmware_type = FIRMWARE_TYPE_DEV;
 	}
 
@@ -185,7 +185,7 @@ uint32_t version_tag_to_vendor_version_number(const char *tag)
 	if ((dash_count == 1 && point_count == 2 && firmware_type == FIRMWARE_TYPE_RELEASE) ||
 	    (dash_count == 2 && point_count == 2) ||
 	    (dash_count == 3 && point_count == 4) ||
-		(dash_count == 4 && point_count == 4)) {
+	    (dash_count == 4 && point_count == 4)) {
 		firmware_type = FIRMWARE_TYPE_DEV;
 	}
 

--- a/src/systemcmds/tests/test_versioning.cpp
+++ b/src/systemcmds/tests/test_versioning.cpp
@@ -51,6 +51,7 @@ bool VersioningTest::run_tests()
 	ut_assert_true(_test_tag_to_version_number("v1.2.3-11-gabababab", 				0x01020300, 0x00000000));
 	ut_assert_true(_test_tag_to_version_number("11.45.99-1.2.3", 					0x0B2D63FF, 0x010203FF));
 	ut_assert_true(_test_tag_to_version_number("v11.45.99-1.2.3rc3-7-g7e282f57", 	0x0B2D6300, 0x01020300));
+	ut_assert_true(_test_tag_to_version_number("v11.45.99-1.2.3-rc3-7-g7e282f57",	0x0B2D6300, 0x01020300));
 	ut_assert_true(_test_tag_to_version_number("v11.45.99-1.2.3rc4", 				0x0B2D63C0, 0x010203C0));
 	ut_assert_true(_test_tag_to_version_number("v11.45.99-1.2.3alpha3-7-g7e282f57", 0x0B2D6300, 0x01020300));
 	ut_assert_true(_test_tag_to_version_number("v11.45.99-1.2.3alpha4", 			0x0B2D6340, 0x01020340));
@@ -77,6 +78,34 @@ bool VersioningTest::run_tests()
 	ut_assert_true(_test_tag_to_version_number("v12.12-randomtextwithnumber", 		0x00000000, 0x00000000));
 	ut_assert_true(_test_tag_to_version_number("...-...", 							0x00000000, 0x00000000));
 	ut_assert_true(_test_tag_to_version_number("v...-...", 							0x00000000, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("v1.2.3-dirty", 						0x01020300, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("v11.45.99-1.2.3-dirty", 			0x0B2D6300, 0x01020300));
+	ut_assert_true(_test_tag_to_version_number("v1.2.3-111-dirty", 					0x01020300, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("v1.2.3-11-gabababab-dirty", 		0x01020300, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("v1.2.3-11-g1d5e979-dirty", 			0x01020300, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("v1.4.9-1.2.3rc3-7-g7e282f57-dirty", 0x01040900, 0x01020300));
+	ut_assert_true(_test_tag_to_version_number("v1.4.9-1.2.3-rc3-7-g7e282f57-dirty", 0x01040900, 0x01020300));
+	ut_assert_true(_test_tag_to_version_number("v1.4.9-1.2.3alpha-7-g7e282f5-dirty", 0x01040900, 0x01020300));
+	ut_assert_true(_test_tag_to_version_number("v11.45.99-1.2.3alpha4-dirty", 		0x0B2D6300, 0x01020300));
+	ut_assert_true(_test_tag_to_version_number("v1.4.9-1.2.3beta-7-g7e282f57-dirty", 0x01040900, 0x01020300));
+	ut_assert_true(_test_tag_to_version_number("v11.45.99-1.2.3beta4-dirty", 		0x0B2D6300, 0x01020300));
+	ut_assert_true(_test_tag_to_version_number("v11.45.99-1.2.3dev4-dirty", 		0x0B2D6300, 0x01020300));
+	ut_assert_true(_test_tag_to_version_number("v1.4.9-1.2.3dev3-7-g7e282f57-dirty", 0x01040900, 0x01020300));
+	ut_assert_true(_test_tag_to_version_number("v1.6.2-1.0.0rc2-dirty", 			0x01060200, 0x01000000));
+	ut_assert_true(_test_tag_to_version_number("v1.6.2-1.0.0-rc2-dirty", 			0x01060200, 0x01000000));
+	ut_assert_true(_test_tag_to_version_number("v1.6.2-1.0.0-rc2-gabababab-dirty", 	0x01060200, 0x01000000));
+	ut_assert_true(_test_tag_to_version_number("v1.6.2-1.0.0rc2-gabababab-dirty", 	0x01060200, 0x01000000));
+	ut_assert_true(_test_tag_to_version_number("v1.6.2-rc2-dirty", 					0x01060200, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("v1.6.2rc1-dirty", 					0x01060200, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("v1.6.2rc1-67-g1d5e979-dirty", 		0x01060200, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("v1.6.2-rc1-67-g1d5e979-dirty", 		0x01060200, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("v1.6.2-0.8.7-67-g1d5e979-dirty", 	0x01060200, 0x00080700));
+	ut_assert_true(_test_tag_to_version_number("v1.8.2alpha4-dirty", 				0x01080200, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("v1.8.2alpha4-67-g1d5e979-dirty", 	0x01080200, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("v1.8.2beta4-dirty", 				0x01080200, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("v1.8.2beta4-67-g1d5e979-dirty", 	0x01080200, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("v1.8.2dev4-dirty", 					0x01080200, 0x00000000));
+	ut_assert_true(_test_tag_to_version_number("v1.8.2dev4-67-g1d5e979-dirty", 		0x01080200, 0x00000000));
 
 	return (_tests_failed == 0);
 }


### PR DESCRIPTION
Fixed the version tag to number and version tag to vendor version number to return dev version in case of any local modifications or in case there's a dash before firmware type in tags that support vendor  version.