### PR TITLE
[WIP] Flight task offboard

### DIFF
--- a/src/lib/FlightTasks/CMakeLists.txt
+++ b/src/lib/FlightTasks/CMakeLists.txt
@@ -43,6 +43,7 @@ px4_add_module(
 		tasks/FlightTaskManualPositionSmooth.cpp
 		tasks/FlightTaskAuto.cpp
 		tasks/FlightTaskAutoLine.cpp
+		tasks/FlightTaskOffboard.cpp
 		tasks/Utility/ManualSmoothingZ.cpp
 		tasks/Utility/ManualSmoothingXY.cpp
 		SubscriptionArray.cpp

--- a/src/lib/FlightTasks/FlightTasks.cpp
+++ b/src/lib/FlightTasks/FlightTasks.cpp
@@ -74,6 +74,9 @@ int FlightTasks::switchTask(FlightTaskIndex new_task_index)
 
 	case FlightTaskIndex::AutoLine:
 		_current_task = new (&_task_union.autoLine) FlightTaskAutoLine(this, "ALN");
+
+	case FlightTaskIndex::Offboard:
+		_current_task = new (&_task_union.offboard) FlightTaskOffboard(this, "OFFB");
 		break;
 
 	default:

--- a/src/lib/FlightTasks/FlightTasks.cpp
+++ b/src/lib/FlightTasks/FlightTasks.cpp
@@ -74,6 +74,7 @@ int FlightTasks::switchTask(FlightTaskIndex new_task_index)
 
 	case FlightTaskIndex::AutoLine:
 		_current_task = new (&_task_union.autoLine) FlightTaskAutoLine(this, "ALN");
+		break;
 
 	case FlightTaskIndex::Offboard:
 		_current_task = new (&_task_union.offboard) FlightTaskOffboard(this, "OFFB");

--- a/src/lib/FlightTasks/FlightTasks.cpp
+++ b/src/lib/FlightTasks/FlightTasks.cpp
@@ -72,7 +72,7 @@ int FlightTasks::switchTask(FlightTaskIndex new_task_index)
 		_current_task = new (&_task_union.sport) FlightTaskSport(this, "SPO");
 		break;
 
-	case 8:
+	case FlightTaskIndex::AutoLine:
 		_current_task = new (&_task_union.autoLine) FlightTaskAutoLine(this, "ALN");
 		break;
 

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -64,6 +64,7 @@ enum class FlightTaskIndex : int {
 	PositionSmooth,
 	Orbit,
 	Sport,
+	AutoLine,
 
 	Count // number of tasks
 };

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -50,6 +50,7 @@
 #include "tasks/FlightTaskAutoLine.hpp"
 #include "tasks/FlightTaskOrbit.hpp"
 #include "tasks/FlightTaskSport.hpp"
+#include "tasks/FlightTaskOffboard.hpp"
 
 #include "SubscriptionArray.hpp"
 
@@ -65,6 +66,7 @@ enum class FlightTaskIndex : int {
 	Orbit,
 	Sport,
 	AutoLine,
+	Offboard,
 
 	Count // number of tasks
 };
@@ -139,6 +141,7 @@ private:
 		FlightTaskOrbit orbit;
 		FlightTaskSport sport;
 		FlightTaskAutoLine autoLine;
+		FlightTaskOffboard offboard;
 	} _task_union; /**< storage for the currently active task */
 
 	FlightTask *_current_task = nullptr;

--- a/src/lib/FlightTasks/tasks/FlightTask.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.cpp
@@ -61,14 +61,6 @@ bool FlightTask::_evaluateVehiclePosition()
 		_velocity = matrix::Vector3f(&_sub_vehicle_local_position->get().vx);
 		_yaw = _sub_vehicle_local_position->get().yaw;
 
-		/* Check if reference has changed and update. */
-		if (_sub_vehicle_local_position->get().ref_timestamp != _time_stamp_reference) {
-			map_projection_init(&_reference_position, _sub_vehicle_local_position->get().ref_lat,
-					    _sub_vehicle_local_position->get().ref_lon);
-			_reference_altitude = _sub_vehicle_local_position->get().ref_alt;
-			_time_stamp_reference = _sub_vehicle_local_position->get().ref_timestamp;
-		}
-
 		return true;
 
 	} else {

--- a/src/lib/FlightTasks/tasks/FlightTask.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.cpp
@@ -28,7 +28,7 @@ bool FlightTask::updateInitialize()
 	_time = (_time_stamp_current - _time_stamp_activate) / 1e6f;
 	_deltatime  = math::min((_time_stamp_current - _time_stamp_last), _timeout) / 1e6f;
 	_time_stamp_last = _time_stamp_current;
-	return _evaluateVehiclePosition();
+	return _evaluateVehicleLocalPosition();
 }
 
 const vehicle_local_position_setpoint_s FlightTask::getPositionSetpoint()
@@ -54,7 +54,7 @@ void FlightTask::_resetSetpoints()
 	_yaw_setpoint = _yawspeed_setpoint = NAN;
 }
 
-bool FlightTask::_evaluateVehiclePosition()
+bool FlightTask::_evaluateVehicleLocalPosition()
 {
 	if ((_time_stamp_current - _sub_vehicle_local_position->get().timestamp) < _timeout) {
 		_position = matrix::Vector3f(&_sub_vehicle_local_position->get().x);

--- a/src/lib/FlightTasks/tasks/FlightTask.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.cpp
@@ -2,7 +2,6 @@
 #include <mathlib/mathlib.h>
 
 constexpr uint64_t FlightTask::_timeout;
-
 /* First index of empty_setpoint corresponds to time-stamp and requires a finite number. */
 const vehicle_local_position_setpoint_s FlightTask::empty_setpoint = {0, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, {NAN, NAN, NAN}};
 
@@ -60,7 +59,6 @@ bool FlightTask::_evaluateVehicleLocalPosition()
 		_position = matrix::Vector3f(&_sub_vehicle_local_position->get().x);
 		_velocity = matrix::Vector3f(&_sub_vehicle_local_position->get().vx);
 		_yaw = _sub_vehicle_local_position->get().yaw;
-
 		return true;
 
 	} else {

--- a/src/lib/FlightTasks/tasks/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.hpp
@@ -131,5 +131,5 @@ protected:
 	 */
 	uORB::Subscription<vehicle_local_position_s> *_sub_vehicle_local_position{nullptr};
 
-	virtual bool _evaluateVehiclePosition();
+	bool _evaluateVehicleLocalPosition();
 };

--- a/src/lib/FlightTasks/tasks/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.hpp
@@ -47,9 +47,7 @@
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_local_position_setpoint.h>
 #include <uORB/topics/vehicle_command.h>
-#include <lib/geo/geo.h>
 #include "../SubscriptionArray.hpp"
-
 
 class FlightTask : public control::Block
 {

--- a/src/lib/FlightTasks/tasks/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.hpp
@@ -124,12 +124,6 @@ protected:
 	 */
 	void _resetSetpoints();
 
-	/**
-	 *  Vehicle local position subscription
-	 *  TODO: Implement a message that is smaller than the
-	 *  current vehicle local position message
-	 */
 	uORB::Subscription<vehicle_local_position_s> *_sub_vehicle_local_position{nullptr};
-
 	bool _evaluateVehicleLocalPosition();
 };

--- a/src/lib/FlightTasks/tasks/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.hpp
@@ -106,7 +106,6 @@ protected:
 	hrt_abstime _time_stamp_activate = 0; /**< time stamp when task was activated */
 	hrt_abstime _time_stamp_current = 0; /**< time stamp at the beginning of the current task update */
 	hrt_abstime _time_stamp_last = 0; /**< time stamp when task was last updated */
-	hrt_abstime _time_stamp_reference = 0; /**< time stamp when last reference update */
 
 	/* Current vehicle state */
 	matrix::Vector3f _position; /**< current vehicle position */
@@ -122,17 +121,17 @@ protected:
 	float _yaw_setpoint;
 	float _yawspeed_setpoint;
 
-	/* Current reference position */
-	map_projection_reference_s _reference_position{}; /**< structure used to project lat/lon setpoint into local frame */
-	float _reference_altitude = 0.0f;  /**< altitude relative to ground */
-
 	/**
 	 * Get the output data
 	 */
 	void _resetSetpoints();
 
-private:
+	/**
+	 *  Vehicle local position subscription
+	 *  TODO: Implement a message that is smaller than the
+	 *  current vehicle local position message
+	 */
 	uORB::Subscription<vehicle_local_position_s> *_sub_vehicle_local_position{nullptr};
 
-	bool _evaluateVehiclePosition();
+	virtual bool _evaluateVehiclePosition();
 };

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
@@ -111,6 +111,13 @@ bool FlightTaskAuto::_evaluateTriplets()
 	target(2) = -(_sub_triplet_setpoint->get().current.alt - _reference_altitude);
 
 
+	_yaw_wp = _sub_triplet_setpoint->get().current.yaw;
+
+	if (!PX4_ISFINITE(_yaw_wp)) {
+		_yaw_wp = _yaw;
+
+	}
+
 	/* Check if anything has changed. We do that by comparing the target
 	 * setpoint to the previous target.
 	 * TODO This is a hack and it would be much
@@ -119,7 +126,7 @@ bool FlightTaskAuto::_evaluateTriplets()
 
 	/* Dont't do any updates if the current target has not changed */
 	if (!(fabsf(target(0) - _target(0)) > 0.001f || fabsf(target(1) - _target(1)) > 0.001f
-	      || fabsf(target(2) - _target(2)) > 0.001f  || fabsf(_sub_triplet_setpoint->get().current.yaw - _yaw_wp) > 0.001f)) {
+	      || fabsf(target(2) - _target(2)) > 0.001f)) {
 		/* Nothing has changed: just keep old waypoints */
 		return true;
 	}
@@ -135,13 +142,6 @@ bool FlightTaskAuto::_evaluateTriplets()
 
 	if (!PX4_ISFINITE(_target(2))) {
 		_target(2) = _position(2);
-	}
-
-	_yaw_wp = _sub_triplet_setpoint->get().current.yaw;
-
-	if (!PX4_ISFINITE(_yaw_wp)) {
-		_yaw_wp = _yaw;
-
 	}
 
 	_prev_prev_wp = _prev_wp; // previous -1 is set to previous

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
@@ -178,7 +178,6 @@ void FlightTaskAuto::_evaluateVehicleGlobalPosition()
 
 	// check if reference has changed and update.
 	if (_sub_vehicle_local_position->get().ref_timestamp != _time_stamp_reference) {
-		PX4_INFO("inside");
 		map_projection_init(&_reference_position,
 				    _sub_vehicle_local_position->get().ref_lat,
 				    _sub_vehicle_local_position->get().ref_lon);

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
@@ -116,13 +116,13 @@ bool FlightTaskAuto::_evaluateTriplets()
 	/* Update all waypoints */
 	_target = target;
 
-	if (!PX4_ISFINITE(target(0)) || !PX4_ISFINITE(target(1))) {
+	if (!PX4_ISFINITE(_target(0)) || !PX4_ISFINITE(_target(1))) {
 		/* Horizontal target is not finite. */
 		_target(0) = _position(0);
 		_target(1) = _position(1);
 	}
 
-	if (!PX4_ISFINITE(2)) {
+	if (!PX4_ISFINITE(_target(2))) {
 		_target(2) = _position(2);
 	}
 

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
@@ -137,7 +137,7 @@ bool FlightTaskAuto::_evaluateTriplets()
 			_prev_wp = _position;
 		}
 
-		/* Check if previous is valid and update accordingly */
+		/* Check if next is valid and update accordingly */
 		if (_type == WaypointType::loiter) {
 			_next_wp = _target;
 

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
@@ -174,9 +174,9 @@ bool FlightTaskAuto::_isFinite(const position_setpoint_s sp)
 	return (PX4_ISFINITE(sp.lat) && PX4_ISFINITE(sp.lon) && PX4_ISFINITE(sp.alt));
 }
 
-bool FlightTaskAuto::_evaluateVehiclePosition()
+bool FlightTaskAuto::_evaluateVehicleGlobalPosition()
 {
-	FlightTask::_evaluateVehiclePosition();
+	FlightTask::_evaluateVehicleLocalPosition();
 
 	/* Check if reference has changed and update. */
 	if (_sub_vehicle_local_position->get().ref_timestamp != _time_stamp_reference) {

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
@@ -95,7 +95,13 @@ bool FlightTaskAuto::_evaluateTriplets()
 	}
 
 	_yaw_wp = _sub_triplet_setpoint->get().current.yaw;
-	_type = (WaypointType)_sub_triplet_setpoint->get().current.type;
+	WaypointType type = (WaypointType)_sub_triplet_setpoint->get().current.type;
+
+	if (type != _type) {
+		_reset();
+	}
+
+	_type = type;
 
 	/* We need to have a valid current triplet */
 	if (_isFinite(_sub_triplet_setpoint->get().current)) {

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
@@ -37,7 +37,6 @@
 #include "FlightTaskAuto.hpp"
 #include <mathlib/mathlib.h>
 #include <float.h>
-#include <lib/geo/geo.h>
 
 using namespace matrix;
 

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
@@ -68,6 +68,7 @@ bool FlightTaskAuto::activate()
 bool FlightTaskAuto::updateInitialize()
 {
 	bool ret = FlightTask::updateInitialize();
+	_evaluateVehicleGlobalPosition();
 	return (ret && _evaluateTriplets());
 }
 
@@ -174,18 +175,17 @@ bool FlightTaskAuto::_isFinite(const position_setpoint_s sp)
 	return (PX4_ISFINITE(sp.lat) && PX4_ISFINITE(sp.lon) && PX4_ISFINITE(sp.alt));
 }
 
-bool FlightTaskAuto::_evaluateVehicleGlobalPosition()
+void FlightTaskAuto::_evaluateVehicleGlobalPosition()
 {
 	FlightTask::_evaluateVehicleLocalPosition();
 
 	/* Check if reference has changed and update. */
 	if (_sub_vehicle_local_position->get().ref_timestamp != _time_stamp_reference) {
+		PX4_INFO("inside");
 		map_projection_init(&_reference_position,
 				    _sub_vehicle_local_position->get().ref_lat,
 				    _sub_vehicle_local_position->get().ref_lon);
 		_reference_altitude = _sub_vehicle_local_position->get().ref_alt;
 		_time_stamp_reference = _sub_vehicle_local_position->get().ref_timestamp;
 	}
-
-	return true;
 }

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
@@ -74,21 +74,20 @@ bool FlightTaskAuto::updateInitialize()
 
 bool FlightTaskAuto::_evaluateTriplets()
 {
-	/* TODO: fix the issues mentioned below */
-	/* We add here some conditions that are only required because
-	 * 1. navigator continuously sends triplet during mission due to yaw setpoint. This
-	 * should be removed in the navigator and only update once the current setpoint actually has changed.
-	 *
-	 * 2. navigator should be responsible to send always three valid setpoints. If there is only one setpoint,
-	 * then previous will be set to current vehicle position and next will be set equal to setpoint.
-	 *
-	 * 3. navigator originally only supports gps guided maneuvers. However, it now also supports some flow-specific features
-	 * such as land and takeoff. The navigator should use for auto takeoff/land with flow the position in xy at the moment the
-	 * takeoff/land was initiated. Until then we do this kind of logic here.
-	 */
+	// TODO: fix the issues mentioned below
+	// We add here some conditions that are only required because:
+	// 1. navigator continuously sends triplet during mission due to yaw setpoint. This
+	// should be removed in the navigator and only updates if the current setpoint actually has changed.
+	//
+	// 2. navigator should be responsible to send always three valid setpoints. If there is only one setpoint,
+	// then previous will be set to current vehicle position and next will be set equal to setpoint.
+	//
+	// 3. navigator originally only supports gps guided maneuvers. However, it now also supports some flow-specific features
+	// such as land and takeoff. The navigator should use for auto takeoff/land with flow the position in xy at the moment the
+	// takeoff/land was initiated. Until then we do this kind of logic here.
 
 	if (!_sub_triplet_setpoint->get().current.valid) {
-		/* Best we can do is to just set all waypoints to current state */
+		// best we can do is to just set all waypoints to current state
 		_prev_prev_wp = _prev_wp = _target = _next_wp = _position;
 		_yaw_wp = _yaw;
 		_type = WaypointType::position;
@@ -96,15 +95,15 @@ bool FlightTaskAuto::_evaluateTriplets()
 	}
 
 	_type = (WaypointType)_sub_triplet_setpoint->get().current.type;
-	/* Always update cruise speed since that can change without waypoint changes */
+	// always update cruise speed since that can change without waypoint changes
 	_mc_cruise_speed = _sub_triplet_setpoint->get().current.cruising_speed;
 
 	if (!PX4_ISFINITE(_mc_cruise_speed) || (_mc_cruise_speed < 0.0f)) {
-		/* Use default */
+		// use default
 		_mc_cruise_speed = _mc_cruise_default.get();
 	}
 
-	/* Get target waypoint. */
+	// get target waypoint.
 	matrix::Vector3f target;
 	map_projection_project(&_reference_position,
 			       _sub_triplet_setpoint->get().current.lat, _sub_triplet_setpoint->get().current.lon, &target(0), &target(1));
@@ -118,24 +117,22 @@ bool FlightTaskAuto::_evaluateTriplets()
 
 	}
 
-	/* Check if anything has changed. We do that by comparing the target
-	 * setpoint to the previous target.
-	 * TODO This is a hack and it would be much
-	 * better if the navigator only sends out a waypoints once tthey have changed.
-	 */
+	// Check if anything has changed. We do that by comparing the target
+	// setpoint to the previous target.
+	// TODO This is a hack and it would be much better if the navigator only sends out a waypoints once tthey have changed.
 
-	/* Dont't do any updates if the current target has not changed */
+	// dont't do any updates if the current target has not changed
 	if (!(fabsf(target(0) - _target(0)) > 0.001f || fabsf(target(1) - _target(1)) > 0.001f
 	      || fabsf(target(2) - _target(2)) > 0.001f)) {
-		/* Nothing has changed: just keep old waypoints */
+		// nothing has changed: just keep old waypoints
 		return true;
 	}
 
-	/* Update all waypoints */
+	// update all waypoints
 	_target = target;
 
 	if (!PX4_ISFINITE(_target(0)) || !PX4_ISFINITE(_target(1))) {
-		/* Horizontal target is not finite. */
+		// Horizontal target is not finite. */
 		_target(0) = _position(0);
 		_target(1) = _position(1);
 	}
@@ -144,7 +141,7 @@ bool FlightTaskAuto::_evaluateTriplets()
 		_target(2) = _position(2);
 	}
 
-	_prev_prev_wp = _prev_wp; // previous -1 is set to previous
+	_prev_prev_wp = _prev_wp;
 
 	if (_isFinite(_sub_triplet_setpoint->get().previous) && _sub_triplet_setpoint->get().previous.valid) {
 		map_projection_project(&_reference_position, _sub_triplet_setpoint->get().previous.lat,
@@ -179,7 +176,7 @@ void FlightTaskAuto::_evaluateVehicleGlobalPosition()
 {
 	FlightTask::_evaluateVehicleLocalPosition();
 
-	/* Check if reference has changed and update. */
+	// check if reference has changed and update.
 	if (_sub_vehicle_local_position->get().ref_timestamp != _time_stamp_reference) {
 		PX4_INFO("inside");
 		map_projection_init(&_reference_position,

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
@@ -131,7 +131,6 @@ bool FlightTaskAuto::_evaluateTriplets()
 	if (!PX4_ISFINITE(_yaw_wp)) {
 		_yaw_wp = _yaw;
 
-	} else {
 	}
 
 	_mc_cruise_speed = _sub_triplet_setpoint->get().current.cruising_speed;

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
@@ -90,9 +90,11 @@ bool FlightTaskAuto::_evaluateTriplets()
 		/* Best we can do is to just set all waypoints to current state */
 		_prev_prev_wp = _prev_wp = _target = _next_wp = _position;
 		_yaw_wp = _yaw;
+		_type = WaypointType::position;
 		return false;
 	}
 
+	_type = (WaypointType)_sub_triplet_setpoint->get().current.type;
 	/* Always update cruise speed since that can change without waypoint changes */
 	_mc_cruise_speed = _sub_triplet_setpoint->get().current.cruising_speed;
 
@@ -140,8 +142,6 @@ bool FlightTaskAuto::_evaluateTriplets()
 		_yaw_wp = _yaw;
 
 	}
-
-	_type = (WaypointType)_sub_triplet_setpoint->get().current.type;
 
 	_prev_prev_wp = _prev_wp; // previous -1 is set to previous
 

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
@@ -143,7 +143,7 @@ bool FlightTaskAuto::_evaluateTriplets()
 
 	_type = (WaypointType)_sub_triplet_setpoint->get().current.type;
 
-	_prev_prev_wp = _prev_wp; // previous -1 is set to previsou
+	_prev_prev_wp = _prev_wp; // previous -1 is set to previous
 
 	if (_isFinite(_sub_triplet_setpoint->get().previous) && _sub_triplet_setpoint->get().previous.valid) {
 		map_projection_project(&_reference_position, _sub_triplet_setpoint->get().previous.lat,
@@ -172,4 +172,20 @@ bool FlightTaskAuto::_evaluateTriplets()
 bool FlightTaskAuto::_isFinite(const position_setpoint_s sp)
 {
 	return (PX4_ISFINITE(sp.lat) && PX4_ISFINITE(sp.lon) && PX4_ISFINITE(sp.alt));
+}
+
+bool FlightTaskAuto::_evaluateVehiclePosition()
+{
+	FlightTask::_evaluateVehiclePosition();
+
+	/* Check if reference has changed and update. */
+	if (_sub_vehicle_local_position->get().ref_timestamp != _time_stamp_reference) {
+		map_projection_init(&_reference_position,
+				    _sub_vehicle_local_position->get().ref_lat,
+				    _sub_vehicle_local_position->get().ref_lon);
+		_reference_altitude = _sub_vehicle_local_position->get().ref_alt;
+		_time_stamp_reference = _sub_vehicle_local_position->get().ref_timestamp;
+	}
+
+	return true;
 }

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
@@ -93,6 +93,14 @@ bool FlightTaskAuto::_evaluateTriplets()
 		return false;
 	}
 
+	/* Always update cruise speed since that can change without waypoint changes */
+	_mc_cruise_speed = _sub_triplet_setpoint->get().current.cruising_speed;
+
+	if (!PX4_ISFINITE(_mc_cruise_speed) || (_mc_cruise_speed < 0.0f)) {
+		/* Use default */
+		_mc_cruise_speed = _mc_cruise_default.get();
+	}
+
 	/* Get target waypoint. */
 	matrix::Vector3f target;
 	map_projection_project(&_reference_position,
@@ -131,13 +139,6 @@ bool FlightTaskAuto::_evaluateTriplets()
 	if (!PX4_ISFINITE(_yaw_wp)) {
 		_yaw_wp = _yaw;
 
-	}
-
-	_mc_cruise_speed = _sub_triplet_setpoint->get().current.cruising_speed;
-
-	if (!PX4_ISFINITE(_mc_cruise_speed) || (_mc_cruise_speed < 0.0f)) {
-		/* Use default */
-		_mc_cruise_speed = _mc_cruise_default.get();
 	}
 
 	_type = (WaypointType)_sub_triplet_setpoint->get().current.type;

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
@@ -91,5 +91,5 @@ private:
 	bool _isFinite(const position_setpoint_s sp);
 	void _updateReference();
 
-	bool _evaluateVehiclePosition() override; /**< Required for reference update */
+	bool _evaluateVehicleGlobalPosition(); /**< Required for reference update */
 };

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
@@ -43,6 +43,7 @@
 #include "FlightTask.hpp"
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/position_setpoint.h>
+#include <lib/geo/geo.h>
 
 /* This enum has to agree with position_setpoint_s type definition */
 enum class WaypointType : int {

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
@@ -42,7 +42,7 @@
 #include "FlightTask.hpp"
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/position_setpoint.h>
-#include <lib/geo/geo.h>
+#include <lib/ecl/geo/geo.h>
 
 /**
  * This enum has to agree with position_setpoint_s type definition

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
@@ -80,6 +80,8 @@ protected:
 		0.0f; /**< Cruise speed with which multicopter flies and gets set by triplet. If no valid, default cruise speed is used. */
 	WaypointType _type{WaypointType::idle}; /**< Type of current target triplet. */
 
+	virtual void _reset() = 0; /**< Method called one type has changed. */
+
 private:
 	control::BlockParamFloat _mc_cruise_default; /**< Default mc cruise speed*/
 

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
@@ -69,6 +69,8 @@ public:
 
 protected:
 
+	virtual void _reset() = 0; /**< Method that gets called once WaypointType has changed. */
+
 	matrix::Vector3f _prev_prev_wp{}; /**< Triplet previous-previous triplet. This will be used for smoothing trajectories -> not used yet. */
 	matrix::Vector3f _prev_wp{}; /**< Triplet previous setpoint in local frame. If not previous triplet is available, the prev_wp is set to current position. */
 	matrix::Vector3f _target{}; /**< Triplet target setpoint in local frame. */
@@ -79,8 +81,6 @@ protected:
 	float _mc_cruise_speed =
 		0.0f; /**< Cruise speed with which multicopter flies and gets set by triplet. If no valid, default cruise speed is used. */
 	WaypointType _type{WaypointType::idle}; /**< Type of current target triplet. */
-
-	virtual void _reset() = 0; /**< Method called one type has changed. */
 
 private:
 	control::BlockParamFloat _mc_cruise_default; /**< Default mc cruise speed*/

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
@@ -73,11 +73,9 @@ protected:
 	matrix::Vector3f _prev_wp{}; /**< Triplet previous setpoint in local frame. If not previous triplet is available, the prev_wp is set to current position. */
 	matrix::Vector3f _target{}; /**< Triplet target setpoint in local frame. */
 	matrix::Vector3f _next_wp{}; /**< Triplet setpoint in local frame. If no next setpoint is available, next is set to target. */
-	float _yaw_wp =
-		0.0f; /**< Triplet yaw waypoint. Unfortunately navigator sends yaw setpoint continuously. It would be better if a yaw setpoint is attached
+	float _yaw_wp{0.0f}; /**< Triplet yaw waypoint. Unfortunately navigator sends yaw setpoint continuously. It would be better if a yaw setpoint is attached
 	to triplet waypoint. This way it would be easy for multicopter to implement features where yaw does not matter. */
-	float _mc_cruise_speed =
-		0.0f; /**< Cruise speed with which multicopter flies and gets set by triplet. If no valid, default cruise speed is used. */
+	float _mc_cruise_speed{0.0f}; /**< Cruise speed with which multicopter flies and gets set by triplet. If no valid, default cruise speed is used. */
 	WaypointType _type{WaypointType::idle}; /**< Type of current target triplet. */
 
 private:

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
@@ -91,5 +91,5 @@ private:
 	bool _isFinite(const position_setpoint_s sp);
 	void _updateReference();
 
-	bool _evaluateVehicleGlobalPosition(); /**< Required for reference update */
+	void _evaluateVehicleGlobalPosition(); /**< Required for reference update */
 };

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
@@ -69,8 +69,6 @@ public:
 
 protected:
 
-	virtual void _reset() = 0; /**< Method that gets called once WaypointType has changed. */
-
 	matrix::Vector3f _prev_prev_wp{}; /**< Triplet previous-previous triplet. This will be used for smoothing trajectories -> not used yet. */
 	matrix::Vector3f _prev_wp{}; /**< Triplet previous setpoint in local frame. If not previous triplet is available, the prev_wp is set to current position. */
 	matrix::Vector3f _target{}; /**< Triplet target setpoint in local frame. */
@@ -84,10 +82,7 @@ protected:
 
 private:
 	control::BlockParamFloat _mc_cruise_default; /**< Default mc cruise speed*/
-
-	matrix::Vector3f _position_lock{}; /**< Position lock is NAN except when target lat/lon are not finite. */
 	map_projection_reference_s _reference; /**< Reference frame from global to local */
-
 	uORB::Subscription<position_setpoint_triplet_s> *_sub_triplet_setpoint{nullptr};
 
 	bool _evaluateTriplets(); /**< Checks and sets triplets */

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
@@ -82,8 +82,13 @@ private:
 	control::BlockParamFloat _mc_cruise_default; /**< Default mc cruise speed*/
 	map_projection_reference_s _reference; /**< Reference frame from global to local */
 	uORB::Subscription<position_setpoint_triplet_s> *_sub_triplet_setpoint{nullptr};
+	map_projection_reference_s _reference_position{}; /**< Structure used to project lat/lon setpoint into local frame */
+	float _reference_altitude = 0.0f;  /**< Altitude relative to ground */
+	hrt_abstime _time_stamp_reference = 0; /**< time stamp when last reference update */
 
 	bool _evaluateTriplets(); /**< Checks and sets triplets */
 	bool _isFinite(const position_setpoint_s sp);
 	void _updateReference();
+
+	bool _evaluateVehiclePosition() override; /**< Required for reference update */
 };

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
@@ -35,7 +35,6 @@
  * @file FlightTaskAuto.hpp
  *
  * Map from global triplet to local quadruple.
- *
  */
 
 #pragma once
@@ -45,9 +44,11 @@
 #include <uORB/topics/position_setpoint.h>
 #include <lib/geo/geo.h>
 
-/* This enum has to agree with position_setpoint_s type definition
+/**
+ * This enum has to agree with position_setpoint_s type definition
  * The only reason for not using the struct position_setpoint is because
- * of the size */
+ * of the size
+ */
 enum class WaypointType : int {
 	position = 0,
 	velocity,
@@ -63,11 +64,8 @@ public:
 	FlightTaskAuto(control::SuperBlock *parent, const char *name);
 
 	virtual ~FlightTaskAuto() = default;
-
 	bool initializeSubscriptions(SubscriptionArray &subscription_array) override;
-
 	bool activate() override;
-
 	bool updateInitialize() override;
 
 protected:

--- a/src/lib/FlightTasks/tasks/FlightTaskAutoLine.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAutoLine.cpp
@@ -59,14 +59,7 @@ FlightTaskAutoLine::FlightTaskAutoLine(control::SuperBlock *parent, const char *
 
 bool FlightTaskAutoLine::activate()
 {
-	_vel_sp_xy = matrix::Vector2f(&_velocity(0));
-	_pos_sp_xy = matrix::Vector2f(&_position(0));
-	_vel_sp_z = _velocity(2);
-	_pos_sp_z = _position(2);
-	_destination = _target;
-	_origin = _prev_wp;
-	_speed_at_target = 0.0f;
-
+	_reset();
 	return FlightTaskAuto::activate();
 }
 
@@ -99,6 +92,19 @@ bool FlightTaskAutoLine::update()
 	_setYawSetpoint(_yaw_wp);
 
 	return true;
+}
+
+
+void FlightTaskAutoLine::_reset()
+{
+	/* Set setpoints equal current state. */
+	_vel_sp_xy = matrix::Vector2f(&_velocity(0));
+	_pos_sp_xy = matrix::Vector2f(&_position(0));
+	_vel_sp_z = _velocity(2);
+	_pos_sp_z = _position(2);
+	_destination = _target;
+	_origin = _prev_wp;
+	_speed_at_target = 0.0f;
 }
 
 void FlightTaskAutoLine::_generateIdleSetpoints()

--- a/src/lib/FlightTasks/tasks/FlightTaskAutoLine.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAutoLine.cpp
@@ -69,15 +69,15 @@ bool FlightTaskAutoLine::update()
 	bool follow_line = _type == WaypointType::loiter || _type == WaypointType::position;
 	bool follow_line_prev = _type_previous == WaypointType::loiter || _type_previous == WaypointType::position;
 
-	/* 1st time that vehicle starts to follow line. Reset all setpoints to current vehicle state. */
+	// 1st time that vehicle starts to follow line. Reset all setpoints to current vehicle state.
 	if (follow_line && !follow_line_prev) {
 		_reset();
 	}
 
-	/* The only time a thrust setpoint is sent out is during
-	 * idle. Hence, reset thrust setpoint to NAN in case the
-	 * vehicle exits idle.
-	 */
+	// The only time a thrust set-point is sent out is during
+	// idle. Hence, reset thrust set-point to NAN in case the
+	// vehicle exits idle.
+
 	if (_type_previous == WaypointType::idle) {
 		_thrust_setpoint = Vector3f(NAN, NAN, NAN);
 	}
@@ -98,13 +98,13 @@ bool FlightTaskAutoLine::update()
 		_generateVelocitySetpoints();
 	}
 
-	/* For now yaw setpoint comes directly form triplets.
-	 * TODO: In the future, however, yaw should be set in this
-	 * task based on flag: yaw along path, yaw based on gimbal, yaw
-	 * same as home yaw ... */
+	// For now yaw-setpoint comes directly form triplets.
+	// TODO: In the future, however, yaw should be set in this
+	// task based on flag: yaw along path, yaw based on gimbal, yaw
+	// same as home yaw ...
 	_yaw_setpoint = _yaw_wp;
 
-	/* Update previous type */
+	// update previous type
 	_type_previous = _type;
 
 	return true;
@@ -112,7 +112,7 @@ bool FlightTaskAutoLine::update()
 
 void FlightTaskAutoLine::_reset()
 {
-	/* Set setpoints equal current state. */
+	// Set setpoints equal current state.
 	_velocity_setpoint = _velocity;
 	_position_setpoint = _position;
 	_destination = _target;
@@ -122,7 +122,7 @@ void FlightTaskAutoLine::_reset()
 
 void FlightTaskAutoLine::_generateIdleSetpoints()
 {
-	/* Send zero thrust setpoint */
+	// Send zero thrust setpoint */
 	_position_setpoint = Vector3f(NAN, NAN, NAN); // Don't require any position/velocity setpoints
 	_velocity_setpoint = Vector3f(NAN, NAN, NAN);
 	_thrust_setpoint.zero();
@@ -130,22 +130,22 @@ void FlightTaskAutoLine::_generateIdleSetpoints()
 
 void FlightTaskAutoLine::_generateLandSetpoints()
 {
-	/* Keep xy-position and go down with landspeed. */
+	// Keep xy-position and go down with landspeed. */
 	_position_setpoint = Vector3f(_target(0), _target(1), NAN);
 	_velocity_setpoint = Vector3f(Vector3f(NAN, NAN, _land_speed.get()));
 }
 
 void FlightTaskAutoLine::_generateTakeoffSetpoints()
 {
-	/* Takeoff is completely defined by target position. */
+	// Takeoff is completely defined by target position. */
 	_position_setpoint = _target;
 	_velocity_setpoint = Vector3f(NAN, NAN, NAN);
 }
 
 void FlightTaskAutoLine::_generateVelocitySetpoints()
 {
-	/* TODO: Remove velocity force logic from navigator, since
-	 * navigator should only send out waypoints. */
+	// TODO: Remove velocity force logic from navigator, since
+	// navigator should only send out waypoints.
 	_position_setpoint = Vector3f(NAN, NAN, _position(2));
 	Vector2f vel_sp_xy = Vector2f(&_velocity(0)).unit_or_zero() * _mc_cruise_speed;
 	_velocity_setpoint = Vector3f(vel_sp_xy(0), vel_sp_xy(1), NAN);
@@ -160,15 +160,14 @@ void FlightTaskAutoLine::_generateSetpoints()
 
 void FlightTaskAutoLine::_updateInternalWaypoints()
 {
-	/* The internal Waypoints might differ from previous_wp and target. The cases where it differs:
-	 * 1. The vehicle already passed the target -> go straight to target
-	 * 2. The vehicle is more than cruise speed in front of previous waypoint -> go straight to previous waypoint
-	 * 3. The vehicle is more than cruise speed from track -> go straight to closest point on track
-	 *
-	 * If a new target is available, then the speed at the target is computed from the angle previous-target-next
-	 */
+	// The internal Waypoints might differ from previous_wp and target. The cases where it differs:
+	// 1. The vehicle already passed the target -> go straight to target
+	// 2. The vehicle is more than cruise speed in front of previous waypoint -> go straight to previous waypoint
+	// 3. The vehicle is more than cruise speed from track -> go straight to closest point on track
+	//
+	// If a new target is available, then the speed at the target is computed from the angle previous-target-next.
 
-	/* Adjust destination and origin based on current vehicle state. */
+	// Adjust destination and origin based on current vehicle state.
 	Vector2f u_prev_to_target = Vector2f(&(_target - _prev_wp)(0)).unit_or_zero();
 	Vector2f pos_to_target = Vector2f(&(_target - _position)(0));
 	Vector2f prev_to_pos = Vector2f(&(_position - _prev_wp)(0));
@@ -176,7 +175,7 @@ void FlightTaskAutoLine::_updateInternalWaypoints()
 
 	if (u_prev_to_target * pos_to_target < 0.0f) {
 
-		/* Target is behind. */
+		// Target is behind. */
 		if (_current_state != State::target_behind) {
 
 			_destination = _target;
@@ -186,8 +185,8 @@ void FlightTaskAutoLine::_updateInternalWaypoints()
 			float angle = 2.0f;
 			_speed_at_target = 0.0f;
 
-			/* angle = cos(x) + 1.0
-			 * angle goes from 0 to 2 with 0 = large angle, 2 = small angle:   0 = PI ; 2 = PI*0 */
+			// angle = cos(x) + 1.0
+			// angle goes from 0 to 2 with 0 = large angle, 2 = small angle:   0 = PI ; 2 = PI*0
 
 			if (Vector2f(&(_destination - _next_wp)(0)).length() > 0.001f &&
 			    (Vector2f(&(_destination - _origin)(0)).length() > _nav_rad.get())) {
@@ -201,7 +200,7 @@ void FlightTaskAutoLine::_updateInternalWaypoints()
 
 	} else if (u_prev_to_target * prev_to_pos < 0.0f && prev_to_pos.length() > _mc_cruise_speed) {
 
-		/* Current position is more than cruise speed in front of previous setpoint. */
+		// Current position is more than cruise speed in front of previous setpoint.
 		if (_current_state != State::previous_infront) {
 			_destination = _prev_wp;
 			_origin = _position;
@@ -210,8 +209,8 @@ void FlightTaskAutoLine::_updateInternalWaypoints()
 			float angle = 2.0f;
 			_speed_at_target = 0.0f;
 
-			/* angle = cos(x) + 1.0
-			 * angle goes from 0 to 2 with 0 = large angle, 2 = small angle:   0 = PI ; 2 = PI*0 */
+			// angle = cos(x) + 1.0
+			// angle goes from 0 to 2 with 0 = large angle, 2 = small angle:   0 = PI ; 2 = PI*0
 			if (Vector2f(&(_destination - _next_wp)(0)).length() > 0.001f &&
 			    (Vector2f(&(_destination - _origin)(0)).length() > _nav_rad.get())) {
 
@@ -225,7 +224,7 @@ void FlightTaskAutoLine::_updateInternalWaypoints()
 
 	} else if (Vector2f(Vector2f(&_position(0)) - closest_pt).length() > _mc_cruise_speed) {
 
-		/* Vehicle is more than cruise speed off track. */
+		// Vehicle is more than cruise speed off track.
 		if (_current_state != State::offtrack) {
 			_destination = matrix::Vector3f(closest_pt(0), closest_pt(1), _target(2));
 			_origin = _position;
@@ -234,8 +233,8 @@ void FlightTaskAutoLine::_updateInternalWaypoints()
 			float angle = 2.0f;
 			_speed_at_target = 0.0f;
 
-			/* angle = cos(x) + 1.0
-			 * angle goes from 0 to 2 with 0 = large angle, 2 = small angle:   0 = PI ; 2 = PI*0 */
+			// angle = cos(x) + 1.0
+			// angle goes from 0 to 2 with 0 = large angle, 2 = small angle:   0 = PI ; 2 = PI*0
 			if (Vector2f(&(_destination - _next_wp)(0)).length() > 0.001f &&
 			    (Vector2f(&(_destination - _origin)(0)).length() > _nav_rad.get())) {
 
@@ -250,7 +249,7 @@ void FlightTaskAutoLine::_updateInternalWaypoints()
 	} else {
 
 		if ((_target - _destination).length() > 0.01f) {
-			/* A new target is available. Update speed at target.*/
+			// A new target is available. Update speed at target.*/
 			_destination = _target;
 			_origin = _prev_wp;
 			_current_state = State::none;
@@ -258,8 +257,8 @@ void FlightTaskAutoLine::_updateInternalWaypoints()
 			float angle = 2.0f;
 			_speed_at_target = 0.0f;
 
-			/* angle = cos(x) + 1.0
-			 * angle goes from 0 to 2 with 0 = large angle, 2 = small angle:   0 = PI ; 2 = PI*0 */
+			// angle = cos(x) + 1.0
+			// angle goes from 0 to 2 with 0 = large angle, 2 = small angle:   0 = PI ; 2 = PI*0
 			if (Vector2f(&(_destination - _next_wp)(0)).length() > 0.001f &&
 			    (Vector2f(&(_destination - _origin)(0)).length() > _nav_rad.get())) {
 
@@ -281,14 +280,14 @@ void FlightTaskAutoLine::_generateXYsetpoints()
 	if ((_speed_at_target < 0.001f && pos_sp_to_dest.length() < _nav_rad.get()) ||
 	    (!has_reached_altitude && pos_sp_to_dest.length() < _nav_rad.get())) {
 
-		/* Vehicle reached target in xy and no passing required. Lock position */
+		// Vehicle reached target in xy and no passing required. Lock position */
 		_position_setpoint(0) = _destination(0);
 		_position_setpoint(1) = _destination(1);
 		_velocity_setpoint(0) = _velocity_setpoint(1) = 0.0f;
 
 	} else {
 
-		/* Get various path specific vectors. */
+		// Get various path specific vectors. */
 		Vector2f u_prev_to_dest = Vector2f(&(_destination - _origin)(0)).unit_or_zero();
 		Vector2f prev_to_pos(&(_position - _origin)(0));
 		Vector2f closest_pt = Vector2f(&_origin(0)) + u_prev_to_dest * (prev_to_pos * u_prev_to_dest);
@@ -297,45 +296,43 @@ void FlightTaskAutoLine::_generateXYsetpoints()
 		float speed_sp_track = _mc_cruise_speed;
 		float speed_sp_prev_track = math::max(Vector2f(&_velocity_setpoint(0)) * u_prev_to_dest, 0.0f);
 
-		/* Distance to target when brake should occur. The assumption is made that
-		 * 1.5 * cruising speed is enough to break. */
+		// Distance to target when brake should occur. The assumption is made that
+		// 1.5 * cruising speed is enough to break.
 		float target_threshold = 1.5f * _mc_cruise_speed;
 		float speed_threshold = _mc_cruise_speed;
 		const float threshold_max = target_threshold;
 
 		if (target_threshold > 0.5f * prev_to_dest.length()) {
-			/* Target threshold cannot be more than distance from previous to target */
+			// Target threshold cannot be more than distance from previous to target
 			target_threshold = 0.5f * prev_to_dest.length();
 		}
 
-		/* Compute maximum speed at target threshold */
+		// Compute maximum speed at target threshold */
 		if (threshold_max > _nav_rad.get()) {
 			float m = (_mc_cruise_speed - _speed_at_target) / (threshold_max - _nav_rad.get());
 			speed_threshold = m * (target_threshold - _nav_rad.get()) + _speed_at_target; // speed at transition
 		}
 
-		/* Either accelerate or decelerate */
+		// Either accelerate or decelerate
 		if (closest_to_dest.length() < target_threshold) {
 
-			/* Vehicle is close to destination. Start to decelerate */
+			// Vehicle is close to destination. Start to decelerate
 
 			if (!has_reached_altitude) {
-				/* Altitude is not reached yet. Vehicle has to stop first before proceeding */
+				// Altitude is not reached yet. Vehicle has to stop first before proceeding
 				_speed_at_target = 0.0f;
 			}
 
 			float acceptance_radius = _nav_rad.get();
 
 			if (_speed_at_target < 0.01f) {
-				/* If vehicle wants to stop at the target, then set acceptance radius
-				 * to zero as well.
-				 */
+				// If vehicle wants to stop at the target, then set acceptance radius to zero as well.
 				acceptance_radius = 0.0f;
 			}
 
 			if ((target_threshold - acceptance_radius) >= SIGMA_NORM) {
 
-				/* Slow down depending on distance to target minus acceptance radius */
+				// Slow down depending on distance to target minus acceptance radius.
 				float m = (speed_threshold - _speed_at_target) / (target_threshold - acceptance_radius);
 				speed_sp_track = m * (closest_to_dest.length() - acceptance_radius) + _speed_at_target; // speed at transition
 
@@ -343,10 +340,9 @@ void FlightTaskAutoLine::_generateXYsetpoints()
 				speed_sp_track = _speed_at_target;
 			}
 
-			/* If we are close to target and the previous speed setpoint along track was smaller than
-			 * current speed setpoint along track, then take over the previous one.
-			 * This ensures smoothness since we anyway want to slow down.
-			 */
+			// If we are close to target and the previous speed setpoint along track was smaller than
+			// current speed setpoint along track, then take over the previous one.
+			// This ensures smoothness since we anyway want to slow down.
 			if ((speed_sp_prev_track < speed_sp_track)
 			    && (speed_sp_track * speed_sp_prev_track > 0.0f)
 			    && (speed_sp_prev_track > _speed_at_target)) {
@@ -355,7 +351,7 @@ void FlightTaskAutoLine::_generateXYsetpoints()
 
 		} else {
 
-			/* Vehicle is still far from destination. Accelerate or keep maximum target speed. */
+			// Vehicle is still far from destination. Accelerate or keep maximum target speed.
 			float acc_track = (speed_sp_track - speed_sp_prev_track) / _deltatime;
 
 			float yaw_diff = 0.0f;
@@ -364,11 +360,11 @@ void FlightTaskAutoLine::_generateXYsetpoints()
 				yaw_diff = _wrap_pi(_yaw_wp - _yaw);
 			}
 
-			/* If yaw offset is large, only accelerate with 0.5 m/s^2. */
+			// If yaw offset is large, only accelerate with 0.5 m/s^2.
 			float acc_max = (fabsf(yaw_diff) > math::radians(_mis_yaw_error.get())) ? 0.5f : _acc_xy.get();
 
 			if (acc_track > acc_max) {
-				/* Accelerate towards target */
+				// accelerate towards target
 				speed_sp_track = acc_max * _deltatime + speed_sp_prev_track;
 			}
 		}
@@ -385,50 +381,48 @@ void FlightTaskAutoLine::_generateXYsetpoints()
 
 void FlightTaskAutoLine::_generateAltitudeSetpoints()
 {
-	/* Total distance between previous and target setpoint */
+	// Total distance between previous and target set-point.
 	const float dist = fabsf(_destination(2) - _origin(2));
 
-	/* If target has not been reached, then compute setpoint depending on maximum velocity */
+	// If target has not been reached, then compute set-point depending on maximum velocity.
 	if ((dist > SIGMA_NORM) && (fabsf(_position(2) - _destination(2)) > 0.1f)) {
 
-		/* get various distances */
+		// get various distances */
 		const float dist_to_prev = fabsf(_position(2) - _origin(2));
 		const float dist_to_target = fabsf(_destination(2) - _position(2));
 
-		/* check sign */
+		// check sign
 		const bool flying_upward = _destination(2) < _position(2);
 
-		/* Speed at threshold is by default maximum speed. Threshold defines
-		 * the point in z at which vehicle slows down to reach target altitude. */
+		// Speed at threshold is by default maximum speed. Threshold defines
+		// the point in z at which vehicle slows down to reach target altitude.
 		float speed_sp = (flying_upward) ? _vel_max_up.get() : _vel_max_down.get();
 
-		/* target threshold defines the distance to target(2) at which
-		 * the vehicle starts to slow down to approach the target smoothly */
+		// Target threshold defines the distance to target(2) at which
+		// the vehicle starts to slow down to approach the target smoothly.
 		float target_threshold = speed_sp * 1.5f;
 
-		/* If the total distance in z is NOT 2x distance of target_threshold, we
-		 * will need to adjust the final_velocity in z */
+		// If the total distance in z is NOT 2x distance of target_threshold, we
+		// will need to adjust the final_velocity in z.
 		const bool is_2_target_threshold = dist >= 2.0f * target_threshold;
 		const float min_vel = 0.2f; // minimum velocity: this is needed since estimation is not perfect
-		const float slope = (speed_sp - min_vel) / (target_threshold); /* defines the the acceleration when slowing down */
+		const float slope = (speed_sp - min_vel) / (target_threshold); // defines the the acceleration when slowing down */
 
 		if (!is_2_target_threshold) {
-			/* adjust final_velocity since we are already are close
-			 * to target and therefore it is not necessary to accelerate
-			 * up to full speed
-			 */
+			// Adjust final_velocity since we are already are close to target and therefore it is not necessary to accelerate
+			// upwards with full speed.
 			target_threshold = dist * 0.5f;
-			/* get the velocity at target_threshold */
+			// get the velocity at target_threshold
 			speed_sp = slope * (target_threshold) + min_vel;
 		}
 
-		/* we want to slow down */
+		// we want to slow down
 		if (dist_to_target < target_threshold) {
 
 			speed_sp = slope * dist_to_target + min_vel;
 
 		} else if (dist_to_prev < target_threshold) {
-			/* we want to accelerate */
+			// we want to accelerate
 
 			const float acc = (speed_sp - fabsf(_velocity_setpoint(2))) / _deltatime;
 			const float acc_max = (flying_upward) ? (_acc_max_up.get() * 0.5f) : (_acc_max_down.get() * 0.5f);
@@ -438,19 +432,19 @@ void FlightTaskAutoLine::_generateAltitudeSetpoints()
 			}
 		}
 
-		/* make sure vel_sp_z is always positive */
+		// make sure vel_sp_z is always positive
 		if (speed_sp < 0.0f) {
 			PX4_WARN("speed cannot be smaller than 0");
 			speed_sp = 0.0f;
 		}
 
-		/* get the sign of vel_sp_z */
+		// get the sign of vel_sp_z
 		_velocity_setpoint(2) = (flying_upward) ? -speed_sp : speed_sp;
-		_position_setpoint(2) = NAN; // We don't care about position setpoint */
+		_position_setpoint(2) = NAN; // We don't care about position setpoint
 
 	} else {
 
-		/* Vehicle reached desired target altitude */
+		// vehicle reached desired target altitude
 		_velocity_setpoint(2) = 0.0f;
 		_position_setpoint(2) = _target(2);
 	}
@@ -458,16 +452,16 @@ void FlightTaskAutoLine::_generateAltitudeSetpoints()
 
 float FlightTaskAutoLine::_getVelocityFromAngle(const float angle)
 {
-	/* Minimum cruise speed when passing waypoint */
+	// minimum cruise speed when passing waypoint
 	float min_cruise_speed = 0.0f;
 
-	/* Make sure that cruise speed is larger than minimum*/
+	// make sure that cruise speed is larger than minimum
 	if ((_mc_cruise_speed - min_cruise_speed) < SIGMA_NORM) {
 		return _mc_cruise_speed;
 	}
 
-	/* Middle cruise speed is a number between maximum cruising speed and minimum cruising speed and corresponds to speed at angle of 90degrees.
-	 * It needs to be always larger than minimum cruise speed. */
+	// Middle cruise speed is a number between maximum cruising speed and minimum cruising speed and corresponds to speed at angle of 90degrees.
+	// It needs to be always larger than minimum cruise speed.
 	float middle_cruise_speed = _cruise_speed_90.get();
 
 	if ((middle_cruise_speed - min_cruise_speed) < SIGMA_NORM) {
@@ -478,34 +472,31 @@ float FlightTaskAutoLine::_getVelocityFromAngle(const float angle)
 		middle_cruise_speed = (_mc_cruise_speed + min_cruise_speed) * 0.5f;
 	}
 
-	/* If middle cruise speed is exactly in the middle, then compute
-	 * speed linearly
-	 */
+	// If middle cruise speed is exactly in the middle, then compute speed linearly.
 	bool use_linear_approach = false;
 
 	if (((_mc_cruise_speed + min_cruise_speed) * 0.5f) - middle_cruise_speed < SIGMA_NORM) {
 		use_linear_approach = true;
 	}
 
-	/* Compute speed sp at target */
+	// compute speed sp at target
 	float speed_close;
 
 	if (use_linear_approach) {
 
-		/* velocity close to target adjusted to angle
-		 * vel_close =  m*x+q
-		 */
+		// velocity close to target adjusted to angle:
+		// vel_close =  m*x+q
 		float slope = -(_mc_cruise_speed - min_cruise_speed) / 2.0f;
 		speed_close = slope * angle + _mc_cruise_speed;
 
 	} else {
 
-		/* Speed close to target adjusted to angle x.
-		 * speed_close = a *b ^x + c; where at angle x = 0 -> speed_close = cruise; angle x = 1 -> speed_close = middle_cruise_speed (this means that at 90degrees
-		 * the velocity at target is middle_cruise_speed);
-		 * angle x = 2 -> speed_close = min_cruising_speed */
+		// Speed close to target adjusted to angle x.
+		// speed_close = a *b ^x + c; where at angle x = 0 -> speed_close = cruise; angle x = 1 -> speed_close = middle_cruise_speed (this means that at 90degrees
+		// the velocity at target is middle_cruise_speed);
+		// angle x = 2 -> speed_close = min_cruising_speed
 
-		/* from maximum cruise speed, minimum cruise speed and middle cruise speed compute constants a, b and c */
+		// from maximum cruise speed, minimum cruise speed and middle cruise speed compute constants a, b and c
 		float a = -((middle_cruise_speed - _mc_cruise_speed) * (middle_cruise_speed - _mc_cruise_speed))
 			  / (2.0f * middle_cruise_speed - _mc_cruise_speed - min_cruise_speed);
 		float c = _mc_cruise_speed - a;
@@ -513,6 +504,6 @@ float FlightTaskAutoLine::_getVelocityFromAngle(const float angle)
 		speed_close = a * powf(b, angle) + c;
 	}
 
-	/* speed_close needs to be in between max and min */
+	// speed_close needs to be in between max and min
 	return math::constrain(speed_close, min_cruise_speed, _mc_cruise_speed);
 }

--- a/src/lib/FlightTasks/tasks/FlightTaskAutoLine.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAutoLine.cpp
@@ -89,7 +89,6 @@ bool FlightTaskAutoLine::update()
 	return true;
 }
 
-
 void FlightTaskAutoLine::_reset()
 {
 	/* Set setpoints equal current state. */

--- a/src/lib/FlightTasks/tasks/FlightTaskAutoLine.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAutoLine.cpp
@@ -124,6 +124,13 @@ void FlightTaskAutoLine::_generateTakeoffSetpoints()
 	/* Takeoff is completely defined by target position. */
 	_position_setpoint = _target;
 
+void FlightTaskAutoLine::_generateVelocitySetpoints()
+{
+	/* TODO: Remove velocity force logic from navigator, since
+	 * navigator should only send out waypoints. */
+	_position_setpoint = Vector3f(NAN, NAN, _position(2));
+	Vector2f vel_sp_xy = Vector2f(&_velocity(0)).unit_or_zero() * _mc_cruise_speed;
+	_velocity_setpoint = Vector3f(vel_sp_xy(0), vel_sp_xy(1), NAN);
 	/* Set member setpoints to current state */
 	_reset();
 }
@@ -431,16 +438,6 @@ void FlightTaskAutoLine::_generateAltitudeSetpoints()
 		_velocity_setpoint(2) = 0.0f;
 		_position_setpoint(2) = _target(2);
 	}
-}
-void FlightTaskAutoLine::_generateVelocitySetpoints()
-{
-	/* TODO: Remove velocity force logic from navigator, since
-	 * navigator should only send out waypoints. */
-	_position_setpoint = Vector3f(NAN, NAN, _position(2));
-	Vector2f vel_sp_xy = Vector2f(&_velocity(0)).unit_or_zero() * _mc_cruise_speed;
-	_velocity_setpoint = Vector3f(vel_sp_xy(0), vel_sp_xy(1), NAN);
-
-	_reset();
 }
 
 float FlightTaskAutoLine::_getVelocityFromAngle(const float angle)

--- a/src/lib/FlightTasks/tasks/FlightTaskAutoLine.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAutoLine.cpp
@@ -339,7 +339,6 @@ void FlightTaskAutoLine::_generateXYsetpoints()
 
 			if (PX4_ISFINITE(_yaw_wp)) {
 				yaw_diff = _wrap_pi(_yaw_wp - _yaw);
-				PX4_WARN("Yaw Waypoint not finite");
 			}
 
 			/* If yaw offset is large, only accelerate with 0.5 m/s^2. */

--- a/src/lib/FlightTasks/tasks/FlightTaskAutoLine.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAutoLine.cpp
@@ -123,10 +123,9 @@ void FlightTaskAutoLine::_reset()
 void FlightTaskAutoLine::_generateIdleSetpoints()
 {
 	/* Send zero thrust setpoint */
+	_position_setpoint = Vector3f(NAN, NAN, NAN); // Don't require any position/velocity setpoints
+	_velocity_setpoint = Vector3f(NAN, NAN, NAN);
 	_thrust_setpoint.zero();
-
-	/* Set member setpoints to current state */
-	_reset();
 }
 
 void FlightTaskAutoLine::_generateLandSetpoints()
@@ -134,15 +133,14 @@ void FlightTaskAutoLine::_generateLandSetpoints()
 	/* Keep xy-position and go down with landspeed. */
 	_position_setpoint = Vector3f(_target(0), _target(1), NAN);
 	_velocity_setpoint = Vector3f(Vector3f(NAN, NAN, _land_speed.get()));
-
-	/* Set member setpoints to current state */
-	_reset();
 }
 
 void FlightTaskAutoLine::_generateTakeoffSetpoints()
 {
 	/* Takeoff is completely defined by target position. */
 	_position_setpoint = _target;
+	_velocity_setpoint = Vector3f(NAN, NAN, NAN);
+}
 
 void FlightTaskAutoLine::_generateVelocitySetpoints()
 {
@@ -151,8 +149,6 @@ void FlightTaskAutoLine::_generateVelocitySetpoints()
 	_position_setpoint = Vector3f(NAN, NAN, _position(2));
 	Vector2f vel_sp_xy = Vector2f(&_velocity(0)).unit_or_zero() * _mc_cruise_speed;
 	_velocity_setpoint = Vector3f(vel_sp_xy(0), vel_sp_xy(1), NAN);
-	/* Set member setpoints to current state */
-	_reset();
 }
 
 void FlightTaskAutoLine::_generateSetpoints()
@@ -165,8 +161,8 @@ void FlightTaskAutoLine::_generateSetpoints()
 void FlightTaskAutoLine::_updateInternalWaypoints()
 {
 	/* The internal Waypoints might differ from previous_wp and target. The cases where it differs:
-	 * 1. The vehicle already passe the target -> go straight to target
-	 * 2. The vehicle is more than cruise speed in front of previous waypoint -> go straight to previous wp
+	 * 1. The vehicle already passed the target -> go straight to target
+	 * 2. The vehicle is more than cruise speed in front of previous waypoint -> go straight to previous waypoint
 	 * 3. The vehicle is more than cruise speed from track -> go straight to closest point on track
 	 *
 	 * If a new target is available, then the speed at the target is computed from the angle previous-target-next
@@ -288,7 +284,7 @@ void FlightTaskAutoLine::_generateXYsetpoints()
 		/* Vehicle reached target in xy and no passing required. Lock position */
 		_position_setpoint(0) = _destination(0);
 		_position_setpoint(1) = _destination(1);
-		_velocity_setpoint.zero();
+		_velocity_setpoint(0) = _velocity_setpoint(1) = 0.0f;
 
 	} else {
 

--- a/src/lib/FlightTasks/tasks/FlightTaskAutoLine.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAutoLine.cpp
@@ -69,7 +69,7 @@ bool FlightTaskAutoLine::update()
 	bool follow_line = _type == WaypointType::loiter || _type == WaypointType::position;
 	bool follow_line_prev = _type_previous == WaypointType::loiter || _type_previous == WaypointType::position;
 
-	/* 1st time that vehicle starts to follow line. Reset all setpoints to current vehicle state */
+	/* 1st time that vehicle starts to follow line. Reset all setpoints to current vehicle state. */
 	if (follow_line && !follow_line_prev) {
 		_reset();
 	}
@@ -100,8 +100,8 @@ bool FlightTaskAutoLine::update()
 
 	/* For now yaw setpoint comes directly form triplets.
 	 * TODO: In the future, however, yaw should be set in this
-	 * task based on flag: yaw along path, yaw along gimbal, yaw
-	 * same as during home... */
+	 * task based on flag: yaw along path, yaw based on gimbal, yaw
+	 * same as home yaw ... */
 	_yaw_setpoint = _yaw_wp;
 
 	/* Update previous type */

--- a/src/lib/FlightTasks/tasks/FlightTaskAutoLine.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAutoLine.cpp
@@ -303,7 +303,7 @@ void FlightTaskAutoLine::_generateXYsetpoints()
 		float speed_threshold = _mc_cruise_speed;
 		const float threshold_max = target_threshold;
 
-		if (target_threshold < 0.5f * prev_to_dest.length()) {
+		if (target_threshold > 0.5f * prev_to_dest.length()) {
 			/* Target threshold cannot be more than distance from previous to target */
 			target_threshold = 0.5f * prev_to_dest.length();
 		}

--- a/src/lib/FlightTasks/tasks/FlightTaskAutoLine.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAutoLine.cpp
@@ -59,8 +59,9 @@ FlightTaskAutoLine::FlightTaskAutoLine(control::SuperBlock *parent, const char *
 
 bool FlightTaskAutoLine::activate()
 {
+	bool ret = FlightTaskAuto::activate();
 	_reset();
-	return FlightTaskAuto::activate();
+	return ret;
 }
 
 bool FlightTaskAutoLine::update()

--- a/src/lib/FlightTasks/tasks/FlightTaskAutoLine.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAutoLine.hpp
@@ -54,9 +54,6 @@ public:
 	bool update() override;
 
 protected:
-
-	void _reset() override;
-
 	matrix::Vector2f _vel_sp_xy{};
 	matrix::Vector2f _pos_sp_xy{};
 	float _vel_sp_z = 0.0f;
@@ -98,4 +95,5 @@ protected:
 
 private:
 	float _getVelocityFromAngle(const float angle); /** Computes the speed at target depending on angle. */
+	void _reset(); /** Resets member variables to current vehicle state */
 };

--- a/src/lib/FlightTasks/tasks/FlightTaskAutoLine.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAutoLine.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/lib/FlightTasks/tasks/FlightTaskAutoLine.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAutoLine.hpp
@@ -93,5 +93,9 @@ protected:
 	void _generateSetpoints(); /**< Generate velocity and position setpoint for following line. */
 	void _generateAltitudeSetpoints(); /**< Generate velocity and position setpoints for following line along z. */
 	void _generateXYsetpoints(); /**< Generate velocity and position setpoints for following line along xy. */
+
+private:
+	float _getVelocityFromAngle(const float angle); /** Computes the speed at target depending on angle. */
+	void _reset(); /** Resets setpoint. */
 	float _getVelcoityFromAngle(const float angle); /** Computes the speed at target depending on angle. */
 };

--- a/src/lib/FlightTasks/tasks/FlightTaskAutoLine.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAutoLine.hpp
@@ -92,4 +92,6 @@ protected:
 private:
 	float _getVelocityFromAngle(const float angle); /** Computes the speed at target depending on angle. */
 	void _reset(); /** Resets member variables to current vehicle state */
+	WaypointType _type_previous{WaypointType::idle}; /**< Previous type of current target triplet. */
+
 };

--- a/src/lib/FlightTasks/tasks/FlightTaskAutoLine.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAutoLine.hpp
@@ -55,6 +55,8 @@ public:
 
 protected:
 
+	void _reset() override;
+
 	matrix::Vector2f _vel_sp_xy{};
 	matrix::Vector2f _pos_sp_xy{};
 	float _vel_sp_z = 0.0f;
@@ -96,5 +98,4 @@ protected:
 
 private:
 	float _getVelocityFromAngle(const float angle); /** Computes the speed at target depending on angle. */
-	void _reset(); /** Resets setpoint. */
 };

--- a/src/lib/FlightTasks/tasks/FlightTaskAutoLine.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAutoLine.hpp
@@ -54,10 +54,6 @@ public:
 	bool update() override;
 
 protected:
-	matrix::Vector2f _vel_sp_xy{};
-	matrix::Vector2f _pos_sp_xy{};
-	float _vel_sp_z = 0.0f;
-	float _pos_sp_z = 0.0f;
 
 	matrix::Vector3f _destination{}; /**< Current target. Is not necessarily the same as triplet target. */
 	matrix::Vector3f _origin{}; /**< Previous waypoint. Is not necessarily the same as triplet previous. */

--- a/src/lib/FlightTasks/tasks/FlightTaskAutoLine.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAutoLine.hpp
@@ -97,5 +97,4 @@ protected:
 private:
 	float _getVelocityFromAngle(const float angle); /** Computes the speed at target depending on angle. */
 	void _reset(); /** Resets setpoint. */
-	float _getVelcoityFromAngle(const float angle); /** Computes the speed at target depending on angle. */
 };

--- a/src/lib/FlightTasks/tasks/FlightTaskAutoLine.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAutoLine.hpp
@@ -46,11 +46,8 @@ class FlightTaskAutoLine : public FlightTaskAuto
 {
 public:
 	FlightTaskAutoLine(control::SuperBlock *parent, const char *name);
-
 	virtual ~FlightTaskAutoLine() = default;
-
 	bool activate() override;
-
 	bool update() override;
 
 protected:

--- a/src/lib/FlightTasks/tasks/FlightTaskManualStabilized.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskManualStabilized.cpp
@@ -44,7 +44,7 @@ FlightTaskManualStabilized::FlightTaskManualStabilized(control::SuperBlock *pare
 	FlightTaskManual(parent, name),
 	_yaw_rate_scaling(parent, "MPC_MAN_Y_MAX", false),
 	_tilt_max_man(parent, "MPC_MAN_TILT_MAX", false),
-	_throttle_min(parent, "MPC_THR_MIN", false),
+	_throttle_min_stabilized(parent, "MPC_THR_MIN", false),
 	_throttle_max(parent, "MPC_THR_MAX", false),
 	_throttle_hover(parent, "MPC_THR_HOVER", false)
 {}
@@ -131,7 +131,7 @@ float FlightTaskManualStabilized::_throttleCurve()
 	float throttle = -((_sticks(2) - 1.0f) * 0.5f);
 
 	if (throttle < 0.5f) {
-		return (_throttle_hover.get() - _throttle_min.get()) / 0.5f * throttle + _throttle_min.get();
+		return (_throttle_hover.get() - _throttle_min_stabilized.get()) / 0.5f * throttle + _throttle_min_stabilized.get();
 
 	} else {
 		return (_throttle_max.get() - _throttle_hover.get()) / 0.5f * (throttle - 1.0f) + _throttle_max.get();

--- a/src/lib/FlightTasks/tasks/FlightTaskManualStabilized.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskManualStabilized.hpp
@@ -68,7 +68,8 @@ private:
 
 	control::BlockParamFloat _yaw_rate_scaling; /**< scaling factor from stick to yaw rate */
 	control::BlockParamFloat _tilt_max_man; /**< maximum tilt allowed for manual flight */
-	control::BlockParamFloat _throttle_min_stabilized; /**< minimum throttle that always has to be satisfied in flight for stabilized mode*/
+	control::BlockParamFloat
+	_throttle_min_stabilized; /**< minimum throttle that always has to be satisfied in flight for stabilized mode*/
 	control::BlockParamFloat _throttle_max; /**< maximum throttle that always has to be satisfied in flight*/
 	control::BlockParamFloat _throttle_hover; /**< throttle value at which vehicle is at hover equilibrium */
 };

--- a/src/lib/FlightTasks/tasks/FlightTaskManualStabilized.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskManualStabilized.hpp
@@ -68,7 +68,7 @@ private:
 
 	control::BlockParamFloat _yaw_rate_scaling; /**< scaling factor from stick to yaw rate */
 	control::BlockParamFloat _tilt_max_man; /**< maximum tilt allowed for manual flight */
-	control::BlockParamFloat _throttle_min; /**< minimum throttle that always has to be satisfied in flight*/
+	control::BlockParamFloat _throttle_min_stabilized; /**< minimum throttle that always has to be satisfied in flight for stabilized mode*/
 	control::BlockParamFloat _throttle_max; /**< maximum throttle that always has to be satisfied in flight*/
 	control::BlockParamFloat _throttle_hover; /**< throttle value at which vehicle is at hover equilibrium */
 };

--- a/src/lib/FlightTasks/tasks/FlightTaskOffboard.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskOffboard.cpp
@@ -1,0 +1,135 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file FlightTaskAuto.cpp
+ */
+#include "FlightTaskOffboard.hpp"
+#include <mathlib/mathlib.h>
+#include <float.h>
+
+using namespace matrix;
+
+FlightTaskOffboard::FlightTaskOffboard(control::SuperBlock *parent, const char *name) :
+	FlightTask(parent, name)
+{}
+
+bool FlightTaskOffboard::initializeSubscriptions(SubscriptionArray &subscription_array)
+{
+	if (!FlightTask::initializeSubscriptions(subscription_array)) {
+		return false;
+	}
+
+	if (!subscription_array.get(ORB_ID(position_setpoint_triplet), _sub_triplet_setpoint)) {
+		return false;
+	}
+
+	return true;
+}
+
+bool FlightTaskOffboard::update()
+{
+	if (!_sub_triplet_setpoint->get().current.valid) {
+		_resetSetpoints();
+		_position_setpoint = _position;
+		return false;
+	}
+
+	// reset setpoint for every loop
+	_resetSetpoints();
+
+	// XY-direction
+	PX4_INFO("position valid: %d", _sub_triplet_setpoint->get().current.position_valid);
+
+	if (_sub_triplet_setpoint->get().current.position_valid && _sub_vehicle_local_position->get().xy_valid) {
+		// offboard position control is on
+		_position_setpoint(0) = _sub_triplet_setpoint->get().current.x;
+		_position_setpoint(1) = _sub_triplet_setpoint->get().current.y;
+	}
+
+	if (_sub_triplet_setpoint->get().current.velocity_valid && _sub_vehicle_local_position->get().v_xy_valid) {
+		// offboard velocity control is on
+		if (_sub_triplet_setpoint->get().current.velocity_frame == position_setpoint_s::VELOCITY_FRAME_LOCAL_NED) {
+			// in local frame: don't require any transformation
+			_velocity_setpoint(0) = _sub_triplet_setpoint->get().current.vx;
+			_velocity_setpoint(1) = _sub_triplet_setpoint->get().current.vy;
+
+		} else if (_sub_triplet_setpoint->get().current.velocity_frame == position_setpoint_s::VELOCITY_FRAME_BODY_NED) {
+			// in body frame: need to transorm first
+			// Note, this transformation is wrong because body-xy is not neccessarily on the same plane as locale-xy
+			_velocity_setpoint(0) = cosf(_yaw) * _sub_triplet_setpoint->get().current.vx - sinf(
+							_yaw) * _sub_triplet_setpoint->get().current.vy;
+			_velocity_setpoint(1) = sinf(_yaw) * _sub_triplet_setpoint->get().current.vx + cosf(
+							_yaw) * _sub_triplet_setpoint->get().current.vy;
+
+		} else {
+			// no valid frame. send zero velocity
+			_velocity_setpoint(0) = _velocity_setpoint(1) = 0.0f;
+		}
+	}
+
+	// Z-direction
+
+	if (_sub_triplet_setpoint->get().current.alt_valid && _sub_vehicle_local_position->get().z_valid) {
+		// altitude control is required
+		_position_setpoint(2) = _sub_triplet_setpoint->get().current.z;
+	}
+
+	if (_sub_triplet_setpoint->get().current.velocity_valid && _sub_vehicle_local_position->get().v_z_valid) {
+		// climb rate control required
+		_velocity_setpoint(2) = _sub_triplet_setpoint->get().current.vz;
+	}
+
+	// Yaw / Yaw-speed
+	if (_sub_triplet_setpoint->get().current.yaw_valid) {
+		// yaw control required
+		_yaw_setpoint = _sub_triplet_setpoint->get().current.yaw;
+	}
+
+	if (_sub_triplet_setpoint->get().current.yawspeed_valid) {
+		_yawspeed_setpoint = _sub_triplet_setpoint->get().current.yawspeed;
+	}
+
+	// Acceleration
+	// Note: this is not supported yet and will be mapped to normalized thrust directly.
+
+	if (_sub_triplet_setpoint->get().current.acceleration_valid) {
+		_thrust_setpoint(0) = _sub_triplet_setpoint->get().current.a_x;
+		_thrust_setpoint(1) = _sub_triplet_setpoint->get().current.a_y;
+		_thrust_setpoint(2) = _sub_triplet_setpoint->get().current.a_z;
+	}
+
+	_position_setpoint.print();
+
+	return true;
+
+}

--- a/src/lib/FlightTasks/tasks/FlightTaskOffboard.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskOffboard.hpp
@@ -1,0 +1,55 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file FlightTaskOffboard.hpp
+ */
+
+#pragma once
+
+#include "FlightTask.hpp"
+#include <uORB/topics/position_setpoint_triplet.h>
+#include <uORB/topics/position_setpoint.h>
+
+class FlightTaskOffboard : public FlightTask
+{
+public:
+	FlightTaskOffboard(control::SuperBlock *parent, const char *name);
+
+	virtual ~FlightTaskOffboard() = default;
+	bool initializeSubscriptions(SubscriptionArray &subscription_array) override;
+	bool update() override;
+
+protected:
+	uORB::Subscription<position_setpoint_triplet_s> *_sub_triplet_setpoint{nullptr};
+};

--- a/src/modules/mc_pos_control/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl.cpp
@@ -178,7 +178,7 @@ void PositionControl::_interfaceMapping()
 void PositionControl::_positionController()
 {
 	// P-position controller
-	Vector3f vel_sp_position = (_pos_sp - _pos).emult(_Pv);
+	Vector3f vel_sp_position = (_pos_sp - _pos).emult(_Pp);
 	_vel_sp = vel_sp_position + _vel_sp;
 
 	// Constrain horizontal velocity by prioritizing the velocity component along the

--- a/src/modules/mc_pos_control/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl.cpp
@@ -45,21 +45,22 @@ using namespace matrix;
 
 PositionControl::PositionControl()
 {
-	_Pz_h   = param_find("MPC_Z_P");
-	_Pvz_h  = param_find("MPC_Z_VEL_P");
-	_Ivz_h  = param_find("MPC_Z_VEL_I");
-	_Dvz_h  = param_find("MPC_Z_VEL_D");
-	_Pxy_h  = param_find("MPC_XY_P");
-	_Pvxy_h = param_find("MPC_XY_VEL_P");
-	_Ivxy_h = param_find("MPC_XY_VEL_I");
-	_Dvxy_h = param_find("MPC_XY_VEL_D");
-	_VelMaxXY_h = param_find("MPC_XY_VEL_MAX");
-	_VelMaxZdown_h = param_find("MPC_Z_VEL_MAX_DN");
-	_VelMaxZup_h = param_find("MPC_Z_VEL_MAX_UP");
-	_ThrHover_h = param_find("MPC_THR_HOVER");
-	_ThrMax_h = param_find("MPC_THR_MAX");
-	_ThrMinPosition_h = param_find("MPC_THR_MIN");
-	_ThrMinStab_h = param_find("MPC_MANTHR_MIN");
+	MPC_Z_P_h   = param_find("MPC_Z_P");
+	MPC_Z_VEL_P_h  = param_find("MPC_Z_VEL_P");
+	MPC_Z_VEL_I_h  = param_find("MPC_Z_VEL_I");
+	MPC_Z_VEL_D_h  = param_find("MPC_Z_VEL_D");
+	MPC_XY_P_h  = param_find("MPC_XY_P");
+	MPC_XY_VEL_P_h = param_find("MPC_XY_VEL_P");
+	MPC_XY_VEL_I_h = param_find("MPC_XY_VEL_I");
+	MPC_XY_VEL_D_h = param_find("MPC_XY_VEL_D");
+	MPC_XY_VEL_MAX_h = param_find("MPC_XY_VEL_MAX");
+	MPC_Z_VEL_MAX_DN_h = param_find("MPC_Z_VEL_MAX_DN");
+	MPC_Z_VEL_MAX_UP_h = param_find("MPC_Z_VEL_MAX_UP");
+	MPC_THR_HOVER_h = param_find("MPC_THR_HOVER");
+	MPC_THR_MAX_h = param_find("MPC_THR_MAX");
+	MPC_THR_MIN_h = param_find("MPC_THR_MIN");
+	MPC_THR_MIN_h = param_find("MPC_MANTHR_MIN");
+	MPC_TILTMAX_AIR_h = param_find("MPC_TILTMAX_AIR");
 	_parameter_sub = orb_subscribe(ORB_ID(parameter_update));
 
 	// set parameter the very first time
@@ -86,24 +87,33 @@ void PositionControl::updateSetpoint(struct vehicle_local_position_setpoint_s se
 
 	// If full manual is required (thrust already generated), don't run position/velocity
 	// controller and just return thrust.
-	_skipController = false;
-	_ThrustLimit.min = _ThrMinPosition;
+	_skip_controller = false;
 
 	if (PX4_ISFINITE(setpoint.thrust[0]) && PX4_ISFINITE(setpoint.thrust[1]) && PX4_ISFINITE(setpoint.thrust[2])) {
-		_skipController = true;
-		_ThrustLimit.min = _ThrMinStab;
-		_pos_sp.zero();
-		_vel_sp.zero();
-		_acc_sp.zero();
+		_skip_controller = true;
 	}
 }
 
 void PositionControl::generateThrustYawSetpoint(const float &dt)
 {
+	if (_skip_controller) {
+		// Already received a valid thrust set-point.
+		// Limit the thrust vector.
+		float thr_mag = _thr_sp.length();
 
-	// Only run position/velocity controller
-	// if thrust needs to be generated.
-	if (!_skipController) {
+		if (thr_mag > MPC_THR_MAX) {
+			_thr_sp = _thr_sp.normalized() * MPC_THR_MAX;
+
+		} else if (thr_mag < MPC_THR_MIN && thr_mag > FLT_EPSILON) {
+			_thr_sp = _thr_sp.normalized() * MPC_THR_MIN;
+		}
+
+		// Just set the set-points equal to the current vehicle state.
+		_pos_sp = _pos;
+		_vel_sp = _vel;
+		_acc_sp = _acc;
+
+	} else {
 		_positionController();
 		_velocityController(dt);
 	}
@@ -158,7 +168,7 @@ void PositionControl::_interfaceMapping()
 	}
 
 	if (!PX4_ISFINITE(_yaw_sp)) {
-		// Set the yaw-sp eaual the current yaw.
+		// Set the yaw-sp equal the current yaw.
 		// That is the best we can do and it also
 		// agrees with FlightTask-interface definition.
 		_yaw_sp = _yaw;
@@ -168,17 +178,17 @@ void PositionControl::_interfaceMapping()
 void PositionControl::_positionController()
 {
 	// P-position controller
-	Vector3f vel_sp_position = (_pos_sp - _pos).emult(Pp);
+	Vector3f vel_sp_position = (_pos_sp - _pos).emult(_Pv);
 	_vel_sp = vel_sp_position + _vel_sp;
 
 	// Constrain horizontal velocity by prioritizing the velocity component along the
 	// the desired position setpoint over the feed-forward term.
-	Vector2f vel_sp_xy = ControlMath::constrainXY(Vector2f(&vel_sp_position(0)), Vector2f(&(_vel_sp - vel_sp_position)(0)),
-			     _VelMaxXY);
+	Vector2f vel_sp_xy = ControlMath::constrainXY(Vector2f(&vel_sp_position(0)),
+			     Vector2f(&(_vel_sp - vel_sp_position)(0)), MPC_XY_VEL_MAX);
 	_vel_sp(0) = vel_sp_xy(0);
 	_vel_sp(1) = vel_sp_xy(1);
-	// Constrain velocity in z-directio.
-	_vel_sp(2) = math::constrain(_vel_sp(2), -_VelMaxZ.up, _VelMaxZ.down);
+	// Constrain velocity in z-direction.
+	_vel_sp(2) = math::constrain(_vel_sp(2), -_constraints.vel_max_z_up, MPC_Z_VEL_MAX_DN);
 }
 
 void PositionControl::_velocityController(const float &dt)
@@ -211,18 +221,18 @@ void PositionControl::_velocityController(const float &dt)
 	Vector3f vel_err = _vel_sp - _vel;
 
 	// Consider thrust in D-direction.
-	float thrust_desired_D = Pv(2) * vel_err(2) + Dv(2) * _vel_dot(2) + _thr_int(2) - _ThrHover;
+	float thrust_desired_D = _Pv(2) * vel_err(2) + _Dv(2) * _vel_dot(2) + _thr_int(2) - MPC_THR_HOVER;
 
 	// The Thrust limits are negated and swapped due to NED-frame.
-	float uMax = -_ThrustLimit.min;
-	float uMin = -_ThrustLimit.max;
+	float uMax = -MPC_THR_MIN;
+	float uMin = -MPC_THR_MAX;
 
 	// Apply Anti-Windup in D-direction.
 	bool stop_integral_D = (thrust_desired_D >= uMax && vel_err(2) >= 0.0f) ||
 			       (thrust_desired_D <= uMin && vel_err(2) <= 0.0f);
 
 	if (!stop_integral_D) {
-		_thr_int(2) += vel_err(2) * Iv(2) * dt;
+		_thr_int(2) += vel_err(2) * _Iv(2) * dt;
 
 	}
 
@@ -232,19 +242,19 @@ void PositionControl::_velocityController(const float &dt)
 	if (fabsf(_thr_sp(0)) + fabsf(_thr_sp(1))  > FLT_EPSILON) {
 		// Thrust set-point in NE-direction is already provided. Only
 		// scaling by the maximum tilt is required.
-		float thr_xy_max = fabsf(_thr_sp(2)) * tanf(_tilt_max);
+		float thr_xy_max = fabsf(_thr_sp(2)) * tanf(MPC_MAN_TILT_MAX);
 		_thr_sp(0) *= thr_xy_max;
 		_thr_sp(1) *= thr_xy_max;
 
 	} else {
 		// PID-velocity controller for NE-direction.
 		Vector2f thrust_desired_NE;
-		thrust_desired_NE(0) = Pv(0) * vel_err(0) + Dv(0) * _vel_dot(0) + _thr_int(0);
-		thrust_desired_NE(1) = Pv(1) * vel_err(1) + Dv(1) * _vel_dot(1) + _thr_int(1);
+		thrust_desired_NE(0) = _Pv(0) * vel_err(0) + _Dv(0) * _vel_dot(0) + _thr_int(0);
+		thrust_desired_NE(1) = _Pv(1) * vel_err(1) + _Dv(1) * _vel_dot(1) + _thr_int(1);
 
 		// Get maximum allowed thrust in NE based on tilt and excess thrust.
-		float thrust_max_NE_tilt = fabsf(_thr_sp(2)) * tanf(_tilt_max);
-		float thrust_max_NE = sqrtf(_ThrustLimit.max * _ThrustLimit.max - _thr_sp(2) * _thr_sp(2));
+		float thrust_max_NE_tilt = fabsf(_thr_sp(2)) * tanf(_constraints.tilt_max);
+		float thrust_max_NE = sqrtf(MPC_THR_MAX * MPC_THR_MAX - _thr_sp(2) * _thr_sp(2));
 		thrust_max_NE = math::min(thrust_max_NE_tilt, thrust_max_NE);
 
 		// Get the direction of (r-y) in NE-direction.
@@ -255,8 +265,8 @@ void PositionControl::_velocityController(const float &dt)
 					 direction_NE >= 0.0f);
 
 		if (!stop_integral_NE) {
-			_thr_int(0) += vel_err(0) * Iv(0) * dt;
-			_thr_int(1) += vel_err(1) * Iv(1) * dt;
+			_thr_int(0) += vel_err(0) * _Iv(0) * dt;
+			_thr_int(1) += vel_err(1) * _Iv(1) * dt;
 		}
 
 		// Saturate thrust in NE-direction.
@@ -277,16 +287,16 @@ void PositionControl::updateConstraints(const Controller::Constraints &constrain
 	// update all parameters since they might have changed
 	_updateParams();
 
-	// maximum tilt cannot exceed 90 degrees
-	_tilt_max = M_PI_2_F;
+	_constraints = constraints;
 
-	if (PX4_ISFINITE(constraints.tilt_max)) {
-		_tilt_max = math::min(constraints.tilt_max, _tilt_max);
+	// Check if adustable contraints are below global constraints. If they are not stricter than global
+	// constraints, then just use global constraints for the limits.
+	if (!PX4_ISFINITE(constraints.tilt_max) || !(constraints.tilt_max < MPC_TILTMAX_AIR)) {
+		_constraints.tilt_max = MPC_TILTMAX_AIR;
 	}
 
-	// maximum velocity upwards cannot exceed global limit
-	if (PX4_ISFINITE(constraints.vel_max_z_up)) {
-		_VelMaxZ.up = math::min(constraints.vel_max_z_up, _VelMaxZ.up);
+	if (!PX4_ISFINITE(constraints.vel_max_z_up) || !(constraints.vel_max_z_up < MPC_Z_VEL_MAX_UP)) {
+		_constraints.vel_max_z_up = MPC_Z_VEL_MAX_UP;
 	}
 }
 
@@ -304,29 +314,25 @@ void PositionControl::_updateParams()
 
 void PositionControl::_setParams()
 {
-	param_get(_Pxy_h, &Pp(0));
-	param_get(_Pxy_h, &Pp(1));
-	param_get(_Pz_h, &Pp(2));
-
-	param_get(_Pvxy_h, &Pv(0));
-	param_get(_Pvxy_h, &Pv(1));
-	param_get(_Pvz_h, &Pv(2));
-
-	param_get(_Ivxy_h, &Iv(0));
-	param_get(_Ivxy_h, &Iv(1));
-	param_get(_Ivz_h, &Iv(2));
-
-	param_get(_Dvxy_h, &Dv(0));
-	param_get(_Dvxy_h, &Dv(1));
-	param_get(_Dvz_h, &Dv(2));
-
-	param_get(_VelMaxXY_h, &_VelMaxXY);
-	param_get(_VelMaxZup_h, &_VelMaxZ.up);
-	param_get(_VelMaxZdown_h, &_VelMaxZ.down);
-
-	param_get(_ThrHover_h, &_ThrHover);
-	param_get(_ThrMax_h, &_ThrustLimit.max);
-	param_get(_ThrMinPosition_h, &_ThrMinPosition);
-	param_get(_ThrMinStab_h, &_ThrMinStab);
-
+	param_get(MPC_XY_P_h, &_Pp(0));
+	param_get(MPC_XY_P_h, &_Pp(1));
+	param_get(MPC_Z_P_h, &_Pp(2));
+	param_get(MPC_XY_VEL_P_h, &_Pv(0));
+	param_get(MPC_XY_VEL_P_h, &_Pv(1));
+	param_get(MPC_Z_VEL_P_h, &_Pv(2));
+	param_get(MPC_XY_VEL_I_h, &_Iv(0));
+	param_get(MPC_XY_VEL_I_h, &_Iv(1));
+	param_get(MPC_Z_VEL_I_h, &_Iv(2));
+	param_get(MPC_XY_VEL_D_h, &_Dv(0));
+	param_get(MPC_XY_VEL_D_h, &_Dv(1));
+	param_get(MPC_Z_VEL_D_h, &_Dv(2));
+	param_get(MPC_XY_VEL_MAX_h, &MPC_XY_VEL_MAX);
+	param_get(MPC_Z_VEL_MAX_UP_h, &MPC_Z_VEL_MAX_UP);
+	param_get(MPC_Z_VEL_MAX_DN_h, &MPC_Z_VEL_MAX_DN);
+	param_get(MPC_THR_HOVER_h, &MPC_THR_HOVER);
+	param_get(MPC_THR_MAX_h, &MPC_THR_MAX);
+	param_get(MPC_THR_MIN_h, &MPC_THR_MIN);
+	param_get(MPC_MANTHR_MIN_h, &MPC_MANTHR_MIN);
+	param_get(MPC_TILTMAX_AIR_h, &MPC_TILTMAX_AIR);
+	param_get(MPC_MAN_TILT_MAX_h, &MPC_MAN_TILT_MAX);
 }

--- a/src/modules/mc_pos_control/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl.cpp
@@ -79,16 +79,6 @@ void PositionControl::updateState(const struct vehicle_local_position_s state, c
 	_vel_dot = vel_dot;
 }
 
-void PositionControl::setIdle()
-{
-	_pos_sp = _pos;
-	_vel_sp.zero();
-	_acc_sp.zero();
-	_thr_sp.zero();
-	_yaw_sp = _yaw_sp_int = _yaw;
-	_yawspeed_sp = 0.0f;
-}
-
 void PositionControl::updateSetpoint(struct vehicle_local_position_setpoint_s setpoint)
 {
 	_pos_sp = Vector3f(&setpoint.x);

--- a/src/modules/mc_pos_control/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl.cpp
@@ -61,6 +61,7 @@ PositionControl::PositionControl()
 	MPC_THR_MIN_h = param_find("MPC_THR_MIN");
 	MPC_THR_MIN_h = param_find("MPC_MANTHR_MIN");
 	MPC_TILTMAX_AIR_h = param_find("MPC_TILTMAX_AIR");
+	MPC_MAN_TILT_MAX_h = param_find("MPC_MAN_TILT_MAX");
 	_parameter_sub = orb_subscribe(ORB_ID(parameter_update));
 
 	// set parameter the very first time
@@ -334,5 +335,8 @@ void PositionControl::_setParams()
 	param_get(MPC_THR_MIN_h, &MPC_THR_MIN);
 	param_get(MPC_MANTHR_MIN_h, &MPC_MANTHR_MIN);
 	param_get(MPC_TILTMAX_AIR_h, &MPC_TILTMAX_AIR);
+	MPC_TILTMAX_AIR = math::radians(MPC_TILTMAX_AIR);
 	param_get(MPC_MAN_TILT_MAX_h, &MPC_MAN_TILT_MAX);
+	MPC_MAN_TILT_MAX = math::radians(MPC_MAN_TILT_MAX);
+
 }

--- a/src/modules/mc_pos_control/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl.cpp
@@ -67,6 +67,7 @@ PositionControl::PositionControl()
 	_ThrMax_h = param_find("MPC_THR_MAX");
 	_ThrMinPosition_h = param_find("MPC_THR_MIN");
 	_ThrMinStab_h = param_find("MPC_MANTHR_MIN");
+	_parameter_sub = orb_subscribe(ORB_ID(parameter_update));
 
 	/* Set parameter the very first time. */
 	_setParams();

--- a/src/modules/mc_pos_control/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl.cpp
@@ -227,10 +227,6 @@ void PositionControl::_velocityController(const float &dt)
 
 	Vector3f vel_err = _vel_sp - _vel;
 
-	/*
-	 * TODO: add offboard acceleration mode
-	 * */
-
 	/* Consider thrust in D-direction */
 	float thrust_desired_D = Pv(2) * vel_err(2) + Dv(2) * _vel_dot(2) + _thr_int(2) - _ThrHover;
 

--- a/src/modules/mc_pos_control/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl.cpp
@@ -95,11 +95,11 @@ void PositionControl::updateSetpoint(struct vehicle_local_position_setpoint_s se
 	 * controller and just return thrust.
 	 */
 	_skipController = false;
-	_ThrLimit[1] = _ThrMinPosition;
+	_ThrustLimit.min = _ThrMinPosition;
 
 	if (PX4_ISFINITE(setpoint.thrust[0]) && PX4_ISFINITE(setpoint.thrust[1]) && PX4_ISFINITE(setpoint.thrust[2])) {
 		_skipController = true;
-		_ThrLimit[1] = _ThrMinStab;
+		_ThrustLimit.min = _ThrMinStab;
 		_pos_sp.zero();
 		_vel_sp.zero();
 		_acc_sp.zero();
@@ -188,7 +188,7 @@ void PositionControl::_positionController()
 			     _VelMaxXY);
 	_vel_sp(0) = vel_sp_xy(0);
 	_vel_sp(1) = vel_sp_xy(1);
-	_vel_sp(2) = math::constrain(_vel_sp(2), -_VelMaxZ[0], _VelMaxZ[1]);
+	_vel_sp(2) = math::constrain(_vel_sp(2), -_VelMaxZ.up, _VelMaxZ.down);
 }
 
 void PositionControl::_velocityController(const float &dt)
@@ -333,7 +333,7 @@ void PositionControl::_setParams()
 	param_get(_VelMaxZdown_h, &_VelMaxZ.down);
 
 	param_get(_ThrHover_h, &_ThrHover);
-	param_get(_ThrMax_h, &_ThrLimit[0]);
+	param_get(_ThrMax_h, &_ThrustLimit.max);
 	param_get(_ThrMinPosition_h, &_ThrMinPosition);
 	param_get(_ThrMinStab_h, &_ThrMinStab);
 }

--- a/src/modules/mc_pos_control/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl.cpp
@@ -188,7 +188,7 @@ void PositionControl::_positionController()
 			     _VelMaxXY);
 	_vel_sp(0) = vel_sp_xy(0);
 	_vel_sp(1) = vel_sp_xy(1);
-	_vel_sp(2) = math::constrain(_vel_sp(2), -_VelMaxZ.up, _VelMaxZ.down);
+	_vel_sp(2) = math::constrain(_vel_sp(2), -_constraints.vel_max_z_up, _VelMaxZ.down);
 }
 
 void PositionControl::_velocityController(const float &dt)

--- a/src/modules/mc_pos_control/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl.cpp
@@ -65,7 +65,8 @@ PositionControl::PositionControl()
 	_VelMaxZup_h = param_find("MPC_Z_VEL_MAX_UP");
 	_ThrHover_h = param_find("MPC_THR_HOVER");
 	_ThrMax_h = param_find("MPC_THR_MAX");
-	_ThrMin_h = param_find("MPC_THR_MIN");
+	_ThrMinPosition_h = param_find("MPC_THR_MIN");
+	_ThrMinStab_h = param_find("MPC_MANTHR_MIN");
 
 	/* Set parameter the very first time. */
 	_setParams();
@@ -93,9 +94,11 @@ void PositionControl::updateSetpoint(struct vehicle_local_position_setpoint_s se
 	 * controller and just return thrust.
 	 */
 	_skipController = false;
+	_ThrLimit[1] = _ThrMinPosition;
 
 	if (PX4_ISFINITE(setpoint.thrust[0]) && PX4_ISFINITE(setpoint.thrust[1]) && PX4_ISFINITE(setpoint.thrust[2])) {
 		_skipController = true;
+		_ThrLimit[1] = _ThrMinStab;
 		_pos_sp.zero();
 		_vel_sp.zero();
 		_acc_sp.zero();
@@ -333,6 +336,7 @@ void PositionControl::_setParams()
 	param_get(_VelMaxZdown_h, &_VelMaxZ.down);
 
 	param_get(_ThrHover_h, &_ThrHover);
-	param_get(_ThrMax_h, &_ThrustLimit.max);
-	param_get(_ThrMin_h, &_ThrustLimit.min);
+	param_get(_ThrMax_h, &_ThrLimit[0]);
+	param_get(_ThrMinPosition_h, &_ThrMinPosition);
+	param_get(_ThrMinStab_h, &_ThrMinStab);
 }

--- a/src/modules/mc_pos_control/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl.hpp
@@ -111,7 +111,8 @@ private:
 	param_t _VelMaxZup_h{PARAM_INVALID};
 	param_t _ThrHover_h{PARAM_INVALID};
 	param_t _ThrMax_h{PARAM_INVALID};
-	param_t _ThrMin_h{PARAM_INVALID};
+	param_t _ThrMinPosition_h{PARAM_INVALID};
+	param_t _ThrMinStab_h{PARAM_INVALID};
 
 	/* Parameters */
 	matrix::Vector3f Pp, Pv, Iv, Dv = matrix::Vector3f{0.0f, 0.0f, 0.0f};
@@ -129,6 +130,8 @@ private:
 	float _ThrHover{0.5f};
 
 	float _ThrLimit[2]; //index 0: max, index 1: min
+	float _ThrMinPosition{0.0f}; // minimum throttle for any position controlled mode
+	float _ThrMinStab{0.0f}; // minimum throttle for stabilized
 	bool _skipController{false};
 
 	/* Helper methods */

--- a/src/modules/mc_pos_control/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl.hpp
@@ -68,6 +68,8 @@ public:
 	void updateSetpoint(struct vehicle_local_position_setpoint_s setpoint);
 	void updateConstraints(const Controller::Constraints &constraints);
 	void generateThrustYawSetpoint(const float &dt);
+	void resetIntegralXY() {_thr_int(0) = _thr_int(1) = 0.0f;};
+	void resetIntegralZ() {_thr_int(2) = 0.0f;};
 
 	matrix::Vector3f getThrustSetpoint() {return _thr_sp;}
 	float getYawSetpoint() { return _yaw_sp;}

--- a/src/modules/mc_pos_control/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl.hpp
@@ -54,6 +54,9 @@ namespace Controller
 {
 struct Constraints {
 	float tilt_max;
+	float vel_max_z_up;
+	float vel_max_z_down;
+	float vel_max_xy;
 };
 }
 

--- a/src/modules/mc_pos_control/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,9 +34,7 @@
 /**
  * @file PositionControl.hpp
  *
- * @inputs: position-, velocity-, acceleration-, thrust-setpoints
- * @outputs: thrust vector
- *
+ * A cascaded position controller for position/velocity control only.
  */
 
 #include <matrix/matrix/math.hpp>
@@ -47,100 +45,189 @@
 
 #pragma once
 
-/* Constraints based on mode:
- * Eventually this structure should be part of local position message
- */
 namespace Controller
 {
+/** Constraints that depends on mode and are lower
+ * 	than the global limits.
+ * 	tilt_max: Cannot exceed PI/2
+ * 	vel_max_z_up: Cannot exceed maximum global velocity upwards
+ * @see _tilt_max
+ * @see _VelMaxZ
+ */
 struct Constraints {
-	float tilt_max;
-	float vel_max_z_up;
+	float tilt_max; /**< maximum tilt always below Pi/2 */
+	float vel_max_z_up; /**< maximum speed upwards always smaller than MPC_VEL_Z_MAX_UP */
 };
 }
-
+/**
+ * 	Core Position-Control for MC.
+ * 	This class contains P-controller for position and
+ * 	PID-controller for velocity.
+ * 	Inputs:
+ * 		vehicle position/velocity/yaw
+ * 		desired set-point position/velocity/thrust/yaw/yaw-speed
+ * 		constraints that are stricter than global limits
+ * 	Output
+ * 		thrust vector and a yaw-setpoint
+ *
+ * 	If there is a position and a velocity set-point present, then
+ * 	the velocity set-point is used as feed-forward. If feed-forward is
+ * 	active, then the velocity component of the P-controller output has
+ * 	priority over the feed-forward component.
+ *
+ * 	A setpoint that is NAN is considered as not set.
+ */
 class PositionControl
 {
 public:
-	PositionControl();
 
+	PositionControl();
 	~PositionControl() {};
 
+	/**
+	 * Update the current vehicle state.
+	 * @param state a vehicle_local_position_s structure
+	 * @param vel_dot the derivative of the vehicle velocity
+	 */
 	void updateState(const struct vehicle_local_position_s state, const matrix::Vector3f &vel_dot);
+
+	/**
+	 * Update the desired setpoints.
+	 * @param setpoint a vehicle_local_position_setpoint_s structure
+	 */
 	void updateSetpoint(struct vehicle_local_position_setpoint_s setpoint);
+
+	/**
+	 * Set constraints that are stricter than the global limits.
+	 * @param constraints a PositionControl structure with supported constraints
+	 */
 	void updateConstraints(const Controller::Constraints &constraints);
+
+	/**
+	 * Apply P-position and PID-velocity controller that updates the member
+	 * thrust, yaw- and yawspeed-setpoints.
+	 * @see _thr_sp
+	 * @see _yaw_sp
+	 * @see _yawspeed_sp
+	 * @param dt the delta-time
+	 */
 	void generateThrustYawSetpoint(const float &dt);
+
+	/**
+	 * 	Set the integral term in xy to 0.
+	 * 	@see _thr_int
+	 */
 	void resetIntegralXY() {_thr_int(0) = _thr_int(1) = 0.0f;};
+
+	/**
+	 * 	Set the integral term in z to 0.
+	 * 	@see _thr_int
+	 */
 	void resetIntegralZ() {_thr_int(2) = 0.0f;};
 
+	/**
+	 * 	Get the
+	 * 	@see _thr_sp
+	 * 	@return The thrust set-point member.
+	 */
 	matrix::Vector3f getThrustSetpoint() {return _thr_sp;}
+
+	/**
+	 * 	Get the
+	 * 	@see _yaw_sp
+	 * 	@return The yaw set-point member.
+	 */
 	float getYawSetpoint() { return _yaw_sp;}
+
+	/**
+	 * 	Get the
+	 * 	@see _yawspeed_sp
+	 * 	@return The yawspeed set-point member.
+	 */
 	float getYawspeedSetpoint() {return _yawspeed_sp;}
+
+	/**
+	 * 	Get the
+	 * 	@see _vel_sp
+	 * 	@return The velocity set-point member.
+	 */
 	matrix::Vector3f getVelSp() {return _vel_sp;}
+
+	/**
+	 * 	Get the
+	 * 	@see _pos_sp
+	 * 	@return The position set-point member.
+	 */
 	matrix::Vector3f getPosSp() {return _pos_sp;}
 
 private:
 
-	/* States */
-	matrix::Vector3f _pos{};
-	matrix::Vector3f _vel{};
-	matrix::Vector3f _vel_dot{};
-	matrix::Vector3f _acc{};
-	float _yaw{0.0f};
+	matrix::Vector3f _pos{}; /**< MC position */
+	matrix::Vector3f _vel{}; /**< MC velocity */
+	matrix::Vector3f _vel_dot{}; /**< MC velocity derivative */
+	matrix::Vector3f _acc{}; /**< MC acceleration */
+	float _yaw{0.0f}; /**< MC yaw */
 
-	/* Setpoints */
-	matrix::Vector3f _pos_sp{};
-	matrix::Vector3f _vel_sp{};
-	matrix::Vector3f _acc_sp{};
-	matrix::Vector3f _thr_sp{};
-	float _yaw_sp{};
-	float _yawspeed_sp{};
+	matrix::Vector3f _pos_sp{}; /**< desired position */
+	matrix::Vector3f _vel_sp{}; /**< desired velocity */
+	matrix::Vector3f _acc_sp{}; /**< desired acceleration: not supported yet */
+	matrix::Vector3f _thr_sp{}; /**< desired thrust */
+	float _yaw_sp{}; /**< desired yaw */
+	float _yawspeed_sp{}; /** desired yaw-speed */
 
-	/* Other variables */
-	matrix::Vector3f _thr_int{};
-	Controller::Constraints _constraints{};
+	matrix::Vector3f _thr_int{}; /**< thrust integral term */
+	Controller::Constraints _constraints{}; /**< variable constraints */
 
-	/* Parameter handles */
-	int _parameter_sub{-1};
-	param_t _Pz_h{PARAM_INVALID};
-	param_t _Pvz_h{PARAM_INVALID};
-	param_t _Ivz_h{PARAM_INVALID};
-	param_t _Dvz_h{PARAM_INVALID};
-	param_t _Pxy_h{PARAM_INVALID};
-	param_t _Pvxy_h{PARAM_INVALID};
-	param_t _Ivxy_h{PARAM_INVALID};
-	param_t _Dvxy_h{PARAM_INVALID};
-	param_t _VelMaxXY_h{PARAM_INVALID};
-	param_t _VelMaxZdown_h{PARAM_INVALID};
-	param_t _VelMaxZup_h{PARAM_INVALID};
-	param_t _ThrHover_h{PARAM_INVALID};
-	param_t _ThrMax_h{PARAM_INVALID};
-	param_t _ThrMinPosition_h{PARAM_INVALID};
-	param_t _ThrMinStab_h{PARAM_INVALID};
-
-	/* Parameters */
+	/**
+	 * Position Gains.
+	 * Pp: P-controller gain for position-controller
+	 * Pv: P-controller gain for velocity-controller
+	 * Iv: I-controller gain for velocity-controller
+	 * Dv: D-controller gain for velocity-controller
+	 */
 	matrix::Vector3f Pp, Pv, Iv, Dv = matrix::Vector3f{0.0f, 0.0f, 0.0f};
-	float _VelMaxXY{};
+
+	float _VelMaxXY{}; /**< maximum global limit for velocity in the horizontal direction */
+
 	struct DirectionD {
 		float up;
 		float down;
 	};
-	DirectionD _VelMaxZ;
+	DirectionD _VelMaxZ; /**< struct for velocity limits in the z-direction */
+
 	struct Limits {
 		float max;
 		float min;
 	};
-	Limits _ThrustLimit;
+	Limits _ThrustLimit; /**< struct for thrust-limits */
 
-	float _ThrHover{0.5f};
-	float _ThrMinPosition{0.0f}; // minimum throttle for any position controlled mode
-	float _ThrMinStab{0.0f}; // minimum throttle for stabilized
-	float _tilt_max{1.5f}; /**< maximum tilt */
-	bool _skipController{false};
+	float _ThrHover{0.5f}; /** equilibrium point for the velocity controller */
+	float _ThrMinPosition{0.0f}; /**< minimum throttle for any position controlled mode */
+	float _ThrMinStab{0.0f}; /**< minimum throttle for stabilized mode */
+	float _tilt_max{1.5f}; /**< maximum tilt for any velocity controlled mode. */
+	bool _skipController{false}; /**< skips position/velocity controller. true for stabilized mode */
 
-	/* Helper methods */
-	void _interfaceMapping();
-	void _positionController();
-	void _velocityController(const float &dt);
-	void _updateParams();
-	void _setParams();
+	void _interfaceMapping(); /** maps setpoints to internal member setpoints */
+	void _positionController(); /** applies the P-position-controller */
+	void _velocityController(const float &dt); /** applies the PID-velocity-controller */
+	void _updateParams(); /** updates parameters */
+	void _setParams(); /** sets parameters to internal member */
+
+	// Parameter handles
+	int _parameter_sub { -1 };
+	param_t _Pz_h { PARAM_INVALID };
+	param_t _Pvz_h { PARAM_INVALID };
+	param_t _Ivz_h { PARAM_INVALID };
+	param_t _Dvz_h { PARAM_INVALID };
+	param_t _Pxy_h { PARAM_INVALID };
+	param_t _Pvxy_h { PARAM_INVALID };
+	param_t _Ivxy_h { PARAM_INVALID };
+	param_t _Dvxy_h { PARAM_INVALID };
+	param_t _VelMaxXY_h { PARAM_INVALID };
+	param_t _VelMaxZdown_h { PARAM_INVALID };
+	param_t _VelMaxZup_h { PARAM_INVALID };
+	param_t _ThrHover_h { PARAM_INVALID };
+	param_t _ThrMax_h { PARAM_INVALID };
+	param_t _ThrMinPosition_h { PARAM_INVALID };
+	param_t _ThrMinStab_h { PARAM_INVALID };
 };

--- a/src/modules/mc_pos_control/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl.hpp
@@ -127,9 +127,8 @@ private:
 		float min;
 	};
 	Limits _ThrustLimit;
-	float _ThrHover{0.5f};
 
-	float _ThrLimit[2]; //index 0: max, index 1: min
+	float _ThrHover{0.5f};
 	float _ThrMinPosition{0.0f}; // minimum throttle for any position controlled mode
 	float _ThrMinStab{0.0f}; // minimum throttle for stabilized
 	bool _skipController{false};

--- a/src/modules/mc_pos_control/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl.hpp
@@ -55,8 +55,6 @@ namespace Controller
 struct Constraints {
 	float tilt_max;
 	float vel_max_z_up;
-	float vel_max_z_down;
-	float vel_max_xy;
 };
 }
 
@@ -136,6 +134,7 @@ private:
 	float _ThrHover{0.5f};
 	float _ThrMinPosition{0.0f}; // minimum throttle for any position controlled mode
 	float _ThrMinStab{0.0f}; // minimum throttle for stabilized
+	float _tilt_max{1.5f}; /**< maximum tilt */
 	bool _skipController{false};
 
 	/* Helper methods */

--- a/src/modules/mc_pos_control/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl.hpp
@@ -49,7 +49,7 @@ namespace Controller
 {
 /** Constraints that depends on mode and are lower
  * 	than the global limits.
- * 	tilt_max: Cannot exceed PI/2
+ * 	tilt_max: Cannot exceed PI/2 radians
  * 	vel_max_z_up: Cannot exceed maximum global velocity upwards
  * @see MPC_TILTMAX_AIR
  * @see MPC_Z_VEL_MAX_DN
@@ -198,8 +198,8 @@ private:
 	float MPC_XY_VEL_MAX{1.0f}; /**< maximum speed in the horizontal direction */
 	float MPC_Z_VEL_MAX_DN{1.0f}; /**< maximum speed in downwards direction */
 	float MPC_Z_VEL_MAX_UP{1.0f}; /**< maximum speed in upwards direction */
-	float MPC_TILTMAX_AIR{1.5}; /**< maximum tilt for any position/velocity controlled mode */
-	float MPC_MAN_TILT_MAX{3.1}; /**< maximum tilt for manual/altitude mode */
+	float MPC_TILTMAX_AIR{1.5}; /**< maximum tilt for any position/velocity controlled mode in radians */
+	float MPC_MAN_TILT_MAX{3.1}; /**< maximum tilt for manual/altitude mode in radians */
 
 	// Parameter handles
 	int _parameter_sub { -1 };

--- a/src/modules/mc_pos_control/Utility/ControlMath.cpp
+++ b/src/modules/mc_pos_control/Utility/ControlMath.cpp
@@ -1,7 +1,7 @@
 
 /****************************************************************************
  *
- *   Copyright (C) 2017 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,11 +34,7 @@
 
 /**
  * @file ControlMath.cpp
- *
- * Simple functions for vector manipulation that do not fit into matrix lib.
- * These functions are specific for controls.
  */
-
 
 #include "ControlMath.hpp"
 #include <platforms/px4_defines.h>
@@ -49,30 +45,29 @@ namespace ControlMath
 {
 vehicle_attitude_setpoint_s thrustToAttitude(const matrix::Vector3f &thr_sp, const float yaw_sp)
 {
-
 	vehicle_attitude_setpoint_s att_sp;
 	att_sp.yaw_body = yaw_sp;
 
-	/* desired body_z axis = -normalize(thrust_vector) */
+	// desired body_z axis = -normalize(thrust_vector)
 	matrix::Vector3f body_x, body_y, body_z;
 
 	if (thr_sp.length() > 0.00001f) {
 		body_z = -thr_sp.normalized();
 
 	} else {
-		/* no thrust, set Z axis to safe value */
+		// no thrust, set Z axis to safe value
 		body_z.zero();
 		body_z(2) = 1.0f;
 	}
 
-	/* vector of desired yaw direction in XY plane, rotated by PI/2 */
+	// vector of desired yaw direction in XY plane, rotated by PI/2
 	matrix::Vector3f y_C(-sinf(att_sp.yaw_body), cosf(att_sp.yaw_body), 0.0f);
 
 	if (fabsf(body_z(2)) > 0.000001f) {
-		/* desired body_x axis, orthogonal to body_z */
+		// desired body_x axis, orthogonal to body_z
 		body_x = y_C % body_z;
 
-		/* keep nose to front while inverted upside down */
+		// keep nose to front while inverted upside down
 		if (body_z(2) < 0.0f) {
 			body_x = -body_x;
 		}
@@ -80,107 +75,96 @@ vehicle_attitude_setpoint_s thrustToAttitude(const matrix::Vector3f &thr_sp, con
 		body_x.normalize();
 
 	} else {
-		/* desired thrust is in XY plane, set X downside to construct correct matrix,
-		 * but yaw component will not be used actually */
+		// desired thrust is in XY plane, set X downside to construct correct matrix,
+		// but yaw component will not be used actually
 		body_x.zero();
 		body_x(2) = 1.0f;
 	}
 
-	/* desired body_y axis */
+	// desired body_y axis
 	body_y = body_z % body_x;
 
 	matrix::Dcmf R_sp;
 
-	/* fill rotation matrix */
+	// fill rotation matrix
 	for (int i = 0; i < 3; i++) {
 		R_sp(i, 0) = body_x(i);
 		R_sp(i, 1) = body_y(i);
 		R_sp(i, 2) = body_z(i);
 	}
 
-	/* copy quaternion setpoint to attitude setpoint topic */
+	//copy quaternion setpoint to attitude setpoint topic
 	matrix::Quatf q_sp = R_sp;
 	q_sp.copyTo(att_sp.q_d);
 	att_sp.q_d_valid = true;
 
-	/* calculate euler angles, for logging only, must not be used for control */
+	// calculate euler angles, for logging only, must not be used for control
 	matrix::Eulerf euler = R_sp;
 	att_sp.roll_body = euler(0);
 	att_sp.pitch_body = euler(1);
 
-	/* fill and publish att_sp message */
+	// fill and publish att_sp message
 	att_sp.thrust = thr_sp.length();
 
 	return att_sp;
 }
-
-/* The sum of two vectors are constraint such that v0 has priority over v1.
- * This means that if the length of v0+v1 exceeds max, then it is constraint such
- * that v0 has priority.
- * Inputs:
- * @max: maximum magnitude of vector (v0 + v1)
- * @v0: vector that is prioritized
- * @v1: vector that is scaled such that max is not exceeded
- * @return: vector that is the sum of v1 and v0 with v0 prioritized.
- */
 matrix::Vector2f constrainXY(const matrix::Vector2f &v0, const matrix::Vector2f &v1, const float max)
 {
 	if (matrix::Vector2f(v0 + v1).norm() <= max) {
-		/* Vector does not exceed maximum magnitude */
+		// vector does not exceed maximum magnitude
 		return v0 + v1;
 
 	} else if (v0.length() >= max) {
-		/* The magnitude along v0, which has priority, already exceeds maximum.*/
+		// the magnitude along v0, which has priority, already exceeds maximum.
 		return v0.normalized() * max;
 
 	} else if (fabsf(matrix::Vector2f(v1 - v0).norm()) < 0.001f) {
-		/* The two vectors are equal. */
+		// the two vectors are equal
 		return v0.normalized() * max;
 
 	} else if (v0.length() < 0.001f) {
-		/* The first vector is 0. */
+		// the first vector is 0.
 		return v1.normalized() * max;
 
 	} else {
-		/*
-		 * vf = final vector with ||vf|| <= max
-		 * s = scaling factor
-		 * u1 = unit of v1
-		 * vf = v0 + v1 = v0 + s * u1
-		 * constraint: ||vf|| <= max
-		 *
-		 * solve for s: ||vf|| = ||v0 + s * u1|| <= max
-		 *
-		 * Derivation:
-		 * For simplicity, replace v0 -> v, u1 -> u
-		 * 				   		   v0(0/1/2) -> v0/1/2
-		 * 				   		   u1(0/1/2) -> u0/1/2
-		 *
-		 * ||v + s * u||^2 = (v0+s*u0)^2+(v1+s*u1)^2+(v1+s*u1)^2 = max^2
-		 * v0^2+2*s*u0*v0+s^2*u0^2 + v1^2+2*s*u1*v1+s^2*u1^2 + v2^2+2*s*u2*v2+s^2*u2^2 = max^2
-		 * s^2*(u0^2+u1^2+u2^2) + s*2*(u0*v0+u1*v1+u2*v2) + (v0^2+v1^2+v2^2-max^2) = 0
-		 *
-		 * quadratic equation:
-		 * -> s^2*a + s*b + c = 0 with solution: s1/2 = (-b +- sqrt(b^2 - 4*a*c))/(2*a)
-		 *
-		 * b = 2 * u.dot(v)
-		 * a = 1 (because u is normalized)
-		 * c = (v0^2+v1^2+v2^2-max^2) = -max^2 + ||v||^2
-		 *
-		 * sqrt(b^2 - 4*a*c) =
-		 * 		sqrt(4*u.dot(v)^2 - 4*(||v||^2 - max^2)) = 2*sqrt(u.dot(v)^2 +- (||v||^2 -max^2))
-		 *
-		 * s1/2 = ( -2*u.dot(v) +- 2*sqrt(u.dot(v)^2 - (||v||^2 -max^2)) / 2
-		 *      =  -u.dot(v) +- sqrt(u.dot(v)^2 - (||v||^2 -max^2))
-		 * m = u.dot(v)
-		 * s = -m + sqrt(m^2 - c)
-		 *
-		 *
-		 *
-		 * notes:
-		 * 	- s (=scaling factor) needs to be positive
-		 * 	- (max - ||v||) always larger than zero, otherwise it never entered this if-statement
-		 * */
+		// vf = final vector with ||vf|| <= max
+		// s = scaling factor
+		// u1 = unit of v1
+		// vf = v0 + v1 = v0 + s * u1
+		// constraint: ||vf|| <= max
+		//
+		// solve for s: ||vf|| = ||v0 + s * u1|| <= max
+		//
+		// Derivation:
+		// For simplicity, replace v0 -> v, u1 -> u
+		// 				   		   v0(0/1/2) -> v0/1/2
+		// 				   		   u1(0/1/2) -> u0/1/2
+		//
+		// ||v + s * u||^2 = (v0+s*u0)^2+(v1+s*u1)^2+(v1+s*u1)^2 = max^2
+		// v0^2+2*s*u0*v0+s^2*u0^2 + v1^2+2*s*u1*v1+s^2*u1^2 + v2^2+2*s*u2*v2+s^2*u2^2 = max^2
+		// s^2*(u0^2+u1^2+u2^2) + s*2*(u0*v0+u1*v1+u2*v2) + (v0^2+v1^2+v2^2-max^2) = 0
+		//
+		// quadratic equation:
+		// -> s^2*a + s*b + c = 0 with solution: s1/2 = (-b +- sqrt(b^2 - 4*a*c))/(2*a)
+		//
+		// b = 2 * u.dot(v)
+		// a = 1 (because u is normalized)
+		// c = (v0^2+v1^2+v2^2-max^2) = -max^2 + ||v||^2
+		//
+		// sqrt(b^2 - 4*a*c) =
+		// 		sqrt(4*u.dot(v)^2 - 4*(||v||^2 - max^2)) = 2*sqrt(u.dot(v)^2 +- (||v||^2 -max^2))
+		//
+		// s1/2 = ( -2*u.dot(v) +- 2*sqrt(u.dot(v)^2 - (||v||^2 -max^2)) / 2
+		//      =  -u.dot(v) +- sqrt(u.dot(v)^2 - (||v||^2 -max^2))
+		// m = u.dot(v)
+		// s = -m + sqrt(m^2 - c)
+		//
+		//
+		//
+		// notes:
+		// 	- s (=scaling factor) needs to be positive
+		// 	- (max - ||v||) always larger than zero, otherwise it never entered this if-statement
+
 		matrix::Vector2f u1 = v1.normalized();
 		float m = u1.dot(v0);
 		float c = v0.length() * v0.length() - max * max;

--- a/src/modules/mc_pos_control/Utility/ControlMath.cpp
+++ b/src/modules/mc_pos_control/Utility/ControlMath.cpp
@@ -139,7 +139,7 @@ matrix::Vector2f constrainXY(const matrix::Vector2f &v0, const matrix::Vector2f 
 
 	} else if (v0.length() < 0.001f) {
 		/* The first vector is 0. */
-		return v0 * 0.0f;
+		return v1.normalized() * max;
 
 	} else {
 		/*
@@ -181,12 +181,10 @@ matrix::Vector2f constrainXY(const matrix::Vector2f &v0, const matrix::Vector2f 
 		 * 	- s (=scaling factor) needs to be positive
 		 * 	- (max - ||v||) always larger than zero, otherwise it never entered this if-statement
 		 * */
-
-		float s = 0.0f;
 		matrix::Vector2f u1 = v1.normalized();
 		float m = u1.dot(v0);
 		float c = v0.length() * v0.length() - max * max;
-		s = -m + sqrtf(m * m - c);
+		float s = -m + sqrtf(m * m - c);
 		return v0 + u1 * s;
 	}
 }

--- a/src/modules/mc_pos_control/Utility/ControlMath.cpp
+++ b/src/modules/mc_pos_control/Utility/ControlMath.cpp
@@ -134,7 +134,6 @@ vehicle_attitude_setpoint_s thrustToAttitude(const matrix::Vector3f &thr_sp, con
  */
 matrix::Vector2f constrainXY(const matrix::Vector2f &v0, const matrix::Vector2f &v1, const float max)
 {
-
 	if (matrix::Vector2f(v0 + v1).norm() <= max) {
 		/* Vector does not exceed maximum magnitude */
 		return v0 + v1;

--- a/src/modules/mc_pos_control/Utility/ControlMath.cpp
+++ b/src/modules/mc_pos_control/Utility/ControlMath.cpp
@@ -116,7 +116,7 @@ vehicle_attitude_setpoint_s thrustToAttitude(const matrix::Vector3f &thr_sp, con
 
 /* The sum of two vectors are constraint such that v0 has priority over v1.
  * This means that if the length of v0+v1 exceeds max, then it is constraint such
- * that that v0 has priority.
+ * that v0 has priority.
  * Inputs:
  * @max => maximum magnitude of vector (v0 + v1)
  * @v0 => vector that is prioritized

--- a/src/modules/mc_pos_control/Utility/ControlMath.hpp
+++ b/src/modules/mc_pos_control/Utility/ControlMath.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2017 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,7 +38,6 @@
  * These functions are specific for controls.
  */
 
-
 #pragma once
 
 #include <matrix/matrix/math.hpp>
@@ -46,6 +45,23 @@
 
 namespace ControlMath
 {
+/**
+ * Converts thrust vector and yaw set-point to a desired attitude.
+ * @param thr_sp a 3D vector
+ * @param yaw_sp the desired yaw
+ * @return vehicle_attitude_setpoints_s structure
+ */
 vehicle_attitude_setpoint_s thrustToAttitude(const matrix::Vector3f &thr_sp, const float yaw_sp);
+
+/**
+ * Outputs the sum of two vectors but respecting the limits and priority.
+ * The sum of two vectors are constraint such that v0 has priority over v1.
+ * This means that if the length of (v0+v1) exceeds max, then it is constraint such
+ * that v0 has priority.
+ *
+ * @param v0 a 2D vector that has priority given the maximum available magnitude.
+ * @param v1 a 2D vector that less priority given the maximum available magnitude.
+ * @return 2D vector
+ */
 matrix::Vector2f constrainXY(const matrix::Vector2f &v0, const matrix::Vector2f &v1, const float max);
 }

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3195,12 +3195,12 @@ MulticopterPositionControl::task_main()
 				/* Vehicle is still landed and no takeoff was initiated yet.
 				 * Adjust for different takeoff cases. */
 
-				if (PX4_ISFINITE(setpoint.z) && setpoint.z < _pos(2) + 0.2f) {
+				if (PX4_ISFINITE(setpoint.z) && setpoint.z  < _pos(2)) {
 					/* There is a position setpoint above current position. Enable smooth takeoff. */
 					_in_smooth_takeoff = true;
 					_takeoff_sp = 0.5f;
 
-				} else if (PX4_ISFINITE(setpoint.vz) && setpoint.vz < -0.6f) {
+				} else if (PX4_ISFINITE(setpoint.vz) && setpoint.vz < -1.0f) {
 					/* There is a velocity setpoint that points upward and larger than 0.6. The 0.6
 					 * ensures that a minimum velocity is first required to initiate a takeoff.*/
 					_in_smooth_takeoff = true;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3226,7 +3226,7 @@ MulticopterPositionControl::task_main()
 					_in_smooth_takeoff = true;
 					_takeoff_sp = 0.5f;
 
-				} else if (PX4_ISFINITE(setpoint.thr[2]) && setpoint.thr[2] < -0.6f) {
+				} else if (PX4_ISFINITE(setpoint.thrust[2]) && setpoint.thrust[2] < -0.6f) {
 					/* There is a thrust setpoint pointing upwards and larger than 0.6f.
 					 * The threshold ensures that there is no takeoff by just switching into manual
 					 */
@@ -3267,18 +3267,18 @@ MulticopterPositionControl::task_main()
 
 					/* Smooth takeoff is achieved once target thrust is reached. (NED frame).
 					 * TODO: test this */
-					_in_smooth_takeoff = _takeoff_sp > setpoint.thr[2];
+					_in_smooth_takeoff = _takeoff_sp > setpoint.thrust[2];
 
 					/* ramp vertical velocity limit up to hover takeoff */
 					if (-_takeoff_sp < 0.5f) {
-						_takeoff_sp += setpoint.thr[2] * _dt / (_takeoff_ramp_time.get() * 0.5f);
+						_takeoff_sp += setpoint.thrust[2] * _dt / (_takeoff_ramp_time.get() * 0.5f);
 
 					} else {
-						_takeoff_sp = setpoint.thr[2];
+						_takeoff_sp = setpoint.thrust[2];
 					}
 
 					/* limit vertical velocity to the current ramp value */
-					setpoint.thr[2] = math::max(setpoint.thr[2], _takeoff_sp);
+					setpoint.thrust[2] = math::max(setpoint.thrust[2], _takeoff_sp);
 				}
 			}
 
@@ -3286,9 +3286,9 @@ MulticopterPositionControl::task_main()
 			// Otherwise just stay idle.
 			if (_vehicle_land_detected.landed && !_in_smooth_takeoff) {
 				// Keep throttle low
-				setpoint.thr[0] = 0.0f;
-				setpoint.thr[1] = 0.0f;
-				setpoint.thr[2] = 0.0f;
+				setpoint.thrust[0] = 0.0f;
+				setpoint.thrust[1] = 0.0f;
+				setpoint.thrust[2] = 0.0f;
 				setpoint.yawspeed = 0.0f;
 				setpoint.yaw = _yaw;
 			}
@@ -3302,7 +3302,7 @@ MulticopterPositionControl::task_main()
 
 			/* We adjust thrust setpoint based on landdetector and the
 			 * vehicle is NOT in pure Manual mode. */
-			if (!_in_smooth_takeoff && !PX4_ISFINITE(setpoint.thr[2])) {
+			if (!_in_smooth_takeoff && !PX4_ISFINITE(setpoint.thrust[2])) {
 				if (_vehicle_land_detected.ground_contact) {
 
 					/* if still or already on ground command zero xy thrust_sp in body
@@ -3345,7 +3345,7 @@ MulticopterPositionControl::task_main()
 			_local_pos_sp.vx = _control.getVelSp()(0);
 			_local_pos_sp.vy = _control.getVelSp()(1);
 			_local_pos_sp.vz = _control.getVelSp()(2);
-			thr_sp.copyTo(_local_pos_sp.thr);
+			thr_sp.copyTo(_local_pos_sp.thrust);
 
 			_att_sp = ControlMath::thrustToAttitude(thr_sp, _control.getYawSetpoint());
 			_att_sp.yaw_sp_move_rate = _control.getYawspeedSetpoint();

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3180,6 +3180,7 @@ MulticopterPositionControl::task_main()
 			_flight_tasks.switchTask(FlightTaskIndex::None);
 		}
 
+
 		if (_test_flight_tasks.get() && _flight_tasks.isAnyTaskActive()) {
 
 			_flight_tasks.update();

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3190,31 +3190,21 @@ MulticopterPositionControl::task_main()
 			Controller::Constraints constraints;
 			updateConstraints(constraints);
 
-			/* Check for smooth takeoff
-			 * TODO: This logic is split between mc_pos_controller and PositionController.
-			 * It would be much better if everything is contained in one class. */
+			/* Check for smooth takeoff */
 			if (_vehicle_land_detected.landed && !_in_smooth_takeoff && _control_mode.flag_armed) {
 				/* Vehicle is still landed and no takeoff was initiated yet.
-				 * Adjust for different takeoff casese. */
+				 * Adjust for different takeoff cases. */
 
 				if (PX4_ISFINITE(setpoint.z) && setpoint.z < _pos(2) - 0.2f) {
-					/* There is a position setpoint above current position. Enable smooth takeoff */
+					/* There is a position setpoint above current position. Enable smooth takeoff. */
 					_in_smooth_takeoff = true;
 					_takeoff_sp = 0.5f;
 
 				} else if (PX4_ISFINITE(setpoint.vz) && setpoint.vz < -0.6f) {
-					/* There is a velocity setpoint point up and larger than 0.6. The 0.6
-					 * ensures that a minimum velocity is first required to initiate a takeoff.
-					 */
+					/* There is a velocity setpoint that points upward and larger than 0.6. The 0.6
+					 * ensures that a minimum velocity is first required to initiate a takeoff.*/
 					_in_smooth_takeoff = true;
 					_takeoff_sp = 0.5f;
-
-				} else if (PX4_ISFINITE(setpoint.thrust[2]) && setpoint.thrust[2] < -0.6f) {
-					/* There is a thrust setpoint pointing upwards and larger than 0.6f.
-					 * The threshold ensures that there is no takeoff by just switching into manual
-					 */
-					_in_smooth_takeoff = true;
-					_takeoff_sp = 0.0f;
 
 				} else {
 					/* Default */
@@ -3222,6 +3212,10 @@ MulticopterPositionControl::task_main()
 				}
 			}
 
+			/* If in smooth takeoff, adjust setpoints based on what is valid:
+			 * 1. position setpoint is valid -> go with 1m/s to specific altitude (TODO: temporary and can be changed to anything)
+			 * 2. position setpoint not valid but velcoit setpoint valid: ramp up velocity
+			 */
 			if (_in_smooth_takeoff) {
 
 				if (PX4_ISFINITE(setpoint.z)) {
@@ -3245,23 +3239,6 @@ MulticopterPositionControl::task_main()
 					_takeoff_sp += setpoint.vz * _dt / _takeoff_ramp_time.get();
 					/* limit vertical velocity to the current ramp value */
 					setpoint.vz = math::max(setpoint.vz, _takeoff_sp);
-
-				} else {
-
-					/* Smooth takeoff is achieved once target thrust is reached. (NED frame).
-					 * TODO: test this */
-					_in_smooth_takeoff = _takeoff_sp > setpoint.thrust[2];
-
-					/* ramp vertical velocity limit up to hover takeoff */
-					if (-_takeoff_sp < 0.5f) {
-						_takeoff_sp += setpoint.thrust[2] * _dt / (_takeoff_ramp_time.get() * 0.5f);
-
-					} else {
-						_takeoff_sp = setpoint.thrust[2];
-					}
-
-					/* limit vertical velocity to the current ramp value */
-					setpoint.thrust[2] = math::max(setpoint.thrust[2], _takeoff_sp);
 				}
 			}
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3187,7 +3187,8 @@ MulticopterPositionControl::task_main()
 			vehicle_local_position_setpoint_s setpoint = _flight_tasks.getPositionSetpoint();
 
 			// Get _contstraints depending on flight mode
-			// This logic will be set by FlightTasks
+			// TODO: define where constraints are supposed to be set.
+			// All constraints could be set in flighttask and passed to the position controller.
 			Controller::Constraints constraints;
 			constraints.vel_max_z_up = _params.vel_max_up;
 
@@ -3212,7 +3213,7 @@ MulticopterPositionControl::task_main()
 
 			// If in smooth takeoff, adjust setpoints based on what is valid:
 			// 1. position setpoint is valid -> go with takeoffspeed to specific altitude
-			// 2. position setpoint not valid but velcoit setpoint valid: ramp up velocity
+			// 2. position setpoint not valid but velocity setpoint valid: ramp up velocity
 			if (_in_smooth_takeoff && (PX4_ISFINITE(setpoint.z) || PX4_ISFINITE(setpoint.vz))) {
 
 				float desired_tko_speed = -setpoint.vz;
@@ -3220,6 +3221,7 @@ MulticopterPositionControl::task_main()
 				if (PX4_ISFINITE(setpoint.z)) {
 					desired_tko_speed =  _params.tko_speed;
 				}
+
 				_takeoff_speed += desired_tko_speed * _dt / _takeoff_ramp_time.get();
 				_takeoff_speed = math::min(_takeoff_speed,  desired_tko_speed);
 				constraints.vel_max_z_up = _takeoff_speed;
@@ -3229,13 +3231,11 @@ MulticopterPositionControl::task_main()
 				_in_smooth_takeoff = false;
 			}
 
-			/* We can only run the control if we're already in-air, have a takeoff setpoint, and are not
-			in pure manual. Otherwise just stay idle. */
+			// We can only run the control if we're already in-air, have a takeoff setpoint, and are not
+			// in pure manual. Otherwise just stay idle.
 			if (_vehicle_land_detected.landed && !_in_smooth_takeoff && !PX4_ISFINITE(setpoint.thrust[2])) {
 				// Keep throttle low
-				setpoint.thrust[0] = 0.0f;
-				setpoint.thrust[1] = 0.0f;
-				setpoint.thrust[2] = 0.0f;
+				setpoint.thrust[0] = setpoint.thrust[1] = setpoint.thrust[2] = 0.0f;
 				setpoint.yawspeed = 0.0f;
 				setpoint.yaw = _yaw;
 			}
@@ -3253,6 +3253,7 @@ MulticopterPositionControl::task_main()
 				// Smooth takeoff is achieved once desired altitude/velocity setpoint is reached or
 				if (PX4_ISFINITE(setpoint.z)) {
 					_in_smooth_takeoff = _pos(2) + 0.2f > setpoint.z;
+
 				} else  {
 					_in_smooth_takeoff = _takeoff_speed < -setpoint.vz;
 				}

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3260,7 +3260,7 @@ MulticopterPositionControl::task_main()
 
 			matrix::Vector3f thr_sp = _control.getThrustSetpoint();
 
-			/* We adjust thrust setpoint based on landdetector and the
+			/* We adjust thrust setpoint based on landdetector only if the
 			 * vehicle is NOT in pure Manual mode. */
 			if (!_in_smooth_takeoff && !PX4_ISFINITE(setpoint.thrust[2])) {
 				if (_vehicle_land_detected.ground_contact) {

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3195,7 +3195,7 @@ MulticopterPositionControl::task_main()
 				/* Vehicle is still landed and no takeoff was initiated yet.
 				 * Adjust for different takeoff cases. */
 
-				if (PX4_ISFINITE(setpoint.z) && setpoint.z < _pos(2) - 0.2f) {
+				if (PX4_ISFINITE(setpoint.z) && setpoint.z < _pos(2) + 0.2f) {
 					/* There is a position setpoint above current position. Enable smooth takeoff. */
 					_in_smooth_takeoff = true;
 					_takeoff_sp = 0.5f;
@@ -3219,11 +3219,11 @@ MulticopterPositionControl::task_main()
 			if (_in_smooth_takeoff) {
 
 				if (PX4_ISFINITE(setpoint.z)) {
-
 					/* Limit velocity setpoint to maximum takeoff velocity which is hard coded at 0.8 m/s.*/
 					setpoint.vz = -0.8f;
-					/* Smooth takeoff is achieved once takeoff altitude is reached */
-					_in_smooth_takeoff = setpoint.z < (_pos(2) + 0.2f);
+					/* Smooth takeoff is achieved once takeoff altitude is reached or
+					 * takeoff setpoint reached desired velocity.*/
+					_in_smooth_takeoff = _takeoff_sp > setpoint.vz && setpoint.z < (_pos(2) + 0.2f);
 					/* For takeoff we only need velocity or thrust. Therefore, set setpoint to NAN */
 					setpoint.z = NAN;
 					/* ramp vertical velocity limit up to takeoff speed */
@@ -3232,8 +3232,7 @@ MulticopterPositionControl::task_main()
 					setpoint.vz = math::max(setpoint.vz, _takeoff_sp);
 
 				} else if (PX4_ISFINITE(setpoint.vz)) {
-
-					/* Smooth takeoff is achieved once takeoff altitude is reached */
+					/* Smooth takeoff is achieved once desired velocity setpoint is reached. */
 					_in_smooth_takeoff = _takeoff_sp > setpoint.vz;
 					/* ramp vertical velocity limit up to takeoff speed */
 					_takeoff_sp += setpoint.vz * _dt / _takeoff_ramp_time.get();

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -403,6 +403,8 @@ private:
 
 	bool manual_wants_takeoff();
 
+	void update_smooth_takeoff();
+
 	void set_takeoff_velocity(float &vel_sp_z);
 
 	void landdetection_thrust_limit(matrix::Vector3f &thrust_sp);
@@ -3160,11 +3162,11 @@ MulticopterPositionControl::task_main()
 				_flight_tasks.switchTask(FlightTaskIndex::Stabilized);
 				break;
 
-			case _vehicle_status.nav_state == _vehicle_status.NAVIGATION_STATE_AUTO_TAKEOFF:
-			case _vehicle_status.nav_state == _vehicle_status.NAVIGATION_STATE_AUTO_LOITER:
-			case _vehicle_status.nav_state == _vehicle_status.NAVIGATION_STATE_AUTO_MISSION:
-			case _vehicle_status.nav_state == _vehicle_status.NAVIGATION_STATE_AUTO_RTL:
-			case _vehicle_status.nav_state == _vehicle_status.NAVIGATION_STATE_AUTO_LAND:
+			case vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF:
+			case vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER:
+			case vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION:
+			case vehicle_status_s::NAVIGATION_STATE_AUTO_RTL:
+			case vehicle_status_s::NAVIGATION_STATE_AUTO_LAND:
 
 				/*TODO: clean up navigation state and commander state, which both share too many equal states */
 				_flight_tasks.switchTask(FlightTaskIndex::AutoLine);
@@ -3182,7 +3184,6 @@ MulticopterPositionControl::task_main()
 
 		if (_test_flight_tasks.get() && _flight_tasks.isAnyTaskActive()) {
 
-			// get all flight-task setpoints
 			_flight_tasks.update();
 			vehicle_local_position_setpoint_s setpoint = _flight_tasks.getPositionSetpoint();
 
@@ -3312,10 +3313,6 @@ MulticopterPositionControl::task_main()
 			publish_local_pos_sp();
 			publish_attitude();
 
-			/*
-			 * ****************** FLIGHTTASK-LOGIC END *****************************************
-			 * */
-
 		} else {
 			if (_control_mode.flag_control_altitude_enabled ||
 			    _control_mode.flag_control_position_enabled ||
@@ -3409,6 +3406,24 @@ MulticopterPositionControl::set_takeoff_velocity(float &vel_sp_z)
 }
 
 void
+MulticopterPositionControl:: update_smooth_takeoff()
+{
+	if (!_in_smooth_takeoff && _vehicle_land_detected.landed
+	    && _control_mode.flag_armed
+	    && (in_auto_takeoff() || manual_wants_takeoff())) {
+		_in_smooth_takeoff = true;
+		// This ramp starts negative and goes to positive later because we want to
+		// be as smooth as possible. If we start at 0, we alrady jump to hover throttle.
+		_takeoff_vel_limit = -0.5f;
+	}
+
+	else if (!_control_mode.flag_armed) {
+		// If we're disarmed and for some reason were in a smooth takeoff, we reset that.
+		_in_smooth_takeoff = false;
+	}
+}
+
+void
 MulticopterPositionControl::publish_attitude()
 {
 	/* publish attitude setpoint
@@ -3462,10 +3477,8 @@ MulticopterPositionControl::landdetection_thrust_limit(matrix::Vector3f &thrust_
 			/* if still or already on ground command zero xy thrust_sp in body
 			 * frame to consider uneven ground */
 
-			/* Temporary until replacement to matrix lib */
-			matrix::Matrix<float, 3, 3> R = matrix::Matrix<float, 3, 3>(&_R(0, 0));
 			/* thrust setpoint in body frame*/
-			matrix::Vector3f thrust_sp_body = R.transpose() * thrust_sp;
+			matrix::Vector3f thrust_sp_body = _R.transpose() * thrust_sp;
 
 			/* we dont want to make any correction in body x and y*/
 			thrust_sp_body(0) = 0.0f;
@@ -3475,7 +3488,7 @@ MulticopterPositionControl::landdetection_thrust_limit(matrix::Vector3f &thrust_
 			thrust_sp_body(2) = thrust_sp(2) > 0.0f ? thrust_sp(2) : 0.0f;
 
 			/* convert back to local frame (NED) */
-			thrust_sp = R * thrust_sp_body;
+			thrust_sp = _R * thrust_sp_body;
 		}
 
 		if (_vehicle_land_detected.maybe_landed) {
@@ -3505,37 +3518,6 @@ MulticopterPositionControl::updateTiltConstraints(Controller::Constraints &const
 	} else {
 		/* Velocity/acceleration control tilt */
 		constraints.tilt_max = _params.tilt_max_air;
-	}
-}
-
-void
-MulticopterPositionControl::landdetection_thrust_limit(matrix::Vector3f &thrust_sp)
-{
-	if (!in_auto_takeoff() && !manual_wants_takeoff()) {
-		if (_vehicle_land_detected.ground_contact) {
-			/* if still or already on ground command zero xy thrust_sp in body
-			 * frame to consider uneven ground */
-
-			/* thrust setpoint in body frame*/
-			matrix::Vector3f thrust_sp_body = _R.transpose() * thrust_sp;
-
-			/* we dont want to make any correction in body x and y*/
-			thrust_sp_body(0) = 0.0f;
-			thrust_sp_body(1) = 0.0f;
-
-			/* make sure z component of thrust_sp_body is larger than 0 (positive thrust is downward) */
-			thrust_sp_body(2) = thrust_sp(2) > 0.0f ? thrust_sp(2) : 0.0f;
-
-			/* convert back to local frame (NED) */
-			thrust_sp = _R * thrust_sp_body;
-		}
-
-		if (_vehicle_land_detected.maybe_landed) {
-			/* we set thrust to zero
-			 * this will help to decide if we are actually landed or not
-			 */
-			thrust_sp.zero();
-		}
 	}
 }
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3289,11 +3289,10 @@ MulticopterPositionControl::task_main()
 				// Keep throttle low
 				setpoint.thr[0] = 0.0f;
 				setpoint.thr[1] = 0.0f;
-				setpoint.thr[0] = 0.0f;
+				setpoint.thr[2] = 0.0f;
 				setpoint.yawspeed = 0.0f;
 				setpoint.yaw = _yaw;
 			}
-
 
 			_control.updateState(_local_pos, matrix::Vector3f(&(_vel_err_d(0))));
 			_control.updateSetpoint(setpoint);

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3220,10 +3220,11 @@ MulticopterPositionControl::task_main()
 
 				if (PX4_ISFINITE(setpoint.z)) {
 					/* Limit velocity setpoint to maximum takeoff velocity which is hard coded at 0.8 m/s.*/
-					setpoint.vz = -0.8f;
-					/* Smooth takeoff is achieved once takeoff altitude is reached or
-					 * takeoff setpoint reached desired velocity.*/
-					_in_smooth_takeoff = _takeoff_sp > setpoint.vz && setpoint.z < (_pos(2) + 0.2f);
+					setpoint.vz = -1.0f;
+					/* Smooth takeoff is ON if altitude is below target altitude AND
+					 * takeoff setpoint reached desired setpoint OR velocity reached desired velocity setpoint.
+					 * The 0.1/0.2 are used for clearance threshold. */
+					_in_smooth_takeoff = (_takeoff_sp > setpoint.vz || _vel(2)  > setpoint.vz + 0.1f) && (_pos(2) > setpoint.z + 0.2f) ;
 					/* For takeoff we only need velocity or thrust. Therefore, set setpoint to NAN */
 					setpoint.z = NAN;
 					/* ramp vertical velocity limit up to takeoff speed */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3204,7 +3204,6 @@ MulticopterPositionControl::task_main()
 				_pos_sp_triplet.previous.valid = false;
 				_hold_offboard_xy = false;
 				_hold_offboard_z = false;
-
 			}
 
 			/* Check for smooth takeoff
@@ -3218,7 +3217,6 @@ MulticopterPositionControl::task_main()
 					/* There is a position setpoint above current position. Enable smooth takeoff */
 					_in_smooth_takeoff = true;
 					_takeoff_sp = 0.5f;
-
 
 				} else if (PX4_ISFINITE(setpoint.vz) && setpoint.vz < -0.6f) {
 					/* There is a velocity setpoint point up and larger than 0.6. The 0.6

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3267,24 +3267,9 @@ MulticopterPositionControl::task_main()
 				if (_vehicle_land_detected.ground_contact) {
 
 					/* if still or already on ground command zero xy thrust_sp in body
-					 * frame to consider uneven ground */
-
-					/* Temporary until replacement to matrix lib */
-					matrix::Matrix<float, 3, 3> R = matrix::Matrix<float, 3, 3>(
-										&_R(0, 0));
-					/* thrust setpoint in body frame*/
-					matrix::Vector3f thrust_sp_body = R.transpose() * thr_sp;
-
-					/* we dont want to make any correction in body x and y*/
-					thrust_sp_body(0) = 0.0f;
-					thrust_sp_body(1) = 0.0f;
-
-					/* make sure z component of thrust_sp_body is larger than 0 (positive thrust is downward) */
-					thrust_sp_body(2) =
-						thr_sp(2) > 0.0f ? thr_sp(2) : 0.0f;
-
-					/* convert back to local frame (NED) */
-					thr_sp = R * thrust_sp_body;
+					/* Set thrust in xy to zero */
+					thr_sp(0) = 0.0f;
+					thr_sp(1) = 0.0f;
 				}
 
 				if (_vehicle_land_detected.maybe_landed) {

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3258,18 +3258,26 @@ MulticopterPositionControl::task_main()
 				}
 			}
 
+			// We adjust thrust setpoint based on landdetector only if the
+			// vehicle is NOT in pure Manual mode.
 			if (!_in_smooth_takeoff && !PX4_ISFINITE(setpoint.thrust[2])) {
 				if (_vehicle_land_detected.ground_contact) {
-					/* Set thrust in xy to zero */
+					// Set thrust in xy to zero
 					thr_sp(0) = 0.0f;
 					thr_sp(1) = 0.0f;
+					// Reset integral in xy is required because PID-controller does
+					// know about the overwrite and would therefore increase the intragral term
+					_control.resetIntegralXY();
 				}
 
 				if (_vehicle_land_detected.maybe_landed) {
-					/* we set thrust to zero
-					 * this will help to decide if we are actually landed or not
-					 */
+					// we set thrust to zero
+					// this will help to decide if we are actually landed or not
 					thr_sp.zero();
+					// We need to reset all integral terms otherwise the PID-controller
+					// will end up with wrong integral sums
+					_control.resetIntegralXY();
+					_control.resetIntegralZ();
 				}
 			}
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3172,6 +3172,10 @@ MulticopterPositionControl::task_main()
 				_flight_tasks.switchTask(FlightTaskIndex::AutoLine);
 				break;
 
+			case vehicle_status_s::NAVIGATION_STATE_OFFBOARD:
+				_flight_tasks.switchTask(FlightTaskIndex::Offboard);
+				break;
+
 			default:
 				/* not supported yet */
 				_flight_tasks.switchTask(FlightTaskIndex::None);

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3310,6 +3310,10 @@ MulticopterPositionControl::task_main()
 
 			_att_sp = ControlMath::thrustToAttitude(thr_sp, _control.getYawSetpoint());
 			_att_sp.yaw_sp_move_rate = _control.getYawspeedSetpoint();
+			_att_sp.fw_control_yaw = false;
+			_att_sp.disable_mc_yaw_control = false;
+			_att_sp.apply_flaps = false;
+			_att_sp.landing_gear = vehicle_attitude_setpoint_s::LANDING_GEAR_DOWN;
 
 			publish_local_pos_sp();
 			publish_attitude();

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3265,8 +3265,6 @@ MulticopterPositionControl::task_main()
 			 * vehicle is NOT in pure Manual mode. */
 			if (!_in_smooth_takeoff && !PX4_ISFINITE(setpoint.thrust[2])) {
 				if (_vehicle_land_detected.ground_contact) {
-
-					/* if still or already on ground command zero xy thrust_sp in body
 					/* Set thrust in xy to zero */
 					thr_sp(0) = 0.0f;
 					thr_sp(1) = 0.0f;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -412,7 +412,7 @@ private:
 	/**
 	 * Temporary method for flight control compuation
 	 */
-	void updateConstraints(Controller::Constraints &constrains);
+	void updateTiltConstraints(Controller::Constraints &constrains);
 
 	void publish_attitude();
 
@@ -3180,17 +3180,16 @@ MulticopterPositionControl::task_main()
 			_flight_tasks.switchTask(FlightTaskIndex::None);
 		}
 
-
 		if (_test_flight_tasks.get() && _flight_tasks.isAnyTaskActive()) {
 
+			// get all flight-task setpoints
 			_flight_tasks.update();
 			vehicle_local_position_setpoint_s setpoint = _flight_tasks.getPositionSetpoint();
 
-			// Get _contstraints depending on flight mode
-			// TODO: define where constraints are supposed to be set.
-			// All constraints could be set in flighttask and passed to the position controller.
+			// structure that replaces global constraints such as tilt,
+			// maximum velocity in z-direction ...
 			Controller::Constraints constraints;
-			constraints.vel_max_z_up = _params.vel_max_up;
+			constraints.vel_max_z_up = NAN; // NAN for not used
 
 			// Check for smooth takeoff
 			if (_vehicle_land_detected.landed && !_in_smooth_takeoff && _control_mode.flag_armed) {
@@ -3198,9 +3197,9 @@ MulticopterPositionControl::task_main()
 				// Adjust for different takeoff cases.
 				// The minimum takeoff altitude needs to be at least 20cm above current position
 				if ((PX4_ISFINITE(setpoint.z) && setpoint.z  < _pos(2) - 0.2f) ||
-				    (PX4_ISFINITE(setpoint.vz) && setpoint.vz < -_params.tko_speed)) {
+				    (PX4_ISFINITE(setpoint.vz) && setpoint.vz < math::min(-_params.tko_speed, -0.6f))) {
 					// There is a position setpoint above current position or velocity setpoint larger than
-					// 1m/s. Enable smooth takeoff.
+					// takeoff speed. Enable smooth takeoff.
 					_in_smooth_takeoff = true;
 					_takeoff_speed = -0.5f;
 
@@ -3214,18 +3213,19 @@ MulticopterPositionControl::task_main()
 			// If in smooth takeoff, adjust setpoints based on what is valid:
 			// 1. position setpoint is valid -> go with takeoffspeed to specific altitude
 			// 2. position setpoint not valid but velocity setpoint valid: ramp up velocity
-			if (_in_smooth_takeoff && (PX4_ISFINITE(setpoint.z) || PX4_ISFINITE(setpoint.vz))) {
-
+			if (_in_smooth_takeoff) {
 				float desired_tko_speed = -setpoint.vz;
 
+				// If there is a valid position setpoint, then set the desired speed to the takeoff speed.
 				if (PX4_ISFINITE(setpoint.z)) {
 					desired_tko_speed =  _params.tko_speed;
 				}
 
+				// Ramp up takeoff speed.
 				_takeoff_speed += desired_tko_speed * _dt / _takeoff_ramp_time.get();
 				_takeoff_speed = math::min(_takeoff_speed,  desired_tko_speed);
+				// Limit the velocity setpoint from the position controller
 				constraints.vel_max_z_up = _takeoff_speed;
-
 
 			} else {
 				_in_smooth_takeoff = false;
@@ -3240,17 +3240,22 @@ MulticopterPositionControl::task_main()
 				setpoint.yaw = _yaw;
 			}
 
-			updateConstraints(constraints);
+			// Update tilt constraints. For now it still requires to know about control mode
+			// TODO: check if it makes sense to have a tilt constraint for landing.
+			updateTiltConstraints(constraints);
+
+			// Update states, setpoints and constraints.
+			_control.updateConstraints(constraints);
 			_control.updateState(_local_pos, matrix::Vector3f(&(_vel_err_d(0))));
 			_control.updateSetpoint(setpoint);
-			_control.updateConstraints(constraints);
+
+			// Generate desired thrust and yaw.
 			_control.generateThrustYawSetpoint(_dt);
-
-
 			matrix::Vector3f thr_sp = _control.getThrustSetpoint();
 
+			// Check if vehicle is still in smooth takeoff.
 			if (_in_smooth_takeoff) {
-				// Smooth takeoff is achieved once desired altitude/velocity setpoint is reached or
+				// Smooth takeoff is achieved once desired altitude/velocity setpoint is reached.
 				if (PX4_ISFINITE(setpoint.z)) {
 					_in_smooth_takeoff = _pos(2) + 0.2f > setpoint.z;
 
@@ -3259,7 +3264,7 @@ MulticopterPositionControl::task_main()
 				}
 			}
 
-			// We adjust thrust setpoint based on landdetector only if the
+			// Adjust thrust setpoint based on landdetector only if the
 			// vehicle is NOT in pure Manual mode.
 			if (!_in_smooth_takeoff && !PX4_ISFINITE(setpoint.thrust[2])) {
 				if (_vehicle_land_detected.ground_contact) {
@@ -3282,7 +3287,7 @@ MulticopterPositionControl::task_main()
 				}
 			}
 
-			/* fill local position, velocity and thrust setpoint */
+			// Fill local position, velocity and thrust setpoint.
 			_local_pos_sp.timestamp = hrt_absolute_time();
 			_local_pos_sp.x = _control.getPosSp()(0);
 			_local_pos_sp.y = _control.getPosSp()(1);
@@ -3295,6 +3300,7 @@ MulticopterPositionControl::task_main()
 			_local_pos_sp.vz = _control.getVelSp()(2);
 			thr_sp.copyTo(_local_pos_sp.thrust);
 
+			// Fill attitude setpoint. Attitude is computed from yaw and thrust setpoint.
 			_att_sp = ControlMath::thrustToAttitude(thr_sp, _control.getYawSetpoint());
 			_att_sp.yaw_sp_move_rate = _control.getYawspeedSetpoint();
 			_att_sp.fw_control_yaw = false;
@@ -3302,8 +3308,13 @@ MulticopterPositionControl::task_main()
 			_att_sp.apply_flaps = false;
 			_att_sp.landing_gear = vehicle_attitude_setpoint_s::LANDING_GEAR_DOWN;
 
+			// Publish local position setpoint (for logging only) and attitude setpoint (for attitude controller).
 			publish_local_pos_sp();
 			publish_attitude();
+
+			/*
+			 * ****************** FLIGHTTASK-LOGIC END *****************************************
+			 * */
 
 		} else {
 			if (_control_mode.flag_control_altitude_enabled ||
@@ -3477,7 +3488,7 @@ MulticopterPositionControl::landdetection_thrust_limit(matrix::Vector3f &thrust_
 }
 
 void
-MulticopterPositionControl::updateConstraints(Controller::Constraints &constraints)
+MulticopterPositionControl::updateTiltConstraints(Controller::Constraints &constraints)
 {
 	/* _contstraints */
 	constraints.tilt_max = NAN; // Default no maximum tilt

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3221,7 +3221,7 @@ MulticopterPositionControl::task_main()
 
 				if (PX4_ISFINITE(setpoint.z)) {
 					/* Limit velocity setpoint to maximum takeoff velocity which is hard coded at 0.8 m/s.*/
-					setpoint.vz = -1.0f;
+					setpoint.vz = _params.tko_speed;
 					/* Smooth takeoff is ON if altitude is below target altitude AND
 					 * takeoff setpoint reached desired setpoint OR velocity reached desired velocity setpoint.
 					 * The 0.1/0.2 are used for clearance threshold. */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3201,7 +3201,7 @@ MulticopterPositionControl::task_main()
 					_takeoff_sp = 0.5f;
 
 				} else if (PX4_ISFINITE(setpoint.vz) && setpoint.vz < -1.0f) {
-					/* There is a velocity setpoint that points upward and larger than 0.6. The 0.6
+					/* There is a velocity setpoint that points upward and larger than 1 m/s. The 1 m/s
 					 * ensures that a minimum velocity is first required to initiate a takeoff.*/
 					_in_smooth_takeoff = true;
 					_takeoff_sp = 0.5f;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3195,8 +3195,9 @@ MulticopterPositionControl::task_main()
 			if (_vehicle_land_detected.landed && !_in_smooth_takeoff && _control_mode.flag_armed) {
 				// Vehicle is still landed and no takeoff was initiated yet.
 				// Adjust for different takeoff cases.
-				if ((PX4_ISFINITE(setpoint.z) && setpoint.z  < _pos(2)) ||
-				    (PX4_ISFINITE(setpoint.vz) && setpoint.vz < -1.0f)) {
+				// The minimum takeoff altitude needs to be at least 20cm above current position
+				if ((PX4_ISFINITE(setpoint.z) && setpoint.z  < _pos(2) - 0.2f) ||
+				    (PX4_ISFINITE(setpoint.vz) && setpoint.vz < -_params.tko_speed)) {
 					// There is a position setpoint above current position or velocity setpoint larger than
 					// 1m/s. Enable smooth takeoff.
 					_in_smooth_takeoff = true;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -309,7 +309,7 @@ private:
 
 	float _min_hagl_limit; /**< minimum continuous height above ground (m) */
 
-	float _takeoff_sp; /**< For flighttask interface used only. It can be thrust or velocity setpoints */
+	float _takeoff_speed; /**< For flighttask interface used only. It can be thrust or velocity setpoints */
 	// counters for reset events on position and velocity states
 	// they are used to identify a reset event
 	uint8_t _z_reset_counter;
@@ -3186,10 +3186,10 @@ MulticopterPositionControl::task_main()
 			_flight_tasks.update();
 			vehicle_local_position_setpoint_s setpoint = _flight_tasks.getPositionSetpoint();
 
-			/* Get _contstraints depending on flight mode
-			 * This logic will be set by FlightTasks */
+			// Get _contstraints depending on flight mode
+			// This logic will be set by FlightTasks
 			Controller::Constraints constraints;
-			updateConstraints(constraints);
+			constraints.vel_max_z_up = _params.vel_max_up;
 
 			// Check for smooth takeoff
 			if (_vehicle_land_detected.landed && !_in_smooth_takeoff && _control_mode.flag_armed) {
@@ -3201,7 +3201,7 @@ MulticopterPositionControl::task_main()
 					// There is a position setpoint above current position or velocity setpoint larger than
 					// 1m/s. Enable smooth takeoff.
 					_in_smooth_takeoff = true;
-					_takeoff_sp = 0.5f;
+					_takeoff_speed = -0.5f;
 
 				} else {
 					// Default
@@ -3209,30 +3209,21 @@ MulticopterPositionControl::task_main()
 				}
 			}
 
+
 			// If in smooth takeoff, adjust setpoints based on what is valid:
 			// 1. position setpoint is valid -> go with takeoffspeed to specific altitude
 			// 2. position setpoint not valid but velcoit setpoint valid: ramp up velocity
 			if (_in_smooth_takeoff && (PX4_ISFINITE(setpoint.z) || PX4_ISFINITE(setpoint.vz))) {
+
+				float desired_tko_speed = -setpoint.vz;
+
 				if (PX4_ISFINITE(setpoint.z)) {
-					// Valid position setpoint. Set speed to takeoff velocity.
-					setpoint.vz = -_params.tko_speed;
-					// Smooth takeoff is ON if altitude is below target altitude AND
-					// takeoff setpoint reached desired setpoint OR velocity reached desired velocity setpoint.
-					// The 0.1 is used as clearance threshold.
-					_in_smooth_takeoff = (_takeoff_sp > setpoint.vz || _vel(2) > setpoint.vz + 0.1f) && (_pos(2) > setpoint.z);
-
-				} else {
-					// Valid velocity septoint.
-					// Smooth takeoff is achieved once desired velocity setpoint is reached.
-					_in_smooth_takeoff = _takeoff_sp > setpoint.vz;
+					desired_tko_speed =  _params.tko_speed;
 				}
+				_takeoff_speed += desired_tko_speed * _dt / _takeoff_ramp_time.get();
+				_takeoff_speed = math::min(_takeoff_speed,  desired_tko_speed);
+				constraints.vel_max_z_up = _takeoff_speed;
 
-				// During takeoff we only care about velocity.
-				setpoint.z = NAN;
-				// Ramp vertical velocity limit up to takeoff speed. */
-				_takeoff_sp += setpoint.vz * _dt / _takeoff_ramp_time.get();
-				// Limit vertical velocity to the current ramp value.
-				setpoint.vz = math::max(setpoint.vz, _takeoff_sp);
 
 			} else {
 				_in_smooth_takeoff = false;
@@ -3249,15 +3240,24 @@ MulticopterPositionControl::task_main()
 				setpoint.yaw = _yaw;
 			}
 
+			updateConstraints(constraints);
 			_control.updateState(_local_pos, matrix::Vector3f(&(_vel_err_d(0))));
 			_control.updateSetpoint(setpoint);
 			_control.updateConstraints(constraints);
 			_control.generateThrustYawSetpoint(_dt);
 
+
 			matrix::Vector3f thr_sp = _control.getThrustSetpoint();
 
-			/* We adjust thrust setpoint based on landdetector only if the
-			 * vehicle is NOT in pure Manual mode. */
+			if (_in_smooth_takeoff) {
+				// Smooth takeoff is achieved once desired altitude/velocity setpoint is reached or
+				if (PX4_ISFINITE(setpoint.z)) {
+					_in_smooth_takeoff = _pos(2) + 0.2f > setpoint.z;
+				} else  {
+					_in_smooth_takeoff = _takeoff_speed < -setpoint.vz;
+				}
+			}
+
 			if (!_in_smooth_takeoff && !PX4_ISFINITE(setpoint.thrust[2])) {
 				if (_vehicle_land_detected.ground_contact) {
 					/* Set thrust in xy to zero */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3166,7 +3166,8 @@ MulticopterPositionControl::task_main()
 			case _vehicle_status.nav_state == _vehicle_status.NAVIGATION_STATE_AUTO_RTL:
 			case _vehicle_status.nav_state == _vehicle_status.NAVIGATION_STATE_AUTO_LAND:
 
-				_flight_tasks.switchTask(8);
+				/*TODO: clean up navigation state and commander state, which both share too many equal states */
+				_flight_tasks.switchTask(FlightTaskIndex::AutoLine);
 				break;
 
 			default:

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3190,23 +3190,6 @@ MulticopterPositionControl::task_main()
 			Controller::Constraints constraints;
 			updateConstraints(constraints);
 
-			/* this logic is only temporary.
-			 * Mode switch related things will be handled within
-			 * Flighttask activate method
-			 */
-			if (_vehicle_status.nav_state
-			    == _vehicle_status.NAVIGATION_STATE_MANUAL) {
-				/* we set triplets to false
-				 * this ensures that when switching to auto, the position
-				 * controller will not use the old triplets but waits until triplets
-				 * have been updated */
-				_mode_auto = false;
-				_pos_sp_triplet.current.valid = false;
-				_pos_sp_triplet.previous.valid = false;
-				_hold_offboard_xy = false;
-				_hold_offboard_z = false;
-			}
-
 			/* Check for smooth takeoff
 			 * TODO: This logic is split between mc_pos_controller and PositionController.
 			 * It would be much better if everything is contained in one class. */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3191,56 +3191,50 @@ MulticopterPositionControl::task_main()
 			Controller::Constraints constraints;
 			updateConstraints(constraints);
 
-			/* Check for smooth takeoff */
+			// Check for smooth takeoff
 			if (_vehicle_land_detected.landed && !_in_smooth_takeoff && _control_mode.flag_armed) {
-				/* Vehicle is still landed and no takeoff was initiated yet.
-				 * Adjust for different takeoff cases. */
-
-				if (PX4_ISFINITE(setpoint.z) && setpoint.z  < _pos(2)) {
-					/* There is a position setpoint above current position. Enable smooth takeoff. */
-					_in_smooth_takeoff = true;
-					_takeoff_sp = 0.5f;
-
-				} else if (PX4_ISFINITE(setpoint.vz) && setpoint.vz < -1.0f) {
-					/* There is a velocity setpoint that points upward and larger than 1 m/s. The 1 m/s
-					 * ensures that a minimum velocity is first required to initiate a takeoff.*/
+				// Vehicle is still landed and no takeoff was initiated yet.
+				// Adjust for different takeoff cases.
+				if ((PX4_ISFINITE(setpoint.z) && setpoint.z  < _pos(2)) ||
+				    (PX4_ISFINITE(setpoint.vz) && setpoint.vz < -1.0f)) {
+					// There is a position setpoint above current position or velocity setpoint larger than
+					// 1m/s. Enable smooth takeoff.
 					_in_smooth_takeoff = true;
 					_takeoff_sp = 0.5f;
 
 				} else {
-					/* Default */
+					// Default
 					_in_smooth_takeoff = false;
 				}
 			}
 
-			/* If in smooth takeoff, adjust setpoints based on what is valid:
-			 * 1. position setpoint is valid -> go with 1m/s to specific altitude (TODO: temporary and can be changed to anything)
-			 * 2. position setpoint not valid but velcoit setpoint valid: ramp up velocity
-			 */
-			if (_in_smooth_takeoff) {
-
+			// If in smooth takeoff, adjust setpoints based on what is valid:
+			// 1. position setpoint is valid -> go with takeoffspeed to specific altitude
+			// 2. position setpoint not valid but velcoit setpoint valid: ramp up velocity
+			if (_in_smooth_takeoff && (PX4_ISFINITE(setpoint.z) || PX4_ISFINITE(setpoint.vz))) {
 				if (PX4_ISFINITE(setpoint.z)) {
-					/* Limit velocity setpoint to maximum takeoff velocity which is hard coded at 0.8 m/s.*/
-					setpoint.vz = _params.tko_speed;
-					/* Smooth takeoff is ON if altitude is below target altitude AND
-					 * takeoff setpoint reached desired setpoint OR velocity reached desired velocity setpoint.
-					 * The 0.1/0.2 are used for clearance threshold. */
-					_in_smooth_takeoff = (_takeoff_sp > setpoint.vz || _vel(2)  > setpoint.vz + 0.1f) && (_pos(2) > setpoint.z + 0.2f) ;
-					/* For takeoff we only need velocity or thrust. Therefore, set setpoint to NAN */
-					setpoint.z = NAN;
-					/* ramp vertical velocity limit up to takeoff speed */
-					_takeoff_sp += setpoint.vz * _dt / _takeoff_ramp_time.get();
-					/* limit vertical velocity to the current ramp value */
-					setpoint.vz = math::max(setpoint.vz, _takeoff_sp);
+					// Valid position setpoint. Set speed to takeoff velocity.
+					setpoint.vz = -_params.tko_speed;
+					// Smooth takeoff is ON if altitude is below target altitude AND
+					// takeoff setpoint reached desired setpoint OR velocity reached desired velocity setpoint.
+					// The 0.1 is used as clearance threshold.
+					_in_smooth_takeoff = (_takeoff_sp > setpoint.vz || _vel(2) > setpoint.vz + 0.1f) && (_pos(2) > setpoint.z);
 
-				} else if (PX4_ISFINITE(setpoint.vz)) {
-					/* Smooth takeoff is achieved once desired velocity setpoint is reached. */
+				} else {
+					// Valid velocity septoint.
+					// Smooth takeoff is achieved once desired velocity setpoint is reached.
 					_in_smooth_takeoff = _takeoff_sp > setpoint.vz;
-					/* ramp vertical velocity limit up to takeoff speed */
-					_takeoff_sp += setpoint.vz * _dt / _takeoff_ramp_time.get();
-					/* limit vertical velocity to the current ramp value */
-					setpoint.vz = math::max(setpoint.vz, _takeoff_sp);
 				}
+
+				// During takeoff we only care about velocity.
+				setpoint.z = NAN;
+				// Ramp vertical velocity limit up to takeoff speed. */
+				_takeoff_sp += setpoint.vz * _dt / _takeoff_ramp_time.get();
+				// Limit vertical velocity to the current ramp value.
+				setpoint.vz = math::max(setpoint.vz, _takeoff_sp);
+
+			} else {
+				_in_smooth_takeoff = false;
 			}
 
 			/* We can only run the control if we're already in-air, have a takeoff setpoint, and are not

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -729,6 +729,7 @@ MulticopterPositionControl::parameters_update(bool force)
 		/* we only use jerk for braking if jerk_hor_max > jerk_hor_min; otherwise just set jerk very large */
 		_manual_jerk_limit_z = (_jerk_hor_max.get() > _jerk_hor_min.get()) ? _jerk_hor_max.get() : 1000000.f;
 
+
 		/* Get parameter values used to fly within optical flow sensor limits */
 		param_t handle = param_find("SENS_FLOW_MINRNG");
 
@@ -739,7 +740,6 @@ MulticopterPositionControl::parameters_update(bool force)
 		if (_params_handles.acc_max_flow_xy != PARAM_INVALID) {
 			param_get(handle, &_params.acc_max_flow_xy);
 		}
-
 	}
 
 	return OK;
@@ -3299,6 +3299,42 @@ MulticopterPositionControl::task_main()
 			_control.updateConstraints(constraints);
 			_control.generateThrustYawSetpoint(_dt);
 
+			matrix::Vector3f thr_sp = _control.getThrustSetpoint();
+
+			/* We adjust thrust setpoint based on landdetector and the
+			 * vehicle is NOT in pure Manual mode. */
+			if (!_in_smooth_takeoff && !PX4_ISFINITE(setpoint.thr[2])) {
+				if (_vehicle_land_detected.ground_contact) {
+
+					/* if still or already on ground command zero xy thrust_sp in body
+					 * frame to consider uneven ground */
+
+					/* Temporary until replacement to matrix lib */
+					matrix::Matrix<float, 3, 3> R = matrix::Matrix<float, 3, 3>(
+										&_R(0, 0));
+					/* thrust setpoint in body frame*/
+					matrix::Vector3f thrust_sp_body = R.transpose() * thr_sp;
+
+					/* we dont want to make any correction in body x and y*/
+					thrust_sp_body(0) = 0.0f;
+					thrust_sp_body(1) = 0.0f;
+
+					/* make sure z component of thrust_sp_body is larger than 0 (positive thrust is downward) */
+					thrust_sp_body(2) =
+						thr_sp(2) > 0.0f ? thr_sp(2) : 0.0f;
+
+					/* convert back to local frame (NED) */
+					thr_sp = R * thrust_sp_body;
+				}
+
+				if (_vehicle_land_detected.maybe_landed) {
+					/* we set thrust to zero
+					 * this will help to decide if we are actually landed or not
+					 */
+					thr_sp.zero();
+				}
+			}
+
 			/* fill local position, velocity and thrust setpoint */
 			_local_pos_sp.timestamp = hrt_absolute_time();
 			_local_pos_sp.x = _control.getPosSp()(0);
@@ -3310,12 +3346,7 @@ MulticopterPositionControl::task_main()
 			_local_pos_sp.vx = _control.getVelSp()(0);
 			_local_pos_sp.vy = _control.getVelSp()(1);
 			_local_pos_sp.vz = _control.getVelSp()(2);
-
-			_control.getThrustSetpoint().copyTo(_local_pos_sp.thr);
-
-			/* We adjust thrust setpoint based on landdetector */
-			matrix::Vector3f thr_sp = _control.getThrustSetpoint();
-			landdetection_thrust_limit(thr_sp); //TODO: only do that if not in pure manual
+			thr_sp.copyTo(_local_pos_sp.thr);
 
 			_att_sp = ControlMath::thrustToAttitude(thr_sp, _control.getYawSetpoint());
 			_att_sp.yaw_sp_move_rate = _control.getYawspeedSetpoint();

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -3242,9 +3242,9 @@ MulticopterPositionControl::task_main()
 				}
 			}
 
-			// We can only run the control if we're already in-air, have a takeoff setpoint,
-			// Otherwise just stay idle.
-			if (_vehicle_land_detected.landed && !_in_smooth_takeoff) {
+			/* We can only run the control if we're already in-air, have a takeoff setpoint, and are not
+			in pure manual. Otherwise just stay idle. */
+			if (_vehicle_land_detected.landed && !_in_smooth_takeoff && !PX4_ISFINITE(setpoint.thrust[2])) {
 				// Keep throttle low
 				setpoint.thrust[0] = 0.0f;
 				setpoint.thrust[1] = 0.0f;

--- a/src/modules/mc_pos_control/mc_pos_control_tests/test_controlmath.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_tests/test_controlmath.cpp
@@ -11,11 +11,13 @@ public:
 
 private:
 	bool testThrAttMapping();
+	bool testPrioritizeVector();
 };
 
 bool ControlMathTest::run_tests()
 {
 	ut_run_test(testThrAttMapping);
+	ut_run_test(testPrioritizeVector);
 
 	return (_tests_failed == 0);
 }
@@ -59,6 +61,44 @@ bool ControlMathTest::testThrAttMapping()
 
 
 	return true;
+}
+
+bool ControlMathTest::testPrioritizeVector()
+{
+	float max = 5.0f;
+
+	// v0 already at max
+	matrix::Vector2f v0(max, 0);
+	matrix::Vector2f v1(v0(1), -v0(0));
+	matrix::Vector2f v_r = ControlMath::constrainXY(v0, v1, max);
+	ut_assert_true(fabsf(v_r(0)) - max < EPS && v_r(0) > 0.0f);
+	ut_assert_true(fabsf(v_r(1) - 0.0f) < EPS);
+
+	// v1 exceeds max but v0 is zero
+	v0.zero();
+	v_r = ControlMath::constrainXY(v0, v1, max);
+	ut_assert_true(fabsf(v_r(1)) - max < EPS && v_r(1) < 0.0f);
+	ut_assert_true(fabsf(v_r(0) - 0.0f) < EPS);
+
+	// v0 and v1 are below max
+	v0 = matrix::Vector2f(0.5f, 0.5f);
+	v1 = matrix::Vector2f(v0(1), -v0(0));
+	v_r = ControlMath::constrainXY(v0, v1, max);
+	float diff = matrix::Vector2f(v_r - (v0 + v1)).length();
+	ut_assert_true(diff < EPS);
+
+	// v0 and v1 exceed max and are perpendicular
+	v0 = matrix::Vector2f(4.0f, 0.0f);
+	v1 = matrix::Vector2f(0.0f, -4.0f);
+	v_r = ControlMath::constrainXY(v0, v1, max);
+	ut_assert_true(v_r(0) - v0(0) < EPS && v_r(0) > 0.0f);
+	float remaining = sqrtf(max * max - (v0(0) * v0(0)));
+	ut_assert_true(fabsf(v_r(1)) - remaining  < EPS && v_r(1) < EPS);
+
+	//TODO: add more tests with vectors not perpendicular
+
+	return true;
+
 }
 
 ut_declare_test_c(test_controlmath, ControlMathTest)


### PR DESCRIPTION
This PR replaces the legacy offboard logic. I did not consider offboard types such as Takeoff or land for the simple reason that a takeoff can now easily be initiated by a position septoint above the home position and land by setting a position setpoint into the ground.

So far I only tested offboard in sitl using position setpoint. 

TODO:
- [ ] map offboard Takeoff/land to setpoint
- [ ] replace triplets with position setpoint because only current is required
- [ ] replace block-params with module-params

This PR is on top of https://github.com/PX4/Firmware/pull/9253.