### PR TITLE
Add RTPS cmake config for AeroFC

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -597,7 +597,18 @@ then
 	fi
 	if param compare SYS_COMPANION 921600
 	then
-		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 921600 -m onboard -r 80000 -x -f
+		if ver hwcmp AEROFC_V1
+		then
+			if protocol_splitter start ${MAVLINK_COMPANION_DEVICE}
+			then
+				mavlink start -d /dev/mavlink -b 921600 -m onboard -r 5000 -x
+				micrortps_client start -d /dev/rtps -b 0 -l -1 -s 2000
+			else
+				 mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 921600 -m onboard -r 80000 -x -f
+			fi
+		else
+			mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 921600 -m onboard -r 80000 -x -f
+		fi
 	fi
 	if param compare SYS_COMPANION 57600
 	then

--- a/cmake/configs/nuttx_aerofc-v1_rtps.cmake
+++ b/cmake/configs/nuttx_aerofc-v1_rtps.cmake
@@ -1,0 +1,7 @@
+include(configs/nuttx_aerofc-v1_default)
+
+
+list(APPEND config_module_list
+	modules/micrortps_bridge
+	drivers/protocol_splitter
+)


### PR DESCRIPTION
Adding a seperate cmake config to support RTPS messaging on AeroFC. This will
include compiling protocol_splitter and micrortps_client, and starting both
of them at boot time.