### PR TITLE
accel and gyro calibration move to msg/

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -40,6 +40,8 @@ set(msg_files
 	airspeed.msg
 	att_pos_mocap.msg
 	battery_status.msg
+	calibration_accel.msg
+	calibration_gyro.msg
 	camera_capture.msg
 	camera_trigger.msg
 	collision_report.msg

--- a/msg/calibration_accel.msg
+++ b/msg/calibration_accel.msg
@@ -1,0 +1,13 @@
+uint64 timestamp		# time since system start (microseconds)
+
+# Accelerometer calibration
+#
+# Vout = (Vin * Vscale) + Voffset
+
+float32 x_offset
+float32 y_offset
+float32 z_offset
+
+float32 x_scale
+float32 y_scale
+float32 z_scale

--- a/msg/calibration_gyro.msg
+++ b/msg/calibration_gyro.msg
@@ -1,0 +1,13 @@
+uint64 timestamp		# time since system start (microseconds)
+
+# Gyro calibration
+#
+# Vout = (Vin * Vscale) + Voffset
+
+float32 x_offset
+float32 y_offset
+float32 z_offset
+
+float32 x_scale
+float32 y_scale
+float32 z_scale

--- a/src/drivers/drv_accel.h
+++ b/src/drivers/drv_accel.h
@@ -51,18 +51,6 @@
 #define ACCEL1_DEVICE_PATH	"/dev/accel1"
 #define ACCEL2_DEVICE_PATH	"/dev/accel2"
 
-#include <uORB/topics/sensor_accel.h>
-#define accel_report sensor_accel_s
-
-/** accel scaling factors; Vout = Vscale * (Vin + Voffset) */
-struct accel_calibration_s {
-	float	x_offset;
-	float	x_scale;
-	float	y_offset;
-	float	y_scale;
-	float	z_offset;
-	float	z_scale;
-};
 /*
  * ioctl() definitions
  *

--- a/src/drivers/drv_gyro.h
+++ b/src/drivers/drv_gyro.h
@@ -51,19 +51,6 @@
 #define GYRO1_DEVICE_PATH	"/dev/gyro1"
 #define GYRO2_DEVICE_PATH	"/dev/gyro2"
 
-#include <uORB/topics/sensor_gyro.h>
-#define gyro_report sensor_gyro_s
-
-/** gyro scaling factors; Vout = (Vin * Vscale) + Voffset */
-struct gyro_calibration_s {
-	float	x_offset;
-	float	x_scale;
-	float	y_offset;
-	float	y_scale;
-	float	z_offset;
-	float	z_scale;
-};
-
 /*
  * ioctl() definitions
  */

--- a/src/drivers/imu/adis16448/adis16448.cpp
+++ b/src/drivers/imu/adis16448/adis16448.cpp
@@ -81,6 +81,11 @@
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
 #include <lib/conversion/rotation.h>
 
+#include <uORB/topics/calibration_accel.h>
+#include <uORB/topics/calibration_gyro.h>
+#include <uORB/topics/sensor_accel.h>
+#include <uORB/topics/sensor_gyro.h>
+
 #define DIR_READ				0x00
 #define DIR_WRITE				0x80
 
@@ -224,21 +229,21 @@ private:
 
 	uint16_t			_product;	/** product code */
 
-	struct hrt_call		_call;
+	struct hrt_call			_call;
 	unsigned			_call_interval;
 
-	ringbuffer::RingBuffer			*_gyro_reports;
+	ringbuffer::RingBuffer		*_gyro_reports;
 
-	struct gyro_calibration_s	_gyro_scale;
+	calibration_gyro_s		_gyro_scale;
 	float				_gyro_range_scale;
 	float				_gyro_range_rad_s;
 
-	ringbuffer::RingBuffer			*_accel_reports;
+	ringbuffer::RingBuffer		*_accel_reports;
 
-	struct accel_calibration_s	_accel_scale;
+	calibration_accel_s		_accel_scale;
 	float				_accel_range_scale;
 	float				_accel_range_m_s2;
-	orb_advert_t		_accel_topic;
+	orb_advert_t			_accel_topic;
 	int					_accel_orb_class_instance;
 	int					_accel_class_instance;
 
@@ -597,13 +602,13 @@ ADIS16448::init()
 	}
 
 	/* allocate basic report buffers */
-	_gyro_reports = new ringbuffer::RingBuffer(2, sizeof(gyro_report));
+	_gyro_reports = new ringbuffer::RingBuffer(2, sizeof(sensor_gyro_s));
 
 	if (_gyro_reports == nullptr) {
 		goto out;
 	}
 
-	_accel_reports = new ringbuffer::RingBuffer(2, sizeof(accel_report));
+	_accel_reports = new ringbuffer::RingBuffer(2, sizeof(sensor_accel_s));
 
 	if (_accel_reports == nullptr) {
 		goto out;
@@ -665,7 +670,7 @@ ADIS16448::init()
 	measure();
 
 	/* advertise sensor topic, measure manually to initialize valid report */
-	struct accel_report arp;
+	sensor_accel_s arp;
 	_accel_reports->get(&arp);
 
 	/* measurement will have generated a report, publish */
@@ -676,7 +681,7 @@ ADIS16448::init()
 		warnx("ADVERT FAIL");
 	}
 
-	struct gyro_report grp;
+	sensor_gyro_s grp;
 
 	_gyro_reports->get(&grp);
 
@@ -841,7 +846,7 @@ ADIS16448::_set_gyro_dyn_range(uint16_t desired_gyro_dyn_range)
 ssize_t
 ADIS16448::read(struct file *filp, char *buffer, size_t buflen)
 {
-	unsigned count = buflen / sizeof(accel_report);
+	unsigned count = buflen / sizeof(sensor_accel_s);
 
 	/* buffer must be large enough */
 	if (count < 1) {
@@ -862,7 +867,7 @@ ADIS16448::read(struct file *filp, char *buffer, size_t buflen)
 	perf_count(_accel_reads);
 
 	/* copy reports out of our buffer to the caller */
-	accel_report *arp = reinterpret_cast<accel_report *>(buffer);
+	sensor_accel_s *arp = reinterpret_cast<sensor_accel_s *>(buffer);
 	int transferred = 0;
 
 	while (count--) {
@@ -875,7 +880,7 @@ ADIS16448::read(struct file *filp, char *buffer, size_t buflen)
 	}
 
 	/* return the number of bytes transferred */
-	return (transferred * sizeof(accel_report));
+	return (transferred * sizeof(sensor_accel_s));
 }
 
 int
@@ -892,7 +897,7 @@ ADIS16448::self_test()
 ssize_t
 ADIS16448::gyro_read(struct file *filp, char *buffer, size_t buflen)
 {
-	unsigned count = buflen / sizeof(gyro_report);
+	unsigned count = buflen / sizeof(sensor_gyro_s);
 
 	/* buffer must be large enough */
 	if (count < 1) {
@@ -913,7 +918,7 @@ ADIS16448::gyro_read(struct file *filp, char *buffer, size_t buflen)
 	perf_count(_gyro_reads);
 
 	/* copy reports out of our buffer to the caller */
-	gyro_report *grp = reinterpret_cast<gyro_report *>(buffer);
+	sensor_gyro_s *grp = reinterpret_cast<sensor_gyro_s *>(buffer);
 	int transferred = 0;
 
 	while (count--) {
@@ -926,7 +931,7 @@ ADIS16448::gyro_read(struct file *filp, char *buffer, size_t buflen)
 	}
 
 	/* return the number of bytes transferred */
-	return (transferred * sizeof(gyro_report));
+	return (transferred * sizeof(sensor_gyro_s));
 }
 
 ssize_t
@@ -1080,7 +1085,7 @@ ADIS16448::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case ACCELIOCSSCALE: {
 			/* copy scale, but only if off by a few percent */
-			struct accel_calibration_s *s = (struct accel_calibration_s *) arg;
+			calibration_accel_s *s = (calibration_accel_s *) arg;
 			float sum = s->x_scale + s->y_scale + s->z_scale;
 
 			if (sum > 2.0f && sum < 4.0f) {
@@ -1094,7 +1099,7 @@ ADIS16448::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case ACCELIOCGSCALE:
 		/* copy scale out */
-		memcpy((struct accel_calibration_s *) arg, &_accel_scale, sizeof(_accel_scale));
+		memcpy((calibration_accel_s *) arg, &_accel_scale, sizeof(_accel_scale));
 		return OK;
 
 	case ACCELIOCSRANGE:
@@ -1150,12 +1155,12 @@ ADIS16448::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case GYROIOCSSCALE:
 		/* copy scale in */
-		memcpy(&_gyro_scale, (struct gyro_calibration_s *) arg, sizeof(_gyro_scale));
+		memcpy(&_gyro_scale, (calibration_gyro_s *) arg, sizeof(_gyro_scale));
 		return OK;
 
 	case GYROIOCGSCALE:
 		/* copy scale out */
-		memcpy((struct gyro_calibration_s *) arg, &_gyro_scale, sizeof(_gyro_scale));
+		memcpy((calibration_gyro_s *) arg, &_gyro_scale, sizeof(_gyro_scale));
 		return OK;
 
 	case GYROIOCSRANGE:
@@ -1377,8 +1382,8 @@ ADIS16448::measure()
 	/*
 	 * Report buffers.
 	 */
-	accel_report	arb;
-	gyro_report		grb;
+	sensor_accel_s		arb;
+	sensor_gyro_s		grb;
 	mag_report		mrb;
 
 	grb.timestamp = arb.timestamp = mrb.timestamp = hrt_absolute_time();
@@ -1774,9 +1779,9 @@ fail:
 void
 test()
 {
-	accel_report a_report;
-	gyro_report  g_report;
-	mag_report 	 m_report;
+	sensor_accel_s	a_report;
+	sensor_gyro_s	g_report;
+	mag_report	m_report;
 
 	ssize_t sz;
 

--- a/src/drivers/imu/adis16477/ADIS16477.cpp
+++ b/src/drivers/imu/adis16477/ADIS16477.cpp
@@ -170,7 +170,7 @@ ADIS16477::init()
 	measure();
 
 	/* advertise sensor topic, measure manually to initialize valid report */
-	accel_report arp = {};
+	sensor_accel_s arp = {};
 
 	/* measurement will have generated a report, publish */
 	_accel_topic = orb_advertise_multi(ORB_ID(sensor_accel), &arp, &_accel_orb_class_instance, ORB_PRIO_MAX);
@@ -179,7 +179,7 @@ ADIS16477::init()
 		PX4_ERR("ADVERT FAIL");
 	}
 
-	gyro_report grp = {};
+	sensor_gyro_s grp = {};
 	_gyro->_gyro_topic = orb_advertise_multi(ORB_ID(sensor_gyro), &grp, &_gyro->_gyro_orb_class_instance, ORB_PRIO_MAX);
 
 	if (_gyro->_gyro_topic == nullptr) {
@@ -383,7 +383,7 @@ ADIS16477::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case ACCELIOCSSCALE: {
 			/* copy scale, but only if off by a few percent */
-			struct accel_calibration_s *s = (struct accel_calibration_s *) arg;
+			calibration_accel_s *s = (calibration_accel_s *) arg;
 			float sum = s->x_scale + s->y_scale + s->z_scale;
 
 			if (sum > 2.0f && sum < 4.0f) {
@@ -397,7 +397,7 @@ ADIS16477::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case ACCELIOCGSCALE:
 		/* copy scale out */
-		memcpy((struct accel_calibration_s *) arg, &_accel_scale, sizeof(_accel_scale));
+		memcpy((calibration_accel_s *) arg, &_accel_scale, sizeof(_accel_scale));
 		return OK;
 
 	case ACCELIOCSRANGE:
@@ -432,12 +432,12 @@ ADIS16477::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case GYROIOCSSCALE:
 		/* copy scale in */
-		memcpy(&_gyro_scale, (struct gyro_calibration_s *) arg, sizeof(_gyro_scale));
+		memcpy(&_gyro_scale, (calibration_gyro_s *) arg, sizeof(_gyro_scale));
 		return OK;
 
 	case GYROIOCGSCALE:
 		/* copy scale out */
-		memcpy((struct gyro_calibration_s *) arg, &_gyro_scale, sizeof(_gyro_scale));
+		memcpy((calibration_gyro_s *) arg, &_gyro_scale, sizeof(_gyro_scale));
 		return OK;
 
 	case GYROIOCSRANGE:
@@ -578,7 +578,7 @@ ADIS16477::measure()
 bool
 ADIS16477::publish_accel(const ADISReport &report)
 {
-	accel_report arb = {};
+	sensor_accel_s arb = {};
 	arb.timestamp = hrt_absolute_time();
 	arb.device_id = _device_id.devid;
 	arb.error_count = perf_event_count(_bad_transfers);
@@ -626,7 +626,7 @@ ADIS16477::publish_accel(const ADISReport &report)
 bool
 ADIS16477::publish_gyro(const ADISReport &report)
 {
-	gyro_report grb = {};
+	sensor_gyro_s grb = {};
 	grb.timestamp = hrt_absolute_time();
 	grb.device_id = _gyro->_device_id.devid;
 	grb.error_count = perf_event_count(_bad_transfers);

--- a/src/drivers/imu/adis16477/ADIS16477.hpp
+++ b/src/drivers/imu/adis16477/ADIS16477.hpp
@@ -50,6 +50,11 @@
 #include <perf/perf_counter.h>
 #include <ecl/geo/geo.h>
 
+#include <uORB/topics/calibration_accel.h>
+#include <uORB/topics/calibration_gyro.h>
+#include <uORB/topics/sensor_accel.h>
+#include <uORB/topics/sensor_gyro.h>
+
 #define ADIS16477_GYRO_DEFAULT_RATE					250
 #define ADIS16477_GYRO_DEFAULT_DRIVER_FILTER_FREQ	30
 
@@ -85,16 +90,16 @@ private:
 
 	uint16_t			_product{0};	/** product code */
 
-	struct hrt_call		_call {};
+	struct hrt_call			_call {};
 	unsigned			_call_interval{0};
 
-	struct gyro_calibration_s	_gyro_scale {};
+	calibration_gyro_s		_gyro_scale {};
 
 	// gyro 0.025 °/sec/LSB
 	float				_gyro_range_scale{0.025f};
 	float				_gyro_range_rad_s{math::radians(500.0f)};
 
-	struct accel_calibration_s	_accel_scale {};
+	calibration_accel_s		_accel_scale {};
 
 	// accel 1.25 mg/LSB
 	float				_accel_range_scale{1.25f * CONSTANTS_ONE_G / 1000.0f};

--- a/src/drivers/imu/adis16477/ADIS16477_gyro.hpp
+++ b/src/drivers/imu/adis16477/ADIS16477_gyro.hpp
@@ -39,6 +39,9 @@
 #include <drivers/device/CDev.hpp>
 #include <drivers/drv_gyro.h>
 
+#include <uORB/topics/calibration_gyro.h>
+#include <uORB/topics/sensor_gyro.h>
+
 /**
  * Helper class implementing the gyro driver node.
  */

--- a/src/drivers/imu/adis16477/ADIS16477_main.cpp
+++ b/src/drivers/imu/adis16477/ADIS16477_main.cpp
@@ -113,8 +113,8 @@ fail:
 void
 test()
 {
-	accel_report a_report;
-	gyro_report  g_report;
+	sensor_accel_s a_report;
+	sensor_gyro_s  g_report;
 
 	ssize_t sz;
 

--- a/src/drivers/imu/bmi055/BMI055_accel.cpp
+++ b/src/drivers/imu/bmi055/BMI055_accel.cpp
@@ -116,7 +116,7 @@ BMI055_accel::init()
 	}
 
 	/* allocate basic report buffers */
-	_accel_reports = new ringbuffer::RingBuffer(2, sizeof(accel_report));
+	_accel_reports = new ringbuffer::RingBuffer(2, sizeof(sensor_accel_s));
 
 	if (_accel_reports == nullptr) {
 		goto out;
@@ -139,7 +139,7 @@ BMI055_accel::init()
 	measure();
 
 	/* advertise sensor topic, measure manually to initialize valid report */
-	struct accel_report arp;
+	sensor_accel_s arp;
 	_accel_reports->get(&arp);
 
 	/* measurement will have generated a report, publish */
@@ -262,7 +262,7 @@ BMI055_accel::accel_set_sample_rate(float frequency)
 ssize_t
 BMI055_accel::read(struct file *filp, char *buffer, size_t buflen)
 {
-	unsigned count = buflen / sizeof(accel_report);
+	unsigned count = buflen / sizeof(sensor_accel_s);
 
 	/* buffer must be large enough */
 	if (count < 1) {
@@ -281,7 +281,7 @@ BMI055_accel::read(struct file *filp, char *buffer, size_t buflen)
 	}
 
 	/* copy reports out of our buffer to the caller */
-	accel_report *arp = reinterpret_cast<accel_report *>(buffer);
+	sensor_accel_s *arp = reinterpret_cast<sensor_accel_s *>(buffer);
 	int transferred = 0;
 
 	while (count--) {
@@ -294,7 +294,7 @@ BMI055_accel::read(struct file *filp, char *buffer, size_t buflen)
 	}
 
 	/* return the number of bytes transferred */
-	return (transferred * sizeof(accel_report));
+	return (transferred * sizeof(sensor_accel_s));
 }
 
 int
@@ -426,7 +426,7 @@ BMI055_accel::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case ACCELIOCSSCALE: {
 			/* copy scale, but only if off by a few percent */
-			struct accel_calibration_s *s = (struct accel_calibration_s *) arg;
+			calibration_accel_s *s = (calibration_accel_s *) arg;
 			float sum = s->x_scale + s->y_scale + s->z_scale;
 
 			if (sum > 2.0f && sum < 4.0f) {
@@ -440,7 +440,7 @@ BMI055_accel::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case ACCELIOCGSCALE:
 		/* copy scale out */
-		memcpy((struct accel_calibration_s *) arg, &_accel_scale, sizeof(_accel_scale));
+		memcpy((calibration_accel_s *) arg, &_accel_scale, sizeof(_accel_scale));
 		return OK;
 
 	case ACCELIOCSRANGE:
@@ -691,7 +691,7 @@ BMI055_accel::measure()
 	/*
 	 * Report buffers.
 	 */
-	accel_report arb;
+	sensor_accel_s        arb;
 
 	arb.timestamp = hrt_absolute_time();
 

--- a/src/drivers/imu/bmi055/BMI055_accel.hpp
+++ b/src/drivers/imu/bmi055/BMI055_accel.hpp
@@ -45,6 +45,8 @@
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
 #include <px4_config.h>
 #include <systemlib/conversions.h>
+#include <uORB/topics/calibration_accel.h>
+#include <uORB/topics/sensor_accel.h>
 
 #define BMI055_DEVICE_PATH_ACCEL	"/dev/bmi055_accel"
 #define BMI055_DEVICE_PATH_ACCEL_EXT	"/dev/bmi055_accel_ext"
@@ -183,7 +185,7 @@ private:
 
 	ringbuffer::RingBuffer  *_accel_reports;
 
-	struct accel_calibration_s  _accel_scale;
+	calibration_accel_s  _accel_scale;
 	float           _accel_range_scale;
 	float           _accel_range_m_s2;
 

--- a/src/drivers/imu/bmi055/BMI055_gyro.cpp
+++ b/src/drivers/imu/bmi055/BMI055_gyro.cpp
@@ -114,7 +114,7 @@ BMI055_gyro::init()
 	}
 
 	/* allocate basic report buffers */
-	_gyro_reports = new ringbuffer::RingBuffer(2, sizeof(gyro_report));
+	_gyro_reports = new ringbuffer::RingBuffer(2, sizeof(sensor_gyro_s));
 
 	if (_gyro_reports == nullptr) {
 		goto out;
@@ -144,7 +144,7 @@ BMI055_gyro::init()
 	measure();
 
 	/* advertise sensor topic, measure manually to initialize valid report */
-	struct gyro_report grp;
+	sensor_gyro_s grp;
 	_gyro_reports->get(&grp);
 
 	_gyro_topic = orb_advertise_multi(ORB_ID(sensor_gyro), &grp,
@@ -270,7 +270,7 @@ BMI055_gyro::test_error()
 ssize_t
 BMI055_gyro::read(struct file *filp, char *buffer, size_t buflen)
 {
-	unsigned count = buflen / sizeof(gyro_report);
+	unsigned count = buflen / sizeof(sensor_gyro_s);
 
 	/* buffer must be large enough */
 	if (count < 1) {
@@ -289,7 +289,7 @@ BMI055_gyro::read(struct file *filp, char *buffer, size_t buflen)
 	}
 
 	/* copy reports out of our buffer to the caller */
-	gyro_report *grp = reinterpret_cast<gyro_report *>(buffer);
+	sensor_gyro_s *grp = reinterpret_cast<sensor_gyro_s *>(buffer);
 	int transferred = 0;
 
 	while (count--) {
@@ -302,7 +302,7 @@ BMI055_gyro::read(struct file *filp, char *buffer, size_t buflen)
 	}
 
 	/* return the number of bytes transferred */
-	return (transferred * sizeof(gyro_report));
+	return (transferred * sizeof(sensor_gyro_s));
 }
 
 int
@@ -644,7 +644,7 @@ BMI055_gyro::measure()
 	/*
 	 * Report buffers.
 	 */
-	gyro_report grb;
+	sensor_gyro_s grb;
 
 	grb.timestamp = hrt_absolute_time();
 

--- a/src/drivers/imu/bmi055/BMI055_gyro.hpp
+++ b/src/drivers/imu/bmi055/BMI055_gyro.hpp
@@ -45,6 +45,8 @@
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
 #include <px4_config.h>
 #include <systemlib/conversions.h>
+#include <uORB/topics/calibration_gyro.h>
+#include <uORB/topics/sensor_gyro.h>
 
 #define BMI055_DEVICE_PATH_GYRO		"/dev/bmi055_gyro"
 #define BMI055_DEVICE_PATH_GYRO_EXT	"/dev/bmi055_gyro_ext"
@@ -174,7 +176,7 @@ private:
 
 	ringbuffer::RingBuffer  *_gyro_reports;
 
-	struct gyro_calibration_s   _gyro_scale;
+	calibration_gyro_s   _gyro_scale;
 	float           _gyro_range_scale;
 	float           _gyro_range_rad_s;
 

--- a/src/drivers/imu/bmi055/bmi055_main.cpp
+++ b/src/drivers/imu/bmi055/bmi055_main.cpp
@@ -225,8 +225,8 @@ test(bool external_bus, enum sensor_type sensor)
 {
 	const char *path_accel = external_bus ? BMI055_DEVICE_PATH_ACCEL_EXT : BMI055_DEVICE_PATH_ACCEL;
 	const char *path_gyro  = external_bus ? BMI055_DEVICE_PATH_GYRO_EXT : BMI055_DEVICE_PATH_GYRO;
-	accel_report a_report;
-	gyro_report g_report;
+	sensor_accel_s a_report;
+	sensor_gyro_s g_report;
 	ssize_t sz;
 
 	if (sensor == BMI055_ACCEL) {

--- a/src/drivers/imu/bmi160/bmi160.cpp
+++ b/src/drivers/imu/bmi160/bmi160.cpp
@@ -138,13 +138,13 @@ BMI160::init()
 	}
 
 	/* allocate basic report buffers */
-	_accel_reports = new ringbuffer::RingBuffer(2, sizeof(accel_report));
+	_accel_reports = new ringbuffer::RingBuffer(2, sizeof(sensor_accel_s));
 
 	if (_accel_reports == nullptr) {
 		goto out;
 	}
 
-	_gyro_reports = new ringbuffer::RingBuffer(2, sizeof(gyro_report));
+	_gyro_reports = new ringbuffer::RingBuffer(2, sizeof(sensor_gyro_s));
 
 	if (_gyro_reports == nullptr) {
 		goto out;
@@ -184,7 +184,7 @@ BMI160::init()
 	measure();
 
 	/* advertise sensor topic, measure manually to initialize valid report */
-	struct accel_report arp;
+	sensor_accel_s arp;
 	_accel_reports->get(&arp);
 
 	/* measurement will have generated a report, publish */
@@ -197,7 +197,7 @@ BMI160::init()
 
 
 	/* advertise sensor topic, measure manually to initialize valid report */
-	struct gyro_report grp;
+	sensor_gyro_s grp;
 	_gyro_reports->get(&grp);
 
 	_gyro->_gyro_topic = orb_advertise_multi(ORB_ID(sensor_gyro), &grp,
@@ -444,7 +444,7 @@ BMI160::_set_dlpf_filter(uint16_t bandwidth)
 ssize_t
 BMI160::read(struct file *filp, char *buffer, size_t buflen)
 {
-	unsigned count = buflen / sizeof(accel_report);
+	unsigned count = buflen / sizeof(sensor_accel_s);
 
 	/* buffer must be large enough */
 	if (count < 1) {
@@ -465,7 +465,7 @@ BMI160::read(struct file *filp, char *buffer, size_t buflen)
 	perf_count(_accel_reads);
 
 	/* copy reports out of our buffer to the caller */
-	accel_report *arp = reinterpret_cast<accel_report *>(buffer);
+	sensor_accel_s *arp = reinterpret_cast<sensor_accel_s *>(buffer);
 	int transferred = 0;
 
 	while (count--) {
@@ -478,7 +478,7 @@ BMI160::read(struct file *filp, char *buffer, size_t buflen)
 	}
 
 	/* return the number of bytes transferred */
-	return (transferred * sizeof(accel_report));
+	return (transferred * sizeof(sensor_accel_s));
 }
 
 int
@@ -506,7 +506,7 @@ BMI160::test_error()
 ssize_t
 BMI160::gyro_read(struct file *filp, char *buffer, size_t buflen)
 {
-	unsigned count = buflen / sizeof(gyro_report);
+	unsigned count = buflen / sizeof(sensor_gyro_s);
 
 	/* buffer must be large enough */
 	if (count < 1) {
@@ -527,7 +527,7 @@ BMI160::gyro_read(struct file *filp, char *buffer, size_t buflen)
 	perf_count(_gyro_reads);
 
 	/* copy reports out of our buffer to the caller */
-	gyro_report *grp = reinterpret_cast<gyro_report *>(buffer);
+	sensor_gyro_s *grp = reinterpret_cast<sensor_gyro_s *>(buffer);
 	int transferred = 0;
 
 	while (count--) {
@@ -540,7 +540,7 @@ BMI160::gyro_read(struct file *filp, char *buffer, size_t buflen)
 	}
 
 	/* return the number of bytes transferred */
-	return (transferred * sizeof(gyro_report));
+	return (transferred * sizeof(sensor_gyro_s));
 }
 
 
@@ -662,7 +662,7 @@ BMI160::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case ACCELIOCSSCALE: {
 			/* copy scale, but only if off by a few percent */
-			struct accel_calibration_s *s = (struct accel_calibration_s *) arg;
+			calibration_accel_s *s = (calibration_accel_s *) arg;
 			float sum = s->x_scale + s->y_scale + s->z_scale;
 
 			if (sum > 2.0f && sum < 4.0f) {
@@ -676,7 +676,7 @@ BMI160::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case ACCELIOCGSCALE:
 		/* copy scale out */
-		memcpy((struct accel_calibration_s *) arg, &_accel_scale, sizeof(_accel_scale));
+		memcpy((calibration_accel_s *) arg, &_accel_scale, sizeof(_accel_scale));
 		return OK;
 
 	case ACCELIOCSRANGE:
@@ -1063,8 +1063,8 @@ BMI160::measure()
 	/*
 	 * Report buffers.
 	 */
-	accel_report		arb;
-	gyro_report		grb;
+	sensor_accel_s		arb;
+	sensor_gyro_s		grb;
 
 	/*
 	 * Adjust and scale results to m/s^2.

--- a/src/drivers/imu/bmi160/bmi160.hpp
+++ b/src/drivers/imu/bmi160/bmi160.hpp
@@ -36,6 +36,10 @@
 #include <drivers/drv_mag.h>
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
 #include <lib/conversion/rotation.h>
+#include <uORB/topics/calibration_accel.h>
+#include <uORB/topics/calibration_gyro.h>
+#include <uORB/topics/sensor_accel.h>
+#include <uORB/topics/sensor_gyro.h>
 
 #define DIR_READ                0x80
 #define DIR_WRITE               0x00
@@ -282,7 +286,7 @@ private:
 
 	ringbuffer::RingBuffer	*_accel_reports;
 
-	struct accel_calibration_s	_accel_scale;
+	calibration_accel_s	_accel_scale;
 	float			_accel_range_scale;
 	float			_accel_range_m_s2;
 	orb_advert_t		_accel_topic;
@@ -291,7 +295,7 @@ private:
 
 	ringbuffer::RingBuffer	*_gyro_reports;
 
-	struct gyro_calibration_s	_gyro_scale;
+	calibration_gyro_s	_gyro_scale;
 	float			_gyro_range_scale;
 	float			_gyro_range_rad_s;
 

--- a/src/drivers/imu/bmi160/bmi160_main.cpp
+++ b/src/drivers/imu/bmi160/bmi160_main.cpp
@@ -121,8 +121,8 @@ test(bool external_bus)
 {
 	const char *path_accel = external_bus ? BMI160_DEVICE_PATH_ACCEL_EXT : BMI160_DEVICE_PATH_ACCEL;
 	const char *path_gyro  = external_bus ? BMI160_DEVICE_PATH_GYRO_EXT : BMI160_DEVICE_PATH_GYRO;
-	accel_report a_report;
-	gyro_report g_report;
+	sensor_accel_s a_report;
+	sensor_gyro_s g_report;
 	ssize_t sz;
 
 	/* get the driver */

--- a/src/drivers/imu/fxas21002c/fxas21002c.cpp
+++ b/src/drivers/imu/fxas21002c/fxas21002c.cpp
@@ -1204,6 +1204,8 @@ FXAS21002C::print_info()
 	}
 
 	::printf("temperature: %.2f\n", (double)_last_temperature);
+
+	print_message(_gyro_scale);
 }
 
 void

--- a/src/drivers/imu/fxas21002c/fxas21002c.cpp
+++ b/src/drivers/imu/fxas21002c/fxas21002c.cpp
@@ -73,6 +73,8 @@
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
 #include <lib/conversion/rotation.h>
 #include <platforms/px4_getopt.h>
+#include <uORB/topics/calibration_gyro.h>
+#include <uORB/topics/sensor_gyro.h>
 
 /* SPI protocol address bits */
 #define DIR_READ(a)                     ((a) | (1 << 7))
@@ -258,7 +260,7 @@ private:
 
 	ringbuffer::RingBuffer *_reports;
 
-	struct gyro_calibration_s _gyro_scale;
+	calibration_gyro_s _gyro_scale;
 	float _gyro_range_scale;
 	float _gyro_range_rad_s;
 	orb_advert_t _gyro_topic;
@@ -529,7 +531,7 @@ FXAS21002C::init()
 	}
 
 	/* allocate basic report buffers */
-	_reports = new ringbuffer::RingBuffer(2, sizeof(gyro_report));
+	_reports = new ringbuffer::RingBuffer(2, sizeof(sensor_gyro_s));
 
 	if (_reports == nullptr) {
 		return PX4_ERROR;
@@ -543,7 +545,7 @@ FXAS21002C::init()
 	_class_instance = register_class_devname(GYRO_BASE_DEVICE_PATH);
 
 	/* advertise sensor topic, measure manually to initialize valid report */
-	struct gyro_report grp;
+	sensor_gyro_s grp;
 	_reports->get(&grp);
 
 	/* measurement will have generated a report, publish */
@@ -610,8 +612,8 @@ FXAS21002C::probe()
 ssize_t
 FXAS21002C::read(struct file *filp, char *buffer, size_t buflen)
 {
-	unsigned count = buflen / sizeof(struct gyro_report);
-	struct gyro_report *gbuf = reinterpret_cast<struct gyro_report *>(buffer);
+	unsigned count = buflen / sizeof(sensor_gyro_s);
+	sensor_gyro_s *gbuf = reinterpret_cast<sensor_gyro_s *>(buffer);
 	int ret = 0;
 
 	/* buffer must be large enough */
@@ -1066,7 +1068,7 @@ FXAS21002C::measure()
 	} raw_gyro_report;
 #pragma pack(pop)
 
-	struct gyro_report gyro_report;
+	sensor_gyro_s gyro_report;
 
 	/* start the performance counter */
 	perf_begin(_sample_perf);
@@ -1334,7 +1336,7 @@ void
 test()
 {
 	int fd_gyro = -1;
-	struct gyro_report g_report;
+	sensor_gyro_s g_report;
 	ssize_t sz;
 
 	/* get the driver */

--- a/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
+++ b/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
@@ -1528,6 +1528,8 @@ FXOS8701CQ::print_info()
 	}
 
 	::printf("temperature: %.2f\n", (double)_last_temperature);
+
+	print_message(_accel_scale);
 }
 
 void

--- a/src/drivers/imu/l3gd20/l3gd20.cpp
+++ b/src/drivers/imu/l3gd20/l3gd20.cpp
@@ -1085,6 +1085,8 @@ L3GD20::print_info()
 				 (unsigned)_checked_values[i]);
 		}
 	}
+
+	print_message(_gyro_scale);
 }
 
 void

--- a/src/drivers/imu/lsm303d/lsm303d.cpp
+++ b/src/drivers/imu/lsm303d/lsm303d.cpp
@@ -1640,6 +1640,8 @@ LSM303D::print_info()
 	}
 
 	::printf("temperature: %.2f\n", (double)_last_temperature);
+
+	print_message(_accel_scale);
 }
 
 void

--- a/src/drivers/imu/mpu9250/main.cpp
+++ b/src/drivers/imu/mpu9250/main.cpp
@@ -316,8 +316,8 @@ void
 test(enum MPU9250_BUS busid)
 {
 	struct mpu9250_bus_option &bus = find_bus(busid);
-	accel_report a_report;
-	gyro_report g_report;
+	sensor_accel_s a_report;
+	sensor_gyro_s g_report;
 	mag_report m_report;
 	ssize_t sz;
 

--- a/src/drivers/imu/mpu9250/mpu9250.h
+++ b/src/drivers/imu/mpu9250/mpu9250.h
@@ -48,11 +48,13 @@
 #include <drivers/drv_mag.h>
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
 #include <lib/conversion/rotation.h>
+#include <uORB/topics/calibration_accel.h>
+#include <uORB/topics/calibration_gyro.h>
+#include <uORB/topics/sensor_accel.h>
+#include <uORB/topics/sensor_gyro.h>
 
 #include "mag.h"
 #include "gyro.h"
-
-
 
 #if defined(PX4_I2C_OBDEV_MPU9250)
 #  define USE_I2C
@@ -293,7 +295,7 @@ private:
 
 	ringbuffer::RingBuffer	*_accel_reports;
 
-	struct accel_calibration_s	_accel_scale;
+	calibration_accel_s	_accel_scale;
 	float			_accel_range_scale;
 	float			_accel_range_m_s2;
 	orb_advert_t		_accel_topic;
@@ -302,7 +304,7 @@ private:
 
 	ringbuffer::RingBuffer	*_gyro_reports;
 
-	struct gyro_calibration_s	_gyro_scale;
+	calibration_gyro_s	_gyro_scale;
 	float			_gyro_range_scale;
 	float			_gyro_range_rad_s;
 

--- a/src/examples/matlab_csv_serial/matlab_csv_serial.c
+++ b/src/examples/matlab_csv_serial/matlab_csv_serial.c
@@ -183,10 +183,10 @@ int matlab_csv_serial_thread_main(int argc, char *argv[])
 	}
 
 	/* subscribe to vehicle status, attitude, sensors and flow*/
-	struct accel_report accel0;
-	struct accel_report accel1;
-	struct gyro_report gyro0;
-	struct gyro_report gyro1;
+	sensor_accel_s accel0;
+	sensor_accel_s accel1;
+	sensor_gyro_s gyro0;
+	sensor_gyro_s gyro1;
 
 	/* subscribe to parameter changes */
 	int accel0_sub = orb_subscribe_multi(ORB_ID(sensor_accel), 0);

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -59,6 +59,10 @@
 #include <uORB/topics/sensor_preflight.h>
 #include <uORB/topics/system_power.h>
 #include <uORB/topics/vehicle_gps_position.h>
+#include <uORB/topics/calibration_accel.h>
+#include <uORB/topics/calibration_gyro.h>
+#include <uORB/topics/sensor_accel.h>
+#include <uORB/topics/sensor_gyro.h>
 #include <uORB/topics/subsystem_info.h>
 
 #include "PreflightCheck.h"
@@ -274,7 +278,7 @@ static bool accelerometerCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &
 
 	if (dynamic) {
 		/* check measurement result range */
-		struct accel_report acc;
+		sensor_accel_s acc;
 		ret = h.read(&acc, sizeof(acc));
 
 		if (ret == sizeof(acc)) {

--- a/src/modules/commander/accelerometer_calibration.cpp
+++ b/src/modules/commander/accelerometer_calibration.cpp
@@ -148,6 +148,8 @@
 #include <systemlib/mavlink_log.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/sensor_correction.h>
+#include <uORB/topics/calibration_accel.h>
+#include <uORB/topics/sensor_accel.h>
 
 static const char *sensor_name = "accel";
 
@@ -177,7 +179,7 @@ int do_accel_calibration(orb_advert_t *mavlink_log_pub)
 
 	calibration_log_info(mavlink_log_pub, CAL_QGC_STARTED_MSG, sensor_name);
 
-	struct accel_calibration_s accel_scale;
+	calibration_accel_s accel_scale;
 	accel_scale.x_offset = 0.0f;
 	accel_scale.x_scale = 1.0f;
 	accel_scale.y_offset = 0.0f;
@@ -479,7 +481,7 @@ calibrate_return do_accel_calibration_measurements(orb_advert_t *mavlink_log_pub
 		for(unsigned i = 0; i < orb_accel_count && !found_cur_accel; i++) {
 			worker_data.subs[cur_accel] = orb_subscribe_multi(ORB_ID(sensor_accel), i);
 
-			struct accel_report report = {};
+			sensor_accel_s report = {};
 			orb_copy(ORB_ID(sensor_accel), worker_data.subs[cur_accel], &report);
 
 #ifdef __PX4_NUTTX
@@ -538,7 +540,7 @@ calibrate_return do_accel_calibration_measurements(orb_advert_t *mavlink_log_pub
 	for (unsigned i = 0; i < max_accel_sens; i++) {
 		if (worker_data.subs[i] >= 0) {
 			/* figure out which sensors were active */
-			struct accel_report arp = {};
+			sensor_accel_s arp = {};
 			(void)orb_copy(ORB_ID(sensor_accel), worker_data.subs[i], &arp);
 			if (arp.timestamp != 0 && timestamps[i] != arp.timestamp) {
 				(*active_sensors)++;
@@ -626,7 +628,7 @@ calibrate_return read_accelerometer_avg(int sensor_correction_sub, int (&subs)[m
 
 				if (changed) {
 
-					struct accel_report arp;
+					sensor_accel_s arp;
 					orb_copy(ORB_ID(sensor_accel), subs[s], &arp);
 
 					// Apply thermal offset corrections in sensor/board frame

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -61,6 +61,7 @@
 #include <parameters/param.h>
 #include <systemlib/err.h>
 #include <uORB/topics/sensor_combined.h>
+#include <uORB/topics/sensor_gyro.h>
 
 static const char *sensor_name = "mag";
 static constexpr unsigned max_mags = 4;
@@ -396,7 +397,7 @@ static calibrate_return mag_calibration_worker(detect_orientation_return orienta
 		int poll_ret = px4_poll(fds, fd_count, 1000);
 
 		if (poll_ret > 0) {
-			struct gyro_report gyro;
+			sensor_gyro_s gyro;
 			orb_copy(ORB_ID(sensor_gyro), sub_gyro, &gyro);
 
 			/* ensure we have a valid first timestamp */

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -90,6 +90,8 @@
 #include <commander/px4_custom_mode.h>
 
 #include <uORB/topics/radio_status.h>
+#include <uORB/topics/sensor_accel.h>
+#include <uORB/topics/sensor_gyro.h>
 #include <uORB/topics/vehicle_command_ack.h>
 
 #include "mavlink_bridge_header.h"
@@ -1975,7 +1977,7 @@ MavlinkReceiver::handle_message_hil_sensor(mavlink_message_t *msg)
 
 	/* gyro */
 	{
-		struct gyro_report gyro = {};
+		sensor_gyro_s gyro = {};
 
 		gyro.timestamp = timestamp;
 		gyro.x_raw = imu.xgyro * 1000.0f;
@@ -1996,7 +1998,7 @@ MavlinkReceiver::handle_message_hil_sensor(mavlink_message_t *msg)
 
 	/* accelerometer */
 	{
-		struct accel_report accel = {};
+		sensor_accel_s accel = {};
 
 		accel.timestamp = timestamp;
 		accel.x_raw = imu.xacc / (CONSTANTS_ONE_G / 1000.0f);
@@ -2396,7 +2398,7 @@ MavlinkReceiver::handle_message_hil_state_quaternion(mavlink_message_t *msg)
 
 	/* accelerometer */
 	{
-		struct accel_report accel = {};
+		sensor_accel_s accel = {};
 
 		accel.timestamp = timestamp;
 		accel.x_raw = hil_state.xacc / CONSTANTS_ONE_G * 1e3f;

--- a/src/modules/sensors/voted_sensors_update.h
+++ b/src/modules/sensors/voted_sensors_update.h
@@ -52,7 +52,11 @@
 #include <lib/ecl/validation/data_validator.h>
 #include <lib/ecl/validation/data_validator_group.h>
 
+#include <uORB/topics/calibration_accel.h>
+#include <uORB/topics/calibration_gyro.h>
+#include <uORB/topics/sensor_accel.h>
 #include <uORB/topics/sensor_combined.h>
+#include <uORB/topics/sensor_gyro.h>
 #include <uORB/topics/sensor_preflight.h>
 #include <uORB/topics/sensor_correction.h>
 #include <uORB/topics/sensor_selection.h>
@@ -216,7 +220,7 @@ private:
 	 * @param device: the device id of the sensor.
 	 * @return: true if config is ok
 	 */
-	bool apply_gyro_calibration(DriverFramework::DevHandle &h, const struct gyro_calibration_s *gcal, const int device_id);
+	bool apply_gyro_calibration(DriverFramework::DevHandle &h, const calibration_gyro_s *gcal, const int device_id);
 
 	/**
 	 * Apply a accel calibration.
@@ -226,8 +230,7 @@ private:
 	 * @param device: the device id of the sensor.
 	 * @return: true if config is ok
 	 */
-	bool apply_accel_calibration(DriverFramework::DevHandle &h, const struct accel_calibration_s *acal,
-				     const int device_id);
+	bool apply_accel_calibration(DriverFramework::DevHandle &h, const calibration_accel_s *acal, const int device_id);
 
 	/**
 	 * Apply a mag calibration.
@@ -237,7 +240,7 @@ private:
 	 * @param device: the device id of the sensor.
 	 * @return: true if config is ok
 	 */
-	bool apply_mag_calibration(DriverFramework::DevHandle &h, const struct mag_calibration_s *mcal, const int device_id);
+	bool apply_mag_calibration(DriverFramework::DevHandle &h, const mag_calibration_s *mcal, const int device_id);
 
 	SensorData _gyro;
 	SensorData _accel;

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -45,6 +45,8 @@
 #include <pthread.h>
 #include <conversion/rotation.h>
 #include <mathlib/mathlib.h>
+#include <uORB/topics/sensor_accel.h>
+#include <uORB/topics/sensor_gyro.h>
 #include <uORB/topics/vehicle_local_position.h>
 
 #include <limits>
@@ -1008,7 +1010,7 @@ int Simulator::publish_sensor_topics(mavlink_hil_sensor_t *imu)
 	*/
 	/* gyro */
 	{
-		struct gyro_report gyro = {};
+		sensor_gyro_s gyro = {};
 
 		gyro.timestamp = timestamp;
 		gyro.x_raw = imu->xgyro * 1000.0f;
@@ -1026,7 +1028,7 @@ int Simulator::publish_sensor_topics(mavlink_hil_sensor_t *imu)
 
 	/* accelerometer */
 	{
-		struct accel_report accel = {};
+		sensor_accel_s accel = {};
 
 		accel.timestamp = timestamp;
 		accel.x_raw = imu->xacc / (CONSTANTS_ONE_G / 1000.0f);

--- a/src/platforms/posix/drivers/df_lsm9ds1_wrapper/df_lsm9ds1_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_lsm9ds1_wrapper/df_lsm9ds1_wrapper.cpp
@@ -65,6 +65,8 @@
 #include <lib/conversion/rotation.h>
 
 #include <uORB/topics/parameter_update.h>
+#include <uORB/topics/sensor_accel.h>
+#include <uORB/topics/sensor_gyro.h>
 
 #include <lsm9ds1/LSM9DS1.hpp>
 #include <DevMgr.hpp>
@@ -239,7 +241,7 @@ DfLsm9ds1Wrapper::~DfLsm9ds1Wrapper()
 int DfLsm9ds1Wrapper::start()
 {
 	// TODO: don't publish garbage here
-	accel_report accel_report = {};
+	sensor_accel_s accel_report = {};
 	_accel_topic = orb_advertise_multi(ORB_ID(sensor_accel), &accel_report,
 					   &_accel_orb_class_instance, ORB_PRIO_DEFAULT);
 
@@ -249,7 +251,7 @@ int DfLsm9ds1Wrapper::start()
 	}
 
 	// TODO: don't publish garbage here
-	gyro_report gyro_report = {};
+	sensor_gyro_s gyro_report = {};
 	_gyro_topic = orb_advertise_multi(ORB_ID(sensor_gyro), &gyro_report,
 					  &_gyro_orb_class_instance, ORB_PRIO_DEFAULT);
 
@@ -618,8 +620,8 @@ int DfLsm9ds1Wrapper::_publish(struct imu_sensor_data &data)
 
 	perf_begin(_publish_perf);
 
-	accel_report accel_report = {};
-	gyro_report gyro_report = {};
+	sensor_accel_s accel_report = {};
+	sensor_gyro_s gyro_report = {};
 	mag_report mag_report = {};
 
 	accel_report.timestamp = gyro_report.timestamp = hrt_absolute_time();

--- a/src/platforms/posix/drivers/df_mpu6050_wrapper/df_mpu6050_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_mpu6050_wrapper/df_mpu6050_wrapper.cpp
@@ -61,6 +61,8 @@
 #include <lib/conversion/rotation.h>
 
 #include <uORB/topics/parameter_update.h>
+#include <uORB/topics/sensor_accel.h>
+#include <uORB/topics/sensor_gyro.h>
 
 #include <mpu6050/MPU6050.hpp>
 #include <DevMgr.hpp>
@@ -488,8 +490,8 @@ int DfMPU6050Wrapper::_publish(struct imu_sensor_data &data)
 
 	perf_begin(_publish_perf);
 
-	accel_report accel_report = {};
-	gyro_report gyro_report = {};
+	sensor_accel_s accel_report = {};
+	sensor_gyro_s gyro_report = {};
 
 	accel_report.timestamp = gyro_report.timestamp = hrt_absolute_time();
 

--- a/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_mpu9250_wrapper/df_mpu9250_wrapper.cpp
@@ -65,7 +65,8 @@
 #include <lib/conversion/rotation.h>
 
 #include <uORB/topics/parameter_update.h>
-
+#include <uORB/topics/sensor_accel.h>
+#include <uORB/topics/sensor_gyro.h>
 #include <mpu9250/MPU9250.hpp>
 #include <DevMgr.hpp>
 
@@ -285,7 +286,7 @@ DfMpu9250Wrapper::~DfMpu9250Wrapper()
 int DfMpu9250Wrapper::start()
 {
 	// TODO: don't publish garbage here
-	accel_report accel_report = {};
+	sensor_accel_s accel_report = {};
 	_accel_topic = orb_advertise_multi(ORB_ID(sensor_accel), &accel_report,
 					   &_accel_orb_class_instance, ORB_PRIO_DEFAULT);
 
@@ -295,7 +296,7 @@ int DfMpu9250Wrapper::start()
 	}
 
 	// TODO: don't publish garbage here
-	gyro_report gyro_report = {};
+	sensor_gyro_s gyro_report = {};
 	_gyro_topic = orb_advertise_multi(ORB_ID(sensor_gyro), &gyro_report,
 					  &_gyro_orb_class_instance, ORB_PRIO_DEFAULT);
 
@@ -612,8 +613,8 @@ int DfMpu9250Wrapper::_publish(struct imu_sensor_data &data)
 		_update_mag_calibration();
 	}
 
-	accel_report accel_report = {};
-	gyro_report gyro_report = {};
+	sensor_accel_s accel_report = {};
+	sensor_gyro_s gyro_report = {};
 	mag_report mag_report = {};
 
 	accel_report.timestamp = gyro_report.timestamp = hrt_absolute_time();

--- a/src/platforms/qurt/fc_addon/mpu_spi/mpu9x50_main.cpp
+++ b/src/platforms/qurt/fc_addon/mpu_spi/mpu9x50_main.cpp
@@ -96,11 +96,11 @@ static int _accel_orb_class_instance;        /**< instance handle for accel devi
 static orb_advert_t _mag_pub = nullptr;		/**< compass data publication */
 static int _mag_orb_class_instance;        /**< instance handle for mag devices */
 static int _params_sub;										/**< parameter update subscription */
-static struct gyro_report _gyro;					/**< gyro report */
-static struct accel_report _accel;				/**< accel report */
+static sensor_gyro_s _gyro;					/**< gyro report */
+static sensor_accel_s _accel;				/**< accel report */
 static struct mag_report _mag;						/**< mag report */
-static struct gyro_calibration_s _gyro_sc;				/**< gyro scale */
-static struct accel_calibration_s _accel_sc;			/**< accel scale */
+static calibration_gyro_s _gyro_sc;				/**< gyro scale */
+static calibration_accel_s _accel_sc;			/**< accel scale */
 static struct mag_calibration_s _mag_sc;					/**< mag scale */
 static enum gyro_lpf_e _gyro_lpf = MPU9X50_GYRO_LPF_20HZ;	/**< gyro lpf enum value */
 static enum acc_lpf_e _accel_lpf = MPU9X50_ACC_LPF_20HZ;	/**< accel lpf enum value */
@@ -367,8 +367,8 @@ void parameters_init()
 bool create_pubs()
 {
 	// initialize the reports
-	memset(&_gyro, 0, sizeof(struct gyro_report));
-	memset(&_accel, 0, sizeof(struct accel_report));
+	memset(&_gyro, 0, sizeof(sensor_gyro_s));
+	memset(&_accel, 0, sizeof(sensor_accel_s));
 	memset(&_mag, 0, sizeof(struct mag_report));
 
 	_gyro_pub = orb_advertise_multi(ORB_ID(sensor_gyro), &_gyro,

--- a/src/systemcmds/config/config.c
+++ b/src/systemcmds/config/config.c
@@ -59,6 +59,10 @@
 #include <drivers/drv_device.h>
 
 #include <parameters/param.h>
+#include <uORB/topics/calibration_accel.h>
+#include <uORB/topics/calibration_gyro.h>
+#include <uORB/topics/sensor_accel.h>
+#include <uORB/topics/sensor_gyro.h>
 
 __EXPORT int config_main(int argc, char *argv[]);
 

--- a/src/systemcmds/tests/test_sensors.c
+++ b/src/systemcmds/tests/test_sensors.c
@@ -59,6 +59,8 @@
 #include <drivers/drv_accel.h>
 #include <drivers/drv_mag.h>
 #include <drivers/drv_baro.h>
+#include <uORB/topics/sensor_accel.h>
+#include <uORB/topics/sensor_gyro.h>
 
 static int accel(int argc, char *argv[], const char *path);
 static int gyro(int argc, char *argv[], const char *path);
@@ -90,7 +92,7 @@ accel(int argc, char *argv[], const char *path)
 	fflush(stdout);
 
 	int		fd;
-	struct accel_report buf;
+	struct sensor_accel_s buf;
 	int		ret;
 
 	fd = px4_open(path, O_RDONLY);
@@ -140,7 +142,7 @@ gyro(int argc, char *argv[], const char *path)
 	fflush(stdout);
 
 	int		fd;
-	struct gyro_report buf;
+	struct sensor_gyro_s buf;
 	int		ret;
 
 	fd = px4_open(path, O_RDONLY);


### PR DESCRIPTION
Debugging possible issues with applying sensor calibrations.

Moving the calibration structs (accel_calibration, gyro_calibration, etc) allows for easy printing (print_message()) and debugging. It also lays the groundwork for moving to something entirely uORB based.

In this PR `mpu6000 status` or `mpu9250 status` will now print the actual calibrations used internally. 

This also unifies how calibrations are applied at the end of a successful calibration between nuttx, linux, qurt.