### PR TITLE
Update rc.sensors : mRo X2.1 to enable the LIS3MDL

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -56,6 +56,7 @@ if ver hwcmp AUAV_X21
 then
 	# External I2C bus
 	hmc5883 -C -T -X start
+	lis3mdl -X start
 
 	# Internal SPI bus ICM-20608-G is rotated 90 deg yaw
 	mpu6000 -R 2 -T 20608 start


### PR DESCRIPTION
This change allows the LIS3MDL based GPS magnetometers to autostart on the mRo x2.1.