### PR TITLE
LPE: sensor fusion bitmask update

### DIFF
--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -180,20 +180,16 @@ BlockLocalPositionEstimator::BlockLocalPositionEstimator() :
 
 	// print fusion settings to console
 	printf("[lpe] fuse gps: %d, flow: %d, vis_pos: %d, "
-	       "vis_yaw: %d, land: %d, pub_agl_z: %d, flow_gyro: %d, "
-	       "baro: %d, landing_target: %d, mocap: %d, lidar: %d, sonar: %d\n",
+	       "landing_target: %d, land: %d, pub_agl_z: %d, flow_gyro: %d, "
+	       "baro: %d\n",
 	       (_fusion.get() & FUSE_GPS) != 0,
 	       (_fusion.get() & FUSE_FLOW) != 0,
 	       (_fusion.get() & FUSE_VIS_POS) != 0,
-	       (_fusion.get() & FUSE_VIS_YAW) != 0,
+	       (_fusion.get() & FUSE_LAND_TARGET) != 0,
 	       (_fusion.get() & FUSE_LAND) != 0,
 	       (_fusion.get() & FUSE_PUB_AGL_Z) != 0,
 	       (_fusion.get() & FUSE_FLOW_GYRO_COMP) != 0,
-	       (_fusion.get() & FUSE_BARO) != 0,
-	       (_fusion.get() & FUSE_LAND_TARGET) != 0,
-	       (_fusion.get() & FUSE_MOCAP) != 0,
-	       (_fusion.get() & FUSE_LIDAR) != 0,
-	       (_fusion.get() & FUSE_SONAR) != 0);
+	       (_fusion.get() & FUSE_BARO) != 0);
 }
 
 BlockLocalPositionEstimator::~BlockLocalPositionEstimator()
@@ -303,9 +299,9 @@ void BlockLocalPositionEstimator::update()
 	bool flowUpdated = (_fusion.get() & FUSE_FLOW) && _sub_flow.updated();
 	bool gpsUpdated = (_fusion.get() & FUSE_GPS) && _sub_gps.updated();
 	bool visionUpdated = (_fusion.get() & FUSE_VIS_POS) && _sub_vision_pos.updated();
-	bool mocapUpdated = (_fusion.get() & FUSE_MOCAP) && _sub_mocap.updated();
-	bool lidarUpdated = (_fusion.get() & FUSE_LIDAR) && (_sub_lidar != nullptr) && _sub_lidar->updated();
-	bool sonarUpdated = (_fusion.get() & FUSE_SONAR) && (_sub_sonar != nullptr) && _sub_sonar->updated();
+	bool mocapUpdated = _sub_mocap.updated();
+	bool lidarUpdated = (_sub_lidar != nullptr) && _sub_lidar->updated();
+	bool sonarUpdated = (_sub_sonar != nullptr) && _sub_sonar->updated();
 	bool landUpdated = landed()
 			   && ((_timeStamp - _time_last_land) > 1.0e6f / LAND_RATE);		// throttle rate
 

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -117,15 +117,11 @@ public:
 		FUSE_GPS = 1 << 0,
 		FUSE_FLOW = 1 << 1,
 		FUSE_VIS_POS = 1 << 2,
-		FUSE_VIS_YAW = 1 << 3,
+		FUSE_LAND_TARGET = 1 << 3,
 		FUSE_LAND = 1 << 4,
 		FUSE_PUB_AGL_Z = 1 << 5,
 		FUSE_FLOW_GYRO_COMP = 1 << 6,
-		FUSE_BARO = 1 << 7,
-		FUSE_LAND_TARGET = 1 << 8,
-		FUSE_MOCAP = 1 << 9,
-		FUSE_LIDAR = 1 << 10,
-		FUSE_SONAR = 1 << 11,
+		FUSE_BARO = 1 << 7
 	};
 
 	enum sensor_t {

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.hpp
@@ -377,6 +377,16 @@ private:
 	uint16_t _sensorFault;
 	uint8_t _estimatorInitialized;
 
+	// sensor update flags
+	bool _flowUpdated;
+	bool _gpsUpdated;
+	bool _visionUpdated;
+	bool _mocapUpdated;
+	bool _lidarUpdated;
+	bool _sonarUpdated;
+	bool _landUpdated;
+	bool _baroUpdated;
+
 	// state space
 	Vector<float, n_x>  _x;	// state vector
 	Vector<float, n_u>  _u;	// input vector

--- a/src/modules/local_position_estimator/params.c
+++ b/src/modules/local_position_estimator/params.c
@@ -431,17 +431,13 @@ PARAM_DEFINE_FLOAT(LPE_LAND_VXY, 0.05f);
  * 0 : Set to true to fuse GPS data if available, also requires GPS for altitude init
  * 1 : Set to true to fuse optical flow data if available
  * 2 : Set to true to fuse vision position
- * 3 : Set to true to fuse vision yaw
+ * 3 : Set to true to enable landing target
  * 4 : Set to true to fuse land detector
  * 5 : Set to true to publish AGL as local position down component
  * 6 : Set to true to enable flow gyro compensation
  * 7 : Set to true to enable baro fusion
- * 8 : Set to true to enable land target
- * 9 : Set to true to enable motion capture fusion
- * 10 : Set to true to enable lidar fusion
- * 11 : Set to true to enable sonar fusion
  *
- * default (145 - GPS only)
+ * default (145 - GPS, baro, land detector)
  *
  * @group Local Position Estimator
  * @min 0
@@ -449,14 +445,10 @@ PARAM_DEFINE_FLOAT(LPE_LAND_VXY, 0.05f);
  * @bit 0  fuse GPS, requires GPS for alt. init
  * @bit 1  fuse optical flow
  * @bit 2  fuse vision position
- * @bit 3  fuse vision yaw
+ * @bit 3  fuse landing target
  * @bit 4  fuse land detector
  * @bit 5  pub agl as lpos down
  * @bit 6  flow gyro compensation
  * @bit 7  fuse baro
- * @bit 8  land_target
- * @bit 9  motion capture
- * @bit 10 lidar
- * @bit 11 sonar
  */
 PARAM_DEFINE_INT32(LPE_FUSION, 145);

--- a/src/modules/local_position_estimator/sensors/sonar.cpp
+++ b/src/modules/local_position_estimator/sensors/sonar.cpp
@@ -79,8 +79,10 @@ void BlockLocalPositionEstimator::sonarCorrect()
 
 	if (sonarMeasure(y) != OK) { return; }
 
-	// do not use sonar if lidar is active
-	//if (_lidarInitialized && (_lidarFault < fault_lvl_disable)) { return; }
+	// do not use sonar if lidar is active and not faulty or timed out
+	if (_lidarUpdated
+	    && !(_sensorFault & SENSOR_LIDAR)
+	    && !(_sensorTimeout & SENSOR_LIDAR)) { return; }
 
 	// calculate covariance
 	float cov = _sub_sonar->get().covariance;


### PR DESCRIPTION
This reverts the changes of #8615.
1. You don't need a mask for mocap, cause actually when you use mocap, you don't want any other sensor source to be fused - so you just deactivate all the other sources and mocap will be fused by default.
2. You don't need a mask for sonar and lidar - it is assumed that when you add a range sensor to the mix, you actually want that sensor data to be fused as you want a more accurate AGL estimate. What was commented actually was the feature that states that the lidar measurement has priority over the sonar measurement when both are connected, since lidar gives a much more robust and reliable AGL. So I reactivated that, as you don't actually want sonar and lidar to be on the same mix, as the sonar is pretty noisy. That could be surpassed by increasing the std dev of the sonar, but I think what we actually want is to deny the sonar readings when we have the lidar readings good and not faulty or timed out.
3. I removed the `FUSION_VISION_YAW` enum value cause this was actually a residual of when the support to the vision attitude was being added as a replacement of Attitude Estimator Q, which turned out to not go further. So I just fit the new `LAND_TARGET` into this bitmask place. @ndepal you should consider having this on the PR.