### PR TITLE
Mission feasibility checker remove 2/3rds distance warnings that don't reject a mission

### DIFF
--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -497,14 +497,6 @@ MissionFeasibilityChecker::checkDistanceToFirstWaypoint(const mission_s &mission
 
 		if (dist_to_1wp < max_distance) {
 
-			if (dist_to_1wp > ((max_distance * 2) / 3)) {
-				/* allow at 2/3 distance, but warn */
-				mavlink_log_critical(_navigator->get_mavlink_log_pub(),
-						     "First waypoint far away: %d meters.", (int)dist_to_1wp);
-
-				_navigator->get_mission_result()->warning = true;
-			}
-
 			return true;
 
 		} else {
@@ -557,17 +549,7 @@ MissionFeasibilityChecker::checkDistancesBetweenWaypoints(const mission_s &missi
 					mission_item.lat, mission_item.lon,
 					last_lat, last_lon);
 
-			if (dist_between_waypoints < max_distance) {
-
-				if (dist_between_waypoints > ((max_distance * 2) / 3)) {
-					/* allow at 2/3 distance, but warn */
-					mavlink_log_critical(_navigator->get_mavlink_log_pub(),
-							     "Distance between waypoints very far: %d meters.", (int)dist_between_waypoints);
-
-					_navigator->get_mission_result()->warning = true;
-				}
-
-			} else {
+			if (dist_between_waypoints > max_distance) {
 				/* item is too far from home */
 				mavlink_log_critical(_navigator->get_mavlink_log_pub(),
 						     "Distance between waypoints too far: %d meters, %d max.",


### PR DESCRIPTION
Could we review the need for these mission feasibility distance warnings? In practice they can be problematic.

![image](https://user-images.githubusercontent.com/84712/41783807-cf8db7c0-760b-11e8-9718-e162f3b479e1.png)

Do we even need these warnings PX4 side? I think of the mission feasibility checker as the last line of defence for loading something bogus. If we also want it to return helpful warnings it needs a better interface.