### PR TITLE
ekf2: Tighten preflight GPS quality checks

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -52,6 +52,7 @@ set(msg_files
 	distance_sensor.msg
 	ekf2_innovations.msg
 	ekf2_timestamps.msg
+	ekf_gps_drift.msg
 	ekf_gps_position.msg
 	esc_report.msg
 	esc_status.msg

--- a/msg/ekf_gps_drift.msg
+++ b/msg/ekf_gps_drift.msg
@@ -1,0 +1,5 @@
+uint64 timestamp		# time since system start (microseconds)
+float32 hpos_drift_rate		# Horizontal position rate magnitude checked using EKF2_REQ_HDRIFT (m/s)
+float32 vpos_drift_rate		# Vertical position rate magnitude checked using EKF2_REQ_VDRIFT (m/s)
+float32 hspd			# Filtered horizontal velocity magnitude checked using EKF2_REQ_HDRIFT (m/s)
+bool blocked			# true when drift calculation is blocked due to IMU movement check controlled by EKF2_MOVE_TEST

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -157,9 +157,9 @@ PARAM_DEFINE_FLOAT(EKF2_AVEL_DELAY, 5);
  * 2 : Maximum allowed horizontal position error set by EKF2_REQ_EPH
  * 3 : Maximum allowed vertical position error set by EKF2_REQ_EPV
  * 4 : Maximum allowed speed error set by EKF2_REQ_SACC
- * 5 : Maximum allowed horizontal position rate set by EKF2_REQ_HDRIFT. This check can only be used if the vehicle is stationary during alignment.
- * 6 : Maximum allowed vertical position rate set by EKF2_REQ_VDRIFT. This check can only be used if the vehicle is stationary during alignment.
- * 7 : Maximum allowed horizontal speed set by EKF2_REQ_HDRIFT. This check can only be used if the vehicle is stationary during alignment.
+ * 5 : Maximum allowed horizontal position rate set by EKF2_REQ_HDRIFT. This check will only run when the vehicle is on ground and stationary. Detecton of the stationary condition is controlled by the EKF2_MOVE_TEST parameter.
+ * 6 : Maximum allowed vertical position rate set by EKF2_REQ_VDRIFT. This check will only run when the vehicle is on ground and stationary. Detecton of the stationary condition is controlled by the EKF2_MOVE_TEST parameter.
+ * 7 : Maximum allowed horizontal speed set by EKF2_REQ_HDRIFT. This check will only run when the vehicle is on ground and stationary. Detecton of the stationary condition is controlled by the EKF2_MOVE_TEST parameter.
  * 8 : Maximum allowed vertical velocity discrepancy set by EKF2_REQ_VDRIFT
  *
  * @group EKF2
@@ -175,7 +175,7 @@ PARAM_DEFINE_FLOAT(EKF2_AVEL_DELAY, 5);
  * @bit 7 Max horizontal speed (EKF2_REQ_HDRIFT)
  * @bit 8 Max vertical velocity discrepancy (EKF2_REQ_VDRIFT)
  */
-PARAM_DEFINE_INT32(EKF2_GPS_CHECK, 21);
+PARAM_DEFINE_INT32(EKF2_GPS_CHECK, 245);
 
 /**
  * Required EPH to use GPS.
@@ -186,7 +186,7 @@ PARAM_DEFINE_INT32(EKF2_GPS_CHECK, 21);
  * @unit m
  * @decimal 1
  */
-PARAM_DEFINE_FLOAT(EKF2_REQ_EPH, 5.0f);
+PARAM_DEFINE_FLOAT(EKF2_REQ_EPH, 3.0f);
 
 /**
  * Required EPV to use GPS.
@@ -197,7 +197,7 @@ PARAM_DEFINE_FLOAT(EKF2_REQ_EPH, 5.0f);
  * @unit m
  * @decimal 1
  */
-PARAM_DEFINE_FLOAT(EKF2_REQ_EPV, 8.0f);
+PARAM_DEFINE_FLOAT(EKF2_REQ_EPV, 5.0f);
 
 /**
  * Required speed accuracy to use GPS.
@@ -208,7 +208,7 @@ PARAM_DEFINE_FLOAT(EKF2_REQ_EPV, 8.0f);
  * @unit m/s
  * @decimal 2
  */
-PARAM_DEFINE_FLOAT(EKF2_REQ_SACC, 1.0f);
+PARAM_DEFINE_FLOAT(EKF2_REQ_SACC, 0.5f);
 
 /**
  * Required satellite count to use GPS.
@@ -238,7 +238,7 @@ PARAM_DEFINE_FLOAT(EKF2_REQ_GDOP, 2.5f);
  * @unit m/s
  * @decimal 2
  */
-PARAM_DEFINE_FLOAT(EKF2_REQ_HDRIFT, 0.3f);
+PARAM_DEFINE_FLOAT(EKF2_REQ_HDRIFT, 0.1f);
 
 /**
  * Maximum vertical drift speed to use GPS.
@@ -249,7 +249,7 @@ PARAM_DEFINE_FLOAT(EKF2_REQ_HDRIFT, 0.3f);
  * @decimal 2
  * @unit m/s
  */
-PARAM_DEFINE_FLOAT(EKF2_REQ_VDRIFT, 0.5f);
+PARAM_DEFINE_FLOAT(EKF2_REQ_VDRIFT, 0.2f);
 
 /**
  * Rate gyro noise for covariance prediction.
@@ -489,7 +489,7 @@ PARAM_DEFINE_INT32(EKF2_DECL_TYPE, 7);
  * If set to 'Magnetic heading' magnetic heading fusion is used at all times
  * If set to '3-axis' 3-axis field fusion is used at all times.
  * If set to 'VTOL custom' the behaviour is the same as 'Automatic', but if fusing airspeed, magnetometer fusion is only allowed to modify the magnetic field states. This can be used by VTOL platforms with large magnetic field disturbances to prevent incorrect bias states being learned during forward flight operation which can adversely affect estimation accuracy after transition to hovering flight.
- * If set to 'MC custom' the behaviour is the same as 'Automatic, but if there are no earth frame position or velocity observations being used, the magnetometer will not be used. This enables vehicles to operate with no GPS in environments where the magnetic field cannot be used to provide a heading reference.
+ * If set to 'MC custom' the behaviour is the same as 'Automatic, but if there are no earth frame position or velocity observations being used, the magnetometer will not be used. This enables vehicles to operate with no GPS in environments where the magnetic field cannot be used to provide a heading reference. Prior to flight, the yaw angle is assumed to be constant if movement tests controlled by the EKF2_MOVE_TEST parameter indicate that the vehicle is static. This allows the vehicle to be placed on the ground to learn the yaw gyro bias prior to flight.
  *
  * @group EKF2
  * @value 0 Automatic
@@ -1301,3 +1301,15 @@ PARAM_DEFINE_INT32(EKF2_GPS_MASK, 0);
  * @decimal 1
  */
 PARAM_DEFINE_FLOAT(EKF2_GPS_TAU, 10.0f);
+
+/**
+ * Vehicle movement test threshold
+ *
+ * Scales the threshold tests applied to IMU data used to determine if the vehicle is static or moving. See parameter descriptions for EKF2_GPS_CHECK and EKF2_MAG_TYPE for further information on the functionality affected by this parameter.
+ *
+ * @group EKF2
+ * @min 0.1
+ * @max 10.0
+ * @decimal 1
+ */
+PARAM_DEFINE_FLOAT(EKF2_MOVE_TEST, 1.0f);

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -614,6 +614,7 @@ void Logger::add_default_topics()
 	add_topic("cpuload");
 	add_topic("distance_sensor", 100);
 	add_topic("ekf2_innovations", 200);
+	add_topic("ekf_gps_drift");
 	add_topic("esc_status", 250);
 	add_topic("estimator_status", 200);
 	add_topic("home_position");


### PR DESCRIPTION
Enables drift checks and reduce thresholds.
Uses ecl version that activates drift checks when vehicle is carried.

Fixes: https://github.com/PX4/Firmware/issues/9549

**TESTING**

See comments