### PR TITLE
Formatted whitespace and comments, standardized comments in src/drivers/boards/px4fmu-v4/board_config.h and  src/drivers/boards/px4fmu-v4/init.c

### DIFF
--- a/src/drivers/boards/px4fmu-v4/board_config.h
+++ b/src/drivers/boards/px4fmu-v4/board_config.h
@@ -65,27 +65,35 @@
 
 #define BOARD_HAS_CONTROL_STATUS_LEDS      1
 
-/*  Define the Chip Selects for SPI1
+/**
+ *  Define the Chip Selects for SPI1
  *  CS           Devices                                 DRDY
  *  ---- ----------------------------------------------- -----
-    PC2  MPU9250                    BMI160               PD15
-    PC15 ICM, ICM_20602, ICM_20608  BMI055_ACCEL         PC14
-    PE15 HMC5983                    BMI055_GYRO          PE12
+ *  PC2  MPU9250                    BMI160               PD15
+ *  PC15 ICM, ICM_20602, ICM_20608  BMI055_ACCEL         PC14
+ *  PE15 HMC5983                    BMI055_GYRO          PE12
  *  ---- ----------------------------------------------- -----
-*/
-/* The BMI160 sensor replaces the MPU9250 on some boards. Only one is actually present and connected
- * to the second GPIO pin on port C. The wrong driver will fail during start because of an incorrect WHO_AM_I register.*/
+ */
+
+/**
+ * The BMI160 sensor replaces the MPU9250 on some boards. Only one is actually present and connected
+ * to the second GPIO pin on port C. The wrong driver will fail during start because of an incorrect WHO_AM_I register.
+ */
 #define GPIO_SPI1_CS_PORTC_PIN2      (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN2)
 
-/* The BMI055 acceleration sensor replaces the ICM20608G on some boards. Only one is actually present and connected
- * to the second GPIO pin on port C. The wrong driver will fail during start because of an incorrect WHO_AM_I register.*/
+/**
+ * The BMI055 acceleration sensor replaces the ICM20608G on some boards. Only one is actually present and connected
+ * to the second GPIO pin on port C. The wrong driver will fail during start because of an incorrect WHO_AM_I register.
+ */
 #define GPIO_SPI1_CS_PORTC_PIN15     (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN15)
 
-/* The BMI055 gyroscope sensor replaces the LIS3MDL, HMC5983 on some boards. Only one is actually present and connected
- * to the second GPIO pin on port E. The wrong driver will fail during start because of an incorrect WHO_AM_I register.*/
+/**
+ * The BMI055 gyroscope sensor replaces the LIS3MDL, HMC5983 on some boards. Only one is actually present and connected
+ * to the second GPIO pin on port E. The wrong driver will fail during start because of an incorrect WHO_AM_I register.
+ */
 #define GPIO_SPI1_CS_PORTE_PIN15     (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTE|GPIO_PIN15)
 
-/*  Define the Data Ready interrupts On SPI 1*/
+/* Define the Data Ready interrupts On SPI 1. */
 
 #define GPIO_DRDY_PORTD_PIN15        (GPIO_INPUT|GPIO_FLOAT|GPIO_EXTI|GPIO_PORTD|GPIO_PIN15)
 #define GPIO_DRDY_PORTC_PIN14        (GPIO_INPUT|GPIO_FLOAT|GPIO_EXTI|GPIO_PORTC|GPIO_PIN14)
@@ -93,39 +101,40 @@
 
 
 
-/*  Define the Chip Selects for SPI2 */
+/* Define the Chip Selects for SPI2. */
 
 #define GPIO_SPI2_CS_MS5611          (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTD|GPIO_PIN7)
 #define GPIO_SPI2_CS_FRAM            (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTD|GPIO_PIN10)
 
-/* There are no DRDY on SPI 2 */
+/* There are no DRDY on SPI 2. */
 
-/*
- *  Define the ability to shut off off the sensor signals
- *  by changing the signals to inputs
+/**
+ * Define the ability to shut off off the sensor signals
+ * by changing the signals to inputs.
  */
 
 #define _PIN_OFF(def) (((def) & (GPIO_PORT_MASK | GPIO_PIN_MASK)) | (GPIO_INPUT|GPIO_PULLDOWN|GPIO_SPEED_2MHz))
 
-/* SPI 1 bus off */
+/* SPI 1 bus off. */
 
 #define GPIO_SPI1_SCK_OFF            _PIN_OFF(GPIO_SPI1_SCK)
 #define GPIO_SPI1_MISO_OFF           _PIN_OFF(GPIO_SPI1_MISO)
 #define GPIO_SPI1_MOSI_OFF           _PIN_OFF(GPIO_SPI1_MOSI)
 
-/* SPI 1 CS's  off */
+/* SPI 1 CS's  off. */
 
 #define GPIO_SPI1_CS_OFF_PORTC_PIN2  _PIN_OFF(GPIO_SPI1_CS_PORTC_PIN2)
 #define GPIO_SPI1_CS_OFF_PORTC_PIN15 _PIN_OFF(GPIO_SPI1_CS_PORTC_PIN15)
 #define GPIO_SPI1_CS_OFF_PORTE_PIN15 _PIN_OFF(GPIO_SPI1_CS_PORTE_PIN15)
 
-/* SPI 1 DRDY's  off */
+/* SPI 1 DRDY's off. */
 
 #define GPIO_DRDY_OFF_PORTD_PIN15    _PIN_OFF(GPIO_DRDY_PORTD_PIN15)
 #define GPIO_DRDY_OFF_PORTC_PIN14    _PIN_OFF(GPIO_DRDY_PORTC_PIN14)
 #define GPIO_DRDY_OFF_PORTE_PIN12    _PIN_OFF(GPIO_DRDY_PORTE_PIN12)
 
-/* N.B we do not have control over the SPI 2 buss powered devices
+/**
+ * N.B we do not have control over the SPI 2 buss powered devices
  * so the the ms5611 is not resetable.
  */
 
@@ -149,9 +158,10 @@
 #define PX4_SPIDEV_BMI055_GYR        PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 13)
 #define PX4_SPIDEV_MPU2              PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS, 14)
 
-/* onboard MS5611 and FRAM are both on bus SPI2
- * spi_dev_e:SPIDEV_FLASH has the value 2 and is used in the NuttX ramtron driver
- * PX4_MK_SPI_SEL  differentiate by adding in PX4_SPI_DEVICE_ID
+/**
+ * Onboard MS5611 and FRAM are both on bus SPI2.
+ * spi_dev_e:SPIDEV_FLASH has the value 2 and is used in the NuttX ramtron driver.
+ * PX4_MK_SPI_SEL  differentiate by adding in PX4_SPI_DEVICE_ID.
  */
 #define PX4_SPIDEV_BARO             PX4_MK_SPI_SEL(PX4_SPI_BUS_BARO, 3)
 
@@ -159,34 +169,33 @@
 #define PX4_I2C_BUS_EXPANSION        1
 #define PX4_I2C_BUS_LED              PX4_I2C_BUS_EXPANSION
 
-/* Devices on the external bus.
- *
+/**
+ * Devices on the external bus.
  * Note that these are unshifted addresses.
  */
 #define PX4_I2C_OBDEV_BMP280         0x76
 
-/*
+/**
  * ADC channels
  *
- * These are the channel numbers of the ADCs of the microcontroller that can be used by the Px4 Firmware in the adc driver
+ * These are the channel numbers of the ADCs of the microcontroller that can be used by the Px4 Firmware in the adc driver.
  */
 #define ADC_CHANNELS (1 << 2) | (1 << 3) | (1 << 4) | (1 << 10) | (1 << 11) | (1 << 12) | (1 << 13) | (1 << 14)
 
-// ADC defines to be used in sensors.cpp to read from a particular channel
+/* ADC defines to be used in sensors.cpp to read from a particular channel. */
 #define ADC_BATTERY_VOLTAGE_CHANNEL  2
 #define ADC_BATTERY_CURRENT_CHANNEL  3
 #define ADC_5V_RAIL_SENSE            4
 #define ADC_RC_RSSI_CHANNEL          11
 
-/* Define Battery 1 Voltage Divider and A per V
- */
+/* Define Battery 1 Voltage Divider and A per V. */
 
 #define BOARD_BATTERY1_V_DIV         (13.653333333f)
 #define BOARD_BATTERY1_A_PER_V       (36.367515152f)
 
 
-/* User GPIOs
- *
+/**
+ * User GPIOs:
  * GPIO0-5 are the PWM servo outputs.
  */
 #define GPIO_GPIO0_INPUT             (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTE|GPIO_PIN14)
@@ -203,18 +212,19 @@
 #define GPIO_GPIO4_OUTPUT            (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTD|GPIO_PIN13)
 #define GPIO_GPIO5_OUTPUT            (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTD|GPIO_PIN14)
 
-/* Power supply control and monitoring GPIOs */
+/* Power supply control and monitoring GPIOs. */
 #define GPIO_VDD_BRICK_VALID         (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTB|GPIO_PIN5)
 #define GPIO_VDD_USB_VALID           (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTC|GPIO_PIN0)
 #define GPIO_VDD_3V3_SENSORS_EN      (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTE|GPIO_PIN3)
 
-/* Tone alarm output */
+/* Tone alarm output. */
 #define TONE_ALARM_TIMER             2    /* timer 2 */
 #define TONE_ALARM_CHANNEL           1    /* channel 1 */
 #define GPIO_TONE_ALARM_IDLE         (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTA|GPIO_PIN15)
 #define GPIO_TONE_ALARM              (GPIO_ALT|GPIO_AF1|GPIO_SPEED_2MHz|GPIO_PUSHPULL|GPIO_PORTA|GPIO_PIN15)
 
-/* PWM
+/**
+ * PWM:
  *
  * Six PWM outputs are configured.
  *
@@ -228,7 +238,8 @@
  * CH6 : PD14 : TIM4_CH3
  */
 
-/* N.B. the added pull down, on the timer being disabled the PD
+/**
+ * N.B. the added pull down, on the timer being disabled the PD
  * will keep the channel low
  */
 #define GPIO_TIM1_CH1OUT             (GPIO_ALT|GPIO_AF1|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PUSHPULL|GPIO_PULLDOWN|GPIO_PORTE|GPIO_PIN9)
@@ -247,22 +258,23 @@
 #define GPIO_TIM4_CH3IN              GPIO_TIM4_CH3IN_2
 #define DIRECT_INPUT_TIMER_CHANNELS  6
 
-/* USB OTG FS
+/**
+ * USB OTG FS:
  *
- * PA9  OTG_FS_VBUS VBUS sensing
+ * PA9  OTG_FS_VBUS VBUS sensing.
  */
 #define GPIO_OTGFS_VBUS              (GPIO_INPUT|GPIO_FLOAT|GPIO_SPEED_100MHz|GPIO_OPENDRAIN|GPIO_PORTA|GPIO_PIN9)
 
 /* High-resolution timer */
-#define HRT_TIMER                    3   /* use timer 3 for the HRT */
-#define HRT_TIMER_CHANNEL            4   /* use capture/compare channel 4 */
+#define HRT_TIMER                    3  /* use timer 3 for the HRT */
+#define HRT_TIMER_CHANNEL            4  /* use capture/compare channel 4 */
 
-#define HRT_PPM_CHANNEL              3    /* use capture/compare channel 3 */
+#define HRT_PPM_CHANNEL              3  /* use capture/compare channel 3 */
 #define GPIO_PPM_IN                  (GPIO_ALT|GPIO_AF2|GPIO_PULLUP|GPIO_PORTB|GPIO_PIN0)
 
 #define RC_SERIAL_PORT               "/dev/ttyS4"
 
-/* PWM input driver. Use FMU AUX5 pins attached to timer4 channel 2 */
+/* PWM input driver. Use FMU AUX5 pins attached to timer4 channel 2. */
 #define PWMIN_TIMER                  4
 #define PWMIN_TIMER_CHANNEL          2
 #define GPIO_PWM_IN                  GPIO_TIM4_CH2IN_2
@@ -271,7 +283,7 @@
 #define GPIO_LED_SAFETY              (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN3)
 #define GPIO_BTN_SAFETY              (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTC|GPIO_PIN4)
 #define GPIO_PERIPH_3V3_EN           (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN5)
-/* for R12, this signal is active high */
+/* For R12, this signal is active high. */
 #define GPIO_SBUS_INV                (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTC|GPIO_PIN13)
 #define BOARD_INVERT_RC_INPUT(_invert_true, _na) px4_arch_gpiowrite(GPIO_SBUS_INV, _invert_true)
 
@@ -281,11 +293,11 @@
 #define GPIO_8266_PD                 (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTE|GPIO_PIN5)
 #define GPIO_8266_RST                (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_SET|GPIO_PORTE|GPIO_PIN6)
 
-/* Power switch controls ******************************************************/
+/* Power switch controls */
 
 #define SPEKTRUM_POWER(_on_true)     px4_arch_gpiowrite(GPIO_SPEKTRUM_PWR_EN, (!_on_true))
 
-/*
+/**
  * FMUv4 has separate RC_IN
  *
  * GPIO PPM_IN on PB0 T3C3
@@ -301,7 +313,8 @@
 
 #define    BOARD_NAME "PX4FMU_V4"
 
-/* By Providing BOARD_ADC_USB_CONNECTED (using the px4_arch abstraction)
+/**
+ * By Providing BOARD_ADC_USB_CONNECTED (using the px4_arch abstraction)
  * this board support the ADC system_power interface, and therefore
  * provides the true logic GPIO BOARD_ADC_xxxx macros.
  */
@@ -325,9 +338,8 @@
 		{GPIO_VDD_BRICK_VALID,   0,                       0}, \
 		{GPIO_VDD_USB_VALID,     0,                       0}, }
 
-/*
+/**
  * PX4FMUv4 GPIO numbers.
- *
  * There are no alternate functions on this board.
  */
 #define GPIO_SERVO_1                 (1<<0)  /**< servo 1 output */
@@ -341,7 +353,7 @@
 #define GPIO_BRICK_VALID             (1<<8)  /**< PB5 - !VDD_BRICK_VALID */
 #define GPIO_USB_VALID               (1<<9)  /**< PC0 - !GPIO_VDD_USB_VALID */
 
-/* This board provides a DMA pool and APIs */
+/* This board provides a DMA pool and APIs. */
 #define BOARD_DMA_ALLOC_POOL_SIZE    5120
 
 #define BOARD_HAS_ON_RESET 1

--- a/src/drivers/boards/px4fmu-v4/init.c
+++ b/src/drivers/boards/px4fmu-v4/init.c
@@ -103,7 +103,7 @@
 #  endif
 #endif
 
-/*
+/**
  * Ideally we'd be able to get these from up_internal.h,
  * but since we want to be able to disable the NuttX use
  * of leds for system indication at will and there is no
@@ -130,22 +130,21 @@ __END_DECLS
  ************************************************************************************/
 __EXPORT void board_peripheral_reset(int ms)
 {
-	/* set the peripheral rails off */
+	// Set the peripheral rails off.
 	stm32_configgpio(GPIO_PERIPH_3V3_EN);
 
 	stm32_gpiowrite(GPIO_PERIPH_3V3_EN, 0);
 
 	bool last = stm32_gpioread(GPIO_SPEKTRUM_PWR_EN);
-	/* Keep Spektum on to discharge rail*/
+	// Keep Spektum on to discharge rail.
 	stm32_gpiowrite(GPIO_SPEKTRUM_PWR_EN, 1);
 
-	/* wait for the peripheral rail to reach GND */
+	// Wait for the peripheral rail to reach GND.
 	usleep(ms * 1000);
 	warnx("reset done, %d ms", ms);
 
-	/* re-enable power */
-
-	/* switch the peripheral rail back on */
+	// Re-enable power.
+	// Switch the peripheral rail back on.
 	stm32_gpiowrite(GPIO_SPEKTRUM_PWR_EN, last);
 	stm32_gpiowrite(GPIO_PERIPH_3V3_EN, 1);
 
@@ -164,8 +163,7 @@ __EXPORT void board_peripheral_reset(int ms)
  ************************************************************************************/
 __EXPORT void board_on_reset(int status)
 {
-	/* configure the GPIO pins to outputs and keep them low */
-
+	// Configure the GPIO pins to outputs and keep them low.
 	stm32_configgpio(GPIO_GPIO0_OUTPUT);
 	stm32_configgpio(GPIO_GPIO1_OUTPUT);
 	stm32_configgpio(GPIO_GPIO2_OUTPUT);
@@ -173,7 +171,8 @@ __EXPORT void board_on_reset(int status)
 	stm32_configgpio(GPIO_GPIO4_OUTPUT);
 	stm32_configgpio(GPIO_GPIO5_OUTPUT);
 
-	/* On resets invoked from system (not boot) insure we establish a low
+	/**
+	 * On resets invoked from system (not boot) insure we establish a low
 	 * output state (discharge the pins) on PWM pins before they become inputs.
 	 */
 
@@ -195,27 +194,28 @@ __EXPORT void board_on_reset(int status)
 __EXPORT void
 stm32_boardinitialize(void)
 {
-	/* Reset all PWM to Low outputs */
+	// Reset all PWM to Low outputs.
 
 	board_on_reset(-1);
 
-	/* configure LEDs */
+	// Configure LEDs.
 	board_autoled_initialize();
 
 
-	/* configure ADC pins */
+	// Configure ADC pins.
 	stm32_configgpio(GPIO_ADC1_IN2);	/* BATT_VOLTAGE_SENS */
 	stm32_configgpio(GPIO_ADC1_IN3);	/* BATT_CURRENT_SENS */
 	stm32_configgpio(GPIO_ADC1_IN4);	/* VDD_5V_SENS */
 	stm32_configgpio(GPIO_ADC1_IN11);	/* RSSI analog in */
 
-	/* configure power supply control/sense pins */
+	// Configure power supply control/sense pins.
 	stm32_configgpio(GPIO_PERIPH_3V3_EN);
 	stm32_configgpio(GPIO_VDD_BRICK_VALID);
 	stm32_configgpio(GPIO_VDD_USB_VALID);
 
-	/* Start with Sensor voltage off We will enable it
-	 * in board_app_initialize
+	/**
+	 * Start with Sensor voltage off We will enable it
+	 * in board_app_initialize.
 	 */
 	stm32_configgpio(GPIO_VDD_3V3_SENSORS_EN);
 
@@ -226,13 +226,13 @@ stm32_boardinitialize(void)
 	stm32_configgpio(GPIO_8266_PD);
 	stm32_configgpio(GPIO_8266_RST);
 
-	/* Safety - led don in led driver */
+	// Safety - led on in led driver.
 
 	stm32_configgpio(GPIO_BTN_SAFETY);
 	stm32_configgpio(GPIO_RSSI_IN);
 	stm32_configgpio(GPIO_PPM_IN);
 
-	/* configure SPI all interfaces GPIO */
+	// Configure SPI all interfaces GPIO.
 
 	stm32_spiinitialize(PX4_SPI_BUS_RAMTRON | PX4_SPI_BUS_SENSORS);
 
@@ -272,7 +272,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #if defined(CONFIG_HAVE_CXX) && defined(CONFIG_HAVE_CXXINITIALIZE)
 
-	/* run C++ ctors before we go any further */
+	// Run C++ ctors before we go any further.
 
 	up_cxxinitialize();
 
@@ -284,27 +284,27 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 #  error platform is dependent on c++ both CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE must be defined.
 #endif
 
-	/* configure the high-resolution time/callout interface */
+	// Configure the high-resolution time/callout interface.
 	hrt_init();
 
 	param_init();
 
-	/* configure the DMA allocator */
+	// Configure the DMA allocator.
 
 	if (board_dma_alloc_init() < 0) {
 		message("DMA alloc FAILED");
 	}
 
-	/* configure CPU load estimation */
+	// Configure CPU load estimation.
 #ifdef CONFIG_SCHED_INSTRUMENTATION
 	cpuload_initialize_once();
 #endif
 
-	/* set up the serial DMA polling */
+	// Set up the serial DMA polling.
 	static struct hrt_call serial_dma_call;
 	struct timespec ts;
 
-	/*
+	/**
 	 * Poll at 1ms intervals for received bytes that have not triggered
 	 * a DMA event.
 	 */
@@ -319,11 +319,12 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 #if defined(CONFIG_STM32_BBSRAM)
 
-	/* NB. the use of the console requires the hrt running
-	 * to poll the DMA
+	/**
+	 * NB. the use of the console requires the hrt running
+	 * to poll the DMA.
 	 */
 
-	/* Using Battery Backed Up SRAM */
+	// Using Battery Backed Up SRAM.
 
 	int filesizes[CONFIG_STM32_BBSRAM_FILES + 1] = BSRAM_FILE_SIZES;
 
@@ -333,7 +334,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	/* Panic Logging in Battery Backed Up Files */
 
-	/*
+	/**
 	 * In an ideal world, if a fault happens in flight the
 	 * system save it to BBSRAM will then reboot. Upon
 	 * rebooting, the system will log the fault to disk, recover
@@ -347,8 +348,9 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	 * the SD card?
 	 */
 
-	/* Do we have an uncommitted hard fault in BBSRAM?
-	 *  - this will be reset after a successful commit to SD
+	/**
+	 * Do we have an uncommitted hard fault in BBSRAM?
+	 *  - this will be reset after a successful commit to SD.
 	 */
 	int hadCrash = hardfault_check_status("boot");
 
@@ -357,20 +359,22 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 		message("[boot] There is a hard fault logged. Hold down the SPACE BAR," \
 			" while booting to halt the system!\n");
 
-		/* Yes. So add one to the boot count - this will be reset after a successful
-		 * commit to SD
+		/**
+		 * Yes. So add one to the boot count - this will be reset after a successful
+		 * commit to SD.
 		 */
 
 		int reboots = hardfault_increment_reboot("boot", false);
 
-		/* Also end the misery for a user that holds for a key down on the console */
+		/* Also end the misery for a user that holds for a key down on the console. */
 
 		int bytesWaiting;
 		ioctl(fileno(stdin), FIONREAD, (unsigned long)((uintptr_t) &bytesWaiting));
 
 		if (reboots > 2 || bytesWaiting != 0) {
 
-			/* Since we can not commit the fault dump to disk. Display it
+			/**
+			 * Since we can not commit the fault dump to disk. Display it
 			 * to the console.
 			 */
 
@@ -381,11 +385,12 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 				(bytesWaiting == 0 ? "" : " Due to Key Press\n"));
 
 
-			/* For those of you with a debugger set a break point on up_assert and
+			/**
+			 * For those of you with a debugger set a break point on up_assert and
 			 * then set dbgContinue = 1 and go.
 			 */
 
-			/* Clear any key press that got us here */
+			// Clear any key press that got us here.
 
 			static volatile bool dbgContinue = false;
 			int c = '>';
@@ -449,17 +454,17 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 #endif // CONFIG_STM32_SAVE_CRASHDUMP
 #endif // CONFIG_STM32_BBSRAM
 
-	/* initial LED state */
+	// Initial LED state.
 	drv_led_start();
 	led_off(LED_RED);
 	led_off(LED_GREEN);
 	led_off(LED_BLUE);
 
-	/* Power up there sensors */
+	// Power up the sensors.
 
 	stm32_gpiowrite(GPIO_VDD_3V3_SENSORS_EN, 1);
 
-	/* Configure SPI-based devices */
+	// Configure SPI-based devices.
 
 	spi1 = stm32_spibus_initialize(1);
 
@@ -470,7 +475,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	}
 
 
-	/* Default SPI1 to 1MHz and de-assert the known chip selects. */
+	// Default SPI1 to 1MHz and de-assert the known chip selects.
 	SPI_SETFREQUENCY(spi1, 10000000);
 	SPI_SETBITS(spi1, 8);
 	SPI_SETMODE(spi1, SPIDEV_MODE3);
@@ -479,7 +484,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	SPI_SELECT(spi1, PX4_SPIDEV_MPU, false);
 	up_udelay(20);
 
-	/* Get the SPI port for the FRAM */
+	// Get the SPI port for the FRAM.
 
 	spi2 = stm32_spibus_initialize(2);
 
@@ -489,11 +494,12 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 		return -ENODEV;
 	}
 
-	/* Default SPI2 to 12MHz and de-assert the known chip selects.
-	 * MS5611 has max SPI clock speed of 20MHz
+	/**
+	 * Default SPI2 to 12MHz and de-assert the known chip selects.
+	 * MS5611 has max SPI clock speed of 20MHz.
 	 */
 
-	// XXX start with 10.4 MHz and go up to 20 once validated
+	// XXX start with 10.4 MHz and go up to 20 once validated.
 	SPI_SETFREQUENCY(spi2, 20 * 1000 * 1000);
 	SPI_SETBITS(spi2, 8);
 	SPI_SETMODE(spi2, SPIDEV_MODE3);
@@ -501,7 +507,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	SPI_SELECT(spi2, PX4_SPIDEV_BARO, false);
 
 #ifdef CONFIG_MMCSD
-	/* First, get an instance of the SDIO interface */
+	// First, get an instance of the SDIO interface.
 
 	sdio = sdio_initialize(CONFIG_NSH_MMCSDSLOTNO);
 
@@ -511,7 +517,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 		return -ENODEV;
 	}
 
-	/* Now bind the SDIO interface to the MMC/SD driver */
+	// Now bind the SDIO interface to the MMC/SD driver.
 	int ret = mmcsd_slotinitialize(CONFIG_NSH_MMCSDMINOR, sdio);
 
 	if (ret != OK) {
@@ -519,7 +525,7 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 		return ret;
 	}
 
-	/* Then let's guess and say that there is a card in the slot. There is no card detect GPIO. */
+	// Then let's guess and say that there is a card in the slot. There is no card detect GPIO.
 	sdio_mediachange(sdio, true);
 
 #endif


### PR DESCRIPTION
Hi,

This PR simply formats comments and whitespace in `src/drivers/boards/px4fmu-v4/board_config.h` and  `src/drivers/boards/px4fmu-v4/init.c` such that the files are stylistically self-consistent throughout the file.

Please let me know if you have any questions on this PR.

-Mark
