### PR TITLE
PX4IO (firmware+driver): re-enable handling of digital RSSI

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1759,7 +1759,7 @@ PX4IO::io_get_raw_rc_input(rc_input_values &input_rc)
 	input_rc.rc_ppm_frame_length = regs[PX4IO_P_RAW_RC_DATA];
 
 	if (!_analog_rc_rssi_stable) {
-		input_rc.rssi = 255;// we do not actually get digital RSSI regs[PX4IO_P_RAW_RC_NRSSI];
+		input_rc.rssi = regs[PX4IO_P_RAW_RC_NRSSI];
 
 	} else {
 		float rssi_analog = ((_analog_rc_rssi_volt - 0.2f) / 3.0f) * 100.0f;

--- a/src/modules/px4iofirmware/controls.c
+++ b/src/modules/px4iofirmware/controls.c
@@ -72,6 +72,10 @@ static uint16_t rc_value_override = 0;
 static unsigned _rssi_adc_counts = 0;
 #endif
 
+/* receive signal strenght indicator (RSSI). 0 = no connection, 100 (RC_INPUT_RSSI_MAX): perfect connection */
+/* Note: this is static because RC-provided telemetry does not occur every tick */
+static uint16_t _rssi = 0;
+
 bool dsm_port_input(uint16_t *rssi, bool *dsm_updated, bool *st24_updated, bool *sumd_updated)
 {
 	perf_begin(c_gather_dsm);
@@ -209,9 +213,6 @@ controls_tick()
 	 * other.  Don't do that.
 	 */
 
-	/* receive signal strenght indicator (RSSI). 0 = no connection, 255: perfect connection */
-	uint16_t rssi = 0;
-
 #ifdef ADC_RSSI
 
 	if (r_setup_features & PX4IO_P_SETUP_FEATURES_ADC_RSSI) {
@@ -223,10 +224,10 @@ controls_tick()
 			/* use 1:1 scaling on 3.3V, 12-Bit ADC input */
 			unsigned mV = _rssi_adc_counts * 3300 / 4095;
 			/* scale to 0..100 (RC_INPUT_RSSI_MAX == 100) */
-			rssi = (mV * RC_INPUT_RSSI_MAX / 3300);
+			_rssi = (mV * RC_INPUT_RSSI_MAX / 3300);
 
-			if (rssi > RC_INPUT_RSSI_MAX) {
-				rssi = RC_INPUT_RSSI_MAX;
+			if (_rssi > RC_INPUT_RSSI_MAX) {
+				_rssi = RC_INPUT_RSSI_MAX;
 			}
 		}
 	}
@@ -235,7 +236,7 @@ controls_tick()
 
 	/* zero RSSI if signal is lost */
 	if (!(r_raw_rc_flags & (PX4IO_P_RAW_RC_FLAGS_RC_OK))) {
-		rssi = 0;
+		_rssi = 0;
 	}
 
 	perf_begin(c_gather_sbus);
@@ -266,7 +267,7 @@ controls_tick()
 
 		/* set RSSI to an emulated value if ADC RSSI is off */
 		if (!(r_setup_features & PX4IO_P_SETUP_FEATURES_ADC_RSSI)) {
-			rssi = sbus_rssi;
+			_rssi = sbus_rssi;
 		}
 
 	}
@@ -295,7 +296,7 @@ controls_tick()
 	if (!((r_status_flags & PX4IO_P_STATUS_FLAGS_RC_SBUS) || (r_status_flags & PX4IO_P_STATUS_FLAGS_RC_PPM))) {
 		perf_begin(c_gather_dsm);
 
-		(void)dsm_port_input(&rssi, &dsm_updated, &st24_updated, &sumd_updated);
+		(void)dsm_port_input(&_rssi, &dsm_updated, &st24_updated, &sumd_updated);
 
 		if (dsm_updated) {
 			PX4_ATOMIC_MODIFY_OR(r_status_flags, PX4IO_P_STATUS_FLAGS_RC_DSM);
@@ -318,7 +319,7 @@ controls_tick()
 	}
 
 	/* store RSSI */
-	r_page_raw_rc_input[PX4IO_P_RAW_RC_NRSSI] = rssi;
+	r_page_raw_rc_input[PX4IO_P_RAW_RC_NRSSI] = _rssi;
 
 	/*
 	 * In some cases we may have received a frame, but input has still


### PR DESCRIPTION
Digital RSSI was not being handled properly in the PX4IO firmware, and as such was being ignored in the PX4IO driver. In the firmware, `PX4IO_P_RAW_RC_NRSSI` was not being updated every frame by receiver routines that return digital RSSI. Then in the driver, if the RSSI wasn't coming from an ADC, its value was being ignored because it wasn't valid most of the time.

This PR fixes setting `PX4IO_P_RAW_RC_NRSSI` in the firmware by promoting the `controls_tick()` local `rssi` variable to static storage so that it doesn't need to be updated every tick. Then it reverts the driver's ignoring of this value so it once again will utilize digital rssi.

Note that the `rssi` variable name changes to `_rssi` to match the style of file-scoped statics elsewhere in the project. This does create a few more lines in the diff than would be technically necessary, and if desired we could go for the smaller diff rather than this conventional change.

Reviewers may also note that a comment about the range of the value contained in `static uint16_t _rssi` has been fixed. Its value is actually between 0 and `RC_INPUT_RSSI_MAX` (defined as 100).