### PR TITLE
[Bebop 2] Fix upload, upload unstripped version to /data/ftp/internal_000

### DIFF
--- a/Tools/adb_upload_to_bebop.sh
+++ b/Tools/adb_upload_to_bebop.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-if [ -z ${BEBOP_IP+x} ]; then
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SRC_DIR="$BASEDIR/../"
+
+if [ -z ${BEBOP_IP+x} ]; then 
   ip=192.168.42.1
   echo "\$BEBOP_IP is not set (use default: $ip)"
 else
@@ -42,13 +45,23 @@ if [[ $adb_return == "" ]]; then
     restart_px4=true
 fi
 
-$(dirname "$0")/adb_upload.sh $@
+# upload PX4
+$BASEDIR/adb_upload.sh $@
+
+# upload mixer and config files
+echo "Uploading mixer and config files to /home/root"
+adb push $SRC_DIR/ROMFS/px4fmu_common/mixers/bebop.main.mix /home/root
+adb push $SRC_DIR/posix-configs/bebop/px4.config /home/root
 
 # restart the process after uploading
 if [ "$restart_px4" = true ]; then
     echo "Restarting PX4 process"
     adb shell /etc/init.d/rcS_mode_default 2>/dev/null 1>/dev/null &
 fi
+
+# make sure all buffered blocks are written to disk
+echo "Syncing FS..."
+adb shell sync
 
 echo "Disconnecting from Bebop"
 adb disconnect

--- a/Tools/adb_upload_to_bebop.sh
+++ b/Tools/adb_upload_to_bebop.sh
@@ -42,7 +42,7 @@ if [[ $adb_return == "" ]]; then
     restart_px4=true
 fi
 
-../Tools/adb_upload.sh $@
+$(dirname "$0")/adb_upload.sh $@
 
 # restart the process after uploading
 if [ "$restart_px4" = true ]; then

--- a/platforms/posix/CMakeLists.txt
+++ b/platforms/posix/CMakeLists.txt
@@ -120,7 +120,6 @@ elseif ("${BOARD}" STREQUAL "bbblue")
 elseif ("${BOARD}" STREQUAL "bebop")
 
 	add_custom_target(upload
-		# COMMAND ${CMAKE_STRIP} -R .comment -R .gnu.version -o $<TARGET_FILE:px4>.stripped $<TARGET_FILE:px4>
 		COMMAND ${PX4_SOURCE_DIR}/Tools/adb_upload_to_bebop.sh $<TARGET_FILE:px4> /data/ftp/internal_000
 		DEPENDS px4
 		COMMENT "uploading px4"

--- a/platforms/posix/CMakeLists.txt
+++ b/platforms/posix/CMakeLists.txt
@@ -120,8 +120,8 @@ elseif ("${BOARD}" STREQUAL "bbblue")
 elseif ("${BOARD}" STREQUAL "bebop")
 
 	add_custom_target(upload
-		COMMAND ${CMAKE_STRIP} -R .comment -R .gnu.version -o $<TARGET_FILE:px4>.stripped $<TARGET_FILE:px4>
-		COMMAND ${PX4_SOURCE_DIR}/Tools/adb_upload_to_bebop.sh $<TARGET_FILE:px4>.stripped /usr/bin
+		# COMMAND ${CMAKE_STRIP} -R .comment -R .gnu.version -o $<TARGET_FILE:px4>.stripped $<TARGET_FILE:px4>
+		COMMAND ${PX4_SOURCE_DIR}/Tools/adb_upload_to_bebop.sh $<TARGET_FILE:px4> /data/ftp/internal_000
 		DEPENDS px4
 		COMMENT "uploading px4"
 		USES_TERMINAL


### PR DESCRIPTION
For better debugging it's better to have the unstripped version now, this also fixes the upload script.

To test run:
 ```
make posix_bebop_default upload

telnet 192.168.42.1
/data/ftp/internal_000/px4 /home/root/px4.config
```
Check full instructions here: https://dev.px4.io/en/setup/building_px4.html