### PR TITLE
rcS: do not reset COM_FLTMODE* on airframe change

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -150,8 +150,8 @@ then
 	#
 	if param compare SYS_AUTOCONFIG 1
 	then
-		# Wipe out params except RC* and total flight time
-		param reset_nostart RC* LND_FLIGHT_T_*
+		# Wipe out params except RC*, flight modes and total flight time
+		param reset_nostart RC* COM_FLTMODE* LND_FLIGHT_T_*
 		set AUTOCNF yes
 	else
 		set AUTOCNF no


### PR DESCRIPTION
An airframe change keeps all RC params except the flight modes. This fixes that.