### PR TITLE
rc.sensors : fix startup for lidars on Pixhawk boards

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -397,7 +397,7 @@ fi
 # Benewake TFMini
 if param greater SENS_EN_TFMINI 0
 then
-	if ver hwcmp PX4FMU_V3
+	if ver hwcmp PX4FMU_V2 PX4FMU_V4PRO
 	then
 		# start the driver on serial 4/5
 		tfmini start -d /dev/ttyS6
@@ -419,7 +419,7 @@ fi
 # LeddarOne
 if param greater SENS_EN_LEDDAR1 0
 then
-	if ver hwcmp PX4FMU_V3
+	if ver hwcmp PX4FMU_V2 PX4FMU_V4PRO
 	then
 		# start the driver on serial 4/5
 		leddar_one -d /dev/ttyS6 start


### PR DESCRIPTION
The check was not changed back to PX4FMU_V2 after we merged V3 and V2 configs.

This is a hotfix till we actually properly structure this whole sensors startup mess. This current way does not scale well as we add new boards and/or drivers.