### PR TITLE
Jenkins tests code coverage build + SIGSEGV handler

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -309,6 +309,12 @@ pipeline {
             }
             sh 'make distclean'
           }
+          post {
+            failure {
+              sh('find . -name core')
+              sh('gdb --batch --quiet -ex "thread apply all bt full" -ex "quit" build/posix_sitl_default/px4 core')
+            }
+          }
         }
 
         stage('check stack') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -292,6 +292,25 @@ pipeline {
           }
         }
 
+        stage('tests (code coverage)') {
+          agent {
+            docker {
+              image 'px4io/px4-dev-ros:2018-03-30'
+              args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
+            }
+          }
+          steps {
+            sh 'export'
+            sh 'make distclean'
+            sh 'ulimit -c unlimited; make tests_coverage'
+            sh 'ls'
+            withCredentials([string(credentialsId: 'FIRMWARE_CODECOV_TOKEN', variable: 'CODECOV_TOKEN')]) {
+              sh 'curl -s https://codecov.io/bash | bash -s'
+            }
+            sh 'make distclean'
+          }
+        }
+
         stage('check stack') {
           agent {
             docker {

--- a/Makefile
+++ b/Makefile
@@ -288,11 +288,6 @@ tests:
 
 tests_coverage:
 	@$(MAKE) clean
-	@$(MAKE) --no-print-directory posix_sitl_default PX4_CMAKE_BUILD_TYPE=Coverage
-	@$(MAKE) --no-print-directory posix_sitl_default sitl_gazebo PX4_CMAKE_BUILD_TYPE=Coverage
-	@$(SRC_DIR)/test/rostest_px4_run.sh mavros_posix_tests_missions.test
-	@$(SRC_DIR)/test/rostest_px4_run.sh mavros_posix_tests_offboard_attctl.test
-	@$(SRC_DIR)/test/rostest_px4_run.sh mavros_posix_tests_offboard_posctl.test
 	@$(MAKE) --no-print-directory posix_sitl_default test_coverage_genhtml PX4_CMAKE_BUILD_TYPE=Coverage
 	@echo "Open $(SRC_DIR)/build/posix_sitl_default/coverage-html/index.html to see coverage"
 


### PR DESCRIPTION
Tests are currently segfaulting when compiled with code coverage options. Opening this PR as a reminder to add a segfault handler, dump and save cores, print the backtrace, etc.