### PR TITLE
posix-config iris_replay: log until SITL exits

### DIFF
--- a/posix-configs/SITL/init/ekf2/iris_replay
+++ b/posix-configs/SITL/init/ekf2/iris_replay
@@ -1,7 +1,7 @@
 uorb start
 
 ekf2 start -r
-logger start -e -t -b 1000 -p vehicle_attitude
+logger start -f -t -b 1000 -p vehicle_attitude
 sleep 0.2
 replay start
 


### PR DESCRIPTION
If a log with multiple (dis)arming events was replayed, multiple logs were
created. This changes the replay to only create a single log.

@CarlOlsson

Fixes https://github.com/PX4/Firmware/issues/8567