### PR TITLE
Structure Scan - Gimbal Orientation

### DIFF
--- a/src/drivers/vmount/input_mavlink.cpp
+++ b/src/drivers/vmount/input_mavlink.cpp
@@ -163,9 +163,9 @@ void InputMavlinkROI::_read_control_data_from_position_setpoint_sub()
 {
 	position_setpoint_triplet_s position_setpoint_triplet;
 	orb_copy(ORB_ID(position_setpoint_triplet), _position_setpoint_triplet_sub, &position_setpoint_triplet);
-	_control_data.type_data.lonlat.lon = position_setpoint_triplet.next.lon;
-	_control_data.type_data.lonlat.lat = position_setpoint_triplet.next.lat;
-	_control_data.type_data.lonlat.altitude = position_setpoint_triplet.next.alt;
+	_control_data.type_data.lonlat.lon = position_setpoint_triplet.current.lon;
+	_control_data.type_data.lonlat.lat = position_setpoint_triplet.current.lat;
+	_control_data.type_data.lonlat.altitude = position_setpoint_triplet.current.alt;
 }
 
 void InputMavlinkROI::print_status()


### PR DESCRIPTION
I have tested the Structure Scan feature and the gimbal doesn't point perpendicularly to the heading.
The gimbal points to the next triplet with an offset of 90deg which is not the area of interest.
![qgc](https://user-images.githubusercontent.com/15078736/39580751-29faafc2-4eea-11e8-812f-d9b373b456f3.png)

In order to have the gimbal pointing towards the structure when `MIS_MNT_YAW_CTL =1`, the gimbal has to point to the current triplet with an offset of 90deg. 