### PR TITLE
VTOL Front transition controls ramp up

### DIFF
--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -69,6 +69,7 @@ private:
 	struct {
 		float pusher_ramp_dt;
 		float back_trans_ramp;
+		float front_trans_ramp;
 		float down_pitch_max;
 		float forward_thrust_scale;
 		float pitch_setpoint_offset;
@@ -79,6 +80,7 @@ private:
 	struct {
 		param_t pusher_ramp_dt;
 		param_t back_trans_ramp;
+		param_t front_trans_ramp;
 		param_t down_pitch_max;
 		param_t forward_thrust_scale;
 		param_t pitch_setpoint_offset;

--- a/src/modules/vtol_att_control/standard_params.c
+++ b/src/modules/vtol_att_control/standard_params.c
@@ -76,6 +76,20 @@ PARAM_DEFINE_FLOAT(VT_FWD_THRUST_SC, 0.0f);
 PARAM_DEFINE_FLOAT(VT_B_TRANS_RAMP, 3.0f);
 
 /**
+ * Front transition FW ramp up time
+ *
+ * This sets the duration after front transition during wich the fixed wing controls ramp up.
+ * This will prevent sudden agrresive behavior after the front transition completes.
+ *
+ * @unit s
+ * @min 0.0
+ * @max 20.0
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_F_TRANS_RAMP, 3.0f);
+
+
+/**
  * Output on airbrakes channel during back transition
  * Used for airbrakes or with ESCs that have reverse thrust enabled on a seperate channel
  * Airbrakes need to be enables for your selected model/mixer


### PR DESCRIPTION
Ramp up roll and ramp down throttle when front transition completes.
This avoids aggressive behavior after front transition.