### PR TITLE
Migrate LOGGER_BUF instances to rc.logging, group OUTPUT_MODE instances, and alphabetize hardware cases in rc.sensors.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.logging
+++ b/ROMFS/px4fmu_common/init.d/rc.logging
@@ -5,6 +5,26 @@
 #
 
 set LOGGER_ARGS ""
+set LOGGER_BUF  14
+
+if param greater UAVCAN_ENABLE 1
+then
+	# Reduce logger buffer to free up some RAM for UAVCAN servers.
+	set LOGGER_BUF 6
+fi
+
+###############################################################################
+#               Begin Setup for board specific configurations.                #
+###############################################################################
+
+if ver hwcmp PX4FMU_V5
+then
+	set LOGGER_BUF 64
+fi
+
+###############################################################################
+#                 End Setup for board specific configurations.                #
+###############################################################################
 
 if param compare SDLOG_MODE 1
 then
@@ -24,3 +44,4 @@ fi
 logger start -b ${LOGGER_BUF} -t ${LOGGER_ARGS}
 
 unset LOGGER_ARGS
+unset LOGGER_BUF

--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -3,6 +3,10 @@
 # Standard startup script for sensor drivers.
 #
 
+###############################################################################
+#               Begin Setup for board specific configurations.                #
+###############################################################################
+
 if ver hwcmp AEROFC_V1 OMNIBUS_F4SD
 then
 	# Aero FC uses separate driver
@@ -40,16 +44,23 @@ else
 	adc start
 fi
 
-if ver hwcmp NXPHLITE_V3
+if ver hwcmp AEROFC_V1
 then
-	# Internal I2C (baro)
-	mpl3115a2 -I start
+	ms5611 -T 0 start
+	mpu9250 -s -R 14 start
 
-	# Internal SPI (accel + mag)
-	fxos8701cq start -a 8 -R 0
+	# Possible external compasses
+	hmc5883 -X start
 
-	# Internal SPI (gyro)
-	fxas21002c start -R 0
+	ist8310 -C -b 1 -R 4 start
+	aerofc_adc start
+	ll40ls start i2c
+fi
+
+if ver hwcmp AEROCORE2
+then
+	l3gd20 -R 12 start
+	lsm303d start
 fi
 
 if ver hwcmp AUAV_X21
@@ -66,6 +77,45 @@ then
 
 	# Internal SPI bus mpu9250 is rotated 90 deg yaw
 	mpu9250 -R 2 start
+fi
+
+if ver hwcmp AV_X_V1
+then
+	adis16477 -R 8 start
+
+	#adis16497 start
+
+	lps22hb start
+
+	lsm303agr -R 4 start
+
+	#ms4525_airspeed start
+fi
+
+if ver hwcmp CRAZYFLIE
+then
+	# Onboard I2C
+	mpu9250 -R 12 start
+
+	# I2C bypass of mpu
+	lps25h start
+
+	# Optical flow deck
+	vl53lxx start
+	pmw3901 start
+
+fi
+
+if ver hwcmp NXPHLITE_V3
+then
+	# Internal I2C (baro)
+	mpl3115a2 -I start
+
+	# Internal SPI (accel + mag)
+	fxos8701cq start -a 8 -R 0
+
+	# Internal SPI (gyro)
+	fxas21002c start -R 0
 fi
 
 if ver hwcmp PX4FMU_V2
@@ -245,33 +295,6 @@ then
 	l3gd20 -R 14 start
 fi
 
-if ver hwcmp CRAZYFLIE
-then
-	# Onboard I2C
-	mpu9250 -R 12 start
-
-	# I2C bypass of mpu
-	lps25h start
-
-	# Optical flow deck
-	vl53lxx start
-	pmw3901 start
-
-fi
-
-if ver hwcmp AEROFC_V1
-then
-	ms5611 -T 0 start
-	mpu9250 -s -R 14 start
-
-	# Possible external compasses
-	hmc5883 -X start
-
-	ist8310 -C -b 1 -R 4 start
-	aerofc_adc start
-	ll40ls start i2c
-fi
-
 if ver hwcmp OMNIBUS_F4SD
 then
 	mpu6000 -R 12 -s start
@@ -329,28 +352,13 @@ then
 	ist8310 -C -b 5 start
 fi
 
-if ver hwcmp AV_X_V1
-then
-	adis16477 -R 8 start
+###############################################################################
+#                 End Setup for board specific configurations.                #
+###############################################################################
 
-	#adis16497 start
-
-	lps22hb start
-
-	lsm303agr -R 4 start
-
-	#ms4525_airspeed start
-fi
-
-if ver hwcmp AEROCORE2
-then
-	l3gd20 -R 12 start
-	lsm303d start
-fi
-
-#
-# Optional drivers
-#
+###############################################################################
+#                           Begin Optional drivers                            #
+###############################################################################
 
 if [ ${VEHICLE_TYPE} == fw -o ${VEHICLE_TYPE} == vtol ]
 then
@@ -391,13 +399,13 @@ then
 	ll40ls start i2c
 fi
 
-# lightware serial lidar sensor
+# Lightware serial lidar sensor
 if param greater SENS_EN_SF0X 0
 then
 	sf0x start
 fi
 
-# lightware i2c lidar sensor
+# Lightware i2c lidar sensor
 if param greater SENS_EN_SF1XX 0
 then
 	sf1xx start -a
@@ -409,7 +417,7 @@ then
 	mb12xx start -a
 fi
 
-# teraranger one tof sensor
+# Teraranger one tof sensor
 if param greater SENS_EN_TRANGER 0
 then
 	teraranger start -a
@@ -457,6 +465,10 @@ then
 		fi
 	fi
 fi
+
+###############################################################################
+#                            End Optional drivers                             #
+###############################################################################
 
 # Wait 20 ms for sensors (because we need to wait for the HRT and work queue callbacks to fire)
 usleep 20000

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -29,7 +29,6 @@ set FMU_MODE                    pwm
 set IO_FILE                     ""
 set IO_PRESENT                  no
 set LOG_FILE                    /fs/microsd/bootlog.txt
-set LOGGER_BUF                  14
 set MAVLINK_F                   default
 set MAVLINK_COMPANION_DEVICE    /dev/ttyS2
 set MAV_TYPE                    none
@@ -215,20 +214,6 @@ else
 	#               Begin setup for board specific configurations.                #
 	###############################################################################
 
-	if ver hwcmp PX4FMU_V5
-	then
-		set LOGGER_BUF 64
-	fi
-
-	if ver hwcmp CRAZYFLIE
-	then
-		if param compare SYS_AUTOSTART 0
-		then
-			param set SYS_AUTOSTART 4900
-			set AUTOCNF yes
-		fi
-	fi
-
 	if ver hwcmp AEROCORE2
 	then
 		set DATAMAN_OPT "-f /fs/mtd_dataman"
@@ -246,6 +231,15 @@ else
 		param set SYS_AUTOSTART 4070
 
 		set DATAMAN_OPT -i
+	fi
+
+	if ver hwcmp CRAZYFLIE
+	then
+		if param compare SYS_AUTOSTART 0
+		then
+			param set SYS_AUTOSTART 4900
+			set AUTOCNF yes
+		fi
 	fi
 
 	if ver hwcmp NXPHLITE_V3
@@ -285,16 +279,16 @@ else
 	#
 	if [ $AUTOCNF == yes ]
 	then
-		# Disable safety switch by default on Pixracer and OmnibusF4SD
-		if ver hwcmp PX4FMU_V4 OMNIBUS_F4SD
-		then
-			param set CBRK_IO_SAFETY 22027
-		fi
-
 		# Run FMU as task on Pixracer and on boards with enough RAM.
 		if ver hwcmp PX4FMU_V4 PX4FMU_V4PRO PX4FMU_V5
 		then
 			param set SYS_FMU_TASK 1
+		fi
+
+		# Disable safety switch by default on Pixracer and OmnibusF4SD
+		if ver hwcmp PX4FMU_V4 OMNIBUS_F4SD
+		then
+			param set CBRK_IO_SAFETY 22027
 		fi
 
 		if ver hwcmp OMNIBUS_F4SD
@@ -390,32 +384,6 @@ else
 		commander start
 	fi
 
-	#
-	# Check if UAVCAN is enabled, default to it for ESCs.
-	#
-	if param greater UAVCAN_ENABLE 0
-	then
-		# Start core UAVCAN module.
-		if uavcan start
-		then
-			if param greater UAVCAN_ENABLE 1
-			then
-				# Reduce logger buffer to free up some RAM for UAVCAN servers.
-				set LOGGER_BUF 6
-
-				# Start UAVCAN firmware update server and dynamic node ID allocation server.
-				uavcan start fw
-
-				if param greater UAVCAN_ENABLE 2
-				then
-					set OUTPUT_MODE uavcan_esc
-				fi
-			fi
-		else
-			tone_alarm ${TUNE_ERR}
-		fi
-	fi
-
 	# Sensors on the PWM interface bank.
 	if param compare SENS_EN_LL40LS 1
 	then
@@ -440,6 +408,29 @@ else
 		camera_trigger start
 		param set CAM_FBACK_MODE 1
 		camera_feedback start
+	fi
+
+	#
+	# Check if UAVCAN is enabled, default to it for ESCs.
+	#
+	if param greater UAVCAN_ENABLE 0
+	then
+		# Start core UAVCAN module.
+		if uavcan start
+		then
+			if param greater UAVCAN_ENABLE 1
+			then
+				# Start UAVCAN firmware update server and dynamic node ID allocation server.
+				uavcan start fw
+
+				if param greater UAVCAN_ENABLE 2
+				then
+					set OUTPUT_MODE uavcan_esc
+				fi
+			fi
+		else
+			tone_alarm ${TUNE_ERR}
+		fi
 	fi
 
 	#
@@ -611,7 +602,6 @@ unset FMU_MODE
 unset IO_FILE
 unset IO_PRESENT
 unset LOG_FILE
-unset LOGGER_BUF
 unset MAVLINK_F
 unset MAVLINK_COMPANION_DEVICE
 unset MAV_TYPE


### PR DESCRIPTION
Hi,

This PR moves the LOGGER_BUF instances to rc.logging, moves OUTPUT_MODE instances closer together by relocating UAVCAN logic block in rcS, and alphabetizes hardware specific logic in rc.sensors.

This work is simply to tidy up the scripts for easier readability and future maintainability.

Let me know if you have any questions or comments on this PR.

-Mark