### PR TITLE
Fix mavlink module not transmitting commands from vehicle_command topic

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1333,13 +1333,15 @@ void Mavlink::send_protocol_version()
 
 MavlinkOrbSubscription *Mavlink::add_orb_subscription(const orb_id_t topic, int instance)
 {
-	/* check if already subscribed to this topic */
-	MavlinkOrbSubscription *sub;
+	if (topic != ORB_ID(vehicle_command)) {
+		/* check if already subscribed to this topic */
+		MavlinkOrbSubscription *sub;
 
-	LL_FOREACH(_subscriptions, sub) {
-		if (sub->get_topic() == topic && sub->get_instance() == instance) {
-			/* already subscribed */
-			return sub;
+		LL_FOREACH(_subscriptions, sub) {
+			if (sub->get_topic() == topic && sub->get_instance() == instance) {
+				/* already subscribed */
+				return sub;
+			}
 		}
 	}
 


### PR DESCRIPTION
The idea of [`MavlinkStreamCommandLong`](https://github.com/PX4/Firmware/blob/5de5d6ea49e25ab846e82e7b8cf60c3e70e38dcd/src/modules/mavlink/mavlink_messages.cpp#L433) is to listen to `vehicle_command` topic and retransmit messages with external target system IDs. Actually, this doesn’t work – most of the published messages are skipped.

To debug it, [`_debug_enabled`](https://github.com/PX4/Firmware/blob/5de5d6ea49e25ab846e82e7b8cf60c3e70e38dcd/src/modules/mavlink/mavlink_command_sender.h#L116) can be set to `true` in `mavlink_commander_sender.h`.

Then, if we run code, that puts messages to `vehicle_command` like this:

```cpp
vehicle_command_s cmd = {};

cmd.command = 123;
cmd.param1 = 456;
cmd.param2 = 123;
cmd.param3 = 456;
cmd.target_system = 8; // random target system
cmd.target_component = 0;
cmd.source_system = 1; // our id

orb_advert_t cmd_pub = orb_advertise_queue(ORB_ID(vehicle_command), &cmd, 5);

while(true) {
    // publish a message once a second
    usleep(1000000);
    cmd.timestamp = hrt_absolute_time();
    orb_publish(ORB_ID(vehicle_command), cmd_pub, &cmd);
}
```

We should see sending attempts `cmd sender new command: 123 (channel: 0)` for each message, but this is not happening. We see sending attempts very rarely (once per 10–20 seconds), so most of the message are skipped.

The cause of that is the [`add_orb_subscription`](https://github.com/PX4/Firmware/blob/5de5d6ea49e25ab846e82e7b8cf60c3e70e38dcd/src/modules/mavlink/mavlink_main.cpp#L1334) method: it returns **the same** subscriber for different consumers in `mavlink` module. This is acceptable for continuous data topics, but not for topics, like `vehicle_command`, where no messages should be skipped.

There is [another](https://github.com/PX4/Firmware/blob/5de5d6ea49e25ab846e82e7b8cf60c3e70e38dcd/src/modules/mavlink/mavlink_main.cpp#L1961)`vehicle_command` consumer in `mavlink` module, and it "eats" most of the messages (calling `orb_check`).

Moreover, a mission [should send](https://github.com/PX4/Firmware/blob/5de5d6ea49e25ab846e82e7b8cf60c3e70e38dcd/src/modules/navigator/mission.cpp#L158)`VEHICLE_CMD_DO_TRIGGER_CONTROL` on activation and on inactivation. This doesn't work as well for the same cause.

Proposed solution is to make `add_orb_subscription` force creating a new subscriber on some defined topics (`vehicle_command` only for now).

As an alternative, something like `force_new` argument can be added to `add_orb_subscription` method, so the consumer code can define, if it wants to force creating a new subscriber.

