### PR TITLE
add killswitch (manual_lockdown) to Snapdragon uart ESC

### DIFF
--- a/src/platforms/qurt/fc_addon/uart_esc/uart_esc_main.cpp
+++ b/src/platforms/qurt/fc_addon/uart_esc/uart_esc_main.cpp
@@ -336,7 +336,7 @@ void task_main(int argc, char *argv[])
 				_outputs.timestamp = hrt_absolute_time();
 				int16_t motor_rpms[UART_ESC_MAX_MOTORS];
 
-				if (_armed.armed) {
+				if (_armed.armed && !_armed.lockdown && !_armed.manual_lockdown) {
 					_outputs.noutputs = mixer->mix(&_outputs.output[0], actuator_controls_s::NUM_ACTUATOR_CONTROLS);
 
 					// Make sure we support only up to UART_ESC_MAX_MOTORS motors


### PR DESCRIPTION
@santiago3dr Could you please test this on a Snapdragon with a Qualcomm ESC board?