### PR TITLE
Windows CI on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,11 @@ init:
 - ver
 
 install:
-- cd C:\
-- certutil -urlcache -split -f "https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.3.msi" Toolchain.msi
-- msiexec /i Toolchain.msi /quiet /qn /norestart /log install.log
+- ps: if (-not (Test-Path C:\Toolchain.msi)) {Invoke-WebRequest https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.3.msi -OutFile C:\Toolchain.msi}
+- start /wait msiexec /i C:\Toolchain.msi /quiet /qn /norestart /log C:\install.log
 
 build_script:
 - call C:\PX4\toolchain\clone-px4-build-sitl.bat
+
+cache:
+- C:\Toolchain.msi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,8 +16,25 @@ install:
 - ps: if (-not (Test-Path C:\Toolchain.msi)) {Invoke-WebRequest https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.3.msi -OutFile C:\Toolchain.msi}
 - start /wait msiexec /i C:\Toolchain.msi /quiet /qn /norestart /log C:\install.log
 
+# Note: using start /wait is important
+# because otherwise the install begins but non-blocking and the result cannot be used just after
+
 build_script:
-- call C:\PX4\toolchain\clone-px4-build-sitl.bat
+# setup the environmental variables to work within the installed cygwin toolchain
+- call C:\PX4\toolchain\setup-environment-variables.bat x
+# safe the repopath for switching to it in cygwin bash
+- for /f %%i in ('cygpath -u %%CD%%') do set repopath=%%i
+# fetch all submodules in parallel
+- call bash --login -c "cd $repopath && git submodule update --init --recursive --jobs=10"
+# make SITL
+- call bash --login -c "cd $repopath && make posix"
+# make pixracer to check NuttX build
+- call bash --login -c "cd $repopath && make px4fmu-v4_default"
+
+# Note: using bash --login is important
+# because otherwise certain things (like python; import numpy) do not work
 
 cache:
-- C:\Toolchain.msi
+# cache toolchain installation file to avoid downloading it from AWS S3 each time
+# it's ~496MB < 1GB free limit for build caches
+- C:\Toolchain.msi -> appveyor.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ init:
 
 install:
 - cd C:\
-- git clone https://github.com/MaEtUgR/PX4Toolchain.git PX4
-- call PX4\toolchain\install-all-components.bat
+- certutil -urlcache -split -f "https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.3.msi" Toolchain.msi
+- msiexec /i Toolchain.msi /quiet /qn /norestart /log install.log
 
 build_script:
 - call C:\PX4\toolchain\clone-px4-build-sitl.bat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+# Build version
+version: "{build}"
+
+# Build worker image (build VM template)
+image: Visual Studio 2017
+
+# build platform, i.e. Win32 (instead of x86), x64, Any CPU. This setting is optional.
+platform:
+- x64
+
+# scripts that are called at very beginning, before repo cloning
+init:
+- ver
+
+install:
+- cd C:\
+- git clone https://github.com/MaEtUgR/PX4Toolchain.git PX4
+- call PX4\toolchain\install-all-components.bat
+
+build_script:
+- call C:\PX4\toolchain\clone-px4-build-sitl.bat


### PR DESCRIPTION
This PR is based on my initiative to support PX4 developent under Windows and @dagar 's request to have CI to inform everyone automatically when a change breaks that support.
Reference: #10002 

**Solution:**
I created an `appveyor.yml` CI script that when enabling the [Appveyor CI service](https://www.appveyor.com/) for the PX4 Firmware repository automatically builds it under Windows. Appveyor in particular is used because it's a convenient cloud service host supporting Windows builds and it offers a free service usage with a certain amount of resources to open source projects.

**Details:**
- It downloads and uses the latest Cygwin Toolchain installer which is described in the Devguide here:
http://dev.px4.io/en/setup/dev_env_windows_cygwin.html
Hence it exactly reproduces the recommended way to build natively under Windows.
- It caches the MSI installer file (496MB) on the Appveyor server to prevent huge amounts of duplicate downloading from AWS S3.
- It sets up the environmental variables exactly as the scripts do for your local usage without using any Appveyor specific feature other than the bare metal Windows 10 machine.
- It builds the `posix` (SITL) and `px4fmu-v4` (to test NuttX build) targets with a complete execution time of ~13 min. Other tests can be added in the future.
- The installer itself uses ~3.5 min but has to be executed everytime because the free build cache is 1GB which the complete toolchain folder exceeds. Also I'm not if the Appveyor cache extracting of that many files would be actually any faster.

**Conclusion:**
I suggest to enable this CI even if we might find any better solution. As stated the process itself is not dependend on Appveyor and the gained experience setting this up could be used on any CI automated Windows machine e.g. a jenkins slave. I'm happy to look into that later on if I get some support to integrate it with [ci.px4.io](http://ci.px4.io/).

The output of the successful build of this pr (and hence currently latest master) is available here: https://ci.appveyor.com/project/MaEtUgR/firmware-b5mk6/build/25

closes #10002
