### PR TITLE
Fix sensors startup on pixhawk boards.

### DIFF
--- a/src/drivers/boards/px4fmu-v2/init.c
+++ b/src/drivers/boards/px4fmu-v2/init.c
@@ -401,6 +401,10 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 		case 0x8:
 			break;
 
+		case 0xB:
+			hw_version = 0x8;
+			break;
+
 		case 0xE:
 			hw_type[1]++;
 			hw_type[2] = '0';


### PR DESCRIPTION
Commit 75b93b0728d57c642641c354dc99390a6ac43ee8 (Fix for HobbyKing boards) was not properly reverted