### PR TITLE
Fix scale application on FW throttle baro compensation

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1870,7 +1870,7 @@ FixedwingPositionControl::tecs_update_pitch_throttle(float alt_sp, float airspee
 			if (PX4_ISFINITE(baro.pressure) && PX4_ISFINITE(_parameters.throttle_alt_scale)) {
 				// scale throttle as a function of sqrt(p0/p) (~ EAS -> TAS at low speeds and altitudes ignoring temperature)
 				const float eas2tas = sqrtf(MSL_PRESSURE_MILLIBAR / baro.pressure);
-				const float scale = constrain(eas2tas * _parameters.throttle_alt_scale, 0.9f, 2.0f);
+				const float scale = constrain((eas2tas - 1.0f) * _parameters.throttle_alt_scale + 1.0f, 1.0f, 2.0f);
 
 				throttle_max = constrain(throttle_max * scale, throttle_min, 1.0f);
 				throttle_cruise = constrain(throttle_cruise * scale, throttle_min + 0.01f, throttle_max - 0.01f);

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -98,7 +98,7 @@ PARAM_DEFINE_FLOAT(FW_THR_CRUISE, 0.6f);
  * The default value of 0 will disable scaling.
  *
  * @min 0.0
- * @max 2.0
+ * @max 10.0
  * @decimal 1
  * @increment 0.1
  * @group FW L1 Control


### PR DESCRIPTION
The scale factor intended for the baro compensation was applied to the entire throttle range.
Now only applied to the eas2tas factor effect so it can be tuned properly