### PR TITLE
mc_att_control_main: do not apply the yaw weight for the feedforward term

### DIFF
--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -76,7 +76,9 @@ MultirotorMixer::MultirotorMixer(ControlCallback control_cb,
 	_rotors(_config_index[(MultirotorGeometryUnderlyingType)geometry]),
 	_outputs_prev(new float[_rotor_count])
 {
-	memset(_outputs_prev, _idle_speed, _rotor_count * sizeof(float));
+	for (unsigned i = 0; i < _rotor_count; ++i) {
+		_outputs_prev[i] = _idle_speed;
+	}
 }
 
 MultirotorMixer::~MultirotorMixer()

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -424,7 +424,6 @@ MulticopterAttitudeControl::control_attitude(float dt)
 	 * because it's the rotation axis for body yaw and multiply it by the rate and gain. */
 	Vector3f yaw_feedforward_rate = q.inversed().dcm_z();
 	yaw_feedforward_rate *= _v_att_sp.yaw_sp_move_rate * _yaw_ff.get();
-	yaw_feedforward_rate(2) *= yaw_w;
 	_rates_sp += yaw_feedforward_rate;
 
 


### PR DESCRIPTION
The meaning of the yaw weight changed with #8003:
- before, the yaw weight decreased with increasing tilt angle error, so it was mostly 1
- now, it is constant and depends on the tuning gains (around 0.4 by default)

It means that #8003 reduced the feedforward term, and we get the closer behavior as before with this change.
It also reduces coupling between different parameters.

This PR fixes a mixer initialization as well.