### PR TITLE
Fix message generation dependencies

### DIFF
--- a/src/modules/micrortps_bridge/CMakeLists.txt
+++ b/src/modules/micrortps_bridge/CMakeLists.txt
@@ -122,7 +122,7 @@ if (GENERATE_RTPS_BRIDGE)
 		VERBATIM
 		)
 	px4_add_library(uorb_msgs_microcdr ${uorb_sources_microcdr})
-	add_dependencies(uorb_msgs_microcdr uorb_headers_microcdr uorb_headers git_micro_cdr lib__micro-CDR)
+	add_dependencies(uorb_msgs_microcdr uorb_headers_microcdr uorb_headers uorb_msgs git_micro_cdr lib__micro-CDR)
 
 	target_link_libraries(uorb_msgs_microcdr PRIVATE lib__micro-CDR)
 

--- a/src/platforms/common/CMakeLists.txt
+++ b/src/platforms/common/CMakeLists.txt
@@ -40,5 +40,6 @@ px4_add_module(
 	DEPENDS
 		prebuild_targets
 		uorb_headers
+		uorb_msgs
 	)
 # vim: set noet ft=cmake fenc=utf-8 ff=unix : 

--- a/src/systemcmds/topic_listener/CMakeLists.txt
+++ b/src/systemcmds/topic_listener/CMakeLists.txt
@@ -33,11 +33,14 @@
 
 add_custom_command(OUTPUT topic_listener.cpp
                 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/generate_listener.py ${PX4_SOURCE_DIR} > topic_listener.cpp
-                DEPENDS generate_listener.py uorb_headers
+                DEPENDS generate_listener.py uorb_msgs
                 )
 
 add_custom_target(generate_topic_listener
-	DEPENDS topic_listener.cpp generate_listener.py
+	DEPENDS
+		topic_listener.cpp
+		generate_listener.py
+		uorb_msgs
 	)
 
 px4_add_module(


### PR DESCRIPTION
This fixes a few broken dependencies I came across. The headers sometimes didn't trigger a rebuild even if the message spec changed. This change tries to catch that by linking the message files directly.