### PR TITLE
add timestamp for sensor_preflight

### DIFF
--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -688,6 +688,7 @@ Sensors::run()
 			 * IMU units as a consistency metric and publish to the sensor preflight topic
 			*/
 			if (!_armed) {
+				preflt.timestamp = hrt_absolute_time();
 				_voted_sensors_update.calc_accel_inconsistency(preflt);
 				_voted_sensors_update.calc_gyro_inconsistency(preflt);
 				_voted_sensors_update.calc_mag_inconsistency(preflt);


### PR DESCRIPTION
I found there is no timestamp setting for sensor_preflight when the sensor_preflight is published.
It caused error using replay.

Thanks

SungTae Moon