### PR TITLE
Improve limit checking and comments of mathlib Functions

### DIFF
--- a/src/lib/mathlib/math/Functions.hpp
+++ b/src/lib/mathlib/math/Functions.hpp
@@ -60,11 +60,12 @@ int sign(T val)
  * 		1 - pure cubic function
  * @return result of function output
  */
-template<typename _Tp>
-inline const _Tp expo(const _Tp &value, const _Tp &e)
+template<typename T>
+inline const T expo(const T &value, const T &e)
 {
-	_Tp x = constrain(value, (_Tp) - 1, (_Tp)1);
-	return (1 - e) * x + e * x * x * x;
+	T x = constrain(value, (T) -1, (T) 1);
+	T ec = constrain(e, (T) 0, (T) 1);
+	return (1 - ec) * x + ec * x * x * x;
 }
 
 /*
@@ -76,29 +77,43 @@ inline const _Tp expo(const _Tp &value, const _Tp &e)
  * @param g [0,1) function parameter to set SuperExpo shape
  * 		0 - pure expo function
  * 		0.99 - very strong bent curve, stays zero until maximum stick input
- * 		1 - DO NOT USE, division by zero on maxima
  * @return result of function output
  */
-template<typename _Tp>
-inline const _Tp superexpo(const _Tp &value, const _Tp &e, const _Tp &g)
+template<typename T>
+inline const T superexpo(const T &value, const T &e, const T &g)
 {
-	_Tp x = constrain(value, (_Tp) - 1, (_Tp)1);
-	return expo(x, e) * (1 - g) / (1 - fabsf(x) * g);
+	T x = constrain(value, (T) -1, (T) 1);
+	T gc = constrain(g, (T) 0, (T) 0.99);
+	return expo(x, e) * (1 - gc) / (1 - fabsf(x) * gc);
 }
 
-template<typename _Tp>
-inline const _Tp deadzone(const _Tp &value, const _Tp &dz)
+/*
+ * Deadzone function being linear and continuous outside of the deadzone
+ * 1                ------
+ *                /
+ *             --
+ *           /
+ * -1 ------
+ *        -1 -dz +dz 1
+ * @param value [-1,1] input value to function
+ * @param dz [0,1) ratio between deazone and complete span
+ * 		0 - no deadzone, linear -1 to 1
+ * 		0.5 - deadzone is half of the span [-0.5,0.5]
+ * 		0.99 - almost entire span is deadzone
+ */
+template<typename T>
+inline const T deadzone(const T &value, const T &dz)
 {
-	_Tp x = constrain(value, (_Tp) - 1, (_Tp)1);
-	_Tp dzc = constrain(dz, (_Tp) - 1, (_Tp)1);
+	T x = constrain(value, (T) -1, (T) 1);
+	T dzc = constrain(dz, (T) 0, (T) 0.99);
 	// Rescale the input such that we get a piecewise linear function that will be continuous with applied deadzone
-	_Tp out = (x - sign(x) * dzc) / (1 - dzc);
+	T out = (x - sign(x) * dzc) / (1 - dzc);
 	// apply the deadzone (values zero around the middle)
 	return out * (fabsf(x) > dzc);
 }
 
-template<typename _Tp>
-inline const _Tp expo_deadzone(const _Tp &value, const _Tp &e, const _Tp &dz)
+template<typename T>
+inline const T expo_deadzone(const T &value, const T &e, const T &dz)
 {
 	return expo(deadzone(value, dz), e);
 }
@@ -113,8 +128,8 @@ inline const _Tp expo_deadzone(const _Tp &value, const _Tp &e, const _Tp &dz)
  * y_low -------
  *         x_low   x_high
  */
-template<typename _Tp>
-inline const _Tp gradual(const _Tp &value, const _Tp &x_low, const _Tp &x_high, const _Tp &y_low, const _Tp &y_high)
+template<typename T>
+inline const T gradual(const T &value, const T &x_low, const T &x_high, const T &y_low, const T &y_high)
 {
 	if (value < x_low) {
 		return y_low;

--- a/src/lib/mathlib/math/Functions.hpp
+++ b/src/lib/mathlib/math/Functions.hpp
@@ -61,9 +61,9 @@ int sign(T val)
  * @return result of function output
  */
 template<typename T>
-inline const T expo(const T &value, const T &e)
+const T expo(const T &value, const T &e)
 {
-	T x = constrain(value, (T) -1, (T) 1);
+	T x = constrain(value, (T) - 1, (T) 1);
 	T ec = constrain(e, (T) 0, (T) 1);
 	return (1 - ec) * x + ec * x * x * x;
 }
@@ -80,9 +80,9 @@ inline const T expo(const T &value, const T &e)
  * @return result of function output
  */
 template<typename T>
-inline const T superexpo(const T &value, const T &e, const T &g)
+const T superexpo(const T &value, const T &e, const T &g)
 {
-	T x = constrain(value, (T) -1, (T) 1);
+	T x = constrain(value, (T) - 1, (T) 1);
 	T gc = constrain(g, (T) 0, (T) 0.99);
 	return expo(x, e) * (1 - gc) / (1 - fabsf(x) * gc);
 }
@@ -102,9 +102,9 @@ inline const T superexpo(const T &value, const T &e, const T &g)
  * 		0.99 - almost entire span is deadzone
  */
 template<typename T>
-inline const T deadzone(const T &value, const T &dz)
+const T deadzone(const T &value, const T &dz)
 {
-	T x = constrain(value, (T) -1, (T) 1);
+	T x = constrain(value, (T) - 1, (T) 1);
 	T dzc = constrain(dz, (T) 0, (T) 0.99);
 	// Rescale the input such that we get a piecewise linear function that will be continuous with applied deadzone
 	T out = (x - sign(x) * dzc) / (1 - dzc);
@@ -113,7 +113,7 @@ inline const T deadzone(const T &value, const T &dz)
 }
 
 template<typename T>
-inline const T expo_deadzone(const T &value, const T &e, const T &dz)
+const T expo_deadzone(const T &value, const T &e, const T &dz)
 {
 	return expo(deadzone(value, dz), e);
 }
@@ -129,7 +129,7 @@ inline const T expo_deadzone(const T &value, const T &e, const T &dz)
  *         x_low   x_high
  */
 template<typename T>
-inline const T gradual(const T &value, const T &x_low, const T &x_high, const T &y_low, const T &y_high)
+const T gradual(const T &value, const T &x_low, const T &x_high, const T &y_low, const T &y_high)
 {
 	if (value < x_low) {
 		return y_low;
@@ -145,4 +145,4 @@ inline const T gradual(const T &value, const T &x_low, const T &x_high, const T 
 	}
 }
 
-}
+} /* namespace math */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -2501,7 +2501,7 @@ MulticopterPositionControl::calculate_velocity_setpoint()
 		_vel_sp(2) = math::max(_vel_sp(2), -vel_limit);
 	}
 
-	// encourage pilot to respect respect flow sensor minimum height limitations
+	// encourage pilot to respect flow sensor minimum height limitations
 	if (_local_pos.limit_hagl && _local_pos.dist_bottom_valid && _control_mode.flag_control_manual_enabled
 	    && _control_mode.flag_control_altitude_enabled) {
 		// If distance to ground is less than limit, increment set point upwards at up to the landing descent rate


### PR DESCRIPTION
As I wrote these functions I feel responsible to clean them up:
- limits were not safe yet:
negative deadzone or 100% deadzone can lead to problems
with the 1/1-x function x should never get 1
in the cubic function if e > 1 the slope in the center gets negative which doesn't make sense
- I renamed the template _Tp which was copied from somewhere to T for readability
- I added a comment for the deadzone