### PR TITLE
delete unused IOCTLs to save flash

### DIFF
--- a/src/drivers/adis16448/adis16448.cpp
+++ b/src/drivers/adis16448/adis16448.cpp
@@ -1197,9 +1197,6 @@ ADIS16448::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 		_set_sample_rate(arg);
 		return OK;
 
-	case GYROIOCGLOWPASS:
-		return _gyro_filter_x.get_cutoff_freq();
-
 	case GYROIOCSSCALE:
 		/* copy scale in */
 		memcpy(&_gyro_scale, (struct gyro_calibration_s *) arg, sizeof(_gyro_scale));

--- a/src/drivers/adis16448/adis16448.cpp
+++ b/src/drivers/adis16448/adis16448.cpp
@@ -1200,13 +1200,6 @@ ADIS16448::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GYROIOCGLOWPASS:
 		return _gyro_filter_x.get_cutoff_freq();
 
-	case GYROIOCSLOWPASS:
-		_gyro_filter_x.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_gyro_filter_y.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_gyro_filter_z.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-
-		return OK;
-
 	case GYROIOCSSCALE:
 		/* copy scale in */
 		memcpy(&_gyro_scale, (struct gyro_calibration_s *) arg, sizeof(_gyro_scale));

--- a/src/drivers/adis16448/adis16448.cpp
+++ b/src/drivers/adis16448/adis16448.cpp
@@ -1111,9 +1111,6 @@ ADIS16448::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _accel_reports->size();
-
 	case ACCELIOCGSAMPLERATE:
 		return _sample_rate;
 
@@ -1187,9 +1184,6 @@ ADIS16448::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _gyro_reports->size();
-
 	case GYROIOCGSAMPLERATE:
 		return _sample_rate;
 
@@ -1254,9 +1248,6 @@ ADIS16448::mag_ioctl(struct file *filp, int cmd, unsigned long arg)
 
 			return OK;
 		}
-
-	case SENSORIOCGQUEUEDEPTH:
-		return _mag_reports->size();
 
 	case MAGIOCGSAMPLERATE:
 		return _sample_rate;

--- a/src/drivers/adis16448/adis16448.cpp
+++ b/src/drivers/adis16448/adis16448.cpp
@@ -1121,9 +1121,6 @@ ADIS16448::ioctl(struct file *filp, int cmd, unsigned long arg)
 		_set_sample_rate(arg);
 		return OK;
 
-	case ACCELIOCGLOWPASS:
-		return _accel_filter_x.get_cutoff_freq();
-
 	case ACCELIOCSSCALE: {
 			/* copy scale, but only if off by a few percent */
 			struct accel_calibration_s *s = (struct accel_calibration_s *) arg;

--- a/src/drivers/adis16448/adis16448.cpp
+++ b/src/drivers/adis16448/adis16448.cpp
@@ -1284,15 +1284,6 @@ ADIS16448::mag_ioctl(struct file *filp, int cmd, unsigned long arg)
 		_set_sample_rate(arg);
 		return OK;
 
-	case MAGIOCGLOWPASS:
-		return _mag_filter_x.get_cutoff_freq();
-
-	case MAGIOCSLOWPASS:
-		_mag_filter_x.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_mag_filter_y.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_mag_filter_z.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		return OK;
-
 	case MAGIOCSSCALE:
 		/* copy scale in */
 		memcpy(&_mag_scale, (struct mag_calibration_s *) arg, sizeof(_mag_scale));

--- a/src/drivers/adis16448/adis16448.cpp
+++ b/src/drivers/adis16448/adis16448.cpp
@@ -1124,12 +1124,6 @@ ADIS16448::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCGLOWPASS:
 		return _accel_filter_x.get_cutoff_freq();
 
-	case ACCELIOCSLOWPASS:
-		_accel_filter_x.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_accel_filter_y.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_accel_filter_z.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		return OK;
-
 	case ACCELIOCSSCALE: {
 			/* copy scale, but only if off by a few percent */
 			struct accel_calibration_s *s = (struct accel_calibration_s *) arg;

--- a/src/drivers/bma180/bma180.cpp
+++ b/src/drivers/bma180/bma180.cpp
@@ -484,9 +484,6 @@ BMA180::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCGSAMPLERATE:
 		return 1200;		/* always operating in low-noise mode */
 
-	case ACCELIOCGLOWPASS:
-		return _current_lowpass;
-
 	case ACCELIOCSSCALE:
 		/* copy scale in */
 		memcpy(&_accel_scale, (struct accel_calibration_s *) arg, sizeof(_accel_scale));

--- a/src/drivers/bma180/bma180.cpp
+++ b/src/drivers/bma180/bma180.cpp
@@ -471,9 +471,6 @@ BMA180::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		/* XXX implement */
 		return -EINVAL;

--- a/src/drivers/bma180/bma180.cpp
+++ b/src/drivers/bma180/bma180.cpp
@@ -484,9 +484,6 @@ BMA180::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCGSAMPLERATE:
 		return 1200;		/* always operating in low-noise mode */
 
-	case ACCELIOCSLOWPASS:
-		return set_lowpass(arg);
-
 	case ACCELIOCGLOWPASS:
 		return _current_lowpass;
 

--- a/src/drivers/bmi055/bmi055_accel.cpp
+++ b/src/drivers/bmi055/bmi055_accel.cpp
@@ -434,9 +434,6 @@ BMI055_accel::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _accel_reports->size();
-
 	case ACCELIOCGSAMPLERATE:
 		return _accel_sample_rate;
 

--- a/src/drivers/bmi055/bmi055_accel.cpp
+++ b/src/drivers/bmi055/bmi055_accel.cpp
@@ -443,9 +443,6 @@ BMI055_accel::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCSSAMPLERATE:
 		return accel_set_sample_rate(arg);
 
-	case ACCELIOCGLOWPASS:
-		return _accel_filter_x.get_cutoff_freq();
-
 	case ACCELIOCSSCALE: {
 			/* copy scale, but only if off by a few percent */
 			struct accel_calibration_s *s = (struct accel_calibration_s *) arg;

--- a/src/drivers/bmi055/bmi055_accel.cpp
+++ b/src/drivers/bmi055/bmi055_accel.cpp
@@ -446,13 +446,6 @@ BMI055_accel::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCGLOWPASS:
 		return _accel_filter_x.get_cutoff_freq();
 
-	case ACCELIOCSLOWPASS:
-		// set software filtering
-		_accel_filter_x.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_accel_filter_y.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_accel_filter_z.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		return OK;
-
 	case ACCELIOCSSCALE: {
 			/* copy scale, but only if off by a few percent */
 			struct accel_calibration_s *s = (struct accel_calibration_s *) arg;

--- a/src/drivers/bmi055/bmi055_accel.cpp
+++ b/src/drivers/bmi055/bmi055_accel.cpp
@@ -471,13 +471,6 @@ BMI055_accel::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCSELFTEST:
 		return accel_self_test();
 
-#ifdef ACCELIOCGHWLOWPASS
-
-	case ACCELIOCGHWLOWPASS:
-		return _dlpf_freq;
-#endif
-
-
 	default:
 		/* give it to the superclass */
 		return SPI::ioctl(filp, cmd, arg);

--- a/src/drivers/bmi055/bmi055_accel.cpp
+++ b/src/drivers/bmi055/bmi055_accel.cpp
@@ -471,12 +471,6 @@ BMI055_accel::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCSELFTEST:
 		return accel_self_test();
 
-#ifdef ACCELIOCSHWLOWPASS
-
-	case ACCELIOCSHWLOWPASS:
-		return OK;
-#endif
-
 #ifdef ACCELIOCGHWLOWPASS
 
 	case ACCELIOCGHWLOWPASS:

--- a/src/drivers/bmi055/bmi055_gyro.cpp
+++ b/src/drivers/bmi055/bmi055_gyro.cpp
@@ -473,12 +473,6 @@ BMI055_gyro::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GYROIOCSELFTEST:
 		return gyro_self_test();
 
-#ifdef GYROIOCSHWLOWPASS
-
-	case GYROIOCSHWLOWPASS:
-		return OK;
-#endif
-
 #ifdef GYROIOCGHWLOWPASS
 
 	case GYROIOCGHWLOWPASS:

--- a/src/drivers/bmi055/bmi055_gyro.cpp
+++ b/src/drivers/bmi055/bmi055_gyro.cpp
@@ -435,9 +435,6 @@ BMI055_gyro::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _gyro_reports->size();
-
 	case GYROIOCGSAMPLERATE:
 		return _gyro_sample_rate;
 

--- a/src/drivers/bmi055/bmi055_gyro.cpp
+++ b/src/drivers/bmi055/bmi055_gyro.cpp
@@ -473,12 +473,6 @@ BMI055_gyro::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GYROIOCSELFTEST:
 		return gyro_self_test();
 
-#ifdef GYROIOCGHWLOWPASS
-
-	case GYROIOCGHWLOWPASS:
-		return _dlpf_freq;
-#endif
-
 	default:
 		/* give it to the superclass */
 		return SPI::ioctl(filp, cmd, arg);

--- a/src/drivers/bmi055/bmi055_gyro.cpp
+++ b/src/drivers/bmi055/bmi055_gyro.cpp
@@ -447,13 +447,6 @@ BMI055_gyro::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GYROIOCGLOWPASS:
 		return _gyro_filter_x.get_cutoff_freq();
 
-	case GYROIOCSLOWPASS:
-		// set software filtering
-		_gyro_filter_x.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_gyro_filter_y.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_gyro_filter_z.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		return OK;
-
 	case GYROIOCSSCALE:
 		/* copy scale in */
 		memcpy(&_gyro_scale, (struct gyro_calibration_s *) arg, sizeof(_gyro_scale));

--- a/src/drivers/bmi055/bmi055_gyro.cpp
+++ b/src/drivers/bmi055/bmi055_gyro.cpp
@@ -444,9 +444,6 @@ BMI055_gyro::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GYROIOCSSAMPLERATE:
 		return gyro_set_sample_rate(arg);
 
-	case GYROIOCGLOWPASS:
-		return _gyro_filter_x.get_cutoff_freq();
-
 	case GYROIOCSSCALE:
 		/* copy scale in */
 		memcpy(&_gyro_scale, (struct gyro_calibration_s *) arg, sizeof(_gyro_scale));

--- a/src/drivers/bmi160/bmi160.cpp
+++ b/src/drivers/bmi160/bmi160.cpp
@@ -795,9 +795,6 @@ BMI160::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GYROIOCSSAMPLERATE:
 		return gyro_set_sample_rate(arg);
 
-	case GYROIOCGLOWPASS:
-		return _gyro_filter_x.get_cutoff_freq();
-
 	case GYROIOCSSCALE:
 		/* copy scale in */
 		memcpy(&_gyro_scale, (struct gyro_calibration_s *) arg, sizeof(_gyro_scale));

--- a/src/drivers/bmi160/bmi160.cpp
+++ b/src/drivers/bmi160/bmi160.cpp
@@ -751,13 +751,6 @@ BMI160::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCSELFTEST:
 		return accel_self_test();
 
-#ifdef ACCELIOCGHWLOWPASS
-
-	case ACCELIOCGHWLOWPASS:
-		return _dlpf_freq;
-#endif
-
-
 	default:
 		/* give it to the superclass */
 		return SPI::ioctl(filp, cmd, arg);

--- a/src/drivers/bmi160/bmi160.cpp
+++ b/src/drivers/bmi160/bmi160.cpp
@@ -726,13 +726,6 @@ BMI160::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCGLOWPASS:
 		return _accel_filter_x.get_cutoff_freq();
 
-	case ACCELIOCSLOWPASS:
-		// set software filtering
-		_accel_filter_x.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_accel_filter_y.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_accel_filter_z.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		return OK;
-
 	case ACCELIOCSSCALE: {
 			/* copy scale, but only if off by a few percent */
 			struct accel_calibration_s *s = (struct accel_calibration_s *) arg;

--- a/src/drivers/bmi160/bmi160.cpp
+++ b/src/drivers/bmi160/bmi160.cpp
@@ -751,13 +751,6 @@ BMI160::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCSELFTEST:
 		return accel_self_test();
 
-#ifdef ACCELIOCSHWLOWPASS
-
-	case ACCELIOCSHWLOWPASS:
-		_set_dlpf_filter(arg);
-		return OK;
-#endif
-
 #ifdef ACCELIOCGHWLOWPASS
 
 	case ACCELIOCGHWLOWPASS:

--- a/src/drivers/bmi160/bmi160.cpp
+++ b/src/drivers/bmi160/bmi160.cpp
@@ -824,13 +824,6 @@ BMI160::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GYROIOCSELFTEST:
 		return gyro_self_test();
 
-#ifdef GYROIOCSHWLOWPASS
-
-	case GYROIOCSHWLOWPASS:
-		_set_dlpf_filter(arg);
-		return OK;
-#endif
-
 #ifdef GYROIOCGHWLOWPASS
 
 	case GYROIOCGHWLOWPASS:

--- a/src/drivers/bmi160/bmi160.cpp
+++ b/src/drivers/bmi160/bmi160.cpp
@@ -798,13 +798,6 @@ BMI160::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GYROIOCGLOWPASS:
 		return _gyro_filter_x.get_cutoff_freq();
 
-	case GYROIOCSLOWPASS:
-		// set software filtering
-		_gyro_filter_x.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_gyro_filter_y.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_gyro_filter_z.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		return OK;
-
 	case GYROIOCSSCALE:
 		/* copy scale in */
 		memcpy(&_gyro_scale, (struct gyro_calibration_s *) arg, sizeof(_gyro_scale));

--- a/src/drivers/bmi160/bmi160.cpp
+++ b/src/drivers/bmi160/bmi160.cpp
@@ -824,12 +824,6 @@ BMI160::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GYROIOCSELFTEST:
 		return gyro_self_test();
 
-#ifdef GYROIOCGHWLOWPASS
-
-	case GYROIOCGHWLOWPASS:
-		return _dlpf_freq;
-#endif
-
 	default:
 		/* give it to the superclass */
 		return SPI::ioctl(filp, cmd, arg);

--- a/src/drivers/bmi160/bmi160.cpp
+++ b/src/drivers/bmi160/bmi160.cpp
@@ -714,9 +714,6 @@ BMI160::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _accel_reports->size();
-
 	case ACCELIOCGSAMPLERATE:
 		return _accel_sample_rate;
 
@@ -785,9 +782,6 @@ BMI160::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 
 			return OK;
 		}
-
-	case SENSORIOCGQUEUEDEPTH:
-		return _gyro_reports->size();
 
 	case GYROIOCGSAMPLERATE:
 		return _gyro_sample_rate;

--- a/src/drivers/bmi160/bmi160.cpp
+++ b/src/drivers/bmi160/bmi160.cpp
@@ -723,9 +723,6 @@ BMI160::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCSSAMPLERATE:
 		return accel_set_sample_rate(arg);
 
-	case ACCELIOCGLOWPASS:
-		return _accel_filter_x.get_cutoff_freq();
-
 	case ACCELIOCSSCALE: {
 			/* copy scale, but only if off by a few percent */
 			struct accel_calibration_s *s = (struct accel_calibration_s *) arg;

--- a/src/drivers/bmm150/bmm150.cpp
+++ b/src/drivers/bmm150/bmm150.cpp
@@ -827,11 +827,6 @@ BMM150::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case MAGIOCGRANGE:
 		return OK;
 
-	case MAGIOCSLOWPASS:
-	case MAGIOCGLOWPASS:
-		/* not supported, no internal filtering */
-		return -EINVAL;
-
 	default:
 		/* give it to the superclass */
 		return I2C::ioctl(filp, cmd, arg);

--- a/src/drivers/bmm150/bmm150.cpp
+++ b/src/drivers/bmm150/bmm150.cpp
@@ -794,9 +794,6 @@ BMM150::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		return reset();
 

--- a/src/drivers/bmp280/bmp280.cpp
+++ b/src/drivers/bmp280/bmp280.cpp
@@ -411,9 +411,6 @@ BMP280::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		/*
 		 * Since we are initialized, we do not need to do anything, since the

--- a/src/drivers/drv_accel.h
+++ b/src/drivers/drv_accel.h
@@ -82,9 +82,6 @@ struct accel_calibration_s {
 /** return the accel internal sample rate in Hz */
 #define ACCELIOCGSAMPLERATE	_ACCELIOC(1)
 
-/** set the accel internal lowpass filter to no lower than (arg) Hz */
-#define ACCELIOCSLOWPASS	_ACCELIOC(2)
-
 /** return the accel internal lowpass filter in Hz */
 #define ACCELIOCGLOWPASS	_ACCELIOC(3)
 

--- a/src/drivers/drv_accel.h
+++ b/src/drivers/drv_accel.h
@@ -82,9 +82,6 @@ struct accel_calibration_s {
 /** return the accel internal sample rate in Hz */
 #define ACCELIOCGSAMPLERATE	_ACCELIOC(1)
 
-/** return the accel internal lowpass filter in Hz */
-#define ACCELIOCGLOWPASS	_ACCELIOC(3)
-
 /** set the accel scaling constants to the structure pointed to by (arg) */
 #define ACCELIOCSSCALE		_ACCELIOC(5)
 

--- a/src/drivers/drv_accel.h
+++ b/src/drivers/drv_accel.h
@@ -97,9 +97,6 @@ struct accel_calibration_s {
 /** get the result of a sensor self-test */
 #define ACCELIOCSELFTEST	_ACCELIOC(9)
 
-/** set the hardware low-pass filter cut-off no lower than (arg) Hz */
-#define ACCELIOCSHWLOWPASS	_ACCELIOC(10)
-
 /** get the hardware low-pass filter cut-off in Hz*/
 #define ACCELIOCGHWLOWPASS	_ACCELIOC(11)
 

--- a/src/drivers/drv_accel.h
+++ b/src/drivers/drv_accel.h
@@ -97,9 +97,6 @@ struct accel_calibration_s {
 /** get the result of a sensor self-test */
 #define ACCELIOCSELFTEST	_ACCELIOC(9)
 
-/** get the hardware low-pass filter cut-off in Hz*/
-#define ACCELIOCGHWLOWPASS	_ACCELIOC(11)
-
 /** determine if hardware is external or onboard */
 #define ACCELIOCGEXTERNAL	_ACCELIOC(12)
 

--- a/src/drivers/drv_gpio.h
+++ b/src/drivers/drv_gpio.h
@@ -77,8 +77,6 @@
 /** clear the GPIOs in (arg) */
 #define GPIO_CLEAR	GPIOC(11)
 
-#define GPIO_SENSOR_RAIL_RESET	GPIOC(13)
-
 #define GPIO_PERIPHERAL_RAIL_RESET	GPIOC(14)
 
 /** configure the board GPIOs in (arg) as outputs, initially low */

--- a/src/drivers/drv_gpio.h
+++ b/src/drivers/drv_gpio.h
@@ -71,9 +71,6 @@
 /** configure the board GPIOs in (arg) as inputs */
 #define GPIO_SET_INPUT	GPIOC(2)
 
-/** configure the board GPIOs in (arg) for the first alternate function (if supported) */
-#define GPIO_SET_ALT_1	GPIOC(3)
-
 /** configure the board GPIO (arg) for the second alternate function (if supported) */
 #define GPIO_SET_ALT_2	GPIOC(4)
 

--- a/src/drivers/drv_gpio.h
+++ b/src/drivers/drv_gpio.h
@@ -89,9 +89,6 @@
 /** clear the GPIOs in (arg) */
 #define GPIO_CLEAR	GPIOC(11)
 
-/** read all the GPIOs and return their values in *(uint32_t *)arg */
-#define GPIO_GET	GPIOC(12)
-
 #define GPIO_SENSOR_RAIL_RESET	GPIOC(13)
 
 #define GPIO_PERIPHERAL_RAIL_RESET	GPIOC(14)

--- a/src/drivers/drv_gpio.h
+++ b/src/drivers/drv_gpio.h
@@ -71,9 +71,6 @@
 /** configure the board GPIOs in (arg) as inputs */
 #define GPIO_SET_INPUT	GPIOC(2)
 
-/** configure the board GPIO (arg) for the second alternate function (if supported) */
-#define GPIO_SET_ALT_2	GPIOC(4)
-
 /** configure the board GPIO (arg) for the third alternate function (if supported) */
 #define GPIO_SET_ALT_3	GPIOC(5)
 

--- a/src/drivers/drv_gpio.h
+++ b/src/drivers/drv_gpio.h
@@ -79,9 +79,6 @@
 
 #define GPIO_PERIPHERAL_RAIL_RESET	GPIOC(14)
 
-/** configure the board GPIOs in (arg) as outputs, initially low */
-#define GPIO_SET_OUTPUT_LOW	GPIOC(15)
-
 /** configure the board GPIOs in (arg) as outputs, initially high */
 #define GPIO_SET_OUTPUT_HIGH	GPIOC(16)
 

--- a/src/drivers/drv_gpio.h
+++ b/src/drivers/drv_gpio.h
@@ -71,9 +71,6 @@
 /** configure the board GPIOs in (arg) as inputs */
 #define GPIO_SET_INPUT	GPIOC(2)
 
-/** configure the board GPIO (arg) for the fourth alternate function (if supported) */
-#define GPIO_SET_ALT_4	GPIOC(6)
-
 /** set the GPIOs in (arg) */
 #define GPIO_SET	GPIOC(10)
 

--- a/src/drivers/drv_gpio.h
+++ b/src/drivers/drv_gpio.h
@@ -79,7 +79,4 @@
 
 #define GPIO_PERIPHERAL_RAIL_RESET	GPIOC(14)
 
-/** configure the board GPIOs in (arg) as outputs, initially high */
-#define GPIO_SET_OUTPUT_HIGH	GPIOC(16)
-
 #endif /* _DRV_GPIO_H */

--- a/src/drivers/drv_gpio.h
+++ b/src/drivers/drv_gpio.h
@@ -71,9 +71,6 @@
 /** configure the board GPIOs in (arg) as inputs */
 #define GPIO_SET_INPUT	GPIOC(2)
 
-/** configure the board GPIO (arg) for the third alternate function (if supported) */
-#define GPIO_SET_ALT_3	GPIOC(5)
-
 /** configure the board GPIO (arg) for the fourth alternate function (if supported) */
 #define GPIO_SET_ALT_4	GPIOC(6)
 

--- a/src/drivers/drv_gpio.h
+++ b/src/drivers/drv_gpio.h
@@ -77,6 +77,4 @@
 /** clear the GPIOs in (arg) */
 #define GPIO_CLEAR	GPIOC(11)
 
-#define GPIO_PERIPHERAL_RAIL_RESET	GPIOC(14)
-
 #endif /* _DRV_GPIO_H */

--- a/src/drivers/drv_gpio.h
+++ b/src/drivers/drv_gpio.h
@@ -68,9 +68,6 @@
 /** configure the board GPIOs in (arg) as outputs */
 #define GPIO_SET_OUTPUT	GPIOC(1)
 
-/** configure the board GPIOs in (arg) as inputs */
-#define GPIO_SET_INPUT	GPIOC(2)
-
 /** set the GPIOs in (arg) */
 #define GPIO_SET	GPIOC(10)
 

--- a/src/drivers/drv_gyro.h
+++ b/src/drivers/drv_gyro.h
@@ -100,9 +100,6 @@ struct gyro_calibration_s {
 /** check the status of the sensor */
 #define GYROIOCSELFTEST		_GYROIOC(8)
 
-/** set the hardware low-pass filter cut-off no lower than (arg) Hz */
-#define GYROIOCSHWLOWPASS	_GYROIOC(9)
-
 /** get the hardware low-pass filter cut-off in Hz*/
 #define GYROIOCGHWLOWPASS	_GYROIOC(10)
 

--- a/src/drivers/drv_gyro.h
+++ b/src/drivers/drv_gyro.h
@@ -80,9 +80,6 @@ struct gyro_calibration_s {
 #define GYROIOCGSAMPLERATE	_GYROIOC(1)
 
 /** set the gyro internal lowpass filter to no lower than (arg) Hz */
-#define GYROIOCSLOWPASS		_GYROIOC(2)
-
-/** set the gyro internal lowpass filter to no lower than (arg) Hz */
 #define GYROIOCGLOWPASS		_GYROIOC(3)
 
 /** set the gyro scaling constants to (arg) */

--- a/src/drivers/drv_gyro.h
+++ b/src/drivers/drv_gyro.h
@@ -94,9 +94,6 @@ struct gyro_calibration_s {
 /** check the status of the sensor */
 #define GYROIOCSELFTEST		_GYROIOC(8)
 
-/** determine if hardware is external or onboard */
-#define GYROIOCGEXTERNAL	_GYROIOC(12)
-
 /** get the current gyro type */
 #define GYROIOCTYPE			_GYROIOC(13)
 

--- a/src/drivers/drv_gyro.h
+++ b/src/drivers/drv_gyro.h
@@ -79,9 +79,6 @@ struct gyro_calibration_s {
 /** return the gyro internal sample rate in Hz */
 #define GYROIOCGSAMPLERATE	_GYROIOC(1)
 
-/** set the gyro internal lowpass filter to no lower than (arg) Hz */
-#define GYROIOCGLOWPASS		_GYROIOC(3)
-
 /** set the gyro scaling constants to (arg) */
 #define GYROIOCSSCALE		_GYROIOC(4)
 

--- a/src/drivers/drv_gyro.h
+++ b/src/drivers/drv_gyro.h
@@ -100,9 +100,6 @@ struct gyro_calibration_s {
 /** check the status of the sensor */
 #define GYROIOCSELFTEST		_GYROIOC(8)
 
-/** get the hardware low-pass filter cut-off in Hz*/
-#define GYROIOCGHWLOWPASS	_GYROIOC(10)
-
 /** determine if hardware is external or onboard */
 #define GYROIOCGEXTERNAL	_GYROIOC(12)
 

--- a/src/drivers/drv_mag.h
+++ b/src/drivers/drv_mag.h
@@ -75,12 +75,6 @@ struct mag_calibration_s {
 /** return the mag internal sample rate in Hz */
 #define MAGIOCGSAMPLERATE	_MAGIOC(1)
 
-/** set the mag internal lowpass filter to no lower than (arg) Hz */
-#define MAGIOCSLOWPASS		_MAGIOC(2)
-
-/** return the mag internal lowpass filter in Hz */
-#define MAGIOCGLOWPASS		_MAGIOC(3)
-
 /** set the mag scaling constants to the structure pointed to by (arg) */
 #define MAGIOCSSCALE		_MAGIOC(4)
 

--- a/src/drivers/drv_pwm_output.h
+++ b/src/drivers/drv_pwm_output.h
@@ -248,9 +248,6 @@ struct pwm_output_rc_config {
 /** force safety switch on (to enable use of safety switch) */
 #define PWM_SERVO_SET_FORCE_SAFETY_ON		_PX4_IOC(_PWM_SERVO_BASE, 28)
 
-/** set the 'OVERRIDE OK' bit, which allows for RC control on FMU loss */
-#define PWM_SERVO_SET_OVERRIDE_OK		_PX4_IOC(_PWM_SERVO_BASE, 30)
-
 /** clear the 'OVERRIDE OK' bit, which allows for RC control on FMU loss */
 #define PWM_SERVO_CLEAR_OVERRIDE_OK		_PX4_IOC(_PWM_SERVO_BASE, 31)
 

--- a/src/drivers/drv_pwm_output.h
+++ b/src/drivers/drv_pwm_output.h
@@ -248,9 +248,6 @@ struct pwm_output_rc_config {
 /** force safety switch on (to enable use of safety switch) */
 #define PWM_SERVO_SET_FORCE_SAFETY_ON		_PX4_IOC(_PWM_SERVO_BASE, 28)
 
-/** clear the 'OVERRIDE OK' bit, which allows for RC control on FMU loss */
-#define PWM_SERVO_CLEAR_OVERRIDE_OK		_PX4_IOC(_PWM_SERVO_BASE, 31)
-
 /** setup OVERRIDE_IMMEDIATE behaviour on FMU fail */
 #define PWM_SERVO_SET_OVERRIDE_IMMEDIATE	_PX4_IOC(_PWM_SERVO_BASE, 32)
 

--- a/src/drivers/drv_pwm_output.h
+++ b/src/drivers/drv_pwm_output.h
@@ -248,9 +248,6 @@ struct pwm_output_rc_config {
 /** force safety switch on (to enable use of safety switch) */
 #define PWM_SERVO_SET_FORCE_SAFETY_ON		_PX4_IOC(_PWM_SERVO_BASE, 28)
 
-/** set RC config for a channel. This takes a pointer to pwm_output_rc_config */
-#define PWM_SERVO_SET_RC_CONFIG			_PX4_IOC(_PWM_SERVO_BASE, 29)
-
 /** set the 'OVERRIDE OK' bit, which allows for RC control on FMU loss */
 #define PWM_SERVO_SET_OVERRIDE_OK		_PX4_IOC(_PWM_SERVO_BASE, 30)
 

--- a/src/drivers/drv_range_finder.h
+++ b/src/drivers/drv_range_finder.h
@@ -48,21 +48,4 @@
 #define RANGE_FINDER0_DEVICE_PATH	"/dev/range_finder0"
 #define MB12XX_MAX_RANGEFINDERS	12	// Maximum number of Maxbotix sensors on bus
 
-/*
- * ioctl() definitions
- *
- * Rangefinder drivers also implement the generic sensor driver
- * interfaces from drv_sensor.h
- */
-
-#define _RANGEFINDERIOCBASE			(0x7900)
-#define __RANGEFINDERIOC(_n)		(_IOC(_RANGEFINDERIOCBASE, _n))
-
-/** set the minimum effective distance of the device */
-#define RANGEFINDERIOCSETMINIUMDISTANCE	__RANGEFINDERIOC(1)
-
-/** set the maximum effective distance of the device */
-#define RANGEFINDERIOCSETMAXIUMDISTANCE	__RANGEFINDERIOC(2)
-
-
 #endif /* _DRV_RANGEFINDER_H */

--- a/src/drivers/drv_rc_input.h
+++ b/src/drivers/drv_rc_input.h
@@ -88,9 +88,6 @@ typedef uint16_t		rc_input_t;
 
 #define _RC_INPUT_BASE		0x2b00
 
-/** Fetch R/C input values into (rc_input_values *)arg */
-#define RC_INPUT_GET			_IOC(_RC_INPUT_BASE, 0)
-
 /** Enable RSSI input via ADC */
 #define RC_INPUT_ENABLE_RSSI_ANALOG	_IOC(_RC_INPUT_BASE, 1)
 

--- a/src/drivers/drv_sensor.h
+++ b/src/drivers/drv_sensor.h
@@ -147,9 +147,4 @@
  */
 #define SENSORIOCRESET		_SENSORIOC(4)
 
-/**
- * Test the sensor calibration
- */
-#define SENSORIOCCALTEST	_SENSORIOC(7)
-
 #endif /* _DRV_SENSOR_H */

--- a/src/drivers/drv_sensor.h
+++ b/src/drivers/drv_sensor.h
@@ -148,11 +148,6 @@
 #define SENSORIOCRESET		_SENSORIOC(4)
 
 /**
- * Get the sensor orientation
- */
-#define SENSORIOCGROTATION	_SENSORIOC(6)
-
-/**
  * Test the sensor calibration
  */
 #define SENSORIOCCALTEST	_SENSORIOC(7)

--- a/src/drivers/drv_sensor.h
+++ b/src/drivers/drv_sensor.h
@@ -148,11 +148,6 @@
 #define SENSORIOCRESET		_SENSORIOC(4)
 
 /**
- * Set the sensor orientation
- */
-#define SENSORIOCSROTATION	_SENSORIOC(5)
-
-/**
  * Get the sensor orientation
  */
 #define SENSORIOCGROTATION	_SENSORIOC(6)

--- a/src/drivers/drv_sensor.h
+++ b/src/drivers/drv_sensor.h
@@ -139,9 +139,6 @@
  */
 #define SENSORIOCSQUEUEDEPTH	_SENSORIOC(2)
 
-/** return the internal queue depth */
-#define SENSORIOCGQUEUEDEPTH	_SENSORIOC(3)
-
 /**
  * Reset the sensor to its default configuration
  */

--- a/src/drivers/fxas21002c/fxas21002c.cpp
+++ b/src/drivers/fxas21002c/fxas21002c.cpp
@@ -723,9 +723,6 @@ FXAS21002C::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GYROIOCGSAMPLERATE:
 		return _current_rate;
 
-	case GYROIOCGLOWPASS:
-		return static_cast<int>(_gyro_filter_x.get_cutoff_freq());
-
 	case GYROIOCSSCALE:
 		/* copy scale in */
 		memcpy(&_gyro_scale, (struct gyro_calibration_s *) arg, sizeof(_gyro_scale));

--- a/src/drivers/fxas21002c/fxas21002c.cpp
+++ b/src/drivers/fxas21002c/fxas21002c.cpp
@@ -710,9 +710,6 @@ FXAS21002C::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		reset();
 		return OK;

--- a/src/drivers/fxas21002c/fxas21002c.cpp
+++ b/src/drivers/fxas21002c/fxas21002c.cpp
@@ -723,14 +723,6 @@ FXAS21002C::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GYROIOCGSAMPLERATE:
 		return _current_rate;
 
-	case GYROIOCSLOWPASS: {
-			float cutoff_freq_hz = arg;
-			float sample_rate = 1.0e6f / _call_interval;
-			set_driver_lowpass_filter(sample_rate, cutoff_freq_hz);
-
-			return OK;
-		}
-
 	case GYROIOCGLOWPASS:
 		return static_cast<int>(_gyro_filter_x.get_cutoff_freq());
 

--- a/src/drivers/fxos8701cq/fxos8701cq.cpp
+++ b/src/drivers/fxos8701cq/fxos8701cq.cpp
@@ -860,9 +860,6 @@ FXOS8701CQ::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCGSAMPLERATE:
 		return _accel_samplerate;
 
-	case ACCELIOCGLOWPASS:
-		return static_cast<int>(_accel_filter_x.get_cutoff_freq());
-
 	case ACCELIOCSSCALE: {
 			/* copy scale, but only if off by a few percent */
 			struct accel_calibration_s *s = (struct accel_calibration_s *) arg;
@@ -1829,13 +1826,6 @@ test()
 	PX4_INFO("accel z: \t%d\traw", (int)accel_report.z_raw);
 
 	PX4_INFO("accel range: %8.4f m/s^2", (double)accel_report.range_m_s2);
-
-	if (PX4_ERROR == (ret = ioctl(fd_accel, ACCELIOCGLOWPASS, 0))) {
-		PX4_ERR("accel antialias filter bandwidth: fail");
-
-	} else {
-		PX4_INFO("accel antialias filter bandwidth: %d Hz", ret);
-	}
 
 	/* get the driver */
 	fd_mag = open(FXOS8701C_DEVICE_PATH_MAG, O_RDONLY);

--- a/src/drivers/fxos8701cq/fxos8701cq.cpp
+++ b/src/drivers/fxos8701cq/fxos8701cq.cpp
@@ -847,9 +847,6 @@ FXOS8701CQ::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _accel_reports->size();
-
 	case SENSORIOCRESET:
 		reset();
 		return OK;
@@ -974,9 +971,6 @@ FXOS8701CQ::mag_ioctl(struct file *filp, int cmd, unsigned long arg)
 
 			return OK;
 		}
-
-	case SENSORIOCGQUEUEDEPTH:
-		return _mag_reports->size();
 
 	case SENSORIOCRESET:
 		reset();

--- a/src/drivers/fxos8701cq/fxos8701cq.cpp
+++ b/src/drivers/fxos8701cq/fxos8701cq.cpp
@@ -860,10 +860,6 @@ FXOS8701CQ::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCGSAMPLERATE:
 		return _accel_samplerate;
 
-	case ACCELIOCSLOWPASS: {
-			return accel_set_driver_lowpass_filter((float)_accel_samplerate, (float)arg);
-		}
-
 	case ACCELIOCGLOWPASS:
 		return static_cast<int>(_accel_filter_x.get_cutoff_freq());
 

--- a/src/drivers/fxos8701cq/fxos8701cq.cpp
+++ b/src/drivers/fxos8701cq/fxos8701cq.cpp
@@ -995,11 +995,6 @@ FXOS8701CQ::mag_ioctl(struct file *filp, int cmd, unsigned long arg)
 	case MAGIOCGSAMPLERATE:
 		return _mag_samplerate;
 
-	case MAGIOCSLOWPASS:
-	case MAGIOCGLOWPASS:
-		/* not supported, no internal filtering */
-		return -EINVAL;
-
 	case MAGIOCSSCALE:
 		/* copy scale in */
 		memcpy(&_mag_scale, (struct mag_calibration_s *) arg, sizeof(_mag_scale));

--- a/src/drivers/hc_sr04/hc_sr04.cpp
+++ b/src/drivers/hc_sr04/hc_sr04.cpp
@@ -445,9 +445,6 @@ HC_SR04::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		/* XXX implement this */
 		return -EINVAL;

--- a/src/drivers/hc_sr04/hc_sr04.cpp
+++ b/src/drivers/hc_sr04/hc_sr04.cpp
@@ -452,18 +452,6 @@ HC_SR04::ioctl(struct file *filp, int cmd, unsigned long arg)
 		/* XXX implement this */
 		return -EINVAL;
 
-	case RANGEFINDERIOCSETMINIUMDISTANCE: {
-			set_minimum_distance(*(float *)arg);
-			return 0;
-		}
-		break;
-
-	case RANGEFINDERIOCSETMAXIUMDISTANCE: {
-			set_maximum_distance(*(float *)arg);
-			return 0;
-		}
-		break;
-
 	default:
 		/* give it to the superclass */
 		return CDev::ioctl(filp, cmd, arg);

--- a/src/drivers/hmc5883/hmc5883.cpp
+++ b/src/drivers/hmc5883/hmc5883.cpp
@@ -704,9 +704,6 @@ HMC5883::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		return reset();
 

--- a/src/drivers/hmc5883/hmc5883.cpp
+++ b/src/drivers/hmc5883/hmc5883.cpp
@@ -724,11 +724,6 @@ HMC5883::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case MAGIOCGRANGE:
 		return _range_ga;
 
-	case MAGIOCSLOWPASS:
-	case MAGIOCGLOWPASS:
-		/* not supported, no internal filtering */
-		return -EINVAL;
-
 	case MAGIOCSSCALE:
 		/* set new scale factors */
 		memcpy(&_scale, (struct mag_calibration_s *)arg, sizeof(_scale));

--- a/src/drivers/ist8310/ist8310.cpp
+++ b/src/drivers/ist8310/ist8310.cpp
@@ -703,9 +703,6 @@ IST8310::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		return reset();
 

--- a/src/drivers/ist8310/ist8310.cpp
+++ b/src/drivers/ist8310/ist8310.cpp
@@ -726,12 +726,6 @@ IST8310::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case MAGIOCEXSTRAP:
 		return set_selftest(arg);
 
-
-	case MAGIOCSLOWPASS:
-	case MAGIOCGLOWPASS:
-		/* not supported, no internal filtering */
-		return -EINVAL;
-
 	case MAGIOCSSCALE:
 		/* set new scale factors */
 		memcpy(&_scale, (struct mag_calibration_s *)arg, sizeof(_scale));

--- a/src/drivers/l3gd20/l3gd20.cpp
+++ b/src/drivers/l3gd20/l3gd20.cpp
@@ -670,9 +670,6 @@ L3GD20::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GYROIOCGSAMPLERATE:
 		return _current_rate;
 
-	case GYROIOCGLOWPASS:
-		return static_cast<int>(_gyro_filter_x.get_cutoff_freq());
-
 	case GYROIOCSSCALE:
 		/* copy scale in */
 		memcpy(&_gyro_scale, (struct gyro_calibration_s *) arg, sizeof(_gyro_scale));

--- a/src/drivers/l3gd20/l3gd20.cpp
+++ b/src/drivers/l3gd20/l3gd20.cpp
@@ -657,9 +657,6 @@ L3GD20::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		reset();
 		return OK;

--- a/src/drivers/l3gd20/l3gd20.cpp
+++ b/src/drivers/l3gd20/l3gd20.cpp
@@ -670,14 +670,6 @@ L3GD20::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GYROIOCGSAMPLERATE:
 		return _current_rate;
 
-	case GYROIOCSLOWPASS: {
-			float cutoff_freq_hz = arg;
-			float sample_rate = 1.0e6f / _call_interval;
-			set_driver_lowpass_filter(sample_rate, cutoff_freq_hz);
-
-			return OK;
-		}
-
 	case GYROIOCGLOWPASS:
 		return static_cast<int>(_gyro_filter_x.get_cutoff_freq());
 

--- a/src/drivers/lis3mdl/lis3mdl.cpp
+++ b/src/drivers/lis3mdl/lis3mdl.cpp
@@ -730,11 +730,6 @@ LIS3MDL::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case MAGIOCGRANGE:
 		return _range_ga;
 
-	case MAGIOCSLOWPASS:
-	case MAGIOCGLOWPASS:
-		/* not supported, no internal filtering */
-		return -EINVAL;
-
 	case MAGIOCSSCALE:
 		/* set new scale factors */
 		memcpy(&_scale, (struct mag_calibration_s *)arg, sizeof(_scale));

--- a/src/drivers/lis3mdl/lis3mdl.cpp
+++ b/src/drivers/lis3mdl/lis3mdl.cpp
@@ -710,9 +710,6 @@ LIS3MDL::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		return reset();
 

--- a/src/drivers/ll40ls/LidarLite.cpp
+++ b/src/drivers/ll40ls/LidarLite.cpp
@@ -152,18 +152,6 @@ int LidarLite::ioctl(struct file *filp, int cmd, unsigned long arg)
 		reset_sensor();
 		return OK;
 
-	case RANGEFINDERIOCSETMINIUMDISTANCE: {
-			set_minimum_distance(*(float *)arg);
-			return OK;
-		}
-		break;
-
-	case RANGEFINDERIOCSETMAXIUMDISTANCE: {
-			set_maximum_distance(*(float *)arg);
-			return OK;
-		}
-		break;
-
 	default:
 		return -EINVAL;
 	}

--- a/src/drivers/ll40ls/LidarLiteI2C.cpp
+++ b/src/drivers/ll40ls/LidarLiteI2C.cpp
@@ -221,9 +221,6 @@ int LidarLiteI2C::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	default: {
 			int result = LidarLite::ioctl(filp, cmd, arg);
 

--- a/src/drivers/lps25h/lps25h.cpp
+++ b/src/drivers/lps25h/lps25h.cpp
@@ -552,9 +552,6 @@ LPS25H::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		return reset();
 

--- a/src/drivers/lsm303d/lsm303d.cpp
+++ b/src/drivers/lsm303d/lsm303d.cpp
@@ -929,10 +929,6 @@ LSM303D::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCGSAMPLERATE:
 		return _accel_samplerate;
 
-	case ACCELIOCSLOWPASS: {
-			return accel_set_driver_lowpass_filter((float)_accel_samplerate, (float)arg);
-		}
-
 	case ACCELIOCGLOWPASS:
 		return static_cast<int>(_accel_filter_x.get_cutoff_freq());
 

--- a/src/drivers/lsm303d/lsm303d.cpp
+++ b/src/drivers/lsm303d/lsm303d.cpp
@@ -916,9 +916,6 @@ LSM303D::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _accel_reports->size();
-
 	case SENSORIOCRESET:
 		reset();
 		return OK;
@@ -1043,9 +1040,6 @@ LSM303D::mag_ioctl(struct file *filp, int cmd, unsigned long arg)
 
 			return OK;
 		}
-
-	case SENSORIOCGQUEUEDEPTH:
-		return _mag_reports->size();
 
 	case SENSORIOCRESET:
 		reset();

--- a/src/drivers/lsm303d/lsm303d.cpp
+++ b/src/drivers/lsm303d/lsm303d.cpp
@@ -929,9 +929,6 @@ LSM303D::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCGSAMPLERATE:
 		return _accel_samplerate;
 
-	case ACCELIOCGLOWPASS:
-		return static_cast<int>(_accel_filter_x.get_cutoff_freq());
-
 	case ACCELIOCSSCALE: {
 			/* copy scale, but only if off by a few percent */
 			struct accel_calibration_s *s = (struct accel_calibration_s *) arg;
@@ -1983,13 +1980,6 @@ test()
 	warnx("accel z: \t%d\traw", (int)accel_report.z_raw);
 
 	warnx("accel range: %8.4f m/s^2", (double)accel_report.range_m_s2);
-
-	if (PX4_ERROR == (ret = ioctl(fd_accel, ACCELIOCGLOWPASS, 0))) {
-		warnx("accel antialias filter bandwidth: fail");
-
-	} else {
-		warnx("accel antialias filter bandwidth: %d Hz", ret);
-	}
 
 	int fd_mag = -1;
 	struct mag_report m_report;

--- a/src/drivers/lsm303d/lsm303d.cpp
+++ b/src/drivers/lsm303d/lsm303d.cpp
@@ -1064,11 +1064,6 @@ LSM303D::mag_ioctl(struct file *filp, int cmd, unsigned long arg)
 	case MAGIOCGSAMPLERATE:
 		return _mag_samplerate;
 
-	case MAGIOCSLOWPASS:
-	case MAGIOCGLOWPASS:
-		/* not supported, no internal filtering */
-		return -EINVAL;
-
 	case MAGIOCSSCALE:
 		/* copy scale in */
 		memcpy(&_mag_scale, (struct mag_calibration_s *) arg, sizeof(_mag_scale));

--- a/src/drivers/mb12xx/mb12xx.cpp
+++ b/src/drivers/mb12xx/mb12xx.cpp
@@ -437,9 +437,6 @@ MB12XX::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		/* XXX implement this */
 		return -EINVAL;

--- a/src/drivers/mb12xx/mb12xx.cpp
+++ b/src/drivers/mb12xx/mb12xx.cpp
@@ -444,18 +444,6 @@ MB12XX::ioctl(struct file *filp, int cmd, unsigned long arg)
 		/* XXX implement this */
 		return -EINVAL;
 
-	case RANGEFINDERIOCSETMINIUMDISTANCE: {
-			set_minimum_distance(*(float *)arg);
-			return 0;
-		}
-		break;
-
-	case RANGEFINDERIOCSETMAXIUMDISTANCE: {
-			set_maximum_distance(*(float *)arg);
-			return 0;
-		}
-		break;
-
 	default:
 		/* give it to the superclass */
 		return I2C::ioctl(filp, cmd, arg);

--- a/src/drivers/mpl3115a2/mpl3115a2.cpp
+++ b/src/drivers/mpl3115a2/mpl3115a2.cpp
@@ -482,9 +482,6 @@ MPL3115A2::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET: {
 			/*
 			 * Since we are initialized, we do not need to do anything, since the

--- a/src/drivers/mpu6000/mpu6000.cpp
+++ b/src/drivers/mpu6000/mpu6000.cpp
@@ -1485,20 +1485,6 @@ MPU6000::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCGLOWPASS:
 		return _accel_filter_x.get_cutoff_freq();
 
-	case ACCELIOCSLOWPASS:
-		// set hardware filtering
-		_set_dlpf_filter(arg);
-
-		if (is_icm_device()) {
-			_set_icm_acc_dlpf_filter(arg);
-		}
-
-		// set software filtering
-		_accel_filter_x.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_accel_filter_y.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_accel_filter_z.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		return OK;
-
 	case ACCELIOCSSCALE: {
 			/* copy scale, but only if off by a few percent */
 			struct accel_calibration_s *s = (struct accel_calibration_s *) arg;

--- a/src/drivers/mpu6000/mpu6000.cpp
+++ b/src/drivers/mpu6000/mpu6000.cpp
@@ -1563,14 +1563,6 @@ MPU6000::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GYROIOCGLOWPASS:
 		return _gyro_filter_x.get_cutoff_freq();
 
-	case GYROIOCSLOWPASS:
-		// set hardware filtering
-		_set_dlpf_filter(arg);
-		_gyro_filter_x.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_gyro_filter_y.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_gyro_filter_z.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		return OK;
-
 	case GYROIOCSSCALE:
 		/* copy scale in */
 		memcpy(&_gyro_scale, (struct gyro_calibration_s *) arg, sizeof(_gyro_scale));

--- a/src/drivers/mpu6000/mpu6000.cpp
+++ b/src/drivers/mpu6000/mpu6000.cpp
@@ -1560,9 +1560,6 @@ MPU6000::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 		_set_sample_rate(arg);
 		return OK;
 
-	case GYROIOCGLOWPASS:
-		return _gyro_filter_x.get_cutoff_freq();
-
 	case GYROIOCSSCALE:
 		/* copy scale in */
 		memcpy(&_gyro_scale, (struct gyro_calibration_s *) arg, sizeof(_gyro_scale));

--- a/src/drivers/mpu6000/mpu6000.cpp
+++ b/src/drivers/mpu6000/mpu6000.cpp
@@ -1482,9 +1482,6 @@ MPU6000::ioctl(struct file *filp, int cmd, unsigned long arg)
 		_set_sample_rate(arg);
 		return OK;
 
-	case ACCELIOCGLOWPASS:
-		return _accel_filter_x.get_cutoff_freq();
-
 	case ACCELIOCSSCALE: {
 			/* copy scale, but only if off by a few percent */
 			struct accel_calibration_s *s = (struct accel_calibration_s *) arg;

--- a/src/drivers/mpu6000/mpu6000.cpp
+++ b/src/drivers/mpu6000/mpu6000.cpp
@@ -1472,9 +1472,6 @@ MPU6000::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _accel_reports->size();
-
 	case ACCELIOCGSAMPLERATE:
 		return _sample_rate;
 
@@ -1547,9 +1544,6 @@ MPU6000::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 
 			return OK;
 		}
-
-	case SENSORIOCGQUEUEDEPTH:
-		return _gyro_reports->size();
 
 	case GYROIOCGSAMPLERATE:
 		return _sample_rate;

--- a/src/drivers/mpu6000/mpu6000.cpp
+++ b/src/drivers/mpu6000/mpu6000.cpp
@@ -1583,9 +1583,6 @@ MPU6000::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GYROIOCSELFTEST:
 		return gyro_self_test();
 
-	case GYROIOCGEXTERNAL:
-		return _interface->ioctl(cmd, dummy);
-
 	default:
 		/* give it to the superclass */
 		return CDev::ioctl(filp, cmd, arg);

--- a/src/drivers/mpu6000/mpu6000.cpp
+++ b/src/drivers/mpu6000/mpu6000.cpp
@@ -1522,8 +1522,6 @@ MPU6000::ioctl(struct file *filp, int cmd, unsigned long arg)
 int
 MPU6000::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 {
-	unsigned dummy = arg;
-
 	switch (cmd) {
 
 	/* these are shared with the accel side */

--- a/src/drivers/mpu9250/mag.cpp
+++ b/src/drivers/mpu9250/mag.cpp
@@ -354,9 +354,6 @@ MPU9250_mag::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _mag_reports->size();
-
 	case MAGIOCGSAMPLERATE:
 		return MPU9250_AK8963_SAMPLE_RATE;
 

--- a/src/drivers/mpu9250/mpu9250.cpp
+++ b/src/drivers/mpu9250/mpu9250.cpp
@@ -974,13 +974,6 @@ MPU9250::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GYROIOCGLOWPASS:
 		return _gyro_filter_x.get_cutoff_freq();
 
-	case GYROIOCSLOWPASS:
-		// set software filtering
-		_gyro_filter_x.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_gyro_filter_y.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_gyro_filter_z.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		return OK;
-
 	case GYROIOCSSCALE:
 		/* copy scale in */
 		memcpy(&_gyro_scale, (struct gyro_calibration_s *) arg, sizeof(_gyro_scale));

--- a/src/drivers/mpu9250/mpu9250.cpp
+++ b/src/drivers/mpu9250/mpu9250.cpp
@@ -888,9 +888,6 @@ MPU9250::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _accel_reports->size();
-
 	case ACCELIOCGSAMPLERATE:
 		return _sample_rate;
 
@@ -960,9 +957,6 @@ MPU9250::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 
 			return OK;
 		}
-
-	case SENSORIOCGQUEUEDEPTH:
-		return _gyro_reports->size();
 
 	case GYROIOCGSAMPLERATE:
 		return _sample_rate;

--- a/src/drivers/mpu9250/mpu9250.cpp
+++ b/src/drivers/mpu9250/mpu9250.cpp
@@ -926,12 +926,6 @@ MPU9250::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCSELFTEST:
 		return accel_self_test();
 
-#ifdef ACCELIOCGHWLOWPASS
-
-	case ACCELIOCGHWLOWPASS:
-		return _dlpf_freq;
-#endif
-
 	default:
 		/* give it to the superclass */
 		return CDev::ioctl(filp, cmd, arg);

--- a/src/drivers/mpu9250/mpu9250.cpp
+++ b/src/drivers/mpu9250/mpu9250.cpp
@@ -971,9 +971,6 @@ MPU9250::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 		_set_sample_rate(arg);
 		return OK;
 
-	case GYROIOCGLOWPASS:
-		return _gyro_filter_x.get_cutoff_freq();
-
 	case GYROIOCSSCALE:
 		/* copy scale in */
 		memcpy(&_gyro_scale, (struct gyro_calibration_s *) arg, sizeof(_gyro_scale));

--- a/src/drivers/mpu9250/mpu9250.cpp
+++ b/src/drivers/mpu9250/mpu9250.cpp
@@ -1004,13 +1004,6 @@ MPU9250::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GYROIOCSELFTEST:
 		return gyro_self_test();
 
-#ifdef GYROIOCSHWLOWPASS
-
-	case GYROIOCSHWLOWPASS:
-		_set_dlpf_filter(arg);
-		return OK;
-#endif
-
 #ifdef GYROIOCGHWLOWPASS
 
 	case GYROIOCGHWLOWPASS:

--- a/src/drivers/mpu9250/mpu9250.cpp
+++ b/src/drivers/mpu9250/mpu9250.cpp
@@ -926,13 +926,6 @@ MPU9250::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCSELFTEST:
 		return accel_self_test();
 
-#ifdef ACCELIOCSHWLOWPASS
-
-	case ACCELIOCSHWLOWPASS:
-		_set_dlpf_filter(arg);
-		return OK;
-#endif
-
 #ifdef ACCELIOCGHWLOWPASS
 
 	case ACCELIOCGHWLOWPASS:

--- a/src/drivers/mpu9250/mpu9250.cpp
+++ b/src/drivers/mpu9250/mpu9250.cpp
@@ -898,9 +898,6 @@ MPU9250::ioctl(struct file *filp, int cmd, unsigned long arg)
 		_set_sample_rate(arg);
 		return OK;
 
-	case ACCELIOCGLOWPASS:
-		return _accel_filter_x.get_cutoff_freq();
-
 	case ACCELIOCSSCALE: {
 			/* copy scale, but only if off by a few percent */
 			struct accel_calibration_s *s = (struct accel_calibration_s *) arg;

--- a/src/drivers/mpu9250/mpu9250.cpp
+++ b/src/drivers/mpu9250/mpu9250.cpp
@@ -901,13 +901,6 @@ MPU9250::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCGLOWPASS:
 		return _accel_filter_x.get_cutoff_freq();
 
-	case ACCELIOCSLOWPASS:
-		// set software filtering
-		_accel_filter_x.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_accel_filter_y.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		_accel_filter_z.set_cutoff_frequency(1.0e6f / _call_interval, arg);
-		return OK;
-
 	case ACCELIOCSSCALE: {
 			/* copy scale, but only if off by a few percent */
 			struct accel_calibration_s *s = (struct accel_calibration_s *) arg;

--- a/src/drivers/mpu9250/mpu9250.cpp
+++ b/src/drivers/mpu9250/mpu9250.cpp
@@ -1004,12 +1004,6 @@ MPU9250::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GYROIOCSELFTEST:
 		return gyro_self_test();
 
-#ifdef GYROIOCGHWLOWPASS
-
-	case GYROIOCGHWLOWPASS:
-		return _dlpf_freq;
-#endif
-
 	default:
 		/* give it to the superclass */
 		return CDev::ioctl(filp, cmd, arg);

--- a/src/drivers/ms5611/ms5611.cpp
+++ b/src/drivers/ms5611/ms5611.cpp
@@ -564,9 +564,6 @@ MS5611::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		/*
 		 * Since we are initialized, we do not need to do anything, since the

--- a/src/drivers/pwm_input/pwm_input.cpp
+++ b/src/drivers/pwm_input/pwm_input.cpp
@@ -455,9 +455,6 @@ PWMIN::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		/* user has asked for the timer to be reset. This may
 		 * be needed if the pin was used for a different

--- a/src/drivers/pwm_out_sim/pwm_out_sim.cpp
+++ b/src/drivers/pwm_out_sim/pwm_out_sim.cpp
@@ -900,10 +900,6 @@ hil_new_mode(PortMode new_mode)
 		break;
 	}
 
-//	/* adjust GPIO config for serial mode(s) */
-//	if (gpio_bits != 0)
-//		g_pwm_sim->ioctl(0, GPIO_SET_ALT_1, gpio_bits);
-
 	/* (re)set the PWM output mode */
 	g_pwm_sim->set_mode(servo_mode);
 

--- a/src/drivers/px4flow/px4flow.cpp
+++ b/src/drivers/px4flow/px4flow.cpp
@@ -388,10 +388,6 @@ PX4FLOW::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case SENSORIOCGQUEUEDEPTH:
 		return _reports->size();
 
-	case SENSORIOCSROTATION:
-		_sensor_rotation = (enum Rotation)arg;
-		return OK;
-
 	case SENSORIOCGROTATION:
 		return _sensor_rotation;
 

--- a/src/drivers/px4flow/px4flow.cpp
+++ b/src/drivers/px4flow/px4flow.cpp
@@ -388,9 +388,6 @@ PX4FLOW::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case SENSORIOCGQUEUEDEPTH:
 		return _reports->size();
 
-	case SENSORIOCGROTATION:
-		return _sensor_rotation;
-
 	case SENSORIOCRESET:
 		/* XXX implement this */
 		return -EINVAL;

--- a/src/drivers/px4flow/px4flow.cpp
+++ b/src/drivers/px4flow/px4flow.cpp
@@ -385,9 +385,6 @@ PX4FLOW::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		/* XXX implement this */
 		return -EINVAL;

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -2928,10 +2928,6 @@ PX4FMU::gpio_ioctl(struct file *filp, int cmd, unsigned long arg)
 		ret = gpio_write(arg, cmd);
 		break;
 
-	case GPIO_GET:
-		ret = gpio_read((uint32_t *)arg);
-		break;
-
 	default:
 		ret = -ENOTTY;
 	}

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -2910,10 +2910,6 @@ PX4FMU::gpio_ioctl(struct file *filp, int cmd, unsigned long arg)
 		ret = gpio_set_function(arg, cmd);
 		break;
 
-	case GPIO_SET_ALT_4:
-		ret = -EINVAL;
-		break;
-
 	case GPIO_SET:
 	case GPIO_CLEAR:
 		ret = gpio_write(arg, cmd);

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -2910,7 +2910,6 @@ PX4FMU::gpio_ioctl(struct file *filp, int cmd, unsigned long arg)
 		ret = gpio_set_function(arg, cmd);
 		break;
 
-	case GPIO_SET_ALT_3:
 	case GPIO_SET_ALT_4:
 		ret = -EINVAL;
 		break;

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -2684,14 +2684,6 @@ PX4FMU::gpio_set_function(uint32_t gpios, int function)
 				}
 
 				break;
-
-			case GPIO_SET_OUTPUT_HIGH:
-				if (_gpio_tab[i].output) {
-					px4_arch_configgpio((_gpio_tab[i].output & ~(GPIO_OUTPUT_CLEAR)) | GPIO_OUTPUT_SET);
-				}
-
-				break;
-
 			}
 		}
 	}
@@ -2893,7 +2885,6 @@ PX4FMU::gpio_ioctl(struct file *filp, int cmd, unsigned long arg)
 		break;
 
 	case GPIO_SET_OUTPUT:
-	case GPIO_SET_OUTPUT_HIGH:
 	case GPIO_SET_INPUT:
 		ret = gpio_set_function(arg, cmd);
 		break;

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -2699,12 +2699,6 @@ PX4FMU::gpio_set_function(uint32_t gpios, int function)
 
 				break;
 
-			case GPIO_SET_ALT_1:
-				if (_gpio_tab[i].alt != 0) {
-					px4_arch_configgpio(_gpio_tab[i].alt);
-				}
-
-				break;
 			}
 		}
 	}
@@ -2913,7 +2907,6 @@ PX4FMU::gpio_ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GPIO_SET_OUTPUT_LOW:
 	case GPIO_SET_OUTPUT_HIGH:
 	case GPIO_SET_INPUT:
-	case GPIO_SET_ALT_1:
 		ret = gpio_set_function(arg, cmd);
 		break;
 

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -2880,10 +2880,6 @@ PX4FMU::gpio_ioctl(struct file *filp, int cmd, unsigned long arg)
 		ret = gpio_reset();
 		break;
 
-	case GPIO_PERIPHERAL_RAIL_RESET:
-		peripheral_reset(arg);
-		break;
-
 	case GPIO_SET_OUTPUT:
 	case GPIO_SET_INPUT:
 		ret = gpio_set_function(arg, cmd);

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -2685,13 +2685,6 @@ PX4FMU::gpio_set_function(uint32_t gpios, int function)
 
 				break;
 
-			case GPIO_SET_OUTPUT_LOW:
-				if (_gpio_tab[i].output) {
-					px4_arch_configgpio((_gpio_tab[i].output & ~(GPIO_OUTPUT_SET)) | GPIO_OUTPUT_CLEAR);
-				}
-
-				break;
-
 			case GPIO_SET_OUTPUT_HIGH:
 				if (_gpio_tab[i].output) {
 					px4_arch_configgpio((_gpio_tab[i].output & ~(GPIO_OUTPUT_CLEAR)) | GPIO_OUTPUT_SET);
@@ -2900,7 +2893,6 @@ PX4FMU::gpio_ioctl(struct file *filp, int cmd, unsigned long arg)
 		break;
 
 	case GPIO_SET_OUTPUT:
-	case GPIO_SET_OUTPUT_LOW:
 	case GPIO_SET_OUTPUT_HIGH:
 	case GPIO_SET_INPUT:
 		ret = gpio_set_function(arg, cmd);

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -2910,7 +2910,6 @@ PX4FMU::gpio_ioctl(struct file *filp, int cmd, unsigned long arg)
 		ret = gpio_set_function(arg, cmd);
 		break;
 
-	case GPIO_SET_ALT_2:
 	case GPIO_SET_ALT_3:
 	case GPIO_SET_ALT_4:
 		ret = -EINVAL;

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -2895,10 +2895,6 @@ PX4FMU::gpio_ioctl(struct file *filp, int cmd, unsigned long arg)
 		ret = gpio_reset();
 		break;
 
-	case GPIO_SENSOR_RAIL_RESET:
-		sensor_reset(arg);
-		break;
-
 	case GPIO_PERIPHERAL_RAIL_RESET:
 		peripheral_reset(arg);
 		break;

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -2671,13 +2671,6 @@ PX4FMU::gpio_set_function(uint32_t gpios, int function)
 	for (unsigned i = 0; i < _ngpio; i++) {
 		if (gpios & (1 << i)) {
 			switch (function) {
-			case GPIO_SET_INPUT:
-				if (_gpio_tab[i].input) {
-					px4_arch_configgpio(_gpio_tab[i].input);
-				}
-
-				break;
-
 			case GPIO_SET_OUTPUT:
 				if (_gpio_tab[i].output) {
 					px4_arch_configgpio(_gpio_tab[i].output);
@@ -2881,7 +2874,6 @@ PX4FMU::gpio_ioctl(struct file *filp, int cmd, unsigned long arg)
 		break;
 
 	case GPIO_SET_OUTPUT:
-	case GPIO_SET_INPUT:
 		ret = gpio_set_function(arg, cmd);
 		break;
 

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -2746,10 +2746,6 @@ PX4IO::ioctl(file *filep, int cmd, unsigned long arg)
 		ret = -EINVAL;
 		break;
 
-	case GPIO_GET:
-		ret = -EINVAL;
-		break;
-
 	case MIXERIOCGETOUTPUTCOUNT:
 		*(unsigned *)arg = _max_actuators;
 		break;

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -2764,44 +2764,6 @@ PX4IO::ioctl(file *filep, int cmd, unsigned long arg)
 			break;
 		}
 
-	case RC_INPUT_GET: {
-			uint16_t status;
-			rc_input_values *rc_val = (rc_input_values *)arg;
-
-			ret = io_reg_get(PX4IO_PAGE_STATUS, PX4IO_P_STATUS_FLAGS, &status, 1);
-
-			if (ret != OK) {
-				break;
-			}
-
-			/* if no R/C input, don't try to fetch anything */
-			if (!(status & PX4IO_P_STATUS_FLAGS_RC_OK)) {
-				ret = -ENOTCONN;
-				break;
-			}
-
-			/* sort out the source of the values */
-			if (status & PX4IO_P_STATUS_FLAGS_RC_PPM) {
-				rc_val->input_source = input_rc_s::RC_INPUT_SOURCE_PX4IO_PPM;
-
-			} else if (status & PX4IO_P_STATUS_FLAGS_RC_DSM) {
-				rc_val->input_source = input_rc_s::RC_INPUT_SOURCE_PX4IO_SPEKTRUM;
-
-			} else if (status & PX4IO_P_STATUS_FLAGS_RC_SBUS) {
-				rc_val->input_source = input_rc_s::RC_INPUT_SOURCE_PX4IO_SBUS;
-
-			} else if (status & PX4IO_P_STATUS_FLAGS_RC_ST24) {
-				rc_val->input_source = input_rc_s::RC_INPUT_SOURCE_PX4IO_ST24;
-
-			} else {
-				rc_val->input_source = input_rc_s::RC_INPUT_SOURCE_UNKNOWN;
-			}
-
-			/* read raw R/C input values */
-			ret = io_reg_get(PX4IO_PAGE_RAW_RC_INPUT, PX4IO_P_RAW_RC_BASE, &(rc_val->values[0]), _max_rc_input);
-			break;
-		}
-
 	case PX4IO_SET_DEBUG:
 		/* set the debug level */
 		ret = io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_SET_DEBUG, arg);

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -2842,35 +2842,6 @@ PX4IO::ioctl(file *filep, int cmd, unsigned long arg)
 
 		break;
 
-	case PWM_SERVO_SET_RC_CONFIG: {
-			/* enable setting of RC configuration without relying
-			   on param_get()
-			*/
-			struct pwm_output_rc_config *config = (struct pwm_output_rc_config *)arg;
-
-			if (config->channel >= input_rc_s::RC_INPUT_MAX_CHANNELS) {
-				/* fail with error */
-				return -E2BIG;
-			}
-
-			/* copy values to registers in IO */
-			uint16_t regs[PX4IO_P_RC_CONFIG_STRIDE];
-			uint16_t offset = config->channel * PX4IO_P_RC_CONFIG_STRIDE;
-			regs[PX4IO_P_RC_CONFIG_MIN]        = config->rc_min;
-			regs[PX4IO_P_RC_CONFIG_CENTER]     = config->rc_trim;
-			regs[PX4IO_P_RC_CONFIG_MAX]        = config->rc_max;
-			regs[PX4IO_P_RC_CONFIG_DEADZONE]   = config->rc_dz;
-			regs[PX4IO_P_RC_CONFIG_ASSIGNMENT] = config->rc_assignment;
-			regs[PX4IO_P_RC_CONFIG_OPTIONS]    = PX4IO_P_RC_CONFIG_OPTIONS_ENABLED;
-
-			if (config->rc_reverse) {
-				regs[PX4IO_P_RC_CONFIG_OPTIONS] |= PX4IO_P_RC_CONFIG_OPTIONS_REVERSE;
-			}
-
-			ret = io_reg_set(PX4IO_PAGE_RC_CONFIG, offset, regs, PX4IO_P_RC_CONFIG_STRIDE);
-			break;
-		}
-
 	case PWM_SERVO_SET_OVERRIDE_OK:
 		/* set the 'OVERRIDE OK' bit */
 		ret = io_reg_modify(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_ARMING, 0, PX4IO_P_SETUP_ARMING_MANUAL_OVERRIDE_OK);

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -2842,12 +2842,6 @@ PX4IO::ioctl(file *filep, int cmd, unsigned long arg)
 
 		break;
 
-	case PWM_SERVO_SET_OVERRIDE_OK:
-		/* set the 'OVERRIDE OK' bit */
-		ret = io_reg_modify(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_ARMING, 0, PX4IO_P_SETUP_ARMING_MANUAL_OVERRIDE_OK);
-		_override_available = true;
-		break;
-
 	case PWM_SERVO_CLEAR_OVERRIDE_OK:
 		/* clear the 'OVERRIDE OK' bit */
 		ret = io_reg_modify(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_ARMING, PX4IO_P_SETUP_ARMING_MANUAL_OVERRIDE_OK, 0);

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -2842,12 +2842,6 @@ PX4IO::ioctl(file *filep, int cmd, unsigned long arg)
 
 		break;
 
-	case PWM_SERVO_CLEAR_OVERRIDE_OK:
-		/* clear the 'OVERRIDE OK' bit */
-		ret = io_reg_modify(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_ARMING, PX4IO_P_SETUP_ARMING_MANUAL_OVERRIDE_OK, 0);
-		_override_available = false;
-		break;
-
 	default:
 		/* see if the parent class can make any use of it */
 		ret = CDev::ioctl(filep, cmd, arg);

--- a/src/drivers/sf0x/sf0x.cpp
+++ b/src/drivers/sf0x/sf0x.cpp
@@ -479,18 +479,6 @@ SF0X::ioctl(struct file *filp, int cmd, unsigned long arg)
 		/* XXX implement this */
 		return -EINVAL;
 
-	case RANGEFINDERIOCSETMINIUMDISTANCE: {
-			set_minimum_distance(*(float *)arg);
-			return 0;
-		}
-		break;
-
-	case RANGEFINDERIOCSETMAXIUMDISTANCE: {
-			set_maximum_distance(*(float *)arg);
-			return 0;
-		}
-		break;
-
 	default:
 		/* give it to the superclass */
 		return CDev::ioctl(filp, cmd, arg);

--- a/src/drivers/sf0x/sf0x.cpp
+++ b/src/drivers/sf0x/sf0x.cpp
@@ -472,9 +472,6 @@ SF0X::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		/* XXX implement this */
 		return -EINVAL;

--- a/src/drivers/sf1xx/sf1xx.cpp
+++ b/src/drivers/sf1xx/sf1xx.cpp
@@ -442,18 +442,6 @@ SF1XX::ioctl(struct file *filp, int cmd, unsigned long arg)
 		/* XXX implement this */
 		return -EINVAL;
 
-	case RANGEFINDERIOCSETMINIUMDISTANCE: {
-			set_minimum_distance(*(float *)arg);
-			return 0;
-		}
-		break;
-
-	case RANGEFINDERIOCSETMAXIUMDISTANCE: {
-			set_maximum_distance(*(float *)arg);
-			return 0;
-		}
-		break;
-
 	default:
 		/* give it to the superclass */
 		return I2C::ioctl(filp, cmd, arg);

--- a/src/drivers/sf1xx/sf1xx.cpp
+++ b/src/drivers/sf1xx/sf1xx.cpp
@@ -435,9 +435,6 @@ SF1XX::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		/* XXX implement this */
 		return -EINVAL;

--- a/src/drivers/srf02/srf02.cpp
+++ b/src/drivers/srf02/srf02.cpp
@@ -438,9 +438,6 @@ SRF02::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		/* XXX implement this */
 		return -EINVAL;

--- a/src/drivers/srf02/srf02.cpp
+++ b/src/drivers/srf02/srf02.cpp
@@ -445,18 +445,6 @@ SRF02::ioctl(struct file *filp, int cmd, unsigned long arg)
 		/* XXX implement this */
 		return -EINVAL;
 
-	case RANGEFINDERIOCSETMINIUMDISTANCE: {
-			set_minimum_distance(*(float *)arg);
-			return 0;
-		}
-		break;
-
-	case RANGEFINDERIOCSETMAXIUMDISTANCE: {
-			set_maximum_distance(*(float *)arg);
-			return 0;
-		}
-		break;
-
 	default:
 		/* give it to the superclass */
 		return I2C::ioctl(filp, cmd, arg);

--- a/src/drivers/srf02_i2c/srf02_i2c.cpp
+++ b/src/drivers/srf02_i2c/srf02_i2c.cpp
@@ -439,9 +439,6 @@ SRF02_I2C::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		/* XXX implement this */
 		return -EINVAL;

--- a/src/drivers/srf02_i2c/srf02_i2c.cpp
+++ b/src/drivers/srf02_i2c/srf02_i2c.cpp
@@ -446,18 +446,6 @@ SRF02_I2C::ioctl(struct file *filp, int cmd, unsigned long arg)
 		/* XXX implement this */
 		return -EINVAL;
 
-	case RANGEFINDERIOCSETMINIUMDISTANCE: {
-			set_minimum_distance(*(float *)arg);
-			return 0;
-		}
-		break;
-
-	case RANGEFINDERIOCSETMAXIUMDISTANCE: {
-			set_maximum_distance(*(float *)arg);
-			return 0;
-		}
-		break;
-
 	default:
 		/* give it to the superclass */
 		return I2C::ioctl(filp, cmd, arg);

--- a/src/drivers/teraranger/teraranger.cpp
+++ b/src/drivers/teraranger/teraranger.cpp
@@ -509,18 +509,6 @@ TERARANGER::ioctl(struct file *filp, int cmd, unsigned long arg)
 		/* XXX implement this */
 		return -EINVAL;
 
-	case RANGEFINDERIOCSETMINIUMDISTANCE: {
-			set_minimum_distance(*(float *)arg);
-			return 0;
-		}
-		break;
-
-	case RANGEFINDERIOCSETMAXIUMDISTANCE: {
-			set_maximum_distance(*(float *)arg);
-			return 0;
-		}
-		break;
-
 	default:
 		/* give it to the superclass */
 		return I2C::ioctl(filp, cmd, arg);

--- a/src/drivers/teraranger/teraranger.cpp
+++ b/src/drivers/teraranger/teraranger.cpp
@@ -502,9 +502,6 @@ TERARANGER::ioctl(struct file *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		/* XXX implement this */
 		return -EINVAL;

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -80,12 +80,7 @@ namespace Preflight
 
 static int check_calibration(DevHandle &h, const char *param_template, int &devid)
 {
-	bool calibration_found;
-
-	/* new style: ask device for calibration state */
-	int ret = h.ioctl(SENSORIOCCALTEST, 0);
-
-	calibration_found = (ret == OK);
+	bool calibration_found = false;
 
 	devid = h.ioctl(DEVIOCGDEVICEID, 0);
 

--- a/src/modules/commander/calibration_routines.cpp
+++ b/src/modules/commander/calibration_routines.cpp
@@ -530,24 +530,25 @@ int run_lm_ellipsoid_fit(const float x[], const float y[], const float z[], floa
 enum detect_orientation_return detect_orientation(orb_advert_t *mavlink_log_pub, int cancel_sub, int accel_sub,
 		bool lenient_still_position)
 {
-	const unsigned ndim = 3;
+	static constexpr unsigned ndim = 3;
 
-	struct sensor_combined_s sensor;
 	float		accel_ema[ndim] = { 0.0f };		// exponential moving average of accel
 	float		accel_disp[3] = { 0.0f, 0.0f, 0.0f };	// max-hold dispersion of accel
-	float		ema_len = 0.5f;				// EMA time constant in seconds
-	const float	normal_still_thr = 0.25;		// normal still threshold
+	static constexpr float		ema_len = 0.5f;				// EMA time constant in seconds
+	static constexpr float	normal_still_thr = 0.25;		// normal still threshold
 	float		still_thr2 = powf(lenient_still_position ? (normal_still_thr * 3) : normal_still_thr, 2);
-	float		accel_err_thr = 5.0f;			// set accel error threshold to 5m/s^2
-	hrt_abstime	still_time = lenient_still_position ? 500000 : 1300000;	// still time required in us
+	static constexpr float		accel_err_thr = 5.0f;			// set accel error threshold to 5m/s^2
+	const hrt_abstime	still_time = lenient_still_position ? 500000 : 1300000;	// still time required in us
 
 	px4_pollfd_struct_t fds[1];
 	fds[0].fd = accel_sub;
 	fds[0].events = POLLIN;
 
-	hrt_abstime t_start = hrt_absolute_time();
+	const hrt_abstime t_start = hrt_absolute_time();
+
 	/* set timeout to 30s */
-	hrt_abstime timeout = 30000000;
+	static constexpr hrt_abstime timeout = 30000000;
+
 	hrt_abstime t_timeout = t_start + timeout;
 	hrt_abstime t = t_start;
 	hrt_abstime t_prev = t_start;
@@ -560,6 +561,7 @@ enum detect_orientation_return detect_orientation(orb_advert_t *mavlink_log_pub,
 		int poll_ret = px4_poll(fds, 1, 1000);
 
 		if (poll_ret) {
+			struct sensor_combined_s sensor;
 			orb_copy(ORB_ID(sensor_combined), accel_sub, &sensor);
 			t = hrt_absolute_time();
 			float dt = (t - t_prev) / 1000000.0f;

--- a/src/modules/uORB/uORB.h
+++ b/src/modules/uORB/uORB.h
@@ -49,8 +49,8 @@
  */
 struct orb_metadata {
 	const char *o_name;		/**< unique object name */
-	const size_t o_size;		/**< object size */
-	const size_t o_size_no_padding;	/**< object size w/o padding at the end (for logger) */
+	const uint16_t o_size;		/**< object size */
+	const uint16_t o_size_no_padding;	/**< object size w/o padding at the end (for logger) */
 	const char *o_fields;		/**< semicolon separated list of fields (with type) */
 };
 

--- a/src/modules/uavcan/sensors/mag.cpp
+++ b/src/modules/uavcan/sensors/mag.cpp
@@ -130,9 +130,7 @@ int UavcanMagnetometerBridge::ioctl(struct file *filp, int cmd, unsigned long ar
 	case MAGIOCGSAMPLERATE:
 	case MAGIOCSRANGE:
 	case MAGIOCGRANGE:
-	case MAGIOCSLOWPASS:
-	case MAGIOCEXSTRAP:
-	case MAGIOCGLOWPASS: {
+	case MAGIOCEXSTRAP: {
 			return -EINVAL;
 		}
 

--- a/src/platforms/posix/drivers/accelsim/accelsim.cpp
+++ b/src/platforms/posix/drivers/accelsim/accelsim.cpp
@@ -705,11 +705,6 @@ ACCELSIM::mag_ioctl(unsigned long cmd, unsigned long arg)
 	case MAGIOCGSAMPLERATE:
 		return _mag_samplerate;
 
-	case MAGIOCSLOWPASS:
-	case MAGIOCGLOWPASS:
-		/* not supported, no internal filtering */
-		return -EINVAL;
-
 	case MAGIOCSSCALE:
 		/* copy scale in */
 		memcpy(&_mag_scale, (struct mag_calibration_s *) arg, sizeof(_mag_scale));

--- a/src/platforms/posix/drivers/accelsim/accelsim.cpp
+++ b/src/platforms/posix/drivers/accelsim/accelsim.cpp
@@ -578,10 +578,6 @@ ACCELSIM::devIOCTL(unsigned long cmd, unsigned long arg)
 	case ACCELIOCGSAMPLERATE:
 		return _accel_samplerate;
 
-	case ACCELIOCSLOWPASS: {
-			return accel_set_driver_lowpass_filter((float)_accel_samplerate, (float)ul_arg);
-		}
-
 	case ACCELIOCSSCALE: {
 			/* copy scale, but only if off by a few percent */
 			struct accel_calibration_s *s = (struct accel_calibration_s *) arg;

--- a/src/platforms/posix/drivers/accelsim/accelsim.cpp
+++ b/src/platforms/posix/drivers/accelsim/accelsim.cpp
@@ -564,9 +564,6 @@ ACCELSIM::devIOCTL(unsigned long cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _accel_reports->size();
-
 	case SENSORIOCRESET:
 		// Nothing to do for simulator
 		return OK;
@@ -686,9 +683,6 @@ ACCELSIM::mag_ioctl(unsigned long cmd, unsigned long arg)
 
 			return OK;
 		}
-
-	case SENSORIOCGQUEUEDEPTH:
-		return _mag_reports->size();
 
 	case SENSORIOCRESET:
 		// Nothing to do for simulator

--- a/src/platforms/posix/drivers/airspeedsim/airspeedsim.cpp
+++ b/src/platforms/posix/drivers/airspeedsim/airspeedsim.cpp
@@ -259,9 +259,6 @@ AirspeedSim::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _reports->size();
-
 	case SENSORIOCRESET:
 		/* XXX implement this */
 		return -EINVAL;

--- a/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
+++ b/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
@@ -786,9 +786,6 @@ GYROSIM::devIOCTL(unsigned long cmd, unsigned long arg)
 			return OK;
 		}
 
-	case SENSORIOCGQUEUEDEPTH:
-		return _accel_reports->size();
-
 	case ACCELIOCGSAMPLERATE:
 		return 1e6 / m_sample_interval_usecs;
 
@@ -853,9 +850,6 @@ GYROSIM::gyro_ioctl(unsigned long cmd, unsigned long arg)
 
 			return OK;
 		}
-
-	case SENSORIOCGQUEUEDEPTH:
-		return _gyro_reports->size();
 
 	case GYROIOCGSAMPLERATE:
 		return 1e6 / m_sample_interval_usecs;

--- a/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
+++ b/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
@@ -864,9 +864,6 @@ GYROSIM::gyro_ioctl(unsigned long cmd, unsigned long arg)
 		_set_sample_rate(arg);
 		return OK;
 
-	case GYROIOCSLOWPASS:
-		return OK;
-
 	case GYROIOCSSCALE:
 		/* copy scale in */
 		memcpy(&_gyro_scale, (struct gyro_calibration_s *) arg, sizeof(_gyro_scale));

--- a/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
+++ b/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
@@ -796,9 +796,6 @@ GYROSIM::devIOCTL(unsigned long cmd, unsigned long arg)
 		_set_sample_rate(arg);
 		return OK;
 
-	case ACCELIOCSLOWPASS:
-		return OK;
-
 	case ACCELIOCSSCALE: {
 			/* copy scale, but only if off by a few percent */
 			struct accel_calibration_s *s = (struct accel_calibration_s *) arg;


### PR DESCRIPTION
This saves a little bit of flash (badly needed on px4fmu-v2). These are only the easy ones that can be deleted without much thought (no PX4 usage at all). The significant wins will require slightly more effort and restructuring. 

There is an enormous amount of duplicated code across the drivers.