### PR TITLE
commander: Fix pre-flight delta velocity bias check level

### DIFF
--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -543,16 +543,17 @@ PARAM_DEFINE_FLOAT(COM_ARM_EKF_HGT, 1.0f);
 PARAM_DEFINE_FLOAT(COM_ARM_EKF_YAW, 0.5f);
 
 /**
- * Maximum value of EKF accelerometer delta velocity bias estimate that will allow arming
+ * Maximum value of EKF accelerometer delta velocity bias estimate that will allow arming.
+ * Note: ekf2 will limit the delta velocity bias estimate magnitude to be less than EKF2_ABL_LIM * FILTER_UPDATE_PERIOD_MS * 0.001 so this parameter must be less than that to be useful.
  *
  * @group Commander
  * @unit m/s
  * @min 0.001
  * @max 0.01
  * @decimal 4
- * @increment 0.0005
+ * @increment 0.0001
  */
-PARAM_DEFINE_FLOAT(COM_ARM_EKF_AB, 5.0e-3f);
+PARAM_DEFINE_FLOAT(COM_ARM_EKF_AB, 2.4e-3f);
 
 /**
  * Maximum value of EKF gyro delta angle bias estimate that will allow arming


### PR DESCRIPTION
Previous check level was less than the max achievable by the estimator using current default parameters making the check ineffective. 

Raised in response to log https://review.px4.io/plot_app?log=f619bcb1-7427-4619-86d6-bc53e5e2024e discussed in this issue: https://github.com/PX4/Firmware/issues/7202#issuecomment-300754802

Current ekf2 internal prediction time step is 8 msec and the default value of EKF2_ABL_LIM is 0.4 m/s/s, so the maximum delta velocity bias estimate output by the EKFis will clip at 3.2E-3 m/s using current parameter defaults. The pre flight check level has been updated to 3/4 that value (an equivalent accel bias of 0.3 m/s/s