### PR TITLE
esc_calibration: increase safety and initialise all data

### DIFF
--- a/src/modules/commander/esc_calibration.cpp
+++ b/src/modules/commander/esc_calibration.cpp
@@ -99,7 +99,7 @@ int do_esc_calibration(orb_advert_t *mavlink_log_pub, struct actuator_armed_s* a
 	bool	batt_updated = false;
 	bool	batt_connected = true;	// for safety resons assume battery is connected, will be cleared below if not the case
 
-	hrt_abstime battery_connect_wait_timeout = 3_s;
+	hrt_abstime battery_connect_wait_timeout = 20_s;
 	hrt_abstime pwm_high_timeout = 3_s;
 	hrt_abstime timeout_start = 0;
 

--- a/src/modules/commander/esc_calibration.cpp
+++ b/src/modules/commander/esc_calibration.cpp
@@ -61,13 +61,15 @@
 #include <drivers/drv_hrt.h>
 #include <systemlib/mavlink_log.h>
 
+using namespace time_literals;
+
 int do_esc_calibration(orb_advert_t *mavlink_log_pub, struct actuator_armed_s* armed)
 {
 	int	return_code = PX4_OK;
 	
 #if defined(__PX4_POSIX_OCPOC)
 	hrt_abstime timeout_start = 0;
-	hrt_abstime timeout_wait = 60*1000*1000;
+	hrt_abstime timeout_wait = 60_s;
 	armed->in_esc_calibration_mode = true;
 	calibration_log_info(mavlink_log_pub, CAL_QGC_DONE_MSG, "begin esc");
 	timeout_start = hrt_absolute_time();
@@ -97,8 +99,8 @@ int do_esc_calibration(orb_advert_t *mavlink_log_pub, struct actuator_armed_s* a
 	bool	batt_updated = false;
 	bool	batt_connected = true;	// for safety resons assume battery is connected, will be cleared below if not the case
 
-	hrt_abstime battery_connect_wait_timeout = 30*1000*1000;
-	hrt_abstime pwm_high_timeout = 3*1000*1000;
+	hrt_abstime battery_connect_wait_timeout = 3_s;
+	hrt_abstime pwm_high_timeout = 3_s;
 	hrt_abstime timeout_start = 0;
 
 	calibration_log_info(mavlink_log_pub, CAL_QGC_STARTED_MSG, "esc");
@@ -181,7 +183,7 @@ int do_esc_calibration(orb_advert_t *mavlink_log_pub, struct actuator_armed_s* a
 				}
 			}
 		}
-		usleep(50*1000);
+		usleep(50_ms);
 	}
 
 Out:

--- a/src/modules/commander/esc_calibration.cpp
+++ b/src/modules/commander/esc_calibration.cpp
@@ -161,7 +161,7 @@ int do_esc_calibration(orb_advert_t *mavlink_log_pub, struct actuator_armed_s* a
 		// sit high.
 		hrt_abstime timeout_wait = batt_connected ? pwm_high_timeout : battery_connect_wait_timeout;
 
-		if (hrt_absolute_time() - timeout_start > timeout_wait) {
+		if (hrt_elapsed_time(&timeout_start) > timeout_wait) {
 			if (!batt_connected) {
 				calibration_log_critical(mavlink_log_pub, CAL_QGC_FAILED_MSG, "Timeout waiting for battery");
 				goto Error;

--- a/src/modules/commander/esc_calibration.cpp
+++ b/src/modules/commander/esc_calibration.cpp
@@ -114,8 +114,8 @@ int do_esc_calibration(orb_advert_t *mavlink_log_pub, struct actuator_armed_s* a
 	// Make sure battery is disconnected
 	if (orb_copy(ORB_ID(battery_status), batt_sub, &battery) == PX4_OK) {
 
-		// battery is not connected if voltage is lower than 3V and we have a recent battery measurement
-		if (battery.voltage_filtered_v < 3.0f && (hrt_absolute_time() - battery.timestamp < 500*1000)) {
+		// battery is not connected if the connected flag is not set and we have a recent battery measurement
+		if (!battery.connected && (hrt_absolute_time() - battery.timestamp < 500_ms)) {
 			batt_connected = false;
 		}
 	}
@@ -175,7 +175,7 @@ int do_esc_calibration(orb_advert_t *mavlink_log_pub, struct actuator_armed_s* a
 			orb_check(batt_sub, &batt_updated);
 			if (batt_updated) {
 				orb_copy(ORB_ID(battery_status), batt_sub, &battery);
-				if (battery.voltage_filtered_v > 3.0f) {
+				if (battery.connected) {
 					// Battery is connected, signal to user and start waiting again
 					batt_connected = true;
 					timeout_start = hrt_absolute_time();

--- a/src/modules/commander/esc_calibration.h
+++ b/src/modules/commander/esc_calibration.h
@@ -44,7 +44,6 @@
 
 #include <uORB/topics/actuator_armed.h>
 
-int check_if_batt_disconnected(orb_advert_t *mavlink_log_pub);
 int do_esc_calibration(orb_advert_t *mavlink_log_pub, struct actuator_armed_s* armed);
 
 #endif


### PR DESCRIPTION
In certain situations it might have been possible to start an ESC calibration even if the battery was still connected. This adds some additional checks to make sure that we have a valid battery measurement.
Furthermore, some data was not initialised and could have possibly led to unexpected behavior.