### PR TITLE
[WIP] Fix integrator timestamping

### DIFF
--- a/msg/sensor_accel.msg
+++ b/msg/sensor_accel.msg
@@ -10,6 +10,7 @@ float32 temperature	# temperature in degrees celsius
 float32 range_m_s2	# range in m/s^2 (+- this value)
 float32 scaling
 
+int32 timestamp_sample_relative	# timestamp of the raw measurement, relative to main timestamp
 int16 x_raw
 int16 y_raw
 int16 z_raw

--- a/msg/sensor_gyro.msg
+++ b/msg/sensor_gyro.msg
@@ -10,6 +10,7 @@ float32 temperature	# temperature in degrees celcius
 float32 range_rad_s
 float32 scaling
 
+int32 timestamp_sample_relative	# timestamp of the raw measurement, relative to main timestamp
 int16 x_raw
 int16 y_raw
 int16 z_raw

--- a/src/drivers/device/integrator.h
+++ b/src/drivers/device/integrator.h
@@ -53,14 +53,15 @@ public:
 	/**
 	 * Put an item into the integral.
 	 *
-	 * @param timestamp	Timestamp of the current value.
+	 * @param timestamp_sample	Timestamp of the current value.
 	 * @param val		Item to put.
 	 * @param integral	Current integral in case the integrator did reset, else the value will not be modified
 	 * @param integral_dt	Get the dt in us of the current integration (only if reset).
+	 * @param timestamp_integral	Timestamp of the integrated value (average).
 	 * @return		true if putting the item triggered an integral reset and the integral should be
 	 *			published.
 	 */
-	bool put(uint64_t timestamp, math::Vector<3> &val, math::Vector<3> &integral, uint64_t &integral_dt);
+	bool put(uint64_t timestamp_sample, math::Vector<3> &val, math::Vector<3> &integral, uint64_t &integral_dt, uint64_t &timestamp_integral);
 
 	/**
 	 * Put an item into the integral but provide an interval instead of a timestamp.
@@ -71,20 +72,22 @@ public:
 	 * @param integral_dt	Get the dt in us of the current integration (only if reset). Note that this
 	 *			values might not be accurate vs. hrt_absolute_time because it is just the sum of the
 	 *			supplied intervals.
+	 * @param timestamp_integral	Timestamp of the integrated value (average).
 	 * @return		true if putting the item triggered an integral reset and the integral should be
 	 *			published.
 	 */
 	bool put_with_interval(unsigned interval_us, math::Vector<3> &val, math::Vector<3> &integral,
-			       uint64_t &integral_dt);
+			       uint64_t &integral_dt, uint64_t &timestamp_integral);
 
 	/**
 	 * Get the current integral and reset the integrator if needed.
 	 *
 	 * @param reset	    	Reset the integral to zero.
 	 * @param integral_dt	Get the dt in us of the current integration (only if reset).
+	 * @param timestamp_integral	Timestamp of the integrated value (average).
 	 * @return		the integral since the last read-reset
 	 */
-	math::Vector<3>		get(bool reset, uint64_t &integral_dt);
+	math::Vector<3>		get(bool reset, uint64_t &integral_dt, uint64_t &timestamp_integral);
 
 	/**
 	 * Get the current integral and reset the integrator if needed. Additionally give the
@@ -93,14 +96,16 @@ public:
 	 * @param reset	    	Reset the integral to zero.
 	 * @param integral_dt	Get the dt in us of the current integration (only if reset).
 	 * @param filtered_val	The integral differentiated by the integration time.
+	 * @param timestamp_integral	Timestamp of the integrated value (average).
 	 * @return		the integral since the last read-reset
 	 */
-	math::Vector<3>		get_and_filtered(bool reset, uint64_t &integral_dt, math::Vector<3> &filtered_val);
+	math::Vector<3>		get_and_filtered(bool reset, uint64_t &integral_dt, math::Vector<3> &filtered_val, uint64_t &timestamp_integral);
 
 private:
 	uint64_t _auto_reset_interval;			/**< the interval after which the content will be published
 							     and the integrator reset, 0 if no auto-reset */
 	uint64_t _last_integration_time;		/**< timestamp of the last integration step */
+	uint64_t _timestamp_integral;		/**< timestamp of the integrated measurement (average) */
 	uint64_t _last_reset_time;			/**< last auto-announcement of integral value */
 	math::Vector<3> _alpha;				/**< integrated value before coning corrections are applied */
 	math::Vector<3> _last_alpha;			/**< previous value of _alpha */

--- a/src/drivers/imu/adis16448/adis16448.cpp
+++ b/src/drivers/imu/adis16448/adis16448.cpp
@@ -1433,7 +1433,8 @@ ADIS16448::measure()
 	gyro_report		grb;
 	mag_report		mrb;
 
-	grb.timestamp = arb.timestamp = mrb.timestamp = hrt_absolute_time();
+	uint64_t timestamp_sample =  hrt_absolute_time();
+	mrb.timestamp = timestamp_sample;
 	grb.error_count = arb.error_count = mrb.error_count = perf_event_count(_bad_transfers);
 
 	/* Gyro report: */
@@ -1466,6 +1467,8 @@ ADIS16448::measure()
 	grb.scaling = _gyro_range_scale * M_PI_F / 180.0f;
 	grb.range_rad_s = _gyro_range_rad_s;
 
+	grb.timestamp_sample_relative = (int32_t)((int64_t)grb.timestamp - (int64_t)timestamp_sample);
+
 	/* Accel report: */
 	arb.x_raw = report.accel_x;
 	arb.y_raw = report.accel_y;
@@ -1495,6 +1498,8 @@ ADIS16448::measure()
 
 	arb.scaling = _accel_range_scale;
 	arb.range_m_s2 = _accel_range_m_s2;
+
+	arb.timestamp_sample_relative = (int32_t)((int64_t)arb.timestamp - (int64_t)timestamp_sample);
 
 	/* Mag report: */
 	mrb.x_raw = report.mag_x;
@@ -1536,7 +1541,7 @@ ADIS16448::measure()
 	math::Vector<3> aval(x_in_new, y_in_new, z_in_new);
 	math::Vector<3> aval_integrated;
 
-	bool accel_notify = _accel_int.put(arb.timestamp, aval, aval_integrated, arb.integral_dt);
+	bool accel_notify = _accel_int.put(timestamp_sample, aval, aval_integrated, arb.integral_dt, arb.timestamp);
 	arb.x_integral = aval_integrated(0);
 	arb.y_integral = aval_integrated(1);
 	arb.z_integral = aval_integrated(2);
@@ -1544,7 +1549,7 @@ ADIS16448::measure()
 	math::Vector<3> gval(x_gyro_in_new, y_gyro_in_new, z_gyro_in_new);
 	math::Vector<3> gval_integrated;
 
-	bool gyro_notify = _gyro_int.put(grb.timestamp, gval, gval_integrated, grb.integral_dt);
+	bool gyro_notify = _gyro_int.put(timestamp_sample, gval, gval_integrated, grb.integral_dt, grb.timestamp);
 	grb.x_integral = gval_integrated(0);
 	grb.y_integral = gval_integrated(1);
 	grb.z_integral = gval_integrated(2);

--- a/src/drivers/imu/bmi055/bmi055_accel.cpp
+++ b/src/drivers/imu/bmi055/bmi055_accel.cpp
@@ -717,9 +717,7 @@ BMI055_accel::measure()
 	 */
 	accel_report        arb;
 
-
-	arb.timestamp = hrt_absolute_time();
-
+	uint64_t timestamp_sample = hrt_absolute_time();
 
 	// report the error count as the sum of the number of bad
 	// transfers and bad register reads. This allows the higher
@@ -761,7 +759,7 @@ BMI055_accel::measure()
 	math::Vector<3> aval(x_in_new, y_in_new, z_in_new);
 	math::Vector<3> aval_integrated;
 
-	bool accel_notify = _accel_int.put(arb.timestamp, aval, aval_integrated, arb.integral_dt);
+	bool accel_notify = _accel_int.put(timestamp_sample, aval, aval_integrated, arb.integral_dt, arb.timestamp);
 	arb.x_integral = aval_integrated(0);
 	arb.y_integral = aval_integrated(1);
 	arb.z_integral = aval_integrated(2);
@@ -773,6 +771,9 @@ BMI055_accel::measure()
 
 	arb.temperature_raw = report.temp;
 	arb.temperature = _last_temperature;
+
+	arb.timestamp_sample_relative = (int32_t)((int64_t)arb.timestamp - (int64_t)timestamp_sample);
+
 	arb.device_id = _device_id.devid;
 
 	_accel_reports->force(&arb);

--- a/src/drivers/imu/bmi055/bmi055_gyro.cpp
+++ b/src/drivers/imu/bmi055/bmi055_gyro.cpp
@@ -687,8 +687,7 @@ BMI055_gyro::measure()
 	 */
 	gyro_report     grb;
 
-
-	grb.timestamp =  hrt_absolute_time();
+	uint64_t timestamp_sample = hrt_absolute_time();
 
 	// report the error count as the sum of the number of bad
 	// transfers and bad register reads. This allows the higher
@@ -733,7 +732,7 @@ BMI055_gyro::measure()
 	math::Vector<3> gval(x_gyro_in_new, y_gyro_in_new, z_gyro_in_new);
 	math::Vector<3> gval_integrated;
 
-	bool gyro_notify = _gyro_int.put(grb.timestamp, gval, gval_integrated, grb.integral_dt);
+	bool gyro_notify = _gyro_int.put(timestamp_sample, gval, gval_integrated, grb.integral_dt, grb.timestamp);
 	grb.x_integral = gval_integrated(0);
 	grb.y_integral = gval_integrated(1);
 	grb.z_integral = gval_integrated(2);
@@ -743,6 +742,9 @@ BMI055_gyro::measure()
 
 	grb.temperature_raw = report.temp;
 	grb.temperature = _last_temperature;
+
+	grb.timestamp_sample_relative = (int32_t)((int64_t)grb.timestamp - (int64_t)timestamp_sample);
+
 	grb.device_id = _device_id.devid;
 
 	_gyro_reports->force(&grb);

--- a/src/drivers/imu/l3gd20/l3gd20.cpp
+++ b/src/drivers/imu/l3gd20/l3gd20.cpp
@@ -983,7 +983,7 @@ L3GD20::measure()
 	 *	 	  the offset is 74 from the origin and subtracting
 	 *		  74 from all measurements centers them around zero.
 	 */
-	report.timestamp = hrt_absolute_time();
+	uint64_t timestamp_sample = hrt_absolute_time();
 	report.error_count = perf_event_count(_bad_registers);
 
 	switch (_orientation) {
@@ -1035,7 +1035,7 @@ L3GD20::measure()
 	math::Vector<3> gval(xin, yin, zin);
 	math::Vector<3> gval_integrated;
 
-	bool gyro_notify = _gyro_int.put(report.timestamp, gval, gval_integrated, report.integral_dt);
+	bool gyro_notify = _gyro_int.put(timestamp_sample, gval, gval_integrated, report.integral_dt, report.timestamp);
 	report.x_integral = gval_integrated(0);
 	report.y_integral = gval_integrated(1);
 	report.z_integral = gval_integrated(2);
@@ -1044,6 +1044,8 @@ L3GD20::measure()
 
 	report.scaling = _gyro_range_scale;
 	report.range_rad_s = _gyro_range_rad_s;
+
+	report.timestamp_sample_relative = (int32_t)((int64_t)report.timestamp - (int64_t)timestamp_sample);
 
 	/* return device ID */
 	report.device_id = _device_id.devid;

--- a/src/drivers/imu/mpu6000/mpu6000.cpp
+++ b/src/drivers/imu/mpu6000/mpu6000.cpp
@@ -1964,7 +1964,7 @@ MPU6000::measure()
 	/*
 	 * Adjust and scale results to m/s^2.
 	 */
-	grb.timestamp = arb.timestamp = hrt_absolute_time();
+	uint64_t timestamp_sample = hrt_absolute_time();
 
 	// report the error count as the sum of the number of bad
 	// transfers and bad register reads. This allows the higher
@@ -2012,7 +2012,7 @@ MPU6000::measure()
 	math::Vector<3> aval(x_in_new, y_in_new, z_in_new);
 	math::Vector<3> aval_integrated;
 
-	bool accel_notify = _accel_int.put(arb.timestamp, aval, aval_integrated, arb.integral_dt);
+	bool accel_notify = _accel_int.put(timestamp_sample, aval, aval_integrated, arb.integral_dt, arb.timestamp);
 	arb.x_integral = aval_integrated(0);
 	arb.y_integral = aval_integrated(1);
 	arb.z_integral = aval_integrated(2);
@@ -2029,6 +2029,8 @@ MPU6000::measure()
 
 	arb.temperature_raw = report.temp;
 	arb.temperature = _last_temperature;
+
+	arb.timestamp_sample_relative = (int32_t)((int64_t)arb.timestamp - (int64_t)timestamp_sample);
 
 	/* return device ID */
 	arb.device_id = _device_id.devid;
@@ -2055,7 +2057,7 @@ MPU6000::measure()
 	math::Vector<3> gval(x_gyro_in_new, y_gyro_in_new, z_gyro_in_new);
 	math::Vector<3> gval_integrated;
 
-	bool gyro_notify = _gyro_int.put(arb.timestamp, gval, gval_integrated, grb.integral_dt);
+	bool gyro_notify = _gyro_int.put(timestamp_sample, gval, gval_integrated, grb.integral_dt, grb.timestamp);
 	grb.x_integral = gval_integrated(0);
 	grb.y_integral = gval_integrated(1);
 	grb.z_integral = gval_integrated(2);
@@ -2065,6 +2067,8 @@ MPU6000::measure()
 
 	grb.temperature_raw = report.temp;
 	grb.temperature = _last_temperature;
+
+	grb.timestamp_sample_relative = (int32_t)((int64_t)grb.timestamp - (int64_t)timestamp_sample);
 
 	/* return device ID */
 	grb.device_id = _gyro->_device_id.devid;

--- a/src/drivers/imu/mpu9250/mpu9250.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250.cpp
@@ -1379,7 +1379,7 @@ MPU9250::measure()
 	/*
 	 * Adjust and scale results to m/s^2.
 	 */
-	grb.timestamp = arb.timestamp = hrt_absolute_time();
+	uint64_t timestamp_sample = hrt_absolute_time();
 
 	// report the error count as the sum of the number of bad
 	// transfers and bad register reads. This allows the higher
@@ -1403,7 +1403,6 @@ MPU9250::measure()
 	 */
 
 	/* NOTE: Axes have been swapped to match the board a few lines above. */
-
 	arb.x_raw = report.accel_x;
 	arb.y_raw = report.accel_y;
 	arb.z_raw = report.accel_z;
@@ -1426,7 +1425,7 @@ MPU9250::measure()
 	math::Vector<3> aval(x_in_new, y_in_new, z_in_new);
 	math::Vector<3> aval_integrated;
 
-	bool accel_notify = _accel_int.put(arb.timestamp, aval, aval_integrated, arb.integral_dt);
+	bool accel_notify = _accel_int.put(timestamp_sample, aval, aval_integrated, arb.integral_dt, arb.timestamp);
 	arb.x_integral = aval_integrated(0);
 	arb.y_integral = aval_integrated(1);
 	arb.z_integral = aval_integrated(2);
@@ -1438,6 +1437,8 @@ MPU9250::measure()
 
 	arb.temperature_raw = report.temp;
 	arb.temperature = _last_temperature;
+	
+	arb.timestamp_sample_relative = (int32_t)((int64_t)arb.timestamp - (int64_t)timestamp_sample);
 
 	/* return device ID */
 	arb.device_id = _device_id.devid;
@@ -1464,7 +1465,7 @@ MPU9250::measure()
 	math::Vector<3> gval(x_gyro_in_new, y_gyro_in_new, z_gyro_in_new);
 	math::Vector<3> gval_integrated;
 
-	bool gyro_notify = _gyro_int.put(arb.timestamp, gval, gval_integrated, grb.integral_dt);
+	bool gyro_notify = _gyro_int.put(timestamp_sample, gval, gval_integrated, grb.integral_dt, grb.timestamp);
 	grb.x_integral = gval_integrated(0);
 	grb.y_integral = gval_integrated(1);
 	grb.z_integral = gval_integrated(2);
@@ -1474,6 +1475,8 @@ MPU9250::measure()
 
 	grb.temperature_raw = report.temp;
 	grb.temperature = _last_temperature;
+
+	grb.timestamp_sample_relative = (int32_t)((int64_t)grb.timestamp - (int64_t)timestamp_sample);
 
 	/* return device ID */
 	grb.device_id = _gyro->_device_id.devid;


### PR DESCRIPTION
I had been chasing an issue where VIO would perform badly when running on the integral data from `sensor_combined`. If you switched to the "raw" fields from it, VIO would work. (Hacky, since the raw data is not rotated, scale/offset compensated, etc.) However, for VIO, it is better to use scale, offset and thermal compensated integral values from a data quality perspective.

It turns out that the timestamp in `sensor_accel` and `sensor_gyro` correspond to that of the last raw value pushed to the integrator (this is why switching to the raw values worked well). I think that this is not good, since at a 250Hz integration rate, a 1.5ms delay is introduced with respect to the "average" measurement.

This PR extends the integrator API to compute an average timestamp for the data. The timestamp of the last raw sample (only used in 1 place in the rate controller) is moved to a `timestamp_sample_relative` field.

Does this make sense? @bkueng @ChristophTobler @dagar @LorenzMeier Comments appreciated.
In the longer term, @dagar and I are working to split the sensor messages so that we can run the IMU topics at higher rate than integrator rate. This PR is just to get some feedback on the integrator timestamping part of things.

TODO : 
 [ ] Fix all IMU drivers to use the modified API.