### PR TITLE
posix_sitl_rtps fail to build (MACOS)

### DIFF
--- a/src/modules/micrortps_bridge/micrortps_client/microRTPS_client.h
+++ b/src/modules/micrortps_bridge/micrortps_client/microRTPS_client.h
@@ -54,6 +54,12 @@
 #define SLEEP_MS 1
 #define BAUDRATE B460800
 #define BAUDRATE_VAL 460800
+#ifndef B460800
+#define B460800 460800
+#endif
+#ifndef B921600
+#define B921600 921600
+#endif
 #define DEVICE "/dev/ttyACM0"
 #define POLL_MS 1
 #define DEFAULT_RECV_PORT 2019


### PR DESCRIPTION
missing defines for B460800 and B921600 in posix_sitl_rtps build on MAC.