### PR TITLE
Continued work to group/condense/consolidate logic in rcS.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -13,16 +13,6 @@ set MIXER_AUX_FILE none
 set OUTPUT_AUX_DEV /dev/pwm_output1
 set SDCARD_MIXERS_PATH /fs/microsd/etc/mixers
 
-if ver hwcmp AEROFC_V1 AV_X_V1 CRAZYFLIE MINDPX_V2 NXPHLITE_V3 PX4FMU_V4 OMNIBUS_F4SD
-then
-	set MIXER_AUX none
-fi
-
-if [ $USE_IO == no ]
-then
-	set MIXER_AUX none
-fi
-
 #
 # If mount (gimbal) control is enabled and output mode is AUX, set the aux
 # mixer to mount (override the airframe-specific MIXER_AUX setting).
@@ -36,6 +26,15 @@ else
         fi
 fi
 
+if ver hwcmp AEROFC_V1 AV_X_V1 CRAZYFLIE MINDPX_V2 NXPHLITE_V3 PX4FMU_V4 OMNIBUS_F4SD
+then
+	set MIXER_AUX none
+fi
+
+if [ $USE_IO == no ]
+then
+	set MIXER_AUX none
+fi
 
 if [ $MIXER != none -a $MIXER != skip ]
 then

--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -23,6 +23,20 @@ then
 	set MIXER_AUX none
 fi
 
+#
+# If mount (gimbal) control is enabled and output mode is AUX, set the aux
+# mixer to mount (override the airframe-specific MIXER_AUX setting).
+#
+if param compare MNT_MODE_IN -1
+then
+else
+        if param compare MNT_MODE_OUT 0
+        then
+                set MIXER_AUX mount
+        fi
+fi
+
+
 if [ $MIXER != none -a $MIXER != skip ]
 then
 	#

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -90,7 +90,7 @@ else
 	then
 		if mount -t vfat /dev/mmcsd0 /fs/microsd
 		then
-			echo "INFO  [init] card formatted"
+			echo "INFO [init] card formatted"
 		else
 			echo "ERROR [init] format failed"
 			tone_alarm MNBG
@@ -135,6 +135,22 @@ else
 	# play startup tone.
 	#
 	tune_control play -t 1
+
+	#
+	# Waypoint storage.
+	# REBOOTWORK this needs to start in parallel.
+	#
+	dataman start $DATAMAN_OPT
+
+	#
+	# Start the socket communication send_event handler.
+	#
+	send_event start
+
+	#
+	# Start the resource load monitor.
+	#
+	load_mon start
 
 	#
 	# Set the parameter file if mtd starts successfully.
@@ -293,7 +309,6 @@ else
 		fi
 
 		param set SYS_AUTOCONFIG 0
-		param save
 	fi
 
 	#
@@ -387,6 +402,7 @@ else
 			then
 				# Reduce logger buffer to free up some RAM for UAVCAN servers.
 				set LOGGER_BUF 6
+
 				# Start UAVCAN firmware update server and dynamic node ID allocation server.
 				uavcan start fw
 
@@ -424,30 +440,6 @@ else
 		camera_trigger start
 		param set CAM_FBACK_MODE 1
 		camera_feedback start
-	fi
-
-	#
-	# If mount (gimbal) control is enabled and output mode is AUX, set the aux
-	# mixer to mount (override the airframe-specific MIXER_AUX setting).
-	#
-	if param compare MNT_MODE_IN -1
-	then
-	else
-		if param compare MNT_MODE_OUT 0
-		then
-			set MIXER_AUX mount
-		fi
-	fi
-
-	#
-	# Start vmount to control mounts such as gimbals, disabled by default.
-	#
-	if param compare MNT_MODE_IN -1
-	then
-	else
-		if vmount start
-		then
-		fi
 	fi
 
 	#
@@ -560,22 +552,6 @@ else
 	fi
 
 	#
-	# Waypoint storage.
-	# REBOOTWORK this needs to start in parallel.
-	#
-	dataman start $DATAMAN_OPT
-
-	#
-	# Start the socket communication send_event handler.
-	#
-	send_event start
-
-	#
-	# Start the resource load monitor.
-	#
-	load_mon start
-
-	#
 	# Start mavlink streams.
 	#
 	sh /etc/init.d/rc.mavlink
@@ -601,6 +577,17 @@ else
 	# Start the logger.
 	#
 	sh /etc/init.d/rc.logging
+
+	#
+	# Start vmount to control mounts such as gimbals, disabled by default.
+	#
+	if param compare MNT_MODE_IN -1
+	then
+	else
+		if vmount start
+		then
+		fi
+	fi
 
 	#
 	# Launch the flow sensor as a background task.

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -241,14 +241,6 @@ else
 	#                 End Setup for board specific configurations.                #
 	###############################################################################
 
-	#
-	# Set USE_IO flag.
-	#
-	if param compare SYS_USE_IO 1
-	then
-		set USE_IO yes
-	fi
-
 	if param compare SYS_FMU_TASK 1
 	then
 		set FMU_ARGS "-t"
@@ -261,19 +253,6 @@ else
 	then
 	else
 		sh /etc/init.d/rc.autostart
-	fi
-
-	#
-	# If mount (gimbal) control is enabled and output mode is AUX, set the aux
-	# mixer to mount (override the airframe-specific MIXER_AUX setting).
-	#
-	if param compare MNT_MODE_IN -1
-	then
-	else
-		if param compare MNT_MODE_OUT 0
-		then
-			set MIXER_AUX mount
-		fi
 	fi
 
 	#
@@ -314,6 +293,7 @@ else
 		fi
 
 		param set SYS_AUTOCONFIG 0
+		param save
 	fi
 
 	#
@@ -361,18 +341,18 @@ else
 		fi
 	fi
 
+	#
+	# Set USE_IO flag.
+	#
+	if param compare SYS_USE_IO 1
+	then
+		set USE_IO yes
+	fi
+
 	if [ $USE_IO == yes -a $IO_PRESENT == no ]
 	then
 		echo "PX4IO not found" >> $LOG_FILE
 		tune_control play -m ${TUNE_ERR}
-	fi
-
-	#
-	# Waypoint storage.
-	# REBOOTWORK this needs to start in parallel.
-	#
-	if dataman start $DATAMAN_OPT
-	then
 	fi
 
 	#
@@ -395,13 +375,9 @@ else
 		commander start
 	fi
 
-	send_event start
-	load_mon start
-
 	#
 	# Check if UAVCAN is enabled, default to it for ESCs.
 	#
-	
 	if param greater UAVCAN_ENABLE 0
 	then
 		# Start core UAVCAN module.
@@ -431,7 +407,7 @@ else
 		set FMU_MODE pwm4
 		set AUX_MODE pwm4
 	fi
-	
+
 	if param greater TRIG_MODE 0
 	then
 		# We ONLY support trigger on pins 5 and 6 when simultanously using AUX for actuator output.
@@ -444,10 +420,34 @@ else
 			set FMU_MODE none
 			set AUX_MODE none
 		fi
-		camera_trigger start
 
+		camera_trigger start
 		param set CAM_FBACK_MODE 1
 		camera_feedback start
+	fi
+
+	#
+	# If mount (gimbal) control is enabled and output mode is AUX, set the aux
+	# mixer to mount (override the airframe-specific MIXER_AUX setting).
+	#
+	if param compare MNT_MODE_IN -1
+	then
+	else
+		if param compare MNT_MODE_OUT 0
+		then
+			set MIXER_AUX mount
+		fi
+	fi
+
+	#
+	# Start vmount to control mounts such as gimbals, disabled by default.
+	#
+	if param compare MNT_MODE_IN -1
+	then
+	else
+		if vmount start
+		then
+		fi
 	fi
 
 	#
@@ -560,16 +560,25 @@ else
 	fi
 
 	#
+	# Waypoint storage.
+	# REBOOTWORK this needs to start in parallel.
+	#
+	dataman start $DATAMAN_OPT
+
+	#
+	# Start the socket communication send_event handler.
+	#
+	send_event start
+
+	#
+	# Start the resource load monitor.
+	#
+	load_mon start
+
+	#
 	# Start mavlink streams.
 	#
 	sh /etc/init.d/rc.mavlink
-
-
-	if ver hwcmp PX4FMU_V2 PX4FMU_V4 PX4FMU_V4PRO MINDPX_V2 PX4FMU_V5 OMNIBUS_F4SD
-	then
-		# Check for flow sensor - as it is a background task, launch it last.
-		px4flow start &
-	fi
 
 	#
 	# Configure vehicle type specific parameters.
@@ -583,33 +592,32 @@ else
 	#
 	navigator start
 
-	# Start any custom addons.
-	if [ -f $FEXTRAS ]
-	then
-		echo "Addons script: ${FEXTRAS}"
-		sh $FEXTRAS
-	fi
-
 	#
 	# Start a thermal calibration if required.
 	#
 	sh /etc/init.d/rc.thermal_cal
 
 	#
-	# vmount to control mounts such as gimbals, disabled by default.
-	#
-	if param compare MNT_MODE_IN -1
-	then
-	else
-		if vmount start
-		then
-		fi
-	fi
-
-	#
 	# Start the logger.
 	#
 	sh /etc/init.d/rc.logging
+
+	#
+	# Launch the flow sensor as a background task.
+	#
+	if ver hwcmp PX4FMU_V2 PX4FMU_V4 PX4FMU_V4PRO MINDPX_V2 PX4FMU_V5 OMNIBUS_F4SD
+	then
+		px4flow start &
+	fi
+
+	#
+	# Start any custom addons.
+	#
+	if [ -f $FEXTRAS ]
+	then
+		echo "Addons script: ${FEXTRAS}"
+		sh $FEXTRAS
+	fi
 
 # End of autostart.
 fi


### PR DESCRIPTION
Hi,

This PR is an additional step to group/condense logic in the rcS startup script to improve readability and maintainability in the startup scripts.  This PR does not conflict with PR  #9936 and is intended to facilitate that work, along with additional future PRs in the startup scripts.

This PR orders the dataman, send_event, load_mon call in the startup script lower in the list, and groups logic aimed toward parameter setting higher up.  For convenience, below is a compare between the changes of between the startup output from PX4/Firmware master branch, (left), and this PR, (right).

Please let me know if you have any questions or feedback on this PR.

-Mark

![image](https://user-images.githubusercontent.com/2497951/42858640-c580cd98-8a0c-11e8-99bc-520648237e6f.png)


 
