### PR TITLE
integrationtests: fix numpy version problem (broken Jenkins)

### DIFF
--- a/integrationtests/run_tests.bash
+++ b/integrationtests/run_tests.bash
@@ -6,6 +6,7 @@
 set -e
 
 # TODO move to docker image
+pip install --upgrade numpy -q
 pip install px4tools pymavlink -q
 
 # A POSIX variable


### PR DESCRIPTION
During px4tools installation the latest version of pandas is installed, which requires numpy>=1.9.0. Pandas installs the required version, however, due to the presence of the old numpy in the docker image, the present version 1.8.2 is used, which leads to an error when importing pandas. It's one of the causes of Jenkins SITL fails.

This PR fixes the problem explicitly upgrading numpy with pip before px4tools installation.

@dagar, please review.