### PR TITLE
Commander: complete thread cycle before emergency shutdown

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2741,13 +2741,14 @@ Commander::run()
 		arm_auth_update(now, params_updated || param_init_forced);
 
 		// Handle shutdown request from emergency battery action
-		if(dangerous_battery_level_requests_poweroff){
+		if(!armed.armed && dangerous_battery_level_requests_poweroff){
 			mavlink_log_critical(&mavlink_log_pub, "DANGEROUSLY LOW BATTERY, SHUT SYSTEM DOWN");
 			usleep(200000);
 			int ret_val = px4_shutdown_request(false, false);
 
 			if (ret_val) {
 				mavlink_log_critical(&mavlink_log_pub, "SYSTEM DOES NOT SUPPORT SHUTDOWN");
+				dangerous_battery_level_requests_poweroff = false;
 
 			} else {
 				while (1) { usleep(1); }


### PR DESCRIPTION
Problem: When an emergency landing occurs as part of the battery failsafe, the vehicle will shutdown immediately after landing.
https://github.com/PX4/Firmware/blob/1ee08da9c4182f7e30c2b39462bdead069c9c588/src/modules/commander/commander.cpp#L1964-L1972

However, many state updates like `vehicle_status.msg` are published at the very end of the cycle:
https://github.com/PX4/Firmware/blob/1ee08da9c4182f7e30c2b39462bdead069c9c588/src/modules/commander/commander.cpp#L2632-L2677

In case of an emergency landing, the code in the second snippet for the updates is not executed, once disarmed. This means that QGC does not register the landed state and last seen state will be the landing in progress. In our case, this appears as a communication loss mid-flight, because armed, which our app treats differently compared to a communication loss when disarmed and landed.

In regard of the new DroneSDK, I would imagine that other apps might run into similar problems. 

The proposed solution in this PR is to finish the thread cycle and execute the shutdown command at the very end. It would probably make sense to do the same thing for all calls of `px4_shutdown_request()` in the commander to avoid similar problems in the future. 

@bkueng May I request your input? :)
