### PR TITLE
circleci OSX builds use ninja

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,4 +27,4 @@ dependencies:
 
 test:
   override:
-    - NO_NINJA_BUILD=1 make -j2 quick_check
+    - make quick_check


### PR DESCRIPTION
This was failing randomly a few months ago. Let's see if it's changed.

@LorenzMeier (or other primary Mac users) is ninja back of your regular workflow?