### PR TITLE
controllib add BlockParamBool for boolean parameters

### DIFF
--- a/src/lib/controllib/block/BlockParam.cpp
+++ b/src/lib/controllib/block/BlockParam.cpp
@@ -82,6 +82,30 @@ BlockParamBase::BlockParamBase(Block *parent, const char *name, bool parent_pref
 };
 
 template <>
+BlockParam<bool>::BlockParam(Block *block, const char *name, bool parent_prefix) :
+	BlockParamBase(block, name, parent_prefix),
+	_val()
+{
+	update();
+}
+
+template <>
+bool BlockParam<bool>::update()
+{
+	int32_t tmp = 0;
+	int ret = param_get(_handle, &tmp);
+
+	if (tmp == 1) {
+		_val = true;
+
+	} else {
+		_val = false;
+	}
+
+	return (ret == PX4_OK);
+}
+
+template <>
 BlockParam<int32_t>::BlockParam(Block *block, const char *name, bool parent_prefix) :
 	BlockParamBase(block, name, parent_prefix),
 	_val()

--- a/src/lib/controllib/block/BlockParam.hpp
+++ b/src/lib/controllib/block/BlockParam.hpp
@@ -63,7 +63,7 @@ public:
 	virtual ~BlockParamBase() = default;
 
 	virtual bool update() = 0;
-	const char *getName() { return param_name(_handle); }
+	const char *getName() const { return param_name(_handle); }
 
 protected:
 	param_t _handle{PARAM_INVALID};
@@ -101,8 +101,12 @@ protected:
 	T _val;
 };
 
+template <>
+bool BlockParam<bool>::update();
+
 typedef BlockParam<float> BlockParamFloat;
 typedef BlockParam<int32_t> BlockParamInt;
+typedef BlockParam<bool> BlockParamBool;
 typedef BlockParam<float &> BlockParamExtFloat;
 typedef BlockParam<int32_t &> BlockParamExtInt;
 

--- a/src/lib/launchdetection/LaunchDetector.h
+++ b/src/lib/launchdetection/LaunchDetector.h
@@ -61,7 +61,7 @@ public:
 
 	void update(float accel_x);
 	LaunchDetectionResult getLaunchDetected();
-	bool launchDetectionEnabled() { return launchdetection_on.get() == 1; }
+	bool launchDetectionEnabled() { return launchdetection_on.get(); }
 
 	/* Returns a maximum pitch in deg. Different launch methods may impose upper pitch limits during launch */
 	float getPitchMax(float pitchMaxDefault);
@@ -77,7 +77,7 @@ private:
 
 	LaunchMethod *launchMethods[1];
 
-	control::BlockParamInt launchdetection_on;
+	control::BlockParamBool launchdetection_on;
 };
 
 } // namespace launchdetection

--- a/src/lib/runway_takeoff/RunwayTakeoff.h
+++ b/src/lib/runway_takeoff/RunwayTakeoff.h
@@ -74,7 +74,7 @@ public:
 	RunwayTakeoffState getState() { return _state; }
 	bool isInitialized() { return _initialized; }
 
-	bool runwayTakeoffEnabled() { return (bool)_runway_takeoff_enabled.get(); }
+	bool runwayTakeoffEnabled() { return _runway_takeoff_enabled.get(); }
 	float getMinAirspeedScaling() { return _min_airspeed_scaling.get(); }
 	float getInitYaw() { return _init_yaw; }
 
@@ -103,7 +103,7 @@ private:
 	math::Vector<2> _start_wp;
 
 	/** parameters **/
-	control::BlockParamInt _runway_takeoff_enabled;
+	control::BlockParamBool _runway_takeoff_enabled;
 	control::BlockParamInt _heading_mode;
 	control::BlockParamFloat _nav_alt;
 	control::BlockParamFloat _takeoff_throttle;


### PR DESCRIPTION
This is a bool convenience wrapper for int32 parameters. In the future we can look at adding a new underlying param type.

This was a small piece of https://github.com/PX4/Firmware/pull/7517 that wasn't merged.