### PR TITLE
move baro altitude calculation to sensors

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -110,6 +110,7 @@ set(msg_files
 	uavcan_parameter_value.msg
 	ulog_stream.msg
 	ulog_stream_ack.msg
+	vehicle_air_data.msg
 	vehicle_attitude.msg
 	vehicle_attitude_setpoint.msg
 	vehicle_command.msg
@@ -120,6 +121,7 @@ set(msg_files
 	vehicle_land_detected.msg
 	vehicle_local_position.msg
 	vehicle_local_position_setpoint.msg
+	vehicle_magnetometer.msg
 	vehicle_rates_setpoint.msg
 	vehicle_roi.msg
 	vehicle_status.msg

--- a/msg/ekf2_timestamps.msg
+++ b/msg/ekf2_timestamps.msg
@@ -12,13 +12,14 @@ int16 RELATIVE_TIMESTAMP_INVALID = 32767 # (0x7fff) If one of the relative times
 # *_timestamp_rel = absolute timestamp). For int16, this allows a maximum
 # difference of +-3.2s to the sensor_combined topic.
 
-
+int16 airspeed_timestamp_rel
+int16 distance_sensor_timestamp_rel
 int16 gps_timestamp_rel
 int16 optical_flow_timestamp_rel
-int16 distance_sensor_timestamp_rel
-int16 airspeed_timestamp_rel
-int16 vision_position_timestamp_rel
+int16 vehicle_air_data_timestamp_rel
+int16 vehicle_magnetometer_timestamp_rel
 int16 vision_attitude_timestamp_rel
+int16 vision_position_timestamp_rel
 
 # Note: this is a high-rate logged topic, so it needs to be as small as possible
 

--- a/msg/sensor_baro.msg
+++ b/msg/sensor_baro.msg
@@ -1,5 +1,4 @@
 float32 pressure	# static pressure measurement in millibar
-float32 altitude	# ISA pressure altitude in meters
 float32 temperature	# static temperature measurement in deg C
 uint64 error_count
 uint32 device_id	# Sensor ID that must be unique for each baro sensor and must not change

--- a/msg/sensor_bias.msg
+++ b/msg/sensor_bias.msg
@@ -3,17 +3,9 @@
 # scale errors, in-run bias and thermal drift (if thermal compensation is enabled and available).
 #
 
-float32 gyro_x		# Bias corrected angular velocity about X body axis (roll) (in rad/s)
-float32 gyro_y		# Bias corrected angular velocity about Y body axis (pitch) (in rad/s)
-float32 gyro_z		# Bias corrected angular velocity about Z body axis (yaw) (in rad/s)
-
 float32 accel_x		# Bias corrected acceleration in body X axis (in rad/s)
 float32 accel_y		# Bias corrected acceleration in body Y axis (in rad/s)
 float32 accel_z		# Bias corrected acceleration in body Z axis (in rad/s)
-
-float32 mag_x		# Bias corrected magnetometer reading in body X axis (in Gauss)
-float32 mag_y		# Bias corrected magnetometer reading in body Y axis (in Gauss)
-float32 mag_z		# Bias corrected magnetometer reading in body Z axis (in Gauss)
 
 # In-run bias estimates (subtract from uncorrected data)
 

--- a/msg/sensor_combined.msg
+++ b/msg/sensor_combined.msg
@@ -20,5 +20,6 @@ int32 magnetometer_timestamp_relative	# timestamp + magnetometer_timestamp_relat
 float32[3] magnetometer_ga		# Magnetic field in NED body frame, in Gauss
 
 int32 baro_timestamp_relative		# timestamp + baro_timestamp_relative = Barometer timestamp
-float32 baro_alt_meter			# Altitude, already temp. comp.
+float32 baro_alt_meter			# Altitude above MSL calculated from temperature compensated baro sensor data using an ISA corrected for sea level pressure SENS_BARO_QNH.
 float32 baro_temp_celcius		# Temperature in degrees celsius
+float32 baro_pressure_pa		# Absolute pressure in pascals

--- a/msg/sensor_combined.msg
+++ b/msg/sensor_combined.msg
@@ -7,7 +7,6 @@
 
 int32 RELATIVE_TIMESTAMP_INVALID = 2147483647 # (0x7fffffff) If one of the relative timestamps is set to this value, it means the associated sensor values are invalid
 
-
 # gyro timstamp is equal to the timestamp of the message
 float32[3] gyro_rad			# average angular rate measured in the XYZ body frame in rad/s over the last gyro sampling period
 uint32 gyro_integral_dt		# gyro measurement sampling period in us
@@ -15,11 +14,3 @@ uint32 gyro_integral_dt		# gyro measurement sampling period in us
 int32 accelerometer_timestamp_relative	# timestamp + accelerometer_timestamp_relative = Accelerometer timestamp
 float32[3] accelerometer_m_s2		# average value acceleration measured in the XYZ body frame in m/s/s over the last accelerometer sampling period
 uint32 accelerometer_integral_dt	# accelerometer measurement sampling period in us
-
-int32 magnetometer_timestamp_relative	# timestamp + magnetometer_timestamp_relative = Magnetometer timestamp
-float32[3] magnetometer_ga		# Magnetic field in NED body frame, in Gauss
-
-int32 baro_timestamp_relative		# timestamp + baro_timestamp_relative = Barometer timestamp
-float32 baro_alt_meter			# Altitude above MSL calculated from temperature compensated baro sensor data using an ISA corrected for sea level pressure SENS_BARO_QNH.
-float32 baro_temp_celcius		# Temperature in degrees celsius
-float32 baro_pressure_pa		# Absolute pressure in pascals

--- a/msg/vehicle_air_data.msg
+++ b/msg/vehicle_air_data.msg
@@ -1,0 +1,6 @@
+
+float32 baro_alt_meter			# Altitude above MSL calculated from temperature compensated baro sensor data using an ISA corrected for sea level pressure SENS_BARO_QNH.
+float32 baro_temp_celcius		# Temperature in degrees celsius
+float32 baro_pressure_pa		# Absolute pressure in pascals
+
+float32 rho						# air density

--- a/msg/vehicle_global_position.msg
+++ b/msg/vehicle_global_position.msg
@@ -25,8 +25,6 @@ float32 epv			# Standard deviation of vertical position error, (metres)
 float32 terrain_alt		# Terrain altitude WGS84, (metres)
 bool terrain_alt_valid		# Terrain altitude estimate is valid
 
-float32 pressure_alt		# Pressure altitude AMSL, (metres)
-
 bool dead_reckoning		# True if this position is estimated through dead-reckoning
 
 # TOPICS vehicle_global_position vehicle_global_position_groundtruth

--- a/msg/vehicle_magnetometer.msg
+++ b/msg/vehicle_magnetometer.msg
@@ -1,0 +1,2 @@
+
+float32[3] magnetometer_ga		# Magnetic field in NED body frame, in Gauss

--- a/src/drivers/barometer/bmp280/bmp280.cpp
+++ b/src/drivers/barometer/bmp280/bmp280.cpp
@@ -117,9 +117,6 @@ private:
 
 	bool			_collect_phase;
 
-	/* altitude conversion calibration */
-	unsigned		_msl_pressure;	/* in Pa */
-
 	orb_advert_t		_baro_topic;
 	int					_orb_class_instance;
 	int					_class_instance;
@@ -157,7 +154,6 @@ BMP280::BMP280(bmp280::IBMP280 *interface, const char *path) :
 	_report_ticks(0),
 	_reports(nullptr),
 	_collect_phase(false),
-	_msl_pressure(101325),
 	_baro_topic(nullptr),
 	_orb_class_instance(-1),
 	_class_instance(-1),
@@ -418,19 +414,6 @@ BMP280::ioctl(struct file *filp, int cmd, unsigned long arg)
 		 */
 		return OK;
 
-	case BAROIOCSMSLPRESSURE:
-
-		/* range-check for sanity */
-		if ((arg < 80000) || (arg > 120000)) {
-			return -EINVAL;
-		}
-
-		_msl_pressure = arg;
-		return OK;
-
-	case BAROIOCGMSLPRESSURE:
-		return _msl_pressure;
-
 	default:
 		break;
 	}
@@ -551,28 +534,6 @@ BMP280::collect()
 	report.temperature = _T;
 	report.pressure = _P / 100.0f; // to mbar
 
-
-	/* altitude calculations based on http://www.kansasflyer.org/index.asp?nav=Avi&sec=Alti&tab=Theory&pg=1 */
-
-	/* tropospheric properties (0-11km) for standard atmosphere */
-	const float T1 = 15.0f + 273.15f;	/* temperature at base height in Kelvin */
-	const float a  = -6.5f / 1000.0f;	/* temperature gradient in degrees per metre */
-	const float g  = 9.80665f;	/* gravity constant in m/s/s */
-	const float R  = 287.05f;	/* ideal gas constant in J/kg/K */
-	float pK = _P / _msl_pressure;
-
-	/*
-	 * Solve:
-	 *
-	 *     /        -(aR / g)     \
-	 *    | (p / p1)          . T1 | - T1
-	 *     \                      /
-	 * h = -------------------------------  + h1
-	 *                   a
-	 */
-	report.altitude = (((powf(pK, (-(a * R) / g))) * T1) - T1) / a;
-
-
 	/* publish it */
 	if (!(_pub_blocked)) {
 		/* publish it */
@@ -595,6 +556,7 @@ BMP280::print_info()
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
 	printf("poll interval:  %u us \n", _report_ticks * USEC_PER_TICK);
+	_reports->print_info("report queue");
 
 	sensor_baro_s brp = {};
 	_reports->get(&brp);
@@ -640,7 +602,6 @@ void	start(enum BMP280_BUS busid);
 void	test(enum BMP280_BUS busid);
 void	reset(enum BMP280_BUS busid);
 void	info();
-void	calibrate(unsigned altitude, enum BMP280_BUS busid);
 void	usage();
 
 
@@ -868,92 +829,10 @@ info()
 	exit(0);
 }
 
-/**
- * Calculate actual MSL pressure given current altitude
- */
-void
-calibrate(unsigned altitude, enum BMP280_BUS busid)
-{
-	struct bmp280_bus_option &bus = find_bus(busid);
-	struct baro_report report;
-	float	pressure;
-	float	p1;
-
-	int fd;
-
-	fd = open(bus.devpath, O_RDONLY);
-
-	if (fd < 0) {
-		PX4_ERR("open failed (try 'bmp280 start' if the driver is not running)");
-		exit(1);
-	}
-
-	/* start the sensor polling at max */
-	if (OK != ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_MAX)) {
-		PX4_ERR("failed to set poll rate");
-		exit(1);
-	}
-
-	/* average a few measurements */
-	pressure = 0.0f;
-
-	for (unsigned i = 0; i < 20; i++) {
-		struct pollfd fds;
-		int ret;
-		ssize_t sz;
-
-		/* wait for data to be ready */
-		fds.fd = fd;
-		fds.events = POLLIN;
-		ret = poll(&fds, 1, 1000);
-
-		if (ret != 1) {
-			PX4_ERR("timed out waiting for sensor data");
-			exit(1);
-		}
-
-		/* now go get it */
-		sz = read(fd, &report, sizeof(report));
-
-		if (sz != sizeof(report)) {
-			PX4_ERR("sensor read failed");
-			exit(1);
-		}
-
-		pressure += report.pressure;
-	}
-
-	pressure /= 20;		/* average */
-	pressure /= 10;		/* scale from millibar to kPa */
-
-	/* tropospheric properties (0-11km) for standard atmosphere */
-	const float T1 = 15.0 + 273.15;	/* temperature at base height in Kelvin */
-	const float a  = -6.5 / 1000;	/* temperature gradient in degrees per metre */
-	const float g  = 9.80665f;	/* gravity constant in m/s/s */
-	const float R  = 287.05f;	/* ideal gas constant in J/kg/K */
-
-	PX4_WARN("averaged pressure %10.4fkPa at %um", (double)pressure, altitude);
-
-	p1 = pressure * (powf(((T1 + (a * (float)altitude)) / T1), (g / (a * R))));
-
-	PX4_WARN("calculated MSL pressure %10.4fkPa", (double)p1);
-
-	/* save as integer Pa */
-	p1 *= 1000.0f;
-
-	if (ioctl(fd, BAROIOCSMSLPRESSURE, (unsigned long)p1) != OK) {
-		PX4_ERR("BAROIOCSMSLPRESSURE");
-		exit(1);
-	}
-
-	close(fd);
-	exit(0);
-}
-
 void
 usage()
 {
-	PX4_WARN("missing command: try 'start', 'info', 'test', 'test2', 'reset', 'calibrate'");
+	PX4_WARN("missing command: try 'start', 'info', 'test', 'test2', 'reset'");
 	PX4_WARN("options:");
 	PX4_WARN("    -X    (external I2C bus TODO)");
 	PX4_WARN("    -I    (internal I2C bus TODO)");
@@ -1024,20 +903,6 @@ bmp280_main(int argc, char *argv[])
 	 */
 	if (!strcmp(verb, "info")) {
 		bmp280::info();
-	}
-
-	/*
-	 * Perform MSL pressure calibration given an altitude in metres
-	 */
-	if (!strcmp(verb, "calibrate")) {
-		if (argc < 2) {
-			PX4_ERR("missing altitude");
-			exit(1);
-		}
-
-		long altitude = strtol(argv[optind + 1], nullptr, 10);
-
-		bmp280::calibrate(altitude, busid);
 	}
 
 	PX4_ERR("unrecognized command, try 'start', 'test', 'reset' or 'info'");

--- a/src/drivers/barometer/ms5611/ms5611.cpp
+++ b/src/drivers/barometer/ms5611/ms5611.cpp
@@ -349,7 +349,7 @@ MS5611::init()
 
 		if (autodetect) {
 			if (_device_type == MS5611_DEVICE) {
-				if (brp.altitude > 5300.f) {
+				if (brp.pressure < 520.0f) {
 					/* This is likely not this device, try again */
 					_device_type = MS5607_DEVICE;
 					_measure_phase = 0;
@@ -358,8 +358,8 @@ MS5611::init()
 				}
 
 			} else if (_device_type == MS5607_DEVICE) {
-				if (brp.altitude > 5300.f) {
-					/* Both devices returned very high altitude;
+				if (brp.pressure < 520.0f) {
+					/* Both devices returned a very low pressure;
 					 * have fun on Everest using MS5611 */
 					_device_type = MS5611_DEVICE;
 				}

--- a/src/drivers/drv_baro.h
+++ b/src/drivers/drv_baro.h
@@ -53,17 +53,4 @@
 #include <uORB/topics/sensor_baro.h>
 #define baro_report sensor_baro_s
 
-/*
- * ioctl() definitions
- */
-
-#define _BAROIOCBASE		(0x2200)
-#define _BAROIOC(_n)		(_PX4_IOC(_BAROIOCBASE, _n))
-
-/** set corrected MSL pressure in pascals */
-#define BAROIOCSMSLPRESSURE	_BAROIOC(0)
-
-/** get current MSL pressure in pascals */
-#define BAROIOCGMSLPRESSURE	_BAROIOC(1)
-
 #endif /* _DRV_BARO_H */

--- a/src/drivers/telemetry/hott/messages.cpp
+++ b/src/drivers/telemetry/hott/messages.cpp
@@ -48,7 +48,7 @@
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/esc_status.h>
 #include <uORB/topics/home_position.h>
-#include <uORB/topics/sensor_combined.h>
+#include <uORB/topics/vehicle_air_data.h>
 #include <uORB/topics/vehicle_gps_position.h>
 
 #include <drivers/drv_hrt.h>
@@ -59,7 +59,7 @@
 static int _battery_sub = -1;
 static int _gps_sub = -1;
 static int _home_sub = -1;
-static int _sensor_sub = -1;
+static int _airdata_sub = -1;
 static int _airspeed_sub = -1;
 static int _esc_sub = -1;
 
@@ -75,7 +75,7 @@ init_sub_messages(void)
 	_battery_sub = orb_subscribe(ORB_ID(battery_status));
 	_gps_sub = orb_subscribe(ORB_ID(vehicle_gps_position));
 	_home_sub = orb_subscribe(ORB_ID(home_position));
-	_sensor_sub = orb_subscribe(ORB_ID(sensor_combined));
+	_airdata_sub = orb_subscribe(ORB_ID(vehicle_air_data));
 	_airspeed_sub = orb_subscribe(ORB_ID(airspeed));
 	_esc_sub = orb_subscribe(ORB_ID(esc_status));
 }
@@ -132,9 +132,8 @@ void
 build_eam_response(uint8_t *buffer, size_t *size)
 {
 	/* get a local copy of the current sensor values */
-	struct sensor_combined_s raw;
-	memset(&raw, 0, sizeof(raw));
-	orb_copy(ORB_ID(sensor_combined), _sensor_sub, &raw);
+	vehicle_air_data_s airdata = {};
+	orb_copy(ORB_ID(vehicle_air_data), _airdata_sub, &airdata);
 
 	/* get a local copy of the battery data */
 	struct battery_status_s battery;
@@ -149,12 +148,12 @@ build_eam_response(uint8_t *buffer, size_t *size)
 	msg.eam_sensor_id = EAM_SENSOR_ID;
 	msg.sensor_text_id = EAM_SENSOR_TEXT_ID;
 
-	msg.temperature1 = (uint8_t)(raw.baro_temp_celcius + 20);
+	msg.temperature1 = (uint8_t)(airdata.baro_temp_celcius + 20);
 	msg.temperature2 = msg.temperature1 - BOARD_TEMP_OFFSET_DEG;
 
 	msg.main_voltage_L = (uint8_t)(battery.voltage_v * 10);
 
-	uint16_t alt = (uint16_t)(raw.baro_alt_meter + 500);
+	uint16_t alt = (uint16_t)(airdata.baro_alt_meter + 500);
 	msg.altitude_L = (uint8_t)alt & 0xff;
 	msg.altitude_H = (uint8_t)(alt >> 8) & 0xff;
 
@@ -209,11 +208,6 @@ build_gam_response(uint8_t *buffer, size_t *size)
 void
 build_gps_response(uint8_t *buffer, size_t *size)
 {
-	/* get a local copy of the current sensor values */
-	struct sensor_combined_s raw;
-	memset(&raw, 0, sizeof(raw));
-	orb_copy(ORB_ID(sensor_combined), _sensor_sub, &raw);
-
 	/* get a local copy of the battery data */
 	struct vehicle_gps_position_s gps;
 	memset(&gps, 0, sizeof(gps));

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -23,6 +23,7 @@
 #include <uORB/topics/vehicle_gps_position.h>
 #include <uORB/topics/att_pos_mocap.h>
 #include <uORB/topics/landing_target_pose.h>
+#include <uORB/topics/vehicle_air_data.h>
 
 // uORB Publications
 #include <uORB/Publication.hpp>
@@ -260,6 +261,7 @@ private:
 	uORB::Subscription<distance_sensor_s> *_sub_lidar;
 	uORB::Subscription<distance_sensor_s> *_sub_sonar;
 	uORB::Subscription<landing_target_pose_s> _sub_landing_target_pose;
+	uORB::Subscription<vehicle_air_data_s> _sub_airdata;
 
 	// publications
 	uORB::Publication<vehicle_local_position_s> _pub_lpos;

--- a/src/modules/local_position_estimator/sensors/baro.cpp
+++ b/src/modules/local_position_estimator/sensors/baro.cpp
@@ -41,9 +41,9 @@ int BlockLocalPositionEstimator::baroMeasure(Vector<float, n_y_baro> &y)
 {
 	//measure
 	y.setZero();
-	y(0) = _sub_sensor.get().baro_alt_meter;
+	y(0) = _sub_airdata.get().baro_alt_meter;
 	_baroStats.update(y);
-	_time_last_baro = _timeStamp;
+	_time_last_baro = _sub_airdata.get().timestamp;
 	return OK;
 }
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -680,7 +680,6 @@ void Logger::add_estimator_replay_topics()
 	add_topic("airspeed");
 	add_topic("distance_sensor");
 	add_topic("optical_flow");
-	add_topic("sensor_baro");
 	add_topic("sensor_combined");
 	add_topic("sensor_selection");
 	add_topic("vehicle_gps_position");

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -682,8 +682,10 @@ void Logger::add_estimator_replay_topics()
 	add_topic("optical_flow");
 	add_topic("sensor_combined");
 	add_topic("sensor_selection");
+	add_topic("vehicle_air_data");
 	add_topic("vehicle_gps_position");
 	add_topic("vehicle_land_detected");
+	add_topic("vehicle_magnetometer");
 	add_topic("vehicle_status");
 	add_topic("vehicle_vision_attitude");
 	add_topic("vehicle_vision_position");

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1965,7 +1965,6 @@ MavlinkReceiver::handle_message_hil_sensor(mavlink_message_t *msg)
 
 		baro.timestamp = timestamp;
 		baro.pressure = imu.abs_pressure;
-		baro.altitude = imu.pressure_alt;
 		baro.temperature = imu.temperature;
 
 		/* fake device ID */

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -54,7 +54,8 @@
 
 Geofence::Geofence(Navigator *navigator) :
 	ModuleParams(navigator),
-	_navigator(navigator)
+	_navigator(navigator),
+	_sub_airdata(ORB_ID(vehicle_air_data))
 {
 	// we assume there's no concurrent fence update on startup
 	_updateFence();
@@ -181,15 +182,13 @@ bool Geofence::checkAll(const struct vehicle_global_position_s &global_position)
 	return checkAll(global_position.lat, global_position.lon, global_position.alt);
 }
 
-bool Geofence::checkAll(const struct vehicle_global_position_s &global_position, float baro_altitude_amsl)
+bool Geofence::checkAll(const struct vehicle_global_position_s &global_position, const float alt)
 {
-	return checkAll(global_position.lat, global_position.lon, baro_altitude_amsl);
+	return checkAll(global_position.lat, global_position.lon, alt);
 }
 
-
-bool Geofence::check(const struct vehicle_global_position_s &global_position,
-		     const struct vehicle_gps_position_s &gps_position, float baro_altitude_amsl,
-		     const struct home_position_s home_pos, bool home_position_set)
+bool Geofence::check(const vehicle_global_position_s &global_position, const vehicle_gps_position_s &gps_position,
+		     const home_position_s home_pos, bool home_position_set)
 {
 	if (getAltitudeMode() == Geofence::GF_ALT_MODE_WGS84) {
 		if (getSource() == Geofence::GF_SOURCE_GLOBALPOS) {
@@ -201,12 +200,15 @@ bool Geofence::check(const struct vehicle_global_position_s &global_position,
 		}
 
 	} else {
+		// get baro altitude
+		_sub_airdata.update();
+		const float baro_altitude_amsl = _sub_airdata.get().baro_alt_meter;
+
 		if (getSource() == Geofence::GF_SOURCE_GLOBALPOS) {
 			return checkAll(global_position, baro_altitude_amsl);
 
 		} else {
-			return checkAll((double)gps_position.lat * 1.0e-7, (double)gps_position.lon * 1.0e-7,
-					baro_altitude_amsl);
+			return checkAll((double)gps_position.lat * 1.0e-7, (double)gps_position.lon * 1.0e-7, baro_altitude_amsl);
 		}
 	}
 }

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -46,9 +46,11 @@
 #include <drivers/drv_hrt.h>
 #include <lib/ecl/geo/geo.h>
 #include <px4_defines.h>
-#include <uORB/topics/sensor_combined.h>
+#include <uORB/Subscription.hpp>
+#include <uORB/topics/home_position.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_gps_position.h>
+#include <uORB/topics/vehicle_air_data.h>
 
 #define GEOFENCE_FILENAME PX4_ROOTFSDIR"/fs/microsd/etc/geofence.txt"
 
@@ -85,9 +87,8 @@ public:
 	 *
 	 * @return true: system is obeying fence, false: system is violating fence
 	 */
-	bool check(const struct vehicle_global_position_s &global_position,
-		   const struct vehicle_gps_position_s &gps_position, float baro_altitude_amsl,
-		   const struct home_position_s home_pos, bool home_position_set);
+	bool check(const vehicle_global_position_s &global_position,
+		   const vehicle_gps_position_s &gps_position, const home_position_s home_pos, bool home_position_set);
 
 	/**
 	 * Return whether a mission item obeys the geofence.
@@ -165,6 +166,8 @@ private:
 		(ParamFloat<px4::params::GF_MAX_VER_DIST>) _param_max_ver_distance
 	)
 
+	uORB::Subscription<vehicle_air_data_s>	_sub_airdata;
+
 	int _outside_counter{0};
 	uint16_t _update_counter{0}; ///< dataman update counter: if it does not match, we polygon data was updated
 
@@ -193,8 +196,8 @@ private:
 	 */
 	bool checkAll(double lat, double lon, float altitude);
 
-	bool checkAll(const struct vehicle_global_position_s &global_position);
-	bool checkAll(const struct vehicle_global_position_s &global_position, float baro_altitude_amsl);
+	bool checkAll(const vehicle_global_position_s &global_position);
+	bool checkAll(const vehicle_global_position_s &global_position, float baro_altitude_amsl);
 
 	/**
 	 * Check if a single point is within a polygon

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -277,7 +277,6 @@ private:
 	int		_local_pos_sub{-1};		/**< local position subscription */
 	int		_offboard_mission_sub{-1};	/**< offboard mission subscription */
 	int		_param_update_sub{-1};		/**< param update subscription */
-	int		_sensor_combined_sub{-1};	/**< sensor combined subscription */
 	int		_traffic_sub{-1};		/**< traffic subscription */
 	int		_vehicle_command_sub{-1};	/**< vehicle commands (onboard and offboard) */
 	int		_vstatus_sub{-1};		/**< vehicle status subscription */
@@ -294,7 +293,6 @@ private:
 	fw_pos_ctrl_status_s				_fw_pos_ctrl_status{};	/**< fixed wing navigation capabilities */
 	home_position_s					_home_pos{};		/**< home position for RTL */
 	mission_result_s				_mission_result{};
-	sensor_combined_s				_sensor_combined{};	/**< sensor values */
 	vehicle_global_position_s			_global_pos{};		/**< global vehicle position */
 	vehicle_gps_position_s				_gps_pos{};		/**< gps position */
 	vehicle_land_detected_s				_land_detected{};	/**< vehicle land_detected */
@@ -366,7 +364,6 @@ private:
 	void		home_position_update(bool force = false);
 	void		local_position_update();
 	void		params_update();
-	void		sensor_combined_update();
 	void		vehicle_land_detected_update();
 	void		vehicle_status_update();
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -133,12 +133,6 @@ Navigator::gps_position_update()
 }
 
 void
-Navigator::sensor_combined_update()
-{
-	orb_copy(ORB_ID(sensor_combined), _sensor_combined_sub, &_sensor_combined);
-}
-
-void
 Navigator::home_position_update(bool force)
 {
 	bool updated = false;
@@ -201,7 +195,6 @@ Navigator::run()
 	_global_pos_sub = orb_subscribe(ORB_ID(vehicle_global_position));
 	_local_pos_sub = orb_subscribe(ORB_ID(vehicle_local_position));
 	_gps_pos_sub = orb_subscribe(ORB_ID(vehicle_gps_position));
-	_sensor_combined_sub = orb_subscribe(ORB_ID(sensor_combined));
 	_fw_pos_ctrl_status_sub = orb_subscribe(ORB_ID(fw_pos_ctrl_status));
 	_vstatus_sub = orb_subscribe(ORB_ID(vehicle_status));
 	_land_detected_sub = orb_subscribe(ORB_ID(vehicle_land_detected));
@@ -217,7 +210,6 @@ Navigator::run()
 	global_position_update();
 	local_position_update();
 	gps_position_update();
-	sensor_combined_update();
 	home_position_update(true);
 	fw_pos_ctrl_status_update(true);
 	params_update();
@@ -279,13 +271,6 @@ Navigator::run()
 			if (_geofence.getSource() == Geofence::GF_SOURCE_GLOBALPOS) {
 				have_geofence_position_data = true;
 			}
-		}
-
-		/* sensors combined updated */
-		orb_check(_sensor_combined_sub, &updated);
-
-		if (updated) {
-			sensor_combined_update();
 		}
 
 		/* parameters updated */
@@ -538,7 +523,7 @@ Navigator::run()
 		    (_geofence.getGeofenceAction() != geofence_result_s::GF_ACTION_NONE) &&
 		    (hrt_elapsed_time(&last_geofence_check) > GEOFENCE_CHECK_INTERVAL)) {
 
-			bool inside = _geofence.check(_global_pos, _gps_pos, _sensor_combined.baro_alt_meter, _home_pos,
+			bool inside = _geofence.check(_global_pos, _gps_pos, _home_pos,
 						      home_position_valid());
 			last_geofence_check = hrt_absolute_time();
 			have_geofence_position_data = false;
@@ -711,7 +696,6 @@ Navigator::run()
 	orb_unsubscribe(_global_pos_sub);
 	orb_unsubscribe(_local_pos_sub);
 	orb_unsubscribe(_gps_pos_sub);
-	orb_unsubscribe(_sensor_combined_sub);
 	orb_unsubscribe(_fw_pos_ctrl_status_sub);
 	orb_unsubscribe(_vstatus_sub);
 	orb_unsubscribe(_land_detected_sub);

--- a/src/modules/replay/replay.hpp
+++ b/src/modules/replay/replay.hpp
@@ -308,13 +308,15 @@ private:
 
 	static constexpr uint16_t msg_id_invalid = 0xffff;
 
-	uint16_t _sensors_combined_msg_id = msg_id_invalid;
+	uint16_t _airspeed_msg_id = msg_id_invalid;
+	uint16_t _distance_sensor_msg_id = msg_id_invalid;
 	uint16_t _gps_msg_id = msg_id_invalid;
 	uint16_t _optical_flow_msg_id = msg_id_invalid;
-	uint16_t _distance_sensor_msg_id = msg_id_invalid;
-	uint16_t _airspeed_msg_id = msg_id_invalid;
-	uint16_t _vehicle_vision_position_msg_id = msg_id_invalid;
+	uint16_t _sensor_combined_msg_id = msg_id_invalid;
+	uint16_t _vehicle_air_data_msg_id = msg_id_invalid;
+	uint16_t _vehicle_magnetometer_msg_id = msg_id_invalid;
 	uint16_t _vehicle_vision_attitude_msg_id = msg_id_invalid;
+	uint16_t _vehicle_vision_position_msg_id = msg_id_invalid;
 
 	int _topic_counter = 0;
 };

--- a/src/modules/replay/replay_main.cpp
+++ b/src/modules/replay/replay_main.cpp
@@ -352,14 +352,10 @@ bool Replay::readAndAddSubscription(std::ifstream &file, uint16_t msg_size)
 		if (topic_name == "sensor_combined") {
 			if (string(orb_meta->o_fields) == "uint64_t timestamp;float[3] gyro_rad;uint32_t gyro_integral_dt;"
 			    "int32_t accelerometer_timestamp_relative;float[3] accelerometer_m_s2;"
-			    "uint32_t accelerometer_integral_dt;int32_t magnetometer_timestamp_relative;"
-			    "float[3] magnetometer_ga;int32_t baro_timestamp_relative;float baro_alt_meter;"
-			    "float baro_temp_celcius;" &&
+			    "uint32_t accelerometer_integral_dt" &&
 			    file_format == "uint64_t timestamp;float[3] gyro_rad;float gyro_integral_dt;"
 			    "int32_t accelerometer_timestamp_relative;float[3] accelerometer_m_s2;"
-			    "float accelerometer_integral_dt;int32_t magnetometer_timestamp_relative;"
-			    "float[3] magnetometer_ga;int32_t baro_timestamp_relative;float baro_alt_meter;"
-			    "float baro_temp_celcius;") {
+			    "float accelerometer_integral_dt;") {
 				int gyro_integral_dt_offset_log;
 				int gyro_integral_dt_offset_intern;
 				int accelerometer_integral_dt_offset_log;

--- a/src/modules/replay/replay_main.cpp
+++ b/src/modules/replay/replay_main.cpp
@@ -62,13 +62,16 @@
 // for ekf2 replay
 #include <uORB/topics/airspeed.h>
 #include <uORB/topics/distance_sensor.h>
+#include <uORB/topics/landing_target_pose.h>
 #include <uORB/topics/optical_flow.h>
 #include <uORB/topics/sensor_combined.h>
-#include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/vehicle_air_data.h>
+#include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_gps_position.h>
 #include <uORB/topics/vehicle_land_detected.h>
-#include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_magnetometer.h>
+#include <uORB/topics/vehicle_status.h>
 
 #include "replay.hpp"
 
@@ -953,7 +956,13 @@ bool ReplayEkf2::handleTopicUpdate(Subscription &sub, void *data, std::ifstream 
 void ReplayEkf2::onSubscriptionAdded(Subscription &sub, uint16_t msg_id)
 {
 	if (sub.orb_meta == ORB_ID(sensor_combined)) {
-		_sensors_combined_msg_id = msg_id;
+		_sensor_combined_msg_id = msg_id;
+
+	} else if (sub.orb_meta == ORB_ID(airspeed)) {
+		_airspeed_msg_id = msg_id;
+
+	} else if (sub.orb_meta == ORB_ID(distance_sensor)) {
+		_distance_sensor_msg_id = msg_id;
 
 	} else if (sub.orb_meta == ORB_ID(vehicle_gps_position)) {
 		_gps_msg_id = msg_id;
@@ -961,17 +970,17 @@ void ReplayEkf2::onSubscriptionAdded(Subscription &sub, uint16_t msg_id)
 	} else if (sub.orb_meta == ORB_ID(optical_flow)) {
 		_optical_flow_msg_id = msg_id;
 
-	} else if (sub.orb_meta == ORB_ID(distance_sensor)) {
-		_distance_sensor_msg_id = msg_id;
+	} else if (sub.orb_meta == ORB_ID(vehicle_air_data)) {
+		_vehicle_air_data_msg_id = msg_id;
 
-	} else if (sub.orb_meta == ORB_ID(airspeed)) {
-		_airspeed_msg_id = msg_id;
-
-	} else if (sub.orb_meta == ORB_ID(vehicle_vision_position)) {
-		_vehicle_vision_position_msg_id = msg_id;
+	} else if (sub.orb_meta == ORB_ID(vehicle_magnetometer)) {
+		_vehicle_magnetometer_msg_id = msg_id;
 
 	} else if (sub.orb_meta == ORB_ID(vehicle_vision_attitude)) {
 		_vehicle_vision_attitude_msg_id = msg_id;
+
+	} else if (sub.orb_meta == ORB_ID(vehicle_vision_position)) {
+		_vehicle_vision_position_msg_id = msg_id;
 	}
 
 	// the main loop should only handle publication of the following topics, the sensor topics are
@@ -989,28 +998,29 @@ bool ReplayEkf2::publishEkf2Topics(const ekf2_timestamps_s &ekf2_timestamps, std
 			findTimestampAndPublish(t, msg_id, replay_file);
 		}
 	};
-	handle_sensor_publication(ekf2_timestamps.gps_timestamp_rel, _gps_msg_id); // gps
-	handle_sensor_publication(ekf2_timestamps.optical_flow_timestamp_rel, _optical_flow_msg_id); // optical flow
-	handle_sensor_publication(ekf2_timestamps.distance_sensor_timestamp_rel, _distance_sensor_msg_id); // distance sensor
-	handle_sensor_publication(ekf2_timestamps.airspeed_timestamp_rel, _airspeed_msg_id); // airspeed
-	handle_sensor_publication(ekf2_timestamps.vision_position_timestamp_rel,
-				  _vehicle_vision_position_msg_id); // vision position
-	handle_sensor_publication(ekf2_timestamps.vision_attitude_timestamp_rel,
-				  _vehicle_vision_attitude_msg_id); // vision attitude
+
+	handle_sensor_publication(ekf2_timestamps.airspeed_timestamp_rel, _airspeed_msg_id);
+	handle_sensor_publication(ekf2_timestamps.distance_sensor_timestamp_rel, _distance_sensor_msg_id);
+	handle_sensor_publication(ekf2_timestamps.gps_timestamp_rel, _gps_msg_id);
+	handle_sensor_publication(ekf2_timestamps.optical_flow_timestamp_rel, _optical_flow_msg_id);
+	handle_sensor_publication(ekf2_timestamps.vehicle_air_data_timestamp_rel, _vehicle_air_data_msg_id);
+	handle_sensor_publication(ekf2_timestamps.vehicle_magnetometer_timestamp_rel, _vehicle_magnetometer_msg_id);
+	handle_sensor_publication(ekf2_timestamps.vision_attitude_timestamp_rel, _vehicle_vision_attitude_msg_id);
+	handle_sensor_publication(ekf2_timestamps.vision_position_timestamp_rel, _vehicle_vision_position_msg_id);
 
 	// sensor_combined: publish last because ekf2 is polling on this
-	if (!findTimestampAndPublish(ekf2_timestamps.timestamp / 100, _sensors_combined_msg_id, replay_file)) {
-		if (_sensors_combined_msg_id == msg_id_invalid) {
+	if (!findTimestampAndPublish(ekf2_timestamps.timestamp / 100, _sensor_combined_msg_id, replay_file)) {
+		if (_sensor_combined_msg_id == msg_id_invalid) {
 			// subscription not found yet or sensor_combined not contained in log
 			return false;
 
-		} else if (!_subscriptions[_sensors_combined_msg_id].orb_meta) {
+		} else if (!_subscriptions[_sensor_combined_msg_id].orb_meta) {
 			return false; // read past end of file
 
 		} else {
 			// we should publish a topic, just publish the same again
-			readTopicDataToBuffer(_subscriptions[_sensors_combined_msg_id], replay_file);
-			publishTopic(_subscriptions[_sensors_combined_msg_id], _read_buffer.data());
+			readTopicDataToBuffer(_subscriptions[_sensor_combined_msg_id], replay_file);
+			publishTopic(_subscriptions[_sensor_combined_msg_id], _read_buffer.data());
 		}
 	}
 
@@ -1068,13 +1078,16 @@ void ReplayEkf2::onExitMainLoop()
 
 	PX4_INFO("");
 	PX4_INFO("Topic, Num Published, Num Error (no timestamp match found):");
-	print_sensor_statistics(_sensors_combined_msg_id, "sensor_combined");
+
+	print_sensor_statistics(_airspeed_msg_id, "airspeed");
+	print_sensor_statistics(_distance_sensor_msg_id, "distance_sensor");
 	print_sensor_statistics(_gps_msg_id, "vehicle_gps_position");
 	print_sensor_statistics(_optical_flow_msg_id, "optical_flow");
-	print_sensor_statistics(_distance_sensor_msg_id, "distance_sensor");
-	print_sensor_statistics(_airspeed_msg_id, "airspeed");
-	print_sensor_statistics(_vehicle_vision_position_msg_id, "vehicle_vision_position");
+	print_sensor_statistics(_sensor_combined_msg_id, "sensor_combined");
+	print_sensor_statistics(_vehicle_air_data_msg_id, "vehicle_air_data");
+	print_sensor_statistics(_vehicle_magnetometer_msg_id, "vehicle_magnetometer");
 	print_sensor_statistics(_vehicle_vision_attitude_msg_id, "vehicle_vision_attitude");
+	print_sensor_statistics(_vehicle_vision_position_msg_id, "vehicle_vision_position");
 
 	orb_unsubscribe(_vehicle_attitude_sub);
 	_vehicle_attitude_sub = -1;

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1357,8 +1357,8 @@ int sdlog2_thread_main(int argc, char *argv[])
 	/* track changes in sensor_combined topic */
 	hrt_abstime gyro_timestamp = 0;
 	hrt_abstime accelerometer_timestamp = 0;
-	hrt_abstime magnetometer_timestamp = 0;
-	hrt_abstime barometer_timestamp = 0;
+	//hrt_abstime magnetometer_timestamp = 0;
+	//hrt_abstime barometer_timestamp = 0;
 
 	/* initialize calculated mean SNR */
 	float snr_mean = 0.0f;
@@ -1526,15 +1526,15 @@ int sdlog2_thread_main(int argc, char *argv[])
 					write_IMU = true;
 				}
 
-				if (buf.sensor.timestamp + buf.sensor.magnetometer_timestamp_relative != magnetometer_timestamp) {
-					magnetometer_timestamp = buf.sensor.timestamp + buf.sensor.magnetometer_timestamp_relative;
-					write_IMU = true;
-				}
+//				if (buf.sensor.timestamp + buf.sensor.magnetometer_timestamp_relative != magnetometer_timestamp) {
+//					magnetometer_timestamp = buf.sensor.timestamp + buf.sensor.magnetometer_timestamp_relative;
+//					write_IMU = true;
+//				}
 
-				if (buf.sensor.timestamp + buf.sensor.baro_timestamp_relative != barometer_timestamp) {
-					barometer_timestamp = buf.sensor.timestamp + buf.sensor.baro_timestamp_relative;
-					write_SENS = true;
-				}
+//				if (buf.sensor.timestamp + buf.sensor.baro_timestamp_relative != barometer_timestamp) {
+//					barometer_timestamp = buf.sensor.timestamp + buf.sensor.baro_timestamp_relative;
+//					write_SENS = true;
+//				}
 
 				if (write_IMU) {
 					log_msg.msg_type = LOG_IMU_MSG;
@@ -1545,9 +1545,9 @@ int sdlog2_thread_main(int argc, char *argv[])
 					log_msg.body.log_IMU.acc_x = buf.sensor.accelerometer_m_s2[0];
 					log_msg.body.log_IMU.acc_y = buf.sensor.accelerometer_m_s2[1];
 					log_msg.body.log_IMU.acc_z = buf.sensor.accelerometer_m_s2[2];
-					log_msg.body.log_IMU.mag_x = buf.sensor.magnetometer_ga[0];
-					log_msg.body.log_IMU.mag_y = buf.sensor.magnetometer_ga[1];
-					log_msg.body.log_IMU.mag_z = buf.sensor.magnetometer_ga[2];
+//					log_msg.body.log_IMU.mag_x = buf.sensor.magnetometer_ga[0];
+//					log_msg.body.log_IMU.mag_y = buf.sensor.magnetometer_ga[1];
+//					log_msg.body.log_IMU.mag_z = buf.sensor.magnetometer_ga[2];
 					log_msg.body.log_IMU.temp_gyro = 0;
 					log_msg.body.log_IMU.temp_acc = 0;
 					log_msg.body.log_IMU.temp_mag = 0;
@@ -1555,12 +1555,12 @@ int sdlog2_thread_main(int argc, char *argv[])
 				}
 
 				if (write_SENS) {
-					log_msg.msg_type = LOG_SENS_MSG;
-
-					log_msg.body.log_SENS.baro_pres = 0;
-					log_msg.body.log_SENS.baro_alt = buf.sensor.baro_alt_meter;
-					log_msg.body.log_SENS.baro_temp = buf.sensor.baro_temp_celcius;
-					LOGBUFFER_WRITE_AND_COUNT(SENS);
+//					log_msg.msg_type = LOG_SENS_MSG;
+//
+//					log_msg.body.log_SENS.baro_pres = 0;
+//					log_msg.body.log_SENS.baro_alt = buf.sensor.baro_alt_meter;
+//					log_msg.body.log_SENS.baro_temp = buf.sensor.baro_temp_celcius;
+//					LOGBUFFER_WRITE_AND_COUNT(SENS);
 				}
 			}
 

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -85,6 +85,8 @@
 #include <uORB/topics/differential_pressure.h>
 #include <uORB/topics/airspeed.h>
 #include <uORB/topics/sensor_preflight.h>
+#include <uORB/topics/vehicle_air_data.h>
+#include <uORB/topics/vehicle_magnetometer.h>
 
 #include <DevMgr.hpp>
 
@@ -169,6 +171,8 @@ private:
 	int 		_params_sub{-1};			/**< notification of parameter updates */
 
 	orb_advert_t	_sensor_pub{nullptr};			/**< combined sensor data topic */
+	orb_advert_t	_airdata_pub{nullptr};			/**< combined sensor data topic */
+	orb_advert_t	_magnetometer_pub{nullptr};			/**< combined sensor data topic */
 	orb_advert_t	_battery_pub[BOARD_NUMBER_BRICKS] {};			/**< battery status */
 
 #if BOARD_NUMBER_BRICKS > 1
@@ -212,7 +216,7 @@ private:
 	 * @param raw			Combined sensor data structure into which
 	 *				data should be returned.
 	 */
-	void		diff_pres_poll(struct sensor_combined_s &raw);
+	void		diff_pres_poll(const vehicle_air_data_s &airdata);
 
 	/**
 	 * Check for changes in vehicle control mode.
@@ -285,7 +289,7 @@ Sensors::adc_init()
 }
 
 void
-Sensors::diff_pres_poll(struct sensor_combined_s &raw)
+Sensors::diff_pres_poll(const vehicle_air_data_s &raw)
 {
 	bool updated;
 	orb_check(_diff_pres_sub, &updated);
@@ -569,7 +573,9 @@ Sensors::run()
 #endif
 	}
 
-	struct sensor_combined_s raw = {};
+	sensor_combined_s raw = {};
+	vehicle_air_data_s airdata = {};
+	vehicle_magnetometer_s magnetometer = {};
 
 	struct sensor_preflight_s preflt = {};
 
@@ -592,14 +598,16 @@ Sensors::run()
 	_actuator_ctrl_0_sub = orb_subscribe(ORB_ID(actuator_controls_0));
 
 	/* get a set of initial values */
-	_voted_sensors_update.sensors_poll(raw);
+	_voted_sensors_update.sensors_poll(raw, airdata, magnetometer);
 
-	diff_pres_poll(raw);
+	diff_pres_poll(airdata);
 
 	_rc_update.rc_parameter_map_poll(_parameter_handles, true /* forced */);
 
 	/* advertise the sensor_combined topic and make the initial publication */
 	_sensor_pub = orb_advertise(ORB_ID(sensor_combined), &raw);
+	_airdata_pub = orb_advertise(ORB_ID(vehicle_air_data), &airdata);
+	_magnetometer_pub = orb_advertise(ORB_ID(vehicle_magnetometer), &magnetometer);
 
 	/* advertise the sensor_preflight topic and make the initial publication */
 	preflt.accel_inconsistency_m_s_s = 0.0f;
@@ -649,18 +657,29 @@ Sensors::run()
 
 		/* the timestamp of the raw struct is updated by the gyro_poll() method (this makes the gyro
 		 * a mandatory sensor) */
-		_voted_sensors_update.sensors_poll(raw);
+		const uint64_t airdata_prev_timestamp = airdata.timestamp;
+		const uint64_t magnetometer_prev_timestamp = magnetometer.timestamp;
+
+		_voted_sensors_update.sensors_poll(raw, airdata, magnetometer);
 
 		/* check battery voltage */
 		adc_poll();
 
-		diff_pres_poll(raw);
+		diff_pres_poll(airdata);
 
 		if (raw.timestamp > 0) {
 
 			_voted_sensors_update.set_relative_timestamps(raw);
 
 			orb_publish(ORB_ID(sensor_combined), _sensor_pub, &raw);
+
+			if (airdata.timestamp != airdata_prev_timestamp) {
+				orb_publish(ORB_ID(vehicle_air_data), _airdata_pub, &airdata);
+			}
+
+			if (magnetometer.timestamp != magnetometer_prev_timestamp) {
+				orb_publish(ORB_ID(vehicle_magnetometer), _magnetometer_pub, &magnetometer);
+			}
 
 			_voted_sensors_update.check_failover();
 
@@ -673,7 +692,6 @@ Sensors::run()
 				_voted_sensors_update.calc_gyro_inconsistency(preflt);
 				_voted_sensors_update.calc_mag_inconsistency(preflt);
 				orb_publish(ORB_ID(sensor_preflight), _sensor_preflight, &preflt);
-
 			}
 		}
 
@@ -704,6 +722,8 @@ Sensors::run()
 	orb_unsubscribe(_params_sub);
 	orb_unsubscribe(_actuator_ctrl_0_sub);
 	orb_unadvertise(_sensor_pub);
+	orb_unadvertise(_airdata_pub);
+	orb_unadvertise(_magnetometer_pub);
 
 	_rc_update.deinit();
 	_voted_sensors_update.deinit();

--- a/src/modules/sensors/voted_sensors_update.h
+++ b/src/modules/sensors/voted_sensors_update.h
@@ -97,9 +97,6 @@ public:
 
 	void print_status();
 
-	/** get the latest baro pressure */
-	float baro_pressure() const { return _last_best_baro_pressure; }
-
 	/**
 	 * call this whenever parameters got updated. Make sure to have initialize_sensors() called at least
 	 * once before calling this.
@@ -246,9 +243,8 @@ private:
 
 	orb_advert_t	_mavlink_log_pub = nullptr;
 
-	float _last_baro_pressure[BARO_COUNT_MAX]; /**< pressure from last baro sensors */
-	float _last_best_baro_pressure = 0.0f; /**< pressure from last best baro */
 	sensor_combined_s _last_sensor_data[SENSOR_COUNT_MAX]; /**< latest sensor data from all sensors instances */
+
 	uint64_t _last_accel_timestamp[ACCEL_COUNT_MAX]; /**< latest full timestamp */
 	uint64_t _last_mag_timestamp[MAG_COUNT_MAX]; /**< latest full timestamp */
 	uint64_t _last_baro_timestamp[BARO_COUNT_MAX]; /**< latest full timestamp */
@@ -273,12 +269,12 @@ private:
 	struct sensor_selection_s _selection = {}; /**< struct containing the sensor selection to be published to the uORB*/
 	orb_advert_t _sensor_selection_pub = nullptr; /**< handle to the sensor selection uORB topic */
 	bool _selection_changed = false; /**< true when a sensor selection has changed and not been published */
+
 	uint32_t _accel_device_id[SENSOR_COUNT_MAX] = {}; /**< accel driver device id for each uorb instance */
 	uint32_t _baro_device_id[SENSOR_COUNT_MAX] = {};
 	uint32_t _gyro_device_id[SENSOR_COUNT_MAX] = {};
 	uint32_t _mag_device_id[SENSOR_COUNT_MAX] = {};
 
-	static const double	_msl_pressure;	/** average sea-level pressure in kPa */
 };
 
 

--- a/src/modules/sensors/voted_sensors_update.h
+++ b/src/modules/sensors/voted_sensors_update.h
@@ -56,6 +56,8 @@
 #include <uORB/topics/sensor_preflight.h>
 #include <uORB/topics/sensor_correction.h>
 #include <uORB/topics/sensor_selection.h>
+#include <uORB/topics/vehicle_air_data.h>
+#include <uORB/topics/vehicle_magnetometer.h>
 
 #include <DevMgr.hpp>
 
@@ -106,7 +108,7 @@ public:
 	/**
 	 * read new sensor data
 	 */
-	void sensors_poll(sensor_combined_s &raw);
+	void sensors_poll(sensor_combined_s &raw, vehicle_air_data_s &airdata, vehicle_magnetometer_s &magnetometer);
 
 	/**
 	 * set the relative timestamps of each sensor timestamp, based on the last sensors_poll,
@@ -189,7 +191,7 @@ private:
 	 * @param raw			Combined sensor data structure into which
 	 *				data should be returned.
 	 */
-	void		mag_poll(struct sensor_combined_s &raw);
+	void		mag_poll(vehicle_magnetometer_s &magnetometer);
 
 	/**
 	 * Poll the barometer for updated data.
@@ -197,7 +199,7 @@ private:
 	 * @param raw			Combined sensor data structure into which
 	 *				data should be returned.
 	 */
-	void		baro_poll(struct sensor_combined_s &raw);
+	void		baro_poll(vehicle_air_data_s &airdata);
 
 	/**
 	 * Check & handle failover of a sensor
@@ -244,10 +246,10 @@ private:
 	orb_advert_t	_mavlink_log_pub = nullptr;
 
 	sensor_combined_s _last_sensor_data[SENSOR_COUNT_MAX]; /**< latest sensor data from all sensors instances */
+	vehicle_air_data_s _last_airdata[SENSOR_COUNT_MAX]; /**< latest sensor data from all sensors instances */
+	vehicle_magnetometer_s _last_magnetometer[SENSOR_COUNT_MAX]; /**< latest sensor data from all sensors instances */
 
 	uint64_t _last_accel_timestamp[ACCEL_COUNT_MAX]; /**< latest full timestamp */
-	uint64_t _last_mag_timestamp[MAG_COUNT_MAX]; /**< latest full timestamp */
-	uint64_t _last_baro_timestamp[BARO_COUNT_MAX]; /**< latest full timestamp */
 
 	matrix::Dcmf	_board_rotation;	/**< rotation matrix for the orientation that the board is mounted */
 	matrix::Dcmf	_mag_rotation[MAG_COUNT_MAX];	/**< rotation matrix for the orientation that the external mag0 is mounted */

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -99,7 +99,6 @@ struct RawMPUData {
 #pragma pack(push, 1)
 struct RawBaroData {
 	float pressure;
-	float altitude;
 	float temperature;
 };
 #pragma pack(pop)

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -245,8 +245,10 @@ void Simulator::update_sensors(mavlink_hil_sensor_t *imu)
 	perf_begin(_perf_mag);
 
 	RawBaroData baro = {};
-	// calculate air pressure from altitude (valid for low altitude)
-	baro.pressure = (PRESS_GROUND - CONSTANTS_ONE_G * DENSITY * imu->pressure_alt) / 100.0f; // convert from Pa to mbar
+
+	// Get air pressure and pressure altitude
+	// valid for troposphere (below 11km AMSL)
+	baro.pressure = imu->abs_pressure;
 	baro.altitude = imu->pressure_alt;
 	baro.temperature = imu->temperature;
 

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -1073,7 +1073,6 @@ int Simulator::publish_sensor_topics(mavlink_hil_sensor_t *imu)
 
 		baro.timestamp = timestamp;
 		baro.pressure = imu->abs_pressure;
-		baro.altitude = imu->pressure_alt;
 		baro.temperature = imu->temperature;
 
 		int baro_multi;

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -249,7 +249,6 @@ void Simulator::update_sensors(mavlink_hil_sensor_t *imu)
 	// Get air pressure and pressure altitude
 	// valid for troposphere (below 11km AMSL)
 	baro.pressure = imu->abs_pressure;
-	baro.altitude = imu->pressure_alt;
 	baro.temperature = imu->temperature;
 
 	write_baro_data(&baro);
@@ -652,7 +651,6 @@ void Simulator::initializeSensorData()
 	RawBaroData baro = {};
 	// calculate air pressure from altitude (valid for low altitude)
 	baro.pressure = 120000.0f;
-	baro.altitude = 0.0f;
 	baro.temperature = 25.0f;
 
 	write_baro_data(&baro);

--- a/src/modules/uavcan/sensors/baro.cpp
+++ b/src/modules/uavcan/sensors/baro.cpp
@@ -98,21 +98,6 @@ ssize_t UavcanBarometerBridge::read(struct file *filp, char *buffer, size_t bufl
 int UavcanBarometerBridge::ioctl(struct file *filp, int cmd, unsigned long arg)
 {
 	switch (cmd) {
-	case BAROIOCSMSLPRESSURE: {
-			if ((arg < 80000) || (arg > 120000)) {
-				return -EINVAL;
-
-			} else {
-				DEVICE_LOG("new msl pressure %u", _msl_pressure);
-				_msl_pressure = arg;
-				return OK;
-			}
-		}
-
-	case BAROIOCGMSLPRESSURE: {
-			return _msl_pressure;
-		}
-
 	case SENSORIOCSPOLLRATE: {
 			// not supported yet, pretend that everything is ok
 			return OK;
@@ -167,20 +152,6 @@ void UavcanBarometerBridge::air_pressure_sub_cb(const
 
 	/* TODO get device ID for sensor */
 	report.device_id = 0;
-
-	/*
-	 * Altitude computation
-	 * Refer to the MS5611 driver for details
-	 */
-	const double T1 = 15.0 + 273.15; // temperature at base height in Kelvin
-	const double a  = -6.5 / 1000;   // temperature gradient in degrees per metre
-	const double g  = 9.80665;       // gravity constant in m/s/s
-	const double R  = 287.05;        // ideal gas constant in J/kg/K
-
-	const double p1 = _msl_pressure / 1000.0;      // current pressure at MSL in kPa
-	const double p = double(msg.static_pressure) / 1000.0; // measured pressure in kPa
-
-	report.altitude = (((std::pow((p / p1), (-(a * R) / g))) * T1) - T1) / a;
 
 	// add to the ring buffer
 	_reports.force(&report);

--- a/src/modules/uavcan/sensors/baro.hpp
+++ b/src/modules/uavcan/sensors/baro.hpp
@@ -79,7 +79,6 @@ private:
 
 	ringbuffer::RingBuffer _reports;
 
-	unsigned _msl_pressure = 101325;
 	float last_temperature_kelvin = 0.0f;
 
 };

--- a/src/platforms/posix/drivers/barosim/CMakeLists.txt
+++ b/src/platforms/posix/drivers/barosim/CMakeLists.txt
@@ -36,7 +36,6 @@ include_directories(${PX4_SOURCE_DIR}/mavlink/include/mavlink)
 px4_add_module(
 	MODULE platforms__posix__drivers__barosim
 	MAIN barosim
-	COMPILE_FLAGS
 	SRCS
 		baro.cpp
 	DEPENDS

--- a/src/platforms/posix/drivers/barosim/baro.cpp
+++ b/src/platforms/posix/drivers/barosim/baro.cpp
@@ -101,9 +101,6 @@ protected:
 	/* last report */
 	struct baro_report	report;
 
-	/* altitude conversion calibration */
-	unsigned		_msl_pressure;	/* in Pa */
-
 	orb_advert_t		_baro_topic;
 	int			_orb_class_instance;
 
@@ -136,7 +133,6 @@ BAROSIM::BAROSIM(const char *path) :
 	VirtDevObj("BAROSIM", path, BARO_BASE_DEVICE_PATH, BAROSIM_MEASURE_INTERVAL_US),
 	_reports(nullptr),
 	report{},
-	_msl_pressure(101325),
 	_baro_topic(nullptr),
 	_orb_class_instance(-1),
 	_sample_perf(perf_alloc(PC_ELAPSED, "barosim_read")),
@@ -202,27 +198,6 @@ out:
 int
 BAROSIM::devIOCTL(unsigned long cmd, unsigned long arg)
 {
-	//PX4_WARN("baro IOCTL %" PRIu64 , hrt_absolute_time());
-
-	switch (cmd) {
-
-	case BAROIOCSMSLPRESSURE:
-
-		/* range-check for sanity */
-		if ((arg < 80000) || (arg > 120000)) {
-			return -EINVAL;
-		}
-
-		_msl_pressure = arg;
-		return OK;
-
-	case BAROIOCGMSLPRESSURE:
-		return _msl_pressure;
-
-	default:
-		break;
-	}
-
 	/* give it to the bus-specific superclass */
 	// return bus_ioctl(filp, cmd, arg);
 	return VirtDevObj::devIOCTL(cmd, arg);
@@ -264,7 +239,6 @@ BAROSIM::collect()
 	}
 
 	report.pressure = raw_baro.pressure;
-	report.altitude = raw_baro.altitude;
 	report.temperature = raw_baro.temperature;
 
 	/* fake device ID */

--- a/src/platforms/posix/drivers/barosim/baro.cpp
+++ b/src/platforms/posix/drivers/barosim/baro.cpp
@@ -139,7 +139,6 @@ BAROSIM::BAROSIM(const char *path) :
 	_measure_perf(perf_alloc(PC_ELAPSED, "barosim_measure")),
 	_comms_errors(perf_alloc(PC_COUNT, "barosim_comms_errors"))
 {
-
 }
 
 BAROSIM::~BAROSIM()
@@ -190,6 +189,9 @@ BAROSIM::init()
 		PX4_ERR("failed to create sensor_baro publication");
 		return -ENODEV;
 	}
+
+	/* fill report structures */
+	start();
 
 out:
 	return ret;

--- a/src/platforms/posix/drivers/df_bmp280_wrapper/df_bmp280_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_bmp280_wrapper/df_bmp280_wrapper.cpp
@@ -150,39 +150,11 @@ int DfBmp280Wrapper::_publish(struct baro_sensor_data &data)
 {
 	perf_begin(_baro_sample_perf);
 
-	baro_report baro_report = {};
+	baro_report baro_report;
 	baro_report.timestamp = hrt_absolute_time();
 
 	baro_report.pressure = data.pressure_pa / 100.0f; // to mbar
 	baro_report.temperature = data.temperature_c;
-
-	// TODO: verify this, it's just copied from the MS5611 driver.
-
-	// Constant for now
-	const double MSL_PRESSURE_KPA = 101325.0 / 1000.0;
-
-	/* tropospheric properties (0-11km) for standard atmosphere */
-	const double T1 = 15.0 + 273.15;	/* temperature at base height in Kelvin */
-	const double a  = -6.5 / 1000;	/* temperature gradient in degrees per metre */
-	const double g  = 9.80665;	/* gravity constant in m/s/s */
-	const double R  = 287.05;	/* ideal gas constant in J/kg/K */
-
-	/* current pressure at MSL in kPa */
-	double p1 = MSL_PRESSURE_KPA;
-
-	/* measured pressure in kPa */
-	double p = static_cast<double>(data.pressure_pa) / 1000.0;
-
-	/*
-	 * Solve:
-	 *
-	 *     /        -(aR / g)     \
-	 *    | (p / p1)          . T1 | - T1
-	 *     \                      /
-	 * h = -------------------------------  + h1
-	 *                   a
-	 */
-	baro_report.altitude = (((pow((p / p1), (-(a * R) / g))) * T1) - T1) / a;
 
 	// TODO: when is this ever blocked?
 	if (!(m_pub_blocked)) {

--- a/src/platforms/posix/drivers/df_ms5607_wrapper/df_ms5607_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_ms5607_wrapper/df_ms5607_wrapper.cpp
@@ -148,39 +148,11 @@ int DfMS5607Wrapper::_publish(struct baro_sensor_data &data)
 {
 	perf_begin(_baro_sample_perf);
 
-	baro_report baro_report = {};
+	baro_report baro_report;
 	baro_report.timestamp = hrt_absolute_time();
 
 	baro_report.pressure = data.pressure_pa;
 	baro_report.temperature = data.temperature_c;
-
-	// TODO: verify this, it's just copied from the MS5611 driver.
-
-	// Constant for now
-	const double MSL_PRESSURE_KPA = 101325.0 / 1000.0;
-
-	/* tropospheric properties (0-11km) for standard atmosphere */
-	const double T1 = 15.0 + 273.15;	/* temperature at base height in Kelvin */
-	const double a  = -6.5 / 1000;	/* temperature gradient in degrees per metre */
-	const double g  = 9.80665;	/* gravity constant in m/s/s */
-	const double R  = 287.05;	/* ideal gas constant in J/kg/K */
-
-	/* current pressure at MSL in kPa */
-	double p1 = MSL_PRESSURE_KPA;
-
-	/* measured pressure in kPa */
-	double p = static_cast<double>(data.pressure_pa) / 1000.0;
-
-	/*
-	 * Solve:
-	 *
-	 *     /        -(aR / g)     \
-	 *    | (p / p1)          . T1 | - T1
-	 *     \                      /
-	 * h = -------------------------------  + h1
-	 *                   a
-	 */
-	baro_report.altitude = (((pow((p / p1), (-(a * R) / g))) * T1) - T1) / a;
 
 	// TODO: when is this ever blocked?
 	if (!(m_pub_blocked)) {

--- a/src/platforms/posix/drivers/df_ms5611_wrapper/df_ms5611_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_ms5611_wrapper/df_ms5611_wrapper.cpp
@@ -148,39 +148,11 @@ int DfMS5611Wrapper::_publish(struct baro_sensor_data &data)
 {
 	perf_begin(_baro_sample_perf);
 
-	baro_report baro_report = {};
+	baro_report baro_report;
 	baro_report.timestamp = hrt_absolute_time();
 
 	baro_report.pressure = data.pressure_pa / 100.0f; // convert to mbar
 	baro_report.temperature = data.temperature_c;
-
-	// TODO: verify this, it's just copied from the MS5611 driver.
-
-	// Constant for now
-	const double MSL_PRESSURE_KPA = 101325.0 / 1000.0;
-
-	/* tropospheric properties (0-11km) for standard atmosphere */
-	const double T1 = 15.0 + 273.15;	/* temperature at base height in Kelvin */
-	const double a  = -6.5 / 1000;	/* temperature gradient in degrees per metre */
-	const double g  = 9.80665;	/* gravity constant in m/s/s */
-	const double R  = 287.05;	/* ideal gas constant in J/kg/K */
-
-	/* current pressure at MSL in kPa */
-	double p1 = MSL_PRESSURE_KPA;
-
-	/* measured pressure in kPa */
-	double p = static_cast<double>(data.pressure_pa) / 1000.0;
-
-	/*
-	 * Solve:
-	 *
-	 *     /        -(aR / g)     \
-	 *    | (p / p1)          . T1 | - T1
-	 *     \                      /
-	 * h = -------------------------------  + h1
-	 *                   a
-	 */
-	baro_report.altitude = (((pow((p / p1), (-(a * R) / g))) * T1) - T1) / a;
 
 	// TODO: when is this ever blocked?
 	if (!(m_pub_blocked)) {

--- a/src/systemcmds/tests/test_sensors.c
+++ b/src/systemcmds/tests/test_sensors.c
@@ -251,8 +251,7 @@ baro(int argc, char *argv[], const char *path)
 		return ERROR;
 
 	} else {
-		printf("\tBARO pressure: %8.4f mbar\talt: %8.4f m\ttemp: %8.4f deg C\n", (double)buf.pressure, (double)buf.altitude,
-		       (double)buf.temperature);
+		printf("\tBARO pressure: %8.4f mbar\t temp: %8.4f deg C\n", (double)buf.pressure, (double)buf.temperature);
 	}
 
 	/* Let user know everything is ok */


### PR DESCRIPTION
Centralizing the altitude pressure calculation removes a ton of duplication (5k of flash on fmu-v2 alone) and seems better architecturally.

What do we need for baro calibration? Should it happen every boot?