### PR TITLE
Fix possibility of deep discharge when battery inserted and USB connected

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2008,8 +2008,7 @@ Commander::run()
 					}
 
 					status_changed = true;
-				} else if (!status_flags.usb_connected &&
-					   battery.warning == battery_status_s::BATTERY_WARNING_CRITICAL &&
+				} else if (battery.warning == battery_status_s::BATTERY_WARNING_CRITICAL &&
 					   !critical_battery_voltage_actions_done) {
 					critical_battery_voltage_actions_done = true;
 
@@ -2043,8 +2042,7 @@ Commander::run()
 
 					status_changed = true;
 
-				} else if (!status_flags.usb_connected &&
-					   battery.warning == battery_status_s::BATTERY_WARNING_EMERGENCY &&
+				} else if (battery.warning == battery_status_s::BATTERY_WARNING_EMERGENCY &&
 					   !emergency_battery_voltage_actions_done) {
 					emergency_battery_voltage_actions_done = true;
 


### PR DESCRIPTION
The autopilot system shuts down automatically with a dangerously low battery level if the drone isn't currently flying. This prevents deep discharge when forgetting to turn it off or unplug the battery. This feature currently doesn't work when the board is simultaneously connected via USB. Benchtesting sometimes requires usb connection and connected battery (of course propellers removed for safety) and if you then forget to look at the battery level it goes to deep discharge voltages (happened to me while I was in the last PX4 dev call).

The removed check is according to our understanding not needed (anymore) because the battery level is anyways only updated if there is a connected battery detected. See: https://github.com/PX4/Firmware/blob/master/src/modules/systemlib/battery.cpp#L207

---
commander: Remove usb_ connected flag on battery warnings
Battery warning gets only fired if a battery is inserted.