### PR TITLE
Takeoff: Arm occasionally triggers `maybe_landed`

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -520,7 +520,7 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 
 		// if already flying (armed and !landed) treat TAKEOFF like regular POSITION
 		if ((_navigator->get_vstatus()->arming_state == vehicle_status_s::ARMING_STATE_ARMED)
-		    && !_navigator->get_land_detected()->landed) {
+		    && !_navigator->get_land_detected()->landed && !_navigator->get_land_detected()->maybe_landed) {
 
 			sp->type = position_setpoint_s::SETPOINT_TYPE_POSITION;
 


### PR DESCRIPTION
**Test data / coverage**
https://review.px4.io/plot_app?log=42ef1074-1762-4a6d-9861-bb0ec3a9ec38
![takeoff](https://user-images.githubusercontent.com/37091262/43223873-b4b6c390-9011-11e8-9402-eb6985511e7b.png)


**Describe problem solved by the proposed pull request**
Very rarely (1 out of 20) an `arm` command will kick the **`land_detector`** into the  _`maybe_landed`_ state due to the torque from the props. This will cause the vehicle to fail to takeoff. I added the log statement (RESETTING TAKEOFF TO POSITION) at line 524 in `mission_block.cpp` which confirms that land detector thinks we are no longer `landed`.

**Describe your preferred solution**
Check that  the vehicle is not  _`maybe_landed`_ as well as not _`landed`_ upon takeoff.
