### PR TITLE
delete useless sensor self tests: ACCELIOCSELFTEST, GYROIOCSELFTEST, MAGIOCSELFTEST

### DIFF
--- a/src/drivers/drv_accel.h
+++ b/src/drivers/drv_accel.h
@@ -94,9 +94,6 @@ struct accel_calibration_s {
 /** get the current accel measurement range in g */
 #define ACCELIOCGRANGE		_ACCELIOC(8)
 
-/** get the result of a sensor self-test */
-#define ACCELIOCSELFTEST	_ACCELIOC(9)
-
 /** determine if hardware is external or onboard */
 #define ACCELIOCGEXTERNAL	_ACCELIOC(12)
 

--- a/src/drivers/drv_gyro.h
+++ b/src/drivers/drv_gyro.h
@@ -91,9 +91,6 @@ struct gyro_calibration_s {
 /** get the current gyro measurement range in degrees per second */
 #define GYROIOCGRANGE		_GYROIOC(7)
 
-/** check the status of the sensor */
-#define GYROIOCSELFTEST		_GYROIOC(8)
-
 /** get the current gyro type */
 #define GYROIOCTYPE			_GYROIOC(13)
 

--- a/src/drivers/drv_mag.h
+++ b/src/drivers/drv_mag.h
@@ -93,9 +93,6 @@ struct mag_calibration_s {
 /** excite strap */
 #define MAGIOCEXSTRAP		_MAGIOC(9)
 
-/** perform self test and report status */
-#define MAGIOCSELFTEST		_MAGIOC(10)
-
 /** determine if mag is external or onboard */
 #define MAGIOCGEXTERNAL		_MAGIOC(11)
 

--- a/src/drivers/imu/adis16448/adis16448.cpp
+++ b/src/drivers/imu/adis16448/adis16448.cpp
@@ -1266,9 +1266,6 @@ ADIS16448::mag_ioctl(struct file *filp, int cmd, unsigned long arg)
 	case MAGIOCGRANGE:
 		return (unsigned long)(_mag_range_mgauss);
 
-	case MAGIOCSELFTEST:
-		return OK;
-
 	case MAGIOCTYPE:
 		return (ADIS16448_Product);
 

--- a/src/drivers/imu/adis16448/adis16448.cpp
+++ b/src/drivers/imu/adis16448/adis16448.cpp
@@ -384,20 +384,6 @@ private:
 	 */
 	int 			self_test();
 
-	/**
-	 * Accel self test
-	 *
-	 * @return 0 on success, 1 on failure
-	 */
-	int 			accel_self_test();
-
-	/**
-	 * Gyro self test
-	 *
-	 * @return 0 on success, 1 on failure
-	 */
-	int 			gyro_self_test();
-
 	/*
 	  set low pass filter frequency
 	 */
@@ -903,26 +889,6 @@ ADIS16448::self_test()
 	return (perf_event_count(_sample_perf) > 0) ? 0 : 1;
 }
 
-int
-ADIS16448::accel_self_test()
-{
-	if (self_test()) {
-		return 1;
-	}
-
-	return 0;
-}
-
-int
-ADIS16448::gyro_self_test()
-{
-	if (self_test()) {
-		return 1;
-	}
-
-	return 0;
-}
-
 ssize_t
 ADIS16448::gyro_read(struct file *filp, char *buffer, size_t buflen)
 {
@@ -1137,9 +1103,6 @@ ADIS16448::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCGRANGE:
 		return (unsigned long)((_accel_range_m_s2) / CONSTANTS_ONE_G + 0.5f);
 
-	case ACCELIOCSELFTEST:
-		return accel_self_test();
-
 	case ACCELIOCTYPE:
 		return (ADIS16448_Product);
 
@@ -1202,9 +1165,6 @@ ADIS16448::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 	case GYROIOCGRANGE:
 		return (unsigned long)(_gyro_range_rad_s * 180.0f / M_PI_F + 0.5f);
 
-	case GYROIOCSELFTEST:
-		return gyro_self_test();
-
 	case GYROIOCTYPE:
 		return (ADIS16448_Product);
 
@@ -1259,9 +1219,6 @@ ADIS16448::mag_ioctl(struct file *filp, int cmd, unsigned long arg)
 		/* copy scale out */
 		memcpy((struct mag_calibration_s *) arg, &_mag_scale, sizeof(_mag_scale));
 		return OK;
-
-	case MAGIOCSRANGE:
-		return -EINVAL;
 
 	case MAGIOCGRANGE:
 		return (unsigned long)(_mag_range_mgauss);

--- a/src/drivers/imu/bmi055/BMI055_accel.cpp
+++ b/src/drivers/imu/bmi055/BMI055_accel.cpp
@@ -308,41 +308,6 @@ BMI055_accel::self_test()
 	return (perf_event_count(_sample_perf) > 0) ? 0 : 1;
 }
 
-int
-BMI055_accel::accel_self_test()
-{
-	if (self_test()) {
-		return 1;
-	}
-
-	/* inspect accel offsets */
-	if (fabsf(_accel_scale.x_offset) < 0.000001f) {
-		return 1;
-	}
-
-	if (fabsf(_accel_scale.x_scale - 1.0f) > 0.4f || fabsf(_accel_scale.x_scale - 1.0f) < 0.000001f) {
-		return 1;
-	}
-
-	if (fabsf(_accel_scale.y_offset) < 0.000001f) {
-		return 1;
-	}
-
-	if (fabsf(_accel_scale.y_scale - 1.0f) > 0.4f || fabsf(_accel_scale.y_scale - 1.0f) < 0.000001f) {
-		return 1;
-	}
-
-	if (fabsf(_accel_scale.z_offset) < 0.000001f) {
-		return 1;
-	}
-
-	if (fabsf(_accel_scale.z_scale - 1.0f) > 0.4f || fabsf(_accel_scale.z_scale - 1.0f) < 0.000001f) {
-		return 1;
-	}
-
-	return 0;
-}
-
 /*
   deliberately trigger an error in the sensor to trigger recovery
  */
@@ -483,9 +448,6 @@ BMI055_accel::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case ACCELIOCGRANGE:
 		return (unsigned long)((_accel_range_m_s2) / CONSTANTS_ONE_G + 0.5f);
-
-	case ACCELIOCSELFTEST:
-		return accel_self_test();
 
 	default:
 		/* give it to the superclass */

--- a/src/drivers/imu/bmi055/BMI055_accel.hpp
+++ b/src/drivers/imu/bmi055/BMI055_accel.hpp
@@ -279,13 +279,6 @@ private:
 	 */
 	int             self_test();
 
-	/**
-	 * Accel self test
-	 *
-	 * @return 0 on success, 1 on failure
-	 */
-	int             accel_self_test();
-
 	/*
 	 * set accel sample rate
 	 */

--- a/src/drivers/imu/bmi055/BMI055_gyro.cpp
+++ b/src/drivers/imu/bmi055/BMI055_gyro.cpp
@@ -256,61 +256,6 @@ BMI055_gyro::self_test()
 	return (perf_event_count(_sample_perf) > 0) ? 0 : 1;
 }
 
-int
-BMI055_gyro::gyro_self_test()
-{
-	if (self_test()) {
-		return 1;
-	}
-
-	/*
-	 * Maximum deviation of 10 degrees
-	 */
-	const float max_offset = (float)(10 * M_PI_F / 180.0f);
-	/* 30% scale error is chosen to catch completely faulty units but
-	 * to let some slight scale error pass. Requires a rate table or correlation
-	 * with mag rotations + data fit to
-	 * calibrate properly and is not done by default.
-	 */
-	const float max_scale = 0.3f;
-
-	/* evaluate gyro offsets, complain if offset -> zero or larger than 30 dps. */
-	if (fabsf(_gyro_scale.x_offset) > max_offset) {
-		return 1;
-	}
-
-	/* evaluate gyro scale, complain if off by more than 30% */
-	if (fabsf(_gyro_scale.x_scale - 1.0f) > max_scale) {
-		return 1;
-	}
-
-	if (fabsf(_gyro_scale.y_offset) > max_offset) {
-		return 1;
-	}
-
-	if (fabsf(_gyro_scale.y_scale - 1.0f) > max_scale) {
-		return 1;
-	}
-
-	if (fabsf(_gyro_scale.z_offset) > max_offset) {
-		return 1;
-	}
-
-	if (fabsf(_gyro_scale.z_scale - 1.0f) > max_scale) {
-		return 1;
-	}
-
-	/* check if all scales are zero */
-	if ((fabsf(_gyro_scale.x_offset) < 0.000001f) &&
-	    (fabsf(_gyro_scale.y_offset) < 0.000001f) &&
-	    (fabsf(_gyro_scale.z_offset) < 0.000001f)) {
-		/* if all are zero, this device is not calibrated */
-		return 1;
-	}
-
-	return 0;
-}
-
 /*
   deliberately trigger an error in the sensor to trigger recovery
  */
@@ -478,9 +423,6 @@ BMI055_gyro::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case GYROIOCGRANGE:
 		return (unsigned long)(_gyro_range_rad_s * 180.0f / M_PI_F + 0.5f);
-
-	case GYROIOCSELFTEST:
-		return gyro_self_test();
 
 	default:
 		/* give it to the superclass */

--- a/src/drivers/imu/bmi055/BMI055_gyro.hpp
+++ b/src/drivers/imu/bmi055/BMI055_gyro.hpp
@@ -268,13 +268,6 @@ private:
 	 */
 	int             self_test();
 
-	/**
-	 * Gyro self test
-	 *
-	 * @return 0 on success, 1 on failure
-	 */
-	int             gyro_self_test();
-
 	/*
 	 * set gyro sample rate
 	 */

--- a/src/drivers/imu/bmi160/bmi160.cpp
+++ b/src/drivers/imu/bmi160/bmi160.cpp
@@ -492,63 +492,6 @@ BMI160::self_test()
 	return (perf_event_count(_sample_perf) > 0) ? 0 : 1;
 }
 
-int
-BMI160::accel_self_test()
-{
-	if (self_test()) {
-		return 1;
-	}
-
-	return 0;
-}
-
-int
-BMI160::gyro_self_test()
-{
-	if (self_test()) {
-		return 1;
-	}
-
-	/*
-	 * Maximum deviation of 10 degrees
-	 */
-	const float max_offset = (float)(10 * M_PI_F / 180.0f);
-	/* 30% scale error is chosen to catch completely faulty units but
-	 * to let some slight scale error pass. Requires a rate table or correlation
-	 * with mag rotations + data fit to
-	 * calibrate properly and is not done by default.
-	 */
-	const float max_scale = 0.3f;
-
-	/* evaluate gyro offsets, complain if offset -> zero or larger than 30 dps. */
-	if (fabsf(_gyro_scale.x_offset) > max_offset) {
-		return 1;
-	}
-
-	/* evaluate gyro scale, complain if off by more than 30% */
-	if (fabsf(_gyro_scale.x_scale - 1.0f) > max_scale) {
-		return 1;
-	}
-
-	if (fabsf(_gyro_scale.y_offset) > max_offset) {
-		return 1;
-	}
-
-	if (fabsf(_gyro_scale.y_scale - 1.0f) > max_scale) {
-		return 1;
-	}
-
-	if (fabsf(_gyro_scale.z_offset) > max_offset) {
-		return 1;
-	}
-
-	if (fabsf(_gyro_scale.z_scale - 1.0f) > max_scale) {
-		return 1;
-	}
-
-	return 0;
-}
-
 /*
   deliberately trigger an error in the sensor to trigger recovery
  */
@@ -742,9 +685,6 @@ BMI160::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCGRANGE:
 		return (unsigned long)((_accel_range_m_s2) / CONSTANTS_ONE_G + 0.5f);
 
-	case ACCELIOCSELFTEST:
-		return accel_self_test();
-
 	default:
 		/* give it to the superclass */
 		return SPI::ioctl(filp, cmd, arg);
@@ -801,9 +741,6 @@ BMI160::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case GYROIOCGRANGE:
 		return (unsigned long)(_gyro_range_rad_s * 180.0f / M_PI_F + 0.5f);
-
-	case GYROIOCSELFTEST:
-		return gyro_self_test();
 
 	default:
 		/* give it to the superclass */

--- a/src/drivers/imu/bmi160/bmi160.hpp
+++ b/src/drivers/imu/bmi160/bmi160.hpp
@@ -430,20 +430,6 @@ private:
 	 */
 	int 			self_test();
 
-	/**
-	 * Accel self test
-	 *
-	 * @return 0 on success, 1 on failure
-	 */
-	int 			accel_self_test();
-
-	/**
-	 * Gyro self test
-	 *
-	 * @return 0 on success, 1 on failure
-	 */
-	int 			gyro_self_test();
-
 	/*
 	  set low pass filter frequency
 	 */

--- a/src/drivers/imu/fxas21002c/fxas21002c.cpp
+++ b/src/drivers/imu/fxas21002c/fxas21002c.cpp
@@ -736,9 +736,6 @@ FXAS21002C::ioctl(struct file *filp, int cmd, unsigned long arg)
 		/* convert to dps and round */
 		return (unsigned long)(_gyro_range_rad_s * 180.0f / M_PI_F + 0.5f);
 
-	case GYROIOCSELFTEST:
-		return self_test();
-
 	default:
 		/* give it to the superclass */
 		return SPI::ioctl(filp, cmd, arg);
@@ -748,14 +745,12 @@ FXAS21002C::ioctl(struct file *filp, int cmd, unsigned long arg)
 int
 FXAS21002C::self_test()
 {
-
 	if (_read == 0) {
 		return 1;
 	}
 
 	return 0;
 }
-
 
 uint8_t
 FXAS21002C::read_reg(unsigned reg)

--- a/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
+++ b/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
@@ -307,13 +307,6 @@ private:
 	void			mag_measure();
 
 	/**
-	 * Accel self test
-	 *
-	 * @return 0 on success, 1 on failure
-	 */
-	int			accel_self_test();
-
-	/**
 	 * Read a register from the FXOS8701C
 	 *
 	 * @param		The register to read.
@@ -877,9 +870,6 @@ FXOS8701CQ::ioctl(struct file *filp, int cmd, unsigned long arg)
 		memcpy((struct accel_calibration_s *) arg, &_accel_scale, sizeof(_accel_scale));
 		return OK;
 
-	case ACCELIOCSELFTEST:
-		return accel_self_test();
-
 	default:
 		/* give it to the superclass */
 		return SPI::ioctl(filp, cmd, arg);
@@ -985,12 +975,6 @@ FXOS8701CQ::mag_ioctl(struct file *filp, int cmd, unsigned long arg)
 		memcpy((struct mag_calibration_s *) arg, &_mag_scale, sizeof(_mag_scale));
 		return OK;
 
-	case MAGIOCSRANGE:
-		return mag_set_range(arg);
-
-	case MAGIOCGRANGE:
-		return _mag_range_ga;
-
 	case MAGIOCGEXTERNAL:
 		/* Even if this sensor is on the "external" SPI bus
 		 * it is still fixed to the autopilot assembly,
@@ -1002,25 +986,6 @@ FXOS8701CQ::mag_ioctl(struct file *filp, int cmd, unsigned long arg)
 		/* give it to the superclass */
 		return SPI::ioctl(filp, cmd, arg);
 	}
-}
-
-int
-FXOS8701CQ::accel_self_test()
-{
-	/*todo:Implement
-	 * set to 2 Jmode Save current samples
-	 *  Light bit and look for the offsets.
-	 * ±2 g mode, X-axis 	+192
-	 * ±2 g mode, Y-axis 	+270
-	 * ±2 g mode, Z-axis 	+1275
-	*/
-
-
-	if (_accel_read == 0) {
-		return 1;
-	}
-
-	return 0;
 }
 
 uint8_t

--- a/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
+++ b/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
@@ -314,13 +314,6 @@ private:
 	int			accel_self_test();
 
 	/**
-	 * Mag self test
-	 *
-	 * @return 0 on success, 1 on failure
-	 */
-	int			mag_self_test();
-
-	/**
 	 * Read a register from the FXOS8701C
 	 *
 	 * @param		The register to read.
@@ -998,9 +991,6 @@ FXOS8701CQ::mag_ioctl(struct file *filp, int cmd, unsigned long arg)
 	case MAGIOCGRANGE:
 		return _mag_range_ga;
 
-	case MAGIOCSELFTEST:
-		return mag_self_test();
-
 	case MAGIOCGEXTERNAL:
 		/* Even if this sensor is on the "external" SPI bus
 		 * it is still fixed to the autopilot assembly,
@@ -1027,32 +1017,6 @@ FXOS8701CQ::accel_self_test()
 
 
 	if (_accel_read == 0) {
-		return 1;
-	}
-
-	return 0;
-}
-
-int
-FXOS8701CQ::mag_self_test()
-{
-	if (_mag_read == 0) {
-		return 1;
-	}
-
-	/**
-	 * inspect mag offsets
-	 * don't check mag scale because it seems this is calibrated on chip
-	 */
-	if (fabsf(_mag_scale.x_offset) < 0.000001f) {
-		return 1;
-	}
-
-	if (fabsf(_mag_scale.y_offset) < 0.000001f) {
-		return 1;
-	}
-
-	if (fabsf(_mag_scale.z_offset) < 0.000001f) {
 		return 1;
 	}
 

--- a/src/drivers/imu/l3gd20/l3gd20.cpp
+++ b/src/drivers/imu/l3gd20/l3gd20.cpp
@@ -685,9 +685,6 @@ L3GD20::ioctl(struct file *filp, int cmd, unsigned long arg)
 		/* convert to dps and round */
 		return (unsigned long)(_gyro_range_rad_s * 180.0f / M_PI_F + 0.5f);
 
-	case GYROIOCSELFTEST:
-		return self_test();
-
 	default:
 		/* give it to the superclass */
 		return SPI::ioctl(filp, cmd, arg);

--- a/src/drivers/imu/lsm303d/lsm303d.cpp
+++ b/src/drivers/imu/lsm303d/lsm303d.cpp
@@ -372,13 +372,6 @@ private:
 	void			mag_measure();
 
 	/**
-	 * Accel self test
-	 *
-	 * @return 0 on success, 1 on failure
-	 */
-	int			accel_self_test();
-
-	/**
 	 * Read a register from the LSM303D
 	 *
 	 * @param		The register to read.
@@ -945,9 +938,6 @@ LSM303D::ioctl(struct file *filp, int cmd, unsigned long arg)
 		memcpy((struct accel_calibration_s *) arg, &_accel_scale, sizeof(_accel_scale));
 		return OK;
 
-	case ACCELIOCSELFTEST:
-		return accel_self_test();
-
 	default:
 		/* give it to the superclass */
 		return SPI::ioctl(filp, cmd, arg);
@@ -1053,12 +1043,6 @@ LSM303D::mag_ioctl(struct file *filp, int cmd, unsigned long arg)
 		memcpy((struct mag_calibration_s *) arg, &_mag_scale, sizeof(_mag_scale));
 		return OK;
 
-	case MAGIOCSRANGE:
-		return mag_set_range(arg);
-
-	case MAGIOCGRANGE:
-		return _mag_range_ga;
-
 	case MAGIOCGEXTERNAL:
 		/* Even if this sensor is on the "external" SPI bus
 		 * it is still fixed to the autopilot assembly,
@@ -1070,16 +1054,6 @@ LSM303D::mag_ioctl(struct file *filp, int cmd, unsigned long arg)
 		/* give it to the superclass */
 		return SPI::ioctl(filp, cmd, arg);
 	}
-}
-
-int
-LSM303D::accel_self_test()
-{
-	if (_accel_read == 0) {
-		return 1;
-	}
-
-	return 0;
 }
 
 uint8_t

--- a/src/drivers/imu/lsm303d/lsm303d.cpp
+++ b/src/drivers/imu/lsm303d/lsm303d.cpp
@@ -379,13 +379,6 @@ private:
 	int			accel_self_test();
 
 	/**
-	 * Mag self test
-	 *
-	 * @return 0 on success, 1 on failure
-	 */
-	int			mag_self_test();
-
-	/**
 	 * Read a register from the LSM303D
 	 *
 	 * @param		The register to read.
@@ -1066,9 +1059,6 @@ LSM303D::mag_ioctl(struct file *filp, int cmd, unsigned long arg)
 	case MAGIOCGRANGE:
 		return _mag_range_ga;
 
-	case MAGIOCSELFTEST:
-		return mag_self_test();
-
 	case MAGIOCGEXTERNAL:
 		/* Even if this sensor is on the "external" SPI bus
 		 * it is still fixed to the autopilot assembly,
@@ -1086,32 +1076,6 @@ int
 LSM303D::accel_self_test()
 {
 	if (_accel_read == 0) {
-		return 1;
-	}
-
-	return 0;
-}
-
-int
-LSM303D::mag_self_test()
-{
-	if (_mag_read == 0) {
-		return 1;
-	}
-
-	/**
-	 * inspect mag offsets
-	 * don't check mag scale because it seems this is calibrated on chip
-	 */
-	if (fabsf(_mag_scale.x_offset) < 0.000001f) {
-		return 1;
-	}
-
-	if (fabsf(_mag_scale.y_offset) < 0.000001f) {
-		return 1;
-	}
-
-	if (fabsf(_mag_scale.z_offset) < 0.000001f) {
 		return 1;
 	}
 

--- a/src/drivers/imu/mpu6000/mpu6000.cpp
+++ b/src/drivers/imu/mpu6000/mpu6000.cpp
@@ -386,20 +386,6 @@ private:
 	 */
 	int 			self_test();
 
-	/**
-	 * Accel self test
-	 *
-	 * @return 0 on success, 1 on failure
-	 */
-	int				accel_self_test();
-
-	/**
-	 * Gyro self test
-	 *
-	 * @return 0 on success, 1 on failure
-	 */
-	int				gyro_self_test();
-
 	/*
 	  set low pass filter frequency
 	 */
@@ -1072,71 +1058,6 @@ MPU6000::self_test()
 	return (perf_event_count(_sample_perf) > 0) ? 0 : 1;
 }
 
-int
-MPU6000::accel_self_test()
-{
-	if (self_test()) {
-		return 1;
-	}
-
-	return 0;
-}
-
-int
-MPU6000::gyro_self_test()
-{
-	if (self_test()) {
-		return 1;
-	}
-
-	/*
-	 * Maximum deviation of 20 degrees, according to
-	 * http://www.farnell.com/datasheets/1788002.pdf
-	 * Section 6.1, initial ZRO tolerance
-	 *
-	 * 20 dps (0.34 rad/s) initial offset
-	 * and 20 dps temperature drift, so 0.34 rad/s * 2
-	 */
-	const float max_offset = 2.0f * 0.34f;
-
-	/* 30% scale error is chosen to catch completely faulty units but
-	 * to let some slight scale error pass. Requires a rate table or correlation
-	 * with mag rotations + data fit to
-	 * calibrate properly and is not done by default.
-	 */
-	const float max_scale = 0.3f;
-
-	/* evaluate gyro offsets, complain if offset -> zero or larger than 20 dps. */
-	if (fabsf(_gyro_scale.x_offset) > max_offset) {
-		return 1;
-	}
-
-	/* evaluate gyro scale, complain if off by more than 30% */
-	if (fabsf(_gyro_scale.x_scale - 1.0f) > max_scale) {
-		return 1;
-	}
-
-	if (fabsf(_gyro_scale.y_offset) > max_offset) {
-		return 1;
-	}
-
-	if (fabsf(_gyro_scale.y_scale - 1.0f) > max_scale) {
-		return 1;
-	}
-
-	if (fabsf(_gyro_scale.z_offset) > max_offset) {
-		return 1;
-	}
-
-	if (fabsf(_gyro_scale.z_scale - 1.0f) > max_scale) {
-		return 1;
-	}
-
-	return 0;
-}
-
-
-
 /*
   perform a self-test comparison to factory trim values. This takes
   about 200ms and will return OK if the current values are within 14%
@@ -1485,9 +1406,6 @@ MPU6000::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCGRANGE:
 		return (unsigned long)((_accel_range_m_s2) / CONSTANTS_ONE_G + 0.5f);
 
-	case ACCELIOCSELFTEST:
-		return accel_self_test();
-
 	case ACCELIOCGEXTERNAL:
 		return _interface->ioctl(cmd, dummy);
 
@@ -1552,9 +1470,6 @@ MPU6000::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case GYROIOCGRANGE:
 		return (unsigned long)(_gyro_range_rad_s * 180.0f / M_PI_F + 0.5f);
-
-	case GYROIOCSELFTEST:
-		return gyro_self_test();
 
 	default:
 		/* give it to the superclass */

--- a/src/drivers/imu/mpu9250/mag.cpp
+++ b/src/drivers/imu/mpu9250/mag.cpp
@@ -384,18 +384,6 @@ MPU9250_mag::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case MAGIOCGRANGE:
 		return 48; // fixed full scale measurement range of +/- 4800 uT == 48 Gauss
 
-#ifdef MAGIOCSHWLOWPASS
-
-	case MAGIOCSHWLOWPASS:
-		return -EINVAL;
-#endif
-
-#ifdef MAGIOCGHWLOWPASS
-
-	case MAGIOCGHWLOWPASS:
-		return -EINVAL;
-#endif
-
 	default:
 		return (int)CDev::ioctl(filp, cmd, arg);
 	}

--- a/src/drivers/imu/mpu9250/mag.cpp
+++ b/src/drivers/imu/mpu9250/mag.cpp
@@ -378,12 +378,6 @@ MPU9250_mag::ioctl(struct file *filp, int cmd, unsigned long arg)
 		memcpy((struct mag_scale *) arg, &_mag_scale, sizeof(_mag_scale));
 		return OK;
 
-	case MAGIOCSRANGE:
-		return -EINVAL;
-
-	case MAGIOCGRANGE:
-		return 48; // fixed full scale measurement range of +/- 4800 uT == 48 Gauss
-
 	default:
 		return (int)CDev::ioctl(filp, cmd, arg);
 	}

--- a/src/drivers/imu/mpu9250/mag.cpp
+++ b/src/drivers/imu/mpu9250/mag.cpp
@@ -384,9 +384,6 @@ MPU9250_mag::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case MAGIOCGRANGE:
 		return 48; // fixed full scale measurement range of +/- 4800 uT == 48 Gauss
 
-	case MAGIOCSELFTEST:
-		return self_test();
-
 #ifdef MAGIOCSHWLOWPASS
 
 	case MAGIOCSHWLOWPASS:
@@ -402,12 +399,6 @@ MPU9250_mag::ioctl(struct file *filp, int cmd, unsigned long arg)
 	default:
 		return (int)CDev::ioctl(filp, cmd, arg);
 	}
-}
-
-int
-MPU9250_mag::self_test(void)
-{
-	return 0;
 }
 
 void

--- a/src/drivers/imu/mpu9250/mpu9250.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250.cpp
@@ -674,65 +674,6 @@ MPU9250::self_test()
 	return (perf_event_count(_sample_perf) > 0) ? 0 : 1;
 }
 
-int
-MPU9250::accel_self_test()
-{
-	if (self_test()) {
-		return 1;
-	}
-
-	return 0;
-}
-
-int
-MPU9250::gyro_self_test()
-{
-	if (self_test()) {
-		return 1;
-	}
-
-	/*
-	 * Maximum deviation of 20 degrees, according to
-	 * http://www.invensense.com/mems/gyro/documents/PS-MPU-9250A-00v3.4.pdf
-	 * Section 6.1, initial ZRO tolerance
-	 */
-	const float max_offset = 0.34f;
-	/* 30% scale error is chosen to catch completely faulty units but
-	 * to let some slight scale error pass. Requires a rate table or correlation
-	 * with mag rotations + data fit to
-	 * calibrate properly and is not done by default.
-	 */
-	const float max_scale = 0.3f;
-
-	/* evaluate gyro offsets, complain if offset -> zero or larger than 20 dps. */
-	if (fabsf(_gyro_scale.x_offset) > max_offset) {
-		return 1;
-	}
-
-	/* evaluate gyro scale, complain if off by more than 30% */
-	if (fabsf(_gyro_scale.x_scale - 1.0f) > max_scale) {
-		return 1;
-	}
-
-	if (fabsf(_gyro_scale.y_offset) > max_offset) {
-		return 1;
-	}
-
-	if (fabsf(_gyro_scale.y_scale - 1.0f) > max_scale) {
-		return 1;
-	}
-
-	if (fabsf(_gyro_scale.z_offset) > max_offset) {
-		return 1;
-	}
-
-	if (fabsf(_gyro_scale.z_scale - 1.0f) > max_scale) {
-		return 1;
-	}
-
-	return 0;
-}
-
 /*
   deliberately trigger an error in the sensor to trigger recovery
  */
@@ -925,9 +866,6 @@ MPU9250::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case ACCELIOCGRANGE:
 		return (unsigned long)((_accel_range_m_s2) / CONSTANTS_ONE_G + 0.5f);
 
-	case ACCELIOCSELFTEST:
-		return accel_self_test();
-
 	default:
 		/* give it to the superclass */
 		return CDev::ioctl(filp, cmd, arg);
@@ -989,9 +927,6 @@ MPU9250::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case GYROIOCGRANGE:
 		return (unsigned long)(_gyro_range_rad_s * 180.0f / M_PI_F + 0.5f);
-
-	case GYROIOCSELFTEST:
-		return gyro_self_test();
 
 	default:
 		/* give it to the superclass */

--- a/src/drivers/imu/mpu9250/mpu9250.h
+++ b/src/drivers/imu/mpu9250/mpu9250.h
@@ -503,20 +503,6 @@ private:
 	 */
 	int 			self_test();
 
-	/**
-	 * Accel self test
-	 *
-	 * @return 0 on success, 1 on failure
-	 */
-	int 			accel_self_test();
-
-	/**
-	 * Gyro self test
-	 *
-	 * @return 0 on success, 1 on failure
-	 */
-	int 			gyro_self_test();
-
 	/*
 	  set low pass filter frequency
 	 */

--- a/src/drivers/magnetometer/bmm150/bmm150.cpp
+++ b/src/drivers/magnetometer/bmm150/bmm150.cpp
@@ -816,12 +816,6 @@ BMM150::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case MAGIOCGSAMPLERATE:
 		return 1000000 / _call_interval;
 
-	case MAGIOCSRANGE:
-		return OK;
-
-	case MAGIOCGRANGE:
-		return OK;
-
 	default:
 		/* give it to the superclass */
 		return I2C::ioctl(filp, cmd, arg);

--- a/src/drivers/magnetometer/bmm150/bmm150.cpp
+++ b/src/drivers/magnetometer/bmm150/bmm150.cpp
@@ -810,9 +810,6 @@ BMM150::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case MAGIOCEXSTRAP:
 		return OK;
 
-	case MAGIOCSELFTEST:
-		return OK;
-
 	case MAGIOCSSAMPLERATE:
 		return ioctl(filp, SENSORIOCSPOLLRATE, arg);
 

--- a/src/drivers/magnetometer/hmc5883/hmc5883.cpp
+++ b/src/drivers/magnetometer/hmc5883/hmc5883.cpp
@@ -311,13 +311,6 @@ private:
 	float			meas_to_float(uint8_t in[2]);
 
 	/**
-	 * Check the current calibration and update device status
-	 *
-	 * @return 0 if calibration is ok, 1 else
-	 */
-	int 			check_calibration();
-
-	/**
 	* Check the current scale calibration
 	*
 	* @return 0 if scale calibration is ok, 1 else
@@ -724,8 +717,6 @@ HMC5883::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case MAGIOCSSCALE:
 		/* set new scale factors */
 		memcpy(&_scale, (struct mag_calibration_s *)arg, sizeof(_scale));
-		/* check calibration, but not actually return an error */
-		(void)check_calibration();
 		return 0;
 
 	case MAGIOCGSCALE:
@@ -738,9 +729,6 @@ HMC5883::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case MAGIOCEXSTRAP:
 		return set_excitement(arg);
-
-	case MAGIOCSELFTEST:
-		return check_calibration();
 
 	case MAGIOCGEXTERNAL:
 		DEVICE_DEBUG("MAGIOCGEXTERNAL in main driver");
@@ -1269,19 +1257,6 @@ int HMC5883::check_offset()
 
 	/* return 0 if calibrated, 1 else */
 	return !offset_valid;
-}
-
-int HMC5883::check_calibration()
-{
-	bool offset_valid = (check_offset() == OK);
-	bool scale_valid  = (check_scale() == OK);
-
-	if (_calibrated != (offset_valid && scale_valid)) {
-		_calibrated = (offset_valid && scale_valid);
-	}
-
-	/* return 0 if calibrated, 1 else */
-	return (!_calibrated);
 }
 
 int HMC5883::set_excitement(unsigned enable)

--- a/src/drivers/magnetometer/ist8310/ist8310.cpp
+++ b/src/drivers/magnetometer/ist8310/ist8310.cpp
@@ -688,12 +688,6 @@ IST8310::ioctl(struct file *filp, int cmd, unsigned long arg)
 		/* same as pollrate because device is in single measurement mode*/
 		return 1000000 / TICK2USEC(_measure_ticks);
 
-	case MAGIOCSRANGE:
-		return OK;
-
-	case MAGIOCGRANGE:
-		return 0;
-
 	case MAGIOCEXSTRAP:
 		return set_selftest(arg);
 

--- a/src/drivers/magnetometer/ist8310/ist8310.cpp
+++ b/src/drivers/magnetometer/ist8310/ist8310.cpp
@@ -358,13 +358,6 @@ private:
 	float       meas_to_float(uint8_t in[2]);
 
 	/**
-	 * Check the current calibration and update device status
-	 *
-	 * @return 0 if calibration is ok, 1 else
-	 */
-	int         check_calibration();
-
-	/**
 	* Check the current scale calibration
 	*
 	* @return 0 if scale calibration is ok, 1 else
@@ -707,8 +700,6 @@ IST8310::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case MAGIOCSSCALE:
 		/* set new scale factors */
 		memcpy(&_scale, (struct mag_calibration_s *)arg, sizeof(_scale));
-		/* check calibration, but not actually return an error */
-		(void)check_calibration();
 		return 0;
 
 	case MAGIOCGSCALE:
@@ -719,11 +710,7 @@ IST8310::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case MAGIOCCALIBRATE:
 		return calibrate(filp, arg);
 
-	case MAGIOCSELFTEST:
-		return check_calibration();
-
 	case MAGIOCGEXTERNAL:
-		DEVICE_DEBUG("MAGIOCGEXTERNAL in main driver");
 		return external();
 
 	default:
@@ -1146,25 +1133,6 @@ int IST8310::check_offset()
 
 	/* return 0 if calibrated, 1 else */
 	return !offset_valid;
-}
-
-int IST8310::check_calibration()
-{
-	bool offset_valid = (check_offset() == OK);
-	bool scale_valid  = (check_scale() == OK);
-
-	if (_calibrated != (offset_valid && scale_valid)) {
-
-		if (!scale_valid || !offset_valid) {
-			PX4_WARN("mag cal status changed %s%s", (scale_valid) ? "" : "scale invalid ",
-				 (offset_valid) ? "" : "offset invalid");
-		}
-
-		_calibrated = (offset_valid && scale_valid);
-	}
-
-	/* return 0 if calibrated, 1 else */
-	return (!_calibrated);
 }
 
 int

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl.cpp
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl.cpp
@@ -287,22 +287,6 @@ out:
 }
 
 int
-LIS3MDL::check_calibration()
-{
-	bool offset_valid = (check_offset() == OK);
-	bool scale_valid  = (check_scale() == OK);
-
-	if (_calibrated != (offset_valid && scale_valid)) {
-		PX4_WARN("mag cal status changed %s%s", (scale_valid) ? "" : "scale invalid ",
-			 (offset_valid) ? "" : "offset invalid");
-		_calibrated = (offset_valid && scale_valid);
-	}
-
-	/* return 0 if calibrated, 1 else */
-	return !_calibrated;
-}
-
-int
 LIS3MDL::check_offset()
 {
 	bool offset_valid;
@@ -613,8 +597,6 @@ LIS3MDL::ioctl(struct file *file_pointer, int cmd, unsigned long arg)
 	case MAGIOCSSCALE:
 		/* set new scale factors */
 		memcpy(&_scale, (struct mag_calibration_s *)arg, sizeof(_scale));
-		/* check calibration, but not actually return an error */
-		(void)check_calibration();
 		return 0;
 
 	case MAGIOCGSCALE:
@@ -622,16 +604,11 @@ LIS3MDL::ioctl(struct file *file_pointer, int cmd, unsigned long arg)
 		memcpy((struct mag_calibration_s *)arg, &_scale, sizeof(_scale));
 		return 0;
 
-
 	case MAGIOCCALIBRATE:
 		return calibrate(file_pointer, arg);
 
 	case MAGIOCEXSTRAP:
 		return set_excitement(arg);
-
-	case MAGIOCSELFTEST:
-		return check_calibration();
-
 
 	case MAGIOCGEXTERNAL:
 		DEVICE_DEBUG("MAGIOCGEXTERNAL in main driver");

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl.h
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl.h
@@ -200,13 +200,6 @@ private:
 	int collect();
 
 	/**
-	 * Check the current calibration and update device status
-	 *
-	 * @return 0 if calibration is ok, 1 else
-	 */
-	int check_calibration();
-
-	/**
 	* Check the current scale calibration
 	*
 	* @return 0 if scale calibration is ok, 1 else

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl_main.cpp
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl_main.cpp
@@ -99,14 +99,6 @@ lis3mdl::init(LIS3MDL_BUS bus_id)
 		PX4_INFO("Poll rate set to max (80hz)");
 	}
 
-	/* Set to 4 Gauss */
-	if (ioctl(fd, MAGIOCSRANGE, 4) != OK) {
-		PX4_WARN("FAILED: MAGIOCSRANGE 4 Gauss");
-
-	} else {
-		PX4_INFO("Set mag range to 4 Gauss");
-	}
-
 	close(fd);
 
 	return true;

--- a/src/drivers/magnetometer/lsm303agr/LSM303AGR.cpp
+++ b/src/drivers/magnetometer/lsm303agr/LSM303AGR.cpp
@@ -331,7 +331,6 @@ LSM303AGR::ioctl(struct file *filp, int cmd, unsigned long arg)
 		return 0;
 
 	case MAGIOCGEXTERNAL:
-		DEVICE_DEBUG("MAGIOCGEXTERNAL in main driver");
 		return external();
 
 	default:

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -142,17 +142,6 @@ static bool magnometerCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &sta
 		goto out;
 	}
 
-	ret = h.ioctl(MAGIOCSELFTEST, 0);
-
-	if (ret != OK) {
-		if (report_fail) {
-			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: MAG #%u SELFTEST FAILED", instance);
-		}
-
-		success = false;
-		goto out;
-	}
-
 out:
 	if (instance==0) set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_MAG, present, !optional, success, status);
 	if (instance==1) set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_MAG2, present, !optional, success, status);
@@ -281,17 +270,6 @@ static bool accelerometerCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &
 		goto out;
 	}
 
-	ret = h.ioctl(ACCELIOCSELFTEST, 0);
-
-	if (ret != OK) {
-		if (report_fail) {
-			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: ACCEL #%u TEST FAILED: %d", instance, ret);
-		}
-
-		success = false;
-		goto out;
-	}
-
 #ifdef __PX4_NUTTX
 
 	if (dynamic) {
@@ -361,17 +339,6 @@ static bool gyroCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status, u
 	if (ret) {
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: GYRO #%u UNCALIBRATED", instance);
-		}
-
-		success = false;
-		goto out;
-	}
-
-	ret = h.ioctl(GYROIOCSELFTEST, 0);
-
-	if (ret != OK) {
-		if (report_fail) {
-			mavlink_log_critical(mavlink_log_pub, "PREFLIGHT FAIL: GYRO #%u SELFTEST FAILED", instance);
 		}
 
 		success = false;

--- a/src/modules/simulator/accelsim/accelsim.cpp
+++ b/src/modules/simulator/accelsim/accelsim.cpp
@@ -717,9 +717,6 @@ ACCELSIM::mag_ioctl(unsigned long cmd, unsigned long arg)
 		 */
 		return 0;
 
-	case MAGIOCSELFTEST:
-		return OK;
-
 	default:
 		/* give it to the superclass */
 		return VirtDevObj::devIOCTL(cmd, arg);

--- a/src/modules/simulator/accelsim/accelsim.cpp
+++ b/src/modules/simulator/accelsim/accelsim.cpp
@@ -601,9 +601,6 @@ ACCELSIM::devIOCTL(unsigned long cmd, unsigned long arg)
 		memcpy((struct accel_calibration_s *) arg, &(_accel_scale), sizeof(_accel_scale));
 		return OK;
 
-	case ACCELIOCSELFTEST:
-		return OK;
-
 	default:
 		/* give it to the superclass */
 		return VirtDevObj::devIOCTL(cmd, arg);

--- a/src/modules/uavcan/sensors/mag.cpp
+++ b/src/modules/uavcan/sensors/mag.cpp
@@ -114,10 +114,6 @@ int UavcanMagnetometerBridge::ioctl(struct file *filp, int cmd, unsigned long ar
 			return 0;
 		}
 
-	case MAGIOCSELFTEST: {
-			return 0;           // Nothing to do
-		}
-
 	case MAGIOCGEXTERNAL: {
 			return 1;           // declare it external rise it's priority and to allow for correct orientation compensation
 		}

--- a/src/systemcmds/config/config.c
+++ b/src/systemcmds/config/config.c
@@ -208,27 +208,6 @@ do_gyro(int argc, char *argv[])
 				return 1;
 			}
 
-		} else if (argc == 2 && !strcmp(argv[0], "check")) {
-			ret = ioctl(fd, GYROIOCSELFTEST, 0);
-
-			if (ret) {
-				PX4_WARN("gyro self test FAILED! Check calibration:");
-				struct gyro_calibration_s scale;
-				ret = ioctl(fd, GYROIOCGSCALE, (long unsigned int)&scale);
-
-				if (ret) {
-					PX4_ERR("failed getting gyro scale");
-					return 1;
-				}
-
-				PX4_INFO("offsets: X: % 9.6f Y: % 9.6f Z: % 9.6f", (double)scale.x_offset, (double)scale.y_offset,
-					 (double)scale.z_offset);
-				PX4_INFO("scale:   X: % 9.6f Y: % 9.6f Z: % 9.6f", (double)scale.x_scale, (double)scale.y_scale, (double)scale.z_scale);
-
-			} else {
-				PX4_INFO("gyro calibration and self test OK");
-			}
-
 		} else {
 			print_usage();
 			return 1;
@@ -361,27 +340,6 @@ do_accel(int argc, char *argv[])
 			if (ret) {
 				PX4_ERR("range could not be set");
 				return 1;
-			}
-
-		} else if (argc == 2 && !strcmp(argv[0], "check")) {
-			ret = ioctl(fd, ACCELIOCSELFTEST, 0);
-
-			if (ret) {
-				PX4_WARN("accel self test FAILED! Check calibration:");
-				struct accel_calibration_s scale;
-				ret = ioctl(fd, ACCELIOCGSCALE, (long unsigned int)&scale);
-
-				if (ret) {
-					PX4_ERR("failed getting accel scale");
-					return 1;
-				}
-
-				PX4_INFO("offsets: X: % 9.6f Y: % 9.6f Z: % 9.6f", (double)scale.x_offset, (double)scale.y_offset,
-					 (double)scale.z_offset);
-				PX4_INFO("scale:   X: % 9.6f Y: % 9.6f Z: % 9.6f", (double)scale.x_scale, (double)scale.y_scale, (double)scale.z_scale);
-
-			} else {
-				PX4_INFO("accel calibration and self test OK");
 			}
 
 		} else {

--- a/src/systemcmds/config/config.c
+++ b/src/systemcmds/config/config.c
@@ -296,27 +296,6 @@ do_mag(int argc, char *argv[])
 				return 1;
 			}
 
-		} else if (argc == 2 && !strcmp(argv[0], "check")) {
-			ret = ioctl(fd, MAGIOCSELFTEST, 0);
-
-			if (ret) {
-				PX4_WARN("mag self test FAILED! Check calibration:");
-				struct mag_calibration_s scale;
-				ret = ioctl(fd, MAGIOCGSCALE, (long unsigned int)&scale);
-
-				if (ret) {
-					PX4_ERR("failed getting mag scale");
-					return 1;
-				}
-
-				PX4_INFO("offsets: X: % 9.6f Y: % 9.6f Z: % 9.6f", (double)scale.x_offset, (double)scale.y_offset,
-					 (double)scale.z_offset);
-				PX4_INFO("scale:   X: % 9.6f Y: % 9.6f Z: % 9.6f", (double)scale.x_scale, (double)scale.y_scale, (double)scale.z_scale);
-
-			} else {
-				PX4_INFO("mag calibration and self test OK");
-			}
-
 		} else {
 			print_usage();
 			return 1;


### PR DESCRIPTION
These checks are pretty worthless and implemented inconsistently (or not at all) in the drivers.