### PR TITLE
FrSky telemetry: add single wire mode

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -617,7 +617,7 @@ fi
 		if ver hwcmp PX4FMU_V4 PX4FMU_V4PRO MINDPX_V2
 		then
 			# This is TELEM4 on Pixhawk 3 Pro
-			frsky_telemetry start -d /dev/ttyS6
+			frsky_telemetry start -d /dev/ttyS6 -t 15
 		fi
 	fi
 

--- a/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
@@ -680,7 +680,7 @@ int frsky_telemetry_main(int argc, char *argv[])
 		frsky_task = px4_task_spawn_cmd("frsky_telemetry",
 						SCHED_DEFAULT,
 						SCHED_PRIORITY_DEFAULT + 4,
-						1268,
+						1320,
 						frsky_telemetry_thread_main,
 						(char *const *)argv);
 


### PR DESCRIPTION
S.Port FrSky telemetry is currently working via:
- Pixracer FrSky port
- [Craft and Theory inverter cable](http://www.craftandtheoryllc.com/store/ct-telemetry-cable-for-frsky-radios/)

However it does not work when using uninverted S.Port (see [here](https://oscarliang.com/uninverted-sbus-smart-port-frsky-receivers/)), and probably also with some other external inverter. To fix this, the UART needs to be put into half-duplex mode.
This PR adds another scanning state to automatically detect that. It allows for example to use telemetry on the Omnibus board without additional chips.

I tested the following configurations:
- S.Port via Pixracer FrSky port
- DType via Pixracer FrSky port
- S.Port via Omnibus on UART6 via [uninverted signal](https://oscarliang.com/uninverted-sbus-smart-port-frsky-receivers/) (connecting both RX & TX)
- S.Port via Pixhawk and an inverter cable on Telem2

In addition this does:
- some code cleanup
- add a scanning timeout of 15 seconds. After that the task exits to free up RAM