### PR TITLE
[DO NOT MERGE] Nxphlite temporary fixes

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -43,7 +43,7 @@ fi
 if ver hwcmp NXPHLITE_V3
 then
 	# External I2C bus
-	hmc5883 -C -X start
+	hmc5883 -C -T -X start
 
 	# Internal I2C (baro)
 	mpl3115a2 -I start

--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -42,6 +42,9 @@ fi
 
 if ver hwcmp NXPHLITE_V3
 then
+	# External I2C bus
+	hmc5883 -C -X start
+
 	# Internal I2C (baro)
 	mpl3115a2 -I start
 

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -389,10 +389,10 @@ then
 	fi
 	# waypoint storage
 	# REBOOTWORK this needs to start in parallel
-	if dataman start $DATAMAN_OPT
-	then
-	fi
-	unset DATAMAN_OPT
+	#if dataman start $DATAMAN_OPT
+	#then
+	#fi
+	#unset DATAMAN_OPT
 
 	#
 	# Sensors System (start before Commander so Preflight checks are properly run)
@@ -966,6 +966,11 @@ then
 	fi
 
 	sh /etc/init.d/rc.logging
+
+	if dataman start $DATAMAN_OPT
+	then
+	fi
+	unset DATAMAN_OPT
 
 # End of autostart
 fi

--- a/src/drivers/boards/nxphlite-v3/board_config.h
+++ b/src/drivers/boards/nxphlite-v3/board_config.h
@@ -262,7 +262,6 @@ __BEGIN_DECLS
 
 #define PX4_I2C_BUS_EXPANSION               PX4_BUS_NUMBER_TO_PX4(0)
 #define PX4_I2C_BUS_ONBOARD                 PX4_BUS_NUMBER_TO_PX4(1)
-#define PX4_I2C_BUS_ONBOARD_EXP				1
 
 #define PX4_I2C_BUS_LED                     PX4_I2C_BUS_EXPANSION
 

--- a/src/drivers/boards/nxphlite-v3/board_config.h
+++ b/src/drivers/boards/nxphlite-v3/board_config.h
@@ -262,6 +262,7 @@ __BEGIN_DECLS
 
 #define PX4_I2C_BUS_EXPANSION               PX4_BUS_NUMBER_TO_PX4(0)
 #define PX4_I2C_BUS_ONBOARD                 PX4_BUS_NUMBER_TO_PX4(1)
+#define PX4_I2C_BUS_ONBOARD_EXP				1
 
 #define PX4_I2C_BUS_LED                     PX4_I2C_BUS_EXPANSION
 

--- a/src/drivers/magnetometer/hmc5883/hmc5883.cpp
+++ b/src/drivers/magnetometer/hmc5883/hmc5883.cpp
@@ -989,6 +989,11 @@ HMC5883::collect()
 	sensor_is_onboard = !_interface->ioctl(MAGIOCGEXTERNAL, dummy);
 	new_report.is_external = !sensor_is_onboard;
 
+#ifdef PX4_I2C_BUS_ONBOARD_EXP
+	sensor_is_onboard = false;
+	new_report.is_external = true;
+#endif
+
 	if (sensor_is_onboard) {
 		// convert onboard so it matches offboard for the
 		// scaling below
@@ -1440,9 +1445,13 @@ struct hmc5883_bus_option {
 #ifdef PX4_I2C_BUS_EXPANSION2
 	{ HMC5883_BUS_I2C_EXTERNAL, "/dev/hmc5883_ext2", &HMC5883_I2C_interface, PX4_I2C_BUS_EXPANSION2, NULL },
 #endif
-#ifdef PX4_I2C_BUS_ONBOARD
+
+#if PX4_I2C_BUS_ONBOARD_EXP == 1
+	{ HMC5883_BUS_I2C_EXTERNAL, "/dev/hmc5883_ext", &HMC5883_I2C_interface, PX4_I2C_BUS_ONBOARD, NULL },
+#elif PX4_I2C_BUS_ONBOARD
 	{ HMC5883_BUS_I2C_INTERNAL, "/dev/hmc5883_int", &HMC5883_I2C_interface, PX4_I2C_BUS_ONBOARD, NULL },
 #endif
+
 #ifdef PX4_SPIDEV_HMC
 	{ HMC5883_BUS_SPI, "/dev/hmc5883_spi", &HMC5883_SPI_interface, PX4_SPI_BUS_SENSORS, NULL },
 #endif

--- a/src/drivers/magnetometer/hmc5883/hmc5883.cpp
+++ b/src/drivers/magnetometer/hmc5883/hmc5883.cpp
@@ -989,7 +989,7 @@ HMC5883::collect()
 	sensor_is_onboard = !_interface->ioctl(MAGIOCGEXTERNAL, dummy);
 	new_report.is_external = !sensor_is_onboard;
 
-#ifdef PX4_I2C_BUS_ONBOARD_EXP
+#ifdef CONFIG_ARCH_BOARD_NXPHLITE_V3
 	sensor_is_onboard = false;
 	new_report.is_external = true;
 #endif
@@ -1446,7 +1446,7 @@ struct hmc5883_bus_option {
 	{ HMC5883_BUS_I2C_EXTERNAL, "/dev/hmc5883_ext2", &HMC5883_I2C_interface, PX4_I2C_BUS_EXPANSION2, NULL },
 #endif
 
-#if PX4_I2C_BUS_ONBOARD_EXP == 1
+#ifdef CONFIG_ARCH_BOARD_NXPHLITE_V3
 	{ HMC5883_BUS_I2C_EXTERNAL, "/dev/hmc5883_ext", &HMC5883_I2C_interface, PX4_I2C_BUS_ONBOARD, NULL },
 #elif PX4_I2C_BUS_ONBOARD
 	{ HMC5883_BUS_I2C_INTERNAL, "/dev/hmc5883_int", &HMC5883_I2C_interface, PX4_I2C_BUS_ONBOARD, NULL },


### PR DESCRIPTION
DO NOT MERGE! 

Hack to fix mag and dataman issue on nxphlite. First of all the hmc5883 driver was not started in the rc.sensors. Second, this mag is on an I2C bus that is defined as internal in the board config. With this modification it will be forced to be set as external. 

Dataman works if started at the end of the rCS. Further investigation is required to understand what is the cause of this. This fix allows to upload/download missions from sd card. 