### PR TITLE
Land enhancement - Braking

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1470,13 +1470,14 @@ MulticopterPositionControl::control_non_manual()
 		_vel_sp(1) = _pos_sp_triplet.current.vy;
 	}
 
-	/* use constant descend rate when landing, ignore altitude setpoint */
+	/* If vehicle is in LAND, arrest horizontal velocity and then begin descent. */
 	if (_pos_sp_triplet.current.valid
 	    && _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
 
 		float vel_xy_mag = sqrtf(_vel(0) * _vel(0) + _vel(1) * _vel(1));
 		bool engage_pos_hold = vel_xy_mag < _hold_max_xy.get();
 
+		/* Brakes until velocity is arrested. */
 		if (!engage_pos_hold && !_is_descending_land) {
 			_vel_sp(0) = 0;
 			_vel_sp(1) = 0;
@@ -1488,6 +1489,7 @@ MulticopterPositionControl::control_non_manual()
 			control_position();
 
 		} else {
+			/* Sets the landing flag, and begins descending in place */
 			_reset_pos_sp  = true;
 			reset_pos_sp();
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -137,6 +137,7 @@ private:
 	bool 		_lnd_reached_ground = false; 		/**<true if controller assumes the vehicle has reached the ground after landing */
 	bool 		_triplet_lat_lon_finite = true; 		/**<true if triplets current is non-finite */
 	bool		_terrain_follow = false;			/**<true is the position controller is controlling height above ground */
+	bool 		_is_descending_land = false;
 
 	int		_control_task;			/**< task handle for task */
 	orb_advert_t	_mavlink_log_pub;		/**< mavlink log advert */
@@ -375,6 +376,8 @@ private:
 	void generate_attitude_setpoint();
 
 	float get_cruising_speed_xy();
+
+	float get_descent_velocity();
 
 	bool in_auto_takeoff();
 
@@ -966,6 +969,26 @@ MulticopterPositionControl::get_cruising_speed_xy()
 		_pos_sp_triplet.current.cruising_speed : _vel_cruise_xy.get());
 }
 
+float
+MulticopterPositionControl::get_descent_velocity()
+{
+	float descent_velocity = 0;
+
+	/* Set descents speeds depending on altitude */
+	if (abs(_local_pos.z) > _slow_land_alt1.get()) {
+		descent_velocity = _vel_max_down.get();
+
+	} else if (abs(_local_pos.z) > _slow_land_alt2.get()) {
+		float velocity_scaling = (abs(_local_pos.z) - _slow_land_alt2.get()) / (_slow_land_alt1.get() - _slow_land_alt2.get());
+		descent_velocity = _land_speed.get() + velocity_scaling * (_vel_max_down.get() - _land_speed.get());
+
+	} else {
+		descent_velocity = _land_speed.get();
+	}
+
+	return descent_velocity;
+}
+
 void
 MulticopterPositionControl::set_manual_acceleration_z(float &max_acceleration, const float stick_z)
 {
@@ -1450,8 +1473,32 @@ MulticopterPositionControl::control_non_manual()
 	/* use constant descend rate when landing, ignore altitude setpoint */
 	if (_pos_sp_triplet.current.valid
 	    && _pos_sp_triplet.current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
-		_vel_sp(2) = _land_speed.get();
-		_run_alt_control = false;
+
+		float vel_xy_mag = sqrtf(_vel(0) * _vel(0) + _vel(1) * _vel(1));
+		bool engage_pos_hold = vel_xy_mag < _hold_max_xy.get();
+
+		if (!engage_pos_hold && !_is_descending_land) {
+			_vel_sp(0) = 0;
+			_vel_sp(1) = 0;
+			_vel_sp(2) = 0;
+
+			_run_pos_control = false;
+			_run_alt_control = false;
+
+			control_position();
+
+		} else {
+			_reset_pos_sp  = true;
+			reset_pos_sp();
+
+			_run_pos_control = true;
+			_run_alt_control = false;
+			_is_descending_land = true;
+
+			_vel_sp(2) = get_descent_velocity();
+
+			control_position();
+		}
 	}
 
 	if (_pos_sp_triplet.current.valid
@@ -3013,6 +3060,7 @@ MulticopterPositionControl::task_main()
 			_hold_offboard_z = false;
 			_in_landing = false;
 			_lnd_reached_ground = false;
+			_is_descending_land = false;
 
 			/* also reset previous setpoints */
 			_yaw_takeoff = _yaw;


### PR DESCRIPTION
This PR supersedes #9772 

I've implemented the desired landing behavior in the multi-copter position controller. The vehicle now arrests it's horizontal velocity before descent. This behavior is identical to the behavior when a user lets go of sticks (sticks go back to center) while flying in position mode. 

I have tested this in the simulator, I tested flying forward and disabling GPS as @Stifael suggested before. I have also flight tested this. I flew this build for 30 minutes and issued ~20 lands. I tested landing in place, landing while giving sticks, and landing while in RTL mode. 

I would love any suggestions anyone has for further testing. How does this implementation look? I appreciate any feedback you guys have. Thanks.