### PR TITLE
Add internal SPI LIS3MDL support for the R15 Pixracer

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -192,7 +192,7 @@ then
 	then
 		# hmc5883 internal SPI bus is rotated 90 deg yaw
 	else
-		if lis3mdl -R 2 start
+		if lis3mdl start
 		then
 			# lis3mdl internal SPI bus is rotated 90 deg yaw
 		else

--- a/src/drivers/boards/px4fmu-v4/spi.c
+++ b/src/drivers/boards/px4fmu-v4/spi.c
@@ -130,6 +130,7 @@ __EXPORT void stm32_spi1select(FAR struct spi_dev_s *dev, uint32_t devid, bool s
 	/* Shared PE15 CS devices */
 
 	case PX4_SPIDEV_HMC:
+	case PX4_SPIDEV_LIS:
 	case PX4_SPIDEV_BMI055_GYR:
 		/* Making sure the other peripherals are not selected */
 		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN2, 1);


### PR DESCRIPTION
This has been tested good on a MRO Pixracer (R15) - (R15 - LIS3MDL replaces the obsolete HMC5983 on SPI).
Also tested on the original R14 Pixracer to confirm there were no ill effects. 