### PR TITLE
[WIP] Jenkins: build posix_sitl_default and nuttx_px4fmu-v5_default under Archlinux (GCC7)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,7 +119,7 @@ pipeline {
             builds["${node_name} (GCC7)"] = {
               node {
                 stage("Build Test ${node_name} (GCC7)") {
-                  docker.image('px4io/px4-dev-base-archlinux:2017-12-06').inside("--env CCACHE_DIR=/tmp/ccache --volume=/tmp/ccache:/tmp/ccache:rw --env CI=true") {
+                  docker.image('px4io/px4-dev-base-archlinux:pr-archlinux').inside("--env CCACHE_DIR=/tmp/ccache --volume=/tmp/ccache:/tmp/ccache:rw --env CI=true") {
                     stage("${node_name}") {
                       checkout scm
                       sh "make clean"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,7 +119,7 @@ pipeline {
             builds["${node_name} (GCC7)"] = {
               node {
                 stage("Build Test ${node_name} (GCC7)") {
-                  docker.image('px4io/px4-dev-base-archlinux:pr-archlinux').inside("--env CCACHE_DIR=/tmp/ccache --volume=/tmp/ccache:/tmp/ccache:rw --env CI=true") {
+                  docker.image('px4io/px4-dev-base-archlinux:2017-12-08').inside("--env CCACHE_DIR=/tmp/ccache --volume=/tmp/ccache:/tmp/ccache:rw --env CI=true") {
                     stage("${node_name}") {
                       checkout scm
                       sh "make clean"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,6 +112,26 @@ pipeline {
             }
           }
 
+          // GCC7 tests
+          for (def option in ["posix_sitl_default", "nuttx_px4fmu-v5_default"]) {
+            def node_name = "${option}"
+
+            builds["${node_name} (GCC7)"] = {
+              node {
+                stage("Build Test ${node_name} (GCC7)") {
+                  docker.image('px4io/px4-dev-base-archlinux:2017-12-06').inside("--env CCACHE_DIR=/tmp/ccache --volume=/tmp/ccache:/tmp/ccache:rw --env CI=true") {
+                    stage("${node_name}") {
+                      checkout scm
+                      sh "make clean"
+                      sh "make ${node_name}"
+                      sh "ccache -s"
+                    }
+                  }
+                }
+              }
+            }
+          }
+
           parallel builds
         }
       }


### PR DESCRIPTION
This will prevent issues like #8417 in the future.

I added build tests under an ArchLinux docker image which brings newer versions of GCC (currently gcc and arm-none-eabi-gcc 7.2.0). The targets are *posix_sitl_default* and *nuttx_px4fmu-v5_default*, feel free to indicate better ones.

Do not merge until DockerHub is ready: https://hub.docker.com/r/px4io/px4-dev-base-archlinux/builds/.
