### PR TITLE
Master can init in board

### DIFF
--- a/cmake/configs/nuttx_aerocore2_default.cmake
+++ b/cmake/configs/nuttx_aerocore2_default.cmake
@@ -1,7 +1,7 @@
 
 px4_nuttx_configure(HWCLASS m4 CONFIG nsh ROMFS y ROMFSROOT px4fmu_common)
 
-set(config_uavcan_num_ifaces 2)
+set(config_uavcan_num_ifaces 1)
 
 set(config_module_list
 	#

--- a/cmake/configs/nuttx_aerofc-v1_default.cmake
+++ b/cmake/configs/nuttx_aerofc-v1_default.cmake
@@ -1,8 +1,6 @@
 
 px4_nuttx_configure(HWCLASS m4 CONFIG nsh ROMFS y ROMFSROOT px4fmu_common)
 
-set(config_uavcan_num_ifaces 2)
-
 set(config_module_list
 	#
 	# Board support modules

--- a/cmake/configs/nuttx_av-x-v1_default.cmake
+++ b/cmake/configs/nuttx_av-x-v1_default.cmake
@@ -1,7 +1,7 @@
 
 px4_nuttx_configure(HWCLASS m7 CONFIG nsh ROMFS y ROMFSROOT px4fmu_common)
 
-set(config_uavcan_num_ifaces 2)
+set(config_uavcan_num_ifaces 1)
 
 set(config_module_list
 	#

--- a/cmake/configs/nuttx_omnibus-f4sd_default.cmake
+++ b/cmake/configs/nuttx_omnibus-f4sd_default.cmake
@@ -1,8 +1,6 @@
 
 px4_nuttx_configure(HWCLASS m4 CONFIG nsh ROMFS y ROMFSROOT px4fmu_common)
 
-set(config_uavcan_num_ifaces 1)
-
 set(config_module_list
 	#
 	# Board support modules

--- a/platforms/nuttx/nuttx-configs/px4fmu-v4pro/include/board.h
+++ b/platforms/nuttx/nuttx-configs/px4fmu-v4pro/include/board.h
@@ -269,47 +269,47 @@
  * The following definitions are used to access individual LEDs.
  */
 
- /* LED index values for use with board_userled() */
+/* LED index values for use with board_userled() */
 
- #define BOARD_LED1        0
- #define BOARD_LED2        1
- #define BOARD_LED3        2
- #define BOARD_NLEDS       3
+#define BOARD_LED1        0
+#define BOARD_LED2        1
+#define BOARD_LED3        2
+#define BOARD_NLEDS       3
 
- #define BOARD_LED_RED     BOARD_LED1
- #define BOARD_LED_GREEN   BOARD_LED2
- #define BOARD_LED_BLUE    BOARD_LED3
+#define BOARD_LED_RED     BOARD_LED1
+#define BOARD_LED_GREEN   BOARD_LED2
+#define BOARD_LED_BLUE    BOARD_LED3
 
- /* LED bits for use with board_userled_all() */
+/* LED bits for use with board_userled_all() */
 
- #define BOARD_LED1_BIT    (1 << BOARD_LED1)
- #define BOARD_LED2_BIT    (1 << BOARD_LED2)
- #define BOARD_LED3_BIT    (1 << BOARD_LED3)
+#define BOARD_LED1_BIT    (1 << BOARD_LED1)
+#define BOARD_LED2_BIT    (1 << BOARD_LED2)
+#define BOARD_LED3_BIT    (1 << BOARD_LED3)
 
- /* If CONFIG_ARCH_LEDS is defined, the usage by the board port is defined in
-  * include/board.h and src/stm32_leds.c. The LEDs are used to encode OS-related
-  * events as follows:
-  *
-  *
-  *   SYMBOL                     Meaning                      LED state
-  *                                                        Red   Green Blue
-  *   ----------------------  --------------------------  ------ ------ ----*/
+/* If CONFIG_ARCH_LEDS is defined, the usage by the board port is defined in
+ * include/board.h and src/stm32_leds.c. The LEDs are used to encode OS-related
+ * events as follows:
+ *
+ *
+ *   SYMBOL                     Meaning                      LED state
+ *                                                        Red   Green Blue
+ *   ----------------------  --------------------------  ------ ------ ----*/
 
- #define LED_STARTED        0 /* NuttX has been started   OFF    OFF   OFF  */
- #define LED_HEAPALLOCATE   1 /* Heap has been allocated  OFF    OFF   ON   */
- #define LED_IRQSENABLED    2 /* Interrupts enabled       OFF    ON    OFF  */
- #define LED_STACKCREATED   3 /* Idle stack created       OFF    ON    ON   */
- #define LED_INIRQ          4 /* In an interrupt          N/C    N/C   GLOW */
- #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
- #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
- #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
- #define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_STARTED        0 /* NuttX has been started   OFF    OFF   OFF  */
+#define LED_HEAPALLOCATE   1 /* Heap has been allocated  OFF    OFF   ON   */
+#define LED_IRQSENABLED    2 /* Interrupts enabled       OFF    ON    OFF  */
+#define LED_STACKCREATED   3 /* Idle stack created       OFF    ON    ON   */
+#define LED_INIRQ          4 /* In an interrupt          N/C    N/C   GLOW */
+#define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
+#define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
+#define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
+#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
 
- /* Thus if the Green LED is statically on, NuttX has successfully booted and
-  * is, apparently, running normally.  If the Red LED is flashing at
-  * approximately 2Hz, then a fatal error has been detected and the system
-  * has halted.
-  */
+/* Thus if the Green LED is statically on, NuttX has successfully booted and
+ * is, apparently, running normally.  If the Red LED is flashing at
+ * approximately 2Hz, then a fatal error has been detected and the system
+ * has halted.
+ */
 
 
 /* Alternate function pin selections ************************************************/
@@ -348,7 +348,7 @@
 /*
  * CAN
  *
- * CAN1 is routed to the onboard transceiver.
+ * CAN1 and CAN2 is routed to the onboard transceiver.
  */
 #define GPIO_CAN1_RX	GPIO_CAN1_RX_3
 #define GPIO_CAN1_TX	GPIO_CAN1_TX_3
@@ -405,14 +405,14 @@
 # define PROBE_6  (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTD|GPIO_PIN14)
 
 # define PROBE_INIT(mask) \
-  do { \
-    if ((mask)& PROBE_N(1)) { stm32_configgpio(PROBE_1); } \
-    if ((mask)& PROBE_N(2)) { stm32_configgpio(PROBE_2); } \
-    if ((mask)& PROBE_N(3)) { stm32_configgpio(PROBE_3); } \
-    if ((mask)& PROBE_N(4)) { stm32_configgpio(PROBE_4); } \
-    if ((mask)& PROBE_N(5)) { stm32_configgpio(PROBE_5); } \
-    if ((mask)& PROBE_N(6)) { stm32_configgpio(PROBE_6); } \
-  } while(0)
+	do { \
+		if ((mask)& PROBE_N(1)) { stm32_configgpio(PROBE_1); } \
+		if ((mask)& PROBE_N(2)) { stm32_configgpio(PROBE_2); } \
+		if ((mask)& PROBE_N(3)) { stm32_configgpio(PROBE_3); } \
+		if ((mask)& PROBE_N(4)) { stm32_configgpio(PROBE_4); } \
+		if ((mask)& PROBE_N(5)) { stm32_configgpio(PROBE_5); } \
+		if ((mask)& PROBE_N(6)) { stm32_configgpio(PROBE_6); } \
+	} while(0)
 
 # define PROBE(n,s)  do {stm32_gpiowrite(PROBE_##n,(s));}while(0)
 # define PROBE_MARK(n) PROBE(n,false);PROBE(n,true)

--- a/src/drivers/boards/aerocore2/init.c
+++ b/src/drivers/boards/aerocore2/init.c
@@ -150,6 +150,9 @@ __EXPORT void board_peripheral_reset(int ms)
 __EXPORT void
 stm32_boardinitialize(void)
 {
+	/* configure LEDs */
+	board_autoled_initialize();
+
 	/* configure ADC pins */
 
 	stm32_configgpio(GPIO_ADC1_IN10);	/* used by battery sense */
@@ -163,11 +166,14 @@ stm32_boardinitialize(void)
 	/* configure spektrum power controller gpio */
 	stm32_configgpio(GPIO_SPEKTRUM_PWR_EN);
 
+	/* configure CAN interface */
+
+	stm32_configgpio(GPIO_CAN1_RX);
+	stm32_configgpio(GPIO_CAN1_TX);
+
 	/* configure SPI interfaces */
 	stm32_spiinitialize();
 
-	/* configure LEDs */
-	board_autoled_initialize();
 }
 
 /****************************************************************************

--- a/src/drivers/boards/auav-x21/board_config.h
+++ b/src/drivers/boards/auav-x21/board_config.h
@@ -247,6 +247,10 @@
 /* This board provides a DMA pool and APIs */
 #define BOARD_DMA_ALLOC_POOL_SIZE 5120
 
+/* This board provides the board_on_reset interface */
+
+#define BOARD_HAS_ON_RESET 1
+
 #define BOARD_HAS_STATIC_MANIFEST 1
 
 __BEGIN_DECLS

--- a/src/drivers/boards/auav-x21/init.c
+++ b/src/drivers/boards/auav-x21/init.c
@@ -210,6 +210,11 @@ stm32_boardinitialize(void)
 	px4_arch_configgpio(GPIO_VDD_BRICK_VALID);
 	px4_arch_configgpio(GPIO_VDD_5V_PERIPH_OC);
 
+	/* configure CAN interface */
+
+	stm32_configgpio(GPIO_CAN1_RX);
+	stm32_configgpio(GPIO_CAN1_TX);
+
 	/* configure SPI interfaces */
 
 	stm32_spiinitialize();

--- a/src/drivers/boards/auav-x21/init.c
+++ b/src/drivers/boards/auav-x21/init.c
@@ -122,6 +122,37 @@ __END_DECLS
  * Public Functions
  ****************************************************************************/
 /************************************************************************************
+ * Name: board_on_reset
+ *
+ * Description:
+ * Optionally provided function called on entry to board_system_reset
+ * It should perform any house keeping prior to the rest.
+ *
+ * status - 1 if resetting to boot loader
+ *          0 if just resetting
+ *
+ ************************************************************************************/
+__EXPORT void board_on_reset(int status)
+{
+	// Configure the GPIO pins to outputs and keep them low.
+	stm32_configgpio(GPIO_GPIO0_OUTPUT);
+	stm32_configgpio(GPIO_GPIO1_OUTPUT);
+	stm32_configgpio(GPIO_GPIO2_OUTPUT);
+	stm32_configgpio(GPIO_GPIO3_OUTPUT);
+	stm32_configgpio(GPIO_GPIO4_OUTPUT);
+	stm32_configgpio(GPIO_GPIO5_OUTPUT);
+
+	/**
+	 * On resets invoked from system (not boot) insure we establish a low
+	 * output state (discharge the pins) on PWM pins before they become inputs.
+	 */
+
+	if (status >= 0) {
+		up_mdelay(400);
+	}
+}
+
+/************************************************************************************
  * Name: board_peripheral_reset
  *
  * Description:
@@ -156,6 +187,10 @@ __EXPORT void board_peripheral_reset(int ms)
 __EXPORT void
 stm32_boardinitialize(void)
 {
+	// Reset all PWM to Low outputs.
+
+	board_on_reset(-1);
+
 	/* configure LEDs */
 
 	board_autoled_initialize();
@@ -174,14 +209,6 @@ stm32_boardinitialize(void)
 	px4_arch_configgpio(GPIO_VDD_3V3_SENSORS_EN);
 	px4_arch_configgpio(GPIO_VDD_BRICK_VALID);
 	px4_arch_configgpio(GPIO_VDD_5V_PERIPH_OC);
-
-	/* configure the GPIO pins to outputs and keep them low */
-	px4_arch_configgpio(GPIO_GPIO0_OUTPUT);
-	px4_arch_configgpio(GPIO_GPIO1_OUTPUT);
-	px4_arch_configgpio(GPIO_GPIO2_OUTPUT);
-	px4_arch_configgpio(GPIO_GPIO3_OUTPUT);
-	px4_arch_configgpio(GPIO_GPIO4_OUTPUT);
-	px4_arch_configgpio(GPIO_GPIO5_OUTPUT);
 
 	/* configure SPI interfaces */
 

--- a/src/drivers/boards/av-x-v1/board_config.h
+++ b/src/drivers/boards/av-x-v1/board_config.h
@@ -401,6 +401,8 @@
 
 #define PX4_GPIO_INIT_LIST { \
 		PX4_ADC_GPIO,                     \
+		GPIO_CAN1_RX,                     \
+		GPIO_CAN1_TX,                     \
 	}
 
 __BEGIN_DECLS

--- a/src/drivers/boards/mindpx-v2/board_config.h
+++ b/src/drivers/boards/mindpx-v2/board_config.h
@@ -334,6 +334,10 @@
 
 #define BOARD_DMA_ALLOC_POOL_SIZE 5120
 
+/* This board provides the board_on_reset interface */
+
+#define BOARD_HAS_ON_RESET 1
+
 __BEGIN_DECLS
 
 /****************************************************************************************************

--- a/src/drivers/boards/mindpx-v2/init.c
+++ b/src/drivers/boards/mindpx-v2/init.c
@@ -190,6 +190,10 @@ stm32_boardinitialize(void)
 	stm32_configgpio(GPIO_SBUS_INV);
 	stm32_configgpio(GPIO_FRSKY_INV);
 
+	/* configure CAN interface */
+
+	stm32_configgpio(GPIO_CAN1_RX);
+	stm32_configgpio(GPIO_CAN1_TX);
 
 	/* configure SPI interfaces */
 

--- a/src/drivers/boards/mindpx-v2/init.c
+++ b/src/drivers/boards/mindpx-v2/init.c
@@ -118,6 +118,39 @@ __END_DECLS
 /****************************************************************************
  * Protected Functions
  ****************************************************************************/
+/************************************************************************************
+ * Name: board_on_reset
+ *
+ * Description:
+ * Optionally provided function called on entry to board_system_reset
+ * It should perform any house keeping prior to the rest.
+ *
+ * status - 1 if resetting to boot loader
+ *          0 if just resetting
+ *
+ ************************************************************************************/
+__EXPORT void board_on_reset(int status)
+{
+	/* configure the GPIO pins to outputs and keep them low */
+	stm32_configgpio(GPIO_GPIO0_OUTPUT);
+	stm32_configgpio(GPIO_GPIO1_OUTPUT);
+	stm32_configgpio(GPIO_GPIO2_OUTPUT);
+	stm32_configgpio(GPIO_GPIO3_OUTPUT);
+	stm32_configgpio(GPIO_GPIO4_OUTPUT);
+	stm32_configgpio(GPIO_GPIO5_OUTPUT);
+	stm32_configgpio(GPIO_GPIO6_OUTPUT);
+	stm32_configgpio(GPIO_GPIO7_OUTPUT);
+
+	/**
+	 * On resets invoked from system (not boot) insure we establish a low
+	 * output state (discharge the pins) on PWM pins before they become inputs.
+	 */
+
+	if (status >= 0) {
+		up_mdelay(400);
+	}
+}
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -134,34 +167,29 @@ __END_DECLS
 __EXPORT void
 stm32_boardinitialize(void)
 {
+	// Reset all PWM to Low outputs.
+
+	board_on_reset(-1);
+
 	/* configure LEDs */
 
 	board_autoled_initialize();
 
 	/* configure ADC pins */
 
-	px4_arch_configgpio(GPIO_ADC1_IN4);	/* VDD_5V_SENS */
-	px4_arch_configgpio(GPIO_ADC1_IN10);	/* BATT_CURRENT_SENS */
-	px4_arch_configgpio(GPIO_ADC1_IN12);	/* BATT_VOLTAGE_SENS */
-	px4_arch_configgpio(GPIO_ADC1_IN11);	/* RSSI analog in */
-	px4_arch_configgpio(GPIO_ADC1_IN13);	/* FMU_AUX_ADC_1 */
-	px4_arch_configgpio(GPIO_ADC1_IN14);	/* FMU_AUX_ADC_2 */
-	px4_arch_configgpio(GPIO_ADC1_IN15);	/* PRESSURE_SENS */
+	stm32_configgpio(GPIO_ADC1_IN4);	/* VDD_5V_SENS */
+	stm32_configgpio(GPIO_ADC1_IN10);	/* BATT_CURRENT_SENS */
+	stm32_configgpio(GPIO_ADC1_IN12);	/* BATT_VOLTAGE_SENS */
+	stm32_configgpio(GPIO_ADC1_IN11);	/* RSSI analog in */
+	stm32_configgpio(GPIO_ADC1_IN13);	/* FMU_AUX_ADC_1 */
+	stm32_configgpio(GPIO_ADC1_IN14);	/* FMU_AUX_ADC_2 */
+	stm32_configgpio(GPIO_ADC1_IN15);	/* PRESSURE_SENS */
 
 	/* configure power supply control/sense pins */
 
-	px4_arch_configgpio(GPIO_SBUS_INV);
-	px4_arch_configgpio(GPIO_FRSKY_INV);
+	stm32_configgpio(GPIO_SBUS_INV);
+	stm32_configgpio(GPIO_FRSKY_INV);
 
-	/* configure the GPIO pins to outputs and keep them low */
-	px4_arch_configgpio(GPIO_GPIO0_OUTPUT);
-	px4_arch_configgpio(GPIO_GPIO1_OUTPUT);
-	px4_arch_configgpio(GPIO_GPIO2_OUTPUT);
-	px4_arch_configgpio(GPIO_GPIO3_OUTPUT);
-	px4_arch_configgpio(GPIO_GPIO4_OUTPUT);
-	px4_arch_configgpio(GPIO_GPIO5_OUTPUT);
-	px4_arch_configgpio(GPIO_GPIO6_OUTPUT);
-	px4_arch_configgpio(GPIO_GPIO7_OUTPUT);
 
 	/* configure SPI interfaces */
 

--- a/src/drivers/boards/nxphlite-v3/board_config.h
+++ b/src/drivers/boards/nxphlite-v3/board_config.h
@@ -492,6 +492,10 @@ __BEGIN_DECLS
 		GPIO_ENET_INH,        \
 		GPIO_ENET_CONFIG0,    \
 		GPIO_ENET_CONFIG1,    \
+		PIN_CAN0_RX,          \
+		PIN_CAN0_TX,          \
+		PIN_CAN1_RX,          \
+		PIN_CAN1_TX,          \
 		GPIO_CAN0_STB,        \
 		GPIO_CAN1_STB,        \
 		GPIO_BTN_SAFETY,      \

--- a/src/drivers/boards/px4cannode-v1/init.c
+++ b/src/drivers/boards/px4cannode-v1/init.c
@@ -114,6 +114,12 @@ __EXPORT void stm32_boardinitialize(void)
 	board_autoled_initialize();
 	board_button_initialize();
 	stm32_configgpio(GPIO_CAN_CTRL);
+
+	/* configure CAN interface */
+
+	stm32_configgpio(GPIO_CAN1_RX);
+	stm32_configgpio(GPIO_CAN1_TX);
+
 #if defined(CONFIG_STM32_SPI1) || defined(CONFIG_STM32_SPI2) || \
     defined(CONFIG_STM32_SPI3)
 	board_spiinitialize();

--- a/src/drivers/boards/px4fmu-v2/init.c
+++ b/src/drivers/boards/px4fmu-v2/init.c
@@ -340,6 +340,18 @@ stm32_boardinitialize(void)
 	stm32_configgpio(GPIO_VDD_USB_VALID);
 	stm32_configgpio(GPIO_VDD_5V_HIPOWER_OC);
 	stm32_configgpio(GPIO_VDD_5V_PERIPH_OC);
+
+	/*
+	 * CAN GPIO config.
+	 * Forced pull up on CAN2 is required for FMUv2  where the second interface lacks a transceiver.
+	 * If no transceiver is connected, the RX pin will float, occasionally causing CAN controller to
+	 * fail during initialization.
+	 */
+	stm32_configgpio(GPIO_CAN1_RX);
+	stm32_configgpio(GPIO_CAN1_TX);
+	stm32_configgpio(GPIO_CAN2_RX | GPIO_PULLUP);
+	stm32_configgpio(GPIO_CAN2_TX);
+
 }
 
 /****************************************************************************
@@ -387,15 +399,19 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	if (OK == determin_hw_version(&hw_version, & hw_revision)) {
 		switch (hw_version) {
-		case 0x8:
+		case HW_VER_FMUV2_STATE:
 			break;
 
-		case 0xE:
+		case HW_VER_FMUV3_STATE:
 			hw_type[1]++;
 			hw_type[2] = '0';
+
+			/* Has CAN2 transceiver Remove pull up */
+			stm32_configgpio(GPIO_CAN2_RX);
+
 			break;
 
-		case 0xA:
+		case HW_VER_FMUV2MINI_STATE:
 			hw_type[2] = 'M';
 			break;
 

--- a/src/drivers/boards/px4fmu-v4/init.c
+++ b/src/drivers/boards/px4fmu-v4/init.c
@@ -208,6 +208,10 @@ stm32_boardinitialize(void)
 	stm32_configgpio(GPIO_ADC1_IN4);	/* VDD_5V_SENS */
 	stm32_configgpio(GPIO_ADC1_IN11);	/* RSSI analog in */
 
+	// Configure CAN interface
+	stm32_configgpio(GPIO_CAN1_RX);
+	stm32_configgpio(GPIO_CAN1_TX);
+
 	// Configure power supply control/sense pins.
 	stm32_configgpio(GPIO_PERIPH_3V3_EN);
 	stm32_configgpio(GPIO_VDD_BRICK_VALID);

--- a/src/drivers/boards/px4fmu-v4pro/init.c
+++ b/src/drivers/boards/px4fmu-v4pro/init.c
@@ -227,6 +227,13 @@ stm32_boardinitialize(void)
 	stm32_configgpio(GPIO_ADC1_IN11);	/* BATT2_VOLTAGE_SENS */
 	stm32_configgpio(GPIO_ADC1_IN13);	/* BATT2_CURRENT_SENS */
 
+	/* configure CAN interfaces */
+
+	stm32_configgpio(GPIO_CAN1_RX);
+	stm32_configgpio(GPIO_CAN1_TX);
+	stm32_configgpio(GPIO_CAN2_RX);
+	stm32_configgpio(GPIO_CAN2_TX);
+
 	/* configure power supply control/sense pins */
 	stm32_configgpio(GPIO_VDD_3V3_PERIPH_EN);
 	stm32_configgpio(GPIO_VDD_5V_PERIPH_EN);

--- a/src/drivers/boards/px4fmu-v5/board_config.h
+++ b/src/drivers/boards/px4fmu-v5/board_config.h
@@ -728,6 +728,12 @@
 		PX4_ADC_GPIO,                     \
 		GPIO_HW_REV_DRIVE,                \
 		GPIO_HW_VER_DRIVE,                \
+		GPIO_CAN1_TX,                     \
+		GPIO_CAN1_RX,                     \
+		GPIO_CAN2_TX,                     \
+		GPIO_CAN2_RX,                     \
+		GPIO_CAN3_TX,                     \
+		GPIO_CAN3_RX,                     \
 		GPIO_CAN1_SILENT_S0,              \
 		GPIO_CAN2_SILENT_S1,              \
 		GPIO_CAN3_SILENT_S2,              \

--- a/src/drivers/boards/px4nucleoF767ZI-v1/init.c
+++ b/src/drivers/boards/px4nucleoF767ZI-v1/init.c
@@ -175,6 +175,16 @@ stm32_boardinitialize(void)
 	stm32_configgpio(GPIO_ADC1_IN4);	/* VDD_5V_SENS */
 	stm32_configgpio(GPIO_ADC1_IN11);	/* RSSI analog in */
 
+	/* configure CAN interface */
+#if defined(GPIO_CAN1_RX)
+	stm32_configgpio(GPIO_CAN1_RX);
+	stm32_configgpio(GPIO_CAN1_TX);
+#endif
+	stm32_configgpio(GPIO_CAN2_RX);
+	stm32_configgpio(GPIO_CAN2_TX);
+	stm32_configgpio(GPIO_CAN3_RX);
+	stm32_configgpio(GPIO_CAN3_TX);
+
 	/* configure power supply control/sense pins */
 	stm32_configgpio(GPIO_PERIPH_3V3_EN);
 	stm32_configgpio(GPIO_VDD_BRICK_VALID);

--- a/src/modules/uavcan/uavcan_main.cpp
+++ b/src/modules/uavcan/uavcan_main.cpp
@@ -534,24 +534,6 @@ int UavcanNode::start(uavcan::NodeID node_id, uint32_t bitrate)
 	}
 
 	/*
-	 * GPIO config.
-	 * Forced pull up on CAN2 is required for Pixhawk v1 where the second interface lacks a transceiver.
-	 * If no transceiver is connected, the RX pin will float, occasionally causing CAN controller to
-	 * fail during initialization.
-	 */
-#if defined(GPIO_CAN1_RX)
-	px4_arch_configgpio(GPIO_CAN1_RX);
-	px4_arch_configgpio(GPIO_CAN1_TX);
-#endif
-#if defined(GPIO_CAN2_RX)
-	px4_arch_configgpio(GPIO_CAN2_RX | GPIO_PULLUP);
-	px4_arch_configgpio(GPIO_CAN2_TX);
-#endif
-#if !defined(GPIO_CAN1_RX) &&  !defined(GPIO_CAN2_RX)
-# error  "Need to define GPIO_CAN1_RX and/or GPIO_CAN2_RX"
-#endif
-
-	/*
 	 * CAN driver init
 	 * Note that we instantiate and initialize CanInitHelper only once, because the STM32's bxCAN driver
 	 * shipped with libuavcan does not support deinitialization.

--- a/src/modules/uavcanesc/uavcanesc_main.cpp
+++ b/src/modules/uavcanesc/uavcanesc_main.cpp
@@ -136,18 +136,6 @@ int UavcanEsc::start(uavcan::NodeID node_id, uint32_t bitrate)
 	}
 
 	/*
-	 * GPIO config.
-	 * Forced pull up on CAN2 is required for Pixhawk v1 where the second interface lacks a transceiver.
-	 * If no transceiver is connected, the RX pin will float, occasionally causing CAN controller to
-	 * fail during initialization.
-	 */
-	px4_arch_configgpio(GPIO_CAN1_RX);
-	px4_arch_configgpio(GPIO_CAN1_TX);
-#if defined(GPIO_CAN2_RX)
-	px4_arch_configgpio(GPIO_CAN2_RX | GPIO_PULLUP);
-	px4_arch_configgpio(GPIO_CAN2_TX);
-#endif
-	/*
 	 * CAN driver init
 	 */
 	static CanInitHelper can;

--- a/src/modules/uavcannode/uavcannode_main.cpp
+++ b/src/modules/uavcannode/uavcannode_main.cpp
@@ -161,18 +161,6 @@ int UavcanNode::start(uavcan::NodeID node_id, uint32_t bitrate)
 	}
 
 	/*
-	 * GPIO config.
-	 * Forced pull up on CAN2 is required for Pixhawk v1 where the second interface lacks a transceiver.
-	 * If no transceiver is connected, the RX pin will float, occasionally causing CAN controller to
-	 * fail during initialization.
-	 */
-	px4_arch_configgpio(GPIO_CAN1_RX);
-	px4_arch_configgpio(GPIO_CAN1_TX);
-#if defined(GPIO_CAN2_RX)
-	px4_arch_configgpio(GPIO_CAN2_RX | GPIO_PULLUP);
-	px4_arch_configgpio(GPIO_CAN2_TX);
-#endif
-	/*
 	 * CAN driver init
 	 */
 	static CanInitHelper can;


### PR DESCRIPTION
- Update libuavcan to master.
- AUAV-X21 Add board_on_reset to avoid motor spin on reset.
- All Board: move CAN IO init to board init. - It was not correct in most cases, as an artifact of V2 HW adding pull ups on CAN 2. 


