### PR TITLE
Navigator mission cleanup

### DIFF
--- a/msg/mission.msg
+++ b/msg/mission.msg
@@ -2,5 +2,3 @@ int8 dataman_id	# default 0, there are two offboard storage places in the datama
 
 uint16 count		# count of the missions stored in the dataman
 int32 current_seq	# default -1, start at the one changed latest
-
-# TOPICS mission offboard_mission onboard_mission

--- a/src/examples/bottle_drop/bottle_drop.cpp
+++ b/src/examples/bottle_drop/bottle_drop.cpp
@@ -188,6 +188,7 @@ BottleDrop::BottleDrop() :
 	_onboard_mission {},
 	_onboard_mission_pub(nullptr)
 {
+	_onboard_mission.dataman_id = DM_KEY_WAYPOINTS_ONBOARD;
 }
 
 BottleDrop::~BottleDrop()
@@ -621,14 +622,15 @@ BottleDrop::task_main()
 						warnx("ERROR: could not save onboard WP");
 					}
 
+					_onboard_mission.timestamp = hrt_absolute_time();
 					_onboard_mission.count = 2;
 					_onboard_mission.current_seq = 0;
 
 					if (_onboard_mission_pub != nullptr) {
-						orb_publish(ORB_ID(onboard_mission), _onboard_mission_pub, &_onboard_mission);
+						orb_publish(ORB_ID(mission), _onboard_mission_pub, &_onboard_mission);
 
 					} else {
-						_onboard_mission_pub = orb_advertise(ORB_ID(onboard_mission), &_onboard_mission);
+						_onboard_mission_pub = orb_advertise(ORB_ID(mission), &_onboard_mission);
 					}
 
 					float approach_direction = get_bearing_to_next_waypoint(flight_vector_s.lat, flight_vector_s.lon, flight_vector_e.lat,
@@ -645,8 +647,9 @@ BottleDrop::task_main()
 							     flight_vector_e.lon);
 
 					if (distance_wp2 < distance_real) {
+						_onboard_mission.timestamp = hrt_absolute_time();
 						_onboard_mission.current_seq = 0;
-						orb_publish(ORB_ID(onboard_mission), _onboard_mission_pub, &_onboard_mission);
+						orb_publish(ORB_ID(mission), _onboard_mission_pub, &_onboard_mission);
 
 					} else {
 
@@ -683,8 +686,9 @@ BottleDrop::task_main()
 									     flight_vector_e.lon);
 
 							if (distance_wp2 < distance_real) {
+								_onboard_mission.timestamp = hrt_absolute_time();
 								_onboard_mission.current_seq = 0;
-								orb_publish(ORB_ID(onboard_mission), _onboard_mission_pub, &_onboard_mission);
+								orb_publish(ORB_ID(mission), _onboard_mission_pub, &_onboard_mission);
 							}
 						}
 					}
@@ -702,9 +706,11 @@ BottleDrop::task_main()
 					mavlink_log_info(&_mavlink_log_pub, "#audio: closing bay");
 
 					// remove onboard mission
+					_onboard_mission.timestamp = hrt_absolute_time();
+					_onboard_mission.dataman_id = DM_KEY_WAYPOINTS_ONBOARD;
 					_onboard_mission.current_seq = -1;
 					_onboard_mission.count = 0;
-					orb_publish(ORB_ID(onboard_mission), _onboard_mission_pub, &_onboard_mission);
+					orb_publish(ORB_ID(mission), _onboard_mission_pub, &_onboard_mission);
 				}
 
 				break;
@@ -804,7 +810,8 @@ BottleDrop::handle_command(struct vehicle_command_s *cmd)
 			_onboard_mission.current_seq = -1;
 
 			if (_onboard_mission_pub != nullptr) {
-				orb_publish(ORB_ID(onboard_mission), _onboard_mission_pub, &_onboard_mission);
+				_onboard_mission.timestamp = hrt_absolute_time();
+				orb_publish(ORB_ID(mission), _onboard_mission_pub, &_onboard_mission);
 			}
 
 		} else {

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1522,18 +1522,15 @@ int commander_thread_main(int argc, char *argv[])
 
 	/* command ack */
 	orb_advert_t command_ack_pub = nullptr;
-
-	/* init mission state, do it here to allow navigator to use stored mission even if mavlink failed to start */
-	mission_s mission;
-
 	orb_advert_t commander_state_pub = nullptr;
-
 	orb_advert_t vehicle_status_flags_pub = nullptr;
 
+	/* init mission state, do it here to allow navigator to use stored mission even if mavlink failed to start */
+	mission_s mission = {};
 	if (dm_read(DM_KEY_MISSION_STATE, 0, &mission, sizeof(mission_s)) == sizeof(mission_s)) {
-		if (mission.dataman_id >= 0 && mission.dataman_id <= 1) {
+		if (mission.dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_0 || mission.dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_1) {
 			if (mission.count > 0) {
-				mavlink_log_info(&mavlink_log_pub, "[cmd] Mission #%d loaded, %u WPs, curr: %d",
+				mavlink_log_info(&mavlink_log_pub, "Mission #%d loaded, %u WPs, curr: %d",
 						 mission.dataman_id, mission.count, mission.current_seq);
 			}
 
@@ -1541,13 +1538,12 @@ int commander_thread_main(int argc, char *argv[])
 			mavlink_log_critical(&mavlink_log_pub, "reading mission state failed");
 
 			/* initialize mission state in dataman */
-			mission.dataman_id = 0;
-			mission.count = 0;
-			mission.current_seq = 0;
+			mission.timestamp = hrt_absolute_time();
+			mission.dataman_id = DM_KEY_WAYPOINTS_OFFBOARD_0;
 			dm_write(DM_KEY_MISSION_STATE, 0, DM_PERSIST_POWER_ON_RESET, &mission, sizeof(mission_s));
 		}
 
-		orb_advert_t mission_pub = orb_advertise(ORB_ID(offboard_mission), &mission);
+		orb_advert_t mission_pub = orb_advertise(ORB_ID(mission), &mission);
 		orb_unadvertise(mission_pub);
 	}
 

--- a/src/modules/dataman/dataman.h
+++ b/src/modules/dataman/dataman.h
@@ -58,8 +58,6 @@ typedef enum {
 	DM_KEY_NUM_KEYS			/* Total number of item types defined */
 } dm_item_t;
 
-#define DM_KEY_WAYPOINTS_OFFBOARD(_id) (_id == 0 ? DM_KEY_WAYPOINTS_OFFBOARD_0 : DM_KEY_WAYPOINTS_OFFBOARD_1)
-
 #if defined(MEMORY_CONSTRAINED_SYSTEM)
 enum {
 	DM_KEY_SAFE_POINTS_MAX = 8,

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -594,8 +594,8 @@ void Logger::add_default_topics()
 	add_topic("home_position");
 	add_topic("input_rc", 200);
 	add_topic("manual_control_setpoint", 200);
+	add_topic("mission");
 	add_topic("mission_result");
-	add_topic("offboard_mission");
 	add_topic("optical_flow", 50);
 	add_topic("position_setpoint_triplet", 200);
 	add_topic("sensor_combined", 100);
@@ -1008,10 +1008,9 @@ void Logger::run()
 			bool data_written = false;
 
 			/* Check if parameters have changed */
-			if (!_should_stop_file_log) { // do not record param changes after disarming
-				if (parameter_update_sub.update()) {
-					write_changed_parameters();
-				}
+			// this needs to change to a timestamped record to record a history of parameter changes
+			if (parameter_update_sub.update()) {
+				write_changed_parameters();
 			}
 
 			/* wait for lock on log buffer */

--- a/src/modules/navigator/datalinkloss.cpp
+++ b/src/modules/navigator/datalinkloss.cpp
@@ -101,7 +101,7 @@ DataLinkLoss::set_dll_item()
 {
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
-	set_previous_pos_setpoint();
+	pos_sp_triplet->previous = pos_sp_triplet->current;
 	_navigator->set_can_loiter_at_sp(false);
 
 	switch (_dll_state) {

--- a/src/modules/navigator/datalinkloss.cpp
+++ b/src/modules/navigator/datalinkloss.cpp
@@ -54,8 +54,6 @@
 #include "navigator.h"
 #include "datalinkloss.h"
 
-#define DELAY_SIGMA	0.01f
-
 DataLinkLoss::DataLinkLoss(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name),
 	_param_commsholdwaittime(this, "CH_T"),
@@ -69,14 +67,6 @@ DataLinkLoss::DataLinkLoss(Navigator *navigator, const char *name) :
 	_param_numberdatalinklosses(this, "N"),
 	_param_skipcommshold(this, "CHSK"),
 	_dll_state(DLL_STATE_NONE)
-{
-	/* load initial params */
-	updateParams();
-	/* initial reset */
-	on_inactive();
-}
-
-DataLinkLoss::~DataLinkLoss()
 {
 }
 

--- a/src/modules/navigator/datalinkloss.h
+++ b/src/modules/navigator/datalinkloss.h
@@ -40,28 +40,21 @@
 #ifndef NAVIGATOR_DATALINKLOSS_H
 #define NAVIGATOR_DATALINKLOSS_H
 
-#include <controllib/blocks.hpp>
-#include <controllib/block/BlockParam.hpp>
-
-#include <uORB/Subscription.hpp>
-
 #include "navigator_mode.h"
 #include "mission_block.h"
 
 class Navigator;
 
-class DataLinkLoss : public MissionBlock
+class DataLinkLoss final : public MissionBlock
 {
 public:
 	DataLinkLoss(Navigator *navigator, const char *name);
 
-	~DataLinkLoss();
+	~DataLinkLoss() = default;
 
-	virtual void on_inactive();
-
-	virtual void on_activation();
-
-	virtual void on_active();
+	void on_inactive() override;
+	void on_activation() override;
+	void on_active() override;
 
 private:
 	/* Params */
@@ -82,7 +75,7 @@ private:
 		DLL_STATE_FLYTOAIRFIELDHOMEWP = 2,
 		DLL_STATE_TERMINATE = 3,
 		DLL_STATE_END = 4
-	} _dll_state;
+	} _dll_state{DLL_STATE_NONE};
 
 	/**
 	 * Set the DLL item

--- a/src/modules/navigator/enginefailure.cpp
+++ b/src/modules/navigator/enginefailure.cpp
@@ -86,7 +86,7 @@ EngineFailure::set_ef_item()
 {
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
-	set_previous_pos_setpoint();
+	pos_sp_triplet->previous = pos_sp_triplet->current;
 	_navigator->set_can_loiter_at_sp(false);
 
 	switch (_ef_state) {

--- a/src/modules/navigator/enginefailure.cpp
+++ b/src/modules/navigator/enginefailure.cpp
@@ -52,19 +52,9 @@
 #include "navigator.h"
 #include "enginefailure.h"
 
-#define DELAY_SIGMA	0.01f
-
 EngineFailure::EngineFailure(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name),
 	_ef_state(EF_STATE_NONE)
-{
-	/* load initial params */
-	updateParams();
-	/* initial reset */
-	on_inactive();
-}
-
-EngineFailure::~EngineFailure()
 {
 }
 

--- a/src/modules/navigator/enginefailure.h
+++ b/src/modules/navigator/enginefailure.h
@@ -40,34 +40,26 @@
 #ifndef NAVIGATOR_ENGINEFAILURE_H
 #define NAVIGATOR_ENGINEFAILURE_H
 
-#include <controllib/blocks.hpp>
-#include <controllib/block/BlockParam.hpp>
-
-#include <uORB/Subscription.hpp>
-
 #include "navigator_mode.h"
 #include "mission_block.h"
 
 class Navigator;
 
-class EngineFailure : public MissionBlock
+class EngineFailure final : public MissionBlock
 {
 public:
 	EngineFailure(Navigator *navigator, const char *name);
+	~EngineFailure() = default;
 
-	~EngineFailure();
-
-	virtual void on_inactive();
-
-	virtual void on_activation();
-
-	virtual void on_active();
+	void on_inactive() override;
+	void on_activation() override;
+	void on_active() override;
 
 private:
 	enum EFState {
 		EF_STATE_NONE = 0,
 		EF_STATE_LOITERDOWN = 1,
-	} _ef_state;
+	} _ef_state{EF_STATE_NONE};
 
 	/**
 	 * Set the DLL item

--- a/src/modules/navigator/follow_target.cpp
+++ b/src/modules/navigator/follow_target.cpp
@@ -60,39 +60,17 @@ constexpr float FollowTarget::_follow_position_matricies[4][9];
 
 FollowTarget::FollowTarget(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name),
-	_navigator(navigator),
 	_param_min_alt(this, "NAV_MIN_FT_HT", false),
 	_param_tracking_dist(this, "NAV_FT_DST", false),
 	_param_tracking_side(this, "NAV_FT_FS", false),
-	_param_tracking_resp(this, "NAV_FT_RS", false),
-	_param_yaw_auto_max(this, "MC_YAWRAUTO_MAX", false),
-	_follow_target_state(SET_WAIT_FOR_TARGET_POSITION),
-	_follow_target_position(FOLLOW_FROM_BEHIND),
-	_follow_target_sub(-1),
-	_step_time_in_ms(0.0f),
-	_follow_offset(OFFSET_M),
-	_target_updates(0),
-	_last_update_time(0),
-	_current_target_motion(),
-	_previous_target_motion(),
-	_yaw_rate(0.0F),
-	_responsiveness(0.0F),
-	_yaw_auto_max(0.0F),
-	_yaw_angle(0.0F)
+	_param_tracking_resp(this, "NAV_FT_RS", false)
 {
-	updateParams();
-	_current_target_motion = {};
-	_previous_target_motion =  {};
 	_current_vel.zero();
 	_step_vel.zero();
 	_est_target_vel.zero();
 	_target_distance.zero();
 	_target_position_offset.zero();
 	_target_position_delta.zero();
-}
-
-FollowTarget::~FollowTarget()
-{
 }
 
 void FollowTarget::on_inactive()
@@ -105,8 +83,6 @@ void FollowTarget::on_activation()
 	_follow_offset = _param_tracking_dist.get() < 1.0F ? 1.0F : _param_tracking_dist.get();
 
 	_responsiveness = math::constrain((float) _param_tracking_resp.get(), .1F, 1.0F);
-
-	_yaw_auto_max = math::radians(_param_yaw_auto_max.get());
 
 	_follow_target_position = _param_tracking_side.get();
 
@@ -231,11 +207,7 @@ void FollowTarget::on_active()
 						_current_target_motion.lat,
 						_current_target_motion.lon);
 
-				_yaw_rate = (_yaw_angle - _navigator->get_global_position()->yaw) / (dt_ms / 1000.0F);
-
-				_yaw_rate = _wrap_pi(_yaw_rate);
-
-				_yaw_rate = math::constrain(_yaw_rate, -1.0F * _yaw_auto_max, _yaw_auto_max);
+				_yaw_rate = _wrap_pi((_yaw_angle - _navigator->get_global_position()->yaw) / (dt_ms / 1000.0f));
 
 			} else {
 				_yaw_angle = _yaw_rate = NAN;

--- a/src/modules/navigator/follow_target.h
+++ b/src/modules/navigator/follow_target.h
@@ -40,24 +40,19 @@
 
 #pragma once
 
-#include <controllib/blocks.hpp>
-#include <controllib/block/BlockParam.hpp>
-#include <lib/mathlib/math/Vector.hpp>
-#include <lib/mathlib/math/Matrix.hpp>
+#include <mathlib/mathlib.h>
+
 #include "navigator_mode.h"
 #include "mission_block.h"
+
 #include <uORB/topics/follow_target.h>
 
-class FollowTarget : public MissionBlock
+class FollowTarget final : public MissionBlock
 {
 
 public:
 	FollowTarget(Navigator *navigator, const char *name);
-
-	FollowTarget(const FollowTarget &) = delete;
-	FollowTarget &operator=(const FollowTarget &) = delete;
-
-	~FollowTarget();
+	~FollowTarget() = default;
 
 	void on_inactive() override;
 	void on_activation() override;
@@ -112,23 +107,20 @@ private:
 	}; // follow left side
 
 
-	Navigator *_navigator;
 	control::BlockParamFloat	_param_min_alt;
 	control::BlockParamFloat 	_param_tracking_dist;
 	control::BlockParamInt 		_param_tracking_side;
 	control::BlockParamFloat 	_param_tracking_resp;
-	control::BlockParamFloat 	_param_yaw_auto_max;
 
+	FollowTargetState _follow_target_state{SET_WAIT_FOR_TARGET_POSITION};
+	int _follow_target_position{FOLLOW_FROM_BEHIND};
 
-	FollowTargetState _follow_target_state;
-	int _follow_target_position;
+	int _follow_target_sub{-1};
+	float _step_time_in_ms{0.0f};
+	float _follow_offset{OFFSET_M};
 
-	int _follow_target_sub;
-	float _step_time_in_ms;
-	float _follow_offset;
-
-	uint64_t _target_updates;
-	uint64_t _last_update_time;
+	uint64_t _target_updates{0};
+	uint64_t _last_update_time{0};
 
 	math::Vector<3> _current_vel;
 	math::Vector<3> _step_vel;
@@ -138,15 +130,14 @@ private:
 	math::Vector<3> _target_position_delta;
 	math::Vector<3> _filtered_target_position_delta;
 
-	follow_target_s _current_target_motion;
-	follow_target_s _previous_target_motion;
-	float _yaw_rate;
-	float _responsiveness;
-	float _yaw_auto_max;
-	float _yaw_angle;
+	follow_target_s _current_target_motion{};
+	follow_target_s _previous_target_motion{};
+
+	float _yaw_rate{0.0f};
+	float _responsiveness{0.0f};
+	float _yaw_angle{0.0f};
 
 	// Mavlink defined motion reporting capabilities
-
 	enum {
 		POS = 0,
 		VEL = 1,
@@ -155,6 +146,7 @@ private:
 	};
 
 	math::Matrix<3, 3> _rot_matrix;
+
 	void track_target_position();
 	void track_target_velocity();
 	bool target_velocity_valid();

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -63,8 +63,6 @@ Geofence::Geofence(Navigator *navigator) :
 	_param_max_hor_distance(this, "GF_MAX_HOR_DIST", false),
 	_param_max_ver_distance(this, "GF_MAX_VER_DIST", false)
 {
-	updateParams();
-
 	// we assume there's no concurrent fence update on startup
 	_updateFence();
 }

--- a/src/modules/navigator/gpsfailure.cpp
+++ b/src/modules/navigator/gpsfailure.cpp
@@ -51,22 +51,13 @@
 using matrix::Eulerf;
 using matrix::Quatf;
 
-static constexpr float DELAY_SIGMA = 0.01f;
-
 GpsFailure::GpsFailure(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name),
 	_param_loitertime(this, "LT"),
 	_param_openlooploiter_roll(this, "R"),
 	_param_openlooploiter_pitch(this, "P"),
-	_param_openlooploiter_thrust(this, "TR"),
-	_gpsf_state(GPSF_STATE_NONE),
-	_timestamp_activation(0)
+	_param_openlooploiter_thrust(this, "TR")
 {
-	/* load initial params */
-	updateParams();
-
-	/* initial reset */
-	on_inactive();
 }
 
 void

--- a/src/modules/navigator/gpsfailure.h
+++ b/src/modules/navigator/gpsfailure.h
@@ -40,18 +40,11 @@
 #ifndef NAVIGATOR_GPSFAILURE_H
 #define NAVIGATOR_GPSFAILURE_H
 
-#include <controllib/blocks.hpp>
-#include <controllib/block/BlockParam.hpp>
-
-#include <uORB/uORB.h>
-#include <uORB/Publication.hpp>
-#include <uORB/topics/vehicle_attitude_setpoint.h>
-
 #include "mission_block.h"
 
 class Navigator;
 
-class GpsFailure : public MissionBlock
+class GpsFailure final : public MissionBlock
 {
 public:
 	GpsFailure(Navigator *navigator, const char *name);

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -38,34 +38,11 @@
  * @author Andreas Antener <andreas@uaventure.com>
  */
 
-#include <string.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <math.h>
-#include <fcntl.h>
-
-#include <systemlib/err.h>
-#include <systemlib/mavlink_log.h>
-
-#include <uORB/uORB.h>
-#include <uORB/topics/position_setpoint_triplet.h>
-
 #include "land.h"
 #include "navigator.h"
 
 Land::Land(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name)
-{
-	/* load initial params */
-	updateParams();
-}
-
-Land::~Land()
-{
-}
-
-void
-Land::on_inactive()
 {
 }
 

--- a/src/modules/navigator/land.h
+++ b/src/modules/navigator/land.h
@@ -41,25 +41,17 @@
 #ifndef NAVIGATOR_LAND_H
 #define NAVIGATOR_LAND_H
 
-#include <controllib/blocks.hpp>
-#include <controllib/block/BlockParam.hpp>
-
 #include "navigator_mode.h"
 #include "mission_block.h"
 
-class Land : public MissionBlock
+class Land final : public MissionBlock
 {
 public:
 	Land(Navigator *navigator, const char *name);
+	~Land() = default;
 
-	~Land();
-
-	virtual void on_inactive();
-
-	virtual void on_activation();
-
-	virtual void on_active();
-
+	void on_activation() override;
+	void on_active() override;
 };
 
 #endif

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -39,33 +39,12 @@
  * @author Anton Babushkin <anton.babushkin@me.com>
  */
 
-#include <string.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <math.h>
-#include <fcntl.h>
-
-#include <geo/geo.h>
-
-#include <systemlib/mavlink_log.h>
-#include <systemlib/err.h>
-
-#include <uORB/uORB.h>
-#include <uORB/topics/position_setpoint_triplet.h>
-
 #include "loiter.h"
 #include "navigator.h"
 
 Loiter::Loiter(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name),
-	_param_yawmode(this, "MIS_YAWMODE", false),
-	_loiter_pos_set(false)
-{
-	// load initial params
-	updateParams();
-}
-
-Loiter::~Loiter()
+	_param_yawmode(this, "MIS_YAWMODE", false)
 {
 }
 

--- a/src/modules/navigator/loiter.h
+++ b/src/modules/navigator/loiter.h
@@ -41,25 +41,20 @@
 #ifndef NAVIGATOR_LOITER_H
 #define NAVIGATOR_LOITER_H
 
-#include <controllib/blocks.hpp>
-#include <controllib/block/BlockParam.hpp>
-
 #include "navigator_mode.h"
 #include "mission_block.h"
 
-class Loiter : public MissionBlock
+class Loiter final : public MissionBlock
 {
 public:
 	Loiter(Navigator *navigator, const char *name);
+	~Loiter() = default;
 
-	~Loiter();
+	void on_inactive() override;
+	void on_activation() override;
+	void on_active() override;
 
-	virtual void on_inactive();
-
-	virtual void on_activation();
-
-	virtual void on_active();
-
+	// TODO: share this with mission
 	enum mission_yaw_mode {
 		MISSION_YAWMODE_NONE = 0,
 		MISSION_YAWMODE_FRONT_TO_WAYPOINT = 1,
@@ -81,7 +76,8 @@ private:
 	void set_loiter_position();
 
 	control::BlockParamInt _param_yawmode;
-	bool _loiter_pos_set;
+
+	bool _loiter_pos_set{false};
 };
 
 #endif

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -69,7 +69,6 @@ Mission::Mission(Navigator *navigator, const char *name) :
 	_param_fw_climbout_diff(this, "FW_CLMBOUT_DIFF", false),
 	_missionFeasibilityChecker(navigator)
 {
-	updateParams();
 }
 
 void

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -60,7 +60,6 @@
 
 Mission::Mission(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name),
-	_param_onboard_enabled(this, "MIS_ONBOARD_EN", false),
 	_param_dist_1wp(this, "MIS_DIST_1WP", false),
 	_param_dist_between_wps(this, "MIS_DIST_WPS", false),
 	_param_altmode(this, "MIS_ALTMODE", false),
@@ -82,14 +81,6 @@ Mission::on_inactive()
 	}
 
 	if (_inited) {
-		/* check if missions have changed so that feedback to ground station is given */
-		bool onboard_updated = false;
-		orb_check(_navigator->get_onboard_mission_sub(), &onboard_updated);
-
-		if (onboard_updated) {
-			update_onboard_mission();
-		}
-
 		bool offboard_updated = false;
 		orb_check(_navigator->get_offboard_mission_sub(), &offboard_updated);
 
@@ -172,13 +163,6 @@ Mission::on_active()
 	check_mission_valid(false);
 
 	/* check if anything has changed */
-	bool onboard_updated = false;
-	orb_check(_navigator->get_onboard_mission_sub(), &onboard_updated);
-
-	if (onboard_updated) {
-		update_onboard_mission();
-	}
-
 	bool offboard_updated = false;
 	orb_check(_navigator->get_offboard_mission_sub(), &offboard_updated);
 
@@ -195,7 +179,7 @@ Mission::on_active()
 	}
 
 	/* reset mission items if needed */
-	if (onboard_updated || offboard_updated) {
+	if (offboard_updated) {
 		set_mission_items();
 	}
 
@@ -278,7 +262,7 @@ Mission::find_offboard_land_start()
 	 * TODO: implement full spec and find closest landing point geographically
 	 */
 
-	dm_item_t dm_current = DM_KEY_WAYPOINTS_OFFBOARD(_offboard_mission.dataman_id);
+	const dm_item_t dm_current = (dm_item_t)_offboard_mission.dataman_id;
 
 	for (size_t i = 0; i < _offboard_mission.count; i++) {
 		struct mission_item_s missionitem = {};
@@ -298,53 +282,6 @@ Mission::find_offboard_land_start()
 }
 
 void
-Mission::update_onboard_mission()
-{
-	/* reset triplets */
-	_navigator->reset_triplets();
-
-	if (orb_copy(ORB_ID(onboard_mission), _navigator->get_onboard_mission_sub(), &_onboard_mission) == OK) {
-		/* accept the current index set by the onboard mission if it is within bounds */
-		if (_onboard_mission.current_seq >= 0
-		    && _onboard_mission.current_seq < (int)_onboard_mission.count) {
-
-			_current_onboard_mission_index = _onboard_mission.current_seq;
-
-		} else {
-			/* if less WPs available, reset to first WP */
-			if (_current_onboard_mission_index >= (int)_onboard_mission.count) {
-				_current_onboard_mission_index = 0;
-				/* if not initialized, set it to 0 */
-
-			} else if (_current_onboard_mission_index < 0) {
-				_current_onboard_mission_index = 0;
-			}
-
-			/* otherwise, just leave it */
-		}
-
-		// XXX check validity here as well
-		_navigator->get_mission_result()->valid = true;
-		/* reset mission failure if we have an updated valid mission */
-		_navigator->get_mission_result()->failure = false;
-
-		/* reset sequence info as well */
-		_navigator->get_mission_result()->seq_reached = -1;
-		_navigator->get_mission_result()->seq_total = _onboard_mission.count;
-
-		/* reset work item if new mission has been accepted */
-		_work_item_type = WORK_ITEM_TYPE_DEFAULT;
-		_navigator->increment_mission_instance_count();
-		_navigator->set_mission_result_updated();
-
-	} else {
-		_onboard_mission.count = 0;
-		_onboard_mission.current_seq = 0;
-		_current_onboard_mission_index = 0;
-	}
-}
-
-void
 Mission::update_offboard_mission()
 {
 	bool failed = true;
@@ -352,11 +289,7 @@ Mission::update_offboard_mission()
 	/* reset triplets */
 	_navigator->reset_triplets();
 
-	if (orb_copy(ORB_ID(offboard_mission), _navigator->get_offboard_mission_sub(), &_offboard_mission) == OK) {
-		// The following is not really a warning, but it can be useful to have this message in the log file
-		PX4_WARN("offboard mission updated: dataman_id=%d, count=%d, current_seq=%d", _offboard_mission.dataman_id,
-			 _offboard_mission.count, _offboard_mission.current_seq);
-
+	if (orb_copy(ORB_ID(mission), _navigator->get_offboard_mission_sub(), &_offboard_mission) == OK) {
 		/* determine current index */
 		if (_offboard_mission.current_seq >= 0 && _offboard_mission.current_seq < (int)_offboard_mission.count) {
 			_current_offboard_mission_index = _offboard_mission.current_seq;
@@ -415,10 +348,6 @@ Mission::advance_mission()
 	}
 
 	switch (_mission_type) {
-	case MISSION_TYPE_ONBOARD:
-		_current_onboard_mission_index++;
-		break;
-
 	case MISSION_TYPE_OFFBOARD:
 		_current_offboard_mission_index++;
 		break;
@@ -446,8 +375,6 @@ Mission::set_mission_items()
 	/* reset the altitude foh (first order hold) logic, if altitude foh is enabled (param) a new foh element starts now */
 	_min_current_sp_distance_xy = FLT_MAX;
 
-	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-
 	/* the home dist check provides user feedback, so we initialize it to this */
 	bool user_feedback_done = false;
 
@@ -457,21 +384,7 @@ Mission::set_mission_items()
 
 	work_item_type new_work_item_type = WORK_ITEM_TYPE_DEFAULT;
 
-	/* try setting onboard mission item */
-	if (_param_onboard_enabled.get()
-	    && prepare_mission_items(true, &_mission_item, &mission_item_next_position, &has_next_position_item)) {
-
-		/* if mission type changed, notify */
-		if (_mission_type != MISSION_TYPE_ONBOARD) {
-			mavlink_log_info(_navigator->get_mavlink_log_pub(), "Executing internal mission.");
-			user_feedback_done = true;
-		}
-
-		_mission_type = MISSION_TYPE_ONBOARD;
-
-		/* try setting offboard mission item */
-
-	} else if (prepare_mission_items(false, &_mission_item, &mission_item_next_position, &has_next_position_item)) {
+	if (prepare_mission_items(&_mission_item, &mission_item_next_position, &has_next_position_item)) {
 		/* if mission type changed, notify */
 		if (_mission_type != MISSION_TYPE_OFFBOARD) {
 			mavlink_log_info(_navigator->get_mavlink_log_pub(), "Executing mission.");
@@ -504,6 +417,7 @@ Mission::set_mission_items()
 		set_loiter_item(&_mission_item, _navigator->get_takeoff_min_alt());
 
 		/* update position setpoint triplet  */
+		position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 		pos_sp_triplet->previous.valid = false;
 		mission_apply_limitation(_mission_item);
 		mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
@@ -548,6 +462,7 @@ Mission::set_mission_items()
 		}
 
 		/* we have a new position item so set previous position setpoint to current */
+		position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 		pos_sp_triplet->previous = pos_sp_triplet->current;
 
 		/* do takeoff before going to setpoint if needed and not already in takeoff */
@@ -670,8 +585,7 @@ Mission::set_mission_items()
 
 			float altitude = _navigator->get_global_position()->alt;
 
-			if (pos_sp_triplet->current.valid
-			    && pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_POSITION) {
+			if (pos_sp_triplet->current.valid && pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_POSITION) {
 				altitude = pos_sp_triplet->current.alt;
 			}
 
@@ -745,6 +659,7 @@ Mission::set_mission_items()
 		}
 
 	} else {
+		position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 		/* handle non-position mission items such as commands */
 
 		/* turn towards next waypoint before MC to FW transition */
@@ -801,6 +716,8 @@ Mission::set_mission_items()
 	}
 
 	/*********************************** set setpoints and check next *********************************************/
+
+	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
 	/* set current position setpoint from mission item (is protected against non-position items) */
 	mission_apply_limitation(_mission_item);
@@ -947,10 +864,8 @@ Mission::set_align_mission_item(struct mission_item_s *mission_item, struct miss
 	mission_item->autocontinue = true;
 	mission_item->time_inside = 0.0f;
 	mission_item->yaw = get_bearing_to_next_waypoint(
-				    _navigator->get_global_position()->lat,
-				    _navigator->get_global_position()->lon,
-				    mission_item_next->lat,
-				    mission_item_next->lon);
+				    _navigator->get_global_position()->lat, _navigator->get_global_position()->lon,
+				    mission_item_next->lat, mission_item_next->lon);
 	mission_item->force_heading = true;
 }
 
@@ -1008,8 +923,7 @@ Mission::heading_sp_update()
 		point_from_latlon[1] = _navigator->get_global_position()->lon;
 
 		/* target location is home */
-		if ((_param_yawmode.get() == MISSION_YAWMODE_FRONT_TO_HOME
-		     || _param_yawmode.get() == MISSION_YAWMODE_BACK_TO_HOME)
+		if ((_param_yawmode.get() == MISSION_YAWMODE_FRONT_TO_HOME || _param_yawmode.get() == MISSION_YAWMODE_BACK_TO_HOME)
 		    // need to be rotary wing for this but not in a transition
 		    // in VTOL mode this will prevent updating yaw during FW flight
 		    // (which would result in a wrong yaw setpoint spike during back transition)
@@ -1122,10 +1036,8 @@ Mission::altitude_sp_foh_update()
 		pos_sp_triplet->current.alt = a + grad * _min_current_sp_distance_xy;
 	}
 
-
 	// we set altitude directly so we can run this in parallel to the heading update
 	_navigator->set_position_setpoint_triplet_updated();
-
 }
 
 void
@@ -1158,9 +1070,9 @@ Mission::do_abort_landing()
 
 	// loiter at the larger of MIS_LTRMIN_ALT above the landing point
 	//  or 2 * FW_CLMBOUT_DIFF above the current altitude
-	float alt_landing = get_absolute_altitude_for_item(_mission_item);
-	float min_climbout = _navigator->get_global_position()->alt + 20.0f;
-	float alt_sp = math::max(alt_landing + _navigator->get_loiter_min_alt(), min_climbout);
+	const float alt_landing = get_absolute_altitude_for_item(_mission_item);
+	const float alt_sp = math::max(alt_landing + _navigator->get_loiter_min_alt(),
+				       _navigator->get_global_position()->alt + 20.0f);
 
 	// turn current landing waypoint into an indefinite loiter
 	_mission_item.nav_cmd = NAV_CMD_LOITER_UNLIMITED;
@@ -1171,12 +1083,11 @@ Mission::do_abort_landing()
 	_mission_item.autocontinue = false;
 	_mission_item.origin = ORIGIN_ONBOARD;
 
-	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 	mission_apply_limitation(_mission_item);
-	mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
+	mission_item_to_position_setpoint(_mission_item, &_navigator->get_position_setpoint_triplet()->current);
 	_navigator->set_position_setpoint_triplet_updated();
 
-	mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "Holding at %dm above landing.",
+	mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "Holding at %d m above landing.",
 				     (int)(alt_sp - alt_landing));
 
 	// reset mission index to start of landing
@@ -1204,18 +1115,18 @@ Mission::do_abort_landing()
 }
 
 bool
-Mission::prepare_mission_items(bool onboard, struct mission_item_s *mission_item,
-			       struct mission_item_s *next_position_mission_item, bool *has_next_position_item)
+Mission::prepare_mission_items(mission_item_s *mission_item, mission_item_s *next_position_mission_item,
+			       bool *has_next_position_item)
 {
 	bool first_res = false;
 	int offset = 1;
 
-	if (read_mission_item(onboard, 0, mission_item)) {
+	if (read_mission_item(0, mission_item)) {
 
 		first_res = true;
 
 		/* trying to find next position mission item */
-		while (read_mission_item(onboard, offset, next_position_mission_item)) {
+		while (read_mission_item(offset, next_position_mission_item)) {
 
 			if (item_contains_position(*next_position_mission_item)) {
 				*has_next_position_item = true;
@@ -1230,30 +1141,19 @@ Mission::prepare_mission_items(bool onboard, struct mission_item_s *mission_item
 }
 
 bool
-Mission::read_mission_item(bool onboard, int offset, struct mission_item_s *mission_item)
+Mission::read_mission_item(int offset, struct mission_item_s *mission_item)
 {
-	/* select onboard/offboard mission */
-	int *mission_index_ptr;
-	dm_item_t dm_item;
-
-	struct mission_s *mission = (onboard) ? &_onboard_mission : &_offboard_mission;
-	int current_index = (onboard) ? _current_onboard_mission_index : _current_offboard_mission_index;
+	/* select offboard mission */
+	struct mission_s *mission = &_offboard_mission;
+	int current_index = _current_offboard_mission_index;
 	int index_to_read = current_index + offset;
+
+	int *mission_index_ptr = (offset == 0) ? &_current_offboard_mission_index : &index_to_read;
+	const dm_item_t dm_item = (dm_item_t)_offboard_mission.dataman_id;
 
 	/* do not work on empty missions */
 	if (mission->count == 0) {
 		return false;
-	}
-
-	if (onboard) {
-		/* onboard mission */
-		mission_index_ptr = (offset == 0) ? &_current_onboard_mission_index : &index_to_read;
-		dm_item = DM_KEY_WAYPOINTS_ONBOARD;
-
-	} else {
-		/* offboard mission */
-		mission_index_ptr = (offset == 0) ? &_current_offboard_mission_index : &index_to_read;
-		dm_item = DM_KEY_WAYPOINTS_OFFBOARD(_offboard_mission.dataman_id);
 	}
 
 	/* Repeat this several times in case there are several DO JUMPS that we need to follow along, however, after
@@ -1264,8 +1164,7 @@ Mission::read_mission_item(bool onboard, int offset, struct mission_item_s *miss
 			/* mission item index out of bounds - if they are equal, we just reached the end */
 			if (*mission_index_ptr != (int)mission->count) {
 				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission item index out of bound, index: %d, max: %d.",
-						     *mission_index_ptr,
-						     (int)mission->count);
+						     *mission_index_ptr, mission->count);
 			}
 
 			return false;
@@ -1295,10 +1194,8 @@ Mission::read_mission_item(bool onboard, int offset, struct mission_item_s *miss
 					(mission_item_tmp.do_jump_current_count)++;
 
 					/* save repeat count */
-					if (dm_write(dm_item, *mission_index_ptr, DM_PERSIST_POWER_ON_RESET,
-						     &mission_item_tmp, len) != len) {
-						/* not supposed to happen unless the datamanager can't access the
-						 * dataman */
+					if (dm_write(dm_item, *mission_index_ptr, DM_PERSIST_POWER_ON_RESET, &mission_item_tmp, len) != len) {
+						/* not supposed to happen unless the datamanager can't access the dataman */
 						mavlink_log_critical(_navigator->get_mavlink_log_pub(), "DO JUMP waypoint could not be written.");
 						return false;
 					}
@@ -1361,6 +1258,7 @@ Mission::save_offboard_mission_state()
 
 	} else {
 		/* invalid data, this must not happen and indicates error in offboard_mission publisher */
+		mission_state.timestamp = hrt_absolute_time();
 		mission_state.dataman_id = _offboard_mission.dataman_id;
 		mission_state.count = _offboard_mission.count;
 		mission_state.current_seq = _current_offboard_mission_index;
@@ -1388,6 +1286,7 @@ Mission::report_do_jump_mission_changed(int index, int do_jumps_remaining)
 	_navigator->get_mission_result()->item_do_jump_changed = true;
 	_navigator->get_mission_result()->item_changed_index = index;
 	_navigator->get_mission_result()->item_do_jump_remaining = do_jumps_remaining;
+
 	_navigator->set_mission_result_updated();
 }
 
@@ -1396,6 +1295,7 @@ Mission::set_mission_item_reached()
 {
 	_navigator->get_mission_result()->seq_reached = _current_offboard_mission_index;
 	_navigator->set_mission_result_updated();
+
 	reset_mission_item_reached();
 }
 
@@ -1404,6 +1304,7 @@ Mission::set_current_offboard_mission_item()
 {
 	_navigator->get_mission_result()->finished = false;
 	_navigator->get_mission_result()->seq_current = _current_offboard_mission_index;
+
 	_navigator->set_mission_result_updated();
 
 	save_offboard_mission_state();
@@ -1435,13 +1336,13 @@ Mission::reset_offboard_mission(struct mission_s &mission)
 	dm_lock(DM_KEY_MISSION_STATE);
 
 	if (dm_read(DM_KEY_MISSION_STATE, 0, &mission, sizeof(mission_s)) == sizeof(mission_s)) {
-		if (mission.dataman_id >= 0 && mission.dataman_id <= 1) {
+		if (mission.dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_0 || mission.dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_1) {
 			/* set current item to 0 */
 			mission.current_seq = 0;
 
 			/* reset jump counters */
 			if (mission.count > 0) {
-				dm_item_t dm_current = DM_KEY_WAYPOINTS_OFFBOARD(mission.dataman_id);
+				const dm_item_t dm_current = (dm_item_t)mission.dataman_id;
 
 				for (unsigned index = 0; index < mission.count; index++) {
 					struct mission_item_s item;
@@ -1467,7 +1368,8 @@ Mission::reset_offboard_mission(struct mission_s &mission)
 			mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Could not read mission.");
 
 			/* initialize mission state in dataman */
-			mission.dataman_id = 0;
+			mission.timestamp = hrt_absolute_time();
+			mission.dataman_id = DM_KEY_WAYPOINTS_OFFBOARD_0;
 			mission.count = 0;
 			mission.current_seq = 0;
 		}

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -61,13 +61,10 @@
 Mission::Mission(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name),
 	_param_onboard_enabled(this, "MIS_ONBOARD_EN", false),
-	_param_takeoff_alt(this, "MIS_TAKEOFF_ALT", false),
 	_param_dist_1wp(this, "MIS_DIST_1WP", false),
 	_param_dist_between_wps(this, "MIS_DIST_WPS", false),
 	_param_altmode(this, "MIS_ALTMODE", false),
-	_param_yawmode(this, "MIS_YAWMODE", false),
-	_param_fw_climbout_diff(this, "FW_CLMBOUT_DIFF", false),
-	_missionFeasibilityChecker(navigator)
+	_param_yawmode(this, "MIS_YAWMODE", false)
 {
 }
 
@@ -447,7 +444,7 @@ void
 Mission::set_mission_items()
 {
 	/* reset the altitude foh (first order hold) logic, if altitude foh is enabled (param) a new foh element starts now */
-	altitude_sp_foh_reset();
+	_min_current_sp_distance_xy = FLT_MAX;
 
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
@@ -504,7 +501,7 @@ Mission::set_mission_items()
 		_mission_type = MISSION_TYPE_NONE;
 
 		/* set loiter mission item and ensure that there is a minimum clearance from home */
-		set_loiter_item(&_mission_item, _param_takeoff_alt.get());
+		set_loiter_item(&_mission_item, _navigator->get_takeoff_min_alt());
 
 		/* update position setpoint triplet  */
 		pos_sp_triplet->previous.valid = false;
@@ -515,7 +512,9 @@ Mission::set_mission_items()
 		/* reuse setpoint for LOITER only if it's not IDLE */
 		_navigator->set_can_loiter_at_sp(pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER);
 
-		set_mission_finished();
+		// set mission finished
+		_navigator->get_mission_result()->finished = true;
+		_navigator->set_mission_result_updated();
 
 		if (!user_feedback_done) {
 			/* only tell users that we got no mission if there has not been any
@@ -545,12 +544,11 @@ Mission::set_mission_items()
 
 		/* force vtol land */
 		if (_navigator->force_vtol() && _mission_item.nav_cmd == NAV_CMD_LAND) {
-
 			_mission_item.nav_cmd = NAV_CMD_VTOL_LAND;
 		}
 
 		/* we have a new position item so set previous position setpoint to current */
-		set_previous_pos_setpoint();
+		pos_sp_triplet->previous = pos_sp_triplet->current;
 
 		/* do takeoff before going to setpoint if needed and not already in takeoff */
 		/* in fixed-wing this whole block will be ignored and a takeoff item is always propagated */
@@ -561,7 +559,7 @@ Mission::set_mission_items()
 			new_work_item_type = WORK_ITEM_TYPE_TAKEOFF;
 
 			/* use current mission item as next position item */
-			memcpy(&mission_item_next_position, &_mission_item, sizeof(struct mission_item_s));
+			mission_item_next_position = _mission_item;
 			mission_item_next_position.nav_cmd = NAV_CMD_WAYPOINT;
 			has_next_position_item = true;
 
@@ -667,7 +665,7 @@ Mission::set_mission_items()
 			new_work_item_type = WORK_ITEM_TYPE_MOVE_TO_LAND;
 
 			/* use current mission item as next position item */
-			memcpy(&mission_item_next_position, &_mission_item, sizeof(struct mission_item_s));
+			mission_item_next_position = _mission_item;
 			has_next_position_item = true;
 
 			float altitude = _navigator->get_global_position()->alt;
@@ -707,7 +705,7 @@ Mission::set_mission_items()
 			new_work_item_type = WORK_ITEM_TYPE_MOVE_TO_LAND;
 
 			/* use current mission item as next position item */
-			memcpy(&mission_item_next_position, &_mission_item, sizeof(struct mission_item_s));
+			mission_item_next_position = _mission_item;
 			has_next_position_item = true;
 
 			/*
@@ -773,7 +771,7 @@ Mission::set_mission_items()
 			new_work_item_type = WORK_ITEM_TYPE_DEFAULT;
 
 			/* set position setpoint to target during the transition */
-			set_previous_pos_setpoint();
+			pos_sp_triplet->previous = pos_sp_triplet->current;
 			generate_waypoint_from_heading(&pos_sp_triplet->current, pos_sp_triplet->current.yaw);
 		}
 
@@ -849,10 +847,8 @@ Mission::set_mission_items()
 	if (pos_sp_triplet->current.valid && pos_sp_triplet->previous.valid) {
 
 		_distance_current_previous = get_distance_to_next_waypoint(
-						     pos_sp_triplet->current.lat,
-						     pos_sp_triplet->current.lon,
-						     pos_sp_triplet->previous.lat,
-						     pos_sp_triplet->previous.lon);
+						     pos_sp_triplet->current.lat, pos_sp_triplet->current.lon,
+						     pos_sp_triplet->previous.lat, pos_sp_triplet->previous.lon);
 	}
 
 	_navigator->set_position_setpoint_triplet_updated();
@@ -966,10 +962,10 @@ Mission::calculate_takeoff_altitude(struct mission_item_s *mission_item)
 
 	/* takeoff to at least MIS_TAKEOFF_ALT above home/ground, even if first waypoint is lower */
 	if (_navigator->get_land_detected()->landed) {
-		takeoff_alt = fmaxf(takeoff_alt, _navigator->get_global_position()->alt + _param_takeoff_alt.get());
+		takeoff_alt = fmaxf(takeoff_alt, _navigator->get_global_position()->alt + _navigator->get_takeoff_min_alt());
 
 	} else {
-		takeoff_alt = fmaxf(takeoff_alt, _navigator->get_home_position()->alt + _param_takeoff_alt.get());
+		takeoff_alt = fmaxf(takeoff_alt, _navigator->get_home_position()->alt + _navigator->get_takeoff_min_alt());
 	}
 
 	return takeoff_alt;
@@ -1042,10 +1038,8 @@ Mission::heading_sp_update()
 		/* stop if positions are close together to prevent excessive yawing */
 		if (d_current > _navigator->get_acceptance_radius()) {
 			float yaw = get_bearing_to_next_waypoint(
-					    point_from_latlon[0],
-					    point_from_latlon[1],
-					    point_to_latlon[0],
-					    point_to_latlon[1]);
+					    point_from_latlon[0], point_from_latlon[1],
+					    point_to_latlon[0], point_to_latlon[1]);
 
 			/* always keep the back of the rotary wing pointing towards home */
 			if (_param_yawmode.get() == MISSION_YAWMODE_BACK_TO_HOME) {
@@ -1135,12 +1129,6 @@ Mission::altitude_sp_foh_update()
 }
 
 void
-Mission::altitude_sp_foh_reset()
-{
-	_min_current_sp_distance_xy = FLT_MAX;
-}
-
-void
 Mission::cruising_speed_sp_update()
 {
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
@@ -1171,7 +1159,7 @@ Mission::do_abort_landing()
 	// loiter at the larger of MIS_LTRMIN_ALT above the landing point
 	//  or 2 * FW_CLMBOUT_DIFF above the current altitude
 	float alt_landing = get_absolute_altitude_for_item(_mission_item);
-	float min_climbout = _navigator->get_global_position()->alt + (2 * _param_fw_climbout_diff.get());
+	float min_climbout = _navigator->get_global_position()->alt + 20.0f;
 	float alt_sp = math::max(alt_landing + _navigator->get_loiter_min_alt(), min_climbout);
 
 	// turn current landing waypoint into an indefinite loiter
@@ -1422,16 +1410,11 @@ Mission::set_current_offboard_mission_item()
 }
 
 void
-Mission::set_mission_finished()
-{
-	_navigator->get_mission_result()->finished = true;
-	_navigator->set_mission_result_updated();
-}
-
-void
 Mission::check_mission_valid(bool force)
 {
 	if ((!_home_inited && _navigator->home_position_valid()) || force) {
+
+		MissionFeasibilityChecker _missionFeasibilityChecker(_navigator);
 
 		_navigator->get_mission_result()->valid =
 			_missionFeasibilityChecker.checkMissionFeasible(_offboard_mission,
@@ -1515,12 +1498,9 @@ void
 Mission::generate_waypoint_from_heading(struct position_setpoint_s *setpoint, float yaw)
 {
 	waypoint_from_heading_and_distance(
-		_navigator->get_global_position()->lat,
-		_navigator->get_global_position()->lon,
-		yaw,
-		1000000.0f,
-		&(setpoint->lat),
-		&(setpoint->lon));
+		_navigator->get_global_position()->lat, _navigator->get_global_position()->lon,
+		yaw, 1000000.0f,
+		&(setpoint->lat), &(setpoint->lon));
 	setpoint->type = position_setpoint_s::SETPOINT_TYPE_POSITION;
 	setpoint->yaw = yaw;
 }

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -51,8 +51,6 @@
 
 #include <cfloat>
 
-#include <controllib/block/BlockParam.hpp>
-#include <controllib/blocks.hpp>
 #include <dataman/dataman.h>
 #include <drivers/drv_hrt.h>
 #include <uORB/topics/home_position.h>
@@ -66,7 +64,7 @@
 
 class Navigator;
 
-class Mission : public MissionBlock
+class Mission final : public MissionBlock
 {
 public:
 	Mission(Navigator *navigator, const char *name);

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -155,11 +155,6 @@ private:
 	void altitude_sp_foh_update();
 
 	/**
-	 * Resets the altitude sp foh logic
-	 */
-	void altitude_sp_foh_reset();
-
-	/**
 	 * Update the cruising speed setpoint.
 	 */
 	void cruising_speed_sp_update();
@@ -209,11 +204,6 @@ private:
 	void set_current_offboard_mission_item();
 
 	/**
-	 * Set that the mission is finished if one exists or that none exists
-	 */
-	void set_mission_finished();
-
-	/**
 	 * Check whether a mission is ready to go
 	 */
 	void check_mission_valid(bool force);
@@ -235,12 +225,10 @@ private:
 	void generate_waypoint_from_heading(struct position_setpoint_s *setpoint, float yaw);
 
 	control::BlockParamInt _param_onboard_enabled;
-	control::BlockParamFloat _param_takeoff_alt;
 	control::BlockParamFloat _param_dist_1wp;
 	control::BlockParamFloat _param_dist_between_wps;
 	control::BlockParamInt _param_altmode;
 	control::BlockParamInt _param_yawmode;
-	control::BlockParamFloat _param_fw_climbout_diff;
 
 	struct mission_s _onboard_mission {};
 	struct mission_s _offboard_mission {};
@@ -258,8 +246,6 @@ private:
 	bool _inited{false};
 	bool _home_inited{false};
 	bool _need_mission_reset{false};
-
-	MissionFeasibilityChecker _missionFeasibilityChecker; /**< class that checks if a mission is feasible */
 
 	float _min_current_sp_distance_xy{FLT_MAX}; /**< minimum distance which was achieved to the current waypoint  */
 

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -94,10 +94,6 @@ public:
 	int find_offboard_land_start();
 
 private:
-	/**
-	 * Update onboard mission topic
-	 */
-	void update_onboard_mission();
 
 	/**
 	 * Update offboard mission topic
@@ -172,8 +168,8 @@ private:
 	 *
 	 * @return true if current mission item available
 	 */
-	bool prepare_mission_items(bool onboard, struct mission_item_s *mission_item,
-				   struct mission_item_s *next_position_mission_item, bool *has_next_position_item);
+	bool prepare_mission_items(mission_item_s *mission_item, mission_item_s *next_position_mission_item,
+				   bool *has_next_position_item);
 
 	/**
 	 * Read current (offset == 0) or a specific (offset > 0) mission item
@@ -181,7 +177,7 @@ private:
 	 *
 	 * @return true if successful
 	 */
-	bool read_mission_item(bool onboard, int offset, struct mission_item_s *mission_item);
+	bool read_mission_item(int offset, mission_item_s *mission_item);
 
 	/**
 	 * Save current offboard mission state to dataman
@@ -224,22 +220,18 @@ private:
 	 */
 	void generate_waypoint_from_heading(struct position_setpoint_s *setpoint, float yaw);
 
-	control::BlockParamInt _param_onboard_enabled;
 	control::BlockParamFloat _param_dist_1wp;
 	control::BlockParamFloat _param_dist_between_wps;
 	control::BlockParamInt _param_altmode;
 	control::BlockParamInt _param_yawmode;
 
-	struct mission_s _onboard_mission {};
 	struct mission_s _offboard_mission {};
 
-	int _current_onboard_mission_index{-1};
 	int _current_offboard_mission_index{-1};
 	bool _need_takeoff{true};					/**< if true, then takeoff must be performed before going to the first waypoint (if needed) */
 
 	enum {
 		MISSION_TYPE_NONE,
-		MISSION_TYPE_ONBOARD,
 		MISSION_TYPE_OFFBOARD
 	} _mission_type{MISSION_TYPE_NONE};
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -55,11 +55,7 @@
 #include <uORB/topics/vtol_vehicle_status.h>
 
 MissionBlock::MissionBlock(Navigator *navigator, const char *name) :
-	NavigatorMode(navigator, name),
-	_param_yaw_timeout(this, "MIS_YAW_TMT", false),
-	_param_yaw_err(this, "MIS_YAW_ERR", false),
-	_param_back_trans_dec_mss(this, "VT_B_DEC_MSS", false),
-	_param_reverse_delay(this, "VT_B_REV_DEL", false)
+	NavigatorMode(navigator, name)
 {
 }
 
@@ -292,9 +288,11 @@ MissionBlock::is_mission_item_reached()
 				float velocity = sqrtf(_navigator->get_local_position()->vx * _navigator->get_local_position()->vx +
 						       _navigator->get_local_position()->vy * _navigator->get_local_position()->vy);
 
-				if (_param_back_trans_dec_mss.get() > FLT_EPSILON && velocity > FLT_EPSILON) {
-					mission_acceptance_radius = ((velocity / _param_back_trans_dec_mss.get() / 2) * velocity) + _param_reverse_delay.get() *
-								    velocity;
+				const float back_trans_dec = _navigator->get_vtol_back_trans_deceleration();
+				const float reverse_delay = _navigator->get_vtol_reverse_delay();
+
+				if (back_trans_dec > FLT_EPSILON && velocity > FLT_EPSILON) {
+					mission_acceptance_radius = ((velocity / back_trans_dec / 2) * velocity) + reverse_delay * velocity;
 
 				}
 
@@ -327,16 +325,16 @@ MissionBlock::is_mission_item_reached()
 			float yaw_err = _wrap_pi(_mission_item.yaw - cog);
 
 			/* accept yaw if reached or if timeout is set in which case we ignore not forced headings */
-			if (fabsf(yaw_err) < math::radians(_param_yaw_err.get())
-			    || (_param_yaw_timeout.get() >= FLT_EPSILON && !_mission_item.force_heading)) {
+			if (fabsf(yaw_err) < math::radians(_navigator->get_yaw_threshold())
+			    || (_navigator->get_yaw_timeout() >= FLT_EPSILON && !_mission_item.force_heading)) {
 
 				_waypoint_yaw_reached = true;
 			}
 
 			/* if heading needs to be reached, the timeout is enabled and we don't make it, abort mission */
 			if (!_waypoint_yaw_reached && _mission_item.force_heading &&
-			    (_param_yaw_timeout.get() >= FLT_EPSILON) &&
-			    (now - _time_wp_reached >= (hrt_abstime)_param_yaw_timeout.get() * 1e6f)) {
+			    (_navigator->get_yaw_timeout() >= FLT_EPSILON) &&
+			    (now - _time_wp_reached >= (hrt_abstime)_navigator->get_yaw_timeout() * 1e6f)) {
 
 				_navigator->set_mission_failure("unable to reach heading within timeout");
 			}

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -557,16 +557,6 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 }
 
 void
-MissionBlock::set_previous_pos_setpoint()
-{
-	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-
-	if (pos_sp_triplet->current.valid) {
-		memcpy(&pos_sp_triplet->previous, &pos_sp_triplet->current, sizeof(struct position_setpoint_s));
-	}
-}
-
-void
 MissionBlock::set_loiter_item(struct mission_item_s *item, float min_clearance)
 {
 	if (_navigator->get_land_detected()->landed) {

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -91,11 +91,6 @@ protected:
 	bool mission_item_to_position_setpoint(const mission_item_s &item, position_setpoint_s *sp);
 
 	/**
-	 * Set previous position setpoint to current setpoint
-	 */
-	void set_previous_pos_setpoint();
-
-	/**
 	 * Set a loiter mission item, if possible reuse the position setpoint, otherwise take the current position
 	 */
 	void set_loiter_item(struct mission_item_s *item, float min_clearance = -1.0f);

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -42,8 +42,12 @@
 #define NAVIGATOR_MISSION_BLOCK_H
 
 #include "navigator_mode.h"
+#include "navigation.h"
 
-#include <navigator/navigation.h>
+#include <controllib/blocks.hpp>
+#include <controllib/block/BlockParam.hpp>
+#include <drivers/drv_hrt.h>
+#include <systemlib/mavlink_log.h>
 #include <uORB/topics/mission.h>
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/vehicle_command.h>
@@ -59,7 +63,7 @@ public:
 	 * Constructor
 	 */
 	MissionBlock(Navigator *navigator, const char *name);
-	~MissionBlock() = default;
+	virtual ~MissionBlock() = default;
 
 	MissionBlock(const MissionBlock &) = delete;
 	MissionBlock &operator=(const MissionBlock &) = delete;
@@ -132,13 +136,6 @@ protected:
 	hrt_abstime _time_wp_reached{0};
 
 	orb_advert_t    _actuator_pub{nullptr};
-
-	control::BlockParamFloat _param_yaw_timeout;
-	control::BlockParamFloat _param_yaw_err;
-
-	// VTOL parameters
-	control::BlockParamFloat _param_back_trans_dec_mss;
-	control::BlockParamFloat _param_reverse_delay;
 };
 
 #endif

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -55,9 +55,6 @@ MissionFeasibilityChecker::checkMissionFeasible(const mission_s &mission,
 		float max_distance_to_1st_waypoint, float max_distance_between_waypoints,
 		bool land_start_req)
 {
-	const dm_item_t dm_current = DM_KEY_WAYPOINTS_OFFBOARD(mission.dataman_id);
-	const size_t nMissionItems = mission.count;
-
 	bool failed = false;
 	bool warned = false;
 
@@ -70,36 +67,36 @@ MissionFeasibilityChecker::checkMissionFeasible(const mission_s &mission,
 		mavlink_log_info(_navigator->get_mavlink_log_pub(), "Not yet ready for mission, no position lock.");
 
 	} else {
-		failed = failed || !checkDistanceToFirstWaypoint(dm_current, nMissionItems, max_distance_to_1st_waypoint);
+		failed = failed || !checkDistanceToFirstWaypoint(mission, max_distance_to_1st_waypoint);
 	}
 
 	const float home_alt = _navigator->get_home_position()->alt;
 
 	// check if all mission item commands are supported
-	failed = failed || !checkMissionItemValidity(dm_current, nMissionItems);
-	failed = failed || !checkDistancesBetweenWaypoints(dm_current, nMissionItems, max_distance_between_waypoints);
-	failed = failed || !checkGeofence(dm_current, nMissionItems, home_alt, home_valid);
-	failed = failed || !checkHomePositionAltitude(dm_current, nMissionItems, home_alt, home_valid, warned);
+	failed = failed || !checkMissionItemValidity(mission);
+	failed = failed || !checkDistancesBetweenWaypoints(mission, max_distance_between_waypoints);
+	failed = failed || !checkGeofence(mission, home_alt, home_valid);
+	failed = failed || !checkHomePositionAltitude(mission, home_alt, home_valid, warned);
 
 	// VTOL always respects rotary wing feasibility
 	if (_navigator->get_vstatus()->is_rotary_wing || _navigator->get_vstatus()->is_vtol) {
-		failed = failed || !checkRotarywing(dm_current, nMissionItems, home_alt, home_valid);
+		failed = failed || !checkRotarywing(mission, home_alt, home_valid);
 
 	} else {
-		failed = failed || !checkFixedwing(dm_current, nMissionItems, home_alt, home_valid, land_start_req);
+		failed = failed || !checkFixedwing(mission, home_alt, home_valid, land_start_req);
 	}
 
 	return !failed;
 }
 
 bool
-MissionFeasibilityChecker::checkRotarywing(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid)
+MissionFeasibilityChecker::checkRotarywing(const mission_s &mission, float home_alt, bool home_valid)
 {
-	for (size_t i = 0; i < nMissionItems; i++) {
+	for (size_t i = 0; i < mission.count; i++) {
 		struct mission_item_s missionitem = {};
 		const ssize_t len = sizeof(struct mission_item_s);
 
-		if (dm_read(dm_current, i, &missionitem, len) != len) {
+		if (dm_read((dm_item_t)mission.dataman_id, i, &missionitem, len) != len) {
 			/* not supposed to happen unless the datamanager can't access the SD card, etc. */
 			return false;
 		}
@@ -130,19 +127,19 @@ MissionFeasibilityChecker::checkRotarywing(dm_item_t dm_current, size_t nMission
 }
 
 bool
-MissionFeasibilityChecker::checkFixedwing(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid,
+MissionFeasibilityChecker::checkFixedwing(const mission_s &mission, float home_alt, bool home_valid,
 		bool land_start_req)
 {
 	/* Perform checks and issue feedback to the user for all checks */
-	bool resTakeoff = checkFixedWingTakeoff(dm_current, nMissionItems, home_alt, home_valid);
-	bool resLanding = checkFixedWingLanding(dm_current, nMissionItems, land_start_req);
+	bool resTakeoff = checkFixedWingTakeoff(mission, home_alt, home_valid);
+	bool resLanding = checkFixedWingLanding(mission, land_start_req);
 
 	/* Mission is only marked as feasible if all checks return true */
 	return (resTakeoff && resLanding);
 }
 
 bool
-MissionFeasibilityChecker::checkGeofence(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid)
+MissionFeasibilityChecker::checkGeofence(const mission_s &mission, float home_alt, bool home_valid)
 {
 	if (_navigator->get_geofence().isHomeRequired() && !home_valid) {
 		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Geofence requires valid home position");
@@ -151,11 +148,11 @@ MissionFeasibilityChecker::checkGeofence(dm_item_t dm_current, size_t nMissionIt
 
 	/* Check if all mission items are inside the geofence (if we have a valid geofence) */
 	if (_navigator->get_geofence().valid()) {
-		for (size_t i = 0; i < nMissionItems; i++) {
+		for (size_t i = 0; i < mission.count; i++) {
 			struct mission_item_s missionitem = {};
 			const ssize_t len = sizeof(missionitem);
 
-			if (dm_read(dm_current, i, &missionitem, len) != len) {
+			if (dm_read((dm_item_t)mission.dataman_id, i, &missionitem, len) != len) {
 				/* not supposed to happen unless the datamanager can't access the SD card, etc. */
 				return false;
 			}
@@ -180,15 +177,15 @@ MissionFeasibilityChecker::checkGeofence(dm_item_t dm_current, size_t nMissionIt
 }
 
 bool
-MissionFeasibilityChecker::checkHomePositionAltitude(dm_item_t dm_current, size_t nMissionItems, float home_alt,
-		bool home_valid, bool throw_error)
+MissionFeasibilityChecker::checkHomePositionAltitude(const mission_s &mission, float home_alt, bool home_valid,
+		bool throw_error)
 {
 	/* Check if all waypoints are above the home altitude */
-	for (size_t i = 0; i < nMissionItems; i++) {
+	for (size_t i = 0; i < mission.count; i++) {
 		struct mission_item_s missionitem = {};
 		const ssize_t len = sizeof(struct mission_item_s);
 
-		if (dm_read(dm_current, i, &missionitem, len) != len) {
+		if (dm_read((dm_item_t)mission.dataman_id, i, &missionitem, len) != len) {
 			_navigator->get_mission_result()->warning = true;
 			/* not supposed to happen unless the datamanager can't access the SD card, etc. */
 			return false;
@@ -231,14 +228,14 @@ MissionFeasibilityChecker::checkHomePositionAltitude(dm_item_t dm_current, size_
 }
 
 bool
-MissionFeasibilityChecker::checkMissionItemValidity(dm_item_t dm_current, size_t nMissionItems)
+MissionFeasibilityChecker::checkMissionItemValidity(const mission_s &mission)
 {
 	// do not allow mission if we find unsupported item
-	for (size_t i = 0; i < nMissionItems; i++) {
+	for (size_t i = 0; i < mission.count; i++) {
 		struct mission_item_s missionitem;
 		const ssize_t len = sizeof(struct mission_item_s);
 
-		if (dm_read(dm_current, i, &missionitem, len) != len) {
+		if (dm_read((dm_item_t)mission.dataman_id, i, &missionitem, len) != len) {
 			// not supposed to happen unless the datamanager can't access the SD card, etc.
 			mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: Cannot access SD card");
 			return false;
@@ -309,14 +306,13 @@ MissionFeasibilityChecker::checkMissionItemValidity(dm_item_t dm_current, size_t
 }
 
 bool
-MissionFeasibilityChecker::checkFixedWingTakeoff(dm_item_t dm_current, size_t nMissionItems, float home_alt,
-		bool home_valid)
+MissionFeasibilityChecker::checkFixedWingTakeoff(const mission_s &mission, float home_alt, bool home_valid)
 {
-	for (size_t i = 0; i < nMissionItems; i++) {
+	for (size_t i = 0; i < mission.count; i++) {
 		struct mission_item_s missionitem = {};
 		const ssize_t len = sizeof(struct mission_item_s);
 
-		if (dm_read(dm_current, i, &missionitem, len) != len) {
+		if (dm_read((dm_item_t)mission.dataman_id, i, &missionitem, len) != len) {
 			/* not supposed to happen unless the datamanager can't access the SD card, etc. */
 			return false;
 		}
@@ -349,7 +345,7 @@ MissionFeasibilityChecker::checkFixedWingTakeoff(dm_item_t dm_current, size_t nM
 }
 
 bool
-MissionFeasibilityChecker::checkFixedWingLanding(dm_item_t dm_current, size_t nMissionItems, bool land_start_req)
+MissionFeasibilityChecker::checkFixedWingLanding(const mission_s &mission, bool land_start_req)
 {
 	/* Go through all mission items and search for a landing waypoint
 	 * if landing waypoint is found: the previous waypoint is checked to be at a feasible distance and altitude given the landing slope */
@@ -360,11 +356,11 @@ MissionFeasibilityChecker::checkFixedWingLanding(dm_item_t dm_current, size_t nM
 	size_t do_land_start_index = 0;
 	size_t landing_approach_index = 0;
 
-	for (size_t i = 0; i < nMissionItems; i++) {
+	for (size_t i = 0; i < mission.count; i++) {
 		struct mission_item_s missionitem;
 		const ssize_t len = sizeof(missionitem);
 
-		if (dm_read(dm_current, i, &missionitem, len) != len) {
+		if (dm_read((dm_item_t)mission.dataman_id, i, &missionitem, len) != len) {
 			/* not supposed to happen unless the datamanager can't access the SD card, etc. */
 			return false;
 		}
@@ -387,7 +383,7 @@ MissionFeasibilityChecker::checkFixedWingLanding(dm_item_t dm_current, size_t nM
 			if (i > 0) {
 				landing_approach_index = i - 1;
 
-				if (dm_read(dm_current, landing_approach_index, &missionitem_previous, len) != len) {
+				if (dm_read((dm_item_t)mission.dataman_id, landing_approach_index, &missionitem_previous, len) != len) {
 					/* not supposed to happen unless the datamanager can't access the SD card, etc. */
 					return false;
 				}
@@ -466,7 +462,7 @@ MissionFeasibilityChecker::checkFixedWingLanding(dm_item_t dm_current, size_t nM
 }
 
 bool
-MissionFeasibilityChecker::checkDistanceToFirstWaypoint(dm_item_t dm_current, size_t nMissionItems, float max_distance)
+MissionFeasibilityChecker::checkDistanceToFirstWaypoint(const mission_s &mission, float max_distance)
 {
 	if (max_distance <= 0.0f) {
 		/* param not set, check is ok */
@@ -474,11 +470,11 @@ MissionFeasibilityChecker::checkDistanceToFirstWaypoint(dm_item_t dm_current, si
 	}
 
 	/* find first waypoint (with lat/lon) item in datamanager */
-	for (size_t i = 0; i < nMissionItems; i++) {
+	for (size_t i = 0; i < mission.count; i++) {
 
 		struct mission_item_s mission_item {};
 
-		if (!(dm_read(dm_current, i, &mission_item, sizeof(mission_item_s)) == sizeof(mission_item_s))) {
+		if (!(dm_read((dm_item_t)mission.dataman_id, i, &mission_item, sizeof(mission_item_s)) == sizeof(mission_item_s))) {
 			/* error reading, mission is invalid */
 			mavlink_log_info(_navigator->get_mavlink_log_pub(), "Error reading offboard mission.");
 			return false;
@@ -522,8 +518,7 @@ MissionFeasibilityChecker::checkDistanceToFirstWaypoint(dm_item_t dm_current, si
 }
 
 bool
-MissionFeasibilityChecker::checkDistancesBetweenWaypoints(dm_item_t dm_current, size_t nMissionItems,
-		float max_distance)
+MissionFeasibilityChecker::checkDistancesBetweenWaypoints(const mission_s &mission, float max_distance)
 {
 	if (max_distance <= 0.0f) {
 		/* param not set, check is ok */
@@ -534,11 +529,11 @@ MissionFeasibilityChecker::checkDistancesBetweenWaypoints(dm_item_t dm_current, 
 	double last_lon = NAN;
 
 	/* Go through all waypoints */
-	for (size_t i = 0; i < nMissionItems; i++) {
+	for (size_t i = 0; i < mission.count; i++) {
 
 		struct mission_item_s mission_item {};
 
-		if (!(dm_read(dm_current, i, &mission_item, sizeof(mission_item_s)) == sizeof(mission_item_s))) {
+		if (!(dm_read((dm_item_t)mission.dataman_id, i, &mission_item, sizeof(mission_item_s)) == sizeof(mission_item_s))) {
 			/* error reading, mission is invalid */
 			mavlink_log_info(_navigator->get_mavlink_log_pub(), "Error reading offboard mission.");
 			return false;

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -55,58 +55,45 @@ MissionFeasibilityChecker::checkMissionFeasible(const mission_s &mission,
 		float max_distance_to_1st_waypoint, float max_distance_between_waypoints,
 		bool land_start_req)
 {
-	dm_item_t dm_current = DM_KEY_WAYPOINTS_OFFBOARD(mission.dataman_id);
+	const dm_item_t dm_current = DM_KEY_WAYPOINTS_OFFBOARD(mission.dataman_id);
 	const size_t nMissionItems = mission.count;
-
-	const bool isRotarywing = (_navigator->get_vstatus()->is_rotary_wing || _navigator->get_vstatus()->is_vtol);
-
-	Geofence &geofence = _navigator->get_geofence();
-	fw_pos_ctrl_status_s *fw_pos_ctrl_status = _navigator->get_fw_pos_ctrl_status();
-	const float home_alt = _navigator->get_home_position()->alt;
-	const bool home_valid = _navigator->home_position_valid();
-
-	bool &warning_issued = _navigator->get_mission_result()->warning;
-	const float default_acceptance_rad  = _navigator->get_default_acceptance_radius();
-	const float default_altitude_acceptance_rad  = _navigator->get_altitude_acceptance_radius();
-	const bool landed = _navigator->get_land_detected()->landed;
 
 	bool failed = false;
 	bool warned = false;
 
 	// first check if we have a valid position
+	const bool home_valid = _navigator->home_position_valid();
+
 	if (!home_valid) {
 		failed = true;
 		warned = true;
 		mavlink_log_info(_navigator->get_mavlink_log_pub(), "Not yet ready for mission, no position lock.");
 
 	} else {
-		failed = failed ||
-			 !checkDistanceToFirstWaypoint(dm_current, nMissionItems, max_distance_to_1st_waypoint, warning_issued);
+		failed = failed || !checkDistanceToFirstWaypoint(dm_current, nMissionItems, max_distance_to_1st_waypoint);
 	}
 
+	const float home_alt = _navigator->get_home_position()->alt;
+
 	// check if all mission item commands are supported
-	failed = failed || !checkMissionItemValidity(dm_current, nMissionItems, landed);
-	failed = failed
-		 || !checkDistancesBetweenWaypoints(dm_current, nMissionItems, max_distance_between_waypoints, warning_issued);
-	failed = failed || !checkGeofence(dm_current, nMissionItems, geofence, home_alt, home_valid);
+	failed = failed || !checkMissionItemValidity(dm_current, nMissionItems);
+	failed = failed || !checkDistancesBetweenWaypoints(dm_current, nMissionItems, max_distance_between_waypoints);
+	failed = failed || !checkGeofence(dm_current, nMissionItems, home_alt, home_valid);
 	failed = failed || !checkHomePositionAltitude(dm_current, nMissionItems, home_alt, home_valid, warned);
 
-	if (isRotarywing) {
-		failed = failed
-			 || !checkRotarywing(dm_current, nMissionItems, home_alt, home_valid, default_altitude_acceptance_rad);
+	// VTOL always respects rotary wing feasibility
+	if (_navigator->get_vstatus()->is_rotary_wing || _navigator->get_vstatus()->is_vtol) {
+		failed = failed || !checkRotarywing(dm_current, nMissionItems, home_alt, home_valid);
 
 	} else {
-		failed = failed
-			 || !checkFixedwing(dm_current, nMissionItems, fw_pos_ctrl_status, home_alt, home_valid,
-					    default_acceptance_rad, land_start_req);
+		failed = failed || !checkFixedwing(dm_current, nMissionItems, home_alt, home_valid, land_start_req);
 	}
 
 	return !failed;
 }
 
 bool
-MissionFeasibilityChecker::checkRotarywing(dm_item_t dm_current, size_t nMissionItems,
-		float home_alt, bool home_valid, float default_altitude_acceptance_rad)
+MissionFeasibilityChecker::checkRotarywing(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid)
 {
 	for (size_t i = 0; i < nMissionItems; i++) {
 		struct mission_item_s missionitem = {};
@@ -121,10 +108,10 @@ MissionFeasibilityChecker::checkRotarywing(dm_item_t dm_current, size_t nMission
 		if (missionitem.nav_cmd == NAV_CMD_TAKEOFF) {
 			// make sure that the altitude of the waypoint is at least one meter larger than the altitude acceptance radius
 			// this makes sure that the takeoff waypoint is not reached before we are at least one meter in the air
-			float takeoff_alt = missionitem.altitude_is_relative ? missionitem.altitude : missionitem.altitude - home_alt;
+			const float takeoff_alt = missionitem.altitude_is_relative ? missionitem.altitude : missionitem.altitude - home_alt;
 
 			// check if we should use default acceptance radius
-			float acceptance_radius = default_altitude_acceptance_rad;
+			float acceptance_radius = _navigator->get_altitude_acceptance_radius();
 
 			// if a specific acceptance radius has been defined, use that one instead
 			if (missionitem.acceptance_radius > NAV_EPSILON_POSITION) {
@@ -143,30 +130,27 @@ MissionFeasibilityChecker::checkRotarywing(dm_item_t dm_current, size_t nMission
 }
 
 bool
-MissionFeasibilityChecker::checkFixedwing(dm_item_t dm_current, size_t nMissionItems,
-		fw_pos_ctrl_status_s *fw_pos_ctrl_status, float home_alt, bool home_valid,
-		float default_acceptance_rad, bool land_start_req)
+MissionFeasibilityChecker::checkFixedwing(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid,
+		bool land_start_req)
 {
 	/* Perform checks and issue feedback to the user for all checks */
-	bool resTakeoff = checkFixedWingTakeoff(dm_current, nMissionItems, home_alt, home_valid, land_start_req);
-	bool resLanding = checkFixedWingLanding(dm_current, nMissionItems, fw_pos_ctrl_status, land_start_req);
+	bool resTakeoff = checkFixedWingTakeoff(dm_current, nMissionItems, home_alt, home_valid);
+	bool resLanding = checkFixedWingLanding(dm_current, nMissionItems, land_start_req);
 
 	/* Mission is only marked as feasible if all checks return true */
 	return (resTakeoff && resLanding);
 }
 
 bool
-MissionFeasibilityChecker::checkGeofence(dm_item_t dm_current, size_t nMissionItems, Geofence &geofence, float home_alt,
-		bool home_valid)
+MissionFeasibilityChecker::checkGeofence(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid)
 {
-
-	if (geofence.isHomeRequired() && !home_valid) {
+	if (_navigator->get_geofence().isHomeRequired() && !home_valid) {
 		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Geofence requires valid home position");
 		return false;
 	}
 
 	/* Check if all mission items are inside the geofence (if we have a valid geofence) */
-	if (geofence.valid()) {
+	if (_navigator->get_geofence().valid()) {
 		for (size_t i = 0; i < nMissionItems; i++) {
 			struct mission_item_s missionitem = {};
 			const ssize_t len = sizeof(missionitem);
@@ -184,8 +168,7 @@ MissionFeasibilityChecker::checkGeofence(dm_item_t dm_current, size_t nMissionIt
 			// Geofence function checks against home altitude amsl
 			missionitem.altitude = missionitem.altitude_is_relative ? missionitem.altitude + home_alt : missionitem.altitude;
 
-			if (MissionBlock::item_contains_position(missionitem) &&
-			    !geofence.check(missionitem)) {
+			if (MissionBlock::item_contains_position(missionitem) && !_navigator->get_geofence().check(missionitem)) {
 
 				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Geofence violation for waypoint %d", i + 1);
 				return false;
@@ -197,8 +180,8 @@ MissionFeasibilityChecker::checkGeofence(dm_item_t dm_current, size_t nMissionIt
 }
 
 bool
-MissionFeasibilityChecker::checkHomePositionAltitude(dm_item_t dm_current, size_t nMissionItems,
-		float home_alt, bool home_valid, bool &warning_issued, bool throw_error)
+MissionFeasibilityChecker::checkHomePositionAltitude(dm_item_t dm_current, size_t nMissionItems, float home_alt,
+		bool home_valid, bool throw_error)
 {
 	/* Check if all waypoints are above the home altitude */
 	for (size_t i = 0; i < nMissionItems; i++) {
@@ -206,7 +189,7 @@ MissionFeasibilityChecker::checkHomePositionAltitude(dm_item_t dm_current, size_
 		const ssize_t len = sizeof(struct mission_item_s);
 
 		if (dm_read(dm_current, i, &missionitem, len) != len) {
-			warning_issued = true;
+			_navigator->get_mission_result()->warning = true;
 			/* not supposed to happen unless the datamanager can't access the SD card, etc. */
 			return false;
 		}
@@ -214,7 +197,7 @@ MissionFeasibilityChecker::checkHomePositionAltitude(dm_item_t dm_current, size_
 		/* reject relative alt without home set */
 		if (missionitem.altitude_is_relative && !home_valid && MissionBlock::item_contains_position(missionitem)) {
 
-			warning_issued = true;
+			_navigator->get_mission_result()->warning = true;
 
 			if (throw_error) {
 				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: No home pos, WP %d uses rel alt", i + 1);
@@ -231,7 +214,7 @@ MissionFeasibilityChecker::checkHomePositionAltitude(dm_item_t dm_current, size_
 
 		if ((home_alt > wp_alt) && MissionBlock::item_contains_position(missionitem)) {
 
-			warning_issued = true;
+			_navigator->get_mission_result()->warning = true;
 
 			if (throw_error) {
 				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: Waypoint %d below home", i + 1);
@@ -248,7 +231,7 @@ MissionFeasibilityChecker::checkHomePositionAltitude(dm_item_t dm_current, size_
 }
 
 bool
-MissionFeasibilityChecker::checkMissionItemValidity(dm_item_t dm_current, size_t nMissionItems, bool landed)
+MissionFeasibilityChecker::checkMissionItemValidity(dm_item_t dm_current, size_t nMissionItems)
 {
 	// do not allow mission if we find unsupported item
 	for (size_t i = 0; i < nMissionItems; i++) {
@@ -315,7 +298,7 @@ MissionFeasibilityChecker::checkMissionItemValidity(dm_item_t dm_current, size_t
 		}
 
 		// check if the mission starts with a land command while the vehicle is landed
-		if (missionitem.nav_cmd == NAV_CMD_LAND && i == 0 && landed) {
+		if ((i == 0) && missionitem.nav_cmd == NAV_CMD_LAND && _navigator->get_land_detected()->landed) {
 
 			mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: starts with landing");
 			return false;
@@ -326,8 +309,8 @@ MissionFeasibilityChecker::checkMissionItemValidity(dm_item_t dm_current, size_t
 }
 
 bool
-MissionFeasibilityChecker::checkFixedWingTakeoff(dm_item_t dm_current, size_t nMissionItems,
-		float home_alt, bool home_valid, float default_acceptance_rad)
+MissionFeasibilityChecker::checkFixedWingTakeoff(dm_item_t dm_current, size_t nMissionItems, float home_alt,
+		bool home_valid)
 {
 	for (size_t i = 0; i < nMissionItems; i++) {
 		struct mission_item_s missionitem = {};
@@ -348,7 +331,7 @@ MissionFeasibilityChecker::checkFixedWingTakeoff(dm_item_t dm_current, size_t nM
 					    : missionitem.altitude - home_alt;
 
 			// check if we should use default acceptance radius
-			float acceptance_radius = default_acceptance_rad;
+			float acceptance_radius = _navigator->get_default_acceptance_radius();
 
 			if (missionitem.acceptance_radius > NAV_EPSILON_POSITION) {
 				acceptance_radius = missionitem.acceptance_radius;
@@ -366,8 +349,7 @@ MissionFeasibilityChecker::checkFixedWingTakeoff(dm_item_t dm_current, size_t nM
 }
 
 bool
-MissionFeasibilityChecker::checkFixedWingLanding(dm_item_t dm_current, size_t nMissionItems,
-		fw_pos_ctrl_status_s *fw_pos_ctrl_status, bool land_start_req)
+MissionFeasibilityChecker::checkFixedWingLanding(dm_item_t dm_current, size_t nMissionItems, bool land_start_req)
 {
 	/* Go through all mission items and search for a landing waypoint
 	 * if landing waypoint is found: the previous waypoint is checked to be at a feasible distance and altitude given the landing slope */
@@ -411,27 +393,33 @@ MissionFeasibilityChecker::checkFixedWingLanding(dm_item_t dm_current, size_t nM
 				}
 
 				if (MissionBlock::item_contains_position(missionitem_previous)) {
-					float wp_distance = get_distance_to_next_waypoint(missionitem_previous.lat, missionitem_previous.lon, missionitem.lat,
-							    missionitem.lon);
 
-					float slope_alt_req = Landingslope::getLandingSlopeAbsoluteAltitude(wp_distance, missionitem.altitude,
-							      fw_pos_ctrl_status->landing_horizontal_slope_displacement, fw_pos_ctrl_status->landing_slope_angle_rad);
+					const bool fw_status_valid = (_navigator->get_fw_pos_ctrl_status()->timestamp > 0);
+					const float wp_distance = get_distance_to_next_waypoint(missionitem_previous.lat, missionitem_previous.lon,
+								  missionitem.lat, missionitem.lon);
 
-					float wp_distance_req = Landingslope::getLandingSlopeWPDistance(missionitem_previous.altitude, missionitem.altitude,
-								fw_pos_ctrl_status->landing_horizontal_slope_displacement, fw_pos_ctrl_status->landing_slope_angle_rad);
-
-					if (wp_distance > fw_pos_ctrl_status->landing_flare_length) {
+					if (fw_status_valid && (wp_distance > _navigator->get_fw_pos_ctrl_status()->landing_flare_length)) {
 						/* Last wp is before flare region */
 
 						const float delta_altitude = missionitem.altitude - missionitem_previous.altitude;
 
 						if (delta_altitude < 0) {
+
+							const float horizontal_slope_displacement = _navigator->get_fw_pos_ctrl_status()->landing_horizontal_slope_displacement;
+							const float slope_angle_rad = _navigator->get_fw_pos_ctrl_status()->landing_slope_angle_rad;
+							const float slope_alt_req = Landingslope::getLandingSlopeAbsoluteAltitude(wp_distance, missionitem.altitude,
+										    horizontal_slope_displacement, slope_angle_rad);
+
 							if (missionitem_previous.altitude > slope_alt_req) {
 								/* Landing waypoint is above altitude of slope at the given waypoint distance */
 								mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: adjust landing approach.");
-								mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Move down %.1fm or move further away by %.1fm.",
-										     (double)(slope_alt_req - missionitem_previous.altitude),
-										     (double)(wp_distance_req - wp_distance));
+
+								const float wp_distance_req = Landingslope::getLandingSlopeWPDistance(missionitem_previous.altitude,
+											      missionitem.altitude, horizontal_slope_displacement, slope_angle_rad);
+
+								mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Move down %d m or move further away by %d m.",
+										     (int)ceilf(slope_alt_req - missionitem_previous.altitude),
+										     (int)ceilf(wp_distance_req - wp_distance));
 
 								return false;
 							}
@@ -478,8 +466,7 @@ MissionFeasibilityChecker::checkFixedWingLanding(dm_item_t dm_current, size_t nM
 }
 
 bool
-MissionFeasibilityChecker::checkDistanceToFirstWaypoint(dm_item_t dm_current, size_t nMissionItems,
-		float max_distance, bool &warning_issued)
+MissionFeasibilityChecker::checkDistanceToFirstWaypoint(dm_item_t dm_current, size_t nMissionItems, float max_distance)
 {
 	if (max_distance <= 0.0f) {
 		/* param not set, check is ok */
@@ -513,7 +500,8 @@ MissionFeasibilityChecker::checkDistanceToFirstWaypoint(dm_item_t dm_current, si
 				/* allow at 2/3 distance, but warn */
 				mavlink_log_critical(_navigator->get_mavlink_log_pub(),
 						     "First waypoint far away: %d meters.", (int)dist_to_1wp);
-				warning_issued = true;
+
+				_navigator->get_mission_result()->warning = true;
 			}
 
 			return true;
@@ -523,7 +511,8 @@ MissionFeasibilityChecker::checkDistanceToFirstWaypoint(dm_item_t dm_current, si
 			mavlink_log_critical(_navigator->get_mavlink_log_pub(),
 					     "First waypoint too far away: %d meters, %d max.",
 					     (int)dist_to_1wp, (int)max_distance);
-			warning_issued = true;
+
+			_navigator->get_mission_result()->warning = true;
 			return false;
 		}
 	}
@@ -534,7 +523,7 @@ MissionFeasibilityChecker::checkDistanceToFirstWaypoint(dm_item_t dm_current, si
 
 bool
 MissionFeasibilityChecker::checkDistancesBetweenWaypoints(dm_item_t dm_current, size_t nMissionItems,
-		float max_distance, bool &warning_issued)
+		float max_distance)
 {
 	if (max_distance <= 0.0f) {
 		/* param not set, check is ok */
@@ -564,18 +553,18 @@ MissionFeasibilityChecker::checkDistancesBetweenWaypoints(dm_item_t dm_current, 
 		if (PX4_ISFINITE(last_lat) && PX4_ISFINITE(last_lon)) {
 
 			/* check distance from current position to item */
-			float dist_between_waypoints = get_distance_to_next_waypoint(
-							       mission_item.lat, mission_item.lon,
-							       last_lat, last_lon);
+			const float dist_between_waypoints = get_distance_to_next_waypoint(
+					mission_item.lat, mission_item.lon,
+					last_lat, last_lon);
 
 			if (dist_between_waypoints < max_distance) {
 
 				if (dist_between_waypoints > ((max_distance * 3) / 2)) {
 					/* allow at 2/3 distance, but warn */
 					mavlink_log_critical(_navigator->get_mavlink_log_pub(),
-							     "Distance between waypoints very far: %d meters.",
-							     (int)dist_between_waypoints);
-					warning_issued = true;
+							     "Distance between waypoints very far: %d meters.", (int)dist_between_waypoints);
+
+					_navigator->get_mission_result()->warning = true;
 				}
 
 			} else {
@@ -583,7 +572,8 @@ MissionFeasibilityChecker::checkDistancesBetweenWaypoints(dm_item_t dm_current, 
 				mavlink_log_critical(_navigator->get_mavlink_log_pub(),
 						     "Distance between waypoints too far: %d meters, %d max.",
 						     (int)dist_between_waypoints, (int)max_distance);
-				warning_issued = true;
+
+				_navigator->get_mission_result()->warning = true;
 				return false;
 			}
 		}

--- a/src/modules/navigator/mission_feasibility_checker.h
+++ b/src/modules/navigator/mission_feasibility_checker.h
@@ -55,24 +55,22 @@ private:
 	Navigator *_navigator{nullptr};
 
 	/* Checks for all airframes */
-	bool checkGeofence(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid);
+	bool checkGeofence(const mission_s &mission, float home_alt, bool home_valid);
 
-	bool checkHomePositionAltitude(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid,
-				       bool throw_error);
+	bool checkHomePositionAltitude(const mission_s &mission, float home_alt, bool home_valid, bool throw_error);
 
-	bool checkMissionItemValidity(dm_item_t dm_current, size_t nMissionItems);
+	bool checkMissionItemValidity(const mission_s &mission);
 
-	bool checkDistanceToFirstWaypoint(dm_item_t dm_current, size_t nMissionItems, float max_distance);
-	bool checkDistancesBetweenWaypoints(dm_item_t dm_current, size_t nMissionItems, float max_distance);
+	bool checkDistanceToFirstWaypoint(const mission_s &mission, float max_distance);
+	bool checkDistancesBetweenWaypoints(const mission_s &mission, float max_distance);
 
 	/* Checks specific to fixedwing airframes */
-	bool checkFixedwing(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid, bool land_start_req);
-
-	bool checkFixedWingTakeoff(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid);
-	bool checkFixedWingLanding(dm_item_t dm_current, size_t nMissionItems, bool land_start_req);
+	bool checkFixedwing(const mission_s &mission, float home_alt, bool home_valid, bool land_start_req);
+	bool checkFixedWingTakeoff(const mission_s &mission, float home_alt, bool home_valid);
+	bool checkFixedWingLanding(const mission_s &mission, bool land_start_req);
 
 	/* Checks specific to rotarywing airframes */
-	bool checkRotarywing(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid);
+	bool checkRotarywing(const mission_s &mission, float home_alt, bool home_valid);
 
 public:
 	MissionFeasibilityChecker(Navigator *navigator) : _navigator(navigator) {}

--- a/src/modules/navigator/mission_feasibility_checker.h
+++ b/src/modules/navigator/mission_feasibility_checker.h
@@ -55,29 +55,24 @@ private:
 	Navigator *_navigator{nullptr};
 
 	/* Checks for all airframes */
-	bool checkGeofence(dm_item_t dm_current, size_t nMissionItems, Geofence &geofence, float home_alt, bool home_valid);
+	bool checkGeofence(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid);
 
 	bool checkHomePositionAltitude(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid,
-				       bool &warning_issued, bool throw_error = false);
+				       bool throw_error);
 
-	bool checkMissionItemValidity(dm_item_t dm_current, size_t nMissionItems, bool condition_landed);
+	bool checkMissionItemValidity(dm_item_t dm_current, size_t nMissionItems);
 
-	bool checkDistanceToFirstWaypoint(dm_item_t dm_current, size_t nMissionItems, float max_distance, bool &warning_issued);
-	bool checkDistancesBetweenWaypoints(dm_item_t dm_current, size_t nMissionItems, float max_distance,
-					    bool &warning_issued);
+	bool checkDistanceToFirstWaypoint(dm_item_t dm_current, size_t nMissionItems, float max_distance);
+	bool checkDistancesBetweenWaypoints(dm_item_t dm_current, size_t nMissionItems, float max_distance);
 
 	/* Checks specific to fixedwing airframes */
-	bool checkFixedwing(dm_item_t dm_current, size_t nMissionItems, fw_pos_ctrl_status_s *fw_pos_ctrl_status,
-			    float home_alt, bool home_valid, float default_acceptance_rad, bool land_start_req);
+	bool checkFixedwing(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid, bool land_start_req);
 
-	bool checkFixedWingTakeoff(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid,
-				   float default_acceptance_rad);
-	bool checkFixedWingLanding(dm_item_t dm_current, size_t nMissionItems, fw_pos_ctrl_status_s *fw_pos_ctrl_status,
-				   bool land_start_req);
+	bool checkFixedWingTakeoff(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid);
+	bool checkFixedWingLanding(dm_item_t dm_current, size_t nMissionItems, bool land_start_req);
 
 	/* Checks specific to rotarywing airframes */
-	bool checkRotarywing(dm_item_t dm_current, size_t nMissionItems,
-			     float home_alt, bool home_valid, float default_altitude_acceptance_rad);
+	bool checkRotarywing(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid);
 
 public:
 	MissionFeasibilityChecker(Navigator *navigator) : _navigator(navigator) {}

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -73,17 +73,6 @@ PARAM_DEFINE_FLOAT(MIS_TAKEOFF_ALT, 2.5f);
 PARAM_DEFINE_FLOAT(MIS_LTRMIN_ALT, -1.0f);
 
 /**
- * Persistent onboard mission storage
- *
- * When enabled, missions that have been uploaded by the GCS are stored
- * and reloaded after reboot persistently.
- *
- * @boolean
- * @group Mission
- */
-PARAM_DEFINE_INT32(MIS_ONBOARD_EN, 1);
-
-/**
  * Maximal horizontal distance from home to first waypoint
  *
  * Failsafe check to prevent running mission stored from previous flight at a new takeoff location.

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -153,7 +153,6 @@ public:
 
 	bool home_position_valid() { return (_home_pos.timestamp > 0 && _home_pos.valid_hpos && _home_pos.valid_alt); }
 
-	int		get_onboard_mission_sub() { return _onboard_mission_sub; }
 	int		get_offboard_mission_sub() { return _offboard_mission_sub; }
 
 	Geofence	&get_geofence() { return _geofence; }
@@ -265,7 +264,6 @@ private:
 	int		_land_detected_sub{-1};		/**< vehicle land detected subscription */
 	int		_local_pos_sub{-1};		/**< local position subscription */
 	int		_offboard_mission_sub{-1};	/**< offboard mission subscription */
-	int		_onboard_mission_sub{-1};	/**< onboard mission subscription */
 	int		_param_update_sub{-1};		/**< param update subscription */
 	int		_sensor_combined_sub{-1};	/**< sensor combined subscription */
 	int		_vehicle_command_sub{-1};	/**< vehicle commands (onboard and offboard) */

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -66,6 +66,7 @@
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
+#include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_gps_position.h>
 #include <uORB/topics/vehicle_land_detected.h>
@@ -242,6 +243,13 @@ public:
 	bool		abort_landing();
 
 	float		get_loiter_min_alt() const { return _param_loiter_min_alt.get(); }
+	float		get_takeoff_min_alt() const { return _param_takeoff_min_alt.get(); }
+	float		get_yaw_timeout() const { return _param_yaw_timeout.get(); }
+	float		get_yaw_threshold() const { return _param_yaw_err.get(); }
+
+	float		get_vtol_back_trans_deceleration() const { return _param_back_trans_dec_mss.get(); }
+	float		get_vtol_reverse_delay() const { return _param_reverse_delay.get(); }
+
 
 	bool		force_vtol() const { return _vstatus.is_vtol && !_vstatus.is_rotary_wing && _param_force_vtol.get(); }
 
@@ -325,7 +333,15 @@ private:
 	control::BlockParamInt _param_traffic_avoidance_mode;	/**< avoiding other aircraft is enabled */
 
 	// non-navigator parameters
+	// Mission (MIS_*)
 	control::BlockParamFloat _param_loiter_min_alt;
+	control::BlockParamFloat _param_takeoff_min_alt;
+	control::BlockParamFloat _param_yaw_timeout;
+	control::BlockParamFloat _param_yaw_err;
+
+	// VTOL parameters TODO: get these out of navigator
+	control::BlockParamFloat _param_back_trans_dec_mss;
+	control::BlockParamFloat _param_reverse_delay;
 
 	float _mission_cruising_speed_mc{-1.0f};
 	float _mission_cruising_speed_fw{-1.0f};

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -105,7 +105,12 @@ Navigator::Navigator() :
 	_param_force_vtol(this, "FORCE_VT"),
 	_param_traffic_avoidance_mode(this, "TRAFF_AVOID"),
 	// non-navigator params
-	_param_loiter_min_alt(this, "MIS_LTRMIN_ALT", false)
+	_param_loiter_min_alt(this, "MIS_LTRMIN_ALT", false),
+	_param_takeoff_min_alt(this, "MIS_TAKEOFF_ALT", false),
+	_param_yaw_timeout(this, "MIS_YAW_TMT", false),
+	_param_yaw_err(this, "MIS_YAW_ERR", false),
+	_param_back_trans_dec_mss(this, "VT_B_DEC_MSS", false),
+	_param_reverse_delay(this, "VT_B_REV_DEL", false)
 {
 	/* Create a list of our possible navigation types */
 	_navigation_mode_array[0] = &_mission;
@@ -214,10 +219,6 @@ Navigator::params_update()
 	parameter_update_s param_update;
 	orb_copy(ORB_ID(parameter_update), _param_update_sub, &param_update);
 	updateParams();
-
-	if (_navigation_mode) {
-		_navigation_mode->updateParams();
-	}
 }
 
 void

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -250,8 +250,7 @@ Navigator::task_main()
 	_vstatus_sub = orb_subscribe(ORB_ID(vehicle_status));
 	_land_detected_sub = orb_subscribe(ORB_ID(vehicle_land_detected));
 	_home_pos_sub = orb_subscribe(ORB_ID(home_position));
-	_onboard_mission_sub = orb_subscribe(ORB_ID(onboard_mission));
-	_offboard_mission_sub = orb_subscribe(ORB_ID(offboard_mission));
+	_offboard_mission_sub = orb_subscribe(ORB_ID(mission));
 	_param_update_sub = orb_subscribe(ORB_ID(parameter_update));
 	_vehicle_command_sub = orb_subscribe(ORB_ID(vehicle_command));
 	_traffic_sub = orb_subscribe(ORB_ID(transponder_report));
@@ -736,7 +735,6 @@ Navigator::task_main()
 	orb_unsubscribe(_vstatus_sub);
 	orb_unsubscribe(_land_detected_sub);
 	orb_unsubscribe(_home_pos_sub);
-	orb_unsubscribe(_onboard_mission_sub);
 	orb_unsubscribe(_offboard_mission_sub);
 	orb_unsubscribe(_param_update_sub);
 	orb_unsubscribe(_vehicle_command_sub);

--- a/src/modules/navigator/navigator_mode.cpp
+++ b/src/modules/navigator/navigator_mode.cpp
@@ -47,8 +47,6 @@ NavigatorMode::NavigatorMode(Navigator *navigator, const char *name) :
 	_navigator(navigator),
 	_active(false)
 {
-	/* load initial params */
-	updateParams();
 	/* set initial mission items */
 	on_inactivation();
 	on_inactive();

--- a/src/modules/navigator/navigator_mode.h
+++ b/src/modules/navigator/navigator_mode.h
@@ -42,14 +42,8 @@
 #ifndef NAVIGATOR_MODE_H
 #define NAVIGATOR_MODE_H
 
-#include <drivers/drv_hrt.h>
-
 #include <controllib/blocks.hpp>
 #include <controllib/block/BlockParam.hpp>
-
-#include <dataman/dataman.h>
-
-#include <uORB/topics/position_setpoint_triplet.h>
 
 class Navigator;
 

--- a/src/modules/navigator/rcloss.cpp
+++ b/src/modules/navigator/rcloss.cpp
@@ -91,7 +91,7 @@ RCLoss::set_rcl_item()
 {
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
-	set_previous_pos_setpoint();
+	pos_sp_triplet->previous = pos_sp_triplet->current;
 	_navigator->set_can_loiter_at_sp(false);
 
 	switch (_rcl_state) {

--- a/src/modules/navigator/rcloss.cpp
+++ b/src/modules/navigator/rcloss.cpp
@@ -53,20 +53,10 @@
 #include "navigator.h"
 #include "datalinkloss.h"
 
-#define DELAY_SIGMA	0.01f
-
 RCLoss::RCLoss(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name),
 	_param_loitertime(this, "LT"),
 	_rcl_state(RCL_STATE_NONE)
-{
-	/* load initial params */
-	updateParams();
-	/* initial reset */
-	on_inactive();
-}
-
-RCLoss::~RCLoss()
 {
 }
 

--- a/src/modules/navigator/rcloss.h
+++ b/src/modules/navigator/rcloss.h
@@ -40,28 +40,20 @@
 #ifndef NAVIGATOR_RCLOSS_H
 #define NAVIGATOR_RCLOSS_H
 
-#include <controllib/blocks.hpp>
-#include <controllib/block/BlockParam.hpp>
-
-#include <uORB/Subscription.hpp>
-
 #include "navigator_mode.h"
 #include "mission_block.h"
 
 class Navigator;
 
-class RCLoss : public MissionBlock
+class RCLoss final : public MissionBlock
 {
 public:
 	RCLoss(Navigator *navigator, const char *name);
+	~RCLoss() = default;
 
-	~RCLoss();
-
-	virtual void on_inactive();
-
-	virtual void on_activation();
-
-	virtual void on_active();
+	void on_inactive() override;
+	void on_activation() override;
+	void on_active() override;
 
 private:
 	/* Params */
@@ -72,7 +64,7 @@ private:
 		RCL_STATE_LOITER = 1,
 		RCL_STATE_TERMINATE = 2,
 		RCL_STATE_END = 3
-	} _rcl_state;
+	} _rcl_state{RCL_STATE_NONE};
 
 	/**
 	 * Set the RCL item

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -139,7 +139,7 @@ RTL::set_rtl_item()
 			_mission_item.origin = ORIGIN_ONBOARD;
 
 			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: climb to %d m (%d m above home)",
-						     (int)(climb_alt), (int)(climb_alt - _navigator->get_home_position()->alt));
+						     (int)ceilf(climb_alt), (int)ceilf(climb_alt - _navigator->get_home_position()->alt));
 			break;
 		}
 
@@ -170,7 +170,7 @@ RTL::set_rtl_item()
 			_mission_item.origin = ORIGIN_ONBOARD;
 
 			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: return at %d m (%d m above home)",
-						     (int)(_mission_item.altitude), (int)(_mission_item.altitude - home.alt));
+						     (int)ceilf(_mission_item.altitude), (int)ceilf(_mission_item.altitude - home.alt));
 
 			break;
 		}
@@ -207,7 +207,7 @@ RTL::set_rtl_item()
 			pos_sp_triplet->previous.valid = false;
 
 			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: descend to %d m (%d m above home)",
-						     (int)(_mission_item.altitude), (int)(_mission_item.altitude - home.alt));
+						     (int)ceilf(_mission_item.altitude), (int)ceilf(_mission_item.altitude - home.alt));
 			break;
 		}
 

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -46,7 +46,7 @@
 
 class Navigator;
 
-class RTL : public MissionBlock
+class RTL final : public MissionBlock
 {
 public:
 	RTL(Navigator *navigator, const char *name);

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -38,35 +38,11 @@
  * @author Lorenz Meier <lorenz@px4.io
  */
 
-#include <string.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <math.h>
-#include <fcntl.h>
-
-#include <systemlib/mavlink_log.h>
-#include <systemlib/err.h>
-
-#include <uORB/uORB.h>
-#include <uORB/topics/position_setpoint_triplet.h>
-
 #include "takeoff.h"
 #include "navigator.h"
 
 Takeoff::Takeoff(Navigator *navigator, const char *name) :
-	MissionBlock(navigator, name),
-	_param_min_alt(this, "MIS_TAKEOFF_ALT", false)
-{
-	// load initial params
-	updateParams();
-}
-
-Takeoff::~Takeoff()
-{
-}
-
-void
-Takeoff::on_inactive()
+	MissionBlock(navigator, name)
 {
 }
 
@@ -108,10 +84,10 @@ Takeoff::set_takeoff_position()
 	float min_abs_altitude;
 
 	if (_navigator->home_position_valid()) { //only use home position if it is valid
-		min_abs_altitude = _navigator->get_global_position()->alt + _param_min_alt.get();
+		min_abs_altitude = _navigator->get_global_position()->alt + _navigator->get_takeoff_min_alt();
 
 	} else { //e.g. flow
-		min_abs_altitude = _param_min_alt.get();
+		min_abs_altitude = _navigator->get_takeoff_min_alt();
 	}
 
 	// Use altitude if it has been set. If home position is invalid use min_abs_altitude
@@ -122,22 +98,21 @@ Takeoff::set_takeoff_position()
 		if (abs_altitude < min_abs_altitude) {
 			abs_altitude = min_abs_altitude;
 			mavlink_log_critical(_navigator->get_mavlink_log_pub(),
-					     "Using minimum takeoff altitude: %.2f m", (double)_param_min_alt.get());
+					     "Using minimum takeoff altitude: %.2f m", (double)_navigator->get_takeoff_min_alt());
 		}
 
 	} else {
 		// Use home + minimum clearance but only notify.
 		abs_altitude = min_abs_altitude;
 		mavlink_log_info(_navigator->get_mavlink_log_pub(),
-				 "Using minimum takeoff altitude: %.2f m", (double)_param_min_alt.get());
+				 "Using minimum takeoff altitude: %.2f m", (double)_navigator->get_takeoff_min_alt());
 	}
 
 
 	if (abs_altitude < _navigator->get_global_position()->alt) {
 		// If the suggestion is lower than our current alt, let's not go down.
 		abs_altitude = _navigator->get_global_position()->alt;
-		mavlink_log_critical(_navigator->get_mavlink_log_pub(),
-				     "Already higher than takeoff altitude");
+		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Already higher than takeoff altitude");
 	}
 
 	// set current mission item to takeoff

--- a/src/modules/navigator/takeoff.h
+++ b/src/modules/navigator/takeoff.h
@@ -47,21 +47,16 @@
 #include "navigator_mode.h"
 #include "mission_block.h"
 
-class Takeoff : public MissionBlock
+class Takeoff final : public MissionBlock
 {
 public:
 	Takeoff(Navigator *navigator, const char *name);
+	~Takeoff() = default;
 
-	~Takeoff();
-
-	virtual void on_inactive();
-
-	virtual void on_activation();
-
-	virtual void on_active();
+	void on_activation() override;
+	void on_active() override;
 
 private:
-	control::BlockParamFloat _param_min_alt;
 
 	void set_takeoff_position();
 };


### PR DESCRIPTION
 - remove remaining parameters from MissionBlock
 - merge onboard and offboard missions (these are simply different dataman ids)
 - remove MIS_ONBOARD_EN parameter (this was confusing to users)
 - initialize all navigator states, but skip redundant updateParams()
 - log mission and mission_result (very helpful for debugging)
