### PR TITLE
Add terrain hold altitude control mode

### DIFF
--- a/posix-configs/SITL/init/ekf2/iris_opt_flow
+++ b/posix-configs/SITL/init/ekf2/iris_opt_flow
@@ -44,10 +44,11 @@ param set EKF2_GBIAS_INIT 0.01
 param set EKF2_ANGERR_INIT 0.01
 param set EKF2_MAG_TYPE 1
 param set EKF2_AID_MASK 2
-param set EKF2_HGT_MODE 2
+param set EKF2_HGT_MODE 0
 param set EKF2_EV_DELAY 5
 param set EKF2_EVP_NOISE 0.05
 param set EKF2_EVA_NOISE 0.05
+param set MPC_ALT_MODE 2
 replay tryapplyparams
 simulator start -s
 tone_alarm start

--- a/src/lib/FlightTasks/tasks/FlightTaskManualAltitude.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskManualAltitude.hpp
@@ -62,12 +62,16 @@ protected:
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTaskManualStabilized,
 					(ParamFloat<px4::params::MPC_HOLD_MAX_Z>) MPC_HOLD_MAX_Z,
-					(ParamInt<px4::params::MPC_ALT_MODE>) MPC_ALT_MODE
+					(ParamInt<px4::params::MPC_ALT_MODE>) MPC_ALT_MODE,
+					(ParamFloat<px4::params::MPC_ALT_MODE_SPD>) MPC_ALT_MODE_SPD,
+					(ParamFloat<px4::params::MPC_Z_P>) MPC_Z_P
 				       )
 private:
 	uint8_t _reset_counter = 0; /**< counter for estimator resets in z-direction */
 	float _max_speed_up = 10.0f;
 	float _min_speed_down = 1.0f;
+	bool _terrain_follow{false}; /**< true when the vehicle is following the terrain height */
+	bool _terrain_hold{false}; /**< true when vehicle is controlling height above a static ground position */
 
 	/**
 	 * Distance to ground during terrain following.

--- a/src/lib/FlightTasks/tasks/FlightTaskManualAltitude.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskManualAltitude.hpp
@@ -63,7 +63,7 @@ protected:
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTaskManualStabilized,
 					(ParamFloat<px4::params::MPC_HOLD_MAX_Z>) MPC_HOLD_MAX_Z,
 					(ParamInt<px4::params::MPC_ALT_MODE>) MPC_ALT_MODE,
-					(ParamFloat<px4::params::MPC_ALT_MODE_SPD>) MPC_ALT_MODE_SPD,
+					(ParamFloat<px4::params::MPC_HOLD_MAX_XY>) MPC_HOLD_MAX_XY,
 					(ParamFloat<px4::params::MPC_Z_P>) MPC_Z_P
 				       )
 private:

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1074,11 +1074,13 @@ PARAM_DEFINE_FLOAT(EKF2_MAGB_K, 0.2f);
  * If this parameter is enabled then the estimator will make use of the range finder measurements
  * to estimate it's height even if range sensor is not the primary height source. It will only do so if conditions
  * for range measurement fusion are met. This enables the range finder to be used during low speed and low altitude
- * operation. Speed and height criteria are controlled by EKF2_RNG_A_VMAX and EKF2_RNG_A_HMAX.
- * It should not be used for terrain following. It is intended to be used where a vertical takeoff and landing
- * is performed, and horizontal flight does not occur until above EKF2_RNG_A_HMAX. If vehicle motion causes
- * repeated switvhing between the rimary height sensor and range finder, an offset in the local position origin
- * can accumulate. For terrain following, it is recommended to use the MPC_ALT_MODE parameter instead.
+ * operation, eg takeoff and landing, where baro interference from rotor wash is excessive and can corrupt EKF state
+ * estimates. It is intended to be used where a vertical takeoff and landing is performed, and horizontal flight does
+ * not occur until above EKF2_RNG_A_HMAX. If vehicle motion causes repeated switching between the primary height
+ * sensor and range finder, an offset in the local position origin can accumulate. Also range finder measurements
+ * are less reliable and can experience unexpected errors. For these reasons, if accurate control of height
+ * relative to ground is required, it is recommended to use the MPC_ALT_MODE parameter instead, unless baro errors
+ * are severe enough to cause problems with landing and takeoff.
  *
  * @group EKF2
  * @value 0 Range aid disabled

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -510,8 +510,9 @@ PARAM_DEFINE_FLOAT(MPC_JERK_MIN, 1.0f);
  * with terrain height variation. Requires a distance to ground sensor. The height controller will
  * revert to using height above origin if the distance to ground estimate becomes invalid as indicated
  * by the local_position.distance_bottom_valid message being false.
- * Set to 2 to control height relative to earth frame origin when stationary and relative to ground
- * distance when moving horizontally. The speed threshold is controlled by the MPC_ALT_MODE_SPD parameter.
+ * Set to 2 to control height relative to ground (requires a distance sensor) when stationary and relative
+ * to earth frame origin when moving horizontally.
+ * The speed threshold is controlled by the MPC_ALT_MODE_SPD parameter.
  *
  * @min 0
  * @max 2

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -504,19 +504,39 @@ PARAM_DEFINE_FLOAT(MPC_JERK_MIN, 1.0f);
 /**
  * Altitude control mode.
  *
- * Set to 1 to control height above ground instead of height above origin.
- * Note: If optical flow is being used as the only source of navigation then the height above ground
- * will be selected automatically and maximum height will be limited to the value set by MPC_MAX_FLOW_HGT.
- * Note: The height controller will revert to using height above origin if the distance to ground estimate
- * becomes invalid as indicated by the local_position.distance_bottom_valid message being false.
+ * Set to 0 to control height relative to the earth frame origin. This origin may move up and down in
+ * flight due to sensor drift.
+ * Set to 1 to control height relative to estimated distance to ground. The vehicle will move up and down
+ * with terrain height variation. Requires a distance to ground sensor. The height controller will
+ * revert to using height above origin if the distance to ground estimate becomes invalid as indicated
+ * by the local_position.distance_bottom_valid message being false.
+ * Set to 2 to control height relative to earth frame origin when stationary and relative to ground
+ * distance when moving horizontally. The speed threshold is controlled by the MPC_ALT_MODE_SPD parameter.
  *
  * @min 0
- * @max 1
+ * @max 2
  * @value 0 Altitude following
  * @value 1 Terrain following
+ * @value 2 Terrain hold
  * @group Multicopter Position Control
  */
 PARAM_DEFINE_INT32(MPC_ALT_MODE, 0);
+
+/**
+ * Terrain hold speed threshold.
+ *
+ * Controls the horizontal speed threshold used when MPC_ALT_MODE = 2. When MPC_ALT_MODE = 2,
+ * the distance to ground will not be used to control height when horizontal speed is greater
+ * than MPC_ALT_MODE_SPD.
+ *
+ * @unit m/s
+ * @min 0.2
+ * @max 2.0
+ * @increment 0.1
+ * @decimal 1
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_ALT_MODE_SPD, 0.5f);
 
 /**
  * Manual control stick exponential curve sensitivity attenuation with small velocity setpoints

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -512,7 +512,7 @@ PARAM_DEFINE_FLOAT(MPC_JERK_MIN, 1.0f);
  * by the local_position.distance_bottom_valid message being false.
  * Set to 2 to control height relative to ground (requires a distance sensor) when stationary and relative
  * to earth frame origin when moving horizontally.
- * The speed threshold is controlled by the MPC_ALT_MODE_SPD parameter.
+ * The speed threshold is controlled by the MPC_HOLD_MAX_XY parameter.
  *
  * @min 0
  * @max 2
@@ -522,22 +522,6 @@ PARAM_DEFINE_FLOAT(MPC_JERK_MIN, 1.0f);
  * @group Multicopter Position Control
  */
 PARAM_DEFINE_INT32(MPC_ALT_MODE, 0);
-
-/**
- * Terrain hold speed threshold.
- *
- * Controls the horizontal speed threshold used when MPC_ALT_MODE = 2. When MPC_ALT_MODE = 2,
- * the distance to ground will not be used to control height when horizontal speed is greater
- * than MPC_ALT_MODE_SPD.
- *
- * @unit m/s
- * @min 0.2
- * @max 2.0
- * @increment 0.1
- * @decimal 1
- * @group Multicopter Position Control
- */
-PARAM_DEFINE_FLOAT(MPC_ALT_MODE_SPD, 0.5f);
 
 /**
  * Manual control stick exponential curve sensitivity attenuation with small velocity setpoints


### PR DESCRIPTION
This PR adds a height control mode that uses a ground reference when not moving horizontally and a local position datum reference when moving. An example application is when operating indoors using optical flow. The vehicle can be flown horizontally over obstacles without height increases that could cause it to to collide with overhead obstacles.

Relevant to https://github.com/PX4/Firmware/issues/9793.

The upper altitude limit has been modified so that the height error gain is consistent with control loop tuning.

This has been tested in SITL using the following branch which contains modifications to simulate baro drift and print transitions: https://github.com/priseborough/Firmware/tree/altControlMode-wip

Test log here: https://logs.px4.io/plot_app?log=05d598f6-181d-421e-a686-164225065079

Note: The upper optical flow height limit is not applied when the vehicle is moving horizontally. This behaviour can be changed, however it will cause a terrain following behaviour under some conditions if we do so.

The reason for adding this altitude control mode is that although an equivalent behaviour can be achieved via use of the EKF2_RNG_AID parameter, this should be avoided if possible. EKF2_RNG_AID was originally developed for an application where the ground effect interference from rotor wash was so severe that it affected vertical velocity estimates and safe takeoffs and landings were not possible. 

Range finders are accurate, but not reliable sensors (they can experience large random readings), the terrain under the vehicle cannot be relied on to be flat and although the EKF can handle slow drift and variation in height reference, anything more than that can cause estimation problems that go beyond the vertical position state. 

For these reasons, unless baro errors are severe, we should be meeting the requirement for accurate ground relative height control in the position controller when possible.