### PR TITLE
mc_att_control: revert to tested cutoff frequency

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -542,7 +542,7 @@ PARAM_DEFINE_FLOAT(MC_TPA_RATE_D, 0.0f);
  * @increment 10
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MC_DTERM_CUTOFF, 0.f);
+PARAM_DEFINE_FLOAT(MC_DTERM_CUTOFF, 30.f);
 
 /**
  * Multicopter air-mode


### PR DESCRIPTION
Revert the disabled d term filter which needs to be enabled
after reducing IMU filtering and was probably unintentionally
during a rebase.

Hopefully fixes #9150