### PR TITLE
update straightline

### DIFF
--- a/src/lib/FlightTasks/tasks/Utility/StraightLine.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/StraightLine.cpp
@@ -55,7 +55,7 @@ void StraightLine::generateSetpoints(matrix::Vector3f &position_setpoint, matrix
 {
 	// Check if target position has been reached
 	if (_desired_speed_at_target < VEL_ZERO_THRESHOLD &&
-				   (_pos - _target).length() < NAV_ACC_RAD.get()) {
+	    (_pos - _target).length() < NAV_ACC_RAD.get()) {
 		// Vehicle has reached target. Lock position
 		position_setpoint = _target;
 		velocity_setpoint = Vector3f(0.0f, 0.0f, 0.0f);
@@ -73,7 +73,8 @@ void StraightLine::generateSetpoints(matrix::Vector3f &position_setpoint, matrix
 	float speed_sp_prev = math::max(velocity_setpoint * u_orig_to_target, 0.0f);
 
 	// Calculate accelerating/decelerating distance depending on speed, speed at target and acceleration/deceleration
-	float acc_dec_distance = fabs((_desired_speed * _desired_speed) - (_desired_speed_at_target * _desired_speed_at_target)) / 2.0f;
+	float acc_dec_distance = fabs((_desired_speed * _desired_speed) - (_desired_speed_at_target *
+				      _desired_speed_at_target)) / 2.0f;
 	acc_dec_distance /= _desired_speed > _desired_speed_at_target ? _desired_deceleration : _desired_acceleration;
 
 	float dist_to_target = (_target - _pos).length(); // distance to target
@@ -193,6 +194,7 @@ void StraightLine::setSpeed(const float &speed)
 
 	if (speed > 0 && speed < vel_max) {
 		_desired_speed = speed;
+
 	} else if (speed > vel_max) {
 		_desired_speed = vel_max;
 	}
@@ -204,6 +206,7 @@ void StraightLine::setSpeedAtTarget(const float &speed_at_target)
 
 	if (speed_at_target > 0 && speed_at_target < vel_max) {
 		_desired_speed_at_target = speed_at_target;
+
 	} else if (speed_at_target > vel_max) {
 		_desired_speed_at_target = vel_max;
 	}
@@ -215,6 +218,7 @@ void StraightLine::setAcceleration(const float &acc)
 
 	if (acc > 0 && acc < acc_max) {
 		_desired_acceleration = acc;
+
 	} else if (acc > acc_max) {
 		_desired_acceleration = acc_max;
 	}
@@ -224,6 +228,7 @@ void StraightLine::setDeceleration(const float &dec)
 {
 	if (dec > 0 && dec < DECELERATION_MAX) {
 		_desired_deceleration = dec;
+
 	} else if (dec > DECELERATION_MAX) {
 		_desired_deceleration = DECELERATION_MAX;
 	}

--- a/src/lib/FlightTasks/tasks/Utility/StraightLine.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/StraightLine.cpp
@@ -187,22 +187,34 @@ void StraightLine::setOrigin(const matrix::Vector3f &origin)
 
 void StraightLine::setSpeed(const float &speed)
 {
-	if (speed > 0 && speed < getMaxVel()) {
+	float vel_max = getMaxVel();
+
+	if (speed > 0 && speed < vel_max) {
 		_desired_speed = speed;
+	} else if (speed > vel_max) {
+		_desired_speed = vel_max;
 	}
 }
 
 void StraightLine::setSpeedAtTarget(const float &speed_at_target)
 {
-	if (speed_at_target > 0 && speed_at_target < getMaxVel()) {
+	float vel_max = getMaxVel();
+
+	if (speed_at_target > 0 && speed_at_target < vel_max) {
 		_desired_speed_at_target = speed_at_target;
+	} else if (speed_at_target > vel_max) {
+		_desired_speed_at_target = vel_max;
 	}
 }
 
 void StraightLine::setAcceleration(const float &acc)
 {
-	if (acc > 0 && acc < getMaxAcc()) {
+	float acc_max = getMaxVel();
+
+	if (acc > 0 && acc < acc_max) {
 		_desired_acceleration = acc;
+	} else if (acc > acc_max) {
+		_desired_acceleration = acc_max;
 	}
 }
 
@@ -210,5 +222,7 @@ void StraightLine::setDeceleration(const float &dec)
 {
 	if (dec > 0 && dec < DECELERATION_MAX) {
 		_desired_deceleration = dec;
+	} else if (dec > DECELERATION_MAX) {
+		_desired_deceleration = DECELERATION_MAX;
 	}
 }

--- a/src/lib/FlightTasks/tasks/Utility/StraightLine.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/StraightLine.cpp
@@ -176,20 +176,15 @@ void StraightLine::setAllDefaults()
 	_desired_deceleration = DECELERATION_MAX;
 }
 
-void StraightLine::setTarget(const matrix::Vector3f &target)
+void StraightLine::setLineFromTo(const matrix::Vector3f &origin, const matrix::Vector3f &target)
 {
-	if (PX4_ISFINITE(target(0)) && PX4_ISFINITE(target(1)) && PX4_ISFINITE(target(2))) {
+	if (PX4_ISFINITE(target(0)) && PX4_ISFINITE(target(1)) && PX4_ISFINITE(target(2)) &&
+	    PX4_ISFINITE(origin(0)) && PX4_ISFINITE(origin(1)) && PX4_ISFINITE(origin(2))) {
 		_target = target;
+		_origin = origin;
 
 		// set all parameters to their default value (depends on the direction)
 		setAllDefaults();
-	}
-}
-
-void StraightLine::setOrigin(const matrix::Vector3f &origin)
-{
-	if (PX4_ISFINITE(origin(0)) && PX4_ISFINITE(origin(1)) && PX4_ISFINITE(origin(2))) {
-		_origin = origin;
 	}
 }
 

--- a/src/lib/FlightTasks/tasks/Utility/StraightLine.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/StraightLine.cpp
@@ -100,6 +100,11 @@ void StraightLine::generateSetpoints(matrix::Vector3f &position_setpoint, matrix
 
 float StraightLine::getMaxAcc()
 {
+	// check if origin and target are different points
+	if ((_target - _origin).length() < FLT_EPSILON) {
+		return MPC_ACC_HOR_MAX.get();
+	}
+
 	// unit vector in the direction of the straight line
 	Vector3f u_orig_to_target = (_target - _origin).unit_or_zero();
 
@@ -130,6 +135,11 @@ float StraightLine::getMaxAcc()
 
 float StraightLine::getMaxVel()
 {
+	// check if origin and target are different points
+	if ((_target - _origin).length() < FLT_EPSILON) {
+		return MPC_XY_VEL_MAX.get();
+	}
+
 	// unit vector in the direction of the straight line
 	Vector3f u_orig_to_target = (_target - _origin).unit_or_zero();
 

--- a/src/lib/FlightTasks/tasks/Utility/StraightLine.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/StraightLine.cpp
@@ -54,12 +54,11 @@ StraightLine::StraightLine(ModuleParams *parent, const float &deltatime, const m
 void StraightLine::generateSetpoints(matrix::Vector3f &position_setpoint, matrix::Vector3f &velocity_setpoint)
 {
 	// Check if target position has been reached
-	if (_is_target_reached || (_desired_speed_at_target < VEL_ZERO_THRESHOLD &&
-				   (_pos - _target).length() < NAV_ACC_RAD.get())) {
+	if (_desired_speed_at_target < VEL_ZERO_THRESHOLD &&
+				   (_pos - _target).length() < NAV_ACC_RAD.get()) {
 		// Vehicle has reached target. Lock position
 		position_setpoint = _target;
 		velocity_setpoint = Vector3f(0.0f, 0.0f, 0.0f);
-		_is_target_reached = true;
 
 		return;
 	}
@@ -171,7 +170,6 @@ void StraightLine::setTarget(const matrix::Vector3f &target)
 {
 	if (PX4_ISFINITE(target(0)) && PX4_ISFINITE(target(1)) && PX4_ISFINITE(target(2))) {
 		_target = target;
-		_is_target_reached = false;
 
 		// set all parameters to their default value (depends on the direction)
 		setAllDefaults();

--- a/src/lib/FlightTasks/tasks/Utility/StraightLine.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/StraightLine.cpp
@@ -74,7 +74,7 @@ void StraightLine::generateSetpoints(matrix::Vector3f &position_setpoint, matrix
 	float speed_sp_prev = math::max(velocity_setpoint * u_orig_to_target, 0.0f);
 
 	// Calculate accelerating/decelerating distance depending on speed, speed at target and acceleration/deceleration
-	float acc_dec_distance = fabs(powf(_desired_speed, 2) - powf(_desired_speed_at_target, 2)) / 2.0f;
+	float acc_dec_distance = fabs(_desired_speed * _desired_speed - _desired_speed_at_target * _desired_speed_at_target) / 2.0f;
 	acc_dec_distance /= _desired_speed > _desired_speed_at_target ? _desired_deceleration : _desired_acceleration;
 
 	float dist_to_target = (_target - _pos).length(); // distance to target
@@ -105,7 +105,7 @@ float StraightLine::getMaxAcc()
 	Vector3f u_orig_to_target = (_target - _origin).unit_or_zero();
 
 	// calculate the maximal horizontal acceleration
-	float divider = (sqrt(powf(u_orig_to_target(0), 2) + powf(u_orig_to_target(1), 2)));
+	float divider = (sqrt(u_orig_to_target(0) * u_orig_to_target(0) + u_orig_to_target(1) * u_orig_to_target(1)));
 	float max_acc_hor = MPC_ACC_HOR_MAX.get();
 
 	if (divider > FLT_EPSILON) {
@@ -135,7 +135,7 @@ float StraightLine::getMaxVel()
 	Vector3f u_orig_to_target = (_target - _origin).unit_or_zero();
 
 	// calculate the maximal horizontal velocity
-	float divider = (sqrt(powf(u_orig_to_target(0), 2) + powf(u_orig_to_target(1), 2)));
+	float divider = (sqrt(u_orig_to_target(0) * u_orig_to_target(0) + u_orig_to_target(1) * u_orig_to_target(1)));
 	float max_vel_hor = MPC_XY_VEL_MAX.get();
 
 	if (divider > FLT_EPSILON) {

--- a/src/lib/FlightTasks/tasks/Utility/StraightLine.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/StraightLine.cpp
@@ -73,7 +73,7 @@ void StraightLine::generateSetpoints(matrix::Vector3f &position_setpoint, matrix
 	float speed_sp_prev = math::max(velocity_setpoint * u_orig_to_target, 0.0f);
 
 	// Calculate accelerating/decelerating distance depending on speed, speed at target and acceleration/deceleration
-	float acc_dec_distance = fabs(_desired_speed * _desired_speed - _desired_speed_at_target * _desired_speed_at_target) / 2.0f;
+	float acc_dec_distance = fabs((_desired_speed * _desired_speed) - (_desired_speed_at_target * _desired_speed_at_target)) / 2.0f;
 	acc_dec_distance /= _desired_speed > _desired_speed_at_target ? _desired_deceleration : _desired_acceleration;
 
 	float dist_to_target = (_target - _pos).length(); // distance to target
@@ -95,7 +95,6 @@ void StraightLine::generateSetpoints(matrix::Vector3f &position_setpoint, matrix
 	// set the position and velocity setpoints
 	position_setpoint = closest_pt_on_line;
 	velocity_setpoint = u_orig_to_target * speed_sp;
-
 }
 
 float StraightLine::getMaxAcc()
@@ -109,7 +108,7 @@ float StraightLine::getMaxAcc()
 	Vector3f u_orig_to_target = (_target - _origin).unit_or_zero();
 
 	// calculate the maximal horizontal acceleration
-	float divider = (sqrt(u_orig_to_target(0) * u_orig_to_target(0) + u_orig_to_target(1) * u_orig_to_target(1)));
+	float divider = Vector2f(u_orig_to_target.data()).length();
 	float max_acc_hor = MPC_ACC_HOR_MAX.get();
 
 	if (divider > FLT_EPSILON) {
@@ -144,7 +143,7 @@ float StraightLine::getMaxVel()
 	Vector3f u_orig_to_target = (_target - _origin).unit_or_zero();
 
 	// calculate the maximal horizontal velocity
-	float divider = (sqrt(u_orig_to_target(0) * u_orig_to_target(0) + u_orig_to_target(1) * u_orig_to_target(1)));
+	float divider = Vector2f(u_orig_to_target.data()).length();
 	float max_vel_hor = MPC_XY_VEL_MAX.get();
 
 	if (divider > FLT_EPSILON) {

--- a/src/lib/FlightTasks/tasks/Utility/StraightLine.hpp
+++ b/src/lib/FlightTasks/tasks/Utility/StraightLine.hpp
@@ -51,8 +51,7 @@ public:
 	~StraightLine() = default;
 
 	// setter functions
-	void setTarget(const matrix::Vector3f &target);
-	void setOrigin(const matrix::Vector3f &origin);
+	void setLineFromTo(const matrix::Vector3f &origin, const matrix::Vector3f &target);
 	void setSpeed(const float &speed);
 	void setSpeedAtTarget(const float &speed_at_target);
 	void setAcceleration(const float &acc);

--- a/src/lib/FlightTasks/tasks/Utility/StraightLine.hpp
+++ b/src/lib/FlightTasks/tasks/Utility/StraightLine.hpp
@@ -92,8 +92,6 @@ private:
 	float _desired_speed{0.0f};              /**< desired maximum velocity */
 	float _desired_speed_at_target{0.0f};    /**< desired velocity at target point */
 
-	bool _is_target_reached{false};
-
 	matrix::Vector3f _target{};              /**< End point of the straight line */
 	matrix::Vector3f _origin{};              /**< Start point of the straight line */
 


### PR DESCRIPTION
@MaEtUgR I addressed your feedback in this PR.

This includes minor improvements and fixes an issue where 'maxVel()' returned 1000 (target was equal to origin)

@mrivi `setTarget()` and `setOrigin()` need to be replaced with `setLineFromTo()`