### PR TITLE
DO NOT MERGE: Mixer combination won't load successfully

### DIFF
--- a/ROMFS/px4fmu_common/mixers/blade130.main.mix
+++ b/ROMFS/px4fmu_common/mixers/blade130.main.mix
@@ -4,11 +4,16 @@ Blade 130x helicopter has longer servo arms left and right. The front servo arm 
 
 H: 3
 T:      0   3000   6000   8000  10000
-P:    500   1500   2500   3500   4500
+P: -10000  -5000      0   5000  10000
 # Swash plate servos:
 S:      0  10000  10000      0  -8000   8000
 S:    140  13054  10000      0  -8000   8000
 S:    220  13054  10000      0  -8000   8000
+
+# Tail servo:
+M: 1
+O:      10000  10000      0 -10000  10000
+S: 0 2  10000  10000      0 -10000  10000
 
 # Tail servo:
 M: 1

--- a/src/lib/mixer/mixer_helicopter.cpp
+++ b/src/lib/mixer/mixer_helicopter.cpp
@@ -90,22 +90,9 @@ HelicopterMixer::from_text(Mixer::ControlCallback control_cb, uintptr_t cb_handl
 	int s[5];
 	int used;
 
-	/* enforce that the mixer ends with space or a new line */
-	for (int i = buflen - 1; i >= 0; i--) {
-		if (buf[i] == '\0') {
-			continue;
-		}
-
-		/* require a space or newline at the end of the buffer, fail on printable chars */
-		if (buf[i] == ' ' || buf[i] == '\n' || buf[i] == '\r') {
-			/* found a line ending or space, so no split symbols / numbers. good. */
-			break;
-
-		} else {
-			debug("simple parser rejected: No newline / space at end of buf. (#%d/%d: 0x%02x)", i, buflen - 1, buf[i]);
-			return nullptr;
-		}
-
+	/* enforce that the mixer ends with a new line */
+	if (!string_well_formed(buf, buflen)) {
+		return nullptr;
 	}
 
 	if (sscanf(buf, "H: %u%n", &swash_plate_servo_count, &used) != 1) {


### PR DESCRIPTION
I found another mixer mixer combination that doesn't load and I haven't yet figured out why. The helicopter mixer was not using the global ```string_well_formed``` check but that didn't help. I modified the Blade mixer as an example of one combination which will not be loaded successfully. The loading doesn't give any error but IO will actually have no mixer present after boot.