### PR TITLE
load_mon: remove usage of CONFIG_RAM_SIZE

### DIFF
--- a/src/modules/load_mon/load_mon.cpp
+++ b/src/modules/load_mon/load_mon.cpp
@@ -246,14 +246,7 @@ float LoadMon::_ram_used()
 	// mem.fordblks: free (bytes)
 	// mem.mxordblk: largest remaining block (bytes)
 
-	float load = (float)mem.uordblks / mem.arena;
-
-	// Check for corruption of the allocation counters
-	if ((mem.arena > CONFIG_RAM_SIZE) || (mem.fordblks > CONFIG_RAM_SIZE)) {
-		load = 1.0f;
-	}
-
-	return load;
+	return (float)mem.uordblks / mem.arena;
 #else
 	return 0.0f;
 #endif


### PR DESCRIPTION
The define should not be used, as it might be wrong.
This is the case on fmu-v5, which meant that the used RAM was always 1.

It is one step towards  #6481 (there are no other usages of CONFIG_RAM_SIZE in the codebase), and fixes the RAM usage always being 1 in logs from fmu-v5.

@simonegu 