### PR TITLE
Arming Logic updates (for arming via switch)

### DIFF
--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2271,9 +2271,9 @@ Commander::run()
 				}
 
 				stick_off_counter++;
-				/* do not reset the counter when holding the arm button longer than needed */
 
 			} else if (!(arm_switch_is_button == 1 && sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_ON)) {
+				/* do not reset the counter when holding the arm button longer than needed */
 				stick_off_counter = 0;
 			}
 

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -2237,14 +2237,17 @@ Commander::run()
 			status.rc_signal_lost = false;
 
 			const bool in_armed_state = (status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
+			const bool arm_switch_or_button_mapped = sp_man.arm_switch != manual_control_setpoint_s::SWITCH_POS_NONE;
 			const bool arm_button_pressed = arm_switch_is_button == 1
 							&& sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_ON;
 
 			/* DISARM
 			 * check if left stick is in lower left position or arm button is pushed or arm switch has transition from arm to disarm
 			 * and we are in MANUAL, Rattitude, or AUTO_READY mode or (ASSIST mode and landed)
-			 * do it only for rotary wings in manual mode or fixed wing if landed */
-			const bool stick_in_lower_left = sp_man.r < -STICK_ON_OFF_LIMIT && sp_man.z < 0.1f;
+			 * do it only for rotary wings in manual mode or fixed wing if landed.
+			 * Disable stick-disarming if arming switch or button is mapped */
+			const bool stick_in_lower_left = sp_man.r < -STICK_ON_OFF_LIMIT && sp_man.z < 0.1f
+					&& !arm_switch_or_button_mapped;
 			const bool arm_switch_to_disarm_transition =  arm_switch_is_button == 0 &&
 					_last_sp_man_arm_switch == manual_control_setpoint_s::SWITCH_POS_ON &&
 					sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_OFF;
@@ -2276,14 +2279,17 @@ Commander::run()
 
 			/* ARM
 			 * check if left stick is in lower right position or arm button is pushed or arm switch has transition from disarm to arm
-			 * and we're in MANUAL mode */
-			const bool stick_in_lower_right = (sp_man.r > STICK_ON_OFF_LIMIT && sp_man.z < 0.1f);
+			 * and we're in MANUAL mode.
+			 * Disable stick-arming if arming switch or button is mapped */
+			const bool stick_in_lower_right = sp_man.r > STICK_ON_OFF_LIMIT && sp_man.z < 0.1f
+					&& !arm_switch_or_button_mapped;
 			/* allow a grace period for re-arming: preflight checks don't need to pass during that time,
 			 * for example for accidential in-air disarming */
 			const bool in_arming_grace_period = last_disarmed_timestamp != 0 && hrt_elapsed_time(&last_disarmed_timestamp) < 5_s;
 			const bool arm_switch_to_arm_transition = arm_switch_is_button == 0 &&
 					_last_sp_man_arm_switch == manual_control_setpoint_s::SWITCH_POS_OFF &&
-					sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_ON;
+					sp_man.arm_switch == manual_control_setpoint_s::SWITCH_POS_ON &&
+					(sp_man.z < 0.1f || in_arming_grace_period);
 
 			if (!in_armed_state &&
 			    status.rc_input_mode != vehicle_status_s::RC_IN_MODE_OFF &&

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -4057,7 +4057,9 @@ bool Commander::preflight_check(bool report)
 	bool success = Preflight::preflightCheck(&mavlink_log_pub, status, status_flags, checkGNSS, report, false,
 			hrt_elapsed_time(&commander_boot_timestamp));
 
-	status_flags.condition_system_sensors_initialized = success;
+	if (success) {
+		status_flags.condition_system_sensors_initialized = true;
+	}
 
 	return success;
 }

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -137,8 +137,9 @@ transition_result_t arming_state_transition(vehicle_status_s *status, const batt
 
 		/* re-run the pre-flight check as long as sensors are failing */
 		if (!status_flags->condition_system_sensors_initialized
-		    && ((new_arming_state == vehicle_status_s::ARMING_STATE_ARMED) || (new_arming_state == vehicle_status_s::ARMING_STATE_STANDBY))
-		    && !hil_enabled) {
+			&& fRunPreArmChecks
+			&& ((new_arming_state == vehicle_status_s::ARMING_STATE_ARMED) || (new_arming_state == vehicle_status_s::ARMING_STATE_STANDBY))
+			&& !hil_enabled) {
 
 			if ((last_preflight_check == 0) || (hrt_elapsed_time(&last_preflight_check) > 1000 * 1000)) {
 

--- a/src/modules/sensors/rc_params.c
+++ b/src/modules/sensors/rc_params.c
@@ -1556,7 +1556,10 @@ PARAM_DEFINE_INT32(RC_MAP_OFFB_SW, 0);
 PARAM_DEFINE_INT32(RC_MAP_KILL_SW, 0);
 
 /**
- * Arm switch channel
+ * Arm switch channel.
+ *
+ * Use it to arm/disarm via switch instead of default throttle stick. If this is
+ * assigned, arming and disarming via stick is disabled.
  *
  * @min 0
  * @max 18


### PR DESCRIPTION
This updates the arming/disarming logic, mostly with regard to arming via switch:
- disable stick (dis-)arming when arming via switch is enabled (a reason to use a switch in the first place is that you cannot accidentally disarm in-air via stick)
- require low throttle when arming via switch
- add a re-arming grace period: during 5 seconds after disarming the preflight checks don't need to pass to arm again. This allows to recover from accidental in-air disarming.

Please review individual commits, the commit messages contain more infos.

Tested in HIL, both switch & stick (dis-)arming in position, manual & acro modes.

This is not meant to go into v1.8.

@MaEtUgR 

