### PR TITLE
fix rgbled On and Powersave value in read mode

### DIFF
--- a/src/drivers/rgbled/rgbled.cpp
+++ b/src/drivers/rgbled/rgbled.cpp
@@ -388,8 +388,8 @@ RGBLED::get(bool &on, bool &powersave, uint8_t &r, uint8_t &g, uint8_t &b)
 	ret = transfer(nullptr, 0, &result[0], 2);
 
 	if (ret == OK) {
-		on = result[0] & SETTING_ENABLE;
-		powersave = !(result[0] & SETTING_NOT_POWERSAVE);
+		on = ((result[0] >> 4) & SETTING_ENABLE);
+		powersave = !((result[0] >> 4) & SETTING_NOT_POWERSAVE);
 		/* XXX check, looks wrong */
 		r = (result[0] & 0x0f) << 4;
 		g = (result[1] & 0xf0);


### PR DESCRIPTION
fix rgbled On and Powersave value in read mode.
In read mode, the ENABLE and SHDN is in bit 4 and bit5, so we may need a 4bit right shift to get a correct value.