### PR TITLE
Adds ability for generate_listener.py to process out-of-tree uORB message definitions as well

### DIFF
--- a/src/systemcmds/topic_listener/CMakeLists.txt
+++ b/src/systemcmds/topic_listener/CMakeLists.txt
@@ -32,7 +32,7 @@
 ############################################################################
 
 add_custom_command(OUTPUT topic_listener.cpp
-                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/generate_listener.py ${PX4_SOURCE_DIR} > topic_listener.cpp
+                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/generate_listener.py ${PX4_SOURCE_DIR} ${EXTERNAL_MODULES_LOCATION} > topic_listener.cpp
                 DEPENDS generate_listener.py uorb_msgs
                 )
 

--- a/src/systemcmds/topic_listener/generate_listener.py
+++ b/src/systemcmds/topic_listener/generate_listener.py
@@ -8,8 +8,12 @@ import re
 # This script is run from Build/<target>_default.build/$(PX4_BASE)/Firmware/src/systemcmds/topic_listener
 
 # argv[1] must be the full path of the top Firmware dir
+# argv[2] (optional) is the full path to the EXTERNAL_MODULES_LOCATION
 
 raw_messages = glob.glob(sys.argv[1]+"/msg/*.msg")
+if len(sys.argv) > 2:
+	external_raw_messages = glob.glob(sys.argv[2]+"/msg/*.msg")
+	raw_messages += external_raw_messages # Append the msgs defined in the EXTERNAL_MODULES_LOCATION to the normal msg list
 messages = []
 topics = []
 message_elements = []


### PR DESCRIPTION
Related to PR #9073.

@mhkabir @bkueng : I didn't realise that `generate_listener.py` was using the original message definition files and not the generated uORB topic headers in order to generate topic_listener.cpp.

topic_listener.cpp will now be generated with the out-of-tree uORB message definitions as well. 