### PR TITLE
Avionics power check type error (int to float)

### DIFF
--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -490,7 +490,7 @@ static bool powerCheck(orb_advert_t *mavlink_log_pub, bool report_fail, bool pre
 			if (hrt_elapsed_time(&system_power.timestamp) < 200000) {
 
 				/* copy avionics voltage */
-				int avionics_power_rail_voltage = system_power.voltage5V_v;
+				float avionics_power_rail_voltage = system_power.voltage5V_v;
 
 				// avionics rail
 				// Check avionics rail voltages


### PR DESCRIPTION
After a refactor inn #9193 a type error was introduced. This was truncating 4.95v down to 4.00v.