### PR TITLE
mc_pos_control: acceleration limit for smooth takeoff instead of velocity ramping

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3014,8 +3014,8 @@ MulticopterPositionControl::task_main()
 		/* set default max velocity in xy to vel_max */
 		_vel_max_xy = _params.vel_max_xy;
 
-		/* reset flags when landed */
-		if (_vehicle_land_detected.landed) {
+		/* reset flags when landed and not taking off */
+		if (_vehicle_land_detected.landed && !_in_smooth_takeoff) {
 			_reset_pos_sp = true;
 			_reset_alt_sp = true;
 			_do_reset_alt_pos_flag = true;


### PR DESCRIPTION
Based on discussions in #8240 and #8258.

Velocity ramping in `calculate_velocity_setpoint()` in current technique to achieve smooth takeoff. It in fact constrains the z-axis acceleration during beginning of takeoff. It looks a bit inconsistent as other acceleration constrains are in `vel_sp_slewrate()` and apply independently. This PR propose to replace separate acceleration limiter with `vel_sp_slewrate()` extension, active during smooth takeoff.

It also allows to move `_vel_sp_prev = _vel_sp` assignment to the end of function, which solves important position setpoint overshoot problem, described in detail in #8240.

The patch was tested in SITL and on a quadcopter (450 frame). [Logs from the quadcopter](https://review.px4.io/plot_app?log=f578a9ba-1982-406c-86e2-96d21f6b0029) (offboard mode mainly) and [logs of POSCTL takeoff](https://review.px4.io/plot_app?log=6efc4360-765b-4153-8273-6104452aa900).

That's takeoff of patched version in SITL: 
![pr-takeoff-acc](https://user-images.githubusercontent.com/20798956/32640722-17dcd45c-c5db-11e7-9845-be76e2497fa6.png)

And takeoff of current master for comparison: 
![master-takeoff](https://user-images.githubusercontent.com/20798956/32640739-27107636-c5db-11e7-8496-00ef7e2fd1f7.png)

However, that's how patch flies in OFFBOARD:
![screenshot_20171110_055653](https://user-images.githubusercontent.com/20798956/32640883-0038daa2-c5dc-11e7-9bfb-5a4dc4e6252f.png)

And current master (up to 15 m overshoots):
![screenshot_20171110_055453](https://user-images.githubusercontent.com/20798956/32640894-114b0a22-c5dc-11e7-97c4-5ea94a576be9.png)
