### PR TITLE
AUTOPILOT_HOST address for Raspberrypi2/3 included in posix CMakeLists

### DIFF
--- a/platforms/posix/CMakeLists.txt
+++ b/platforms/posix/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 
 if ("${BOARD}" STREQUAL "rpi")
 	add_custom_target(upload
-		COMMAND scp -r $<TARGET_FILE:px4> ${PX4_SOURCE_DIR}/posix-configs/rpi/*.config ${PX4_SOURCE_DIR}/ROMFS pi@navio:/home/pi
+		COMMAND scp -r $<TARGET_FILE:px4> ${PX4_SOURCE_DIR}/posix-configs/rpi/*.config ${PX4_SOURCE_DIR}/ROMFS pi@"ENV{AUTOPILOT_HOST}":/home/pi
 		DEPENDS px4
 		COMMENT "uploading px4"
 		USES_TERMINAL


### PR DESCRIPTION
Changed the navio2 upload address from `pi@navio` to `pi@"ENV{AUTOPILOT_HOST}"`, to be consistent with the doucmentation https://dev.px4.io/en/setup/building_px4.html#raspberry-pi-23-boards. 