### PR TITLE
Potential critical NuttX alignment issue in bss prophylactic fix.

### DIFF
--- a/nuttx-configs/aerocore2/scripts/ld.script
+++ b/nuttx-configs/aerocore2/scripts/ld.script
@@ -140,6 +140,7 @@ SECTIONS
 		*(.bss .bss.*)
 		*(.gnu.linkonce.b.*)
 		*(COMMON)
+		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
 	} > sram
 

--- a/nuttx-configs/aerofc-v1/scripts/ld.script
+++ b/nuttx-configs/aerofc-v1/scripts/ld.script
@@ -131,6 +131,7 @@ SECTIONS
 		*(.bss .bss.*)
 		*(.gnu.linkonce.b.*)
 		*(COMMON)
+		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
 	} > sram
 

--- a/nuttx-configs/auav-x21/scripts/ld.script
+++ b/nuttx-configs/auav-x21/scripts/ld.script
@@ -139,6 +139,7 @@ SECTIONS
 		*(.bss .bss.*)
 		*(.gnu.linkonce.b.*)
 		*(COMMON)
+		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
 	} > sram
 

--- a/nuttx-configs/crazyflie/scripts/ld.script
+++ b/nuttx-configs/crazyflie/scripts/ld.script
@@ -137,6 +137,7 @@ SECTIONS
 		*(.bss .bss.*)
 		*(.gnu.linkonce.b.*)
 		*(COMMON)
+		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
 	} > sram
 

--- a/nuttx-configs/esc35-v1/scripts/ld.script
+++ b/nuttx-configs/esc35-v1/scripts/ld.script
@@ -134,6 +134,7 @@ SECTIONS
     *(.bss .bss.*)
     *(.gnu.linkonce.b.*)
     *(COMMON)
+    . = ALIGN(4);
     _ebss = ABSOLUTE(.);
   } > sram
 

--- a/nuttx-configs/mindpx-v2/scripts/ld.script
+++ b/nuttx-configs/mindpx-v2/scripts/ld.script
@@ -139,6 +139,7 @@ SECTIONS
 		*(.bss .bss.*)
 		*(.gnu.linkonce.b.*)
 		*(COMMON)
+		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
 	} > sram
 

--- a/nuttx-configs/nxphlite-v3/scripts/ld.script
+++ b/nuttx-configs/nxphlite-v3/scripts/ld.script
@@ -141,6 +141,7 @@ SECTIONS
 		*(.bss .bss.*)
 		*(.gnu.linkonce.b.*)
 		*(COMMON)
+		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
 	} > datasram
 

--- a/nuttx-configs/px4-same70xplained-v1/scripts/flash-dtcm.ld
+++ b/nuttx-configs/px4-same70xplained-v1/scripts/flash-dtcm.ld
@@ -103,6 +103,7 @@ SECTIONS
 		*(.bss .bss.*)
 		*(.gnu.linkonce.b.*)
 		*(COMMON)
+		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
 	} > sram
 

--- a/nuttx-configs/px4-same70xplained-v1/scripts/flash-sram.ld
+++ b/nuttx-configs/px4-same70xplained-v1/scripts/flash-sram.ld
@@ -100,6 +100,7 @@ SECTIONS
 		*(.bss .bss.*)
 		*(.gnu.linkonce.b.*)
 		*(COMMON)
+		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
 	} > sram
 

--- a/nuttx-configs/px4-same70xplained-v1/scripts/ld.script
+++ b/nuttx-configs/px4-same70xplained-v1/scripts/ld.script
@@ -125,6 +125,7 @@ SECTIONS
 		*(.bss .bss.*)
 		*(.gnu.linkonce.b.*)
 		*(COMMON)
+		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
 	} > sram
 

--- a/nuttx-configs/px4-stm32f4discovery/scripts/ld.script
+++ b/nuttx-configs/px4-stm32f4discovery/scripts/ld.script
@@ -130,6 +130,7 @@ SECTIONS
 		*(.bss .bss.*)
 		*(.gnu.linkonce.b.*)
 		*(COMMON)
+		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
 	} > sram
 

--- a/nuttx-configs/px4cannode-v1/scripts/ld.script
+++ b/nuttx-configs/px4cannode-v1/scripts/ld.script
@@ -133,6 +133,7 @@ SECTIONS
     *(.bss .bss.*)
     *(.gnu.linkonce.b.*)
     *(COMMON)
+    . = ALIGN(4);
     _ebss = ABSOLUTE(.);
   } > sram
 

--- a/nuttx-configs/px4esc-v1/scripts/ld.script
+++ b/nuttx-configs/px4esc-v1/scripts/ld.script
@@ -135,6 +135,7 @@ SECTIONS
     *(.bss .bss.*)
     *(.gnu.linkonce.b.*)
     *(COMMON)
+    . = ALIGN(4);
     _ebss = ABSOLUTE(.);
   } > sram
 

--- a/nuttx-configs/px4flow-v2/scripts/ld.script
+++ b/nuttx-configs/px4flow-v2/scripts/ld.script
@@ -138,6 +138,7 @@ SECTIONS
     *(.bss .bss.*)
     *(.gnu.linkonce.b.*)
     *(COMMON)
+    . = ALIGN(4);
     _ebss = ABSOLUTE(.);
   } > sram
 

--- a/nuttx-configs/px4fmu-v2/scripts/ld.script
+++ b/nuttx-configs/px4fmu-v2/scripts/ld.script
@@ -140,6 +140,7 @@ SECTIONS
 		*(.bss .bss.*)
 		*(.gnu.linkonce.b.*)
 		*(COMMON)
+		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
 	} > sram
 

--- a/nuttx-configs/px4fmu-v2/scripts/ld_full.script
+++ b/nuttx-configs/px4fmu-v2/scripts/ld_full.script
@@ -139,6 +139,7 @@ SECTIONS
 		*(.bss .bss.*)
 		*(.gnu.linkonce.b.*)
 		*(COMMON)
+		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
 	} > sram
 

--- a/nuttx-configs/px4fmu-v4/scripts/ld.script
+++ b/nuttx-configs/px4fmu-v4/scripts/ld.script
@@ -139,6 +139,7 @@ SECTIONS
 		*(.bss .bss.*)
 		*(.gnu.linkonce.b.*)
 		*(COMMON)
+		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
 	} > sram
 

--- a/nuttx-configs/px4fmu-v4pro/scripts/ld.script
+++ b/nuttx-configs/px4fmu-v4pro/scripts/ld.script
@@ -139,6 +139,7 @@ SECTIONS
 		*(.bss .bss.*)
 		*(.gnu.linkonce.b.*)
 		*(COMMON)
+		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
 	} > sram
 

--- a/nuttx-configs/px4fmu-v5/scripts/ld.script
+++ b/nuttx-configs/px4fmu-v5/scripts/ld.script
@@ -163,6 +163,7 @@ SECTIONS
 		*(.bss .bss.*)
 		*(.gnu.linkonce.b.*)
 		*(COMMON)
+		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
 	} > sram1
 

--- a/nuttx-configs/px4io-v2/scripts/ld.script
+++ b/nuttx-configs/px4io-v2/scripts/ld.script
@@ -116,6 +116,7 @@ SECTIONS
 		*(.bss .bss.*)
 		*(.gnu.linkonce.b.*)
 		*(COMMON)
+		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
 	} > sram
 

--- a/nuttx-configs/px4nucleoF767ZI-v1/scripts/ld.script
+++ b/nuttx-configs/px4nucleoF767ZI-v1/scripts/ld.script
@@ -160,6 +160,7 @@ SECTIONS
 		*(.bss .bss.*)
 		*(.gnu.linkonce.b.*)
 		*(COMMON)
+		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
 	} > sram1
 

--- a/nuttx-configs/s2740vc-v1/scripts/ld.script
+++ b/nuttx-configs/s2740vc-v1/scripts/ld.script
@@ -122,6 +122,7 @@ SECTIONS
     *(.bss .bss.*)
     *(.gnu.linkonce.b.*)
     *(COMMON)
+    . = ALIGN(4);
     _ebss = ABSOLUTE(.);
   } > sram
 

--- a/nuttx-configs/tap-v1/scripts/ld.script
+++ b/nuttx-configs/tap-v1/scripts/ld.script
@@ -131,6 +131,7 @@ SECTIONS
 		*(.bss .bss.*)
 		*(.gnu.linkonce.b.*)
 		*(COMMON)
+		. = ALIGN(4);
 		_ebss = ABSOLUTE(.);
 	} > sram
 

--- a/nuttx-configs/zubaxgnss-v1/scripts/ld.script
+++ b/nuttx-configs/zubaxgnss-v1/scripts/ld.script
@@ -133,6 +133,7 @@ SECTIONS
     *(.bss .bss.*)
     *(.gnu.linkonce.b.*)
     *(COMMON)
+    . = ALIGN(4);
     _ebss = ABSOLUTE(.);
   } > sram
 


### PR DESCRIPTION
This resolves issue #8367 Potential critical NuttX alignment issue

The PX4 build did not have the issue as reported by @BazookaJoe1900 with his build.  


```
Without alignment 
20005b58 00000001 b g_nextmtdno
20005b5c 00000004 b g_pfirstmtd
20005b60 00000004 b g_pipecreated
20005b64 00000004 b g_pipeset
20005b68 A _ebss

$ make sizes
   text    data     bss     dec     hex filename
1025240    4050   19304 1048594  100012 build/px4fmu-v2_default/nuttx_px4fmu-v2_default.elf

ALIGN(16) - Prove it works :)
20005b60 00000004 b g_pipecreated
20005b64 00000004 b g_pipeset
20005b70 A _ebss
$ make sizes
   text    data     bss     dec     hex filename
1025240    4050   19312 1048602  10001a build/px4fmu-v2_default/nuttx_px4fmu-v2_default.elf


ALIGN(4) - As of this PR N.B. No change

20005b60 00000004 b g_pipecreated
20005b64 00000004 b g_pipeset
20005b68 A _ebss
02:11:18 {master *$=} ~/Desktop/dev/PX4/repos/mainline/Firmware$ make sizes
   text    data     bss     dec     hex filename
1025240    4050   19304 1048594  100012 build/px4fmu-v2_default/nuttx_px4fmu-v2_default.elf
  56500     560    2935   59995    ea5b build/px4io-v2_default/nuttx_px4io-v2_default.elf
02:11:
```