### PR TITLE
Remove whitespace from the top-level CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,7 +466,7 @@ if ("${CMAKE_SYSTEM}" MATCHES "Linux")
 	if (EXISTS ${DPKG_PROGRAM})
 		list (APPEND CPACK_GENERATOR "DEB")
 	endif()
-else()	
+else()
 	set(CPACK_GENERATOR "ZIP")
 endif()
 


### PR DESCRIPTION
Hi,

This PR removes whitespace that git version 2.14.1 complains about.

Let me know if you have any questions!

-Mark