### PR TITLE
Reduce default memory usage (SYS_COMPANION off by default)

### DIFF
--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -131,7 +131,7 @@ PARAM_DEFINE_INT32(SYS_MC_EST_GROUP, 2);
  * @reboot_required true
  * @group System
  */
-PARAM_DEFINE_INT32(SYS_COMPANION, 157600);
+PARAM_DEFINE_INT32(SYS_COMPANION, 0);
 
 /**
  * Parameter version


### PR DESCRIPTION
Unless anyone strongly objects I think we shouldn't enable mavlink on telem2 (SYS_COMPANION) by default for now. It's still too easy for a regular user to run out of memory in a default setup.

![image](https://user-images.githubusercontent.com/84712/34656229-97156cc0-f3e4-11e7-815a-716140d75e5a.png)


Next things to prioritize
 - getting calibration out of commander and removing the low priority thread (https://github.com/PX4/Firmware/pull/8200)
 - consider determining the logger buffer size at the end of bootup based on actual RAM availability
 - maybe there are other things we can do when calibration is requested to ensure resources are available?

We can consider reverting this change later if things ease up a bit.
  
  