### PR TITLE
Waypoint time inside

### DIFF
--- a/msg/position_setpoint.msg
+++ b/msg/position_setpoint.msg
@@ -51,3 +51,5 @@ float32 acceptance_radius   # navigation acceptance_radius if we're doing waypoi
 
 float32 cruising_speed		# the generally desired cruising speed (not a hard constraint)
 float32 cruising_throttle	# the generally desired cruising throttle (not a hard constraint)
+
+float32 time_inside	# time needed to hover/loiter at a certain waypoint

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1985,7 +1985,7 @@ void MulticopterPositionControl::control_auto()
 			/* check if we just want to stay at current position */
 			matrix::Vector2f pos_sp_diff((_curr_pos_sp(0) - _pos_sp(0)), (_curr_pos_sp(1) - _pos_sp(1)));
 			bool stay_at_current_pos = (_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LOITER
-						    || !next_setpoint_valid)
+						    || !next_setpoint_valid || _pos_sp_triplet.current.time_inside > 0.0f)
 						   && ((pos_sp_diff.length()) < SIGMA_NORM);
 
 			/* only follow line if previous to current has a minimum distance */
@@ -2077,7 +2077,8 @@ void MulticopterPositionControl::control_auto()
 						float acceptance_radius = 0.0f;
 
 						/* we want to pass and need to compute the desired velocity close to current setpoint */
-						if (next_setpoint_valid &&  !(_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LOITER)) {
+						if (next_setpoint_valid &&  !(_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LOITER
+									      || _pos_sp_triplet.current.time_inside > 0.0f)) {
 							/* get velocity close to current that depends on angle between prev-current and current-next line */
 							vel_close = get_vel_close(unit_prev_to_current, unit_current_to_next);
 							acceptance_radius = _nav_rad.get();
@@ -2120,7 +2121,8 @@ void MulticopterPositionControl::control_auto()
 					bool reached_altitude = (dist_to_current_z < _nav_rad.get()) ? true : false;
 
 					if (reached_altitude && next_setpoint_valid
-					    && !(_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LOITER)) {
+					    && !(_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LOITER
+						 || _pos_sp_triplet.current.time_inside > 0.0f)) {
 						/* since we have a next setpoint use the angle prev-current-next to compute velocity setpoint limit */
 
 						/* get velocity close to current that depends on angle between prev-current and current-next line */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1984,9 +1984,11 @@ void MulticopterPositionControl::control_auto()
 
 			/* check if we just want to stay at current position */
 			matrix::Vector2f pos_sp_diff((_curr_pos_sp(0) - _pos_sp(0)), (_curr_pos_sp(1) - _pos_sp(1)));
-			bool stay_at_current_pos = (_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LOITER
-						    || !next_setpoint_valid || _pos_sp_triplet.current.time_inside > 0.0f)
-						   && ((pos_sp_diff.length()) < SIGMA_NORM);
+
+			bool decelerate_towards_target = (_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LOITER
+							  || !next_setpoint_valid || _pos_sp_triplet.current.time_inside > 0.0f);
+
+			bool stay_at_current_pos = decelerate_towards_target && ((pos_sp_diff.length()) < SIGMA_NORM);
 
 			/* only follow line if previous to current has a minimum distance */
 			if ((vec_prev_to_current.length()  > _nav_rad.get()) && !stay_at_current_pos) {
@@ -2077,8 +2079,7 @@ void MulticopterPositionControl::control_auto()
 						float acceptance_radius = 0.0f;
 
 						/* we want to pass and need to compute the desired velocity close to current setpoint */
-						if (next_setpoint_valid &&  !(_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LOITER
-									      || _pos_sp_triplet.current.time_inside > 0.0f)) {
+						if (!decelerate_towards_target) {
 							/* get velocity close to current that depends on angle between prev-current and current-next line */
 							vel_close = get_vel_close(unit_prev_to_current, unit_current_to_next);
 							acceptance_radius = _nav_rad.get();
@@ -2120,9 +2121,7 @@ void MulticopterPositionControl::control_auto()
 					/* check if altidue is within acceptance radius */
 					bool reached_altitude = (dist_to_current_z < _nav_rad.get()) ? true : false;
 
-					if (reached_altitude && next_setpoint_valid
-					    && !(_pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LOITER
-						 || _pos_sp_triplet.current.time_inside > 0.0f)) {
+					if (reached_altitude && !decelerate_towards_target) {
 						/* since we have a next setpoint use the angle prev-current-next to compute velocity setpoint limit */
 
 						/* get velocity close to current that depends on angle between prev-current and current-next line */

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -507,6 +507,7 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 
 	sp->cruising_speed = _navigator->get_cruising_speed();
 	sp->cruising_throttle = _navigator->get_cruising_throttle();
+	sp->time_inside = item.time_inside;
 
 	switch (item.nav_cmd) {
 	case NAV_CMD_IDLE:


### PR DESCRIPTION
There are different ways to tell the autopilot to stop at the current waypoint. 
1. target is a loiter
2. there is no next waypoint available
3. target is a position-waypoint with a time component

The first two are handled correctly by the MC position controller where the vehicle decelerates towards the target  waypoint. The third, however, was not known by the position controller and therefore the vehicle tried to pass that particular waypoint with full speed. It is to note that the vehicle will stop regardless, but only because the navigator does not update. The missing deceleration can lead to very abrupt stops. 

In this PR, I added a time_inside field to the position_setpoint message. Once this field is larger than 0, the vehicle will decelerate towards the target waypoint.

I consider this as a short-term fix. For the future, we should again review the meaning of a MC loiter. I prefer to keep the definition of a loiter the same as for fixed-wings (@dagar I think you have suggested that) and all other mission/re-position/rtl maneuvers are just a set of position-waypoints with time_inside information. 