### PR TITLE
Multicopter mixer saturation handling strategy -- continue

### DIFF
--- a/src/drivers/pwm_out_sim/PWMSim.hpp
+++ b/src/drivers/pwm_out_sim/PWMSim.hpp
@@ -49,6 +49,7 @@
 #include <uORB/topics/actuator_armed.h>
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/actuator_outputs.h>
+#include <uORB/topics/parameter_update.h>
 
 class PWMSim : public device::CDev, public ModuleBase<PWMSim>
 {
@@ -129,10 +130,13 @@ private:
 	actuator_controls_s _controls[actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS] {};
 	orb_id_t	_control_topics[actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS] {};
 
+	bool 	_airmode{false}; 	///< multicopter air-mode
+
 	static int	control_callback(uintptr_t handle, uint8_t control_group, uint8_t control_index, float &input);
 
 	void 	subscribe();
 
+	void 	update_params();
 };
 
 #endif /* DRIVERS_PWM_OUT_SIM_PWMSIM_HPP_ */

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1294,7 +1294,6 @@ PX4FMU::cycle()
 					// factor 2 is needed because actuator outputs are in the range [-1,1]
 					const float delta_out_max = 2.0f * 1000.0f * dt / (_max_pwm[0] - _min_pwm[0]) / _mot_t_max;
 					_mixers->set_max_delta_out_once(delta_out_max);
-					_mixers->set_airmode(_airmode);
 				}
 
 				if (_thr_mdl_fac > FLT_EPSILON) {
@@ -1362,6 +1361,8 @@ PX4FMU::cycle()
 					orb_publish_auto(ORB_ID(multirotor_motor_limits), &_to_mixer_status, &motor_limits, &_class_instance,
 							 ORB_PRIO_DEFAULT);
 				}
+
+				_mixers->set_airmode(_airmode);
 
 				perf_end(_ctl_latency);
 			}
@@ -1791,7 +1792,7 @@ void PX4FMU::update_params()
 	param_handle = param_find("MC_AIRMODE");
 
 	if (param_handle != PARAM_INVALID) {
-		int val;
+		int32_t val;
 		param_get(param_handle, &val);
 		_airmode = val > 0;
 		PX4_DEBUG("%s: %d", "MC_AIRMODE", _airmode);

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1221,6 +1221,14 @@ PX4IO::task_main()
 					param_get(parm_handle, &param_val);
 					(void)io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_MOTOR_SLEW_MAX, FLOAT_TO_REG(param_val));
 				}
+
+				/* air-mode */
+				parm_handle = param_find("MC_AIRMODE");
+
+				if (parm_handle != PARAM_INVALID) {
+					param_get(parm_handle, &param_val);
+					(void)io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_AIRMODE, SIGNED_TO_REG(param_val));
+				}
 			}
 
 		}

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1226,8 +1226,9 @@ PX4IO::task_main()
 				parm_handle = param_find("MC_AIRMODE");
 
 				if (parm_handle != PARAM_INVALID) {
-					param_get(parm_handle, &param_val);
-					(void)io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_AIRMODE, SIGNED_TO_REG(param_val));
+					int32_t param_val_int;
+					param_get(parm_handle, &param_val_int);
+					(void)io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_AIRMODE, SIGNED_TO_REG(param_val_int));
 				}
 			}
 

--- a/src/lib/mixer/mixer.h
+++ b/src/lib/mixer/mixer.h
@@ -218,6 +218,13 @@ public:
 	 */
 	virtual void 			set_thrust_factor(float val) {}
 
+	/**
+	 * @brief Set airmode. Airmode allows the mixer to increase the total thrust in order to unsaturate the motors.
+	 *
+	 * @param[in]  airmode   Dis/-activate airmode by setting it to false/true
+	 */
+	virtual void set_airmode(bool airmode) {};
+
 protected:
 	/** client-supplied callback used when fetching control values */
 	ControlCallback			_control_cb;
@@ -402,6 +409,8 @@ public:
 	 * @param[in]  val   The value
 	 */
 	virtual void	set_thrust_factor(float val);
+
+	virtual void 	set_airmode(bool airmode);
 
 private:
 	Mixer				*_first;	/**< linked list of mixers */
@@ -650,6 +659,8 @@ public:
 	 */
 	virtual void			set_thrust_factor(float val) {_thrust_factor = val;}
 
+	virtual void 			set_airmode(bool airmode);
+
 	union saturation_status {
 		struct {
 			uint16_t valid		: 1; // 0 - true when the saturation status is used
@@ -674,6 +685,8 @@ private:
 	float				_idle_speed;
 	float 				_delta_out_max;
 	float 				_thrust_factor;
+
+	bool                		_airmode;
 
 	void update_saturation_status(unsigned index, bool clipping_high, bool clipping_low);
 	saturation_status _saturation_status;

--- a/src/lib/mixer/mixer.h
+++ b/src/lib/mixer/mixer.h
@@ -221,7 +221,7 @@ public:
 	/**
 	 * @brief Set airmode. Airmode allows the mixer to increase the total thrust in order to unsaturate the motors.
 	 *
-	 * @param[in]  airmode   Dis/-activate airmode by setting it to false/true
+	 * @param[in]  airmode   De/-activate airmode by setting it to false/true
 	 */
 	virtual void set_airmode(bool airmode) {};
 

--- a/src/lib/mixer/mixer_group.cpp
+++ b/src/lib/mixer/mixer_group.cpp
@@ -185,7 +185,17 @@ MixerGroup::set_thrust_factor(float val)
 		mixer->set_thrust_factor(val);
 		mixer = mixer->_next;
 	}
+}
 
+void
+MixerGroup::set_airmode(bool airmode)
+{
+	Mixer	*mixer = _first;
+
+	while (mixer != nullptr) {
+		mixer->set_airmode(airmode);
+		mixer = mixer->_next;
+	}
 }
 
 uint16_t

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -210,15 +210,7 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 	// TODO: revise the saturation/boosting strategy
 
 	if (min_out < 0.0f && max_out < 1.0f && -min_out <= 1.0f - max_out) {
-		float max_thrust_diff = thrust * thrust_increase_factor - thrust;
-
-		if (max_thrust_diff >= -min_out) {
-			boost = -min_out;
-
-		} else {
-			boost = max_thrust_diff;
-			roll_pitch_scale = (thrust + boost) / (thrust - min_out);
-		}
+		boost = -min_out;
 
 	} else if (max_out > 1.0f && min_out > 0.0f && min_out >= max_out - 1.0f) {
 		float max_thrust_diff = thrust - thrust_decrease_factor * thrust;

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -209,10 +209,10 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 	// which may result in motor saturation after thrust boost is applied
 	// TODO: revise the saturation/boosting strategy
 
-	if (min_out < 0.0f && max_out < 1.0f && -min_out <= 1.0f - max_out) {
+	if (min_out < 0.0f && max_out < 1.0f && max_out - min_out <= 1.0f) {
 		boost = -min_out;
 
-	} else if (max_out > 1.0f && min_out > 0.0f && min_out >= max_out - 1.0f) {
+	} else if (max_out > 1.0f && min_out > 0.0f && max_out - min_out <= 1.0f) {
 		float max_thrust_diff = thrust - thrust_decrease_factor * thrust;
 
 		if (max_thrust_diff >= max_out - 1.0f) {
@@ -223,12 +223,12 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 			roll_pitch_scale = (1 - (thrust + boost)) / (max_out - thrust);
 		}
 
-	} else if (min_out < 0.0f && max_out < 1.0f && -min_out > 1.0f - max_out) {
+	} else if (min_out < 0.0f && max_out < 1.0f && max_out - min_out > 1.0f) {
 		float max_thrust_diff = thrust * thrust_increase_factor - thrust;
 		boost = math::constrain(-min_out - (1.0f - max_out) / 2.0f, 0.0f, max_thrust_diff);
 		roll_pitch_scale = (thrust + boost) / (thrust - min_out);
 
-	} else if (max_out > 1.0f && min_out > 0.0f && min_out < max_out - 1.0f) {
+	} else if (max_out > 1.0f && min_out > 0.0f && max_out - min_out > 1.0f) {
 		float max_thrust_diff = thrust - thrust_decrease_factor * thrust;
 		boost = math::constrain(-(max_out - 1.0f - min_out) / 2.0f, -max_thrust_diff, 0.0f);
 		roll_pitch_scale = (1 - (thrust + boost)) / (max_out - thrust);

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -179,10 +179,6 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 	// clean out class variable used to capture saturation
 	_saturation_status.value = 0;
 
-	// thrust boost parameters
-	float thrust_increase_factor = 1.5f;
-	float thrust_decrease_factor = 0.6f;
-
 	/* perform initial mix pass yielding unbounded outputs, ignore yaw */
 	for (unsigned i = 0; i < _rotor_count; i++) {
 		float out = roll * _rotors[i].roll_scale +
@@ -216,18 +212,15 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 		boost = -(max_out - 1.0f);
 
 	} else if (min_out < 0.0f && max_out < 1.0f && max_out - min_out > 1.0f) {
-		float max_thrust_diff = thrust * thrust_increase_factor - thrust;
-		boost = math::constrain(-min_out - (1.0f - max_out) / 2.0f, 0.0f, max_thrust_diff);
+		boost = -min_out - (1.0f - max_out) / 2.0f;
 		roll_pitch_scale = (thrust + boost) / (thrust - min_out);
 
 	} else if (max_out > 1.0f && min_out > 0.0f && max_out - min_out > 1.0f) {
-		float max_thrust_diff = thrust - thrust_decrease_factor * thrust;
-		boost = math::constrain(-(max_out - 1.0f - min_out) / 2.0f, -max_thrust_diff, 0.0f);
+		boost = -(max_out - min_out - 1.0f) / 2.0f;
 		roll_pitch_scale = (1 - (thrust + boost)) / (max_out - thrust);
 
 	} else if (min_out < 0.0f && max_out > 1.0f) {
-		boost = math::constrain(-(max_out - 1.0f + min_out) / 2.0f, thrust_decrease_factor * thrust - thrust,
-					thrust_increase_factor * thrust - thrust);
+		boost = -(max_out - 1.0f + min_out) / 2.0f;
 		roll_pitch_scale = (thrust + boost) / (thrust - min_out);
 	}
 

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -213,15 +213,7 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 		boost = -min_out;
 
 	} else if (max_out > 1.0f && min_out > 0.0f && max_out - min_out <= 1.0f) {
-		float max_thrust_diff = thrust - thrust_decrease_factor * thrust;
-
-		if (max_thrust_diff >= max_out - 1.0f) {
-			boost = -(max_out - 1.0f);
-
-		} else {
-			boost = -max_thrust_diff;
-			roll_pitch_scale = (1 - (thrust + boost)) / (max_out - thrust);
-		}
+		boost = -(max_out - 1.0f);
 
 	} else if (min_out < 0.0f && max_out < 1.0f && max_out - min_out > 1.0f) {
 		float max_thrust_diff = thrust * thrust_increase_factor - thrust;

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -220,13 +220,13 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 		}
 
 	} else {
-		roll_pitch_scale = 1 / (delta_out_max);
+		roll_pitch_scale = 1.0f / (delta_out_max);
 		boost = 1.0f - ((max_out - thrust) * roll_pitch_scale + thrust);
 	}
 
 	if (!_airmode) {
 		// disable positive boosting if not in air-mode
-		// boosting is positive when min_out < 0.0
+		// boosting can only be positive when min_out < 0.0
 		// roll_pitch_scale is reduced accordingly
 		if (boost > 0.0f) {
 			roll_pitch_scale = thrust / (thrust - min_out);

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -207,8 +207,8 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 	// Otherwise, a scaler is computed to make the distance between the two extrema exacly 1.0 and the boost
 	// value is computed to maximize the roll-pitch control.
 	//
-	// Note: thrust boost is computed assuming thrust_gain==1 for all motors.
-	// On asymmetric platforms, some motors have thrust_gain<1,
+	// Note: thrust boost is computed assuming thrust_scale==1 for all motors.
+	// On asymmetric platforms, some motors have thrust_scale<1,
 	// which may result in motor saturation after thrust boost is applied
 	// TODO: revise the saturation/boosting strategy
 	if (delta_out_max <= 1.0f) {

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -217,7 +217,6 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 
 		} else if (max_out > 1.0f) {
 			boost = -(max_out - 1.0f);
-
 		}
 
 	} else {
@@ -226,7 +225,13 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 	}
 
 	if (!_airmode) {
-		boost = math::min(boost, 0.0f); // Disable positive boosting if not in air-mode
+		// disable positive boosting if not in air-mode
+		// boosting is positive when min_out < 0.0
+		// roll_pitch_scale is reduced accordingly
+		if (boost > 0.0f) {
+			roll_pitch_scale = thrust / (thrust - min_out);
+			boost = 0.0f;
+		}
 	}
 
 	// capture saturation

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -220,7 +220,7 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 		}
 
 	} else {
-		roll_pitch_scale = 1 / (max_out - min_out);
+		roll_pitch_scale = 1 / (delta_out_max);
 		boost = 1.0f - ((max_out - thrust) * roll_pitch_scale + thrust);
 	}
 

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -84,6 +84,7 @@ MultirotorMixer::MultirotorMixer(ControlCallback control_cb,
 	_idle_speed(-1.0f + idle_speed * 2.0f),	/* shift to output range here to avoid runtime calculation */
 	_delta_out_max(0.0f),
 	_thrust_factor(0.0f),
+	_airmode(false),
 	_rotor_count(_config_rotor_count[(MultirotorGeometryUnderlyingType)geometry]),
 	_rotors(_config_index[(MultirotorGeometryUnderlyingType)geometry]),
 	_outputs_prev(new float[_rotor_count])
@@ -224,6 +225,9 @@ MultirotorMixer::mix(float *outputs, unsigned space)
 		boost = 1.0f - ((max_out - thrust) * roll_pitch_scale + thrust);
 	}
 
+	if (!_airmode) {
+		boost = math::min(boost, 0.0f); // Disable positive boosting if not in air-mode
+	}
 
 	// capture saturation
 	if (min_out < 0.0f) {
@@ -423,6 +427,12 @@ MultirotorMixer::update_saturation_status(unsigned index, bool clipping_high, bo
 	}
 
 	_saturation_status.flags.valid = true;
+}
+
+void
+MultirotorMixer::set_airmode(bool airmode)
+{
+	_airmode = airmode;
 }
 
 void

--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -547,7 +547,7 @@ PARAM_DEFINE_FLOAT(MC_DTERM_CUTOFF, 0.f);
 /**
  * Multicopter air-mode
  *
- * The air-mode enables the mixer to increase or decrease the total thrust of the multirotor
+ * The air-mode enables the mixer to increase the total thrust of the multirotor
  * in order to keep attitude and rate control even at low and high throttle.
  * This function should be disabled during tuning as it will help the controller
  * to diverge if the closed-loop is unstable.

--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -542,4 +542,18 @@ PARAM_DEFINE_FLOAT(MC_TPA_RATE_D, 0.0f);
  * @increment 10
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MC_DTERM_CUTOFF, 30.f);
+PARAM_DEFINE_FLOAT(MC_DTERM_CUTOFF, 0.f);
+
+/**
+ * Multicopter air-mode
+ *
+ * The air-mode enables the mixer to increase or decrease the total thrust of the multirotor
+ * in order to keep attitude and rate control even at low and high throttle.
+ * This function should be disabled during tuning as it will help the controller
+ * to diverge if the closed-loop is unstable.
+ *
+ * @boolean
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_INT32(MC_AIRMODE, 0);
+

--- a/src/modules/px4iofirmware/mixer.cpp
+++ b/src/modules/px4iofirmware/mixer.cpp
@@ -254,6 +254,11 @@ mixer_tick(void)
 	 */
 	mixer_group.set_trims(r_page_servo_control_trim, PX4IO_SERVO_COUNT);
 
+	/*
+	 * Update air-mode parameter
+	 */
+	mixer_group.set_airmode(REG_TO_BOOL(r_setup_airmode));
+
 
 	/*
 	 * Run the mixers.

--- a/src/modules/px4iofirmware/protocol.h
+++ b/src/modules/px4iofirmware/protocol.h
@@ -78,6 +78,8 @@
 #define REG_TO_FLOAT(_reg)	((float)REG_TO_SIGNED(_reg) / 10000.0f)
 #define FLOAT_TO_REG(_float)	SIGNED_TO_REG((int16_t)floorf((_float + 0.00005f) * 10000.0f))
 
+#define REG_TO_BOOL(_reg) 	((bool)(_reg))
+
 #define PX4IO_PROTOCOL_VERSION		4
 
 /* maximum allowable sizes on this protocol version */
@@ -231,6 +233,8 @@ enum {							/* DSM bind states */
 #define PX4IO_P_SETUP_SBUS_RATE			22	/* frame rate of SBUS1 output in Hz */
 
 #define PX4IO_P_SETUP_MOTOR_SLEW_MAX		24 	/* max motor slew rate */
+
+#define PX4IO_P_SETUP_AIRMODE 			27 	/* air-mode */
 
 #define PX4IO_P_SETUP_THR_MDL_FAC 		25	/* factor for modelling static pwm output to thrust relationship */
 

--- a/src/modules/px4iofirmware/px4io.h
+++ b/src/modules/px4iofirmware/px4io.h
@@ -132,6 +132,7 @@ extern uint16_t			r_page_servo_disarmed[];	/* PX4IO_PAGE_DISARMED_PWM */
 #define r_setup_sbus_rate	r_page_setup[PX4IO_P_SETUP_SBUS_RATE]
 #define r_setup_thr_fac		r_page_setup[PX4IO_P_SETUP_THR_MDL_FAC]
 #define r_setup_slew_max	r_page_setup[PX4IO_P_SETUP_MOTOR_SLEW_MAX]
+#define r_setup_airmode		r_page_setup[PX4IO_P_SETUP_AIRMODE]
 
 #define r_control_values	(&r_page_controls[0])
 

--- a/src/modules/px4iofirmware/registers.c
+++ b/src/modules/px4iofirmware/registers.c
@@ -178,6 +178,7 @@ volatile uint16_t	r_page_setup[] = {
 	[PX4IO_P_SETUP_SCALE_PITCH] = 10000,
 	[PX4IO_P_SETUP_SCALE_YAW] = 10000,
 	[PX4IO_P_SETUP_MOTOR_SLEW_MAX] = 0,
+	[PX4IO_P_SETUP_AIRMODE] = 0,
 	[PX4IO_P_SETUP_THR_MDL_FAC] = 0,
 	[PX4IO_P_SETUP_THERMAL] = PX4IO_THERMAL_IGNORE
 };
@@ -702,6 +703,10 @@ registers_set_one(uint8_t page, uint8_t offset, uint16_t value)
 		case PX4IO_P_SETUP_SBUS_RATE:
 			r_page_setup[offset] = value;
 			sbus1_set_output_rate_hz(value);
+			break;
+
+		case PX4IO_P_SETUP_AIRMODE:
+			r_page_setup[PX4IO_P_SETUP_AIRMODE] = value;
 			break;
 
 		case PX4IO_P_SETUP_THR_MDL_FAC:

--- a/src/modules/uavcan/uavcan_main.cpp
+++ b/src/modules/uavcan/uavcan_main.cpp
@@ -417,6 +417,20 @@ int  UavcanNode::get_param(int remote_node_id, const char *name)
 	return rv;
 }
 
+void UavcanNode::update_params()
+{
+    param_t param_handle;
+
+    // multicopter air-mode
+    param_handle = param_find("MC_AIRMODE");
+
+    if (param_handle != PARAM_INVALID) {
+	    int val;
+	    param_get(param_handle, &val);
+	    _airmode = val > 0;
+    }
+}
+
 int UavcanNode::start_fw_server()
 {
 	int rv = -1;
@@ -821,6 +835,8 @@ int UavcanNode::run()
 
 	while (!_task_should_exit) {
 
+		update_params();
+
 		switch (_fw_server_action) {
 		case Start:
 			_fw_server_status = start_fw_server();
@@ -907,6 +923,8 @@ int UavcanNode::run()
 				// XXX one output group has 8 outputs max,
 				// but this driver could well serve multiple groups.
 				unsigned num_outputs_max = 8;
+
+				_mixers->set_airmode(_airmode);
 
 				// Do mixing
 				_outputs.noutputs = _mixers->mix(&_outputs.output[0], num_outputs_max);

--- a/src/modules/uavcan/uavcan_main.hpp
+++ b/src/modules/uavcan/uavcan_main.hpp
@@ -152,6 +152,7 @@ private:
 	int		request_fw_check();
 	int		print_params(uavcan::protocol::param::GetSet::Response &resp);
 	int		get_set_param(int nodeid, const char *name, uavcan::protocol::param::GetSet::Request &req);
+	void 		update_params();
 	void		set_setget_response(uavcan::protocol::param::GetSet::Response *resp)
 	{
 		_setget_response = resp;
@@ -206,6 +207,8 @@ private:
 	actuator_direct_s		_actuator_direct = {};
 
 	actuator_outputs_s		_outputs = {};
+
+	bool 				_airmode = false;
 
 	// index into _poll_fds for each _control_subs handle
 	uint8_t				_poll_ids[NUM_ACTUATOR_CONTROL_GROUPS_UAVCAN];


### PR DESCRIPTION
Follows #7920
Rebased onto master

Works on:
- [x] FMU
- [x] IO
- [x] UAVCAN
- [x] Linux
- [x] Sim
- [x] Snapdragon

When MC_AIRMODE is disabled, it is possible to tune the attitude/rate controllers really safely since no positive boosting will be applied by the mixer. This has the consequence to be able to cut completely the throttle of all the motors (idle) if the RC throttle is at zero.