### PR TITLE
use int32_t instead of int

### DIFF
--- a/src/platforms/qurt/fc_addon/uart_esc/uart_esc_main.cpp
+++ b/src/platforms/qurt/fc_addon/uart_esc/uart_esc_main.cpp
@@ -148,7 +148,7 @@ void parameters_init()
 void parameters_update()
 {
 	PX4_WARN("uart_esc_main parameters_update");
-	int v_int;
+	int32_t v_int;
 
 	if (param_get(_parameter_handles.model, &v_int) == 0) {
 		_parameters.model = v_int;


### PR DESCRIPTION
fixes
```
../../src/platforms/qurt/fc_addon/uart_esc/uart_esc_main.cpp:153:6: fatal error: no matching function for call to 'param_get_cplusplus'
        if (param_get(_parameter_handles.model, &v_int) == 0) {
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../src/modules/systemlib/param/param.h:483:31: note: expanded from macro 'param_get'
#define param_get(param, val) param_get_cplusplus(param, val)
                              ^~~~~~~~~~~~~~~~~~~
../../src/modules/systemlib/param/param.h:471:19: note: candidate function not viable: no known conversion from 'int *' to 'float *' for 2nd argument
static inline int param_get_cplusplus(param_t param, float *val)
                  ^
../../src/modules/systemlib/param/param.h:476:19: note: candidate function not viable: no known conversion from 'int *' to 'int32_t *' (aka 'long *') for 2nd argument
static inline int param_get_cplusplus(param_t param, int32_t *val)
```
for `make eagle_legacy_default`