### PR TITLE
Fixed-wing autoland improvements

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -847,7 +847,7 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 
 			float alt_sp = pos_sp_curr.alt;
 
-			if (pos_sp_next.type == position_setpoint_s::SETPOINT_TYPE_LAND && pos_sp_next.valid) {
+			if (pos_sp_next.type == position_setpoint_s::SETPOINT_TYPE_LAND && pos_sp_next.valid && _l1_control.circle_mode()) {
 				// We're in a loiter directly before a landing WP. Enable our landing configuration (flaps,
 				// landing airspeed and potentially tighter throttle control) already such that we don't
 				// have to do this switch (which can cause significant altitude errors) close to the ground.

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1461,8 +1461,7 @@ FixedwingPositionControl::control_landing(const Vector2f &curr_pos, const Vector
 	 * horizontal limit (with some tolerance)
 	 * The horizontal limit is only applied when we are in front of the wp
 	 */
-	if (((_global_pos.alt < terrain_alt + _landingslope.flare_relative_alt()) &&
-	     (wp_distance_save < _landingslope.flare_length() + 5.0f)) ||
+	if ((_global_pos.alt < terrain_alt + _landingslope.flare_relative_alt()) ||
 	    _land_noreturn_vertical) {  //checking for land_noreturn to avoid unwanted climb out
 
 		/* land with minimal speed */
@@ -1479,7 +1478,9 @@ FixedwingPositionControl::control_landing(const Vector2f &curr_pos, const Vector
 			_att_sp.fw_control_yaw = true;
 		}
 
-		if (_global_pos.alt < terrain_alt + _landingslope.motor_lim_relative_alt() || _land_motor_lim) {
+		if (((_global_pos.alt < terrain_alt + _landingslope.motor_lim_relative_alt()) &&
+		     (wp_distance_save < _landingslope.flare_length() + 5.0f)) || // Only kill throttle when close to WP
+		    _land_motor_lim) {
 			throttle_max = min(throttle_max, _parameters.throttle_land_max);
 
 			if (!_land_motor_lim) {

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -75,6 +75,7 @@ FixedwingPositionControl::FixedwingPositionControl() :
 	_parameter_handles.land_thrust_lim_alt_relative = param_find("FW_LND_TLALT");
 	_parameter_handles.land_heading_hold_horizontal_distance = param_find("FW_LND_HHDIST");
 	_parameter_handles.land_use_terrain_estimate = param_find("FW_LND_USETER");
+	_parameter_handles.land_early_config_change = param_find("FW_LND_EARLYCFG");
 	_parameter_handles.land_airspeed_scale = param_find("FW_LND_AIRSPD_SC");
 	_parameter_handles.land_throtTC_scale = param_find("FW_LND_THRTC_SC");
 
@@ -148,6 +149,7 @@ FixedwingPositionControl::parameters_update()
 	param_get(_parameter_handles.land_flare_pitch_min_deg, &(_parameters.land_flare_pitch_min_deg));
 	param_get(_parameter_handles.land_flare_pitch_max_deg, &(_parameters.land_flare_pitch_max_deg));
 	param_get(_parameter_handles.land_use_terrain_estimate, &(_parameters.land_use_terrain_estimate));
+	param_get(_parameter_handles.land_early_config_change, &(_parameters.land_early_config_change));
 	param_get(_parameter_handles.land_airspeed_scale, &(_parameters.land_airspeed_scale));
 	param_get(_parameter_handles.land_throtTC_scale, &(_parameters.land_throtTC_scale));
 
@@ -847,7 +849,8 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 
 			float alt_sp = pos_sp_curr.alt;
 
-			if (pos_sp_next.type == position_setpoint_s::SETPOINT_TYPE_LAND && pos_sp_next.valid && _l1_control.circle_mode()) {
+			if (pos_sp_next.type == position_setpoint_s::SETPOINT_TYPE_LAND && pos_sp_next.valid
+			    && _l1_control.circle_mode() && _parameters.land_early_config_change == 1) {
 				// We're in a loiter directly before a landing WP. Enable our landing configuration (flaps,
 				// landing airspeed and potentially tighter throttle control) already such that we don't
 				// have to do this switch (which can cause significant altitude errors) close to the ground.

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -267,6 +267,7 @@ private:
 		float max_climb_rate;
 		float max_sink_rate;
 		float speed_weight;
+		float time_const_throt;
 
 		float airspeed_min;
 		float airspeed_trim;
@@ -294,6 +295,7 @@ private:
 		float land_flare_pitch_max_deg;
 		int32_t land_use_terrain_estimate;
 		float land_airspeed_scale;
+		float land_throtTC_scale;
 
 		// VTOL
 		float airspeed_trans;
@@ -357,6 +359,7 @@ private:
 		param_t land_flare_pitch_max_deg;
 		param_t land_use_terrain_estimate;
 		param_t land_airspeed_scale;
+		param_t land_throtTC_scale;
 
 		param_t vtol_type;
 	} _parameter_handles {};				///< handles for interesting parameters */
@@ -418,7 +421,7 @@ private:
 	bool		update_desired_altitude(float dt);
 
 	bool		control_position(const Vector2f &curr_pos, const Vector2f &ground_speed, const position_setpoint_s &pos_sp_prev,
-					 const position_setpoint_s &pos_sp_curr);
+					 const position_setpoint_s &pos_sp_curr, const position_setpoint_s &pos_sp_next);
 	void		control_takeoff(const Vector2f &curr_pos, const Vector2f &ground_speed, const position_setpoint_s &pos_sp_prev,
 					const position_setpoint_s &pos_sp_curr);
 	void		control_landing(const Vector2f &curr_pos, const Vector2f &ground_speed, const position_setpoint_s &pos_sp_prev,

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -294,6 +294,7 @@ private:
 		float land_flare_pitch_min_deg;
 		float land_flare_pitch_max_deg;
 		int32_t land_use_terrain_estimate;
+		int32_t land_early_config_change;
 		float land_airspeed_scale;
 		float land_throtTC_scale;
 
@@ -358,6 +359,7 @@ private:
 		param_t land_flare_pitch_min_deg;
 		param_t land_flare_pitch_max_deg;
 		param_t land_use_terrain_estimate;
+		param_t land_early_config_change;
 		param_t land_airspeed_scale;
 		param_t land_throtTC_scale;
 

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -329,6 +329,23 @@ PARAM_DEFINE_FLOAT(FW_LND_HHDIST, 15.0f);
 PARAM_DEFINE_INT32(FW_LND_USETER, 0);
 
 /**
+ * Early landing configuration deployment
+ *
+ * When set to 0/disabled, the landing configuration (flaps, landing airspeed, etc.) is only activated
+ * on the final approach to landing. When set to 1/enabled, it is already activated when entering the
+ * final loiter-down (loiter-to-alt) WP before the landing approach. This shifts the (often large)
+ * altitude and airspeed errors caused by the configuration change away from the ground such that
+ * these are not so critical. It also gives the controller enough time to adapt to the new
+ * configuration such that the landing approach starts with a cleaner initial state.
+ *
+ * @value 0 Disable early land configuration deployment
+ * @value 1 Enable early land configuration deployment
+ *
+ * @group FW L1 Control
+ */
+PARAM_DEFINE_INT32(FW_LND_EARLYCFG, 1);
+
+/**
  * Flare, minimum pitch
  *
  * Minimum pitch during flare, a positive sign means nose up
@@ -386,7 +403,7 @@ PARAM_DEFINE_FLOAT(FW_LND_AIRSPD_SC, 1.3f);
  * @min 0.2
  * @max 1.0
  * @increment 0.1
- * @group FW TECS
+ * @group FW L1 Control
  */
 PARAM_DEFINE_FLOAT(FW_LND_THRTC_SC, 1.0f);
 

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -374,6 +374,22 @@ PARAM_DEFINE_FLOAT(FW_LND_FL_PMAX, 15.0f);
  */
 PARAM_DEFINE_FLOAT(FW_LND_AIRSPD_SC, 1.3f);
 
+/**
+ * Throttle time constant factor for landing
+ *
+ * Set this parameter to <1.0 to make the TECS throttle loop react faster during
+ * landing than during normal flight (i.e. giving efficiency and low motor wear at
+ * high altitudes but control accuracy during landing). During landing, the TECS
+ * throttle time constant (FW_T_THRO_CONST) is multiplied by this value.
+ *
+ * @unit
+ * @min 0.2
+ * @max 1.0
+ * @increment 0.1
+ * @group FW TECS
+ */
+PARAM_DEFINE_FLOAT(FW_LND_THRTC_SC, 1.0f);
+
 
 
 /*

--- a/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
+++ b/src/modules/fw_pos_control_l1/fw_pos_control_l1_params.c
@@ -225,10 +225,10 @@ PARAM_DEFINE_FLOAT(FW_THR_MIN, 0.0f);
 PARAM_DEFINE_FLOAT(FW_THR_IDLE, 0.15f);
 
 /**
- * Throttle limit value before flare
+ * Throttle limit during landing below throttle limit altitude
  *
- * This throttle value will be set as throttle limit at FW_LND_TLALT,
- * before aircraft will flare.
+ * During the flare of the autonomous landing process, this value will be set
+ * as throttle limit when the aircraft altitude is below FW_LND_TLALT.
  *
  * @unit norm
  * @min 0.0
@@ -332,7 +332,7 @@ PARAM_DEFINE_INT32(FW_LND_USETER, 0);
  * Flare, minimum pitch
  *
  * Minimum pitch during flare, a positive sign means nose up
- * Applied once FW_LND_TLALT is reached
+ * Applied once FW_LND_FLALT is reached
  *
  * @unit deg
  * @min 0
@@ -347,7 +347,7 @@ PARAM_DEFINE_FLOAT(FW_LND_FL_PMIN, 2.5f);
  * Flare, maximum pitch
  *
  * Maximum pitch during flare, a positive sign means nose up
- * Applied once FW_LND_TLALT is reached
+ * Applied once FW_LND_FLALT is reached
  *
  * @unit deg
  * @min 0

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -243,7 +243,7 @@ MissionBlock::is_mission_item_reached()
 						&dist_xy, &dist_z);
 
 				if (dist >= 0.0f && dist <= _navigator->get_acceptance_radius(fabsf(_mission_item.loiter_radius) * 1.2f)
-				    && dist_z <= _navigator->get_altitude_acceptance_radius()) {
+				    && dist_z <= _navigator->get_default_altitude_acceptance_radius()) {
 
 					// now set the loiter to the final altitude in the NAV_CMD_LOITER_TO_ALT mission item
 					curr_sp->alt = altitude_amsl;
@@ -251,26 +251,15 @@ MissionBlock::is_mission_item_reached()
 				}
 
 			} else {
-				// Determine altitude acceptance radius. By default, this is taken from the respective parameter.
-				// However, before a landing approach the acceptance radius needs to be tighter: Assume a 30% error
-				// w.r.t. the remaining descent altitude is OK, but enforce min/max values (e.g. min=3m to make
-				// sure that the waypoint can still be reached in case of wrong user input).
-				float alt_accept_rad = _navigator->get_altitude_acceptance_radius();
-				struct position_setpoint_s next_sp = _navigator->get_position_setpoint_triplet()->next;
-
-				if (next_sp.type == position_setpoint_s::SETPOINT_TYPE_LAND && next_sp.valid) {
-					alt_accept_rad = math::constrain(0.3f * (curr_sp->alt - next_sp.alt), 3.0f,
-									 _navigator->get_altitude_acceptance_radius());
-					PX4_INFO("Accept:%5.3f", double(alt_accept_rad));
-				}
-
 				if (dist >= 0.0f && dist <= _navigator->get_acceptance_radius(fabsf(_mission_item.loiter_radius) * 1.2f)
-				    && dist_z <= alt_accept_rad) {
+				    && dist_z <= _navigator->get_altitude_acceptance_radius()) {
 
 					_waypoint_position_reached = true;
 
 					// set required yaw from bearing to the next mission item
 					if (_mission_item.force_heading) {
+						const position_setpoint_s &next_sp = _navigator->get_position_setpoint_triplet()->next;
+
 						if (next_sp.valid) {
 							_mission_item.yaw = get_bearing_to_next_waypoint(_navigator->get_global_position()->lat,
 									    _navigator->get_global_position()->lon,

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -182,6 +182,13 @@ public:
 	float		get_acceptance_radius();
 
 	/**
+	 * Get the default altitude acceptance radius (i.e. from parameters)
+	 *
+	 * @return the distance from the target altitude before considering the waypoint reached
+	 */
+	float		get_default_altitude_acceptance_radius();
+
+	/**
 	 * Get the altitude acceptance radius
 	 *
 	 * @return the distance from the target altitude before considering the waypoint reached

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -345,6 +345,8 @@ private:
 		(ParamFloat<px4::params::NAV_ACC_RAD>) _param_acceptance_radius,	/**< acceptance for takeoff */
 		(ParamFloat<px4::params::NAV_FW_ALT_RAD>)
 		_param_fw_alt_acceptance_radius,	/**< acceptance radius for fixedwing altitude */
+		(ParamFloat<px4::params::NAV_FW_ALTL_RAD>)
+		_param_fw_alt_lnd_acceptance_radius,	/**< acceptance radius for fixedwing altitude before landing*/
 		(ParamFloat<px4::params::NAV_MC_ALT_RAD>)
 		_param_mc_alt_acceptance_radius,	/**< acceptance radius for multicopter altitude */
 		(ParamInt<px4::params::NAV_FORCE_VT>) _param_force_vtol,	/**< acceptance radius for multicopter altitude */

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -868,15 +868,11 @@ float
 Navigator::get_altitude_acceptance_radius()
 {
 	if (!get_vstatus()->is_rotary_wing) {
-		// The fixed-wing altitude acceptance radius default is the respective parameter. However, before a landing
-		// approach it needs to be tighter: Assume a 30% error w.r.t. the remaining descent altitude is OK, but enforce
-		// min/max values (e.g. min=3m to make sure that the waypoint can still be reached in case of wrong user input).
-
 		const position_setpoint_s &next_sp = get_position_setpoint_triplet()->next;
-		const position_setpoint_s &curr_sp = get_position_setpoint_triplet()->current;
 
 		if (next_sp.type == position_setpoint_s::SETPOINT_TYPE_LAND && next_sp.valid) {
-			return math::constrain(0.3f * (curr_sp.alt - next_sp.alt), 3.0f, _param_fw_alt_acceptance_radius.get());
+			// Use separate (tighter) altitude acceptance for clean altitude starting point before landing
+			return _param_fw_alt_lnd_acceptance_radius.get();
 		}
 	}
 

--- a/src/modules/navigator/navigator_params.c
+++ b/src/modules/navigator/navigator_params.c
@@ -84,6 +84,20 @@ PARAM_DEFINE_FLOAT(NAV_ACC_RAD, 10.0f);
 PARAM_DEFINE_FLOAT(NAV_FW_ALT_RAD, 10.0f);
 
 /**
+ * FW Altitude Acceptance Radius before a landing
+ *
+ * Altitude acceptance used for the last waypoint before a fixed-wing landing. This is usually smaller
+ * than the standard vertical acceptance because close to the ground higher accuracy is required.
+ *
+ * @unit m
+ * @min 0.05
+ * @max 200.0
+ * @decimal 1
+ * @group Mission
+ */
+PARAM_DEFINE_FLOAT(NAV_FW_ALTL_RAD, 5.0f);
+
+/**
  * MC Altitude Acceptance Radius
  *
  * Acceptance radius for multicopter altitude.


### PR DESCRIPTION
Fixed-wing autoland seems quite suboptimal at the moment. We have had very mixed results during flight tests so far, i.e. while on small foamy-like platforms or when landing on huge runways you may not have any issues, on short-field landings with larger and more complex (e.g. different flap configurations, wide airspeed range) platforms in challenging environments you will definitely see the shortcomings of the current autoland. This PR therefore introduces some improvements:

### Improvements

1. **Airplane landing configuration activated during loiter down (commit 2448863)**
_Issue_: The landing configuration (i.e. setting the flaps and changing the airspeed from nominal to landing speed) was previously performed only when entering the final approach, i.e. at relatively low altitude above ground (15m is a good rule). In our flight tests, the flap and airspeed changes caused huge altitude errors (+5m), and the aircraft corrected by pitching down significantly and nearly slamming into the ground (alos because the integrators can wind up). This is extremely unsafe. _Solution_: The mode change (flaps, airspeed) is now performed when approaching the loiter-down WP, i.e. usually at much higher altitude of 50m+. The discontinuity is of course still there, but it happens at an altitude where it is safe and the controller (especially the integrators) still have plenty of time to adapt to this new configuration.

2. **Separate and tigther gains for landing (commit 2448863)**
_Issue_: To avoid motor wear and to allow a good flight efficiency, one usually wants to somewhat relax the TECS throttle time constant (FW_T_THRO_CONST). However, the alt/airspeed control may then not accurate enough for landings anymore. _Solution_: Introduced a throttle time constant scaling factor which is ONLY activated during landings (and loiter-down-to-landing) and is 100% by default such that it doesnt make a difference by default. Note that I am still debating a bit whether we should introduce even more landing-specific parameters (for example, the pitch setpoint offset FW_PSP_OFF changes quite a lot with flaps on our platform), but tried to reduce the amount of additional parameters in this PR. Any thoughts on that?

3. **Tighter altitude acceptance radius for landings (commit https://github.com/PX4/Firmware/commit/d8cc40c67c521ef35cf74d41ee28b7adb8fe0c11)**
_Issue_: Currently, the final decision on whether to enter the landing approch or not uses the standard altitude acceptance radius parameter for fixed wings (see [here](https://github.com/PX4/Firmware/blob/master/src/modules/navigator/mission_block.cpp#L255). This parameter is 10m by default, and we often set it to 20m because at higher altitudes it just does not matter. This is however not accurate enough for autolandings: Imagine you want to enter the landing approach at hAGL=15m, then the plane would still initiate the autoland at hAGL=5m...25m. Very unsafe and potentially not even feasible for the plane due to sink/climb rate constraints! _Solution_: A "relative" altitude acceptance radius, i.e. we assume a 30% error w.r.t. the remaining altitude difference to the landing waypoint can still be handled by the plane. Assuming hLandingApproach=15m, this means 4.5m of altitude acceptance radius. We of course constrain the altitude acceptance radius (see code).

4. **ALWAYS flare when close to the ground (commit https://github.com/PX4/Firmware/commit/02e380af538ea8ef80a433da8fa63f63ed7601fb)**
_Issue_: During previous flight testing, we were surprised to _sometimes_ see nice flares from the aircraft and sometimes not (i.e. the aircraft just impacted the ground with nominal sink speed of 0.5-0.8m/s). We always thought it is a tuning issue, but turns out it is also because the airplane _only_ flares when it is horizontally close enough to the landing waypoint. This can a) mean that the aircraft (e.g. simply due to errors in the altitude control) never really flares or b) that it will always flare at different altitudes AGL, so the impact velocity is always different. _Solution_: ALWAYS flare when close to the ground, thus guaranteeing a smooth landing in all cases. Note that the motor still _only_ shuts off when we are close to the land WP such that, e.g. if a downdraft pushed the aircraft too close to the ground, the aircraft still continues to fight that downdraft using the motor.

### Notes
 - These are simple effective fixes that make autoland better without changing its overall structure. I know it can be improved a lot, but I think implementing these improvements as a first-shot solution is very important.
 - This was discussed with @dagar already. @priseborough @tstastny @LorenzMeier I am looking for feedback on why the changes I propose would NOT be suitable/better than the current implementation (or what could be improved quickly and effectively without changing the overall code too much)
 - Tested extensively in HIL already, i.e. that all mode changes and parameter changes work. The final tests (both HIL + flight testing) will be performed after feedback from you guys and the respective code changes.