### PR TITLE
SITL startup fixes

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2062,8 +2062,6 @@ Mavlink::task_main(int argc, char *argv[])
 		configure_stream("POSITION_TARGET_LOCAL_NED", 10.0f);
 		configure_stream("RC_CHANNELS", 20.0f);
 		configure_stream("SCALED_IMU", 50.0f);
-		configure_stream("SCALED_IMU2", 50.0f);
-		configure_stream("SCALED_IMU3", 50.0f);
 		configure_stream("SERVO_OUTPUT_RAW_0", 10.0f);
 		configure_stream("SYS_STATUS", 5.0f);
 		configure_stream("SYSTEM_TIME", 1.0f);

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -582,7 +582,7 @@ void
 Sensors::run()
 {
 	if (!_hil_enabled) {
-#if !defined(__PX4_QURT) && !defined(__PX4_POSIX_BEBOP)
+#if !defined(__PX4_QURT) && BOARD_NUMBER_BRICKS > 0
 		adc_init();
 #endif
 	}


### PR DESCRIPTION
- remove non-existing mavlink streams SCALED_IMU2 and SCALED_IMU3. Introduced in #9531 (@mcsauder ). Fixes these warnings:
```
    WARN  [mavlink] stream SCALED_IMU2 not found
    WARN  [mavlink] stream SCALED_IMU3 not found
```
- initialize adc only if BOARD_NUMBER_BRICKS > 0. Fixes the SITL startup error:
```
    ERROR [sensors] no ADC found: /dev/adc0 (9)
```

@RomanBapst can you test this quickly on Snapdragon, the eagle board config also defines BOARD_NUMBER_BRICKS to 0?
