### PR TITLE
px_uploader: fix Python3 upload

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -125,7 +125,7 @@ class firmware(object):
 
         # pad image to 4-byte length
         while ((len(self.image) % 4) != 0):
-            self.image.append('\xff')
+            self.image.extend(b'\xff')
 
     def property(self, propname):
         return self.desc[propname]


### PR DESCRIPTION
This fixes the error below when using Python3:
```
  File "Tools/px_uploader.py", line 128, in
  __init__
      self.image.append('\xff')
      TypeError: an integer is required
```