### PR TITLE
Some IO/mixer updates

### DIFF
--- a/src/lib/mixer/mixer.h
+++ b/src/lib/mixer/mixer.h
@@ -461,12 +461,12 @@ public:
 	virtual void 			set_offset(float trim) {}
 	unsigned set_trim(float trim)
 	{
-		return 0;
+		return 1;
 	}
 
 	unsigned get_trim(float *trim)
 	{
-		return 0;
+		return 1;
 	}
 
 };
@@ -783,7 +783,7 @@ public:
 
 	unsigned get_trim(float *trim)
 	{
-		return 0;
+		return 4;
 	}
 
 private:

--- a/src/lib/mixer/mixer_helicopter.cpp
+++ b/src/lib/mixer/mixer_helicopter.cpp
@@ -65,22 +65,9 @@ HelicopterMixer::from_text(Mixer::ControlCallback control_cb, uintptr_t cb_handl
 	int s[5];
 	int used;
 
-	/* enforce that the mixer ends with space or a new line */
-	for (int i = buflen - 1; i >= 0; i--) {
-		if (buf[i] == '\0') {
-			continue;
-		}
-
-		/* require a space or newline at the end of the buffer, fail on printable chars */
-		if (buf[i] == ' ' || buf[i] == '\n' || buf[i] == '\r') {
-			/* found a line ending or space, so no split symbols / numbers. good. */
-			break;
-
-		} else {
-			debug("simple parser rejected: No newline / space at end of buf. (#%d/%d: 0x%02x)", i, buflen - 1, buf[i]);
-			return nullptr;
-		}
-
+	/* enforce that the mixer ends with a new line */
+	if (!string_well_formed(buf, buflen)) {
+		return nullptr;
 	}
 
 	if (sscanf(buf, "H: %u%n", &swash_plate_servo_count, &used) != 1) {

--- a/src/modules/px4iofirmware/px4io.h
+++ b/src/modules/px4iofirmware/px4io.h
@@ -154,6 +154,7 @@ struct sys_state_s {
 extern struct sys_state_s system_state;
 extern float dt;
 extern bool update_mc_thrust_param;
+extern bool update_trims;
 
 /*
  * PWM limit structure

--- a/src/modules/px4iofirmware/registers.c
+++ b/src/modules/px4iofirmware/registers.c
@@ -688,24 +688,9 @@ registers_set_one(uint8_t page, uint8_t offset, uint16_t value)
 
 			break;
 
-		case PX4IO_P_SETUP_PWM_REVERSE:
-			r_page_setup[PX4IO_P_SETUP_PWM_REVERSE] = value;
-			break;
-
-		case PX4IO_P_SETUP_TRIM_ROLL:
-		case PX4IO_P_SETUP_TRIM_PITCH:
-		case PX4IO_P_SETUP_TRIM_YAW:
-		case PX4IO_P_SETUP_SCALE_ROLL:
-		case PX4IO_P_SETUP_SCALE_PITCH:
-		case PX4IO_P_SETUP_SCALE_YAW:
-		case PX4IO_P_SETUP_MOTOR_SLEW_MAX:
 		case PX4IO_P_SETUP_SBUS_RATE:
 			r_page_setup[offset] = value;
 			sbus1_set_output_rate_hz(value);
-			break;
-
-		case PX4IO_P_SETUP_AIRMODE:
-			r_page_setup[PX4IO_P_SETUP_AIRMODE] = value;
 			break;
 
 		case PX4IO_P_SETUP_THR_MDL_FAC:
@@ -713,8 +698,17 @@ registers_set_one(uint8_t page, uint8_t offset, uint16_t value)
 			r_page_setup[offset] = value;
 			break;
 
+		case PX4IO_P_SETUP_PWM_REVERSE:
+		case PX4IO_P_SETUP_TRIM_ROLL:
+		case PX4IO_P_SETUP_TRIM_PITCH:
+		case PX4IO_P_SETUP_TRIM_YAW:
+		case PX4IO_P_SETUP_SCALE_ROLL:
+		case PX4IO_P_SETUP_SCALE_PITCH:
+		case PX4IO_P_SETUP_SCALE_YAW:
+		case PX4IO_P_SETUP_MOTOR_SLEW_MAX:
+		case PX4IO_P_SETUP_AIRMODE:
 		case PX4IO_P_SETUP_THERMAL:
-			r_page_setup[PX4IO_P_SETUP_THERMAL] = value;
+			r_page_setup[offset] = value;
 			break;
 
 		default:

--- a/src/modules/px4iofirmware/registers.c
+++ b/src/modules/px4iofirmware/registers.c
@@ -58,6 +58,8 @@ static int	registers_set_one(uint8_t page, uint8_t offset, uint16_t value);
 static void	pwm_configure_rates(uint16_t map, uint16_t defaultrate, uint16_t altrate);
 
 bool update_mc_thrust_param;
+bool update_trims;
+
 /**
  * PAGE 0
  *
@@ -404,6 +406,8 @@ registers_set(uint8_t page, uint8_t offset, const uint16_t *values, unsigned num
 			num_values--;
 			values++;
 		}
+
+		update_trims = true;
 
 		break;
 


### PR DESCRIPTION
- fixes setting/getting trims with heli and null mixers
- fixes sbus output rate update (was called when setting other registers)
- (nice to have) only sets trims when changed, re-use global check function in heli mixer

See single commits