### PR TITLE
mpu9250 allow a 2nd internal spi instance and remove px4fmu-v4 external

### DIFF
--- a/src/drivers/boards/px4fmu-v4/board_config.h
+++ b/src/drivers/boards/px4fmu-v4/board_config.h
@@ -133,7 +133,6 @@
 #define PX4_SPI_BUS_SENSORS          1
 #define PX4_SPI_BUS_RAMTRON          2
 #define PX4_SPI_BUS_BARO             PX4_SPI_BUS_RAMTRON
-#define PX4_SPI_BUS_EXT              1
 
 /* Use these in place of the uint32_t enumeration to select a specific SPI device on SPI1 */
 #define PX4_SPIDEV_GYRO              PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 1)
@@ -148,7 +147,7 @@
 #define PX4_SPIDEV_ICM_20602         PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 11)
 #define PX4_SPIDEV_BMI055_ACC        PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 12)
 #define PX4_SPIDEV_BMI055_GYR        PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 13)
-#define PX4_SPIDEV_EXT_MPU           PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 14)
+#define PX4_SPIDEV_MPU2              PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 14)
 
 /* onboard MS5611 and FRAM are both on bus SPI2
  * spi_dev_e:SPIDEV_FLASH has the value 2 and is used in the NuttX ramtron driver

--- a/src/drivers/boards/px4fmu-v4/spi.c
+++ b/src/drivers/boards/px4fmu-v4/spi.c
@@ -121,7 +121,7 @@ __EXPORT void stm32_spi1select(FAR struct spi_dev_s *dev, uint32_t devid, bool s
 	case PX4_SPIDEV_ICM_20602:
 	case PX4_SPIDEV_ICM_20608:
 	case PX4_SPIDEV_BMI055_ACC:
-	case PX4_SPIDEV_EXT_MPU:
+	case PX4_SPIDEV_MPU2:
 		/* Making sure the other peripherals are not selected */
 		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN2, 1);
 		px4_arch_gpiowrite(GPIO_SPI1_CS_PORTC_PIN15, !selected);
@@ -237,6 +237,4 @@ __EXPORT void board_spi_reset(int ms)
 	stm32_configgpio(GPIO_SPI1_SCK);
 	stm32_configgpio(GPIO_SPI1_MISO);
 	stm32_configgpio(GPIO_SPI1_MOSI);
-
-
 }

--- a/src/drivers/imu/mpu9250/mpu9250.h
+++ b/src/drivers/imu/mpu9250/mpu9250.h
@@ -231,14 +231,11 @@ struct MPUReport {
 #  define MPU9250_LOW_SPEED_OP(r)			MPU9250_REG((r))
 
 /* interface factories */
-extern device::Device *MPU9250_SPI_interface(int bus, bool external_bus);
-extern device::Device *MPU9250_I2C_interface(int bus, bool external_bus);
+extern device::Device *MPU9250_SPI_interface(int bus, uint32_t cs, bool external_bus);
+extern device::Device *MPU9250_I2C_interface(int bus, uint32_t address, bool external_bus);
 extern int MPU9250_probe(device::Device *dev, int device_type);
 
-typedef device::Device *(*MPU9250_constructor)(int, bool);
-
-
-
+typedef device::Device *(*MPU9250_constructor)(int, uint32_t, bool);
 
 class MPU9250_mag;
 class MPU9250_gyro;

--- a/src/drivers/imu/mpu9250/mpu9250_i2c.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250_i2c.cpp
@@ -61,15 +61,14 @@
 
 #ifdef USE_I2C
 
-device::Device *MPU9250_I2C_interface(int bus, bool external_bus);
+device::Device *MPU9250_I2C_interface(int bus, uint32_t address, bool external_bus);
 
 class MPU9250_I2C : public device::I2C
 {
 public:
-	MPU9250_I2C(int bus);
-	virtual ~MPU9250_I2C();
+	MPU9250_I2C(int bus, uint32_t address);
+	virtual ~MPU9250_I2C() = default;
 
-	virtual int	init();
 	virtual int	read(unsigned address, void *data, unsigned count);
 	virtual int	write(unsigned address, void *data, unsigned count);
 
@@ -80,34 +79,22 @@ protected:
 
 };
 
-
 device::Device *
-MPU9250_I2C_interface(int bus, bool external_bus)
+MPU9250_I2C_interface(int bus, uint32_t address, bool external_bus)
 {
-	return new MPU9250_I2C(bus);
+	return new MPU9250_I2C(bus, address);
 }
 
-MPU9250_I2C::MPU9250_I2C(int bus) :
-	I2C("MPU9250_I2C", nullptr, bus, PX4_I2C_OBDEV_MPU9250, 400000)
+MPU9250_I2C::MPU9250_I2C(int bus, uint32_t address) :
+	I2C("MPU9250_I2C", nullptr, bus, address, 400000)
 {
 	_device_id.devid_s.devtype =  DRV_ACC_DEVTYPE_MPU9250;
-}
-
-MPU9250_I2C::~MPU9250_I2C()
-{
-}
-
-int
-MPU9250_I2C::init()
-{
-	/* this will call probe() */
-	return I2C::init();
 }
 
 int
 MPU9250_I2C::ioctl(unsigned operation, unsigned &arg)
 {
-	int ret;
+	int ret = PX4_ERROR;
 
 	switch (operation) {
 
@@ -154,7 +141,6 @@ MPU9250_I2C::read(unsigned reg_speed, void *data, unsigned count)
 	uint8_t cmd = MPU9250_REG(reg_speed);
 	return transfer(&cmd, 1, &((uint8_t *)data)[offset], count);
 }
-
 
 int
 MPU9250_I2C::probe()


### PR DESCRIPTION
RE: https://github.com/PX4/Firmware/pull/9372

Adding a fake "external" SPI bus to px4fmu-v4 isn't quite right because the rotations will likely be wrong (depending on the board).

This PR partially reverts #9372 and creates a second optional MPU device for the px4fmu-v4.

Note: this is still horrible, we need to find a better way to split the drivers and board configurations.