### PR TITLE
Fix vulnerability in pre flight checks and failsafe

### DIFF
--- a/msg/estimator_status.msg
+++ b/msg/estimator_status.msg
@@ -97,3 +97,5 @@ uint16 solution_status_flags # Bitmask indicating which filter kinematic state o
 # 10 - True if the EKF has detected a GPS glitch
 
 float32 time_slip # cumulative amount of time in seconds that the EKF inertial calculation has slipped relative to system time
+
+bool pre_flt_fail # true when estimator has failed pre-flight checks and the vehicle should not be flown regardless of flight mode

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -502,6 +502,12 @@ static bool ekf2Check(orb_advert_t *mavlink_log_pub, bool optional, bool report_
 		goto out;
 	}
 
+	// Check if preflight check perfomred by estimator has failed
+	if (status.pre_flt_fail) {
+		success = false;
+		goto out;
+	}
+
 	// check vertical position innovation test ratio
 	param_get(param_find("COM_ARM_EKF_HGT"), &test_limit);
 	if (status.hgt_test_ratio > test_limit) {

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -789,9 +789,9 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool check
 	// only check EKF2 data if EKF2 is selected as the estimator and GNSS checking is enabled
 	int32_t estimator_type;
 	param_get(param_find("SYS_MC_EST_GROUP"), &estimator_type);
-	if (estimator_type == 2 && checkGNSS) {
+	if (estimator_type == 2) {
 		// don't fail if not using GPS for the first 20s after gaining 3D lock because quality checks take time to pass
-		bool enforce_gps_required = (_time_last_no_gps_lock > 20 * 1000000);
+		bool enforce_gps_required = (_time_last_no_gps_lock > 20 * 1000000) && checkGNSS;
 
 		if (!ekf2Check(mavlink_log_pub, true, reportFailures, enforce_gps_required)) {
 			failed = true;

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -121,6 +121,7 @@
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_status_flags.h>
 #include <uORB/topics/vtol_vehicle_status.h>
+#include <uORB/topics/estimator_status.h>
 
 typedef enum VEHICLE_MODE_FLAG
 {
@@ -1649,6 +1650,16 @@ int commander_thread_main(int argc, char *argv[])
 	memset(&vtol_status, 0, sizeof(vtol_status));
 	vtol_status.vtol_in_rw_mode = true;		//default for vtol is rotary wing
 
+	/* subscribe to estimator status topic */
+	int estimator_status_sub = orb_subscribe(ORB_ID(estimator_status));
+	struct estimator_status_s estimator_status;
+
+	/* class variables used to check for navigation failure after takeoff */
+	hrt_abstime time_at_takeoff = 0; // last time we were on the ground
+	hrt_abstime time_last_innov_pass = 0; // last time velocity innovations passed
+	bool nav_test_passed = false; // true if the post takeoff navigation test has passed
+	bool nav_test_failed = false; // true if the post takeoff navigation test has failed
+
 	int cpuload_sub = orb_subscribe(ORB_ID(cpuload));
 	memset(&cpuload, 0, sizeof(cpuload));
 
@@ -2158,11 +2169,59 @@ int commander_thread_main(int argc, char *argv[])
 			status_flags.condition_global_velocity_valid = false;
 		}
 
+		/* Check estimator status for signs of bad yaw induced post takeoff navigation failure
+		 * for a short time interval after takeoff. Fixed wing vehicles can recover using GPS heading,
+		 *  but rotary wing vehicles cannot so the position and velocity validity needs to be latched
+		 * to false after failure to prevent flyaway crashes */
+		if (run_quality_checks && status.is_rotary_wing) {
+			bool estimator_status_updated = false;
+			orb_check(estimator_status_sub, &estimator_status_updated);
+			if (estimator_status_updated) {
+				orb_copy(ORB_ID(estimator_status), estimator_status_sub, &estimator_status);
+
+				// record time of takeoff
+				if (land_detector.landed) {
+					time_at_takeoff = hrt_absolute_time();
+				} else {
+					// if nav status is unconfirmed, confirm yaw angle as passed after 30 seconds or achieving 5 m/s of speed
+					bool sufficient_time = (hrt_absolute_time() - time_at_takeoff > 30*1000*1000);
+					bool sufficient_speed = local_position.vx*local_position.vx + local_position.vy*local_position.vy > 25.0f;
+					bool innovation_pass = estimator_status.vel_test_ratio < 1.0f && estimator_status.pos_test_ratio < 1.0f;
+					if (!nav_test_failed) {
+						if (!nav_test_passed) {
+							// pass if sufficient time or speed
+							if (sufficient_time || sufficient_speed) {
+								nav_test_passed = true;
+							}
+
+							// record the last time the innovation check passed
+							if (innovation_pass) {
+								time_last_innov_pass = hrt_absolute_time();
+							}
+
+							// if the innovation test has failed continuously, declare the nav as failed
+							if ((hrt_absolute_time() - time_last_innov_pass) > 1000*1000) {
+								nav_test_failed = true;
+								mavlink_log_emergency(&mavlink_log_pub, "CRITICAL NAVIGATION FAILURE - CHECK SENSOR CALIBRATION");
+							}
+						}
+					}
+				}
+			}
+		}
+
 		/* run global position accuracy checks */
 		if (gpos_updated) {
 			if (run_quality_checks) {
-				check_posvel_validity(true, global_position.eph, eph_threshold, global_position.timestamp, &last_gpos_fail_time_us, &gpos_probation_time_us, &status_flags.condition_global_position_valid, &status_changed);
-				check_posvel_validity(true, global_position.evh, evh_threshold, global_position.timestamp, &last_gvel_fail_time_us, &gvel_probation_time_us, &status_flags.condition_global_velocity_valid, &status_changed);
+				// If nav is failed, then declare local position and velocity as invalid
+				if (nav_test_failed) {
+					status_flags.condition_global_position_valid = false;
+					status_flags.condition_global_velocity_valid = false;
+				} else {
+					// use global position message to determine validity
+					check_posvel_validity(true, global_position.eph, eph_threshold, global_position.timestamp, &last_gpos_fail_time_us, &gpos_probation_time_us, &status_flags.condition_global_position_valid, &status_changed);
+					check_posvel_validity(true, global_position.evh, evh_threshold, global_position.timestamp, &last_gvel_fail_time_us, &gvel_probation_time_us, &status_flags.condition_global_velocity_valid, &status_changed);
+				}
 			}
 		}
 
@@ -2175,8 +2234,15 @@ int commander_thread_main(int argc, char *argv[])
 			orb_copy(ORB_ID(vehicle_local_position), local_position_sub, &local_position);
 
 			if (run_quality_checks) {
-				check_posvel_validity(local_position.xy_valid, local_position.eph, eph_threshold, local_position.timestamp, &last_lpos_fail_time_us, &lpos_probation_time_us, &status_flags.condition_local_position_valid, &status_changed);
-				check_posvel_validity(local_position.v_xy_valid, local_position.evh, evh_threshold, local_position.timestamp, &last_lvel_fail_time_us, &lvel_probation_time_us, &status_flags.condition_local_velocity_valid, &status_changed);
+				// If nav is failed, then declare local position and velocity as invalid
+				if (nav_test_failed) {
+					status_flags.condition_local_position_valid = false;
+					status_flags.condition_local_velocity_valid = false;
+				} else {
+					// use local position message to determine validity
+					check_posvel_validity(local_position.xy_valid, local_position.eph, eph_threshold, local_position.timestamp, &last_lpos_fail_time_us, &lpos_probation_time_us, &status_flags.condition_local_position_valid, &status_changed);
+					check_posvel_validity(local_position.v_xy_valid, local_position.evh, evh_threshold, local_position.timestamp, &last_lvel_fail_time_us, &lvel_probation_time_us, &status_flags.condition_local_velocity_valid, &status_changed);
+				}
 			}
 		}
 

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2178,9 +2178,13 @@ int commander_thread_main(int argc, char *argv[])
 			orb_check(estimator_status_sub, &estimator_status_updated);
 			if (estimator_status_updated) {
 				orb_copy(ORB_ID(estimator_status), estimator_status_sub, &estimator_status);
-
-				// record time of takeoff
-				if (land_detector.landed) {
+				if (status.arming_state == vehicle_status_s::ARMING_STATE_STANDBY) {
+					// reset flags and timer
+					time_at_takeoff = hrt_absolute_time();
+					nav_test_failed = false;
+					nav_test_passed = false;
+				} else if (land_detector.landed) {
+					// record time of takeoff
 					time_at_takeoff = hrt_absolute_time();
 				} else {
 					// if nav status is unconfirmed, confirm yaw angle as passed after 30 seconds or achieving 5 m/s of speed

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -143,15 +143,21 @@ private:
 	float _last_valid_variance[3] = {};	///< variances for the last valid magnetometer XYZ bias estimates (mGauss**2)
 
 	// Used to filter velocity innovations during pre-flight checks
-	bool _vel_innov_preflt_fail = false;	///< true if the norm of the filtered innovation vector is too large before flight
-	Vector3f _vel_innov_lpf_ned = {};	///< Preflight low pass filtered velocity innovations (m/sec)
+	bool _preflt_horiz_fail = false;	///< true if preflight horizontal innovation checks are failed
+	bool _preflt_vert_fail = false;		///< true if preflight vertical innovation checks are failed
+	bool _preflt_fail = false;		///< true if any preflight innovation checks are failed
+	Vector2f _vel_ne_innov_lpf = {};	///< Preflight low pass filtered NE axis velocity innovations (m/sec)
+	float _vel_d_innov_lpf = {};		///< Preflight low pass filtered D axis velocity innovations (m/sec)
 	float _hgt_innov_lpf = 0.0f;		///< Preflight low pass filtered height innovation (m)
+	float _yaw_innov_magnitude_lpf = 0.0f;	///< Preflight low pass filtered yaw innovation magntitude (rad)
 
 	static constexpr float _innov_lpf_tau_inv = 0.2f;	///< Preflight low pass filter time constant inverse (1/sec)
 	static constexpr float _vel_innov_test_lim =
 		0.5f;	///< Maximum permissible velocity innovation to pass pre-flight checks (m/sec)
 	static constexpr float _hgt_innov_test_lim =
 		1.5f;	///< Maximum permissible height innovation to pass pre-flight checks (m)
+	static constexpr float _yaw_innov_test_lim =
+		0.25f;	///< Maximum permissible yaw innovation to pass pre-flight checks (rad)
 	const float _vel_innov_spike_lim = 2.0f * _vel_innov_test_lim;	///< preflight velocity innovation spike limit (m/sec)
 	const float _hgt_innov_spike_lim = 2.0f * _hgt_innov_test_lim;	///< preflight position innovation spike limit (m)
 
@@ -937,10 +943,10 @@ void Ekf2::run()
 			lpos.az = vel_deriv[2];
 
 			// TODO: better status reporting
-			lpos.xy_valid = _ekf.local_position_is_valid() && !_vel_innov_preflt_fail;
-			lpos.z_valid = !_vel_innov_preflt_fail;
-			lpos.v_xy_valid = _ekf.local_position_is_valid() && !_vel_innov_preflt_fail;
-			lpos.v_z_valid = !_vel_innov_preflt_fail;
+			lpos.xy_valid = _ekf.local_position_is_valid() && !_preflt_horiz_fail;
+			lpos.z_valid = !_preflt_vert_fail;
+			lpos.v_xy_valid = _ekf.local_position_is_valid() && !_preflt_horiz_fail;
+			lpos.v_z_valid = !_preflt_vert_fail;
 
 			// Position of local NED origin in GPS / WGS84 frame
 			map_projection_reference_s ekf_origin;
@@ -987,7 +993,7 @@ void Ekf2::run()
 			// publish vehicle local position data
 			_vehicle_local_position_pub.update();
 
-			if (_ekf.global_position_is_valid() && !_vel_innov_preflt_fail) {
+			if (_ekf.global_position_is_valid() && !_preflt_fail) {
 				// generate and publish global position data
 				vehicle_global_position_s &global_pos = _vehicle_global_position_pub.get();
 
@@ -1092,6 +1098,7 @@ void Ekf2::run()
 		_ekf.get_ekf_soln_status(&status.solution_status_flags);
 		_ekf.get_imu_vibe_metrics(status.vibe);
 		status.time_slip = _last_time_slip_us / 1e6f;
+		status.pre_flt_fail = _preflt_fail;
 
 		if (_estimator_status_pub == nullptr) {
 			_estimator_status_pub = orb_advertise(ORB_ID(estimator_status), &status);
@@ -1245,23 +1252,47 @@ void Ekf2::run()
 
 				// calculate noise filtered velocity innovations which are used for pre-flight checking
 				if (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_STANDBY) {
+					// calculate coefficients for LPF applied to innovation sequences
 					float alpha = constrain(sensors.accelerometer_integral_dt / 1.e6f * _innov_lpf_tau_inv, 0.0f, 1.0f);
 					float beta = 1.0f - alpha;
-					_vel_innov_lpf_ned(0) = beta * _vel_innov_lpf_ned(0) + alpha * constrain(innovations.vel_pos_innov[0],
-								-_vel_innov_spike_lim, _vel_innov_spike_lim);
-					_vel_innov_lpf_ned(1) = beta * _vel_innov_lpf_ned(1) + alpha * constrain(innovations.vel_pos_innov[1],
-								-_vel_innov_spike_lim, _vel_innov_spike_lim);
-					_vel_innov_lpf_ned(2) = beta * _vel_innov_lpf_ned(2) + alpha * constrain(innovations.vel_pos_innov[2],
-								-_vel_innov_spike_lim, _vel_innov_spike_lim);
+
+					// filter the velocity and innvovations
+					_vel_ne_innov_lpf(0) = beta * _vel_ne_innov_lpf(0) + alpha * constrain(innovations.vel_pos_innov[0],
+							       -_vel_innov_spike_lim, _vel_innov_spike_lim);
+					_vel_ne_innov_lpf(1) = beta * _vel_ne_innov_lpf(1) + alpha * constrain(innovations.vel_pos_innov[1],
+							       -_vel_innov_spike_lim, _vel_innov_spike_lim);
+					_vel_d_innov_lpf = beta * _vel_d_innov_lpf + alpha * constrain(innovations.vel_pos_innov[2],
+							   -_vel_innov_spike_lim, _vel_innov_spike_lim);
+
+					// filter the yaw innovations using a decaying envelope filter to prevent innovation sign changes due to angle wrapping allowinging large innvoations to pass checks after filtering.
+					_yaw_innov_magnitude_lpf = fmaxf(beta * _yaw_innov_magnitude_lpf,
+									 fminf(fabsf(innovations.heading_innov), 2.0f * _yaw_innov_test_lim));
+
 					_hgt_innov_lpf = beta * _hgt_innov_lpf + alpha * constrain(innovations.vel_pos_innov[5], -_hgt_innov_spike_lim,
 							 _hgt_innov_spike_lim);
-					_vel_innov_preflt_fail = ((_vel_innov_lpf_ned.norm() > _vel_innov_test_lim)
-								  || (fabsf(_hgt_innov_lpf) > _hgt_innov_test_lim));
+
+					// check the yaw and horizontal velocity innovations
+					float vel_ne_innov_length = sqrtf(innovations.vel_pos_innov[0] * innovations.vel_pos_innov[0] +
+									  innovations.vel_pos_innov[1] * innovations.vel_pos_innov[1]);
+					_preflt_horiz_fail = (_vel_ne_innov_lpf.norm() > _vel_innov_test_lim)
+							     || (vel_ne_innov_length > 2.0f * _vel_innov_test_lim)
+							     || (_yaw_innov_magnitude_lpf > _yaw_innov_test_lim);
+
+					// check the vertical velocity and position innovations
+					_preflt_vert_fail = (fabsf(_vel_d_innov_lpf) > _vel_innov_test_lim)
+							    || (fabsf(innovations.vel_pos_innov[2]) > 2.0f * _vel_innov_test_lim)
+							    || (fabsf(_hgt_innov_lpf) > _hgt_innov_test_lim);
+
+					// master pass-fail status
+					_preflt_fail = _preflt_horiz_fail || _preflt_vert_fail;
 
 				} else {
-					_vel_innov_lpf_ned.zero();
+					_vel_ne_innov_lpf.zero();
+					_vel_d_innov_lpf = 0.0f;
 					_hgt_innov_lpf = 0.0f;
-					_vel_innov_preflt_fail = false;
+					_preflt_horiz_fail = false;
+					_preflt_vert_fail = false;
+					_preflt_fail = false;
 				}
 
 				if (_estimator_innovations_pub == nullptr) {


### PR DESCRIPTION
The preflight checking of ekf2 health status as currently implemented in the commander has a two main vulnerabilities:

If GPS arming checks had been disabled via the COM_ARM_WO_GPS parameter, then this was also bypassing the ekf2 health checks.
The ekf2Check() function in the commander is only called once per mode change or arming request which means that the status is a snapshot of the EKF output and does not handle transient errors or noise well.
This PR improves the continuous ekf2 pre-arm checks and publishes the result as a boolean on the estimator_status message, which is then checked by the ekf2Check() function in the commander.
It also removes the bypass of ekf2Check()

Preflight checking changes:

- Separate the vertical and horizontal checks for use by local position validity reporting
- Add checking of yaw using a decaying envelope filter to the horizontal checks.
- Publish the check result to estimator_status topic.

Log from testing of preflight checks here: https://logs.px4.io/plot_app?log=1bc435b7-86e3-4c73-82a5-a98c77949a3d. A magnet was used to cause large changes in magnetic yaw and fail preflight checks whilst attempting to arm.

![screen shot 2017-11-27 at 1 29 43 pm](https://user-images.githubusercontent.com/3596952/33248223-073adfea-d378-11e7-85c6-472212894ea8.png)

If a RW vehicle takeoff off with a large yaw error, the EKF will start to reject the GPS data due to the inconsistency with the  INS solution. This combined with the position controller can cause an uncontrolled high speed flight condition. When this occurs, the EKF reports the navigation output as invalid, however after reset back to GPS, the navigation solution will be reported as valid again for a varying interval. This causes an interaction with the commander failsafe resulting in unpredictable transitions in and out of the failsafe mode. The solution implemented by https://github.com/PX4/Firmware/commit/39134325740a193fd755763e52faffe030073e5f

- Checks for loss of navigation for up to 30 seconds after takeoff or until  a horizontal speed of 5 m/s has been achieved.
- If the vehicle is not landed and the check is active, then the navigation is declared as failed if the velocity innovations fail for a continuous period of 1 second.
- This will cause the local and global position and velocity validity to be latched false to prevent unsafe use of position control modes.
- An emergency message 'CRITICAL NAVIGATION FAILURE - CHECK SENSOR CALIBRATION' is output to console and mavlink if the failsafe is activated.

Test log generated using SITL with  90 degree misaligned compass data here: https://logs.px4.io/plot_app?log=6aa3a650-a65a-499a-a4ed-9ab287e9e764