### PR TITLE
microRTPS_bridge: mark task as not running when running stop()

### DIFF
--- a/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
+++ b/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
@@ -261,6 +261,8 @@ int micrortps_client_main(int argc, char *argv[])
 
 		if (nullptr != transport_node) { transport_node->close(); }
 
+		_rtps_task = -1;
+
 		return 0;
 	}
 


### PR DESCRIPTION
@avinash-palleti and I found during testing that it wasn't possible to stop the microRTPS_bridge and restart it because the task was not set to -1.