### PR TITLE
Logger: add watchdog to boost its priority in case of a busy-looping task

### DIFF
--- a/src/modules/logger/CMakeLists.txt
+++ b/src/modules/logger/CMakeLists.txt
@@ -43,6 +43,7 @@ px4_add_module(
 		log_writer.cpp
 		log_writer_file.cpp
 		log_writer_mavlink.cpp
+		watchdog.cpp
 	DEPENDS
 		platforms__common
 		modules__uORB

--- a/src/modules/logger/log_writer.h
+++ b/src/modules/logger/log_writer.h
@@ -137,6 +137,13 @@ public:
 		return 0;
 	}
 
+	pthread_t thread_id_file() const
+	{
+		if (_log_writer_file) { return _log_writer_file->thread_id(); }
+
+		return (pthread_t)0;
+	}
+
 
 	/**
 	 * Indicate to the underlying backend whether future write_message() calls need a reliable

--- a/src/modules/logger/log_writer_file.h
+++ b/src/modules/logger/log_writer_file.h
@@ -113,6 +113,8 @@ public:
 		return _need_reliable_transfer;
 	}
 
+	pthread_t thread_id() const { return _thread; }
+
 private:
 	static void *run_helper(void *);
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -88,10 +88,19 @@
 
 using namespace px4::logger;
 
+
+struct timer_callback_data_s {
+	px4_sem_t semaphore;
+
+};
+
 /* This is used to schedule work for the logger (periodic scan for updated topics) */
 static void timer_callback(void *arg)
 {
-	px4_sem_t *semaphore = (px4_sem_t *)arg;
+	/* Note: we are in IRQ context here (on NuttX) */
+
+	timer_callback_data_s *data = (timer_callback_data_s *)arg;
+
 
 	/* check the value of the semaphore: if the logger cannot keep up with running it's main loop as fast
 	 * as the timer_callback here increases the semaphore count, the counter would increase unbounded,
@@ -101,11 +110,12 @@ static void timer_callback(void *arg)
 	 * multiple iterations at once, the next time it's scheduled). */
 	int semaphore_value;
 
-	if (px4_sem_getvalue(semaphore, &semaphore_value) == 0 && semaphore_value > 1) {
+	if (px4_sem_getvalue(&data->semaphore, &semaphore_value) == 0 && semaphore_value > 1) {
 		return;
 	}
 
-	px4_sem_post(semaphore);
+	px4_sem_post(&data->semaphore);
+
 }
 
 
@@ -922,12 +932,11 @@ void Logger::run()
 	}
 
 	/* init the update timer */
-	struct hrt_call timer_call;
-	memset(&timer_call, 0, sizeof(hrt_call));
-	px4_sem_t timer_semaphore;
-	px4_sem_init(&timer_semaphore, 0, 0);
+	struct hrt_call timer_call{};
+	timer_callback_data_s timer_callback_data;
+	px4_sem_init(&timer_callback_data.semaphore, 0, 0);
 	/* timer_semaphore use case is a signal */
-	px4_sem_setprotocol(&timer_semaphore, SEM_PRIO_NONE);
+	px4_sem_setprotocol(&timer_callback_data.semaphore, SEM_PRIO_NONE);
 
 	int polling_topic_sub = -1;
 
@@ -939,7 +948,8 @@ void Logger::run()
 		}
 
 	} else {
-		hrt_call_every(&timer_call, _log_interval, _log_interval, timer_callback, &timer_semaphore);
+
+		hrt_call_every(&timer_call, _log_interval, _log_interval, timer_callback, &timer_callback_data);
 	}
 
 	// check for new subscription data
@@ -1200,14 +1210,14 @@ void Logger::run()
 			 * And on linux this is quite accurate as well, but under NuttX it is not accurate,
 			 * because usleep() has only a granularity of CONFIG_MSEC_PER_TICK (=1ms).
 			 */
-			while (px4_sem_wait(&timer_semaphore) != 0);
+			while (px4_sem_wait(&timer_callback_data.semaphore) != 0);
 		}
 	}
 
 	stop_log_file();
 
 	hrt_cancel(&timer_call);
-	px4_sem_destroy(&timer_semaphore);
+	px4_sem_destroy(&timer_callback_data.semaphore);
 
 	// stop the writer thread
 	_writer.thread_stop();

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -34,6 +34,7 @@
 #include <px4_config.h>
 #include "logger.h"
 #include "messages.h"
+#include "watchdog.h"
 
 #include <dirent.h>
 #include <sys/stat.h>
@@ -92,6 +93,8 @@ using namespace px4::logger;
 struct timer_callback_data_s {
 	px4_sem_t semaphore;
 
+	watchdog_data_t watchdog_data;
+	volatile bool watchdog_triggered = false;
 };
 
 /* This is used to schedule work for the logger (periodic scan for updated topics) */
@@ -101,6 +104,9 @@ static void timer_callback(void *arg)
 
 	timer_callback_data_s *data = (timer_callback_data_s *)arg;
 
+	if (watchdog_update(data->watchdog_data)) {
+		data->watchdog_triggered = true;
+	}
 
 	/* check the value of the semaphore: if the logger cannot keep up with running it's main loop as fast
 	 * as the timer_callback here increases the semaphore count, the counter would increase unbounded,
@@ -949,6 +955,17 @@ void Logger::run()
 
 	} else {
 
+		if (_writer.backend() & LogWriter::BackendFile) {
+
+			const pid_t pid_self = getpid();
+			// The pthread_t ID is equal to the PID on NuttX
+			const pid_t pid_writer = _writer.thread_id_file();
+
+			// sched_note_start is already called from pthread_create and task_create,
+			// which means we can expect to find the tasks in system_load.tasks, as required in watchdog_initialize
+			watchdog_initialize(pid_self, pid_writer, timer_callback_data.watchdog_data);
+		}
+
 		hrt_call_every(&timer_call, _log_interval, _log_interval, timer_callback, &timer_callback_data);
 	}
 
@@ -1024,6 +1041,11 @@ void Logger::run()
 			}
 		}
 
+
+		if (timer_callback_data.watchdog_triggered) {
+			timer_callback_data.watchdog_triggered = false;
+			initialize_load_output(PrintLoadReason::Watchdog);
+		}
 
 
 		const hrt_abstime loop_time = hrt_absolute_time();
@@ -1622,6 +1644,9 @@ void Logger::initialize_load_output(PrintLoadReason reason)
 
 void Logger::write_load_output()
 {
+	if (_print_load_reason == PrintLoadReason::Watchdog) {
+		PX4_ERR("Writing watchdog data"); // this is just that we see it easily in the log
+	}
 	perf_callback_data_t callback_data = {};
 	char buffer[140];
 	callback_data.logger = this;

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -976,7 +976,7 @@ void Logger::run()
 
 				} else {
 					// delayed stop: we measure the process loads and then stop
-					initialize_load_output();
+					initialize_load_output(PrintLoadReason::Postflight);
 					_should_stop_file_log = true;
 				}
 			}
@@ -1026,12 +1026,12 @@ void Logger::run()
 
 				if (_should_stop_file_log) {
 					_should_stop_file_log = false;
-					write_load_output(false);
+					write_load_output();
 					stop_log_file();
 					continue; // skip to next loop iteration
 
 				} else {
-					write_load_output(true);
+					write_load_output();
 				}
 			}
 
@@ -1482,7 +1482,7 @@ void Logger::start_log_file()
 
 	_start_time_file = hrt_absolute_time();
 
-	initialize_load_output();
+	initialize_load_output(PrintLoadReason::Preflight);
 }
 
 void Logger::stop_log_file()
@@ -1518,7 +1518,7 @@ void Logger::start_log_mavlink()
 	_writer.unselect_write_backend();
 	_writer.notify();
 
-	initialize_load_output();
+	initialize_load_output(PrintLoadReason::Preflight);
 }
 
 void Logger::stop_log_mavlink()
@@ -1576,18 +1576,26 @@ void Logger::print_load_callback(void *user)
 		return;
 	}
 
-	if (callback_data->preflight) {
-		perf_name = "perf_top_preflight";
-
-	} else {
-		perf_name = "perf_top_postflight";
+	switch (callback_data->logger->_print_load_reason) {
+		case PrintLoadReason::Preflight:
+			perf_name = "perf_top_preflight";
+			break;
+		case PrintLoadReason::Postflight:
+			perf_name = "perf_top_postflight";
+			break;
+		case PrintLoadReason::Watchdog:
+			perf_name = "perf_top_watchdog";
+			break;
+		default:
+			perf_name = "perf_top";
+			break;
 	}
 
 	callback_data->logger->write_info_multiple(perf_name, callback_data->buffer, callback_data->counter != 0);
 	++callback_data->counter;
 }
 
-void Logger::initialize_load_output()
+void Logger::initialize_load_output(PrintLoadReason reason)
 {
 	perf_callback_data_t callback_data;
 	callback_data.logger = this;
@@ -1599,16 +1607,16 @@ void Logger::initialize_load_output()
 	// this will not yet print anything
 	print_load_buffer(curr_time, buffer, sizeof(buffer), print_load_callback, &callback_data, &_load);
 	_next_load_print = curr_time + 1000000;
+	_print_load_reason = reason;
 }
 
-void Logger::write_load_output(bool preflight)
+void Logger::write_load_output()
 {
 	perf_callback_data_t callback_data = {};
 	char buffer[140];
 	callback_data.logger = this;
 	callback_data.counter = 0;
 	callback_data.buffer = buffer;
-	callback_data.preflight = preflight;
 	hrt_abstime curr_time = hrt_absolute_time();
 	_writer.set_need_reliable_transfer(true);
 	// TODO: maybe we should restrict the output to a selected backend (eg. when file logging is running

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -161,6 +161,12 @@ public:
 
 private:
 
+	enum class PrintLoadReason {
+		Preflight,
+		Postflight,
+		Watchdog
+	};
+
 	/**
 	 * Write an ADD_LOGGED_MSG to the log for a all current subscriptions and instances
 	 */
@@ -297,12 +303,12 @@ private:
 	/**
 	 * initialize the output for the process load, so that ~1 second later it will be written to the log
 	 */
-	void initialize_load_output();
+	void initialize_load_output(PrintLoadReason reason);
 
 	/**
 	 * write the process load, which was previously initialized with initialize_load_output()
 	 */
-	void write_load_output(bool preflight);
+	void write_load_output();
 
 
 	static constexpr size_t 	MAX_TOPICS_NUM = 64; /**< Maximum number of logged topics */
@@ -344,6 +350,7 @@ private:
 											will be stopped after load printing */
 	print_load_s					_load{}; ///< process load data
 	hrt_abstime					_next_load_print{0}; ///< timestamp when to print the process load
+	PrintLoadReason					_print_load_reason;
 
 	// control
 	param_t						_sdlog_profile_handle{PARAM_INVALID};

--- a/src/modules/logger/watchdog.cpp
+++ b/src/modules/logger/watchdog.cpp
@@ -1,0 +1,168 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "watchdog.h"
+
+#include <px4_log.h>
+
+using namespace time_literals;
+
+namespace px4
+{
+namespace logger
+{
+
+bool watchdog_update(watchdog_data_t &watchdog_data)
+{
+
+#ifdef __PX4_NUTTX
+
+	if (system_load.initialized && watchdog_data.logger_main_task_index >= 0
+	    && watchdog_data.logger_writer_task_index >= 0) {
+		const hrt_abstime now = hrt_absolute_time();
+		const system_load_taskinfo_s &log_writer_task = system_load.tasks[watchdog_data.logger_writer_task_index];
+
+		if (log_writer_task.valid) {
+			// Trigger the watchdog if the log writer task has been ready to run for a
+			// minimum duration and it has not been scheduled during that time.
+			// When the writer is waiting for an SD transfer, it is not in ready state, thus a long dropout
+			// will not trigger it. The longest period in ready state I measured was around 70ms,
+			// after a param change.
+			// We only check the log writer because it runs at lower priority than the main thread.
+			// No need to lock the tcb access, since we are in IRQ context
+
+			// update the timestamp if it has been scheduled recently
+			if (log_writer_task.curr_start_time > watchdog_data.ready_to_run_timestamp) {
+				watchdog_data.ready_to_run_timestamp = log_writer_task.curr_start_time;
+			}
+
+			// update the timestamp if not ready to run or if transitioned into ready to run
+			uint8_t current_state = log_writer_task.tcb->task_state;
+
+			if (current_state != TSTATE_TASK_READYTORUN
+			    || (watchdog_data.last_state != TSTATE_TASK_READYTORUN && current_state == TSTATE_TASK_READYTORUN)) {
+				watchdog_data.ready_to_run_timestamp = now;
+			}
+
+			watchdog_data.last_state = current_state;
+
+#if 0 // for debugging
+			// test code that prints the maximum time in ready state
+			static uint64_t max_time = 0;
+
+			if (now - watchdog_data.ready_to_run_timestamp > max_time) {
+				max_time = now - watchdog_data.ready_to_run_timestamp;
+			}
+
+			static int counter = 0;
+
+			if (++counter > 300) {
+				PX4_ERR("max time in ready: %i ms", (int)max_time / 1000);
+				counter = 0;
+				max_time = 0;
+			}
+
+#endif
+
+			if (now - watchdog_data.ready_to_run_timestamp > 1_s) {
+				PX4_ERR("watchdog triggered!"); // this will most likely not be logged due to dropouts
+
+				// boost the priority to make sure the logger continues to write to the log
+				sched_param param{};
+				param.sched_priority = SCHED_PRIORITY_MAX;
+				int ret;
+
+				if (system_load.tasks[watchdog_data.logger_main_task_index].valid) {
+					ret = sched_setparam(system_load.tasks[watchdog_data.logger_main_task_index].tcb->pid, &param);
+
+					if (ret < 0) {
+						PX4_ERR("sched_reprioritize failed (%i)", ret);
+					}
+				}
+
+				ret = sched_setparam(log_writer_task.tcb->pid, &param);
+
+				if (ret < 0) {
+					PX4_ERR("sched_reprioritize failed (%i)", ret);
+				}
+
+				// make sure we won't trigger again
+				watchdog_data.logger_main_task_index = -1;
+				return true;
+			}
+
+		} else {
+			// should never happen
+			watchdog_data.logger_main_task_index = -1;
+		}
+	}
+
+#endif /* __PX4_NUTTX */
+
+	return false;
+
+}
+
+void watchdog_initialize(const pid_t pid_logger_main, const pid_t pid_logger_writer, watchdog_data_t &watchdog_data)
+{
+#ifdef __PX4_NUTTX
+
+	sched_lock(); // need to lock the tcb access
+
+	for (int i = 0; i < CONFIG_MAX_TASKS; i++) {
+		if (system_load.tasks[i].valid) {
+			if (system_load.tasks[i].tcb->pid == pid_logger_writer) {
+				watchdog_data.logger_writer_task_index = i;
+			}
+
+			if (system_load.tasks[i].tcb->pid == pid_logger_main) {
+				watchdog_data.logger_main_task_index = i;
+			}
+		}
+	}
+
+	sched_unlock();
+
+	if (watchdog_data.logger_writer_task_index == -1 ||
+	    watchdog_data.logger_main_task_index == -1) {
+		// If we land here it means the NuttX implementation changed
+		// and one of our assumptions is not valid anymore
+		PX4_ERR("watchdog init failed");
+	}
+
+#endif /* __PX4_NUTTX */
+}
+
+
+} // namespace logger
+} // namespace px4

--- a/src/modules/logger/watchdog.h
+++ b/src/modules/logger/watchdog.h
@@ -1,0 +1,78 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <drivers/drv_hrt.h>
+
+#ifdef __PX4_NUTTX
+#include <sched.h>
+#include <systemlib/cpuload.h>
+#endif /* __PX4_NUTTX */
+
+namespace px4
+{
+namespace logger
+{
+
+struct watchdog_data_t {
+#ifdef __PX4_NUTTX
+	int logger_main_task_index = -1;
+	int logger_writer_task_index = -1;
+	hrt_abstime ready_to_run_timestamp = hrt_absolute_time();
+	uint8_t last_state = TSTATE_TASK_INVALID;
+#endif /* __PX4_NUTTX */
+};
+
+
+/**
+ * Initialize the watchdog, fill in watchdog_data.
+ */
+void watchdog_initialize(const pid_t pid_logger_main, const pid_t pid_logger_writer, watchdog_data_t &watchdog_data);
+
+/**
+ * Update the watchdog and trigger it if necessary. It is triggered when the log writer task is in
+ * ready state for a certain period of time, but did not get scheduled. It means that most likely
+ * some other higher-prio task runs busy.
+ * When the watchdog triggers, it boosts the priority of the logger's main & writer tasks to maximum, so
+ * that they get scheduled again.
+ *
+ * Expected to be called from IRQ context.
+ *
+ * @param watchdog_data
+ * @return true if watchdog is triggered, false otherwise
+ */
+bool watchdog_update(watchdog_data_t &watchdog_data);
+
+} //namespace logger
+} //namespace px4

--- a/src/modules/systemlib/cpuload.c
+++ b/src/modules/systemlib/cpuload.c
@@ -167,7 +167,11 @@ void sched_note_resume(FAR struct tcb_s *tcb)
 
 		for (int i = 0; i < CONFIG_MAX_TASKS; i++) {
 			if (system_load.tasks[i].valid && system_load.tasks[i].tcb->pid == tcb->pid) {
+				// curr_start_time is accessed from an IRQ handler (in logger), so we need
+				// to make the update atomic
+				irqstate_t irq_state = px4_enter_critical_section();
 				system_load.tasks[i].curr_start_time = new_time;
+				px4_leave_critical_section(irq_state);
 				break;
 			}
 		}

--- a/src/systemcmds/top/CMakeLists.txt
+++ b/src/systemcmds/top/CMakeLists.txt
@@ -34,6 +34,7 @@ px4_add_module(
 	MODULE systemcmds__top
 	MAIN top
 	STACK_MAIN 1700
+	PRIORITY 255
 	COMPILE_FLAGS
 	SRCS
 		top.c


### PR DESCRIPTION
In case a task with higher prio than the log file writer starts to busy-loop, the log just stops. And since the writer runs at very low prio, most tasks can cause it.
So this PR adds a watchdog that checks from a timer interrupt if the log writer task has been in ready state but has not been scheduled over the last second. This means that someone else is hogging the CPU and we boost the priority of the logger and writer to maximum.
In case the wachdog triggers, logger will also log the CPU load of all running tasks.

The watchdog timeout is fairly low at 1 second. It will only give a false positive if there is a long-running computation of another task without interruption (which we should avoid anyway). But even if it triggers, the system will continue to work fine.

### Testing
- tested by letting navigator busy-loop after 30 seconds after bootup. Log: https://logs.px4.io/plot_app?log=1b38110f-04e2-4f95-a344-b512b2a3de38
- tested on a slow SD card, with high logging rate active: when the writer waits for an SD transfer, it is not in ready state (thus a long logging dropout will not trigger it)
- tested with running logger and the writer at max prio with HIL: the vehicle still flies well.

This might help with debugging https://github.com/PX4/Firmware/issues/9271, since the log stops in-air. There might be different causes for the different reports, and in some cases a busy-looping task could be the cause.

Careful review required.