### PR TITLE
MC: disable roll/pitch modification in manual mode

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -2916,8 +2916,8 @@ MulticopterPositionControl::generate_attitude_setpoint()
 		_att_sp.pitch_body = euler_sp(1);
 		_att_sp.yaw_body += euler_sp(2);
 
-		/* only if optimal recovery is not used, modify roll/pitch */
-		if (!(_vehicle_status.is_vtol && _params.opt_recover)) {
+		/* only if we're a VTOL and optimal recovery is not used, modify roll/pitch */
+		if (_vehicle_status.is_vtol && !_params.opt_recover) {
 			// construct attitude setpoint rotation matrix. modify the setpoints for roll
 			// and pitch such that they reflect the user's intention even if a yaw error
 			// (yaw_sp - yaw) is present. In the presence of a yaw error constructing a rotation matrix


### PR DESCRIPTION
This disables the roll/pitch modifications in presence of large yaw errors for multicopters, introduced in #4564. As discussed in https://github.com/PX4/Firmware/issues/7949, it is the cause of oscillations and unstable flight, when flying at large tilt angles (>50 deg) and fast maneuvers.
As yaw control got improved already (#7997), I don't think it's needed for multicopters in general.
It is the last change required to fix https://github.com/PX4/Firmware/issues/7949.

I have been flying with this and https://github.com/PX4/Firmware/pull/7920 for several months now on different vehicles, and the flight performance is noticeably improved.

I left it enabled for VTOL's, but generally they will have the same problems, so we should reconsider for VTOL's as well (if we ever want to have a VTOL racer it will become relevant).

@MaEtUgR @tumbili 