### PR TITLE
Fix: Increase pwmsim stack again to avoid load_mon warning

### DIFF
--- a/src/drivers/pwm_out_sim/PWMSim.cpp
+++ b/src/drivers/pwm_out_sim/PWMSim.cpp
@@ -536,7 +536,7 @@ PWMSim::task_spawn(int argc, char *argv[])
 	_task_id = px4_task_spawn_cmd("pwmsim",
 				      SCHED_DEFAULT,
 				      SCHED_PRIORITY_ACTUATOR_OUTPUTS,
-				      1000,
+				      1100,
 				      (px4_main_t)&run_trampoline,
 				      nullptr);
 


### PR DESCRIPTION
#### Issue: 
PR https://github.com/PX4/Firmware/pull/9007 decreased the stack size of the pwmsim module, however, the load_mon app now gives a "pwmsim low on stack warning" when running HIL using the current master branch (pwm sim has 1000->980 bytes stack, and needs ca 736 bytes, the load_mon required stack size margin is 300 bytes). I used px4fmu-v2 with rev. 3 silicon, but that should not matter.

#### Solutions:
1) Apply this PR -> Done
2) Decrease the required stack size margin in load_mon

@dagar @LorenzMeier Your decision.