### PR TITLE
[WIP] Mavlink: rotate attitude for tailsitter in FW mode

### DIFF
--- a/msg/telemetry_status.msg
+++ b/msg/telemetry_status.msg
@@ -5,9 +5,13 @@ uint8 TELEMETRY_STATUS_RADIO_TYPE_WIRE = 3
 uint8 TELEMETRY_STATUS_RADIO_TYPE_USB = 4
 uint8 TELEMETRY_STATUS_RADIO_TYPE_IRIDIUM = 5
 
+uint8 TELEMETRY_STATUS_REMOTE_TYPE_GCS = 4                  # MAV_TYPE_GCS
+uint8 TELEMETRY_STATUS_REMOTE_TYPE_ONBOARD_CONTROLLER = 18  # MAV_TYPE_ONBOARD_CONTROLLER
+
 uint64 heartbeat_time			# Time of last received heartbeat from remote system
 uint64 telem_time			# Time of last received telemetry status packet, 0 for none
 uint8 type				# type of the radio hardware
+uint8 remote_type		# type of the remote system (defined in MAVLink MAV_TYPE ENUM)
 uint8 rssi				# local signal strength
 uint8 remote_rssi			# remote signal strength
 uint16 rxerrors				# receive errors

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -53,6 +53,7 @@ uint8 component_id			# subsystem / component id, contains MAVLink's component ID
 
 bool is_rotary_wing			# True if system is in rotary wing configuration, so for a VTOL this is only true while flying as a multicopter
 bool is_vtol				# True if the system is VTOL capable
+bool is_vtol_tailsitter		# True if VTOL performs -90° downward pitch during transition from rotary wing to fixed wing configuration
 bool vtol_fw_permanent_stab		# True if VTOL should stabilize attitude for fw in manual mode
 bool in_transition_mode			# True if VTOL is doing a transition
 bool in_transition_to_fw		# True if VTOL is doing a transition from MC to FW

--- a/msg/vtol_vehicle_status.msg
+++ b/msg/vtol_vehicle_status.msg
@@ -10,3 +10,4 @@ bool vtol_in_trans_mode
 bool in_transition_to_fw		# True if VTOL is doing a transition from MC to FW
 bool vtol_transition_failsafe	# vtol in transition failsafe mode
 bool fw_permanent_stab			# In fw mode stabilize attitude even if in manual mode
+bool is_vtol_tailsitter         # True if VTOL pitches 90 degrees down to transition from rotary wing to fixed wing configuration

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -1702,6 +1702,7 @@ Commander::run()
 			/* vtol status changed */
 			orb_copy(ORB_ID(vtol_vehicle_status), vtol_vehicle_status_sub, &vtol_status);
 			status.vtol_fw_permanent_stab = vtol_status.fw_permanent_stab;
+			status.is_vtol_tailsitter = vtol_status.is_vtol_tailsitter;
 
 			/* Make sure that this is only adjusted if vehicle really is of type vtol */
 			if (is_vtol(&status)) {

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -4055,47 +4055,51 @@ void Commander::poll_telemetry_status()
 			telemetry_status_s telemetry = {};
 			orb_copy(ORB_ID(telemetry_status), _telemetry[i].subscriber, &telemetry);
 
-			/* perform system checks when new telemetry link connected */
-			if (/* we first connect a link or re-connect a link after loosing it or haven't yet reported anything */
-				(_telemetry[i].last_heartbeat == 0 || (hrt_elapsed_time(&_telemetry[i].last_heartbeat) > 3_s)
-				 || !_telemetry[i].preflight_checks_reported) &&
-				/* and this link has a communication partner */
-				(telemetry.heartbeat_time > 0) &&
-				/* and it is still connected */
-				(hrt_elapsed_time(&telemetry.heartbeat_time) < 2_s) &&
-				/* and the system is not already armed (and potentially flying) */
-				!armed.armed) {
+			/* this is a ground control station */
+			if (telemetry.remote_type == telemetry_status_s::TELEMETRY_STATUS_REMOTE_TYPE_GCS) {
 
-				/* flag the checks as reported for this link when we actually report them */
-				_telemetry[i].preflight_checks_reported = status_flags.condition_system_hotplug_timeout;
+				/* perform system checks when new telemetry link connected */
+				if (/* we first connect a link or re-connect a link after loosing it or haven't yet reported anything */
+					(_telemetry[i].last_heartbeat == 0 || (hrt_elapsed_time(&_telemetry[i].last_heartbeat) > 3_s)
+					|| !_telemetry[i].preflight_checks_reported) &&
+					/* and this link has a communication partner */
+					(telemetry.heartbeat_time > 0) &&
+					/* and it is still connected */
+					(hrt_elapsed_time(&telemetry.heartbeat_time) < 2_s) &&
+					/* and the system is not already armed (and potentially flying) */
+					!armed.armed) {
 
-				preflight_check(true);
+					/* flag the checks as reported for this link when we actually report them */
+					_telemetry[i].preflight_checks_reported = status_flags.condition_system_hotplug_timeout;
 
-				// Provide feedback on mission state
-				const mission_result_s &mission_result = _mission_result_sub.get();
+					preflight_check(true);
 
-				if ((mission_result.timestamp > commander_boot_timestamp) && status_flags.condition_system_hotplug_timeout &&
-				    (mission_result.instance_count > 0) && !mission_result.valid) {
+					// Provide feedback on mission state
+					const mission_result_s &mission_result = _mission_result_sub.get();
 
-					mavlink_log_critical(&mavlink_log_pub, "Planned mission fails check. Please upload again.");
+					if ((mission_result.timestamp > commander_boot_timestamp) && status_flags.condition_system_hotplug_timeout &&
+						(mission_result.instance_count > 0) && !mission_result.valid) {
+
+						mavlink_log_critical(&mavlink_log_pub, "Planned mission fails check. Please upload again.");
+					}
 				}
-			}
 
-			/* set (and don't reset) telemetry via USB as active once a MAVLink connection is up */
-			if (telemetry.type == telemetry_status_s::TELEMETRY_STATUS_RADIO_TYPE_USB) {
-				status_flags.usb_connected = true;
-			}
+				/* set (and don't reset) telemetry via USB as active once a MAVLink connection is up */
+				if (telemetry.type == telemetry_status_s::TELEMETRY_STATUS_RADIO_TYPE_USB) {
+					status_flags.usb_connected = true;
+				}
 
-			/* set latency type of the telemetry connection */
-			if (telemetry.type == telemetry_status_s::TELEMETRY_STATUS_RADIO_TYPE_IRIDIUM) {
-				_telemetry[i].high_latency = true;
+				/* set latency type of the telemetry connection */
+				if (telemetry.type == telemetry_status_s::TELEMETRY_STATUS_RADIO_TYPE_IRIDIUM) {
+					_telemetry[i].high_latency = true;
 
-			} else {
-				_telemetry[i].high_latency = false;
-			}
+				} else {
+					_telemetry[i].high_latency = false;
+				}
 
-			if (telemetry.heartbeat_time > 0 && (_telemetry[i].last_heartbeat < telemetry.heartbeat_time)) {
-				_telemetry[i].last_heartbeat = telemetry.heartbeat_time;
+				if (telemetry.heartbeat_time > 0 && (_telemetry[i].last_heartbeat < telemetry.heartbeat_time)) {
+					_telemetry[i].last_heartbeat = telemetry.heartbeat_time;
+				}
 			}
 		}
 	}

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2622,6 +2622,59 @@ Mavlink::display_status()
 			break;
 		}
 
+		printf("\tremote type:\t");
+
+		switch (_rstatus.remote_type) {
+		case MAV_TYPE_GENERIC:
+		case MAV_TYPE_FIXED_WING:
+		case MAV_TYPE_QUADROTOR:
+		case MAV_TYPE_COAXIAL:
+		case MAV_TYPE_HELICOPTER:
+		case MAV_TYPE_VTOL_DUOROTOR:
+		case MAV_TYPE_VTOL_QUADROTOR:
+		case MAV_TYPE_VTOL_TILTROTOR:
+		case MAV_TYPE_VTOL_RESERVED2:
+		case MAV_TYPE_VTOL_RESERVED3:
+		case MAV_TYPE_VTOL_RESERVED4:
+		case MAV_TYPE_VTOL_RESERVED5:
+		case MAV_TYPE_DODECAROTOR:
+		case MAV_TYPE_AIRSHIP:
+		case MAV_TYPE_HEXAROTOR:
+		case MAV_TYPE_OCTOROTOR:
+		case MAV_TYPE_TRICOPTER:
+		case MAV_TYPE_FLAPPING_WING:
+		case MAV_TYPE_KITE:
+		case MAV_TYPE_FREE_BALLOON:
+		case MAV_TYPE_PARAFOIL:
+		case MAV_TYPE_ROCKET:
+		case MAV_TYPE_GROUND_ROVER:
+		case MAV_TYPE_SURFACE_BOAT:
+		case MAV_TYPE_SUBMARINE:
+			printf("MICRO AIR VEHICLE\n");
+			break;
+
+		case MAV_TYPE_GCS:
+			printf("GROUND CONTROL STATION\n");
+			break;
+
+		case MAV_TYPE_ONBOARD_CONTROLLER:
+			printf("COMPANION COMPUTER\n");
+			break;
+
+		case MAV_TYPE_ANTENNA_TRACKER:
+		case MAV_TYPE_GIMBAL:
+		case MAV_TYPE_CAMERA:
+		case MAV_TYPE_CHARGING_STATION:
+		case MAV_TYPE_ADSB:
+		case MAV_TYPE_FLARM:
+		default:
+			printf("OTHER\n");
+			break;
+		}
+
+		printf("\tremote sysid:\t%i\n", _rstatus.system_id);
+		printf("\tremote compid:\t%i\n", _rstatus.component_id);
+
 	} else {
 		printf("\tno telem status.\n");
 	}

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -908,10 +908,18 @@ protected:
 			vehicle_status_s status = {};
 			_status_sub->update(&status);
 
+			telemetry_status_s telemetry_status = _mavlink->get_rx_status();
+
 			mavlink_attitude_t msg = {};
 			msg.time_boot_ms = att.timestamp / 1000;
 
-			if (!(status.is_vtol && status.is_vtol_tailsitter && !status.is_rotary_wing)) {
+			// Tailsitters in fixed wing mode require to report rotated attitude to GCS
+			bool do_tailsitter_attitude_rotation = (status.is_vtol                     // this system is a vtol
+								&& status.is_vtol_tailsitter                           // of tailsitter type
+								&& !status.is_rotary_wing                              // that is flying in fixed wing mode
+								&& (telemetry_status.remote_type == MAV_TYPE_GCS));    // and we are talking to a ground control station
+
+			if (!do_tailsitter_attitude_rotation) {
 				// Normal attitude
 				matrix::Eulerf euler = matrix::Quatf(att.q);
 				msg.roll = euler.phi();
@@ -999,10 +1007,18 @@ protected:
 			vehicle_status_s status = {};
 			_status_sub->update(&status);
 
+			telemetry_status_s telemetry_status = _mavlink->get_rx_status();
+
 			mavlink_attitude_quaternion_t msg = {};
 			msg.time_boot_ms = att.timestamp / 1000;
 
-			if (!(status.is_vtol && status.is_vtol_tailsitter && !status.is_rotary_wing)) {
+			// Tailsitters in fixed wing mode require to report rotated attitude to GCS
+			bool do_tailsitter_attitude_rotation = (status.is_vtol                     // this system is a vtol
+								&& status.is_vtol_tailsitter                           // of tailsitter type
+								&& !status.is_rotary_wing                              // that is flying in fixed wing mode
+								&& (telemetry_status.remote_type == MAV_TYPE_GCS));    // and we are talking to a ground control station
+
+			if (!do_tailsitter_attitude_rotation) {
 				// Normal attitude
 				msg.q1 = att.q[0];
 				msg.q2 = att.q[1];

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1354,8 +1354,7 @@ MavlinkReceiver::handle_message_radio_status(mavlink_message_t *msg)
 		tstatus.remote_noise = rstatus.remnoise;
 		tstatus.rxerrors = rstatus.rxerrors;
 		tstatus.fixed = rstatus.fixed;
-		tstatus.system_id = msg->sysid;
-		tstatus.component_id = msg->compid;
+		/* tstatus.system_id and tstatus.component_id are set by system heartbeats */
 
 		if (_telemetry_status_pub == nullptr) {
 			int multi_instance;
@@ -1699,6 +1698,12 @@ MavlinkReceiver::handle_message_heartbeat(mavlink_message_t *msg)
 			 */
 			tstatus.timestamp = hrt_absolute_time();
 			tstatus.heartbeat_time = tstatus.timestamp;
+
+			/* set remote system id, component id, and type
+			 */
+			tstatus.system_id = msg->sysid;
+			tstatus.component_id = msg->compid;
+			tstatus.remote_type = hb.type;
 
 			if (_telemetry_status_pub == nullptr) {
 				int multi_instance;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1688,8 +1688,8 @@ MavlinkReceiver::handle_message_heartbeat(mavlink_message_t *msg)
 		mavlink_heartbeat_t hb;
 		mavlink_msg_heartbeat_decode(msg, &hb);
 
-		/* ignore own heartbeats, accept only heartbeats from GCS */
-		if (msg->sysid != mavlink_system.sysid && hb.type == MAV_TYPE_GCS) {
+		/* ignore own heartbeats */
+		if (msg->sysid != mavlink_system.sysid) {
 
 			struct telemetry_status_s &tstatus = _mavlink->get_rx_status();
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -515,6 +515,9 @@ VtolAttitudeControl::parameters_update()
 		_params.fw_motors_off = 12345678;
 	}
 
+	// Report whether the VTOL is a tailsitter
+	_vtol_vehicle_status.is_vtol_tailsitter = (_params.vtol_type == vtol_type::TAILSITTER);
+
 	// make sure parameters are feasible, require at least 1 m/s difference between transition and blend airspeed
 	_params.airspeed_blend = math::min(_params.airspeed_blend, _params.transition_airspeed - 1.0f);
 


### PR DESCRIPTION
Attitude was incorrectly reported when a tailsitter flies in FW mode, see #5291 
With this PR, when a tailsitter has made a transition to fixed wing mode, the mavlink app rotates the attitude before sending the messages ATTITUDE and ATTITUDE_QUATERNION.

Before PR:
![screenshot from 2018-05-08 12-31-06](https://user-images.githubusercontent.com/1379463/39752568-24d0738a-52bc-11e8-8a8d-66aa180b424b.png)

After PR:
![screenshot from 2018-05-08 12-28-21](https://user-images.githubusercontent.com/1379463/39752577-28c3fef8-52bc-11e8-85bc-3ee9230d7e1c.png)

(edit: addressed in #9473) There is a discontinuity in the reported attitude at the end of the transition. It should be harmless for a GCS, but may be a problem for a companion computer. Is there a way to know if the mavlink instance is talking to a GCS?