### PR TITLE
astyle allow version 3.1

### DIFF
--- a/Tools/astyle/check_code_style_all.sh
+++ b/Tools/astyle/check_code_style_all.sh
@@ -5,6 +5,7 @@ set -eu
 ASTYLE_VER_REQUIRED_1="Artistic Style Version 2.06"
 ASTYLE_VER_REQUIRED_2="Artistic Style Version 3.0"
 ASTYLE_VER_REQUIRED_3="Artistic Style Version 3.0.1"
+ASTYLE_VER_REQUIRED_4="Artistic Style Version 3.1"
 
 astyle_ver() {
 	echo "PX4 requires at least ${ASTYLE_VER_REQUIRED_1}"
@@ -23,10 +24,11 @@ else
 
 	if [ "$ASTYLE_VER" != "$ASTYLE_VER_REQUIRED_1" -a \
 	     "$ASTYLE_VER" != "$ASTYLE_VER_REQUIRED_2" -a \
-	     "$ASTYLE_VER" != "$ASTYLE_VER_REQUIRED_3" ];
+	     "$ASTYLE_VER" != "$ASTYLE_VER_REQUIRED_3" -a \
+	     "$ASTYLE_VER" != "$ASTYLE_VER_REQUIRED_4" ];
 	then
 	    echo "Error: you're using ${ASTYLE_VER}"
-	    echo "but should be using ${ASTYLE_VER_REQUIRED_1}, ${ASTYLE_VER_REQUIRED_2}, or ${ASTYLE_VER_REQUIRED_3} instead"
+	    echo "but should be using ${ASTYLE_VER_REQUIRED_1}, ${ASTYLE_VER_REQUIRED_2}, ${ASTYLE_VER_REQUIRED_3}, or ${ASTYLE_VER_REQUIRED_4} instead"
 	    exit 1
 	fi
 fi

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -1160,9 +1160,9 @@ protected:
 			msg.v_acc = gps.epv * 1e3f;
 			msg.vel_acc = gps.s_variance_m_s * 1e3f;
 			msg.hdg_acc = gps.c_variance_rad * 1e5f / M_DEG_TO_RAD_F;
-			msg.vel = cm_uint16_from_m_float(gps.vel_m_s),
-			    msg.cog = _wrap_2pi(gps.cog_rad) * M_RAD_TO_DEG_F * 1e2f,
-				msg.satellites_visible = gps.satellites_used;
+			msg.vel = cm_uint16_from_m_float(gps.vel_m_s);
+			msg.cog = _wrap_2pi(gps.cog_rad) * M_RAD_TO_DEG_F * 1e2f;
+			msg.satellites_visible = gps.satellites_used;
 
 			mavlink_msg_gps_raw_int_send_struct(_mavlink->get_channel(), &msg);
 


### PR DESCRIPTION
Circleci builds (OSX) are failing because astyle v3.1 is now being installed. Let's see if we can tolerate the additional version without code changes.