### PR TITLE
logger: fix SD card space computation

### DIFF
--- a/platforms/nuttx/Debug/Nuttx.py
+++ b/platforms/nuttx/Debug/Nuttx.py
@@ -81,7 +81,7 @@ class NX_register_set(object):
 			self.regs['LR']         = self.mon_reg_call('lr')
 			self.regs['R15']        = self.mon_reg_call('r15')
 			self.regs['PC']         = self.mon_reg_call('pc')
-			self.regs['XPSR']       = self.mon_reg_call('xPSR')
+			#self.regs['XPSR']       = self.mon_reg_call('xPSR')
 		else:
 			for key in self.v7em_regmap.keys():
 				self.regs[key] = int(xcpt_regs[self.v7em_regmap[key]])
@@ -91,11 +91,11 @@ class NX_register_set(object):
 		register is the register as a string e.g. 'pc'
 		return integer containing the value of the register
 		"""
-		str_to_eval = "mon reg "+register
+		str_to_eval = "info registers "+register
 		resp = gdb.execute(str_to_eval,to_string = True)
-		content = resp.split()[-1];
+		content = resp.split()[-1]
 		try:
-			return int(content,16)
+			return int(content)
 		except:
 			return 0
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -2117,7 +2117,7 @@ int Logger::check_free_space()
 
 
 		uint64_t min_free_bytes = 300ULL * 1024ULL * 1024ULL;
-		uint64_t total_bytes = statfs_buf.f_blocks * statfs_buf.f_bsize / 10;
+		uint64_t total_bytes = statfs_buf.f_blocks * statfs_buf.f_bsize;
 
 		if (total_bytes / 10 < min_free_bytes) { // reduce the minimum if it's larger than 10% of the disk size
 			min_free_bytes = total_bytes / 10;
@@ -2149,7 +2149,7 @@ int Logger::check_free_space()
 		}
 
 		PX4_INFO("removing log directory %s to get more space (left=%u MiB)", directory_to_delete,
-			 (unsigned int)(statfs_buf.f_bavail / 1024U * statfs_buf.f_bsize / 1024U));
+			 (unsigned int)(statfs_buf.f_bavail * statfs_buf.f_bsize / 1024U / 1024U));
 
 		if (remove_directory(directory_to_delete)) {
 			PX4_ERR("Failed to delete directory");
@@ -2163,7 +2163,7 @@ int Logger::check_free_space()
 	if (statfs_buf.f_bavail < (px4_statfs_buf_f_bavail_t)(50 * 1024 * 1024 / statfs_buf.f_bsize)) {
 		mavlink_log_critical(&_mavlink_log_pub,
 				     "[logger] Not logging; SD almost full: %u MiB",
-				     (unsigned int)(statfs_buf.f_bavail / 1024U * statfs_buf.f_bsize / 1024U));
+				     (unsigned int)(statfs_buf.f_bavail * statfs_buf.f_bsize / 1024U / 1024U));
 		return 1;
 	}
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -2117,7 +2117,7 @@ int Logger::check_free_space()
 
 
 		uint64_t min_free_bytes = 300ULL * 1024ULL * 1024ULL;
-		uint64_t total_bytes = statfs_buf.f_blocks * statfs_buf.f_bsize;
+		uint64_t total_bytes = (uint64_t)statfs_buf.f_blocks * statfs_buf.f_bsize;
 
 		if (total_bytes / 10 < min_free_bytes) { // reduce the minimum if it's larger than 10% of the disk size
 			min_free_bytes = total_bytes / 10;


### PR DESCRIPTION
- total space computation off by a factor of 10 (not sure how this could happen :)
- 32 bit integers overflow for cards > 4GB
- (unrelated) Nuttx.py debug script fixes

Thanks to @simonegu and his team for finding & fixing this!