### PR TITLE
Indicate if the mavlink instance did not start correctly

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2621,7 +2621,12 @@ Mavlink::start(int argc, char *argv[])
 		count++;
 	}
 
-	return OK;
+	if (ic == Mavlink::instance_count()) {
+		return PX4_ERROR;
+
+	} else {
+		return PX4_OK;
+	}
 }
 
 void


### PR DESCRIPTION
Return an error if the mavlink instance did not boot up correctly in time.
This makes it possible to catch it in the startup script and react accordingly.