### PR TITLE
commander state machine helper shorten names

### DIFF
--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -75,13 +75,13 @@ static constexpr const bool arming_transitions[vehicle_status_s::ARMING_STATE_MA
 };
 
 // You can index into the array with an arming_state_t in order to get its textual representation
-const char *const arming_state_names[vehicle_status_s::ARMING_STATE_MAX] = {
-	"ARMING_STATE_INIT",
-	"ARMING_STATE_STANDBY",
-	"ARMING_STATE_ARMED",
-	"ARMING_STATE_STANDBY_ERROR",
-	"ARMING_STATE_REBOOT",
-	"ARMING_STATE_IN_AIR_RESTORE",
+const char * const arming_state_names[vehicle_status_s::ARMING_STATE_MAX] = {
+	"INIT",
+	"STANDBY",
+	"ARMED",
+	"STANDBY_ERROR",
+	"REBOOT",
+	"IN_AIR_RESTORE",
 };
 
 static hrt_abstime last_preflight_check = 0;	///< initialize so it gets checked immediately
@@ -339,7 +339,7 @@ transition_result_t arming_state_transition(vehicle_status_s *status, const batt
 	if (ret == TRANSITION_DENIED) {
 		/* print to MAVLink and console if we didn't provide any feedback yet */
 		if (!feedback_provided) {
-			mavlink_log_critical(mavlink_log_pub, "TRANSITION_DENIED: %s - %s",
+			mavlink_log_critical(mavlink_log_pub, "TRANSITION_DENIED: %s to %s",
 					     arming_state_names[status->arming_state], arming_state_names[new_arming_state]);
 		}
 	}


### PR DESCRIPTION
These arming state strings are too long for the mavlink message.

![image](https://user-images.githubusercontent.com/84712/38119191-e55aa3bc-338d-11e8-828f-f5e731181623.png)
