### PR TITLE
camera_trigger:Refacter GPIO camera triggering

### DIFF
--- a/src/drivers/camera_trigger/camera_trigger_params.c
+++ b/src/drivers/camera_trigger/camera_trigger_params.c
@@ -117,7 +117,7 @@ PARAM_DEFINE_INT32(TRIG_MODE, 0);
  * triggers on every pin individually. Example: Value 56 would trigger on pins 5 and 6.
  * For GPIO mode Pin 6 will be triggered followed by 5. With a value of 65 pin 5 will
  * be triggered followed by 6. Pins may be non contiguous. I.E. 16 or 61.
- * for GPIO mode the delay pin to pin is < .2 uS.
+ * In GPIO mode the delay pin to pin is < .2 uS.
  *
  * @min 1
  * @max 123456

--- a/src/drivers/camera_trigger/camera_trigger_params.c
+++ b/src/drivers/camera_trigger/camera_trigger_params.c
@@ -115,6 +115,9 @@ PARAM_DEFINE_INT32(TRIG_MODE, 0);
  * Selects which pin is used, ranges from 1 to 6 (AUX1-AUX6 on px4fmu-v2 and the rail
  * pins on px4fmu-v4). The PWM interface takes two pins per camera, while relay
  * triggers on every pin individually. Example: Value 56 would trigger on pins 5 and 6.
+ * For GPIO mode Pin 6 will be triggered followed by 5. With a value of 65 pin 5 will
+ * be triggered followed by 6. Pins may be non contiguous. I.E. 16 or 61.
+ * for GPIO mode the delay pin to pin is < .2 uS.
  *
  * @min 1
  * @max 123456

--- a/src/drivers/camera_trigger/interfaces/src/camera_interface.h
+++ b/src/drivers/camera_trigger/interfaces/src/camera_interface.h
@@ -27,7 +27,7 @@ public:
 	 * trigger the camera
 	 * @param enable
 	 */
-	virtual void trigger(bool enable) {}
+	virtual void trigger(bool trigger_on_true) {}
 
 	/**
 	 * send command to turn the camera on/off

--- a/src/drivers/camera_trigger/interfaces/src/gpio.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/gpio.cpp
@@ -7,12 +7,13 @@ constexpr uint32_t CameraInterfaceGPIO::_gpios[6];
 
 CameraInterfaceGPIO::CameraInterfaceGPIO():
 	CameraInterface(),
-	_trigger_invert(false)
+	_trigger_invert(false),
+	_triggers{0}
 {
 	_p_polarity = param_find("TRIG_POLARITY");
 
 	// polarity of the trigger (0 = active low, 1 = active high )
-	int polarity;
+	int32_t polarity;
 	param_get(_p_polarity, &polarity);
 	_trigger_invert = (polarity == 0);
 
@@ -26,8 +27,6 @@ CameraInterfaceGPIO::~CameraInterfaceGPIO()
 
 void CameraInterfaceGPIO::setup()
 {
-	memset(_triggers, 0, sizeof(_triggers));
-
 	for (unsigned i = 0, t = 0; i < arraySize(_pins); i++) {
 
 		// Pin range is from 1 to 6, indexes are 0 to 5

--- a/src/drivers/camera_trigger/interfaces/src/gpio.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/gpio.cpp
@@ -1,15 +1,20 @@
 #ifdef __PX4_NUTTX
 
 #include "gpio.h"
+#include <cstring>
 
 constexpr uint32_t CameraInterfaceGPIO::_gpios[6];
 
 CameraInterfaceGPIO::CameraInterfaceGPIO():
 	CameraInterface(),
-	_polarity(0)
+	_trigger_invert(false)
 {
 	_p_polarity = param_find("TRIG_POLARITY");
-	param_get(_p_polarity, &_polarity);
+
+	// polarity of the trigger (0 = active low, 1 = active high )
+	int polarity;
+	param_get(_p_polarity, &polarity);
+	_trigger_invert = (polarity == 0);
 
 	get_pins();
 	setup();
@@ -21,32 +26,30 @@ CameraInterfaceGPIO::~CameraInterfaceGPIO()
 
 void CameraInterfaceGPIO::setup()
 {
-	for (unsigned i = 0; i < arraySize(_pins); i++) {
-		// Pin range is from 0 to 5
+	memset(_triggers, 0, sizeof(_triggers));
+
+	for (unsigned i = 0, t = 0; i < arraySize(_pins); i++) {
+
+		// Pin range is from 1 to 6, indexes are 0 to 5
+
 		if (_pins[i] >= 0 && _pins[i] < (int)arraySize(_gpios)) {
-			px4_arch_configgpio(_gpios[_pins[i]]);
-			px4_arch_gpiowrite(_gpios[_pins[i]], !_polarity);
+			uint32_t gpio = _gpios[_pins[i]];
+			_triggers[t++] = gpio;
+			px4_arch_configgpio(gpio);
+			px4_arch_gpiowrite(gpio, false ^ _trigger_invert);
 		}
 	}
 }
 
-void CameraInterfaceGPIO::trigger(bool enable)
+void CameraInterfaceGPIO::trigger(bool trigger_on_true)
 {
-	if (enable) {
-		for (unsigned i = 0; i < arraySize(_pins); i++) {
-			if (_pins[i] >= 0 && _pins[i] < (int)arraySize(_gpios)) {
-				// ACTIVE_LOW == 1
-				px4_arch_gpiowrite(_gpios[_pins[i]], _polarity);
-			}
-		}
+	bool trigger_state = trigger_on_true ^ _trigger_invert;
 
-	} else {
-		for (unsigned i = 0; i < arraySize(_pins); i++) {
-			if (_pins[i] >= 0 && _pins[i] < (int)arraySize(_gpios)) {
-				// ACTIVE_LOW == 1
-				px4_arch_gpiowrite(_gpios[_pins[i]], !_polarity);
-			}
-		}
+	for (unsigned i = 0; i < arraySize(_triggers); i++) {
+
+		if (_triggers[i] == 0) { break; }
+
+		px4_arch_gpiowrite(_triggers[i], trigger_state);
 	}
 }
 
@@ -54,7 +57,7 @@ void CameraInterfaceGPIO::info()
 {
 	PX4_INFO("GPIO trigger mode, pins enabled : [%d][%d][%d][%d][%d][%d], polarity : %s",
 		 _pins[5], _pins[4], _pins[3], _pins[2], _pins[1], _pins[0],
-		 _polarity ? "ACTIVE_HIGH" : "ACTIVE_LOW");
+		 _trigger_invert ? "ACTIVE_LOW" : "ACTIVE_HIGH");
 }
 
 #endif /* ifdef __PX4_NUTTX */

--- a/src/drivers/camera_trigger/interfaces/src/gpio.h
+++ b/src/drivers/camera_trigger/interfaces/src/gpio.h
@@ -18,7 +18,7 @@ public:
 	CameraInterfaceGPIO();
 	virtual ~CameraInterfaceGPIO();
 
-	void trigger(bool enable);
+	void trigger(bool trigger_on_true);
 
 	void info();
 

--- a/src/drivers/camera_trigger/interfaces/src/gpio.h
+++ b/src/drivers/camera_trigger/interfaces/src/gpio.h
@@ -39,7 +39,7 @@ private:
 		GPIO_GPIO5_OUTPUT
 	};
 
-	uint32_t _triggers[arraySize(_gpios) + 1];
+	uint32_t _triggers[arraySize(_gpios)];
 };
 
 #endif /* ifdef __PX4_NUTTX */

--- a/src/drivers/camera_trigger/interfaces/src/gpio.h
+++ b/src/drivers/camera_trigger/interfaces/src/gpio.h
@@ -28,7 +28,7 @@ private:
 
 	param_t _p_polarity;
 
-	int _polarity;
+	bool _trigger_invert;
 
 	static constexpr uint32_t _gpios[6] = {
 		GPIO_GPIO0_OUTPUT,
@@ -39,6 +39,7 @@ private:
 		GPIO_GPIO5_OUTPUT
 	};
 
+	uint32_t _triggers[arraySize(_gpios) + 1];
 };
 
 #endif /* ifdef __PX4_NUTTX */

--- a/src/drivers/camera_trigger/interfaces/src/pwm.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.cpp
@@ -46,12 +46,12 @@ void CameraInterfacePWM::setup()
 
 }
 
-void CameraInterfacePWM::trigger(bool enable)
+void CameraInterfacePWM::trigger(bool trigger_on_true)
 {
 	for (unsigned i = 0; i < arraySize(_pins); i++) {
 		if (_pins[i] >= 0) {
 			// Set all valid pins to shoot or neutral levels
-			up_pwm_trigger_set(_pins[i], math::constrain(enable ? PWM_CAMERA_SHOOT : PWM_CAMERA_NEUTRAL, 1000, 2000));
+			up_pwm_trigger_set(_pins[i], math::constrain(trigger_on_true ? PWM_CAMERA_SHOOT : PWM_CAMERA_NEUTRAL, 1000, 2000));
 		}
 	}
 }

--- a/src/drivers/camera_trigger/interfaces/src/pwm.h
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.h
@@ -20,7 +20,7 @@ public:
 	CameraInterfacePWM();
 	virtual ~CameraInterfacePWM();
 
-	void trigger(bool enable);
+	void trigger(bool trigger_on_true);
 
 	void info();
 

--- a/src/drivers/camera_trigger/interfaces/src/seagull_map2.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/seagull_map2.cpp
@@ -52,7 +52,7 @@ void CameraInterfaceSeagull::setup()
 	PX4_ERR("Bad pin configuration - Seagull MAP2 requires 2 consecutive pins for control.");
 }
 
-void CameraInterfaceSeagull::trigger(bool enable)
+void CameraInterfaceSeagull::trigger(bool trigger_on_true)
 {
 
 	if (!_camera_is_on) {
@@ -62,7 +62,7 @@ void CameraInterfaceSeagull::trigger(bool enable)
 	for (unsigned i = 0; i < arraySize(_pins); i = i + 2) {
 		if (_pins[i] >= 0 && _pins[i + 1] >= 0) {
 			// Set channel 1 to shoot or neutral levels
-			up_pwm_trigger_set(_pins[i + 1], enable ? PWM_1_CAMERA_INSTANT_SHOOT : PWM_CAMERA_NEUTRAL);
+			up_pwm_trigger_set(_pins[i + 1], trigger_on_true ? PWM_1_CAMERA_INSTANT_SHOOT : PWM_CAMERA_NEUTRAL);
 		}
 	}
 }

--- a/src/drivers/camera_trigger/interfaces/src/seagull_map2.h
+++ b/src/drivers/camera_trigger/interfaces/src/seagull_map2.h
@@ -18,7 +18,7 @@ public:
 	CameraInterfaceSeagull();
 	virtual ~CameraInterfaceSeagull();
 
-	void trigger(bool enable);
+	void trigger(bool trigger_on_true);
 
 	void send_keep_alive(bool enable);
 


### PR DESCRIPTION
Refactored for efficiency and simplicity.

This preserves the ordering of GPIO firing order as LDS to MSD. (16 fires pin 6 then pin 1).
The delay on a auav-2.1 Pin to pin is .187 Us. 