### PR TITLE
Battery compensation fix

### DIFF
--- a/src/modules/systemlib/battery.cpp
+++ b/src/modules/systemlib/battery.cpp
@@ -174,7 +174,7 @@ Battery::estimateRemaining(float voltage_v, float current_a, float throttle_norm
 
 	// remaining battery capacity based on voltage
 	float cell_voltage = voltage_v / _n_cells.get();
-	
+
 	// correct battery voltage locally for load drop to avoid estimation fluctuations
 	if (_r_internal.get() >= 0.f) {
 		cell_voltage += _r_internal.get() * current_a;
@@ -184,6 +184,7 @@ Battery::estimateRemaining(float voltage_v, float current_a, float throttle_norm
 		// good assumption if throttle represents RPM
 		cell_voltage += throttle_normalized * throttle_normalized * _v_load_drop.get();
 	}
+
 	_remaining_voltage = math::gradual(cell_voltage, _v_empty.get(), _v_charged.get(), 0.f, 1.f);
 
 	// choose which quantity we're using for final reporting

--- a/src/modules/systemlib/battery.cpp
+++ b/src/modules/systemlib/battery.cpp
@@ -173,7 +173,7 @@ Battery::estimateRemaining(float voltage_v, float current_a, float throttle_norm
 
 
 	// remaining battery capacity based on voltage
-	const float cell_voltage = voltage_v / _n_cells.get();
+	float cell_voltage = voltage_v / _n_cells.get();
 	
 	// correct battery voltage locally for load drop to avoid estimation fluctuations
 	if (_r_internal.get() >= 0.f) {

--- a/src/modules/systemlib/battery.cpp
+++ b/src/modules/systemlib/battery.cpp
@@ -170,18 +170,20 @@ Battery::sumDischarged(hrt_abstime timestamp, float current_a)
 void
 Battery::estimateRemaining(float voltage_v, float current_a, float throttle_normalized, bool armed)
 {
+
+
+	// remaining battery capacity based on voltage
+	const float cell_voltage = voltage_v / _n_cells.get();
+	
 	// correct battery voltage locally for load drop to avoid estimation fluctuations
 	if (_r_internal.get() >= 0.f) {
-		voltage_v += _r_internal.get() * current_a;
+		cell_voltage += _r_internal.get() * current_a;
 
 	} else {
 		// assume quadratic relation between throttle and current
 		// good assumption if throttle represents RPM
-		voltage_v += throttle_normalized * throttle_normalized * _v_load_drop.get();
+		cell_voltage += throttle_normalized * throttle_normalized * _v_load_drop.get();
 	}
-
-	// remaining battery capacity based on voltage
-	const float cell_voltage = voltage_v / _n_cells.get();
 	_remaining_voltage = math::gradual(cell_voltage, _v_empty.get(), _v_charged.get(), 0.f, 1.f);
 
 	// choose which quantity we're using for final reporting


### PR DESCRIPTION
I noticed that even though the firmware takes into account the voltage drop caused by putting load on the battery I haven't been able to get  this compensation to work properly. Even if I set the voltage drop to it's maximum value of 0.5V I find that the battery estimation will be all the way down at ~10% only to land and have the estimation rise back up to 60%.

After looking at the code that handles this compensation it looks like even though the BAT_R_INTERNAL and BAT_V_LOAD_DROP are meant to be in terms of a single cell of the battery they are actually being applied to the total battery voltage instead of the cell voltage. This means that on a 3S battery the compensation only ends up being 1/3rd of what would be expected.

This PR makes it so that voltage compensation is applied to the cell voltage rather than the total voltage.