### PR TITLE
 LandDetector: Fix parameter descriptions

### DIFF
--- a/ROMFS/px4fmu_common/init.d/3100_tbs_caipirinha
+++ b/ROMFS/px4fmu_common/init.d/3100_tbs_caipirinha
@@ -16,7 +16,7 @@ then
 	param set FW_AIRSPD_MIN 12.5
 	param set FW_AIRSPD_TRIM 16.5
 	param set LNDFW_AIRSPD_MAX 6
-	param set LNDFW_VELI_MAX 4
+	param set LNDFW_XYACC_MAX 4
 	param set LNDFW_VEL_XY_MAX 3
 	param set LNDFW_VEL_Z_MAX 5
 	param set FW_R_TC 0.4

--- a/msg/sensor_bias.msg
+++ b/msg/sensor_bias.msg
@@ -3,9 +3,9 @@
 # scale errors, in-run bias and thermal drift (if thermal compensation is enabled and available).
 #
 
-float32 accel_x		# Bias corrected acceleration in body X axis (in rad/s)
-float32 accel_y		# Bias corrected acceleration in body Y axis (in rad/s)
-float32 accel_z		# Bias corrected acceleration in body Z axis (in rad/s)
+float32 accel_x		# Bias corrected acceleration in body X axis (in m/s^2)
+float32 accel_y		# Bias corrected acceleration in body Y axis (in m/s^2)
+float32 accel_z		# Bias corrected acceleration in body Z axis (in m/s^2)
 
 # In-run bias estimates (subtract from uncorrected data)
 

--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -54,7 +54,7 @@ FixedwingLandDetector::FixedwingLandDetector()
 	_paramHandle.maxVelocity = param_find("LNDFW_VEL_XY_MAX");
 	_paramHandle.maxClimbRate = param_find("LNDFW_VEL_Z_MAX");
 	_paramHandle.maxAirSpeed = param_find("LNDFW_AIRSPD_MAX");
-	_paramHandle.maxIntVelocity = param_find("LNDFW_VELI_MAX");
+	_paramHandle.maxXYAccel = param_find("LNDFW_XYACC_MAX");
 
 	// Use Trigger time when transitioning from in-air (false) to landed (true) / ground contact (true).
 	_landed_hysteresis.set_hysteresis_time_from(false, LANDED_TRIGGER_TIME_US);
@@ -81,7 +81,7 @@ void FixedwingLandDetector::_update_params()
 	param_get(_paramHandle.maxVelocity, &_params.maxVelocity);
 	param_get(_paramHandle.maxClimbRate, &_params.maxClimbRate);
 	param_get(_paramHandle.maxAirSpeed, &_params.maxAirSpeed);
-	param_get(_paramHandle.maxIntVelocity, &_params.maxIntVelocity);
+	param_get(_paramHandle.maxXYAccel, &_params.maxXYAccel);
 }
 
 float FixedwingLandDetector::_get_max_altitude()
@@ -130,7 +130,7 @@ bool FixedwingLandDetector::_get_landed_state()
 		landDetected = _velocity_xy_filtered < _params.maxVelocity
 			       && _velocity_z_filtered < _params.maxClimbRate
 			       && _airspeed_filtered < _params.maxAirSpeed
-			       && _accel_horz_lp < _params.maxIntVelocity;
+			       && _accel_horz_lp < _params.maxXYAccel;
 
 	} else {
 		// Control state topic has timed out and we need to assume we're landed.

--- a/src/modules/land_detector/FixedwingLandDetector.h
+++ b/src/modules/land_detector/FixedwingLandDetector.h
@@ -77,14 +77,14 @@ private:
 		param_t maxVelocity;
 		param_t maxClimbRate;
 		param_t maxAirSpeed;
-		param_t maxIntVelocity;
+		param_t maxXYAccel;
 	} _paramHandle{};
 
 	struct {
 		float maxVelocity;
 		float maxClimbRate;
 		float maxAirSpeed;
-		float maxIntVelocity;
+		float maxXYAccel;
 	} _params{};
 
 	int _airspeedSub{-1};

--- a/src/modules/land_detector/land_detector_params_fw.c
+++ b/src/modules/land_detector/land_detector_params_fw.c
@@ -51,27 +51,27 @@ PARAM_DEFINE_FLOAT(LNDFW_VEL_XY_MAX, 5.0f);
  * Maximum vertical velocity allowed in the landed state (m/s up and down)
  *
  * @unit m/s
- * @min 5
+ * @min 0.1
  * @max 20
  * @decimal 1
  *
  * @group Land Detector
  */
-PARAM_DEFINE_FLOAT(LNDFW_VEL_Z_MAX, 10.0f);
+PARAM_DEFINE_FLOAT(LNDFW_VEL_Z_MAX, 3.0f);
 
 /**
- * Fixedwing max short-term velocity
+ * Fixedwing max horizontal acceleration
  *
- * Maximum velocity integral in flight direction allowed in the landed state (m/s)
+ * Maximum horizontal (x,y body axes) acceleration allowed in the landed state (m/s^2)
  *
- * @unit m/s
+ * @unit m/s^2
  * @min 2
- * @max 10
+ * @max 15
  * @decimal 1
  *
  * @group Land Detector
  */
-PARAM_DEFINE_FLOAT(LNDFW_VELI_MAX, 8.0f);
+PARAM_DEFINE_FLOAT(LNDFW_XYACC_MAX, 8.0f);
 
 /**
  * Airspeed max


### PR DESCRIPTION
Both the parameter min/max values, their units, their descriptions as well as the respective variable names inside the code seemed quite outdated and sometimes wrong. This small PR fixes that.

@dagar