### PR TITLE
commander mission valid check require updated mission_result

### DIFF
--- a/msg/mission.msg
+++ b/msg/mission.msg
@@ -1,6 +1,4 @@
-int8 dataman_id	# default 0, there are two offboard storage places in the dataman: 0 or 1
+uint8 dataman_id	# default 0, there are two offboard storage places in the dataman: 0 or 1
 
 uint16 count		# count of the missions stored in the dataman
 int32 current_seq	# default -1, start at the one changed latest
-
-# TOPICS mission offboard_mission onboard_mission

--- a/src/examples/bottle_drop/bottle_drop.cpp
+++ b/src/examples/bottle_drop/bottle_drop.cpp
@@ -188,6 +188,7 @@ BottleDrop::BottleDrop() :
 	_onboard_mission {},
 	_onboard_mission_pub(nullptr)
 {
+	_onboard_mission.dataman_id = DM_KEY_WAYPOINTS_ONBOARD;
 }
 
 BottleDrop::~BottleDrop()
@@ -621,14 +622,15 @@ BottleDrop::task_main()
 						warnx("ERROR: could not save onboard WP");
 					}
 
+					_onboard_mission.timestamp = hrt_absolute_time();
 					_onboard_mission.count = 2;
 					_onboard_mission.current_seq = 0;
 
 					if (_onboard_mission_pub != nullptr) {
-						orb_publish(ORB_ID(onboard_mission), _onboard_mission_pub, &_onboard_mission);
+						orb_publish(ORB_ID(mission), _onboard_mission_pub, &_onboard_mission);
 
 					} else {
-						_onboard_mission_pub = orb_advertise(ORB_ID(onboard_mission), &_onboard_mission);
+						_onboard_mission_pub = orb_advertise(ORB_ID(mission), &_onboard_mission);
 					}
 
 					float approach_direction = get_bearing_to_next_waypoint(flight_vector_s.lat, flight_vector_s.lon, flight_vector_e.lat,
@@ -645,8 +647,9 @@ BottleDrop::task_main()
 							     flight_vector_e.lon);
 
 					if (distance_wp2 < distance_real) {
+						_onboard_mission.timestamp = hrt_absolute_time();
 						_onboard_mission.current_seq = 0;
-						orb_publish(ORB_ID(onboard_mission), _onboard_mission_pub, &_onboard_mission);
+						orb_publish(ORB_ID(mission), _onboard_mission_pub, &_onboard_mission);
 
 					} else {
 
@@ -683,8 +686,9 @@ BottleDrop::task_main()
 									     flight_vector_e.lon);
 
 							if (distance_wp2 < distance_real) {
+								_onboard_mission.timestamp = hrt_absolute_time();
 								_onboard_mission.current_seq = 0;
-								orb_publish(ORB_ID(onboard_mission), _onboard_mission_pub, &_onboard_mission);
+								orb_publish(ORB_ID(mission), _onboard_mission_pub, &_onboard_mission);
 							}
 						}
 					}
@@ -702,9 +706,11 @@ BottleDrop::task_main()
 					mavlink_log_info(&_mavlink_log_pub, "#audio: closing bay");
 
 					// remove onboard mission
+					_onboard_mission.timestamp = hrt_absolute_time();
+					_onboard_mission.dataman_id = DM_KEY_WAYPOINTS_ONBOARD;
 					_onboard_mission.current_seq = -1;
 					_onboard_mission.count = 0;
-					orb_publish(ORB_ID(onboard_mission), _onboard_mission_pub, &_onboard_mission);
+					orb_publish(ORB_ID(mission), _onboard_mission_pub, &_onboard_mission);
 				}
 
 				break;
@@ -804,7 +810,8 @@ BottleDrop::handle_command(struct vehicle_command_s *cmd)
 			_onboard_mission.current_seq = -1;
 
 			if (_onboard_mission_pub != nullptr) {
-				orb_publish(ORB_ID(onboard_mission), _onboard_mission_pub, &_onboard_mission);
+				_onboard_mission.timestamp = hrt_absolute_time();
+				orb_publish(ORB_ID(mission), _onboard_mission_pub, &_onboard_mission);
 			}
 
 		} else {

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -38,22 +38,23 @@
 #include <px4_module.h>
 
 // publications
+#include <uORB/Publication.hpp>
 #include <uORB/topics/actuator_armed.h>
 #include <uORB/topics/home_position.h>
 #include <uORB/topics/vehicle_command_ack.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_status_flags.h>
-#include <uORB/Publication.hpp>
 
 // subscriptions
+#include <uORB/Subscription.hpp>
 #include <uORB/topics/geofence_result.h>
+#include <uORB/topics/mission_result.h>
 #include <uORB/topics/safety.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_local_position.h>
-#include <uORB/Subscription.hpp>
 
 using control::BlockParamFloat;
 using control::BlockParamInt;
@@ -64,7 +65,8 @@ class Commander : public control::SuperBlock, public ModuleBase<Commander>
 {
 public:
 	Commander() :
-		SuperBlock(nullptr, "COM")
+		SuperBlock(nullptr, "COM"),
+		_mission_result_sub(ORB_ID(mission_result), 0, 0, &getSubscriptions())
 	{
 		updateParams();
 	}
@@ -87,6 +89,9 @@ public:
 	void enable_hil();
 
 private:
+
+	// Subscriptions
+	Subscription<mission_result_s> _mission_result_sub;
 
 	bool handle_command(vehicle_status_s *status, const safety_s *safety, vehicle_command_s *cmd,
 			    actuator_armed_s *armed, home_position_s *home, vehicle_global_position_s *global_pos,

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -102,6 +102,8 @@ private:
 				const vehicle_local_position_s &localPosition, const vehicle_global_position_s &globalPosition,
 				const vehicle_attitude_s &attitude, bool set_alt_only_to_lpos_ref);
 
+	void mission_init();
+
 };
 
 #endif /* COMMANDER_HPP_ */

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -229,8 +229,6 @@ static struct home_position_s _home = {};
 static int32_t _flight_mode_slots[manual_control_setpoint_s::MODE_SLOT_MAX];
 static struct commander_state_s internal_state = {};
 
-static struct mission_result_s _mission_result = {};
-
 static uint8_t main_state_before_rtl = commander_state_s::MAIN_STATE_MAX;
 
 static manual_control_setpoint_s sp_man = {};		///< the current manual control setpoint
@@ -1119,7 +1117,7 @@ Commander::handle_command(vehicle_status_s *status_local, const safety_s *safety
 		if (status_flags.condition_auto_mission_available) {
 
 			// requested first mission item valid
-			if (PX4_ISFINITE(cmd->param1) && (cmd->param1 >= -1) && (cmd->param1 < _mission_result.seq_total)) {
+			if (PX4_ISFINITE(cmd->param1) && (cmd->param1 >= -1) && (cmd->param1 < _mission_result_sub.get().seq_total)) {
 
 				// switch to AUTO_MISSION and ARM
 				if ((TRANSITION_DENIED != main_state_transition(status_local, commander_state_s::MAIN_STATE_AUTO_MISSION, main_state_prev, &status_flags, &internal_state))
@@ -1458,9 +1456,6 @@ Commander::run()
 	memset(&safety, 0, sizeof(safety));
 	safety.safety_switch_available = false;
 	safety.safety_off = false;
-
-	/* Subscribe to mission result topic */
-	int mission_result_sub = orb_subscribe(ORB_ID(mission_result));
 
 	/* Subscribe to geofence result topic */
 	int geofence_result_sub = orb_subscribe(ORB_ID(geofence_result));
@@ -1909,8 +1904,9 @@ Commander::run()
 					}
 
 					// Provide feedback on mission state
-					if ((_mission_result.timestamp > commander_boot_timestamp) && hotplug_timeout &&
-						(_mission_result.instance_count > 0) && !_mission_result.valid) {
+					const mission_result_s& mission_result = _mission_result_sub.get();
+					if ((mission_result.timestamp > commander_boot_timestamp) && hotplug_timeout &&
+						(mission_result.instance_count > 0) && !mission_result.valid) {
 
 						mavlink_log_critical(&mavlink_log_pub, "Planned mission fails check. Please upload again.");
 					}
@@ -2440,47 +2436,41 @@ Commander::run()
 		}
 
 		/* start mission result check */
-		orb_check(mission_result_sub, &updated);
+		const auto prev_mission_instance_count = _mission_result_sub.get().instance_count;
+		if (_mission_result_sub.update()) {
+			const mission_result_s& mission_result = _mission_result_sub.get();
 
-		if (updated) {
-			mission_result_s new_mission_result = {};
+			// if mission_result is valid for the current mission
+			const bool mission_result_ok = (mission_result.timestamp > commander_boot_timestamp) && (mission_result.instance_count > 0);
 
-			if (orb_copy(ORB_ID(mission_result), mission_result_sub, &new_mission_result) == PX4_OK) {
+			status_flags.condition_auto_mission_available = mission_result_ok && mission_result.valid;
 
-				// if mission_result is valid for the current mission
-				const bool mission_result_ok = (new_mission_result.timestamp > commander_boot_timestamp) && (new_mission_result.instance_count > 0);
+			if (mission_result_ok) {
 
-				status_flags.condition_auto_mission_available = mission_result_ok && new_mission_result.valid;
+				if (status.mission_failure != mission_result.failure) {
+					status.mission_failure = mission_result.failure;
+					status_changed = true;
 
-				if (mission_result_ok) {
-
-					if (status.mission_failure != new_mission_result.failure) {
-						status.mission_failure = new_mission_result.failure;
-						status_changed = true;
-
-						if (status.mission_failure) {
-							mavlink_log_critical(&mavlink_log_pub, "Mission cannot be completed");
-						}
-					}
-
-					/* Only evaluate mission state if home is set */
-					if (status_flags.condition_home_position_valid &&
-						(_mission_result.instance_count != new_mission_result.instance_count)) {
-
-						if (!status_flags.condition_auto_mission_available) {
-							/* the mission is invalid */
-							tune_mission_fail(true);
-						} else if (new_mission_result.warning) {
-							/* the mission has a warning */
-							tune_mission_fail(true);
-						} else {
-							/* the mission is valid */
-							tune_mission_ok(true);
-						}
+					if (status.mission_failure) {
+						mavlink_log_critical(&mavlink_log_pub, "Mission cannot be completed");
 					}
 				}
 
-				_mission_result = new_mission_result;
+				/* Only evaluate mission state if home is set */
+				if (status_flags.condition_home_position_valid &&
+					(prev_mission_instance_count != mission_result.instance_count)) {
+
+					if (!status_flags.condition_auto_mission_available) {
+						/* the mission is invalid */
+						tune_mission_fail(true);
+					} else if (mission_result.warning) {
+						/* the mission has a warning */
+						tune_mission_fail(true);
+					} else {
+						/* the mission is valid */
+						tune_mission_ok(true);
+					}
+				}
 			}
 		}
 
@@ -2597,7 +2587,7 @@ Commander::run()
 
 
 		/* Check for mission flight termination */
-		if (armed.armed && _mission_result.flight_termination &&
+		if (armed.armed && _mission_result_sub.get().flight_termination &&
 		    !status_flags.circuit_breaker_flight_termination_disabled) {
 
 			armed.force_failsafe = true;
@@ -2891,11 +2881,11 @@ Commander::run()
 		 * as finished even though we only just started with the takeoff. Therefore, we also
 		 * check the timestamp of the mission_result topic. */
 		if (internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_TAKEOFF
-			&& (_mission_result.timestamp > internal_state.timestamp)
-			&& _mission_result.finished) {
+			&& (_mission_result_sub.get().timestamp > internal_state.timestamp)
+			&& _mission_result_sub.get().finished) {
 
-			const bool mission_available = (_mission_result.timestamp > commander_boot_timestamp)
-				&& (_mission_result.instance_count > 0) && _mission_result.valid;
+			const bool mission_available = (_mission_result_sub.get().timestamp > commander_boot_timestamp)
+				&& (_mission_result_sub.get().instance_count > 0) && _mission_result_sub.get().valid;
 
 			if ((takeoff_complete_act == 1) && mission_available) {
 				main_state_transition(&status, commander_state_s::MAIN_STATE_AUTO_MISSION, main_state_prev, &status_flags, &internal_state);
@@ -3049,8 +3039,8 @@ Commander::run()
 											   &internal_state,
 											   &mavlink_log_pub,
 											   (link_loss_actions_t)datalink_loss_act,
-											   _mission_result.finished,
-											   _mission_result.stay_in_failsafe,
+											   _mission_result_sub.get().finished,
+											   _mission_result_sub.get().stay_in_failsafe,
 											   &status_flags,
 											   land_detector.landed,
 											   (link_loss_actions_t)rc_loss_act,

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -454,9 +454,8 @@ main_state_transition(struct vehicle_status_s *status, main_state_t new_main_sta
 	case commander_state_s::MAIN_STATE_AUTO_MISSION:
 
 		/* need global position, home position, and a valid mission */
-		// TODO: require mission? condition_auto_mission_available
 		if (status_flags->condition_global_position_valid &&
-		    status_flags->condition_home_position_valid) {
+		    status_flags->condition_auto_mission_available) {
 
 			ret = TRANSITION_CHANGED;
 		}
@@ -1128,7 +1127,6 @@ int prearm_check(struct vehicle_status_s *status, orb_advert_t *mavlink_log_pub,
 	// mission required
 	if ((arm_requirements & ARM_REQ_MISSION_BIT) &&
 		(!status_flags->condition_auto_mission_available ||
-		!status_flags->condition_home_position_valid ||
 		!status_flags->condition_global_position_valid)) {
 
 		prearm_ok = false;

--- a/src/modules/dataman/dataman.h
+++ b/src/modules/dataman/dataman.h
@@ -51,14 +51,12 @@ typedef enum {
 	DM_KEY_SAFE_POINTS = 0,		/* Safe points coordinates, safe point 0 is home point */
 	DM_KEY_FENCE_POINTS,		/* Fence vertex coordinates */
 	DM_KEY_WAYPOINTS_OFFBOARD_0,	/* Mission way point coordinates sent over mavlink */
-	DM_KEY_WAYPOINTS_OFFBOARD_1,	/* (alernate between 0 and 1) */
+	DM_KEY_WAYPOINTS_OFFBOARD_1,	/* (alternate between 0 and 1) */
 	DM_KEY_WAYPOINTS_ONBOARD,	/* Mission way point coordinates generated onboard */
 	DM_KEY_MISSION_STATE,		/* Persistent mission state */
 	DM_KEY_COMPAT,
 	DM_KEY_NUM_KEYS			/* Total number of item types defined */
 } dm_item_t;
-
-#define DM_KEY_WAYPOINTS_OFFBOARD(_id) (_id == 0 ? DM_KEY_WAYPOINTS_OFFBOARD_0 : DM_KEY_WAYPOINTS_OFFBOARD_1)
 
 #if defined(MEMORY_CONSTRAINED_SYSTEM)
 enum {

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -594,8 +594,8 @@ void Logger::add_default_topics()
 	add_topic("home_position");
 	add_topic("input_rc", 200);
 	add_topic("manual_control_setpoint", 200);
+	add_topic("mission");
 	add_topic("mission_result");
-	add_topic("offboard_mission");
 	add_topic("optical_flow", 50);
 	add_topic("position_setpoint_triplet", 200);
 	add_topic("sensor_combined", 100);

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -54,7 +54,7 @@
 #include <uORB/topics/mission.h>
 #include <uORB/topics/mission_result.h>
 
-int8_t MavlinkMissionManager::_dataman_id = 0;
+dm_item_t MavlinkMissionManager::_dataman_id = DM_KEY_WAYPOINTS_OFFBOARD_0;
 bool MavlinkMissionManager::_dataman_init = false;
 uint16_t MavlinkMissionManager::_count[3] = { 0, 0, 0 };
 int32_t MavlinkMissionManager::_current_seq = 0;
@@ -71,7 +71,7 @@ MavlinkMissionManager::MavlinkMissionManager(Mavlink *mavlink) :
 	_verbose(mavlink->verbose()),
 	_mavlink(mavlink)
 {
-	_offboard_mission_sub = orb_subscribe(ORB_ID(offboard_mission));
+	_offboard_mission_sub = orb_subscribe(ORB_ID(mission));
 	_mission_result_sub = orb_subscribe(ORB_ID(mission_result));
 
 	init_offboard_mission();
@@ -86,14 +86,26 @@ MavlinkMissionManager::~MavlinkMissionManager()
 void
 MavlinkMissionManager::init_offboard_mission()
 {
-	mission_s mission_state;
-
 	if (!_dataman_init) {
 		_dataman_init = true;
+
+		/* lock MISSION_STATE item */
+		int dm_lock_ret = dm_lock(DM_KEY_MISSION_STATE);
+
+		if (dm_lock_ret != 0) {
+			PX4_ERR("DM_KEY_MISSION_STATE lock failed");
+		}
+
+		mission_s mission_state;
 		int ret = dm_read(DM_KEY_MISSION_STATE, 0, &mission_state, sizeof(mission_s));
 
+		/* unlock MISSION_STATE item */
+		if (dm_lock_ret == 0) {
+			dm_unlock(DM_KEY_MISSION_STATE);
+		}
+
 		if (ret > 0) {
-			_dataman_id = mission_state.dataman_id;
+			_dataman_id = (dm_item_t)mission_state.dataman_id;
 			_count[MAV_MISSION_TYPE_MISSION] = mission_state.count;
 			_current_seq = mission_state.current_seq;
 
@@ -139,10 +151,10 @@ MavlinkMissionManager::load_safepoint_stats()
 }
 
 /**
- * Write new mission state to dataman and publish offboard_mission topic to notify navigator about changes.
+ * Publish mission topic to notify navigator about changes.
  */
 int
-MavlinkMissionManager::update_active_mission(int8_t dataman_id, uint16_t count, int32_t seq)
+MavlinkMissionManager::update_active_mission(dm_item_t dataman_id, uint16_t count, int32_t seq)
 {
 	mission_s mission;
 	mission.timestamp = hrt_absolute_time();
@@ -151,7 +163,20 @@ MavlinkMissionManager::update_active_mission(int8_t dataman_id, uint16_t count, 
 	mission.current_seq = seq;
 
 	/* update mission state in dataman */
+
+	/* lock MISSION_STATE item */
+	int dm_lock_ret = dm_lock(DM_KEY_MISSION_STATE);
+
+	if (dm_lock_ret != 0) {
+		PX4_ERR("DM_KEY_MISSION_STATE lock failed");
+	}
+
 	int res = dm_write(DM_KEY_MISSION_STATE, 0, DM_PERSIST_POWER_ON_RESET, &mission, sizeof(mission_s));
+
+	/* unlock MISSION_STATE item */
+	if (dm_lock_ret == 0) {
+		dm_unlock(DM_KEY_MISSION_STATE);
+	}
 
 	if (res == sizeof(mission_s)) {
 		/* update active mission state */
@@ -162,10 +187,10 @@ MavlinkMissionManager::update_active_mission(int8_t dataman_id, uint16_t count, 
 
 		/* mission state saved successfully, publish offboard_mission topic */
 		if (_offboard_mission_pub == nullptr) {
-			_offboard_mission_pub = orb_advertise(ORB_ID(offboard_mission), &mission);
+			_offboard_mission_pub = orb_advertise(ORB_ID(mission), &mission);
 
 		} else {
-			orb_publish(ORB_ID(offboard_mission), _offboard_mission_pub, &mission);
+			orb_publish(ORB_ID(mission), _offboard_mission_pub, &mission);
 		}
 
 		return PX4_OK;
@@ -292,16 +317,13 @@ MavlinkMissionManager::send_mission_count(uint8_t sysid, uint8_t compid, uint16_
 void
 MavlinkMissionManager::send_mission_item(uint8_t sysid, uint8_t compid, uint16_t seq)
 {
-	dm_item_t dm_item;
-	struct mission_item_s mission_item {};
+	mission_item_s mission_item = {};
 	bool read_success = false;
 
 	switch (_mission_type) {
 
 	case MAV_MISSION_TYPE_MISSION: {
-			dm_item = DM_KEY_WAYPOINTS_OFFBOARD(_dataman_id);
-			read_success = dm_read(dm_item, seq, &mission_item, sizeof(struct mission_item_s)) ==
-				       sizeof(struct mission_item_s);
+			read_success = dm_read(_dataman_id, seq, &mission_item, sizeof(mission_item_s)) == sizeof(mission_item_s);
 		}
 		break;
 
@@ -309,6 +331,7 @@ MavlinkMissionManager::send_mission_item(uint8_t sysid, uint8_t compid, uint16_t
 			mission_fence_point_s mission_fence_point;
 			read_success = dm_read(DM_KEY_FENCE_POINTS, seq + 1, &mission_fence_point, sizeof(mission_fence_point_s)) ==
 				       sizeof(mission_fence_point_s);
+
 			mission_item.nav_cmd = mission_fence_point.nav_cmd;
 			mission_item.frame = mission_fence_point.frame;
 			mission_item.lat = mission_fence_point.lat;
@@ -329,6 +352,7 @@ MavlinkMissionManager::send_mission_item(uint8_t sysid, uint8_t compid, uint16_t
 			mission_save_point_s mission_save_point;
 			read_success = dm_read(DM_KEY_SAFE_POINTS, seq + 1, &mission_save_point, sizeof(mission_save_point_s)) ==
 				       sizeof(mission_save_point_s);
+
 			mission_item.nav_cmd = MAV_CMD_NAV_RALLY_POINT;
 			mission_item.frame = mission_save_point.frame;
 			mission_item.lat = mission_save_point.lat;
@@ -864,8 +888,16 @@ MavlinkMissionManager::handle_mission_count(const mavlink_message_t *msg)
 
 				switch (_mission_type) {
 				case MAV_MISSION_TYPE_MISSION:
+
 					/* alternate dataman ID anyway to let navigator know about changes */
-					update_active_mission(_dataman_id == 0 ? 1 : 0, 0, 0);
+
+					if (_dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_0) {
+						update_active_mission(DM_KEY_WAYPOINTS_OFFBOARD_1, 0, 0);
+
+					} else {
+						update_active_mission(DM_KEY_WAYPOINTS_OFFBOARD_0, 0, 0);
+					}
+
 					break;
 
 				case MAV_MISSION_TYPE_FENCE:
@@ -893,7 +925,8 @@ MavlinkMissionManager::handle_mission_count(const mavlink_message_t *msg)
 			_transfer_partner_sysid = msg->sysid;
 			_transfer_partner_compid = msg->compid;
 			_transfer_count = wpc.count;
-			_transfer_dataman_id = _dataman_id == 0 ? 1 : 0;	// use inactive storage for transmission
+			_transfer_dataman_id = (_dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_0 ? DM_KEY_WAYPOINTS_OFFBOARD_1 :
+						DM_KEY_WAYPOINTS_OFFBOARD_0);	// use inactive storage for transmission
 			_transfer_current_seq = -1;
 
 			if (_mission_type == MAV_MISSION_TYPE_FENCE) {
@@ -1045,7 +1078,7 @@ MavlinkMissionManager::handle_mission_item_both(const mavlink_message_t *msg)
 					check_failed = true;
 
 				} else {
-					dm_item_t dm_item = DM_KEY_WAYPOINTS_OFFBOARD(_transfer_dataman_id);
+					dm_item_t dm_item = _transfer_dataman_id;
 
 					write_failed = dm_write(dm_item, wp.seq, DM_PERSIST_POWER_ON_RESET, &mission_item,
 								sizeof(struct mission_item_s)) != sizeof(struct mission_item_s);
@@ -1192,7 +1225,8 @@ MavlinkMissionManager::handle_mission_clear_all(const mavlink_message_t *msg)
 
 			switch (wpca.mission_type) {
 			case MAV_MISSION_TYPE_MISSION:
-				ret = update_active_mission(_dataman_id == 0 ? 1 : 0, 0, 0);
+				ret = update_active_mission(_dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_0 ? DM_KEY_WAYPOINTS_OFFBOARD_1 :
+							    DM_KEY_WAYPOINTS_OFFBOARD_0, 0, 0);
 				break;
 
 			case MAV_MISSION_TYPE_FENCE:
@@ -1204,7 +1238,8 @@ MavlinkMissionManager::handle_mission_clear_all(const mavlink_message_t *msg)
 				break;
 
 			case MAV_MISSION_TYPE_ALL:
-				ret = update_active_mission(_dataman_id == 0 ? 1 : 0, 0, 0);
+				ret = update_active_mission(_dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_0 ? DM_KEY_WAYPOINTS_OFFBOARD_1 :
+							    DM_KEY_WAYPOINTS_OFFBOARD_0, 0, 0);
 				ret = update_geofence_count(0) || ret;
 				ret = update_safepoint_count(0) || ret;
 				break;

--- a/src/modules/mavlink/mavlink_mission.h
+++ b/src/modules/mavlink/mavlink_mission.h
@@ -104,8 +104,9 @@ private:
 
 	unsigned		_filesystem_errcount{0};		///< File system error count
 
-	static int8_t		_dataman_id;				///< Global Dataman storage ID for active mission
-	int8_t			_my_dataman_id{0};			///< class Dataman storage ID
+	static dm_item_t		_dataman_id;				///< Global Dataman storage ID for active mission
+	dm_item_t			_my_dataman_id{DM_KEY_WAYPOINTS_OFFBOARD_0};			///< class Dataman storage ID
+
 	static bool		_dataman_init;				///< Dataman initialized
 
 	static uint16_t		_count[3];				///< Count of items in (active) mission for each MAV_MISSION_TYPE
@@ -113,7 +114,7 @@ private:
 
 	int32_t			_last_reached{-1};			///< Last reached waypoint in active mission (-1 means nothing reached)
 
-	int8_t			_transfer_dataman_id{0};		///< Dataman storage ID for current transmission
+	dm_item_t			_transfer_dataman_id{DM_KEY_WAYPOINTS_OFFBOARD_1};		///< Dataman storage ID for current transmission
 
 	uint16_t		_transfer_count{0};			///< Items count in current transmission
 	uint16_t		_transfer_seq{0};			///< Item sequence in current transmission
@@ -160,7 +161,7 @@ private:
 
 	void init_offboard_mission();
 
-	int update_active_mission(int8_t dataman_id, uint16_t count, int32_t seq);
+	int update_active_mission(dm_item_t dataman_id, uint16_t count, int32_t seq);
 
 	/** store the geofence count to dataman */
 	int update_geofence_count(unsigned count);

--- a/src/modules/navigator/datalinkloss.cpp
+++ b/src/modules/navigator/datalinkloss.cpp
@@ -54,8 +54,6 @@
 #include "navigator.h"
 #include "datalinkloss.h"
 
-#define DELAY_SIGMA	0.01f
-
 DataLinkLoss::DataLinkLoss(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name),
 	_param_commsholdwaittime(this, "CH_T"),
@@ -69,12 +67,6 @@ DataLinkLoss::DataLinkLoss(Navigator *navigator, const char *name) :
 	_param_numberdatalinklosses(this, "N"),
 	_param_skipcommshold(this, "CHSK"),
 	_dll_state(DLL_STATE_NONE)
-{
-	/* initial reset */
-	on_inactive();
-}
-
-DataLinkLoss::~DataLinkLoss()
 {
 }
 

--- a/src/modules/navigator/datalinkloss.cpp
+++ b/src/modules/navigator/datalinkloss.cpp
@@ -101,7 +101,7 @@ DataLinkLoss::set_dll_item()
 {
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
-	set_previous_pos_setpoint();
+	pos_sp_triplet->previous = pos_sp_triplet->current;
 	_navigator->set_can_loiter_at_sp(false);
 
 	switch (_dll_state) {

--- a/src/modules/navigator/datalinkloss.h
+++ b/src/modules/navigator/datalinkloss.h
@@ -40,28 +40,21 @@
 #ifndef NAVIGATOR_DATALINKLOSS_H
 #define NAVIGATOR_DATALINKLOSS_H
 
-#include <controllib/blocks.hpp>
-#include <controllib/block/BlockParam.hpp>
-
-#include <uORB/Subscription.hpp>
-
 #include "navigator_mode.h"
 #include "mission_block.h"
 
 class Navigator;
 
-class DataLinkLoss : public MissionBlock
+class DataLinkLoss final : public MissionBlock
 {
 public:
 	DataLinkLoss(Navigator *navigator, const char *name);
 
-	~DataLinkLoss();
+	~DataLinkLoss() = default;
 
-	virtual void on_inactive();
-
-	virtual void on_activation();
-
-	virtual void on_active();
+	void on_inactive() override;
+	void on_activation() override;
+	void on_active() override;
 
 private:
 	/* Params */
@@ -82,7 +75,7 @@ private:
 		DLL_STATE_FLYTOAIRFIELDHOMEWP = 2,
 		DLL_STATE_TERMINATE = 3,
 		DLL_STATE_END = 4
-	} _dll_state;
+	} _dll_state{DLL_STATE_NONE};
 
 	/**
 	 * Set the DLL item

--- a/src/modules/navigator/enginefailure.cpp
+++ b/src/modules/navigator/enginefailure.cpp
@@ -52,17 +52,9 @@
 #include "navigator.h"
 #include "enginefailure.h"
 
-#define DELAY_SIGMA	0.01f
-
 EngineFailure::EngineFailure(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name),
 	_ef_state(EF_STATE_NONE)
-{
-	/* initial reset */
-	on_inactive();
-}
-
-EngineFailure::~EngineFailure()
 {
 }
 

--- a/src/modules/navigator/enginefailure.cpp
+++ b/src/modules/navigator/enginefailure.cpp
@@ -86,7 +86,7 @@ EngineFailure::set_ef_item()
 {
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
-	set_previous_pos_setpoint();
+	pos_sp_triplet->previous = pos_sp_triplet->current;
 	_navigator->set_can_loiter_at_sp(false);
 
 	switch (_ef_state) {

--- a/src/modules/navigator/enginefailure.h
+++ b/src/modules/navigator/enginefailure.h
@@ -40,34 +40,26 @@
 #ifndef NAVIGATOR_ENGINEFAILURE_H
 #define NAVIGATOR_ENGINEFAILURE_H
 
-#include <controllib/blocks.hpp>
-#include <controllib/block/BlockParam.hpp>
-
-#include <uORB/Subscription.hpp>
-
 #include "navigator_mode.h"
 #include "mission_block.h"
 
 class Navigator;
 
-class EngineFailure : public MissionBlock
+class EngineFailure final : public MissionBlock
 {
 public:
 	EngineFailure(Navigator *navigator, const char *name);
+	~EngineFailure() = default;
 
-	~EngineFailure();
-
-	virtual void on_inactive();
-
-	virtual void on_activation();
-
-	virtual void on_active();
+	void on_inactive() override;
+	void on_activation() override;
+	void on_active() override;
 
 private:
 	enum EFState {
 		EF_STATE_NONE = 0,
 		EF_STATE_LOITERDOWN = 1,
-	} _ef_state;
+	} _ef_state{EF_STATE_NONE};
 
 	/**
 	 * Set the DLL item

--- a/src/modules/navigator/follow_target.cpp
+++ b/src/modules/navigator/follow_target.cpp
@@ -60,38 +60,17 @@ constexpr float FollowTarget::_follow_position_matricies[4][9];
 
 FollowTarget::FollowTarget(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name),
-	_navigator(navigator),
 	_param_min_alt(this, "NAV_MIN_FT_HT", false),
 	_param_tracking_dist(this, "NAV_FT_DST", false),
 	_param_tracking_side(this, "NAV_FT_FS", false),
-	_param_tracking_resp(this, "NAV_FT_RS", false),
-	_param_yaw_auto_max(this, "MC_YAWRAUTO_MAX", false),
-	_follow_target_state(SET_WAIT_FOR_TARGET_POSITION),
-	_follow_target_position(FOLLOW_FROM_BEHIND),
-	_follow_target_sub(-1),
-	_step_time_in_ms(0.0f),
-	_follow_offset(OFFSET_M),
-	_target_updates(0),
-	_last_update_time(0),
-	_current_target_motion(),
-	_previous_target_motion(),
-	_yaw_rate(0.0F),
-	_responsiveness(0.0F),
-	_yaw_auto_max(0.0F),
-	_yaw_angle(0.0F)
+	_param_tracking_resp(this, "NAV_FT_RS", false)
 {
-	_current_target_motion = {};
-	_previous_target_motion =  {};
 	_current_vel.zero();
 	_step_vel.zero();
 	_est_target_vel.zero();
 	_target_distance.zero();
 	_target_position_offset.zero();
 	_target_position_delta.zero();
-}
-
-FollowTarget::~FollowTarget()
-{
 }
 
 void FollowTarget::on_inactive()
@@ -104,8 +83,6 @@ void FollowTarget::on_activation()
 	_follow_offset = _param_tracking_dist.get() < 1.0F ? 1.0F : _param_tracking_dist.get();
 
 	_responsiveness = math::constrain((float) _param_tracking_resp.get(), .1F, 1.0F);
-
-	_yaw_auto_max = math::radians(_param_yaw_auto_max.get());
 
 	_follow_target_position = _param_tracking_side.get();
 
@@ -230,11 +207,7 @@ void FollowTarget::on_active()
 						_current_target_motion.lat,
 						_current_target_motion.lon);
 
-				_yaw_rate = (_yaw_angle - _navigator->get_global_position()->yaw) / (dt_ms / 1000.0F);
-
-				_yaw_rate = _wrap_pi(_yaw_rate);
-
-				_yaw_rate = math::constrain(_yaw_rate, -1.0F * _yaw_auto_max, _yaw_auto_max);
+				_yaw_rate = _wrap_pi((_yaw_angle - _navigator->get_global_position()->yaw) / (dt_ms / 1000.0f));
 
 			} else {
 				_yaw_angle = _yaw_rate = NAN;

--- a/src/modules/navigator/follow_target.h
+++ b/src/modules/navigator/follow_target.h
@@ -40,24 +40,19 @@
 
 #pragma once
 
-#include <controllib/blocks.hpp>
-#include <controllib/block/BlockParam.hpp>
-#include <lib/mathlib/math/Vector.hpp>
-#include <lib/mathlib/math/Matrix.hpp>
+#include <mathlib/mathlib.h>
+
 #include "navigator_mode.h"
 #include "mission_block.h"
+
 #include <uORB/topics/follow_target.h>
 
-class FollowTarget : public MissionBlock
+class FollowTarget final : public MissionBlock
 {
 
 public:
 	FollowTarget(Navigator *navigator, const char *name);
-
-	FollowTarget(const FollowTarget &) = delete;
-	FollowTarget &operator=(const FollowTarget &) = delete;
-
-	~FollowTarget();
+	~FollowTarget() = default;
 
 	void on_inactive() override;
 	void on_activation() override;
@@ -112,23 +107,20 @@ private:
 	}; // follow left side
 
 
-	Navigator *_navigator;
 	control::BlockParamFloat	_param_min_alt;
 	control::BlockParamFloat 	_param_tracking_dist;
 	control::BlockParamInt 		_param_tracking_side;
 	control::BlockParamFloat 	_param_tracking_resp;
-	control::BlockParamFloat 	_param_yaw_auto_max;
 
+	FollowTargetState _follow_target_state{SET_WAIT_FOR_TARGET_POSITION};
+	int _follow_target_position{FOLLOW_FROM_BEHIND};
 
-	FollowTargetState _follow_target_state;
-	int _follow_target_position;
+	int _follow_target_sub{-1};
+	float _step_time_in_ms{0.0f};
+	float _follow_offset{OFFSET_M};
 
-	int _follow_target_sub;
-	float _step_time_in_ms;
-	float _follow_offset;
-
-	uint64_t _target_updates;
-	uint64_t _last_update_time;
+	uint64_t _target_updates{0};
+	uint64_t _last_update_time{0};
 
 	math::Vector<3> _current_vel;
 	math::Vector<3> _step_vel;
@@ -138,15 +130,14 @@ private:
 	math::Vector<3> _target_position_delta;
 	math::Vector<3> _filtered_target_position_delta;
 
-	follow_target_s _current_target_motion;
-	follow_target_s _previous_target_motion;
-	float _yaw_rate;
-	float _responsiveness;
-	float _yaw_auto_max;
-	float _yaw_angle;
+	follow_target_s _current_target_motion{};
+	follow_target_s _previous_target_motion{};
+
+	float _yaw_rate{0.0f};
+	float _responsiveness{0.0f};
+	float _yaw_angle{0.0f};
 
 	// Mavlink defined motion reporting capabilities
-
 	enum {
 		POS = 0,
 		VEL = 1,
@@ -155,6 +146,7 @@ private:
 	};
 
 	math::Matrix<3, 3> _rot_matrix;
+
 	void track_target_position();
 	void track_target_velocity();
 	bool target_velocity_valid();

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -296,7 +296,6 @@ bool Geofence::checkPolygons(double lat, double lon, float altitude)
 	int ret = dm_read(DM_KEY_FENCE_POINTS, 0, &stats, sizeof(mission_stats_entry_s));
 
 	if (ret == sizeof(mission_stats_entry_s) && _update_counter != stats.update_counter) {
-		PX4_INFO("reloading geofence");
 		_updateFence();
 	}
 

--- a/src/modules/navigator/gpsfailure.cpp
+++ b/src/modules/navigator/gpsfailure.cpp
@@ -51,19 +51,13 @@
 using matrix::Eulerf;
 using matrix::Quatf;
 
-static constexpr float DELAY_SIGMA = 0.01f;
-
 GpsFailure::GpsFailure(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name),
 	_param_loitertime(this, "LT"),
 	_param_openlooploiter_roll(this, "R"),
 	_param_openlooploiter_pitch(this, "P"),
-	_param_openlooploiter_thrust(this, "TR"),
-	_gpsf_state(GPSF_STATE_NONE),
-	_timestamp_activation(0)
+	_param_openlooploiter_thrust(this, "TR")
 {
-	/* initial reset */
-	on_inactive();
 }
 
 void

--- a/src/modules/navigator/gpsfailure.h
+++ b/src/modules/navigator/gpsfailure.h
@@ -40,18 +40,11 @@
 #ifndef NAVIGATOR_GPSFAILURE_H
 #define NAVIGATOR_GPSFAILURE_H
 
-#include <controllib/blocks.hpp>
-#include <controllib/block/BlockParam.hpp>
-
-#include <uORB/uORB.h>
-#include <uORB/Publication.hpp>
-#include <uORB/topics/vehicle_attitude_setpoint.h>
-
 #include "mission_block.h"
 
 class Navigator;
 
-class GpsFailure : public MissionBlock
+class GpsFailure final : public MissionBlock
 {
 public:
 	GpsFailure(Navigator *navigator, const char *name);

--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -38,32 +38,11 @@
  * @author Andreas Antener <andreas@uaventure.com>
  */
 
-#include <string.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <math.h>
-#include <fcntl.h>
-
-#include <systemlib/err.h>
-#include <systemlib/mavlink_log.h>
-
-#include <uORB/uORB.h>
-#include <uORB/topics/position_setpoint_triplet.h>
-
 #include "land.h"
 #include "navigator.h"
 
 Land::Land(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name)
-{
-}
-
-Land::~Land()
-{
-}
-
-void
-Land::on_inactive()
 {
 }
 

--- a/src/modules/navigator/land.h
+++ b/src/modules/navigator/land.h
@@ -41,25 +41,17 @@
 #ifndef NAVIGATOR_LAND_H
 #define NAVIGATOR_LAND_H
 
-#include <controllib/blocks.hpp>
-#include <controllib/block/BlockParam.hpp>
-
 #include "navigator_mode.h"
 #include "mission_block.h"
 
-class Land : public MissionBlock
+class Land final : public MissionBlock
 {
 public:
 	Land(Navigator *navigator, const char *name);
+	~Land() = default;
 
-	~Land();
-
-	virtual void on_inactive();
-
-	virtual void on_activation();
-
-	virtual void on_active();
-
+	void on_activation() override;
+	void on_active() override;
 };
 
 #endif

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -39,31 +39,12 @@
  * @author Anton Babushkin <anton.babushkin@me.com>
  */
 
-#include <string.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <math.h>
-#include <fcntl.h>
-
-#include <geo/geo.h>
-
-#include <systemlib/mavlink_log.h>
-#include <systemlib/err.h>
-
-#include <uORB/uORB.h>
-#include <uORB/topics/position_setpoint_triplet.h>
-
 #include "loiter.h"
 #include "navigator.h"
 
 Loiter::Loiter(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name),
-	_param_yawmode(this, "MIS_YAWMODE", false),
-	_loiter_pos_set(false)
-{
-}
-
-Loiter::~Loiter()
+	_param_yawmode(this, "MIS_YAWMODE", false)
 {
 }
 

--- a/src/modules/navigator/loiter.h
+++ b/src/modules/navigator/loiter.h
@@ -41,25 +41,20 @@
 #ifndef NAVIGATOR_LOITER_H
 #define NAVIGATOR_LOITER_H
 
-#include <controllib/blocks.hpp>
-#include <controllib/block/BlockParam.hpp>
-
 #include "navigator_mode.h"
 #include "mission_block.h"
 
-class Loiter : public MissionBlock
+class Loiter final : public MissionBlock
 {
 public:
 	Loiter(Navigator *navigator, const char *name);
+	~Loiter() = default;
 
-	~Loiter();
+	void on_inactive() override;
+	void on_activation() override;
+	void on_active() override;
 
-	virtual void on_inactive();
-
-	virtual void on_activation();
-
-	virtual void on_active();
-
+	// TODO: share this with mission
 	enum mission_yaw_mode {
 		MISSION_YAWMODE_NONE = 0,
 		MISSION_YAWMODE_FRONT_TO_WAYPOINT = 1,
@@ -81,7 +76,8 @@ private:
 	void set_loiter_position();
 
 	control::BlockParamInt _param_yawmode;
-	bool _loiter_pos_set;
+
+	bool _loiter_pos_set{false};
 };
 
 #endif

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -60,7 +60,6 @@
 
 Mission::Mission(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name),
-	_param_onboard_enabled(this, "MIS_ONBOARD_EN", false),
 	_param_dist_1wp(this, "MIS_DIST_1WP", false),
 	_param_dist_between_wps(this, "MIS_DIST_WPS", false),
 	_param_altmode(this, "MIS_ALTMODE", false),
@@ -82,14 +81,6 @@ Mission::on_inactive()
 	}
 
 	if (_inited) {
-		/* check if missions have changed so that feedback to ground station is given */
-		bool onboard_updated = false;
-		orb_check(_navigator->get_onboard_mission_sub(), &onboard_updated);
-
-		if (onboard_updated) {
-			update_onboard_mission();
-		}
-
 		bool offboard_updated = false;
 		orb_check(_navigator->get_offboard_mission_sub(), &offboard_updated);
 
@@ -175,13 +166,6 @@ Mission::on_active()
 	check_mission_valid(false);
 
 	/* check if anything has changed */
-	bool onboard_updated = false;
-	orb_check(_navigator->get_onboard_mission_sub(), &onboard_updated);
-
-	if (onboard_updated) {
-		update_onboard_mission();
-	}
-
 	bool offboard_updated = false;
 	orb_check(_navigator->get_offboard_mission_sub(), &offboard_updated);
 
@@ -198,7 +182,7 @@ Mission::on_active()
 	}
 
 	/* reset mission items if needed */
-	if (onboard_updated || offboard_updated) {
+	if (offboard_updated) {
 		set_mission_items();
 	}
 
@@ -282,7 +266,7 @@ Mission::find_offboard_land_start()
 	 * TODO: implement full spec and find closest landing point geographically
 	 */
 
-	dm_item_t dm_current = DM_KEY_WAYPOINTS_OFFBOARD(_offboard_mission.dataman_id);
+	const dm_item_t dm_current = (dm_item_t)_offboard_mission.dataman_id;
 
 	for (size_t i = 0; i < _offboard_mission.count; i++) {
 		struct mission_item_s missionitem = {};
@@ -335,53 +319,6 @@ Mission::landing()
 }
 
 void
-Mission::update_onboard_mission()
-{
-	/* reset triplets */
-	_navigator->reset_triplets();
-
-	if (orb_copy(ORB_ID(onboard_mission), _navigator->get_onboard_mission_sub(), &_onboard_mission) == OK) {
-		/* accept the current index set by the onboard mission if it is within bounds */
-		if (_onboard_mission.current_seq >= 0
-		    && _onboard_mission.current_seq < (int)_onboard_mission.count) {
-
-			_current_onboard_mission_index = _onboard_mission.current_seq;
-
-		} else {
-			/* if less WPs available, reset to first WP */
-			if (_current_onboard_mission_index >= (int)_onboard_mission.count) {
-				_current_onboard_mission_index = 0;
-				/* if not initialized, set it to 0 */
-
-			} else if (_current_onboard_mission_index < 0) {
-				_current_onboard_mission_index = 0;
-			}
-
-			/* otherwise, just leave it */
-		}
-
-		// XXX check validity here as well
-		_navigator->get_mission_result()->valid = true;
-		/* reset mission failure if we have an updated valid mission */
-		_navigator->get_mission_result()->failure = false;
-
-		/* reset sequence info as well */
-		_navigator->get_mission_result()->seq_reached = -1;
-		_navigator->get_mission_result()->seq_total = _onboard_mission.count;
-
-		/* reset work item if new mission has been accepted */
-		_work_item_type = WORK_ITEM_TYPE_DEFAULT;
-		_navigator->increment_mission_instance_count();
-		_navigator->set_mission_result_updated();
-
-	} else {
-		_onboard_mission.count = 0;
-		_onboard_mission.current_seq = 0;
-		_current_onboard_mission_index = 0;
-	}
-}
-
-void
 Mission::update_offboard_mission()
 {
 	bool failed = true;
@@ -389,11 +326,7 @@ Mission::update_offboard_mission()
 	/* reset triplets */
 	_navigator->reset_triplets();
 
-	if (orb_copy(ORB_ID(offboard_mission), _navigator->get_offboard_mission_sub(), &_offboard_mission) == OK) {
-		// The following is not really a warning, but it can be useful to have this message in the log file
-		PX4_WARN("offboard mission updated: dataman_id=%d, count=%d, current_seq=%d", _offboard_mission.dataman_id,
-			 _offboard_mission.count, _offboard_mission.current_seq);
-
+	if (orb_copy(ORB_ID(mission), _navigator->get_offboard_mission_sub(), &_offboard_mission) == OK) {
 		/* determine current index */
 		if (_offboard_mission.current_seq >= 0 && _offboard_mission.current_seq < (int)_offboard_mission.count) {
 			_current_offboard_mission_index = _offboard_mission.current_seq;
@@ -455,10 +388,6 @@ Mission::advance_mission()
 	}
 
 	switch (_mission_type) {
-	case MISSION_TYPE_ONBOARD:
-		_current_onboard_mission_index++;
-		break;
-
 	case MISSION_TYPE_OFFBOARD:
 		_current_offboard_mission_index++;
 		break;
@@ -486,8 +415,6 @@ Mission::set_mission_items()
 	/* reset the altitude foh (first order hold) logic, if altitude foh is enabled (param) a new foh element starts now */
 	_min_current_sp_distance_xy = FLT_MAX;
 
-	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-
 	/* the home dist check provides user feedback, so we initialize it to this */
 	bool user_feedback_done = false;
 
@@ -497,21 +424,7 @@ Mission::set_mission_items()
 
 	work_item_type new_work_item_type = WORK_ITEM_TYPE_DEFAULT;
 
-	/* try setting onboard mission item */
-	if (_param_onboard_enabled.get()
-	    && prepare_mission_items(true, &_mission_item, &mission_item_next_position, &has_next_position_item)) {
-
-		/* if mission type changed, notify */
-		if (_mission_type != MISSION_TYPE_ONBOARD) {
-			mavlink_log_info(_navigator->get_mavlink_log_pub(), "Executing internal mission.");
-			user_feedback_done = true;
-		}
-
-		_mission_type = MISSION_TYPE_ONBOARD;
-
-		/* try setting offboard mission item */
-
-	} else if (prepare_mission_items(false, &_mission_item, &mission_item_next_position, &has_next_position_item)) {
+	if (prepare_mission_items(&_mission_item, &mission_item_next_position, &has_next_position_item)) {
 		/* if mission type changed, notify */
 		if (_mission_type != MISSION_TYPE_OFFBOARD) {
 			mavlink_log_info(_navigator->get_mavlink_log_pub(), "Executing mission.");
@@ -544,6 +457,7 @@ Mission::set_mission_items()
 		set_loiter_item(&_mission_item, _navigator->get_takeoff_min_alt());
 
 		/* update position setpoint triplet  */
+		position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 		pos_sp_triplet->previous.valid = false;
 		mission_apply_limitation(_mission_item);
 		mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
@@ -588,6 +502,7 @@ Mission::set_mission_items()
 		}
 
 		/* we have a new position item so set previous position setpoint to current */
+		position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 		pos_sp_triplet->previous = pos_sp_triplet->current;
 
 		/* do takeoff before going to setpoint if needed and not already in takeoff */
@@ -710,8 +625,7 @@ Mission::set_mission_items()
 
 			float altitude = _navigator->get_global_position()->alt;
 
-			if (pos_sp_triplet->current.valid
-			    && pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_POSITION) {
+			if (pos_sp_triplet->current.valid && pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_POSITION) {
 				altitude = pos_sp_triplet->current.alt;
 			}
 
@@ -785,6 +699,7 @@ Mission::set_mission_items()
 		}
 
 	} else {
+		position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 		/* handle non-position mission items such as commands */
 
 		/* turn towards next waypoint before MC to FW transition */
@@ -841,6 +756,8 @@ Mission::set_mission_items()
 	}
 
 	/*********************************** set setpoints and check next *********************************************/
+
+	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
 	/* set current position setpoint from mission item (is protected against non-position items) */
 	mission_apply_limitation(_mission_item);
@@ -987,10 +904,8 @@ Mission::set_align_mission_item(struct mission_item_s *mission_item, struct miss
 	mission_item->autocontinue = true;
 	mission_item->time_inside = 0.0f;
 	mission_item->yaw = get_bearing_to_next_waypoint(
-				    _navigator->get_global_position()->lat,
-				    _navigator->get_global_position()->lon,
-				    mission_item_next->lat,
-				    mission_item_next->lon);
+				    _navigator->get_global_position()->lat, _navigator->get_global_position()->lon,
+				    mission_item_next->lat, mission_item_next->lon);
 	mission_item->force_heading = true;
 }
 
@@ -1048,8 +963,7 @@ Mission::heading_sp_update()
 		point_from_latlon[1] = _navigator->get_global_position()->lon;
 
 		/* target location is home */
-		if ((_param_yawmode.get() == MISSION_YAWMODE_FRONT_TO_HOME
-		     || _param_yawmode.get() == MISSION_YAWMODE_BACK_TO_HOME)
+		if ((_param_yawmode.get() == MISSION_YAWMODE_FRONT_TO_HOME || _param_yawmode.get() == MISSION_YAWMODE_BACK_TO_HOME)
 		    // need to be rotary wing for this but not in a transition
 		    // in VTOL mode this will prevent updating yaw during FW flight
 		    // (which would result in a wrong yaw setpoint spike during back transition)
@@ -1196,9 +1110,9 @@ Mission::do_abort_landing()
 
 	// loiter at the larger of MIS_LTRMIN_ALT above the landing point
 	//  or 2 * FW_CLMBOUT_DIFF above the current altitude
-	float alt_landing = get_absolute_altitude_for_item(_mission_item);
-	float min_climbout = _navigator->get_global_position()->alt + 20.0f;
-	float alt_sp = math::max(alt_landing + _navigator->get_loiter_min_alt(), min_climbout);
+	const float alt_landing = get_absolute_altitude_for_item(_mission_item);
+	const float alt_sp = math::max(alt_landing + _navigator->get_loiter_min_alt(),
+				       _navigator->get_global_position()->alt + 20.0f);
 
 	// turn current landing waypoint into an indefinite loiter
 	_mission_item.nav_cmd = NAV_CMD_LOITER_UNLIMITED;
@@ -1209,12 +1123,11 @@ Mission::do_abort_landing()
 	_mission_item.autocontinue = false;
 	_mission_item.origin = ORIGIN_ONBOARD;
 
-	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 	mission_apply_limitation(_mission_item);
-	mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
+	mission_item_to_position_setpoint(_mission_item, &_navigator->get_position_setpoint_triplet()->current);
 	_navigator->set_position_setpoint_triplet_updated();
 
-	mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "Holding at %dm above landing.",
+	mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "Holding at %d m above landing.",
 				     (int)(alt_sp - alt_landing));
 
 	// reset mission index to start of landing
@@ -1240,18 +1153,18 @@ Mission::do_abort_landing()
 }
 
 bool
-Mission::prepare_mission_items(bool onboard, struct mission_item_s *mission_item,
-			       struct mission_item_s *next_position_mission_item, bool *has_next_position_item)
+Mission::prepare_mission_items(mission_item_s *mission_item, mission_item_s *next_position_mission_item,
+			       bool *has_next_position_item)
 {
 	bool first_res = false;
 	int offset = 1;
 
-	if (read_mission_item(onboard, 0, mission_item)) {
+	if (read_mission_item(0, mission_item)) {
 
 		first_res = true;
 
 		/* trying to find next position mission item */
-		while (read_mission_item(onboard, offset, next_position_mission_item)) {
+		while (read_mission_item(offset, next_position_mission_item)) {
 
 			if (item_contains_position(*next_position_mission_item)) {
 				*has_next_position_item = true;
@@ -1266,30 +1179,19 @@ Mission::prepare_mission_items(bool onboard, struct mission_item_s *mission_item
 }
 
 bool
-Mission::read_mission_item(bool onboard, int offset, struct mission_item_s *mission_item)
+Mission::read_mission_item(int offset, struct mission_item_s *mission_item)
 {
-	/* select onboard/offboard mission */
-	int *mission_index_ptr;
-	dm_item_t dm_item;
-
-	struct mission_s *mission = (onboard) ? &_onboard_mission : &_offboard_mission;
-	int current_index = (onboard) ? _current_onboard_mission_index : _current_offboard_mission_index;
+	/* select offboard mission */
+	struct mission_s *mission = &_offboard_mission;
+	int current_index = _current_offboard_mission_index;
 	int index_to_read = current_index + offset;
+
+	int *mission_index_ptr = (offset == 0) ? &_current_offboard_mission_index : &index_to_read;
+	const dm_item_t dm_item = (dm_item_t)_offboard_mission.dataman_id;
 
 	/* do not work on empty missions */
 	if (mission->count == 0) {
 		return false;
-	}
-
-	if (onboard) {
-		/* onboard mission */
-		mission_index_ptr = (offset == 0) ? &_current_onboard_mission_index : &index_to_read;
-		dm_item = DM_KEY_WAYPOINTS_ONBOARD;
-
-	} else {
-		/* offboard mission */
-		mission_index_ptr = (offset == 0) ? &_current_offboard_mission_index : &index_to_read;
-		dm_item = DM_KEY_WAYPOINTS_OFFBOARD(_offboard_mission.dataman_id);
 	}
 
 	/* Repeat this several times in case there are several DO JUMPS that we need to follow along, however, after
@@ -1300,8 +1202,7 @@ Mission::read_mission_item(bool onboard, int offset, struct mission_item_s *miss
 			/* mission item index out of bounds - if they are equal, we just reached the end */
 			if (*mission_index_ptr != (int)mission->count) {
 				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission item index out of bound, index: %d, max: %d.",
-						     *mission_index_ptr,
-						     (int)mission->count);
+						     *mission_index_ptr, mission->count);
 			}
 
 			return false;
@@ -1331,10 +1232,8 @@ Mission::read_mission_item(bool onboard, int offset, struct mission_item_s *miss
 					(mission_item_tmp.do_jump_current_count)++;
 
 					/* save repeat count */
-					if (dm_write(dm_item, *mission_index_ptr, DM_PERSIST_POWER_ON_RESET,
-						     &mission_item_tmp, len) != len) {
-						/* not supposed to happen unless the datamanager can't access the
-						 * dataman */
+					if (dm_write(dm_item, *mission_index_ptr, DM_PERSIST_POWER_ON_RESET, &mission_item_tmp, len) != len) {
+						/* not supposed to happen unless the datamanager can't access the dataman */
 						mavlink_log_critical(_navigator->get_mavlink_log_pub(), "DO JUMP waypoint could not be written.");
 						return false;
 					}
@@ -1376,7 +1275,7 @@ Mission::save_offboard_mission_state()
 	int dm_lock_ret = dm_lock(DM_KEY_MISSION_STATE);
 
 	if (dm_lock_ret != 0) {
-		PX4_ERR("lock failed");
+		PX4_ERR("DM_KEY_MISSION_STATE lock failed");
 	}
 
 	/* read current state */
@@ -1387,16 +1286,19 @@ Mission::save_offboard_mission_state()
 		if (mission_state.dataman_id == _offboard_mission.dataman_id && mission_state.count == _offboard_mission.count) {
 			/* navigator may modify only sequence, write modified state only if it changed */
 			if (mission_state.current_seq != _current_offboard_mission_index) {
+				mission_state.timestamp = hrt_absolute_time();
+
 				if (dm_write(DM_KEY_MISSION_STATE, 0, DM_PERSIST_POWER_ON_RESET, &mission_state,
 					     sizeof(mission_s)) != sizeof(mission_s)) {
 
-					mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Can't save mission state.");
+					PX4_ERR("Can't save mission state");
 				}
 			}
 		}
 
 	} else {
 		/* invalid data, this must not happen and indicates error in offboard_mission publisher */
+		mission_state.timestamp = hrt_absolute_time();
 		mission_state.dataman_id = _offboard_mission.dataman_id;
 		mission_state.count = _offboard_mission.count;
 		mission_state.current_seq = _current_offboard_mission_index;
@@ -1407,7 +1309,7 @@ Mission::save_offboard_mission_state()
 		if (dm_write(DM_KEY_MISSION_STATE, 0, DM_PERSIST_POWER_ON_RESET, &mission_state,
 			     sizeof(mission_s)) != sizeof(mission_s)) {
 
-			mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Can't save mission state.");
+			PX4_ERR("Can't save mission state");
 		}
 	}
 
@@ -1424,6 +1326,7 @@ Mission::report_do_jump_mission_changed(int index, int do_jumps_remaining)
 	_navigator->get_mission_result()->item_do_jump_changed = true;
 	_navigator->get_mission_result()->item_changed_index = index;
 	_navigator->get_mission_result()->item_do_jump_remaining = do_jumps_remaining;
+
 	_navigator->set_mission_result_updated();
 }
 
@@ -1432,6 +1335,7 @@ Mission::set_mission_item_reached()
 {
 	_navigator->get_mission_result()->seq_reached = _current_offboard_mission_index;
 	_navigator->set_mission_result_updated();
+
 	reset_mission_item_reached();
 }
 
@@ -1440,6 +1344,7 @@ Mission::set_current_offboard_mission_item()
 {
 	_navigator->get_mission_result()->finished = false;
 	_navigator->get_mission_result()->seq_current = _current_offboard_mission_index;
+
 	_navigator->set_mission_result_updated();
 
 	save_offboard_mission_state();
@@ -1474,13 +1379,13 @@ Mission::reset_offboard_mission(struct mission_s &mission)
 	dm_lock(DM_KEY_MISSION_STATE);
 
 	if (dm_read(DM_KEY_MISSION_STATE, 0, &mission, sizeof(mission_s)) == sizeof(mission_s)) {
-		if (mission.dataman_id >= 0 && mission.dataman_id <= 1) {
+		if (mission.dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_0 || mission.dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_1) {
 			/* set current item to 0 */
 			mission.current_seq = 0;
 
 			/* reset jump counters */
 			if (mission.count > 0) {
-				dm_item_t dm_current = DM_KEY_WAYPOINTS_OFFBOARD(mission.dataman_id);
+				const dm_item_t dm_current = (dm_item_t)mission.dataman_id;
 
 				for (unsigned index = 0; index < mission.count; index++) {
 					struct mission_item_s item;
@@ -1506,7 +1411,8 @@ Mission::reset_offboard_mission(struct mission_s &mission)
 			mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Could not read mission.");
 
 			/* initialize mission state in dataman */
-			mission.dataman_id = 0;
+			mission.timestamp = hrt_absolute_time();
+			mission.dataman_id = DM_KEY_WAYPOINTS_OFFBOARD_0;
 			mission.count = 0;
 			mission.current_seq = 0;
 		}

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -51,8 +51,6 @@
 
 #include <cfloat>
 
-#include <controllib/block/BlockParam.hpp>
-#include <controllib/blocks.hpp>
 #include <dataman/dataman.h>
 #include <drivers/drv_hrt.h>
 #include <uORB/topics/home_position.h>
@@ -66,7 +64,7 @@
 
 class Navigator;
 
-class Mission : public MissionBlock
+class Mission final : public MissionBlock
 {
 public:
 	Mission(Navigator *navigator, const char *name);

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -158,11 +158,6 @@ private:
 	void altitude_sp_foh_update();
 
 	/**
-	 * Resets the altitude sp foh logic
-	 */
-	void altitude_sp_foh_reset();
-
-	/**
 	 * Update the cruising speed setpoint.
 	 */
 	void cruising_speed_sp_update();
@@ -212,11 +207,6 @@ private:
 	void set_current_offboard_mission_item();
 
 	/**
-	 * Set that the mission is finished if one exists or that none exists
-	 */
-	void set_mission_finished();
-
-	/**
 	 * Check whether a mission is ready to go
 	 */
 	void check_mission_valid(bool force);
@@ -243,12 +233,10 @@ private:
 	bool find_offboard_land_start();
 
 	control::BlockParamInt _param_onboard_enabled;
-	control::BlockParamFloat _param_takeoff_alt;
 	control::BlockParamFloat _param_dist_1wp;
 	control::BlockParamFloat _param_dist_between_wps;
 	control::BlockParamInt _param_altmode;
 	control::BlockParamInt _param_yawmode;
-	control::BlockParamFloat _param_fw_climbout_diff;
 
 	struct mission_s _onboard_mission {};
 	struct mission_s _offboard_mission {};
@@ -271,8 +259,6 @@ private:
 	bool _inited{false};
 	bool _home_inited{false};
 	bool _need_mission_reset{false};
-
-	MissionFeasibilityChecker _missionFeasibilityChecker; /**< class that checks if a mission is feasible */
 
 	float _min_current_sp_distance_xy{FLT_MAX}; /**< minimum distance which was achieved to the current waypoint  */
 

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -97,10 +97,6 @@ public:
 	uint16_t get_land_start_index() const { return _land_start_index; }
 
 private:
-	/**
-	 * Update onboard mission topic
-	 */
-	void update_onboard_mission();
 
 	/**
 	 * Update offboard mission topic
@@ -175,8 +171,8 @@ private:
 	 *
 	 * @return true if current mission item available
 	 */
-	bool prepare_mission_items(bool onboard, struct mission_item_s *mission_item,
-				   struct mission_item_s *next_position_mission_item, bool *has_next_position_item);
+	bool prepare_mission_items(mission_item_s *mission_item, mission_item_s *next_position_mission_item,
+				   bool *has_next_position_item);
 
 	/**
 	 * Read current (offset == 0) or a specific (offset > 0) mission item
@@ -184,7 +180,7 @@ private:
 	 *
 	 * @return true if successful
 	 */
-	bool read_mission_item(bool onboard, int offset, struct mission_item_s *mission_item);
+	bool read_mission_item(int offset, mission_item_s *mission_item);
 
 	/**
 	 * Save current offboard mission state to dataman
@@ -232,16 +228,13 @@ private:
 	 */
 	bool find_offboard_land_start();
 
-	control::BlockParamInt _param_onboard_enabled;
 	control::BlockParamFloat _param_dist_1wp;
 	control::BlockParamFloat _param_dist_between_wps;
 	control::BlockParamInt _param_altmode;
 	control::BlockParamInt _param_yawmode;
 
-	struct mission_s _onboard_mission {};
 	struct mission_s _offboard_mission {};
 
-	int32_t _current_onboard_mission_index{-1};
 	int32_t _current_offboard_mission_index{-1};
 
 	// track location of planned mission landing
@@ -252,7 +245,6 @@ private:
 
 	enum {
 		MISSION_TYPE_NONE,
-		MISSION_TYPE_ONBOARD,
 		MISSION_TYPE_OFFBOARD
 	} _mission_type{MISSION_TYPE_NONE};
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -558,16 +558,6 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 }
 
 void
-MissionBlock::set_previous_pos_setpoint()
-{
-	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
-
-	if (pos_sp_triplet->current.valid) {
-		memcpy(&pos_sp_triplet->previous, &pos_sp_triplet->current, sizeof(struct position_setpoint_s));
-	}
-}
-
-void
 MissionBlock::set_loiter_item(struct mission_item_s *item, float min_clearance)
 {
 	if (_navigator->get_land_detected()->landed) {

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -91,11 +91,6 @@ protected:
 	bool mission_item_to_position_setpoint(const mission_item_s &item, position_setpoint_s *sp);
 
 	/**
-	 * Set previous position setpoint to current setpoint
-	 */
-	void set_previous_pos_setpoint();
-
-	/**
 	 * Set a loiter mission item, if possible reuse the position setpoint, otherwise take the current position
 	 */
 	void set_loiter_item(struct mission_item_s *item, float min_clearance = -1.0f);

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -42,8 +42,12 @@
 #define NAVIGATOR_MISSION_BLOCK_H
 
 #include "navigator_mode.h"
+#include "navigation.h"
 
-#include <navigator/navigation.h>
+#include <controllib/blocks.hpp>
+#include <controllib/block/BlockParam.hpp>
+#include <drivers/drv_hrt.h>
+#include <systemlib/mavlink_log.h>
 #include <uORB/topics/mission.h>
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/vehicle_command.h>
@@ -59,7 +63,7 @@ public:
 	 * Constructor
 	 */
 	MissionBlock(Navigator *navigator, const char *name);
-	~MissionBlock() = default;
+	virtual ~MissionBlock() = default;
 
 	MissionBlock(const MissionBlock &) = delete;
 	MissionBlock &operator=(const MissionBlock &) = delete;
@@ -130,13 +134,6 @@ protected:
 	hrt_abstime _time_wp_reached{0};
 
 	orb_advert_t    _actuator_pub{nullptr};
-
-	control::BlockParamFloat _param_yaw_timeout;
-	control::BlockParamFloat _param_yaw_err;
-
-	// VTOL parameters
-	control::BlockParamFloat _param_back_trans_dec_mss;
-	control::BlockParamFloat _param_reverse_delay;
 };
 
 #endif

--- a/src/modules/navigator/mission_feasibility_checker.h
+++ b/src/modules/navigator/mission_feasibility_checker.h
@@ -55,24 +55,22 @@ private:
 	Navigator *_navigator{nullptr};
 
 	/* Checks for all airframes */
-	bool checkGeofence(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid);
+	bool checkGeofence(const mission_s &mission, float home_alt, bool home_valid);
 
-	bool checkHomePositionAltitude(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_alt_valid,
-				       bool throw_error);
+	bool checkHomePositionAltitude(const mission_s &mission, float home_alt, bool home_alt_valid, bool throw_error);
 
-	bool checkMissionItemValidity(dm_item_t dm_current, size_t nMissionItems);
+	bool checkMissionItemValidity(const mission_s &mission);
 
-	bool checkDistanceToFirstWaypoint(dm_item_t dm_current, size_t nMissionItems, float max_distance);
-	bool checkDistancesBetweenWaypoints(dm_item_t dm_current, size_t nMissionItems, float max_distance);
+	bool checkDistanceToFirstWaypoint(const mission_s &mission, float max_distance);
+	bool checkDistancesBetweenWaypoints(const mission_s &mission, float max_distance);
 
 	/* Checks specific to fixedwing airframes */
-	bool checkFixedwing(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_alt_valid, bool land_start_req);
-
-	bool checkFixedWingTakeoff(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_alt_valid);
-	bool checkFixedWingLanding(dm_item_t dm_current, size_t nMissionItems, bool land_start_req);
+	bool checkFixedwing(const mission_s &mission, float home_alt, bool home_alt_valid, bool land_start_req);
+	bool checkFixedWingTakeoff(const mission_s &mission, float home_alt, bool home_alt_valid);
+	bool checkFixedWingLanding(const mission_s &mission, bool land_start_req);
 
 	/* Checks specific to rotarywing airframes */
-	bool checkRotarywing(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_alt_valid);
+	bool checkRotarywing(const mission_s &mission, float home_alt, bool home_alt_valid);
 
 public:
 	MissionFeasibilityChecker(Navigator *navigator) : _navigator(navigator) {}

--- a/src/modules/navigator/mission_feasibility_checker.h
+++ b/src/modules/navigator/mission_feasibility_checker.h
@@ -55,29 +55,24 @@ private:
 	Navigator *_navigator{nullptr};
 
 	/* Checks for all airframes */
-	bool checkGeofence(dm_item_t dm_current, size_t nMissionItems, Geofence &geofence, float home_alt, bool home_valid);
+	bool checkGeofence(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid);
 
 	bool checkHomePositionAltitude(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_alt_valid,
-				       bool &warning_issued, bool throw_error = false);
+				       bool throw_error);
 
-	bool checkMissionItemValidity(dm_item_t dm_current, size_t nMissionItems, bool condition_landed);
+	bool checkMissionItemValidity(dm_item_t dm_current, size_t nMissionItems);
 
-	bool checkDistanceToFirstWaypoint(dm_item_t dm_current, size_t nMissionItems, float max_distance, bool &warning_issued);
-	bool checkDistancesBetweenWaypoints(dm_item_t dm_current, size_t nMissionItems, float max_distance,
-					    bool &warning_issued);
+	bool checkDistanceToFirstWaypoint(dm_item_t dm_current, size_t nMissionItems, float max_distance);
+	bool checkDistancesBetweenWaypoints(dm_item_t dm_current, size_t nMissionItems, float max_distance);
 
 	/* Checks specific to fixedwing airframes */
-	bool checkFixedwing(dm_item_t dm_current, size_t nMissionItems, fw_pos_ctrl_status_s *fw_pos_ctrl_status,
-			    float home_alt, bool home_alt_valid, float default_acceptance_rad, bool land_start_req);
+	bool checkFixedwing(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_alt_valid, bool land_start_req);
 
-	bool checkFixedWingTakeoff(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_alt_valid,
-				   float default_acceptance_rad);
-	bool checkFixedWingLanding(dm_item_t dm_current, size_t nMissionItems, fw_pos_ctrl_status_s *fw_pos_ctrl_status,
-				   bool land_start_req);
+	bool checkFixedWingTakeoff(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_alt_valid);
+	bool checkFixedWingLanding(dm_item_t dm_current, size_t nMissionItems, bool land_start_req);
 
 	/* Checks specific to rotarywing airframes */
-	bool checkRotarywing(dm_item_t dm_current, size_t nMissionItems,
-			     float home_alt, bool home_alt_valid, float default_altitude_acceptance_rad);
+	bool checkRotarywing(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_alt_valid);
 
 public:
 	MissionFeasibilityChecker(Navigator *navigator) : _navigator(navigator) {}

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -73,17 +73,6 @@ PARAM_DEFINE_FLOAT(MIS_TAKEOFF_ALT, 2.5f);
 PARAM_DEFINE_FLOAT(MIS_LTRMIN_ALT, -1.0f);
 
 /**
- * Persistent onboard mission storage
- *
- * When enabled, missions that have been uploaded by the GCS are stored
- * and reloaded after reboot persistently.
- *
- * @boolean
- * @group Mission
- */
-PARAM_DEFINE_INT32(MIS_ONBOARD_EN, 1);
-
-/**
  * Maximal horizontal distance from home to first waypoint
  *
  * Failsafe check to prevent running mission stored from previous flight at a new takeoff location.

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -154,7 +154,6 @@ public:
 	bool home_alt_valid() { return (_home_pos.timestamp > 0 && _home_pos.valid_alt); }
 	bool home_position_valid() { return (_home_pos.timestamp > 0 && _home_pos.valid_alt && _home_pos.valid_hpos); }
 
-	int		get_onboard_mission_sub() { return _onboard_mission_sub; }
 	int		get_offboard_mission_sub() { return _offboard_mission_sub; }
 
 	Geofence	&get_geofence() { return _geofence; }
@@ -272,7 +271,6 @@ private:
 	int		_land_detected_sub{-1};		/**< vehicle land detected subscription */
 	int		_local_pos_sub{-1};		/**< local position subscription */
 	int		_offboard_mission_sub{-1};	/**< offboard mission subscription */
-	int		_onboard_mission_sub{-1};	/**< onboard mission subscription */
 	int		_param_update_sub{-1};		/**< param update subscription */
 	int		_sensor_combined_sub{-1};	/**< sensor combined subscription */
 	int		_traffic_sub{-1};		/**< traffic subscription */

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -66,6 +66,7 @@
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
+#include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_gps_position.h>
 #include <uORB/topics/vehicle_land_detected.h>
@@ -250,6 +251,13 @@ public:
 
 	// Param access
 	float		get_loiter_min_alt() const { return _param_loiter_min_alt.get(); }
+	float		get_takeoff_min_alt() const { return _param_takeoff_min_alt.get(); }
+	float		get_yaw_timeout() const { return _param_yaw_timeout.get(); }
+	float		get_yaw_threshold() const { return _param_yaw_err.get(); }
+
+	float		get_vtol_back_trans_deceleration() const { return _param_back_trans_dec_mss.get(); }
+	float		get_vtol_reverse_delay() const { return _param_reverse_delay.get(); }
+
 	bool		force_vtol() const { return _vstatus.is_vtol && !_vstatus.is_rotary_wing && _param_force_vtol.get(); }
 
 private:
@@ -330,7 +338,15 @@ private:
 	control::BlockParamInt _param_traffic_avoidance_mode;	/**< avoiding other aircraft is enabled */
 
 	// non-navigator parameters
+	// Mission (MIS_*)
 	control::BlockParamFloat _param_loiter_min_alt;
+	control::BlockParamFloat _param_takeoff_min_alt;
+	control::BlockParamFloat _param_yaw_timeout;
+	control::BlockParamFloat _param_yaw_err;
+
+	// VTOL parameters TODO: get these out of navigator
+	control::BlockParamFloat _param_back_trans_dec_mss;
+	control::BlockParamFloat _param_reverse_delay;
 
 	float _mission_cruising_speed_mc{-1.0f};
 	float _mission_cruising_speed_fw{-1.0f};

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -105,7 +105,12 @@ Navigator::Navigator() :
 	_param_force_vtol(this, "FORCE_VT"),
 	_param_traffic_avoidance_mode(this, "TRAFF_AVOID"),
 	// non-navigator params
-	_param_loiter_min_alt(this, "MIS_LTRMIN_ALT", false)
+	_param_loiter_min_alt(this, "MIS_LTRMIN_ALT", false),
+	_param_takeoff_min_alt(this, "MIS_TAKEOFF_ALT", false),
+	_param_yaw_timeout(this, "MIS_YAW_TMT", false),
+	_param_yaw_err(this, "MIS_YAW_ERR", false),
+	_param_back_trans_dec_mss(this, "VT_B_DEC_MSS", false),
+	_param_reverse_delay(this, "VT_B_REV_DEL", false)
 {
 	/* Create a list of our possible navigation types */
 	_navigation_mode_array[0] = &_mission;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1128,10 +1128,6 @@ Navigator::publish_mission_result()
 		_mission_result_pub = orb_advertise(ORB_ID(mission_result), &_mission_result);
 	}
 
-	// Don't reset current waypoint because it won't be updated e.g. if not in mission mode
-	// however, the current is still valid and therefore helpful for ground stations.
-	//_mission_result.seq_current = 0;
-
 	/* reset some of the flags */
 	_mission_result.item_do_jump_changed = false;
 	_mission_result.item_changed_index = 0;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -248,8 +248,7 @@ Navigator::task_main()
 	_vstatus_sub = orb_subscribe(ORB_ID(vehicle_status));
 	_land_detected_sub = orb_subscribe(ORB_ID(vehicle_land_detected));
 	_home_pos_sub = orb_subscribe(ORB_ID(home_position));
-	_onboard_mission_sub = orb_subscribe(ORB_ID(onboard_mission));
-	_offboard_mission_sub = orb_subscribe(ORB_ID(offboard_mission));
+	_offboard_mission_sub = orb_subscribe(ORB_ID(mission));
 	_param_update_sub = orb_subscribe(ORB_ID(parameter_update));
 	_vehicle_command_sub = orb_subscribe(ORB_ID(vehicle_command));
 	_traffic_sub = orb_subscribe(ORB_ID(transponder_report));
@@ -740,7 +739,6 @@ Navigator::task_main()
 	orb_unsubscribe(_vstatus_sub);
 	orb_unsubscribe(_land_detected_sub);
 	orb_unsubscribe(_home_pos_sub);
-	orb_unsubscribe(_onboard_mission_sub);
 	orb_unsubscribe(_offboard_mission_sub);
 	orb_unsubscribe(_param_update_sub);
 	orb_unsubscribe(_vehicle_command_sub);

--- a/src/modules/navigator/navigator_mode.h
+++ b/src/modules/navigator/navigator_mode.h
@@ -42,14 +42,8 @@
 #ifndef NAVIGATOR_MODE_H
 #define NAVIGATOR_MODE_H
 
-#include <drivers/drv_hrt.h>
-
 #include <controllib/blocks.hpp>
 #include <controllib/block/BlockParam.hpp>
-
-#include <dataman/dataman.h>
-
-#include <uORB/topics/position_setpoint_triplet.h>
 
 class Navigator;
 

--- a/src/modules/navigator/rcloss.cpp
+++ b/src/modules/navigator/rcloss.cpp
@@ -91,7 +91,7 @@ RCLoss::set_rcl_item()
 {
 	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 
-	set_previous_pos_setpoint();
+	pos_sp_triplet->previous = pos_sp_triplet->current;
 	_navigator->set_can_loiter_at_sp(false);
 
 	switch (_rcl_state) {

--- a/src/modules/navigator/rcloss.cpp
+++ b/src/modules/navigator/rcloss.cpp
@@ -53,18 +53,10 @@
 #include "navigator.h"
 #include "datalinkloss.h"
 
-#define DELAY_SIGMA	0.01f
-
 RCLoss::RCLoss(Navigator *navigator, const char *name) :
 	MissionBlock(navigator, name),
 	_param_loitertime(this, "LT"),
 	_rcl_state(RCL_STATE_NONE)
-{
-	/* initial reset */
-	on_inactive();
-}
-
-RCLoss::~RCLoss()
 {
 }
 

--- a/src/modules/navigator/rcloss.h
+++ b/src/modules/navigator/rcloss.h
@@ -40,28 +40,20 @@
 #ifndef NAVIGATOR_RCLOSS_H
 #define NAVIGATOR_RCLOSS_H
 
-#include <controllib/blocks.hpp>
-#include <controllib/block/BlockParam.hpp>
-
-#include <uORB/Subscription.hpp>
-
 #include "navigator_mode.h"
 #include "mission_block.h"
 
 class Navigator;
 
-class RCLoss : public MissionBlock
+class RCLoss final : public MissionBlock
 {
 public:
 	RCLoss(Navigator *navigator, const char *name);
+	~RCLoss() = default;
 
-	~RCLoss();
-
-	virtual void on_inactive();
-
-	virtual void on_activation();
-
-	virtual void on_active();
+	void on_inactive() override;
+	void on_activation() override;
+	void on_active() override;
 
 private:
 	/* Params */
@@ -72,7 +64,7 @@ private:
 		RCL_STATE_LOITER = 1,
 		RCL_STATE_TERMINATE = 2,
 		RCL_STATE_END = 3
-	} _rcl_state;
+	} _rcl_state{RCL_STATE_NONE};
 
 	/**
 	 * Set the RCL item

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -167,7 +167,7 @@ RTL::set_rtl_item()
 			_mission_item.origin = ORIGIN_ONBOARD;
 
 			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: climb to %d m (%d m above home)",
-						     (int)(climb_alt), (int)(climb_alt - _navigator->get_home_position()->alt));
+						     (int)ceilf(climb_alt), (int)ceilf(climb_alt - _navigator->get_home_position()->alt));
 			break;
 		}
 
@@ -198,7 +198,7 @@ RTL::set_rtl_item()
 			_mission_item.origin = ORIGIN_ONBOARD;
 
 			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: return at %d m (%d m above home)",
-						     (int)(_mission_item.altitude), (int)(_mission_item.altitude - home.alt));
+						     (int)ceilf(_mission_item.altitude), (int)ceilf(_mission_item.altitude - home.alt));
 
 			break;
 		}
@@ -235,7 +235,7 @@ RTL::set_rtl_item()
 			pos_sp_triplet->previous.valid = false;
 
 			mavlink_and_console_log_info(_navigator->get_mavlink_log_pub(), "RTL: descend to %d m (%d m above home)",
-						     (int)(_mission_item.altitude), (int)(_mission_item.altitude - home.alt));
+						     (int)ceilf(_mission_item.altitude), (int)ceilf(_mission_item.altitude - home.alt));
 			break;
 		}
 

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -46,7 +46,7 @@
 
 class Navigator;
 
-class RTL : public MissionBlock
+class RTL final : public MissionBlock
 {
 public:
 	RTL(Navigator *navigator, const char *name);

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -38,33 +38,11 @@
  * @author Lorenz Meier <lorenz@px4.io
  */
 
-#include <string.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <math.h>
-#include <fcntl.h>
-
-#include <systemlib/mavlink_log.h>
-#include <systemlib/err.h>
-
-#include <uORB/uORB.h>
-#include <uORB/topics/position_setpoint_triplet.h>
-
 #include "takeoff.h"
 #include "navigator.h"
 
 Takeoff::Takeoff(Navigator *navigator, const char *name) :
-	MissionBlock(navigator, name),
-	_param_min_alt(this, "MIS_TAKEOFF_ALT", false)
-{
-}
-
-Takeoff::~Takeoff()
-{
-}
-
-void
-Takeoff::on_inactive()
+	MissionBlock(navigator, name)
 {
 }
 
@@ -106,10 +84,10 @@ Takeoff::set_takeoff_position()
 	float min_abs_altitude;
 
 	if (_navigator->home_position_valid()) { //only use home position if it is valid
-		min_abs_altitude = _navigator->get_global_position()->alt + _param_min_alt.get();
+		min_abs_altitude = _navigator->get_global_position()->alt + _navigator->get_takeoff_min_alt();
 
 	} else { //e.g. flow
-		min_abs_altitude = _param_min_alt.get();
+		min_abs_altitude = _navigator->get_takeoff_min_alt();
 	}
 
 	// Use altitude if it has been set. If home position is invalid use min_abs_altitude
@@ -120,22 +98,21 @@ Takeoff::set_takeoff_position()
 		if (abs_altitude < min_abs_altitude) {
 			abs_altitude = min_abs_altitude;
 			mavlink_log_critical(_navigator->get_mavlink_log_pub(),
-					     "Using minimum takeoff altitude: %.2f m", (double)_param_min_alt.get());
+					     "Using minimum takeoff altitude: %.2f m", (double)_navigator->get_takeoff_min_alt());
 		}
 
 	} else {
 		// Use home + minimum clearance but only notify.
 		abs_altitude = min_abs_altitude;
 		mavlink_log_info(_navigator->get_mavlink_log_pub(),
-				 "Using minimum takeoff altitude: %.2f m", (double)_param_min_alt.get());
+				 "Using minimum takeoff altitude: %.2f m", (double)_navigator->get_takeoff_min_alt());
 	}
 
 
 	if (abs_altitude < _navigator->get_global_position()->alt) {
 		// If the suggestion is lower than our current alt, let's not go down.
 		abs_altitude = _navigator->get_global_position()->alt;
-		mavlink_log_critical(_navigator->get_mavlink_log_pub(),
-				     "Already higher than takeoff altitude");
+		mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Already higher than takeoff altitude");
 	}
 
 	// set current mission item to takeoff

--- a/src/modules/navigator/takeoff.h
+++ b/src/modules/navigator/takeoff.h
@@ -47,21 +47,16 @@
 #include "navigator_mode.h"
 #include "mission_block.h"
 
-class Takeoff : public MissionBlock
+class Takeoff final : public MissionBlock
 {
 public:
 	Takeoff(Navigator *navigator, const char *name);
+	~Takeoff() = default;
 
-	~Takeoff();
-
-	virtual void on_inactive();
-
-	virtual void on_activation();
-
-	virtual void on_active();
+	void on_activation() override;
+	void on_active() override;
 
 private:
-	control::BlockParamFloat _param_min_alt;
 
 	void set_takeoff_position();
 };


### PR DESCRIPTION
This PR closes a few holes with commander mission checking.

In the future we should split mission validity reporting from the overall navigator result.