### PR TITLE
uORB generated headers use full topic name in C defines

### DIFF
--- a/msg/templates/uorb/msg.h.template
+++ b/msg/templates/uorb/msg.h.template
@@ -57,6 +57,7 @@ import gencpp
 from px_generate_uorb_topic_helper import * # this is in Tools/
 
 uorb_struct = '%s_s'%spec.short_name
+uorb_struct_upper = spec.short_name.upper()
 topic_name = spec.short_name
 }@
 
@@ -83,7 +84,7 @@ for field in spec.parsed_fields():
 @# Constants c style
 #ifndef __cplusplus
 @[for constant in spec.constants]@
-#define @(constant.name) @(int(constant.val))
+#define @(uorb_struct_upper)_@(constant.name) @(int(constant.val))
 @[end for]
 #endif
 

--- a/src/modules/commander/CMakeLists.txt
+++ b/src/modules/commander/CMakeLists.txt
@@ -38,20 +38,21 @@ px4_add_module(
 	COMPILE_FLAGS
 		-Wno-sign-compare # TODO: fix all sign-compare
 	SRCS
-		commander.cpp
-		state_machine_helper.cpp
-		commander_helper.cpp
-		calibration_routines.cpp
 		accelerometer_calibration.cpp
-		gyro_calibration.cpp
-		mag_calibration.cpp
-		baro_calibration.cpp
-		rc_calibration.cpp
 		airspeed_calibration.cpp
-		esc_calibration.cpp
-		PreflightCheck.cpp
 		arm_auth.cpp
+		baro_calibration.cpp
+		calibration_routines.cpp
+		commander.cpp
+		commander_helper.cpp
+		esc_calibration.cpp
+		gyro_calibration.cpp
 		health_flag_helper.cpp
+		mag_calibration.cpp
+		PreflightCheck.cpp
+		rc_calibration.cpp
+		rc_check.cpp
+		state_machine_helper.cpp
 	DEPENDS
 		df_driver_framework
 		git_ecl

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -42,18 +42,8 @@
 
 #include <px4_config.h>
 #include <px4_posix.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <fcntl.h>
-#include <errno.h>
-#include <math.h>
-#include <poll.h>
 
-#include <systemlib/err.h>
 #include <parameters/param.h>
-#include <systemlib/rc_check.h>
 #include <systemlib/mavlink_log.h>
 
 #include <drivers/drv_hrt.h>
@@ -73,6 +63,7 @@
 
 #include "PreflightCheck.h"
 #include "health_flag_helper.h"
+#include "rc_check.h"
 
 #include "DevMgr.hpp"
 

--- a/src/modules/commander/commander.cpp
+++ b/src/modules/commander/commander.cpp
@@ -78,8 +78,6 @@
 #include <systemlib/hysteresis/hysteresis.h>
 #include <systemlib/mavlink_log.h>
 #include <parameters/param.h>
-#include <systemlib/rc_check.h>
-#include <systemlib/state_table.h>
 
 #include <cmath>
 #include <cfloat>

--- a/src/modules/commander/rc_check.cpp
+++ b/src/modules/commander/rc_check.cpp
@@ -37,6 +37,8 @@
  * RC calibration check
  */
 
+#include "rc_check.h"
+
 #include <px4_config.h>
 #include <px4_time.h>
 
@@ -45,7 +47,7 @@
 #include <fcntl.h>
 
 #include <systemlib/err.h>
-#include <systemlib/rc_check.h>
+
 #include <parameters/param.h>
 #include <systemlib/mavlink_log.h>
 #include <drivers/drv_rc_input.h>
@@ -54,7 +56,6 @@
 
 int rc_calibration_check(orb_advert_t *mavlink_log_pub, bool report_fail, bool isVTOL)
 {
-
 	char nbuf[20];
 	param_t _parameter_handles_min, _parameter_handles_trim, _parameter_handles_max,
 		_parameter_handles_rev, _parameter_handles_dz;
@@ -63,7 +64,7 @@ int rc_calibration_check(orb_advert_t *mavlink_log_pub, bool report_fail, bool i
 
 	const char *rc_map_mandatory[] = {	/*"RC_MAP_MODE_SW",*/
 		/* needs discussion if this should be mandatory "RC_MAP_POSCTL_SW"*/
-		0 /* end marker */
+		nullptr /* end marker */
 	};
 
 	unsigned j = 0;
@@ -93,7 +94,7 @@ int rc_calibration_check(orb_advert_t *mavlink_log_pub, bool report_fail, bool i
 
 
 	/* first check channel mappings */
-	while (rc_map_mandatory[j] != 0) {
+	while (rc_map_mandatory[j] != nullptr) {
 
 		param_t map_parm = param_find(rc_map_mandatory[j]);
 
@@ -110,7 +111,7 @@ int rc_calibration_check(orb_advert_t *mavlink_log_pub, bool report_fail, bool i
 		int32_t mapping;
 		param_get(map_parm, &mapping);
 
-		if (mapping > RC_INPUT_MAX_CHANNELS) {
+		if (mapping > input_rc_s::RC_INPUT_MAX_CHANNELS) {
 			if (report_fail) { mavlink_log_critical(mavlink_log_pub, "RC ERROR: %s >= NUMBER OF CHANNELS.", rc_map_mandatory[j]); }
 
 			/* give system time to flush error message in case there are more */
@@ -132,7 +133,7 @@ int rc_calibration_check(orb_advert_t *mavlink_log_pub, bool report_fail, bool i
 	unsigned total_fail_count = 0;
 	unsigned channels_failed = 0;
 
-	for (unsigned i = 0; i < RC_INPUT_MAX_CHANNELS; i++) {
+	for (unsigned i = 0; i < input_rc_s::RC_INPUT_MAX_CHANNELS; i++) {
 		/* should the channel be enabled? */
 		uint8_t count = 0;
 

--- a/src/modules/commander/rc_check.h
+++ b/src/modules/commander/rc_check.h
@@ -36,12 +36,9 @@
  *
  * RC calibration check
  */
-#include <stdbool.h>
 #include <uORB/uORB.h>
 
 #pragma once
-
-__BEGIN_DECLS
 
 /**
  * Check the RC calibration
@@ -49,6 +46,4 @@ __BEGIN_DECLS
  * @return			0 / OK if RC calibration is ok, index + 1 of the first
  *				channel that failed else (so 1 == first channel failed)
  */
-__EXPORT int	rc_calibration_check(orb_advert_t *mavlink_log_pub, bool report_fail, bool isVTOL);
-
-__END_DECLS
+int	rc_calibration_check(orb_advert_t *mavlink_log_pub, bool report_fail, bool isVTOL);

--- a/src/modules/gpio_led/gpio_led.c
+++ b/src/modules/gpio_led/gpio_led.c
@@ -304,8 +304,8 @@ void gpio_led_cycle(FAR void *arg)
 	/* select pattern for current vehiclestatus */
 	int pattern = 0;
 
-	if (priv->vehicle_status.arming_state == ARMING_STATE_ARMED) {
-		if (priv->battery_status.warning == BATTERY_WARNING_NONE
+	if (priv->vehicle_status.arming_state == VEHICLE_STATUS_ARMING_STATE_ARMED) {
+		if (priv->battery_status.warning == BATTERY_STATUS_BATTERY_WARNING_NONE
 		    && !priv->vehicle_status.failsafe) {
 			pattern = 0x3f;	// ****** solid (armed)
 
@@ -313,10 +313,10 @@ void gpio_led_cycle(FAR void *arg)
 			pattern = 0x3e;	// *****_ slow blink (armed, battery low or failsafe)
 		}
 
-	} else if (priv->vehicle_status.arming_state == ARMING_STATE_STANDBY) {
+	} else if (priv->vehicle_status.arming_state == VEHICLE_STATUS_ARMING_STATE_STANDBY) {
 		pattern = 0x38;	// ***___ slow blink (disarmed, ready)
 
-	} else if (priv->vehicle_status.arming_state == ARMING_STATE_STANDBY_ERROR) {
+	} else if (priv->vehicle_status.arming_state == VEHICLE_STATUS_ARMING_STATE_STANDBY_ERROR) {
 		pattern = 0x28;	// *_*___ slow double blink (disarmed, error)
 
 	}

--- a/src/modules/sdlog2/sdlog2.c
+++ b/src/modules/sdlog2/sdlog2.c
@@ -385,7 +385,7 @@ int sdlog2_main(int argc, char *argv[])
 		struct vehicle_command_s cmd;
 
 		memset(&cmd, 0, sizeof(cmd));
-		cmd.command = VEHICLE_CMD_PREFLIGHT_STORAGE;
+		cmd.command = VEHICLE_COMMAND_VEHICLE_CMD_PREFLIGHT_STORAGE;
 		cmd.param1 = -1;
 		cmd.param2 = -1;
 		cmd.param3 = 1;
@@ -398,7 +398,7 @@ int sdlog2_main(int argc, char *argv[])
 		struct vehicle_command_s cmd;
 
 		memset(&cmd, 0, sizeof(cmd));
-		cmd.command = VEHICLE_CMD_PREFLIGHT_STORAGE;
+		cmd.command = VEHICLE_COMMAND_VEHICLE_CMD_PREFLIGHT_STORAGE;
 		cmd.param1 = -1;
 		cmd.param2 = -1;
 		cmd.param3 = 2;
@@ -2223,7 +2223,7 @@ void handle_command(struct vehicle_command_s *cmd)
 	/* request to set different system mode */
 	switch (cmd->command) {
 
-	case VEHICLE_CMD_PREFLIGHT_STORAGE:
+	case VEHICLE_COMMAND_VEHICLE_CMD_PREFLIGHT_STORAGE:
 		param = (int)(cmd->param3 + 0.5f);
 
 		if (param == 1)	{
@@ -2246,7 +2246,7 @@ void handle_command(struct vehicle_command_s *cmd)
 void handle_status(struct vehicle_status_s *status)
 {
 	// TODO use flag from actuator_armed here?
-	bool armed = status->arming_state == ARMING_STATE_ARMED;
+	bool armed = status->arming_state == VEHICLE_STATUS_ARMING_STATE_ARMED;
 
 	if (armed != flag_system_armed) {
 		flag_system_armed = armed;

--- a/src/modules/systemlib/CMakeLists.txt
+++ b/src/modules/systemlib/CMakeLists.txt
@@ -43,7 +43,6 @@ set(SRCS
 	otp.c
 	pid/pid.c
 	pwm_limit/pwm_limit.c
-	rc_check.c
 	)
 
 if(${OS} STREQUAL "nuttx")


### PR DESCRIPTION
This makes some of the existing defines a bit verbose, but it prevents possible collisions.

# Example


### master

	#ifndef __cplusplus
	#define RC_INPUT_SOURCE_UNKNOWN 0
	#define RC_INPUT_SOURCE_PX4FMU_PPM 1
	#define RC_INPUT_SOURCE_PX4IO_PPM 2
	#define RC_INPUT_SOURCE_PX4IO_SPEKTRUM 3
	#define RC_INPUT_SOURCE_PX4IO_SBUS 4
	#define RC_INPUT_SOURCE_PX4IO_ST24 5
	#define RC_INPUT_SOURCE_MAVLINK 6
	#define RC_INPUT_SOURCE_QURT 7
	#define RC_INPUT_SOURCE_PX4FMU_SPEKTRUM 8
	#define RC_INPUT_SOURCE_PX4FMU_SBUS 9
	#define RC_INPUT_SOURCE_PX4FMU_ST24 10
	#define RC_INPUT_SOURCE_PX4FMU_SUMD 11
	#define RC_INPUT_SOURCE_PX4FMU_DSM 12
	#define RC_INPUT_SOURCE_PX4IO_SUMD 13
	#define RC_INPUT_MAX_CHANNELS 18

	#endif


### PR

	#ifndef __cplusplus
	#define INPUT_RC_S_RC_INPUT_SOURCE_UNKNOWN 0
	#define INPUT_RC_S_RC_INPUT_SOURCE_PX4FMU_PPM 1
	#define INPUT_RC_S_RC_INPUT_SOURCE_PX4IO_PPM 2
	#define INPUT_RC_S_RC_INPUT_SOURCE_PX4IO_SPEKTRUM 3
	#define INPUT_RC_S_RC_INPUT_SOURCE_PX4IO_SBUS 4
	#define INPUT_RC_S_RC_INPUT_SOURCE_PX4IO_ST24 5
	#define INPUT_RC_S_RC_INPUT_SOURCE_MAVLINK 6
	#define INPUT_RC_S_RC_INPUT_SOURCE_QURT 7
	#define INPUT_RC_S_RC_INPUT_SOURCE_PX4FMU_SPEKTRUM 8
	#define INPUT_RC_S_RC_INPUT_SOURCE_PX4FMU_SBUS 9
	#define INPUT_RC_S_RC_INPUT_SOURCE_PX4FMU_ST24 10
	#define INPUT_RC_S_RC_INPUT_SOURCE_PX4FMU_SUMD 11
	#define INPUT_RC_S_RC_INPUT_SOURCE_PX4FMU_DSM 12
	#define INPUT_RC_S_RC_INPUT_SOURCE_PX4IO_SUMD 13
	#define INPUT_RC_S_RC_INPUT_MAX_CHANNELS 18

	#endif

The constants could be renamed with this in mind.
