### PR TITLE
clang-tidy modernize-use-equals-default

### DIFF
--- a/src/drivers/camera_trigger/interfaces/src/camera_interface.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/camera_interface.cpp
@@ -12,9 +12,7 @@ CameraInterface::CameraInterface():
 {
 }
 
-CameraInterface::~CameraInterface()
-{
-}
+CameraInterface::~CameraInterface() = default;
 
 void CameraInterface::get_pins()
 {

--- a/src/drivers/distance_sensor/ll40ls/LidarLite.cpp
+++ b/src/drivers/distance_sensor/ll40ls/LidarLite.cpp
@@ -48,9 +48,7 @@ LidarLite::LidarLite() :
 {
 }
 
-LidarLite::~LidarLite()
-{
-}
+LidarLite::~LidarLite() = default;
 
 void LidarLite::set_minimum_distance(const float min)
 {

--- a/src/examples/segway/blocks.cpp
+++ b/src/examples/segway/blocks.cpp
@@ -51,7 +51,7 @@ BlockWaypointGuidance::BlockWaypointGuidance(SuperBlock *parent, const char *nam
 {
 }
 
-BlockWaypointGuidance::~BlockWaypointGuidance() {};
+BlockWaypointGuidance::~BlockWaypointGuidance() = default;;
 
 void BlockWaypointGuidance::update(
 	const vehicle_global_position_s &pos,

--- a/src/lib/drivers/device/integrator.cpp
+++ b/src/lib/drivers/device/integrator.cpp
@@ -54,13 +54,9 @@ Integrator::Integrator(uint64_t auto_reset_interval, bool coning_compensation) :
 	_last_delta_alpha(0.0f, 0.0f, 0.0f),
 	_coning_comp_on(coning_compensation)
 {
-
 }
 
-Integrator::~Integrator()
-{
-
-}
+Integrator::~Integrator() = default;
 
 bool
 Integrator::put(uint64_t timestamp, matrix::Vector3f &val, matrix::Vector3f &integral, uint64_t &integral_dt)

--- a/src/lib/drivers/led/led.cpp
+++ b/src/lib/drivers/led/led.cpp
@@ -72,9 +72,7 @@ LED::LED() : CDev("led", LED0_DEVICE_PATH)
 	init();
 }
 
-LED::~LED()
-{
-}
+LED::~LED() = default;
 
 int
 LED::init()

--- a/src/modules/commander/commander_tests/state_machine_helper_test.cpp
+++ b/src/modules/commander/commander_tests/state_machine_helper_test.cpp
@@ -46,8 +46,8 @@
 class StateMachineHelperTest : public UnitTest
 {
 public:
-	StateMachineHelperTest();
-	virtual ~StateMachineHelperTest();
+	StateMachineHelperTest() = default;
+	virtual ~StateMachineHelperTest() = default;
 
 	virtual bool run_tests();
 
@@ -56,12 +56,6 @@ private:
 	bool mainStateTransitionTest();
 	bool isSafeTest();
 };
-
-StateMachineHelperTest::StateMachineHelperTest() {
-}
-
-StateMachineHelperTest::~StateMachineHelperTest() {
-}
 
 bool StateMachineHelperTest::armingStateTransitionTest()
 {

--- a/src/modules/landing_target_estimator/LandingTargetEstimator.cpp
+++ b/src/modules/landing_target_estimator/LandingTargetEstimator.cpp
@@ -78,9 +78,7 @@ LandingTargetEstimator::LandingTargetEstimator() :
 	_check_params(true);
 }
 
-LandingTargetEstimator::~LandingTargetEstimator()
-{
-}
+LandingTargetEstimator::~LandingTargetEstimator() = default;
 
 void LandingTargetEstimator::update()
 {

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -332,8 +332,8 @@ private:
 	MavlinkOrbSubscription *_status_sub;
 
 	/* do not allow top copying this class */
-	MavlinkStreamHeartbeat(MavlinkStreamHeartbeat &);
-	MavlinkStreamHeartbeat &operator = (const MavlinkStreamHeartbeat &);
+	MavlinkStreamHeartbeat(MavlinkStreamHeartbeat &) = delete;
+	MavlinkStreamHeartbeat &operator = (const MavlinkStreamHeartbeat &) = delete;
 
 protected:
 	explicit MavlinkStreamHeartbeat(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -397,8 +397,8 @@ public:
 
 private:
 	/* do not allow top copying this class */
-	MavlinkStreamStatustext(MavlinkStreamStatustext &);
-	MavlinkStreamStatustext &operator = (const MavlinkStreamStatustext &);
+	MavlinkStreamStatustext(MavlinkStreamStatustext &) = delete;
+	MavlinkStreamStatustext &operator = (const MavlinkStreamStatustext &) = delete;
 
 protected:
 	explicit MavlinkStreamStatustext(Mavlink *mavlink) : MavlinkStream(mavlink)
@@ -465,16 +465,14 @@ public:
 
 private:
 	MavlinkOrbSubscription *_cmd_sub;
-	uint64_t _cmd_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamCommandLong(MavlinkStreamCommandLong &);
-	MavlinkStreamCommandLong &operator = (const MavlinkStreamCommandLong &);
+	MavlinkStreamCommandLong(MavlinkStreamCommandLong &) = delete;
+	MavlinkStreamCommandLong &operator = (const MavlinkStreamCommandLong &) = delete;
 
 protected:
 	explicit MavlinkStreamCommandLong(Mavlink *mavlink) : MavlinkStream(mavlink),
-		_cmd_sub(_mavlink->add_orb_subscription(ORB_ID(vehicle_command))),
-		_cmd_time(0)
+		_cmd_sub(_mavlink->add_orb_subscription(ORB_ID(vehicle_command)))
 	{}
 
 	bool send(const hrt_abstime t)
@@ -544,8 +542,8 @@ private:
 	uint64_t _battery_status_timestamp{0};
 
 	/* do not allow top copying this class */
-	MavlinkStreamSysStatus(MavlinkStreamSysStatus &);
-	MavlinkStreamSysStatus &operator = (const MavlinkStreamSysStatus &);
+	MavlinkStreamSysStatus(MavlinkStreamSysStatus &) = delete;
+	MavlinkStreamSysStatus &operator = (const MavlinkStreamSysStatus &) = delete;
 
 protected:
 	explicit MavlinkStreamSysStatus(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -669,8 +667,8 @@ private:
 	uint64_t _dpres_timestamp;
 
 	/* do not allow top copying this class */
-	MavlinkStreamHighresIMU(MavlinkStreamHighresIMU &);
-	MavlinkStreamHighresIMU &operator = (const MavlinkStreamHighresIMU &);
+	MavlinkStreamHighresIMU(MavlinkStreamHighresIMU &) = delete;
+	MavlinkStreamHighresIMU &operator = (const MavlinkStreamHighresIMU &) = delete;
 
 protected:
 	explicit MavlinkStreamHighresIMU(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -805,8 +803,8 @@ private:
 	uint64_t _raw_gyro_time;
 
 	// do not allow top copy this class
-	MavlinkStreamScaledIMU(MavlinkStreamScaledIMU &);
-	MavlinkStreamScaledIMU &operator = (const MavlinkStreamScaledIMU &);
+	MavlinkStreamScaledIMU(MavlinkStreamScaledIMU &) = delete;
+	MavlinkStreamScaledIMU &operator = (const MavlinkStreamScaledIMU &) = delete;
 
 protected:
 	explicit MavlinkStreamScaledIMU(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -888,8 +886,8 @@ private:
 	uint64_t _att_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamAttitude(MavlinkStreamAttitude &);
-	MavlinkStreamAttitude &operator = (const MavlinkStreamAttitude &);
+	MavlinkStreamAttitude(MavlinkStreamAttitude &) = delete;
+	MavlinkStreamAttitude &operator = (const MavlinkStreamAttitude &) = delete;
 
 
 protected:
@@ -961,8 +959,8 @@ private:
 	uint64_t _att_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamAttitudeQuaternion(MavlinkStreamAttitudeQuaternion &);
-	MavlinkStreamAttitudeQuaternion &operator = (const MavlinkStreamAttitudeQuaternion &);
+	MavlinkStreamAttitudeQuaternion(MavlinkStreamAttitudeQuaternion &) = delete;
+	MavlinkStreamAttitudeQuaternion &operator = (const MavlinkStreamAttitudeQuaternion &) = delete;
 
 protected:
 	explicit MavlinkStreamAttitudeQuaternion(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -1049,8 +1047,8 @@ private:
 	MavlinkOrbSubscription *_air_data_sub;
 
 	/* do not allow top copying this class */
-	MavlinkStreamVFRHUD(MavlinkStreamVFRHUD &);
-	MavlinkStreamVFRHUD &operator = (const MavlinkStreamVFRHUD &);
+	MavlinkStreamVFRHUD(MavlinkStreamVFRHUD &) = delete;
+	MavlinkStreamVFRHUD &operator = (const MavlinkStreamVFRHUD &) = delete;
 
 protected:
 	explicit MavlinkStreamVFRHUD(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -1173,8 +1171,8 @@ private:
 	uint64_t _gps_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamGPSRawInt(MavlinkStreamGPSRawInt &);
-	MavlinkStreamGPSRawInt &operator = (const MavlinkStreamGPSRawInt &);
+	MavlinkStreamGPSRawInt(MavlinkStreamGPSRawInt &) = delete;
+	MavlinkStreamGPSRawInt &operator = (const MavlinkStreamGPSRawInt &) = delete;
 
 protected:
 	explicit MavlinkStreamGPSRawInt(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -1249,8 +1247,8 @@ public:
 
 private:
 	/* do not allow top copying this class */
-	MavlinkStreamSystemTime(MavlinkStreamSystemTime &);
-	MavlinkStreamSystemTime &operator = (const MavlinkStreamSystemTime &);
+	MavlinkStreamSystemTime(MavlinkStreamSystemTime &) = delete;
+	MavlinkStreamSystemTime &operator = (const MavlinkStreamSystemTime &) = delete;
 
 protected:
 	explicit MavlinkStreamSystemTime(Mavlink *mavlink) : MavlinkStream(mavlink)
@@ -1312,8 +1310,8 @@ public:
 
 private:
 	/* do not allow top copying this class */
-	MavlinkStreamTimesync(MavlinkStreamTimesync &);
-	MavlinkStreamTimesync &operator = (const MavlinkStreamTimesync &);
+	MavlinkStreamTimesync(MavlinkStreamTimesync &) = delete;
+	MavlinkStreamTimesync &operator = (const MavlinkStreamTimesync &) = delete;
 
 protected:
 	explicit MavlinkStreamTimesync(Mavlink *mavlink) : MavlinkStream(mavlink)
@@ -1375,8 +1373,8 @@ private:
 	uint64_t _pos_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamADSBVehicle(MavlinkStreamADSBVehicle &);
-	MavlinkStreamADSBVehicle &operator = (const MavlinkStreamADSBVehicle &);
+	MavlinkStreamADSBVehicle(MavlinkStreamADSBVehicle &) = delete;
+	MavlinkStreamADSBVehicle &operator = (const MavlinkStreamADSBVehicle &) = delete;
 
 protected:
 	explicit MavlinkStreamADSBVehicle(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -1467,8 +1465,8 @@ private:
 	uint64_t _collision_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamCollision(MavlinkStreamCollision &);
-	MavlinkStreamCollision &operator = (const MavlinkStreamCollision &);
+	MavlinkStreamCollision(MavlinkStreamCollision &) = delete;
+	MavlinkStreamCollision &operator = (const MavlinkStreamCollision &) = delete;
 
 protected:
 	explicit MavlinkStreamCollision(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -1543,8 +1541,8 @@ private:
 	uint64_t _trigger_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamCameraTrigger(MavlinkStreamCameraTrigger &);
-	MavlinkStreamCameraTrigger &operator = (const MavlinkStreamCameraTrigger &);
+	MavlinkStreamCameraTrigger(MavlinkStreamCameraTrigger &) = delete;
+	MavlinkStreamCameraTrigger &operator = (const MavlinkStreamCameraTrigger &) = delete;
 
 protected:
 	explicit MavlinkStreamCameraTrigger(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -1652,8 +1650,8 @@ private:
 	uint64_t _capture_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamCameraImageCaptured(MavlinkStreamCameraImageCaptured &);
-	MavlinkStreamCameraImageCaptured &operator = (const MavlinkStreamCameraImageCaptured &);
+	MavlinkStreamCameraImageCaptured(MavlinkStreamCameraImageCaptured &) = delete;
+	MavlinkStreamCameraImageCaptured &operator = (const MavlinkStreamCameraImageCaptured &) = delete;
 
 protected:
 	explicit MavlinkStreamCameraImageCaptured(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -1737,8 +1735,8 @@ private:
 	MavlinkOrbSubscription *_air_data_sub;
 
 	/* do not allow top copying this class */
-	MavlinkStreamGlobalPositionInt(MavlinkStreamGlobalPositionInt &);
-	MavlinkStreamGlobalPositionInt &operator = (const MavlinkStreamGlobalPositionInt &);
+	MavlinkStreamGlobalPositionInt(MavlinkStreamGlobalPositionInt &) = delete;
+	MavlinkStreamGlobalPositionInt &operator = (const MavlinkStreamGlobalPositionInt &) = delete;
 
 protected:
 	explicit MavlinkStreamGlobalPositionInt(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -1851,8 +1849,8 @@ private:
 	uint64_t _att_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamVisionPositionEstimate(MavlinkStreamVisionPositionEstimate &);
-	MavlinkStreamVisionPositionEstimate &operator = (const MavlinkStreamVisionPositionEstimate &);
+	MavlinkStreamVisionPositionEstimate(MavlinkStreamVisionPositionEstimate &) = delete;
+	MavlinkStreamVisionPositionEstimate &operator = (const MavlinkStreamVisionPositionEstimate &) = delete;
 
 protected:
 	explicit MavlinkStreamVisionPositionEstimate(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -1927,8 +1925,8 @@ private:
 	uint64_t _pos_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamLocalPositionNED(MavlinkStreamLocalPositionNED &);
-	MavlinkStreamLocalPositionNED &operator = (const MavlinkStreamLocalPositionNED &);
+	MavlinkStreamLocalPositionNED(MavlinkStreamLocalPositionNED &) = delete;
+	MavlinkStreamLocalPositionNED &operator = (const MavlinkStreamLocalPositionNED &) = delete;
 
 protected:
 	explicit MavlinkStreamLocalPositionNED(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -1999,8 +1997,8 @@ private:
 	uint64_t _est_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamLocalPositionNEDCOV(MavlinkStreamLocalPositionNEDCOV &);
-	MavlinkStreamLocalPositionNEDCOV &operator = (const MavlinkStreamLocalPositionNEDCOV &);
+	MavlinkStreamLocalPositionNEDCOV(MavlinkStreamLocalPositionNEDCOV &) = delete;
+	MavlinkStreamLocalPositionNEDCOV &operator = (const MavlinkStreamLocalPositionNEDCOV &) = delete;
 
 protected:
 	explicit MavlinkStreamLocalPositionNEDCOV(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -2081,8 +2079,8 @@ private:
 	uint64_t _est_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamEstimatorStatus(MavlinkStreamEstimatorStatus &);
-	MavlinkStreamEstimatorStatus &operator = (const MavlinkStreamEstimatorStatus &);
+	MavlinkStreamEstimatorStatus(MavlinkStreamEstimatorStatus &) = delete;
+	MavlinkStreamEstimatorStatus &operator = (const MavlinkStreamEstimatorStatus &) = delete;
 
 protected:
 	explicit MavlinkStreamEstimatorStatus(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -2162,8 +2160,8 @@ private:
 	uint64_t _mocap_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamAttPosMocap(MavlinkStreamAttPosMocap &);
-	MavlinkStreamAttPosMocap &operator = (const MavlinkStreamAttPosMocap &);
+	MavlinkStreamAttPosMocap(MavlinkStreamAttPosMocap &) = delete;
+	MavlinkStreamAttPosMocap &operator = (const MavlinkStreamAttPosMocap &) = delete;
 
 protected:
 	explicit MavlinkStreamAttPosMocap(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -2234,8 +2232,8 @@ private:
 	MavlinkOrbSubscription *_home_sub;
 
 	/* do not allow top copying this class */
-	MavlinkStreamHomePosition(MavlinkStreamHomePosition &);
-	MavlinkStreamHomePosition &operator = (const MavlinkStreamHomePosition &);
+	MavlinkStreamHomePosition(MavlinkStreamHomePosition &) = delete;
+	MavlinkStreamHomePosition &operator = (const MavlinkStreamHomePosition &) = delete;
 
 protected:
 	explicit MavlinkStreamHomePosition(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -2334,8 +2332,8 @@ private:
 	uint64_t _act_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamServoOutputRaw(MavlinkStreamServoOutputRaw &);
-	MavlinkStreamServoOutputRaw &operator = (const MavlinkStreamServoOutputRaw &);
+	MavlinkStreamServoOutputRaw(MavlinkStreamServoOutputRaw &) = delete;
+	MavlinkStreamServoOutputRaw &operator = (const MavlinkStreamServoOutputRaw &) = delete;
 
 protected:
 	explicit MavlinkStreamServoOutputRaw(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -2421,8 +2419,8 @@ private:
 	uint64_t _att_ctrl_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamActuatorControlTarget(MavlinkStreamActuatorControlTarget &);
-	MavlinkStreamActuatorControlTarget &operator = (const MavlinkStreamActuatorControlTarget &);
+	MavlinkStreamActuatorControlTarget(MavlinkStreamActuatorControlTarget &) = delete;
+	MavlinkStreamActuatorControlTarget &operator = (const MavlinkStreamActuatorControlTarget &) = delete;
 
 protected:
 	explicit MavlinkStreamActuatorControlTarget(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -2512,8 +2510,8 @@ private:
 	uint64_t _act_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamHILActuatorControls(MavlinkStreamHILActuatorControls &);
-	MavlinkStreamHILActuatorControls &operator = (const MavlinkStreamHILActuatorControls &);
+	MavlinkStreamHILActuatorControls(MavlinkStreamHILActuatorControls &) = delete;
+	MavlinkStreamHILActuatorControls &operator = (const MavlinkStreamHILActuatorControls &) = delete;
 
 protected:
 	explicit MavlinkStreamHILActuatorControls(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -2671,8 +2669,8 @@ private:
 	uint64_t _pos_sp_triplet_timestamp{0};
 
 	/* do not allow top copying this class */
-	MavlinkStreamPositionTargetGlobalInt(MavlinkStreamPositionTargetGlobalInt &);
-	MavlinkStreamPositionTargetGlobalInt &operator = (const MavlinkStreamPositionTargetGlobalInt &);
+	MavlinkStreamPositionTargetGlobalInt(MavlinkStreamPositionTargetGlobalInt &) = delete;
+	MavlinkStreamPositionTargetGlobalInt &operator = (const MavlinkStreamPositionTargetGlobalInt &) = delete;
 
 protected:
 	explicit MavlinkStreamPositionTargetGlobalInt(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -2740,8 +2738,8 @@ private:
 	uint64_t _pos_sp_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamLocalPositionSetpoint(MavlinkStreamLocalPositionSetpoint &);
-	MavlinkStreamLocalPositionSetpoint &operator = (const MavlinkStreamLocalPositionSetpoint &);
+	MavlinkStreamLocalPositionSetpoint(MavlinkStreamLocalPositionSetpoint &) = delete;
+	MavlinkStreamLocalPositionSetpoint &operator = (const MavlinkStreamLocalPositionSetpoint &) = delete;
 
 protected:
 	explicit MavlinkStreamLocalPositionSetpoint(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -2819,8 +2817,8 @@ private:
 	uint64_t _att_sp_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamAttitudeTarget(MavlinkStreamAttitudeTarget &);
-	MavlinkStreamAttitudeTarget &operator = (const MavlinkStreamAttitudeTarget &);
+	MavlinkStreamAttitudeTarget(MavlinkStreamAttitudeTarget &) = delete;
+	MavlinkStreamAttitudeTarget &operator = (const MavlinkStreamAttitudeTarget &) = delete;
 
 protected:
 	explicit MavlinkStreamAttitudeTarget(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -2903,8 +2901,8 @@ private:
 	uint64_t _rc_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamRCChannels(MavlinkStreamRCChannels &);
-	MavlinkStreamRCChannels &operator = (const MavlinkStreamRCChannels &);
+	MavlinkStreamRCChannels(MavlinkStreamRCChannels &) = delete;
+	MavlinkStreamRCChannels &operator = (const MavlinkStreamRCChannels &) = delete;
 
 protected:
 	explicit MavlinkStreamRCChannels(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -3008,8 +3006,8 @@ private:
 	uint64_t _manual_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamManualControl(MavlinkStreamManualControl &);
-	MavlinkStreamManualControl &operator = (const MavlinkStreamManualControl &);
+	MavlinkStreamManualControl(MavlinkStreamManualControl &) = delete;
+	MavlinkStreamManualControl &operator = (const MavlinkStreamManualControl &) = delete;
 
 protected:
 	explicit MavlinkStreamManualControl(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -3085,8 +3083,8 @@ private:
 	uint64_t _flow_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamOpticalFlowRad(MavlinkStreamOpticalFlowRad &);
-	MavlinkStreamOpticalFlowRad &operator = (const MavlinkStreamOpticalFlowRad &);
+	MavlinkStreamOpticalFlowRad(MavlinkStreamOpticalFlowRad &) = delete;
+	MavlinkStreamOpticalFlowRad &operator = (const MavlinkStreamOpticalFlowRad &) = delete;
 
 protected:
 	explicit MavlinkStreamOpticalFlowRad(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -3162,8 +3160,8 @@ private:
 	uint64_t _debug_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamNamedValueFloat(MavlinkStreamNamedValueFloat &);
-	MavlinkStreamNamedValueFloat &operator = (const MavlinkStreamNamedValueFloat &);
+	MavlinkStreamNamedValueFloat(MavlinkStreamNamedValueFloat &) = delete;
+	MavlinkStreamNamedValueFloat &operator = (const MavlinkStreamNamedValueFloat &) = delete;
 
 protected:
 	explicit MavlinkStreamNamedValueFloat(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -3231,8 +3229,8 @@ private:
 	uint64_t _debug_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamDebug(MavlinkStreamDebug &);
-	MavlinkStreamDebug &operator = (const MavlinkStreamDebug &);
+	MavlinkStreamDebug(MavlinkStreamDebug &) = delete;
+	MavlinkStreamDebug &operator = (const MavlinkStreamDebug &) = delete;
 
 protected:
 	explicit MavlinkStreamDebug(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -3298,8 +3296,8 @@ private:
 	uint64_t _debug_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamDebugVect(MavlinkStreamDebugVect &);
-	MavlinkStreamDebugVect &operator = (const MavlinkStreamDebugVect &);
+	MavlinkStreamDebugVect(MavlinkStreamDebugVect &) = delete;
+	MavlinkStreamDebugVect &operator = (const MavlinkStreamDebugVect &) = delete;
 
 protected:
 	explicit MavlinkStreamDebugVect(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -3373,8 +3371,8 @@ private:
 	uint64_t _tecs_status_timestamp{0};
 
 	/* do not allow top copying this class */
-	MavlinkStreamNavControllerOutput(MavlinkStreamNavControllerOutput &);
-	MavlinkStreamNavControllerOutput &operator = (const MavlinkStreamNavControllerOutput &);
+	MavlinkStreamNavControllerOutput(MavlinkStreamNavControllerOutput &) = delete;
+	MavlinkStreamNavControllerOutput &operator = (const MavlinkStreamNavControllerOutput &) = delete;
 
 protected:
 	explicit MavlinkStreamNavControllerOutput(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -3449,8 +3447,8 @@ private:
 	MavlinkOrbSubscription *_status_sub;
 
 	/* do not allow top copying this class */
-	MavlinkStreamCameraCapture(MavlinkStreamCameraCapture &);
-	MavlinkStreamCameraCapture &operator = (const MavlinkStreamCameraCapture &);
+	MavlinkStreamCameraCapture(MavlinkStreamCameraCapture &) = delete;
+	MavlinkStreamCameraCapture &operator = (const MavlinkStreamCameraCapture &) = delete;
 
 protected:
 	explicit MavlinkStreamCameraCapture(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -3523,8 +3521,8 @@ private:
 	uint64_t _dist_sensor_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamDistanceSensor(MavlinkStreamDistanceSensor &);
-	MavlinkStreamDistanceSensor &operator = (const MavlinkStreamDistanceSensor &);
+	MavlinkStreamDistanceSensor(MavlinkStreamDistanceSensor &) = delete;
+	MavlinkStreamDistanceSensor &operator = (const MavlinkStreamDistanceSensor &) = delete;
 
 protected:
 	explicit MavlinkStreamDistanceSensor(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -3619,8 +3617,8 @@ private:
 	mavlink_extended_sys_state_t _msg;
 
 	/* do not allow top copying this class */
-	MavlinkStreamExtendedSysState(MavlinkStreamExtendedSysState &);
-	MavlinkStreamExtendedSysState &operator = (const MavlinkStreamExtendedSysState &);
+	MavlinkStreamExtendedSysState(MavlinkStreamExtendedSysState &) = delete;
+	MavlinkStreamExtendedSysState &operator = (const MavlinkStreamExtendedSysState &) = delete;
 
 protected:
 	explicit MavlinkStreamExtendedSysState(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -3735,8 +3733,8 @@ private:
 	uint64_t _local_pos_time{0};
 
 	/* do not allow top copying this class */
-	MavlinkStreamAltitude(MavlinkStreamAltitude &);
-	MavlinkStreamAltitude &operator = (const MavlinkStreamAltitude &);
+	MavlinkStreamAltitude(MavlinkStreamAltitude &) = delete;
+	MavlinkStreamAltitude &operator = (const MavlinkStreamAltitude &) = delete;
 
 protected:
 	explicit MavlinkStreamAltitude(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -3857,8 +3855,8 @@ private:
 	MavlinkOrbSubscription *_local_pos_sub;
 
 	/* do not allow top copying this class */
-	MavlinkStreamWind(MavlinkStreamWind &);
-	MavlinkStreamWind &operator = (const MavlinkStreamWind &);
+	MavlinkStreamWind(MavlinkStreamWind &) = delete;
+	MavlinkStreamWind &operator = (const MavlinkStreamWind &) = delete;
 
 protected:
 	explicit MavlinkStreamWind(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -3938,8 +3936,8 @@ private:
 	uint64_t _mount_orientation_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamMountOrientation(MavlinkStreamMountOrientation &);
-	MavlinkStreamMountOrientation &operator = (const MavlinkStreamMountOrientation &);
+	MavlinkStreamMountOrientation(MavlinkStreamMountOrientation &) = delete;
+	MavlinkStreamMountOrientation &operator = (const MavlinkStreamMountOrientation &) = delete;
 
 protected:
 	explicit MavlinkStreamMountOrientation(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -4009,8 +4007,8 @@ private:
 	uint64_t _gpos_time;
 
 	/* do not allow top copying this class */
-	MavlinkStreamGroundTruth(MavlinkStreamGroundTruth &);
-	MavlinkStreamGroundTruth &operator = (const MavlinkStreamGroundTruth &);
+	MavlinkStreamGroundTruth(MavlinkStreamGroundTruth &) = delete;
+	MavlinkStreamGroundTruth &operator = (const MavlinkStreamGroundTruth &) = delete;
 
 protected:
 	explicit MavlinkStreamGroundTruth(Mavlink *mavlink) : MavlinkStream(mavlink),
@@ -4105,8 +4103,8 @@ private:
 	uint32_t _sequence;
 
 	/* do not allow top copying this class */
-	MavlinkStreamPing(MavlinkStreamPing &);
-	MavlinkStreamPing &operator = (const MavlinkStreamPing &);
+	MavlinkStreamPing(MavlinkStreamPing &) = delete;
+	MavlinkStreamPing &operator = (const MavlinkStreamPing &) = delete;
 
 protected:
 	explicit MavlinkStreamPing(Mavlink *mavlink) : MavlinkStream(mavlink),

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -404,7 +404,7 @@ protected:
 	explicit MavlinkStreamStatustext(Mavlink *mavlink) : MavlinkStream(mavlink)
 	{}
 
-	~MavlinkStreamStatustext() {}
+	~MavlinkStreamStatustext() = default;
 
 
 	bool send(const hrt_abstime t)

--- a/src/modules/mavlink/mavlink_rate_limiter.cpp
+++ b/src/modules/mavlink/mavlink_rate_limiter.cpp
@@ -48,9 +48,7 @@ MavlinkRateLimiter::MavlinkRateLimiter(unsigned int interval) : _last_sent(0), _
 {
 }
 
-MavlinkRateLimiter::~MavlinkRateLimiter()
-{
-}
+MavlinkRateLimiter::~MavlinkRateLimiter() = default;
 
 void
 MavlinkRateLimiter::set_interval(unsigned int interval)

--- a/src/modules/mavlink/mavlink_shell.cpp
+++ b/src/modules/mavlink/mavlink_shell.cpp
@@ -54,9 +54,7 @@
 #include <asm/socket.h>
 #endif
 
-MavlinkShell::MavlinkShell()
-{
-}
+MavlinkShell::MavlinkShell() = default;
 
 MavlinkShell::~MavlinkShell()
 {

--- a/src/modules/mavlink/mavlink_stream.cpp
+++ b/src/modules/mavlink/mavlink_stream.cpp
@@ -52,9 +52,7 @@ MavlinkStream::MavlinkStream(Mavlink *mavlink) :
 {
 }
 
-MavlinkStream::~MavlinkStream()
-{
-}
+MavlinkStream::~MavlinkStream() = default;
 
 /**
  * Set messages interval in ms

--- a/src/modules/mavlink/mavlink_tests/mavlink_ftp_test.cpp
+++ b/src/modules/mavlink/mavlink_tests/mavlink_ftp_test.cpp
@@ -65,10 +65,7 @@ MavlinkFtpTest::MavlinkFtpTest() :
 {
 }
 
-MavlinkFtpTest::~MavlinkFtpTest()
-{
-
-}
+MavlinkFtpTest::~MavlinkFtpTest() = default;
 
 /// @brief Called before every test to initialize the FTP Server.
 void MavlinkFtpTest::_init()

--- a/src/modules/mc_pos_control/mc_pos_control_tests/mc_pos_control_tests.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_tests/mc_pos_control_tests.cpp
@@ -58,22 +58,14 @@ public:
 class McPosControlTests : public UnitTest
 {
 public:
-	McPosControlTests();
-	virtual ~McPosControlTests();
+	McPosControlTests() = default;
+	virtual ~McPosControlTests() = default;
 
 	virtual bool run_tests();
 
 private:
 	bool cross_sphere_line_test();
 };
-
-McPosControlTests::McPosControlTests()
-{
-}
-
-McPosControlTests::~McPosControlTests()
-{
-}
 
 bool McPosControlTests::cross_sphere_line_test()
 {

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -136,8 +136,7 @@ class Sensors : public ModuleBase<Sensors>, public ModuleParams
 {
 public:
 	Sensors(bool hil_enabled);
-
-	~Sensors() {}
+	~Sensors() = default;
 
 	/** @see ModuleBase */
 	static int task_spawn(int argc, char *argv[]);

--- a/src/modules/simulator/accelsim/accelsim.cpp
+++ b/src/modules/simulator/accelsim/accelsim.cpp
@@ -973,9 +973,7 @@ ACCELSIM_mag::ACCELSIM_mag(ACCELSIM *parent) :
 	m_id.dev_id_s.devtype = DRV_ACC_DEVTYPE_ACCELSIM;
 }
 
-ACCELSIM_mag::~ACCELSIM_mag()
-{
-}
+ACCELSIM_mag::~ACCELSIM_mag() = default;
 
 ssize_t
 ACCELSIM_mag::devRead(void *buffer, size_t buflen)

--- a/src/modules/simulator/accelsim/accelsim.cpp
+++ b/src/modules/simulator/accelsim/accelsim.cpp
@@ -230,8 +230,8 @@ private:
 	virtual void	_measure();
 
 	/* this class does not allow copying due to ptr data members */
-	ACCELSIM_mag(const ACCELSIM_mag &);
-	ACCELSIM_mag operator=(const ACCELSIM_mag &);
+	ACCELSIM_mag(const ACCELSIM_mag &) = delete;
+	ACCELSIM_mag operator=(const ACCELSIM_mag &) = delete;
 };
 
 

--- a/src/modules/simulator/gyrosim/gyrosim.cpp
+++ b/src/modules/simulator/gyrosim/gyrosim.cpp
@@ -278,7 +278,7 @@ class GYROSIM_gyro  : public VirtDevObj
 {
 public:
 	GYROSIM_gyro(GYROSIM *parent, const char *path);
-	virtual ~GYROSIM_gyro() {}
+	virtual ~GYROSIM_gyro() = default;
 
 	virtual ssize_t		devRead(void *buffer, size_t buflen);
 	virtual int		devIOCTL(unsigned long cmd, unsigned long arg);

--- a/src/modules/simulator/gyrosim/gyrosim.cpp
+++ b/src/modules/simulator/gyrosim/gyrosim.cpp
@@ -155,7 +155,6 @@ private:
 	float			_accel_range_m_s2;
 	orb_advert_t		_accel_topic;
 	int			_accel_orb_class_instance;
-	int			_accel_class_instance;
 
 	ringbuffer::RingBuffer	*_gyro_reports;
 
@@ -171,8 +170,6 @@ private:
 
 	Integrator _accel_int;
 	Integrator _gyro_int;
-
-	enum Rotation		_rotation;
 
 	// last temperature reading for print_info()
 	float			_last_temperature;
@@ -245,8 +242,8 @@ private:
 	void _set_sample_rate(unsigned desired_sample_rate_hz);
 
 	/* do not allow to copy this class due to pointer data members */
-	GYROSIM(const GYROSIM &);
-	GYROSIM operator=(const GYROSIM &);
+	GYROSIM(const GYROSIM &) = delete;
+	GYROSIM operator=(const GYROSIM &) = delete;
 
 #pragma pack(push, 1)
 	/**
@@ -295,8 +292,8 @@ private:
 	int			_gyro_orb_class_instance;
 
 	/* do not allow to copy this class due to pointer data members */
-	GYROSIM_gyro(const GYROSIM_gyro &);
-	GYROSIM_gyro operator=(const GYROSIM_gyro &);
+	GYROSIM_gyro(const GYROSIM_gyro &) = delete;
+	GYROSIM_gyro operator=(const GYROSIM_gyro &) = delete;
 };
 
 /** driver 'main' command */
@@ -312,7 +309,6 @@ GYROSIM::GYROSIM(const char *path_accel, const char *path_gyro, enum Rotation ro
 	_accel_range_m_s2(0.0f),
 	_accel_topic(nullptr),
 	_accel_orb_class_instance(-1),
-	_accel_class_instance(-1),
 	_gyro_reports(nullptr),
 	_gyro_scale{},
 	_gyro_range_scale(0.0f),
@@ -324,7 +320,6 @@ GYROSIM::GYROSIM(const char *path_accel, const char *path_gyro, enum Rotation ro
 	_reset_retries(perf_alloc(PC_COUNT, "gyrosim_reset_retries")),
 	_accel_int(1000000 / GYROSIM_ACCEL_DEFAULT_RATE, true),
 	_gyro_int(1000000 / GYROSIM_GYRO_DEFAULT_RATE, true),
-	_rotation(rotation),
 	_last_temperature(0)
 {
 

--- a/src/modules/simulator/ledsim/led.cpp
+++ b/src/modules/simulator/ledsim/led.cpp
@@ -63,7 +63,7 @@ class LED : public VirtDevObj
 {
 public:
 	LED();
-	virtual ~LED();
+	virtual ~LED() = default;
 
 	virtual int		init();
 	virtual int		devIOCTL(unsigned long cmd, unsigned long arg);
@@ -77,10 +77,6 @@ LED::LED() :
 {
 	// force immediate init/device registration
 	init();
-}
-
-LED::~LED()
-{
 }
 
 int

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -70,9 +70,7 @@ Standard::Standard(VtolAttitudeControl *attc) :
 	_params_handles_standard.reverse_delay = param_find("VT_B_REV_DEL");
 }
 
-Standard::~Standard()
-{
-}
+Standard::~Standard() = default;
 
 void
 Standard::parameters_update()

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -65,10 +65,7 @@ Tailsitter::Tailsitter(VtolAttitudeControl *attc) :
 	_params_handles_tailsitter.front_trans_dur_p2 = param_find("VT_TRANS_P2_DUR");
 }
 
-Tailsitter::~Tailsitter()
-{
-
-}
+Tailsitter::~Tailsitter() = default;
 
 void
 Tailsitter::parameters_update()

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -65,10 +65,7 @@ Tiltrotor::Tiltrotor(VtolAttitudeControl *attc) :
 	_params_handles_tiltrotor.diff_thrust_scale = param_find("VT_FW_DIFTHR_SC");
 }
 
-Tiltrotor::~Tiltrotor()
-{
-
-}
+Tiltrotor::~Tiltrotor() = default;
 
 void
 Tiltrotor::parameters_update()

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -76,10 +76,7 @@ VtolType::VtolType(VtolAttitudeControl *att_controller) :
 	}
 }
 
-VtolType::~VtolType()
-{
-
-}
+VtolType::~VtolType() = default;
 
 bool VtolType::init()
 {

--- a/src/platforms/posix/tests/vcdev_test/vcdevtest_example.cpp
+++ b/src/platforms/posix/tests/vcdev_test/vcdevtest_example.cpp
@@ -94,7 +94,7 @@ class PrivData
 {
 public:
 	PrivData() : _read_offset(0) {}
-	~PrivData() {}
+	~PrivData() = default;
 
 	size_t _read_offset;
 };
@@ -107,7 +107,7 @@ public:
 		_is_open_for_write(false),
 		_write_offset(0) {}
 
-	~VCDevNode() {}
+	~VCDevNode() = default;
 
 	virtual int open(device::file_t *handlep);
 	virtual int close(device::file_t *handlep);


### PR DESCRIPTION
This check replaces default bodies of special member functions with = default;. The explicitly defaulted function declarations enable more opportunities in optimization, because the compiler might treat explicitly defaulted functions as trivial.


https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-equals-default.html