### PR TITLE
mc_pos_control: smooth takeoff does not require slewrate

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -2453,12 +2453,9 @@ MulticopterPositionControl::calculate_velocity_setpoint(float dt)
 	_vel_sp(2) = math::min(_vel_sp(2), vel_limit);
 
 	/* apply slewrate (aka acceleration limit) for smooth flying */
-
-	if (!_control_mode.flag_control_auto_enabled) {
+	if (!_control_mode.flag_control_auto_enabled && !_in_smooth_takeoff) {
 		vel_sp_slewrate(dt);
 	}
-
-	_vel_sp_prev = _vel_sp;
 
 	/* special velocity setpoint limitation for smooth takeoff (after slewrate!) */
 	if (_in_smooth_takeoff) {
@@ -2478,6 +2475,8 @@ MulticopterPositionControl::calculate_velocity_setpoint(float dt)
 	}
 
 	_vel_sp(2) = math::constrain(_vel_sp(2), -_params.vel_max_up, _params.vel_max_down);
+
+	_vel_sp_prev = _vel_sp;
 }
 
 void


### PR DESCRIPTION
It's the same as #8258 just rebased on newest master. I messed up the branches such that I wasn't able to reopen...

I discussed with @Stifael and this exact fix here was already planned because the smooth takeoff should be independent of the slewrate.

For clarification:
- The slewrate is designed to smooth out manual flight in a "feed-forward fashion". It was never meant to support auto flight or offboard flight smoothing. In fact it only produced either slugish perfomance or overshoot problems (like the one described here: #8240 ). It works pretty well ofr manual flight right now but maybe needs to be revised for that as well in the future.
- For auto and offborad smoothing it is important to enable trajectory flying which can be a smooth or an agressive trajectory but the controller should not just ramp it's setpoint around regardless of the actual error.
- The smooth takeoff should be independent of and not affected by the slewrate. Otherwise it doesn't work correctly. It's goal is too basically ramp the multicopters total thrust (and hence motor speeds) to the thrust wich is necessary to achieve the current velocity setpoint in z direction just at the beginning of a flight. It's designed to be always enabled to allow for a nicer start in terms of power, sound and looks for any altitude controlled mode just after switching out of the idle motor speeds.

FYI @korigod 