### PR TITLE
aerofc: Look for px4flow sensor on telemetry port

### DIFF
--- a/src/drivers/px4flow/px4flow.cpp
+++ b/src/drivers/px4flow/px4flow.cpp
@@ -754,6 +754,10 @@ start(int argc, char *argv[])
 #ifdef PX4_I2C_BUS_ONBOARD
 			PX4_I2C_BUS_ONBOARD,
 #endif
+#ifdef PX4_I2C_BUS_EXPANSION1
+			PX4_I2C_BUS_EXPANSION1,
+#endif
+
 			-1
 		};
 


### PR DESCRIPTION
If user connects the px4flow sensor on telemetery port of intel aero, it is not working as px4flow sensor driver is not looking for the desired slave address on the expansion port.