### PR TITLE
mavlink_receiver: implement MAV_CMD_REQUEST_STORAGE_INFORMATION

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -190,6 +190,8 @@ private:
 
 	void send_flight_information();
 
+	void send_storage_information(int storage_id);
+
 	Mavlink	*_mavlink;
 
 	MavlinkMissionManager		*_mission_manager;


### PR DESCRIPTION
Tested on Pixracer and Pixhawk.
Can be used for example in QGC to check if an SD card is inserted.