### PR TITLE
Feature/dynamixel position

### DIFF
--- a/src/drivers/dynamixel/CMakeLists.txt
+++ b/src/drivers/dynamixel/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2018 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/drivers/dynamixel/CMakeLists.txt
+++ b/src/drivers/dynamixel/CMakeLists.txt
@@ -1,0 +1,44 @@
+############################################################################
+#
+#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+px4_add_module(
+	MODULE drivers__dynamixel
+	MAIN dynamixel_position
+	STACK_MAIN 1200
+	COMPILE_FLAGS
+	SRCS
+    message.c
+		dynamixel_position.c
+	DEPENDS
+		platforms__common
+	)
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/drivers/dynamixel/dynamixel_position.c
+++ b/src/drivers/dynamixel/dynamixel_position.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/drivers/dynamixel/dynamixel_position.c
+++ b/src/drivers/dynamixel/dynamixel_position.c
@@ -1,0 +1,326 @@
+#include <drivers/drv_hrt.h>
+#include <math.h>
+#include <poll.h>
+#include <px4_config.h>
+#include <px4_posix.h>
+#include <px4_tasks.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <termios.h>
+#include <uORB/topics/actuator_armed.h>
+#include <uORB/topics/actuator_controls.h>
+#include <unistd.h>
+
+#include "message.h"
+
+#define DEFAULT_UART "/dev/ttyS1"  // Serial1
+#define DEFAULT_BAUDRATE B115200
+#define DEFAULT_IGNORE_DISARM true
+#define ANGLE_RES 651.898646904f  // 4096 / (2*pi)
+
+static int _thread_should_exit = false; /**< Deamon exit flag */
+static int _thread_running = false;     /**< Deamon status flag */
+static int _deamon_task;                /**< Handle of deamon task / thread */
+static const char _daemon_name[] = "dynamixel_position";
+static const char _commandline_usage[] =
+    "usage: dynamixel_position start|status|stop [-d <device> -b <baudrate> -u "
+    "<update_rate_hz> -i <ignore_disarm>]";
+
+void open_uart(const char *device, const speed_t baudrate);
+bool write_uart(const uint8_t *msg, int msg_length);
+bool set_angles(const float32 *angles);
+bool enable(void);
+bool disable(void);
+void update_armed_status(int armed_sub, bool ignore_disarm);
+void get_commandline_values(int argc, char *argv[], char **device,
+                            speed_t *baudrate, bool *ignore_disarm);
+int dynamixel_position_thread_main(int argc, char *argv[]);
+
+struct termios _uart_config_original;
+int _uart = 0;
+
+void open_uart(const char *device, const speed_t baudrate) {
+  /* open uart */
+  _uart = open(device, O_RDWR | O_NOCTTY);
+
+  if (_uart < 0) {
+    err(1, "ERR: opening %s", device);
+  }
+
+  /* Back up the original uart configuration to restore it after exit */
+  int termios_state;
+
+  if ((termios_state = tcgetattr(_uart, &_uart_config_original)) < 0) {
+    close(_uart);
+    err(1, "ERR: %s: %d", device, termios_state);
+  }
+
+  /* Fill the struct for the new configuration */
+  struct termios uart_config;
+  tcgetattr(_uart, &uart_config);
+
+  /* Clear ONLCR flag (which appends a CR for every LF) */
+  uart_config.c_oflag &= ~ONLCR;
+
+  /* Set baud rate */
+  if (cfsetispeed(&uart_config, baudrate) < 0 ||
+      cfsetospeed(&uart_config, baudrate) < 0) {
+    close(_uart);
+    err(1, "ERR: %s: %d (cfsetispeed, cfsetospeed)", device, termios_state);
+  }
+
+  if ((termios_state = tcsetattr(_uart, TCSANOW, &uart_config)) < 0) {
+    close(_uart);
+    err(1, "ERR: %s (tcsetattr)", device);
+  }
+}
+
+bool write_uart(const uint8_t *msg, int msg_length) {
+  return write(_uart, msg, msg_length) != 0;
+}
+
+bool set_angles(const float32 *angles) {
+  int32_t int_angles[NUM_DYNAMIXELS];
+  for (uint16_t i = 0; i < NUM_DYNAMIXELS; ++i) {
+    int_angles[i] = (int)(((float32)ANGLE_RES) * angles[i]);
+  }
+
+  uint8_t msg[WRITE_32_BIT_MESSAGE_SIZE];
+  build_write_32_bit_message(GOAL_POSITION_ADDRESS, int_angles, msg);
+
+  if (!write_uart(msg, WRITE_32_BIT_MESSAGE_SIZE)) {
+    return false;
+  }
+
+  return true;
+}
+
+bool enable(void) {
+  uint8_t enable_flags[NUM_DYNAMIXELS];
+  uint8_t disable_flags[NUM_DYNAMIXELS];
+  uint8_t control_flags[NUM_DYNAMIXELS];
+  for (uint8_t i = 0; i < NUM_DYNAMIXELS; ++i) {
+    enable_flags[i] = 1;
+    disable_flags[i] = 0;
+    control_flags[i] = EXTENDED_POSITION_CONTROL_MODE;
+  }
+
+  uint8_t msg[WRITE_8_BIT_MESSAGE_SIZE];
+
+  // disable msg status feedback
+  build_write_8_bit_message(RETURN_LEVEL_SET_ADDRESS, disable_flags, msg);
+  if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
+    return false;
+  }
+
+  // set to extended position control mode
+  build_write_8_bit_message(OPERATING_MODE_ADDRESS, control_flags, msg);
+  if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
+    return false;
+  }
+
+  // enable servo
+  build_write_8_bit_message(ENABLE_ADDRESS, enable_flags, msg);
+  if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
+    return false;
+  }
+
+  // turn on led to get some feedback
+  build_write_8_bit_message(LED_ADDRESS, enable_flags, msg);
+  if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
+    return false;
+  }
+
+  return true;
+}
+
+bool disable(void) {
+  uint8_t disable_flags[NUM_DYNAMIXELS];
+  for (uint8_t i = 0; i < NUM_DYNAMIXELS; ++i) {
+    disable_flags[i] = 0;
+  }
+
+  uint8_t msg[WRITE_8_BIT_MESSAGE_SIZE];
+
+  // disable servo
+  build_write_8_bit_message(ENABLE_ADDRESS, disable_flags, msg);
+  if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
+    return false;
+  }
+
+  // turn off led to get some feedback
+  build_write_8_bit_message(LED_ADDRESS, disable_flags, msg);
+  if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
+    return false;
+  }
+
+  return true;
+}
+
+void update_armed_status(int armed_sub, bool ignore_disarm) {
+  bool armed_updated;
+  orb_check(armed_sub, &armed_updated);
+
+  if (armed_updated) {
+    struct actuator_armed_s armed_status;
+    orb_copy(ORB_ID(actuator_armed), armed_sub, &armed_status);
+
+    if (armed_status.lockdown || armed_status.force_failsafe ||
+        armed_status.in_esc_calibration_mode ||
+        (!armed_status.armed && !ignore_disarm)) {
+      if (!disable()) {
+        warn("failed to disable dynamixels");
+      }
+    } else {
+      if (!enable()) {
+        warn("failed to enable dynamixels");
+      }
+    }
+  }
+}
+
+void get_commandline_values(int argc, char *argv[], char **device,
+                            speed_t *baudrate, bool *ignore_disarm) {
+  *device = DEFAULT_UART;
+  *baudrate = DEFAULT_BAUDRATE;
+  *ignore_disarm = DEFAULT_IGNORE_DISARM;
+
+  for (int i = 0; i < argc && argv[i]; i++) {
+    if (strcmp(argv[i], "-d") == 0 || strcmp(argv[i], "--device") == 0) {
+      if (argc > i + 1) {
+        *device = argv[i + 1];
+      } else {
+        _thread_running = false;
+        errx(1, "missing parameter to -d\n%s", _commandline_usage);
+      }
+    }
+    if (strcmp(argv[i], "-b") == 0 || strcmp(argv[i], "--baudrate") == 0) {
+      if (argc > i + 1) {
+        if (strcmp(argv[i + 1], "57600") == 0) {
+          *baudrate = B57600;
+        } else if (strcmp(argv[i + 1], "115200") == 0) {
+          *baudrate = B115200;
+        } else {
+          _thread_running = false;
+          errx(1,
+               "invalid baudrate set, currently only 57600 and 115200 are "
+               "supported");
+        }
+      } else {
+        _thread_running = false;
+        errx(1, "missing parameter to -b\n%s", _commandline_usage);
+      }
+    }
+    if (strcmp(argv[i], "-i") == 0 || strcmp(argv[i], "--ignore_disarm") == 0) {
+      if (argc > i + 1) {
+        if (strcmp(argv[i + 1], "true") == 0) {
+          *ignore_disarm = true;
+        } else if (strcmp(argv[i + 1], "false") == 0) {
+          *ignore_disarm = false;
+        } else {
+          _thread_running = false;
+          errx(
+              1,
+              "invalid parameter to -i, possible values are 'true' or 'false'");
+        }
+      } else {
+        _thread_running = false;
+        errx(1, "missing parameter to -i\n%s", _commandline_usage);
+      }
+    }
+  }
+}
+
+int dynamixel_position_thread_main(int argc, char *argv[]) {
+  _thread_running = true;
+
+  char *device;
+  speed_t baudrate;
+  bool ignore_disarm;
+
+  get_commandline_values(argc, argv, &device, &baudrate, &ignore_disarm);
+
+  open_uart(device, baudrate);
+
+  if (_uart == 0) {
+    return PX4_ERROR;
+  }
+
+  int sub_fd = orb_subscribe(ORB_ID(actuator_controls_2));
+  int armed_sub = orb_subscribe(ORB_ID(actuator_armed));
+
+  // limit the update rate to something the uart can easily handle
+  if(baudrate == B57600){
+    orb_set_interval(sub_fd, 20);
+  }
+  else{
+    orb_set_interval(sub_fd, 10);
+  }
+
+  px4_pollfd_struct_t fds[] = {
+      {.fd = sub_fd, .events = POLLIN},
+  };
+
+  while (!_thread_should_exit) {
+    int poll_ret = px4_poll(fds, 1, 1000);
+
+    if ((poll_ret > 0) && fds[0].revents & POLLIN) {
+      update_armed_status(armed_sub, ignore_disarm);
+
+      struct actuator_controls_s angles_in_struct;
+      orb_copy(ORB_ID(actuator_controls_2), sub_fd, &angles_in_struct);
+      if (!set_angles(angles_in_struct.control)) {
+        warn("failed to set dynamixel angles!");
+      }
+    }
+  }
+
+  close(_uart);
+
+  _thread_running = false;
+
+  return PX4_OK;
+}
+
+__EXPORT int dynamixel_position_main(int argc, char *argv[]);
+
+/**
+ * Process command line arguments and start the daemon.
+ */
+int dynamixel_position_main(int argc, char *argv[]) {
+  if (argc < 1) {
+    errx(1, "missing command\n%s", _commandline_usage);
+  }
+
+  if (!strcmp(argv[1], "start")) {
+    if (_thread_running) {
+      warnx("already running");
+      exit(0);
+    }
+
+    _thread_should_exit = false;
+    _deamon_task = px4_task_spawn_cmd(
+        _daemon_name, SCHED_DEFAULT, SCHED_PRIORITY_DEFAULT, 1500,
+        dynamixel_position_thread_main,
+        (argv) ? (char *const *)&argv[2] : (char *const *)NULL);
+    exit(0);
+  }
+
+  if (!strcmp(argv[1], "stop")) {
+    _thread_should_exit = true;
+    exit(0);
+  }
+
+  if (!strcmp(argv[1], "status")) {
+    if (_thread_running) {
+      warnx("is running");
+    } else {
+      warnx("not started");
+    }
+
+    exit(0);
+  }
+
+  errx(1, "unrecognized command\n%s", _commandline_usage);
+}

--- a/src/drivers/dynamixel/dynamixel_position.c
+++ b/src/drivers/dynamixel/dynamixel_position.c
@@ -38,7 +38,7 @@
  * @author Zachary Taylor	<ztaylor@ethz.ch>
  *
  * A simple controller for working with dynamixel servos that use protocal 2.0.
- * The servos are set into extended position mode and can be given an angle between -512*PI and 512*PI. 
+ * The servos are set into extended position mode and can be given an angle between -512*PI and 512*PI.
  * The angle is given via actuator control group 2, unlike most other actuators its value is not normalized.
  * All feedback from the servos is disabled to allow higher throughput when using the ttl servos.
  */
@@ -69,10 +69,10 @@ static int _thread_running = false;     /**< Deamon status flag */
 static int _deamon_task;                /**< Handle of deamon task / thread */
 static const char _daemon_name[] = "dynamixel_position";
 static const char _commandline_usage[] =
-    "sends values (interpreted as angles in radians) in Control Group #2 to up "
-    "to 8 dynamixels\n"
-    "usage: dynamixel_position start|status|stop [-d <device> -b <baudrate> -u "
-    "<update_rate_hz> -i <ignore_disarm>]";
+	"sends values (interpreted as angles in radians) in Control Group #2 to up "
+	"to 8 dynamixels\n"
+	"usage: dynamixel_position start|status|stop [-d <device> -b <baudrate> -u "
+	"<update_rate_hz> -i <ignore_disarm>]";
 
 struct termios _uart_config_original;
 int _uart = 0;
@@ -111,253 +111,282 @@ void update_armed_status(int armed_sub, bool ignore_disarm);
  * Sets parameters specified on the command line.
  */
 void get_commandline_values(int argc, char *argv[], char **device,
-                            speed_t *baudrate, bool *ignore_disarm);
+			    speed_t *baudrate, bool *ignore_disarm);
 
 /**
  * Main loop that passes specified angles to the dynamixels.
  */
 int dynamixel_position_thread_main(int argc, char *argv[]);
 
-void open_uart(const char *device, const speed_t baudrate) {
-  /* open uart */
-  _uart = open(device, O_RDWR | O_NOCTTY);
+void open_uart(const char *device, const speed_t baudrate)
+{
+	/* open uart */
+	_uart = open(device, O_RDWR | O_NOCTTY);
 
-  if (_uart < 0) {
-    err(1, "ERR: opening %s", device);
-  }
+	if (_uart < 0) {
+		err(1, "ERR: opening %s", device);
+	}
 
-  /* Back up the original uart configuration to restore it after exit */
-  int termios_state;
+	/* Back up the original uart configuration to restore it after exit */
+	int termios_state;
 
-  if ((termios_state = tcgetattr(_uart, &_uart_config_original)) < 0) {
-    close(_uart);
-    err(1, "ERR: %s: %d", device, termios_state);
-  }
+	if ((termios_state = tcgetattr(_uart, &_uart_config_original)) < 0) {
+		close(_uart);
+		err(1, "ERR: %s: %d", device, termios_state);
+	}
 
-  /* Fill the struct for the new configuration */
-  struct termios uart_config;
-  tcgetattr(_uart, &uart_config);
+	/* Fill the struct for the new configuration */
+	struct termios uart_config;
+	tcgetattr(_uart, &uart_config);
 
-  /* Clear ONLCR flag (which appends a CR for every LF) */
-  uart_config.c_oflag &= ~ONLCR;
+	/* Clear ONLCR flag (which appends a CR for every LF) */
+	uart_config.c_oflag &= ~ONLCR;
 
-  /* Set baud rate */
-  if (cfsetispeed(&uart_config, baudrate) < 0 ||
-      cfsetospeed(&uart_config, baudrate) < 0) {
-    close(_uart);
-    err(1, "ERR: %s: %d (cfsetispeed, cfsetospeed)", device, termios_state);
-  }
+	/* Set baud rate */
+	if (cfsetispeed(&uart_config, baudrate) < 0 ||
+	    cfsetospeed(&uart_config, baudrate) < 0) {
+		close(_uart);
+		err(1, "ERR: %s: %d (cfsetispeed, cfsetospeed)", device, termios_state);
+	}
 
-  if ((termios_state = tcsetattr(_uart, TCSANOW, &uart_config)) < 0) {
-    close(_uart);
-    err(1, "ERR: %s (tcsetattr)", device);
-  }
+	if ((termios_state = tcsetattr(_uart, TCSANOW, &uart_config)) < 0) {
+		close(_uart);
+		err(1, "ERR: %s (tcsetattr)", device);
+	}
 }
 
-bool write_uart(const uint8_t *msg, int msg_length) {
-  return write(_uart, msg, msg_length) != 0;
+bool write_uart(const uint8_t *msg, int msg_length)
+{
+	return write(_uart, msg, msg_length) != 0;
 }
 
-bool set_angles(const float32 *angles) {
-  int32_t int_angles[NUM_DYNAMIXELS];
-  for (uint16_t i = 0; i < NUM_DYNAMIXELS; ++i) {
-    int_angles[i] = (int)(((float32)ANGLE_RES) * angles[i]);
-  }
+bool set_angles(const float32 *angles)
+{
+	int32_t int_angles[NUM_DYNAMIXELS];
 
-  uint8_t msg[WRITE_32_BIT_MESSAGE_SIZE];
-  build_write_32_bit_message(GOAL_POSITION_ADDRESS, int_angles, msg);
+	for (uint16_t i = 0; i < NUM_DYNAMIXELS; ++i) {
+		int_angles[i] = (int)(((float32)ANGLE_RES) * angles[i]);
+	}
 
-  if (!write_uart(msg, WRITE_32_BIT_MESSAGE_SIZE)) {
-    return false;
-  }
+	uint8_t msg[WRITE_32_BIT_MESSAGE_SIZE];
+	build_write_32_bit_message(GOAL_POSITION_ADDRESS, int_angles, msg);
 
-  return true;
+	if (!write_uart(msg, WRITE_32_BIT_MESSAGE_SIZE)) {
+		return false;
+	}
+
+	return true;
 }
 
-bool enable(void) {
-  uint8_t enable_flags[NUM_DYNAMIXELS];
-  uint8_t disable_flags[NUM_DYNAMIXELS];
-  uint8_t control_flags[NUM_DYNAMIXELS];
-  for (uint8_t i = 0; i < NUM_DYNAMIXELS; ++i) {
-    enable_flags[i] = 1;
-    disable_flags[i] = 0;
-    control_flags[i] = EXTENDED_POSITION_CONTROL_MODE;
-  }
+bool enable(void)
+{
+	uint8_t enable_flags[NUM_DYNAMIXELS];
+	uint8_t disable_flags[NUM_DYNAMIXELS];
+	uint8_t control_flags[NUM_DYNAMIXELS];
 
-  uint8_t msg[WRITE_8_BIT_MESSAGE_SIZE];
+	for (uint8_t i = 0; i < NUM_DYNAMIXELS; ++i) {
+		enable_flags[i] = 1;
+		disable_flags[i] = 0;
+		control_flags[i] = EXTENDED_POSITION_CONTROL_MODE;
+	}
 
-  /* disable msg status feedback */
-  build_write_8_bit_message(RETURN_LEVEL_SET_ADDRESS, disable_flags, msg);
-  if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
-    return false;
-  }
+	uint8_t msg[WRITE_8_BIT_MESSAGE_SIZE];
 
-  /* set to extended position control mode */
-  build_write_8_bit_message(OPERATING_MODE_ADDRESS, control_flags, msg);
-  if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
-    return false;
-  }
+	/* disable msg status feedback */
+	build_write_8_bit_message(RETURN_LEVEL_SET_ADDRESS, disable_flags, msg);
 
-  /* enable servo */
-  build_write_8_bit_message(ENABLE_ADDRESS, enable_flags, msg);
-  if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
-    return false;
-  }
+	if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
+		return false;
+	}
 
-  /* turn on led to get some feedback */
-  build_write_8_bit_message(LED_ADDRESS, enable_flags, msg);
-  if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
-    return false;
-  }
+	/* set to extended position control mode */
+	build_write_8_bit_message(OPERATING_MODE_ADDRESS, control_flags, msg);
 
-  return true;
+	if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
+		return false;
+	}
+
+	/* enable servo */
+	build_write_8_bit_message(ENABLE_ADDRESS, enable_flags, msg);
+
+	if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
+		return false;
+	}
+
+	/* turn on led to get some feedback */
+	build_write_8_bit_message(LED_ADDRESS, enable_flags, msg);
+
+	if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
+		return false;
+	}
+
+	return true;
 }
 
-bool disable(void) {
-  uint8_t disable_flags[NUM_DYNAMIXELS];
-  for (uint8_t i = 0; i < NUM_DYNAMIXELS; ++i) {
-    disable_flags[i] = 0;
-  }
+bool disable(void)
+{
+	uint8_t disable_flags[NUM_DYNAMIXELS];
 
-  uint8_t msg[WRITE_8_BIT_MESSAGE_SIZE];
+	for (uint8_t i = 0; i < NUM_DYNAMIXELS; ++i) {
+		disable_flags[i] = 0;
+	}
 
-  /* disable servo */
-  build_write_8_bit_message(ENABLE_ADDRESS, disable_flags, msg);
-  if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
-    return false;
-  }
+	uint8_t msg[WRITE_8_BIT_MESSAGE_SIZE];
 
-  /* turn off led to get some feedback */
-  build_write_8_bit_message(LED_ADDRESS, disable_flags, msg);
-  if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
-    return false;
-  }
+	/* disable servo */
+	build_write_8_bit_message(ENABLE_ADDRESS, disable_flags, msg);
 
-  return true;
+	if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
+		return false;
+	}
+
+	/* turn off led to get some feedback */
+	build_write_8_bit_message(LED_ADDRESS, disable_flags, msg);
+
+	if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
+		return false;
+	}
+
+	return true;
 }
 
-void update_armed_status(int armed_sub, bool ignore_disarm) {
-  bool armed_updated;
-  orb_check(armed_sub, &armed_updated);
+void update_armed_status(int armed_sub, bool ignore_disarm)
+{
+	bool armed_updated;
+	orb_check(armed_sub, &armed_updated);
 
-  if (armed_updated) {
-    struct actuator_armed_s armed_status;
-    orb_copy(ORB_ID(actuator_armed), armed_sub, &armed_status);
+	if (armed_updated) {
+		struct actuator_armed_s armed_status;
+		orb_copy(ORB_ID(actuator_armed), armed_sub, &armed_status);
 
-    if (armed_status.lockdown || armed_status.force_failsafe ||
-        armed_status.in_esc_calibration_mode ||
-        (!armed_status.armed && !ignore_disarm)) {
-      if (!disable()) {
-        warn("failed to disable dynamixels");
-      }
-    } else {
-      if (!enable()) {
-        warn("failed to enable dynamixels");
-      }
-    }
-  }
+		if (armed_status.lockdown || armed_status.force_failsafe ||
+		    armed_status.in_esc_calibration_mode ||
+		    (!armed_status.armed && !ignore_disarm)) {
+			if (!disable()) {
+				warn("failed to disable dynamixels");
+			}
+
+		} else {
+			if (!enable()) {
+				warn("failed to enable dynamixels");
+			}
+		}
+	}
 }
 
 void get_commandline_values(int argc, char *argv[], char **device,
-                            speed_t *baudrate, bool *ignore_disarm) {
-  *device = DEFAULT_UART;
-  *baudrate = DEFAULT_BAUDRATE;
-  *ignore_disarm = DEFAULT_IGNORE_DISARM;
+			    speed_t *baudrate, bool *ignore_disarm)
+{
+	*device = DEFAULT_UART;
+	*baudrate = DEFAULT_BAUDRATE;
+	*ignore_disarm = DEFAULT_IGNORE_DISARM;
 
-  for (int i = 0; i < argc && argv[i]; i++) {
-    if (strcmp(argv[i], "-d") == 0 || strcmp(argv[i], "--device") == 0) {
-      if (argc > i + 1) {
-        *device = argv[i + 1];
-      } else {
-        _thread_running = false;
-        errx(1, "missing parameter to -d\n%s", _commandline_usage);
-      }
-    }
-    if (strcmp(argv[i], "-b") == 0 || strcmp(argv[i], "--baudrate") == 0) {
-      if (argc > i + 1) {
-        if (strcmp(argv[i + 1], "57600") == 0) {
-          *baudrate = B57600;
-        } else if (strcmp(argv[i + 1], "115200") == 0) {
-          *baudrate = B115200;
-        } else {
-          _thread_running = false;
-          errx(1,
-               "invalid baudrate set, currently only 57600 and 115200 are "
-               "supported");
-        }
-      } else {
-        _thread_running = false;
-        errx(1, "missing parameter to -b\n%s", _commandline_usage);
-      }
-    }
-    if (strcmp(argv[i], "-i") == 0 || strcmp(argv[i], "--ignore_disarm") == 0) {
-      if (argc > i + 1) {
-        if (strcmp(argv[i + 1], "true") == 0) {
-          *ignore_disarm = true;
-        } else if (strcmp(argv[i + 1], "false") == 0) {
-          *ignore_disarm = false;
-        } else {
-          _thread_running = false;
-          errx(
-              1,
-              "invalid parameter to -i, possible values are 'true' or 'false'");
-        }
-      } else {
-        _thread_running = false;
-        errx(1, "missing parameter to -i\n%s", _commandline_usage);
-      }
-    }
-  }
+	for (int i = 0; i < argc && argv[i]; i++) {
+		if (strcmp(argv[i], "-d") == 0 || strcmp(argv[i], "--device") == 0) {
+			if (argc > i + 1) {
+				*device = argv[i + 1];
+
+			} else {
+				_thread_running = false;
+				errx(1, "missing parameter to -d\n%s", _commandline_usage);
+			}
+		}
+
+		if (strcmp(argv[i], "-b") == 0 || strcmp(argv[i], "--baudrate") == 0) {
+			if (argc > i + 1) {
+				if (strcmp(argv[i + 1], "57600") == 0) {
+					*baudrate = B57600;
+
+				} else if (strcmp(argv[i + 1], "115200") == 0) {
+					*baudrate = B115200;
+
+				} else {
+					_thread_running = false;
+					errx(1,
+					     "invalid baudrate set, currently only 57600 and 115200 are "
+					     "supported");
+				}
+
+			} else {
+				_thread_running = false;
+				errx(1, "missing parameter to -b\n%s", _commandline_usage);
+			}
+		}
+
+		if (strcmp(argv[i], "-i") == 0 || strcmp(argv[i], "--ignore_disarm") == 0) {
+			if (argc > i + 1) {
+				if (strcmp(argv[i + 1], "true") == 0) {
+					*ignore_disarm = true;
+
+				} else if (strcmp(argv[i + 1], "false") == 0) {
+					*ignore_disarm = false;
+
+				} else {
+					_thread_running = false;
+					errx(
+						1,
+						"invalid parameter to -i, possible values are 'true' or 'false'");
+				}
+
+			} else {
+				_thread_running = false;
+				errx(1, "missing parameter to -i\n%s", _commandline_usage);
+			}
+		}
+	}
 }
 
-int dynamixel_position_thread_main(int argc, char *argv[]) {
-  _thread_running = true;
+int dynamixel_position_thread_main(int argc, char *argv[])
+{
+	_thread_running = true;
 
-  char *device;
-  speed_t baudrate;
-  bool ignore_disarm;
+	char *device;
+	speed_t baudrate;
+	bool ignore_disarm;
 
-  get_commandline_values(argc, argv, &device, &baudrate, &ignore_disarm);
+	get_commandline_values(argc, argv, &device, &baudrate, &ignore_disarm);
 
-  open_uart(device, baudrate);
+	open_uart(device, baudrate);
 
-  if (_uart == 0) {
-    return PX4_ERROR;
-  }
+	if (_uart == 0) {
+		return PX4_ERROR;
+	}
 
-  int sub_fd = orb_subscribe(ORB_ID(actuator_controls_2));
-  int armed_sub = orb_subscribe(ORB_ID(actuator_armed));
+	int sub_fd = orb_subscribe(ORB_ID(actuator_controls_2));
+	int armed_sub = orb_subscribe(ORB_ID(actuator_armed));
 
-  /* limit the update rate to something the uart can easily handle */
-  if (baudrate == B57600) {
-    orb_set_interval(sub_fd, 20);
-  } else {
-    orb_set_interval(sub_fd, 10);
-  }
+	/* limit the update rate to something the uart can easily handle */
+	if (baudrate == B57600) {
+		orb_set_interval(sub_fd, 20);
 
-  px4_pollfd_struct_t fds[] = {
-      {.fd = sub_fd, .events = POLLIN},
-  };
+	} else {
+		orb_set_interval(sub_fd, 10);
+	}
 
-  while (!_thread_should_exit) {
-    int poll_ret = px4_poll(fds, 1, 1000);
+	px4_pollfd_struct_t fds[] = {
+		{.fd = sub_fd, .events = POLLIN},
+	};
 
-    if ((poll_ret > 0) && fds[0].revents & POLLIN) {
-      update_armed_status(armed_sub, ignore_disarm);
+	while (!_thread_should_exit) {
+		int poll_ret = px4_poll(fds, 1, 1000);
 
-      struct actuator_controls_s angles_in_struct;
-      orb_copy(ORB_ID(actuator_controls_2), sub_fd, &angles_in_struct);
-      if (!set_angles(angles_in_struct.control)) {
-        warn("failed to set dynamixel angles!");
-      }
-    }
-  }
+		if ((poll_ret > 0) && fds[0].revents & POLLIN) {
+			update_armed_status(armed_sub, ignore_disarm);
 
-  close(_uart);
+			struct actuator_controls_s angles_in_struct;
+			orb_copy(ORB_ID(actuator_controls_2), sub_fd, &angles_in_struct);
 
-  _thread_running = false;
+			if (!set_angles(angles_in_struct.control)) {
+				warn("failed to set dynamixel angles!");
+			}
+		}
+	}
 
-  return PX4_OK;
+	close(_uart);
+
+	_thread_running = false;
+
+	return PX4_OK;
 }
 
 __EXPORT int dynamixel_position_main(int argc, char *argv[]);
@@ -365,39 +394,41 @@ __EXPORT int dynamixel_position_main(int argc, char *argv[]);
 /**
  * Process command line arguments and start the daemon.
  */
-int dynamixel_position_main(int argc, char *argv[]) {
-  if (argc < 1) {
-    errx(1, "missing command\n%s", _commandline_usage);
-  }
+int dynamixel_position_main(int argc, char *argv[])
+{
+	if (argc < 1) {
+		errx(1, "missing command\n%s", _commandline_usage);
+	}
 
-  if (!strcmp(argv[1], "start")) {
-    if (_thread_running) {
-      warnx("already running");
-      exit(0);
-    }
+	if (!strcmp(argv[1], "start")) {
+		if (_thread_running) {
+			warnx("already running");
+			exit(0);
+		}
 
-    _thread_should_exit = false;
-    _deamon_task = px4_task_spawn_cmd(
-        _daemon_name, SCHED_DEFAULT, SCHED_PRIORITY_DEFAULT, 1500,
-        dynamixel_position_thread_main,
-        (argv) ? (char *const *)&argv[2] : (char *const *)NULL);
-    exit(0);
-  }
+		_thread_should_exit = false;
+		_deamon_task = px4_task_spawn_cmd(
+				       _daemon_name, SCHED_DEFAULT, SCHED_PRIORITY_DEFAULT, 1500,
+				       dynamixel_position_thread_main,
+				       (argv) ? (char *const *)&argv[2] : (char *const *)NULL);
+		exit(0);
+	}
 
-  if (!strcmp(argv[1], "stop")) {
-    _thread_should_exit = true;
-    exit(0);
-  }
+	if (!strcmp(argv[1], "stop")) {
+		_thread_should_exit = true;
+		exit(0);
+	}
 
-  if (!strcmp(argv[1], "status")) {
-    if (_thread_running) {
-      warnx("is running");
-    } else {
-      warnx("not started");
-    }
+	if (!strcmp(argv[1], "status")) {
+		if (_thread_running) {
+			warnx("is running");
 
-    exit(0);
-  }
+		} else {
+			warnx("not started");
+		}
 
-  errx(1, "unrecognized command\n%s", _commandline_usage);
+		exit(0);
+	}
+
+	errx(1, "unrecognized command\n%s", _commandline_usage);
 }

--- a/src/drivers/dynamixel/dynamixel_position.c
+++ b/src/drivers/dynamixel/dynamixel_position.c
@@ -1,3 +1,48 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file dynamixel_position.c
+ * Dynamixel position driver.
+ *
+ * @author Zachary Taylor	<ztaylor@ethz.ch>
+ *
+ * A simple controller for working with dynamixel servos that use protocal 2.0.
+ * The servos are set into extended position mode and can be given an angle between -512*PI and 512*PI. 
+ * The angle is given via actuator control group 2, unlike most other actuators its value is not normalized.
+ * All feedback from the servos is disabled to allow higher throughput when using the ttl servos.
+ */
+
 #include <drivers/drv_hrt.h>
 #include <math.h>
 #include <poll.h>
@@ -14,31 +59,64 @@
 
 #include "message.h"
 
-#define DEFAULT_UART "/dev/ttyS1"  // Serial1
+#define DEFAULT_UART "/dev/ttyS1"  /* Serial1 */
 #define DEFAULT_BAUDRATE B115200
 #define DEFAULT_IGNORE_DISARM true
-#define ANGLE_RES 651.898646904f  // 4096 / (2*pi)
+#define ANGLE_RES 651.898646904f  /* 4096 / (2*pi) */
 
 static int _thread_should_exit = false; /**< Deamon exit flag */
 static int _thread_running = false;     /**< Deamon status flag */
 static int _deamon_task;                /**< Handle of deamon task / thread */
 static const char _daemon_name[] = "dynamixel_position";
 static const char _commandline_usage[] =
+    "sends values (interpreted as angles in radians) in Control Group #2 to up "
+    "to 8 dynamixels\n"
     "usage: dynamixel_position start|status|stop [-d <device> -b <baudrate> -u "
     "<update_rate_hz> -i <ignore_disarm>]";
 
-void open_uart(const char *device, const speed_t baudrate);
-bool write_uart(const uint8_t *msg, int msg_length);
-bool set_angles(const float32 *angles);
-bool enable(void);
-bool disable(void);
-void update_armed_status(int armed_sub, bool ignore_disarm);
-void get_commandline_values(int argc, char *argv[], char **device,
-                            speed_t *baudrate, bool *ignore_disarm);
-int dynamixel_position_thread_main(int argc, char *argv[]);
-
 struct termios _uart_config_original;
 int _uart = 0;
+
+/**
+ * Sets uart parameters and opens it.
+ */
+void open_uart(const char *device, const speed_t baudrate);
+
+/**
+ * Writes a given message to the uart.
+ */
+bool write_uart(const uint8_t *msg, int msg_length);
+
+/**
+ * Sends the specified angles to the dynamixels.
+ */
+bool set_angles(const float32 *angles);
+
+/**
+ * Sets up and enables torque for the dynamixels.
+ */
+bool enable(void);
+
+/**
+ * Disables torque in the dynamixels.
+ */
+bool disable(void);
+
+/**
+ * Enables/disables the dynamixels, in response to the armed status of the system.
+ */
+void update_armed_status(int armed_sub, bool ignore_disarm);
+
+/**
+ * Sets parameters specified on the command line.
+ */
+void get_commandline_values(int argc, char *argv[], char **device,
+                            speed_t *baudrate, bool *ignore_disarm);
+
+/**
+ * Main loop that passes specified angles to the dynamixels.
+ */
+int dynamixel_position_thread_main(int argc, char *argv[]);
 
 void open_uart(const char *device, const speed_t baudrate) {
   /* open uart */
@@ -108,25 +186,25 @@ bool enable(void) {
 
   uint8_t msg[WRITE_8_BIT_MESSAGE_SIZE];
 
-  // disable msg status feedback
+  /* disable msg status feedback */
   build_write_8_bit_message(RETURN_LEVEL_SET_ADDRESS, disable_flags, msg);
   if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
     return false;
   }
 
-  // set to extended position control mode
+  /* set to extended position control mode */
   build_write_8_bit_message(OPERATING_MODE_ADDRESS, control_flags, msg);
   if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
     return false;
   }
 
-  // enable servo
+  /* enable servo */
   build_write_8_bit_message(ENABLE_ADDRESS, enable_flags, msg);
   if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
     return false;
   }
 
-  // turn on led to get some feedback
+  /* turn on led to get some feedback */
   build_write_8_bit_message(LED_ADDRESS, enable_flags, msg);
   if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
     return false;
@@ -143,13 +221,13 @@ bool disable(void) {
 
   uint8_t msg[WRITE_8_BIT_MESSAGE_SIZE];
 
-  // disable servo
+  /* disable servo */
   build_write_8_bit_message(ENABLE_ADDRESS, disable_flags, msg);
   if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
     return false;
   }
 
-  // turn off led to get some feedback
+  /* turn off led to get some feedback */
   build_write_8_bit_message(LED_ADDRESS, disable_flags, msg);
   if (!write_uart(msg, WRITE_8_BIT_MESSAGE_SIZE)) {
     return false;
@@ -250,11 +328,10 @@ int dynamixel_position_thread_main(int argc, char *argv[]) {
   int sub_fd = orb_subscribe(ORB_ID(actuator_controls_2));
   int armed_sub = orb_subscribe(ORB_ID(actuator_armed));
 
-  // limit the update rate to something the uart can easily handle
-  if(baudrate == B57600){
+  /* limit the update rate to something the uart can easily handle */
+  if (baudrate == B57600) {
     orb_set_interval(sub_fd, 20);
-  }
-  else{
+  } else {
     orb_set_interval(sub_fd, 10);
   }
 

--- a/src/drivers/dynamixel/message.c
+++ b/src/drivers/dynamixel/message.c
@@ -1,0 +1,194 @@
+#include "message.h"
+#include <math.h>
+
+uint16_t calc_crc(uint8_t* data_blk_ptr, uint16_t data_blk_size) {
+  uint16_t i, j;
+  uint16_t crc_table[256] = {
+      0x0000, 0x8005, 0x800F, 0x000A, 0x801B, 0x001E, 0x0014, 0x8011, 0x8033,
+      0x0036, 0x003C, 0x8039, 0x0028, 0x802D, 0x8027, 0x0022, 0x8063, 0x0066,
+      0x006C, 0x8069, 0x0078, 0x807D, 0x8077, 0x0072, 0x0050, 0x8055, 0x805F,
+      0x005A, 0x804B, 0x004E, 0x0044, 0x8041, 0x80C3, 0x00C6, 0x00CC, 0x80C9,
+      0x00D8, 0x80DD, 0x80D7, 0x00D2, 0x00F0, 0x80F5, 0x80FF, 0x00FA, 0x80EB,
+      0x00EE, 0x00E4, 0x80E1, 0x00A0, 0x80A5, 0x80AF, 0x00AA, 0x80BB, 0x00BE,
+      0x00B4, 0x80B1, 0x8093, 0x0096, 0x009C, 0x8099, 0x0088, 0x808D, 0x8087,
+      0x0082, 0x8183, 0x0186, 0x018C, 0x8189, 0x0198, 0x819D, 0x8197, 0x0192,
+      0x01B0, 0x81B5, 0x81BF, 0x01BA, 0x81AB, 0x01AE, 0x01A4, 0x81A1, 0x01E0,
+      0x81E5, 0x81EF, 0x01EA, 0x81FB, 0x01FE, 0x01F4, 0x81F1, 0x81D3, 0x01D6,
+      0x01DC, 0x81D9, 0x01C8, 0x81CD, 0x81C7, 0x01C2, 0x0140, 0x8145, 0x814F,
+      0x014A, 0x815B, 0x015E, 0x0154, 0x8151, 0x8173, 0x0176, 0x017C, 0x8179,
+      0x0168, 0x816D, 0x8167, 0x0162, 0x8123, 0x0126, 0x012C, 0x8129, 0x0138,
+      0x813D, 0x8137, 0x0132, 0x0110, 0x8115, 0x811F, 0x011A, 0x810B, 0x010E,
+      0x0104, 0x8101, 0x8303, 0x0306, 0x030C, 0x8309, 0x0318, 0x831D, 0x8317,
+      0x0312, 0x0330, 0x8335, 0x833F, 0x033A, 0x832B, 0x032E, 0x0324, 0x8321,
+      0x0360, 0x8365, 0x836F, 0x036A, 0x837B, 0x037E, 0x0374, 0x8371, 0x8353,
+      0x0356, 0x035C, 0x8359, 0x0348, 0x834D, 0x8347, 0x0342, 0x03C0, 0x83C5,
+      0x83CF, 0x03CA, 0x83DB, 0x03DE, 0x03D4, 0x83D1, 0x83F3, 0x03F6, 0x03FC,
+      0x83F9, 0x03E8, 0x83ED, 0x83E7, 0x03E2, 0x83A3, 0x03A6, 0x03AC, 0x83A9,
+      0x03B8, 0x83BD, 0x83B7, 0x03B2, 0x0390, 0x8395, 0x839F, 0x039A, 0x838B,
+      0x038E, 0x0384, 0x8381, 0x0280, 0x8285, 0x828F, 0x028A, 0x829B, 0x029E,
+      0x0294, 0x8291, 0x82B3, 0x02B6, 0x02BC, 0x82B9, 0x02A8, 0x82AD, 0x82A7,
+      0x02A2, 0x82E3, 0x02E6, 0x02EC, 0x82E9, 0x02F8, 0x82FD, 0x82F7, 0x02F2,
+      0x02D0, 0x82D5, 0x82DF, 0x02DA, 0x82CB, 0x02CE, 0x02C4, 0x82C1, 0x8243,
+      0x0246, 0x024C, 0x8249, 0x0258, 0x825D, 0x8257, 0x0252, 0x0270, 0x8275,
+      0x827F, 0x027A, 0x826B, 0x026E, 0x0264, 0x8261, 0x0220, 0x8225, 0x822F,
+      0x022A, 0x823B, 0x023E, 0x0234, 0x8231, 0x8213, 0x0216, 0x021C, 0x8219,
+      0x0208, 0x820D, 0x8207, 0x0202};
+
+  uint16_t crc_accum = 0;
+
+  for (j = 0; j < data_blk_size; j++) {
+    i = ((uint16_t)(crc_accum >> 8) ^ data_blk_ptr[j]) & 0xFF;
+    crc_accum = (crc_accum << 8) ^ crc_table[i];
+  }
+
+  return crc_accum;
+}
+
+void add_message_header(uint8_t* msg) {
+  msg[MESSAGE_HEADER_START_BYTE] = HEADER_BYTE_0;
+  msg[MESSAGE_HEADER_START_BYTE + 1] = HEADER_BYTE_1;
+  msg[MESSAGE_HEADER_START_BYTE + 2] = HEADER_BYTE_2;
+}
+
+void add_message_reserved_byte(uint8_t* msg) {
+  msg[MESSAGE_RESERVED_START_BYTE] = RESERVED_BYTE;
+}
+
+void add_message_broadcast_target(uint8_t* msg) {
+  msg[MESSAGE_TARGET_START_BYTE] = BROADCAST_BYTE;
+}
+
+void add_message_instruction(uint8_t instruction, uint8_t* msg) {
+  msg[MESSAGE_INSTRUCTION_START_BYTE] = instruction;
+}
+
+void add_message_address(uint16_t message_address, uint8_t* msg) {
+  memcpy(&(msg[MESSAGE_ADDRESS_START_BYTE]), &message_address,
+         sizeof(uint16_t));
+}
+
+void add_message_data_length(uint16_t data_length, uint8_t* msg) {
+  memcpy(&(msg[MESSAGE_DATA_LENGTH_START_BYTE]), &data_length,
+         sizeof(uint16_t));
+}
+
+void add_message_read_data_packet(uint8_t target_id, uint8_t* msg) {
+  msg[MESSAGE_BODY_START_BYTE + target_id] = target_id;
+}
+
+void add_message_32_bit_write_data_packet(uint8_t target_id, int32_t data,
+                                          uint8_t* msg) {
+  msg[MESSAGE_BODY_START_BYTE + WRITE_32_BIT_PACKET_SIZE * target_id] =
+      target_id;
+  memcpy(&(msg[MESSAGE_BODY_START_BYTE + WRITE_32_BIT_PACKET_SIZE * target_id +
+               PACKET_HEADER_SIZE]),
+         &data, sizeof(int32_t));
+}
+
+void add_message_16_bit_write_data_packet(uint8_t target_id, uint16_t data,
+                                          uint8_t* msg) {
+  msg[MESSAGE_BODY_START_BYTE + WRITE_16_BIT_PACKET_SIZE * target_id] =
+      target_id;
+  memcpy(&(msg[MESSAGE_BODY_START_BYTE + WRITE_16_BIT_PACKET_SIZE * target_id +
+               PACKET_HEADER_SIZE]),
+         &data, sizeof(uint16_t));
+}
+
+void add_message_8_bit_write_data_packet(uint8_t target_id, uint8_t data,
+                                         uint8_t* msg) {
+  msg[MESSAGE_BODY_START_BYTE + WRITE_8_BIT_PACKET_SIZE * target_id] =
+      target_id;
+  memcpy(&(msg[MESSAGE_BODY_START_BYTE + WRITE_8_BIT_PACKET_SIZE * target_id +
+               PACKET_HEADER_SIZE]),
+         &data, sizeof(uint8_t));
+}
+
+void add_message_size_and_crc(uint16_t packet_size, uint8_t* msg) {
+  uint16_t message_size = BASE_MESSAGE_SIZE + NUM_DYNAMIXELS * packet_size -
+                          MESSAGE_INSTRUCTION_START_BYTE;
+  memcpy(&(msg[MESSAGE_SIZE_START_BYTE]), &message_size, sizeof(uint16_t));
+
+  uint16_t crc =
+      calc_crc(msg, MESSAGE_BODY_START_BYTE + NUM_DYNAMIXELS * packet_size);
+  memcpy(&(msg[MESSAGE_BODY_START_BYTE + NUM_DYNAMIXELS * packet_size]), &crc,
+         sizeof(uint16_t));
+}
+
+void build_read_message(uint16_t read_address, uint8_t* msg) {
+  add_message_header(msg);
+  add_message_reserved_byte(msg);
+  add_message_broadcast_target(msg);
+  add_message_instruction(READ_INSTRUCTION, msg);
+  add_message_address(read_address, msg);
+  add_message_data_length(sizeof(int32_t), msg);
+
+  for (int i = 0; i < NUM_DYNAMIXELS; ++i) {
+    add_message_read_data_packet(i, msg);
+  }
+
+  add_message_size_and_crc(READ_PACKET_SIZE, msg);
+}
+
+void build_write_32_bit_message(uint16_t write_address, int32_t* data,
+                                uint8_t* msg) {
+  add_message_header(msg);
+  add_message_reserved_byte(msg);
+  add_message_broadcast_target(msg);
+  add_message_instruction(WRITE_INSTRUCTION, msg);
+  add_message_address(write_address, msg);
+  add_message_data_length(sizeof(int32_t), msg);
+
+  for (int i = 0; i < NUM_DYNAMIXELS; ++i) {
+    add_message_32_bit_write_data_packet(i, data[i], msg);
+  }
+
+  add_message_size_and_crc(WRITE_32_BIT_PACKET_SIZE, msg);
+}
+
+void build_write_16_bit_message(uint16_t write_address, uint16_t* data,
+                                uint8_t* msg) {
+  add_message_header(msg);
+  add_message_reserved_byte(msg);
+  add_message_broadcast_target(msg);
+  add_message_instruction(WRITE_INSTRUCTION, msg);
+  add_message_address(write_address, msg);
+  add_message_data_length(sizeof(uint16_t), msg);
+
+  for (int i = 0; i < NUM_DYNAMIXELS; ++i) {
+    add_message_16_bit_write_data_packet(i, data[i], msg);
+  }
+
+  add_message_size_and_crc(WRITE_16_BIT_PACKET_SIZE, msg);
+}
+
+void build_write_8_bit_message(uint16_t write_address, uint8_t* data,
+                               uint8_t* msg) {
+  add_message_header(msg);
+  add_message_reserved_byte(msg);
+  add_message_broadcast_target(msg);
+  add_message_instruction(WRITE_INSTRUCTION, msg);
+  add_message_address(write_address, msg);
+  add_message_data_length(sizeof(uint8_t), msg);
+
+  for (int i = 0; i < NUM_DYNAMIXELS; ++i) {
+    add_message_8_bit_write_data_packet(i, data[i], msg);
+  }
+
+  add_message_size_and_crc(WRITE_8_BIT_PACKET_SIZE, msg);
+}
+
+uint8_t parse_status_messages(uint8_t* msg, uint8_t* ids, int32_t* data) {
+  // extract status
+  for (int i = 0; i < NUM_DYNAMIXELS; ++i) {
+    uint8_t error = msg[STATUS_MESSAGE_SIZE * i + STATUS_ERROR_BYTE];
+
+    if(error != 0x00){
+      return error;
+    }
+
+    ids[i] = msg[STATUS_MESSAGE_SIZE * i + STATUS_ID_BYTE];
+    memcpy(&(data[i]), &(msg[STATUS_MESSAGE_SIZE * i + STATUS_DATA_START_BYTE]),
+           sizeof(int32_t));
+  }
+  return 0x00;
+}

--- a/src/drivers/dynamixel/message.c
+++ b/src/drivers/dynamixel/message.c
@@ -34,194 +34,213 @@
 #include "message.h"
 #include <math.h>
 
-uint16_t calc_crc(uint8_t* data_blk_ptr, uint16_t data_blk_size) {
-  uint16_t i, j;
-  uint16_t crc_table[256] = {
-      0x0000, 0x8005, 0x800F, 0x000A, 0x801B, 0x001E, 0x0014, 0x8011, 0x8033,
-      0x0036, 0x003C, 0x8039, 0x0028, 0x802D, 0x8027, 0x0022, 0x8063, 0x0066,
-      0x006C, 0x8069, 0x0078, 0x807D, 0x8077, 0x0072, 0x0050, 0x8055, 0x805F,
-      0x005A, 0x804B, 0x004E, 0x0044, 0x8041, 0x80C3, 0x00C6, 0x00CC, 0x80C9,
-      0x00D8, 0x80DD, 0x80D7, 0x00D2, 0x00F0, 0x80F5, 0x80FF, 0x00FA, 0x80EB,
-      0x00EE, 0x00E4, 0x80E1, 0x00A0, 0x80A5, 0x80AF, 0x00AA, 0x80BB, 0x00BE,
-      0x00B4, 0x80B1, 0x8093, 0x0096, 0x009C, 0x8099, 0x0088, 0x808D, 0x8087,
-      0x0082, 0x8183, 0x0186, 0x018C, 0x8189, 0x0198, 0x819D, 0x8197, 0x0192,
-      0x01B0, 0x81B5, 0x81BF, 0x01BA, 0x81AB, 0x01AE, 0x01A4, 0x81A1, 0x01E0,
-      0x81E5, 0x81EF, 0x01EA, 0x81FB, 0x01FE, 0x01F4, 0x81F1, 0x81D3, 0x01D6,
-      0x01DC, 0x81D9, 0x01C8, 0x81CD, 0x81C7, 0x01C2, 0x0140, 0x8145, 0x814F,
-      0x014A, 0x815B, 0x015E, 0x0154, 0x8151, 0x8173, 0x0176, 0x017C, 0x8179,
-      0x0168, 0x816D, 0x8167, 0x0162, 0x8123, 0x0126, 0x012C, 0x8129, 0x0138,
-      0x813D, 0x8137, 0x0132, 0x0110, 0x8115, 0x811F, 0x011A, 0x810B, 0x010E,
-      0x0104, 0x8101, 0x8303, 0x0306, 0x030C, 0x8309, 0x0318, 0x831D, 0x8317,
-      0x0312, 0x0330, 0x8335, 0x833F, 0x033A, 0x832B, 0x032E, 0x0324, 0x8321,
-      0x0360, 0x8365, 0x836F, 0x036A, 0x837B, 0x037E, 0x0374, 0x8371, 0x8353,
-      0x0356, 0x035C, 0x8359, 0x0348, 0x834D, 0x8347, 0x0342, 0x03C0, 0x83C5,
-      0x83CF, 0x03CA, 0x83DB, 0x03DE, 0x03D4, 0x83D1, 0x83F3, 0x03F6, 0x03FC,
-      0x83F9, 0x03E8, 0x83ED, 0x83E7, 0x03E2, 0x83A3, 0x03A6, 0x03AC, 0x83A9,
-      0x03B8, 0x83BD, 0x83B7, 0x03B2, 0x0390, 0x8395, 0x839F, 0x039A, 0x838B,
-      0x038E, 0x0384, 0x8381, 0x0280, 0x8285, 0x828F, 0x028A, 0x829B, 0x029E,
-      0x0294, 0x8291, 0x82B3, 0x02B6, 0x02BC, 0x82B9, 0x02A8, 0x82AD, 0x82A7,
-      0x02A2, 0x82E3, 0x02E6, 0x02EC, 0x82E9, 0x02F8, 0x82FD, 0x82F7, 0x02F2,
-      0x02D0, 0x82D5, 0x82DF, 0x02DA, 0x82CB, 0x02CE, 0x02C4, 0x82C1, 0x8243,
-      0x0246, 0x024C, 0x8249, 0x0258, 0x825D, 0x8257, 0x0252, 0x0270, 0x8275,
-      0x827F, 0x027A, 0x826B, 0x026E, 0x0264, 0x8261, 0x0220, 0x8225, 0x822F,
-      0x022A, 0x823B, 0x023E, 0x0234, 0x8231, 0x8213, 0x0216, 0x021C, 0x8219,
-      0x0208, 0x820D, 0x8207, 0x0202};
+uint16_t calc_crc(uint8_t *data_blk_ptr, uint16_t data_blk_size)
+{
+	uint16_t i, j;
+	uint16_t crc_table[256] = {
+		0x0000, 0x8005, 0x800F, 0x000A, 0x801B, 0x001E, 0x0014, 0x8011, 0x8033,
+		0x0036, 0x003C, 0x8039, 0x0028, 0x802D, 0x8027, 0x0022, 0x8063, 0x0066,
+		0x006C, 0x8069, 0x0078, 0x807D, 0x8077, 0x0072, 0x0050, 0x8055, 0x805F,
+		0x005A, 0x804B, 0x004E, 0x0044, 0x8041, 0x80C3, 0x00C6, 0x00CC, 0x80C9,
+		0x00D8, 0x80DD, 0x80D7, 0x00D2, 0x00F0, 0x80F5, 0x80FF, 0x00FA, 0x80EB,
+		0x00EE, 0x00E4, 0x80E1, 0x00A0, 0x80A5, 0x80AF, 0x00AA, 0x80BB, 0x00BE,
+		0x00B4, 0x80B1, 0x8093, 0x0096, 0x009C, 0x8099, 0x0088, 0x808D, 0x8087,
+		0x0082, 0x8183, 0x0186, 0x018C, 0x8189, 0x0198, 0x819D, 0x8197, 0x0192,
+		0x01B0, 0x81B5, 0x81BF, 0x01BA, 0x81AB, 0x01AE, 0x01A4, 0x81A1, 0x01E0,
+		0x81E5, 0x81EF, 0x01EA, 0x81FB, 0x01FE, 0x01F4, 0x81F1, 0x81D3, 0x01D6,
+		0x01DC, 0x81D9, 0x01C8, 0x81CD, 0x81C7, 0x01C2, 0x0140, 0x8145, 0x814F,
+		0x014A, 0x815B, 0x015E, 0x0154, 0x8151, 0x8173, 0x0176, 0x017C, 0x8179,
+		0x0168, 0x816D, 0x8167, 0x0162, 0x8123, 0x0126, 0x012C, 0x8129, 0x0138,
+		0x813D, 0x8137, 0x0132, 0x0110, 0x8115, 0x811F, 0x011A, 0x810B, 0x010E,
+		0x0104, 0x8101, 0x8303, 0x0306, 0x030C, 0x8309, 0x0318, 0x831D, 0x8317,
+		0x0312, 0x0330, 0x8335, 0x833F, 0x033A, 0x832B, 0x032E, 0x0324, 0x8321,
+		0x0360, 0x8365, 0x836F, 0x036A, 0x837B, 0x037E, 0x0374, 0x8371, 0x8353,
+		0x0356, 0x035C, 0x8359, 0x0348, 0x834D, 0x8347, 0x0342, 0x03C0, 0x83C5,
+		0x83CF, 0x03CA, 0x83DB, 0x03DE, 0x03D4, 0x83D1, 0x83F3, 0x03F6, 0x03FC,
+		0x83F9, 0x03E8, 0x83ED, 0x83E7, 0x03E2, 0x83A3, 0x03A6, 0x03AC, 0x83A9,
+		0x03B8, 0x83BD, 0x83B7, 0x03B2, 0x0390, 0x8395, 0x839F, 0x039A, 0x838B,
+		0x038E, 0x0384, 0x8381, 0x0280, 0x8285, 0x828F, 0x028A, 0x829B, 0x029E,
+		0x0294, 0x8291, 0x82B3, 0x02B6, 0x02BC, 0x82B9, 0x02A8, 0x82AD, 0x82A7,
+		0x02A2, 0x82E3, 0x02E6, 0x02EC, 0x82E9, 0x02F8, 0x82FD, 0x82F7, 0x02F2,
+		0x02D0, 0x82D5, 0x82DF, 0x02DA, 0x82CB, 0x02CE, 0x02C4, 0x82C1, 0x8243,
+		0x0246, 0x024C, 0x8249, 0x0258, 0x825D, 0x8257, 0x0252, 0x0270, 0x8275,
+		0x827F, 0x027A, 0x826B, 0x026E, 0x0264, 0x8261, 0x0220, 0x8225, 0x822F,
+		0x022A, 0x823B, 0x023E, 0x0234, 0x8231, 0x8213, 0x0216, 0x021C, 0x8219,
+		0x0208, 0x820D, 0x8207, 0x0202
+	};
 
-  uint16_t crc_accum = 0;
+	uint16_t crc_accum = 0;
 
-  for (j = 0; j < data_blk_size; j++) {
-    i = ((uint16_t)(crc_accum >> 8) ^ data_blk_ptr[j]) & 0xFF;
-    crc_accum = (crc_accum << 8) ^ crc_table[i];
-  }
+	for (j = 0; j < data_blk_size; j++) {
+		i = ((uint16_t)(crc_accum >> 8) ^ data_blk_ptr[j]) & 0xFF;
+		crc_accum = (crc_accum << 8) ^ crc_table[i];
+	}
 
-  return crc_accum;
+	return crc_accum;
 }
 
-void add_message_header(uint8_t* msg) {
-  msg[MESSAGE_HEADER_START_BYTE] = HEADER_BYTE_0;
-  msg[MESSAGE_HEADER_START_BYTE + 1] = HEADER_BYTE_1;
-  msg[MESSAGE_HEADER_START_BYTE + 2] = HEADER_BYTE_2;
+void add_message_header(uint8_t *msg)
+{
+	msg[MESSAGE_HEADER_START_BYTE] = HEADER_BYTE_0;
+	msg[MESSAGE_HEADER_START_BYTE + 1] = HEADER_BYTE_1;
+	msg[MESSAGE_HEADER_START_BYTE + 2] = HEADER_BYTE_2;
 }
 
-void add_message_reserved_byte(uint8_t* msg) {
-  msg[MESSAGE_RESERVED_START_BYTE] = RESERVED_BYTE;
+void add_message_reserved_byte(uint8_t *msg)
+{
+	msg[MESSAGE_RESERVED_START_BYTE] = RESERVED_BYTE;
 }
 
-void add_message_broadcast_target(uint8_t* msg) {
-  msg[MESSAGE_TARGET_START_BYTE] = BROADCAST_BYTE;
+void add_message_broadcast_target(uint8_t *msg)
+{
+	msg[MESSAGE_TARGET_START_BYTE] = BROADCAST_BYTE;
 }
 
-void add_message_instruction(uint8_t instruction, uint8_t* msg) {
-  msg[MESSAGE_INSTRUCTION_START_BYTE] = instruction;
+void add_message_instruction(uint8_t instruction, uint8_t *msg)
+{
+	msg[MESSAGE_INSTRUCTION_START_BYTE] = instruction;
 }
 
-void add_message_address(uint16_t message_address, uint8_t* msg) {
-  memcpy(&(msg[MESSAGE_ADDRESS_START_BYTE]), &message_address,
-         sizeof(uint16_t));
+void add_message_address(uint16_t message_address, uint8_t *msg)
+{
+	memcpy(&(msg[MESSAGE_ADDRESS_START_BYTE]), &message_address,
+	       sizeof(uint16_t));
 }
 
-void add_message_data_length(uint16_t data_length, uint8_t* msg) {
-  memcpy(&(msg[MESSAGE_DATA_LENGTH_START_BYTE]), &data_length,
-         sizeof(uint16_t));
+void add_message_data_length(uint16_t data_length, uint8_t *msg)
+{
+	memcpy(&(msg[MESSAGE_DATA_LENGTH_START_BYTE]), &data_length,
+	       sizeof(uint16_t));
 }
 
-void add_message_read_data_packet(uint8_t target_id, uint8_t* msg) {
-  msg[MESSAGE_BODY_START_BYTE + target_id] = target_id;
+void add_message_read_data_packet(uint8_t target_id, uint8_t *msg)
+{
+	msg[MESSAGE_BODY_START_BYTE + target_id] = target_id;
 }
 
 void add_message_32_bit_write_data_packet(uint8_t target_id, int32_t data,
-                                          uint8_t* msg) {
-  msg[MESSAGE_BODY_START_BYTE + WRITE_32_BIT_PACKET_SIZE * target_id] =
-      target_id;
-  memcpy(&(msg[MESSAGE_BODY_START_BYTE + WRITE_32_BIT_PACKET_SIZE * target_id +
-               PACKET_HEADER_SIZE]),
-         &data, sizeof(int32_t));
+		uint8_t *msg)
+{
+	msg[MESSAGE_BODY_START_BYTE + WRITE_32_BIT_PACKET_SIZE * target_id] =
+		target_id;
+	memcpy(&(msg[MESSAGE_BODY_START_BYTE + WRITE_32_BIT_PACKET_SIZE * target_id +
+					     PACKET_HEADER_SIZE]),
+	       &data, sizeof(int32_t));
 }
 
 void add_message_16_bit_write_data_packet(uint8_t target_id, uint16_t data,
-                                          uint8_t* msg) {
-  msg[MESSAGE_BODY_START_BYTE + WRITE_16_BIT_PACKET_SIZE * target_id] =
-      target_id;
-  memcpy(&(msg[MESSAGE_BODY_START_BYTE + WRITE_16_BIT_PACKET_SIZE * target_id +
-               PACKET_HEADER_SIZE]),
-         &data, sizeof(uint16_t));
+		uint8_t *msg)
+{
+	msg[MESSAGE_BODY_START_BYTE + WRITE_16_BIT_PACKET_SIZE * target_id] =
+		target_id;
+	memcpy(&(msg[MESSAGE_BODY_START_BYTE + WRITE_16_BIT_PACKET_SIZE * target_id +
+					     PACKET_HEADER_SIZE]),
+	       &data, sizeof(uint16_t));
 }
 
 void add_message_8_bit_write_data_packet(uint8_t target_id, uint8_t data,
-                                         uint8_t* msg) {
-  msg[MESSAGE_BODY_START_BYTE + WRITE_8_BIT_PACKET_SIZE * target_id] =
-      target_id;
-  memcpy(&(msg[MESSAGE_BODY_START_BYTE + WRITE_8_BIT_PACKET_SIZE * target_id +
-               PACKET_HEADER_SIZE]),
-         &data, sizeof(uint8_t));
+		uint8_t *msg)
+{
+	msg[MESSAGE_BODY_START_BYTE + WRITE_8_BIT_PACKET_SIZE * target_id] =
+		target_id;
+	memcpy(&(msg[MESSAGE_BODY_START_BYTE + WRITE_8_BIT_PACKET_SIZE * target_id +
+					     PACKET_HEADER_SIZE]),
+	       &data, sizeof(uint8_t));
 }
 
-void add_message_size_and_crc(uint16_t packet_size, uint8_t* msg) {
-  uint16_t message_size = BASE_MESSAGE_SIZE + NUM_DYNAMIXELS * packet_size -
-                          MESSAGE_INSTRUCTION_START_BYTE;
-  memcpy(&(msg[MESSAGE_SIZE_START_BYTE]), &message_size, sizeof(uint16_t));
+void add_message_size_and_crc(uint16_t packet_size, uint8_t *msg)
+{
+	uint16_t message_size = BASE_MESSAGE_SIZE + NUM_DYNAMIXELS * packet_size -
+				MESSAGE_INSTRUCTION_START_BYTE;
+	memcpy(&(msg[MESSAGE_SIZE_START_BYTE]), &message_size, sizeof(uint16_t));
 
-  uint16_t crc =
-      calc_crc(msg, MESSAGE_BODY_START_BYTE + NUM_DYNAMIXELS * packet_size);
-  memcpy(&(msg[MESSAGE_BODY_START_BYTE + NUM_DYNAMIXELS * packet_size]), &crc,
-         sizeof(uint16_t));
+	uint16_t crc =
+		calc_crc(msg, MESSAGE_BODY_START_BYTE + NUM_DYNAMIXELS * packet_size);
+	memcpy(&(msg[MESSAGE_BODY_START_BYTE + NUM_DYNAMIXELS * packet_size]), &crc,
+	       sizeof(uint16_t));
 }
 
-void build_read_message(uint16_t read_address, uint8_t* msg) {
-  add_message_header(msg);
-  add_message_reserved_byte(msg);
-  add_message_broadcast_target(msg);
-  add_message_instruction(READ_INSTRUCTION, msg);
-  add_message_address(read_address, msg);
-  add_message_data_length(sizeof(int32_t), msg);
+void build_read_message(uint16_t read_address, uint8_t *msg)
+{
+	add_message_header(msg);
+	add_message_reserved_byte(msg);
+	add_message_broadcast_target(msg);
+	add_message_instruction(READ_INSTRUCTION, msg);
+	add_message_address(read_address, msg);
+	add_message_data_length(sizeof(int32_t), msg);
 
-  for (int i = 0; i < NUM_DYNAMIXELS; ++i) {
-    add_message_read_data_packet(i, msg);
-  }
+	for (int i = 0; i < NUM_DYNAMIXELS; ++i) {
+		add_message_read_data_packet(i, msg);
+	}
 
-  add_message_size_and_crc(READ_PACKET_SIZE, msg);
+	add_message_size_and_crc(READ_PACKET_SIZE, msg);
 }
 
-void build_write_32_bit_message(uint16_t write_address, int32_t* data,
-                                uint8_t* msg) {
-  add_message_header(msg);
-  add_message_reserved_byte(msg);
-  add_message_broadcast_target(msg);
-  add_message_instruction(WRITE_INSTRUCTION, msg);
-  add_message_address(write_address, msg);
-  add_message_data_length(sizeof(int32_t), msg);
+void build_write_32_bit_message(uint16_t write_address, int32_t *data,
+				uint8_t *msg)
+{
+	add_message_header(msg);
+	add_message_reserved_byte(msg);
+	add_message_broadcast_target(msg);
+	add_message_instruction(WRITE_INSTRUCTION, msg);
+	add_message_address(write_address, msg);
+	add_message_data_length(sizeof(int32_t), msg);
 
-  for (int i = 0; i < NUM_DYNAMIXELS; ++i) {
-    add_message_32_bit_write_data_packet(i, data[i], msg);
-  }
+	for (int i = 0; i < NUM_DYNAMIXELS; ++i) {
+		add_message_32_bit_write_data_packet(i, data[i], msg);
+	}
 
-  add_message_size_and_crc(WRITE_32_BIT_PACKET_SIZE, msg);
+	add_message_size_and_crc(WRITE_32_BIT_PACKET_SIZE, msg);
 }
 
-void build_write_16_bit_message(uint16_t write_address, uint16_t* data,
-                                uint8_t* msg) {
-  add_message_header(msg);
-  add_message_reserved_byte(msg);
-  add_message_broadcast_target(msg);
-  add_message_instruction(WRITE_INSTRUCTION, msg);
-  add_message_address(write_address, msg);
-  add_message_data_length(sizeof(uint16_t), msg);
+void build_write_16_bit_message(uint16_t write_address, uint16_t *data,
+				uint8_t *msg)
+{
+	add_message_header(msg);
+	add_message_reserved_byte(msg);
+	add_message_broadcast_target(msg);
+	add_message_instruction(WRITE_INSTRUCTION, msg);
+	add_message_address(write_address, msg);
+	add_message_data_length(sizeof(uint16_t), msg);
 
-  for (int i = 0; i < NUM_DYNAMIXELS; ++i) {
-    add_message_16_bit_write_data_packet(i, data[i], msg);
-  }
+	for (int i = 0; i < NUM_DYNAMIXELS; ++i) {
+		add_message_16_bit_write_data_packet(i, data[i], msg);
+	}
 
-  add_message_size_and_crc(WRITE_16_BIT_PACKET_SIZE, msg);
+	add_message_size_and_crc(WRITE_16_BIT_PACKET_SIZE, msg);
 }
 
-void build_write_8_bit_message(uint16_t write_address, uint8_t* data,
-                               uint8_t* msg) {
-  add_message_header(msg);
-  add_message_reserved_byte(msg);
-  add_message_broadcast_target(msg);
-  add_message_instruction(WRITE_INSTRUCTION, msg);
-  add_message_address(write_address, msg);
-  add_message_data_length(sizeof(uint8_t), msg);
+void build_write_8_bit_message(uint16_t write_address, uint8_t *data,
+			       uint8_t *msg)
+{
+	add_message_header(msg);
+	add_message_reserved_byte(msg);
+	add_message_broadcast_target(msg);
+	add_message_instruction(WRITE_INSTRUCTION, msg);
+	add_message_address(write_address, msg);
+	add_message_data_length(sizeof(uint8_t), msg);
 
-  for (int i = 0; i < NUM_DYNAMIXELS; ++i) {
-    add_message_8_bit_write_data_packet(i, data[i], msg);
-  }
+	for (int i = 0; i < NUM_DYNAMIXELS; ++i) {
+		add_message_8_bit_write_data_packet(i, data[i], msg);
+	}
 
-  add_message_size_and_crc(WRITE_8_BIT_PACKET_SIZE, msg);
+	add_message_size_and_crc(WRITE_8_BIT_PACKET_SIZE, msg);
 }
 
-uint8_t parse_status_messages(uint8_t* msg, uint8_t* ids, int32_t* data) {
-  // extract status
-  for (int i = 0; i < NUM_DYNAMIXELS; ++i) {
-    uint8_t error = msg[STATUS_MESSAGE_SIZE * i + STATUS_ERROR_BYTE];
+uint8_t parse_status_messages(uint8_t *msg, uint8_t *ids, int32_t *data)
+{
+	// extract status
+	for (int i = 0; i < NUM_DYNAMIXELS; ++i) {
+		uint8_t error = msg[STATUS_MESSAGE_SIZE * i + STATUS_ERROR_BYTE];
 
-    if(error != 0x00){
-      return error;
-    }
+		if (error != 0x00) {
+			return error;
+		}
 
-    ids[i] = msg[STATUS_MESSAGE_SIZE * i + STATUS_ID_BYTE];
-    memcpy(&(data[i]), &(msg[STATUS_MESSAGE_SIZE * i + STATUS_DATA_START_BYTE]),
-           sizeof(int32_t));
-  }
-  return 0x00;
+		ids[i] = msg[STATUS_MESSAGE_SIZE * i + STATUS_ID_BYTE];
+		memcpy(&(data[i]), &(msg[STATUS_MESSAGE_SIZE * i + STATUS_DATA_START_BYTE]),
+		       sizeof(int32_t));
+	}
+
+	return 0x00;
 }

--- a/src/drivers/dynamixel/message.c
+++ b/src/drivers/dynamixel/message.c
@@ -1,3 +1,36 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
 #include "message.h"
 #include <math.h>
 

--- a/src/drivers/dynamixel/message.c
+++ b/src/drivers/dynamixel/message.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,6 +37,7 @@
 uint16_t calc_crc(uint8_t *data_blk_ptr, uint16_t data_blk_size)
 {
 	uint16_t i, j;
+	/** CRC table for the CRC-16. The poly is 0x8005 (x^16 + x^15 + x^2 + 1) */
 	uint16_t crc_table[256] = {
 		0x0000, 0x8005, 0x800F, 0x000A, 0x801B, 0x001E, 0x0014, 0x8011, 0x8033,
 		0x0036, 0x003C, 0x8039, 0x0028, 0x802D, 0x8027, 0x0022, 0x8063, 0x0066,

--- a/src/drivers/dynamixel/message.h
+++ b/src/drivers/dynamixel/message.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2012-2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/drivers/dynamixel/message.h
+++ b/src/drivers/dynamixel/message.h
@@ -68,18 +68,18 @@
 
 #define MESSAGE_HEADER_START_BYTE 0
 #define MESSAGE_RESERVED_START_BYTE \
-  (MESSAGE_HEADER_START_BYTE + 3 * sizeof(uint8_t))
+	(MESSAGE_HEADER_START_BYTE + 3 * sizeof(uint8_t))
 #define MESSAGE_TARGET_START_BYTE \
-  (MESSAGE_RESERVED_START_BYTE + sizeof(uint8_t))
+	(MESSAGE_RESERVED_START_BYTE + sizeof(uint8_t))
 #define MESSAGE_SIZE_START_BYTE (MESSAGE_TARGET_START_BYTE + sizeof(uint8_t))
 #define MESSAGE_INSTRUCTION_START_BYTE \
-  (MESSAGE_SIZE_START_BYTE + sizeof(uint16_t))
+	(MESSAGE_SIZE_START_BYTE + sizeof(uint16_t))
 #define MESSAGE_ADDRESS_START_BYTE \
-  (MESSAGE_INSTRUCTION_START_BYTE + sizeof(uint8_t))
+	(MESSAGE_INSTRUCTION_START_BYTE + sizeof(uint8_t))
 #define MESSAGE_DATA_LENGTH_START_BYTE \
-  (MESSAGE_ADDRESS_START_BYTE + sizeof(uint16_t))
+	(MESSAGE_ADDRESS_START_BYTE + sizeof(uint16_t))
 #define MESSAGE_BODY_START_BYTE \
-  (MESSAGE_DATA_LENGTH_START_BYTE + sizeof(uint16_t))
+	(MESSAGE_DATA_LENGTH_START_BYTE + sizeof(uint16_t))
 
 #define PACKET_HEADER_SIZE sizeof(uint8_t)
 #define READ_PACKET_SIZE PACKET_HEADER_SIZE
@@ -89,40 +89,40 @@
 
 #define BASE_MESSAGE_SIZE (MESSAGE_BODY_START_BYTE + sizeof(uint16_t))
 #define READ_MESSAGE_SIZE \
-  (BASE_MESSAGE_SIZE + NUM_DYNAMIXELS * READ_PACKET_SIZE)
+	(BASE_MESSAGE_SIZE + NUM_DYNAMIXELS * READ_PACKET_SIZE)
 #define WRITE_32_BIT_MESSAGE_SIZE \
-  (BASE_MESSAGE_SIZE + NUM_DYNAMIXELS * WRITE_32_BIT_PACKET_SIZE)
+	(BASE_MESSAGE_SIZE + NUM_DYNAMIXELS * WRITE_32_BIT_PACKET_SIZE)
 #define WRITE_16_BIT_MESSAGE_SIZE \
-  (BASE_MESSAGE_SIZE + NUM_DYNAMIXELS * WRITE_16_BIT_PACKET_SIZE)
+	(BASE_MESSAGE_SIZE + NUM_DYNAMIXELS * WRITE_16_BIT_PACKET_SIZE)
 #define WRITE_8_BIT_MESSAGE_SIZE \
-  (BASE_MESSAGE_SIZE + NUM_DYNAMIXELS * WRITE_8_BIT_PACKET_SIZE)
+	(BASE_MESSAGE_SIZE + NUM_DYNAMIXELS * WRITE_8_BIT_PACKET_SIZE)
 #define STATUS_MESSAGE_SIZE 15
 
-uint16_t calc_crc(uint8_t* data_blk_ptr, uint16_t data_blk_size);
-void add_message_header(uint8_t* msg);
-void add_message_reserved_byte(uint8_t* msg);
-void add_message_broadcast_target(uint8_t* msg);
-void add_message_instruction(uint8_t instruction, uint8_t* msg);
-void add_message_address(uint16_t message_address, uint8_t* msg);
-void add_message_data_length(uint16_t data_length, uint8_t* msg);
-void add_message_read_data_packet(uint8_t target_id, uint8_t* msg);
+uint16_t calc_crc(uint8_t *data_blk_ptr, uint16_t data_blk_size);
+void add_message_header(uint8_t *msg);
+void add_message_reserved_byte(uint8_t *msg);
+void add_message_broadcast_target(uint8_t *msg);
+void add_message_instruction(uint8_t instruction, uint8_t *msg);
+void add_message_address(uint16_t message_address, uint8_t *msg);
+void add_message_data_length(uint16_t data_length, uint8_t *msg);
+void add_message_read_data_packet(uint8_t target_id, uint8_t *msg);
 void add_message_32_bit_write_data_packet(uint8_t target_id, int32_t data,
-                                          uint8_t* msg);
+		uint8_t *msg);
 void add_message_16_bit_write_data_packet(uint8_t target_id, uint16_t data,
-                                          uint8_t* msg);
+		uint8_t *msg);
 void add_message_8_bit_write_data_packet(uint8_t target_id, uint8_t data,
-                                         uint8_t* msg);
-void add_message_size_and_crc(uint16_t packet_size, uint8_t* msg);
+		uint8_t *msg);
+void add_message_size_and_crc(uint16_t packet_size, uint8_t *msg);
 int calc_message_size(uint16_t packet_size);
 
-void build_read_message(uint16_t read_address, uint8_t* msg);
-void build_write_32_bit_message(uint16_t write_address, int32_t* data,
-                                uint8_t* msg);
-void build_write_16_bit_message(uint16_t write_address, uint16_t* data,
-                                uint8_t* msg);
-void build_write_8_bit_message(uint16_t write_address, uint8_t* data,
-                               uint8_t* msg);
+void build_read_message(uint16_t read_address, uint8_t *msg);
+void build_write_32_bit_message(uint16_t write_address, int32_t *data,
+				uint8_t *msg);
+void build_write_16_bit_message(uint16_t write_address, uint16_t *data,
+				uint8_t *msg);
+void build_write_8_bit_message(uint16_t write_address, uint8_t *data,
+			       uint8_t *msg);
 
-uint8_t parse_status_messages(uint8_t* msg, uint8_t* ids, int32_t* data);
+uint8_t parse_status_messages(uint8_t *msg, uint8_t *ids, int32_t *data);
 
 #endif //_DYNAMIXEL_MESSAGE_H

--- a/src/drivers/dynamixel/message.h
+++ b/src/drivers/dynamixel/message.h
@@ -1,3 +1,36 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
 #ifndef _DYNAMIXEL_MESSAGE_H
 #define _DYNAMIXEL_MESSAGE_H
 
@@ -80,17 +113,13 @@ void add_message_16_bit_write_data_packet(uint8_t target_id, uint16_t data,
 void add_message_8_bit_write_data_packet(uint8_t target_id, uint8_t data,
                                          uint8_t* msg);
 void add_message_size_and_crc(uint16_t packet_size, uint8_t* msg);
-
 int calc_message_size(uint16_t packet_size);
 
 void build_read_message(uint16_t read_address, uint8_t* msg);
-
 void build_write_32_bit_message(uint16_t write_address, int32_t* data,
                                 uint8_t* msg);
-
 void build_write_16_bit_message(uint16_t write_address, uint16_t* data,
                                 uint8_t* msg);
-
 void build_write_8_bit_message(uint16_t write_address, uint8_t* data,
                                uint8_t* msg);
 

--- a/src/drivers/dynamixel/message.h
+++ b/src/drivers/dynamixel/message.h
@@ -1,0 +1,99 @@
+#ifndef _DYNAMIXEL_MESSAGE_H
+#define _DYNAMIXEL_MESSAGE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define NUM_DYNAMIXELS 8
+
+#define OPERATING_MODE_ADDRESS 0x0B
+#define ENABLE_ADDRESS 0x40
+#define LED_ADDRESS 0x41
+#define RETURN_LEVEL_SET_ADDRESS 0x44
+#define POSITION_D_ADDRESS 0x50
+#define POSITION_I_ADDRESS 0x52
+#define POSITION_P_ADDRESS 0x54
+#define GOAL_POSITION_ADDRESS 0x74
+#define CURRENT_POSITION_ADDRESS 0x84
+
+#define EXTENDED_POSITION_CONTROL_MODE 0x04
+
+#define HEADER_BYTE_0 0xFF
+#define HEADER_BYTE_1 0xFF
+#define HEADER_BYTE_2 0xFD
+#define RESERVED_BYTE 0x00
+#define BROADCAST_BYTE 0xFE
+
+#define READ_INSTRUCTION 0x82
+#define WRITE_INSTRUCTION 0x83
+
+#define STATUS_ID_BYTE 0x04
+#define STATUS_ERROR_BYTE 0x08
+#define STATUS_DATA_START_BYTE 0x09
+
+#define MESSAGE_HEADER_START_BYTE 0
+#define MESSAGE_RESERVED_START_BYTE \
+  (MESSAGE_HEADER_START_BYTE + 3 * sizeof(uint8_t))
+#define MESSAGE_TARGET_START_BYTE \
+  (MESSAGE_RESERVED_START_BYTE + sizeof(uint8_t))
+#define MESSAGE_SIZE_START_BYTE (MESSAGE_TARGET_START_BYTE + sizeof(uint8_t))
+#define MESSAGE_INSTRUCTION_START_BYTE \
+  (MESSAGE_SIZE_START_BYTE + sizeof(uint16_t))
+#define MESSAGE_ADDRESS_START_BYTE \
+  (MESSAGE_INSTRUCTION_START_BYTE + sizeof(uint8_t))
+#define MESSAGE_DATA_LENGTH_START_BYTE \
+  (MESSAGE_ADDRESS_START_BYTE + sizeof(uint16_t))
+#define MESSAGE_BODY_START_BYTE \
+  (MESSAGE_DATA_LENGTH_START_BYTE + sizeof(uint16_t))
+
+#define PACKET_HEADER_SIZE sizeof(uint8_t)
+#define READ_PACKET_SIZE PACKET_HEADER_SIZE
+#define WRITE_32_BIT_PACKET_SIZE (PACKET_HEADER_SIZE + sizeof(int32_t))
+#define WRITE_16_BIT_PACKET_SIZE (PACKET_HEADER_SIZE + sizeof(uint16_t))
+#define WRITE_8_BIT_PACKET_SIZE (PACKET_HEADER_SIZE + sizeof(uint8_t))
+
+#define BASE_MESSAGE_SIZE (MESSAGE_BODY_START_BYTE + sizeof(uint16_t))
+#define READ_MESSAGE_SIZE \
+  (BASE_MESSAGE_SIZE + NUM_DYNAMIXELS * READ_PACKET_SIZE)
+#define WRITE_32_BIT_MESSAGE_SIZE \
+  (BASE_MESSAGE_SIZE + NUM_DYNAMIXELS * WRITE_32_BIT_PACKET_SIZE)
+#define WRITE_16_BIT_MESSAGE_SIZE \
+  (BASE_MESSAGE_SIZE + NUM_DYNAMIXELS * WRITE_16_BIT_PACKET_SIZE)
+#define WRITE_8_BIT_MESSAGE_SIZE \
+  (BASE_MESSAGE_SIZE + NUM_DYNAMIXELS * WRITE_8_BIT_PACKET_SIZE)
+#define STATUS_MESSAGE_SIZE 15
+
+uint16_t calc_crc(uint8_t* data_blk_ptr, uint16_t data_blk_size);
+void add_message_header(uint8_t* msg);
+void add_message_reserved_byte(uint8_t* msg);
+void add_message_broadcast_target(uint8_t* msg);
+void add_message_instruction(uint8_t instruction, uint8_t* msg);
+void add_message_address(uint16_t message_address, uint8_t* msg);
+void add_message_data_length(uint16_t data_length, uint8_t* msg);
+void add_message_read_data_packet(uint8_t target_id, uint8_t* msg);
+void add_message_32_bit_write_data_packet(uint8_t target_id, int32_t data,
+                                          uint8_t* msg);
+void add_message_16_bit_write_data_packet(uint8_t target_id, uint16_t data,
+                                          uint8_t* msg);
+void add_message_8_bit_write_data_packet(uint8_t target_id, uint8_t data,
+                                         uint8_t* msg);
+void add_message_size_and_crc(uint16_t packet_size, uint8_t* msg);
+
+int calc_message_size(uint16_t packet_size);
+
+void build_read_message(uint16_t read_address, uint8_t* msg);
+
+void build_write_32_bit_message(uint16_t write_address, int32_t* data,
+                                uint8_t* msg);
+
+void build_write_16_bit_message(uint16_t write_address, uint16_t* data,
+                                uint8_t* msg);
+
+void build_write_8_bit_message(uint16_t write_address, uint8_t* data,
+                               uint8_t* msg);
+
+uint8_t parse_status_messages(uint8_t* msg, uint8_t* ids, int32_t* data);
+
+#endif //_DYNAMIXEL_MESSAGE_H


### PR DESCRIPTION
Adds a driver to allow the px4 to interface with dynamixel servos that use the dynamixel 2.0 protocol (http://support.robotis.com/en/product/actuator/dynamixel_pro/communication.htm)

This driver uses a very small subset of the possible dynamixel options, only implementing a broadcast write instruction and broadcast read instruction (currently unused).

It allows using the dynamixels in extended position control mode taking commanded angles on the actuator control group 2. It disables all feedback from the servos as many dynamixel servos use a 1 wire interface and waiting for the response significantly limits the bandwidth.

I have not included it in any builds, as I figure this would be quite a rarely used driver that only a small number of people would be interested in.

Tested with 6 dynamixel XL430-W250-T servos.