### PR TITLE
mavlink: add sysid to UUID

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1310,6 +1310,14 @@ void Mavlink::send_autopilot_capabilites()
 		board_get_uuid32(uid);
 		msg.uid = (((uint64_t)uid[PX4_CPU_UUID_WORD32_UNIQUE_M]) << 32) | uid[PX4_CPU_UUID_WORD32_UNIQUE_H];
 
+#ifdef CONFIG_ARCH_BOARD_SITL
+		// To avoid that multiple SITL instances have the same UUID, we add the mavlink
+		// system ID. We subtract 1, so that the first UUID remains unchanged given the
+		// default system ID is 1.
+		//
+		// Note that the UUID show in `ver` will still be the same for all instances.
+		msg.uid += mavlink_system.sysid - 1;
+#endif
 		mavlink_msg_autopilot_version_send_struct(get_channel(), &msg);
 	}
 }


### PR DESCRIPTION
To avoid that multiple SITL instances have the same UUID we add the
mavlink system ID to the UUID which is sent via mavlink.

This should resolve the case where multiple vehicles show up with the
same UUID in simulation.

Note that the UUID show in `ver` will still be the same for all
instances.

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary.

Untested.

Fixes #9286.