### PR TITLE
Fix up references to pixhawk.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This repository contains code supporting these boards:
     * [Pixhawk](https://docs.px4.io/en/flight_controller/pixhawk.html)
     * [Pixhawk Mini](https://docs.px4.io/en/flight_controller/pixhawk_mini.html)
     * [Pixfalcon](https://docs.px4.io/en/flight_controller/pixfalcon.html)
-  * FMUv3.x [Pixhawk 2](https://pixhawk.org/modules/pixhawk2)
+  * FMUv3.x [Pixhawk 2](https://docs.px4.io/en/flight_controller/pixhawk-2.html)
   * FMUv4.x
     * [Pixracer](https://docs.px4.io/en/flight_controller/pixracer.html)
     * [Pixhawk 3 Pro](https://docs.px4.io/en/flight_controller/pixhawk3_pro.html)

--- a/ROMFS/px4fmu_common/init.d/3030_io_camflyer
+++ b/ROMFS/px4fmu_common/init.d/3030_io_camflyer
@@ -2,8 +2,6 @@
 #
 # @name IO Camflyer
 #
-# @url https://pixhawk.org/platforms/planes/bormatec_camflyer_q
-#
 # @type Flying Wing
 # @class Plane
 #

--- a/ROMFS/px4fmu_common/init.d/3031_phantom
+++ b/ROMFS/px4fmu_common/init.d/3031_phantom
@@ -2,7 +2,7 @@
 #
 # @name Phantom FPV Flying Wing
 #
-# @url https://pixhawk.org/platforms/planes/z-84_wing_wing
+# @url https://docs.px4.io/en/frames_plane/wing_wing_z84.html
 #
 # @type Flying Wing
 # @class Plane

--- a/ROMFS/px4fmu_common/init.d/3032_skywalker_x5
+++ b/ROMFS/px4fmu_common/init.d/3032_skywalker_x5
@@ -2,8 +2,6 @@
 #
 # @name Skywalker X5 Flying Wing
 #
-# @url https://pixhawk.org/platforms/planes/skywalker_x5
-#
 # @type Flying Wing
 # @class Plane
 #

--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -292,7 +292,7 @@ class uploader(object):
 
         except NotImplementedError:
             raise RuntimeError("Programing not supported for this version of silicon!\n"
-                               "See https://pixhawk.org/help/errata")
+                               "See https://docs.px4.io/en/flight_controller/silicon_errata.html")
         except RuntimeError:
             # timeout, no response yet
             return False

--- a/src/examples/hwtest/hwtest.c
+++ b/src/examples/hwtest/hwtest.c
@@ -34,7 +34,6 @@
  * @file hwtest.c
  *
  * Simple output test.
- * @ref Documentation https://pixhawk.org/dev/examples/write_output
  *
  * @author Lorenz Meier <lm@inf.ethz.ch>
  */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -39,8 +39,6 @@
  * Daniel Mellinger and Vijay Kumar. Minimum Snap Trajectory Generation and Control for Quadrotors.
  * Int. Conf. on Robotics and Automation, Shanghai, China, May 2011
  *
- * Also inspired by https://pixhawk.org/firmware/apps/fw_pos_control_l1
- *
  * The controller has two loops: P loop for position error and PID loop for velocity error.
  * Output of velocity controller is thrust vector that splitted to thrust direction
  * (i.e. rotation matrix for multicopter orientation) and thrust module (i.e. multicopter thrust itself).

--- a/src/systemcmds/ver/ver.c
+++ b/src/systemcmds/ver/ver.c
@@ -262,7 +262,7 @@ int ver_main(int argc, char *argv[])
 						printf("\nWARNING   WARNING   WARNING!\n"
 						       "Revision %c has a silicon errata:\n"
 						       "%s"
-						       "\nhttps://pixhawk.org/help/errata\n\n", rev, errata);
+						       "\nhttps://docs.px4.io/en/flight_controller/silicon_errata.html\n\n", rev, errata);
 					}
 				}
 


### PR DESCRIPTION
Replaces https://github.com/PX4/Firmware/pull/9780

There are still a couple open- any thoughts on :
1. In \Firmware\README.md we have link to https://pixhawk.org/modules/stm32f4discovery - is the discovery kit still available, used, or useful? If not will delete that line.
2.  In text below there is a link to http://pixhawk.org/dev/circuit_breakers  that just points to the devguide. Do we need a circuitbreakers topic?

```
\src\modules\systemlib\circuit_breaker.h Line 47:
* SAFETY WARNING  --  SAFETY WARNING  --  SAFETY WARNING
 *
 * OBEY THE DOCUMENTATION FOR ALL CIRCUIT BREAKERS HERE,
 * ENSURE TO READ CAREFULLY ALL SAFETY WARNINGS.
 * http://pixhawk.org/dev/circuit_breakers
 *
 * CIRCUIT BREAKERS ARE NOT PART OF THE STANDARD OPERATION PROCEDURE
 * AND MAY DISABLE CHECKS THAT ARE VITAL FOR SAFE FLIGHT.
 */
```
