### PR TITLE
commander.cpp: remove ｓuperfluous judgment

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1474,11 +1474,6 @@ Commander::run()
 	if (status.hil_state == vehicle_status_s::HIL_STATE_ON) {
 		// HIL configuration selected: real sensors will be disabled
 		status_flags.condition_system_sensors_initialized = false;
-	} else {
-			// sensor diagnostics done continuously, not just at boot so don't warn about any issues just yet
-			status_flags.condition_system_sensors_initialized = Preflight::preflightCheck(&mavlink_log_pub, true,
-				checkAirspeed, (status.rc_input_mode == vehicle_status_s::RC_IN_MODE_DEFAULT), !status_flags.circuit_breaker_engaged_gpsfailure_check,
-				false, is_vtol(&status), false, false, hrt_elapsed_time(&commander_boot_timestamp));
 	}
 
 	// user adjustable duration required to assert arm/disarm via throttle/rudder stick


### PR DESCRIPTION
When we run commander, this hrt_elapsed_time(&commander_boot_timestamp) about 200.
so there : https://github.com/PX4/Firmware/blob/master/src/modules/commander/PreflightCheck.cpp#L576 will return true
we should remove this invalid detection smiley We run the preflightCheck function in the main(while) loop.