### PR TITLE
Refactor MC attitude controller: use module base and Param classes

### DIFF
--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -1,0 +1,268 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2013-2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <lib/mathlib/mathlib.h>
+#include <lib/mixer/mixer.h>
+#include <mathlib/math/filter/LowPassFilter2p.hpp>
+#include <systemlib/perf_counter.h>
+#include <px4_config.h>
+#include <px4_defines.h>
+#include <px4_module.h>
+#include <px4_posix.h>
+#include <px4_tasks.h>
+#include <uORB/topics/actuator_controls.h>
+#include <uORB/topics/battery_status.h>
+#include <uORB/topics/manual_control_setpoint.h>
+#include <uORB/topics/multirotor_motor_limits.h>
+#include <uORB/topics/parameter_update.h>
+#include <uORB/topics/rate_ctrl_status.h>
+#include <uORB/topics/sensor_bias.h>
+#include <uORB/topics/sensor_correction.h>
+#include <uORB/topics/sensor_gyro.h>
+#include <uORB/topics/vehicle_attitude.h>
+#include <uORB/topics/vehicle_attitude_setpoint.h>
+#include <uORB/topics/vehicle_control_mode.h>
+#include <uORB/topics/vehicle_rates_setpoint.h>
+#include <uORB/topics/vehicle_status.h>
+
+/**
+ * Multicopter attitude control app start / stop handling function
+ */
+extern "C" __EXPORT int mc_att_control_main(int argc, char *argv[]);
+
+#define MAX_GYRO_COUNT 3
+
+
+class MulticopterAttitudeControl : public ModuleBase<MulticopterAttitudeControl>
+{
+public:
+	MulticopterAttitudeControl();
+
+	virtual ~MulticopterAttitudeControl() = default;
+
+	/** @see ModuleBase */
+	static int task_spawn(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static MulticopterAttitudeControl *instantiate(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int custom_command(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int print_usage(const char *reason = nullptr);
+
+	/** @see ModuleBase::run() */
+	void run() override;
+
+private:
+
+	int		_v_att_sub;		/**< vehicle attitude subscription */
+	int		_v_att_sp_sub;			/**< vehicle attitude setpoint subscription */
+	int		_v_rates_sp_sub;		/**< vehicle rates setpoint subscription */
+	int		_v_control_mode_sub;	/**< vehicle control mode subscription */
+	int		_params_sub;			/**< parameter updates subscription */
+	int		_manual_control_sp_sub;	/**< manual control setpoint subscription */
+	int		_vehicle_status_sub;	/**< vehicle status subscription */
+	int		_motor_limits_sub;		/**< motor limits subscription */
+	int		_battery_status_sub;	/**< battery status subscription */
+	int		_sensor_gyro_sub[MAX_GYRO_COUNT];	/**< gyro data subscription */
+	int		_sensor_correction_sub;	/**< sensor thermal correction subscription */
+	int		_sensor_bias_sub;	/**< sensor in-run bias correction subscription */
+
+	unsigned _gyro_count;
+	int _selected_gyro;
+
+	orb_advert_t	_v_rates_sp_pub;		/**< rate setpoint publication */
+	orb_advert_t	_actuators_0_pub;		/**< attitude actuator controls publication */
+	orb_advert_t	_controller_status_pub;	/**< controller status publication */
+
+	orb_id_t _rates_sp_id;	/**< pointer to correct rates setpoint uORB metadata structure */
+	orb_id_t _actuators_id;	/**< pointer to correct actuator controls0 uORB metadata structure */
+
+	bool		_actuators_0_circuit_breaker_enabled;	/**< circuit breaker to suppress output */
+
+	struct vehicle_attitude_s		_v_att;			/**< vehicle attitude */
+	struct vehicle_attitude_setpoint_s	_v_att_sp;		/**< vehicle attitude setpoint */
+	struct vehicle_rates_setpoint_s		_v_rates_sp;		/**< vehicle rates setpoint */
+	struct manual_control_setpoint_s	_manual_control_sp;	/**< manual control setpoint */
+	struct vehicle_control_mode_s		_v_control_mode;	/**< vehicle control mode */
+	struct actuator_controls_s		_actuators;		/**< actuator controls */
+	struct vehicle_status_s			_vehicle_status;	/**< vehicle status */
+	struct battery_status_s			_battery_status;	/**< battery status */
+	struct sensor_gyro_s			_sensor_gyro;		/**< gyro data before thermal correctons and ekf bias estimates are applied */
+	struct sensor_correction_s		_sensor_correction;	/**< sensor thermal corrections */
+	struct sensor_bias_s			_sensor_bias;		/**< sensor in-run bias corrections */
+
+	MultirotorMixer::saturation_status _saturation_status{};
+
+	perf_counter_t	_loop_perf;			/**< loop performance counter */
+	perf_counter_t	_controller_latency_perf;
+
+	math::LowPassFilter2p _lp_filters_d[3];                      /**< low-pass filters for D-term (roll, pitch & yaw) */
+	static constexpr const float initial_update_rate_hz = 250.f; /**< loop update rate used for initialization */
+	float _loop_update_rate_hz;                                  /**< current rate-controller loop update rate in [Hz] */
+
+	math::Vector<3>		_rates_prev;		/**< angular rates on previous step */
+	math::Vector<3>		_rates_prev_filtered;	/**< angular rates on previous step (low-pass filtered) */
+	math::Vector<3>		_rates_sp;		/**< angular rates setpoint */
+	math::Vector<3>		_rates_int;		/**< angular rates integral error */
+	float			_thrust_sp;		/**< thrust setpoint */
+	math::Vector<3>		_att_control;	/**< attitude control vector */
+
+	math::Matrix<3, 3>	_board_rotation = {};	/**< rotation matrix for the orientation that the board is mounted */
+
+	struct {
+		param_t roll_p;
+		param_t roll_rate_p;
+		param_t roll_rate_i;
+		param_t roll_rate_integ_lim;
+		param_t roll_rate_d;
+		param_t roll_rate_ff;
+		param_t pitch_p;
+		param_t pitch_rate_p;
+		param_t pitch_rate_i;
+		param_t pitch_rate_integ_lim;
+		param_t pitch_rate_d;
+		param_t pitch_rate_ff;
+		param_t d_term_cutoff_freq;
+		param_t tpa_breakpoint_p;
+		param_t tpa_breakpoint_i;
+		param_t tpa_breakpoint_d;
+		param_t tpa_rate_p;
+		param_t tpa_rate_i;
+		param_t tpa_rate_d;
+		param_t yaw_p;
+		param_t yaw_rate_p;
+		param_t yaw_rate_i;
+		param_t yaw_rate_integ_lim;
+		param_t yaw_rate_d;
+		param_t yaw_rate_ff;
+		param_t yaw_ff;
+		param_t roll_rate_max;
+		param_t pitch_rate_max;
+		param_t yaw_rate_max;
+		param_t yaw_auto_max;
+
+		param_t acro_roll_max;
+		param_t acro_pitch_max;
+		param_t acro_yaw_max;
+		param_t acro_expo;
+		param_t acro_superexpo;
+		param_t rattitude_thres;
+
+		param_t vtol_wv_yaw_rate_scale;
+
+		param_t bat_scale_en;
+
+		param_t board_rotation;
+
+		param_t board_offset[3];
+
+	}		_params_handles;		/**< handles for interesting parameters */
+
+	struct {
+		matrix::Vector3f attitude_p;					/**< P gain for attitude control */
+		math::Vector<3> rate_p;				/**< P gain for angular rate error */
+		math::Vector<3> rate_i;				/**< I gain for angular rate error */
+		math::Vector<3> rate_int_lim;			/**< integrator state limit for rate loop */
+		math::Vector<3> rate_d;				/**< D gain for angular rate error */
+		math::Vector<3>	rate_ff;			/**< Feedforward gain for desired rates */
+		float yaw_ff;						/**< yaw control feed-forward */
+
+		float d_term_cutoff_freq;			/**< Cutoff frequency for the D-term filter */
+
+		float tpa_breakpoint_p;				/**< Throttle PID Attenuation breakpoint */
+		float tpa_breakpoint_i;				/**< Throttle PID Attenuation breakpoint */
+		float tpa_breakpoint_d;				/**< Throttle PID Attenuation breakpoint */
+		float tpa_rate_p;					/**< Throttle PID Attenuation slope */
+		float tpa_rate_i;					/**< Throttle PID Attenuation slope */
+		float tpa_rate_d;					/**< Throttle PID Attenuation slope */
+
+		float roll_rate_max;
+		float pitch_rate_max;
+		float yaw_rate_max;
+		float yaw_auto_max;
+		math::Vector<3> mc_rate_max;		/**< attitude rate limits in stabilized modes */
+		math::Vector<3> auto_rate_max;		/**< attitude rate limits in auto modes */
+		matrix::Vector3f acro_rate_max;		/**< max attitude rates in acro mode */
+		float acro_expo;					/**< function parameter for expo stick curve shape */
+		float acro_superexpo;				/**< function parameter for superexpo stick curve shape */
+		float rattitude_thres;
+
+		float vtol_wv_yaw_rate_scale;			/**< Scale value [0, 1] for yaw rate setpoint  */
+
+		int32_t bat_scale_en;
+
+		int32_t board_rotation;
+
+		float board_offset[3];
+
+	}		_params;
+
+	/**
+	 * Update our local parameter cache.
+	 */
+	void			parameters_update();
+
+	/**
+	 * Check for parameter update and handle it.
+	 */
+	void		battery_status_poll();
+	void		parameter_update_poll();
+	void		sensor_bias_poll();
+	void		sensor_correction_poll();
+	void		vehicle_attitude_poll();
+	void		vehicle_attitude_setpoint_poll();
+	void		vehicle_control_mode_poll();
+	void		vehicle_manual_poll();
+	void		vehicle_motor_limits_poll();
+	void		vehicle_rates_setpoint_poll();
+	void		vehicle_status_poll();
+
+	/**
+	 * Attitude controller.
+	 */
+	void		control_attitude(float dt);
+
+	/**
+	 * Attitude rates controller.
+	 */
+	void		control_attitude_rates(float dt);
+
+	/**
+	 * Throttle PID attenuation.
+	 */
+	math::Vector<3> pid_attenuations(float tpa_breakpoint, float tpa_rate);
+};
+

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -31,9 +31,9 @@
  *
  ****************************************************************************/
 
-#include <lib/mathlib/mathlib.h>
 #include <lib/mixer/mixer.h>
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
+#include <matrix/matrix/math.hpp>
 #include <systemlib/perf_counter.h>
 #include <px4_config.h>
 #include <px4_defines.h>
@@ -121,7 +121,7 @@ private:
 	/**
 	 * Throttle PID attenuation.
 	 */
-	math::Vector<3> pid_attenuations(float tpa_breakpoint, float tpa_rate);
+	matrix::Vector3f pid_attenuations(float tpa_breakpoint, float tpa_rate);
 
 
 	int		_v_att_sub{-1};			/**< vehicle attitude subscription */
@@ -170,14 +170,14 @@ private:
 	static constexpr const float initial_update_rate_hz = 250.f; /**< loop update rate used for initialization */
 	float _loop_update_rate_hz{initial_update_rate_hz};          /**< current rate-controller loop update rate in [Hz] */
 
-	math::Vector<3>		_rates_prev;		/**< angular rates on previous step */
-	math::Vector<3>		_rates_prev_filtered;	/**< angular rates on previous step (low-pass filtered) */
-	math::Vector<3>		_rates_sp;		/**< angular rates setpoint */
-	math::Vector<3>		_rates_int;		/**< angular rates integral error */
-	float			_thrust_sp;		/**< thrust setpoint */
-	math::Vector<3>		_att_control;	/**< attitude control vector */
+	matrix::Vector3f _rates_prev;			/**< angular rates on previous step */
+	matrix::Vector3f _rates_prev_filtered;		/**< angular rates on previous step (low-pass filtered) */
+	matrix::Vector3f _rates_sp;			/**< angular rates setpoint */
+	matrix::Vector3f _rates_int;			/**< angular rates integral error */
+	float _thrust_sp;				/**< thrust setpoint */
+	matrix::Vector3f _att_control;			/**< attitude control vector */
 
-	math::Matrix<3, 3>	_board_rotation;	/**< rotation matrix for the orientation that the board is mounted */
+	matrix::Dcmf _board_rotation;			/**< rotation matrix for the orientation that the board is mounted */
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MC_ROLL_P>) _roll_p,
@@ -236,16 +236,16 @@ private:
 		(ParamFloat<px4::params::VT_WV_YAWR_SCL>) _vtol_wv_yaw_rate_scale		/**< Scale value [0, 1] for yaw rate setpoint  */
 	)
 
-	matrix::Vector3f _attitude_p;				/**< P gain for attitude control */
-	math::Vector<3> _rate_p;				/**< P gain for angular rate error */
-	math::Vector<3> _rate_i;				/**< I gain for angular rate error */
-	math::Vector<3> _rate_int_lim;				/**< integrator state limit for rate loop */
-	math::Vector<3> _rate_d;				/**< D gain for angular rate error */
-	math::Vector<3>	_rate_ff;				/**< Feedforward gain for desired rates */
+	matrix::Vector3f _attitude_p;		/**< P gain for attitude control */
+	matrix::Vector3f _rate_p;		/**< P gain for angular rate error */
+	matrix::Vector3f _rate_i;		/**< I gain for angular rate error */
+	matrix::Vector3f _rate_int_lim;		/**< integrator state limit for rate loop */
+	matrix::Vector3f _rate_d;		/**< D gain for angular rate error */
+	matrix::Vector3f _rate_ff;		/**< Feedforward gain for desired rates */
 
-	math::Vector<3> _mc_rate_max;				/**< attitude rate limits in stabilized modes */
-	math::Vector<3> _auto_rate_max;				/**< attitude rate limits in auto modes */
-	matrix::Vector3f _acro_rate_max;			/**< max attitude rates in acro mode */
+	matrix::Vector3f _mc_rate_max;		/**< attitude rate limits in stabilized modes */
+	matrix::Vector3f _auto_rate_max;	/**< attitude rate limits in auto modes */
+	matrix::Vector3f _acro_rate_max;	/**< max attitude rates in acro mode */
 
 };
 

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -87,42 +87,42 @@ public:
 
 private:
 
-	int		_v_att_sub;		/**< vehicle attitude subscription */
-	int		_v_att_sp_sub;			/**< vehicle attitude setpoint subscription */
-	int		_v_rates_sp_sub;		/**< vehicle rates setpoint subscription */
-	int		_v_control_mode_sub;	/**< vehicle control mode subscription */
-	int		_params_sub;			/**< parameter updates subscription */
-	int		_manual_control_sp_sub;	/**< manual control setpoint subscription */
-	int		_vehicle_status_sub;	/**< vehicle status subscription */
-	int		_motor_limits_sub;		/**< motor limits subscription */
-	int		_battery_status_sub;	/**< battery status subscription */
+	int		_v_att_sub{-1};			/**< vehicle attitude subscription */
+	int		_v_att_sp_sub{-1};		/**< vehicle attitude setpoint subscription */
+	int		_v_rates_sp_sub{-1};		/**< vehicle rates setpoint subscription */
+	int		_v_control_mode_sub{-1};	/**< vehicle control mode subscription */
+	int		_params_sub{-1};		/**< parameter updates subscription */
+	int		_manual_control_sp_sub{-1};	/**< manual control setpoint subscription */
+	int		_vehicle_status_sub{-1};	/**< vehicle status subscription */
+	int		_motor_limits_sub{-1};		/**< motor limits subscription */
+	int		_battery_status_sub{-1};	/**< battery status subscription */
 	int		_sensor_gyro_sub[MAX_GYRO_COUNT];	/**< gyro data subscription */
-	int		_sensor_correction_sub;	/**< sensor thermal correction subscription */
-	int		_sensor_bias_sub;	/**< sensor in-run bias correction subscription */
+	int		_sensor_correction_sub{-1};	/**< sensor thermal correction subscription */
+	int		_sensor_bias_sub{-1};		/**< sensor in-run bias correction subscription */
 
-	unsigned _gyro_count;
-	int _selected_gyro;
+	unsigned _gyro_count{1};
+	int _selected_gyro{0};
 
-	orb_advert_t	_v_rates_sp_pub;		/**< rate setpoint publication */
-	orb_advert_t	_actuators_0_pub;		/**< attitude actuator controls publication */
-	orb_advert_t	_controller_status_pub;	/**< controller status publication */
+	orb_advert_t	_v_rates_sp_pub{nullptr};		/**< rate setpoint publication */
+	orb_advert_t	_actuators_0_pub{nullptr};		/**< attitude actuator controls publication */
+	orb_advert_t	_controller_status_pub{nullptr};	/**< controller status publication */
 
-	orb_id_t _rates_sp_id;	/**< pointer to correct rates setpoint uORB metadata structure */
-	orb_id_t _actuators_id;	/**< pointer to correct actuator controls0 uORB metadata structure */
+	orb_id_t _rates_sp_id{nullptr};		/**< pointer to correct rates setpoint uORB metadata structure */
+	orb_id_t _actuators_id{nullptr};	/**< pointer to correct actuator controls0 uORB metadata structure */
 
-	bool		_actuators_0_circuit_breaker_enabled;	/**< circuit breaker to suppress output */
+	bool		_actuators_0_circuit_breaker_enabled{false};	/**< circuit breaker to suppress output */
 
-	struct vehicle_attitude_s		_v_att;			/**< vehicle attitude */
-	struct vehicle_attitude_setpoint_s	_v_att_sp;		/**< vehicle attitude setpoint */
-	struct vehicle_rates_setpoint_s		_v_rates_sp;		/**< vehicle rates setpoint */
-	struct manual_control_setpoint_s	_manual_control_sp;	/**< manual control setpoint */
-	struct vehicle_control_mode_s		_v_control_mode;	/**< vehicle control mode */
-	struct actuator_controls_s		_actuators;		/**< actuator controls */
-	struct vehicle_status_s			_vehicle_status;	/**< vehicle status */
-	struct battery_status_s			_battery_status;	/**< battery status */
-	struct sensor_gyro_s			_sensor_gyro;		/**< gyro data before thermal correctons and ekf bias estimates are applied */
-	struct sensor_correction_s		_sensor_correction;	/**< sensor thermal corrections */
-	struct sensor_bias_s			_sensor_bias;		/**< sensor in-run bias corrections */
+	struct vehicle_attitude_s		_v_att {};		/**< vehicle attitude */
+	struct vehicle_attitude_setpoint_s	_v_att_sp {};		/**< vehicle attitude setpoint */
+	struct vehicle_rates_setpoint_s		_v_rates_sp {};		/**< vehicle rates setpoint */
+	struct manual_control_setpoint_s	_manual_control_sp {};	/**< manual control setpoint */
+	struct vehicle_control_mode_s		_v_control_mode {};	/**< vehicle control mode */
+	struct actuator_controls_s		_actuators {};		/**< actuator controls */
+	struct vehicle_status_s			_vehicle_status {};	/**< vehicle status */
+	struct battery_status_s			_battery_status {};	/**< battery status */
+	struct sensor_gyro_s			_sensor_gyro {};	/**< gyro data before thermal correctons and ekf bias estimates are applied */
+	struct sensor_correction_s		_sensor_correction {};	/**< sensor thermal corrections */
+	struct sensor_bias_s			_sensor_bias {};	/**< sensor in-run bias corrections */
 
 	MultirotorMixer::saturation_status _saturation_status{};
 
@@ -131,7 +131,7 @@ private:
 
 	math::LowPassFilter2p _lp_filters_d[3];                      /**< low-pass filters for D-term (roll, pitch & yaw) */
 	static constexpr const float initial_update_rate_hz = 250.f; /**< loop update rate used for initialization */
-	float _loop_update_rate_hz;                                  /**< current rate-controller loop update rate in [Hz] */
+	float _loop_update_rate_hz{initial_update_rate_hz};          /**< current rate-controller loop update rate in [Hz] */
 
 	math::Vector<3>		_rates_prev;		/**< angular rates on previous step */
 	math::Vector<3>		_rates_prev_filtered;	/**< angular rates on previous step (low-pass filtered) */

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -38,6 +38,7 @@
 #include <px4_config.h>
 #include <px4_defines.h>
 #include <px4_module.h>
+#include <px4_module_params.h>
 #include <px4_posix.h>
 #include <px4_tasks.h>
 #include <uORB/topics/actuator_controls.h>
@@ -63,7 +64,7 @@ extern "C" __EXPORT int mc_att_control_main(int argc, char *argv[]);
 #define MAX_GYRO_COUNT 3
 
 
-class MulticopterAttitudeControl : public ModuleBase<MulticopterAttitudeControl>
+class MulticopterAttitudeControl : public ModuleBase<MulticopterAttitudeControl>, public ModuleParams
 {
 public:
 	MulticopterAttitudeControl();
@@ -140,100 +141,80 @@ private:
 	float			_thrust_sp;		/**< thrust setpoint */
 	math::Vector<3>		_att_control;	/**< attitude control vector */
 
-	math::Matrix<3, 3>	_board_rotation = {};	/**< rotation matrix for the orientation that the board is mounted */
+	math::Matrix<3, 3>	_board_rotation;	/**< rotation matrix for the orientation that the board is mounted */
 
-	struct {
-		param_t roll_p;
-		param_t roll_rate_p;
-		param_t roll_rate_i;
-		param_t roll_rate_integ_lim;
-		param_t roll_rate_d;
-		param_t roll_rate_ff;
-		param_t pitch_p;
-		param_t pitch_rate_p;
-		param_t pitch_rate_i;
-		param_t pitch_rate_integ_lim;
-		param_t pitch_rate_d;
-		param_t pitch_rate_ff;
-		param_t d_term_cutoff_freq;
-		param_t tpa_breakpoint_p;
-		param_t tpa_breakpoint_i;
-		param_t tpa_breakpoint_d;
-		param_t tpa_rate_p;
-		param_t tpa_rate_i;
-		param_t tpa_rate_d;
-		param_t yaw_p;
-		param_t yaw_rate_p;
-		param_t yaw_rate_i;
-		param_t yaw_rate_integ_lim;
-		param_t yaw_rate_d;
-		param_t yaw_rate_ff;
-		param_t yaw_ff;
-		param_t roll_rate_max;
-		param_t pitch_rate_max;
-		param_t yaw_rate_max;
-		param_t yaw_auto_max;
+	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::MC_ROLL_P>) _roll_p,
+		(ParamFloat<px4::params::MC_ROLLRATE_P>) _roll_rate_p,
+		(ParamFloat<px4::params::MC_ROLLRATE_I>) _roll_rate_i,
+		(ParamFloat<px4::params::MC_RR_INT_LIM>) _roll_rate_integ_lim,
+		(ParamFloat<px4::params::MC_ROLLRATE_D>) _roll_rate_d,
+		(ParamFloat<px4::params::MC_ROLLRATE_FF>) _roll_rate_ff,
 
-		param_t acro_roll_max;
-		param_t acro_pitch_max;
-		param_t acro_yaw_max;
-		param_t acro_expo;
-		param_t acro_superexpo;
-		param_t rattitude_thres;
+		(ParamFloat<px4::params::MC_PITCH_P>) _pitch_p,
+		(ParamFloat<px4::params::MC_PITCHRATE_P>) _pitch_rate_p,
+		(ParamFloat<px4::params::MC_PITCHRATE_I>) _pitch_rate_i,
+		(ParamFloat<px4::params::MC_PR_INT_LIM>) _pitch_rate_integ_lim,
+		(ParamFloat<px4::params::MC_PITCHRATE_D>) _pitch_rate_d,
+		(ParamFloat<px4::params::MC_PITCHRATE_FF>) _pitch_rate_ff,
 
-		param_t vtol_wv_yaw_rate_scale;
+		(ParamFloat<px4::params::MC_YAW_P>) _yaw_p,
+		(ParamFloat<px4::params::MC_YAWRATE_P>) _yaw_rate_p,
+		(ParamFloat<px4::params::MC_YAWRATE_I>) _yaw_rate_i,
+		(ParamFloat<px4::params::MC_YR_INT_LIM>) _yaw_rate_integ_lim,
+		(ParamFloat<px4::params::MC_YAWRATE_D>) _yaw_rate_d,
+		(ParamFloat<px4::params::MC_YAWRATE_FF>) _yaw_rate_ff,
 
-		param_t bat_scale_en;
+		(ParamFloat<px4::params::MC_YAW_FF>) _yaw_ff,					/**< yaw control feed-forward */
 
-		param_t board_rotation;
+		(ParamFloat<px4::params::MC_DTERM_CUTOFF>) _d_term_cutoff_freq,			/**< Cutoff frequency for the D-term filter */
 
-		param_t board_offset[3];
+		(ParamFloat<px4::params::MC_TPA_BREAK_P>) _tpa_breakpoint_p,			/**< Throttle PID Attenuation breakpoint */
+		(ParamFloat<px4::params::MC_TPA_BREAK_I>) _tpa_breakpoint_i,			/**< Throttle PID Attenuation breakpoint */
+		(ParamFloat<px4::params::MC_TPA_BREAK_D>) _tpa_breakpoint_d,			/**< Throttle PID Attenuation breakpoint */
+		(ParamFloat<px4::params::MC_TPA_RATE_P>) _tpa_rate_p,				/**< Throttle PID Attenuation slope */
+		(ParamFloat<px4::params::MC_TPA_RATE_I>) _tpa_rate_i,				/**< Throttle PID Attenuation slope */
+		(ParamFloat<px4::params::MC_TPA_RATE_D>) _tpa_rate_d,				/**< Throttle PID Attenuation slope */
 
-	}		_params_handles;		/**< handles for interesting parameters */
+		(ParamFloat<px4::params::MC_ROLLRATE_MAX>) _roll_rate_max,
+		(ParamFloat<px4::params::MC_PITCHRATE_MAX>) _pitch_rate_max,
+		(ParamFloat<px4::params::MC_YAWRATE_MAX>) _yaw_rate_max,
+		(ParamFloat<px4::params::MC_YAWRAUTO_MAX>) _yaw_auto_max,
 
-	struct {
-		matrix::Vector3f attitude_p;					/**< P gain for attitude control */
-		math::Vector<3> rate_p;				/**< P gain for angular rate error */
-		math::Vector<3> rate_i;				/**< I gain for angular rate error */
-		math::Vector<3> rate_int_lim;			/**< integrator state limit for rate loop */
-		math::Vector<3> rate_d;				/**< D gain for angular rate error */
-		math::Vector<3>	rate_ff;			/**< Feedforward gain for desired rates */
-		float yaw_ff;						/**< yaw control feed-forward */
+		(ParamFloat<px4::params::MC_ACRO_R_MAX>) _acro_roll_max,
+		(ParamFloat<px4::params::MC_ACRO_P_MAX>) _acro_pitch_max,
+		(ParamFloat<px4::params::MC_ACRO_Y_MAX>) _acro_yaw_max,
+		(ParamFloat<px4::params::MC_ACRO_EXPO>) _acro_expo,				/**< function parameter for expo stick curve shape */
+		(ParamFloat<px4::params::MC_ACRO_SUPEXPO>) _acro_superexpo,			/**< function parameter for superexpo stick curve shape */
 
-		float d_term_cutoff_freq;			/**< Cutoff frequency for the D-term filter */
+		(ParamFloat<px4::params::MC_RATT_TH>) _rattitude_thres,
 
-		float tpa_breakpoint_p;				/**< Throttle PID Attenuation breakpoint */
-		float tpa_breakpoint_i;				/**< Throttle PID Attenuation breakpoint */
-		float tpa_breakpoint_d;				/**< Throttle PID Attenuation breakpoint */
-		float tpa_rate_p;					/**< Throttle PID Attenuation slope */
-		float tpa_rate_i;					/**< Throttle PID Attenuation slope */
-		float tpa_rate_d;					/**< Throttle PID Attenuation slope */
+		(ParamBool<px4::params::MC_BAT_SCALE_EN>) _bat_scale_en,
 
-		float roll_rate_max;
-		float pitch_rate_max;
-		float yaw_rate_max;
-		float yaw_auto_max;
-		math::Vector<3> mc_rate_max;		/**< attitude rate limits in stabilized modes */
-		math::Vector<3> auto_rate_max;		/**< attitude rate limits in auto modes */
-		matrix::Vector3f acro_rate_max;		/**< max attitude rates in acro mode */
-		float acro_expo;					/**< function parameter for expo stick curve shape */
-		float acro_superexpo;				/**< function parameter for superexpo stick curve shape */
-		float rattitude_thres;
+		(ParamInt<px4::params::SENS_BOARD_ROT>) _board_rotation_param,
 
-		float vtol_wv_yaw_rate_scale;			/**< Scale value [0, 1] for yaw rate setpoint  */
+		(ParamFloat<px4::params::SENS_BOARD_X_OFF>) _board_offset_x,
+		(ParamFloat<px4::params::SENS_BOARD_Y_OFF>) _board_offset_y,
+		(ParamFloat<px4::params::SENS_BOARD_Z_OFF>) _board_offset_z,
 
-		int32_t bat_scale_en;
+		(ParamFloat<px4::params::VT_WV_YAWR_SCL>) _vtol_wv_yaw_rate_scale		/**< Scale value [0, 1] for yaw rate setpoint  */
+	)
 
-		int32_t board_rotation;
+	matrix::Vector3f _attitude_p;				/**< P gain for attitude control */
+	math::Vector<3> _rate_p;				/**< P gain for angular rate error */
+	math::Vector<3> _rate_i;				/**< I gain for angular rate error */
+	math::Vector<3> _rate_int_lim;				/**< integrator state limit for rate loop */
+	math::Vector<3> _rate_d;				/**< D gain for angular rate error */
+	math::Vector<3>	_rate_ff;				/**< Feedforward gain for desired rates */
 
-		float board_offset[3];
-
-	}		_params;
+	math::Vector<3> _mc_rate_max;				/**< attitude rate limits in stabilized modes */
+	math::Vector<3> _auto_rate_max;				/**< attitude rate limits in auto modes */
+	matrix::Vector3f _acro_rate_max;			/**< max attitude rates in acro mode */
 
 	/**
 	 * Update our local parameter cache.
 	 */
-	void			parameters_update();
+	void			parameters_updated();
 
 	/**
 	 * Check for parameter update and handle it.

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -88,6 +88,42 @@ public:
 
 private:
 
+	/**
+	 * initialize some vectors/matrices from parameters
+	 */
+	void			parameters_updated();
+
+	/**
+	 * Check for parameter update and handle it.
+	 */
+	void		battery_status_poll();
+	void		parameter_update_poll();
+	void		sensor_bias_poll();
+	void		sensor_correction_poll();
+	void		vehicle_attitude_poll();
+	void		vehicle_attitude_setpoint_poll();
+	void		vehicle_control_mode_poll();
+	void		vehicle_manual_poll();
+	void		vehicle_motor_limits_poll();
+	void		vehicle_rates_setpoint_poll();
+	void		vehicle_status_poll();
+
+	/**
+	 * Attitude controller.
+	 */
+	void		control_attitude(float dt);
+
+	/**
+	 * Attitude rates controller.
+	 */
+	void		control_attitude_rates(float dt);
+
+	/**
+	 * Throttle PID attenuation.
+	 */
+	math::Vector<3> pid_attenuations(float tpa_breakpoint, float tpa_rate);
+
+
 	int		_v_att_sub{-1};			/**< vehicle attitude subscription */
 	int		_v_att_sp_sub{-1};		/**< vehicle attitude setpoint subscription */
 	int		_v_rates_sp_sub{-1};		/**< vehicle rates setpoint subscription */
@@ -211,39 +247,5 @@ private:
 	math::Vector<3> _auto_rate_max;				/**< attitude rate limits in auto modes */
 	matrix::Vector3f _acro_rate_max;			/**< max attitude rates in acro mode */
 
-	/**
-	 * Update our local parameter cache.
-	 */
-	void			parameters_updated();
-
-	/**
-	 * Check for parameter update and handle it.
-	 */
-	void		battery_status_poll();
-	void		parameter_update_poll();
-	void		sensor_bias_poll();
-	void		sensor_correction_poll();
-	void		vehicle_attitude_poll();
-	void		vehicle_attitude_setpoint_poll();
-	void		vehicle_control_mode_poll();
-	void		vehicle_manual_poll();
-	void		vehicle_motor_limits_poll();
-	void		vehicle_rates_setpoint_poll();
-	void		vehicle_status_poll();
-
-	/**
-	 * Attitude controller.
-	 */
-	void		control_attitude(float dt);
-
-	/**
-	 * Attitude rates controller.
-	 */
-	void		control_attitude_rates(float dt);
-
-	/**
-	 * Throttle PID attenuation.
-	 */
-	math::Vector<3> pid_attenuations(float tpa_breakpoint, float tpa_rate);
 };
 

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -97,54 +97,13 @@ To reduce control latency, the module directly polls on the gyro topic published
 }
 
 MulticopterAttitudeControl::MulticopterAttitudeControl() :
-
-	/* subscriptions */
-	_v_att_sub(-1),
-	_v_att_sp_sub(-1),
-	_v_control_mode_sub(-1),
-	_params_sub(-1),
-	_manual_control_sp_sub(-1),
-	_vehicle_status_sub(-1),
-	_motor_limits_sub(-1),
-	_battery_status_sub(-1),
-	_sensor_correction_sub(-1),
-	_sensor_bias_sub(-1),
-
-	/* gyro selection */
-	_gyro_count(1),
-	_selected_gyro(0),
-
-	/* publications */
-	_v_rates_sp_pub(nullptr),
-	_actuators_0_pub(nullptr),
-	_controller_status_pub(nullptr),
-	_rates_sp_id(nullptr),
-	_actuators_id(nullptr),
-
-	_actuators_0_circuit_breaker_enabled(false),
-
-	_v_att{},
-	_v_att_sp{},
-	_v_rates_sp{},
-	_manual_control_sp{},
-	_v_control_mode{},
-	_actuators{},
-	_vehicle_status{},
-	_battery_status{},
-	_sensor_gyro{},
-	_sensor_correction{},
-	_sensor_bias{},
-	_saturation_status{},
-	/* performance counters */
 	_loop_perf(perf_alloc(PC_ELAPSED, "mc_att_control")),
 	_controller_latency_perf(perf_alloc_once(PC_ELAPSED, "ctrl_latency")),
 
 	_lp_filters_d{
 	{initial_update_rate_hz, 50.f},
 	{initial_update_rate_hz, 50.f},
-	{initial_update_rate_hz, 50.f}}, // will be initialized correctly when params are loaded
-
-_loop_update_rate_hz(initial_update_rate_hz)
+	{initial_update_rate_hz, 50.f}} // will be initialized correctly when params are loaded
 {
 	for (uint8_t i = 0; i < MAX_GYRO_COUNT; i++) {
 		_sensor_gyro_sub[i] = -1;

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -1017,6 +1017,22 @@ MulticopterAttitudeControl::run()
 		perf_end(_loop_perf);
 	}
 
+	orb_unsubscribe(_v_att_sub);
+	orb_unsubscribe(_v_att_sp_sub);
+	orb_unsubscribe(_v_rates_sp_sub);
+	orb_unsubscribe(_v_control_mode_sub);
+	orb_unsubscribe(_params_sub);
+	orb_unsubscribe(_manual_control_sp_sub);
+	orb_unsubscribe(_vehicle_status_sub);
+	orb_unsubscribe(_motor_limits_sub);
+	orb_unsubscribe(_battery_status_sub);
+
+	for (unsigned s = 0; s < _gyro_count; s++) {
+		orb_unsubscribe(_sensor_gyro_sub[s]);
+	}
+
+	orb_unsubscribe(_sensor_correction_sub);
+	orb_unsubscribe(_sensor_bias_sub);
 }
 
 int MulticopterAttitudeControl::task_spawn(int argc, char *argv[])

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -49,7 +49,6 @@
 #include <drivers/drv_hrt.h>
 #include <lib/geo/geo.h>
 #include <systemlib/circuit_breaker.h>
-#include <systemlib/param/param.h>
 
 #define MIN_TAKEOFF_THRUST    0.2f
 #define TPA_RATE_LOWER_LIMIT 0.05f


### PR DESCRIPTION
- use ModuleBase class and add module documentation
- move class declaration into a separate header
- switch all params from the C API to the C++ Param class
- add some missing orb_unsubscribe's

@dagar this will conflict a bit with https://github.com/PX4/Firmware/pull/9103. I can do the rebase, should it be accepted and this be merged first.