### PR TITLE
mission: warn at 2/3 of the max distance

### DIFF
--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -497,7 +497,7 @@ MissionFeasibilityChecker::checkDistanceToFirstWaypoint(const mission_s &mission
 
 		if (dist_to_1wp < max_distance) {
 
-			if (dist_to_1wp > ((max_distance * 3) / 2)) {
+			if (dist_to_1wp > ((max_distance * 2) / 3)) {
 				/* allow at 2/3 distance, but warn */
 				mavlink_log_critical(_navigator->get_mavlink_log_pub(),
 						     "First waypoint far away: %d meters.", (int)dist_to_1wp);
@@ -559,7 +559,7 @@ MissionFeasibilityChecker::checkDistancesBetweenWaypoints(const mission_s &missi
 
 			if (dist_between_waypoints < max_distance) {
 
-				if (dist_between_waypoints > ((max_distance * 3) / 2)) {
+				if (dist_between_waypoints > ((max_distance * 2) / 3)) {
 					/* allow at 2/3 distance, but warn */
 					mavlink_log_critical(_navigator->get_mavlink_log_pub(),
 							     "Distance between waypoints very far: %d meters.", (int)dist_between_waypoints);


### PR DESCRIPTION
This was wrong, instead of warning at 2/3 of the max distance as
mentioned in the comment, we would start to warn at 3/2 of the distance
which would then never actually happen.

Found by @CornerOfSkyline.