### PR TITLE
airspeed calibration log critical when ports are swapped

### DIFF
--- a/src/modules/commander/airspeed_calibration.cpp
+++ b/src/modules/commander/airspeed_calibration.cpp
@@ -225,8 +225,8 @@ int do_airspeed_calibration(orb_advert_t *mavlink_log_pub)
 					break;
 				} else {
 					/* do not allow negative values */
-					calibration_log_info(mavlink_log_pub, "[cal] Negative pressure difference detected (%d Pa)", (int)diff_pres.differential_pressure_filtered_pa);
-					calibration_log_info(mavlink_log_pub, "[cal] Swap static and dynamic ports!");
+					calibration_log_critical(mavlink_log_pub, "[cal] Negative pressure difference detected (%d Pa)", (int)diff_pres.differential_pressure_filtered_pa);
+					calibration_log_critical(mavlink_log_pub, "[cal] Swap static and dynamic ports!");
 
 					/* the user setup is wrong, wipe the calibration to force a proper re-calibration */
 					diff_pres_offset = 0.0f;


### PR DESCRIPTION
Use critical so we can catch this in a log.