### PR TITLE
Precland fixes

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1603,6 +1603,7 @@ MavlinkMissionManager::format_mavlink_mission_item(const struct mission_item_s *
 
 		case NAV_CMD_LAND:
 			// TODO: param1 abort alt
+			mavlink_mission_item->param2 = mission_item->land_precision;
 			mavlink_mission_item->param4 = math::degrees(mission_item->yaw);
 			break;
 

--- a/src/modules/navigator/precland.cpp
+++ b/src/modules/navigator/precland.cpp
@@ -477,7 +477,7 @@ bool PrecLand::check_state_conditions(PrecLandState state)
 		}
 
 		// If we're trying to switch to this state, the target needs to be visible
-		return _target_pose_updated && _target_pose.abs_pos_valid;
+		return _target_pose_updated && _target_pose_valid && _target_pose.abs_pos_valid;
 
 	case PrecLandState::DescendAboveTarget:
 


### PR DESCRIPTION
This PR addresses two precland-related isses:

1. When the copter switches to the horizontal approach state, the check of landing target pose validity is not fully correct: an old message (when the landing target is seen the last time) can switch the state.

2. When downloading mission with a precision landing waypoint from the copter, the precision land parameter is lost.

@ndepal 