### PR TITLE
adis16477 probe and reset

### DIFF
--- a/src/drivers/boards/av-x-v1/init.c
+++ b/src/drivers/boards/av-x-v1/init.c
@@ -163,6 +163,14 @@ stm32_boardinitialize(void)
 
 __EXPORT int board_app_initialize(uintptr_t arg)
 {
+#ifdef GPIO_SPI1_RESET_ADIS16477
+	// ADIS16477 reset pin
+	stm32_configgpio(GPIO_SPI1_RESET_ADIS16477);
+	stm32_gpiowrite(GPIO_SPI1_RESET_ADIS16477, false);
+	up_udelay(10);
+	stm32_gpiowrite(GPIO_SPI1_RESET_ADIS16477, true);
+#endif /* GPIO_SPI1_RESET_ADIS16477 */
+
 	/* run C++ ctors before we go any further */
 	up_cxxinitialize();
 

--- a/src/drivers/imu/adis16477/ADIS16477.cpp
+++ b/src/drivers/imu/adis16477/ADIS16477.cpp
@@ -79,14 +79,6 @@ ADIS16477::ADIS16477(int bus, const char *path_accel, const char *path_gyro, uin
 	_bad_transfers(perf_alloc(PC_COUNT, "adis16477_bad_transfers")),
 	_rotation(rotation)
 {
-#ifdef GPIO_SPI1_RESET_ADIS16477
-	// ADIS16477 reset pin
-	stm32_configgpio(GPIO_SPI1_RESET_ADIS16477);
-	stm32_gpiowrite(GPIO_SPI1_RESET_ADIS16477, false);
-	up_mdelay(10);
-	stm32_gpiowrite(GPIO_SPI1_RESET_ADIS16477, true);
-#endif /* GPIO_SPI1_RESET_ADIS16477 */
-
 	_device_id.devid_s.devtype = DRV_ACC_DEVTYPE_ADIS16477;
 
 	_gyro->_device_id.devid = _device_id.devid;


### PR DESCRIPTION
The ADIS16477 seems to require more time than specified in the datasheet to initialize after a reset. This PR moves the RESET (via RST pin) to the board initialization (to maximize the time before probe) and cleans up the probe and reset logic in the ADIS16477 driver. The ADIS16477 debug output has also been left on for now until there's a more definitive answer.