### PR TITLE
add support for vtol attitude offboard setpoints

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1245,7 +1245,7 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 		/* If we are in VTOL mode, publish uORB ID to virtual_setpoint */
 		bool updated;
 		orb_check(_vehicle_status_sub, &updated);
-        
+
 		if (updated) {
 			orb_copy(ORB_ID(vehicle_status), _vehicle_status_sub, &_vehicle_status);
 
@@ -1253,6 +1253,7 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 			if (!_attitude_setpoint_id) {
 				if (_vehicle_status.is_vtol) {
 					_attitude_setpoint_id = ORB_ID(mc_virtual_attitude_setpoint);
+
 				} else {
 					_attitude_setpoint_id = ORB_ID(vehicle_attitude_setpoint);
 				}
@@ -1262,7 +1263,7 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 		/* If we are in offboard control mode and offboard control loop through is enabled
 		 * also publish the setpoint topic which is read by the controller */
 		if (_mavlink->get_forward_externalsp()) {
-			
+
 			orb_check(_control_mode_sub, &updated);
 
 			if (updated) {

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -244,10 +244,12 @@ private:
 	orb_advert_t _debug_key_value_pub;
 	orb_advert_t _debug_value_pub;
 	orb_advert_t _debug_vect_pub;
+	orb_id_t _attitude_setpoint_id;
 	static const int _gps_inject_data_queue_size = 6;
 	orb_advert_t _gps_inject_data_pub;
 	orb_advert_t _command_ack_pub;
 	int _control_mode_sub;
+	int	_vehicle_status_sub;		/**< vehicle status subscription */
 	int _actuator_armed_sub;
 	uint64_t _global_ref_timestamp;
 	int _hil_frames;
@@ -258,6 +260,7 @@ private:
 	struct offboard_control_mode_s _offboard_control_mode;
 	struct vehicle_attitude_setpoint_s _att_sp;
 	struct vehicle_rates_setpoint_s _rates_sp;
+	struct vehicle_status_s _vehicle_status; 	/**< vehicle status */
 	double _time_offset_avg_alpha;
 	int64_t _time_offset;
 	int	_orb_class_instance;


### PR DESCRIPTION
The previous firmware dose not support off-board attitude control for VTOL vehicles.
We add support to this function in hover state by changing the mavlink message head.
We tested it with Gazebo simulation and indoor flight experiment, px4fmu-v2_lpe ([log](https://logs.px4.io/plot_app?log=73bb8d87-5595-406a-9732-42b3596491af)).