### PR TITLE
MPU6000: unadvertises the accel and gyro uORB topics in destructor

### DIFF
--- a/src/drivers/imu/mpu6000/mpu6000.cpp
+++ b/src/drivers/imu/mpu6000/mpu6000.cpp
@@ -594,6 +594,9 @@ MPU6000::~MPU6000()
 	/* make sure we are truly inactive */
 	stop();
 
+	orb_unadvertise(_accel_topic);
+	orb_unadvertise(_gyro->_gyro_topic);
+
 	/* delete the gyro subdriver */
 	delete _gyro;
 


### PR DESCRIPTION
The uORB topics were not being destroyed correctly in the destructor. This meant that if the driver was stopped and then restarted, the messages would not be published on the uORB correctly.

This commit now unadvertises the uORB topics in the destructor, similarly to what is done in the MPU9250 driver.