### PR TITLE
optical flow: move rotation to msg and apply in estimator

### DIFF
--- a/msg/optical_flow.msg
+++ b/msg/optical_flow.msg
@@ -1,15 +1,16 @@
 # Optical flow in XYZ body frame in SI units.
 # @see http://en.wikipedia.org/wiki/International_System_of_Units
 
-uint8 sensor_id			# id of the sensor emitting the flow value
-float32 pixel_flow_x_integral	# accumulated optical flow in radians where a positive value is produced by a RH rotation about the X body axis
-float32 pixel_flow_y_integral	# accumulated optical flow in radians where a positive value is produced by a RH rotation about the Y body axis
-float32 gyro_x_rate_integral	# accumulated gyro value in radians where a positive value is produced by a RH rotation about the X body axis
-float32 gyro_y_rate_integral	# accumulated gyro value in radians where a positive value is produced by a RH rotation about the Y body axis
-float32 gyro_z_rate_integral	# accumulated gyro value in radians where a positive value is produced by a RH rotation about the Z body axis
-float32 ground_distance_m	# Altitude / distance to ground in meters
-uint32 integration_timespan	# accumulation timespan in microseconds
-uint32 time_since_last_sonar_update	# time since last sonar update in microseconds
-uint16 frame_count_since_last_readout	# number of accumulated frames in timespan
-int16 gyro_temperature	# Temperature * 100 in centi-degrees Celsius
-uint8 quality	# Average of quality of accumulated frames, 0: bad quality, 255: maximum quality
+uint8 sensor_id                       # id of the sensor emitting the flow value
+float32 pixel_flow_x_integral         # with the rotation applied (see below): accumulated optical flow in radians where a positive value is produced by a RH rotation about the X body axis
+float32 pixel_flow_y_integral         # with the rotation applied (see below): accumulated optical flow in radians where a positive value is produced by a RH rotation about the Y body axis
+float32 gyro_x_rate_integral          # with the rotation applied (see below): accumulated gyro value in radians where a positive value is produced by a RH rotation about the X body axis
+float32 gyro_y_rate_integral          # with the rotation applied (see below): accumulated gyro value in radians where a positive value is produced by a RH rotation about the Y body axis
+float32 gyro_z_rate_integral          # with the rotation applied (see below): accumulated gyro value in radians where a positive value is produced by a RH rotation about the Z body axis
+float32 ground_distance_m             # Altitude / distance to ground in meters
+uint32 integration_timespan           # accumulation timespan in microseconds
+uint32 time_since_last_sonar_update   # time since last sonar update in microseconds
+uint16 frame_count_since_last_readout # number of accumulated frames in timespan
+int16 gyro_temperature                # Temperature * 100 in centi-degrees Celsius
+uint8 quality                         # Average of quality of accumulated frames, 0: bad quality, 255: maximum quality
+uint8 rotation                        # Board Yaw rotation (0-7: 45 degree steps starting with 0 := no rotation)

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -50,6 +50,7 @@
 #include <px4_posix.h>
 #include <px4_tasks.h>
 #include <px4_time.h>
+#include <conversion/rotation.h>
 #include <uORB/topics/airspeed.h>
 #include <uORB/topics/distance_sensor.h>
 #include <uORB/topics/ekf2_innovations.h>
@@ -829,6 +830,14 @@ void Ekf2::run()
 
 		if (optical_flow_updated) {
 			flow_message flow;
+
+			// rotate measurements according to parameter
+			const enum Rotation flow_rot = (Rotation)optical_flow.rotation;
+			float zeroval = 0.0f;
+			rotate_3f(flow_rot, optical_flow.pixel_flow_x_integral, optical_flow.pixel_flow_y_integral, zeroval);
+			rotate_3f(flow_rot, optical_flow.gyro_x_rate_integral, optical_flow.gyro_y_rate_integral,
+				  optical_flow.gyro_z_rate_integral);
+
 			flow.flowdata(0) = optical_flow.pixel_flow_x_integral;
 			flow.flowdata(1) = optical_flow.pixel_flow_y_integral;
 			flow.quality = optical_flow.quality;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -615,9 +615,9 @@ MavlinkReceiver::handle_message_optical_flow_rad(mavlink_message_t *msg)
 	mavlink_optical_flow_rad_t flow;
 	mavlink_msg_optical_flow_rad_decode(msg, &flow);
 
+	// get rotation parameter
 	int32_t flow_rot_int;
 	param_get(param_find("SENS_FLOW_ROT"), &flow_rot_int);
-	const enum Rotation flow_rot = (Rotation)flow_rot_int;
 
 	struct optical_flow_s f = {};
 
@@ -633,11 +633,7 @@ MavlinkReceiver::handle_message_optical_flow_rad(mavlink_message_t *msg)
 	f.quality = flow.quality;
 	f.sensor_id = flow.sensor_id;
 	f.gyro_temperature = flow.temperature;
-
-	/* rotate measurements according to parameter */
-	float zeroval = 0.0f;
-	rotate_3f(flow_rot, f.pixel_flow_x_integral, f.pixel_flow_y_integral, zeroval);
-	rotate_3f(flow_rot, f.gyro_x_rate_integral, f.gyro_y_rate_integral, f.gyro_z_rate_integral);
+	f.rotation = (uint8_t)flow_rot_int; // rotation will be applied by the user (estimator)
 
 	if (_flow_pub == nullptr) {
 		_flow_pub = orb_advertise(ORB_ID(optical_flow), &f);
@@ -676,6 +672,10 @@ MavlinkReceiver::handle_message_hil_optical_flow(mavlink_message_t *msg)
 	mavlink_hil_optical_flow_t flow;
 	mavlink_msg_hil_optical_flow_decode(msg, &flow);
 
+	// get rotation parameter
+	int32_t flow_rot_int;
+	param_get(param_find("SENS_FLOW_ROT"), &flow_rot_int);
+
 	struct optical_flow_s f;
 	memset(&f, 0, sizeof(f));
 
@@ -691,6 +691,7 @@ MavlinkReceiver::handle_message_hil_optical_flow(mavlink_message_t *msg)
 	f.quality = flow.quality;
 	f.sensor_id = flow.sensor_id;
 	f.gyro_temperature = flow.temperature;
+	f.rotation = (uint8_t)flow_rot_int; // rotation will be applied by the user (estimator)
 
 	if (_flow_pub == nullptr) {
 		_flow_pub = orb_advertise(ORB_ID(optical_flow), &f);

--- a/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
@@ -69,6 +69,7 @@
 #include <geo/geo.h>
 #include <drivers/drv_hrt.h>
 #include <platforms/px4_defines.h>
+#include <conversion/rotation.h>
 
 #include <terrain_estimation/terrain_estimator.h>
 #include "position_estimator_inav_params.h"
@@ -611,6 +612,12 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 
 			if (updated && lidar_valid) {
 				orb_copy(ORB_ID(optical_flow), optical_flow_sub, &flow);
+
+				// rotate measurements according to parameter
+				const enum Rotation flow_rot = (Rotation)flow.rotation;
+				float zeroval = 0.0f;
+				rotate_3f(flow_rot, flow.pixel_flow_x_integral, flow.pixel_flow_y_integral, zeroval);
+				rotate_3f(flow_rot, flow.gyro_x_rate_integral, flow.gyro_y_rate_integral, flow.gyro_z_rate_integral);
 
 				flow_time = t;
 				float flow_q = flow.quality / 255.0f;

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -1091,6 +1091,10 @@ int Simulator::publish_flow_topic(mavlink_hil_optical_flow_t *flow_mavlink)
 	struct optical_flow_s flow;
 	memset(&flow, 0, sizeof(flow));
 
+	/* get rotation parameter */
+	int32_t flow_rot_int;
+	param_get(param_find("SENS_FLOW_ROT"), &flow_rot_int);
+
 	flow.sensor_id = flow_mavlink->sensor_id;
 	flow.timestamp = timestamp;
 	flow.time_since_last_sonar_update = 0;
@@ -1105,15 +1109,7 @@ int Simulator::publish_flow_topic(mavlink_hil_optical_flow_t *flow_mavlink)
 	flow.pixel_flow_x_integral = flow_mavlink->integrated_x;
 	flow.pixel_flow_y_integral = flow_mavlink->integrated_y;
 	flow.quality = flow_mavlink->quality;
-
-	/* rotate measurements according to parameter */
-	int32_t flow_rot_int;
-	param_get(param_find("SENS_FLOW_ROT"), &flow_rot_int);
-	const enum Rotation flow_rot = (Rotation)flow_rot_int;
-
-	float zeroval = 0.0f;
-	rotate_3f(flow_rot, flow.pixel_flow_x_integral, flow.pixel_flow_y_integral, zeroval);
-	rotate_3f(flow_rot, flow.gyro_x_rate_integral, flow.gyro_y_rate_integral, flow.gyro_z_rate_integral);
+	flow.rotation = (uint8_t)flow_rot_int; // rotation will be applied by the user (estimator)
 
 	int flow_multi;
 	orb_publish_auto(ORB_ID(optical_flow), &_flow_pub, &flow, &flow_multi, ORB_PRIO_HIGH);


### PR DESCRIPTION
@LorenzMeier @dagar 
This is replacing https://github.com/PX4/Firmware/pull/8495 as discussed in the messaging call.

I realized two things:
- one downside is debugging. The Logs (and QGC Analyze/Mavlink in general) contain the not rotated optical flow msg...

- The msg states `accumulated optical flow in radians where a positive value is produced by a RH rotation about the X/Y body axis` which means that adding a rotation parameter seems weird. So it could mean that all apps (e.g. the Intel optical flow FastRTPS app) have to send it in this configuration and no rotation parameter can be used.
This would mean that we can leave everything as it was and force apps that don't use Mavlink to send the msgs in the correct way. Thoughts?

This has been tested in simulation with all 3 estimators and hand-held with a PX4Flow (which means the parameter has no effect)
  