### PR TITLE
HOTFIX for param_export

### DIFF
--- a/src/modules/systemlib/bson/tinybson.c
+++ b/src/modules/systemlib/bson/tinybson.c
@@ -46,7 +46,7 @@
 #include "tinybson.h"
 
 #if 0
-# define debug(fmt, args...)		do { warnx("BSON: " fmt, ##args); } while(0)
+# define debug(fmt, args...)		do { PX4_INFO("BSON: " fmt, ##args); } while(0)
 #else
 # define debug(fmt, args...)		do { } while(0)
 #endif
@@ -56,7 +56,7 @@
 
 #define BSON_READ  read
 #define BSON_WRITE write
-#define BSON_FSYNC px4_fsync
+#define BSON_FSYNC fsync
 
 static int
 read_x(bson_decoder_t decoder, void *p, size_t s)

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -1035,7 +1035,6 @@ param_export(int fd, bool only_unsaved)
 	int	result = -1;
 
 	struct bson_encoder_s encoder;
-	encoder.realloc_ok = 0;
 
 	int shutdown_lock_ret = px4_shutdown_lock();
 
@@ -1072,9 +1071,9 @@ param_export(int fd, bool only_unsaved)
 		const size_t size = param_size(s->param);
 
 		// check remaining buffer size and commit to disk
-		//  total size = name + param size + bson header + bson end
+		//  total size = strlen(name) + 1 (null char) + param size + 1 (bson header) + 1 (bson end)
 		// size is doubled (floats saved as doubles)
-		const size_t total_size = strlen(name) + 2 * size + 2;
+		const size_t total_size = strlen(name) + 2 * size + 3;
 
 		if (encoder.bufpos > encoder.bufsize - total_size) {
 			// write buffer to disk and continue

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -1140,14 +1140,14 @@ param_export(int fd, bool only_unsaved)
 out:
 
 	if (result == 0) {
-		result = bson_encoder_fini(&encoder); // this will call fsync
+		result = bson_encoder_fini(&encoder);
 
 		// write and finish
 		if ((result != 0) || write(fd, encoder.buf, encoder.bufpos) != encoder.bufpos) {
 			PX4_ERR("param write error");
 
 		} else {
-			px4_fsync(fd);
+			fsync(fd);
 		}
 	}
 

--- a/src/modules/systemlib/param/param.c
+++ b/src/modules/systemlib/param/param.c
@@ -1048,7 +1048,7 @@ param_export(int fd, bool only_unsaved)
 
 	param_lock_reader();
 
-	uint8_t bson_buffer[512];
+	uint8_t bson_buffer[256];
 	bson_encoder_init_buf(&encoder, &bson_buffer, sizeof(bson_buffer));
 
 	/* no modified parameters -> we are done */

--- a/src/modules/systemlib/param/param.h
+++ b/src/modules/systemlib/param/param.h
@@ -299,6 +299,7 @@ __EXPORT void		param_reset_excludes(const char *excludes[], int num_excludes);
 
 /**
  * Export changed parameters to a file.
+ * Note: this method requires a large amount of stack size!
  *
  * @param fd		File descriptor to export to.
  * @param only_unsaved	Only export changed parameters that have not yet been exported.
@@ -365,6 +366,7 @@ __EXPORT const char	*param_get_default_file(void);
 
 /**
  * Save parameters to the default file.
+ * Note: this method requires a large amount of stack size!
  *
  * This function saves all parameters with non-default values.
  *


### PR DESCRIPTION
Seems like #8391 has been merged a bit too quickly.

This fixes a corner case where param saving failed because the buffer was too small by 1 byte. In that case all params are lost.

In addition it reduces the buffer size from 512 to 256 bytes, which will avoid buffer overflows when `param_save_default` is called from other places (for example temperature calibration).

Here are some timing results (all times in microseconds):
```
Buffer size,        export times (multiple runs)
512:                26373, 30756, 26505, 28248
256:                31545, 34755, 37166, 36336
512 + usleep:       213256, 208465, 214441
no buffer + usleep: 767825, 779391
```

It also shows the contribution of removing the `usleep` vs. adding the buffer.