### PR TITLE
[df_ms5607_wrapper] convert to mbar, fix error_count, device_id

### DIFF
--- a/src/platforms/posix/drivers/df_ms5607_wrapper/df_ms5607_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_ms5607_wrapper/df_ms5607_wrapper.cpp
@@ -151,8 +151,10 @@ int DfMS5607Wrapper::_publish(struct baro_sensor_data &data)
 	baro_report baro_report;
 	baro_report.timestamp = hrt_absolute_time();
 
-	baro_report.pressure = data.pressure_pa;
+	baro_report.pressure = data.pressure_pa / 100.0f; // convert to mbar
 	baro_report.temperature = data.temperature_c;
+	baro_report.error_count = data.error_counter;
+	baro_report.device_id = m_id.dev_id;
 
 	// TODO: when is this ever blocked?
 	if (!(m_pub_blocked)) {


### PR DESCRIPTION
* The ms5611 and ms5607 wrappers are exactly the same so these changes also apply to ms5607: https://github.com/PX4/Firmware/pull/9721
