### PR TITLE
airframes: update 4050 generic 250 racer defaults

### DIFF
--- a/ROMFS/px4fmu_common/init.d/4050_generic_250
+++ b/ROMFS/px4fmu_common/init.d/4050_generic_250
@@ -13,32 +13,38 @@ sh /etc/init.d/4001_quad_x
 if [ $AUTOCNF == yes ]
 then
 	param set MC_ROLL_P 8.0
-	param set MC_ROLLRATE_P 0.19
-	param set MC_ROLLRATE_I 0.1
-	param set MC_ROLLRATE_D 0.0055
+	param set MC_ROLLRATE_P 0.08
+	param set MC_ROLLRATE_I 0.25
+	param set MC_ROLLRATE_D 0.001
 	param set MC_PITCH_P 8.0
-	param set MC_PITCHRATE_P 0.19
-	param set MC_PITCHRATE_I 0.1
-	param set MC_PITCHRATE_D 0.0055
+	param set MC_PITCHRATE_P 0.08
+	param set MC_PITCHRATE_I 0.25
+	param set MC_PITCHRATE_D 0.001
 	param set MC_YAW_P 4.0
 	param set MC_YAWRATE_P 0.2
 	param set MC_YAWRATE_I 0.1
 	param set MC_YAWRATE_D 0.0
 	param set MC_YAW_FF 0.5
-	param set MC_ROLLRATE_MAX 720.0
-	param set MC_PITCHRATE_MAX 720.0
-	param set MC_YAWRATE_MAX 400.0
-	param set MC_ACRO_R_MAX 360.0
-	param set MC_ACRO_P_MAX 360.0
-	param set MC_TPA_BREAK_P 0.5
-	param set MC_TPA_RATE_P 0.5
+
+	param set MC_ROLLRATE_MAX 1600.0
+	param set MC_PITCHRATE_MAX 1600.0
+	param set MC_YAWRATE_MAX 1000.0
+
+	param set MPC_MANTHR_MIN 0.0
+	param set MPC_MAN_TILT_MAX 60
+
+	# use thrust curve factor (instead of TPA)
+	param set THR_MDL_FAC 0.3
 
 	param set PWM_MIN 1075
+	# enable one-shot
+	param set PWM_RATE 0
 
-	param set MPC_THR_MIN 0.06
-	param set MPC_MANTHR_MIN 0.06
+	# enable high-rate logging profile (helps with tuning)
+	param set SDLOG_PROFILE 19
 
-	param set ATT_BIAS_MAX 0.0
+	# disable RC filtering
+	param set RC_FLT_CUTOFF 0.00000
 
 	param set CBRK_IO_SAFETY 22027
 fi


### PR DESCRIPTION
- P and D gains are too high for a racer
- default I gain is too low (0.25 is still quite low)
- use the thrust curve param instead of TPA
- improve responsiveness in Manual & increase max tilt angle to 60 degrees
- enable one-shot
- enable high-rate logging profile
- disable RC filter