### PR TITLE
Mavlink: initialize _ping_stats

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -259,6 +259,7 @@ Mavlink::Mavlink() :
 	_network_port(14556),
 	_remote_port(DEFAULT_REMOTE_PORT_UDP),
 	_rstatus {},
+	_ping_stats{},
 	_message_buffer {},
 	_message_buffer_mutex {},
 	_send_mutex {},


### PR DESCRIPTION
Uninitialized `_ping_stats.last_ping_time` caused ping statistics to be printed even when no ping was received.

FYI @mhkabir 