### PR TITLE
[WIP] Avoidance feedback

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -80,6 +80,7 @@ set(msg_files
 	optical_flow.msg
 	parameter_update.msg
 	ping.msg
+	position_controller_status.msg
 	position_setpoint.msg
 	position_setpoint_triplet.msg
 	power_button_state.msg
@@ -119,6 +120,7 @@ set(msg_files
 	vehicle_attitude_setpoint.msg
 	vehicle_command.msg
 	vehicle_command_ack.msg
+	vehicle_constraints.msg
 	vehicle_control_mode.msg
 	vehicle_global_position.msg
 	vehicle_gps_position.msg
@@ -133,7 +135,6 @@ set(msg_files
 	vehicle_trajectory_waypoint.msg
 	vtol_vehicle_status.msg
 	wind_estimate.msg
-	vehicle_constraints.msg
 	)
 
 if(NOT EXTERNAL_MODULES_LOCATION STREQUAL "")

--- a/msg/fw_pos_ctrl_status.msg
+++ b/msg/fw_pos_ctrl_status.msg
@@ -5,9 +5,7 @@ float32 nav_bearing
 float32 target_bearing
 float32 wp_dist
 float32 xtrack_error
-float32 turn_distance		# the optimal distance to a waypoint to switch to the next
 
 float32 landing_horizontal_slope_displacement
 float32 landing_slope_angle_rad
 float32 landing_flare_length
-bool abort_landing

--- a/msg/position_controller_status.msg
+++ b/msg/position_controller_status.msg
@@ -1,0 +1,6 @@
+
+float32 acceptance_radius		# the optimal distance to a waypoint to switch to the next
+
+float32 yaw_acceptance			# NaN if not set
+
+bool abort_landing				# true if landing should be aborted

--- a/msg/position_controller_status.msg
+++ b/msg/position_controller_status.msg
@@ -3,4 +3,6 @@ float32 acceptance_radius		# the optimal distance to a waypoint to switch to the
 
 float32 yaw_acceptance			# NaN if not set
 
+float32 altitude_acceptance_radius # the optimal vertical distance to a waypoint to switch to the next
+
 bool abort_landing				# true if landing should be aborted

--- a/src/lib/FlightTasks/FlightTasks.cpp
+++ b/src/lib/FlightTasks/FlightTasks.cpp
@@ -47,6 +47,17 @@ const vehicle_constraints_s FlightTasks::getConstraints()
 	}
 }
 
+const vehicle_trajectory_waypoint_s FlightTasks::getAvoidanceWaypoint()
+{
+
+	if (isAnyTaskActive()) {
+		return _current_task.task->getAvoidanceWaypoint();
+
+	} else {
+		return FlightTask::empty_trajectory_waypoint;
+	}
+}
+
 int FlightTasks::_initTask(FlightTaskIndex task_index)
 {
 

--- a/src/lib/FlightTasks/FlightTasks.cpp
+++ b/src/lib/FlightTasks/FlightTasks.cpp
@@ -58,6 +58,12 @@ const vehicle_trajectory_waypoint_s FlightTasks::getAvoidanceWaypoint()
 	}
 }
 
+const vehicle_trajectory_waypoint_s FlightTasks::getEmptyAvoidanceWaypoint()
+{
+
+	return FlightTask::empty_trajectory_waypoint;
+}
+
 int FlightTasks::_initTask(FlightTaskIndex task_index)
 {
 

--- a/src/lib/FlightTasks/FlightTasks.cpp
+++ b/src/lib/FlightTasks/FlightTasks.cpp
@@ -49,7 +49,6 @@ const vehicle_constraints_s FlightTasks::getConstraints()
 
 const vehicle_trajectory_waypoint_s FlightTasks::getAvoidanceWaypoint()
 {
-
 	if (isAnyTaskActive()) {
 		return _current_task.task->getAvoidanceWaypoint();
 
@@ -60,7 +59,6 @@ const vehicle_trajectory_waypoint_s FlightTasks::getAvoidanceWaypoint()
 
 const vehicle_trajectory_waypoint_s FlightTasks::getEmptyAvoidanceWaypoint()
 {
-
 	return FlightTask::empty_trajectory_waypoint;
 }
 

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -110,6 +110,12 @@ public:
 	const vehicle_trajectory_waypoint_s getAvoidanceWaypoint();
 
 	/**
+	 * Get empty avoidance desired waypoints
+	 * @return empty triplets in the mc_pos_control
+	 */
+	const vehicle_trajectory_waypoint_s getEmptyAvoidanceWaypoint();
+
+	/**
 	 * Switch to the next task in the available list (for testing)
 	 * @return 1 on success, <0 on error
 	 */

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -104,6 +104,12 @@ public:
 	const vehicle_constraints_s getConstraints();
 
 	/**
+	 * Get task avoidance desired waypoints
+	 * @return auto triplets in the mc_pos_control
+	 */
+	const vehicle_trajectory_waypoint_s getAvoidanceWaypoint();
+
+	/**
 	 * Switch to the next task in the available list (for testing)
 	 * @return 1 on success, <0 on error
 	 */

--- a/src/lib/FlightTasks/tasks/FlightTask.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.cpp
@@ -5,7 +5,17 @@
 constexpr uint64_t FlightTask::_timeout;
 // First index of empty_setpoint corresponds to time-stamp and requires a finite number.
 const vehicle_local_position_setpoint_s FlightTask::empty_setpoint = {0, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, {NAN, NAN, NAN}};
+
 const vehicle_constraints_s FlightTask::empty_constraints = {0, NAN, NAN, NAN, NAN, NAN, NAN, NAN, vehicle_constraints_s::GEAR_KEEP, {}};
+const vehicle_trajectory_waypoint_s FlightTask::empty_trajectory_waypoint = {0, 0, {0, 0, 0, 0, 0, 0, 0},
+	{	{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false},
+		{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false},
+		{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false},
+		{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false},
+		{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false}
+	}
+};
+
 bool FlightTask::initializeSubscriptions(SubscriptionArray &subscription_array)
 {
 	if (!subscription_array.get(ORB_ID(vehicle_local_position), _sub_vehicle_local_position)) {
@@ -69,6 +79,7 @@ void FlightTask::_resetSetpoints()
 	_acceleration_setpoint *= NAN;
 	_thrust_setpoint *= NAN;
 	_yaw_setpoint = _yawspeed_setpoint = NAN;
+	_desired_waypoint = FlightTask::empty_trajectory_waypoint;
 }
 
 bool FlightTask::_evaluateVehicleLocalPosition()

--- a/src/lib/FlightTasks/tasks/FlightTask.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.cpp
@@ -8,11 +8,11 @@ const vehicle_local_position_setpoint_s FlightTask::empty_setpoint = {0, NAN, NA
 
 const vehicle_constraints_s FlightTask::empty_constraints = {0, NAN, NAN, NAN, NAN, NAN, NAN, NAN, vehicle_constraints_s::GEAR_KEEP, {}};
 const vehicle_trajectory_waypoint_s FlightTask::empty_trajectory_waypoint = {0, 0, {0, 0, 0, 0, 0, 0, 0},
-	{	{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false},
-		{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false},
-		{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false},
-		{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false},
-		{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false}
+	{	{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false, {0, 0, 0}},
+		{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false, {0, 0, 0}},
+		{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false, {0, 0, 0}},
+		{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false, {0, 0, 0}},
+		{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false, {0, 0, 0}}
 	}
 };
 

--- a/src/lib/FlightTasks/tasks/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.hpp
@@ -108,6 +108,10 @@ public:
 	 */
 	const vehicle_constraints_s getConstraints() {return _constraints;};
 
+	/**
+	 * Get avoidance desired waypoint
+	 * @return desired waypoints
+	 */
 	const vehicle_trajectory_waypoint_s getAvoidanceWaypoint() {return _desired_waypoint;};
 
 	/**

--- a/src/lib/FlightTasks/tasks/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask.hpp
@@ -50,6 +50,7 @@
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_constraints.h>
 #include <uORB/topics/vehicle_attitude.h>
+#include <uORB/topics/vehicle_trajectory_waypoint.h>
 #include "../SubscriptionArray.hpp"
 
 class FlightTask : public ModuleParams
@@ -107,6 +108,8 @@ public:
 	 */
 	const vehicle_constraints_s getConstraints() {return _constraints;};
 
+	const vehicle_trajectory_waypoint_s getAvoidanceWaypoint() {return _desired_waypoint;};
+
 	/**
 	 * Empty setpoint.
 	 * All setpoints are set to NAN.
@@ -118,6 +121,12 @@ public:
 	 * All constraints are set to NAN.
 	 */
 	static const vehicle_constraints_s empty_constraints;
+
+	/**
+	 * Empty desired waypoints.
+	 * All waypoints are set to NAN.
+	 */
+	static const vehicle_trajectory_waypoint_s empty_trajectory_waypoint;
 
 	/**
 	 * Call this whenever a parameter update notification is received (parameter_update uORB message)
@@ -182,6 +191,12 @@ protected:
 	 * The constraints can vary with tasks.
 	 */
 	vehicle_constraints_s _constraints;
+
+	/**
+	 * Desired waypoints.
+	 * Goals set by the FCU to be sent to the obstacle avoidance system.
+	 */
+	vehicle_trajectory_waypoint_s _desired_waypoint;
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(ModuleParams,
 					(ParamFloat<px4::params::MPC_XY_VEL_MAX>) MPC_XY_VEL_MAX,

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
@@ -217,7 +217,9 @@ bool FlightTaskAuto::_evaluateTriplets()
 		_updateAvoidanceWaypoints();
 	}
 
-	_checkAvoidanceProgress();
+	if (MPC_OBS_AVOID.get()) {
+		_checkAvoidanceProgress();
+	}
 
 	return true;
 }

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
@@ -269,18 +269,16 @@ void FlightTaskAuto::_updateAvoidanceWaypoints()
 {
 	_desired_waypoint.timestamp = hrt_absolute_time();
 
-	_target.copyTo(_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_1].position);
+	_triplet_target.copyTo(_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_1].position);
 	Vector3f(NAN, NAN, NAN).copyTo(_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_1].velocity);
 	Vector3f(NAN, NAN, NAN).copyTo(_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_1].acceleration);
 
-	_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_1].yaw = _sub_triplet_setpoint->get().current.yaw;
-	_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_1].yaw_speed =
-		_sub_triplet_setpoint->get().current.yawspeed_valid ?
-		_sub_triplet_setpoint->get().current.yawspeed : NAN;
+	_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_1].yaw = _yaw_setpoint;
+	_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_1].yaw_speed = _yawspeed_setpoint;
 	_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_1].point_valid = true;
 
 
-	_next_wp.copyTo(_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_2].position);
+	_triplet_next_wp.copyTo(_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_2].position);
 	Vector3f(NAN, NAN, NAN).copyTo(_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_2].velocity);
 	Vector3f(NAN, NAN, NAN).copyTo(_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_2].acceleration);
 

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
@@ -289,7 +289,6 @@ void FlightTaskAuto::_updateAvoidanceWaypoints()
 		_sub_triplet_setpoint->get().next.yawspeed_valid ?
 		_sub_triplet_setpoint->get().next.yawspeed : NAN;
 	_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_2].point_valid = true;
-
 }
 
 bool FlightTaskAuto::_isFinite(const position_setpoint_s sp)

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
@@ -214,6 +214,7 @@ bool FlightTaskAuto::_evaluateTriplets()
 
 	if (triplet_update || (_current_state != previous_state)) {
 		_updateInternalWaypoints();
+		_updateAvoidanceWaypoints();
 	}
 
 	return true;
@@ -262,6 +263,33 @@ void FlightTaskAuto::_set_heading_from_mode()
 	} else {
 		_yaw_setpoint = NAN;
 	}
+}
+
+void FlightTaskAuto::_updateAvoidanceWaypoints()
+{
+	_desired_waypoint.timestamp = hrt_absolute_time();
+
+	_target.copyTo(_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_1].position);
+	Vector3f(NAN, NAN, NAN).copyTo(_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_1].velocity);
+	Vector3f(NAN, NAN, NAN).copyTo(_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_1].acceleration);
+
+	_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_1].yaw = _sub_triplet_setpoint->get().current.yaw;
+	_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_1].yaw_speed =
+		_sub_triplet_setpoint->get().current.yawspeed_valid ?
+		_sub_triplet_setpoint->get().current.yawspeed : NAN;
+	_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_1].point_valid = true;
+
+
+	_next_wp.copyTo(_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_2].position);
+	Vector3f(NAN, NAN, NAN).copyTo(_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_2].velocity);
+	Vector3f(NAN, NAN, NAN).copyTo(_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_2].acceleration);
+
+	_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_2].yaw = _sub_triplet_setpoint->get().next.yaw;
+	_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_2].yaw_speed =
+		_sub_triplet_setpoint->get().next.yawspeed_valid ?
+		_sub_triplet_setpoint->get().next.yawspeed : NAN;
+	_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_2].point_valid = true;
+
 }
 
 bool FlightTaskAuto::_isFinite(const position_setpoint_s sp)

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
@@ -217,6 +217,8 @@ bool FlightTaskAuto::_evaluateTriplets()
 		_updateAvoidanceWaypoints();
 	}
 
+	_checkAvoidanceProgress();
+
 	return true;
 }
 
@@ -287,6 +289,37 @@ void FlightTaskAuto::_updateAvoidanceWaypoints()
 		_sub_triplet_setpoint->get().next.yawspeed_valid ?
 		_sub_triplet_setpoint->get().next.yawspeed : NAN;
 	_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_2].point_valid = true;
+}
+
+void FlightTaskAuto::_checkAvoidanceProgress()
+{
+	position_controller_status_s pos_control_status = {};
+	pos_control_status.timestamp = hrt_absolute_time();
+
+	// vector from previous triplet to current target
+	Vector2f prev_to_target = Vector2f(&(_triplet_target - _triplet_prev_wp)(0));
+	// vector from previous triplet to the vehicle projected position on the line previous-target triplet
+	Vector2f prev_to_closest_pt = _closest_pt - Vector2f(&(_triplet_prev_wp)(0));
+	// fraction of the previous-tagerget line that has been flown
+	const float prev_curr_travelled = prev_to_closest_pt.length() / prev_to_target.length();
+
+	if (prev_curr_travelled > 1.0f) {
+		// if the vehicle projected position on the line previous-target is past the target waypoint,
+		// increase the target acceptance radius such that navigator will update the triplets
+		pos_control_status.acceptance_radius = Vector2f(&(_triplet_target - _position)(0)).length() + 0.5f;
+	}
+
+	// do not check for waypoints yaw acceptance in navigator
+	pos_control_status.yaw_acceptance = NAN;
+
+	if (_pub_pos_control_status == nullptr) {
+		_pub_pos_control_status = orb_advertise(ORB_ID(position_controller_status), &pos_control_status);
+
+	} else {
+		orb_publish(ORB_ID(position_controller_status), _pub_pos_control_status, &pos_control_status);
+
+	}
+
 }
 
 bool FlightTaskAuto::_isFinite(const position_setpoint_s sp)

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.cpp
@@ -309,6 +309,14 @@ void FlightTaskAuto::_checkAvoidanceProgress()
 		pos_control_status.acceptance_radius = Vector2f(&(_triplet_target - _position)(0)).length() + 0.5f;
 	}
 
+	Vector2f pos_to_target = Vector2f(&(_triplet_target - _position)(0));
+	const float pos_to_target_z = fabsf(_triplet_target(2) - _position(2));
+
+	if (pos_to_target.length() < NAV_ACC_RAD.get() && pos_to_target_z > NAV_MC_ALT_RAD.get()) {
+		// vehicle above or below the target waypoint
+		pos_control_status.altitude_acceptance_radius = pos_to_target_z + 0.5f;
+	}
+
 	// do not check for waypoints yaw acceptance in navigator
 	pos_control_status.yaw_acceptance = NAN;
 

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
@@ -43,6 +43,7 @@
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/position_setpoint.h>
 #include <uORB/topics/home_position.h>
+#include <uORB/topics/position_controller_status.h>
 #include <lib/ecl/geo/geo.h>
 
 /**
@@ -122,10 +123,13 @@ private:
 	float _reference_altitude = NAN;  /**< Altitude relative to ground. */
 	hrt_abstime _time_stamp_reference = 0; /**< time stamp when last reference update occured. */
 
+	orb_advert_t _pub_pos_control_status = nullptr; /**< Publisher for the position controller status */
+
 	bool _evaluateTriplets(); /**< Checks and sets triplets. */
 	bool _isFinite(const position_setpoint_s sp); /**< Checks if all waypoint triplets are finite. */
 	bool _evaluateGlobalReference(); /**< Check is global reference is available. */
 	float _getVelocityFromAngle(const float angle); /**< Computes the speed at target depending on angle. */
 	State _getCurrentState(); /**< Computes the current vehicle state based on the vehicle position and navigator triplets. */
 	void _set_heading_from_mode(); /**< @see  MPC_YAW_MODE */
+	void _checkAvoidanceProgress();
 };

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
@@ -104,7 +104,8 @@ protected:
 					(ParamFloat<px4::params::MPC_CRUISE_90>) MPC_CRUISE_90, // speed at corner when angle is 90 degrees move to line
 					(ParamFloat<px4::params::NAV_ACC_RAD>) NAV_ACC_RAD, // acceptance radius at which waypoints are updated move to line
 					(ParamFloat<px4::params::NAV_MC_ALT_RAD>) NAV_MC_ALT_RAD, //vertical acceptance radius at which waypoints are updated
-					(ParamInt<px4::params::MPC_YAW_MODE>) MPC_YAW_MODE // defines how heading is executed
+					(ParamInt<px4::params::MPC_YAW_MODE>) MPC_YAW_MODE, // defines how heading is executed,
+					(ParamInt<px4::params::MPC_OBS_AVOID>) MPC_OBS_AVOID // obstacle avoidance active
 				       );
 
 private:

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
@@ -103,6 +103,7 @@ protected:
 					(ParamFloat<px4::params::MPC_XY_CRUISE>) MPC_XY_CRUISE,
 					(ParamFloat<px4::params::MPC_CRUISE_90>) MPC_CRUISE_90, // speed at corner when angle is 90 degrees move to line
 					(ParamFloat<px4::params::NAV_ACC_RAD>) NAV_ACC_RAD, // acceptance radius at which waypoints are updated move to line
+					(ParamFloat<px4::params::NAV_MC_ALT_RAD>) NAV_MC_ALT_RAD, //vertical acceptance radius at which waypoints are updated
 					(ParamInt<px4::params::MPC_YAW_MODE>) MPC_YAW_MODE // defines how heading is executed
 				       );
 

--- a/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTaskAuto.hpp
@@ -84,6 +84,7 @@ protected:
 	matrix::Vector2f _getTargetVelocityXY(); /**< only used for follow-me and only here because of legacy reason.*/
 	void _updateInternalWaypoints(); /**< Depending on state of vehicle, the internal waypoints might differ from target (for instance if offtrack). */
 	bool _compute_heading_from_2D_vector(float &heading, matrix::Vector2f v); /**< Computes and sets heading a 2D vector */
+	void _updateAvoidanceWaypoints(); /**< fill desired_waypoints with the triplets. */
 
 	matrix::Vector3f _prev_prev_wp{}; /**< Pre-previous waypoint (local frame). This will be used for smoothing trajectories -> not used yet. */
 	matrix::Vector3f _prev_wp{}; /**< Previous waypoint  (local frame). If no previous triplet is available, the prev_wp is set to current position. */

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -66,11 +66,13 @@
 #include <px4_posix.h>
 #include <px4_tasks.h>
 #include <perf/perf_counter.h>
+#include <uORB/Publication.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/airspeed.h>
 #include <uORB/topics/fw_pos_ctrl_status.h>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/parameter_update.h>
+#include <uORB/topics/position_controller_status.h>
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/sensor_baro.h>
 #include <uORB/topics/sensor_bias.h>
@@ -114,6 +116,7 @@ using matrix::Quatf;
 using matrix::Vector2f;
 using matrix::Vector3f;
 
+using uORB::Publication;
 using uORB::Subscription;
 
 using namespace launchdetection;
@@ -180,6 +183,8 @@ private:
 
 	Subscription<airspeed_s> _sub_airspeed;
 	Subscription<sensor_bias_s> _sub_sensors;
+
+	Publication<position_controller_status_s> _position_controller_status_pub{ORB_ID(position_controller_status)};
 
 	perf_counter_t	_loop_perf;				///< loop performance counter */
 

--- a/src/modules/gnd_pos_control/GroundRoverPositionControl.cpp
+++ b/src/modules/gnd_pos_control/GroundRoverPositionControl.cpp
@@ -151,9 +151,6 @@ GroundRoverPositionControl::parameters_update()
 			   _parameters.gndspeed_max);
 
 	/* Update and publish the navigation capabilities */
-	_gnd_pos_ctrl_status.landing_slope_angle_rad = 0;
-	_gnd_pos_ctrl_status.landing_horizontal_slope_displacement = 0;
-	_gnd_pos_ctrl_status.landing_flare_length = 0;
 	gnd_pos_ctrl_status_publish();
 
 	return OK;
@@ -197,10 +194,10 @@ void GroundRoverPositionControl::gnd_pos_ctrl_status_publish()
 	_gnd_pos_ctrl_status.timestamp = hrt_absolute_time();
 
 	if (_gnd_pos_ctrl_status_pub != nullptr) {
-		orb_publish(ORB_ID(fw_pos_ctrl_status), _gnd_pos_ctrl_status_pub, &_gnd_pos_ctrl_status);
+		orb_publish(ORB_ID(position_controller_status), _gnd_pos_ctrl_status_pub, &_gnd_pos_ctrl_status);
 
 	} else {
-		_gnd_pos_ctrl_status_pub = orb_advertise(ORB_ID(fw_pos_ctrl_status), &_gnd_pos_ctrl_status);
+		_gnd_pos_ctrl_status_pub = orb_advertise(ORB_ID(position_controller_status), &_gnd_pos_ctrl_status);
 	}
 }
 
@@ -447,22 +444,22 @@ GroundRoverPositionControl::task_main()
 
 				/* lazily publish navigation capabilities */
 				if ((hrt_elapsed_time(&_gnd_pos_ctrl_status.timestamp) > 1000000)
-				    || (fabsf(turn_distance - _gnd_pos_ctrl_status.turn_distance) > FLT_EPSILON
+				    || (fabsf(turn_distance - _gnd_pos_ctrl_status.acceptance_radius) > FLT_EPSILON
 					&& turn_distance > 0)) {
 
 					/* set new turn distance */
-					_gnd_pos_ctrl_status.turn_distance = turn_distance;
+					_gnd_pos_ctrl_status.acceptance_radius = turn_distance;
 
-					_gnd_pos_ctrl_status.nav_roll = _gnd_control.get_roll_setpoint();
-					_gnd_pos_ctrl_status.nav_pitch = 0.0f;
-					_gnd_pos_ctrl_status.nav_bearing = _gnd_control.nav_bearing();
-
-					_gnd_pos_ctrl_status.target_bearing = _gnd_control.target_bearing();
-					_gnd_pos_ctrl_status.xtrack_error = _gnd_control.crosstrack_error();
-
-					matrix::Vector2f curr_wp((float)_pos_sp_triplet.current.lat, (float)_pos_sp_triplet.current.lon);
-					_gnd_pos_ctrl_status.wp_dist = get_distance_to_next_waypoint((double)current_position(0), (double)current_position(1),
-								       (double)curr_wp(0), (double)curr_wp(1));
+//					_gnd_pos_ctrl_status.nav_roll = _gnd_control.get_roll_setpoint();
+//					_gnd_pos_ctrl_status.nav_pitch = 0.0f;
+//					_gnd_pos_ctrl_status.nav_bearing = _gnd_control.nav_bearing();
+//
+//					_gnd_pos_ctrl_status.target_bearing = _gnd_control.target_bearing();
+//					_gnd_pos_ctrl_status.xtrack_error = _gnd_control.crosstrack_error();
+//
+//					matrix::Vector2f curr_wp((float)_pos_sp_triplet.current.lat, (float)_pos_sp_triplet.current.lon);
+//					_gnd_pos_ctrl_status.wp_dist = get_distance_to_next_waypoint((double)current_position(0), (double)current_position(1),
+//								       (double)curr_wp(0), (double)curr_wp(1));
 
 					gnd_pos_ctrl_status_publish();
 				}

--- a/src/modules/gnd_pos_control/GroundRoverPositionControl.hpp
+++ b/src/modules/gnd_pos_control/GroundRoverPositionControl.hpp
@@ -55,7 +55,7 @@
 #include <perf/perf_counter.h>
 #include <pid/pid.h>
 #include <uORB/Subscription.hpp>
-#include <uORB/topics/fw_pos_ctrl_status.h>
+#include <uORB/topics/position_controller_status.h>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/position_setpoint_triplet.h>
@@ -105,7 +105,7 @@ private:
 	int		_params_sub{-1};			/**< notification of parameter updates */
 	int		_pos_sp_triplet_sub{-1};
 
-	fw_pos_ctrl_status_s			_gnd_pos_ctrl_status{};		/**< navigation capabilities */
+	position_controller_status_s			_gnd_pos_ctrl_status{};		/**< navigation capabilities */
 	manual_control_setpoint_s		_manual{};			/**< r/c channel data */
 	position_setpoint_triplet_s		_pos_sp_triplet{};		/**< triplet of mission items */
 	vehicle_attitude_setpoint_s		_att_sp{};			/**< vehicle attitude setpoint */

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -960,13 +960,11 @@ MulticopterPositionControl::update_avoidance_waypoint_desired(PositionControlSta
 	_traj_wp_avoidance_desired.waypoints[vehicle_trajectory_waypoint_s::POINT_0].yaw = states.yaw;
 	_traj_wp_avoidance_desired.waypoints[vehicle_trajectory_waypoint_s::POINT_0].yaw_speed = NAN;
 	_traj_wp_avoidance_desired.waypoints[vehicle_trajectory_waypoint_s::POINT_0].point_valid = true;
-
 }
 
 void
 MulticopterPositionControl::execute_avoidance_waypoint()
 {
-
 	vehicle_local_position_setpoint_s setpoint;
 
 	setpoint.x = _traj_wp_avoidance.waypoints[vehicle_trajectory_waypoint_s::POINT_0].position[0];
@@ -983,7 +981,6 @@ MulticopterPositionControl::execute_avoidance_waypoint()
 	Vector3f(NAN, NAN, NAN).copyTo(setpoint.thrust);
 
 	_control.updateSetpoint(setpoint);
-
 }
 
 bool
@@ -1011,7 +1008,6 @@ MulticopterPositionControl::publish_avoidance_desired_waypoint()
 
 	//reset avoidance waypoint desired
 	_traj_wp_avoidance_desired = _flight_tasks.getEmptyAvoidanceWaypoint();
-
 }
 
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -137,7 +137,8 @@ private:
 		(ParamFloat<px4::params::MPC_LAND_ALT2>) MPC_LAND_ALT2, // altitude at which speed limit downwards reached minimum speed
 		(ParamInt<px4::params::MPC_POS_MODE>) MPC_POS_MODE,
 		(ParamInt<px4::params::MPC_ALT_MODE>) MPC_ALT_MODE,
-		(ParamFloat<px4::params::MPC_IDLE_TKO>) MPC_IDLE_TKO /**< time constant for smooth takeoff ramp */
+		(ParamFloat<px4::params::MPC_IDLE_TKO>) MPC_IDLE_TKO, /**< time constant for smooth takeoff ramp */
+		(ParamInt<px4::params::MPC_OBS_AVOID>) MPC_OBS_AVOID /**< enable obstacle avoidance */
 	);
 
 	control::BlockDerivative _vel_x_deriv; /**< velocity derivative in x */
@@ -989,7 +990,8 @@ bool
 MulticopterPositionControl::use_obstacle_avoidance()
 {
 	/* check that external obstacle avoidance is sending data and that the first point is valid */
-	return ((hrt_elapsed_time((hrt_abstime *)&_traj_wp_avoidance.timestamp) < TRAJECTORY_STREAM_TIMEOUT_US)
+	return (MPC_OBS_AVOID.get()
+		&& (hrt_elapsed_time((hrt_abstime *)&_traj_wp_avoidance.timestamp) < TRAJECTORY_STREAM_TIMEOUT_US)
 		&& (_traj_wp_avoidance.waypoints[vehicle_trajectory_waypoint_s::POINT_0].point_valid == true)
 		&& ((_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION) ||
 		    (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_RTL)));

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -153,14 +153,6 @@ private:
 	/** Timeout in us for trajectory data to get considered invalid */
 	static constexpr uint64_t TRAJECTORY_STREAM_TIMEOUT_US = 500000;
 
-	static constexpr vehicle_trajectory_waypoint_s empty_trajectory_waypoint = {0, 0, {0, 0, 0, 0, 0, 0, 0}, {{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false},
-			{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false},
-			{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false},
-			{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false},
-			{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false}
-		}
-	};
-
 	/**
 	 * Hysteresis that turns true once vehicle is armed for MPC_IDLE_TKO seconds.
 	 * A real vehicle requires some time to accelerates the propellers to IDLE speed. To ensure
@@ -1014,7 +1006,8 @@ MulticopterPositionControl::publish_avoidance_desired_waypoint()
 	}
 
 	//reset avoidance waypoint desired
-	_traj_wp_avoidance_desired = empty_trajectory_waypoint;
+	_traj_wp_avoidance_desired = _flight_tasks.getEmptyAvoidanceWaypoint();
+
 }
 
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -654,9 +654,11 @@ MulticopterPositionControl::task_main()
 			// Update states, setpoints and constraints.
 			_control.updateConstraints(constraints);
 			_control.updateState(_states);
-			_control.updateSetpoint(setpoint);
 
-			if (use_obstacle_avoidance()) {
+			if (!use_obstacle_avoidance()) {
+				_control.updateSetpoint(setpoint);
+
+			} else {
 				execute_avoidance_waypoint();
 			}
 

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -322,7 +322,7 @@ MissionBlock::is_mission_item_reached()
 
 		if ((_navigator->get_vstatus()->is_rotary_wing
 		     || (_mission_item.nav_cmd == NAV_CMD_LOITER_TO_ALT && _mission_item.force_heading))
-		    && PX4_ISFINITE(_mission_item.yaw)) {
+		    && PX4_ISFINITE(_navigator->get_yaw_acceptance(_mission_item.yaw))) {
 
 			/* check course if defined only for rotary wing except takeoff */
 			float cog = _navigator->get_vstatus()->is_rotary_wing ? _navigator->get_global_position()->yaw : atan2f(

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -395,19 +395,21 @@ MissionFeasibilityChecker::checkFixedWingLanding(const mission_s &mission, bool 
 
 				if (MissionBlock::item_contains_position(missionitem_previous)) {
 
-					const bool fw_status_valid = (_navigator->get_fw_pos_ctrl_status()->timestamp > 0);
+					uORB::Subscription<fw_pos_ctrl_status_s> fw_pos_ctrl_status{ORB_ID(fw_pos_ctrl_status)};
+
+					const bool fw_status_valid = (fw_pos_ctrl_status.get().timestamp > 0);
 					const float wp_distance = get_distance_to_next_waypoint(missionitem_previous.lat, missionitem_previous.lon,
 								  missionitem.lat, missionitem.lon);
 
-					if (fw_status_valid && (wp_distance > _navigator->get_fw_pos_ctrl_status()->landing_flare_length)) {
+					if (fw_status_valid && (wp_distance > fw_pos_ctrl_status.get().landing_flare_length)) {
 						/* Last wp is before flare region */
 
 						const float delta_altitude = missionitem.altitude - missionitem_previous.altitude;
 
 						if (delta_altitude < 0) {
 
-							const float horizontal_slope_displacement = _navigator->get_fw_pos_ctrl_status()->landing_horizontal_slope_displacement;
-							const float slope_angle_rad = _navigator->get_fw_pos_ctrl_status()->landing_slope_angle_rad;
+							const float horizontal_slope_displacement = fw_pos_ctrl_status.get().landing_horizontal_slope_displacement;
+							const float slope_angle_rad = fw_pos_ctrl_status.get().landing_slope_angle_rad;
 							const float slope_alt_req = Landingslope::getLandingSlopeAbsoluteAltitude(wp_distance, missionitem.altitude,
 										    horizontal_slope_displacement, slope_angle_rad);
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -59,11 +59,11 @@
 #include <px4_module_params.h>
 #include <px4_module.h>
 #include <perf/perf_counter.h>
-#include <uORB/topics/fw_pos_ctrl_status.h>
 #include <uORB/topics/geofence_result.h>
 #include <uORB/topics/mission.h>
 #include <uORB/topics/mission_result.h>
 #include <uORB/topics/parameter_update.h>
+#include <uORB/topics/position_controller_status.h>
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_command.h>
@@ -145,7 +145,6 @@ public:
 	/**
 	 * Getters
 	 */
-	struct fw_pos_ctrl_status_s *get_fw_pos_ctrl_status() { return &_fw_pos_ctrl_status; }
 	struct home_position_s *get_home_position() { return &_home_pos; }
 	struct mission_result_s *get_mission_result() { return &_mission_result; }
 	struct position_setpoint_triplet_s *get_position_setpoint_triplet() { return &_pos_sp_triplet; }
@@ -271,7 +270,6 @@ public:
 	bool		force_vtol();
 
 private:
-	int		_fw_pos_ctrl_status_sub{-1};	/**< notification of vehicle capabilities updates */
 	int		_global_pos_sub{-1};		/**< global position subscription */
 	int		_gps_pos_sub{-1};		/**< gps position subscription */
 	int		_home_pos_sub{-1};		/**< home position subscription */
@@ -292,7 +290,6 @@ private:
 	orb_advert_t	_vehicle_roi_pub{nullptr};
 
 	// Subscriptions
-	fw_pos_ctrl_status_s				_fw_pos_ctrl_status{};	/**< fixed wing navigation capabilities */
 	home_position_s					_home_pos{};		/**< home position for RTL */
 	mission_result_s				_mission_result{};
 	vehicle_global_position_s			_global_pos{};		/**< global vehicle position */
@@ -300,7 +297,10 @@ private:
 	vehicle_land_detected_s				_land_detected{};	/**< vehicle land_detected */
 	vehicle_local_position_s			_local_pos{};		/**< local vehicle position */
 	vehicle_status_s				_vstatus{};		/**< vehicle status */
+	uORB::Subscription<position_controller_status_s>	_position_controller_status_sub{ORB_ID(position_controller_status)};
+
 	uint8_t					_previous_nav_state{}; /**< nav_state of the previous iteration*/
+
 	// Publications
 	geofence_result_s				_geofence_result{};
 	position_setpoint_triplet_s			_pos_sp_triplet{};	/**< triplet of position setpoints */
@@ -360,7 +360,6 @@ private:
 	float _mission_throttle{-1.0f};
 
 	// update subscriptions
-	void		fw_pos_ctrl_status_update(bool force = false);
 	void		global_position_update();
 	void		gps_position_update();
 	void		home_position_update(bool force = false);

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -239,6 +239,16 @@ public:
 	 */
 	float		get_acceptance_radius(float mission_item_radius);
 
+	/**
+	 * Get the yaw acceptance given the current mission item
+	 *
+	 * @param mission_item_yaw the yaw to use in case the controller-derived radius is finite
+	 *
+	 * @return the yaw at which the next waypoint should be used or if the yaw at a waypoint
+	 * should be ignored
+	 */
+	float 		get_yaw_acceptance(float mission_item_yaw);
+
 	orb_advert_t	*get_mavlink_log_pub() { return &_mavlink_log_pub; }
 
 	void		increment_mission_instance_count() { _mission_result.instance_count++; }

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -928,6 +928,20 @@ Navigator::get_acceptance_radius(float mission_item_radius)
 	return radius;
 }
 
+float
+Navigator::get_yaw_acceptance(float mission_item_yaw)
+{
+	float yaw = mission_item_yaw;
+
+	const position_controller_status_s &pos_ctrl_status = _position_controller_status_sub.get();
+
+	if ((pos_ctrl_status.timestamp > _pos_sp_triplet.timestamp) && !PX4_ISFINITE(pos_ctrl_status.yaw_acceptance)) {
+		yaw = pos_ctrl_status.yaw_acceptance;
+	}
+
+	return yaw;
+}
+
 void
 Navigator::load_fence_from_file(const char *filename)
 {

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -844,7 +844,16 @@ Navigator::get_altitude_acceptance_radius()
 		return _param_fw_alt_acceptance_radius.get();
 
 	} else {
-		return _param_mc_alt_acceptance_radius.get();
+		float alt_acceptance_radius = _param_mc_alt_acceptance_radius.get();
+
+		const position_controller_status_s &pos_ctrl_status = _position_controller_status_sub.get();
+
+		if ((pos_ctrl_status.timestamp > _pos_sp_triplet.timestamp)
+		    && pos_ctrl_status.altitude_acceptance_radius > alt_acceptance_radius) {
+			alt_acceptance_radius = pos_ctrl_status.altitude_acceptance_radius;
+		}
+
+		return alt_acceptance_radius;
 	}
 }
 


### PR DESCRIPTION
Branch based on #10013 plus #10037 cherry-picked on top. 
- if the vehicle projected position on the line previous-current triplet is past the current triplet, the acceptance radius is enlarged such that navigator updates the triplets
- if the vehicle is within the xy acceptance radius but not inside the z one, enlarge the altitude acceptance radius such that navigator updates the triplets
- set the feedback yaw acceptance to NAN such that it is ignored by navigator

Missions shouldn't get stuck anymore because a waypoint is not reachable or a waypoint is reached with a heading different from what navigator expects