### PR TITLE
mc_pos_control: set triplets to NAN if not in auto mode

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1803,7 +1803,7 @@ void MulticopterPositionControl::control_auto(float dt)
 			diff = fabsf(_curr_pos_sp(2) - curr_pos_sp(2));
 		}
 
-		if (diff > FLT_EPSILON) {
+		if (diff > FLT_EPSILON || !PX4_ISFINITE(diff)) {
 			triplet_updated = true;
 		}
 
@@ -2365,6 +2365,7 @@ MulticopterPositionControl::do_control(float dt)
 		 * have been updated */
 		_pos_sp_triplet.current.valid = false;
 		_pos_sp_triplet.previous.valid = false;
+		_curr_pos_sp = math::Vector<3>(NAN, NAN, NAN);
 
 		_hold_offboard_xy = false;
 		_hold_offboard_z = false;


### PR DESCRIPTION
In auto, the position controller uses a line from previous setpoint to current setpoint. Since previous setpoint is not always set in the navigator (which would be the correct solution) and the current setpoint updates continuously in mission due to yaw setpoints (which should be removed), the position controller uses a logic to set the current and previous setpoint. This logic depends on the diff between the current triplet and the internal stored position control triplet. Depending on the difference between internal and navigator triplet, the previous setpoint will be updated as well. 
In this PR, the internal position control triplet will be set to NAN. This ensures that the position controller knows when a new triplet in terms of lat/lon is sent out from the navigator.