### PR TITLE
Breakout rc.mavlink from rcS script.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/CMakeLists.txt
@@ -107,13 +107,14 @@ px4_add_romfs_files(
 	rc.interface
 	rc.io
 	rc.logging
+	rc.mavlink
 	rc.mc_apps
 	rc.mc_defaults
-	rcS
 	rc.sensors
 	rc.thermal_cal
 	rc.ugv_apps
 	rc.ugv_defaults
 	rc.vtol_apps
 	rc.vtol_defaults
+	rcS
 )

--- a/ROMFS/px4fmu_common/init.d/rc.mavlink
+++ b/ROMFS/px4fmu_common/init.d/rc.mavlink
@@ -1,0 +1,218 @@
+#!nsh
+#
+# MAVLINK stream startup script.
+#
+# NOTE: Script variables are declared/initialized/unset in the rcS script.
+#
+# NOTE: Normal mode uses baud rate of 57600 (default) and data rate of 1000 bytes/s.
+#
+#------------------------------------------------------------------------------
+#
+# UART mapping on FMUv2/3/4:
+#
+# UART1         /dev/ttyS0      IO debug (except v4, there ttyS0 is the wifi)
+# USART2        /dev/ttyS1      TELEM1 (flow control)
+# USART3        /dev/ttyS2      TELEM2 (flow control)
+# UART4
+# UART7                         CONSOLE
+# UART8                         SERIAL4
+#
+#------------------------------------------------------------------------------
+#
+# UART mapping on FMUv5:
+#
+# UART1         /dev/ttyS0      GPS
+# USART2        /dev/ttyS1      TELEM1 (flow control)
+# USART3        /dev/ttyS2      TELEM2 (flow control)
+# UART4         /dev/ttyS3      TELEM4
+# USART6        /dev/ttyS4      TELEM3 (flow control)
+# UART7         /dev/ttyS5
+# UART8         /dev/ttyS6      CONSOLE
+#
+#------------------------------------------------------------------------------
+#
+# UART mapping on OMNIBUSF4SD:
+#
+# USART1        /dev/ttyS0      SerialRX
+# USART4        /dev/ttyS1      TELEM1
+# USART6        /dev/ttyS2      GPS
+#
+
+
+
+if [ $MAVLINK_F == default ]
+then
+	# Normal mode, use baudrate 57600 (default) and data rate 1000 bytes/s
+	set MAVLINK_F "-r 1200 -f"
+
+	if ver hwcmp AEROFC_V1
+	then
+		set MAVLINK_F "-r 1200 -d /dev/ttyS3"
+
+		# Only start mavlink if the Benewake TFMini or LeddarOne isn't being used
+		if param greater SENS_EN_TFMINI 0
+		then
+			set MAVLINK_F none
+		fi
+		if param greater SENS_EN_LEDDAR1 0
+		then
+			set MAVLINK_F none
+		fi
+	fi
+
+	# Use ttyS1 for MAVLink on FMUv4 in addition to ttyS0 (debug)
+	if ver hwcmp PX4FMU_V4
+	then
+		set MAVLINK_F "-r 1200 -d /dev/ttyS1"
+		# Start MAVLink on Wifi (ESP8266 port)
+		mavlink start -r 20000 -b 921600 -d /dev/ttyS0
+	fi
+
+	# Use ttyS3 (TELEM4) for MAVLink on FMUv5 in addition to ttyS1 (TELEM1) and ttyS2 (TELEM2)
+	if ver hwcmp PX4FMU_V5
+	then
+		mavlink start -r 2000 -b 57600 -d /dev/ttyS3
+	fi
+
+	if ver hwcmp CRAZYFLIE OMNIBUS_F4SD
+	then
+		# Avoid using either of the two available serials
+		set MAVLINK_F none
+	fi
+fi
+
+if [ "x$MAVLINK_F" == xnone ]
+then
+else
+	mavlink start ${MAVLINK_F}
+fi
+
+#
+# MAVLink onboard / TELEM2
+#
+# XXX We need a better way for runtime eval of shell variables,
+# but this works for now
+if param compare SYS_COMPANION 10
+then
+	frsky_telemetry start -d ${MAVLINK_COMPANION_DEVICE}
+else
+	if ver hwcmp PX4FMU_V4 PX4FMU_V4PRO MINDPX_V2
+	then
+		# This is TELEM4 on Pixhawk 3 Pro
+		frsky_telemetry start -d /dev/ttyS6 -t 15
+	fi
+fi
+
+if param compare SYS_COMPANION 20
+then
+	syslink start
+	mavlink start -d /dev/bridge0 -b 57600 -m osd -r 40000
+fi
+
+#
+# 19200 Baud Rate.
+#
+if param compare SYS_COMPANION 319200
+then
+	mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 19200 -r 1000 -f
+fi
+if param compare SYS_COMPANION 419200
+then
+	iridiumsbd start -d ${MAVLINK_COMPANION_DEVICE}
+	mavlink start -d /dev/iridium -b 19200 -m iridium -r 10
+fi
+if param compare SYS_COMPANION 519200
+then
+	mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 19200 -m minimal -r 1000
+fi
+
+#
+# 38400 Baud Rate.
+#
+if param compare SYS_COMPANION 338400
+then
+	mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 38400 -r 1000 -f
+fi
+if param compare SYS_COMPANION 538400
+then
+	mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 38400 -m minimal -r 1000
+fi
+
+#
+# 57600 Baud Rate.
+#
+if param compare SYS_COMPANION 57600
+then
+	mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 57600 -m onboard -r 5000 -x -f
+fi
+if param compare SYS_COMPANION 157600
+then
+	mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 57600 -m osd -r 1000
+fi
+if param compare SYS_COMPANION 257600
+then
+	mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 57600 -m magic -r 5000 -x -f
+fi
+if param compare SYS_COMPANION 357600
+then
+	mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 57600 -r 1000 -f
+fi
+if param compare SYS_COMPANION 557600
+then
+	mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 57600 -m minimal -r 1000
+fi
+
+#
+# 115200 Baud Rate.
+#
+if param compare SYS_COMPANION 3115200
+then
+	mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 115200 -r 1000 -f
+fi
+if param compare SYS_COMPANION 5115200
+then
+	mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 115200 -m minimal -r 1000
+fi
+
+#
+# 460800 Baud Rate.
+#
+if param compare SYS_COMPANION 460800
+then
+	mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 460800 -m onboard -r 5000 -x -f
+fi
+if param compare SYS_COMPANION 6460800
+then
+	micrortps_client start -t UART -d /dev/ttyS2 -b 460800
+fi
+
+#
+# 921600 Baud Rate.
+#
+if param compare SYS_COMPANION 921600
+then
+	if ver hwcmp AEROFC_V1
+	then
+		if protocol_splitter start ${MAVLINK_COMPANION_DEVICE}
+		then
+			mavlink start -d /dev/mavlink -b 921600 -m onboard -r 5000 -x
+			micrortps_client start -d /dev/rtps -b 921600 -l -1 -s 2000
+		else
+			mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 921600 -m onboard -r 80000 -x -f
+		fi
+	else
+		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 921600 -m onboard -r 80000 -x -f
+	fi
+fi
+if param compare SYS_COMPANION 1921600
+then
+	mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 921600 -r 20000
+fi
+
+#
+# 1500000 Baud Rate.
+#
+if param compare SYS_COMPANION 1500000
+then
+	mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 1500000 -m onboard -r 10000 -x -f
+fi

--- a/ROMFS/px4fmu_common/init.d/rc.thermal_cal
+++ b/ROMFS/px4fmu_common/init.d/rc.thermal_cal
@@ -5,7 +5,7 @@
 # NOTE: Script variables are declared/initialized/unset in the rcS script.
 #
 
-set TEMP_CALIB_ARGS	""
+set TEMP_CALIB_ARGS ""
 
 #
 # Determine if a thermal calibration should be started.

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -13,31 +13,6 @@ set +e
 #
 # NOTE: COMMENT LINES ARE REMOVED BEFORE STORED IN ROMFS.
 #
-# UART mapping on OMNIBUSF4SD:
-#
-# USART1                /dev/ttyS0              SerialRX
-# USART4                /dev/ttyS1              TELEM1
-# USART6                /dev/ttyS2              GPS
-#
-# UART mapping on FMUv2/3/4:
-#
-# UART1                 /dev/ttyS0              IO debug (except v4, there ttyS0 is the wifi)
-# USART2                /dev/ttyS1              TELEM1 (flow control)
-# USART3                /dev/ttyS2              TELEM2 (flow control)
-# UART4
-# UART7                                                 CONSOLE
-# UART8                                                 SERIAL4
-#
-#
-# UART mapping on FMUv5:
-#
-# UART1                 /dev/ttyS0              GPS
-# USART2                /dev/ttyS1              TELEM1 (flow control)
-# USART3                /dev/ttyS2              TELEM2 (flow control)
-# UART4                 /dev/ttyS3              TELEM4
-# USART6                /dev/ttyS4              TELEM3 (flow control)
-# UART7                 /dev/ttyS5              ?
-# UART8                 /dev/ttyS6              CONSOLE
 
 #
 # Set default paramter values
@@ -549,154 +524,10 @@ then
 		fi
 	fi
 
-	if [ $MAVLINK_F == default ]
-	then
-		# Normal mode, use baudrate 57600 (default) and data rate 1000 bytes/s
-		set MAVLINK_F "-r 1200 -f"
-
-		# Use ttyS1 for MAVLink on FMUv4 in addition to ttyS0 (debug)
-		if ver hwcmp PX4FMU_V4
-		then
-			set MAVLINK_F "-r 1200 -d /dev/ttyS1"
-			# Start MAVLink on Wifi (ESP8266 port)
-			mavlink start -r 20000 -b 921600 -d /dev/ttyS0
-		fi
-
-		# Use ttyS3 (TELEM4) for MAVLink on FMUv5 in addition to ttyS1 (TELEM1) and ttyS2 (TELEM2)
-		if ver hwcmp PX4FMU_V5
-		then
-			mavlink start -r 2000 -b 57600 -d /dev/ttyS3
-		fi
-
-		if ver hwcmp AEROFC_V1
-		then
-			set MAVLINK_F "-r 1200 -d /dev/ttyS3"
-
-			# Only start mavlink if the Benewake TFMini or LeddarOne isn't being used
-			if param greater SENS_EN_TFMINI 0
-			then
-				set MAVLINK_F none
-			fi
-			if param greater SENS_EN_LEDDAR1 0
-			then
-				set MAVLINK_F none
-			fi
-		fi
-
-		if ver hwcmp CRAZYFLIE OMNIBUS_F4SD
-		then
-			# Avoid using either of the two available serials
-			set MAVLINK_F none
-		fi
-	fi
-
-	if [ "x$MAVLINK_F" == xnone ]
-	then
-	else
-		mavlink start ${MAVLINK_F}
-	fi
-
 	#
-	# MAVLink onboard / TELEM2
+	# Start mavlink streams.
 	#
-	# XXX We need a better way for runtime eval of shell variables,
-	# but this works for now
-	if param compare SYS_COMPANION 10
-	then
-		frsky_telemetry start -d ${MAVLINK_COMPANION_DEVICE}
-	else
-		if ver hwcmp PX4FMU_V4 PX4FMU_V4PRO MINDPX_V2
-		then
-			# This is TELEM4 on Pixhawk 3 Pro
-			frsky_telemetry start -d /dev/ttyS6 -t 15
-		fi
-	fi
-
-	if param compare SYS_COMPANION 20
-	then
-		syslink start
-		mavlink start -d /dev/bridge0 -b 57600 -m osd -r 40000
-	fi
-	if param compare SYS_COMPANION 921600
-	then
-		if ver hwcmp AEROFC_V1
-		then
-			if protocol_splitter start ${MAVLINK_COMPANION_DEVICE}
-			then
-				mavlink start -d /dev/mavlink -b 921600 -m onboard -r 5000 -x
-				micrortps_client start -d /dev/rtps -b 921600 -l -1 -s 2000
-			else
-				mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 921600 -m onboard -r 80000 -x -f
-			fi
-		else
-			mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 921600 -m onboard -r 80000 -x -f
-		fi
-	fi
-	if param compare SYS_COMPANION 57600
-	then
-		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 57600 -m onboard -r 5000 -x -f
-	fi
-	if param compare SYS_COMPANION 460800
-	then
-		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 460800 -m onboard -r 5000 -x -f
-	fi
-	if param compare SYS_COMPANION 157600
-	then
-		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 57600 -m osd -r 1000
-	fi
-	if param compare SYS_COMPANION 257600
-	then
-		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 57600 -m magic -r 5000 -x -f
-	fi
-	if param compare SYS_COMPANION 319200
-	then
-		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 19200 -r 1000 -f
-	fi
-	if param compare SYS_COMPANION 338400
-	then
-		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 38400 -r 1000 -f
-	fi
-	if param compare SYS_COMPANION 357600
-	then
-		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 57600 -r 1000 -f
-	fi
-	if param compare SYS_COMPANION 3115200
-	then
-		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 115200 -r 1000 -f
-	fi
-	if param compare SYS_COMPANION 419200
-	then
-		iridiumsbd start -d ${MAVLINK_COMPANION_DEVICE}
-		mavlink start -d /dev/iridium -b 19200 -m iridium -r 10
-	fi
-	if param compare SYS_COMPANION 519200
-	then
-		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 19200 -m minimal -r 1000
-	fi
-	if param compare SYS_COMPANION 538400
-	then
-		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 38400 -m minimal -r 1000
-	fi
-	if param compare SYS_COMPANION 557600
-	then
-		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 57600 -m minimal -r 1000
-	fi
-	if param compare SYS_COMPANION 5115200
-	then
-		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 115200 -m minimal -r 1000
-	fi
-	if param compare SYS_COMPANION 6460800
-	then
-		micrortps_client start -t UART -d /dev/ttyS2 -b 460800
-	fi
-	if param compare SYS_COMPANION 1921600
-	then
-		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 921600 -r 20000
-	fi
-	if param compare SYS_COMPANION 1500000
-	then
-		mavlink start -d ${MAVLINK_COMPANION_DEVICE} -b 1500000 -m onboard -r 10000 -x -f
-	fi
+	sh /etc/init.d/rc.mavlink
 
 	#
 	# Starting stuff according to UAVCAN_ENABLE value
@@ -894,12 +725,12 @@ then
 	fi
 
 	#
-	# Start the navigator
+	# Start the navigator.
 	#
 	navigator start
 
 	#
-	# Generic setup (autostart ID not found)
+	# Generic setup (autostart ID not found).
 	#
 	if [ $VEHICLE_TYPE == none ]
 	then
@@ -907,7 +738,7 @@ then
 		ekf2 start
 	fi
 
-	# Start any custom addons
+	# Start any custom addons.
 	if [ -f $FEXTRAS ]
 	then
 		echo "Addons script: ${FEXTRAS}"
@@ -916,17 +747,17 @@ then
 
 	if ver hwcmp CRAZYFLIE
 	then
-		# CF2 shouldn't have an sd card
+		# CF2 shouldn't have an sd card.
 	else
 
 		if ver hwcmp AEROCORE2
 		then
-			# AEROCORE2 shouldn't have an sd card
+			# AEROCORE2 shouldn't have an sd card.
 		else
-			# Run no SD alarm
+			# Run no SD alarm.
 			if [ $LOG_FILE == /dev/null ]
 			then
-				# Play SOS
+				# Play SOS.
 				tone_alarm error
 			fi
 
@@ -950,9 +781,12 @@ then
 		fi
 	fi
 
+	#
+	# Start the logger.
+	#
 	sh /etc/init.d/rc.logging
 
-# End of autostart
+# End of autostart.
 fi
 
 # There is no further script processing, so we can free some RAM


### PR DESCRIPTION
Hi,

This PR breaks rc.mavlink out of the rcS startup script.  This PR aims to allow better future maintainability by focusing the content of subscripts on accomplishing more specific task objectives; in this case, starting the mavlink and other telemetry data streams.

This PR is a copy/paste of the original code from the rcS file into rc.mavlink along with an appropriate file header section.  I have grouped SYS_COMPANION parameter set baud rates together in order to ease readability of the script.  CMakeLists.txt is updated and a tab/space correction is made in rc.thermal_cal.

Please let me know if you have any questions on this PR.

-Mark