### PR TITLE
Cygwin: Enable ARM NuttX Upload within Cygwin Environment

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -667,7 +667,7 @@ def main():
             # on unix-like platforms use glob to support wildcard ports. This allows
             # the use of /dev/serial/by-id/usb-3D_Robotics on Linux, which prevents the upload from
             # causing modem hangups etc
-            if "linux" in _platform or "darwin" in _platform:
+            if "linux" in _platform or "darwin" in _platform or "cygwin" in _platform:
                 import glob
                 for pattern in patterns:
                     portlist += glob.glob(pattern)
@@ -688,6 +688,10 @@ def main():
                             up = uploader(port, args.baud_bootloader, baud_flightstack)
                     elif "darwin" in _platform:
                         # OS X, don't open Windows and Linux ports
+                        if "COM" not in port and "ACM" not in port:
+                            up = uploader(port, args.baud_bootloader, baud_flightstack)
+                    elif "cygwin" in _platform:
+                        # Cygwin, don't open native Windows COM and Linux ports
                         if "COM" not in port and "ACM" not in port:
                             up = uploader(port, args.baud_bootloader, baud_flightstack)
                     elif "win" in _platform:

--- a/Tools/upload.sh
+++ b/Tools/upload.sh
@@ -20,6 +20,11 @@ then
 SERIAL_PORTS="/dev/serial/by-id/*_PX4_*,/dev/serial/by-id/usb-3D_Robotics*,/dev/serial/by-id/usb-The_Autopilot*,/dev/serial/by-id/usb-Bitcraze*,/dev/serial/by-id/pci-Bitcraze*,/dev/serial/by-id/usb-Gumstix*,"
 fi
 
+if [[ $SYSTYPE = *"CYGWIN"* ]];
+then
+SERIAL_PORTS="/dev/ttyS*"
+fi
+
 if [ $SYSTYPE = "" ];
 then
 SERIAL_PORTS="COM32,COM31,COM30,COM29,COM28,COM27,COM26,COM25,COM24,COM23,COM22,COM21,COM20,COM19,COM18,COM17,COM16,COM15,COM14,COM13,COM12,COM11,COM10,COM9,COM8,COM7,COM6,COM5,COM4,COM3,COM2,COM1,COM0"

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -166,6 +166,10 @@ if (TARGET parameters_xml AND TARGET airframes_xml)
 			list(APPEND serial_ports
 				/dev/tty.usbmodemPX*,/dev/tty.usbmodem*
 				)
+		elseif(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "CYGWIN")
+			list(APPEND serial_ports
+				/dev/ttyS*
+				)
 		elseif(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
 			foreach(port RANGE 32 0)
 				list(APPEND serial_ports


### PR DESCRIPTION
In the Cygwin environment the native Windows serial COM# ports get mapped
to /dev/ttyS# for POSIX compatibility. While # is one number lower inside
the environment than the COM port number because it's 0 indexed instead
of 1.

I added the necessary handling to all the dependent parts I found which
allows uploading to /dev/ttyS# when the cygwin platform is detected.
Now the usual `make px4fmu-v4 upload` and
`./Tools/upload.sh build/px4fmu-v4_default/px4fmu-v4_default.px4` work.