### PR TITLE
launch fix for px4 shutdown

### DIFF
--- a/launch/posix_sitl.launch
+++ b/launch/posix_sitl.launch
@@ -26,7 +26,7 @@
     <!-- PX4 SITL -->
     <arg unless="$(arg interactive)" name="px4_command_arg1" value="-d"/>
     <arg     if="$(arg interactive)" name="px4_command_arg1" value=""/>
-    <node name="sitl" pkg="px4" type="px4" output="screen" args="$(find px4) $(arg rcS) $(arg px4_command_arg1)"/>
+    <node name="sitl" pkg="px4" type="px4" output="screen" args="$(find px4) $(arg rcS) $(arg px4_command_arg1)" required="true"/>
     <!-- Gazebo sim -->
     <include file="$(find gazebo_ros)/launch/empty_world.launch">
         <arg name="gui" value="$(arg gui)"/>


### PR DESCRIPTION
The problem mentioned here https://github.com/PX4/Firmware/issues/9667 was masked with a failure message that wasn't the actual issue. If we make the PX4 node required in the launch, we can see that the shutdown is what caused the test to stop. Setting the required arg means "If node dies, kill entire roslaunch." This makes sense to have because you can't do anything if the firmware dies anyway. In the case of our failure, PX4 died and the test continued to run, eventually failing because there were no messages being received, due to MAVROS having no connection to the FCU.

The fix for the problem has been merged in already https://github.com/PX4/Firmware/pull/9672. This only helps to correctly identify future issues of the same nature.

Here is what the error message looks like with this PR (note that it says "ROS shutdown request"):
![screenshot from 2018-06-14 12-19-43](https://user-images.githubusercontent.com/10533707/41440637-490c0e54-6ffd-11e8-8998-7fc9e75057fe.png)