### PR TITLE
Move some constant arrays from data to text section

### DIFF
--- a/msg/templates/uorb/uORBTopics.cpp.template
+++ b/msg/templates/uorb/uORBTopics.cpp.template
@@ -56,7 +56,7 @@ msgs_count_all = len(msg_names_all)
 @[end for]
 
 const size_t _uorb_topics_count = @(msgs_count_all);
-const struct orb_metadata* _uorb_topics_list[_uorb_topics_count] = { 
+const constexpr struct orb_metadata* const _uorb_topics_list[_uorb_topics_count] = {
 @[for idx, msg_name in enumerate(msg_names_all, 1)]@
     ORB_ID(@(msg_name))@[if idx != msgs_count_all],@[end if]
 @[end for]
@@ -67,7 +67,7 @@ size_t orb_topics_count()
 	return _uorb_topics_count;
 }
 
-const struct orb_metadata **orb_get_topics()
+const struct orb_metadata *const*orb_get_topics()
 {
 	return _uorb_topics_list;
 }

--- a/src/lib/tunes/default_tunes.cpp
+++ b/src/lib/tunes/default_tunes.cpp
@@ -38,7 +38,7 @@
 #include "tunes.h"
 
 // initialise default tunes
-const char *Tunes::_default_tunes[] = {
+const char *const Tunes::_default_tunes[] = {
 	"", // empty to align with the index
 	"MFT240L8 O4aO5dc O4aO5dc O4aO5dc L16dcdcdcdc", // startup tune
 	"MBT200a8a8a8PaaaP", // ERROR tone

--- a/src/lib/tunes/tunes.h
+++ b/src/lib/tunes/tunes.h
@@ -126,7 +126,7 @@ public:
 	unsigned int get_maximum_update_interval() {return (unsigned int)TUNE_MAX_UPDATE_INTERVAL_US;}
 
 private:
-	static const char *_default_tunes[];
+	static const char *const _default_tunes[];
 	static const uint8_t _note_tab[];
 	static const unsigned int _default_tunes_size;
 	bool _repeat = false;	     ///< if true, tune restarts at end

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -402,7 +402,7 @@ Logger::Logger(LogWriter::Backend backend, size_t buffer_size, uint32_t log_inte
 	_sdlog_profile_handle = param_find("SDLOG_PROFILE");
 
 	if (poll_topic_name) {
-		const orb_metadata **topics = orb_get_topics();
+		const orb_metadata *const*topics = orb_get_topics();
 
 		for (size_t i = 0; i < orb_topics_count(); i++) {
 			if (strcmp(poll_topic_name, topics[i]->o_name) == 0) {
@@ -478,7 +478,7 @@ LoggerSubscription* Logger::add_topic(const orb_metadata *topic)
 
 bool Logger::add_topic(const char *name, unsigned interval)
 {
-	const orb_metadata **topics = orb_get_topics();
+	const orb_metadata *const*topics = orb_get_topics();
 	LoggerSubscription *subscription = nullptr;
 
 	for (size_t i = 0; i < orb_topics_count(); i++) {
@@ -1625,7 +1625,7 @@ void Logger::write_formats()
 {
 	_writer.lock();
 	ulog_message_format_s msg = {};
-	const orb_metadata **topics = orb_get_topics();
+	const orb_metadata *const*topics = orb_get_topics();
 
 	//write all known formats
 	for (size_t i = 0; i < orb_topics_count(); i++) {

--- a/src/modules/replay/replay_main.cpp
+++ b/src/modules/replay/replay_main.cpp
@@ -631,7 +631,7 @@ bool Replay::nextDataMessage(std::ifstream &file, Subscription &subscription, in
 
 const orb_metadata *Replay::findTopic(const std::string &name)
 {
-	const orb_metadata **topics = orb_get_topics();
+	const orb_metadata *const *topics = orb_get_topics();
 
 	for (size_t i = 0; i < orb_topics_count(); i++) {
 		if (name == topics[i]->o_name) {

--- a/src/modules/uORB/uORBTopics.h
+++ b/src/modules/uORB/uORBTopics.h
@@ -45,6 +45,6 @@ extern size_t orb_topics_count() __EXPORT;
 /*
  * Returns array of topics metadata
  */
-extern const struct orb_metadata **orb_get_topics() __EXPORT;
+extern const struct orb_metadata *const *orb_get_topics() __EXPORT;
 
 #endif /* MODULES_UORB_UORBTOPICS_H_ */


### PR DESCRIPTION
2 Arrays with constant data in uORB and the tunes library were marked as 'const T *' array, which means the data of the array was not actually const and thus landed in the data section (so in RAM instead of FLASH).

Reduces RAM usage by ~500 bytes.

@potaito fyi