### PR TITLE
convergence config: increase multirotor idle speed

### DIFF
--- a/ROMFS/px4fmu_common/init.d/13012_convergence
+++ b/ROMFS/px4fmu_common/init.d/13012_convergence
@@ -23,7 +23,7 @@ if [ $AUTOCNF == yes ]
 then
     param set VT_MOT_COUNT 3
     param set VT_FW_MOT_OFFID 3
-    param set VT_IDLE_PWM_MC 1150
+    param set VT_IDLE_PWM_MC 1200
     param set VT_TYPE 1
 
     param set VT_B_TRANS_DUR  1.0


### PR DESCRIPTION
Just a small increase in idle speed when hovering since we experienced some rear motor stalls when throttle was very low. Prior to that we calibrated the ESCs.