### PR TITLE
FixedwingPositionControl: fix air_gnd_angle judgement condition.

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -658,7 +658,7 @@ FixedwingPositionControl::control_position(const math::Vector<2> &curr_pos, cons
 	float air_gnd_angle = acosf((air_speed_2d * ground_speed) / (air_speed_2d.length() * ground_speed.length()));
 
 	// if angle > 90 degrees or groundspeed is less than threshold, replace groundspeed with airspeed projection
-	if ((fabsf(air_gnd_angle) > M_PI_F) || (ground_speed.length() < 3.0f)) {
+	if ((fabsf(air_gnd_angle) > M_PI_2_F) || (ground_speed.length() < 3.0f)) {
 		nav_speed_2d = air_speed_2d;
 
 	} else {


### PR DESCRIPTION
air_gnd_angle is calculated from acosf() function, and will never return a value that bigger than M_PI_F, and the comments said it should be M_PI/2.
@MaEtUgR can you have a check.