### PR TITLE
Land: fix on_active() so mission finishes

### DIFF
--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -80,7 +80,7 @@ Land::on_active()
 	}
 
 
-	if (is_mission_item_reached() && !_navigator->get_mission_result()->finished) {
+	if (_navigator->get_land_detected()->landed) {
 		_navigator->get_mission_result()->finished = true;
 		_navigator->set_mission_result_updated();
 		set_idle_item(&_mission_item);


### PR DESCRIPTION
**Test data / coverage**
Verified that the mission can actually finish using a print statement and running a test in gazebo.

**Describe problem solved by the proposed pull request**
Not a problem per se, but it is indeed a bug with `land` from the perspective of a mission. 

**Describe your preferred solution**
Use the function available to us `_navigator->get_land_detected()` to verify that we have indeed landed. The previous implementation was looking for  `is_mission_item_reached()`, which was unreachable because during land the mission item altitude set point was being set to absolute zero.
