### PR TITLE
Land enhancement

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1450,8 +1450,20 @@ MulticopterPositionControl::control_non_manual()
 	/* use constant descend rate when landing, ignore altitude setpoint */
 	if (_pos_sp_triplet.current.valid
 	    && _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
-		_vel_sp(2) = _land_speed.get();
 		_run_alt_control = false;
+
+		/* Set descents speeds depending on altitude */
+		if (abs(_local_pos.z) > _slow_land_alt1.get()) {
+			_vel_sp(2) = _vel_max_down.get();
+
+		} else if (abs(_local_pos.z) > _slow_land_alt2.get()) {
+			float velocity_scaling = (abs(_local_pos.z) - _slow_land_alt2.get()) / (_slow_land_alt1.get() - _slow_land_alt2.get());
+			_vel_sp(2) = _land_speed.get() + velocity_scaling * (_vel_max_down.get() - _land_speed.get());
+
+		} else {
+			_vel_sp(2) = _land_speed.get();
+		}
+
 	}
 
 	if (_pos_sp_triplet.current.valid

--- a/src/modules/navigator/land.h
+++ b/src/modules/navigator/land.h
@@ -51,4 +51,6 @@ public:
 
 	void on_activation() override;
 	void on_active() override;
+	void advance_land();
+
 };

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -641,11 +641,21 @@ MissionBlock::set_land_item(struct mission_item_s *item, enum LandState land_sta
 	switch (land_state) {
 	case LAND_STATE_RETURN_HOME:
 		item->nav_cmd = NAV_CMD_WAYPOINT;
+
 		/* use home position */
-		item->lat = _navigator->get_home_position()->lat;
-		item->lon = _navigator->get_home_position()->lon;
-		item->yaw = _navigator->get_home_position()->yaw;
-		item->altitude = _navigator->get_global_position()->alt;
+		if (_navigator->get_vstatus()->failsafe) {
+			item->lat = NAN; //descend at current position
+			item->lon = NAN; //descend at current position
+			item->yaw = _navigator->get_local_position()->yaw;
+			item->altitude = 0;
+
+		} else {
+			item->lat = _navigator->get_home_position()->lat;
+			item->lon = _navigator->get_home_position()->lon;
+			item->yaw = _navigator->get_home_position()->yaw;
+			item->altitude = _navigator->get_global_position()->alt;
+		}
+
 		item->acceptance_radius = _navigator->get_acceptance_radius(0.5);
 		item->time_inside = 1.0f;
 		item->autocontinue = true;
@@ -654,11 +664,21 @@ MissionBlock::set_land_item(struct mission_item_s *item, enum LandState land_sta
 
 	case LAND_STATE_RETURN:
 		item->nav_cmd = NAV_CMD_WAYPOINT;
+
 		/* use current position */
-		item->lat = _navigator->get_global_position()->lat;
-		item->lon = _navigator->get_global_position()->lon;
-		item->yaw = _navigator->get_global_position()->yaw;
-		item->altitude = _navigator->get_global_position()->alt;
+		if (_navigator->get_vstatus()->failsafe) {
+			item->lat = NAN; //descend at current position
+			item->lon = NAN; //descend at current position
+			item->yaw = _navigator->get_local_position()->yaw;
+			item->altitude = 0;
+
+		} else {
+			item->lat = _navigator->get_global_position()->lat;
+			item->lon = _navigator->get_global_position()->lon;
+			item->yaw = _navigator->get_global_position()->yaw;
+			item->altitude = _navigator->get_global_position()->alt;
+		}
+
 		item->acceptance_radius = _navigator->get_acceptance_radius(0.5);
 		item->time_inside = 1.0f;
 		item->autocontinue = true;

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -68,6 +68,16 @@ public:
 	static bool item_contains_position(const mission_item_s &item);
 
 protected:
+
+	enum LandState {
+		LAND_STATE_NONE = 0,
+		LAND_STATE_RETURN_HOME,
+		LAND_STATE_RETURN,
+		LAND_STATE_DESCEND,
+		LAND_STATE_LAND,
+		LAND_STATE_LANDED,
+	} _land_state{LAND_STATE_NONE};
+
 	/**
 	 * Check if mission item has been reached
 	 * @return true if successfully reached
@@ -100,7 +110,7 @@ protected:
 	/**
 	 * Set a land mission item
 	 */
-	void set_land_item(struct mission_item_s *item, bool at_current_location);
+	void set_land_item(struct mission_item_s *item, enum LandState land_state);
 
 	/**
 	 * Set idle mission item


### PR DESCRIPTION
This PR fixes two problems with _Land_. See #9691 & #9768

**Problems**
1. _Land_ can cause vehicle to flip upon land if the command was issued while the vehicle was moving quickly. 

2. _Land_ descent velocity was only **MPC_LAND_SPEED**. 


**Solutions**
1. Vehicle will return to LAT/LON location where the _Land_ command was issued and begin descending from there. In the future, I want to implement a **_BRAKE_** setpoint type, but this is a good fix until that work is done.

2. The vehicle now respects MPC_LAND_ALT1 and MPC_LAND_ALT2 to control descent velocities.

I have simulation tested and physically flight tested this on our quadcopter and have seen no problems. I would love if someone could please test this with a fixed wing aircraft to verify. 

Please let me know if you have any questions, thanks!
Jake