### PR TITLE
fw: add takeoff flaps setting

### DIFF
--- a/msg/vehicle_attitude_setpoint.msg
+++ b/msg/vehicle_attitude_setpoint.msg
@@ -20,7 +20,7 @@ bool yaw_reset_integral				# Reset yaw integral part (navigation logic change)
 bool fw_control_yaw					# control heading with rudder (used for auto takeoff on runway)
 bool disable_mc_yaw_control			# control yaw for mc (used for vtol weather-vane mode)
 
-bool apply_flaps
+int8 apply_flaps      # 0 = no flaps, 1 = landing flaps setting, 2 = take-off flaps setting
 
 float32 landing_gear
 

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.hpp
@@ -196,6 +196,7 @@ private:
 		float acro_max_z_rate_rad;
 
 		float flaps_scale;				/**< Scale factor for flaps */
+		float flaps_takeoff_scale; /**< Scale factor for flaps on take-off */
 		float flaperon_scale;			/**< Scale factor for flaperons */
 
 		float rattitude_thres;
@@ -264,6 +265,7 @@ private:
 		param_t acro_max_z_rate;
 
 		param_t flaps_scale;
+		param_t flaps_takeoff_scale;
 		param_t flaperon_scale;
 
 		param_t rattitude_thres;

--- a/src/modules/fw_att_control/fw_att_control_params.c
+++ b/src/modules/fw_att_control/fw_att_control_params.c
@@ -486,6 +486,20 @@ PARAM_DEFINE_FLOAT(FW_MAN_P_MAX, 45.0f);
 PARAM_DEFINE_FLOAT(FW_FLAPS_SCL, 1.0f);
 
 /**
+ * Flaps setting during take-off
+ *
+ * Sets a fraction of full flaps (FW_FLAPS_SCL) during take-off
+ *
+ * @unit norm
+ * @min 0.0
+ * @max 1.0
+ * @decimal 2
+ * @increment 0.01
+ * @group FW Attitude Control
+ */
+PARAM_DEFINE_FLOAT(FW_FLAPS_TO_SCL, 0.0f);
+
+/**
  * Scale factor for flaperons
  *
  * @unit norm

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -704,7 +704,7 @@ FixedwingPositionControl::control_position(const Vector2f &curr_pos, const Vecto
 	bool setpoint = true;
 
 	_att_sp.fw_control_yaw = false;		// by default we don't want yaw to be contoller directly with rudder
-	_att_sp.apply_flaps = false;		// by default we don't use flaps
+	_att_sp.apply_flaps = 0;		// by default we don't use flaps
 
 	calculate_gndspeed_undershoot(curr_pos, ground_speed, pos_sp_prev, pos_sp_curr);
 
@@ -1137,6 +1137,10 @@ FixedwingPositionControl::control_takeoff(const Vector2f &curr_pos, const Vector
 		prev_wp(1) = (float)pos_sp_curr.lon;
 	}
 
+	// apply flaps for takeoff according to the corresponding scale factor set
+	// via FW_FLAPS_TO_SCL
+	_att_sp.apply_flaps = 2;
+
 	// continuously reset launch detection and runway takeoff until armed
 	if (!_control_mode.flag_armed) {
 		_launchDetector.reset();
@@ -1305,7 +1309,7 @@ FixedwingPositionControl::control_landing(const Vector2f &curr_pos, const Vector
 
 	// apply full flaps for landings. this flag will also trigger the use of flaperons
 	// if they have been enabled using the corresponding parameter
-	_att_sp.apply_flaps = true;
+	_att_sp.apply_flaps = 1;
 
 	// save time at which we started landing and reset abort_landing
 	if (_time_started_landing == 0) {


### PR DESCRIPTION
**Issue**: currently no flaps are applied during auto-take-off.

**Solution**: add take-off specific flaps scale to enable some percentage of full flaps during take-off.

**Description**: Adds an extra parameter for scaling the given flap allowance for a specific take-off configuration. I.e., the FW_FLAPS_TO_SCL is actually scaling the FW_FLAPS_SCL value -- maybe slightly confusing, but I wasn't sure if there was a better way to add this without people needing to change their current flaps param settings.

**Structural changes**: I changed the apply flaps bool in uorb vehicle_attitude_setpoint to an int8 with 0=no flaps, 1=landing flaps, and 2=takeoff flaps configs. This way the position controller could pass the different options to the attitude controller. Currently, the flaperon functionality is unaffected by this -- but if any flaperon users want to include flaperons in the take-off, it could also be added with a similar extra param.

**HITL logs**: see https://review.px4.io/plot_app?log=3a43d493-6575-4908-9db6-54de352bed27 . I noticed the flaperon signal on that log for some reason doesnt show up in the flight review -- maybe I missed an output designation or mapping in the params, but I confirmed that the actuator_control_target0 output for sure got there after converting the logs --  see below:
![flaps_flaperons_takeoff-flaps](https://user-images.githubusercontent.com/8026163/42421538-702c2a0e-82d7-11e8-981c-395e3b6741ae.png)


There are several ways to approach this, the present implementation only one of those. Open to discussion on this. @philipoe @dagar @Antiheavy @ryanjAA