### PR TITLE
camera_trigger: start counting camera triggers from one instead of zero

### DIFF
--- a/src/drivers/camera_trigger/camera_trigger.cpp
+++ b/src/drivers/camera_trigger/camera_trigger.cpp
@@ -773,12 +773,10 @@ CameraTrigger::engage(void *arg)
 	px4_clock_gettime(CLOCK_REALTIME, &tv);
 	trigger.timestamp_utc = (uint64_t) tv.tv_sec * 1000000 + tv.tv_nsec / 1000;
 
-	trigger.seq = trig->_trigger_seq;
+	// increment frame count
+	trigger.seq = ++trig->_trigger_seq;
 
 	orb_publish(ORB_ID(camera_trigger), trig->_trigger_pub, &trigger);
-
-	// increment frame count
-	trig->_trigger_seq++;
 
 }
 


### PR DESCRIPTION
Now you can see when all images were triggered using a listener and in logging by only looking at the sequence number and not the timestamp of the messages.

Maybe this is not a large enough benefit to start counting from 1?
 