### PR TITLE
commander state machine fix preflight and prearm error

### DIFF
--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -2,7 +2,6 @@
 
 bool condition_calibration_enabled
 bool condition_system_sensors_initialized
-bool condition_system_prearm_error_reported	# true if errors have already been reported
 bool condition_system_hotplug_timeout		# true if the hotplug sensor search is over
 bool condition_system_returned_to_home
 bool condition_auto_mission_available

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -83,6 +83,9 @@ public:
 
 	void enable_hil();
 
+	// TODO: only temporarily static until low priority thread is removed
+	static bool preflight_check(bool report);
+
 private:
 	bool handle_command(vehicle_status_s *status_local, const vehicle_command_s &cmd,
 			    actuator_armed_s *armed_local, home_position_s *home, const vehicle_global_position_s &global_pos,

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -121,13 +121,13 @@ private:
 	 * Update the telemetry status and the corresponding status variables.
 	 * Perform system checks when new telemetry link connected.
 	 */
-	void poll_telemetry_status(bool checkAirspeed, bool *hotplug_timeout);
+	void poll_telemetry_status();
 
 	/**
 	 * Checks the status of all available data links and handles switching between different system telemetry states.
 	 */
 	void data_link_checks(int32_t highlatencydatalink_loss_timeout, int32_t highlatencydatalink_regain_timeout,
-			int32_t datalink_loss_timeout, int32_t datalink_regain_timeout, bool *status_changed);
+			      int32_t datalink_loss_timeout, int32_t datalink_regain_timeout, bool *status_changed);
 
 	// telemetry variables
 	struct telemetry_data {

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -570,7 +570,7 @@ out:
 }
 
 bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool checkAirspeed, bool checkRC, bool checkGNSS,
-		    bool checkDynamic, bool isVTOL, bool reportFailures, bool prearm, hrt_abstime time_since_boot)
+		    bool checkDynamic, bool isVTOL, bool reportFailures, bool prearm, const hrt_abstime& time_since_boot)
 {
 
 	if (time_since_boot < 2000000) {

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -109,6 +109,7 @@ static int check_calibration(DevHandle &h, const char *param_template, int &devi
 				break;
 			}
 		}
+
 		instance++;
 	}
 
@@ -140,6 +141,7 @@ static bool magnometerCheck(orb_advert_t *mavlink_log_pub, unsigned instance, bo
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: MAG #%u UNCALIBRATED", instance);
 		}
+
 		success = false;
 		goto out;
 	}
@@ -150,6 +152,7 @@ static bool magnometerCheck(orb_advert_t *mavlink_log_pub, unsigned instance, bo
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: MAG #%u SELFTEST FAILED", instance);
 		}
+
 		success = false;
 		goto out;
 	}
@@ -175,6 +178,7 @@ static bool imuConsistencyCheck(orb_advert_t *mavlink_log_pub, bool report_statu
 	// Use the difference between IMU's to detect a bad calibration.
 	// If a single IMU is fitted, the value being checked will be zero so this check will always pass.
 	param_get(param_find("COM_ARM_IMU_ACC"), &test_limit);
+
 	if (sensors.accel_inconsistency_m_s_s > test_limit) {
 		if (report_status) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: ACCELS INCONSISTENT - CHECK CAL");
@@ -191,10 +195,12 @@ static bool imuConsistencyCheck(orb_advert_t *mavlink_log_pub, bool report_statu
 
 	// Fail if gyro difference greater than 5 deg/sec and notify if greater than 2.5 deg/sec
 	param_get(param_find("COM_ARM_IMU_GYR"), &test_limit);
+
 	if (sensors.gyro_inconsistency_rad_s > test_limit) {
 		if (report_status) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: GYROS INCONSISTENT - CHECK CAL");
 		}
+
 		success = false;
 		goto out;
 
@@ -215,27 +221,32 @@ static bool magConsistencyCheck(orb_advert_t *mavlink_log_pub, bool report_statu
 	// get the sensor preflight data
 	int sensors_sub = orb_subscribe(ORB_ID(sensor_preflight));
 	struct sensor_preflight_s sensors = {};
+
 	if (orb_copy(ORB_ID(sensor_preflight), sensors_sub, &sensors) != 0) {
 		// can happen if not advertised (yet)
 		return true;
 	}
+
 	orb_unsubscribe(sensors_sub);
 
 	// Use the difference between sensors to detect a bad calibration, orientation or magnetic interference.
 	// If a single sensor is fitted, the value being checked will be zero so this check will always pass.
 	float test_limit;
 	param_get(param_find("COM_ARM_MAG"), &test_limit);
+
 	if (sensors.mag_inconsistency_ga > test_limit) {
 		if (report_status) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: MAG SENSORS INCONSISTENT");
 		}
+
 		return false;
 	}
 
 	return true;
 }
 
-static bool accelerometerCheck(orb_advert_t *mavlink_log_pub, unsigned instance, bool optional, bool dynamic, int &device_id, bool report_fail)
+static bool accelerometerCheck(orb_advert_t *mavlink_log_pub, unsigned instance, bool optional, bool dynamic,
+			       int &device_id, bool report_fail)
 {
 	bool success = true;
 
@@ -260,6 +271,7 @@ static bool accelerometerCheck(orb_advert_t *mavlink_log_pub, unsigned instance,
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: ACCEL #%u UNCALIBRATED", instance);
 		}
+
 		success = false;
 		goto out;
 	}
@@ -270,11 +282,13 @@ static bool accelerometerCheck(orb_advert_t *mavlink_log_pub, unsigned instance,
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: ACCEL #%u TEST FAILED: %d", instance, ret);
 		}
+
 		success = false;
 		goto out;
 	}
 
 #ifdef __PX4_NUTTX
+
 	if (dynamic) {
 		/* check measurement result range */
 		struct accel_report acc;
@@ -288,19 +302,23 @@ static bool accelerometerCheck(orb_advert_t *mavlink_log_pub, unsigned instance,
 				if (report_fail) {
 					mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: ACCEL RANGE, hold still on arming");
 				}
+
 				/* this is frickin' fatal */
 				success = false;
 				goto out;
 			}
+
 		} else {
 			if (report_fail) {
 				mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: ACCEL READ");
 			}
+
 			/* this is frickin' fatal */
 			success = false;
 			goto out;
 		}
 	}
+
 #endif
 
 out:
@@ -333,6 +351,7 @@ static bool gyroCheck(orb_advert_t *mavlink_log_pub, unsigned instance, bool opt
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: GYRO #%u UNCALIBRATED", instance);
 		}
+
 		success = false;
 		goto out;
 	}
@@ -343,6 +362,7 @@ static bool gyroCheck(orb_advert_t *mavlink_log_pub, unsigned instance, bool opt
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: GYRO #%u SELFTEST FAILED", instance);
 		}
+
 		success = false;
 		goto out;
 	}
@@ -403,6 +423,7 @@ static bool airspeedCheck(orb_advert_t *mavlink_log_pub, bool optional, bool rep
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: AIRSPEED SENSOR MISSING");
 		}
+
 		success = false;
 		goto out;
 	}
@@ -412,6 +433,7 @@ static bool airspeedCheck(orb_advert_t *mavlink_log_pub, bool optional, bool rep
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: AIRSPEED SENSOR MISSING");
 		}
+
 		success = false;
 		goto out;
 	}
@@ -426,6 +448,7 @@ static bool airspeedCheck(orb_advert_t *mavlink_log_pub, bool optional, bool rep
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: AIRSPEED SENSOR STUCK");
 		}
+
 		success = false;
 		goto out;
 	}
@@ -439,6 +462,7 @@ static bool airspeedCheck(orb_advert_t *mavlink_log_pub, bool optional, bool rep
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: CHECK AIRSPEED CAL OR PITOT");
 		}
+
 		success = false;
 		goto out;
 	}
@@ -454,8 +478,8 @@ static bool powerCheck(orb_advert_t *mavlink_log_pub, bool report_fail, bool pre
 	bool success = true;
 
 	if (!prearm) {
-	    // Ignore power check after arming.
-	    return true;
+		// Ignore power check after arming.
+		return true;
 
 	} else {
 		int system_power_sub = orb_subscribe(ORB_ID(system_power));
@@ -515,66 +539,81 @@ static bool ekf2Check(orb_advert_t *mavlink_log_pub, bool optional, bool report_
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: EKF INTERNAL CHECKS");
 		}
+
 		success = false;
 		goto out;
 	}
 
 	// check vertical position innovation test ratio
 	param_get(param_find("COM_ARM_EKF_HGT"), &test_limit);
+
 	if (status.hgt_test_ratio > test_limit) {
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: EKF HGT ERROR");
 		}
+
 		success = false;
 		goto out;
 	}
 
 	// check velocity innovation test ratio
 	param_get(param_find("COM_ARM_EKF_VEL"), &test_limit);
+
 	if (status.vel_test_ratio > test_limit) {
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: EKF VEL ERROR");
 		}
+
 		success = false;
 		goto out;
 	}
 
 	// check horizontal position innovation test ratio
 	param_get(param_find("COM_ARM_EKF_POS"), &test_limit);
+
 	if (status.pos_test_ratio > test_limit) {
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: EKF HORIZ POS ERROR");
 		}
+
 		success = false;
 		goto out;
 	}
 
 	// check magnetometer innovation test ratio
 	param_get(param_find("COM_ARM_EKF_YAW"), &test_limit);
+
 	if (status.mag_test_ratio > test_limit) {
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: EKF YAW ERROR");
 		}
+
 		success = false;
 		goto out;
 	}
 
 	// check accelerometer delta velocity bias estimates
 	param_get(param_find("COM_ARM_EKF_AB"), &test_limit);
-	if (fabsf(status.states[13]) > test_limit || fabsf(status.states[14]) > test_limit || fabsf(status.states[15]) > test_limit) {
+
+	if (fabsf(status.states[13]) > test_limit || fabsf(status.states[14]) > test_limit
+	    || fabsf(status.states[15]) > test_limit) {
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: EKF HIGH IMU ACCEL BIAS");
 		}
+
 		success = false;
 		goto out;
 	}
 
 	// check gyro delta angle bias estimates
 	param_get(param_find("COM_ARM_EKF_GB"), &test_limit);
-	if (fabsf(status.states[10]) > test_limit || fabsf(status.states[11]) > test_limit || fabsf(status.states[12]) > test_limit) {
+
+	if (fabsf(status.states[10]) > test_limit || fabsf(status.states[11]) > test_limit
+	    || fabsf(status.states[12]) > test_limit) {
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: EKF HIGH IMU GYRO BIAS");
 		}
+
 		success = false;
 		goto out;
 	}
@@ -583,30 +622,36 @@ static bool ekf2Check(orb_advert_t *mavlink_log_pub, bool optional, bool report_
 	if (enforce_gps_required) {
 		bool ekf_gps_fusion = status.control_mode_flags & (1 << 2);
 		bool ekf_gps_check_fail = status.gps_check_fail_flags > 0;
+
 		if (!ekf_gps_fusion) {
 			// The EKF is not using GPS
 			if (report_fail) {
 				if (ekf_gps_check_fail) {
 					// Poor GPS qulaity is the likely cause
 					mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: GPS QUALITY POOR");
+
 				} else {
 					// Likely cause unknown
 					mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: EKF NOT USING GPS");
 				}
 			}
+
 			success = false;
 			goto out;
+
 		} else {
 			// The EKF is using GPS so check for bad quality on key performance indicators
 			bool gps_quality_fail = ((status.gps_check_fail_flags & ((1 << estimator_status_s::GPS_CHECK_FAIL_MIN_SAT_COUNT)
-										 + (1 << estimator_status_s::GPS_CHECK_FAIL_MIN_GDOP)
-										 + (1 << estimator_status_s::GPS_CHECK_FAIL_MAX_HORZ_ERR)
-										 + (1 << estimator_status_s::GPS_CHECK_FAIL_MAX_VERT_ERR)
-										 + (1 << estimator_status_s::GPS_CHECK_FAIL_MAX_SPD_ERR))) > 0);
+						  + (1 << estimator_status_s::GPS_CHECK_FAIL_MIN_GDOP)
+						  + (1 << estimator_status_s::GPS_CHECK_FAIL_MAX_HORZ_ERR)
+						  + (1 << estimator_status_s::GPS_CHECK_FAIL_MAX_VERT_ERR)
+						  + (1 << estimator_status_s::GPS_CHECK_FAIL_MAX_SPD_ERR))) > 0);
+
 			if (gps_quality_fail) {
 				if (report_fail) {
 					mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: GPS QUALITY POOR");
 				}
+
 				success = false;
 				goto out;
 			}
@@ -618,14 +663,32 @@ out:
 	return success;
 }
 
-bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool checkAirspeed, bool checkRC, bool checkGNSS,
-		    bool checkDynamic, bool checkPower, bool isVTOL, bool reportFailures, bool prearm, const hrt_abstime &time_since_boot)
+bool preflightCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status,
+		    const vehicle_status_flags_s &status_flags, bool checkGNSS, bool reportFailures, bool prearm,
+		    const hrt_abstime &time_since_boot)
 {
 
 	if (time_since_boot < 2000000) {
 		// the airspeed driver filter doesn't deliver the actual value yet
 		reportFailures = false;
 	}
+
+	const bool hil_enabled = (status.hil_state == vehicle_status_s::HIL_STATE_ON);
+
+	bool checkSensors = !hil_enabled;
+	const bool checkRC = (status.rc_input_mode == vehicle_status_s::RC_IN_MODE_DEFAULT);
+	const bool checkDynamic = !hil_enabled;
+	const bool checkPower = (status_flags.condition_power_input_valid && !status_flags.circuit_breaker_engaged_power_check);
+
+	bool checkAirspeed = false;
+
+	/* Perform airspeed check only if circuit breaker is not
+	 * engaged and it's not a rotary wing */
+	if (!status_flags.circuit_breaker_engaged_airspd_check && (!status.is_rotary_wing || status.is_vtol)) {
+		checkAirspeed = true;
+	}
+
+	reportFailures = (reportFailures && status_flags.condition_system_hotplug_timeout);
 
 #ifdef __PX4_QURT
 	// WARNING: Preflight checks are important and should be added back when
@@ -673,6 +736,7 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool check
 			if ((reportFailures && !failed)) {
 				mavlink_log_critical(mavlink_log_pub, "Primary compass not found");
 			}
+
 			failed = true;
 		}
 
@@ -696,7 +760,8 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool check
 			bool required = (i < max_mandatory_accel_count);
 			int device_id = -1;
 
-			if (!accelerometerCheck(mavlink_log_pub, i, !required, checkDynamic, device_id, (reportFailures && !accel_fail_reported)) && required) {
+			if (!accelerometerCheck(mavlink_log_pub, i, !required, checkDynamic, device_id, (reportFailures
+						&& !accel_fail_reported)) && required) {
 				failed = true;
 				accel_fail_reported = true;
 			}
@@ -711,6 +776,7 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool check
 			if ((reportFailures && !failed)) {
 				mavlink_log_critical(mavlink_log_pub, "Primary accelerometer not found");
 			}
+
 			failed = true;
 		}
 	}
@@ -743,6 +809,7 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool check
 			if ((reportFailures && !failed)) {
 				mavlink_log_critical(mavlink_log_pub, "Primary gyro not found");
 			}
+
 			failed = true;
 		}
 	}
@@ -776,6 +843,7 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool check
 			if (reportFailures && !failed) {
 				mavlink_log_critical(mavlink_log_pub, "Primary barometer not operational");
 			}
+
 			failed = true;
 		}
 	}
@@ -796,7 +864,7 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool check
 
 	/* ---- RC CALIBRATION ---- */
 	if (checkRC) {
-		if (rc_calibration_check(mavlink_log_pub, reportFailures, isVTOL) != OK) {
+		if (rc_calibration_check(mavlink_log_pub, reportFailures, status.is_vtol) != OK) {
 			if (reportFailures) {
 				mavlink_log_critical(mavlink_log_pub, "RC calibration check failed");
 			}
@@ -816,6 +884,7 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool check
 	// only check EKF2 data if EKF2 is selected as the estimator and GNSS checking is enabled
 	int32_t estimator_type;
 	param_get(param_find("SYS_MC_EST_GROUP"), &estimator_type);
+
 	if (estimator_type == 2) {
 		// don't report ekf failures for the first 10 seconds to allow time for the filter to start
 		bool report_ekf_fail = (time_since_boot > 10 * 1000000);

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -67,6 +67,7 @@
 #include <uORB/topics/differential_pressure.h>
 #include <uORB/topics/estimator_status.h>
 #include <uORB/topics/sensor_preflight.h>
+#include <uORB/topics/system_power.h>
 #include <uORB/topics/vehicle_gps_position.h>
 
 #include "PreflightCheck.h"
@@ -448,6 +449,54 @@ out:
 	return success;
 }
 
+static bool powerCheck(orb_advert_t *mavlink_log_pub, bool report_fail, bool prearm)
+{
+	bool success = true;
+
+	if (!prearm) {
+	    // Ignore power check after arming.
+	    return true;
+
+	} else {
+		int system_power_sub = orb_subscribe(ORB_ID(system_power));
+
+		system_power_s system_power;
+
+		if (orb_copy(ORB_ID(system_power), system_power_sub, &system_power) == PX4_OK) {
+
+			if (hrt_elapsed_time(&system_power.timestamp) < 200000) {
+
+				/* copy avionics voltage */
+				int avionics_power_rail_voltage = system_power.voltage5V_v;
+
+				// avionics rail
+				// Check avionics rail voltages
+				if (avionics_power_rail_voltage < 4.5f) {
+					success = false;
+
+					if (report_fail) {
+						mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: Avionics power low: %6.2f Volt", (double)avionics_power_rail_voltage);
+					}
+
+				} else if (avionics_power_rail_voltage < 4.9f) {
+					if (report_fail) {
+						mavlink_log_critical(mavlink_log_pub, "CAUTION: Avionics power low: %6.2f Volt", (double)avionics_power_rail_voltage);
+					}
+
+				} else if (avionics_power_rail_voltage > 5.4f) {
+					if (report_fail) {
+						mavlink_log_critical(mavlink_log_pub, "CAUTION: Avionics power high: %6.2f Volt", (double)avionics_power_rail_voltage);
+					}
+				}
+			}
+		}
+
+		orb_unsubscribe(system_power_sub);
+	}
+
+	return success;
+}
+
 static bool ekf2Check(orb_advert_t *mavlink_log_pub, bool optional, bool report_fail, bool enforce_gps_required)
 {
 	bool success = true; // start with a pass and change to a fail if any test fails
@@ -461,7 +510,7 @@ static bool ekf2Check(orb_advert_t *mavlink_log_pub, bool optional, bool report_
 		goto out;
 	}
 
-	// Check if preflight check perfomred by estimator has failed
+	// Check if preflight check performed by estimator has failed
 	if (status.pre_flt_fail) {
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: EKF INTERNAL CHECKS");
@@ -570,7 +619,7 @@ out:
 }
 
 bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool checkAirspeed, bool checkRC, bool checkGNSS,
-		    bool checkDynamic, bool isVTOL, bool reportFailures, bool prearm, const hrt_abstime& time_since_boot)
+		    bool checkDynamic, bool checkPower, bool isVTOL, bool reportFailures, bool prearm, const hrt_abstime &time_since_boot)
 {
 
 	if (time_since_boot < 2000000) {
@@ -622,7 +671,7 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool check
 		/* check if the primary device is present */
 		if (!prime_found && prime_id != 0) {
 			if ((reportFailures && !failed)) {
-				mavlink_log_critical(mavlink_log_pub, "Warning: Primary compass not found");
+				mavlink_log_critical(mavlink_log_pub, "Primary compass not found");
 			}
 			failed = true;
 		}
@@ -660,7 +709,7 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool check
 		/* check if the primary device is present */
 		if (!prime_found && prime_id != 0) {
 			if ((reportFailures && !failed)) {
-				mavlink_log_critical(mavlink_log_pub, "Warning: Primary accelerometer not found");
+				mavlink_log_critical(mavlink_log_pub, "Primary accelerometer not found");
 			}
 			failed = true;
 		}
@@ -692,7 +741,7 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool check
 		/* check if the primary device is present */
 		if (!prime_found && prime_id != 0) {
 			if ((reportFailures && !failed)) {
-				mavlink_log_critical(mavlink_log_pub, "Warning: Primary gyro not found");
+				mavlink_log_critical(mavlink_log_pub, "Primary gyro not found");
 			}
 			failed = true;
 		}
@@ -725,7 +774,7 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool check
 		// // check if the primary device is present
 		if (!prime_found && prime_id != 0) {
 			if (reportFailures && !failed) {
-				mavlink_log_critical(mavlink_log_pub, "warning: primary barometer not operational");
+				mavlink_log_critical(mavlink_log_pub, "Primary barometer not operational");
 			}
 			failed = true;
 		}
@@ -751,6 +800,14 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool check
 			if (reportFailures) {
 				mavlink_log_critical(mavlink_log_pub, "RC calibration check failed");
 			}
+
+			failed = true;
+		}
+	}
+
+	/* ---- SYSTEM POWER ---- */
+	if (checkPower) {
+		if (!powerCheck(mavlink_log_pub, (reportFailures && !failed), prearm)) {
 			failed = true;
 		}
 	}

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -575,7 +575,7 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool check
 
 	if (time_since_boot < 2000000) {
 		// the airspeed driver filter doesn't deliver the actual value yet
-		return true;
+		reportFailures = false;
 	}
 
 #ifdef __PX4_QURT

--- a/src/modules/commander/PreflightCheck.h
+++ b/src/modules/commander/PreflightCheck.h
@@ -40,6 +40,8 @@
  */
 
 #include <drivers/drv_hrt.h>
+#include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/vehicle_status_flags.h>
 
 #pragma once
 
@@ -70,8 +72,9 @@ namespace Preflight
 * @param checkPower
 *   true if the system power should be checked
 **/
-bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool checkAirspeed, bool checkRC, bool checkGNSS,
-		    bool checkDynamic, bool checkPower, bool isVTOL, bool reportFailures, bool prearm, const hrt_abstime &time_since_boot);
+bool preflightCheck(orb_advert_t *mavlink_log_pub, const vehicle_status_s &status,
+		    const vehicle_status_flags_s &status_flags, bool checkGNSS, bool reportFailures, bool prearm,
+		    const hrt_abstime &time_since_boot);
 
 static constexpr unsigned max_mandatory_gyro_count = 1;
 static constexpr unsigned max_optional_gyro_count = 3;

--- a/src/modules/commander/PreflightCheck.h
+++ b/src/modules/commander/PreflightCheck.h
@@ -67,9 +67,11 @@ namespace Preflight
 *   true if the Remote Controller should be checked
 * @param checkGNSS
 *   true if the GNSS receiver should be checked
+* @param checkPower
+*   true if the system power should be checked
 **/
 bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool checkAirspeed, bool checkRC, bool checkGNSS,
-    bool checkDynamic, bool isVTOL, bool reportFailures, bool prearm, const hrt_abstime& time_since_boot);
+		    bool checkDynamic, bool checkPower, bool isVTOL, bool reportFailures, bool prearm, const hrt_abstime &time_since_boot);
 
 static constexpr unsigned max_mandatory_gyro_count = 1;
 static constexpr unsigned max_optional_gyro_count = 3;

--- a/src/modules/commander/PreflightCheck.h
+++ b/src/modules/commander/PreflightCheck.h
@@ -69,7 +69,7 @@ namespace Preflight
 *   true if the GNSS receiver should be checked
 **/
 bool preflightCheck(orb_advert_t *mavlink_log_pub, bool checkSensors, bool checkAirspeed, bool checkRC, bool checkGNSS,
-    bool checkDynamic, bool isVTOL, bool reportFailures, bool prearm, hrt_abstime time_since_boot);
+    bool checkDynamic, bool isVTOL, bool reportFailures, bool prearm, const hrt_abstime& time_since_boot);
 
 static constexpr unsigned max_mandatory_gyro_count = 1;
 static constexpr unsigned max_optional_gyro_count = 3;

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -168,7 +168,6 @@ static orb_advert_t power_button_state_pub = nullptr;
 static volatile bool thread_should_exit = false;	/**< daemon exit flag */
 static volatile bool thread_running = false;		/**< daemon status flag */
 
-static bool _usb_telemetry_active = false;
 static hrt_abstime commander_boot_timestamp = 0;
 
 static unsigned int leds_counter;
@@ -1268,7 +1267,6 @@ Commander::run()
 	status.data_link_lost = true;
 	status_flags.offboard_control_loss_timeout = false;
 
-	status_flags.condition_system_prearm_error_reported = false;
 	status_flags.condition_system_hotplug_timeout = false;
 
 	status.timestamp = hrt_absolute_time();
@@ -1734,9 +1732,6 @@ Commander::run()
 					usleep(400000);
 					px4_shutdown_request(true, false);
 				}
-
-				/* finally judge the USB connected state based on software detection */
-				status_flags.usb_connected = _usb_telemetry_active;
 			}
 		}
 

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -102,6 +102,7 @@
 #include <uORB/topics/subsystem_info.h>
 #include <uORB/topics/system_power.h>
 #include <uORB/topics/telemetry_status.h>
+#include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_command_ack.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_land_detected.h>
@@ -389,7 +390,7 @@ int commander_main(int argc, char *argv[])
 	}
 
 	if (!strcmp(argv[1], "check")) {
-		bool checkres = prearm_check(&mavlink_log_pub, true, &status_flags, battery, arm_requirements, hrt_elapsed_time(&commander_boot_timestamp));
+		bool checkres = prearm_check(&mavlink_log_pub, status_flags, battery, arm_requirements, hrt_elapsed_time(&commander_boot_timestamp));
 		PX4_INFO("Prearm check: %s", checkres ? "OK" : "FAILED");
 
 		return 0;
@@ -1049,10 +1050,10 @@ Commander::handle_command(vehicle_status_s *status_local,
 	}
 	break;
 	case vehicle_command_s::VEHICLE_CMD_CONTROL_HIGH_LATENCY: {
-			// only send the acknowledge from the commander, the command actually is handled by each mavlink instance
-			cmd_result = vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED;
-		}
-		break;
+		// only send the acknowledge from the commander, the command actually is handled by each mavlink instance
+		cmd_result = vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED;
+	}
+	break;
 	case vehicle_command_s::VEHICLE_CMD_CUSTOM_0:
 	case vehicle_command_s::VEHICLE_CMD_CUSTOM_1:
 	case vehicle_command_s::VEHICLE_CMD_CUSTOM_2:

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -832,7 +832,6 @@ Commander::handle_command(vehicle_status_s *status_local,
 				transition_result_t arming_res = arm_disarm(cmd_arms, &mavlink_log_pub, "arm/disarm component command");
 
 				if (arming_res == TRANSITION_DENIED) {
-					mavlink_log_critical(&mavlink_log_pub, "Arming not possible in this state");
 					cmd_result = vehicle_command_s::VEHICLE_CMD_RESULT_TEMPORARILY_REJECTED;
 
 				} else {

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -389,12 +389,8 @@ int commander_main(int argc, char *argv[])
 	}
 
 	if (!strcmp(argv[1], "check")) {
-		int checkres = 0;
-		checkres = prearm_check(&mavlink_log_pub, false, true, &status_flags, battery, ARM_REQ_GPS_BIT, hrt_elapsed_time(&commander_boot_timestamp));
-		warnx("Preflight check: %s", (checkres == 0) ? "OK" : "FAILED");
-
-		checkres = prearm_check(&mavlink_log_pub, true, true, &status_flags, battery, arm_requirements, hrt_elapsed_time(&commander_boot_timestamp));
-		warnx("Prearm check: %s", (checkres == 0) ? "OK" : "FAILED");
+		bool checkres = prearm_check(&mavlink_log_pub, true, true, &status_flags, battery, arm_requirements, hrt_elapsed_time(&commander_boot_timestamp));
+		PX4_INFO("Prearm check: %s", checkres ? "OK" : "FAILED");
 
 		return 0;
 	}

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -390,7 +390,7 @@ int commander_main(int argc, char *argv[])
 		bool preflight_check_res = Commander::preflight_check(true);
 		PX4_INFO("Preflight check: %s", preflight_check_res ? "OK" : "FAILED");
 
-		bool prearm_check_res = prearm_check(&mavlink_log_pub, status_flags, battery, arm_requirements, hrt_elapsed_time(&commander_boot_timestamp));
+		bool prearm_check_res = prearm_check(&mavlink_log_pub, status_flags, battery, safety, arm_requirements, hrt_elapsed_time(&commander_boot_timestamp));
 		PX4_INFO("Prearm check: %s", prearm_check_res ? "OK" : "FAILED");
 
 		return 0;

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -389,7 +389,7 @@ int commander_main(int argc, char *argv[])
 	}
 
 	if (!strcmp(argv[1], "check")) {
-		bool checkres = prearm_check(&mavlink_log_pub, true, true, &status_flags, battery, arm_requirements, hrt_elapsed_time(&commander_boot_timestamp));
+		bool checkres = prearm_check(&mavlink_log_pub, true, &status_flags, battery, arm_requirements, hrt_elapsed_time(&commander_boot_timestamp));
 		PX4_INFO("Prearm check: %s", checkres ? "OK" : "FAILED");
 
 		return 0;

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -705,25 +705,32 @@ Commander::handle_command(vehicle_status_s *status_local,
 						case PX4_CUSTOM_SUB_MODE_AUTO_LOITER:
 							main_ret = main_state_transition(*status_local, commander_state_s::MAIN_STATE_AUTO_LOITER, status_flags, &internal_state);
 							break;
+
 						case PX4_CUSTOM_SUB_MODE_AUTO_MISSION:
 							if (status_flags.condition_auto_mission_available) {
 								main_ret = main_state_transition(*status_local, commander_state_s::MAIN_STATE_AUTO_MISSION, status_flags, &internal_state);
 							} else {
 								main_ret = TRANSITION_DENIED;
 							}
+
 							break;
+
 						case PX4_CUSTOM_SUB_MODE_AUTO_RTL:
 							main_ret = main_state_transition(*status_local, commander_state_s::MAIN_STATE_AUTO_RTL, status_flags, &internal_state);
 							break;
+
 						case PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF:
 							main_ret = main_state_transition(*status_local, commander_state_s::MAIN_STATE_AUTO_TAKEOFF, status_flags, &internal_state);
 							break;
+
 						case PX4_CUSTOM_SUB_MODE_AUTO_LAND:
 							main_ret = main_state_transition(*status_local, commander_state_s::MAIN_STATE_AUTO_LAND, status_flags, &internal_state);
 							break;
+
 						case PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET:
 							main_ret = main_state_transition(*status_local, commander_state_s::MAIN_STATE_AUTO_FOLLOW_TARGET, status_flags, &internal_state);
 							break;
+
 						case PX4_CUSTOM_SUB_MODE_AUTO_PRECLAND:
 							main_ret = main_state_transition(*status_local, commander_state_s::MAIN_STATE_AUTO_PRECLAND, status_flags, &internal_state);
 							break;
@@ -770,6 +777,7 @@ Commander::handle_command(vehicle_status_s *status_local,
 					} else if (base_mode & VEHICLE_MODE_FLAG_STABILIZE_ENABLED) {
 						/* STABILIZED */
 						main_ret = main_state_transition(*status_local, commander_state_s::MAIN_STATE_STAB, status_flags, &internal_state);
+
 					} else {
 						/* MANUAL */
 						main_ret = main_state_transition(*status_local, commander_state_s::MAIN_STATE_MANUAL, status_flags, &internal_state);
@@ -815,11 +823,11 @@ Commander::handle_command(vehicle_status_s *status_local,
 
 					// Refuse to arm if in manual with non-zero throttle
 					if (cmd_arms
-						&& (status_local->nav_state == vehicle_status_s::NAVIGATION_STATE_MANUAL
+					    && (status_local->nav_state == vehicle_status_s::NAVIGATION_STATE_MANUAL
 						|| status_local->nav_state == vehicle_status_s::NAVIGATION_STATE_ACRO
 						|| status_local->nav_state == vehicle_status_s::NAVIGATION_STATE_STAB
 						|| status_local->nav_state == vehicle_status_s::NAVIGATION_STATE_RATTITUDE)
-						&& (sp_man.z > 0.1f)) {
+					    && (sp_man.z > 0.1f)) {
 
 						mavlink_log_critical(&mavlink_log_pub, "Arming DENIED. Manual throttle non-zero.");
 						cmd_result = vehicle_command_s::VEHICLE_CMD_RESULT_DENIED;
@@ -837,8 +845,8 @@ Commander::handle_command(vehicle_status_s *status_local,
 
 					/* update home position on arming if at least 500 ms from commander start spent to avoid setting home on in-air restart */
 					if (cmd_arms && (arming_res == TRANSITION_CHANGED) &&
-						(hrt_absolute_time() > (commander_boot_timestamp + INAIR_RESTART_HOLDOFF_INTERVAL)) &&
-						!home->manual_home) {
+					    (hrt_absolute_time() > (commander_boot_timestamp + INAIR_RESTART_HOLDOFF_INTERVAL)) &&
+					    !home->manual_home) {
 
 						set_home_position(*home_pub, *home, local_pos, global_pos, false);
 					}
@@ -1047,10 +1055,11 @@ Commander::handle_command(vehicle_status_s *status_local,
 	}
 	break;
 	case vehicle_command_s::VEHICLE_CMD_CONTROL_HIGH_LATENCY: {
-		// only send the acknowledge from the commander, the command actually is handled by each mavlink instance
-		cmd_result = vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED;
-	}
-	break;
+			// only send the acknowledge from the commander, the command actually is handled by each mavlink instance
+			cmd_result = vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED;
+		}
+		break;
+
 	case vehicle_command_s::VEHICLE_CMD_CUSTOM_0:
 	case vehicle_command_s::VEHICLE_CMD_CUSTOM_1:
 	case vehicle_command_s::VEHICLE_CMD_CUSTOM_2:
@@ -1106,8 +1115,8 @@ Commander::handle_command(vehicle_status_s *status_local,
 **/
 bool
 Commander::set_home_position(orb_advert_t &homePub, home_position_s &home,
-					const vehicle_local_position_s &localPosition, const vehicle_global_position_s &globalPosition,
-					bool set_alt_only_to_lpos_ref)
+			     const vehicle_local_position_s &localPosition, const vehicle_global_position_s &globalPosition,
+			     bool set_alt_only_to_lpos_ref)
 {
 	if (!set_alt_only_to_lpos_ref) {
 		//Need global and local position fix to be able to set home
@@ -1532,6 +1541,7 @@ Commander::run()
 			if (!armed.armed) {
 				if (param_get(_param_sys_type, &system_type) != OK) {
 					PX4_ERR("failed getting new system type");
+
 				} else {
 					status.system_type = (uint8_t)system_type;
 				}
@@ -1629,6 +1639,7 @@ Commander::run()
 		if (updated) {
 			power_button_state_s button_state;
 			orb_copy(ORB_ID(power_button_state), power_button_state_sub, &button_state);
+
 			if (button_state.event == power_button_state_s::PWR_BUTTON_STATE_REQUEST_SHUTDOWN) {
 				px4_shutdown_request(false, false);
 			}
@@ -1669,7 +1680,7 @@ Commander::run()
 				} else {
 					/* wait for timeout if set */
 					status_flags.offboard_control_loss_timeout = offboard_control_mode.timestamp +
-						OFFBOARD_TIMEOUT + offboard_loss_timeout * 1e6f < hrt_absolute_time();
+							OFFBOARD_TIMEOUT + offboard_loss_timeout * 1e6f < hrt_absolute_time();
 				}
 
 				if (status_flags.offboard_control_loss_timeout) {
@@ -1679,11 +1690,12 @@ Commander::run()
 		}
 
 		// poll the telemetry status
-		poll_telemetry_status(checkAirspeed, &hotplug_timeout);
+		poll_telemetry_status();
 
 		orb_check(system_power_sub, &updated);
 
 		if (updated) {
+			system_power_s system_power = {};
 			orb_copy(ORB_ID(system_power), system_power_sub, &system_power);
 
 			if (hrt_elapsed_time(&system_power.timestamp) < 200000) {
@@ -1715,15 +1727,17 @@ Commander::run()
 
 		if (updated) {
 			bool previous_safety_off = safety.safety_off;
+
 			if (orb_copy(ORB_ID(safety), safety_sub, &safety) == PX4_OK) {
 
 				/* disarm if safety is now on and still armed */
 				if (armed.armed && (status.hil_state == vehicle_status_s::HIL_STATE_OFF)
-					&& safety.safety_switch_available && !safety.safety_off) {
+				    && safety.safety_switch_available && !safety.safety_off) {
 
-					if (TRANSITION_CHANGED == arming_state_transition(&status, battery, safety, vehicle_status_s::ARMING_STATE_STANDBY, &armed, true /* fRunPreArmChecks */, &mavlink_log_pub,
-															&status_flags, arm_requirements, hrt_elapsed_time(&commander_boot_timestamp))
-					) {
+					if (TRANSITION_CHANGED == arming_state_transition(&status, battery, safety, vehicle_status_s::ARMING_STATE_STANDBY,
+							&armed, true /* fRunPreArmChecks */, &mavlink_log_pub,
+							&status_flags, arm_requirements, hrt_elapsed_time(&commander_boot_timestamp))
+					   ) {
 						status_changed = true;
 					}
 				}
@@ -1788,6 +1802,7 @@ Commander::run()
 		/* update global position estimate and check for timeout */
 		bool gpos_updated =  false;
 		orb_check(global_position_sub, &gpos_updated);
+
 		if (gpos_updated) {
 			orb_copy(ORB_ID(vehicle_global_position), global_position_sub, &global_position);
 			gpos_last_update_time_us = hrt_absolute_time();
@@ -1806,21 +1821,26 @@ Commander::run()
 		if (run_quality_checks && status.is_rotary_wing) {
 			bool estimator_status_updated = false;
 			orb_check(estimator_status_sub, &estimator_status_updated);
+
 			if (estimator_status_updated) {
 				orb_copy(ORB_ID(estimator_status), estimator_status_sub, &estimator_status);
+
 				if (status.arming_state == vehicle_status_s::ARMING_STATE_STANDBY) {
 					// reset flags and timer
 					time_at_takeoff = hrt_absolute_time();
 					nav_test_failed = false;
 					nav_test_passed = false;
+
 				} else if (land_detector.landed) {
 					// record time of takeoff
 					time_at_takeoff = hrt_absolute_time();
+
 				} else {
 					// if nav status is unconfirmed, confirm yaw angle as passed after 30 seconds or achieving 5 m/s of speed
-					bool sufficient_time = (hrt_absolute_time() - time_at_takeoff > 30*1000*1000);
-					bool sufficient_speed = local_position.vx*local_position.vx + local_position.vy*local_position.vy > 25.0f;
+					bool sufficient_time = (hrt_absolute_time() - time_at_takeoff > 30 * 1000 * 1000);
+					bool sufficient_speed = local_position.vx * local_position.vx + local_position.vy * local_position.vy > 25.0f;
 					bool innovation_pass = estimator_status.vel_test_ratio < 1.0f && estimator_status.pos_test_ratio < 1.0f;
+
 					if (!nav_test_failed) {
 						if (!nav_test_passed) {
 							// pass if sufficient time or speed
@@ -1834,7 +1854,7 @@ Commander::run()
 							}
 
 							// if the innovation test has failed continuously, declare the nav as failed
-							if ((hrt_absolute_time() - time_last_innov_pass) > 1000*1000) {
+							if ((hrt_absolute_time() - time_last_innov_pass) > 1000 * 1000) {
 								nav_test_failed = true;
 								mavlink_log_emergency(&mavlink_log_pub, "CRITICAL NAVIGATION FAILURE - CHECK SENSOR CALIBRATION");
 							}
@@ -1850,6 +1870,7 @@ Commander::run()
 				// If nav is failed, then declare local position and velocity as invalid
 				if (nav_test_failed) {
 					status_flags.condition_global_position_valid = false;
+
 				} else {
 					// use global position message to determine validity
 					check_posvel_validity(true, global_position.eph, eph_threshold, global_position.timestamp, &last_gpos_fail_time_us, &gpos_probation_time_us, &status_flags.condition_global_position_valid, &status_changed);
@@ -1870,6 +1891,7 @@ Commander::run()
 				if (nav_test_failed) {
 					status_flags.condition_local_position_valid = false;
 					status_flags.condition_local_velocity_valid = false;
+
 				} else {
 					// use local position message to determine validity
 					check_posvel_validity(local_position.xy_valid, local_position.eph, eph_threshold, local_position.timestamp, &last_lpos_fail_time_us, &lpos_probation_time_us, &status_flags.condition_local_position_valid, &status_changed);
@@ -1883,6 +1905,7 @@ Commander::run()
 
 		/* Update land detector */
 		orb_check(land_detector_sub, &updated);
+
 		if (updated) {
 			orb_copy(ORB_ID(vehicle_land_detected), land_detector_sub, &land_detector);
 
@@ -1891,6 +1914,7 @@ Commander::run()
 				if (was_landed != land_detector.landed) {
 					if (land_detector.landed) {
 						mavlink_and_console_log_info(&mavlink_log_pub, "Landing detected");
+
 					} else {
 						mavlink_and_console_log_info(&mavlink_log_pub, "Takeoff detected");
 						have_taken_off_since_arming = true;
@@ -1927,6 +1951,7 @@ Commander::run()
 		// Check for auto-disarm
 		if (armed.armed && land_detector.landed && disarm_when_landed > 0) {
 			auto_disarm_hysteresis.set_state_and_update(true);
+
 		} else {
 			auto_disarm_hysteresis.set_state_and_update(false);
 		}
@@ -1941,8 +1966,8 @@ Commander::run()
 			main_state_before_rtl = internal_state.main_state;
 
 		} else if (internal_state.main_state != commander_state_s::MAIN_STATE_AUTO_RTL
-			&& internal_state.main_state != commander_state_s::MAIN_STATE_AUTO_LOITER
-			&& internal_state.main_state != commander_state_s::MAIN_STATE_AUTO_LAND) {
+			   && internal_state.main_state != commander_state_s::MAIN_STATE_AUTO_LOITER
+			   && internal_state.main_state != commander_state_s::MAIN_STATE_AUTO_LAND) {
 			// reset flag again when we switched out of it
 			warning_action_on = false;
 		}
@@ -1966,9 +1991,12 @@ Commander::run()
 				/* if battery voltage is getting lower, warn using buzzer, etc. */
 				if (battery.warning == battery_status_s::BATTERY_WARNING_LOW &&
 				   !low_battery_voltage_actions_done) {
+
 					low_battery_voltage_actions_done = true;
+
 					if (armed.armed) {
 						mavlink_log_critical(&mavlink_log_pub, "LOW BATTERY, RETURN TO LAND ADVISED");
+
 					} else {
 						mavlink_log_critical(&mavlink_log_pub, "LOW BATTERY, TAKEOFF DISCOURAGED");
 					}
@@ -1976,6 +2004,7 @@ Commander::run()
 					status_changed = true;
 				} else if (battery.warning == battery_status_s::BATTERY_WARNING_CRITICAL &&
 					   !critical_battery_voltage_actions_done) {
+
 					critical_battery_voltage_actions_done = true;
 
 					if (!armed.armed) {
@@ -2010,16 +2039,19 @@ Commander::run()
 
 				} else if (battery.warning == battery_status_s::BATTERY_WARNING_EMERGENCY &&
 					   !emergency_battery_voltage_actions_done) {
+
 					emergency_battery_voltage_actions_done = true;
 
 					if (!armed.armed) {
 						mavlink_log_critical(&mavlink_log_pub, "DANGEROUSLY LOW BATTERY, SHUT SYSTEM DOWN");
 						usleep(200000);
 						int ret_val = px4_shutdown_request(false, false);
+
 						if (ret_val) {
 							mavlink_log_critical(&mavlink_log_pub, "SYSTEM DOES NOT SUPPORT SHUTDOWN");
+
 						} else {
-							while(1) { usleep(1); }
+							while (1) { usleep(1); }
 						}
 
 					} else {
@@ -2083,8 +2115,8 @@ Commander::run()
 		if (!status_flags.condition_calibration_enabled && status.arming_state == vehicle_status_s::ARMING_STATE_INIT) {
 
 			arming_ret = arming_state_transition(&status, battery, safety, vehicle_status_s::ARMING_STATE_STANDBY, &armed,
-									true /* fRunPreArmChecks */, &mavlink_log_pub, &status_flags,
-									arm_requirements, hrt_elapsed_time(&commander_boot_timestamp));
+							     true /* fRunPreArmChecks */, &mavlink_log_pub, &status_flags,
+							     arm_requirements, hrt_elapsed_time(&commander_boot_timestamp));
 
 			if (arming_ret == TRANSITION_DENIED) {
 				/* do not complain if not allowed into standby */
@@ -2094,8 +2126,9 @@ Commander::run()
 
 		/* start mission result check */
 		const auto prev_mission_instance_count = _mission_result_sub.get().instance_count;
+
 		if (_mission_result_sub.update()) {
-			const mission_result_s& mission_result = _mission_result_sub.get();
+			const mission_result_s &mission_result = _mission_result_sub.get();
 
 			// if mission_result is valid for the current mission
 			const bool mission_result_ok = (mission_result.timestamp > commander_boot_timestamp) && (mission_result.instance_count > 0);
@@ -2115,14 +2148,16 @@ Commander::run()
 
 				/* Only evaluate mission state if home is set */
 				if (status_flags.condition_home_position_valid &&
-					(prev_mission_instance_count != mission_result.instance_count)) {
+				    (prev_mission_instance_count != mission_result.instance_count)) {
 
 					if (!status_flags.condition_auto_mission_available) {
 						/* the mission is invalid */
 						tune_mission_fail(true);
+
 					} else if (mission_result.warning) {
 						/* the mission has a warning */
 						tune_mission_fail(true);
+
 					} else {
 						/* the mission is valid */
 						tune_mission_ok(true);
@@ -2148,6 +2183,7 @@ Commander::run()
 			if (geofence_result.geofence_violated) {
 				static hrt_abstime last_geofence_violation = 0;
 				const hrt_abstime geofence_violation_action_interval = 10000000; // 10 seconds
+
 				if (hrt_elapsed_time(&last_geofence_violation) > geofence_violation_action_interval) {
 
 					last_geofence_violation = hrt_absolute_time();
@@ -2165,12 +2201,14 @@ Commander::run()
 							if (TRANSITION_CHANGED == main_state_transition(status, commander_state_s::MAIN_STATE_AUTO_LOITER, status_flags, &internal_state)) {
 								geofence_loiter_on = true;
 							}
+
 							break;
 						}
 						case (geofence_result_s::GF_ACTION_RTL) : {
 							if (TRANSITION_CHANGED == main_state_transition(status, commander_state_s::MAIN_STATE_AUTO_RTL, status_flags, &internal_state)) {
 								geofence_rtl_on = true;
 							}
+
 							break;
 						}
 						case (geofence_result_s::GF_ACTION_TERMINATE) : {
@@ -2186,15 +2224,15 @@ Commander::run()
 
 			// reset if no longer in LOITER or if manually switched to LOITER
 			geofence_loiter_on = geofence_loiter_on
-									&& (internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LOITER)
-									&& (sp_man.loiter_switch == manual_control_setpoint_s::SWITCH_POS_OFF
-										|| sp_man.loiter_switch == manual_control_setpoint_s::SWITCH_POS_NONE);
+					     && (internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LOITER)
+					     && (sp_man.loiter_switch == manual_control_setpoint_s::SWITCH_POS_OFF
+						 || sp_man.loiter_switch == manual_control_setpoint_s::SWITCH_POS_NONE);
 
 			// reset if no longer in RTL or if manually switched to RTL
 			geofence_rtl_on = geofence_rtl_on
-								&& (internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_RTL)
-								&& (sp_man.return_switch == manual_control_setpoint_s::SWITCH_POS_OFF
-									|| sp_man.return_switch == manual_control_setpoint_s::SWITCH_POS_NONE);
+					  && (internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_RTL)
+					  && (sp_man.return_switch == manual_control_setpoint_s::SWITCH_POS_OFF
+					      || sp_man.return_switch == manual_control_setpoint_s::SWITCH_POS_NONE);
 
 			warning_action_on = warning_action_on || (geofence_loiter_on || geofence_rtl_on);
 		}
@@ -2202,19 +2240,19 @@ Commander::run()
 		// revert geofence failsafe transition if sticks are moved and we were previously in a manual mode
 		// but only if not in a low battery handling action
 		if (rc_override != 0 && !critical_battery_voltage_actions_done && (warning_action_on &&
-		   (main_state_before_rtl == commander_state_s::MAIN_STATE_MANUAL ||
-			main_state_before_rtl == commander_state_s::MAIN_STATE_ALTCTL ||
-			main_state_before_rtl == commander_state_s::MAIN_STATE_POSCTL ||
-			main_state_before_rtl == commander_state_s::MAIN_STATE_ACRO ||
-			main_state_before_rtl == commander_state_s::MAIN_STATE_RATTITUDE ||
-			main_state_before_rtl == commander_state_s::MAIN_STATE_STAB))) {
+				(main_state_before_rtl == commander_state_s::MAIN_STATE_MANUAL ||
+				 main_state_before_rtl == commander_state_s::MAIN_STATE_ALTCTL ||
+				 main_state_before_rtl == commander_state_s::MAIN_STATE_POSCTL ||
+				 main_state_before_rtl == commander_state_s::MAIN_STATE_ACRO ||
+				 main_state_before_rtl == commander_state_s::MAIN_STATE_RATTITUDE ||
+				 main_state_before_rtl == commander_state_s::MAIN_STATE_STAB))) {
 
 			// transition to previous state if sticks are touched
 			if ((_last_sp_man.timestamp != sp_man.timestamp) &&
-				((fabsf(sp_man.x - _last_sp_man.x) > min_stick_change) ||
-				 (fabsf(sp_man.y - _last_sp_man.y) > min_stick_change) ||
-				 (fabsf(sp_man.z - _last_sp_man.z) > min_stick_change) ||
-				 (fabsf(sp_man.r - _last_sp_man.r) > min_stick_change))) {
+			    ((fabsf(sp_man.x - _last_sp_man.x) > min_stick_change) ||
+			     (fabsf(sp_man.y - _last_sp_man.y) > min_stick_change) ||
+			     (fabsf(sp_man.z - _last_sp_man.z) > min_stick_change) ||
+			     (fabsf(sp_man.r - _last_sp_man.r) > min_stick_change))) {
 
 				// revert to position control in any case
 				main_state_transition(status, commander_state_s::MAIN_STATE_POSCTL, status_flags, &internal_state);
@@ -2225,16 +2263,16 @@ Commander::run()
 		// abort landing or auto or loiter if sticks are moved significantly
 		// but only if not in a low battery handling action
 		if (rc_override != 0 && !critical_battery_voltage_actions_done &&
-			(internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LAND ||
-			internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_MISSION ||
-			internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LOITER)) {
+		    (internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LAND ||
+		     internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_MISSION ||
+		     internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_LOITER)) {
 			// transition to previous state if sticks are touched
 
 			if ((_last_sp_man.timestamp != sp_man.timestamp) &&
-				((fabsf(sp_man.x - _last_sp_man.x) > min_stick_change) ||
-				 (fabsf(sp_man.y - _last_sp_man.y) > min_stick_change) ||
-				 (fabsf(sp_man.z - _last_sp_man.z) > min_stick_change) ||
-				 (fabsf(sp_man.r - _last_sp_man.r) > min_stick_change))) {
+			    ((fabsf(sp_man.x - _last_sp_man.x) > min_stick_change) ||
+			     (fabsf(sp_man.y - _last_sp_man.y) > min_stick_change) ||
+			     (fabsf(sp_man.z - _last_sp_man.z) > min_stick_change) ||
+			     (fabsf(sp_man.r - _last_sp_man.r) > min_stick_change))) {
 
 				// revert to position control in any case
 				main_state_transition(status, commander_state_s::MAIN_STATE_POSCTL, status_flags, &internal_state);
@@ -2272,7 +2310,7 @@ Commander::run()
 			} else {
 				if (status.rc_signal_lost) {
 					mavlink_log_info(&mavlink_log_pub, "MANUAL CONTROL REGAINED after %llums",
-							     (hrt_absolute_time() - rc_signal_lost_timestamp) / 1000);
+							 (hrt_absolute_time() - rc_signal_lost_timestamp) / 1000);
 					status_changed = true;
 				}
 			}
@@ -2280,7 +2318,8 @@ Commander::run()
 			status.rc_signal_lost = false;
 
 			const bool in_armed_state = (status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
-			const bool arm_button_pressed = arm_switch_is_button == 1 && sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_ON;
+			const bool arm_button_pressed = arm_switch_is_button == 1
+							&& sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_ON;
 
 			/* DISARM
 			 * check if left stick is in lower left position or arm button is pushed or arm switch has transition from arm to disarm
@@ -2292,23 +2331,26 @@ Commander::run()
 					sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_OFF;
 
 			if (in_armed_state &&
-				status.rc_input_mode != vehicle_status_s::RC_IN_MODE_OFF &&
-				(status.is_rotary_wing || (!status.is_rotary_wing && land_detector.landed)) &&
-				(stick_in_lower_left || arm_button_pressed || arm_switch_to_disarm_transition) ) {
+			    status.rc_input_mode != vehicle_status_s::RC_IN_MODE_OFF &&
+			    (status.is_rotary_wing || (!status.is_rotary_wing && land_detector.landed)) &&
+			    (stick_in_lower_left || arm_button_pressed || arm_switch_to_disarm_transition)) {
 
 				if (internal_state.main_state != commander_state_s::MAIN_STATE_MANUAL &&
-						internal_state.main_state != commander_state_s::MAIN_STATE_ACRO &&
-						internal_state.main_state != commander_state_s::MAIN_STATE_STAB &&
-						internal_state.main_state != commander_state_s::MAIN_STATE_RATTITUDE &&
-						!land_detector.landed) {
+				    internal_state.main_state != commander_state_s::MAIN_STATE_ACRO &&
+				    internal_state.main_state != commander_state_s::MAIN_STATE_STAB &&
+				    internal_state.main_state != commander_state_s::MAIN_STATE_RATTITUDE &&
+				    !land_detector.landed) {
 					print_reject_arm("NOT DISARMING: Not in manual mode or landed yet.");
 
 				} else if ((stick_off_counter == rc_arm_hyst && stick_on_counter < rc_arm_hyst) || arm_switch_to_disarm_transition) {
-					arming_ret = arming_state_transition(&status, battery, safety, vehicle_status_s::ARMING_STATE_STANDBY, &armed, true /* fRunPreArmChecks */,
-													&mavlink_log_pub, &status_flags, arm_requirements, hrt_elapsed_time(&commander_boot_timestamp));
+					arming_ret = arming_state_transition(&status, battery, safety, vehicle_status_s::ARMING_STATE_STANDBY, &armed,
+									     true /* fRunPreArmChecks */,
+									     &mavlink_log_pub, &status_flags, arm_requirements, hrt_elapsed_time(&commander_boot_timestamp));
 				}
+
 				stick_off_counter++;
-			/* do not reset the counter when holding the arm button longer than needed */
+				/* do not reset the counter when holding the arm button longer than needed */
+
 			} else if (!(arm_switch_is_button == 1 && sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_ON)) {
 				stick_off_counter = 0;
 			}
@@ -2322,8 +2364,8 @@ Commander::run()
 					sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_ON;
 
 			if (!in_armed_state &&
-				status.rc_input_mode != vehicle_status_s::RC_IN_MODE_OFF &&
-				(stick_in_lower_right || arm_button_pressed || arm_switch_to_arm_transition) ) {
+			    status.rc_input_mode != vehicle_status_s::RC_IN_MODE_OFF &&
+			    (stick_in_lower_right || arm_button_pressed || arm_switch_to_arm_transition)) {
 				if ((stick_on_counter == rc_arm_hyst && stick_off_counter < rc_arm_hyst) || arm_switch_to_arm_transition) {
 
 					/* we check outside of the transition function here because the requirement
@@ -2332,21 +2374,22 @@ Commander::run()
 					 */
 
 					if ((internal_state.main_state != commander_state_s::MAIN_STATE_MANUAL)
-						&& (internal_state.main_state != commander_state_s::MAIN_STATE_ACRO)
-						&& (internal_state.main_state != commander_state_s::MAIN_STATE_STAB)
-						&& (internal_state.main_state != commander_state_s::MAIN_STATE_ALTCTL)
-						&& (internal_state.main_state != commander_state_s::MAIN_STATE_POSCTL)
-						&& (internal_state.main_state != commander_state_s::MAIN_STATE_RATTITUDE)
-						) {
+					    && (internal_state.main_state != commander_state_s::MAIN_STATE_ACRO)
+					    && (internal_state.main_state != commander_state_s::MAIN_STATE_STAB)
+					    && (internal_state.main_state != commander_state_s::MAIN_STATE_ALTCTL)
+					    && (internal_state.main_state != commander_state_s::MAIN_STATE_POSCTL)
+					    && (internal_state.main_state != commander_state_s::MAIN_STATE_RATTITUDE)
+					   ) {
 						print_reject_arm("NOT ARMING: Switch to a manual mode first.");
 
 					} else if (!status_flags.condition_home_position_valid &&
-								geofence_action == geofence_result_s::GF_ACTION_RTL) {
+						   geofence_action == geofence_result_s::GF_ACTION_RTL) {
 						print_reject_arm("NOT ARMING: Geofence RTL requires valid home");
 
 					} else if (status.arming_state == vehicle_status_s::ARMING_STATE_STANDBY) {
-						arming_ret = arming_state_transition(&status, battery, safety, vehicle_status_s::ARMING_STATE_ARMED, &armed, true /* fRunPreArmChecks */,
-												&mavlink_log_pub, &status_flags, arm_requirements, hrt_elapsed_time(&commander_boot_timestamp));
+						arming_ret = arming_state_transition(&status, battery, safety, vehicle_status_s::ARMING_STATE_ARMED, &armed,
+										     true /* fRunPreArmChecks */,
+										     &mavlink_log_pub, &status_flags, arm_requirements, hrt_elapsed_time(&commander_boot_timestamp));
 
 						if (arming_ret != TRANSITION_CHANGED) {
 							usleep(100000);
@@ -2354,8 +2397,10 @@ Commander::run()
 						}
 					}
 				}
+
 				stick_on_counter++;
-			/* do not reset the counter when holding the arm button longer than needed */
+				/* do not reset the counter when holding the arm button longer than needed */
+
 			} else if (!(arm_switch_is_button == 1 && sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_ON)) {
 				stick_on_counter = 0;
 			}
@@ -2397,6 +2442,7 @@ Commander::run()
 					status_changed = true;
 					armed.manual_lockdown = true;
 				}
+
 			} else if (sp_man.kill_switch == manual_control_setpoint_s::SWITCH_POS_OFF) {
 				if (armed.manual_lockdown) {
 					mavlink_log_emergency(&mavlink_log_pub, "MANUAL KILL SWITCH OFF");
@@ -2404,7 +2450,9 @@ Commander::run()
 					armed.manual_lockdown = false;
 				}
 			}
+
 			/* no else case: do not change lockdown flag in unconfigured case */
+
 		} else {
 			if (!status_flags.rc_input_blocked && !status.rc_signal_lost) {
 				mavlink_log_critical(&mavlink_log_pub, "MANUAL CONTROL LOST (at t=%llums)", hrt_absolute_time() / 1000);
@@ -2435,13 +2483,13 @@ Commander::run()
 				const float current2throttle = battery.current_a / throttle;
 
 				if (((throttle > ef_throttle_thres) && (current2throttle < ef_current2throttle_thres))
-					|| status.engine_failure) {
+				    || status.engine_failure) {
 
 					const float elapsed = hrt_elapsed_time(&timestamp_engine_healthy) / 1e6f;
 
 					/* potential failure, measure time */
 					if ((timestamp_engine_healthy > 0) && (elapsed > ef_time_thres)
-						&& !status.engine_failure) {
+					    && !status.engine_failure) {
 
 						status.engine_failure = true;
 						status_changed = true;
@@ -2466,11 +2514,11 @@ Commander::run()
 		 * as finished even though we only just started with the takeoff. Therefore, we also
 		 * check the timestamp of the mission_result topic. */
 		if (internal_state.main_state == commander_state_s::MAIN_STATE_AUTO_TAKEOFF
-			&& (_mission_result_sub.get().timestamp > internal_state.timestamp)
-			&& _mission_result_sub.get().finished) {
+		    && (_mission_result_sub.get().timestamp > internal_state.timestamp)
+		    && _mission_result_sub.get().finished) {
 
 			const bool mission_available = (_mission_result_sub.get().timestamp > commander_boot_timestamp)
-				&& (_mission_result_sub.get().instance_count > 0) && _mission_result_sub.get().valid;
+						       && (_mission_result_sub.get().instance_count > 0) && _mission_result_sub.get().valid;
 
 			if ((takeoff_complete_act == 1) && mission_available) {
 				main_state_transition(status, commander_state_s::MAIN_STATE_AUTO_MISSION, status_flags, &internal_state);
@@ -2488,7 +2536,7 @@ Commander::run()
 			 * we can as well just wait in a hold mode which enables tablet control.
 			 */
 			if (status.rc_signal_lost && (internal_state.main_state == commander_state_s::MAIN_STATE_MANUAL)
-				&& status_flags.condition_home_position_valid) {
+			    && status_flags.condition_home_position_valid) {
 
 				main_state_transition(status, commander_state_s::MAIN_STATE_AUTO_LOITER, status_flags, &internal_state);
 			}
@@ -2570,11 +2618,12 @@ Commander::run()
 		if (!_home.manual_home) {
 			if (armed.armed) {
 				if ((!was_armed || (was_landed && !land_detector.landed)) &&
-					(now > commander_boot_timestamp + INAIR_RESTART_HOLDOFF_INTERVAL)) {
+				    (now > commander_boot_timestamp + INAIR_RESTART_HOLDOFF_INTERVAL)) {
 
 					/* update home position on arming if at least 500 ms from commander start spent to avoid setting home on in-air restart */
 					set_home_position(home_pub, _home, local_position, global_position, false);
 				}
+
 			} else {
 				if (status_flags.condition_home_position_valid) {
 					if (land_detector.landed && local_position.xy_valid && local_position.z_valid) {
@@ -2582,8 +2631,8 @@ Commander::run()
 						float home_dist_xy = -1.0f;
 						float home_dist_z = -1.0f;
 						mavlink_wpm_distance_to_point_local(_home.x, _home.y, _home.z,
-								local_position.x, local_position.y, local_position.z,
-								&home_dist_xy, &home_dist_z);
+										    local_position.x, local_position.y, local_position.z,
+										    &home_dist_xy, &home_dist_z);
 
 						if ((home_dist_xy > local_position.eph * 2) || (home_dist_z > local_position.epv * 2)) {
 
@@ -2591,6 +2640,7 @@ Commander::run()
 							set_home_position(home_pub, _home, local_position, global_position, false);
 						}
 					}
+
 				} else {
 					/* First time home position update - but only if disarmed */
 					set_home_position(home_pub, _home, local_position, global_position, false);
@@ -2621,21 +2671,20 @@ Commander::run()
 
 		/* now set navigation state according to failsafe and main state */
 		bool nav_state_changed = set_nav_state(&status,
-											   &armed,
-											   &internal_state,
-											   &mavlink_log_pub,
-											   (link_loss_actions_t)datalink_loss_act,
-											   _mission_result_sub.get().finished,
-											   _mission_result_sub.get().stay_in_failsafe,
-											   status_flags,
-											   land_detector.landed,
-											   (link_loss_actions_t)rc_loss_act,
-											   offboard_loss_act,
-											   offboard_loss_rc_act,
-											   posctl_nav_loss_act);
+						       &armed,
+						       &internal_state,
+						       &mavlink_log_pub,
+						       (link_loss_actions_t)datalink_loss_act,
+						       _mission_result_sub.get().finished,
+						       _mission_result_sub.get().stay_in_failsafe,
+						       status_flags,
+						       land_detector.landed,
+						       (link_loss_actions_t)rc_loss_act,
+						       offboard_loss_act,
+						       offboard_loss_rc_act,
+						       posctl_nav_loss_act);
 
-		if (status.failsafe != failsafe_old)
-		{
+		if (status.failsafe != failsafe_old) {
 			status_changed = true;
 
 			if (status.failsafe) {
@@ -2670,6 +2719,7 @@ Commander::run()
 
 				/* safety is off, go into prearmed */
 				armed.prearmed = safety.safety_off;
+
 			} else {
 				/* safety is not present, go into prearmed
 				 * (all output drivers should be started / unlocked last in the boot process
@@ -2677,6 +2727,7 @@ Commander::run()
 				 */
 				armed.prearmed = (hrt_elapsed_time(&commander_boot_timestamp) > 5 * 1000 * 1000);
 			}
+
 			orb_publish(ORB_ID(actuator_armed), armed_pub, &armed);
 
 			/* publish internal state for logging purposes */
@@ -2692,6 +2743,7 @@ Commander::run()
 
 			if (vehicle_status_flags_pub != nullptr) {
 				orb_publish(ORB_ID(vehicle_status_flags), vehicle_status_flags_pub, &status_flags);
+
 			} else {
 				vehicle_status_flags_pub = orb_advertise(ORB_ID(vehicle_status_flags), &status_flags);
 			}
@@ -2717,6 +2769,7 @@ Commander::run()
 
 		} else if (status.failsafe) {
 			tune_failsafe(true);
+
 		} else {
 			set_tune(TONE_STOP_TUNE);
 		}
@@ -2735,7 +2788,8 @@ Commander::run()
 		/* play sensor failure tunes if we already waited for hotplug sensors to come up and failed */
 		status_flags.condition_system_hotplug_timeout = (hrt_elapsed_time(&commander_boot_timestamp) > HOTPLUG_SENS_TIMEOUT);
 
-		if (!sensor_fail_tune_played && (!status_flags.condition_system_sensors_initialized && status_flags.condition_system_hotplug_timeout)) {
+		if (!sensor_fail_tune_played && (!status_flags.condition_system_sensors_initialized
+						 && status_flags.condition_system_hotplug_timeout)) {
 			set_tune_override(TONE_GPS_WARNING_TUNE);
 			sensor_fail_tune_played = true;
 			status_changed = true;
@@ -2824,7 +2878,7 @@ Commander::check_valid(const hrt_abstime& timestamp, const hrt_abstime& timeout,
 
 void
 control_status_leds(vehicle_status_s *status_local, const actuator_armed_s *actuator_armed,
-	bool changed, battery_status_s *battery_local, const cpuload_s *cpuload_local)
+		    bool changed, battery_status_s *battery_local, const cpuload_s *cpuload_local)
 {
 	static hrt_abstime overload_start = 0;
 
@@ -2832,6 +2886,7 @@ control_status_leds(vehicle_status_s *status_local, const actuator_armed_s *actu
 
 	if (overload_start == 0 && overload) {
 		overload_start = hrt_absolute_time();
+
 	} else if (!overload) {
 		overload_start = 0;
 	}
@@ -2881,8 +2936,10 @@ control_status_leds(vehicle_status_s *status_local, const actuator_armed_s *actu
 
 			} else if (battery_local->warning == battery_status_s::BATTERY_WARNING_LOW) {
 				led_color = led_control_s::COLOR_AMBER;
+
 			} else if (battery_local->warning == battery_status_s::BATTERY_WARNING_CRITICAL) {
 				led_color = led_control_s::COLOR_RED;
+
 			} else {
 				if (status_flags.condition_home_position_valid && status_flags.condition_global_position_valid) {
 					led_color = led_control_s::COLOR_GREEN;
@@ -2892,6 +2949,7 @@ control_status_leds(vehicle_status_s *status_local, const actuator_armed_s *actu
 				}
 			}
 		}
+
 		if (led_mode != led_control_s::MODE_OFF) {
 			rgbled_set_color_and_mode(led_color, led_mode);
 		}
@@ -2905,9 +2963,11 @@ control_status_leds(vehicle_status_s *status_local, const actuator_armed_s *actu
 	if (actuator_armed->armed) {
 		if (status.failsafe) {
 			led_off(LED_BLUE);
+
 			if (leds_counter % 5 == 0) {
 				led_toggle(LED_GREEN);
 			}
+
 		} else {
 			led_off(LED_GREEN);
 
@@ -2917,6 +2977,7 @@ control_status_leds(vehicle_status_s *status_local, const actuator_armed_s *actu
 
 	} else if (actuator_armed->ready_to_arm) {
 		led_off(LED_BLUE);
+
 		/* ready to arm, blink at 1Hz */
 		if (leds_counter % 20 == 0) {
 			led_toggle(LED_GREEN);
@@ -2924,6 +2985,7 @@ control_status_leds(vehicle_status_s *status_local, const actuator_armed_s *actu
 
 	} else {
 		led_off(LED_BLUE);
+
 		/* not ready to arm, blink at 10Hz */
 		if (leds_counter % 2 == 0) {
 			led_toggle(LED_GREEN);
@@ -2946,17 +3008,19 @@ control_status_leds(vehicle_status_s *status_local, const actuator_armed_s *actu
 }
 
 transition_result_t
-Commander::set_main_state(const vehicle_status_s& status_local, const vehicle_global_position_s& global_position, const vehicle_local_position_s& local_position, bool *changed)
+Commander::set_main_state(const vehicle_status_s &status_local, const vehicle_global_position_s &global_position,
+			  const vehicle_local_position_s &local_position, bool *changed)
 {
 	if (safety.override_available && safety.override_enabled) {
 		return set_main_state_override_on(status_local, changed);
+
 	} else {
 		return set_main_state_rc(status_local, global_position, local_position, changed);
 	}
 }
 
 transition_result_t
-Commander::set_main_state_override_on(const vehicle_status_s& status_local, bool *changed)
+Commander::set_main_state_override_on(const vehicle_status_s &status_local, bool *changed)
 {
 	transition_result_t res = main_state_transition(status_local, commander_state_s::MAIN_STATE_MANUAL, status_flags, &internal_state);
 	*changed = (res == TRANSITION_CHANGED);
@@ -2965,7 +3029,8 @@ Commander::set_main_state_override_on(const vehicle_status_s& status_local, bool
 }
 
 transition_result_t
-Commander::set_main_state_rc(const vehicle_status_s& status_local, const vehicle_global_position_s& global_position, const vehicle_local_position_s& local_position, bool *changed)
+Commander::set_main_state_rc(const vehicle_status_s &status_local, const vehicle_global_position_s &global_position,
+			     const vehicle_local_position_s &local_position, bool *changed)
 {
 	/* set main state according to RC switches */
 	transition_result_t res = TRANSITION_DENIED;
@@ -2976,8 +3041,8 @@ Commander::set_main_state_rc(const vehicle_status_s& status_local, const vehicle
 
 	/* manual setpoint has not updated, do not re-evaluate it */
 	if (!(!_last_condition_global_position_valid &&
-		status_flags.condition_global_position_valid)
-		&& (((_last_sp_man.timestamp != 0) && (_last_sp_man.timestamp == sp_man.timestamp)) ||
+	      status_flags.condition_global_position_valid)
+	    && (((_last_sp_man.timestamp != 0) && (_last_sp_man.timestamp == sp_man.timestamp)) ||
 		((_last_sp_man.offboard_switch == sp_man.offboard_switch) &&
 		 (_last_sp_man.return_switch == sp_man.return_switch) &&
 		 (_last_sp_man.mode_switch == sp_man.mode_switch) &&
@@ -2994,7 +3059,7 @@ Commander::set_main_state_rc(const vehicle_status_s& status_local, const vehicle
 		// the sticks to break out of the autonomous state
 
 		if (!warning_action_on
-			&& (internal_state.main_state == commander_state_s::MAIN_STATE_MANUAL ||
+		    && (internal_state.main_state == commander_state_s::MAIN_STATE_MANUAL ||
 			internal_state.main_state == commander_state_s::MAIN_STATE_ALTCTL ||
 			internal_state.main_state == commander_state_s::MAIN_STATE_POSCTL ||
 			internal_state.main_state == commander_state_s::MAIN_STATE_ACRO ||
@@ -3210,7 +3275,7 @@ Commander::set_main_state_rc(const vehicle_status_s& status_local, const vehicle
 
 	case manual_control_setpoint_s::SWITCH_POS_OFF:		// MANUAL
 		if (sp_man.stab_switch == manual_control_setpoint_s::SWITCH_POS_NONE &&
-			sp_man.man_switch == manual_control_setpoint_s::SWITCH_POS_NONE) {
+		    sp_man.man_switch == manual_control_setpoint_s::SWITCH_POS_NONE) {
 			/*
 			 * Legacy mode:
 			 * Acro switch being used as stabilized switch in FW.
@@ -3343,7 +3408,8 @@ Commander::set_main_state_rc(const vehicle_status_s& status_local, const vehicle
 }
 
 void
-Commander::reset_posvel_validity(const vehicle_global_position_s& global_position, const vehicle_local_position_s& local_position, bool *changed)
+Commander::reset_posvel_validity(const vehicle_global_position_s &global_position,
+				 const vehicle_local_position_s &local_position, bool *changed)
 {
 	// reset all the check probation times back to the minimum value
 	gpos_probation_time_us = POSVEL_PROBATION_MIN;
@@ -3357,7 +3423,9 @@ Commander::reset_posvel_validity(const vehicle_global_position_s& global_positio
 }
 
 bool
-Commander::check_posvel_validity(const bool data_valid, const float data_accuracy, const float required_accuracy, const hrt_abstime& data_timestamp_us, hrt_abstime* last_fail_time_us, hrt_abstime *probation_time_us, bool *valid_state, bool *validity_changed)
+Commander::check_posvel_validity(const bool data_valid, const float data_accuracy, const float required_accuracy,
+				 const hrt_abstime &data_timestamp_us, hrt_abstime *last_fail_time_us, hrt_abstime *probation_time_us, bool *valid_state,
+				 bool *validity_changed)
 {
 	const bool was_valid = *valid_state;
 	bool valid = was_valid;
@@ -3378,17 +3446,20 @@ Commander::check_posvel_validity(const bool data_valid, const float data_accurac
 			// still valid, continue to decrease probation time
 			const int64_t probation_time_new = *probation_time_us - hrt_elapsed_time(last_fail_time_us);
 			*probation_time_us = math::constrain(probation_time_new, POSVEL_PROBATION_MIN, POSVEL_PROBATION_MAX);
+
 		} else {
 			// check if probation period has elapsed
 			if (hrt_elapsed_time(last_fail_time_us) > *probation_time_us) {
 				valid = true;
 			}
 		}
+
 	} else {
 		// level check failed
 		if (was_valid) {
 			// FAILURE! no longer valid
 			valid = false;
+
 		} else {
 			// failed again, increase probation time
 			const int64_t probation_time_new = *probation_time_us + hrt_elapsed_time(last_fail_time_us) * posctl_nav_loss_gain;
@@ -3490,7 +3561,8 @@ set_control_mode()
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_RCRECOVER:
 		/* override is not ok for the RTL and recovery mode */
 		control_mode.flag_external_manual_override_ok = false;
-		/* fallthrough */
+
+	/* fallthrough */
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_FOLLOW_TARGET:
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_RTGS:
 	case vehicle_status_s::NAVIGATION_STATE_AUTO_LAND:
@@ -3580,33 +3652,33 @@ set_control_mode()
 		 * Inner loop flags (e.g. attitude) also depend on outer loop ignore flags (e.g. position)
 		 */
 		control_mode.flag_control_rates_enabled = !offboard_control_mode.ignore_bodyrate ||
-			!offboard_control_mode.ignore_attitude ||
-			!offboard_control_mode.ignore_position ||
-			!offboard_control_mode.ignore_velocity ||
-			!offboard_control_mode.ignore_acceleration_force;
+				!offboard_control_mode.ignore_attitude ||
+				!offboard_control_mode.ignore_position ||
+				!offboard_control_mode.ignore_velocity ||
+				!offboard_control_mode.ignore_acceleration_force;
 
 		control_mode.flag_control_attitude_enabled = !offboard_control_mode.ignore_attitude ||
-			!offboard_control_mode.ignore_position ||
-			!offboard_control_mode.ignore_velocity ||
-			!offboard_control_mode.ignore_acceleration_force;
+				!offboard_control_mode.ignore_position ||
+				!offboard_control_mode.ignore_velocity ||
+				!offboard_control_mode.ignore_acceleration_force;
 
 		control_mode.flag_control_rattitude_enabled = false;
 
 		control_mode.flag_control_acceleration_enabled = !offboard_control_mode.ignore_acceleration_force &&
-		  !status.in_transition_mode;
+				!status.in_transition_mode;
 
 		control_mode.flag_control_velocity_enabled = (!offboard_control_mode.ignore_velocity ||
-			!offboard_control_mode.ignore_position) && !status.in_transition_mode &&
-			!control_mode.flag_control_acceleration_enabled;
+				!offboard_control_mode.ignore_position) && !status.in_transition_mode &&
+				!control_mode.flag_control_acceleration_enabled;
 
 		control_mode.flag_control_climb_rate_enabled = (!offboard_control_mode.ignore_velocity ||
-			!offboard_control_mode.ignore_position) && !control_mode.flag_control_acceleration_enabled;
+				!offboard_control_mode.ignore_position) && !control_mode.flag_control_acceleration_enabled;
 
 		control_mode.flag_control_position_enabled = !offboard_control_mode.ignore_position && !status.in_transition_mode &&
-		  !control_mode.flag_control_acceleration_enabled;
+				!control_mode.flag_control_acceleration_enabled;
 
 		control_mode.flag_control_altitude_enabled = (!offboard_control_mode.ignore_velocity ||
-			!offboard_control_mode.ignore_position) && !control_mode.flag_control_acceleration_enabled;
+				!offboard_control_mode.ignore_position) && !control_mode.flag_control_acceleration_enabled;
 
 		break;
 
@@ -3621,7 +3693,7 @@ stabilization_required()
 	return (status.is_rotary_wing ||		// is a rotary wing, or
 		status.vtol_fw_permanent_stab || 	// is a VTOL in fixed wing mode and stabilisation is on, or
 		(vtol_status.vtol_in_trans_mode && 	// is currently a VTOL transitioning AND
-			!status.is_rotary_wing));	// is a fixed wing, ie: transitioning back to rotary wing mode
+		 !status.is_rotary_wing));	// is a fixed wing, ie: transitioning back to rotary wing mode
 }
 
 void
@@ -3694,7 +3766,8 @@ void answer_command(const vehicle_command_s &cmd, unsigned result, orb_advert_t 
 		orb_publish(ORB_ID(vehicle_command_ack), command_ack_pub, &command_ack);
 
 	} else {
-		command_ack_pub = orb_advertise_queue(ORB_ID(vehicle_command_ack), &command_ack, vehicle_command_ack_s::ORB_QUEUE_LENGTH);
+		command_ack_pub = orb_advertise_queue(ORB_ID(vehicle_command_ack), &command_ack,
+						      vehicle_command_ack_s::ORB_QUEUE_LENGTH);
 	}
 }
 
@@ -3724,6 +3797,7 @@ void *commander_low_prio_loop(void *arg)
 			/* this is undesirable but not much we can do - might want to flag unhappy status */
 			warn("commander: poll error %d, %d", pret, errno);
 			continue;
+
 		} else if (pret != 0) {
 			struct vehicle_command_s cmd;
 
@@ -3780,11 +3854,12 @@ void *commander_low_prio_loop(void *arg)
 
 					/* try to go to INIT/PREFLIGHT arming state */
 					if (TRANSITION_DENIED == arming_state_transition(&status, battery, safety, vehicle_status_s::ARMING_STATE_INIT, &armed,
-													false /* fRunPreArmChecks */, &mavlink_log_pub, &status_flags,
-													arm_requirements, hrt_elapsed_time(&commander_boot_timestamp))) {
+							false /* fRunPreArmChecks */, &mavlink_log_pub, &status_flags,
+							arm_requirements, hrt_elapsed_time(&commander_boot_timestamp))) {
 
 						answer_command(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_DENIED, command_ack_pub);
 						break;
+
 					} else {
 						status_flags.condition_calibration_enabled = true;
 					}
@@ -3795,8 +3870,8 @@ void *commander_low_prio_loop(void *arg)
 						calib_ret = do_gyro_calibration(&mavlink_log_pub);
 
 					} else if ((int)(cmd.param1) == vehicle_command_s::PREFLIGHT_CALIBRATION_TEMPERATURE_CALIBRATION ||
-							(int)(cmd.param5) == vehicle_command_s::PREFLIGHT_CALIBRATION_TEMPERATURE_CALIBRATION ||
-							(int)(cmd.param7) == vehicle_command_s::PREFLIGHT_CALIBRATION_TEMPERATURE_CALIBRATION) {
+						   (int)(cmd.param5) == vehicle_command_s::PREFLIGHT_CALIBRATION_TEMPERATURE_CALIBRATION ||
+						   (int)(cmd.param7) == vehicle_command_s::PREFLIGHT_CALIBRATION_TEMPERATURE_CALIBRATION) {
 						/* temperature calibration: handled in events module */
 						break;
 
@@ -3826,10 +3901,12 @@ void *commander_low_prio_loop(void *arg)
 						/* accelerometer calibration */
 						answer_command(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED, command_ack_pub);
 						calib_ret = do_accel_calibration(&mavlink_log_pub);
+
 					} else if ((int)(cmd.param5) == 2) {
 						// board offset calibration
 						answer_command(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED, command_ack_pub);
 						calib_ret = do_level_calibration(&mavlink_log_pub);
+
 					} else if ((int)(cmd.param6) == 1 || (int)(cmd.param6) == 2) {
 						// TODO: param6 == 1 is deprecated, but we still accept it for a while (feb 2017)
 						/* airspeed calibration */
@@ -3848,9 +3925,11 @@ void *commander_low_prio_loop(void *arg)
 							status_flags.rc_input_blocked = false;
 							mavlink_log_info(&mavlink_log_pub, "CAL: Re-enabling RC IN");
 						}
+
 						answer_command(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED, command_ack_pub);
 						/* this always succeeds */
 						calib_ret = OK;
+
 					} else {
 						answer_command(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_UNSUPPORTED, command_ack_pub);
 					}
@@ -3862,8 +3941,9 @@ void *commander_low_prio_loop(void *arg)
 
 						Commander::preflight_check(false);
 
-						arming_state_transition(&status, battery, safety, vehicle_status_s::ARMING_STATE_STANDBY, &armed, false /* fRunPreArmChecks */,
-								&mavlink_log_pub, &status_flags, arm_requirements, hrt_elapsed_time(&commander_boot_timestamp));
+						arming_state_transition(&status, battery, safety, vehicle_status_s::ARMING_STATE_STANDBY, &armed,
+									false /* fRunPreArmChecks */,
+									&mavlink_log_pub, &status_flags, arm_requirements, hrt_elapsed_time(&commander_boot_timestamp));
 
 					} else {
 						tune_negative(true);
@@ -3924,6 +4004,7 @@ void *commander_low_prio_loop(void *arg)
 
 							answer_command(cmd, vehicle_command_s::VEHICLE_CMD_RESULT_FAILED, command_ack_pub);
 						}
+
 					} else if (((int)(cmd.param1)) == 2) {
 
 						/* reset parameters and save empty file */
@@ -4010,6 +4091,7 @@ void Commander::mission_init()
 {
 	/* init mission state, do it here to allow navigator to use stored mission even if mavlink failed to start */
 	mission_s mission = {};
+
 	if (dm_read(DM_KEY_MISSION_STATE, 0, &mission, sizeof(mission_s)) == sizeof(mission_s)) {
 		if (mission.dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_0 || mission.dataman_id == DM_KEY_WAYPOINTS_OFFBOARD_1) {
 			if (mission.count > 0) {
@@ -4034,16 +4116,18 @@ bool Commander::preflight_check(bool report)
 {
 	const bool checkGNSS = (arm_requirements & ARM_REQ_GPS_BIT);
 
-	bool success = Preflight::preflightCheck(&mavlink_log_pub, status, status_flags, checkGNSS, report, false, hrt_elapsed_time(&commander_boot_timestamp));
+	bool success = Preflight::preflightCheck(&mavlink_log_pub, status, status_flags, checkGNSS, report, false,
+			hrt_elapsed_time(&commander_boot_timestamp));
 
 	status_flags.condition_system_sensors_initialized = success;
 
 	return success;
 }
 
-void Commander::poll_telemetry_status(bool checkAirspeed, bool *hotplug_timeout)
+void Commander::poll_telemetry_status()
 {
 	bool updated = false;
+
 	for (int i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
 
 		if (_telemetry[i].subscriber < 0) {
@@ -4058,36 +4142,25 @@ void Commander::poll_telemetry_status(bool checkAirspeed, bool *hotplug_timeout)
 
 			/* perform system checks when new telemetry link connected */
 			if (/* we first connect a link or re-connect a link after loosing it or haven't yet reported anything */
-			    (_telemetry[i].last_heartbeat == 0 || (hrt_elapsed_time(&_telemetry[i].last_heartbeat) > 3 * 1000 * 1000)
-			        || !_telemetry[i].preflight_checks_reported) &&
-			    /* and this link has a communication partner */
-			    (telemetry.heartbeat_time > 0) &&
-			    /* and it is still connected */
-			    (hrt_elapsed_time(&telemetry.heartbeat_time) < 2 * 1000 * 1000) &&
-			    /* and the system is not already armed (and potentially flying) */
-			    !armed.armed) {
+				(_telemetry[i].last_heartbeat == 0 || (hrt_elapsed_time(&_telemetry[i].last_heartbeat) > 3 * 1000 * 1000)
+				 || !_telemetry[i].preflight_checks_reported) &&
+				/* and this link has a communication partner */
+				(telemetry.heartbeat_time > 0) &&
+				/* and it is still connected */
+				(hrt_elapsed_time(&telemetry.heartbeat_time) < 2 * 1000 * 1000) &&
+				/* and the system is not already armed (and potentially flying) */
+				!armed.armed) {
 
-				*hotplug_timeout = hrt_elapsed_time(&commander_boot_timestamp) > HOTPLUG_SENS_TIMEOUT;
 				/* flag the checks as reported for this link when we actually report them */
-				_telemetry[i].preflight_checks_reported = *hotplug_timeout;
+				_telemetry[i].preflight_checks_reported = status_flags.condition_system_hotplug_timeout;
 
-				/* provide RC and sensor status feedback to the user */
-				if (status.hil_state == vehicle_status_s::HIL_STATE_ON) {
-					/* HITL configuration: check only RC input */
-					Preflight::preflightCheck(&mavlink_log_pub, false, false,
-							(status.rc_input_mode == vehicle_status_s::RC_IN_MODE_DEFAULT), false,
-							 true, is_vtol(&status), false, false, hrt_elapsed_time(&commander_boot_timestamp));
-				} else {
-					/* check sensors also */
-					Preflight::preflightCheck(&mavlink_log_pub, true, checkAirspeed,
-							(status.rc_input_mode == vehicle_status_s::RC_IN_MODE_DEFAULT), arm_requirements & ARM_REQ_GPS_BIT,
-							 true, is_vtol(&status), *hotplug_timeout, false, hrt_elapsed_time(&commander_boot_timestamp));
-				}
+				preflight_check(true);
 
 				// Provide feedback on mission state
-				const mission_result_s& mission_result = _mission_result_sub.get();
-				if ((mission_result.timestamp > commander_boot_timestamp) && *hotplug_timeout &&
-					(mission_result.instance_count > 0) && !mission_result.valid) {
+				const mission_result_s &mission_result = _mission_result_sub.get();
+
+				if ((mission_result.timestamp > commander_boot_timestamp) && status_flags.condition_system_hotplug_timeout &&
+				    (mission_result.instance_count > 0) && !mission_result.valid) {
 
 					mavlink_log_critical(&mavlink_log_pub, "Planned mission fails check. Please upload again.");
 				}
@@ -4095,12 +4168,13 @@ void Commander::poll_telemetry_status(bool checkAirspeed, bool *hotplug_timeout)
 
 			/* set (and don't reset) telemetry via USB as active once a MAVLink connection is up */
 			if (telemetry.type == telemetry_status_s::TELEMETRY_STATUS_RADIO_TYPE_USB) {
-				_usb_telemetry_active = true;
+				status_flags.usb_connected = true;
 			}
 
 			/* set latency type of the telemetry connection */
 			if (telemetry.type == telemetry_status_s::TELEMETRY_STATUS_RADIO_TYPE_IRIDIUM) {
 				_telemetry[i].high_latency = true;
+
 			} else {
 				_telemetry[i].high_latency = false;
 			}
@@ -4113,7 +4187,7 @@ void Commander::poll_telemetry_status(bool checkAirspeed, bool *hotplug_timeout)
 }
 
 void Commander::data_link_checks(int32_t highlatencydatalink_loss_timeout, int32_t highlatencydatalink_regain_timeout,
-		int32_t datalink_loss_timeout, int32_t datalink_regain_timeout, bool *status_changed)
+				 int32_t datalink_loss_timeout, int32_t datalink_regain_timeout, bool *status_changed)
 {
 	/* data links check */
 	bool have_link = false;
@@ -4125,40 +4199,44 @@ void Commander::data_link_checks(int32_t highlatencydatalink_loss_timeout, int32
 	for (int i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
 		if (_telemetry[i].high_latency) {
 			high_latency_link_exists = true;
+
 			if (status.high_latency_data_link_active) {
 				dl_loss_timeout_local = highlatencydatalink_loss_timeout;
 				dl_regain_timeout_local = highlatencydatalink_regain_timeout;
+
 			} else {
 				// if the high latency link is inactive we do not want to accidentally detect it as an active link
 				dl_loss_timeout_local = INT32_MIN;
 				dl_regain_timeout_local = INT32_MAX;
 			}
+
 		} else {
 			dl_loss_timeout_local = datalink_loss_timeout;
 			dl_regain_timeout_local = datalink_regain_timeout;
 		}
 
 		if (_telemetry[i].last_heartbeat != 0 &&
-			hrt_elapsed_time(&_telemetry[i].last_heartbeat) < dl_loss_timeout_local * 1e6) {
+		    hrt_elapsed_time(&_telemetry[i].last_heartbeat) < dl_loss_timeout_local * 1e6) {
 			/* handle the case where data link was gained first time or regained,
 			 * accept datalink as healthy only after datalink_regain_timeout seconds
 			 * */
 			if (_telemetry[i].lost &&
-				hrt_elapsed_time(&_telemetry[i].last_dl_loss) > dl_regain_timeout_local * 1e6) {
+			    hrt_elapsed_time(&_telemetry[i].last_dl_loss) > dl_regain_timeout_local * 1e6) {
 
 				/* report a regain */
 				if (_telemetry[i].last_dl_loss > 0) {
 					mavlink_and_console_log_info(&mavlink_log_pub, "data link #%i regained", i);
+
 				} else if (_telemetry[i].last_dl_loss == 0) {
 					/* new link */
 				}
 
 				/* got link again or new */
-				status_flags.condition_system_prearm_error_reported = false;
 				*status_changed = true;
 
 				_telemetry[i].lost = false;
 				have_link = true;
+
 				if (!_telemetry[i].high_latency) {
 					have_low_latency_link = true;
 				}
@@ -4167,6 +4245,7 @@ void Commander::data_link_checks(int32_t highlatencydatalink_loss_timeout, int32
 				/* telemetry was healthy also in last iteration
 				 * we don't have to check a timeout */
 				have_link = true;
+
 				if (!_telemetry[i].high_latency) {
 					have_low_latency_link = true;
 				}
@@ -4213,6 +4292,7 @@ void Commander::data_link_checks(int32_t highlatencydatalink_loss_timeout, int32
 				_vehicle_cmd_pub = orb_advertise(ORB_ID(vehicle_command), &vehicle_cmd);
 			}
 		}
+
 	} else {
 		if (high_latency_link_exists && !status.high_latency_data_link_active && armed.armed) {
 			// low latency telemetry lost and high latency link existing
@@ -4243,13 +4323,16 @@ void Commander::data_link_checks(int32_t highlatencydatalink_loss_timeout, int32
 
 			if (!status.data_link_lost) {
 				mavlink_log_critical(&mavlink_log_pub, "ALL LOW LATENCY DATA LINKS LOST, ACTIVATING HIGH LATENCY LINK");
+
 			} else {
 				mavlink_log_critical(&mavlink_log_pub, "ACTIVATING AVAILABLE HIGH LATENCY LINK");
 			}
+
 		} else if (!status.data_link_lost) {
 			if (armed.armed) {
 				mavlink_log_critical(&mavlink_log_pub, "ALL DATA LINKS LOST");
 			}
+
 			status.data_link_lost = true;
 			status.data_link_lost_counter++;
 			*status_changed = true;

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -4032,26 +4032,9 @@ void Commander::mission_init()
 
 bool Commander::preflight_check(bool report)
 {
-	const bool hil_enabled = (status.hil_state == vehicle_status_s::HIL_STATE_ON);
-
-	const bool checkSensors = !hil_enabled;
-	const bool checkRC = (status.rc_input_mode == vehicle_status_s::RC_IN_MODE_DEFAULT);
 	const bool checkGNSS = (arm_requirements & ARM_REQ_GPS_BIT);
-	const bool checkDynamic = !hil_enabled;
-	const bool checkPower = (status_flags.condition_power_input_valid && !status_flags.circuit_breaker_engaged_power_check);
 
-	const bool reportFailures = (report && status_flags.condition_system_hotplug_timeout);
-
-	bool checkAirspeed = false;
-
-	/* Perform airspeed check only if circuit breaker is not
-	 * engaged and it's not a rotary wing */
-	if (!status_flags.circuit_breaker_engaged_airspd_check && (!status.is_rotary_wing || status.is_vtol)) {
-		checkAirspeed = true;
-	}
-
-	bool success = Preflight::preflightCheck(&mavlink_log_pub, checkSensors, checkAirspeed, checkRC, checkGNSS, checkDynamic, checkPower,
-						status.is_vtol, reportFailures, false, hrt_elapsed_time(&commander_boot_timestamp));
+	bool success = Preflight::preflightCheck(&mavlink_log_pub, status, status_flags, checkGNSS, report, false, hrt_elapsed_time(&commander_boot_timestamp));
 
 	status_flags.condition_system_sensors_initialized = success;
 

--- a/src/modules/commander/commander_tests/state_machine_helper_test.cpp
+++ b/src/modules/commander/commander_tests/state_machine_helper_test.cpp
@@ -265,7 +265,6 @@ bool StateMachineHelperTest::armingStateTransitionTest()
 				false /* no pre-arm checks */,
 				nullptr /* no mavlink_log_pub */,
 				&status_flags,
-				5.0f, /* avionics rail voltage */
 				(check_gps ? ARM_REQ_GPS_BIT : 0),
 				2e6 /* 2 seconds after boot, everything should be checked */
 				);

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -289,14 +289,6 @@ transition_result_t arming_state_transition(vehicle_status_s *status, const batt
 			}
 		}
 
-		if ((arm_requirements & ARM_REQ_ARM_AUTH_BIT) && (new_arming_state == vehicle_status_s::ARMING_STATE_ARMED)
-		    && valid_transition) {
-			if (arm_auth_check() != vehicle_command_ack_s::VEHICLE_RESULT_ACCEPTED) {
-				feedback_provided = true;
-				valid_transition = false;
-			}
-		}
-
 		// Finish up the state transition
 		if (valid_transition) {
 			armed->armed = (new_arming_state == vehicle_status_s::ARMING_STATE_ARMED);
@@ -1048,6 +1040,14 @@ bool prearm_check(orb_advert_t *mavlink_log_pub, const vehicle_status_flags_s &s
 
 		if (reportFailures) {
 			mavlink_log_critical(mavlink_log_pub, "ARMING DENIED: valid mission required");
+		}
+	}
+
+	// arm authorization check
+	if (arm_requirements & ARM_REQ_ARM_AUTH_BIT) {
+		if (arm_auth_check() != vehicle_command_ack_s::VEHICLE_RESULT_ACCEPTED) {
+			// feedback provided in arm_auth_check
+			prearm_ok = false;
 		}
 	}
 

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -284,14 +284,6 @@ transition_result_t arming_state_transition(vehicle_status_s *status, const batt
 			   (status->arming_state != vehicle_status_s::ARMING_STATE_STANDBY_ERROR)) {
 
 			if (!status_flags->condition_system_sensors_initialized) {
-
-				if (status_flags->condition_system_hotplug_timeout) {
-					if (!status_flags->condition_system_prearm_error_reported) {
-						mavlink_log_critical(mavlink_log_pub, "Not ready to fly: Sensors not set up correctly");
-						status_flags->condition_system_prearm_error_reported = true;
-					}
-				}
-
 				feedback_provided = true;
 				valid_transition = false;
 			}
@@ -319,13 +311,6 @@ transition_result_t arming_state_transition(vehicle_status_s *status, const batt
 			} else {
 				armed->armed_time_ms = 0;
 			}
-		}
-
-		/* reset feedback state */
-		if (status->arming_state != vehicle_status_s::ARMING_STATE_STANDBY_ERROR &&
-		    status->arming_state != vehicle_status_s::ARMING_STATE_INIT &&
-		    valid_transition) {
-			status_flags->condition_system_prearm_error_reported = false;
 		}
 
 		/* end of atomic state update */

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -222,35 +222,11 @@ transition_result_t arming_state_transition(vehicle_status_s *status, const batt
 			valid_transition = true;
 		}
 
-		// Check if we are trying to arm, checks look good but we are in STANDBY_ERROR
-		if (status->arming_state == vehicle_status_s::ARMING_STATE_STANDBY_ERROR) {
-
-			if (new_arming_state == vehicle_status_s::ARMING_STATE_ARMED) {
-
-				if (status_flags->condition_system_sensors_initialized) {
-					mavlink_log_critical(mavlink_log_pub, "Preflight check resolved, reboot before arming");
-
-				} else {
-					mavlink_log_critical(mavlink_log_pub, "Preflight check failed, refusing to arm");
-				}
-
-				feedback_provided = true;
-
-			} else if ((new_arming_state == vehicle_status_s::ARMING_STATE_STANDBY) &&
-				   status_flags->condition_system_sensors_initialized) {
-				mavlink_log_critical(mavlink_log_pub, "Preflight check resolved, reboot to complete");
-				feedback_provided = true;
-
-			} else {
-				// Silent ignore
-				feedback_provided = true;
-			}
-
-			// Sensors need to be initialized for STANDBY state, except for HIL
-
-		} else if (!hil_enabled &&
+		if (!hil_enabled &&
 			   (new_arming_state == vehicle_status_s::ARMING_STATE_STANDBY) &&
 			   (status->arming_state != vehicle_status_s::ARMING_STATE_STANDBY_ERROR)) {
+
+			// Sensors need to be initialized for STANDBY state, except for HIL
 
 			if (!status_flags->condition_system_sensors_initialized) {
 				feedback_provided = true;

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -117,8 +117,8 @@ transition_result_t arming_state_transition(vehicle_status_s *status, const batt
 		/*
 		 * Get sensing state if necessary
 		 */
-		bool preflight_check_ret = false;
-		bool prearm_check_ret = false;
+		bool preflight_check_ret = true;
+		bool prearm_check_ret = true;
 
 		const bool checkSensors = !hil_enabled;
 		const bool checkRC = (status->rc_input_mode == vehicle_status_s::RC_IN_MODE_DEFAULT);
@@ -177,8 +177,6 @@ transition_result_t arming_state_transition(vehicle_status_s *status, const batt
 		/* enforce lockdown in HIL */
 		if (hil_enabled) {
 			armed->lockdown = true;
-			preflight_check_ret = true;
-			prearm_check_ret = true;
 			status_flags->condition_system_sensors_initialized = true;
 
 			/* recover from a prearm fail */

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -75,13 +75,13 @@ static constexpr const bool arming_transitions[vehicle_status_s::ARMING_STATE_MA
 };
 
 // You can index into the array with an arming_state_t in order to get its textual representation
-const char *const arming_state_names[vehicle_status_s::ARMING_STATE_MAX] = {
-	"ARMING_STATE_INIT",
-	"ARMING_STATE_STANDBY",
-	"ARMING_STATE_ARMED",
-	"ARMING_STATE_STANDBY_ERROR",
-	"ARMING_STATE_REBOOT",
-	"ARMING_STATE_IN_AIR_RESTORE",
+const char * const arming_state_names[vehicle_status_s::ARMING_STATE_MAX] = {
+	"INIT",
+	"STANDBY",
+	"ARMED",
+	"STANDBY_ERROR",
+	"REBOOT",
+	"IN_AIR_RESTORE",
 };
 
 static hrt_abstime last_preflight_check = 0;	///< initialize so it gets checked immediately
@@ -339,7 +339,7 @@ transition_result_t arming_state_transition(vehicle_status_s *status, const batt
 	if (ret == TRANSITION_DENIED) {
 		/* print to MAVLink and console if we didn't provide any feedback yet */
 		if (!feedback_provided) {
-			mavlink_log_critical(mavlink_log_pub, "TRANSITION_DENIED: %s - %s",
+			mavlink_log_critical(mavlink_log_pub, "TRANSITION_DENIED: %s to %s",
 					     arming_state_names[status->arming_state], arming_state_names[new_arming_state]);
 		}
 	}

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -984,8 +984,6 @@ bool prearm_check(orb_advert_t *mavlink_log_pub, const vehicle_status_flags_s &s
 
 			prearm_ok = false;
 		}
-
-
 	}
 
 	// safety button

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -1018,18 +1018,36 @@ bool prearm_check(orb_advert_t *mavlink_log_pub, const vehicle_status_flags_s &s
 		}
 	}
 
-	// mission required
-	if ((arm_requirements & ARM_REQ_MISSION_BIT)
-	    && (!status_flags.condition_auto_mission_available || !status_flags.condition_global_position_valid)) {
+	// Arm Requirements: mission
+	if (arm_requirements & ARM_REQ_MISSION_BIT) {
 
-		prearm_ok = false;
+		if (!status_flags.condition_auto_mission_available) {
+			prearm_ok = false;
 
-		if (reportFailures) {
-			mavlink_log_critical(mavlink_log_pub, "ARMING DENIED: valid mission required");
+			if (reportFailures) {
+				mavlink_log_critical(mavlink_log_pub, "ARMING DENIED: valid mission required");
+			}
+		}
+
+		if (!status_flags.condition_global_position_valid) {
+			prearm_ok = false;
+
+			if (reportFailures) {
+				mavlink_log_critical(mavlink_log_pub, "ARMING DENIED: global position required");
+			}
 		}
 	}
 
-	// arm authorization check
+	// Arm Requirements: global position
+	if ((arm_requirements & ARM_REQ_GPS_BIT) && (!status_flags.condition_global_position_valid)) {
+		prearm_ok = false;
+
+		if (reportFailures) {
+			mavlink_log_critical(mavlink_log_pub, "ARMING DENIED: global position required");
+		}
+	}
+
+	// Arm Requirements: authorization
 	if (arm_requirements & ARM_REQ_ARM_AUTH_BIT) {
 		if (arm_auth_check() != vehicle_command_ack_s::VEHICLE_RESULT_ACCEPTED) {
 			// feedback provided in arm_auth_check

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -136,7 +136,7 @@ transition_result_t arming_state_transition(vehicle_status_s *status, const batt
 					       (status->rc_input_mode == vehicle_status_s::RC_IN_MODE_DEFAULT), arm_requirements & ARM_REQ_GPS_BIT, true,
 					       status->is_vtol, true, true, time_since_boot);
 
-			prearm_check_ret = prearm_check(mavlink_log_pub, true /* pre-arm */, false /* force_report */, status_flags, battery,
+			prearm_check_ret = prearm_check(mavlink_log_pub, false /* force_report */, status_flags, battery,
 						  arm_requirements, time_since_boot);
 
 			if (!preflight_check) {
@@ -1031,7 +1031,7 @@ void reset_link_loss_globals(actuator_armed_s *armed, const bool old_failsafe, c
 	}
 }
 
-bool prearm_check(orb_advert_t *mavlink_log_pub, const bool prearm, const bool force_report,
+bool prearm_check(orb_advert_t *mavlink_log_pub, const bool force_report,
 		 vehicle_status_flags_s *status_flags, const battery_status_s &battery, const uint8_t arm_requirements,
 		 const hrt_abstime &time_since_boot)
 {
@@ -1039,7 +1039,7 @@ bool prearm_check(orb_advert_t *mavlink_log_pub, const bool prearm, const bool f
 					       status_flags->condition_system_hotplug_timeout);
 	bool prearm_ok = true;
 
-	if (!status_flags->circuit_breaker_engaged_usb_check && status_flags->usb_connected && prearm) {
+	if (!status_flags->circuit_breaker_engaged_usb_check && status_flags->usb_connected) {
 		prearm_ok = false;
 
 		if (reportFailures) {

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -81,7 +81,7 @@ bool is_safe(const safety_s &safety, const actuator_armed_s &armed);
 
 transition_result_t arming_state_transition(vehicle_status_s *status, const battery_status_s &battery,
 		const safety_s &safety, const arming_state_t new_arming_state, actuator_armed_s *armed, const bool fRunPreArmChecks,
-		orb_advert_t *mavlink_log_pub, vehicle_status_flags_s *status_flags, const float avionics_power_rail_voltage,
+		orb_advert_t *mavlink_log_pub, vehicle_status_flags_s *status_flags,
 		const uint8_t arm_requirements, const hrt_abstime &time_since_boot);
 
 transition_result_t

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -107,6 +107,7 @@ bool check_invalid_pos_nav_state(vehicle_status_s *status, bool old_failsafe, or
 				 const vehicle_status_flags_s &status_flags, const bool use_rc, const bool using_global_pos);
 
 bool prearm_check(orb_advert_t *mavlink_log_pub, const vehicle_status_flags_s &status_flags,
-		  const battery_status_s &battery, const uint8_t arm_requirements, const hrt_abstime &time_since_boot);
+		  const battery_status_s &battery, const safety_s &safety, const uint8_t arm_requirements,
+		  const hrt_abstime &time_since_boot);
 
 #endif /* STATE_MACHINE_HELPER_H_ */

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -106,7 +106,7 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 bool check_invalid_pos_nav_state(vehicle_status_s *status, bool old_failsafe, orb_advert_t *mavlink_log_pub,
 				 const vehicle_status_flags_s &status_flags, const bool use_rc, const bool using_global_pos);
 
-int prearm_check(orb_advert_t *mavlink_log_pub, const bool prearm, const bool force_report,
+bool prearm_check(orb_advert_t *mavlink_log_pub, const bool prearm, const bool force_report,
 		 vehicle_status_flags_s *status_flags, const battery_status_s &battery, const uint8_t arm_requirements,
 		 const hrt_abstime &time_since_boot);
 

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -106,8 +106,7 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 bool check_invalid_pos_nav_state(vehicle_status_s *status, bool old_failsafe, orb_advert_t *mavlink_log_pub,
 				 const vehicle_status_flags_s &status_flags, const bool use_rc, const bool using_global_pos);
 
-bool prearm_check(orb_advert_t *mavlink_log_pub, const bool force_report,
-		 vehicle_status_flags_s *status_flags, const battery_status_s &battery, const uint8_t arm_requirements,
-		 const hrt_abstime &time_since_boot);
+bool prearm_check(orb_advert_t *mavlink_log_pub, const vehicle_status_flags_s &status_flags,
+		  const battery_status_s &battery, const uint8_t arm_requirements, const hrt_abstime &time_since_boot);
 
 #endif /* STATE_MACHINE_HELPER_H_ */

--- a/src/modules/commander/state_machine_helper.h
+++ b/src/modules/commander/state_machine_helper.h
@@ -106,7 +106,7 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 bool check_invalid_pos_nav_state(vehicle_status_s *status, bool old_failsafe, orb_advert_t *mavlink_log_pub,
 				 const vehicle_status_flags_s &status_flags, const bool use_rc, const bool using_global_pos);
 
-bool prearm_check(orb_advert_t *mavlink_log_pub, const bool prearm, const bool force_report,
+bool prearm_check(orb_advert_t *mavlink_log_pub, const bool force_report,
 		 vehicle_status_flags_s *status_flags, const battery_status_s &battery, const uint8_t arm_requirements,
 		 const hrt_abstime &time_since_boot);
 


### PR DESCRIPTION
 -  fixes #9155

There were many issues. The most important immediate issue is that preflight checks haven't been blocking arming. Additionally many little annoying edge cases I've experienced finally make sense to me where you might not be provided appropriate (or any) feedback trying to arm.

There's still a lot more to do here, but this restores a level of sanity. The next steps from my perspective would be removing the actual sensor check calls from the state machine and centralizing all of it on the commander side. Then commander would simple pass the appropriate flags into a much simpler generated (and documented) state machine.