### PR TITLE
some px4fmu v5 fixes

### DIFF
--- a/cmake/configs/nuttx_auav-x21_default.cmake
+++ b/cmake/configs/nuttx_auav-x21_default.cmake
@@ -58,6 +58,7 @@ set(config_module_list
 	systemcmds/sd_bench
 	systemcmds/top
 	systemcmds/topic_listener
+	systemcmds/tune_control
 	systemcmds/ver
 
 	#

--- a/cmake/configs/nuttx_mindpx-v2_default.cmake
+++ b/cmake/configs/nuttx_mindpx-v2_default.cmake
@@ -53,6 +53,7 @@ set(config_module_list
 	systemcmds/hardfault_log
 	systemcmds/reboot
 	systemcmds/topic_listener
+	systemcmds/tune_control
 	systemcmds/top
 	systemcmds/config
 	systemcmds/nshterm

--- a/cmake/configs/nuttx_nxphlite-v3_default.cmake
+++ b/cmake/configs/nuttx_nxphlite-v3_default.cmake
@@ -146,6 +146,7 @@ set(config_module_list
 	lib/runway_takeoff
 	lib/tailsitter_recovery
 	lib/terrain_estimation
+	lib/tunes
 	lib/version
 	lib/DriverFramework/framework
 

--- a/cmake/configs/nuttx_nxphlite-v3_default.cmake
+++ b/cmake/configs/nuttx_nxphlite-v3_default.cmake
@@ -66,6 +66,7 @@ set(config_module_list
 	systemcmds/sd_bench
 	systemcmds/top
 	systemcmds/topic_listener
+	systemcmds/tune_control
 	systemcmds/usb_connected
 	systemcmds/ver
 

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -71,6 +71,7 @@ set(config_module_list
 	#systemcmds/sd_bench
 	systemcmds/top
 	#systemcmds/topic_listener
+	systemcmds/tune_control
 	systemcmds/ver
 
 	#

--- a/cmake/configs/nuttx_px4fmu-v3_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v3_default.cmake
@@ -72,6 +72,7 @@ set(config_module_list
 	systemcmds/sd_bench
 	systemcmds/top
 	systemcmds/topic_listener
+	systemcmds/tune_control
 	systemcmds/ver
 
 	#

--- a/cmake/configs/nuttx_px4fmu-v4pro_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v4pro_default.cmake
@@ -64,6 +64,7 @@ set(config_module_list
 	systemcmds/sd_bench
 	systemcmds/top
 	systemcmds/topic_listener
+	systemcmds/tune_control
 	systemcmds/ver
 
 	#

--- a/cmake/configs/nuttx_px4fmu-v5_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v5_default.cmake
@@ -15,6 +15,7 @@ set(config_module_list
 	drivers/airspeed
 	drivers/blinkm
 	drivers/bma180
+	drivers/bmi055
 	drivers/bmi160
 	drivers/boards
 	drivers/bst

--- a/cmake/configs/nuttx_px4fmu-v5_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v5_default.cmake
@@ -64,6 +64,7 @@ set(config_module_list
 	systemcmds/sd_bench
 	systemcmds/top
 	systemcmds/topic_listener
+	systemcmds/tune_control
 	systemcmds/ver
 
 	#

--- a/cmake/configs/nuttx_px4nucleoF767ZI-v1_default.cmake
+++ b/cmake/configs/nuttx_px4nucleoF767ZI-v1_default.cmake
@@ -60,6 +60,7 @@ set(config_module_list
 	systemcmds/sd_bench
 	systemcmds/top
 	systemcmds/topic_listener
+	systemcmds/tune_control
 	systemcmds/ver
 
 	#

--- a/cmake/configs/nuttx_tap-v1_default.cmake
+++ b/cmake/configs/nuttx_tap-v1_default.cmake
@@ -44,6 +44,7 @@ set(config_module_list
 	systemcmds/dumpfile
 	systemcmds/ver
 	systemcmds/topic_listener
+	systemcmds/tune_control
 
 	#
 	# General system control

--- a/cmake/configs/posix_rpi_common.cmake
+++ b/cmake/configs/posix_rpi_common.cmake
@@ -39,6 +39,7 @@ set(config_module_list
 	systemcmds/esc_calib
 	systemcmds/reboot
 	systemcmds/topic_listener
+	systemcmds/tune_control
 	systemcmds/perf
 
 	#

--- a/cmake/configs/posix_rpi_common.cmake
+++ b/cmake/configs/posix_rpi_common.cmake
@@ -105,6 +105,7 @@ set(config_module_list
 	lib/runway_takeoff
 	lib/tailsitter_recovery
 	lib/terrain_estimation
+	lib/tunes
 	lib/version
 
 	#

--- a/cmake/configs/posix_sdflight_default.cmake
+++ b/cmake/configs/posix_sdflight_default.cmake
@@ -81,6 +81,7 @@ set(config_module_list
 	lib/runway_takeoff
 	lib/tailsitter_recovery
 	lib/terrain_estimation
+	lib/tunes
 	lib/version
 
 	platforms/common

--- a/cmake/configs/posix_sdflight_default.cmake
+++ b/cmake/configs/posix_sdflight_default.cmake
@@ -44,6 +44,7 @@ set(config_module_list
 	systemcmds/mixer
 	systemcmds/ver
 	systemcmds/topic_listener
+	systemcmds/tune_control
 
 	modules/mavlink
 

--- a/cmake/configs/posix_sdflight_legacy.cmake
+++ b/cmake/configs/posix_sdflight_legacy.cmake
@@ -36,6 +36,7 @@ set(config_module_list
 	systemcmds/mixer
 	systemcmds/ver
 	systemcmds/topic_listener
+	systemcmds/tune_control
 
 	modules/mavlink
 

--- a/cmake/configs/posix_sdflight_legacy.cmake
+++ b/cmake/configs/posix_sdflight_legacy.cmake
@@ -73,6 +73,7 @@ set(config_module_list
 	lib/runway_takeoff
 	lib/tailsitter_recovery
 	lib/terrain_estimation
+	lib/tunes
 	lib/version
 
 	platforms/common

--- a/cmake/configs/posix_sitl_default.cmake
+++ b/cmake/configs/posix_sitl_default.cmake
@@ -132,6 +132,7 @@ set(config_module_list
 	lib/runway_takeoff
 	lib/tailsitter_recovery
 	lib/terrain_estimation
+	lib/tunes
 	lib/version
 
 	#

--- a/cmake/configs/posix_sitl_default.cmake
+++ b/cmake/configs/posix_sitl_default.cmake
@@ -44,6 +44,7 @@ set(config_module_list
 	systemcmds/sd_bench
 	systemcmds/top
 	systemcmds/topic_listener
+	systemcmds/tune_control
 	systemcmds/ver
 
 	#

--- a/src/drivers/boards/px4fmu-v5/board_config.h
+++ b/src/drivers/boards/px4fmu-v5/board_config.h
@@ -322,6 +322,12 @@
 	 (1 << ADC1_SPARE_1_CHANNEL))
 #endif
 
+/* Define Battery 1 Voltage Divider and A per V
+ */
+
+#define BOARD_BATTERY1_V_DIV         (10.133333333f)
+#define BOARD_BATTERY1_A_PER_V       (36.367515152f)
+
 /* HW has to large of R termination on ADC todo:change when HW value is chosen */
 
 #define BOARD_ADC_OPEN_CIRCUIT_V               (5.6f)

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -225,7 +225,7 @@ private:
 	 * @param raw			Combined sensor data structure into which
 	 *				data should be returned.
 	 */
-	void		adc_poll(struct sensor_combined_s &raw);
+	void		adc_poll();
 };
 
 Sensors::Sensors(bool hil_enabled) :
@@ -421,7 +421,7 @@ Sensors::parameter_update_poll(bool forced)
 }
 
 void
-Sensors::adc_poll(struct sensor_combined_s &raw)
+Sensors::adc_poll()
 {
 	/* only read if not in HIL mode */
 	if (_hil_enabled) {
@@ -669,7 +669,7 @@ Sensors::run()
 		_voted_sensors_update.sensors_poll(raw);
 
 		/* check battery voltage */
-		adc_poll(raw);
+		adc_poll();
 
 		diff_pres_poll(raw);
 

--- a/src/systemcmds/tune_control/tune_control.cpp
+++ b/src/systemcmds/tune_control/tune_control.cpp
@@ -51,7 +51,7 @@
 
 #define MAX_NOTE_ITERATION 50
 
-static void	usage(void);
+static void	usage();
 
 static orb_advert_t tune_control_pub = nullptr;
 
@@ -91,10 +91,10 @@ tune_control_main(int argc, char *argv[])
 {
 	Tunes tunes;
 	bool string_input = false;
-	const char *tune_string  = NULL;
+	const char *tune_string  = nullptr;
 	int myoptind = 1;
 	int ch;
-	const char *myoptarg = NULL;
+	const char *myoptarg = nullptr;
 	unsigned int value;
 	tune_control_s tune_control = {};
 	tune_control.tune_id = 0;
@@ -103,7 +103,7 @@ tune_control_main(int argc, char *argv[])
 	while ((ch = px4_getopt(argc, argv, "f:d:t:m:s:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'f':
-			value = (uint16_t)(strtol(myoptarg, NULL, 0));
+			value = (uint16_t)(strtol(myoptarg, nullptr, 0));
 
 			if (value > 0 && value < 22000) {
 				tune_control.frequency = value;
@@ -116,11 +116,11 @@ tune_control_main(int argc, char *argv[])
 			break;
 
 		case 'd':
-			tune_control.duration = (uint32_t)(strtol(myoptarg, NULL, 0));
+			tune_control.duration = (uint32_t)(strtol(myoptarg, nullptr, 0));
 			break;
 
 		case 't':
-			value = (uint8_t)(strtol(myoptarg, NULL, 0));
+			value = (uint8_t)(strtol(myoptarg, nullptr, 0));
 
 			if (value > 0 && value < tunes.get_default_tunes_size()) {
 				tune_control.tune_id = value;
@@ -145,7 +145,7 @@ tune_control_main(int argc, char *argv[])
 			break;
 
 		case 's':
-			value = (uint16_t)(strtol(myoptarg, NULL, 0));
+			value = (uint16_t)(strtol(myoptarg, nullptr, 0));
 
 			if (value > 0 && value < 100) {
 				tune_control.strength = value;


### PR DESCRIPTION
- accidental drop of `drivers/bmi055` in cmake config
- battery voltage & current readout board defines
- forgotten `systemcmds/tune_control` in https://github.com/PX4/Firmware/pull/8679