### PR TITLE
Use Nuttx defconfig defines to determine arch

### DIFF
--- a/platforms/nuttx/cmake/px4_impl_os.cmake
+++ b/platforms/nuttx/cmake/px4_impl_os.cmake
@@ -182,9 +182,9 @@ function(px4_os_add_flags)
 	)
 
 	include_directories(
-		${PX4_BINARY_DIR}/NuttX/nuttx/arch/arm/src/armv7-m
-		${PX4_BINARY_DIR}/NuttX/nuttx/arch/arm/src/chip
-		${PX4_BINARY_DIR}/NuttX/nuttx/arch/arm/src/common
+		${PX4_BINARY_DIR}/NuttX/nuttx/arch/${CONFIG_ARCH}/src/${CONFIG_ARCH_FAMILY}
+		${PX4_BINARY_DIR}/NuttX/nuttx/arch/${CONFIG_ARCH}/src/chip
+		${PX4_BINARY_DIR}/NuttX/nuttx/arch/${CONFIG_ARCH}/src/common
 
 		${PX4_BINARY_DIR}/NuttX/apps/include
 		)


### PR DESCRIPTION
These hard coded paths assume all Nuttx targets are ARMv7-M targets. Updating them to use ${CONFIG_ARCH} and ${CONFIG_ARCH_FAMILY} instead allows for the architecture defined by the incoming Nuttx defconfig to be correctly targeted.