### PR TITLE
Fixing build of px4fmu-v3_default with arm-none-eabi-g++ 4.9.3 20150529

### DIFF
--- a/src/drivers/barometer/bmp280/bmp280_spi.cpp
+++ b/src/drivers/barometer/bmp280/bmp280_spi.cpp
@@ -87,10 +87,10 @@ bmp280::IBMP280 *bmp280_spi_interface(uint8_t busnum, uint8_t device, bool exter
 	return new BMP280_SPI(busnum, device, external);
 }
 
-BMP280_SPI::BMP280_SPI(uint8_t bus, uint32_t device, bool externalL) :
+BMP280_SPI::BMP280_SPI(uint8_t bus, uint32_t device, bool _is_external) :
 	SPI("BMP280_SPI", nullptr, bus, device, SPIDEV_MODE3, 10 * 1000 * 1000)
 {
-	_external = externalL;
+	_external = _is_external;
 }
 
 bool BMP280_SPI::is_external()

--- a/src/drivers/barometer/bmp280/bmp280_spi.cpp
+++ b/src/drivers/barometer/bmp280/bmp280_spi.cpp
@@ -65,7 +65,7 @@ struct spi_calibration_s {
 class BMP280_SPI: public device::SPI, public bmp280::IBMP280
 {
 public:
-	BMP280_SPI(uint8_t bus, uint32_t device, bool external);
+	BMP280_SPI(uint8_t bus, uint32_t device, bool is_external_device);
 	virtual ~BMP280_SPI() = default;
 
 	bool is_external();
@@ -87,10 +87,10 @@ bmp280::IBMP280 *bmp280_spi_interface(uint8_t busnum, uint8_t device, bool exter
 	return new BMP280_SPI(busnum, device, external);
 }
 
-BMP280_SPI::BMP280_SPI(uint8_t bus, uint32_t device, bool _is_external) :
+BMP280_SPI::BMP280_SPI(uint8_t bus, uint32_t device, bool is_external_device) :
 	SPI("BMP280_SPI", nullptr, bus, device, SPIDEV_MODE3, 10 * 1000 * 1000)
 {
-	_external = _is_external;
+	_external = is_external_device;
 }
 
 bool BMP280_SPI::is_external()


### PR DESCRIPTION
That pull-request fixing the following build problem from _tags/v1.7.3_ with the latest available _arm-none-eabi-g++_ on Ubuntu - _4.9.3 20150529_:
```
$ **make px4fmu-v3_default**
[2/8] Building CXX object src/drivers/bmp280/CMakeFiles/drivers__bmp280.dir/bmp280_spi.cpp.obj
FAILED: /usr/bin/arm-none-eabi-g++   -DBUILD_URI=localhost -DCONFIG_ARCH_BOARD_PX4FMU_V2 -DMODULE_NAME=\"bmp280\" -DPX4_MAIN=bmp280_app_main -D__DF_NUTTX -D__PX4_NUTTX -D__STDC_FORMAT_MACROS -I. -Isrc -Isrc/modules -I../../src -I../../src/drivers/boards/px4fmu-v2 -I../../src/include -I../../src/lib -I../../src/lib/DriverFramework/framework/include -I../../src/lib/matrix -I../../src/modules -I../../src/platforms -INuttX/nuttx/arch/arm/src/armv7-m -INuttX/nuttx/arch/arm/src/chip -INuttX/nuttx/arch/arm/src/common -INuttX/nuttx/include -INuttX/nuttx/include/cxx -I../../platforms/nuttx/NuttX/apps/include -Iexternal/Install/include -fno-common -ffunction-sections -fdata-sections -mcpu=cortex-m4 -mthumb -march=armv7e-m -mfpu=fpv4-sp-d16 -mfloat-abi=hard -fno-common -ffunction-sections -fdata-sections -g -fno-exceptions -fno-rtti -std=gnu++11 -fno-threadsafe-statics -DCONFIG_WCHAR_BUILTIN -D__CUSTOM_FILE_IO__ -fcheck-new -Wall -Warray-bounds -Wdisabled-optimization -Werror -Wextra -Wfatal-errors -Wfloat-equal -Wformat-security -Winit-self -Wlogical-op -Wmissing-declarations -Wmissing-field-initializers -Wpointer-arith -Wshadow -Wuninitialized -Wunknown-pragmas -Wunused-variable -Wno-unused-parameter -Wunused-but-set-variable -Wformat=1 -Wdouble-promotion -Wno-missing-field-initializers -Wno-overloaded-virtual -Wreorder -fvisibility=hidden -include visibility.h -fno-strict-aliasing -fomit-frame-pointer -funsafe-math-optimizations -ffunction-sections -fdata-sections -fno-strength-reduce -fno-builtin-printf -Os -DNDEBUG   -fno-strict-aliasing -fomit-frame-pointer -funsafe-math-optimizations -ffunction-sections -fdata-sections -fno-strength-reduce -fno-builtin-printf -Wframe-larger-than=1024 -MMD -MT src/drivers/bmp280/CMakeFiles/drivers__bmp280.dir/bmp280_spi.cpp.obj -MF src/drivers/bmp280/CMakeFiles/drivers__bmp280.dir/bmp280_spi.cpp.obj.d -o src/drivers/bmp280/CMakeFiles/drivers__bmp280.dir/bmp280_spi.cpp.obj -c ../../src/drivers/bmp280/bmp280_spi.cpp
../../src/drivers/bmp280/bmp280_spi.cpp: In constructor 'BMP280_SPI::BMP280_SPI(uint8_t, uint32_t, bool)':
../../src/drivers/bmp280/bmp280_spi.cpp:90:67: error: declaration of 'external' shadows a member of 'this' [-Werror=shadow]
 BMP280_SPI::BMP280_SPI(uint8_t bus, uint32_t device, bool external) :
                                                                   ^
compilation terminated due to -Wfatal-errors.
cc1plus: all warnings being treated as errors
[2/8] Generating git hash header
ninja: build stopped: subcommand failed.
Makefile:153: recipe for target 'px4fmu-v3_default' failed
make: *** [px4fmu-v3_default] Error 1
```

```
$ **/usr/bin/arm-none-eabi-g++ --version**
arm-none-eabi-g++ (15:4.9.3+svn231177-1) 4.9.3 20150529 (prerelease)
Copyright (C) 2014 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```