### PR TITLE
Change the name of sdlog file in case of differential gps

### DIFF
--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1442,7 +1442,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 
 		if (gps_pos_updated && log_name_timestamp) {
 			gps_time_sec = buf_gps_pos.time_utc_usec / 1e6;
-			has_gps_3d_fix = buf_gps_pos.fix_type == 3;
+			has_gps_3d_fix = buf_gps_pos.fix_type >= 3;
 		}
 
 		if (!logging_enabled) {


### PR DESCRIPTION
The fix_type variable in ubx.cpp may be assigned to 4(DGPS) or 5(Float RTK) or 6(Fixed RTK). So if we use differential gps, the value of the fix_type variable may not be 3. But gps still has 3d data and gps time. So The name of the file should named with gps time.My ublox differential gps fix_type is 5 (Float RTK).