### PR TITLE
Fixes for SatCom

### DIFF
--- a/src/drivers/telemetry/iridiumsbd/IridiumSBD.cpp
+++ b/src/drivers/telemetry/iridiumsbd/IridiumSBD.cpp
@@ -77,7 +77,7 @@ int IridiumSBD::start(int argc, char *argv[])
 	IridiumSBD::instance = new IridiumSBD();
 
 	IridiumSBD::task_handle = px4_task_spawn_cmd("iridiumsbd", SCHED_DEFAULT,
-				  SCHED_PRIORITY_SLOW_DRIVER, 1300, (main_t)&IridiumSBD::main_loop_helper, argv);
+				  SCHED_PRIORITY_SLOW_DRIVER, 1350, (main_t)&IridiumSBD::main_loop_helper, argv);
 
 	return OK;
 }

--- a/src/modules/mavlink/mavlink_high_latency2.cpp
+++ b/src/modules/mavlink/mavlink_high_latency2.cpp
@@ -103,7 +103,9 @@ MavlinkStreamHighLatency2::MavlinkStreamHighLatency2(Mavlink *mavlink) : Mavlink
 	_temperature(SimpleAnalyzer::AVERAGE),
 	_throttle(SimpleAnalyzer::AVERAGE),
 	_windspeed(SimpleAnalyzer::AVERAGE)
-{}
+{
+	reset_last_sent();
+}
 
 bool MavlinkStreamHighLatency2::send(const hrt_abstime t)
 {

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2207,7 +2207,7 @@ Mavlink::task_main(int argc, char *argv[])
 				if (_transmitting_enabled &&
 				    !status.high_latency_data_link_active &&
 				    !_transmitting_enabled_commanded &&
-				    (_last_write_success_time > 0u)) { // a first message is written
+				    (_first_heartbeat_sent)) {
 					_transmitting_enabled = false;
 					mavlink_and_console_log_info(&_mavlink_log_pub, "Disable transmitting with IRIDIUM mavlink on device %s", _device_name);
 
@@ -2369,6 +2369,19 @@ Mavlink::task_main(int argc, char *argv[])
 		MavlinkStream *stream;
 		LL_FOREACH(_streams, stream) {
 			stream->update(t);
+
+			if (!_first_heartbeat_sent) {
+				if (_mode == MAVLINK_MODE_IRIDIUM) {
+					if (stream->get_id() == MAVLINK_MSG_ID_HIGH_LATENCY2) {
+						_first_heartbeat_sent = stream->first_message_sent();
+					}
+
+				} else {
+					if (stream->get_id() == MAVLINK_MSG_ID_HEARTBEAT) {
+						_first_heartbeat_sent = stream->first_message_sent();
+					}
+				}
+			}
 		}
 
 		/* pass messages from other UARTs */

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -500,6 +500,7 @@ private:
 	int			_instance_id;
 	bool			_transmitting_enabled;
 	bool			_transmitting_enabled_commanded;
+	bool			_first_heartbeat_sent{false};
 
 	orb_advert_t		_mavlink_log_pub;
 	bool			_task_running;

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -480,6 +480,11 @@ MavlinkMissionManager::send_mission_item_reached(uint16_t seq)
 void
 MavlinkMissionManager::send(const hrt_abstime now)
 {
+	// do not send anything over high latency communication
+	if (_mavlink->get_mode() == Mavlink::MAVLINK_MODE_IRIDIUM) {
+		return;
+	}
+
 	bool updated = false;
 	orb_check(_mission_result_sub, &updated);
 
@@ -1651,6 +1656,11 @@ MavlinkMissionManager::format_mavlink_mission_item(const struct mission_item_s *
 
 void MavlinkMissionManager::check_active_mission()
 {
+	// do not send anything over high latency communication
+	if (_mavlink->get_mode() == Mavlink::MAVLINK_MODE_IRIDIUM) {
+		return;
+	}
+
 	if (!(_my_dataman_id == _dataman_id)) {
 		PX4_DEBUG("WPM: New mission detected (possibly over different Mavlink instance) Updating");
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -100,7 +100,7 @@ using matrix::wrap_2pi;
 
 MavlinkReceiver::MavlinkReceiver(Mavlink *parent) :
 	_mavlink(parent),
-	_mission_manager(nullptr),
+	_mission_manager(parent),
 	_parameters_manager(parent),
 	_mavlink_ftp(parent),
 	_mavlink_log_handler(parent),
@@ -163,20 +163,12 @@ MavlinkReceiver::MavlinkReceiver(Mavlink *parent) :
 	_p_bat_crit_thr(param_find("BAT_CRIT_THR")),
 	_p_bat_low_thr(param_find("BAT_LOW_THR"))
 {
-	if (_mavlink->get_mode() != Mavlink::MAVLINK_MODE_IRIDIUM) {
-		_mission_manager = new MavlinkMissionManager(parent);
-	}
 }
 
 MavlinkReceiver::~MavlinkReceiver()
 {
 	orb_unsubscribe(_control_mode_sub);
 	orb_unsubscribe(_actuator_armed_sub);
-
-	if (_mission_manager != nullptr) {
-		delete _mission_manager;
-		_mission_manager = nullptr;
-	}
 }
 
 void MavlinkReceiver::acknowledge(uint8_t sysid, uint8_t compid, uint16_t command, uint8_t result)
@@ -2584,9 +2576,8 @@ MavlinkReceiver::receive_thread(void *arg)
 						handle_message(&msg);
 
 						/* handle packet with mission manager */
-						if (_mission_manager != nullptr) {
-							_mission_manager->handle_message(&msg);
-						}
+						_mission_manager.handle_message(&msg);
+
 
 						/* handle packet with parameter component */
 						_parameters_manager.handle_message(&msg);
@@ -2617,10 +2608,8 @@ MavlinkReceiver::receive_thread(void *arg)
 		hrt_abstime t = hrt_absolute_time();
 
 		if (t - last_send_update > timeout * 1000) {
-			if (_mission_manager != nullptr) {
-				_mission_manager->check_active_mission();
-				_mission_manager->send(t);
-			}
+			_mission_manager.check_active_mission();
+			_mission_manager.send(t);
 
 			_parameters_manager.send(t);
 

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -194,7 +194,7 @@ private:
 
 	Mavlink	*_mavlink;
 
-	MavlinkMissionManager		*_mission_manager;
+	MavlinkMissionManager		_mission_manager;
 	MavlinkParametersManager	_parameters_manager;
 	MavlinkFTP			_mavlink_ftp;
 	MavlinkLogHandler		_mavlink_log_handler;

--- a/src/modules/mavlink/mavlink_stream.cpp
+++ b/src/modules/mavlink/mavlink_stream.cpp
@@ -66,6 +66,10 @@ MavlinkStream::update(const hrt_abstime &t)
 		// on the link scheduling
 		if (send(t)) {
 			_last_sent = hrt_absolute_time();
+
+			if (!_first_message_sent) {
+				_first_message_sent = true;
+			}
 		}
 
 		return 0;
@@ -103,6 +107,11 @@ MavlinkStream::update(const hrt_abstime &t)
 		// long time not sending anything, sending multiple messages in a short time is avoided.
 		if (send(t)) {
 			_last_sent = ((interval > 0) && ((int64_t)(1.5f * interval) > dt)) ? _last_sent + interval : t;
+
+			if (!_first_message_sent) {
+				_first_message_sent = true;
+			}
+
 			return 0;
 
 		} else {

--- a/src/modules/mavlink/mavlink_stream.h
+++ b/src/modules/mavlink/mavlink_stream.h
@@ -101,6 +101,17 @@ public:
 	 */
 	virtual unsigned get_size_avg() { return get_size(); }
 
+	/**
+	 * @return true if the first message of this stream has been sent
+	 */
+	bool first_message_sent() const { return _first_message_sent; }
+
+	/**
+	 * Reset the time of last sent to 0. Can be used if a message over this
+	 * stream needs to be sent immediately.
+	 */
+	void reset_last_sent() { _last_sent = 0; }
+
 protected:
 	Mavlink      *const _mavlink;
 	int _interval{1000000};		///< if set to negative value = unlimited rate
@@ -117,6 +128,7 @@ protected:
 
 private:
 	hrt_abstime _last_sent{0};
+	bool _first_message_sent{false};
 };
 
 


### PR DESCRIPTION
Some general fixes for SatCom. The changes plus the explanation why they were implemented:

- Increase the stack size for the IridiumSBD driver.
     - We got an error message that it is low on stack during one of our latest flights.

- Re-enable the MissionManager for the Iridium Mavlink instance
    - The MissionManager handles the set current mission index command which still should be supported using SatCom

- Make sure that a first heartbeat (HIGH_LATENCY_2) message is sent before it is deactivated.
    - It sometimes happened that a command_ack was sent before the HL2 command which then resulted in the SatCom link not being initialized properly 