### PR TITLE
add library dependencies for modules

### DIFF
--- a/src/drivers/snapdragon_pwm_out/CMakeLists.txt
+++ b/src/drivers/snapdragon_pwm_out/CMakeLists.txt
@@ -37,5 +37,5 @@ px4_add_module(
 	SRCS
 		snapdragon_pwm_out.cpp
 	DEPENDS
-		mixer_gen
+		mixer
 	)

--- a/src/drivers/spektrum_rc/CMakeLists.txt
+++ b/src/drivers/spektrum_rc/CMakeLists.txt
@@ -37,5 +37,6 @@ px4_add_module(
 	SRCS
 		spektrum_rc.cpp
 	DEPENDS
+		rc
 	)
 

--- a/src/modules/commander/CMakeLists.txt
+++ b/src/modules/commander/CMakeLists.txt
@@ -53,4 +53,6 @@ px4_add_module(
 		arm_auth.cpp
 	DEPENDS
 		df_driver_framework
+		git_ecl
+		ecl_geo
 	)

--- a/src/modules/mc_att_control/CMakeLists.txt
+++ b/src/modules/mc_att_control/CMakeLists.txt
@@ -40,5 +40,6 @@ px4_add_module(
 	SRCS
 		mc_att_control_main.cpp
 	DEPENDS
+		conversion
 		mathlib
 	)

--- a/src/modules/sensors/CMakeLists.txt
+++ b/src/modules/sensors/CMakeLists.txt
@@ -46,8 +46,9 @@ px4_add_module(
 		temperature_compensation.cpp
 
 	DEPENDS
-		drivers__device
 		battery
+		conversion
+		drivers__device
 		git_ecl
 		ecl_validation
 	)


### PR DESCRIPTION
These are some of the trivial additions needed to get snapdragon working again.
@RomanBapst 