### PR TITLE
RC input: allow disabling the RC filtering via RC_FLT_CUTOFF

### DIFF
--- a/src/modules/sensors/parameters.cpp
+++ b/src/modules/sensors/parameters.cpp
@@ -368,7 +368,7 @@ int update_parameters(const ParameterHandles &parameter_handles, Parameters &par
 	parameters.rc_flt_smp_rate = math::max(1.0f, parameters.rc_flt_smp_rate);
 	param_get(parameter_handles.rc_flt_cutoff, &(parameters.rc_flt_cutoff));
 	/* make sure the filter is in its stable region -> fc < fs/2 */
-	parameters.rc_flt_cutoff = math::constrain(parameters.rc_flt_cutoff, 0.1f, (parameters.rc_flt_smp_rate / 2) - 1.f);
+	parameters.rc_flt_cutoff = math::min(parameters.rc_flt_cutoff, (parameters.rc_flt_smp_rate / 2) - 1.f);
 
 	/* Airspeed offset */
 	param_get(parameter_handles.diff_pres_offset_pa, &(parameters.diff_pres_offset_pa));

--- a/src/modules/sensors/rc_params.c
+++ b/src/modules/sensors/rc_params.c
@@ -2214,8 +2214,9 @@ PARAM_DEFINE_FLOAT(RC_FLT_SMP_RATE, 50.0f);
  * Cutoff frequency for the low pass filter on roll, pitch, yaw and throttle
  *
  * Does not get set unless below RC_FLT_SMP_RATE/2 because of filter instability characteristics.
+ * Set to 0 to disable the filter.
  *
- * @min 0.1
+ * @min 0
  * @unit Hz
  * @group Radio Calibration
  */


### PR DESCRIPTION
The default value of 10 Hz adds noticeable lag.