### PR TITLE
Jenkins update all containers to latest except NuttX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,11 +243,11 @@ set(BUILD_SHARED_LIBS OFF)
 #=============================================================================
 # ccache
 #
-option(CCACHE "Use ccache if available" OFF)
+option(CCACHE "Use ccache if available" ON)
 find_program(CCACHE_PROGRAM ccache)
-if (CCACHE AND CCACHE_PROGRAM)
-	message(STATUS "Enabled ccache: ${CCACHE_PROGRAM}")
+if (CCACHE AND CCACHE_PROGRAM AND NOT DEFINED ENV{CCACHE_DISABLE})
 	set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+else()
 endif()
 
 #=============================================================================

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,7 +114,7 @@ pipeline {
             builds["${node_name}"] = {
               node {
                 stage("Build Test ${node_name}") {
-                  docker.image('px4io/px4-dev-base:2017-10-23').inside('-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw') {
+                  docker.image('px4io/px4-dev-base:2017-12-30').inside('-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw') {
                     stage("${node_name}") {
                       checkout scm
                       sh "make clean"
@@ -136,7 +136,7 @@ pipeline {
             builds["${node_name}"] = {
               node {
                 stage("Build Test ${node_name}") {
-                  docker.image('px4io/px4-dev-raspi:2017-10-23').inside('-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw') {
+                  docker.image('px4io/px4-dev-raspi:2017-12-30').inside('-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw') {
                     stage("${node_name}") {
                       checkout scm
                       sh "make clean"
@@ -158,7 +158,7 @@ pipeline {
             builds["${node_name}"] = {
               node {
                 stage("Build Test ${node_name}") {
-                  docker.image('px4io/px4-dev-armhf:2017-10-23').inside('-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw') {
+                  docker.image('px4io/px4-dev-armhf:2017-12-30').inside('-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw') {
                     stage("${node_name}") {
                       checkout scm
                       sh "make clean"
@@ -181,7 +181,7 @@ pipeline {
               node {
                 stage("Build Test ${node_name}") {
                   docker.withRegistry('https://registry.hub.docker.com', 'docker_hub_dagar') {
-                    docker.image("lorenzmeier/px4-dev-snapdragon:2017-10-23").inside {
+                    docker.image("lorenzmeier/px4-dev-snapdragon:2017-12-29").inside('-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw') {
                       stage("${node_name}") {
                         checkout scm
                         sh "make clean"
@@ -204,7 +204,7 @@ pipeline {
             builds["${node_name} (GCC7)"] = {
               node {
                 stage("Build Test ${node_name} (GCC7)") {
-                  docker.image('px4io/px4-dev-base-archlinux:2017-12-08').inside('-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw') {
+                  docker.image('px4io/px4-dev-base-archlinux:2017-12-30').inside('-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw') {
                     stage("${node_name}") {
                       checkout scm
                       sh "make clean"
@@ -250,7 +250,7 @@ pipeline {
         stage('check style') {
           agent {
             docker {
-              image 'px4io/px4-dev-base:2017-10-23'
+              image 'px4io/px4-dev-base:2017-12-30'
               args '-e CI=true'
             }
           }
@@ -262,7 +262,7 @@ pipeline {
         stage('clang analyzer') {
           agent {
             docker {
-              image 'px4io/px4-dev-clang:2017-10-23'
+              image 'px4io/px4-dev-clang:2017-12-30'
               args '-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw'
             }
           }
@@ -280,12 +280,19 @@ pipeline {
               reportName: 'Clang Static Analyzer'
             ]
           }
+          when {
+            anyOf {
+              branch 'master'
+              branch 'beta'
+              branch 'stable'
+            }
+          }
         }
 
         stage('clang tidy') {
           agent {
             docker {
-              image 'px4io/px4-dev-clang:2017-10-23'
+              image 'px4io/px4-dev-clang:2017-12-30'
               args '-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw'
             }
           }
@@ -316,12 +323,19 @@ pipeline {
               reportName: 'Cppcheck'
             ]
           }
+          when {
+            anyOf {
+              branch 'master'
+              branch 'beta'
+              branch 'stable'
+            }
+          }
         }
 
         stage('tests') {
           agent {
             docker {
-              image 'px4io/px4-dev-base:2017-10-23'
+              image 'px4io/px4-dev-base:2017-12-30'
               args '-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw'
             }
           }
@@ -336,7 +350,7 @@ pipeline {
         //stage('tests coverage') {
         //  agent {
         //    docker {
-        //      image 'px4io/px4-dev-base:2017-10-23'
+        //      image 'px4io/px4-dev-base:2017-12-30'
         //      args '-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw'
         //    }
         //  }
@@ -364,7 +378,7 @@ pipeline {
 
         stage('airframe') {
           agent {
-            docker { image 'px4io/px4-dev-base:2017-10-23' }
+            docker { image 'px4io/px4-dev-base:2017-12-30' }
           }
           steps {
             sh 'make airframe_metadata'
@@ -374,7 +388,7 @@ pipeline {
 
         stage('parameter') {
           agent {
-            docker { image 'px4io/px4-dev-base:2017-10-23' }
+            docker { image 'px4io/px4-dev-base:2017-12-30' }
           }
           steps {
             sh 'make parameters_metadata'
@@ -384,7 +398,7 @@ pipeline {
 
         stage('module') {
           agent {
-            docker { image 'px4io/px4-dev-base:2017-10-23' }
+            docker { image 'px4io/px4-dev-base:2017-12-30' }
           }
           steps {
             sh 'make module_documentation'
@@ -396,7 +410,7 @@ pipeline {
 
     stage('S3 Upload') {
       agent {
-        docker { image 'px4io/px4-dev-base:2017-10-23' }
+        docker { image 'px4io/px4-dev-base:2017-12-30' }
       }
 
       when {

--- a/src/modules/muorb/krait/CMakeLists.txt
+++ b/src/modules/muorb/krait/CMakeLists.txt
@@ -33,17 +33,17 @@
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PX4_SOURCE_DIR}/cmake/cmake_hexagon")
 include(hexagon_sdk)
 
-include_directories(${PX4_BINARY_DIR}/src/firmware/posix)
-include_directories(${HEXAGON_SDK_INCLUDES})
-
 px4_add_module(
 	MODULE modules__muorb__krait
 	MAIN muorb
+	INCLUDES
+		${HEXAGON_SDK_INCLUDES}
+		${PX4_BINARY_DIR}/src/firmware/posix
 	SRCS
 		uORBKraitFastRpcChannel.cpp
 		px4muorb_KraitRpcWrapper.cpp
 		muorb_main.cpp
 	DEPENDS
 		platforms__common
+		generate_px4muorb_stubs
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix :


### PR DESCRIPTION
 - enables ccache for raspi, ocpoc, eagle
 - only run static analyzers in master/beta/stable (clang static analyzer and cppcheck)
 - cmake use ccache directly if found on system and not disabled

I'll update the NuttX containers in a separate PR because they jump to GCC 7.