### PR TITLE
rcS: automate tfmini start

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -400,6 +400,18 @@ then
 	then
 		# start the driver on serial 4/5
 		tfmini start -d /dev/ttyS6
+	else
+		if ver hwcmp AEROFC_V1
+		then
+			# start the driver on telemetry
+			tfmini start -d /dev/ttyS3
+		else
+			if param compare SYS_COMPANION 0
+			then
+				# start on default mavlink companion device
+				tfmini start -d /dev/ttyS2
+			fi
+		fi
 	fi
 fi
 

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -554,7 +554,13 @@ then
 
 		if ver hwcmp AEROFC_V1
 		then
-			set MAVLINK_F "-r 1200 -d /dev/ttyS3"
+			# Only start mavlink if the Benewake TFMini isn't being used
+			if param greater SENS_EN_TFMINI 0
+			then
+				set MAVLINK_F none
+			else
+				set MAVLINK_F "-r 1200 -d /dev/ttyS3"
+			fi
 		fi
 
 		if ver hwcmp CRAZYFLIE


### PR DESCRIPTION
This isn't super nice but it makes enabling the tfmini a bit easier.
For the different boards:
* V3: enable it by setting `SENS_EN_TFMINI` -> plug into serial 4/5
* Aerofc: enable it by setting `SENS_EN_TFMINI` -> plug into telemetry
* else: disable `SYS_COMPANION` and enable `SENS_EN_TFMINI` -> plug into TELEM2

We could also use TELEM 2 on V3, I guess. What do you guys think?