### PR TITLE
Mavlink stream updates

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2660,20 +2660,23 @@ Mavlink::display_status()
 		printf("\tno telem status.\n");
 	}
 
-	printf("\tflow control:\t%s\n", (_flow_control_mode) ? "ON" : "OFF");
+	printf("\tflow control: %s\n", _flow_control_mode ? "ON" : "OFF");
 	printf("\trates:\n");
-	printf("\ttx: %.3f kB/s\n", (double)_rate_tx);
-	printf("\ttxerr: %.3f kB/s\n", (double)_rate_txerr);
-	printf("\trx: %.3f kB/s\n", (double)_rate_rx);
-	printf("\trate mult: %.3f\n", (double)_rate_mult);
+	printf("\t  tx: %.3f kB/s\n", (double)_rate_tx);
+	printf("\t  txerr: %.3f kB/s\n", (double)_rate_txerr);
+	printf("\t  tx rate mult: %.3f\n", (double)_rate_mult);
+	printf("\t  tx rate max: %i B/s\n", _datarate);
+	printf("\t  rx: %.3f kB/s\n", (double)_rate_rx);
 
 	if (_mavlink_ulog) {
 		printf("\tULog rate: %.1f%% of max %.1f%%\n", (double)_mavlink_ulog->current_data_rate() * 100.,
 		       (double)_mavlink_ulog->maximum_data_rate() * 100.);
 	}
 
-	printf("\taccepting commands: %s, FTP enabled: %s\n", accepting_commands() ? "YES" : "NO", _ftp_on ? "YES" : "NO");
-	printf("\ttransmitting enabled: %s\n", _transmitting_enabled ? "YES" : "NO");
+	printf("\taccepting commands: %s, FTP enabled: %s, TX enabled: %s\n",
+	       accepting_commands() ? "YES" : "NO",
+	       _ftp_on ? "YES" : "NO",
+	       _transmitting_enabled ? "YES" : "NO");
 	printf("\tmode: %s\n", mavlink_mode_str(_mode));
 	printf("\tMAVLink version: %i\n", _protocol_version);
 
@@ -2681,7 +2684,14 @@ Mavlink::display_status()
 
 	switch (_protocol) {
 	case UDP:
-		printf("UDP (%i)\n", _network_port);
+		printf("UDP (%i, remote port: %i)\n", _network_port, _remote_port);
+#ifdef __PX4_POSIX
+
+		if (get_client_source_initialized()) {
+			printf("\tpartner IP: %s\n", inet_ntoa(get_client_source_address().sin_addr));
+		}
+
+#endif
 		break;
 
 	case TCP:
@@ -2695,11 +2705,11 @@ Mavlink::display_status()
 
 	if (_ping_stats.last_ping_time > 0) {
 		printf("\tping statistics:\n");
-		printf("\t last: %0.2f ms\n", (double)_ping_stats.last_rtt);
-		printf("\t mean: %0.2f ms\n", (double)_ping_stats.mean_rtt);
-		printf("\t max: %0.2f ms\n", (double)_ping_stats.max_rtt);
-		printf("\t min: %0.2f ms\n", (double)_ping_stats.min_rtt);
-		printf("\t dropped packets: %u\n", _ping_stats.dropped_packets);
+		printf("\t  last: %0.2f ms\n", (double)_ping_stats.last_rtt);
+		printf("\t  mean: %0.2f ms\n", (double)_ping_stats.mean_rtt);
+		printf("\t  max: %0.2f ms\n", (double)_ping_stats.max_rtt);
+		printf("\t  min: %0.2f ms\n", (double)_ping_stats.min_rtt);
+		printf("\t  dropped packets: %u\n", _ping_stats.dropped_packets);
 	}
 }
 

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -2871,7 +2871,7 @@ Mavlink::stream_command(int argc, char *argv[])
 		i++;
 	}
 
-	if (!err_flag && rate >= 0.0f && stream_name != nullptr) {
+	if (!err_flag && stream_name != nullptr) {
 
 		Mavlink *inst = nullptr;
 
@@ -2884,6 +2884,10 @@ Mavlink::stream_command(int argc, char *argv[])
 		} else if (provided_device && provided_network_port) {
 			PX4_WARN("please provide either a device name or a network port");
 			return 1;
+		}
+
+		if (rate < 0.f) {
+			rate = -2.f; // use default rate
 		}
 
 		if (inst != nullptr) {
@@ -2904,7 +2908,7 @@ Mavlink::stream_command(int argc, char *argv[])
 		}
 
 	} else {
-		PX4_INFO("usage: mavlink stream [-d device] [-u network_port] -s stream -r rate");
+		usage();
 		return 1;
 	}
 
@@ -2991,7 +2995,7 @@ $ mavlink stream -u 14556 -s HIGHRES_IMU -r 50
 #endif
 	PRINT_MODULE_USAGE_PARAM_STRING('d', nullptr, "<file:dev>", "Select Mavlink instance via Serial Device", true);
 	PRINT_MODULE_USAGE_PARAM_STRING('s', nullptr, nullptr, "Mavlink stream to configure", false);
-	PRINT_MODULE_USAGE_PARAM_FLOAT('r', 0.f, 0.f, 2000.f, "Rate in Hz (0 = turn off)", false);
+	PRINT_MODULE_USAGE_PARAM_FLOAT('r', -1.f, 0.f, 2000.f, "Rate in Hz (0 = turn off, -1 = set to default)", false);
 
 	PRINT_MODULE_USAGE_COMMAND_DESCR("boot_complete",
 					 "Enable sending of messages. (Must be) called as last step in startup script.");

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -859,19 +859,16 @@ Mavlink::set_hil_enabled(bool hil_enabled)
 {
 	int ret = OK;
 
-	/* enable HIL */
-	if (hil_enabled && !_hil_enabled && (_mode != MAVLINK_MODE_IRIDIUM)) {
+	/* enable HIL (only on links with sufficient bandwidth) */
+	if (hil_enabled && !_hil_enabled && _datarate > 5000) {
 		_hil_enabled = true;
-		configure_stream("HIL_ACTUATOR_CONTROLS", 200.0f);
+		ret = configure_stream("HIL_ACTUATOR_CONTROLS", 200.0f);
 	}
 
 	/* disable HIL */
 	if (!hil_enabled && _hil_enabled) {
 		_hil_enabled = false;
-		configure_stream("HIL_ACTUATOR_CONTROLS", 0.0f);
-
-	} else {
-		ret = PX4_ERROR;
+		ret = configure_stream("HIL_ACTUATOR_CONTROLS", 0.0f);
 	}
 
 	return ret;

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1366,6 +1366,8 @@ Mavlink::interval_from_rate(float rate)
 int
 Mavlink::configure_stream(const char *stream_name, const float rate)
 {
+	PX4_DEBUG("configure_stream(%s, %.3f)", stream_name, (double)rate);
+
 	/* calculate interval in us, -1 means unlimited stream, 0 means disabled */
 	int interval = interval_from_rate(rate);
 
@@ -1723,6 +1725,189 @@ Mavlink::update_rate_mult()
 }
 
 int
+Mavlink::configure_streams_to_default(const char *configure_single_stream)
+{
+	int ret = 0;
+	bool stream_configured = false;
+
+	auto configure_stream_local =
+	[&stream_configured, configure_single_stream, &ret, this](const char *stream_name, float rate) {
+		if (!configure_single_stream || strcmp(configure_single_stream, stream_name) == 0) {
+			int ret_local = configure_stream(stream_name, rate);
+
+			if (ret_local != 0) {
+				ret = ret_local;
+			}
+
+			stream_configured = true;
+		}
+	};
+
+	const float unlimited_rate = -1.f;
+
+	switch (_mode) {
+	case MAVLINK_MODE_NORMAL:
+		configure_stream_local("ADSB_VEHICLE", unlimited_rate);
+		configure_stream_local("ALTITUDE", 1.0f);
+		configure_stream_local("ATTITUDE", 20.0f);
+		configure_stream_local("ATTITUDE_TARGET", 2.0f);
+		configure_stream_local("CAMERA_IMAGE_CAPTURED", unlimited_rate);
+		configure_stream_local("COLLISION", unlimited_rate);
+		configure_stream_local("DEBUG", 1.0f);
+		configure_stream_local("DEBUG_VECT", 1.0f);
+		configure_stream_local("DISTANCE_SENSOR", 0.5f);
+		configure_stream_local("ESTIMATOR_STATUS", 0.5f);
+		configure_stream_local("EXTENDED_SYS_STATE", 1.0f);
+		configure_stream_local("GLOBAL_POSITION_INT", 5.0f);
+		configure_stream_local("GPS_RAW_INT", 1.0f);
+		configure_stream_local("HIGHRES_IMU", 1.5f);
+		configure_stream_local("HOME_POSITION", 0.5f);
+		configure_stream_local("LOCAL_POSITION_NED", 1.0f);
+		configure_stream_local("NAMED_VALUE_FLOAT", 1.0f);
+		configure_stream_local("NAV_CONTROLLER_OUTPUT", 1.5f);
+		configure_stream_local("OPTICAL_FLOW_RAD", 1.0f);
+		configure_stream_local("PING", 0.1f);
+		configure_stream_local("POSITION_TARGET_LOCAL_NED", 1.5f);
+		configure_stream_local("POSITION_TARGET_GLOBAL_INT", 1.5f);
+		configure_stream_local("RC_CHANNELS", 5.0f);
+		configure_stream_local("SERVO_OUTPUT_RAW_0", 1.0f);
+		configure_stream_local("SYS_STATUS", 1.0f);
+		configure_stream_local("VFR_HUD", 4.0f);
+		configure_stream_local("VISION_POSITION_ESTIMATE", 1.0f);
+		configure_stream_local("WIND_COV", 1.0f);
+		break;
+
+	case MAVLINK_MODE_ONBOARD:
+		configure_stream_local("ACTUATOR_CONTROL_TARGET0", 10.0f);
+		configure_stream_local("ADSB_VEHICLE", unlimited_rate);
+		configure_stream_local("ALTITUDE", 10.0f);
+		configure_stream_local("ATTITUDE", 100.0f);
+		configure_stream_local("ATTITUDE_QUATERNION", 50.0f);
+		configure_stream_local("ATTITUDE_TARGET", 10.0f);
+		configure_stream_local("CAMERA_CAPTURE", 2.0f);
+		configure_stream_local("CAMERA_IMAGE_CAPTURED", unlimited_rate);
+		configure_stream_local("CAMERA_TRIGGER", unlimited_rate);
+		configure_stream_local("COLLISION", unlimited_rate);
+		configure_stream_local("DEBUG", 10.0f);
+		configure_stream_local("DEBUG_VECT", 10.0f);
+		configure_stream_local("DISTANCE_SENSOR", 10.0f);
+		configure_stream_local("ESTIMATOR_STATUS", 1.0f);
+		configure_stream_local("EXTENDED_SYS_STATE", 5.0f);
+		configure_stream_local("GLOBAL_POSITION_INT", 50.0f);
+		configure_stream_local("GPS_RAW_INT", unlimited_rate);
+		configure_stream_local("HIGHRES_IMU", 50.0f);
+		configure_stream_local("HOME_POSITION", 0.5f);
+		configure_stream_local("LOCAL_POSITION_NED", 30.0f);
+		configure_stream_local("NAMED_VALUE_FLOAT", 10.0f);
+		configure_stream_local("NAV_CONTROLLER_OUTPUT", 10.0f);
+		configure_stream_local("OPTICAL_FLOW_RAD", 10.0f);
+		configure_stream_local("PING", 1.0f);
+		configure_stream_local("POSITION_TARGET_GLOBAL_INT", 10.0f);
+		configure_stream_local("POSITION_TARGET_LOCAL_NED", 10.0f);
+		configure_stream_local("RC_CHANNELS", 20.0f);
+		configure_stream_local("SCALED_IMU", 50.0f);
+		configure_stream_local("SERVO_OUTPUT_RAW_0", 10.0f);
+		configure_stream_local("SYS_STATUS", 5.0f);
+		configure_stream_local("SYSTEM_TIME", 1.0f);
+		configure_stream_local("TIMESYNC", 10.0f);
+		configure_stream_local("VFR_HUD", 10.0f);
+		configure_stream_local("VISION_POSITION_ESTIMATE", 10.0f);
+		configure_stream_local("WIND_COV", 10.0f);
+		break;
+
+	case MAVLINK_MODE_OSD:
+		configure_stream_local("ALTITUDE", 1.0f);
+		configure_stream_local("ATTITUDE", 25.0f);
+		configure_stream_local("ATTITUDE_TARGET", 10.0f);
+		configure_stream_local("ESTIMATOR_STATUS", 1.0f);
+		configure_stream_local("EXTENDED_SYS_STATE", 1.0f);
+		configure_stream_local("GLOBAL_POSITION_INT", 10.0f);
+		configure_stream_local("GPS_RAW_INT", 1.0f);
+		configure_stream_local("HOME_POSITION", 0.5f);
+		configure_stream_local("RC_CHANNELS", 5.0f);
+		configure_stream_local("SERVO_OUTPUT_RAW_0", 1.0f);
+		configure_stream_local("SYS_STATUS", 5.0f);
+		configure_stream_local("SYSTEM_TIME", 1.0f);
+		configure_stream_local("VFR_HUD", 25.0f);
+		configure_stream_local("WIND_COV", 2.0f);
+		break;
+
+	case MAVLINK_MODE_MAGIC:
+
+	/* fallthrough */
+	case MAVLINK_MODE_CUSTOM:
+		//stream nothing
+		break;
+
+	case MAVLINK_MODE_CONFIG:
+		// Enable a number of interesting streams we want via USB
+		configure_stream_local("ACTUATOR_CONTROL_TARGET0", 30.0f);
+		configure_stream_local("ADSB_VEHICLE", unlimited_rate);
+		configure_stream_local("ALTITUDE", 10.0f);
+		configure_stream_local("ATTITUDE", 50.0f);
+		configure_stream_local("ATTITUDE_TARGET", 8.0f);
+		configure_stream_local("ATTITUDE_QUATERNION", 50.0f);
+		configure_stream_local("CAMERA_TRIGGER", unlimited_rate);
+		configure_stream_local("CAMERA_IMAGE_CAPTURED", unlimited_rate);
+		configure_stream_local("COLLISION", unlimited_rate);
+		configure_stream_local("DEBUG", 50.0f);
+		configure_stream_local("DEBUG_VECT", 50.0f);
+		configure_stream_local("DISTANCE_SENSOR", 10.0f);
+		configure_stream_local("GPS_RAW_INT", unlimited_rate);
+		configure_stream_local("ESTIMATOR_STATUS", 5.0f);
+		configure_stream_local("EXTENDED_SYS_STATE", 2.0f);
+		configure_stream_local("GLOBAL_POSITION_INT", 10.0f);
+		configure_stream_local("HIGHRES_IMU", 50.0f);
+		configure_stream_local("HOME_POSITION", 0.5f);
+		configure_stream_local("LOCAL_POSITION_NED", 30.0f);
+		configure_stream_local("MANUAL_CONTROL", 5.0f);
+		configure_stream_local("NAMED_VALUE_FLOAT", 50.0f);
+		configure_stream_local("NAV_CONTROLLER_OUTPUT", 10.0f);
+		configure_stream_local("OPTICAL_FLOW_RAD", 10.0f);
+		configure_stream_local("PING", 1.0f);
+		configure_stream_local("POSITION_TARGET_GLOBAL_INT", 10.0f);
+		configure_stream_local("RC_CHANNELS", 10.0f);
+		configure_stream_local("SERVO_OUTPUT_RAW_0", 20.0f);
+		configure_stream_local("SERVO_OUTPUT_RAW_1", 20.0f);
+		configure_stream_local("SYS_STATUS", 1.0f);
+		configure_stream_local("SYSTEM_TIME", 1.0f);
+		configure_stream_local("TIMESYNC", 10.0f);
+		configure_stream_local("VFR_HUD", 20.0f);
+		configure_stream_local("VISION_POSITION_ESTIMATE", 10.0f);
+		configure_stream_local("WIND_COV", 10.0f);
+		break;
+
+	case MAVLINK_MODE_IRIDIUM:
+		configure_stream_local("HIGH_LATENCY2", 0.015f);
+		break;
+
+	case MAVLINK_MODE_MINIMAL:
+		configure_stream_local("ALTITUDE", 0.5f);
+		configure_stream_local("ATTITUDE", 10.0f);
+		configure_stream_local("EXTENDED_SYS_STATE", 0.1f);
+		configure_stream_local("GPS_RAW_INT", 0.5f);
+		configure_stream_local("GLOBAL_POSITION_INT", 5.0f);
+		configure_stream_local("HOME_POSITION", 0.1f);
+		configure_stream_local("NAMED_VALUE_FLOAT", 1.0f);
+		configure_stream_local("RC_CHANNELS", 0.5f);
+		configure_stream_local("SYS_STATUS", 0.1f);
+		configure_stream_local("VFR_HUD", 1.0f);
+		break;
+
+	default:
+		ret = -1;
+		break;
+	}
+
+	if (configure_single_stream && !stream_configured && strcmp(configure_single_stream, "HEARTBEAT") != 0) {
+		// stream was not found, assume it is disabled by default
+		return configure_stream(configure_single_stream, 0.f);
+	}
+
+	return ret;
+}
+
+int
 Mavlink::task_main(int argc, char *argv[])
 {
 	int ch;
@@ -1999,154 +2184,8 @@ Mavlink::task_main(int argc, char *argv[])
 
 	}
 
-	switch (_mode) {
-	case MAVLINK_MODE_NORMAL:
-		configure_stream("ADSB_VEHICLE");
-		configure_stream("ALTITUDE", 1.0f);
-		configure_stream("ATTITUDE", 20.0f);
-		configure_stream("ATTITUDE_TARGET", 2.0f);
-		configure_stream("CAMERA_IMAGE_CAPTURED");
-		configure_stream("COLLISION");
-		configure_stream("DEBUG", 1.0f);
-		configure_stream("DEBUG_VECT", 1.0f);
-		configure_stream("DISTANCE_SENSOR", 0.5f);
-		configure_stream("ESTIMATOR_STATUS", 0.5f);
-		configure_stream("EXTENDED_SYS_STATE", 1.0f);
-		configure_stream("GLOBAL_POSITION_INT", 5.0f);
-		configure_stream("GPS_RAW_INT", 1.0f);
-		configure_stream("HIGHRES_IMU", 1.5f);
-		configure_stream("HOME_POSITION", 0.5f);
-		configure_stream("LOCAL_POSITION_NED", 1.0f);
-		configure_stream("NAMED_VALUE_FLOAT", 1.0f);
-		configure_stream("NAV_CONTROLLER_OUTPUT", 1.5f);
-		configure_stream("OPTICAL_FLOW_RAD", 1.0f);
-		configure_stream("PING", 0.1f);
-		configure_stream("POSITION_TARGET_LOCAL_NED", 1.5f);
-		configure_stream("POSITION_TARGET_GLOBAL_INT", 1.5f);
-		configure_stream("RC_CHANNELS", 5.0f);
-		configure_stream("SERVO_OUTPUT_RAW_0", 1.0f);
-		configure_stream("SYS_STATUS", 1.0f);
-		configure_stream("VFR_HUD", 4.0f);
-		configure_stream("VISION_POSITION_ESTIMATE", 1.0f);
-		configure_stream("WIND_COV", 1.0f);
-		break;
-
-	case MAVLINK_MODE_ONBOARD:
-		configure_stream("ACTUATOR_CONTROL_TARGET0", 10.0f);
-		configure_stream("ADSB_VEHICLE");
-		configure_stream("ALTITUDE", 10.0f);
-		configure_stream("ATTITUDE", 100.0f);
-		configure_stream("ATTITUDE_QUATERNION", 50.0f);
-		configure_stream("ATTITUDE_TARGET", 10.0f);
-		configure_stream("CAMERA_CAPTURE", 2.0f);
-		configure_stream("CAMERA_IMAGE_CAPTURED");
-		configure_stream("CAMERA_TRIGGER");
-		configure_stream("COLLISION");
-		configure_stream("DEBUG", 10.0f);
-		configure_stream("DEBUG_VECT", 10.0f);
-		configure_stream("DISTANCE_SENSOR", 10.0f);
-		configure_stream("ESTIMATOR_STATUS", 1.0f);
-		configure_stream("EXTENDED_SYS_STATE", 5.0f);
-		configure_stream("GLOBAL_POSITION_INT", 50.0f);
-		configure_stream("GPS_RAW_INT");
-		configure_stream("HIGHRES_IMU", 50.0f);
-		configure_stream("HOME_POSITION", 0.5f);
-		configure_stream("LOCAL_POSITION_NED", 30.0f);
-		configure_stream("NAMED_VALUE_FLOAT", 10.0f);
-		configure_stream("NAV_CONTROLLER_OUTPUT", 10.0f);
-		configure_stream("OPTICAL_FLOW_RAD", 10.0f);
-		configure_stream("PING", 1.0f);
-		configure_stream("POSITION_TARGET_GLOBAL_INT", 10.0f);
-		configure_stream("POSITION_TARGET_LOCAL_NED", 10.0f);
-		configure_stream("RC_CHANNELS", 20.0f);
-		configure_stream("SCALED_IMU", 50.0f);
-		configure_stream("SERVO_OUTPUT_RAW_0", 10.0f);
-		configure_stream("SYS_STATUS", 5.0f);
-		configure_stream("SYSTEM_TIME", 1.0f);
-		configure_stream("TIMESYNC", 10.0f);
-		configure_stream("VFR_HUD", 10.0f);
-		configure_stream("VISION_POSITION_ESTIMATE", 10.0f);
-		configure_stream("WIND_COV", 10.0f);
-		break;
-
-	case MAVLINK_MODE_OSD:
-		configure_stream("ALTITUDE", 1.0f);
-		configure_stream("ATTITUDE", 25.0f);
-		configure_stream("ATTITUDE_TARGET", 10.0f);
-		configure_stream("ESTIMATOR_STATUS", 1.0f);
-		configure_stream("EXTENDED_SYS_STATE", 1.0f);
-		configure_stream("GLOBAL_POSITION_INT", 10.0f);
-		configure_stream("GPS_RAW_INT", 1.0f);
-		configure_stream("HOME_POSITION", 0.5f);
-		configure_stream("RC_CHANNELS", 5.0f);
-		configure_stream("SERVO_OUTPUT_RAW_0", 1.0f);
-		configure_stream("SYS_STATUS", 5.0f);
-		configure_stream("SYSTEM_TIME", 1.0f);
-		configure_stream("VFR_HUD", 25.0f);
-		configure_stream("WIND_COV", 2.0f);
-		break;
-
-	case MAVLINK_MODE_MAGIC:
-		//stream nothing
-		break;
-
-	case MAVLINK_MODE_CONFIG:
-		// Enable a number of interesting streams we want via USB
-		configure_stream("ACTUATOR_CONTROL_TARGET0", 30.0f);
-		configure_stream("ADSB_VEHICLE");
-		configure_stream("ALTITUDE", 10.0f);
-		configure_stream("ATTITUDE", 50.0f);
-		configure_stream("ATTITUDE_TARGET", 8.0f);
-		configure_stream("ATTITUDE_QUATERNION", 50.0f);
-		configure_stream("CAMERA_TRIGGER");
-		configure_stream("CAMERA_IMAGE_CAPTURED");
-		configure_stream("COLLISION");
-		configure_stream("DEBUG", 50.0f);
-		configure_stream("DEBUG_VECT", 50.0f);
-		configure_stream("DISTANCE_SENSOR", 10.0f);
-		configure_stream("GPS_RAW_INT");
-		configure_stream("ESTIMATOR_STATUS", 5.0f);
-		configure_stream("EXTENDED_SYS_STATE", 2.0f);
-		configure_stream("GLOBAL_POSITION_INT", 10.0f);
-		configure_stream("HIGHRES_IMU", 50.0f);
-		configure_stream("HOME_POSITION", 0.5f);
-		configure_stream("LOCAL_POSITION_NED", 30.0f);
-		configure_stream("MANUAL_CONTROL", 5.0f);
-		configure_stream("NAMED_VALUE_FLOAT", 50.0f);
-		configure_stream("NAV_CONTROLLER_OUTPUT", 10.0f);
-		configure_stream("OPTICAL_FLOW_RAD", 10.0f);
-		configure_stream("PING", 1.0f);
-		configure_stream("POSITION_TARGET_GLOBAL_INT", 10.0f);
-		configure_stream("RC_CHANNELS", 10.0f);
-		configure_stream("SERVO_OUTPUT_RAW_0", 20.0f);
-		configure_stream("SERVO_OUTPUT_RAW_1", 20.0f);
-		configure_stream("SYS_STATUS", 1.0f);
-		configure_stream("SYSTEM_TIME", 1.0f);
-		configure_stream("TIMESYNC", 10.0f);
-		configure_stream("VFR_HUD", 20.0f);
-		configure_stream("VISION_POSITION_ESTIMATE", 10.0f);
-		configure_stream("WIND_COV", 10.0f);
-		break;
-
-	case MAVLINK_MODE_IRIDIUM:
-		configure_stream("HIGH_LATENCY2", 0.015f);
-		break;
-
-	case MAVLINK_MODE_MINIMAL:
-		configure_stream("ALTITUDE", 0.5f);
-		configure_stream("ATTITUDE", 10.0f);
-		configure_stream("EXTENDED_SYS_STATE", 0.1f);
-		configure_stream("GPS_RAW_INT", 0.5f);
-		configure_stream("GLOBAL_POSITION_INT", 5.0f);
-		configure_stream("HOME_POSITION", 0.1f);
-		configure_stream("NAMED_VALUE_FLOAT", 1.0f);
-		configure_stream("RC_CHANNELS", 0.5f);
-		configure_stream("SYS_STATUS", 0.1f);
-		configure_stream("VFR_HUD", 1.0f);
-		break;
-
-	default:
-		break;
+	if (configure_streams_to_default() != 0) {
+		PX4_ERR("configure_streams_to_default() failed");
 	}
 
 	/* set main loop delay depending on data rate to minimize CPU overhead */
@@ -2331,7 +2370,20 @@ Mavlink::task_main(int argc, char *argv[])
 
 		/* check for requested subscriptions */
 		if (_subscribe_to_stream != nullptr) {
-			if (OK == configure_stream(_subscribe_to_stream, _subscribe_to_stream_rate)) {
+			if (_subscribe_to_stream_rate < -1.5f) {
+				if (configure_streams_to_default(_subscribe_to_stream) == 0) {
+					if (get_protocol() == SERIAL) {
+						PX4_DEBUG("stream %s on device %s set to default rate", _subscribe_to_stream, _device_name);
+
+					} else if (get_protocol() == UDP) {
+						PX4_DEBUG("stream %s on UDP port %d set to default rate", _subscribe_to_stream, _network_port);
+					}
+
+				} else {
+					PX4_ERR("setting stream %s to default failed", _subscribe_to_stream);
+				}
+
+			} else if (configure_stream(_subscribe_to_stream, _subscribe_to_stream_rate) == 0) {
 				if (fabsf(_subscribe_to_stream_rate) > 0.00001f) {
 					if (get_protocol() == SERIAL) {
 						PX4_DEBUG("stream %s on device %s enabled with rate %.1f Hz", _subscribe_to_stream, _device_name,
@@ -2344,19 +2396,19 @@ Mavlink::task_main(int argc, char *argv[])
 
 				} else {
 					if (get_protocol() == SERIAL) {
-						PX4_INFO("stream %s on device %s disabled", _subscribe_to_stream, _device_name);
+						PX4_DEBUG("stream %s on device %s disabled", _subscribe_to_stream, _device_name);
 
 					} else if (get_protocol() == UDP) {
-						PX4_INFO("stream %s on UDP port %d disabled", _subscribe_to_stream, _network_port);
+						PX4_DEBUG("stream %s on UDP port %d disabled", _subscribe_to_stream, _network_port);
 					}
 				}
 
 			} else {
 				if (get_protocol() == SERIAL) {
-					PX4_WARN("stream %s on device %s not found", _subscribe_to_stream, _device_name);
+					PX4_ERR("stream %s on device %s not found", _subscribe_to_stream, _device_name);
 
 				} else if (get_protocol() == UDP) {
-					PX4_WARN("stream %s on UDP port %d not found", _subscribe_to_stream, _network_port);
+					PX4_ERR("stream %s on UDP port %d not found", _subscribe_to_stream, _network_port);
 				}
 			}
 

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -109,6 +109,11 @@ public:
 	 */
 	void			display_status();
 
+	/**
+	 * Display the status of all enabled streams.
+	 */
+	void			display_status_streams();
+
 	static int		stream_command(int argc, char *argv[]);
 
 	static int		instance_count();
@@ -136,7 +141,7 @@ public:
 
 	static int		destroy_all_instances();
 
-	static int		get_status_all_instances();
+	static int		get_status_all_instances(bool show_streams_status);
 
 	static bool		instance_exists(const char *device_name, Mavlink *self);
 

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -559,7 +559,7 @@ private:
 	bool			mavlink_link_termination_allowed;
 
 	char 			*_subscribe_to_stream;
-	float			_subscribe_to_stream_rate;
+	float			_subscribe_to_stream_rate;  ///< rate of stream to subscribe to (0=disable, -1=unlimited, -2=default)
 	bool 			_udp_initialised;
 
 	enum FLOW_CONTROL_MODE	_flow_control_mode;
@@ -637,7 +637,21 @@ private:
 	static constexpr unsigned RADIO_BUFFER_LOW_PERCENTAGE = 35;
 	static constexpr unsigned RADIO_BUFFER_HALF_PERCENTAGE = 50;
 
+	/**
+	 * Configure a single stream.
+	 * @param stream_name
+	 * @param rate streaming rate in Hz, -1 = unlimited rate
+	 * @return 0 on success, <0 on error
+	 */
 	int configure_stream(const char *stream_name, const float rate = -1.0f);
+
+	/**
+	 * Configure default streams according to _mode for either all streams or only a single
+	 * stream.
+	 * @param configure_single_stream: if nullptr, configure all streams, else only a single stream
+	 * @return 0 on success, <0 on error
+	 */
+	int configure_streams_to_default(const char *configure_single_stream = nullptr);
 
 	/**
 	 * Adjust the stream rates based on the current rate

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -432,7 +432,7 @@ public:
 
 	const in_addr compute_broadcast_addr(const in_addr &host_addr, const in_addr &netmask_addr);
 
-	struct sockaddr_in 	*get_client_source_address() { return &_src_addr; }
+	struct sockaddr_in 	&get_client_source_address() { return _src_addr; }
 
 	void			set_client_source_initialized() { _src_addr_initialized = true; }
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2546,7 +2546,7 @@ MavlinkReceiver::receive_thread(void *arg)
 				// could be TCP or other protocol
 			}
 
-			struct sockaddr_in *srcaddr_last = _mavlink->get_client_source_address();
+			struct sockaddr_in &srcaddr_last = _mavlink->get_client_source_address();
 
 			int localhost = (127 << 24) + 1;
 
@@ -2558,9 +2558,9 @@ MavlinkReceiver::receive_thread(void *arg)
 				hrt_abstime stime = _mavlink->get_start_time();
 
 				if ((stime != 0 && (hrt_elapsed_time(&stime) > 3 * 1000 * 1000))
-				    || (srcaddr_last->sin_addr.s_addr == htonl(localhost))) {
-					srcaddr_last->sin_addr.s_addr = srcaddr.sin_addr.s_addr;
-					srcaddr_last->sin_port = srcaddr.sin_port;
+				    || (srcaddr_last.sin_addr.s_addr == htonl(localhost))) {
+					srcaddr_last.sin_addr.s_addr = srcaddr.sin_addr.s_addr;
+					srcaddr_last.sin_port = srcaddr.sin_port;
 					_mavlink->set_client_source_initialized();
 					PX4_INFO("partner IP: %s", inet_ntoa(srcaddr.sin_addr));
 				}

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1844,7 +1844,7 @@ MavlinkReceiver::handle_message_heartbeat(mavlink_message_t *msg)
 int
 MavlinkReceiver::set_message_interval(int msgId, float interval, int data_rate)
 {
-	if (msgId == 0) {
+	if (msgId == MAVLINK_MSG_ID_HEARTBEAT) {
 		return PX4_ERROR;
 	}
 
@@ -1853,18 +1853,16 @@ MavlinkReceiver::set_message_interval(int msgId, float interval, int data_rate)
 	}
 
 	// configure_stream wants a rate (msgs/second), so convert here.
-	float rate = 0;
+	float rate = 0.f;
 
-	if (interval < 0) {
-		// stop the stream.
-		rate = 0;
+	if (interval < -0.00001f) {
+		rate = 0.f; // stop the stream
 
-	} else if (interval > 0) {
+	} else if (interval > 0.00001f) {
 		rate = 1000000.0f / interval;
 
 	} else {
-		// note: mavlink spec says rate == 0 is requesting a default rate but our streams
-		// don't publish a default rate so for now let's pick a default rate of zero.
+		rate = -2.f; // set default rate
 	}
 
 	bool found_id = false;


### PR DESCRIPTION
- improve mavlink status output (add datarate, UDP remote port and partner IP)
- only enable HIL_ACTUATOR_CONTROLS in hil if link has enough bandwidth
- allow resetting mavlink streams to default rate via MAV_CMD_SET_MESSAGE_INTERVAL (@DonLakeFlyer )
- add a `mavlink status streams` command to display all configured streams. Example output:
```
instance #1:
        Name                Rate Config (current) [Hz] Message Size (if active) [B]
        HEARTBEAT                       1.00 (1.000)    21
        STATUSTEXT                     20.00 (6.320)
        COMMAND_LONG                  unlimited
        ALTITUDE                        1.00 (0.316)
        ATTITUDE                       25.00 (7.900)    40
        ATTITUDE_TARGET                10.00 (3.160)    49
        ESTIMATOR_STATUS                1.00 (0.316)    44
        EXTENDED_SYS_STATE              1.00 (0.316)    14
        GLOBAL_POSITION_INT            10.00 (3.160)    40
        GPS_RAW_INT                     1.00 (0.316)    62
        HOME_POSITION                   0.50 (0.158)
        RC_CHANNELS                     5.00 (1.580)
        SERVO_OUTPUT_RAW_0              1.00 (0.316)    49
        SYS_STATUS                      5.00 (1.580)    43
        SYSTEM_TIME                     1.00 (0.316)    24
        VFR_HUD                        25.00 (7.900)    32
        WIND_COV                        2.00 (0.632)
```

Fixes #9561