### PR TITLE
mag_calibration: only allocate as much memory as needed

### DIFF
--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -569,7 +569,15 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 
 	char str[30];
 
-	for (size_t cur_mag = 0; cur_mag < max_mags; cur_mag++) {
+	// Get actual mag count and alloate only as much memory as needed
+	const unsigned orb_mag_count = orb_group_count(ORB_ID(sensor_mag));
+
+	// Warn that we will not calibrate more than max_mags magnetometers
+	if (orb_mag_count > max_mags) {
+		calibration_log_critical(mavlink_log_pub, "Detected %u mags, but will calibrate only %u", orb_mag_count, max_mags);
+	}
+
+	for (size_t cur_mag = 0; cur_mag < orb_mag_count && cur_mag < max_mags; cur_mag++) {
 		worker_data.x[cur_mag] = reinterpret_cast<float *>(malloc(sizeof(float) * calibration_points_maxcount));
 		worker_data.y[cur_mag] = reinterpret_cast<float *>(malloc(sizeof(float) * calibration_points_maxcount));
 		worker_data.z[cur_mag] = reinterpret_cast<float *>(malloc(sizeof(float) * calibration_points_maxcount));
@@ -585,13 +593,6 @@ calibrate_return mag_calibrate_all(orb_advert_t *mavlink_log_pub)
 	if (result == calibrate_return_ok) {
 
 		// We should not try to subscribe if the topic doesn't actually exist and can be counted.
-		const unsigned orb_mag_count = orb_group_count(ORB_ID(sensor_mag));
-
-		// Warn that we will not calibrate more than max_mags magnetometers
-		if (orb_mag_count > max_mags) {
-			calibration_log_critical(mavlink_log_pub, "Detected %u mags, but will calibrate only %u", orb_mag_count, max_mags);
-		}
-
 		for (unsigned cur_mag = 0; cur_mag < orb_mag_count && cur_mag < max_mags; cur_mag++) {
 
 			// Lock in to correct ORB instance


### PR DESCRIPTION
PX4 has a hard-coded maximum number of magnetometers it supports, which is 4:
https://github.com/PX4/Firmware/blob/123f11fcdda9dc6c39ebd94657c5ee94ee53cc90/src/modules/commander/mag_calibration.cpp#L66

Current situation: The calibration routine always allocates the memory for four mags to be calibrated, even when the platform only has a single compass. 

Suggestion: Only allocate the memory for the number of mags that the platform actually carries. In case of a single mag, the memory footprint is lowered by almost 75%.
