### PR TITLE
uORB: update msgs fields from camelCase to snake_case

### DIFF
--- a/msg/system_power.msg
+++ b/msg/system_power.msg
@@ -1,12 +1,12 @@
-float32 voltage5V_v		# peripheral 5V rail voltage
-float32 voltage3V3_v	# Sensor 3V3 rail voltage
+float32 voltage5v_v		# peripheral 5V rail voltage
+float32 voltage3v3_v		# Sensor 3V3 rail voltage
 uint8 v3v3_valid		# Sensor 3V3 rail voltage was read.
 uint8 usb_connected		# USB is connected when 1
 uint8 brick_valid		# brick bits power is good when bit 1
 uint8 usb_valid 		# USB is valid when 1
 uint8 servo_valid		# servo power is good when 1
-uint8 periph_5V_OC		# peripheral overcurrent when 1
-uint8 hipower_5V_OC		# hi power peripheral overcurrent when 1
+uint8 periph_5v_oc		# peripheral overcurrent when 1
+uint8 hipower_5v_oc		# hi power peripheral overcurrent when 1
 
 uint8 BRICK1_VALID_SHIFTS=0
 uint8 BRICK1_VALID_MASK=1
@@ -16,4 +16,3 @@ uint8 BRICK3_VALID_SHIFTS=2
 uint8 BRICK3_VALID_MASK=4
 uint8 BRICK4_VALID_SHIFTS=3
 uint8 BRICK4_VALID_MASK=8
-

--- a/msg/tecs_status.msg
+++ b/msg/tecs_status.msg
@@ -7,19 +7,19 @@ uint8 TECS_MODE_BAD_DESCENT = 5
 uint8 TECS_MODE_CLIMBOUT = 6
 
 
-float32 altitudeSp
+float32 altitude_sp
 float32 altitude_filtered
-float32 flightPathAngleSp
-float32 flightPathAngle
-float32 airspeedSp
+float32 flight_path_angle_sp
+float32 flight_path_angle
+float32 airspeed_sp
 float32 airspeed_filtered
-float32 airspeedDerivativeSp
-float32 airspeedDerivative
+float32 airspeed_derivative_sp
+float32 airspeed_derivative
 
-float32 totalEnergyError
-float32 energyDistributionError
-float32 totalEnergyRateError
-float32 energyDistributionRateError
+float32 total_energy_error
+float32 energy_distribution_error
+float32 total_energy_rate_error
+float32 energy_distribution_rate_error
 
 float32 throttle_integ
 float32 pitch_integ

--- a/msg/tools/px_generate_uorb_topic_helper.py
+++ b/msg/tools/px_generate_uorb_topic_helper.py
@@ -107,7 +107,7 @@ def sizeof_field_type(field):
 def get_children_fields(base_type, search_path):
     (package, name) = genmsg.names.package_resource_name(base_type)
     tmp_msg_context = genmsg.msg_loader.MsgContext.create_default()
-    spec_temp = genmsg.msg_loader.load_msg_by_type(tmp_msg_context, '%s/%s' %(package, name), search_path)  
+    spec_temp = genmsg.msg_loader.load_msg_by_type(tmp_msg_context, '%s/%s' %(package, name), search_path)
     sorted_fields = sorted(spec_temp.parsed_fields(), key=sizeof_field_type, reverse=True)
     return sorted_fields
 
@@ -184,6 +184,9 @@ def print_field(field):
     Echo printf line
     """
 
+    # check if there are any upper case letters in the field name
+    assert not any(a.isupper() for a in field.name), "%r field contains uppercase letters" % field.name
+
     # skip padding
     if field.name.startswith('_padding'):
         return
@@ -250,6 +253,10 @@ def print_field_def(field):
     """
     Print the C type from a field
     """
+
+    # check if there are any upper case letters in the field name
+    assert not any(a.isupper() for a in field.name), "%r field contains uppercase letters" % field.name
+
     type_name = field.type
     # detect embedded types
     sl_pos = type_name.find('/')

--- a/msg/transponder_report.msg
+++ b/msg/transponder_report.msg
@@ -1,4 +1,4 @@
-uint32 ICAO_address 	# ICAO address
+uint32 icao_address 	# ICAO address
 float64 lat 		# Latitude, expressed as degrees
 float64 lon 		# Longitude, expressed as degrees
 uint8 altitude_type	# Type from ADSB_ALTITUDE_TYPE enum

--- a/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
+++ b/src/drivers/differential_pressure/ms4525/ms4525_airspeed.cpp
@@ -327,7 +327,7 @@ MEASAirspeed::voltage_correction(float &diff_press_pa, float &temperature)
 		orb_copy(ORB_ID(system_power), _t_system_power, &system_power);
 	}
 
-	if (system_power.voltage5V_v < 3.0f || system_power.voltage5V_v > 6.0f) {
+	if (system_power.voltage5v_v < 3.0f || system_power.voltage5v_v > 6.0f) {
 		// not valid, skip correction
 		return;
 	}
@@ -336,7 +336,7 @@ MEASAirspeed::voltage_correction(float &diff_press_pa, float &temperature)
 	/*
 	  apply a piecewise linear correction, flattening at 0.5V from 5V
 	 */
-	float voltage_diff = system_power.voltage5V_v - 5.0f;
+	float voltage_diff = system_power.voltage5v_v - 5.0f;
 
 	if (voltage_diff > 0.5f) {
 		voltage_diff = 0.5f;
@@ -352,7 +352,7 @@ MEASAirspeed::voltage_correction(float &diff_press_pa, float &temperature)
 	  the temperature masurement varies as well
 	 */
 	const float temp_slope = 0.887f;
-	voltage_diff = system_power.voltage5V_v - 5.0f;
+	voltage_diff = system_power.voltage5v_v - 5.0f;
 
 	if (voltage_diff > 0.5f) {
 		voltage_diff = 0.5f;

--- a/src/drivers/kinetis/adc/adc.cpp
+++ b/src/drivers/kinetis/adc/adc.cpp
@@ -368,7 +368,7 @@ ADC::update_system_power(hrt_abstime now)
 	system_power_s system_power = {};
 	system_power.timestamp = now;
 
-	system_power.voltage5V_v = 0;
+	system_power.voltage5v_v = 0;
 
 #if defined(ADC_5V_RAIL_SENSE)
 
@@ -376,7 +376,7 @@ ADC::update_system_power(hrt_abstime now)
 
 		if (_samples[i].am_channel == ADC_5V_RAIL_SENSE) {
 			// it is 2:1 scaled
-			system_power.voltage5V_v = _samples[i].am_data * (6.6f / 4096.0f);
+			system_power.voltage5v_v = _samples[i].am_data * (6.6f / 4096.0f);
 		}
 	}
 
@@ -402,8 +402,8 @@ ADC::update_system_power(hrt_abstime now)
 	system_power.servo_valid   = BOARD_ADC_SERVO_VALID;
 
 	// OC pins are active low
-	system_power.periph_5V_OC  = BOARD_ADC_PERIPH_5V_OC;
-	system_power.hipower_5V_OC = BOARD_ADC_HIPOWER_5V_OC;
+	system_power.periph_5v_oc  = BOARD_ADC_PERIPH_5V_OC;
+	system_power.hipower_5v_oc = BOARD_ADC_HIPOWER_5V_OC;
 
 	/* lazily publish */
 	if (_to_system_power != nullptr) {

--- a/src/drivers/stm32/adc/adc.cpp
+++ b/src/drivers/stm32/adc/adc.cpp
@@ -386,8 +386,8 @@ ADC::update_system_power(hrt_abstime now)
 	system_power_s system_power = {};
 	system_power.timestamp = now;
 
-	system_power.voltage5V_v = 0;
-	system_power.voltage3V3_v = 0;
+	system_power.voltage5v_v = 0;
+	system_power.voltage3v3_v = 0;
 	system_power.v3v3_valid = 0;
 
 	/* Assume HW provides only ADC_SCALED_V5_SENSE */
@@ -402,7 +402,7 @@ ADC::update_system_power(hrt_abstime now)
 
 		if (_samples[i].am_channel == ADC_SCALED_V5_SENSE) {
 			// it is 2:1 scaled
-			system_power.voltage5V_v = _samples[i].am_data * (ADC_V5_V_FULL_SCALE / 4096.0f);
+			system_power.voltage5v_v = _samples[i].am_data * (ADC_V5_V_FULL_SCALE / 4096.0f);
 			cnt--;
 
 		} else
@@ -411,7 +411,7 @@ ADC::update_system_power(hrt_abstime now)
 		{
 			if (_samples[i].am_channel == ADC_SCALED_V3V3_SENSORS_SENSE) {
 				// it is 2:1 scaled
-				system_power.voltage3V3_v = _samples[i].am_data * (ADC_3V3_SCALE * (3.3f / 4096.0f));
+				system_power.voltage3v3_v = _samples[i].am_data * (ADC_3V3_SCALE * (3.3f / 4096.0f));
 				system_power.v3v3_valid = 1;
 				cnt--;
 			}
@@ -451,8 +451,8 @@ ADC::update_system_power(hrt_abstime now)
 	system_power.servo_valid   = BOARD_ADC_SERVO_VALID;
 
 	// OC pins are active low
-	system_power.periph_5V_OC  = BOARD_ADC_PERIPH_5V_OC;
-	system_power.hipower_5V_OC = BOARD_ADC_HIPOWER_5V_OC;
+	system_power.periph_5v_oc  = BOARD_ADC_PERIPH_5V_OC;
+	system_power.hipower_5v_oc = BOARD_ADC_HIPOWER_5V_OC;
 
 	/* lazily publish */
 	if (_to_system_power != nullptr) {

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -507,7 +507,7 @@ static bool powerCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, 
 			if (hrt_elapsed_time(&system_power.timestamp) < 200000) {
 
 				/* copy avionics voltage */
-				float avionics_power_rail_voltage = system_power.voltage5V_v;
+				float avionics_power_rail_voltage = system_power.voltage5v_v;
 
 				// avionics rail
 				// Check avionics rail voltages

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1956,21 +1956,21 @@ FixedwingPositionControl::tecs_update_pitch_throttle(float alt_sp, float airspee
 		break;
 	}
 
-	t.altitudeSp			= _tecs.hgt_setpoint_adj();
+	t.altitude_sp			= _tecs.hgt_setpoint_adj();
 	t.altitude_filtered		= _tecs.vert_pos_state();
-	t.airspeedSp			= _tecs.TAS_setpoint_adj();
-	t.airspeed_filtered 	= _tecs.tas_state();
+	t.airspeed_sp			= _tecs.TAS_setpoint_adj();
+	t.airspeed_filtered 		= _tecs.tas_state();
 
-	t.flightPathAngleSp		= _tecs.hgt_rate_setpoint();
-	t.flightPathAngle		= _tecs.vert_vel_state();
+	t.flight_path_angle_sp		= _tecs.hgt_rate_setpoint();
+	t.flight_path_angle		= _tecs.vert_vel_state();
 
-	t.airspeedDerivativeSp	= _tecs.TAS_rate_setpoint();
-	t.airspeedDerivative	= _tecs.speed_derivative();
+	t.airspeed_derivative_sp	= _tecs.TAS_rate_setpoint();
+	t.airspeed_derivative		= _tecs.speed_derivative();
 
-	t.totalEnergyError				= _tecs.STE_error();
-	t.totalEnergyRateError			= _tecs.STE_rate_error();
-	t.energyDistributionError		= _tecs.SEB_error();
-	t.energyDistributionRateError	= _tecs.SEB_rate_error();
+	t.total_energy_error			= _tecs.STE_error();
+	t.total_energy_rate_error		= _tecs.STE_rate_error();
+	t.energy_distribution_error		= _tecs.SEB_error();
+	t.energy_distribution_rate_error	= _tecs.SEB_rate_error();
 
 	t.throttle_integ	= _tecs.throttle_integ_state();
 	t.pitch_integ		= _tecs.pitch_integ_state();

--- a/src/modules/mavlink/mavlink_high_latency2.cpp
+++ b/src/modules/mavlink/mavlink_high_latency2.cpp
@@ -362,7 +362,7 @@ bool MavlinkStreamHighLatency2::write_tecs_status(mavlink_high_latency2_t *msg)
 
 	if (_tecs_time > 0) {
 		int16_t target_altitude;
-		convert_limit_safe(tecs_status.altitudeSp, target_altitude);
+		convert_limit_safe(tecs_status.altitude_sp, target_altitude);
 		msg->target_altitude = target_altitude;
 	}
 
@@ -502,7 +502,7 @@ void MavlinkStreamHighLatency2::update_tecs_status()
 	tecs_status_s tecs_status;
 
 	if (_tecs_status_sub->update(&tecs_status)) {
-		_airspeed_sp.add_value(tecs_status.airspeedSp, _update_rate_filtered);
+		_airspeed_sp.add_value(tecs_status.airspeed_sp, _update_rate_filtered);
 	}
 }
 

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -1378,7 +1378,7 @@ protected:
 
 			if (!(pos.flags & transponder_report_s::PX4_ADSB_FLAGS_RETRANSLATE)) { continue; }
 
-			msg.ICAO_address = pos.ICAO_address;
+			msg.ICAO_address = pos.icao_address;
 			msg.lat = pos.lat * 1e7;
 			msg.lon = pos.lon * 1e7;
 			msg.altitude_type = pos.altitude_type;
@@ -3517,8 +3517,8 @@ protected:
 			msg.target_bearing = (int16_t)math::degrees(_fw_pos_ctrl_status.target_bearing);
 			msg.wp_dist = (uint16_t)_fw_pos_ctrl_status.wp_dist;
 			msg.xtrack_error = _fw_pos_ctrl_status.xtrack_error;
-			msg.alt_error = _tecs_status.altitude_filtered - _tecs_status.altitudeSp;
-			msg.aspd_error = _tecs_status.airspeed_filtered - _tecs_status.airspeedSp;
+			msg.alt_error = _tecs_status.altitude_filtered - _tecs_status.altitude_sp;
+			msg.aspd_error = _tecs_status.airspeed_filtered - _tecs_status.airspeed_sp;
 
 			mavlink_msg_nav_controller_output_send_struct(_mavlink->get_channel(), &msg);
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2167,7 +2167,7 @@ void MavlinkReceiver::handle_message_adsb_vehicle(mavlink_message_t *msg)
 
 	t.timestamp = hrt_absolute_time();
 
-	t.ICAO_address = adsb.ICAO_address;
+	t.icao_address = adsb.ICAO_address;
 	t.lat = adsb.lat * 1e-7;
 	t.lon = adsb.lon * 1e-7;
 	t.altitude_type = adsb.altitude_type;

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -967,7 +967,7 @@ void Navigator::fake_traffic(const char *callsign, float distance, float directi
 
 	transponder_report_s tr = {};
 	tr.timestamp = hrt_absolute_time();
-	tr.ICAO_address = 1234;
+	tr.icao_address = 1234;
 	tr.lat = lat; // Latitude, expressed as degrees
 	tr.lon = lon; // Longitude, expressed as degrees
 	tr.altitude_type = 0;

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -210,11 +210,11 @@ void VtolType::check_quadchute_condition()
 			// We use tecs for tracking in FW and local_pos_sp during transitions
 			if (_tecs_running) {
 				// 1 second rolling average
-				_ra_hrate = (49 * _ra_hrate + _tecs_status->flightPathAngle) / 50;
-				_ra_hrate_sp = (49 * _ra_hrate_sp + _tecs_status->flightPathAngleSp) / 50;
+				_ra_hrate = (49 * _ra_hrate + _tecs_status->flight_path_angle) / 50;
+				_ra_hrate_sp = (49 * _ra_hrate_sp + _tecs_status->flight_path_angle_sp) / 50;
 
 				// are we dropping while requesting significant ascend?
-				if (((_tecs_status->altitudeSp - _tecs_status->altitude_filtered) > _params->fw_alt_err) &&
+				if (((_tecs_status->altitude_sp - _tecs_status->altitude_filtered) > _params->fw_alt_err) &&
 				    (_ra_hrate < -1.0f) &&
 				    (_ra_hrate_sp > 1.0f)) {
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
In the process of developing a ROS2 package that will be interfacing PX4 with ROS2 through fast-RTPS, I found out that while trying to building the package with the respective ROS msg generation, `rosidl_generate_interfaces()` does not process msg fields which have uppercase letters.

**Describe your preferred solution**
This is an harmless PR which changes some message fields that have uppercase letters (or present a camelCase naming convention) so `rosidl_generate_interfaces()` is able to generate code for ROS IDL files. It basically replaces the uppercase with lowercase, and where required, change the naming convention to snake_case.

**Describe possible alternatives**
Not really much more we can do about it, unless one changes the copied file online during the build process, which is not really efficient.