### PR TITLE
FMU: fix safety button

### DIFF
--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1650,7 +1650,8 @@ PX4IO::io_handle_status(uint16_t status)
 		orb_publish(ORB_ID(safety), _to_safety, &safety);
 
 	} else {
-		_to_safety = orb_advertise(ORB_ID(safety), &safety);
+		int instance;
+		_to_safety = orb_advertise_multi(ORB_ID(safety), &safety, &instance, ORB_PRIO_DEFAULT);
 	}
 
 	return ret;

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1228,6 +1228,27 @@ out:
 		unregister_driver(PWM_OUTPUT0_DEVICE_PATH);
 	}
 
+	if (_to_input_rc) {
+		orb_unadvertise(_to_input_rc);
+	}
+
+	if (_to_outputs) {
+		orb_unadvertise(_to_outputs);
+	}
+
+	if (_to_servorail) {
+		orb_unadvertise(_to_servorail);
+	}
+
+	if (_to_safety) {
+		orb_unadvertise(_to_safety);
+	}
+
+	if (_to_mixer_status) {
+		orb_unadvertise(_to_mixer_status);
+	}
+
+
 	/* tell the dtor that we are exiting */
 	_task = -1;
 	_exit(0);


### PR DESCRIPTION
The safety button broke with https://github.com/PX4/Firmware/pull/9978. The problem was that fmu did not listen to the safety topic.

- use the orb topic safety to check the safety state, because the actual safety state can come from the IO
- fix initialization if circuit breaker is set