### PR TITLE
[DO NOT MERGE] Saves 9640 bytes of FLASH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "mavlink/include/mavlink/v2.0"]
 	path = mavlink/include/mavlink/v2.0
-	url = https://github.com/mavlink/c_library_v2.git
+	url = https://github.com/PX4-Works/c_library_v2.git
 	branch = master
 [submodule "src/modules/uavcan/libuavcan"]
 	path = src/modules/uavcan/libuavcan

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -77,7 +77,7 @@
 #include <uORB/topics/vehicle_command_ack.h>
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/mavlink_log.h>
-
+#include <v2.0/mavlink_implement.h>
 #include "mavlink_bridge_header.h"
 #include "mavlink_main.h"
 #include "mavlink_messages.h"


### PR DESCRIPTION
This will save 9640 bytes of FLASH. It is dependant on this breaking (***manageable**) change. https://github.com/mavlink/c_library_v2/pull/2/commits/9b3d6b2b62bf9b4c727d8d84ef507a8dcd0995f1  

Commit 797c52e50287a8734540db5b67350338b3d89bf5 should be dropped if the PR is taken in upstream mavlink.


***The mavlink_inplement. file MUST be included in one and only one source file (.c or .cpp)**