### PR TITLE
Update IMU gyro and D term filter defaults

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -570,4 +570,4 @@ PARAM_DEFINE_FLOAT(MC_TPA_RATE_D, 0.0f);
  * @increment 10
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MC_DTERM_CUTOFF, 0.f);
+PARAM_DEFINE_FLOAT(MC_DTERM_CUTOFF, 30.f);

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -248,7 +248,7 @@ PARAM_DEFINE_INT32(SENS_EN_THERMAL, -1);
 * @reboot_required true
 * @group Sensors
 */
-PARAM_DEFINE_FLOAT(IMU_GYRO_CUTOFF, 30.0f);
+PARAM_DEFINE_FLOAT(IMU_GYRO_CUTOFF, 80.0f);
 
 /**
 * Driver level cutoff frequency for accel


### PR DESCRIPTION
This sets IMU_GYRO_CUTOFF to 80 and enables the D-term filter by setting MC_DTERM_CUTOFF to 30.

Tested on at least 5 different vehicles, including AeroFC. The values should be conservative, good setups (with low vibrations) can increase these values even further.

Increasing IMU_GYRO_CUTOFF allows for better tuning gains.
The next step is to disable/adjust the on-chip filter (https://github.com/PX4/Firmware/pull/8731).

Fixes https://github.com/PX4/Firmware/issues/8962.