### PR TITLE
Mavlink fixes & perf improvement

### DIFF
--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -317,7 +317,14 @@ public:
 
 	void			handle_message(const mavlink_message_t *msg);
 
-	MavlinkOrbSubscription *add_orb_subscription(const orb_id_t topic, int instance = 0);
+	/**
+	 * Add a mavlink orb topic subscription while ensuring that only a single object exists
+	 * for a given topic id and instance.
+	 * @param topic orb topic id
+	 * @param instance topic instance
+	 * @param disable_sharing if true, force creating a new instance
+	 */
+	MavlinkOrbSubscription *add_orb_subscription(const orb_id_t topic, int instance = 0, bool disable_sharing = false);
 
 	int			get_instance_id();
 

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -466,7 +466,7 @@ private:
 
 protected:
 	explicit MavlinkStreamCommandLong(Mavlink *mavlink) : MavlinkStream(mavlink),
-		_cmd_sub(_mavlink->add_orb_subscription(ORB_ID(vehicle_command)))
+		_cmd_sub(_mavlink->add_orb_subscription(ORB_ID(vehicle_command), 0, true))
 	{}
 
 	bool send(const hrt_abstime t)


### PR DESCRIPTION
- add optional `disable_sharing` flag to `add_orb_subscription`.
  It is a more generic solution for 532a97041, and also enables it for vehicle_command_ack's.
- `MavlinkOrbSubscription::update`:
    - reorders operations, such that the most expensive one (orb_copy) is done only when really needed.
    - fix corner case: when the topic was not advertised yet, orb_stat() would fail and then update() was called, which succeeds for the first advertisement.
      In that case the timestamp was incorrectly set to 0 and true was returned. The next call would again return true, because the timestamp was updated, but the topic data was still the same.
    
Reduces CPU load by ~2% on a Pixracer.