### PR TITLE
set MODULE_NAME for parameters module and update ecl

### DIFF
--- a/src/lib/parameters/CMakeLists.txt
+++ b/src/lib/parameters/CMakeLists.txt
@@ -129,6 +129,7 @@ if (NOT "${CONFIG}" MATCHES "px4io")
 	endif()
 
 	target_link_libraries(parameters PRIVATE perf tinybson)
+	target_compile_definitions(parameters PRIVATE -DMODULE_NAME="parameters")
 	target_compile_options(parameters PRIVATE -Wno-sign-compare) # TODO: fix this
 else()
 	add_library(parameters ${PX4_SOURCE_DIR}/src/platforms/empty.c)

--- a/src/lib/parameters/flashparams/CMakeLists.txt
+++ b/src/lib/parameters/flashparams/CMakeLists.txt
@@ -36,5 +36,6 @@ add_library(flashparams
 	flashparams.c
 )
 add_dependencies(flashparams prebuild_targets)
+target_compile_definitions(flashparams PRIVATE -DMODULE_NAME="flashparams")
 target_compile_options(flashparams PRIVATE -Wno-sign-compare) # TODO: fix this
 target_link_libraries(flashparams PRIVATE nuttx_arch)

--- a/src/lib/parameters/tinybson/CMakeLists.txt
+++ b/src/lib/parameters/tinybson/CMakeLists.txt
@@ -32,5 +32,6 @@
 ############################################################################
 
 add_library(tinybson tinybson.c)
+target_compile_definitions(tinybson PRIVATE -DMODULE_NAME="tinybson")
 target_compile_options(tinybson PRIVATE -Wno-sign-compare) # TODO: fix this
 add_dependencies(tinybson prebuild_targets)


### PR DESCRIPTION
Everything in PX4 is either a PX4 module (px4_add_module), PX4 library (px4_add_library), or regular library (add_library). PX4 modules and PX4 libraries are automatically given access to the parameter system, uORB, etc. As a result this leaves the parameter library in a weird place where it can't be a full PX4 library, so it needs to be manually setup for PX4_INFO, PX4_WARN, PX4_ERR, etc. 

This PR also includes the ECL side update. https://github.com/PX4/ecl/pull/455

**Current master**
![image](https://user-images.githubusercontent.com/84712/40589292-c912f200-61b8-11e8-81f7-a8e8c7ebae06.png)

![image](https://user-images.githubusercontent.com/84712/40589293-ce1c949a-61b8-11e8-8e7d-25d7b6788e5d.png)


**PR**
![image](https://user-images.githubusercontent.com/84712/40589295-df8114a4-61b8-11e8-827e-d4873bb36de6.png)

![image](https://user-images.githubusercontent.com/84712/40589299-e36ce3d6-61b8-11e8-8bd5-cdddbd10eab2.png)

