### PR TITLE
[DO NOT MERGE] FMU v5 voltage & current readout

### DIFF
--- a/src/drivers/boards/px4fmu-v5/board_config.h
+++ b/src/drivers/boards/px4fmu-v5/board_config.h
@@ -305,6 +305,12 @@
 	 (1 << ADC1_SPARE_1_CHANNEL))
 #endif
 
+/* Define Battery 1 Voltage Divider and A per V
+ */
+
+#define BOARD_BATTERY1_V_DIV         (10.177939394f)
+#define BOARD_BATTERY1_A_PER_V       (36.367515152f)
+
 /* HW has to large of R termination on ADC todo:change when HW value is chosen */
 
 #define BOARD_ADC_OPEN_CIRCUIT_V               (5.6f)

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -229,7 +229,7 @@ private:
 	 * @param raw			Combined sensor data structure into which
 	 *				data should be returned.
 	 */
-	void		adc_poll(struct sensor_combined_s &raw);
+	void		adc_poll();
 };
 
 Sensors::Sensors(bool hil_enabled) :
@@ -419,7 +419,7 @@ Sensors::parameter_update_poll(bool forced)
 }
 
 void
-Sensors::adc_poll(struct sensor_combined_s &raw)
+Sensors::adc_poll()
 {
 	/* only read if not in HIL mode */
 	if (_hil_enabled) {
@@ -668,7 +668,7 @@ Sensors::run()
 		_voted_sensors_update.sensors_poll(raw);
 
 		/* check battery voltage */
-		adc_poll(raw);
+		adc_poll();
 
 		diff_pres_poll(raw);
 


### PR DESCRIPTION
This adds the necessary board config defines for voltage & current readout.

**TODO**: the values are most likely not correct yet, they need to be adjusted according to the schematics. @LorenzMeier @davids5 

Also I'm not sure if it's the same value for both power inputs.