### PR TITLE
Yaw mode manual auto

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -393,9 +393,9 @@ private:
 
 	bool manual_wants_takeoff();
 
-	void yaw_from_mode_auto(); /**< MIS_YAWMODE defines the heading of the  in auto mode */
+	void yaw_from_mode_auto(); /**< MPC_YAWMODE defines the heading of the  in auto mode */
 
-	void yaw_from_mode_manual(); /**< MIS_YAWMODE defines the heading of the vehicle in manual mode */
+	void yaw_from_mode_manual(); /**< MPC_YAWMODE defines the heading of the vehicle in manual mode */
 
 	/**
 	 * Shim for calling task_main from task_create.
@@ -459,7 +459,7 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_jerk_hor_max(this, "JERK_MAX", true),
 	_jerk_hor_min(this, "JERK_MIN", true),
 	_mis_yaw_error(this, "MIS_YAW_ERR", false),
-	_yaw_mode(this, "MIS_YAWMODE", false),
+	_yaw_mode(this, "MPC_YAWMODE", false),
 	_vel_x_deriv(this, "VELD"),
 	_vel_y_deriv(this, "VELD"),
 	_vel_z_deriv(this, "VELD"),

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -393,9 +393,9 @@ private:
 
 	bool manual_wants_takeoff();
 
-	void yaw_from_mode_auto(); /**< MIS_YAWMODE defined the heading of the vehicle */
+	void yaw_from_mode_auto(); /**< MIS_YAWMODE defines the heading of the  in auto mode */
 
-
+	void yaw_from_mode_manual(); /**< MIS_YAWMODE defines the heading of the vehicle in manual mode */
 
 	/**
 	 * Shim for calling task_main from task_create.
@@ -2874,25 +2874,7 @@ MulticopterPositionControl::generate_attitude_setpoint()
 
 	} else if (!_vehicle_land_detected.landed &&
 		   !(!_control_mode.flag_control_altitude_enabled && _manual.z < 0.1f)) {
-
-		/* do not move yaw while sitting on the ground */
-
-		/* we want to know the real constraint, and global overrides manual */
-		const float yaw_rate_max = (_params.man_yaw_max < _params.global_yaw_max) ? _params.man_yaw_max :
-					   _params.global_yaw_max;
-		const float yaw_offset_max = yaw_rate_max / _params.mc_att_yaw_p;
-
-		_att_sp.yaw_sp_move_rate = _manual.r * yaw_rate_max;
-		float yaw_target = _wrap_pi(_att_sp.yaw_body + _att_sp.yaw_sp_move_rate * _dt);
-		float yaw_offs = _wrap_pi(yaw_target - _yaw);
-
-		// If the yaw offset became too big for the system to track stop
-		// shifting it, only allow if it would make the offset smaller again.
-		if (fabsf(yaw_offs) < yaw_offset_max ||
-		    (_att_sp.yaw_sp_move_rate > 0 && yaw_offs < 0) ||
-		    (_att_sp.yaw_sp_move_rate < 0 && yaw_offs > 0)) {
-			_att_sp.yaw_body = yaw_target;
-		}
+		yaw_from_mode_manual();
 	}
 
 	/* control throttle directly if no climb rate controller is active */
@@ -3073,8 +3055,69 @@ void MulticopterPositionControl::yaw_from_mode_auto()
 		// Dot product: (x(0)*v(0)+(x(1)*v(1)) = v(0)
 		// Cross product: x(0)*v(1) - v(0)*x(1) = v(1)
 		_att_sp.yaw_body = math::sign(v(1)) * _wrap_pi(acosf(v(0)));
-		//PX4_INFO("sp: %.5f, yaw: %.5f",(double)_att_sp.yaw_body, (double)_yaw);
+	}
+}
 
+void MulticopterPositionControl::yaw_from_mode_manual()
+{
+	matrix::Vector2f v; // Vector that points towards desired location
+
+	switch (_yaw_mode.get()) {
+	case 0: {
+			// Heading is not changing.
+			break;
+		}
+
+	case 1: {
+			// Heading is set by manual setpoint.
+			// maximum yaw rate
+			const float yaw_rate_max =
+				(_params.man_yaw_max < _params.global_yaw_max) ?
+				_params.man_yaw_max : _params.global_yaw_max;
+			const float yaw_offset_max = yaw_rate_max / _params.mc_att_yaw_p;
+
+			_att_sp.yaw_sp_move_rate = _manual.r * yaw_rate_max;
+			float yaw_target = _wrap_pi(
+						   _att_sp.yaw_body + _att_sp.yaw_sp_move_rate * _dt);
+			float yaw_offs = _wrap_pi(yaw_target - _yaw);
+
+			// If the yaw offset became too big for the system to track stop
+			// shifting it, only allow if it would make the offset smaller again.
+			if (fabsf(yaw_offs) < yaw_offset_max
+			    || (_att_sp.yaw_sp_move_rate > 0 && yaw_offs < 0)
+			    || (_att_sp.yaw_sp_move_rate < 0 && yaw_offs > 0)) {
+				_att_sp.yaw_body = yaw_target;
+			}
+
+			break;
+		}
+
+	case 2:
+
+		// Heading towards home
+		if (_home_pos.valid_hpos) {
+			v = matrix::Vector2f(_home_pos.x, _home_pos.y) - matrix::Vector2f(&_pos(0));
+		}
+
+	case 3: {
+			// Heading away from home
+			if (_home_pos.valid_hpos && v.length() < FLT_EPSILON) {
+				v = matrix::Vector2f(&_pos(0)) - matrix::Vector2f(_home_pos.x, _home_pos.y);
+			}
+
+			// We only adjust yaw if outside of acceptance radius.
+			// This prevents excessive yawing.
+			if (v.length() > _nav_rad.get()) {
+				v.normalize();
+				// To find yaw: take dot product of x = (1,0) and v
+				// and multiply by the sign given of cross product of x and v.
+				// Dot product: (x(0)*v(0)+(x(1)*v(1)) = v(0)
+				// Cross product: x(0)*v(1) - v(0)*x(1) = v(1)
+				_att_sp.yaw_body = math::sign(v(1)) * _wrap_pi(acosf(v(0)));
+			}
+
+			break;
+		}
 	}
 }
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3016,19 +3016,17 @@ void MulticopterPositionControl::yaw_from_mode_auto()
 	switch (_yaw_mode.get()) {
 	case 0: {
 			// Heading is set by waypoint.
-			// Don't have anything to do because
-			// it is already taken care by a valid triplet yaw.
 			break;
 		}
 
 	case 1: {
-			// Heading is always towards the current waypoint.
+			// Heading points towards the current waypoint.
 			v = matrix::Vector2f(&_curr_pos_sp(0)) - matrix::Vector2f(&_pos(0));
 			break;
 		}
 
 	case 2: {
-			// Heading towards home
+			// Heading points towards home.
 			if (_home_pos.valid_hpos) {
 				v = matrix::Vector2f(_home_pos.x, _home_pos.y) -  matrix::Vector2f(&_pos(0));
 			}
@@ -3037,7 +3035,7 @@ void MulticopterPositionControl::yaw_from_mode_auto()
 		}
 
 	case 3: {
-			// Heading away from home
+			// Heading points away from home.
 			if (_home_pos.valid_hpos) {
 				v = matrix::Vector2f(&_pos(0)) -  matrix::Vector2f(_home_pos.x, _home_pos.y);
 			}
@@ -3046,7 +3044,7 @@ void MulticopterPositionControl::yaw_from_mode_auto()
 		}
 	}
 
-	// We only adjust yaw if outside of acceptance radius.
+	// We only adjust yaw if vehicle is outside of acceptance radius.
 	// This prevents excessive yawing.
 	if (v.length() > _nav_rad.get()) {
 		v.normalize();
@@ -3064,7 +3062,7 @@ void MulticopterPositionControl::yaw_from_mode_manual()
 
 	switch (_yaw_mode.get()) {
 	case 0: {
-			// Heading is not changing.
+			// Heading is not changing and equals vehicle yaw when sitched to case 0.
 			break;
 		}
 
@@ -3094,13 +3092,13 @@ void MulticopterPositionControl::yaw_from_mode_manual()
 
 	case 2:
 
-		// Heading towards home
+		// Heading points towards home.
 		if (_home_pos.valid_hpos) {
 			v = matrix::Vector2f(_home_pos.x, _home_pos.y) - matrix::Vector2f(&_pos(0));
 		}
 
 	case 3: {
-			// Heading away from home
+			// Heading points away from home.
 			if (_home_pos.valid_hpos && v.length() < FLT_EPSILON) {
 				v = matrix::Vector2f(&_pos(0)) - matrix::Vector2f(_home_pos.x, _home_pos.y);
 			}
@@ -3121,8 +3119,7 @@ void MulticopterPositionControl::yaw_from_mode_manual()
 	}
 }
 
-void
-MulticopterPositionControl::task_main()
+void MulticopterPositionControl::task_main()
 {
 	/*
 	 * do subscriptions

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -179,6 +179,7 @@ private:
 	control::BlockParamFloat _jerk_hor_max; /**< maximum jerk in manual controlled mode when braking to zero */
 	control::BlockParamFloat _jerk_hor_min; /**< minimum jerk in manual controlled mode when braking to zero */
 	control::BlockParamFloat _mis_yaw_error; /**< yaw error threshold that is used in mission as update criteria */
+	control::BlockParamInt _yaw_mode; /**< Yaw modes: towards/from home; towards target; set by waypoint; normal */
 	control::BlockDerivative _vel_x_deriv;
 	control::BlockDerivative _vel_y_deriv;
 	control::BlockDerivative _vel_z_deriv;
@@ -386,14 +387,15 @@ private:
 
 	void set_manual_acceleration_z(float &max_acc_z, const float stick_input_z_NED);
 
-	/**
-	 * limit altitude based on several conditions
-	 */
 	void limit_altitude();
 
 	void warn_rate_limited(const char *str);
 
 	bool manual_wants_takeoff();
+
+	void yaw_from_mode_auto(); /**< MIS_YAWMODE defined the heading of the vehicle */
+
+
 
 	/**
 	 * Shim for calling task_main from task_create.
@@ -457,6 +459,7 @@ MulticopterPositionControl::MulticopterPositionControl() :
 	_jerk_hor_max(this, "JERK_MAX", true),
 	_jerk_hor_min(this, "JERK_MIN", true),
 	_mis_yaw_error(this, "MIS_YAW_ERR", false),
+	_yaw_mode(this, "MIS_YAWMODE", false),
 	_vel_x_deriv(this, "VELD"),
 	_vel_y_deriv(this, "VELD"),
 	_vel_z_deriv(this, "VELD"),
@@ -1890,7 +1893,12 @@ void MulticopterPositionControl::control_auto()
 			_att_sp.yaw_body = _att_sp.yaw_body + _pos_sp_triplet.current.yawspeed * _dt;
 
 		} else if (PX4_ISFINITE(_pos_sp_triplet.current.yaw)) {
+			// Navigator has a valid yaw. Yaw-mode is ignored.
 			_att_sp.yaw_body = _pos_sp_triplet.current.yaw;
+
+		} else {
+			// No valid yaw available. Yaw is defined by the yaw mode
+			yaw_from_mode_auto();
 		}
 
 		float yaw_diff = _wrap_pi(_att_sp.yaw_body - _yaw);
@@ -3017,6 +3025,57 @@ bool MulticopterPositionControl::manual_wants_takeoff()
 
 	// Manual takeoff is triggered if the throttle stick is above 65%.
 	return (has_manual_control_present && _manual.z > 0.65f);
+}
+
+void MulticopterPositionControl::yaw_from_mode_auto()
+{
+	matrix::Vector2f v; // Vector that points towards desired location
+
+	switch (_yaw_mode.get()) {
+	case 0: {
+			// Heading is set by waypoint.
+			// Don't have anything to do because
+			// it is already taken care by a valid triplet yaw.
+			break;
+		}
+
+	case 1: {
+			// Heading is always towards the current waypoint.
+			v = matrix::Vector2f(&_curr_pos_sp(0)) - matrix::Vector2f(&_pos(0));
+			break;
+		}
+
+	case 2: {
+			// Heading towards home
+			if (_home_pos.valid_hpos) {
+				v = matrix::Vector2f(_home_pos.x, _home_pos.y) -  matrix::Vector2f(&_pos(0));
+			}
+
+			break;
+		}
+
+	case 3: {
+			// Heading away from home
+			if (_home_pos.valid_hpos) {
+				v = matrix::Vector2f(&_pos(0)) -  matrix::Vector2f(_home_pos.x, _home_pos.y);
+			}
+
+			break;
+		}
+	}
+
+	// We only adjust yaw if outside of acceptance radius.
+	// This prevents excessive yawing.
+	if (v.length() > _nav_rad.get()) {
+		v.normalize();
+		// To find yaw: take dot product of x = (1,0) and v
+		// and multiply by the sign given of cross product of x and v.
+		// Dot product: (x(0)*v(0)+(x(1)*v(1)) = v(0)
+		// Cross product: x(0)*v(1) - v(0)*x(1) = v(1)
+		_att_sp.yaw_body = math::sign(v(1)) * _wrap_pi(acosf(v(0)));
+		//PX4_INFO("sp: %.5f, yaw: %.5f",(double)_att_sp.yaw_body, (double)_yaw);
+
+	}
 }
 
 void

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -589,3 +589,18 @@ PARAM_DEFINE_FLOAT(MPC_LAND_ALT2, 5.0f);
  * @group Multicopter Position Control
  */
 PARAM_DEFINE_FLOAT(MPC_TKO_RAMP_T, 0.4f);
+
+/**
+ * Yaw mode.
+ *
+ * Specifies the heading in Auto/Manual.
+ *
+ * @min 0
+ * @max 3
+ * @value 0 Auto: set by waypoint; Manual: set by heading when switched to 0
+ * @value 1 Auto: towards waypoint; Manual
+ * @value 2 Auto/Manual: towards home
+ * @value 3 Auto/Manual: away from home
+ * @group Mission
+ */
+PARAM_DEFINE_INT32(MPC_YAWMODE, 1);

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -112,7 +112,6 @@ Loiter::set_loiter_position()
 	pos_sp_triplet->next.valid = false;
 
 	_navigator->set_can_loiter_at_sp(pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER);
-
 	_navigator->set_position_setpoint_triplet_updated();
 }
 
@@ -139,26 +138,7 @@ Loiter::reposition()
 		memcpy(&pos_sp_triplet->current, &rep->current, sizeof(rep->current));
 		pos_sp_triplet->next.valid = false;
 
-		// set yaw (depends on the value of parameter MIS_YAWMODE):
-		// MISSION_YAWMODE_NONE: do not change yaw setpoint
-		// MISSION_YAWMODE_FRONT_TO_WAYPOINT: point to next waypoint
-		if (_param_yawmode.get() != MISSION_YAWMODE_NONE) {
-			float travel_dist = get_distance_to_next_waypoint(_navigator->get_global_position()->lat,
-					    _navigator->get_global_position()->lon,
-					    pos_sp_triplet->current.lat, pos_sp_triplet->current.lon);
-
-			if (travel_dist > 1.0f) {
-				// calculate direction the vehicle should point to.
-				pos_sp_triplet->current.yaw = get_bearing_to_next_waypoint(
-								      _navigator->get_global_position()->lat,
-								      _navigator->get_global_position()->lon,
-								      pos_sp_triplet->current.lat,
-								      pos_sp_triplet->current.lon);
-			}
-		}
-
 		_navigator->set_can_loiter_at_sp(pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER);
-
 		_navigator->set_position_setpoint_triplet_updated();
 
 		// mark this as done

--- a/src/modules/navigator/loiter.h
+++ b/src/modules/navigator/loiter.h
@@ -76,9 +76,5 @@ private:
 	 */
 	void set_loiter_position();
 
-	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::MIS_YAWMODE>) _param_yawmode
-	)
-
 	bool _loiter_pos_set{false};
 };

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1016,8 +1016,7 @@ Mission::heading_sp_update()
 		case vehicle_roi_s::ROI_WPINDEX:
 		case vehicle_roi_s::ROI_TARGET:
 		case vehicle_roi_s::ROI_ENUM_END:
-		default: {
-			}
+			break;
 		}
 
 		// Get desired heading and update it.

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -215,14 +215,22 @@ Mission::on_active()
 	}
 
 	/* see if we need to update the current yaw heading */
-	if (_navigator->get_vroi().mode == vehicle_roi_s::ROI_LOCATION
-	    || (_param_yawmode.get() != MISSION_YAWMODE_NONE
-		&& _param_yawmode.get() < MISSION_YAWMODE_MAX
-		&& _mission_type != MISSION_TYPE_NONE)
-	    || _navigator->get_vstatus()->is_vtol) {
-
+	if (!_param_mnt_yaw_ctl.get() && (_navigator->get_vstatus()->is_rotary_wing)
+	    && (_navigator->get_vroi().mode != vehicle_roi_s::ROI_NONE)
+	    && !(_mission_item.nav_cmd == NAV_CMD_TAKEOFF
+		 || _mission_item.nav_cmd == NAV_CMD_VTOL_TAKEOFF
+		 || _mission_item.nav_cmd == NAV_CMD_DO_VTOL_TRANSITION
+		 || _mission_item.nav_cmd == NAV_CMD_LAND
+		 || _mission_item.nav_cmd == NAV_CMD_VTOL_LAND
+		 || _work_item_type == WORK_ITEM_TYPE_ALIGN)) {
+		// Mount control is disabled If the vehicle is in ROI-mode, the vehicle
+		// needs to rotate such that ROI is in the field of view.
+		// ROI only makes sense for multicopters.
 		heading_sp_update();
 	}
+
+	// TODO: Add vtol heading update method if required.
+	// Question: Why does vtol ever have to update heading?
 
 	/* check if landing needs to be aborted */
 	if ((_mission_item.nav_cmd == NAV_CMD_LAND)
@@ -970,112 +978,67 @@ Mission::calculate_takeoff_altitude(struct mission_item_s *mission_item)
 void
 Mission::heading_sp_update()
 {
-	/* we don't want to be yawing during takeoff, landing or aligning for a transition */
-	if (_mission_item.nav_cmd == NAV_CMD_TAKEOFF
-	    || _mission_item.nav_cmd == NAV_CMD_VTOL_TAKEOFF
-	    || _mission_item.nav_cmd == NAV_CMD_DO_VTOL_TRANSITION
-	    || _mission_item.nav_cmd == NAV_CMD_LAND
-	    || _mission_item.nav_cmd == NAV_CMD_VTOL_LAND
-	    || _work_item_type == WORK_ITEM_TYPE_ALIGN) {
+	struct position_setpoint_triplet_s *pos_sp_triplet =
+		_navigator->get_position_setpoint_triplet();
 
-		return;
-	}
+	// Only update if current triplet is valid
+	if (pos_sp_triplet->current.valid) {
 
-	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
+		double point_from_latlon[2] = { _navigator->get_global_position()->lat,
+						_navigator->get_global_position()->lon
+					      };
+		double point_to_latlon[2] = { _navigator->get_global_position()->lat,
+					      _navigator->get_global_position()->lon
+					    };
+		float yaw_offset = 0.0f;
 
-	/* Don't change setpoint if last and current waypoint are not valid */
-	if (!pos_sp_triplet->current.valid) {
-		return;
-	}
+		// Depending on ROI-mode, update heading
+		switch (_navigator->get_vroi().mode) {
+		case vehicle_roi_s::ROI_LOCATION: {
+				// ROI is a fixed location. Vehicle needs to point towards that location
+				point_to_latlon[0] = _navigator->get_vroi().lat;
+				point_to_latlon[1] = _navigator->get_vroi().lon;
+				// No yaw offset required
+				yaw_offset = 0.0f;
+				break;
+			}
 
-	/* Calculate direction the vehicle should point to. */
+		case vehicle_roi_s::ROI_WPNEXT: {
+				// ROI is current waypoint. Vehcile needs to point towards current waypoint
+				point_to_latlon[0] = pos_sp_triplet->current.lat;
+				point_to_latlon[1] = pos_sp_triplet->current.lon;
+				// Add the gimbal's yaw offset
+				yaw_offset = _navigator->get_vroi().yaw_offset;
+				break;
+			}
 
-	double point_from_latlon[2];
-	double point_to_latlon[2];
+		case vehicle_roi_s::ROI_NONE:
+		case vehicle_roi_s::ROI_WPINDEX:
+		case vehicle_roi_s::ROI_TARGET:
+		case vehicle_roi_s::ROI_ENUM_END:
+		default: {
+			}
+		}
 
-	point_from_latlon[0] = _navigator->get_global_position()->lat;
-	point_from_latlon[1] = _navigator->get_global_position()->lon;
-
-	if (_navigator->get_vroi().mode == vehicle_roi_s::ROI_LOCATION && !_param_mnt_yaw_ctl.get()) {
-		point_to_latlon[0] = _navigator->get_vroi().lat;
-		point_to_latlon[1] = _navigator->get_vroi().lon;
-
-		/* stop if positions are close together to prevent excessive yawing */
-		float d_current = get_distance_to_next_waypoint(
-					  point_from_latlon[0], point_from_latlon[1],
-					  point_to_latlon[0], point_to_latlon[1]);
+		// Get desired heading and update it.
+		// However, only update if distance to desired heading is
+		// larger than acceptance radius to prevent excessive yawing
+		float d_current = get_distance_to_next_waypoint(point_from_latlon[0],
+				  point_from_latlon[1], point_to_latlon[0], point_to_latlon[1]);
 
 		if (d_current > _navigator->get_acceptance_radius()) {
-			float yaw = get_bearing_to_next_waypoint(
-					    point_from_latlon[0], point_from_latlon[1],
-					    point_to_latlon[0], point_to_latlon[1]);
+			float yaw = _wrap_pi(
+					    get_bearing_to_next_waypoint(point_from_latlon[0],
+							    point_from_latlon[1], point_to_latlon[0],
+							    point_to_latlon[1]) + yaw_offset);
 
 			_mission_item.yaw = yaw;
 			pos_sp_triplet->current.yaw = _mission_item.yaw;
 		}
 
-	} else {
-		/* set yaw angle for the waypoint if a loiter time has been specified */
-		if (_waypoint_position_reached && get_time_inside(_mission_item) > FLT_EPSILON) {
-			// XXX: should actually be param4 from mission item
-			// at the moment it will just keep the heading it has
-			//_mission_item.yaw = _on_arrival_yaw;
-			//pos_sp_triplet->current.yaw = _mission_item.yaw;
-
-		} else {
-			/* target location is home */
-			if ((_param_yawmode.get() == MISSION_YAWMODE_FRONT_TO_HOME
-			     || _param_yawmode.get() == MISSION_YAWMODE_BACK_TO_HOME)
-			    // need to be rotary wing for this but not in a transition
-			    // in VTOL mode this will prevent updating yaw during FW flight
-			    // (which would result in a wrong yaw setpoint spike during back transition)
-			    && _navigator->get_vstatus()->is_rotary_wing
-			    && !(_mission_item.nav_cmd == NAV_CMD_DO_VTOL_TRANSITION || _navigator->get_vstatus()->in_transition_mode)) {
-
-				point_to_latlon[0] = _navigator->get_home_position()->lat;
-				point_to_latlon[1] = _navigator->get_home_position()->lon;
-
-			} else {
-				/* target location is next (current) waypoint */
-				point_to_latlon[0] = pos_sp_triplet->current.lat;
-				point_to_latlon[1] = pos_sp_triplet->current.lon;
-			}
-
-			float d_current = get_distance_to_next_waypoint(
-						  point_from_latlon[0], point_from_latlon[1],
-						  point_to_latlon[0], point_to_latlon[1]);
-
-			/* stop if positions are close together to prevent excessive yawing */
-			if (d_current > _navigator->get_acceptance_radius()) {
-				float yaw = get_bearing_to_next_waypoint(
-						    point_from_latlon[0],
-						    point_from_latlon[1],
-						    point_to_latlon[0],
-						    point_to_latlon[1]);
-
-				/* always keep the back of the rotary wing pointing towards home */
-				if (_param_yawmode.get() == MISSION_YAWMODE_BACK_TO_HOME) {
-					_mission_item.yaw = _wrap_pi(yaw + M_PI_F);
-					pos_sp_triplet->current.yaw = _mission_item.yaw;
-
-				} else if (_param_yawmode.get() == MISSION_YAWMODE_FRONT_TO_WAYPOINT
-					   && _navigator->get_vroi().mode == vehicle_roi_s::ROI_WPNEXT && !_param_mnt_yaw_ctl.get()) {
-					/* if yaw control for the mount is disabled and we have a valid ROI that points to the next
-					 * waypoint, we add the gimbal's yaw offset to the vehicle's yaw */
-					yaw += _navigator->get_vroi().yaw_offset;
-					_mission_item.yaw = yaw;
-					pos_sp_triplet->current.yaw = _mission_item.yaw;
-
-				} else {
-					_mission_item.yaw = yaw;
-					pos_sp_triplet->current.yaw = _mission_item.yaw;
-				}
-			}
-		}
+		// we set yaw directly so we can run this in parallel to the FOH update
+		_navigator->set_position_setpoint_triplet_updated();
 	}
-
-	// we set yaw directly so we can run this in parallel to the FOH update
-	_navigator->set_position_setpoint_triplet_updated();
 }
 
 void

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -231,7 +231,6 @@ private:
 		(ParamFloat<px4::params::MIS_DIST_1WP>) _param_dist_1wp,
 		(ParamFloat<px4::params::MIS_DIST_WPS>) _param_dist_between_wps,
 		(ParamInt<px4::params::MIS_ALTMODE>) _param_altmode,
-		(ParamInt<px4::params::MIS_YAWMODE>) _param_yawmode,
 		(ParamInt<px4::params::MIS_MNT_YAW_CTL>) _param_mnt_yaw_ctl
 	)
 

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -120,24 +120,9 @@ PARAM_DEFINE_FLOAT(MIS_DIST_WPS, 900);
 PARAM_DEFINE_INT32(MIS_ALTMODE, 1);
 
 /**
- * Multirotor only. Yaw setpoint mode.
- *
- * The values are defined in the enum mission_altitude_mode
- *
- * @min 0
- * @max 3
- * @value 0 Auto: set by waypoint; Manual: set by heading when switched to 0
- * @value 1 Auto: towards waypoint; Manual
- * @value 2 Auto/Manual: towards home
- * @value 3 Auto/Manual: away from home
- * @group Mission
- */
-PARAM_DEFINE_INT32(MIS_YAWMODE, 1);
-
-/**
 * Enable yaw control of the mount. (Only affects multicopters and ROI mission items)
 *
-* If enabled, yaw commands will be sent to the mount and the vehicle will follow its heading mode as specified by MIS_YAWMODE.
+* If enabled, yaw commands will be sent to the mount and the vehicle will follow its heading mode as specified by MPC_YAWMODE.
 * If disabled, the vehicle will yaw towards the ROI.
 *
 * @value 0 Disable

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -126,10 +126,10 @@ PARAM_DEFINE_INT32(MIS_ALTMODE, 1);
  *
  * @min 0
  * @max 3
- * @value 0 Heading as set by waypoint
- * @value 1 Heading towards waypoint
- * @value 2 Heading towards home
- * @value 3 Heading away from home
+ * @value 0 Auto: set by waypoint; Manual: set by heading when switched to 0
+ * @value 1 Auto: towards waypoint; Manual
+ * @value 2 Auto/Manual: towards home
+ * @value 3 Auto/Manual: away from home
  * @group Mission
  */
 PARAM_DEFINE_INT32(MIS_YAWMODE, 1);

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -156,7 +156,7 @@ RTL::set_rtl_item()
 			_mission_item.lon = gpos.lon;
 			_mission_item.altitude = climb_alt;
 			_mission_item.altitude_is_relative = false;
-			_mission_item.yaw = NAN;
+			_mission_item.yaw = _navigator->get_local_position()->yaw;
 			_mission_item.acceptance_radius = _navigator->get_acceptance_radius();
 			_mission_item.time_inside = 0.0f;
 			_mission_item.autocontinue = true;


### PR DESCRIPTION
Based on the discussion [here](https://github.com/PX4/Firmware/issues/9114).

What this PR does:
* move logic defined by MIS_YAWMODE to mc_pos_control
* Navigator has higher priority than mc_pos_control to set yaw (only applies to auto) 
  *  Navigator sends yaw if: waypoint contains yaw (!=NAN), ROI is turned on but mount has no yaw control
* MIS_YAWMODE has an affect on manual (pleas give feedback if that makes sense)
   * `0`: yaw is not changed and is equal to the yaw when MIS_YAWMODE switched to 0
   * `1`: yaw is controlled from sticks
   * `2`: heading points towards home if available. otherwise mode `0` applies.
   * `3`: heading points away from home if available. otherwise 1 mode `0` applies.

~~Although MIS_YAWMODE is not used in the navigator anymore, I kept this parameter for legacy reason.~~

@dagar, I was very confused about the `heading_sp_update` method (https://github.com/PX4/Firmware/compare/yaw_mode_manual_auto?expand=1#diff-9b5a77642a641b107c8f8a966de34acdL222), in particular about the different flags. For instance, to me it is not clear why the heading update method gets entered if the vehicle is a vtol...

The biggest advantage of PR is that for MC, the triplets are no longer sent continuously during mission.