### PR TITLE
Pr aero battery initialization hotfix

### DIFF
--- a/src/modules/systemlib/battery.cpp
+++ b/src/modules/systemlib/battery.cpp
@@ -89,10 +89,14 @@ Battery::updateBatteryStatus(hrt_abstime timestamp, float voltage_v, float curre
 	filterCurrent(current_a);
 	sumDischarged(timestamp, current_a);
 	estimateRemaining(_voltage_filtered_v, _current_filtered_a, throttle_normalized, armed);
-	determineWarning(connected);
 	computeScale();
 
+	if (_battery_initialized) {
+		determineWarning(connected);
+	}
+
 	if (_voltage_filtered_v > 2.1f) {
+		_battery_initialized = true;
 		battery_status->voltage_v = voltage_v;
 		battery_status->voltage_filtered_v = _voltage_filtered_v;
 		battery_status->scale = _scale;
@@ -110,7 +114,7 @@ Battery::updateBatteryStatus(hrt_abstime timestamp, float voltage_v, float curre
 void
 Battery::filterVoltage(float voltage_v)
 {
-	if (_voltage_filtered_v < 0.f) {
+	if (!_battery_initialized) {
 		_voltage_filtered_v = voltage_v;
 	}
 
@@ -125,7 +129,7 @@ Battery::filterVoltage(float voltage_v)
 void
 Battery::filterCurrent(float current_a)
 {
-	if (_current_filtered_a < 0.f) {
+	if (!_battery_initialized) {
 		_current_filtered_a = current_a;
 	}
 
@@ -183,7 +187,7 @@ Battery::estimateRemaining(float voltage_v, float current_a, float throttle_norm
 	// choose which quantity we're using for final reporting
 	if (_capacity.get() > 0.f) {
 		// if battery capacity is known, fuse voltage measurement with used capacity
-		if (_remaining > 1.f) {
+		if (!_battery_initialized) {
 			// initialization of the estimation state
 			_remaining = _remaining_voltage;
 

--- a/src/modules/systemlib/battery.cpp
+++ b/src/modules/systemlib/battery.cpp
@@ -53,13 +53,6 @@ Battery::Battery() :
 	_low_thr(this, "LOW_THR"),
 	_crit_thr(this, "CRIT_THR"),
 	_emergency_thr(this, "EMERGEN_THR"),
-	_voltage_filtered_v(-1.f),
-	_current_filtered_a(-1.f),
-	_discharged_mah(0.f),
-	_discharged_mah_loop(0.f),
-	_remaining_voltage(1.f),
-	_remaining(2.f),
-	_scale(1.f),
 	_warning(battery_status_s::BATTERY_WARNING_NONE),
 	_last_timestamp(0)
 {

--- a/src/modules/systemlib/battery.h
+++ b/src/modules/systemlib/battery.h
@@ -113,12 +113,13 @@ private:
 	control::BlockParamFloat _crit_thr;
 	control::BlockParamFloat _emergency_thr;
 
+	bool _battery_initialized = false;
 	float _voltage_filtered_v = -1.f;
 	float _current_filtered_a = -1.f;
 	float _discharged_mah = 0.f;
 	float _discharged_mah_loop = 0.f;
-	float _remaining_voltage = 1.f;		///< normalized battery charge level remaining based on voltage
-	float _remaining = 2.f;			///< normalized battery charge level, selected based on config param
+	float _remaining_voltage = -1.f;		///< normalized battery charge level remaining based on voltage
+	float _remaining = -1.f;			///< normalized battery charge level, selected based on config param
 	float _scale = 1.f;
 	uint8_t _warning;
 	hrt_abstime _last_timestamp;

--- a/src/modules/systemlib/battery.h
+++ b/src/modules/systemlib/battery.h
@@ -113,13 +113,13 @@ private:
 	control::BlockParamFloat _crit_thr;
 	control::BlockParamFloat _emergency_thr;
 
-	float _voltage_filtered_v;
-	float _current_filtered_a;
-	float _discharged_mah;
-	float _discharged_mah_loop;
-	float _remaining_voltage;		///< normalized battery charge level remaining based on voltage
-	float _remaining;			///< normalized battery charge level, selected based on config param
-	float _scale;
+	float _voltage_filtered_v = -1.f;
+	float _current_filtered_a = -1.f;
+	float _discharged_mah = 0.f;
+	float _discharged_mah_loop = 0.f;
+	float _remaining_voltage = 1.f;		///< normalized battery charge level remaining based on voltage
+	float _remaining = 2.f;			///< normalized battery charge level, selected based on config param
+	float _scale = 1.f;
 	uint8_t _warning;
 	hrt_abstime _last_timestamp;
 };


### PR DESCRIPTION
On the Intel Aero and probably also other specific platforms the first measured voltage values despite connected battery are unuasable. The solution here is to start filtering and determining warning only after a measurement above 2.1V was received. This condition was anyways used before to determine if the battery status report gets filled at all.

I bench tested this on an Intel Aero. Can someone else please also confirm?

fixes #8930