### PR TITLE
cmake nuttx build and link libnet if networking is enabled

### DIFF
--- a/nuttx-configs/PX4_Warnings.mk
+++ b/nuttx-configs/PX4_Warnings.mk
@@ -43,9 +43,9 @@ PX4_ARCHWARNINGS = -Wall \
                    -Wpointer-arith \
                    -Wshadow \
                    -Wno-sign-compare \
-                   -Wno-unused-parameter \
-                   -Wno-nonnull-compare \
-                   -Wno-misleading-indentation
+                   -Wno-unused-parameter
+                   #-Wno-nonnull-compare \ # re-enable GCC >= 6
+                   #-Wno-misleading-indentation # re-enable GCC >= 6
 
 #   -Wcast-qual  - generates spurious noreturn attribute warnings, try again later
 #   -Wconversion - would be nice, but too many "risky-but-safe" conversions in the code

--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -189,6 +189,10 @@ add_nuttx_dir(c libc n "")
 add_nuttx_dir(cxx libxx n "")
 add_nuttx_dir(mm mm n "")
 
+if (CONFIG_NET)
+	add_nuttx_dir(net net y -D__KERNEL__)
+endif()
+
 # oldconfig helper
 add_custom_target(oldconfig
 	COMMAND make --no-print-directory --silent -C ${NUTTX_DIR} CONFIG_ARCH_BOARD=${BOARD} oldconfig

--- a/src/firmware/nuttx/CMakeLists.txt
+++ b/src/firmware/nuttx/CMakeLists.txt
@@ -10,13 +10,8 @@ get_property(module_libraries GLOBAL PROPERTY PX4_LIBRARIES)
 # build NuttX
 add_subdirectory(${PX4_SOURCE_DIR}/platforms/nuttx/NuttX ${PX4_BINARY_DIR}/NuttX)
 
-target_link_libraries(${fw_name}
-	-T${PX4_BINARY_DIR}/NuttX/nuttx/configs/${BOARD}/scripts/ld.script
-	-Wl,-Map=${PX4_BINARY_DIR}/${CONFIG}.map
-	-Wl,--warn-common
-	-Wl,--gc-sections
-	-Wl,--start-group
-	${module_libraries}
+set(nuttx_libs)
+list(APPEND nuttx_libs
 	nuttx_apps
 	nuttx_arch
 	nuttx_binfmt
@@ -28,6 +23,20 @@ target_link_libraries(${fw_name}
 	nuttx_fs
 	nuttx_mm
 	nuttx_sched
+	)
+
+if (CONFIG_NET)
+	list(APPEND nuttx_libs nuttx_net)
+endif()
+
+target_link_libraries(${fw_name}
+	-T${PX4_BINARY_DIR}/NuttX/nuttx/configs/${BOARD}/scripts/ld.script
+	-Wl,-Map=${PX4_BINARY_DIR}/${CONFIG}.map
+	-Wl,--warn-common
+	-Wl,--gc-sections
+	-Wl,--start-group
+	${module_libraries}
+	${nuttx_libs}
 	-Wl,--end-group
 	m
 	gcc


### PR DESCRIPTION
Minor convenience for those using PX4 on NuttX with networking. No change for the existing builds.