### PR TITLE
VTOL cleanup transition switch and vtol_vehicle_status

### DIFF
--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -54,7 +54,6 @@ uint8 component_id			# subsystem / component id, contains MAVLink's component ID
 bool is_rotary_wing			# True if system is in rotary wing configuration, so for a VTOL this is only true while flying as a multicopter
 bool is_vtol				# True if the system is VTOL capable
 bool in_transition_mode			# True if VTOL is doing a transition
-bool in_transition_to_fw		# True if VTOL is doing a transition from MC to FW
 
 bool rc_signal_lost				# true if RC reception lost
 uint8 rc_input_mode				# set to 1 to disable the RC input, 2 to enable manual control to RC in mapping.

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -53,7 +53,6 @@ uint8 component_id			# subsystem / component id, contains MAVLink's component ID
 
 bool is_rotary_wing			# True if system is in rotary wing configuration, so for a VTOL this is only true while flying as a multicopter
 bool is_vtol				# True if the system is VTOL capable
-bool vtol_fw_permanent_stab		# True if VTOL should stabilize attitude for fw in manual mode
 bool in_transition_mode			# True if VTOL is doing a transition
 bool in_transition_to_fw		# True if VTOL is doing a transition from MC to FW
 

--- a/msg/vtol_vehicle_status.msg
+++ b/msg/vtol_vehicle_status.msg
@@ -5,8 +5,8 @@ uint8 VEHICLE_VTOL_STATE_TRANSITION_TO_MC = 2
 uint8 VEHICLE_VTOL_STATE_MC = 3
 uint8 VEHICLE_VTOL_STATE_FW = 4
 
-bool vtol_in_rw_mode			# true: vtol vehicle is in rotating wing mode
-bool vtol_in_trans_mode
-bool in_transition_to_fw		# True if VTOL is doing a transition from MC to FW
+uint8 vtol_state
+
 bool vtol_transition_failsafe	# vtol in transition failsafe mode
+
 bool fw_permanent_stab			# In fw mode stabilize attitude even if in manual mode

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -436,23 +436,15 @@ int commander_main(int argc, char *argv[])
 
 	if (!strcmp(argv[1], "transition")) {
 
-		struct vehicle_command_s cmd = {
-			.timestamp = 0,
-			.param5 = NAN,
-			.param6 = NAN,
-			/* transition to the other mode */
-			.param1 = (float)((status.is_rotary_wing) ? vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW : vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC),
-			.param2 = NAN,
-			.param3 = NAN,
-			.param4 = NAN,
-			.param7 = NAN,
-			.command = vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION,
-			.target_system = status.system_id,
-			.target_component = status.component_id
-		};
+		vehicle_command_s vcmd = {};
+		vcmd.timestamp = hrt_absolute_time();
+		vcmd.command = vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION;
+		vcmd.param1 = (float)((status.is_rotary_wing) ? vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW : vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC);
+		vcmd.target_system = status.system_id;
+		vcmd.target_component = status.component_id;
 
-		orb_advert_t h = orb_advertise_queue(ORB_ID(vehicle_command), &cmd, vehicle_command_s::ORB_QUEUE_LENGTH);
-		(void)orb_unadvertise(h);
+		orb_advert_t h = orb_advertise_queue(ORB_ID(vehicle_command), &vcmd, vehicle_command_s::ORB_QUEUE_LENGTH);
+		orb_unadvertise(h);
 
 		return 0;
 	}
@@ -1349,9 +1341,6 @@ Commander::run()
 
 	/* Subscribe to vtol vehicle status topic */
 	int vtol_vehicle_status_sub = orb_subscribe(ORB_ID(vtol_vehicle_status));
-	//struct vtol_vehicle_status_s vtol_status;
-	memset(&vtol_status, 0, sizeof(vtol_status));
-	vtol_status.vtol_in_rw_mode = true;		//default for vtol is rotary wing
 
 	/* subscribe to estimator status topic */
 	int estimator_status_sub = orb_subscribe(ORB_ID(estimator_status));
@@ -1488,15 +1477,6 @@ Commander::run()
 					status.system_type = (uint8_t)system_type;
 				}
 
-				/* disable manual override for all systems that rely on electronic stabilization */
-				if (is_rotary_wing(&status) || (is_vtol(&status) && vtol_status.vtol_in_rw_mode)) {
-					status.is_rotary_wing = true;
-
-				} else {
-					status.is_rotary_wing = false;
-				}
-
-				/* set vehicle_status.is_vtol flag */
 				status.is_vtol = is_vtol(&status);
 
 				/* check and update system / component ID */
@@ -1586,7 +1566,34 @@ Commander::run()
 		orb_check(sp_man_sub, &updated);
 
 		if (updated) {
-			orb_copy(ORB_ID(manual_control_setpoint), sp_man_sub, &sp_man);
+			if (orb_copy(ORB_ID(manual_control_setpoint), sp_man_sub, &sp_man) == PX4_OK) {
+
+				// VTOL transition switch
+				if ((sp_man.transition_switch != _last_sp_man.transition_switch) &&
+					(sp_man.transition_switch != manual_control_setpoint_s::SWITCH_POS_NONE) &&
+					control_mode.flag_control_manual_enabled) {
+
+					uint8_t vtol_new_state = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_UNDEFINED;
+
+					if (sp_man.transition_switch == manual_control_setpoint_s::SWITCH_POS_ON) {
+						vtol_new_state = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW;
+					} else if (sp_man.transition_switch == manual_control_setpoint_s::SWITCH_POS_OFF) {
+						vtol_new_state = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC;
+					}
+
+					if (vtol_new_state != vtol_status.vtol_state) {
+						vehicle_command_s vcmd = {};
+						vcmd.timestamp = hrt_absolute_time();
+						vcmd.param1 = vtol_new_state;
+						vcmd.command = vehicle_command_s::VEHICLE_CMD_DO_VTOL_TRANSITION;
+						vcmd.target_system = status.system_id;
+						vcmd.target_component = status.component_id;
+
+						orb_advert_t h = orb_advertise_queue(ORB_ID(vehicle_command), &vcmd, vehicle_command_s::ORB_QUEUE_LENGTH);
+						orb_unadvertise(h);
+					}
+				}
+			}
 		}
 
 		orb_check(offboard_control_mode_sub, &updated);
@@ -1699,31 +1706,29 @@ Commander::run()
 		orb_check(vtol_vehicle_status_sub, &updated);
 
 		if (updated) {
-			/* vtol status changed */
-			orb_copy(ORB_ID(vtol_vehicle_status), vtol_vehicle_status_sub, &vtol_status);
-			status.vtol_fw_permanent_stab = vtol_status.fw_permanent_stab;
+			const uint8_t prev_vtol_state = vtol_status.vtol_state;
+			if (orb_copy(ORB_ID(vtol_vehicle_status), vtol_vehicle_status_sub, &vtol_status) == PX4_OK) {
 
-			/* Make sure that this is only adjusted if vehicle really is of type vtol */
-			if (is_vtol(&status)) {
+				status_flags.vtol_transition_failure = vtol_status.vtol_transition_failsafe;
 
-				// Check if there has been any change while updating the flags
-				if (status.is_rotary_wing != vtol_status.vtol_in_rw_mode) {
-					status.is_rotary_wing = vtol_status.vtol_in_rw_mode;
-					status_changed = true;
+				status.is_rotary_wing = true;
+				status.in_transition_mode = false;
+				status.in_transition_to_fw = false;
+
+				switch (vtol_status.vtol_state) {
+				case vtol_vehicle_status_s::VEHICLE_VTOL_STATE_TRANSITION_TO_FW:
+				case vtol_vehicle_status_s::VEHICLE_VTOL_STATE_TRANSITION_TO_MC:
+					status.in_transition_mode = true;
+					break;
+				case vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW:
+					status.is_rotary_wing = false;
+					status.in_transition_to_fw = true;
+					break;
+				default:
+					break;
 				}
 
-				if (status.in_transition_mode != vtol_status.vtol_in_trans_mode) {
-					status.in_transition_mode = vtol_status.vtol_in_trans_mode;
-					status_changed = true;
-				}
-
-				if (status.in_transition_to_fw != vtol_status.in_transition_to_fw) {
-					status.in_transition_to_fw = vtol_status.in_transition_to_fw;
-					status_changed = true;
-				}
-
-				if (status_flags.vtol_transition_failure != vtol_status.vtol_transition_failsafe) {
-					status_flags.vtol_transition_failure = vtol_status.vtol_transition_failsafe;
+				if (vtol_status.vtol_state != prev_vtol_state) {
 					status_changed = true;
 				}
 
@@ -2962,6 +2967,7 @@ Commander::set_main_state_rc(const vehicle_status_s &status_local, bool *changed
 		 (_last_sp_man.rattitude_switch == sp_man.rattitude_switch) &&
 		 (_last_sp_man.posctl_switch == sp_man.posctl_switch) &&
 		 (_last_sp_man.loiter_switch == sp_man.loiter_switch) &&
+		 (_last_sp_man.transition_switch == sp_man.transition_switch) &&
 		 (_last_sp_man.mode_slot == sp_man.mode_slot) &&
 		 (_last_sp_man.stab_switch == sp_man.stab_switch) &&
 		 (_last_sp_man.man_switch == sp_man.man_switch)))) {
@@ -3605,9 +3611,9 @@ bool
 stabilization_required()
 {
 	return (status.is_rotary_wing ||		// is a rotary wing, or
-		status.vtol_fw_permanent_stab || 	// is a VTOL in fixed wing mode and stabilisation is on, or
-		(vtol_status.vtol_in_trans_mode && 	// is currently a VTOL transitioning AND
-		 !status.is_rotary_wing));	// is a fixed wing, ie: transitioning back to rotary wing mode
+		vtol_status.fw_permanent_stab || 	// is a VTOL in fixed wing mode and stabilisation is on, or
+		(status.in_transition_mode && 		// is currently a VTOL transitioning AND
+		 !status.is_rotary_wing));		// is a fixed wing, ie: transitioning back to rotary wing mode
 }
 
 void

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1713,7 +1713,6 @@ Commander::run()
 
 				status.is_rotary_wing = true;
 				status.in_transition_mode = false;
-				status.in_transition_to_fw = false;
 
 				switch (vtol_status.vtol_state) {
 				case vtol_vehicle_status_s::VEHICLE_VTOL_STATE_TRANSITION_TO_FW:
@@ -1722,7 +1721,6 @@ Commander::run()
 					break;
 				case vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW:
 					status.is_rotary_wing = false;
-					status.in_transition_to_fw = true;
 					break;
 				default:
 					break;

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -33,6 +33,8 @@
 
 #include "FixedwingAttitudeControl.hpp"
 
+using namespace time_literals;
+
 /**
  * Fixedwing attitude control app start / stop handling function
  *
@@ -372,19 +374,21 @@ FixedwingAttitudeControl::vehicle_status_poll()
 
 		/* set correct uORB ID, depending on if vehicle is VTOL or not */
 		if (!_rates_sp_id) {
-			if (_vehicle_status.is_vtol) {
-				_rates_sp_id = ORB_ID(fw_virtual_rates_setpoint);
-				_actuators_id = ORB_ID(actuator_controls_virtual_fw);
-				_attitude_setpoint_id = ORB_ID(fw_virtual_attitude_setpoint);
+			if (hrt_elapsed_time(&_vehicle_status.timestamp) < 1_s) {
+				if (_vehicle_status.is_vtol) {
+					_rates_sp_id = ORB_ID(fw_virtual_rates_setpoint);
+					_actuators_id = ORB_ID(actuator_controls_virtual_fw);
+					_attitude_setpoint_id = ORB_ID(fw_virtual_attitude_setpoint);
 
-				_parameter_handles.vtol_type = param_find("VT_TYPE");
+					_parameter_handles.vtol_type = param_find("VT_TYPE");
 
-				parameters_update();
+					parameters_update();
 
-			} else {
-				_rates_sp_id = ORB_ID(vehicle_rates_setpoint);
-				_actuators_id = ORB_ID(actuator_controls_0);
-				_attitude_setpoint_id = ORB_ID(vehicle_attitude_setpoint);
+				} else {
+					_rates_sp_id = ORB_ID(vehicle_rates_setpoint);
+					_actuators_id = ORB_ID(actuator_controls_0);
+					_attitude_setpoint_id = ORB_ID(vehicle_attitude_setpoint);
+				}
 			}
 		}
 	}

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -33,6 +33,8 @@
 
 #include "FixedwingPositionControl.hpp"
 
+using namespace time_literals;
+
 extern "C" __EXPORT int fw_pos_control_l1_main(int argc, char *argv[]);
 
 FixedwingPositionControl::FixedwingPositionControl() :
@@ -329,16 +331,18 @@ FixedwingPositionControl::vehicle_status_poll()
 
 		/* set correct uORB ID, depending on if vehicle is VTOL or not */
 		if (_attitude_setpoint_id == nullptr) {
-			if (_vehicle_status.is_vtol) {
-				_attitude_setpoint_id = ORB_ID(fw_virtual_attitude_setpoint);
+			if (hrt_elapsed_time(&_vehicle_status.timestamp) < 1_s) {
+				if (_vehicle_status.is_vtol) {
+					_attitude_setpoint_id = ORB_ID(fw_virtual_attitude_setpoint);
 
-				_parameter_handles.airspeed_trans = param_find("VT_ARSP_TRANS");
-				_parameter_handles.vtol_type = param_find("VT_TYPE");
+					_parameter_handles.airspeed_trans = param_find("VT_ARSP_TRANS");
+					_parameter_handles.vtol_type = param_find("VT_TYPE");
 
-				parameters_update();
+					parameters_update();
 
-			} else {
-				_attitude_setpoint_id = ORB_ID(vehicle_attitude_setpoint);
+				} else {
+					_attitude_setpoint_id = ORB_ID(vehicle_attitude_setpoint);
+				}
 			}
 		}
 	}

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -626,7 +626,7 @@ void Logger::add_default_topics()
 	add_topic("vehicle_status_flags");
 	add_topic("vehicle_vision_attitude");
 	add_topic("vehicle_vision_position");
-	add_topic("vtol_vehicle_status", 200);
+	add_topic("vtol_vehicle_status");
 	add_topic("wind_estimate", 200);
 
 #ifdef CONFIG_ARCH_BOARD_SITL

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -3613,6 +3613,7 @@ public:
 
 private:
 	MavlinkOrbSubscription *_status_sub;
+	MavlinkOrbSubscription *_vtol_status_sub;
 	MavlinkOrbSubscription *_landed_sub;
 	MavlinkOrbSubscription *_pos_sp_triplet_sub;
 	MavlinkOrbSubscription *_control_mode_sub;
@@ -3625,6 +3626,7 @@ private:
 protected:
 	explicit MavlinkStreamExtendedSysState(Mavlink *mavlink) : MavlinkStream(mavlink),
 		_status_sub(_mavlink->add_orb_subscription(ORB_ID(vehicle_status))),
+		_vtol_status_sub(_mavlink->add_orb_subscription(ORB_ID(vtol_vehicle_status))),
 		_landed_sub(_mavlink->add_orb_subscription(ORB_ID(vehicle_land_detected))),
 		_pos_sp_triplet_sub(_mavlink->add_orb_subscription(ORB_ID(position_setpoint_triplet))),
 		_control_mode_sub(_mavlink->add_orb_subscription(ORB_ID(vehicle_control_mode))),
@@ -3642,20 +3644,10 @@ protected:
 
 		if (_status_sub->update(&status)) {
 			updated = true;
+			vtol_vehicle_status_s vtol_status;
 
-			if (status.is_vtol) {
-				if (!status.in_transition_mode && status.is_rotary_wing) {
-					_msg.vtol_state = MAV_VTOL_STATE_MC;
-
-				} else if (!status.in_transition_mode) {
-					_msg.vtol_state = MAV_VTOL_STATE_FW;
-
-				} else if (status.in_transition_mode && status.in_transition_to_fw) {
-					_msg.vtol_state = MAV_VTOL_STATE_TRANSITION_TO_FW;
-
-				} else if (status.in_transition_mode) {
-					_msg.vtol_state = MAV_VTOL_STATE_TRANSITION_TO_MC;
-				}
+			if (status.is_vtol && _vtol_status_sub->update(&vtol_status)) {
+				_msg.vtol_state = vtol_status.vtol_state;
 			}
 		}
 

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -61,7 +61,7 @@
 #define AXIS_COUNT 3
 
 using namespace matrix;
-
+using namespace time_literals;
 
 int MulticopterAttitudeControl::print_usage(const char *reason)
 {
@@ -279,13 +279,14 @@ MulticopterAttitudeControl::vehicle_status_poll()
 
 		/* set correct uORB ID, depending on if vehicle is VTOL or not */
 		if (_rates_sp_id == nullptr) {
-			if (_vehicle_status.is_vtol) {
-				_rates_sp_id = ORB_ID(mc_virtual_rates_setpoint);
-				_actuators_id = ORB_ID(actuator_controls_virtual_mc);
-
-			} else {
-				_rates_sp_id = ORB_ID(vehicle_rates_setpoint);
-				_actuators_id = ORB_ID(actuator_controls_0);
+			if (hrt_elapsed_time(&_vehicle_status.timestamp) < 1_s) {
+				if (_vehicle_status.is_vtol) {
+					_rates_sp_id = ORB_ID(mc_virtual_rates_setpoint);
+					_actuators_id = ORB_ID(actuator_controls_virtual_mc);
+				} else {
+					_rates_sp_id = ORB_ID(vehicle_rates_setpoint);
+					_actuators_id = ORB_ID(actuator_controls_0);
+				}
 			}
 		}
 	}

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -80,6 +80,8 @@
 #include "PositionControl.hpp"
 #include "Utility/ControlMath.hpp"
 
+using namespace time_literals;
+
 #define SIGMA_SINGLE_OP			0.000001f
 #define SIGMA_NORM			0.001f
 /**
@@ -656,11 +658,13 @@ MulticopterPositionControl::poll_subscriptions()
 
 		/* set correct uORB ID, depending on if vehicle is VTOL or not */
 		if (!_attitude_setpoint_id) {
-			if (_vehicle_status.is_vtol) {
-				_attitude_setpoint_id = ORB_ID(mc_virtual_attitude_setpoint);
+			if (hrt_elapsed_time(&_vehicle_status.timestamp) < 1_s) {
+				if (_vehicle_status.is_vtol) {
+					_attitude_setpoint_id = ORB_ID(mc_virtual_attitude_setpoint);
 
-			} else {
-				_attitude_setpoint_id = ORB_ID(vehicle_attitude_setpoint);
+				} else {
+					_attitude_setpoint_id = ORB_ID(vehicle_attitude_setpoint);
+				}
 			}
 		}
 	}

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1036,7 +1036,7 @@ bool
 Navigator::force_vtol()
 {
 	return _vstatus.is_vtol &&
-	       (!_vstatus.is_rotary_wing || _vstatus.in_transition_to_fw)
+	       (!_vstatus.is_rotary_wing || (_vstatus.is_rotary_wing && _vstatus.in_transition_mode))
 	       && _param_force_vtol.get();
 }
 

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1567,8 +1567,8 @@ int sdlog2_thread_main(int argc, char *argv[])
 			/* --- VTOL VEHICLE STATUS --- */
 			if(copy_if_updated(ORB_ID(vtol_vehicle_status), &subs.vtol_status_sub, &buf.vtol_status)) {
 				log_msg.msg_type = LOG_VTOL_MSG;
-				log_msg.body.log_VTOL.rw_mode = buf.vtol_status.vtol_in_rw_mode;
-				log_msg.body.log_VTOL.trans_mode = buf.vtol_status.vtol_in_trans_mode;
+				log_msg.body.log_VTOL.rw_mode = (buf.vtol_status.vtol_state != VEHICLE_VTOL_STATE_FW);
+				log_msg.body.log_VTOL.trans_mode = (buf.vtol_status.vtol_state == VEHICLE_VTOL_STATE_TRANSITION_TO_FW) || (buf.vtol_status.vtol_state == VEHICLE_VTOL_STATE_TRANSITION_TO_MC);
 				log_msg.body.log_VTOL.failsafe_mode = buf.vtol_status.vtol_transition_failsafe;
 				LOGBUFFER_WRITE_AND_COUNT(VTOL);
 			}

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -125,26 +125,23 @@ void Standard::update_vtol_state()
 		// the transition to fw mode switch is off
 		if (_vtol_schedule.flight_mode == MC_MODE) {
 			// in mc mode
-			_vtol_schedule.flight_mode = MC_MODE;
 			mc_weight = 1.0f;
 			_pusher_throttle = 0.0f;
 			_reverse_output = 0.0f;
 
 		} else if (_vtol_schedule.flight_mode == FW_MODE) {
 			// transition to mc mode
-			if (_vtol_vehicle_status->vtol_transition_failsafe == true) {
+			if (_vtol_vehicle_status->vtol_transition_failsafe) {
 				// Failsafe event, engage mc motors immediately
 				_vtol_schedule.flight_mode = MC_MODE;
 				_pusher_throttle = 0.0f;
 				_reverse_output = 0.0f;
-
 
 			} else {
 				// Regular backtransition
 				_vtol_schedule.flight_mode = TRANSITION_TO_MC;
 				_vtol_schedule.transition_start = hrt_absolute_time();
 				_reverse_output = _params_standard.reverse_output;
-
 			}
 
 		} else if (_vtol_schedule.flight_mode == TRANSITION_TO_FW) {

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -389,7 +389,7 @@ void Standard::update_mc_state()
 void Standard::fill_actuator_outputs()
 {
 	// multirotor controls
-	_actuators_out_0->timestamp = _actuators_mc_in->timestamp;
+	_actuators_out_0->timestamp_sample = _actuators_mc_in->timestamp_sample;
 
 	// roll
 	_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] =
@@ -406,7 +406,7 @@ void Standard::fill_actuator_outputs()
 
 
 	// fixed wing controls
-	_actuators_out_1->timestamp = _actuators_fw_in->timestamp;
+	_actuators_out_1->timestamp_sample = _actuators_fw_in->timestamp_sample;
 
 	if (_vtol_schedule.flight_mode != MC_MODE) {
 		// roll

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -70,10 +70,6 @@ Standard::Standard(VtolAttitudeControl *attc) :
 	_params_handles_standard.reverse_delay = param_find("VT_B_REV_DEL");
 }
 
-Standard::~Standard()
-{
-}
-
 void
 Standard::parameters_update()
 {
@@ -131,7 +127,7 @@ void Standard::update_vtol_state()
 
 		} else if (_vtol_schedule.flight_mode == FW_MODE) {
 			// transition to mc mode
-			if (_vtol_vehicle_status->vtol_transition_failsafe) {
+			if (_vtol_vehicle_status.vtol_transition_failsafe) {
 				// Failsafe event, engage mc motors immediately
 				_vtol_schedule.flight_mode = MC_MODE;
 				_pusher_throttle = 0.0f;
@@ -162,9 +158,11 @@ void Standard::update_vtol_state()
 
 			if (time_since_trans_start > _params->back_trans_duration ||
 			    (_local_pos->v_xy_valid && x_vel <= _params->mpc_xy_cruise)) {
-				_vtol_schedule.flight_mode = MC_MODE;
-			}
 
+				_vtol_schedule.flight_mode = MC_MODE;
+
+				PX4_DEBUG("Transition to MC completed in %.3f", (double)time_since_trans_start);
+			}
 		}
 
 	} else {
@@ -192,8 +190,9 @@ void Standard::update_vtol_state()
 
 				// don't set pusher throttle here as it's being ramped up elsewhere
 				_trans_finished_ts = hrt_absolute_time();
-			}
 
+				PX4_DEBUG("Transition to FW completed in %.3f", (double)time_since_trans_start);
+			}
 		}
 	}
 
@@ -320,7 +319,7 @@ void Standard::update_mc_state()
 
 	// Do not engage pusher assist during a failsafe event
 	// There could be a problem with the fixed wing drive
-	if (_attc->get_vtol_vehicle_status()->vtol_transition_failsafe) {
+	if (_attc->get_vtol_vehicle_status().vtol_transition_failsafe) {
 		return;
 	}
 
@@ -381,11 +380,6 @@ void Standard::update_mc_state()
 
 	_pusher_throttle = _pusher_throttle < 0.0f ? 0.0f : _pusher_throttle;
 
-}
-
-void Standard::update_fw_state()
-{
-	VtolType::update_fw_state();
 }
 
 /**

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -55,11 +55,10 @@ class Standard : public VtolType
 public:
 
 	Standard(VtolAttitudeControl *_att_controller);
-	~Standard();
+	~Standard() = default;
 
 	virtual void update_vtol_state();
 	virtual void update_transition_state();
-	virtual void update_fw_state();
 	virtual void update_mc_state();
 	virtual void fill_actuator_outputs();
 	virtual void waiting_on_tecs();

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -154,24 +154,20 @@ void Tailsitter::update_vtol_state()
 	switch (_vtol_schedule.flight_mode) {
 	case MC_MODE:
 		_vtol_mode = ROTARY_WING;
-		_vtol_vehicle_status->vtol_in_trans_mode = false;
 		_flag_was_in_trans_mode = false;
 		break;
 
 	case FW_MODE:
 		_vtol_mode = FIXED_WING;
-		_vtol_vehicle_status->vtol_in_trans_mode = false;
 		_flag_was_in_trans_mode = false;
 		break;
 
 	case TRANSITION_FRONT_P1:
 		_vtol_mode = TRANSITION_TO_FW;
-		_vtol_vehicle_status->vtol_in_trans_mode = true;
 		break;
 
 	case TRANSITION_BACK:
 		_vtol_mode = TRANSITION_TO_MC;
-		_vtol_vehicle_status->vtol_in_trans_mode = true;
 		break;
 	}
 }

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -230,8 +230,6 @@ void Tailsitter::update_transition_state()
 	_mc_pitch_weight = math::constrain(_mc_pitch_weight, 0.0f, 1.0f);
 
 	// compute desired attitude and thrust setpoint for the transition
-
-	_v_att_sp->timestamp = hrt_absolute_time();
 	_v_att_sp->roll_body = 0.0f;
 	_v_att_sp->yaw_body = _yaw_transition;
 
@@ -251,17 +249,17 @@ void Tailsitter::waiting_on_tecs()
 */
 void Tailsitter::fill_actuator_outputs()
 {
+	_actuators_out_0->timestamp_sample = _actuators_mc_in->timestamp_sample;
+	_actuators_out_1->timestamp_sample = _actuators_fw_in->timestamp_sample;
+
 	switch (_vtol_mode) {
 	case ROTARY_WING:
-		_actuators_out_0->timestamp = _actuators_mc_in->timestamp;
 		_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] = _actuators_mc_in->control[actuator_controls_s::INDEX_ROLL];
 		_actuators_out_0->control[actuator_controls_s::INDEX_PITCH] =
 			_actuators_mc_in->control[actuator_controls_s::INDEX_PITCH];
 		_actuators_out_0->control[actuator_controls_s::INDEX_YAW] = _actuators_mc_in->control[actuator_controls_s::INDEX_YAW];
 		_actuators_out_0->control[actuator_controls_s::INDEX_THROTTLE] =
 			_actuators_mc_in->control[actuator_controls_s::INDEX_THROTTLE];
-
-		_actuators_out_1->timestamp = _actuators_mc_in->timestamp;
 
 		if (_params->elevons_mc_lock) {
 			_actuators_out_1->control[0] = 0;
@@ -279,7 +277,7 @@ void Tailsitter::fill_actuator_outputs()
 
 	case FIXED_WING:
 		// in fixed wing mode we use engines only for providing thrust, no moments are generated
-		_actuators_out_0->timestamp = _actuators_fw_in->timestamp;
+
 		_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] = 0;
 		_actuators_out_0->control[actuator_controls_s::INDEX_PITCH] = 0;
 		_actuators_out_0->control[actuator_controls_s::INDEX_YAW] = 0;
@@ -299,8 +297,7 @@ void Tailsitter::fill_actuator_outputs()
 	case TRANSITION_TO_FW:
 	case TRANSITION_TO_MC:
 		// in transition engines are mixed by weight (BACK TRANSITION ONLY)
-		_actuators_out_0->timestamp = _actuators_mc_in->timestamp;
-		_actuators_out_1->timestamp = _actuators_mc_in->timestamp;
+
 		_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] = _actuators_mc_in->control[actuator_controls_s::INDEX_ROLL]
 				* _mc_roll_weight;
 		_actuators_out_0->control[actuator_controls_s::INDEX_PITCH] =

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -65,11 +65,6 @@ Tailsitter::Tailsitter(VtolAttitudeControl *attc) :
 	_params_handles_tailsitter.front_trans_dur_p2 = param_find("VT_TRANS_P2_DUR");
 }
 
-Tailsitter::~Tailsitter()
-{
-
-}
-
 void
 Tailsitter::parameters_update()
 {
@@ -82,7 +77,6 @@ Tailsitter::parameters_update()
 
 void Tailsitter::update_vtol_state()
 {
-
 	/* simple logic using a two way switch to perform transitions.
 	 * after flipping the switch the vehicle will start tilting in MC control mode, picking up
 	 * forward speed. After the vehicle has picked up enough and sufficient pitch angle the uav will go into FW mode.
@@ -250,16 +244,6 @@ void Tailsitter::waiting_on_tecs()
 {
 	// copy the last trust value from the front transition
 	_v_att_sp->thrust = _thrust_transition;
-}
-
-void Tailsitter::update_mc_state()
-{
-	VtolType::update_mc_state();
-}
-
-void Tailsitter::update_fw_state()
-{
-	VtolType::update_fw_state();
 }
 
 /**

--- a/src/modules/vtol_att_control/tailsitter.h
+++ b/src/modules/vtol_att_control/tailsitter.h
@@ -52,12 +52,10 @@ class Tailsitter : public VtolType
 
 public:
 	Tailsitter(VtolAttitudeControl *_att_controller);
-	~Tailsitter();
+	~Tailsitter() = default;
 
 	virtual void update_vtol_state();
 	virtual void update_transition_state();
-	virtual void update_mc_state();
-	virtual void update_fw_state();
 	virtual void fill_actuator_outputs();
 	virtual void waiting_on_tecs();
 

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -45,8 +45,7 @@
 #define ARSP_YAW_CTRL_DISABLE 7.0f	// airspeed at which we stop controlling yaw during a front transition
 
 Tiltrotor::Tiltrotor(VtolAttitudeControl *attc) :
-	VtolType(attc),
-	_tilt_control(0.0f)
+	VtolType(attc)
 {
 	_vtol_schedule.flight_mode = MC_MODE;
 	_vtol_schedule.transition_start = 0;
@@ -63,11 +62,6 @@ Tiltrotor::Tiltrotor(VtolAttitudeControl *attc) :
 	_params_handles_tiltrotor.front_trans_dur_p2 = param_find("VT_TRANS_P2_DUR");
 	_params_handles_tiltrotor.diff_thrust = param_find("VT_FW_DIFTHR_EN");
 	_params_handles_tiltrotor.diff_thrust_scale = param_find("VT_FW_DIFTHR_SC");
-}
-
-Tiltrotor::~Tiltrotor()
-{
-
 }
 
 void

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -330,7 +330,8 @@ void Tiltrotor::waiting_on_tecs()
 */
 void Tiltrotor::fill_actuator_outputs()
 {
-	_actuators_out_0->timestamp = _actuators_mc_in->timestamp;
+	_actuators_out_0->timestamp_sample = _actuators_mc_in->timestamp_sample;
+
 	_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] = _actuators_mc_in->control[actuator_controls_s::INDEX_ROLL]
 			* _mc_roll_weight;
 	_actuators_out_0->control[actuator_controls_s::INDEX_PITCH] =
@@ -353,7 +354,9 @@ void Tiltrotor::fill_actuator_outputs()
 			_actuators_mc_in->control[actuator_controls_s::INDEX_THROTTLE];
 	}
 
-	_actuators_out_1->timestamp = _actuators_fw_in->timestamp;
+
+	_actuators_out_1->timestamp_sample = _actuators_fw_in->timestamp_sample;
+
 	_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] =
 		-_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL];
 	_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =

--- a/src/modules/vtol_att_control/tiltrotor.h
+++ b/src/modules/vtol_att_control/tiltrotor.h
@@ -50,7 +50,7 @@ class Tiltrotor : public VtolType
 public:
 
 	Tiltrotor(VtolAttitudeControl *_att_controller);
-	~Tiltrotor();
+	~Tiltrotor() = default;
 
 	virtual void update_vtol_state();
 	virtual void update_transition_state();
@@ -93,13 +93,12 @@ private:
 	 * they need to idle otherwise they need too much time to spin up for mc mode.
 	 */
 
-
 	struct {
 		vtol_mode flight_mode;			/**< vtol flight mode, defined by enum vtol_mode */
-		hrt_abstime transition_start;	/**< absoulte time at which front transition started */
+		hrt_abstime transition_start;	/**< absolute time at which front transition started */
 	} _vtol_schedule;
 
-	float _tilt_control;		/**< actuator value for the tilt servo */
+	float _tilt_control{0.0f};		/**< actuator value for the tilt servo */
 
 	/**
 	 * Update parameters.

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -112,6 +112,7 @@ VtolAttitudeControl::VtolAttitudeControl()
 
 	if (_vtol_type == nullptr || !_vtol_type->init()) {
 		request_stop();
+
 	}
 
 	_airspeed_sub = orb_subscribe(ORB_ID(airspeed));

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -390,13 +390,11 @@ VtolAttitudeControl::is_fixed_wing_requested()
 	bool to_fw = (_transition_command == vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW);
 
 	// handle abort request
-	if (_abort_front_transition) {
-		if (to_fw) {
-			to_fw = false;
+	if (_vtol_vehicle_status.vtol_transition_failsafe) {
+		to_fw = false;
 
-		} else {
+		if (_vtol_vehicle_status.vtol_state == vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC) {
 			// the state changed to MC mode, reset the abort request
-			_abort_front_transition = false;
 			_vtol_vehicle_status.vtol_transition_failsafe = false;
 		}
 	}
@@ -410,9 +408,8 @@ VtolAttitudeControl::is_fixed_wing_requested()
 void
 VtolAttitudeControl::abort_front_transition(const char *reason)
 {
-	if (!_abort_front_transition) {
+	if (!_vtol_vehicle_status.vtol_transition_failsafe) {
 		mavlink_log_critical(&_mavlink_log_pub, "Abort: %s", reason);
-		_abort_front_transition = true;
 		_vtol_vehicle_status.vtol_transition_failsafe = true;
 	}
 }
@@ -699,10 +696,6 @@ void VtolAttitudeControl::task_main()
 		}
 
 		if (_vtol_vehicle_status.vtol_state != _vtol_type->get_mode()) {
-			publish_status = true;
-		}
-
-		if (_vtol_vehicle_status.vtol_transition_failsafe != _abort_front_transition) {
 			publish_status = true;
 		}
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -654,12 +654,18 @@ void VtolAttitudeControl::run()
 
 		_vtol_type->fill_actuator_outputs();
 
+		// attitude setpoint publish
+		_v_att_sp.timestamp = hrt_absolute_time();
+
 		if (_v_att_sp_pub != nullptr) {
 			orb_publish(ORB_ID(vehicle_attitude_setpoint), _v_att_sp_pub, &_v_att_sp);
 
 		} else {
 			_v_att_sp_pub = orb_advertise(ORB_ID(vehicle_attitude_setpoint), &_v_att_sp);
 		}
+
+		// actuators 0 publish
+		_actuators_out_0.timestamp = hrt_absolute_time();
 
 		if (_actuators_0_pub != nullptr) {
 			orb_publish(ORB_ID(actuator_controls_0), _actuators_0_pub, &_actuators_out_0);
@@ -668,6 +674,9 @@ void VtolAttitudeControl::run()
 			_actuators_0_pub = orb_advertise(ORB_ID(actuator_controls_0), &_actuators_out_0);
 		}
 
+		// actuators 1 publish
+		_actuators_out_1.timestamp = hrt_absolute_time();
+
 		if (_actuators_1_pub != nullptr) {
 			orb_publish(ORB_ID(actuator_controls_1), _actuators_1_pub, &_actuators_out_1);
 
@@ -675,6 +684,7 @@ void VtolAttitudeControl::run()
 			_actuators_1_pub = orb_advertise(ORB_ID(actuator_controls_1), &_actuators_out_1);
 		}
 
+		// vtol vehicle status publish
 		bool publish_status = false;
 
 		if (hrt_elapsed_time(&_vtol_vehicle_status.timestamp) > 1_s) {

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -110,6 +110,10 @@ VtolAttitudeControl::VtolAttitudeControl()
 		request_stop();
 	}
 
+	if (_vtol_type == nullptr || !_vtol_type->init()) {
+		request_stop();
+	}
+
 	_airspeed_sub = orb_subscribe(ORB_ID(airspeed));
 	_land_detected_sub = orb_subscribe(ORB_ID(vehicle_land_detected));
 	_local_pos_sp_sub = orb_subscribe(ORB_ID(vehicle_local_position_setpoint));
@@ -132,9 +136,6 @@ VtolAttitudeControl::VtolAttitudeControl()
 	_fw_virtual_att_sp_sub = orb_subscribe(ORB_ID(fw_virtual_attitude_setpoint));
 	_fw_virtual_v_rates_sp_sub = orb_subscribe(ORB_ID(fw_virtual_rates_setpoint));
 
-	if (!_vtol_type->init()) {
-		request_stop();
-	}
 }
 
 VtolAttitudeControl::~VtolAttitudeControl()

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -63,7 +63,6 @@
 
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/airspeed.h>
-#include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/tecs_status.h>
 #include <uORB/topics/vehicle_attitude.h>
@@ -131,7 +130,6 @@ private:
 	int	_land_detected_sub{-1};
 	int	_local_pos_sp_sub{-1};			// setpoint subscription
 	int	_local_pos_sub{-1};			// sensor subscription
-	int	_manual_control_sp_sub{-1};	//manual control setpoint subscription
 	int	_mc_virtual_att_sp_sub{-1};
 	int	_mc_virtual_v_rates_sp_sub{-1};		//vehicle rates setpoint subscription
 	int	_params_sub{-1};			//parameter updates subscription
@@ -163,7 +161,6 @@ private:
 	actuator_controls_s			_actuators_out_1{};	//actuator controls going to the fw mixer (used for elevons)
 
 	airspeed_s 				_airspeed{};			// airspeed
-	manual_control_setpoint_s		_manual_control_sp{}; //manual control setpoint
 	position_setpoint_triplet_s		_pos_sp_triplet{};
 	tecs_status_s				_tecs_status{};
 	vehicle_attitude_s			_v_att{};				//vehicle attitude
@@ -221,7 +218,6 @@ private:
 	void		vehicle_attitude_poll();  //Check for attitude updates.
 	void		vehicle_cmd_poll();
 	void		vehicle_control_mode_poll();	//Check for changes in vehicle control mode.
-	void		vehicle_manual_poll();			//Check for changes in manual inputs.
 	void 		actuator_controls_fw_poll();	//Check for changes in fw_attitude_control output
 	void 		actuator_controls_mc_poll();	//Check for changes in mc_attitude_control output
 	void 		fw_virtual_att_sp_poll();

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -200,11 +200,7 @@ private:
 		param_t fw_motors_off;
 	} _params_handles{};
 
-	/* for multicopters it is usual to have a non-zero idle speed of the engines
-	 * for fixed wings we want to have an idle speed of zero since we do not want
-	 * to waste energy when gliding. */
-	int _transition_command{vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC};
-	bool _abort_front_transition{false};
+	uint8_t _transition_command{vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC};
 
 	VtolType *_vtol_type{nullptr};	// base class for different vtol types
 

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -48,14 +48,14 @@
 
 VtolType::VtolType(VtolAttitudeControl *att_controller) :
 	_attc(att_controller),
-	_vtol_mode(ROTARY_WING)
+	_vtol_mode(ROTARY_WING),
+	_vtol_vehicle_status(_attc->get_vtol_vehicle_status())
 {
 	_v_att = _attc->get_att();
 	_v_att_sp = _attc->get_att_sp();
 	_mc_virtual_att_sp = _attc->get_mc_virtual_att_sp();
 	_fw_virtual_att_sp = _attc->get_fw_virtual_att_sp();
 	_v_control_mode = _attc->get_control_mode();
-	_vtol_vehicle_status = _attc->get_vtol_vehicle_status();
 	_actuators_out_0 = _attc->get_actuators_out0();
 	_actuators_out_1 = _attc->get_actuators_out1();
 	_actuators_mc_in = _attc->get_actuators_mc_in();
@@ -74,11 +74,6 @@ VtolType::VtolType(VtolAttitudeControl *att_controller) :
 	for (auto &pwm_disarmed : _disarmed_pwm_values.values) {
 		pwm_disarmed = PWM_MOTOR_OFF;
 	}
-}
-
-VtolType::~VtolType()
-{
-
 }
 
 bool VtolType::init()

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -104,6 +104,8 @@ bool VtolType::init()
 		return false;
 	}
 
+	parameters_update();
+
 	return true;
 
 }

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -114,10 +114,10 @@ class VtolType
 public:
 
 	VtolType(VtolAttitudeControl *att_controller);
+	~VtolType() = default;
+
 	VtolType(const VtolType &) = delete;
 	VtolType &operator=(const VtolType &) = delete;
-
-	virtual ~VtolType();
 
 	/**
 	 * Initialise.
@@ -165,9 +165,7 @@ public:
 	 */
 	bool can_transition_on_ground();
 
-
-
-	mode get_mode() {return _vtol_mode;}
+	mode get_mode() { return _vtol_mode; }
 
 	virtual void parameters_update() = 0;
 
@@ -180,7 +178,6 @@ protected:
 	struct vehicle_attitude_setpoint_s *_mc_virtual_att_sp;	// virtual mc attitude setpoint
 	struct vehicle_attitude_setpoint_s *_fw_virtual_att_sp;	// virtual fw attitude setpoint
 	struct vehicle_control_mode_s		*_v_control_mode;	//vehicle control mode
-	struct vtol_vehicle_status_s 		*_vtol_vehicle_status;
 	struct actuator_controls_s			*_actuators_out_0;			//actuator controls going to the mc mixer
 	struct actuator_controls_s			*_actuators_out_1;			//actuator controls going to the fw mixer (used for elevons)
 	struct actuator_controls_s			*_actuators_mc_in;			//actuator controls from mc_att_control
@@ -190,6 +187,8 @@ protected:
 	struct airspeed_s 				*_airspeed;					// airspeed
 	struct tecs_status_s				*_tecs_status;
 	struct vehicle_land_detected_s			*_land_detected;
+
+	const vtol_vehicle_status_s		&_vtol_vehicle_status;
 
 	struct Params 					*_params;
 

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -46,6 +46,7 @@
 #include <lib/mathlib/mathlib.h>
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_pwm_output.h>
+#include <uORB/topics/vtol_vehicle_status.h>
 
 struct Params {
 	int32_t idle_pwm_mc;			// pwm value for idle in mc mode
@@ -75,10 +76,10 @@ struct Params {
 
 // Has to match 1:1 msg/vtol_vehicle_status.msg
 enum mode {
-	TRANSITION_TO_FW = 1,
-	TRANSITION_TO_MC = 2,
-	ROTARY_WING = 3,
-	FIXED_WING = 4
+	TRANSITION_TO_FW = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_TRANSITION_TO_FW,
+	TRANSITION_TO_MC = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_TRANSITION_TO_MC,
+	ROTARY_WING = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC,
+	FIXED_WING = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW,
 };
 
 enum vtol_type {
@@ -214,8 +215,6 @@ protected:
 	hrt_abstime _tecs_running_ts = 0;
 
 	motor_state _motor_state = motor_state::DISABLED;
-
-
 
 	/**
 	 * @brief      Sets mc motor minimum pwm to VT_IDLE_PWM_MC which ensures


### PR DESCRIPTION
 - fixes VTOL transition switch problems after quadchute has been triggered
 - limits vtol_vehicle_status publication rate
 - publish full vtol_state
 - allow transition switch to abort front transition