### PR TITLE
Remove extra newline in omnibus-f4sd/usb.c to quiet git warning.

### DIFF
--- a/src/drivers/boards/omnibus-f4sd/usb.c
+++ b/src/drivers/boards/omnibus-f4sd/usb.c
@@ -105,4 +105,3 @@ __EXPORT void stm32_usbsuspend(FAR struct usbdev_s *dev, bool resume)
 {
 	uinfo("resume: %d\n", resume);
 }
-


### PR DESCRIPTION
Hi,

This PR removes an extra newline in omnibus-f4sd/usb.c to quiet git new blank line at EOF warning:
`src/drivers/boards/omnibus-f4sd/usb.c:108: new blank line at EOF.`

Let me know if you have any questions!

-Mark