### PR TITLE
enable -fno-math-errno as we never check errno

### DIFF
--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -361,7 +361,10 @@ function(px4_add_common_flags)
 	set(_optimization_flags
 		-fno-strict-aliasing
 		-fomit-frame-pointer
+
+		-fno-math-errno
 		-funsafe-math-optimizations
+
 		-ffunction-sections
 		-fdata-sections
 		)


### PR DESCRIPTION
 - disables setting of the errno variable as required by C89/C99 on
   calling math library routines

This ends up being a small optimization because the compiler can now inline the sqrtf() call (with code for checks) into a single vsqrt.f32. On a pixhawk this reduces cpu usage by a few percent and saves about 1.5K of flash.


current master

	 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE FD
	   0 Idle Task                   25600 42.658   548/  748   0 (  0)  READY  3
	   1 hpwork                       1066  2.045   888/ 1780 249 (249)  w:sig 13
	   2 lpwork                        182  0.073   680/ 1780  50 ( 50)  w:sig  8
	   3 init                        26576  0.000  1784/ 2580 100 (100)  w:sem  3
	 351 top                           174  3.214  1296/ 1684 100 (100)  RUN    3
	 150 sensors                      7424  6.793  1384/ 1964 249 (249)  w:sem 18
	 106 gps                           115  0.146  1032/ 1580 220 (220)  w:sig  5
	 152 commander                     456  0.876  1968/ 3212 140 (140)  w:sig 28
	 153 commander_low_prio              1  0.000   568/ 2996  50 ( 50)  w:sem 28
	 164 fmu                          1075  2.118   864/ 1292 251 (251)  w:sem 10
	 167 mavlink_if0                  2523  4.674  1720/ 2396 100 (100)  READY 32
	 168 mavlink_rcv_if0               202  0.438  1232/ 2836 175 (175)  w:sem 32
	 174 mavlink_if1                   949  1.753  1640/ 2420 100 (100)  w:sig 32
	 175 mavlink_rcv_if1               222  0.365  1200/ 2836 175 (175)  w:sem 32
	 179 frsky_telemetry                 0  0.000   584/ 1188 104 (104)  w:sem  4
	 189 mavlink_if2                   531  0.949  1720/ 2388 100 (100)  w:sig 29
	 190 mavlink_rcv_if2               203  0.438  1200/ 2836 175 (175)  w:sem 29
	 229 mavlink_if3                  2582  5.113  1616/ 2388 100 (100)  w:sig 32
	 230 mavlink_rcv_if3               190  0.438  1120/ 2836 175 (175)  w:sem 32
	 274 ekf2                         7727 16.727  5096/ 6572 250 (250)  w:sem 19
	 277 mc_att_control               1743  3.652   816/ 1660 251 (251)  w:sem 16
	 282 mc_pos_control               1990  4.747  1136/ 1876 250 (250)  w:sem 12
	 297 navigator                      86  0.219  1008/ 1764 105 (105)  w:sem 15
	 336 logger                        612  1.168  1032/ 3540 245 (245)  w:sem 35
	 337 log_writer_file                 0  0.000   344/ 1068  60 ( 60)  w:sem 35

	Processes: 25 total, 3 running, 22 sleeping, max FDs: 54
	CPU usage: 55.95% tasks, 1.39% sched, 42.66% idle
	DMA Memory: 5120 total, 0 used 0 peak
	Uptime: 53.842s total, 25.601s idle

	nsh> ekf2 status
	INFO  [ekf2] local position OK yes
	INFO  [ekf2] global position OK yes
	INFO  [ekf2] time slip: 35 us

	nsh> free
		     total       used       free    largest
	Mem:        233136     194832      38304      35904

this PR (same base)

	 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE FD
	   0 Idle Task                  103546 45.109   548/  748   0 (  0)  READY  3
	   1 hpwork                       4156  2.043   840/ 1780 249 (249)  w:sig 13
	   2 lpwork                        383  0.145   656/ 1780  50 ( 50)  w:sig  8
	   3 init                         9090  0.000  1784/ 2580 100 (100)  w:sem  3
	 348 top                           177  3.211  1296/ 1684 100 (100)  RUN    3
	 150 sensors                     14942  5.328  1352/ 1964 249 (249)  w:sem 18
	 106 gps                           451  0.218  1016/ 1580 220 (220)  w:sig  5
	 152 commander                    1748  0.802  1992/ 3212 140 (140)  w:sig 28
	 153 commander_low_prio              8  0.000   568/ 2996  50 ( 50)  w:sem 28
	 164 fmu                          4564  2.189   928/ 1292 251 (251)  w:sem 10
	 167 mavlink_if0                 10223  4.890  1720/ 2396 100 (100)  READY 32
	 168 mavlink_rcv_if0               795  0.364  1128/ 2836 175 (175)  w:sem 32
	 174 mavlink_if1                  3734  1.824  1720/ 2420 100 (100)  READY 32
	 175 mavlink_rcv_if1               807  0.437  1052/ 2836 175 (175)  w:sem 32
	 179 frsky_telemetry                 2  0.000   592/ 1188 104 (104)  w:sem  4
	 189 mavlink_if2                  2009  0.875  1720/ 2388 100 (100)  w:sig 29
	 190 mavlink_rcv_if2               828  0.437  1200/ 2836 175 (175)  w:sem 29
	 229 mavlink_if3                 10737  5.328  1632/ 2388 100 (100)  w:sig 32
	 230 mavlink_rcv_if3               744  0.437  1120/ 2836 175 (175)  w:sem 32
	 274 ekf2                        30464 15.182  5104/ 6572 250 (250)  w:sem 19
	 277 mc_att_control               6797  3.284   856/ 1660 251 (251)  w:sem 16
	 282 mc_pos_control              10143  5.255  1152/ 1876 250 (250)  w:sem 12
	 297 navigator                     371  0.218  1000/ 1764 105 (105)  w:sem 15
	 336 logger                       2394  1.021  1032/ 3540 245 (245)  w:sem 35
	 337 log_writer_file                 0  0.000   344/ 1068  60 ( 60)  w:sem 35

	Processes: 25 total, 4 running, 21 sleeping, max FDs: 54
	CPU usage: 53.50% tasks, 1.39% sched, 45.11% idle
	DMA Memory: 5120 total, 0 used 0 peak
	Uptime: 209.811s total, 103.547s idle

	nsh> ekf2 status
	INFO  [ekf2] local position OK yes
	INFO  [ekf2] global position OK yes
	INFO  [ekf2] time slip: 27 us

	nsh> free
		     total       used       free    largest
	Mem:        233136     194832      38304      35888

Binary comparison

	     VM SIZE                                                                                        FILE SIZE
	 --------------                                                                                  --------------
	  [NEW]     +58 __powisf2                                                                            +58  [NEW]
	  +0.0%     +22 [Unmapped]                                                                       -7.78Ki  -0.1%
	  -5.1%     -24 Ekf::calcRotVecVariances()                                                           -24  -5.1%
	  -2.2%     -24 MulticopterPositionControl::control_manual()                                         -24  -2.2%
	 -34.3%     -24 mavlink_wpm_distance_to_point_local                                                  -24 -34.3%
	 -13.2%     -28 Ekf::get_ekf_gpos_accuracy(float*, float*, bool*)                                    -28 -13.2%
	  -2.4%     -28 Ekf::gps_is_good(estimator::gps_message*)                                            -28  -2.4%
	 -16.7%     -32 Ekf::get_ekf_lpos_accuracy(float*, float*, bool*)                                    -32 -16.7%
	 -10.1%     -32 Ekf::get_ekf_vel_accuracy(float*, float*, bool*)                                     -32 -10.1%
	  -0.6%     -36 Ekf2::run()                                                                          -36  -0.6%
	  -2.8%     -36 Ekf::initialiseQuatCovariances(matrix::Vector3<float>&)                              -36  -2.8%
	  -2.8%     -36 do_level_calibration(void**)                                                         -36  -2.8%
	  -5.6%     -56 Standard::update_mc_state() (.part.0)                                                -56  -5.6%
	  -1.1%     -58 Ekf::fuseDrag()                                                                      -58  -1.1%
	  -1.7%     -60 MulticopterPositionControl::control_auto()                                           -60  -1.7%
	  -6.2%     -64 MulticopterPositionControl::set_manual_acceleration_xy(matrix::Vector2<float>&)      -64  -6.2%
	 -13.8%     -68 Ekf::resetWindStates()                                                               -68 -13.8%
	  -8.2%     -68 VtolType::check_quadchute_condition()                                                -68  -8.2%
	 -18.9%     -68 matrix::Euler<float>::Euler(matrix::Quaternion<float> const&)                        -68 -18.9%
	 -12.0%     -68 vmount::OutputBase::_calculate_output_angles(unsigned long long const&)              -68 -12.0%
	  -6.3%     -76 ControlMath::thrustToAttitude(matrix::Vector3<float> const&, float)                  -76  -6.3%
	  -4.8%     -84 Ekf::resetMagHeading(matrix::Vector3<float>&)                                        -84  -4.8%
	  -7.2%     -84 run_lm_sphere_fit(float const*, float const*, float const*, float&, float&, unsi     -84  -7.2%
	  -6.7%     -92 run_lm_ellipsoid_fit(float const*, float const*, float const*, float&, float&, u     -92  -6.7%
	  [DEL]    -172 sqrtf                                                                               -172  [DEL]
	  -0.6%    -290 [53 Others]                                                                         -290  -0.6%
	  -0.1% -1.49Ki TOTAL                                                                            -9.29Ki  -0.1%
