### PR TITLE
vmount: don't ignore commands to all component ids and prevent race

### DIFF
--- a/src/drivers/vmount/input_mavlink.cpp
+++ b/src/drivers/vmount/input_mavlink.cpp
@@ -230,8 +230,12 @@ int InputMavlinkCmdMount::update_impl(unsigned int timeout_ms, ControlData **con
 			vehicle_command_s vehicle_command;
 			orb_copy(ORB_ID(vehicle_command), _vehicle_command_sub, &vehicle_command);
 
-			// process only if the command is for us
-			if (vehicle_command.target_system != _mav_sys_id || vehicle_command.target_component != _mav_comp_id) {
+			// Process only if the command is for us or for anyone.
+			const bool sysid_correct = (vehicle_command.target_system == _mav_sys_id);
+			const bool compid_correct = ((vehicle_command.target_component == _mav_comp_id) ||
+						     (vehicle_command.target_component == MAV_COMP_ID_ALL));
+
+			if (!sysid_correct || !compid_correct) {
 				return 0;
 			}
 

--- a/src/drivers/vmount/input_mavlink.cpp
+++ b/src/drivers/vmount/input_mavlink.cpp
@@ -230,10 +230,10 @@ int InputMavlinkCmdMount::update_impl(unsigned int timeout_ms, ControlData **con
 			vehicle_command_s vehicle_command;
 			orb_copy(ORB_ID(vehicle_command), _vehicle_command_sub, &vehicle_command);
 
-			// Process only if the command is for us or for anyone.
+			// Process only if the command is for us or for anyone (component id 0).
 			const bool sysid_correct = (vehicle_command.target_system == _mav_sys_id);
 			const bool compid_correct = ((vehicle_command.target_component == _mav_comp_id) ||
-						     (vehicle_command.target_component == MAV_COMP_ID_ALL));
+						     (vehicle_command.target_component == 0));
 
 			if (!sysid_correct || !compid_correct) {
 				return 0;

--- a/src/drivers/vmount/vmount.cpp
+++ b/src/drivers/vmount/vmount.cpp
@@ -352,6 +352,8 @@ static int vmount_thread_main(int argc, char *argv[])
 			}
 		}
 
+		bool input_changed = false;
+
 		if (thread_data.input_objs_len > 0) {
 
 			//get input: we cannot make the timeout too large, because the output needs to update
@@ -373,11 +375,17 @@ static int vmount_thread_main(int argc, char *argv[])
 				if (control_data_to_check != nullptr || already_active) {
 					control_data = control_data_to_check;
 					last_active = i;
+
+					if (!already_active) {
+						input_changed = true;
+					}
 				}
 			}
 
 			hrt_abstime now = hrt_absolute_time();
-			if (now - last_output_update > 10000) { // rate-limit the update of outputs
+			// Rate-limit the update of outputs, unless we just changed inputs because we wouldn't
+			// want to miss the new control data.
+			if (now - last_output_update > 10000 || input_changed) {
 				last_output_update = now;
 
 				//update output


### PR DESCRIPTION
This resolves the case where a gimbal command assembled by
QGroundControl is rejected because the component id is set to 0 (for
all) and the component id of the vehicle is e.g. 1.