### PR TITLE
caipirinha vtol: do not lock elevons in hover mode

### DIFF
--- a/ROMFS/px4fmu_common/init.d/13001_caipirinha_vtol
+++ b/ROMFS/px4fmu_common/init.d/13001_caipirinha_vtol
@@ -38,6 +38,7 @@ then
 	param set VT_IDLE_PWM_MC  1080
 	param set VT_TYPE 0
 	param set MAV_TYPE 19
+	param set VT_ELEV_MC_LOCK 0
 fi
 
 set MIXER caipirinha_vtol


### PR DESCRIPTION
This was preventing elevons to work in hover mode.