### PR TITLE
Parameter Notification Improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,8 +252,8 @@ coverity_scan: posix_sitl_default
 .PHONY: parameters_metadata airframe_metadata module_documentation px4_metadata
 
 parameters_metadata:
-	@python $(SRC_DIR)/src/modules/systemlib/param/px_process_params.py -s `find $(SRC_DIR)/src -maxdepth 3 -type d` --inject-xml $(SRC_DIR)/src/modules/systemlib/param/parameters_injected.xml --markdown
-	@python $(SRC_DIR)/src/modules/systemlib/param/px_process_params.py -s `find $(SRC_DIR)/src -maxdepth 3 -type d` --inject-xml $(SRC_DIR)/src/modules/systemlib/param/parameters_injected.xml --xml
+	@python $(SRC_DIR)/src/modules/systemlib/param/px_process_params.py -s `find $(SRC_DIR)/src -maxdepth 4 -type d` --inject-xml $(SRC_DIR)/src/modules/systemlib/param/parameters_injected.xml --markdown
+	@python $(SRC_DIR)/src/modules/systemlib/param/px_process_params.py -s `find $(SRC_DIR)/src -maxdepth 4 -type d` --inject-xml $(SRC_DIR)/src/modules/systemlib/param/parameters_injected.xml --xml
 
 airframe_metadata:
 	@python $(SRC_DIR)/Tools/px_process_airframes.py -v -a $(SRC_DIR)/ROMFS/px4fmu_common/init.d --markdown

--- a/Tools/qgc_meta_sync.sh
+++ b/Tools/qgc_meta_sync.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
-make posix_sitl_default
-cp build/posix_sitl_default/parameters.xml ../qgroundcontrol/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml
-#cp build/posix_sitl_default/airframes.xml ../qgroundcontrol/src/AutoPilotPlugins/PX4/AirframeFactMetaData.xml
+make parameters_metadata
+cp parameters.xml ../qgroundcontrol/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml
+make airframe_metadata
+cp airframes.xml ../qgroundcontrol/src/AutoPilotPlugins/PX4/AirframeFactMetaData.xml

--- a/Tools/qgc_meta_sync.sh
+++ b/Tools/qgc_meta_sync.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-make px4fmu-v4_default
-cp build/px4fmu-v4_default/parameters.xml ../qgroundcontrol/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml
-cp build/px4fmu-v4_default/airframes.xml ../qgroundcontrol/src/AutoPilotPlugins/PX4/AirframeFactMetaData.xml
+make posix_sitl_default
+cp build/posix_sitl_default/parameters.xml ../qgroundcontrol/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml
+#cp build/posix_sitl_default/airframes.xml ../qgroundcontrol/src/AutoPilotPlugins/PX4/AirframeFactMetaData.xml

--- a/msg/parameter_update.msg
+++ b/msg/parameter_update.msg
@@ -1,3 +1,3 @@
 # This message is used to notify the system about one or more parameter changes
 
-uint32 dummy       # unused
+uint32 instance       # Instance count - constantly incrementing

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -697,6 +697,8 @@ PARAM_DEFINE_INT32(COM_POS_FS_GAIN, 10);
  * The first flight is 0.
  *
  * @group Commander
+ * @category system
+ * @volatile
  * @min 0
  */
 PARAM_DEFINE_INT32(COM_FLIGHT_UUID, 0);

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -978,6 +978,8 @@ PARAM_DEFINE_FLOAT(EKF2_RNG_PITCH, 0.0f);
  * @min -0.5
  * @max 0.5
  * @reboot_required true
+ * @volatile
+ * @level system
  * @unit mGauss
  * @decimal 3
  */
@@ -991,6 +993,8 @@ PARAM_DEFINE_FLOAT(EKF2_MAGBIAS_X, 0.0f);
  * @min -0.5
  * @max 0.5
  * @reboot_required true
+ * @volatile
+ * @level system
  * @unit mGauss
  * @decimal 3
  */
@@ -1004,6 +1008,8 @@ PARAM_DEFINE_FLOAT(EKF2_MAGBIAS_Y, 0.0f);
  * @min -0.5
  * @max 0.5
  * @reboot_required true
+ * @volatile
+ * @level system
  * @unit mGauss
  * @decimal 3
  */
@@ -1014,6 +1020,7 @@ PARAM_DEFINE_FLOAT(EKF2_MAGBIAS_Z, 0.0f);
  *
  * @group EKF2
  * @reboot_required true
+ * @level system
  */
 PARAM_DEFINE_INT32(EKF2_MAGBIAS_ID, 0);
 

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -979,7 +979,7 @@ PARAM_DEFINE_FLOAT(EKF2_RNG_PITCH, 0.0f);
  * @max 0.5
  * @reboot_required true
  * @volatile
- * @level system
+ * @category system
  * @unit mGauss
  * @decimal 3
  */
@@ -994,7 +994,7 @@ PARAM_DEFINE_FLOAT(EKF2_MAGBIAS_X, 0.0f);
  * @max 0.5
  * @reboot_required true
  * @volatile
- * @level system
+ * @category system
  * @unit mGauss
  * @decimal 3
  */
@@ -1009,7 +1009,7 @@ PARAM_DEFINE_FLOAT(EKF2_MAGBIAS_Y, 0.0f);
  * @max 0.5
  * @reboot_required true
  * @volatile
- * @level system
+ * @category system
  * @unit mGauss
  * @decimal 3
  */
@@ -1020,7 +1020,7 @@ PARAM_DEFINE_FLOAT(EKF2_MAGBIAS_Z, 0.0f);
  *
  * @group EKF2
  * @reboot_required true
- * @level system
+ * @category system
  */
 PARAM_DEFINE_INT32(EKF2_MAGBIAS_ID, 0);
 

--- a/src/modules/land_detector/land_detector_params.c
+++ b/src/modules/land_detector/land_detector_params.c
@@ -38,6 +38,8 @@
  * Flight time in microseconds = (LND_FLIGHT_T_HI << 32) | LND_FLIGHT_T_LO.
  *
  * @min 0
+ * @volatile
+ * @category system
  * @group Land Detector
  *
  */
@@ -50,6 +52,8 @@ PARAM_DEFINE_INT32(LND_FLIGHT_T_HI, 0);
  * Flight time in microseconds = (LND_FLIGHT_T_HI << 32) | LND_FLIGHT_T_LO.
  *
  * @min 0
+ * @volatile
+ * @category system
  * @group Land Detector
  *
  */

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1836,7 +1836,7 @@ void Logger::write_parameters()
 	param_t param = 0;
 
 	do {
-		// get next parameter which is invalid OR used
+		// skip over all parameters which are not invalid and not used
 		do {
 			param = param_for_index(param_idx);
 			++param_idx;
@@ -1844,7 +1844,7 @@ void Logger::write_parameters()
 
 		// save parameters which are valid AND used
 		if (param != PARAM_INVALID) {
-			/* get parameter type and size */
+			// get parameter type and size
 			const char *type_str;
 			param_type_t type = param_type(param);
 			size_t value_size = 0;
@@ -1864,11 +1864,11 @@ void Logger::write_parameters()
 				continue;
 			}
 
-			/* format parameter key (type and name) */
+			// format parameter key (type and name)
 			msg.key_len = snprintf(msg.key, sizeof(msg.key), "%s %s", type_str, param_name(param));
 			size_t msg_size = sizeof(msg) - sizeof(msg.key) + msg.key_len;
 
-			/* copy parameter value directly to buffer */
+			// copy parameter value directly to buffer
 			switch (type) {
 			case PARAM_TYPE_INT32:
 				param_get(param, (int32_t*)&buffer[msg_size]);
@@ -1904,7 +1904,7 @@ void Logger::write_changed_parameters()
 	param_t param = 0;
 
 	do {
-		// get next parameter which is invalid OR used
+		// skip over all parameters which are not invalid and not used
 		do {
 			param = param_for_index(param_idx);
 			++param_idx;
@@ -1913,7 +1913,7 @@ void Logger::write_changed_parameters()
 		// log parameters which are valid AND used AND unsaved
 		if ((param != PARAM_INVALID) && param_value_unsaved(param)) {
 
-			/* get parameter type and size */
+			// get parameter type and size
 			const char *type_str;
 			param_type_t type = param_type(param);
 			size_t value_size = 0;
@@ -1933,11 +1933,11 @@ void Logger::write_changed_parameters()
 				continue;
 			}
 
-			/* format parameter key (type and name) */
+			// format parameter key (type and name)
 			msg.key_len = snprintf(msg.key, sizeof(msg.key), "%s %s", type_str, param_name(param));
 			size_t msg_size = sizeof(msg) - sizeof(msg.key) + msg.key_len;
 
-			/* copy parameter value directly to buffer */
+			// copy parameter value directly to buffer
 			switch (type) {
 			case PARAM_TYPE_INT32:
 				param_get(param, (int32_t*)&buffer[msg_size]);
@@ -1952,7 +1952,7 @@ void Logger::write_changed_parameters()
 			}
 			msg_size += value_size;
 
-			/* msg_size is now 1 (msg_type) + 2 (msg_size) + 1 (key_len) + key_len + value_size */
+			// msg_size is now 1 (msg_type) + 2 (msg_size) + 1 (key_len) + key_len + value_size
 			msg.msg_size = msg_size - ULOG_MSG_HEADER_LEN;
 
 			write_message(buffer, msg_size);
@@ -1977,7 +1977,7 @@ int Logger::check_free_space()
 		max_log_dirs_to_keep = INT32_MAX;
 	}
 
-	/* remove old logs if the free space falls below a threshold */
+	// remove old logs if the free space falls below a threshold
 	do {
 		if (statfs(LOG_ROOT, &statfs_buf) != 0) {
 			return PX4_ERROR;

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2190,23 +2190,9 @@ Mavlink::task_main(int argc, char *argv[])
 
 		update_rate_mult();
 
-		/* param update backoff: update only after 50 ms after the last change */
-		param_sub->update(&param_time, nullptr);
-
-		if (param_time + 100 * 1000 > hrt_absolute_time()) {
+		if (param_sub->update(&param_time, nullptr)) {
 			/* parameters updated */
 			mavlink_update_system();
-			/* send out param cache value */
-			uint32_t hash = param_hash_check();
-
-			/* build the one-off response message */
-			mavlink_param_value_t param_value;
-			param_value.param_count = param_count_used();
-			param_value.param_index = -1;
-			strncpy(param_value.param_id, HASH_PARAM, MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN);
-			param_value.param_type = MAV_PARAM_TYPE_UINT32;
-			memcpy(&param_value.param_value, &hash, sizeof(hash));
-			mavlink_msg_param_value_send_struct(get_channel(), &param_value);
 		}
 
 		check_radio_config();

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -77,6 +77,8 @@ enum Protocol {
 	TCP,
 };
 
+#define HASH_PARAM "_HASH_CHECK"
+
 class Mavlink
 {
 

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -155,7 +155,7 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 					param_set(param, &(set.param_value));
 
 					// Check if the parameter changed. If it didn't change, send current value back
-					if ((curr_val - set.param_value) == 0.0f) {
+					if (!(fabsf(curr_val - set.param_value) > 0.0f)) {
 						send_param(param);
 					}
 				}

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -150,16 +150,6 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 					/* set and send parameter */
 					param_set(param, &(set.param_value));
 					send_param(param);
-
-					/* check for deprecated value, coming from an older GCS */
-					if (strcmp(name, "SYS_MC_EST_GROUP") == 0) {
-						uint32_t val = *(uint32_t *)&set.param_value;
-
-						if (val == 0) { //INAV
-							mavlink_log_critical(_mavlink->get_mavlink_log_pub(),
-									     "INAV is deprecated. Using LPE after reboot");
-						}
-					}
 				}
 			}
 

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -47,8 +47,6 @@
 #include "mavlink_parameters.h"
 #include "mavlink_main.h"
 
-#define HASH_PARAM "_HASH_CHECK"
-
 MavlinkParametersManager::MavlinkParametersManager(Mavlink *mavlink) :
 	_send_all_index(-1),
 	_uavcan_open_request_list(nullptr),

--- a/src/modules/mavlink/mavlink_parameters.h
+++ b/src/modules/mavlink/mavlink_parameters.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2015 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,6 +37,7 @@
  *
  * @author Anton Babushkin <anton.babushkin@me.com>
  * @author Lorenz Meier <lorenz@px4.io>
+ * @author Beat Kueng <beat@px4.io>
  */
 
 #pragma once
@@ -47,6 +48,7 @@
 #include <uORB/uORB.h>
 #include <uORB/topics/rc_parameter_map.h>
 #include <uORB/topics/uavcan_parameter_request.h>
+#include <uORB/topics/parameter_update.h>
 #include <drivers/drv_hrt.h>
 
 class Mavlink;
@@ -79,6 +81,21 @@ protected:
 	/// @return true if a parameter was sent
 	bool send_one();
 
+	/**
+	 * Handle any open param send transfer
+	 */
+	bool send_params();
+
+	/**
+	 * Send UAVCAN params
+	 */
+	bool send_uavcan();
+
+	/**
+	 * Send untransmitted params
+	 */
+	bool send_untransmitted();
+
 	int send_param(param_t param, int component_id = -1);
 
 	// Item of a single-linked list to store requested uavcan parameters
@@ -87,22 +104,33 @@ protected:
 		struct _uavcan_open_request_list_item *next;
 	};
 
-	// Request the next uavcan parameter
+	/**
+	 * Request the next uavcan parameter
+	 */
 	void request_next_uavcan_parameter();
-	// Enque one uavcan parameter reqest. We store 10 at max.
+
+	/**
+	 * Enqueue one uavcan parameter reqest. We store 10 at max.
+	 */
 	void enque_uavcan_request(uavcan_parameter_request_s *req);
-	// Drop the first reqest from the list
+
+	/**
+	 * Drop the first reqest from the list
+	 */
 	void dequeue_uavcan_request();
 
-	_uavcan_open_request_list_item *_uavcan_open_request_list; // Pointer to the first item in the linked list
-	bool _uavcan_waiting_for_request_response; // We have reqested a parameter and wait for the response
-	uint16_t _uavcan_queued_request_items;	// Number of stored parameter requests currently in the list
+	_uavcan_open_request_list_item *_uavcan_open_request_list; ///< Pointer to the first item in the linked list
+	bool _uavcan_waiting_for_request_response; ///< We have reqested a parameter and wait for the response
+	uint16_t _uavcan_queued_request_items;	///< Number of stored parameter requests currently in the list
 
 	orb_advert_t _rc_param_map_pub;
 	struct rc_parameter_map_s _rc_param_map;
 
 	orb_advert_t _uavcan_parameter_request_pub;
 	int _uavcan_parameter_value_sub;
+	int _mavlink_parameter_sub;
+	hrt_abstime _param_update_time;
+	int _param_update_index;
 
 	Mavlink *_mavlink;
 };

--- a/src/modules/position_estimator_inav/params.c
+++ b/src/modules/position_estimator_inav/params.c
@@ -340,6 +340,7 @@ PARAM_DEFINE_FLOAT(INAV_LIDAR_OFF, 0.0f);
  * @reboot_required true
  * @min 0
  * @max 328754
+ * @category Developer
  * @group Position Estimator INAV
  */
 PARAM_DEFINE_INT32(CBRK_NO_VISION, 0);

--- a/src/modules/sensors/sensor_params_acc0.c
+++ b/src/modules/sensors/sensor_params_acc0.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2017 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,6 +34,7 @@
 /**
  * ID of the Accelerometer that the calibration is for.
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_INT32(CAL_ACC0_ID, 0);
@@ -42,6 +43,7 @@ PARAM_DEFINE_INT32(CAL_ACC0_ID, 0);
  * Accelerometer 0 enabled
  *
  * @boolean
+ * @category developer
  * @group Sensor Calibration
  */
 PARAM_DEFINE_INT32(CAL_ACC0_EN, 1);
@@ -49,6 +51,7 @@ PARAM_DEFINE_INT32(CAL_ACC0_EN, 1);
 /**
  * Accelerometer X-axis offset
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(CAL_ACC0_XOFF, 0.0f);
@@ -56,6 +59,7 @@ PARAM_DEFINE_FLOAT(CAL_ACC0_XOFF, 0.0f);
 /**
  * Accelerometer Y-axis offset
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(CAL_ACC0_YOFF, 0.0f);
@@ -63,6 +67,7 @@ PARAM_DEFINE_FLOAT(CAL_ACC0_YOFF, 0.0f);
 /**
  * Accelerometer Z-axis offset
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(CAL_ACC0_ZOFF, 0.0f);
@@ -70,6 +75,7 @@ PARAM_DEFINE_FLOAT(CAL_ACC0_ZOFF, 0.0f);
 /**
  * Accelerometer X-axis scaling factor
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(CAL_ACC0_XSCALE, 1.0f);
@@ -77,6 +83,7 @@ PARAM_DEFINE_FLOAT(CAL_ACC0_XSCALE, 1.0f);
 /**
  * Accelerometer Y-axis scaling factor
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(CAL_ACC0_YSCALE, 1.0f);
@@ -84,6 +91,7 @@ PARAM_DEFINE_FLOAT(CAL_ACC0_YSCALE, 1.0f);
 /**
  * Accelerometer Z-axis scaling factor
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(CAL_ACC0_ZSCALE, 1.0f);

--- a/src/modules/sensors/sensor_params_acc1.c
+++ b/src/modules/sensors/sensor_params_acc1.c
@@ -34,6 +34,7 @@
 /**
  * ID of the Accelerometer that the calibration is for.
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_INT32(CAL_ACC1_ID, 0);
@@ -42,6 +43,7 @@ PARAM_DEFINE_INT32(CAL_ACC1_ID, 0);
  * Accelerometer 1 enabled
  *
  * @boolean
+ * @category developer
  * @group Sensor Calibration
  */
 PARAM_DEFINE_INT32(CAL_ACC1_EN, 1);
@@ -49,6 +51,7 @@ PARAM_DEFINE_INT32(CAL_ACC1_EN, 1);
 /**
  * Accelerometer X-axis offset
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(CAL_ACC1_XOFF, 0.0f);
@@ -56,6 +59,7 @@ PARAM_DEFINE_FLOAT(CAL_ACC1_XOFF, 0.0f);
 /**
  * Accelerometer Y-axis offset
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(CAL_ACC1_YOFF, 0.0f);
@@ -63,6 +67,7 @@ PARAM_DEFINE_FLOAT(CAL_ACC1_YOFF, 0.0f);
 /**
  * Accelerometer Z-axis offset
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(CAL_ACC1_ZOFF, 0.0f);
@@ -70,6 +75,7 @@ PARAM_DEFINE_FLOAT(CAL_ACC1_ZOFF, 0.0f);
 /**
  * Accelerometer X-axis scaling factor
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(CAL_ACC1_XSCALE, 1.0f);
@@ -77,6 +83,7 @@ PARAM_DEFINE_FLOAT(CAL_ACC1_XSCALE, 1.0f);
 /**
  * Accelerometer Y-axis scaling factor
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(CAL_ACC1_YSCALE, 1.0f);
@@ -84,6 +91,7 @@ PARAM_DEFINE_FLOAT(CAL_ACC1_YSCALE, 1.0f);
 /**
  * Accelerometer Z-axis scaling factor
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(CAL_ACC1_ZSCALE, 1.0f);

--- a/src/modules/sensors/sensor_params_acc2.c
+++ b/src/modules/sensors/sensor_params_acc2.c
@@ -34,6 +34,7 @@
 /**
  * ID of the Accelerometer that the calibration is for.
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_INT32(CAL_ACC2_ID, 0);
@@ -42,6 +43,7 @@ PARAM_DEFINE_INT32(CAL_ACC2_ID, 0);
  * Accelerometer 2 enabled
  *
  * @boolean
+ * @category developer
  * @group Sensor Calibration
  */
 PARAM_DEFINE_INT32(CAL_ACC2_EN, 1);
@@ -49,6 +51,7 @@ PARAM_DEFINE_INT32(CAL_ACC2_EN, 1);
 /**
  * Accelerometer X-axis offset
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(CAL_ACC2_XOFF, 0.0f);
@@ -56,6 +59,7 @@ PARAM_DEFINE_FLOAT(CAL_ACC2_XOFF, 0.0f);
 /**
  * Accelerometer Y-axis offset
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(CAL_ACC2_YOFF, 0.0f);
@@ -63,6 +67,7 @@ PARAM_DEFINE_FLOAT(CAL_ACC2_YOFF, 0.0f);
 /**
  * Accelerometer Z-axis offset
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(CAL_ACC2_ZOFF, 0.0f);
@@ -70,6 +75,7 @@ PARAM_DEFINE_FLOAT(CAL_ACC2_ZOFF, 0.0f);
 /**
  * Accelerometer X-axis scaling factor
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(CAL_ACC2_XSCALE, 1.0f);
@@ -77,6 +83,7 @@ PARAM_DEFINE_FLOAT(CAL_ACC2_XSCALE, 1.0f);
 /**
  * Accelerometer Y-axis scaling factor
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(CAL_ACC2_YSCALE, 1.0f);
@@ -84,6 +91,7 @@ PARAM_DEFINE_FLOAT(CAL_ACC2_YSCALE, 1.0f);
 /**
  * Accelerometer Z-axis scaling factor
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(CAL_ACC2_ZSCALE, 1.0f);

--- a/src/modules/sensors/sensor_params_accel.c
+++ b/src/modules/sensors/sensor_params_accel.c
@@ -34,6 +34,7 @@
 /**
  * Primary accel ID
  *
+ * @category system
  * @group Sensor Calibration
  */
 PARAM_DEFINE_INT32(CAL_ACC_PRIME, 0);

--- a/src/modules/systemlib/circuit_breaker_params.c
+++ b/src/modules/systemlib/circuit_breaker_params.c
@@ -52,6 +52,7 @@
  * @reboot_required true
  * @min 0
  * @max 894281
+ * @category Developer
  * @group Circuit Breaker
  */
 PARAM_DEFINE_INT32(CBRK_SUPPLY_CHK, 0);
@@ -66,6 +67,7 @@ PARAM_DEFINE_INT32(CBRK_SUPPLY_CHK, 0);
  * @reboot_required true
  * @min 0
  * @max 140253
+ * @category Developer
  * @group Circuit Breaker
  */
 PARAM_DEFINE_INT32(CBRK_RATE_CTRL, 0);
@@ -79,6 +81,7 @@ PARAM_DEFINE_INT32(CBRK_RATE_CTRL, 0);
  * @reboot_required true
  * @min 0
  * @max 22027
+ * @category Developer
  * @group Circuit Breaker
  */
 PARAM_DEFINE_INT32(CBRK_IO_SAFETY, 0);
@@ -92,6 +95,7 @@ PARAM_DEFINE_INT32(CBRK_IO_SAFETY, 0);
  * @reboot_required true
  * @min 0
  * @max 162128
+ * @category Developer
  * @group Circuit Breaker
  */
 PARAM_DEFINE_INT32(CBRK_AIRSPD_CHK, 0);
@@ -106,6 +110,7 @@ PARAM_DEFINE_INT32(CBRK_AIRSPD_CHK, 0);
  * @reboot_required true
  * @min 0
  * @max 121212
+ * @category Developer
  * @group Circuit Breaker
  */
 PARAM_DEFINE_INT32(CBRK_FLIGHTTERM, 121212);
@@ -121,6 +126,7 @@ PARAM_DEFINE_INT32(CBRK_FLIGHTTERM, 121212);
  * @reboot_required true
  * @min 0
  * @max 284953
+ * @category Developer
  * @group Circuit Breaker
  */
 PARAM_DEFINE_INT32(CBRK_ENGINEFAIL, 284953);
@@ -138,6 +144,7 @@ PARAM_DEFINE_INT32(CBRK_ENGINEFAIL, 284953);
  * @reboot_required true
  * @min 0
  * @max 240024
+ * @category Developer
  * @group Circuit Breaker
  */
 PARAM_DEFINE_INT32(CBRK_GPSFAIL, 0);
@@ -152,6 +159,7 @@ PARAM_DEFINE_INT32(CBRK_GPSFAIL, 0);
  * @reboot_required true
  * @min 0
  * @max 782097
+ * @category Developer
  * @group Circuit Breaker
  */
 PARAM_DEFINE_INT32(CBRK_BUZZER, 0);
@@ -166,6 +174,7 @@ PARAM_DEFINE_INT32(CBRK_BUZZER, 0);
  * @reboot_required true
  * @min 0
  * @max 197848
+ * @category Developer
  * @group Circuit Breaker
  */
 PARAM_DEFINE_INT32(CBRK_USB_CHK, 0);
@@ -180,6 +189,7 @@ PARAM_DEFINE_INT32(CBRK_USB_CHK, 0);
  * @reboot_required true
  * @min 0
  * @max 201607
+ * @category Developer
  * @group Circuit Breaker
  */
 PARAM_DEFINE_INT32(CBRK_VELPOSERR, 0);

--- a/src/modules/systemlib/param/CMakeLists.txt
+++ b/src/modules/systemlib/param/CMakeLists.txt
@@ -78,7 +78,7 @@ add_custom_command(OUTPUT ${parameters_xml}
 		--inject-xml ${CMAKE_CURRENT_SOURCE_DIR}/parameters_injected.xml
 		--overrides ${PARAM_DEFAULT_OVERRIDES}
 		#--verbose
-	DEPENDS ${param_src_files} px_process_params.py px4params/srcparser.py px4params/srcscanner.py parameters_injected.xml
+	DEPENDS ${param_src_files} px_process_params.py px4params/srcparser.py px4params/srcscanner.py px4params/xmlout.py parameters_injected.xml
 	COMMENT "Generating parameters.xml"
 )
 add_custom_target(parameters_xml DEPENDS ${parameters_xml})

--- a/src/modules/systemlib/param/CMakeLists.txt
+++ b/src/modules/systemlib/param/CMakeLists.txt
@@ -78,7 +78,7 @@ add_custom_command(OUTPUT ${parameters_xml}
 		--inject-xml ${CMAKE_CURRENT_SOURCE_DIR}/parameters_injected.xml
 		--overrides ${PARAM_DEFAULT_OVERRIDES}
 		#--verbose
-	DEPENDS ${param_src_files} px_process_params.py parameters_injected.xml
+	DEPENDS ${param_src_files} px_process_params.py px4params/srcparser.py px4params/srcscanner.py parameters_injected.xml
 	COMMENT "Generating parameters.xml"
 )
 add_custom_target(parameters_xml DEPENDS ${parameters_xml})

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -149,6 +149,7 @@ FLASH_PARAMS_EXPOSE const UT_icd    param_icd = {sizeof(struct param_wbuf_s), NU
 #if !defined(PARAM_NO_ORB)
 /** parameter update topic handle */
 static orb_advert_t param_topic = NULL;
+static unsigned int param_instance = 0;
 #endif
 
 static void param_set_used_internal(param_t param);
@@ -302,7 +303,7 @@ _param_notify_changes(void)
 #if !defined(PARAM_NO_ORB)
 	struct parameter_update_s pup = {
 		.timestamp = hrt_absolute_time(),
-		.dummy = 0
+		.instance = param_instance++,
 	};
 
 	/*

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2015 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -490,6 +490,12 @@ param_name(param_t param)
 }
 
 bool
+param_is_volatile(param_t param)
+{
+	return handle_in_range(param) ? param_info_base[param].volatile_param : false;
+}
+
+bool
 param_value_is_default(param_t param)
 {
 	struct param_wbuf_s *s;
@@ -510,8 +516,9 @@ param_value_unsaved(param_t param)
 	return ret;
 }
 
-enum param_type_e
-param_type(param_t param) {
+param_type_t
+param_type(param_t param)
+{
 	return handle_in_range(param) ? param_info_base[param].type : PARAM_TYPE_UNKNOWN;
 }
 
@@ -679,7 +686,6 @@ param_control_autosave(bool enable)
 	param_unlock_writer();
 #endif /* PARAM_NO_AUTOSAVE */
 }
-
 
 static int
 param_set_internal(param_t param, const void *val, bool mark_saved, bool notify_changes)
@@ -1357,7 +1363,7 @@ uint32_t param_hash_check(void)
 
 	/* compute the CRC32 over all string param names and 4 byte values */
 	for (param_t param = 0; handle_in_range(param); param++) {
-		if (!param_used(param)) {
+		if (!param_used(param) && param_is_volatile(param)) {
 			continue;
 		}
 

--- a/src/modules/systemlib/param/param.h
+++ b/src/modules/systemlib/param/param.h
@@ -50,24 +50,20 @@
 #include <sys/types.h>
 
 /** Maximum size of the parameter backing file */
-#define PARAM_FILE_MAXSIZE	4096
+#define PARAM_FILE_MAXSIZE		4096
 
 __BEGIN_DECLS
 
 /**
  * Parameter types.
  */
-typedef enum param_type_e {
-	/* globally-known parameter types */
-	PARAM_TYPE_INT32 = 0,
-	PARAM_TYPE_FLOAT,
+#define PARAM_TYPE_INT32		0
+#define PARAM_TYPE_FLOAT		1
+#define PARAM_TYPE_STRUCT		100
+#define PARAM_TYPE_STRUCT_MAX	(16384 + PARAM_TYPE_STRUCT)
+#define PARAM_TYPE_UNKNOWN		(0xffff)
 
-	/* structure parameters; size is encoded in the type value */
-	PARAM_TYPE_STRUCT = 100,
-	PARAM_TYPE_STRUCT_MAX = 16384 + PARAM_TYPE_STRUCT,
-
-	PARAM_TYPE_UNKNOWN = 0xffff
-} param_type_t;
+typedef uint16_t param_type_t;
 
 
 #ifdef __PX4_NUTTX // on NuttX use 16 bits to save RAM
@@ -199,6 +195,14 @@ __EXPORT int		param_get_used_index(param_t param);
 __EXPORT const char	*param_name(param_t param);
 
 /**
+ * Obtain the volatile state of a parameter.
+ *
+ * @param param		A handle returned by param_find or passed by param_foreach.
+ * @return			true if the parameter is volatile
+ */
+__EXPORT bool		param_is_volatile(param_t param);
+
+/**
  * Test whether a parameter's value has changed from the default.
  *
  * @return		If true, the parameter's value has not been changed from the default.
@@ -262,7 +266,7 @@ __EXPORT int		param_set_no_notification(param_t param, const void *val);
  * Notify the system about parameter changes. Can be used for example after several calls to
  * param_set_no_notification() to avoid unnecessary system notifications.
  */
-__EXPORT void param_notify_changes(void);
+__EXPORT void		param_notify_changes(void);
 
 /**
  * Reset a parameter to its default value.
@@ -281,7 +285,6 @@ __EXPORT int		param_reset(param_t param);
  * This function also releases the storage used by struct parameters.
  */
 __EXPORT void		param_reset_all(void);
-
 
 /**
  * Reset all parameters to their default values except for excluded parameters.
@@ -446,6 +449,7 @@ struct param_info_s {
 	;
 #endif
 	param_type_t	type;
+	uint16_t		volatile_param: 1;
 	union param_value_u val;
 };
 

--- a/src/modules/systemlib/param/param_shmem.c
+++ b/src/modules/systemlib/param/param_shmem.c
@@ -128,6 +128,7 @@ extern void copy_params_to_shmem(struct param_info_s *param_info_base);
 
 extern struct shmem_info *shmem_info_p;
 uint64_t sync_other_prev_time = 0, sync_other_current_time = 0;
+int param_instance = 0;
 
 extern void update_to_shmem(param_t param, union param_value_u value);
 extern int update_from_shmem(param_t param, union param_value_u *value);
@@ -269,7 +270,7 @@ param_find_changed(param_t param)
 static void
 _param_notify_changes(void)
 {
-	struct parameter_update_s pup = { .timestamp = hrt_absolute_time(), .dummy = 0 };
+	struct parameter_update_s pup = { .timestamp = hrt_absolute_time(), .instance = param_instance++ };
 
 	/*
 	 * If we don't have a handle to our topic, create one now; otherwise
@@ -469,8 +470,9 @@ param_value_unsaved(param_t param)
 	return ret;
 }
 
-enum param_type_e
-param_type(param_t param) {
+param_type_t
+param_type(param_t param)
+{
 	return handle_in_range(param) ? param_info_base[param].type : PARAM_TYPE_UNKNOWN;
 }
 

--- a/src/modules/systemlib/param/px4params/srcparser.py
+++ b/src/modules/systemlib/param/px4params/srcparser.py
@@ -155,7 +155,7 @@ class SourceParser(object):
     re_remove_dots = re.compile(r'\.+$')
     re_remove_carriage_return = re.compile('\n+')
 
-    valid_tags = set(["group", "board", "min", "max", "unit", "decimal", "increment", "reboot_required", "value", "boolean", "bit"])
+    valid_tags = set(["group", "board", "min", "max", "unit", "decimal", "increment", "reboot_required", "value", "boolean", "bit", "level", "volatile"])
 
     # Order of parameter groups
     priority = {

--- a/src/modules/systemlib/param/px4params/srcparser.py
+++ b/src/modules/systemlib/param/px4params/srcparser.py
@@ -57,6 +57,7 @@ class Parameter(object):
         self.name = name
         self.type = type
         self.default = default
+        self.volatile = "false"
 
     def GetName(self):
         return self.name
@@ -66,6 +67,9 @@ class Parameter(object):
 
     def GetDefault(self):
         return self.default
+
+    def GetVolatile(self):
+        return self.volatile
 
     def SetField(self, code, value):
         """
@@ -84,6 +88,12 @@ class Parameter(object):
         Set named enum value
         """
         self.bitmask[index] = bit
+
+    def SetVolatile(self):
+        """
+        Set volatile flag
+        """
+        self.volatile = "true"
 
     def GetFieldCodes(self):
         """
@@ -282,6 +292,8 @@ class SourceParser(object):
                         for tag in tags:
                             if tag == "group":
                                 group = tags[tag]
+                            elif tag == "volatile":
+                                param.SetVolatile()
                             elif tag not in self.valid_tags:
                                 sys.stderr.write("Skipping invalid documentation tag: '%s'\n" % tag)
                                 return False
@@ -332,6 +344,9 @@ class SourceParser(object):
                 if default != "" and not self.IsNumber(default):
                     sys.stderr.write("Default value not number: {0} {1}\n".format(name, default))
                     return False
+                # if default != "" and "." not in default:
+                #     sys.stderr.write("Default value does not contain dot (e.g. 10 needs to be written as 10.0): {0} {1}\n".format(name, default))
+                #     return False
                 if min != "":
                     if not self.IsNumber(min):
                         sys.stderr.write("Min value not number: {0} {1}\n".format(name, min))

--- a/src/modules/systemlib/param/px4params/srcparser.py
+++ b/src/modules/systemlib/param/px4params/srcparser.py
@@ -58,6 +58,7 @@ class Parameter(object):
         self.type = type
         self.default = default
         self.volatile = "false"
+        self.category = ""
 
     def GetName(self):
         return self.name
@@ -67,6 +68,9 @@ class Parameter(object):
 
     def GetDefault(self):
         return self.default
+
+    def GetCategory(self):
+        return self.category.title()
 
     def GetVolatile(self):
         return self.volatile
@@ -94,6 +98,12 @@ class Parameter(object):
         Set volatile flag
         """
         self.volatile = "true"
+
+    def SetCategory(self, category):
+        """
+        Set param category
+        """
+        self.category = category
 
     def GetFieldCodes(self):
         """
@@ -165,7 +175,7 @@ class SourceParser(object):
     re_remove_dots = re.compile(r'\.+$')
     re_remove_carriage_return = re.compile('\n+')
 
-    valid_tags = set(["group", "board", "min", "max", "unit", "decimal", "increment", "reboot_required", "value", "boolean", "bit", "level", "volatile"])
+    valid_tags = set(["group", "board", "min", "max", "unit", "decimal", "increment", "reboot_required", "value", "boolean", "bit", "category", "volatile"])
 
     # Order of parameter groups
     priority = {
@@ -294,6 +304,8 @@ class SourceParser(object):
                                 group = tags[tag]
                             elif tag == "volatile":
                                 param.SetVolatile()
+                            elif tag == "category":
+                                param.SetCategory(tags[tag])
                             elif tag not in self.valid_tags:
                                 sys.stderr.write("Skipping invalid documentation tag: '%s'\n" % tag)
                                 return False

--- a/src/modules/systemlib/param/px4params/xmlout.py
+++ b/src/modules/systemlib/param/px4params/xmlout.py
@@ -41,7 +41,10 @@ class XMLOutput():
                     xml_param.attrib["name"] = param.GetName()
                     xml_param.attrib["default"] = param.GetDefault()
                     xml_param.attrib["type"] = param.GetType()
-                    xml_param.attrib["volatile"] = param.GetVolatile()
+                    if (param.GetVolatile() == "true"):
+                        xml_param.attrib["volatile"] = param.GetVolatile()
+                    if (param.GetCategory()):
+                        xml_param.attrib["category"] = param.GetCategory()
                     last_param_name = param.GetName()
                     for code in param.GetFieldCodes():
                         value = param.GetFieldValue(code)

--- a/src/modules/systemlib/param/px4params/xmlout.py
+++ b/src/modules/systemlib/param/px4params/xmlout.py
@@ -41,6 +41,7 @@ class XMLOutput():
                     xml_param.attrib["name"] = param.GetName()
                     xml_param.attrib["default"] = param.GetDefault()
                     xml_param.attrib["type"] = param.GetType()
+                    xml_param.attrib["volatile"] = param.GetVolatile()
                     last_param_name = param.GetName()
                     for code in param.GetFieldCodes():
                         value = param.GetFieldValue(code)

--- a/src/modules/systemlib/param/templates/px4_parameters.c.jinja
+++ b/src/modules/systemlib/param/templates/px4_parameters.c.jinja
@@ -16,6 +16,11 @@ struct px4_parameters_t px4_parameters = {
 	{
 		"{{ param.attrib["name"] }}",
 		PARAM_TYPE_{{ param.attrib["type"] }},
+	{%- if param.attrib["volatile"] == "true" %}
+		.volatile_param = 1,
+	{%- else %}
+		.volatile_param = 0,
+	{%- endif %}
 	{%- if param.attrib["type"] == "FLOAT" %}
 		.val.f = {{ param.attrib["default"] }}
 	{%- elif param.attrib["type"] == "INT32" %}

--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -87,6 +87,8 @@ PARAM_DEFINE_INT32(SYS_HITL, 0);
  * @value 0 Data survives resets
  * @value 1 Data survives in-flight resets only
  * @value 2 Data does not survive reset
+ * @category system
+ * @volatile
  * @group System
  */
 PARAM_DEFINE_INT32(SYS_RESTART_TYPE, 2);

--- a/src/systemcmds/reboot/reboot.c
+++ b/src/systemcmds/reboot/reboot.c
@@ -1,7 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2012 PX4 Development Team. All rights reserved.
- *   Author: @author Lorenz Meier <lm@inf.ethz.ch>
+ *   Copyright (c) 2012-2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,6 +34,8 @@
 /**
  * @file reboot.c
  * Tool similar to UNIX reboot command
+ *
+ * @author Lorenz Meier <lorenz@px4.io>
  */
 
 #include <px4_config.h>


### PR DESCRIPTION
This PR brings a few fundamental improvements to the param system to update it to today's usage:

  * Support for async changes: Anything happening on the vehicle will now be reflected to the GCS
  * Support for volatile parameters, which are now not any more forcing a complete list re-transfer
  * Support for categories, which allows to convey an intent to the user about what they should be able to change and what not.

I also cleaned up minor things along the way, some of which might make UAVCAN params more reliable.

<img width="1120" alt="screen shot 2018-01-07 at 20 16 12" src="https://user-images.githubusercontent.com/1208119/34653286-2df14600-f3ea-11e7-82ed-311eaa1b9c8a.png">
