### PR TITLE
Use filtered throttle for battery voltage compensation

### DIFF
--- a/src/modules/systemlib/battery.cpp
+++ b/src/modules/systemlib/battery.cpp
@@ -86,9 +86,10 @@ Battery::updateBatteryStatus(hrt_abstime timestamp, float voltage_v, float curre
 	reset(battery_status);
 	battery_status->timestamp = timestamp;
 	filterVoltage(voltage_v);
+	filterThrottle(throttle_normalized);
 	filterCurrent(current_a);
 	sumDischarged(timestamp, current_a);
-	estimateRemaining(_voltage_filtered_v, _current_filtered_a, throttle_normalized, armed);
+	estimateRemaining(_voltage_filtered_v, _current_filtered_a, _throttle_filtered, armed);
 	computeScale();
 
 	if (_battery_initialized) {
@@ -141,6 +142,17 @@ Battery::filterCurrent(float current_a)
 	}
 }
 
+void Battery::filterThrottle(float throttle){
+	if (!_battery_initialized) {
+		_throttle_filtered = throttle;
+	}
+
+	const float filtered_next = _throttle_filtered * 0.99f + throttle * 0.01f;
+
+	if (PX4_ISFINITE(filtered_next)){
+		_throttle_filtered = filtered_next;
+	}
+}
 
 void
 Battery::sumDischarged(hrt_abstime timestamp, float current_a)
@@ -165,7 +177,7 @@ Battery::sumDischarged(hrt_abstime timestamp, float current_a)
 }
 
 void
-Battery::estimateRemaining(float voltage_v, float current_a, float throttle_normalized, bool armed)
+Battery::estimateRemaining(float voltage_v, float current_a, float throttle, bool armed)
 {
 	// remaining battery capacity based on voltage
 	float cell_voltage = voltage_v / _n_cells.get();
@@ -176,7 +188,7 @@ Battery::estimateRemaining(float voltage_v, float current_a, float throttle_norm
 
 	} else {
 		// assume linear relation between throttle and voltage drop
-		cell_voltage += throttle_normalized * _v_load_drop.get();
+		cell_voltage += throttle * _v_load_drop.get();
 	}
 
 	_remaining_voltage = math::gradual(cell_voltage, _v_empty.get(), _v_charged.get(), 0.f, 1.f);

--- a/src/modules/systemlib/battery.cpp
+++ b/src/modules/systemlib/battery.cpp
@@ -142,14 +142,15 @@ Battery::filterCurrent(float current_a)
 	}
 }
 
-void Battery::filterThrottle(float throttle){
+void Battery::filterThrottle(float throttle)
+{
 	if (!_battery_initialized) {
 		_throttle_filtered = throttle;
 	}
 
 	const float filtered_next = _throttle_filtered * 0.99f + throttle * 0.01f;
 
-	if (PX4_ISFINITE(filtered_next)){
+	if (PX4_ISFINITE(filtered_next)) {
 		_throttle_filtered = filtered_next;
 	}
 }

--- a/src/modules/systemlib/battery.h
+++ b/src/modules/systemlib/battery.h
@@ -97,9 +97,10 @@ public:
 
 private:
 	void filterVoltage(float voltage_v);
+	void filterThrottle(float throttle);
 	void filterCurrent(float current_a);
 	void sumDischarged(hrt_abstime timestamp, float current_a);
-	void estimateRemaining(float voltage_v, float current_a, float throttle_normalized, bool armed);
+	void estimateRemaining(float voltage_v, float current_a, float throttle, bool armed);
 	void determineWarning(bool connected);
 	void computeScale();
 
@@ -115,6 +116,7 @@ private:
 
 	bool _battery_initialized = false;
 	float _voltage_filtered_v = -1.f;
+	float _throttle_filtered = -1.f;
 	float _current_filtered_a = -1.f;
 	float _discharged_mah = 0.f;
 	float _discharged_mah_loop = 0.f;


### PR DESCRIPTION
When an internal resistance for the battery has not been selected the firmware uses throttle and the `BAT_V_LOAD_DROP` parameter to compensate for the voltage drop due to load on the battery. The battery voltage has a delayed response to a change in load and it is further filtered to get rid of high-frequency noise. However the throttle value that is used in the calculation can change immediately, this means that when the throttle changes suddenly the compensation will be way off until the filtered voltage has had time to stabilize.

This issue can be seen at 18:24.75 in this log:
https://review.px4.io/plot_app?log=53b9938b-ad16-453a-b6f5-e0d5637eba66

When the quadcopter is switched from manual mode to position mode the throttle jumps from 100% to 6%. This causes the battery estimation to drop from ~40% down to 0%. It then slowly recovers back to 40% as the voltage rises.

This pull request replaces the battery voltage drop compensation's raw throttle value with a value that has been filtered at the same time constant as the battery voltage. This prevents the compensation from overshooting during sudden changes of throttle.