### PR TITLE
Send camera trigger mavlink message in simulation

### DIFF
--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -370,6 +370,7 @@ private:
 	int _vehicle_attitude_sub;
 	int _manual_sub;
 	int _vehicle_status_sub;
+	int _camera_trigger_sub;
 
 	// hil map_ref data
 	struct map_projection_reference_s _hil_local_proj_ref;
@@ -391,6 +392,7 @@ private:
 	void poll_topics();
 	void handle_message(mavlink_message_t *msg, bool publish);
 	void send_controls();
+	void send_camera_trigger();
 	void pollForMAVLinkMessages(bool publish, int udp_port);
 
 	void pack_actuator_message(mavlink_hil_actuator_controls_t &actuator_msg, unsigned index);

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -46,6 +46,7 @@
 #include <conversion/rotation.h>
 #include <mathlib/mathlib.h>
 #include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/camera_trigger.h>
 
 extern "C" __EXPORT hrt_abstime hrt_reset(void);
 
@@ -185,6 +186,18 @@ void Simulator::send_controls()
 		send_mavlink_message(message);
 
 	}
+}
+
+void Simulator::send_camera_trigger()
+{
+        mavlink_command_long_t cmd_long = {};
+	mavlink_message_t message = {};
+	cmd_long.command = MAV_CMD_IMAGE_START_CAPTURE;
+	cmd_long.param1 = 0.0;
+	cmd_long.param2 = 0.0;
+	cmd_long.param3 = 1.0; // capture 1 image
+	mavlink_msg_command_long_encode(0, 50, &message, &cmd_long);
+	send_mavlink_message(message);
 }
 
 static void fill_rc_input_msg(struct rc_input_values *rc, mavlink_rc_channels_t *rc_channels)
@@ -562,21 +575,28 @@ void Simulator::send_mavlink_message(const mavlink_message_t &aMsg)
 void Simulator::poll_topics()
 {
 	// copy new actuator data if available
-	bool updated;
+        bool vehicle_status_updated, camera_trigger_updated;
 
 	for (unsigned i = 0; i < (sizeof(_actuator_outputs_sub) / sizeof(_actuator_outputs_sub[0])); i++) {
 
-		orb_check(_actuator_outputs_sub[i], &updated);
+		orb_check(_actuator_outputs_sub[i], &vehicle_status_updated);
 
-		if (updated) {
+		if (vehicle_status_updated) {
 			orb_copy(ORB_ID(actuator_outputs), _actuator_outputs_sub[i], &_actuators[i]);
 		}
 	}
 
-	orb_check(_vehicle_status_sub, &updated);
+	orb_check(_vehicle_status_sub, &vehicle_status_updated);
 
-	if (updated) {
+	if (vehicle_status_updated) {
 		orb_copy(ORB_ID(vehicle_status), _vehicle_status_sub, &_vehicle_status);
+	}
+
+	orb_check(_camera_trigger_sub, &camera_trigger_updated);
+	if(camera_trigger_updated) {
+	        struct camera_trigger_s camera_trigger_message;
+	        orb_copy(ORB_ID(camera_trigger), _camera_trigger_sub, &camera_trigger_message);
+		send_camera_trigger();
 	}
 }
 
@@ -794,6 +814,7 @@ void Simulator::pollForMAVLinkMessages(bool publish, int udp_port)
 	}
 
 	_vehicle_status_sub = orb_subscribe(ORB_ID(vehicle_status));
+	_camera_trigger_sub = orb_subscribe(ORB_ID(camera_trigger));
 
 	// got data from simulator, now activate the sending thread
 	pthread_create(&sender_thread, &sender_thread_attr, Simulator::sending_trampoline, nullptr);


### PR DESCRIPTION
I've implemented camera trigger over simulation mavlink interface. Fixes #8739 

I've tested it in sitl by using `camera_trigger test` from the px4 command line, and used QGC to fly mission (in AirSim) where camera is triggered (AirSim doesn't normally read this message so I've modded it to do this).

I'm ready for review or instructions of further testing.