### PR TITLE
convergence config: increase idle speed in mc mode

### DIFF
--- a/ROMFS/px4fmu_common/init.d/13012_convergence
+++ b/ROMFS/px4fmu_common/init.d/13012_convergence
@@ -23,7 +23,7 @@ if [ $AUTOCNF == yes ]
 then
     param set VT_MOT_COUNT 3
     param set VT_FW_MOT_OFFID 3
-    param set VT_IDLE_PWM_MC 1080
+    param set VT_IDLE_PWM_MC 1150
     param set VT_TYPE 1
 
     param set VT_B_TRANS_DUR  1.0


### PR DESCRIPTION
- this makes sure that all motors are idling in mc mode. having this too
low can lead to a motor stopping in flight which is critical for
attitude control
- experienced loss of attitude control in RTL during descent prior to this
change

Signed-off-by: Roman <bapstroman@gmail.com>