### PR TITLE
micrortps_bridge: add optical_flow to the set of received topics

### DIFF
--- a/src/modules/micrortps_bridge/CMakeLists.txt
+++ b/src/modules/micrortps_bridge/CMakeLists.txt
@@ -46,6 +46,7 @@ set(config_rtps_send_topics
 
 set(config_rtps_receive_topics
    sensor_baro
+   optical_flow
    )
 
 if (FASTRTPSGEN AND (config_rtps_send_topics OR config_rtps_receive_topics))


### PR DESCRIPTION
Required for Optical Flow on the Aero via RTPS