### PR TITLE
Yaw remove slewrate

### DIFF
--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
@@ -84,13 +84,16 @@ protected:
 	WaypointType _type{WaypointType::idle}; /**< Type of current target triplet. */
 	uORB::Subscription<home_position_s> *_sub_home_position{nullptr};
 
+	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTask,
+					(ParamFloat<px4::params::MPC_XY_CRUISE>) MPC_XY_CRUISE, /**< Default mc cruise speed.*/
+					(ParamFloat<px4::params::NAV_ACC_RAD>) NAV_ACC_RAD, // acceptance radius at which waypoints are updated
+					(ParamInt<px4::params::MPC_YAW_MODE>) MPC_YAW_MODE /**< Defines how heading is executed. */
+				       )
+
 private:
 	matrix::Vector2f _lock_position_xy{NAN, NAN};
 
 	uORB::Subscription<position_setpoint_triplet_s> *_sub_triplet_setpoint{nullptr};
-
-	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTask,
-					(ParamFloat<px4::params::MPC_XY_CRUISE>) MPC_XY_CRUISE); /**< Default mc cruise speed.*/
 
 	map_projection_reference_s _reference_position{}; /**< Structure used to project lat/lon setpoint into local frame. */
 	float _reference_altitude = NAN;  /**< Altitude relative to ground. */
@@ -99,4 +102,5 @@ private:
 	bool _evaluateTriplets(); /**< Checks and sets triplets. */
 	bool _isFinite(const position_setpoint_s sp); /**< Checks if all waypoint triplets are finite. */
 	bool _evaluateGlobalReference(); /**< Check is global reference is available. */
+	void _set_heading_from_mode(); /**< @see  MPC_YAW_MODE */
 };

--- a/src/lib/FlightTasks/tasks/FlightTaskAutoLine.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAutoLine.hpp
@@ -68,7 +68,6 @@ protected:
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTaskAuto,
 					(ParamFloat<px4::params::MPC_LAND_SPEED>) MPC_LAND_SPEED,
 					(ParamFloat<px4::params::MPC_CRUISE_90>) MPC_CRUISE_90, // speed at corner when angle is 90 degrees
-					(ParamFloat<px4::params::NAV_ACC_RAD>) NAV_ACC_RAD, // acceptance radius at which waypoints are updated
 					(ParamFloat<px4::params::MIS_YAW_ERR>) MIS_YAW_ERR, // yaw-error threshold
 					(ParamFloat<px4::params::MPC_LAND_ALT1>) MPC_LAND_ALT1, // altitude at which speed limit downwards reaches maximum speed
 					(ParamFloat<px4::params::MPC_LAND_ALT2>) MPC_LAND_ALT2, // altitude at which speed limit downwards reached minimum speed

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -657,3 +657,18 @@ PARAM_DEFINE_FLOAT(MPC_IDLE_TKO, 0.0f);
  * @group Multicopter Position Control
  */
 PARAM_DEFINE_INT32(MPC_OBS_AVOID, 0);
+
+/**
+ * Yaw mode.
+ *
+ * Specifies the heading in Auto.
+ *
+ * @min 0
+ * @max 3
+ * @value 0 set by waypoint
+ * @value 1 towards waypoint
+ * @value 2 towards home
+ * @value 3 away from home
+ * @group Mission
+ */
+PARAM_DEFINE_INT32(MPC_YAW_MODE, 1);

--- a/src/modules/navigator/loiter.cpp
+++ b/src/modules/navigator/loiter.cpp
@@ -112,7 +112,6 @@ Loiter::set_loiter_position()
 	pos_sp_triplet->next.valid = false;
 
 	_navigator->set_can_loiter_at_sp(pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER);
-
 	_navigator->set_position_setpoint_triplet_updated();
 }
 
@@ -139,26 +138,7 @@ Loiter::reposition()
 		memcpy(&pos_sp_triplet->current, &rep->current, sizeof(rep->current));
 		pos_sp_triplet->next.valid = false;
 
-		// set yaw (depends on the value of parameter MIS_YAWMODE):
-		// MISSION_YAWMODE_NONE: do not change yaw setpoint
-		// MISSION_YAWMODE_FRONT_TO_WAYPOINT: point to next waypoint
-		if (_param_yawmode.get() != MISSION_YAWMODE_NONE) {
-			float travel_dist = get_distance_to_next_waypoint(_navigator->get_global_position()->lat,
-					    _navigator->get_global_position()->lon,
-					    pos_sp_triplet->current.lat, pos_sp_triplet->current.lon);
-
-			if (travel_dist > 1.0f) {
-				// calculate direction the vehicle should point to.
-				pos_sp_triplet->current.yaw = get_bearing_to_next_waypoint(
-								      _navigator->get_global_position()->lat,
-								      _navigator->get_global_position()->lon,
-								      pos_sp_triplet->current.lat,
-								      pos_sp_triplet->current.lon);
-			}
-		}
-
 		_navigator->set_can_loiter_at_sp(pos_sp_triplet->current.type == position_setpoint_s::SETPOINT_TYPE_LOITER);
-
 		_navigator->set_position_setpoint_triplet_updated();
 
 		// mark this as done

--- a/src/modules/navigator/loiter.h
+++ b/src/modules/navigator/loiter.h
@@ -76,9 +76,5 @@ private:
 	 */
 	void set_loiter_position();
 
-	DEFINE_PARAMETERS(
-		(ParamInt<px4::params::MIS_YAWMODE>) _param_yawmode
-	)
-
 	bool _loiter_pos_set{false};
 };

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -54,7 +54,6 @@
 #include <systemlib/mavlink_log.h>
 #include <systemlib/err.h>
 #include <lib/ecl/geo/geo.h>
-#include <lib/mathlib/mathlib.h>
 #include <navigator/navigation.h>
 #include <uORB/uORB.h>
 #include <uORB/topics/mission.h>
@@ -1227,7 +1226,7 @@ Mission::heading_sp_update()
 				  point_from_latlon[1], point_to_latlon[0], point_to_latlon[1]);
 
 		if (d_current > _navigator->get_acceptance_radius()) {
-			float yaw = _wrap_pi(
+			float yaw = wrap_pi(
 					    get_bearing_to_next_waypoint(point_from_latlon[0],
 							    point_from_latlon[1], point_to_latlon[0],
 							    point_to_latlon[1]) + yaw_offset);

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -246,14 +246,22 @@ Mission::on_active()
 	}
 
 	/* see if we need to update the current yaw heading */
-	if (_navigator->get_vroi().mode == vehicle_roi_s::ROI_LOCATION
-	    || (_param_yawmode.get() != MISSION_YAWMODE_NONE
-		&& _param_yawmode.get() < MISSION_YAWMODE_MAX
-		&& _mission_type != MISSION_TYPE_NONE)
-	    || _navigator->get_vstatus()->is_vtol) {
-
+	if (!_param_mnt_yaw_ctl.get() && (_navigator->get_vstatus()->is_rotary_wing)
+	    && (_navigator->get_vroi().mode != vehicle_roi_s::ROI_NONE)
+	    && !(_mission_item.nav_cmd == NAV_CMD_TAKEOFF
+		 || _mission_item.nav_cmd == NAV_CMD_VTOL_TAKEOFF
+		 || _mission_item.nav_cmd == NAV_CMD_DO_VTOL_TRANSITION
+		 || _mission_item.nav_cmd == NAV_CMD_LAND
+		 || _mission_item.nav_cmd == NAV_CMD_VTOL_LAND
+		 || _work_item_type == WORK_ITEM_TYPE_ALIGN)) {
+		// Mount control is disabled If the vehicle is in ROI-mode, the vehicle
+		// needs to rotate such that ROI is in the field of view.
+		// ROI only makes sense for multicopters.
 		heading_sp_update();
 	}
+
+	// TODO: Add vtol heading update method if required.
+	// Question: Why does vtol ever have to update heading?
 
 	/* check if landing needs to be aborted */
 	if ((_mission_item.nav_cmd == NAV_CMD_LAND)
@@ -1170,112 +1178,67 @@ Mission::calculate_takeoff_altitude(struct mission_item_s *mission_item)
 void
 Mission::heading_sp_update()
 {
-	/* we don't want to be yawing during takeoff, landing or aligning for a transition */
-	if (_mission_item.nav_cmd == NAV_CMD_TAKEOFF
-	    || _mission_item.nav_cmd == NAV_CMD_VTOL_TAKEOFF
-	    || _mission_item.nav_cmd == NAV_CMD_DO_VTOL_TRANSITION
-	    || _mission_item.nav_cmd == NAV_CMD_LAND
-	    || _mission_item.nav_cmd == NAV_CMD_VTOL_LAND
-	    || _work_item_type == WORK_ITEM_TYPE_ALIGN) {
+	struct position_setpoint_triplet_s *pos_sp_triplet =
+		_navigator->get_position_setpoint_triplet();
 
-		return;
-	}
+	// Only update if current triplet is valid
+	if (pos_sp_triplet->current.valid) {
 
-	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
+		double point_from_latlon[2] = { _navigator->get_global_position()->lat,
+						_navigator->get_global_position()->lon
+					      };
+		double point_to_latlon[2] = { _navigator->get_global_position()->lat,
+					      _navigator->get_global_position()->lon
+					    };
+		float yaw_offset = 0.0f;
 
-	/* Don't change setpoint if last and current waypoint are not valid */
-	if (!pos_sp_triplet->current.valid) {
-		return;
-	}
+		// Depending on ROI-mode, update heading
+		switch (_navigator->get_vroi().mode) {
+		case vehicle_roi_s::ROI_LOCATION: {
+				// ROI is a fixed location. Vehicle needs to point towards that location
+				point_to_latlon[0] = _navigator->get_vroi().lat;
+				point_to_latlon[1] = _navigator->get_vroi().lon;
+				// No yaw offset required
+				yaw_offset = 0.0f;
+				break;
+			}
 
-	/* Calculate direction the vehicle should point to. */
+		case vehicle_roi_s::ROI_WPNEXT: {
+				// ROI is current waypoint. Vehcile needs to point towards current waypoint
+				point_to_latlon[0] = pos_sp_triplet->current.lat;
+				point_to_latlon[1] = pos_sp_triplet->current.lon;
+				// Add the gimbal's yaw offset
+				yaw_offset = _navigator->get_vroi().yaw_offset;
+				break;
+			}
 
-	double point_from_latlon[2];
-	double point_to_latlon[2];
+		case vehicle_roi_s::ROI_NONE:
+		case vehicle_roi_s::ROI_WPINDEX:
+		case vehicle_roi_s::ROI_TARGET:
+		case vehicle_roi_s::ROI_ENUM_END:
+		default: {
+			}
+		}
 
-	point_from_latlon[0] = _navigator->get_global_position()->lat;
-	point_from_latlon[1] = _navigator->get_global_position()->lon;
-
-	if (_navigator->get_vroi().mode == vehicle_roi_s::ROI_LOCATION && !_param_mnt_yaw_ctl.get()) {
-		point_to_latlon[0] = _navigator->get_vroi().lat;
-		point_to_latlon[1] = _navigator->get_vroi().lon;
-
-		/* stop if positions are close together to prevent excessive yawing */
-		float d_current = get_distance_to_next_waypoint(
-					  point_from_latlon[0], point_from_latlon[1],
-					  point_to_latlon[0], point_to_latlon[1]);
+		// Get desired heading and update it.
+		// However, only update if distance to desired heading is
+		// larger than acceptance radius to prevent excessive yawing
+		float d_current = get_distance_to_next_waypoint(point_from_latlon[0],
+				  point_from_latlon[1], point_to_latlon[0], point_to_latlon[1]);
 
 		if (d_current > _navigator->get_acceptance_radius()) {
-			float yaw = get_bearing_to_next_waypoint(
-					    point_from_latlon[0], point_from_latlon[1],
-					    point_to_latlon[0], point_to_latlon[1]);
+			float yaw = _wrap_pi(
+					    get_bearing_to_next_waypoint(point_from_latlon[0],
+							    point_from_latlon[1], point_to_latlon[0],
+							    point_to_latlon[1]) + yaw_offset);
 
 			_mission_item.yaw = yaw;
 			pos_sp_triplet->current.yaw = _mission_item.yaw;
 		}
 
-	} else {
-		/* set yaw angle for the waypoint if a loiter time has been specified */
-		if (_waypoint_position_reached && get_time_inside(_mission_item) > FLT_EPSILON) {
-			// XXX: should actually be param4 from mission item
-			// at the moment it will just keep the heading it has
-			//_mission_item.yaw = _on_arrival_yaw;
-			//pos_sp_triplet->current.yaw = _mission_item.yaw;
-
-		} else {
-			/* target location is home */
-			if ((_param_yawmode.get() == MISSION_YAWMODE_FRONT_TO_HOME
-			     || _param_yawmode.get() == MISSION_YAWMODE_BACK_TO_HOME)
-			    // need to be rotary wing for this but not in a transition
-			    // in VTOL mode this will prevent updating yaw during FW flight
-			    // (which would result in a wrong yaw setpoint spike during back transition)
-			    && _navigator->get_vstatus()->is_rotary_wing
-			    && !(_mission_item.nav_cmd == NAV_CMD_DO_VTOL_TRANSITION || _navigator->get_vstatus()->in_transition_mode)) {
-
-				point_to_latlon[0] = _navigator->get_home_position()->lat;
-				point_to_latlon[1] = _navigator->get_home_position()->lon;
-
-			} else {
-				/* target location is next (current) waypoint */
-				point_to_latlon[0] = pos_sp_triplet->current.lat;
-				point_to_latlon[1] = pos_sp_triplet->current.lon;
-			}
-
-			float d_current = get_distance_to_next_waypoint(
-						  point_from_latlon[0], point_from_latlon[1],
-						  point_to_latlon[0], point_to_latlon[1]);
-
-			/* stop if positions are close together to prevent excessive yawing */
-			if (d_current > _navigator->get_acceptance_radius()) {
-				float yaw = get_bearing_to_next_waypoint(
-						    point_from_latlon[0],
-						    point_from_latlon[1],
-						    point_to_latlon[0],
-						    point_to_latlon[1]);
-
-				/* always keep the back of the rotary wing pointing towards home */
-				if (_param_yawmode.get() == MISSION_YAWMODE_BACK_TO_HOME) {
-					_mission_item.yaw = wrap_pi(yaw + M_PI_F);
-					pos_sp_triplet->current.yaw = _mission_item.yaw;
-
-				} else if (_param_yawmode.get() == MISSION_YAWMODE_FRONT_TO_WAYPOINT
-					   && _navigator->get_vroi().mode == vehicle_roi_s::ROI_WPNEXT && !_param_mnt_yaw_ctl.get()) {
-					/* if yaw control for the mount is disabled and we have a valid ROI that points to the next
-					 * waypoint, we add the gimbal's yaw offset to the vehicle's yaw */
-					yaw += _navigator->get_vroi().yaw_offset;
-					_mission_item.yaw = yaw;
-					pos_sp_triplet->current.yaw = _mission_item.yaw;
-
-				} else {
-					_mission_item.yaw = yaw;
-					pos_sp_triplet->current.yaw = _mission_item.yaw;
-				}
-			}
-		}
+		// we set yaw directly so we can run this in parallel to the FOH update
+		_navigator->set_position_setpoint_triplet_updated();
 	}
-
-	// we set yaw directly so we can run this in parallel to the FOH update
-	_navigator->set_position_setpoint_triplet_updated();
 }
 
 void

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -247,7 +247,6 @@ private:
 		(ParamFloat<px4::params::MIS_DIST_1WP>) _param_dist_1wp,
 		(ParamFloat<px4::params::MIS_DIST_WPS>) _param_dist_between_wps,
 		(ParamInt<px4::params::MIS_ALTMODE>) _param_altmode,
-		(ParamInt<px4::params::MIS_YAWMODE>) _param_yawmode,
 		(ParamInt<px4::params::MIS_MNT_YAW_CTL>) _param_mnt_yaw_ctl
 	)
 

--- a/src/modules/navigator/mission_params.c
+++ b/src/modules/navigator/mission_params.c
@@ -120,21 +120,6 @@ PARAM_DEFINE_FLOAT(MIS_DIST_WPS, 900);
 PARAM_DEFINE_INT32(MIS_ALTMODE, 1);
 
 /**
- * Multirotor only. Yaw setpoint mode.
- *
- * The values are defined in the enum mission_altitude_mode
- *
- * @min 0
- * @max 3
- * @value 0 Heading as set by waypoint
- * @value 1 Heading towards waypoint
- * @value 2 Heading towards home
- * @value 3 Heading away from home
- * @group Mission
- */
-PARAM_DEFINE_INT32(MIS_YAWMODE, 1);
-
-/**
 * Enable yaw control of the mount. (Only affects multicopters and ROI mission items)
 *
 * If enabled, yaw commands will be sent to the mount and the vehicle will follow its heading mode as specified by MIS_YAWMODE.

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -157,7 +157,7 @@ RTL::set_rtl_item()
 			_mission_item.lon = gpos.lon;
 			_mission_item.altitude = return_alt;
 			_mission_item.altitude_is_relative = false;
-			_mission_item.yaw = NAN;
+			_mission_item.yaw = _navigator->get_local_position()->yaw;
 			_mission_item.acceptance_radius = _navigator->get_acceptance_radius();
 			_mission_item.time_inside = 0.0f;
 			_mission_item.autocontinue = true;


### PR DESCRIPTION
Similar to this [PR](https://github.com/PX4/Firmware/pull/9146) but without manual changes. 
This PR moves the heading computation from navigator to FlightTaskAuto, which will also remove
the continuous triplet update due to heading computation. 