### PR TITLE
Landing target estmator fixes

### DIFF
--- a/src/modules/landing_target_estimator/LandingTargetEstimator.cpp
+++ b/src/modules/landing_target_estimator/LandingTargetEstimator.cpp
@@ -162,8 +162,10 @@ void LandingTargetEstimator::update()
 
 	if (!_estimator_initialized) {
 		PX4_INFO("Init");
-		_kalman_filter_x.init(_rel_pos(0), 0, _params.pos_unc_init, _params.vel_unc_init);
-		_kalman_filter_y.init(_rel_pos(1), 0, _params.pos_unc_init, _params.vel_unc_init);
+		float vx_init = _vehicleLocalPosition.v_xy_valid ? -_vehicleLocalPosition.vx : 0.f;
+		float vy_init = _vehicleLocalPosition.v_xy_valid ? -_vehicleLocalPosition.vy : 0.f;
+		_kalman_filter_x.init(_rel_pos(0), vx_init, _params.pos_unc_init, _params.vel_unc_init);
+		_kalman_filter_y.init(_rel_pos(1), vy_init, _params.pos_unc_init, _params.vel_unc_init);
 
 		_estimator_initialized = true;
 		_last_update = hrt_absolute_time();

--- a/src/modules/landing_target_estimator/LandingTargetEstimator.cpp
+++ b/src/modules/landing_target_estimator/LandingTargetEstimator.cpp
@@ -94,14 +94,13 @@ void LandingTargetEstimator::update()
 			PX4_WARN("Timeout");
 			_estimator_initialized = false;
 
-		} else if (_vehicleLocalPosition_valid
-			   && _vehicleLocalPosition.v_xy_valid) {
+		} else {
 			float dt = (hrt_absolute_time() - _last_predict) / SEC2USEC;
 
 			// predict target position with the help of accel data
 			matrix::Vector3f a;
 
-			if (_sensorBias_valid) {
+			if (_vehicleAttitude_valid && _sensorBias_valid) {
 				matrix::Quaternion<float> q_att(&_vehicleAttitude.q[0]);
 				_R_att = matrix::Dcm<float>(q_att);
 				a(0) = _sensorBias.accel_x;
@@ -272,7 +271,6 @@ void LandingTargetEstimator::_check_params(const bool force)
 
 void LandingTargetEstimator::_initialize_topics()
 {
-	// subscribe to position, attitude, arming and velocity changes
 	_vehicleLocalPositionSub = orb_subscribe(ORB_ID(vehicle_local_position));
 	_attitudeSub = orb_subscribe(ORB_ID(vehicle_attitude));
 	_sensorBiasSub = orb_subscribe(ORB_ID(sensor_bias));

--- a/src/modules/landing_target_estimator/landing_target_estimator_params.c
+++ b/src/modules/landing_target_estimator/landing_target_estimator_params.c
@@ -107,7 +107,7 @@ PARAM_DEFINE_FLOAT(LTEST_POS_UNC_IN, 0.1f);
  *
  * @group Landing target Estimator
  */
-PARAM_DEFINE_FLOAT(LTEST_VEL_UNC_IN, 1.0f);
+PARAM_DEFINE_FLOAT(LTEST_VEL_UNC_IN, 0.1f);
 
 /**
  * Scale factor for sensor measurements in sensor x axis


### PR DESCRIPTION
This initializes the landing target's velocity to the inverse of the vehicle velocity, which improves estimation right after target acquisition. 

Also adds a small fix such that the validity of the correct uorb messages is checked before using their data in the prediction.