### PR TITLE
Group MIXER and MIXER_AUX logic in rc.interface, add `-p` pwm failsafe argument per issue #9775.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -182,7 +182,7 @@ then
 
 		if [ $FAILSAFE_AUX != none ]
 		then
-			pwm failsafe -p ${FAILSAFE} -d ${OUTPUT_AUX_DEV}
+			pwm failsafe -c ${PWM_AUX_OUT} -p ${FAILSAFE} -d ${OUTPUT_AUX_DEV}
 		fi
 	fi
 fi
@@ -226,7 +226,7 @@ then
 
 	if [ $FAILSAFE != none ]
 	then
-		pwm failsafe -p ${FAILSAFE} -d ${OUTPUT_DEV}
+		pwm failsafe -c ${PWM_OUT} -p ${FAILSAFE} -d ${OUTPUT_DEV}
 	fi
 fi
 

--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -9,26 +9,36 @@
 #  Otherwise, the variable name goes to the end of the argument.
 #
 
+set MIXER_AUX_FILE none
+set OUTPUT_AUX_DEV /dev/pwm_output1
 set SDCARD_MIXERS_PATH /fs/microsd/etc/mixers
+
+if ver hwcmp AEROFC_V1 AV_X_V1 CRAZYFLIE MINDPX_V2 NXPHLITE_V3 PX4FMU_V4 OMNIBUS_F4SD
+then
+	set MIXER_AUX none
+fi
+
+if [ $USE_IO == no ]
+then
+	set MIXER_AUX none
+fi
 
 if [ $MIXER != none -a $MIXER != skip ]
 then
 	#
-	# Load main mixer
+	# Load main mixer.
 	#
-
 	if [ $MIXER_AUX == none -a $USE_IO == yes ]
 	then
 		set MIXER_AUX ${MIXER}
 	fi
 
-	# Use the mixer file from the SD-card if it exists
 	if [ -f ${SDCARD_MIXERS_PATH}/${MIXER}.main.mix ]
 	then
+		# Use the mixer file from the SD-card if it exists.
 		set MIXER_FILE ${SDCARD_MIXERS_PATH}/${MIXER}.main.mix
-	# Try out the old convention, for backward compatibility
 	else
-
+		# Try out the old convention, for backward compatibility.
 		if [ -f ${SDCARD_MIXERS_PATH}/${MIXER}.mix ]
 		then
 			set MIXER_FILE ${SDCARD_MIXERS_PATH}/${MIXER}.mix
@@ -73,72 +83,11 @@ else
 	fi
 fi
 
-if [ $OUTPUT_MODE == fmu -o $OUTPUT_MODE == io ]
-then
-	if [ $PWM_OUT != none ]
-	then
-		#
-		# Set PWM output frequency
-		#
-		if [ $PWM_RATE != none ]
-		then
-			pwm rate -c ${PWM_OUT} -r ${PWM_RATE}
-		fi
-
-		#
-		# Set disarmed, min and max PWM values
-		#
-		if [ $PWM_DISARMED != none ]
-		then
-			pwm disarmed -c ${PWM_OUT} -p ${PWM_DISARMED}
-		fi
-		if [ $PWM_MIN != none ]
-		then
-			pwm min -c ${PWM_OUT} -p ${PWM_MIN}
-		fi
-		if [ $PWM_MAX != none ]
-		then
-			pwm max -c ${PWM_OUT} -p ${PWM_MAX}
-		fi
-	fi
-
-	#
-	# Per channel disarmed settings
-	#
-	pwm disarmed -c 1 -p p:PWM_MAIN_DIS1
-	pwm disarmed -c 2 -p p:PWM_MAIN_DIS2
-	pwm disarmed -c 3 -p p:PWM_MAIN_DIS3
-	pwm disarmed -c 4 -p p:PWM_MAIN_DIS4
-	pwm disarmed -c 5 -p p:PWM_MAIN_DIS5
-	pwm disarmed -c 6 -p p:PWM_MAIN_DIS6
-	pwm disarmed -c 7 -p p:PWM_MAIN_DIS7
-	pwm disarmed -c 8 -p p:PWM_MAIN_DIS8
-
-	if [ $FAILSAFE != none ]
-	then
-		pwm failsafe -d ${OUTPUT_DEV} ${FAILSAFE}
-	fi
-fi
-
-if ver hwcmp MINDPX_V2 CRAZYFLIE AEROFC_V1 PX4FMU_V4 NXPHLITE_V3 OMNIBUS_F4SD AV_X_V1
-then
-	set MIXER_AUX none
-fi
-
-if [ $USE_IO == no ]
-then
-	set MIXER_AUX none
-fi
-
 if [ $MIXER_AUX != none -a $AUX_MODE != none ]
 then
 	#
-	# Load aux mixer
+	# Load aux mixer.
 	#
-
-	set MIXER_AUX_FILE none
-	set OUTPUT_AUX_DEV /dev/pwm_output1
-
 	if [ -f ${SDCARD_MIXERS_PATH}/${MIXER_AUX}.aux.mix ]
 	then
 		set MIXER_AUX_FILE ${SDCARD_MIXERS_PATH}/${MIXER_AUX}.aux.mix
@@ -154,7 +103,7 @@ then
 	then
 		if fmu mode_${AUX_MODE} $FMU_ARGS
 		then
-			# Append aux mixer to main device
+			# Append aux mixer to main device.
 			if param compare SYS_HITL 1
 			then
 				if mixer append ${OUTPUT_DEV} ${MIXER_AUX_FILE}
@@ -185,12 +134,10 @@ then
 			set FAILSAFE_AUX none
 		fi
 
-		# Set min / max for aux out and rates
+		# Set min / max for aux out and rates.
 		if [ $PWM_AUX_OUT != none ]
 		then
-			#
-			# Set PWM_AUX output frequency
-			#
+			# Set PWM_AUX output frequency.
 			if [ $PWM_AUX_RATE != none ]
 			then
 				pwm rate -c ${PWM_AUX_OUT} -r ${PWM_AUX_RATE} -d ${OUTPUT_AUX_DEV}
@@ -206,17 +153,17 @@ then
 			fi
 		fi
 
-		# Set disarmed values for aux out
-
-		# Transitional support until all configs
-		# are updated
+		#
+		# Set disarmed values for aux out.
+		# Transitional support until all configs are updated.
+		#
 		if [ $PWM_ACHDIS == none ]
 		then
 			set PWM_ACHDIS ${PWM_AUX_OUT}
 		fi
 
 		#
-		# Set disarmed, min and max PWM_AUX values
+		# Set disarmed, min and max PWM_AUX values.
 		#
 		if [ $PWM_AUX_DISARMED != none -a $PWM_ACHDIS != none ]
 		then
@@ -224,7 +171,7 @@ then
 		fi
 
 		#
-		# Per channel disarmed settings
+		# Per channel disarmed settings.
 		#
 		pwm disarmed -c 1 -p p:PWM_AUX_DIS1 -d ${OUTPUT_AUX_DEV}
 		pwm disarmed -c 2 -p p:PWM_AUX_DIS2 -d ${OUTPUT_AUX_DEV}
@@ -235,23 +182,54 @@ then
 
 		if [ $FAILSAFE_AUX != none ]
 		then
-			pwm failsafe -d ${OUTPUT_AUX_DEV} ${FAILSAFE}
+			pwm failsafe -p ${FAILSAFE} -d ${OUTPUT_AUX_DEV}
 		fi
-
 	fi
 fi
 
-unset PWM_OUT
-unset PWM_RATE
-unset PWM_ACHDIS
-unset PWM_MIN
-unset PWM_MAX
-unset PWM_AUX_OUT
-unset PWM_AUX_RATE
-unset PWM_AUX_DISARMED
-unset PWM_AUX_MIN
-unset PWM_AUX_MAX
-unset FAILSAFE_AUX
-unset FAILSAFE
-unset OUTPUT_DEV
+if [ $OUTPUT_MODE == fmu -o $OUTPUT_MODE == io ]
+then
+	if [ $PWM_OUT != none ]
+	then
+		# Set PWM output frequency.
+		if [ $PWM_RATE != none ]
+		then
+			pwm rate -c ${PWM_OUT} -r ${PWM_RATE}
+		fi
+
+		# Set disarmed, min and max PWM values.
+		if [ $PWM_DISARMED != none ]
+		then
+			pwm disarmed -c ${PWM_OUT} -p ${PWM_DISARMED}
+		fi
+		if [ $PWM_MIN != none ]
+		then
+			pwm min -c ${PWM_OUT} -p ${PWM_MIN}
+		fi
+		if [ $PWM_MAX != none ]
+		then
+			pwm max -c ${PWM_OUT} -p ${PWM_MAX}
+		fi
+	fi
+
+	#
+	# Per channel disarmed settings.
+	#
+	pwm disarmed -c 1 -p p:PWM_MAIN_DIS1
+	pwm disarmed -c 2 -p p:PWM_MAIN_DIS2
+	pwm disarmed -c 3 -p p:PWM_MAIN_DIS3
+	pwm disarmed -c 4 -p p:PWM_MAIN_DIS4
+	pwm disarmed -c 5 -p p:PWM_MAIN_DIS5
+	pwm disarmed -c 6 -p p:PWM_MAIN_DIS6
+	pwm disarmed -c 7 -p p:PWM_MAIN_DIS7
+	pwm disarmed -c 8 -p p:PWM_MAIN_DIS8
+
+	if [ $FAILSAFE != none ]
+	then
+		pwm failsafe -p ${FAILSAFE} -d ${OUTPUT_DEV}
+	fi
+fi
+
+unset MIXER_AUX_FILE
 unset OUTPUT_AUX_DEV
+unset SDCARD_MIXERS_PATH

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -39,17 +39,17 @@ set MK_MODE                     none
 set MKBLCTRL_ARG                ""
 set OUTPUT_MODE                 none
 set PARAM_FILE                  /fs/microsd/params
-set PWM_OUT                     none
-set PWM_RATE                    p:PWM_RATE
-set PWM_DISARMED                p:PWM_DISARMED
-set PWM_MIN                     p:PWM_MIN
-set PWM_MAX                     p:PWM_MAX
-set PWM_AUX_OUT                 none
-set PWM_AUX_RATE                none
 set PWM_ACHDIS                  none
 set PWM_AUX_DISARMED            p:PWM_AUX_DISARMED
-set PWM_AUX_MIN                 p:PWM_AUX_MIN
 set PWM_AUX_MAX                 p:PWM_AUX_MAX
+set PWM_AUX_MIN                 p:PWM_AUX_MIN
+set PWM_AUX_OUT                 none
+set PWM_AUX_RATE                none
+set PWM_DISARMED                p:PWM_DISARMED
+set PWM_MAX                     p:PWM_MAX
+set PWM_MIN                     p:PWM_MIN
+set PWM_OUT                     none
+set PWM_RATE                    p:PWM_RATE
 set TUNE_ERR                    "ML<<CP4CP4CP4CP4CP4"
 set USE_IO                      no
 set VEHICLE_TYPE                none
@@ -636,22 +636,20 @@ unset MIXER
 unset MIXER_AUX
 unset MK_MODE
 unset MKBLCTRL_ARG
-unset OUTPUT_AUX_DEV
 unset OUTPUT_DEV
 unset OUTPUT_MODE
 unset PARAM_FILE
 unset PWM_ACHDIS
+unset PWM_AUX_DISARMED
+unset PWM_AUX_MAX
+unset PWM_AUX_MIN
+unset PWM_AUX_OUT
+unset PWM_AUX_RATE
 unset PWM_OUT
 unset PWM_RATE
 unset PWM_DISARMED
-unset PWM_MIN
 unset PWM_MAX
-unset PWM_AUX_OUT
-unset PWM_AUX_RATE
-unset PWM_ACHDIS
-unset PWM_AUX_DISARMED
-unset PWM_AUX_MIN
-unset PWM_AUX_MAX
+unset PWM_MIN
 unset TUNE_ERR
 unset USE_IO
 unset VEHICLE_TYPE


### PR DESCRIPTION
Hi,

This PR moves the OUTPUT_MODE logic block lower in rc.interface to group MIXER and MIXER_AUX logic, adds a `-p` argument to `pwm failsafe` calls per issue #9775, and alphabetizes a bit of the set/unset list in rcS.

This PR has been tested on a pixracer.  For convenience, the startup script output is below.

Let me know if you have any questions on this PR.

-Mark

```
nsh> reboot
WARN  [platforms__common] Reboot NOW.
[boot] Fault Log info File No 4 Length 3177 flags:0x01 state:1
[boot] Fault Log is Armed
sercon: Registering CDC/ACM serial driver
sercon: Successfully registered the CDC/ACM serial driver
HW arch: PX4FMU_V4
FW git-hash: 9b27f14a76b058ee3222a3adcda8626e3e3d417d
FW version: 1.8.0 0 (17301504)
OS: NuttX
OS version: Release 7.22.0 (118882559)
OS git-hash: 8957a027f4214416646f384bb47b838ec3686643
Build datetime: Jul 17 2018 04:27:52
Build uri: BUILD_URI
Toolchain: GNU GCC, 5.4.1 20160919
MFGUID: 363539313535510a004d002c
MCU: STM32F42x, rev. 3
UID: 4D002C:3535510A:36353931 
nsh: mount: mount failed: No such device
INFO  [tone_alarm] missing command, try 'start', status, 'stop'
nsh: mkfatfs: mkfatfs failed: No such device
INFO  [tone_alarm] missing command, try 'start', status, 'stop'
INFO  [tune_control] Publishing standard tune 1
INFO  [param] selected parameter default file /fs/mtd_params
WARN  [rgbled] no RGB led on bus #1
WARN  [blinkm] I2C init failed
WARN  [blinkm] init failed
nsh: rgbled_pwm: command not found
ERROR [param] Parameter SYS_USE_IO not found
WARN  [dataman] Could not open data manager file /fs/microsd/dataman
ERROR [dataman] dataman start failed
WARN  [drivers_board] reset done, 50 ms
MS5611_SPI on SPI bus 2 at 3 (20000 KHz)
WARN  [bst] no devices found
WARN  [hmc5883] no device on bus 1 (type: 2)
WARN  [lis3mdl] no device on bus 2
BMP280_I2C on I2C bus 1 at 0x76 (bus: 100 KHz, max: 100 KHz)
WARN  [bmp280] id of your baro is not: 0x58
WARN  [bmp280] bus option number is 2
ERROR [bmp280] driver start failed
ERROR [bmm150] Internal I2C not available
HMC5883_SPI on SPI bus 1 at 5 (11000 KHz)
WARN  [hmc5883] no device on bus 1 (type: 3)
WARN  [lis3mdl] no device on bus 2
LIS3MDL_SPI on SPI bus 1 at 7 (11000 KHz)
WARN  [lis3mdl] no device on bus 3
WARN  [bmi055] No BMI055 gyro found
WARN  [mpu6000] no device on bus #3 (SPI1)
WARN  [mpu6000] no device on bus #3 (SPI1)
WARN  [bmi055] No BMI055 accel found
MPU9250 on SPI bus 1 at 4 (1000 KHz)
INFO  [mpu9250] accel cutoff set to 30.00 Hz
INFO  [mpu9250] gyro cutoff set to 80.00 Hz
WARN  [mpu9250] probe failed! 255
WARN  [mpu9250] no device on bus 4
INFO  [load_mon] stack check enabled
INFO  [mavlink] mode: Config, data rate: 800000 B/s on /dev/ttyACM0 @ 57600B
ERROR [mavlink] DM_KEY_MISSION_STATE lock failed
ERROR [mavlink] offboard mission init failed (-1)
INFO  [mavlink] mode: Normal, data rate: 20000 B/s on /dev/ttyS0 @ 921600B
WARN  [mavlink] hardware flow control not supported
INFO  [mavlink] mode: Normal, data rate: 1200 B/s on /dev/ttyS1 @ 57600B
INFO  [mavlink] mode: Normal, data rate: 20000 B/s on /dev/ttyS2 @ 921600B
px4flow [244:100]
No autostart ID found 
INFO  [px4flow] scanning I2C buses for device..
INFO  [logger] logger started (mode=all)
INFO  [logger] log root dir created: /fs/microsd/log

NuttShell (NSH)
nsh> INFO  [ecl/EKF] EKF aligned, (pressure height, IMU buf: 22, OBS buf: 14)
INFO  [frsky_telemetry] Scanning timeout: exiting
```