### PR TITLE
fw_att_control: Fix stuttering rudder in manual mode

### DIFF
--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -261,14 +261,10 @@ FixedwingAttitudeControl::vehicle_control_mode_poll()
 void
 FixedwingAttitudeControl::vehicle_manual_poll()
 {
-	bool manual_updated;
-
-	/* get pilots inputs */
-	orb_check(_manual_sub, &manual_updated);
-
 	// only update manual if in a manual mode
-	if (_vcontrol_mode.flag_control_manual_enabled && manual_updated) {
+	if (_vcontrol_mode.flag_control_manual_enabled) {
 
+		// Always copy the new manual setpoint, even it it wasn't updated, to fill the _actuators with valid values
 		if (orb_copy(ORB_ID(manual_control_setpoint), _manual_sub, &_manual) == PX4_OK) {
 
 			// Check if we are in rattitude mode and the pilot is above the threshold on pitch

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -264,7 +264,7 @@ FixedwingAttitudeControl::vehicle_manual_poll()
 	// only update manual if in a manual mode
 	if (_vcontrol_mode.flag_control_manual_enabled) {
 
-		// Always copy the new manual setpoint, even it wasn't updated, to fill the _actuators with valid values
+		// Always copy the new manual setpoint, even if it wasn't updated, to fill the _actuators with valid values
 		if (orb_copy(ORB_ID(manual_control_setpoint), _manual_sub, &_manual) == PX4_OK) {
 
 			// Check if we are in rattitude mode and the pilot is above the threshold on pitch

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -264,7 +264,7 @@ FixedwingAttitudeControl::vehicle_manual_poll()
 	// only update manual if in a manual mode
 	if (_vcontrol_mode.flag_control_manual_enabled) {
 
-		// Always copy the new manual setpoint, even it it wasn't updated, to fill the _actuators with valid values
+		// Always copy the new manual setpoint, even it wasn't updated, to fill the _actuators with valid values
 		if (orb_copy(ORB_ID(manual_control_setpoint), _manual_sub, &_manual) == PX4_OK) {
 
 			// Check if we are in rattitude mode and the pilot is above the threshold on pitch


### PR DESCRIPTION
Fixes the bug that caused the rudder to stutter when FW_RLL_TO_YAW_FF>0 and aileron input was supplied, i.e. the issue described in detail in https://github.com/PX4/Firmware/issues/9601. It was tested on ground and in HIL in all flight modes.