### PR TITLE
cmake add git submodule replace . in target name

### DIFF
--- a/cmake/common/px4_git.cmake
+++ b/cmake/common/px4_git.cmake
@@ -73,6 +73,7 @@ function(px4_add_git_submodule)
 			)
 
 	string(REPLACE "/" "_" NAME ${PATH})
+	string(REPLACE "." "_" NAME ${NAME})
 
 	add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/git_init_${NAME}.stamp
 		COMMAND bash ${PX4_SOURCE_DIR}/Tools/check_submodules.sh ${PATH}


### PR DESCRIPTION
Removing the period from the target name (eg mavlink/include/mavlink/v1.0).