### PR TITLE
CI: improve mavros SITL tests logging

### DIFF
--- a/integrationtests/python_src/px4_it/mavros/mavros_offboard_attctl_test.py
+++ b/integrationtests/python_src/px4_it/mavros/mavros_offboard_attctl_test.py
@@ -43,8 +43,9 @@ PKG = 'px4'
 
 import rospy
 from geometry_msgs.msg import Quaternion, Vector3
-from mavros_msgs.msg import AttitudeTarget, ExtendedState
+from mavros_msgs.msg import AttitudeTarget
 from mavros_test_common import MavrosTestCommon
+from pymavlink import mavutil
 from std_msgs.msg import Header
 from threading import Thread
 from tf.transformations import quaternion_from_euler
@@ -72,7 +73,7 @@ class MavrosOffboardAttctlTest(MavrosTestCommon):
         self.att_thread.start()
 
     def tearDown(self):
-        pass
+        super(MavrosOffboardAttctlTest, self).tearDown()
 
     #
     # Helper methods
@@ -107,8 +108,10 @@ class MavrosOffboardAttctlTest(MavrosTestCommon):
 
         # make sure the simulation is ready to start the mission
         self.wait_for_topics(60)
-        self.wait_on_landed_state(ExtendedState.LANDED_STATE_ON_GROUND, 10, -1)
+        self.wait_for_landed_state(mavutil.mavlink.MAV_LANDED_STATE_ON_GROUND,
+                                   10, -1)
 
+        self.log_topic_vars()
         self.set_mode("OFFBOARD", 5)
         self.set_arm(True, 5)
 

--- a/integrationtests/python_src/px4_it/mavros/mavros_offboard_posctl_test.py
+++ b/integrationtests/python_src/px4_it/mavros/mavros_offboard_posctl_test.py
@@ -45,8 +45,8 @@ import rospy
 import math
 import numpy as np
 from geometry_msgs.msg import PoseStamped, Quaternion
-from mavros_msgs.msg import ExtendedState
 from mavros_test_common import MavrosTestCommon
+from pymavlink import mavutil
 from std_msgs.msg import Header
 from threading import Thread
 from tf.transformations import quaternion_from_euler
@@ -77,7 +77,7 @@ class MavrosOffboardPosctlTest(MavrosTestCommon):
         self.pos_thread.start()
 
     def tearDown(self):
-        pass
+        super(MavrosOffboardPosctlTest, self).tearDown()
 
     #
     # Helper methods
@@ -155,8 +155,10 @@ class MavrosOffboardPosctlTest(MavrosTestCommon):
 
         # make sure the simulation is ready to start the mission
         self.wait_for_topics(60)
-        self.wait_on_landed_state(ExtendedState.LANDED_STATE_ON_GROUND, 10, -1)
+        self.wait_for_landed_state(mavutil.mavlink.MAV_LANDED_STATE_ON_GROUND,
+                                   10, -1)
 
+        self.log_topic_vars()
         self.set_mode("OFFBOARD", 5)
         self.set_arm(True, 5)
 


### PR DESCRIPTION
* add more logging to help with #8556
* log subscribed topics on mission start and test exit (pass or fail)
* use mavlink enums everywhere to avoid maintaining dictionary mappings and to have readable values
* log when the FCU advances to next mission item without satisfying the position reached offset/radius 
* some renaming for readability
* log more state value changes (connected and MAV_STATUS)

The overall goal is to make interpreting failures easier and be able to see what is going on in the case of hard to replicate intermittent failures. This aims to identify when the PX4 sitl process terminates during the test, seen by the connected value reported by mavros. Also logs a message when the position offset/radius isn't satisfied. Before, this would fail after the timeout, reporting at that time how far away it was from the goal with a "took too long to reach"  message, which isn't completely helpful. You may want to see how far away it was when the FCU determined it got there and moved on. It is also important to see the radius values being used at that moment as they change in FW and VTOL transition events.  Removing magic numbers and using mavlink enums is an added bonus to this PR. Formatting done with yapf w/ default settings.

@dagar 