### PR TITLE
MultirotorMixer: Apply thrust gain independently from other axes

### DIFF
--- a/src/lib/mixer/geometries/tools/px_generate_mixers.py
+++ b/src/lib/mixer/geometries/tools/px_generate_mixers.py
@@ -195,6 +195,7 @@ def normalize_mix_px4(B):
     '''
     B_norm = np.linalg.norm(B, axis=0)
     B_max = np.abs(B).max(axis=0)
+    B_sum = np.sum(B, axis=0)
 
     # Same scale on roll and pitch
     B_norm[0] = max(B_norm[0], B_norm[1]) / np.sqrt(B.shape[0] / 2.0)
@@ -208,7 +209,7 @@ def normalize_mix_px4(B):
     B_norm[4] = B_norm[3]
 
     # Scale z thrust separately
-    B_norm[5] = B_max[5]
+    B_norm[5] = - B_sum[5] / np.count_nonzero(B[:,5])
 
     # Normalize
     B_norm[np.abs(B_norm) < 1e-3] = 1

--- a/src/lib/mixer/mixer.h
+++ b/src/lib/mixer/mixer.h
@@ -546,10 +546,10 @@ public:
 	 * Precalculated rotor mix.
 	 */
 	struct Rotor {
-		float	roll_scale;	/**< scales roll for this rotor */
+		float	roll_scale;		/**< scales roll for this rotor */
 		float	pitch_scale;	/**< scales pitch for this rotor */
-		float	yaw_scale;	/**< scales yaw for this rotor */
-		float	out_scale;	/**< scales total out for this rotor */
+		float	yaw_scale;		/**< scales yaw for this rotor */
+		float	thrust_scale;	/**< scales thrust for this rotor */
 	};
 
 	/**


### PR DESCRIPTION
Align the way motor output is computed with the model used in the mixer generation script.
previous:
`out = (roll_gain*roll + pitch_gain*pitch + yaw_gain*yaw + thrust)*out_gain`
new:
`out = roll_gain*roll + pitch_gain*pitch + yaw_gain*yaw + thrust_gain*thrust`
which is the standard matrix*vector multiplication.

This commit has 0 effect on symmetric platforms (i.e. most) as thrust_gain==1 on these platforms.
On asymmetric platform --where some thrust_gain are lower than 1-- the previous formulation resulted in coupling between thrust and other axes.

fixes #8628