### PR TITLE
vision position covariance usage

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -861,8 +861,11 @@ void Ekf2::run()
 			ev_data.posErr = fmaxf(_ev_pos_noise.get(), fmaxf(ev_pos.eph, ev_pos.epv));
 			ev_data.angErr = _ev_ang_noise.get();
 
-			// use timestamp from external computer, clocks are synchronized when using MAVROS
-			_ekf.setExtVisionData(vision_position_updated ? ev_pos.timestamp : ev_att.timestamp, &ev_data);
+			// only set data if all positions and velocities are valid
+			if (ev_pos.xy_valid && ev_pos.z_valid && ev_pos.v_xy_valid && ev_pos.v_z_valid) {
+				// use timestamp from external computer, clocks are synchronized when using MAVROS
+				_ekf.setExtVisionData(vision_position_updated ? ev_pos.timestamp : ev_att.timestamp, &ev_data);
+			}
 		}
 
 		orb_check(vehicle_land_detected_sub, &vehicle_land_detected_updated);

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -858,7 +858,7 @@ void Ekf2::run()
 			ev_data.quat = q;
 
 			// position measurement error from parameters. TODO : use covariances from topic
-			ev_data.posErr = _ev_pos_noise.get();
+			ev_data.posErr = fmaxf(_ev_pos_noise.get(), fmaxf(ev_pos.eph, ev_pos.epv));
 			ev_data.angErr = _ev_ang_noise.get();
 
 			// use timestamp from external computer, clocks are synchronized when using MAVROS

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1135,6 +1135,25 @@ MavlinkReceiver::handle_message_local_position_ned_cov(mavlink_message_t *msg)
 	vision_position.eph = sqrtf(fmaxf(pos.covariance[0], pos.covariance[9]));
 	vision_position.epv = sqrtf(pos.covariance[17]);
 
+	// set position/velocity invalid if standard deviation is bigger than ev_max_std_dev
+	const float ev_max_std_dev = 100.0f;
+
+	if (vision_position.eph > ev_max_std_dev) {
+		vision_position.xy_valid = false;
+	}
+
+	if (sqrtf(fmaxf(pos.covariance[24], pos.covariance[30])) > ev_max_std_dev) {
+		vision_position.v_xy_valid = false;
+	}
+
+	if (vision_position.epv > ev_max_std_dev) {
+		vision_position.z_valid = false;
+	}
+
+	if (sqrtf(pos.covariance[35]) > ev_max_std_dev) {
+		vision_position.v_z_valid = false;
+	}
+
 	vision_position.xy_global = globallocalconverter_initialized();
 	vision_position.z_global = globallocalconverter_initialized();
 	vision_position.ref_timestamp = _global_ref_timestamp;

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -1111,6 +1111,11 @@ int Simulator::publish_ev_topic(mavlink_vision_position_estimate_t *ev_mavlink)
 	vision_position.y = ev_mavlink->y;
 	vision_position.z = ev_mavlink->z;
 
+	vision_position.xy_valid = true;
+	vision_position.z_valid = true;
+	vision_position.v_xy_valid = true;
+	vision_position.v_z_valid = true;
+
 	struct vehicle_attitude_s vision_attitude = {};
 
 	vision_attitude.timestamp = timestamp;


### PR DESCRIPTION
I added the validation parameters in the `vehicle_vision_position` to signalize the EKF2 if it should use it. Currently I use the `eph/epv` parameters for passing through noise parameters and a threshold of `100` to set it valid/invalid.
@priseborough thoughts?