### PR TITLE
version lib fix BUILD_URI properly

### DIFF
--- a/src/lib/version/version.c
+++ b/src/lib/version/version.c
@@ -58,6 +58,11 @@ enum FIRMWARE_TYPE {
 	FIRMWARE_TYPE_RELEASE = 255
 };
 
+const char *px4_build_uri(void)
+{
+	return STRINGIFY(BUILD_URI);
+}
+
 uint32_t version_tag_to_number(const char *tag)
 {
 	uint32_t version_number = 0;

--- a/src/lib/version/version.h
+++ b/src/lib/version/version.h
@@ -93,10 +93,7 @@ static inline int px4_board_hw_revision(void)
 /**
  * get the build URI (used for crash logging)
  */
-static inline const char *px4_build_uri(void)
-{
-	return STRINGIFY(BUILD_URI);
-}
+const char *px4_build_uri(void);
 
 /**
  * Convert a version tag string to a number


### PR DESCRIPTION
Move px4_build_uri out of header so that other users of the header don't miss the define.

**master**
![image](https://user-images.githubusercontent.com/84712/43378418-d74aedec-9394-11e8-8a6b-c18b75b86973.png)




**PR**
![image](https://user-images.githubusercontent.com/84712/43378397-ae226d46-9394-11e8-9ab8-b4faa198157f.png)
