### PR TITLE
logger: fix potential semaphore counter overflow

### DIFF
--- a/src/systemcmds/hardfault_log/hardfault_log.c
+++ b/src/systemcmds/hardfault_log/hardfault_log.c
@@ -110,7 +110,7 @@ static int genfault(int fault)
 		k =  1 / fault;
 
 		/* This is not going to happen
-		 * Enable divide by 0 fault generation
+		 * Disable divide by 0 fault generation
 		 */
 
 		*pCCR &= ~0x10;


### PR DESCRIPTION
When the timer callback is called at a higher rate than the logger can
execute the main loop (which is never the case under normal conditions),
the semaphore counter will increase unbounded, and eventually lead to
an assertion failure in NuttX.
The maximum semaphore counter is 0x7FFF, and when the logger runs at
default rate (3.5ms), the logger task must be blocked for 0x7FFF*3.5/1000
= 114 seconds continuously for an overflow to happen.

I see 2 cases where that could happen:
- the logger execution blocks somehow, or busy-loops in an inner loop
- a higher-prio task runs busy and hogs the CPU over a long period of time