### PR TITLE
px4fmu-v5/board_config.h: update BOARD_BATTERY1_V_DIV

### DIFF
--- a/src/drivers/boards/px4fmu-v5/board_config.h
+++ b/src/drivers/boards/px4fmu-v5/board_config.h
@@ -316,7 +316,7 @@
 /* Define Battery 1 Voltage Divider and A per V
  */
 
-#define BOARD_BATTERY1_V_DIV         (10.133333333f)
+#define BOARD_BATTERY1_V_DIV         (18.1f) 		/* measured with the provided PM board */
 #define BOARD_BATTERY1_A_PER_V       (36.367515152f)
 
 /* HW has to large of R termination on ADC todo:change when HW value is chosen */


### PR DESCRIPTION
To match with the provided PM board.
According to Holybro BOARD_BATTERY1_A_PER_V is correct.

Fixes https://github.com/PX4/Firmware/issues/9526