### PR TITLE
VTOL standard transition improvements

### DIFF
--- a/msg/vehicle_control_mode.msg
+++ b/msg/vehicle_control_mode.msg
@@ -5,9 +5,6 @@ bool flag_armed
 
 bool flag_external_manual_override_ok		# external override non-fatal for system. Only true for fixed wing
 
-# XXX needs yet to be set by state machine helper
-bool flag_system_hil_enabled
-
 bool flag_control_manual_enabled		# true if manual input is mixed in
 bool flag_control_auto_enabled			# true if onboard autopilot should act
 bool flag_control_offboard_enabled		# true if offboard control should be used

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -56,7 +56,6 @@ bool is_rotary_wing			# True if system is in rotary wing configuration, so for a
 bool is_vtol				# True if the system is VTOL capable
 bool vtol_fw_permanent_stab		# True if VTOL should stabilize attitude for fw in manual mode
 bool in_transition_mode			# True if VTOL is doing a transition
-bool in_transition_to_fw		# True if VTOL is doing a transition from MC to FW
 
 bool rc_signal_lost				# true if RC reception lost
 uint8 rc_input_mode				# set to 1 to disable the RC input, 2 to enable manual control to RC in mapping.

--- a/msg/vtol_vehicle_status.msg
+++ b/msg/vtol_vehicle_status.msg
@@ -5,8 +5,8 @@ uint8 VEHICLE_VTOL_STATE_TRANSITION_TO_MC = 2
 uint8 VEHICLE_VTOL_STATE_MC = 3
 uint8 VEHICLE_VTOL_STATE_FW = 4
 
-bool vtol_in_rw_mode			# true: vtol vehicle is in rotating wing mode
-bool vtol_in_trans_mode
-bool in_transition_to_fw		# True if VTOL is doing a transition from MC to FW
+uint8 vtol_state
+
 bool vtol_transition_failsafe	# vtol in transition failsafe mode
+
 bool fw_permanent_stab			# In fw mode stabilize attitude even if in manual mode

--- a/posix-configs/SITL/init/ekf2/standard_vtol
+++ b/posix-configs/SITL/init/ekf2/standard_vtol
@@ -59,6 +59,7 @@ param set SYS_RESTART_TYPE 2
 param set VT_MOT_COUNT 4
 param set VT_TRANS_THR 0.75
 param set VT_TYPE 2
+param set VT_ARSP_TRANS 18
 replay tryapplyparams
 simulator start -s
 tone_alarm start

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -50,6 +50,7 @@
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/geofence_result.h>
 #include <uORB/topics/mission_result.h>
+#include <uORB/topics/offboard_control_mode.h>
 #include <uORB/topics/safety.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_command.h>
@@ -66,7 +67,8 @@ class Commander : public control::SuperBlock, public ModuleBase<Commander>
 public:
 	Commander() :
 		SuperBlock(nullptr, "COM"),
-		_mission_result_sub(ORB_ID(mission_result), 0, 0, &getSubscriptions())
+		_mission_result_sub(ORB_ID(mission_result), 0, 0, &getSubscriptions()),
+		_offboard_control_mode_sub(ORB_ID(offboard_control_mode), 0, 0, &getSubscriptions())
 	{
 		updateParams();
 	}
@@ -92,6 +94,9 @@ private:
 
 	// Subscriptions
 	Subscription<mission_result_s> _mission_result_sub;
+	Subscription<offboard_control_mode_s> _offboard_control_mode_sub;
+
+	orb_advert_t _control_mode_pub{nullptr};
 
 	bool handle_command(vehicle_status_s *status, const safety_s *safety, vehicle_command_s *cmd,
 			    actuator_armed_s *armed, home_position_s *home, vehicle_global_position_s *global_pos,
@@ -99,8 +104,10 @@ private:
 			    orb_advert_t *command_ack_pub, bool *changed);
 
 	bool set_home_position(orb_advert_t &homePub, home_position_s &home,
-				const vehicle_local_position_s &localPosition, const vehicle_global_position_s &globalPosition,
-				const vehicle_attitude_s &attitude, bool set_alt_only_to_lpos_ref);
+			       const vehicle_local_position_s &localPosition, const vehicle_global_position_s &globalPosition,
+			       const vehicle_attitude_s &attitude, bool set_alt_only_to_lpos_ref);
+
+	bool publish_control_mode(const vehicle_status_s &vstatus, const offboard_control_mode_s &offboard_control_mode);
 
 	void mission_init();
 

--- a/src/modules/commander/commander_helper.cpp
+++ b/src/modules/commander/commander_helper.cpp
@@ -83,28 +83,30 @@ using namespace DriverFramework;
 
 #define BLINK_MSG_TIME	700000	// 3 fast blinks (in us)
 
-bool is_multirotor(const struct vehicle_status_s *current_status)
+bool is_multirotor(const vehicle_status_s &vstatus)
 {
-	return ((current_status->system_type == VEHICLE_TYPE_QUADROTOR) ||
-		(current_status->system_type == VEHICLE_TYPE_HEXAROTOR) ||
-		(current_status->system_type == VEHICLE_TYPE_OCTOROTOR) ||
-		(current_status->system_type == VEHICLE_TYPE_TRICOPTER));
+	return ((vstatus.system_type == VEHICLE_TYPE_QUADROTOR) ||
+		(vstatus.system_type == VEHICLE_TYPE_HEXAROTOR) ||
+		(vstatus.system_type == VEHICLE_TYPE_OCTOROTOR) ||
+		(vstatus.system_type == VEHICLE_TYPE_TRICOPTER));
 }
 
-bool is_rotary_wing(const struct vehicle_status_s *current_status)
+bool is_rotary_wing(const vehicle_status_s &vstatus)
 {
-	return is_multirotor(current_status) || (current_status->system_type == VEHICLE_TYPE_HELICOPTER)
-		   || (current_status->system_type == VEHICLE_TYPE_COAXIAL);
+	return is_multirotor(vstatus) ||
+	       (vstatus.system_type == VEHICLE_TYPE_HELICOPTER) ||
+	       (vstatus.system_type == VEHICLE_TYPE_COAXIAL);
 }
 
-bool is_vtol(const struct vehicle_status_s * current_status) {
-	return (current_status->system_type == VEHICLE_TYPE_VTOL_DUOROTOR ||
-		current_status->system_type == VEHICLE_TYPE_VTOL_QUADROTOR ||
-		current_status->system_type == VEHICLE_TYPE_VTOL_TILTROTOR ||
-		current_status->system_type == VEHICLE_TYPE_VTOL_RESERVED2 ||
-		current_status->system_type == VEHICLE_TYPE_VTOL_RESERVED3 ||
-		current_status->system_type == VEHICLE_TYPE_VTOL_RESERVED4 ||
-		current_status->system_type == VEHICLE_TYPE_VTOL_RESERVED5);
+bool is_vtol(const vehicle_status_s &vstatus)
+{
+	return (vstatus.system_type == VEHICLE_TYPE_VTOL_DUOROTOR ||
+		vstatus.system_type == VEHICLE_TYPE_VTOL_QUADROTOR ||
+		vstatus.system_type == VEHICLE_TYPE_VTOL_TILTROTOR ||
+		vstatus.system_type == VEHICLE_TYPE_VTOL_RESERVED2 ||
+		vstatus.system_type == VEHICLE_TYPE_VTOL_RESERVED3 ||
+		vstatus.system_type == VEHICLE_TYPE_VTOL_RESERVED4 ||
+		vstatus.system_type == VEHICLE_TYPE_VTOL_RESERVED5);
 }
 
 static hrt_abstime blink_msg_end = 0;	// end time for currently blinking LED message, 0 if no blink message
@@ -334,6 +336,7 @@ void rgbled_set_color_and_mode(uint8_t color, uint8_t mode, uint8_t blinks, uint
 	orb_publish(ORB_ID(led_control), led_control_pub, &led_control);
 }
 
-void rgbled_set_color_and_mode(uint8_t color, uint8_t mode){
+void rgbled_set_color_and_mode(uint8_t color, uint8_t mode)
+{
 	rgbled_set_color_and_mode(color, mode, 0, 0);
 }

--- a/src/modules/commander/commander_helper.h
+++ b/src/modules/commander/commander_helper.h
@@ -50,9 +50,9 @@
 #include <drivers/drv_board_led.h>
 
 
-bool is_multirotor(const struct vehicle_status_s *current_status);
-bool is_rotary_wing(const struct vehicle_status_s *current_status);
-bool is_vtol(const struct vehicle_status_s *current_status);
+bool is_multirotor(const vehicle_status_s &vstatus);
+bool is_rotary_wing(const vehicle_status_s &vstatus);
+bool is_vtol(const vehicle_status_s &vstatus);
 
 int buzzer_init(void);
 void buzzer_deinit(void);

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -80,6 +80,7 @@
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_local_position_setpoint.h>
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/uORB.h>
@@ -159,6 +160,7 @@ private:
 	int		_params_sub{-1};			///< notification of parameter updates */
 	int		_manual_control_sub{-1};		///< notification of manual control updates */
 	int		_sensor_baro_sub{-1};
+	int		_local_position_sp_sub{-1};
 
 	orb_advert_t	_attitude_sp_pub{nullptr};		///< attitude setpoint */
 	orb_advert_t	_tecs_status_pub{nullptr};		///< TECS status publication */
@@ -239,12 +241,7 @@ private:
 	float _pitch{0.0f};
 	float _yaw{0.0f};
 
-	bool _reinitialize_tecs{true};				///< indicates if the TECS states should be reinitialized (used for VTOL)
 	bool _is_tecs_running{false};
-	hrt_abstime _last_tecs_update{0};
-
-	float _asp_after_transition{0.0f};
-	bool _was_in_transition{false};
 
 	// estimator reset counters
 	uint8_t _pos_reset_counter{0};				///< captures the number of times the estimator has reset the horizontal position
@@ -285,7 +282,6 @@ private:
 		float airspeed_min;
 		float airspeed_trim;
 		float airspeed_max;
-		float airspeed_trans;
 		int32_t airspeed_disabled;
 
 		float pitch_limit_min;
@@ -344,7 +340,6 @@ private:
 		param_t airspeed_min;
 		param_t airspeed_trim;
 		param_t airspeed_max;
-		param_t airspeed_trans;
 		param_t airspeed_disabled;
 
 		param_t pitch_limit_min;

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -3687,6 +3687,7 @@ public:
 
 private:
 	MavlinkOrbSubscription *_status_sub;
+	MavlinkOrbSubscription *_vtol_status_sub;
 	MavlinkOrbSubscription *_landed_sub;
 	MavlinkOrbSubscription *_pos_sp_triplet_sub;
 	MavlinkOrbSubscription *_control_mode_sub;
@@ -3699,6 +3700,7 @@ private:
 protected:
 	explicit MavlinkStreamExtendedSysState(Mavlink *mavlink) : MavlinkStream(mavlink),
 		_status_sub(_mavlink->add_orb_subscription(ORB_ID(vehicle_status))),
+		_vtol_status_sub(_mavlink->add_orb_subscription(ORB_ID(vtol_vehicle_status))),
 		_landed_sub(_mavlink->add_orb_subscription(ORB_ID(vehicle_land_detected))),
 		_pos_sp_triplet_sub(_mavlink->add_orb_subscription(ORB_ID(position_setpoint_triplet))),
 		_control_mode_sub(_mavlink->add_orb_subscription(ORB_ID(vehicle_control_mode))),
@@ -3710,26 +3712,16 @@ protected:
 
 	bool send(const hrt_abstime t)
 	{
-		struct vehicle_status_s status;
-		struct vehicle_land_detected_s land_detected;
+		vehicle_status_s status;
+		vehicle_land_detected_s land_detected;
 		bool updated = false;
 
 		if (_status_sub->update(&status)) {
 			updated = true;
+			vtol_vehicle_status_s vtol_status = {};
 
-			if (status.is_vtol) {
-				if (!status.in_transition_mode && status.is_rotary_wing) {
-					_msg.vtol_state = MAV_VTOL_STATE_MC;
-
-				} else if (!status.in_transition_mode) {
-					_msg.vtol_state = MAV_VTOL_STATE_FW;
-
-				} else if (status.in_transition_mode && status.in_transition_to_fw) {
-					_msg.vtol_state = MAV_VTOL_STATE_TRANSITION_TO_FW;
-
-				} else if (status.in_transition_mode) {
-					_msg.vtol_state = MAV_VTOL_STATE_TRANSITION_TO_MC;
-				}
+			if (status.is_vtol && _vtol_status_sub->update(&vtol_status)) {
+				_msg.vtol_state = vtol_status.vtol_state;
 			}
 		}
 

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1567,8 +1567,8 @@ int sdlog2_thread_main(int argc, char *argv[])
 			/* --- VTOL VEHICLE STATUS --- */
 			if(copy_if_updated(ORB_ID(vtol_vehicle_status), &subs.vtol_status_sub, &buf.vtol_status)) {
 				log_msg.msg_type = LOG_VTOL_MSG;
-				log_msg.body.log_VTOL.rw_mode = buf.vtol_status.vtol_in_rw_mode;
-				log_msg.body.log_VTOL.trans_mode = buf.vtol_status.vtol_in_trans_mode;
+				log_msg.body.log_VTOL.rw_mode = (buf.vtol_status.vtol_state != VEHICLE_VTOL_STATE_FW);
+				log_msg.body.log_VTOL.trans_mode = (buf.vtol_status.vtol_state == VEHICLE_VTOL_STATE_TRANSITION_TO_FW) || (buf.vtol_status.vtol_state == VEHICLE_VTOL_STATE_TRANSITION_TO_MC);
 				log_msg.body.log_VTOL.failsafe_mode = buf.vtol_status.vtol_transition_failsafe;
 				LOGBUFFER_WRITE_AND_COUNT(VTOL);
 			}

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -62,7 +62,6 @@ public:
 	virtual void update_fw_state();
 	virtual void update_mc_state();
 	virtual void fill_actuator_outputs();
-	virtual void waiting_on_tecs();
 
 private:
 
@@ -78,11 +77,14 @@ private:
 		float down_pitch_max;
 		float forward_thrust_scale;
 		int32_t airspeed_disabled;
+		float airspeed_min;
+		float airspeed_trim;
 		float pitch_setpoint_offset;
 		float reverse_output;
 		float reverse_delay;
 		float back_trans_throttle;
 		float mpc_xy_cruise;
+		float mpc_thr_hover;
 	} _params_standard;
 
 	struct {
@@ -97,11 +99,14 @@ private:
 		param_t down_pitch_max;
 		param_t forward_thrust_scale;
 		param_t airspeed_disabled;
+		param_t airspeed_min;
+		param_t airspeed_trim;
 		param_t pitch_setpoint_offset;
 		param_t reverse_output;
 		param_t reverse_delay;
 		param_t back_trans_throttle;
 		param_t mpc_xy_cruise;
+		param_t mpc_thr_hover;
 	} _params_handles_standard;
 
 	enum vtol_mode {
@@ -119,7 +124,6 @@ private:
 	bool _flag_enable_mc_motors;
 	float _pusher_throttle;
 	float _reverse_output;
-	float _airspeed_trans_blend_margin;
 
 	void set_max_mc(unsigned pwm_value);
 

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -193,29 +193,24 @@ void Tailsitter::update_vtol_state()
 	switch (_vtol_schedule.flight_mode) {
 	case MC_MODE:
 		_vtol_mode = ROTARY_WING;
-		_vtol_vehicle_status->vtol_in_trans_mode = false;
 		_flag_was_in_trans_mode = false;
 		break;
 
 	case FW_MODE:
 		_vtol_mode = FIXED_WING;
-		_vtol_vehicle_status->vtol_in_trans_mode = false;
 		_flag_was_in_trans_mode = false;
 		break;
 
 	case TRANSITION_FRONT_P1:
 		_vtol_mode = TRANSITION_TO_FW;
-		_vtol_vehicle_status->vtol_in_trans_mode = true;
 		break;
 
 	case TRANSITION_FRONT_P2:
 		_vtol_mode = TRANSITION_TO_FW;
-		_vtol_vehicle_status->vtol_in_trans_mode = true;
 		break;
 
 	case TRANSITION_BACK:
 		_vtol_mode = TRANSITION_TO_MC;
-		_vtol_vehicle_status->vtol_in_trans_mode = true;
 		break;
 	}
 }
@@ -336,12 +331,6 @@ void Tailsitter::update_transition_state()
 	math::Quaternion q_sp;
 	q_sp.from_euler(_v_att_sp->roll_body, _v_att_sp->pitch_body, _v_att_sp->yaw_body);
 	memcpy(&_v_att_sp->q_d[0], &q_sp.data[0], sizeof(_v_att_sp->q_d));
-}
-
-void Tailsitter::waiting_on_tecs()
-{
-	// copy the last trust value from the front transition
-	_v_att_sp->thrust = _thrust_transition;
 }
 
 void Tailsitter::update_mc_state()

--- a/src/modules/vtol_att_control/tailsitter.h
+++ b/src/modules/vtol_att_control/tailsitter.h
@@ -59,7 +59,6 @@ public:
 	virtual void update_mc_state();
 	virtual void update_fw_state();
 	virtual void fill_actuator_outputs();
-	virtual void waiting_on_tecs();
 
 private:
 

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -403,12 +403,6 @@ void Tiltrotor::update_transition_state()
 	memcpy(_v_att_sp, _mc_virtual_att_sp, sizeof(vehicle_attitude_setpoint_s));
 }
 
-void Tiltrotor::waiting_on_tecs()
-{
-	// keep multicopter thrust until we get data from TECS
-	_v_att_sp->thrust = _thrust_transition;
-}
-
 /**
 * Write data to actuator output topic.
 */

--- a/src/modules/vtol_att_control/tiltrotor.h
+++ b/src/modules/vtol_att_control/tiltrotor.h
@@ -57,7 +57,6 @@ public:
 	virtual void fill_actuator_outputs();
 	virtual void update_mc_state();
 	virtual void update_fw_state();
-	virtual void waiting_on_tecs();
 
 private:
 

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -45,6 +45,7 @@
 
 #include <lib/mathlib/mathlib.h>
 #include <drivers/drv_hrt.h>
+#include <uORB/topics/vtol_vehicle_status.h>
 
 struct Params {
 	int32_t idle_pwm_mc;			// pwm value for idle in mc mode
@@ -65,10 +66,10 @@ struct Params {
 
 // Has to match 1:1 msg/vtol_vehicle_status.msg
 enum mode {
-	TRANSITION_TO_FW = 1,
-	TRANSITION_TO_MC = 2,
-	ROTARY_WING = 3,
-	FIXED_WING = 4
+	TRANSITION_TO_FW = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_TRANSITION_TO_FW,
+	TRANSITION_TO_MC = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_TRANSITION_TO_MC,
+	ROTARY_WING = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC,
+	FIXED_WING = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW,
 };
 
 enum vtol_type {
@@ -113,12 +114,6 @@ public:
 	 * Write control values to actuator output topics.
 	 */
 	virtual void fill_actuator_outputs() = 0;
-
-	/**
-	 * Special handling opportunity for the time right after transition to FW
-	 * before TECS is running.
-	 */
-	virtual void waiting_on_tecs() {}
 
 	/**
 	 * Checks for fixed-wing failsafe condition and issues abort request if needed.
@@ -174,9 +169,6 @@ protected:
 	float _ra_hrate_sp = 0.0f;		// rolling average on height rate setpoint for quadchute condition
 
 	bool _flag_was_in_trans_mode = false;	// true if mode has just switched to transition
-	hrt_abstime _trans_finished_ts = 0;
-	bool _tecs_running = false;
-	hrt_abstime _tecs_running_ts = 0;
 
 };
 


### PR DESCRIPTION
This PR allows TECS to run during vtol standard transition to FW if altitude control is enabled. During the transition TECS is configured with a speed weight of 0 (100% height rate priority) and underspeed disabled. This gives it control of throttle and pitch to maintain altitude, while the MC controller is still responsible for throttle. Once FW transition completes there's no abrupt transfer.

Additionally we can disable the blending entirely (airspeed or time based) as the MC motors will automatically fade out. The airspeed and time based blending are still preserved for transitions without altitude control enabled.

Opening now for early review and discussion. There's a lot more that can be done from here, including significant back transition improvements.