### PR TITLE
[WIP]sensors handle multiple differential pressure and move consistency check to validator

### DIFF
--- a/msg/airspeed.msg
+++ b/msg/airspeed.msg
@@ -1,5 +1,6 @@
 float32 indicated_airspeed_m_s		# indicated airspeed in meters per second, -1 if unknown
 float32 true_airspeed_m_s		# true filtered airspeed in meters per second, -1 if unknown
-float32 true_airspeed_unfiltered_m_s	# true airspeed in meters per second, -1 if unknown
-float32 air_temperature_celsius		# air temperature in degrees celsius, -1000 if unknown
+
+float32 air_temperature_celsius		# air temperature in degrees celsius, NAN if unknown
+
 float32 confidence			# confidence value from 0 to 1 for this sensor

--- a/msg/vehicle_air_data.msg
+++ b/msg/vehicle_air_data.msg
@@ -1,6 +1,10 @@
 
 float32 baro_alt_meter			# Altitude above MSL calculated from temperature compensated baro sensor data using an ISA corrected for sea level pressure SENS_BARO_QNH.
+
 float32 baro_temp_celcius		# Temperature in degrees celsius
+
 float32 baro_pressure_pa		# Absolute pressure in pascals
 
-float32 rho						# air density
+float32 air_density			# air density
+
+float32 temperature			# air temperature in degrees celsius, NAN if unknown

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -42,16 +42,7 @@
 
 #include <px4_config.h>
 #include <px4_posix.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <fcntl.h>
-#include <errno.h>
-#include <math.h>
-#include <poll.h>
 
-#include <systemlib/err.h>
 #include <parameters/param.h>
 #include <systemlib/rc_check.h>
 #include <systemlib/mavlink_log.h>

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -789,7 +789,7 @@ void Ekf2::run()
 					// take mean across sample period
 					float balt_data_avg = _balt_data_sum / (float)_balt_sample_count;
 
-					_ekf.set_air_density(airdata.rho);
+					_ekf.set_air_density(airdata.air_density);
 
 					// calculate static pressure error = Pmeas - Ptruth
 					// model position error sensitivity as a body fixed ellipse with different scale in the positive and negtive X direction
@@ -809,11 +809,11 @@ void Ekf2::run()
 					const float y_v2 = fminf(vel_body_wind(1) * vel_body_wind(1), max_airspeed_sq);
 					const float z_v2 = fminf(vel_body_wind(2) * vel_body_wind(2), max_airspeed_sq);
 
-					const float pstatic_err = 0.5f * airdata.rho *
+					const float pstatic_err = 0.5f * airdata.air_density *
 								  (K_pstatic_coef_x * x_v2) + (_K_pstatic_coef_y.get() * y_v2) + (_K_pstatic_coef_z.get() * z_v2);
 
 					// correct baro measurement using pressure error estimate and assuming sea level gravity
-					balt_data_avg += pstatic_err / (airdata.rho * CONSTANTS_ONE_G);
+					balt_data_avg += pstatic_err / (airdata.air_density * CONSTANTS_ONE_G);
 
 					// push to estimator
 					_ekf.setBaroData(1000 * (uint64_t)balt_time_ms, balt_data_avg);

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -1878,7 +1878,6 @@ int sdlog2_thread_main(int argc, char *argv[])
 				log_msg.msg_type = LOG_AIRS_MSG;
 				log_msg.body.log_AIRS.indicated_airspeed_m_s = buf.airspeed.indicated_airspeed_m_s;
 				log_msg.body.log_AIRS.true_airspeed_m_s = buf.airspeed.true_airspeed_m_s;
-				log_msg.body.log_AIRS.true_airspeed_unfiltered_m_s = buf.airspeed.true_airspeed_unfiltered_m_s;
 				log_msg.body.log_AIRS.air_temperature_celsius = buf.airspeed.air_temperature_celsius;
 				log_msg.body.log_AIRS.confidence = buf.airspeed.confidence;
 				LOGBUFFER_WRITE_AND_COUNT(AIRS);

--- a/src/modules/sdlog2/sdlog2_messages.h
+++ b/src/modules/sdlog2/sdlog2_messages.h
@@ -201,7 +201,6 @@ struct log_OUT_s {
 struct log_AIRS_s {
 	float indicated_airspeed_m_s;
 	float true_airspeed_m_s;
-	float true_airspeed_unfiltered_m_s;
 	float air_temperature_celsius;
 	float confidence;
 };
@@ -605,7 +604,7 @@ static const struct log_format_s log_formats[] = {
 	LOG_FORMAT(RC, "ffffffffffffBBBL",		"C0,C1,C2,C3,C4,C5,C6,C7,C8,C9,C10,C11,RSSI,CNT,Lost,Drop"),
 	LOG_FORMAT_S(OUT0, OUT, "ffffffff",		"Out0,Out1,Out2,Out3,Out4,Out5,Out6,Out7"),
 	LOG_FORMAT_S(OUT1, OUT, "ffffffff",		"Out0,Out1,Out2,Out3,Out4,Out5,Out6,Out7"),
-	LOG_FORMAT(AIRS, "fffff",			"IAS,TAS,TASraw,Temp,Confidence"),
+	LOG_FORMAT(AIRS, "ffff",			"IAS,TAS,Temp,Confidence"),
 	LOG_FORMAT(ARSP, "fff",			"RollRateSP,PitchRateSP,YawRateSP"),
 	LOG_FORMAT(FLOW, "BffffffLLHhB",	"ID,RawX,RawY,RX,RY,RZ,Dist,TSpan,DtSonar,FrmCnt,GT,Qlty"),
 	LOG_FORMAT(GPOS, "LLfffffff",		"Lat,Lon,Alt,VelN,VelE,VelD,EPH,EPV,TALT"),

--- a/src/modules/sensors/common.h
+++ b/src/modules/sensors/common.h
@@ -43,14 +43,16 @@
 namespace sensors
 {
 
-constexpr uint8_t MAG_COUNT_MAX = 4;
-constexpr uint8_t GYRO_COUNT_MAX = 3;
-constexpr uint8_t ACCEL_COUNT_MAX = 3;
-constexpr uint8_t BARO_COUNT_MAX = 3;
+static constexpr uint8_t MAG_COUNT_MAX = 4;
+static constexpr uint8_t GYRO_COUNT_MAX = 3;
+static constexpr uint8_t ACCEL_COUNT_MAX = 3;
+static constexpr uint8_t BARO_COUNT_MAX = 3;
+static constexpr uint8_t DPRES_COUNT_MAX = 3;
 
-constexpr uint8_t SENSOR_COUNT_MAX = math::max(MAG_COUNT_MAX,
-				     math::max(GYRO_COUNT_MAX,
-						     math::max(ACCEL_COUNT_MAX,
-								     BARO_COUNT_MAX)));
+static constexpr uint8_t SENSOR_COUNT_MAX = math::max(MAG_COUNT_MAX,
+		math::max(GYRO_COUNT_MAX,
+			  math::max(ACCEL_COUNT_MAX,
+				    math::max(BARO_COUNT_MAX,
+						    DPRES_COUNT_MAX))));
 
 } /* namespace sensors */

--- a/src/modules/systemlib/airspeed.h
+++ b/src/modules/systemlib/airspeed.h
@@ -44,8 +44,7 @@
 
 #include "math.h"
 #include "conversions.h"
-
-__BEGIN_DECLS
+#include <ecl/geo/geo.h>
 
 enum AIRSPEED_SENSOR_MODEL {
 	AIRSPEED_SENSOR_MODEL_MEMBRANE = 0,
@@ -69,9 +68,9 @@ enum AIRSPEED_COMPENSATION_MODEL {
  * @param static_pressure pressure at the side of the tube/airplane
  * @return indicated airspeed in m/s
  */
-__EXPORT float calc_indicated_airspeed_corrected(enum AIRSPEED_COMPENSATION_MODEL pmodel,
-		enum AIRSPEED_SENSOR_MODEL smodel,
-		float tube_len, float tube_dia_mm, float differential_pressure, float pressure_ambient, float temperature_celsius);
+float calc_indicated_airspeed_corrected(enum AIRSPEED_COMPENSATION_MODEL pmodel,
+					enum AIRSPEED_SENSOR_MODEL smodel,
+					float tube_len, float tube_dia_mm, float differential_pressure, float pressure_ambient, float temperature_celsius);
 
 /**
  * Calculate indicated airspeed.
@@ -84,7 +83,7 @@ __EXPORT float calc_indicated_airspeed_corrected(enum AIRSPEED_COMPENSATION_MODE
  * @param static_pressure pressure at the side of the tube/airplane
  * @return indicated airspeed in m/s
  */
-__EXPORT float calc_indicated_airspeed(float differential_pressure);
+float calc_indicated_airspeed(float differential_pressure, float air_density = CONSTANTS_AIR_DENSITY_SEA_LEVEL_15C);
 
 /**
  * Calculate true airspeed from indicated airspeed.
@@ -96,8 +95,8 @@ __EXPORT float calc_indicated_airspeed(float differential_pressure);
  * @param temperature_celsius air temperature in degrees celcius
  * @return true airspeed in m/s
  */
-__EXPORT float calc_true_airspeed_from_indicated(float speed_indicated, float pressure_ambient,
-		float temperature_celsius);
+float calc_true_airspeed_from_indicated(float speed_indicated, float pressure_ambient,
+					float temperature_celsius);
 
 /**
  * Directly calculate true airspeed
@@ -109,7 +108,7 @@ __EXPORT float calc_true_airspeed_from_indicated(float speed_indicated, float pr
  * @param temperature_celsius air temperature in degrees celcius
  * @return true airspeed in m/s
  */
-__EXPORT float calc_true_airspeed(float total_pressure, float static_pressure, float temperature_celsius);
+float calc_true_airspeed(float total_pressure, float static_pressure, float temperature_celsius);
 
 /**
 * Calculates air density.
@@ -117,8 +116,7 @@ __EXPORT float calc_true_airspeed(float total_pressure, float static_pressure, f
 * @param static_pressure ambient pressure in millibar
 * @param temperature_celcius air / ambient temperature in celcius
 */
-__EXPORT float get_air_density(float static_pressure, float temperature_celsius);
+float get_air_density(float static_pressure, float temperature_celsius);
 
-__END_DECLS
 
 #endif

--- a/src/modules/systemlib/otp.h
+++ b/src/modules/systemlib/otp.h
@@ -130,11 +130,6 @@ union udid {
 
 __BEGIN_DECLS
 
-/**
- *   s
- */
-//__EXPORT float calc_indicated_airspeed(float differential_pressure);
-
 __EXPORT void F_unlock(void);
 __EXPORT void F_lock(void);
 __EXPORT int val_read(void *dest, volatile const void *src, int bytes);


### PR DESCRIPTION
This PR updates the sensors module to handle multiple differential pressure sensors alongside multiple gyros, accels, baros, mags. 

 - moved the preflight consistency check to the data validator module which seemed like a good fit because it already has all the necessary data. 
 - split up the gigantic parameter update function and reduced stack requirements by a few hundred bytes
 - overall frees up ~ 1KB ram on a pixhawk 2
 - update airspeed and air density calculations to use real air temperature when available
 - requires https://github.com/PX4/ecl/pull/428


Next steps
 - all calibration parameters for each differential pressure sensor
 - update differential pressure calibration routine to walk through each sensor