### PR TITLE
Updates & Fixes for Nxphlite-v3

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -120,7 +120,7 @@ then
 	fi
 fi
 
-if ver hwcmp MINDPX_V2 CRAZYFLIE AEROFC_V1 PX4FMU_V4
+if ver hwcmp MINDPX_V2 CRAZYFLIE AEROFC_V1 PX4FMU_V4 NXPHLITE_V3
 then
 	set MIXER_AUX none
 fi

--- a/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
+++ b/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
@@ -1393,9 +1393,7 @@ FXOS8701CQ::measure()
 	 * one device to the next
 	 */
 
-	write_checked_reg(FXOS8701CQ_M_CTRL_REG1, M_CTRL_REG1_HMS_A | M_CTRL_REG1_OS(7));
 	_last_temperature = (read_reg(FXOS8701CQ_TEMP)) * 0.96f;
-	write_checked_reg(FXOS8701CQ_M_CTRL_REG1, M_CTRL_REG1_HMS_AM | M_CTRL_REG1_OS(7));
 
 	accel_report.temperature = _last_temperature;
 

--- a/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
+++ b/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
@@ -1698,6 +1698,7 @@ void	start(bool external_bus, enum Rotation rotation, unsigned range);
 void	test();
 void	reset();
 void	info();
+void	stop();
 void	regdump();
 void	usage();
 void	test_error();
@@ -1941,6 +1942,20 @@ info()
 	exit(0);
 }
 
+void
+stop()
+{
+	if (g_dev == nullptr) {
+		PX4_ERR("driver not running\n");
+		exit(1);
+	}
+
+	delete g_dev;
+	g_dev = nullptr;
+
+	exit(0);
+}
+
 /**
  * dump registers from device
  */
@@ -1977,7 +1992,7 @@ test_error()
 void
 usage()
 {
-	PX4_INFO("missing command: try 'start', 'info', 'test', 'reset', 'testerror' or 'regdump'");
+	PX4_INFO("missing command: try 'start', 'info', 'stop', 'test', 'reset', 'testerror' or 'regdump'");
 	PX4_INFO("options:");
 	PX4_INFO("    -X    (external bus)");
 	PX4_INFO("    -R rotation");
@@ -2034,6 +2049,10 @@ fxos8701cq_main(int argc, char *argv[])
 		fxos8701cq::test();
 	}
 
+	if (!strcmp(verb, "stop")) {
+		fxos8701cq::stop();
+	}
+
 	/*
 	 * Reset the driver.
 	 */
@@ -2062,5 +2081,5 @@ fxos8701cq_main(int argc, char *argv[])
 		fxos8701cq::test_error();
 	}
 
-	errx(1, "unrecognized command, try 'start', 'test', 'reset', 'info', 'testerror' or 'regdump'");
+	errx(1, "unrecognized command, try 'start', 'stop', 'test', 'reset', 'info', 'testerror' or 'regdump'");
 }

--- a/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
+++ b/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
@@ -98,6 +98,7 @@
 #  define XYZ_DATA_CFG_FS_8G       (2 << XYZ_DATA_CFG_FS_SHIFTS)
 
 #define FXOS8701CQ_WHOAMI          0x0d
+#  define FXOS8700CQ_WHOAMI_VAL    0xC7
 #  define FXOS8701CQ_WHOAMI_VAL    0xCA
 
 #define FXOS8701CQ_CTRL_REG1       0x2a
@@ -670,10 +671,11 @@ int
 FXOS8701CQ::probe()
 {
 	/* verify that the device is attached and functioning */
-	bool success = (read_reg(FXOS8701CQ_WHOAMI) == FXOS8701CQ_WHOAMI_VAL);
+	uint8_t whoami = read_reg(FXOS8701CQ_WHOAMI);
+	bool success = (whoami == FXOS8700CQ_WHOAMI_VAL) || (whoami == FXOS8701CQ_WHOAMI_VAL);
 
 	if (success) {
-		_checked_values[0] = FXOS8701CQ_WHOAMI_VAL;
+		_checked_values[0] = whoami;
 		return OK;
 	}
 

--- a/src/drivers/kinetis/drv_hrt.c
+++ b/src/drivers/kinetis/drv_hrt.c
@@ -346,11 +346,6 @@ static void hrt_ppm_decode(uint32_t status)
 	uint16_t interval;
 	unsigned i;
 
-	/* if we missed an edge, we have to give up */
-	if (status & TPM_STATUS_TOF) {
-		goto error;
-	}
-
 	/* how long since the last edge? - this handles counter wrapping implicitly. */
 	width = count - ppm.last_edge;
 
@@ -510,7 +505,7 @@ hrt_tim_isr(int irq, void *context, void *arg)
 #ifdef HRT_PPM_CHANNEL
 
 	/* was this a PPM edge? */
-	if (status & (STATUS_PPM | TPM_STATUS_TOF)) {
+	if (status & (STATUS_PPM)) {
 		hrt_ppm_decode(status);
 	}
 

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1684,12 +1684,10 @@ PX4FMU::cycle()
 				px4_arch_configgpio(GPIO_PPM_IN);
 				rc_io_invert(false);
 
-			} else if (_rc_scan_locked
-				   || _cycle_timestamp - _rc_scan_begin < rc_scan_max) {
+			} else if (_rc_scan_locked || _cycle_timestamp - _rc_scan_begin < rc_scan_max) {
 
 				// see if we have new PPM input data
-				if ((ppm_last_valid_decode != _rc_in.timestamp_last_signal)
-				    && ppm_decoded_channels > 3) {
+				if ((ppm_last_valid_decode != _rc_in.timestamp_last_signal) && ppm_decoded_channels > 3) {
 					// we have a new PPM frame. Publish it.
 					rc_updated = true;
 					_rc_in.input_source = input_rc_s::RC_INPUT_SOURCE_PX4FMU_PPM;
@@ -1718,12 +1716,12 @@ PX4FMU::cycle()
 #ifdef HRT_PPM_CHANNEL
 
 		// see if we have new PPM input data
-		if ((ppm_last_valid_decode != _rc_in.timestamp_last_signal)
-		    && ppm_decoded_channels > 3) {
+		if ((ppm_last_valid_decode != _rc_in.timestamp_last_signal) && ppm_decoded_channels > 3) {
 			// we have a new PPM frame. Publish it.
 			rc_updated = true;
-			fill_rc_in(ppm_decoded_channels, ppm_buffer, hrt_absolute_time(),
-				   false, false, 0);
+			fill_rc_in(ppm_decoded_channels, ppm_buffer, _cycle_timestamp, false, false, 0);
+			_rc_in.rc_ppm_frame_length = ppm_frame_length;
+			_rc_in.timestamp_last_signal = ppm_last_valid_decode;
 		}
 
 #endif  // HRT_PPM_CHANNEL


### PR DESCRIPTION
From: https://github.com/PX4/Firmware/pull/8030

This is a WIP for the NXP flight V3 HW based on the K66. It builds but is incomplete as it is missing key Nuttx support in the Kinetis architecture.

The drivers/kinetis/\* is just stubbed out.  There is SPI, or DMA support

Missing Components
- [x]  FPU support in the OS
- [ ] DMA
- [x] SPI - Completed
- [ ] CAN
- [ ] VBAT - for bootloader app commnincation.
- [x] Timers PIT, LPTM, and FTM, PDB - for pwm, capture, tones, and hrt.
- [x] RESET up_systemreset(void) noreturn_function;
  
  Incomplete Drivers:
- [x] PWM supports only 1 chan per timer.
- [x] USB The K66 has 2 USB USB0 is FS (Nuttx has driver) USB1 is HS (No NuttX driver!) 
- [ ] UART lacking DMA kinetis_serial_dma_poll(void)
- [x] TERMIOS for serial
- [ ] RTC - up_rtc_getdatetime
- [ ] SDHC DMA disabled will not work with it yet

OS/System dependant SW
- [x] Cannot use FPU yet on kinetis
- [x] Termios
- [x] tcgetattr
- [x] tcsetattr
- [x] cfsetspeed

PX4 FMUV2 Modules removed from build due to No External SPI
- [ ] drivers/bma180
- [ ] drivers/bmi160
  
  NOT Portable YET
- [ ] /Firmware/src/modules/systemlib/mcu_version.c
- [ ] drivers/pwm_input
- [ ] drivers/test_ppm
- [ ] systemcmds/hardfault_log - needs bsram
- [ ] modules/uavcan
- [ ] uavcan
- [ ] uavcan_stm32_driver - need Kinetis CAN driver

PX4 Drivers Needing porting
- [ ] drivers/kinetis/*
- [ ] drv_hrt.c 
   - [x] HRT 
   - [x] PPM
- [ ] drv_input_capture.c
- [x] drv_io_timer.c
- [ ] drv_led_pwm.cpp
- [x] drv_pwm_servo.c
- [x] drivers/kinetis/adc
- [x] drivers/kinetis/tone_alarm
