### PR TITLE
Add baro temperature to sensor voter observation

### DIFF
--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -831,7 +831,7 @@ void VotedSensorsUpdate::baro_poll(vehicle_air_data_s &airdata)
 			_baro_device_id[uorb_index] = baro_report.device_id;
 
 			got_update = true;
-			matrix::Vector3f vect(baro_report.pressure, 0.f, 0.f);
+			matrix::Vector3f vect(baro_report.pressure, baro_report.temperature, 0.f);
 
 			_last_airdata[uorb_index].timestamp = baro_report.timestamp;
 			_last_airdata[uorb_index].baro_temp_celcius = baro_report.temperature;


### PR DESCRIPTION
For our baro sensor (no driver in px4 master), I keep getting STALE errors every few seconds since a recent merge of master.

```
ERROR [sensors] Baro #0 fail:  STALE!
ERROR [sensors] Baro #0 fail:  STALE!
ERROR [sensors] Baro #0 fail:  STALE!
```

The errors appear while the vehicle is steady on a table indoors. Apparently the pressure reading from the baro can stay at a specific value for roughly a second under these conditions. As soon as `> 100` ([source in ecl](https://github.com/PX4/ecl/blob/372f9f430bb0edb901b3265ecd0cddf8ee4d1ffb/validation/data_validator.h#L194)) samples have the same value, the error above is triggered and the sensor flagged as stale.

A recent PR (https://github.com/PX4/Firmware/pull/8466) modified the way baro measurements are published. Instead of the derived altitude, the message now only contains the pressure, which makes sense. Before that change however, the altitude was compared in the sensor voter and not the pressure. The altitude computation might have introduced some numerical magic that caused the measurement to be a bit more noisy - numerically speaking.  :confused: 

My idea is to also add the baro temperature to the voter. But I am not sure if that's intelligent. What if the baro reading actually does become stale, but the temperature reading does not? I don't have enough experience to know what failure scenario the stale check is trying to detect.

@dagar any input? :)


-----
Altitude example output:
```
altitude: 385.899048
altitude: 385.928375
altitude: 385.925751
altitude: 385.905731
altitude: 385.928894
altitude: 385.860107
altitude: 385.890503
altitude: 385.889740
altitude: 385.891541
altitude: 385.921204
altitude: 385.923889
altitude: 385.912598
altitude: 385.855103
altitude: 385.878265
altitude: 385.876770
altitude: 385.860931
altitude: 385.864838
altitude: 385.873047
altitude: 385.919250
altitude: 385.925293
altitude: 385.914398
altitude: 385.921326
altitude: 385.915283
altitude: 385.914581
altitude: 385.871460
altitude: 385.921387
altitude: 385.937500
altitude: 385.935303
altitude: 385.879333
altitude: 385.919769
altitude: 385.878693
altitude: 385.882874
altitude: 385.887695
```

Pressure example output of same sensor, different px4 version:
```
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.789978  <- fluctuation
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.809998
pressure: 967.799988
pressure: 967.789978  <- fluctuation
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988
pressure: 967.799988

```
