### PR TITLE
mavlink add minimal mode

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -651,8 +651,24 @@ then
 	fi
 	if param compare SYS_COMPANION 419200
 	then
-		iridiumsbd start -d /dev/ttyS2
+		iridiumsbd start -d ${MAVLINK_COMPANION_DEVICE}
 		mavlink start -d /dev/iridium -b 19200 -m iridium -r 10
+	fi
+	if param compare SYS_COMPANION 519200
+	then
+		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 19200 -m minimal -r 1000
+	fi
+	if param compare SYS_COMPANION 538400
+	then
+		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 38400 -m minimal -r 1000
+	fi
+	if param compare SYS_COMPANION 557600
+	then
+		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 57600 -m minimal -r 1000
+	fi
+	if param compare SYS_COMPANION 5115200
+	then
+		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 115200 -m minimal -r 1000
 	fi
 	if param compare SYS_COMPANION 1921600
 	then

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -369,12 +369,6 @@ Mavlink::count_txerr()
 	perf_count(_txerr_perf);
 }
 
-void
-Mavlink::set_mode(enum MAVLINK_MODE mode)
-{
-	_mode = mode;
-}
-
 int
 Mavlink::instance_count()
 {
@@ -1871,6 +1865,9 @@ Mavlink::task_main(int argc, char *argv[])
 			} else if (strcmp(myoptarg, "iridium") == 0) {
 				_mode = MAVLINK_MODE_IRIDIUM;
 				_rstatus.type = telemetry_status_s::TELEMETRY_STATUS_RADIO_TYPE_IRIDIUM;
+
+			} else if (strcmp(myoptarg, "minimal") == 0) {
+				_mode = MAVLINK_MODE_MINIMAL;
 			}
 
 			break;
@@ -2119,6 +2116,19 @@ Mavlink::task_main(int argc, char *argv[])
 
 	case MAVLINK_MODE_IRIDIUM:
 		configure_stream("HIGH_LATENCY", 0.1f);
+		break;
+
+	case MAVLINK_MODE_MINIMAL:
+		configure_stream("SYS_STATUS", 0.1f);
+		configure_stream("EXTENDED_SYS_STATE", 0.1f);
+		configure_stream("ATTITUDE", 10.0f);
+		configure_stream("RC_CHANNELS", 0.5f);
+		configure_stream("ALTITUDE", 0.5f);
+		configure_stream("GPS_RAW_INT", 0.5f);
+		configure_stream("GLOBAL_POSITION_INT", 5.0f);
+		configure_stream("HOME_POSITION", 0.1f);
+		configure_stream("NAMED_VALUE_FLOAT", 1.0f);
+		configure_stream("VFR_HUD", 1.0f);
 		break;
 
 	default:
@@ -2773,7 +2783,7 @@ $ mavlink stream -u 14556 -s HIGHRES_IMU -r 50
 	PRINT_MODULE_USAGE_PARAM_STRING('t', "127.0.0.1", nullptr,
 					"Partner IP (broadcasting can be enabled via MAV_BROADCAST param)", true);
 #endif
-	PRINT_MODULE_USAGE_PARAM_STRING('m', "normal", "custom|camera|onboard|osd|magic|config|iridium",
+	PRINT_MODULE_USAGE_PARAM_STRING('m', "normal", "custom|camera|onboard|osd|magic|config|iridium|minimal",
 					"Mode: sets default streams and rates", true);
 	PRINT_MODULE_USAGE_PARAM_FLAG('f', "Enable message forwarding to other Mavlink instances", true);
 	PRINT_MODULE_USAGE_PARAM_FLAG('w', "Wait to send, until first message received", true);

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -169,7 +169,8 @@ public:
 		MAVLINK_MODE_OSD,
 		MAVLINK_MODE_MAGIC,
 		MAVLINK_MODE_CONFIG,
-		MAVLINK_MODE_IRIDIUM
+		MAVLINK_MODE_IRIDIUM,
+		MAVLINK_MODE_MINIMAL
 	};
 
 	enum BROADCAST_MODE {
@@ -201,12 +202,14 @@ public:
 		case MAVLINK_MODE_IRIDIUM:
 			return "Iridium";
 
+		case MAVLINK_MODE_MINIMAL:
+			return "Minimal";
+
 		default:
 			return "Unknown";
 		}
 	}
 
-	void			set_mode(enum MAVLINK_MODE);
 	enum MAVLINK_MODE	get_mode() { return _mode; }
 
 	bool			get_hil_enabled() { return _hil_enabled; }

--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -126,6 +126,10 @@ PARAM_DEFINE_INT32(SYS_MC_EST_GROUP, 2);
  * @value 357600 Normal Telemetry (57600 baud, 8N1)
  * @value 3115200 Normal Telemetry (115200 baud, 8N1)
  * @value 419200 Iridium Telemetry (19200 baud, 8N1)
+ * @value 519200 Minimal Telemetry (19200 baud, 8N1)
+ * @value 538400 Minimal Telemetry (38400 baud, 8N1)
+ * @value 557600 Minimal Telemetry (57600 baud, 8N1)
+ * @value 5115200 Minimal Telemetry (115200 baud, 8N1)
  * @value 1921600 ESP8266 (921600 baud, 8N1)
  *
  * @min 0


### PR DESCRIPTION
New mavlink mode intended for the minimum telemetry stream needed for regular QGC usage over a slow serial radio with no ability to throttle (eg Dragonlink UHF without flow control).