### PR TITLE
[WIP] TBS Caipirinha: suggestion for vehicle adjustments from setting one up

### DIFF
--- a/ROMFS/px4fmu_common/init.d/3100_tbs_caipirinha
+++ b/ROMFS/px4fmu_common/init.d/3100_tbs_caipirinha
@@ -45,7 +45,6 @@ then
 	param set SYS_COMPANION 157600
 	param set PWM_MAIN_REV1 1
 	param set PWM_MAIN_REV2 1
-	param set PWM_DISARMED 0
 	param set PWM_MIN 900
 	param set PWM_MAX 2100
 	param set MIS_TAKEOFF_ALT 50


### PR DESCRIPTION
I'll add suggestions on the way of setting my build up and maiden flying it.

- Setting PWM_DISARMED to 0 results in no PWM output to the ESC for the pusher motor.
Most ESCs start beeping endless in short intervals if they don't get a signal.
I remove changing this parameter which is 900 by default to always command the motor to stand still.

@bkueng you can push your changes as well if you want 😉 