### PR TITLE
Fix posix shell startup race

### DIFF
--- a/platforms/posix/src/px4_daemon/client.cpp
+++ b/platforms/posix/src/px4_daemon/client.cpp
@@ -170,7 +170,7 @@ Client::_send_cmds(const int argc, const char **argv)
 	_client_send_pipe_fd = open(get_client_send_pipe_path(_instance_id).c_str(), O_WRONLY);
 
 	if (_client_send_pipe_fd < 0) {
-		PX4_ERR("pipe open fail");
+		PX4_ERR("pipe open fail (%i)", errno);
 		return _client_send_pipe_fd;
 	}
 
@@ -178,7 +178,7 @@ Client::_send_cmds(const int argc, const char **argv)
 	int bytes_sent = write(_client_send_pipe_fd, &packet, bytes_to_send);
 
 	if (bytes_sent != bytes_to_send) {
-		PX4_ERR("write fail");
+		PX4_ERR("write fail (%i)", errno);
 		return bytes_sent;
 	}
 

--- a/platforms/posix/src/px4_daemon/server.cpp
+++ b/platforms/posix/src/px4_daemon/server.cpp
@@ -72,6 +72,15 @@ Server::~Server()
 int
 Server::start()
 {
+	std::string client_send_pipe_path = get_client_send_pipe_path(_instance_id);
+
+	// Delete pipe in case it exists already.
+	unlink(client_send_pipe_path.c_str());
+
+	// Create new pipe to listen to clients.
+	// This needs to happen before we return from this method, so that the caller can launch clients.
+	mkfifo(client_send_pipe_path.c_str(), 0666);
+
 	if (0 != pthread_create(&_server_main_pthread,
 				nullptr,
 				_server_main_trampoline,
@@ -112,12 +121,6 @@ Server::_server_main(void *arg)
 	}
 
 	std::string client_send_pipe_path = get_client_send_pipe_path(_instance_id);
-
-	// Delete pipe in case it exists already.
-	unlink(client_send_pipe_path.c_str());
-
-	// Create new pipe to listen to clients.
-	mkfifo(client_send_pipe_path.c_str(), 0666);
 	int client_send_pipe_fd = open(client_send_pipe_path.c_str(), O_RDONLY);
 
 	while (true) {


### PR DESCRIPTION
The FIFO was created in the server thread, and the PX4 main thread could already have continued and started to execute the bash script. In that case the client tried to open the FIFO but it did not exist yet.

Client error as seen in CI (I did not reproduce it):
```
ERROR [px4_daemon] pipe open fail
ERROR [px4_daemon] Could not send commands
```

Fixes #10220