### PR TITLE
cmake: add force-upload target

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -555,7 +555,8 @@ class uploader(object):
                                    "high that it is not safe! If unsure, use px4fmu-v2_default.\n"
                                    "\n"
                                    "If you know you that the board does not have the silicon errata, use\n"
-                                   "this script with --force, or update the bootloader.\n")
+                                   "this script with --force, or update the bootloader. If you are invoking\n"
+                                   "upload using make, you can use force-upload target to force the upload.\n")
 
         self.__erase("Erase  ")
         self.__program("Program", fw)

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -189,6 +189,14 @@ if (TARGET parameters_xml AND TARGET airframes_xml)
 			VERBATIM
 			USES_TERMINAL
 			)
+		add_custom_target(force-upload
+			COMMAND ${PYTHON_EXECUTABLE}
+				${PX4_SOURCE_DIR}/Tools/px_uploader.py --force --port ${serial_ports} ${fw_file}
+			DEPENDS ${fw_file}
+			COMMENT "uploading px4 with --force"
+			VERBATIM
+			USES_TERMINAL
+			)
 	endif()
 endif()
 


### PR DESCRIPTION
If the `PX4FMUv2` board does not have the v5 uploader, it's not possible to check the silicon revision to make sure it's safe to upload the firmware which is more than 1 MB. However, if the user is sure the silicon revision is not affected by this errata, he can upload the firmware using `px4_uploader.py` with --force argument. This commit adds `force-upload` `make` target to do it more convenient way.