### PR TITLE
fix the bug for comparison with max image size

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -496,7 +496,7 @@ class uploader(object):
         # Prevent uploads where the maximum image size of the board config is smaller than the flash
         # of the board. This is a hint the user chose the wrong config and will lack features
         # for this particular board.
-        if self.fw_maxsize > fw.property('image_maxsize'):
+        if self.fw_maxsize < fw.property('image_maxsize'):
             raise RuntimeError("Board can accept larger flash images (%u bytes) than board config (%u bytes). Please use the correct board configuration to avoid lacking critical functionality."
                 % (self.fw_maxsize, fw.property('image_maxsize')))
 


### PR DESCRIPTION
Hello, @LorenzMeier 

When I upload the firmware image to pixhawk1 (px4fmu-v2),  I got the error message
```
ERROR: Board can accept larger flash images (2080768 bytes) than board config (1032192 bytes). Please use the correct board configuration to avoid lacking critical functionality.
```

I'm not sure that there is a bug or not.....

However, INFO_FLASH_SIZE in pixhawk is about 2MB. and image_maxsize  is about 1MB.
Do you want to say that it is wrong if maximum image size of  image is larger than hardware flash memory ?
Why is image_maxsize in px4fmu-v2.prototype is about 1MB? I read real hardware flash size is 2MB.

Anyway, in pixhawk1, I cannot upload the image file....

If the solution is not, could you solve this problem?

Thanks 
SungTae Moon