### PR TITLE
Fix astyle Display Language Dependency & Makefile Colored Output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,11 +126,11 @@ define cmake-build
 +@(cd $(BUILD_DIR) && $(PX4_MAKE) $(PX4_MAKE_ARGS) $(ARGS))
 endef
 
-COLOR_BLUE = \033[0;34m
+COLOR_BLUE = \033[0;94m
 NO_COLOR   = \033[m
 
 define colorecho
-+@echo "${COLOR_BLUE}${1} ${NO_COLOR}"
++@echo -e "${COLOR_BLUE}${1} ${NO_COLOR}"
 endef
 
 # Get a list of all config targets cmake/configs/*.cmake

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ COLOR_BLUE = \033[0;94m
 NO_COLOR   = \033[m
 
 define colorecho
-+@echo -e "${COLOR_BLUE}${1} ${NO_COLOR}"
++@echo -e '${COLOR_BLUE}${1} ${NO_COLOR}'
 endef
 
 # Get a list of all config targets cmake/configs/*.cmake
@@ -231,7 +231,7 @@ quick_check: check_posix_sitl_default check_px4fmu-v4pro_default tests check_for
 
 check_%:
 	@echo
-	$(call colorecho,"Building" $(subst check_,,$@))
+	$(call colorecho,'Building' $(subst check_,,$@))
 	@$(MAKE) --no-print-directory $(subst check_,,$@)
 	@echo
 
@@ -269,12 +269,12 @@ px4_metadata: parameters_metadata airframe_metadata module_documentation
 .PHONY: check_format format
 
 check_format:
-	$(call colorecho,"Checking formatting with astyle")
+	$(call colorecho,'Checking formatting with astyle')
 	@$(SRC_DIR)/Tools/astyle/check_code_style_all.sh
 	@cd $(SRC_DIR) && git diff --check
 
 format:
-	$(call colorecho,"Formatting with astyle")
+	$(call colorecho,'Formatting with astyle')
 	@$(SRC_DIR)/Tools/astyle/check_code_style_all.sh --fix
 
 # Testing

--- a/Tools/astyle/check_code_style.sh
+++ b/Tools/astyle/check_code_style.sh
@@ -4,8 +4,8 @@ FILE=$1
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 if [ -f "$FILE" ]; then
-	${DIR}/fix_code_style.sh --dry-run $FILE | grep --quiet Formatted
-	if [[ $? -eq 0 ]]; then
+	CHECK_FAILED=$(${DIR}/fix_code_style.sh --dry-run --formatted $FILE)
+	if [[ $CHECK_FAILED ]]; then
 		${DIR}/fix_code_style.sh --quiet < $FILE > $FILE.pretty
 
 		echo

--- a/Tools/astyle/check_code_style.sh
+++ b/Tools/astyle/check_code_style.sh
@@ -5,7 +5,7 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 if [ -f "$FILE" ]; then
 	CHECK_FAILED=$(${DIR}/fix_code_style.sh --dry-run --formatted $FILE)
-	if [[ $CHECK_FAILED ]]; then
+	if [ -n "$CHECK_FAILED" ]; then
 		${DIR}/fix_code_style.sh --quiet < $FILE > $FILE.pretty
 
 		echo


### PR DESCRIPTION
This PR solves two problems which I found during Cygwin Toolchain usage:

- **astyle check passes in any case**
The shell script which checks the style relies on greping for the keyword "Formatted" in the output of astyle. But the program has localization support and will output in other languages e.g. german. This leads to all style checks always succeeding. I only tested this on Windows in Cygwin but I can imagine the problem also exists on non-english Ubuntu installations.
**Solution:** is the parameter --formatted of astyle which only produces any output if there was something to fix. This allows for a display language independent condition for an empty string inside the shell script.

- **Makefile colors do not work** e.g. `\033[0;34mFormatting with astyle \033[m`
Certain terminal combinations like cygwin - mintty - xterm - bash do not escape colors by default.
**Solution:** Force interpretation of backslash escapes with the parameter -e of echo.

I also switched the colored messages to a lighter blue (94 instead of 34) because in certain terminals default blue is hard to read on black background while on linux both blues were easy to read (see pictures).

![terminal1](https://user-images.githubusercontent.com/4668506/39757751-146deae2-52ce-11e8-8d97-4d014704a878.JPG)
![terminal2](https://user-images.githubusercontent.com/4668506/39757750-1453e606-52ce-11e8-82be-f0f1a8bac104.JPG)
