### PR TITLE
rcS preserve accel, gyro, and temp cal parameters

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -194,7 +194,7 @@ else
 	if param compare SYS_AUTOCONFIG 1
 	then
 		# Wipe out params except RC*, flight modes and total flight time
-		param reset_nostart RC* COM_FLTMODE* LND_FLIGHT_T_*
+		param reset_nostart RC* COM_FLTMODE* LND_FLIGHT_T_* TC_* CAL_ACC* CAL_GYRO*
 		set AUTOCNF yes
 	else
 		set AUTOCNF no


### PR DESCRIPTION
Accelerometer and gyro calibration parameters don't need to be reset when changing airframes.
Temperature compensation parameters should also be preserved.