### PR TITLE
tune_control: added define for tune strength

### DIFF
--- a/msg/tune_control.msg
+++ b/msg/tune_control.msg
@@ -25,3 +25,5 @@ uint16 frequency     # in Hz
 uint32 duration      # in us
 uint32 silence 		 # in us
 uint8 strength       # value between 0-100 if supported by backend
+
+uint8 STRENGTH_NORMAL = 40

--- a/src/modules/commander/commander_helper.cpp
+++ b/src/modules/commander/commander_helper.cpp
@@ -140,6 +140,7 @@ void buzzer_deinit()
 void set_tune_override(int tune)
 {
 	tune_control.tune_id = tune;
+	tune_control.strength = tune_control_s::STRENGTH_NORMAL;
 	tune_control.tune_override = 1;
 	tune_control.timestamp = hrt_absolute_time();
 	orb_publish(ORB_ID(tune_control), tune_control_pub, &tune_control);
@@ -154,6 +155,7 @@ void set_tune(int tune)
 		/* allow interrupting current non-repeating tune by the same tune */
 		if (tune != tune_current || new_tune_duration != 0) {
 			tune_control.tune_id = tune;
+			tune_control.strength = tune_control_s::STRENGTH_NORMAL;
 			tune_control.tune_override = 0;
 			tune_control.timestamp = hrt_absolute_time();
 			orb_publish(ORB_ID(tune_control), tune_control_pub, &tune_control);

--- a/src/systemcmds/tune_control/tune_control.cpp
+++ b/src/systemcmds/tune_control/tune_control.cpp
@@ -98,7 +98,7 @@ tune_control_main(int argc, char *argv[])
 	unsigned int value;
 	tune_control_s tune_control = {};
 	tune_control.tune_id = 0;
-	tune_control.strength = 40;
+	tune_control.strength = tune_control_s::STRENGTH_NORMAL;
 
 	while ((ch = px4_getopt(argc, argv, "f:d:t:m:s:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
@@ -151,7 +151,7 @@ tune_control_main(int argc, char *argv[])
 				tune_control.strength = value;
 
 			} else {
-				tune_control.strength = 40;
+				tune_control.strength = tune_control_s::STRENGTH_NORMAL;
 			}
 
 			break;


### PR DESCRIPTION
This adds a define for the tune strength instead of hard-coding it with
a magic number.