### PR TITLE
Fix uorb priority when subscribed before advertising

### DIFF
--- a/src/modules/uORB/uORBDevices.cpp
+++ b/src/modules/uORB/uORBDevices.cpp
@@ -927,6 +927,7 @@ uORB::DeviceMaster::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 
 						if ((existing_node != nullptr) && !(existing_node->is_published())) {
 							/* nothing has been published yet, lets claim it */
+							existing_node->set_priority(adv->priority);
 							ret = PX4_OK;
 
 						} else {

--- a/src/modules/uORB/uORBDevices.hpp
+++ b/src/modules/uORB/uORBDevices.hpp
@@ -185,6 +185,8 @@ public:
 	unsigned int published_message_count() const { return _generation; }
 	const struct orb_metadata *get_meta() const { return _meta; }
 
+	void set_priority(uint8_t priority) { _priority = priority; }
+
 protected:
 	virtual pollevent_t poll_state(device::file_t *filp);
 	virtual void poll_notify_one(px4_pollfd_struct_t *fds, pollevent_t events);
@@ -215,7 +217,7 @@ private:
 	uint8_t     *_data;   /**< allocated object buffer */
 	hrt_abstime   _last_update; /**< time the object was last updated */
 	volatile unsigned   _generation;  /**< object generation count */
-	const uint8_t   _priority;  /**< priority of the topic */
+	uint8_t   _priority;  /**< priority of the topic */
 	bool _published;  /**< has ever data been published */
 	uint8_t _queue_size; /**< maximum number of elements in the queue */
 	int16_t _subscriber_count;

--- a/src/modules/uORB/uORBManager.cpp
+++ b/src/modules/uORB/uORBManager.cpp
@@ -435,6 +435,17 @@ int uORB::Manager::node_open
 		}
 	}
 
+	/*
+	 else if (advertiser) {
+		 * We have a valid fd and are an advertiser.
+		 * This can happen if the topic is already subscribed/published, and orb_advertise() is called,
+		 * where instance==nullptr.
+		 * We would need to set the priority here (via px4_ioctl(fd, ...) and a new IOCTL), but orb_advertise()
+		 * uses ORB_PRIO_DEFAULT, and a subscriber also creates the node with ORB_PRIO_DEFAULT. So we don't need
+		 * to do anything here.
+	 }
+	 */
+
 	if (fd < 0) {
 		errno = EIO;
 		return ERROR;


### PR DESCRIPTION
This fixes the case where a topic instance is already subscribed, and
advertised later. The subscriber will create the DeviceNode with default
priority, and the advertiser will just use the existing DeviceNode,
without updating to the requested priority.

Fixes  #8724. Credits for discovering this go to @lijieamd, thanks!