### PR TITLE
Battery: Switch thrust based load compensation back to linear

### DIFF
--- a/src/modules/systemlib/battery.cpp
+++ b/src/modules/systemlib/battery.cpp
@@ -170,8 +170,6 @@ Battery::sumDischarged(hrt_abstime timestamp, float current_a)
 void
 Battery::estimateRemaining(float voltage_v, float current_a, float throttle_normalized, bool armed)
 {
-
-
 	// remaining battery capacity based on voltage
 	float cell_voltage = voltage_v / _n_cells.get();
 
@@ -180,9 +178,8 @@ Battery::estimateRemaining(float voltage_v, float current_a, float throttle_norm
 		cell_voltage += _r_internal.get() * current_a;
 
 	} else {
-		// assume quadratic relation between throttle and current
-		// good assumption if throttle represents RPM
-		cell_voltage += throttle_normalized * throttle_normalized * _v_load_drop.get();
+		// assume linear relation between throttle and voltage drop
+		cell_voltage += throttle_normalized * _v_load_drop.get();
 	}
 
 	_remaining_voltage = math::gradual(cell_voltage, _v_empty.get(), _v_charged.get(), 0.f, 1.f);


### PR DESCRIPTION
To account for the parameter definition:
https://github.com/PX4/Firmware/blob/master/src/modules/systemlib/battery_params.c#L129
My tests if quadratic is actually better in practise were anyways not clearly conclusive.

I saw this inconsistency while looking at #8868
FYI @nanthony21 