### PR TITLE
Python import error: Recommend pip over apt-get

### DIFF
--- a/src/lib/mixer/geometries/tools/px_generate_mixers.py
+++ b/src/lib/mixer/geometries/tools/px_generate_mixers.py
@@ -46,11 +46,7 @@ except ImportError as e:
     print('''
 Required python packages not installed.
 
-On a Debian/Ubuntu system please run:
-
-  sudo apt-get install python-toml python-numpy
-
-On MacOS please run:
+On a GNU/Linux or MacOS system please run:
   sudo pip install numpy toml
 
 On Windows please run:


### PR DESCRIPTION
closes #8297

The package python-toml does not exist in older (<= 14.04) versions of ubuntu.