### PR TITLE
Airspeed sensors: scan all busses for sensor 

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -343,11 +343,7 @@ if [ ${VEHICLE_TYPE} == fw -o ${VEHICLE_TYPE} == vtol ]
 then
 	if param compare CBRK_AIRSPD_CHK 0
 	then
-		if sdp3x_airspeed start
-		then
-		else
-			sdp3x_airspeed start -b 2
-		fi
+		sdp3x_airspeed start -a
 
 		# Pixhawk 2.1 has a MS5611 on I2C which gets wrongly
 		# detected as MS5525 because the chip manufacturer was so
@@ -357,20 +353,13 @@ then
 		then
 			ms5525_airspeed start -b 2
 		else
-			ms5525_airspeed start
+			ms5525_airspeed start -a
 		fi
 
-		if ms4525_airspeed start
-		then
-		else
-			ms4525_airspeed start -b 2
-		fi
+		ms4525_airspeed start -a
 
-		if ets_airspeed start
-		then
-		else
-			ets_airspeed start -b 1
-		fi
+		ets_airspeed start -a
+
 	fi
 fi
 

--- a/src/drivers/differential_pressure/ets/ets_airspeed.cpp
+++ b/src/drivers/differential_pressure/ets/ets_airspeed.cpp
@@ -249,6 +249,9 @@ int bus_options[] = {
 #ifdef PX4_I2C_BUS_EXPANSION2
 	PX4_I2C_BUS_EXPANSION2,
 #endif
+#ifdef PX4_I2C_BUS_ONBOARD
+	PX4_I2C_BUS_ONBOARD,
+#endif
 };
 
 #define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))

--- a/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
+++ b/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
@@ -389,7 +389,7 @@ int bus_options[] = {
 #define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
 
 int start(int i2c_bus);
-bool start_bus(int i2c_bus);
+int start_bus(int i2c_bus);
 int stop();
 int reset();
 
@@ -412,7 +412,7 @@ start(int i2c_bus)
 
 }
 
-bool
+int
 start_bus(int i2c_bus)
 {
 	int fd;

--- a/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
+++ b/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
@@ -384,6 +384,9 @@ int bus_options[] = {
 #ifdef PX4_I2C_BUS_EXPANSION2
 	PX4_I2C_BUS_EXPANSION2,
 #endif
+#ifdef PX4_I2C_BUS_ONBOARD
+	PX4_I2C_BUS_ONBOARD,
+#endif
 };
 
 #define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))

--- a/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
+++ b/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
@@ -394,11 +394,13 @@ int stop();
 int reset();
 
 /**
- * Start the driver.
- *
- * This function call only returns once the driver is up and running
- * or failed to detect the sensor.
- */
+* Attempt to start driver on all available I2C busses.
+*
+* This function will return as soon as the first sensor
+* is detected on one of the available busses or if no
+* sensors are detected.
+*
+*/
 int
 start()
 {
@@ -412,6 +414,12 @@ start()
 
 }
 
+/**
+ * Start the driver on a specific bus.
+ *
+ * This function call only returns once the driver is up and running
+ * or failed to detect the sensor.
+ */
 int
 start_bus(int i2c_bus)
 {

--- a/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
+++ b/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
@@ -388,7 +388,7 @@ int bus_options[] = {
 
 #define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
 
-int start(int i2c_bus);
+int start();
 int start_bus(int i2c_bus);
 int stop();
 int reset();
@@ -400,7 +400,7 @@ int reset();
  * or failed to detect the sensor.
  */
 int
-start(int i2c_bus)
+start()
 {
 	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
 		if (start_bus(bus_options[i]) == PX4_OK) {
@@ -554,7 +554,7 @@ ms4525_airspeed_main(int argc, char *argv[])
 	 */
 	if (!strcmp(argv[myoptind], "start")) {
 		if (start_all) {
-			return meas_airspeed::start(i2c_bus);
+			return meas_airspeed::start();
 
 		} else {
 			return meas_airspeed::start_bus(i2c_bus);

--- a/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
+++ b/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
@@ -81,7 +81,6 @@
 #define MEAS_DRIVER_FILTER_FREQ 1.2f
 #define CONVERSION_INTERVAL	(1000000 / MEAS_RATE)	/* microseconds */
 
-#define PX4_I2C_ALL 0xFF
 
 class MEASAirspeed : public Airspeed
 {
@@ -403,18 +402,14 @@ int reset();
 int
 start(int i2c_bus)
 {
-	if (i2c_bus == PX4_I2C_ALL) {
-		for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
-			if (start_bus(bus_options[i]) == PX4_OK) {
-				return PX4_OK;
-			}
+	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
+		if (start_bus(bus_options[i]) == PX4_OK) {
+			return PX4_OK;
 		}
-
-		return PX4_ERROR;
-
-	} else {
-		return start_bus(i2c_bus);
 	}
+
+	return PX4_ERROR;
+
 }
 
 bool
@@ -531,6 +526,8 @@ ms4525_airspeed_main(int argc, char *argv[])
 	int ch;
 	const char *myoptarg = nullptr;
 
+	bool start_all = false;
+
 	while ((ch = px4_getopt(argc, argv, "ab:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'b':
@@ -538,7 +535,7 @@ ms4525_airspeed_main(int argc, char *argv[])
 			break;
 
 		case 'a':
-			i2c_bus = PX4_I2C_ALL;
+			start_all = true;
 			break;
 
 		default:
@@ -556,7 +553,13 @@ ms4525_airspeed_main(int argc, char *argv[])
 	 * Start/load the driver.
 	 */
 	if (!strcmp(argv[myoptind], "start")) {
-		return meas_airspeed::start(i2c_bus);
+		if (start_all) {
+			return meas_airspeed::start(i2c_bus);
+
+		} else {
+			return meas_airspeed::start_bus(i2c_bus);
+		}
+
 	}
 
 	/*

--- a/src/drivers/differential_pressure/ms5525/MS5525_main.cpp
+++ b/src/drivers/differential_pressure/ms5525/MS5525_main.cpp
@@ -53,6 +53,9 @@ int bus_options[] = {
 #ifdef PX4_I2C_BUS_EXPANSION2
 	PX4_I2C_BUS_EXPANSION2,
 #endif
+#ifdef PX4_I2C_BUS_ONBOARD
+	PX4_I2C_BUS_ONBOARD,
+#endif
 };
 
 #define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
@@ -179,12 +182,12 @@ int reset()
 static void
 ms5525_airspeed_usage()
 {
-	PX4_WARN("usage: ms5525_airspeed command [options]");
-	PX4_WARN("options:");
-	PX4_WARN("\t-b --bus i2cbus (%d)", PX4_I2C_BUS_DEFAULT);
+	PX4_INFO("usage: ms5525_airspeed command [options]");
+	PX4_INFO("options:");
+	PX4_INFO("\t-b --bus i2cbus (%d)", PX4_I2C_BUS_DEFAULT);
 	PX4_INFO("\t-a --all");
-	PX4_WARN("command:");
-	PX4_WARN("\tstart|stop|reset");
+	PX4_INFO("command:");
+	PX4_INFO("\tstart|stop|reset");
 }
 
 int

--- a/src/drivers/differential_pressure/sdp3x/SDP3X_main.cpp
+++ b/src/drivers/differential_pressure/sdp3x/SDP3X_main.cpp
@@ -42,15 +42,53 @@ namespace sdp3x_airspeed
 {
 SDP3X *g_dev = nullptr;
 
-int start(uint8_t i2c_bus);
+int bus_options[] = {
+#ifdef PX4_I2C_BUS_EXPANSION
+	PX4_I2C_BUS_EXPANSION,
+#endif
+#ifdef PX4_I2C_BUS_EXPANSION1
+	PX4_I2C_BUS_EXPANSION1,
+#endif
+#ifdef PX4_I2C_BUS_EXPANSION2
+	PX4_I2C_BUS_EXPANSION2,
+#endif
+};
+
+#define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
+
+int start();
+int start_bus(uint8_t i2c_bus);
 int stop();
 int reset();
 
-// Start the driver.
-// This function call only returns once the driver is up and running
-// or failed to detect the sensor.
+/**
+ * Attempt to start driver on all available I2C busses.
+ *
+ * This function will return as soon as the first sensor
+ * is detected on one of the available busses or if no
+ * sensors are detected.
+ *
+ */
 int
-start(uint8_t i2c_bus)
+start()
+{
+	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
+		if (start_bus(bus_options[i]) == PX4_OK) {
+			return PX4_OK;
+		}
+	}
+
+	return PX4_ERROR;
+}
+
+/**
+ * Start the driver on a specific bus.
+ *
+ * This function call only returns once the driver is up and running
+ * or failed to detect the sensor.
+ */
+int
+start_bus(uint8_t i2c_bus)
 {
 	int fd = -1;
 
@@ -156,6 +194,7 @@ sdp3x_airspeed_usage()
 	PX4_WARN("usage: sdp3x_airspeed command [options]");
 	PX4_WARN("options:");
 	PX4_WARN("\t-b --bus i2cbus (%d)", PX4_I2C_BUS_DEFAULT);
+	PX4_INFO("\t-a --all");
 	PX4_WARN("command:");
 	PX4_WARN("\tstart|stop|reset");
 }
@@ -168,11 +207,16 @@ sdp3x_airspeed_main(int argc, char *argv[])
 	int myoptind = 1;
 	int ch;
 	const char *myoptarg = nullptr;
+	bool start_all = false;
 
-	while ((ch = px4_getopt(argc, argv, "b:", &myoptind, &myoptarg)) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "ab:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'b':
 			i2c_bus = atoi(myoptarg);
+			break;
+
+		case 'a':
+			start_all = true;
 			break;
 
 		default:
@@ -191,7 +235,12 @@ sdp3x_airspeed_main(int argc, char *argv[])
 	 * Start/load the driver.
 	 */
 	if (!strcmp(argv[myoptind], "start")) {
-		return sdp3x_airspeed::start(i2c_bus);
+		if (start_all) {
+			return sdp3x_airspeed::start();
+
+		} else {
+			return sdp3x_airspeed::start_bus(i2c_bus);
+		}
 	}
 
 	/*

--- a/src/drivers/differential_pressure/sdp3x/SDP3X_main.cpp
+++ b/src/drivers/differential_pressure/sdp3x/SDP3X_main.cpp
@@ -52,6 +52,9 @@ int bus_options[] = {
 #ifdef PX4_I2C_BUS_EXPANSION2
 	PX4_I2C_BUS_EXPANSION2,
 #endif
+#ifdef PX4_I2C_BUS_ONBOARD
+	PX4_I2C_BUS_ONBOARD,
+#endif
 };
 
 #define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
@@ -191,12 +194,12 @@ int reset()
 static void
 sdp3x_airspeed_usage()
 {
-	PX4_WARN("usage: sdp3x_airspeed command [options]");
-	PX4_WARN("options:");
-	PX4_WARN("\t-b --bus i2cbus (%d)", PX4_I2C_BUS_DEFAULT);
+	PX4_INFO("usage: sdp3x_airspeed command [options]");
+	PX4_INFO("options:");
+	PX4_INFO("\t-b --bus i2cbus (%d)", PX4_I2C_BUS_DEFAULT);
 	PX4_INFO("\t-a --all");
-	PX4_WARN("command:");
-	PX4_WARN("\tstart|stop|reset");
+	PX4_INFO("command:");
+	PX4_INFO("\tstart|stop|reset");
 }
 
 int


### PR DESCRIPTION
Add -a argument to start airspeed sensor drivers and search for a device on all I2C busses. This is useful for platforms such as fmu-v5 that has 3 external i2c busses.

Still needs testing, but when it will be ok I will add this to all airspeed sensor drivers and change this also in the rc.sensors.