### PR TITLE
Add rc.vehicle_setup to CMakeLists.txt, move additional logic block to rc.vehicle_setup, and relocate hardware specific sd card logic in rcS

### DIFF
--- a/ROMFS/px4fmu_common/init.d/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/CMakeLists.txt
@@ -114,6 +114,7 @@ px4_add_romfs_files(
 	rc.thermal_cal
 	rc.ugv_apps
 	rc.ugv_defaults
+	rc.vehicle_setup
 	rc.vtol_apps
 	rc.vtol_defaults
 	rcS

--- a/ROMFS/px4fmu_common/init.d/rc.vehicle_setup
+++ b/ROMFS/px4fmu_common/init.d/rc.vehicle_setup
@@ -165,3 +165,12 @@ then
 	# Start standard UGV apps
 	sh /etc/init.d/rc.ugv_apps
 fi
+
+#
+# Generic setup (autostart ID not found).
+#
+if [ $VEHICLE_TYPE == none ]
+then
+	echo "No autostart ID found"
+	ekf2 start
+fi

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -100,6 +100,18 @@ else
 	fi
 fi
 
+if ver hwcmp CRAZYFLIE -o ver hwcmp AEROCORE2
+then
+	# AEROCORE2 and CF2 shouldn't have an sd card.
+else
+	# Run no SD alarm.
+	if [ $LOG_FILE == /dev/null ]
+	then
+		# Play SOS.
+		tone_alarm error
+	fi
+fi
+
 #
 # Look for an init script on the microSD card.
 # Disable autostart if the script found.
@@ -561,40 +573,11 @@ then
 	#
 	navigator start
 
-	#
-	# Generic setup (autostart ID not found).
-	#
-	if [ $VEHICLE_TYPE == none ]
-	then
-		echo "No autostart ID found"
-		ekf2 start
-	fi
-
 	# Start any custom addons.
 	if [ -f $FEXTRAS ]
 	then
 		echo "Addons script: ${FEXTRAS}"
 		sh $FEXTRAS
-	fi
-
-	if ver hwcmp CRAZYFLIE
-	then
-		# CF2 shouldn't have an sd card.
-	else
-
-		if ver hwcmp AEROCORE2
-		then
-			# AEROCORE2 shouldn't have an sd card.
-		else
-			# Run no SD alarm.
-			if [ $LOG_FILE == /dev/null ]
-			then
-				# Play SOS.
-				tone_alarm error
-			fi
-
-		fi
-
 	fi
 
 	#


### PR DESCRIPTION
Hi,

This PR moves an additional logic block to rc.vehicle_setup, adds rc.vehicle_setup to CMakeLists.txt, and relocates a hardware specific sd card logic block higher up in the rcS script.  As with previous commits, the objective of these changes is to improve readability and maintainability in the startup scripts.

Please let me know if you have any questions or comments on this PR!

-Mark

