### PR TITLE
CDev::poll() performance improvements

### DIFF
--- a/src/lib/drivers/device/CDev.cpp
+++ b/src/lib/drivers/device/CDev.cpp
@@ -394,21 +394,12 @@ CDev::poll_notify_one(px4_pollfd_struct_t *fds, pollevent_t events)
 {
 	DEVICE_DEBUG("CDev::poll_notify_one");
 
-#ifdef __PX4_NUTTX
-	int value = fds->sem->semcount;
-#else
-	int value = -1;
-	px4_sem_getvalue(fds->sem, &value);
-#endif
-
 	/* update the reported event set */
 	fds->revents |= fds->events & events;
 
-	DEVICE_DEBUG(" Events fds=%p %0x %0x %0x %d", fds, fds->revents, fds->events, events, value);
+	DEVICE_DEBUG(" Events fds=%p %0x %0x %0x", fds, fds->revents, fds->events, events);
 
-	/* if the state is now interesting, wake the waiter if it's still asleep */
-	/* XXX semcount check here is a vile hack; counting semphores should not be abused as cvars */
-	if ((fds->revents != 0) && (value <= 0)) {
+	if (fds->revents != 0) {
 		px4_sem_post(fds->sem);
 	}
 }

--- a/src/lib/drivers/device/CDev.hpp
+++ b/src/lib/drivers/device/CDev.hpp
@@ -293,14 +293,14 @@ private:
 	 *
 	 * @return		OK, or -errno on error.
 	 */
-	int		store_poll_waiter(px4_pollfd_struct_t *fds);
+	inline int	store_poll_waiter(px4_pollfd_struct_t *fds);
 
 	/**
 	 * Remove a poll waiter.
 	 *
 	 * @return		OK, or -errno on error.
 	 */
-	int		remove_poll_waiter(px4_pollfd_struct_t *fds);
+	inline int	remove_poll_waiter(px4_pollfd_struct_t *fds);
 
 	/* do not allow copying this class */
 	CDev(const CDev &);

--- a/src/lib/drivers/device/CDev.hpp
+++ b/src/lib/drivers/device/CDev.hpp
@@ -289,7 +289,7 @@ private:
 	/**
 	 * Store a pollwaiter in a slot where we can find it later.
 	 *
-	 * Expands the pollset as required.  Must be called with the driver locked.
+	 * Must be called with the driver locked.
 	 *
 	 * @return		OK, or -errno on error.
 	 */

--- a/src/modules/uORB/uORB_tests/CMakeLists.txt
+++ b/src/modules/uORB/uORB_tests/CMakeLists.txt
@@ -44,6 +44,7 @@ px4_add_module(
 	MODULE modules__uORB__uORB_tests
 	MAIN uorb_tests
 	STACK_MAIN 2048
+	PRIORITY "SCHED_PRIORITY_MAX"
 	COMPILE_FLAGS
 	SRCS ${SRCS}
 	DEPENDS

--- a/src/modules/uORB/uORB_tests/uORBTest_UnitTest.cpp
+++ b/src/modules/uORB/uORB_tests/uORBTest_UnitTest.cpp
@@ -88,9 +88,12 @@ int uORBTest::UnitTest::pubsublatency_main()
 
 	const unsigned maxruns = 1000;
 	unsigned timingsgroup = 0;
+	int current_value = t.val;
+	int num_missed = 0;
 
 	// timings has to be on the heap to keep frame size below 2048 bytes
 	unsigned *timings = new unsigned[maxruns];
+	unsigned timing_min = 9999999, timing_max = 0;
 
 	for (unsigned i = 0; i < maxruns; i++) {
 		/* wait for up to 500ms for data */
@@ -110,13 +113,24 @@ int uORBTest::UnitTest::pubsublatency_main()
 		}
 
 		if (pret < 0) {
-			warn("poll error %d, %d", pret, errno);
+			PX4_ERR("poll error %d, %d", pret, errno);
 			continue;
 		}
 
-		hrt_abstime elt = hrt_elapsed_time(&t.time);
+		num_missed += t.val - current_value - 1;
+		current_value = t.val;
+
+		unsigned elt = (unsigned)hrt_elapsed_time(&t.time);
 		latency_integral += elt;
 		timings[i] = elt;
+
+		if (elt > timing_max) {
+			timing_max = elt;
+		}
+
+		if (elt < timing_min) {
+			timing_min = elt;
+		}
 	}
 
 	orb_unsubscribe(test_multi_sub);
@@ -129,7 +143,7 @@ int uORBTest::UnitTest::pubsublatency_main()
 		FILE *f = fopen(fname, "w");
 
 		if (f == nullptr) {
-			warnx("Error opening file!\n");
+			PX4_ERR("Error opening file!");
 			delete[] timings;
 			return PX4_ERROR;
 		}
@@ -141,9 +155,22 @@ int uORBTest::UnitTest::pubsublatency_main()
 		fclose(f);
 	}
 
+
+	float std_dev = 0.f;
+	float mean = latency_integral / maxruns;
+
+	for (unsigned i = 0; i < maxruns; i++) {
+		float diff = (float)timings[i] - mean;
+		std_dev += diff * diff;
+	}
+
 	delete[] timings;
 
-	warnx("mean: %8.4f us", static_cast<double>(latency_integral / maxruns));
+	PX4_INFO("mean:    %8.4f us", static_cast<double>(mean));
+	PX4_INFO("std dev: %8.4f us", static_cast<double>(sqrtf(std_dev / (maxruns - 1))));
+	PX4_INFO("min:     %3i us", timing_min);
+	PX4_INFO("max:     %3i us", timing_max);
+	PX4_INFO("missed topic updates: %i", num_missed);
 
 	pubsubtest_passed = true;
 

--- a/src/modules/uORB/uORB_tests/uORBTest_UnitTest.hpp
+++ b/src/modules/uORB/uORB_tests/uORBTest_UnitTest.hpp
@@ -153,7 +153,7 @@ int uORBTest::UnitTest::latency_test(orb_id_t T, bool print)
 
 	/* give the test task some data */
 	while (!pubsubtest_passed) {
-		t.val = 308;
+		++t.val;
 		t.time = hrt_absolute_time();
 
 		if (PX4_OK != orb_publish(T, pfd0, &t)) {

--- a/src/modules/uORB/uORB_tests/uORBTest_UnitTest.hpp
+++ b/src/modules/uORB/uORB_tests/uORBTest_UnitTest.hpp
@@ -146,8 +146,8 @@ int uORBTest::UnitTest::latency_test(orb_id_t T, bool print)
 	// prevent access if the caller data goes out of scope
 	int pubsub_task = px4_task_spawn_cmd("uorb_latency",
 					     SCHED_DEFAULT,
-					     SCHED_PRIORITY_MAX - 5,
-					     1500,
+					     SCHED_PRIORITY_MAX,
+					     1700,
 					     (px4_main_t)&uORBTest::UnitTest::pubsubtest_threadEntry,
 					     args);
 

--- a/src/systemcmds/top/CMakeLists.txt
+++ b/src/systemcmds/top/CMakeLists.txt
@@ -34,7 +34,7 @@ px4_add_module(
 	MODULE systemcmds__top
 	MAIN top
 	STACK_MAIN 1700
-	PRIORITY 255
+	PRIORITY "SCHED_PRIORITY_MAX"
 	COMPILE_FLAGS
 	SRCS
 		top.c


### PR DESCRIPTION
When looking at the uorb latency test with `uorb_tests latency_test` the latency for publish-poll-wakeup is 40 us. This seems small, but running at 1kHz it accounts for 4% CPU load for a single pub-sub pair.

This PR reduces the latency to 30us by avoiding the use of an expensive semaphore and disabling IRQs instead (the actual critical section is very small).
It also improves the `uorb_tests latency_test` for better output and more consistent results.

master:
```
uORB note: ---------------- LATENCY TEST ------------------
INFO  [uorb_tests] mean:     40.4320 us
INFO  [uorb_tests] std dev:   1.3466 us
INFO  [uorb_tests] min:      39 us
INFO  [uorb_tests] max:      57 us
INFO  [uorb_tests] missed topic updates: 0
```
This PR:
```
uORB note: ---------------- LATENCY TEST ------------------
INFO  [uorb_tests] mean:     30.4120 us
INFO  [uorb_tests] std dev:   1.0637 us
INFO  [uorb_tests] min:      29 us
INFO  [uorb_tests] max:      45 us
INFO  [uorb_tests] missed topic updates: 0
```

The changes here will become relevant when increasing the rate controller loop to 1kHz. I quickly tested running the attitude controller and fmu at 1kHz and the difference in CPU load is 4% (35 vs 31).

I've been using and flying with these changes for over a week.

Changes are split into separate commits with further explanations.

### Jitter

One interesting side note is looking at the latency after stopping mavlink (`mavlink stop-all`):
```
uORB note: ---------------- LATENCY TEST ------------------
INFO  [uorb_tests] mean:     30.1050 us
INFO  [uorb_tests] std dev:   0.3288 us
INFO  [uorb_tests] min:      29 us
INFO  [uorb_tests] max:      34 us
INFO  [uorb_tests] missed topic updates: 0
```
It can be seen that there is quite a bit less jitter that comes from UART interrupts/critical sections. I think having UART TX DMA would help here.