### PR TITLE
Increase fixed-wing l1 navigation radius limit

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1644,7 +1644,7 @@ FixedwingPositionControl::task_main()
 				}
 
 				/* XXX check if radius makes sense here */
-				float turn_distance = _l1_control.switch_distance(100.0f);
+				float turn_distance = _l1_control.switch_distance(500.0f);
 
 				/* lazily publish navigation capabilities */
 				if ((hrt_elapsed_time(&_fw_pos_ctrl_status.timestamp) > 1000000)


### PR DESCRIPTION
@dagar have you never encountered an issue with this? I found this to be a problem for quite common fixed-wing setups already. As soon as we start to reduce max bank angles the turn radius will become 200m and more easily.

I wonder if the limit should be removed entirely.