### PR TITLE
Ethernet : Added support in ethernet

### DIFF
--- a/src/modules/network_manager/CMakeLists.txt
+++ b/src/modules/network_manager/CMakeLists.txt
@@ -1,0 +1,41 @@
+############################################################################
+#
+#   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+px4_add_module(
+	MODULE modules__network_manager
+	MAIN network_manager
+	STACK_MAIN 1200
+	COMPILE_FLAGS
+	SRCS
+		network_manager_main.cpp
+	DEPENDS
+	)

--- a/src/modules/network_manager/network_manager_main.cpp
+++ b/src/modules/network_manager/network_manager_main.cpp
@@ -1,0 +1,179 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "network_manager_main.h"
+
+#define NET_DEVNAME "eth0"
+
+extern "C" __EXPORT int network_manager_main(int argc, char *argv[]);
+
+//Network_manager class single instance
+NetworkManager *_network_manager_instance = nullptr;
+
+
+void NetworkManager::start()
+{
+	_network_manager_instance = new NetworkManager();
+
+	if (_network_manager_instance == nullptr) {
+		warnx("Out of memory");
+
+	} else {
+		struct network_manager_param_handles network_manager_param_handles = {0};
+		struct network_manager_params network_manager_params = {0};
+
+		_network_manager_instance->param_init(&network_manager_param_handles);
+		_network_manager_instance->param_update(&network_manager_param_handles, &network_manager_params);
+
+		_network_manager_instance->set_gateway_addr(&network_manager_params);
+		_network_manager_instance->set_ip_addr(&network_manager_params);
+		_network_manager_instance->set_netmask_addr(&network_manager_params);
+
+		//set mac address will only take effect after ifup
+		netlib_ifdown(NET_DEVNAME);
+		_network_manager_instance->set_mac_addr(&network_manager_params);
+		netlib_ifup(NET_DEVNAME);
+	}
+
+	if (_network_manager_instance != nullptr) {
+		delete _network_manager_instance;
+		_network_manager_instance = nullptr;
+	}
+}
+
+//get handles to network parameters
+void NetworkManager::param_init(struct network_manager_param_handles *h)
+{
+	h->ip_addr = param_find("ETH_IP_ADDR");
+
+	h->sub_pref_s = param_find("ETH_SUB_PREF_S");
+
+	h->gateway = param_find("ETH_GATEWAY");
+
+	h->mac_addr_0 = param_find("ETH_MAC_ADDR_0");
+	h->mac_addr_1 = param_find("ETH_MAC_ADDR_1");
+	h->mac_addr_2 = param_find("ETH_MAC_ADDR_2");
+	h->mac_addr_3 = param_find("ETH_MAC_ADDR_3");
+	h->mac_addr_4 = param_find("ETH_MAC_ADDR_4");
+	h->mac_addr_5 = param_find("ETH_MAC_ADDR_5");
+}
+
+//update attributes according to network parameters
+void NetworkManager::param_update(const struct network_manager_param_handles *h, struct network_manager_params *p)
+{
+	param_get(h->ip_addr, &(p->ip_addr));
+
+	param_get(h->sub_pref_s, &(p->sub_pref_s));
+
+	param_get(h->gateway, &(p->gateway));
+
+	param_get(h->mac_addr_0, &(p->mac_addr[0]));
+	param_get(h->mac_addr_1, &(p->mac_addr[1]));
+	param_get(h->mac_addr_2, &(p->mac_addr[2]));
+	param_get(h->mac_addr_3, &(p->mac_addr[3]));
+	param_get(h->mac_addr_4, &(p->mac_addr[4]));
+	param_get(h->mac_addr_5, &(p->mac_addr[5]));
+}
+
+void NetworkManager::set_mac_addr(const struct network_manager_params *p)
+{
+	uint8_t u8mac_addr[6];
+
+	u8mac_addr[0] = p->mac_addr[0] & 0xFF;
+	u8mac_addr[1] = p->mac_addr[1] & 0xFF;
+	u8mac_addr[2] = p->mac_addr[2] & 0xFF;
+	u8mac_addr[3] = p->mac_addr[3] & 0xFF;
+	u8mac_addr[4] = p->mac_addr[4] & 0xFF;
+	u8mac_addr[5] = p->mac_addr[5] & 0xFF;
+
+	netlib_setmacaddr(NET_DEVNAME, u8mac_addr);
+}
+
+void NetworkManager::set_ip_addr(const struct network_manager_params *p)
+{
+	struct in_addr addr;
+
+	addr.s_addr = HTONL(p->ip_addr);
+	netlib_set_ipv4addr(NET_DEVNAME, &addr);
+}
+
+void NetworkManager::set_netmask_addr(const struct network_manager_params *p)
+{
+	struct in_addr addr;
+
+	uint32_t unetmask = ~(0xFFFFFFFF & ((1 << (32 - p->sub_pref_s)) - 1));
+
+	addr.s_addr = HTONL(unetmask);
+	netlib_set_ipv4netmask(NET_DEVNAME, &addr);
+}
+
+void NetworkManager::set_gateway_addr(const struct network_manager_params *p)
+{
+	struct in_addr addr;
+
+	addr.s_addr = HTONL(p->gateway);
+	netlib_set_dripv4addr(NET_DEVNAME, &addr);
+}
+
+int network_manager_main(int argc, char *argv[])
+{
+	//No command
+	if (argc < 2) {
+		PX4_INFO("usage : Network manager {start|status}");
+		return 1;
+	}
+
+	if (!strcmp(argv[1], "status")) {
+		if (!_network_manager_instance) {
+			PX4_INFO("Network manager not running");
+			return 1;
+		}
+
+		PX4_INFO("Network manager is running");
+		return 0;
+
+	} else if (!strcmp(argv[1], "start")) {
+		if (_network_manager_instance) {
+			PX4_INFO("Network manager already running");
+			return 1;
+		}
+
+		NetworkManager::start();
+
+		return 0;
+	}
+
+	//Unrecognized command
+	PX4_INFO("usage : Network manager {start|status}");
+	return 1;
+}

--- a/src/modules/network_manager/network_manager_main.h
+++ b/src/modules/network_manager/network_manager_main.h
@@ -1,0 +1,82 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <px4_config.h>					//Configuration flags used in code
+#include <px4_defines.h>				//Generally used magic defines
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <uORB/uORB.h>					//API for the uORB lightweight object broker
+#include <systemlib/err.h>				//Simple error/warning functions
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include "netutils/netlib.h"
+
+struct network_manager_param_handles {
+	param_t ip_addr;
+	param_t sub_pref_s;
+	param_t gateway;
+	param_t mac_addr_0, mac_addr_1, mac_addr_2, mac_addr_3, mac_addr_4, mac_addr_5;
+};	//network parameters handles
+
+struct network_manager_params {
+	int32_t ip_addr;
+	int32_t sub_pref_s;
+	int32_t gateway;
+	int32_t mac_addr[6];
+};	//network attributes
+
+
+class NetworkManager
+{
+private:
+	NetworkManager() {;}
+
+	NetworkManager(const NetworkManager &);
+	NetworkManager operator=(const NetworkManager &);
+
+	void param_init(struct network_manager_param_handles *h);
+	void param_update(const struct network_manager_param_handles *h, struct network_manager_params *p);
+	void set_mac_addr(const struct network_manager_params *p);
+	void set_ip_addr(const struct network_manager_params *p);
+	void set_netmask_addr(const struct network_manager_params *p);
+	void set_gateway_addr(const struct network_manager_params *p);
+
+public:
+	~NetworkManager() {;}
+
+	static void start();
+};

--- a/src/modules/network_manager/network_params.c
+++ b/src/modules/network_manager/network_params.c
@@ -1,0 +1,124 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file network_params.c
+ * Parameter definition for network.
+ *
+ */
+
+
+/**
+ * Board Unique MAC Address byte #0
+ * Address is read by MAC EEPROM from the board and should be not modified by user
+ *
+ * @group Ethernet
+ * @min 0
+ * @max 255
+ */
+PARAM_DEFINE_INT32(ETH_MAC_ADDR_0, 0);
+
+/**
+ * Board Unique MAC Address byte #1
+ * Address is read by MAC EEPROM from the board and should be not modified by user
+ *
+ * @group Ethernet
+ * @min 0
+ * @max 255
+ */
+PARAM_DEFINE_INT32(ETH_MAC_ADDR_1, 0);
+
+/**
+ * Board Unique MAC Address byte #2
+ * Address is read by MAC EEPROM from the board and should be not modified by user
+ *
+ * @group Ethernet
+ * @min 0
+ * @max 255
+ */
+PARAM_DEFINE_INT32(ETH_MAC_ADDR_2, 0);
+
+/**
+ * Board Unique MAC Address byte #3
+ * Address is read by MAC EEPROM from the board and should be not modified by user
+ *
+ * @group Ethernet
+ * @min 0
+ * @max 255
+ */
+PARAM_DEFINE_INT32(ETH_MAC_ADDR_3, 0);
+
+/**
+ * Board Unique MAC Address byte #4
+ * Address is read by MAC EEPROM from the board and should be not modified by user
+ *
+ * @group Ethernet
+ * @min 0
+ * @max 255
+ */
+PARAM_DEFINE_INT32(ETH_MAC_ADDR_4, 0);
+
+/**
+ * Board Unique MAC Address byte #5
+ * Address is read by MAC EEPROM from the board and should be not modified by user
+ *
+ * @group Ethernet
+ * @min 0
+ * @max 255
+ */
+PARAM_DEFINE_INT32(ETH_MAC_ADDR_5, 0);
+
+/**
+ * Board IP Address
+ *
+ * @group Ethernet
+ *
+ */
+PARAM_DEFINE_INT32(ETH_IP_ADDR, -1062731775);
+
+/**
+ * Board NETMASK Address byte #0
+ *
+ * @group Ethernet
+ * @min 0
+ * @max 32
+ */
+PARAM_DEFINE_INT32(ETH_SUB_PREF_S, 24);
+
+/**
+ * Board GATEWAY Address
+ *
+ * @group Ethernet
+ *
+ */
+PARAM_DEFINE_INT32(ETH_GATEWAY, 0);


### PR DESCRIPTION
-new network_manager module gives the ability to control Ethernet related (as ip,mac and etc...) through parameters

**Additional context**
-To use network_manager in rcS add the line "network_manager start" before mavlink