### PR TITLE
commander add parameters for eph, eph, evh thresholds

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.fw_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.fw_defaults
@@ -8,8 +8,11 @@ then
 	# Default parameters for FW
 	#
 	param set COM_POS_FS_DELAY 5
-	param set COM_POS_FS_PROB 1
+	param set COM_POS_FS_EPH 25
+	param set COM_POS_FS_EPV 50
 	param set COM_POS_FS_GAIN 0
+	param set COM_POS_FS_PROB 1
+	param set COM_VEL_FS_EVH 5
 
 	param set EKF2_ARSP_THR 8.0
 	param set EKF2_FUSE_BETA 1

--- a/posix-configs/SITL/init/ekf2/plane
+++ b/posix-configs/SITL/init/ekf2/plane
@@ -19,9 +19,12 @@ param set CAL_MAG0_ID 196616
 param set CAL_MAG0_XOFF 0.01
 
 param set COM_POS_FS_DELAY 5
+param set COM_POS_FS_EPH 25
+param set COM_POS_FS_EPV 50
 param set COM_POS_FS_GAIN 0
 param set COM_POS_FS_PROB 1
 param set COM_RC_IN_MODE 1
+param set COM_VEL_FS_EVH 5
 
 param set EKF2_AID_MASK 1
 param set EKF2_ANGERR_INIT 0.01

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -105,9 +105,8 @@ private:
 		(ParamInt<px4::params::COM_POS_FS_GAIN>) _failsafe_pos_gain
 	)
 
-	static constexpr int64_t sec_to_usec = (1000 * 1000);
-	const int64_t POSVEL_PROBATION_MIN = 1 * sec_to_usec;	/**< minimum probation duration (usec) */
-	const int64_t POSVEL_PROBATION_MAX = 100 * sec_to_usec;	/**< maximum probation duration (usec) */
+	const int64_t POSVEL_PROBATION_MIN = 1_s;	/**< minimum probation duration (usec) */
+	const int64_t POSVEL_PROBATION_MAX = 100_s;	/**< maximum probation duration (usec) */
 
 	hrt_abstime	_last_gpos_fail_time_us{0};	/**< Last time that the global position validity recovery check failed (usec) */
 	hrt_abstime	_last_lpos_fail_time_us{0};	/**< Last time that the local position validity recovery check failed (usec) */

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -87,6 +87,16 @@ public:
 	static bool preflight_check(bool report);
 
 private:
+
+	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::COM_HOME_H_T>) _home_eph_threshold,
+		(ParamFloat<px4::params::COM_HOME_V_T>) _home_epv_threshold,
+
+		(ParamFloat<px4::params::COM_POS_FS_EPH>) _eph_threshold,
+		(ParamFloat<px4::params::COM_POS_FS_EPV>) _epv_threshold,
+		(ParamFloat<px4::params::COM_VEL_FS_EVH>) _evh_threshold,
+	)
+
 	bool handle_command(vehicle_status_s *status_local, const vehicle_command_s &cmd,
 			    actuator_armed_s *armed_local, home_position_s *home, const vehicle_global_position_s &global_pos,
 			    const vehicle_local_position_s &local_pos, orb_advert_t *home_pub, orb_advert_t *command_ack_pub, bool *changed);

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1531,6 +1531,8 @@ Commander::run()
 			struct parameter_update_s param_changed;
 			orb_copy(ORB_ID(parameter_update), param_changed_sub, &param_changed);
 
+			updateParams();
+
 			/* update parameters */
 			if (!armed.armed) {
 				if (param_get(_param_sys_type, &system_type) != OK) {

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -131,7 +131,6 @@ typedef enum VEHICLE_MODE_FLAG
 #define STICK_ON_OFF_LIMIT 0.9f
 
 #define OFFBOARD_TIMEOUT		500000
-#define DIFFPRESS_TIMEOUT		2000000
 
 static constexpr uint64_t HOTPLUG_SENS_TIMEOUT = 8_s;	/**< wait for hotplug sensors to come online for upto 8 seconds */
 

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -715,6 +715,36 @@ PARAM_DEFINE_INT32(COM_POS_FS_PROB, 30);
 PARAM_DEFINE_INT32(COM_POS_FS_GAIN, 10);
 
 /**
+ * Horizontal position error threshold.
+ *
+ * This is the horizontal position error (EPV) threshold that will trigger a failsafe. The default is appropriate for a multicopter. Can be increased for a fixed-wing.
+ *
+ * @unit m
+ * @group Commander
+ */
+PARAM_DEFINE_FLOAT(COM_POS_FS_EPH, 5);
+
+/**
+ * Vertical position error threshold.
+ *
+ * This is the vertical position error (EPV) threshold that will trigger a failsafe. The default is appropriate for a multicopter. Can be increased for a fixed-wing.
+ *
+ * @unit m
+ * @group Commander
+ */
+PARAM_DEFINE_FLOAT(COM_POS_FS_EPV, 10);
+
+/**
+ * Horizontal velocity error threshold.
+ *
+ * This is the horizontal velocity error (EVH) threshold that will trigger a failsafe. The default is appropriate for a multicopter. Can be increased for a fixed-wing.
+ *
+ * @unit m
+ * @group Commander
+ */
+PARAM_DEFINE_FLOAT(COM_VEL_FS_EVH, 1);
+
+/**
  * Next flight UUID
  *
  * This number is incremented automatically after every flight on

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -685,6 +685,8 @@ PARAM_DEFINE_INT32(COM_ARM_AUTH, 256010);
  * @unit sec
  * @reboot_required true
  * @group Commander
+ * @min 1
+ * @max 100
  */
 PARAM_DEFINE_INT32(COM_POS_FS_DELAY, 1);
 
@@ -700,6 +702,8 @@ PARAM_DEFINE_INT32(COM_POS_FS_DELAY, 1);
  * @unit sec
  * @reboot_required true
  * @group Commander
+ * @min 1
+ * @max 100
  */
 PARAM_DEFINE_INT32(COM_POS_FS_PROB, 30);
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -287,6 +287,8 @@ private:
 		(ParamExtInt<px4::params::EKF2_AID_MASK>)
 		_fusion_mode,		///< bitmasked integer that selects which of the GPS and optical flow aiding sources will be used
 		(ParamExtInt<px4::params::EKF2_HGT_MODE>) _vdist_sensor_type,	///< selects the primary source for height data
+		(ParamExtInt<px4::params::EKF2_NOAID_TOUT>)
+		_valid_timeout_max,	///< maximum lapsed time from last fusion of measurements that constrain drift before the EKF will report the horizontal nav solution invalid (uSec)
 
 		// range finder fusion
 		(ParamExtFloat<px4::params::EKF2_RNG_NOISE>) _range_noise,	///< observation noise for range finder measurements (m)
@@ -353,7 +355,7 @@ private:
 		(ParamExtFloat<px4::params::EKF2_TAU_POS>)
 		_tau_pos,		///< time constant used by the output position complementary filter (sec)
 
-		// IMU switch on bias paameters
+		// IMU switch on bias parameters
 		(ParamExtFloat<px4::params::EKF2_GBIAS_INIT>) _gyr_bias_init,	///< 1-sigma gyro bias uncertainty at switch on (rad/sec)
 		(ParamExtFloat<px4::params::EKF2_ABIAS_INIT>)
 		_acc_bias_init,	///< 1-sigma accelerometer bias uncertainty at switch on (m/sec**2)
@@ -453,6 +455,7 @@ Ekf2::Ekf2():
 	_requiredVdrift(_params->req_vdrift),
 	_fusion_mode(_params->fusion_mode),
 	_vdist_sensor_type(_params->vdist_sensor_type),
+	_valid_timeout_max(_params->valid_timeout_max),
 	_range_noise(_params->range_noise),
 	_range_noise_scaler(_params->range_noise_scaler),
 	_range_innov_gate(_params->range_innov_gate),

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -867,7 +867,7 @@ void Ekf2::run()
 		if (airspeed_updated) {
 			airspeed_s airspeed;
 
-			if (orb_copy(ORB_ID(airspeed), _airspeed_sub, &airspeed)) {
+			if (orb_copy(ORB_ID(airspeed), _airspeed_sub, &airspeed) == PX4_OK) {
 				// only set airspeed data if condition for airspeed fusion are met
 				if ((_arspFusionThreshold.get() > FLT_EPSILON) && (airspeed.true_airspeed_m_s > _arspFusionThreshold.get())) {
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1117,9 +1117,8 @@ void Ekf2::run()
 
 			lpos.dist_bottom_rate = -lpos.vz; // Distance to bottom surface (ground) change rate
 
-			bool dead_reckoning;
-			_ekf.get_ekf_lpos_accuracy(&lpos.eph, &lpos.epv, &dead_reckoning);
-			_ekf.get_ekf_vel_accuracy(&lpos.evh, &lpos.evv, &dead_reckoning);
+			_ekf.get_ekf_lpos_accuracy(&lpos.eph, &lpos.epv);
+			_ekf.get_ekf_vel_accuracy(&lpos.evh, &lpos.evv);
 
 			// get state reset information of position and velocity
 			_ekf.get_posD_reset(&lpos.delta_z, &lpos.z_reset_counter);
@@ -1161,7 +1160,9 @@ void Ekf2::run()
 
 				global_pos.yaw = lpos.yaw; // Yaw in radians -PI..+PI.
 
-				_ekf.get_ekf_gpos_accuracy(&global_pos.eph, &global_pos.epv, &global_pos.dead_reckoning);
+				_ekf.get_ekf_gpos_accuracy(&global_pos.eph, &global_pos.epv);
+
+				global_pos.dead_reckoning = _ekf.inertial_dead_reckoning();
 
 				global_pos.terrain_alt_valid = lpos.dist_bottom_valid;
 

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -607,6 +607,17 @@ PARAM_DEFINE_INT32(EKF2_AID_MASK, 1);
 PARAM_DEFINE_INT32(EKF2_HGT_MODE, 0);
 
 /**
+ * Maximum lapsed time from last fusion of measurements that constrain velocity drift before the EKF will report the horizontal nav solution as invalid.
+ *
+ * @group EKF2
+ * @group EKF2
+ * @min 500000
+ * @max 10000000
+ * @unit uSec
+ */
+PARAM_DEFINE_INT32(EKF2_NOAID_TOUT, 5000000);
+
+/**
  * Measurement noise for range finder fusion
  *
  * @group EKF2


### PR DESCRIPTION
This PR adds separate parameters for required eph, eph, evh thresholds. Previously eph and epv thresholds were set from COM_HOME_H_T and COM_HOME_V_T.

COM_POS_FS_EPH

COM_POS_FS_EPV

COM_VEL_FS_EVH

https://github.com/PX4/Firmware/issues/8260