### PR TITLE
Enable mavlink forwarding in SITL for all FW/VTOL

### DIFF
--- a/posix-configs/SITL/init/ekf2/plane
+++ b/posix-configs/SITL/init/ekf2/plane
@@ -71,8 +71,8 @@ fw_att_control start
 land_detector start fixedwing
 wind_estimator start
 mixer load /dev/pwm_output0 ROMFS/sitl/mixers/plane_sitl.main.mix
-mavlink start -x -u 14556 -r 2000000
-mavlink start -x -u 14557 -r 2000000 -m onboard -o 14540
+mavlink start -x -u 14556 -r 2000000 -f
+mavlink start -x -u 14557 -r 2000000 -m onboard -o 14540 -f
 mavlink stream -r 80 -s POSITION_TARGET_LOCAL_NED -u 14556
 mavlink stream -r 80 -s LOCAL_POSITION_NED -u 14556
 mavlink stream -r 80 -s GLOBAL_POSITION_INT -u 14556

--- a/posix-configs/SITL/init/ekf2/tailsitter
+++ b/posix-configs/SITL/init/ekf2/tailsitter
@@ -62,8 +62,8 @@ fw_pos_control_l1 start
 fw_att_control start
 wind_estimator start
 mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/quad_x_vtol_sim.main.mix
-mavlink start -x -u 14556 -r 2000000
-mavlink start -x -u 14557 -r 2000000 -m onboard -o 14540
+mavlink start -x -u 14556 -r 2000000 -f
+mavlink start -x -u 14557 -r 2000000 -m onboard -o 14540 -f
 mavlink stream -r 80 -s POSITION_TARGET_LOCAL_NED -u 14556
 mavlink stream -r 80 -s LOCAL_POSITION_NED -u 14556
 mavlink stream -r 80 -s GLOBAL_POSITION_INT -u 14556

--- a/posix-configs/SITL/init/lpe/plane
+++ b/posix-configs/SITL/init/lpe/plane
@@ -68,8 +68,8 @@ fw_pos_control_l1 start
 fw_att_control start
 land_detector start fixedwing
 mixer load /dev/pwm_output0 ROMFS/sitl/mixers/plane_sitl.main.mix
-mavlink start -x -u 14556 -r 2000000
-mavlink start -x -u 14557 -r 2000000 -m onboard -o 14540
+mavlink start -x -u 14556 -r 2000000 -f
+mavlink start -x -u 14557 -r 2000000 -m onboard -o 14540 -f
 mavlink stream -r 80 -s POSITION_TARGET_LOCAL_NED -u 14556
 mavlink stream -r 80 -s LOCAL_POSITION_NED -u 14556
 mavlink stream -r 80 -s GLOBAL_POSITION_INT -u 14556

--- a/posix-configs/SITL/init/lpe/standard_vtol
+++ b/posix-configs/SITL/init/lpe/standard_vtol
@@ -76,8 +76,8 @@ mc_att_control start
 fw_pos_control_l1 start
 fw_att_control start
 mixer load /dev/pwm_output0 ROMFS/sitl/mixers/standard_vtol_sitl.main.mix
-mavlink start -x -u 14556 -r 2000000
-mavlink start -x -u 14557 -r 2000000 -m onboard -o 14540
+mavlink start -x -u 14556 -r 2000000 -f
+mavlink start -x -u 14557 -r 2000000 -m onboard -o 14540 -f
 mavlink stream -r 20 -s EXTENDED_SYS_STATE -u 14540
 mavlink stream -r 80 -s POSITION_TARGET_LOCAL_NED -u 14556
 mavlink stream -r 80 -s LOCAL_POSITION_NED -u 14556


### PR DESCRIPTION
Some vehicles have this enabled and others have it disabled depending on which estimator is used which is confusing. As far as I know, there aren't any drawbacks to enabling this everywhere and there isn't any reason they aren't already, so this enables it for `plane`, `standard_vtol` and `tailsitter`. I'm not sure if it's safe to enable it for all the multicopter vehicles, so I left those as is for now.