### PR TITLE
add option to use startup config script location and name for the working directory

### DIFF
--- a/launch/single_vehicle_spawn.launch
+++ b/launch/single_vehicle_spawn.launch
@@ -19,7 +19,7 @@
     <arg name="cmd" default="$(find xacro)/xacro $(find px4)/Tools/sitl_gazebo/models/rotors_description/urdf/$(arg vehicle)_base.xacro rotors_description_dir:=$(find px4)/Tools/sitl_gazebo/models/rotors_description mavlink_udp_port:=$(arg mavlink_udp_port) --inorder"/>
     <param command="$(arg cmd)" name="rotors_description"/>
     <!-- PX4 SITL -->
-    <node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" args="$(find px4) $(arg rcS)">
+    <node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" args="-w $(find px4) $(arg rcS)">
     </node>
     <!-- spawn vehicle -->
     <node name="$(arg vehicle)_$(arg ID)_spawn" output="screen" pkg="gazebo_ros" type="spawn_model" args="-urdf -param rotors_description -model $(arg vehicle)_$(arg ID) -package_to_model -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)"/>


### PR DESCRIPTION
@dagar This addresses #9046. It adds an optional switch `-w` to change the working directory for posix. Currently rootfs gets put in the CWD, which includes params and dataman. Using `-w` tells the script to use the startup configuration path and name as the working directory instead. It is necessary to have different working directories for multi vehicle simulations. As a side benefit, this also allows for per-model working directories for single vehicle as well, which is nice for maintaining params for different vehicles. This is only been tested for my particular use-case, using ROS for multi-vehicle simulations. 

Because multiple vehicles each require different startup scripts to configure the appropriate ports and mav ID, using the script path and name, guarantees this to be unique and is a simple way to solve the problem.

Before -- shared working directory in ~/.ros:
![screenshot from 2018-03-15 15-32-15](https://user-images.githubusercontent.com/10533707/37488347-b4565262-286a-11e8-9a7d-f2804cb9a418.png)

in px4/Firmware/posix-configs/SITL/init/ekf2/:
![screenshot from 2018-03-15 15-33-09](https://user-images.githubusercontent.com/10533707/37488378-c73a5e82-286a-11e8-8f79-7426a7d4bf8f.png)

With added arg -- single vehicle, `roslaunch px4 posix_sitl.launch` in px4/Firmware/posix-configs/SITL/init/ekf2/:
![screenshot from 2018-03-15 15-17-41](https://user-images.githubusercontent.com/10533707/37488394-d5f837b4-286a-11e8-852a-fdb3a5338ef4.png)

With added arg -- multi-vehicle, `roslaunch px4 multi_uav_mavros_sitl.launch` in px4/Firmware/posix-configs/SITL/init/ekf2/:
![screenshot from 2018-03-15 15-40-45](https://user-images.githubusercontent.com/10533707/37488364-bd029286-286a-11e8-946a-e6e8306a5486.png)