### PR TITLE
Proposal: move NuttX back to PX4 organization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -48,11 +48,11 @@
 	branch = master
 [submodule "platforms/nuttx/NuttX/nuttx"]
 	path = platforms/nuttx/NuttX/nuttx
-	url = https://github.com/PX4-NuttX/nuttx.git
+	url = https://github.com/PX4/NuttX.git
 	branch = px4_firmware_nuttx-7.22+
 [submodule "platforms/nuttx/NuttX/apps"]
 	path = platforms/nuttx/NuttX/apps
-	url = https://github.com/PX4-NuttX/apps.git
+	url = https://github.com/PX4/NuttX-apps.git
 	branch = px4_firmware_nuttx-7.22+
 [submodule "cmake/configs/uavcan_board_ident"]
 	path = cmake/configs/uavcan_board_ident


### PR DESCRIPTION
The PX4 NuttX fork + patches currently reside in the separate PX4-NuttX organization. There's nothing inherently wrong with this, but due to the history of the original PX4/NuttX it's causing minor confusion semi-regularly. The older project is still being forked and cloned (look at the stats under Insights) and on multiple occasions I've come across people with the impression that we're stalled on an ancient fork of NuttX. There are also minor issues relating to org ownership (cross org github project board) and permissions (both devs and CI).

They still share a common base, so keeping the old legacy master as a branch with the new NuttX repo only adds around 10% to the size of NuttX git on disk.

Overall I think these fairly minor issues/annoyances still justify moving back, but perhaps more importantly I don't really see a reason not to.