### PR TITLE
fmu v2 flash

### DIFF
--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -12,26 +12,34 @@ set(config_module_list
 	#drivers/magnetometer
 	#drivers/telemetry
 
-	#drivers/imu/adis16448
+	#drivers/barometer/bmp280
 	drivers/barometer/ms5611
 	#drivers/blinkm
-	#drivers/imu/bmi160
-	#drivers/barometer/bmp280
 	#drivers/bst
 	drivers/camera_trigger
+	drivers/distance_sensor/ll40ls
+	#drivers/distance_sensor/mb12xx
+	drivers/distance_sensor/sf0x
+	drivers/distance_sensor/sf1xx
+	drivers/distance_sensor/srf02
+	drivers/distance_sensor/teraranger
+	drivers/distance_sensor/tfmini
+	#drivers/distance_sensor/ulanding
 	#drivers/frsky_telemetry
 	drivers/gps
 	#drivers/hott
-	#drivers/iridiumsbd
-	#drivers/irlock
+	#drivers/imu/adis16448
+	#drivers/imu/bmi160
 	drivers/imu/l3gd20
 	drivers/imu/lsm303d
+	drivers/imu/mpu6000
+	drivers/imu/mpu9250
+	#drivers/iridiumsbd
+	#drivers/irlock
 	drivers/magnetometer/hmc5883
 	drivers/magnetometer/lis3mdl
 	#drivers/mb12xx
 	#drivers/mkblctrl
-	drivers/imu/mpu6000
-	drivers/imu/mpu9250
 	#drivers/oreoled
 	#drivers/protocol_splitter
 	drivers/pwm_input
@@ -45,16 +53,6 @@ set(config_module_list
 	drivers/stm32/tone_alarm
 	#drivers/tap_esc
 	drivers/vmount
-
-	# distance sensors
-	drivers/distance_sensor/ll40ls
-	#drivers/distance_sensor/mb12xx
-	drivers/distance_sensor/sf0x
-	drivers/distance_sensor/sf1xx
-	drivers/distance_sensor/srf02
-	drivers/distance_sensor/teraranger
-	drivers/distance_sensor/tfmini
-	#drivers/distance_sensor/ulanding
 	modules/sensors
 
 	#

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -26,7 +26,7 @@ set(config_module_list
 	drivers/distance_sensor/sf0x
 	drivers/distance_sensor/sf1xx
 	drivers/distance_sensor/srf02
-	drivers/distance_sensor/teraranger
+	#drivers/distance_sensor/teraranger
 	#drivers/distance_sensor/tfmini
 	#drivers/distance_sensor/ulanding
 	#drivers/frsky_telemetry

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -7,7 +7,7 @@ set(config_module_list
 	# Board support modules
 	#
 	#drivers/barometer
-	drivers/differential_pressure
+	#drivers/differential_pressure
 	#drivers/distance_sensor
 	#drivers/magnetometer
 	#drivers/telemetry
@@ -17,6 +17,10 @@ set(config_module_list
 	#drivers/blinkm
 	#drivers/bst
 	drivers/camera_trigger
+	#drivers/differential_pressure/ets
+	drivers/differential_pressure/ms4525
+	drivers/differential_pressure/ms5525
+	drivers/differential_pressure/sdp3x
 	drivers/distance_sensor/ll40ls
 	#drivers/distance_sensor/mb12xx
 	drivers/distance_sensor/sf0x

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -27,7 +27,7 @@ set(config_module_list
 	drivers/distance_sensor/sf1xx
 	drivers/distance_sensor/srf02
 	drivers/distance_sensor/teraranger
-	drivers/distance_sensor/tfmini
+	#drivers/distance_sensor/tfmini
 	#drivers/distance_sensor/ulanding
 	#drivers/frsky_telemetry
 	drivers/gps


### PR DESCRIPTION
This gets px4fmu-v2_default building in master again (the events rc alarm pushed it over) and leaves another 6KB free.

Should help unblock https://github.com/PX4/Firmware/pull/9270 https://github.com/PX4/Firmware/pull/9765.
