### PR TITLE
px4_base: switch visibility.h back to relative include path

### DIFF
--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -454,7 +454,7 @@ function(px4_add_common_flags)
 
 	set(visibility_flags
 		-fvisibility=hidden
-		-include ${PX4_SOURCE_DIR}/src/include/visibility.h
+		-include visibility.h
 		)
 
 	set(added_c_flags


### PR DESCRIPTION
The include path of `visibility.h` was recently changed back to absolute here: https://github.com/PX4/Firmware/commit/83fd5a5fd1e5d35f8c705b43cb61e81f825136bd

The Cygwin toolcahin does not find the file with this absolute path generation and hence master does not build anymore.

Can we merge this pr and change it back to relative? It was changed to realtive before: https://github.com/PX4/Firmware/commit/3f0653e824949f5e991bc279d9f1f4749a7914c0#diff-5f4402a03edacf409e7501a9039d3392R582

**What's the advantage of the absolute path here?**

Alternatively I could add an extra absolute path generation dealing with cygpath conversion that does not break under Cygwin but I'd like to avoid that.
