### PR TITLE
CI: mavros restart

### DIFF
--- a/launch/mavros_posix_sitl.launch
+++ b/launch/mavros_posix_sitl.launch
@@ -21,8 +21,9 @@
     <arg name="verbose" default="false"/>
     <arg name="paused" default="false"/>
     <arg name="respawn_gazebo" default="false"/>
-    <!-- MAVROS connection -->
+    <!-- MAVROS configs -->
     <arg name="fcu_url" default="udp://:14540@localhost:14557"/>
+    <arg name="respawn_mavros" default="false"/>
     <!-- PX4 SITL and Gazebo -->
     <include file="$(find px4)/launch/posix_sitl.launch">
         <arg name="x" value="$(arg x)"/>
@@ -46,5 +47,6 @@
         <!-- GCS link is provided by SITL -->
         <arg name="gcs_url" value=""/>
         <arg name="fcu_url" value="$(arg fcu_url)"/>
+        <arg name="respawn_mavros" value="$(arg respawn_mavros)"/>
     </include>
 </launch>

--- a/test/mavros_posix_test_mission.test
+++ b/test/mavros_posix_test_mission.test
@@ -2,17 +2,16 @@
 <launch>
     <!-- Posix SITL MAVROS integration tests -->
     <!-- Test a mission -->
-    <arg name="gui" default="false"/>
     <arg name="est" default="ekf2"/>
+    <arg name="gui" default="false"/>
+    <arg name="vehicle" default="iris"/>
     <arg name="mission"/>
-    <arg name="vehicle"/>
-    <arg name="respawn_gazebo" default="true"/>
     <!-- MAVROS, PX4 SITL, Gazebo -->
     <include file="$(find px4)/launch/mavros_posix_sitl.launch">
+        <arg name="est" value="$(arg est)"/>
         <arg name="gui" value="$(arg gui)"/>
         <arg name="vehicle" value="$(arg vehicle)"/>
-        <arg name="est" value="$(arg est)"/>
-        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>
     </include>
     <!-- ROStest -->

--- a/test/mavros_posix_test_mission.test
+++ b/test/mavros_posix_test_mission.test
@@ -13,6 +13,7 @@
         <arg name="vehicle" value="$(arg vehicle)"/>
         <arg name="est" value="$(arg est)"/>
         <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="respawn_mavros" value="true"/>
     </include>
     <!-- ROStest -->
     <test test-name="$(arg mission)" pkg="px4" type="mission_test.py" time-limit="300.0" args="$(arg mission).plan"/>

--- a/test/mavros_posix_tests_iris_opt_flow.test
+++ b/test/mavros_posix_tests_iris_opt_flow.test
@@ -11,6 +11,7 @@
         <arg name="vehicle" value="iris_opt_flow"/>
         <arg name="est" value="$(arg est)"/>
         <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="respawn_mavros" value="true"/>
     </include>
     <!-- ROStest -->
     <test test-name="mavros_flow_offboard_posctl_test" pkg="px4" type="mavros_offboard_posctl_test.py" time-limit="300.0"/>

--- a/test/mavros_posix_tests_iris_opt_flow.test
+++ b/test/mavros_posix_tests_iris_opt_flow.test
@@ -2,15 +2,14 @@
 <launch>
     <!-- Posix SITL MAVROS integration tests -->
     <!-- Test offboard local posistion and attitude control with optical flow iris -->
-    <arg name="gui" default="false"/>
     <arg name="est" default="ekf2"/>
-    <arg name="respawn_gazebo" default="true"/>
+    <arg name="gui" default="false"/>
     <!-- MAVROS, PX4 SITL, Gazebo -->
     <include file="$(find px4)/launch/mavros_posix_sitl.launch">
+        <arg name="est" value="$(arg est)"/>
         <arg name="gui" value="$(arg gui)"/>
         <arg name="vehicle" value="iris_opt_flow"/>
-        <arg name="est" value="$(arg est)"/>
-        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>
     </include>
     <!-- ROStest -->

--- a/test/mavros_posix_tests_missions.test
+++ b/test/mavros_posix_tests_missions.test
@@ -1,23 +1,23 @@
 <?xml version="1.0"?>
 <launch>
     <!-- Posix SITL MAVROS integration tests -->
-    <!-- Test all missions with standard VTOL -->
-    <arg name="gui" default="false"/>
+    <!-- Test all missions -->
     <arg name="est" default="ekf2"/>
-    <arg name="respawn_gazebo" default="true"/>
+    <arg name="gui" default="false"/>
+    <arg name="vehicle" default="standard_vtol"/>
     <!-- MAVROS, PX4 SITL, Gazebo -->
     <include file="$(find px4)/launch/mavros_posix_sitl.launch">
-        <arg name="gui" value="$(arg gui)"/>
-        <arg name="vehicle" value="standard_vtol"/>
         <arg name="est" value="$(arg est)"/>
-        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="vehicle" value="$(arg vehicle)"/>
+        <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>
     </include>
     <!-- ROStest -->
-    <test test-name="multicopter_box" pkg="px4" type="mission_test.py" time-limit="300.0" args="multirotor_box.plan"/>
-    <test test-name="mission_test_new_1" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_new_1.plan"/>
-    <test test-name="mission_test_new_2" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_new_2.plan"/>
-    <test test-name="mission_test_old_1" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_old_1.plan"/>
-    <test test-name="mission_test_old_2" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_old_2.plan"/>
-    <test test-name="mission_test_old_3" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_old_3.plan"/>
+    <test test-name="multirotor_box" pkg="px4" type="mission_test.py" time-limit="300.0" args="multirotor_box.plan"/>
+    <test test-name="vtol_new_1" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_new_1.plan"/>
+    <test test-name="vtol_new_2" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_new_2.plan"/>
+    <test test-name="vtol_old_1" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_old_1.plan"/>
+    <test test-name="vtol_old_2" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_old_2.plan"/>
+    <test test-name="vtol_old_3" pkg="px4" type="mission_test.py" time-limit="300.0" args="vtol_old_3.plan"/>
 </launch>

--- a/test/mavros_posix_tests_missions.test
+++ b/test/mavros_posix_tests_missions.test
@@ -11,6 +11,7 @@
         <arg name="vehicle" value="standard_vtol"/>
         <arg name="est" value="$(arg est)"/>
         <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="respawn_mavros" value="true"/>
     </include>
     <!-- ROStest -->
     <test test-name="multicopter_box" pkg="px4" type="mission_test.py" time-limit="300.0" args="multirotor_box.plan"/>

--- a/test/mavros_posix_tests_offboard_attctl.test
+++ b/test/mavros_posix_tests_offboard_attctl.test
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
 <launch>
     <!-- Posix SITL MAVROS integration tests -->
-    <!-- Test offboard attitude control with iris -->
-    <arg name="gui" default="false"/>
+    <!-- Test offboard attitude control -->
     <arg name="est" default="ekf2"/>
-    <arg name="respawn_gazebo" default="true"/>
+    <arg name="gui" default="false"/>
+    <arg name="vehicle" default="iris"/>
     <!-- MAVROS, PX4 SITL, Gazebo -->
     <include file="$(find px4)/launch/mavros_posix_sitl.launch">
-        <arg name="gui" value="$(arg gui)"/>
-        <arg name="vehicle" value="iris"/>
         <arg name="est" value="$(arg est)"/>
-        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="vehicle" value="$(arg vehicle)"/>
+        <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>
     </include>
     <!-- ROStest -->

--- a/test/mavros_posix_tests_offboard_attctl.test
+++ b/test/mavros_posix_tests_offboard_attctl.test
@@ -11,6 +11,7 @@
         <arg name="vehicle" value="iris"/>
         <arg name="est" value="$(arg est)"/>
         <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="respawn_mavros" value="true"/>
     </include>
     <!-- ROStest -->
     <test test-name="mavros_offboard_attctl_test" pkg="px4" type="mavros_offboard_attctl_test.py" time-limit="300.0"/>

--- a/test/mavros_posix_tests_offboard_posctl.test
+++ b/test/mavros_posix_tests_offboard_posctl.test
@@ -11,6 +11,7 @@
         <arg name="vehicle" value="iris"/>
         <arg name="est" value="$(arg est)"/>
         <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="respawn_mavros" value="true"/>
     </include>
     <!-- ROStest -->
     <test test-name="mavros_offboard_posctl_test" pkg="px4" type="mavros_offboard_posctl_test.py" time-limit="300.0"/>

--- a/test/mavros_posix_tests_offboard_posctl.test
+++ b/test/mavros_posix_tests_offboard_posctl.test
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
 <launch>
     <!-- Posix SITL MAVROS integration tests -->
-    <!-- Test offboard local posistion control with iris -->
-    <arg name="gui" default="false"/>
+    <!-- Test offboard local posistion control -->
     <arg name="est" default="ekf2"/>
-    <arg name="respawn_gazebo" default="true"/>
+    <arg name="gui" default="false"/>
+    <arg name="vehicle" default="iris"/>
     <!-- MAVROS, PX4 SITL, Gazebo -->
     <include file="$(find px4)/launch/mavros_posix_sitl.launch">
-        <arg name="gui" value="$(arg gui)"/>
-        <arg name="vehicle" value="iris"/>
         <arg name="est" value="$(arg est)"/>
-        <arg name="respawn_gazebo" value="$(arg respawn_gazebo)"/>
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="vehicle" value="$(arg vehicle)"/>
+        <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>
     </include>
     <!-- ROStest -->


### PR DESCRIPTION
This adds the `respawn_mavros` arg introduced in mavros 0.23.2. Now that we've updated CI containers with 04ecc81a70232d89bea5d3284b6c878e388fc895 we can make use of it. Before and with `respawn_mavros=false`, all nodes in the launch file will be killed if mavros dies. Setting this to `true` restarts mavros and lets the other nodes continue to live. This will harden CI against potential issues with mavros. The only negative here, which I feel is not an issue, is if users try to use `mavros_posix_sitl.launch` or any of the `.test` files with a version of mavros<0.23.2, they will see an error from roslaunch and it will fail to launch.