### PR TITLE
mc_att_control: reenable TPA for I term

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -519,7 +519,7 @@ MulticopterAttitudeControl::control_attitude_rates(float dt)
 	rates(2) -= _sensor_bias.gyro_z_bias;
 
 	Vector3f rates_p_scaled = _rate_p.emult(pid_attenuations(_tpa_breakpoint_p.get(), _tpa_rate_p.get()));
-	//Vector3f rates_i_scaled = _rate_i.emult(pid_attenuations(_tpa_breakpoint_i.get(), _tpa_rate_i.get()));
+	Vector3f rates_i_scaled = _rate_i.emult(pid_attenuations(_tpa_breakpoint_i.get(), _tpa_rate_i.get()));
 	Vector3f rates_d_scaled = _rate_d.emult(pid_attenuations(_tpa_breakpoint_d.get(), _tpa_rate_d.get()));
 
 	/* angular rates error */
@@ -567,7 +567,7 @@ MulticopterAttitudeControl::control_attitude_rates(float dt)
 			}
 
 			// Perform the integration using a first order method and do not propagate the result if out of range or invalid
-			float rate_i = _rates_int(i) + _rate_i(i) * rates_err(i) * dt;
+			float rate_i = _rates_int(i) + rates_i_scaled(i) * rates_err(i) * dt;
 
 			if (PX4_ISFINITE(rate_i) && rate_i > -_rate_int_lim(i) && rate_i < _rate_int_lim(i)) {
 				_rates_int(i) = rate_i;


### PR DESCRIPTION
As a reaction to https://github.com/PX4/Firmware/pull/9113#discussion_r177103775 I started into looking why this line https://github.com/PX4/Firmware/blob/500a1c808d0c392bc1836e6bf2f57e418414dae9/src/modules/mc_att_control/mc_att_control_main.cpp#L522 was commented out.

It was:
- introduced with TPA https://github.com/PX4/Firmware/commit/a2c0391bcce3e035fe9b0421c852eb18d481a337
- made useless shortly probably because of a rebase error https://github.com/PX4/Firmware/commit/eb67686b110a995a258e80298fe180149c41c2a5
- commented out without further analysis when the compiler started complaining https://github.com/PX4/Firmware/commit/d6e9287f516aee8fa69ca571a400090de15e58ba

This pr should finally introduce TPA for the I term back...