### PR TITLE
uORB messages generated pretty print

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -165,7 +165,7 @@ add_custom_command(OUTPUT ${uorb_headers}
 		-e templates/uorb
 		-t ${CMAKE_CURRENT_BINARY_DIR}/tmp/headers
 		-q
-	DEPENDS ${msg_files}
+	DEPENDS ${msg_files} templates/uorb/msg.h.template
 	COMMENT "Generating uORB topic headers"
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 	VERBATIM
@@ -182,7 +182,7 @@ add_custom_command(OUTPUT ${uorb_sources}
 		-e templates/uorb
 		-t ${CMAKE_CURRENT_BINARY_DIR}/tmp/sources
 		-q
-	DEPENDS ${msg_files}
+	DEPENDS ${msg_files} templates/uorb/msg.cpp.template
 	COMMENT "Generating uORB topic sources"
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 	VERBATIM

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -165,7 +165,10 @@ add_custom_command(OUTPUT ${uorb_headers}
 		-e templates/uorb
 		-t ${CMAKE_CURRENT_BINARY_DIR}/tmp/headers
 		-q
-	DEPENDS ${msg_files} templates/uorb/msg.h.template
+	DEPENDS
+		${msg_files}
+		templates/uorb/msg.h.template
+		tools/px_generate_uorb_topic_files.py
 	COMMENT "Generating uORB topic headers"
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 	VERBATIM
@@ -182,7 +185,10 @@ add_custom_command(OUTPUT ${uorb_sources}
 		-e templates/uorb
 		-t ${CMAKE_CURRENT_BINARY_DIR}/tmp/sources
 		-q
-	DEPENDS ${msg_files} templates/uorb/msg.cpp.template
+	DEPENDS
+		${msg_files}
+		templates/uorb/msg.cpp.template
+		tools/px_generate_uorb_topic_files.py
 	COMMENT "Generating uORB topic sources"
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 	VERBATIM

--- a/msg/templates/uorb/msg.cpp.template
+++ b/msg/templates/uorb/msg.cpp.template
@@ -64,6 +64,9 @@ struct_size, padding_end_size = add_padding_bytes(sorted_fields, search_path)
 topic_fields = ["uint64_t timestamp"]+["%s %s" % (convert_type(field.type), field.name) for field in sorted_fields]
 }@
 
+#include <cinttypes>
+#include <cstdio>
+#include <px4_defines.h>
 #include <uORB/topics/@(topic_name).h>
 
 @# join all msg files in one line e.g: "float[3] position;float[3] velocity;bool armed"
@@ -73,3 +76,12 @@ constexpr char __orb_@(topic_name)_fields[] = "@( ";".join(topic_fields) );";
 @[for multi_topic in topics]@
 ORB_DEFINE(@multi_topic, struct @uorb_struct, @(struct_size-padding_end_size), __orb_@(topic_name)_fields);
 @[end for]
+
+void print_message(const @uorb_struct& message)
+{
+    printf(" @(uorb_struct)\n");
+	printf("\ttimestamp: %" PRIu64 "\n", message.timestamp);
+@[for field in sorted_fields]@
+	@( px4_printf(field) )
+@[end for]
+}

--- a/msg/templates/uorb/msg.cpp.template
+++ b/msg/templates/uorb/msg.cpp.template
@@ -68,6 +68,7 @@ topic_fields = ["uint64_t timestamp"]+["%s %s" % (convert_type(field.type), fiel
 #include <cstdio>
 #include <px4_defines.h>
 #include <uORB/topics/@(topic_name).h>
+#include <drivers/drv_hrt.h>
 
 @# join all msg files in one line e.g: "float[3] position;float[3] velocity;bool armed"
 @# This is used for the logger
@@ -80,7 +81,7 @@ ORB_DEFINE(@multi_topic, struct @uorb_struct, @(struct_size-padding_end_size), _
 void print_message(const @uorb_struct& message)
 {
     printf(" @(uorb_struct)\n");
-	printf("\ttimestamp: %" PRIu64 "\n", message.timestamp);
+	printf("\ttimestamp: %" PRIu64 " (%.6f seconds ago)\n", message.timestamp, hrt_elapsed_time(&message.timestamp) / 1e6);
 @[for field in sorted_fields]@
 	@( px4_printf(field) )
 @[end for]

--- a/msg/templates/uorb/msg.cpp.template
+++ b/msg/templates/uorb/msg.cpp.template
@@ -80,9 +80,14 @@ ORB_DEFINE(@multi_topic, struct @uorb_struct, @(struct_size-padding_end_size), _
 
 void print_message(const @uorb_struct& message)
 {
-    printf(" @(uorb_struct)\n");
-	printf("\ttimestamp: %" PRIu64 " (%.6f seconds ago)\n", message.timestamp, hrt_elapsed_time(&message.timestamp) / 1e6);
+	printf(" @(uorb_struct)\n");
+	printf("\ttimestamp: %" PRIu64, message.timestamp);
+	if (message.timestamp != 0) {
+		printf(" (%.6f seconds ago)\n", hrt_elapsed_time(&message.timestamp) / 1e6);
+	} else {
+		printf("\n");
+	}
 @[for field in sorted_fields]@
-	@( print_field(field) )
-@[end for]
+	@( print_field(field) )@
+@[end for]@
 }

--- a/msg/templates/uorb/msg.cpp.template
+++ b/msg/templates/uorb/msg.cpp.template
@@ -83,6 +83,6 @@ void print_message(const @uorb_struct& message)
     printf(" @(uorb_struct)\n");
 	printf("\ttimestamp: %" PRIu64 " (%.6f seconds ago)\n", message.timestamp, hrt_elapsed_time(&message.timestamp) / 1e6);
 @[for field in sorted_fields]@
-	@( px4_printf(field) )
+	@( print_field(field) )
 @[end for]
 }

--- a/msg/templates/uorb/msg.h.template
+++ b/msg/templates/uorb/msg.h.template
@@ -133,3 +133,7 @@ for constant in spec.constants:
 @[for multi_topic in topics]@
 ORB_DECLARE(@multi_topic);
 @[end for]
+
+#ifdef __cplusplus
+void print_message(const @uorb_struct& message);
+#endif

--- a/msg/tools/px_generate_uorb_topic_helper.py
+++ b/msg/tools/px_generate_uorb_topic_helper.py
@@ -68,6 +68,20 @@ msgtype_size_map = {
     'char': 1,
 }
 
+type_printf_map = {
+    'int8': '%d',
+    'int16': '%d',
+    'int32': '%" PRId32 "',
+    'int64': '%" PRId64 "',
+    'uint8': '%u',
+    'uint16': '%u',
+    'uint32': '%" PRIu32 "',
+    'uint64': '%" PRIu64 "',
+    'float32': '%.3f',
+    'float64': '%.3f',
+    'bool': '%u',
+    'char': '%c',
+}
 
 def bare_name(msg_type):
     """
@@ -163,6 +177,70 @@ def convert_type(spec_type):
     if is_array:
         return c_type + "[" + str(array_length) + "]"
     return c_type
+
+
+def px4_printf(field):
+    """
+    Echo printf line
+    """
+
+    # skip padding
+    if ("_padding" in field.name):
+        return
+
+    bare_type = field.type
+    if '/' in field.type:
+        # removing prefix
+        bare_type = (bare_type.split('/'))[1]
+
+    msg_type, is_array, array_length = genmsg.msgs.parse_type(bare_type)
+
+    field_name = ""
+
+    if is_array:
+        c_type = "["
+
+        if msg_type in type_map:
+            p_type = type_printf_map[msg_type]
+
+        else:
+            for i in range(array_length):
+                print("printf(\"   " + field.type + " " + field.name + "[" + str(i) + "]\");")
+                print(" print_message(message." + field.name + "[" + str(i) + "]);")
+            return
+
+        for i in range(array_length):
+
+            if i > 0:
+                c_type += ", "
+                field_name += ", "
+
+            if "float32" in field.type:
+                field_name += "(double)message." + field.name + "[" + str(i) + "]"
+            else:
+                field_name += "message." + field.name + "[" + str(i) + "]"
+
+            c_type += str(p_type)
+
+        c_type += "]"
+
+    else:
+        c_type = msg_type
+        if msg_type in type_map:
+            c_type = type_printf_map[msg_type]
+
+            field_name = "message." + field.name
+
+            # cast double
+            if field.type == "float32":
+                field_name = "(double)" + field_name
+
+        else:
+            print("printf(\"  " + field.name + "\");")
+            print("\tprint_message(message."+ field.name + ");")
+            return
+
+    print("printf(\"\t" + field.name + ": " + c_type + "\\n\", " + field_name + ");" )
 
 
 def print_field_def(field):

--- a/msg/tools/px_generate_uorb_topic_helper.py
+++ b/msg/tools/px_generate_uorb_topic_helper.py
@@ -179,7 +179,7 @@ def convert_type(spec_type):
     return c_type
 
 
-def px4_printf(field):
+def print_field(field):
     """
     Echo printf line
     """

--- a/msg/tools/px_generate_uorb_topic_helper.py
+++ b/msg/tools/px_generate_uorb_topic_helper.py
@@ -205,7 +205,7 @@ def print_field(field):
 
         else:
             for i in range(array_length):
-                print("printf(\"   " + field.type + " " + field.name + "[" + str(i) + "]\");")
+                print("printf(\"\\t" + field.type + " " + field.name + "[" + str(i) + "]\");")
                 print(" print_message(message." + field.name + "[" + str(i) + "]);")
             return
 
@@ -236,11 +236,11 @@ def print_field(field):
                 field_name = "(double)" + field_name
 
         else:
-            print("printf(\"  " + field.name + "\");")
+            print("printf(\"\\n\\t" + field.name + "\");")
             print("\tprint_message(message."+ field.name + ");")
             return
 
-    print("printf(\"\t" + field.name + ": " + c_type + "\\n\", " + field_name + ");" )
+    print("printf(\"\\t" + field.name + ": " + c_type + "\\n\", " + field_name + ");" )
 
 
 def print_field_def(field):

--- a/msg/tools/px_generate_uorb_topic_helper.py
+++ b/msg/tools/px_generate_uorb_topic_helper.py
@@ -185,7 +185,7 @@ def print_field(field):
     """
 
     # skip padding
-    if ("_padding" in field.name):
+    if field.name.startswith('_padding'):
         return
 
     bare_type = field.type

--- a/src/drivers/barometer/bmp280/bmp280.cpp
+++ b/src/drivers/barometer/bmp280/bmp280.cpp
@@ -595,11 +595,10 @@ BMP280::print_info()
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
 	printf("poll interval:  %u us \n", _report_ticks * USEC_PER_TICK);
-	_reports->print_info("report queue");
-	printf("P Pa:              %.3f\n", (double)_P);
-	printf("T:              %.3f\n", (double)_T);
-	printf("MSL pressure Pa:   %u\n", _msl_pressure);
 
+	sensor_baro_s brp = {};
+	_reports->get(&brp);
+	print_message(brp);
 }
 
 /**
@@ -778,11 +777,7 @@ test(enum BMP280_BUS busid)
 		exit(1);
 	}
 
-	PX4_WARN("single read");
-	PX4_WARN("pressure:    %10.4f", (double)report.pressure);
-	PX4_WARN("altitude:    %11.4f", (double)report.altitude);
-	PX4_WARN("temperature: %8.4f", (double)report.temperature);
-	PX4_WARN("time:        %lld", report.timestamp);
+	print_message(report);
 
 	/* set the queue depth to 10 */
 	if (OK != ioctl(fd, SENSORIOCSQUEUEDEPTH, 10)) {
@@ -818,11 +813,7 @@ test(enum BMP280_BUS busid)
 			exit(1);
 		}
 
-		PX4_WARN("periodic read %u", i);
-		PX4_WARN("pressure:    %10.4f", (double)report.pressure);
-		PX4_WARN("altitude:    %11.4f", (double)report.altitude);
-		PX4_WARN("temperature K: %8.4f", (double)report.temperature);
-		PX4_WARN("time:        %lld", report.timestamp);
+		print_message(report);
 	}
 
 	close(fd);

--- a/src/drivers/barometer/lps25h/lps25h.cpp
+++ b/src/drivers/barometer/lps25h/lps25h.cpp
@@ -799,9 +799,7 @@ LPS25H::print_info()
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
 	printf("poll interval:  %u ticks\n", _measure_ticks);
-	printf("pressure    %.2f\n", (double)_last_report.pressure);
-	printf("altitude:    %.2f\n", (double)_last_report.altitude);
-	printf("temperature %.2f\n", (double)_last_report.temperature);
+	print_message(_last_report);
 
 	_reports->print_info("report queue");
 }
@@ -959,11 +957,7 @@ test(enum LPS25H_BUS busid)
 		err(1, "immediate read failed");
 	}
 
-	warnx("single read");
-	warnx("pressure:    %10.4f", (double)report.pressure);
-	warnx("altitude:    %11.4f", (double)report.altitude);
-	warnx("temperature: %8.4f", (double)report.temperature);
-	warnx("time:        %lld", report.timestamp);
+	print_message(report);
 
 	/* set the queue depth to 10 */
 	if (OK != ioctl(fd, SENSORIOCSQUEUEDEPTH, 10)) {
@@ -995,11 +989,7 @@ test(enum LPS25H_BUS busid)
 			err(1, "periodic read failed");
 		}
 
-		warnx("periodic read %u", i);
-		warnx("pressure:    %10.4f", (double)report.pressure);
-		warnx("altitude:    %11.4f", (double)report.altitude);
-		warnx("temperature K: %8.4f", (double)report.temperature);
-		warnx("time:        %lld", report.timestamp);
+		print_message(report);
 	}
 
 	close(fd);

--- a/src/drivers/barometer/mpl3115a2/mpl3115a2.cpp
+++ b/src/drivers/barometer/mpl3115a2/mpl3115a2.cpp
@@ -732,10 +732,10 @@ MPL3115A2::print_info()
 	perf_print_counter(_comms_errors);
 	printf("poll interval:  %u ticks\n", _measure_ticks);
 	_reports->print_info("report queue");
-	printf("device:         mpl3115a2\n");
-	printf("P:              %.3f\n", (double)_P);
-	printf("T:              %.3f\n", (double)_T);
-	printf("MSL pressure:   %10.4f\n", (double)(_msl_pressure / 100.f));
+
+	sensor_baro_s brp = {};
+	_reports->get(&brp);
+	print_message(brp);
 }
 
 /**
@@ -899,11 +899,7 @@ test(enum MPL3115A2_BUS busid)
 		err(1, "immediate read failed");
 	}
 
-	warnx("single read");
-	warnx("pressure:    %10.4f", (double)report.pressure);
-	warnx("altitude:    %11.4f", (double)report.altitude);
-	warnx("temperature: %8.4f", (double)report.temperature);
-	warnx("time:        %lld", report.timestamp);
+	print_message(report);
 
 	/* set the queue depth to 10 */
 	if (OK != ioctl(fd, SENSORIOCSQUEUEDEPTH, 10)) {
@@ -935,11 +931,7 @@ test(enum MPL3115A2_BUS busid)
 			err(1, "periodic read failed");
 		}
 
-		warnx("periodic read %u", i);
-		warnx("pressure:    %10.4f", (double)report.pressure);
-		warnx("altitude:    %11.4f", (double)report.altitude);
-		warnx("temperature: %8.4f", (double)report.temperature);
-		warnx("time:        %lld", report.timestamp);
+		print_message(report);
 	}
 
 	close(fd);

--- a/src/drivers/barometer/ms5611/ms5611.cpp
+++ b/src/drivers/barometer/ms5611/ms5611.cpp
@@ -895,9 +895,6 @@ MS5611::print_info()
 	printf("TEMP:           %d\n", _TEMP);
 	printf("SENS:           %lld\n", _SENS);
 	printf("OFF:            %lld\n", _OFF);
-	printf("P:              %.3f\n", (double)_P);
-	printf("T:              %.3f\n", (double)_T);
-	printf("MSL pressure:   %10.4f\n", (double)(_msl_pressure / 100.f));
 
 	printf("factory_setup             %u\n", _prom.factory_setup);
 	printf("c1_pressure_sens          %u\n", _prom.c1_pressure_sens);
@@ -907,6 +904,10 @@ MS5611::print_info()
 	printf("c5_reference_temp         %u\n", _prom.c5_reference_temp);
 	printf("c6_temp_coeff_temp        %u\n", _prom.c6_temp_coeff_temp);
 	printf("serial_and_crc            %u\n", _prom.serial_and_crc);
+
+	sensor_baro_s brp = {};
+	_reports->get(&brp);
+	print_message(brp);
 }
 
 /**
@@ -1118,11 +1119,7 @@ test(enum MS5611_BUS busid)
 		err(1, "immediate read failed");
 	}
 
-	warnx("single read");
-	warnx("pressure:    %10.4f", (double)report.pressure);
-	warnx("altitude:    %11.4f", (double)report.altitude);
-	warnx("temperature: %8.4f", (double)report.temperature);
-	warnx("time:        %lld", report.timestamp);
+	print_message(report);
 
 	/* set the queue depth to 10 */
 	if (OK != ioctl(fd, SENSORIOCSQUEUEDEPTH, 10)) {
@@ -1154,11 +1151,7 @@ test(enum MS5611_BUS busid)
 			err(1, "periodic read failed");
 		}
 
-		warnx("periodic read %u", i);
-		warnx("pressure:    %10.4f", (double)report.pressure);
-		warnx("altitude:    %11.4f", (double)report.altitude);
-		warnx("temperature: %8.4f", (double)report.temperature);
-		warnx("time:        %lld", report.timestamp);
+		print_message(report);
 	}
 
 	close(fd);

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -317,10 +317,7 @@ BATT_SMBUS::test()
 
 		if (updated) {
 			if (orb_copy(ORB_ID(battery_status), sub, &status) == OK) {
-				PX4_INFO("V=%4.2f C=%4.2f AveC=%4.2f DismAh=%f Cap:%hu TempC:%4.2f Remaining:%3.2f\n RunTimeToEmpty:%hu AveTimeToEmpty:%hu CycleCount:%hu SerialNum:%04x",
-					 (double)status.voltage_v, (double)status.current_a, (double)status.average_current_a, (double)status.discharged_mah,
-					 (uint16_t)status.capacity, (double)status.temperature, (double)status.remaining, (uint16_t)status.run_time_to_empty,
-					 (uint16_t)status.average_time_to_empty, (uint16_t)status.cycle_count, (uint16_t)status.serial_number);
+				print_message(status);
 			}
 		}
 

--- a/src/drivers/distance_sensor/hc_sr04/hc_sr04.cpp
+++ b/src/drivers/distance_sensor/hc_sr04/hc_sr04.cpp
@@ -801,10 +801,7 @@ test()
 		err(1, "immediate read failed");
 	}
 
-	warnx("single read");
-	warnx("measurement: %0.2f of sonar %d,id=%d", (double)report.distance_vector[report.just_updated], report.just_updated,
-	      report.id[report.just_updated]);
-	warnx("time:        %lld", report.timestamp);
+	print_message(report);
 
 	/* start the sensor polling at 2Hz */
 	if (OK != ioctl(fd, SENSORIOCSPOLLRATE, 2)) {
@@ -831,14 +828,7 @@ test()
 			err(1, "periodic read failed");
 		}
 
-		warnx("periodic read %u", i);
-
-		/* Print the sonar rangefinder report sonar distance vector */
-		for (uint8_t count = 0; count < SRF02_MAX_RANGEFINDERS; count++) {
-			warnx("measurement: %0.3f of sonar %u, id=%d", (double)report.distance_vector[count], count + 1, report.id[count]);
-		}
-
-		warnx("time:        %lld", report.timestamp);
+		print_message(report);
 	}
 
 	/* reset the sensor polling to default rate */

--- a/src/drivers/distance_sensor/leddar_one/leddar_one.cpp
+++ b/src/drivers/distance_sensor/leddar_one/leddar_one.cpp
@@ -231,16 +231,7 @@ int leddar_one_main(int argc, char *argv[])
 			return PX4_ERROR;
 		}
 
-		bool valid = false;
-
-		if (report.current_distance > report.min_distance
-		    && report.current_distance < report.max_distance) {
-			valid = true;
-		}
-
-		warnx("valid: %u\n", valid);
-		warnx("distance: %0.3fm\n", (double)report.current_distance);
-		warnx("time: %llu\n", report.timestamp);
+		print_message(report);
 
 	} else {
 		help();

--- a/src/drivers/distance_sensor/ll40ls/LidarLitePWM.cpp
+++ b/src/drivers/distance_sensor/ll40ls/LidarLitePWM.cpp
@@ -123,7 +123,8 @@ void LidarLitePWM::print_info()
 	perf_print_counter(_read_errors);
 	perf_print_counter(_sensor_zero_resets);
 	warnx("poll interval:  %u ticks", getMeasureTicks());
-	warnx("distance: %.3fm", (double)_range.current_distance);
+
+	print_message(_range);
 }
 
 void LidarLitePWM::print_registers()

--- a/src/drivers/distance_sensor/ll40ls/ll40ls.cpp
+++ b/src/drivers/distance_sensor/ll40ls/ll40ls.cpp
@@ -217,9 +217,7 @@ test()
 		return;
 	}
 
-	PX4_INFO("single read");
-	PX4_INFO("measurement: %0.2f m", (double)report.current_distance);
-	PX4_INFO("time:        %lld", report.timestamp);
+	print_message(report);
 
 	/* start the sensor polling at 2Hz */
 	if (PX4_OK != px4_ioctl(fd, SENSORIOCSPOLLRATE, 2)) {
@@ -249,11 +247,7 @@ test()
 			return;
 		}
 
-		PX4_INFO("periodic read %u", i);
-		PX4_INFO("valid %u", (float)report.current_distance > report.min_distance
-			 && (float)report.current_distance < report.max_distance ? 1 : 0);
-		PX4_INFO("measurement: %0.3f m", (double)report.current_distance);
-		PX4_INFO("time:        %lld", report.timestamp);
+		print_message(report);
 	}
 
 	/* reset the sensor polling to default rate */

--- a/src/drivers/distance_sensor/mb12xx/mb12xx.cpp
+++ b/src/drivers/distance_sensor/mb12xx/mb12xx.cpp
@@ -797,9 +797,7 @@ test()
 		err(1, "immediate read failed");
 	}
 
-	warnx("single read");
-	warnx("measurement: %0.2f m", (double)report.current_distance);
-	warnx("time:        %llu", report.timestamp);
+	print_message(report);
 
 	/* start the sensor polling at 2Hz */
 	if (OK != ioctl(fd, SENSORIOCSPOLLRATE, 2)) {
@@ -826,11 +824,7 @@ test()
 			err(1, "periodic read failed");
 		}
 
-		warnx("periodic read %u", i);
-		warnx("valid %u", (float)report.current_distance > report.min_distance
-		      && (float)report.current_distance < report.max_distance ? 1 : 0);
-		warnx("measurement: %0.3f", (double)report.current_distance);
-		warnx("time:        %llu", report.timestamp);
+		print_message(report);
 	}
 
 	/* reset the sensor polling to default rate */

--- a/src/drivers/distance_sensor/sf0x/sf0x.cpp
+++ b/src/drivers/distance_sensor/sf0x/sf0x.cpp
@@ -863,9 +863,7 @@ test()
 		err(1, "immediate read failed");
 	}
 
-	warnx("single read");
-	warnx("measurement:  %0.2f m", (double)report.current_distance);
-	warnx("time: %llu", report.timestamp);
+	print_message(report);
 
 	/* start the sensor polling at 2 Hz rate */
 	if (OK != ioctl(fd, SENSORIOCSPOLLRATE, 2)) {
@@ -894,11 +892,7 @@ test()
 			break;
 		}
 
-		warnx("read #%u", i);
-		warnx("valid %u", (float)report.current_distance > report.min_distance
-		      && (float)report.current_distance < report.max_distance ? 1 : 0);
-		warnx("measurement:  %0.3f m", (double)report.current_distance);
-		warnx("time: %llu", report.timestamp);
+		print_message(report);
 	}
 
 	/* reset the sensor polling to the default rate */

--- a/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
+++ b/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
@@ -732,9 +732,7 @@ test()
 		err(1, "immediate read failed");
 	}
 
-	warnx("single read");
-	warnx("measurement: %0.2f m", (double)report.current_distance);
-	warnx("time:        %llu", report.timestamp);
+	print_message(report);
 
 	/* start the sensor polling at 2Hz */
 	if (OK != ioctl(fd, SENSORIOCSPOLLRATE, 2)) {
@@ -761,11 +759,7 @@ test()
 			err(1, "periodic read failed");
 		}
 
-		warnx("periodic read %u", i);
-		warnx("valid %u", (float)report.current_distance > report.min_distance
-		      && (float)report.current_distance < report.max_distance ? 1 : 0);
-		warnx("measurement: %0.3f", (double)report.current_distance);
-		warnx("time:        %llu", report.timestamp);
+		print_message(report);
 	}
 
 	/* reset the sensor polling to default rate */

--- a/src/drivers/distance_sensor/srf02/srf02.cpp
+++ b/src/drivers/distance_sensor/srf02/srf02.cpp
@@ -801,9 +801,7 @@ test()
 		err(1, "immediate read failed");
 	}
 
-	warnx("single read");
-	warnx("measurement: %0.2f m", (double)report.current_distance);
-	warnx("time:        %llu", report.timestamp);
+	print_message(report);
 
 	/* start the sensor polling at 2Hz */
 	if (OK != ioctl(fd, SENSORIOCSPOLLRATE, 2)) {
@@ -830,11 +828,7 @@ test()
 			err(1, "periodic read failed");
 		}
 
-		warnx("periodic read %u", i);
-		warnx("valid %u", (float)report.current_distance > report.min_distance
-		      && (float)report.current_distance < report.max_distance ? 1 : 0);
-		warnx("measurement: %0.3f", (double)report.current_distance);
-		warnx("time:        %llu", report.timestamp);
+		print_message(report);
 	}
 
 	/* reset the sensor polling to default rate */

--- a/src/drivers/distance_sensor/srf02_i2c/srf02_i2c.cpp
+++ b/src/drivers/distance_sensor/srf02_i2c/srf02_i2c.cpp
@@ -801,9 +801,7 @@ test()
 		err(1, "immediate read failed");
 	}
 
-	warnx("single read");
-	warnx("measurement: %0.2f m", (double)report.current_distance);
-	warnx("time:        %llu", report.timestamp);
+	print_message(report);
 
 	/* start the sensor polling at 2Hz */
 	if (OK != ioctl(fd, SENSORIOCSPOLLRATE, 2)) {
@@ -830,11 +828,7 @@ test()
 			err(1, "periodic read failed");
 		}
 
-		warnx("periodic read %u", i);
-		warnx("valid %u", (float)report.current_distance > report.min_distance
-		      && (float)report.current_distance < report.max_distance ? 1 : 0);
-		warnx("measurement: %0.3f", (double)report.current_distance);
-		warnx("time:        %llu", report.timestamp);
+		print_message(report);
 	}
 
 	/* reset the sensor polling to default rate */

--- a/src/drivers/distance_sensor/teraranger/teraranger.cpp
+++ b/src/drivers/distance_sensor/teraranger/teraranger.cpp
@@ -845,9 +845,7 @@ test()
 		err(1, "immediate read failed");
 	}
 
-	warnx("single read");
-	warnx("measurement: %0.2f m", (double)report.current_distance);
-	warnx("time:        %llu", report.timestamp);
+	print_message(report);
 
 	/* start the sensor polling at 2Hz */
 	if (OK != ioctl(fd, SENSORIOCSPOLLRATE, 2)) {
@@ -874,9 +872,7 @@ test()
 			err(1, "periodic read failed");
 		}
 
-		warnx("periodic read %u", i);
-		warnx("measurement: %0.3f", (double)report.current_distance);
-		warnx("time:        %llu", report.timestamp);
+		print_message(report);
 	}
 
 	/* reset the sensor polling to default rate */

--- a/src/drivers/distance_sensor/tfmini/tfmini.cpp
+++ b/src/drivers/distance_sensor/tfmini/tfmini.cpp
@@ -828,9 +828,7 @@ test()
 		err(1, "immediate read failed");
 	}
 
-	warnx("single read");
-	warnx("measurement:  %0.2f m", (double)report.current_distance);
-	warnx("time: %llu", report.timestamp);
+	print_message(report);
 
 	/* start the sensor polling at 2 Hz rate */
 	if (OK != px4_ioctl(fd, SENSORIOCSPOLLRATE, 2)) {
@@ -859,11 +857,7 @@ test()
 			break;
 		}
 
-		warnx("read #%u", i);
-		warnx("valid %u", (float)report.current_distance > report.min_distance
-		      && (float)report.current_distance < report.max_distance ? 1 : 0);
-		warnx("measurement:  %0.3f m", (double)report.current_distance);
-		warnx("time: %llu", report.timestamp);
+		print_message(report);
 	}
 
 	/* reset the sensor polling to the default rate */

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -873,19 +873,10 @@ GPS::print_status()
 	}
 
 	PX4_INFO("port: %s, baudrate: %d, status: %s", _port, _baudrate, _healthy ? "OK" : "NOT OK");
-	PX4_INFO("sat info: %s, noise: %d, jamming detected: %s",
-		 (_p_report_sat_info != nullptr) ? "enabled" : "disabled",
-		 _report_gps_pos.noise_per_ms,
-		 _report_gps_pos.jamming_indicator == 255 ? "YES" : "NO");
+	PX4_INFO("sat info: %s", (_p_report_sat_info != nullptr) ? "enabled" : "disabled");
 
 	if (_report_gps_pos.timestamp != 0) {
-		PX4_INFO("position lock: %d, satellites: %d, last update: %8.4fms ago", (int)_report_gps_pos.fix_type,
-			 _report_gps_pos.satellites_used, (double)(hrt_absolute_time() - _report_gps_pos.timestamp) / 1000.0);
-		PX4_INFO("lat: %d, lon: %d, alt: %d", _report_gps_pos.lat, _report_gps_pos.lon, _report_gps_pos.alt);
-		PX4_INFO("vel: %.2fm/s, %.2fm/s, %.2fm/s", (double)_report_gps_pos.vel_n_m_s,
-			 (double)_report_gps_pos.vel_e_m_s, (double)_report_gps_pos.vel_d_m_s);
-		PX4_INFO("hdop: %.2f, vdop: %.2f", (double)_report_gps_pos.hdop, (double)_report_gps_pos.vdop);
-		PX4_INFO("eph: %.2fm, epv: %.2fm", (double)_report_gps_pos.eph, (double)_report_gps_pos.epv);
+		print_message(_report_gps_pos);
 
 		if (_helper) {
 			PX4_INFO("rate position: \t\t%6.2f Hz", (double)_helper->getPositionUpdateRate());

--- a/src/drivers/imu/adis16448/adis16448.cpp
+++ b/src/drivers/imu/adis16448/adis16448.cpp
@@ -1869,16 +1869,7 @@ test()
 		err(1, "immediate acc read failed");
 	}
 
-	warnx("single read");
-	warnx("time:     %lld", a_report.timestamp);
-	warnx("acc  x:  \t%8.4f\tm/s^2", (double)a_report.x);
-	warnx("acc  y:  \t%8.4f\tm/s^2", (double)a_report.y);
-	warnx("acc  z:  \t%8.4f\tm/s^2", (double)a_report.z);
-	warnx("acc  x:  \t%d\traw 0x%0x", (short)a_report.x_raw, (unsigned short)a_report.x_raw);
-	warnx("acc  y:  \t%d\traw 0x%0x", (short)a_report.y_raw, (unsigned short)a_report.y_raw);
-	warnx("acc  z:  \t%d\traw 0x%0x", (short)a_report.z_raw, (unsigned short)a_report.z_raw);
-	warnx("acc range: %8.4f m/s^2 (%8.4f g)", (double)a_report.range_m_s2,
-	      (double)(a_report.range_m_s2 / ADIS16448_ONE_G));
+	print_message(a_report);
 
 	/* do a simple demand read */
 	sz = read(fd_gyro, &g_report, sizeof(g_report));
@@ -1888,14 +1879,7 @@ test()
 		err(1, "immediate gyro read failed");
 	}
 
-	warnx("gyro x: \t% 9.5f\trad/s", (double)g_report.x);
-	warnx("gyro y: \t% 9.5f\trad/s", (double)g_report.y);
-	warnx("gyro z: \t% 9.5f\trad/s", (double)g_report.z);
-	warnx("gyro x: \t%d\traw", (int)g_report.x_raw);
-	warnx("gyro y: \t%d\traw", (int)g_report.y_raw);
-	warnx("gyro z: \t%d\traw", (int)g_report.z_raw);
-	warnx("gyro range: %8.4f rad/s (%d deg/s)", (double)g_report.range_rad_s,
-	      (int)((g_report.range_rad_s / M_PI_F) * 180.0f + 0.5f));
+	print_message(g_report);
 
 	/* do a simple mag demand read */
 	sz = read(fd_mag, &m_report, sizeof(m_report));
@@ -1905,16 +1889,7 @@ test()
 		err(1, "immediate mag read failed");
 	}
 
-	warnx("mag x: \t% 9.5f\tgauss", (double)m_report.x);
-	warnx("mag y: \t% 9.5f\tgauss", (double)m_report.y);
-	warnx("mag z: \t% 9.5f\tgauss", (double)m_report.z);
-	warnx("mag x: \t%d\traw", (int)m_report.x_raw);
-	warnx("mag y: \t%d\traw", (int)m_report.y_raw);
-	warnx("mag z: \t%d\traw", (int)m_report.z_raw);
-	warnx("mag range: %8.4f gauss", (double)m_report.range_ga);
-
-	warnx("temp:  \t%8.4f\tdeg celsius", (double)a_report.temperature);
-	warnx("temp:  \t%d\traw 0x%0x", (short)a_report.temperature_raw, (unsigned short)a_report.temperature_raw);
+	print_message(m_report);
 
 	/* XXX add poll-rate tests here too */
 	close(fd_mag);

--- a/src/drivers/imu/bma180/bma180.cpp
+++ b/src/drivers/imu/bma180/bma180.cpp
@@ -838,18 +838,7 @@ test()
 		err(1, "immediate acc read failed");
 	}
 
-	warnx("single read");
-	warnx("time:     %lld", a_report.timestamp);
-	warnx("acc  x:  \t%8.4f\tm/s^2", (double)a_report.x);
-	warnx("acc  y:  \t%8.4f\tm/s^2", (double)a_report.y);
-	warnx("acc  z:  \t%8.4f\tm/s^2", (double)a_report.z);
-	warnx("acc  x:  \t%d\traw 0x%0x", (short)a_report.x_raw, (unsigned short)a_report.x_raw);
-	warnx("acc  y:  \t%d\traw 0x%0x", (short)a_report.y_raw, (unsigned short)a_report.y_raw);
-	warnx("acc  z:  \t%d\traw 0x%0x", (short)a_report.z_raw, (unsigned short)a_report.z_raw);
-	warnx("acc range: %8.4f m/s^2 (%8.4f g)", (double)a_report.range_m_s2,
-	      (double)(a_report.range_m_s2 / 9.81f));
-
-	/* XXX add poll-rate tests here too */
+	print_message(a_report);
 
 	reset();
 	errx(0, "PASS");

--- a/src/drivers/imu/bmi055/bmi055_main.cpp
+++ b/src/drivers/imu/bmi055/bmi055_main.cpp
@@ -225,19 +225,7 @@ test(bool external_bus, enum sensor_type sensor)
 			err(1, "immediate accel read failed");
 		}
 
-		warnx("single read");
-		warnx("time:     %lld", a_report.timestamp);
-		warnx("acc  x:  \t%8.4f\tm/s^2", (double)a_report.x);
-		warnx("acc  y:  \t%8.4f\tm/s^2", (double)a_report.y);
-		warnx("acc  z:  \t%8.4f\tm/s^2", (double)a_report.z);
-		warnx("acc  x:  \t%d\traw 0x%0x", (short)a_report.x_raw, (unsigned short)a_report.x_raw);
-		warnx("acc  y:  \t%d\traw 0x%0x", (short)a_report.y_raw, (unsigned short)a_report.y_raw);
-		warnx("acc  z:  \t%d\traw 0x%0x", (short)a_report.z_raw, (unsigned short)a_report.z_raw);
-		warnx("acc range: %8.4f m/s^2 (%8.4f g)", (double)a_report.range_m_s2,
-		      (double)(a_report.range_m_s2 / BMI055_ONE_G));
-		warnx("temp:  \t%8.4f\tdeg celsius", (double)a_report.temperature);
-		warnx("temp:  \t%d\traw 0x%0x", (short)g_report.temperature_raw, (unsigned short)a_report.temperature_raw);
-
+		print_message(a_report);
 
 		/* reset to default polling */
 		if (ioctl(fd_acc, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT) < 0) {
@@ -261,7 +249,6 @@ test(bool external_bus, enum sensor_type sensor)
 			err(1, "gyro reset to manual polling");
 		}
 
-
 		/* do a simple demand read */
 		sz = read(fd_gyr, &g_report, sizeof(g_report));
 
@@ -270,15 +257,7 @@ test(bool external_bus, enum sensor_type sensor)
 			err(1, "immediate gyro read failed");
 		}
 
-		warnx("gyr x: \t% 9.5f\trad/s", (double)g_report.x);
-		warnx("gyr y: \t% 9.5f\trad/s", (double)g_report.y);
-		warnx("gyr z: \t% 9.5f\trad/s", (double)g_report.z);
-		warnx("gyr x: \t%d\traw", (int)g_report.x_raw);
-		warnx("gyr y: \t%d\traw", (int)g_report.y_raw);
-		warnx("gyr z: \t%d\traw", (int)g_report.z_raw);
-		warnx("gyr range: %8.4f rad/s (%d deg/s)", (double)g_report.range_rad_s,
-		      (int)((g_report.range_rad_s / M_PI_F) * 180.0f + 0.5f));
-
+		print_message(g_report);
 
 		/* reset to default polling */
 		if (ioctl(fd_gyr, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT) < 0) {
@@ -286,7 +265,6 @@ test(bool external_bus, enum sensor_type sensor)
 		}
 
 		close(fd_gyr);
-
 	}
 
 	if ((sensor == BMI055_ACCEL) || (sensor == BMI055_GYRO)) {
@@ -295,7 +273,6 @@ test(bool external_bus, enum sensor_type sensor)
 	}
 
 	errx(0, "PASS");
-
 }
 
 /**

--- a/src/drivers/imu/bmi160/bmi160_main.cpp
+++ b/src/drivers/imu/bmi160/bmi160_main.cpp
@@ -151,16 +151,7 @@ test(bool external_bus)
 		err(1, "immediate acc read failed");
 	}
 
-	warnx("single read");
-	warnx("time:     %lld", a_report.timestamp);
-	warnx("acc  x:  \t%8.4f\tm/s^2", (double)a_report.x);
-	warnx("acc  y:  \t%8.4f\tm/s^2", (double)a_report.y);
-	warnx("acc  z:  \t%8.4f\tm/s^2", (double)a_report.z);
-	warnx("acc  x:  \t%d\traw 0x%0x", (short)a_report.x_raw, (unsigned short)a_report.x_raw);
-	warnx("acc  y:  \t%d\traw 0x%0x", (short)a_report.y_raw, (unsigned short)a_report.y_raw);
-	warnx("acc  z:  \t%d\traw 0x%0x", (short)a_report.z_raw, (unsigned short)a_report.z_raw);
-	warnx("acc range: %8.4f m/s^2 (%8.4f g)", (double)a_report.range_m_s2,
-	      (double)(a_report.range_m_s2 / BMI160_ONE_G));
+	print_message(a_report);
 
 	/* do a simple demand read */
 	sz = read(fd_gyro, &g_report, sizeof(g_report));
@@ -170,17 +161,7 @@ test(bool external_bus)
 		err(1, "immediate gyro read failed");
 	}
 
-	warnx("gyro x: \t% 9.5f\trad/s", (double)g_report.x);
-	warnx("gyro y: \t% 9.5f\trad/s", (double)g_report.y);
-	warnx("gyro z: \t% 9.5f\trad/s", (double)g_report.z);
-	warnx("gyro x: \t%d\traw", (int)g_report.x_raw);
-	warnx("gyro y: \t%d\traw", (int)g_report.y_raw);
-	warnx("gyro z: \t%d\traw", (int)g_report.z_raw);
-	warnx("gyro range: %8.4f rad/s (%d deg/s)", (double)g_report.range_rad_s,
-	      (int)((g_report.range_rad_s / M_PI_F) * 180.0f + 0.5f));
-
-	warnx("temp:  \t%8.4f\tdeg celsius", (double)a_report.temperature);
-	warnx("temp:  \t%d\traw 0x%0x", (short)a_report.temperature_raw, (unsigned short)a_report.temperature_raw);
+	print_message(g_report);
 
 	/* reset to default polling */
 	if (ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT) < 0) {

--- a/src/drivers/imu/fxas21002c/fxas21002c.cpp
+++ b/src/drivers/imu/fxas21002c/fxas21002c.cpp
@@ -1273,16 +1273,7 @@ test()
 		err(1, "immediate gyro read failed");
 	}
 
-	warnx("gyro x: \t% 9.5f\trad/s", (double)g_report.x);
-	warnx("gyro y: \t% 9.5f\trad/s", (double)g_report.y);
-	warnx("gyro z: \t% 9.5f\trad/s", (double)g_report.z);
-	warnx("temp: \t%d\tC", (int)g_report.temperature);
-	warnx("gyro x: \t%d\traw", (int)g_report.x_raw);
-	warnx("gyro y: \t%d\traw", (int)g_report.y_raw);
-	warnx("gyro z: \t%d\traw", (int)g_report.z_raw);
-	warnx("temp: \t%d\traw", (int)g_report.temperature_raw);
-	warnx("gyro range: %8.4f rad/s (%d deg/s)", (double)g_report.range_rad_s,
-	      (int)((g_report.range_rad_s / M_PI_F) * 180.0f + 0.5f));
+	print_message(g_report);
 
 	if (ioctl(fd_gyro, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT) < 0) {
 		err(1, "reset to default polling");

--- a/src/drivers/imu/l3gd20/l3gd20.cpp
+++ b/src/drivers/imu/l3gd20/l3gd20.cpp
@@ -1251,16 +1251,7 @@ test()
 		err(1, "immediate gyro read failed");
 	}
 
-	warnx("gyro x: \t% 9.5f\trad/s", (double)g_report.x);
-	warnx("gyro y: \t% 9.5f\trad/s", (double)g_report.y);
-	warnx("gyro z: \t% 9.5f\trad/s", (double)g_report.z);
-	warnx("temp: \t%d\tC", (int)g_report.temperature);
-	warnx("gyro x: \t%d\traw", (int)g_report.x_raw);
-	warnx("gyro y: \t%d\traw", (int)g_report.y_raw);
-	warnx("gyro z: \t%d\traw", (int)g_report.z_raw);
-	warnx("temp: \t%d\traw", (int)g_report.temperature_raw);
-	warnx("gyro range: %8.4f rad/s (%d deg/s)", (double)g_report.range_rad_s,
-	      (int)((g_report.range_rad_s / M_PI_F) * 180.0f + 0.5f));
+	print_message(g_report);
 
 	if (ioctl(fd_gyro, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT) < 0) {
 		err(1, "reset to default polling");

--- a/src/drivers/imu/lsm303d/lsm303d.cpp
+++ b/src/drivers/imu/lsm303d/lsm303d.cpp
@@ -1965,15 +1965,7 @@ test()
 		err(1, "immediate read failed");
 	}
 
-
-	warnx("accel x: \t% 9.5f\tm/s^2", (double)accel_report.x);
-	warnx("accel y: \t% 9.5f\tm/s^2", (double)accel_report.y);
-	warnx("accel z: \t% 9.5f\tm/s^2", (double)accel_report.z);
-	warnx("accel x: \t%d\traw", (int)accel_report.x_raw);
-	warnx("accel y: \t%d\traw", (int)accel_report.y_raw);
-	warnx("accel z: \t%d\traw", (int)accel_report.z_raw);
-
-	warnx("accel range: %8.4f m/s^2", (double)accel_report.range_m_s2);
+	print_message(accel_report);
 
 	int fd_mag = -1;
 	struct mag_report m_report;
@@ -1999,13 +1991,7 @@ test()
 		err(1, "immediate read failed");
 	}
 
-	warnx("mag x: \t% 9.5f\tga", (double)m_report.x);
-	warnx("mag y: \t% 9.5f\tga", (double)m_report.y);
-	warnx("mag z: \t% 9.5f\tga", (double)m_report.z);
-	warnx("mag x: \t%d\traw", (int)m_report.x_raw);
-	warnx("mag y: \t%d\traw", (int)m_report.y_raw);
-	warnx("mag z: \t%d\traw", (int)m_report.z_raw);
-	warnx("mag range: %8.4f ga", (double)m_report.range_ga);
+	print_message(m_report);
 
 	/* reset to default polling */
 	if (ioctl(fd_accel, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT) < 0) {

--- a/src/drivers/imu/mpu6000/mpu6000.cpp
+++ b/src/drivers/imu/mpu6000/mpu6000.cpp
@@ -2456,16 +2456,7 @@ test(enum MPU6000_BUS busid)
 		err(1, "immediate acc read failed");
 	}
 
-	warnx("single read");
-	warnx("time:     %lld", a_report.timestamp);
-	warnx("acc  x:  \t%8.4f\tm/s^2", (double)a_report.x);
-	warnx("acc  y:  \t%8.4f\tm/s^2", (double)a_report.y);
-	warnx("acc  z:  \t%8.4f\tm/s^2", (double)a_report.z);
-	warnx("acc  x:  \t%d\traw 0x%0x", (short)a_report.x_raw, (unsigned short)a_report.x_raw);
-	warnx("acc  y:  \t%d\traw 0x%0x", (short)a_report.y_raw, (unsigned short)a_report.y_raw);
-	warnx("acc  z:  \t%d\traw 0x%0x", (short)a_report.z_raw, (unsigned short)a_report.z_raw);
-	warnx("acc range: %8.4f m/s^2 (%8.4f g)", (double)a_report.range_m_s2,
-	      (double)(a_report.range_m_s2 / MPU6000_ONE_G));
+	print_message(a_report);
 
 	/* do a simple demand read */
 	sz = read(fd_gyro, &g_report, sizeof(g_report));
@@ -2475,17 +2466,7 @@ test(enum MPU6000_BUS busid)
 		err(1, "immediate gyro read failed");
 	}
 
-	warnx("gyro x: \t% 9.5f\trad/s", (double)g_report.x);
-	warnx("gyro y: \t% 9.5f\trad/s", (double)g_report.y);
-	warnx("gyro z: \t% 9.5f\trad/s", (double)g_report.z);
-	warnx("gyro x: \t%d\traw", (int)g_report.x_raw);
-	warnx("gyro y: \t%d\traw", (int)g_report.y_raw);
-	warnx("gyro z: \t%d\traw", (int)g_report.z_raw);
-	warnx("gyro range: %8.4f rad/s (%d deg/s)", (double)g_report.range_rad_s,
-	      (int)((g_report.range_rad_s / M_PI_F) * 180.0f + 0.5f));
-
-	warnx("temp:  \t%8.4f\tdeg celsius", (double)a_report.temperature);
-	warnx("temp:  \t%d\traw 0x%0x", (short)a_report.temperature_raw, (unsigned short)a_report.temperature_raw);
+	print_message(g_report);
 
 	/* reset to default polling */
 	if (ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT) < 0) {

--- a/src/drivers/imu/mpu9250/main.cpp
+++ b/src/drivers/imu/mpu9250/main.cpp
@@ -331,16 +331,7 @@ test(enum MPU9250_BUS busid)
 		err(1, "immediate acc read failed");
 	}
 
-	warnx("single read");
-	warnx("time:     %lld", a_report.timestamp);
-	warnx("acc  x:  \t%8.4f\tm/s^2", (double)a_report.x);
-	warnx("acc  y:  \t%8.4f\tm/s^2", (double)a_report.y);
-	warnx("acc  z:  \t%8.4f\tm/s^2", (double)a_report.z);
-	warnx("acc  x:  \t%d\traw 0x%0x", (short)a_report.x_raw, (unsigned short)a_report.x_raw);
-	warnx("acc  y:  \t%d\traw 0x%0x", (short)a_report.y_raw, (unsigned short)a_report.y_raw);
-	warnx("acc  z:  \t%d\traw 0x%0x", (short)a_report.z_raw, (unsigned short)a_report.z_raw);
-	warnx("acc range: %8.4f m/s^2 (%8.4f g)", (double)a_report.range_m_s2,
-	      (double)(a_report.range_m_s2 / MPU9250_ONE_G));
+	print_message(a_report);
 
 	/* do a simple demand read */
 	sz = read(fd_gyro, &g_report, sizeof(g_report));
@@ -350,17 +341,7 @@ test(enum MPU9250_BUS busid)
 		err(1, "immediate gyro read failed");
 	}
 
-	warnx("gyro x: \t% 9.5f\trad/s", (double)g_report.x);
-	warnx("gyro y: \t% 9.5f\trad/s", (double)g_report.y);
-	warnx("gyro z: \t% 9.5f\trad/s", (double)g_report.z);
-	warnx("gyro x: \t%d\traw", (int)g_report.x_raw);
-	warnx("gyro y: \t%d\traw", (int)g_report.y_raw);
-	warnx("gyro z: \t%d\traw", (int)g_report.z_raw);
-	warnx("gyro range: %8.4f rad/s (%d deg/s)", (double)g_report.range_rad_s,
-	      (int)((g_report.range_rad_s / M_PI_F) * 180.0f + 0.5f));
-
-	warnx("temp:  \t%8.4f\tdeg celsius", (double)a_report.temperature);
-	warnx("temp:  \t%d\traw 0x%0x", (short)a_report.temperature_raw, (unsigned short)a_report.temperature_raw);
+	print_message(g_report);
 
 	/* do a simple demand read */
 	sz = read(fd_mag, &m_report, sizeof(m_report));
@@ -370,14 +351,7 @@ test(enum MPU9250_BUS busid)
 		err(1, "immediate mag read failed");
 	}
 
-	warnx("mag x: \t% 9.5f\tGa", (double)m_report.x);
-	warnx("mag y: \t% 9.5f\tGa", (double)m_report.y);
-	warnx("mag z: \t% 9.5f\tGa", (double)m_report.z);
-	warnx("mag x: \t%d\traw", (int)m_report.x_raw);
-	warnx("mag y: \t%d\traw", (int)m_report.y_raw);
-	warnx("mag z: \t%d\traw", (int)m_report.z_raw);
-	warnx("mag range: %8.4f Ga", (double)m_report.range_ga);
-	warnx("mag temp:  %8.4f\tdeg celsius", (double)m_report.temperature);
+	print_message(m_report);
 
 	/* reset to default polling */
 	if (ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT) < 0) {

--- a/src/drivers/magnetometer/hmc5883/hmc5883.cpp
+++ b/src/drivers/magnetometer/hmc5883/hmc5883.cpp
@@ -1413,12 +1413,7 @@ HMC5883::print_info()
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
 	printf("poll interval:  %u ticks\n", _measure_ticks);
-	printf("output  (%.2f %.2f %.2f)\n", (double)_last_report.x, (double)_last_report.y, (double)_last_report.z);
-	printf("offsets (%.2f %.2f %.2f)\n", (double)_scale.x_offset, (double)_scale.y_offset, (double)_scale.z_offset);
-	printf("scaling (%.2f %.2f %.2f) 1/range_scale %.2f range_ga %.2f\n",
-	       (double)_scale.x_scale, (double)_scale.y_scale, (double)_scale.z_scale,
-	       (double)(1.0f / _range_scale), (double)_range_ga);
-	printf("temperature %.2f\n", (double)_last_report.temperature);
+	print_message(_last_report);
 	_reports->print_info("report queue");
 }
 
@@ -1598,9 +1593,7 @@ test(enum HMC5883_BUS busid)
 		err(1, "immediate read failed");
 	}
 
-	warnx("single read");
-	warnx("measurement: %.6f  %.6f  %.6f", (double)report.x, (double)report.y, (double)report.z);
-	warnx("time:        %lld", report.timestamp);
+	print_message(report);
 
 	/* check if mag is onboard or external */
 	if ((ret = ioctl(fd, MAGIOCGEXTERNAL, 0)) < 0) {
@@ -1639,9 +1632,7 @@ test(enum HMC5883_BUS busid)
 			err(1, "periodic read failed");
 		}
 
-		warnx("periodic read %u", i);
-		warnx("measurement: %.6f  %.6f  %.6f", (double)report.x, (double)report.y, (double)report.z);
-		warnx("time:        %lld", report.timestamp);
+		print_message(report);
 	}
 
 	errx(0, "PASS");

--- a/src/drivers/magnetometer/ist8310/ist8310.cpp
+++ b/src/drivers/magnetometer/ist8310/ist8310.cpp
@@ -1253,12 +1253,7 @@ IST8310::print_info()
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
 	printf("poll interval:  %u ticks\n", _measure_ticks);
-	printf("output  (%.2f %.2f %.2f)\n", (double)_last_report.x, (double)_last_report.y, (double)_last_report.z);
-	printf("offsets (%.2f %.2f %.2f)\n", (double)_scale.x_offset, (double)_scale.y_offset, (double)_scale.z_offset);
-	printf("scaling (%.2f %.2f %.2f) 1/range_scale %.2f\n",
-	       (double)_scale.x_scale, (double)_scale.y_scale, (double)_scale.z_scale,
-	       (double)(1.0f / _range_scale));
-	printf("temperature %.2f\n", (double)_last_report.temperature);
+	print_message(_last_report);
 	_reports->print_info("report queue");
 }
 
@@ -1412,16 +1407,12 @@ test(enum IST8310_BUS busid)
 		err(1, "immediate read failed");
 	}
 
-	PX4_INFO("single read");
-	PX4_INFO("measurement: %.6f  %.6f  %.6f", (double)report.x, (double)report.y, (double)report.z);
-	PX4_INFO("time:        %lld", report.timestamp);
+	print_message(report);
 
 	/* check if mag is onboard or external */
 	if ((ret = ioctl(fd, MAGIOCGEXTERNAL, 0)) < 0) {
 		errx(1, "failed to get if mag is onboard or external");
 	}
-
-	PX4_INFO("device active: %s", ret ? "external" : "onboard");
 
 	/* set the queue depth to 5 */
 	if (OK != ioctl(fd, SENSORIOCSQUEUEDEPTH, 10)) {
@@ -1453,9 +1444,7 @@ test(enum IST8310_BUS busid)
 			err(1, "periodic read failed");
 		}
 
-		PX4_INFO("periodic read %u", i);
-		PX4_INFO("measurement: %.6f  %.6f  %.6f", (double)report.x, (double)report.y, (double)report.z);
-		PX4_INFO("time:        %lld", report.timestamp);
+		print_message(report);
 	}
 
 	PX4_INFO("PASS");

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl.cpp
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl.cpp
@@ -1297,12 +1297,7 @@ LIS3MDL::print_info()
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
 	printf("poll interval:  %u ticks\n", _measure_ticks);
-	printf("output  (%.2f %.2f %.2f)\n", (double)_last_report.x, (double)_last_report.y, (double)_last_report.z);
-	printf("offsets (%.2f %.2f %.2f)\n", (double)_scale.x_offset, (double)_scale.y_offset, (double)_scale.z_offset);
-	printf("scaling (%.2f %.2f %.2f) 1/range_scale %.2f range_ga %.2f\n",
-	       (double)_scale.x_scale, (double)_scale.y_scale, (double)_scale.z_scale,
-	       (double)(1.0f / _range_scale), (double)_range_ga);
-	printf("temperature %.2f\n", (double)_last_report.temperature);
+	print_message(_last_report);
 	_reports->print_info("report queue");
 }
 
@@ -1494,16 +1489,12 @@ test(enum LIS3MDL_BUS busid)
 		err(1, "immediate read failed");
 	}
 
-	warnx("single read");
-	warnx("measurement: %.6f  %.6f  %.6f", (double)report.x, (double)report.y, (double)report.z);
-	warnx("time:        %lld", report.timestamp);
+	print_message(report);
 
 	/* check if mag is onboard or external */
 	if ((ret = ioctl(fd, MAGIOCGEXTERNAL, 0)) < 0) {
 		errx(1, "failed to get if mag is onboard or external");
 	}
-
-	warnx("device active: %s", ret ? "external" : "onboard");
 
 	/* set the queue depth to 5 */
 	if (OK != ioctl(fd, SENSORIOCSQUEUEDEPTH, 10)) {
@@ -1535,9 +1526,7 @@ test(enum LIS3MDL_BUS busid)
 			err(1, "periodic read failed");
 		}
 
-		warnx("periodic read %u", i);
-		warnx("measurement: %.6f  %.6f  %.6f", (double)report.x, (double)report.y, (double)report.z);
-		warnx("time:        %lld", report.timestamp);
+		print_message(report);
 	}
 
 	errx(0, "PASS");

--- a/src/drivers/px4flow/px4flow.cpp
+++ b/src/drivers/px4flow/px4flow.cpp
@@ -872,11 +872,7 @@ test()
 		warnx("immediate read failed");
 	}
 
-	warnx("single read");
-	warnx("pixel_flow_x_integral: %i", f_integral.pixel_flow_x_integral);
-	warnx("pixel_flow_y_integral: %i", f_integral.pixel_flow_y_integral);
-	warnx("framecount_integral: %u",
-	      f_integral.frame_count_since_last_readout);
+	print_message(report);
 
 	/* start the sensor polling at 10Hz */
 	if (OK != ioctl(fd, SENSORIOCSPOLLRATE, 10)) {
@@ -903,25 +899,7 @@ test()
 			err(1, "periodic read failed");
 		}
 
-		warnx("periodic read %u", i);
-
-		warnx("framecount_total: %u", f.frame_count);
-		warnx("framecount_integral: %u",
-		      f_integral.frame_count_since_last_readout);
-		warnx("pixel_flow_x_integral: %i", f_integral.pixel_flow_x_integral);
-		warnx("pixel_flow_y_integral: %i", f_integral.pixel_flow_y_integral);
-		warnx("gyro_x_rate_integral: %i", f_integral.gyro_x_rate_integral);
-		warnx("gyro_y_rate_integral: %i", f_integral.gyro_y_rate_integral);
-		warnx("gyro_z_rate_integral: %i", f_integral.gyro_z_rate_integral);
-		warnx("integration_timespan [us]: %u", f_integral.integration_timespan);
-		warnx("ground_distance: %0.2f m",
-		      (double) f_integral.ground_distance / 1000);
-		warnx("time since last sonar update [us]: %i",
-		      f_integral.sonar_timestamp);
-		warnx("quality integration average : %i", f_integral.qual);
-		warnx("quality : %i", f.qual);
-
-
+		print_message(report);
 	}
 
 	errx(0, "PASS");

--- a/src/modules/uavcan/uavcan_main.cpp
+++ b/src/modules/uavcan/uavcan_main.cpp
@@ -1214,7 +1214,7 @@ UavcanNode::print_info()
 	printf("ESC mixer: %s\n", (_mixers == nullptr) ? "NONE" : "OK");
 
 	if (_outputs.noutputs != 0) {
-		printf("ESC output: ");
+		PX4_INFO("ESC output: ");
 
 		for (uint8_t i = 0; i < _outputs.noutputs; i++) {
 			printf("%d ", (int)(_outputs.output[i] * 1000));
@@ -1224,28 +1224,11 @@ UavcanNode::print_info()
 
 		// ESC status
 		int esc_sub = orb_subscribe(ORB_ID(esc_status));
-		struct esc_status_s esc;
-		memset(&esc, 0, sizeof(esc));
+		esc_status_s esc = {};
 		orb_copy(ORB_ID(esc_status), esc_sub, &esc);
-
-		printf("ESC Status:\n");
-		printf("Addr\tV\tA\tTemp\tSetpt\tRPM\tErr\n");
-
-		for (uint8_t i = 0; i < _outputs.noutputs; i++) {
-			const float temp_celsius = (esc.esc[i].esc_temperature > 0) ?
-						   (esc.esc[i].esc_temperature - 273.15F) : 0.0F;
-
-			printf("%d\t",    esc.esc[i].esc_address);
-			printf("%3.2f\t", (double)esc.esc[i].esc_voltage);
-			printf("%3.2f\t", (double)esc.esc[i].esc_current);
-			printf("%3.2f\t", (double)temp_celsius);
-			printf("%3.2f\t", (double)esc.esc[i].esc_setpoint);
-			printf("%d\t",    esc.esc[i].esc_rpm);
-			printf("%d",      esc.esc[i].esc_errorcount);
-			printf("\n");
-		}
-
 		orb_unsubscribe(esc_sub);
+
+		print_message(esc);
 	}
 
 	// Sensor bridges

--- a/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp
+++ b/src/platforms/posix/drivers/airspeedsim/meas_airspeed_sim.cpp
@@ -395,8 +395,7 @@ test()
 		return 1;
 	}
 
-	PX4_WARN("single read");
-	PX4_WARN("diff pressure: %d pa", (int)report.differential_pressure_filtered_pa);
+	print_message(report);
 
 	/* start the sensor polling at 2Hz */
 	if (OK != px4_ioctl(fd, SENSORIOCSPOLLRATE, 2)) {
@@ -423,9 +422,7 @@ test()
 			PX4_WARN("periodic read failed");
 		}
 
-		PX4_WARN("periodic read %u", i);
-		PX4_WARN("diff pressure: %d pa", (int)report.differential_pressure_filtered_pa);
-		PX4_WARN("temperature: %d C (0x%02x)", (int)report.temperature, (unsigned) report.temperature);
+		print_message(report);
 	}
 
 	/* reset the sensor polling to its default rate */

--- a/src/platforms/posix/drivers/gpssim/gpssim.cpp
+++ b/src/platforms/posix/drivers/gpssim/gpssim.cpp
@@ -380,16 +380,7 @@ GPSSIM::print_info()
 		 _report_gps_pos.jamming_indicator == 255 ? "YES" : "NO");
 
 	if (_report_gps_pos.timestamp != 0) {
-		PX4_INFO("position lock: %dD, satellites: %d, last update: %8.4fms ago", (int)_report_gps_pos.fix_type,
-			 _report_gps_pos.satellites_used, (double)(hrt_absolute_time() - _report_gps_pos.timestamp) / 1000.0);
-		PX4_INFO("lat: %d, lon: %d, alt: %d", _report_gps_pos.lat, _report_gps_pos.lon, _report_gps_pos.alt);
-		PX4_INFO("vel: %.2fm/s, %.2fm/s, %.2fm/s", (double)_report_gps_pos.vel_n_m_s,
-			 (double)_report_gps_pos.vel_e_m_s, (double)_report_gps_pos.vel_d_m_s);
-		PX4_INFO("eph: %.2fm, epv: %.2fm", (double)_report_gps_pos.eph, (double)_report_gps_pos.epv);
-		//PX4_INFO("rate position: \t%6.2f Hz", (double)_Helper->get_position_update_rate());
-		//PX4_INFO("rate velocity: \t%6.2f Hz", (double)_Helper->get_velocity_update_rate());
-		PX4_INFO("rate publication:\t%6.2f Hz", (double)_rate);
-
+		print_message(_report_gps_pos);
 	}
 
 	usleep(100000);

--- a/src/systemcmds/topic_listener/generate_listener.py
+++ b/src/systemcmds/topic_listener/generate_listener.py
@@ -18,11 +18,8 @@ messages = []
 topics = []
 message_elements = []
 
-# large and not worth printing (find better solution)
-raw_messes = [raw_messages.remove(x) for x in raw_messages if 'qshell_req' in x]
-raw_messes = [raw_messages.remove(x) for x in raw_messages if 'ulog_stream' in x]
-raw_messes = [raw_messages.remove(x) for x in raw_messages if 'gps_inject_data' in x]
-raw_messes = [raw_messages.remove(x) for x in raw_messages if 'gps_dump' in x]
+# large and not worth printing
+raw_messages = [x for x in raw_messages if not any(exception in x for exception in ['qshell_req', 'ulog_stream', 'gps_inject_data', 'gps_dump'])]
 
 for index,m in enumerate(raw_messages):
 	topic_list = []


### PR DESCRIPTION
This is an old branch I resurrected and didn't want to lose track of again. The idea is to create a print function for each uORB message at generation time. Currently the topic_listener does this with a separate python script (https://github.com/PX4/Firmware/blob/cc26c34691db1e622cddac6d330679fe61467d37/src/systemcmds/topic_listener/generate_listener.py), but has several small issues that are easily resolved when generating this properly at the source.

With a mechanism to print an arbitrary uORB message we can move listener over, and replace the many status and test messages throughout various drivers and modules. I'm also hopeful we can eventually fit this back into flash constrained devices. For example `ekf2 status` would grab and print the last copy of each published output message (estimator_status, etc). This largely eliminates the need for listener.

TODO

* general review, restructuring, and cleanup
* consider sharing the strings between the generated fields string and print helper
 eg vehicle_attitude

    ```C
    constexpr char __orb_vehicle_attitude_fields[] = "uint64_t timestamp;float rollspeed;float pitchspeed;float yawspeed;float[4] q;float[4] delta_q_reset;uint8_t quat_reset_counter;uint8_t[3] _padding0;";``` void print_message(const vehicle_attitude_s& message)
    {
    printf("vehicle_attitude_s\n");
    printf("timestamp: %llu\n", message.timestamp);
    printf("rollspeed: %.3f\n", (double)message.rollspeed);
    printf("pitchspeed: %.3f\n", (double)message.pitchspeed);
    printf("yawspeed: %.3f\n", (double)message.yawspeed);
    printf("q: [%.3f, %.3f, %.3f, %.3f]\n", (double)message.q[0], (double)message.q[1], (double)message.q[2], (double)message.q[3]);
    printf("delta_q_reset: [%.3f, %.3f, %.3f, %.3f]\n", (double)message.delta_q_reset[0], (double)message.delta_q_reset[1], (double)message.delta_q_reset[2], (double)message.delta_q_reset[3]);
    printf("quat_reset_counter: %u\n", message.quat_reset_counter);
    }
    ```* ignore padding* update and simplify listener
  * command line syntax is horrible for specifying the number of messages or instance
  * ability to subscribe at a lower rate would be very helpful
  * listener -n <number of messages> -i <instance number> -r <rate> message
  * should make it clear if a message has never been published
* consider adding pretty print options like...
  * time elapsed in seconds next to the timestamp in microseconds
    * eg `timestamp: 12345678 (1.2 seconds ago)`
  * euler angles next to a quaternion
  * decode some bitmasks?
  * boolean true/false
* check all nested structures work

