### PR TITLE
vtol_att_control: ack transition commands

### DIFF
--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -72,6 +72,7 @@
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_command.h>
+#include <uORB/topics/vehicle_command_ack.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/vehicle_local_position.h>
@@ -159,6 +160,7 @@ private:
 	orb_advert_t	_vtol_vehicle_status_pub;
 	orb_advert_t	_v_rates_sp_pub;
 	orb_advert_t	_v_att_sp_pub;
+	orb_advert_t	_v_cmd_ack_pub;
 
 //*******************data containers***********************************************************
 	struct vehicle_attitude_s			_v_att;				//vehicle attitude


### PR DESCRIPTION
Previously transition commands were not acked at all which meant that a
mavlink consumer such as a ground station would not get feedback if the
command arrived.

This solution is not optimal because it does not take into account if
the transition actually happened but at least it is feedback that the
command has arrived at the destination.

This solves an issue raised in https://github.com/dronecore/DroneCore/pull/150.

Tested in SITL using
```
make posix gazebo_standard_vtol
```

and for DroneCore:

```
make && build/default/integration_tests_runner --gtest_filter="SitlTest.ActionSimpleTransition"
```