### PR TITLE
ecl_ekf tools batch processing: enable resumed analysis

### DIFF
--- a/Tools/ecl_ekf/batch_process_logdata_ekf.py
+++ b/Tools/ecl_ekf/batch_process_logdata_ekf.py
@@ -4,7 +4,7 @@ import argparse
 import os, glob
 
 """
-Runs process_logdata_ekf.py on the .ulg files in the supplied directory. ulg files are skipped from the analysis, if a 
+Runs process_logdata_ekf.py on the .ulg files in the supplied directory. ulog files are skipped from the analysis, if a 
  corresponding .pdf file already exists (unless the overwrite flag was set). 
 """
 
@@ -32,6 +32,7 @@ ulog_files = glob.glob(os.path.join(ulog_directory, '*.ulg'))
 # remove the files already analysed unless the overwrite flag was specified. A ulog file is consired to be analysed if
 # a corresponding .pdf file exists.'
 if not args.overwrite:
+    print("skipping already analysed ulg files.")
     ulog_files = [ulog_file for ulog_file in ulog_files if not os.path.exists('{}.pdf'.format(ulog_file))]
 
 # analyse all ulog files

--- a/Tools/ecl_ekf/batch_process_logdata_ekf.py
+++ b/Tools/ecl_ekf/batch_process_logdata_ekf.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import argparse
-import os
+import os, glob
 
 """
-Runs process_logdata_ekf.py on all the files in the suplied directory with a .ulg extension
+Runs process_logdata_ekf.py on the .ulg files in the supplied directory. ulg files are skipped from the analysis, if a 
+ corresponding .pdf file already exists (unless the overwrite flag was set). 
 """
 
-parser = argparse.ArgumentParser(description='Analyse the estimator_status and ekf2_innovation message data for all .ulg files in the specified directory')
+parser = argparse.ArgumentParser(description='Analyse the estimator_status and ekf2_innovation message data for the'
+                                             ' .ulg files in the specified directory')
 parser.add_argument("directory_path")
+parser.add_argument('-ow', '--overwrite', action='store_true',
+                    help='Whether to overwrite an already analysed file. If a file with .pdf extension exists for a .ulg'
+                         'file, the log file will be skipped from analysis unless this flag has been set.')
 
 def is_valid_directory(parser, arg):
     if os.path.isdir(arg):
@@ -19,9 +24,17 @@ def is_valid_directory(parser, arg):
 
 args = parser.parse_args()
 ulog_directory = args.directory_path
-print("\n"+"analysing all .ulog files in "+ulog_directory)
-# Run the analysis script on all the log files found in the specified directory
-for file in os.listdir(ulog_directory):
-    if file.endswith(".ulg"):
-        print("\n"+"loading "+file+" for analysis")
-        os.system("python process_logdata_ekf.py '{}'".format(os.path.join(ulog_directory, file)))
+print("\n"+"analysing the .ulg files in "+ulog_directory)
+
+# get all the ulog files found in the specified directory
+ulog_files = glob.glob(os.path.join(ulog_directory, '*.ulg'))
+
+# remove the files already analysed unless the overwrite flag was specified. A ulog file is consired to be analysed if
+# a corresponding .pdf file exists.'
+if not args.overwrite:
+    ulog_files = [ulog_file for ulog_file in ulog_files if not os.path.exists('{}.pdf'.format(ulog_file))]
+
+# analyse all ulog files
+for ulog_file in ulog_files:
+    print("\n"+"loading "+ulog_file +" for analysis")
+    os.system("python process_logdata_ekf.py '{}'".format(ulog_file))

--- a/Tools/ecl_ekf/batch_process_logdata_ekf.py
+++ b/Tools/ecl_ekf/batch_process_logdata_ekf.py
@@ -11,7 +11,7 @@ Runs process_logdata_ekf.py on the .ulg files in the supplied directory. ulog fi
 parser = argparse.ArgumentParser(description='Analyse the estimator_status and ekf2_innovation message data for the'
                                              ' .ulg files in the specified directory')
 parser.add_argument("directory_path")
-parser.add_argument('-ow', '--overwrite', action='store_true',
+parser.add_argument('-o', '--overwrite', action='store_true',
                     help='Whether to overwrite an already analysed file. If a file with .pdf extension exists for a .ulg'
                          'file, the log file will be skipped from analysis unless this flag has been set.')
 


### PR DESCRIPTION
update the batch process script of the ekf analysis tool to support resumed analysis. 
- already analysed ulog files are skipped from the resumed analysis (default behaviour)
- an overwrite flag can be set to analyse the existing files nonetheless