### PR TITLE
Cmake nuttx upload: add verbatim parameter

### DIFF
--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -183,6 +183,7 @@ if (TARGET parameters_xml AND TARGET airframes_xml)
 				${PX4_SOURCE_DIR}/Tools/px_uploader.py --port ${serial_ports} ${fw_file}
 			DEPENDS ${fw_file}
 			COMMENT "uploading px4"
+			VERBATIM
 			USES_TERMINAL
 			)
 	endif()


### PR DESCRIPTION
to disable automatic evaluation of /dev/ttyS* expression in **cygwin**.
On linux verbatim seems to be default anyways. At least it doesn't get
evaluated on linux.