### PR TITLE
px4fmu v2 sensor init (again) and cleanup

### DIFF
--- a/cmake/configs/nuttx_px4fmu-v3_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v3_default.cmake
@@ -19,21 +19,22 @@ set(config_module_list
 	drivers/magnetometer
 	drivers/telemetry
 
-	drivers/imu/adis16448
 	drivers/airspeed
 	drivers/batt_smbus
 	drivers/blinkm
-	drivers/imu/bmi160
 	drivers/boards
 	drivers/camera_trigger
 	drivers/device
 	drivers/gps
-	drivers/irlock
+	drivers/imu/adis16448
+	drivers/imu/bmi160
 	drivers/imu/l3gd20
-	drivers/led
-	drivers/mkblctrl
+	drivers/imu/lsm303d
 	drivers/imu/mpu6000
 	drivers/imu/mpu9250
+	drivers/irlock
+	drivers/led
+	drivers/mkblctrl
 	drivers/oreoled
 	drivers/protocol_splitter
 	drivers/pwm_input

--- a/src/drivers/boards/px4fmu-v2/spi.c
+++ b/src/drivers/boards/px4fmu-v2/spi.c
@@ -82,30 +82,20 @@ static void stm32_spi1_initialize(void)
 
 	stm32_configgpio(GPIO_SPI1_EXTI_DRDY_PD15);
 
-#  if !defined(BOARD_HAS_VERSIONING)
-	stm32_configgpio(GPIO_SPI1_EXTI_DRDY_PB0);
-	stm32_configgpio(GPIO_SPI1_EXTI_DRDY_PB1);
-	stm32_configgpio(GPIO_SPI1_EXTI_DRDY_PB4);
-	stm32_configgpio(GPIO_SPI1_CS_PC13);
-	stm32_configgpio(GPIO_SPI1_CS_PC15);
-#  else
-
-	if (HW_VER_FMUV2 == board_get_hw_version()) {
-		stm32_configgpio(GPIO_SPI1_EXTI_DRDY_PB0);
-		stm32_configgpio(GPIO_SPI1_EXTI_DRDY_PB1);
-		stm32_configgpio(GPIO_SPI1_EXTI_DRDY_PB4);
-		stm32_configgpio(GPIO_SPI1_CS_PC13);
-		stm32_configgpio(GPIO_SPI1_CS_PC15);
-
-	} else if (HW_VER_FMUV2MINI == board_get_hw_version()) {
+	if (HW_VER_FMUV2MINI == board_get_hw_version()) {
 		stm32_configgpio(GPIO_SPI1_EXTI_20608_DRDY_PC14);
 		stm32_configgpio(GPIO_SPI1_CS_PC15);
 
 	} else if (HW_VER_FMUV3 == board_get_hw_version()) {
 		stm32_configgpio(GPIO_SPI1_CS_PC1);
-	}
 
-#  endif
+	} else {
+		stm32_configgpio(GPIO_SPI1_EXTI_DRDY_PB0);
+		stm32_configgpio(GPIO_SPI1_EXTI_DRDY_PB1);
+		stm32_configgpio(GPIO_SPI1_EXTI_DRDY_PB4);
+		stm32_configgpio(GPIO_SPI1_CS_PC13);
+		stm32_configgpio(GPIO_SPI1_CS_PC15);
+	}
 }
 #endif // CONFIG_STM32_SPI1
 
@@ -119,10 +109,6 @@ static void stm32_spi4_initialize(void)
 {
 	stm32_configgpio(GPIO_SPI4_NSS_PE4);
 
-#  if !defined(BOARD_HAS_VERSIONING)
-	stm32_configgpio(GPIO_SPI4_GPIO_PC14);
-#  else
-
 	if (HW_VER_FMUV3 == board_get_hw_version()) {
 		stm32_configgpio(GPIO_SPI4_EXTI_DRDY_PB0);
 		stm32_configgpio(GPIO_SPI4_CS_PB1);
@@ -133,8 +119,6 @@ static void stm32_spi4_initialize(void)
 	if (HW_VER_FMUV2MINI != board_get_hw_version()) {
 		stm32_configgpio(GPIO_SPI4_GPIO_PC14);
 	}
-
-#  endif
 }
 #endif //CONFIG_STM32_SPI4
 
@@ -156,52 +140,6 @@ __EXPORT void stm32_spiinitialize(void)
 #ifdef CONFIG_STM32_SPI1
 __EXPORT void stm32_spi1select(FAR struct spi_dev_s *dev, uint32_t devid, bool selected)
 {
-	/* SPI select is active low, so write !selected to select the device */
-
-#  if !defined(BOARD_HAS_VERSIONING)
-	switch (devid) {
-	case PX4_SPIDEV_GYRO:
-		/* Making sure the other peripherals are not selected */
-		stm32_gpiowrite(GPIO_SPI1_CS_PC13, !selected);
-		stm32_gpiowrite(GPIO_SPI1_CS_PC15, 1);
-		stm32_gpiowrite(GPIO_SPI1_CS_PD7, 1);
-		stm32_gpiowrite(GPIO_SPI1_CS_PC2, 1);
-		break;
-
-#    if defined(PX4_SPIDEV_ICM_20608)
-
-	case PX4_SPIDEV_ICM_20608:
-#    endif
-	case PX4_SPIDEV_ACCEL_MAG:
-		/* Making sure the other peripherals are not selected */
-		stm32_gpiowrite(GPIO_SPI1_CS_PC13, 1);
-		stm32_gpiowrite(GPIO_SPI1_CS_PC15, !selected);
-		stm32_gpiowrite(GPIO_SPI1_CS_PD7, 1);
-		stm32_gpiowrite(GPIO_SPI1_CS_PC2, 1);
-		break;
-
-	case PX4_SPIDEV_BARO:
-		/* Making sure the other peripherals are not selected */
-		stm32_gpiowrite(GPIO_SPI1_CS_PC13, 1);
-		stm32_gpiowrite(GPIO_SPI1_CS_PC15, 1);
-		stm32_gpiowrite(GPIO_SPI1_CS_PD7, !selected);
-		stm32_gpiowrite(GPIO_SPI1_CS_PC2, 1);
-		break;
-
-	case PX4_SPIDEV_MPU:
-		/* Making sure the other peripherals are not selected */
-		stm32_gpiowrite(GPIO_SPI1_CS_PC13, 1);
-		stm32_gpiowrite(GPIO_SPI1_CS_PC15, 1);
-		stm32_gpiowrite(GPIO_SPI1_CS_PD7, 1);
-		stm32_gpiowrite(GPIO_SPI1_CS_PC2, !selected);
-		break;
-
-	default:
-		break;
-	}
-
-#  else // defined(BOARD_HAS_VERSIONING)
-
 	/* SPI select is active low, so write !selected to select the device */
 	/*   Verification
 	 *        PA5 PA6 PA7 PB0 PB1 PB4 PC1 PC2 PC13 PC14 PC15 PD7 PD15 PE2 PE4 PE5 PE6
@@ -230,10 +168,7 @@ __EXPORT void stm32_spi1select(FAR struct spi_dev_s *dev, uint32_t devid, bool s
 
 		break;
 
-#    if defined(PX4_SPIDEV_ICM_20608)
-
 	case PX4_SPIDEV_ICM_20608:
-#    endif
 	case PX4_SPIDEV_ACCEL_MAG:
 
 		/* Making sure the other peripherals are not selected */
@@ -315,8 +250,6 @@ __EXPORT void stm32_spi1select(FAR struct spi_dev_s *dev, uint32_t devid, bool s
 	default:
 		break;
 	}
-
-#  endif // defined(BOARD_HAS_VERSIONING)
 }
 
 __EXPORT uint8_t stm32_spi1status(FAR struct spi_dev_s *dev, uint32_t devid)
@@ -343,28 +276,6 @@ __EXPORT uint8_t stm32_spi2status(FAR struct spi_dev_s *dev, uint32_t devid)
 #ifdef CONFIG_STM32_SPI4
 __EXPORT void stm32_spi4select(FAR struct spi_dev_s *dev, uint32_t devid, bool selected)
 {
-	/* SPI select is active low, so write !selected to select the device */
-
-#  if !defined(BOARD_HAS_VERSIONING)
-	switch (devid) {
-	case PX4_SPIDEV_EXT_MPU:
-		/* Making sure the other peripherals are not selected */
-		stm32_gpiowrite(GPIO_SPI4_NSS_PE4, !selected);
-		stm32_gpiowrite(GPIO_SPI4_GPIO_PC14, 1);
-		break;
-
-	case PX4_SPIDEV_EXT_BARO:
-		/* Making sure the other peripherals are not selected */
-		stm32_gpiowrite(GPIO_SPI4_NSS_PE4, 1);
-		stm32_gpiowrite(GPIO_SPI4_GPIO_PC14, !selected);
-		break;
-
-	default:
-		break;
-
-	}
-
-#  else // defined(BOARD_HAS_VERSIONING)
 	/* SPI select is active low, so write !selected to select the device */
 	/*   Verification
 	 *        PA5 PA6 PA7 PB0 PB1 PB4 PC1 PC2 PC13 PC14 PC15 PD7 PD15 PE2 PE4 PE5 PE6
@@ -403,10 +314,7 @@ __EXPORT void stm32_spi4select(FAR struct spi_dev_s *dev, uint32_t devid, bool s
 
 		break;
 
-#  if defined(PX4_SPIDEV_ICM_20608)
-
 	case PX4_SPIDEV_ICM_20608:
-#  endif
 	case PX4_SPIDEV_EXT_ACCEL_MAG:
 		/* Making sure the other peripherals are not selected */
 		stm32_gpiowrite(GPIO_SPI4_NSS_PE4, 1);
@@ -442,9 +350,6 @@ __EXPORT void stm32_spi4select(FAR struct spi_dev_s *dev, uint32_t devid, bool s
 		break;
 
 	}
-
-#  endif // defined(BOARD_HAS_VERSIONING)
-
 }
 __EXPORT uint8_t stm32_spi4status(FAR struct spi_dev_s *dev, uint32_t devid)
 {
@@ -489,8 +394,6 @@ __EXPORT void board_spi_reset(int ms)
 	stm32_gpiowrite(_PIN_OFF(GPIO_SPI1_EXTI_DRDY_PB4), 0);
 	stm32_gpiowrite(_PIN_OFF(GPIO_SPI1_EXTI_DRDY_PD15), 0);
 
-#if defined(BOARD_HAS_VERSIONING)
-
 	if (HW_VER_FMUV2 != board_get_hw_version()) {
 		stm32_configgpio(_PIN_OFF(GPIO_SPI4_CS_PC14));
 		stm32_gpiowrite(_PIN_OFF(GPIO_SPI4_CS_PC14), 0);
@@ -510,10 +413,7 @@ __EXPORT void board_spi_reset(int ms)
 		stm32_gpiowrite(_PIN_OFF(GPIO_SPI4_SCK), 0);
 		stm32_gpiowrite(_PIN_OFF(GPIO_SPI4_MISO), 0);
 		stm32_gpiowrite(_PIN_OFF(GPIO_SPI4_MOSI), 0);
-
 	}
-
-#endif
 
 	/* set the sensor rail off */
 	stm32_configgpio(GPIO_VDD_3V3_SENSORS_EN);
@@ -536,16 +436,12 @@ __EXPORT void board_spi_reset(int ms)
 	stm32_configgpio(GPIO_SPI1_MISO);
 	stm32_configgpio(GPIO_SPI1_MOSI);
 
-#if defined(BOARD_HAS_VERSIONING)
-
 	if (HW_VER_FMUV3 == board_get_hw_version()) {
 		stm32_configgpio(GPIO_SPI4_SCK);
 		stm32_configgpio(GPIO_SPI4_MISO);
 		stm32_configgpio(GPIO_SPI4_MOSI);
 		stm32_spi4_initialize();
 	}
-
-#endif
 
 	stm32_spi1_initialize();
 }


### PR DESCRIPTION
This is similar to the fix @svpcom implemented in https://github.com/PX4/Firmware/pull/8703, except instead of forcing to FMU-v2 in a particular error case this PR defaults to treating the board like a traditional FMU-v2 in all cases where a cube or pixhawk mini aren't detected.

I also dropped the BOARD_HAS_SIMPLE_HW_VERSIONING defines because we don't have a build with that disabled.

Checking sensors status for each board. Pass means all expected onboard sensors found. 

| Board        | after flash| reboot cmd | reset button  | cold boot  | notes
| ------------- |:-------------:| -----:| -----:| -----:|-----:|
3DR pixhawk (fmu-v2) | ✓ | ✓ | ✓ | ✓ | 2 x accel, 2 x gyro, 1 x mag, 1 x baro
mRo pixhawk (fmu-v2) | ✓ | ✓ | ✓ | ✓ | same
bad hobbyking pixhawk (R635 issue) (fmu-v2) | ✓ | ✓ | ✓ | ✓ | same
new holybro pixhawk (fmu-v3) | ✓ | ✓ | ✓ | ✓ | same
pixhack v3 (fmu-v2) | ✓ | ✓ | ✓ | ✓  |  2 x accel, 2 x gyro, 1 x baro, internal mag missing
3DR pixhawk 2 (fmu-v2) | ✓ | ✓ | n/a | ✓ | 3 x accel, 3 x gyro, 2 x mag, 2 x baro, reset button not accessible
proficnc pixhawk 2.1 (fmu-v3) | ✓ | ✓ | n/a | ✓ | 3 x accel, 3 x gyro, 3 x mag, 2 x baro, reset button not accessible
3DR pixhawk mini (fmu-v2) | ✓ | ✓ | ✓ | ✓ | Only single IMU present, no mag, 1 x baro