### PR TITLE
mission feasibility full home position isn't always needed

### DIFF
--- a/src/modules/navigator/mission_feasibility_checker.h
+++ b/src/modules/navigator/mission_feasibility_checker.h
@@ -57,7 +57,7 @@ private:
 	/* Checks for all airframes */
 	bool checkGeofence(dm_item_t dm_current, size_t nMissionItems, Geofence &geofence, float home_alt, bool home_valid);
 
-	bool checkHomePositionAltitude(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid,
+	bool checkHomePositionAltitude(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_alt_valid,
 				       bool &warning_issued, bool throw_error = false);
 
 	bool checkMissionItemValidity(dm_item_t dm_current, size_t nMissionItems, bool condition_landed);
@@ -68,16 +68,16 @@ private:
 
 	/* Checks specific to fixedwing airframes */
 	bool checkFixedwing(dm_item_t dm_current, size_t nMissionItems, fw_pos_ctrl_status_s *fw_pos_ctrl_status,
-			    float home_alt, bool home_valid, float default_acceptance_rad, bool land_start_req);
+			    float home_alt, bool home_alt_valid, float default_acceptance_rad, bool land_start_req);
 
-	bool checkFixedWingTakeoff(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_valid,
+	bool checkFixedWingTakeoff(dm_item_t dm_current, size_t nMissionItems, float home_alt, bool home_alt_valid,
 				   float default_acceptance_rad);
 	bool checkFixedWingLanding(dm_item_t dm_current, size_t nMissionItems, fw_pos_ctrl_status_s *fw_pos_ctrl_status,
 				   bool land_start_req);
 
 	/* Checks specific to rotarywing airframes */
 	bool checkRotarywing(dm_item_t dm_current, size_t nMissionItems,
-			     float home_alt, bool home_valid, float default_altitude_acceptance_rad);
+			     float home_alt, bool home_alt_valid, float default_altitude_acceptance_rad);
 
 public:
 	MissionFeasibilityChecker(Navigator *navigator) : _navigator(navigator) {}

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -150,7 +150,8 @@ public:
 
 	const vehicle_roi_s &get_vroi() { return _vroi; }
 
-	bool home_position_valid() { return (_home_pos.timestamp > 0 && _home_pos.valid_hpos && _home_pos.valid_alt); }
+	bool home_alt_valid() { return (_home_pos.timestamp > 0 && _home_pos.valid_alt); }
+	bool home_position_valid() { return (_home_pos.timestamp > 0 && _home_pos.valid_alt && _home_pos.valid_hpos); }
 
 	int		get_onboard_mission_sub() { return _onboard_mission_sub; }
 	int		get_offboard_mission_sub() { return _offboard_mission_sub; }


### PR DESCRIPTION
Most mission feasibility checks only require a home altitude for checking relative waypoints. The only current exception is geofence checks (around home).

This reduces unnecessary mission rejection errors when syncing. Full global position validity is still needed to actually execute the mission.