### PR TITLE
SITL_configs: by default, disable datalink and RC failsafes 

### DIFF
--- a/posix-configs/SITL/init/ekf2/hippocampus
+++ b/posix-configs/SITL/init/ekf2/hippocampus
@@ -9,6 +9,8 @@ param set MAV_TYPE 3
 param set SDLOG_DIRS_MAX 7
 param set SYS_AUTOSTART 4010
 param set SYS_RESTART_TYPE 2
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 dataman start
 
 simulator start -s

--- a/posix-configs/SITL/init/ekf2/iris
+++ b/posix-configs/SITL/init/ekf2/iris
@@ -35,7 +35,8 @@ param set MPC_HOLD_MAX_Z 2.0
 param set MPC_Z_VEL_I 0.15
 param set MPC_Z_VEL_P 0.6
 param set NAV_ACC_RAD 2.0
-param set NAV_DLL_ACT 2
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set RTL_DESCEND_ALT 5.0
 param set RTL_LAND_DELAY 5
 param set RTL_RETURN_ALT 30.0

--- a/posix-configs/SITL/init/ekf2/iris_1
+++ b/posix-configs/SITL/init/ekf2/iris_1
@@ -36,7 +36,8 @@ param set MPC_HOLD_MAX_Z 2.0
 param set MPC_Z_VEL_I 0.15
 param set MPC_Z_VEL_P 0.6
 param set NAV_ACC_RAD 2.0
-param set NAV_DLL_ACT 2
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set RTL_DESCEND_ALT 5.0
 param set RTL_LAND_DELAY 5
 param set RTL_RETURN_ALT 30.0

--- a/posix-configs/SITL/init/ekf2/iris_2
+++ b/posix-configs/SITL/init/ekf2/iris_2
@@ -36,7 +36,8 @@ param set MPC_HOLD_MAX_Z 2.0
 param set MPC_Z_VEL_I 0.15
 param set MPC_Z_VEL_P 0.6
 param set NAV_ACC_RAD 2.0
-param set NAV_DLL_ACT 2
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set RTL_DESCEND_ALT 5.0
 param set RTL_LAND_DELAY 5
 param set RTL_RETURN_ALT 30.0

--- a/posix-configs/SITL/init/ekf2/iris_irlock
+++ b/posix-configs/SITL/init/ekf2/iris_irlock
@@ -35,7 +35,8 @@ param set MPC_HOLD_MAX_Z 2.0
 param set MPC_Z_VEL_I 0.15
 param set MPC_Z_VEL_P 0.6
 param set NAV_ACC_RAD 2.0
-param set NAV_DLL_ACT 2
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set RTL_DESCEND_ALT 5.0
 param set RTL_LAND_DELAY 5
 param set RTL_RETURN_ALT 30.0

--- a/posix-configs/SITL/init/ekf2/iris_opt_flow
+++ b/posix-configs/SITL/init/ekf2/iris_opt_flow
@@ -22,8 +22,9 @@ param set CAL_MAG0_XOFF 0.01
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set NAV_DLL_ACT 2
 param set COM_DISARM_LAND 3
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set NAV_ACC_RAD 2.0
 param set COM_OF_LOSS_T 5
 param set COM_OBL_ACT 2

--- a/posix-configs/SITL/init/ekf2/iris_rplidar
+++ b/posix-configs/SITL/init/ekf2/iris_rplidar
@@ -35,7 +35,8 @@ param set MPC_HOLD_MAX_Z 2.0
 param set MPC_Z_VEL_I 0.15
 param set MPC_Z_VEL_P 0.6
 param set NAV_ACC_RAD 2.0
-param set NAV_DLL_ACT 2
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set RTL_DESCEND_ALT 5.0
 param set RTL_LAND_DELAY 5
 param set RTL_RETURN_ALT 30.0

--- a/posix-configs/SITL/init/ekf2/multiple_iris
+++ b/posix-configs/SITL/init/ekf2/multiple_iris
@@ -35,7 +35,8 @@ param set MPC_HOLD_MAX_Z 2.0
 param set MPC_Z_VEL_I 0.15
 param set MPC_Z_VEL_P 0.6
 param set NAV_ACC_RAD 2.0
-param set NAV_DLL_ACT 2
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set RTL_DESCEND_ALT 5.0
 param set RTL_LAND_DELAY 5
 param set RTL_RETURN_ALT 30.0

--- a/posix-configs/SITL/init/ekf2/plane
+++ b/posix-configs/SITL/init/ekf2/plane
@@ -23,7 +23,8 @@ param set COM_RC_IN_MODE 1
 param set MIS_LTRMIN_ALT 30
 param set MIS_TAKEOFF_ALT 30
 param set NAV_ACC_RAD 15.0
-param set NAV_DLL_ACT 2
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set NAV_LOITER_RAD 50
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001

--- a/posix-configs/SITL/init/ekf2/rover
+++ b/posix-configs/SITL/init/ekf2/rover
@@ -40,6 +40,7 @@ param set MIS_LTRMIN_ALT 0.01
 param set MIS_TAKEOFF_ALT 0.01
 param set NAV_ACC_RAD 0.5
 param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set NAV_LOITER_RAD 2
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001

--- a/posix-configs/SITL/init/ekf2/solo
+++ b/posix-configs/SITL/init/ekf2/solo
@@ -32,7 +32,8 @@ param set MPC_HOLD_MAX_Z 2.0
 param set MPC_Z_VEL_I 0.15
 param set MPC_Z_VEL_P 0.6
 param set NAV_ACC_RAD 2.0
-param set NAV_DLL_ACT 2
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set RTL_DESCEND_ALT 10.0
 param set RTL_LAND_DELAY 0
 param set RTL_RETURN_ALT 30.0

--- a/posix-configs/SITL/init/ekf2/standard_vtol
+++ b/posix-configs/SITL/init/ekf2/standard_vtol
@@ -44,7 +44,8 @@ param set MPC_Z_VEL_I 0.15
 param set MPC_Z_VEL_MAX_DN 1.5
 param set MPC_Z_VEL_P 0.6
 param set NAV_ACC_RAD 5.0
-param set NAV_DLL_ACT 2
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set NAV_LOITER_RAD 80
 param set RTL_DESCEND_ALT 10.0
 param set RTL_LAND_DELAY 0

--- a/posix-configs/SITL/init/ekf2/tailsitter
+++ b/posix-configs/SITL/init/ekf2/tailsitter
@@ -31,7 +31,8 @@ param set MPC_XY_VEL_D 0.005
 param set MPC_XY_VEL_P 0.05
 param set MPC_Z_VEL_I 0.15
 param set MPC_Z_VEL_P 0.8
-param set NAV_DLL_ACT 2
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set SDLOG_DIRS_MAX 7
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001

--- a/posix-configs/SITL/init/ekf2/typhoon_h480
+++ b/posix-configs/SITL/init/ekf2/typhoon_h480
@@ -34,7 +34,8 @@ param set MPC_XY_VEL_P 0.15
 param set MPC_Z_VEL_I 0.15
 param set MPC_Z_VEL_P 0.6
 param set NAV_ACC_RAD 2.0
-param set NAV_DLL_ACT 2
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set RTL_DESCEND_ALT 10.0
 param set RTL_LAND_DELAY 0
 param set RTL_RETURN_ALT 30.0

--- a/posix-configs/SITL/init/inav/iris
+++ b/posix-configs/SITL/init/inav/iris
@@ -42,7 +42,8 @@ param set MP_ROLLRATE_D 0.001
 param set MP_PITCH_P 4
 param set MP_PITCHRATE_P 0.3
 param set COM_RC_IN_MODE 1
-param set NAV_DLL_ACT 2
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 replay tryapplyparams
 simulator start -s
 tone_alarm start

--- a/posix-configs/SITL/init/inav/iris_opt_flow
+++ b/posix-configs/SITL/init/inav/iris_opt_flow
@@ -22,7 +22,8 @@ param set CAL_MAG0_XOFF 0.01
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set NAV_DLL_ACT 2
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set COM_DISARM_LAND 3
 param set NAV_ACC_RAD 12.0
 param set RTL_RETURN_ALT 30.0

--- a/posix-configs/SITL/init/lpe/hippocampus
+++ b/posix-configs/SITL/init/lpe/hippocampus
@@ -9,6 +9,8 @@ param set MAV_TYPE 3
 param set SDLOG_DIRS_MAX 7
 param set SYS_AUTOSTART 4010
 param set SYS_RESTART_TYPE 2
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 dataman start
 
 simulator start -s

--- a/posix-configs/SITL/init/lpe/iris
+++ b/posix-configs/SITL/init/lpe/iris
@@ -22,8 +22,9 @@ param set CAL_MAG0_XOFF 0.01
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set NAV_DLL_ACT 2
 param set COM_DISARM_LAND 3
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set NAV_ACC_RAD 2.0
 param set COM_OF_LOSS_T 5
 param set COM_OBL_ACT 2

--- a/posix-configs/SITL/init/lpe/iris_1
+++ b/posix-configs/SITL/init/lpe/iris_1
@@ -23,8 +23,9 @@ param set CAL_MAG0_XOFF 0.01
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set NAV_DLL_ACT 2
 param set COM_DISARM_LAND 3
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set NAV_ACC_RAD 2.0
 param set COM_OF_LOSS_T 5
 param set COM_OBL_ACT 2

--- a/posix-configs/SITL/init/lpe/iris_2
+++ b/posix-configs/SITL/init/lpe/iris_2
@@ -23,8 +23,9 @@ param set CAL_MAG0_XOFF 0.01
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set NAV_DLL_ACT 2
 param set COM_DISARM_LAND 3
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set NAV_ACC_RAD 2.0
 param set COM_OF_LOSS_T 5
 param set COM_OBL_ACT 2

--- a/posix-configs/SITL/init/lpe/iris_irlock
+++ b/posix-configs/SITL/init/lpe/iris_irlock
@@ -22,8 +22,9 @@ param set CAL_MAG0_XOFF 0.01
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set NAV_DLL_ACT 2
 param set COM_DISARM_LAND 3
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set NAV_ACC_RAD 2.0
 param set COM_OF_LOSS_T 5
 param set COM_OBL_ACT 2

--- a/posix-configs/SITL/init/lpe/iris_opt_flow
+++ b/posix-configs/SITL/init/lpe/iris_opt_flow
@@ -22,8 +22,9 @@ param set CAL_MAG0_XOFF 0.01
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set NAV_DLL_ACT 2
 param set COM_DISARM_LAND 3
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set NAV_ACC_RAD 2.0
 param set RTL_RETURN_ALT 30.0
 param set RTL_DESCEND_ALT 10.0

--- a/posix-configs/SITL/init/lpe/iris_rplidar
+++ b/posix-configs/SITL/init/lpe/iris_rplidar
@@ -22,8 +22,9 @@ param set CAL_MAG0_XOFF 0.01
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set NAV_DLL_ACT 2
 param set COM_DISARM_LAND 3
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set NAV_ACC_RAD 2.0
 param set COM_OF_LOSS_T 5
 param set COM_OBL_ACT 2

--- a/posix-configs/SITL/init/lpe/plane
+++ b/posix-configs/SITL/init/lpe/plane
@@ -23,7 +23,8 @@ param set SENS_BOARD_ROT 0
 param set SENS_DPRES_OFF 0.001
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set NAV_DLL_ACT 2
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set NAV_ACC_RAD 15.0
 param set NAV_LOITER_RAD 50
 param set MIS_LTRMIN_ALT 30

--- a/posix-configs/SITL/init/lpe/rover
+++ b/posix-configs/SITL/init/lpe/rover
@@ -36,6 +36,7 @@ param set MIS_LTRMIN_ALT 0.01
 param set MIS_TAKEOFF_ALT 0.01
 param set NAV_ACC_RAD 0.5
 param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set NAV_LOITER_RAD 2
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001

--- a/posix-configs/SITL/init/lpe/solo
+++ b/posix-configs/SITL/init/lpe/solo
@@ -22,8 +22,9 @@ param set CAL_MAG0_XOFF 0.01
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set NAV_DLL_ACT 2
 param set COM_DISARM_LAND 3
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set NAV_ACC_RAD 2.0
 param set COM_OF_LOSS_T 5
 param set COM_OBL_ACT 2

--- a/posix-configs/SITL/init/lpe/standard_vtol
+++ b/posix-configs/SITL/init/lpe/standard_vtol
@@ -41,7 +41,8 @@ param set SENS_BOARD_ROT 0
 param set SENS_DPRES_OFF 0.001
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set NAV_DLL_ACT 2
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set NAV_ACC_RAD 5.0
 param set NAV_LOITER_RAD 50
 param set MPC_TKO_SPEED 1.0

--- a/posix-configs/SITL/init/lpe/typhoon_h480
+++ b/posix-configs/SITL/init/lpe/typhoon_h480
@@ -22,8 +22,9 @@ param set CAL_MAG0_XOFF 0.01
 param set SENS_BOARD_ROT 0
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set NAV_DLL_ACT 2
 param set COM_DISARM_LAND 3
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set NAV_ACC_RAD 2.0
 param set RTL_RETURN_ALT 30.0
 param set RTL_DESCEND_ALT 10.0

--- a/posix-configs/SITL/init/rcS_gazebo_delta_wing
+++ b/posix-configs/SITL/init/rcS_gazebo_delta_wing
@@ -22,7 +22,8 @@ param set SENS_BOARD_ROT 8
 param set SENS_DPRES_OFF 0.001
 param set SENS_BOARD_X_OFF 0.000001
 param set COM_RC_IN_MODE 1
-param set NAV_DLL_ACT 2
+param set NAV_DLL_ACT 0
+param set NAV_RCL_ACT 0
 param set NAV_ACC_RAD 15.0
 param set FW_THR_IDLE 0.6
 param set FS_GCS_ENABLE 2


### PR DESCRIPTION
The purpose is to avoid SITL to get into RTL after takeoff and if not using QGC or RC.