### PR TITLE
Fix temperature readout for Invensense IMUs

### DIFF
--- a/src/drivers/imu/mpu6000/mpu6000.cpp
+++ b/src/drivers/imu/mpu6000/mpu6000.cpp
@@ -2012,11 +2012,16 @@ MPU6000::measure()
 	arb.scaling = _accel_range_scale;
 	arb.range_m_s2 = _accel_range_m_s2;
 
+	// We calculate sensor temperature as :
+	// temperature_real = temperature_raw / temperature_sensitivity + zero_offset
+	//
+	// Sensitivity (in LSB/degC) is from the Invensense datasheet for the specific sensor
+	// Zero offset (in degC) varies from part to part, and this datasheet value is a good default
 	if (is_icm_device()) { // if it is an ICM20608
 		_last_temperature = (report.temp) / 326.8f + 25.0f;
 
 	} else { // If it is an MPU6000
-		_last_temperature = (report.temp) / 361.0f + 35.0f;
+		_last_temperature = (report.temp) / 340.0f + 35.0f;
 	}
 
 	arb.temperature_raw = report.temp;

--- a/src/drivers/imu/mpu9250/mpu9250.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250.cpp
@@ -1439,7 +1439,12 @@ MPU9250::measure()
 	arb.scaling = _accel_range_scale;
 	arb.range_m_s2 = _accel_range_m_s2;
 
-	_last_temperature = (report.temp) / 361.0f + 35.0f;
+	// We calculate sensor temperature as :
+	// temperature_real = temperature_raw / temperature_sensitivity + zero_offset
+	//
+	// Sensitivity (in LSB/degC) is from the Invensense datasheet for the specific sensor
+	// Zero offset (in degC) varies from part to part, and this datasheet value is a good default
+	_last_temperature = (report.temp) / 333.87f + 21.0f;
 
 	arb.temperature_raw = report.temp;
 	arb.temperature = _last_temperature;


### PR DESCRIPTION
This fixes the temperature readout for the MPU/ICM IMUs. The sensitivity parameters were originally incorrect. This is needed for enabling the Pixhawk 2.1 IMU heater and holding a temperature set-point.