### PR TITLE
NuttX upgrade default compiler to GCC 7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
             builds["${node_name}"] = {
               node {
                 stage("Build Test ${node_name}") {
-                  docker.image('px4io/px4-dev-nuttx:2017-10-23').inside('-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw') {
+                  docker.image('px4io/px4-dev-nuttx:2017-12-30').inside('-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw') {
                     stage("${node_name}") {
                       checkout scm
                       sh "make distclean"
@@ -38,7 +38,7 @@ pipeline {
           builds["px4fmu-v2"] = {
             node {
               stage("Build Test ${node_name}") {
-                docker.image('px4io/px4-dev-nuttx:2017-10-23').inside('-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw') {
+                docker.image('px4io/px4-dev-nuttx:2017-12-30').inside('-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw') {
                   stage("${node_name}") {
                     checkout scm
                     sh "make distclean"
@@ -66,7 +66,7 @@ pipeline {
             builds["${node_name}"] = {
               node {
                 stage("Build Test ${node_name}") {
-                  docker.image('px4io/px4-dev-nuttx:2017-10-23').inside('-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw') {
+                  docker.image('px4io/px4-dev-nuttx:2017-12-30').inside('-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw') {
                     stage("${node_name}") {
                       checkout scm
                       sh "make distclean"
@@ -91,7 +91,7 @@ pipeline {
             builds["${node_name}"] = {
               node {
                 stage("Build Test ${node_name}") {
-                  docker.image('px4io/px4-dev-nuttx:2017-10-23').inside('-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw') {
+                  docker.image('px4io/px4-dev-nuttx:2017-12-30').inside('-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw') {
                     stage("${node_name}") {
                       checkout scm
                       sh "make distclean"
@@ -210,27 +210,6 @@ pipeline {
                       sh "make distclean"
                       sh "ccache -z"
                       sh "make posix_${node_name}"
-                      sh "ccache -s"
-                    }
-                  }
-                }
-              }
-            }
-          }
-
-          // GCC7 nuttx
-          for (def option in ["px4fmu-v5_default"]) {
-            def node_name = "${option}"
-
-            builds["${node_name} (GCC7)"] = {
-              node {
-                stage("Build Test ${node_name} (GCC7)") {
-                  docker.image('px4io/px4-dev-base-archlinux:2017-12-08').inside('-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw') {
-                    stage("${node_name}") {
-                      checkout scm
-                      sh "make distclean"
-                      sh "ccache -z"
-                      sh "make nuttx_${node_name}"
                       sh "ccache -s"
                     }
                   }
@@ -597,29 +576,6 @@ pipeline {
             }
           }
         }
-
-        // temporarily disabled until stable
-        //stage('tests coverage') {
-        //  agent {
-        //    docker {
-        //      image 'px4io/px4-dev-base:2017-12-30'
-        //      args '-e CI=true -e CCACHE_BASEDIR=$WORKSPACE -e CCACHE_DIR=/tmp/ccache -v /tmp/ccache:/tmp/ccache:rw'
-        //    }
-        //  }
-        //  steps {
-        //    sh 'make distclean'
-        //    sh 'make tests_coverage'
-        //    // publish html
-        //    publishHTML target: [
-        //      allowMissing: false,
-        //      alwaysLinkToLastBuild: false,
-        //      keepAll: true,
-        //      reportDir: 'build/posix_sitl_default/coverage-html',
-        //      reportFiles: '*',
-        //      reportName: 'Coverage Report'
-        //    ]
-        //  }
-        //}
 
       }
     }

--- a/Tools/docker_run.sh
+++ b/Tools/docker_run.sh
@@ -4,7 +4,7 @@ if [ -z ${PX4_DOCKER_REPO+x} ]; then
 	echo "guessing PX4_DOCKER_REPO based on input";
 	if [[ $@ =~ .*px4fmu.* ]]; then
 		# nuttx-px4fmu-v{1,2,3,4,5}
-		PX4_DOCKER_REPO="px4io/px4-dev-nuttx:2017-10-23"
+		PX4_DOCKER_REPO="px4io/px4-dev-nuttx:2017-12-30"
 	elif [[ $@ =~ .*rpi.* ]] || [[ $@ =~ .*bebop.* ]]; then
 		# posix_rpi_cross, posix_bebop_default
 		PX4_DOCKER_REPO="px4io/px4-dev-raspi:2017-12-30"
@@ -30,7 +30,7 @@ fi
 
 # otherwise default to nuttx
 if [ -z ${PX4_DOCKER_REPO+x} ]; then
-	PX4_DOCKER_REPO="px4io/px4-dev-nuttx:2017-10-23"
+	PX4_DOCKER_REPO="px4io/px4-dev-nuttx:2017-12-30"
 fi
 
 # docker hygiene

--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -332,6 +332,8 @@ function(px4_add_common_flags)
 		-Wunknown-pragmas
 		-Wunused-variable
 
+		-Wno-implicit-fallthrough # set appropriate level and update
+
 		-Wno-unused-parameter
 		)
 

--- a/msg/templates/urtps/microRTPS_transport.h
+++ b/msg/templates/urtps/microRTPS_transport.h
@@ -32,7 +32,6 @@
 
 #pragma once
 
-#include <string>
 #include <cstring>
 #include <arpa/inet.h>
 #include <poll.h>

--- a/platforms/nuttx/nuttx-configs/Make.defs.in
+++ b/platforms/nuttx/nuttx-configs/Make.defs.in
@@ -51,6 +51,7 @@ CFLAGS = -Os -g2 -I${PX4_SOURCE_DIR}/src/include ${CMAKE_C_FLAGS} -I. -isystem $
 	-Wno-float-equal \
 	-Wno-implicit-fallthrough \
 	-Wno-implicit-function-declaration \
+	-Wno-logical-op \
 	-Wno-maybe-uninitialized \
 	-Wno-missing-declarations \
 	-Wno-missing-field-initializers \


### PR DESCRIPTION
Update NuttX GNU Arm Embedded Toolchain to the latest stable version.

GNU Arm Embedded Toolchain: 7-2017-q4-major December 18, 2017

	nsh> ver all
	HW arch: PX4FMU_V2
	HW type: V2M
	HW version: 0x0009000A
	HW revision: 0x00000000
	FW git-hash: 3bd0f045169ddc69a9ec74de4f53a2cb795bf685
	FW version: 1.7.2 0 (17236480)
	OS: NuttX
	OS version: Release 7.22.0 (118882559)
	OS git-hash: b18053574bf41712cef93e31bf178518f451a350
	Build datetime: Jan  1 2018 15:32:02
	Build uri: localhost
	Toolchain: GNU GCC, 7.2.1 20170904 (release) [ARM/embedded-7-branch revision 255204]
	MFGUID: 313237313036510500470037
	MCU: STM32F42x, rev. 3
	UID: 470037:30365105:31323731 


https://github.com/PX4/containers/blob/5c29816a92b5dad22333a41860ec0a0d0f608567/docker/px4-dev/Dockerfile_nuttx#L27-L30