### PR TITLE
Fix gcc7 warnings

### DIFF
--- a/nuttx-configs/PX4_Warnings.mk
+++ b/nuttx-configs/PX4_Warnings.mk
@@ -43,13 +43,16 @@ PX4_ARCHWARNINGS = -Wall \
                    -Wpointer-arith \
                    -Wshadow \
                    -Wno-sign-compare \
-                   -Wno-unused-parameter
-                   #-Wno-nonnull-compare \ # re-enable GCC >= 6
+                   -Wno-unused-parameter \
+                   -Wno-nonnull-compare \
+                   -Wno-implicit-fallthrough
                    #-Wno-misleading-indentation # re-enable GCC >= 6
 
-#   -Wcast-qual  - generates spurious noreturn attribute warnings, try again later
-#   -Wconversion - would be nice, but too many "risky-but-safe" conversions in the code
-#   -Wcast-align - would help catch bad casts in some cases, but generates too many false positives
+#   -Wimplicit-fallthrough - generates compilation errors with GCC >= 7
+#   -Wnonnull-compare      - generates compilation errors with GCC >= 7
+#   -Wcast-qual            - generates spurious noreturn attribute warnings, try again later
+#   -Wconversion           - would be nice, but too many "risky-but-safe" conversions in the code
+#   -Wcast-align           - would help catch bad casts in some cases, but generates too many false positives
 
 PX4_ARCHCWARNINGS = \
                    -Wbad-function-cast \

--- a/src/drivers/lis3mdl/lis3mdl_i2c.cpp
+++ b/src/drivers/lis3mdl/lis3mdl_i2c.cpp
@@ -114,6 +114,8 @@ LIS3MDL_I2C::ioctl(unsigned operation, unsigned &arg)
 	case MAGIOCGEXTERNAL:
 		external();
 
+	/* FALLTHROUGH */
+
 	case DEVIOCGDEVICEID:
 		return CDev::ioctl(nullptr, operation, arg);
 

--- a/src/drivers/mpu6000/mpu6000_spi.cpp
+++ b/src/drivers/mpu6000/mpu6000_spi.cpp
@@ -242,6 +242,8 @@ MPU6000_SPI::ioctl(unsigned operation, unsigned &arg)
 	case ACCELIOCGEXTERNAL:
 		external();
 
+	/* FALLTHROUGH */
+
 	case DEVIOCGDEVICEID:
 		return CDev::ioctl(nullptr, operation, arg);
 

--- a/src/drivers/mpu9250/mpu9250_spi.cpp
+++ b/src/drivers/mpu9250/mpu9250_spi.cpp
@@ -170,6 +170,8 @@ MPU9250_SPI::ioctl(unsigned operation, unsigned &arg)
 	case ACCELIOCGEXTERNAL:
 		external();
 
+	/* FALLTHROUGH */
+
 	case DEVIOCGDEVICEID:
 		return CDev::ioctl(nullptr, operation, arg);
 

--- a/src/drivers/protocol_splitter/protocol_splitter.cpp
+++ b/src/drivers/protocol_splitter/protocol_splitter.cpp
@@ -379,7 +379,8 @@ ssize_t Mavlink2Dev::write(struct file *filp, const char *buffer, size_t buflen)
 			return 0;
 		}
 
-	//no break
+	/* FALLTHROUGH */
+
 	case ParserState::GotLength: {
 			_packet_len -= buflen;
 			int buf_free;
@@ -509,8 +510,8 @@ ssize_t RtpsDev::write(struct file *filp, const char *buffer, size_t buflen)
 		_parser_state = ParserState::GotLength;
 		lock(Write);
 
+	/* FALLTHROUGH */
 
-	//no break
 	case ParserState::GotLength: {
 			_packet_len -= buflen;
 			int buf_free;


### PR DESCRIPTION
Build is broken on gcc7, because of the warnings -Wimplicit-fallthrough and -Wnonnull-compare.
This PR:
- fixes the gcc7-only warnings in PX4 codebase
- silences the gcc7-only warnings in NuttX codebase. As these warnings are not checked by NuttX developpers, it will be difficult to prevent them from reappearing. Other suggestions are welcome!

In order to test both posix and nuttx target with gcc7, I created an ArchLinux docker image: https://github.com/PX4/containers/pull/84

@dagar