### PR TITLE
Mavlink: round battery percentage up instead of down

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -553,7 +553,7 @@ protected:
 			msg.load = cpuload.load * 1000.0f;
 			msg.voltage_battery = (battery_status.connected) ? battery_status.voltage_filtered_v * 1000.0f : UINT16_MAX;
 			msg.current_battery = (battery_status.connected) ? battery_status.current_filtered_a * 100.0f : -1;
-			msg.battery_remaining = (battery_status.connected) ? battery_status.remaining * 100.0f : -1;
+			msg.battery_remaining = (battery_status.connected) ? ceilf(battery_status.remaining * 100.0f) : -1;
 			// TODO: fill in something useful in the fields below
 			msg.drop_rate_comm = 0;
 			msg.errors_comm = 0;
@@ -572,7 +572,7 @@ protected:
 			bat_msg.current_consumed = (battery_status.connected) ? battery_status.discharged_mah : -1;
 			bat_msg.energy_consumed = -1;
 			bat_msg.current_battery = (battery_status.connected) ? battery_status.current_filtered_a * 100 : -1;
-			bat_msg.battery_remaining = (battery_status.connected) ? battery_status.remaining * 100.0f : -1;
+			bat_msg.battery_remaining = (battery_status.connected) ? ceilf(battery_status.remaining * 100.0f) : -1;
 			bat_msg.temperature = INT16_MAX;
 
 			for (unsigned int i = 0; i < (sizeof(bat_msg.voltages) / sizeof(bat_msg.voltages[0])); i++) {


### PR DESCRIPTION
I propse this change because of a user experience issue I found even myself running into almost every time: I set the low battery reaction to e.g. 15% in QGC through the parameter menu, test it while flying around looking at the battery percentage and when the percentage in QGC shows 15% I expect something to happen but it doesn't. It happens when QGC shows 14%.

Because:
- The battery ratio still available is a float between 0 and 1 in the firmware for maximum accuracy.
- The mavlink message is defined to only show integer (uint8_t) percentage for the battery level.
- The mavlink receiver just assigns [unit8_t] = [float between 0 and 1] * 100.f which casts implicitly and rounds down.

It's mathematically all resonable but still not intuitive to the user like me or @potaito and I'm sure we're not alone. We expect the reaction to happen when the percentage is reached in terms of the integer we can see in the UI.

I think we need to fix the user experience no matter how it's done technically. We could als trigger the reaction with the rounded up number or similar. It just ssemed to me that the root cause is the rounding  during conversion to MAVLink and that's why rounding up instead of down exactly where it happens is the go to solution.

FYI @Stifael 