### PR TITLE
Disable the PX4 shell for CI ROS tests

### DIFF
--- a/launch/mavros_posix_sitl.launch
+++ b/launch/mavros_posix_sitl.launch
@@ -24,6 +24,8 @@
     <!-- MAVROS configs -->
     <arg name="fcu_url" default="udp://:14540@localhost:14557"/>
     <arg name="respawn_mavros" default="false"/>
+    <!-- PX4 configs -->
+    <arg name="interactive" default="true"/>
     <!-- PX4 SITL and Gazebo -->
     <include file="$(find px4)/launch/posix_sitl.launch">
         <arg name="x" value="$(arg x)"/>
@@ -37,6 +39,7 @@
         <arg name="sdf" value="$(arg sdf)"/>
         <arg name="rcS" value="$(arg rcS)"/>
         <arg name="gui" value="$(arg gui)"/>
+        <arg name="interactive" value="$(arg interactive)"/>
         <arg name="debug" value="$(arg debug)"/>
         <arg name="verbose" value="$(arg verbose)"/>
         <arg name="paused" value="$(arg paused)"/>

--- a/launch/posix_sitl.launch
+++ b/launch/posix_sitl.launch
@@ -21,8 +21,12 @@
     <arg name="verbose" default="false"/>
     <arg name="paused" default="false"/>
     <arg name="respawn_gazebo" default="false"/>
+    <!-- PX4 configs -->
+    <arg name="interactive" default="true"/>
     <!-- PX4 SITL -->
-    <node name="sitl" pkg="px4" type="px4" output="screen" args="$(find px4) $(arg rcS)"/>
+    <arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
+    <node name="sitl" pkg="px4" type="px4" output="screen" args="$(find px4) $(arg rcS) $(arg px4_command_arg1)"/>
     <!-- Gazebo sim -->
     <include file="$(find gazebo_ros)/launch/empty_world.launch">
         <arg name="gui" value="$(arg gui)"/>

--- a/launch/single_vehicle_spawn.launch
+++ b/launch/single_vehicle_spawn.launch
@@ -15,11 +15,15 @@
     <arg name="ID" default="1"/>
     <arg name="rcS" default="$(find px4)/posix-configs/SITL/init/$(arg est)/$(arg vehicle)_$(arg ID)"/>
     <arg name="mavlink_udp_port" default="14560"/>
+    <!-- PX4 configs -->
+    <arg name="interactive" default="true"/>
     <!-- generate urdf vehicle model -->
     <arg name="cmd" default="$(find xacro)/xacro $(find px4)/Tools/sitl_gazebo/models/rotors_description/urdf/$(arg vehicle)_base.xacro rotors_description_dir:=$(find px4)/Tools/sitl_gazebo/models/rotors_description mavlink_udp_port:=$(arg mavlink_udp_port) --inorder"/>
     <param command="$(arg cmd)" name="rotors_description"/>
     <!-- PX4 SITL -->
-    <node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" args="$(find px4) $(arg rcS)">
+    <arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>
+    <arg     if="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" args="$(find px4) $(arg rcS) $(arg px4_command_arg1)">
     </node>
     <!-- spawn vehicle -->
     <node name="$(arg vehicle)_$(arg ID)_spawn" output="screen" pkg="gazebo_ros" type="spawn_model" args="-urdf -param rotors_description -model $(arg vehicle)_$(arg ID) -package_to_model -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)"/>

--- a/test/mavros_posix_test_mission.test
+++ b/test/mavros_posix_test_mission.test
@@ -4,12 +4,14 @@
     <!-- Test a mission -->
     <arg name="est" default="ekf2"/>
     <arg name="gui" default="false"/>
+    <arg name="interactive" default="false"/>
     <arg name="vehicle" default="iris"/>
     <arg name="mission"/>
     <!-- MAVROS, PX4 SITL, Gazebo -->
     <include file="$(find px4)/launch/mavros_posix_sitl.launch">
         <arg name="est" value="$(arg est)"/>
         <arg name="gui" value="$(arg gui)"/>
+        <arg name="interactive" value="$(arg interactive)"/>
         <arg name="vehicle" value="$(arg vehicle)"/>
         <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>

--- a/test/mavros_posix_tests_iris_opt_flow.test
+++ b/test/mavros_posix_tests_iris_opt_flow.test
@@ -4,10 +4,12 @@
     <!-- Test offboard local posistion and attitude control with optical flow iris -->
     <arg name="est" default="ekf2"/>
     <arg name="gui" default="false"/>
+    <arg name="interactive" default="false"/>
     <!-- MAVROS, PX4 SITL, Gazebo -->
     <include file="$(find px4)/launch/mavros_posix_sitl.launch">
         <arg name="est" value="$(arg est)"/>
         <arg name="gui" value="$(arg gui)"/>
+        <arg name="interactive" value="$(arg interactive)"/>
         <arg name="vehicle" value="iris_opt_flow"/>
         <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>

--- a/test/mavros_posix_tests_missions.test
+++ b/test/mavros_posix_tests_missions.test
@@ -5,10 +5,12 @@
     <arg name="est" default="ekf2"/>
     <arg name="gui" default="false"/>
     <arg name="vehicle" default="standard_vtol"/>
+    <arg name="interactive" default="false"/>
     <!-- MAVROS, PX4 SITL, Gazebo -->
     <include file="$(find px4)/launch/mavros_posix_sitl.launch">
         <arg name="est" value="$(arg est)"/>
         <arg name="gui" value="$(arg gui)"/>
+        <arg name="interactive" value="$(arg interactive)"/>
         <arg name="vehicle" value="$(arg vehicle)"/>
         <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>

--- a/test/mavros_posix_tests_offboard_attctl.test
+++ b/test/mavros_posix_tests_offboard_attctl.test
@@ -5,10 +5,12 @@
     <arg name="est" default="ekf2"/>
     <arg name="gui" default="false"/>
     <arg name="vehicle" default="iris"/>
+    <arg name="interactive" default="false"/>
     <!-- MAVROS, PX4 SITL, Gazebo -->
     <include file="$(find px4)/launch/mavros_posix_sitl.launch">
         <arg name="est" value="$(arg est)"/>
         <arg name="gui" value="$(arg gui)"/>
+        <arg name="interactive" value="$(arg interactive)"/>
         <arg name="vehicle" value="$(arg vehicle)"/>
         <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>

--- a/test/mavros_posix_tests_offboard_posctl.test
+++ b/test/mavros_posix_tests_offboard_posctl.test
@@ -5,10 +5,12 @@
     <arg name="est" default="ekf2"/>
     <arg name="gui" default="false"/>
     <arg name="vehicle" default="iris"/>
+    <arg name="interactive" default="false"/>
     <!-- MAVROS, PX4 SITL, Gazebo -->
     <include file="$(find px4)/launch/mavros_posix_sitl.launch">
         <arg name="est" value="$(arg est)"/>
         <arg name="gui" value="$(arg gui)"/>
+        <arg name="interactive" value="$(arg interactive)"/>
         <arg name="vehicle" value="$(arg vehicle)"/>
         <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>


### PR DESCRIPTION
Automated tests should not run interactively. This adds an `interactive` argument to the ROS launch scripts and disables it for the tests.

I did not test it yet.

Fix for https://github.com/PX4/Firmware/issues/9667