### PR TITLE
Drivers switch most DEVICE_DEBUG -> PX4_DEBUG

### DIFF
--- a/src/drivers/barometer/bmp280/bmp280.cpp
+++ b/src/drivers/barometer/bmp280/bmp280.cpp
@@ -199,7 +199,7 @@ BMP280::init()
 	ret = CDev::init();
 
 	if (ret != OK) {
-		DEVICE_DEBUG("CDev init failed");
+		PX4_DEBUG("CDev init failed");
 		return ret;
 	}
 
@@ -207,7 +207,7 @@ BMP280::init()
 	_reports = new ringbuffer::RingBuffer(2, sizeof(baro_report));
 
 	if (_reports == nullptr) {
-		DEVICE_DEBUG("can't get memory for reports");
+		PX4_DEBUG("can't get memory for reports");
 		ret = -ENOMEM;
 		return ret;
 	}

--- a/src/drivers/barometer/lps22hb/LPS22HB.cpp
+++ b/src/drivers/barometer/lps22hb/LPS22HB.cpp
@@ -79,7 +79,7 @@ LPS22HB::init()
 	int ret = CDev::init();
 
 	if (ret != OK) {
-		DEVICE_DEBUG("CDev init failed");
+		PX4_DEBUG("CDev init failed");
 		goto out;
 	}
 
@@ -227,7 +227,7 @@ LPS22HB::cycle()
 
 		/* perform collection */
 		if (OK != collect()) {
-			DEVICE_DEBUG("collection error");
+			PX4_DEBUG("collection error");
 			/* restart the measurement state machine */
 			start();
 			return;
@@ -254,7 +254,7 @@ LPS22HB::cycle()
 
 	/* measurement phase */
 	if (OK != measure()) {
-		DEVICE_DEBUG("measure error");
+		PX4_DEBUG("measure error");
 	}
 
 	/* next phase is collection */
@@ -334,7 +334,7 @@ LPS22HB::collect()
 							  (sensor_is_onboard) ? ORB_PRIO_HIGH : ORB_PRIO_MAX);
 
 			if (_baro_topic == nullptr) {
-				DEVICE_DEBUG("ADVERT FAIL");
+				PX4_DEBUG("ADVERT FAIL");
 			}
 		}
 	}

--- a/src/drivers/barometer/lps22hb/LPS22HB_I2C.cpp
+++ b/src/drivers/barometer/lps22hb/LPS22HB_I2C.cpp
@@ -85,14 +85,14 @@ LPS22HB_I2C::probe()
 	_retries = 10;
 
 	if (read(WHO_AM_I, &id, 1)) {
-		DEVICE_DEBUG("read_reg fail");
+		PX4_DEBUG("read_reg fail");
 		return -EIO;
 	}
 
 	_retries = 2;
 
 	if (id != LPS22HB_ID_WHO_AM_I) {
-		DEVICE_DEBUG("ID byte mismatch (%02x != %02x)", LPS22HB_ID_WHO_AM_I, id);
+		PX4_DEBUG("ID byte mismatch (%02x != %02x)", LPS22HB_ID_WHO_AM_I, id);
 		return -EIO;
 	}
 

--- a/src/drivers/barometer/lps22hb/LPS22HB_SPI.cpp
+++ b/src/drivers/barometer/lps22hb/LPS22HB_SPI.cpp
@@ -83,7 +83,7 @@ LPS22HB_SPI::init()
 	int ret = SPI::init();
 
 	if (ret != OK) {
-		DEVICE_DEBUG("SPI init failed");
+		PX4_DEBUG("SPI init failed");
 		return -EIO;
 	}
 
@@ -91,12 +91,12 @@ LPS22HB_SPI::init()
 	uint8_t id = 0;
 
 	if (read(WHO_AM_I, &id, 1)) {
-		DEVICE_DEBUG("read_reg fail");
+		PX4_DEBUG("read_reg fail");
 		return -EIO;
 	}
 
 	if (id != LPS22HB_ID_WHO_AM_I) {
-		DEVICE_DEBUG("ID byte mismatch (%02x != %02x)", LPS22HB_ID_WHO_AM_I, id);
+		PX4_DEBUG("ID byte mismatch (%02x != %02x)", LPS22HB_ID_WHO_AM_I, id);
 		return -EIO;
 	}
 

--- a/src/drivers/barometer/lps25h/lps25h.cpp
+++ b/src/drivers/barometer/lps25h/lps25h.cpp
@@ -328,8 +328,6 @@ LPS25H::LPS25H(device::Device *interface, const char *path) :
 	_device_id.devid_s.address = _interface->get_device_address();
 	_device_id.devid_s.devtype = DRV_BARO_DEVTYPE_LPS25H;
 
-	// enable debug() calls
-	_debug_enabled = false;
 
 	// work_cancel in the dtor will explode if we don't do this...
 	memset(&_work, 0, sizeof(_work));
@@ -363,7 +361,7 @@ LPS25H::init()
 	ret = CDev::init();
 
 	if (ret != OK) {
-		DEVICE_DEBUG("CDev init failed");
+		PX4_DEBUG("CDev init failed");
 		goto out;
 	}
 
@@ -371,7 +369,7 @@ LPS25H::init()
 	_reports = new ringbuffer::RingBuffer(2, sizeof(sensor_baro_s));
 
 	if (_reports == nullptr) {
-		DEVICE_DEBUG("can't get memory for reports");
+		PX4_DEBUG("can't get memory for reports");
 		ret = -ENOMEM;
 		goto out;
 	}
@@ -605,7 +603,7 @@ LPS25H::cycle()
 
 		/* perform collection */
 		if (OK != collect()) {
-			DEVICE_DEBUG("collection error");
+			PX4_DEBUG("collection error");
 			/* restart the measurement state machine */
 			start();
 			return;
@@ -632,7 +630,7 @@ LPS25H::cycle()
 
 	/* measurement phase */
 	if (OK != measure()) {
-		DEVICE_DEBUG("measure error");
+		PX4_DEBUG("measure error");
 	}
 
 	/* next phase is collection */
@@ -725,7 +723,7 @@ LPS25H::collect()
 							  &_orb_class_instance, (sensor_is_onboard) ? ORB_PRIO_HIGH : ORB_PRIO_MAX);
 
 			if (_baro_topic == nullptr) {
-				DEVICE_DEBUG("ADVERT FAIL");
+				PX4_DEBUG("ADVERT FAIL");
 			}
 		}
 	}

--- a/src/drivers/barometer/lps25h/lps25h_i2c.cpp
+++ b/src/drivers/barometer/lps25h/lps25h_i2c.cpp
@@ -127,14 +127,14 @@ LPS25H_I2C::probe()
 	_retries = 10;
 
 	if (read(ADDR_WHO_AM_I, &id, 1)) {
-		DEVICE_DEBUG("read_reg fail");
+		PX4_DEBUG("read_reg fail");
 		return -EIO;
 	}
 
 	_retries = 2;
 
 	if (id != ID_WHO_AM_I) {
-		DEVICE_DEBUG("ID byte mismatch (%02x != %02x)", ID_WHO_AM_I, id);
+		PX4_DEBUG("ID byte mismatch (%02x != %02x)", ID_WHO_AM_I, id);
 		return -EIO;
 	}
 

--- a/src/drivers/barometer/lps25h/lps25h_spi.cpp
+++ b/src/drivers/barometer/lps25h/lps25h_spi.cpp
@@ -107,7 +107,7 @@ LPS25H_SPI::init()
 	ret = SPI::init();
 
 	if (ret != OK) {
-		DEVICE_DEBUG("SPI init failed");
+		PX4_DEBUG("SPI init failed");
 		return -EIO;
 	}
 
@@ -115,12 +115,12 @@ LPS25H_SPI::init()
 	uint8_t id;
 
 	if (read(ADDR_ID, &id, 1)) {
-		DEVICE_DEBUG("read_reg fail");
+		PX4_DEBUG("read_reg fail");
 		return -EIO;
 	}
 
 	if (id != ID_WHO_AM_I) {
-		DEVICE_DEBUG("ID byte mismatch (%02x != %02x)", ID_WHO_AM_I, id);
+		PX4_DEBUG("ID byte mismatch (%02x != %02x)", ID_WHO_AM_I, id);
 		return -EIO;
 	}
 

--- a/src/drivers/barometer/mpl3115a2/mpl3115a2.cpp
+++ b/src/drivers/barometer/mpl3115a2/mpl3115a2.cpp
@@ -253,7 +253,7 @@ MPL3115A2::init()
 	ret = CDev::init();
 
 	if (ret != OK) {
-		DEVICE_DEBUG("CDev init failed");
+		PX4_DEBUG("CDev init failed");
 		goto out;
 	}
 
@@ -261,7 +261,7 @@ MPL3115A2::init()
 	_reports = new ringbuffer::RingBuffer(2, sizeof(sensor_baro_s));
 
 	if (_reports == nullptr) {
-		DEVICE_DEBUG("can't get memory for reports");
+		PX4_DEBUG("can't get memory for reports");
 		ret = -ENOMEM;
 		goto out;
 	}

--- a/src/drivers/barometer/ms5611/ms5611.cpp
+++ b/src/drivers/barometer/ms5611/ms5611.cpp
@@ -289,7 +289,7 @@ MS5611::init()
 	ret = CDev::init();
 
 	if (ret != OK) {
-		DEVICE_DEBUG("CDev init failed");
+		PX4_DEBUG("CDev init failed");
 		goto out;
 	}
 
@@ -297,7 +297,7 @@ MS5611::init()
 	_reports = new ringbuffer::RingBuffer(2, sizeof(sensor_baro_s));
 
 	if (_reports == nullptr) {
-		DEVICE_DEBUG("can't get memory for reports");
+		PX4_DEBUG("can't get memory for reports");
 		ret = -ENOMEM;
 		goto out;
 	}

--- a/src/drivers/barometer/ms5611/ms5611_spi.cpp
+++ b/src/drivers/barometer/ms5611/ms5611_spi.cpp
@@ -153,7 +153,7 @@ MS5611_SPI::init()
 	ret = SPI::init();
 
 	if (ret != OK) {
-		DEVICE_DEBUG("SPI init failed");
+		PX4_DEBUG("SPI init failed");
 		goto out;
 	}
 
@@ -161,7 +161,7 @@ MS5611_SPI::init()
 	ret = _reset();
 
 	if (ret != OK) {
-		DEVICE_DEBUG("reset failed");
+		PX4_DEBUG("reset failed");
 		goto out;
 	}
 
@@ -169,7 +169,7 @@ MS5611_SPI::init()
 	ret = _read_prom();
 
 	if (ret != OK) {
-		DEVICE_DEBUG("prom readout failed");
+		PX4_DEBUG("prom readout failed");
 		goto out;
 	}
 
@@ -265,18 +265,18 @@ MS5611_SPI::_read_prom()
 			all_zero = false;
 		}
 
-		//DEVICE_DEBUG("prom[%u]=0x%x", (unsigned)i, (unsigned)_prom.c[i]);
+		//PX4_DEBUG("prom[%u]=0x%x", (unsigned)i, (unsigned)_prom.c[i]);
 	}
 
 	/* calculate CRC and return success/failure accordingly */
 	int ret = ms5611::crc4(&_prom.c[0]) ? OK : -EIO;
 
 	if (ret != OK) {
-		DEVICE_DEBUG("crc failed");
+		PX4_DEBUG("crc failed");
 	}
 
 	if (all_zero) {
-		DEVICE_DEBUG("prom all zero");
+		PX4_DEBUG("prom all zero");
 		ret = -EIO;
 	}
 

--- a/src/drivers/blinkm/blinkm.cpp
+++ b/src/drivers/blinkm/blinkm.cpp
@@ -359,7 +359,7 @@ BlinkM::probe()
 	ret = get_firmware_version(version);
 
 	if (ret == OK) {
-		DEVICE_DEBUG("found BlinkM firmware version %c%c", version[1], version[0]);
+		PX4_DEBUG("found BlinkM firmware version %c%c", version[1], version[0]);
 	}
 
 	return ret;

--- a/src/drivers/differential_pressure/ets/ets_airspeed.cpp
+++ b/src/drivers/differential_pressure/ets/ets_airspeed.cpp
@@ -215,7 +215,7 @@ ETSAirspeed::cycle()
 	ret = measure();
 
 	if (OK != ret) {
-		DEVICE_DEBUG("measure error");
+		PX4_DEBUG("measure error");
 	}
 
 	_sensor_ok = (ret == OK);

--- a/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
+++ b/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
@@ -283,7 +283,7 @@ MEASAirspeed::cycle()
 	ret = measure();
 
 	if (OK != ret) {
-		DEVICE_DEBUG("measure error");
+		PX4_DEBUG("measure error");
 	}
 
 	_sensor_ok = (ret == OK);

--- a/src/drivers/differential_pressure/ms5525/MS5525.cpp
+++ b/src/drivers/differential_pressure/ms5525/MS5525.cpp
@@ -306,7 +306,7 @@ MS5525::cycle()
 	ret = measure();
 
 	if (OK != ret) {
-		DEVICE_DEBUG("measure error");
+		PX4_DEBUG("measure error");
 	}
 
 	_sensor_ok = (ret == OK);

--- a/src/drivers/differential_pressure/sdp3x/SDP3X.cpp
+++ b/src/drivers/differential_pressure/sdp3x/SDP3X.cpp
@@ -177,7 +177,7 @@ SDP3X::cycle()
 
 	if (PX4_OK != ret) {
 		_sensor_ok = false;
-		DEVICE_DEBUG("measure error");
+		PX4_DEBUG("measure error");
 	}
 
 	// schedule a fresh cycle call when the measurement is done

--- a/src/drivers/distance_sensor/hc_sr04/hc_sr04.cpp
+++ b/src/drivers/distance_sensor/hc_sr04/hc_sr04.cpp
@@ -222,8 +222,6 @@ HC_SR04::HC_SR04(unsigned sonars) :
 	_status(0)
 
 {
-	/* enable debug() calls */
-	_debug_enabled = false;
 
 	/* work_cancel in the dtor will explode if we don't do this... */
 	memset(&_work, 0, sizeof(_work));
@@ -290,7 +288,7 @@ HC_SR04::init()
 	_cycling_rate = SR04_CONVERSION_INTERVAL;
 
 	/* show the connected sonars in terminal */
-	DEVICE_DEBUG("Number of sonars set: %d", _sonars);
+	PX4_DEBUG("Number of sonars set: %d", _sonars);
 
 	ret = OK;
 	/* sensor is ok, but we don't really know if it is within range */
@@ -533,7 +531,7 @@ HC_SR04::collect()
 
 	/* read from the sensor */
 	if (_status != 2) {
-		DEVICE_DEBUG("erro sonar %d ,status=%d", _cycle_counter, _status);
+		PX4_DEBUG("erro sonar %d ,status=%d", _cycle_counter, _status);
 		px4_arch_gpiosetevent(_gpio_tab[_cycle_counter].echo_port, true, true, false, nullptr);
 		perf_end(_sample_perf);
 		return (ret);
@@ -645,7 +643,7 @@ HC_SR04::cycle()
 	/*_circle_count 计录当前sonar　*/
 	/* perform collection */
 	if (OK != collect()) {
-		DEVICE_DEBUG("collection error");
+		PX4_DEBUG("collection error");
 	}
 
 	/* change to next sonar */
@@ -657,7 +655,7 @@ HC_SR04::cycle()
 
 	/* 测量next sonar */
 	if (OK != measure()) {
-		DEVICE_DEBUG("measure error sonar adress %d", _cycle_counter);
+		PX4_DEBUG("measure error sonar adress %d", _cycle_counter);
 	}
 
 

--- a/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
+++ b/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.cpp
@@ -124,7 +124,7 @@ int LidarLiteI2C::init()
 				 &_orb_class_instance, ORB_PRIO_LOW);
 
 	if (_distance_sensor_topic == nullptr) {
-		DEVICE_DEBUG("failed to create distance_sensor object. Did you start uOrb?");
+		PX4_DEBUG("failed to create distance_sensor object. Did you start uOrb?");
 	}
 
 	ret = OK;
@@ -184,9 +184,9 @@ int LidarLiteI2C::probe()
 			goto ok;
 		}
 
-		DEVICE_DEBUG("probe failed hw_version=0x%02x sw_version=0x%02x\n",
-			     (unsigned)_hw_version,
-			     (unsigned)_sw_version);
+		PX4_DEBUG("probe failed hw_version=0x%02x sw_version=0x%02x\n",
+			  (unsigned)_hw_version,
+			  (unsigned)_sw_version);
 	}
 
 	// not found on any address
@@ -308,7 +308,7 @@ int LidarLiteI2C::measure()
 
 	if (OK != ret) {
 		perf_count(_comms_errors);
-		DEVICE_DEBUG("i2c::transfer returned %d", ret);
+		PX4_DEBUG("i2c::transfer returned %d", ret);
 
 		// if we are getting lots of I2C transfer errors try
 		// resetting the sensor
@@ -406,7 +406,7 @@ int LidarLiteI2C::collect()
 			  read before it is ready, so only consider it
 			  an error if more than 100ms has elapsed.
 			 */
-			DEVICE_DEBUG("error reading from sensor: %d", ret);
+			PX4_DEBUG("error reading from sensor: %d", ret);
 			perf_count(_comms_errors);
 
 			if (perf_event_count(_comms_errors) % 10 == 0) {
@@ -506,7 +506,7 @@ void LidarLiteI2C::cycle()
 
 		/* try a collection */
 		if (OK != collect()) {
-			DEVICE_DEBUG("collection error");
+			PX4_DEBUG("collection error");
 
 			/* if we've been waiting more than 200ms then
 			   send a new acquire */
@@ -538,7 +538,7 @@ void LidarLiteI2C::cycle()
 	if (_collect_phase == false) {
 		/* measurement phase */
 		if (OK != measure()) {
-			DEVICE_DEBUG("measure error");
+			PX4_DEBUG("measure error");
 
 		} else {
 			/* next phase is collection. Don't switch to

--- a/src/drivers/distance_sensor/ll40ls/LidarLitePWM.cpp
+++ b/src/drivers/distance_sensor/ll40ls/LidarLitePWM.cpp
@@ -111,7 +111,7 @@ int LidarLitePWM::init()
 				 &_orb_class_instance, ORB_PRIO_LOW);
 
 	if (_distance_sensor_topic == nullptr) {
-		DEVICE_DEBUG("failed to create distance_sensor object. Did you start uOrb?");
+		PX4_DEBUG("failed to create distance_sensor object. Did you start uOrb?");
 	}
 
 	return PX4_OK;
@@ -167,7 +167,7 @@ int LidarLitePWM::measure()
 	perf_begin(_sample_perf);
 
 	if (PX4_OK != collect()) {
-		DEVICE_DEBUG("collection error");
+		PX4_DEBUG("collection error");
 		perf_count(_read_errors);
 		perf_end(_sample_perf);
 		return PX4_ERROR;

--- a/src/drivers/distance_sensor/mb12xx/mb12xx.cpp
+++ b/src/drivers/distance_sensor/mb12xx/mb12xx.cpp
@@ -212,8 +212,6 @@ MB12XX::MB12XX(uint8_t rotation, int bus, int address) :
 	_index_counter(0) 	/* initialising temp sonar i2c address to zero */
 
 {
-	/* enable debug() calls */
-	_debug_enabled = false;
 
 	/* work_cancel in the dtor will explode if we don't do this... */
 	memset(&_work, 0, sizeof(_work));
@@ -283,7 +281,7 @@ MB12XX::init()
 
 		if (ret2 == 0) { /* sonar is present -> store address_index in array */
 			addr_ind.push_back(_index_counter);
-			DEVICE_DEBUG("sonar added");
+			PX4_DEBUG("sonar added");
 			_latest_sonar_measurements.push_back(200);
 		}
 	}
@@ -304,7 +302,7 @@ MB12XX::init()
 		DEVICE_LOG("sonar %d with address %d added", (i + 1), addr_ind[i]);
 	}
 
-	DEVICE_DEBUG("Number of sonars connected: %lu", addr_ind.size());
+	PX4_DEBUG("Number of sonars connected: %lu", addr_ind.size());
 
 	ret = OK;
 	/* sensor is ok, but we don't really know if it is within range */
@@ -519,7 +517,7 @@ MB12XX::measure()
 
 	if (OK != ret) {
 		perf_count(_comms_errors);
-		DEVICE_DEBUG("i2c::transfer returned %d", ret);
+		PX4_DEBUG("i2c::transfer returned %d", ret);
 		return ret;
 	}
 
@@ -541,7 +539,7 @@ MB12XX::collect()
 	ret = transfer(nullptr, 0, &val[0], 2);
 
 	if (ret < 0) {
-		DEVICE_DEBUG("error reading from sensor: %d", ret);
+		PX4_DEBUG("error reading from sensor: %d", ret);
 		perf_count(_comms_errors);
 		perf_end(_sample_perf);
 		return ret;
@@ -614,7 +612,7 @@ MB12XX::cycle()
 
 		/* perform collection */
 		if (OK != collect()) {
-			DEVICE_DEBUG("collection error");
+			PX4_DEBUG("collection error");
 			/* if error restart the measurement state machine */
 			start();
 			return;
@@ -653,7 +651,7 @@ MB12XX::cycle()
 
 	/* Perform measurement */
 	if (OK != measure()) {
-		DEVICE_DEBUG("measure error sonar adress %d", _index_counter);
+		PX4_DEBUG("measure error sonar adress %d", _index_counter);
 	}
 
 	/* next phase is collection */

--- a/src/drivers/distance_sensor/sf0x/sf0x.cpp
+++ b/src/drivers/distance_sensor/sf0x/sf0x.cpp
@@ -232,8 +232,6 @@ SF0X::SF0X(const char *port, uint8_t rotation) :
 		warnx("ERR baud %d ATTR", termios_state);
 	}
 
-	// disable debug() calls
-	_debug_enabled = false;
 
 	// work_cancel in the dtor will explode if we don't do this...
 	memset(&_work, 0, sizeof(_work));
@@ -574,7 +572,7 @@ SF0X::collect()
 	ret = ::read(_fd, &readbuf[0], readlen);
 
 	if (ret < 0) {
-		DEVICE_DEBUG("read err: %d", ret);
+		PX4_DEBUG("read err: %d", ret);
 		perf_count(_comms_errors);
 		perf_end(_sample_perf);
 
@@ -605,7 +603,7 @@ SF0X::collect()
 		return -EAGAIN;
 	}
 
-	DEVICE_DEBUG("val (float): %8.4f, raw: %s, valid: %s", (double)distance_m, _linebuf, ((valid) ? "OK" : "NO"));
+	PX4_DEBUG("val (float): %8.4f, raw: %s, valid: %s", (double)distance_m, _linebuf, ((valid) ? "OK" : "NO"));
 
 	struct distance_sensor_s report;
 

--- a/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
+++ b/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
@@ -194,8 +194,6 @@ SF1XX::SF1XX(uint8_t rotation, int bus, int address) :
 	_comms_errors(perf_alloc(PC_COUNT, "sf1xx_com_err"))
 
 {
-	/* enable debug() calls */
-	_debug_enabled = false;
 
 	/* work_cancel in the dtor will explode if we don't do this... */
 	memset(&_work, 0, sizeof(_work));
@@ -516,7 +514,7 @@ SF1XX::measure()
 
 	if (OK != ret) {
 		perf_count(_comms_errors);
-		DEVICE_DEBUG("i2c::transfer returned %d", ret);
+		PX4_DEBUG("i2c::transfer returned %d", ret);
 		return ret;
 	}
 
@@ -537,7 +535,7 @@ SF1XX::collect()
 	ret = transfer(nullptr, 0, &val[0], 2);
 
 	if (ret < 0) {
-		DEVICE_DEBUG("error reading from sensor: %d", ret);
+		PX4_DEBUG("error reading from sensor: %d", ret);
 		perf_count(_comms_errors);
 		perf_end(_sample_perf);
 		return ret;
@@ -605,7 +603,7 @@ SF1XX::cycle()
 {
 	/* Collect results */
 	if (OK != collect()) {
-		DEVICE_DEBUG("collection error");
+		PX4_DEBUG("collection error");
 		/* if error restart the measurement state machine */
 		start();
 		return;

--- a/src/drivers/distance_sensor/srf02/srf02.cpp
+++ b/src/drivers/distance_sensor/srf02/srf02.cpp
@@ -212,8 +212,6 @@ SRF02::SRF02(uint8_t rotation, int bus, int address) :
 	_index_counter(0) 	/* initialising temp sonar i2c address to zero */
 
 {
-	/* enable debug() calls */
-	_debug_enabled = false;
 
 	/* work_cancel in the dtor will explode if we don't do this... */
 	memset(&_work, 0, sizeof(_work));
@@ -283,7 +281,7 @@ SRF02::init()
 
 		if (ret2 == 0) { /* sonar is present -> store address_index in array */
 			addr_ind.push_back(_index_counter);
-			DEVICE_DEBUG("sonar added");
+			PX4_DEBUG("sonar added");
 			_latest_sonar_measurements.push_back(200);
 		}
 	}
@@ -304,7 +302,7 @@ SRF02::init()
 		DEVICE_LOG("sonar %d with address %d added", (i + 1), addr_ind[i]);
 	}
 
-	DEVICE_DEBUG("Number of sonars connected: %zu", addr_ind.size());
+	PX4_DEBUG("Number of sonars connected: %zu", addr_ind.size());
 
 	ret = OK;
 	/* sensor is ok, but we don't really know if it is within range */
@@ -521,7 +519,7 @@ SRF02::measure()
 
 	if (OK != ret) {
 		perf_count(_comms_errors);
-		DEVICE_DEBUG("i2c::transfer returned %d", ret);
+		PX4_DEBUG("i2c::transfer returned %d", ret);
 		return ret;
 	}
 
@@ -544,7 +542,7 @@ SRF02::collect()
 	ret = transfer(nullptr, 0, &val[0], 2);
 
 	if (ret < 0) {
-		DEVICE_DEBUG("error reading from sensor: %d", ret);
+		PX4_DEBUG("error reading from sensor: %d", ret);
 		perf_count(_comms_errors);
 		perf_end(_sample_perf);
 		return ret;
@@ -617,7 +615,7 @@ SRF02::cycle()
 
 		/* perform collection */
 		if (OK != collect()) {
-			DEVICE_DEBUG("collection error");
+			PX4_DEBUG("collection error");
 			/* if error restart the measurement state machine */
 			start();
 			return;
@@ -656,7 +654,7 @@ SRF02::cycle()
 
 	/* Perform measurement */
 	if (OK != measure()) {
-		DEVICE_DEBUG("measure error sonar adress %d", _index_counter);
+		PX4_DEBUG("measure error sonar adress %d", _index_counter);
 	}
 
 	/* next phase is collection */

--- a/src/drivers/distance_sensor/teraranger/teraranger.cpp
+++ b/src/drivers/distance_sensor/teraranger/teraranger.cpp
@@ -247,8 +247,6 @@ TERARANGER::TERARANGER(uint8_t rotation, int bus, int address) :
 	// up the retries since the device misses the first measure attempts
 	I2C::_retries = 3;
 
-	// enable debug() calls
-	_debug_enabled = false;
 
 	// work_cancel in the dtor will explode if we don't do this...
 	memset(&_work, 0, sizeof(_work));
@@ -391,9 +389,9 @@ TERARANGER::probe()
 		}
 	}
 
-	DEVICE_DEBUG("WHO_AM_I byte mismatch 0x%02x should be 0x%02x\n",
-		     (unsigned)who_am_i,
-		     TERARANGER_WHO_AM_I_REG_VAL);
+	PX4_DEBUG("WHO_AM_I byte mismatch 0x%02x should be 0x%02x\n",
+		  (unsigned)who_am_i,
+		  TERARANGER_WHO_AM_I_REG_VAL);
 
 	// not found on any address
 	return -EIO;

--- a/src/drivers/distance_sensor/tfmini/tfmini.cpp
+++ b/src/drivers/distance_sensor/tfmini/tfmini.cpp
@@ -194,8 +194,6 @@ TFMINI::TFMINI(const char *port, uint8_t rotation) :
 	/* enforce null termination */
 	_port[sizeof(_port) - 1] = '\0';
 
-	// disable debug() calls
-	_debug_enabled = false;
 
 	// work_cancel in the dtor will explode if we don't do this...
 	memset(&_work, 0, sizeof(_work));
@@ -538,7 +536,7 @@ TFMINI::collect()
 	ret = ::read(_fd, &readbuf[0], readlen);
 
 	if (ret < 0) {
-		DEVICE_DEBUG("read err: %d", ret);
+		PX4_DEBUG("read err: %d", ret);
 		perf_count(_comms_errors);
 		perf_end(_sample_perf);
 
@@ -569,7 +567,7 @@ TFMINI::collect()
 		return -EAGAIN;
 	}
 
-	DEVICE_DEBUG("val (float): %8.4f, raw: %s, valid: %s", (double)distance_m, _linebuf, ((valid) ? "OK" : "NO"));
+	PX4_DEBUG("val (float): %8.4f, raw: %s, valid: %s", (double)distance_m, _linebuf, ((valid) ? "OK" : "NO"));
 
 	struct distance_sensor_s report;
 

--- a/src/drivers/distance_sensor/ulanding/ulanding.cpp
+++ b/src/drivers/distance_sensor/ulanding/ulanding.cpp
@@ -152,8 +152,6 @@ Radar::Radar(uint8_t rotation, const char *port) :
 	/* enforce null termination */
 	_port[sizeof(_port) - 1] = '\0';
 
-	// disable debug() calls
-	_debug_enabled = false;
 
 	memset(&_buf[0], 0, sizeof(_buf));
 }

--- a/src/drivers/distance_sensor/vl53lxx/vl53lxx.cpp
+++ b/src/drivers/distance_sensor/vl53lxx/vl53lxx.cpp
@@ -219,8 +219,6 @@ VL53LXX::VL53LXX(uint8_t rotation, int bus, int address) :
 	// up the retries since the device misses the first measure attempts
 	I2C::_retries = 3;
 
-	// enable debug() calls
-	_debug_enabled = false;
 
 	// work_cancel in the dtor will explode if we don't do this...
 	memset(&_work, 0, sizeof(_work));

--- a/src/drivers/imu/adis16448/adis16448.cpp
+++ b/src/drivers/imu/adis16448/adis16448.cpp
@@ -524,8 +524,6 @@ ADIS16448::ADIS16448(int bus, const char *path_accel, const char *path_gyro, con
 	_gyro_int(1000000 / ADIS16448_GYRO_MAX_OUTPUT_RATE, true),
 	_rotation(rotation)
 {
-	// disable debug() calls
-	_debug_enabled = false;
 
 	_device_id.devid_s.devtype = DRV_ACC_DEVTYPE_ADIS16448;
 
@@ -606,7 +604,7 @@ ADIS16448::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("SPI setup failed");
+		PX4_DEBUG("SPI setup failed");
 		return ret;
 	}
 
@@ -660,7 +658,7 @@ ADIS16448::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("gyro init failed");
+		PX4_DEBUG("gyro init failed");
 		return ret;
 	}
 
@@ -669,7 +667,7 @@ ADIS16448::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("mag init failed");
+		PX4_DEBUG("mag init failed");
 		return ret;
 	}
 
@@ -761,12 +759,12 @@ ADIS16448::probe()
 	/* verify product ID */
 	switch (_product) {
 	case ADIS16448_Product:
-		DEVICE_DEBUG("ADIS16448 is detected ID: 0x%02x, Serial: 0x%02x", _product, serial_number);
+		PX4_DEBUG("ADIS16448 is detected ID: 0x%02x, Serial: 0x%02x", _product, serial_number);
 		modify_reg16(ADIS16448_GPIO_CTRL, 0x0200, 0x0002);			/* Turn on ADIS16448 adaptor board led */
 		return OK;
 	}
 
-	DEVICE_DEBUG("unexpected ID 0x%02x", _product);
+	PX4_DEBUG("unexpected ID 0x%02x", _product);
 	return -EIO;
 }
 
@@ -795,7 +793,7 @@ ADIS16448::_set_sample_rate(uint16_t desired_sample_rate_hz)
 	modify_reg16(ADIS16448_SMPL_PRD, 0x1f00, smpl_prd);
 
 	if ((read_reg16(ADIS16448_SMPL_PRD) & 0x1f00) != smpl_prd) {
-		DEVICE_DEBUG("failed to set IMU sample rate");
+		PX4_DEBUG("failed to set IMU sample rate");
 	}
 
 }
@@ -809,7 +807,7 @@ ADIS16448::_set_dlpf_filter(uint16_t desired_filter_tap)
 	/* Verify data write on the IMU */
 
 	if ((read_reg16(ADIS16448_SENS_AVG) & 0x0007) != desired_filter_tap) {
-		DEVICE_DEBUG("failed to set IMU filter");
+		PX4_DEBUG("failed to set IMU filter");
 	}
 
 }
@@ -843,7 +841,7 @@ ADIS16448::_set_gyro_dyn_range(uint16_t desired_gyro_dyn_range)
 	/* Verify data write on the IMU */
 
 	if ((read_reg16(ADIS16448_SENS_AVG) & 0x0700) != gyro_range_selection) {
-		DEVICE_DEBUG("failed to set gyro range");
+		PX4_DEBUG("failed to set gyro range");
 
 	} else {
 		_gyro_range_rad_s  = ((float)(gyro_range_selection >> 8) * 250.0f / 180.0f) * M_PI_F;
@@ -1656,7 +1654,7 @@ ADIS16448_gyro::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("gyro init failed");
+		PX4_DEBUG("gyro init failed");
 		return ret;
 	}
 
@@ -1716,7 +1714,7 @@ ADIS16448_mag::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("mag init failed");
+		PX4_DEBUG("mag init failed");
 		return ret;
 	}
 

--- a/src/drivers/imu/adis16477/ADIS16477.cpp
+++ b/src/drivers/imu/adis16477/ADIS16477.cpp
@@ -126,7 +126,7 @@ ADIS16477::init()
 	/* do SPI init (and probe) first */
 	if (SPI::init() != OK) {
 		/* if probe/setup failed, bail now */
-		DEVICE_DEBUG("SPI setup failed");
+		PX4_DEBUG("SPI setup failed");
 		return PX4_ERROR;
 	}
 
@@ -155,7 +155,7 @@ ADIS16477::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("gyro init failed");
+		PX4_DEBUG("gyro init failed");
 		return ret;
 	}
 
@@ -236,7 +236,7 @@ ADIS16477::probe()
 		up_udelay(T_STALL);
 	}
 
-	DEVICE_DEBUG("unexpected ID 0x%02x", _product);
+	PX4_DEBUG("unexpected ID 0x%02x", _product);
 	return -EIO;
 }
 
@@ -256,7 +256,7 @@ ADIS16477::_set_dlpf_filter(uint16_t desired_filter_tap)
 	/* Verify data write on the IMU */
 
 	//if ((read_reg16(ADIS16477_SENS_AVG) & 0x0007) != desired_filter_tap) {
-	//	DEVICE_DEBUG("failed to set IMU filter");
+	//	PX4_DEBUG("failed to set IMU filter");
 	//}
 }
 

--- a/src/drivers/imu/adis16477/ADIS16477_gyro.cpp
+++ b/src/drivers/imu/adis16477/ADIS16477_gyro.cpp
@@ -56,7 +56,7 @@ ADIS16477_gyro::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("gyro init failed");
+		PX4_DEBUG("gyro init failed");
 		return ret;
 	}
 

--- a/src/drivers/imu/bmi055/bmi055_accel.cpp
+++ b/src/drivers/imu/bmi055/bmi055_accel.cpp
@@ -32,8 +32,6 @@ BMI055_accel::BMI055_accel(int bus, const char *path_accel, uint32_t device, enu
 	_last_temperature(0),
 	_got_duplicate(false)
 {
-	// disable debug() calls
-	_debug_enabled = false;
 
 	_device_id.devid_s.devtype = DRV_ACC_DEVTYPE_BMI055;
 
@@ -79,7 +77,7 @@ BMI055_accel::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("SPI setup failed");
+		PX4_DEBUG("SPI setup failed");
 		return ret;
 	}
 
@@ -179,7 +177,7 @@ BMI055_accel::probe()
 		return OK;
 	}
 
-	DEVICE_DEBUG("unexpected whoami 0x%02x", _whoami);
+	PX4_DEBUG("unexpected whoami 0x%02x", _whoami);
 	return -EIO;
 }
 

--- a/src/drivers/imu/bmi055/bmi055_gyro.cpp
+++ b/src/drivers/imu/bmi055/bmi055_gyro.cpp
@@ -34,8 +34,6 @@ BMI055_gyro::BMI055_gyro(int bus, const char *path_gyro, uint32_t device, enum R
 	_gyro_int(1000000 / BMI055_GYRO_MAX_PUBLISH_RATE, true),
 	_last_temperature(0)
 {
-	// disable debug() calls
-	_debug_enabled = false;
 
 	_device_id.devid_s.devtype = DRV_GYR_DEVTYPE_BMI055;
 
@@ -79,7 +77,7 @@ BMI055_gyro::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("SPI setup failed");
+		PX4_DEBUG("SPI setup failed");
 		return ret;
 	}
 
@@ -105,7 +103,7 @@ BMI055_gyro::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("gyro init failed");
+		PX4_DEBUG("gyro init failed");
 		return ret;
 	}
 
@@ -184,7 +182,7 @@ BMI055_gyro::probe()
 		return OK;
 	}
 
-	DEVICE_DEBUG("unexpected whoami 0x%02x", _whoami);
+	PX4_DEBUG("unexpected whoami 0x%02x", _whoami);
 	return -EIO;
 }
 

--- a/src/drivers/imu/bmi160/bmi160.cpp
+++ b/src/drivers/imu/bmi160/bmi160.cpp
@@ -62,8 +62,6 @@ BMI160::BMI160(int bus, const char *path_accel, const char *path_gyro, uint32_t 
 	_last_accel{},
 	_got_duplicate(false)
 {
-	// disable debug() calls
-	_debug_enabled = false;
 
 	_device_id.devid_s.devtype = DRV_ACC_DEVTYPE_BMI160;
 
@@ -133,7 +131,7 @@ BMI160::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("SPI setup failed");
+		PX4_DEBUG("SPI setup failed");
 		return ret;
 	}
 
@@ -175,7 +173,7 @@ BMI160::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("gyro init failed");
+		PX4_DEBUG("gyro init failed");
 		return ret;
 	}
 
@@ -285,7 +283,7 @@ BMI160::probe()
 		return OK;
 	}
 
-	DEVICE_DEBUG("unexpected whoami 0x%02x", _whoami);
+	PX4_DEBUG("unexpected whoami 0x%02x", _whoami);
 	return -EIO;
 }
 

--- a/src/drivers/imu/bmi160/bmi160_gyro.cpp
+++ b/src/drivers/imu/bmi160/bmi160_gyro.cpp
@@ -27,7 +27,7 @@ BMI160_gyro::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("gyro init failed");
+		PX4_DEBUG("gyro init failed");
 		return ret;
 	}
 

--- a/src/drivers/imu/fxas21002c/fxas21002c.cpp
+++ b/src/drivers/imu/fxas21002c/fxas21002c.cpp
@@ -450,8 +450,6 @@ FXAS21002C::FXAS21002C(int bus, const char *path, uint32_t device, enum Rotation
 	_checked_values{},
 	_checked_next(0)
 {
-	// enable debug() calls
-	_debug_enabled = false;
 
 	_device_id.devid_s.devtype = DRV_GYR_DEVTYPE_FXAS2100C;
 

--- a/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
+++ b/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
@@ -507,8 +507,6 @@ FXOS8701CQ::FXOS8701CQ(int bus, const char *path, uint32_t device, enum Rotation
 	_last_raw_mag_z(0),
 	_checked_next(0)
 {
-	// enable debug() calls
-	_debug_enabled = false;
 
 	_device_id.devid_s.devtype = DRV_ACC_DEVTYPE_FXOS8701C;
 

--- a/src/drivers/imu/l3gd20/l3gd20.cpp
+++ b/src/drivers/imu/l3gd20/l3gd20.cpp
@@ -483,7 +483,7 @@ L3GD20::init()
 					  &_orb_class_instance, (external()) ? ORB_PRIO_VERY_HIGH : ORB_PRIO_DEFAULT);
 
 	if (_gyro_topic == nullptr) {
-		DEVICE_DEBUG("failed to create sensor_gyro publication");
+		PX4_DEBUG("failed to create sensor_gyro publication");
 	}
 
 	ret = OK;
@@ -867,7 +867,7 @@ L3GD20::disable_i2c(void)
 		}
 	}
 
-	DEVICE_DEBUG("FAILED TO DISABLE I2C");
+	PX4_DEBUG("FAILED TO DISABLE I2C");
 }
 
 void

--- a/src/drivers/imu/mpu6000/mpu6000.cpp
+++ b/src/drivers/imu/mpu6000/mpu6000.cpp
@@ -526,8 +526,6 @@ MPU6000::MPU6000(device::Device *interface, const char *path_accel, const char *
 	_last_accel{},
 	_got_duplicate(false)
 {
-	// disable debug() calls
-	_debug_enabled = false;
 
 	// set the device type from the interface
 	_device_id.devid_s.bus_type = _interface->get_device_bus_type();
@@ -641,7 +639,7 @@ MPU6000::init()
 
 	if (ret != OK) {
 
-		DEVICE_DEBUG("CDev init failed");
+		PX4_DEBUG("CDev init failed");
 		return ret;
 	}
 
@@ -651,7 +649,7 @@ MPU6000::init()
 
 	/* if init failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("CDev init failed");
+		PX4_DEBUG("CDev init failed");
 		return ret;
 	}
 
@@ -724,7 +722,7 @@ MPU6000::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("gyro init failed");
+		PX4_DEBUG("gyro init failed");
 		return ret;
 	}
 
@@ -880,7 +878,7 @@ MPU6000::probe()
 	}
 
 	if (whoami != expected) {
-		DEVICE_DEBUG("unexpected WHOAMI 0x%02x", whoami);
+		PX4_DEBUG("unexpected WHOAMI 0x%02x", whoami);
 		return -EIO;
 	}
 
@@ -912,7 +910,7 @@ MPU6000::probe()
 
 	_checked_values[MPU6000_CHECKED_PRODUCT_ID_INDEX] = _product;
 
-	DEVICE_DEBUG("ID 0x%02x", _product);
+	PX4_DEBUG("ID 0x%02x", _product);
 
 	if (unknown_product_id) {
 
@@ -2165,7 +2163,7 @@ MPU6000_gyro::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("gyro init failed");
+		PX4_DEBUG("gyro init failed");
 		return ret;
 	}
 

--- a/src/drivers/imu/mpu6000/mpu6000_spi.cpp
+++ b/src/drivers/imu/mpu6000/mpu6000_spi.cpp
@@ -225,7 +225,7 @@ MPU6000_SPI::init()
 	ret = SPI::init();
 
 	if (ret != OK) {
-		DEVICE_DEBUG("SPI init failed");
+		PX4_DEBUG("SPI init failed");
 		return -EIO;
 	}
 

--- a/src/drivers/imu/mpu9250/gyro.cpp
+++ b/src/drivers/imu/mpu9250/gyro.cpp
@@ -95,7 +95,7 @@ MPU9250_gyro::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("gyro init failed");
+		PX4_DEBUG("gyro init failed");
 		return ret;
 	}
 

--- a/src/drivers/imu/mpu9250/mag.cpp
+++ b/src/drivers/imu/mpu9250/mag.cpp
@@ -129,7 +129,7 @@ MPU9250_mag::init()
 
 	/* if cdev init failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("MPU9250 mag init failed");
+		PX4_DEBUG("MPU9250 mag init failed");
 		return ret;
 	}
 

--- a/src/drivers/imu/mpu9250/mpu9250.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250.cpp
@@ -163,8 +163,6 @@ MPU9250::MPU9250(device::Device *interface, device::Device *mag_interface, const
 	_last_accel_data{},
 	_got_duplicate(false)
 {
-	// disable debug() calls
-	_debug_enabled = false;
 
 	/* Set device parameters and make sure parameters of the bus device are adopted */
 	_device_id.devid_s.devtype = DRV_ACC_DEVTYPE_MPU9250;
@@ -273,7 +271,7 @@ MPU9250::init()
 	int ret = probe();
 
 	if (ret != OK) {
-		DEVICE_DEBUG("MPU9250 probe failed");
+		PX4_DEBUG("MPU9250 probe failed");
 		return ret;
 	}
 
@@ -283,7 +281,7 @@ MPU9250::init()
 
 	/* if init failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("CDev init failed");
+		PX4_DEBUG("CDev init failed");
 		return ret;
 	}
 
@@ -355,7 +353,7 @@ MPU9250::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("gyro init failed");
+		PX4_DEBUG("gyro init failed");
 		return ret;
 	}
 
@@ -374,7 +372,7 @@ MPU9250::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("mag init failed");
+		PX4_DEBUG("mag init failed");
 		return ret;
 	}
 
@@ -384,7 +382,7 @@ MPU9250::init()
 	}
 
 	if (ret != OK) {
-		DEVICE_DEBUG("mag reset failed");
+		PX4_DEBUG("mag reset failed");
 		return ret;
 	}
 
@@ -546,7 +544,7 @@ MPU9250::probe()
 		return OK;
 	}
 
-	DEVICE_DEBUG("unexpected whoami 0x%02x", _whoami);
+	PX4_DEBUG("unexpected whoami 0x%02x", _whoami);
 	return -EIO;
 }
 

--- a/src/drivers/kinetis/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/kinetis/tone_alarm/tone_alarm.cpp
@@ -410,7 +410,7 @@ ToneAlarm::init()
 	/* default the timer to a modulo value of 1; playing notes will change this */
 	rMOD = 0;
 
-	DEVICE_DEBUG("ready");
+	PX4_DEBUG("ready");
 	return OK;
 }
 
@@ -811,14 +811,14 @@ ToneAlarm::ioctl(file *filp, int cmd, unsigned long arg)
 {
 	int result = OK;
 
-	DEVICE_DEBUG("ioctl %i %u", cmd, arg);
+	PX4_DEBUG("ioctl %i %u", cmd, arg);
 
 //	irqstate_t flags = px4_enter_critical_section();
 
 	/* decide whether to increase the alarm level to cmd or leave it alone */
 	switch (cmd) {
 	case TONE_SET_ALARM:
-		DEVICE_DEBUG("TONE_SET_ALARM %u", arg);
+		PX4_DEBUG("TONE_SET_ALARM %u", arg);
 
 		if (arg < TONE_NUMBER_OF_TUNES) {
 			if (arg == TONE_STOP_TUNE) {

--- a/src/drivers/magnetometer/bmm150/bmm150.cpp
+++ b/src/drivers/magnetometer/bmm150/bmm150.cpp
@@ -333,7 +333,7 @@ int BMM150::init()
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("I2C setup failed");
+		PX4_DEBUG("I2C setup failed");
 		return ret;
 	}
 

--- a/src/drivers/magnetometer/hmc5883/hmc5883.cpp
+++ b/src/drivers/magnetometer/hmc5883/hmc5883.cpp
@@ -372,8 +372,6 @@ HMC5883::HMC5883(device::Device *interface, const char *path, enum Rotation rota
 	_device_id.devid_s.address = _interface->get_device_address();
 	_device_id.devid_s.devtype = DRV_MAG_DEVTYPE_HMC5883;
 
-	// enable debug() calls
-	_debug_enabled = false;
 
 	// default scaling
 	_scale.x_offset = 0;
@@ -415,7 +413,7 @@ HMC5883::init()
 	ret = CDev::init();
 
 	if (ret != OK) {
-		DEVICE_DEBUG("CDev init failed");
+		PX4_DEBUG("CDev init failed");
 		goto out;
 	}
 
@@ -743,7 +741,7 @@ HMC5883::ioctl(struct file *filp, int cmd, unsigned long arg)
 		return check_calibration();
 
 	case MAGIOCGEXTERNAL:
-		DEVICE_DEBUG("MAGIOCGEXTERNAL in main driver");
+		PX4_DEBUG("MAGIOCGEXTERNAL in main driver");
 		return _interface->ioctl(cmd, dummy);
 
 	case MAGIOCSTEMPCOMP:
@@ -803,7 +801,7 @@ HMC5883::cycle()
 
 		/* perform collection */
 		if (OK != collect()) {
-			DEVICE_DEBUG("collection error");
+			PX4_DEBUG("collection error");
 			/* restart the measurement state machine */
 			start();
 			return;
@@ -830,7 +828,7 @@ HMC5883::cycle()
 
 	/* measurement phase */
 	if (OK != measure()) {
-		DEVICE_DEBUG("measure error");
+		PX4_DEBUG("measure error");
 	}
 
 	/* next phase is collection */
@@ -907,7 +905,7 @@ HMC5883::collect()
 
 	if (ret != OK) {
 		perf_count(_comms_errors);
-		DEVICE_DEBUG("data/status read error");
+		PX4_DEBUG("data/status read error");
 		goto out;
 	}
 
@@ -961,7 +959,7 @@ HMC5883::collect()
 					  and can't do temperature. Disable it
 					*/
 					_temperature_error_count = 0;
-					DEVICE_DEBUG("disabling temperature compensation");
+					PX4_DEBUG("disabling temperature compensation");
 					set_temperature_compensation(0);
 				}
 			}
@@ -1023,7 +1021,7 @@ HMC5883::collect()
 							 &_orb_class_instance, (sensor_is_onboard) ? ORB_PRIO_HIGH : ORB_PRIO_MAX);
 
 			if (_mag_topic == nullptr) {
-				DEVICE_DEBUG("ADVERT FAIL");
+				PX4_DEBUG("ADVERT FAIL");
 			}
 		}
 	}

--- a/src/drivers/magnetometer/hmc5883/hmc5883_i2c.cpp
+++ b/src/drivers/magnetometer/hmc5883/hmc5883_i2c.cpp
@@ -133,7 +133,7 @@ HMC5883_I2C::probe()
 	if (read(ADDR_ID_A, &data[0], 1) ||
 	    read(ADDR_ID_B, &data[1], 1) ||
 	    read(ADDR_ID_C, &data[2], 1)) {
-		DEVICE_DEBUG("read_reg fail");
+		PX4_DEBUG("read_reg fail");
 		return -EIO;
 	}
 
@@ -142,7 +142,7 @@ HMC5883_I2C::probe()
 	if ((data[0] != ID_A_WHO_AM_I) ||
 	    (data[1] != ID_B_WHO_AM_I) ||
 	    (data[2] != ID_C_WHO_AM_I)) {
-		DEVICE_DEBUG("ID byte mismatch (%02x,%02x,%02x)", data[0], data[1], data[2]);
+		PX4_DEBUG("ID byte mismatch (%02x,%02x,%02x)", data[0], data[1], data[2]);
 		return -EIO;
 	}
 

--- a/src/drivers/magnetometer/hmc5883/hmc5883_spi.cpp
+++ b/src/drivers/magnetometer/hmc5883/hmc5883_spi.cpp
@@ -108,7 +108,7 @@ HMC5883_SPI::init()
 	ret = SPI::init();
 
 	if (ret != OK) {
-		DEVICE_DEBUG("SPI init failed");
+		PX4_DEBUG("SPI init failed");
 		return -EIO;
 	}
 
@@ -118,13 +118,13 @@ HMC5883_SPI::init()
 	if (read(ADDR_ID_A, &data[0], 1) ||
 	    read(ADDR_ID_B, &data[1], 1) ||
 	    read(ADDR_ID_C, &data[2], 1)) {
-		DEVICE_DEBUG("read_reg fail");
+		PX4_DEBUG("read_reg fail");
 	}
 
 	if ((data[0] != ID_A_WHO_AM_I) ||
 	    (data[1] != ID_B_WHO_AM_I) ||
 	    (data[2] != ID_C_WHO_AM_I)) {
-		DEVICE_DEBUG("ID byte mismatch (%02x,%02x,%02x)", data[0], data[1], data[2]);
+		PX4_DEBUG("ID byte mismatch (%02x,%02x,%02x)", data[0], data[1], data[2]);
 		return -EIO;
 	}
 

--- a/src/drivers/magnetometer/ist8310/ist8310.cpp
+++ b/src/drivers/magnetometer/ist8310/ist8310.cpp
@@ -419,8 +419,6 @@ IST8310::IST8310(int bus_number, int address, const char *path, enum Rotation ro
 {
 	_device_id.devid_s.devtype = DRV_MAG_DEVTYPE_IST8310;
 
-	// enable debug() calls
-	_debug_enabled = false;
 
 	// default scaling
 	_scale.x_offset = 0;
@@ -462,7 +460,7 @@ IST8310::init()
 	ret = I2C::init();
 
 	if (ret != OK) {
-		DEVICE_DEBUG("CDev init failed");
+		PX4_DEBUG("CDev init failed");
 		goto out;
 	}
 
@@ -742,7 +740,7 @@ IST8310::ioctl(struct file *filp, int cmd, unsigned long arg)
 		return check_calibration();
 
 	case MAGIOCGEXTERNAL:
-		DEVICE_DEBUG("MAGIOCGEXTERNAL in main driver");
+		PX4_DEBUG("MAGIOCGEXTERNAL in main driver");
 		return external();
 
 	default:
@@ -801,14 +799,14 @@ IST8310::probe()
 	_retries = 10;
 
 	if (read(ADDR_WAI, &data[0], 1)) {
-		DEVICE_DEBUG("read_reg fail");
+		PX4_DEBUG("read_reg fail");
 		return -EIO;
 	}
 
 	_retries = 2;
 
 	if ((data[0] != WAI_EXPECTED_VALUE)) {
-		DEVICE_DEBUG("ID byte mismatch (%02x) expected %02x", data[0], WAI_EXPECTED_VALUE);
+		PX4_DEBUG("ID byte mismatch (%02x) expected %02x", data[0], WAI_EXPECTED_VALUE);
 		return -EIO;
 	}
 
@@ -823,7 +821,7 @@ IST8310::cycle()
 
 		/* perform collection */
 		if (OK != collect()) {
-			DEVICE_DEBUG("collection error");
+			PX4_DEBUG("collection error");
 			/* restart the measurement state machine */
 			start();
 			return;
@@ -850,7 +848,7 @@ IST8310::cycle()
 
 	/* measurement phase */
 	if (OK != measure()) {
-		DEVICE_DEBUG("measure error");
+		PX4_DEBUG("measure error");
 	}
 
 	/* next phase is collection */
@@ -926,7 +924,7 @@ IST8310::collect()
 
 	if (ret != OK) {
 		perf_count(_comms_errors);
-		DEVICE_DEBUG("I2C read error");
+		PX4_DEBUG("I2C read error");
 		goto out;
 	}
 
@@ -944,7 +942,7 @@ IST8310::collect()
 	    report.y > IST8310_MAX_VAL_XY || report.y < IST8310_MIN_VAL_XY ||
 	    report.z > IST8310_MAX_VAL_Z  || report.z < IST8310_MIN_VAL_Z) {
 		perf_count(_range_errors);
-		DEVICE_DEBUG("data/status read error");
+		PX4_DEBUG("data/status read error");
 		goto out;
 	}
 
@@ -983,7 +981,7 @@ IST8310::collect()
 							 &_orb_class_instance, sensor_is_external ? ORB_PRIO_MAX : ORB_PRIO_HIGH);
 
 			if (_mag_topic == nullptr) {
-				DEVICE_DEBUG("ADVERT FAIL");
+				PX4_DEBUG("ADVERT FAIL");
 			}
 		}
 	}

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl.cpp
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl.cpp
@@ -79,8 +79,6 @@ LIS3MDL::LIS3MDL(device::Device *interface, const char *path, enum Rotation rota
 	_device_id.devid_s.address = _interface->get_device_address();
 	_device_id.devid_s.devtype = DRV_MAG_DEVTYPE_LIS3MDL;
 
-	// enable debug() calls
-	_debug_enabled = false;
 
 	// default scaling
 	_scale.x_offset = 0;
@@ -436,7 +434,7 @@ LIS3MDL::collect()
 							 &_orb_class_instance, (sensor_is_onboard) ? ORB_PRIO_HIGH : ORB_PRIO_MAX);
 
 			if (_mag_topic == nullptr) {
-				DEVICE_DEBUG("ADVERT FAIL");
+				PX4_DEBUG("ADVERT FAIL");
 			}
 		}
 	}
@@ -465,7 +463,7 @@ LIS3MDL::cycle()
 
 	/* Collect last measurement at the start of every cycle */
 	if (collect() != OK) {
-		DEVICE_DEBUG("collection error");
+		PX4_DEBUG("collection error");
 		/* restart the measurement state machine */
 		start();
 		return;
@@ -473,7 +471,7 @@ LIS3MDL::cycle()
 
 
 	if (measure() != OK) {
-		DEVICE_DEBUG("measure error");
+		PX4_DEBUG("measure error");
 	}
 
 	if (_measure_ticks > 0) {
@@ -502,7 +500,7 @@ LIS3MDL::init()
 	ret = CDev::init();
 
 	if (ret != OK) {
-		DEVICE_DEBUG("CDev init failed");
+		PX4_DEBUG("CDev init failed");
 		return ret;
 	}
 
@@ -635,7 +633,7 @@ LIS3MDL::ioctl(struct file *file_pointer, int cmd, unsigned long arg)
 
 
 	case MAGIOCGEXTERNAL:
-		DEVICE_DEBUG("MAGIOCGEXTERNAL in main driver");
+		PX4_DEBUG("MAGIOCGEXTERNAL in main driver");
 		return _interface->ioctl(cmd, dummy);
 
 	case DEVIOCGDEVICEID:

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl_i2c.cpp
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl_i2c.cpp
@@ -127,14 +127,14 @@ LIS3MDL_I2C::probe()
 	_retries = 10;
 
 	if (read(ADDR_WHO_AM_I, &data, 1)) {
-		DEVICE_DEBUG("read_reg fail");
+		PX4_DEBUG("read_reg fail");
 		return -EIO;
 	}
 
 	_retries = 2;
 
 	if (data != ID_WHO_AM_I) {
-		DEVICE_DEBUG("LIS3MDL bad ID: %02x", data);
+		PX4_DEBUG("LIS3MDL bad ID: %02x", data);
 		return -EIO;
 	}
 

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl_spi.cpp
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl_spi.cpp
@@ -103,7 +103,7 @@ LIS3MDL_SPI::init()
 	ret = SPI::init();
 
 	if (ret != OK) {
-		DEVICE_DEBUG("SPI init failed");
+		PX4_DEBUG("SPI init failed");
 		return -EIO;
 	}
 
@@ -111,11 +111,11 @@ LIS3MDL_SPI::init()
 	uint8_t data = 0;
 
 	if (read(ADDR_WHO_AM_I, &data, 1)) {
-		DEVICE_DEBUG("LIS3MDL read_reg fail");
+		PX4_DEBUG("LIS3MDL read_reg fail");
 	}
 
 	if (data != ID_WHO_AM_I) {
-		DEVICE_DEBUG("LIS3MDL bad ID: %02x", data);
+		PX4_DEBUG("LIS3MDL bad ID: %02x", data);
 		return -EIO;
 	}
 

--- a/src/drivers/mkblctrl/mkblctrl.cpp
+++ b/src/drivers/mkblctrl/mkblctrl.cpp
@@ -312,7 +312,7 @@ MK::init(unsigned motors)
 
 
 	if (_task < 0) {
-		DEVICE_DEBUG("task start failed: %d", errno);
+		PX4_DEBUG("task start failed: %d", errno);
 		return -errno;
 	}
 
@@ -1089,7 +1089,7 @@ MK::pwm_ioctl(file *filp, int cmd, unsigned long arg)
 				ret = _mixers->load_from_buf(buf, buflen);
 
 				if (ret != 0) {
-					DEVICE_DEBUG("mixer load failed with %d", ret);
+					PX4_DEBUG("mixer load failed with %d", ret);
 					delete _mixers;
 					_mixers = nullptr;
 					ret = -EINVAL;

--- a/src/drivers/pca9685/pca9685.cpp
+++ b/src/drivers/pca9685/pca9685.cpp
@@ -330,8 +330,8 @@ PCA9685::i2cpwm()
 				 * the control[i] values are on the range -1 ... 1 */
 				uint16_t new_value = PCA9685_PWMCENTER +
 						     (_actuator_controls.control[i] * M_PI_F * PCA9685_SCALE);
-				DEVICE_DEBUG("%d: current: %u, new %u, control %.2f", i, _current_values[i], new_value,
-					     (double)_actuator_controls.control[i]);
+				PX4_DEBUG("%d: current: %u, new %u, control %.2f", i, _current_values[i], new_value,
+					  (double)_actuator_controls.control[i]);
 
 				if (new_value != _current_values[i] &&
 				    isfinite(new_value) &&

--- a/src/drivers/pmw3901/pmw3901.cpp
+++ b/src/drivers/pmw3901/pmw3901.cpp
@@ -209,8 +209,6 @@ PMW3901::PMW3901(uint8_t rotation, int bus) :
 	_sensor_rotation((enum Rotation)rotation)
 {
 
-	// enable debug() calls
-	_debug_enabled = false;
 
 	// work_cancel in the dtor will explode if we don't do this...
 	memset(&_work, 0, sizeof(_work));

--- a/src/drivers/px4flow/px4flow.cpp
+++ b/src/drivers/px4flow/px4flow.cpp
@@ -209,8 +209,6 @@ PX4FLOW::PX4FLOW(int bus, int address, enum Rotation rotation, int conversion_in
 	_conversion_interval(conversion_interval),
 	_sensor_rotation(rotation)
 {
-	// disable debug() calls
-	_debug_enabled = false;
 
 	// work_cancel in the dtor will explode if we don't do this...
 	memset(&_work, 0, sizeof(_work));
@@ -495,7 +493,7 @@ PX4FLOW::measure()
 
 	if (OK != ret) {
 		perf_count(_comms_errors);
-		DEVICE_DEBUG("i2c::transfer returned %d", ret);
+		PX4_DEBUG("i2c::transfer returned %d", ret);
 		return ret;
 	}
 
@@ -523,7 +521,7 @@ PX4FLOW::collect()
 	}
 
 	if (ret < 0) {
-		DEVICE_DEBUG("error reading from sensor: %d", ret);
+		PX4_DEBUG("error reading from sensor: %d", ret);
 		perf_count(_comms_errors);
 		perf_end(_sample_perf);
 		return ret;
@@ -643,12 +641,12 @@ void
 PX4FLOW::cycle()
 {
 	if (OK != measure()) {
-		DEVICE_DEBUG("measure error");
+		PX4_DEBUG("measure error");
 	}
 
 	/* perform collection */
 	if (OK != collect()) {
-		DEVICE_DEBUG("collection error");
+		PX4_DEBUG("collection error");
 		/* restart the measurement state machine */
 		start();
 		return;

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -443,9 +443,6 @@ PX4FMU::PX4FMU(bool run_as_task) :
 #ifndef GPIO_BTN_SAFETY
 	_safety_off = true;
 #endif
-
-	/* only enable this during development */
-	_debug_enabled = false;
 }
 
 PX4FMU::~PX4FMU()
@@ -659,13 +656,13 @@ PX4FMU::set_mode(Mode mode)
 	case MODE_2PWM2CAP:	// v1 multi-port with flow control lines as PWM
 		up_input_capture_set(2, Rising, 0, NULL, NULL);
 		up_input_capture_set(3, Rising, 0, NULL, NULL);
-		DEVICE_DEBUG("MODE_2PWM2CAP");
+		PX4_DEBUG("MODE_2PWM2CAP");
 #endif
 
 	/* FALLTHROUGH */
 
 	case MODE_2PWM:	// v1 multi-port with flow control lines as PWM
-		DEVICE_DEBUG("MODE_2PWM");
+		PX4_DEBUG("MODE_2PWM");
 
 		/* default output rates */
 		_pwm_default_rate = 50;
@@ -680,14 +677,14 @@ PX4FMU::set_mode(Mode mode)
 #if defined(BOARD_HAS_CAPTURE)
 
 	case MODE_3PWM1CAP:	// v1 multi-port with flow control lines as PWM
-		DEVICE_DEBUG("MODE_3PWM1CAP");
+		PX4_DEBUG("MODE_3PWM1CAP");
 		up_input_capture_set(3, Rising, 0, NULL, NULL);
 #endif
 
 	/* FALLTHROUGH */
 
 	case MODE_3PWM:	// v1 multi-port with flow control lines as PWM
-		DEVICE_DEBUG("MODE_3PWM");
+		PX4_DEBUG("MODE_3PWM");
 
 		/* default output rates */
 		_pwm_default_rate = 50;
@@ -700,7 +697,7 @@ PX4FMU::set_mode(Mode mode)
 		break;
 
 	case MODE_4PWM: // v1 or v2 multi-port as 4 PWM outs
-		DEVICE_DEBUG("MODE_4PWM");
+		PX4_DEBUG("MODE_4PWM");
 
 		/* default output rates */
 		_pwm_default_rate = 50;
@@ -715,7 +712,7 @@ PX4FMU::set_mode(Mode mode)
 #if defined(BOARD_HAS_PWM) && BOARD_HAS_PWM >= 6
 
 	case MODE_6PWM:
-		DEVICE_DEBUG("MODE_6PWM");
+		PX4_DEBUG("MODE_6PWM");
 
 		/* default output rates */
 		_pwm_default_rate = 50;
@@ -731,7 +728,7 @@ PX4FMU::set_mode(Mode mode)
 #if defined(BOARD_HAS_PWM) && BOARD_HAS_PWM >= 8
 
 	case MODE_8PWM: // AeroCore PWMs as 8 PWM outs
-		DEVICE_DEBUG("MODE_8PWM");
+		PX4_DEBUG("MODE_8PWM");
 		/* default output rates */
 		_pwm_default_rate = 50;
 		_pwm_alt_rate = 50;
@@ -746,7 +743,7 @@ PX4FMU::set_mode(Mode mode)
 #if defined(BOARD_HAS_PWM) && BOARD_HAS_PWM >= 14
 
 	case MODE_14PWM:
-		DEVICE_DEBUG("MODE_14PWM");
+		PX4_DEBUG("MODE_14PWM");
 		/* default output rates */
 		_pwm_default_rate = 50;
 		_pwm_alt_rate = 50;
@@ -759,7 +756,7 @@ PX4FMU::set_mode(Mode mode)
 #endif
 
 	case MODE_NONE:
-		DEVICE_DEBUG("MODE_NONE");
+		PX4_DEBUG("MODE_NONE");
 
 		_pwm_default_rate = 10;	/* artificially reduced output rate */
 		_pwm_alt_rate = 10;
@@ -903,12 +900,12 @@ PX4FMU::subscribe()
 
 	for (unsigned i = 0; i < actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS; i++) {
 		if (sub_groups & (1 << i)) {
-			DEVICE_DEBUG("subscribe to actuator_controls_%d", i);
+			PX4_DEBUG("subscribe to actuator_controls_%d", i);
 			_control_subs[i] = orb_subscribe(_control_topics[i]);
 		}
 
 		if (unsub_groups & (1 << i)) {
-			DEVICE_DEBUG("unsubscribe from actuator_controls_%d", i);
+			PX4_DEBUG("unsubscribe from actuator_controls_%d", i);
 			orb_unsubscribe(_control_subs[i]);
 			_control_subs[i] = -1;
 		}

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -854,7 +854,7 @@ PX4IO::init()
 				   nullptr);
 
 	if (_task < 0) {
-		DEVICE_DEBUG("task start failed: %d", errno);
+		PX4_DEBUG("task start failed: %d", errno);
 		return -errno;
 	}
 
@@ -1229,7 +1229,7 @@ PX4IO::task_main()
 	unlock();
 
 out:
-	DEVICE_DEBUG("exiting");
+	PX4_DEBUG("exiting");
 
 	/* clean up the alternate device node */
 	if (_primary_pwm_device) {
@@ -1929,14 +1929,14 @@ PX4IO::io_reg_set(uint8_t page, uint8_t offset, const uint16_t *values, unsigned
 {
 	/* range check the transfer */
 	if (num_values > ((_max_transfer) / sizeof(*values))) {
-		DEVICE_DEBUG("io_reg_set: too many registers (%u, max %u)", num_values, _max_transfer / 2);
+		PX4_DEBUG("io_reg_set: too many registers (%u, max %u)", num_values, _max_transfer / 2);
 		return -EINVAL;
 	}
 
 	int ret =  _interface->write((page << 8) | offset, (void *)values, num_values);
 
 	if (ret != (int)num_values) {
-		DEVICE_DEBUG("io_reg_set(%hhu,%hhu,%u): error %d", page, offset, num_values, ret);
+		PX4_DEBUG("io_reg_set(%hhu,%hhu,%u): error %d", page, offset, num_values, ret);
 		return -1;
 	}
 
@@ -1954,14 +1954,14 @@ PX4IO::io_reg_get(uint8_t page, uint8_t offset, uint16_t *values, unsigned num_v
 {
 	/* range check the transfer */
 	if (num_values > ((_max_transfer) / sizeof(*values))) {
-		DEVICE_DEBUG("io_reg_get: too many registers (%u, max %u)", num_values, _max_transfer / 2);
+		PX4_DEBUG("io_reg_get: too many registers (%u, max %u)", num_values, _max_transfer / 2);
 		return -EINVAL;
 	}
 
 	int ret = _interface->read((page << 8) | offset, reinterpret_cast<void *>(values), num_values);
 
 	if (ret != (int)num_values) {
-		DEVICE_DEBUG("io_reg_get(%hhu,%hhu,%u): data error %d", page, offset, num_values, ret);
+		PX4_DEBUG("io_reg_get(%hhu,%hhu,%u): data error %d", page, offset, num_values, ret);
 		return -1;
 	}
 
@@ -2791,7 +2791,7 @@ PX4IO::ioctl(file *filep, int cmd, unsigned long arg)
 			}
 
 			if (io_crc != arg) {
-				DEVICE_DEBUG("crc mismatch 0x%08x 0x%08lx", io_crc, arg);
+				PX4_DEBUG("crc mismatch 0x%08x 0x%08lx", io_crc, arg);
 				return -EINVAL;
 			}
 

--- a/src/drivers/samv7/adc/adc.cpp
+++ b/src/drivers/samv7/adc/adc.cpp
@@ -247,7 +247,7 @@ ADC::init()
 	}
 
 
-	DEVICE_DEBUG("init done");
+	PX4_DEBUG("init done");
 
 	/* create the device node */
 	return CDev::init();

--- a/src/drivers/samv7/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/samv7/tone_alarm/tone_alarm.cpp
@@ -397,7 +397,7 @@ ToneAlarm::init()
 	/* make sure the timer is running */
 	rCR1 = GTIM_CR1_CEN;
 #endif
-	DEVICE_DEBUG("ready");
+	PX4_DEBUG("ready");
 	return OK;
 }
 
@@ -807,14 +807,14 @@ ToneAlarm::ioctl(file *filp, int cmd, unsigned long arg)
 {
 	int result = OK;
 
-	DEVICE_DEBUG("ioctl %i %u", cmd, arg);
+	PX4_DEBUG("ioctl %i %u", cmd, arg);
 
 //	irqstate_t flags = enter_critical_section();
 
 	/* decide whether to increase the alarm level to cmd or leave it alone */
 	switch (cmd) {
 	case TONE_SET_ALARM:
-		DEVICE_DEBUG("TONE_SET_ALARM %u", arg);
+		PX4_DEBUG("TONE_SET_ALARM %u", arg);
 
 		if (arg < TONE_NUMBER_OF_TUNES) {
 			if (arg == TONE_STOP_TUNE) {

--- a/src/drivers/stm32/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/stm32/tone_alarm/tone_alarm.cpp
@@ -370,8 +370,6 @@ ToneAlarm::ToneAlarm() :
 	_cbrk(CBRK_UNINIT),
 	_tune_control_sub(-1)
 {
-	// enable debug() calls
-	//_debug_enabled = true;
 }
 
 ToneAlarm::~ToneAlarm()
@@ -429,7 +427,7 @@ int ToneAlarm::init()
 	/* make sure the timer is running */
 	rCR1 = GTIM_CR1_CEN;
 
-	DEVICE_DEBUG("ready");
+	PX4_DEBUG("ready");
 
 	_running = true;
 	work_queue(HPWORK, &_work, (worker_t)&ToneAlarm::next_trampoline, this, 0);

--- a/src/drivers/tap_esc/tap_esc.cpp
+++ b/src/drivers/tap_esc/tap_esc.cpp
@@ -351,12 +351,12 @@ void TAP_ESC::subscribe()
 
 	for (unsigned i = 0; i < actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS; i++) {
 		if (sub_groups & (1 << i)) {
-			DEVICE_DEBUG("subscribe to actuator_controls_%d", i);
+			PX4_DEBUG("subscribe to actuator_controls_%d", i);
 			_control_subs[i] = orb_subscribe(_control_topics[i]);
 		}
 
 		if (unsub_groups & (1 << i)) {
-			DEVICE_DEBUG("unsubscribe from actuator_controls_%d", i);
+			PX4_DEBUG("unsubscribe from actuator_controls_%d", i);
 			orb_unsubscribe(_control_subs[i]);
 			_control_subs[i] = -1;
 		}
@@ -414,7 +414,7 @@ void TAP_ESC::cycle()
 		for (unsigned i = 0; i < actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS; i++) {
 			if (_control_subs[i] >= 0) {
 				orb_set_interval(_control_subs[i], TAP_ESC_CTRL_UORB_UPDATE_INTERVAL);
-				DEVICE_DEBUG("New actuator update interval: %ums", TAP_ESC_CTRL_UORB_UPDATE_INTERVAL);
+				PX4_DEBUG("New actuator update interval: %ums", TAP_ESC_CTRL_UORB_UPDATE_INTERVAL);
 			}
 		}
 	}
@@ -684,7 +684,7 @@ int TAP_ESC::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 				ret = _mixers->load_from_buf(buf, buflen);
 
 				if (ret != 0) {
-					DEVICE_DEBUG("mixer load failed with %d", ret);
+					PX4_DEBUG("mixer load failed with %d", ret);
 					delete _mixers;
 					_mixers = nullptr;
 					_groups_required = 0;

--- a/src/lib/drivers/airspeed/airspeed.cpp
+++ b/src/lib/drivers/airspeed/airspeed.cpp
@@ -69,8 +69,6 @@ Airspeed::Airspeed(int bus, int address, unsigned conversion_interval, const cha
 	_sample_perf(perf_alloc(PC_ELAPSED, "aspd_read")),
 	_comms_errors(perf_alloc(PC_COUNT, "aspd_com_err"))
 {
-	// enable debug() calls
-	_debug_enabled = false;
 
 	// work_cancel in the dtor will explode if we don't do this...
 	memset(&_work, 0, sizeof(_work));

--- a/src/lib/drivers/led/led.cpp
+++ b/src/lib/drivers/led/led.cpp
@@ -77,7 +77,7 @@ LED::~LED() = default;
 int
 LED::init()
 {
-	DEVICE_DEBUG("LED::init");
+	PX4_DEBUG("LED::init");
 	CDev::init();
 	led_init();
 

--- a/src/modules/simulator/airspeedsim/airspeedsim.cpp
+++ b/src/modules/simulator/airspeedsim/airspeedsim.cpp
@@ -83,8 +83,6 @@ AirspeedSim::AirspeedSim(int bus, int address, unsigned conversion_interval, con
 	_sample_perf(perf_alloc(PC_ELAPSED, "airspeed_read")),
 	_comms_errors(perf_alloc(PC_COUNT, "airspeed_comms_errors"))
 {
-	// enable debug() calls
-	_debug_enabled = false;
 
 	// work_cancel in the dtor will explode if we don't do this...
 	memset(&_work, 0, sizeof(_work));
@@ -116,7 +114,7 @@ AirspeedSim::init()
 
 	/* init base class */
 	if (CDev::init() != OK) {
-		DEVICE_DEBUG("CDev init failed");
+		PX4_DEBUG("CDev init failed");
 		goto out;
 	}
 

--- a/src/modules/simulator/airspeedsim/meas_airspeed_sim.cpp
+++ b/src/modules/simulator/airspeedsim/meas_airspeed_sim.cpp
@@ -256,7 +256,7 @@ MEASAirspeedSim::cycle()
 	ret = measure();
 
 	if (OK != ret) {
-		DEVICE_DEBUG("measure error");
+		PX4_DEBUG("measure error");
 	}
 
 	_sensor_ok = (ret == OK);

--- a/src/modules/syslink/syslink_bridge.cpp
+++ b/src/modules/syslink/syslink_bridge.cpp
@@ -68,7 +68,7 @@ SyslinkBridge::init()
 
 	/* if init failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("CDev init failed");
+		PX4_DEBUG("CDev init failed");
 		return ret;
 	}
 

--- a/src/modules/syslink/syslink_memory.cpp
+++ b/src/modules/syslink/syslink_memory.cpp
@@ -61,7 +61,7 @@ SyslinkMemory::init()
 
 	/* if init failed, bail now */
 	if (ret != OK) {
-		DEVICE_DEBUG("CDev init failed");
+		PX4_DEBUG("CDev init failed");
 		return ret;
 	}
 


### PR DESCRIPTION
DEVICE_DEBUG is a macro in the Device base class that prints error messages when the _debug_enabled flag is set.

PX4_DEBUG is a debug message that prints if the `DEBUG_BUILD` define is set, otherwise it's omitted from the build entirely.

This PR switches the majority of DEVICE_DEBUG usage to PX4_DEBUG. I've only kept DEVICE_DEBUG in the I2C and SPI classes to help with debugging issues with new drivers.

This saves 3.8 kB of flash on px4fmu-v2 and 4.6 kB on px4fmu-v4.