### PR TITLE
mavlink properly wrap heading fields

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -1061,7 +1061,6 @@ protected:
 		actuator_armed_s armed = {};
 		airspeed_s airspeed = {};
 
-
 		bool updated = false;
 		updated |= _pos_sub->update(&_pos_time, &pos);
 		updated |= _armed_sub->update(&_armed_time, &armed);
@@ -4068,9 +4067,9 @@ protected:
 
 			mavlink_mount_orientation_t msg = {};
 
-			msg.roll = 180.0f / M_PI_F * mount_orientation.attitude_euler_angle[0];
-			msg.pitch = 180.0f / M_PI_F * mount_orientation.attitude_euler_angle[1];
-			msg.yaw = 180.0f / M_PI_F * mount_orientation.attitude_euler_angle[2];
+			msg.roll = math::degrees(mount_orientation.attitude_euler_angle[0]);
+			msg.pitch = math::degrees(mount_orientation.attitude_euler_angle[1]);
+			msg.yaw = math::degrees(mount_orientation.attitude_euler_angle[2]);
 
 			mavlink_msg_mount_orientation_send_struct(_mavlink->get_channel(), &msg);
 


### PR DESCRIPTION
These fields are unsigned 0 to 360 degrees, so the yaw estimate in radians need to be wrapped 0 to 2pi first, then converted to degrees, and then sometimes scaled.

 - fixes #9867
