### PR TITLE
 uorb: allow an orb subscription to retrieve data that was published prior to the subscribe

### DIFF
--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -311,7 +311,7 @@ void AttitudeEstimatorQ::task_main()
 				_accel(2) = sensors.accelerometer_m_s2[2];
 
 				if (_accel.length() < 0.01f) {
-					PX4_ERR("WARNING: degenerate accel!");
+					PX4_ERR("degenerate accel!");
 					continue;
 				}
 			}
@@ -324,7 +324,7 @@ void AttitudeEstimatorQ::task_main()
 		orb_check(_magnetometer_sub, &magnetometer_updated);
 
 		if (magnetometer_updated) {
-			vehicle_magnetometer_s magnetometer = {};
+			vehicle_magnetometer_s magnetometer;
 
 			if (orb_copy(ORB_ID(vehicle_magnetometer), _magnetometer_sub, &magnetometer) == PX4_OK) {
 				_mag(0) = magnetometer.magnetometer_ga[0];
@@ -332,7 +332,7 @@ void AttitudeEstimatorQ::task_main()
 				_mag(2) = magnetometer.magnetometer_ga[2];
 
 				if (_mag.length() < 0.01f) {
-					PX4_ERR("WARNING: degenerate mag!");
+					PX4_ERR("degenerate mag!");
 					continue;
 				}
 			}

--- a/src/modules/mavlink/mavlink_orb_subscription.cpp
+++ b/src/modules/mavlink/mavlink_orb_subscription.cpp
@@ -119,21 +119,13 @@ MavlinkOrbSubscription::update(void *data)
 bool
 MavlinkOrbSubscription::update_if_changed(void *data)
 {
-	bool prevpub = _published;
-
 	if (!is_published()) {
 		return false;
 	}
 
 	bool updated;
 
-	if (orb_check(_fd, &updated)) {
-		return false;
-	}
-
-	// If we didn't update and this topic did not change
-	// its publication status then nothing really changed
-	if (!updated && prevpub == _published) {
+	if (orb_check(_fd, &updated) || !updated) {
 		return false;
 	}
 
@@ -160,7 +152,7 @@ MavlinkOrbSubscription::is_published()
 	// We don't want to subscribe to anything that does not exist
 	// in order to save memory and file descriptors.
 	// However, for some topics like vehicle_command_ack, we want to subscribe
-	// from the beginning in order not to miss the first publish respective advertise.
+	// from the beginning in order not to miss or delay the first publish respective advertise.
 	if (!_subscribe_from_beginning && orb_exists(_topic, _instance)) {
 		return false;
 	}
@@ -174,15 +166,6 @@ MavlinkOrbSubscription::is_published()
 
 	if (updated) {
 		_published = true;
-	}
-
-	// topic may have been last published before we subscribed
-	uint64_t time_topic = 0;
-
-	if (!_published && orb_stat(_fd, &time_topic) == PX4_OK) {
-		if (time_topic != 0) {
-			_published = true;
-		}
 	}
 
 	return _published;

--- a/src/modules/sensors/sensors.cpp
+++ b/src/modules/sensors/sensors.cpp
@@ -618,11 +618,6 @@ Sensors::run()
 
 	_rc_update.rc_parameter_map_poll(_parameter_handles, true /* forced */);
 
-	/* advertise the sensor_combined topic and make the initial publication */
-	_sensor_pub = orb_advertise(ORB_ID(sensor_combined), &raw);
-	_airdata_pub = orb_advertise(ORB_ID(vehicle_air_data), &airdata);
-	_magnetometer_pub = orb_advertise(ORB_ID(vehicle_magnetometer), &magnetometer);
-
 	/* advertise the sensor_preflight topic and make the initial publication */
 	preflt.accel_inconsistency_m_s_s = 0.0f;
 
@@ -685,14 +680,15 @@ Sensors::run()
 
 			_voted_sensors_update.set_relative_timestamps(raw);
 
-			orb_publish(ORB_ID(sensor_combined), _sensor_pub, &raw);
+			int instance;
+			orb_publish_auto(ORB_ID(sensor_combined), &_sensor_pub, &raw, &instance, ORB_PRIO_DEFAULT);
 
 			if (airdata.timestamp != airdata_prev_timestamp) {
-				orb_publish(ORB_ID(vehicle_air_data), _airdata_pub, &airdata);
+				orb_publish_auto(ORB_ID(vehicle_air_data), &_airdata_pub, &airdata, &instance, ORB_PRIO_DEFAULT);
 			}
 
 			if (magnetometer.timestamp != magnetometer_prev_timestamp) {
-				orb_publish(ORB_ID(vehicle_magnetometer), _magnetometer_pub, &magnetometer);
+				orb_publish_auto(ORB_ID(vehicle_magnetometer), &_magnetometer_pub, &magnetometer, &instance, ORB_PRIO_DEFAULT);
 			}
 
 			_voted_sensors_update.check_failover();
@@ -735,9 +731,18 @@ Sensors::run()
 	orb_unsubscribe(_vcontrol_mode_sub);
 	orb_unsubscribe(_params_sub);
 	orb_unsubscribe(_actuator_ctrl_0_sub);
-	orb_unadvertise(_sensor_pub);
-	orb_unadvertise(_airdata_pub);
-	orb_unadvertise(_magnetometer_pub);
+
+	if (_sensor_pub) {
+		orb_unadvertise(_sensor_pub);
+	}
+
+	if (_airdata_pub) {
+		orb_unadvertise(_airdata_pub);
+	}
+
+	if (_magnetometer_pub) {
+		orb_unadvertise(_magnetometer_pub);
+	}
 
 	_rc_update.deinit();
 	_voted_sensors_update.deinit();

--- a/src/modules/uORB/uORB.cpp
+++ b/src/modules/uORB/uORB.cpp
@@ -67,23 +67,6 @@ int orb_unadvertise(orb_advert_t handle)
 	return uORB::Manager::get_instance()->orb_unadvertise(handle);
 }
 
-int orb_publish_auto(const struct orb_metadata *meta, orb_advert_t *handle, const void *data, int *instance,
-		     int priority)
-{
-	if (*handle == nullptr) {
-		*handle = orb_advertise_multi(meta, data, instance, priority);
-
-		if (*handle != nullptr) {
-			return 0;
-		}
-
-	} else {
-		return orb_publish(meta, *handle, data);
-	}
-
-	return -1;
-}
-
 int  orb_publish(const struct orb_metadata *meta, orb_advert_t handle, const void *data)
 {
 	return uORB::Manager::get_instance()->orb_publish(meta, handle, data);

--- a/src/modules/uORB/uORB.h
+++ b/src/modules/uORB/uORB.h
@@ -162,6 +162,11 @@ extern orb_advert_t orb_advertise_multi_queue(const struct orb_metadata *meta, c
 extern int orb_unadvertise(orb_advert_t handle) __EXPORT;
 
 /**
+ * @see uORB::Manager::orb_publish()
+ */
+extern int	orb_publish(const struct orb_metadata *meta, orb_advert_t handle, const void *data) __EXPORT;
+
+/**
  * Advertise as the publisher of a topic.
  *
  * This performs the initial advertisement of a topic; it creates the topic
@@ -169,13 +174,23 @@ extern int orb_unadvertise(orb_advert_t handle) __EXPORT;
  *
  * @see uORB::Manager::orb_advertise_multi() for meaning of the individual parameters
  */
-extern int orb_publish_auto(const struct orb_metadata *meta, orb_advert_t *handle, const void *data, int *instance,
-			    int priority);
+static inline int orb_publish_auto(const struct orb_metadata *meta, orb_advert_t *handle, const void *data,
+				   int *instance,
+				   int priority)
+{
+	if (!*handle) {
+		*handle = orb_advertise_multi(meta, data, instance, priority);
 
-/**
- * @see uORB::Manager::orb_publish()
- */
-extern int	orb_publish(const struct orb_metadata *meta, orb_advert_t handle, const void *data) __EXPORT;
+		if (*handle) {
+			return 0;
+		}
+
+	} else {
+		return orb_publish(meta, *handle, data);
+	}
+
+	return -1;
+}
 
 /**
  * @see uORB::Manager::orb_subscribe()

--- a/src/modules/uORB/uORBDevices.cpp
+++ b/src/modules/uORB/uORBDevices.cpp
@@ -146,13 +146,8 @@ uORB::DeviceNode::open(device::file_t *filp)
 			return -ENOMEM;
 		}
 
-		/* If queue size >1, allow the subscriber to read the data in the queue. Otherwise, assume subscriber is up to date.*/
-		if (_queue_size <= 1) {
-			sd->generation = _generation;
-
-		} else {
-			sd->generation = _generation - (_queue_size < _generation ? _queue_size : _generation);
-		}
+		/* If there were any previous publications, allow the subscriber to read them */
+		sd->generation = _generation - (_queue_size < _generation ? _queue_size : _generation);
 
 		/* set priority */
 		sd->set_priority(_priority);

--- a/src/modules/uORB/uORBManager.hpp
+++ b/src/modules/uORB/uORBManager.hpp
@@ -186,6 +186,9 @@ public:
 	 * in order to wait for updates to a topic, as well as topic_read,
 	 * orb_check and orb_stat.
 	 *
+	 * If there were any publications of the topic prior to the subscription,
+	 * an orb_check right after orb_subscribe will return true.
+	 *
 	 * Subscription will succeed even if the topic has not been advertised;
 	 * in this case the topic will have a timestamp of zero, it will never
 	 * signal a poll() event, checking will always return false and it cannot
@@ -212,6 +215,9 @@ public:
 	 * The returned value is a file descriptor that can be passed to poll()
 	 * in order to wait for updates to a topic, as well as topic_read,
 	 * orb_check and orb_stat.
+	 *
+	 * If there were any publications of the topic prior to the subscription,
+	 * an orb_check right after orb_subscribe_multi will return true.
 	 *
 	 * Subscription will succeed even if the topic has not been advertised;
 	 * in this case the topic will have a timestamp of zero, it will never


### PR DESCRIPTION
Allows a subscriber to get data that was published prior to the subscription.
We already did that for the queued topics, this changes it to all topics.