### PR TITLE
ekf2: Add support for use of multiple GPS receivers

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -121,6 +121,7 @@ set(msg_files
 	vehicle_control_mode.msg
 	vehicle_global_position.msg
 	vehicle_gps_position.msg
+	ekf_gps_position.msg
 	vehicle_land_detected.msg
 	vehicle_local_position.msg
 	vehicle_local_position_setpoint.msg

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -52,6 +52,7 @@ set(msg_files
 	distance_sensor.msg
 	ekf2_innovations.msg
 	ekf2_timestamps.msg
+	ekf_gps_position.msg
 	esc_report.msg
 	esc_status.msg
 	estimator_status.msg
@@ -121,16 +122,15 @@ set(msg_files
 	vehicle_control_mode.msg
 	vehicle_global_position.msg
 	vehicle_gps_position.msg
-	ekf_gps_position.msg
 	vehicle_land_detected.msg
 	vehicle_local_position.msg
 	vehicle_local_position_setpoint.msg
 	vehicle_magnetometer.msg
 	vehicle_rates_setpoint.msg
 	vehicle_roi.msg
-	vehicle_trajectory_waypoint.msg
 	vehicle_status.msg
 	vehicle_status_flags.msg
+	vehicle_trajectory_waypoint.msg
 	vtol_vehicle_status.msg
 	wind_estimate.msg
 	vehicle_constraints.msg

--- a/msg/ekf_gps_position.msg
+++ b/msg/ekf_gps_position.msg
@@ -1,0 +1,16 @@
+# EKF blended position in WGS84 coordinates.
+int32 lat			# Latitude in 1E-7 degrees
+int32 lon			# Longitude in 1E-7 degrees
+int32 alt			# Altitude in 1E-3 meters above MSL, (millimetres)
+int32 alt_ellipsoid 		# Altitude in 1E-3 meters bove Ellipsoid, (millimetres)
+float32 s_variance_m_s		# GPS speed accuracy estimate, (metres/sec)
+uint8 fix_type # 0-1: no fix, 2: 2D fix, 3: 3D fix, 4: RTCM code differential, 5: Real-Time Kinematic, float, 6: Real-Time Kinematic, fixed, 8: Extrapolated. Some applications will not use the value of this field unless it is at least two, so always correctly fill in the fix.
+float32 eph			# GPS horizontal position accuracy (metres)
+float32 epv			# GPS vertical position accuracy (metres)
+float32 vel_m_s			# GPS ground speed, (metres/sec)
+float32 vel_n_m_s		# GPS North velocity, (metres/sec)
+float32 vel_e_m_s		# GPS East velocity, (metres/sec)
+float32 vel_d_m_s		# GPS Down velocity, (metres/sec)
+bool vel_ned_valid		# True if NED velocity is valid
+uint8 satellites_used		# Number of satellites used
+uint8 selected			# GPS selection: 0: GPS1, 1: GPS2. 2: GPS1+GPS2 blend

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -233,7 +233,7 @@ private:
 
 	// because we can have multiple GPS instances
 	int _gps_subs[ORB_MULTI_MAX_INSTANCES];
-	int32_t _gps_orb_instance{-1};
+	int _gps_orb_instance{-1};
 
 	orb_advert_t _att_pub{nullptr};
 	orb_advert_t _wind_pub{nullptr};

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1984,18 +1984,12 @@ void Ekf2::update_gps_blend_states(void)
 	float blended_alt_offset_mm = 0.0f;
 
 	for (uint8_t i = 0; i < GPS_MAX_RECEIVERS; i++) {
-		if (_blend_weights[i] > 0.0f) {
+		if ((_blend_weights[i] > 0.0f) && (i != _gps_best_index)) {
 			// calculate the horizontal offset
 			Vector2f horiz_offset{};
-
-			if (i != _gps_best_index) {
-				get_vector_to_next_waypoint((_gps_blended_state.lat / 1.0e7),
-							    (_gps_blended_state.lon / 1.0e7), (_gps_state[i].lat / 1.0e7), (_gps_state[i].lon / 1.0e7),
-							    &horiz_offset(0), &horiz_offset(1));
-
-			} else {
-				horiz_offset.zero();
-			}
+			get_vector_to_next_waypoint((_gps_blended_state.lat / 1.0e7),
+						    (_gps_blended_state.lon / 1.0e7), (_gps_state[i].lat / 1.0e7), (_gps_state[i].lon / 1.0e7),
+						    &horiz_offset(0), &horiz_offset(1));
 
 			// sum weighted offsets
 			blended_NE_offset_m += horiz_offset * _blend_weights[i];

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -2160,16 +2160,14 @@ void Ekf2::calc_gps_blend_output(void)
 	}
 
 	// Add the sum of weighted offsets to the reference position to obtain the blended output
-	{
-		double lat_deg_now = (double)_gps_output[GPS_BLENDED_INSTANCE].lat * 1.0e-7;
-		double lon_deg_now = (double)_gps_output[GPS_BLENDED_INSTANCE].lon * 1.0e-7;
-		double lat_deg_res, lon_deg_res;
-		add_vector_to_global_position(lat_deg_now, lon_deg_now, blended_NE_offset_m(0), blended_NE_offset_m(1), &lat_deg_res,
-					      &lon_deg_res);
-		_gps_output[GPS_BLENDED_INSTANCE].lat = (int32_t)(1.0E7 * lat_deg_res);
-		_gps_output[GPS_BLENDED_INSTANCE].lon = (int32_t)(1.0E7 * lon_deg_res);
-		_gps_output[GPS_BLENDED_INSTANCE].alt += (int32_t)blended_alt_offset_mm;
-	}
+	double lat_deg_now = (double)_gps_output[GPS_BLENDED_INSTANCE].lat * 1.0e-7;
+	double lon_deg_now = (double)_gps_output[GPS_BLENDED_INSTANCE].lon * 1.0e-7;
+	double lat_deg_res, lon_deg_res;
+	add_vector_to_global_position(lat_deg_now, lon_deg_now, blended_NE_offset_m(0), blended_NE_offset_m(1), &lat_deg_res,
+				      &lon_deg_res);
+	_gps_output[GPS_BLENDED_INSTANCE].lat = (int32_t)(1.0E7 * lat_deg_res);
+	_gps_output[GPS_BLENDED_INSTANCE].lon = (int32_t)(1.0E7 * lon_deg_res);
+	_gps_output[GPS_BLENDED_INSTANCE].alt += (int32_t)blended_alt_offset_mm;
 
 	// Copy remaining data from internal states to output
 	_gps_output[GPS_BLENDED_INSTANCE].time_usec	= _gps_blended_state.time_usec;

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -582,7 +582,6 @@ Ekf2::Ekf2():
 	_vehicle_land_detected_sub = orb_subscribe(ORB_ID(vehicle_land_detected));
 
 	for (unsigned i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
-		_gps_subs[i] = -1;
 		_gps_subs[i] = orb_subscribe_multi(ORB_ID(vehicle_gps_position), i);
 		_range_finder_subs[i] = orb_subscribe_multi(ORB_ID(distance_sensor), i);
 	}

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -233,6 +233,7 @@ private:
 
 	// because we can have multiple GPS instances
 	int _gps_subs[ORB_MULTI_MAX_INSTANCES];
+	int32_t _gps_orb_instance{-1};
 
 	orb_advert_t _att_pub{nullptr};
 	orb_advert_t _wind_pub{nullptr};
@@ -1019,9 +1020,7 @@ void Ekf2::run()
 				gps.satellites_used = _gps_output[_gps_select_index].nsats;
 
 				// Publish to the GPS multi-topic
-				int32_t gps_orb_instance;
-				orb_publish_auto(ORB_ID(vehicle_gps_position), &_blended_gps_pub, &gps, &gps_orb_instance,
-						 ORB_PRIO_HIGH);
+				orb_publish_auto(ORB_ID(vehicle_gps_position), &_blended_gps_pub, &gps, &_gps_orb_instance, ORB_PRIO_LOW);
 			}
 		}
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -939,6 +939,16 @@ void Ekf2::run()
 				_gps_state[0].gdop = 0.0f;
 
 				ekf2_timestamps.gps_timestamp_rel = (int16_t)((int64_t)gps.timestamp / 100 - (int64_t)ekf2_timestamps.timestamp / 100);
+
+				if (_gps_blend_mask.get() == 0) {
+					// When GPS blending is disabled we always use the first receiver instance
+					_ekf.setGpsData(_gps_state[0].time_usec, &_gps_state[0]);
+				}
+
+				if (_gps_blend_mask.get() == 0) {
+					// When GPS blending is disabled we always use the first receiver instance
+					_ekf.setGpsData(_gps_state[0].time_usec, &_gps_state[0]);
+				}
 			}
 		}
 
@@ -2128,11 +2138,11 @@ void Ekf2::calc_gps_blend_output(void)
 			// calculate the horizontal offset
 			Vector2f horiz_offset{};
 			get_vector_to_next_waypoint((_gps_blended_state.lat / 1.0e7),
-				(_gps_blended_state.lon / 1.0e7),
-				(_gps_output[i].lat / 1.0e7),
-				(_gps_output[i].lon / 1.0e7),
-				&horiz_offset(0),
-				&horiz_offset(1));
+						    (_gps_blended_state.lon / 1.0e7),
+						    (_gps_output[i].lat / 1.0e7),
+						    (_gps_output[i].lon / 1.0e7),
+						    &horiz_offset(0),
+						    &horiz_offset(1));
 
 			// sum weighted offsets
 			blended_NE_offset_m += horiz_offset * _blend_weights[i];

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -665,12 +665,6 @@ void Ekf2::run()
 	vehicle_status_s vehicle_status = {};
 	sensor_selection_s sensor_selection = {};
 
-	// Position of local NED origin in GPS / WGS84 frame
-	map_projection_reference_s ekf_origin = {};
-	float ref_alt = 0.0f;
-	uint64_t origin_time = 0;
-	bool ekf_origin_valid = false;
-
 	while (!should_exit()) {
 		int ret = px4_poll(fds, sizeof(fds) / sizeof(fds[0]), 1000);
 
@@ -1715,8 +1709,8 @@ bool Ekf2::calc_gps_blend_weights(void)
 	memset(&_blend_weights, 0, sizeof(_blend_weights));
 
 	// Use the oldest non-zero time, but if time difference is excessive, use newest to prevent a disconnected receiver from blocking updates
-	int64_t max_us = 0; // newest non-zero system time of arrival of a GPS message
-	int64_t min_us = -1; // oldest non-zero system time of arrival of a GPS message
+	uint64_t max_us = 0; // newest non-zero system time of arrival of a GPS message
+	uint64_t min_us = -1; // oldest non-zero system time of arrival of a GPS message
 
 	for (uint8_t i = 0; i < GPS_MAX_RECEIVERS; i++) {
 		// Find largest and smallest times
@@ -1729,7 +1723,7 @@ bool Ekf2::calc_gps_blend_weights(void)
 		}
 	}
 
-	if ((int64_t)(max_us - min_us) < 300000) {
+	if ((max_us - min_us) < 300000) {
 		// data is not too delayed so use the oldest time_stamp to give a chance for data from that receiver to be updated
 		_gps_blended_state.time_usec = min_us;
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1713,7 +1713,7 @@ const Vector3f Ekf2::get_vel_body_wind()
 /*
  calculate the weightings used to blend GPS location and velocity data
 */
-bool Ekf2::calc_gps_blend_weights(void)
+bool Ekf2::calc_gps_blend_weights()
 {
 	// zero the blend weights
 	memset(&_blend_weights, 0, sizeof(_blend_weights));
@@ -1887,7 +1887,7 @@ bool Ekf2::calc_gps_blend_weights(void)
  * because if physical receivers have significant position differences,  variation in receiver estimated accuracy will
  * cause undesirable variation in the position soution.
 */
-void Ekf2::update_gps_blend_states(void)
+void Ekf2::update_gps_blend_states()
 {
 	// initialise the blended states so we can accumulate the results using the weightings for each GPS receiver.
 	_gps_blended_state.time_usec = 0;
@@ -2025,7 +2025,7 @@ void Ekf2::update_gps_blend_states(void)
  * To mitigate this effect a low-pass filtered offset from each GPS location to the blended location is
  * calculated.
 */
-void Ekf2::update_gps_offsets(void)
+void Ekf2::update_gps_offsets()
 {
 
 	// Calculate filter coefficients to be applied to the offsets for each GPS position and height offset
@@ -2092,7 +2092,7 @@ void Ekf2::update_gps_offsets(void)
 /*
  * Apply the steady state physical receiver offsets calculated by update_gps_offsets().
 */
-void Ekf2::apply_gps_offsets(void)
+void Ekf2::apply_gps_offsets()
 {
 	// calculate offset corrected output for each physical GPS.
 	for (uint8_t i = 0; i < GPS_MAX_RECEIVERS; i++) {
@@ -2125,7 +2125,7 @@ void Ekf2::apply_gps_offsets(void)
 /*
  Calculate GPS output that is a blend of the offset corrected physical receiver data
 */
-void Ekf2::calc_gps_blend_output(void)
+void Ekf2::calc_gps_blend_output()
 {
 	// Convert each GPS position to a local NEU offset relative to the reference position
 	// which is defined as the positon of the blended solution calculated from non offset corrected data

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -55,23 +55,23 @@
 #include <uORB/topics/distance_sensor.h>
 #include <uORB/topics/ekf2_innovations.h>
 #include <uORB/topics/ekf2_timestamps.h>
+#include <uORB/topics/ekf_gps_position.h>
 #include <uORB/topics/estimator_status.h>
+#include <uORB/topics/landing_target_pose.h>
 #include <uORB/topics/optical_flow.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/sensor_bias.h>
 #include <uORB/topics/sensor_combined.h>
 #include <uORB/topics/sensor_selection.h>
+#include <uORB/topics/vehicle_air_data.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_gps_position.h>
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_magnetometer.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/wind_estimate.h>
-#include <uORB/topics/landing_target_pose.h>
-#include <uORB/topics/vehicle_air_data.h>
-#include <uORB/topics/vehicle_magnetometer.h>
-#include <uORB/topics/ekf_gps_position.h>
 
 // defines used to specify the mask position for use of different accuracy metrics in the GPS blending algorithm
 #define BLEND_MASK_USE_SPD_ACC      1

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -71,6 +71,7 @@
 #include <uORB/topics/landing_target_pose.h>
 #include <uORB/topics/vehicle_air_data.h>
 #include <uORB/topics/vehicle_magnetometer.h>
+#include <uORB/topics/ekf_gps_position.h>
 
 // defines used to specify the mask position for use of different accuracy metrics in the GPS blending algorithm
 #define BLEND_MASK_USE_SPD_ACC      1
@@ -1018,7 +1019,7 @@ void Ekf2::run()
 
 			// log blended solution as a third GPS instance
 			if (_gps_select_index == 2) {
-				vehicle_gps_position_s gps;
+				ekf_gps_position_s gps;
 				gps.timestamp = _gps_output[_gps_select_index].time_usec;
 				gps.lat = _gps_output[_gps_select_index].lat;
 				gps.lon = _gps_output[_gps_select_index].lon;
@@ -1034,8 +1035,8 @@ void Ekf2::run()
 				gps.vel_ned_valid = _gps_output[_gps_select_index].vel_ned_valid;
 				gps.satellites_used = _gps_output[_gps_select_index].nsats;
 
-				// Publish to the GPS multi-topic
-				orb_publish_auto(ORB_ID(vehicle_gps_position), &_blended_gps_pub, &gps, &_gps_orb_instance, ORB_PRIO_LOW);
+				// Publish to the EKF blended GPS topic
+				orb_publish_auto(ORB_ID(ekf_gps_position), &_blended_gps_pub, &gps, &_gps_orb_instance, ORB_PRIO_LOW);
 			}
 		}
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -938,16 +938,6 @@ void Ekf2::run()
 				_gps_state[0].gdop = 0.0f;
 
 				ekf2_timestamps.gps_timestamp_rel = (int16_t)((int64_t)gps.timestamp / 100 - (int64_t)ekf2_timestamps.timestamp / 100);
-
-				if (_gps_blend_mask.get() == 0) {
-					// When GPS blending is disabled we always use the first receiver instance
-					_ekf.setGpsData(_gps_state[0].time_usec, &_gps_state[0]);
-				}
-
-				if (_gps_blend_mask.get() == 0) {
-					// When GPS blending is disabled we always use the first receiver instance
-					_ekf.setGpsData(_gps_state[0].time_usec, &_gps_state[0]);
-				}
 			}
 		}
 
@@ -978,8 +968,13 @@ void Ekf2::run()
 			}
 		}
 
-		// blend dual receivers if available
-		if ((_gps_blend_mask.get() > 0) && (gps1_updated || gps2_updated)) {
+		if ((_gps_blend_mask.get() == 0) && gps1_updated) {
+			// When GPS blending is disabled we always use the first receiver instance
+			_ekf.setGpsData(_gps_state[0].time_usec, &_gps_state[0]);
+
+		} else if ((_gps_blend_mask.get() > 0) && (gps1_updated || gps2_updated)) {
+			// blend dual receivers if available
+
 			// calculate blending weights
 			if (calc_gps_blend_weights()) {
 				// With updated weights we can calculate a blended GPS solution and

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1018,7 +1018,7 @@ void Ekf2::run()
 			_ekf.setGpsData(_gps_output[_gps_select_index].time_usec, &_gps_output[_gps_select_index]);
 
 			// log blended solution as a third GPS instance
-			if (_gps_select_index == 2) {
+			if (_gps_blend_mask.get() > 0) {
 				ekf_gps_position_s gps;
 				gps.timestamp = _gps_output[_gps_select_index].time_usec;
 				gps.lat = _gps_output[_gps_select_index].lat;
@@ -1034,6 +1034,7 @@ void Ekf2::run()
 				gps.vel_d_m_s = _gps_output[_gps_select_index].vel_ned[2];
 				gps.vel_ned_valid = _gps_output[_gps_select_index].vel_ned_valid;
 				gps.satellites_used = _gps_output[_gps_select_index].nsats;
+				gps.selected = _gps_select_index;
 
 				// Publish to the EKF blended GPS topic
 				orb_publish_auto(ORB_ID(ekf_gps_position), &_blended_gps_pub, &gps, &_gps_orb_instance, ORB_PRIO_LOW);

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -213,9 +213,9 @@ private:
 	const float _hgt_innov_spike_lim = 2.0f * _hgt_innov_test_lim;	///< preflight position innovation spike limit (m)
 
 	// GPS blending and switching
-	struct gps_message _gps_state[GPS_MAX_RECEIVERS]; ///< internal state data for the physical GPS
-	struct gps_message _gps_blended_state;		///< internal state data for the blended GPS
-	struct gps_message _gps_output[GPS_MAX_RECEIVERS + 1]; ///< output state data for the physical and blended GPS
+	gps_message _gps_state[GPS_MAX_RECEIVERS] {}; ///< internal state data for the physical GPS
+	gps_message _gps_blended_state{};		///< internal state data for the blended GPS
+	gps_message _gps_output[GPS_MAX_RECEIVERS + 1] {}; ///< output state data for the physical and blended GPS
 	Vector2f _NE_pos_offset_m[GPS_MAX_RECEIVERS] = {}; ///< Filtered North,East position offset from GPS instance to blended solution in _output_state.location (m)
 	float _hgt_offset_mm[GPS_MAX_RECEIVERS] = {};	///< Filtered height offset from GPS instance relative to blended solution in _output_state.location (mm)
 	Vector3f _blended_antenna_offset = {};		///< blended antenna offset
@@ -238,11 +238,11 @@ private:
 	int _vehicle_land_detected_sub{-1};
 
 	// because we can have several distance sensor instances with different orientations
-	int _range_finder_subs[ORB_MULTI_MAX_INSTANCES];
+	int _range_finder_subs[ORB_MULTI_MAX_INSTANCES] {};
 	int _range_finder_sub_index = -1; // index for downward-facing range finder subscription
 
 	// because we can have multiple GPS instances
-	int _gps_subs[ORB_MULTI_MAX_INSTANCES];
+	int _gps_subs[ORB_MULTI_MAX_INSTANCES] {};
 	int _gps_orb_instance{-1};
 
 	orb_advert_t _att_pub{nullptr};

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1016,27 +1016,25 @@ void Ekf2::run()
 			_ekf.setGpsData(_gps_output[_gps_select_index].time_usec, &_gps_output[_gps_select_index]);
 
 			// log blended solution as a third GPS instance
-			if (_gps_blend_mask.get() > 0) {
-				ekf_gps_position_s gps;
-				gps.timestamp = _gps_output[_gps_select_index].time_usec;
-				gps.lat = _gps_output[_gps_select_index].lat;
-				gps.lon = _gps_output[_gps_select_index].lon;
-				gps.alt = _gps_output[_gps_select_index].alt;
-				gps.fix_type = _gps_output[_gps_select_index].fix_type;
-				gps.eph = _gps_output[_gps_select_index].eph;
-				gps.epv = _gps_output[_gps_select_index].epv;
-				gps.s_variance_m_s = _gps_output[_gps_select_index].sacc;
-				gps.vel_m_s = _gps_output[_gps_select_index].vel_m_s;
-				gps.vel_n_m_s = _gps_output[_gps_select_index].vel_ned[0];
-				gps.vel_e_m_s = _gps_output[_gps_select_index].vel_ned[1];
-				gps.vel_d_m_s = _gps_output[_gps_select_index].vel_ned[2];
-				gps.vel_ned_valid = _gps_output[_gps_select_index].vel_ned_valid;
-				gps.satellites_used = _gps_output[_gps_select_index].nsats;
-				gps.selected = _gps_select_index;
+			ekf_gps_position_s gps;
+			gps.timestamp = _gps_output[_gps_select_index].time_usec;
+			gps.lat = _gps_output[_gps_select_index].lat;
+			gps.lon = _gps_output[_gps_select_index].lon;
+			gps.alt = _gps_output[_gps_select_index].alt;
+			gps.fix_type = _gps_output[_gps_select_index].fix_type;
+			gps.eph = _gps_output[_gps_select_index].eph;
+			gps.epv = _gps_output[_gps_select_index].epv;
+			gps.s_variance_m_s = _gps_output[_gps_select_index].sacc;
+			gps.vel_m_s = _gps_output[_gps_select_index].vel_m_s;
+			gps.vel_n_m_s = _gps_output[_gps_select_index].vel_ned[0];
+			gps.vel_e_m_s = _gps_output[_gps_select_index].vel_ned[1];
+			gps.vel_d_m_s = _gps_output[_gps_select_index].vel_ned[2];
+			gps.vel_ned_valid = _gps_output[_gps_select_index].vel_ned_valid;
+			gps.satellites_used = _gps_output[_gps_select_index].nsats;
+			gps.selected = _gps_select_index;
 
-				// Publish to the EKF blended GPS topic
-				orb_publish_auto(ORB_ID(ekf_gps_position), &_blended_gps_pub, &gps, &_gps_orb_instance, ORB_PRIO_LOW);
-			}
+			// Publish to the EKF blended GPS topic
+			orb_publish_auto(ORB_ID(ekf_gps_position), &_blended_gps_pub, &gps, &_gps_orb_instance, ORB_PRIO_LOW);
 		}
 
 		bool airspeed_updated = false;

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1289,7 +1289,7 @@ PARAM_DEFINE_INT32(EKF2_GPS_MASK, 0);
 /**
  * Multi GPS Blending Time Constant
  *
- * Sets the longest time constant that will be applied to the calculation of  GPS position and height offsets used to correct data from multiple GPS data for steady state position differences.
+ * Sets the longest time constant that will be applied to the calculation of GPS position and height offsets used to correct data from multiple GPS data for steady state position differences.
  *
  *
  * @group EKF2

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1268,3 +1268,34 @@ PARAM_DEFINE_FLOAT(EKF2_ABL_GYRLIM, 3.0f);
  * @decimal 2
  */
 PARAM_DEFINE_FLOAT(EKF2_ABL_TAU, 0.5f);
+
+/**
+ * Multi GPS Blending Control Mask.
+ *
+ * Set bits in the following positions to set which GPS accuracy metrics will be used to calculate the blending weight. Set to zero to disable and always used first GPS instance.
+ * 0 : Set to true to use speed accuracy
+ * 1 : Set to true to use horizontal position accuracy
+ * 2 : Set to true to use vertical position accuracy
+ *
+ * @group EKF2
+ * @min 0
+ * @max 7
+ * @bit 0 use speed accuracy
+ * @bit 1 use hpos accuracy
+ * @bit 2 use vpos accuracy
+ */
+PARAM_DEFINE_INT32(EKF2_GPS_MASK, 0);
+
+/**
+ * Multi GPS Blending Time Constant
+ *
+ * Sets the longest time constant that will be applied to the calculation of  GPS position and height offsets used to correct data from multiple GPS data for steady state position differences.
+ *
+ *
+ * @group EKF2
+ * @min 1.0
+ * @max 100.0
+ * @unit s
+ * @decimal 1
+ */
+PARAM_DEFINE_FLOAT(EKF2_GPS_TAU, 10.0f);

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -687,6 +687,7 @@ void Logger::add_estimator_replay_topics()
 {
 	// for estimator replay (need to be at full rate)
 	add_topic("ekf2_timestamps");
+	add_topic("ekf_gps_position");
 
 	// current EKF2 subscriptions
 	add_topic("airspeed");


### PR DESCRIPTION
Submitted in response to  https://github.com/PX4/Firmware/issues/9431

This PR  gives ekf2 the ability to use two GPS receivers if available to create a blended solution where the blending weights and position/height offset correction adapts to the reported accuracy. If one receiver loses lock or data, it will automatically switch across to the good receiver.

Because a long term position offset is calculated separately for each receiver, switching between either GPS1, GPS2 and the blended solution can be performed without large position and altitude jumps.

This feature relies on use of the reported accuracy metrics contained in the vehicle_gps_position.eph, epv and s_variance_m_s messages.  The EKF2_GPS_MASK parameter controls which accuracy metrics are used to set the blending ratios. By default it is zero which disables the blending. If different model receivers are used, they must both have the same update rate and both output the accuracy metrics selected by the EKF2_GPS_MASK parameter. An RTK and non RTK receiver can be used.

The EKF2_GPS_TAU parameter controls the time constant used to adjust the position offset that is applied to each GPS solution.

The blended GPS solution is published as a third GPS instance and can be found in the log as vehicle_gps_position_2

Bench test log here: https://logs.px4.io/plot_app?log=1bfcfab1-1652-48e3-b349-a42cd493e3cd

Method used to log blended GPS to a third instance may not be correct. I am relying on the uORB orb_publish_auto function to correctly assign a new instance.

Noise on blended lat/lon in log needs investigating. It was not present on logs generated using earlier replay data.