### PR TITLE
MC: set default MPC_THR_MAX & MPC_MANTHR_MAX to 1

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -74,24 +74,22 @@ PARAM_DEFINE_FLOAT(MPC_THR_HOVER, 0.5f);
 /**
  * Maximum thrust in auto thrust control
  *
- * Limit max allowed thrust. Setting a value of one can put
- * the system into actuator saturation as no spread between
- * the motors is possible any more. A value of 0.8 - 0.9
- * is recommended.
+ * Limit max allowed thrust
  *
  * @unit norm
  * @min 0.0
- * @max 0.95
+ * @max 1.0
  * @decimal 2
  * @increment 0.01
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_THR_MAX, 0.9f);
+PARAM_DEFINE_FLOAT(MPC_THR_MAX, 1.0f);
 
 /**
  * Minimum manual thrust
  *
  * Minimum vertical thrust. It's recommended to set it > 0 to avoid free fall with zero thrust.
+ * With MC_AIRMODE set to 1, this can safely be set to 0.
  *
  * @unit norm
  * @min 0.0
@@ -105,10 +103,7 @@ PARAM_DEFINE_FLOAT(MPC_MANTHR_MIN, 0.08f);
 /**
  * Maximum manual thrust
  *
- * Limit max allowed thrust. Setting a value of one can put
- * the system into actuator saturation as no spread between
- * the motors is possible any more. A value of 0.8 - 0.9
- * is recommended.
+ * Limit max allowed thrust for Manual mode.
  *
  * @unit norm
  * @min 0.0
@@ -117,7 +112,7 @@ PARAM_DEFINE_FLOAT(MPC_MANTHR_MIN, 0.08f);
  * @increment 0.01
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_MANTHR_MAX, 0.9f);
+PARAM_DEFINE_FLOAT(MPC_MANTHR_MAX, 1.0f);
 
 /**
  * Proportional gain for vertical position error


### PR DESCRIPTION
With the updated mixer (#9062) it's safe to set maximum thrust to 1 (in both cases, if MC_AIRMODE is set, or not set).
So I see no reason to limit the maximum thrust.

@MaEtUgR @RomanBapst 