### PR TITLE
Ethernet : Added support in ethernet (Mavlink)

### DIFF
--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -50,19 +50,20 @@
 #include <nuttx/fs/fs.h>
 #else
 #include <sys/socket.h>
-#include <netinet/in.h>
 #include <arpa/inet.h>
 #include <drivers/device/device.h>
 #endif
+
+#if defined(CONFIG_NET) || !defined(__PX4_NUTTX)
+#include <netinet/in.h>
+#include <net/if.h>
+#endif
+
 #include <parameters/param.h>
 #include <perf/perf_counter.h>
 #include <pthread.h>
 #include <systemlib/mavlink_log.h>
 #include <drivers/device/ringbuffer.h>
-
-#ifdef __PX4_POSIX
-#include <net/if.h>
-#endif
 
 #include <uORB/uORB.h>
 #include <uORB/topics/mission.h>
@@ -184,7 +185,8 @@ public:
 
 	enum BROADCAST_MODE {
 		BROADCAST_MODE_OFF = 0,
-		BROADCAST_MODE_ON
+		BROADCAST_MODE_ON,
+		BROADCAST_MODE_MULTICAST
 	};
 
 	enum FLOW_CONTROL_MODE {
@@ -423,9 +425,9 @@ public:
 	 */
 	telemetry_status_s	&get_telemetry_status() { return _tstatus; }
 
-	void				set_telemetry_status_type(uint8_t type) { _tstatus.type = type; }
+	void			set_telemetry_status_type(uint8_t type) { _tstatus.type = type; }
 
-	void update_radio_status(const radio_status_s &radio_status);
+	void			update_radio_status(const radio_status_s &radio_status);
 
 	ringbuffer::RingBuffer	*get_logbuffer() { return &_logbuffer; }
 
@@ -438,11 +440,14 @@ public:
 	unsigned short		get_remote_port() { return _remote_port; }
 
 	int 			get_socket_fd() { return _socket_fd; };
+
 #ifdef __PX4_POSIX
 	const in_addr query_netmask_addr(const int socket_fd, const ifreq &ifreq);
 
 	const in_addr compute_broadcast_addr(const in_addr &host_addr, const in_addr &netmask_addr);
+#endif
 
+#if defined(CONFIG_NET) || defined(__PX4_POSIX)
 	struct sockaddr_in 	&get_client_source_address() { return _src_addr; }
 
 	void			set_client_source_initialized() { _src_addr_initialized = true; }
@@ -589,7 +594,7 @@ private:
 	unsigned		_bytes_rx;
 	uint64_t		_bytes_timestamp;
 
-#ifdef __PX4_POSIX
+#if defined(CONFIG_NET) || defined(__PX4_POSIX)
 	struct sockaddr_in _myaddr;
 	struct sockaddr_in _src_addr;
 	struct sockaddr_in _bcast_addr;
@@ -640,7 +645,7 @@ private:
 
 	perf_counter_t		_loop_perf;			/**< loop performance counter */
 
-	void mavlink_update_parameters();
+	void			mavlink_update_parameters();
 
 	int			mavlink_open_uart(int baudrate, const char *uart_name, bool force_flow_control);
 

--- a/src/modules/mavlink/mavlink_params.c
+++ b/src/modules/mavlink/mavlink_params.c
@@ -138,6 +138,7 @@ PARAM_DEFINE_INT32(MAV_FWDEXTSP, 1);
  *
  * @value 0 Never broadcast
  * @value 1 Always broadcast
+ * @value 2 Only multicast
  * @group MAVLink
  */
 PARAM_DEFINE_INT32(MAV_BROADCAST, 0);

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -67,6 +67,13 @@
 #ifndef __PX4_POSIX
 #include <termios.h>
 #endif
+
+#ifdef CONFIG_NET
+#include <net/if.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#endif
+
 #include <errno.h>
 #include <stdlib.h>
 #include <poll.h>
@@ -96,6 +103,12 @@
 #include "mavlink_receiver.h"
 #include "mavlink_main.h"
 #include "mavlink_command_sender.h"
+
+#ifdef CONFIG_NET
+#define MAVLINK_RECEIVER_NET_ADDED_STACK 1360
+#else
+#define MAVLINK_RECEIVER_NET_ADDED_STACK 0
+#endif
 
 using matrix::wrap_2pi;
 
@@ -2558,7 +2571,7 @@ void MavlinkReceiver::handle_message_debug_vect(mavlink_message_t *msg)
 }
 
 /**
- * Receive data from UART.
+ * Receive data from UART/UDP
  */
 void *
 MavlinkReceiver::receive_thread(void *arg)
@@ -2574,9 +2587,12 @@ MavlinkReceiver::receive_thread(void *arg)
 	// poll timeout in ms. Also defines the max update frequency of the mission & param manager, etc.
 	const int timeout = 10;
 
-#ifdef __PX4_POSIX
+#if defined(__PX4_POSIX)
 	/* 1500 is the Wifi MTU, so we make sure to fit a full packet */
 	uint8_t buf[1600 * 5];
+#elif defined(CONFIG_NET)
+	/* 1500 is the Wifi MTU, so we make sure to fit a full packet */
+	uint8_t buf[1000];
 #else
 	/* the serial port buffers internally as well, we just need to fit a small chunk */
 	uint8_t buf[64];
@@ -2590,7 +2606,7 @@ MavlinkReceiver::receive_thread(void *arg)
 		fds[0].events = POLLIN;
 	}
 
-#ifdef __PX4_POSIX
+#if defined(CONFIG_NET) || defined(__PX4_POSIX)
 	struct sockaddr_in srcaddr = {};
 	socklen_t addrlen = sizeof(srcaddr);
 
@@ -2625,7 +2641,7 @@ MavlinkReceiver::receive_thread(void *arg)
 				}
 			}
 
-#ifdef __PX4_POSIX
+#if defined(CONFIG_NET) || defined(__PX4_POSIX)
 
 			if (_mavlink->get_protocol() == UDP) {
 				if (fds[0].revents & POLLIN) {
@@ -2757,7 +2773,7 @@ MavlinkReceiver::receive_start(pthread_t *thread, Mavlink *parent)
 	param.sched_priority = SCHED_PRIORITY_MAX - 80;
 	(void)pthread_attr_setschedparam(&receiveloop_attr, &param);
 
-	pthread_attr_setstacksize(&receiveloop_attr, PX4_STACK_ADJUSTED(2840));
+	pthread_attr_setstacksize(&receiveloop_attr, PX4_STACK_ADJUSTED(2840 + MAVLINK_RECEIVER_NET_ADDED_STACK));
 	pthread_create(thread, &receiveloop_attr, MavlinkReceiver::start_helper, (void *)parent);
 
 	pthread_attr_destroy(&receiveloop_attr);


### PR DESCRIPTION
-Mavlink now supports Ethernet on stm32
-Mavlink now supports multicast

Additional context
-In order to use ethernet one needs to make the right changes to defconfig and specific board.
-In order to use mavlink multicast in rcS add to your mavlink start "-c {multicast address}" and to use addroute function