### PR TITLE
mission feasibility: add small tolerance to fw landing slope alt

### DIFF
--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -411,8 +411,8 @@ MissionFeasibilityChecker::checkFixedWingLanding(const mission_s &mission, bool 
 							const float slope_alt_req = Landingslope::getLandingSlopeAbsoluteAltitude(wp_distance, missionitem.altitude,
 										    horizontal_slope_displacement, slope_angle_rad);
 
-							if (missionitem_previous.altitude > slope_alt_req) {
-								/* Landing waypoint is above altitude of slope at the given waypoint distance */
+							if (missionitem_previous.altitude > slope_alt_req + 1.0f) {
+								/* Landing waypoint is above altitude of slope at the given waypoint distance (with small tolerance for floating point discrepancies) */
 								mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: adjust landing approach.");
 
 								const float wp_distance_req = Landingslope::getLandingSlopeWPDistance(missionitem_previous.altitude,


### PR DESCRIPTION
Once sent from QGC to pixhawk, the fixed-wing landing pattern coordinates are again converted to local distances for feasibility checks, where small floating point errors can cause a rejection -- and the need to modify and resend the waypoints (somewhat tedious on the field). This PR simply adds a small tolerance to the check condition to avoid this.

(also open to recommendations on the value of this tolerance, I just put 1m for now)

Partially addresses #9472.

