### PR TITLE
Adds ability to have out-of-tree uORB message definitions

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -128,6 +128,18 @@ set(msg_files
 	wind_estimate.msg
 	)
 
+if(NOT EXTERNAL_MODULES_LOCATION STREQUAL "")
+	# Check that the msg directory and the CMakeLists.txt file exists
+	if(EXISTS ${EXTERNAL_MODULES_LOCATION}/msg/CMakeLists.txt)
+		add_subdirectory(${EXTERNAL_MODULES_LOCATION}/msg external_msg)
+
+		# Add each of the external message files to the global msg_files list
+		foreach(external_msg_file ${config_msg_list_external})
+			list(APPEND msg_files ${EXTERNAL_MODULES_LOCATION}/msg/${external_msg_file})
+		endforeach()
+	endif()
+endif()
+
 px4_add_git_submodule(TARGET git_gencpp PATH tools/gencpp)
 px4_add_git_submodule(TARGET git_genmsg PATH tools/genmsg)
 


### PR DESCRIPTION
If the EXTERNAL_MODULES_LOCATION variable has been set, and the
EXTERNAL_MODULES_LOCATION/msg/ directory exists containing a
CMakeLists.txt file with the following format:
```
    set(config_msg_list_external
      message1.msg
      message2.msg
      message3.msg
      ...
      PARENT_SCOPE
      )
```
then the messages defined in config_msg_list_external are added to the
msg_files list in Firmware/msg/CMakeLists.txt and are used to generate uORB
message headers. The generated uORB message headers are placed in the same
location as the normal uORB message headers in the build directory, namely,
<build_dir>/uORB/topics. The uORB topic sources are generated in
<build_dir>/msg/topics_sources.

This should help users who do a lot of out-of-tree development. This will keep the custom msg definitions out of the PX4/Firmware tree.