### PR TITLE
vehicle command ROI: do not erroneously report command unsupported

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1195,6 +1195,8 @@ bool handle_command(struct vehicle_status_s *status_local, const struct safety_s
 	case vehicle_command_s::VEHICLE_CMD_LOGGING_START:
 	case vehicle_command_s::VEHICLE_CMD_LOGGING_STOP:
 	case vehicle_command_s::VEHICLE_CMD_NAV_DELAY:
+	case vehicle_command_s::VEHICLE_CMD_DO_SET_ROI:
+	case vehicle_command_s::VEHICLE_CMD_NAV_ROI:
 		/* ignore commands that are handled by other parts of the system */
 		break;
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -525,7 +525,8 @@ Navigator::task_main()
 				// TODO: handle responses for supported DO_CHANGE_SPEED options?
 				publish_vehicle_command_ack(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED);
 
-			} else if (cmd.command == vehicle_command_s::VEHICLE_CMD_DO_SET_ROI) {
+			} else if (cmd.command == vehicle_command_s::VEHICLE_CMD_DO_SET_ROI
+				   || cmd.command == vehicle_command_s::VEHICLE_CMD_NAV_ROI) {
 				_vroi = {};
 				_vroi.mode = cmd.param1;
 


### PR DESCRIPTION
and handle VEHICLE_CMD_DO_SET_ROI and VEHICLE_CMD_NAV_ROI identically

commander reports these commands to be unsupported even though they are handled by navigator.