### PR TITLE
Optical Flow Use Improvements

### DIFF
--- a/msg/estimator_status.msg
+++ b/msg/estimator_status.msg
@@ -13,38 +13,40 @@ float32[24] covariances	# Diagonal Elements of Covariance Matrix
 
 uint16 gps_check_fail_flags     # Bitmask to indicate status of GPS checks - see definition below
 # bits are true when corresponding test has failed
-uint16 GPS_CHECK_FAIL_GPS_FIX = 0				# 0 : insufficient fix type (no 3D solution)
-uint16 GPS_CHECK_FAIL_MIN_SAT_COUNT = 1			# 1 : minimum required sat count fail
-uint16 GPS_CHECK_FAIL_MIN_GDOP = 2				# 2 : minimum required GDoP fail
-uint16 GPS_CHECK_FAIL_MAX_HORZ_ERR = 3			# 3 : maximum allowed horizontal position error fail
-uint16 GPS_CHECK_FAIL_MAX_VERT_ERR = 4			# 4 : maximum allowed vertical position error fail
-uint16 GPS_CHECK_FAIL_MAX_SPD_ERR = 5			# 5 : maximum allowed speed error fail
-uint16 GPS_CHECK_FAIL_MAX_HORZ_DRIFT = 6		# 6 : maximum allowed horizontal position drift fail - requires stationary vehicle
-uint16 GPS_CHECK_FAIL_MAX_VERT_DRIFT = 7		# 7 : maximum allowed vertical position drift fail - requires stationary vehicle
-uint16 GPS_CHECK_FAIL_MAX_HORZ_SPD_ERR = 8		# 8 : maximum allowed horizontal speed fail - requires stationary vehicle
-uint16 GPS_CHECK_FAIL_MAX_VERT_SPD_ERR = 9		# 9 : maximum allowed vertical velocity discrepancy fail
+uint8 GPS_CHECK_FAIL_GPS_FIX = 0		# 0 : insufficient fix type (no 3D solution)
+uint8 GPS_CHECK_FAIL_MIN_SAT_COUNT = 1		# 1 : minimum required sat count fail
+uint8 GPS_CHECK_FAIL_MIN_GDOP = 2		# 2 : minimum required GDoP fail
+uint8 GPS_CHECK_FAIL_MAX_HORZ_ERR = 3		# 3 : maximum allowed horizontal position error fail
+uint8 GPS_CHECK_FAIL_MAX_VERT_ERR = 4		# 4 : maximum allowed vertical position error fail
+uint8 GPS_CHECK_FAIL_MAX_SPD_ERR = 5		# 5 : maximum allowed speed error fail
+uint8 GPS_CHECK_FAIL_MAX_HORZ_DRIFT = 6		# 6 : maximum allowed horizontal position drift fail - requires stationary vehicle
+uint8 GPS_CHECK_FAIL_MAX_VERT_DRIFT = 7		# 7 : maximum allowed vertical position drift fail - requires stationary vehicle
+uint8 GPS_CHECK_FAIL_MAX_HORZ_SPD_ERR = 8	# 8 : maximum allowed horizontal speed fail - requires stationary vehicle
+uint8 GPS_CHECK_FAIL_MAX_VERT_SPD_ERR = 9	# 9 : maximum allowed vertical velocity discrepancy fail
 
 uint32 control_mode_flags	# Bitmask to indicate EKF logic state
-# 0 - true if the filter tilt alignment is complete
-# 1 - true if the filter yaw alignment is complete
-# 2 - true if GPS measurements are being fused
-# 3 - true if optical flow measurements are being fused
-# 4 - true if a simple magnetic yaw heading is being fused
-# 5 - true if 3-axis magnetometer measurement are being fused
-# 6 - true if synthetic magnetic declination measurements are being fused
-# 7 - true when the vehicle is airborne
-# 8 - true when wind velocity is being estimated
-# 9 - true when baro height is being fused as a primary height reference
-# 10 - true when range finder height is being fused as a primary height reference
-# 11 - true when GPS height is being fused as a primary height reference
-# 12 - true when local position data from external vision is being fused
-# 13 - true when yaw data from external vision measurements is being fused
-# 14 - true when height data from external vision measurements is being fused
-# 15 - true when synthetic sideslip measurements are being fused
-# 16 - true when only the magnetic field states are updated by the magnetometer
-# 17 - true when the vehicle is operating as a fixed wing vehicle
-# 18 - true when the magnetomer has been declared faulty and is no longer being used
-# 19 - true when airspeed measurements are being fused
+uint8 CS_TILT_ALIGN = 0		# 0 - true if the filter tilt alignment is complete
+uint8 CS_YAW_ALIGN = 1		# 1 - true if the filter yaw alignment is complete
+uint8 CS_GPS = 2		# 2 - true if GPS measurements are being fused
+uint8 CS_OPT_FLOW = 3		# 3 - true if optical flow measurements are being fused
+uint8 CS_MAG_HDG = 4		# 4 - true if a simple magnetic yaw heading is being fused
+uint8 CS_MAG_3D = 5		# 5 - true if 3-axis magnetometer measurement are being fused
+uint8 CS_MAG_DEC = 6		# 6 - true if synthetic magnetic declination measurements are being fused
+uint8 CS_IN_AIR = 7		# 7 - true when thought to be airborne
+uint8 CS_WIND = 8		# 8 - true when wind velocity is being estimated
+uint8 CS_BARO_HGT = 9		# 9 - true when baro height is being fused as a primary height reference
+uint8 CS_RNG_HGT = 10		# 10 - true when range finder height is being fused as a primary height reference
+uint8 CS_GPS_HGT = 11		# 11 - true when GPS height is being fused as a primary height reference
+uint8 CS_EV_POS = 12		# 12 - true when local position data from external vision is being fused
+uint8 CS_EV_YAW = 13		# 13 - true when yaw data from external vision measurements is being fused
+uint8 CS_EV_HGT = 14		# 14 - true when height data from external vision measurements is being fused
+uint8 CS_BETA = 15		# 15 - true when synthetic sideslip measurements are being fused
+uint8 CS_MAG_FIELD = 16		# 16 - true when only the magnetic field states are updated by the magnetometer
+uint8 CS_FIXED_WING = 17	# 17 - true when thought to be operating as a fixed wing vehicle with constrained sideslip
+uint8 CS_MAG_FAULT = 18		# 18 - true when the magnetomer has been declared faulty and is no longer being used
+uint8 CS_ASPD = 19		# 19 - true when airspeed measurements are being fused
+uint8 CS_GND_EFFECT = 20	# 20 - true when when protection from ground effect induced static pressure rise is active
+uint8 CS_RNG_STUCK = 21		# 21 - true when a stuck range finder sensor has been detected
 
 uint16 filter_fault_flags	# Bitmask to indicate EKF internal faults
 # 0 - true if the fusion of the magnetometer X-axis has encountered a numerical error

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -185,6 +185,8 @@ static bool _last_condition_global_position_valid = false;
 
 static struct vehicle_land_detected_s land_detector = {};
 
+static float _eph_threshold_adj = INFINITY;	///< maximum allowable horizontal position uncertainty after adjustment for flight condition
+
 /**
  * The daemon app only briefly exists to start
  * the background job. The stack size assigned in the
@@ -1737,6 +1739,19 @@ Commander::run()
 		_local_position_sub.update();
 		_global_position_sub.update();
 
+		// Set the allowable positon uncertainty based on combination of flight and estimator state
+		// When we are in a operator demanded position control mode and are solely reliant on optical flow, do not check position error becasue it will gradually increase throughout flight and the operator will compensate for the drift
+		bool reliant_on_opt_flow = ((estimator_status.control_mode_flags & (1 << estimator_status_s::CS_OPT_FLOW))
+					    && !(estimator_status.control_mode_flags & (1 << estimator_status_s::CS_GPS))
+					    && !(estimator_status.control_mode_flags & (1 << estimator_status_s::CS_EV_POS)));
+		bool operator_controlled_position = (internal_state.main_state == commander_state_s::MAIN_STATE_POSCTL);
+		bool skip_pos_accuracy_check = reliant_on_opt_flow && operator_controlled_position;
+		if (skip_pos_accuracy_check) {
+			_eph_threshold_adj = INFINITY;
+		} else {
+			_eph_threshold_adj = _eph_threshold.get();
+		}
+
 		// Check if quality checking of position accuracy and consistency is to be performed
 		const bool run_quality_checks = !status_flags.circuit_breaker_engaged_posfailure_check;
 
@@ -1804,11 +1819,11 @@ Commander::run()
 			} else {
 				// use global position message to determine validity
 				const vehicle_global_position_s&global_position = _global_position_sub.get();
-				check_posvel_validity(true, global_position.eph, _eph_threshold.get(), global_position.timestamp, &_last_gpos_fail_time_us, &_gpos_probation_time_us, &status_flags.condition_global_position_valid, &status_changed);
+				check_posvel_validity(true, global_position.eph, _eph_threshold_adj, global_position.timestamp, &_last_gpos_fail_time_us, &_gpos_probation_time_us, &status_flags.condition_global_position_valid, &status_changed);
 
 				// use local position message to determine validity
 				const vehicle_local_position_s &local_position = _local_position_sub.get();
-				check_posvel_validity(local_position.xy_valid, local_position.eph, _eph_threshold.get(), local_position.timestamp, &_last_lpos_fail_time_us, &_lpos_probation_time_us, &status_flags.condition_local_position_valid, &status_changed);
+				check_posvel_validity(local_position.xy_valid, local_position.eph, _eph_threshold_adj, local_position.timestamp, &_last_lpos_fail_time_us, &_lpos_probation_time_us, &status_flags.condition_local_position_valid, &status_changed);
 				check_posvel_validity(local_position.v_xy_valid, local_position.evh, _evh_threshold.get(), local_position.timestamp, &_last_lvel_fail_time_us, &_lvel_probation_time_us, &status_flags.condition_local_velocity_valid, &status_changed);
 			}
 		}
@@ -3331,8 +3346,8 @@ Commander::reset_posvel_validity(bool *changed)
 	const vehicle_global_position_s &global_position = _global_position_sub.get();
 
 	// recheck validity
-	check_posvel_validity(true, global_position.eph, _eph_threshold.get(), global_position.timestamp, &_last_gpos_fail_time_us, &_gpos_probation_time_us, &status_flags.condition_global_position_valid, changed);
-	check_posvel_validity(local_position.xy_valid, local_position.eph, _eph_threshold.get(), local_position.timestamp, &_last_lpos_fail_time_us, &_lpos_probation_time_us, &status_flags.condition_local_position_valid, changed);
+	check_posvel_validity(true, global_position.eph, _eph_threshold_adj, global_position.timestamp, &_last_gpos_fail_time_us, &_gpos_probation_time_us, &status_flags.condition_global_position_valid, changed);
+	check_posvel_validity(local_position.xy_valid, local_position.eph, _eph_threshold_adj, local_position.timestamp, &_last_lpos_fail_time_us, &_lpos_probation_time_us, &status_flags.condition_local_position_valid, changed);
 	check_posvel_validity(local_position.v_xy_valid, local_position.evh, _evh_threshold.get(), local_position.timestamp, &_last_lvel_fail_time_us, &_lvel_probation_time_us, &status_flags.condition_local_velocity_valid, changed);
 }
 

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -186,6 +186,7 @@ static bool _last_condition_global_position_valid = false;
 static struct vehicle_land_detected_s land_detector = {};
 
 static float _eph_threshold_adj = INFINITY;	///< maximum allowable horizontal position uncertainty after adjustment for flight condition
+static bool _skip_pos_accuracy_check = false;
 
 /**
  * The daemon app only briefly exists to start
@@ -1745,8 +1746,8 @@ Commander::run()
 					    && !(estimator_status.control_mode_flags & (1 << estimator_status_s::CS_GPS))
 					    && !(estimator_status.control_mode_flags & (1 << estimator_status_s::CS_EV_POS)));
 		bool operator_controlled_position = (internal_state.main_state == commander_state_s::MAIN_STATE_POSCTL);
-		bool skip_pos_accuracy_check = reliant_on_opt_flow && operator_controlled_position;
-		if (skip_pos_accuracy_check) {
+		_skip_pos_accuracy_check = reliant_on_opt_flow && operator_controlled_position;
+		if (_skip_pos_accuracy_check) {
 			_eph_threshold_adj = INFINITY;
 		} else {
 			_eph_threshold_adj = _eph_threshold.get();
@@ -1817,9 +1818,11 @@ Commander::run()
 				status_flags.condition_local_velocity_valid = false;
 
 			} else {
-				// use global position message to determine validity
-				const vehicle_global_position_s&global_position = _global_position_sub.get();
-				check_posvel_validity(true, global_position.eph, _eph_threshold_adj, global_position.timestamp, &_last_gpos_fail_time_us, &_gpos_probation_time_us, &status_flags.condition_global_position_valid, &status_changed);
+				if (!_skip_pos_accuracy_check) {
+					// use global position message to determine validity
+					const vehicle_global_position_s&global_position = _global_position_sub.get();
+					check_posvel_validity(true, global_position.eph, _eph_threshold_adj, global_position.timestamp, &_last_gpos_fail_time_us, &_gpos_probation_time_us, &status_flags.condition_global_position_valid, &status_changed);
+				}
 
 				// use local position message to determine validity
 				const vehicle_local_position_s &local_position = _local_position_sub.get();
@@ -3346,7 +3349,9 @@ Commander::reset_posvel_validity(bool *changed)
 	const vehicle_global_position_s &global_position = _global_position_sub.get();
 
 	// recheck validity
-	check_posvel_validity(true, global_position.eph, _eph_threshold_adj, global_position.timestamp, &_last_gpos_fail_time_us, &_gpos_probation_time_us, &status_flags.condition_global_position_valid, changed);
+	if (!_skip_pos_accuracy_check) {
+		check_posvel_validity(true, global_position.eph, _eph_threshold_adj, global_position.timestamp, &_last_gpos_fail_time_us, &_gpos_probation_time_us, &status_flags.condition_global_position_valid, changed);
+	}
 	check_posvel_validity(local_position.xy_valid, local_position.eph, _eph_threshold_adj, local_position.timestamp, &_last_lpos_fail_time_us, &_lpos_probation_time_us, &status_flags.condition_local_position_valid, changed);
 	check_posvel_validity(local_position.v_xy_valid, local_position.evh, _evh_threshold.get(), local_position.timestamp, &_last_lvel_fail_time_us, &_lvel_probation_time_us, &status_flags.condition_local_velocity_valid, changed);
 }

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1079,7 +1079,12 @@ PARAM_DEFINE_FLOAT(EKF2_MAGB_K, 0.2f);
  *
  * If this parameter is enabled then the estimator will make use of the range finder measurements
  * to estimate it's height even if range sensor is not the primary height source. It will only do so if conditions
- * for range measurement fusion are met.
+ * for range measurement fusion are met. This enables the range finder to be used during low speed and low altitude
+ * operation. Speed and height criteria are controlled by EKF2_RNG_A_VMAX and EKF2_RNG_A_HMAX.
+ * It should not be used for terrain following. It is intended to be used where a vertical takeoff and landing
+ * is performed, and horizontal flight does not occur until above EKF2_RNG_A_HMAX. If vehicle motion causes
+ * repeated switvhing between the rimary height sensor and range finder, an offset in the local position origin
+ * can accumulate. For terrain following, it is recommended to use the MPC_ALT_MODE parameter instead.
  *
  * @group EKF2
  * @value 0 Range aid disabled

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -853,14 +853,17 @@ MulticopterPositionControl::limit_altitude()
 {
 	float altitude_above_home = -(_pos(2) - _home_pos.z);
 	bool applying_flow_height_limit = false;
+
 	if (_terrain_follow && _local_pos.limit_hagl) {
 		// Don't allow the height setpoint to exceed the optical flow limits
 		if (_pos_sp(2) < -_flow_max_hgt.get()) {
 			_pos_sp(2) = -_flow_max_hgt.get();
 		}
+
 		applying_flow_height_limit = true;
 
-	} else if (_run_alt_control && (_vehicle_land_detected.alt_max > 0.0f) && (altitude_above_home > _vehicle_land_detected.alt_max)) {
+	} else if (_run_alt_control && (_vehicle_land_detected.alt_max > 0.0f)
+		   && (altitude_above_home > _vehicle_land_detected.alt_max)) {
 		// we are above maximum altitude
 		_pos_sp(2) = -_vehicle_land_detected.alt_max +  _home_pos.z;
 
@@ -876,10 +879,12 @@ MulticopterPositionControl::limit_altitude()
 		float pos_z_next = _pos(2) + _vel(2) * delta_t + 0.5f * _acceleration_z_max_down.get() * delta_t *delta_t;
 
 
-		if (!applying_flow_height_limit && (-(pos_z_next - _home_pos.z) > _vehicle_land_detected.alt_max) && (_vehicle_land_detected.alt_max > 0.0f)) {
+		if (!applying_flow_height_limit && (-(pos_z_next - _home_pos.z) > _vehicle_land_detected.alt_max)
+		    && (_vehicle_land_detected.alt_max > 0.0f)) {
 			// prevent the vehicle from exceeding maximum altitude by switching back to altitude control with maximum altitude as setpoint
 			_pos_sp(2) = -_vehicle_land_detected.alt_max + _home_pos.z;
 			_run_alt_control = true;
+
 		} else if (applying_flow_height_limit && (pos_z_next < -_flow_max_hgt.get())) {
 			// prevent the vehicle from exceeding maximum altitude by switching back to altitude control with maximum altitude as setpoint
 			_pos_sp(2) = -_flow_max_hgt.get();
@@ -2276,6 +2281,7 @@ MulticopterPositionControl::update_velocity_derivative()
 				_reset_alt_sp = true;
 				reset_alt_sp();
 			}
+
 			_pos(2) = -_local_pos.dist_bottom;
 
 		} else {
@@ -2284,6 +2290,7 @@ MulticopterPositionControl::update_velocity_derivative()
 				_reset_alt_sp = true;
 				reset_alt_sp();
 			}
+
 			_pos(2) = _local_pos.z;
 		}
 	}

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -448,6 +448,19 @@ PARAM_DEFINE_FLOAT(MPC_DEC_HOR_SLOW, 5.0f);
 PARAM_DEFINE_FLOAT(MPC_ACC_HOR_FLOW, 0.5f);
 
 /**
+ * Maximum height above ground when reliant on optical flow.
+ * The height setpoint will be limited to be no greater than this value when the navigation system is completely reliant on optical flow data.
+ *
+ * @unit m
+ * @min 1.0
+ * @max 25.0
+ * @increment 0.5
+ * @decimal 1
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_MAX_FLOW_HGT, 3.0f);
+
+/**
  * Maximum vertical acceleration in velocity controlled modes upward
  *
  * @unit m/s/s

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -449,7 +449,9 @@ PARAM_DEFINE_FLOAT(MPC_ACC_HOR_FLOW, 0.5f);
 
 /**
  * Maximum height above ground when reliant on optical flow.
- * The height setpoint will be limited to be no greater than this value when the navigation system is completely reliant on optical flow data.
+ * The height setpoint will be limited to be no greater than this value when the navigation system
+ * is completely reliant on optical flow data and the height above ground estimate is valid as indicated
+ * by the local_position.dist_bottom_valid message being true.
  *
  * @unit m
  * @min 1.0
@@ -514,7 +516,13 @@ PARAM_DEFINE_FLOAT(MPC_JERK_MAX, 0.0f);
 PARAM_DEFINE_FLOAT(MPC_JERK_MIN, 1.0f);
 
 /**
- * Altitude control mode, note mode 1 only tested with LPE
+ * Altitude control mode.
+ *
+ * Set to 1 to control height above ground instead of height above origin.
+ * Note: If optical flow is being used as the only source of navigation then the height above ground
+ * will be selected automatically and maximum height will be limited to the value set by MPC_MAX_FLOW_HGT.
+ * Note: The height controller will revert to using height above origin if the distance to ground estimate
+ * becomes invalid as indicated by the local_position.distance_bottom_valid message being false.
  *
  * @min 0
  * @max 1


### PR DESCRIPTION
For discussion/comment

**Addresses the following issues:**

When the estimator is using optical flow as the only aiding source, the uncertainty in the position relative to the starting point will increase over time. At some point this will cause the position validity check to fail. This is unnecessary if operating in POSCTRL because the operator will be correcting for the drift throughout the flight. This PR sets the required hpos accuracy to INFINITY when using only optical flow in POSCTL.

The only way to maintain a constant height independent of baro drift when using flow was to use the EKF2_RNG_AID parameter, however this was originally designed for a limited use case where the vehicle performed a vertical launch and recovery and clibed above the max range finder use height before moving horizontally. When used for general flying, repeated switching between range finder and baro could result in the reference height datum ratcheting up or down. This PR transfers the responsibility for terrain following when reliant on optical flow to the position controller

There was no maximum height limit applied when using flow, so the operator could fly the vehicle high enough to lose navigation.

Relates to https://github.com/PX4/Firmware/issues/9398

**TESTING**

TODO