### PR TITLE
Move SENS_FLOW_ROT to uorb layer

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -55,7 +55,7 @@
 #include <uORB/topics/ekf2_innovations.h>
 #include <uORB/topics/ekf2_timestamps.h>
 #include <uORB/topics/estimator_status.h>
-#include <uORB/topics/optical_flow.h>
+#include <uORB/topics/optical_flow_rot.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/sensor_baro.h>
 #include <uORB/topics/sensor_bias.h>
@@ -456,7 +456,7 @@ void Ekf2::run()
 	int gps_sub = orb_subscribe(ORB_ID(vehicle_gps_position));
 	int airspeed_sub = orb_subscribe(ORB_ID(airspeed));
 	int params_sub = orb_subscribe(ORB_ID(parameter_update));
-	int optical_flow_sub = orb_subscribe(ORB_ID(optical_flow));
+	int optical_flow_sub = orb_subscribe(ORB_ID(optical_flow_rot));
 	int ev_pos_sub = orb_subscribe(ORB_ID(vehicle_vision_position));
 	int ev_att_sub = orb_subscribe(ORB_ID(vehicle_vision_attitude));
 	int vehicle_land_detected_sub = orb_subscribe(ORB_ID(vehicle_land_detected));
@@ -487,7 +487,7 @@ void Ekf2::run()
 	sensor_combined_s sensors = {};
 	vehicle_gps_position_s gps = {};
 	airspeed_s airspeed = {};
-	optical_flow_s optical_flow = {};
+	optical_flow_rot_s optical_flow = {};
 	distance_sensor_s range_finder = {};
 	vehicle_land_detected_s vehicle_land_detected = {};
 	vehicle_local_position_s ev_pos = {};
@@ -594,7 +594,7 @@ void Ekf2::run()
 		orb_check(optical_flow_sub, &optical_flow_updated);
 
 		if (optical_flow_updated) {
-			orb_copy(ORB_ID(optical_flow), optical_flow_sub, &optical_flow);
+			orb_copy(ORB_ID(optical_flow_rot), optical_flow_sub, &optical_flow);
 		}
 
 		if (range_finder_sub_index >= 0) {

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -26,7 +26,7 @@ BlockLocalPositionEstimator::BlockLocalPositionEstimator() :
 	_sub_land(ORB_ID(vehicle_land_detected), 1000 / 2, 0, &getSubscriptions()),
 	_sub_att(ORB_ID(vehicle_attitude), 1000 / 100, 0, &getSubscriptions()),
 	// set flow max update rate higher than expected to we don't lose packets
-	_sub_flow(ORB_ID(optical_flow), 1000 / 100, 0, &getSubscriptions()),
+	_sub_flow(ORB_ID(optical_flow_rot), 1000 / 100, 0, &getSubscriptions()),
 	// main prediction loop, 100 hz
 	_sub_sensor(ORB_ID(sensor_combined), 1000 / 100, 0, &getSubscriptions()),
 	// status updates 2 hz

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -14,7 +14,7 @@
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
-#include <uORB/topics/optical_flow.h>
+#include <uORB/topics/optical_flow_rot.h>
 #include <uORB/topics/sensor_combined.h>
 #include <uORB/topics/distance_sensor.h>
 #include <uORB/topics/parameter_update.h>
@@ -239,7 +239,7 @@ private:
 	uORB::Subscription<actuator_armed_s> _sub_armed;
 	uORB::Subscription<vehicle_land_detected_s> _sub_land;
 	uORB::Subscription<vehicle_attitude_s> _sub_att;
-	uORB::Subscription<optical_flow_s> _sub_flow;
+	uORB::Subscription<optical_flow_rot_s> _sub_flow;
 	uORB::Subscription<sensor_combined_s> _sub_sensor;
 	uORB::Subscription<parameter_update_s> _sub_param_update;
 	uORB::Subscription<vehicle_gps_position_s> _sub_gps;

--- a/src/modules/local_position_estimator/sensors/flow.cpp
+++ b/src/modules/local_position_estimator/sensors/flow.cpp
@@ -87,7 +87,7 @@ int BlockLocalPositionEstimator::flowMeasure(Vector<float, n_y_flow> &y)
 	//double(flow_x_rad), double(flow_y_rad), double(gyro_x_rad), double(gyro_y_rad), double(d));
 
 	// compute velocities in body frame using ground distance
-	// note that the integral rates in the optical_flow uORB topic are RH rotations about body axes
+	// note that the integral rates in the optical_flow_rot uORB topic are RH rotations about body axes
 	Vector3f delta_b(
 		+(flow_y_rad - gyro_y_rad) * d,
 		-(flow_x_rad - gyro_x_rad) * d,

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -74,7 +74,7 @@
 #include <uORB/topics/home_position.h>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/mavlink_log.h>
-#include <uORB/topics/optical_flow.h>
+#include <uORB/topics/optical_flow_rot.h>
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/sensor_combined.h>
 #include <uORB/topics/sensor_bias.h>
@@ -3078,13 +3078,13 @@ private:
 
 protected:
 	explicit MavlinkStreamOpticalFlowRad(Mavlink *mavlink) : MavlinkStream(mavlink),
-		_flow_sub(_mavlink->add_orb_subscription(ORB_ID(optical_flow))),
+		_flow_sub(_mavlink->add_orb_subscription(ORB_ID(optical_flow_rot))),
 		_flow_time(0)
 	{}
 
 	bool send(const hrt_abstime t)
 	{
-		struct optical_flow_s flow;
+		struct optical_flow_rot_s flow;
 
 		if (_flow_sub->update(&_flow_time, &flow)) {
 			mavlink_optical_flow_rad_t msg = {};

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -615,10 +615,6 @@ MavlinkReceiver::handle_message_optical_flow_rad(mavlink_message_t *msg)
 	mavlink_optical_flow_rad_t flow;
 	mavlink_msg_optical_flow_rad_decode(msg, &flow);
 
-	int32_t flow_rot_int;
-	param_get(param_find("SENS_FLOW_ROT"), &flow_rot_int);
-	const enum Rotation flow_rot = (Rotation)flow_rot_int;
-
 	struct optical_flow_s f = {};
 
 	f.timestamp = flow.time_usec;
@@ -633,11 +629,6 @@ MavlinkReceiver::handle_message_optical_flow_rad(mavlink_message_t *msg)
 	f.quality = flow.quality;
 	f.sensor_id = flow.sensor_id;
 	f.gyro_temperature = flow.temperature;
-
-	/* rotate measurements according to parameter */
-	float zeroval = 0.0f;
-	rotate_3f(flow_rot, f.pixel_flow_x_integral, f.pixel_flow_y_integral, zeroval);
-	rotate_3f(flow_rot, f.gyro_x_rate_integral, f.gyro_y_rate_integral, f.gyro_z_rate_integral);
 
 	if (_flow_pub == nullptr) {
 		_flow_pub = orb_advertise(ORB_ID(optical_flow), &f);

--- a/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
@@ -61,7 +61,7 @@
 #include <uORB/topics/vehicle_gps_position.h>
 #include <uORB/topics/vehicle_rates_setpoint.h>
 #include <uORB/topics/att_pos_mocap.h>
-#include <uORB/topics/optical_flow.h>
+#include <uORB/topics/optical_flow_rot.h>
 #include <uORB/topics/distance_sensor.h>
 #include <poll.h>
 #include <systemlib/err.h>
@@ -356,7 +356,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 	memset(&att, 0, sizeof(att));
 	struct vehicle_local_position_s local_pos;
 	memset(&local_pos, 0, sizeof(local_pos));
-	struct optical_flow_s flow;
+	struct optical_flow_rot_s flow;
 	memset(&flow, 0, sizeof(flow));
 	struct vehicle_local_position_s vision;
 	memset(&vision, 0, sizeof(vision));
@@ -375,7 +375,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 	int armed_sub = orb_subscribe(ORB_ID(actuator_armed));
 	int sensor_combined_sub = orb_subscribe(ORB_ID(sensor_combined));
 	int vehicle_attitude_sub = orb_subscribe(ORB_ID(vehicle_attitude));
-	int optical_flow_sub = orb_subscribe(ORB_ID(optical_flow));
+	int optical_flow_sub = orb_subscribe(ORB_ID(optical_flow_rot));
 	int vehicle_gps_position_sub = orb_subscribe(ORB_ID(vehicle_gps_position));
 	int vision_position_sub = orb_subscribe(ORB_ID(vehicle_vision_position));
 	int att_pos_mocap_sub = orb_subscribe(ORB_ID(att_pos_mocap));
@@ -610,7 +610,7 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 			orb_check(optical_flow_sub, &updated);
 
 			if (updated && lidar_valid) {
-				orb_copy(ORB_ID(optical_flow), optical_flow_sub, &flow);
+				orb_copy(ORB_ID(optical_flow_rot), optical_flow_sub, &flow);
 
 				flow_time = t;
 				float flow_q = flow.quality / 255.0f;

--- a/src/modules/replay/replay_main.cpp
+++ b/src/modules/replay/replay_main.cpp
@@ -62,7 +62,7 @@
 // for ekf2 replay
 #include <uORB/topics/airspeed.h>
 #include <uORB/topics/distance_sensor.h>
-#include <uORB/topics/optical_flow.h>
+#include <uORB/topics/optical_flow_rot.h>
 #include <uORB/topics/sensor_combined.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_gps_position.h>
@@ -962,7 +962,7 @@ void ReplayEkf2::onSubscriptionAdded(Subscription &sub, uint16_t msg_id)
 	} else if (sub.orb_meta == ORB_ID(vehicle_gps_position)) {
 		_gps_msg_id = msg_id;
 
-	} else if (sub.orb_meta == ORB_ID(optical_flow)) {
+	} else if (sub.orb_meta == ORB_ID(optical_flow_rot)) {
 		_optical_flow_msg_id = msg_id;
 
 	} else if (sub.orb_meta == ORB_ID(distance_sensor)) {

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -79,7 +79,7 @@
 #include <uORB/topics/vehicle_gps_position.h>
 #include <uORB/topics/satellite_info.h>
 #include <uORB/topics/att_pos_mocap.h>
-#include <uORB/topics/optical_flow.h>
+#include <uORB/topics/optical_flow_rot.h>
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/differential_pressure.h>
 #include <uORB/topics/airspeed.h>
@@ -1170,7 +1170,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 		struct att_pos_mocap_s att_pos_mocap;
 		struct vehicle_local_position_s vision_pos;
 		struct vehicle_attitude_s vision_att;
-		struct optical_flow_s flow;
+		struct optical_flow_rot_s flow;
 		struct rc_channels_s rc;
 		struct differential_pressure_s diff_pres;
 		struct airspeed_s airspeed;
@@ -1844,7 +1844,7 @@ int sdlog2_thread_main(int argc, char *argv[])
 			}
 
 			/* --- FLOW --- */
-			if (copy_if_updated(ORB_ID(optical_flow), &subs.flow_sub, &buf.flow)) {
+			if (copy_if_updated(ORB_ID(optical_flow_rot), &subs.flow_sub, &buf.flow)) {
 				log_msg.msg_type = LOG_FLOW_MSG;
 				log_msg.body.log_FLOW.ground_distance_m = buf.flow.ground_distance_m;
 				log_msg.body.log_FLOW.gyro_temperature = buf.flow.gyro_temperature;

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -84,6 +84,8 @@
 #include <uORB/topics/differential_pressure.h>
 #include <uORB/topics/airspeed.h>
 #include <uORB/topics/sensor_preflight.h>
+#include <uORB/topics/optical_flow.h>
+#include <uORB/topics/optical_flow_rot.h>
 
 #include <DevMgr.hpp>
 
@@ -166,6 +168,7 @@ private:
 	int		_diff_pres_sub{-1};			/**< raw differential pressure subscription */
 	int		_vcontrol_mode_sub{-1};		/**< vehicle control mode subscription */
 	int 		_params_sub{-1};			/**< notification of parameter updates */
+	int 		_optical_flow_sub{-1};			/**< unrotated optical flow */
 
 	orb_advert_t	_sensor_pub{nullptr};			/**< combined sensor data topic */
 	orb_advert_t	_battery_pub[BOARD_NUMBER_BRICKS] {};			/**< battery status */
@@ -177,6 +180,7 @@ private:
 	orb_advert_t	_airspeed_pub{nullptr};			/**< airspeed */
 	orb_advert_t	_diff_pres_pub{nullptr};			/**< differential_pressure */
 	orb_advert_t	_sensor_preflight{nullptr};		/**< sensor preflight topic */
+	orb_advert_t	_optical_flow_rot_pub{nullptr};			/**< rotated optical flow */
 
 	perf_counter_t	_loop_perf;			/**< loop performance counter */
 
@@ -230,6 +234,11 @@ private:
 	 *				data should be returned.
 	 */
 	void		adc_poll(struct sensor_combined_s &raw);
+
+	/**
+	 * Check if there is a new optical flow msg that needs to be rotated and published
+	 */
+	void		rotate_optical_flow();
 };
 
 Sensors::Sensors(bool hil_enabled) :
@@ -573,6 +582,34 @@ Sensors::adc_poll(struct sensor_combined_s &raw)
 	}
 }
 
+void
+Sensors::rotate_optical_flow()
+{
+	bool optical_flow_updated;
+	orb_check(_optical_flow_sub, &optical_flow_updated);
+
+	if (optical_flow_updated) {
+
+		struct optical_flow_s flow_report;
+		orb_copy(ORB_ID(optical_flow), _optical_flow_sub, &flow_report);
+
+		// rotate measurements according to parameter
+		int32_t flow_rot_int;
+		param_get(param_find("SENS_FLOW_ROT"), &flow_rot_int);
+		const enum Rotation flow_rot = (Rotation)flow_rot_int;
+
+		float zeroval = 0.0f;
+		rotate_3f(flow_rot, flow_report.pixel_flow_x_integral, flow_report.pixel_flow_y_integral, zeroval);
+		rotate_3f(flow_rot, flow_report.gyro_x_rate_integral, flow_report.gyro_y_rate_integral, flow_report.gyro_z_rate_integral);
+
+		// publish on rotated topic (optical_flow_rot.msg)
+		int instance;
+		orb_publish_auto(ORB_ID(optical_flow_rot), &_optical_flow_rot_pub, &flow_report, &instance,
+				 ORB_PRIO_DEFAULT);
+
+	}
+}
+
 
 void
 Sensors::run()
@@ -604,6 +641,8 @@ Sensors::run()
 	_params_sub = orb_subscribe(ORB_ID(parameter_update));
 
 	_actuator_ctrl_0_sub = orb_subscribe(ORB_ID(actuator_controls_0));
+
+	_optical_flow_sub = orb_subscribe(ORB_ID(optical_flow));
 
 	for (int b = 0; b < BOARD_NUMBER_BRICKS; b++) {
 		_battery[b].reset(&_battery_status[b]);
@@ -659,6 +698,9 @@ Sensors::run()
 		}
 
 		perf_begin(_loop_perf);
+
+		// check for new optical flow msgs that need to be rotated
+		rotate_optical_flow();
 
 		/* check vehicle status for changes to publication state */
 		vehicle_control_mode_poll();
@@ -718,7 +760,9 @@ Sensors::run()
 	orb_unsubscribe(_vcontrol_mode_sub);
 	orb_unsubscribe(_params_sub);
 	orb_unsubscribe(_actuator_ctrl_0_sub);
+	orb_unsubscribe(_optical_flow_sub);
 	orb_unadvertise(_sensor_pub);
+	orb_unadvertise(_optical_flow_rot_pub);
 
 	_rc_update.deinit();
 	_voted_sensors_update.deinit();

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -57,7 +57,7 @@
 #include <controllib/blocks.hpp>
 #include <controllib/block/BlockParam.hpp>
 #include <uORB/uORB.h>
-#include <uORB/topics/optical_flow.h>
+#include <uORB/topics/optical_flow_rot.h>
 #include <uORB/topics/distance_sensor.h>
 #include <v1.0/mavlink_types.h>
 #include <v1.0/common/mavlink.h>

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -1087,7 +1087,7 @@ int Simulator::publish_flow_topic(mavlink_hil_optical_flow_t *flow_mavlink)
 {
 	uint64_t timestamp = hrt_absolute_time();
 
-	struct optical_flow_s flow;
+	struct optical_flow_rot_s flow;
 	memset(&flow, 0, sizeof(flow));
 
 	flow.sensor_id = flow_mavlink->sensor_id;
@@ -1115,7 +1115,7 @@ int Simulator::publish_flow_topic(mavlink_hil_optical_flow_t *flow_mavlink)
 	rotate_3f(flow_rot, flow.gyro_x_rate_integral, flow.gyro_y_rate_integral, flow.gyro_z_rate_integral);
 
 	int flow_multi;
-	orb_publish_auto(ORB_ID(optical_flow), &_flow_pub, &flow, &flow_multi, ORB_PRIO_HIGH);
+	orb_publish_auto(ORB_ID(optical_flow_rot), &_flow_pub, &flow, &flow_multi, ORB_PRIO_HIGH);
 
 	return OK;
 }


### PR DESCRIPTION
This is needed if you want to send optical flow with a middleware (e.g. FastRTPS) and still use the parameter `SENS_FLOW_ROT`.
@bkueng as discussed, I moved the rotation to `sensors.cpp` and added a new function so that we don't have to fiddle with FastRTPS auto-generated stuff. Or would it be cleaner to use a optical_flow_raw msg?