### PR TITLE
SITL: limit number of log directories to 7

### DIFF
--- a/posix-configs/SITL/init/ekf2/hippocampus
+++ b/posix-configs/SITL/init/ekf2/hippocampus
@@ -1,14 +1,15 @@
 uorb start
 param load
-param set MAV_TYPE 3
-param set SYS_AUTOSTART 4010
-param set SYS_RESTART_TYPE 2
-param set COM_DISARM_LAND 0
-dataman start
 param set CAL_GYRO0_ID 2293768
 param set CAL_ACC0_ID 1376264
 param set CAL_ACC1_ID 1310728
 param set CAL_MAG0_ID 196616
+param set COM_DISARM_LAND 0
+param set MAV_TYPE 3
+param set SDLOG_DIRS_MAX 7
+param set SYS_AUTOSTART 4010
+param set SYS_RESTART_TYPE 2
+dataman start
 
 simulator start -s
 

--- a/posix-configs/SITL/init/ekf2/iris
+++ b/posix-configs/SITL/init/ekf2/iris
@@ -39,6 +39,7 @@ param set NAV_DLL_ACT 2
 param set RTL_DESCEND_ALT 5.0
 param set RTL_LAND_DELAY 5
 param set RTL_RETURN_ALT 30.0
+param set SDLOG_DIRS_MAX 7
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set SYS_AUTOSTART 4010

--- a/posix-configs/SITL/init/ekf2/iris_1
+++ b/posix-configs/SITL/init/ekf2/iris_1
@@ -40,12 +40,13 @@ param set NAV_DLL_ACT 2
 param set RTL_DESCEND_ALT 5.0
 param set RTL_LAND_DELAY 5
 param set RTL_RETURN_ALT 30.0
+param set SDLOG_DIRS_MAX 7
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
+param set SITL_UDP_PRT 14560
 param set SYS_AUTOSTART 4010
 param set SYS_MC_EST_GROUP 2
 param set SYS_RESTART_TYPE 2
-param set SITL_UDP_PRT 14560
 replay tryapplyparams
 simulator start -s
 tone_alarm start

--- a/posix-configs/SITL/init/ekf2/iris_2
+++ b/posix-configs/SITL/init/ekf2/iris_2
@@ -40,12 +40,13 @@ param set NAV_DLL_ACT 2
 param set RTL_DESCEND_ALT 5.0
 param set RTL_LAND_DELAY 5
 param set RTL_RETURN_ALT 30.0
+param set SDLOG_DIRS_MAX 7
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
+param set SITL_UDP_PRT 14562
 param set SYS_AUTOSTART 4010
 param set SYS_MC_EST_GROUP 2
 param set SYS_RESTART_TYPE 2
-param set SITL_UDP_PRT 14562
 replay tryapplyparams
 simulator start -s
 tone_alarm start

--- a/posix-configs/SITL/init/ekf2/iris_irlock
+++ b/posix-configs/SITL/init/ekf2/iris_irlock
@@ -39,6 +39,7 @@ param set NAV_DLL_ACT 2
 param set RTL_DESCEND_ALT 5.0
 param set RTL_LAND_DELAY 5
 param set RTL_RETURN_ALT 30.0
+param set SDLOG_DIRS_MAX 7
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set SYS_AUTOSTART 4010

--- a/posix-configs/SITL/init/ekf2/iris_opt_flow
+++ b/posix-configs/SITL/init/ekf2/iris_opt_flow
@@ -31,6 +31,7 @@ param set COM_OBL_RC_ACT 0
 param set RTL_RETURN_ALT 30.0
 param set RTL_DESCEND_ALT 5.0
 param set RTL_LAND_DELAY 5
+param set SDLOG_DIRS_MAX 7
 param set MIS_TAKEOFF_ALT 2.5
 param set MC_ROLLRATE_P 0.2
 param set MC_PITCHRATE_P 0.2

--- a/posix-configs/SITL/init/ekf2/iris_replay
+++ b/posix-configs/SITL/init/ekf2/iris_replay
@@ -1,4 +1,5 @@
 uorb start
+param set SDLOG_DIRS_MAX 7
 
 ekf2 start -r
 logger start -f -t -b 1000 -p vehicle_attitude

--- a/posix-configs/SITL/init/ekf2/iris_rplidar
+++ b/posix-configs/SITL/init/ekf2/iris_rplidar
@@ -39,6 +39,7 @@ param set NAV_DLL_ACT 2
 param set RTL_DESCEND_ALT 5.0
 param set RTL_LAND_DELAY 5
 param set RTL_RETURN_ALT 30.0
+param set SDLOG_DIRS_MAX 7
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set SYS_AUTOSTART 4010

--- a/posix-configs/SITL/init/ekf2/multiple_iris
+++ b/posix-configs/SITL/init/ekf2/multiple_iris
@@ -39,6 +39,7 @@ param set NAV_DLL_ACT 2
 param set RTL_DESCEND_ALT 5.0
 param set RTL_LAND_DELAY 5
 param set RTL_RETURN_ALT 30.0
+param set SDLOG_DIRS_MAX 7
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set SYS_AUTOSTART 4010

--- a/posix-configs/SITL/init/ekf2/plane
+++ b/posix-configs/SITL/init/ekf2/plane
@@ -28,6 +28,7 @@ param set NAV_LOITER_RAD 50
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set SENS_DPRES_OFF 0.001
+param set SDLOG_DIRS_MAX 7
 
 param set EKF2_AID_MASK 1
 param set EKF2_ANGERR_INIT 0.01

--- a/posix-configs/SITL/init/ekf2/rover
+++ b/posix-configs/SITL/init/ekf2/rover
@@ -44,6 +44,7 @@ param set NAV_LOITER_RAD 2
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set SENS_DPRES_OFF 0.001
+param set SDLOG_DIRS_MAX 7
 param set SYS_AUTOSTART 50002
 param set SYS_MC_EST_GROUP 2
 param set SYS_RESTART_TYPE 2

--- a/posix-configs/SITL/init/ekf2/solo
+++ b/posix-configs/SITL/init/ekf2/solo
@@ -36,6 +36,7 @@ param set NAV_DLL_ACT 2
 param set RTL_DESCEND_ALT 10.0
 param set RTL_LAND_DELAY 0
 param set RTL_RETURN_ALT 30.0
+param set SDLOG_DIRS_MAX 7
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set SYS_AUTOSTART 4010

--- a/posix-configs/SITL/init/ekf2/standard_vtol
+++ b/posix-configs/SITL/init/ekf2/standard_vtol
@@ -49,6 +49,7 @@ param set NAV_LOITER_RAD 80
 param set RTL_DESCEND_ALT 10.0
 param set RTL_LAND_DELAY 0
 param set RTL_RETURN_ALT 30.0
+param set SDLOG_DIRS_MAX 7
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set SENS_DPRES_OFF 0.001

--- a/posix-configs/SITL/init/ekf2/tailsitter
+++ b/posix-configs/SITL/init/ekf2/tailsitter
@@ -32,6 +32,7 @@ param set MPC_XY_VEL_P 0.05
 param set MPC_Z_VEL_I 0.15
 param set MPC_Z_VEL_P 0.8
 param set NAV_DLL_ACT 2
+param set SDLOG_DIRS_MAX 7
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set SENS_DPRES_OFF 0.001

--- a/posix-configs/SITL/init/ekf2/typhoon_h480
+++ b/posix-configs/SITL/init/ekf2/typhoon_h480
@@ -38,6 +38,7 @@ param set NAV_DLL_ACT 2
 param set RTL_DESCEND_ALT 10.0
 param set RTL_LAND_DELAY 0
 param set RTL_RETURN_ALT 30.0
+param set SDLOG_DIRS_MAX 7
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set SYS_AUTOSTART 6001

--- a/posix-configs/SITL/init/lpe/hippocampus
+++ b/posix-configs/SITL/init/lpe/hippocampus
@@ -1,14 +1,15 @@
 uorb start
 param load
-param set MAV_TYPE 3
-param set SYS_AUTOSTART 4010
-param set SYS_RESTART_TYPE 2
-param set COM_DISARM_LAND 0
-dataman start
 param set CAL_GYRO0_ID 2293768
 param set CAL_ACC0_ID 1376264
 param set CAL_ACC1_ID 1310728
 param set CAL_MAG0_ID 196616
+param set COM_DISARM_LAND 0
+param set MAV_TYPE 3
+param set SDLOG_DIRS_MAX 7
+param set SYS_AUTOSTART 4010
+param set SYS_RESTART_TYPE 2
+dataman start
 
 simulator start -s
 

--- a/posix-configs/SITL/init/lpe/iris
+++ b/posix-configs/SITL/init/lpe/iris
@@ -41,6 +41,7 @@ param set MPC_Z_VEL_P 0.6
 param set MPC_Z_VEL_I 0.15
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01
+param set SDLOG_DIRS_MAX 7
 # GPS only mode
 param set LPE_FUSION 145
 

--- a/posix-configs/SITL/init/lpe/iris_1
+++ b/posix-configs/SITL/init/lpe/iris_1
@@ -43,6 +43,7 @@ param set MPC_Z_VEL_I 0.15
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01
 param set SITL_UDP_PRT 14560
+param set SDLOG_DIRS_MAX 7
 # GPS only mode
 param set LPE_FUSION 145
 

--- a/posix-configs/SITL/init/lpe/iris_2
+++ b/posix-configs/SITL/init/lpe/iris_2
@@ -43,6 +43,7 @@ param set MPC_Z_VEL_I 0.15
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01
 param set SITL_UDP_PRT 14562
+param set SDLOG_DIRS_MAX 7
 # GPS only mode
 param set LPE_FUSION 145
 

--- a/posix-configs/SITL/init/lpe/iris_irlock
+++ b/posix-configs/SITL/init/lpe/iris_irlock
@@ -45,6 +45,7 @@ param set MC_PITCHRATE_MAX 150
 param set MC_ROLLRATE_MAX 150
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01
+param set SDLOG_DIRS_MAX 7
 # GPS only mode
 param set LPE_FUSION 145
 param set LPE_EPH_MAX 5

--- a/posix-configs/SITL/init/lpe/iris_opt_flow
+++ b/posix-configs/SITL/init/lpe/iris_opt_flow
@@ -40,6 +40,7 @@ param set MPC_Z_VEL_P 0.8
 param set MPC_Z_VEL_I 0.15
 param set MPC_XY_VEL_P 0.15
 param set MPC_XY_VEL_I 0.2
+param set SDLOG_DIRS_MAX 7
 
 # changes for optical flow navigation
 param set MC_PITCH_P 5.0

--- a/posix-configs/SITL/init/lpe/iris_rplidar
+++ b/posix-configs/SITL/init/lpe/iris_rplidar
@@ -41,6 +41,7 @@ param set MPC_HOLD_XY_DZ 0.1
 param set MPC_Z_VEL_P 0.6
 param set MPC_Z_VEL_I 0.15
 param set LPE_FUSION 242
+param set SDLOG_DIRS_MAX 7
 
 replay tryapplyparams
 simulator start -s

--- a/posix-configs/SITL/init/lpe/plane
+++ b/posix-configs/SITL/init/lpe/plane
@@ -28,6 +28,7 @@ param set NAV_ACC_RAD 15.0
 param set NAV_LOITER_RAD 50
 param set MIS_LTRMIN_ALT 30
 param set MIS_TAKEOFF_ALT 30
+param set SDLOG_DIRS_MAX 7
 
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01

--- a/posix-configs/SITL/init/lpe/rover
+++ b/posix-configs/SITL/init/lpe/rover
@@ -43,6 +43,7 @@ param set SENS_DPRES_OFF 0.001
 param set SYS_AUTOSTART 50002
 param set SYS_MC_EST_GROUP 1
 param set SYS_RESTART_TYPE 2
+param set SDLOG_DIRS_MAX 7
 replay tryapplyparams
 simulator start -s
 tone_alarm start

--- a/posix-configs/SITL/init/lpe/solo
+++ b/posix-configs/SITL/init/lpe/solo
@@ -41,6 +41,7 @@ param set MPC_Z_VEL_P 0.6
 param set MPC_Z_VEL_I 0.15
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01
+param set SDLOG_DIRS_MAX 7
 param set LPE_FUSION 247
 # 11110111 no vis yaw (1 << 3)
 

--- a/posix-configs/SITL/init/lpe/standard_vtol
+++ b/posix-configs/SITL/init/lpe/standard_vtol
@@ -53,6 +53,7 @@ param set RTL_DESCEND_ALT 10.0
 param set RTL_LAND_DELAY 0
 param set COM_DISARM_LAND 5
 param set MPC_ACC_HOR_MAX 2
+param set SDLOG_DIRS_MAX 7
 replay tryapplyparams
 simulator start -s
 tone_alarm start

--- a/posix-configs/SITL/init/lpe/typhoon_h480
+++ b/posix-configs/SITL/init/lpe/typhoon_h480
@@ -41,6 +41,7 @@ param set MPC_XY_VEL_I 0.2
 param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01
 param set EKF2_MAG_TYPE 1
+param set SDLOG_DIRS_MAX 7
 replay tryapplyparams
 simulator start -s
 tone_alarm start

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -2072,7 +2072,7 @@ int Logger::check_free_space()
 			break;
 		}
 
-		PX4_WARN("removing log directory %s to get more space (left=%u MiB)", directory_to_delete,
+		PX4_INFO("removing log directory %s to get more space (left=%u MiB)", directory_to_delete,
 			 (unsigned int)(statfs_buf.f_bavail / 1024U * statfs_buf.f_bsize / 1024U));
 
 		if (remove_directory(directory_to_delete)) {


### PR DESCRIPTION
This makes sure to only keep the logs from the last 7 different dates, to avoid huge log directories.