### PR TITLE
WIP: Add offboard fixed altitude yaw rate control

### DIFF
--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -295,7 +295,7 @@ FixedwingAttitudeControl::vehicle_manual_poll()
 					_rates_sp.roll = _manual.y * _parameters.acro_max_x_rate_rad;
 					_rates_sp.pitch = -_manual.x * _parameters.acro_max_y_rate_rad;
 					_rates_sp.yaw = _manual.r * _parameters.acro_max_z_rate_rad;
-					_rates_sp.thrust = _manual.z;
+                    _rates_sp.thrust = _manual.z;
 
 					if (_rate_sp_pub != nullptr) {
 						/* publish the attitude rates setpoint */
@@ -391,6 +391,7 @@ FixedwingAttitudeControl::vehicle_land_detected_poll()
 
 void FixedwingAttitudeControl::run()
 {
+    static int k = 0;
 	/*
 	 * do subscriptions
 	 */
@@ -639,6 +640,10 @@ void FixedwingAttitudeControl::run()
 				control_input.groundspeed_scaler = groundspeed_scaler;
 
 				/* Run attitude controllers */
+                if(k++%1000 == 0){
+                    PX4_WARN("roll_sp %f, pitch_sp %f, thrust %f", (double)roll_sp, (double)pitch_sp, (double)throttle_sp);
+                }
+
 				if (_vcontrol_mode.flag_control_attitude_enabled) {
 					if (PX4_ISFINITE(roll_sp) && PX4_ISFINITE(pitch_sp)) {
 						_roll_ctrl.control_attitude(control_input);
@@ -650,6 +655,7 @@ void FixedwingAttitudeControl::run()
 						control_input.roll_rate_setpoint = _roll_ctrl.get_desired_rate();
 						control_input.pitch_rate_setpoint = _pitch_ctrl.get_desired_rate();
 						control_input.yaw_rate_setpoint = _yaw_ctrl.get_desired_rate();
+
 
 						/* Run attitude RATE controllers which need the desired attitudes from above, add trim */
 						float roll_u = _roll_ctrl.control_euler_rate(control_input);
@@ -678,6 +684,11 @@ void FixedwingAttitudeControl::run()
 						} else {
 							yaw_u = _yaw_ctrl.control_euler_rate(control_input);
 						}
+
+                        if(k%1000 == 0){
+                            PX4_WARN("yaw_u %f pitch_u %f roll_u %f", (double)yaw_u, (double)pitch_u, (double)roll_u);
+                        }
+
 
 						_actuators.control[actuator_controls_s::INDEX_YAW] = (PX4_ISFINITE(yaw_u)) ? yaw_u + _parameters.trim_yaw :
 								_parameters.trim_yaw;

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -639,11 +639,7 @@ void FixedwingAttitudeControl::run()
 				control_input.groundspeed = groundspeed;
 				control_input.groundspeed_scaler = groundspeed_scaler;
 
-				/* Run attitude controllers */
-                if(k++%1000 == 0){
-                    PX4_WARN("roll_sp %f, pitch_sp %f, thrust %f", (double)roll_sp, (double)pitch_sp, (double)throttle_sp);
-                }
-
+                /* Run attitude controllers */
 				if (_vcontrol_mode.flag_control_attitude_enabled) {
 					if (PX4_ISFINITE(roll_sp) && PX4_ISFINITE(pitch_sp)) {
 						_roll_ctrl.control_attitude(control_input);
@@ -684,11 +680,6 @@ void FixedwingAttitudeControl::run()
 						} else {
 							yaw_u = _yaw_ctrl.control_euler_rate(control_input);
 						}
-
-                        if(k%1000 == 0){
-                            PX4_WARN("yaw_u %f pitch_u %f roll_u %f", (double)yaw_u, (double)pitch_u, (double)roll_u);
-                        }
-
 
 						_actuators.control[actuator_controls_s::INDEX_YAW] = (PX4_ISFINITE(yaw_u)) ? yaw_u + _parameters.trim_yaw :
 								_parameters.trim_yaw;

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -391,7 +391,6 @@ FixedwingAttitudeControl::vehicle_land_detected_poll()
 
 void FixedwingAttitudeControl::run()
 {
-	static int k = 0;
 	/*
 	 * do subscriptions
 	 */

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -295,7 +295,7 @@ FixedwingAttitudeControl::vehicle_manual_poll()
 					_rates_sp.roll = _manual.y * _parameters.acro_max_x_rate_rad;
 					_rates_sp.pitch = -_manual.x * _parameters.acro_max_y_rate_rad;
 					_rates_sp.yaw = _manual.r * _parameters.acro_max_z_rate_rad;
-                    _rates_sp.thrust = _manual.z;
+					_rates_sp.thrust = _manual.z;
 
 					if (_rate_sp_pub != nullptr) {
 						/* publish the attitude rates setpoint */
@@ -391,7 +391,7 @@ FixedwingAttitudeControl::vehicle_land_detected_poll()
 
 void FixedwingAttitudeControl::run()
 {
-    static int k = 0;
+	static int k = 0;
 	/*
 	 * do subscriptions
 	 */
@@ -639,7 +639,7 @@ void FixedwingAttitudeControl::run()
 				control_input.groundspeed = groundspeed;
 				control_input.groundspeed_scaler = groundspeed_scaler;
 
-                /* Run attitude controllers */
+				/* Run attitude controllers */
 				if (_vcontrol_mode.flag_control_attitude_enabled) {
 					if (PX4_ISFINITE(roll_sp) && PX4_ISFINITE(pitch_sp)) {
 						_roll_ctrl.control_attitude(control_input);

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -628,7 +628,7 @@ bool
 FixedwingPositionControl::control_position(const math::Vector<2> &curr_pos, const math::Vector<2> &ground_speed,
 		const position_setpoint_s &pos_sp_prev, const position_setpoint_s &pos_sp_curr)
 {
-    static int i = 0;
+	static int i = 0;
 	float dt = 0.01f;
 
 	if (_control_position_last_called > 0) {
@@ -687,7 +687,7 @@ FixedwingPositionControl::control_position(const math::Vector<2> &curr_pos, cons
 		_tecs.reset_state();
 	}
 
-    if (_control_mode.flag_control_auto_enabled && pos_sp_curr.valid) {
+	if (_control_mode.flag_control_auto_enabled && pos_sp_curr.valid) {
 
 		/* AUTONOMOUS FLIGHT */
 
@@ -1195,8 +1195,8 @@ FixedwingPositionControl::control_position(const math::Vector<2> &curr_pos, cons
 		}
 
 	} else if (_control_mode.flag_control_velocity_enabled &&
-           _control_mode.flag_control_altitude_enabled &&
-           !_control_mode.flag_control_offboard_enabled) {
+		   _control_mode.flag_control_altitude_enabled &&
+		   !_control_mode.flag_control_offboard_enabled) {
 		/* POSITION CONTROL: pitch stick moves altitude setpoint, throttle stick sets airspeed,
 		   heading is set to a distant waypoint */
 
@@ -1306,88 +1306,88 @@ FixedwingPositionControl::control_position(const math::Vector<2> &curr_pos, cons
 			_att_sp.yaw_body = 0;
 		}
 
-    } else if (_control_mode.flag_control_altitude_enabled
-               && _control_mode.flag_control_offboard_enabled
-               && pos_sp_curr.valid) {
-        /* Offboard altitude mode, control on yaw rate with fixed altitude */
-        _control_mode_current = FW_POSCTRL_MODE_OFFBOARD_ALTITUDE;
+	} else if (_control_mode.flag_control_altitude_enabled
+		   && _control_mode.flag_control_offboard_enabled
+		   && pos_sp_curr.valid) {
+		/* Offboard altitude mode, control on yaw rate with fixed altitude */
+		_control_mode_current = FW_POSCTRL_MODE_OFFBOARD_ALTITUDE;
 
-        _hold_alt = _global_pos.alt;
-        float airspeed = _parameters.airspeed_trim;
-        float throttle = _parameters.throttle_cruise;
+		_hold_alt = _global_pos.alt;
+		float airspeed = _parameters.airspeed_trim;
+		float throttle = _parameters.throttle_cruise;
 
-        if(PX4_ISFINITE(pos_sp_curr.cruising_speed) &&
-           pos_sp_curr.cruising_speed > 0.1f) {
-            airspeed = pos_sp_curr.cruising_speed;
-        }
+		if (PX4_ISFINITE(pos_sp_curr.cruising_speed) &&
+		    pos_sp_curr.cruising_speed > 0.1f) {
+			airspeed = pos_sp_curr.cruising_speed;
+		}
 
-        if (PX4_ISFINITE(pos_sp_curr.cruising_throttle) &&
-            pos_sp_curr.cruising_throttle > 0.01f) {
+		if (PX4_ISFINITE(pos_sp_curr.cruising_throttle) &&
+		    pos_sp_curr.cruising_throttle > 0.01f) {
 
-            throttle = pos_sp_curr.cruising_throttle;
-        }
+			throttle = pos_sp_curr.cruising_throttle;
+		}
 
-        float speed = calculate_target_airspeed(airspeed);
-        tecs_update_pitch_throttle(pos_sp_curr.z,
-                       speed,
-                       radians(_parameters.pitch_limit_min) - _parameters.pitchsp_offset_rad,
-                       radians(_parameters.pitch_limit_max) - _parameters.pitchsp_offset_rad,
-                       _parameters.throttle_min,
-                       _parameters.throttle_max,
-                       throttle,
-                       false,
-                       radians(_parameters.pitch_limit_min));
+		float speed = calculate_target_airspeed(airspeed);
+		tecs_update_pitch_throttle(pos_sp_curr.z,
+					   speed,
+					   radians(_parameters.pitch_limit_min) - _parameters.pitchsp_offset_rad,
+					   radians(_parameters.pitch_limit_max) - _parameters.pitchsp_offset_rad,
+					   _parameters.throttle_min,
+					   _parameters.throttle_max,
+					   throttle,
+					   false,
+					   radians(_parameters.pitch_limit_min));
 
-       // Calculate the bank angle needed to achieve the yaw rate
-       float roll_sp = atan2(pos_sp_curr.yawspeed * speed, 9.81f);
-        _att_sp.roll_body = math::constrain(roll_sp, -_parameters.roll_limit, _parameters.roll_limit);
+		// Calculate the bank angle needed to achieve the yaw rate
+		float roll_sp = atan2(pos_sp_curr.yawspeed * speed, 9.81f);
+		_att_sp.roll_body = math::constrain(roll_sp, -_parameters.roll_limit, _parameters.roll_limit);
 
-    } else if (_control_mode.flag_control_altitude_enabled) {
-        /* ALTITUDE CONTROL: pitch stick moves altitude setpoint, throttle stick sets airspeed */
-        if (_control_mode_current != FW_POSCTRL_MODE_OFFBOARD_ALTITUDE &&
-                _control_mode_current != FW_POSCTRL_MODE_POSITION &&
-                _control_mode_current != FW_POSCTRL_MODE_ALTITUDE) {
-            /* Need to init because last loop iteration was in a different mode */
-            _hold_alt = _global_pos.alt;
-        }
+	} else if (_control_mode.flag_control_altitude_enabled) {
+		/* ALTITUDE CONTROL: pitch stick moves altitude setpoint, throttle stick sets airspeed */
+		if (_control_mode_current != FW_POSCTRL_MODE_OFFBOARD_ALTITUDE &&
+		    _control_mode_current != FW_POSCTRL_MODE_POSITION &&
+		    _control_mode_current != FW_POSCTRL_MODE_ALTITUDE) {
+			/* Need to init because last loop iteration was in a different mode */
+			_hold_alt = _global_pos.alt;
+		}
 
-        _control_mode_current = FW_POSCTRL_MODE_ALTITUDE;
+		_control_mode_current = FW_POSCTRL_MODE_ALTITUDE;
 
-        /* Get demanded airspeed */
-        float altctrl_airspeed = get_demanded_airspeed();
+		/* Get demanded airspeed */
+		float altctrl_airspeed = get_demanded_airspeed();
 
-        /* update desired altitude based on user pitch stick input */
-        bool climbout_requested = update_desired_altitude(dt);
+		/* update desired altitude based on user pitch stick input */
+		bool climbout_requested = update_desired_altitude(dt);
 
-        /* if we assume that user is taking off then help by demanding altitude setpoint well above ground
-        * and set limit to pitch angle to prevent stearing into ground
-        */
-        float pitch_limit_min{0.0f};
-        do_takeoff_help(&_hold_alt, &pitch_limit_min);
+		/* if we assume that user is taking off then help by demanding altitude setpoint well above ground
+		* and set limit to pitch angle to prevent stearing into ground
+		*/
+		float pitch_limit_min{0.0f};
+		do_takeoff_help(&_hold_alt, &pitch_limit_min);
 
-        /* throttle limiting */
-        throttle_max = _parameters.throttle_max;
+		/* throttle limiting */
+		throttle_max = _parameters.throttle_max;
 
-        if (_vehicle_land_detected.landed && (fabsf(_manual.z) < THROTTLE_THRESH)) {
-            throttle_max = 0.0f;
-        }
+		if (_vehicle_land_detected.landed && (fabsf(_manual.z) < THROTTLE_THRESH)) {
+			throttle_max = 0.0f;
+		}
 
-        tecs_update_pitch_throttle(_hold_alt,
-                       altctrl_airspeed,
-                       radians(_parameters.pitch_limit_min),
-                       radians(_parameters.pitch_limit_max),
-                       _parameters.throttle_min,
-                       throttle_max,
-                       _parameters.throttle_cruise,
-                       climbout_requested,
-                       climbout_requested ? radians(10.0f) : pitch_limit_min,
-                       tecs_status_s::TECS_MODE_NORMAL);
+		tecs_update_pitch_throttle(_hold_alt,
+					   altctrl_airspeed,
+					   radians(_parameters.pitch_limit_min),
+					   radians(_parameters.pitch_limit_max),
+					   _parameters.throttle_min,
+					   throttle_max,
+					   _parameters.throttle_cruise,
+					   climbout_requested,
+					   climbout_requested ? radians(10.0f) : pitch_limit_min,
+					   tecs_status_s::TECS_MODE_NORMAL);
 
-        _att_sp.roll_body = _manual.y * _parameters.man_roll_max_rad;
-        _att_sp.yaw_body = 0;
+		_att_sp.roll_body = _manual.y * _parameters.man_roll_max_rad;
+		_att_sp.yaw_body = 0;
 
 	} else {
-        _control_mode_current = FW_POSCTRL_MODE_OTHER;
+		_control_mode_current = FW_POSCTRL_MODE_OTHER;
 
 		/* do not publish the setpoint */
 		setpoint = false;
@@ -1577,7 +1577,7 @@ FixedwingPositionControl::run()
 
 			/* update parameters from storage */
 			parameters_update();
-        }
+		}
 
 		/* only run controller if position changed */
 		if ((fds[0].revents & POLLIN) != 0) {
@@ -1624,7 +1624,7 @@ FixedwingPositionControl::run()
 			/*
 			 * Attempt to control position, on success (= sensors present and not in manual mode),
 			 * publish setpoint.
-             */
+			*/
 			if (control_position(curr_pos, ground_speed, _pos_sp_triplet.previous, _pos_sp_triplet.current)) {
 				_att_sp.timestamp = hrt_absolute_time();
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -628,7 +628,6 @@ bool
 FixedwingPositionControl::control_position(const math::Vector<2> &curr_pos, const math::Vector<2> &ground_speed,
 		const position_setpoint_s &pos_sp_prev, const position_setpoint_s &pos_sp_curr)
 {
-	static int i = 0;
 	float dt = 0.01f;
 
 	if (_control_position_last_called > 0) {

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -259,8 +259,8 @@ private:
 	enum FW_POSCTRL_MODE {
 		FW_POSCTRL_MODE_AUTO,
 		FW_POSCTRL_MODE_POSITION,
-        FW_POSCTRL_MODE_OFFBOARD_ALTITUDE,
-        FW_POSCTRL_MODE_ALTITUDE,
+		FW_POSCTRL_MODE_OFFBOARD_ALTITUDE,
+		FW_POSCTRL_MODE_ALTITUDE,
 		FW_POSCTRL_MODE_OTHER
 	} _control_mode_current{FW_POSCTRL_MODE_OTHER};		///< used to check the mode in the last control loop iteration. Use to check if the last iteration was in the same mode.
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -259,7 +259,8 @@ private:
 	enum FW_POSCTRL_MODE {
 		FW_POSCTRL_MODE_AUTO,
 		FW_POSCTRL_MODE_POSITION,
-		FW_POSCTRL_MODE_ALTITUDE,
+        FW_POSCTRL_MODE_OFFBOARD_ALTITUDE,
+        FW_POSCTRL_MODE_ALTITUDE,
 		FW_POSCTRL_MODE_OTHER
 	} _control_mode_current{FW_POSCTRL_MODE_OTHER};		///< used to check the mode in the last control loop iteration. Use to check if the last iteration was in the same mode.
 


### PR DESCRIPTION
Things to do: 

- Using `roll_limit parameter` to constrain the bank angle used to turn but it seems to not be strict enough as with high yaw rates the plane will not sustain altitude.
- Numerical sanity checks on `airspeed` and `yawspeed` maybe? not super necessary since the roll angle is constrained regardless.
- I changed the condition of velocity control to only occur if not in offboard mode, probably need to think of a better way to do this since the offboard mode control flag is used almost nowhere inside the control modules.

How to run:
Give a message to `/mavros/setpoint_raw/local with yaw rate` and z axis of the position. Mavros takes coordinates in `local_ned` so the altitude would have to be negative.