### PR TITLE
ekf2: Reinstate saving of mag declination for use next start

### DIFF
--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -432,6 +432,7 @@ PARAM_DEFINE_FLOAT(EKF2_BETA_NOISE, 0.3f);
  * Magnetic declination
  *
  * @group EKF2
+ * @volatile
  * @unit deg
  * @decimal 1
  */


### PR DESCRIPTION
Fixes  https://github.com/PX4/Firmware/issues/10023

The capability and parameter selected default behaviour to save the magnetic declination for the last location had been removed unintentionally by previous changes. This PR reinstates the behaviour.

Requires https://github.com/PX4/ecl/pull/486 to be merged first.

Reported here

**Test data / coverage**

1. Start QGC and connect autopilot via USB
2. Load parameters and set EKF2_MAG_DECL to 0
3. Repower board and wait for GPS checks to pass.
4. Reload parameters in QGC and verify EKF2_MAG_DECL has been updated.
5. Repower board with GPS disconnected and and check EKF2_MAG_DECL value has been saved. See screen shot below

![screen shot 2018-07-25 at 11 23 35 am](https://user-images.githubusercontent.com/3596952/43174412-366b0f78-8ffd-11e8-886e-9fa80e8b7c59.png)