### PR TITLE
improve mavros SITL tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -358,7 +358,7 @@ pipeline {
             sh 'git fetch --tags'
             sh 'make posix_sitl_default'
             sh 'make posix_sitl_default sitl_gazebo'
-            sh './test/rostest_px4_run.sh mavros_posix_test_mission.test mission:=vtol_new_1.txt vehicle:=vtol_standard'
+            sh './test/rostest_px4_run.sh mavros_posix_test_mission.test mission:=vtol_new_1.txt vehicle:=standard_vtol'
           }
           post {
             success {
@@ -391,7 +391,7 @@ pipeline {
             sh 'git fetch --tags'
             sh 'make posix_sitl_default'
             sh 'make posix_sitl_default sitl_gazebo'
-            sh './test/rostest_px4_run.sh mavros_posix_test_mission.test mission:=vtol_new_2.txt vehicle:=vtol_standard'
+            sh './test/rostest_px4_run.sh mavros_posix_test_mission.test mission:=vtol_new_2.txt vehicle:=standard_vtol'
           }
           post {
             success {
@@ -424,7 +424,7 @@ pipeline {
             sh 'git fetch --tags'
             sh 'make posix_sitl_default'
             sh 'make posix_sitl_default sitl_gazebo'
-            sh './test/rostest_px4_run.sh mavros_posix_test_mission.test mission:=vtol_old_1.txt vehicle:=vtol_standard'
+            sh './test/rostest_px4_run.sh mavros_posix_test_mission.test mission:=vtol_old_1.txt vehicle:=standard_vtol'
           }
           post {
             success {
@@ -457,7 +457,7 @@ pipeline {
             sh 'git fetch --tags'
             sh 'make posix_sitl_default'
             sh 'make posix_sitl_default sitl_gazebo'
-            sh './test/rostest_px4_run.sh mavros_posix_test_mission.test mission:=vtol_old_2.txt vehicle:=vtol_standard'
+            sh './test/rostest_px4_run.sh mavros_posix_test_mission.test mission:=vtol_old_2.txt vehicle:=standard_vtol'
           }
           post {
             success {
@@ -490,7 +490,7 @@ pipeline {
             sh 'git fetch --tags'
             sh 'make posix_sitl_default'
             sh 'make posix_sitl_default sitl_gazebo'
-            sh './test/rostest_px4_run.sh mavros_posix_test_mission.test mission:=vtol_old_3.txt vehicle:=vtol_standard'
+            sh './test/rostest_px4_run.sh mavros_posix_test_mission.test mission:=vtol_old_3.txt vehicle:=standard_vtol'
           }
           post {
             success {

--- a/integrationtests/python_src/px4_it/mavros/mavros_offboard_posctl_test.py
+++ b/integrationtests/python_src/px4_it/mavros/mavros_offboard_posctl_test.py
@@ -41,19 +41,18 @@ from __future__ import division
 
 PKG = 'px4'
 
-import unittest
 import rospy
 import math
 import numpy as np
+from geometry_msgs.msg import PoseStamped, Quaternion
+from mavros_msgs.msg import ExtendedState
+from mavros_test_common import MavrosTestCommon
+from std_msgs.msg import Header
 from threading import Thread
 from tf.transformations import quaternion_from_euler
-from geometry_msgs.msg import PoseStamped, Quaternion
-from mavros_msgs.msg import HomePosition, State
-from mavros_msgs.srv import CommandBool, SetMode
-from std_msgs.msg import Header
 
 
-class MavrosOffboardPosctlTest(unittest.TestCase):
+class MavrosOffboardPosctlTest(MavrosTestCommon):
     """
     Tests flying a path in offboard control by sending position setpoints
     via MAVROS.
@@ -64,34 +63,13 @@ class MavrosOffboardPosctlTest(unittest.TestCase):
     """
 
     def setUp(self):
-        self.local_position = PoseStamped()
-        self.state = State()
+        super(MavrosOffboardPosctlTest, self).setUp()
+
         self.pos = PoseStamped()
-        self.sub_topics_ready = {
-            key: False
-            for key in ['local_pos', 'home_pos', 'state']
-        }
+        self.radius = 1
 
-        # setup ROS topics and services
-        try:
-            rospy.wait_for_service('mavros/cmd/arming', 30)
-            rospy.wait_for_service('mavros/set_mode', 30)
-        except rospy.ROSException:
-            self.fail("failed to connect to mavros services")
-
-        self.set_arming_srv = rospy.ServiceProxy('/mavros/cmd/arming',
-                                                 CommandBool)
-        self.set_mode_srv = rospy.ServiceProxy('/mavros/set_mode', SetMode)
-        self.local_pos_sub = rospy.Subscriber('mavros/local_position/pose',
-                                              PoseStamped,
-                                              self.local_position_callback)
-        self.home_pos_sub = rospy.Subscriber('mavros/home_position/home',
-                                             HomePosition,
-                                             self.home_position_callback)
-        self.state_sub = rospy.Subscriber('mavros/state', State,
-                                          self.state_callback)
         self.pos_setpoint_pub = rospy.Publisher(
-            'mavros/setpoint_position/local', PoseStamped, queue_size=10)
+            'mavros/setpoint_position/local', PoseStamped, queue_size=1)
 
         # send setpoints in seperate thread to better prevent failsafe
         self.pos_thread = Thread(target=self.send_pos, args=())
@@ -100,29 +78,6 @@ class MavrosOffboardPosctlTest(unittest.TestCase):
 
     def tearDown(self):
         pass
-
-    #
-    # Callback functions
-    #
-    def local_position_callback(self, data):
-        self.local_position = data
-
-        if not self.sub_topics_ready['local_pos']:
-            self.sub_topics_ready['local_pos'] = True
-
-    def home_position_callback(self, data):
-        # this topic publishing seems to be a better indicator that the sim
-        # is ready, it's not actually needed
-        self.home_pos_sub.unregister()
-
-        if not self.sub_topics_ready['home_pos']:
-            self.sub_topics_ready['home_pos'] = True
-
-    def state_callback(self, data):
-        self.state = data
-
-        if not self.sub_topics_ready['state']:
-            self.sub_topics_ready['state'] = True
 
     #
     # Helper methods
@@ -140,85 +95,12 @@ class MavrosOffboardPosctlTest(unittest.TestCase):
             except rospy.ROSInterruptException:
                 pass
 
-    def set_mode(self, mode, timeout):
-        """mode: PX4 mode string, timeout(int): seconds"""
-        old_mode = self.state.mode
-        loop_freq = 1  # Hz
-        rate = rospy.Rate(loop_freq)
-        mode_set = False
-        for i in xrange(timeout * loop_freq):
-            if self.state.mode == mode:
-                mode_set = True
-                rospy.loginfo(
-                    "set mode success | new mode: {0}, old mode: {1} | seconds: {2} of {3}".
-                    format(mode, old_mode, i / loop_freq, timeout))
-                break
-            else:
-                try:
-                    res = self.set_mode_srv(0, mode)  # 0 is custom mode
-                    if not res.mode_sent:
-                        rospy.logerr("failed to send mode command")
-                except rospy.ServiceException as e:
-                    rospy.logerr(e)
-
-            rate.sleep()
-
-        self.assertTrue(mode_set, (
-            "failed to set mode | new mode: {0}, old mode: {1} | timeout(seconds): {2}".
-            format(mode, self.state.mode, timeout)))
-
-    def set_arm(self, arm, timeout):
-        """arm: True to arm or False to disarm, timeout(int): seconds"""
-        old_arm = self.state.armed
-        loop_freq = 1  # Hz
-        rate = rospy.Rate(loop_freq)
-        arm_set = False
-        for i in xrange(timeout * loop_freq):
-            if self.state.armed == arm:
-                arm_set = True
-                rospy.loginfo(
-                    "set arm success | new arm: {0}, old arm: {1} | seconds: {2} of {3}".
-                    format(arm, old_arm, i / loop_freq, timeout))
-                break
-            else:
-                try:
-                    res = self.set_arming_srv(arm)
-                    if not res.success:
-                        rospy.logerr("failed to send arm command")
-                except rospy.ServiceException as e:
-                    rospy.logerr(e)
-
-            rate.sleep()
-
-        self.assertTrue(arm_set, (
-            "failed to set arm | new arm: {0}, old arm: {1} | timeout(seconds): {2}".
-            format(arm, self.state.armed, timeout)))
-
-    def wait_for_topics(self, timeout):
-        """wait for simulation to be ready, make sure we're getting topic info
-        from all topics by checking dictionary of flag values set in callbacks,
-        timeout(int): seconds"""
-        rospy.loginfo("waiting for simulation topics to be ready")
-        loop_freq = 1  # Hz
-        rate = rospy.Rate(loop_freq)
-        simulation_ready = False
-        for i in xrange(timeout * loop_freq):
-            if all(value for value in self.sub_topics_ready.values()):
-                simulation_ready = True
-                rospy.loginfo("simulation topics ready | seconds: {0} of {1}".
-                              format(i / loop_freq, timeout))
-                break
-
-            rate.sleep()
-
-        self.assertTrue(simulation_ready, (
-            "failed to hear from all subscribed simulation topics | topic ready flags: {0} | timeout(seconds): {1}".
-            format(self.sub_topics_ready, timeout)))
-
     def is_at_position(self, x, y, z, offset):
-        rospy.logdebug("current position | x:{0}, y:{1}, z:{2}".format(
-            self.local_position.pose.position.x, self.local_position.pose.
-            position.y, self.local_position.pose.position.z))
+        """offset: meters"""
+        rospy.logdebug(
+            "current position | x:{0:.2f}, y:{1:.2f}, z:{2:.2f}".format(
+                self.local_position.pose.position.x, self.local_position.pose.
+                position.y, self.local_position.pose.position.z))
 
         desired = np.array((x, y, z))
         pos = np.array((self.local_position.pose.position.x,
@@ -227,12 +109,16 @@ class MavrosOffboardPosctlTest(unittest.TestCase):
         return np.linalg.norm(desired - pos) < offset
 
     def reach_position(self, x, y, z, timeout):
+        """timeout(int): seconds"""
         # set a position setpoint
         self.pos.pose.position.x = x
         self.pos.pose.position.y = y
         self.pos.pose.position.z = z
-        rospy.loginfo("attempting to reach position | x: {0}, y: {1}, z: {2}".
-                      format(x, y, z))
+        rospy.loginfo(
+            "attempting to reach position | x: {0}, y: {1}, z: {2} | current position x: {3:.2f}, y: {4:.2f}, z: {5:.2f}".
+            format(x, y, z, self.local_position.pose.position.x,
+                   self.local_position.pose.position.y,
+                   self.local_position.pose.position.z))
 
         # For demo purposes we will lock yaw/heading to north.
         yaw_degrees = 0  # North
@@ -241,13 +127,13 @@ class MavrosOffboardPosctlTest(unittest.TestCase):
         self.pos.pose.orientation = Quaternion(*quaternion)
 
         # does it reach the position in 'timeout' seconds?
-        loop_freq = 10  # Hz
+        loop_freq = 2  # Hz
         rate = rospy.Rate(loop_freq)
         reached = False
         for i in xrange(timeout * loop_freq):
             if self.is_at_position(self.pos.pose.position.x,
                                    self.pos.pose.position.y,
-                                   self.pos.pose.position.z, 1):
+                                   self.pos.pose.position.z, self.radius):
                 rospy.loginfo("position reached | seconds: {0} of {1}".format(
                     i / loop_freq, timeout))
                 reached = True
@@ -256,7 +142,7 @@ class MavrosOffboardPosctlTest(unittest.TestCase):
             rate.sleep()
 
         self.assertTrue(reached, (
-            "took too long to get to position | current position x: {0}, y: {1}, z: {2} | timeout(seconds): {3}".
+            "took too long to get to position | current position x: {0:.2f}, y: {1:.2f}, z: {2:.2f} | timeout(seconds): {3}".
             format(self.local_position.pose.position.x,
                    self.local_position.pose.position.y,
                    self.local_position.pose.position.z, timeout)))
@@ -267,12 +153,11 @@ class MavrosOffboardPosctlTest(unittest.TestCase):
     def test_posctl(self):
         """Test offboard position control"""
 
-        # delay starting the mission
-        self.wait_for_topics(30)
+        # make sure the simulation is ready to start the mission
+        self.wait_for_topics(60)
+        self.wait_on_landed_state(ExtendedState.LANDED_STATE_ON_GROUND, 10, -1)
 
-        rospy.loginfo("seting mission mode")
         self.set_mode("OFFBOARD", 5)
-        rospy.loginfo("arming")
         self.set_arm(True, 5)
 
         rospy.loginfo("run mission")
@@ -282,7 +167,6 @@ class MavrosOffboardPosctlTest(unittest.TestCase):
             self.reach_position(positions[i][0], positions[i][1],
                                 positions[i][2], 18)
 
-        rospy.loginfo("disarming")
         self.set_arm(False, 5)
 
 

--- a/integrationtests/python_src/px4_it/mavros/mavros_test_common.py
+++ b/integrationtests/python_src/px4_it/mavros/mavros_test_common.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python2
+from __future__ import division
+
+import unittest
+import rospy
+import math
+from geometry_msgs.msg import PoseStamped
+from mavros_msgs.msg import Altitude, ExtendedState, HomePosition, State, \
+                            WaypointList
+from mavros_msgs.srv import CommandBool, ParamGet, SetMode, WaypointClear, \
+                            WaypointPush
+from sensor_msgs.msg import NavSatFix
+
+
+class MavrosTestCommon(unittest.TestCase):
+    # dictionaries correspond to mavros ExtendedState msg
+    LAND_STATES = {
+        0: 'UNDEFINED',
+        1: 'ON_GROUND',
+        2: 'IN_AIR',
+        3: 'TAKEOFF',
+        4: 'LANDING'
+    }
+    VTOL_STATES = {
+        0: 'VTOL UNDEFINED',
+        1: 'VTOL MC-to-FW',
+        2: 'VTOL FW-to-MC',
+        3: 'VTOL MC',
+        4: 'VTOL FW'
+    }
+
+    def __init__(self, *args):
+        super(MavrosTestCommon, self).__init__(*args)
+
+    def setUp(self):
+        self.altitude = Altitude()
+        self.extended_state = ExtendedState()
+        self.global_position = NavSatFix()
+        self.home_position = HomePosition()
+        self.local_position = PoseStamped()
+        self.mission_wp = WaypointList()
+        self.state = State()
+        self.mav_type = None
+
+        self.sub_topics_ready = {
+            key: False
+            for key in [
+                'alt', 'ext_state', 'global_pos', 'home_pos', 'local_pos',
+                'mission_wp', 'state'
+            ]
+        }
+
+        # ROS services
+        service_timeout = 30
+        rospy.loginfo("waiting for ROS services")
+        try:
+            rospy.wait_for_service('mavros/param/get', service_timeout)
+            rospy.wait_for_service('mavros/cmd/arming', service_timeout)
+            rospy.wait_for_service('mavros/mission/push', service_timeout)
+            rospy.wait_for_service('mavros/mission/clear', service_timeout)
+            rospy.wait_for_service('mavros/set_mode', service_timeout)
+            rospy.loginfo("ROS services are up")
+        except rospy.ROSException:
+            self.fail("failed to connect to services")
+        self.get_param_srv = rospy.ServiceProxy('mavros/param/get', ParamGet)
+        self.set_arming_srv = rospy.ServiceProxy('/mavros/cmd/arming',
+                                                 CommandBool)
+        self.set_mode_srv = rospy.ServiceProxy('mavros/set_mode', SetMode)
+        self.wp_clear_srv = rospy.ServiceProxy('mavros/mission/clear',
+                                               WaypointClear)
+        self.wp_push_srv = rospy.ServiceProxy('mavros/mission/push',
+                                              WaypointPush)
+
+        # ROS subscribers
+        self.alt_sub = rospy.Subscriber('mavros/altitude', Altitude,
+                                        self.altitude_callback)
+        self.ext_state_sub = rospy.Subscriber('mavros/extended_state',
+                                              ExtendedState,
+                                              self.extended_state_callback)
+        self.global_pos_sub = rospy.Subscriber('mavros/global_position/global',
+                                               NavSatFix,
+                                               self.global_position_callback)
+        self.home_pos_sub = rospy.Subscriber('mavros/home_position/home',
+                                             HomePosition,
+                                             self.home_position_callback)
+        self.local_pos_sub = rospy.Subscriber('mavros/local_position/pose',
+                                              PoseStamped,
+                                              self.local_position_callback)
+        self.mission_wp_sub = rospy.Subscriber(
+            'mavros/mission/waypoints', WaypointList, self.mission_wp_callback)
+        self.state_sub = rospy.Subscriber('mavros/state', State,
+                                          self.state_callback)
+
+    #
+    # Callback functions
+    #
+    def altitude_callback(self, data):
+        self.altitude = data
+
+        # amsl has been observed to be nan while other fields are valid
+        if not self.sub_topics_ready['alt'] and not math.isnan(data.amsl):
+            self.sub_topics_ready['alt'] = True
+
+    def extended_state_callback(self, data):
+        if self.extended_state.vtol_state != data.vtol_state:
+            rospy.loginfo("VTOL state changed from {0} to {1}".format(
+                self.VTOL_STATES.get(self.extended_state.vtol_state),
+                self.VTOL_STATES.get(data.vtol_state)))
+
+        if self.extended_state.landed_state != data.landed_state:
+            rospy.loginfo("landed state changed from {0} to {1}".format(
+                self.LAND_STATES.get(self.extended_state.landed_state),
+                self.LAND_STATES.get(data.landed_state)))
+
+        self.extended_state = data
+
+        if not self.sub_topics_ready['ext_state']:
+            self.sub_topics_ready['ext_state'] = True
+
+    def global_position_callback(self, data):
+        self.global_position = data
+
+        if not self.sub_topics_ready['global_pos']:
+            self.sub_topics_ready['global_pos'] = True
+
+    def home_position_callback(self, data):
+        self.home_position = data
+
+        if not self.sub_topics_ready['home_pos']:
+            self.sub_topics_ready['home_pos'] = True
+
+    def local_position_callback(self, data):
+        self.local_position = data
+
+        if not self.sub_topics_ready['local_pos']:
+            self.sub_topics_ready['local_pos'] = True
+
+    def mission_wp_callback(self, data):
+        if self.mission_wp.current_seq != data.current_seq:
+            rospy.loginfo("current mission waypoint sequence updated: {0}".
+                          format(data.current_seq))
+
+        self.mission_wp = data
+
+        if not self.sub_topics_ready['mission_wp']:
+            self.sub_topics_ready['mission_wp'] = True
+
+    def state_callback(self, data):
+        if self.state.armed != data.armed:
+            rospy.loginfo("armed state changed from {0} to {1}".format(
+                self.state.armed, data.armed))
+
+        if self.state.mode != data.mode:
+            rospy.loginfo("mode changed from {0} to {1}".format(
+                self.state.mode, data.mode))
+
+        self.state = data
+
+        # mavros publishes a disconnected state message on init
+        if not self.sub_topics_ready['state'] and data.connected:
+            self.sub_topics_ready['state'] = True
+
+    #
+    # Helper methods
+    #
+    def set_arm(self, arm, timeout):
+        """arm: True to arm or False to disarm, timeout(int): seconds"""
+        rospy.loginfo("setting FCU arm: {0}".format(arm))
+        old_arm = self.state.armed
+        loop_freq = 1  # Hz
+        rate = rospy.Rate(loop_freq)
+        arm_set = False
+        for i in xrange(timeout * loop_freq):
+            if self.state.armed == arm:
+                arm_set = True
+                rospy.loginfo(
+                    "set arm success | new arm: {0}, old arm: {1} | seconds: {2} of {3}".
+                    format(arm, old_arm, i / loop_freq, timeout))
+                break
+            else:
+                try:
+                    res = self.set_arming_srv(arm)
+                    if not res.success:
+                        rospy.logerr("failed to send arm command")
+                except rospy.ServiceException as e:
+                    rospy.logerr(e)
+
+            rate.sleep()
+
+        self.assertTrue(arm_set, (
+            "failed to set arm | new arm: {0}, old arm: {1} | timeout(seconds): {2}".
+            format(arm, old_arm, timeout)))
+
+    def set_mode(self, mode, timeout):
+        """mode: PX4 mode string, timeout(int): seconds"""
+        rospy.loginfo("setting FCU mode: {0}".format(mode))
+        old_mode = self.state.mode
+        loop_freq = 1  # Hz
+        rate = rospy.Rate(loop_freq)
+        mode_set = False
+        for i in xrange(timeout * loop_freq):
+            if self.state.mode == mode:
+                mode_set = True
+                rospy.loginfo(
+                    "set mode success | new mode: {0}, old mode: {1} | seconds: {2} of {3}".
+                    format(mode, old_mode, i / loop_freq, timeout))
+                break
+            else:
+                try:
+                    res = self.set_mode_srv(0, mode)  # 0 is custom mode
+                    if not res.mode_sent:
+                        rospy.logerr("failed to send mode command")
+                except rospy.ServiceException as e:
+                    rospy.logerr(e)
+
+            rate.sleep()
+
+        self.assertTrue(mode_set, (
+            "failed to set mode | new mode: {0}, old mode: {1} | timeout(seconds): {2}".
+            format(mode, old_mode, timeout)))
+
+    def wait_for_topics(self, timeout):
+        """wait for simulation to be ready, make sure we're getting topic info
+        from all topics by checking dictionary of flag values set in callbacks,
+        timeout(int): seconds"""
+        rospy.loginfo("waiting for subscribed topics to be ready")
+        loop_freq = 1  # Hz
+        rate = rospy.Rate(loop_freq)
+        simulation_ready = False
+        for i in xrange(timeout * loop_freq):
+            if all(value for value in self.sub_topics_ready.values()):
+                simulation_ready = True
+                rospy.loginfo("simulation topics ready | seconds: {0} of {1}".
+                              format(i / loop_freq, timeout))
+                break
+
+            rate.sleep()
+
+        self.assertTrue(simulation_ready, (
+            "failed to hear from all subscribed simulation topics | topic ready flags: {0} | timeout(seconds): {1}".
+            format(self.sub_topics_ready, timeout)))
+
+    def wait_on_landed_state(self, desired_landed_state, timeout, index):
+        rospy.loginfo(
+            "waiting for landed state | state: {0}, index: {1}".format(
+                self.LAND_STATES.get(desired_landed_state), index))
+        loop_freq = 10  # Hz
+        rate = rospy.Rate(loop_freq)
+        landed_state_confirmed = False
+        for i in xrange(timeout * loop_freq):
+            if self.extended_state.landed_state == desired_landed_state:
+                landed_state_confirmed = True
+                rospy.loginfo(
+                    "landed state confirmed | state: {0}, index: {1} | seconds: {2} of {3}".
+                    format(
+                        self.LAND_STATES.get(desired_landed_state), index, i /
+                        loop_freq, timeout))
+                break
+
+            rate.sleep()
+
+        self.assertTrue(landed_state_confirmed, (
+            "landed state not detected | desired: {0}, current: {1} | index: {2}, timeout(seconds): {3}".
+            format(
+                self.LAND_STATES.get(desired_landed_state),
+                self.LAND_STATES.get(self.extended_state.landed_state), index,
+                timeout)))
+
+    def wait_on_transition(self, transition, timeout, index):
+        """Wait for VTOL transition, timeout(int): seconds"""
+        rospy.loginfo(
+            "waiting for VTOL transition | transition: {0}, index: {1}".format(
+                self.VTOL_STATES.get(transition), index))
+        loop_freq = 10  # Hz
+        rate = rospy.Rate(loop_freq)
+        transitioned = False
+        for i in xrange(timeout * loop_freq):
+            if transition == self.extended_state.vtol_state:
+                rospy.loginfo(
+                    "transitioned | index: {0} | seconds: {1} of {2}".format(
+                        index, i / loop_freq, timeout))
+                transitioned = True
+                break
+
+            rate.sleep()
+
+        self.assertTrue(transitioned, (
+            "transition not detected | index: {0} | timeout(seconds): {1}".
+            format(index, timeout)))
+
+    def clear_wps(self, timeout):
+        """timeout(int): seconds"""
+        loop_freq = 1  # Hz
+        rate = rospy.Rate(loop_freq)
+        wps_cleared = False
+        for i in xrange(timeout * loop_freq):
+            if not self.mission_wp.waypoints:
+                wps_cleared = True
+                rospy.loginfo("clear waypoints success | seconds: {0} of {1}".
+                              format(i / loop_freq, timeout))
+                break
+            else:
+                try:
+                    res = self.wp_clear_srv()
+                    if not res.success:
+                        rospy.logerr("failed to send waypoint clear command")
+                except rospy.ServiceException as e:
+                    rospy.logerr(e)
+
+            rate.sleep()
+
+        self.assertTrue(wps_cleared, (
+            "failed to clear waypoints | timeout(seconds): {0}".format(timeout)
+        ))
+
+    def send_wps(self, waypoints, timeout):
+        """waypoints, timeout(int): seconds"""
+        rospy.loginfo("sending mission waypoints")
+        if self.mission_wp.waypoints:
+            rospy.loginfo("FCU already has mission waypoints")
+
+        loop_freq = 1  # Hz
+        rate = rospy.Rate(loop_freq)
+        wps_sent = False
+        wps_verified = False
+        for i in xrange(timeout * loop_freq):
+            if not wps_sent:
+                try:
+                    res = self.wp_push_srv(start_index=0, waypoints=waypoints)
+                    wps_sent = res.success
+                    if wps_sent:
+                        rospy.loginfo("waypoints successfully transferred")
+                except rospy.ServiceException as e:
+                    rospy.logerr(e)
+            else:
+                if len(waypoints) == len(self.mission_wp.waypoints):
+                    rospy.loginfo("number of waypoints transferred: {0}".
+                                  format(len(waypoints)))
+                    wps_verified = True
+
+            if wps_sent and wps_verified:
+                rospy.loginfo("send waypoints success | seconds: {0} of {1}".
+                              format(i / loop_freq, timeout))
+                break
+
+            rate.sleep()
+
+        self.assertTrue((
+            wps_sent and wps_verified
+        ), "mission could not be transferred and verified | timeout(seconds): {0}".
+                        format(timeout))
+
+    def wait_for_mav_type(self, timeout):
+        """Wait for MAV_TYPE parameter, timeout(int): seconds"""
+        rospy.loginfo("waiting for MAV_TYPE")
+        loop_freq = 1  # Hz
+        rate = rospy.Rate(loop_freq)
+        res = False
+        for i in xrange(timeout * loop_freq):
+            try:
+                res = self.get_param_srv('MAV_TYPE')
+                if res.success:
+                    self.mav_type = res.value.integer
+                    rospy.loginfo(
+                        "MAV_TYPE received | value: {0} | seconds: {1} of {2}".
+                        format(self.mav_type, i / loop_freq, timeout))
+                    break
+            except rospy.ServiceException as e:
+                rospy.logerr(e)
+
+            rate.sleep()
+
+        self.assertTrue(res.success, (
+            "MAV_TYPE param get failed | timeout(seconds): {0}".format(timeout)
+        ))

--- a/test/mavros_posix_test_mission.test
+++ b/test/mavros_posix_test_mission.test
@@ -6,12 +6,13 @@
     <arg name="gui" default="false"/>
     <arg name="est" default="ekf2"/>
     <arg name="mission"/>
+    <arg name="vehicle"/>
 
     <include file="$(find px4)/launch/mavros_posix_sitl.launch">
         <arg name="ns" value="$(arg ns)"/>
         <arg name="headless" value="$(arg headless)"/>
         <arg name="gui" value="$(arg gui)"/>
-        <arg name="vehicle" value="standard_vtol"/>
+        <arg name="vehicle" value="$(arg vehicle)"/>
         <arg name="est" value="$(arg est)"/>
     </include>
 

--- a/test/mavros_posix_tests_missions.test
+++ b/test/mavros_posix_tests_missions.test
@@ -15,11 +15,11 @@
     </include>
 
     <group ns="$(arg ns)">
-        <test test-name="multicopter_box" pkg="px4" type="mission_test.py" vehicle="iris" time-limit="120.0" args="multirotor_box.mission"/>
-        <test test-name="mission_test_new_1" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_new_1.txt" />
-        <test test-name="mission_test_new_2" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_new_2.txt" />
-        <test test-name="mission_test_old_1" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_old_1.txt" />
-        <test test-name="mission_test_old_2" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_old_2.txt" />
-        <test test-name="mission_test_old_3" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_old_3.txt" />
+        <test test-name="multicopter_box" pkg="px4" type="mission_test.py" time-limit="120.0" args="multirotor_box.mission"/>
+        <test test-name="mission_test_new_1" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_new_1.txt"/>
+        <test test-name="mission_test_new_2" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_new_2.txt"/>
+        <test test-name="mission_test_old_1" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_old_1.txt"/>
+        <test test-name="mission_test_old_2" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_old_2.txt"/>
+        <test test-name="mission_test_old_3" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_old_3.txt"/>
     </group>
 </launch>


### PR DESCRIPTION
PR created to have Jenkins test this to see if it helps https://github.com/PX4/Firmware/issues/8556.

- created a test base class to centralize redundant methods among the different tests
- added mission waypoint list topic listener (this also helps make sure the simulation is ready)
- check number of mission waypoints in FCU against mission
- increase time for mavros topics to be ready from 30 to 60 seconds
- reduced loop rates for position checks

EDIT: See commit message for additions/fixes that were "riders" with this PR. yapf with default settings is used to format .py files.