### PR TITLE
fw_att_control: schedule trims for airspeed and flap deployment

### DIFF
--- a/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
@@ -174,6 +174,14 @@ private:
 		float trim_roll;
 		float trim_pitch;
 		float trim_yaw;
+		float dtrim_roll_vmin;
+		float dtrim_pitch_vmin;
+		float dtrim_yaw_vmin;
+		float dtrim_roll_vmax;
+		float dtrim_pitch_vmax;
+		float dtrim_yaw_vmax;
+		float dtrim_roll_flaps;
+		float dtrim_pitch_flaps;
 		float rollsp_offset_deg;		/**< Roll Setpoint Offset in deg */
 		float pitchsp_offset_deg;		/**< Pitch Setpoint Offset in deg */
 		float rollsp_offset_rad;		/**< Roll Setpoint Offset in rad */
@@ -235,6 +243,14 @@ private:
 		param_t trim_roll;
 		param_t trim_pitch;
 		param_t trim_yaw;
+		param_t dtrim_roll_vmin;
+		param_t dtrim_pitch_vmin;
+		param_t dtrim_yaw_vmin;
+		param_t dtrim_roll_vmax;
+		param_t dtrim_pitch_vmax;
+		param_t dtrim_yaw_vmax;
+		param_t dtrim_roll_flaps;
+		param_t dtrim_pitch_flaps;
 		param_t rollsp_offset_deg;
 		param_t pitchsp_offset_deg;
 		param_t man_roll_max;

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -618,3 +618,107 @@ PARAM_DEFINE_FLOAT(FW_ACRO_Z_MAX, 45);
  * @group FW Attitude Control
  */
 PARAM_DEFINE_FLOAT(FW_RATT_TH, 0.8f);
+
+/**
+* Roll trim increment at minimum airspeed
+*
+* This increment is added to TRIM_ROLL when airspeed is FW_AIRSPD_MIN.
+ *
+ * @group FW Attitude Control
+ * @min -0.25
+ * @max 0.25
+ * @decimal 2
+ * @increment 0.01
+ */
+PARAM_DEFINE_FLOAT(FW_DTRIM_R_VMIN, 0.0f);
+
+/**
+* Pitch trim increment at minimum airspeed
+*
+* This increment is added to TRIM_PITCH when airspeed is FW_AIRSPD_MIN.
+ *
+ * @group FW Attitude Control
+ * @min -0.25
+ * @max 0.25
+ * @decimal 2
+ * @increment 0.01
+ */
+PARAM_DEFINE_FLOAT(FW_DTRIM_P_VMIN, 0.0f);
+
+/**
+* Yaw trim increment at minimum airspeed
+*
+* This increment is added to TRIM_YAW when airspeed is FW_AIRSPD_MIN.
+ *
+ * @group FW Attitude Control
+ * @min -0.25
+ * @max 0.25
+ * @decimal 2
+ * @increment 0.01
+ */
+PARAM_DEFINE_FLOAT(FW_DTRIM_Y_VMIN, 0.0f);
+
+/**
+* Roll trim increment at maximum airspeed
+*
+* This increment is added to TRIM_ROLL when airspeed is FW_AIRSP_MAX.
+ *
+ * @group FW Attitude Control
+ * @min -0.25
+ * @max 0.25
+ * @decimal 2
+ * @increment 0.01
+ */
+PARAM_DEFINE_FLOAT(FW_DTRIM_R_VMAX, 0.0f);
+
+/**
+* Pitch trim increment at maximum airspeed
+*
+* This increment is added to TRIM_PITCH when airspeed is FW_AIRSP_MAX.
+ *
+ * @group FW Attitude Control
+ * @min -0.25
+ * @max 0.25
+ * @decimal 2
+ * @increment 0.01
+ */
+PARAM_DEFINE_FLOAT(FW_DTRIM_P_VMAX, 0.0f);
+
+/**
+* Yaw trim increment at maximum airspeed
+*
+* This increment is added to TRIM_YAW when airspeed is FW_AIRSP_MAX.
+ *
+ * @group FW Attitude Control
+ * @min -0.25
+ * @max 0.25
+ * @decimal 2
+ * @increment 0.01
+ */
+PARAM_DEFINE_FLOAT(FW_DTRIM_Y_VMAX, 0.0f);
+
+/**
+ * Roll trim increment for flaps configuration
+ *
+ * This increment is added to TRIM_ROLL whenever flaps are fully deployed.
+ *
+ * @group FW Attitude Control
+ * @min -0.25
+ * @max 0.25
+ * @decimal 2
+ * @increment 0.01
+ */
+PARAM_DEFINE_FLOAT(FW_DTRIM_R_FLPS, 0.0f);
+
+/**
+ * Pitch trim increment for flaps configuration
+ *
+ * This increment is added to the pitch trim whenever flaps are fully deployed.
+ *
+ * @group FW Attitude Control
+ * @min -0.25
+ * @max 0.25
+ * @decimal 2
+ * @increment 0.01
+ */
+PARAM_DEFINE_FLOAT(FW_DTRIM_P_FLPS, 0.0f);


### PR DESCRIPTION
Currently, there are only one set of actuator trims for the FW controller, and rate integrators are relied on to retrim in various off-nominal conditions. Depending on the platform and the extent of the flight envelope in which one needs to operate, performance can be improved by scheduling trims via airspeed, then only relying on the integrator for smaller corrections. This is especially the case for landing configurations where flaps will e.g. change the required elevator trim. This PR incorporates scheduling of trims for these cases, but not changing the nominal operation for users who do not need these additions.

Additions:
- Adds trim settings for minimum and maximum airspeed and bi-linearly interpolates with the airspeed (nominal) trim.
- Adds a delta-trim for flap deployment, adding this increment whenever flaps are deployed.

Notes:
- These trims are applied in all modes *except manual, where only the nominal trims are applied.
- If the trims for vmin and vmax are both zero for a given actuator - the nominal trim is applied