### PR TITLE
FlightTask Smoothing: check dt before dividing

### DIFF
--- a/src/lib/FlightTasks/tasks/Utility/ManualSmoothingXY.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/ManualSmoothingXY.cpp
@@ -197,7 +197,11 @@ void
 ManualSmoothingXY::_velocitySlewRate(matrix::Vector2f &vel_sp, const float dt)
 {
 	// Adjust velocity setpoint if demand exceeds acceleration. /
-	matrix::Vector2f acc = (vel_sp - _vel_sp_prev) / dt;
+	matrix::Vector2f acc{};
+
+	if (dt > FLT_EPSILON) {
+		acc = (vel_sp - _vel_sp_prev) / dt;
+	}
 
 	if (acc.length() > _acc_state_dependent) {
 		vel_sp = acc.normalized() * _acc_state_dependent  * dt + _vel_sp_prev;

--- a/src/lib/FlightTasks/tasks/Utility/ManualSmoothingZ.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/ManualSmoothingZ.cpp
@@ -146,7 +146,12 @@ void
 ManualSmoothingZ::velocitySlewRate(float &vel_sp, const float dt)
 {
 	// limit vertical acceleration
-	float acc = (vel_sp - _vel_sp_prev) / dt;
+	float acc = 0.f;
+
+	if (dt > FLT_EPSILON) {
+		acc = (vel_sp - _vel_sp_prev) / dt;
+	}
+
 	float max_acc = (acc < 0.0f) ? -_acc_state_dependent : _acc_state_dependent;
 
 	if (fabsf(acc) > fabsf(max_acc)) {

--- a/src/lib/FlightTasks/tasks/Utility/StraightLine.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/StraightLine.cpp
@@ -83,7 +83,11 @@ void StraightLine::generateSetpoints(matrix::Vector3f &position_setpoint, matrix
 	float speed_sp    = dist_to_target > acc_dec_distance ? _desired_speed        :  _desired_speed_at_target;
 	float max_acc_dec = speed_sp > speed_sp_prev          ? _desired_acceleration : -_desired_deceleration;
 
-	float acc_track = (speed_sp - speed_sp_prev) / _deltatime;
+	float acc_track = 0.0f;
+
+	if (_deltatime > FLT_EPSILON) {
+		acc_track = (speed_sp - speed_sp_prev) / _deltatime;
+	}
 
 	if (fabs(acc_track) > fabs(max_acc_dec)) {
 		// accelerate/decelerate with desired acceleration/deceleration towards target
@@ -192,7 +196,7 @@ void StraightLine::setSpeed(const float &speed)
 {
 	float vel_max = getMaxVel();
 
-	if (speed > 0 && speed < vel_max) {
+	if (speed > FLT_EPSILON && speed < vel_max) {
 		_desired_speed = speed;
 
 	} else if (speed > vel_max) {
@@ -204,7 +208,7 @@ void StraightLine::setSpeedAtTarget(const float &speed_at_target)
 {
 	float vel_max = getMaxVel();
 
-	if (speed_at_target > 0 && speed_at_target < vel_max) {
+	if (speed_at_target > FLT_EPSILON && speed_at_target < vel_max) {
 		_desired_speed_at_target = speed_at_target;
 
 	} else if (speed_at_target > vel_max) {
@@ -216,7 +220,7 @@ void StraightLine::setAcceleration(const float &acc)
 {
 	float acc_max = getMaxVel();
 
-	if (acc > 0 && acc < acc_max) {
+	if (acc > FLT_EPSILON && acc < acc_max) {
 		_desired_acceleration = acc;
 
 	} else if (acc > acc_max) {
@@ -226,7 +230,7 @@ void StraightLine::setAcceleration(const float &acc)
 
 void StraightLine::setDeceleration(const float &dec)
 {
-	if (dec > 0 && dec < DECELERATION_MAX) {
+	if (dec > FLT_EPSILON && dec < DECELERATION_MAX) {
 		_desired_deceleration = dec;
 
 	} else if (dec > DECELERATION_MAX) {


### PR DESCRIPTION
We should check if `dt` is zero before the division. In simulation I sometimes have `dt` equal to zero...
