### PR TITLE
[Hotfix] Fixed-wing autoland/flare bug

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1478,20 +1478,21 @@ FixedwingPositionControl::control_landing(const Vector2f &curr_pos, const Vector
 
 		if (!_land_noreturn_vertical) {
 			// just started with the flaring phase
-			_att_sp.pitch_body = 0.0f;
+			_flare_pitch_sp = 0.0f;
 			_flare_height = _global_pos.alt - terrain_alt;
 			mavlink_log_info(&_mavlink_log_pub, "Landing, flaring");
 			_land_noreturn_vertical = true;
 
 		} else {
 			if (_global_pos.vel_d > 0.1f) {
-				_att_sp.pitch_body = radians(_parameters.land_flare_pitch_min_deg) *
-						     constrain((_flare_height - (_global_pos.alt - terrain_alt)) / _flare_height, 0.0f, 1.0f);
+				_flare_pitch_sp = radians(_parameters.land_flare_pitch_min_deg) *
+						  constrain((_flare_height - (_global_pos.alt - terrain_alt)) / _flare_height, 0.0f, 1.0f);
 			}
 
-			// otherwise continue using previous _att_sp.pitch_body
+			// otherwise continue using previous _flare_pitch_sp
 		}
 
+		_att_sp.pitch_body = _flare_pitch_sp;
 		_flare_curve_alt_rel_last = flare_curve_alt_rel;
 
 	} else {

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -211,6 +211,7 @@ private:
 	hrt_abstime _time_last_t_alt{0};			///< time at which we had last valid terrain alt */
 
 	float _flare_height{0.0f};				///< estimated height to ground at which flare started */
+	float _flare_pitch_sp{0.0f};			///< Current forced (i.e. not determined using TECS) flare pitch setpoint */
 	float _flare_curve_alt_rel_last{0.0f};
 	float _target_bearing{0.0f};				///< estimated height to ground at which flare started */
 


### PR DESCRIPTION
### Issue:
During fix-wing autolands, a flare is commanded by increasing a pitch reference as long as the downwards velocity is >0.1m/s as seen [here](https://github.com/PX4/Firmware/blob/master/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp#L1487). However, this pitch increase together with the fact that the motor may not be disabled yet (i.e. we have reached FW_LND_FLALT but not FW_LND_TLALT) can result in vel_d<0.1m/s (i.e. aircraft does not descend anymore or even ascends in altitude). In that case, [this line ](https://github.com/PX4/Firmware/blob/master/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp#L1492) indicates that the current pitch set point (att_sp.pitch_body) should just be kept, which is in general OK. However, [this line](https://github.com/PX4/Firmware/blob/master/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp#L1710) constantly increases att_sp.pitch_body with the pitch offset parameter during every iteration.  

This issue thus only occurs if FW_PSP_OFF!=0, and also just occurs during the flare-mode because in all other modes the attitude setpoint is constantly reset by TECS. This is probably why so few people (if any) have seen this bug so far. The result is however potentially disastrous, i.e. a pitch up including a stall of the aircraft can happen. This was tested in HIL so far, see the image below. Note the pitch_ref >90° ....

![screenshot from 2018-06-14 14-21-11_mod](https://user-images.githubusercontent.com/2565608/41412042-0d2d5b04-6fdf-11e8-9bfb-6d2201dbb4b0.png)

### Solution:
Introduce separate variable that is NOT automatically incremented by  [this line](https://github.com/PX4/Firmware/blob/master/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp#L1710). I also thought about whether we could just NOT increment att_sp in line 1710, and then just publish the att_sp.pitch+offset in that code section, but that seemed more tedious code-wise to me.

@tstastny FYI.