### PR TITLE
RTL: If already landing, go straight to RTL_LAND

### DIFF
--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -520,7 +520,7 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 
 		// if already flying (armed and !landed) treat TAKEOFF like regular POSITION
 		if ((_navigator->get_vstatus()->arming_state == vehicle_status_s::ARMING_STATE_ARMED)
-		    && !_navigator->get_land_detected()->landed) {
+		    && !_navigator->get_land_detected()->landed && !_navigator->get_land_detected()->maybe_landed) {
 
 			sp->type = position_setpoint_s::SETPOINT_TYPE_POSITION;
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -520,7 +520,7 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 
 		// if already flying (armed and !landed) treat TAKEOFF like regular POSITION
 		if ((_navigator->get_vstatus()->arming_state == vehicle_status_s::ARMING_STATE_ARMED)
-		    && !_navigator->get_land_detected()->landed && !_navigator->get_land_detected()->maybe_landed) {
+		    && !_navigator->get_land_detected()->landed) {
 
 			sp->type = position_setpoint_s::SETPOINT_TYPE_POSITION;
 

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -72,8 +72,9 @@ RTL::rtl_type() const
 void
 RTL::on_activation()
 {
-	if (_navigator->get_land_detected()->landed) {
-		// for safety reasons don't go into RTL if landed
+	if (_navigator->get_land_detected()->landed
+	    || (_navigator->get_position_setpoint_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_LAND)) {
+		// for safety reasons don't go into RTL if landed or currently in landing
 		_rtl_state = RTL_STATE_LANDED;
 
 	} else if ((rtl_type() == RTL_LAND) && _navigator->on_mission_landing()) {

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -69,7 +69,8 @@ RTL::on_activation()
 		// For safety reasons don't go into RTL if landed.
 		_rtl_state = RTL_STATE_LANDED;
 
-	} else if (_navigator->get_position_setpoint_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
+	} else if (_navigator->get_position_setpoint_triplet()->current.valid
+		   && _navigator->get_position_setpoint_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
 		// Skip straight to land if already performing a land.
 		_rtl_state = RTL_STATE_LAND;
 

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013-2017 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013-2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,13 +40,6 @@
 #include "rtl.h"
 #include "navigator.h"
 
-#include <cfloat>
-
-#include <mathlib/mathlib.h>
-#include <systemlib/mavlink_log.h>
-
-using math::max;
-using math::min;
 
 static constexpr float DELAY_SIGMA = 0.01f;
 
@@ -73,11 +66,11 @@ void
 RTL::on_activation()
 {
 	if (_navigator->get_land_detected()->landed) {
-		// For safety reasons don't go into RTL if landed or currently in landing.
+		// For safety reasons don't go into RTL if landed.
 		_rtl_state = RTL_STATE_LANDED;
 
 	} else if (_navigator->get_position_setpoint_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
-		// Do not go into full RTL if already performing a land.
+		// Skip straight to land if already performing a land.
 		_rtl_state = RTL_STATE_LAND;
 
 	} else if ((rtl_type() == RTL_LAND) && _navigator->on_mission_landing()) {
@@ -143,7 +136,7 @@ RTL::set_rtl_item()
 	const float home_dist = get_distance_to_next_waypoint(home.lat, home.lon, gpos.lat, gpos.lon);
 
 	// Compute the return altitude.
-	float return_alt = max(home.alt + _param_return_alt.get(), gpos.alt);
+	float return_alt = math::max(home.alt + _param_return_alt.get(), gpos.alt);
 
 	// We are close to home, limit climb to min.
 	if (home_dist < _param_rtl_min_dist.get()) {
@@ -151,7 +144,7 @@ RTL::set_rtl_item()
 	}
 
 	// Compute the loiter altitude.
-	const float loiter_altitude = min(home.alt + _param_descend_alt.get(), gpos.alt);
+	const float loiter_altitude = math::min(home.alt + _param_descend_alt.get(), gpos.alt);
 
 	switch (_rtl_state) {
 	case RTL_STATE_CLIMB: {
@@ -248,7 +241,7 @@ RTL::set_rtl_item()
 			_mission_item.yaw = home.yaw;
 			_mission_item.loiter_radius = _navigator->get_loiter_radius();
 			_mission_item.acceptance_radius = _navigator->get_acceptance_radius();
-			_mission_item.time_inside = max(_param_land_delay.get(), 0.0f);
+			_mission_item.time_inside = math::max(_param_land_delay.get(), 0.0f);
 			_mission_item.autocontinue = autoland;
 			_mission_item.origin = ORIGIN_ONBOARD;
 


### PR DESCRIPTION
**Test data / coverage**
Tested issuing a `land` command followed by an `rtl` command in gazebo. Vehicle continues to descend as expected.

**Describe problem solved by the proposed pull request**
RTL interrupts a land. This is an issue if an operator is trying to land the vehicle and a critically low battery triggers an RTL. We have seen many times the vehicle takeoff back into the air (RTL) when it is about to touch down for landing.

**Describe your preferred solution**
Do not allow RTL to `CLIMB` if already `position_setpoint_s::SETPOINT_TYPE_LAND`

_I also cleaned up the comments, removed unnecessary includes, and got rid of namepacing_