### PR TITLE
Add omitted airframe config files in CMakeLists.txt and standardize param orders across config files.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/1002_standard_vtol.hil
+++ b/ROMFS/px4fmu_common/init.d/1002_standard_vtol.hil
@@ -57,6 +57,7 @@ then
 fi
 
 set MIXER standard_vtol_hitl
+
 set MAV_TYPE 22
 
 set PWM_OUT 1234

--- a/ROMFS/px4fmu_common/init.d/13002_firefly6
+++ b/ROMFS/px4fmu_common/init.d/13002_firefly6
@@ -49,10 +49,10 @@ then
 	param set VT_TYPE 1
 fi
 
-set MIXER firefly6
-set PWM_OUT 12345678
-set PWM_RATE 400
+set MAV_TYPE 21
 
+set MIXER firefly6
 set MIXER_AUX firefly6
 
-set MAV_TYPE 21
+set PWM_OUT 12345678
+set PWM_RATE 400

--- a/ROMFS/px4fmu_common/init.d/13003_quad_tailsitter
+++ b/ROMFS/px4fmu_common/init.d/13003_quad_tailsitter
@@ -18,9 +18,10 @@ then
 	param set VT_ELEV_MC_LOCK 1
 fi
 
+set MAV_TYPE 20
+
 set MIXER quad_x_vtol
 
 set PWM_OUT 1234
 set PWM_MAX 2000
 set PWM_RATE 400
-set MAV_TYPE 20

--- a/ROMFS/px4fmu_common/init.d/13004_quad+_tailsitter
+++ b/ROMFS/px4fmu_common/init.d/13004_quad+_tailsitter
@@ -29,9 +29,10 @@ then
 	param set VT_ELEV_MC_LOCK 1
 fi
 
+set MAV_TYPE 20
+
 set MIXER quad_+_vtol
 
 set PWM_OUT 1234
 set PWM_MAX 2000
 set PWM_RATE 400
-set MAV_TYPE 20

--- a/ROMFS/px4fmu_common/init.d/13005_vtol_AAERT_quad
+++ b/ROMFS/px4fmu_common/init.d/13005_vtol_AAERT_quad
@@ -62,12 +62,13 @@ then
 	param set VT_TYPE 2
 fi
 
+set MAV_TYPE 22
+
 set MIXER quad_x
+set MIXER_AUX vtol_AAERT
+
 set PWM_OUT 1234
 set PWM_RATE 400
 
-set MIXER_AUX vtol_AAERT
 set PWM_ACHDIS 5
 set PWM_AUX_DISARMED 950
-
-set MAV_TYPE 22

--- a/ROMFS/px4fmu_common/init.d/13006_vtol_standard_delta
+++ b/ROMFS/px4fmu_common/init.d/13006_vtol_standard_delta
@@ -52,12 +52,13 @@ then
 	param set VT_TYPE 2
 fi
 
+set MAV_TYPE 22
+
 set MIXER quad_x
+set MIXER_AUX vtol_delta
+
 set PWM_OUT 1234
 set PWM_RATE 400
 
-set MIXER_AUX vtol_delta
 set PWM_ACHDIS 3
 set PWM_AUX_DISARMED 950
-
-set MAV_TYPE 22

--- a/ROMFS/px4fmu_common/init.d/13007_vtol_AAVVT_quad
+++ b/ROMFS/px4fmu_common/init.d/13007_vtol_AAVVT_quad
@@ -40,12 +40,13 @@ then
 	param set VT_TYPE 2
 fi
 
+set MAV_TYPE 22
+
 set MIXER quad_x
+set MIXER_AUX vtol_AAVVT
+
 set PWM_OUT 1234
 set PWM_RATE 400
 
-set MIXER_AUX vtol_AAVVT
 set PWM_ACHDIS 5
 set PWM_AUX_DISARMED 950
-
-set MAV_TYPE 22

--- a/ROMFS/px4fmu_common/init.d/13008_QuadRanger
+++ b/ROMFS/px4fmu_common/init.d/13008_QuadRanger
@@ -60,12 +60,13 @@ then
 	param set VT_TYPE 2
 fi
 
+set MAV_TYPE 22
+
 set MIXER quad_x
+set MIXER_AUX vtol_AAERT
+
 set PWM_OUT 1234
 set PWM_RATE 400
 
-set MIXER_AUX vtol_AAERT
 set PWM_ACHDIS 5
 set PWM_AUX_DISARMED 950
-
-set MAV_TYPE 22

--- a/ROMFS/px4fmu_common/init.d/13009_vtol_spt_ranger
+++ b/ROMFS/px4fmu_common/init.d/13009_vtol_spt_ranger
@@ -76,12 +76,13 @@ then
 	param set PWM_AUX_REV4    1
 fi
 
+set MAV_TYPE 22
+
 set MIXER quad_x
+set MIXER_AUX vtol_AAERT
+
 set PWM_OUT 1234
 set PWM_RATE 400
 
-set MIXER_AUX vtol_AAERT
 set PWM_ACHDIS 5
 set PWM_AUX_DISARMED 950
-
-set MAV_TYPE 22

--- a/ROMFS/px4fmu_common/init.d/13010_claire
+++ b/ROMFS/px4fmu_common/init.d/13010_claire
@@ -14,27 +14,28 @@ sh /etc/init.d/rc.vtol_defaults
 
 if [ $AUTOCNF == yes ]
 then
-param set VT_TYPE 1
-param set VT_TILT_MC 0.08
-param set VT_TILT_TRANS 0.5
-param set VT_TILT_FW 0.9
+	param set VT_TYPE 1
+	param set VT_TILT_MC 0.08
+	param set VT_TILT_TRANS 0.5
+	param set VT_TILT_FW 0.9
 
-param set VT_MOT_COUNT 4
-param set VT_FW_MOT_OFFID 13
-param set VT_IDLE_PWM_MC 1080
-param set VT_TYPE 1
+	param set VT_MOT_COUNT 4
+	param set VT_FW_MOT_OFFID 13
+	param set VT_IDLE_PWM_MC 1080
+	param set VT_TYPE 1
 fi
 
+set MAV_TYPE 21
+
 set MIXER claire
+set MIXER_AUX claire
+
 set PWM_OUT 1234
 set PWM_RATE 400
 set PWM_MAX 2000
 
-set MIXER_AUX claire
 set PWM_AUX_RATE 50
 set PWM_AUX_RATE 123
 set PWM_AUX_MIN 1000
 set PWM_AUX_MAX 2000
 set PWM_AUX_DISARMED 1000
-
-set MAV_TYPE 21

--- a/ROMFS/px4fmu_common/init.d/13012_convergence
+++ b/ROMFS/px4fmu_common/init.d/13012_convergence
@@ -76,8 +76,9 @@ then
 	param set SENS_BOARD_ROT 8
 fi
 
+set MAV_TYPE 21
+
 set MIXER vtol_convergence
+
 set PWM_OUT 1234
 set PWM_RATE 400
-
-set MAV_TYPE 21

--- a/ROMFS/px4fmu_common/init.d/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/13013_deltaquad
@@ -140,17 +140,18 @@ then
 	param set SENS_BOARD_ROT 18
 fi
 
+set MAV_TYPE 22
+
 set MIXER deltaquad
+set MIXER_AUX pass
+
 set PWM_OUT 1234
 set PWM_RATE 400
+
+set PWM_AUX_OUT 12345
+set PWM_AUX_DISARMED 950
 
 param set PWM_MAIN_DIS5 1500
 param set PWM_MAIN_DIS6 1500
 param set PWM_MAIN_DIS7 900
 param set PWM_MAIN_DIS8 900
-
-set MIXER_AUX pass
-set PWM_AUX_OUT 12345
-set PWM_AUX_DISARMED 950
-
-set MAV_TYPE 22

--- a/ROMFS/px4fmu_common/init.d/16001_helicopter
+++ b/ROMFS/px4fmu_common/init.d/16001_helicopter
@@ -16,13 +16,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-# Configure as helicopter (number 4 defined in commander_helper.cpp)
-set MAV_TYPE 4
-
-set MIXER blade130
-
-#set PWM_OUT 1234
-
 if [ $AUTOCNF == yes ]
 then
 	param set MC_ROLL_P 5.0
@@ -55,3 +48,10 @@ then
 
 	param set CBRK_IO_SAFETY 22027
 fi
+
+# Configure as helicopter (number 4 defined in commander_helper.cpp)
+set MAV_TYPE 4
+
+set MIXER blade130
+
+#set PWM_OUT 1234

--- a/ROMFS/px4fmu_common/init.d/24001_dodeca_cox
+++ b/ROMFS/px4fmu_common/init.d/24001_dodeca_cox
@@ -37,15 +37,15 @@ then
 	param set RTL_LAND_DELAY 0
 fi
 
-set PWM_AUX_RATE 400
-# Note: May Have to set these parameters manually. They don't appear to save.
-set PWM_AUX_DISARMED 900
-param set PWM_AUX_MIN 1075
-param set PWM_AUX_MAX 1950
-
 set MIXER dodeca_top_cox
 set MIXER_AUX dodeca_bottom_cox
 
 # Need to set all 8 channels
 set PWM_OUT 12345678
 set PWM_AUX_OUT 123456
+set PWM_AUX_RATE 400
+set PWM_AUX_DISARMED 900
+
+# Note: May Have to set these parameters manually. They don't appear to save.
+param set PWM_AUX_MIN 1075
+param set PWM_AUX_MAX 1950

--- a/ROMFS/px4fmu_common/init.d/3033_wingwing
+++ b/ROMFS/px4fmu_common/init.d/3033_wingwing
@@ -43,8 +43,10 @@ fi
 
 # Configure this as plane
 set MAV_TYPE 1
+
 # Set mixer
 set MIXER wingwing
+
 # Provide ESC a constant 1000 us pulse
 set PWM_OUT 4
 set PWM_DISARMED 1000

--- a/ROMFS/px4fmu_common/init.d/3100_tbs_caipirinha
+++ b/ROMFS/px4fmu_common/init.d/3100_tbs_caipirinha
@@ -53,4 +53,5 @@ then
 fi
 
 set MIXER caipi
+
 set PWM_OUT 1234

--- a/ROMFS/px4fmu_common/init.d/4002_quad_x_mount
+++ b/ROMFS/px4fmu_common/init.d/4002_quad_x_mount
@@ -23,8 +23,8 @@
 sh /etc/init.d/rc.mc_defaults
 
 set MIXER quad_x
-set PWM_OUT 1234
-
 set MIXER_AUX mount
+
+set PWM_OUT 1234
 set PWM_AUX_OUT 123456
 set PWM_AUX_RATE 50

--- a/ROMFS/px4fmu_common/init.d/4013_bebop
+++ b/ROMFS/px4fmu_common/init.d/4013_bebop
@@ -38,6 +38,6 @@ then
 	param set MC_YAW_FF 0.7
 fi
 
+set MIXER bebop
 set OUTPUT_MODE bebop
 set USE_IO no
-set MIXER bebop

--- a/ROMFS/px4fmu_common/init.d/4030_3dr_solo
+++ b/ROMFS/px4fmu_common/init.d/4030_3dr_solo
@@ -87,9 +87,9 @@ then
 fi
 
 set MIXER quad_x
+set MIXER_AUX none
 
 set PWM_OUT 1234
-set MIXER_AUX none
 
 # enable high-speed link on telem 1
 set MAVLINK_F "-d /dev/ttyS1 -b 921600 -r 80000 -m onboard -x"

--- a/ROMFS/px4fmu_common/init.d/4040_reaper
+++ b/ROMFS/px4fmu_common/init.d/4040_reaper
@@ -39,10 +39,10 @@ then
 fi
 
 set MIXER quad_h
-
-set PWM_RATE 50
-set PWM_OUT 1234
-
 set MIXER_AUX pass
-set PWM_AUX_RATE 50
+
+set PWM_OUT 1234
+set PWM_RATE 50
+
 set PWM_AUX_OUT 1234
+set PWM_AUX_RATE 50

--- a/ROMFS/px4fmu_common/init.d/4051_s250aq
+++ b/ROMFS/px4fmu_common/init.d/4051_s250aq
@@ -21,11 +21,6 @@
 
 sh /etc/init.d/rc.mc_defaults
 
-set MIXER quad_s250aq
-set MAV_TYPE 2
-
-set PWM_OUT 1234
-
 if [ $AUTOCNF == yes ]
 then
 	param set MC_ROLL_P 8.0
@@ -63,3 +58,9 @@ then
 
 	param set CBRK_IO_SAFETY 22027
 fi
+
+set MAV_TYPE 2
+
+set MIXER quad_s250aq
+
+set PWM_OUT 1234

--- a/ROMFS/px4fmu_common/init.d/4070_aerofc
+++ b/ROMFS/px4fmu_common/init.d/4070_aerofc
@@ -70,14 +70,13 @@ fi
 
 if param compare SYS_HITL 0
 then
-  tap_esc start -d /dev/ttyS0 -n 4
-  usleep 300000
-
-  set OUTPUT_MODE tap_esc
+	tap_esc start -d /dev/ttyS0 -n 4
+	usleep 300000
+	set OUTPUT_MODE tap_esc
 fi
 
+set MAVLINK_COMPANION_DEVICE /dev/ttyS1
 set MIXER quad_x
 set USE_IO no
 
 param set SYS_COMPANION 921600
-set MAVLINK_COMPANION_DEVICE /dev/ttyS1

--- a/ROMFS/px4fmu_common/init.d/4100_tiltquadrotor
+++ b/ROMFS/px4fmu_common/init.d/4100_tiltquadrotor
@@ -24,7 +24,6 @@ sh /etc/init.d/rc.mc_defaults
 #Parameters here:
 param set LED_RGB_MAXBRT 8
 
-
 # Configure this as Quadrotor
 # set MAV_TYPE 14
 

--- a/ROMFS/px4fmu_common/init.d/4900_crazyflie
+++ b/ROMFS/px4fmu_common/init.d/4900_crazyflie
@@ -58,6 +58,7 @@ then
 	param set NAV_RCL_ACT 3
 	param set SENS_FLOW_MINRNG 0.05
 fi
+
 set PWM_MIN none
 set PWM_MAX none
 set PWM_DISARMED none

--- a/ROMFS/px4fmu_common/init.d/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/CMakeLists.txt
@@ -34,6 +34,7 @@
 px4_add_romfs_files(
 	1000_rc_fw_easystar.hil
 	1001_rc_quad_x.hil
+	1002_standard_vtol.hil
 	2100_standard_plane
 	2105_maja
 	2106_albatross
@@ -67,6 +68,7 @@ px4_add_romfs_files(
 	4070_aerofc
 	4080_zmr250
 	4090_nanomind
+	4100_tiltquadrotor
 	4900_crazyflie
 	5001_quad_+
 	6001_hexa_x

--- a/ROMFS/px4fmu_common/init.d/rc.thermal_cal
+++ b/ROMFS/px4fmu_common/init.d/rc.thermal_cal
@@ -5,7 +5,7 @@
 # NOTE: Script variables are declared/initialized/unset in the rcS script.
 #
 
-set TEMP_CALIB_ARGS	""
+set TEMP_CALIB_ARGS ""
 
 #
 # Determine if a thermal calibration should be started.


### PR DESCRIPTION
Hi,

This PR updates CMakeLists.txt file to include omitted config files and alphabetizes/groups paramters in the config files. Hardware testing completed on stock pixracer and custom hardware (px4fmu-v4).

Let me know if you have any questions.  Thanks!

-Mark

