### PR TITLE
Update ADC voltage calculation instances to avoid divide by integer.

### DIFF
--- a/src/drivers/kinetis/adc/adc.cpp
+++ b/src/drivers/kinetis/adc/adc.cpp
@@ -376,7 +376,7 @@ ADC::update_system_power(hrt_abstime now)
 
 		if (_samples[i].am_channel == ADC_5V_RAIL_SENSE) {
 			// it is 2:1 scaled
-			system_power.voltage5V_v = _samples[i].am_data * (6.6f / 4096);
+			system_power.voltage5V_v = _samples[i].am_data * (6.6f / 4096.0f);
 		}
 	}
 

--- a/src/drivers/samv7/adc/adc.cpp
+++ b/src/drivers/samv7/adc/adc.cpp
@@ -324,7 +324,7 @@ ADC::update_system_power(void)
 	for (unsigned i = 0; i < _channel_count; i++) {
 		if (_samples[i].am_channel == 4) {
 			// it is 2:1 scaled
-			system_power.voltage5V_v = _samples[i].am_data * (6.6f / 4096);
+			system_power.voltage5V_v = _samples[i].am_data * (6.6f / 4096.0f);
 		}
 	}
 

--- a/src/drivers/stm32/adc/adc.cpp
+++ b/src/drivers/stm32/adc/adc.cpp
@@ -281,6 +281,7 @@ int board_adc_init()
 
 	return OK;
 }
+
 int
 ADC::init()
 {
@@ -401,7 +402,7 @@ ADC::update_system_power(hrt_abstime now)
 
 		if (_samples[i].am_channel == ADC_SCALED_V5_SENSE) {
 			// it is 2:1 scaled
-			system_power.voltage5V_v = _samples[i].am_data * (ADC_V5_V_FULL_SCALE / 4096);
+			system_power.voltage5V_v = _samples[i].am_data * (ADC_V5_V_FULL_SCALE / 4096.0f);
 			cnt--;
 
 		} else


### PR DESCRIPTION
Hello,

This PR modifies instances of ADC 5V voltage computation to divide by float rather than the current divide by integer.  Other instances that I have located are already divide by float, these are the only instances I could locate that were divide by int.

Please let me know if you have any questions on this PR!

-Mark