### PR TITLE
cmake consistency with build directory and and nuttx binary naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,10 +120,11 @@ endif
 # --------------------------------------------------------------------
 # describe how to build a cmake config
 define cmake-build
-+@$(eval BUILD_DIR = $(SRC_DIR)/build/$@$(BUILD_DIR_SUFFIX))
++@$(eval PX4_CONFIG = $(1))
++@$(eval BUILD_DIR = $(SRC_DIR)/build/$(PX4_CONFIG)$(BUILD_DIR_SUFFIX))
 +@if [ $(PX4_CMAKE_GENERATOR) = "Ninja" ] && [ -e $(BUILD_DIR)/Makefile ]; then rm -rf $(BUILD_DIR); fi
-+@if [ ! -e $(BUILD_DIR)/CMakeCache.txt ]; then mkdir -p $(BUILD_DIR) && cd $(BUILD_DIR) && cmake $(2) -G"$(PX4_CMAKE_GENERATOR)" $(CMAKE_ARGS) -DCONFIG=$(1) || (rm -rf $(BUILD_DIR)); fi
-+@(cd $(BUILD_DIR) && $(PX4_MAKE) $(PX4_MAKE_ARGS) $(ARGS))
++@if [ ! -e $(BUILD_DIR)/CMakeCache.txt ]; then mkdir -p $(BUILD_DIR) && cd $(BUILD_DIR) && cmake $(SRC_DIR) -G"$(PX4_CMAKE_GENERATOR)" $(CMAKE_ARGS) -DCONFIG=$(PX4_CONFIG) || (rm -rf $(BUILD_DIR)); fi
++@$(PX4_MAKE) -C $(BUILD_DIR) $(PX4_MAKE_ARGS) $(ARGS)
 endef
 
 COLOR_BLUE = \033[0;94m
@@ -144,13 +145,13 @@ NUTTX_CONFIG_TARGETS := $(patsubst nuttx_%,%,$(filter nuttx_%,$(ALL_CONFIG_TARGE
 
 # All targets.
 $(ALL_CONFIG_TARGETS):
-	$(call cmake-build,$@,$(SRC_DIR))
+	$(call cmake-build,$@)
 
 # Abbreviated config targets.
 
 # nuttx_ is left off by default; provide a rule to allow that.
 $(NUTTX_CONFIG_TARGETS):
-	$(call cmake-build,nuttx_$@,$(SRC_DIR))
+	$(call cmake-build,nuttx_$@)
 
 all_nuttx_targets: $(NUTTX_CONFIG_TARGETS)
 

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -115,9 +115,12 @@ if (config_romfs_root)
 endif()
 
 # create px4 file (combined firmware and metadata)
+# for historical reasons we name the final output binary without nuttx_
+set(fw_name_short)
+string(REPLACE "nuttx_" "" fw_name_short ${FW_NAME})
+
 set(fw_file ${PX4_BINARY_DIR}/${FW_NAME})
 string(REPLACE ".elf" ".px4" fw_file ${fw_file})
-string(REPLACE "nuttx_" "" fw_file ${fw_file})
 
 add_custom_command(OUTPUT ${PX4_BINARY_DIR_REL}/${BOARD}.bin
 	COMMAND ${OBJCOPY} -O binary ${PX4_BINARY_DIR_REL}/${FW_NAME} ${PX4_BINARY_DIR_REL}/${BOARD}.bin
@@ -135,7 +138,7 @@ if (TARGET parameters_xml AND TARGET airframes_xml)
 			--git_identity ${PX4_SOURCE_DIR}
 			--parameter_xml ${PX4_BINARY_DIR}/parameters.xml
 			--airframe_xml ${PX4_BINARY_DIR}/airframes.xml
-			--image ${PX4_BINARY_DIR}/${BOARD}.bin > ${fw_file}
+			--image ${PX4_BINARY_DIR}/${BOARD}.bin > ${fw_name_short}
 		DEPENDS ${PX4_BINARY_DIR}/${BOARD}.bin parameters_xml airframes_xml
 		COMMENT "Creating ${fw_file}"
 		)

--- a/src/drivers/px4io/CMakeLists.txt
+++ b/src/drivers/px4io/CMakeLists.txt
@@ -47,7 +47,7 @@ px4_add_module(
 # include the px4io binary in ROMFS
 message(STATUS "Building and including ${config_io_board}")
 
-set(fw_io_exe "${PX4_SOURCE_DIR}/build/${config_io_board}_default/nuttx_${config_io_board}_default.elf")
+set(fw_io_exe "${PX4_SOURCE_DIR}/build/nuttx_${config_io_board}_default/nuttx_${config_io_board}_default.elf")
 set(fw_io_bin "${PX4_BINARY_DIR}/genromfs/${config_romfs_root}/extras/${config_io_board}.bin")
 
 file(GLOB_RECURSE px4io_driver_files ${PX4_SOURCE_DIR}/src/drivers/boards/${config_io_board}/*)
@@ -55,7 +55,7 @@ file(GLOB_RECURSE px4io_config_files ${PX4_SOURCE_DIR}/platforms/nuttx/NuttX/con
 file(GLOB_RECURSE px4io_firmware_files ${PX4_SOURCE_DIR}/src/modules/px4iofirmware/*)
 file(GLOB_RECURSE px4io_rc_files ${PX4_SOURCE_DIR}/src/lib/rc/*)
 add_custom_command(OUTPUT ${fw_io_exe}
-	COMMAND make --no-print-directory ${config_io_board}_default
+	COMMAND make --no-print-directory nuttx_${config_io_board}_default
 	DEPENDS ${px4io_driver_files} ${px4io_config_files} ${px4io_firmware_files} ${px4io_rc_files}
 	WORKING_DIRECTORY ${PX4_SOURCE_DIR}
 	COMMENT "Building ${config_io_board}"


### PR DESCRIPTION
This ensures the build directory is always named with the OS prefix. The mechanism where the FMU build kicks off the IO build and reaches through to copy over the binary is always going to be a little fragile. This at least removes one more level of potential problem.