### PR TITLE
px4_posix.h: avoid defining PX4_F_RDONLY as O_RDONLY

### DIFF
--- a/src/lib/drivers/device/posix/cdev_platform.cpp
+++ b/src/lib/drivers/device/posix/cdev_platform.cpp
@@ -162,7 +162,7 @@ extern "C" {
 		int i;
 		mode_t mode;
 
-		if (!dev && (flags & (PX4_F_WRONLY | PX4_F_CREAT)) != 0 &&
+		if (!dev && (flags & PX4_F_WRONLY) != 0 &&
 		    strncmp(path, "/obj/", 5) != 0 &&
 		    strncmp(path, "/dev/", 5) != 0) {
 			va_list p;

--- a/src/platforms/px4_posix.h
+++ b/src/platforms/px4_posix.h
@@ -55,11 +55,10 @@
 
 #include "px4_sem.h"
 
-
-#ifdef __PX4_NUTTX
-
 #define  PX4_F_RDONLY 1
 #define  PX4_F_WRONLY 2
+
+#ifdef __PX4_NUTTX
 
 typedef struct pollfd px4_pollfd_struct_t;
 
@@ -82,9 +81,6 @@ typedef struct pollfd px4_pollfd_struct_t;
 
 #elif defined(__PX4_POSIX)
 
-#define  PX4_F_RDONLY O_RDONLY
-#define  PX4_F_WRONLY O_WRONLY
-#define  PX4_F_CREAT  O_CREAT
 #define	 PX4_STACK_OVERHEAD	8192
 
 __BEGIN_DECLS


### PR DESCRIPTION
- There is an assumption in uORB that PX4_F_RDONLY is not 0.
- But O_RDONLY is 0 on Linux. orb_exists passes 0 to px4_open, which in
  uORB::DeviceNode::open leads to an unnecessary allocation of SubscriberData()
- PX4_F_RDONLY is only used in combination with px4_open, never with open()

However even if it was wrong/unexpected, it did not cause any problems, just the unnecessary allocation & free.