### PR TITLE
Pr wind est work queue

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.fw_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.fw_apps
@@ -26,3 +26,8 @@ fw_pos_control_l1 start
 # Start Land Detector
 #
 land_detector start fixedwing
+
+#
+# Start Wind and Airspeed Scale Estimator
+#
+wind_estimator start

--- a/ROMFS/px4fmu_common/init.d/rc.fw_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.fw_apps
@@ -30,4 +30,4 @@ land_detector start fixedwing
 #
 # Start Wind and Airspeed Scale Estimator
 #
-wind_estimator start
+#wind_estimator start

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_apps
@@ -51,3 +51,8 @@ fw_pos_control_l1 start
 # Multicopter for now until we have something for VTOL
 #
 land_detector start vtol
+
+#
+# Start Wind and Airspeed Scale Estimator
+#
+wind_estimator start

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_apps
@@ -55,4 +55,4 @@ land_detector start vtol
 #
 # Start Wind and Airspeed Scale Estimator
 #
-wind_estimator start
+#wind_estimator start

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -119,7 +119,7 @@ set(config_module_list
 	#modules/local_position_estimator
 	#modules/position_estimator_inav
 	#modules/landing_target_estimator
-	modules/wind_estimator
+	#modules/wind_estimator
 
 	#
 	# Vehicle Control

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -119,6 +119,7 @@ set(config_module_list
 	#modules/local_position_estimator
 	#modules/position_estimator_inav
 	#modules/landing_target_estimator
+	modules/wind_estimator
 
 	#
 	# Vehicle Control

--- a/cmake/configs/nuttx_px4fmu-v3_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v3_default.cmake
@@ -108,6 +108,7 @@ set(config_module_list
 	modules/landing_target_estimator
 	modules/local_position_estimator
 	modules/position_estimator_inav
+	modules/wind_estimator
 
 	#
 	# Vehicle Control

--- a/cmake/configs/nuttx_px4fmu-v4_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v4_default.cmake
@@ -95,6 +95,7 @@ set(config_module_list
 	modules/landing_target_estimator
 	modules/local_position_estimator
 	modules/position_estimator_inav
+	modules/wind_estimator
 
 	#
 	# Vehicle Control

--- a/cmake/configs/nuttx_px4fmu-v4pro_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v4pro_default.cmake
@@ -99,6 +99,7 @@ set(config_module_list
 	modules/landing_target_estimator
 	modules/local_position_estimator
 	modules/position_estimator_inav
+	modules/wind_estimator
 
 	#
 	# Vehicle Control

--- a/cmake/configs/nuttx_px4fmu-v5_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v5_default.cmake
@@ -100,6 +100,7 @@ set(config_module_list
 	modules/landing_target_estimator
 	modules/local_position_estimator
 	modules/position_estimator_inav
+	modules/wind_estimator
 
 	#
 	# Vehicle Control

--- a/cmake/configs/posix_sitl_default.cmake
+++ b/cmake/configs/posix_sitl_default.cmake
@@ -88,6 +88,7 @@ set(config_module_list
 	modules/ekf2
 	modules/local_position_estimator
 	modules/position_estimator_inav
+	modules/wind_estimator
 
 	#
 	# Vehicle Control

--- a/msg/wind_estimate.msg
+++ b/msg/wind_estimate.msg
@@ -3,3 +3,10 @@ float32 windspeed_east		# Wind component in east / Y direction (m/sec)
 
 float32 variance_north		# Wind estimate error variance in north / X direction (m/sec)**2 - set to zero (no uncertainty) if not estimated
 float32 variance_east		# Wind estimate error variance in east / Y direction (m/sec)**2 - set to zero (no uncertainty) if not estimated
+
+float32 tas_innov 		# True airspeed innovation
+float32 tas_innov_var 		# True airspeed innovation variance
+float32 tas_scale 		# Estimated true airspeed scale factor
+
+float32 beta_innov 		# Sideslip measurement innovation
+float32 beta_innov_var 		# Sideslip measurement innovation variance

--- a/posix-configs/SITL/init/ekf2/plane
+++ b/posix-configs/SITL/init/ekf2/plane
@@ -69,6 +69,7 @@ ekf2 start
 fw_pos_control_l1 start
 fw_att_control start
 land_detector start fixedwing
+wind_estimator start
 mixer load /dev/pwm_output0 ROMFS/sitl/mixers/plane_sitl.main.mix
 mavlink start -x -u 14556 -r 2000000
 mavlink start -x -u 14557 -r 2000000 -m onboard -o 14540

--- a/posix-configs/SITL/init/ekf2/standard_vtol
+++ b/posix-configs/SITL/init/ekf2/standard_vtol
@@ -79,6 +79,7 @@ mc_pos_control start
 mc_att_control start
 fw_pos_control_l1 start
 fw_att_control start
+wind_estimator start
 mixer load /dev/pwm_output0 ROMFS/sitl/mixers/standard_vtol_sitl.main.mix
 mavlink start -x -u 14556 -r 2000000 -f
 mavlink start -x -u 14557 -r 2000000 -m onboard -o 14540 -f

--- a/posix-configs/SITL/init/ekf2/tailsitter
+++ b/posix-configs/SITL/init/ekf2/tailsitter
@@ -60,6 +60,7 @@ mc_pos_control start
 mc_att_control start
 fw_pos_control_l1 start
 fw_att_control start
+wind_estimator start
 mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_x_vtol_sim.main.mix
 mavlink start -x -u 14556 -r 2000000
 mavlink start -x -u 14557 -r 2000000 -m onboard -o 14540

--- a/posix-configs/SITL/init/ekf2/tiltrotor
+++ b/posix-configs/SITL/init/ekf2/tiltrotor
@@ -81,6 +81,7 @@ mc_pos_control start
 mc_att_control start
 fw_pos_control_l1 start
 fw_att_control start
+wind_estimator start
 mixer load /dev/pwm_output0 ROMFS/sitl/mixers/tiltrotor_sitl.main.mix
 mavlink start -x -u 14556 -r 2000000 -f
 mavlink start -x -u 14557 -r 2000000 -m onboard -o 14540 -f

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -479,6 +479,9 @@ Ekf2::Ekf2():
 	_bcoef_x(_params->bcoef_x),
 	_bcoef_y(_params->bcoef_y)
 {
+	// advertise the wind topic early to make sure we get the first instance (before the standalone wind estimator)
+	wind_estimate_s wind_estimate = {};
+	_wind_pub = orb_advertise(ORB_ID(wind_estimate), &wind_estimate);
 }
 
 int Ekf2::print_status()

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -479,9 +479,6 @@ Ekf2::Ekf2():
 	_bcoef_x(_params->bcoef_x),
 	_bcoef_y(_params->bcoef_y)
 {
-	// advertise the wind topic early to make sure we get the first instance (before the standalone wind estimator)
-	wind_estimate_s wind_estimate = {};
-	_wind_pub = orb_advertise(ORB_ID(wind_estimate), &wind_estimate);
 }
 
 int Ekf2::print_status()

--- a/src/modules/wind_estimator/CMakeLists.txt
+++ b/src/modules/wind_estimator/CMakeLists.txt
@@ -1,0 +1,38 @@
+############################################################################
+#
+#   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+px4_add_module(
+	MODULE modules__wind_estimator
+	MAIN wind_estimator
+	SRCS
+		wind_estimator_main.cpp
+)

--- a/src/modules/wind_estimator/CMakeLists.txt
+++ b/src/modules/wind_estimator/CMakeLists.txt
@@ -33,6 +33,8 @@
 px4_add_module(
 	MODULE modules__wind_estimator
 	MAIN wind_estimator
+	INCLUDES
+		${PX4_SOURCE_DIR}/src/lib/ecl
 	SRCS
 		wind_estimator_main.cpp
 )

--- a/src/modules/wind_estimator/wind_estimator_main.cpp
+++ b/src/modules/wind_estimator/wind_estimator_main.cpp
@@ -1,0 +1,313 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <ecl/airdata/WindEstimator.hpp>
+
+#include <px4_module.h>
+#include <px4_workqueue.h>
+#include <uORB/topics/vehicle_local_position.h>
+
+#include <drivers/drv_hrt.h>
+#include <matrix/matrix/math.hpp>
+#include <uORB/topics/airspeed.h>
+#include <uORB/topics/wind_estimate.h>
+#include <uORB/topics/vehicle_attitude.h>
+#include <uORB/topics/vehicle_local_position.h>
+#include <systemlib/param/param.h>
+
+#define SCHEDULE_INTERVAL	100000	/**< The schedule interval in usec (10 Hz) */
+
+class WindEstimatorModule : public ModuleBase<WindEstimatorModule>
+{
+public:
+
+	WindEstimatorModule() {};
+
+	/** @see ModuleBase */
+	static int task_spawn(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static WindEstimatorModule *instantiate(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int custom_command(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int print_usage(const char *reason = nullptr);
+
+	/**
+	 * run the main loop: if running as task, continuously iterate, otherwise execute only one single cycle
+	 */
+	void cycle();
+
+	/** @see ModuleBase::print_status() */
+	int print_status() override;
+
+private:
+	static struct work_s	_work;
+
+	WindEstimator _wind_estimator;
+	orb_advert_t 	_wind_est_pub{nullptr};			/**< wind estimate topic */
+
+	hrt_abstime _time_last_airspeed_fused{0};		/* timestamp of when last time airspeed measurement was fused into wind estimator */
+	hrt_abstime _time_last_beta_fused{0};		/* timestamp of when last time sideslip measurement was fused into wind estimator */
+
+	int _vehicle_attitude_sub{-1};
+	int _vehicle_local_position_sub{-1};
+	int _airspeed_sub{-1};
+
+	bool _topics_subscribed{false};
+
+	static void	cycle_trampoline(void *arg);
+	int 		start();
+
+	void		update_params();
+
+	bool 		subscribe_topics();
+};
+
+work_s	WindEstimatorModule::_work = {};
+
+int
+WindEstimatorModule::task_spawn(int argc, char *argv[])
+{
+	/* schedule a cycle to start things */
+	work_queue(LPWORK, &_work, (worker_t)&WindEstimatorModule::cycle_trampoline, nullptr, 0);
+
+	// wait until task is up & running (the mode_* commands depend on it)
+	if (wait_until_running() < 0) {
+		_task_id = -1;
+		return -1;
+	}
+
+	return PX4_OK;
+}
+
+void
+WindEstimatorModule::cycle_trampoline(void *arg)
+{
+	WindEstimatorModule *dev = reinterpret_cast<WindEstimatorModule *>(arg);
+
+	// check if the trampoline is called for the first time
+	if (!dev) {
+		dev = new WindEstimatorModule();
+
+		if (!dev) {
+			PX4_ERR("alloc failed");
+			return;
+		}
+
+		_object = dev;
+	}
+
+	dev->cycle();
+}
+
+bool
+WindEstimatorModule::subscribe_topics()
+{
+	if (_vehicle_attitude_sub < 0) {
+		_vehicle_attitude_sub = orb_subscribe(ORB_ID(vehicle_attitude));
+	}
+
+	if (_vehicle_local_position_sub < 0) {
+		_vehicle_local_position_sub = orb_subscribe(ORB_ID(vehicle_local_position));
+	}
+
+	if (_airspeed_sub < 0) {
+		_airspeed_sub = orb_subscribe(ORB_ID(airspeed));
+	}
+
+	return true;
+}
+
+void
+WindEstimatorModule::cycle()
+{
+	vehicle_attitude_s vehicle_attitude = {};
+	vehicle_local_position_s vehicle_local_position = {};
+	airspeed_s airspeed = {};
+
+	if (!_topics_subscribed) {
+		_topics_subscribed = subscribe_topics();
+	}
+
+	hrt_abstime time_now_usec = hrt_absolute_time();
+
+	// update wind and airspeed estimator
+	_wind_estimator.update(time_now_usec);
+
+	// limit airspeed and sideslip fusion rate to 20Hz
+	bool fuse_airspeed = (time_now_usec - _time_last_airspeed_fused) > 50 * 1000;
+	bool fuse_beta = (time_now_usec - _time_last_beta_fused) > 50 * 1000;
+
+	if (fuse_beta || fuse_airspeed) {
+
+		// we need to fuse, so update topics
+		orb_copy(ORB_ID(vehicle_attitude), _vehicle_attitude_sub, &vehicle_attitude);
+		orb_copy(ORB_ID(airspeed), _airspeed_sub, &airspeed);
+		orb_copy(ORB_ID(vehicle_local_position), _vehicle_local_position_sub, &vehicle_local_position);
+
+		matrix::Dcmf R_to_earth(matrix::Quatf(vehicle_attitude.q));
+		matrix::Vector3f vI(vehicle_local_position.vx, vehicle_local_position.vy, vehicle_local_position.vz);
+
+		if (fuse_beta && vehicle_local_position.v_xy_valid) {
+			_wind_estimator.fuse_beta(time_now_usec, &vI._data[0][0], vehicle_attitude.q);
+			_time_last_beta_fused = time_now_usec;
+		}
+
+		if (fuse_airspeed && vehicle_local_position.v_xy_valid) {
+			matrix::Vector3f vel_var(vehicle_local_position.evh, vehicle_local_position.evh, vehicle_local_position.evv);
+			vel_var = R_to_earth * vel_var;
+			_wind_estimator.fuse_airspeed(time_now_usec, airspeed.indicated_airspeed_m_s, &vI._data[0][0],
+						      &vel_var._data[0][0]);
+			_time_last_airspeed_fused = time_now_usec;
+		}
+	}
+
+
+	// if we fused either airspeed or sideslip we publish a wind_estimate message
+	if (_time_last_beta_fused == time_now_usec || _time_last_airspeed_fused == time_now_usec) {
+		wind_estimate_s wind_est = {};
+
+		wind_est.timestamp = time_now_usec;
+		float wind[2];
+		_wind_estimator.get_wind(wind);
+		wind_est.windspeed_north = wind[0];
+		wind_est.windspeed_east = wind[1];
+		float wind_cov[2];
+		_wind_estimator.get_wind_var(wind_cov);
+		wind_est.variance_north = wind_cov[0];
+		wind_est.variance_east = wind_cov[1];
+		wind_est.tas_innov = _wind_estimator.get_tas_innov();
+		wind_est.tas_innov_var = _wind_estimator.get_tas_innov_var();
+		wind_est.beta_innov = _wind_estimator.get_beta_innov();
+		wind_est.beta_innov_var = _wind_estimator.get_beta_innov_var();
+		wind_est.tas_scale = _wind_estimator.get_tas_scale();
+
+		int instance;
+		orb_publish_auto(ORB_ID(wind_estimate), &_wind_est_pub, &wind_est, &instance, ORB_PRIO_DEFAULT);
+	}
+
+	if (should_exit()) {
+		exit_and_cleanup();
+
+	} else {
+		/* schedule next cycle */
+		work_queue(HPWORK, &_work, (worker_t)&WindEstimatorModule::cycle_trampoline, this, USEC2TICK(SCHEDULE_INTERVAL));
+	}
+}
+
+void WindEstimatorModule::update_params()
+{
+	param_t p_wind_p_noise = param_find("WEST_W_P_NOISE");
+	param_t p_tas_scale_p_noise = param_find("WEST_SC_P_NOISE");
+	param_t p_tas_noise = param_find("WEST_TAS_NOISE");
+	param_t p_beta_noise = param_find("WEST_BETA_NOISE");
+
+	float wind_p_noise = 0.0f;
+	param_get(p_wind_p_noise, &wind_p_noise);
+
+	float tas_scale_p_noise = 0.0f;
+	param_get(p_tas_scale_p_noise, &tas_scale_p_noise);
+
+	float tas_noise = 0.0f;
+	param_get(p_tas_noise, &tas_noise);
+
+	float beta_noise = 0.0f;
+	param_get(p_beta_noise, &beta_noise);
+
+	// update wind & airspeed scale estimator parameters
+	_wind_estimator.set_wind_p_noise(wind_p_noise);
+	_wind_estimator.set_tas_scale_p_noise(tas_scale_p_noise);
+	_wind_estimator.set_tas_noise(tas_noise);
+	_wind_estimator.set_beta_noise(beta_noise);
+
+}
+
+WindEstimatorModule *WindEstimatorModule::instantiate(int argc, char *argv[])
+{
+	// No arguments to parse. We also know that we should run as task
+	return new WindEstimatorModule();
+}
+
+int WindEstimatorModule::custom_command(int argc, char *argv[])
+{
+	/* start the FMU if not running */
+	if (!is_running()) {
+		int ret = WindEstimatorModule::task_spawn(argc, argv);
+
+		if (ret) {
+			return ret;
+		}
+	}
+
+	return print_usage("unknown command");
+}
+
+int WindEstimatorModule::print_usage(const char *reason)
+{
+	if (reason) {
+		PX4_WARN("%s\n", reason);
+	}
+
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+This module runs a combined wind and airspeed scale factor estimator.
+If provided the vehicle NED speed and the vehicle attitude it can estimate the horizontal wind components based on a zero
+sideslip assumption. This makes the estimator only suitable for fixed wing vehicles.
+If additionally provided an airspeed measurment this module also estimates an airspeed scale factor based on the following model:
+measured_airspeed = scale_factor * real_airspeed.
+
+)DESCR_STR");
+
+	PRINT_MODULE_USAGE_NAME("wind_estimator", "estimator");
+	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+
+	return 0;
+}
+
+int WindEstimatorModule::print_status()
+{
+	return 0;
+}
+
+extern "C" __EXPORT int wind_estimator_main(int argc, char *argv[]);
+
+int
+wind_estimator_main(int argc, char *argv[])
+{
+	return WindEstimatorModule::main(argc, argv);
+}

--- a/src/modules/wind_estimator/wind_estimator_main.cpp
+++ b/src/modules/wind_estimator/wind_estimator_main.cpp
@@ -70,7 +70,7 @@ public:
 	static int print_usage(const char *reason = nullptr);
 
 	/**
-	 * run the main loop: if running as task, continuously iterate, otherwise execute only one single cycle
+	 * run the main loop
 	 */
 	void cycle();
 
@@ -131,7 +131,7 @@ WindEstimatorModule::task_spawn(int argc, char *argv[])
 	/* schedule a cycle to start things */
 	work_queue(LPWORK, &_work, (worker_t)&WindEstimatorModule::cycle_trampoline, nullptr, 0);
 
-	// wait until task is up & running (the mode_* commands depend on it)
+	// wait until task is up & running
 	if (wait_until_running() < 0) {
 		_task_id = -1;
 		return -1;

--- a/src/modules/wind_estimator/wind_estimator_main.cpp
+++ b/src/modules/wind_estimator/wind_estimator_main.cpp
@@ -126,6 +126,8 @@ WindEstimatorModule::task_spawn(int argc, char *argv[])
 		return -1;
 	}
 
+	_task_id = task_id_is_work_queue;
+
 	return PX4_OK;
 }
 

--- a/src/modules/wind_estimator/wind_estimator_main.cpp
+++ b/src/modules/wind_estimator/wind_estimator_main.cpp
@@ -299,9 +299,9 @@ int WindEstimatorModule::print_usage(const char *reason)
 		R"DESCR_STR(
 ### Description
 This module runs a combined wind and airspeed scale factor estimator.
-If provided the vehicle NED speed and the vehicle attitude it can estimate the horizontal wind components based on a zero
+If provided the vehicle NED speed and attitude it can estimate the horizontal wind components based on a zero
 sideslip assumption. This makes the estimator only suitable for fixed wing vehicles.
-If additionally provided an airspeed measurment this module also estimates an airspeed scale factor based on the following model:
+If provided an airspeed measurement this module also estimates an airspeed scale factor based on the following model:
 measured_airspeed = scale_factor * real_airspeed.
 
 )DESCR_STR");

--- a/src/modules/wind_estimator/wind_estimator_main.cpp
+++ b/src/modules/wind_estimator/wind_estimator_main.cpp
@@ -93,7 +93,9 @@ private:
 		(ParamFloat<px4::params::WEST_W_P_NOISE>) wind_p_noise,
 		(ParamFloat<px4::params::WEST_SC_P_NOISE>) tas_scale_p_noise,
 		(ParamFloat<px4::params::WEST_TAS_NOISE>) tas_noise,
-		(ParamFloat<px4::params::WEST_BETA_NOISE>) beta_noise
+		(ParamFloat<px4::params::WEST_BETA_NOISE>) beta_noise,
+		(ParamInt<px4::params::WEST_TAS_GATE>) airspeed_gate,
+		(ParamInt<px4::params::WEST_BETA_GATE>) sideslip_gate
 	)
 
 	static void	cycle_trampoline(void *arg);
@@ -274,6 +276,8 @@ void WindEstimatorModule::update_params()
 	_wind_estimator.set_tas_scale_p_noise(tas_scale_p_noise.get());
 	_wind_estimator.set_tas_noise(tas_noise.get());
 	_wind_estimator.set_beta_noise(beta_noise.get());
+	_wind_estimator.set_tas_gate(airspeed_gate.get());
+	_wind_estimator.set_beta_gate(sideslip_gate.get());
 }
 
 int WindEstimatorModule::custom_command(int argc, char *argv[])

--- a/src/modules/wind_estimator/wind_estimator_params.c
+++ b/src/modules/wind_estimator/wind_estimator_params.c
@@ -1,0 +1,38 @@
+/**
+ * Wind estimator wind process noise.
+ *
+ * @min 0
+ * @max 1
+ * @unit m/s/s
+ * @group Wind Estimator
+ */
+PARAM_DEFINE_FLOAT(WEST_W_P_NOISE, 0.1f);
+
+/**
+ * Wind estimator true airspeed scale process noise.
+ *
+ * @min 0
+ * @max 0.1
+ * @group Wind Estimator
+ */
+PARAM_DEFINE_FLOAT(WEST_SC_P_NOISE, 0.0001);
+
+/**
+ * Wind estimator true airspeed measurement noise.
+ *
+ * @min 0
+ * @max 4
+ * @unit m/s
+ * @group Wind Estimator
+ */
+PARAM_DEFINE_FLOAT(WEST_TAS_NOISE, 1.4);
+
+/**
+ * Wind estimator sideslip measurement noise.
+ *
+ * @min 0
+ * @max 1
+ * @unit rad
+ * @group Wind Estimator
+ */
+PARAM_DEFINE_FLOAT(WEST_BETA_NOISE, 0.3);

--- a/src/modules/wind_estimator/wind_estimator_params.c
+++ b/src/modules/wind_estimator/wind_estimator_params.c
@@ -36,3 +36,27 @@ PARAM_DEFINE_FLOAT(WEST_TAS_NOISE, 1.4);
  * @group Wind Estimator
  */
 PARAM_DEFINE_FLOAT(WEST_BETA_NOISE, 0.3);
+
+/**
+ * Gate size for true airspeed fusion.
+ *
+ * Sets the number of standard deviations used by the innovation consistency test.
+ *
+ * @min 1
+ * @max 5
+ * @unit SD
+ * @group Wind Estimator
+ */
+PARAM_DEFINE_INT32(WEST_TAS_GATE, 3);
+
+/**
+ * Gate size for true sideslip fusion.
+ *
+ * Sets the number of standard deviations used by the innovation consistency test.
+ *
+ * @min 1
+ * @max 5
+ * @unit SD
+ * @group Wind Estimator
+ */
+PARAM_DEFINE_INT32(WEST_BETA_GATE, 1);


### PR DESCRIPTION
This is a replacement of #9041 and implements the standalone wind and airspeed scale factor estimator as a work queue. Previously, the estimator was living in the sensors module which did not really make sense.

Advantages: 
- the estimator is now a separate module and can be run only for VTOL and fixed wing configs
- we can extend this module to take data of multiple airspeed sensors and run multiple estimators and then use this information for airspeed failure detection

Disadvantages:
- we have some overhead in terms of memory due to the work queue and the fact that we need to subscribe to three topics, one of them is local_position which is rather large

@dagar @priseborough FYI