### PR TITLE
Distance sensors: scan all busses for sensor and remove nuttx deps 

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -381,25 +381,25 @@ fi
 # lightware serial lidar sensor
 if param greater SENS_EN_SF0X 0
 then
-	sf0x start
+	sf0x start -a
 fi
 
 # lightware i2c lidar sensor
 if param greater SENS_EN_SF1XX 0
 then
-	sf1xx start
+	sf1xx start -a
 fi
 
 # mb12xx sonar sensor
 if param greater SENS_EN_MB12XX 0
 then
-	mb12xx start
+	mb12xx start -a
 fi
 
 # teraranger one tof sensor
 if param greater SENS_EN_TRANGER 0
 then
-	teraranger start
+	teraranger start -a
 fi
 
 # Benewake TFMini

--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -381,7 +381,7 @@ fi
 # lightware serial lidar sensor
 if param greater SENS_EN_SF0X 0
 then
-	sf0x start -a
+	sf0x start
 fi
 
 # lightware i2c lidar sensor

--- a/src/drivers/differential_pressure/ets/ets_airspeed.cpp
+++ b/src/drivers/differential_pressure/ets/ets_airspeed.cpp
@@ -237,24 +237,7 @@ ETSAirspeed::cycle()
 namespace ets_airspeed
 {
 
-ETSAirspeed	*g_dev;
-
-int bus_options[] = {
-#ifdef PX4_I2C_BUS_EXPANSION
-	PX4_I2C_BUS_EXPANSION,
-#endif
-#ifdef PX4_I2C_BUS_EXPANSION1
-	PX4_I2C_BUS_EXPANSION1,
-#endif
-#ifdef PX4_I2C_BUS_EXPANSION2
-	PX4_I2C_BUS_EXPANSION2,
-#endif
-#ifdef PX4_I2C_BUS_ONBOARD
-	PX4_I2C_BUS_ONBOARD,
-#endif
-};
-
-#define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
+ETSAirspeed	*g_dev = nullptr;
 
 int start();
 int start_bus(int i2c_bus);
@@ -273,8 +256,8 @@ int info();
 int
 start()
 {
-	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
-		if (start_bus(bus_options[i]) == PX4_OK) {
+	for (unsigned i = 0; i < NUM_I2C_BUS_OPTIONS; i++) {
+		if (start_bus(i2c_bus_options[i]) == PX4_OK) {
 			return PX4_OK;
 		}
 	}
@@ -329,8 +312,6 @@ fail:
 		delete g_dev;
 		g_dev = nullptr;
 	}
-
-	PX4_WARN("not started on bus %d", i2c_bus);
 
 	return PX4_ERROR;
 }

--- a/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
+++ b/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
@@ -374,23 +374,6 @@ namespace meas_airspeed
 
 MEASAirspeed	*g_dev = nullptr;
 
-int bus_options[] = {
-#ifdef PX4_I2C_BUS_EXPANSION
-	PX4_I2C_BUS_EXPANSION,
-#endif
-#ifdef PX4_I2C_BUS_EXPANSION1
-	PX4_I2C_BUS_EXPANSION1,
-#endif
-#ifdef PX4_I2C_BUS_EXPANSION2
-	PX4_I2C_BUS_EXPANSION2,
-#endif
-#ifdef PX4_I2C_BUS_ONBOARD
-	PX4_I2C_BUS_ONBOARD,
-#endif
-};
-
-#define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
-
 int start();
 int start_bus(int i2c_bus);
 int stop();
@@ -407,8 +390,8 @@ int reset();
 int
 start()
 {
-	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
-		if (start_bus(bus_options[i]) == PX4_OK) {
+	for (unsigned i = 0; i < NUM_I2C_BUS_OPTIONS; i++) {
+		if (start_bus(i2c_bus_options[i]) == PX4_OK) {
 			return PX4_OK;
 		}
 	}
@@ -464,8 +447,6 @@ fail:
 		delete g_dev;
 		g_dev = nullptr;
 	}
-
-	PX4_WARN("not started on bus %d", i2c_bus);
 
 	return PX4_ERROR;
 }

--- a/src/drivers/differential_pressure/ms5525/MS5525_main.cpp
+++ b/src/drivers/differential_pressure/ms5525/MS5525_main.cpp
@@ -43,23 +43,6 @@ namespace ms5525_airspeed
 {
 MS5525 *g_dev = nullptr;
 
-int bus_options[] = {
-#ifdef PX4_I2C_BUS_EXPANSION
-	PX4_I2C_BUS_EXPANSION,
-#endif
-#ifdef PX4_I2C_BUS_EXPANSION1
-	PX4_I2C_BUS_EXPANSION1,
-#endif
-#ifdef PX4_I2C_BUS_EXPANSION2
-	PX4_I2C_BUS_EXPANSION2,
-#endif
-#ifdef PX4_I2C_BUS_ONBOARD
-	PX4_I2C_BUS_ONBOARD,
-#endif
-};
-
-#define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
-
 int start();
 int start_bus(uint8_t i2c_bus);
 int stop();
@@ -76,8 +59,8 @@ int reset();
 int
 start()
 {
-	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
-		if (start_bus(bus_options[i]) == PX4_OK) {
+	for (unsigned i = 0; i < NUM_I2C_BUS_OPTIONS; i++) {
+		if (start_bus(i2c_bus_options[i]) == PX4_OK) {
 			return PX4_OK;
 		}
 	}
@@ -132,8 +115,6 @@ fail:
 		delete g_dev;
 		g_dev = nullptr;
 	}
-
-	PX4_WARN("not started on bus %d", i2c_bus);
 
 	return PX4_ERROR;
 }

--- a/src/drivers/differential_pressure/sdp3x/SDP3X_main.cpp
+++ b/src/drivers/differential_pressure/sdp3x/SDP3X_main.cpp
@@ -42,23 +42,6 @@ namespace sdp3x_airspeed
 {
 SDP3X *g_dev = nullptr;
 
-int bus_options[] = {
-#ifdef PX4_I2C_BUS_EXPANSION
-	PX4_I2C_BUS_EXPANSION,
-#endif
-#ifdef PX4_I2C_BUS_EXPANSION1
-	PX4_I2C_BUS_EXPANSION1,
-#endif
-#ifdef PX4_I2C_BUS_EXPANSION2
-	PX4_I2C_BUS_EXPANSION2,
-#endif
-#ifdef PX4_I2C_BUS_ONBOARD
-	PX4_I2C_BUS_ONBOARD,
-#endif
-};
-
-#define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
-
 int start();
 int start_bus(uint8_t i2c_bus);
 int stop();
@@ -75,8 +58,8 @@ int reset();
 int
 start()
 {
-	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
-		if (start_bus(bus_options[i]) == PX4_OK) {
+	for (unsigned i = 0; i < NUM_I2C_BUS_OPTIONS; i++) {
+		if (start_bus(i2c_bus_options[i]) == PX4_OK) {
 			return PX4_OK;
 		}
 	}
@@ -144,8 +127,6 @@ fail:
 		delete g_dev;
 		g_dev = nullptr;
 	}
-
-	PX4_WARN("not started on bus %d", i2c_bus);
 
 	return PX4_ERROR;
 }

--- a/src/drivers/distance_sensor/mb12xx/mb12xx.cpp
+++ b/src/drivers/distance_sensor/mb12xx/mb12xx.cpp
@@ -761,7 +761,7 @@ start_bus(uint8_t rotation, int i2c_bus)
 	}
 
 	/* set the poll rate to default, starts automatic data collection */
-	fd = open(MB12XX_DEVICE_PATH, O_RDONLY);
+	fd = px4_open(MB12XX_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		goto fail;
@@ -771,13 +771,13 @@ start_bus(uint8_t rotation, int i2c_bus)
 		goto fail;
 	}
 
-	close(fd);
+	px4_close(fd);
 	return PX4_OK;
 
 fail:
 
 	if (fd >= 0) {
-		close(fd);
+		px4_close(fd);
 	}
 
 	if (g_dev != nullptr) {
@@ -819,7 +819,7 @@ test()
 	ssize_t sz;
 	int ret;
 
-	int fd = open(MB12XX_DEVICE_PATH, O_RDONLY);
+	int fd = px4_open(MB12XX_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		PX4_ERR("%s open failed (try 'mb12xx start' if the driver is not running)", MB12XX_DEVICE_PATH);
@@ -883,7 +883,7 @@ test()
 int
 reset()
 {
-	int fd = open(MB12XX_DEVICE_PATH, O_RDONLY);
+	int fd = px4_open(MB12XX_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		PX4_ERR("failed");
@@ -900,7 +900,7 @@ reset()
 		return PX4_ERROR;
 	}
 
-	close(fd);
+	px4_close(fd);
 	return PX4_OK;
 }
 

--- a/src/drivers/distance_sensor/mb12xx/mb12xx.cpp
+++ b/src/drivers/distance_sensor/mb12xx/mb12xx.cpp
@@ -683,23 +683,6 @@ namespace mb12xx
 
 MB12XX	*g_dev;
 
-int bus_options[] = {
-#ifdef PX4_I2C_BUS_EXPANSION
-	PX4_I2C_BUS_EXPANSION,
-#endif
-#ifdef PX4_I2C_BUS_EXPANSION1
-	PX4_I2C_BUS_EXPANSION1,
-#endif
-#ifdef PX4_I2C_BUS_EXPANSION2
-	PX4_I2C_BUS_EXPANSION2,
-#endif
-#ifdef PX4_I2C_BUS_ONBOARD
-	PX4_I2C_BUS_ONBOARD,
-#endif
-};
-
-#define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
-
 int 	start(uint8_t rotation);
 int 	start_bus(uint8_t rotation, int i2c_bus);
 int 	stop();
@@ -724,8 +707,8 @@ start(uint8_t rotation)
 		return PX4_ERROR;
 	}
 
-	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
-		if (start_bus(rotation, bus_options[i]) == PX4_OK) {
+	for (unsigned i = 0; i < NUM_I2C_BUS_OPTIONS; i++) {
+		if (start_bus(rotation, i2c_bus_options[i]) == PX4_OK) {
 			return PX4_OK;
 		}
 	}
@@ -785,7 +768,6 @@ fail:
 		g_dev = nullptr;
 	}
 
-	PX4_ERR("not started on bus %d", i2c_bus);
 	return PX4_ERROR;
 }
 

--- a/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
+++ b/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
@@ -696,6 +696,11 @@ start_bus(uint8_t rotation, int i2c_bus)
 {
 	int fd = -1;
 
+	if (g_dev != nullptr) {
+		PX4_ERR("already started");
+		return PX4_ERROR;
+	}
+
 	/* create the driver */
 	g_dev = new SF1XX(rotation, i2c_bus);
 

--- a/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
+++ b/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
@@ -75,7 +75,7 @@
 #include <board_config.h>
 
 /* Configuration Constants */
-#define SF1XX_BUS 		PX4_I2C_BUS_EXPANSION
+#define SF1XX_BUS_DEFAULT 		PX4_I2C_BUS_EXPANSION
 #define SF1XX_BASEADDR 	0x66
 #define SF1XX_DEVICE_PATH	"/dev/sf1xx"
 
@@ -87,7 +87,7 @@
 class SF1XX : public device::I2C
 {
 public:
-	SF1XX(uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING, int bus = SF1XX_BUS,
+	SF1XX(uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING, int bus = SF1XX_BUS_DEFAULT,
 	      int address = SF1XX_BASEADDR);
 	virtual ~SF1XX();
 
@@ -637,26 +637,69 @@ namespace sf1xx
 
 SF1XX	*g_dev;
 
-void	start(uint8_t rotation);
-void	stop();
-void	test();
-void	reset();
-void	info();
+int bus_options[] = {
+#ifdef PX4_I2C_BUS_EXPANSION
+	PX4_I2C_BUS_EXPANSION,
+#endif
+#ifdef PX4_I2C_BUS_EXPANSION1
+	PX4_I2C_BUS_EXPANSION1,
+#endif
+#ifdef PX4_I2C_BUS_EXPANSION2
+	PX4_I2C_BUS_EXPANSION2,
+#endif
+#ifdef PX4_I2C_BUS_ONBOARD
+	PX4_I2C_BUS_ONBOARD,
+#endif
+};
+
+#define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
+
+int 	start(uint8_t rotation);
+int 	start_bus(uint8_t rotation, int i2c_bus);
+int 	stop();
+int 	test();
+int 	reset();
+int 	info();
 
 /**
- * Start the driver.
+ *
+ * Attempt to start driver on all available I2C busses.
+ *
+ * This function will return as soon as the first sensor
+ * is detected on one of the available busses or if no
+ * sensors are detected.
+ *
  */
-void
+int
 start(uint8_t rotation)
+{
+	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
+		if (start_bus(rotation, bus_options[i]) == PX4_OK) {
+			return PX4_OK;
+		}
+	}
+
+	return PX4_ERROR;
+}
+
+/**
+ * Start the driver on a specific bus.
+ *
+ * This function only returns if the sensor is up and running
+ * or could not be detected successfully.
+ */
+int
+start_bus(uint8_t rotation, int i2c_bus)
 {
 	int fd = -1;
 
 	if (g_dev != nullptr) {
-		errx(1, "already started");
+		PX4_ERR("already started");
+		return PX4_ERROR;
 	}
 
 	/* create the driver */
-	g_dev = new SF1XX(rotation, SF1XX_BUS);
+	g_dev = new SF1XX(rotation, i2c_bus);
 
 	if (g_dev == nullptr) {
 		goto fail;
@@ -679,7 +722,7 @@ start(uint8_t rotation)
 	}
 
 	::close(fd);
-	exit(0);
+	return PX4_OK;
 
 fail:
 
@@ -688,23 +731,26 @@ fail:
 		g_dev = nullptr;
 	}
 
-	errx(1, "driver start failed");
+	PX4_ERR("not started on bus %d", i2c_bus);
+	return PX4_ERROR;
 }
 
 /**
  * Stop the driver
  */
-void stop()
+int
+stop()
 {
 	if (g_dev != nullptr) {
 		delete g_dev;
 		g_dev = nullptr;
 
 	} else {
-		errx(1, "driver not running");
+		PX4_ERR("driver not running");
+		return PX4_ERROR;
 	}
 
-	exit(0);
+	return PX4_OK;
 }
 
 /**
@@ -712,7 +758,7 @@ void stop()
  * make sure we can collect data from the sensor in polled
  * and automatic modes.
  */
-void
+int
 test()
 {
 	struct distance_sensor_s report;
@@ -722,21 +768,24 @@ test()
 	int fd = open(SF1XX_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
-		err(1, "%s open failed (try 'sf1xx start' if the driver is not running", SF1XX_DEVICE_PATH);
+		PX4_ERR("%s open failed (try 'sf1xx start' if the driver is not running)", SF1XX_DEVICE_PATH);
+		return PX4_ERROR;
 	}
 
 	/* do a simple demand read */
 	sz = read(fd, &report, sizeof(report));
 
 	if (sz != sizeof(report)) {
-		err(1, "immediate read failed");
+		PX4_ERR("immediate read failed");
+		return PX4_ERROR;
 	}
 
 	print_message(report);
 
 	/* start the sensor polling at 2Hz */
 	if (OK != ioctl(fd, SENSORIOCSPOLLRATE, 2)) {
-		errx(1, "failed to set 2Hz poll rate");
+		PX4_ERR("failed to set 2Hz poll rate");
+		return PX4_ERROR;
 	}
 
 	/* read the sensor 5x and report each value */
@@ -749,14 +798,16 @@ test()
 		ret = poll(&fds, 1, 2000);
 
 		if (ret != 1) {
-			errx(1, "timed out waiting for sensor data");
+			PX4_ERR("timed out waiting for sensor data");
+			return PX4_ERROR;
 		}
 
 		/* now go get it */
 		sz = read(fd, &report, sizeof(report));
 
 		if (sz != sizeof(report)) {
-			err(1, "periodic read failed");
+			PX4_ERR("periodic read failed");
+			return PX4_ERROR;
 		}
 
 		print_message(report);
@@ -764,54 +815,75 @@ test()
 
 	/* reset the sensor polling to default rate */
 	if (OK != ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT)) {
-		errx(1, "failed to set default poll rate");
+		PX4_ERR("failed to set default poll rate");
+		return PX4_ERROR;
 	}
 
 	::close(fd);
-	errx(0, "PASS");
+
+	PX4_INFO("PASS");
+	return PX4_OK;
 }
 
 /**
  * Reset the driver.
  */
-void
+int
 reset()
 {
 	int fd = open(SF1XX_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
-		err(1, "failed ");
+		PX4_ERR("failed");
+		return PX4_ERROR;
 	}
 
 	if (ioctl(fd, SENSORIOCRESET, 0) < 0) {
-		err(1, "driver reset failed");
+		PX4_ERR("driver reset failed");
+		return PX4_ERROR;
 	}
 
 	if (ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT) < 0) {
-		err(1, "driver poll restart failed");
+		PX4_ERR("driver poll restart failed");
+		return PX4_ERROR;
 	}
 
 	::close(fd);
-	exit(0);
+
+	return PX4_OK;
 }
 
 /**
  * Print a little info about the driver.
  */
-void
+int
 info()
 {
 	if (g_dev == nullptr) {
-		errx(1, "driver not running");
+		PX4_ERR("driver not running");
+		return PX4_ERROR;
 	}
 
 	printf("state @ %p\n", g_dev);
 	g_dev->print_info();
 
-	exit(0);
+	return PX4_OK;
 }
 
 } /* namespace */
+
+
+static void
+sf1xx_usage()
+{
+	PX4_INFO("usage: sf1xx command [options]");
+	PX4_INFO("options:");
+	PX4_INFO("\t-b --bus i2cbus (%d)", SF1XX_BUS_DEFAULT);
+	PX4_INFO("\t-a --all");
+	PX4_INFO("\t-R --rotation (%d)", distance_sensor_s::ROTATION_DOWNWARD_FACING);
+	PX4_INFO("command:");
+	PX4_INFO("\tstart|stop|test|reset|info");
+}
 
 int
 sf1xx_main(int argc, char *argv[])
@@ -820,16 +892,27 @@ sf1xx_main(int argc, char *argv[])
 	int myoptind = 1;
 	const char *myoptarg = nullptr;
 	uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
+	bool start_all = false;
 
-	while ((ch = px4_getopt(argc, argv, "R:", &myoptind, &myoptarg)) != EOF) {
+	int i2c_bus = SF1XX_BUS_DEFAULT;
+
+	while ((ch = px4_getopt(argc, argv, "ab:R:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'R':
 			rotation = (uint8_t)atoi(myoptarg);
 			break;
 
+		case 'b':
+			i2c_bus = atoi(myoptarg);
+			break;
+
+		case 'a':
+			start_all = true;
+			break;
+
 		default:
 			PX4_WARN("Unknown option!");
-			return -1;
+			goto out_error;
 		}
 	}
 
@@ -841,38 +924,43 @@ sf1xx_main(int argc, char *argv[])
 	 * Start/load the driver.
 	 */
 	if (!strcmp(argv[myoptind], "start")) {
-		sf1xx::start(rotation);
+		if (start_all) {
+			return sf1xx::start(rotation);
+
+		} else {
+			return sf1xx::start_bus(rotation, i2c_bus);
+		}
 	}
 
 	/*
 	 * Stop the driver
 	 */
 	if (!strcmp(argv[myoptind], "stop")) {
-		sf1xx::stop();
+		return sf1xx::stop();
 	}
 
 	/*
 	 * Test the driver/device.
 	 */
 	if (!strcmp(argv[myoptind], "test")) {
-		sf1xx::test();
+		return sf1xx::test();
 	}
 
 	/*
 	 * Reset the driver.
 	 */
 	if (!strcmp(argv[myoptind], "reset")) {
-		sf1xx::reset();
+		return sf1xx::reset();
 	}
 
 	/*
 	 * Print driver information.
 	 */
 	if (!strcmp(argv[myoptind], "info") || !strcmp(argv[myoptind], "status")) {
-		sf1xx::info();
+		return sf1xx::info();
 	}
 
 out_error:
-	PX4_ERR("unrecognized command, try 'start', 'test', 'reset' or 'info'");
-	return -1;
+	sf1xx_usage();
+	return PX4_ERROR;
 }

--- a/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
+++ b/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
@@ -713,18 +713,18 @@ start_bus(uint8_t rotation, int i2c_bus)
 	}
 
 	/* set the poll rate to default, starts automatic data collection */
-	fd = open(SF1XX_DEVICE_PATH, O_RDONLY);
+	fd = px4_open(SF1XX_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		goto fail;
 	}
 
 	if (ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT) < 0) {
-		::close(fd);
+		px4_close(fd);
 		goto fail;
 	}
 
-	::close(fd);
+	px4_close(fd);
 	return PX4_OK;
 
 fail:
@@ -768,7 +768,7 @@ test()
 	ssize_t sz;
 	int ret;
 
-	int fd = open(SF1XX_DEVICE_PATH, O_RDONLY);
+	int fd = px4_open(SF1XX_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		PX4_ERR("%s open failed (try 'sf1xx start' if the driver is not running)", SF1XX_DEVICE_PATH);
@@ -822,7 +822,7 @@ test()
 		return PX4_ERROR;
 	}
 
-	::close(fd);
+	px4_close(fd);
 
 	PX4_INFO("PASS");
 	return PX4_OK;
@@ -834,7 +834,7 @@ test()
 int
 reset()
 {
-	int fd = open(SF1XX_DEVICE_PATH, O_RDONLY);
+	int fd = px4_open(SF1XX_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		PX4_ERR("failed");
@@ -851,7 +851,7 @@ reset()
 		return PX4_ERROR;
 	}
 
-	::close(fd);
+	px4_close(fd);
 
 	return PX4_OK;
 }

--- a/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
+++ b/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
@@ -635,23 +635,6 @@ namespace sf1xx
 
 SF1XX	*g_dev;
 
-int bus_options[] = {
-#ifdef PX4_I2C_BUS_EXPANSION
-	PX4_I2C_BUS_EXPANSION,
-#endif
-#ifdef PX4_I2C_BUS_EXPANSION1
-	PX4_I2C_BUS_EXPANSION1,
-#endif
-#ifdef PX4_I2C_BUS_EXPANSION2
-	PX4_I2C_BUS_EXPANSION2,
-#endif
-#ifdef PX4_I2C_BUS_ONBOARD
-	PX4_I2C_BUS_ONBOARD,
-#endif
-};
-
-#define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
-
 int 	start(uint8_t rotation);
 int 	start_bus(uint8_t rotation, int i2c_bus);
 int 	stop();
@@ -676,8 +659,8 @@ start(uint8_t rotation)
 		return PX4_ERROR;
 	}
 
-	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
-		if (start_bus(rotation, bus_options[i]) == PX4_OK) {
+	for (unsigned i = 0; i < NUM_I2C_BUS_OPTIONS; i++) {
+		if (start_bus(rotation, i2c_bus_options[i]) == PX4_OK) {
 			return PX4_OK;
 		}
 	}
@@ -734,7 +717,6 @@ fail:
 		g_dev = nullptr;
 	}
 
-	PX4_ERR("not started on bus %d", i2c_bus);
 	return PX4_ERROR;
 }
 

--- a/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
+++ b/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
@@ -56,14 +56,12 @@
 #include <string.h>
 #include <fcntl.h>
 #include <poll.h>
-#include <errno.h>
 #include <stdio.h>
 #include <math.h>
 #include <unistd.h>
 #include <vector>
 
 #include <perf/perf_counter.h>
-#include <systemlib/err.h>
 
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_range_finder.h>
@@ -673,6 +671,11 @@ int 	info();
 int
 start(uint8_t rotation)
 {
+	if (g_dev != nullptr) {
+		PX4_ERR("already started");
+		return PX4_ERROR;
+	}
+
 	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
 		if (start_bus(rotation, bus_options[i]) == PX4_OK) {
 			return PX4_OK;
@@ -692,11 +695,6 @@ int
 start_bus(uint8_t rotation, int i2c_bus)
 {
 	int fd = -1;
-
-	if (g_dev != nullptr) {
-		PX4_ERR("already started");
-		return PX4_ERROR;
-	}
 
 	/* create the driver */
 	g_dev = new SF1XX(rotation, i2c_bus);

--- a/src/drivers/distance_sensor/srf02/srf02.cpp
+++ b/src/drivers/distance_sensor/srf02/srf02.cpp
@@ -686,23 +686,6 @@ namespace srf02
 
 SRF02	*g_dev;
 
-int bus_options[] = {
-#ifdef PX4_I2C_BUS_EXPANSION
-	PX4_I2C_BUS_EXPANSION,
-#endif
-#ifdef PX4_I2C_BUS_EXPANSION1
-	PX4_I2C_BUS_EXPANSION1,
-#endif
-#ifdef PX4_I2C_BUS_EXPANSION2
-	PX4_I2C_BUS_EXPANSION2,
-#endif
-#ifdef PX4_I2C_BUS_ONBOARD
-	PX4_I2C_BUS_ONBOARD,
-#endif
-};
-
-#define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
-
 int 	start(uint8_t rotation);
 int 	start_bus(uint8_t rotation, int i2c_bus);
 int 	stop();
@@ -727,8 +710,8 @@ start(uint8_t rotation)
 		return PX4_ERROR;
 	}
 
-	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
-		if (start_bus(rotation, bus_options[i]) == PX4_OK) {
+	for (unsigned i = 0; i < NUM_I2C_BUS_OPTIONS; i++) {
+		if (start_bus(rotation, i2c_bus_options[i]) == PX4_OK) {
 			return PX4_OK;
 		}
 	}
@@ -788,7 +771,6 @@ fail:
 		g_dev = nullptr;
 	}
 
-	PX4_ERR("not started on bus %d", i2c_bus);
 	return PX4_ERROR;
 }
 

--- a/src/drivers/distance_sensor/srf02/srf02.cpp
+++ b/src/drivers/distance_sensor/srf02/srf02.cpp
@@ -764,7 +764,7 @@ start_bus(uint8_t rotation, int i2c_bus)
 	}
 
 	/* set the poll rate to default, starts automatic data collection */
-	fd = open(SRF02_DEVICE_PATH, O_RDONLY);
+	fd = px4_open(SRF02_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		goto fail;
@@ -774,13 +774,13 @@ start_bus(uint8_t rotation, int i2c_bus)
 		goto fail;
 	}
 
-	close(fd);
+	px4_close(fd);
 	return PX4_OK;
 
 fail:
 
 	if (fd >= 0) {
-		close(fd);
+		px4_close(fd);
 	}
 
 	if (g_dev != nullptr) {
@@ -822,7 +822,7 @@ test()
 	ssize_t sz;
 	int ret;
 
-	int fd = open(SRF02_DEVICE_PATH, O_RDONLY);
+	int fd = px4_open(SRF02_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		PX4_ERR("%s open failed (try 'srf02 start' if the driver is not running)", SRF02_DEVICE_PATH);
@@ -886,7 +886,7 @@ test()
 int
 reset()
 {
-	int fd = open(SRF02_DEVICE_PATH, O_RDONLY);
+	int fd = px4_open(SRF02_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		PX4_ERR("failed");
@@ -903,7 +903,7 @@ reset()
 		return PX4_ERROR;
 	}
 
-	close(fd);
+	px4_close(fd);
 	return PX4_OK;
 }
 

--- a/src/drivers/distance_sensor/srf02/srf02.cpp
+++ b/src/drivers/distance_sensor/srf02/srf02.cpp
@@ -52,14 +52,12 @@
 #include <string.h>
 #include <fcntl.h>
 #include <poll.h>
-#include <errno.h>
 #include <stdio.h>
 #include <math.h>
 #include <unistd.h>
 #include <vector>
 
 #include <perf/perf_counter.h>
-#include <systemlib/err.h>
 
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_range_finder.h>
@@ -71,7 +69,7 @@
 #include <board_config.h>
 
 /* Configuration Constants */
-#define SRF02_BUS 		PX4_I2C_BUS_EXPANSION
+#define SRF02_BUS_DEFAULT		PX4_I2C_BUS_EXPANSION
 #define SRF02_BASEADDR 	0x70 /* 7-bit address. 8-bit address is 0xE0 */
 #define SRF02_DEVICE_PATH	"/dev/srf02"
 
@@ -96,7 +94,7 @@
 class SRF02 : public device::I2C
 {
 public:
-	SRF02(uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING, int bus = SRF02_BUS,
+	SRF02(uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING, int bus = SRF02_BUS_DEFAULT,
 	      int address = SRF02_BASEADDR);
 	virtual ~SRF02();
 
@@ -688,26 +686,74 @@ namespace srf02
 
 SRF02	*g_dev;
 
-void	start(uint8_t rotation);
-void	stop();
-void	test();
-void	reset();
-void	info();
+int bus_options[] = {
+#ifdef PX4_I2C_BUS_EXPANSION
+	PX4_I2C_BUS_EXPANSION,
+#endif
+#ifdef PX4_I2C_BUS_EXPANSION1
+	PX4_I2C_BUS_EXPANSION1,
+#endif
+#ifdef PX4_I2C_BUS_EXPANSION2
+	PX4_I2C_BUS_EXPANSION2,
+#endif
+#ifdef PX4_I2C_BUS_ONBOARD
+	PX4_I2C_BUS_ONBOARD,
+#endif
+};
+
+#define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
+
+int 	start(uint8_t rotation);
+int 	start_bus(uint8_t rotation, int i2c_bus);
+int 	stop();
+int 	test();
+int 	reset();
+int 	info();
 
 /**
- * Start the driver.
+ *
+ * Attempt to start driver on all available I2C busses.
+ *
+ * This function will return as soon as the first sensor
+ * is detected on one of the available busses or if no
+ * sensors are detected.
+ *
  */
-void
+int
 start(uint8_t rotation)
+{
+	if (g_dev != nullptr) {
+		PX4_ERR("already started");
+		return PX4_ERROR;
+	}
+
+	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
+		if (start_bus(rotation, bus_options[i]) == PX4_OK) {
+			return PX4_OK;
+		}
+	}
+
+	return PX4_ERROR;
+}
+
+/**
+ * Start the driver on a specific bus.
+ *
+ * This function only returns if the sensor is up and running
+ * or could not be detected successfully.
+ */
+int
+start_bus(uint8_t rotation, int i2c_bus)
 {
 	int fd = -1;
 
 	if (g_dev != nullptr) {
-		errx(1, "already started");
+		PX4_ERR("already started");
+		return PX4_ERROR;
 	}
 
 	/* create the driver */
-	g_dev = new SRF02(rotation, SRF02_BUS);
+	g_dev = new SRF02(rotation, i2c_bus);
 
 	if (g_dev == nullptr) {
 		goto fail;
@@ -729,7 +775,7 @@ start(uint8_t rotation)
 	}
 
 	close(fd);
-	exit(0);
+	return PX4_OK;
 
 fail:
 
@@ -742,23 +788,26 @@ fail:
 		g_dev = nullptr;
 	}
 
-	errx(1, "driver start failed");
+	PX4_ERR("not started on bus %d", i2c_bus);
+	return PX4_ERROR;
 }
 
 /**
  * Stop the driver
  */
-void stop()
+int
+stop()
 {
 	if (g_dev != nullptr) {
 		delete g_dev;
 		g_dev = nullptr;
 
 	} else {
-		errx(1, "driver not running");
+		PX4_ERR("driver not running");
+		return PX4_ERROR;
 	}
 
-	exit(0);
+	return PX4_OK;
 }
 
 /**
@@ -766,7 +815,7 @@ void stop()
  * make sure we can collect data from the sensor in polled
  * and automatic modes.
  */
-void
+int
 test()
 {
 	struct distance_sensor_s report;
@@ -776,21 +825,24 @@ test()
 	int fd = open(SRF02_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
-		err(1, "%s open failed (try 'srf02 start' if the driver is not running", SRF02_DEVICE_PATH);
+		PX4_ERR("%s open failed (try 'srf02 start' if the driver is not running)", SRF02_DEVICE_PATH);
+		return PX4_ERROR;
 	}
 
 	/* do a simple demand read */
 	sz = read(fd, &report, sizeof(report));
 
 	if (sz != sizeof(report)) {
-		err(1, "immediate read failed");
+		PX4_ERR("immediate read failed");
+		return PX4_ERROR;
 	}
 
 	print_message(report);
 
 	/* start the sensor polling at 2Hz */
 	if (OK != ioctl(fd, SENSORIOCSPOLLRATE, 2)) {
-		errx(1, "failed to set 2Hz poll rate");
+		PX4_ERR("failed to set 2Hz poll rate");
+		return PX4_ERROR;
 	}
 
 	/* read the sensor 5x and report each value */
@@ -803,14 +855,16 @@ test()
 		ret = poll(&fds, 1, 2000);
 
 		if (ret != 1) {
-			errx(1, "timed out waiting for sensor data");
+			PX4_ERR("timed out waiting for sensor data");
+			return PX4_ERROR;
 		}
 
 		/* now go get it */
 		sz = read(fd, &report, sizeof(report));
 
 		if (sz != sizeof(report)) {
-			err(1, "periodic read failed");
+			PX4_ERR("periodic read failed");
+			return PX4_ERROR;
 		}
 
 		print_message(report);
@@ -818,52 +872,71 @@ test()
 
 	/* reset the sensor polling to default rate */
 	if (OK != ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT)) {
-		errx(1, "failed to set default poll rate");
+		PX4_ERR("failed to set default poll rate");
+		return PX4_ERROR;
 	}
 
-	errx(0, "PASS");
+	PX4_INFO("PASS");
+	return PX4_OK;
 }
 
 /**
  * Reset the driver.
  */
-void
+int
 reset()
 {
 	int fd = open(SRF02_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
-		err(1, "failed ");
+		PX4_ERR("failed");
+		return PX4_ERROR;
 	}
 
 	if (ioctl(fd, SENSORIOCRESET, 0) < 0) {
-		err(1, "driver reset failed");
+		PX4_ERR("driver reset failed");
+		return PX4_ERROR;
 	}
 
 	if (ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT) < 0) {
-		err(1, "driver poll restart failed");
+		PX4_ERR("driver poll restart failed");
+		return PX4_ERROR;
 	}
 
-	exit(0);
+	return PX4_OK;
 }
 
 /**
  * Print a little info about the driver.
  */
-void
+int
 info()
 {
 	if (g_dev == nullptr) {
-		errx(1, "driver not running");
+		PX4_ERR("driver not running");
+		return PX4_ERROR;
 	}
 
 	printf("state @ %p\n", g_dev);
 	g_dev->print_info();
 
-	exit(0);
+	return PX4_OK;
 }
 
 } /* namespace */
+
+
+static void
+srf02_usage()
+{
+	PX4_INFO("usage: srf02 command [options]");
+	PX4_INFO("options:");
+	PX4_INFO("\t-b --bus i2cbus (%d)", SRF02_BUS_DEFAULT);
+	PX4_INFO("\t-a --all");
+	PX4_INFO("\t-R --rotation (%d)", distance_sensor_s::ROTATION_DOWNWARD_FACING);
+	PX4_INFO("command:");
+	PX4_INFO("\tstart|stop|test|reset|info");
+}
 
 int
 srf02_main(int argc, char *argv[])
@@ -872,16 +945,27 @@ srf02_main(int argc, char *argv[])
 	int myoptind = 1;
 	const char *myoptarg = nullptr;
 	uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
+	bool start_all = false;
 
-	while ((ch = px4_getopt(argc, argv, "R:", &myoptind, &myoptarg)) != EOF) {
+	int i2c_bus = SRF02_BUS_DEFAULT;
+
+	while ((ch = px4_getopt(argc, argv, "ab:R:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'R':
 			rotation = (uint8_t)atoi(myoptarg);
 			break;
 
+		case 'b':
+			i2c_bus = atoi(myoptarg);
+			break;
+
+		case 'a':
+			start_all = true;
+			break;
+
 		default:
 			PX4_WARN("Unknown option!");
-			return -1;
+			goto out_error;
 		}
 	}
 
@@ -893,38 +977,43 @@ srf02_main(int argc, char *argv[])
 	 * Start/load the driver.
 	 */
 	if (!strcmp(argv[myoptind], "start")) {
-		srf02::start(rotation);
+		if (start_all) {
+			return srf02::start(rotation);
+
+		} else {
+			return srf02::start_bus(rotation, i2c_bus);
+		}
 	}
 
 	/*
 	 * Stop the driver
 	 */
 	if (!strcmp(argv[myoptind], "stop")) {
-		srf02::stop();
+		return srf02::stop();
 	}
 
 	/*
 	 * Test the driver/device.
 	 */
 	if (!strcmp(argv[myoptind], "test")) {
-		srf02::test();
+		return srf02::test();
 	}
 
 	/*
 	 * Reset the driver.
 	 */
 	if (!strcmp(argv[myoptind], "reset")) {
-		srf02::reset();
+		return srf02::reset();
 	}
 
 	/*
 	 * Print driver information.
 	 */
 	if (!strcmp(argv[myoptind], "info") || !strcmp(argv[myoptind], "status")) {
-		srf02::info();
+		return srf02::info();
 	}
 
 out_error:
-	PX4_ERR("unrecognized command, try 'start', 'test', 'reset' or 'info'");
+	srf02_usage();
 	return PX4_ERROR;
 }

--- a/src/drivers/distance_sensor/srf02/srf02.cpp
+++ b/src/drivers/distance_sensor/srf02/srf02.cpp
@@ -903,6 +903,7 @@ reset()
 		return PX4_ERROR;
 	}
 
+	close(fd);
 	return PX4_OK;
 }
 

--- a/src/drivers/distance_sensor/teraranger/teraranger.cpp
+++ b/src/drivers/distance_sensor/teraranger/teraranger.cpp
@@ -807,6 +807,11 @@ start_bus(uint8_t rotation, int i2c_bus)
 {
 	int fd = -1;
 
+	if (g_dev != nullptr) {
+		PX4_ERR("already started");
+		return PX4_ERROR;
+	}
+
 	/* create the driver */
 	g_dev = new TERARANGER(rotation, i2c_bus);
 

--- a/src/drivers/distance_sensor/teraranger/teraranger.cpp
+++ b/src/drivers/distance_sensor/teraranger/teraranger.cpp
@@ -825,7 +825,7 @@ start_bus(uint8_t rotation, int i2c_bus)
 	}
 
 	/* set the poll rate to default, starts automatic data collection */
-	fd = open(TERARANGER_DEVICE_PATH, O_RDONLY);
+	fd = px4_open(TERARANGER_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		goto fail;
@@ -835,13 +835,13 @@ start_bus(uint8_t rotation, int i2c_bus)
 		goto fail;
 	}
 
-	close(fd);
+	px4_close(fd);
 	return PX4_OK;
 
 fail:
 
 	if (fd >= 0) {
-		close(fd);
+		px4_close(fd);
 	}
 
 	if (g_dev != nullptr) {
@@ -883,7 +883,7 @@ test()
 	ssize_t sz;
 	int ret;
 
-	int fd = open(TERARANGER_DEVICE_PATH, O_RDONLY);
+	int fd = px4_open(TERARANGER_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		PX4_ERR("%s open failed (try 'teraranger start' if the driver is not running)", TERARANGER_DEVICE_PATH);
@@ -937,7 +937,7 @@ test()
 		return PX4_ERROR;
 	}
 
-	close(fd);
+	px4_close(fd);
 	PX4_INFO("PASS");
 	return PX4_OK;
 
@@ -949,7 +949,7 @@ test()
 int
 reset()
 {
-	int fd = open(TERARANGER_DEVICE_PATH, O_RDONLY);
+	int fd = px4_open(TERARANGER_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		PX4_ERR("failed");
@@ -966,7 +966,7 @@ reset()
 		return PX4_ERROR;
 	}
 
-	close(fd);
+	px4_close(fd);
 	return PX4_OK;
 }
 

--- a/src/drivers/distance_sensor/teraranger/teraranger.cpp
+++ b/src/drivers/distance_sensor/teraranger/teraranger.cpp
@@ -746,23 +746,6 @@ namespace teraranger
 
 TERARANGER	*g_dev;
 
-int bus_options[] = {
-#ifdef PX4_I2C_BUS_EXPANSION
-	PX4_I2C_BUS_EXPANSION,
-#endif
-#ifdef PX4_I2C_BUS_EXPANSION1
-	PX4_I2C_BUS_EXPANSION1,
-#endif
-#ifdef PX4_I2C_BUS_EXPANSION2
-	PX4_I2C_BUS_EXPANSION2,
-#endif
-#ifdef PX4_I2C_BUS_ONBOARD
-	PX4_I2C_BUS_ONBOARD,
-#endif
-};
-
-#define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
-
 int 	start(uint8_t rotation);
 int 	start_bus(uint8_t rotation, int i2c_bus);
 int 	stop();
@@ -787,8 +770,8 @@ start(uint8_t rotation)
 		return PX4_ERROR;
 	}
 
-	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
-		if (start_bus(rotation, bus_options[i]) == PX4_OK) {
+	for (unsigned i = 0; i < NUM_I2C_BUS_OPTIONS; i++) {
+		if (start_bus(rotation, i2c_bus_options[i]) == PX4_OK) {
 			return PX4_OK;
 		}
 	}
@@ -849,7 +832,6 @@ fail:
 		g_dev = nullptr;
 	}
 
-	PX4_ERR("not started on bus %d", i2c_bus);
 	return PX4_ERROR;
 }
 

--- a/src/drivers/distance_sensor/teraranger/teraranger.cpp
+++ b/src/drivers/distance_sensor/teraranger/teraranger.cpp
@@ -71,7 +71,7 @@
 #include <board_config.h>
 
 /* Configuration Constants */
-#define TERARANGER_BUS           PX4_I2C_BUS_EXPANSION
+#define TERARANGER_BUS_DEFAULT           PX4_I2C_BUS_EXPANSION
 #define TRONE_BASEADDR      0x30 /* 7-bit address */
 #define TREVO_BASEADDR      0x31 /* 7-bit address */
 #define TERARANGER_DEVICE_PATH   	"/dev/teraranger"
@@ -101,7 +101,7 @@ class TERARANGER : public device::I2C
 {
 public:
 	TERARANGER(uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING,
-		   int bus = TERARANGER_BUS, int address = TRONE_BASEADDR);
+		   int bus = TERARANGER_BUS_DEFAULT, int address = TRONE_BASEADDR);
 	virtual ~TERARANGER();
 
 	virtual int 		init();
@@ -748,26 +748,69 @@ namespace teraranger
 
 TERARANGER	*g_dev;
 
-void	start(uint8_t rotation);
-void	stop();
-void	test();
-void	reset();
-void	info();
+int bus_options[] = {
+#ifdef PX4_I2C_BUS_EXPANSION
+	PX4_I2C_BUS_EXPANSION,
+#endif
+#ifdef PX4_I2C_BUS_EXPANSION1
+	PX4_I2C_BUS_EXPANSION1,
+#endif
+#ifdef PX4_I2C_BUS_EXPANSION2
+	PX4_I2C_BUS_EXPANSION2,
+#endif
+#ifdef PX4_I2C_BUS_ONBOARD
+	PX4_I2C_BUS_ONBOARD,
+#endif
+};
+
+#define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
+
+int 	start(uint8_t rotation);
+int 	start_bus(uint8_t rotation, int i2c_bus);
+int 	stop();
+int 	test();
+int 	reset();
+int 	info();
 
 /**
  * Start the driver.
+ * Attempt to start driver on all available I2C busses.
+ *
+ * This function will return as soon as the first sensor
+ * is detected on one of the available busses or if no
+ * sensors are detected.
+ *
  */
-void
+int
 start(uint8_t rotation)
+{
+	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
+		if (start_bus(rotation, bus_options[i]) == PX4_OK) {
+			return PX4_OK;
+		}
+	}
+
+	return PX4_ERROR;
+}
+
+/**
+ * Start the driver on a specific bus.
+ *
+ * This function only returns if the sensor is up and running
+ * or could not be detected successfully.
+ */
+int
+start_bus(uint8_t rotation, int i2c_bus)
 {
 	int fd;
 
 	if (g_dev != nullptr) {
-		errx(1, "already started");
+		PX4_ERR("already started");
+		return PX4_ERROR;
 	}
 
 	/* create the driver */
-	g_dev = new TERARANGER(rotation, TERARANGER_BUS);
+	g_dev = new TERARANGER(rotation, i2c_bus);
 
 
 	if (g_dev == nullptr) {
@@ -789,7 +832,7 @@ start(uint8_t rotation)
 		goto fail;
 	}
 
-	exit(0);
+	return PX4_OK;
 
 fail:
 
@@ -798,23 +841,26 @@ fail:
 		g_dev = nullptr;
 	}
 
-	errx(1, "driver start failed");
+	PX4_WARN("not started on bus %d", i2c_bus);
+	return PX4_ERROR;
 }
 
 /**
  * Stop the driver
  */
-void stop()
+int
+stop()
 {
 	if (g_dev != nullptr) {
 		delete g_dev;
 		g_dev = nullptr;
 
 	} else {
-		errx(1, "driver not running");
+		PX4_ERR("driver not running");
+		return PX4_ERROR;
 	}
 
-	exit(0);
+	return PX4_OK;
 }
 
 /**
@@ -822,7 +868,7 @@ void stop()
  * make sure we can collect data from the sensor in polled
  * and automatic modes.
  */
-void
+int
 test()
 {
 	struct distance_sensor_s report;
@@ -832,21 +878,24 @@ test()
 	int fd = open(TERARANGER_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
-		err(1, "%s open failed (try 'teraranger start' if the driver is not running", TERARANGER_DEVICE_PATH);
+		PX4_ERR("%s open failed (try 'teraranger start' if the driver is not running)", TERARANGER_DEVICE_PATH);
+		return PX4_ERROR;
 	}
 
 	/* do a simple demand read */
 	sz = read(fd, &report, sizeof(report));
 
 	if (sz != sizeof(report)) {
-		err(1, "immediate read failed");
+		PX4_ERR("immediate read failed");
+		return PX4_ERROR;
 	}
 
 	print_message(report);
 
 	/* start the sensor polling at 2Hz */
 	if (OK != ioctl(fd, SENSORIOCSPOLLRATE, 2)) {
-		errx(1, "failed to set 2Hz poll rate");
+		PX4_ERR("failed to set 2Hz poll rate");
+		return PX4_ERROR;
 	}
 
 	/* read the sensor 50x and report each value */
@@ -859,14 +908,16 @@ test()
 		ret = poll(&fds, 1, 2000);
 
 		if (ret != 1) {
-			errx(1, "timed out waiting for sensor data");
+			PX4_ERR("timed out waiting for sensor data");
+			return PX4_ERROR;
 		}
 
 		/* now go get it */
 		sz = read(fd, &report, sizeof(report));
 
 		if (sz != sizeof(report)) {
-			err(1, "periodic read failed");
+			PX4_ERR("periodic read failed");
+			return PX4_ERROR;
 		}
 
 		print_message(report);
@@ -874,52 +925,72 @@ test()
 
 	/* reset the sensor polling to default rate */
 	if (OK != ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT)) {
-		errx(1, "failed to set default poll rate");
+		PX4_ERR("failed to set default poll rate");
+		return PX4_ERROR;
 	}
 
-	errx(0, "PASS");
+	PX4_INFO("PASS");
+	return PX4_OK;
+
 }
 
 /**
  * Reset the driver.
  */
-void
+int
 reset()
 {
 	int fd = open(TERARANGER_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
-		err(1, "failed ");
+		PX4_ERR("failed");
+		return PX4_ERROR;
 	}
 
 	if (ioctl(fd, SENSORIOCRESET, 0) < 0) {
-		err(1, "driver reset failed");
+		PX4_ERR("driver reset failed");
+		return PX4_ERROR;
 	}
 
 	if (ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT) < 0) {
-		err(1, "driver poll restart failed");
+		PX4_ERR("driver poll restart failed");
+		return PX4_ERROR;
 	}
 
-	exit(0);
+	return PX4_OK;
 }
 
 /**
  * Print a little info about the driver.
  */
-void
+int
 info()
 {
 	if (g_dev == nullptr) {
-		errx(1, "driver not running");
+		PX4_ERR("driver not running");
+		return PX4_ERROR;
 	}
 
 	printf("state @ %p\n", g_dev);
 	g_dev->print_info();
 
-	exit(0);
+	return PX4_OK;
 }
 
 } // namespace
+
+
+static void
+teraranger_usage()
+{
+	PX4_INFO("usage: teraranger command [options]");
+	PX4_INFO("options:");
+	PX4_INFO("\t-b --bus i2cbus (%d)", TERARANGER_BUS_DEFAULT);
+	PX4_INFO("\t-a --all");
+	PX4_INFO("\t-R --rotation (%d)", distance_sensor_s::ROTATION_DOWNWARD_FACING);
+	PX4_INFO("command:");
+	PX4_INFO("\tstart|stop|test|reset|info");
+}
 
 int
 teraranger_main(int argc, char *argv[])
@@ -928,16 +999,27 @@ teraranger_main(int argc, char *argv[])
 	int myoptind = 1;
 	const char *myoptarg = nullptr;
 	uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
+	bool start_all = false;
 
-	while ((ch = px4_getopt(argc, argv, "R:", &myoptind, &myoptarg)) != EOF) {
+	int i2c_bus = TERARANGER_BUS_DEFAULT;
+
+	while ((ch = px4_getopt(argc, argv, "ab:R:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'R':
 			rotation = (uint8_t)atoi(myoptarg);
 			break;
 
+		case 'b':
+			i2c_bus = atoi(myoptarg);
+			break;
+
+		case 'a':
+			start_all = true;
+			break;
+
 		default:
 			PX4_WARN("Unknown option!");
-			return -1;
+			goto out_error;
 		}
 	}
 
@@ -949,38 +1031,44 @@ teraranger_main(int argc, char *argv[])
 	 * Start/load the driver.
 	 */
 	if (!strcmp(argv[myoptind], "start")) {
-		teraranger::start(rotation);
+
+		if (start_all) {
+			return teraranger::start(rotation);
+
+		} else {
+			return teraranger::start_bus(rotation, i2c_bus);
+		}
 	}
 
 	/*
 	 * Stop the driver
 	 */
 	if (!strcmp(argv[myoptind], "stop")) {
-		teraranger::stop();
+		return teraranger::stop();
 	}
 
 	/*
 	 * Test the driver/device.
 	 */
 	if (!strcmp(argv[myoptind], "test")) {
-		teraranger::test();
+		return teraranger::test();
 	}
 
 	/*
 	 * Reset the driver.
 	 */
 	if (!strcmp(argv[myoptind], "reset")) {
-		teraranger::reset();
+		return teraranger::reset();
 	}
 
 	/*
 	 * Print driver information.
 	 */
 	if (!strcmp(argv[myoptind], "info") || !strcmp(argv[myoptind], "status")) {
-		teraranger::info();
+		return teraranger::info();
 	}
 
 out_error:
-	PX4_ERR("unrecognized command, try 'start', 'test', 'reset' or 'info'");
-	return -1;
+	teraranger_usage();
+	return PX4_ERROR;
 }

--- a/src/drivers/distance_sensor/teraranger/teraranger.cpp
+++ b/src/drivers/distance_sensor/teraranger/teraranger.cpp
@@ -773,7 +773,7 @@ int 	reset();
 int 	info();
 
 /**
- * Start the driver.
+ *
  * Attempt to start driver on all available I2C busses.
  *
  * This function will return as soon as the first sensor
@@ -841,7 +841,7 @@ fail:
 		g_dev = nullptr;
 	}
 
-	PX4_WARN("not started on bus %d", i2c_bus);
+	PX4_ERR("not started on bus %d", i2c_bus);
 	return PX4_ERROR;
 }
 

--- a/src/drivers/distance_sensor/vl53lxx/vl53lxx.cpp
+++ b/src/drivers/distance_sensor/vl53lxx/vl53lxx.cpp
@@ -1044,7 +1044,7 @@ start_bus(uint8_t rotation, int i2c_bus)
 	}
 
 	/* set the poll rate to default, starts automatic data collection */
-	fd = open(VL53LXX_DEVICE_PATH, O_RDONLY);
+	fd = px4_open(VL53LXX_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		goto fail;
@@ -1054,13 +1054,13 @@ start_bus(uint8_t rotation, int i2c_bus)
 		goto fail;
 	}
 
-	close(fd);
+	px4_close(fd);
 	return PX4_OK;
 
 fail:
 
 	if (fd >= 0) {
-		close(fd);
+		px4_close(fd);
 	}
 
 	if (g_dev != nullptr) {
@@ -1101,7 +1101,7 @@ test()
 	struct distance_sensor_s report;
 	ssize_t sz;
 
-	int fd = open(VL53LXX_DEVICE_PATH, O_RDONLY);
+	int fd = px4_open(VL53LXX_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
 		PX4_ERR("%s open failed (try 'vl53lxx start' if the driver is not running)", VL53LXX_DEVICE_PATH);
@@ -1118,7 +1118,7 @@ test()
 
 	print_message(report);
 
-	close(fd);
+	px4_close(fd);
 
 	PX4_INFO("PASS");
 	return PX4_OK;

--- a/src/drivers/distance_sensor/vl53lxx/vl53lxx.cpp
+++ b/src/drivers/distance_sensor/vl53lxx/vl53lxx.cpp
@@ -53,13 +53,11 @@
 #include <string.h>
 #include <fcntl.h>
 #include <poll.h>
-#include <errno.h>
 #include <stdio.h>
 #include <math.h>
 #include <unistd.h>
 
 #include <perf/perf_counter.h>
-#include <systemlib/err.h>
 
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_range_finder.h>
@@ -67,16 +65,11 @@
 
 #include <uORB/uORB.h>
 #include <uORB/topics/distance_sensor.h>
-#include <uORB/topics/obstacle_distance.h>
 
 #include <board_config.h>
 
 /* Configuration Constants */
-#ifdef PX4_I2C_BUS_EXPANSION
-#define VL53LXX_BUS PX4_I2C_BUS_EXPANSION
-#else
-#define VL53LXX_BUS 0
-#endif
+#define VL53LXX_BUS_DEFAULT PX4_I2C_BUS_EXPANSION
 
 #define VL53LXX_BASEADDR 0b0101001 // 7-bit address
 #define VL53LXX_DEVICE_PATH "/dev/vl53lxx"
@@ -116,7 +109,7 @@ class VL53LXX : public device::I2C
 {
 public:
 	VL53LXX(uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING,
-		int bus = VL53LXX_BUS, int address = VL53LXX_BASEADDR);
+		int bus = VL53LXX_BUS_DEFAULT, int address = VL53LXX_BASEADDR);
 
 	virtual ~VL53LXX();
 
@@ -477,7 +470,6 @@ VL53LXX::readRegister(uint8_t reg_address, uint8_t &value)
 	ret = transfer(&reg_address, sizeof(reg_address), nullptr, 0);
 
 	if (OK != ret) {
-		DEVICE_LOG("i2c::transfer returned %d", ret);
 		perf_count(_comms_errors);
 		return ret;
 	}
@@ -486,7 +478,6 @@ VL53LXX::readRegister(uint8_t reg_address, uint8_t &value)
 	ret = transfer(nullptr, 0, &value, 1);
 
 	if (OK != ret) {
-		DEVICE_LOG("error reading from sensor: %d", ret);
 		perf_count(_comms_errors);
 		return ret;
 	}
@@ -505,7 +496,7 @@ VL53LXX::readRegisterMulti(uint8_t reg_address, uint8_t *value, uint8_t length)
 	ret = transfer(&reg_address, 1, nullptr, 0);
 
 	if (OK != ret) {
-		DEVICE_LOG("i2c::transfer returned %d", ret);
+		perf_count(_comms_errors);
 		return ret;
 	}
 
@@ -513,7 +504,6 @@ VL53LXX::readRegisterMulti(uint8_t reg_address, uint8_t *value, uint8_t length)
 	ret = transfer(nullptr, 0, &value[0], length);
 
 	if (OK != ret) {
-		DEVICE_LOG("error reading from sensor: %d", ret);
 		perf_count(_comms_errors);
 		return ret;
 	}
@@ -536,7 +526,6 @@ VL53LXX::writeRegister(uint8_t reg_address, uint8_t value)
 
 	if (OK != ret) {
 		perf_count(_comms_errors);
-		DEVICE_LOG("i2c::transfer returned %d", ret);
 		return ret;
 	}
 
@@ -566,7 +555,6 @@ VL53LXX::writeRegisterMulti(uint8_t reg_address, uint8_t *value,
 
 	if (OK != ret) {
 		perf_count(_comms_errors);
-		DEVICE_LOG("i2c::transfer returned %d", ret);
 		return ret;
 	}
 
@@ -979,26 +967,68 @@ namespace vl53lxx
 
 VL53LXX	*g_dev;
 
-void	start(uint8_t rotation);
-void	stop();
-void	test();
-void	info();
+int bus_options[] = {
+#ifdef PX4_I2C_BUS_EXPANSION
+	PX4_I2C_BUS_EXPANSION,
+#endif
+#ifdef PX4_I2C_BUS_EXPANSION1
+	PX4_I2C_BUS_EXPANSION1,
+#endif
+#ifdef PX4_I2C_BUS_EXPANSION2
+	PX4_I2C_BUS_EXPANSION2,
+#endif
+#ifdef PX4_I2C_BUS_ONBOARD
+	PX4_I2C_BUS_ONBOARD,
+#endif
+};
+
+#define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
+
+int 	start(uint8_t rotation);
+int 	start_bus(uint8_t rotation, int i2c_bus);
+int 	stop();
+int 	test();
+int 	info();
 
 /**
- * Start the driver.
+ *
+ * Attempt to start driver on all available I2C busses.
+ *
+ * This function will return as soon as the first sensor
+ * is detected on one of the available busses or if no
+ * sensors are detected.
+ *
  */
-void
+int
 start(uint8_t rotation)
+{
+	if (g_dev != nullptr) {
+		PX4_ERR("already started");
+		return PX4_ERROR;
+	}
+
+	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
+		if (start_bus(rotation, bus_options[i]) == PX4_OK) {
+			return PX4_OK;
+		}
+	}
+
+	return PX4_ERROR;
+}
+
+/**
+ * Start the driver on a specific bus.
+ *
+ * This function only returns if the sensor is up and running
+ * or could not be detected successfully.
+ */
+int
+start_bus(uint8_t rotation, int i2c_bus)
 {
 	int fd = -1;
 
-	if (g_dev != nullptr) {
-		errx(1, "already started");
-	}
-
 	/* create the driver */
-	g_dev = new VL53LXX(rotation, VL53LXX_BUS);
-
+	g_dev = new VL53LXX(rotation, i2c_bus);
 
 	if (g_dev == nullptr) {
 		goto fail;
@@ -1019,7 +1049,8 @@ start(uint8_t rotation)
 		goto fail;
 	}
 
-	exit(0);
+	close(fd);
+	return PX4_OK;
 
 fail:
 
@@ -1032,23 +1063,26 @@ fail:
 		g_dev = nullptr;
 	}
 
-	errx(1, "driver start failed");
+	PX4_ERR("not started on bus %d", i2c_bus);
+	return PX4_ERROR;
 }
 
 /**
  * Stop the driver
  */
-void stop()
+int
+stop()
 {
 	if (g_dev != nullptr) {
 		delete g_dev;
 		g_dev = nullptr;
 
 	} else {
-		errx(1, "driver not running");
+		PX4_ERR("driver not running");
+		return PX4_ERROR;
 	}
 
-	exit(0);
+	return PX4_OK;
 }
 
 /**
@@ -1056,7 +1090,7 @@ void stop()
  * make sure we can collect data from the sensor in polled
  * and automatic modes.
  */
-void
+int
 test()
 {
 	struct distance_sensor_s report;
@@ -1065,84 +1099,126 @@ test()
 	int fd = open(VL53LXX_DEVICE_PATH, O_RDONLY);
 
 	if (fd < 0) {
-		err(1, "%s open failed (try 'vl53lxx start' if the driver is not running)", VL53LXX_DEVICE_PATH);
+		PX4_ERR("%s open failed (try 'vl53lxx start' if the driver is not running)", VL53LXX_DEVICE_PATH);
+		return PX4_ERROR;
 	}
 
 	/* do a simple demand read */
 	sz = read(fd, &report, sizeof(report));
 
 	if (sz != sizeof(report)) {
-		PX4_ERR("ret: %d, expected: %d", sz, sizeof(report));
-		err(1, "immediate acc read failed");
+		PX4_ERR("immediate read failed");
+		return PX4_ERROR;
 	}
 
 	print_message(report);
 
 	close(fd);
 
-	errx(0, "PASS");
+	PX4_INFO("PASS");
+	return PX4_OK;
 }
 
 
 /**
  * Print a little info about the driver.
  */
-void
+int
 info()
 {
 	if (g_dev == nullptr) {
-		errx(1, "driver not running");
+		PX4_ERR("driver not running");
+		return PX4_ERROR;
 	}
 
 	printf("state @ %p\n", g_dev);
 	g_dev->print_info();
 
-	exit(0);
+	return PX4_OK;
 }
 
 } // namespace vl53lxx
 
 
+static void
+vl53lxx_usage()
+{
+	PX4_INFO("usage: vl53lxx command [options]");
+	PX4_INFO("options:");
+	PX4_INFO("\t-b --bus i2cbus (%d)", VL53LXX_BUS_DEFAULT);
+	PX4_INFO("\t-a --all");
+	PX4_INFO("\t-R --rotation (%d)", distance_sensor_s::ROTATION_DOWNWARD_FACING);
+	PX4_INFO("command:");
+	PX4_INFO("\tstart|stop|test|info");
+}
+
+
 int
 vl53lxx_main(int argc, char *argv[])
 {
+	int ch;
 	int myoptind = 1;
+	const char *myoptarg = nullptr;
 	uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING;
+	bool start_all = false;
 
-	if (argc < 2) {
-		goto out;
+	int i2c_bus = VL53LXX_BUS_DEFAULT;
+
+	while ((ch = px4_getopt(argc, argv, "ab:R:", &myoptind, &myoptarg)) != EOF) {
+		switch (ch) {
+		case 'R':
+			rotation = (uint8_t)atoi(myoptarg);
+			break;
+
+		case 'b':
+			i2c_bus = atoi(myoptarg);
+			break;
+
+		case 'a':
+			start_all = true;
+			break;
+
+		default:
+			PX4_WARN("Unknown option!");
+			goto out_error;
+		}
 	}
 
 	/*
 	 * Start/load the driver.
 	 */
 	if (!strcmp(argv[myoptind], "start")) {
-		vl53lxx::start(rotation);
+		if (start_all) {
+			return vl53lxx::start(rotation);
+
+		} else {
+			return vl53lxx::start_bus(rotation, i2c_bus);
+		}
 	}
 
 	/*
 	 * Stop the driver
 	 */
 	if (!strcmp(argv[myoptind], "stop")) {
-		vl53lxx::stop();
+		return vl53lxx::stop();
 	}
 
 	/*
 	 * Test the driver/device.
 	 */
 	if (!strcmp(argv[myoptind], "test")) {
-		vl53lxx::test();
+		return vl53lxx::test();
 	}
 
 	/*
 	 * Print driver information.
 	 */
 	if (!strcmp(argv[myoptind], "info") || !strcmp(argv[myoptind], "status")) {
-		vl53lxx::info();
+		return vl53lxx::info();
 	}
 
-out:
+out_error:
 
-	PX4_ERR("unrecognized command, try 'start', 'test', or 'info'");
+	vl53lxx_usage();
 	return PX4_ERROR;
 }

--- a/src/drivers/distance_sensor/vl53lxx/vl53lxx.cpp
+++ b/src/drivers/distance_sensor/vl53lxx/vl53lxx.cpp
@@ -967,23 +967,6 @@ namespace vl53lxx
 
 VL53LXX	*g_dev;
 
-int bus_options[] = {
-#ifdef PX4_I2C_BUS_EXPANSION
-	PX4_I2C_BUS_EXPANSION,
-#endif
-#ifdef PX4_I2C_BUS_EXPANSION1
-	PX4_I2C_BUS_EXPANSION1,
-#endif
-#ifdef PX4_I2C_BUS_EXPANSION2
-	PX4_I2C_BUS_EXPANSION2,
-#endif
-#ifdef PX4_I2C_BUS_ONBOARD
-	PX4_I2C_BUS_ONBOARD,
-#endif
-};
-
-#define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
-
 int 	start(uint8_t rotation);
 int 	start_bus(uint8_t rotation, int i2c_bus);
 int 	stop();
@@ -1007,8 +990,8 @@ start(uint8_t rotation)
 		return PX4_ERROR;
 	}
 
-	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
-		if (start_bus(rotation, bus_options[i]) == PX4_OK) {
+	for (unsigned i = 0; i < NUM_I2C_BUS_OPTIONS; i++) {
+		if (start_bus(rotation, i2c_bus_options[i]) == PX4_OK) {
 			return PX4_OK;
 		}
 	}
@@ -1068,7 +1051,6 @@ fail:
 		g_dev = nullptr;
 	}
 
-	PX4_ERR("not started on bus %d", i2c_bus);
 	return PX4_ERROR;
 }
 

--- a/src/drivers/distance_sensor/vl53lxx/vl53lxx.cpp
+++ b/src/drivers/distance_sensor/vl53lxx/vl53lxx.cpp
@@ -1027,6 +1027,11 @@ start_bus(uint8_t rotation, int i2c_bus)
 {
 	int fd = -1;
 
+	if (g_dev != nullptr) {
+		PX4_ERR("already started");
+		return PX4_ERROR;
+	}
+
 	/* create the driver */
 	g_dev = new VL53LXX(rotation, i2c_bus);
 

--- a/src/lib/drivers/device/i2c.h
+++ b/src/lib/drivers/device/i2c.h
@@ -37,3 +37,21 @@
 #else
 #include "posix/I2C.hpp"
 #endif
+
+
+static const int i2c_bus_options[] = {
+#ifdef PX4_I2C_BUS_EXPANSION
+	PX4_I2C_BUS_EXPANSION,
+#endif
+#ifdef PX4_I2C_BUS_EXPANSION1
+	PX4_I2C_BUS_EXPANSION1,
+#endif
+#ifdef PX4_I2C_BUS_EXPANSION2
+	PX4_I2C_BUS_EXPANSION2,
+#endif
+#ifdef PX4_I2C_BUS_ONBOARD
+	PX4_I2C_BUS_ONBOARD,
+#endif
+};
+
+#define NUM_I2C_BUS_OPTIONS (sizeof(i2c_bus_options)/sizeof(i2c_bus_options[0]))

--- a/src/lib/drivers/device/i2c.h
+++ b/src/lib/drivers/device/i2c.h
@@ -38,6 +38,8 @@
 #include "posix/I2C.hpp"
 #endif
 
+#include <board_config.h>
+
 
 static const int i2c_bus_options[] = {
 #ifdef PX4_I2C_BUS_EXPANSION


### PR DESCRIPTION
Add -a and -b argument to start distance sensor drivers and search for a device on all I2C busses or to start on a specific bus. Up to now these drivers have a default bus and no possibility to change. This is useful for platforms such as fmu-v5 that has 3 external i2c busses.

Moreover I removed some nuttx dependencies such as the err, errx and exit functions.

I started with the teraranger driver because I have one to test with. Soon I will apply these changes to all distance sensor drivers that use I2C.