### PR TITLE
Flight task custom

### DIFF
--- a/msg/commander_state.msg
+++ b/msg/commander_state.msg
@@ -16,5 +16,6 @@ uint8 MAIN_STATE_AUTO_LAND = 11
 uint8 MAIN_STATE_AUTO_FOLLOW_TARGET = 12
 uint8 MAIN_STATE_AUTO_PRECLAND = 13
 uint8 MAIN_STATE_MAX = 14
+uint8 MAIN_STATE_CUSTOM = 15
 
 uint8 main_state		    	# main state machine

--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -35,7 +35,8 @@ uint8 NAVIGATION_STATE_AUTO_TAKEOFF = 17	# Takeoff
 uint8 NAVIGATION_STATE_AUTO_LAND = 18		# Land
 uint8 NAVIGATION_STATE_AUTO_FOLLOW_TARGET = 19	# Auto Follow
 uint8 NAVIGATION_STATE_AUTO_PRECLAND = 20	# Precision land with landing target
-uint8 NAVIGATION_STATE_MAX = 21
+uint8 NAVIGATION_STATE_CUSTOM = 21 # Custom flight task from vehicle command
+uint8 NAVIGATION_STATE_MAX = 22
 
 uint8 RC_IN_MODE_DEFAULT = 0
 uint8 RC_IN_MODE_OFF = 1

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -102,6 +102,7 @@ public:
 	 */
 	int switchTask(FlightTaskIndex new_task_index);
 	int switchTask(int new_task_index);
+	int switchTask(const vehicle_command_s &command, uint8_t &cmd_result);
 
 	/**
 	 * Get the number of the active task
@@ -157,12 +158,9 @@ private:
 		{-3, "Activation Failed"}
 	};
 	/**
-	 * Check for vehicle commands (received via MAVLink), evaluate and acknowledge them
+	 * Map vehicle command to Flght Task
 	 */
-	void _updateCommand();
 	FlightTaskIndex switchVehicleCommand(const int command);
-	int _sub_vehicle_command = -1; /**< topic handle on which commands are received */
-	orb_advert_t _pub_vehicle_command_ack = nullptr; /**< topic handle to which commands get acknowledged */
 
 	int _initTask(FlightTaskIndex task_index);
 };

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -991,6 +991,18 @@ Commander::handle_command(vehicle_status_s *status_local, const vehicle_command_
 		}
 		break;
 
+	case vehicle_command_s::VEHICLE_CMD_DO_ORBIT: {
+			/* ok, home set, use it to take off */
+			if (TRANSITION_CHANGED == main_state_transition(*status_local, commander_state_s::MAIN_STATE_CUSTOM, status_flags, &internal_state)) {
+				cmd_result = vehicle_command_s::VEHICLE_CMD_RESULT_ACCEPTED;
+
+			} else {
+				mavlink_log_critical(&mavlink_log_pub, "Custom command rejected");
+				cmd_result = vehicle_command_s::VEHICLE_CMD_RESULT_TEMPORARILY_REJECTED;
+			}
+		}
+		break;
+
 	case vehicle_command_s::VEHICLE_CMD_CUSTOM_0:
 	case vehicle_command_s::VEHICLE_CMD_CUSTOM_1:
 	case vehicle_command_s::VEHICLE_CMD_CUSTOM_2:
@@ -1022,7 +1034,6 @@ Commander::handle_command(vehicle_status_s *status_local, const vehicle_command_
 	case vehicle_command_s::VEHICLE_CMD_DO_SET_ROI_LOCATION:
 	case vehicle_command_s::VEHICLE_CMD_DO_SET_ROI_WPNEXT_OFFSET:
 	case vehicle_command_s::VEHICLE_CMD_DO_SET_ROI_NONE:
-	case vehicle_command_s::VEHICLE_CMD_DO_ORBIT:
 		/* ignore commands that are handled by other parts of the system */
 		break;
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3280,6 +3280,7 @@ set_control_mode()
 
 	switch (status.nav_state) {
 	case vehicle_status_s::NAVIGATION_STATE_MANUAL:
+	case vehicle_status_s::NAVIGATION_STATE_CUSTOM:
 		control_mode.flag_control_manual_enabled = true;
 		control_mode.flag_control_auto_enabled = false;
 		control_mode.flag_control_rates_enabled = stabilization_required();

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -540,15 +540,27 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 
 	case commander_state_s::MAIN_STATE_CUSTOM: {
 
-			if (status->engine_failure) {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
+			if (rc_lost && is_armed) {
+					enable_failsafe(status, old_failsafe, mavlink_log_pub, reason_no_rc);
 
-			} else {
-				status->nav_state = vehicle_status_s::NAVIGATION_STATE_CUSTOM;
+					set_link_loss_nav_state(status, armed, status_flags, internal_state, rc_loss_act,
+								vehicle_status_s::NAVIGATION_STATE_AUTO_RCRECOVER);
+
+					/* As long as there is RC, we can fallback to ALTCTL, or STAB. */
+					/* A local position estimate is enough for POSCTL for multirotors,
+					* this enables POSCTL using e.g. flow.
+					* For fixedwing, a global position is needed. */
+
+				} else if (is_armed
+					&& check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, !(posctl_nav_loss_act == 1),
+							!status->is_rotary_wing)) {
+					// nothing to do - everything done in check_invalid_pos_nav_state
+
+				} else {
+					status->nav_state = vehicle_status_s::NAVIGATION_STATE_CUSTOM;
+				}
 			}
-
-		}
-		break;
+			break;
 
 	case commander_state_s::MAIN_STATE_AUTO_MISSION:
 

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -350,6 +350,13 @@ main_state_transition(const vehicle_status_s &status, const main_state_t new_mai
 
 		break;
 
+	case commander_state_s::MAIN_STATE_CUSTOM:
+
+		// checks will be done in flight tasks
+		ret = TRANSITION_CHANGED;
+
+		break;
+
 	case commander_state_s::MAIN_STATE_MAX:
 	default:
 		break;
@@ -528,6 +535,18 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 			} else {
 				status->nav_state = vehicle_status_s::NAVIGATION_STATE_POSCTL;
 			}
+		}
+		break;
+
+	case commander_state_s::MAIN_STATE_CUSTOM: {
+
+			if (status->engine_failure) {
+				status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL;
+
+			} else {
+				status->nav_state = vehicle_status_s::NAVIGATION_STATE_CUSTOM;
+			}
+
 		}
 		break;
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -781,7 +781,19 @@ MulticopterPositionControl::start_flight_task()
 			task_failure = true;
 		}
 
-	} else if (_control_mode.flag_control_auto_enabled) {
+	}
+
+	// Auto related maneuvers
+	if (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION ||
+	    _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER ||
+	    _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_RTL ||
+	    _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_RCRECOVER ||
+	    _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_RTGS ||
+	    _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_LANDENGFAIL ||
+	    _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF ||
+	    _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_LAND ||
+	    _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_AUTO_PRECLAND ||
+	    _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_DESCEND) {
 		// Auto related maneuvers
 		int error = _flight_tasks.switchTask(FlightTaskIndex::AutoLine);
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -100,38 +100,37 @@ public:
 
 private:
 
-	bool		_task_should_exit = false;			/**<true if task should exit */
-	bool 		_in_smooth_takeoff = false; 		/**<true if takeoff ramp is applied */
+	bool _task_should_exit = false;  /**<true if task should exit */
+	bool _in_smooth_takeoff = false; /**<true if takeoff ramp is applied */
 
-	orb_advert_t	_att_sp_pub{nullptr};			/**< attitude setpoint publication */
-	orb_advert_t	_local_pos_sp_pub{nullptr};		/**< vehicle local position setpoint publication */
+	orb_advert_t _att_sp_pub{nullptr};                    /**< attitude setpoint publication */
+	orb_advert_t _local_pos_sp_pub{nullptr};              /**< vehicle local position setpoint publication */
 	orb_advert_t _traj_wp_avoidance_desired_pub{nullptr}; /**< trajectory waypoint desired publication */
-	orb_advert_t _pub_vehicle_command_ack{nullptr}; /**< vehicle command acknowledgement publication */
+	orb_advert_t _pub_vehicle_command_ack{nullptr};       /**< vehicle command acknowledgement publication */
 	orb_id_t _attitude_setpoint_id{nullptr};
 
-	int		_control_task{-1};			/**< task handle for task */
-	int		_vehicle_status_sub{-1};		/**< vehicle status subscription */
-	int		_vehicle_land_detected_sub{-1};	/**< vehicle land detected subscription */
-	int		_control_mode_sub{-1};		/**< vehicle control mode subscription */
-	int		_params_sub{-1};			/**< notification of parameter updates */
-	int		_local_pos_sub{-1};			/**< vehicle local position */
-	int		_home_pos_sub{-1}; 			/**< home position */
-	int		_traj_wp_avoidance_sub{-1};	/**< trajectory waypoint */
+	int _control_task{-1};              /**< task handle for task */
+	int _vehicle_status_sub{-1};        /**< vehicle status subscription */
+	int _vehicle_land_detected_sub{-1}; /**< vehicle land detected subscription */
+	int _control_mode_sub{-1};          /**< vehicle control mode subscription */
+	int _params_sub{-1};                /**< notification of parameter updates */
+	int _local_pos_sub{-1};             /**< vehicle local position */
+	int _home_pos_sub{-1};              /**< home position */
+	int _traj_wp_avoidance_sub{-1};     /**< trajectory waypoint */
 	int _vehicle_command_sub{-1};       /**< vehicle command subscription */
 
 	float _takeoff_speed = -1.f; /**< For flighttask interface used only. It can be thrust or velocity setpoints */
 
-	vehicle_status_s 			_vehicle_status{}; 	/**< vehicle status */
-	vehicle_land_detected_s 			_vehicle_land_detected{};	/**< vehicle land detected */
-	vehicle_attitude_setpoint_s		_att_sp{};		/**< vehicle attitude setpoint */
-	vehicle_control_mode_s			_control_mode{};		/**< vehicle control mode */
-	vehicle_local_position_s			_local_pos{};		/**< vehicle local position */
-	vehicle_local_position_setpoint_s	_local_pos_sp{};		/**< vehicle local position setpoint */
-	home_position_s				_home_pos{}; 				/**< home position */
-	vehicle_trajectory_waypoint_s		_traj_wp_avoidance; /**< trajectory waypoint */
-	vehicle_trajectory_waypoint_s
-	_traj_wp_avoidance_desired; /**< desired waypoints, inputs to an obstacle avoidance module */
-	vehicle_command_s                 _vehicle_command{};       /**< vehicle command */
+	vehicle_status_s                  _vehicle_status{};            /**< vehicle status */
+	vehicle_land_detected_s           _vehicle_land_detected{};     /**< vehicle land detected */
+	vehicle_attitude_setpoint_s       _att_sp{};                    /**< vehicle attitude setpoint */
+	vehicle_control_mode_s            _control_mode{};              /**< vehicle control mode */
+	vehicle_local_position_s          _local_pos{};                 /**< vehicle local position */
+	vehicle_local_position_setpoint_s _local_pos_sp{};              /**< vehicle local position setpoint */
+	home_position_s                   _home_pos{};                  /**< home position */
+	vehicle_trajectory_waypoint_s     _traj_wp_avoidance{};         /**< trajectory waypoint */
+	vehicle_trajectory_waypoint_s     _traj_wp_avoidance_desired{}; /**< desired waypoints, inputs to an obstacle avoidance module */
+	vehicle_command_s                 _vehicle_command{};           /**< vehicle command */
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MPC_TKO_RAMP_T>) _takeoff_ramp_time, /**< time constant for smooth takeoff ramp */
@@ -150,8 +149,8 @@ private:
 	control::BlockDerivative _vel_y_deriv; /**< velocity derivative in y */
 	control::BlockDerivative _vel_z_deriv; /**< velocity derivative in z */
 
-	FlightTasks _flight_tasks; /**< class that generates position controller tracking setpoints*/
-	PositionControl _control; /**< class that handles the core PID position controller */
+	FlightTasks _flight_tasks;     /**< class that generates position controller tracking setpoints*/
+	PositionControl _control;      /**< class that handles the core PID position controller */
 	PositionControlStates _states; /**< structure that contains required state information for position control */
 
 	hrt_abstime _last_warn = 0; /**< timer when the last warn message was sent out */


### PR DESCRIPTION
@MaEtUgR @Stifael 

As discussed, I added the `CUSTOM` state to launch a custom flight task. We use this for logging purposes and to avoid other switching corner cases.
I also moved the command handling into the position controller so that upon failure the behavior is the same for all tasks.

Things that need to be changed/improved in following PRs:
- feedback to commander if a task fails
- getting rid of all the control mode flags -> The flight tasks themselves know if a switch is possible