### PR TITLE
tfmini fixes

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -194,7 +194,7 @@ then
 			# lis3mdl internal SPI bus is rotated 90 deg yaw
 		else
 			# BMI055 gyro internal SPI bus
-			bmi055 -G start	
+			bmi055 -G start
 		fi
 	fi
 
@@ -396,7 +396,11 @@ fi
 # Benewake TFMini
 if param greater SENS_EN_TFMINI 0
 then
-	tfmini start
+	if ver hwcmp PX4FMU_V3
+	then
+		# start the driver on serial 4/5
+		tfmini start -d /dev/ttyS6
+	fi
 fi
 
 # Wait 20 ms for sensors (because we need to wait for the HRT and work queue callbacks to fire)


### PR DESCRIPTION
This fixes the tfmini for other boards than Pixhawk v2.

The main issue was the default device path https://github.com/PX4/Firmware/blob/master/src/drivers/distance_sensor/tfmini/tfmini.cpp#L84

The driver was started without any specific device path which resulted in problems for other boards -> e.g. disables other sensors.
Stopping the driver and restarting it on the correct device path didn't work... not sure why. By requiring the device path we can solve the issue.