### PR TITLE
differential pressure sensors delete test helpers

### DIFF
--- a/src/drivers/differential_pressure/ets/ets_airspeed.cpp
+++ b/src/drivers/differential_pressure/ets/ets_airspeed.cpp
@@ -240,7 +240,6 @@ ETSAirspeed	*g_dev;
 
 int start(int i2c_bus);
 int stop();
-int test();
 int reset();
 int info();
 
@@ -315,76 +314,6 @@ stop()
 }
 
 /**
- * Perform some basic functional tests on the driver;
- * make sure we can collect data from the sensor in polled
- * and automatic modes.
- */
-int
-test()
-{
-	struct differential_pressure_s report;
-	ssize_t sz;
-	int ret;
-
-	int fd = px4_open(ETS_PATH, O_RDONLY);
-
-	if (fd < 0) {
-		PX4_ERR("%s open failed (try 'ets_airspeed start' if the driver is not running", ETS_PATH);
-		return PX4_ERROR;
-	}
-
-	/* do a simple demand read */
-	sz = px4_read(fd, &report, sizeof(report));
-
-	if (sz != sizeof(report)) {
-		PX4_ERR("immediate read failed");
-		return PX4_ERROR;
-	}
-
-	PX4_INFO("single read");
-	PX4_INFO("diff pressure: %d pa", (int)report.differential_pressure_filtered_pa);
-
-	/* start the sensor polling at 2Hz */
-	if (OK != px4_ioctl(fd, SENSORIOCSPOLLRATE, 2)) {
-		PX4_ERR("failed to set 2Hz poll rate");
-		return PX4_ERROR;
-	}
-
-	/* read the sensor 5x and report each value */
-	for (unsigned i = 0; i < 5; i++) {
-		px4_pollfd_struct_t fds;
-
-		/* wait for data to be ready */
-		fds.fd = fd;
-		fds.events = POLLIN;
-		ret = px4_poll(&fds, 1, 2000);
-
-		if (ret != 1) {
-			PX4_ERR("timed out waiting for sensor data");
-			return PX4_ERROR;
-		}
-
-		/* now go get it */
-		sz = px4_read(fd, &report, sizeof(report));
-
-		if (sz != sizeof(report)) {
-			PX4_ERR("periodic read failed");
-		}
-
-		PX4_INFO("periodic read %u", i);
-		PX4_INFO("diff pressure: %f pa", (double)report.differential_pressure_filtered_pa);
-	}
-
-	/* reset the sensor polling to its default rate */
-	if (OK != px4_ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT)) {
-		PX4_ERR("failed to set default rate");
-		return PX4_ERROR;
-	}
-
-	return PX4_OK;
-}
-
-/**
  * Reset the driver.
  */
 int
@@ -420,7 +349,7 @@ ets_airspeed_usage()
 	PX4_INFO("options:");
 	PX4_INFO("\t-b --bus i2cbus (%d)", PX4_I2C_BUS_DEFAULT);
 	PX4_INFO("command:");
-	PX4_INFO("\tstart|stop|reset|test|info");
+	PX4_INFO("\tstart|stop|reset|info");
 }
 
 int
@@ -450,13 +379,6 @@ ets_airspeed_main(int argc, char *argv[])
 	 */
 	if (!strcmp(argv[1], "stop")) {
 		return ets_airspeed::stop();
-	}
-
-	/*
-	 * Test the driver/device.
-	 */
-	if (!strcmp(argv[1], "test")) {
-		return ets_airspeed::test();
 	}
 
 	/*

--- a/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
+++ b/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
@@ -376,7 +376,6 @@ MEASAirspeed	*g_dev = nullptr;
 
 int start(int i2c_bus);
 int stop();
-int test();
 int reset();
 
 /**
@@ -451,78 +450,6 @@ stop()
 }
 
 /**
- * Perform some basic functional tests on the driver;
- * make sure we can collect data from the sensor in polled
- * and automatic modes.
- */
-int
-test()
-{
-	struct differential_pressure_s report;
-	ssize_t sz;
-	int ret;
-
-	int fd = px4_open(PATH_MS4525, O_RDONLY);
-
-	if (fd < 0) {
-		PX4_ERR("%s open failed (try 'meas_airspeed start' if the driver is not running", PATH_MS4525);
-		return PX4_ERROR;
-	}
-
-	/* do a simple demand read */
-	sz = px4_read(fd, &report, sizeof(report));
-
-	if (sz != sizeof(report)) {
-		PX4_ERR("immediate read failed");
-		return PX4_ERROR;
-	}
-
-	PX4_INFO("single read");
-	PX4_INFO("diff pressure: %d pa", (int)report.differential_pressure_filtered_pa);
-
-	/* start the sensor polling at 2Hz */
-	if (OK != px4_ioctl(fd, SENSORIOCSPOLLRATE, 2)) {
-		PX4_ERR("failed to set 2Hz poll rate");
-		return PX4_ERROR;
-	}
-
-	/* read the sensor 5x and report each value */
-	for (unsigned i = 0; i < 5; i++) {
-		px4_pollfd_struct_t fds;
-
-		/* wait for data to be ready */
-		fds.fd = fd;
-		fds.events = POLLIN;
-		ret = px4_poll(&fds, 1, 2000);
-
-		if (ret != 1) {
-			PX4_ERR("timed out waiting for sensor data");
-			return PX4_ERROR;
-		}
-
-		/* now go get it */
-		sz = px4_read(fd, &report, sizeof(report));
-
-		if (sz != sizeof(report)) {
-			PX4_ERR("periodic read failed");
-			return PX4_ERROR;
-		}
-
-		PX4_INFO("periodic read %u", i);
-		PX4_INFO("diff pressure: %d pa", (int)report.differential_pressure_filtered_pa);
-		PX4_INFO("temperature: %d C (0x%02x)", (int)report.temperature, (unsigned) report.temperature);
-	}
-
-	/* reset the sensor polling to its default rate */
-	if (OK != px4_ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT)) {
-		PX4_ERR("failed to set default rate");
-		return PX4_ERROR;
-	}
-
-	return PX4_OK;
-}
-
-/**
  * Reset the driver.
  */
 int
@@ -558,7 +485,7 @@ meas_airspeed_usage()
 	PX4_INFO("options:");
 	PX4_INFO("\t-b --bus i2cbus (%d)", PX4_I2C_BUS_DEFAULT);
 	PX4_INFO("command:");
-	PX4_INFO("\tstart|stop|reset|test");
+	PX4_INFO("\tstart|stop|reset");
 }
 
 int
@@ -588,13 +515,6 @@ ms4525_airspeed_main(int argc, char *argv[])
 	 */
 	if (!strcmp(argv[1], "stop")) {
 		return meas_airspeed::stop();
-	}
-
-	/*
-	 * Test the driver/device.
-	 */
-	if (!strcmp(argv[1], "test")) {
-		return meas_airspeed::test();
 	}
 
 	/*

--- a/src/drivers/differential_pressure/ms5525/MS5525_main.cpp
+++ b/src/drivers/differential_pressure/ms5525/MS5525_main.cpp
@@ -43,7 +43,6 @@ MS5525 *g_dev = nullptr;
 
 int start(uint8_t i2c_bus);
 int stop();
-int test();
 int reset();
 
 // Start the driver.
@@ -111,72 +110,6 @@ int stop()
 	return PX4_OK;
 }
 
-// perform some basic functional tests on the driver;
-// make sure we can collect data from the sensor in polled
-// and automatic modes.
-int test()
-{
-	int fd = px4_open(PATH_MS5525, O_RDONLY);
-
-	if (fd < 0) {
-		PX4_WARN("%s open failed (try 'ms5525_airspeed start' if the driver is not running", PATH_MS5525);
-		return PX4_ERROR;
-	}
-
-	// do a simple demand read
-	differential_pressure_s report;
-	ssize_t sz = px4_read(fd, &report, sizeof(report));
-
-	if (sz != sizeof(report)) {
-		PX4_WARN("immediate read failed");
-		return PX4_ERROR;
-	}
-
-	PX4_WARN("single read");
-	PX4_WARN("diff pressure: %d pa", (int)report.differential_pressure_filtered_pa);
-
-	/* start the sensor polling at 2Hz */
-	if (OK != px4_ioctl(fd, SENSORIOCSPOLLRATE, 2)) {
-		PX4_WARN("failed to set 2Hz poll rate");
-		return PX4_ERROR;
-	}
-
-	/* read the sensor 5x and report each value */
-	for (unsigned i = 0; i < 5; i++) {
-		px4_pollfd_struct_t fds;
-
-		/* wait for data to be ready */
-		fds.fd = fd;
-		fds.events = POLLIN;
-		int ret = px4_poll(&fds, 1, 2000);
-
-		if (ret != 1) {
-			PX4_ERR("timed out");
-			return PX4_ERROR;
-		}
-
-		/* now go get it */
-		sz = px4_read(fd, &report, sizeof(report));
-
-		if (sz != sizeof(report)) {
-			PX4_ERR("periodic read failed");
-			return PX4_ERROR;
-		}
-
-		PX4_WARN("periodic read %u", i);
-		PX4_WARN("diff pressure: %d pa", (int)report.differential_pressure_filtered_pa);
-		PX4_WARN("temperature: %d C (0x%02x)", (int)report.temperature, (unsigned) report.temperature);
-	}
-
-	/* reset the sensor polling to its default rate */
-	if (PX4_OK != px4_ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT)) {
-		PX4_WARN("failed to set default rate");
-		return PX4_ERROR;
-	}
-
-	return PX4_OK;
-}
-
 // reset the driver
 int reset()
 {
@@ -210,7 +143,7 @@ ms5525_airspeed_usage()
 	PX4_WARN("options:");
 	PX4_WARN("\t-b --bus i2cbus (%d)", PX4_I2C_BUS_DEFAULT);
 	PX4_WARN("command:");
-	PX4_WARN("\tstart|stop|reset|test");
+	PX4_WARN("\tstart|stop|reset");
 }
 
 int
@@ -238,13 +171,6 @@ ms5525_airspeed_main(int argc, char *argv[])
 	 */
 	if (!strcmp(argv[1], "stop")) {
 		return ms5525_airspeed::stop();
-	}
-
-	/*
-	 * Test the driver/device.
-	 */
-	if (!strcmp(argv[1], "test")) {
-		return ms5525_airspeed::test();
 	}
 
 	/*


### PR DESCRIPTION
 - these are redundant with `listener differential_pressure`