### PR TITLE
Fix uncontrolled height gain in hold/loiter mode

### DIFF
--- a/msg/home_position.msg
+++ b/msg/home_position.msg
@@ -12,3 +12,6 @@ float32 yaw				# Yaw angle in radians
 float32 direction_x		# Takeoff direction in NED X
 float32 direction_y		# Takeoff direction in NED Y
 float32 direction_z		# Takeoff direction in NED Z
+
+bool valid_alt		# true when the altitude has been set
+bool valid_hpos		# true when the latitude and longitude have been set

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -138,6 +138,7 @@ BlockLocalPositionEstimator::BlockLocalPositionEstimator() :
 	// reference altitudes
 	_altOrigin(0),
 	_altOriginInitialized(false),
+	_altOriginGlobal(false),
 	_baroAltOrigin(0),
 	_gpsAltOrigin(0),
 
@@ -614,7 +615,7 @@ void BlockLocalPositionEstimator::publishLocalPos()
 
 		_pub_lpos.get().yaw = _eul(2);
 		_pub_lpos.get().xy_global = _estimatorInitialized & EST_XY;
-		_pub_lpos.get().z_global = !(_sensorTimeout & SENSOR_BARO);
+		_pub_lpos.get().z_global = !(_sensorTimeout & SENSOR_BARO) && _altOriginGlobal;
 		_pub_lpos.get().ref_timestamp = _time_origin;
 		_pub_lpos.get().ref_lat = _map_ref.lat_rad * 180 / M_PI;
 		_pub_lpos.get().ref_lon = _map_ref.lon_rad * 180 / M_PI;

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -365,6 +365,7 @@ private:
 	// reference altitudes
 	float _altOrigin;
 	bool _altOriginInitialized;
+	bool _altOriginGlobal; // true when the altitude of the origin is defined wrt a global reference frame
 	float _baroAltOrigin;
 	float _gpsAltOrigin;
 

--- a/src/modules/local_position_estimator/sensors/baro.cpp
+++ b/src/modules/local_position_estimator/sensors/baro.cpp
@@ -31,6 +31,7 @@ void BlockLocalPositionEstimator::baroInit()
 
 		if (!_altOriginInitialized) {
 			_altOriginInitialized = true;
+			_altOriginGlobal = false;
 			_altOrigin = _baroAltOrigin;
 		}
 	}

--- a/src/modules/local_position_estimator/sensors/gps.cpp
+++ b/src/modules/local_position_estimator/sensors/gps.cpp
@@ -73,6 +73,7 @@ void BlockLocalPositionEstimator::gpsInit()
 				// possible baro offset in global altitude at init
 				_altOrigin = _gpsAltOrigin;
 				_altOriginInitialized = true;
+				_altOriginGlobal = true;
 
 				mavlink_and_console_log_info(&mavlink_log_pub, "[lpe] global origin init (gps) : lat %6.2f lon %6.2f alt %5.1f m",
 							     gpsLatOrigin, gpsLonOrigin, double(_gpsAltOrigin));

--- a/src/modules/local_position_estimator/sensors/mocap.cpp
+++ b/src/modules/local_position_estimator/sensors/mocap.cpp
@@ -34,6 +34,7 @@ void BlockLocalPositionEstimator::mocapInit()
 
 		if (!_altOriginInitialized) {
 			_altOriginInitialized = true;
+			_altOriginGlobal = false;
 			_altOrigin = 0;
 		}
 	}

--- a/src/modules/local_position_estimator/sensors/vision.cpp
+++ b/src/modules/local_position_estimator/sensors/vision.cpp
@@ -48,6 +48,7 @@ void BlockLocalPositionEstimator::visionInit()
 
 		if (!_altOriginInitialized) {
 			_altOriginInitialized = true;
+			_altOriginGlobal = true;
 			_altOrigin = _sub_vision_pos.get().z_global ? _sub_vision_pos.get().ref_alt : 0.0f;
 		}
 	}

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -268,6 +268,7 @@ private:
 
 	struct map_projection_reference_s _ref_pos;
 	float _ref_alt;
+	bool _ref_alt_is_global; /** true when the reference altitude is defined in a global reference frame */
 	hrt_abstime _ref_timestamp;
 	hrt_abstime _last_warn;
 
@@ -458,6 +459,7 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_user_intention_xy(brake),
 	_user_intention_z(brake),
 	_ref_alt(0.0f),
+	_ref_alt_is_global(false),
 	_ref_timestamp(0),
 	_last_warn(0),
 	_yaw(0.0f),
@@ -849,13 +851,15 @@ MulticopterPositionControl::update_ref()
 	// normal state when the estimator origin is set. Changing reference point in flight causes large controller
 	// setpoint changes. Changing reference point in other arming states is untested and shoud not be performed.
 	if ((_local_pos.ref_timestamp != _ref_timestamp)
-	    && (_vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_STANDBY)) {
+	    && ((_vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_STANDBY)
+		|| (!_ref_alt_is_global && _local_pos.z_global))) {
 		double lat_sp, lon_sp;
 		float alt_sp = 0.0f;
 
 		if (_ref_timestamp != 0) {
 			// calculate current position setpoint in global frame
 			map_projection_reproject(&_ref_pos, _pos_sp(0), _pos_sp(1), &lat_sp, &lon_sp);
+
 			// the altitude setpoint is the reference altitude (Z up) plus the (Z down)
 			// NED setpoint, multiplied out to minus
 			alt_sp = _ref_alt - _pos_sp(2);
@@ -864,6 +868,10 @@ MulticopterPositionControl::update_ref()
 		// update local projection reference including altitude
 		map_projection_init(&_ref_pos, _local_pos.ref_lat, _local_pos.ref_lon);
 		_ref_alt = _local_pos.ref_alt;
+
+		if (_local_pos.z_global) {
+			_ref_alt_is_global = true;
+		}
 
 		if (_ref_timestamp != 0) {
 			// reproject position setpoint to new reference

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -150,7 +150,7 @@ public:
 
 	const vehicle_roi_s &get_vroi() { return _vroi; }
 
-	bool home_position_valid() { return (_home_pos.timestamp > 0); }
+	bool home_position_valid() { return (_home_pos.timestamp > 0 && _home_pos.valid_hpos && _home_pos.valid_alt); }
 
 	int		get_onboard_mission_sub() { return _onboard_mission_sub; }
 	int		get_offboard_mission_sub() { return _offboard_mission_sub; }


### PR DESCRIPTION
This fixes the height gain bug that occurs when using hold/loiter mode after taking off without GPS and gaining it's use in-flight. Reported by https://github.com/PX4/Firmware/issues/8400

It also fixes a bug causing the  height in the mavlink global position relative_alt message to be AMSL instead of height above takeoff location if GPS checks pass after takeoff.

The practice of allowing use of hold and position change commands via GCS inputs after a non-GPS takeoff has wider implications. In such a scenario, both RTL and geofencing are disabled, the user may not be aware of this, and unlike flying using stick inputs, it would be easy for the user to inadvertently fly the vehicle to a range where comms are lost or recovery using stick demands is impossible. 

This has been tested in SITL using the following procedure:

1) Modify the SITL startup script to inhibit GPS lock by adding 'gpssim set -t 0' at the end
2) Run 'make posix_sitl_default gazebo' and wait for the ekf to initialise
3) Select 'altitud'e mode on QGC, arm and takeoff using throttle stick
4) Enable GPS lock using 'gpssim set -t 3'
5) Wait for EKF GPS fusion to start
6) Select 'hold' mode on QGC and command a positive altitude change using the slider and confirm completion
7) Command a position change on QGC using the 'fly to click' feature and confirm completion
8) Command a negative altitude change using the slider and confirm completion
9) Command  a landing at current location.

Log file here: https://logs.px4.io/plot_app?log=afea809a-e7fe-463c-bfe7-ef6296064330