### PR TITLE
Do not set the closest mission item in normal mission mode

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -155,7 +155,11 @@ void
 Mission::on_activation()
 {
 	if (_mission_waypoints_changed) {
-		_current_offboard_mission_index = index_closest_mission_item();
+		// do not set the closest mission item in the normal mission mode
+		if (_mission_execution_mode != mission_result_s::MISSION_EXECUTION_MODE_NORMAL) {
+			_current_offboard_mission_index = index_closest_mission_item();
+		}
+
 		_mission_waypoints_changed = false;
 	}
 
@@ -199,7 +203,11 @@ Mission::on_active()
 	/* reset mission items if needed */
 	if (offboard_updated || _mission_waypoints_changed || _execution_mode_changed) {
 		if (_mission_waypoints_changed) {
-			_current_offboard_mission_index = index_closest_mission_item();
+			// do not set the closest mission item in the normal mission mode
+			if (_mission_execution_mode != mission_result_s::MISSION_EXECUTION_MODE_NORMAL) {
+				_current_offboard_mission_index = index_closest_mission_item();
+			}
+
 			_mission_waypoints_changed = false;
 		}
 


### PR DESCRIPTION
As requested in [#9606](https://github.com/PX4/Firmware/issues/9606).

Tested in SITL for normal mission flight and RTL.

@potaito can you confirm that now it works as you expect?
