### PR TITLE
snapdragon disable power module

### DIFF
--- a/posix-configs/eagle/flight/px4.config
+++ b/posix-configs/eagle/flight/px4.config
@@ -9,7 +9,7 @@ df_hmc5883_wrapper start
 df_mpu9250_wrapper start
 df_bmp280_wrapper start
 df_trone_wrapper start
-df_ltc2946_wrapper start
+#df_ltc2946_wrapper start # (currently not working on all boards...)
 #df_isl29501_wrapper start
 sensors start
 commander start


### PR DESCRIPTION
currently doesn't work on all boards... Until there's a fix, I'll just disable it.

fixes https://github.com/PX4/Firmware/issues/8756

FYI @santiago3dr 