### PR TITLE
Jenkins: update docker image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
   agent {
     docker {
-      image 'px4io/px4-dev-simulation:2017-09-26'
+      image 'px4io/px4-dev-simulation:2017-10-23'
       args '--env CCACHE_DISABLE=1 --env CI=true'
     }
   }


### PR DESCRIPTION
Update the docker image used for Jenkins builds.

I tried to make the same change in #8063, but it was not used during the build.
Apparently Jenkins does not use a Jenkinsfile that was modified by a PR, it falls back to the Jenkinsfile in master. It took me a while to understand that. That makes sense in terms of safety. Interestingly though, we will know if builds pass for this PR only *after* it is merged to master!

@dagar