### PR TITLE
mavlink: include differential pressure in fields updated bit shift

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -666,6 +666,7 @@ private:
 	uint64_t _gyro_timestamp;
 	uint64_t _mag_timestamp;
 	uint64_t _baro_timestamp;
+	uint64_t _dpres_timestamp;
 
 	/* do not allow top copying this class */
 	MavlinkStreamHighresIMU(MavlinkStreamHighresIMU &);
@@ -682,7 +683,8 @@ protected:
 		_accel_timestamp(0),
 		_gyro_timestamp(0),
 		_mag_timestamp(0),
-		_baro_timestamp(0)
+		_baro_timestamp(0),
+		_dpres_timestamp(0)
 	{}
 
 	bool send(const hrt_abstime t)
@@ -717,7 +719,7 @@ protected:
 			_air_data_sub->update(&air_data);
 
 			if (_baro_timestamp != air_data.timestamp) {
-				/* mark last group dimensions as changed */
+				/* mark fourth group (baro fields) dimensions as changed */
 				fields_updated |= (1 << 9) | (1 << 11) | (1 << 12);
 				_baro_timestamp = air_data.timestamp;
 			}
@@ -727,6 +729,12 @@ protected:
 
 			differential_pressure_s differential_pressure = {};
 			_differential_pressure_sub->update(&differential_pressure);
+
+			if (_dpres_timestamp != differential_pressure.timestamp) {
+				/* mark fourth group (dpres field) dimensions as changed */
+				fields_updated |= (1 << 10);
+				_dpres_timestamp = differential_pressure.timestamp;
+			}
 
 			mavlink_highres_imu_t msg = {};
 


### PR DESCRIPTION
adds differential pressure to the bit shifts on the fields_updated integer. diff pres values are already shown on QGC, but the MAVROS imu plugin has a condition with the fields_updated int before publishing new values. See https://github.com/mavlink/mavros/pull/1001

Only question would be if including the bit shift within the "air_data" timestamp condition (a separate topic) is actually the most proper thing to do, or should there be a separate check specifically for the differential_pressure topic. And if so, how best to do this when "air_data" lumps all four quantities into one group?