### PR TITLE
Navigator: Fix fixed-wing first order altitude hold

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1297,8 +1297,15 @@ Mission::altitude_sp_foh_update()
 		return;
 	}
 
+	// Calculate acceptance radius, i.e. the radius within which we do not perform a first order hold anymore
+	float acc_rad = _navigator->get_acceptance_radius(_mission_item.acceptance_radius);
+
+	if (pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER) {
+		acc_rad = _navigator->get_acceptance_radius(fabsf(_mission_item.loiter_radius) * 1.2f);
+	}
+
 	/* Do not try to find a solution if the last waypoint is inside the acceptance radius of the current one */
-	if (_distance_current_previous - _navigator->get_acceptance_radius(_mission_item.acceptance_radius) < FLT_EPSILON) {
+	if (_distance_current_previous - acc_rad < FLT_EPSILON) {
 		return;
 	}
 
@@ -1327,7 +1334,7 @@ Mission::altitude_sp_foh_update()
 
 	/* if the minimal distance is smaller then the acceptance radius, we should be at waypoint alt
 	 * navigator will soon switch to the next waypoint item (if there is one) as soon as we reach this altitude */
-	if (_min_current_sp_distance_xy < _navigator->get_acceptance_radius(_mission_item.acceptance_radius)) {
+	if (_min_current_sp_distance_xy < acc_rad) {
 		pos_sp_triplet->current.alt = get_absolute_altitude_for_item(_mission_item);
 
 	} else {
@@ -1337,8 +1344,7 @@ Mission::altitude_sp_foh_update()
 		 * radius around the current waypoint
 		 **/
 		float delta_alt = (get_absolute_altitude_for_item(_mission_item) - pos_sp_triplet->previous.alt);
-		float grad = -delta_alt / (_distance_current_previous - _navigator->get_acceptance_radius(
-						   _mission_item.acceptance_radius));
+		float grad = -delta_alt / (_distance_current_previous - acc_rad);
 		float a = pos_sp_triplet->previous.alt - grad * _distance_current_previous;
 		pos_sp_triplet->current.alt = a + grad * _min_current_sp_distance_xy;
 	}


### PR DESCRIPTION
**Issue**
Navigator's fixed-wing first-order altitude hold (FOH) is currently causing altitude reference oscillations when in any LOITER mode. See screenshot below. Not only altitude, but also pitch and throttle can thus oscillate significantly. We observed this during a recent test flight.

![image](https://user-images.githubusercontent.com/2565608/42387985-53c6343e-8144-11e8-86d2-a42aecc4c5c0.png)


Log file from SITL where this can be seen: https://review.px4.io/plot_app?log=f18c45ab-622e-4b1d-9819-03cfb06af2b5 . Here, after t=3:20 the true altitude setpoint is still the same as before t=2:20 (i.e. 630m AMSL) but the FOH logic just wrongly sets it to 660m and adds slight oscillations on top. The exact amount of oscillations depends on waypoint distance, altitude difference etc, but i have seen altitude ref oscillations of up to 30m, resulting in full pitch up/down of the aircraft.

**Analysis**
See the commit for the location of the code where this is happening. Essentially, every time that the loiter radius of any loiter WP is larger than the acceptance radius calculated from the L1 turn distance, then the Navigator FOH would _not_ consider the waypoint reached and would thus not stop modifying the current altitude setpoint. This leads to the oscillations or offsets in the altitude reference. 

**Solution**
If in any loiter mode, consider the loiter radius times a factor of 1.2 (same as for the waypoint_reached logic [here](https://github.com/PX4/Firmware/blob/master/src/modules/navigator/mission_block.cpp#L217) as the acceptance radius. Tested in SITL, which should be sufficient for this case.

@acfloria @ryanjAA @antiheavy FYI
@dagar Made this PR as a quick hotfix independently of your PR at https://github.com/PX4/Firmware/pull/8883/files which supposedly also fixes this but is much larger and where it is more uncertain when this would be merged.