### PR TITLE
Backport backup register

### DIFF
--- a/src/drivers/boards/common/stm32/board_reset.c
+++ b/src/drivers/boards/common/stm32/board_reset.c
@@ -62,7 +62,13 @@ int board_set_bootload_mode(board_reset_e mode)
 	}
 
 	stm32_pwr_enablebkp(true);
-	*(uint32_t *)STM32_RTC_BKR(0) = regvalue;
+
+// Check if we can to use the new register definition
+#ifndef STM32_RTC_BK0R
+	*(uint32_t *)STM32_BKP_BASE = regvalue;
+#else
+	*(uint32_t *)STM32_RTC_BK0R = regvalue;
+#endif
 	stm32_pwr_enablebkp(false);
 	return OK;
 }

--- a/src/drivers/boards/common/stm32/board_reset.c
+++ b/src/drivers/boards/common/stm32/board_reset.c
@@ -40,6 +40,7 @@
 #include <px4_config.h>
 #include <errno.h>
 #include <stm32_pwr.h>
+#include <stm32_rtc.h>
 #include <nuttx/board.h>
 
 
@@ -61,7 +62,7 @@ int board_set_bootload_mode(board_reset_e mode)
 	}
 
 	stm32_pwr_enablebkp(true);
-	*(uint32_t *)STM32_BKP_BASE = regvalue;
+	*(uint32_t *)STM32_RTC_BKR(0) = regvalue;
 	stm32_pwr_enablebkp(false);
 	return OK;
 }

--- a/src/platforms/px4_micro_hal.h
+++ b/src/platforms/px4_micro_hal.h
@@ -68,6 +68,7 @@ __BEGIN_DECLS
 
 #    if defined(CONFIG_ARCH_CHIP_STM32F7)
 #      include <chip.h>
+#      include <up_internal.h> //include up_systemreset() which is included on stm32.h
 #      include <stm32_bbsram.h>
 #      define PX4_BBSRAM_SIZE STM32F7_BBSRAM_SIZE
 #      define PX4_BBSRAM_GETDESC_IOCTL STM32F7_BBSRAM_GETDESC_IOCTL


### PR DESCRIPTION
Change to be coherent with the change on NuttX upstream, in the future
STM32_BKP_BASE will be removed. This is using the definition over stm32_rtc.h interface. 
In addition, the definition of `STM32_BKP_BASE` is not correct for stm32f7.

This PR also add a missing definition for stm32f7 boards for `up_systemreset()` which was usually included in stm32.h which is not defined for stm32f7 boards.