### PR TITLE
Jenkins remove fast fail

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -207,7 +207,6 @@ pipeline {
             }
           }
 
-          builds.failFast = true
           parallel builds
         }
       }


### PR DESCRIPTION
This saves build resources, but makes finding the actual failure rather hard (with the current blue ocean gui).