### PR TITLE
IridiumSBD Debug Message + Acknowlege fix

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -62,6 +62,7 @@ set(msg_files
 	gps_inject_data.msg
 	home_position.msg
 	input_rc.msg
+	iridiumsbd_status.msg
 	irlock_report.msg
 	landing_target_innovations.msg
 	landing_target_pose.msg

--- a/msg/iridiumsbd_status.msg
+++ b/msg/iridiumsbd_status.msg
@@ -1,0 +1,14 @@
+uint64 last_heartbeat				# timestamp of the last successful sbd session
+uint16 tx_buf_write_index			# current size of the tx buffer
+uint16 rx_buf_read_index			# the rx buffer is parsed up to that index
+uint16 rx_buf_end_index				# current size of the rx buffer
+uint16 failed_sbd_sessions			# number of failed sbd sessions
+uint16 successful_sbd_sessions      # number of successfull sbd sessions
+uint16 num_tx_buf_reset             # number of times the tx buffer was reset
+uint8 signal_quality                # current signal quality, 0 is no signal, 5 the best
+uint8 state                         # current state of the driver, see the satcom_state of IridiumSBD.h for the definition
+bool ring_pending                   # indicates if a ring call is pending
+bool tx_buf_write_pending           # indicates if a tx buffer write is pending
+bool tx_session_pending             # indicates if a tx session is pending
+bool rx_read_pending                # indicates if a rx read is pending
+bool rx_session_pending             # indicates if a rx session is pending

--- a/src/drivers/telemetry/iridiumsbd/IridiumSBD.h
+++ b/src/drivers/telemetry/iridiumsbd/IridiumSBD.h
@@ -41,6 +41,7 @@
 
 #include <uORB/uORB.h>
 #include <uORB/topics/telemetry_status.h>
+#include <uORB/topics/iridiumsbd_status.h>
 
 typedef enum {
 	SATCOM_OK = 0,
@@ -259,6 +260,8 @@ private:
 	 */
 	void publish_telemetry_status(void);
 
+	void publish_iridium_status(void);
+
 	/**
 	 * Notification of the first open of CDev.
 	 *
@@ -297,11 +300,14 @@ private:
 	hrt_abstime _last_signal_check = 0;
 	uint8_t _signal_quality = 0;
 	uint16_t _failed_sbd_sessions = 0;
+	uint16_t _successful_sbd_sessions = 0;
+	uint16_t _num_tx_buf_reset = 0;
 
 	bool _writing_mavlink_packet = false;
 	uint16_t _packet_length = 0;
 
 	orb_advert_t _telemetry_status_pub = nullptr;
+	orb_advert_t _iridiumsbd_status_pub = nullptr;
 
 	bool _test_pending = false;
 	char _test_command[32];
@@ -335,4 +341,6 @@ private:
 
 	pthread_mutex_t _tx_buf_mutex = pthread_mutex_t();
 	bool _verbose = false;
+
+	iridiumsbd_status_s _status = {};
 };

--- a/src/drivers/telemetry/iridiumsbd/IridiumSBD.h
+++ b/src/drivers/telemetry/iridiumsbd/IridiumSBD.h
@@ -333,6 +333,8 @@ private:
 	satcom_state _new_state = SATCOM_STATE_STANDBY;
 
 	pthread_mutex_t _tx_buf_mutex = pthread_mutex_t();
+	pthread_mutex_t _rx_buf_mutex = pthread_mutex_t();
+
 	bool _verbose = false;
 
 	iridiumsbd_status_s _status = {};

--- a/src/drivers/telemetry/iridiumsbd/IridiumSBD.h
+++ b/src/drivers/telemetry/iridiumsbd/IridiumSBD.h
@@ -40,7 +40,6 @@
 #include <drivers/drv_hrt.h>
 
 #include <uORB/uORB.h>
-#include <uORB/topics/telemetry_status.h>
 #include <uORB/topics/iridiumsbd_status.h>
 
 typedef enum {
@@ -255,11 +254,6 @@ private:
 	 */
 	pollevent_t poll_state(struct file *filp);
 
-	/*
-	 * Publish the up to date telemetry status
-	 */
-	void publish_telemetry_status(void);
-
 	void publish_iridium_status(void);
 
 	/**
@@ -306,7 +300,6 @@ private:
 	bool _writing_mavlink_packet = false;
 	uint16_t _packet_length = 0;
 
-	orb_advert_t _telemetry_status_pub = nullptr;
 	orb_advert_t _iridiumsbd_status_pub = nullptr;
 
 	bool _test_pending = false;

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -45,6 +45,7 @@
 #include <uORB/Publication.hpp>
 #include <uORB/topics/actuator_armed.h>
 #include <uORB/topics/home_position.h>
+#include <uORB/topics/iridiumsbd_status.h>
 #include <uORB/topics/vehicle_command_ack.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_status.h>
@@ -168,13 +169,11 @@ private:
 		bool high_latency = false;
 	} _telemetry[ORB_MULTI_MAX_INSTANCES];
 
-	// publisher
-	orb_advert_t _vehicle_cmd_pub = nullptr;
-
 	// Subscriptions
 	Subscription<mission_result_s>			_mission_result_sub;
 	Subscription<vehicle_global_position_s>		_global_position_sub;
 	Subscription<vehicle_local_position_s>		_local_position_sub;
+	Subscription<iridiumsbd_status_s> 		_iridiumsbd_status_sub;
 };
 
 #endif /* COMMANDER_HPP_ */

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1021,7 +1021,10 @@ Commander::handle_command(vehicle_status_s *status_local, const vehicle_command_
 	break;
 	case vehicle_command_s::VEHICLE_CMD_CONTROL_HIGH_LATENCY: {
 			// only send the acknowledge from the commander, the command actually is handled by each mavlink instance
-			cmd_result = vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED;
+			// only send the acknowledge if the command is received from an external source
+			if (cmd.from_external) {
+				cmd_result = vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED;
+			}
 		}
 		break;
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -600,6 +600,7 @@ void Logger::add_default_topics()
 	add_topic("estimator_status", 200);
 	add_topic("home_position");
 	add_topic("input_rc", 200);
+	add_topic("iridiumsbd_status");
 	add_topic("landing_target_pose");
 	add_topic("manual_control_setpoint", 200);
 	add_topic("mission");

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1971,6 +1971,9 @@ Mavlink::task_main(int argc, char *argv[])
 	ack_sub->subscribe_from_beginning(true);
 	cmd_sub->subscribe_from_beginning(true);
 
+	/* command ack */
+	orb_advert_t command_ack_pub = nullptr;
+
 	MavlinkOrbSubscription *mavlink_log_sub = add_orb_subscription(ORB_ID(mavlink_log));
 
 	struct vehicle_status_s status;
@@ -2195,6 +2198,20 @@ Mavlink::task_main(int argc, char *argv[])
 			set_hil_enabled(status.hil_state == vehicle_status_s::HIL_STATE_ON);
 
 			set_manual_input_mode_generation(status.rc_input_mode == vehicle_status_s::RC_IN_MODE_GENERATED);
+
+			if (_mode == MAVLINK_MODE_IRIDIUM) {
+				if (_transmitting_enabled &&
+				    !status.high_latency_data_link_active &&
+				    !_transmitting_enabled_commanded &&
+				    (_last_write_success_time > 0u)) { // a first message is written
+					_transmitting_enabled = false;
+					mavlink_and_console_log_info(&_mavlink_log_pub, "Disable transmitting with IRIDIUM mavlink on device %s", _device_name);
+
+				} else if (!_transmitting_enabled && status.high_latency_data_link_active) {
+					_transmitting_enabled = true;
+					mavlink_and_console_log_info(&_mavlink_log_pub, "Enable transmitting with IRIDIUM mavlink on device %s", _device_name);
+				}
+			}
 		}
 
 		struct vehicle_command_s vehicle_cmd;
@@ -2204,7 +2221,8 @@ Mavlink::task_main(int argc, char *argv[])
 			    (_mode == MAVLINK_MODE_IRIDIUM)) {
 				if (vehicle_cmd.param1 > 0.5f) {
 					if (!_transmitting_enabled) {
-						PX4_INFO("Enable transmitting with IRIDIUM mavlink on device %s by command", _device_name);
+						mavlink_and_console_log_info(&_mavlink_log_pub, "Enable transmitting with IRIDIUM mavlink on device %s by command",
+									     _device_name);
 					}
 
 					_transmitting_enabled = true;
@@ -2212,11 +2230,32 @@ Mavlink::task_main(int argc, char *argv[])
 
 				} else {
 					if (_transmitting_enabled) {
-						PX4_INFO("Disable transmitting with IRIDIUM mavlink on device %s by command", _device_name);
+						mavlink_and_console_log_info(&_mavlink_log_pub, "Disable transmitting with IRIDIUM mavlink on device %s by command",
+									     _device_name);
 					}
 
 					_transmitting_enabled = false;
 					_transmitting_enabled_commanded = false;
+				}
+
+				// send positive command ack
+				struct vehicle_command_ack_s command_ack = {
+					.timestamp = vehicle_cmd.timestamp,
+					.result_param2 = 0,
+					.command = vehicle_cmd.command,
+					.result = vehicle_command_ack_s::VEHICLE_RESULT_ACCEPTED,
+					.from_external = !vehicle_cmd.from_external,
+					.result_param1 = 0,
+					.target_system = vehicle_cmd.source_system,
+					.target_component = vehicle_cmd.source_component
+				};
+
+				if (command_ack_pub != nullptr) {
+					orb_publish(ORB_ID(vehicle_command_ack), command_ack_pub, &command_ack);
+
+				} else {
+					command_ack_pub = orb_advertise_queue(ORB_ID(vehicle_command_ack), &command_ack,
+									      vehicle_command_ack_s::ORB_QUEUE_LENGTH);
 				}
 			}
 		}
@@ -2326,13 +2365,6 @@ Mavlink::task_main(int argc, char *argv[])
 		MavlinkStream *stream;
 		LL_FOREACH(_streams, stream) {
 			stream->update(t);
-		}
-
-		if (_mode == MAVLINK_MODE_IRIDIUM) {
-			if ((_last_write_success_time > 0u) && !_transmitting_enabled_commanded && _transmitting_enabled) {
-				_transmitting_enabled = false;
-				PX4_INFO("Disable Iridium Mavlink after first packet is sent");
-			}
 		}
 
 		/* pass messages from other UARTs */

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2348,6 +2348,22 @@ MavlinkReceiver::receive_thread(void *arg)
 	// poll timeout in ms. Also defines the max update frequency of the mission & param manager, etc.
 	const int timeout = 10;
 
+	// publish the telemetry status once for the iridium telemetry
+	if (_mavlink->get_mode() == Mavlink::MAVLINK_MODE_IRIDIUM) {
+		struct telemetry_status_s &tstatus = _mavlink->get_rx_status();
+
+		tstatus.timestamp = hrt_absolute_time();
+		tstatus.type = telemetry_status_s::TELEMETRY_STATUS_RADIO_TYPE_IRIDIUM;
+
+		if (_telemetry_status_pub == nullptr) {
+			int multi_instance;
+			_telemetry_status_pub = orb_advertise_multi(ORB_ID(telemetry_status), &tstatus, &multi_instance, ORB_PRIO_HIGH);
+
+		} else {
+			orb_publish(ORB_ID(telemetry_status), _telemetry_status_pub, &tstatus);
+		}
+	}
+
 #ifdef __PX4_POSIX
 	/* 1500 is the Wifi MTU, so we make sure to fit a full packet */
 	uint8_t buf[1600 * 5];


### PR DESCRIPTION
- Add a message with the status of the iridiumsbd driver. It is published at every loop of the driver if the status changed.

- Only send the acknowledge for the VEHICLE_CMD_CONTROL_HIGH_LATENCY command if the command is coming from external.