### PR TITLE
UAVCAN : Correct startup sequence and improve parameter description

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -686,10 +686,16 @@ then
 	#
 	if param greater UAVCAN_ENABLE 0
 	then
+		# Start core UAVCAN module
 		if uavcan start
 		then
-			set LOGGER_BUF 6
-			uavcan start fw
+			if param greater UAVCAN_ENABLE 1
+			then
+				# Reduce logger buffer to free up some RAM for UAVCAN servers
+				set LOGGER_BUF 6
+				# Start UAVCAN firmware update server and dynamic node ID allocation server
+				uavcan start fw
+			fi
 		else
 			tone_alarm ${TUNE_ERR}
 		fi

--- a/src/modules/uavcan/uavcan_params.c
+++ b/src/modules/uavcan/uavcan_params.c
@@ -42,15 +42,16 @@
  * UAVCAN mode
  *
  *  0 - UAVCAN disabled.
- *  1 - Basic support for UAVCAN actuators and sensors.
- *  2 - Full support for dynamic node ID allocation and firmware update.
- *  3 - Sets the motor control outputs to UAVCAN and enables support for dynamic node ID allocation and firmware update.
+ *  1 - Enables support for UAVCAN sensors without dynamic node ID allocation and firmware update.
+ *  2 - Enables support for UAVCAN sensors with dynamic node ID allocation and firmware update.
+ *  3 - Enables support for UAVCAN sensors and actuators with dynamic node ID allocation and firmware update. Also sets the motor control outputs to UAVCAN.
  *
  * @min 0
  * @max 3
  * @value 0 Disabled
- * @value 2 Only Sensors
- * @value 3 Sensors and Motors
+ * @value 1 Sensors Manual Config
+ * @value 2 Sensors Automatic Config
+ * @value 3 Sensors and Actuators (ESCs) Automatic Config
  * @reboot_required true
  * @group UAVCAN
  */


### PR DESCRIPTION
This allows UAVCAN sensors to be used in static-allocation mode (no dynamic node ID allocation and no firmware update), which reduces memory usage significantly.

(This used to work before but got lost along the way at some point)