### PR TITLE
precland: support receiving LANDING_TARGET message

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -74,6 +74,7 @@
 #include <uORB/topics/time_offset.h>
 #include <uORB/topics/distance_sensor.h>
 #include <uORB/topics/follow_target.h>
+#include <uORB/topics/landing_target_pose.h>
 #include <uORB/topics/transponder_report.h>
 #include <uORB/topics/gps_inject_data.h>
 #include <uORB/topics/collision_report.h>
@@ -149,6 +150,7 @@ private:
 	void handle_message_hil_state_quaternion(mavlink_message_t *msg);
 	void handle_message_distance_sensor(mavlink_message_t *msg);
 	void handle_message_follow_target(mavlink_message_t *msg);
+	void handle_message_landing_target(mavlink_message_t *msg);
 	void handle_message_adsb_vehicle(mavlink_message_t *msg);
 	void handle_message_collision(mavlink_message_t *msg);
 	void handle_message_gps_rtcm_data(mavlink_message_t *msg);
@@ -242,6 +244,7 @@ private:
 	orb_advert_t _land_detector_pub;
 	orb_advert_t _time_offset_pub;
 	orb_advert_t _follow_target_pub;
+	orb_advert_t _landing_target_pose_pub;
 	orb_advert_t _transponder_report_pub;
 	orb_advert_t _collision_report_pub;
 	orb_advert_t _debug_key_value_pub;

--- a/src/modules/navigator/precland.cpp
+++ b/src/modules/navigator/precland.cpp
@@ -116,7 +116,7 @@ PrecLand::on_active()
 		_target_pose_valid = true;
 	}
 
-	if ((hrt_elapsed_time(&_target_pose.timestamp) / 1e-6f) > _param_timeout.get()) {
+	if ((hrt_elapsed_time(&_target_pose.timestamp) / 1e6f) > _param_timeout.get()) {
 		_target_pose_valid = false;
 	}
 

--- a/src/modules/navigator/precland.cpp
+++ b/src/modules/navigator/precland.cpp
@@ -69,8 +69,8 @@ void
 PrecLand::on_activation()
 {
 	// We need to subscribe here and not in the constructor because constructor is called before the navigator task is spawned
-	if (!_targetPoseSub) {
-		_targetPoseSub = orb_subscribe(ORB_ID(landing_target_pose));
+	if (!_target_pose_sub) {
+		_target_pose_sub = orb_subscribe(ORB_ID(landing_target_pose));
 	}
 
 	_state = PrecLandState::Start;
@@ -109,10 +109,10 @@ PrecLand::on_active()
 {
 	// get new target measurement
 	bool updated = false;
-	orb_check(_targetPoseSub, &updated);
+	orb_check(_target_pose_sub, &updated);
 
 	if (updated) {
-		orb_copy(ORB_ID(landing_target_pose), _targetPoseSub, &_target_pose);
+		orb_copy(ORB_ID(landing_target_pose), _target_pose_sub, &_target_pose);
 		_target_pose_valid = true;
 	}
 
@@ -212,7 +212,7 @@ PrecLand::run_state_horizontal_approach()
 
 	// check if target visible, if not go to start
 	if (!check_state_conditions(PrecLandState::HorizontalApproach)) {
-		PX4_WARN("Lost landing target while landig (horizontal approach).");
+		PX4_WARN("Lost landing target while landing (horizontal approach).");
 
 		// Stay at current position for searching for the landing target
 		pos_sp_triplet->current.lat = _navigator->get_global_position()->lat;

--- a/src/modules/navigator/precland.cpp
+++ b/src/modules/navigator/precland.cpp
@@ -69,7 +69,7 @@ void
 PrecLand::on_activation()
 {
 	// We need to subscribe here and not in the constructor because constructor is called before the navigator task is spawned
-	if (!_target_pose_sub) {
+	if (_target_pose_sub < 0) {
 		_target_pose_sub = orb_subscribe(ORB_ID(landing_target_pose));
 	}
 

--- a/src/modules/navigator/precland.h
+++ b/src/modules/navigator/precland.h
@@ -100,8 +100,8 @@ private:
 
 	landing_target_pose_s _target_pose{}; /**< precision landing target position */
 
-	int _targetPoseSub{-1};
-	bool _target_pose_valid{false}; /**< wether we have received a landing target position message */
+	int _target_pose_sub{-1};
+	bool _target_pose_valid{false}; /**< whether we have received a landing target position message */
 
 	struct map_projection_reference_s _map_ref {}; /**< reference for local/global projections */
 

--- a/src/modules/navigator/precland.h
+++ b/src/modules/navigator/precland.h
@@ -102,6 +102,7 @@ private:
 
 	int _target_pose_sub{-1};
 	bool _target_pose_valid{false}; /**< whether we have received a landing target position message */
+	bool _target_pose_updated{false}; /**< wether the landing target position message is updated */
 
 	struct map_projection_reference_s _map_ref {}; /**< reference for local/global projections */
 


### PR DESCRIPTION
I added support for receiving `LANDING_TARGET` MAVLINK message. This is useful for setups, when we don't use IRLock for precise landing, but an external computer, that detects the landing target (a visual marker, for example). The receiver simply retransmits the message to the `landing_target_pose` uORB topic.

Unfortunately, `LANDING_TARGET` lacks some helpful fields, that `landing_target_pose` topic has:
* Landing target relative velocities
* Is the target static? Considered, that not, for now
* Landing place size in meters (contains only the fields, that are described as sizes in radians)
* Covariances

I think, adding this fields to `LANDING_TARGET` should be considered.

Also, two issues in precland.cpp were fixed:
* typo, where `y_rel` should be `y_abs`
* removed using `x_rel` and `y_rel` for two reasons: 
  * this is fields are lacked in `LANDING_TARGET` message
  * they can be easily recalculated from `x_abs`, `y_abs` (and this is done in other parts of the code).

Tested the landing is SITL and on a real drone (see the video below).