### PR TITLE
Max flash size sync between uploader and board

### DIFF
--- a/Images/aerocore2.prototype
+++ b/Images/aerocore2.prototype
@@ -7,6 +7,7 @@
     "summary": "AEROCORE2",
     "version": "0.1",
     "image_size": 0,
+    "image_maxsize": 1032192,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/aerofc-v1.prototype
+++ b/Images/aerofc-v1.prototype
@@ -7,6 +7,7 @@
     "summary": "AEROFCv1",
     "version": "0.1",
     "image_size": 0,
+    "image_maxsize": 999424,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/auav-x21.prototype
+++ b/Images/auav-x21.prototype
@@ -7,6 +7,7 @@
     "summary": "AUAV X2.1",
     "version": "0.1",
     "image_size": 0,
+    "image_maxsize": 2080768,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/crazyflie.prototype
+++ b/Images/crazyflie.prototype
@@ -7,6 +7,7 @@
     "summary": "CRAZYFLIE",
     "version": "0.1",
     "image_size": 0,
+    "image_maxsize": 1032192,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/esc35-v1.prototype
+++ b/Images/esc35-v1.prototype
@@ -7,6 +7,7 @@
     "summary": "ESC35v1",
     "version": "0.1",
     "image_size": 0,
+    "image_maxsize": 229376,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/mindpx-v2.prototype
+++ b/Images/mindpx-v2.prototype
@@ -7,6 +7,7 @@
     "summary": "MindPXFMUv2",
     "version": "2.1",
     "image_size": 0,
+    "image_maxsize": 2080768,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/nxphlite-v3.prototype
+++ b/Images/nxphlite-v3.prototype
@@ -7,6 +7,7 @@
     "summary": "NXPHLITEv3",
     "version": "0.1",
     "image_size": 0,
+    "image_maxsize": 2096112,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/px4-same70xplained-v1.prototype
+++ b/Images/px4-same70xplained-v1.prototype
@@ -7,6 +7,7 @@
     "summary": "PX4/SAME70xplained",
     "version": "0.1",
     "image_size": 0,
+    "image_maxsize": 2097152,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/px4-stm32f4discovery.prototype
+++ b/Images/px4-stm32f4discovery.prototype
@@ -7,6 +7,7 @@
     "summary": "PX4/STM32F4Discovery",
     "version": "0.1",
     "image_size": 0,
+    "image_maxsize": 1032192,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/px4cannode-v1.prototype
+++ b/Images/px4cannode-v1.prototype
@@ -7,6 +7,7 @@
     "summary": "PX4CANNODEv1",
     "version": "0.1",
     "image_size": 0,
+    "image_maxsize": 122880,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/px4esc-v1.prototype
+++ b/Images/px4esc-v1.prototype
@@ -7,6 +7,7 @@
     "summary": "PX4ESCv1",
     "version": "0.1",
     "image_size": 0,
+    "image_maxsize": 475136,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/px4flow-v2.prototype
+++ b/Images/px4flow-v2.prototype
@@ -1,12 +1,13 @@
 {
     "board_id": 24,
     "magic": "FLOWv1",
-    "description": "Firmware for the PX4FLowV1 board",
+    "description": "Firmware for the PX4FlowV2 board",
     "image": "",
     "build_time": 0,
-    "summary": "PX4FLOWv1",
+    "summary": "PX4FLOWv2",
     "version": "0.1",
     "image_size": 0,
+    "image_maxsize": 2080768,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/px4fmu-v2.prototype
+++ b/Images/px4fmu-v2.prototype
@@ -7,6 +7,7 @@
     "summary": "PX4FMUv2",
     "version": "0.1",
     "image_size": 0,
+    "image_maxsize": 1032192,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/px4fmu-v3.prototype
+++ b/Images/px4fmu-v3.prototype
@@ -7,6 +7,7 @@
     "summary": "PX4FMUv3",
     "version": "0.1",
     "image_size": 0,
+    "image_maxsize": 2080768,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/px4fmu-v4.prototype
+++ b/Images/px4fmu-v4.prototype
@@ -7,6 +7,7 @@
     "summary": "PX4FMUv4",
     "version": "0.1",
     "image_size": 0,
+    "image_maxsize": 2080768,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/px4fmu-v4pro.prototype
+++ b/Images/px4fmu-v4pro.prototype
@@ -7,6 +7,7 @@
     "summary": "PX4FMUv4PRO",
     "version": "0.1",
     "image_size": 0,
+    "image_maxsize": 2080768,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/px4fmu-v5.prototype
+++ b/Images/px4fmu-v5.prototype
@@ -7,6 +7,7 @@
     "summary": "PX4FMUv5",
     "version": "0.1",
     "image_size": 0,
+    "image_maxsize": 2064384,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/px4io-v2.prototype
+++ b/Images/px4io-v2.prototype
@@ -7,6 +7,7 @@
     "summary": "PX4IOv2",
     "version": "2.0",
     "image_size": 0,
+    "image_maxsize": 61440,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/px4nucleoF767ZI-v1.prototype
+++ b/Images/px4nucleoF767ZI-v1.prototype
@@ -7,6 +7,7 @@
     "summary": "PX4NUCLEOF767ZIv1",
     "version": "0.1",
     "image_size": 0,
+    "image_maxsize": 2097152,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/s2740vc-v1.prototype
+++ b/Images/s2740vc-v1.prototype
@@ -7,6 +7,7 @@
     "summary": "S2740VCv1",
     "version": "0.1",
     "image_size": 0,
+    "image_maxsize": 65536,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/tap-v1.prototype
+++ b/Images/tap-v1.prototype
@@ -7,6 +7,7 @@
     "summary": "TAPv1",
     "version": "0.1",
     "image_size": 0,
+    "image_maxsize": 999424,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Images/zubaxgnss-v1.prototype
+++ b/Images/zubaxgnss-v1.prototype
@@ -7,6 +7,7 @@
     "summary": "ZUBAXGNSSv1",
     "version": "0.0",
     "image_size": 0,
+    "image_maxsize": 253952,
     "git_identity": "",
     "board_revision": 0
 }

--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -488,8 +488,17 @@ class uploader(object):
                 print("FORCED WRITE, FLASHING ANYWAY!")
             else:
                 raise IOError(msg)
+
+        # Prevent uploads where the image would overflow the flash
         if self.fw_maxsize < fw.property('image_size'):
             raise RuntimeError("Firmware image is too large for this board")
+
+        # Prevent uploads where the maximum image size of the board config is smaller than the flash
+        # of the board. This is a hint the user chose the wrong config and will lack features
+        # for this particular board.
+        if self.fw_maxsize > fw.property('image_maxsize'):
+            raise RuntimeError("Board can accept larger flash images (%u bytes) than board config (%u bytes). Please use the correct board configuration to avoid lacking critical functionality."
+                % (self.fw_maxsize, fw.property('image_maxsize')))
 
         # OTP added in v4:
         if self.bl_rev > 3:

--- a/cmake/configs/nuttx_px4fmu-v3_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v3_default.cmake
@@ -2,6 +2,7 @@
 # FMUv3 is FMUv2 with access to the full 2MB flash
 set(BOARD px4fmu-v2 CACHE string "" FORCE)
 set(FW_NAME nuttx_px4fmu-v3_default.elf CACHE string "" FORCE)
+set(FW_PROTOTYPE px4fmu-v3 CACHE string "" FORCE)
 set(LD_SCRIPT ld_full.script CACHE string "" FORCE)
 
 include(nuttx/px4_impl_nuttx)

--- a/src/firmware/nuttx/CMakeLists.txt
+++ b/src/firmware/nuttx/CMakeLists.txt
@@ -66,10 +66,14 @@ add_custom_command(OUTPUT ${BOARD}.bin
 	DEPENDS ${FW_NAME}
 	)
 
+if (NOT FW_PROTOTYPE)
+	set(FW_PROTOTYPE ${BOARD})
+endif()
+
 if (TARGET parameters_xml AND TARGET airframes_xml)
 	add_custom_command(OUTPUT ${fw_file}
 		COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/px_mkfw.py
-			--prototype ${PX4_SOURCE_DIR}/Images/${BOARD}.prototype
+			--prototype ${PX4_SOURCE_DIR}/Images/${FW_PROTOTYPE}.prototype
 			--git_identity ${PX4_SOURCE_DIR}
 			--parameter_xml ${PX4_BINARY_DIR}/parameters.xml
 			--airframe_xml ${PX4_BINARY_DIR}/airframes.xml


### PR DESCRIPTION
The goal is to force developers to use the correct target with the correct flash size. This prevents criticial functionality missing and is in particular important for FMUv2/FMUv3 boards. It is unmaintainable otherwise for the Pixhawk series.

Reject looks like this:
```
Loaded firmware for 9,0, size: 1028685 bytes, waiting for the bootloader...
If the board does not respond within 1-2 seconds, unplug and re-plug the USB connector.
Attempting reboot on /dev/tty.usbmodem1 with baudrate=57600...
If the board does not respond, unplug and re-plug the USB connector.
Found board 9,0 bootloader rev 4 on /dev/tty.usbmodem1

ERROR: Board can accept larger flash images (2080768 bytes) than board config (1032192 bytes). Please use the correct board configuration to avoid lacking critical functionality.
```