### PR TITLE
[RFC] Adds the ability to add additional optional files to the ROMFS at compile time

### DIFF
--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -69,6 +69,23 @@ endfunction()
 # get list of all ROMFS files
 add_subdirectory(${romfs_src_dir})
 
+# Copy the optional files into ROMFS
+if (DEFINED romfs_optional_files)
+	set(optional_files)
+	message(STATUS "The ROMFS optional files: ${romfs_optional_files}")
+	foreach(optional_file ${romfs_optional_files})
+		get_filename_component(file_name ${optional_file} NAME)
+		set(file_dest ${romfs_temp_dir}/extras/${file_name})
+		add_custom_command(OUTPUT ${file_dest}
+			COMMAND mkdir -p ${romfs_temp_dir}/extras/
+			COMMAND cmake -E copy ${optional_file} ${file_dest}
+			DEPENDS ${optional_file}
+			COMMENT "Adding extra ROMFS file: ${optional_file}"
+			)
+		list(APPEND optional_files ${file_dest})
+	endforeach()
+endif()
+
 # directory setup
 # copy all romfs files, process airframes, prune comments
 add_custom_command(OUTPUT ${romfs_temp_dir}/init.d/rcS ${romfs_temp_dir}/init.d/rc.autostart
@@ -83,6 +100,7 @@ add_custom_command(OUTPUT ${romfs_temp_dir}/init.d/rcS ${romfs_temp_dir}/init.d/
 		${config_romfs_files_list}
 		${PX4_SOURCE_DIR}/ROMFS/${config_romfs_root}/init.d/rcS
 		${PX4_SOURCE_DIR}/Tools/px_process_airframes.py
+		${optional_files}
 	)
 
 set(romfs_dependencies)


### PR DESCRIPTION
I don't know whether this is a useful feature for the rest of the Px4 community. I find it useful to copy in some "default" files for particular builds into the ROMFS.

When the ROMFS is built/compiled, the files listed in the romfs_optional_files
variable are copied into the ROMFS/px4fmu_common/extras directory within the build directory.

Once the firmware is uploaded, these ROMFS files are present in the etc/extras/ directory
on the Px4 board.

The romfs_optional_files variable is set in the board-specific cmake file (e.g. nuttx_px4fmu-v3_default.cmake). Add the following to the cmake file to add optional extra files to the ROMFS:

```
set(romfs_optional_files
<path to file 1>
<path to file 2>
<path to file 3>
...
)
```