### PR TITLE
Jenkins generate uorb graphs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -621,6 +621,16 @@ pipeline {
             archiveArtifacts(artifacts: 'modules/*.md', fingerprint: true)
           }
         }
+
+        stage('uorb graphs') {
+          agent {
+            docker { image 'px4io/px4-dev-nuttx:2017-12-30' }
+          }
+          steps {
+            sh 'make uorb_graphs'
+            archiveArtifacts(artifacts: 'Tools/uorb_graph/graph_sitl.json')
+          }
+        }
       }
     }
 


### PR DESCRIPTION
https://github.com/PX4/Firmware/pull/8393#issuecomment-352369052

At the moment I've used secondary jobs outside of the pipeline to upload generated metadata. Once a day it grabs the artifacts from the latest stable master build and uploads it wherever (gitbook, s3, etc). Eventually I'd like to get it all into the single pipeline.