### PR TITLE
ecl-ekf tools: set exit code to -1 if the log analysis fails -> CI check fails for failing SITL log analyis

### DIFF
--- a/Tools/ecl_ekf/analyse_logdata_ekf.py
+++ b/Tools/ecl_ekf/analyse_logdata_ekf.py
@@ -965,7 +965,7 @@ def analyse_ekf(estimator_status, ekf2_innovations, sensor_preflight, check_leve
         plt.xlabel('time (sec)')
         plt.grid()
         plt.subplot(3, 1, 2)
-        inclination = rad2deg * np.arcsin(estimator_status['states[18]'] / strength)
+        inclination = rad2deg * np.arcsin(estimator_status['states[18]'] / np.maximum(strength, np.finfo(np.float32).eps) )
         plt.plot(1e-6 * estimator_status['timestamp'], inclination, 'b')
         plt.ylabel('inclination (deg)')
         plt.xlabel('time (sec)')

--- a/Tools/ecl_ekf/analyse_logdata_ekf.py
+++ b/Tools/ecl_ekf/analyse_logdata_ekf.py
@@ -1166,7 +1166,7 @@ def analyse_ekf(estimator_status, ekf2_innovations, sensor_preflight, check_leve
     }
     # generate test metadata
     # reduction of innovation message data
-    if (innov_early_end_index > (innov_late_start_index + 100)):
+    if (innov_early_end_index > (innov_late_start_index + 50)):
         # Output Observer Tracking Errors
         test_results['output_obs_ang_err_median'][0] = np.median(
             ekf2_innovations['output_tracking_error[0]'][innov_late_start_index:innov_early_end_index + 1])
@@ -1175,7 +1175,7 @@ def analyse_ekf(estimator_status, ekf2_innovations, sensor_preflight, check_leve
         test_results['output_obs_pos_err_median'][0] = np.median(
             ekf2_innovations['output_tracking_error[2]'][innov_late_start_index:innov_early_end_index + 1])
     # reduction of status message data
-    if (early_end_index > (late_start_index + 100)):
+    if (early_end_index > (late_start_index + 50)):
         # IMU vibration checks
         temp = np.amax(estimator_status['vibe[0]'][late_start_index:early_end_index])
         if (temp > 0.0):

--- a/Tools/ecl_ekf/analyse_logdata_ekf.py
+++ b/Tools/ecl_ekf/analyse_logdata_ekf.py
@@ -1311,17 +1311,20 @@ def analyse_ekf(estimator_status, ekf2_innovations, sensor_preflight, check_leve
         test_results['master_status'][0] = 'Warning'
         test_results['imu_sensor_status'][0] = 'Warning'
         test_results['imu_vibration_check'][0] = 'Warning'
+        print('IMU vibration check warning.')
     if ((test_results.get('imu_dang_bias_median')[0] > check_levels.get('imu_dang_bias_median_warn')) or
             (test_results.get('imu_dvel_bias_median')[0] > check_levels.get('imu_dvel_bias_median_warn'))):
         test_results['master_status'][0] = 'Warning'
         test_results['imu_sensor_status'][0] = 'Warning'
         test_results['imu_bias_check'][0] = 'Warning'
+        print('IMU bias check warning.')
     if ((test_results.get('output_obs_ang_err_median')[0] > check_levels.get('obs_ang_err_median_warn')) or
             (test_results.get('output_obs_vel_err_median')[0] > check_levels.get('obs_vel_err_median_warn')) or
             (test_results.get('output_obs_pos_err_median')[0] > check_levels.get('obs_pos_err_median_warn'))):
         test_results['master_status'][0] = 'Warning'
         test_results['imu_sensor_status'][0] = 'Warning'
         test_results['imu_output_predictor_check'][0] = 'Warning'
+        print('IMU output predictor check warning.')
     # check for failures
     if ((test_results.get('magx_fail_percentage')[0] > check_levels.get('mag_fail_pct')) or
             (test_results.get('magy_fail_percentage')[0] > check_levels.get('mag_fail_pct')) or
@@ -1329,33 +1332,41 @@ def analyse_ekf(estimator_status, ekf2_innovations, sensor_preflight, check_leve
             (test_results.get('mag_percentage_amber')[0] > check_levels.get('mag_amber_fail_pct'))):
         test_results['master_status'][0] = 'Fail'
         test_results['mag_sensor_status'][0] = 'Fail'
+        print('Magnetometer sensor check failure.')
     if (test_results.get('yaw_fail_percentage')[0] > check_levels.get('yaw_fail_pct')):
         test_results['master_status'][0] = 'Fail'
         test_results['yaw_sensor_status'][0] = 'Fail'
+        print('Yaw sensor check failure.')
     if ((test_results.get('vel_fail_percentage')[0] > check_levels.get('vel_fail_pct')) or
             (test_results.get('vel_percentage_amber')[0] > check_levels.get('vel_amber_fail_pct'))):
         test_results['master_status'][0] = 'Fail'
         test_results['vel_sensor_status'][0] = 'Fail'
+        print('Velocity sensor check failure.')
     if ((test_results.get('pos_fail_percentage')[0] > check_levels.get('pos_fail_pct')) or
             (test_results.get('pos_percentage_amber')[0] > check_levels.get('pos_amber_fail_pct'))):
         test_results['master_status'][0] = 'Fail'
         test_results['pos_sensor_status'][0] = 'Fail'
+        print('Position sensor check failure.')
     if ((test_results.get('hgt_fail_percentage')[0] > check_levels.get('hgt_fail_pct')) or
             (test_results.get('hgt_percentage_amber')[0] > check_levels.get('hgt_amber_fail_pct'))):
         test_results['master_status'][0] = 'Fail'
         test_results['hgt_sensor_status'][0] = 'Fail'
+        print('Height sensor check failure.')
     if ((test_results.get('tas_fail_percentage')[0] > check_levels.get('tas_fail_pct')) or
             (test_results.get('tas_percentage_amber')[0] > check_levels.get('tas_amber_fail_pct'))):
         test_results['master_status'][0] = 'Fail'
         test_results['tas_sensor_status'][0] = 'Fail'
+        print('Airspeed sensor check failure.')
     if ((test_results.get('hagl_fail_percentage')[0] > check_levels.get('hagl_fail_pct')) or
             (test_results.get('hagl_percentage_amber')[0] > check_levels.get('hagl_amber_fail_pct'))):
         test_results['master_status'][0] = 'Fail'
         test_results['hagl_sensor_status'][0] = 'Fail'
+        print('Height above ground sensor check failure.')
     if ((test_results.get('ofx_fail_percentage')[0] > check_levels.get('flow_fail_pct')) or
             (test_results.get('ofy_fail_percentage')[0] > check_levels.get('flow_fail_pct'))):
         test_results['master_status'][0] = 'Fail'
         test_results['flow_sensor_status'][0] = 'Fail'
+        print('Optical flow sensor check failure.')
     if (test_results.get('filter_faults_max')[0] > 0):
         test_results['master_status'][0] = 'Fail'
         test_results['filter_fault_status'][0] = 'Fail'

--- a/Tools/ecl_ekf/batch_process_logdata_ekf.py
+++ b/Tools/ecl_ekf/batch_process_logdata_ekf.py
@@ -40,7 +40,7 @@ if not args.overwrite:
 
 # analyse all ulog files
 for ulog_file in ulog_files:
-    print("\n"+"loading "+ulog_file +" for analysis")
+    print("\n"+"loading " + ulog_file + " for analysis")
     if args.no_sensor_safety_margin:
         os.system("python process_logdata_ekf.py {} --no-sensor-safety-margin".format(ulog_file))
     else:

--- a/Tools/ecl_ekf/batch_process_logdata_ekf.py
+++ b/Tools/ecl_ekf/batch_process_logdata_ekf.py
@@ -14,6 +14,9 @@ parser.add_argument("directory_path")
 parser.add_argument('-o', '--overwrite', action='store_true',
                     help='Whether to overwrite an already analysed file. If a file with .pdf extension exists for a .ulg'
                          'file, the log file will be skipped from analysis unless this flag has been set.')
+parser.add_argument('--no-sensor-safety-margin', action='store_true',
+                    help='Whether to not cut-off 5s after take-off and 5s before landing '
+                         '(for certain sensors that might be influence by proximity to ground).')
 
 def is_valid_directory(parser, arg):
     if os.path.isdir(arg):
@@ -26,8 +29,8 @@ args = parser.parse_args()
 ulog_directory = args.directory_path
 print("\n"+"analysing the .ulg files in "+ulog_directory)
 
-# get all the ulog files found in the specified directory
-ulog_files = glob.glob(os.path.join(ulog_directory, '*.ulg'))
+# get all the ulog files found in the specified directory and in subdirectories
+ulog_files = glob.glob(os.path.join(ulog_directory, '**/*.ulg'), recursive=True)
 
 # remove the files already analysed unless the overwrite flag was specified. A ulog file is consired to be analysed if
 # a corresponding .pdf file exists.'
@@ -38,4 +41,7 @@ if not args.overwrite:
 # analyse all ulog files
 for ulog_file in ulog_files:
     print("\n"+"loading "+ulog_file +" for analysis")
-    os.system("python process_logdata_ekf.py '{}'".format(ulog_file))
+    if args.no_sensor_safety_margin:
+        os.system("python process_logdata_ekf.py {} --no-sensor-safety-margin".format(ulog_file))
+    else:
+        os.system("python process_logdata_ekf.py {}".format(ulog_file))

--- a/Tools/ecl_ekf/process_logdata_ekf.py
+++ b/Tools/ecl_ekf/process_logdata_ekf.py
@@ -3,11 +3,11 @@
 from __future__ import print_function
 
 import argparse
-import os
+import os, sys
 
 from pyulog import *
 
-from analyse_logdata_ekf import *
+from analyse_logdata_ekf import analyse_ekf
 
 """
 Performs a health assessment on the ecl EKF navigation estimator data contained in a an ULog file
@@ -21,6 +21,9 @@ parser.add_argument('--no-plots', action='store_true',
                     help='Whether to only analyse and not plot the summaries for developers.')
 parser.add_argument('--check-level-thresholds', type=str, default=None,
                     help='The csv file of fail and warning test thresholds for analysis.')
+parser.add_argument('--no-sensor-safety-margin', action='store_true',
+                    help='Whether to not cut-off 5s after take-off and 5s before landing '
+                         '(for certain sensors that might be influence by proximity to ground).')
 
 def is_valid_directory(parser, arg):
     if os.path.isdir(arg):
@@ -73,15 +76,8 @@ print('Using test criteria loaded from {:s}'.format(check_level_dict_filename))
 # perform the ekf analysis
 test_results = analyse_ekf(
     estimator_status_data, ekf2_innovations_data, sensor_preflight_data,
-    check_levels, plot=not args.no_plots, output_plot_filename=args.filename + ".pdf")
-
-# print master test status to console
-if (test_results['master_status'][0] == 'Pass'):
-    print('No anomalies detected')
-elif (test_results['master_status'][0] == 'Warning'):
-    print('Minor anomalies detected')
-elif (test_results['master_status'][0] == 'Fail'):
-    print('Major anomalies detected')
+    check_levels, plot=not args.no_plots, output_plot_filename=args.filename + ".pdf",
+    late_start_early_ending=not args.no_sensor_safety_margin)
 
 # write metadata to a .csv file
 with open(args.filename + ".mdat.csv", "w") as file:
@@ -99,3 +95,12 @@ print('Test results written to {:s}.mdat.csv'.format(args.filename))
 
 if not args.no_plots:
     print('Plots saved to {:s}.pdf'.format(args.filename))
+
+# print master test status to console
+if (test_results['master_status'][0] == 'Pass'):
+    print('No anomalies detected')
+elif (test_results['master_status'][0] == 'Warning'):
+    print('Minor anomalies detected')
+elif (test_results['master_status'][0] == 'Fail'):
+    print('Major anomalies detected')
+    sys.exit(-1)


### PR DESCRIPTION
This pull request sets the exit code of the log analysis script to -1 if the analysis detects a failure in the flight log. The CI check will therefore fail, if the log analysis of a SITL flight fails. The pr adds two additional small changes (see details below).

- `process_logdata_ekf`: exit with code -1 if whole system analysis fails
- `batch_process_logdata` and `process_logdata_ekf`: add arguments for analyzing without a sensor safety
margin to forward, the default mode will still stay as it used to
- reduce the minimum necessary log length for the analysis to 50 samples (at the moment the analysis is not performed for logs that have less than 100 innovation samples)