### PR TITLE
Accept onboard computer heartbeats as telemetry

### DIFF
--- a/msg/telemetry_status.msg
+++ b/msg/telemetry_status.msg
@@ -5,9 +5,13 @@ uint8 TELEMETRY_STATUS_RADIO_TYPE_WIRE = 3
 uint8 TELEMETRY_STATUS_RADIO_TYPE_USB = 4
 uint8 TELEMETRY_STATUS_RADIO_TYPE_IRIDIUM = 5
 
+uint8 TELEMETRY_SOURCE_GCS = 6
+uint8 TELEMETRY_SOURCE_ONBOARD_CONTROLLER = 18
+
 uint64 heartbeat_time			# Time of last received heartbeat from remote system
 uint64 telem_time			# Time of last received telemetry status packet, 0 for none
 uint8 type				# type of the radio hardware
+uint8 source			# telemetry source type (GCS, onboard computer, etc)
 uint8 rssi				# local signal strength
 uint8 remote_rssi			# remote signal strength
 uint16 rxerrors				# receive errors

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -169,6 +169,7 @@ private:
 		bool preflight_checks_reported = false;
 		bool lost = true;
 		bool high_latency = false;
+		uint8_t source = 0;
 	} _telemetry[ORB_MULTI_MAX_INSTANCES];
 
 	void estimator_check(bool *status_changed);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -93,7 +93,7 @@ PARAM_DEFINE_FLOAT(TRIM_PITCH, 0.0f);
 PARAM_DEFINE_FLOAT(TRIM_YAW, 0.0f);
 
 /**
- * Datalink loss time threshold
+ * GCS datalink loss time threshold
  *
  * After this amount of seconds without datalink the data link lost mode triggers
  *
@@ -107,7 +107,7 @@ PARAM_DEFINE_FLOAT(TRIM_YAW, 0.0f);
 PARAM_DEFINE_INT32(COM_DL_LOSS_T, 10);
 
 /**
- * Datalink regain time threshold
+ * GCS datalink regain time threshold
  *
  * After a data link loss: after this this amount of seconds with a healthy datalink the 'datalink loss'
  * flag is set back to false

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -56,7 +56,7 @@ static constexpr const char reason_no_offboard[] = "no offboard";
 static constexpr const char reason_no_rc_and_no_offboard[] = "no RC and no offboard";
 static constexpr const char reason_no_local_position[] = "no local position";
 static constexpr const char reason_no_global_position[] = "no global position";
-static constexpr const char reason_no_datalink[] = "no datalink";
+static constexpr const char reason_no_datalink[] = "no GCS datalink";
 
 // This array defines the arming state transitions. The rows are the new state, and the columns
 // are the current state. Using new state and current state you can index into the array which

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1863,6 +1863,7 @@ MavlinkReceiver::handle_message_heartbeat(mavlink_message_t *msg)
 			 */
 			tstatus.timestamp = hrt_absolute_time();
 			tstatus.heartbeat_time = tstatus.timestamp;
+			tstatus.source = hb.type;
 
 			if (_telemetry_status_pub == nullptr) {
 				int multi_instance;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1854,9 +1854,8 @@ MavlinkReceiver::handle_message_heartbeat(mavlink_message_t *msg)
 		mavlink_heartbeat_t hb;
 		mavlink_msg_heartbeat_decode(msg, &hb);
 
-		/* ignore own heartbeats, accept only heartbeats from GCS */
-		if (msg->sysid != mavlink_system.sysid && hb.type == MAV_TYPE_GCS) {
-
+		/* ignore own heartbeats, accept only heartbeats from GCS or Onboard computers */
+		if (msg->sysid != mavlink_system.sysid && (hb.type == MAV_TYPE_GCS || hb.type == MAV_TYPE_ONBOARD_CONTROLLER)) {
 			struct telemetry_status_s &tstatus = _mavlink->get_rx_status();
 
 			/* set heartbeat time and topic time and publish -

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1854,8 +1854,8 @@ MavlinkReceiver::handle_message_heartbeat(mavlink_message_t *msg)
 		mavlink_heartbeat_t hb;
 		mavlink_msg_heartbeat_decode(msg, &hb);
 
-		/* ignore own heartbeats, accept only heartbeats from GCS or Onboard computers */
-		if (msg->sysid != mavlink_system.sysid && (hb.type == MAV_TYPE_GCS || hb.type == MAV_TYPE_ONBOARD_CONTROLLER)) {
+		/* accept only heartbeats from GCS or Onboard computers */
+		if (hb.type == MAV_TYPE_GCS || hb.type == MAV_TYPE_ONBOARD_CONTROLLER) {
 			struct telemetry_status_s &tstatus = _mavlink->get_rx_status();
 
 			/* set heartbeat time and topic time and publish -

--- a/src/modules/navigator/navigator_params.c
+++ b/src/modules/navigator/navigator_params.c
@@ -98,7 +98,7 @@ PARAM_DEFINE_FLOAT(NAV_FW_ALT_RAD, 10.0f);
 PARAM_DEFINE_FLOAT(NAV_MC_ALT_RAD, 0.8f);
 
 /**
- * Set data link loss failsafe mode
+ * Set GCS data link loss failsafe mode
  *
  * The data link loss failsafe will only be entered after a timeout,
  * set by COM_DL_LOSS_T in seconds. Once the timeout occurs the selected


### PR DESCRIPTION
This PR solves #10042 problem, that `STATUSTEXT` messages are not passed, when there is no GCS.
Also, this is a partial implementation of #7985.

I pass `telemetry_status`, when OBC heartbeats received, but I changed the commander logic, for not considering OBC as a datalink.

So `NAV_DLL_ACT`, `COM_DL_LOSS_T`, `COM_DL_REG_T` are only about GCS link, not OBC (not renaming for backwards compatibility).

The OBC failsafe params, like `NAV_OBC_DLL_ACT`, `COM_OBC_DL_LOSS_T`, `COM_OBC_DL_REG_T` can be added later.

@LorenzMeier , @TSC21 .