### PR TITLE
printload: fix buffer overflow on NuttX

### DIFF
--- a/src/modules/systemlib/printload.c
+++ b/src/modules/systemlib/printload.c
@@ -175,8 +175,8 @@ void print_load_buffer(uint64_t t, char *buffer, int buffer_length, print_load_c
 		unsigned tcb_pid = system_load.tasks[i].tcb->pid;
 		size_t stack_size = system_load.tasks[i].tcb->adj_stack_size;
 		ssize_t stack_free = 0;
-		char tcb_name[CONFIG_TASK_NAME_SIZE];
-		strncpy(tcb_name, system_load.tasks[i].tcb->name, CONFIG_TASK_NAME_SIZE);
+		char tcb_name[CONFIG_TASK_NAME_SIZE + 1];
+		strncpy(tcb_name, system_load.tasks[i].tcb->name, CONFIG_TASK_NAME_SIZE + 1);
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 3
 


### PR DESCRIPTION
The NuttX config variable `CONFIG_TASK_NAME_SIZE` does not include the
null terminator byte, thus the buffer needs to be longer by 1 byte.

We have `CONFIG_TASK_NAME_SIZE` set to 24 and most of the task names are shorter than that, so we did not notice. Except for `landing_target_estimator`, which lead to random bytes being printed when it was running.
This then lead to invalid strings in the log file, since the output of printload is logged.

Fixes https://github.com/PX4/Firmware/issues/8877