### PR TITLE
Mavlink expand telemetry_status and split radio_status

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -86,6 +86,7 @@ set(msg_files
 	pwm_input.msg
 	qshell_req.msg
 	qshell_retval.msg
+	radio_status.msg
 	rate_ctrl_status.msg
 	rc_channels.msg
 	rc_parameter_map.msg
@@ -120,6 +121,7 @@ set(msg_files
 	vehicle_attitude_setpoint.msg
 	vehicle_command.msg
 	vehicle_command_ack.msg
+	vehicle_constraints.msg
 	vehicle_control_mode.msg
 	vehicle_global_position.msg
 	vehicle_gps_position.msg
@@ -134,7 +136,6 @@ set(msg_files
 	vehicle_trajectory_waypoint.msg
 	vtol_vehicle_status.msg
 	wind_estimate.msg
-	vehicle_constraints.msg
 	)
 
 if(NOT EXTERNAL_MODULES_LOCATION STREQUAL "")

--- a/msg/radio_status.msg
+++ b/msg/radio_status.msg
@@ -1,0 +1,22 @@
+
+uint64 timestamp	# time since system start (microseconds)
+
+uint8 RADIO_TYPE_GENERIC = 0
+uint8 RADIO_TYPE_3DR_RADIO = 1
+uint8 RADIO_TYPE_UBIQUITY_BULLET = 2
+uint8 RADIO_TYPE_WIRE = 3
+uint8 RADIO_TYPE_USB = 4
+uint8 RADIO_TYPE_IRIDIUM = 5
+
+uint8 type				# type of the radio hardware
+
+uint8 rssi				# local signal strength
+uint8 remote_rssi			# remote signal strength
+
+uint8 txbuf				# how full the tx buffer is as a percentage
+uint8 noise				# background noise level
+
+uint8 remote_noise			# remote background noise level
+uint16 rxerrors				# receive errors
+
+uint16 fixed				# count of error corrected packets

--- a/msg/telemetry_status.msg
+++ b/msg/telemetry_status.msg
@@ -8,14 +8,26 @@ uint8 TELEMETRY_STATUS_RADIO_TYPE_USB = 4
 uint8 TELEMETRY_STATUS_RADIO_TYPE_IRIDIUM = 5
 
 uint64 heartbeat_time			# Time of last received heartbeat from remote system
-uint64 telem_time			# Time of last received telemetry status packet, 0 for none
+
 uint8 type				# type of the radio hardware
-uint8 rssi				# local signal strength
-uint8 remote_rssi			# remote signal strength
-uint16 rxerrors				# receive errors
-uint16 fixed				# count of error corrected packets
-uint8 noise				# background noise level
-uint8 remote_noise			# remote background noise level
-uint8 txbuf				# how full the tx buffer is as a percentage
+
 uint8 system_id				# system id of the remote system
 uint8 component_id			# component id of the remote system
+
+uint8 mode
+
+bool flow_control
+bool forwarding
+bool mavlink_v2
+bool ftp
+
+uint8 streams
+
+float32 data_rate
+
+float32 rate_multiplier
+
+float32 rate_rx
+
+float32 rate_tx
+float32 rate_txerr

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -624,11 +624,13 @@ void Logger::add_default_topics()
 	add_topic("mission_result");
 	add_topic("optical_flow", 50);
 	add_topic("position_setpoint_triplet", 200);
+	add_topic("radio_status");
 	add_topic("rate_ctrl_status", 30);
 	add_topic("sensor_combined", 100);
 	add_topic("sensor_preflight", 200);
 	add_topic("system_power", 500);
 	add_topic("tecs_status", 200);
+	add_topic("telemetry_status");
 	add_topic("vehicle_attitude", 30);
 	add_topic("vehicle_attitude_setpoint", 100);
 	add_topic("vehicle_command");

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -229,7 +229,7 @@ private:
 	orb_advert_t _att_pos_mocap_pub;
 	orb_advert_t _vision_position_pub;
 	orb_advert_t _vision_attitude_pub;
-	orb_advert_t _telemetry_status_pub;
+	orb_advert_t _radio_status_pub;
 	orb_advert_t _ping_pub;
 	orb_advert_t _rc_pub;
 	orb_advert_t _manual_pub;


### PR DESCRIPTION
I needed better insight into what mavlink is actually doing over time for debugging poor mavlink performance on various radios.

This PR adds some of the important internal state of each mavlink instance to the telemetry_status message. The existing fields corresponding only to RADIO_STATUS (https://mavlink.io/en/messages/common.html#RADIO_STATUS) from a SiK radio have been moved to a new radio_status message.

Telemetry_status now publishes continuously at 1Hz rather than only on HEARTBEAT.