### PR TITLE
Param Save Improvements

### DIFF
--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -62,7 +62,6 @@ FixedwingLandDetector::FixedwingLandDetector()
 
 void FixedwingLandDetector::_initialize_topics()
 {
-	_armingSub = orb_subscribe(ORB_ID(actuator_armed));
 	_airspeedSub = orb_subscribe(ORB_ID(airspeed));
 	_local_pos_sub = orb_subscribe(ORB_ID(vehicle_local_position));
 	_sensor_bias_sub = orb_subscribe(ORB_ID(sensor_bias));
@@ -70,7 +69,6 @@ void FixedwingLandDetector::_initialize_topics()
 
 void FixedwingLandDetector::_update_topics()
 {
-	_orb_update(ORB_ID(actuator_armed), _armingSub, &_arming);
 	_orb_update(ORB_ID(airspeed), _airspeedSub, &_airspeed);
 	_orb_update(ORB_ID(sensor_bias), _sensor_bias_sub, &_sensors);
 	_orb_update(ORB_ID(vehicle_local_position), _local_pos_sub, &_local_pos);

--- a/src/modules/land_detector/FixedwingLandDetector.h
+++ b/src/modules/land_detector/FixedwingLandDetector.h
@@ -42,7 +42,6 @@
 
 #pragma once
 
-#include <uORB/topics/actuator_armed.h>
 #include <uORB/topics/airspeed.h>
 #include <uORB/topics/sensor_bias.h>
 #include <uORB/topics/vehicle_local_position.h>
@@ -86,12 +85,10 @@ private:
 		float maxIntVelocity;
 	} _params{};
 
-	int _armingSub{-1};
 	int _airspeedSub{-1};
 	int _sensor_bias_sub{-1};
 	int _local_pos_sub{-1};
 
-	actuator_armed_s _arming{};
 	airspeed_s _airspeed{};
 	sensor_bias_s _sensors{};
 	vehicle_local_position_s _local_pos{};

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -48,6 +48,7 @@
 #include <systemlib/param/param.h>
 #include <systemlib/perf_counter.h>
 #include <uORB/uORB.h>
+#include <uORB/topics/actuator_armed.h>
 #include <uORB/topics/vehicle_land_detected.h>
 
 namespace land_detector
@@ -150,6 +151,7 @@ protected:
 	vehicle_land_detected_s _landDetected{};
 
 	int _parameterSub{-1};
+	int _armingSub{-1};
 
 	LandDetectionState _state{LandDetectionState::LANDED};
 
@@ -157,6 +159,8 @@ protected:
 	systemlib::Hysteresis _landed_hysteresis{true};
 	systemlib::Hysteresis _maybe_landed_hysteresis{true};
 	systemlib::Hysteresis _ground_contact_hysteresis{true};
+
+	struct actuator_armed_s	_arming {};
 
 private:
 	static void _cycle_trampoline(void *arg);
@@ -175,6 +179,8 @@ private:
 	struct work_s	_work {};
 
 	perf_counter_t	_cycle_perf;
+
+	bool _previous_arming_state{false}; ///< stores the previous _arming.armed state
 };
 
 

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -77,7 +77,6 @@ MulticopterLandDetector::MulticopterLandDetector() :
 	_vehicleLocalPositionSub(-1),
 	_vehicleLocalPositionSetpointSub(-1),
 	_actuatorsSub(-1),
-	_armingSub(-1),
 	_attitudeSub(-1),
 	_sensor_bias_sub(-1),
 	_vehicle_control_mode_sub(-1),
@@ -85,7 +84,6 @@ MulticopterLandDetector::MulticopterLandDetector() :
 	_vehicleLocalPosition{},
 	_vehicleLocalPositionSetpoint{},
 	_actuators{},
-	_arming{},
 	_vehicleAttitude{},
 	_sensors{},
 	_control_mode{},
@@ -113,12 +111,11 @@ MulticopterLandDetector::MulticopterLandDetector() :
 
 void MulticopterLandDetector::_initialize_topics()
 {
-	// subscribe to position, attitude, arming and velocity changes
+	// subscribe to position, attitude and velocity changes
 	_vehicleLocalPositionSub = orb_subscribe(ORB_ID(vehicle_local_position));
 	_vehicleLocalPositionSetpointSub = orb_subscribe(ORB_ID(vehicle_local_position_setpoint));
 	_attitudeSub = orb_subscribe(ORB_ID(vehicle_attitude));
 	_actuatorsSub = orb_subscribe(ORB_ID(actuator_controls_0));
-	_armingSub = orb_subscribe(ORB_ID(actuator_armed));
 	_parameterSub = orb_subscribe(ORB_ID(parameter_update));
 	_sensor_bias_sub = orb_subscribe(ORB_ID(sensor_bias));
 	_vehicle_control_mode_sub = orb_subscribe(ORB_ID(vehicle_control_mode));
@@ -131,7 +128,6 @@ void MulticopterLandDetector::_update_topics()
 	_orb_update(ORB_ID(vehicle_local_position_setpoint), _vehicleLocalPositionSetpointSub, &_vehicleLocalPositionSetpoint);
 	_orb_update(ORB_ID(vehicle_attitude), _attitudeSub, &_vehicleAttitude);
 	_orb_update(ORB_ID(actuator_controls_0), _actuatorsSub, &_actuators);
-	_orb_update(ORB_ID(actuator_armed), _armingSub, &_arming);
 	_orb_update(ORB_ID(sensor_bias), _sensor_bias_sub, &_sensors);
 	_orb_update(ORB_ID(vehicle_control_mode), _vehicle_control_mode_sub, &_control_mode);
 	_orb_update(ORB_ID(battery_status), _battery_sub, &_battery);

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -49,7 +49,6 @@
 #include <uORB/topics/vehicle_local_position_setpoint.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/actuator_controls.h>
-#include <uORB/topics/actuator_armed.h>
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/parameter_update.h>
@@ -130,7 +129,6 @@ private:
 	int _vehicleLocalPositionSub;
 	int _vehicleLocalPositionSetpointSub;
 	int _actuatorsSub;
-	int _armingSub;
 	int _attitudeSub;
 	int _sensor_bias_sub;
 	int _vehicle_control_mode_sub;
@@ -139,7 +137,6 @@ private:
 	struct vehicle_local_position_s				_vehicleLocalPosition;
 	struct vehicle_local_position_setpoint_s	_vehicleLocalPositionSetpoint;
 	struct actuator_controls_s					_actuators;
-	struct actuator_armed_s						_arming;
 	struct vehicle_attitude_s					_vehicleAttitude;
 	struct sensor_bias_s					_sensors;
 	struct vehicle_control_mode_s				_control_mode;

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1005,9 +1005,10 @@ void Logger::run()
 			bool data_written = false;
 
 			/* Check if parameters have changed */
-			// this needs to change to a timestamped record to record a history of parameter changes
-			if (parameter_update_sub.update()) {
-				write_changed_parameters();
+			if (!_should_stop_file_log) { // do not record param changes after disarming
+				if (parameter_update_sub.update()) {
+					write_changed_parameters();
+				}
 			}
 
 			/* wait for lock on log buffer */


### PR DESCRIPTION
First commit is more preventive (see commit message), the second is:

Before 0c34e89, different modules (ekf2, commander & land detector) changed
params upon different events:
- ekf2 & commander set params after disarm
- land detector set params on land detected

If the 2 events were several 100ms appart, it led to 2 param saves, and
the latter param set could have been blocked by an ongoing save. And if
the land detector was blocked, it could lead to mag timeouts.

This patch makes all modules use the same event, thus only a single param
save will happen.

If we want to have guarantees to never block, we should introduce a `param_try_set()` API method. The solution in this PR is less invasive, and thus better suited for the release.