### PR TITLE
MC rate controller: add low-pass filter for D-term

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -558,12 +558,15 @@ MulticopterAttitudeControl::parameters_update()
 	_params.rate_ff(1) = v;
 
 	param_get(_params_handles.d_term_cutoff_freq, &_params.d_term_cutoff_freq);
-	_lp_filters_d[0].set_cutoff_frequency(_loop_update_rate_hz, _params.d_term_cutoff_freq);
-	_lp_filters_d[1].set_cutoff_frequency(_loop_update_rate_hz, _params.d_term_cutoff_freq);
-	_lp_filters_d[2].set_cutoff_frequency(_loop_update_rate_hz, _params.d_term_cutoff_freq);
-	_lp_filters_d[0].reset(_rates_prev(0));
-	_lp_filters_d[1].reset(_rates_prev(1));
-	_lp_filters_d[2].reset(_rates_prev(2));
+
+	if (fabsf(_lp_filters_d[0].get_cutoff_freq() - _params.d_term_cutoff_freq) > 0.01f) {
+		_lp_filters_d[0].set_cutoff_frequency(_loop_update_rate_hz, _params.d_term_cutoff_freq);
+		_lp_filters_d[1].set_cutoff_frequency(_loop_update_rate_hz, _params.d_term_cutoff_freq);
+		_lp_filters_d[2].set_cutoff_frequency(_loop_update_rate_hz, _params.d_term_cutoff_freq);
+		_lp_filters_d[0].reset(_rates_prev(0));
+		_lp_filters_d[1].reset(_rates_prev(1));
+		_lp_filters_d[2].reset(_rates_prev(2));
+	}
 
 	param_get(_params_handles.tpa_breakpoint_p, &_params.tpa_breakpoint_p);
 	param_get(_params_handles.tpa_breakpoint_i, &_params.tpa_breakpoint_i);

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -1093,6 +1093,8 @@ MulticopterAttitudeControl::task_main()
 	px4_pollfd_struct_t poll_fds = {};
 	poll_fds.events = POLLIN;
 
+	hrt_abstime last_run = task_start;
+
 	while (!_task_should_exit) {
 
 		poll_fds.fd = _sensor_gyro_sub[_selected_gyro];
@@ -1117,9 +1119,9 @@ MulticopterAttitudeControl::task_main()
 
 		/* run controller on gyro changes */
 		if (poll_fds.revents & POLLIN) {
-			static uint64_t last_run = 0;
-			float dt = (hrt_absolute_time() - last_run) / 1000000.0f;
-			last_run = hrt_absolute_time();
+			const hrt_abstime now = hrt_absolute_time();
+			float dt = (now - last_run) / 1e6f;
+			last_run = now;
 
 			/* guard against too small (< 2ms) and too large (> 20ms) dt's */
 			if (dt < 0.002f) {

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -174,7 +174,6 @@ private:
 
 	math::Vector<3>		_rates_prev;		/**< angular rates on previous step */
 	math::Vector<3>		_rates_prev_filtered;	/**< angular rates on previous step (low-pass filtered) */
-	math::Vector<3>		_rates_sp_prev;		/**< previous rates setpoint */
 	math::Vector<3>		_rates_sp;		/**< angular rates setpoint */
 	math::Vector<3>		_rates_int;		/**< angular rates integral error */
 	float			_thrust_sp;		/**< thrust setpoint */
@@ -418,7 +417,6 @@ _loop_update_rate_hz(initial_update_rate_hz)
 	_rates_prev.zero();
 	_rates_prev_filtered.zero();
 	_rates_sp.zero();
-	_rates_sp_prev.zero();
 	_rates_int.zero();
 	_thrust_sp = 0.0f;
 	_att_control.zero();
@@ -1036,7 +1034,6 @@ MulticopterAttitudeControl::control_attitude_rates(float dt)
 		       rates_d_scaled.emult(rates_filtered - _rates_prev_filtered) / dt +
 		       _params.rate_ff.emult(_rates_sp);
 
-	_rates_sp_prev = _rates_sp;
 	_rates_prev = rates;
 	_rates_prev_filtered = rates_filtered;
 

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -60,6 +60,7 @@
 #include <lib/geo/geo.h>
 #include <lib/mathlib/mathlib.h>
 #include <lib/mixer/mixer.h>
+#include <mathlib/math/filter/LowPassFilter2p.hpp>
 #include <px4_config.h>
 #include <px4_defines.h>
 #include <px4_posix.h>
@@ -167,11 +168,16 @@ private:
 	perf_counter_t	_loop_perf;			/**< loop performance counter */
 	perf_counter_t	_controller_latency_perf;
 
-	math::Vector<3>		_rates_prev;	/**< angular rates on previous step */
-	math::Vector<3>		_rates_sp_prev; /**< previous rates setpoint */
+	math::LowPassFilter2p _lp_filters_d[3];                      /**< low-pass filters for D-term (roll, pitch & yaw) */
+	static constexpr const float initial_update_rate_hz = 250.f; /**< loop update rate used for initialization */
+	float _loop_update_rate_hz;                                  /**< current rate-controller loop update rate in [Hz] */
+
+	math::Vector<3>		_rates_prev;		/**< angular rates on previous step */
+	math::Vector<3>		_rates_prev_filtered;	/**< angular rates on previous step (low-pass filtered) */
+	math::Vector<3>		_rates_sp_prev;		/**< previous rates setpoint */
 	math::Vector<3>		_rates_sp;		/**< angular rates setpoint */
 	math::Vector<3>		_rates_int;		/**< angular rates integral error */
-	float				_thrust_sp;		/**< thrust setpoint */
+	float			_thrust_sp;		/**< thrust setpoint */
 	math::Vector<3>		_att_control;	/**< attitude control vector */
 
 	math::Matrix<3, 3>  _I;				/**< identity matrix */
@@ -191,6 +197,7 @@ private:
 		param_t pitch_rate_integ_lim;
 		param_t pitch_rate_d;
 		param_t pitch_rate_ff;
+		param_t d_term_cutoff_freq;
 		param_t tpa_breakpoint_p;
 		param_t tpa_breakpoint_i;
 		param_t tpa_breakpoint_d;
@@ -239,6 +246,8 @@ private:
 		math::Vector<3> rate_d;				/**< D gain for angular rate error */
 		math::Vector<3>	rate_ff;			/**< Feedforward gain for desired rates */
 		float yaw_ff;						/**< yaw control feed-forward */
+
+		float d_term_cutoff_freq;			/**< Cutoff frequency for the D-term filter */
 
 		float tpa_breakpoint_p;				/**< Throttle PID Attenuation breakpoint */
 		float tpa_breakpoint_i;				/**< Throttle PID Attenuation breakpoint */
@@ -368,7 +377,14 @@ MulticopterAttitudeControl::MulticopterAttitudeControl() :
 	_saturation_status{},
 	/* performance counters */
 	_loop_perf(perf_alloc(PC_ELAPSED, "mc_att_control")),
-	_controller_latency_perf(perf_alloc_once(PC_ELAPSED, "ctrl_latency"))
+	_controller_latency_perf(perf_alloc_once(PC_ELAPSED, "ctrl_latency")),
+
+	_lp_filters_d{
+	{initial_update_rate_hz, 50.f},
+	{initial_update_rate_hz, 50.f},
+	{initial_update_rate_hz, 50.f}}, // will be initialized correctly when params are loaded
+
+_loop_update_rate_hz(initial_update_rate_hz)
 {
 	for (uint8_t i = 0; i < MAX_GYRO_COUNT; i++) {
 		_sensor_gyro_sub[i] = -1;
@@ -400,6 +416,7 @@ MulticopterAttitudeControl::MulticopterAttitudeControl() :
 	_params.board_offset[2] = 0.0f;
 
 	_rates_prev.zero();
+	_rates_prev_filtered.zero();
 	_rates_sp.zero();
 	_rates_sp_prev.zero();
 	_rates_int.zero();
@@ -422,6 +439,8 @@ MulticopterAttitudeControl::MulticopterAttitudeControl() :
 	_params_handles.pitch_rate_integ_lim	= 	param_find("MC_PR_INT_LIM");
 	_params_handles.pitch_rate_d		= 	param_find("MC_PITCHRATE_D");
 	_params_handles.pitch_rate_ff 		= 	param_find("MC_PITCHRATE_FF");
+
+	_params_handles.d_term_cutoff_freq	= 	param_find("MC_DTERM_CUTOFF");
 
 	_params_handles.tpa_breakpoint_p 	= 	param_find("MC_TPA_BREAK_P");
 	_params_handles.tpa_breakpoint_i 	= 	param_find("MC_TPA_BREAK_I");
@@ -539,6 +558,14 @@ MulticopterAttitudeControl::parameters_update()
 	_params.rate_d(1) = v * (ATTITUDE_TC_DEFAULT / pitch_tc);
 	param_get(_params_handles.pitch_rate_ff, &v);
 	_params.rate_ff(1) = v;
+
+	param_get(_params_handles.d_term_cutoff_freq, &_params.d_term_cutoff_freq);
+	_lp_filters_d[0].set_cutoff_frequency(_loop_update_rate_hz, _params.d_term_cutoff_freq);
+	_lp_filters_d[1].set_cutoff_frequency(_loop_update_rate_hz, _params.d_term_cutoff_freq);
+	_lp_filters_d[2].set_cutoff_frequency(_loop_update_rate_hz, _params.d_term_cutoff_freq);
+	_lp_filters_d[0].reset(_rates_prev(0));
+	_lp_filters_d[1].reset(_rates_prev(1));
+	_lp_filters_d[2].reset(_rates_prev(2));
 
 	param_get(_params_handles.tpa_breakpoint_p, &_params.tpa_breakpoint_p);
 	param_get(_params_handles.tpa_breakpoint_i, &_params.tpa_breakpoint_i);
@@ -998,13 +1025,20 @@ MulticopterAttitudeControl::control_attitude_rates(float dt)
 	/* angular rates error */
 	math::Vector<3> rates_err = _rates_sp - rates;
 
+	/* apply low-pass filtering to the rates for D-term */
+	math::Vector<3> rates_filtered(
+		_lp_filters_d[0].apply(rates(0)),
+		_lp_filters_d[1].apply(rates(1)),
+		_lp_filters_d[2].apply(rates(2)));
+
 	_att_control = rates_p_scaled.emult(rates_err) +
-		       _rates_int +
-		       rates_d_scaled.emult(_rates_prev - rates) / dt +
+		       _rates_int -
+		       rates_d_scaled.emult(rates_filtered - _rates_prev_filtered) / dt +
 		       _params.rate_ff.emult(_rates_sp);
 
 	_rates_sp_prev = _rates_sp;
 	_rates_prev = rates;
+	_rates_prev_filtered = rates_filtered;
 
 	/* update integral only if motors are providing enough thrust to be effective */
 	if (_thrust_sp > MIN_TAKEOFF_THRUST) {
@@ -1093,7 +1127,10 @@ MulticopterAttitudeControl::task_main()
 	px4_pollfd_struct_t poll_fds = {};
 	poll_fds.events = POLLIN;
 
+	const hrt_abstime task_start = hrt_absolute_time();
 	hrt_abstime last_run = task_start;
+	float dt_accumulator = 0.f;
+	int loop_counter = 0;
 
 	while (!_task_should_exit) {
 
@@ -1299,6 +1336,23 @@ MulticopterAttitudeControl::task_main()
 					}
 				}
 			}
+
+			/* calculate loop update rate while disarmed or at least a few times (updating the filter is expensive) */
+			if (!_v_control_mode.flag_armed || (now - task_start) < 3300000) {
+				dt_accumulator += dt;
+				++loop_counter;
+
+				if (dt_accumulator > 1.f) {
+					const float loop_update_rate = (float)loop_counter / dt_accumulator;
+					_loop_update_rate_hz = _loop_update_rate_hz * 0.5f + loop_update_rate * 0.5f;
+					dt_accumulator = 0;
+					loop_counter = 0;
+					_lp_filters_d[0].set_cutoff_frequency(_loop_update_rate_hz, _params.d_term_cutoff_freq);
+					_lp_filters_d[1].set_cutoff_frequency(_loop_update_rate_hz, _params.d_term_cutoff_freq);
+					_lp_filters_d[2].set_cutoff_frequency(_loop_update_rate_hz, _params.d_term_cutoff_freq);
+				}
+			}
+
 		}
 
 		perf_end(_loop_perf);

--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -554,3 +554,20 @@ PARAM_DEFINE_FLOAT(MC_TPA_RATE_I, 0.0f);
  * @group Multicopter Attitude Control
  */
 PARAM_DEFINE_FLOAT(MC_TPA_RATE_D, 0.0f);
+
+/**
+ * Cutoff frequency for the low pass filter on the D-term in the rate controller
+ *
+ * The D-term uses the derivative of the rate and thus is the most susceptible to noise.
+ * Therefore, using a D-term filter allows to decrease the driver-level filtering, which
+ * leads to reduced control latency and permits to increase the P gains.
+ * A value of 0 disables the filter.
+ *
+ * @unit Hz
+ * @min 0
+ * @max 1000
+ * @decimal 0
+ * @increment 10
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MC_DTERM_CUTOFF, 0.f);

--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -74,7 +74,7 @@ PARAM_DEFINE_FLOAT(MC_PITCH_TC, 0.2f);
  *
  * @unit 1/s
  * @min 0.0
- * @max 8
+ * @max 12
  * @decimal 2
  * @increment 0.1
  * @group Multicopter Attitude Control
@@ -149,7 +149,7 @@ PARAM_DEFINE_FLOAT(MC_ROLLRATE_FF, 0.0f);
  *
  * @unit 1/s
  * @min 0.0
- * @max 10
+ * @max 12
  * @decimal 2
  * @increment 0.1
  * @group Multicopter Attitude Control

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -227,13 +227,13 @@ PARAM_DEFINE_FLOAT(SENS_BOARD_Z_OFF, 0.0f);
 PARAM_DEFINE_INT32(SENS_EN_THERMAL, -1);
 
 /**
-* Driver level cut frequency for gyro
+* Driver level cutoff frequency for gyro
 *
-* The cut frequency for the 2nd order butterworth filter on the gyro driver. This features
+* The cutoff frequency for the 2nd order butterworth filter on the gyro driver. This features
 * is currently supported by the mpu6000 and mpu9250. This only affects the signal sent to the
 * controllers, not the estimators. 0 disables the filter.
 *
-* @min 5
+* @min 0
 * @max 1000
 * @unit Hz
 * @reboot_required true
@@ -242,13 +242,13 @@ PARAM_DEFINE_INT32(SENS_EN_THERMAL, -1);
 PARAM_DEFINE_FLOAT(IMU_GYRO_CUTOFF, 30.0f);
 
 /**
-* Driver level cut frequency for accel
+* Driver level cutoff frequency for accel
 *
-* The cut frequency for the 2nd order butterworth filter on the accel driver. This features
+* The cutoff frequency for the 2nd order butterworth filter on the accel driver. This features
 * is currently supported by the mpu6000 and mpu9250. This only affects the signal sent to the
 * controllers, not the estimators. 0 disables the filter.
 *
-* @min 5
+* @min 0
 * @max 1000
 * @unit Hz
 * @reboot_required true


### PR DESCRIPTION
Simpler version of https://github.com/PX4/Firmware/pull/7698.

This adds a butterworth low-pass filter to the D-term of the rate controller.
The idea behind this is: The D-term uses the derivative of the rate and thus is the most susceptible to noise. Therefore, using a D-term filter allows to decrease the driver-level filtering, which leads to reduced control latency and permits to increase the P gains.

### Output Noise
I was using `IMU_GYRO_CUTOFF=90` for my testing. I think I could go even higher, but I should also reduce the on-chip filtering (which I did not do for these tests).

With `IMU_GYRO_CUTOFF=90`, I have visible noise on the outputs, but the quad still flies. I tested different values for the D-term cutoff filter frequency, and it reduces the noise on the output indeed. I found for my quad a cutoff frequency of 70 removes most of the noise.
This is the FFT for actuator outputs without D-term filter (first 3 motors):
![fft_actuator_outputs_mc_dterm_cutoff 0](https://user-images.githubusercontent.com/281593/36379170-e4958790-157d-11e8-824b-9a87f6b6aa4d.png)

This is using D-term filter frequency = 30:
![fft_actuator_outputs_mc_dterm_cutoff 30](https://user-images.githubusercontent.com/281593/36379180-ec2ca13c-157d-11e8-97d9-9466a8b8e7b5.png)


### Tuning Gains
I was flying with a P gain of 0.18 before, and was able to increase it to 0.28 now. I tested the same gains against the state of master (`IMU_GYRO_CUTOFF=30`, `MC_DTERM_CUTOFF=0`), and it has strong, visible oscillations, meaning it doesn't fly:
- master: https://logs.px4.io/plot_app?log=980137fc-7bae-48b5-9b93-238989e1ecf4
- this PR with IMU_GYRO_CUTOFF=90, MC_DTERM_CUTOFF=70: https://logs.px4.io/plot_app?log=06ba3019-f8fb-40a8-8fba-5cdc789d07c3

The filter is disabled by default, thus it should not be problematic to merge. We should evaluate the whole filtering pipeline and default values once we have https://github.com/PX4/Firmware/pull/8731.
In future, we can also experiment with different lp filters.

@AndreasAntener @bresch @MaEtUgR @RomanBapst  @Stifael 