### PR TITLE
GPS: add Trimble MB-Two RTK with heading support

### DIFF
--- a/msg/vehicle_gps_position.msg
+++ b/msg/vehicle_gps_position.msg
@@ -29,3 +29,5 @@ int32 timestamp_time_relative	# timestamp + timestamp_time_relative = Time of th
 uint64 time_utc_usec		# Timestamp (microseconds, UTC), this is the timestamp which comes from the gps module. It might be unavailable right after cold start, indicated by a value of 0 
 
 uint8 satellites_used		# Number of satellites used 
+
+float32 heading		# heading in NED. Set to NaN if not set (used for dual antenna GPS), (rad, [-PI, PI])

--- a/msg/vehicle_gps_position.msg
+++ b/msg/vehicle_gps_position.msg
@@ -23,7 +23,6 @@ float32 vel_n_m_s		# GPS North velocity, (metres/sec)
 float32 vel_e_m_s		# GPS East velocity, (metres/sec)
 float32 vel_d_m_s		# GPS Down velocity, (metres/sec) 
 float32 cog_rad			# Course over ground (NOT heading, but direction of movement), -PI..PI, (radians) 
-float32 heading			# Heading to true north (for RTK units with multiple antennas and heading support). Set to NaN if unknown.
 bool vel_ned_valid		# True if NED velocity is valid 
 
 int32 timestamp_time_relative	# timestamp + timestamp_time_relative = Time of the UTC timestamp since system start, (microseconds)

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -281,6 +281,8 @@ GPS::GPS(const char *path, gps_driver_mode_t mode, GPSHelper::Interface interfac
 	/* enforce null termination */
 	_port[sizeof(_port) - 1] = '\0';
 
+	_report_gps_pos.heading = NAN;
+
 	/* create satellite info data object if requested */
 	if (enable_sat_info) {
 		_sat_info = new GPS_Sat_Info();
@@ -650,6 +652,7 @@ GPS::run()
 			_report_gps_pos.cog_rad = 0.0f;
 			_report_gps_pos.vel_ned_valid = true;
 			_report_gps_pos.satellites_used = 10;
+			_report_gps_pos.heading = NAN;
 
 			/* no time and satellite information simulated */
 
@@ -700,6 +703,7 @@ GPS::run()
 
 				/* reset report */
 				memset(&_report_gps_pos, 0, sizeof(_report_gps_pos));
+				_report_gps_pos.heading = NAN;
 
 				if (_mode == GPS_DRIVER_MODE_UBX) {
 

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -151,8 +151,6 @@ private:
 	char				_port[20] {};					///< device / serial port path
 
 	bool				_healthy{false};				///< flag to signal if the GPS is ok
-	bool				_baudrate_changed{false};			///< flag to signal that the baudrate with the GPS has changed
-	bool				_mode_changed{false};				///< flag that the GPS mode has changed
 	bool        			_mode_auto;				///< if true, auto-detect which GPS is attached
 
 	gps_driver_mode_t		_mode;						///< current mode

--- a/src/drivers/gps/params.c
+++ b/src/drivers/gps/params.c
@@ -63,3 +63,27 @@ PARAM_DEFINE_INT32(GPS_DUMP_COMM, 0);
  * @group GPS
  */
 PARAM_DEFINE_INT32(GPS_UBX_DYNMODEL, 7);
+
+
+/**
+ * Heading/Yaw offset for dual antenna GPS
+ *
+ * Heading offset angle for dual antenna GPS setups that support heading estimation.
+ * (currently only for the Trimble MB-Two).
+ *
+ * Set this to 0 if the antennas are parallel to the forward-facing direction of the vehicle and the first antenna is in
+ * front. The offset angle increases counterclockwise.
+ *
+ * Set this to 90 if the first antenna is placed on the right side and the second on the left side of the vehicle.
+ *
+ * @min 0
+ * @max 360
+ * @unit deg
+ * @reboot_required true
+ * @decimal 0
+ *
+ * @group GPS
+ */
+PARAM_DEFINE_FLOAT(GPS_YAW_OFFSET, 0.f);
+
+

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2139,6 +2139,8 @@ MavlinkReceiver::handle_message_hil_gps(mavlink_message_t *msg)
 	hil_gps.fix_type = gps.fix_type;
 	hil_gps.satellites_used = gps.satellites_visible;  //TODO: rename mavlink_hil_gps_t sats visible to used?
 
+	hil_gps.heading = NAN;
+
 	if (_gps_pub == nullptr) {
 		_gps_pub = orb_advertise(ORB_ID(vehicle_gps_position), &hil_gps);
 

--- a/src/modules/simulator/gpssim/gpssim.cpp
+++ b/src/modules/simulator/gpssim/gpssim.cpp
@@ -178,6 +178,7 @@ GPSSIM::GPSSIM(const char *uart_path, bool fake_gps, bool enable_sat_info,
 {
 	/* we need this potentially before it could be set in task_main */
 	g_dev = this;
+	_report_gps_pos.heading = NAN;
 
 	/* create satellite info data object if requested */
 	if (enable_sat_info) {

--- a/src/modules/simulator/gpssim/gpssim.cpp
+++ b/src/modules/simulator/gpssim/gpssim.cpp
@@ -107,20 +107,12 @@ protected:
 private:
 
 	bool				_task_should_exit;				///< flag to make the main worker task exit
-	int				_serial_fd;					///< serial interface to GPS
-	unsigned			_baudrate;					///< current baudrate
-	char				_port[20];					///< device / serial port path
 	volatile int			_task;						///< worker task
-	bool				_healthy;					///< flag to signal if the GPS is ok
-	bool				_baudrate_changed;				///< flag to signal that the baudrate with the GPS has changed
-	bool				_mode_changed;					///< flag that the GPS mode has changed
-	//gps_driver_mode_t		_mode;						///< current mode
 	GPS_Sat_Info			*_Sat_Info;					///< instance of GPS sat info data object
 	struct vehicle_gps_position_s	_report_gps_pos;				///< uORB topic for gps position
 	orb_advert_t			_report_gps_pos_pub;				///< uORB pub for gps position
 	struct satellite_info_s		*_p_report_sat_info;				///< pointer to uORB topic for satellite info
 	orb_advert_t			_report_sat_info_pub;				///< uORB pub for satellite info
-	float				_rate;						///< position update rate
 	SyncObj				_sync;
 	int _fix_type;
 	int _num_sat;
@@ -175,27 +167,17 @@ GPSSIM::GPSSIM(const char *uart_path, bool fake_gps, bool enable_sat_info,
 	       int fix_type, int num_sat, int noise_multiplier) :
 	VirtDevObj("gps", GPSSIM_DEVICE_PATH, nullptr, 1e6 / 10),
 	_task_should_exit(false),
-	//_healthy(false),
-	//_mode_changed(false),
-	//_mode(GPS_DRIVER_MODE_UBX),
-	//_Helper(nullptr),
 	_Sat_Info(nullptr),
+	_report_gps_pos{},
 	_report_gps_pos_pub(nullptr),
 	_p_report_sat_info(nullptr),
 	_report_sat_info_pub(nullptr),
-	_rate(0.0f),
 	_fix_type(fix_type),
 	_num_sat(num_sat),
 	_noise_multiplier(noise_multiplier)
 {
-	// /* store port name */
-	// strncpy(_port, uart_path, sizeof(_port));
-	// /* enforce null termination */
-	// _port[sizeof(_port) - 1] = '\0';
-
 	/* we need this potentially before it could be set in task_main */
 	g_dev = this;
-	memset(&_report_gps_pos, 0, sizeof(_report_gps_pos));
 
 	/* create satellite info data object if requested */
 	if (enable_sat_info) {
@@ -329,9 +311,6 @@ GPSSIM::task_main()
 	/* loop handling received serial bytes and also configuring in between */
 	while (!_task_should_exit) {
 
-		// GPS is obviously detected successfully, reset statistics
-		//_Helper->reset_update_rates();
-
 		int recv_ret = receive(TIMEOUT_100MS);
 
 		if (recv_ret > 0) {
@@ -382,7 +361,6 @@ GPSSIM::print_info()
 	//GPS Mode
 	PX4_INFO("protocol: SIM");
 
-	PX4_INFO("port: %s, baudrate: %d, status: %s", _port, _baudrate, (_healthy) ? "OK" : "NOT OK");
 	PX4_INFO("sat info: %s, noise: %d, jamming detected: %s",
 		 (_p_report_sat_info != nullptr) ? "enabled" : "disabled",
 		 _report_gps_pos.noise_per_ms,

--- a/src/modules/uavcan/sensors/gnss.cpp
+++ b/src/modules/uavcan/sensors/gnss.cpp
@@ -379,6 +379,8 @@ void UavcanGnssBridge::process_fixx(const uavcan::ReceivedDataStructure<FixType>
 	report.hdop = msg.pdop;
 	report.vdop = msg.pdop;
 
+	report.heading = NAN;
+
 	// Publish to a multi-topic
 	int32_t gps_orb_instance;
 	orb_publish_auto(ORB_ID(vehicle_gps_position), &_report_pub, &report, &gps_orb_instance,


### PR DESCRIPTION
The submodule update in https://github.com/PX4/Firmware/pull/9910 was not done correctly, as there were some API changes to the GPS drivers that need to be updated in sync.

I initially had problems with auto-configure when changing the baudrate for the MB-Two. So we might have to add an additional param for that.

Next steps: integrate heading into the estimator. The heading comes in with about 1Hz.
@priseborough do you want the heading to be set to NaN whenever it is not updated? The current behavior is to keep the previous value.