### PR TITLE
frsky_telemetry improved com port init (fix #9783), minor refactor

### DIFF
--- a/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
@@ -221,9 +221,9 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 	argv += 2;
 
 	int ch;
-	
+
 	device_name = "/dev/ttyS6"; /* default USART8 */
-	
+
 	while ((ch = getopt(argc, argv, "d:")) != EOF) {
 		switch (ch) {
 		case 'd':
@@ -644,13 +644,13 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 
 	/* Reset the UART flags to original state */
 	tcsetattr(uart, TCSANOW, &uart_config_original);
-	
+
 	close(uart);
-	
+
 	device_name = NULL;
-	
+
 	thread_running = false;
-	
+
 	return 0;
 }
 
@@ -660,7 +660,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
  */
 int frsky_telemetry_main(int argc, char *argv[])
 {
-	
+
 
 	if (argc < 2) {
 		warnx("missing command");
@@ -685,7 +685,7 @@ int frsky_telemetry_main(int argc, char *argv[])
 		while (!thread_running) {
 			usleep(200);
 		}
-		
+
 		exit(0);
 	}
 
@@ -702,7 +702,7 @@ int frsky_telemetry_main(int argc, char *argv[])
 			usleep(1000000);
 			warnx(".");
 		}
-		
+
 		warnx("terminated.");
 		device_name = NULL;
 		exit(0);
@@ -711,31 +711,31 @@ int frsky_telemetry_main(int argc, char *argv[])
 	if (!strcmp(argv[1], "status")) {
 		if (thread_running) {
 			switch (frsky_state) {
-				
+
 			case SCANNING:
 				PX4_INFO("running: SCANNING");
-				PX4_INFO("port: %s\n", device_name);
-				exit(0);
+				PX4_INFO("port: %s", device_name);
+				return 0;
 				break;
-			
+
 			case SPORT:
 				PX4_INFO("running: SPORT");
-				PX4_INFO("port: %s\n", device_name);
-				PX4_INFO("packets sent: %d\n", sentPackets);
-				exit(0);
+				PX4_INFO("port: %s", device_name);
+				PX4_INFO("packets sent: %d", sentPackets);
+				return 0;
 				break;
 
 			case DTYPE:
 				PX4_INFO("running: DTYPE");
-				PX4_INFO("port: %s\n", device_name);
-				PX4_INFO("packets sent: %d\n", sentPackets);
-				exit(0);
+				PX4_INFO("port: %s", device_name);
+				PX4_INFO("packets sent: %d", sentPackets);
+				return 0;
 				break;
 			}
 
 		} else {
 			PX4_INFO("not running");
-			exit(0);
+			return 0;
 		}
 	}
 

--- a/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
@@ -697,7 +697,7 @@ int frsky_telemetry_main(int argc, char *argv[])
 			warnx(".");
 		}
 		
-		*device_name = NULL;
+		device_name = NULL;
 		warnx("terminated.");
 		exit(0);
 	}

--- a/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
@@ -78,7 +78,7 @@ static frsky_state_t frsky_state = SCANNING;
 
 static unsigned long int sentPackets = 0;
 /* Default values for arguments */
-const char *device_name = "/dev/ttyS6"; /* USART8 */
+const char *device_name = NULL;
 
 /* functions */
 static int sPort_open_uart(const char *uart_name, struct termios *uart_config, struct termios *uart_config_original);
@@ -654,6 +654,8 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
  */
 int frsky_telemetry_main(int argc, char *argv[])
 {
+	device_name = "/dev/ttyS6"; /* default USART8 */
+
 	if (argc < 2) {
 		warnx("missing command");
 		usage();
@@ -694,7 +696,8 @@ int frsky_telemetry_main(int argc, char *argv[])
 			usleep(1000000);
 			warnx(".");
 		}
-
+		
+		device_name = NULL;
 		warnx("terminated.");
 		exit(0);
 	}
@@ -724,8 +727,8 @@ int frsky_telemetry_main(int argc, char *argv[])
 			}
 
 		} else {
-		    PX4_INFO("not running");
-		    exit(0);
+			PX4_INFO("not running");
+			exit(0);
 		}
 	}
 

--- a/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
@@ -36,8 +36,10 @@
  * @file frsky_telemetry.c
  * @author Stefan Rado <px4@sradonia.net>
  * @author Mark Whitehorn <kd0aij@github.com>
+ * @author Gianni Carbone <gianni.carbone@gmail.com>
  *
  * FrSky D8 mode and SmartPort (D16 mode) telemetry implementation.
+ * Compatibility with hardware flow control serial port.
  *
  * This daemon emulates the FrSky Sensor Hub for D8 mode.
  * For X series receivers (D16 mode) it emulates SmartPort sensors by responding to polling
@@ -73,6 +75,10 @@ static volatile bool thread_running = false;
 static int frsky_task;
 typedef enum { SCANNING, SPORT, DTYPE } frsky_state_t;
 static frsky_state_t frsky_state = SCANNING;
+
+static unsigned long int sentPackets = 0;
+/* Default values for arguments */
+const char *device_name = "/dev/ttyS6"; /* USART8 */
 
 /* functions */
 static int sPort_open_uart(const char *uart_name, struct termios *uart_config, struct termios *uart_config_original);
@@ -147,6 +153,17 @@ static int sPort_open_uart(const char *uart_name, struct termios *uart_config, s
 	/* Disable output post-processing */
 	uart_config->c_oflag &= ~OPOST;
 
+	uart_config->c_cflag |= (CLOCAL | CREAD);    /* ignore modem controls */
+	uart_config->c_cflag &= ~CSIZE;
+	uart_config->c_cflag |= CS8;         /* 8-bit characters */
+	uart_config->c_cflag &= ~PARENB;     /* no parity bit */
+	uart_config->c_cflag &= ~CSTOPB;     /* only need 1 stop bit */
+	uart_config->c_cflag &= ~CRTSCTS;    /* no hardware flowcontrol */
+
+	/* setup for non-canonical mode */
+	uart_config->c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
+	uart_config->c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
+
 	/* Set baud rate */
 	const speed_t speed = B9600;
 
@@ -199,9 +216,6 @@ static void usage()
  */
 static int frsky_telemetry_thread_main(int argc, char *argv[])
 {
-	/* Default values for arguments */
-	const char *device_name = "/dev/ttyS6"; /* USART8 */
-
 	/* Work around some stupidity in task_create's argv handling */
 	argc -= 2;
 	argv += 2;
@@ -392,6 +406,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					lastBATV_ms = now_ms;
 					/* send battery voltage */
 					sPort_send_BATV(uart);
+          sentPackets++;
 				}
 
 				break;
@@ -404,6 +419,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					lastCUR_ms = now_ms;
 					/* send battery current */
 					sPort_send_CUR(uart);
+          sentPackets++;
 				}
 
 				break;
@@ -416,6 +432,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					lastALT_ms = now_ms;
 					/* send altitude */
 					sPort_send_ALT(uart);
+          sentPackets++;
 				}
 
 				break;
@@ -428,6 +445,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					lastSPD_ms = now_ms;
 					/* send speed */
 					sPort_send_SPD(uart);
+          sentPackets++;
 				}
 
 				break;
@@ -439,6 +457,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					lastFUEL_ms = now_ms;
 					/* send fuel */
 					sPort_send_FUEL(uart);
+          sentPackets++;
 				}
 
 				break;
@@ -456,6 +475,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					lastVSPD_ms = now_ms;
 
 					sPort_send_VSPD(uart, speed);
+          sentPackets++;
 				}
 
 				break;
@@ -496,6 +516,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					case 5:
 						sPort_send_GPS_TIME(uart);
 						elementCount = 0;
+            sentPackets += elementCount;
 						break;
 					}
 
@@ -510,6 +531,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					lastNAV_STATE_ms = now_ms;
 					/* send T1 */
 					sPort_send_NAV_STATE(uart);
+          sentPackets++;
 				}
 
 				/* report satcount and fix as DIY_GPSFIX at 2Hz */
@@ -517,6 +539,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					lastGPS_FIX_ms = now_ms;
 					/* send T2 */
 					sPort_send_GPS_FIX(uart);
+          sentPackets++;
 				}
 
 				break;
@@ -527,10 +550,12 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					switch (elementCount++ % 2) {
 					case 0:
 						sPort_send_flight_mode(uart);
+            sentPackets++;
 						break;
 
 					default:
 						sPort_send_GPS_info(uart);
+            sentPackets++;
 						break;
 					}
 				}
@@ -589,17 +614,19 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 			/* Send frame 1 (every 200ms): acceleration values, altitude (vario), temperatures, current & voltages, RPM */
 			if (iteration % 2 == 0) {
 				frsky_send_frame1(uart);
+        sentPackets++;
 			}
 
 			/* Send frame 2 (every 1000ms): course, latitude, longitude, speed, altitude (GPS), fuel level */
 			if (iteration % 10 == 0) {
 				frsky_send_frame2(uart);
+        sentPackets++;
 			}
 
 			/* Send frame 3 (every 5000ms): date, time */
 			if (iteration % 50 == 0) {
 				frsky_send_frame3(uart);
-
+        sentPackets++;
 				iteration = 0;
 			}
 
@@ -676,21 +703,30 @@ int frsky_telemetry_main(int argc, char *argv[])
 		if (thread_running) {
 			switch (frsky_state) {
 			case SCANNING:
-				errx(0, "running: SCANNING");
-				break;
-
+        PX4_INFO("running: SCANNING");
+        printf("port: %s\n", device_name);
+        exit(0);				
+      break;
+ 
 			case SPORT:
-				errx(0, "running: SPORT");
-				break;
+        PX4_INFO("running: SPORT");
+        printf("port: %s\n", device_name);
+        printf("packets sent: %d\n", sentPackets);
+        exit(0);			
+      break;
 
 			case DTYPE:
-				errx(0, "running: DTYPE");
-				break;
+        PX4_INFO("running: DTYPE");
+        printf("port: %s\n", device_name);
+        printf("packets sent: %d\n", sentPackets);
+        exit(0);				
+      break;
 
 			}
 
 		} else {
-			errx(1, "not running");
+      PX4_INFO("not running");
+      exit(0);
 		}
 	}
 

--- a/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
@@ -697,7 +697,7 @@ int frsky_telemetry_main(int argc, char *argv[])
 			warnx(".");
 		}
 		
-		device_name = NULL;
+		*device_name = NULL;
 		warnx("terminated.");
 		exit(0);
 	}
@@ -710,8 +710,8 @@ int frsky_telemetry_main(int argc, char *argv[])
 				PX4_INFO("port: %s\n", device_name);
 				exit(0);
 				break;
- 
-			case SPORT:
+				
+ 			case SPORT:
 				PX4_INFO("running: SPORT");
 				PX4_INFO("port: %s\n", device_name);
 				PX4_INFO("packets sent: %d\n", sentPackets);

--- a/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
@@ -724,8 +724,8 @@ int frsky_telemetry_main(int argc, char *argv[])
 			}
 
 		} else {
-		  PX4_INFO("not running");
-		  exit(0);
+		    PX4_INFO("not running");
+		    exit(0);
 		}
 	}
 

--- a/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
@@ -406,7 +406,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					lastBATV_ms = now_ms;
 					/* send battery voltage */
 					sPort_send_BATV(uart);
-          sentPackets++;
+					sentPackets++;
 				}
 
 				break;
@@ -419,7 +419,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					lastCUR_ms = now_ms;
 					/* send battery current */
 					sPort_send_CUR(uart);
-          sentPackets++;
+					sentPackets++;
 				}
 
 				break;
@@ -432,7 +432,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					lastALT_ms = now_ms;
 					/* send altitude */
 					sPort_send_ALT(uart);
-          sentPackets++;
+					sentPackets++;
 				}
 
 				break;
@@ -445,7 +445,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					lastSPD_ms = now_ms;
 					/* send speed */
 					sPort_send_SPD(uart);
-          sentPackets++;
+					sentPackets++;
 				}
 
 				break;
@@ -457,7 +457,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					lastFUEL_ms = now_ms;
 					/* send fuel */
 					sPort_send_FUEL(uart);
-          sentPackets++;
+					sentPackets++;
 				}
 
 				break;
@@ -475,7 +475,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					lastVSPD_ms = now_ms;
 
 					sPort_send_VSPD(uart, speed);
-          sentPackets++;
+					sentPackets++;
 				}
 
 				break;
@@ -516,7 +516,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					case 5:
 						sPort_send_GPS_TIME(uart);
 						elementCount = 0;
-            sentPackets += elementCount;
+						sentPackets += elementCount;
 						break;
 					}
 
@@ -531,7 +531,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					lastNAV_STATE_ms = now_ms;
 					/* send T1 */
 					sPort_send_NAV_STATE(uart);
-          sentPackets++;
+					sentPackets++;
 				}
 
 				/* report satcount and fix as DIY_GPSFIX at 2Hz */
@@ -539,7 +539,7 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					lastGPS_FIX_ms = now_ms;
 					/* send T2 */
 					sPort_send_GPS_FIX(uart);
-          sentPackets++;
+					sentPackets++;
 				}
 
 				break;
@@ -550,12 +550,12 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 					switch (elementCount++ % 2) {
 					case 0:
 						sPort_send_flight_mode(uart);
-            sentPackets++;
+						sentPackets++;
 						break;
 
 					default:
 						sPort_send_GPS_info(uart);
-            sentPackets++;
+						sentPackets++;
 						break;
 					}
 				}
@@ -614,19 +614,19 @@ static int frsky_telemetry_thread_main(int argc, char *argv[])
 			/* Send frame 1 (every 200ms): acceleration values, altitude (vario), temperatures, current & voltages, RPM */
 			if (iteration % 2 == 0) {
 				frsky_send_frame1(uart);
-        sentPackets++;
+				sentPackets++;
 			}
 
 			/* Send frame 2 (every 1000ms): course, latitude, longitude, speed, altitude (GPS), fuel level */
 			if (iteration % 10 == 0) {
 				frsky_send_frame2(uart);
-        sentPackets++;
+				sentPackets++;
 			}
 
 			/* Send frame 3 (every 5000ms): date, time */
 			if (iteration % 50 == 0) {
 				frsky_send_frame3(uart);
-        sentPackets++;
+				sentPackets++;
 				iteration = 0;
 			}
 
@@ -703,30 +703,29 @@ int frsky_telemetry_main(int argc, char *argv[])
 		if (thread_running) {
 			switch (frsky_state) {
 			case SCANNING:
-        PX4_INFO("running: SCANNING");
-        printf("port: %s\n", device_name);
-        exit(0);				
-      break;
+				PX4_INFO("running: SCANNING");
+				PX4_INFO("port: %s\n", device_name);
+				exit(0);
+				break;
  
 			case SPORT:
-        PX4_INFO("running: SPORT");
-        printf("port: %s\n", device_name);
-        printf("packets sent: %d\n", sentPackets);
-        exit(0);			
-      break;
+				PX4_INFO("running: SPORT");
+				PX4_INFO("port: %s\n", device_name);
+				PX4_INFO("packets sent: %d\n", sentPackets);
+				exit(0);
+				break;
 
 			case DTYPE:
-        PX4_INFO("running: DTYPE");
-        printf("port: %s\n", device_name);
-        printf("packets sent: %d\n", sentPackets);
-        exit(0);				
-      break;
-
+				PX4_INFO("running: DTYPE");
+				PX4_INFO("port: %s\n", device_name);
+				PX4_INFO("packets sent: %d\n", sentPackets);
+				exit(0);
+				break;
 			}
 
 		} else {
-      PX4_INFO("not running");
-      exit(0);
+		  PX4_INFO("not running");
+		  exit(0);
 		}
 	}
 


### PR DESCRIPTION
Change code setup for the serial port used for sending data.
Fix the problem using serial port with hardware flow control, for example /dev/ttyS1 in pixhawk hardware.
It could be useful if you have to use that port when others are used by attached devices (i.e. esp telemetry on telem2 and tfmini ranger on serial 4)

fixes issue #9783

Some code rework: 
- errx( replaced by PX4_INFO( and printf in show status code
- added sent packet counter
- used phisical port and packet sent counter now shown in "status" output
