### PR TITLE
Stop parameter names from wrapping in markdown table

### DIFF
--- a/src/modules/systemlib/param/px4params/markdownout.py
+++ b/src/modules/systemlib/param/px4params/markdownout.py
@@ -18,7 +18,7 @@ class MarkdownTablesOutput():
                 result+='\nThe module where these parameters are defined is: *%s*.\n\n' %  list(scope_set)[0]
             
             
-            result += '<table style="width: 100%; table-layout:fixed; font-size:1.5rem;">\n'
+            result += '<table style="width: 100%; table-layout:fixed; font-size:1.5rem; overflow: auto; display:block;">\n'
             result += ' <colgroup><col style="width: 23%"><col style="width: 46%"><col style="width: 11%"><col style="width: 11%"><col style="width: 9%"></colgroup>\n'
             result += ' <thead>\n'
             result += '   <tr><th>Name</th><th>Description</th><th>Min > Max (Incr.)</th><th>Default</th><th>Units</th></tr>\n'
@@ -59,7 +59,7 @@ class MarkdownTablesOutput():
 
                 if name == code:
                     name = ""
-                code='<strong id="%s" style="white-space: nowrap;">%s</strong>' % (code, code)
+                code='<strong id="%s">%s</strong>' % (code, code)
 
                 if reboot_required:
                     reboot_required='<p><b>Reboot required:</b> %s</p>\n' % reboot_required

--- a/src/modules/systemlib/param/px4params/markdownout.py
+++ b/src/modules/systemlib/param/px4params/markdownout.py
@@ -59,7 +59,7 @@ class MarkdownTablesOutput():
 
                 if name == code:
                     name = ""
-                code='<strong id="%s">%s</strong>' % (code, code)
+                code='<strong id="%s" style="white-space: nowrap;">%s</strong>' % (code, code)
 
                 if reboot_required:
                     reboot_required='<p><b>Reboot required:</b> %s</p>\n' % reboot_required


### PR DESCRIPTION
@dagar As requested, this is all that is required to stop the titles wrapping.
BUT, I cannot test this since I can't work out how to invoke the script (it appears to have become more complicated???)
I tried `make parameters_metadata` but that failed as shown:
```
D:\Github\forks\px4\Firmware>make parameters_metadata
File not found - "*_sdflight_*"
FIND: Parameter format not correct
Warning: no parameters found
Creating markdown file parameters.md
FIND: Parameter format not correct
Warning: no parameters found
```
