### PR TITLE
enable aux mixer for FMU-v5

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -120,7 +120,7 @@ then
 	fi
 fi
 
-if ver hwcmp MINDPX_V2 CRAZYFLIE AEROFC_V1 PX4FMU_V4 PX4FMU_V5
+if ver hwcmp MINDPX_V2 CRAZYFLIE AEROFC_V1 PX4FMU_V4
 then
 	set MIXER_AUX none
 fi


### PR DESCRIPTION
Now that we have the IO running, we can enable the AUX mixer.