### PR TITLE
[WIP] PX4 development environment setup scripts

### DIFF
--- a/Tools/setup/OSX.sh
+++ b/Tools/setup/OSX.sh
@@ -1,0 +1,14 @@
+#! /usr/bin/env bash
+
+# script directory
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+brew tap PX4/px4
+brew install px4-dev
+
+# python dependencies
+sudo easy_install pip
+pip install -r ${DIR}/requirements.txt
+
+# Optional, but recommended additional simulation tools:
+brew install px4-sim

--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -1,0 +1,10 @@
+argparse>=1.2
+empy>=3.3
+jinja2>=2.8
+numpy>=1.13
+pandas>=0.21
+pyserial>=3.0
+pyulog>=0.5.0
+setuptools>=39.2.0
+toml>=0.9
+wheel>=0.31.1

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -1,0 +1,53 @@
+#! /usr/bin/env bash
+
+# script directory
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+# check ubuntu version
+# instructions for 16.04, 18.04
+# otherwise warn and point to docker?
+UBUNTU_RELEASE=`lsb_release -rs`
+
+if [[ "${UBUNTU_RELEASE}" == "14.04" ]]
+then
+	echo "Ubuntu 14.04 unsupported, see docker px4io/px4-dev-base"
+	exit 1
+elif [[ "${UBUNTU_RELEASE}" == "16.04" ]]
+then
+	echo "Ubuntu 16.04"
+elif [[ "${UBUNTU_RELEASE}" == "18.04" ]]
+then
+	echo "Ubuntu 18.04"
+	echo "WARNING, instructions only tested on Ubuntu 16.04"
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+sudo apt-get update -yy --quiet
+sudo apt-get -yy --quiet --no-install-recommends install \
+	bzip2 \
+	ca-certificates \
+	ccache \
+	cmake \
+	g++ \
+	gcc \
+	git \
+	lcov \
+	make \
+	ninja-build \
+	python-pip
+	rsync \
+	unzip \
+	wget \
+	wget \
+	xsltproc \
+	zip
+
+# python dependencies
+python -m pip install --user --upgrade pip setuptools wheel
+python -m pip install --user -r ${DIR}/requirements.txt
+
+# java (jmavsim or fastrtps)
+# TODO: only install when necessary
+sudo apt-get -y --quiet --no-install-recommends install \
+	default-jre-headless \
+	default-jdk-headless \


### PR DESCRIPTION
The idea is to store the development environment setup scripts/instructions in PX4 itself. The documentation can refer to them directly, the PX4 dev docker containers can directly use them, and all aspects will stay in sync and tested.

Which platforms should we cover?
 - ubuntu lts
 - OSX
 - fedora or centos (@davids5)
 - arch? (@julianoes @jlecoeur)
 - anything for windows? The ubuntu versions should also work within Bash on Windows.

The scripts themselves should be idempotent and be suitable for most developers to run directly and stay in sync. Whenever possible we should make an effort for multiple versions to coexist in parallel. Then developers can jump between branches where official toolchain versions have changed, but still have both compilers.

The installation should be somewhat granular (more or less following the container layout).
 - nuttx optional
 - raspi and generic armhf?
 - fastrtps optional
 - gazebo
 - ROS (ubuntu only)