### PR TITLE
fastrtps: clean up and fix template for client/agent code

### DIFF
--- a/msg/templates/urtps/Publisher.cpp.template
+++ b/msg/templates/urtps/Publisher.cpp.template
@@ -48,7 +48,7 @@ topic = spec.short_name
  *
  ****************************************************************************/
 
-/*! 
+/*!
  * @@file @(topic)_Publisher.cpp
  * This file contains the implementation of the publisher functions.
  *
@@ -74,26 +74,26 @@ topic = spec.short_name
 bool @(topic)_Publisher::init()
 {
     // Create RTPSParticipant
-    
+
     ParticipantAttributes PParam;
     PParam.rtps.builtin.domainId = 0;
     PParam.rtps.builtin.leaseDuration = c_TimeInfinite;
-    PParam.rtps.setName("Participant_publisher");  //You can put here the name you want
+    PParam.rtps.setName("@(topic)_publisher");  //You can put here the name you want
     mp_participant = Domain::createParticipant(PParam);
     if(mp_participant == nullptr)
         return false;
-    
+
     //Register the type
-    
-    Domain::registerType(mp_participant,(TopicDataType*) &myType);
-    
+
+    Domain::registerType(mp_participant, (TopicDataType*) &myType);
+
     // Create Publisher
-    
+
     PublisherAttributes Wparam;
     Wparam.topic.topicKind = NO_KEY;
     Wparam.topic.topicDataType = myType.getName();  //This type MUST be registered
-    Wparam.topic.topicName = "@(topic)_PubSubTopic";
-    mp_publisher = Domain::createPublisher(mp_participant,Wparam,(PublisherListener*)&m_listener);
+    Wparam.topic.topicName = "@(topic)";
+    mp_publisher = Domain::createPublisher(mp_participant, Wparam, (PublisherListener*) &m_listener);
     if(mp_publisher == nullptr)
         return false;
     //std::cout << "Publisher created, waiting for Subscribers." << std::endl;
@@ -120,13 +120,13 @@ void @(topic)_Publisher::run()
     {
         eClock::my_sleep(250); // Sleep 250 ms
     }
-    
+
     // Publication code
-    
+
     @(topic)_ st;
-    
+
     /* Initialize your structure here */
-    
+
     int msgsent = 0;
     char ch = 'y';
     do

--- a/msg/templates/urtps/Publisher.h.template
+++ b/msg/templates/urtps/Publisher.h.template
@@ -48,7 +48,7 @@ topic = spec.short_name
  *
  ****************************************************************************/
 
-/*! 
+/*!
  * @@file @(topic)_Publisher.h
  * This header file contains the declaration of the publisher functions.
  *
@@ -65,8 +65,9 @@ topic = spec.short_name
 #include "@(topic)_PubSubTypes.h"
 
 using namespace eprosima::fastrtps;
+using namespace eprosima::fastrtps::rtps;
 
-class @(topic)_Publisher 
+class @(topic)_Publisher
 {
 public:
     @(topic)_Publisher();
@@ -77,13 +78,13 @@ public:
 private:
     Participant *mp_participant;
     Publisher *mp_publisher;
-    
+
     class PubListener : public PublisherListener
     {
     public:
         PubListener() : n_matched(0){};
         ~PubListener(){};
-        void onPublicationMatched(Publisher* pub,MatchingInfo& info);
+        void onPublicationMatched(Publisher* pub, MatchingInfo& info);
         int n_matched;
     } m_listener;
     @(topic)_PubSubType myType;

--- a/msg/templates/urtps/Subscriber.cpp.template
+++ b/msg/templates/urtps/Subscriber.cpp.template
@@ -48,7 +48,7 @@ topic = spec.short_name
  *
  ****************************************************************************/
 
-/*! 
+/*!
  * @@file @(topic)_Subscriber.cpp
  * This file contains the implementation of the subscriber functions.
  *
@@ -72,26 +72,26 @@ topic = spec.short_name
 bool @(topic)_Subscriber::init()
 {
     // Create RTPSParticipant
-    
+
     ParticipantAttributes PParam;
     PParam.rtps.builtin.domainId = 0; //MUST BE THE SAME AS IN THE PUBLISHER
     PParam.rtps.builtin.leaseDuration = c_TimeInfinite;
-    PParam.rtps.setName("Participant_subscriber"); //You can put the name you want
+    PParam.rtps.setName("@(topic)_subscriber"); //You can put the name you want
     mp_participant = Domain::createParticipant(PParam);
     if(mp_participant == nullptr)
             return false;
-    
+
     //Register the type
-    
-    Domain::registerType(mp_participant,(TopicDataType*) &myType);
-            
+
+    Domain::registerType(mp_participant, (TopicDataType*) &myType);
+
     // Create Subscriber
-            
+
     SubscriberAttributes Rparam;
     Rparam.topic.topicKind = NO_KEY;
     Rparam.topic.topicDataType = myType.getName(); //Must be registered before the creation of the subscriber
-    Rparam.topic.topicName = "@(topic)_PubSubTopic";
-    mp_subscriber = Domain::createSubscriber(mp_participant,Rparam,(SubscriberListener*)&m_listener);
+    Rparam.topic.topicName = "@(topic)";
+    mp_subscriber = Domain::createSubscriber(mp_participant, Rparam, (SubscriberListener*) &m_listener);
     if(mp_subscriber == nullptr)
         return false;
     return true;

--- a/msg/templates/urtps/Subscriber.h.template
+++ b/msg/templates/urtps/Subscriber.h.template
@@ -48,7 +48,7 @@ topic = spec.short_name
  *
  ****************************************************************************/
 
-/*! 
+/*!
  * @@file @(topic)_Subscriber.h
  * This header file contains the declaration of the subscriber functions.
  *
@@ -65,8 +65,9 @@ topic = spec.short_name
 #include "@(topic)_PubSubTypes.h"
 
 using namespace eprosima::fastrtps;
+using namespace eprosima::fastrtps::rtps;
 
-class @(topic)_Subscriber 
+class @(topic)_Subscriber
 {
 public:
     @(topic)_Subscriber();
@@ -78,13 +79,13 @@ public:
 private:
     Participant *mp_participant;
     Subscriber *mp_subscriber;
-    
+
     class SubListener : public SubscriberListener
     {
     public:
-        SubListener() : n_matched(0),n_msg(0){};
+        SubListener() : n_matched(0), n_msg(0){};
         ~SubListener(){};
-        void onSubscriptionMatched(Subscriber* sub,MatchingInfo& info);
+        void onSubscriptionMatched(Subscriber* sub, MatchingInfo& info);
         void onNewDataMessage(Subscriber* sub);
         SampleInfo_t m_info;
         int n_matched;

--- a/msg/templates/urtps/microRTPS_agent.cpp.template
+++ b/msg/templates/urtps/microRTPS_agent.cpp.template
@@ -194,7 +194,7 @@ void t_send(void *data)
         // Send subscribed topics over UART
         while (topics.hasMsg(&topic_ID))
         {
-            uint16_t header_length = get_header_length();
+            uint16_t header_length = transport_node->get_header_length();
             /* make room for the header to fill in later */
             eprosima::fastcdr::FastBuffer cdrbuffer(&data_buffer[header_length], sizeof(data_buffer)-header_length);
             eprosima::fastcdr::Cdr scdr(cdrbuffer);

--- a/src/modules/systemlib/system_params.c
+++ b/src/modules/systemlib/system_params.c
@@ -134,7 +134,7 @@ PARAM_DEFINE_INT32(SYS_MC_EST_GROUP, 2);
  * @value 1921600 ESP8266 (921600 baud, 8N1)
  *
  * @min 0
- * @max 1921600
+ * @max 6460800
  * @reboot_required true
  * @group System
  */


### PR DESCRIPTION
This PR fixes the `micrortps` code, which was not compiling given some missing namespace references. Also, it makes naming and function arguments a little bit more readable.

Main fixes:
1. Add `using namespace eprosima::fastrtps::rtps;` to `Publisher` and `Subscriber` templates;
2. Replace `uint16_t header_length = get_header_length();` with `uint16_t header_length = transport_node->get_header_length();` (missing the object pointer, which was leading to the compiler stating that ` get_header_length` was not declared.