### PR TITLE
px_romfs_pruner: reduce multiple consecutive spaces into a single space for mixers

### DIFF
--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -81,6 +81,7 @@ add_custom_command(OUTPUT ${romfs_temp_dir}/init.d/rcS ${romfs_temp_dir}/init.d/
 		--folder ${romfs_temp_dir} --board ${BOARD}
 	DEPENDS
 		${config_romfs_files_list}
+		${PX4_SOURCE_DIR}/Tools/px_romfs_pruner.py
 		${PX4_SOURCE_DIR}/ROMFS/${config_romfs_root}/init.d/rcS
 		${PX4_SOURCE_DIR}/Tools/px_process_airframes.py
 	)

--- a/Tools/px_romfs_pruner.py
+++ b/Tools/px_romfs_pruner.py
@@ -95,7 +95,9 @@ def main():
                     # handle mixer files differently than startup files
                     if file_path.endswith(".mix"):
                         if line.startswith(("Z:", "M:", "R: ", "O:", "S:", "H:", "T:", "P:")):
-                            pruned_content += line
+                            # reduce multiple consecutive spaces into a single space
+                            line_reduced = re.sub(' +', ' ', line)
+                            pruned_content += line_reduced
                     else:
                         if not line.isspace() \
                                 and not line.strip().startswith("#"):


### PR DESCRIPTION
Reduces FLASH usage by about 3kb.

Plus add a missing cmake dependency.