### PR TITLE
Pr tailsitter fix

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -92,6 +92,10 @@ FixedwingPositionControl::FixedwingPositionControl() :
 	_parameter_handles.heightrate_ff =			param_find("FW_T_HRATE_FF");
 	_parameter_handles.speedrate_p =			param_find("FW_T_SRATE_P");
 
+	// if vehicle is vtol these handles will be set when we get the vehicle status
+	_parameter_handles.airspeed_trans = PARAM_INVALID;
+	_parameter_handles.vtol_type = PARAM_INVALID;
+
 	// initialize to invalid vtol type
 	_parameters.vtol_type = -1;
 
@@ -172,6 +176,14 @@ FixedwingPositionControl::parameters_update()
 	param_get(_parameter_handles.land_flare_pitch_max_deg, &(_parameters.land_flare_pitch_max_deg));
 	param_get(_parameter_handles.land_use_terrain_estimate, &(_parameters.land_use_terrain_estimate));
 	param_get(_parameter_handles.land_airspeed_scale, &(_parameters.land_airspeed_scale));
+
+	if (_parameter_handles.vtol_type != PARAM_INVALID) {
+		param_get(_parameter_handles.vtol_type, &_parameters.vtol_type);
+	}
+
+	if (_parameter_handles.airspeed_trans != PARAM_INVALID) {
+		param_get(_parameter_handles.airspeed_trans, &_parameters.airspeed_trans);
+	}
 
 	_l1_control.set_l1_damping(_parameters.l1_damping);
 	_l1_control.set_l1_period(_parameters.l1_period);

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -240,14 +240,7 @@ void Tailsitter::update_transition_state()
 		_v_att_sp->pitch_body = math::constrain(_v_att_sp->pitch_body, PITCH_TRANSITION_FRONT_P1 - 0.2f,
 							_pitch_transition_start);
 
-		/** create time dependant throttle signal higher than  in MC and growing untill  P2 switch speed reached */
-		if (_airspeed->indicated_airspeed_m_s <= _params_tailsitter.airspeed_trans) {
-			_thrust_transition = _thrust_transition_start + (fabsf(THROTTLE_TRANSITION_MAX * _thrust_transition_start) *
-					     (float)hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params_tailsitter.front_trans_dur * 1000000.0f));
-			_thrust_transition = math::constrain(_thrust_transition, _thrust_transition_start,
-							     (1.0f + THROTTLE_TRANSITION_MAX) * _thrust_transition_start);
-			_v_att_sp->thrust = _thrust_transition;
-		}
+		_v_att_sp->thrust = _mc_virtual_att_sp->thrust;
 
 		// disable mc yaw control once the plane has picked up speed
 		if (_airspeed->indicated_airspeed_m_s > ARSP_YAW_CTRL_DISABLE) {
@@ -309,8 +302,8 @@ void Tailsitter::update_transition_state()
 					(float)hrt_elapsed_time(&_vtol_schedule.transition_start) / (_params_tailsitter.back_trans_dur * 1000000.0f);
 		_v_att_sp->pitch_body = math::constrain(_v_att_sp->pitch_body, -2.0f, PITCH_TRANSITION_BACK + 0.2f);
 
-		//  throttle value is decreesed
-		_v_att_sp->thrust = _thrust_transition_start * 0.9f;
+
+		_v_att_sp->thrust = _mc_virtual_att_sp->thrust;
 
 		/** keep yaw disabled */
 		_mc_yaw_weight = 0.0f;


### PR DESCRIPTION
- fw position control module did not update the vehicle type parameter and the transition airspeed parameter

- remove fixed thrust handling during transition, let mc pos controller handle thrust (will iterate when we start doing flight tests)