### PR TITLE
Add support for another MPU9250 or MPU6500 on px4fmu-v4 internal SPI Bus

### DIFF
--- a/src/drivers/boards/px4fmu-v4/board_config.h
+++ b/src/drivers/boards/px4fmu-v4/board_config.h
@@ -133,6 +133,7 @@
 #define PX4_SPI_BUS_SENSORS          1
 #define PX4_SPI_BUS_RAMTRON          2
 #define PX4_SPI_BUS_BARO             PX4_SPI_BUS_RAMTRON
+#define PX4_SPI_BUS_EXT              1
 
 /* Use these in place of the uint32_t enumeration to select a specific SPI device on SPI1 */
 #define PX4_SPIDEV_GYRO              PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 1)
@@ -147,6 +148,7 @@
 #define PX4_SPIDEV_ICM_20602         PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 11)
 #define PX4_SPIDEV_BMI055_ACC        PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 12)
 #define PX4_SPIDEV_BMI055_GYR        PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 13)
+#define PX4_SPIDEV_EXT_MPU           PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 14)
 
 /* onboard MS5611 and FRAM are both on bus SPI2
  * spi_dev_e:SPIDEV_FLASH has the value 2 and is used in the NuttX ramtron driver

--- a/src/drivers/boards/px4fmu-v4/spi.c
+++ b/src/drivers/boards/px4fmu-v4/spi.c
@@ -121,6 +121,7 @@ __EXPORT void stm32_spi1select(FAR struct spi_dev_s *dev, uint32_t devid, bool s
 	case PX4_SPIDEV_ICM_20602:
 	case PX4_SPIDEV_ICM_20608:
 	case PX4_SPIDEV_BMI055_ACC:
+	case PX4_SPIDEV_EXT_MPU:
 		/* Making sure the other peripherals are not selected */
 		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN2, 1);
 		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN15, !selected);


### PR DESCRIPTION
Adds support for another MPU9250 or MPU6500 on px4fmu-v4 internal SPI bus. Adds PX4_SPI_BUS_EXT, PX4_SPIDEV_EXT_MPU to board config and spi.c. Call 'mpu9250 -S start' to enable.