### PR TITLE
aerofc cmake: add baro driver again

### DIFF
--- a/cmake/configs/nuttx_aerofc-v1_default.cmake
+++ b/cmake/configs/nuttx_aerofc-v1_default.cmake
@@ -13,6 +13,7 @@ set(config_module_list
 	drivers/distance_sensor
 	drivers/gps
 	drivers/led
+	drivers/barometer/ms5611
 	drivers/magnetometer/hmc5883
 	drivers/magnetometer/ist8310
 	drivers/mpu9250


### PR DESCRIPTION
This has been forgotten in https://github.com/PX4/Firmware/pull/8695/commits/48296a74cb8a1e84b11e5649bd0996d9cc2126c8#diff-2724f4dc49bcf81de6316e855f55a7c6L19