### PR TITLE
Nuttx GCC7: enable -Wimplicit-fallthrough

### DIFF
--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -332,8 +332,6 @@ function(px4_add_common_flags)
 		-Wunknown-pragmas
 		-Wunused-variable
 
-		-Wno-implicit-fallthrough # set appropriate level and update
-
 		-Wno-unused-parameter
 		)
 

--- a/src/drivers/bmp280/bmp280.cpp
+++ b/src/drivers/bmp280/bmp280.cpp
@@ -355,12 +355,12 @@ BMP280::ioctl(struct file *filp, int cmd, unsigned long arg)
 				return -EINVAL;
 
 			case SENSOR_POLLRATE_MAX:
+				[[fallthrough]];
 
-			/* FALLTHROUGH */
 			case SENSOR_POLLRATE_DEFAULT:
 				ticks = _max_mesure_ticks;
+				[[fallthrough]];
 
-			/* FALLTHROUGH */
 			default: {
 					if (ticks == 0) {
 						ticks = USEC2TICK(USEC_PER_SEC / arg);

--- a/src/drivers/boards/px4cannode-v1/px4cannode_led.c
+++ b/src/drivers/boards/px4cannode-v1/px4cannode_led.c
@@ -157,8 +157,7 @@ __EXPORT void board_autoled_off(int led)
 	case LED_IRQSENABLED:
 	case LED_STACKCREATED:
 		phy_set_led(BOARD_LED_GREEN, false);
-
-	/* FALLTHROUGH */
+		__attribute__((fallthrough));
 
 	case LED_INIRQ:
 	case LED_SIGNAL:

--- a/src/drivers/frsky_telemetry/frsky_telemetry.c
+++ b/src/drivers/frsky_telemetry/frsky_telemetry.c
@@ -503,10 +503,9 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 						elementCount = 0;
 						break;
 					}
-
 				}
 
-			/* FALLTHROUGH */
+				__attribute__((fallthrough));  // we cannot use	[[fallthrough]] in a C file
 
 			case SMARTPORT_POLL_8:
 

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -677,8 +677,8 @@ GPS::run()
 			switch (_mode) {
 			case GPS_DRIVER_MODE_NONE:
 				_mode = GPS_DRIVER_MODE_UBX;
+				[[fallthrough]];
 
-			/* FALLTHROUGH */
 			case GPS_DRIVER_MODE_UBX: {
 					int32_t param_gps_ubx_dynmodel = 7; // default to 7: airborne with <2g acceleration
 					param_get(param_find("GPS_UBX_DYNMODEL"), &param_gps_ubx_dynmodel);

--- a/src/drivers/lis3mdl/lis3mdl_i2c.cpp
+++ b/src/drivers/lis3mdl/lis3mdl_i2c.cpp
@@ -113,8 +113,7 @@ LIS3MDL_I2C::ioctl(unsigned operation, unsigned &arg)
 
 	case MAGIOCGEXTERNAL:
 		external();
-
-	/* FALLTHROUGH */
+		[[fallthrough]];
 
 	case DEVIOCGDEVICEID:
 		return CDev::ioctl(nullptr, operation, arg);

--- a/src/drivers/mpu6000/mpu6000_spi.cpp
+++ b/src/drivers/mpu6000/mpu6000_spi.cpp
@@ -241,8 +241,7 @@ MPU6000_SPI::ioctl(unsigned operation, unsigned &arg)
 
 	case ACCELIOCGEXTERNAL:
 		external();
-
-	/* FALLTHROUGH */
+		[[fallthrough]];
 
 	case DEVIOCGDEVICEID:
 		return CDev::ioctl(nullptr, operation, arg);

--- a/src/drivers/mpu9250/mpu9250_spi.cpp
+++ b/src/drivers/mpu9250/mpu9250_spi.cpp
@@ -169,8 +169,7 @@ MPU9250_SPI::ioctl(unsigned operation, unsigned &arg)
 
 	case ACCELIOCGEXTERNAL:
 		external();
-
-	/* FALLTHROUGH */
+		[[fallthrough]];
 
 	case DEVIOCGDEVICEID:
 		return CDev::ioctl(nullptr, operation, arg);

--- a/src/drivers/ms5611/ms5611.cpp
+++ b/src/drivers/ms5611/ms5611.cpp
@@ -1347,7 +1347,7 @@ ms5611_main(int argc, char *argv[])
 				}
 			}
 
-		/* FALLTHROUGH */
+			[[fallthrough]];
 
 		default:
 			ms5611::usage();

--- a/src/drivers/protocol_splitter/protocol_splitter.cpp
+++ b/src/drivers/protocol_splitter/protocol_splitter.cpp
@@ -379,7 +379,7 @@ ssize_t Mavlink2Dev::write(struct file *filp, const char *buffer, size_t buflen)
 			return 0;
 		}
 
-	/* FALLTHROUGH */
+		[[fallthrough]];
 
 	case ParserState::GotLength: {
 			_packet_len -= buflen;
@@ -509,8 +509,7 @@ ssize_t RtpsDev::write(struct file *filp, const char *buffer, size_t buflen)
 		_packet_len = payload_len + HEADER_SIZE;
 		_parser_state = ParserState::GotLength;
 		lock(Write);
-
-	/* FALLTHROUGH */
+		[[fallthrough]];
 
 	case ParserState::GotLength: {
 			_packet_len -= buflen;

--- a/src/drivers/pwm_out_sim/pwm_out_sim.cpp
+++ b/src/drivers/pwm_out_sim/pwm_out_sim.cpp
@@ -701,7 +701,7 @@ PWMSim::pwm_ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			break;
 		}
 
-	/* FALLTHROUGH */
+		[[fallthrough]];
 
 	case PWM_SERVO_SET(0):
 	case PWM_SERVO_SET(1):
@@ -724,7 +724,7 @@ PWMSim::pwm_ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			break;
 		}
 
-	/* FALLTHROUGH */
+		[[fallthrough]];
 
 	case PWM_SERVO_GET(3):
 	case PWM_SERVO_GET(2):
@@ -733,7 +733,7 @@ PWMSim::pwm_ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			break;
 		}
 
-	/* FALLTHROUGH */
+		[[fallthrough]];
 
 	case PWM_SERVO_GET(1):
 	case PWM_SERVO_GET(0): {

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -648,9 +648,9 @@ PX4FMU::set_mode(Mode mode)
 		up_input_capture_set(2, Rising, 0, NULL, NULL);
 		up_input_capture_set(3, Rising, 0, NULL, NULL);
 		DEVICE_DEBUG("MODE_2PWM2CAP");
-#endif
+		[[fallthrough]];
 
-	/* FALLTHROUGH */
+#endif
 
 	case MODE_2PWM:	// v1 multi-port with flow control lines as PWM
 		DEVICE_DEBUG("MODE_2PWM");
@@ -670,9 +670,9 @@ PX4FMU::set_mode(Mode mode)
 	case MODE_3PWM1CAP:	// v1 multi-port with flow control lines as PWM
 		DEVICE_DEBUG("MODE_3PWM1CAP");
 		up_input_capture_set(3, Rising, 0, NULL, NULL);
-#endif
+		[[fallthrough]];
 
-	/* FALLTHROUGH */
+#endif
 
 	case MODE_3PWM:	// v1 multi-port with flow control lines as PWM
 		DEVICE_DEBUG("MODE_3PWM");
@@ -2183,45 +2183,45 @@ PX4FMU::pwm_ioctl(file *filp, int cmd, unsigned long arg)
 #if defined(BOARD_HAS_PWM) && BOARD_HAS_PWM >= 8
 
 	case PWM_SERVO_SET(7):
-
-	/* FALLTHROUGH */
 	case PWM_SERVO_SET(6):
 		if (_mode < MODE_8PWM) {
 			ret = -EINVAL;
 			break;
 		}
 
+		[[fallthrough]];
+
 #endif
 
 #if defined(BOARD_HAS_PWM) && BOARD_HAS_PWM >= 6
 
-	/* FALLTHROUGH */
 	case PWM_SERVO_SET(5):
-
-	/* FALLTHROUGH */
 	case PWM_SERVO_SET(4):
 		if (_mode < MODE_6PWM) {
 			ret = -EINVAL;
 			break;
 		}
 
+		[[fallthrough]];
+
 #endif
 
-	/* FALLTHROUGH */
 	case PWM_SERVO_SET(3):
 		if (_mode < MODE_4PWM) {
 			ret = -EINVAL;
 			break;
 		}
 
-	/* FALLTHROUGH */
+		[[fallthrough]];
+
 	case PWM_SERVO_SET(2):
 		if (_mode < MODE_3PWM) {
 			ret = -EINVAL;
 			break;
 		}
 
-	/* FALLTHROUGH */
+		[[fallthrough]];
+
 	case PWM_SERVO_SET(1):
 	case PWM_SERVO_SET(0):
 		if (arg <= 2100) {
@@ -2246,10 +2246,11 @@ PX4FMU::pwm_ioctl(file *filp, int cmd, unsigned long arg)
 			break;
 		}
 
+		[[fallthrough]];
+
 #endif
 #if defined(BOARD_HAS_PWM) && BOARD_HAS_PWM >= 8
 
-	/* FALLTHROUGH */
 	case PWM_SERVO_GET(7):
 	case PWM_SERVO_GET(6):
 		if (_mode < MODE_8PWM) {
@@ -2257,11 +2258,12 @@ PX4FMU::pwm_ioctl(file *filp, int cmd, unsigned long arg)
 			break;
 		}
 
+		[[fallthrough]];
+
 #endif
 
 #if defined(BOARD_HAS_PWM) && BOARD_HAS_PWM >= 6
 
-	/* FALLTHROUGH */
 	case PWM_SERVO_GET(5):
 	case PWM_SERVO_GET(4):
 		if (_mode < MODE_6PWM) {
@@ -2269,23 +2271,26 @@ PX4FMU::pwm_ioctl(file *filp, int cmd, unsigned long arg)
 			break;
 		}
 
+		[[fallthrough]];
+
 #endif
 
-	/* FALLTHROUGH */
 	case PWM_SERVO_GET(3):
 		if (_mode < MODE_4PWM) {
 			ret = -EINVAL;
 			break;
 		}
 
-	/* FALLTHROUGH */
+		[[fallthrough]];
+
 	case PWM_SERVO_GET(2):
 		if (_mode < MODE_3PWM) {
 			ret = -EINVAL;
 			break;
 		}
 
-	/* FALLTHROUGH */
+		[[fallthrough]];
+
 	case PWM_SERVO_GET(1):
 	case PWM_SERVO_GET(0):
 		*(servo_position_t *)arg = up_pwm_servo_get(cmd - PWM_SERVO_GET(0));

--- a/src/drivers/vmount/input_mavlink.cpp
+++ b/src/drivers/vmount/input_mavlink.cpp
@@ -246,8 +246,7 @@ int InputMavlinkCmdMount::update_impl(unsigned int timeout_ms, ControlData **con
 				switch ((int)vehicle_command.param7) {
 				case vehicle_command_s::VEHICLE_MOUNT_MODE_RETRACT:
 					_control_data.gimbal_shutter_retract = true;
-
-				/* FALLTHROUGH */
+					[[fallthrough]];
 
 				case vehicle_command_s::VEHICLE_MOUNT_MODE_NEUTRAL:
 					_control_data.type = ControlData::Type::Neutral;

--- a/src/lib/led/led.cpp
+++ b/src/lib/led/led.cpp
@@ -238,7 +238,8 @@ void LedController::get_control_data(LedControlData &control_data)
 					flash_output_active = false;
 				}
 
-			/* FALLTHROUGH */
+				[[fallthrough]];
+
 			case led_control_s::MODE_BLINK_FAST:
 			case led_control_s::MODE_BLINK_NORMAL:
 			case led_control_s::MODE_BLINK_SLOW:

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -3926,7 +3926,8 @@ set_control_mode()
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_RCRECOVER:
 		/* override is not ok for the RTL and recovery mode */
 		control_mode.flag_external_manual_override_ok = false;
-		/* fallthrough */
+		[[fallthrough]];
+
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_FOLLOW_TARGET:
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_RTGS:
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_LAND:

--- a/src/modules/navigator/follow_target.cpp
+++ b/src/modules/navigator/follow_target.cpp
@@ -339,7 +339,7 @@ void FollowTarget::on_active()
 			_follow_target_state = WAIT_FOR_TARGET_POSITION;
 		}
 
-	/* FALLTHROUGH */
+		[[fallthrough]];
 
 	case WAIT_FOR_TARGET_POSITION: {
 

--- a/src/modules/navigator/geofence.cpp
+++ b/src/modules/navigator/geofence.cpp
@@ -127,8 +127,8 @@ void Geofence::_updateFence()
 		case MAV_CMD_NAV_FENCE_CIRCLE_INCLUSION:
 		case MAV_CMD_NAV_FENCE_CIRCLE_EXCLUSION:
 			is_circle_area = true;
+			[[fallthrough]];
 
-		/* FALLTHROUGH */
 		case MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION:
 		case MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION:
 			if (!is_circle_area && mission_fence_point.vertex_count == 0) {

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -543,7 +543,8 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 			sp->alt = _navigator->get_global_position()->alt;
 		}
 
-	// fall through
+		[[fallthrough]];
+
 	case NAV_CMD_LOITER_TIME_LIMIT:
 	case NAV_CMD_LOITER_UNLIMITED:
 		sp->type = position_setpoint_s::SETPOINT_TYPE_LOITER;

--- a/src/modules/px4iofirmware/mixer.cpp
+++ b/src/modules/px4iofirmware/mixer.cpp
@@ -569,7 +569,8 @@ mixer_handle_text(const void *buffer, size_t length)
 		mixer_group.reset();
 		mixer_text_length = 0;
 
-	/* FALLTHROUGH */
+		[[fallthrough]];
+
 	case F2I_MIXER_ACTION_APPEND:
 		isr_debug(2, "append %d", length);
 

--- a/src/modules/uavcan/sensors/gnss.cpp
+++ b/src/modules/uavcan/sensors/gnss.cpp
@@ -193,7 +193,7 @@ void UavcanGnssBridge::gnss_fix2_sub_cb(const uavcan::ReceivedDataStructure<uavc
 			vel_cov[8] = msg.covariance[20];
 		}
 
-	/* FALLTHROUGH */
+		[[fallthrough]];
 
 	// Full matrix 6x6.
 	// This code has been carefully optimized by hand. We could use unpackSquareMatrix(), but it's slow.
@@ -226,7 +226,7 @@ void UavcanGnssBridge::gnss_fix2_sub_cb(const uavcan::ReceivedDataStructure<uavc
 			vel_cov[8] = msg.covariance[35];
 		}
 
-	/* FALLTHROUGH */
+		[[fallthrough]];
 
 	// Either empty or invalid sized, interpret as zero matrix
 	default: {


### PR DESCRIPTION
Re-enable implicit fallthrough (with default level 3) warning in #8551 

I tried various warning levels but they seem ineffective in the docker image.
- -Wimplicit-fallthrough=0 correctly disables the warning
- levels 1, 2 and 3 do not correctly accepts fallthrough comments
See here for what the behaviour should be https://gcc.gnu.org/onlinedocs/gcc-7.2.0/gcc/Warning-Options.html#Warning-Options.

I replaced the comments `/* FALLTHROUGH */` by attributes `[[fallthrough]]` in C++ files, and by `__attribute__((fallthrough))` in two C files.