### PR TITLE
mc_att_control: revert rate feed forward

### DIFF
--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -173,6 +173,7 @@ private:
 	matrix::Vector3f _rates_prev;			/**< angular rates on previous step */
 	matrix::Vector3f _rates_prev_filtered;		/**< angular rates on previous step (low-pass filtered) */
 	matrix::Vector3f _rates_sp;			/**< angular rates setpoint */
+	matrix::Vector3f _rates_sp_prev;		/**< angular rates setpoint from last loop iteration for derivative */
 	matrix::Vector3f _rates_int;			/**< angular rates integral error */
 	float _thrust_sp;				/**< thrust setpoint */
 	matrix::Vector3f _att_control;			/**< attitude control vector */

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -534,8 +534,9 @@ MulticopterAttitudeControl::control_attitude_rates(float dt)
 	_att_control = rates_p_scaled.emult(rates_err) +
 		       _rates_int -
 		       rates_d_scaled.emult(rates_filtered - _rates_prev_filtered) / dt +
-		       _rate_ff.emult(_rates_sp);
+		       _rate_ff.emult(_rates_sp - _rates_sp_prev) / dt;
 
+	_rates_sp_prev = _rates_sp;
 	_rates_prev = rates;
 	_rates_prev_filtered = rates_filtered;
 

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -117,12 +117,7 @@ MulticopterAttitudeControl::MulticopterAttitudeControl() :
 	_v_att.q[0] = 1.f;
 	_v_att_sp.q_d[0] = 1.f;
 
-	_rates_prev.zero();
-	_rates_prev_filtered.zero();
-	_rates_sp.zero();
-	_rates_int.zero();
 	_thrust_sp = 0.0f;
-	_att_control.zero();
 
 	/* initialize thermal corrections as we might not immediately get a topic update (only non-zero values) */
 	for (unsigned i = 0; i < 3; i++) {


### PR DESCRIPTION
Based on the findings of @bigbellmercy and the discussion here https://github.com/PX4/Firmware/commit/7f04e3c759b04d6b622ea9743cdc93a3c9a09f8f#r28424755
We can continue in this pr. It would be interesting to hear why is was changed in the first place prsumably for the helicopter application of @bartslinger.

---

It seems that a theoretically incorrect calculation
was introduced and this pr reverts to the original state.

Reverting attitude control part of 7f04e3c759b04d6b622ea9743cdc93a3c9a09f8f and 5b7c062f67c2d971f58b0f22f41587fdcccd01c9