### PR TITLE
ekf2: relax preflight yaw check when possible

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -162,7 +162,6 @@ private:
 		0.52f;	///< Maximum permissible yaw innovation to pass pre-flight checks when not aiding inertial nav using NE frame observations (rad)
 	const float _vel_innov_spike_lim = 2.0f * _vel_innov_test_lim;	///< preflight velocity innovation spike limit (m/sec)
 	const float _hgt_innov_spike_lim = 2.0f * _hgt_innov_test_lim;	///< preflight position innovation spike limit (m)
-	filter_control_status_u _ekf_control_mask; ///< Integer mask used by ekf control status
 
 	orb_advert_t _att_pub{nullptr};
 	orb_advert_t _wind_pub{nullptr};
@@ -1269,9 +1268,11 @@ void Ekf2::run()
 
 					// set the max allowed yaw innovaton depending on whether we are not aiding navigation using
 					// observations in the NE reference frame.
-					float yaw_test_limit;
+					filter_control_status_u _ekf_control_mask;
 					_ekf.get_control_mode(&_ekf_control_mask.value);
 					bool doing_ne_aiding = _ekf_control_mask.flags.gps ||  _ekf_control_mask.flags.ev_pos;
+
+					float yaw_test_limit;
 
 					if (doing_ne_aiding) {
 						// use a smaller tolerance when doing NE inertial frame aiding

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -159,7 +159,7 @@ private:
 	static constexpr float _nav_yaw_innov_test_lim =
 		0.25f;	///< Maximum permissible yaw innovation to pass pre-flight checks when aiding inertial nav using NE frame observations (rad)
 	static constexpr float _yaw_innov_test_lim =
-		1.0f;	///< Maximum permissible yaw innovation to pass pre-flight checks when not aiding inertial nav using NE frame observations (rad)
+		0.52f;	///< Maximum permissible yaw innovation to pass pre-flight checks when not aiding inertial nav using NE frame observations (rad)
 	const float _vel_innov_spike_lim = 2.0f * _vel_innov_test_lim;	///< preflight velocity innovation spike limit (m/sec)
 	const float _hgt_innov_spike_lim = 2.0f * _hgt_innov_test_lim;	///< preflight position innovation spike limit (m)
 	filter_control_status_u _ekf_control_mask; ///< Integer mask used by ekf control status
@@ -1272,6 +1272,7 @@ void Ekf2::run()
 					float yaw_test_limit;
 					_ekf.get_control_mode(&_ekf_control_mask.value);
 					bool doing_ne_aiding = _ekf_control_mask.flags.gps ||  _ekf_control_mask.flags.ev_pos;
+
 					if (doing_ne_aiding) {
 						// use a smaller tolerance when doing NE inertial frame aiding
 						yaw_test_limit = _nav_yaw_innov_test_lim;


### PR DESCRIPTION
When the EKF is not fusing in position or velocity observations in a global reference frame to constrain navigation errors, the tolerance to yaw errors is much higher. Examples of this include operation using only optical flow (which is in body frame) or operation without aiding where only attitude and height is estimated.

These changes will help reduce false triggering associated with indoor operation where magnetic interference and anomaly levels are high.