### PR TITLE
FW controllers initialize vtol_type to a non-valid value

### DIFF
--- a/src/modules/fw_att_control/fw_att_control_main.cpp
+++ b/src/modules/fw_att_control/fw_att_control_main.cpp
@@ -456,6 +456,9 @@ FixedwingAttitudeControl::FixedwingAttitudeControl() :
 
 	_parameter_handles.bat_scale_en = param_find("FW_BAT_SCALE_EN");
 
+	// initialize to invalid VTOL type
+	_parameters.vtol_type = -1;
+
 	/* fetch initial parameter values */
 	parameters_update();
 }

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -94,6 +94,9 @@ FixedwingPositionControl::FixedwingPositionControl() :
 	_parameter_handles.heightrate_ff =			param_find("FW_T_HRATE_FF");
 	_parameter_handles.speedrate_p =			param_find("FW_T_SRATE_P");
 
+	// initialize to invalid vtol type
+	_parameters.vtol_type = -1;
+
 	/* fetch initial parameter values */
 	parameters_update();
 }


### PR DESCRIPTION
 - tailsitter is vtol type 0