### PR TITLE
drivers device interface improvements

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -33,6 +33,7 @@ Checks:          '*
 		,-cppcoreguidelines-pro-type-vararg
 		,-cppcoreguidelines-special-member-functions
 		,-google-build-using-namespace
+		,-google-default-arguments
 		,-google-explicit-constructor
 		,-google-global-names-in-headers
 		,-google-readability-casting

--- a/src/drivers/barometer/lps22hb/LPS22HB.cpp
+++ b/src/drivers/barometer/lps22hb/LPS22HB.cpp
@@ -103,8 +103,6 @@ out:
 int
 LPS22HB::ioctl(struct file *filp, int cmd, unsigned long arg)
 {
-	unsigned dummy = arg;
-
 	switch (cmd) {
 	case SENSORIOCSPOLLRATE: {
 			switch (arg) {
@@ -175,9 +173,6 @@ LPS22HB::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case SENSORIOCRESET:
 		return reset();
-
-	case DEVIOCGDEVICEID:
-		return _interface->ioctl(cmd, dummy);
 
 	default:
 		/* give it to the superclass */

--- a/src/drivers/barometer/lps25h/lps25h.cpp
+++ b/src/drivers/barometer/lps25h/lps25h.cpp
@@ -451,8 +451,6 @@ LPS25H::read(struct file *filp, char *buffer, size_t buflen)
 int
 LPS25H::ioctl(struct file *filp, int cmd, unsigned long arg)
 {
-	unsigned dummy = arg;
-
 	switch (cmd) {
 	case SENSORIOCSPOLLRATE: {
 			switch (arg) {
@@ -539,9 +537,6 @@ LPS25H::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case SENSORIOCRESET:
 		return reset();
-
-	case DEVIOCGDEVICEID:
-		return _interface->ioctl(cmd, dummy);
 
 	default:
 		/* give it to the superclass */

--- a/src/drivers/barometer/lps25h/lps25h_i2c.cpp
+++ b/src/drivers/barometer/lps25h/lps25h_i2c.cpp
@@ -67,17 +67,13 @@ class LPS25H_I2C : public device::I2C
 {
 public:
 	LPS25H_I2C(int bus);
-	virtual ~LPS25H_I2C();
+	virtual ~LPS25H_I2C() = default;
 
-	virtual int	init();
 	virtual int	read(unsigned address, void *data, unsigned count);
 	virtual int	write(unsigned address, void *data, unsigned count);
 
-	virtual int	ioctl(unsigned operation, unsigned &arg);
-
 protected:
 	virtual int	probe();
-
 };
 
 device::Device *
@@ -89,34 +85,6 @@ LPS25H_I2C_interface(int bus)
 LPS25H_I2C::LPS25H_I2C(int bus) :
 	I2C("LPS25H_I2C", nullptr, bus, LPS25H_ADDRESS, 400000)
 {
-}
-
-LPS25H_I2C::~LPS25H_I2C()
-{
-}
-
-int
-LPS25H_I2C::init()
-{
-	/* this will call probe() */
-	return I2C::init();
-}
-
-int
-LPS25H_I2C::ioctl(unsigned operation, unsigned &arg)
-{
-	int ret;
-
-	switch (operation) {
-
-	case DEVIOCGDEVICEID:
-		return CDev::ioctl(nullptr, operation, arg);
-
-	default:
-		ret = -EINVAL;
-	}
-
-	return ret;
 }
 
 int

--- a/src/drivers/barometer/lps25h/lps25h_spi.cpp
+++ b/src/drivers/barometer/lps25h/lps25h_spi.cpp
@@ -73,14 +73,11 @@ class LPS25H_SPI : public device::SPI
 {
 public:
 	LPS25H_SPI(int bus, uint32_t device);
-	virtual ~LPS25H_SPI();
+	virtual ~LPS25H_SPI() = default;
 
 	virtual int	init();
 	virtual int	read(unsigned address, void *data, unsigned count);
 	virtual int	write(unsigned address, void *data, unsigned count);
-
-	virtual int	ioctl(unsigned operation, unsigned &arg);
-
 };
 
 device::Device *
@@ -93,10 +90,6 @@ LPS25H_SPI::LPS25H_SPI(int bus, uint32_t device) :
 	SPI("LPS25H_SPI", nullptr, bus, device, SPIDEV_MODE3, 11 * 1000 * 1000 /* will be rounded to 10.4 MHz */)
 {
 	_device_id.devid_s.devtype = DRV_MAG_DEVTYPE_LPS25H;
-}
-
-LPS25H_SPI::~LPS25H_SPI()
-{
 }
 
 int
@@ -125,24 +118,6 @@ LPS25H_SPI::init()
 	}
 
 	return OK;
-}
-
-int
-LPS25H_SPI::ioctl(unsigned operation, unsigned &arg)
-{
-	int ret;
-
-	switch (operation) {
-
-	case DEVIOCGDEVICEID:
-		return CDev::ioctl(nullptr, operation, arg);
-
-	default: {
-			ret = -EINVAL;
-		}
-	}
-
-	return ret;
 }
 
 int

--- a/src/drivers/barometer/mpl3115a2/mpl3115a2.cpp
+++ b/src/drivers/barometer/mpl3115a2/mpl3115a2.cpp
@@ -483,8 +483,7 @@ MPL3115A2::ioctl(struct file *filp, int cmd, unsigned long arg)
 			 * Since we are initialized, we do not need to do anything, since the
 			 * PROM is correctly read and the part does not need to be configured.
 			 */
-			unsigned int dummy;
-			_interface->ioctl(IOCTL_RESET, dummy);
+			_interface->reset();
 			return OK;
 		}
 
@@ -527,7 +526,6 @@ void
 MPL3115A2::cycle()
 {
 	int ret;
-	unsigned dummy;
 
 	/* collection phase? */
 	if (_collect_phase) {
@@ -537,7 +535,7 @@ MPL3115A2::cycle()
 
 		if (ret == -EIO) {
 			/* issue a reset command to the sensor */
-			_interface->ioctl(IOCTL_RESET, dummy);
+			_interface->reset();
 			/* reset the collection state machine and try again - we need
 			 * to wait 2.8 ms after issuing the sensor reset command
 			 * according to the MPL3115A2 datasheet
@@ -568,7 +566,7 @@ MPL3115A2::cycle()
 
 	if (ret == -EIO) {
 		/* issue a reset command to the sensor */
-		_interface->ioctl(IOCTL_RESET, dummy);
+		_interface->reset();
 		/* reset the collection state machine and try again */
 		start_cycle();
 		return;
@@ -596,7 +594,7 @@ MPL3115A2::measure()
 	 * Send the command to read the ADC for P and T.
 	 */
 	unsigned addr = (MPL3115A2_CTRL_REG1 << 8) | MPL3115A2_CTRL_TRIGGER;
-	ret = _interface->ioctl(IOCTL_MEASURE, addr);
+	ret = _interface->measure(addr);
 
 	if (ret == -EIO) {
 		perf_count(_comms_errors);

--- a/src/drivers/barometer/mpl3115a2/mpl3115a2.h
+++ b/src/drivers/barometer/mpl3115a2/mpl3115a2.h
@@ -54,10 +54,6 @@
 #  define CTRL_REG1_OST          (1 << 1)
 #  define CTRL_REG1_SBYB         (1 << 0)
 
-/* interface ioctls */
-#define IOCTL_RESET         1
-#define IOCTL_MEASURE       2
-
 typedef begin_packed_struct struct MPL3115A2_data_t {
 	union {
 		uint32_t q;

--- a/src/drivers/barometer/mpl3115a2/mpl3115a2_i2c.cpp
+++ b/src/drivers/barometer/mpl3115a2/mpl3115a2_i2c.cpp
@@ -64,27 +64,26 @@ class MPL3115A2_I2C : public device::I2C
 {
 public:
 	MPL3115A2_I2C(uint8_t bus);
-	virtual ~MPL3115A2_I2C();
+	virtual ~MPL3115A2_I2C() = default;
 
-	virtual int	init();
 	virtual int	read(unsigned offset, void *data, unsigned count);
-	virtual int	ioctl(unsigned operation, unsigned &arg);
-
-protected:
-	virtual int	probe();
-
-private:
 
 	/**
 	 * Send a measure command to the MPL3115A2.
 	 *
 	 * @param addr		Which address to use for the measure operation.
 	 */
-	int		_measure(unsigned addr);
+	int		measure(unsigned addr) override;
+
+	int	reset() override;
+
+protected:
+	virtual int	probe();
+
+private:
 
 	int reg_read(uint8_t reg, void *data, unsigned count = 1);
 	int reg_write(uint8_t reg, uint8_t data);
-	int	reset();
 
 };
 
@@ -97,18 +96,8 @@ MPL3115A2_i2c_interface(uint8_t busnum)
 MPL3115A2_I2C::MPL3115A2_I2C(uint8_t bus) :
 	I2C("MPL3115A2_I2C", nullptr, bus, 0, 400000)
 {
-}
-
-MPL3115A2_I2C::~MPL3115A2_I2C()
-{
-}
-
-int
-MPL3115A2_I2C::init()
-{
 	/* this will call probe() */
 	set_device_address(MPL3115A2_ADDRESS);
-	return I2C::init();
 }
 
 int
@@ -165,27 +154,6 @@ MPL3115A2_I2C::read(unsigned offset, void *data, unsigned count)
 }
 
 int
-MPL3115A2_I2C::ioctl(unsigned operation, unsigned &arg)
-{
-	int ret;
-
-	switch (operation) {
-	case IOCTL_RESET:
-		ret = reset();
-		break;
-
-	case IOCTL_MEASURE:
-		ret = _measure(arg);
-		break;
-
-	default:
-		ret = EINVAL;
-	}
-
-	return ret;
-}
-
-int
 MPL3115A2_I2C::probe()
 {
 	_retries = 10;
@@ -204,7 +172,7 @@ MPL3115A2_I2C::probe()
 }
 
 int
-MPL3115A2_I2C::_measure(unsigned addr)
+MPL3115A2_I2C::measure(unsigned addr)
 {
 	/*
 	 * Disable retries on this command; we can't know whether failure

--- a/src/drivers/barometer/ms5611/ms5611.cpp
+++ b/src/drivers/barometer/ms5611/ms5611.cpp
@@ -605,7 +605,6 @@ void
 MS5611::cycle()
 {
 	int ret;
-	unsigned dummy;
 
 	/* collection phase? */
 	if (_collect_phase) {
@@ -625,7 +624,8 @@ MS5611::cycle()
 			}
 
 			/* issue a reset command to the sensor */
-			_interface->ioctl(IOCTL_RESET, dummy);
+			_interface->reset();
+
 			/* reset the collection state machine and try again - we need
 			 * to wait 2.8 ms after issuing the sensor reset command
 			 * according to the MS5611 datasheet
@@ -661,7 +661,7 @@ MS5611::cycle()
 
 	if (ret != OK) {
 		/* issue a reset command to the sensor */
-		_interface->ioctl(IOCTL_RESET, dummy);
+		_interface->reset();
 		/* reset the collection state machine and try again */
 		start_cycle();
 		return;
@@ -693,7 +693,7 @@ MS5611::measure()
 	/*
 	 * Send the command to begin measuring.
 	 */
-	ret = _interface->ioctl(IOCTL_MEASURE, addr);
+	ret = _interface->measure(addr);
 
 	if (OK != ret) {
 		perf_count(_comms_errors);

--- a/src/drivers/barometer/ms5611/ms5611.h
+++ b/src/drivers/barometer/ms5611/ms5611.h
@@ -40,10 +40,6 @@
 #define ADDR_RESET_CMD			0x1E	/* write to this address to reset chip */
 #define ADDR_PROM_SETUP			0xA0	/* address of 8x 2 bytes factory and calibration data */
 
-/* interface ioctls */
-#define IOCTL_RESET			2
-#define IOCTL_MEASURE			3
-
 namespace ms5611
 {
 

--- a/src/drivers/barometer/ms5611/ms5611_spi.cpp
+++ b/src/drivers/barometer/ms5611/ms5611_spi.cpp
@@ -67,11 +67,10 @@ class MS5611_SPI : public device::SPI
 {
 public:
 	MS5611_SPI(uint8_t bus, uint32_t device, ms5611::prom_u &prom_buf);
-	virtual ~MS5611_SPI();
+	virtual ~MS5611_SPI() = default;
 
 	virtual int	init();
 	virtual int	read(unsigned offset, void *data, unsigned count);
-	virtual int	ioctl(unsigned operation, unsigned &arg);
 
 private:
 	ms5611::prom_u	&_prom;
@@ -81,14 +80,14 @@ private:
 	 *
 	 * This is required after any bus reset.
 	 */
-	int		_reset();
+	int		reset() override;
 
 	/**
 	 * Send a measure command to the MS5611.
 	 *
 	 * @param addr		Which address to use for the measure operation.
 	 */
-	int		_measure(unsigned addr);
+	int		measure(unsigned addr) override;
 
 	/**
 	 * Read the MS5611 PROM
@@ -136,10 +135,6 @@ MS5611_SPI::MS5611_SPI(uint8_t bus, uint32_t device, ms5611::prom_u &prom_buf) :
 {
 }
 
-MS5611_SPI::~MS5611_SPI()
-{
-}
-
 int
 MS5611_SPI::init()
 {
@@ -158,7 +153,7 @@ MS5611_SPI::init()
 	}
 
 	/* send reset command */
-	ret = _reset();
+	ret = reset();
 
 	if (ret != OK) {
 		DEVICE_DEBUG("reset failed");
@@ -203,33 +198,7 @@ MS5611_SPI::read(unsigned offset, void *data, unsigned count)
 }
 
 int
-MS5611_SPI::ioctl(unsigned operation, unsigned &arg)
-{
-	int ret;
-
-	switch (operation) {
-	case IOCTL_RESET:
-		ret = _reset();
-		break;
-
-	case IOCTL_MEASURE:
-		ret = _measure(arg);
-		break;
-
-	default:
-		ret = EINVAL;
-	}
-
-	if (ret != OK) {
-		errno = ret;
-		return -1;
-	}
-
-	return 0;
-}
-
-int
-MS5611_SPI::_reset()
+MS5611_SPI::reset()
 {
 	uint8_t cmd = ADDR_RESET_CMD | DIR_WRITE;
 
@@ -237,13 +206,12 @@ MS5611_SPI::_reset()
 }
 
 int
-MS5611_SPI::_measure(unsigned addr)
+MS5611_SPI::measure(unsigned addr)
 {
 	uint8_t cmd = addr | DIR_WRITE;
 
 	return _transfer(&cmd, nullptr, 1);
 }
-
 
 int
 MS5611_SPI::_read_prom()

--- a/src/drivers/imu/bmi160/bmi160.hpp
+++ b/src/drivers/imu/bmi160/bmi160.hpp
@@ -354,7 +354,7 @@ private:
 	 *
 	 * Resets the chip and measurements ranges, but not scale and offset.
 	 */
-	int			reset();
+	int			reset() override;
 
 	/**
 	 * Static trampoline from the hrt_call context; because we don't have a

--- a/src/drivers/imu/bmi160/bmi160_gyro.cpp
+++ b/src/drivers/imu/bmi160/bmi160_gyro.cpp
@@ -51,13 +51,5 @@ BMI160_gyro::read(struct file *filp, char *buffer, size_t buflen)
 int
 BMI160_gyro::ioctl(struct file *filp, int cmd, unsigned long arg)
 {
-
-	switch (cmd) {
-	case DEVIOCGDEVICEID:
-		return (int)CDev::ioctl(filp, cmd, arg);
-		break;
-
-	default:
-		return _parent->gyro_ioctl(filp, cmd, arg);
-	}
+	return _parent->gyro_ioctl(filp, cmd, arg);
 }

--- a/src/drivers/imu/fxas21002c/fxas21002c.cpp
+++ b/src/drivers/imu/fxas21002c/fxas21002c.cpp
@@ -306,7 +306,7 @@ private:
 	 *
 	 * Resets the chip and measurements ranges, but not scale and offset.
 	 */
-	void			reset();
+	int			reset() override;
 
 	/**
 	 * disable I2C on the chip
@@ -532,7 +532,7 @@ out:
 }
 
 
-void
+int
 FXAS21002C::reset()
 {
 	/* write 0 0 0 000 00 = 0x00 to CTRL_REG1 to place FXOS21002 in Standby
@@ -564,6 +564,8 @@ FXAS21002C::reset()
 	set_range(FXAS21002C_DEFAULT_RANGE_DPS);
 	set_driver_lowpass_filter(FXAS21002C_DEFAULT_RATE, FXAS21002C_DEFAULT_FILTER_FREQ);
 	_read = 0;
+
+	return PX4_OK;
 }
 
 int

--- a/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
+++ b/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
@@ -266,7 +266,7 @@ private:
 	 *
 	 * Resets the chip and measurements ranges, but not scale and offset.
 	 */
-	void			reset();
+	int			reset() override;
 
 	/**
 	 * disable I2C on the chip
@@ -630,10 +630,9 @@ out:
 }
 
 
-void
+int
 FXOS8701CQ::reset()
 {
-
 	/* enable accel set it To Standby */
 
 	write_checked_reg(FXOS8701CQ_CTRL_REG1, 0);
@@ -665,6 +664,8 @@ FXOS8701CQ::reset()
 
 	_accel_read = 0;
 	_mag_read = 0;
+
+	return PX4_OK;
 }
 
 int
@@ -1662,14 +1663,7 @@ FXOS8701CQ_mag::read(struct file *filp, char *buffer, size_t buflen)
 int
 FXOS8701CQ_mag::ioctl(struct file *filp, int cmd, unsigned long arg)
 {
-	switch (cmd) {
-	case DEVIOCGDEVICEID:
-		return (int)CDev::ioctl(filp, cmd, arg);
-		break;
-
-	default:
-		return _parent->mag_ioctl(filp, cmd, arg);
-	}
+	return _parent->mag_ioctl(filp, cmd, arg);
 }
 
 void

--- a/src/drivers/imu/l3gd20/l3gd20.cpp
+++ b/src/drivers/imu/l3gd20/l3gd20.cpp
@@ -275,7 +275,7 @@ private:
 	/**
 	 * Reset the driver
 	 */
-	void			reset();
+	int			reset() override;
 
 	/**
 	 * disable I2C on the chip
@@ -870,7 +870,7 @@ L3GD20::disable_i2c(void)
 	DEVICE_DEBUG("FAILED TO DISABLE I2C");
 }
 
-void
+int
 L3GD20::reset()
 {
 	// ensure the chip doesn't interpret any other bus traffic as I2C
@@ -895,6 +895,8 @@ L3GD20::reset()
 	set_driver_lowpass_filter(L3GD20_DEFAULT_RATE, L3GD20_DEFAULT_FILTER_FREQ);
 
 	_read = 0;
+
+	return PX4_OK;
 }
 
 void

--- a/src/drivers/imu/mpu6000/mpu6000.cpp
+++ b/src/drivers/imu/mpu6000/mpu6000.cpp
@@ -259,7 +259,7 @@ private:
 	 *
 	 * Resets the chip and measurements ranges, but not scale and offset.
 	 */
-	int			reset();
+	int			reset() override;
 
 	/**
 	 * is_icm_device
@@ -368,17 +368,6 @@ private:
 	 * Swap a 16-bit value read from the MPU6000 to native byte order.
 	 */
 	uint16_t		swap16(uint16_t val) { return (val >> 8) | (val << 8);	}
-
-	/**
-	 * Get the internal / external state
-	 *
-	 * @return true if the sensor is not on the main MCU board
-	 */
-	bool			is_external()
-	{
-		unsigned dummy;
-		return _interface->ioctl(ACCELIOCGEXTERNAL, dummy);
-	}
 
 	/**
 	 * Measurement self test
@@ -628,8 +617,7 @@ MPU6000::init()
 {
 
 #if defined(USE_I2C)
-	unsigned dummy;
-	use_i2c(_interface->ioctl(MPUIOCGIS_I2C, dummy));
+	use_i2c(_interface->get_device_bus_type() == DeviceBusType_I2C);
 #endif
 
 
@@ -738,7 +726,7 @@ MPU6000::init()
 
 	/* measurement will have generated a report, publish */
 	_accel_topic = orb_advertise_multi(ORB_ID(sensor_accel), &arp,
-					   &_accel_orb_class_instance, (is_external()) ? ORB_PRIO_MAX : ORB_PRIO_HIGH);
+					   &_accel_orb_class_instance, _interface->external() ? ORB_PRIO_MAX : ORB_PRIO_HIGH);
 
 	if (_accel_topic == nullptr) {
 		PX4_WARN("ADVERT FAIL");
@@ -749,7 +737,7 @@ MPU6000::init()
 	_gyro_reports->get(&grp);
 
 	_gyro->_gyro_topic = orb_advertise_multi(ORB_ID(sensor_gyro), &grp,
-			     &_gyro->_gyro_orb_class_instance, (is_external()) ? ORB_PRIO_MAX : ORB_PRIO_HIGH);
+			     &_gyro->_gyro_orb_class_instance, _interface->external() ? ORB_PRIO_MAX : ORB_PRIO_HIGH);
 
 	if (_gyro->_gyro_topic == nullptr) {
 		PX4_WARN("ADVERT FAIL");
@@ -766,8 +754,6 @@ int MPU6000::reset()
 	// come as zero
 	uint8_t tries = 5;
 	irqstate_t state;
-
-
 
 	while (--tries != 0) {
 		state = px4_enter_critical_section();
@@ -1358,8 +1344,6 @@ MPU6000::gyro_read(struct file *filp, char *buffer, size_t buflen)
 int
 MPU6000::ioctl(struct file *filp, int cmd, unsigned long arg)
 {
-	unsigned dummy = arg;
-
 	switch (cmd) {
 
 	case SENSORIOCRESET:
@@ -1500,7 +1484,7 @@ MPU6000::ioctl(struct file *filp, int cmd, unsigned long arg)
 		return accel_self_test();
 
 	case ACCELIOCGEXTERNAL:
-		return _interface->ioctl(cmd, dummy);
+		return _interface->external();
 
 	default:
 		/* give it to the superclass */
@@ -2189,15 +2173,7 @@ MPU6000_gyro::read(struct file *filp, char *buffer, size_t buflen)
 int
 MPU6000_gyro::ioctl(struct file *filp, int cmd, unsigned long arg)
 {
-
-	switch (cmd) {
-	case DEVIOCGDEVICEID:
-		return (int)CDev::ioctl(filp, cmd, arg);
-		break;
-
-	default:
-		return _parent->gyro_ioctl(filp, cmd, arg);
-	}
+	return _parent->gyro_ioctl(filp, cmd, arg);
 }
 
 /**

--- a/src/drivers/imu/mpu6000/mpu6000.h
+++ b/src/drivers/imu/mpu6000/mpu6000.h
@@ -212,14 +212,6 @@
 
 #define MPU6000_DEFAULT_ONCHIP_FILTER_FREQ			98
 
-#ifdef PX4_SPI_BUS_EXT
-#define EXTERNAL_BUS PX4_SPI_BUS_EXT
-#else
-#define EXTERNAL_BUS 0
-#endif
-
-#define MPUIOCGIS_I2C	(unsigned)(DEVIOCGDEVICEID+100)
-
 #pragma pack(push, 1)
 /**
  * Report conversation within the MPU6000, including command byte and

--- a/src/drivers/imu/mpu6000/mpu6000_i2c.cpp
+++ b/src/drivers/imu/mpu6000/mpu6000_i2c.cpp
@@ -67,13 +67,10 @@ class MPU6000_I2C : public device::I2C
 {
 public:
 	MPU6000_I2C(int bus, int device_type);
-	virtual ~MPU6000_I2C();
+	virtual ~MPU6000_I2C() = default;
 
-	virtual int	init();
 	virtual int	read(unsigned address, void *data, unsigned count);
 	virtual int	write(unsigned address, void *data, unsigned count);
-
-	virtual int	ioctl(unsigned operation, unsigned &arg);
 
 protected:
 	virtual int	probe();
@@ -95,40 +92,6 @@ MPU6000_I2C::MPU6000_I2C(int bus, int device_type) :
 	_device_type(device_type)
 {
 	_device_id.devid_s.devtype =  DRV_ACC_DEVTYPE_MPU6000;
-}
-
-MPU6000_I2C::~MPU6000_I2C()
-{
-}
-
-int
-MPU6000_I2C::init()
-{
-	/* this will call probe() */
-	return I2C::init();
-}
-
-int
-MPU6000_I2C::ioctl(unsigned operation, unsigned &arg)
-{
-	int ret;
-
-	switch (operation) {
-
-	case ACCELIOCGEXTERNAL:
-		return external();
-
-	case DEVIOCGDEVICEID:
-		return CDev::ioctl(nullptr, operation, arg);
-
-	case MPUIOCGIS_I2C:
-		return 1;
-
-	default:
-		ret = -EINVAL;
-	}
-
-	return ret;
 }
 
 int

--- a/src/drivers/imu/mpu6000/mpu6000_spi.cpp
+++ b/src/drivers/imu/mpu6000/mpu6000_spi.cpp
@@ -101,13 +101,11 @@ class MPU6000_SPI : public device::SPI
 {
 public:
 	MPU6000_SPI(int bus, uint32_t device, int device_type);
-	virtual ~MPU6000_SPI();
+	virtual ~MPU6000_SPI() = default;
 
-	virtual int	init();
 	virtual int	read(unsigned address, void *data, unsigned count);
 	virtual int	write(unsigned address, void *data, unsigned count);
 
-	virtual int	ioctl(unsigned operation, unsigned &arg);
 protected:
 	virtual int probe();
 
@@ -210,63 +208,16 @@ MPU6000_SPI::MPU6000_SPI(int bus, uint32_t device, int device_type) :
 	SPI("MPU6000", nullptr, bus, device, SPIDEV_MODE3, MPU6000_LOW_SPI_BUS_SPEED),
 	_device_type(device_type)
 {
-	_device_id.devid_s.devtype =  DRV_ACC_DEVTYPE_MPU6000;
-}
-
-MPU6000_SPI::~MPU6000_SPI()
-{
-}
-
-int
-MPU6000_SPI::init()
-{
-	int ret;
-
-	ret = SPI::init();
-
-	if (ret != OK) {
-		DEVICE_DEBUG("SPI init failed");
-		return -EIO;
-	}
-
-	return OK;
-}
-
-int
-MPU6000_SPI::ioctl(unsigned operation, unsigned &arg)
-{
-	int ret;
-
-	switch (operation) {
-
-	case ACCELIOCGEXTERNAL:
-		external();
-
-	/* FALLTHROUGH */
-
-	case DEVIOCGDEVICEID:
-		return CDev::ioctl(nullptr, operation, arg);
-
-	case MPUIOCGIS_I2C:
-		return 0;
-
-	default: {
-			ret = -EINVAL;
-		}
-	}
-
-	return ret;
+	_device_id.devid_s.devtype = DRV_ACC_DEVTYPE_MPU6000;
 }
 
 void
 MPU6000_SPI::set_bus_frequency(unsigned &reg_speed)
 {
 	/* Set the desired speed */
-
 	set_frequency(MPU6000_IS_HIGH_SPEED(reg_speed) ? _max_frequency : MPU6000_LOW_SPI_BUS_SPEED);
 
 	/* Isolate the register on return */
-
 	reg_speed = MPU6000_REG(reg_speed);
 }
 

--- a/src/drivers/imu/mpu9250/gyro.cpp
+++ b/src/drivers/imu/mpu9250/gyro.cpp
@@ -119,13 +119,5 @@ MPU9250_gyro::read(struct file *filp, char *buffer, size_t buflen)
 int
 MPU9250_gyro::ioctl(struct file *filp, int cmd, unsigned long arg)
 {
-
-	switch (cmd) {
-	case DEVIOCGDEVICEID:
-		return (int)CDev::ioctl(filp, cmd, arg);
-		break;
-
-	default:
-		return _parent->gyro_ioctl(filp, cmd, arg);
-	}
+	return _parent->gyro_ioctl(filp, cmd, arg);
 }

--- a/src/drivers/imu/mpu9250/mag_i2c.cpp
+++ b/src/drivers/imu/mpu9250/mag_i2c.cpp
@@ -69,13 +69,10 @@ class AK8963_I2C : public device::I2C
 {
 public:
 	AK8963_I2C(int bus);
-	virtual ~AK8963_I2C();
+	virtual ~AK8963_I2C() = default;
 
-	virtual int	init();
 	virtual int	read(unsigned address, void *data, unsigned count);
 	virtual int	write(unsigned address, void *data, unsigned count);
-
-	virtual int	ioctl(unsigned operation, unsigned &arg);
 
 protected:
 	virtual int	probe();
@@ -92,41 +89,7 @@ AK8963_I2C_interface(int bus, bool external_bus)
 AK8963_I2C::AK8963_I2C(int bus) :
 	I2C("AK8963_I2C", nullptr, bus, AK8963_I2C_ADDR, 400000)
 {
-	_device_id.devid_s.devtype =  DRV_MAG_DEVTYPE_MPU9250;
-}
-
-AK8963_I2C::~AK8963_I2C()
-{
-}
-
-int
-AK8963_I2C::init()
-{
-	/* this will call probe() */
-	return I2C::init();
-}
-
-int
-AK8963_I2C::ioctl(unsigned operation, unsigned &arg)
-{
-	int ret;
-
-	switch (operation) {
-
-	case ACCELIOCGEXTERNAL:
-		return external();
-
-	case DEVIOCGDEVICEID:
-		return CDev::ioctl(nullptr, operation, arg);
-
-	case MPUIOCGIS_I2C:
-		return 1;
-
-	default:
-		ret = -EINVAL;
-	}
-
-	return ret;
+	_device_id.devid_s.devtype = DRV_MAG_DEVTYPE_MPU9250;
 }
 
 int
@@ -149,7 +112,6 @@ AK8963_I2C::read(unsigned reg_speed, void *data, unsigned count)
 	uint8_t cmd = MPU9250_REG(reg_speed);
 	return transfer(&cmd, 1, (uint8_t *)data, count);
 }
-
 
 int
 AK8963_I2C::probe()

--- a/src/drivers/imu/mpu9250/mpu9250.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250.cpp
@@ -256,8 +256,7 @@ MPU9250::init()
 {
 
 #if defined(USE_I2C)
-	unsigned dummy;
-	use_i2c(_interface->ioctl(MPUIOCGIS_I2C, dummy));
+	use_i2c(_interface->get_device_bus_type() == DeviceBusType_I2C);
 #endif
 
 	/*
@@ -400,7 +399,7 @@ MPU9250::init()
 
 	/* measurement will have generated a report, publish */
 	_accel_topic = orb_advertise_multi(ORB_ID(sensor_accel), &arp,
-					   &_accel_orb_class_instance, (is_external()) ? ORB_PRIO_MAX - 1 : ORB_PRIO_HIGH - 1);
+					   &_accel_orb_class_instance, _interface->external() ? ORB_PRIO_MAX - 1 : ORB_PRIO_HIGH - 1);
 
 	if (_accel_topic == nullptr) {
 		PX4_ERR("ADVERT FAIL");
@@ -412,7 +411,7 @@ MPU9250::init()
 	_gyro_reports->get(&grp);
 
 	_gyro->_gyro_topic = orb_advertise_multi(ORB_ID(sensor_gyro), &grp,
-			     &_gyro->_gyro_orb_class_instance, (is_external()) ? ORB_PRIO_MAX - 1 : ORB_PRIO_HIGH - 1);
+			     &_gyro->_gyro_orb_class_instance, _interface->external() ? ORB_PRIO_MAX - 1 : ORB_PRIO_HIGH - 1);
 
 	if (_gyro->_gyro_topic == nullptr) {
 		PX4_ERR("ADVERT FAIL");

--- a/src/drivers/imu/mpu9250/mpu9250.h
+++ b/src/drivers/imu/mpu9250/mpu9250.h
@@ -190,9 +190,6 @@
 
 #define MPU9250_DEFAULT_ONCHIP_FILTER_FREQ	92
 
-#define MPUIOCGIS_I2C	(unsigned)(DEVIOCGDEVICEID+100)
-
-
 #pragma pack(push, 1)
 /**
  * Report conversation within the mpu, including command byte and
@@ -406,9 +403,6 @@ private:
 
 	bool is_i2c(void) { return !_use_hrt; }
 
-
-
-
 	/**
 	 * Static trampoline from the hrt_call context; because we don't have a
 	 * generic hrt wrapper yet.
@@ -484,17 +478,6 @@ private:
 	 * Swap a 16-bit value read from the mpu to native byte order.
 	 */
 	uint16_t		swap16(uint16_t val) { return (val >> 8) | (val << 8);	}
-
-	/**
-	 * Get the internal / external state
-	 *
-	 * @return true if the sensor is not on the main MCU board
-	 */
-	bool			is_external()
-	{
-		unsigned dummy;
-		return _interface->ioctl(ACCELIOCGEXTERNAL, dummy);
-	}
 
 	/**
 	 * Measurement self test

--- a/src/drivers/imu/mpu9250/mpu9250_i2c.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250_i2c.cpp
@@ -72,8 +72,6 @@ public:
 	virtual int	read(unsigned address, void *data, unsigned count);
 	virtual int	write(unsigned address, void *data, unsigned count);
 
-	virtual int	ioctl(unsigned operation, unsigned &arg);
-
 protected:
 	virtual int	probe();
 
@@ -89,29 +87,6 @@ MPU9250_I2C::MPU9250_I2C(int bus, uint32_t address) :
 	I2C("MPU9250_I2C", nullptr, bus, address, 400000)
 {
 	_device_id.devid_s.devtype =  DRV_ACC_DEVTYPE_MPU9250;
-}
-
-int
-MPU9250_I2C::ioctl(unsigned operation, unsigned &arg)
-{
-	int ret = PX4_ERROR;
-
-	switch (operation) {
-
-	case ACCELIOCGEXTERNAL:
-		return external();
-
-	case DEVIOCGDEVICEID:
-		return CDev::ioctl(nullptr, operation, arg);
-
-	case MPUIOCGIS_I2C:
-		return 1;
-
-	default:
-		ret = -EINVAL;
-	}
-
-	return ret;
 }
 
 int

--- a/src/drivers/imu/mpu9250/mpu9250_spi.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250_spi.cpp
@@ -89,14 +89,12 @@ public:
 	virtual int	read(unsigned address, void *data, unsigned count);
 	virtual int	write(unsigned address, void *data, unsigned count);
 
-	virtual int	ioctl(unsigned operation, unsigned &arg);
 protected:
 	virtual int probe();
 
 private:
 
 	/* Helper to set the desired speed and isolate the register on return */
-
 	void set_bus_frequency(unsigned &reg_speed_reg_out);
 };
 
@@ -121,44 +119,16 @@ MPU9250_SPI_interface(int bus, uint32_t cs, bool external_bus)
 MPU9250_SPI::MPU9250_SPI(int bus, uint32_t device) :
 	SPI("MPU9250", nullptr, bus, device, SPIDEV_MODE3, MPU9250_LOW_SPI_BUS_SPEED)
 {
-	_device_id.devid_s.devtype =  DRV_ACC_DEVTYPE_MPU9250;
-}
-
-int
-MPU9250_SPI::ioctl(unsigned operation, unsigned &arg)
-{
-	int ret;
-
-	switch (operation) {
-
-	case ACCELIOCGEXTERNAL:
-		external();
-
-	/* FALLTHROUGH */
-
-	case DEVIOCGDEVICEID:
-		return CDev::ioctl(nullptr, operation, arg);
-
-	case MPUIOCGIS_I2C:
-		return 0;
-
-	default: {
-			ret = -EINVAL;
-		}
-	}
-
-	return ret;
+	_device_id.devid_s.devtype = DRV_ACC_DEVTYPE_MPU9250;
 }
 
 void
 MPU9250_SPI::set_bus_frequency(unsigned &reg_speed)
 {
 	/* Set the desired speed */
-
 	set_frequency(MPU9250_IS_HIGH_SPEED(reg_speed) ? MPU9250_HIGH_SPI_BUS_SPEED : MPU9250_LOW_SPI_BUS_SPEED);
 
-	/* Isoolate the register on return */
-
+	/* Isolate the register on return */
 	reg_speed = MPU9250_REG(reg_speed);
 }
 
@@ -172,7 +142,6 @@ MPU9250_SPI::write(unsigned reg_speed, void *data, unsigned count)
 	}
 
 	/* Set the desired speed and isolate the register */
-
 	set_bus_frequency(reg_speed);
 
 	cmd[0] = reg_speed | DIR_WRITE;
@@ -195,32 +164,24 @@ MPU9250_SPI::read(unsigned reg_speed, void *data, unsigned count)
 
 
 	if (count < sizeof(MPUReport))  {
-
 		/* add command */
-
 		count++;
 	}
 
 	set_bus_frequency(reg_speed);
 
 	/* Set command */
-
 	pbuff[0] = reg_speed | DIR_READ ;
 
 	/* Transfer the command and get the data */
-
 	int ret = transfer(pbuff, pbuff, count);
 
 	if (ret == OK && pbuff == &cmd[0]) {
-
 		/* Adjust the count back */
-
 		count--;
 
 		/* Return the data */
-
 		memcpy(data, &cmd[1], count);
-
 	}
 
 	return ret;

--- a/src/drivers/magnetometer/hmc5883/hmc5883.cpp
+++ b/src/drivers/magnetometer/hmc5883/hmc5883.cpp
@@ -195,7 +195,7 @@ private:
 	/**
 	 * Reset the device
 	 */
-	int			reset();
+	int			reset() override;
 
 	/**
 	 * Perform the on-sensor scale calibration routine.
@@ -617,8 +617,6 @@ HMC5883::read(struct file *filp, char *buffer, size_t buflen)
 int
 HMC5883::ioctl(struct file *filp, int cmd, unsigned long arg)
 {
-	unsigned dummy = arg;
-
 	switch (cmd) {
 	case SENSORIOCSPOLLRATE: {
 			switch (arg) {
@@ -743,8 +741,7 @@ HMC5883::ioctl(struct file *filp, int cmd, unsigned long arg)
 		return check_calibration();
 
 	case MAGIOCGEXTERNAL:
-		DEVICE_DEBUG("MAGIOCGEXTERNAL in main driver");
-		return _interface->ioctl(cmd, dummy);
+		return _interface->external();
 
 	case MAGIOCSTEMPCOMP:
 		return set_temperature_compensation(arg);
@@ -985,8 +982,7 @@ HMC5883::collect()
 	/* scale values for output */
 
 	// XXX revisit for SPI part, might require a bus type IOCTL
-	unsigned dummy;
-	sensor_is_onboard = !_interface->ioctl(MAGIOCGEXTERNAL, dummy);
+	sensor_is_onboard = !_interface->external();
 	new_report.is_external = !sensor_is_onboard;
 
 	if (sensor_is_onboard) {

--- a/src/drivers/magnetometer/hmc5883/hmc5883_i2c.cpp
+++ b/src/drivers/magnetometer/hmc5883/hmc5883_i2c.cpp
@@ -67,13 +67,10 @@ class HMC5883_I2C : public device::I2C
 {
 public:
 	HMC5883_I2C(int bus);
-	virtual ~HMC5883_I2C();
+	virtual ~HMC5883_I2C() = default;
 
-	virtual int	init();
 	virtual int	read(unsigned address, void *data, unsigned count);
 	virtual int	write(unsigned address, void *data, unsigned count);
-
-	virtual int	ioctl(unsigned operation, unsigned &arg);
 
 protected:
 	virtual int	probe();
@@ -90,37 +87,6 @@ HMC5883_I2C::HMC5883_I2C(int bus) :
 	I2C("HMC5883_I2C", nullptr, bus, HMC5883L_ADDRESS, 400000)
 {
 	_device_id.devid_s.devtype = DRV_MAG_DEVTYPE_HMC5883;
-}
-
-HMC5883_I2C::~HMC5883_I2C()
-{
-}
-
-int
-HMC5883_I2C::init()
-{
-	/* this will call probe() */
-	return I2C::init();
-}
-
-int
-HMC5883_I2C::ioctl(unsigned operation, unsigned &arg)
-{
-	int ret;
-
-	switch (operation) {
-
-	case MAGIOCGEXTERNAL:
-		return external();
-
-	case DEVIOCGDEVICEID:
-		return CDev::ioctl(nullptr, operation, arg);
-
-	default:
-		ret = -EINVAL;
-	}
-
-	return ret;
 }
 
 int

--- a/src/drivers/magnetometer/hmc5883/hmc5883_spi.cpp
+++ b/src/drivers/magnetometer/hmc5883/hmc5883_spi.cpp
@@ -74,13 +74,11 @@ class HMC5883_SPI : public device::SPI
 {
 public:
 	HMC5883_SPI(int bus, uint32_t device);
-	virtual ~HMC5883_SPI();
+	virtual ~HMC5883_SPI() = default;
 
 	virtual int	init();
 	virtual int	read(unsigned address, void *data, unsigned count);
 	virtual int	write(unsigned address, void *data, unsigned count);
-
-	virtual int	ioctl(unsigned operation, unsigned &arg);
 
 };
 
@@ -96,16 +94,10 @@ HMC5883_SPI::HMC5883_SPI(int bus, uint32_t device) :
 	_device_id.devid_s.devtype = DRV_MAG_DEVTYPE_HMC5883;
 }
 
-HMC5883_SPI::~HMC5883_SPI()
-{
-}
-
 int
 HMC5883_SPI::init()
 {
-	int ret;
-
-	ret = SPI::init();
+	int ret = SPI::init();
 
 	if (ret != OK) {
 		DEVICE_DEBUG("SPI init failed");
@@ -129,32 +121,6 @@ HMC5883_SPI::init()
 	}
 
 	return OK;
-}
-
-int
-HMC5883_SPI::ioctl(unsigned operation, unsigned &arg)
-{
-	int ret;
-
-	switch (operation) {
-
-	case MAGIOCGEXTERNAL:
-		/*
-		 * Even if this sensor is on the external SPI
-		 * bus it is still internal to the autopilot
-		 * assembly, so always return 0 for internal.
-		 */
-		return 0;
-
-	case DEVIOCGDEVICEID:
-		return CDev::ioctl(nullptr, operation, arg);
-
-	default: {
-			ret = -EINVAL;
-		}
-	}
-
-	return ret;
 }
 
 int

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl_i2c.cpp
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl_i2c.cpp
@@ -65,15 +65,13 @@ class LIS3MDL_I2C : public device::I2C
 {
 public:
 	LIS3MDL_I2C(int bus);
-	virtual ~LIS3MDL_I2C();
+	virtual ~LIS3MDL_I2C() = default;
 
-	virtual int     init();
-	virtual int     ioctl(unsigned operation, unsigned &arg);
-	virtual int     read(unsigned address, void *data, unsigned count);
-	virtual int     write(unsigned address, void *data, unsigned count);
+	virtual int	read(unsigned address, void *data, unsigned count);
+	virtual int	write(unsigned address, void *data, unsigned count);
 
 protected:
-	virtual int     probe();
+	virtual int	probe();
 
 };
 
@@ -90,33 +88,6 @@ LIS3MDL_I2C::LIS3MDL_I2C(int bus) :
 	I2C("LIS3MDL_I2C", nullptr, bus, LIS3MDLL_ADDRESS, 400000)
 {
 	_device_id.devid_s.devtype = DRV_MAG_DEVTYPE_LIS3MDL;
-}
-
-LIS3MDL_I2C::~LIS3MDL_I2C()
-{
-}
-
-int
-LIS3MDL_I2C::init()
-{
-	/* this will call probe() */
-	return I2C::init();
-}
-
-int
-LIS3MDL_I2C::ioctl(unsigned operation, unsigned &arg)
-{
-	switch (operation) {
-
-	case MAGIOCGEXTERNAL:
-		return external();
-
-	case DEVIOCGDEVICEID:
-		return CDev::ioctl(nullptr, operation, arg);
-
-	default:
-		return  -EINVAL;
-	}
 }
 
 int

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl_spi.cpp
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl_spi.cpp
@@ -68,12 +68,11 @@ class LIS3MDL_SPI : public device::SPI
 {
 public:
 	LIS3MDL_SPI(int bus, uint32_t device);
-	virtual ~LIS3MDL_SPI();
+	virtual ~LIS3MDL_SPI() = default;
 
-	virtual int     init();
-	virtual int     ioctl(unsigned operation, unsigned &arg);
-	virtual int     read(unsigned address, void *data, unsigned count);
-	virtual int     write(unsigned address, void *data, unsigned count);
+	virtual int	init();
+	virtual int	read(unsigned address, void *data, unsigned count);
+	virtual int	write(unsigned address, void *data, unsigned count);
 };
 
 device::Device *
@@ -89,10 +88,6 @@ LIS3MDL_SPI::LIS3MDL_SPI(int bus, uint32_t device) :
 	SPI("LIS3MDL_SPI", nullptr, bus, device, SPIDEV_MODE3, 11 * 1000 * 1000 /* will be rounded to 10.4 MHz */)
 {
 	_device_id.devid_s.devtype = DRV_MAG_DEVTYPE_LIS3MDL;
-}
-
-LIS3MDL_SPI::~LIS3MDL_SPI()
-{
 }
 
 int
@@ -120,32 +115,6 @@ LIS3MDL_SPI::init()
 	}
 
 	return OK;
-}
-
-int
-LIS3MDL_SPI::ioctl(unsigned operation, unsigned &arg)
-{
-	int ret;
-
-	switch (operation) {
-
-	case MAGIOCGEXTERNAL:
-		/*
-		 * Even if this sensor is on the external SPI
-		 * bus it is still internal to the autopilot
-		 * assembly, so always return 0 for internal.
-		 */
-		return 0;
-
-	case DEVIOCGDEVICEID:
-		return CDev::ioctl(nullptr, operation, arg);
-
-	default: {
-			ret = -EINVAL;
-		}
-	}
-
-	return ret;
 }
 
 int

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -3267,7 +3267,7 @@ if_test(unsigned mode)
 	int result;
 
 	if (interface) {
-		result = interface->ioctl(1, mode); /* XXX magic numbers */
+		result = interface->test(1, mode); /* XXX magic numbers */
 		delete interface;
 
 	} else {

--- a/src/lib/drivers/device/CDev.cpp
+++ b/src/lib/drivers/device/CDev.cpp
@@ -120,12 +120,7 @@ CDev::init()
 {
 	DEVICE_DEBUG("CDev::init");
 
-	// base class init first
-	int ret = Device::init();
-
-	if (ret != PX4_OK) {
-		goto out;
-	}
+	int ret = PX4_ERROR;
 
 	// now register the driver
 	if (_devname != nullptr) {
@@ -255,7 +250,8 @@ CDev::ioctl(file_t *filep, int cmd, unsigned long arg)
 		break;
 
 	case DEVIOCGDEVICEID:
-		ret = (int)_device_id.devid;
+		// TODO: split CDev and Device
+		ret = get_device_id();
 		break;
 
 	default:

--- a/src/lib/drivers/device/CDev.cpp
+++ b/src/lib/drivers/device/CDev.cpp
@@ -56,7 +56,7 @@ CDev::CDev(const char *name, const char *devname) :
 	int ret = px4_sem_init(&_lock, 0, 1);
 
 	if (ret != 0) {
-		PX4_WARN("SEM INIT FAIL: ret %d", ret);
+		PX4_ERR("SEM INIT FAIL: ret %d", ret);
 	}
 }
 
@@ -120,7 +120,7 @@ CDev::init()
 {
 	DEVICE_DEBUG("CDev::init");
 
-	int ret = PX4_ERROR;
+	int ret = PX4_OK;
 
 	// now register the driver
 	if (_devname != nullptr) {
@@ -166,13 +166,6 @@ CDev::open(file_t *filep)
 }
 
 int
-CDev::open_first(file_t *filep)
-{
-	DEVICE_DEBUG("CDev::open_first");
-	return PX4_OK;
-}
-
-int
 CDev::close(file_t *filep)
 {
 	DEVICE_DEBUG("CDev::close");
@@ -196,34 +189,6 @@ CDev::close(file_t *filep)
 	unlock();
 
 	return ret;
-}
-
-int
-CDev::close_last(file_t *filep)
-{
-	DEVICE_DEBUG("CDev::close_last");
-	return PX4_OK;
-}
-
-ssize_t
-CDev::read(file_t *filep, char *buffer, size_t buflen)
-{
-	DEVICE_DEBUG("CDev::read");
-	return -ENOSYS;
-}
-
-ssize_t
-CDev::write(file_t *filep, const char *buffer, size_t buflen)
-{
-	DEVICE_DEBUG("CDev::write");
-	return -ENOSYS;
-}
-
-off_t
-CDev::seek(file_t *filep, off_t offset, int whence)
-{
-	DEVICE_DEBUG("CDev::seek");
-	return -ENOSYS;
 }
 
 int
@@ -346,21 +311,13 @@ CDev::poll_notify_one(px4_pollfd_struct_t *fds, pollevent_t events)
 	/* update the reported event set */
 	fds->revents |= fds->events & events;
 
-	DEVICE_DEBUG(" Events fds=%p %0x %0x %0x %d", fds, fds->revents, fds->events, events, value);
+	//DEVICE_DEBUG("Events fds=%p %0x %0x %0x %d", fds, fds->revents, fds->events, events, value);
 
 	/* if the state is now interesting, wake the waiter if it's still asleep */
 	/* XXX semcount check here is a vile hack; counting semphores should not be abused as cvars */
 	if ((fds->revents != 0) && (value <= 0)) {
 		px4_sem_post(fds->sem);
 	}
-}
-
-pollevent_t
-CDev::poll_state(file_t *filep)
-{
-	DEVICE_DEBUG("CDev::poll_notify");
-	/* by default, no poll events to report */
-	return 0;
 }
 
 int
@@ -416,7 +373,6 @@ CDev::remove_poll_waiter(px4_pollfd_struct_t *fds)
 
 			_pollset[i] = nullptr;
 			return PX4_OK;
-
 		}
 	}
 

--- a/src/lib/drivers/device/CDev.hpp
+++ b/src/lib/drivers/device/CDev.hpp
@@ -73,6 +73,12 @@ public:
 
 	virtual ~CDev();
 
+	// no copy, assignment, move, move assignment
+	CDev(const CDev &) = delete;
+	CDev &operator=(const CDev &) = delete;
+	CDev(CDev &&) = delete;
+	CDev &operator=(CDev &&) = delete;
+
 	virtual int	init();
 
 	/**
@@ -301,10 +307,6 @@ private:
 	 * @return		OK, or -errno on error.
 	 */
 	int		remove_poll_waiter(px4_pollfd_struct_t *fds);
-
-	/* do not allow copying this class */
-	CDev(const CDev &);
-	CDev operator=(const CDev &);
 };
 
 } // namespace device

--- a/src/lib/drivers/device/CDev.hpp
+++ b/src/lib/drivers/device/CDev.hpp
@@ -113,7 +113,7 @@ public:
 	 * @param buflen	The number of bytes to be read.
 	 * @return		The number of bytes read or -errno otherwise.
 	 */
-	virtual ssize_t	read(file_t *filep, char *buffer, size_t buflen);
+	virtual ssize_t	read(file_t *filep, char *buffer, size_t buflen) { return -ENOSYS; }
 
 	/**
 	 * Perform a write to the device.
@@ -125,7 +125,7 @@ public:
 	 * @param buflen	The number of bytes to be written.
 	 * @return		The number of bytes written or -errno otherwise.
 	 */
-	virtual ssize_t	write(file_t *filep, const char *buffer, size_t buflen);
+	virtual ssize_t	write(file_t *filep, const char *buffer, size_t buflen) { return -ENOSYS; }
 
 	/**
 	 * Perform a logical seek operation on the device.
@@ -137,7 +137,7 @@ public:
 	 * @param whence	SEEK_OFS, SEEK_CUR or SEEK_END.
 	 * @return		The previous offset, or -errno otherwise.
 	 */
-	virtual off_t	seek(file_t *filep, off_t offset, int whence);
+	virtual off_t	seek(file_t *filep, off_t offset, int whence) { return -ENOSYS; }
 
 	/**
 	 * Perform an ioctl operation on the device.
@@ -185,7 +185,7 @@ protected:
 	 * @param filep		The file that's interested.
 	 * @return		The current set of poll events.
 	 */
-	virtual pollevent_t poll_state(file_t *filep);
+	virtual pollevent_t poll_state(file_t *filep) { return 0; }
 
 	/**
 	 * Report new poll events.
@@ -216,7 +216,7 @@ protected:
 	 * @param filep		Pointer to the NuttX file structure.
 	 * @return		OK if the open should proceed, -errno otherwise.
 	 */
-	virtual int	open_first(file_t *filep);
+	virtual int	open_first(file_t *filep) { return PX4_OK; }
 
 	/**
 	 * Notification of the last close.
@@ -229,7 +229,7 @@ protected:
 	 * @param filep		Pointer to the NuttX file structure.
 	 * @return		OK if the open should return OK, -errno otherwise.
 	 */
-	virtual int	close_last(file_t *filep);
+	virtual int	close_last(file_t *filep) { return PX4_OK; }
 
 	/**
 	 * Register a class device name, automatically adding device

--- a/src/lib/drivers/device/Device.hpp
+++ b/src/lib/drivers/device/Device.hpp
@@ -104,22 +104,11 @@ public:
 	 */
 	virtual int	write(unsigned address, void *data, unsigned count) { return -ENODEV; }
 
-	/**
-	 * Perform a device-specific operation.
-	 *
-	 * @param operation	The operation to perform.
-	 * @param arg		An argument to the operation.
-	 * @return		Negative errno on error, OK or positive value on success.
-	 */
-	virtual int	ioctl(unsigned operation, unsigned &arg)
-	{
-		switch (operation) {
-		case DEVIOCGDEVICEID:
-			return get_device_id();
-		}
+	virtual int reset() { return PX4_OK; }
 
-		return -ENODEV;
-	}
+	virtual int test(unsigned arg1 = 0, unsigned arg2 = 0) { return PX4_ERROR; }
+
+	virtual int measure(unsigned address = 0) { return PX4_ERROR; }
 
 	/** Device bus types for DEVID */
 	enum DeviceBusType {
@@ -146,12 +135,7 @@ protected:
 	union DeviceId {
 		uint32_t devid;
 
-		/*
-		  broken out device elements. The bitfields are used to keep
-		  the overall value small enough to fit in a float accurately,
-		  which makes it possible to transport over the MAVLink
-		  parameter protocol without loss of information.
-		 */
+		// broken out device elements
 		struct DeviceStructure {
 			enum DeviceBusType bus_type : 3;
 			uint8_t bus: 5;    // which instance of the bus type

--- a/src/lib/drivers/device/nuttx/I2C.cpp
+++ b/src/lib/drivers/device/nuttx/I2C.cpp
@@ -56,10 +56,12 @@ I2C::I2C(const char *name, const char *devname, int bus, uint16_t address, uint3
 	_frequency(frequency)
 {
 	DEVICE_DEBUG("I2C::I2C name = %s devname = %s", name, devname);
+
 	// fill in _device_id fields for a I2C device
 	_device_id.devid_s.bus_type = DeviceBusType_I2C;
 	_device_id.devid_s.bus = bus;
 	_device_id.devid_s.address = address;
+
 	// devtype needs to be filled in by the driver
 	_device_id.devid_s.devtype = 0;
 }

--- a/src/lib/drivers/device/nuttx/I2C.hpp
+++ b/src/lib/drivers/device/nuttx/I2C.hpp
@@ -55,7 +55,7 @@ class __EXPORT I2C : public CDev
 
 public:
 
-	static int	set_bus_clock(unsigned bus, unsigned clock_hz);
+	static int		set_bus_clock(unsigned bus, unsigned clock_hz);
 
 	static unsigned	int	_bus_clocks[BOARD_NUMBER_I2C_BUSES];
 
@@ -75,7 +75,7 @@ protected:
 	 * @param address	I2C bus address, or zero if set_address will be used
 	 * @param frequency	I2C bus frequency for the device (currently not used)
 	 */
-	I2C(const char *name, const char *devname, int bus, uint16_t address, uint32_t frequency);
+	I2C(const char *name, const char *devname, int bus, uint16_t address, uint32_t frequency = 0);
 	virtual ~I2C();
 
 	virtual int	init();

--- a/src/lib/drivers/device/nuttx/SPI.cpp
+++ b/src/lib/drivers/device/nuttx/SPI.cpp
@@ -57,18 +57,9 @@
 namespace device
 {
 
-SPI::SPI(const char *name,
-	 const char *devname,
-	 int bus,
-	 uint32_t device,
-	 enum spi_mode_e mode,
-	 uint32_t frequency) :
-	// base class
+SPI::SPI(const char *name, const char *devname, int bus, uint32_t device, enum spi_mode_e mode, uint32_t frequency) :
 	CDev(name, devname),
-	// public
-	// protected
 	locking_mode(LOCK_PREEMPTION),
-	// private
 	_device(device),
 	_mode(mode),
 	_frequency(frequency),

--- a/src/lib/drivers/device/nuttx/SPI.hpp
+++ b/src/lib/drivers/device/nuttx/SPI.hpp
@@ -63,12 +63,8 @@ protected:
 	 * @param mode		SPI clock/data mode
 	 * @param frequency	SPI clock frequency
 	 */
-	SPI(const char *name,
-	    const char *devname,
-	    int bus,
-	    uint32_t device,
-	    enum spi_mode_e mode,
-	    uint32_t frequency);
+	SPI(const char *name, const char *devname, int bus, uint32_t device, enum spi_mode_e mode, uint32_t frequency);
+
 	virtual ~SPI();
 
 	/**
@@ -163,7 +159,7 @@ private:
 	SPI operator=(const SPI &);
 
 protected:
-	int	_transfer(uint8_t *send, uint8_t *recv, unsigned len);
+	int		_transfer(uint8_t *send, uint8_t *recv, unsigned len);
 
 	int	_transferhword(uint16_t *send, uint16_t *recv, unsigned len);
 

--- a/src/lib/drivers/device/posix/I2C.cpp
+++ b/src/lib/drivers/device/posix/I2C.cpp
@@ -63,10 +63,12 @@ I2C::I2C(const char *name, const char *devname, int bus, uint16_t address, uint3
 	CDev(name, devname)
 {
 	DEVICE_DEBUG("I2C::I2C name = %s devname = %s", name, devname);
+
 	// fill in _device_id fields for a I2C device
 	_device_id.devid_s.bus_type = DeviceBusType_I2C;
 	_device_id.devid_s.bus = bus;
 	_device_id.devid_s.address = address;
+
 	// devtype needs to be filled in by the driver
 	_device_id.devid_s.devtype = 0;
 }

--- a/src/modules/uORB/uORBDevices.cpp
+++ b/src/modules/uORB/uORBDevices.cpp
@@ -703,7 +703,7 @@ uORB::DeviceNode::update_deferred_trampoline(void *arg)
 }
 
 bool
-uORB::DeviceNode::print_statistics(bool reset)
+uORB::DeviceNode::print_statistics(bool should_reset)
 {
 	if (!_lost_messages) {
 		return false;
@@ -713,7 +713,7 @@ uORB::DeviceNode::print_statistics(bool reset)
 	//This can be wrong: if a reader never reads, _lost_messages will not be increased either
 	uint32_t lost_messages = _lost_messages;
 
-	if (reset) {
+	if (should_reset) {
 		_lost_messages = 0;
 	}
 
@@ -951,7 +951,7 @@ uORB::DeviceMaster::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 	}
 }
 
-void uORB::DeviceMaster::printStatistics(bool reset)
+void uORB::DeviceMaster::printStatistics(bool should_reset)
 {
 	hrt_abstime current_time = hrt_absolute_time();
 	PX4_INFO("Statistics, since last output (%i ms):",
@@ -965,7 +965,7 @@ void uORB::DeviceMaster::printStatistics(bool reset)
 	ITERATE_NODE_MAP() {
 		INIT_NODE_MAP_VARS(node, node_name)
 
-		if (node->print_statistics(reset)) {
+		if (node->print_statistics(should_reset)) {
 			had_print = true;
 		}
 	}

--- a/src/modules/uORB/uORBDevices.hpp
+++ b/src/modules/uORB/uORBDevices.hpp
@@ -174,10 +174,10 @@ public:
 
 	/**
 	 * Print statistics (nr of lost messages)
-	 * @param reset if true, reset statistics afterwards
+	 * @param should_reset if true, reset statistics afterwards
 	 * @return true if printed something, false otherwise (if no lost messages)
 	 */
-	bool print_statistics(bool reset);
+	bool print_statistics(bool should_reset);
 
 	unsigned int get_queue_size() const { return _queue_size; }
 	int16_t subscriber_count() const { return _subscriber_count; }
@@ -285,7 +285,7 @@ public:
 	 * Print statistics for each existing topic.
 	 * @param reset if true, reset statistics afterwards
 	 */
-	void printStatistics(bool reset);
+	void printStatistics(bool should_reset);
 
 	/**
 	 * Continuously print statistics, like the unix top command for processes.


### PR DESCRIPTION
This can wait until after v1.7.0.

Next step is to split CDev out of Device. Device is the base class for a physical device (eg i2c or spi sensor) with a bus, address, and unique id. There are many CDevs in the system (like all uORB topics) that aren't physical devices.

Additionally there are many device interfaces throughout common drivers like mpu6000, mpu9250, etc that don't need to be CDevs.