### PR TITLE
RTL fix RTL_LAND_DELAY behaviour

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -254,7 +254,7 @@ RTL::set_rtl_item()
 			_mission_item.autocontinue = true;
 			_mission_item.origin = ORIGIN_ONBOARD;
 
-			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: land at home");
+			mavlink_log_critical(_navigator->get_mavlink_log_pub(), "RTL: land at home");
 			break;
 		}
 

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -48,6 +48,8 @@
 using math::max;
 using math::min;
 
+static constexpr float DELAY_SIGMA = 0.01f;
+
 RTL::RTL(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name),
 	_param_return_alt(this, "RTL_RETURN_ALT", false),
@@ -305,7 +307,7 @@ RTL::advance_rtl()
 	case RTL_STATE_DESCEND:
 
 		/* only go to land if autoland is enabled */
-		if (_param_land_delay.get() > FLT_EPSILON) {
+		if (_param_land_delay.get() < -DELAY_SIGMA || _param_land_delay.get() > DELAY_SIGMA) {
 			_rtl_state = RTL_STATE_LOITER;
 
 		} else {


### PR DESCRIPTION
Fixed wing test flight reported RTL ignoring the RTL_LAND_DELAY setting and landing immediately.
https://logs.px4.io/plot_app?log=c412160a-56e3-4154-b3d8-2c582aa9b9f1

This PR introduces a helper for float comparison, uses it to fix RTL_LAND_DELAY, and changes the RTL land notification to critical so that the user is alerted and the RTL state change is a little more obvious in logs.

Tested in SITL.

@santiago3dr 
