### PR TITLE
ICM20948 integration into MPU9250 driver

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -100,6 +100,9 @@ then
 	teraranger start -a
 fi
 
+# ICM20948 as external magnetometer on I2C (e.g. Here GPS)
+mpu9250 -X -R 6 start
+
 ###############################################################################
 #                            End Optional drivers                             #
 ###############################################################################

--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -101,7 +101,7 @@ then
 fi
 
 # ICM20948 as external magnetometer on I2C (e.g. Here GPS)
-mpu9250 -X -R 6 start
+mpu9250 -X -M -R 6 start
 
 ###############################################################################
 #                            End Optional drivers                             #

--- a/src/drivers/imu/mpu9250/CMakeLists.txt
+++ b/src/drivers/imu/mpu9250/CMakeLists.txt
@@ -40,7 +40,7 @@ px4_add_module(
 		mpu9250_i2c.cpp
 		mpu9250_spi.cpp
 		main.cpp
-        accel.cpp
+		accel.cpp
 		gyro.cpp
 		mag.cpp
 		mag_i2c.cpp

--- a/src/drivers/imu/mpu9250/CMakeLists.txt
+++ b/src/drivers/imu/mpu9250/CMakeLists.txt
@@ -40,6 +40,7 @@ px4_add_module(
 		mpu9250_i2c.cpp
 		mpu9250_spi.cpp
 		main.cpp
+        accel.cpp
 		gyro.cpp
 		mag.cpp
 		mag_i2c.cpp

--- a/src/drivers/imu/mpu9250/accel.cpp
+++ b/src/drivers/imu/mpu9250/accel.cpp
@@ -1,0 +1,131 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file gyro.cpp
+ *
+ * Driver for the Invensense mpu9250 connected via SPI.
+ *
+ * @author Andrew Tridgell
+ *
+ * based on the mpu6000 driver
+ */
+
+#include <px4_config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdio.h>
+
+#include <perf/perf_counter.h>
+
+#include <board_config.h>
+#include <drivers/drv_hrt.h>
+
+#include <drivers/device/spi.h>
+#include <drivers/device/ringbuffer.h>
+#include <drivers/device/integrator.h>
+#include <drivers/drv_accel.h>
+#include <drivers/drv_gyro.h>
+#include <drivers/drv_mag.h>
+#include <mathlib/math/filter/LowPassFilter2p.hpp>
+#include <lib/conversion/rotation.h>
+
+#include "mag.h"
+#include "gyro.h"
+#include "mpu9250.h"
+
+MPU9250_accel::MPU9250_accel(MPU9250 *parent, const char *path) :
+	CDev("MPU9250_accel", path),
+	_parent(parent),
+	_accel_topic(nullptr),
+	_accel_orb_class_instance(-1),
+	_accel_class_instance(-1)
+{
+}
+
+MPU9250_accel::~MPU9250_accel()
+{
+	if (_accel_class_instance != -1) {
+		unregister_class_devname(ACCEL_BASE_DEVICE_PATH, _accel_class_instance);
+	}
+}
+
+int
+MPU9250_accel::init()
+{
+	int ret;
+
+	// do base class init
+	ret = CDev::init();
+
+	/* if probe/setup failed, bail now */
+	if (ret != OK) {
+		DEVICE_DEBUG("accel init failed");
+		return ret;
+	}
+
+	_accel_class_instance = register_class_devname(ACCEL_BASE_DEVICE_PATH);
+
+	return ret;
+}
+
+void
+MPU9250_accel::parent_poll_notify()
+{
+	poll_notify(POLLIN);
+}
+
+ssize_t
+MPU9250_accel::read(struct file *filp, char *buffer, size_t buflen)
+{
+	return _parent->accel_read(filp, buffer, buflen);
+}
+
+int
+MPU9250_accel::ioctl(struct file *filp, int cmd, unsigned long arg)
+{
+
+	switch (cmd) {
+	case DEVIOCGDEVICEID:
+		return (int)CDev::ioctl(filp, cmd, arg);
+		break;
+
+	default:
+		return _parent->accel_ioctl(filp, cmd, arg);
+	}
+}

--- a/src/drivers/imu/mpu9250/accel.cpp
+++ b/src/drivers/imu/mpu9250/accel.cpp
@@ -72,10 +72,7 @@
 
 MPU9250_accel::MPU9250_accel(MPU9250 *parent, const char *path) :
 	CDev("MPU9250_accel", path),
-	_parent(parent),
-	_accel_topic(nullptr),
-	_accel_orb_class_instance(-1),
-	_accel_class_instance(-1)
+	_parent(parent)
 {
 }
 
@@ -89,10 +86,8 @@ MPU9250_accel::~MPU9250_accel()
 int
 MPU9250_accel::init()
 {
-	int ret;
-
 	// do base class init
-	ret = CDev::init();
+	int ret = CDev::init();
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
@@ -111,12 +106,6 @@ MPU9250_accel::parent_poll_notify()
 	poll_notify(POLLIN);
 }
 
-ssize_t
-MPU9250_accel::read(struct file *filp, char *buffer, size_t buflen)
-{
-	return _parent->accel_read(filp, buffer, buflen);
-}
-
 int
 MPU9250_accel::ioctl(struct file *filp, int cmd, unsigned long arg)
 {
@@ -126,7 +115,6 @@ MPU9250_accel::ioctl(struct file *filp, int cmd, unsigned long arg)
 	 */
 
 	switch (cmd) {
-
 	case SENSORIOCRESET: {
 			return _parent->reset();
 		}
@@ -148,18 +136,9 @@ MPU9250_accel::ioctl(struct file *filp, int cmd, unsigned long arg)
 		}
 
 	case ACCELIOCSSCALE: {
-			/* copy scale, but only if off by a few percent */
-			DEVICE_DEBUG("I'm on bus %d, type %d", _parent->_interface->get_device_bus(), _parent->_device_type);
 			struct accel_calibration_s *s = (struct accel_calibration_s *) arg;
-			float sum = s->x_scale + s->y_scale + s->z_scale;
-
-			if (sum > 2.0f && sum < 4.0f) {
-				memcpy(&_parent->_accel_scale, s, sizeof(_parent->_accel_scale));
-				return OK;
-
-			} else {
-				return -EINVAL;
-			}
+			memcpy(&_parent->_accel_scale, s, sizeof(_parent->_accel_scale));
+			return OK;
 		}
 
 	default:

--- a/src/drivers/imu/mpu9250/accel.h
+++ b/src/drivers/imu/mpu9250/accel.h
@@ -44,7 +44,6 @@ public:
 	MPU9250_accel(MPU9250 *parent, const char *path);
 	~MPU9250_accel();
 
-	virtual ssize_t		read(struct file *filp, char *buffer, size_t buflen);
 	virtual int		ioctl(struct file *filp, int cmd, unsigned long arg);
 
 	virtual int		init();
@@ -56,11 +55,9 @@ protected:
 
 private:
 	MPU9250			*_parent;
-	orb_advert_t		_accel_topic;
-	int			_accel_orb_class_instance;
-	int			_accel_class_instance;
 
-	/* do not allow to copy this class due to pointer data members */
-	MPU9250_accel(const MPU9250_accel &);
-	MPU9250_accel operator=(const MPU9250_accel &);
+	orb_advert_t		_accel_topic{nullptr};
+	int			_accel_orb_class_instance{-1};
+	int			_accel_class_instance{-1};
+
 };

--- a/src/drivers/imu/mpu9250/accel.h
+++ b/src/drivers/imu/mpu9250/accel.h
@@ -1,0 +1,66 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2012-2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+class MPU9250;
+
+/**
+ * Helper class implementing the accel driver node.
+ */
+class MPU9250_accel : public device::CDev
+{
+public:
+	MPU9250_accel(MPU9250 *parent, const char *path);
+	~MPU9250_accel();
+
+	virtual ssize_t		read(struct file *filp, char *buffer, size_t buflen);
+	virtual int		ioctl(struct file *filp, int cmd, unsigned long arg);
+
+	virtual int		init();
+
+protected:
+	friend class MPU9250;
+
+	void			parent_poll_notify();
+
+private:
+	MPU9250			*_parent;
+	orb_advert_t		_accel_topic;
+	int			_accel_orb_class_instance;
+	int			_accel_class_instance;
+
+	/* do not allow to copy this class due to pointer data members */
+	MPU9250_accel(const MPU9250_accel &);
+	MPU9250_accel operator=(const MPU9250_accel &);
+};

--- a/src/drivers/imu/mpu9250/gyro.cpp
+++ b/src/drivers/imu/mpu9250/gyro.cpp
@@ -42,27 +42,14 @@
  */
 
 #include <px4_config.h>
-
-#include <sys/types.h>
-#include <stdint.h>
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <stdio.h>
-
-#include <perf/perf_counter.h>
-
-#include <board_config.h>
-#include <drivers/drv_hrt.h>
-
+#include <lib/perf/perf_counter.h>
 #include <drivers/device/spi.h>
 #include <drivers/device/ringbuffer.h>
 #include <drivers/device/integrator.h>
 #include <drivers/drv_accel.h>
 #include <drivers/drv_gyro.h>
 #include <drivers/drv_mag.h>
-#include <mathlib/math/filter/LowPassFilter2p.hpp>
+#include <lib/mathlib/math/filter/LowPassFilter2p.hpp>
 #include <lib/conversion/rotation.h>
 
 #include "mag.h"
@@ -71,10 +58,7 @@
 
 MPU9250_gyro::MPU9250_gyro(MPU9250 *parent, const char *path) :
 	CDev("MPU9250_gyro", path),
-	_parent(parent),
-	_gyro_topic(nullptr),
-	_gyro_orb_class_instance(-1),
-	_gyro_class_instance(-1)
+	_parent(parent)
 {
 }
 
@@ -88,10 +72,8 @@ MPU9250_gyro::~MPU9250_gyro()
 int
 MPU9250_gyro::init()
 {
-	int ret;
-
 	// do base class init
-	ret = CDev::init();
+	int ret = CDev::init();
 
 	/* if probe/setup failed, bail now */
 	if (ret != OK) {
@@ -110,16 +92,9 @@ MPU9250_gyro::parent_poll_notify()
 	poll_notify(POLLIN);
 }
 
-ssize_t
-MPU9250_gyro::read(struct file *filp, char *buffer, size_t buflen)
-{
-	return _parent->gyro_read(filp, buffer, buflen);
-}
-
 int
 MPU9250_gyro::ioctl(struct file *filp, int cmd, unsigned long arg)
 {
-
 	switch (cmd) {
 
 	/* these are shared with the accel side */

--- a/src/drivers/imu/mpu9250/gyro.cpp
+++ b/src/drivers/imu/mpu9250/gyro.cpp
@@ -121,11 +121,18 @@ MPU9250_gyro::ioctl(struct file *filp, int cmd, unsigned long arg)
 {
 
 	switch (cmd) {
-	case DEVIOCGDEVICEID:
-		return (int)CDev::ioctl(filp, cmd, arg);
-		break;
+
+	/* these are shared with the accel side */
+	case SENSORIOCSPOLLRATE:
+	case SENSORIOCRESET:
+		return _parent->_accel->ioctl(filp, cmd, arg);
+
+	case GYROIOCSSCALE:
+		/* copy scale in */
+		memcpy(&_parent->_gyro_scale, (struct gyro_calibration_s *) arg, sizeof(_parent->_gyro_scale));
+		return OK;
 
 	default:
-		return _parent->gyro_ioctl(filp, cmd, arg);
+		return CDev::ioctl(filp, cmd, arg);
 	}
 }

--- a/src/drivers/imu/mpu9250/gyro.h
+++ b/src/drivers/imu/mpu9250/gyro.h
@@ -44,7 +44,6 @@ public:
 	MPU9250_gyro(MPU9250 *parent, const char *path);
 	~MPU9250_gyro();
 
-	virtual ssize_t		read(struct file *filp, char *buffer, size_t buflen);
 	virtual int		ioctl(struct file *filp, int cmd, unsigned long arg);
 
 	virtual int		init();
@@ -56,11 +55,8 @@ protected:
 
 private:
 	MPU9250			*_parent;
-	orb_advert_t		_gyro_topic;
-	int			_gyro_orb_class_instance;
-	int			_gyro_class_instance;
 
-	/* do not allow to copy this class due to pointer data members */
-	MPU9250_gyro(const MPU9250_gyro &);
-	MPU9250_gyro operator=(const MPU9250_gyro &);
+	orb_advert_t		_gyro_topic{nullptr};
+	int			_gyro_orb_class_instance{-1};
+	int			_gyro_class_instance{-1};
 };

--- a/src/drivers/imu/mpu9250/mag.cpp
+++ b/src/drivers/imu/mpu9250/mag.cpp
@@ -338,25 +338,8 @@ MPU9250_mag::ioctl(struct file *filp, int cmd, unsigned long arg)
 		return ak8963_reset();
 
 	case SENSORIOCSPOLLRATE: {
-			switch (arg) {
-
-			/* zero would be bad */
-			case 0:
-				return -EINVAL;
-
-			/* set default polling rate */
-			case SENSOR_POLLRATE_DEFAULT:
-				return ioctl(filp, SENSORIOCSPOLLRATE, MPU9250_AK8963_SAMPLE_RATE);
-
-			/* adjust to a legal polling interval in Hz */
-			default: {
-					if (MPU9250_AK8963_SAMPLE_RATE != arg) {
-						return -EINVAL;
-					}
-
-					return OK;
-				}
-			}
+			/* mag is polled through main driver only */
+			return _parent->accel_ioctl(filp, cmd, arg);
 		}
 
 	case MAGIOCSSCALE:

--- a/src/drivers/imu/mpu9250/mag.cpp
+++ b/src/drivers/imu/mpu9250/mag.cpp
@@ -346,21 +346,21 @@ MPU9250_mag::ioctl(struct file *filp, int cmd, unsigned long arg)
 	case SENSORIOCRESET:
 		return ak8963_reset();
 
-    case SENSORIOCSPOLLRATE: {
-        switch (arg) {
+	case SENSORIOCSPOLLRATE: {
+			switch (arg) {
 
-        /* zero would be bad */
-        case 0:
-            return -EINVAL;
+			/* zero would be bad */
+			case 0:
+				return -EINVAL;
 
-        case SENSOR_POLLRATE_DEFAULT:
-            return ioctl(filp, SENSORIOCSPOLLRATE, MPU9250_ACCEL_DEFAULT_RATE);
+			case SENSOR_POLLRATE_DEFAULT:
+				return ioctl(filp, SENSORIOCSPOLLRATE, MPU9250_ACCEL_DEFAULT_RATE);
 
-        /* adjust to a legal polling interval in Hz */
-        default:
-            return _parent->_set_pollrate(arg);
-        }
-    }
+			/* adjust to a legal polling interval in Hz */
+			default:
+				return _parent->_set_pollrate(arg);
+			}
+		}
 
 	case MAGIOCSSCALE:
 		/* copy scale in */

--- a/src/drivers/imu/mpu9250/mag.cpp
+++ b/src/drivers/imu/mpu9250/mag.cpp
@@ -264,6 +264,10 @@ MPU9250_mag::_measure(struct ak8963_regs data)
 	/* apply user specified rotation */
 	rotate_3f(_parent->_rotation, xraw_f, yraw_f, zraw_f);
 
+	if (_parent->_device_type == MPU_DEVICE_TYPE_ICM20948) {
+		rotate_3f(ROTATION_YAW_270, xraw_f, yraw_f, zraw_f); //offset between accel/gyro and mag on icm20948
+	}
+
 	mrb.x = ((xraw_f * _mag_range_scale * _mag_asa_x) - _mag_scale.x_offset) * _mag_scale.x_scale;
 	mrb.y = ((yraw_f * _mag_range_scale * _mag_asa_y) - _mag_scale.y_offset) * _mag_scale.y_scale;
 	mrb.z = ((zraw_f * _mag_range_scale * _mag_asa_z) - _mag_scale.z_offset) * _mag_scale.z_scale;

--- a/src/drivers/imu/mpu9250/mag.h
+++ b/src/drivers/imu/mpu9250/mag.h
@@ -139,7 +139,6 @@ public:
 	MPU9250_mag(MPU9250 *parent, device::Device *interface, const char *path);
 	~MPU9250_mag();
 
-	virtual ssize_t read(struct file *filp, char *buffer, size_t buflen);
 	virtual int ioctl(struct file *filp, int cmd, unsigned long arg);
 	virtual int init();
 
@@ -165,14 +164,10 @@ protected:
 	/* Update the state with prefetched data (internally called by the regular measure() )*/
 	void _measure(struct ak8963_regs data);
 
-
 	uint8_t read_reg(unsigned reg);
 	void write_reg(unsigned reg, uint8_t value);
 
-
 	bool is_passthrough() { return _interface == nullptr; }
-
-	int self_test(void);
 
 private:
 	MPU9250 *_parent;

--- a/src/drivers/imu/mpu9250/mag.h
+++ b/src/drivers/imu/mpu9250/mag.h
@@ -66,6 +66,38 @@
 #define AK8963_16BIT_ADC        0x10
 #define AK8963_14BIT_ADC        0x00
 #define AK8963_RESET            0x01
+#define AK8963_HOFL             0x08
+
+/* ak09916 deviating register addresses and bit definitions */
+
+#define AK09916_DEVICE_ID_A		0x48	// same as AK8963
+#define AK09916_DEVICE_ID_B		0x09	// additional ID byte ("INFO" on AK9063 without content specification.)
+
+#define AK09916REG_HXL        0x11
+#define AK09916REG_HXH        0x12
+#define AK09916REG_HYL        0x13
+#define AK09916REG_HYH        0x14
+#define AK09916REG_HZL        0x15
+#define AK09916REG_HZH        0x16
+#define AK09916REG_ST1        0x10
+#define AK09916REG_ST2        0x18
+#define AK09916REG_CNTL2          0x31
+#define AK09916REG_CNTL3          0x32
+
+
+#define AK09916_CNTL2_POWERDOWN_MODE            0x00
+#define AK09916_CNTL2_SINGLE_MODE               0x01 /* default */
+#define AK09916_CNTL2_CONTINOUS_MODE_10HZ       0x02
+#define AK09916_CNTL2_CONTINOUS_MODE_20HZ       0x04
+#define AK09916_CNTL2_CONTINOUS_MODE_50HZ       0x06
+#define AK09916_CNTL2_CONTINOUS_MODE_100HZ      0x08
+#define AK09916_CNTL2_SELFTEST_MODE             0x10
+#define AK09916_CNTL3_SRST                      0x01
+#define AK09916_ST1_DRDY                        0x01
+#define AK09916_ST1_DOR                         0x02
+
+
+#define AK_MPU_OR_ICM(m,i)					((_parent->_device_type==MPU_DEVICE_TYPE_MPU9250) ? m : i)
 
 
 
@@ -80,6 +112,18 @@ struct ak8963_regs {
 	uint8_t st2;
 };
 #pragma pack(pop)
+
+#pragma pack(push, 1)
+struct ak09916_regs {
+	uint8_t st1;
+	int16_t x;
+	int16_t y;
+	int16_t z;
+	uint8_t tmps;
+	uint8_t st2;
+};
+#pragma pack(pop)
+
 
 extern device::Device *AK8963_I2C_interface(int bus, bool external_bus);
 

--- a/src/drivers/imu/mpu9250/mag.h
+++ b/src/drivers/imu/mpu9250/mag.h
@@ -97,7 +97,7 @@
 #define AK09916_ST1_DOR                         0x02
 
 
-#define AK_MPU_OR_ICM(m,i)					((_parent->_device_type==MPU_DEVICE_TYPE_MPU9250) ? m : i)
+#define AK_MPU_OR_ICM(m,i)					((_parent->_device_type==MPU_DEVICE_TYPE_MPU9250) ? (m) : (i))
 
 
 

--- a/src/drivers/imu/mpu9250/mag_i2c.cpp
+++ b/src/drivers/imu/mpu9250/mag_i2c.cpp
@@ -102,7 +102,7 @@ AK8963_I2C::probe()
 	uint8_t whoami = 0;
 	uint8_t expected = AK8963_DEVICE_ID;
 
-	if (read(AK8963REG_WIA, &whoami, 1)) {
+	if (PX4_OK != read(AK8963REG_WIA, &whoami, 1)) {
 		return -EIO;
 	}
 

--- a/src/drivers/imu/mpu9250/main.cpp
+++ b/src/drivers/imu/mpu9250/main.cpp
@@ -91,6 +91,30 @@
 #define MPU_DEVICE_PATH_GYRO_EXT2	"/dev/mpu9250_gyro_ext2"
 #define MPU_DEVICE_PATH_MAG_EXT2	"/dev/mpu9250_mag_ext2"
 
+#define MPU_DEVICE_PATH_MPU6500_ACCEL       "/dev/mpu6500_accel"
+#define MPU_DEVICE_PATH_MPU6500_GYRO        "/dev/mpu6500_gyro"
+#define MPU_DEVICE_PATH_MPU6500_MAG         "/dev/mpu6500_mag"
+
+#define MPU_DEVICE_PATH_MPU6500_ACCEL_1     "/dev/mpu6500_accel1"
+#define MPU_DEVICE_PATH_MPU6500_GYRO_1      "/dev/mpu6500_gyro1"
+#define MPU_DEVICE_PATH_MPU6500_MAG_1       "/dev/mpu6500_mag1"
+
+#define MPU_DEVICE_PATH_MPU6500_ACCEL_EXT   "/dev/mpu6500_accel_ext"
+#define MPU_DEVICE_PATH_MPU6500_GYRO_EXT    "/dev/mpu6500_gyro_ext"
+#define MPU_DEVICE_PATH_MPU6500_MAG_EXT     "/dev/mpu6500_mag_ext"
+
+#define MPU_DEVICE_PATH_ICM_ACCEL_EXT  "/dev/mpu9250_icm_accel_ext"
+#define MPU_DEVICE_PATH_ICM_GYRO_EXT   "/dev/mpu9250_icm_gyro_ext"
+#define MPU_DEVICE_PATH_ICM_MAG_EXT    "/dev/mpu9250_icm_mag_ext"
+
+#define MPU_DEVICE_PATH_ICM_ACCEL_EXT1	"/dev/mpu9250_icm_accel_ext1"
+#define MPU_DEVICE_PATH_ICM_GYRO_EXT1	"/dev/mpu9250_icm_gyro_ext1"
+#define MPU_DEVICE_PATH_ICM_MAG_EXT1 	"/dev/mpu9250_icm_mag_ext1"
+
+#define MPU_DEVICE_PATH_ICM_ACCEL_EXT2	"/dev/mpu9250_icm_accel_ext2"
+#define MPU_DEVICE_PATH_ICM_GYRO_EXT2	"/dev/mpu9250_icm_gyro_ext2"
+#define MPU_DEVICE_PATH_ICM_MAG_EXT2	"/dev/mpu9250_icm_mag_ext2"
+
 /** driver 'main' command */
 extern "C" { __EXPORT int mpu9250_main(int argc, char *argv[]); }
 
@@ -117,6 +141,7 @@ namespace mpu9250
 
 struct mpu9250_bus_option {
 	enum MPU9250_BUS busid;
+	MPU_DEVICE_TYPE device_type;
 	const char *accelpath;
 	const char *gyropath;
 	const char *magpath;
@@ -127,35 +152,43 @@ struct mpu9250_bus_option {
 	MPU9250	*dev;
 } bus_options[] = {
 #if defined (USE_I2C)
-#  if defined(PX4_I2C_BUS_ONBOARD)
-	{ MPU9250_BUS_I2C_INTERNAL, MPU_DEVICE_PATH_ACCEL, MPU_DEVICE_PATH_GYRO, MPU_DEVICE_PATH_MAG,  &MPU9250_I2C_interface, false, PX4_I2C_BUS_ONBOARD, PX4_I2C_OBDEV_MPU9250, NULL },
+#  if defined(PX4_I2C_BUS_ONBOARD) && defined(PX4_I2C_OBDEV_MPU9250)
+	{ MPU9250_BUS_I2C_INTERNAL, MPU_DEVICE_TYPE_MPU9250, MPU_DEVICE_PATH_ACCEL, MPU_DEVICE_PATH_GYRO, MPU_DEVICE_PATH_MAG,  &MPU9250_I2C_interface, false, PX4_I2C_BUS_ONBOARD, PX4_I2C_OBDEV_MPU9250, NULL },
+	{ MPU9250_BUS_I2C_INTERNAL, MPU_DEVICE_TYPE_MPU6500, MPU_DEVICE_PATH_ACCEL, MPU_DEVICE_PATH_GYRO, MPU_DEVICE_PATH_MAG,  &MPU9250_I2C_interface, false, PX4_I2C_BUS_ONBOARD, PX4_I2C_OBDEV_MPU9250, NULL },
 #  endif
 #  if defined(PX4_I2C_BUS_EXPANSION)
-	{ MPU9250_BUS_I2C_EXTERNAL, MPU_DEVICE_PATH_ACCEL_EXT, MPU_DEVICE_PATH_GYRO_EXT, MPU_DEVICE_PATH_MAG_EXT, &MPU9250_I2C_interface, false, PX4_I2C_BUS_EXPANSION, PX4_I2C_OBDEV_MPU9250, NULL },
+#  if defined(PX4_I2C_OBDEV_MPU9250)
+	{ MPU9250_BUS_I2C_EXTERNAL, MPU_DEVICE_TYPE_MPU9250, MPU_DEVICE_PATH_ACCEL_EXT, MPU_DEVICE_PATH_GYRO_EXT, MPU_DEVICE_PATH_MAG_EXT, &MPU9250_I2C_interface, false, PX4_I2C_BUS_EXPANSION, PX4_I2C_OBDEV_MPU9250, NULL },
+	{ MPU9250_BUS_I2C_EXTERNAL, MPU_DEVICE_TYPE_MPU6500, MPU_DEVICE_PATH_ACCEL_EXT, MPU_DEVICE_PATH_GYRO_EXT, MPU_DEVICE_PATH_MAG_EXT, &MPU9250_I2C_interface, false, PX4_I2C_BUS_EXPANSION, PX4_I2C_OBDEV_MPU9250, NULL },
 #  endif
-#  if defined(PX4_I2C_BUS_EXPANSION1)
+	{ MPU9250_BUS_I2C_EXTERNAL, MPU_DEVICE_TYPE_ICM20948, MPU_DEVICE_PATH_ICM_ACCEL_EXT, MPU_DEVICE_PATH_ICM_GYRO_EXT, MPU_DEVICE_PATH_ICM_MAG_EXT, &MPU9250_I2C_interface, false, PX4_I2C_BUS_EXPANSION, PX4_I2C_EXT_ICM20948_1, NULL },
+#endif
+#  if defined(PX4_I2C_BUS_EXPANSION1) && defined(PX4_I2C_OBDEV_MPU9250)
 	{ MPU9250_BUS_I2C_EXTERNAL, MPU_DEVICE_PATH_ACCEL_EXT1, MPU_DEVICE_PATH_GYRO_EXT1, MPU_DEVICE_PATH_MAG_EXT1, &MPU9250_I2C_interface, false, PX4_I2C_BUS_EXPANSION1, PX4_I2C_OBDEV_MPU9250, NULL },
 #  endif
-#  if defined(PX4_I2C_BUS_EXPANSION2)
+#  if defined(PX4_I2C_BUS_EXPANSION2) && defined(PX4_I2C_OBDEV_MPU9250)
 	{ MPU9250_BUS_I2C_EXTERNAL, MPU_DEVICE_PATH_ACCEL_EXT2, MPU_DEVICE_PATH_GYRO_EXT2, MPU_DEVICE_PATH_MAG_EXT2, &MPU9250_I2C_interface, false, PX4_I2C_BUS_EXPANSION2, PX4_I2C_OBDEV_MPU9250, NULL },
 #  endif
 #endif
 #ifdef PX4_SPIDEV_MPU
-	{ MPU9250_BUS_SPI_INTERNAL, MPU_DEVICE_PATH_ACCEL, MPU_DEVICE_PATH_GYRO, MPU_DEVICE_PATH_MAG, &MPU9250_SPI_interface, true, PX4_SPI_BUS_SENSORS, PX4_SPIDEV_MPU, NULL },
+	{ MPU9250_BUS_SPI_INTERNAL, MPU_DEVICE_TYPE_MPU9250, MPU_DEVICE_PATH_ACCEL, MPU_DEVICE_PATH_GYRO, MPU_DEVICE_PATH_MAG, &MPU9250_SPI_interface, true, PX4_SPI_BUS_SENSORS, PX4_SPIDEV_MPU, NULL },
+	{ MPU9250_BUS_SPI_INTERNAL, MPU_DEVICE_TYPE_MPU6500, MPU_DEVICE_PATH_MPU6500_ACCEL, MPU_DEVICE_PATH_MPU6500_GYRO, MPU_DEVICE_PATH_MPU6500_MAG, &MPU9250_SPI_interface, true, PX4_SPI_BUS_SENSORS, PX4_SPIDEV_MPU, NULL },
 #endif
 #ifdef PX4_SPIDEV_MPU2
-	{ MPU9250_BUS_SPI_INTERNAL2, MPU_DEVICE_PATH_ACCEL_1, MPU_DEVICE_PATH_GYRO_1, MPU_DEVICE_PATH_MAG_1, &MPU9250_SPI_interface, true, PX4_SPI_BUS_SENSORS, PX4_SPIDEV_MPU2, NULL },
+	{ MPU9250_BUS_SPI_INTERNAL2, MPU_DEVICE_TYPE_MPU9250, MPU_DEVICE_PATH_ACCEL_1, MPU_DEVICE_PATH_GYRO_1, MPU_DEVICE_PATH_MAG_1, &MPU9250_SPI_interface, true, PX4_SPI_BUS_SENSORS, PX4_SPIDEV_MPU2, NULL },
+	{ MPU9250_BUS_SPI_INTERNAL2, MPU_DEVICE_TYPE_MPU6500, MPU_DEVICE_PATH_MPU6500_ACCEL_1, MPU_DEVICE_PATH_MPU6500_GYRO_1, MPU_DEVICE_PATH_MPU6500_MAG_1, &MPU9250_SPI_interface, true, PX4_SPI_BUS_SENSORS, PX4_SPIDEV_MPU2, NULL },
 #endif
 #if defined(PX4_SPI_BUS_EXT) && defined(PX4_SPIDEV_EXT_MPU)
-	{ MPU9250_BUS_SPI_EXTERNAL, MPU_DEVICE_PATH_ACCEL_EXT, MPU_DEVICE_PATH_GYRO_EXT, MPU_DEVICE_PATH_MAG_EXT, &MPU9250_SPI_interface, true, PX4_SPI_BUS_EXT, PX4_SPIDEV_EXT_MPU, NULL },
+	{ MPU9250_BUS_SPI_EXTERNAL, MPU_DEVICE_TYPE_MPU9250, MPU_DEVICE_PATH_ACCEL_EXT, MPU_DEVICE_PATH_GYRO_EXT, MPU_DEVICE_PATH_MAG_EXT, &MPU9250_SPI_interface, true, PX4_SPI_BUS_EXT, PX4_SPIDEV_EXT_MPU, NULL },
+	{ MPU9250_BUS_SPI_EXTERNAL, MPU_DEVICE_TYPE_MPU6500, MPU_DEVICE_PATH_MPU6500_ACCEL_EXT, MPU_DEVICE_PATH_MPU6500_GYRO_EXT, MPU_DEVICE_PATH_MPU6500_MAG_EXT, &MPU9250_SPI_interface, true, PX4_SPI_BUS_EXT, PX4_SPIDEV_EXT_MPU, NULL },
 #endif
 };
 
 #define NUM_BUS_OPTIONS (sizeof(bus_options)/sizeof(bus_options[0]))
 
 
-void	start(enum MPU9250_BUS busid, enum Rotation rotation, bool external_bus);
-bool	start_bus(struct mpu9250_bus_option &bus, enum Rotation rotation, bool external_bus);
+void	start(enum MPU9250_BUS busid, enum Rotation rotation, bool external_bus, bool magnetometer_only);
+bool	start_bus(struct mpu9250_bus_option &bus, enum Rotation rotation, bool external_bus, bool magnetometer_only);
 struct mpu9250_bus_option &find_bus(enum MPU9250_BUS busid);
 void	stop(enum MPU9250_BUS busid);
 void	test(enum MPU9250_BUS busid);
@@ -184,16 +217,18 @@ struct mpu9250_bus_option &find_bus(enum MPU9250_BUS busid)
  * start driver for a specific bus option
  */
 bool
-start_bus(struct mpu9250_bus_option &bus, enum Rotation rotation, bool external)
+start_bus(struct mpu9250_bus_option &bus, enum Rotation rotation, bool external, bool magnetometer_only)
 {
 	int fd = -1;
+
+	PX4_INFO("Bus probed: %d", bus.busid);
 
 	if (bus.dev != nullptr) {
 		warnx("%s SPI not available", external ? "External" : "Internal");
 		return false;
 	}
 
-	device::Device *interface = bus.interface_constructor(bus.busnum, bus.address, external);
+	device::Device *interface = bus.interface_constructor(bus.busnum, bus.device_type, bus.address, external);
 
 	if (interface == nullptr) {
 		warnx("no device on bus %u", (unsigned)bus.busid);
@@ -218,10 +253,16 @@ start_bus(struct mpu9250_bus_option &bus, enum Rotation rotation, bool external)
 
 #endif
 
-	bus.dev = new MPU9250(interface, mag_interface, bus.accelpath, bus.gyropath, bus.magpath, rotation);
+	bus.dev = new MPU9250(interface, mag_interface, bus.accelpath, bus.gyropath, bus.magpath, rotation, bus.device_type,
+			      magnetometer_only);
 
 	if (bus.dev == nullptr) {
 		delete interface;
+
+		if (mag_interface != nullptr) {
+			delete mag_interface;
+		}
+
 		return false;
 	}
 
@@ -266,7 +307,7 @@ fail:
  * or failed to detect the sensor.
  */
 void
-start(enum MPU9250_BUS busid, enum Rotation rotation, bool external)
+start(enum MPU9250_BUS busid, enum Rotation rotation, bool external, bool magnetometer_only)
 {
 
 	bool started = false;
@@ -282,7 +323,9 @@ start(enum MPU9250_BUS busid, enum Rotation rotation, bool external)
 			continue;
 		}
 
-		started |= start_bus(bus_options[i], rotation, external);
+		started |= start_bus(bus_options[i], rotation, external, magnetometer_only);
+
+		if (started) { break; }
 	}
 
 	exit(started ? 0 : 1);
@@ -480,6 +523,7 @@ usage()
 	PX4_INFO("    -S    (spi external bus)");
 	PX4_INFO("    -t    (spi internal bus, 2nd instance)");
 	PX4_INFO("    -R rotation");
+	PX4_INFO("    -M only enable magnetometer, accel/gyro disabled");
 
 }
 
@@ -494,8 +538,9 @@ mpu9250_main(int argc, char *argv[])
 
 	enum MPU9250_BUS busid = MPU9250_BUS_ALL;
 	enum Rotation rotation = ROTATION_NONE;
+	bool magnetometer_only = false;
 
-	while ((ch = px4_getopt(argc, argv, "XISstR:", &myoptind, &myoptarg)) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "XISstMR:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'X':
 			busid = MPU9250_BUS_I2C_EXTERNAL;
@@ -521,6 +566,10 @@ mpu9250_main(int argc, char *argv[])
 			rotation = (enum Rotation)atoi(myoptarg);
 			break;
 
+		case 'M':
+			magnetometer_only = true;
+			break;
+
 		default:
 			mpu9250::usage();
 			return 0;
@@ -539,7 +588,7 @@ mpu9250_main(int argc, char *argv[])
 	 * Start/load the driver.
 	 */
 	if (!strcmp(verb, "start")) {
-		mpu9250::start(busid, rotation, external);
+		mpu9250::start(busid, rotation, external, magnetometer_only);
 	}
 
 	if (!strcmp(verb, "stop")) {

--- a/src/drivers/imu/mpu9250/main.cpp
+++ b/src/drivers/imu/mpu9250/main.cpp
@@ -270,8 +270,11 @@ start_bus(struct mpu9250_bus_option &bus, enum Rotation rotation, bool external,
 		goto fail;
 	}
 
-	/* set the poll rate to default, starts automatic data collection */
-	fd = open(bus.accelpath, O_RDONLY);
+	/*
+	 * Set the poll rate to default, starts automatic data collection.
+	 * Doing this through the mag device for the time being - it's always there, even in magnetometer only mode.
+	 */
+	fd = open(bus.magpath, O_RDONLY);
 
 	if (fd < 0) {
 		goto fail;

--- a/src/drivers/imu/mpu9250/main.cpp
+++ b/src/drivers/imu/mpu9250/main.cpp
@@ -273,8 +273,14 @@ start_bus(struct mpu9250_bus_option &bus, enum Rotation rotation, bool external,
 	/*
 	 * Set the poll rate to default, starts automatic data collection.
 	 * Doing this through the mag device for the time being - it's always there, even in magnetometer only mode.
+	 * Using accel device for MPU6500.
 	 */
-	fd = open(bus.magpath, O_RDONLY);
+	if (bus.device_type == MPU_DEVICE_TYPE_MPU6500) {
+		fd = open(bus.accelpath, O_RDONLY);
+
+	} else {
+		fd = open(bus.magpath, O_RDONLY);
+	}
 
 	if (fd < 0) {
 		goto fail;
@@ -323,6 +329,11 @@ start(enum MPU9250_BUS busid, enum Rotation rotation, bool external, bool magnet
 
 		if (busid != MPU9250_BUS_ALL && bus_options[i].busid != busid) {
 			// not the one that is asked for
+			continue;
+		}
+
+		if (bus_options[i].device_type == MPU_DEVICE_TYPE_MPU6500 && magnetometer_only) {
+			// prevent starting MPU6500 in magnetometer only mode
 			continue;
 		}
 
@@ -526,7 +537,7 @@ usage()
 	PX4_INFO("    -S    (spi external bus)");
 	PX4_INFO("    -t    (spi internal bus, 2nd instance)");
 	PX4_INFO("    -R rotation");
-	PX4_INFO("    -M only enable magnetometer, accel/gyro disabled");
+	PX4_INFO("    -M only enable magnetometer, accel/gyro disabled - not av. on MPU6500");
 
 }
 

--- a/src/drivers/imu/mpu9250/mpu9250.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250.cpp
@@ -202,23 +202,25 @@ MPU9250::MPU9250(device::Device *interface, device::Device *mag_interface, const
 		_accel->_device_id.devid_s.address = _interface->get_device_address();
 	}
 
-	/* Prime _gyro with common devid. */
-	/* Set device parameters and make sure parameters of the bus device are adopted */
-	_gyro->_device_id.devid = _accel->_device_id.devid;
-	_gyro->_device_id.devid_s.devtype = DRV_GYR_DEVTYPE_MPU9250;
-	_gyro->_device_id.devid_s.bus_type = _interface->get_device_bus_type();
-	_gyro->_device_id.devid_s.bus = _interface->get_device_bus();
-	_gyro->_device_id.devid_s.address = _interface->get_device_address();
+	if (_gyro != nullptr) {
+		/* Prime _gyro with common devid. */
+		/* Set device parameters and make sure parameters of the bus device are adopted */
+		_gyro->_device_id.devid = 0;
+		_gyro->_device_id.devid_s.devtype = DRV_GYR_DEVTYPE_MPU9250;
+		_gyro->_device_id.devid_s.bus_type = _interface->get_device_bus_type();
+		_gyro->_device_id.devid_s.bus = _interface->get_device_bus();
+		_gyro->_device_id.devid_s.address = _interface->get_device_address();
+	}
 
 	/* Prime _mag with common devid. */
-	_mag->_device_id.devid = _accel->_device_id.devid;
+	_mag->_device_id.devid = 0;
 	_mag->_device_id.devid_s.devtype = DRV_MAG_DEVTYPE_MPU9250;
 	_mag->_device_id.devid_s.bus_type = _interface->get_device_bus_type();
 	_mag->_device_id.devid_s.bus = _interface->get_device_bus();
 	_mag->_device_id.devid_s.address = _interface->get_device_address();
 
 	/* For an independent mag, ensure that it is connected to the i2c bus */
-	_interface->set_device_type(_accel->_device_id.devid_s.devtype);
+	_interface->set_device_type(DRV_ACC_DEVTYPE_MPU9250);
 
 	// default accel scale factors
 	_accel_scale.x_offset = 0;
@@ -246,9 +248,12 @@ MPU9250::~MPU9250()
 {
 	/* make sure we are truly inactive */
 	stop();
+	_call_interval = 0;
 
-	orb_unadvertise(_accel_topic);
-	orb_unadvertise(_gyro->_gyro_topic);
+	if (!_magnetometer_only) {
+		orb_unadvertise(_accel_topic);
+		orb_unadvertise(_gyro->_gyro_topic);
+	}
 
 	/* delete the accel subdriver */
 	delete _accel;
@@ -695,11 +700,6 @@ MPU9250::_set_sample_rate(unsigned desired_sample_rate_hz)
 		_sample_rate = 1100 / div;
 		break;
 	}
-
-	/*
-	 * Adjust pollrate to new sample rate.
-	 */
-	_set_pollrate(_sample_rate);
 }
 
 /*

--- a/src/drivers/imu/mpu9250/mpu9250.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250.cpp
@@ -79,6 +79,7 @@
 #include <lib/conversion/rotation.h>
 
 #include "mag.h"
+#include "accel.h"
 #include "gyro.h"
 #include "mpu9250.h"
 
@@ -134,9 +135,10 @@ MPU9250::MPU9250(device::Device *interface, device::Device *mag_interface, const
 		 enum Rotation rotation,
 		 int device_type,
 		 bool magnetometer_only) :
-	CDev("MPU9250", path_accel),
 	_interface(interface),
-	_gyro(new MPU9250_gyro(this, path_gyro)),
+	_name("MPU9250"),
+	_accel(magnetometer_only ? nullptr : new MPU9250_accel(this, path_accel)),
+	_gyro(magnetometer_only ? nullptr : new MPU9250_gyro(this, path_gyro)),
 	_mag(new MPU9250_mag(this, mag_interface, path_mag)),
 	_whoami(0),
 	_device_type(device_type),
@@ -155,8 +157,6 @@ MPU9250::MPU9250(device::Device *interface, device::Device *mag_interface, const
 	_accel_range_scale(0.0f),
 	_accel_range_m_s2(0.0f),
 	_accel_topic(nullptr),
-	_accel_orb_class_instance(-1),
-	_accel_class_instance(-1),
 	_gyro_reports(nullptr),
 	_gyro_scale{},
 	_gyro_range_scale(0.0f),
@@ -194,29 +194,31 @@ MPU9250::MPU9250(device::Device *interface, device::Device *mag_interface, const
 	// disable debug() calls
 	_debug_enabled = false;
 
-	/* Set device parameters and make sure parameters of the bus device are adopted */
-	_device_id.devid_s.devtype = DRV_ACC_DEVTYPE_MPU9250;
-	_device_id.devid_s.bus_type = (device::Device::DeviceBusType)_interface->get_device_bus_type();
-	_device_id.devid_s.bus = _interface->get_device_bus();
-	_device_id.devid_s.address = _interface->get_device_address();
+	if (_accel != nullptr) {
+		/* Set device parameters and make sure parameters of the bus device are adopted */
+		_accel->_device_id.devid_s.devtype = DRV_ACC_DEVTYPE_MPU9250;
+		_accel->_device_id.devid_s.bus_type = (device::Device::DeviceBusType)_interface->get_device_bus_type();
+		_accel->_device_id.devid_s.bus = _interface->get_device_bus();
+		_accel->_device_id.devid_s.address = _interface->get_device_address();
+	}
 
-	/* Prime _gyro with parents devid. */
+	/* Prime _gyro with common devid. */
 	/* Set device parameters and make sure parameters of the bus device are adopted */
-	_gyro->_device_id.devid = _device_id.devid;
+	_gyro->_device_id.devid = _accel->_device_id.devid;
 	_gyro->_device_id.devid_s.devtype = DRV_GYR_DEVTYPE_MPU9250;
 	_gyro->_device_id.devid_s.bus_type = _interface->get_device_bus_type();
 	_gyro->_device_id.devid_s.bus = _interface->get_device_bus();
 	_gyro->_device_id.devid_s.address = _interface->get_device_address();
 
-	/* Prime _mag with parents devid. */
-	_mag->_device_id.devid = _device_id.devid;
+	/* Prime _mag with common devid. */
+	_mag->_device_id.devid = _accel->_device_id.devid;
 	_mag->_device_id.devid_s.devtype = DRV_MAG_DEVTYPE_MPU9250;
 	_mag->_device_id.devid_s.bus_type = _interface->get_device_bus_type();
 	_mag->_device_id.devid_s.bus = _interface->get_device_bus();
 	_mag->_device_id.devid_s.address = _interface->get_device_address();
 
 	/* For an independent mag, ensure that it is connected to the i2c bus */
-	_interface->set_device_type(_device_id.devid_s.devtype);
+	_interface->set_device_type(_accel->_device_id.devid_s.devtype);
 
 	// default accel scale factors
 	_accel_scale.x_offset = 0;
@@ -248,6 +250,9 @@ MPU9250::~MPU9250()
 	orb_unadvertise(_accel_topic);
 	orb_unadvertise(_gyro->_gyro_topic);
 
+	/* delete the accel subdriver */
+	delete _accel;
+
 	/* delete the gyro subdriver */
 	delete _gyro;
 
@@ -261,10 +266,6 @@ MPU9250::~MPU9250()
 
 	if (_gyro_reports != nullptr) {
 		delete _gyro_reports;
-	}
-
-	if (_accel_class_instance != -1) {
-		unregister_class_devname(ACCEL_BASE_DEVICE_PATH, _accel_class_instance);
 	}
 
 	/* delete the perf counter */
@@ -305,12 +306,12 @@ MPU9250::init()
 		return ret;
 	}
 
-	/* do init */
-	ret = CDev::init();
+	state = px4_enter_critical_section();
+	_reset_wait = hrt_absolute_time() + 100000;
+	px4_leave_critical_section(state);
 
-	/* if init failed, bail now */
-	if (ret != OK) {
-		DEVICE_DEBUG("CDev init failed");
+	if (reset_mpu() != OK) {
+		PX4_ERR("Exiting! Device failed to take initialization");
 		return ret;
 	}
 
@@ -328,63 +329,55 @@ MPU9250::init()
 		if (_gyro_reports == nullptr) {
 			return ret;
 		}
-	}
 
-	state = px4_enter_critical_section();
-	_reset_wait = hrt_absolute_time() + 100000;
-	px4_leave_critical_section(state);
+		/* Initialize offsets and scales */
+		_accel_scale.x_offset = 0;
+		_accel_scale.x_scale  = 1.0f;
+		_accel_scale.y_offset = 0;
+		_accel_scale.y_scale  = 1.0f;
+		_accel_scale.z_offset = 0;
+		_accel_scale.z_scale  = 1.0f;
 
-	if (reset_mpu() != OK) {
-		PX4_ERR("Exiting! Device failed to take initialization");
-		return ret;
-	}
+		_gyro_scale.x_offset = 0;
+		_gyro_scale.x_scale  = 1.0f;
+		_gyro_scale.y_offset = 0;
+		_gyro_scale.y_scale  = 1.0f;
+		_gyro_scale.z_offset = 0;
+		_gyro_scale.z_scale  = 1.0f;
 
-	/* Initialize offsets and scales */
-	_accel_scale.x_offset = 0;
-	_accel_scale.x_scale  = 1.0f;
-	_accel_scale.y_offset = 0;
-	_accel_scale.y_scale  = 1.0f;
-	_accel_scale.z_offset = 0;
-	_accel_scale.z_scale  = 1.0f;
+		// set software low pass filter for controllers
+		param_t accel_cut_ph = param_find("IMU_ACCEL_CUTOFF");
+		float accel_cut = MPU9250_ACCEL_DEFAULT_DRIVER_FILTER_FREQ;
 
-	_gyro_scale.x_offset = 0;
-	_gyro_scale.x_scale  = 1.0f;
-	_gyro_scale.y_offset = 0;
-	_gyro_scale.y_scale  = 1.0f;
-	_gyro_scale.z_offset = 0;
-	_gyro_scale.z_scale  = 1.0f;
+		if (accel_cut_ph != PARAM_INVALID && (param_get(accel_cut_ph, &accel_cut) == PX4_OK)) {
+			PX4_INFO("accel cutoff set to %.2f Hz", double(accel_cut));
 
-	// set software low pass filter for controllers
-	param_t accel_cut_ph = param_find("IMU_ACCEL_CUTOFF");
-	float accel_cut = MPU9250_ACCEL_DEFAULT_DRIVER_FILTER_FREQ;
+			_accel_filter_x.set_cutoff_frequency(MPU9250_ACCEL_DEFAULT_RATE, accel_cut);
+			_accel_filter_y.set_cutoff_frequency(MPU9250_ACCEL_DEFAULT_RATE, accel_cut);
+			_accel_filter_z.set_cutoff_frequency(MPU9250_ACCEL_DEFAULT_RATE, accel_cut);
 
-	if (accel_cut_ph != PARAM_INVALID && (param_get(accel_cut_ph, &accel_cut) == PX4_OK)) {
-		PX4_INFO("accel cutoff set to %.2f Hz", double(accel_cut));
+		} else {
+			PX4_ERR("IMU_ACCEL_CUTOFF param invalid");
+		}
 
-		_accel_filter_x.set_cutoff_frequency(MPU9250_ACCEL_DEFAULT_RATE, accel_cut);
-		_accel_filter_y.set_cutoff_frequency(MPU9250_ACCEL_DEFAULT_RATE, accel_cut);
-		_accel_filter_z.set_cutoff_frequency(MPU9250_ACCEL_DEFAULT_RATE, accel_cut);
+		param_t gyro_cut_ph = param_find("IMU_GYRO_CUTOFF");
+		float gyro_cut = MPU9250_GYRO_DEFAULT_DRIVER_FILTER_FREQ;
 
-	} else {
-		PX4_ERR("IMU_ACCEL_CUTOFF param invalid");
-	}
+		if (gyro_cut_ph != PARAM_INVALID && (param_get(gyro_cut_ph, &gyro_cut) == PX4_OK)) {
+			PX4_INFO("gyro cutoff set to %.2f Hz", double(gyro_cut));
 
-	param_t gyro_cut_ph = param_find("IMU_GYRO_CUTOFF");
-	float gyro_cut = MPU9250_GYRO_DEFAULT_DRIVER_FILTER_FREQ;
+			_gyro_filter_x.set_cutoff_frequency(MPU9250_GYRO_DEFAULT_RATE, gyro_cut);
+			_gyro_filter_y.set_cutoff_frequency(MPU9250_GYRO_DEFAULT_RATE, gyro_cut);
+			_gyro_filter_z.set_cutoff_frequency(MPU9250_GYRO_DEFAULT_RATE, gyro_cut);
 
-	if (gyro_cut_ph != PARAM_INVALID && (param_get(gyro_cut_ph, &gyro_cut) == PX4_OK)) {
-		PX4_INFO("gyro cutoff set to %.2f Hz", double(gyro_cut));
+		} else {
+			PX4_ERR("IMU_GYRO_CUTOFF param invalid");
+		}
 
-		_gyro_filter_x.set_cutoff_frequency(MPU9250_GYRO_DEFAULT_RATE, gyro_cut);
-		_gyro_filter_y.set_cutoff_frequency(MPU9250_GYRO_DEFAULT_RATE, gyro_cut);
-		_gyro_filter_z.set_cutoff_frequency(MPU9250_GYRO_DEFAULT_RATE, gyro_cut);
+		/* do CDev init for the accel device node */
+		ret = _accel->init();
 
-	} else {
-		PX4_ERR("IMU_GYRO_CUTOFF param invalid");
-	}
-
-	/* do CDev init for the gyro device node, keep it optional */
-	if (!_magnetometer_only) {
+		/* do CDev init for the gyro device node */
 		ret = _gyro->init();
 
 		/* if probe/setup failed, bail now */
@@ -425,10 +418,6 @@ MPU9250::init()
 		}
 	}
 
-	if (!_magnetometer_only) {
-		_accel_class_instance = register_class_devname(ACCEL_BASE_DEVICE_PATH);
-	}
-
 	measure();
 
 	if (!_magnetometer_only) {
@@ -438,7 +427,7 @@ MPU9250::init()
 
 		/* measurement will have generated a report, publish */
 		_accel_topic = orb_advertise_multi(ORB_ID(sensor_accel), &arp,
-						   &_accel_orb_class_instance, (is_external()) ? ORB_PRIO_MAX - 1 : ORB_PRIO_HIGH - 1);
+						   &_accel->_accel_orb_class_instance, (is_external()) ? ORB_PRIO_MAX - 1 : ORB_PRIO_HIGH - 1);
 
 		if (_accel_topic == nullptr) {
 			PX4_ERR("ADVERT FAIL");
@@ -706,6 +695,66 @@ MPU9250::_set_sample_rate(unsigned desired_sample_rate_hz)
 		_sample_rate = 1100 / div;
 		break;
 	}
+
+	/*
+	 * Adjust pollrate to new sample rate.
+	 */
+	_set_pollrate(_sample_rate);
+}
+
+/*
+ * Set poll rate
+ */
+int
+MPU9250::_set_pollrate(unsigned long rate)
+{
+	if (rate == 0) {
+		return -EINVAL;
+
+	} else {
+		/* do we need to start internal polling? */
+		bool want_start = (_call_interval == 0);
+
+		/* convert hz to hrt interval via microseconds */
+		unsigned ticks = 1000000 / rate;
+
+		/* check against maximum sane rate */
+		if (ticks < 1000) {
+			return -EINVAL;
+		}
+
+		// adjust filters
+		float cutoff_freq_hz = _accel_filter_x.get_cutoff_freq();
+		float sample_rate = 1.0e6f / ticks;
+		_accel_filter_x.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
+		_accel_filter_y.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
+		_accel_filter_z.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
+
+
+		float cutoff_freq_hz_gyro = _gyro_filter_x.get_cutoff_freq();
+		_gyro_filter_x.set_cutoff_frequency(sample_rate, cutoff_freq_hz_gyro);
+		_gyro_filter_y.set_cutoff_frequency(sample_rate, cutoff_freq_hz_gyro);
+		_gyro_filter_z.set_cutoff_frequency(sample_rate, cutoff_freq_hz_gyro);
+
+		/* update interval for next measurement */
+		/* XXX this is a bit shady, but no other way to adjust... */
+		_call_interval = ticks;
+
+		/*
+		  set call interval faster than the sample time. We
+		  then detect when we have duplicate samples and reject
+		  them. This prevents aliasing due to a beat between the
+		  stm32 clock and the mpu9250 clock
+		 */
+		_call.period = _call_interval - MPU9250_TIMER_REDUCTION;
+
+		/* if we need to start the poll state machine, do it */
+		if (want_start) {
+			start();
+		}
+
+		return OK;
+	}
 }
 
 /*
@@ -850,7 +899,7 @@ MPU9250::_set_dlpf_filter(uint16_t frequency_hz)
 }
 
 ssize_t
-MPU9250::read(struct file *filp, char *buffer, size_t buflen)
+MPU9250::accel_read(struct file *filp, char *buffer, size_t buflen)
 {
 	unsigned count = buflen / sizeof(sensor_accel_s);
 
@@ -956,7 +1005,7 @@ MPU9250::gyro_read(struct file *filp, char *buffer, size_t buflen)
 }
 
 int
-MPU9250::ioctl(struct file *filp, int cmd, unsigned long arg)
+MPU9250::accel_ioctl(struct file *filp, int cmd, unsigned long arg)
 {
 	switch (cmd) {
 
@@ -973,53 +1022,11 @@ MPU9250::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 			/* set default polling rate */
 			case SENSOR_POLLRATE_DEFAULT:
-				return ioctl(filp, SENSORIOCSPOLLRATE, MPU9250_ACCEL_DEFAULT_RATE);
+				return accel_ioctl(filp, SENSORIOCSPOLLRATE, MPU9250_ACCEL_DEFAULT_RATE);
 
 			/* adjust to a legal polling interval in Hz */
-			default: {
-					/* do we need to start internal polling? */
-					bool want_start = (_call_interval == 0);
-
-					/* convert hz to hrt interval via microseconds */
-					unsigned ticks = 1000000 / arg;
-
-					/* check against maximum sane rate */
-					if (ticks < 1000) {
-						return -EINVAL;
-					}
-
-					// adjust filters
-					float cutoff_freq_hz = _accel_filter_x.get_cutoff_freq();
-					float sample_rate = 1.0e6f / ticks;
-					_accel_filter_x.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
-					_accel_filter_y.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
-					_accel_filter_z.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
-
-
-					float cutoff_freq_hz_gyro = _gyro_filter_x.get_cutoff_freq();
-					_gyro_filter_x.set_cutoff_frequency(sample_rate, cutoff_freq_hz_gyro);
-					_gyro_filter_y.set_cutoff_frequency(sample_rate, cutoff_freq_hz_gyro);
-					_gyro_filter_z.set_cutoff_frequency(sample_rate, cutoff_freq_hz_gyro);
-
-					/* update interval for next measurement */
-					/* XXX this is a bit shady, but no other way to adjust... */
-					_call_interval = ticks;
-
-					/*
-					  set call interval faster than the sample time. We
-					  then detect when we have duplicate samples and reject
-					  them. This prevents aliasing due to a beat between the
-					  stm32 clock and the mpu9250 clock
-					 */
-					_call.period = _call_interval - MPU9250_TIMER_REDUCTION;
-
-					/* if we need to start the poll state machine, do it */
-					if (want_start) {
-						start();
-					}
-
-					return OK;
-				}
+			default:
+				return _set_pollrate(arg);
 			}
 		}
 
@@ -1039,7 +1046,7 @@ MPU9250::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	default:
 		/* give it to the superclass */
-		return CDev::ioctl(filp, cmd, arg);
+		return _gyro->ioctl(filp, cmd, arg);
 	}
 }
 
@@ -1051,7 +1058,7 @@ MPU9250::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 	/* these are shared with the accel side */
 	case SENSORIOCSPOLLRATE:
 	case SENSORIOCRESET:
-		return ioctl(filp, cmd, arg);
+		return accel_ioctl(filp, cmd, arg);
 
 	case GYROIOCSSCALE:
 		/* copy scale in */
@@ -1060,7 +1067,7 @@ MPU9250::gyro_ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	default:
 		/* give it to the superclass */
-		return CDev::ioctl(filp, cmd, arg);
+		return _accel->ioctl(filp, cmd, arg);
 	}
 }
 
@@ -1609,7 +1616,7 @@ MPU9250::measure()
 		 * Report buffers.
 		 */
 		sensor_accel_s		arb;
-		sensor_gyro_s		grb;
+		sensor_gyro_s			grb;
 
 		/*
 		 * Adjust and scale results to m/s^2.
@@ -1673,7 +1680,7 @@ MPU9250::measure()
 		arb.temperature = _last_temperature;
 
 		/* return device ID */
-		arb.device_id = _device_id.devid;
+		arb.device_id = _accel->_device_id.devid;
 
 		grb.x_raw = report.gyro_x;
 		grb.y_raw = report.gyro_y;
@@ -1714,19 +1721,19 @@ MPU9250::measure()
 
 		/* notify anyone waiting for data */
 		if (accel_notify) {
-			poll_notify(POLLIN);
+			_accel->poll_notify(POLLIN);
 		}
 
 		if (gyro_notify) {
 			_gyro->parent_poll_notify();
 		}
 
-		if (accel_notify && !(_pub_blocked)) {
+		if (accel_notify && !(_accel->_pub_blocked)) {
 			/* publish it */
 			orb_publish(ORB_ID(sensor_accel), _accel_topic, &arb);
 		}
 
-		if (gyro_notify && !(_pub_blocked)) {
+		if (gyro_notify && !(_gyro->_pub_blocked)) {
 			/* publish it */
 			orb_publish(ORB_ID(sensor_gyro), _gyro->_gyro_topic, &grb);
 		}
@@ -1748,15 +1755,20 @@ MPU9250::print_info()
 	perf_print_counter(_good_transfers);
 	perf_print_counter(_reset_retries);
 	perf_print_counter(_duplicates);
-	_accel_reports->print_info("accel queue");
-	_gyro_reports->print_info("gyro queue");
-	_mag->_mag_reports->print_info("mag queue");
+
+	if (!_magnetometer_only) {
+		_accel_reports->print_info("accel queue");
+		_gyro_reports->print_info("gyro queue");
+		_mag->_mag_reports->print_info("mag queue");
+
+		float accel_cut = _accel_filter_x.get_cutoff_freq();
+		::printf("accel cutoff set to %10.2f Hz\n", double(accel_cut));
+		float gyro_cut = _gyro_filter_x.get_cutoff_freq();
+		::printf("gyro cutoff set to %10.2f Hz\n", double(gyro_cut));
+
+	}
 
 	::printf("temperature: %.1f\n", (double)_last_temperature);
-	float accel_cut = _accel_filter_x.get_cutoff_freq();
-	::printf("accel cutoff set to %10.2f Hz\n", double(accel_cut));
-	float gyro_cut = _gyro_filter_x.get_cutoff_freq();
-	::printf("gyro cutoff set to %10.2f Hz\n", double(gyro_cut));
 
 
 }

--- a/src/drivers/imu/mpu9250/mpu9250.h
+++ b/src/drivers/imu/mpu9250/mpu9250.h
@@ -49,12 +49,22 @@
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
 #include <lib/conversion/rotation.h>
 
+#include <uORB/uORB.h>
+#include <uORB/topics/debug_key_value.h>
+
 #include "mag.h"
 #include "gyro.h"
 
 
+/* List of supported device types */
+enum MPU_DEVICE_TYPE {
+	MPU_DEVICE_TYPE_MPU9250	= 9250,
+	MPU_DEVICE_TYPE_MPU6500 = 6500,
+	MPU_DEVICE_TYPE_ICM20948 = 20948
+};
 
-#if defined(PX4_I2C_OBDEV_MPU9250)
+
+#if defined(PX4_I2C_OBDEV_MPU9250) || defined(PX4_I2C_BUS_EXPANSION)
 #  define USE_I2C
 #endif
 
@@ -177,8 +187,9 @@
 #define BIT_I2C_SLV2_DLY_EN         0x04
 #define BIT_I2C_SLV3_DLY_EN         0x08
 
-#define MPU_WHOAMI_9250			0x71
-#define MPU_WHOAMI_6500			0x70
+#define MPU_WHOAMI_9250             0x71
+#define MPU_WHOAMI_6500             0x70
+#define ICM_WHOAMI_20948            0xEA
 
 #define MPU9250_ACCEL_DEFAULT_RATE	1000
 #define MPU9250_ACCEL_MAX_OUTPUT_RATE			280
@@ -191,6 +202,135 @@
 #define MPU9250_DEFAULT_ONCHIP_FILTER_FREQ	92
 
 #define MPUIOCGIS_I2C	(unsigned)(DEVIOCGDEVICEID+100)
+
+
+
+// ICM20948 registers and data
+
+/*
+ * ICM20948 I2C address LSB can be switched by the chip's AD0 pin, thus is device dependent.
+ * Noting this down for now. Here GPS uses 0x69. To support a device implementing the second
+ * address, probably an additional MPU_DEVICE_TYPE is the way to go.
+ */
+#define PX4_I2C_EXT_ICM20948_0			0x68
+#define PX4_I2C_EXT_ICM20948_1			0x69
+
+/*
+ * ICM20948 uses register banks. Register 127 (0x7F) is used to switch between 4 banks.
+ * There's room in the upper address byte below the port speed setting to code in the
+ * used bank. This is a bit more efficient, already in use for the speed setting and more
+ * in one place than a solution with a lookup table for address/bank pairs.
+ */
+
+#define BANK0	0x0000
+#define BANK1	0x0100
+#define BANK2	0x0200
+#define BANK3	0x0300
+
+#define BANK_REG_MASK	0x0300
+#define REG_BANK(r) 			(((r) & BANK_REG_MASK)>>4)
+#define REG_ADDRESS(r)			((r) & ~BANK_REG_MASK)
+
+#define ICMREG_20948_BANK_SEL 0x7F
+
+#define	ICMREG_20948_WHOAMI					(0x00 | BANK0)
+#define ICMREG_20948_USER_CTRL				(0x03 | BANK0)
+#define ICMREG_20948_PWR_MGMT_1				(0x06 | BANK0)
+#define ICMREG_20948_PWR_MGMT_2				(0x07 | BANK0)
+#define ICMREG_20948_INT_PIN_CFG			(0x0F | BANK0)
+#define ICMREG_20948_INT_ENABLE				(0x10 | BANK0)
+#define ICMREG_20948_INT_ENABLE_1			(0x11 | BANK0)
+#define ICMREG_20948_ACCEL_XOUT_H			(0x2D | BANK0)
+#define ICMREG_20948_INT_ENABLE_2			(0x12 | BANK0)
+#define ICMREG_20948_INT_ENABLE_3			(0x13 | BANK0)
+#define ICMREG_20948_EXT_SLV_SENS_DATA_00	(0x3B | BANK0)
+#define ICMREG_20948_GYRO_SMPLRT_DIV		(0x00 | BANK2)
+#define ICMREG_20948_GYRO_CONFIG_1			(0x01 | BANK2)
+#define ICMREG_20948_GYRO_CONFIG_2			(0x02 | BANK2)
+#define ICMREG_20948_ACCEL_SMPLRT_DIV_1		(0x10 | BANK2)
+#define ICMREG_20948_ACCEL_SMPLRT_DIV_2		(0x11 | BANK2)
+#define ICMREG_20948_ACCEL_CONFIG			(0x14 | BANK2)
+#define ICMREG_20948_ACCEL_CONFIG_2			(0x15 | BANK2)
+#define ICMREG_20948_I2C_MST_CTRL			(0x01 | BANK3)
+#define ICMREG_20948_I2C_SLV0_ADDR			(0x03 | BANK3)
+#define ICMREG_20948_I2C_SLV0_REG			(0x04 | BANK3)
+#define ICMREG_20948_I2C_SLV0_CTRL			(0x05 | BANK3)
+#define ICMREG_20948_I2C_SLV0_DO			(0x06 | BANK3)
+
+
+
+/*
+* ICM20948 register bits
+* Most of the regiser set values from MPU9250 have the same
+* meaning on ICM20948. The exceptions and values not already
+* defined for MPU9250 are defined below
+*/
+#define ICM_BIT_PWR_MGMT_1_ENABLE       	0x00
+#define ICM_BIT_USER_CTRL_I2C_MST_DISABLE   0x00
+
+#define ICM_BITS_GYRO_DLPF_CFG_197HZ		0x01
+#define ICM_BITS_GYRO_DLPF_CFG_151HZ		0x09
+#define ICM_BITS_GYRO_DLPF_CFG_119HZ		0x11
+#define ICM_BITS_GYRO_DLPF_CFG_51HZ			0x19
+#define ICM_BITS_GYRO_DLPF_CFG_23HZ			0x21
+#define ICM_BITS_GYRO_DLPF_CFG_11HZ			0x29
+#define ICM_BITS_GYRO_DLPF_CFG_5HZ			0x31
+#define ICM_BITS_GYRO_DLPF_CFG_361HZ		0x39
+#define ICM_BITS_GYRO_DLPF_CFG_MASK			0x39
+
+#define ICM_BITS_GYRO_FS_SEL_250DPS			0x00
+#define ICM_BITS_GYRO_FS_SEL_500DPS			0x02
+#define ICM_BITS_GYRO_FS_SEL_1000DPS		0x04
+#define ICM_BITS_GYRO_FS_SEL_2000DPS		0x06
+#define ICM_BITS_GYRO_FS_SEL_MASK			0x06
+
+#define ICM_BITS_ACCEL_DLPF_CFG_246HZ		0x09
+#define ICM_BITS_ACCEL_DLPF_CFG_111HZ		0x11
+#define ICM_BITS_ACCEL_DLPF_CFG_50HZ		0x19
+#define ICM_BITS_ACCEL_DLPF_CFG_23HZ		0x21
+#define ICM_BITS_ACCEL_DLPF_CFG_11HZ		0x29
+#define ICM_BITS_ACCEL_DLPF_CFG_5HZ			0x31
+#define ICM_BITS_ACCEL_DLPF_CFG_473HZ		0x39
+#define ICM_BITS_ACCEL_DLPF_CFG_MASK		0x39
+
+#define ICM_BITS_ACCEL_FS_SEL_250DPS		0x00
+#define ICM_BITS_ACCEL_FS_SEL_500DPS		0x02
+#define ICM_BITS_ACCEL_FS_SEL_1000DPS		0x04
+#define ICM_BITS_ACCEL_FS_SEL_2000DPS		0x06
+#define ICM_BITS_ACCEL_FS_SEL_MASK			0x06
+
+#define ICM_BITS_DEC3_CFG_4					0x00
+#define ICM_BITS_DEC3_CFG_8					0x01
+#define ICM_BITS_DEC3_CFG_16				0x10
+#define ICM_BITS_DEC3_CFG_32				0x11
+#define ICM_BITS_DEC3_CFG_MASK				0x11
+
+#define ICM_BITS_I2C_MST_CLOCK_370KHZ    	0x00
+#define ICM_BITS_I2C_MST_CLOCK_400HZ    	0x07	// recommended by datasheet for 400kHz target clock
+
+
+
+#define MPU_OR_ICM(m,i)					((_device_type==MPU_DEVICE_TYPE_ICM20948) ? i : m)
+
+
+#pragma pack(push, 1)
+/**
+ * Report conversation within the mpu, including command byte and
+ * interrupt status.
+ */
+struct ICMReport {
+	uint8_t		accel_x[2];
+	uint8_t		accel_y[2];
+	uint8_t		accel_z[2];
+	uint8_t		gyro_x[2];
+	uint8_t		gyro_y[2];
+	uint8_t		gyro_z[2];
+	uint8_t		temp[2];
+	struct ak8963_regs mag;
+};
+#pragma pack(pop)
+
+
 
 
 #pragma pack(push, 1)
@@ -224,18 +364,19 @@ struct MPUReport {
  */
 #define MPU9250_LOW_BUS_SPEED				0
 #define MPU9250_HIGH_BUS_SPEED				0x8000
+#define MPU9250_REG_MASK					0x00FF
 #  define MPU9250_IS_HIGH_SPEED(r) 			((r) & MPU9250_HIGH_BUS_SPEED)
-#  define MPU9250_REG(r) 					((r) &~MPU9250_HIGH_BUS_SPEED)
+#  define MPU9250_REG(r) 					((r) & MPU9250_REG_MASK)
 #  define MPU9250_SET_SPEED(r, s) 			((r)|(s))
 #  define MPU9250_HIGH_SPEED_OP(r) 			MPU9250_SET_SPEED((r), MPU9250_HIGH_BUS_SPEED)
-#  define MPU9250_LOW_SPEED_OP(r)			MPU9250_REG((r))
+#  define MPU9250_LOW_SPEED_OP(r)			((r) &~MPU9250_HIGH_BUS_SPEED)
 
 /* interface factories */
-extern device::Device *MPU9250_SPI_interface(int bus, uint32_t cs, bool external_bus);
-extern device::Device *MPU9250_I2C_interface(int bus, uint32_t address, bool external_bus);
+extern device::Device *MPU9250_SPI_interface(int bus, int device_type, uint32_t cs, bool external_bus);
+extern device::Device *MPU9250_I2C_interface(int bus, int device_type, uint32_t address, bool external_bus);
 extern int MPU9250_probe(device::Device *dev, int device_type);
 
-typedef device::Device *(*MPU9250_constructor)(int, uint32_t, bool);
+typedef device::Device *(*MPU9250_constructor)(int, int, uint32_t, bool);
 
 class MPU9250_mag;
 class MPU9250_gyro;
@@ -245,7 +386,9 @@ class MPU9250 : public device::CDev
 public:
 	MPU9250(device::Device *interface, device::Device *mag_interface, const char *path_accel, const char *path_gyro,
 		const char *path_mag,
-		enum Rotation rotation);
+		enum Rotation rotation,
+		int device_type,
+		bool magnetometer_only);
 	virtual ~MPU9250();
 
 	virtual int		init();
@@ -278,6 +421,10 @@ private:
 	MPU9250_gyro	*_gyro;
 	MPU9250_mag     *_mag;
 	uint8_t			_whoami;	/** whoami result */
+	int 			_device_type;
+	uint8_t 		_selected_bank;			/* Remember selected memory bank to avoid polling / setting on each read/write */
+	bool
+	_magnetometer_only;     /* To disable accel and gyro reporting if only magnetometer is used (e.g. as external magnetometer) */
 
 #if defined(USE_I2C)
 	/*
@@ -307,6 +454,8 @@ private:
 	float			_gyro_range_rad_s;
 
 	unsigned		_dlpf_freq;
+	unsigned		_dlpf_freq_icm_gyro;
+	unsigned		_dlpf_freq_icm_accel;
 
 	unsigned		_sample_rate;
 	perf_counter_t		_accel_reads;
@@ -336,16 +485,28 @@ private:
 	// this is used to support runtime checking of key
 	// configuration registers to detect SPI bus errors and sensor
 	// reset
+
+#ifndef MAX
+#define MAX(X,Y) ((X) > (Y) ? (X) : (Y))
+#endif
+
 #define MPU9250_NUM_CHECKED_REGISTERS 11
-	static const uint8_t	_checked_registers[MPU9250_NUM_CHECKED_REGISTERS];
-	uint8_t			_checked_values[MPU9250_NUM_CHECKED_REGISTERS];
-	uint8_t			_checked_bad[MPU9250_NUM_CHECKED_REGISTERS];
-	uint8_t			_checked_next;
+	static const uint16_t	_mpu9250_checked_registers[MPU9250_NUM_CHECKED_REGISTERS];
+#define ICM20948_NUM_CHECKED_REGISTERS 15
+	static const uint16_t	_icm20948_checked_registers[ICM20948_NUM_CHECKED_REGISTERS];
+
+	const uint16_t			*_checked_registers;
+
+	uint8_t					_checked_values[MAX(MPU9250_NUM_CHECKED_REGISTERS, ICM20948_NUM_CHECKED_REGISTERS)];
+	uint8_t					_checked_bad[MAX(MPU9250_NUM_CHECKED_REGISTERS, ICM20948_NUM_CHECKED_REGISTERS)];
+	unsigned				_checked_next;
+	unsigned				_num_checked_registers;
+
 
 	// last temperature reading for print_info()
 	float			_last_temperature;
 
-	bool check_null_data(uint32_t *data, uint8_t size);
+	bool check_null_data(uint16_t *data, uint8_t size);
 	bool check_duplicate(uint8_t *accel_data);
 	// keep last accel reading for duplicate detection
 	uint8_t			_last_accel_data[6];
@@ -426,13 +587,38 @@ private:
 	void			measure();
 
 	/**
+	 * Select a register bank in ICM20948
+	 *
+	 * Only actually switches if the remembered bank is different from the
+	 * requested one
+	 *
+	 * @param		The index of the register bank to switch to (0-3)
+	 * @return		Error code
+	 */
+	int				select_register_bank(uint8_t bank);
+
+
+	/**
 	 * Read a register from the mpu
 	 *
 	 * @param		The register to read.
+	* @param       The bus speed to read with.
 	 * @return		The value that was read.
 	 */
 	uint8_t			read_reg(unsigned reg, uint32_t speed = MPU9250_LOW_BUS_SPEED);
 	uint16_t		read_reg16(unsigned reg);
+
+
+	/**
+	 * Read a register range from the mpu
+	 *
+	 * @param       The start address to read from.
+	 * @param       The bus speed to read with.
+	 * @param       The address of the target data buffer.
+	 * @param       The count of bytes to be read.
+	 * @return      The value that was read.
+	 */
+	uint8_t read_reg_range(unsigned start_reg, uint32_t speed, uint8_t *buf, uint16_t count);
 
 	/**
 	 * Write a register in the mpu

--- a/src/drivers/imu/mpu9250/mpu9250.h
+++ b/src/drivers/imu/mpu9250/mpu9250.h
@@ -396,7 +396,6 @@ public:
 	virtual int		init();
 
 	virtual ssize_t		accel_read(struct file *filp, char *buffer, size_t buflen);
-	virtual int		accel_ioctl(struct file *filp, int cmd, unsigned long arg);
 
 	/**
 	 * Diagnostics - print some basic information about the driver.
@@ -421,7 +420,6 @@ protected:
 	friend class MPU9250_gyro;
 
 	virtual ssize_t		gyro_read(struct file *filp, char *buffer, size_t buflen);
-	virtual int		gyro_ioctl(struct file *filp, int cmd, unsigned long arg);
 
 private:
 	MPU9250_accel   *_accel;

--- a/src/drivers/imu/mpu9250/mpu9250.h
+++ b/src/drivers/imu/mpu9250/mpu9250.h
@@ -391,35 +391,24 @@ public:
 		enum Rotation rotation,
 		int device_type,
 		bool magnetometer_only);
+
 	virtual ~MPU9250();
 
 	virtual int		init();
-
-	virtual ssize_t		accel_read(struct file *filp, char *buffer, size_t buflen);
 
 	/**
 	 * Diagnostics - print some basic information about the driver.
 	 */
 	void			print_info();
 
-	void			print_registers();
-
-	// deliberately cause a sensor error
-	void 			test_error();
-
 protected:
 	device::Device *_interface;
-
-	const char  *_name;
-	bool        _debug_enabled{false};
 
 	virtual int		probe();
 
 	friend class MPU9250_accel;
 	friend class MPU9250_mag;
 	friend class MPU9250_gyro;
-
-	virtual ssize_t		gyro_read(struct file *filp, char *buffer, size_t buflen);
 
 private:
 	MPU9250_accel   *_accel;
@@ -436,11 +425,11 @@ private:
 	 * SPI bus based device use hrt
 	 * I2C bus needs to use work queue
 	 */
-	work_s			_work;
+	work_s			_work{};
 #endif
 	bool 			_use_hrt;
 
-	struct hrt_call		_call;
+	struct hrt_call		_call {};
 	unsigned		_call_interval;
 
 	ringbuffer::RingBuffer	*_accel_reports;
@@ -680,13 +669,6 @@ private:
 	 * @return true if the sensor is not on the main MCU board
 	 */
 	bool			is_external() { return _interface->external(); }
-
-	/**
-	 * Measurement self test
-	 *
-	 * @return 0 on success, 1 on failure
-	 */
-	int 			self_test();
 
 	/*
 	  set low pass filter frequency

--- a/src/drivers/imu/mpu9250/mpu9250_i2c.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250_i2c.cpp
@@ -46,30 +46,34 @@
 
 #ifdef USE_I2C
 
-device::Device *MPU9250_I2C_interface(int bus, uint32_t address, bool external_bus);
+device::Device *MPU9250_I2C_interface(int bus, int device_type, uint32_t address, bool external_bus);
 
 class MPU9250_I2C : public device::I2C
 {
 public:
-	MPU9250_I2C(int bus, uint32_t address);
+	MPU9250_I2C(int bus, int device_type, uint32_t address);
 	~MPU9250_I2C() override = default;
 
 	int	read(unsigned address, void *data, unsigned count) override;
 	int	write(unsigned address, void *data, unsigned count) override;
 
 protected:
-	int	probe() override;
+	virtual int	probe();
+
+private:
+	int 		_device_type;
 
 };
 
 device::Device *
-MPU9250_I2C_interface(int bus, uint32_t address, bool external_bus)
+MPU9250_I2C_interface(int bus, int device_type, uint32_t address, bool external_bus)
 {
-	return new MPU9250_I2C(bus, address);
+	return new MPU9250_I2C(bus, device_type, address);
 }
 
-MPU9250_I2C::MPU9250_I2C(int bus, uint32_t address) :
-	I2C("MPU9250_I2C", nullptr, bus, address, 400000)
+MPU9250_I2C::MPU9250_I2C(int bus, int device_type, uint32_t address) :
+	I2C("MPU9250_I2C", nullptr, bus, address, 400000),
+	_device_type(device_type)
 {
 	_device_id.devid_s.devtype = DRV_ACC_DEVTYPE_MPU9250;
 }
@@ -106,8 +110,34 @@ int
 MPU9250_I2C::probe()
 {
 	uint8_t whoami = 0;
-	uint8_t expected = MPU_WHOAMI_9250;
-	return (read(MPUREG_WHOAMI, &whoami, 1) == OK && (whoami == expected)) ? 0 : -EIO;
+	uint8_t reg_whoami = 0;
+	uint8_t expected = 0;
+	uint8_t register_select = REG_BANK(BANK0);  // register bank containing WHOAMI for ICM20948
+
+	switch (_device_type) {
+	case MPU_DEVICE_TYPE_MPU9250:
+		reg_whoami = MPUREG_WHOAMI;
+		expected = MPU_WHOAMI_9250;
+		break;
+
+	case MPU_DEVICE_TYPE_MPU6500:
+		reg_whoami = MPUREG_WHOAMI;
+		expected = MPU_WHOAMI_6500;
+		break;
+
+	case MPU_DEVICE_TYPE_ICM20948:
+		reg_whoami = ICMREG_20948_WHOAMI;
+		expected = ICM_WHOAMI_20948;
+		/*
+		 * make sure register bank 0 is selected - whoami is only present on bank 0, and that is
+		 * not sure e.g. if the device has rebooted without repowering the sensor
+		 */
+		write(ICMREG_20948_BANK_SEL, &register_select, 1);
+
+		break;
+	}
+
+	return (read(reg_whoami, &whoami, 1) == OK && (whoami == expected)) ? 0 : -EIO;
 }
 
 #endif /* USE_I2C */

--- a/src/drivers/imu/mpu9250/mpu9250_spi.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250_spi.cpp
@@ -63,7 +63,7 @@
 #define MPU9250_LOW_SPI_BUS_SPEED	1000*1000
 #define MPU9250_HIGH_SPI_BUS_SPEED	20*1000*1000
 
-device::Device *MPU9250_SPI_interface(int bus, uint32_t cs, bool external_bus);
+device::Device *MPU9250_SPI_interface(int bus, int device_type, uint32_t cs, bool external_bus);
 
 class MPU9250_SPI : public device::SPI
 {
@@ -84,7 +84,7 @@ private:
 };
 
 device::Device *
-MPU9250_SPI_interface(int bus, uint32_t cs, bool external_bus)
+MPU9250_SPI_interface(int bus, int device_type, uint32_t cs, bool external_bus)
 {
 	device::Device *interface = nullptr;
 


### PR DESCRIPTION
I condensed the history of #9362 in this new PR to make a clear review of the changes easier and get up to date with the master branch.

The data delivered by the ICM looks good. Set Rotation 6/270° Yaw for the external magnetometer for a Here GNSS mounted in flight direction (I kept the chips own coordinate system to not obfuscate it by rotating it fitting to a specific device). rc.sensors is modified to activate the whole IMU in the Here GNSS (on Pixhawk 2/2.1) for testing purposes. To use only the magnetometer: mpu9250 -X -R 6 -M start

I'm thinking about improvements to the bus_options[] array and the associated bulk of device path definitions - they increased a lot with the new bus options added through the master branch while I was working on this. I would still need to add some to make the set complete. In the end the path strings are redundant information in bus_options[] and can be generated from bus, bus type and device type.

I'll add a test flight log as soon as possible.