### PR TITLE
vehicle_global_position delete unused pos_d_deriv

### DIFF
--- a/msg/vehicle_global_position.msg
+++ b/msg/vehicle_global_position.msg
@@ -17,8 +17,6 @@ float32 vel_n			# North velocity in NED earth-fixed frame, (metres/sec)
 float32 vel_e			# East velocity in NED earth-fixed frame, (metres/sec)
 float32 vel_d			# Down velocity in NED earth-fixed frame, (metres/sec)
 
-float32 pos_d_deriv		# Down position time derivative in NED earth-fixed frame, (metres/sec)
-
 float32 yaw 			# Euler yaw angle relative to NED earth-fixed frame, -PI..+PI, (radians)
 
 float32 eph			# Standard deviation of horizontal position error, (metres)

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1048,8 +1048,6 @@ void Ekf2::run()
 				global_pos.vel_e = lpos.vy; // Ground east velocity, m/s
 				global_pos.vel_d = lpos.vz; // Ground downside velocity, m/s
 
-				global_pos.pos_d_deriv = lpos.z_deriv; // vertical position time derivative, m/s
-
 				global_pos.yaw = lpos.yaw; // Yaw in radians -PI..+PI.
 
 				_ekf.get_ekf_gpos_accuracy(&global_pos.eph, &global_pos.epv, &global_pos.dead_reckoning);

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -721,9 +721,6 @@ void BlockLocalPositionEstimator::publishGlobalPos()
 		_pub_gpos.get().vel_e = xLP(X_vy);
 		_pub_gpos.get().vel_d = xLP(X_vz);
 
-		// this estimator does not provide a separate vertical position time derivative estimate, so use the vertical velocity
-		_pub_gpos.get().pos_d_deriv = xLP(X_vz);
-
 		_pub_gpos.get().yaw = _eul(2);
 		_pub_gpos.get().eph = eph;
 		_pub_gpos.get().epv = epv;

--- a/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
@@ -1392,9 +1392,6 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 				global_pos.vel_e = local_pos.vy;
 				global_pos.vel_d = local_pos.vz;
 
-				// this estimator does not provide a separate vertical position time derivative estimate, so use the vertical velocity
-				global_pos.pos_d_deriv = local_pos.vz;
-
 				global_pos.yaw = local_pos.yaw;
 
 				global_pos.eph = eph;


### PR DESCRIPTION
This is still available in vehicle_local_position z_deriv.