### PR TITLE
Iris: set mixer to quad_wide

### DIFF
--- a/ROMFS/px4fmu_common/init.d/10016_3dr_iris
+++ b/ROMFS/px4fmu_common/init.d/10016_3dr_iris
@@ -40,6 +40,6 @@ then
 	param set BAT_A_PER_V 15.39103
 fi
 
-set MIXER quad_dc
+set MIXER quad_w
 
 set PWM_OUT 1234

--- a/posix-configs/SITL/init/ekf2/iris
+++ b/posix-configs/SITL/init/ekf2/iris
@@ -60,7 +60,7 @@ navigator start
 ekf2 start
 mc_pos_control start
 mc_att_control start
-mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_dc.main.mix
+mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_w.main.mix
 mavlink start -x -u 14556 -r 4000000
 mavlink start -x -u 14557 -r 4000000 -m onboard -o 14540
 mavlink stream -r 50 -s POSITION_TARGET_LOCAL_NED -u 14556

--- a/posix-configs/SITL/init/ekf2/iris_1
+++ b/posix-configs/SITL/init/ekf2/iris_1
@@ -62,7 +62,7 @@ navigator start
 ekf2 start
 mc_pos_control start
 mc_att_control start
-mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_dc.main.mix
+mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_w.main.mix
 mavlink start -x -u 14556 -r 4000000
 mavlink start -x -u 14557 -r 4000000 -m onboard -o 14540
 mavlink stream -r 50 -s POSITION_TARGET_LOCAL_NED -u 14556

--- a/posix-configs/SITL/init/ekf2/iris_2
+++ b/posix-configs/SITL/init/ekf2/iris_2
@@ -62,7 +62,7 @@ navigator start
 ekf2 start
 mc_pos_control start
 mc_att_control start
-mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_dc.main.mix
+mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_w.main.mix
 mavlink start -x -u 14558 -r 4000000
 mavlink start -x -u 14559 -r 4000000 -m onboard -o 14541
 mavlink stream -r 50 -s POSITION_TARGET_LOCAL_NED -u 14558

--- a/posix-configs/SITL/init/ekf2/iris_irlock
+++ b/posix-configs/SITL/init/ekf2/iris_irlock
@@ -62,7 +62,7 @@ ekf2 start
 landing_target_estimator start
 mc_pos_control start
 mc_att_control start
-mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_dc.main.mix
+mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_w.main.mix
 mavlink start -u 14556 -r 4000000
 mavlink start -u 14557 -r 4000000 -m onboard -o 14540
 mavlink stream -r 50 -s POSITION_TARGET_LOCAL_NED -u 14556

--- a/posix-configs/SITL/init/ekf2/iris_rplidar
+++ b/posix-configs/SITL/init/ekf2/iris_rplidar
@@ -60,7 +60,7 @@ navigator start
 ekf2 start
 mc_pos_control start
 mc_att_control start
-mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_dc.main.mix
+mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_w.main.mix
 mavlink start -x -u 14556 -r 4000000
 mavlink start -x -u 14557 -r 4000000 -m onboard -o 14540
 mavlink stream -r 50 -s POSITION_TARGET_LOCAL_NED -u 14556

--- a/posix-configs/SITL/init/ekf2/multiple_iris
+++ b/posix-configs/SITL/init/ekf2/multiple_iris
@@ -60,7 +60,7 @@ navigator start
 ekf2 start
 mc_pos_control start
 mc_att_control start
-mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_dc.main.mix
+mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_w.main.mix
 mavlink start -x -u _MAVPORT_ -r 4000000 -o _MAVOPORT_
 mavlink start -x -u _MAVPORT2_ -r 4000000 -m onboard -o _MAVOPORT2_
 mavlink stream -r 50 -s POSITION_TARGET_LOCAL_NED -u _MAVPORT_

--- a/posix-configs/SITL/init/lpe/iris
+++ b/posix-configs/SITL/init/lpe/iris
@@ -61,7 +61,7 @@ attitude_estimator_q start
 local_position_estimator start
 mc_pos_control start
 mc_att_control start
-mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_dc.main.mix
+mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_w.main.mix
 mavlink start -x -u 14556 -r 4000000
 mavlink start -x -u 14557 -r 4000000 -m onboard -o 14540
 mavlink stream -r 50 -s POSITION_TARGET_LOCAL_NED -u 14556

--- a/posix-configs/SITL/init/lpe/iris_1
+++ b/posix-configs/SITL/init/lpe/iris_1
@@ -63,7 +63,7 @@ attitude_estimator_q start
 local_position_estimator start
 mc_pos_control start
 mc_att_control start
-mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_dc.main.mix
+mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_w.main.mix
 mavlink start -x -u 14556 -r 4000000
 mavlink start -x -u 14557 -r 4000000 -m onboard -o 14540
 mavlink stream -r 50 -s POSITION_TARGET_LOCAL_NED -u 14556

--- a/posix-configs/SITL/init/lpe/iris_2
+++ b/posix-configs/SITL/init/lpe/iris_2
@@ -63,7 +63,7 @@ attitude_estimator_q start
 local_position_estimator start
 mc_pos_control start
 mc_att_control start
-mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_dc.main.mix
+mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_w.main.mix
 mavlink start -x -u 14558 -r 4000000
 mavlink start -x -u 14559 -r 4000000 -m onboard -o 14541
 mavlink stream -r 50 -s POSITION_TARGET_LOCAL_NED -u 14558

--- a/posix-configs/SITL/init/lpe/iris_irlock
+++ b/posix-configs/SITL/init/lpe/iris_irlock
@@ -70,7 +70,7 @@ local_position_estimator start
 landing_target_estimator start
 mc_pos_control start
 mc_att_control start
-mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_dc.main.mix
+mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_w.main.mix
 mavlink start -u 14556 -r 4000000
 mavlink start -u 14557 -r 4000000 -m onboard -o 14540
 mavlink stream -r 50 -s POSITION_TARGET_LOCAL_NED -u 14556

--- a/posix-configs/SITL/init/lpe/iris_opt_flow
+++ b/posix-configs/SITL/init/lpe/iris_opt_flow
@@ -79,7 +79,7 @@ attitude_estimator_q start
 local_position_estimator start
 mc_pos_control start
 mc_att_control start
-mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_dc.main.mix
+mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_w.main.mix
 mavlink start -x -u 14556 -r 2000000
 mavlink start -x -u 14557 -r 2000000 -m onboard -o 14540
 mavlink stream -r 80 -s POSITION_TARGET_LOCAL_NED -u 14556

--- a/posix-configs/SITL/init/lpe/iris_rplidar
+++ b/posix-configs/SITL/init/lpe/iris_rplidar
@@ -61,7 +61,7 @@ attitude_estimator_q start
 local_position_estimator start
 mc_pos_control start
 mc_att_control start
-mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_dc.main.mix
+mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_w.main.mix
 mavlink start -x -u 14556 -r 4000000
 mavlink start -x -u 14557 -r 4000000 -m onboard -o 14540
 mavlink stream -r 50 -s POSITION_TARGET_LOCAL_NED -u 14556


### PR DESCRIPTION
The geometry was previously `quad_deadcat` in which front motors are closer to the CG and thus more loaded in hover. `quad_wide` is the same geometry as `quad_deadcat` except the CG is centered so all motors are loaded equally.
Flight logs on Iris showed that `quad_deadcat` is not the correct mixer because all motors are equally loaded during hover (actuator_outputs 0 to 3 have similar values), and a negative pitch offset is building up soon after takeoff (visible in actuator_controls). This is not the case with `quad_wide`.

Logs:
- quad_deadcat, simulation: https://logs.px4.io/plot_app?log=b7bdae51-dcb8-4b5d-891a-da06136e7080#Nav-Actuator-Controls-0
- quad_deadcat, real flight: https://review.px4.io/plot_app?log=2575c200-200d-410e-b2af-6a55bfa7818b#Nav-Actuator-Controls-0
- quad_wide, simulation: https://logs.px4.io/plot_app?log=47ca349b-8ad9-4f07-aeb3-bee98f35e38a#Nav-Actuator-Controls-0
- quad_wide, real flight: TODO

@PX4/testflights Please do a normal test flight on 3DR Iris, just checking there is no regression. You should see a slightly improved behaviour right after take-off (less pitch up moment).