### PR TITLE
various getopt & argc index check fixes

### DIFF
--- a/src/drivers/barometer/bmp280/bmp280.cpp
+++ b/src/drivers/barometer/bmp280/bmp280.cpp
@@ -50,7 +50,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <unistd.h>
-#include <getopt.h>
+#include <px4_getopt.h>
 #include <px4_log.h>
 
 #include <nuttx/arch.h>
@@ -849,11 +849,12 @@ usage()
 int
 bmp280_main(int argc, char *argv[])
 {
-	enum BMP280_BUS busid = BMP280_BUS_ALL;
+	int myoptind = 1;
 	int ch;
+	const char *myoptarg = nullptr;
+	enum BMP280_BUS busid = BMP280_BUS_ALL;
 
-	/* jump over start/off/etc and look at options first */
-	while ((ch = getopt(argc, argv, "XISs")) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "XISs", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'X':
 			busid = BMP280_BUS_I2C_EXTERNAL;
@@ -861,8 +862,6 @@ bmp280_main(int argc, char *argv[])
 
 		case 'I':
 			busid = BMP280_BUS_I2C_INTERNAL;
-			//PX4_ERR("not supported yet");
-			//exit(1);
 			break;
 
 		case 'S':
@@ -875,11 +874,16 @@ bmp280_main(int argc, char *argv[])
 
 		default:
 			bmp280::usage();
-			exit(0);
+			return 0;
 		}
 	}
 
-	const char *verb = argv[optind];
+	if (myoptind >= argc) {
+		bmp280::usage();
+		return -1;
+	}
+
+	const char *verb = argv[myoptind];
 
 	/*
 	 * Start/load the driver.
@@ -910,5 +914,5 @@ bmp280_main(int argc, char *argv[])
 	}
 
 	PX4_ERR("unrecognized command, try 'start', 'test', 'reset' or 'info'");
-	exit(1);
+	return -1;
 }

--- a/src/drivers/barometer/lps22hb/LPS22HB.hpp
+++ b/src/drivers/barometer/lps22hb/LPS22HB.hpp
@@ -48,7 +48,6 @@
 #include <uORB/uORB.h>
 
 #include <float.h>
-#include <getopt.h>
 
 static constexpr uint8_t WHO_AM_I = 0x0F;
 static constexpr uint8_t LPS22HB_ID_WHO_AM_I = 0xB1;

--- a/src/drivers/barometer/lps22hb/lps22hb_main.cpp
+++ b/src/drivers/barometer/lps22hb/lps22hb_main.cpp
@@ -33,6 +33,8 @@
 
 #include "LPS22HB.hpp"
 
+#include <px4_getopt.h>
+
 #include <cstring>
 
 extern "C" __EXPORT int lps22hb_main(int argc, char *argv[]);
@@ -234,10 +236,13 @@ usage()
 int
 lps22hb_main(int argc, char *argv[])
 {
-	enum LPS22HB_BUS busid = LPS22HB_BUS_ALL;
+	int myoptind = 1;
 	int ch;
+	const char *myoptarg = nullptr;
 
-	while ((ch = getopt(argc, argv, "XIS:")) != EOF) {
+	enum LPS22HB_BUS busid = LPS22HB_BUS_ALL;
+
+	while ((ch = px4_getopt(argc, argv, "XIS:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 #if (PX4_I2C_BUS_ONBOARD || PX4_SPIDEV_HMC)
 
@@ -256,11 +261,16 @@ lps22hb_main(int argc, char *argv[])
 
 		default:
 			lps22hb::usage();
-			exit(0);
+			return 0;
 		}
 	}
 
-	const char *verb = argv[optind];
+	if (myoptind >= argc) {
+		lps22hb::usage();
+		return -1;
+	}
+
+	const char *verb = argv[myoptind];
 
 	/*
 	 * Start/load the driver.

--- a/src/drivers/barometer/ms5611/ms5611.cpp
+++ b/src/drivers/barometer/ms5611/ms5611.cpp
@@ -50,7 +50,6 @@
 #include <stdio.h>
 #include <math.h>
 #include <unistd.h>
-#include <getopt.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/wqueue.h>
@@ -1198,8 +1197,13 @@ ms5611_main(int argc, char *argv[])
 
 		default:
 			ms5611::usage();
-			exit(0);
+			return 0;
 		}
+	}
+
+	if (myoptind >= argc) {
+		ms5611::usage();
+		return -1;
 	}
 
 	const char *verb = argv[myoptind];
@@ -1232,5 +1236,6 @@ ms5611_main(int argc, char *argv[])
 		ms5611::info();
 	}
 
-	errx(1, "unrecognised command, try 'start', 'test', 'reset' or 'info'");
+	PX4_ERR("unrecognised command, try 'start', 'test', 'reset' or 'info'");
+	return -1;
 }

--- a/src/drivers/differential_pressure/ets/ets_airspeed.cpp
+++ b/src/drivers/differential_pressure/ets/ets_airspeed.cpp
@@ -46,6 +46,7 @@
 #include <systemlib/err.h>
 #include <parameters/param.h>
 #include <perf/perf_counter.h>
+#include <px4_getopt.h>
 
 #include <drivers/drv_airspeed.h>
 #include <drivers/drv_hrt.h>
@@ -357,38 +358,48 @@ ets_airspeed_main(int argc, char *argv[])
 {
 	int i2c_bus = PX4_I2C_BUS_DEFAULT;
 
-	int i;
+	int myoptind = 1;
+	int ch;
+	const char *myoptarg = nullptr;
 
-	for (i = 1; i < argc; i++) {
-		if (strcmp(argv[i], "-b") == 0 || strcmp(argv[i], "--bus") == 0) {
-			if (argc > i + 1) {
-				i2c_bus = atoi(argv[i + 1]);
-			}
+	while ((ch = px4_getopt(argc, argv, "b:", &myoptind, &myoptarg)) != EOF) {
+		switch (ch) {
+		case 'b':
+			i2c_bus = atoi(myoptarg);
+			break;
+
+		default:
+			ets_airspeed_usage();
+			return 0;
 		}
+	}
+
+	if (myoptind >= argc) {
+		ets_airspeed_usage();
+		return -1;
 	}
 
 	/*
 	 * Start/load the driver.
 	 */
-	if (!strcmp(argv[1], "start")) {
+	if (!strcmp(argv[myoptind], "start")) {
 		return ets_airspeed::start(i2c_bus);
 	}
 
 	/*
 	 * Stop the driver
 	 */
-	if (!strcmp(argv[1], "stop")) {
+	if (!strcmp(argv[myoptind], "stop")) {
 		return ets_airspeed::stop();
 	}
 
 	/*
 	 * Reset the driver.
 	 */
-	if (!strcmp(argv[1], "reset")) {
+	if (!strcmp(argv[myoptind], "reset")) {
 		return ets_airspeed::reset();
 	}
 
 	ets_airspeed_usage();
-
-	return PX4_OK;
+	return 0;
 }

--- a/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
+++ b/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
@@ -50,6 +50,7 @@
  */
 
 #include <px4_config.h>
+#include <px4_getopt.h>
 
 #include <drivers/device/i2c.h>
 
@@ -493,38 +494,48 @@ ms4525_airspeed_main(int argc, char *argv[])
 {
 	int i2c_bus = PX4_I2C_BUS_DEFAULT;
 
-	int i;
+	int myoptind = 1;
+	int ch;
+	const char *myoptarg = nullptr;
 
-	for (i = 1; i < argc; i++) {
-		if (strcmp(argv[i], "-b") == 0 || strcmp(argv[i], "--bus") == 0) {
-			if (argc > i + 1) {
-				i2c_bus = atoi(argv[i + 1]);
-			}
+	while ((ch = px4_getopt(argc, argv, "b:", &myoptind, &myoptarg)) != EOF) {
+		switch (ch) {
+		case 'b':
+			i2c_bus = atoi(myoptarg);
+			break;
+
+		default:
+			meas_airspeed_usage();
+			return 0;
 		}
+	}
+
+	if (myoptind >= argc) {
+		meas_airspeed_usage();
+		return -1;
 	}
 
 	/*
 	 * Start/load the driver.
 	 */
-	if (!strcmp(argv[1], "start")) {
+	if (!strcmp(argv[myoptind], "start")) {
 		return meas_airspeed::start(i2c_bus);
 	}
 
 	/*
 	 * Stop the driver
 	 */
-	if (!strcmp(argv[1], "stop")) {
+	if (!strcmp(argv[myoptind], "stop")) {
 		return meas_airspeed::stop();
 	}
 
 	/*
 	 * Reset the driver.
 	 */
-	if (!strcmp(argv[1], "reset")) {
+	if (!strcmp(argv[myoptind], "reset")) {
 		return meas_airspeed::reset();
 	}
 
 	meas_airspeed_usage();
-
-	return PX4_OK;
+	return 0;
 }

--- a/src/drivers/differential_pressure/ms5525/MS5525_main.cpp
+++ b/src/drivers/differential_pressure/ms5525/MS5525_main.cpp
@@ -33,6 +33,8 @@
 
 #include "MS5525.hpp"
 
+#include <px4_getopt.h>
+
 // Driver 'main' command.
 extern "C" __EXPORT int ms5525_airspeed_main(int argc, char *argv[]);
 
@@ -151,36 +153,48 @@ ms5525_airspeed_main(int argc, char *argv[])
 {
 	uint8_t i2c_bus = PX4_I2C_BUS_DEFAULT;
 
-	for (int i = 1; i < argc; i++) {
-		if (strcmp(argv[i], "-b") == 0 || strcmp(argv[i], "--bus") == 0) {
-			if (argc > i + 1) {
-				i2c_bus = atoi(argv[i + 1]);
-			}
+	int myoptind = 1;
+	int ch;
+	const char *myoptarg = nullptr;
+
+	while ((ch = px4_getopt(argc, argv, "b:", &myoptind, &myoptarg)) != EOF) {
+		switch (ch) {
+		case 'b':
+			i2c_bus = atoi(myoptarg);
+			break;
+
+		default:
+			ms5525_airspeed_usage();
+			return 0;
 		}
+	}
+
+	if (myoptind >= argc) {
+		ms5525_airspeed_usage();
+		return -1;
 	}
 
 	/*
 	 * Start/load the driver.
 	 */
-	if (!strcmp(argv[1], "start")) {
+	if (!strcmp(argv[myoptind], "start")) {
 		return ms5525_airspeed::start(i2c_bus);
 	}
 
 	/*
 	 * Stop the driver
 	 */
-	if (!strcmp(argv[1], "stop")) {
+	if (!strcmp(argv[myoptind], "stop")) {
 		return ms5525_airspeed::stop();
 	}
 
 	/*
 	 * Reset the driver.
 	 */
-	if (!strcmp(argv[1], "reset")) {
+	if (!strcmp(argv[myoptind], "reset")) {
 		return ms5525_airspeed::reset();
 	}
 
 	ms5525_airspeed_usage();
-
-	return PX4_OK;
+	return 0;
 }

--- a/src/drivers/differential_pressure/sdp3x/SDP3X_main.cpp
+++ b/src/drivers/differential_pressure/sdp3x/SDP3X_main.cpp
@@ -32,6 +32,7 @@
  ****************************************************************************/
 
 #include "SDP3X.hpp"
+#include <px4_getopt.h>
 
 // Driver 'main' command.
 extern "C" __EXPORT int sdp3x_airspeed_main(int argc, char *argv[]);
@@ -164,36 +165,49 @@ sdp3x_airspeed_main(int argc, char *argv[])
 {
 	uint8_t i2c_bus = PX4_I2C_BUS_DEFAULT;
 
-	for (int i = 1; i < argc; i++) {
-		if (strcmp(argv[i], "-b") == 0 || strcmp(argv[i], "--bus") == 0) {
-			if (argc > i + 1) {
-				i2c_bus = atoi(argv[i + 1]);
-			}
+	int myoptind = 1;
+	int ch;
+	const char *myoptarg = nullptr;
+
+	while ((ch = px4_getopt(argc, argv, "b:", &myoptind, &myoptarg)) != EOF) {
+		switch (ch) {
+		case 'b':
+			i2c_bus = atoi(myoptarg);
+			break;
+
+		default:
+			sdp3x_airspeed_usage();
+			return 0;
 		}
 	}
+
+	if (myoptind >= argc) {
+		sdp3x_airspeed_usage();
+		return -1;
+	}
+
 
 	/*
 	 * Start/load the driver.
 	 */
-	if (!strcmp(argv[1], "start")) {
+	if (!strcmp(argv[myoptind], "start")) {
 		return sdp3x_airspeed::start(i2c_bus);
 	}
 
 	/*
 	 * Stop the driver
 	 */
-	if (!strcmp(argv[1], "stop")) {
+	if (!strcmp(argv[myoptind], "stop")) {
 		return sdp3x_airspeed::stop();
 	}
 
 	/*
 	 * Reset the driver.
 	 */
-	if (!strcmp(argv[1], "reset")) {
+	if (!strcmp(argv[myoptind], "reset")) {
 		return sdp3x_airspeed::reset();
 	}
 
 	sdp3x_airspeed_usage();
-
-	return PX4_OK;
+	return 0;
 }

--- a/src/drivers/distance_sensor/mb12xx/mb12xx.cpp
+++ b/src/drivers/distance_sensor/mb12xx/mb12xx.cpp
@@ -879,23 +879,25 @@ info()
 int
 mb12xx_main(int argc, char *argv[])
 {
-	// check for optional arguments
 	int ch;
 	int myoptind = 1;
 	const char *myoptarg = nullptr;
 	uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
 
-
 	while ((ch = px4_getopt(argc, argv, "R:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'R':
 			rotation = (uint8_t)atoi(myoptarg);
-			PX4_INFO("Setting distance sensor orientation to %d", (int)rotation);
 			break;
 
 		default:
 			PX4_WARN("Unknown option!");
+			return -1;
 		}
+	}
+
+	if (myoptind >= argc) {
+		goto out_error;
 	}
 
 	/*
@@ -929,10 +931,11 @@ mb12xx_main(int argc, char *argv[])
 	/*
 	 * Print driver information.
 	 */
-	if (!strcmp(argv[myoptind], "info") || !strcmp(argv[1], "status")) {
+	if (!strcmp(argv[myoptind], "info") || !strcmp(argv[myoptind], "status")) {
 		mb12xx::info();
 	}
 
+out_error:
 	PX4_ERR("unrecognized command, try 'start', 'test', 'reset' or 'info'");
 	return PX4_ERROR;
 }

--- a/src/drivers/distance_sensor/sf0x/sf0x.cpp
+++ b/src/drivers/distance_sensor/sf0x/sf0x.cpp
@@ -947,23 +947,25 @@ info()
 int
 sf0x_main(int argc, char *argv[])
 {
-	// check for optional arguments
 	int ch;
 	uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
 	int myoptind = 1;
 	const char *myoptarg = nullptr;
 
-
 	while ((ch = px4_getopt(argc, argv, "R:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'R':
 			rotation = (uint8_t)atoi(myoptarg);
-			PX4_INFO("Setting distance sensor orientation to %d", (int)rotation);
 			break;
 
 		default:
 			PX4_WARN("Unknown option!");
+			return -1;
 		}
+	}
+
+	if (myoptind >= argc) {
+		goto out_error;
 	}
 
 	/*
@@ -1002,10 +1004,11 @@ sf0x_main(int argc, char *argv[])
 	/*
 	 * Print driver information.
 	 */
-	if (!strcmp(argv[myoptind], "info") || !strcmp(argv[1], "status")) {
+	if (!strcmp(argv[myoptind], "info") || !strcmp(argv[myoptind], "status")) {
 		sf0x::info();
 	}
 
+out_error:
 	PX4_ERR("unrecognized command, try 'start', 'test', 'reset' or 'info'");
-	return PX4_ERROR;
+	return -1;
 }

--- a/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
+++ b/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
@@ -816,23 +816,25 @@ info()
 int
 sf1xx_main(int argc, char *argv[])
 {
-	// check for optional arguments
 	int ch;
 	int myoptind = 1;
 	const char *myoptarg = nullptr;
 	uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
 
-
 	while ((ch = px4_getopt(argc, argv, "R:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'R':
 			rotation = (uint8_t)atoi(myoptarg);
-			PX4_INFO("Setting distance sensor orientation to %d", (int)rotation);
 			break;
 
 		default:
 			PX4_WARN("Unknown option!");
+			return -1;
 		}
+	}
+
+	if (myoptind >= argc) {
+		goto out_error;
 	}
 
 	/*
@@ -870,6 +872,7 @@ sf1xx_main(int argc, char *argv[])
 		sf1xx::info();
 	}
 
+out_error:
 	PX4_ERR("unrecognized command, try 'start', 'test', 'reset' or 'info'");
-	return PX4_ERROR;
+	return -1;
 }

--- a/src/drivers/distance_sensor/srf02/srf02.cpp
+++ b/src/drivers/distance_sensor/srf02/srf02.cpp
@@ -882,23 +882,25 @@ info()
 int
 srf02_main(int argc, char *argv[])
 {
-	// check for optional arguments
 	int ch;
 	int myoptind = 1;
 	const char *myoptarg = nullptr;
 	uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
 
-
 	while ((ch = px4_getopt(argc, argv, "R:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'R':
 			rotation = (uint8_t)atoi(myoptarg);
-			PX4_INFO("Setting distance sensor orientation to %d", (int)rotation);
 			break;
 
 		default:
 			PX4_WARN("Unknown option!");
+			return -1;
 		}
+	}
+
+	if (myoptind >= argc) {
+		goto out_error;
 	}
 
 	/*
@@ -936,6 +938,7 @@ srf02_main(int argc, char *argv[])
 		srf02::info();
 	}
 
+out_error:
 	PX4_ERR("unrecognized command, try 'start', 'test', 'reset' or 'info'");
 	return PX4_ERROR;
 }

--- a/src/drivers/distance_sensor/teraranger/teraranger.cpp
+++ b/src/drivers/distance_sensor/teraranger/teraranger.cpp
@@ -950,12 +950,16 @@ teraranger_main(int argc, char *argv[])
 		switch (ch) {
 		case 'R':
 			rotation = (uint8_t)atoi(myoptarg);
-			PX4_INFO("Setting sensor orientation to %d", (int)rotation);
 			break;
 
 		default:
 			PX4_WARN("Unknown option!");
+			return -1;
 		}
+	}
+
+	if (myoptind >= argc) {
+		goto out_error;
 	}
 
 	/*
@@ -989,10 +993,11 @@ teraranger_main(int argc, char *argv[])
 	/*
 	 * Print driver information.
 	 */
-	if (!strcmp(argv[myoptind], "info") || !strcmp(argv[1], "status")) {
+	if (!strcmp(argv[myoptind], "info") || !strcmp(argv[myoptind], "status")) {
 		teraranger::info();
 	}
 
+out_error:
 	PX4_ERR("unrecognized command, try 'start', 'test', 'reset' or 'info'");
-	return PX4_ERROR;
+	return -1;
 }

--- a/src/drivers/distance_sensor/tfmini/tfmini.cpp
+++ b/src/drivers/distance_sensor/tfmini/tfmini.cpp
@@ -922,29 +922,30 @@ usage()
 int
 tfmini_main(int argc, char *argv[])
 {
-	// check for optional arguments
 	int ch;
 	uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
 	const char *device_path = "";
 	int myoptind = 1;
 	const char *myoptarg = nullptr;
 
-
 	while ((ch = px4_getopt(argc, argv, "R:d:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'R':
 			rotation = (uint8_t)atoi(myoptarg);
-			PX4_INFO("Setting distance sensor orientation to %d", (int)rotation);
 			break;
 
 		case 'd':
 			device_path = myoptarg;
-			PX4_INFO("Using device path '%s'", device_path);
 			break;
 
 		default:
 			PX4_WARN("Unknown option!");
+			return -1;
 		}
+	}
+
+	if (myoptind >= argc) {
+		goto out_error;
 	}
 
 	/*
@@ -957,7 +958,7 @@ tfmini_main(int argc, char *argv[])
 		} else {
 			PX4_WARN("Please specify device path!");
 			tfmini::usage();
-			return PX4_ERROR;
+			return -1;
 		}
 	}
 
@@ -985,10 +986,11 @@ tfmini_main(int argc, char *argv[])
 	/*
 	 * Print driver information.
 	 */
-	if (!strcmp(argv[myoptind], "info") || !strcmp(argv[1], "status")) {
+	if (!strcmp(argv[myoptind], "info") || !strcmp(argv[myoptind], "status")) {
 		tfmini::info();
 	}
 
+out_error:
 	PX4_ERR("unrecognized command, try 'start', 'test', 'reset' or 'info'");
-	return PX4_ERROR;
+	return -1;
 }

--- a/src/drivers/imu/bma180/bma180.cpp
+++ b/src/drivers/imu/bma180/bma180.cpp
@@ -890,9 +890,12 @@ info()
 int
 bma180_main(int argc, char *argv[])
 {
+	if (argc < 2) {
+		goto out_error;
+	}
+
 	/*
 	 * Start/load the driver.
-
 	 */
 	if (!strcmp(argv[1], "start")) {
 		bma180::start();
@@ -919,5 +922,6 @@ bma180_main(int argc, char *argv[])
 		bma180::info();
 	}
 
+out_error:
 	errx(1, "unrecognised command, try 'start', 'test', 'reset' or 'info'");
 }

--- a/src/drivers/imu/bmi160/bmi160_main.cpp
+++ b/src/drivers/imu/bmi160/bmi160_main.cpp
@@ -2,6 +2,7 @@
 #include "bmi160.hpp"
 
 #include <board_config.h>
+#include <px4_getopt.h>
 
 /** driver 'main' command */
 extern "C" { __EXPORT int bmi160_main(int argc, char *argv[]); }
@@ -271,32 +272,37 @@ usage()
 int
 bmi160_main(int argc, char *argv[])
 {
-	bool external_bus = false;
+	int myoptind = 1;
 	int ch;
+	const char *myoptarg = nullptr;
+	bool external_bus = false;
 	enum Rotation rotation = ROTATION_NONE;
 
-	/* jump over start/off/etc and look at options first */
-	while ((ch = getopt(argc, argv, "XR:")) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "XR:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'X':
 			external_bus = true;
 			break;
 
 		case 'R':
-			rotation = (enum Rotation)atoi(optarg);
+			rotation = (enum Rotation)atoi(myoptarg);
 			break;
 
 		default:
 			bmi160::usage();
-			exit(0);
+			return 0;
 		}
 	}
 
-	const char *verb = argv[optind];
+	if (myoptind >= argc) {
+		bmi160::usage();
+		return -1;
+	}
+
+	const char *verb = argv[myoptind];
 
 	/*
 	 * Start/load the driver.
-
 	 */
 	if (!strcmp(verb, "start")) {
 		bmi160::start(external_bus, rotation);
@@ -339,5 +345,5 @@ bmi160_main(int argc, char *argv[])
 	}
 
 	bmi160::usage();
-	exit(1);
+	return -1;
 }

--- a/src/drivers/imu/mpu6000/mpu6000.cpp
+++ b/src/drivers/imu/mpu6000/mpu6000.cpp
@@ -71,7 +71,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <unistd.h>
-#include <getopt.h>
+#include <px4_getopt.h>
 
 #include <perf/perf_counter.h>
 #include <systemlib/err.h>
@@ -2590,14 +2590,16 @@ usage()
 int
 mpu6000_main(int argc, char *argv[])
 {
+	int myoptind = 1;
+	int ch;
+	const char *myoptarg = nullptr;
+
 	enum MPU6000_BUS busid = MPU6000_BUS_ALL;
 	int device_type = MPU_DEVICE_TYPE_MPU6000;
-	int ch;
 	enum Rotation rotation = ROTATION_NONE;
 	int accel_range = MPU6000_ACCEL_DEFAULT_RANGE_G;
 
-	/* jump over start/off/etc and look at options first */
-	while ((ch = getopt(argc, argv, "T:XISsZzR:a:")) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "T:XISsZzR:a:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'X':
 			busid = MPU6000_BUS_I2C_EXTERNAL;
@@ -2624,28 +2626,32 @@ mpu6000_main(int argc, char *argv[])
 			break;
 
 		case 'T':
-			device_type = atoi(optarg);
+			device_type = atoi(myoptarg);
 			break;
 
 		case 'R':
-			rotation = (enum Rotation)atoi(optarg);
+			rotation = (enum Rotation)atoi(myoptarg);
 			break;
 
 		case 'a':
-			accel_range = atoi(optarg);
+			accel_range = atoi(myoptarg);
 			break;
 
 		default:
 			mpu6000::usage();
-			exit(0);
+			return 0;
 		}
 	}
 
-	const char *verb = argv[optind];
+	if (myoptind >= argc) {
+		mpu6000::usage();
+		return -1;
+	}
+
+	const char *verb = argv[myoptind];
 
 	/*
 	 * Start/load the driver.
-
 	 */
 	if (!strcmp(verb, "start")) {
 		mpu6000::start(busid, rotation, accel_range, device_type);
@@ -2692,5 +2698,5 @@ mpu6000_main(int argc, char *argv[])
 	}
 
 	mpu6000::usage();
-	exit(1);
+	return -1;
 }

--- a/src/drivers/imu/mpu9250/mpu9250.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250.cpp
@@ -57,7 +57,6 @@
 #include <stdio.h>
 #include <math.h>
 #include <unistd.h>
-#include <getopt.h>
 
 #include <perf/perf_counter.h>
 #include <systemlib/err.h>

--- a/src/drivers/magnetometer/bmm150/bmm150.cpp
+++ b/src/drivers/magnetometer/bmm150/bmm150.cpp
@@ -37,6 +37,7 @@
  */
 
 #include "bmm150.hpp"
+#include <px4_getopt.h>
 
 /** driver 'main' command */
 extern "C" { __EXPORT int bmm150_main(int argc, char *argv[]); }
@@ -1128,28 +1129,34 @@ BMM150::print_registers()
 int
 bmm150_main(int argc, char *argv[])
 {
-	bool external_bus = false;
+	int myoptind = 1;
 	int ch;
+	const char *myoptarg = nullptr;
+	bool external_bus = false;
 	enum Rotation rotation = ROTATION_NONE;
 
-	/* jump over start/off/etc and look at options first */
-	while ((ch = getopt(argc, argv, "XR:")) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "XR:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'X':
 			external_bus = true;
 			break;
 
 		case 'R':
-			rotation = (enum Rotation)atoi(optarg);
+			rotation = (enum Rotation)atoi(myoptarg);
 			break;
 
 		default:
 			bmm150::usage();
-			exit(0);
+			return 0;
 		}
 	}
 
-	const char *verb = argv[optind];
+	if (myoptind >= argc) {
+		bmm150::usage();
+		return -1;
+	}
+
+	const char *verb = argv[myoptind];
 
 	/*
 	 * Start/load the driver.
@@ -1189,5 +1196,5 @@ bmm150_main(int argc, char *argv[])
 
 
 	bmm150::usage();
-	exit(1);
+	return -1;
 }

--- a/src/drivers/magnetometer/bmm150/bmm150.hpp
+++ b/src/drivers/magnetometer/bmm150/bmm150.hpp
@@ -16,7 +16,6 @@
 #include <stdio.h>
 #include <math.h>
 #include <unistd.h>
-#include <getopt.h>
 #include <px4_log.h>
 
 #include <perf/perf_counter.h>

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl.h
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl.h
@@ -40,7 +40,6 @@
 #pragma once
 
 #include <float.h>
-#include <getopt.h>
 
 #include <drivers/device/i2c.h>
 #include <drivers/device/ringbuffer.h>

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl_main.cpp
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl_main.cpp
@@ -38,6 +38,7 @@
  */
 
 #include "lis3mdl_main.h"
+#include <px4_getopt.h>
 
 /**
  * Driver 'main' command.
@@ -295,16 +296,18 @@ lis3mdl::usage()
 int
 lis3mdl_main(int argc, char *argv[])
 {
-	int index = 0;
-	bool calibrate = false;
+	int myoptind = 1;
+	int ch;
+	const char *myoptarg = nullptr;
 
+	bool calibrate = false;
 	enum LIS3MDL_BUS bus_id = LIS3MDL_BUS_ALL;
 	enum Rotation rotation = ROTATION_NONE;
 
-	while ((index = getopt(argc, argv, "XISR:CT")) != EOF) {
-		switch (index) {
+	while ((ch = px4_getopt(argc, argv, "XISR:CT", &myoptind, &myoptarg)) != EOF) {
+		switch (ch) {
 		case 'R':
-			rotation = (enum Rotation)atoi(optarg);
+			rotation = (enum Rotation)atoi(myoptarg);
 			break;
 #if (PX4_I2C_BUS_ONBOARD || PX4_SPIDEV_LIS)
 
@@ -331,10 +334,15 @@ lis3mdl_main(int argc, char *argv[])
 		}
 	}
 
-	const char *arg = argv[optind];
+	if (myoptind >= argc) {
+		lis3mdl::usage();
+		return -1;
+	}
+
+	const char *verb = argv[myoptind];
 
 	// Start/load the driver
-	if (!strcmp(arg, "start")) {
+	if (!strcmp(verb, "start")) {
 
 		if (lis3mdl::start(bus_id, rotation)) {
 			if (calibrate) {
@@ -354,28 +362,28 @@ lis3mdl_main(int argc, char *argv[])
 	}
 
 	// Stop the driver
-	if (!strcmp(arg, "stop")) {
+	if (!strcmp(verb, "stop")) {
 		return lis3mdl::stop();
 	}
 
 	// Test the driver/device
-	if (!strcmp(arg, "test")) {
+	if (!strcmp(verb, "test")) {
 		return lis3mdl::test(bus_id);
 	}
 
 	// Reset the driver
-	if (!strcmp(arg, "reset")) {
+	if (!strcmp(verb, "reset")) {
 		return lis3mdl::reset(bus_id);
 	}
 
 	// Print driver information
-	if (!strcmp(arg, "info") ||
-	    !strcmp(arg, "status")) {
+	if (!strcmp(verb, "info") ||
+	    !strcmp(verb, "status")) {
 		return lis3mdl::info(bus_id);
 	}
 
 	// Autocalibrate the scaling
-	if (!strcmp(arg, "calibrate")) {
+	if (!strcmp(verb, "calibrate")) {
 		if (lis3mdl::calibrate(bus_id) == 0) {
 			PX4_INFO("calibration successful");
 			return 0;

--- a/src/drivers/pwm_input/pwm_input.cpp
+++ b/src/drivers/pwm_input/pwm_input.cpp
@@ -267,6 +267,7 @@ static void pwmin_start();
 static void pwmin_info(void);
 static void pwmin_test(void);
 static void pwmin_reset(void);
+static void pwmin_usage(void);
 
 static PWMIN *g_dev;
 
@@ -647,12 +648,21 @@ static void pwmin_info(void)
 	exit(0);
 }
 
+static void pwmin_usage()
+{
+	PX4_ERR("unrecognized command, try 'start', 'info', 'reset' or 'test'");
+}
 
 /*
  * driver entry point
  */
 int pwm_input_main(int argc, char *argv[])
 {
+	if (argc < 2) {
+		pwmin_usage();
+		return -1;
+	}
+
 	const char *verb = argv[1];
 
 	/*
@@ -683,6 +693,6 @@ int pwm_input_main(int argc, char *argv[])
 		pwmin_reset();
 	}
 
-	errx(1, "unrecognized command, try 'start', 'info', 'reset' or 'test'");
-	return 0;
+	pwmin_usage();
+	return -1;
 }

--- a/src/drivers/telemetry/iridiumsbd/IridiumSBD.cpp
+++ b/src/drivers/telemetry/iridiumsbd/IridiumSBD.cpp
@@ -1076,6 +1076,10 @@ int	IridiumSBD::close_last(struct file *filep)
 
 int iridiumsbd_main(int argc, char *argv[])
 {
+	if (argc < 2) {
+		goto out_error;
+	}
+
 	if (!strcmp(argv[1], "start")) {
 		return IridiumSBD::start(argc, argv);
 
@@ -1091,6 +1095,7 @@ int iridiumsbd_main(int argc, char *argv[])
 		return OK;
 	}
 
+out_error:
 	PX4_INFO("usage: iridiumsbd {start|stop|status|test} [-d uart_device]");
 
 	return PX4_ERROR;

--- a/src/drivers/test_ppm/test_ppm.cpp
+++ b/src/drivers/test_ppm/test_ppm.cpp
@@ -249,23 +249,26 @@ usage()
 int
 test_ppm_main(int argc, char *argv[])
 {
+	if (argc < 2) {
+		test_ppm::usage();
+		return -1;
+	}
+
 	const char *verb = argv[1];
 	unsigned  channels = 7;
 
 	/*
 	 * Start/load the driver.
-
 	 */
-
 	if (!strcmp(verb, "start")) {
 		test_ppm::start(channels);
-		exit(0);
+		return 0;
 	}
 
 	if (!strcmp(verb, "stop")) {
 
 		test_ppm::stop();
-		exit(0);
+		return 0;
 	}
 
 	/*
@@ -280,11 +283,9 @@ test_ppm_main(int argc, char *argv[])
 		unsigned value	= strtol(argv[3], NULL, 0);
 
 		test_ppm::set(channel, value);
-		exit(0);
+		return 0;
 	}
 
-
-
 	test_ppm::usage();
-	exit(1);
+	return -1;
 }

--- a/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
+++ b/src/modules/position_estimator_inav/position_estimator_inav_main.cpp
@@ -134,6 +134,7 @@ int position_estimator_inav_main(int argc, char *argv[])
 {
 	if (argc < 2) {
 		usage("missing command");
+		return -1;
 	}
 
 	if (!strcmp(argv[1], "start")) {

--- a/src/platforms/common/px4_getopt.c
+++ b/src/platforms/common/px4_getopt.c
@@ -82,6 +82,10 @@ static int reorder(int argc, char **argv, const char *options)
 			tmpidx++;
 
 			if (takesarg) {
+				if (idx + 1 >= argc) { //Error: option takes an argument, but there is no more argument
+					return 1;
+				}
+
 				tmp_argv[tmpidx] = argv[idx + 1];
 				// printf("tmp_argv[%d] = %s\n", tmpidx, tmp_argv[tmpidx]);
 				tmpidx++;


### PR DESCRIPTION
The following commands would all lead to a crash when called w/o argument:
  bma180
  bmi160
  bmm150
  bmp280
  ets_airspeed
  iridiumsbd
  lis3mdl
  lps22hb
  mb12xx
  mpu6000
  mpu9250
  ms4525_airspeed
  ms5525_airspeed
  ms5611
  position_estimator_inav
  pwm_input
  sdp3x_airspeed
  sf0x
  teraranger
  tfmini
  sf1xx
  srf02
  test_ppm

This PR fixes all of these and switches from `getopt` to `px4_getopt`. In addition, there's a fix for a corner case in `px4_getopt`.

Fixes: https://github.com/PX4/Firmware/issues/9532