### PR TITLE
Optical Flow Use Improvements - supersedes #9435

### DIFF
--- a/msg/estimator_status.msg
+++ b/msg/estimator_status.msg
@@ -13,38 +13,40 @@ float32[24] covariances	# Diagonal Elements of Covariance Matrix
 
 uint16 gps_check_fail_flags     # Bitmask to indicate status of GPS checks - see definition below
 # bits are true when corresponding test has failed
-uint16 GPS_CHECK_FAIL_GPS_FIX = 0				# 0 : insufficient fix type (no 3D solution)
-uint16 GPS_CHECK_FAIL_MIN_SAT_COUNT = 1			# 1 : minimum required sat count fail
-uint16 GPS_CHECK_FAIL_MIN_GDOP = 2				# 2 : minimum required GDoP fail
-uint16 GPS_CHECK_FAIL_MAX_HORZ_ERR = 3			# 3 : maximum allowed horizontal position error fail
-uint16 GPS_CHECK_FAIL_MAX_VERT_ERR = 4			# 4 : maximum allowed vertical position error fail
-uint16 GPS_CHECK_FAIL_MAX_SPD_ERR = 5			# 5 : maximum allowed speed error fail
-uint16 GPS_CHECK_FAIL_MAX_HORZ_DRIFT = 6		# 6 : maximum allowed horizontal position drift fail - requires stationary vehicle
-uint16 GPS_CHECK_FAIL_MAX_VERT_DRIFT = 7		# 7 : maximum allowed vertical position drift fail - requires stationary vehicle
-uint16 GPS_CHECK_FAIL_MAX_HORZ_SPD_ERR = 8		# 8 : maximum allowed horizontal speed fail - requires stationary vehicle
-uint16 GPS_CHECK_FAIL_MAX_VERT_SPD_ERR = 9		# 9 : maximum allowed vertical velocity discrepancy fail
+uint8 GPS_CHECK_FAIL_GPS_FIX = 0		# 0 : insufficient fix type (no 3D solution)
+uint8 GPS_CHECK_FAIL_MIN_SAT_COUNT = 1		# 1 : minimum required sat count fail
+uint8 GPS_CHECK_FAIL_MIN_GDOP = 2		# 2 : minimum required GDoP fail
+uint8 GPS_CHECK_FAIL_MAX_HORZ_ERR = 3		# 3 : maximum allowed horizontal position error fail
+uint8 GPS_CHECK_FAIL_MAX_VERT_ERR = 4		# 4 : maximum allowed vertical position error fail
+uint8 GPS_CHECK_FAIL_MAX_SPD_ERR = 5		# 5 : maximum allowed speed error fail
+uint8 GPS_CHECK_FAIL_MAX_HORZ_DRIFT = 6		# 6 : maximum allowed horizontal position drift fail - requires stationary vehicle
+uint8 GPS_CHECK_FAIL_MAX_VERT_DRIFT = 7		# 7 : maximum allowed vertical position drift fail - requires stationary vehicle
+uint8 GPS_CHECK_FAIL_MAX_HORZ_SPD_ERR = 8	# 8 : maximum allowed horizontal speed fail - requires stationary vehicle
+uint8 GPS_CHECK_FAIL_MAX_VERT_SPD_ERR = 9	# 9 : maximum allowed vertical velocity discrepancy fail
 
 uint32 control_mode_flags	# Bitmask to indicate EKF logic state
-# 0 - true if the filter tilt alignment is complete
-# 1 - true if the filter yaw alignment is complete
-# 2 - true if GPS measurements are being fused
-# 3 - true if optical flow measurements are being fused
-# 4 - true if a simple magnetic yaw heading is being fused
-# 5 - true if 3-axis magnetometer measurement are being fused
-# 6 - true if synthetic magnetic declination measurements are being fused
-# 7 - true when the vehicle is airborne
-# 8 - true when wind velocity is being estimated
-# 9 - true when baro height is being fused as a primary height reference
-# 10 - true when range finder height is being fused as a primary height reference
-# 11 - true when GPS height is being fused as a primary height reference
-# 12 - true when local position data from external vision is being fused
-# 13 - true when yaw data from external vision measurements is being fused
-# 14 - true when height data from external vision measurements is being fused
-# 15 - true when synthetic sideslip measurements are being fused
-# 16 - true when only the magnetic field states are updated by the magnetometer
-# 17 - true when the vehicle is operating as a fixed wing vehicle
-# 18 - true when the magnetomer has been declared faulty and is no longer being used
-# 19 - true when airspeed measurements are being fused
+uint8 CS_TILT_ALIGN = 0		# 0 - true if the filter tilt alignment is complete
+uint8 CS_YAW_ALIGN = 1		# 1 - true if the filter yaw alignment is complete
+uint8 CS_GPS = 2		# 2 - true if GPS measurements are being fused
+uint8 CS_OPT_FLOW = 3		# 3 - true if optical flow measurements are being fused
+uint8 CS_MAG_HDG = 4		# 4 - true if a simple magnetic yaw heading is being fused
+uint8 CS_MAG_3D = 5		# 5 - true if 3-axis magnetometer measurement are being fused
+uint8 CS_MAG_DEC = 6		# 6 - true if synthetic magnetic declination measurements are being fused
+uint8 CS_IN_AIR = 7		# 7 - true when thought to be airborne
+uint8 CS_WIND = 8		# 8 - true when wind velocity is being estimated
+uint8 CS_BARO_HGT = 9		# 9 - true when baro height is being fused as a primary height reference
+uint8 CS_RNG_HGT = 10		# 10 - true when range finder height is being fused as a primary height reference
+uint8 CS_GPS_HGT = 11		# 11 - true when GPS height is being fused as a primary height reference
+uint8 CS_EV_POS = 12		# 12 - true when local position data from external vision is being fused
+uint8 CS_EV_YAW = 13		# 13 - true when yaw data from external vision measurements is being fused
+uint8 CS_EV_HGT = 14		# 14 - true when height data from external vision measurements is being fused
+uint8 CS_BETA = 15		# 15 - true when synthetic sideslip measurements are being fused
+uint8 CS_MAG_FIELD = 16		# 16 - true when only the magnetic field states are updated by the magnetometer
+uint8 CS_FIXED_WING = 17	# 17 - true when thought to be operating as a fixed wing vehicle with constrained sideslip
+uint8 CS_MAG_FAULT = 18		# 18 - true when the magnetomer has been declared faulty and is no longer being used
+uint8 CS_ASPD = 19		# 19 - true when airspeed measurements are being fused
+uint8 CS_GND_EFFECT = 20	# 20 - true when when protection from ground effect induced static pressure rise is active
+uint8 CS_RNG_STUCK = 21		# 21 - true when a stuck range finder sensor has been detected
 
 uint16 filter_fault_flags	# Bitmask to indicate EKF internal faults
 # 0 - true if the fusion of the magnetometer X-axis has encountered a numerical error

--- a/msg/optical_flow.msg
+++ b/msg/optical_flow.msg
@@ -13,3 +13,7 @@ uint32 time_since_last_sonar_update	# time since last sonar update in microsecon
 uint16 frame_count_since_last_readout	# number of accumulated frames in timespan
 int16 gyro_temperature	# Temperature * 100 in centi-degrees Celsius
 uint8 quality	# Average of quality of accumulated frames, 0: bad quality, 255: maximum quality
+
+float32 max_flow_rate # Magnitude of maximum angular which the optical flow sensor can measure reliably
+float32 min_ground_distance # Minimum distance from ground at which the optical flow sensor operates reliably
+float32 max_ground_distance # Maximum distance from ground at which the optical flow sensor operates reliably

--- a/msg/vehicle_local_position.msg
+++ b/msg/vehicle_local_position.msg
@@ -56,7 +56,9 @@ float32 evh				# Standard deviation of horizontal velocity error, (metres/sec)
 float32 evv				# Standard deviation of horizontal velocity error, (metres/sec)
 
 # estimator specified vehicle limits
-float32 vxy_max				# maximum horizontal speed - set to 0 when not applicable (metres/sec)
-bool limit_hagl				# true when the height above ground needs to be limited to observe optical flow focus and range finder limits
+float32 vxy_max				# maximum horizontal speed - set to 0 when limiting not required (meters/sec)
+float32 vz_max				# maximum vertical speed - set to 0 when limiting not required (meters/sec)
+float32 hagl_min			# minimum height above ground level - set to 0 when limiting not required (meters)
+float32 hagl_max			# maximum height above ground level - set to 0 when limiting not required (meters)
 
 # TOPICS vehicle_local_position vehicle_local_position_groundtruth vehicle_vision_position

--- a/src/drivers/px4flow/px4flow.cpp
+++ b/src/drivers/px4flow/px4flow.cpp
@@ -144,7 +144,11 @@ private:
 	perf_counter_t		_comms_errors;
 
 	unsigned                 _conversion_interval;
+
 	enum Rotation       _sensor_rotation;
+	float 				_sensor_min_range;
+	float 				_sensor_max_range;
+	float 				_sensor_max_flow_rate;
 
 	/**
 	 * Test whether the device supported by the driver is present at a
@@ -268,12 +272,39 @@ PX4FLOW::init()
 	/* get yaw rotation from sensor frame to body frame */
 	param_t rot = param_find("SENS_FLOW_ROT");
 
-	/* only set it if the parameter exists */
 	if (rot != PARAM_INVALID) {
 		int32_t val = 6; // the recommended installation for the flow sensor is with the Y sensor axis forward
 		param_get(rot, &val);
 
 		_sensor_rotation = (enum Rotation)val;
+	}
+
+	/* get operational limits of the sensor */
+	param_t hmin = param_find("SENS_FLOW_MINHGT");
+
+	if (hmin != PARAM_INVALID) {
+		float val = 0.7;
+		param_get(hmin, &val);
+
+		_sensor_min_range = val;
+	}
+
+	param_t hmax = param_find("SENS_FLOW_MAXHGT");
+
+	if (hmax != PARAM_INVALID) {
+		float val = 3.0;
+		param_get(hmax, &val);
+
+		_sensor_max_range = val;
+	}
+
+	param_t ratemax = param_find("SENS_FLOW_MAXR");
+
+	if (ratemax != PARAM_INVALID) {
+		float val = 2.5;
+		param_get(ratemax, &val);
+
+		_sensor_max_flow_rate = val;
 	}
 
 	return ret;
@@ -536,6 +567,12 @@ PX4FLOW::collect()
 	report.gyro_temperature = f_integral.gyro_temperature;//Temperature * 100 in centi-degrees Celsius
 
 	report.sensor_id = 0;
+
+	report.max_flow_rate = _sensor_max_flow_rate;
+
+	report.min_ground_distance = _sensor_min_range;
+
+	report.max_ground_distance = _sensor_max_range;
 
 	/* rotate measurements in yaw from sensor frame to body frame according to parameter SENS_FLOW_ROT */
 	float zeroval = 0.0f;

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -185,6 +185,8 @@ static bool _last_condition_global_position_valid = false;
 
 static struct vehicle_land_detected_s land_detector = {};
 
+static float _eph_threshold_adj = INFINITY;	///< maximum allowable horizontal position uncertainty after adjustment for flight condition
+
 /**
  * The daemon app only briefly exists to start
  * the background job. The stack size assigned in the
@@ -1748,6 +1750,19 @@ Commander::run()
 		_local_position_sub.update();
 		_global_position_sub.update();
 
+		// Set the allowable positon uncertainty based on combination of flight and estimator state
+		// When we are in a operator demanded position control mode and are solely reliant on optical flow, do not check position error becasue it will gradually increase throughout flight and the operator will compensate for the drift
+		bool reliant_on_opt_flow = ((estimator_status.control_mode_flags & (1 << estimator_status_s::CS_OPT_FLOW))
+					    && !(estimator_status.control_mode_flags & (1 << estimator_status_s::CS_GPS))
+					    && !(estimator_status.control_mode_flags & (1 << estimator_status_s::CS_EV_POS)));
+		bool operator_controlled_position = (internal_state.main_state == commander_state_s::MAIN_STATE_POSCTL);
+		bool skip_pos_accuracy_check = reliant_on_opt_flow && operator_controlled_position;
+		if (skip_pos_accuracy_check) {
+			_eph_threshold_adj = INFINITY;
+		} else {
+			_eph_threshold_adj = _eph_threshold.get();
+		}
+
 		// Check if quality checking of position accuracy and consistency is to be performed
 		const bool run_quality_checks = !status_flags.circuit_breaker_engaged_posfailure_check;
 
@@ -1815,11 +1830,11 @@ Commander::run()
 			} else {
 				// use global position message to determine validity
 				const vehicle_global_position_s&global_position = _global_position_sub.get();
-				check_posvel_validity(true, global_position.eph, _eph_threshold.get(), global_position.timestamp, &_last_gpos_fail_time_us, &_gpos_probation_time_us, &status_flags.condition_global_position_valid, &status_changed);
+				check_posvel_validity(true, global_position.eph, _eph_threshold_adj, global_position.timestamp, &_last_gpos_fail_time_us, &_gpos_probation_time_us, &status_flags.condition_global_position_valid, &status_changed);
 
 				// use local position message to determine validity
 				const vehicle_local_position_s &local_position = _local_position_sub.get();
-				check_posvel_validity(local_position.xy_valid, local_position.eph, _eph_threshold.get(), local_position.timestamp, &_last_lpos_fail_time_us, &_lpos_probation_time_us, &status_flags.condition_local_position_valid, &status_changed);
+				check_posvel_validity(local_position.xy_valid, local_position.eph, _eph_threshold_adj, local_position.timestamp, &_last_lpos_fail_time_us, &_lpos_probation_time_us, &status_flags.condition_local_position_valid, &status_changed);
 				check_posvel_validity(local_position.v_xy_valid, local_position.evh, _evh_threshold.get(), local_position.timestamp, &_last_lvel_fail_time_us, &_lvel_probation_time_us, &status_flags.condition_local_velocity_valid, &status_changed);
 			}
 		}
@@ -3342,8 +3357,8 @@ Commander::reset_posvel_validity(bool *changed)
 	const vehicle_global_position_s &global_position = _global_position_sub.get();
 
 	// recheck validity
-	check_posvel_validity(true, global_position.eph, _eph_threshold.get(), global_position.timestamp, &_last_gpos_fail_time_us, &_gpos_probation_time_us, &status_flags.condition_global_position_valid, changed);
-	check_posvel_validity(local_position.xy_valid, local_position.eph, _eph_threshold.get(), local_position.timestamp, &_last_lpos_fail_time_us, &_lpos_probation_time_us, &status_flags.condition_local_position_valid, changed);
+	check_posvel_validity(true, global_position.eph, _eph_threshold_adj, global_position.timestamp, &_last_gpos_fail_time_us, &_gpos_probation_time_us, &status_flags.condition_global_position_valid, changed);
+	check_posvel_validity(local_position.xy_valid, local_position.eph, _eph_threshold_adj, local_position.timestamp, &_last_lpos_fail_time_us, &_lpos_probation_time_us, &status_flags.condition_local_position_valid, changed);
 	check_posvel_validity(local_position.v_xy_valid, local_position.evh, _evh_threshold.get(), local_position.timestamp, &_last_lvel_fail_time_us, &_lvel_probation_time_us, &status_flags.condition_local_velocity_valid, changed);
 }
 

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -186,6 +186,7 @@ static bool _last_condition_global_position_valid = false;
 static struct vehicle_land_detected_s land_detector = {};
 
 static float _eph_threshold_adj = INFINITY;	///< maximum allowable horizontal position uncertainty after adjustment for flight condition
+static bool _skip_pos_accuracy_check = false;
 
 /**
  * The daemon app only briefly exists to start
@@ -1756,8 +1757,8 @@ Commander::run()
 					    && !(estimator_status.control_mode_flags & (1 << estimator_status_s::CS_GPS))
 					    && !(estimator_status.control_mode_flags & (1 << estimator_status_s::CS_EV_POS)));
 		bool operator_controlled_position = (internal_state.main_state == commander_state_s::MAIN_STATE_POSCTL);
-		bool skip_pos_accuracy_check = reliant_on_opt_flow && operator_controlled_position;
-		if (skip_pos_accuracy_check) {
+		_skip_pos_accuracy_check = reliant_on_opt_flow && operator_controlled_position;
+		if (_skip_pos_accuracy_check) {
 			_eph_threshold_adj = INFINITY;
 		} else {
 			_eph_threshold_adj = _eph_threshold.get();
@@ -1828,9 +1829,11 @@ Commander::run()
 				status_flags.condition_local_velocity_valid = false;
 
 			} else {
-				// use global position message to determine validity
-				const vehicle_global_position_s&global_position = _global_position_sub.get();
-				check_posvel_validity(true, global_position.eph, _eph_threshold_adj, global_position.timestamp, &_last_gpos_fail_time_us, &_gpos_probation_time_us, &status_flags.condition_global_position_valid, &status_changed);
+				if (!_skip_pos_accuracy_check) {
+					// use global position message to determine validity
+					const vehicle_global_position_s&global_position = _global_position_sub.get();
+					check_posvel_validity(true, global_position.eph, _eph_threshold_adj, global_position.timestamp, &_last_gpos_fail_time_us, &_gpos_probation_time_us, &status_flags.condition_global_position_valid, &status_changed);
+				}
 
 				// use local position message to determine validity
 				const vehicle_local_position_s &local_position = _local_position_sub.get();
@@ -3357,7 +3360,9 @@ Commander::reset_posvel_validity(bool *changed)
 	const vehicle_global_position_s &global_position = _global_position_sub.get();
 
 	// recheck validity
-	check_posvel_validity(true, global_position.eph, _eph_threshold_adj, global_position.timestamp, &_last_gpos_fail_time_us, &_gpos_probation_time_us, &status_flags.condition_global_position_valid, changed);
+	if (!_skip_pos_accuracy_check) {
+		check_posvel_validity(true, global_position.eph, _eph_threshold_adj, global_position.timestamp, &_last_gpos_fail_time_us, &_gpos_probation_time_us, &status_flags.condition_global_position_valid, changed);
+	}
 	check_posvel_validity(local_position.xy_valid, local_position.eph, _eph_threshold_adj, local_position.timestamp, &_last_lpos_fail_time_us, &_lpos_probation_time_us, &status_flags.condition_local_position_valid, changed);
 	check_posvel_validity(local_position.v_xy_valid, local_position.evh, _evh_threshold.get(), local_position.timestamp, &_last_lvel_fail_time_us, &_lvel_probation_time_us, &status_flags.condition_local_velocity_valid, changed);
 }

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -322,7 +322,6 @@ private:
 		(ParamExtInt<px4::params::EKF2_OF_QMIN>) _flow_qual_min,	///< minimum acceptable quality integer from  the flow sensor
 		(ParamExtFloat<px4::params::EKF2_OF_GATE>)
 		_flow_innov_gate,	///< optical flow fusion innovation consistency gate size (STD)
-		(ParamExtFloat<px4::params::EKF2_OF_RMAX>) _flow_rate_max,	///< maximum valid optical flow rate (rad/sec)
 
 		// sensor positions in body frame
 		(ParamExtFloat<px4::params::EKF2_IMU_POS_X>) _imu_pos_x,		///< X position of IMU in body frame (m)
@@ -470,7 +469,6 @@ Ekf2::Ekf2():
 	_flow_noise_qual_min(_params->flow_noise_qual_min),
 	_flow_qual_min(_params->flow_qual_min),
 	_flow_innov_gate(_params->flow_innov_gate),
-	_flow_rate_max(_params->flow_rate_max),
 	_imu_pos_x(_params->imu_pos_body(0)),
 	_imu_pos_y(_params->imu_pos_body(1)),
 	_imu_pos_z(_params->imu_pos_body(2)),
@@ -903,6 +901,9 @@ void Ekf2::run()
 					_ekf.setOpticalFlowData(optical_flow.timestamp, &flow);
 				}
 
+				// Save sensor limits reported by the optical flow sensor
+				_ekf.set_optical_flow_limits(optical_flow.max_flow_rate, optical_flow.min_ground_distance, optical_flow.max_ground_distance);
+
 				ekf2_timestamps.optical_flow_timestamp_rel = (int16_t)((int64_t)optical_flow.timestamp / 100 -
 						(int64_t)ekf2_timestamps.timestamp / 100);
 			}
@@ -930,6 +931,9 @@ void Ekf2::run()
 					}
 
 					_ekf.setRangeData(range_finder.timestamp, range_finder.current_distance);
+
+					// Save sensor limits reported by the rangefinder
+					_ekf.set_rangefinder_limits(range_finder.min_distance, range_finder.max_distance);
 
 					ekf2_timestamps.distance_sensor_timestamp_rel = (int16_t)((int64_t)range_finder.timestamp / 100 -
 							(int64_t)ekf2_timestamps.timestamp / 100);
@@ -1127,11 +1131,20 @@ void Ekf2::run()
 			_ekf.get_velNE_reset(&lpos.delta_vxy[0], &lpos.vxy_reset_counter);
 
 			// get control limit information
-			_ekf.get_ekf_ctrl_limits(&lpos.vxy_max, &lpos.limit_hagl);
+			_ekf.get_ekf_ctrl_limits(&lpos.vxy_max, &lpos.vz_max, &lpos.hagl_min, &lpos.hagl_max);
 
 			// convert NaN to zero
 			if (!PX4_ISFINITE(lpos.vxy_max)) {
 				lpos.vxy_max = 0.0f;
+			}
+			if (!PX4_ISFINITE(lpos.vz_max)) {
+				lpos.vz_max = 0.0f;
+			}
+			if (!PX4_ISFINITE(lpos.hagl_min)) {
+				lpos.hagl_min = 0.0f;
+			}
+			if (!PX4_ISFINITE(lpos.hagl_max)) {
+				lpos.hagl_max = 0.0f;
 			}
 
 			// publish vehicle local position data

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -902,7 +902,8 @@ void Ekf2::run()
 				}
 
 				// Save sensor limits reported by the optical flow sensor
-				_ekf.set_optical_flow_limits(optical_flow.max_flow_rate, optical_flow.min_ground_distance, optical_flow.max_ground_distance);
+				_ekf.set_optical_flow_limits(optical_flow.max_flow_rate, optical_flow.min_ground_distance,
+							     optical_flow.max_ground_distance);
 
 				ekf2_timestamps.optical_flow_timestamp_rel = (int16_t)((int64_t)optical_flow.timestamp / 100 -
 						(int64_t)ekf2_timestamps.timestamp / 100);
@@ -1133,18 +1134,21 @@ void Ekf2::run()
 			// get control limit information
 			_ekf.get_ekf_ctrl_limits(&lpos.vxy_max, &lpos.vz_max, &lpos.hagl_min, &lpos.hagl_max);
 
-			// convert NaN to zero
+			// convert NaN to INFINITY
 			if (!PX4_ISFINITE(lpos.vxy_max)) {
-				lpos.vxy_max = 0.0f;
+				lpos.vxy_max = INFINITY;
 			}
+
 			if (!PX4_ISFINITE(lpos.vz_max)) {
-				lpos.vz_max = 0.0f;
+				lpos.vz_max = INFINITY;
 			}
+
 			if (!PX4_ISFINITE(lpos.hagl_min)) {
-				lpos.hagl_min = 0.0f;
+				lpos.hagl_min = INFINITY;
 			}
+
 			if (!PX4_ISFINITE(lpos.hagl_max)) {
-				lpos.hagl_max = 0.0f;
+				lpos.hagl_max = INFINITY;
 			}
 
 			// publish vehicle local position data

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1079,7 +1079,12 @@ PARAM_DEFINE_FLOAT(EKF2_MAGB_K, 0.2f);
  *
  * If this parameter is enabled then the estimator will make use of the range finder measurements
  * to estimate it's height even if range sensor is not the primary height source. It will only do so if conditions
- * for range measurement fusion are met.
+ * for range measurement fusion are met. This enables the range finder to be used during low speed and low altitude
+ * operation. Speed and height criteria are controlled by EKF2_RNG_A_VMAX and EKF2_RNG_A_HMAX.
+ * It should not be used for terrain following. It is intended to be used where a vertical takeoff and landing
+ * is performed, and horizontal flight does not occur until above EKF2_RNG_A_HMAX. If vehicle motion causes
+ * repeated switvhing between the rimary height sensor and range finder, an offset in the local position origin
+ * can accumulate. For terrain following, it is recommended to use the MPC_ALT_MODE parameter instead.
  *
  * @group EKF2
  * @value 0 Range aid disabled

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -739,17 +739,6 @@ PARAM_DEFINE_INT32(EKF2_OF_QMIN, 1);
 PARAM_DEFINE_FLOAT(EKF2_OF_GATE, 3.0f);
 
 /**
- * Optical Flow data will not fused if the magnitude of the flow rate > EKF2_OF_RMAX.
- * Control loops will be instructed to limit ground speed such that the flow rate produced by movement over ground is less than 50% of EKF2_OF_RMAX.
- *
- * @group EKF2
- * @min 1.0
- * @unit rad/s
- * @decimal 2
- */
-PARAM_DEFINE_FLOAT(EKF2_OF_RMAX, 2.5f);
-
-/**
  * Terrain altitude process noise - accounts for instability in vehicle height estimate
  *
  * @group EKF2

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -482,14 +482,19 @@ PARAM_DEFINE_INT32(EKF2_DECL_TYPE, 7);
 /**
  * Type of magnetometer fusion
  *
- * Integer controlling the type of magnetometer fusion used - magnetic heading or 3-axis magnetometer.
- * If set to automatic: heading fusion on-ground and 3-axis fusion in-flight with fallback to heading fusion if there is insufficient motion to make yaw or mag biases observable.
+ * Integer controlling the type of magnetometer fusion used - magnetic heading or 3-component vector. The fuson of magnetomer data as a three component vector enables vehicle body fixed hard iron errors to be learned, but requires a stable earth field.
+ * If set to 'Automatic' magnetic heading fusion is used when on-ground and 3-axis magnetic field fusion in-flight with fallback to magnetic heading fusion if there is insufficient motion to make yaw or magnetic field states observable.
+ * If set to 'Magnetic heading' magnetic heading fusion is used at all times
+ * If set to '3-axis' 3-axis field fusion is used at all times.
+ * If set to 'VTOL custom' the behaviour is the same as 'Automatic', but if fusing airspeed, magnetometer fusion is only allowed to modify the magnetic field states. This can be used by VTOL platforms with large magnetic field disturbances to prevent incorrect bias states being learned during forward flight operation which can adversely affect estimation accuracy after transition to hovering flight.
+ * If set to 'MC custom' the behaviour is the same as 'Automatic, but if there are no earth frame position or velocity observations being used, the magnetometer will not be used. This enables vehicles to operate with no GPS in environments where the magnetic field cannot be used to provide a heading reference.
  *
  * @group EKF2
  * @value 0 Automatic
  * @value 1 Magnetic heading
- * @value 2 3-axis fusion
- * @value 3 None
+ * @value 2 3-axis
+ * @value 3 VTOL customn
+ * @value 4 MC custom
  * @reboot_required true
  */
 PARAM_DEFINE_INT32(EKF2_MAG_TYPE, 0);

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -109,7 +109,7 @@ void LandDetector::_cycle()
 	const bool freefallDetected = (_state == LandDetectionState::FREEFALL);
 	const bool maybe_landedDetected = (_state == LandDetectionState::MAYBE_LANDED);
 	const bool ground_contactDetected = (_state == LandDetectionState::GROUND_CONTACT);
-	const float alt_max = _get_max_altitude();
+	const float alt_max = _get_max_altitude() > 0.0f ? _get_max_altitude() : INFINITY;
 
 	const hrt_abstime now = hrt_absolute_time();
 

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -604,8 +604,11 @@ void BlockLocalPositionEstimator::publishLocalPos()
 		//TODO provide calculated values for these
 		_pub_lpos.get().evh = 0.0f;
 		_pub_lpos.get().evv = 0.0f;
-		_pub_lpos.get().vxy_max = 0.0f;
-		_pub_lpos.get().limit_hagl = false;
+		_pub_lpos.get().vxy_max = INFINITY;
+		_pub_lpos.get().vz_max = INFINITY;
+		_pub_lpos.get().hagl_min = INFINITY;
+		_pub_lpos.get().hagl_max = INFINITY;
+
 	}
 }
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2259,8 +2259,10 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 		_hil_local_pos.yaw = euler.psi();
 		_hil_local_pos.xy_global = true;
 		_hil_local_pos.z_global = true;
-		_hil_local_pos.vxy_max = 0.0f;
-		_hil_local_pos.limit_hagl = false;
+		_hil_local_pos.vxy_max = INFINITY;
+		_hil_local_pos.vz_max = INFINITY;
+		_hil_local_pos.hagl_min = INFINITY;
+		_hil_local_pos.hagl_max = INFINITY;
 
 		if (_local_pos_pub == nullptr) {
 			_local_pos_pub = orb_advertise(ORB_ID(vehicle_local_position), &_hil_local_pos);

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -853,14 +853,17 @@ MulticopterPositionControl::limit_altitude()
 {
 	float altitude_above_home = -(_pos(2) - _home_pos.z);
 	bool applying_flow_height_limit = false;
+
 	if (_terrain_follow && _local_pos.limit_hagl) {
 		// Don't allow the height setpoint to exceed the optical flow limits
 		if (_pos_sp(2) < -_flow_max_hgt.get()) {
 			_pos_sp(2) = -_flow_max_hgt.get();
 		}
+
 		applying_flow_height_limit = true;
 
-	} else if (_run_alt_control && (_vehicle_land_detected.alt_max > 0.0f) && (altitude_above_home > _vehicle_land_detected.alt_max)) {
+	} else if (_run_alt_control && (_vehicle_land_detected.alt_max > 0.0f)
+		   && (altitude_above_home > _vehicle_land_detected.alt_max)) {
 		// we are above maximum altitude
 		_pos_sp(2) = -_vehicle_land_detected.alt_max +  _home_pos.z;
 
@@ -876,10 +879,12 @@ MulticopterPositionControl::limit_altitude()
 		float pos_z_next = _pos(2) + _vel(2) * delta_t + 0.5f * _acceleration_z_max_down.get() * delta_t *delta_t;
 
 
-		if (!applying_flow_height_limit && (-(pos_z_next - _home_pos.z) > _vehicle_land_detected.alt_max) && (_vehicle_land_detected.alt_max > 0.0f)) {
+		if (!applying_flow_height_limit && (-(pos_z_next - _home_pos.z) > _vehicle_land_detected.alt_max)
+		    && (_vehicle_land_detected.alt_max > 0.0f)) {
 			// prevent the vehicle from exceeding maximum altitude by switching back to altitude control with maximum altitude as setpoint
 			_pos_sp(2) = -_vehicle_land_detected.alt_max + _home_pos.z;
 			_run_alt_control = true;
+
 		} else if (applying_flow_height_limit && (pos_z_next < -_flow_max_hgt.get())) {
 			// prevent the vehicle from exceeding maximum altitude by switching back to altitude control with maximum altitude as setpoint
 			_pos_sp(2) = -_flow_max_hgt.get();
@@ -2276,6 +2281,7 @@ MulticopterPositionControl::update_velocity_derivative()
 				_reset_alt_sp = true;
 				reset_alt_sp();
 			}
+
 			_pos(2) = -_local_pos.dist_bottom;
 
 		} else {
@@ -2284,6 +2290,7 @@ MulticopterPositionControl::update_velocity_derivative()
 				_reset_alt_sp = true;
 				reset_alt_sp();
 			}
+
 			_pos(2) = _local_pos.z;
 		}
 	}

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -448,6 +448,19 @@ PARAM_DEFINE_FLOAT(MPC_DEC_HOR_SLOW, 5.0f);
 PARAM_DEFINE_FLOAT(MPC_ACC_HOR_FLOW, 0.5f);
 
 /**
+ * Maximum height above ground when reliant on optical flow.
+ * The height setpoint will be limited to be no greater than this value when the navigation system is completely reliant on optical flow data.
+ *
+ * @unit m
+ * @min 1.0
+ * @max 25.0
+ * @increment 0.5
+ * @decimal 1
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_MAX_FLOW_HGT, 3.0f);
+
+/**
  * Maximum vertical acceleration in velocity controlled modes upward
  *
  * @unit m/s/s

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -449,7 +449,9 @@ PARAM_DEFINE_FLOAT(MPC_ACC_HOR_FLOW, 0.5f);
 
 /**
  * Maximum height above ground when reliant on optical flow.
- * The height setpoint will be limited to be no greater than this value when the navigation system is completely reliant on optical flow data.
+ * The height setpoint will be limited to be no greater than this value when the navigation system
+ * is completely reliant on optical flow data and the height above ground estimate is valid as indicated
+ * by the local_position.dist_bottom_valid message being true.
  *
  * @unit m
  * @min 1.0
@@ -514,7 +516,13 @@ PARAM_DEFINE_FLOAT(MPC_JERK_MAX, 0.0f);
 PARAM_DEFINE_FLOAT(MPC_JERK_MIN, 1.0f);
 
 /**
- * Altitude control mode, note mode 1 only tested with LPE
+ * Altitude control mode.
+ *
+ * Set to 1 to control height above ground instead of height above origin.
+ * Note: If optical flow is being used as the only source of navigation then the height above ground
+ * will be selected automatically and maximum height will be limited to the value set by MPC_MAX_FLOW_HGT.
+ * Note: The height controller will revert to using height above origin if the distance to ground estimate
+ * becomes invalid as indicated by the local_position.distance_bottom_valid message being false.
  *
  * @min 0
  * @max 1

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -448,21 +448,6 @@ PARAM_DEFINE_FLOAT(MPC_DEC_HOR_SLOW, 5.0f);
 PARAM_DEFINE_FLOAT(MPC_ACC_HOR_FLOW, 0.5f);
 
 /**
- * Maximum height above ground when reliant on optical flow.
- * The height setpoint will be limited to be no greater than this value when the navigation system
- * is completely reliant on optical flow data and the height above ground estimate is valid as indicated
- * by the local_position.dist_bottom_valid message being true.
- *
- * @unit m
- * @min 1.0
- * @max 25.0
- * @increment 0.5
- * @decimal 1
- * @group Multicopter Position Control
- */
-PARAM_DEFINE_FLOAT(MPC_MAX_FLOW_HGT, 3.0f);
-
-/**
  * Maximum vertical acceleration in velocity controlled modes upward
  *
  * @unit m/s/s

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -434,8 +434,9 @@ PARAM_DEFINE_FLOAT(MPC_ACC_HOR, 5.0f);
 PARAM_DEFINE_FLOAT(MPC_DEC_HOR_SLOW, 5.0f);
 
 /**
- * Horizontal acceleration in manual modes when optical flow ground speed limit is removed.
- * If full stick is being applied and the EKF starts using GPS whilst using optical flow,
+ * Horizontal acceleration in manual modes when te estimator speed limit is removed.
+ * If full stick is being applied and the estimator stops demanding a speed limit,
+ * which it had been before (e.g if GPS is gained while flying on optical flow/vision only),
  * the vehicle will accelerate at this rate until the normal position control speed is achieved.
  *
  * @unit m/s/s
@@ -445,7 +446,7 @@ PARAM_DEFINE_FLOAT(MPC_DEC_HOR_SLOW, 5.0f);
  * @decimal 1
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_ACC_HOR_FLOW, 0.5f);
+PARAM_DEFINE_FLOAT(MPC_ACC_HOR_ESTM, 0.5f);
 
 /**
  * Maximum vertical acceleration in velocity controlled modes upward

--- a/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
@@ -1374,8 +1374,10 @@ int position_estimator_inav_thread_main(int argc, char *argv[])
 			// TODO provide calculated values for these
 			local_pos.evh = 0.0f;
 			local_pos.evv = 0.0f;
-			local_pos.vxy_max = 0.0f;
-			local_pos.limit_hagl = false;
+			local_pos.vxy_max = INFINITY;
+			local_pos.vz_max = INFINITY;
+			local_pos.hagl_min = INFINITY;
+			local_pos.hagl_max = INFINITY;
 
 			// this estimator does not provide a separate vertical position time derivative estimate, so use the vertical velocity
 			local_pos.z_deriv = z_est[1];

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -163,37 +163,6 @@ PARAM_DEFINE_FLOAT(SENS_BARO_QNH, 1013.25f);
 PARAM_DEFINE_INT32(SENS_BOARD_ROT, 0);
 
 /**
- * PX4Flow board rotation
- *
- * This parameter defines the yaw rotation of the PX4FLOW board relative to the vehicle body frame.
- * Zero rotation is defined as X on flow board pointing towards front of vehicle.
- * The recommneded installation default for the PX4FLOW board is with the Y axis forward (270 deg yaw).
- *
- * @value 0 No rotation
- * @value 1 Yaw 45°
- * @value 2 Yaw 90°
- * @value 3 Yaw 135°
- * @value 4 Yaw 180°
- * @value 5 Yaw 225°
- * @value 6 Yaw 270°
- * @value 7 Yaw 315°
- *
- * @reboot_required true
- *
- * @group Sensors
- */
-PARAM_DEFINE_INT32(SENS_FLOW_ROT, 6);
-
-/**
- * Optical Flow minimum focus distance
- *
- * This parameter defines the minimum distance from ground required for the optical flow sensor to operate reliably. The sensor may be usable below this height, but accuracy will progressively reduce to loss of focus.
- * *
- * @group Sensor Calibration
- */
-PARAM_DEFINE_FLOAT(SENS_FLOW_MINRNG, 0.7f);
-
-/**
  * Board rotation Y (Pitch) offset
  *
  * This parameter defines a rotational offset in degrees around the Y (Pitch) axis. It allows the user

--- a/src/modules/sensors/sensor_params_flow.c
+++ b/src/modules/sensors/sensor_params_flow.c
@@ -84,3 +84,16 @@ PARAM_DEFINE_FLOAT(SENS_FLOW_MINHGT, 0.7f);
  * @group Sensor Calibration
  */
 PARAM_DEFINE_FLOAT(SENS_FLOW_MAXHGT, 3.0f);
+
+/**
+ * Magnitude of maximum angular flow rate reliably measurable by the optical flow sensor.
+ * Optical flow data will not fused by the estimators if the magnitude of the flow rate exceeds this value and
+ * control loops will be instructed to limit ground speed such that the flow rate produced by movement over ground
+ * is less than 50% of this value.
+ *
+ * @unit rad/s
+ * @min 1.0
+ * @decimal 2
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(SENS_FLOW_MAXR, 2.5f);

--- a/src/modules/sensors/sensor_params_flow.c
+++ b/src/modules/sensors/sensor_params_flow.c
@@ -1,0 +1,86 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * PX4Flow board rotation
+ *
+ * This parameter defines the yaw rotation of the PX4FLOW board relative to the vehicle body frame.
+ * Zero rotation is defined as X on flow board pointing towards front of vehicle.
+ * The recommneded installation default for the PX4FLOW board is with the Y axis forward (270 deg yaw).
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ *
+ * @reboot_required true
+ *
+ * @group Sensors
+ */
+PARAM_DEFINE_INT32(SENS_FLOW_ROT, 6);
+
+/**
+ * Minimum height above ground when reliant on optical flow.
+ *
+ * This parameter defines the minimum distance from ground at which the optical flow sensor operates reliably.
+ * The sensor may be usable below this height, but accuracy will progressively reduce to loss of focus.
+ *
+ * @unit m
+ * @min 0.0
+ * @max 1.0
+ * @increment 0.1
+ * @decimal 1
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(SENS_FLOW_MINHGT, 0.7f);
+
+/**
+ * Maximum height above ground when reliant on optical flow.
+ *
+ * This parameter defines the maximum distance from ground at which the optical flow sensor operates reliably.
+ * The height setpoint will be limited to be no greater than this value when the navigation system
+ * is completely reliant on optical flow data and the height above ground estimate is valid.
+ * The sensor may be usable above this height, but accuracy will progressively degrade.
+ *
+ * @unit m
+ * @min 1.0
+ * @max 25.0
+ * @increment 0.1
+ * @decimal 1
+ * @group Sensor Calibration
+ */
+PARAM_DEFINE_FLOAT(SENS_FLOW_MAXHGT, 3.0f);

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -525,7 +525,9 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 			hil_lpos.ref_alt = _hil_ref_alt;
 			hil_lpos.ref_timestamp = _hil_ref_timestamp;
 			hil_lpos.vxy_max = 0.0f;
-			hil_lpos.limit_hagl = false;
+			hil_lpos.vz_max = 0.0f;
+			hil_lpos.hagl_min = 0.0f;
+			hil_lpos.hagl_max = 0.0f;
 
 			// always publish ground truth attitude message
 			int hil_lpos_multi;
@@ -1098,6 +1100,18 @@ int Simulator::publish_flow_topic(mavlink_hil_optical_flow_t *flow_mavlink)
 	flow.pixel_flow_x_integral = flow_mavlink->integrated_x;
 	flow.pixel_flow_y_integral = flow_mavlink->integrated_y;
 	flow.quality = flow_mavlink->quality;
+
+	/* fill in sensor limits */
+	float flow_rate_max;
+	param_get(param_find("SENS_FLOW_MAXR"), &flow_rate_max);
+	float flow_min_hgt;
+	param_get(param_find("SENS_FLOW_MINHGT"), &flow_min_hgt);
+	float flow_max_hgt;
+	param_get(param_find("SENS_FLOW_MAXHGT"), &flow_max_hgt);
+
+	flow.max_flow_rate = flow_rate_max;
+	flow.min_ground_distance = flow_min_hgt;
+	flow.max_ground_distance = flow_max_hgt;
 
 	/* rotate measurements according to parameter */
 	int32_t flow_rot_int;


### PR DESCRIPTION
Replaces https://github.com/PX4/Firmware/pull/9435

Addresses the following issues:

When the estimator is using optical flow as the only aiding source, the uncertainty in the position relative to the starting point will increase over time. At some point this will cause the position validity check to fail. This is unnecessary if operating in POSCTRL because the operator will be correcting for the drift throughout the flight. This PR sets the required hpos accuracy to INFINITY when using only optical flow in POSCTL.

The only way to maintain a constant height independent of baro drift when using flow was to use the EKF2_RNG_AID parameter, however this was originally designed for a limited use case where the vehicle performed a vertical launch and recovery and clibed above the max range finder use height before moving horizontally. When used for general flying, repeated switching between range finder and baro could result in the reference height datum ratcheting up or down. This PR transfers the responsibility for terrain following when reliant on optical flow to the position controller.

There was no maximum height limit applied when using flow, so the operator could fly the vehicle high enough to lose navigation.

With these changers, the Intended default behaviour is to control height using local_position.z. and the minimum allowed value of the local position z setpoint is adjusted dynamically using the dist_bottom estimate to enforce the maximum allowed height during optical flow operation. Terrain following behaviour can still be enabled via the MPC_ALT_MODE parameter.

Relates to #9398

TESTING

TODO