### PR TITLE
GPS: fix heading offset & baudrate param

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -618,6 +618,14 @@ GPS::run()
 		param_get(handle, &gps_ubx_dynmodel);
 	}
 
+	int32_t configured_baudrate = 0; // auto-detect
+	handle = param_find("SER_GPS1_BAUD");
+
+	if (handle != PARAM_INVALID) {
+		param_get(handle, &configured_baudrate);
+	}
+
+
 	_orb_inject_data_fd = orb_subscribe(ORB_ID(gps_inject_data));
 
 	initializeCommunicationDump();
@@ -686,7 +694,7 @@ GPS::run()
 				break;
 			}
 
-			_baudrate = 0; // auto-detect
+			_baudrate = configured_baudrate;
 
 			if (_helper && _helper->configure(_baudrate, GPSHelper::OutputMode::GPS) == 0) {
 

--- a/src/drivers/gps/params.c
+++ b/src/drivers/gps/params.c
@@ -85,3 +85,22 @@ PARAM_DEFINE_INT32(GPS_UBX_DYNMODEL, 7);
  * @group GPS
  */
 PARAM_DEFINE_FLOAT(GPS_YAW_OFFSET, 0.f);
+
+
+/**
+ * GPS Baudrate
+ *
+ * Configure the Baudrate for the GPS Serial Port. In most cases this can be set to Auto.
+ *
+ * The Trimble MB-Two GPS does not support auto-detection and uses a baudrate of 115200.
+ *
+ * @value 0 Auto
+ * @value 9600 9600 8N1
+ * @value 19200 19200 8N1
+ * @value 38400 38400 8N1
+ * @value 57600 57600 8N1
+ * @value 115200 115200 8N1
+ * @reboot_required true
+ * @group GPS
+ */
+PARAM_DEFINE_INT32(SER_GPS1_BAUD, 0);


### PR DESCRIPTION
- the gps heading offset used the wrong sign
- add a param for the GPS baudrate, because the Trimble MB-Two does not get detected reliably when changing the baudrate.