### PR TITLE
Makefile: Fix CLANG-tidy calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,12 +326,12 @@ posix_sitl_default-clang:
 	@$(PX4_MAKE) -C $(SRC_DIR)/build/posix_sitl_default-clang
 
 clang-tidy: posix_sitl_default-clang
-	@cd $(SRC_DIR)/build/posix_sitl_default-clang && run-clang-tidy-4.0.py -header-filter=".*\.hpp" -j$(j) -p .
+	@cd $(SRC_DIR)/build/posix_sitl_default-clang && $(SRC_DIR)/Tools/run-clang-tidy.py -header-filter=".*\.hpp" -j$(j) -p .
 
 # to automatically fix a single check at a time, eg modernize-redundant-void-arg
 #  % run-clang-tidy-4.0.py -fix -j4 -checks=-\*,modernize-redundant-void-arg -p .
 clang-tidy-fix: posix_sitl_default-clang
-	@cd $(SRC_DIR)/build/posix_sitl_default-clang && run-clang-tidy-4.0.py -header-filter=".*\.hpp" -j$(j) -fix -p .
+	@cd $(SRC_DIR)/build/posix_sitl_default-clang && $(SRC_DIR)/Tools/run-clang-tidy.py -header-filter=".*\.hpp" -j$(j) -fix -p .
 
 # modified version of run-clang-tidy.py to return error codes and only output relevant results
 clang-tidy-quiet: posix_sitl_default-clang


### PR DESCRIPTION
The calls have not been updated as the CI target has been.