### PR TITLE
IridiumSBD: Fix for multiple MT messages

### DIFF
--- a/src/drivers/telemetry/iridiumsbd/IridiumSBD.cpp
+++ b/src/drivers/telemetry/iridiumsbd/IridiumSBD.cpp
@@ -473,12 +473,18 @@ void IridiumSBD::sbdsession_loop(void)
 		VERBOSE_INFO("SBD SESSION: SUCCESS (%d)", mo_status);
 
 		_ring_pending = false;
-		_rx_session_pending = false;
 		_tx_session_pending = false;
 		_last_read_time = hrt_absolute_time();
 		_last_heartbeat = _last_read_time;
 		++_successful_sbd_sessions;
 
+		if (mt_queued > 0) {
+			_rx_session_pending = true;
+
+		} else {
+			_rx_session_pending = false;
+
+		}
 
 		if (mt_len > 0) {
 			_rx_read_pending = true;


### PR DESCRIPTION
If MT messages are waiting on the server immediately restart a new session. This assures that the messages are downloaded to the vehicle as fast as possible.