### PR TITLE
ROI bugfix and improved precision

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1363,8 +1363,8 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 				mission_item->nav_cmd = NAV_CMD_DO_SET_ROI;
 				mission_item->params[0] = MAV_ROI_LOCATION;
 
-				mission_item->params[4] = mavlink_mission_item->x;
-				mission_item->params[5] = mavlink_mission_item->y;
+				mission_item->params[4] = mission_item->lat;
+				mission_item->params[5] = mission_item->lon;
 				mission_item->params[6] = mavlink_mission_item->z;
 
 			} else if ((int)mavlink_mission_item->param1 == MAV_ROI_NONE) {
@@ -1379,8 +1379,8 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 
 		case MAV_CMD_DO_SET_ROI_LOCATION:
 			mission_item->nav_cmd = NAV_CMD_DO_SET_ROI_LOCATION;
-			mission_item->params[4] = mavlink_mission_item->x;
-			mission_item->params[5] = mavlink_mission_item->y;
+			mission_item->params[4] = mission_item->lat;
+			mission_item->params[5] = mission_item->lon;
 			mission_item->params[6] = mavlink_mission_item->z;
 			break;
 

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1363,8 +1363,6 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 				mission_item->nav_cmd = NAV_CMD_DO_SET_ROI;
 				mission_item->params[0] = MAV_ROI_LOCATION;
 
-				mission_item->params[4] = mission_item->lat;
-				mission_item->params[5] = mission_item->lon;
 				mission_item->params[6] = mavlink_mission_item->z;
 
 			} else if ((int)mavlink_mission_item->param1 == MAV_ROI_NONE) {
@@ -1379,8 +1377,6 @@ MavlinkMissionManager::parse_mavlink_mission_item(const mavlink_mission_item_t *
 
 		case MAV_CMD_DO_SET_ROI_LOCATION:
 			mission_item->nav_cmd = NAV_CMD_DO_SET_ROI_LOCATION;
-			mission_item->params[4] = mission_item->lat;
-			mission_item->params[5] = mission_item->lon;
 			mission_item->params[6] = mavlink_mission_item->z;
 			break;
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -459,8 +459,8 @@ MissionBlock::issue_command(const mission_item_s &item)
 			vcmd.param7 = item.altitude + _navigator->get_home_position()->alt;
 
 		} else {
-			vcmd.param5 = item.params[4];
-			vcmd.param6 = item.params[5];
+			vcmd.param5 = (double)item.params[4];
+			vcmd.param6 = (double)item.params[5];
 			vcmd.param7 = item.params[6];
 		}
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -452,13 +452,15 @@ MissionBlock::issue_command(const mission_item_s &item)
 		vcmd.param2 = item.params[1];
 		vcmd.param3 = item.params[2];
 		vcmd.param4 = item.params[3];
-		vcmd.param5 = (double)item.params[4];
-		vcmd.param6 = (double)item.params[5];
 
 		if (item.nav_cmd == NAV_CMD_DO_SET_ROI_LOCATION && item.altitude_is_relative) {
+			vcmd.param5 = item.lat;
+			vcmd.param6 = item.lon;
 			vcmd.param7 = item.params[6] + _navigator->get_home_position()->alt;
 
 		} else {
+			vcmd.param5 = item.params[4];
+			vcmd.param6 = item.params[5];
 			vcmd.param7 = item.params[6];
 		}
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -456,7 +456,7 @@ MissionBlock::issue_command(const mission_item_s &item)
 		if (item.nav_cmd == NAV_CMD_DO_SET_ROI_LOCATION && item.altitude_is_relative) {
 			vcmd.param5 = item.lat;
 			vcmd.param6 = item.lon;
-			vcmd.param7 = item.params[6] + _navigator->get_home_position()->alt;
+			vcmd.param7 = item.altitude + _navigator->get_home_position()->alt;
 
 		} else {
 			vcmd.param5 = item.params[4];


### PR DESCRIPTION
## The ROI all-zeros bug

When transmitting a mission with QGC, occasionally the ROI waypoints are broken in the sense that the ROI lat/lon is set to `(0.0, 0.0)`. Some digging showed that this only happens when the `MAV_CMD` used to send the mission is in INT mode. The reason is the conversion  from `mavlink_mission` to `mission_item`. In INT mode the latitude and longitude need scaling:

https://github.com/PX4/Firmware/blob/bb8e653469e67afb43dbb9ecf3899cf50ef6162f/src/modules/mavlink/mavlink_mission.cpp#L1282-L1294

However, further down when setting the ROI parameters for LAT/LONG/ALT, the conversion is missing and the values are simply copied (cast) regardless of `_int_mode`:

https://github.com/PX4/Firmware/blob/bb8e653469e67afb43dbb9ecf3899cf50ef6162f/src/modules/mavlink/mavlink_mission.cpp#L1355-L1363

A proposed fix is in the first commit.

### Reproducing the issue:
The bug occurs only when the vehicle already has a mission loaded, with is removed in QGC, and then a new mission is sent containing the ROI. I am not sure why in one case INT mode is used, and in another case it's not...

## ROI waypoint floating-point precision
Looking at the situation with @MaEtUgR and @julianoes, we noticed that some precision is lost when using the parameter fields (float) of the vehicle message to store/access the ROI latitude and longitude (param 5 and param6):
https://github.com/PX4/Firmware/blob/bb8e653469e67afb43dbb9ecf3899cf50ef6162f/src/modules/navigator/mission_block.cpp#L445-L463

Instead, we can just as well use the mission item's latitude and longitude, which are `double`s instead of `float`s:
https://github.com/PX4/Firmware/blob/bb8e653469e67afb43dbb9ecf3899cf50ef6162f/src/modules/navigator/navigation.h#L135-L153

The proposed fix is in the second commit, making the other commit redundant. 

------

@julianoes Please take a look :)