### PR TITLE
Change the  compass calibration calculation

### DIFF
--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -821,9 +821,9 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 					mscale.x_offset = sphere_x[cur_mag];
 					mscale.y_offset = sphere_y[cur_mag];
 					mscale.z_offset = sphere_z[cur_mag];
-					mscale.x_scale = diag_x[cur_mag];
-					mscale.y_scale = diag_y[cur_mag];
-					mscale.z_scale = diag_z[cur_mag];
+					mscale.x_scale *= diag_x[cur_mag];
+					mscale.y_scale *= diag_y[cur_mag];
+					mscale.z_scale *= diag_z[cur_mag];
 
 #ifdef __PX4_NUTTX
 


### PR DESCRIPTION
"result = px4_ioctl (fd, MAGIOCCALIBRATE, fd);" This sentence will cause the compass driver to self-calibrate.
The driver program of hmc5883 compass  can self-calibration. This will change the scale factor of hmc5883 driver. Therefore, compass calibration input data may have been multiplied by a scale factor.So we have to consider that the scale factor in the driver might not be 1.0.
If mscale.*_scale is 1.0f, then it will not affect the calculation results. If mscale.*_scale is not 1.0, then take the scale of the driver into account.