### PR TITLE
px4fmu-v2 sensor reset

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -31,8 +31,8 @@ else
 	# External SPI
 	ms5611 -S start
 
-	# Internal SPI
-	ms5611 -s start
+	# Internal SPI (auto detect ms5611 or ms5607)
+	ms5611 -T 0 -s start
 
 	# Blacksheep telemetry
 	bst start
@@ -136,9 +136,9 @@ then
 		then
 			# v2.0 internal MPU6000 is rotated 180 deg roll, 270 deg yaw
 			mpu6000 -R 14 start
+
 			# v2.0 Has internal hmc5883 on SPI1
 			hmc5883 -C -T -S -R 8 start
-
 		fi
 
 		if [ $BOARD_FMUV3 == 21 ]
@@ -165,6 +165,8 @@ then
 		l3gd20 start
 		lsm303d start
 	fi
+
+	unset BOARD_FMUV3
 fi
 
 if ver hwcmp PX4_SAME70XPLAINED_V1

--- a/src/drivers/boards/px4fmu-v2/init.c
+++ b/src/drivers/boards/px4fmu-v2/init.c
@@ -186,6 +186,9 @@ __EXPORT void board_on_reset(int status)
 
 	if (status >= 0) {
 		up_mdelay(400);
+
+		/* on reboot (status >= 0) reset sensors and peripherals */
+		board_spi_reset(10);
 	}
 }
 


### PR DESCRIPTION
This isn't the ideal solution, but for the majority of cases (good boards and bad) it will bring all sensors back (hard reset and reboot commanded).

Tested on several different pixhawks (3dr, hobbyking, etc).

@svpcom could you try this?