### PR TITLE
EKF2 set zero unused estimator_status fields

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1102,6 +1102,9 @@ void Ekf2::run()
 		_ekf.get_ekf_soln_status(&status.solution_status_flags);
 		_ekf.get_imu_vibe_metrics(status.vibe);
 		status.time_slip = _last_time_slip_us / 1e6f;
+		status.nan_flags = 0.0f; // unused
+		status.health_flags = 0.0f; // unused
+		status.timeout_flags = 0.0f; // unused
 		status.pre_flt_fail = _preflt_fail;
 
 		if (_estimator_status_pub == nullptr) {


### PR DESCRIPTION
These fields are only used by LPE and cause confusion on flight review.

![image](https://user-images.githubusercontent.com/84712/34894672-3d2b3292-f7b0-11e7-9d74-61937c1e06a2.png)


