### PR TITLE
VTOL parameter cleanup

### DIFF
--- a/ROMFS/px4fmu_common/init.d/13005_vtol_AAERT_quad
+++ b/ROMFS/px4fmu_common/init.d/13005_vtol_AAERT_quad
@@ -24,7 +24,7 @@ if [ $AUTOCNF == yes ]
 then
 	param set VT_TYPE 2
 	param set VT_MOT_COUNT 4
-	param set VT_TRANS_THR 0.75
+	param set VT_F_TRANS_THR 0.75
 	param set VT_ARSP_TRANS 12
 	param set VT_ARSP_BLEND 6
 

--- a/ROMFS/px4fmu_common/init.d/13006_vtol_standard_delta
+++ b/ROMFS/px4fmu_common/init.d/13006_vtol_standard_delta
@@ -22,7 +22,7 @@ if [ $AUTOCNF == yes ]
 then
 	param set VT_TYPE 2
 	param set VT_MOT_COUNT 4
-	param set VT_TRANS_THR 0.75
+	param set VT_F_TRANS_THR 0.75
 
 	param set MC_ROLL_P 6.5
 	param set MC_ROLLRATE_P 0.15

--- a/ROMFS/px4fmu_common/init.d/13007_vtol_AAVVT_quad
+++ b/ROMFS/px4fmu_common/init.d/13007_vtol_AAVVT_quad
@@ -14,7 +14,7 @@ if [ $AUTOCNF == yes ]
 then
 	param set VT_TYPE 2
 	param set VT_MOT_COUNT 4
-	param set VT_TRANS_THR 0.75
+	param set VT_F_TRANS_THR 0.75
 
 	param set MC_ROLL_P 7.0
 	param set MC_ROLLRATE_P 0.15

--- a/ROMFS/px4fmu_common/init.d/13008_QuadRanger
+++ b/ROMFS/px4fmu_common/init.d/13008_QuadRanger
@@ -14,7 +14,7 @@ if [ $AUTOCNF == yes ]
 then
 	param set VT_TYPE 2
 	param set VT_MOT_COUNT 4
-	param set VT_TRANS_THR 0.75
+	param set VT_F_TRANS_THR 0.75
 
 	param set PWM_AUX_REV1 1
 	param set PWM_AUX_REV2 1

--- a/ROMFS/px4fmu_common/init.d/13009_vtol_spt_ranger
+++ b/ROMFS/px4fmu_common/init.d/13009_vtol_spt_ranger
@@ -19,7 +19,7 @@ then
     param set VT_ARSP_TRANS   15.0
     param set VT_B_TRANS_DUR  4.0
     param set VT_TRANS_MIN_TM 5.0
-    param set VT_TRANS_THR    0.6
+    param set VT_F_TRANS_THR    0.6
     param set VT_TRANS_TIMEOUT    30.0
 
     param set FW_AIRSPD_MAX   22.0

--- a/ROMFS/px4fmu_common/init.d/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/13013_deltaquad
@@ -23,7 +23,7 @@ if [ $AUTOCNF == yes ]
 then
 	param set VT_TYPE 2
 	param set VT_MOT_COUNT 4
-	param set VT_TRANS_THR 1
+	param set VT_F_TRANS_THR 1
 	param set VT_DWN_PITCH_MAX 8
 	param set VT_FW_QC_P 55
 	param set VT_FW_QC_R 55

--- a/posix-configs/SITL/init/ekf2/standard_vtol
+++ b/posix-configs/SITL/init/ekf2/standard_vtol
@@ -57,7 +57,7 @@ param set SYS_AUTOSTART 13006
 param set SYS_MC_EST_GROUP 2
 param set SYS_RESTART_TYPE 2
 param set VT_MOT_COUNT 4
-param set VT_TRANS_THR 0.75
+param set VT_F_TRANS_THR 0.75
 param set VT_TYPE 2
 replay tryapplyparams
 simulator start -s

--- a/posix-configs/SITL/init/ekf2/tiltrotor
+++ b/posix-configs/SITL/init/ekf2/tiltrotor
@@ -57,7 +57,7 @@ param set SYS_AUTOSTART 13006
 param set SYS_MC_EST_GROUP 2
 param set SYS_RESTART_TYPE 2
 param set VT_MOT_COUNT 4
-param set VT_TRANS_THR 0.75
+param set VT_F_TRANS_THR 0.75
 param set VT_TYPE 1
 param set VT_TILT_FW 3.1415
 param set VT_TILT_TRANS 1.2

--- a/posix-configs/SITL/init/lpe/standard_vtol
+++ b/posix-configs/SITL/init/lpe/standard_vtol
@@ -3,7 +3,7 @@ param load
 param set MAV_TYPE 22
 param set VT_TYPE 2
 param set VT_MOT_COUNT 4
-param set VT_TRANS_THR 0.75
+param set VT_F_TRANS_THR 0.75
 param set SYS_AUTOSTART 13006
 param set SYS_RESTART_TYPE 2
 param set SYS_MC_EST_GROUP 1

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -62,23 +62,13 @@ Standard::Standard(VtolAttitudeControl *attc) :
 	_mc_yaw_weight = 1.0f;
 	_mc_throttle_weight = 1.0f;
 
-	_params_handles_standard.front_trans_dur = param_find("VT_F_TRANS_DUR");
-	_params_handles_standard.back_trans_dur = param_find("VT_B_TRANS_DUR");
+	_params_handles_standard.pusher_ramp_dt = param_find("VT_PSHER_RMP_DT");
 	_params_handles_standard.back_trans_ramp = param_find("VT_B_TRANS_RAMP");
-	_params_handles_standard.pusher_trans = param_find("VT_TRANS_THR");
-	_params_handles_standard.airspeed_blend = param_find("VT_ARSP_BLEND");
-	_params_handles_standard.airspeed_trans = param_find("VT_ARSP_TRANS");
-	_params_handles_standard.front_trans_timeout = param_find("VT_TRANS_TIMEOUT");
-	_params_handles_standard.front_trans_time_min = param_find("VT_TRANS_MIN_TM");
 	_params_handles_standard.down_pitch_max = param_find("VT_DWN_PITCH_MAX");
 	_params_handles_standard.forward_thrust_scale = param_find("VT_FWD_THRUST_SC");
-	_params_handles_standard.airspeed_disabled = param_find("FW_ARSP_MODE");
 	_params_handles_standard.pitch_setpoint_offset = param_find("FW_PSP_OFF");
 	_params_handles_standard.reverse_output = param_find("VT_B_REV_OUT");
 	_params_handles_standard.reverse_delay = param_find("VT_B_REV_DEL");
-	_params_handles_standard.back_trans_throttle = param_find("VT_B_TRANS_THR");
-	_params_handles_standard.mpc_xy_cruise = param_find("MPC_XY_CRUISE");
-
 }
 
 Standard::~Standard()
@@ -89,39 +79,16 @@ void
 Standard::parameters_update()
 {
 	float v;
-	int i;
 
 	/* duration of a forwards transition to fw mode */
-	param_get(_params_handles_standard.front_trans_dur, &v);
-	_params_standard.front_trans_dur = math::constrain(v, 0.0f, 20.0f);
-
-	/* duration of a back transition to mc mode */
-	param_get(_params_handles_standard.back_trans_dur, &v);
-	_params_standard.back_trans_dur = math::constrain(v, 0.0f, 20.0f);
+	param_get(_params_handles_standard.pusher_ramp_dt, &v);
+	_params_standard.pusher_ramp_dt = math::constrain(v, 0.0f, 20.0f);
 
 	/* MC ramp up during back transition to mc mode */
 	param_get(_params_handles_standard.back_trans_ramp, &v);
-	_params_standard.back_trans_ramp = math::constrain(v, 0.0f, _params_standard.back_trans_dur);
+	_params_standard.back_trans_ramp = math::constrain(v, 0.0f, _params->back_trans_duration);
 
-	/* target throttle value for pusher motor during the transition to fw mode */
-	param_get(_params_handles_standard.pusher_trans, &v);
-	_params_standard.pusher_trans = math::constrain(v, 0.0f, 5.0f);
-
-	/* airspeed at which we should switch to fw mode */
-	param_get(_params_handles_standard.airspeed_trans, &v);
-	_params_standard.airspeed_trans = math::constrain(v, 1.0f, 20.0f);
-
-	/* airspeed at which we start blending mc/fw controls */
-	param_get(_params_handles_standard.airspeed_blend, &v);
-	_params_standard.airspeed_blend = math::constrain(v, 0.0f, 20.0f);
-
-	_airspeed_trans_blend_margin = _params_standard.airspeed_trans - _params_standard.airspeed_blend;
-
-	/* timeout for transition to fw mode */
-	param_get(_params_handles_standard.front_trans_timeout, &_params_standard.front_trans_timeout);
-
-	/* minimum time for transition to fw mode */
-	param_get(_params_handles_standard.front_trans_time_min, &_params_standard.front_trans_time_min);
+	_airspeed_trans_blend_margin = _params->transition_airspeed - _params->airspeed_blend;
 
 	/* maximum down pitch allowed */
 	param_get(_params_handles_standard.down_pitch_max, &v);
@@ -129,10 +96,6 @@ Standard::parameters_update()
 
 	/* scale for fixed wing thrust used for forward acceleration in multirotor mode */
 	param_get(_params_handles_standard.forward_thrust_scale, &_params_standard.forward_thrust_scale);
-
-	/* airspeed mode */
-	param_get(_params_handles_standard.airspeed_disabled, &i);
-	_params_standard.airspeed_disabled = math::constrain(i, 0, 1);
 
 	/* pitch setpoint offset */
 	param_get(_params_handles_standard.pitch_setpoint_offset, &v);
@@ -146,13 +109,6 @@ Standard::parameters_update()
 	param_get(_params_handles_standard.reverse_delay, &v);
 	_params_standard.reverse_delay = math::constrain(v, 0.0f, 10.0f);
 
-	/* reverse throttle */
-	param_get(_params_handles_standard.back_trans_throttle, &v);
-	_params_standard.back_trans_throttle = math::constrain(v, -1.0f, 1.0f);
-
-	/* mpc cruise speed */
-	param_get(_params_handles_standard.mpc_xy_cruise, &_params_standard.mpc_xy_cruise);
-
 }
 
 void Standard::update_vtol_state()
@@ -163,6 +119,8 @@ void Standard::update_vtol_state()
 	 */
 
 	float mc_weight = _mc_roll_weight;
+	float time_now = (float)hrt_absolute_time();
+	float time_since_trans_start = time_now - (float)_vtol_schedule.transition_start;
 
 	if (!_attc->is_fixed_wing_requested()) {
 
@@ -209,9 +167,8 @@ void Standard::update_vtol_state()
 
 			float x_vel = vel(0);
 
-			if (hrt_elapsed_time(&_vtol_schedule.transition_start) >
-			    (_params_standard.back_trans_dur * 1000000.0f) ||
-			    (_local_pos->v_xy_valid && x_vel <= _params_standard.mpc_xy_cruise)) {
+			if (time_since_trans_start > _params->back_trans_duration * 1e6f ||
+			    (_local_pos->v_xy_valid && x_vel <= _params->mpc_xy_cruise)) {
 				_vtol_schedule.flight_mode = MC_MODE;
 			}
 
@@ -233,10 +190,9 @@ void Standard::update_vtol_state()
 
 		} else if (_vtol_schedule.flight_mode == TRANSITION_TO_FW) {
 			// continue the transition to fw mode while monitoring airspeed for a final switch to fw mode
-			if (((_params_standard.airspeed_disabled == 1 ||
-			      _airspeed->indicated_airspeed_m_s >= _params_standard.airspeed_trans) &&
-			     (float)hrt_elapsed_time(&_vtol_schedule.transition_start)
-			     > (_params_standard.front_trans_time_min * 1000000.0f)) ||
+			if (((_params->airspeed_mode == 1 ||
+			      _airspeed->indicated_airspeed_m_s >= _params->transition_airspeed) &&
+			     time_since_trans_start > _params->front_trans_time_min * 1e6f) ||
 			    can_transition_on_ground()) {
 
 				_vtol_schedule.flight_mode = FW_MODE;
@@ -277,6 +233,9 @@ void Standard::update_vtol_state()
 void Standard::update_transition_state()
 {
 	float mc_weight = 1.0f;
+	float time_now = (float)hrt_absolute_time();
+	float time_since_trans_start = time_now - (float)
+				       _vtol_schedule.transition_start;	// time in microseconds since transition started
 
 	VtolType::update_transition_state();
 
@@ -284,32 +243,28 @@ void Standard::update_transition_state()
 	memcpy(_v_att_sp, _mc_virtual_att_sp, sizeof(vehicle_attitude_setpoint_s));
 
 	if (_vtol_schedule.flight_mode == TRANSITION_TO_FW) {
-		if (_params_standard.front_trans_dur <= 0.0f) {
+		if (_params_standard.pusher_ramp_dt <= 0.0f) {
 			// just set the final target throttle value
-			_pusher_throttle = _params_standard.pusher_trans;
+			_pusher_throttle = _params->front_trans_throttle;
 
-		} else if (_pusher_throttle <= _params_standard.pusher_trans) {
+		} else if (_pusher_throttle <= _params->front_trans_throttle) {
 			// ramp up throttle to the target throttle value
-			_pusher_throttle = _params_standard.pusher_trans *
-					   (float)hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params_standard.front_trans_dur * 1000000.0f);
+			_pusher_throttle = _params->front_trans_throttle * time_since_trans_start / (_params_standard.pusher_ramp_dt * 1e6f);
 		}
 
 		// do blending of mc and fw controls if a blending airspeed has been provided and the minimum transition time has passed
 		if (_airspeed_trans_blend_margin > 0.0f &&
-		    _airspeed->indicated_airspeed_m_s >= _params_standard.airspeed_blend &&
-		    (float)hrt_elapsed_time(&_vtol_schedule.transition_start) > (_params_standard.front_trans_time_min * 1000000.0f)
-		   ) {
-			mc_weight = 1.0f - fabsf(_airspeed->indicated_airspeed_m_s - _params_standard.airspeed_blend) /
+		    _airspeed->indicated_airspeed_m_s >= _params->airspeed_blend &&
+		    time_since_trans_start > _params->front_trans_time_min * 1e6f) {
+			mc_weight = 1.0f - fabsf(_airspeed->indicated_airspeed_m_s - _params->airspeed_blend) /
 				    _airspeed_trans_blend_margin;
 			// time based blending when no airspeed sensor is set
 
-		} else if (_params_standard.airspeed_disabled &&
-			   hrt_elapsed_time(&_vtol_schedule.transition_start) < (_params_standard.front_trans_time_min * 1e6f) &&
-			   hrt_elapsed_time(&_vtol_schedule.transition_start) > ((_params_standard.front_trans_time_min / 2.0f) * 1e6f)
-			  ) {
-			mc_weight = 1.0f - ((float)(hrt_elapsed_time(&_vtol_schedule.transition_start) - ((
-							    _params_standard.front_trans_time_min / 2.0f) * 1000000.0f)) /
-					    ((_params_standard.front_trans_time_min / 2.0f) * 1000000.0f));
+		} else if (_params->airspeed_mode == 1 &&
+			   time_since_trans_start < _params->front_trans_time_min * 1e6f &&
+			   time_since_trans_start > _params->front_trans_time_min * 1e6f / 2.0f) {
+			mc_weight = 1.0f - ((time_since_trans_start -  _params->front_trans_time_min * 1e6f / 2.0f) /
+					    (_params->front_trans_time_min * 1e6f / 2.0f));
 
 		}
 
@@ -320,8 +275,8 @@ void Standard::update_transition_state()
 		_v_att_sp->q_d_valid = true;
 
 		// check front transition timeout
-		if (_params_standard.front_trans_timeout > FLT_EPSILON) {
-			if (hrt_elapsed_time(&_vtol_schedule.transition_start) > (_params_standard.front_trans_timeout * 1e6f)) {
+		if (_params->front_trans_timeout > FLT_EPSILON) {
+			if (time_since_trans_start > _params->front_trans_timeout * 1e6f) {
 				// transition timeout occured, abort transition
 				_attc->abort_front_transition("Transition timeout");
 			}
@@ -335,22 +290,21 @@ void Standard::update_transition_state()
 		q_sp.copyTo(_v_att_sp->q_d);
 		_v_att_sp->q_d_valid = true;
 
-		hrt_abstime btrans_start;
-		btrans_start = _vtol_schedule.transition_start + uint64_t(_params_standard.reverse_delay) * 1000000.0f;
+		float btrans_start = (float)_vtol_schedule.transition_start + _params_standard.reverse_delay * 1e6f;
+
 		_pusher_throttle = 0.0f;
 
-		if (hrt_absolute_time() >= btrans_start) {
+		if (time_now >= btrans_start) {
 			// Handle throttle reversal for active breaking
-			float thrscale = (float)hrt_elapsed_time(&btrans_start) / (_params_standard.front_trans_dur *
-					 1000000.0f);
+			float thrscale = (time_now - btrans_start) / (_params_standard.pusher_ramp_dt * 1e6f);
 			thrscale = math::constrain(thrscale, 0.0f, 1.0f);
-			_pusher_throttle = thrscale * _params_standard.back_trans_throttle;
+			_pusher_throttle = thrscale * _params->back_trans_throttle;
 		}
 
 		// continually increase mc attitude control as we transition back to mc mode
 		if (_params_standard.back_trans_ramp > FLT_EPSILON) {
-			mc_weight = (float)hrt_elapsed_time(&_vtol_schedule.transition_start) /
-				    ((_params_standard.back_trans_ramp) * 1000000.0f);
+			mc_weight = time_since_trans_start /
+				    ((_params_standard.back_trans_ramp) * 1e6f);
 
 		}
 

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -119,7 +119,7 @@ void Standard::update_vtol_state()
 	 */
 
 	float mc_weight = _mc_roll_weight;
-	float time_since_trans_start = ((float)(hrt_absolute_time() - _vtol_schedule.transition_start)) / 1e6f;
+	float time_since_trans_start = (float)(hrt_absolute_time() - _vtol_schedule.transition_start) * 1e-6f;
 
 	if (!_attc->is_fixed_wing_requested()) {
 
@@ -232,7 +232,7 @@ void Standard::update_vtol_state()
 void Standard::update_transition_state()
 {
 	float mc_weight = 1.0f;
-	float time_since_trans_start = ((float)(hrt_absolute_time() - _vtol_schedule.transition_start)) / 1e6f;
+	float time_since_trans_start = (float)(hrt_absolute_time() - _vtol_schedule.transition_start) * 1e-6f;
 
 	VtolType::update_transition_state();
 

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -190,7 +190,7 @@ void Standard::update_vtol_state()
 
 		} else if (_vtol_schedule.flight_mode == TRANSITION_TO_FW) {
 			// continue the transition to fw mode while monitoring airspeed for a final switch to fw mode
-			if (((_params->airspeed_mode == 1 ||
+			if (((_params->airspeed_disabled ||
 			      _airspeed->indicated_airspeed_m_s >= _params->transition_airspeed) &&
 			     time_since_trans_start > _params->front_trans_time_min * 1e6f) ||
 			    can_transition_on_ground()) {
@@ -260,7 +260,7 @@ void Standard::update_transition_state()
 				    _airspeed_trans_blend_margin;
 			// time based blending when no airspeed sensor is set
 
-		} else if (_params->airspeed_mode == 1 &&
+		} else if (_params->airspeed_disabled &&
 			   time_since_trans_start < _params->front_trans_time_min * 1e6f &&
 			   time_since_trans_start > _params->front_trans_time_min * 1e6f / 2.0f) {
 			mc_weight = 1.0f - ((time_since_trans_start -  _params->front_trans_time_min * 1e6f / 2.0f) /

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -257,11 +257,9 @@ void Standard::update_transition_state()
 				    _airspeed_trans_blend_margin;
 			// time based blending when no airspeed sensor is set
 
-		} else if (_params->airspeed_disabled &&
-			   time_since_trans_start < _params->front_trans_time_min &&
-			   time_since_trans_start > _params->front_trans_time_min / 2.0f) {
-			mc_weight = 1.0f - ((time_since_trans_start -  _params->front_trans_time_min / 2.0f) /
-					    (_params->front_trans_time_min / 2.0f));
+		} else if (_params->airspeed_disabled) {
+			mc_weight = 1.0f - (time_since_trans_start -  _params->front_trans_time_min) / _params->front_trans_time_min;
+			mc_weight = math::constrain(2.0f * mc_weight, 0.0f, 1.0f);
 
 		}
 

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -258,7 +258,7 @@ void Standard::update_transition_state()
 			// time based blending when no airspeed sensor is set
 
 		} else if (_params->airspeed_disabled) {
-			mc_weight = 1.0f - (time_since_trans_start -  _params->front_trans_time_min) / _params->front_trans_time_min;
+			mc_weight = 1.0f - time_since_trans_start / _params->front_trans_time_min;
 			mc_weight = math::constrain(2.0f * mc_weight, 0.0f, 1.0f);
 
 		}

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -67,41 +67,23 @@ public:
 private:
 
 	struct {
-		float front_trans_dur;
-		float back_trans_dur;
+		float pusher_ramp_dt;
 		float back_trans_ramp;
-		float pusher_trans;
-		float airspeed_blend;
-		float airspeed_trans;
-		float front_trans_timeout;
-		float front_trans_time_min;
 		float down_pitch_max;
 		float forward_thrust_scale;
-		int32_t airspeed_disabled;
 		float pitch_setpoint_offset;
 		float reverse_output;
 		float reverse_delay;
-		float back_trans_throttle;
-		float mpc_xy_cruise;
 	} _params_standard;
 
 	struct {
-		param_t front_trans_dur;
-		param_t back_trans_dur;
+		param_t pusher_ramp_dt;
 		param_t back_trans_ramp;
-		param_t pusher_trans;
-		param_t airspeed_blend;
-		param_t airspeed_trans;
-		param_t front_trans_timeout;
-		param_t front_trans_time_min;
 		param_t down_pitch_max;
 		param_t forward_thrust_scale;
-		param_t airspeed_disabled;
 		param_t pitch_setpoint_offset;
 		param_t reverse_output;
 		param_t reverse_delay;
-		param_t back_trans_throttle;
-		param_t mpc_xy_cruise;
 	} _params_handles_standard;
 
 	enum vtol_mode {

--- a/src/modules/vtol_att_control/standard_params.c
+++ b/src/modules/vtol_att_control/standard_params.c
@@ -39,16 +39,6 @@
  * @author Roman Bapst	<roman@px4.io>
  */
 
-/**
- * Target throttle value for pusher/puller motor during the transition to fw mode
- *
- * @min 0.0
- * @max 1.0
- * @increment 0.01
- * @decimal 3
- * @group VTOL Attitude Control
- */
-PARAM_DEFINE_FLOAT(VT_TRANS_THR, 0.6f);
 
 /**
  * Maximum allowed down-pitch the controller is able to demand. This prevents large, negative
@@ -113,14 +103,12 @@ PARAM_DEFINE_FLOAT(VT_B_REV_OUT, 0.0f);
 PARAM_DEFINE_FLOAT(VT_B_REV_DEL, 0.0f);
 
 /**
- * Thottle output during back transition
- * For ESCs and mixers that support reverse thrust on low PWM values set this to a negative value to apply active breaking
- * For ESCs that support thrust reversal with a control channel please set VT_B_REV_OUT and set this to a positive value to apply active breaking
+ * Defines the time window during which the pusher throttle will be ramped up linearly to VT_F_TRANS_THR during a transition
+ * to fixed wing mode. Zero or negative values will produce an instant throttle rise to VT_F_TRANS_THR.
  *
- * @min -1
- * @max 1
+ * @max 20
  * @increment 0.01
  * @decimal 2
  * @group VTOL Attitude Control
  */
-PARAM_DEFINE_FLOAT(VT_B_TRANS_THR, 0.0f);
+PARAM_DEFINE_FLOAT(VT_PSHER_RMP_DT, 3.0f);

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -175,7 +175,7 @@ void Tailsitter::update_vtol_state()
 
 void Tailsitter::update_transition_state()
 {
-	float time_since_trans_start = ((float)(hrt_absolute_time() - _vtol_schedule.transition_start)) / 1e6f;
+	float time_since_trans_start = (float)(hrt_absolute_time() - _vtol_schedule.transition_start) * 1e-6f;
 
 	if (!_flag_was_in_trans_mode) {
 		// save desired heading for transition and last thrust value

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -227,8 +227,7 @@ void Tailsitter::update_transition_state()
 		_mc_yaw_weight = 0.0f;
 
 		// smoothly move control weight to MC
-		_mc_roll_weight = 1.0f * time_since_trans_start / _params->back_trans_duration;
-		_mc_pitch_weight = 1.0f * time_since_trans_start / _params->back_trans_duration;
+		_mc_roll_weight = _mc_pitch_weight = 1.0f * time_since_trans_start / _params->back_trans_duration;
 
 	}
 

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -175,7 +175,7 @@ void Tailsitter::update_vtol_state()
 
 void Tailsitter::update_transition_state()
 {
-	float time_since_trans_start = (float)(hrt_absolute_time() - _vtol_schedule.transition_start);
+	float time_since_trans_start = ((float)(hrt_absolute_time() - _vtol_schedule.transition_start)) / 1e6f;
 
 	if (!_flag_was_in_trans_mode) {
 		// save desired heading for transition and last thrust value
@@ -190,8 +190,8 @@ void Tailsitter::update_transition_state()
 	if (_vtol_schedule.flight_mode == TRANSITION_FRONT_P1) {
 
 		// create time dependant pitch angle set point + 0.2 rad overlap over the switch value
-		_v_att_sp->pitch_body = _pitch_transition_start	- (fabsf(PITCH_TRANSITION_FRONT_P1 - _pitch_transition_start) *
-					time_since_trans_start / (_params->front_trans_duration * 1e6f));
+		_v_att_sp->pitch_body = _pitch_transition_start	- fabsf(PITCH_TRANSITION_FRONT_P1 - _pitch_transition_start) *
+					time_since_trans_start / _params->front_trans_duration;
 		_v_att_sp->pitch_body = math::constrain(_v_att_sp->pitch_body, PITCH_TRANSITION_FRONT_P1 - 0.2f,
 							_pitch_transition_start);
 
@@ -217,7 +217,7 @@ void Tailsitter::update_transition_state()
 
 		// create time dependant pitch angle set point stating at -pi/2 + 0.2 rad overlap over the switch value
 		_v_att_sp->pitch_body = M_PI_2_F + _pitch_transition_start + fabsf(PITCH_TRANSITION_BACK + 1.57f) *
-					time_since_trans_start / (_params->back_trans_duration * 1e6f);
+					time_since_trans_start / _params->back_trans_duration;
 		_v_att_sp->pitch_body = math::constrain(_v_att_sp->pitch_body, -2.0f, PITCH_TRANSITION_BACK + 0.2f);
 
 
@@ -227,8 +227,8 @@ void Tailsitter::update_transition_state()
 		_mc_yaw_weight = 0.0f;
 
 		// smoothly move control weight to MC
-		_mc_roll_weight = 1.0f * time_since_trans_start / (_params->back_trans_duration * 1e6f);
-		_mc_pitch_weight = 1.0f * time_since_trans_start / (_params->back_trans_duration * 1e6f);
+		_mc_roll_weight = 1.0f * time_since_trans_start / _params->back_trans_duration;
+		_mc_pitch_weight = 1.0f * time_since_trans_start / _params->back_trans_duration;
 
 	}
 

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -45,7 +45,6 @@
 #define ARSP_YAW_CTRL_DISABLE 4.0f	// airspeed at which we stop controlling yaw during a front transition
 #define THROTTLE_TRANSITION_MAX 0.25f	// maximum added thrust above last value in transition
 #define PITCH_TRANSITION_FRONT_P1 -1.1f	// pitch angle to switch to TRANSITION_P2
-#define PITCH_TRANSITION_FRONT_P2 -1.2f	// pitch angle to switch to FW
 #define PITCH_TRANSITION_BACK -0.25f	// pitch angle to switch to MC
 
 Tailsitter::Tailsitter(VtolAttitudeControl *attc) :
@@ -109,12 +108,6 @@ void Tailsitter::update_vtol_state()
 			_vtol_schedule.flight_mode = MC_MODE;
 			break;
 
-		case TRANSITION_FRONT_P2:
-			// NOT USED
-			// failsafe into multicopter mode
-			//_vtol_schedule.flight_mode = MC_MODE;
-			break;
-
 		case TRANSITION_BACK:
 
 			// check if we have reached pitch angle to switch to MC mode
@@ -143,20 +136,13 @@ void Tailsitter::update_vtol_state()
 			if ((_airspeed->indicated_airspeed_m_s >= _params->transition_airspeed
 			     && pitch <= PITCH_TRANSITION_FRONT_P1) || can_transition_on_ground()) {
 				_vtol_schedule.flight_mode = FW_MODE;
-				//_vtol_schedule.transition_start = hrt_absolute_time();
 			}
 
 			break;
 
-		case TRANSITION_FRONT_P2:
-
 		case TRANSITION_BACK:
 			// failsafe into fixed wing mode
 			_vtol_schedule.flight_mode = FW_MODE;
-
-			/*  **LATER***  if pitch is closer to mc (-45>)
-			*   go to transition P1
-			*/
 			break;
 		}
 	}
@@ -180,11 +166,6 @@ void Tailsitter::update_vtol_state()
 		_vtol_vehicle_status->vtol_in_trans_mode = true;
 		break;
 
-	case TRANSITION_FRONT_P2:
-		_vtol_mode = TRANSITION_TO_FW;
-		_vtol_vehicle_status->vtol_in_trans_mode = true;
-		break;
-
 	case TRANSITION_BACK:
 		_vtol_mode = TRANSITION_TO_MC;
 		_vtol_vehicle_status->vtol_in_trans_mode = true;
@@ -194,6 +175,8 @@ void Tailsitter::update_vtol_state()
 
 void Tailsitter::update_transition_state()
 {
+	float time_since_trans_start = (float)(hrt_absolute_time() - _vtol_schedule.transition_start);
+
 	if (!_flag_was_in_trans_mode) {
 		// save desired heading for transition and last thrust value
 		_yaw_transition = _v_att_sp->yaw_body;
@@ -206,9 +189,9 @@ void Tailsitter::update_transition_state()
 
 	if (_vtol_schedule.flight_mode == TRANSITION_FRONT_P1) {
 
-		/** create time dependant pitch angle set point + 0.2 rad overlap over the switch value*/
+		// create time dependant pitch angle set point + 0.2 rad overlap over the switch value
 		_v_att_sp->pitch_body = _pitch_transition_start	- (fabsf(PITCH_TRANSITION_FRONT_P1 - _pitch_transition_start) *
-					(float)hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params->front_trans_duration * 1000000.0f));
+					time_since_trans_start / (_params->front_trans_duration * 1e6f));
 		_v_att_sp->pitch_body = math::constrain(_v_att_sp->pitch_body, PITCH_TRANSITION_FRONT_P1 - 0.2f,
 							_pitch_transition_start);
 
@@ -225,43 +208,6 @@ void Tailsitter::update_transition_state()
 		_mc_roll_weight = 1.0f;
 		_mc_pitch_weight = 1.0f;
 
-	} else if (_vtol_schedule.flight_mode == TRANSITION_FRONT_P2) {
-		// the plane is ready to go into fixed wing mode, smoothly switch the actuator controls, keep pitching down
-
-		/** no motor  switching */
-
-		if (flag_idle_mc) {
-			set_idle_fw();
-			flag_idle_mc = false;
-		}
-
-		/** create time dependant pitch angle set point  + 0.2 rad overlap over the switch value*/
-		if (_v_att_sp->pitch_body >= (PITCH_TRANSITION_FRONT_P2 - 0.2f)) {
-			_v_att_sp->pitch_body = PITCH_TRANSITION_FRONT_P1 -
-						(fabsf(PITCH_TRANSITION_FRONT_P2 - PITCH_TRANSITION_FRONT_P1) * (float)hrt_elapsed_time(
-							 &_vtol_schedule.transition_start) / (_params_tailsitter.front_trans_dur_p2 * 1000000.0f));
-
-			if (_v_att_sp->pitch_body <= (PITCH_TRANSITION_FRONT_P2 - 0.2f)) {
-				_v_att_sp->pitch_body = PITCH_TRANSITION_FRONT_P2 - 0.2f;
-			}
-
-		}
-
-		_v_att_sp->thrust = _thrust_transition;
-
-		/** start blending MC and FW controls from pitch -45 to pitch -70 for smooth control takeover*/
-
-		//_mc_roll_weight = 1.0f - 1.0f * ((float)hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params_tailsitter.front_trans_dur_p2 * 1000000.0f));
-		//_mc_pitch_weight = 1.0f - 1.0f * ((float)hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params_tailsitter.front_trans_dur_p2 * 1000000.0f));
-
-
-		_mc_roll_weight = 0.0f;
-		_mc_pitch_weight = 0.0f;
-
-		/** keep yaw disabled */
-		_mc_yaw_weight = 0.0f;
-
-
 	} else if (_vtol_schedule.flight_mode == TRANSITION_BACK) {
 
 		if (!flag_idle_mc) {
@@ -269,22 +215,20 @@ void Tailsitter::update_transition_state()
 			flag_idle_mc = true;
 		}
 
-		/** create time dependant pitch angle set point stating at -pi/2 + 0.2 rad overlap over the switch value*/
+		// create time dependant pitch angle set point stating at -pi/2 + 0.2 rad overlap over the switch value
 		_v_att_sp->pitch_body = M_PI_2_F + _pitch_transition_start + fabsf(PITCH_TRANSITION_BACK + 1.57f) *
-					(float)hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params->back_trans_duration * 1000000.0f);
+					time_since_trans_start / (_params->back_trans_duration * 1e6f);
 		_v_att_sp->pitch_body = math::constrain(_v_att_sp->pitch_body, -2.0f, PITCH_TRANSITION_BACK + 0.2f);
 
 
 		_v_att_sp->thrust = _mc_virtual_att_sp->thrust;
 
-		/** keep yaw disabled */
+		// keep yaw disabled
 		_mc_yaw_weight = 0.0f;
 
-		/** smoothly move control weight to MC */
-		_mc_roll_weight = 1.0f * (float)hrt_elapsed_time(&_vtol_schedule.transition_start) /
-				  (_params->back_trans_duration * 1000000.0f);
-		_mc_pitch_weight = 1.0f * (float)hrt_elapsed_time(&_vtol_schedule.transition_start) /
-				   (_params->back_trans_duration * 1000000.0f);
+		// smoothly move control weight to MC
+		_mc_roll_weight = 1.0f * time_since_trans_start / (_params->back_trans_duration * 1e6f);
+		_mc_pitch_weight = 1.0f * time_since_trans_start / (_params->back_trans_duration * 1e6f);
 
 	}
 

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -227,7 +227,7 @@ void Tailsitter::update_transition_state()
 		_mc_yaw_weight = 0.0f;
 
 		// smoothly move control weight to MC
-		_mc_roll_weight = _mc_pitch_weight = 1.0f * time_since_trans_start / _params->back_trans_duration;
+		_mc_roll_weight = _mc_pitch_weight = time_since_trans_start / _params->back_trans_duration;
 
 	}
 

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -50,7 +50,6 @@
 
 Tailsitter::Tailsitter(VtolAttitudeControl *attc) :
 	VtolType(attc),
-	_min_front_trans_dur(0.5f),
 	_thrust_transition_start(0.0f),
 	_yaw_transition(0.0f),
 	_pitch_transition_start(0.0f)
@@ -64,11 +63,7 @@ Tailsitter::Tailsitter(VtolAttitudeControl *attc) :
 
 	_flag_was_in_trans_mode = false;
 
-	_params_handles_tailsitter.front_trans_dur = param_find("VT_F_TRANS_DUR");
 	_params_handles_tailsitter.front_trans_dur_p2 = param_find("VT_TRANS_P2_DUR");
-	_params_handles_tailsitter.back_trans_dur = param_find("VT_B_TRANS_DUR");
-	_params_handles_tailsitter.airspeed_trans = param_find("VT_ARSP_TRANS");
-	_params_handles_tailsitter.airspeed_blend_start = param_find("VT_ARSP_BLEND");
 }
 
 Tailsitter::~Tailsitter()
@@ -81,32 +76,9 @@ Tailsitter::parameters_update()
 {
 	float v;
 
-	/* vtol duration of a front transition */
-	param_get(_params_handles_tailsitter.front_trans_dur, &v);
-	_params_tailsitter.front_trans_dur = math::constrain(v, 1.0f, 5.0f);
-
 	/* vtol front transition phase 2 duration */
 	param_get(_params_handles_tailsitter.front_trans_dur_p2, &v);
 	_params_tailsitter.front_trans_dur_p2 = v;
-
-	/* vtol duration of a back transition */
-	param_get(_params_handles_tailsitter.back_trans_dur, &v);
-	_params_tailsitter.back_trans_dur = math::constrain(v, 0.0f, 5.0f);
-
-	/* vtol airspeed at which it is ok to switch to fw mode */
-	param_get(_params_handles_tailsitter.airspeed_trans, &v);
-	_params_tailsitter.airspeed_trans = v;
-
-	/* vtol airspeed at which we start blending mc/fw controls */
-	param_get(_params_handles_tailsitter.airspeed_blend_start, &v);
-	_params_tailsitter.airspeed_blend_start = v;
-
-	/* avoid parameters which will lead to zero division in the transition code */
-	_params_tailsitter.front_trans_dur = math::max(_params_tailsitter.front_trans_dur, _min_front_trans_dur);
-
-	if (_params_tailsitter.airspeed_trans < _params_tailsitter.airspeed_blend_start + 1.0f) {
-		_params_tailsitter.airspeed_trans = _params_tailsitter.airspeed_blend_start + 1.0f;
-	}
 }
 
 void Tailsitter::update_vtol_state()
@@ -168,7 +140,7 @@ void Tailsitter::update_vtol_state()
 		case TRANSITION_FRONT_P1:
 
 			// check if we have reached airspeed  and pitch angle to switch to TRANSITION P2 mode
-			if ((_airspeed->indicated_airspeed_m_s >= _params_tailsitter.airspeed_trans
+			if ((_airspeed->indicated_airspeed_m_s >= _params->transition_airspeed
 			     && pitch <= PITCH_TRANSITION_FRONT_P1) || can_transition_on_ground()) {
 				_vtol_schedule.flight_mode = FW_MODE;
 				//_vtol_schedule.transition_start = hrt_absolute_time();
@@ -236,7 +208,7 @@ void Tailsitter::update_transition_state()
 
 		/** create time dependant pitch angle set point + 0.2 rad overlap over the switch value*/
 		_v_att_sp->pitch_body = _pitch_transition_start	- (fabsf(PITCH_TRANSITION_FRONT_P1 - _pitch_transition_start) *
-					(float)hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params_tailsitter.front_trans_dur * 1000000.0f));
+					(float)hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params->front_trans_duration * 1000000.0f));
 		_v_att_sp->pitch_body = math::constrain(_v_att_sp->pitch_body, PITCH_TRANSITION_FRONT_P1 - 0.2f,
 							_pitch_transition_start);
 
@@ -299,7 +271,7 @@ void Tailsitter::update_transition_state()
 
 		/** create time dependant pitch angle set point stating at -pi/2 + 0.2 rad overlap over the switch value*/
 		_v_att_sp->pitch_body = M_PI_2_F + _pitch_transition_start + fabsf(PITCH_TRANSITION_BACK + 1.57f) *
-					(float)hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params_tailsitter.back_trans_dur * 1000000.0f);
+					(float)hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params->back_trans_duration * 1000000.0f);
 		_v_att_sp->pitch_body = math::constrain(_v_att_sp->pitch_body, -2.0f, PITCH_TRANSITION_BACK + 0.2f);
 
 
@@ -310,9 +282,9 @@ void Tailsitter::update_transition_state()
 
 		/** smoothly move control weight to MC */
 		_mc_roll_weight = 1.0f * (float)hrt_elapsed_time(&_vtol_schedule.transition_start) /
-				  (_params_tailsitter.back_trans_dur * 1000000.0f);
+				  (_params->back_trans_duration * 1000000.0f);
 		_mc_pitch_weight = 1.0f * (float)hrt_elapsed_time(&_vtol_schedule.transition_start) /
-				   (_params_tailsitter.back_trans_dur * 1000000.0f);
+				   (_params->back_trans_duration * 1000000.0f);
 
 	}
 

--- a/src/modules/vtol_att_control/tailsitter.h
+++ b/src/modules/vtol_att_control/tailsitter.h
@@ -64,20 +64,11 @@ public:
 private:
 
 	struct {
-		float front_trans_dur;			/**< duration of first part of front transition */
 		float front_trans_dur_p2;
-		float back_trans_dur;			/**< duration of back transition */
-		float airspeed_trans;			/**< airspeed at which we switch to fw mode after transition */
-		float airspeed_blend_start;		/**< airspeed at which we start blending mc/fw controls */
 	} _params_tailsitter;
 
 	struct {
-		param_t front_trans_dur;
 		param_t front_trans_dur_p2;
-		param_t back_trans_dur;
-		param_t airspeed_trans;
-		param_t airspeed_blend_start;
-
 	} _params_handles_tailsitter;
 
 	enum vtol_mode {
@@ -92,9 +83,6 @@ private:
 		vtol_mode flight_mode;			/**< vtol flight mode, defined by enum vtol_mode */
 		hrt_abstime transition_start;	/**< absoulte time at which front transition started */
 	} _vtol_schedule;
-
-	/** not sure about it yet ?! **/
-	float _min_front_trans_dur;	/**< min possible time in which rotors are rotated into the first position */
 
 	float _thrust_transition_start; // throttle value when we start the front transition
 	float _yaw_transition;	// yaw angle in which transition will take place

--- a/src/modules/vtol_att_control/tailsitter.h
+++ b/src/modules/vtol_att_control/tailsitter.h
@@ -74,7 +74,6 @@ private:
 	enum vtol_mode {
 		MC_MODE = 0,			/**< vtol is in multicopter mode */
 		TRANSITION_FRONT_P1,	/**< vtol is in front transition part 1 mode */
-		TRANSITION_FRONT_P2,	/**< vtol is in front transition part 2 mode */
 		TRANSITION_BACK,		/**< vtol is in back transition mode */
 		FW_MODE					/**< vtol is in fixed wing mode */
 	};

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -179,7 +179,7 @@ void Tiltrotor::update_vtol_state()
 				// allow switch if we are not armed for the sake of bench testing
 				bool transition_to_p2 = can_transition_on_ground();
 
-				float time_since_trans_start = ((float)(hrt_absolute_time() - _vtol_schedule.transition_start)) / 1e6f;
+				float time_since_trans_start = (float)(hrt_absolute_time() - _vtol_schedule.transition_start) * 1e-6f;
 
 				// check if we have reached airspeed to switch to fw mode
 				transition_to_p2 |= !_params->airspeed_disabled &&
@@ -279,7 +279,7 @@ void Tiltrotor::update_transition_state()
 {
 	VtolType::update_transition_state();
 
-	float time_since_trans_start = ((float)(hrt_absolute_time() - _vtol_schedule.transition_start)) / 1e6f;
+	float time_since_trans_start = (float)(hrt_absolute_time() - _vtol_schedule.transition_start) * 1e-6f;
 
 	if (!_flag_was_in_trans_mode) {
 		// save desired heading for transition and last thrust value

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -47,8 +47,7 @@
 Tiltrotor::Tiltrotor(VtolAttitudeControl *attc) :
 	VtolType(attc),
 	_rear_motors(ENABLED),
-	_tilt_control(0.0f),
-	_min_front_trans_dur(0.5f)
+	_tilt_control(0.0f)
 {
 	_vtol_schedule.flight_mode = MC_MODE;
 	_vtol_schedule.transition_start = 0;
@@ -59,16 +58,11 @@ Tiltrotor::Tiltrotor(VtolAttitudeControl *attc) :
 
 	_flag_was_in_trans_mode = false;
 
-	_params_handles_tiltrotor.front_trans_dur = param_find("VT_F_TRANS_DUR");
-	_params_handles_tiltrotor.back_trans_dur = param_find("VT_B_TRANS_DUR");
 	_params_handles_tiltrotor.tilt_mc = param_find("VT_TILT_MC");
 	_params_handles_tiltrotor.tilt_transition = param_find("VT_TILT_TRANS");
 	_params_handles_tiltrotor.tilt_fw = param_find("VT_TILT_FW");
-	_params_handles_tiltrotor.airspeed_trans = param_find("VT_ARSP_TRANS");
-	_params_handles_tiltrotor.airspeed_blend_start = param_find("VT_ARSP_BLEND");
 	_params_handles_tiltrotor.front_trans_dur_p2 = param_find("VT_TRANS_P2_DUR");
 	_params_handles_tiltrotor.fw_motors_off = param_find("VT_FW_MOT_OFFID");
-	_params_handles_tiltrotor.airspeed_disabled = param_find("FW_ARSP_MODE");
 	_params_handles_tiltrotor.diff_thrust = param_find("VT_FW_DIFTHR_EN");
 	_params_handles_tiltrotor.diff_thrust_scale = param_find("VT_FW_DIFTHR_SC");
 }
@@ -88,14 +82,6 @@ Tiltrotor::parameters_update()
 	param_get(_params_handles_tiltrotor.fw_motors_off, &l);
 	_params_tiltrotor.fw_motors_off = get_motor_off_channels(l);
 
-	/* vtol duration of a front transition */
-	param_get(_params_handles_tiltrotor.front_trans_dur, &v);
-	_params_tiltrotor.front_trans_dur = math::constrain(v, 1.0f, 5.0f);
-
-	/* vtol duration of a back transition */
-	param_get(_params_handles_tiltrotor.back_trans_dur, &v);
-	_params_tiltrotor.back_trans_dur = math::constrain(v, 0.0f, 5.0f);
-
 	/* vtol tilt mechanism position in mc mode */
 	param_get(_params_handles_tiltrotor.tilt_mc, &v);
 	_params_tiltrotor.tilt_mc = v;
@@ -108,28 +94,9 @@ Tiltrotor::parameters_update()
 	param_get(_params_handles_tiltrotor.tilt_fw, &v);
 	_params_tiltrotor.tilt_fw = v;
 
-	/* vtol airspeed at which it is ok to switch to fw mode */
-	param_get(_params_handles_tiltrotor.airspeed_trans, &v);
-	_params_tiltrotor.airspeed_trans = v;
-
-	/* vtol airspeed at which we start blending mc/fw controls */
-	param_get(_params_handles_tiltrotor.airspeed_blend_start, &v);
-	_params_tiltrotor.airspeed_blend_start = v;
-
 	/* vtol front transition phase 2 duration */
 	param_get(_params_handles_tiltrotor.front_trans_dur_p2, &v);
 	_params_tiltrotor.front_trans_dur_p2 = v;
-
-	/* avoid parameters which will lead to zero division in the transition code */
-	_params_tiltrotor.front_trans_dur = math::max(_params_tiltrotor.front_trans_dur, _min_front_trans_dur);
-
-	if (_params_tiltrotor.airspeed_trans < _params_tiltrotor.airspeed_blend_start + 1.0f) {
-		_params_tiltrotor.airspeed_trans = _params_tiltrotor.airspeed_blend_start + 1.0f;
-	}
-
-	/* airspeed mode */
-	param_get(_params_handles_tiltrotor.airspeed_disabled, &l);
-	_params_tiltrotor.airspeed_disabled = math::constrain(l, 0, 1);
 
 	param_get(_params_handles_tiltrotor.diff_thrust, &_params_tiltrotor.diff_thrust);
 
@@ -213,12 +180,12 @@ void Tiltrotor::update_vtol_state()
 				bool transition_to_p2 = can_transition_on_ground();
 
 				// check if we have reached airspeed to switch to fw mode
-				transition_to_p2 |= !_params_tiltrotor.airspeed_disabled &&
-						    _airspeed->indicated_airspeed_m_s >= _params_tiltrotor.airspeed_trans &&
+				transition_to_p2 |= !_params->airspeed_disabled &&
+						    _airspeed->indicated_airspeed_m_s >= _params->transition_airspeed &&
 						    (float)hrt_elapsed_time(&_vtol_schedule.transition_start) > (_params->front_trans_time_min * 1e6f);
 
 				// check if airspeed is invalid and transition by time
-				transition_to_p2 |= _params_tiltrotor.airspeed_disabled &&
+				transition_to_p2 |= _params->airspeed_disabled &&
 						    _tilt_control > _params_tiltrotor.tilt_transition &&
 						    (float)hrt_elapsed_time(&_vtol_schedule.transition_start) > (_params->front_trans_time_openloop * 1e6f);
 
@@ -325,27 +292,26 @@ void Tiltrotor::update_transition_state()
 		if (_tilt_control <= _params_tiltrotor.tilt_transition) {
 			_tilt_control = _params_tiltrotor.tilt_mc +
 					fabsf(_params_tiltrotor.tilt_transition - _params_tiltrotor.tilt_mc) * (float)hrt_elapsed_time(
-						&_vtol_schedule.transition_start) / (_params_tiltrotor.front_trans_dur * 1000000.0f);
+						&_vtol_schedule.transition_start) / (_params->front_trans_duration * 1e6f);
 		}
 
-		bool use_airspeed = !_params_tiltrotor.airspeed_disabled;
 
 		// at low speeds give full weight to MC
 		_mc_roll_weight = 1.0f;
 		_mc_yaw_weight = 1.0f;
 
 		// reduce MC controls once the plane has picked up speed
-		if (use_airspeed && _airspeed->indicated_airspeed_m_s > ARSP_YAW_CTRL_DISABLE) {
+		if (!_params->airspeed_disabled && _airspeed->indicated_airspeed_m_s > ARSP_YAW_CTRL_DISABLE) {
 			_mc_yaw_weight = 0.0f;
 		}
 
-		if (use_airspeed && _airspeed->indicated_airspeed_m_s >= _params_tiltrotor.airspeed_blend_start) {
-			_mc_roll_weight = 1.0f - (_airspeed->indicated_airspeed_m_s - _params_tiltrotor.airspeed_blend_start) /
-					  (_params_tiltrotor.airspeed_trans - _params_tiltrotor.airspeed_blend_start);
+		if (!_params->airspeed_disabled && _airspeed->indicated_airspeed_m_s >= _params->airspeed_blend) {
+			_mc_roll_weight = 1.0f - (_airspeed->indicated_airspeed_m_s - _params->airspeed_blend) /
+					  (_params->transition_airspeed - _params->airspeed_blend);
 		}
 
 		// without airspeed do timed weight changes
-		if (!use_airspeed
+		if (_params->airspeed_disabled
 		    && (float)hrt_elapsed_time(&_vtol_schedule.transition_start) > (_params->front_trans_time_min * 1e6f)) {
 			_mc_roll_weight = 1.0f - ((float)hrt_elapsed_time(&_vtol_schedule.transition_start) - _params->front_trans_time_min *
 						  1e6f) / (_params->front_trans_time_openloop * 1e6f - _params->front_trans_time_min * 1e6f);
@@ -386,7 +352,7 @@ void Tiltrotor::update_transition_state()
 		if (_tilt_control > _params_tiltrotor.tilt_mc) {
 			_tilt_control = _params_tiltrotor.tilt_fw -
 					fabsf(_params_tiltrotor.tilt_fw - _params_tiltrotor.tilt_mc) * (float)hrt_elapsed_time(
-						&_vtol_schedule.transition_start) / (_params_tiltrotor.back_trans_dur * 1000000.0f);
+						&_vtol_schedule.transition_start) / (_params->back_trans_duration * 1e6f);
 		}
 
 		// set zero throttle for backtransition otherwise unwanted moments will be created

--- a/src/modules/vtol_att_control/tiltrotor.h
+++ b/src/modules/vtol_att_control/tiltrotor.h
@@ -62,31 +62,21 @@ public:
 private:
 
 	struct {
-		float front_trans_dur;			/**< duration of first part of front transition */
-		float back_trans_dur;			/**< duration of back transition */
 		float tilt_mc;					/**< actuator value corresponding to mc tilt */
 		float tilt_transition;			/**< actuator value corresponding to transition tilt (e.g 45 degrees) */
 		float tilt_fw;					/**< actuator value corresponding to fw tilt */
-		float airspeed_trans;			/**< airspeed at which we switch to fw mode after transition */
-		float airspeed_blend_start;		/**< airspeed at which we start blending mc/fw controls */
 		float front_trans_dur_p2;
 		int32_t fw_motors_off;			/**< bitmask of all motors that should be off in fixed wing mode */
-		int32_t airspeed_disabled;
 		int32_t diff_thrust;
 		float diff_thrust_scale;
 	} _params_tiltrotor;
 
 	struct {
-		param_t front_trans_dur;
-		param_t back_trans_dur;
 		param_t tilt_mc;
 		param_t tilt_transition;
 		param_t tilt_fw;
-		param_t airspeed_trans;
-		param_t airspeed_blend_start;
 		param_t front_trans_dur_p2;
 		param_t fw_motors_off;
-		param_t airspeed_disabled;
 		param_t diff_thrust;
 		param_t diff_thrust_scale;
 	} _params_handles_tiltrotor;
@@ -117,8 +107,6 @@ private:
 	} _vtol_schedule;
 
 	float _tilt_control;		/**< actuator value for the tilt servo */
-
-	const float _min_front_trans_dur;	/**< min possible time in which rotors are rotated into the first position */
 
 	/**
 	 * Return a bitmap of channels that should be turned off in fixed wing mode.

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -505,7 +505,8 @@ VtolAttitudeControl::parameters_update()
 	param_get(_params_handles.front_trans_throttle, &_params.front_trans_throttle);
 	param_get(_params_handles.back_trans_throttle, &_params.back_trans_throttle);
 	param_get(_params_handles.airspeed_blend, &_params.airspeed_blend);
-	param_get(_params_handles.airspeed_mode, &_params.airspeed_mode);
+	param_get(_params_handles.airspeed_mode, &l);
+	_params.airspeed_disabled = l != 0;
 	param_get(_params_handles.front_trans_timeout, &_params.front_trans_timeout);
 	param_get(_params_handles.mpc_xy_cruise, &_params.mpc_xy_cruise);
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -77,6 +77,17 @@ VtolAttitudeControl::VtolAttitudeControl()
 	_params_handles.front_trans_time_openloop = param_find("VT_F_TR_OL_TM");
 	_params_handles.front_trans_time_min = param_find("VT_TRANS_MIN_TM");
 
+	_params_handles.front_trans_duration = param_find("VT_F_TRANS_DUR");
+	_params_handles.back_trans_duration = param_find("VT_B_TRANS_DUR");
+	_params_handles.transition_airspeed = param_find("VT_ARSP_TRANS");
+	_params_handles.front_trans_throttle = param_find("VT_F_TRANS_THR");
+	_params_handles.back_trans_throttle = param_find("VT_B_TRANS_THR");
+	_params_handles.airspeed_blend = param_find("VT_ARSP_BLEND");
+	_params_handles.airspeed_mode = param_find("FW_ARSP_MODE");
+	_params_handles.front_trans_timeout = param_find("VT_TRANS_TIMEOUT");
+	_params_handles.mpc_xy_cruise = param_find("MPC_XY_CRUISE");
+
+
 	_params_handles.wv_takeoff = param_find("VT_WV_TKO_EN");
 	_params_handles.wv_land = param_find("VT_WV_LND_EN");
 	_params_handles.wv_loiter = param_find("VT_WV_LTR_EN");
@@ -486,6 +497,17 @@ VtolAttitudeControl::parameters_update()
 
 	param_get(_params_handles.wv_land, &l);
 	_params.wv_land = (l == 1);
+
+
+	param_get(_params_handles.front_trans_duration, &_params.front_trans_duration);
+	param_get(_params_handles.back_trans_duration, &_params.back_trans_duration);
+	param_get(_params_handles.transition_airspeed, &_params.transition_airspeed);
+	param_get(_params_handles.front_trans_throttle, &_params.front_trans_throttle);
+	param_get(_params_handles.back_trans_throttle, &_params.back_trans_throttle);
+	param_get(_params_handles.airspeed_blend, &_params.airspeed_blend);
+	param_get(_params_handles.airspeed_mode, &_params.airspeed_mode);
+	param_get(_params_handles.front_trans_timeout, &_params.front_trans_timeout);
+	param_get(_params_handles.mpc_xy_cruise, &_params.mpc_xy_cruise);
 
 	// update the parameters of the instances of base VtolType
 	if (_vtol_type != nullptr) {

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -510,6 +510,9 @@ VtolAttitudeControl::parameters_update()
 	param_get(_params_handles.front_trans_timeout, &_params.front_trans_timeout);
 	param_get(_params_handles.mpc_xy_cruise, &_params.mpc_xy_cruise);
 
+	// make sure parameters are feasible, require at least 1 m/s difference between transition and blend airspeed
+	_params.airspeed_blend = math::min(_params.airspeed_blend, _params.transition_airspeed - 1.0f);
+
 	// update the parameters of the instances of base VtolType
 	if (_vtol_type != nullptr) {
 		_vtol_type->parameters_update();

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -192,6 +192,15 @@ private:
 		param_t wv_takeoff;
 		param_t wv_loiter;
 		param_t wv_land;
+		param_t front_trans_duration;
+		param_t back_trans_duration;
+		param_t transition_airspeed;
+		param_t front_trans_throttle;
+		param_t back_trans_throttle;
+		param_t airspeed_blend;
+		param_t airspeed_mode;
+		param_t front_trans_timeout;
+		param_t mpc_xy_cruise;
 	} _params_handles{};
 
 	/* for multicopters it is usual to have a non-zero idle speed of the engines

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -138,6 +138,36 @@ PARAM_DEFINE_FLOAT(VT_F_TRANS_DUR, 5.0f);
 PARAM_DEFINE_FLOAT(VT_B_TRANS_DUR, 4.0f);
 
 /**
+ * Target throttle value for the transition to fixed wing flight.
+ * standard vtol: pusher
+ * tailsitter, tiltrotor: main throttle
+ *
+ * @min 0.0
+ * @max 1.0
+ * @increment 0.01
+ * @decimal 3
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_F_TRANS_THR, 0.7f);
+
+/**
+ * Target throttle value for the transition to hover flight.
+ * standard vtol: pusher
+ * tailsitter, tiltrotor: main throttle
+ *
+ * Note for standard vtol:
+ * For ESCs and mixers that support reverse thrust on low PWM values set this to a negative value to apply active breaking
+ * For ESCs that support thrust reversal with a control channel please set VT_B_REV_OUT and set this to a positive value to apply active breaking
+ *
+ * @min -1
+ * @max 1
+ * @increment 0.01
+ * @decimal 2
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_B_TRANS_THR, 0.0f);
+
+/**
  * Approximate deceleration during back transition
  *
  * The approximate deceleration during a back transition in m/s/s

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -148,7 +148,7 @@ PARAM_DEFINE_FLOAT(VT_B_TRANS_DUR, 4.0f);
  * @decimal 3
  * @group VTOL Attitude Control
  */
-PARAM_DEFINE_FLOAT(VT_F_TRANS_THR, 0.7f);
+PARAM_DEFINE_FLOAT(VT_F_TRANS_THR, 1.0f);
 
 /**
  * Target throttle value for the transition to hover flight.

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -61,6 +61,15 @@ struct Params {
 	bool wv_takeoff;
 	bool wv_loiter;
 	bool wv_land;
+	float front_trans_duration;
+	float back_trans_duration;
+	float transition_airspeed;
+	float front_trans_throttle;
+	float back_trans_throttle;
+	float airspeed_blend;
+	int32_t airspeed_mode;
+	float front_trans_timeout;
+	float mpc_xy_cruise;
 };
 
 // Has to match 1:1 msg/vtol_vehicle_status.msg

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -67,7 +67,7 @@ struct Params {
 	float front_trans_throttle;
 	float back_trans_throttle;
 	float airspeed_blend;
-	int32_t airspeed_mode;
+	bool airspeed_disabled;
 	float front_trans_timeout;
 	float mpc_xy_cruise;
 };


### PR DESCRIPTION
- moved many generic parameters out of standard.cpp into vtol_type class so that not every vtol_type needs to define the same parameter again
- cleaned up usage of hrt_elapsed_time (thanks @bkueng  for suggestions)

Needs CAREFUL review and fair amount of testing!

Next: Do the same thing for tiltrotor.cpp and tailsitter.cpp

## SITL testing:

### Standard VTOL Transitions
- [x]   Manual
- [x]   Stabilized
- [x]   Altitude
- [x]   Position
- [x]   Mission

### Tiltrotor Transitions
- [x]   Manual
- [x]   Stabilized
- [x]   Altitude
- [x]   Position
- [x]   Mission

### Tailsitter Transitions
- [x]   Manual
- [x]   Stabilized
- [x]   Altitude
- [x]   Position
- [x]   Mission

