### PR TITLE
ll40ls: Increase the number of samples used for every measurement

### DIFF
--- a/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
+++ b/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
@@ -335,12 +335,13 @@ int LidarLiteI2C::reset_sensor()
 {
 	int ret;
 	ret = write_reg(LL40LS_MEASURE_REG, LL40LS_MSRREG_RESET);
+
 	if (ret != OK) {
 		return ret;
 	}
 
 	// wait for sensor reset to complete
-	usleep(1000);
+	usleep(50000);
 	ret = write_reg(LL40LS_SIG_COUNT_VAL_REG, LL40LS_SIG_COUNT_VAL_MAX);
 
 	if (ret != OK) {

--- a/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
+++ b/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
@@ -329,17 +329,25 @@ int LidarLiteI2C::measure()
 }
 
 /*
-  reset the sensor to power on defaults
+  reset the sensor to power on defaults plus additional configurations
  */
 int LidarLiteI2C::reset_sensor()
 {
-	int ret = write_reg(LL40LS_MEASURE_REG, LL40LS_MSRREG_RESET);
-
+	int ret;
+	ret = write_reg(LL40LS_MEASURE_REG, LL40LS_MSRREG_RESET);
 	if (ret != OK) {
 		return ret;
 	}
 
 	// wait for sensor reset to complete
+	usleep(1000);
+	ret = write_reg(LL40LS_SIG_COUNT_VAL_REG, LL40LS_SIG_COUNT_VAL_MAX);
+
+	if (ret != OK) {
+		return ret;
+	}
+
+	// wait for register write to complete
 	usleep(1000);
 
 	return OK;

--- a/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.h
+++ b/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.h
@@ -68,6 +68,9 @@
 #define LL40LS_SW_VERSION         0x4f
 #define LL40LS_SIGNAL_STRENGTH_REG  0x5b
 
+#define LL40LS_SIG_COUNT_VAL_REG      0x02        /* Maximum acquisition count register */
+#define LL40LS_SIG_COUNT_VAL_MAX     0xFF        /* Maximum acquisition count max value */
+
 class LidarLiteI2C : public LidarLite, public device::I2C
 {
 public:


### PR DESCRIPTION
Increase the number of samples the sensor use to find a correlation peak and report a measurement. Benefit is increased range and more robust measurement, downside is if you want to read out the sensor at a very high rate, but for the majority of applications I don't think that is a problem.

This has only been bench tested so far