### PR TITLE
VTOL defaults set MIS_TAKEOFF_ALT 30 and remove tuning

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -4,7 +4,7 @@ set VEHICLE_TYPE vtol
 
 if [ $AUTOCNF == yes ]
 then
-	param set MIS_TAKEOFF_ALT 30
+	param set MIS_TAKEOFF_ALT 20
 	param set MIS_YAW_TMT 10
 
 	param set MPC_ACC_HOR_MAX 2.0

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -4,20 +4,17 @@ set VEHICLE_TYPE vtol
 
 if [ $AUTOCNF == yes ]
 then
-	param set MC_ROLL_P 6.0
-	param set MC_PITCH_P 6.0
-	param set MC_YAW_P 4
-
-	#
-	# Default parameters for mission and position handling
-	#
-	param set NAV_ACC_RAD 3
-	param set MPC_TKO_SPEED 1.0
-	param set MPC_LAND_SPEED 0.7
-	param set MPC_Z_VEL_MAX_DN 1.5
-	param set MPC_XY_VEL_MAX 4.0
+	param set MIS_TAKEOFF_ALT 30
 	param set MIS_YAW_TMT 10
+
 	param set MPC_ACC_HOR_MAX 2.0
+	param set MPC_LAND_SPEED 0.7
+	param set MPC_TKO_SPEED 1.0
+	param set MPC_XY_VEL_MAX 4.0
+	param set MPC_Z_VEL_MAX_DN 1.5
+
+	param set NAV_ACC_RAD 3
+
 	param set RTL_LAND_DELAY 0
 fi
 


### PR DESCRIPTION
 - setting MIS_TAKEOFF_ALT to something safe for transition would have prevented https://github.com/PX4/Firmware/issues/8468
 - I don't think default MC attitude controller tuning here makes sense