### PR TITLE
Add check if timestamp is from the future in hrt_elapsed_time

### DIFF
--- a/platforms/posix/src/px4_layer/drv_hrt.c
+++ b/platforms/posix/src/px4_layer/drv_hrt.c
@@ -245,7 +245,13 @@ hrt_abstime ts_to_abstime(struct timespec *ts)
  */
 hrt_abstime hrt_elapsed_time(const volatile hrt_abstime *then)
 {
-	hrt_abstime delta = hrt_absolute_time() - *then;
+	hrt_abstime now = hrt_absolute_time();
+
+	if (*then > now) {
+		return 0;
+	}
+
+	hrt_abstime delta = now - *then;
 	return delta;
 }
 

--- a/platforms/qurt/src/px4_layer/drv_hrt.c
+++ b/platforms/qurt/src/px4_layer/drv_hrt.c
@@ -137,7 +137,13 @@ hrt_abstime ts_to_abstime(struct timespec *ts)
  */
 hrt_abstime hrt_elapsed_time(const volatile hrt_abstime *then)
 {
-	hrt_abstime delta = hrt_absolute_time() - *then;
+	hrt_abstime now = hrt_absolute_time();
+
+	if (*then > now) {
+		return 0;
+	}
+
+	hrt_abstime delta = now - *then;
 	return delta;
 }
 

--- a/src/drivers/drv_hrt.h
+++ b/src/drivers/drv_hrt.h
@@ -94,7 +94,7 @@ __EXPORT extern void	abstime_to_ts(struct timespec *ts, hrt_abstime abstime);
 
 /**
  * Compute the delta between a timestamp taken in the past
- * and now.
+ * and now. If the timestamp is from the future zero is returned.
  *
  * This function is safe to use even if the timestamp is updated
  * by an interrupt during execution.

--- a/src/drivers/kinetis/drv_hrt.c
+++ b/src/drivers/kinetis/drv_hrt.c
@@ -613,7 +613,14 @@ hrt_elapsed_time(const volatile hrt_abstime *then)
 {
 	irqstate_t flags = px4_enter_critical_section();
 
-	hrt_abstime delta = hrt_absolute_time() - *then;
+	hrt_abstime now = hrt_absolute_time();
+
+	if (*then > now) {
+		px4_leave_critical_section(flags);
+		return 0;
+	}
+
+	hrt_abstime delta = now - *then;
 
 	px4_leave_critical_section(flags);
 

--- a/src/drivers/samv7/drv_hrt.c
+++ b/src/drivers/samv7/drv_hrt.c
@@ -689,7 +689,14 @@ hrt_elapsed_time(const volatile hrt_abstime *then)
 {
 	irqstate_t flags = enter_critical_section();
 
-	hrt_abstime delta = hrt_absolute_time() - *then;
+	hrt_abstime now = hrt_absolute_time();
+
+	if (*then > now) {
+		px4_leave_critical_section(flags);
+		return 0;
+	}
+
+	hrt_abstime delta = now - *then;
 
 	leave_critical_section(flags);
 

--- a/src/drivers/stm32/drv_hrt.c
+++ b/src/drivers/stm32/drv_hrt.c
@@ -729,7 +729,14 @@ hrt_elapsed_time(const volatile hrt_abstime *then)
 {
 	irqstate_t flags = px4_enter_critical_section();
 
-	hrt_abstime delta = hrt_absolute_time() - *then;
+	hrt_abstime now = hrt_absolute_time();
+
+	if (*then > now) {
+		px4_leave_critical_section(flags);
+		return 0;
+	}
+
+	hrt_abstime delta = now - *then;
 
 	px4_leave_critical_section(flags);
 


### PR DESCRIPTION
This check avoids that the two's complement is returned if the timestamp is in the future.