### PR TITLE
Cygwin: repair NuttX build 

### DIFF
--- a/cmake/toolchains/Toolchain-arm-none-eabi.cmake
+++ b/cmake/toolchains/Toolchain-arm-none-eabi.cmake
@@ -16,7 +16,6 @@
 # CMAKE_FIND_ROOT_PATH_MODE_INCLUDE
 
 include(CMakeForceCompiler)
-include(cygwin_cygpath)
 
 # this one is important
 set(CMAKE_SYSTEM_NAME Generic)
@@ -83,9 +82,6 @@ elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "cortex-m3")
 else ()
 	message(FATAL_ERROR "Processor not recognised in toolchain file")
 endif()
-
-# only in the cygwin environment: convert absolute PX4 include path used in Make.defs.in to mixed windows (C:/...)
-CYGPATH(PX4_SOURCE_DIR PX4_SOURCE_DIR_CYG)
 
 set(c_flags "-fno-common -ffunction-sections -fdata-sections")
 set(cxx_flags "-fno-common -ffunction-sections -fdata-sections")

--- a/cmake/toolchains/Toolchain-arm-none-eabi.cmake
+++ b/cmake/toolchains/Toolchain-arm-none-eabi.cmake
@@ -16,11 +16,12 @@
 # CMAKE_FIND_ROOT_PATH_MODE_INCLUDE
 
 include(CMakeForceCompiler)
+include(cygwin_cygpath)
 
 # this one is important
 set(CMAKE_SYSTEM_NAME Generic)
 
-#this one not so much
+# this one not so much
 set(CMAKE_SYSTEM_VERSION 1)
 
 # specify the cross compiler
@@ -82,6 +83,9 @@ elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "cortex-m3")
 else ()
 	message(FATAL_ERROR "Processor not recognised in toolchain file")
 endif()
+
+# only in the cygwin environment: convert absolute PX4 include path used in Make.defs.in to mixed windows (C:/...)
+CYGPATH(PX4_SOURCE_DIR PX4_SOURCE_DIR_CYG)
 
 set(c_flags "-fno-common -ffunction-sections -fdata-sections")
 set(cxx_flags "-fno-common -ffunction-sections -fdata-sections")

--- a/platforms/nuttx/nuttx-configs/Make.defs.in
+++ b/platforms/nuttx/nuttx-configs/Make.defs.in
@@ -45,7 +45,21 @@ NM = ${CMAKE_NM}
 OBJCOPY = ${CMAKE_OBJCOPY}
 OBJDUMP = ${CMAKE_OBJDUMP}
 
-CFLAGS = -Os -g2 -I${PX4_SOURCE_DIR}/src/include ${CMAKE_C_FLAGS} -I. -isystem $(TOPDIR)/include \
+ifeq ($(WINTOOL),y)
+  # Cygwin toolchain
+  DIRLINK = $(TOPDIR)/tools/copydir.sh
+  DIRUNLINK = $(TOPDIR)/tools/unlink.sh
+  MKDEP = $(TOPDIR)/tools/mknulldeps.sh
+  ARCHINCLUDES = -I. -isystem "$(shell cygpath -w $(TOPDIR)/include)"
+  ARCHXXINCLUDES = $(ARCHINCLUDES) -isystem "$(shell cygpath -w $(TOPDIR)/include/cxx)"
+else
+  # Linux
+  MKDEP = $(TOPDIR)/tools/mkdeps$(HOSTEXEEXT)
+  ARCHINCLUDES = -I. -isystem $(TOPDIR)/include
+  ARCHXXINCLUDES = $(ARCHINCLUDES) -isystem $(TOPDIR)/include/cxx
+endif
+
+CFLAGS = -Os -g2 -I${PX4_SOURCE_DIR_CYG}/src/include ${CMAKE_C_FLAGS} $(ARCHINCLUDES) \
 	-Wno-bad-function-cast \
 	-Wno-cpp \
 	-Wno-float-equal \
@@ -62,7 +76,7 @@ CFLAGS = -Os -g2 -I${PX4_SOURCE_DIR}/src/include ${CMAKE_C_FLAGS} -I. -isystem $
 	-Wno-sign-compare \
 	-Wno-type-limits
 
-CXXFLAGS = -Os -g2 -I${PX4_SOURCE_DIR}/src/include ${CMAKE_CXX_FLAGS} -I. -isystem $(TOPDIR)/include -isystem $(TOPDIR)/include/cxx \
+CXXFLAGS = -Os -g2 -I${PX4_SOURCE_DIR_CYG}/src/include ${CMAKE_CXX_FLAGS} $(ARCHXXINCLUDES) \
 	-fcheck-new \
 	-fno-builtin \
 	-Wno-double-promotion \

--- a/platforms/nuttx/nuttx-configs/Make.defs.in
+++ b/platforms/nuttx/nuttx-configs/Make.defs.in
@@ -45,21 +45,26 @@ NM = ${CMAKE_NM}
 OBJCOPY = ${CMAKE_OBJCOPY}
 OBJDUMP = ${CMAKE_OBJDUMP}
 
-ifeq ($(WINTOOL),y)
-  # Cygwin toolchain
-  DIRLINK = $(TOPDIR)/tools/copydir.sh
-  DIRUNLINK = $(TOPDIR)/tools/unlink.sh
-  MKDEP = $(TOPDIR)/tools/mknulldeps.sh
-  ARCHINCLUDES = -I. -isystem "$(shell cygpath -w $(TOPDIR)/include)"
+# Include paths with Cygwin path conversion
+ifneq (, $(findstring CYGWIN, $(shell uname)))
+  WINTOOL = y
+  PX4INCLUDES = -I"$(shell cygpath -w ${PX4_SOURCE_DIR}/src/include)"
+  ARCHINCLUDES = $(PX4INCLUDES) -I. -isystem "$(shell cygpath -w $(TOPDIR)/include)"
   ARCHXXINCLUDES = $(ARCHINCLUDES) -isystem "$(shell cygpath -w $(TOPDIR)/include/cxx)"
 else
-  # Linux
-  MKDEP = $(TOPDIR)/tools/mkdeps$(HOSTEXEEXT)
-  ARCHINCLUDES = -I. -isystem $(TOPDIR)/include
+  PX4INCLUDES = -I${PX4_SOURCE_DIR}/src/include
+  ARCHINCLUDES = $(PX4INCLUDES) -I. -isystem $(TOPDIR)/include
   ARCHXXINCLUDES = $(ARCHINCLUDES) -isystem $(TOPDIR)/include/cxx
 endif
 
-CFLAGS = -Os -g2 -I${PX4_SOURCE_DIR_CYG}/src/include ${CMAKE_C_FLAGS} $(ARCHINCLUDES) \
+# Windows toolchain (MSYS & Cygwin) symbolic link handling
+ifeq ($(WINTOOL),y)
+  DIRLINK = $(TOPDIR)/tools/copydir.sh
+  DIRUNLINK = $(TOPDIR)/tools/unlink.sh
+  MKDEP = $(TOPDIR)/tools/mknulldeps.sh
+endif
+
+CFLAGS = -Os -g2 ${CMAKE_C_FLAGS} $(ARCHINCLUDES) \
 	-Wno-bad-function-cast \
 	-Wno-cpp \
 	-Wno-float-equal \
@@ -76,7 +81,7 @@ CFLAGS = -Os -g2 -I${PX4_SOURCE_DIR_CYG}/src/include ${CMAKE_C_FLAGS} $(ARCHINCL
 	-Wno-sign-compare \
 	-Wno-type-limits
 
-CXXFLAGS = -Os -g2 -I${PX4_SOURCE_DIR_CYG}/src/include ${CMAKE_CXX_FLAGS} $(ARCHXXINCLUDES) \
+CXXFLAGS = -Os -g2 ${CMAKE_CXX_FLAGS} $(ARCHXXINCLUDES) \
 	-fcheck-new \
 	-fno-builtin \
 	-Wno-double-promotion \


### PR DESCRIPTION
after 1f63d85869b3495f3f66a3300b365c57469f1020

all the NuttX specific WINTOOL define handling was skipped in cmake Make.defs generation (#8573)
The Nuttx build is makfile based and needs its cygwin treatment (https://github.com/PX4-NuttX/nuttx/blob/b18053574bf41712cef93e31bf178518f451a350/configs/stm32f4discovery/scripts/Make.defs#L42-L56)

Additionally the ${PX4_SOURCE_DIR}/src/include which was added through cmake needs path conversion

The two root causes for the special handling are:
- ARM GCC for Windows doesn't support cygwin paths passed as an argument
  so they need to be either relative or converted via cypath tool
- Symbolic links are totally different under Windows and because NuttX uses them extensively
  it has special handling scripts that need to be fed with the correct defines

---

@dagar Now it's partly makefile `${shell ...}` path conversion like NuttX did it before and partly  cmake `CYGPATH(...)` conversion because you added  `${PX4_SOURCE_DIR}/src/include` via cmake. What do you think?

How was `${PX4_SOURCE_DIR}/src/include` included before? It always found `visibility.h` so it was included but not in the `CFLAGS`...

I tested `make px4fmu-v4_default` and `make px4fmu-v2_default` and they run through fine with these changes.