### PR TITLE
Send RTPS header and payload in one stream

### DIFF
--- a/msg/templates/uorb_microcdr/microRTPS_client.cpp.template
+++ b/msg/templates/uorb_microcdr/microRTPS_client.cpp.template
@@ -79,6 +79,7 @@ void* send(void* /*unused*/)
     uint64_t sent = 0, total_sent = 0;
     int loop = 0, read = 0;
     uint32_t length = 0;
+    uint16_t header_length = 0;
 
     /* subscribe to topics */
     int fds[@(len(send_topics))] = {};
@@ -91,7 +92,8 @@ void* send(void* /*unused*/)
 
     // microBuffer to serialized using the user defined buffer
     struct microBuffer microBufferWriter;
-    initStaticAlignedBuffer(data_buffer, BUFFER_SIZE, &microBufferWriter);
+    header_length=transport_node->get_header_length();
+    initStaticAlignedBuffer(&data_buffer[header_length], BUFFER_SIZE-header_length, &microBufferWriter);
     // microCDR structs for managing the microBuffer
     struct microCDR microCDRWriter;
     initMicroCDR(&microCDRWriter, &microBufferWriter);
@@ -110,7 +112,9 @@ void* send(void* /*unused*/)
             struct @(topic)_s data;
             // copy raw data into local buffer
             if (orb_copy(ORB_ID(@(topic)), fds[@(idx)], &data) == 0) {
-                serialize_@(topic)(&data, data_buffer, &length, &microCDRWriter);
+                /* payload is shifted by header length to make room for header*/
+                serialize_@(topic)(&data, &data_buffer[header_length], &length, &microCDRWriter);
+
                 if (0 < (read = transport_node->write((char)@(message_id(topic)), data_buffer, length)))
                 {
                     total_sent += read;

--- a/msg/templates/urtps/microRTPS_agent.cpp.template
+++ b/msg/templates/urtps/microRTPS_agent.cpp.template
@@ -166,12 +166,14 @@ void t_send(void *data)
         // Send subscribed topics over UART
         while (topics.hasMsg(&topic_ID))
         {
-            eprosima::fastcdr::FastBuffer cdrbuffer(data_buffer, sizeof(data_buffer));
+            uint16_t header_length = get_header_length();
+            /* make room for the header to fill in later */
+            eprosima::fastcdr::FastBuffer cdrbuffer(&data_buffer[header_length], sizeof(data_buffer)-header_length);
             eprosima::fastcdr::Cdr scdr(cdrbuffer);
             if (topics.getMsg(topic_ID, scdr))
             {
                 length = scdr.getSerializedDataLength();
-                if (0 < (length = transport_node->write(topic_ID, scdr.getBufferPointer(), length)))
+                if (0 < (length = transport_node->write(topic_ID, data_buffer, length)))
                 {
                     total_sent += length;
                     ++sent;

--- a/msg/templates/urtps/microRTPS_transport.h
+++ b/msg/templates/urtps/microRTPS_transport.h
@@ -46,6 +46,8 @@ public:
 	virtual uint8_t close() {return 0;}
 	ssize_t read(uint8_t *topic_ID, char out_buffer[], size_t buffer_len);
 	ssize_t write(const uint8_t topic_ID, char buffer[], size_t length);
+	/* Get the Length of struct Header to make headroom for the size of struct Header alongwith payload*/
+	ssize_t get_header_length();
 
 protected:
 	virtual ssize_t node_read(void *buffer, size_t len) = 0;


### PR DESCRIPTION
This avoids assembling the header and payload on the receiver side.