### PR TITLE
VTOL Weathervane functionality - cleaned

### DIFF
--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -87,10 +87,17 @@ VtolAttitudeControl::VtolAttitudeControl()
 	_params_handles.mpc_xy_cruise = param_find("MPC_XY_CRUISE");
 	_params_handles.fw_motors_off = param_find("VT_FW_MOT_OFFID");
 
-
 	_params_handles.wv_takeoff = param_find("VT_WV_TKO_EN");
 	_params_handles.wv_land = param_find("VT_WV_LND_EN");
 	_params_handles.wv_loiter = param_find("VT_WV_LTR_EN");
+	_params_handles.wv_auto = param_find("VT_WV_AUTO_EN");
+	_params_handles.wv_manual = param_find("VT_WV_MANUAL_EN");
+
+	_params_handles.wv_max_yaw_rate = param_find("VT_WV_MAX_Y_RATE");
+	_params_handles.wv_gain = param_find("VT_WV_GAIN");
+	_params_handles.wv_min_roll = param_find("VT_WV_MIN_ROLL");
+	_params_handles.wv_strategy = param_find("VT_WV_STRATEGY");
+
 
 	/* fetch initial parameter values */
 	parameters_update();
@@ -489,7 +496,20 @@ VtolAttitudeControl::parameters_update()
 	param_get(_params_handles.wv_land, &l);
 	_params.wv_land = (l == 1);
 
+	param_get(_params_handles.wv_manual, &l);
+	_params.wv_manual = (l == 1);
 
+	param_get(_params_handles.wv_auto, &l);
+	_params.wv_auto = (l == 1);
+
+	param_get(_params_handles.wv_max_yaw_rate, &v);
+	_params.wv_max_yaw_rate = math::radians(v);
+
+	param_get(_params_handles.wv_min_roll, &v);
+	_params.wv_min_roll = math::radians(v);
+
+	param_get(_params_handles.wv_gain, &_params.wv_gain);
+	param_get(_params_handles.wv_strategy, &_params.wv_strategy);
 	param_get(_params_handles.front_trans_duration, &_params.front_trans_duration);
 	param_get(_params_handles.back_trans_duration, &_params.back_trans_duration);
 	param_get(_params_handles.transition_airspeed, &_params.transition_airspeed);

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -202,6 +202,12 @@ private:
 		param_t front_trans_timeout;
 		param_t mpc_xy_cruise;
 		param_t fw_motors_off;
+		param_t wv_max_yaw_rate;
+		param_t wv_gain;
+		param_t wv_min_roll;
+		param_t wv_strategy;
+		param_t wv_manual;
+		param_t wv_auto;
 	} _params_handles{};
 
 	/* for multicopters it is usual to have a non-zero idle speed of the engines

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -327,3 +327,67 @@ PARAM_DEFINE_INT32(VT_WV_LND_EN, 0);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_INT32(VT_FW_MOT_OFFID, 0);
+
+/**
+ * Weather-vane mode for manual position control
+ *
+ * @boolean
+ * @group Mission
+ */
+PARAM_DEFINE_INT32(VT_WV_MANUAL_EN, 0);
+
+/**
+ * Weather-vane mode for auto mission (any waypoint in MC mode)
+ *
+ * @boolean
+ * @group Mission
+ */
+PARAM_DEFINE_INT32(VT_WV_AUTO_EN, 0);
+
+/**
+ * Weather-vane strategy
+ *
+ * @value 0 Passive
+ * @value 1 Active
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_INT32(VT_WV_STRATEGY, 0);
+
+/**
+ * Weather-vane minimum activation roll
+ *
+ * The desired roll sp from the position control to start weather-vaning.
+ *
+ * @min 0.0
+ * @max 40
+ * @increment 0.5
+ * @decimal 2
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_WV_MIN_ROLL, 1.0f);
+
+/**
+ * Weather-vane yaw rate from roll gain.
+ *
+ * The desired gain to convert roll sp into yaw rate sp.
+ *
+ * @min 0.0
+ * @max 3.0
+ * @increment 0.01
+ * @decimal 3
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_WV_GAIN, 1.0f);
+
+/**
+ * Weather-vane maximum yaw rate.
+ *
+ * The maximum yaw rate the VTOL attitude controller can output.
+ *
+ * @min 0.0
+ * @max 60.0
+ * @increment 0.5
+ * @decimal 3
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_FLOAT(VT_WV_MAX_Y_RATE, 30.0f);

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -108,6 +108,59 @@ bool VtolType::init()
 
 }
 
+
+void VtolType::set_weather_vane_yaw_rate()
+{
+	// First we set the yaw setpoint to the yaw position in order not to have any other control action influencing yaw
+	// Get euler angles
+	matrix::Dcmf R(matrix::Quatf(_v_att->q));
+	matrix::Dcmf R_sp(matrix::Quatf(_v_att_sp->q_d));
+	matrix::Eulerf euler(R);
+	matrix::Eulerf euler_sp(R_sp);
+
+	// compute the yaw error and than rotate the setpoint in a way that yaw is not compensated for
+	float yaw_error = _wrap_pi(euler_sp(2) - euler(2));
+	matrix::Dcmf R_yaw_correction = matrix::Eulerf(0.0f, 0.0f, -yaw_error);
+	matrix::Dcmf R_sp_new = R_sp * R_yaw_correction;
+
+	// save the new modified desired attitude
+	matrix::Quatf(R_sp_new).copyTo(_v_att_sp->q_d);
+
+	// adapt yaw euler angle in uorb message for backward compatibility
+	_v_att_sp->yaw_body = euler(2);
+
+	// direction of desired body z axis represented in earth frame
+	matrix::Vector3f body_z_sp(R_sp(0, 2), R_sp(1, 2), R_sp(2, 2));
+
+	// rotate desired body z axis into new frame which is rotated in z by the current
+	// heading of the vehicle. we refer to this as the heading frame.
+	matrix::Dcmf R_yaw = matrix::Eulerf(0.0f, 0.0f, -euler(2));
+	body_z_sp = R_yaw * body_z_sp;
+	body_z_sp.normalize();
+
+	float roll_sp = -asinf(body_z_sp(1));
+
+	float roll_exceeding_treshold = 0;
+
+	if (roll_sp > _params->wv_min_roll){
+		roll_exceeding_treshold = roll_sp - _params->wv_min_roll;
+
+	} else if (roll_sp < -_params->wv_min_roll){
+		roll_exceeding_treshold = roll_sp + _params->wv_min_roll;
+
+	} else {
+		_v_att_sp-> yaw_sp_move_rate = 0;
+		return;
+	}
+
+	_v_att_sp-> yaw_sp_move_rate = math::constrain(roll_exceeding_treshold * _params->wv_gain, -_params->wv_max_yaw_rate,
+				       _params->wv_max_yaw_rate);
+
+}
+
+
+
+
 void VtolType::update_mc_state()
 {
 	if (!flag_idle_mc) {
@@ -125,22 +178,45 @@ void VtolType::update_mc_state()
 	_mc_pitch_weight = 1.0f;
 	_mc_yaw_weight = 1.0f;
 
+
 	// VTOL weathervane
-	_v_att_sp->disable_mc_yaw_control = false;
+	// TODO: Add check regarding data integrity. To avoid "pitch up"-bug at start.
+	if (_v_control_mode->flag_control_manual_enabled) {
 
-	if (_attc->get_pos_sp_triplet()->current.valid &&
-	    !_v_control_mode->flag_control_manual_enabled) {
+		if (_params->wv_manual && _v_control_mode->flag_control_velocity_enabled) {
+			wv_do_strategy();
 
-		if (_params->wv_takeoff && _attc->get_pos_sp_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF) {
-			_v_att_sp->disable_mc_yaw_control = true;
+		}
+
+	} else if (_attc->get_pos_sp_triplet()->current.valid) {
+
+		if (_params->wv_auto) {
+			wv_do_strategy();
+
+		} else if (_params->wv_takeoff
+			   && _attc->get_pos_sp_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF) {
+			wv_do_strategy();
 
 		} else if (_params->wv_loiter
 			   && _attc->get_pos_sp_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER) {
-			_v_att_sp->disable_mc_yaw_control = true;
+			wv_do_strategy();
 
 		} else if (_params->wv_land && _attc->get_pos_sp_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
-			_v_att_sp->disable_mc_yaw_control = true;
+			wv_do_strategy();
 		}
+	}
+}
+
+void VtolType::wv_do_strategy()
+{
+	_v_att_sp->disable_mc_yaw_control = false;
+
+	if (_params->wv_strategy) {
+		set_weather_vane_yaw_rate();
+
+	} else {
+		_v_att_sp->disable_mc_yaw_control = true;
+
 	}
 }
 

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -61,6 +61,12 @@ struct Params {
 	bool wv_takeoff;
 	bool wv_loiter;
 	bool wv_land;
+	bool wv_manual;
+	bool wv_auto;
+	float wv_max_yaw_rate;
+	float wv_gain;
+	float wv_min_roll;
+	int32_t wv_strategy;
 	float front_trans_duration;
 	float back_trans_duration;
 	float transition_airspeed;
@@ -214,7 +220,13 @@ protected:
 	hrt_abstime _tecs_running_ts = 0;
 
 	motor_state _motor_state = motor_state::DISABLED;
+	float _wv_yaw_rate = 0;
 
+
+	/**
+	 * @brief      Apply the right weather-vane strategy depending on parameter.
+	 */
+	void wv_do_strategy();
 
 
 	/**
@@ -246,6 +258,12 @@ protected:
 	 */
 	motor_state set_motor_state(const motor_state current_state, const motor_state next_state, const int value = 0);
 
+
+	/**
+	 * @brief      Set a yaw rate value for weather vaning based on the commanded roll angle.
+	 */
+	void set_weather_vane_yaw_rate();
+
 private:
 
 
@@ -273,7 +291,6 @@ private:
 	 * @return     True if motor off channel, False otherwise.
 	 */
 	bool is_motor_off_channel(const int channel);
-
 };
 
 #endif


### PR DESCRIPTION
vtol_att_control

Orients the VTOL aircraft with the nose facing the wind.

This is done by using the (nonzero) roll setpoint necessary to stay on a fixed position to determine in which direction to turn in order to turn nose to wind. When nose is against wind only pitch/pusher will be necessary for staying in one position.

Signed-off-by: Ivo Drescher <ivo.drescher@gmail.com>

@RomanBapst @dagar