### PR TITLE
WIP: Parameter interface stability

### DIFF
--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -978,6 +978,8 @@ PARAM_DEFINE_FLOAT(EKF2_RNG_PITCH, 0.0f);
  * @min -0.5
  * @max 0.5
  * @reboot_required true
+ * @volatile
+ * @level system
  * @unit mGauss
  * @decimal 3
  */
@@ -991,6 +993,8 @@ PARAM_DEFINE_FLOAT(EKF2_MAGBIAS_X, 0.0f);
  * @min -0.5
  * @max 0.5
  * @reboot_required true
+ * @volatile
+ * @level system
  * @unit mGauss
  * @decimal 3
  */
@@ -1004,6 +1008,8 @@ PARAM_DEFINE_FLOAT(EKF2_MAGBIAS_Y, 0.0f);
  * @min -0.5
  * @max 0.5
  * @reboot_required true
+ * @volatile
+ * @level system
  * @unit mGauss
  * @decimal 3
  */
@@ -1014,6 +1020,7 @@ PARAM_DEFINE_FLOAT(EKF2_MAGBIAS_Z, 0.0f);
  *
  * @group EKF2
  * @reboot_required true
+ * @level system
  */
 PARAM_DEFINE_INT32(EKF2_MAGBIAS_ID, 0);
 

--- a/src/modules/systemlib/param/CMakeLists.txt
+++ b/src/modules/systemlib/param/CMakeLists.txt
@@ -78,7 +78,7 @@ add_custom_command(OUTPUT ${parameters_xml}
 		--inject-xml ${CMAKE_CURRENT_SOURCE_DIR}/parameters_injected.xml
 		--overrides ${PARAM_DEFAULT_OVERRIDES}
 		#--verbose
-	DEPENDS ${param_src_files} px_process_params.py parameters_injected.xml
+	DEPENDS ${param_src_files} px_process_params.py px4params/srcparser.py px4params/srcscanner.py parameters_injected.xml
 	COMMENT "Generating parameters.xml"
 )
 add_custom_target(parameters_xml DEPENDS ${parameters_xml})

--- a/src/modules/systemlib/param/px4params/srcparser.py
+++ b/src/modules/systemlib/param/px4params/srcparser.py
@@ -155,7 +155,7 @@ class SourceParser(object):
     re_remove_dots = re.compile(r'\.+$')
     re_remove_carriage_return = re.compile('\n+')
 
-    valid_tags = set(["group", "board", "min", "max", "unit", "decimal", "increment", "reboot_required", "value", "boolean", "bit"])
+    valid_tags = set(["group", "board", "min", "max", "unit", "decimal", "increment", "reboot_required", "value", "boolean", "bit", "level", "volatile"])
 
     # Order of parameter groups
     priority = {


### PR DESCRIPTION
Goal of this PR is to stabilise the param transfers and simplify the user-facing UI by:

  * Marking system and advanced parameters to enable the GCS UI to display them differently to indicate to the user that these are typically not changed
  * Mark parameters that are modified by the system itself commonly as volatile. This also excludes them from param hashing, as their change is not considered a significant configuration change

WIP: The volatile flag is not being used on the firmware side yet.