### PR TITLE
ekf2: Enable use of flow sensors not fitted with gyros

### DIFF
--- a/msg/optical_flow.msg
+++ b/msg/optical_flow.msg
@@ -4,9 +4,9 @@
 uint8 sensor_id			# id of the sensor emitting the flow value
 float32 pixel_flow_x_integral	# accumulated optical flow in radians where a positive value is produced by a RH rotation about the X body axis
 float32 pixel_flow_y_integral	# accumulated optical flow in radians where a positive value is produced by a RH rotation about the Y body axis
-float32 gyro_x_rate_integral	# accumulated gyro value in radians where a positive value is produced by a RH rotation about the X body axis
-float32 gyro_y_rate_integral	# accumulated gyro value in radians where a positive value is produced by a RH rotation about the Y body axis
-float32 gyro_z_rate_integral	# accumulated gyro value in radians where a positive value is produced by a RH rotation about the Z body axis
+float32 gyro_x_rate_integral	# accumulated gyro value in radians where a positive value is produced by a RH rotation about the X body axis. Set to NaN if flow sensor does not have 3-axis gyro data.
+float32 gyro_y_rate_integral	# accumulated gyro value in radians where a positive value is produced by a RH rotation about the Y body axis. Set to NaN if flow sensor does not have 3-axis gyro data.
+float32 gyro_z_rate_integral	# accumulated gyro value in radians where a positive value is produced by a RH rotation about the Z body axis. Set to NaN if flow sensor does not have 3-axis gyro data.
 float32 ground_distance_m	# Altitude / distance to ground in meters
 uint32 integration_timespan	# accumulation timespan in microseconds
 uint32 time_since_last_sonar_update	# time since last sonar update in microseconds


### PR DESCRIPTION
Updates the ecl to a version that is able to do the optical flow rate gyro delta angle integration internal to the EKF if NaN's are received on any of the optical_flow gyro rate integral messages.

Enables use of the Bitcraze flow deck.

See https://github.com/PX4/ecl/pull/458 for details