### PR TITLE
[WIP] Timestamps - Add timestamp chaining through timestamp_sample

### DIFF
--- a/msg/actuator_outputs.msg
+++ b/msg/actuator_outputs.msg
@@ -2,3 +2,5 @@ uint8 NUM_ACTUATOR_OUTPUTS		= 16
 uint8 NUM_ACTUATOR_OUTPUT_GROUPS	= 4	# for sanity checking
 uint32 noutputs				# valid outputs
 float32[16] output			# output data, in natural output units
+
+uint64 timestamp_sample	    # the timestamp the data this control response is based on was sampled

--- a/msg/vehicle_attitude.msg
+++ b/msg/vehicle_attitude.msg
@@ -1,5 +1,7 @@
 # This is similar to the mavlink message ATTITUDE_QUATERNION, but for onboard use
 
+uint64 timestamp_sample	    # the timestamp the data this control response is based on was sampled
+
 float32 rollspeed	# Bias corrected angular velocity about X body axis in rad/s
 float32 pitchspeed	# Bias corrected angular velocity about Y body axis in rad/s
 float32 yawspeed	# Bias corrected angular velocity about Z body axis in rad/s

--- a/src/drivers/linux_pwm_out/linux_pwm_out.cpp
+++ b/src/drivers/linux_pwm_out/linux_pwm_out.cpp
@@ -379,6 +379,19 @@ void task_main(int argc, char *argv[])
 				pwm_out->send_output_pwm(pwm, _outputs.noutputs);
 			}
 
+			// copy first valid timestamp_sample into actuator_outputs for measuring latency
+			for (uint8_t i = 0; i < actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS; i++) {
+				const bool required = _groups_required & (1 << i);
+				const hrt_abstime &ts = _controls[i].timestamp_sample;
+
+				if (required && (ts > 0)) {
+					actuator_outputs.timestamp_sample = ts;
+					break;
+				}
+			}
+
+			_outputs.timestamp = hrt_absolute_time();
+
 			if (_outputs_pub != nullptr) {
 				orb_publish(ORB_ID(actuator_outputs), _outputs_pub, &_outputs);
 

--- a/src/drivers/pwm_out_sim/PWMSim.hpp
+++ b/src/drivers/pwm_out_sim/PWMSim.hpp
@@ -118,8 +118,8 @@ private:
 	unsigned 	_pwm_min[MAX_ACTUATORS] {};
 	unsigned 	_pwm_max[MAX_ACTUATORS] {};
 
-	uint32_t	_groups_required{0};
-	uint32_t	_groups_subscribed{0};
+	uint8_t	_groups_required{0};
+	uint8_t	_groups_subscribed{0};
 
 	bool	_armed{false};
 	bool	_lockdown{false};

--- a/src/lib/mixer/mixer.cpp
+++ b/src/lib/mixer/mixer.cpp
@@ -187,7 +187,7 @@ NullMixer::get_saturation_status()
 }
 
 void
-NullMixer::groups_required(uint32_t &groups)
+NullMixer::groups_required(uint8_t &groups)
 {
 
 }

--- a/src/lib/mixer/mixer.h
+++ b/src/lib/mixer/mixer.h
@@ -185,9 +185,9 @@ public:
 	 * Analyses the mix configuration and updates a bitmask of groups
 	 * that are required.
 	 *
-	 * @param groups		A bitmask of groups (0-31) that the mixer requires.
+	 * @param groups		A bitmask of groups (0-7) that the mixer requires.
 	 */
-	virtual void			groups_required(uint32_t &groups) = 0;
+	virtual void			groups_required(uint8_t &groups) = 0;
 
 	/**
 	 * @brief      Empty method, only implemented for MultirotorMixer and MixerGroup class.
@@ -298,7 +298,7 @@ public:
 
 	virtual unsigned		mix(float *outputs, unsigned space);
 	virtual uint16_t		get_saturation_status(void);
-	virtual void			groups_required(uint32_t &groups);
+	virtual void			groups_required(uint8_t &groups);
 
 	/**
 	 * Add a mixer to the group.
@@ -448,7 +448,7 @@ public:
 
 	virtual unsigned		mix(float *outputs, unsigned space);
 	virtual uint16_t		get_saturation_status(void);
-	virtual void			groups_required(uint32_t &groups);
+	virtual void			groups_required(uint8_t &groups);
 	virtual void 			set_offset(float trim) {}
 	unsigned set_trim(float trim)
 	{
@@ -521,7 +521,7 @@ public:
 
 	virtual unsigned		mix(float *outputs, unsigned space);
 	virtual uint16_t		get_saturation_status(void);
-	virtual void			groups_required(uint32_t &groups);
+	virtual void			groups_required(uint8_t &groups);
 
 	/**
 	 * Check that the mixer configuration as loaded is sensible.
@@ -628,7 +628,7 @@ public:
 
 	virtual unsigned		mix(float *outputs, unsigned space);
 	virtual uint16_t		get_saturation_status(void);
-	virtual void			groups_required(uint32_t &groups);
+	virtual void			groups_required(uint8_t &groups);
 
 	/**
 	 * @brief      Update slew rate parameter. This tells the multicopter mixer
@@ -763,7 +763,7 @@ public:
 			unsigned &buflen);
 
 	virtual unsigned		mix(float *outputs, unsigned space);
-	virtual void			groups_required(uint32_t &groups);
+	virtual void			groups_required(uint8_t &groups);
 
 	virtual uint16_t		get_saturation_status(void) { return 0; }
 

--- a/src/lib/mixer/mixer_group.cpp
+++ b/src/lib/mixer/mixer_group.cpp
@@ -227,9 +227,9 @@ MixerGroup::count()
 }
 
 void
-MixerGroup::groups_required(uint32_t &groups)
+MixerGroup::groups_required(uint8_t &groups)
 {
-	Mixer	*mixer = _first;
+	Mixer *mixer = _first;
 
 	while (mixer != nullptr) {
 		mixer->groups_required(groups);

--- a/src/lib/mixer/mixer_helicopter.cpp
+++ b/src/lib/mixer/mixer_helicopter.cpp
@@ -252,7 +252,7 @@ HelicopterMixer::mix(float *outputs, unsigned space)
 }
 
 void
-HelicopterMixer::groups_required(uint32_t &groups)
+HelicopterMixer::groups_required(uint8_t &groups)
 {
 	/* XXX for now, hardcoded to indexes 0-3 in control group zero */
 	groups |= (1 << 0);

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -428,7 +428,7 @@ MultirotorMixer::set_airmode(bool airmode)
 }
 
 void
-MultirotorMixer::groups_required(uint32_t &groups)
+MultirotorMixer::groups_required(uint8_t &groups)
 {
 	/* XXX for now, hardcoded to indexes 0-3 in control group zero */
 	groups |= (1 << 0);

--- a/src/lib/mixer/mixer_simple.cpp
+++ b/src/lib/mixer/mixer_simple.cpp
@@ -311,7 +311,7 @@ SimpleMixer::get_saturation_status()
 }
 
 void
-SimpleMixer::groups_required(uint32_t &groups)
+SimpleMixer::groups_required(uint8_t &groups)
 {
 	for (unsigned i = 0; i < _pinfo->control_count; i++) {
 		groups |= 1 << _pinfo->controls[i].control_group;
@@ -325,8 +325,8 @@ SimpleMixer::check()
 	float junk;
 
 	/* sanity that presumes that a mixer includes a control no more than once */
-	/* max of 32 groups due to groups_required API */
-	if (_pinfo->control_count > 32) {
+	/* max of 8 groups due to groups_required API */
+	if (_pinfo->control_count > 8) {
 		return -2;
 	}
 

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -429,6 +429,7 @@ void AttitudeEstimatorQ::task_main()
 		if (update(dt)) {
 			vehicle_attitude_s att = {
 				.timestamp = sensors.timestamp,
+				.timestamp_sample = sensors.timestamp,
 				.rollspeed = _rates(0),
 				.pitchspeed = _rates(1),
 				.yawspeed = _rates(2),

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1028,6 +1028,7 @@ void Ekf2::run()
 				// generate vehicle attitude quaternion data
 				vehicle_attitude_s att;
 				att.timestamp = now;
+				att.timestamp_sample = sensors.timestamp;
 
 				q.copyTo(att.q);
 				_ekf.get_quat_reset(&att.delta_q_reset[0], &att.quat_reset_counter);

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -834,23 +834,23 @@ void FixedwingAttitudeControl::run()
 			// FIXME: this should use _vcontrol_mode.landing_gear_pos in the future
 			_actuators.control[7] = _manual.aux3;
 
-			/* lazily publish the setpoint only once available */
-			_actuators.timestamp = hrt_absolute_time();
-			_actuators.timestamp_sample = _att.timestamp;
-			_actuators_airframe.timestamp = hrt_absolute_time();
-			_actuators_airframe.timestamp_sample = _att.timestamp;
-
 			/* Only publish if any of the proper modes are enabled */
 			if (_vcontrol_mode.flag_control_rates_enabled ||
 			    _vcontrol_mode.flag_control_attitude_enabled ||
 			    _vcontrol_mode.flag_control_manual_enabled) {
-				/* publish the actuator controls */
+
+				_actuators.timestamp = hrt_absolute_time();
+				_actuators.timestamp_sample = _att.timestamp_sample;
+
 				if (_actuators_0_pub != nullptr) {
 					orb_publish(_actuators_id, _actuators_0_pub, &_actuators);
 
 				} else if (_actuators_id) {
 					_actuators_0_pub = orb_advertise(_actuators_id, &_actuators);
 				}
+
+
+				_actuators_airframe.timestamp = hrt_absolute_time();
 
 				if (_actuators_2_pub != nullptr) {
 					/* publish the actuator controls*/

--- a/src/modules/uavcan/uavcan_main.hpp
+++ b/src/modules/uavcan/uavcan_main.hpp
@@ -193,8 +193,10 @@ private:
 
 	MixerGroup			*_mixers = nullptr;
 	ITxQueueInjector		*_tx_injector;
-	uint32_t			_groups_required = 0;
-	uint32_t			_groups_subscribed = 0;
+
+	uint8_t			_groups_required = 0;
+	uint8_t			_groups_subscribed = 0;
+
 	int				_control_subs[NUM_ACTUATOR_CONTROL_GROUPS_UAVCAN] = {};
 	actuator_controls_s		_controls[NUM_ACTUATOR_CONTROL_GROUPS_UAVCAN] = {};
 	orb_id_t			_control_topics[NUM_ACTUATOR_CONTROL_GROUPS_UAVCAN] = {};

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -398,7 +398,8 @@ void Standard::update_fw_state()
 void Standard::fill_actuator_outputs()
 {
 	// multirotor controls
-	_actuators_out_0->timestamp = _actuators_mc_in->timestamp;
+	_actuators_out_0->timestamp = hrt_absolute_time();
+	_actuators_out_0->timestamp_sample = _actuators_mc_in->timestamp_sample;
 
 	// roll
 	_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] =
@@ -415,7 +416,8 @@ void Standard::fill_actuator_outputs()
 
 
 	// fixed wing controls
-	_actuators_out_1->timestamp = _actuators_fw_in->timestamp;
+	_actuators_out_1->timestamp = hrt_absolute_time();
+	_actuators_out_1->timestamp_sample = _actuators_fw_in->timestamp_sample;
 
 	if (_vtol_schedule.flight_mode != MC_MODE) {
 		// roll

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -269,17 +269,20 @@ void Tailsitter::update_fw_state()
 */
 void Tailsitter::fill_actuator_outputs()
 {
+	_actuators_out_0->timestamp = hrt_absolute_time();
+	_actuators_out_0->timestamp_sample = _actuators_mc_in->timestamp_sample;
+
+	_actuators_out_1->timestamp = hrt_absolute_time();
+	_actuators_out_1->timestamp_sample = _actuators_fw_in->timestamp_sample;
+
 	switch (_vtol_mode) {
 	case ROTARY_WING:
-		_actuators_out_0->timestamp = _actuators_mc_in->timestamp;
 		_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] = _actuators_mc_in->control[actuator_controls_s::INDEX_ROLL];
 		_actuators_out_0->control[actuator_controls_s::INDEX_PITCH] =
 			_actuators_mc_in->control[actuator_controls_s::INDEX_PITCH];
 		_actuators_out_0->control[actuator_controls_s::INDEX_YAW] = _actuators_mc_in->control[actuator_controls_s::INDEX_YAW];
 		_actuators_out_0->control[actuator_controls_s::INDEX_THROTTLE] =
 			_actuators_mc_in->control[actuator_controls_s::INDEX_THROTTLE];
-
-		_actuators_out_1->timestamp = _actuators_mc_in->timestamp;
 
 		if (_params->elevons_mc_lock) {
 			_actuators_out_1->control[0] = 0;
@@ -297,7 +300,6 @@ void Tailsitter::fill_actuator_outputs()
 
 	case FIXED_WING:
 		// in fixed wing mode we use engines only for providing thrust, no moments are generated
-		_actuators_out_0->timestamp = _actuators_fw_in->timestamp;
 		_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] = 0;
 		_actuators_out_0->control[actuator_controls_s::INDEX_PITCH] = 0;
 		_actuators_out_0->control[actuator_controls_s::INDEX_YAW] = 0;
@@ -317,8 +319,6 @@ void Tailsitter::fill_actuator_outputs()
 	case TRANSITION_TO_FW:
 	case TRANSITION_TO_MC:
 		// in transition engines are mixed by weight (BACK TRANSITION ONLY)
-		_actuators_out_0->timestamp = _actuators_mc_in->timestamp;
-		_actuators_out_1->timestamp = _actuators_mc_in->timestamp;
 		_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] = _actuators_mc_in->control[actuator_controls_s::INDEX_ROLL]
 				* _mc_roll_weight;
 		_actuators_out_0->control[actuator_controls_s::INDEX_PITCH] =

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -336,7 +336,9 @@ void Tiltrotor::waiting_on_tecs()
 */
 void Tiltrotor::fill_actuator_outputs()
 {
-	_actuators_out_0->timestamp = _actuators_mc_in->timestamp;
+	_actuators_out_0->timestamp = hrt_absolute_time();
+	_actuators_out_0->timestamp_sample = _actuators_mc_in->timestamp_sample;
+
 	_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] = _actuators_mc_in->control[actuator_controls_s::INDEX_ROLL]
 			* _mc_roll_weight;
 	_actuators_out_0->control[actuator_controls_s::INDEX_PITCH] =
@@ -359,7 +361,9 @@ void Tiltrotor::fill_actuator_outputs()
 			_actuators_mc_in->control[actuator_controls_s::INDEX_THROTTLE];
 	}
 
-	_actuators_out_1->timestamp = _actuators_fw_in->timestamp;
+	_actuators_out_1->timestamp = hrt_absolute_time();
+	_actuators_out_1->timestamp_sample = _actuators_fw_in->timestamp_sample;
+
 	_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] =
 		-_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL];
 	_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =


### PR DESCRIPTION
The `timestamp_sample` field has been used to propagate the timestamp of a measurement through the `actuator_controls` topic. I completed the chain to have this working though the VTOL code in order to estimate the dead-time this module adds and being able to get the complete computation time at each loop.
Here is the result of a run on a PixHawk Pro autopilot from Drotek:
![delays](https://user-images.githubusercontent.com/14822839/35804013-3ba331b2-0a76-11e8-87f9-9b7e6132311f.png)
>`sensor_combined` -> 0.75ms  -> `vehicle_attitude` -> 0.25ms -> `actuator_controls_virtual` -> 3.25ms -> `actuator_controls` -> 0.5ms -> `actuator_outputs`

The total delay - from `sensors_combined` to `actuator_outputs` is approximately 4.75ms. Which makes a maximum loop frequency of ~211Hz... not 250.

@dagar Not sure if you would like to merge this, but at least you have the results here.