### PR TITLE
BUGFIX:GPS not working. Invalid values passed to px4_arch_configgpio

### DIFF
--- a/src/drivers/camera_trigger/interfaces/src/gpio.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/gpio.cpp
@@ -22,8 +22,8 @@ CameraInterfaceGPIO::~CameraInterfaceGPIO()
 void CameraInterfaceGPIO::setup()
 {
 	for (unsigned i = 0; i < arraySize(_pins); i++) {
-		// Pin range is ranges from 1 to 6
-		if (_pins[i] > 0 && _pins[i] < (int)arraySize(_gpios)) {
+		// Pin range is from 0 to 5
+		if (_pins[i] >= 0 && _pins[i] < (int)arraySize(_gpios)) {
 			px4_arch_configgpio(_gpios[_pins[i]]);
 			px4_arch_gpiowrite(_gpios[_pins[i]], !_polarity);
 		}
@@ -34,7 +34,7 @@ void CameraInterfaceGPIO::trigger(bool enable)
 {
 	if (enable) {
 		for (unsigned i = 0; i < arraySize(_pins); i++) {
-			if (_pins[i] >= 0) {
+			if (_pins[i] >= 0 && _pins[i] < (int)arraySize(_gpios)) {
 				// ACTIVE_LOW == 1
 				px4_arch_gpiowrite(_gpios[_pins[i]], _polarity);
 			}
@@ -42,7 +42,7 @@ void CameraInterfaceGPIO::trigger(bool enable)
 
 	} else {
 		for (unsigned i = 0; i < arraySize(_pins); i++) {
-			if (_pins[i] >= 0) {
+			if (_pins[i] >= 0 && _pins[i] < (int)arraySize(_gpios)) {
 				// ACTIVE_LOW == 1
 				px4_arch_gpiowrite(_gpios[_pins[i]], !_polarity);
 			}

--- a/src/drivers/camera_trigger/interfaces/src/gpio.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/gpio.cpp
@@ -22,8 +22,11 @@ CameraInterfaceGPIO::~CameraInterfaceGPIO()
 void CameraInterfaceGPIO::setup()
 {
 	for (unsigned i = 0; i < arraySize(_pins); i++) {
-		px4_arch_configgpio(_gpios[_pins[i]]);
-		px4_arch_gpiowrite(_gpios[_pins[i]], !_polarity);
+		// Pin range is ranges from 1 to 6
+		if (_pins[i] > 0 && _pins[i] < (int)arraySize(_gpios)) {
+			px4_arch_configgpio(_gpios[_pins[i]]);
+			px4_arch_gpiowrite(_gpios[_pins[i]], !_polarity);
+		}
 	}
 }
 

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -787,17 +787,6 @@ GPS::run()
 				case GPS_DRIVER_MODE_ASHTECH:
 					_mode = GPS_DRIVER_MODE_UBX;
 					usleep(500000); // tried all possible drivers. Wait a bit before next round
-
-					//FIXME: reopen the uart to work around an issue where the gps is not detected
-					// sometimes on startup on the mRo X2.1 board (see https://github.com/PX4/Firmware/issues/9461)
-					close(_serial_fd);
-					_serial_fd = ::open(_port, O_RDWR | O_NOCTTY);
-
-					if (_serial_fd < 0) {
-						PX4_ERR("failed to reopen the UART (%i)", errno);
-						request_stop();
-					}
-
 					break;
 
 				default:


### PR DESCRIPTION
This is the root cause of https://github.com/PX4/Firmware/issues/9461 The _pins array was initialized to -1. It was used to index the _gpios array. The value at _gpios[-1] was a number that mapped to Analog mode on Port A pin 0. This is the UART4_TX pin and was being reconfigured by the fault in the camera_trigger to an analog input.

reverts hotfix