### PR TITLE
Offboard position and altitude control

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -3618,6 +3618,13 @@ set_control_mode()
 		control_mode.flag_control_altitude_enabled = (!offboard_control_mode.ignore_velocity ||
 				!offboard_control_mode.ignore_position) && !control_mode.flag_control_acceleration_enabled;
 
+		// These are all required for altitude control
+		control_mode.flag_control_altitude_enabled	= !offboard_control_mode.ignore_alt_hold || control_mode.flag_control_altitude_enabled;
+		control_mode.flag_control_attitude_enabled	= !offboard_control_mode.ignore_alt_hold || control_mode.flag_control_attitude_enabled;
+		control_mode.flag_control_rates_enabled		= !offboard_control_mode.ignore_alt_hold || control_mode.flag_control_rates_enabled;
+		control_mode.flag_control_climb_rate_enabled= !offboard_control_mode.ignore_alt_hold || control_mode.flag_control_climb_rate_enabled;
+		control_mode.flag_control_velocity_enabled	= !offboard_control_mode.ignore_alt_hold || control_mode.flag_control_velocity_enabled;
+
 		break;
 
 	default:

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -3623,7 +3623,6 @@ set_control_mode()
 		control_mode.flag_control_attitude_enabled	= !offboard_control_mode.ignore_alt_hold || control_mode.flag_control_attitude_enabled;
 		control_mode.flag_control_rates_enabled		= !offboard_control_mode.ignore_alt_hold || control_mode.flag_control_rates_enabled;
 		control_mode.flag_control_climb_rate_enabled= !offboard_control_mode.ignore_alt_hold || control_mode.flag_control_climb_rate_enabled;
-		control_mode.flag_control_velocity_enabled	= !offboard_control_mode.ignore_alt_hold || control_mode.flag_control_velocity_enabled;
 
 		break;
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1535,6 +1535,13 @@ MulticopterPositionControl::control_offboard()
 
 			_hold_offboard_z = false;
 
+			/* disable position control as it is not enabled */
+			if(_control_mode.flag_control_position_enabled){
+				_run_pos_control = true;
+			} else {
+				_run_pos_control = false;
+			}
+
 		} else if (_control_mode.flag_control_climb_rate_enabled && _pos_sp_triplet.current.velocity_valid) {
 
 			/* reset alt setpoint to current altitude if needed */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3241,8 +3241,9 @@ MulticopterPositionControl::task_main()
 			 * attitude setpoints for the transition).
 			 */
 			if (!(_control_mode.flag_control_offboard_enabled &&
-			      !(_control_mode.flag_control_position_enabled ||
-				_control_mode.flag_control_velocity_enabled ||
+			      !(_control_mode.flag_control_altitude_enabled  ||
+			    _control_mode.flag_control_position_enabled      ||
+				_control_mode.flag_control_velocity_enabled      ||
 				_control_mode.flag_control_acceleration_enabled))) {
 
 				if (_att_sp_pub != nullptr) {


### PR DESCRIPTION
* This PR accompanies https://github.com/dronecore/DroneCore/pull/260
* Hoist flags in commander for offboard altitude control.
* Turn of position control when altitude is controlled and position
  should be ignored.