### PR TITLE
integrator minor cleanup and use c++11 default destructors everywhere

### DIFF
--- a/src/drivers/barometer/bmp280/bmp280.cpp
+++ b/src/drivers/barometer/bmp280/bmp280.cpp
@@ -194,9 +194,7 @@ BMP280::~BMP280()
 int
 BMP280::init()
 {
-	int ret;
-
-	ret = CDev::init();
+	int ret = CDev::init();
 
 	if (ret != OK) {
 		DEVICE_DEBUG("CDev init failed");

--- a/src/drivers/barometer/lps25h/lps25h_i2c.cpp
+++ b/src/drivers/barometer/lps25h/lps25h_i2c.cpp
@@ -67,9 +67,8 @@ class LPS25H_I2C : public device::I2C
 {
 public:
 	LPS25H_I2C(int bus);
-	virtual ~LPS25H_I2C();
+	virtual ~LPS25H_I2C() = default;
 
-	virtual int	init();
 	virtual int	read(unsigned address, void *data, unsigned count);
 	virtual int	write(unsigned address, void *data, unsigned count);
 
@@ -89,17 +88,6 @@ LPS25H_I2C_interface(int bus)
 LPS25H_I2C::LPS25H_I2C(int bus) :
 	I2C("LPS25H_I2C", nullptr, bus, LPS25H_ADDRESS, 400000)
 {
-}
-
-LPS25H_I2C::~LPS25H_I2C()
-{
-}
-
-int
-LPS25H_I2C::init()
-{
-	/* this will call probe() */
-	return I2C::init();
 }
 
 int

--- a/src/drivers/barometer/lps25h/lps25h_spi.cpp
+++ b/src/drivers/barometer/lps25h/lps25h_spi.cpp
@@ -73,7 +73,7 @@ class LPS25H_SPI : public device::SPI
 {
 public:
 	LPS25H_SPI(int bus, uint32_t device);
-	virtual ~LPS25H_SPI();
+	virtual ~LPS25H_SPI() = default;
 
 	virtual int	init();
 	virtual int	read(unsigned address, void *data, unsigned count);
@@ -93,10 +93,6 @@ LPS25H_SPI::LPS25H_SPI(int bus, uint32_t device) :
 	SPI("LPS25H_SPI", nullptr, bus, device, SPIDEV_MODE3, 11 * 1000 * 1000 /* will be rounded to 10.4 MHz */)
 {
 	_device_id.devid_s.devtype = DRV_MAG_DEVTYPE_LPS25H;
-}
-
-LPS25H_SPI::~LPS25H_SPI()
-{
 }
 
 int

--- a/src/drivers/barometer/mpl3115a2/mpl3115a2_i2c.cpp
+++ b/src/drivers/barometer/mpl3115a2/mpl3115a2_i2c.cpp
@@ -64,7 +64,7 @@ class MPL3115A2_I2C : public device::I2C
 {
 public:
 	MPL3115A2_I2C(uint8_t bus);
-	virtual ~MPL3115A2_I2C();
+	virtual ~MPL3115A2_I2C() = default;
 
 	virtual int	init();
 	virtual int	read(unsigned offset, void *data, unsigned count);
@@ -96,10 +96,6 @@ MPL3115A2_i2c_interface(uint8_t busnum)
 
 MPL3115A2_I2C::MPL3115A2_I2C(uint8_t bus) :
 	I2C("MPL3115A2_I2C", nullptr, bus, 0, 400000)
-{
-}
-
-MPL3115A2_I2C::~MPL3115A2_I2C()
 {
 }
 

--- a/src/drivers/barometer/ms5611/ms5611_i2c.cpp
+++ b/src/drivers/barometer/ms5611/ms5611_i2c.cpp
@@ -67,9 +67,8 @@ class MS5611_I2C : public device::I2C
 {
 public:
 	MS5611_I2C(uint8_t bus, ms5611::prom_u &prom_buf);
-	virtual ~MS5611_I2C();
+	virtual ~MS5611_I2C() = default;
 
-	virtual int	init();
 	virtual int	read(unsigned offset, void *data, unsigned count);
 	virtual int	ioctl(unsigned operation, unsigned &arg);
 
@@ -114,17 +113,6 @@ MS5611_I2C::MS5611_I2C(uint8_t bus, ms5611::prom_u &prom) :
 	I2C("MS5611_I2C", nullptr, bus, 0, 400000),
 	_prom(prom)
 {
-}
-
-MS5611_I2C::~MS5611_I2C()
-{
-}
-
-int
-MS5611_I2C::init()
-{
-	/* this will call probe(), and thereby _probe_address */
-	return I2C::init();
 }
 
 int

--- a/src/drivers/barometer/ms5611/ms5611_spi.cpp
+++ b/src/drivers/barometer/ms5611/ms5611_spi.cpp
@@ -67,7 +67,7 @@ class MS5611_SPI : public device::SPI
 {
 public:
 	MS5611_SPI(uint8_t bus, uint32_t device, ms5611::prom_u &prom_buf);
-	virtual ~MS5611_SPI();
+	virtual ~MS5611_SPI() = default;
 
 	virtual int	init();
 	virtual int	read(unsigned offset, void *data, unsigned count);
@@ -133,10 +133,6 @@ MS5611_spi_interface(ms5611::prom_u &prom_buf, uint8_t busnum)
 MS5611_SPI::MS5611_SPI(uint8_t bus, uint32_t device, ms5611::prom_u &prom_buf) :
 	SPI("MS5611_SPI", nullptr, bus, device, SPIDEV_MODE3, 20 * 1000 * 1000 /* will be rounded to 10.4 MHz */),
 	_prom(prom_buf)
-{
-}
-
-MS5611_SPI::~MS5611_SPI()
 {
 }
 

--- a/src/drivers/blinkm/blinkm.cpp
+++ b/src/drivers/blinkm/blinkm.cpp
@@ -135,7 +135,7 @@ class BlinkM : public device::I2C
 {
 public:
 	BlinkM(int bus, int blinkm);
-	virtual ~BlinkM();
+	virtual ~BlinkM() = default;
 
 
 	virtual int		init();
@@ -309,10 +309,6 @@ BlinkM::BlinkM(int bus, int blinkm) :
 	num_of_used_sats(0)
 {
 	memset(&_work, 0, sizeof(_work));
-}
-
-BlinkM::~BlinkM()
-{
 }
 
 int

--- a/src/drivers/camera_trigger/interfaces/src/camera_interface.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/camera_interface.cpp
@@ -12,8 +12,6 @@ CameraInterface::CameraInterface():
 {
 }
 
-CameraInterface::~CameraInterface() = default;
-
 void CameraInterface::get_pins()
 {
 

--- a/src/drivers/camera_trigger/interfaces/src/camera_interface.h
+++ b/src/drivers/camera_trigger/interfaces/src/camera_interface.h
@@ -21,7 +21,7 @@ public:
 	/**
 	 * Destructor.
 	 */
-	virtual ~CameraInterface();
+	virtual ~CameraInterface() = default;
 
 	/**
 	 * trigger the camera

--- a/src/drivers/camera_trigger/interfaces/src/gpio.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/gpio.cpp
@@ -21,10 +21,6 @@ CameraInterfaceGPIO::CameraInterfaceGPIO():
 	setup();
 }
 
-CameraInterfaceGPIO::~CameraInterfaceGPIO()
-{
-}
-
 void CameraInterfaceGPIO::setup()
 {
 	for (unsigned i = 0, t = 0; i < arraySize(_pins); i++) {

--- a/src/drivers/camera_trigger/interfaces/src/gpio.h
+++ b/src/drivers/camera_trigger/interfaces/src/gpio.h
@@ -16,7 +16,7 @@ class CameraInterfaceGPIO : public CameraInterface
 {
 public:
 	CameraInterfaceGPIO();
-	virtual ~CameraInterfaceGPIO();
+	virtual ~CameraInterfaceGPIO() = default;
 
 	void trigger(bool trigger_on_true);
 

--- a/src/drivers/distance_sensor/ll40ls/LidarLite.cpp
+++ b/src/drivers/distance_sensor/ll40ls/LidarLite.cpp
@@ -48,8 +48,6 @@ LidarLite::LidarLite() :
 {
 }
 
-LidarLite::~LidarLite() = default;
-
 void LidarLite::set_minimum_distance(const float min)
 {
 	_min_distance = min;

--- a/src/drivers/distance_sensor/ll40ls/LidarLite.h
+++ b/src/drivers/distance_sensor/ll40ls/LidarLite.h
@@ -58,7 +58,7 @@ class LidarLite
 public:
 	LidarLite();
 
-	virtual ~LidarLite();
+	virtual ~LidarLite() = default;
 
 	virtual int init() = 0;
 

--- a/src/drivers/imu/mpu6000/mpu6000_i2c.cpp
+++ b/src/drivers/imu/mpu6000/mpu6000_i2c.cpp
@@ -67,9 +67,8 @@ class MPU6000_I2C : public device::I2C
 {
 public:
 	MPU6000_I2C(int bus, int device_type);
-	virtual ~MPU6000_I2C();
+	virtual ~MPU6000_I2C() = default;
 
-	virtual int	init();
 	virtual int	read(unsigned address, void *data, unsigned count);
 	virtual int	write(unsigned address, void *data, unsigned count);
 
@@ -95,17 +94,6 @@ MPU6000_I2C::MPU6000_I2C(int bus, int device_type) :
 	_device_type(device_type)
 {
 	_device_id.devid_s.devtype =  DRV_ACC_DEVTYPE_MPU6000;
-}
-
-MPU6000_I2C::~MPU6000_I2C()
-{
-}
-
-int
-MPU6000_I2C::init()
-{
-	/* this will call probe() */
-	return I2C::init();
 }
 
 int

--- a/src/drivers/imu/mpu6000/mpu6000_spi.cpp
+++ b/src/drivers/imu/mpu6000/mpu6000_spi.cpp
@@ -101,7 +101,7 @@ class MPU6000_SPI : public device::SPI
 {
 public:
 	MPU6000_SPI(int bus, uint32_t device, int device_type);
-	virtual ~MPU6000_SPI();
+	virtual ~MPU6000_SPI() = default;
 
 	virtual int	init();
 	virtual int	read(unsigned address, void *data, unsigned count);
@@ -211,10 +211,6 @@ MPU6000_SPI::MPU6000_SPI(int bus, uint32_t device, int device_type) :
 	_device_type(device_type)
 {
 	_device_id.devid_s.devtype =  DRV_ACC_DEVTYPE_MPU6000;
-}
-
-MPU6000_SPI::~MPU6000_SPI()
-{
 }
 
 int

--- a/src/drivers/imu/mpu9250/mag_i2c.cpp
+++ b/src/drivers/imu/mpu9250/mag_i2c.cpp
@@ -69,9 +69,8 @@ class AK8963_I2C : public device::I2C
 {
 public:
 	AK8963_I2C(int bus);
-	virtual ~AK8963_I2C();
+	virtual ~AK8963_I2C() = default;
 
-	virtual int	init();
 	virtual int	read(unsigned address, void *data, unsigned count);
 	virtual int	write(unsigned address, void *data, unsigned count);
 
@@ -93,17 +92,6 @@ AK8963_I2C::AK8963_I2C(int bus) :
 	I2C("AK8963_I2C", nullptr, bus, AK8963_I2C_ADDR, 400000)
 {
 	_device_id.devid_s.devtype =  DRV_MAG_DEVTYPE_MPU9250;
-}
-
-AK8963_I2C::~AK8963_I2C()
-{
-}
-
-int
-AK8963_I2C::init()
-{
-	/* this will call probe() */
-	return I2C::init();
 }
 
 int

--- a/src/drivers/kinetis/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/kinetis/tone_alarm/tone_alarm.cpp
@@ -199,7 +199,7 @@ class ToneAlarm : public device::CDev
 {
 public:
 	ToneAlarm();
-	~ToneAlarm();
+	~ToneAlarm() = default;
 
 	virtual int		init();
 
@@ -340,10 +340,6 @@ ToneAlarm::ToneAlarm() :
 	_tune_names[TONE_BARO_WARNING_TUNE] = "baro_warning";			// baro warning
 	_tune_names[TONE_SINGLE_BEEP_TUNE] = "beep";                    // single beep
 	_tune_names[TONE_HOME_SET] = "home_set";
-}
-
-ToneAlarm::~ToneAlarm()
-{
 }
 
 int

--- a/src/drivers/magnetometer/hmc5883/hmc5883_i2c.cpp
+++ b/src/drivers/magnetometer/hmc5883/hmc5883_i2c.cpp
@@ -67,9 +67,8 @@ class HMC5883_I2C : public device::I2C
 {
 public:
 	HMC5883_I2C(int bus);
-	virtual ~HMC5883_I2C();
+	virtual ~HMC5883_I2C() = default;
 
-	virtual int	init();
 	virtual int	read(unsigned address, void *data, unsigned count);
 	virtual int	write(unsigned address, void *data, unsigned count);
 
@@ -90,17 +89,6 @@ HMC5883_I2C::HMC5883_I2C(int bus) :
 	I2C("HMC5883_I2C", nullptr, bus, HMC5883L_ADDRESS, 400000)
 {
 	_device_id.devid_s.devtype = DRV_MAG_DEVTYPE_HMC5883;
-}
-
-HMC5883_I2C::~HMC5883_I2C()
-{
-}
-
-int
-HMC5883_I2C::init()
-{
-	/* this will call probe() */
-	return I2C::init();
 }
 
 int

--- a/src/drivers/magnetometer/hmc5883/hmc5883_spi.cpp
+++ b/src/drivers/magnetometer/hmc5883/hmc5883_spi.cpp
@@ -74,7 +74,7 @@ class HMC5883_SPI : public device::SPI
 {
 public:
 	HMC5883_SPI(int bus, uint32_t device);
-	virtual ~HMC5883_SPI();
+	virtual ~HMC5883_SPI() = default;
 
 	virtual int	init();
 	virtual int	read(unsigned address, void *data, unsigned count);
@@ -94,10 +94,6 @@ HMC5883_SPI::HMC5883_SPI(int bus, uint32_t device) :
 	SPI("HMC5883_SPI", nullptr, bus, device, SPIDEV_MODE3, 11 * 1000 * 1000 /* will be rounded to 10.4 MHz */)
 {
 	_device_id.devid_s.devtype = DRV_MAG_DEVTYPE_HMC5883;
-}
-
-HMC5883_SPI::~HMC5883_SPI()
-{
 }
 
 int

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl_i2c.cpp
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl_i2c.cpp
@@ -65,9 +65,8 @@ class LIS3MDL_I2C : public device::I2C
 {
 public:
 	LIS3MDL_I2C(int bus);
-	virtual ~LIS3MDL_I2C();
+	virtual ~LIS3MDL_I2C() = default;
 
-	virtual int     init();
 	virtual int     ioctl(unsigned operation, unsigned &arg);
 	virtual int     read(unsigned address, void *data, unsigned count);
 	virtual int     write(unsigned address, void *data, unsigned count);
@@ -90,17 +89,6 @@ LIS3MDL_I2C::LIS3MDL_I2C(int bus) :
 	I2C("LIS3MDL_I2C", nullptr, bus, LIS3MDLL_ADDRESS, 400000)
 {
 	_device_id.devid_s.devtype = DRV_MAG_DEVTYPE_LIS3MDL;
-}
-
-LIS3MDL_I2C::~LIS3MDL_I2C()
-{
-}
-
-int
-LIS3MDL_I2C::init()
-{
-	/* this will call probe() */
-	return I2C::init();
 }
 
 int

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl_spi.cpp
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl_spi.cpp
@@ -68,7 +68,7 @@ class LIS3MDL_SPI : public device::SPI
 {
 public:
 	LIS3MDL_SPI(int bus, uint32_t device);
-	virtual ~LIS3MDL_SPI();
+	virtual ~LIS3MDL_SPI() = default;
 
 	virtual int     init();
 	virtual int     ioctl(unsigned operation, unsigned &arg);
@@ -89,10 +89,6 @@ LIS3MDL_SPI::LIS3MDL_SPI(int bus, uint32_t device) :
 	SPI("LIS3MDL_SPI", nullptr, bus, device, SPIDEV_MODE3, 11 * 1000 * 1000 /* will be rounded to 10.4 MHz */)
 {
 	_device_id.devid_s.devtype = DRV_MAG_DEVTYPE_LIS3MDL;
-}
-
-LIS3MDL_SPI::~LIS3MDL_SPI()
-{
 }
 
 int

--- a/src/drivers/md25/md25.cpp
+++ b/src/drivers/md25/md25.cpp
@@ -121,10 +121,6 @@ MD25::MD25(const char *deviceName, int bus,
 	setTimeout(true);
 }
 
-MD25::~MD25()
-{
-}
-
 int MD25::readData()
 {
 	uint8_t sendBuf[1];

--- a/src/drivers/md25/md25.hpp
+++ b/src/drivers/md25/md25.hpp
@@ -120,7 +120,7 @@ public:
 	/**
 	 * deconstructor
 	 */
-	virtual ~MD25();
+	virtual ~MD25() = default;
 
 	/**
 	 * @return software version

--- a/src/drivers/pca8574/pca8574.cpp
+++ b/src/drivers/pca8574/pca8574.cpp
@@ -74,10 +74,8 @@ class PCA8574 : public device::I2C
 {
 public:
 	PCA8574(int bus, int pca8574);
-	virtual ~PCA8574();
+	virtual ~PCA8574() = default;
 
-
-	virtual int		init();
 	virtual int		probe();
 	virtual int		info();
 	virtual int		ioctl(struct file *filp, int cmd, unsigned long arg);
@@ -131,23 +129,6 @@ PCA8574::PCA8574(int bus, int pca8574) :
 	_counter(0)
 {
 	memset(&_work, 0, sizeof(_work));
-}
-
-PCA8574::~PCA8574()
-{
-}
-
-int
-PCA8574::init()
-{
-	int ret;
-	ret = I2C::init();
-
-	if (ret != OK) {
-		return ret;
-	}
-
-	return OK;
 }
 
 int

--- a/src/drivers/pca9685/pca9685.cpp
+++ b/src/drivers/pca9685/pca9685.cpp
@@ -112,7 +112,7 @@ class PCA9685 : public device::I2C
 {
 public:
 	PCA9685(int bus = PCA9685_BUS, uint8_t address = ADDR);
-	virtual ~PCA9685();
+	virtual ~PCA9685() = default;
 
 
 	virtual int		init();
@@ -196,10 +196,6 @@ PCA9685::PCA9685(int bus, uint8_t address) :
 	memset(&_work, 0, sizeof(_work));
 	memset(_msg, 0, sizeof(_msg));
 	memset(_current_values, 0, sizeof(_current_values));
-}
-
-PCA9685::~PCA9685()
-{
 }
 
 int

--- a/src/drivers/px4io/px4io_uploader.cpp
+++ b/src/drivers/px4io/px4io_uploader.cpp
@@ -70,10 +70,6 @@ PX4IO_Uploader::PX4IO_Uploader() :
 {
 }
 
-PX4IO_Uploader::~PX4IO_Uploader()
-{
-}
-
 int
 PX4IO_Uploader::upload(const char *filenames[])
 {

--- a/src/drivers/px4io/uploader.h
+++ b/src/drivers/px4io/uploader.h
@@ -47,7 +47,7 @@ class PX4IO_Uploader
 {
 public:
 	PX4IO_Uploader();
-	virtual ~PX4IO_Uploader();
+	virtual ~PX4IO_Uploader() = default;
 
 	int			upload(const char *filenames[]);
 

--- a/src/drivers/samv7/drv_input_capture.c
+++ b/src/drivers/samv7/drv_input_capture.c
@@ -87,13 +87,12 @@ static struct channel_handler_entry {
 	void			  *context;
 } channel_handlers[MAX_TIMER_IO_CHANNELS];
 
-
-
 static void input_capture_chan_handler(void *context, const io_timers_t *timer, uint32_t chan_index,
 				       const timer_io_channels_t *chan,
 				       hrt_abstime isrs_time, uint16_t isrs_rcnt)
 {
 }
+
 static void input_capture_bind(unsigned channel, capture_callback_t callback, void *context)
 {
 	irqstate_t flags = enter_critical_section();

--- a/src/drivers/samv7/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/samv7/tone_alarm/tone_alarm.cpp
@@ -212,7 +212,7 @@ class ToneAlarm : public device::CDev
 {
 public:
 	ToneAlarm();
-	~ToneAlarm();
+	~ToneAlarm() = default;
 
 	virtual int		init();
 
@@ -353,10 +353,6 @@ ToneAlarm::ToneAlarm() :
 	_tune_names[TONE_BARO_WARNING_TUNE] = "baro_warning";			// baro warning
 	_tune_names[TONE_SINGLE_BEEP_TUNE] = "beep";                    // single beep
 	_tune_names[TONE_HOME_SET] = "home_set";
-}
-
-ToneAlarm::~ToneAlarm()
-{
 }
 
 int

--- a/src/examples/segway/blocks.cpp
+++ b/src/examples/segway/blocks.cpp
@@ -54,8 +54,6 @@ BlockWaypointGuidance::BlockWaypointGuidance(SuperBlock *parent, const char *nam
 {
 }
 
-BlockWaypointGuidance::~BlockWaypointGuidance() = default;;
-
 void BlockWaypointGuidance::update(
 	const vehicle_global_position_s &pos,
 	const vehicle_attitude_s &att,

--- a/src/examples/segway/blocks.hpp
+++ b/src/examples/segway/blocks.hpp
@@ -75,11 +75,13 @@ private:
 	float _psiCmd;
 public:
 	BlockWaypointGuidance(SuperBlock *parent, const char *name);
-	virtual ~BlockWaypointGuidance();
+	virtual ~BlockWaypointGuidance() = default;
+
 	void update(const vehicle_global_position_s &pos,
 		    const vehicle_attitude_s &att,
 		    const position_setpoint_s &missionCmd,
 		    const position_setpoint_s &lastMissionCmd);
+
 	float getPsiCmd() { return _psiCmd; }
 };
 

--- a/src/lib/drivers/device/integrator.cpp
+++ b/src/lib/drivers/device/integrator.cpp
@@ -41,22 +41,14 @@
  */
 
 #include "integrator.h"
+
 #include <drivers/drv_hrt.h>
 
 Integrator::Integrator(uint64_t auto_reset_interval, bool coning_compensation) :
 	_auto_reset_interval(auto_reset_interval),
-	_last_integration_time(0),
-	_last_reset_time(0),
-	_alpha(0.0f, 0.0f, 0.0f),
-	_last_alpha(0.0f, 0.0f, 0.0f),
-	_beta(0.0f, 0.0f, 0.0f),
-	_last_val(0.0f, 0.0f, 0.0f),
-	_last_delta_alpha(0.0f, 0.0f, 0.0f),
 	_coning_comp_on(coning_compensation)
 {
 }
-
-Integrator::~Integrator() = default;
 
 bool
 Integrator::put(uint64_t timestamp, matrix::Vector3f &val, matrix::Vector3f &integral, uint64_t &integral_dt)

--- a/src/lib/drivers/device/integrator.h
+++ b/src/lib/drivers/device/integrator.h
@@ -49,7 +49,13 @@ class Integrator
 {
 public:
 	Integrator(uint64_t auto_reset_interval = 4000 /* 250 Hz */, bool coning_compensation = false);
-	virtual ~Integrator();
+	~Integrator() = default;
+
+	// no copy, assignment, move, move assignment
+	Integrator(const Integrator &) = delete;
+	Integrator &operator=(const Integrator &) = delete;
+	Integrator(Integrator &&) = delete;
+	Integrator &operator=(Integrator &&) = delete;
 
 	/**
 	 * Put an item into the integral.
@@ -105,26 +111,22 @@ public:
 	 *
 	 * @param auto_reset_interval	    	New reset time interval for the integrator.
 	 */
-	void set_autoreset_interval(uint64_t auto_reset_interval)
-	{
-		_auto_reset_interval = auto_reset_interval;
-	}
+	void set_autoreset_interval(uint64_t auto_reset_interval) { _auto_reset_interval = auto_reset_interval; }
 
 private:
-	uint64_t _auto_reset_interval;			/**< the interval after which the content will be published
+	uint64_t _auto_reset_interval{0};			/**< the interval after which the content will be published
 							     and the integrator reset, 0 if no auto-reset */
-	uint64_t _last_integration_time;		/**< timestamp of the last integration step */
-	uint64_t _last_reset_time;			/**< last auto-announcement of integral value */
-	matrix::Vector3f _alpha;			/**< integrated value before coning corrections are applied */
-	matrix::Vector3f _last_alpha;			/**< previous value of _alpha */
-	matrix::Vector3f _beta;				/**< accumulated coning corrections */
-	matrix::Vector3f _last_val;			/**< previous input */
-	matrix::Vector3f _last_delta_alpha;		/**< integral from previous previous sampling interval */
-	bool _coning_comp_on;				/**< true to turn on coning corrections */
 
-	/* we don't want this class to be copied */
-	Integrator(const Integrator &);
-	Integrator operator=(const Integrator &);
+	uint64_t _last_integration_time{0};		/**< timestamp of the last integration step */
+	uint64_t _last_reset_time{0};			/**< last auto-announcement of integral value */
+
+	matrix::Vector3f _alpha{0.0f, 0.0f, 0.0f};			/**< integrated value before coning corrections are applied */
+	matrix::Vector3f _last_alpha{0.0f, 0.0f, 0.0f};			/**< previous value of _alpha */
+	matrix::Vector3f _beta{0.0f, 0.0f, 0.0f};				/**< accumulated coning corrections */
+	matrix::Vector3f _last_val{0.0f, 0.0f, 0.0f};	/**< previous input */
+	matrix::Vector3f _last_delta_alpha{0.0f, 0.0f, 0.0f};		/**< integral from previous previous sampling interval */
+
+	bool _coning_comp_on{false};				/**< true to turn on coning corrections */
 
 	/* Do a reset.
 	 *

--- a/src/lib/drivers/led/led.cpp
+++ b/src/lib/drivers/led/led.cpp
@@ -60,7 +60,7 @@ class LED : device::CDev
 {
 public:
 	LED();
-	virtual ~LED();
+	virtual ~LED() = default;
 
 	virtual int		init();
 	virtual int		ioctl(device::file_t *filp, int cmd, unsigned long arg);
@@ -71,8 +71,6 @@ LED::LED() : CDev("led", LED0_DEVICE_PATH)
 	// force immediate init/device registration
 	init();
 }
-
-LED::~LED() = default;
 
 int
 LED::init()

--- a/src/modules/landing_target_estimator/LandingTargetEstimator.cpp
+++ b/src/modules/landing_target_estimator/LandingTargetEstimator.cpp
@@ -78,8 +78,6 @@ LandingTargetEstimator::LandingTargetEstimator() :
 	_check_params(true);
 }
 
-LandingTargetEstimator::~LandingTargetEstimator() = default;
-
 void LandingTargetEstimator::update()
 {
 	_check_params(false);

--- a/src/modules/landing_target_estimator/LandingTargetEstimator.h
+++ b/src/modules/landing_target_estimator/LandingTargetEstimator.h
@@ -67,7 +67,7 @@ class LandingTargetEstimator
 public:
 
 	LandingTargetEstimator();
-	virtual ~LandingTargetEstimator();
+	virtual ~LandingTargetEstimator() = default;
 
 	/*
 	 * Get new measurements and update the state estimate

--- a/src/modules/mavlink/mavlink_shell.cpp
+++ b/src/modules/mavlink/mavlink_shell.cpp
@@ -54,8 +54,6 @@
 #include <asm/socket.h>
 #endif
 
-MavlinkShell::MavlinkShell() = default;
-
 MavlinkShell::~MavlinkShell()
 {
 	//closing the pipes will stop the thread as well

--- a/src/modules/mavlink/mavlink_shell.h
+++ b/src/modules/mavlink/mavlink_shell.h
@@ -48,7 +48,7 @@
 class MavlinkShell
 {
 public:
-	MavlinkShell();
+	MavlinkShell() = default;
 
 	~MavlinkShell();
 

--- a/src/modules/mavlink/mavlink_tests/mavlink_ftp_test.cpp
+++ b/src/modules/mavlink/mavlink_tests/mavlink_ftp_test.cpp
@@ -65,8 +65,6 @@ MavlinkFtpTest::MavlinkFtpTest() :
 {
 }
 
-MavlinkFtpTest::~MavlinkFtpTest() = default;
-
 /// @brief Called before every test to initialize the FTP Server.
 void MavlinkFtpTest::_init()
 {

--- a/src/modules/mavlink/mavlink_tests/mavlink_ftp_test.h
+++ b/src/modules/mavlink/mavlink_tests/mavlink_ftp_test.h
@@ -44,7 +44,7 @@ class MavlinkFtpTest : public UnitTest
 {
 public:
 	MavlinkFtpTest();
-	virtual ~MavlinkFtpTest();
+	virtual ~MavlinkFtpTest() = default;
 
 	virtual bool run_tests(void);
 

--- a/src/modules/muorb/krait/px4muorb_KraitRpcWrapper.cpp
+++ b/src/modules/muorb/krait/px4muorb_KraitRpcWrapper.cpp
@@ -145,14 +145,6 @@ int calc_timer_diff_to_dsp_us(int32_t *time_diff_us)
 	return 0;
 }
 
-px4muorb::KraitRpcWrapper::KraitRpcWrapper()
-{
-}
-
-px4muorb::KraitRpcWrapper::~KraitRpcWrapper()
-{
-}
-
 bool px4muorb::KraitRpcWrapper::Initialize()
 {
 	bool rc = true;

--- a/src/modules/muorb/krait/px4muorb_KraitRpcWrapper.hpp
+++ b/src/modules/muorb/krait/px4muorb_KraitRpcWrapper.hpp
@@ -45,12 +45,12 @@ public:
 	/**
 	 * Constructor
 	 */
-	KraitRpcWrapper();
+	KraitRpcWrapper() = default;
 
 	/**
 	 * destructor
 	 */
-	~KraitRpcWrapper();
+	~KraitRpcWrapper() = default;
 
 	/**
 	 * Initiatizes the rpc channel px4 muorb

--- a/src/modules/simulator/accelsim/accelsim.cpp
+++ b/src/modules/simulator/accelsim/accelsim.cpp
@@ -209,7 +209,7 @@ class ACCELSIM_mag : public VirtDevObj
 {
 public:
 	ACCELSIM_mag(ACCELSIM *parent);
-	~ACCELSIM_mag();
+	~ACCELSIM_mag() = default;
 
 	virtual ssize_t	devRead(void *buffer, size_t buflen);
 	virtual int	devIOCTL(unsigned long cmd, unsigned long arg);
@@ -972,8 +972,6 @@ ACCELSIM_mag::ACCELSIM_mag(ACCELSIM *parent) :
 	m_id.dev_id_s.bus = 1;
 	m_id.dev_id_s.devtype = DRV_ACC_DEVTYPE_ACCELSIM;
 }
-
-ACCELSIM_mag::~ACCELSIM_mag() = default;
 
 ssize_t
 ACCELSIM_mag::devRead(void *buffer, size_t buflen)

--- a/src/modules/vtol_att_control/standard.cpp
+++ b/src/modules/vtol_att_control/standard.cpp
@@ -72,8 +72,6 @@ Standard::Standard(VtolAttitudeControl *attc) :
 	_params_handles_standard.reverse_delay = param_find("VT_B_REV_DEL");
 }
 
-Standard::~Standard() = default;
-
 void
 Standard::parameters_update()
 {

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -55,7 +55,7 @@ class Standard : public VtolType
 public:
 
 	Standard(VtolAttitudeControl *_att_controller);
-	~Standard();
+	~Standard() = default;
 
 	virtual void update_vtol_state();
 	virtual void update_transition_state();

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -65,8 +65,6 @@ Tailsitter::Tailsitter(VtolAttitudeControl *attc) :
 	_params_handles_tailsitter.front_trans_dur_p2 = param_find("VT_TRANS_P2_DUR");
 }
 
-Tailsitter::~Tailsitter() = default;
-
 void
 Tailsitter::parameters_update()
 {

--- a/src/modules/vtol_att_control/tailsitter.h
+++ b/src/modules/vtol_att_control/tailsitter.h
@@ -52,7 +52,7 @@ class Tailsitter : public VtolType
 
 public:
 	Tailsitter(VtolAttitudeControl *_att_controller);
-	~Tailsitter();
+	~Tailsitter() = default;
 
 	virtual void update_vtol_state();
 	virtual void update_transition_state();

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -65,8 +65,6 @@ Tiltrotor::Tiltrotor(VtolAttitudeControl *attc) :
 	_params_handles_tiltrotor.diff_thrust_scale = param_find("VT_FW_DIFTHR_SC");
 }
 
-Tiltrotor::~Tiltrotor() = default;
-
 void
 Tiltrotor::parameters_update()
 {

--- a/src/modules/vtol_att_control/tiltrotor.h
+++ b/src/modules/vtol_att_control/tiltrotor.h
@@ -50,7 +50,7 @@ class Tiltrotor : public VtolType
 public:
 
 	Tiltrotor(VtolAttitudeControl *_att_controller);
-	~Tiltrotor();
+	~Tiltrotor() = default;
 
 	virtual void update_vtol_state();
 	virtual void update_transition_state();

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -76,8 +76,6 @@ VtolType::VtolType(VtolAttitudeControl *att_controller) :
 	}
 }
 
-VtolType::~VtolType() = default;
-
 bool VtolType::init()
 {
 	const char *dev = PWM_OUTPUT0_DEVICE_PATH;

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -116,7 +116,7 @@ public:
 	VtolType(const VtolType &) = delete;
 	VtolType &operator=(const VtolType &) = delete;
 
-	virtual ~VtolType();
+	virtual ~VtolType() = default;
 
 	/**
 	 * Initialise.


### PR DESCRIPTION
Nothing too exciting, but it saves a couple hundred bytes of flash.