### PR TITLE
navigator: make FollowTarget::_follow_position_matricies constexpr

### DIFF
--- a/src/modules/navigator/follow_target.cpp
+++ b/src/modules/navigator/follow_target.cpp
@@ -56,6 +56,8 @@
 
 #include "navigator.h"
 
+constexpr float FollowTarget::_follow_position_matricies[4][9];
+
 FollowTarget::FollowTarget(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name),
 	_navigator(navigator),

--- a/src/modules/navigator/follow_target.h
+++ b/src/modules/navigator/follow_target.h
@@ -85,7 +85,7 @@ private:
 		FOLLOW_FROM_LEFT
 	};
 
-	float _follow_position_matricies[4][9] = {
+	static constexpr float _follow_position_matricies[4][9] = {
 		{
 			1.0F,  -1.0F, 0.0F,
 			1.0F,   1.0F, 0.0F,


### PR DESCRIPTION
The matrix is never changed and has a size of 144 bytes.