### PR TITLE
Pr wind estimator

### DIFF
--- a/cmake/configs/nuttx_aerocore2_default.cmake
+++ b/cmake/configs/nuttx_aerocore2_default.cmake
@@ -121,6 +121,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/tunes
 	lib/version
+	lib/wind_estimator
 
 	#
 	# OBC challenge

--- a/cmake/configs/nuttx_aerofc-v1_default.cmake
+++ b/cmake/configs/nuttx_aerofc-v1_default.cmake
@@ -85,4 +85,5 @@ set(config_module_list
 	lib/mixer
 	lib/rc
 	lib/version
+	lib/wind_estimator
 )

--- a/cmake/configs/nuttx_auav-x21_default.cmake
+++ b/cmake/configs/nuttx_auav-x21_default.cmake
@@ -132,6 +132,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/tunes
 	lib/version
+	lib/wind_estimator
 
 	#
 	# OBC challenge

--- a/cmake/configs/nuttx_crazyflie_default.cmake
+++ b/cmake/configs/nuttx_crazyflie_default.cmake
@@ -89,6 +89,7 @@ set(config_module_list
 	lib/rc
 	lib/terrain_estimation
 	lib/version
+	lib/wind_estimator
 
 	#
 	# OBC challenge

--- a/cmake/configs/nuttx_mindpx-v2_default.cmake
+++ b/cmake/configs/nuttx_mindpx-v2_default.cmake
@@ -137,6 +137,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/tunes
 	lib/version
+	lib/wind_estimator
 
 	#
 	# OBC challenge

--- a/cmake/configs/nuttx_px4-same70xplained-v1_default.cmake
+++ b/cmake/configs/nuttx_px4-same70xplained-v1_default.cmake
@@ -113,6 +113,7 @@ set(config_module_list
 	lib/rc
 	lib/terrain_estimation
 	lib/version
+	lib/wind_estimator
 
 	#
 	# OBC challenge

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -160,6 +160,7 @@ set(config_module_list
 	#lib/terrain_estimation
 	lib/tunes
 	lib/version
+	lib/wind_estimator
 
 	#
 	# OBC challenge

--- a/cmake/configs/nuttx_px4fmu-v3_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v3_default.cmake
@@ -148,6 +148,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/tunes
 	lib/version
+	lib/wind_estimator
 
 	#
 	# OBC challenge

--- a/cmake/configs/nuttx_px4fmu-v4_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v4_default.cmake
@@ -141,6 +141,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/tunes
 	lib/version
+	lib/wind_estimator
 
 	#
 	# OBC challenge

--- a/cmake/configs/nuttx_px4fmu-v4pro_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v4pro_default.cmake
@@ -140,6 +140,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/tunes
 	lib/version
+	lib/wind_estimator
 
 	#
 	# OBC challenge

--- a/cmake/configs/nuttx_px4fmu-v5_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v5_default.cmake
@@ -142,6 +142,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/tunes
 	lib/version
+	lib/wind_estimator
 
 	#
 	# OBC challenge

--- a/cmake/configs/nuttx_px4nucleoF767ZI-v1_default.cmake
+++ b/cmake/configs/nuttx_px4nucleoF767ZI-v1_default.cmake
@@ -120,6 +120,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/tunes
 	lib/version
+	lib/wind_estimator
 
 	#
 	# OBC challenge

--- a/cmake/configs/nuttx_tap-v1_default.cmake
+++ b/cmake/configs/nuttx_tap-v1_default.cmake
@@ -1,4 +1,3 @@
-
 px4_nuttx_configure(HWCLASS m4 CONFIG nsh ROMFS y ROMFSROOT tap_common)
 
 set(target_definitions MEMORY_CONSTRAINED_SYSTEM)
@@ -98,4 +97,5 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/tunes
 	lib/version
+	lib/wind_estimator
 )

--- a/cmake/configs/posix_bebop_default.cmake
+++ b/cmake/configs/posix_bebop_default.cmake
@@ -81,6 +81,7 @@ set(config_module_list
 	lib/mixer
 	lib/terrain_estimation
 	lib/version
+	lib/wind_estimator
 )
 
 set(config_df_driver_list

--- a/cmake/configs/posix_rpi_common.cmake
+++ b/cmake/configs/posix_rpi_common.cmake
@@ -106,6 +106,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/tunes
 	lib/version
+	lib/wind_estimator
 )
 
 #

--- a/cmake/configs/posix_sdflight_default.cmake
+++ b/cmake/configs/posix_sdflight_default.cmake
@@ -80,4 +80,5 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/tunes
 	lib/version
+	lib/wind_estimator
 )

--- a/cmake/configs/posix_sitl_default.cmake
+++ b/cmake/configs/posix_sitl_default.cmake
@@ -131,6 +131,7 @@ set(config_module_list
 	lib/terrain_estimation
 	lib/tunes
 	lib/version
+	lib/wind_estimator
 
 	#
 	# OBC challenge

--- a/cmake/configs/qurt_sdflight_default.cmake
+++ b/cmake/configs/qurt_sdflight_default.cmake
@@ -93,6 +93,7 @@ set(config_module_list
 	lib/rc
 	lib/terrain_estimation
 	lib/version
+	lib/wind_estimator
 
 	#
 	# sources for muorb over fastrpc

--- a/cmake/configs/qurt_sdflight_legacy.cmake
+++ b/cmake/configs/qurt_sdflight_legacy.cmake
@@ -92,6 +92,7 @@ set(config_module_list
 	lib/rc
 	lib/terrain_estimation
 	lib/version
+	lib/wind_estimator
 
 	#
 	# sources for muorb over fastrpc

--- a/msg/airspeed.msg
+++ b/msg/airspeed.msg
@@ -3,3 +3,5 @@ float32 true_airspeed_m_s		# true filtered airspeed in meters per second, -1 if 
 float32 true_airspeed_unfiltered_m_s	# true airspeed in meters per second, -1 if unknown
 float32 air_temperature_celsius		# air temperature in degrees celsius, -1000 if unknown
 float32 confidence			# confidence value from 0 to 1 for this sensor
+float32 differential_pressure_filtered_pa # filtered differential pressure, can be negative
+float32 scale 				# estimated airspeed scale factor.

--- a/msg/wind_estimate.msg
+++ b/msg/wind_estimate.msg
@@ -3,3 +3,10 @@ float32 windspeed_east		# Wind component in east / Y direction (m/sec)
 
 float32 variance_north		# Wind estimate error variance in north / X direction (m/sec)**2 - set to zero (no uncertainty) if not estimated
 float32 variance_east		# Wind estimate error variance in east / Y direction (m/sec)**2 - set to zero (no uncertainty) if not estimated
+
+float32 tas_innov 		# True airspeed innovation
+float32 tas_innov_var 		# True airspeed innovation variance
+float32 tas_scale 		# Estimated true airspeed scale factor
+
+float32 beta_innov 		# Sideslip measurement innovation
+float32 beta_innov_var 		# Sideslip measurement innovation variance

--- a/src/lib/wind_estimator/CMakeLists.txt
+++ b/src/lib/wind_estimator/CMakeLists.txt
@@ -1,0 +1,42 @@
+############################################################################
+#
+#   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+px4_add_module(
+	MODULE lib__wind_estimator
+	STACK_MAIN 1024
+	COMPILE_FLAGS
+	SRCS
+		WindEstimator.cpp
+	DEPENDS
+		platforms__common
+	)
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/lib/wind_estimator/WindEstimator.cpp
+++ b/src/lib/wind_estimator/WindEstimator.cpp
@@ -1,0 +1,318 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file WindEstimator.cpp
+ * A wind and airspeed scale estimator.
+ */
+
+#include "WindEstimator.hpp"
+
+
+bool
+WindEstimator::initialise(const Vector3f &velI, const Vector2f &velIvar, const float tas_meas)
+{
+	// do no initialise if ground velocity is low
+	// this should prevent the filter from initialising on the ground
+	if (sqrtf(velI(0) * velI(0) + velI(1) * velI(1)) < 3.0f) {
+		return false;
+	}
+
+	const float v_n = velI(0);
+	const float v_e = velI(1);
+
+	// estimate heading from ground velocity
+	const float heading_est = atan2f(v_e, v_n);
+
+	// initilaise wind states assuming zero side slip and horizontal flight
+	_state(w_n) = velI(w_n) - tas_meas * cosf(heading_est);
+	_state(w_e) = velI(w_e) - tas_meas * sinf(heading_est);
+	_state(tas) = 1.0f;
+
+	// compute jacobian of states wrt north/each earth velocity states and true airspeed measurement
+	float L0 = v_e * v_e;
+	float L1 = v_n * v_n;
+	float L2 = L0 + L1;
+	float L3 = tas_meas / (L2 * sqrtf(L2));
+	float L4 = L3 * v_e * v_n + 1.0f;
+	float L5 = 1.0f / sqrtf(L2);
+	float L6 = -L5 * tas_meas;
+
+	Matrix3f L;
+	L.setZero();
+	L(0, 0) = L4;
+	L(0, 1) = L0 * L3 + L6;
+	L(1, 0) = L1 * L3 + L6;
+	L(1, 1) = L4;
+	L(2, 2) = 1.0f;
+
+	// get an estimate of the state covariance matrix given the estimated variance of ground velocity
+	// and measured airspeed
+	_P.setZero();
+	_P(w_n, w_n) = velIvar(0);
+	_P(w_e, w_e) = velIvar(1);
+	_P(tas, tas) = 0.0001f;
+
+	_P = L * _P * L.transpose();
+
+	return true;
+}
+
+void
+WindEstimator::update(uint64_t time_now)
+{
+	if (!_initialised) {
+		return;
+	}
+
+	// run covariance prediction at 1Hz
+	if (time_now - _time_last_update < 1e6 || _time_last_update == 0) {
+		if (_time_last_update == 0) {
+			_time_last_update = time_now;
+		}
+
+		return;
+	}
+
+	float dt = (float)(time_now - _time_last_update) * 0.000001f;
+	_time_last_update = time_now;
+
+	float q_w = _wind_p_var;
+	float q_k_tas = _tas_scale_p_var;
+
+	float SPP0 = dt * dt;
+	float SPP1 = SPP0 * q_w;
+	float SPP2 = SPP1 + _P(0, 1);
+
+	Matrix3f P_next;
+
+	P_next(0, 0) = SPP1 + _P(0, 0);
+	P_next(0, 1) = SPP2;
+	P_next(0, 2) = _P(0, 2);
+	P_next(1, 0) = SPP2;
+	P_next(1, 1) = SPP1 + _P(1, 1);
+	P_next(1, 2) = _P(1, 2);
+	P_next(2, 0) = _P(0, 2);
+	P_next(2, 1) = _P(1, 2);
+	P_next(2, 2) = SPP0 * q_k_tas + _P(2, 2);
+	_P = P_next;
+}
+
+void
+WindEstimator::fuse_airspeed(uint64_t time_now, const float true_airspeed, const Vector3f &velI,
+			     const Vector2f &velIvar)
+{
+	Vector2f velIvar_constrained = { max(0.01f, velIvar(0)), max(0.01f, velIvar(1)) };
+
+	if (!_initialised) {
+		// try to initialise
+		_initialised =	initialise(velI, velIvar_constrained, true_airspeed);
+		return;
+	}
+
+	// don't fuse faster than 10Hz
+	if (time_now - _time_last_airspeed_fuse < 1e5) {
+		return;
+	}
+
+	_time_last_airspeed_fuse = time_now;
+
+	// assign helper variables
+	const float v_n = velI(0);
+	const float v_e = velI(1);
+	const float v_d = velI(2);
+
+	const float k_tas = _state(tas);
+
+	// compute kalman gain K
+	const float HH0 = sqrtf(v_d * v_d + (v_e - w_e) * (v_e - w_e) + (v_n - w_n) * (v_n - w_n));
+	const float HH1 = k_tas / HH0;
+
+	Matrix<float, 1, 3> H_tas;
+	H_tas(0, 0) = HH1 * (-v_n + w_n);
+	H_tas(0, 1) = HH1 * (-v_e + w_e);
+	H_tas(0, 2) = HH0;
+
+	Matrix<float, 3, 1> K = _P * H_tas.transpose();
+
+	const Matrix<float, 1, 1> S = H_tas * _P * H_tas.transpose() + _tas_var;
+
+	K /= (S._data[0][0]);
+	// compute innovation
+	const float airspeed_pred = _state(tas) * sqrtf((v_n - _state(w_n)) * (v_n - _state(w_n)) + (v_e - _state(w_e)) *
+				    (v_e - _state(w_e)) + v_d * v_d);
+
+	_tas_innov = true_airspeed - airspeed_pred;
+
+	// innovation variance
+	_tas_innov_var = S._data[0][0];
+
+	if (_tas_innov_var < 0.0f) {
+		return;
+	}
+
+	// apply correction to state
+	_state(w_n) += _tas_innov * K(0, 0);
+	_state(w_e) += _tas_innov * K(1, 0);
+	_state(tas) += _tas_innov * K(2, 0);
+
+	// update covariance matrix
+	_P = _P - K * H_tas * _P;
+
+	run_sanity_checks();
+}
+
+void
+WindEstimator::fuse_beta(uint64_t time_now, const Vector3f &velI, const Quatf &q_att)
+{
+	if (!_initialised) {
+		_initialised =	initialise(velI, Vector2f(0.1f, 0.1f), velI.length());
+		return;
+	}
+
+	// don't fuse faster than 10Hz
+	if (time_now - _time_last_beta_fuse < 1e5) {
+		return;
+	}
+
+	_time_last_beta_fuse = time_now;
+
+	const float v_n = velI(0);
+	const float v_e = velI(1);
+	const float v_d = velI(2);
+
+	// compute sideslip observation vector
+	float HB0 = 2.0f * q_att(0);
+	float HB1 = HB0 * q_att(3);
+	float HB2 = 2.0f * q_att(1);
+	float HB3 = HB2 * q_att(2);
+	float HB4 = v_e - w_e;
+	float HB5 = HB1 + HB3;
+	float HB6 = v_n - w_n;
+	float HB7 = q_att(0) * q_att(0);
+	float HB8 = q_att(3) * q_att(3);
+	float HB9 = HB7 - HB8;
+	float HB10 = q_att(1) * q_att(1);
+	float HB11 = q_att(2) * q_att(2);
+	float HB12 = HB10 - HB11;
+	float HB13 = HB12 + HB9;
+	float HB14 = HB13 * HB6 + HB4 * HB5 + v_d * (-HB0 * q_att(2) + HB2 * q_att(3));
+	float HB15 = 1.0f / HB14;
+	float HB16 = (HB4 * (-HB10 + HB11 + HB9) + HB6 * (-HB1 + HB3) + v_d * (HB0 * q_att(1) + 2.0f * q_att(2) * q_att(3))) /
+		     (HB14 * HB14);
+
+	Matrix<float, 1, 3> H_beta;
+	H_beta(0, 0) = HB13 * HB16 + HB15 * (HB1 - HB3);
+	H_beta(0, 1) = HB15 * (HB12 - HB7 + HB8) + HB16 * HB5;
+	H_beta(0, 2) = 0;
+
+	// compute kalman gain
+	Matrix<float, 3, 1> K = _P * H_beta.transpose();
+
+	const Matrix<float, 1, 1> S = H_beta * _P * H_beta.transpose() + _beta_var;
+
+	K /= (S._data[0][0]);
+
+	// compute predicted side slip angle
+	Vector3f rel_wind = Vector3f(velI(0) - _state(w_n), velI(1) - _state(w_e), velI(2));
+	Dcmf R_body_to_earth = Quatf(q_att);
+	rel_wind = R_body_to_earth.transpose() * rel_wind;
+
+	if (fabsf(rel_wind(0)) < 0.1f) {
+		return;
+	}
+
+	// use small angle approximation, sin(x) = x for small x
+	const float beta_pred = rel_wind(1) / rel_wind(0);
+
+	_beta_innov = 0.0f - beta_pred;
+	_beta_innov_var = S._data[0][0];
+
+	if (fabsf(_beta_innov) > sqrtf(_beta_innov_var)) {
+		_time_rejected_beta = _time_rejected_beta == 0 ? time_now : _time_rejected_beta;
+
+	} else {
+		_time_rejected_beta = 0;
+	}
+
+	if (time_now - _time_rejected_beta > 5e6 && _time_rejected_beta != 0) {
+		_initialised =	initialise(velI, Vector2f(0.1f, 0.1f), velI.length());
+	}
+
+	// apply correction to state
+	_state(w_n) += _beta_innov * K(0, 0);
+	_state(w_e) += _beta_innov * K(1, 0);
+	_state(tas) += _beta_innov * K(2, 0);
+
+	// update covariance matrix
+	_P = _P - K * H_beta * _P;
+
+	run_sanity_checks();
+}
+
+void
+WindEstimator::run_sanity_checks()
+{
+	for (unsigned i = 0; i < 3; i++) {
+		if (_P(i, i) < 0.0f) {
+			// ill-conditioned covariance matrix, reset filter
+			_initialised = false;
+			return;
+		}
+
+		// limit covariance diagonals if they grow too large
+		if (i < 2) {
+			_P(i, i) = _P(i, i) > 25.0f ? 25.0f : _P(i, i);
+
+		} else if (i == 2) {
+			_P(i, i) = _P(i, i) > 0.1f ? 0.1f : _P(i, i);
+		}
+	}
+
+	if (!PX4_ISFINITE(_state(w_n)) || !PX4_ISFINITE(_state(w_e)) || !PX4_ISFINITE(_state(tas))) {
+		_initialised = false;
+		return;
+	}
+
+	// constrain airspeed scale factor
+	_state(tas) = constrain(_state(tas), 0.7f, 1.2f);
+
+	// attain symmetry
+	for (unsigned row = 0; row < 3; row++) {
+		for (unsigned column = 0; column < row; column++) {
+			float tmp = (_P(row, column) + _P(column, row)) / 2;
+			_P(row, column) = tmp;
+			_P(column, row) = tmp;
+		}
+	}
+}

--- a/src/lib/wind_estimator/WindEstimator.hpp
+++ b/src/lib/wind_estimator/WindEstimator.hpp
@@ -1,0 +1,120 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file WindEstimator.hpp
+ * A wind and airspeed scale estimator.
+ */
+
+#pragma once
+
+#include <mathlib/mathlib.h>
+
+using namespace matrix;
+using math::max;
+using math::constrain;
+
+class WindEstimator
+{
+public:
+	WindEstimator() = default;
+	~WindEstimator() = default;
+
+	// no copy, assignment, move, move assignment
+	WindEstimator(const WindEstimator &) = delete;
+	WindEstimator &operator=(const WindEstimator &) = delete;
+	WindEstimator(WindEstimator &&) = delete;
+	WindEstimator &operator=(WindEstimator &&) = delete;
+
+	void update(uint64_t time_now);
+
+	void fuse_airspeed(uint64_t time_now, float true_airspeed, const Vector3f &velI, const Vector2f &velIvar);
+	void fuse_beta(uint64_t time_now, const Vector3f &velI, const Quatf &q_att);
+
+	void get_wind(float wind[2])
+	{
+		wind[0] = _state(w_n);
+		wind[1] = _state(w_e);
+	}
+
+	bool is_estimate_valid() { return _initialised; }
+
+	float get_tas_scale() { return _state(tas); }
+	float get_tas_innov() { return _tas_innov; }
+	float get_tas_innov_var() { return _tas_innov_var; }
+	float get_beta_innov() { return _beta_innov; }
+	float get_beta_innov_var() { return _beta_innov_var; }
+	void get_wind_var(float wind_var[2])
+	{
+		wind_var[0] = _P(0, 0);
+		wind_var[1] = _P(1, 1);
+	}
+
+	void set_wind_p_noise(float wind_sigma) { _wind_p_var = wind_sigma * wind_sigma; }
+	void set_tas_scale_p_noise(float tas_scale_sigma) { _tas_scale_p_var = tas_scale_sigma * tas_scale_sigma; }
+	void set_tas_noise(float tas_sigma) { _tas_var = tas_sigma * tas_sigma; }
+	void set_beta_noise(float beta_var) { _beta_var = beta_var * beta_var; }
+
+private:
+	enum {
+		w_n = 0,
+		w_e,
+		tas
+	};	// enum which can be used to access state.
+
+	Vector3f _state;		// state vector
+	Matrix3f _P;		// state covariance matrix
+
+	float _tas_innov{0.0f};	// true airspeed innovation
+	float _tas_innov_var{0.0f};	// true airspeed innovation variance
+
+	float _beta_innov{0.0f};	// sideslip innovation
+	float _beta_innov_var{0.0f};	// sideslip innovation variance
+
+	bool _initialised{false};	// True: filter has been initialised
+
+	float _wind_p_var{0.1f};	// wind process noise variance
+	float _tas_scale_p_var{0.0001f};	// true airspeed scale process noise variance
+	float _tas_var{1.4f};		// true airspeed measurement noise variance
+	float _beta_var{0.5f};	// sideslip measurement noise variance
+
+	uint64_t _time_last_airspeed_fuse = 0;	// timestamp of last airspeed fusion
+	uint64_t _time_last_beta_fuse = 0;		// timestamp of last sideslip fusion
+	uint64_t _time_last_update = 0;			// timestamp of last covariance prediction
+	uint64_t _time_rejected_beta = 0;
+
+	// initialise state and state covariance matrix
+	bool initialise(const Vector3f &velI, const Vector2f &velIvar, const float tas_meas);
+
+	void run_sanity_checks();
+};

--- a/src/lib/wind_estimator/python/wind_est_derivation.py
+++ b/src/lib/wind_estimator/python/wind_est_derivation.py
@@ -1,0 +1,188 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Nov  1 19:14:39 2016
+
+@author: roman
+"""
+
+from sympy import *
+
+# q: quaternion describing rotation from frame 1 to frame 2
+# returns a rotation matrix derived form q which describes the same
+# rotation
+def quat2Rot(q):
+    q0 = q[0]
+    q1 = q[1]
+    q2 = q[2]
+    q3 = q[3]
+
+    Rot = Matrix([[q0**2 + q1**2 - q2**2 - q3**2, 2*(q1*q2 - q0*q3), 2*(q1*q3 + q0*q2)],
+                  [2*(q1*q2 + q0*q3), q0**2 - q1**2 + q2**2 - q3**2, 2*(q2*q3 - q0*q1)],
+                   [2*(q1*q3-q0*q2), 2*(q2*q3 + q0*q1), q0**2 - q1**2 - q2**2 + q3**2]])
+
+    return Rot
+
+# take an expression calculated by the cse() method and write the expression
+# into a text file in C format
+def write_simplified(P_touple, filename, out_name):
+    subs = P_touple[0]
+    P = Matrix(P_touple[1])
+    fd = open(filename, 'a')
+
+    is_vector = P.shape[0] == 1 or P.shape[1] == 1
+
+    # write sub expressions
+    for index, item in enumerate(subs):
+        fd.write('float ' + str(item[0]) + ' = ' + str(item[1]) + ';\n')
+
+    # write actual matrix values
+    fd.write('\n')
+
+    if not is_vector:
+        iterator = range(0,sqrt(len(P)), 1)
+        for row in iterator:
+            for column in iterator:
+                fd.write(out_name + '(' + str(row) + ',' + str(column) + ') = ' + str(P[row, column]) + ';\n')
+    else:
+        iterator = range(0, len(P), 1)
+
+        for item in iterator:
+            fd.write(out_name + '(' + str(item) + ') = ' + str(P[item]) + ';\n')
+
+    fd.write('\n\n')
+    fd.close()
+
+########## Symbolic variable definition #######################################
+
+# model state
+w_n = Symbol("w_n", real=True)  # wind in north direction
+w_e = Symbol("w_e", real=True)  # wind in east direction
+k_tas = Symbol("k_tas", real=True) # true airspeed scale factor
+state = Matrix([w_n, w_e, k_tas])
+
+# process noise
+q_w = Symbol("q_w", real=True) # process noise for wind states
+q_k_tas = Symbol("q_k_tas", real=True) # process noise for airspeed scale state
+
+# airspeed measurement noise
+r_tas = Symbol("r_tas", real=True)
+
+# sideslip measurement noise
+r_beta = Symbol("r_beta", real=True)
+
+# true airspeed measurement
+tas_meas = Symbol("tas_meas", real=True)
+
+# ground velocity variance
+v_n_var = Symbol("v_n_var", real=True)
+v_e_var = Symbol("v_e_var", real=True)
+
+#################### time varying parameters ##################################
+
+# vehicle velocity
+v_n = Symbol("v_n", real=True)  # north velocity in earth fixed frame
+v_e = Symbol("v_e", real=True)  # east velocity in earth fixed frame
+v_d = Symbol("v_d", real=True)  # down velocity in earth fixed frame
+
+# unit quaternion describing vehicle attitude, qw is real part
+qw = Symbol("q_att[0]", real=True)
+qx = Symbol("q_att[1]", real=True)
+qy = Symbol("q_att[2]", real=True)
+qz = Symbol("q_att[3]", real=True)
+q_att = Matrix([qw, qx, qy, qz])
+
+# sampling time in seconds
+dt = Symbol("dt", real=True)
+
+######################## State and covariance prediction ######################
+
+# state transition matrix is zero because we are using a stationary
+# process model. We only need to provide formula for covariance prediction
+
+# create process noise matrix for covariance prediction
+state_new = state + Matrix([q_w, q_w, q_k_tas]) * dt
+Q = diag(q_w, q_k_tas)
+L = state_new.jacobian([q_w, q_k_tas])
+Q = L * Q * Transpose(L)
+
+# define symbolic covariance matrix
+p00 = Symbol('_P(0,0)', real=True)
+p01 = Symbol('_P(0,1)', real=True)
+p02 = Symbol('_P(0,2)', real=True)
+p12 = Symbol('_P(1,2)', real=True)
+p11 = Symbol('_P(1,1)', real=True)
+p22 = Symbol('_P(2,2)', real=True)
+P = Matrix([[p00, p01, p02], [p01, p11, p12], [p02, p12, p22]])
+
+# covariance prediction equation
+P_next = P + Q
+
+# simplify the result and write it to a text file in C format
+PP_simple = cse(P_next, symbols('SPP0:30'))
+P_pred = Matrix(PP_simple[1])
+write_simplified(PP_simple, "cov_pred.txt", 'P_next')
+
+
+############################ Measurement update ###############################
+
+# airspeed fusion
+
+tas_pred = Matrix([((v_n - w_n)**2 + (v_e - w_e)**2 + v_d**2)**0.5]) * k_tas
+# compute true airspeed observation matrix
+H_tas = tas_pred.jacobian(state)
+# simplify the result and write it to a text file in C format
+H_tas_simple = cse(H_tas, symbols('HH0:30'))
+write_simplified(H_tas_simple, "airspeed_fusion.txt", 'H_tas')
+K = P * Transpose(H_tas)
+denom = H_tas * P * Transpose(H_tas) + Matrix([r_tas])
+denom = 1/denom.values()[0]
+K = K * denom
+
+K_simple = cse(K, symbols('KTAS0:30'))
+write_simplified(K_simple, "airspeed_fusion.txt", "K")
+
+P_m = P - K*H_tas*P
+P_m_simple = cse(P_m, symbols('PM0:50'))
+write_simplified(P_m_simple, "airspeed_fusion.txt", "P_next")
+
+# sideslip fusion
+
+# compute relative wind vector in vehicle body frame
+relative_wind_earth = Matrix([v_n - w_n, v_e - w_e, v_d])
+R_body_to_earth = quat2Rot(q_att)
+relative_wind_body = Transpose(R_body_to_earth) * relative_wind_earth
+# small angle approximation of side slip model
+beta_pred = relative_wind_body[1] / relative_wind_body[0]
+# compute side slip observation matrix
+H_beta = Matrix([beta_pred]).jacobian(state)
+# simplify the result and write it to a text file in C format
+H_beta_simple = cse(H_beta, symbols('HB0:30'))
+write_simplified(H_beta_simple, "beta_fusion.txt", 'H_beta')
+K = P * Transpose(H_beta)
+denom = H_beta * P * Transpose(H_beta) + Matrix([r_beta])
+denom = 1/denom.values()[0]
+K = K*denom
+K_simple = cse(K, symbols('KB0:30'))
+write_simplified(K_simple, "beta_fusion.txt", 'K')
+
+P_m = P - K*H_beta*P
+P_m_simple = cse(P_m, symbols('PM0:50'))
+write_simplified(P_m_simple, "beta_fusion.txt", "P_next")
+
+# wind covariance initialisation via velocity
+
+# estimate heading from ground velocity
+heading_est = atan2(v_n, v_e)
+
+# calculate wind speed estimate from vehicle ground velocity, heading and
+# airspeed measurement
+w_n_est = v_n - tas_meas * cos(heading_est)
+w_e_est = v_e - tas_meas * sin(heading_est)
+wind_est = Matrix([w_n_est, w_e_est])
+
+# calculate estimate of state covariance matrix
+P_wind = diag(v_n_var, v_e_var, r_tas)
+
+wind_jac = wind_est.jacobian([v_n, v_e, tas_meas])
+wind_jac_simple = cse(wind_jac, symbols('L0:30'))
+write_simplified(wind_jac_simple, "cov_init.txt", "L")

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1260,12 +1260,8 @@ void Ekf2::run()
 					wind_estimate.variance_north = status.covariances[22];
 					wind_estimate.variance_east = status.covariances[23];
 
-					if (_wind_pub == nullptr) {
-						_wind_pub = orb_advertise(ORB_ID(wind_estimate), &wind_estimate);
-
-					} else {
-						orb_publish(ORB_ID(wind_estimate), _wind_pub, &wind_estimate);
-					}
+					int wind_instance;
+					orb_publish_auto(ORB_ID(wind_estimate), &_wind_pub, &wind_estimate, &wind_instance, ORB_PRIO_DEFAULT);
 				}
 			}
 

--- a/src/modules/sensors/parameters.cpp
+++ b/src/modules/sensors/parameters.cpp
@@ -161,6 +161,12 @@ void initialize_parameter_handles(ParameterHandles &parameter_handles)
 	parameter_handles.air_tube_length = param_find("CAL_AIR_TUBELEN");
 	parameter_handles.air_tube_diameter_mm = param_find("CAL_AIR_TUBED_MM");
 
+	parameter_handles.wind_p_noise = param_find("WEST_W_P_NOISE");
+	parameter_handles.tas_scale_p_noise = param_find("WEST_SC_P_NOISE");
+	parameter_handles.tas_noise = param_find("WEST_TAS_NOISE");
+	parameter_handles.beta_noise = param_find("WEST_BETA_NOISE");
+
+
 	// These are parameters for which QGroundControl always expects to be returned in a list request.
 	// We do a param_find here to force them into the list.
 	(void)param_find("RC_CHAN_CNT");
@@ -492,6 +498,11 @@ int update_parameters(const ParameterHandles &parameter_handles, Parameters &par
 	param_get(parameter_handles.air_cmodel, &parameters.air_cmodel);
 	param_get(parameter_handles.air_tube_length, &parameters.air_tube_length);
 	param_get(parameter_handles.air_tube_diameter_mm, &parameters.air_tube_diameter_mm);
+
+	param_get(parameter_handles.wind_p_noise, &parameters.wind_p_noise);
+	param_get(parameter_handles.tas_scale_p_noise, &parameters.tas_scale_p_noise);
+	param_get(parameter_handles.tas_noise, &parameters.tas_noise);
+	param_get(parameter_handles.beta_noise, &parameters.beta_noise);
 
 	return ret;
 }

--- a/src/modules/sensors/parameters.h
+++ b/src/modules/sensors/parameters.h
@@ -149,6 +149,11 @@ struct Parameters {
 	int32_t air_cmodel;
 	float air_tube_length;
 	float air_tube_diameter_mm;
+
+	float wind_p_noise;
+	float tas_scale_p_noise;
+	float tas_noise;
+	float beta_noise;
 };
 
 struct ParameterHandles {
@@ -233,6 +238,11 @@ struct ParameterHandles {
 	param_t air_cmodel;
 	param_t air_tube_length;
 	param_t air_tube_diameter_mm;
+
+	param_t wind_p_noise;
+	param_t tas_scale_p_noise;
+	param_t tas_noise;
+	param_t beta_noise;
 
 };
 

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -344,3 +344,39 @@ PARAM_DEFINE_INT32(SENS_EN_TFMINI, 0);
  * @group Sensors
  */
 PARAM_DEFINE_INT32(SENS_EN_LEDDAR1, 0);
+
+/**
+ * Wind estimator wind process noise.
+ *
+ * @min 0
+ * @max 1
+ * @group Wind Estimator
+ */
+PARAM_DEFINE_FLOAT(WEST_W_P_NOISE, 0.1f);
+
+/**
+ * Wind estimator true airspeed scale process noise.
+ *
+ * @min 0
+ * @max 0.1
+ * @group Wind Estimator
+ */
+PARAM_DEFINE_FLOAT(WEST_SC_P_NOISE, 0.0001);
+
+/**
+ * Wind estimator true airspeed measurement noise.
+ *
+ * @min 0
+ * @max 4
+ * @group Wind Estimator
+ */
+PARAM_DEFINE_FLOAT(WEST_TAS_NOISE, 1.4);
+
+/**
+ * Wind estimator sideslip measurement noise.
+ *
+ * @min 0
+ * @max 1
+ * @group Wind Estimator
+ */
+PARAM_DEFINE_FLOAT(WEST_BETA_NOISE, 0.3);

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -60,6 +60,7 @@
 #include <errno.h>
 #include <math.h>
 #include <mathlib/mathlib.h>
+#include <matrix/matrix/math.hpp>
 
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_rc_input.h>
@@ -73,6 +74,7 @@
 #include <systemlib/err.h>
 #include <systemlib/perf_counter.h>
 #include <systemlib/battery.h>
+#include <wind_estimator/WindEstimator.hpp>
 
 #include <conversion/rotation.h>
 
@@ -84,6 +86,9 @@
 #include <uORB/topics/differential_pressure.h>
 #include <uORB/topics/airspeed.h>
 #include <uORB/topics/sensor_preflight.h>
+#include <uORB/topics/wind_estimate.h>
+#include <uORB/topics/vehicle_attitude.h>
+#include <uORB/topics/vehicle_local_position.h>
 
 #include <DevMgr.hpp>
 
@@ -166,6 +171,8 @@ private:
 	int		_diff_pres_sub{-1};			/**< raw differential pressure subscription */
 	int		_vcontrol_mode_sub{-1};		/**< vehicle control mode subscription */
 	int 		_params_sub{-1};			/**< notification of parameter updates */
+	int		_vehicle_local_position_sub{-1};	/**< notification of local position updates from the nav estimator*/
+	int		_vehicle_attitude_sub{-1};		/**< notification of attitude quaternion updates from the nav estimator*/
 
 	orb_advert_t	_sensor_pub{nullptr};			/**< combined sensor data topic */
 	orb_advert_t	_battery_pub[BOARD_NUMBER_BRICKS] {};			/**< battery status */
@@ -178,9 +185,17 @@ private:
 	orb_advert_t	_diff_pres_pub{nullptr};			/**< differential_pressure */
 	orb_advert_t	_sensor_preflight{nullptr};		/**< sensor preflight topic */
 
+	orb_advert_t 	_wind_est_pub{nullptr};			/**< wind estimate topic */
+
 	perf_counter_t	_loop_perf;			/**< loop performance counter */
 
 	DataValidator	_airspeed_validator;		/**< data validator to monitor airspeed */
+
+	airspeed_s _airspeed{};
+	struct wind_estimate_s _wind_est;		/**< wind estimate */
+
+	struct vehicle_local_position_s _vehicle_local_position = {};	/**< local position and velocity estimates */
+	struct vehicle_attitude_s _vehicle_attitude = {};		/**< attitude quaternion estimates */
 
 	Battery		_battery[BOARD_NUMBER_BRICKS];			/**< Helper lib to publish battery_status topic. */
 
@@ -189,6 +204,11 @@ private:
 
 	RCUpdate		_rc_update;
 	VotedSensorsUpdate _voted_sensors_update;
+
+	WindEstimator _wind_estimator;
+
+	hrt_abstime _time_last_airspeed_fused; /* last time airspeed measurement was fused into wind estimator */
+	hrt_abstime _time_last_beta_fused;	/* last time sideslip measurement was fused into wind estimator */
 
 
 	/**
@@ -220,6 +240,16 @@ private:
 	void 		parameter_update_poll(bool forced = false);
 
 	/**
+	 * Check for changes in local position and velocity estimates.
+	 */
+	void 		vehicle_local_position_poll();
+
+	/**
+	 * Check for changes in attitude quaternion estimates.
+	 */
+	void 		vehicle_attitude_poll();
+
+	/**
 	 * Poll the ADC and update readings to suit.
 	 *
 	 * @param raw			Combined sensor data structure into which
@@ -232,7 +262,10 @@ Sensors::Sensors(bool hil_enabled) :
 	_hil_enabled(hil_enabled),
 	_loop_perf(perf_alloc(PC_ELAPSED, "sensors")),
 	_rc_update(_parameters),
-	_voted_sensors_update(_parameters, hil_enabled)
+	_voted_sensors_update(_parameters, hil_enabled),
+	_wind_estimator(),
+	_time_last_airspeed_fused(0),
+	_time_last_beta_fused(0)
 {
 	initialize_parameter_handles(_parameter_handles);
 
@@ -315,16 +348,15 @@ Sensors::diff_pres_poll(struct sensor_combined_s &raw)
 		float air_temperature_celsius = (diff_pres.temperature > -300.0f) ? diff_pres.temperature :
 						(raw.baro_temp_celcius - PCB_TEMP_ESTIMATE_DEG);
 
-		airspeed_s airspeed;
-		airspeed.timestamp = diff_pres.timestamp;
+		_airspeed.timestamp = diff_pres.timestamp;
 
 		/* push data into validator */
 		float airspeed_input[3] = { diff_pres.differential_pressure_raw_pa, diff_pres.temperature, 0.0f };
 
-		_airspeed_validator.put(airspeed.timestamp, airspeed_input, diff_pres.error_count,
+		_airspeed_validator.put(_airspeed.timestamp, airspeed_input, diff_pres.error_count,
 					ORB_PRIO_HIGH);
 
-		airspeed.confidence = _airspeed_validator.confidence(hrt_absolute_time());
+		_airspeed.confidence = _airspeed_validator.confidence(hrt_absolute_time());
 
 		enum AIRSPEED_SENSOR_MODEL smodel;
 
@@ -346,24 +378,73 @@ Sensors::diff_pres_poll(struct sensor_combined_s &raw)
 		}
 
 		/* don't risk to feed negative airspeed into the system */
-		airspeed.indicated_airspeed_m_s = math::max(0.0f,
-						  calc_indicated_airspeed_corrected((enum AIRSPEED_COMPENSATION_MODEL)_parameters.air_cmodel,
-								  smodel, _parameters.air_tube_length, _parameters.air_tube_diameter_mm,
-								  diff_pres.differential_pressure_filtered_pa, _voted_sensors_update.baro_pressure(),
-								  air_temperature_celsius));
+		_airspeed.indicated_airspeed_m_s = math::max(0.0f,
+						   calc_indicated_airspeed_corrected((enum AIRSPEED_COMPENSATION_MODEL)_parameters.air_cmodel,
+								   smodel, _parameters.air_tube_length, _parameters.air_tube_diameter_mm,
+								   diff_pres.differential_pressure_filtered_pa, _voted_sensors_update.baro_pressure(),
+								   air_temperature_celsius));
 
-		airspeed.true_airspeed_m_s = math::max(0.0f,
-						       calc_true_airspeed_from_indicated(airspeed.indicated_airspeed_m_s,
-								       _voted_sensors_update.baro_pressure(), air_temperature_celsius));
-
-		airspeed.true_airspeed_unfiltered_m_s = math::max(0.0f,
-							calc_true_airspeed(diff_pres.differential_pressure_raw_pa + _voted_sensors_update.baro_pressure(),
+		_airspeed.true_airspeed_m_s = math::max(0.0f,
+							calc_true_airspeed_from_indicated(_airspeed.indicated_airspeed_m_s,
 									_voted_sensors_update.baro_pressure(), air_temperature_celsius));
 
-		airspeed.air_temperature_celsius = air_temperature_celsius;
+		_airspeed.true_airspeed_unfiltered_m_s = math::max(0.0f,
+				calc_true_airspeed(diff_pres.differential_pressure_raw_pa + _voted_sensors_update.baro_pressure(),
+						   _voted_sensors_update.baro_pressure(), air_temperature_celsius));
 
-		int instance;
-		orb_publish_auto(ORB_ID(airspeed), &_airspeed_pub, &airspeed, &instance, ORB_PRIO_DEFAULT);
+		_airspeed.air_temperature_celsius = air_temperature_celsius;
+	}
+
+	// update wind and airspeed estimator
+	_wind_estimator.update(hrt_absolute_time());
+
+	bool fuse_airspeed = updated && (hrt_elapsed_time(&_time_last_airspeed_fused) > 5e4);
+	bool fuse_beta = (hrt_elapsed_time(&_time_last_beta_fused) > 5e4) && _vehicle_local_position.v_xy_valid;
+
+	if (fuse_beta || fuse_airspeed) {
+		matrix::Dcmf R_to_earth(matrix::Quatf(_vehicle_attitude.q));
+		matrix::Vector3f vI(_vehicle_local_position.vx, _vehicle_local_position.vy, _vehicle_local_position.vz);
+
+		if (fuse_beta) {
+			_wind_estimator.fuse_beta(hrt_absolute_time(), &vI._data[0][0], _vehicle_attitude.q);
+			_time_last_beta_fused = hrt_absolute_time();
+		}
+
+		if (fuse_airspeed) {
+			matrix::Vector3f vel_var(_vehicle_local_position.evh, _vehicle_local_position.evh, _vehicle_local_position.evv);
+			vel_var = R_to_earth * vel_var;
+			_wind_estimator.fuse_airspeed(hrt_absolute_time(), _airspeed.indicated_airspeed_m_s, &vI._data[0][0],
+						      &vel_var._data[0][0]);
+			_time_last_airspeed_fused = hrt_absolute_time();
+		}
+	}
+
+	int instance;
+
+	if (updated) {
+		_airspeed.scale = _wind_estimator.get_tas_scale();
+
+		orb_publish_auto(ORB_ID(airspeed), &_airspeed_pub, &_airspeed, &instance, ORB_PRIO_DEFAULT);
+
+	}
+
+	if (fuse_beta) {
+		_wind_est.timestamp = hrt_absolute_time();
+		float wind[2];
+		_wind_estimator.get_wind(wind);
+		_wind_est.windspeed_north = wind[0];
+		_wind_est.windspeed_east = wind[1];
+		float wind_cov[2];
+		_wind_estimator.get_wind_var(wind_cov);
+		_wind_est.variance_north = wind_cov[0];
+		_wind_est.variance_east = wind_cov[1];
+		_wind_est.tas_innov = _wind_estimator.get_tas_innov();
+		_wind_est.tas_innov_var = _wind_estimator.get_tas_innov_var();
+		_wind_est.beta_innov = _wind_estimator.get_beta_innov();
+		_wind_est.beta_innov_var = _wind_estimator.get_beta_innov_var();
+		_wind_est.tas_scale = _wind_estimator.get_tas_scale();
+
+		orb_publish_auto(ORB_ID(wind_estimate), &_wind_est_pub, &_wind_est, &instance, ORB_PRIO_HIGH);
 	}
 }
 
@@ -397,6 +478,12 @@ Sensors::parameter_update_poll(bool forced)
 
 		parameters_update();
 
+		// update wind & airspeed scale estimator parameters
+		_wind_estimator.set_wind_p_noise(_parameters.wind_p_noise);
+		_wind_estimator.set_tas_scale_p_noise(_parameters.tas_scale_p_noise);
+		_wind_estimator.set_tas_noise(_parameters.tas_noise);
+		_wind_estimator.set_beta_noise(_parameters.beta_noise);
+
 		/* update airspeed scale */
 		int fd = px4_open(AIRSPEED0_DEVICE_PATH, 0);
 
@@ -417,6 +504,28 @@ Sensors::parameter_update_poll(bool forced)
 		for (int b = 0; b < BOARD_NUMBER_BRICKS; b++) {
 			_battery[b].updateParams();
 		}
+	}
+}
+
+void Sensors::vehicle_local_position_poll()
+{
+	bool updated;
+
+	orb_check(_vehicle_local_position_sub, &updated);
+
+	if (updated) {
+		orb_copy(ORB_ID(vehicle_local_position), _vehicle_local_position_sub, &_vehicle_local_position);
+	}
+}
+
+void Sensors::vehicle_attitude_poll()
+{
+	bool updated;
+
+	orb_check(_vehicle_attitude_sub, &updated);
+
+	if (updated) {
+		orb_copy(ORB_ID(vehicle_attitude), _vehicle_attitude_sub, &_vehicle_attitude);
 	}
 }
 
@@ -608,6 +717,10 @@ Sensors::run()
 
 	_actuator_ctrl_0_sub = orb_subscribe(ORB_ID(actuator_controls_0));
 
+	_vehicle_attitude_sub = orb_subscribe(ORB_ID(vehicle_attitude));
+
+	_vehicle_local_position_sub = orb_subscribe(ORB_ID(vehicle_local_position));
+
 	/* get a set of initial values */
 	_voted_sensors_update.sensors_poll(raw);
 
@@ -712,6 +825,10 @@ Sensors::run()
 		/* Look for new r/c input data */
 		_rc_update.rc_poll(_parameter_handles);
 
+		/* Look for new attitude and velocity data required for wind estimation */
+		vehicle_attitude_poll();
+		vehicle_local_position_poll();
+
 		perf_end(_loop_perf);
 	}
 
@@ -720,6 +837,8 @@ Sensors::run()
 	orb_unsubscribe(_params_sub);
 	orb_unsubscribe(_actuator_ctrl_0_sub);
 	orb_unadvertise(_sensor_pub);
+	orb_unsubscribe(_vehicle_attitude_sub);
+	orb_unsubscribe(_vehicle_local_position_sub);
 
 	_rc_update.deinit();
 	_voted_sensors_update.deinit();


### PR DESCRIPTION
Replacement for #7721 

Estimator outputs reasonable results in SITL using both true airspeed and sideslip fusion (See plots below).
We still need to do the proper integration with ekf2.

Wind estimates
![wind](https://user-images.githubusercontent.com/7610489/32701827-885f7740-c7aa-11e7-914f-a410116b630c.png)

True airspeed scale
![tas_scale](https://user-images.githubusercontent.com/7610489/32701831-9159105e-c7aa-11e7-95ac-3d392380133f.png)

True airspeed innovation and innovation sigma
![airspeed_innov](https://user-images.githubusercontent.com/7610489/32701835-9ed6e44a-c7aa-11e7-910d-205749795a3a.png)

Sideslip innovation and innovation sigma
![beta_innov](https://user-images.githubusercontent.com/7610489/32701838-aa9e71bc-c7aa-11e7-8103-fb1cf7ba4e4f.png)


