### PR TITLE
Use gyro/accel/mag raw values for SCALED_IMU mavlink msg

### DIFF
--- a/msg/sensor_accel.msg
+++ b/msg/sensor_accel.msg
@@ -10,9 +10,9 @@ float32 temperature	# temperature in degrees celsius
 float32 range_m_s2	# range in m/s^2 (+- this value)
 float32 scaling
 
-int16 x_raw
-int16 y_raw
-int16 z_raw
+int16 x_raw # acceleration in the NED X board axis in m/s^2 * 1000
+int16 y_raw # acceleration in the NED Y board axis in m/s^2 * 1000
+int16 z_raw # acceleration in the NED Z board axis in m/s^2 * 1000
 int16 temperature_raw
 
 uint32 device_id	# unique device ID for the sensor that does not change between power cycles

--- a/msg/sensor_gyro.msg
+++ b/msg/sensor_gyro.msg
@@ -10,9 +10,9 @@ float32 temperature	# temperature in degrees celcius
 float32 range_rad_s
 float32 scaling
 
-int16 x_raw
-int16 y_raw
-int16 z_raw
+int16 x_raw # angular velocity in the NED X board axis in rad/s * 1000
+int16 y_raw # angular velocity in the NED Y board axis in rad/s * 1000
+int16 z_raw # angular velocity in the NED Z board axis in rad/s * 1000
 int16 temperature_raw
 
 uint32 device_id	# unique device ID for the sensor that does not change between power cycles

--- a/msg/sensor_mag.msg
+++ b/msg/sensor_mag.msg
@@ -1,15 +1,14 @@
 uint64 error_count
-float32 x
-float32 y
-float32 z
+float32 x # [Gauss]
+float32 y # [Gauss]
+float32 z # [Gauss]
 float32 range_ga
 float32 scaling
 float32 temperature
 
-int16 x_raw
-int16 y_raw
-int16 z_raw
+int16 x_raw # [milli Gauss]
+int16 y_raw # [milli Gauss]
+int16 z_raw # [milli Gauss]
 
 uint32 device_id	# unique device ID for the sensor that does not change between power cycles
 bool  is_external  # if true the mag is external (i.e. not built into the board)
-

--- a/src/drivers/adis16448/adis16448.cpp
+++ b/src/drivers/adis16448/adis16448.cpp
@@ -1437,16 +1437,16 @@ ADIS16448::measure()
 	grb.error_count = arb.error_count = mrb.error_count = perf_event_count(_bad_transfers);
 
 	/* Gyro report: */
-	grb.x_raw = report.gyro_x;
-	grb.y_raw = report.gyro_y;
-	grb.z_raw = report.gyro_z;
-
 	float xraw_f = report.gyro_x;
 	float yraw_f = report.gyro_y;
 	float zraw_f = report.gyro_z;
 
 	// apply user specified rotation
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	grb.x_raw = (int16_t)(xraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
+	grb.y_raw = (int16_t)(yraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
+	grb.z_raw = (int16_t)(zraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
 
 	float x_gyro_in_new = ((xraw_f * _gyro_range_scale) * M_PI_F / 180.0f - _gyro_scale.x_offset) * _gyro_scale.x_scale;
 	float y_gyro_in_new = ((yraw_f * _gyro_range_scale) * M_PI_F / 180.0f - _gyro_scale.y_offset) * _gyro_scale.y_scale;
@@ -1467,16 +1467,16 @@ ADIS16448::measure()
 	grb.range_rad_s = _gyro_range_rad_s;
 
 	/* Accel report: */
-	arb.x_raw = report.accel_x;
-	arb.y_raw = report.accel_y;
-	arb.z_raw = report.accel_z;
-
 	xraw_f = report.accel_x;
 	yraw_f = report.accel_y;
 	zraw_f = report.accel_z;
 
 	// apply user specified rotation
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	arb.x_raw = (int16_t)(xraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
+	arb.y_raw = (int16_t)(yraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
+	arb.z_raw = (int16_t)(zraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
 
 	float x_in_new = ((xraw_f * _accel_range_scale) - _accel_scale.x_offset) * _accel_scale.x_scale;
 	float y_in_new = ((yraw_f * _accel_range_scale) - _accel_scale.y_offset) * _accel_scale.y_scale;
@@ -1497,16 +1497,16 @@ ADIS16448::measure()
 	arb.range_m_s2 = _accel_range_m_s2;
 
 	/* Mag report: */
-	mrb.x_raw = report.mag_x;
-	mrb.y_raw = report.mag_y;
-	mrb.z_raw = report.mag_z;
-
 	xraw_f = report.mag_x;
 	yraw_f = report.mag_y;
 	zraw_f = report.mag_z;
 
 	// apply user specified rotation
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	mrb.x_raw = (int16_t)(xraw_f * _mag_range_scale * 1000); // (int16) [Gs * 1000]
+	mrb.y_raw = (int16_t)(yraw_f * _mag_range_scale * 1000); // (int16) [Gs * 1000]
+	mrb.z_raw = (int16_t)(zraw_f * _mag_range_scale * 1000); // (int16) [Gs * 1000]
 
 	float x_mag_new = ((xraw_f * _mag_range_scale) - _mag_scale.x_offset) * _mag_scale.x_scale;
 	float y_mag_new = ((yraw_f * _mag_range_scale) - _mag_scale.y_offset) * _mag_scale.y_scale;

--- a/src/drivers/bma180/bma180.cpp
+++ b/src/drivers/bma180/bma180.cpp
@@ -725,6 +725,11 @@ BMA180::measure()
 	report.x = ((report.x_raw * _accel_range_scale) - _accel_scale.x_offset) * _accel_scale.x_scale;
 	report.y = ((report.y_raw * _accel_range_scale) - _accel_scale.y_offset) * _accel_scale.y_scale;
 	report.z = ((report.z_raw * _accel_range_scale) - _accel_scale.z_offset) * _accel_scale.z_scale;
+
+	report.x_raw = (int16_t)(report.x_raw * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
+	report.y_raw = (int16_t)(report.y_raw * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
+	report.z_raw = (int16_t)(report.z_raw * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
+
 	report.scaling = _accel_range_scale;
 	report.range_m_s2 = _accel_range_m_s2;
 

--- a/src/drivers/bmi055/bmi055_accel.cpp
+++ b/src/drivers/bmi055/bmi055_accel.cpp
@@ -739,16 +739,16 @@ BMI055_accel::measure()
 	 *
 	 */
 
-	arb.x_raw = report.accel_x;
-	arb.y_raw = report.accel_y;
-	arb.z_raw = report.accel_z;
-
 	float xraw_f = report.accel_x;
 	float yraw_f = report.accel_y;
 	float zraw_f = report.accel_z;
 
 	// apply user specified rotation
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	arb.x_raw = (int16_t)(xraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
+	arb.y_raw = (int16_t)(yraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
+	arb.z_raw = (int16_t)(zraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
 
 	float x_in_new = ((xraw_f * _accel_range_scale) - _accel_scale.x_offset) * _accel_scale.x_scale;
 	float y_in_new = ((yraw_f * _accel_range_scale) - _accel_scale.y_offset) * _accel_scale.y_scale;
@@ -863,5 +863,3 @@ BMI055_accel::print_registers()
 
 	printf("\n");
 }
-
-

--- a/src/drivers/bmi055/bmi055_gyro.cpp
+++ b/src/drivers/bmi055/bmi055_gyro.cpp
@@ -711,16 +711,16 @@ BMI055_gyro::measure()
 	 *        74 from all measurements centers them around zero.
 	 */
 
-	grb.x_raw = report.gyro_x;
-	grb.y_raw = report.gyro_y;
-	grb.z_raw = report.gyro_z;
-
 	float xraw_f = report.gyro_x;
 	float yraw_f = report.gyro_y;
 	float zraw_f = report.gyro_z;
 
 	// apply user specified rotation
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	grb.x_raw = (int16_t)(xraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
+	grb.y_raw = (int16_t)(yraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
+	grb.z_raw = (int16_t)(zraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
 
 	float x_gyro_in_new = ((xraw_f * _gyro_range_scale) - _gyro_scale.x_offset) * _gyro_scale.x_scale;
 	float y_gyro_in_new = ((yraw_f * _gyro_range_scale) - _gyro_scale.y_offset) * _gyro_scale.y_scale;
@@ -842,7 +842,3 @@ BMI055_gyro::print_registers()
 
 	printf("\n");
 }
-
-
-
-

--- a/src/drivers/bmi160/bmi160.cpp
+++ b/src/drivers/bmi160/bmi160.cpp
@@ -1161,16 +1161,16 @@ BMI160::measure()
 
 	/* NOTE: Axes have been swapped to match the board a few lines above. */
 
-	arb.x_raw = report.accel_x;
-	arb.y_raw = report.accel_y;
-	arb.z_raw = report.accel_z;
-
 	float xraw_f = report.accel_x;
 	float yraw_f = report.accel_y;
 	float zraw_f = report.accel_z;
 
 	// apply user specified rotation
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	arb.x_raw = (int16_t)(xraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
+	arb.y_raw = (int16_t)(yraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
+	arb.z_raw = (int16_t)(zraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
 
 	float x_in_new = ((xraw_f * _accel_range_scale) - _accel_scale.x_offset) * _accel_scale.x_scale;
 	float y_in_new = ((yraw_f * _accel_range_scale) - _accel_scale.y_offset) * _accel_scale.y_scale;
@@ -1199,16 +1199,16 @@ BMI160::measure()
 	/* return device ID */
 	arb.device_id = _device_id.devid;
 
-	grb.x_raw = report.gyro_x;
-	grb.y_raw = report.gyro_y;
-	grb.z_raw = report.gyro_z;
-
 	xraw_f = report.gyro_x;
 	yraw_f = report.gyro_y;
 	zraw_f = report.gyro_z;
 
 	// apply user specified rotation
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	grb.x_raw = (int16_t)(xraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
+	grb.y_raw = (int16_t)(yraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
+	grb.z_raw = (int16_t)(zraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
 
 	float x_gyro_in_new = ((xraw_f * _gyro_range_scale) - _gyro_scale.x_offset) * _gyro_scale.x_scale;
 	float y_gyro_in_new = ((yraw_f * _gyro_range_scale) - _gyro_scale.y_offset) * _gyro_scale.y_scale;

--- a/src/drivers/bmm150/bmm150.cpp
+++ b/src/drivers/bmm150/bmm150.cpp
@@ -687,6 +687,10 @@ BMM150::collect()
 	// apply user specified rotation
 	rotate_3f(_rotation, mrb.x, mrb.y, mrb.z);
 
+	mrb.x_raw = (int16_t)(mrb.x * _range_scale * 1000); // (int16) [Gs * 1000]
+	mrb.y_raw = (int16_t)(mrb.y * _range_scale * 1000); // (int16) [Gs * 1000]
+	mrb.z_raw = (int16_t)(mrb.z * _range_scale * 1000); // (int16) [Gs * 1000]
+
 
 	/* Scaling the data */
 	mrb.x = ((mrb.x * _range_scale) - _scale.x_offset) * _scale.x_scale;

--- a/src/drivers/fxas21002c/fxas21002c.cpp
+++ b/src/drivers/fxas21002c/fxas21002c.cpp
@@ -1045,16 +1045,16 @@ FXAS21002C::measure()
 	// whether it has had failures
 	gyro_report.error_count = perf_event_count(_bad_registers);
 
-	gyro_report.x_raw = swap16(raw_gyro_report.x);
-	gyro_report.y_raw = swap16(raw_gyro_report.y);
-	gyro_report.z_raw = swap16(raw_gyro_report.z);
-
-	float xraw_f = gyro_report.x_raw;
-	float yraw_f = gyro_report.y_raw;
-	float zraw_f = gyro_report.z_raw;
+	float xraw_f = swap16(raw_gyro_report.x);
+	float yraw_f = swap16(raw_gyro_report.y);
+	float zraw_f = swap16(raw_gyro_report.z);
 
 	// apply user specified rotation
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	gyro_report.x_raw = (int16_t)(xraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
+	gyro_report.y_raw = (int16_t)(yraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
+	gyro_report.z_raw = (int16_t)(zraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
 
 	float x_in_new = ((xraw_f * _gyro_range_scale) - _gyro_scale.x_offset) * _gyro_scale.x_scale;
 	float y_in_new = ((yraw_f * _gyro_range_scale) - _gyro_scale.y_offset) * _gyro_scale.y_scale;

--- a/src/drivers/fxos8701cq/fxos8701cq.cpp
+++ b/src/drivers/fxos8701cq/fxos8701cq.cpp
@@ -1405,22 +1405,22 @@ FXOS8701CQ::measure()
 	// whether it has had failures
 	accel_report.error_count = perf_event_count(_bad_registers) + perf_event_count(_bad_values);
 
-	accel_report.x_raw = swap16RightJustify14(raw_accel_mag_report.x);
-	accel_report.y_raw = swap16RightJustify14(raw_accel_mag_report.y);
-	accel_report.z_raw = swap16RightJustify14(raw_accel_mag_report.z);
-
 	/* Save off the Mag readings todo: revist integrating theses */
 
 	_last_raw_mag_x = swap16(raw_accel_mag_report.mx);
 	_last_raw_mag_y = swap16(raw_accel_mag_report.my);
 	_last_raw_mag_z = swap16(raw_accel_mag_report.mz);
 
-	float xraw_f = accel_report.x_raw;
-	float yraw_f = accel_report.y_raw;
-	float zraw_f = accel_report.z_raw;
+	float xraw_f = swap16RightJustify14(raw_accel_mag_report.x);
+	float yraw_f = swap16RightJustify14(raw_accel_mag_report.y);
+	float zraw_f = swap16RightJustify14(raw_accel_mag_report.z);
 
 	// apply user specified rotation
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	accel_report.x_raw = (int16_t)(xraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
+	accel_report.y_raw = (int16_t)(yraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
+	accel_report.z_raw = (int16_t)(zraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
 
 	float x_in_new = ((xraw_f * _accel_range_scale) - _accel_scale.x_offset) * _accel_scale.x_scale;
 	float y_in_new = ((yraw_f * _accel_range_scale) - _accel_scale.y_offset) * _accel_scale.y_scale;
@@ -1522,16 +1522,16 @@ FXOS8701CQ::mag_measure()
 	mag_report.timestamp = hrt_absolute_time();
 	mag_report.is_external = external();
 
-	mag_report.x_raw = _last_raw_mag_x;
-	mag_report.y_raw = _last_raw_mag_y;
-	mag_report.z_raw = _last_raw_mag_z;
-
-	float xraw_f = mag_report.x_raw;
-	float yraw_f = mag_report.y_raw;
-	float zraw_f = mag_report.z_raw;
+	float xraw_f = _last_raw_mag_x;
+	float yraw_f = _last_raw_mag_y;
+	float zraw_f = _last_raw_mag_z;
 
 	/* apply user specified rotation */
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	mag_report.x_raw = (int16_t)(xraw_f * _mag_range_scale * 1000); // (int16) [Gs * 1000]
+	mag_report.y_raw = (int16_t)(yraw_f * _mag_range_scale * 1000); // (int16) [Gs * 1000]
+	mag_report.z_raw = (int16_t)(zraw_f * _mag_range_scale * 1000); // (int16) [Gs * 1000]
 
 	mag_report.x = ((xraw_f * _mag_range_scale) - _mag_scale.x_offset) * _mag_scale.x_scale;
 	mag_report.y = ((yraw_f * _mag_range_scale) - _mag_scale.y_offset) * _mag_scale.y_scale;

--- a/src/drivers/hmc5883/hmc5883.cpp
+++ b/src/drivers/hmc5883/hmc5883.cpp
@@ -971,17 +971,6 @@ HMC5883::collect()
 		}
 	}
 
-	/*
-	 * RAW outputs
-	 *
-	 * to align the sensor axes with the board, x and y need to be flipped
-	 * and y needs to be negated
-	 */
-	new_report.x_raw = -report.y;
-	new_report.y_raw = report.x;
-	/* z remains z */
-	new_report.z_raw = report.z;
-
 	/* scale values for output */
 
 	// XXX revisit for SPI part, might require a bus type IOCTL
@@ -1005,6 +994,10 @@ HMC5883::collect()
 
 	// apply user specified rotation
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	new_report.x_raw = (int16_t)(xraw_f * _range_scale * 1000); // (int16) [Gs * 1000]
+	new_report.y_raw = (int16_t)(yraw_f * _range_scale * 1000); // (int16) [Gs * 1000]
+	new_report.z_raw = (int16_t)(zraw_f * _range_scale * 1000); // (int16) [Gs * 1000]
 
 	new_report.x = ((xraw_f * _range_scale) - _scale.x_offset) * _scale.x_scale;
 	/* flip axes and negate value for y */

--- a/src/drivers/ist8310/ist8310.cpp
+++ b/src/drivers/ist8310/ist8310.cpp
@@ -950,16 +950,6 @@ IST8310::collect()
 	/* temperature measurement is not available on IST8310 */
 	new_report.temperature = 0;
 
-	/*
-	 * raw outputs
-	 *
-	 * Sensor doesn't follow right hand rule, swap x and y to make it obey
-	 * it.
-	 */
-	new_report.x_raw = report.y;
-	new_report.y_raw = report.x;
-	new_report.z_raw = report.z;
-
 	/* scale values for output */
 	xraw_f = report.y;
 	yraw_f = report.x;
@@ -967,6 +957,11 @@ IST8310::collect()
 
 	/* apply user specified rotation */
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	new_report.x_raw = (int16_t)(xraw_f * _range_scale * 1000); // (int16) [Gs * 1000]
+	new_report.y_raw = (int16_t)(yraw_f * _range_scale * 1000); // (int16) [Gs * 1000]
+	new_report.z_raw = (int16_t)(zraw_f * _range_scale * 1000); // (int16) [Gs * 1000]
+
 	new_report.x = ((xraw_f * _range_scale) - _scale.x_offset) * _scale.x_scale;
 	new_report.y = ((yraw_f * _range_scale) - _scale.y_offset) * _scale.y_scale;
 	new_report.z = ((zraw_f * _range_scale) - _scale.z_offset) * _scale.z_scale;

--- a/src/drivers/l3gd20/l3gd20.cpp
+++ b/src/drivers/l3gd20/l3gd20.cpp
@@ -1024,6 +1024,10 @@ L3GD20::measure()
 	// apply user specified rotation
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
 
+	report.x_raw = (int16_t)(xraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
+	report.y_raw = (int16_t)(yraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
+	report.z_raw = (int16_t)(zraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
+
 	float xin = ((xraw_f * _gyro_range_scale) - _gyro_scale.x_offset) * _gyro_scale.x_scale;
 	float yin = ((yraw_f * _gyro_range_scale) - _gyro_scale.y_offset) * _gyro_scale.y_scale;
 	float zin = ((zraw_f * _gyro_range_scale) - _gyro_scale.z_offset) * _gyro_scale.z_scale;

--- a/src/drivers/lis3mdl/lis3mdl.cpp
+++ b/src/drivers/lis3mdl/lis3mdl.cpp
@@ -938,14 +938,6 @@ LIS3MDL::collect()
 	sensor_is_onboard = !_interface->ioctl(MAGIOCGEXTERNAL, dummy);
 	new_report.is_external = !sensor_is_onboard;
 
-	/*
-	 * RAW outputs
-	 *
-	 */
-	new_report.x_raw = report.x;
-	new_report.y_raw = report.y;
-	new_report.z_raw = report.z;
-
 	/* the LIS3MDL mag on Pixhawk Pro by Drotek has x pointing towards,
 	 * y pointing to the right, and z down, therefore no switch needed,
 	 * it is better to have no artificial rotation inside the
@@ -957,6 +949,10 @@ LIS3MDL::collect()
 
 	// apply user specified rotation
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	new_report.x_raw = (int16_t)(xraw_f * _range_scale * 1000); // (int16) [Gs * 1000]
+	new_report.y_raw = (int16_t)(yraw_f * _range_scale * 1000); // (int16) [Gs * 1000]
+	new_report.z_raw = (int16_t)(zraw_f * _range_scale * 1000); // (int16) [Gs * 1000]
 
 	new_report.x = ((xraw_f * _range_scale) - _scale.x_offset) * _scale.x_scale;
 	/* flip axes and negate value for y */

--- a/src/drivers/lsm303d/lsm303d.cpp
+++ b/src/drivers/lsm303d/lsm303d.cpp
@@ -1518,16 +1518,16 @@ LSM303D::measure()
 	// whether it has had failures
 	accel_report.error_count = perf_event_count(_bad_registers) + perf_event_count(_bad_values);
 
-	accel_report.x_raw = raw_accel_report.x;
-	accel_report.y_raw = raw_accel_report.y;
-	accel_report.z_raw = raw_accel_report.z;
-
 	float xraw_f = raw_accel_report.x;
 	float yraw_f = raw_accel_report.y;
 	float zraw_f = raw_accel_report.z;
 
 	// apply user specified rotation
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	accel_report.x_raw = (int16_t)(xraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
+	accel_report.y_raw = (int16_t)(yraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
+	accel_report.z_raw = (int16_t)(zraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
 
 	float x_in_new = ((xraw_f * _accel_range_scale) - _accel_scale.x_offset) * _accel_scale.x_scale;
 	float y_in_new = ((yraw_f * _accel_range_scale) - _accel_scale.y_offset) * _accel_scale.y_scale;
@@ -1644,16 +1644,16 @@ LSM303D::mag_measure()
 	mag_report.timestamp = hrt_absolute_time();
 	mag_report.is_external = external();
 
-	mag_report.x_raw = raw_mag_report.x;
-	mag_report.y_raw = raw_mag_report.y;
-	mag_report.z_raw = raw_mag_report.z;
-
-	float xraw_f = mag_report.x_raw;
-	float yraw_f = mag_report.y_raw;
-	float zraw_f = mag_report.z_raw;
+	float xraw_f = raw_mag_report.x;
+	float yraw_f = raw_mag_report.y;
+	float zraw_f = raw_mag_report.z;
 
 	/* apply user specified rotation */
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	mag_report.x_raw = (int16_t)(xraw_f * _mag_range_scale * 1000); // (int16) [Gs * 1000]
+	mag_report.y_raw = (int16_t)(yraw_f * _mag_range_scale * 1000); // (int16) [Gs * 1000]
+	mag_report.z_raw = (int16_t)(zraw_f * _mag_range_scale * 1000); // (int16) [Gs * 1000]
 
 	mag_report.x = ((xraw_f * _mag_range_scale) - _mag_scale.x_offset) * _mag_scale.x_scale;
 	mag_report.y = ((yraw_f * _mag_range_scale) - _mag_scale.y_offset) * _mag_scale.y_scale;

--- a/src/drivers/mpu6000/mpu6000.cpp
+++ b/src/drivers/mpu6000/mpu6000.cpp
@@ -1990,16 +1990,16 @@ MPU6000::measure()
 
 	/* NOTE: Axes have been swapped to match the board a few lines above. */
 
-	arb.x_raw = report.accel_x;
-	arb.y_raw = report.accel_y;
-	arb.z_raw = report.accel_z;
-
 	float xraw_f = report.accel_x;
 	float yraw_f = report.accel_y;
 	float zraw_f = report.accel_z;
 
 	// apply user specified rotation
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	arb.x_raw = (int16_t)(xraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
+	arb.y_raw = (int16_t)(yraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
+	arb.z_raw = (int16_t)(zraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
 
 	float x_in_new = ((xraw_f * _accel_range_scale) - _accel_scale.x_offset) * _accel_scale.x_scale;
 	float y_in_new = ((yraw_f * _accel_range_scale) - _accel_scale.y_offset) * _accel_scale.y_scale;
@@ -2033,16 +2033,16 @@ MPU6000::measure()
 	/* return device ID */
 	arb.device_id = _device_id.devid;
 
-	grb.x_raw = report.gyro_x;
-	grb.y_raw = report.gyro_y;
-	grb.z_raw = report.gyro_z;
-
 	xraw_f = report.gyro_x;
 	yraw_f = report.gyro_y;
 	zraw_f = report.gyro_z;
 
 	// apply user specified rotation
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	grb.x_raw = (int16_t)(xraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
+	grb.y_raw = (int16_t)(yraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
+	grb.z_raw = (int16_t)(zraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
 
 	float x_gyro_in_new = ((xraw_f * _gyro_range_scale) - _gyro_scale.x_offset) * _gyro_scale.x_scale;
 	float y_gyro_in_new = ((yraw_f * _gyro_range_scale) - _gyro_scale.y_offset) * _gyro_scale.y_scale;

--- a/src/drivers/mpu9250/mag.cpp
+++ b/src/drivers/mpu9250/mag.cpp
@@ -211,9 +211,6 @@ MPU9250_mag::_measure(struct ak8963_regs data)
 	 * Align axes - note the accel & gryo are also re-aligned so this
 	 *              doesn't look obvious with the datasheet
 	 */
-	mrb.x_raw =  data.x;
-	mrb.y_raw = -data.y;
-	mrb.z_raw = -data.z;
 
 	float xraw_f =  data.x;
 	float yraw_f = -data.y;
@@ -221,6 +218,10 @@ MPU9250_mag::_measure(struct ak8963_regs data)
 
 	/* apply user specified rotation */
 	rotate_3f(_parent->_rotation, xraw_f, yraw_f, zraw_f);
+
+	mrb.x_raw = (int16_t)(xraw_f * _mag_range_scale * _mag_asa_x * 1000); // (int16) [Gs * 1000]
+	mrb.y_raw = (int16_t)(yraw_f * _mag_range_scale * _mag_asa_x * 1000); // (int16) [Gs * 1000]
+	mrb.z_raw = (int16_t)(zraw_f * _mag_range_scale * _mag_asa_x * 1000); // (int16) [Gs * 1000]
 
 	mrb.x = ((xraw_f * _mag_range_scale * _mag_asa_x) - _mag_scale.x_offset) * _mag_scale.x_scale;
 	mrb.y = ((yraw_f * _mag_range_scale * _mag_asa_y) - _mag_scale.y_offset) * _mag_scale.y_scale;

--- a/src/drivers/mpu9250/mpu9250.cpp
+++ b/src/drivers/mpu9250/mpu9250.cpp
@@ -1404,16 +1404,16 @@ MPU9250::measure()
 
 	/* NOTE: Axes have been swapped to match the board a few lines above. */
 
-	arb.x_raw = report.accel_x;
-	arb.y_raw = report.accel_y;
-	arb.z_raw = report.accel_z;
-
 	float xraw_f = report.accel_x;
 	float yraw_f = report.accel_y;
 	float zraw_f = report.accel_z;
 
 	// apply user specified rotation
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	arb.x_raw = (int16_t)(xraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
+	arb.y_raw = (int16_t)(yraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
+	arb.z_raw = (int16_t)(zraw_f * _accel_range_scale * 1000); // (int16) [m / s^2 * 1000]
 
 	float x_in_new = ((xraw_f * _accel_range_scale) - _accel_scale.x_offset) * _accel_scale.x_scale;
 	float y_in_new = ((yraw_f * _accel_range_scale) - _accel_scale.y_offset) * _accel_scale.y_scale;
@@ -1442,16 +1442,16 @@ MPU9250::measure()
 	/* return device ID */
 	arb.device_id = _device_id.devid;
 
-	grb.x_raw = report.gyro_x;
-	grb.y_raw = report.gyro_y;
-	grb.z_raw = report.gyro_z;
-
 	xraw_f = report.gyro_x;
 	yraw_f = report.gyro_y;
 	zraw_f = report.gyro_z;
 
 	// apply user specified rotation
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	grb.x_raw = (int16_t)(xraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
+	grb.y_raw = (int16_t)(yraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
+	grb.z_raw = (int16_t)(zraw_f * _gyro_range_scale * 1000); // (int16) [rad / s * 1000]
 
 	float x_gyro_in_new = ((xraw_f * _gyro_range_scale) - _gyro_scale.x_offset) * _gyro_scale.x_scale;
 	float y_gyro_in_new = ((yraw_f * _gyro_range_scale) - _gyro_scale.y_offset) * _gyro_scale.y_scale;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -90,8 +90,6 @@
 #include "mavlink_main.h"
 #include "mavlink_command_sender.h"
 
-static const float mg2ms2 = CONSTANTS_ONE_G / 1000.0f;
-
 MavlinkReceiver::MavlinkReceiver(Mavlink *parent) :
 	_mavlink(parent),
 	_mission_manager(parent),
@@ -1860,9 +1858,9 @@ MavlinkReceiver::handle_message_hil_sensor(mavlink_message_t *msg)
 		struct accel_report accel = {};
 
 		accel.timestamp = timestamp;
-		accel.x_raw = imu.xacc / mg2ms2;
-		accel.y_raw = imu.yacc / mg2ms2;
-		accel.z_raw = imu.zacc / mg2ms2;
+		accel.x_raw = imu.xacc * 1000;
+		accel.y_raw = imu.yacc * 1000;
+		accel.z_raw = imu.zacc * 1000;
 		accel.x = imu.xacc;
 		accel.y = imu.yacc;
 		accel.z = imu.zacc;
@@ -2219,9 +2217,9 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 		struct accel_report accel = {};
 
 		accel.timestamp = timestamp;
-		accel.x_raw = hil_state.xacc / CONSTANTS_ONE_G * 1e3f;
-		accel.y_raw = hil_state.yacc / CONSTANTS_ONE_G * 1e3f;
-		accel.z_raw = hil_state.zacc / CONSTANTS_ONE_G * 1e3f;
+		accel.x_raw = hil_state.xacc * 1000;
+		accel.y_raw = hil_state.yacc * 1000;
+		accel.z_raw = hil_state.zacc * 1000;
 		accel.x = hil_state.xacc;
 		accel.y = hil_state.yacc;
 		accel.z = hil_state.zacc;

--- a/src/platforms/posix/drivers/accelsim/accelsim.cpp
+++ b/src/platforms/posix/drivers/accelsim/accelsim.cpp
@@ -853,9 +853,9 @@ ACCELSIM::_measure()
 	// whether it has had failures
 	accel_report.error_count = perf_event_count(_bad_registers) + perf_event_count(_bad_values);
 
-	accel_report.x_raw = (int16_t)(raw_accel_report.x / _accel_range_scale);
-	accel_report.y_raw = (int16_t)(raw_accel_report.y / _accel_range_scale);
-	accel_report.z_raw = (int16_t)(raw_accel_report.z / _accel_range_scale);
+	accel_report.x_raw = (int16_t)(raw_accel_report.x * 1000);
+	accel_report.y_raw = (int16_t)(raw_accel_report.y * 1000);
+	accel_report.z_raw = (int16_t)(raw_accel_report.z * 1000);
 
 	accel_report.x = raw_accel_report.x;
 	accel_report.y = raw_accel_report.y;
@@ -929,17 +929,17 @@ ACCELSIM::mag_measure()
 	mag_report.timestamp = hrt_absolute_time();
 	mag_report.is_external = false;
 
-	mag_report.x_raw = (int16_t)(raw_mag_report.x / _mag_range_scale);
-	mag_report.y_raw = (int16_t)(raw_mag_report.y / _mag_range_scale);
-	mag_report.z_raw = (int16_t)(raw_mag_report.z / _mag_range_scale);
-
-	float xraw_f = (int16_t)(raw_mag_report.x / _mag_range_scale);
-	float yraw_f = (int16_t)(raw_mag_report.y / _mag_range_scale);
-	float zraw_f = (int16_t)(raw_mag_report.z / _mag_range_scale);
+	float xraw_f = raw_mag_report.x / _mag_range_scale;
+	float yraw_f = raw_mag_report.y / _mag_range_scale;
+	float zraw_f = raw_mag_report.z / _mag_range_scale;
 
 
 	/* apply user specified rotation */
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	mag_report.x_raw = (int16_t)(xraw_f * 1000); // (int16) [Gs * 1000]
+	mag_report.y_raw = (int16_t)(xraw_f * 1000); // (int16) [Gs * 1000]
+	mag_report.z_raw = (int16_t)(xraw_f * 1000); // (int16) [Gs * 1000]
 
 	/* remember the temperature. The datasheet isn't clear, but it
 	 * seems to be a signed offset from 25 degrees C in units of 0.125C

--- a/src/platforms/posix/drivers/df_ak8963_wrapper/df_ak8963_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_ak8963_wrapper/df_ak8963_wrapper.cpp
@@ -280,15 +280,14 @@ int DfAK8963Wrapper::_publish(struct mag_sensor_data &data)
 	mag_report.timestamp = hrt_absolute_time();
 	mag_report.is_external = true;
 
-	// TODO: remove these (or get the values)
-	mag_report.x_raw = 0;
-	mag_report.y_raw = 0;
-	mag_report.z_raw = 0;
-
 	math::Vector<3> mag_val(data.field_x_ga, data.field_y_ga, data.field_z_ga);
 
 	// apply sensor rotation on the accel measurement
 	mag_val = _rotation_matrix * mag_val;
+
+	mag_report.x_raw = (int16_t)(mag_val(0) * 1000); // (int16) [Gs * 1000]
+	mag_report.y_raw = (int16_t)(mag_val(1) * 1000); // (int16) [Gs * 1000]
+	mag_report.z_raw = (int16_t)(mag_val(2) * 1000); // (int16) [Gs * 1000]
 
 	mag_report.x = (mag_val(0) - _mag_calibration.x_offset) * _mag_calibration.x_scale;
 	mag_report.y = (mag_val(1) - _mag_calibration.y_offset) * _mag_calibration.y_scale;

--- a/src/platforms/posix/drivers/df_hmc5883_wrapper/df_hmc5883_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_hmc5883_wrapper/df_hmc5883_wrapper.cpp
@@ -278,17 +278,16 @@ int DfHmc5883Wrapper::_publish(struct mag_sensor_data &data)
 	data.field_x_ga = -data.field_y_ga;
 	data.field_y_ga = tmp;
 
-	// TODO: remove these (or get the values)
-	mag_report.x_raw = 0;
-	mag_report.y_raw = 0;
-	mag_report.z_raw = 0;
-
 	math::Vector<3> mag_val(data.field_x_ga,
 				data.field_y_ga,
 				data.field_z_ga);
 
 	// apply sensor rotation on the accel measurement
 	mag_val = _rotation_matrix * mag_val;
+
+	mag_report.x_raw = (int16_t)(mag_val(0) * 1000); // (int16) [Gs * 1000]
+	mag_report.y_raw = (int16_t)(mag_val(1) * 1000); // (int16) [Gs * 1000]
+	mag_report.z_raw = (int16_t)(mag_val(2) * 1000); // (int16) [Gs * 1000]
 
 	// Apply calibration after rotation.
 	mag_report.x = (mag_val(0) - _mag_calibration.x_offset) * _mag_calibration.x_scale;

--- a/src/platforms/posix/drivers/df_mpu6050_wrapper/df_mpu6050_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_mpu6050_wrapper/df_mpu6050_wrapper.cpp
@@ -434,10 +434,17 @@ int DfMPU6050Wrapper::_publish(struct imu_sensor_data &data)
 	math::Vector<3> vec_integrated_unused;
 	uint64_t integral_dt_unused;
 
+	accel_report accel_report = {};
+	gyro_report gyro_report = {};
+
 	math::Vector<3> accel_val(data.accel_m_s2_x, data.accel_m_s2_y, data.accel_m_s2_z);
 
 	// apply sensor rotation on the accel measurement
 	accel_val = _rotation_matrix * accel_val;
+
+	accel_report.x_raw = (int16_t)(accel_val(0) * 1000); // (int16) [rad / s * 1000]
+	accel_report.y_raw = (int16_t)(accel_val(1) * 1000); // (int16) [rad / s * 1000]
+	accel_report.z_raw = (int16_t)(accel_val(2) * 1000); // (int16) [rad / s * 1000]
 
 	accel_val(0) = (accel_val(0) - _accel_calibration.x_offset) * _accel_calibration.x_scale;
 	accel_val(1) = (accel_val(1) - _accel_calibration.y_offset) * _accel_calibration.y_scale;
@@ -452,6 +459,10 @@ int DfMPU6050Wrapper::_publish(struct imu_sensor_data &data)
 
 	// apply sensor rotation on the gyro measurement
 	gyro_val = _rotation_matrix * gyro_val;
+
+	gyro_report.x_raw = (int16_t)(gyro_val(0) * 1000); // (int16) [rad / s * 1000]
+	gyro_report.y_raw = (int16_t)(gyro_val(1) * 1000); // (int16) [rad / s * 1000]
+	gyro_report.z_raw = (int16_t)(gyro_val(2) * 1000); // (int16) [rad / s * 1000]
 
 	gyro_val(0) = (gyro_val(0) - _gyro_calibration.x_offset) * _gyro_calibration.x_scale;
 	gyro_val(1) = (gyro_val(1) - _gyro_calibration.y_offset) * _gyro_calibration.y_scale;
@@ -488,9 +499,6 @@ int DfMPU6050Wrapper::_publish(struct imu_sensor_data &data)
 
 	perf_begin(_publish_perf);
 
-	accel_report accel_report = {};
-	gyro_report gyro_report = {};
-
 	accel_report.timestamp = gyro_report.timestamp = hrt_absolute_time();
 
 	// TODO: get these right
@@ -501,15 +509,6 @@ int DfMPU6050Wrapper::_publish(struct imu_sensor_data &data)
 	accel_report.scaling = -1.0f;
 	accel_report.range_m_s2 = -1.0f;
 	accel_report.device_id = m_id.dev_id;
-
-	// TODO: remove these (or get the values)
-	gyro_report.x_raw = 0;
-	gyro_report.y_raw = 0;
-	gyro_report.z_raw = 0;
-
-	accel_report.x_raw = 0;
-	accel_report.y_raw = 0;
-	accel_report.z_raw = 0;
 
 	math::Vector<3> gyro_val_filt;
 	math::Vector<3> accel_val_filt;

--- a/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
@@ -599,17 +599,16 @@ int DfMpu9250Wrapper::_publish(struct imu_sensor_data &data)
 
 	// ACCEL
 
-	// write raw data (without rotation)
-	accel_report.x_raw = data.accel_m_s2_x;
-	accel_report.y_raw = data.accel_m_s2_y;
-	accel_report.z_raw = data.accel_m_s2_z;
-
 	float xraw_f = data.accel_m_s2_x;
 	float yraw_f = data.accel_m_s2_y;
 	float zraw_f = data.accel_m_s2_z;
 
 	// apply user specified rotation
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	accel_report.x_raw = xraw_f * 1000; // (int16) [m / s^2 * 1000]
+	accel_report.y_raw = yraw_f * 1000; // (int16) [m / s^2 * 1000]
+	accel_report.z_raw = zraw_f * 1000; // (int16) [m / s^2 * 1000]
 
 	// adjust values according to the calibration
 	float x_in_new = (xraw_f - _accel_calibration.x_offset) * _accel_calibration.x_scale;
@@ -630,17 +629,16 @@ int DfMpu9250Wrapper::_publish(struct imu_sensor_data &data)
 
 	// GYRO
 
-	// write raw data (withoud rotation)
-	gyro_report.x_raw = data.gyro_rad_s_x;
-	gyro_report.y_raw = data.gyro_rad_s_y;
-	gyro_report.z_raw = data.gyro_rad_s_z;
-
 	xraw_f = data.gyro_rad_s_x;
 	yraw_f = data.gyro_rad_s_y;
 	zraw_f = data.gyro_rad_s_z;
 
 	// apply user specified rotation
 	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+	gyro_report.x_raw = xraw_f * 1000; // (int16) [rad / s * 1000]
+	gyro_report.y_raw = yraw_f * 1000; // (int16) [rad / s * 1000]
+	gyro_report.z_raw = zraw_f * 1000; // (int16) [rad / s * 1000]
 
 	// adjust values according to the calibration
 	float x_gyro_in_new = (xraw_f - _gyro_calibration.x_offset) * _gyro_calibration.x_scale;
@@ -706,15 +704,15 @@ int DfMpu9250Wrapper::_publish(struct imu_sensor_data &data)
 		mag_report.range_ga = -1.0f;
 		mag_report.device_id = m_id.dev_id;
 
-		mag_report.x_raw = 0;
-		mag_report.y_raw = 0;
-		mag_report.z_raw = 0;
-
 		xraw_f = data.mag_ga_x;
 		yraw_f = data.mag_ga_y;
 		zraw_f = data.mag_ga_z;
 
 		rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
+
+		mag_report.x_raw = xraw_f * 1000; // (int16) [Gs * 1000]
+		mag_report.y_raw = yraw_f * 1000; // (int16) [Gs * 1000]
+		mag_report.z_raw = zraw_f * 1000; // (int16) [Gs * 1000]
 
 		mag_report.x = (xraw_f - _mag_calibration.x_offset) * _mag_calibration.x_scale;
 		mag_report.y = (yraw_f - _mag_calibration.y_offset) * _mag_calibration.y_scale;

--- a/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
+++ b/src/platforms/posix/drivers/gyrosim/gyrosim.cpp
@@ -1034,9 +1034,9 @@ GYROSIM::_measure()
 
 	/* NOTE: Axes have been swapped to match the board a few lines above. */
 
-	arb.x_raw = (int16_t)(mpu_report.accel_x / _accel_range_scale);
-	arb.y_raw = (int16_t)(mpu_report.accel_y / _accel_range_scale);
-	arb.z_raw = (int16_t)(mpu_report.accel_z / _accel_range_scale);
+	arb.x_raw = (int16_t)(mpu_report.accel_x * 1000);
+	arb.y_raw = (int16_t)(mpu_report.accel_y * 1000);
+	arb.z_raw = (int16_t)(mpu_report.accel_z * 1000);
 
 	arb.scaling = _accel_range_scale;
 	arb.range_m_s2 = _accel_range_m_s2;
@@ -1061,9 +1061,9 @@ GYROSIM::_measure()
 	/* fake device ID */
 	arb.device_id = 6789478;
 
-	grb.x_raw = (int16_t)(mpu_report.gyro_x / _gyro_range_scale);
-	grb.y_raw = (int16_t)(mpu_report.gyro_y / _gyro_range_scale);
-	grb.z_raw = (int16_t)(mpu_report.gyro_z / _gyro_range_scale);
+	grb.x_raw = (int16_t)(mpu_report.gyro_x * 1000); // (int16) [rad / s * 1000]
+	grb.y_raw = (int16_t)(mpu_report.gyro_y * 1000); // (int16) [rad / s * 1000]
+	grb.z_raw = (int16_t)(mpu_report.gyro_z * 1000); // (int16) [rad / s * 1000]
 
 	grb.scaling = _gyro_range_scale;
 	grb.range_rad_s = _gyro_range_rad_s;

--- a/src/platforms/qurt/fc_addon/mpu_spi/mpu9x50_main.cpp
+++ b/src/platforms/qurt/fc_addon/mpu_spi/mpu9x50_main.cpp
@@ -407,9 +407,9 @@ void update_reports()
 	_gyro.temperature = _data.temperature;
 	_gyro.range_rad_s = _data.gyro_range_rad_s;
 	_gyro.scaling = _data.gyro_scaling;
-	_gyro.x_raw = _data.gyro_raw[0];
-	_gyro.y_raw = _data.gyro_raw[1];
-	_gyro.z_raw = _data.gyro_raw[2];
+	_gyro.x_raw = (int16_t)(_data.gyro_raw[0] * _data.gyro_scaling * 1000); // (int16) [rad / s * 1000]
+	_gyro.y_raw = (int16_t)(_data.gyro_raw[1] * _data.gyro_scaling * 1000); // (int16) [rad / s * 1000]
+	_gyro.z_raw = (int16_t)(_data.gyro_raw[2] * _data.gyro_scaling * 1000); // (int16) [rad / s * 1000]
 	_gyro.temperature_raw = _data.temperature_raw;
 
 	_accel.timestamp = _data.timestamp;
@@ -419,9 +419,9 @@ void update_reports()
 	_accel.temperature = _data.temperature;
 	_accel.range_m_s2 = _data.accel_range_m_s2;
 	_accel.scaling = _data.accel_scaling;
-	_accel.x_raw = _data.accel_raw[0];
-	_accel.y_raw = _data.accel_raw[1];
-	_accel.z_raw = _data.accel_raw[2];
+	_accel.x_raw = (int16_t)(_data.accel_raw[0] * _data.accel_scaling * 1000); // (int16) [m / s^2 * 1000]
+	_accel.y_raw = (int16_t)(_data.accel_raw[1] * _data.accel_scaling * 1000); // (int16) [m / s^2 * 1000]
+	_accel.z_raw = (int16_t)(_data.accel_raw[2] * _data.accel_scaling * 1000); // (int16) [m / s^2 * 1000]
 	_accel.temperature_raw = _data.temperature_raw;
 
 	if (_data.mag_data_ready) {
@@ -432,9 +432,9 @@ void update_reports()
 		_mag.range_ga = _data.mag_range_ga;
 		_mag.scaling = _data.mag_scaling;
 		_mag.temperature = _data.temperature;
-		_mag.x_raw = _data.mag_raw[0];
-		_mag.y_raw = _data.mag_raw[1];
-		_mag.z_raw = _data.mag_raw[2];
+		_mag.x_raw = (int16_t)(_data.mag_raw[0] * _data.mag_scaling * 1000); // (int16) [Gs * 1000]
+		_mag.y_raw = (int16_t)(_data.mag_raw[1] * _data.mag_scaling * 1000); // (int16) [Gs * 1000]
+		_mag.z_raw = (int16_t)(_data.mag_raw[2] * _data.mag_scaling * 1000); // (int16) [Gs * 1000]
 	}
 }
 


### PR DESCRIPTION
We currently need to stream the raw/unfiltered gyro/accel values on the Snapdragon via Mavlink for VIO estimation (probably also on other platforms). Since the raw values don't seem to be used (was even inconsistent) I changed to to be the unfiltered values. There can then be streamed via the `SCALED_IMU` Mavlink msg.

Hopefully, I got all drivers...