### PR TITLE
ekf2: Consolidate range finder checking

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -939,23 +939,11 @@ void Ekf2::run()
 				distance_sensor_s range_finder;
 
 				if (orb_copy(ORB_ID(distance_sensor), _range_finder_subs[_range_finder_sub_index], &range_finder) == PX4_OK) {
-					// check if distance sensor is within working boundaries
-					if (range_finder.min_distance >= range_finder.current_distance ||
-					    range_finder.max_distance <= range_finder.current_distance) {
-						// use rng_gnd_clearance if on ground
-						if (_ekf.get_in_air_status()) {
-							range_finder_updated = false;
-
-						} else {
-							range_finder.current_distance = _rng_gnd_clearance.get();
-						}
-					}
-
+					// push range and range limit data
 					_ekf.setRangeData(range_finder.timestamp, range_finder.current_distance);
-
-					// Save sensor limits reported by the rangefinder
 					_ekf.set_rangefinder_limits(range_finder.min_distance, range_finder.max_distance);
 
+					// set timestamp logged to enable replay of sensor data
 					ekf2_timestamps.distance_sensor_timestamp_rel = (int16_t)((int64_t)range_finder.timestamp / 100 -
 							(int64_t)ekf2_timestamps.timestamp / 100);
 				}


### PR DESCRIPTION
**DESCRIPTION**

This brings all the range finder data checks (excluding innovation consistency checks) into one place and eliminates the need to perform range checking external to the library. Having checks in multiple places has previously resulted in unintended loss of functionality over time which had to be fixed by #476. This PR should reduce the likelihood of this type of bug being introduced in the future.

The hard coded optical flow tilt limit has also been changed to use the same value as the range finder for consistency.

Variable names have been changed changed to make a clear distinction between the max/min values calculated by by the stuck range check and the max/min valid values published by the sensor.

**DEPENDENCIES**

Requires https://github.com/PX4/ecl/pull/477

Impacts https://github.com/PX4/Firmware/pull/9865 (could be incorporated)

**TESTING REQUIRED**

For full test coverage we need to check:

Data below min valid (on ground and in air)
Data above min valid (on ground and in air)
Data returning to valid range after > 10 seconds out of range and sticking at a constant value (on ground and in air)
Vehicle tilted > 45 deg

Initial reversion test using replay log here: https://logs.px4.io/plot_app?log=a56f0800-6944-4f46-8171-4a7fab048923