### PR TITLE
Vl53lxx Driver Coverity Fixes

### DIFF
--- a/src/drivers/distance_sensor/vl53lxx/vl53lxx.cpp
+++ b/src/drivers/distance_sensor/vl53lxx/vl53lxx.cpp
@@ -1061,9 +1061,8 @@ test()
 {
 	struct distance_sensor_s report;
 	ssize_t sz;
-	int fd = -1;
 
-	fd = open(VL53LXX_DEVICE_PATH, O_RDONLY);
+	int fd = open(VL53LXX_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		err(1, "%s open failed (try 'vl53lxx start' if the driver is not running)", VL53LXX_DEVICE_PATH);


### PR DESCRIPTION
Fixes:
- 2 file descriptors were not closed (in start and test functions)
- _stop_variable was not initialized in constructor (although it was used by readRegister)

False Positives:
- "fd" is passed to a parameter that cannot be negative (in test function) -> there is a check for this
- Passing null pointer "vl53lxx::g_dev" to "print_info", which dereferences it -> there is a check for this
