### PR TITLE
cmake add missing generate_px4muorb_stubs dependency

### DIFF
--- a/src/modules/muorb/adsp/CMakeLists.txt
+++ b/src/modules/muorb/adsp/CMakeLists.txt
@@ -39,6 +39,6 @@ px4_add_module(
 		px4muorb.cpp
 		uORBFastRpcChannel.cpp
 	DEPENDS
+		generate_px4muorb_stubs
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/posix/px4_layer/CMakeLists.txt
+++ b/src/platforms/posix/px4_layer/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
+set(EXTRA_DEPENDS)
 if("${CONFIG_SHMEM}" STREQUAL "1")
 	set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PX4_SOURCE_DIR}/cmake/cmake_hexagon")
 	include(hexagon_sdk)
@@ -42,6 +43,7 @@ if("${CONFIG_SHMEM}" STREQUAL "1")
 	)
 	# TODO: This didn't seem to be tracked correctly from posix_eagle_release.cmake
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCONFIG_SHMEM")
+	set(EXTRA_DEPENDS generate_px4muorb_stubs)
 endif()
 
 px4_add_module(
@@ -57,5 +59,5 @@ px4_add_module(
 		${SHMEM_SRCS}
 	DEPENDS
 		platforms__common
+		${EXTRA_DEPENDS}
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix :


### PR DESCRIPTION
Addresses this build failure. http://ci.px4.io:8080/blue/organizations/jenkins/Firmware/detail/PR-8558/1/pipeline/#step-557-log-413

Fails intermittently as the stubs are typically generated by the time the modules are actually built.