### PR TITLE
libtunes: Various bugfixes and improvements

### DIFF
--- a/src/lib/tunes/tunes.cpp
+++ b/src/lib/tunes/tunes.cpp
@@ -88,6 +88,7 @@ void Tunes::config_tone(bool repeat_flag)
 int Tunes::set_control(const tune_control_s &tune_control)
 {
 	bool reset_playing_tune = false;
+	_repeat = false;
 
 	if (tune_control.tune_id < _default_tunes_size) {
 		switch (tune_control.tune_id) {

--- a/src/lib/tunes/tunes.cpp
+++ b/src/lib/tunes/tunes.cpp
@@ -62,7 +62,7 @@ Tunes::Tunes(unsigned default_tempo, unsigned default_octave, unsigned default_n
 	config_tone(false);
 }
 
-Tunes::Tunes(): Tunes(120, 4, 4, NoteMode::NORMAL)
+Tunes::Tunes(): Tunes(TUNE_DEFAULT_TEMPO, TUNE_DEFAULT_OCTAVE, TUNE_DEFAULT_NOTE_LENGTH, NoteMode::NORMAL)
 {
 }
 
@@ -141,7 +141,7 @@ int Tunes::set_control(const tune_control_s &tune_control)
 	return OK;
 }
 
-void Tunes::set_string(const char *string)
+void Tunes::set_string(const char *const string)
 {
 	// set tune string the first time
 	if (_tune == nullptr) {
@@ -353,13 +353,13 @@ tune_end:
 	}
 }
 
-unsigned Tunes::note_to_frequency(unsigned note)
+uint32_t Tunes::note_to_frequency(unsigned note) const
 {
 	// compute the frequency (Hz)
 	return (unsigned)(880.0f * powf(2.0f, ((int)note - 46) / 12.0f));
 }
 
-unsigned Tunes::note_duration(unsigned &silence, unsigned note_length, unsigned dots)
+unsigned Tunes::note_duration(unsigned &silence, unsigned note_length, unsigned dots) const
 {
 	unsigned whole_note_period = BEAT_TIME_CONVERSION / _tempo;
 
@@ -396,7 +396,7 @@ unsigned Tunes::note_duration(unsigned &silence, unsigned note_length, unsigned 
 	return note_period;
 }
 
-unsigned Tunes::rest_duration(unsigned rest_length, unsigned dots)
+unsigned Tunes::rest_duration(unsigned rest_length, unsigned dots) const
 {
 	unsigned whole_note_period = BEAT_TIME_CONVERSION / _tempo;
 

--- a/src/lib/tunes/tunes.cpp
+++ b/src/lib/tunes/tunes.cpp
@@ -110,7 +110,12 @@ int Tunes::set_control(const tune_control_s &tune_control)
 		reset(_repeat);
 
 		// Strength will remain valid for the entire tune, unless interrupted.
-		_strength = (unsigned)tune_control.strength;
+		if ((unsigned)tune_control.strength <= TUNE_MAX_STRENGTH) {
+			_strength = (unsigned)tune_control.strength;
+
+		} else {
+			_strength = TUNE_MAX_STRENGTH;
+		}
 
 		// Special treatment for custom tunes
 		if (tune_control.tune_id == static_cast<int>(TuneID::CUSTOM)) {
@@ -138,7 +143,13 @@ void Tunes::set_string(const char *const string, uint8_t strength)
 		_tune = string;
 		_tune_start_ptr = string;
 		_next = _tune;
-		_strength = strength;
+
+		if (strength <= TUNE_MAX_STRENGTH) {
+			_strength = strength;
+
+		} else {
+			_strength = TUNE_MAX_STRENGTH;
+		}
 	}
 }
 

--- a/src/lib/tunes/tunes.cpp
+++ b/src/lib/tunes/tunes.cpp
@@ -92,10 +92,13 @@ int Tunes::set_control(const tune_control_s &tune_control)
 	if (tune_control.tune_id < _default_tunes_size) {
 		switch (tune_control.tune_id) {
 		case static_cast<int>(TuneID::CUSTOM):
-			_frequency = (unsigned)tune_control.frequency;
-			_duration = (unsigned)tune_control.duration;
-			_silence = (unsigned)tune_control.silence;
-			_using_custom_msg = true;
+			if (_tune == nullptr || tune_control.tune_override) {
+				_frequency = (unsigned)tune_control.frequency;
+				_duration = (unsigned)tune_control.duration;
+				_silence = (unsigned)tune_control.silence;
+				_using_custom_msg = true;
+			}
+
 			break;
 
 		// tunes that have a high priority

--- a/src/lib/tunes/tunes.cpp
+++ b/src/lib/tunes/tunes.cpp
@@ -89,7 +89,6 @@ int Tunes::set_control(const tune_control_s &tune_control)
 {
 	// Sanity check
 	if (tune_control.tune_id >= _default_tunes_size) {
-		PX4_WARN("Tune ID not recognized.");
 		return -EINVAL;
 	}
 

--- a/src/lib/tunes/tunes.cpp
+++ b/src/lib/tunes/tunes.cpp
@@ -59,14 +59,14 @@ Tunes::Tunes(unsigned default_tempo, unsigned default_octave, unsigned default_n
 	_default_mode(default_mode),
 	_default_octave(default_octave)
 {
-	config_tone(false);
+	reset(false);
 }
 
 Tunes::Tunes(): Tunes(TUNE_DEFAULT_TEMPO, TUNE_DEFAULT_OCTAVE, TUNE_DEFAULT_NOTE_LENGTH, NoteMode::NORMAL)
 {
 }
 
-void Tunes::config_tone(bool repeat_flag)
+void Tunes::reset(bool repeat_flag)
 {
 	// reset pointer
 	if (!repeat_flag)	{
@@ -122,7 +122,7 @@ int Tunes::set_control(const tune_control_s &tune_control)
 		case static_cast<int>(TuneID::NOTIFY_NEUTRAL):
 		case static_cast<int>(TuneID::NOTIFY_NEGATIVE):
 			reset_playing_tune = true;
-			config_tone(false);
+			reset(false);
 
 		/* FALLTHROUGH */
 		default:
@@ -358,12 +358,12 @@ int Tunes::get_next_tune(unsigned &frequency, unsigned &duration,
 tune_error:
 	// syslog(LOG_ERR, "tune error\n");
 	_repeat = false;		// don't loop on error
-	config_tone(_repeat);
+	reset(_repeat);
 	return TUNE_ERROR;
 	// stop (and potentially restart) the tune
 tune_end:
 	// restore intial parameter
-	config_tone(_repeat);
+	reset(_repeat);
 
 	if (_repeat) {
 		return TUNE_CONTINUE;

--- a/src/lib/tunes/tunes.cpp
+++ b/src/lib/tunes/tunes.cpp
@@ -115,7 +115,6 @@ int Tunes::set_control(const tune_control_s &tune_control)
 		// Special treatment for custom tunes
 		if (tune_control.tune_id == static_cast<int>(TuneID::CUSTOM)) {
 			_using_custom_msg = true;
-			_tune = nullptr;  // remove tune in case of override
 			_frequency = (unsigned)tune_control.frequency;
 			_duration = (unsigned)tune_control.duration;
 			_silence = (unsigned)tune_control.silence;
@@ -144,7 +143,7 @@ void Tunes::set_string(const char *const string, uint8_t strength)
 }
 
 int Tunes::get_next_tune(unsigned &frequency, unsigned &duration,
-			 unsigned &silence, unsigned &strength)
+			 unsigned &silence, uint8_t &strength)
 {
 	int ret = get_next_tune(frequency, duration, silence);
 

--- a/src/lib/tunes/tunes.cpp
+++ b/src/lib/tunes/tunes.cpp
@@ -94,6 +94,7 @@ int Tunes::set_control(const tune_control_s &tune_control)
 		switch (tune_control.tune_id) {
 		case static_cast<int>(TuneID::CUSTOM):
 			if (_tune == nullptr || tune_control.tune_override) {
+				_tune = nullptr;  // remove tune in case of override
 				_frequency = (unsigned)tune_control.frequency;
 				_duration = (unsigned)tune_control.duration;
 				_silence = (unsigned)tune_control.silence;

--- a/src/lib/tunes/tunes.cpp
+++ b/src/lib/tunes/tunes.cpp
@@ -96,6 +96,10 @@ int Tunes::set_control(const tune_control_s &tune_control)
 		_repeat = false;
 		_using_custom_msg = false;
 		_tune = nullptr;
+
+		// New tune will be played. This is the place to store the strength
+		// which will remain valid for the entire tune, unless interrupted.
+		_strength = (unsigned)tune_control.strength;
 	}
 
 	if (tune_control.tune_id < _default_tunes_size) {
@@ -151,7 +155,24 @@ void Tunes::set_string(const char *const string)
 	}
 }
 
-int Tunes::get_next_tune(unsigned &frequency, unsigned &duration, unsigned &silence)
+int Tunes::get_next_tune(unsigned &frequency, unsigned &duration,
+			 unsigned &silence, unsigned &strength)
+{
+	int ret = get_next_tune(frequency, duration, silence);
+
+	// Check if note should not be heard -> adjust strength to 0 to be safe
+	if (frequency == 0 || duration == 0) {
+		strength = 0;
+
+	} else {
+		strength = _strength;
+	}
+
+	return ret;
+}
+
+int Tunes::get_next_tune(unsigned &frequency, unsigned &duration,
+			 unsigned &silence)
 {
 	// Return the vaules for frequency and duration if the custom msg was received
 	if (_using_custom_msg) {
@@ -331,7 +352,6 @@ int Tunes::get_next_tune(unsigned &frequency, unsigned &duration, unsigned &sile
 
 	// compute the note frequency
 	frequency = note_to_frequency(note);
-
 	return TUNE_CONTINUE;
 
 	// tune looks bad (unexpected EOF, bad character, etc.)

--- a/src/lib/tunes/tunes.cpp
+++ b/src/lib/tunes/tunes.cpp
@@ -88,7 +88,15 @@ void Tunes::config_tone(bool repeat_flag)
 int Tunes::set_control(const tune_control_s &tune_control)
 {
 	bool reset_playing_tune = false;
-	_repeat = false;
+
+	// Only reset these flags if the new tune will actually be played.
+	// Note that repeated tunes can always be interrupted, even without the
+	// override flag.
+	if (_repeat || _tune == nullptr || tune_control.tune_override) {
+		_repeat = false;
+		_using_custom_msg = false;
+		_tune = nullptr;
+	}
 
 	if (tune_control.tune_id < _default_tunes_size) {
 		switch (tune_control.tune_id) {

--- a/src/lib/tunes/tunes.cpp
+++ b/src/lib/tunes/tunes.cpp
@@ -131,14 +131,15 @@ int Tunes::set_control(const tune_control_s &tune_control)
 	return OK;
 }
 
-void Tunes::set_string(const char *const string)
+void Tunes::set_string(const char *const string, uint8_t strength)
 {
-	// Only play new tune if current tune is a repeated one nothing is being played
-	if (_repeat || _tune == nullptr) {
+	// Only play new tune if nothing is being played currently
+	if (_tune == nullptr) {
 		// set tune string the first time
 		_tune = string;
 		_tune_start_ptr = string;
 		_next = _tune;
+		_strength = strength;
 	}
 }
 

--- a/src/lib/tunes/tunes.h
+++ b/src/lib/tunes/tunes.h
@@ -106,6 +106,18 @@ public:
 	int get_next_tune(unsigned &frequency, unsigned &duration, unsigned &silence);
 
 	/**
+	 * Get next note in the current tune, which has been provided by either
+	 * set_control or play_string
+	 * @param  frequency return frequency value (Hz)
+	 * @param  duration  return duration of the tone (us)
+	 * @param  silence   return silence duration (us)
+	 * @param  strength  return the strength of the note (between 0-100)
+	 * @return           -1 for error, 0 for play one tone and 1 for continue a sequence
+	 */
+	int get_next_tune(unsigned &frequency, unsigned &duration, unsigned &silence,
+			  unsigned &strength);
+
+	/**
 	 *  Get the number of default tunes. This is useful for when a tune is
 	 *  requested via its tune ID.
 	 *  @return		Number of default tunes accessible via tune ID
@@ -136,6 +148,7 @@ private:
 	unsigned _frequency;
 	unsigned _duration;
 	unsigned _silence;
+	unsigned _strength;
 	bool _using_custom_msg = false;
 
 	/**

--- a/src/lib/tunes/tunes.h
+++ b/src/lib/tunes/tunes.h
@@ -46,6 +46,8 @@
 #define TUNE_DEFAULT_TEMPO 120
 #define TUNE_DEFAULT_OCTAVE 4
 #define TUNE_DEFAULT_NOTE_LENGTH 4
+#define TUNE_MAX_STRENGTH 100
+
 
 /**
  *  Library for parsing tunes from melody-strings or dedicated tune messages.

--- a/src/lib/tunes/tunes.h
+++ b/src/lib/tunes/tunes.h
@@ -73,9 +73,6 @@ public:
 	 */
 	Tunes(unsigned default_tempo, unsigned default_octave, unsigned default_note_length, NoteMode default_mode);
 
-	/**
-	 * Default destructor
-	 */
 	~Tunes() = default;
 
 	/**

--- a/src/lib/tunes/tunes.h
+++ b/src/lib/tunes/tunes.h
@@ -203,8 +203,10 @@ private:
 	unsigned next_dots();
 
 	/**
-	 * if repeat false set the tune parameters to default else point to the beginning of the tune
+	 * Reset the tune parameters. This is necessary when for example a tune moved
+	 * one or more octaves up or down. reset() should always be called before
+	 * (re)-starting a tune.
 	 */
-	void config_tone(bool repeat);
+	void reset(bool repeat_flag);
 
 };

--- a/src/lib/tunes/tunes.h
+++ b/src/lib/tunes/tunes.h
@@ -96,7 +96,7 @@ private:
 	static const char *_default_tunes[];
 	static const uint8_t _note_tab[];
 	static const unsigned int _default_tunes_size;
-	bool _repeat;	///< if true, tune restarts at end
+	bool _repeat = false;	     ///< if true, tune restarts at end
 
 	const char *_tune = nullptr; ///< current tune string
 	const char *_next = nullptr; ///< next note in the string

--- a/src/lib/tunes/tunes.h
+++ b/src/lib/tunes/tunes.h
@@ -93,7 +93,7 @@ public:
 	 *
 	 * @param  string    tune input string
 	 */
-	void set_string(const char *const string);
+	void set_string(const char *const string, uint8_t strength);
 
 	/**
 	 * Get next note in the current tune, which has been provided by either
@@ -115,7 +115,7 @@ public:
 	 * @return           -1 for error, 0 for play one tone and 1 for continue a sequence
 	 */
 	int get_next_tune(unsigned &frequency, unsigned &duration, unsigned &silence,
-			  unsigned &strength);
+			  uint8_t &strength);
 
 	/**
 	 *  Get the number of default tunes. This is useful for when a tune is
@@ -148,7 +148,7 @@ private:
 	unsigned _frequency;
 	unsigned _duration;
 	unsigned _silence;
-	unsigned _strength;
+	uint8_t _strength;
 	bool _using_custom_msg = false;
 
 	/**

--- a/src/systemcmds/tune_control/tune_control.cpp
+++ b/src/systemcmds/tune_control/tune_control.cpp
@@ -71,6 +71,8 @@ usage()
 		"\t-d <duration>\t\tDuration of the tone in us\n"
 		"\t-s <strength>\t\tStrength of the tone between 0-100\n"
 		"\t-m <melody>\t\tMelody in a string form ex: \"MFT200e8a8a\"\n"
+		"\n"
+		"tune_control stop \t\t Stops playback, useful for repeated tunes\n"
 	);
 }
 
@@ -185,7 +187,7 @@ tune_control_main(int argc, char *argv[])
 				usleep(duration + silence);
 				exit_counter++;
 
-				// exit if the loop is doing more thatn 50 iteration
+				// exit if the loop is doing too many iterations
 				if (exit_counter > MAX_NOTE_ITERATION) {
 					break;
 				}
@@ -193,7 +195,7 @@ tune_control_main(int argc, char *argv[])
 
 			PX4_INFO("Playback finished.");
 
-		} else {
+		} else {  // tune id instead of string has been provided
 			if (tune_control.tune_id == 0) {
 				tune_control.tune_id = 1;
 			}
@@ -210,13 +212,22 @@ tune_control_main(int argc, char *argv[])
 			usleep(500000);
 			exit_counter++;
 
-			// exit if the loop is doing more thatn 50 iteration
+			// exit if the loop is doing too many iterations
 			if (exit_counter > MAX_NOTE_ITERATION) {
 				break;
 			}
 		}
 
-	} else {
+	} else if (!strcmp(argv[myoptind], "stop")) {
+		PX4_INFO("Stopping playback...");
+		tune_control.tune_id = 0;
+		tune_control.frequency = 0;
+		tune_control.duration = 0;
+		tune_control.silence = 0;
+		tune_control.tune_override = true;
+		publish_tune_control(tune_control);
+
+	}	else {
 		usage();
 		return 1;
 	}

--- a/src/systemcmds/tune_control/tune_control.cpp
+++ b/src/systemcmds/tune_control/tune_control.cpp
@@ -72,7 +72,7 @@ usage()
 		"\t-s <strength>\t\tStrength of the tone between 0-100\n"
 		"\t-m <melody>\t\tMelody in a string form ex: \"MFT200e8a8a\"\n"
 		"\n"
-		"tune_control stop \t\t Stops playback, useful for repeated tunes\n"
+		"tune_control stop \t\tStops playback, useful for repeated tunes\n"
 	);
 }
 
@@ -147,7 +147,7 @@ tune_control_main(int argc, char *argv[])
 			break;
 
 		case 's':
-			value = (uint16_t)(strtol(myoptarg, nullptr, 0));
+			value = (uint8_t)(strtol(myoptarg, nullptr, 0));
 
 			if (value > 0 && value < 100) {
 				tune_control.strength = value;
@@ -170,20 +170,21 @@ tune_control_main(int argc, char *argv[])
 		return 1;
 	}
 
-	unsigned frequency, duration, silence, strength;
+	unsigned frequency, duration, silence;
+	uint8_t strength;
 	int exit_counter = 0;
 
 	if (!strcmp(argv[myoptind], "play")) {
 		if (string_input) {
 			PX4_INFO("Start playback...");
-			tunes.set_string(tune_string);
+			tunes.set_string(tune_string, tune_control.strength);
 
 			while (tunes.get_next_tune(frequency, duration, silence, strength) > 0) {
 				tune_control.tune_id = 0;
 				tune_control.frequency = (uint16_t)frequency;
 				tune_control.duration = (uint32_t)duration;
 				tune_control.silence = (uint32_t)silence;
-				tune_control.strength = (uint32_t)strength;
+				tune_control.strength = (uint8_t)strength;
 				publish_tune_control(tune_control);
 				usleep(duration + silence);
 				exit_counter++;

--- a/src/systemcmds/tune_control/tune_control.cpp
+++ b/src/systemcmds/tune_control/tune_control.cpp
@@ -207,7 +207,11 @@ tune_control_main(int argc, char *argv[])
 		}
 
 	} else if (!strcmp(argv[myoptind], "libtest")) {
-		tunes.set_control(tune_control);
+		int ret = tunes.set_control(tune_control);
+
+		if (ret == -EINVAL) {
+			PX4_WARN("Tune ID not recognized.");
+		}
 
 		while (tunes.get_next_tune(frequency, duration, silence, strength) > 0) {
 			PX4_INFO("frequency: %d, duration %d, silence %d, strength%d",

--- a/src/systemcmds/tune_control/tune_control.cpp
+++ b/src/systemcmds/tune_control/tune_control.cpp
@@ -170,7 +170,7 @@ tune_control_main(int argc, char *argv[])
 		return 1;
 	}
 
-	unsigned frequency, duration, silence;
+	unsigned frequency, duration, silence, strength;
 	int exit_counter = 0;
 
 	if (!strcmp(argv[myoptind], "play")) {
@@ -178,11 +178,12 @@ tune_control_main(int argc, char *argv[])
 			PX4_INFO("Start playback...");
 			tunes.set_string(tune_string);
 
-			while (tunes.get_next_tune(frequency, duration, silence) > 0) {
+			while (tunes.get_next_tune(frequency, duration, silence, strength) > 0) {
 				tune_control.tune_id = 0;
 				tune_control.frequency = (uint16_t)frequency;
 				tune_control.duration = (uint32_t)duration;
 				tune_control.silence = (uint32_t)silence;
+				tune_control.strength = (uint32_t)strength;
 				publish_tune_control(tune_control);
 				usleep(duration + silence);
 				exit_counter++;
@@ -207,8 +208,9 @@ tune_control_main(int argc, char *argv[])
 	} else if (!strcmp(argv[myoptind], "libtest")) {
 		tunes.set_control(tune_control);
 
-		while (tunes.get_next_tune(frequency, duration, silence) > 0) {
-			PX4_INFO("frequency: %d, duration %d, silence %d", frequency, duration, silence);
+		while (tunes.get_next_tune(frequency, duration, silence, strength) > 0) {
+			PX4_INFO("frequency: %d, duration %d, silence %d, strength%d",
+				 frequency, duration, silence, strength);
 			usleep(500000);
 			exit_counter++;
 


### PR DESCRIPTION
@bkueng Could you take a look? This is part 2/2 of my libtunes additions, part 1/2 being #9096.

### Bugfixes
* Custom messages (id 0) would always override everything. In my opinion, this is what the `override` flag in the tune message is for. 
* Repeated tunes (for example the battery warning) could not be interrupted except with other high-priority tunes, which are:
  https://github.com/PX4/Firmware/blob/d87b7ac7f4f3a86b49b64a976e982e469d361bd0/src/lib/tunes/tunes.cpp#L101-L106
* Occasionally, repeated tunes would not be played back repeatedly (`_repeat` was uninitialized and most compilers would set it to 0 then, but not all I guess).
* Fixed playback of string melodies (when calling `tune_control play -m "<melody_string>"` for example)

### Improvements
* **New rule / open for discussion**: repeated tunes can be interrupted by any other tune without the override flag. I also experimented with a version where repeated tunes could be interrupted by non-repeated tunes. Once the latter are finished being played, the repeated tune would be resumed. It's probably the most intuitive solution, but I'd like your input before I code it up with all its corner cases.
  In the current implementation this means, that repeated tunes have lowest priority, followed by normal tunes, followed by tunes with hard-coded high-priority, followed by tunes with the `tune_override` flag set. In the future I assume that the hard-coded priorities will be removed and the override flag correctly used instead.
* General cleanup / type fixes 
* Added tune strength to output `int Tunes::get_next_tune()`. This way the code playing back the tunes does not need to store the strength separately. Also, when tunes are interrupted or overridden, a player would not know that it might have to adjust the strength for a new tune. With this change, libtunes keeps track of the tune strength.
* Removed the switch-case statement in `tunes.cpp` and replaced it with an if-statement for better code readability. 

---- 
Tested on a pixracer (`px4fmu-v4_default`) with a piezo buzzer and the `tune_control` system command.
