### PR TITLE
GPS: explicitly disable flow control

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -530,8 +530,8 @@ int GPS::setBaudrate(unsigned baud)
 	//
 	uart_config.c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN | ISIG);
 
-	/* no parity, one stop bit */
-	uart_config.c_cflag &= ~(CSTOPB | PARENB);
+	/* no parity, one stop bit, disable flow control */
+	uart_config.c_cflag &= ~(CSTOPB | PARENB | CRTSCTS);
 
 	/* set baud rate */
 	if ((termios_state = cfsetispeed(&uart_config, speed)) < 0) {


### PR DESCRIPTION
If the GPS driver was used on another port (e.g. TELEM2), it would get stuck in a `write` call and not return anymore. Disabling flow control fixes that.

CPU usage is unchanged.

Tested on a Pixracer, dual gps now works too: `gps start -d /dev/ttyS2 -e /dev/ttyS3` (although for testing I only had one GPS connected at a time).

Fixes https://github.com/PX4/Firmware/issues/8945