### PR TITLE
attitude setpoint publish: mc_pos_control publish with ORB_PRIO_DEFAU…

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1381,12 +1381,9 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 						att_sp.thrust = set_attitude_target.thrust;
 					}
 
-					if (_att_sp_pub == nullptr) {
-						_att_sp_pub = orb_advertise(ORB_ID(vehicle_attitude_setpoint), &att_sp);
-
-					} else {
-						orb_publish(ORB_ID(vehicle_attitude_setpoint), _att_sp_pub, &att_sp);
-					}
+					int instance; // provides the instance ID or the publication
+					ORB_PRIO priority = ORB_PRIO_HIGH; // since it is an override, set priority high
+					orb_publish_auto(ORB_ID(vehicle_attitude_setpoint), &_att_sp_pub, &att_sp, &instance, priority);
 				}
 
 				/* Publish attitude rate setpoint if bodyrate and thrust ignore bits are not set */

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -56,6 +56,7 @@
 #include <uORB/topics/vehicle_rates_setpoint.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_land_detected.h>
+#include <drivers/drv_hrt.h>
 
 /**
  * Multicopter attitude control app start / stop handling function
@@ -64,6 +65,7 @@ extern "C" __EXPORT int mc_att_control_main(int argc, char *argv[]);
 
 #define MAX_GYRO_COUNT 3
 
+using namespace time_literals;
 
 class MulticopterAttitudeControl : public ModuleBase<MulticopterAttitudeControl>, public ModuleParams
 {
@@ -88,6 +90,10 @@ public:
 	void run() override;
 
 private:
+
+	static constexpr hrt_abstime VEHICLE_ATT_SP_TIMEOUT = 10_ms;
+	hrt_abstime _timeout_att_sp = 0;
+	int32_t _priority_att_sp = 0;
 
 	/**
 	 * initialize some vectors/matrices from parameters

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -125,9 +125,8 @@ private:
 	 */
 	matrix::Vector3f pid_attenuations(float tpa_breakpoint, float tpa_rate);
 
-
+	int		_v_att_sp_subs[ORB_MULTI_MAX_INSTANCES];		/**< vehicle attitude setpoint subscriptions */
 	int		_v_att_sub{-1};			/**< vehicle attitude subscription */
-	int		_v_att_sp_sub{-1};		/**< vehicle attitude setpoint subscription */
 	int		_v_rates_sp_sub{-1};		/**< vehicle rates setpoint subscription */
 	int		_v_control_mode_sub{-1};	/**< vehicle control mode subscription */
 	int		_params_sub{-1};		/**< parameter updates subscription */

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -91,9 +91,9 @@ public:
 
 private:
 
-	static constexpr hrt_abstime VEHICLE_ATT_SP_TIMEOUT = 10_ms;
+	static constexpr hrt_abstime VEHICLE_ATT_SP_TIMEOUT = 150_ms; /**< defines timeout for attitude setpoint subscription */
 	hrt_abstime _timeout_att_sp = 0;
-	int32_t _priority_att_sp = 0;
+	int32_t _priority_att_sp = 0; /**< attitude setpoint subscription priority */
 
 	/**
 	 * initialize some vectors/matrices from parameters

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -246,13 +246,12 @@ MulticopterAttitudeControl::vehicle_manual_poll()
 void
 MulticopterAttitudeControl::vehicle_attitude_setpoint_poll()
 {
-	/* check if there is a new setpoint */
+	// check if there is a new setpoint
 	bool updated;
 	int32_t priority = 0;
 
 	for (int &sub : _v_att_sp_subs) {
 		orb_priority(sub, &priority);
-
 		// only update if setpoint priority is larger equal than previous subscription
 		if (priority >= _priority_att_sp) {
 			// check if anything has updated

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -46,7 +46,6 @@
 #include "mc_att_control.hpp"
 
 #include <conversion/rotation.h>
-#include <drivers/drv_hrt.h>
 #include <lib/ecl/geo/geo.h>
 #include <circuit_breaker/circuit_breaker.h>
 #include <mathlib/math/Limits.hpp>
@@ -60,7 +59,6 @@
 #define AXIS_COUNT 3
 
 using namespace matrix;
-
 
 int MulticopterAttitudeControl::print_usage(const char *reason)
 {
@@ -253,14 +251,22 @@ MulticopterAttitudeControl::vehicle_attitude_setpoint_poll()
 	int32_t priority = 0;
 
 	for (int &sub : _v_att_sp_subs) {
-		orb_check(sub, &updated);
-		int32_t priority_tmp;
-		orb_priority(sub, &priority_tmp);
+		orb_priority(sub, &priority);
 
-		// only update if setpoint has updated and priority is larger than previous subscription
-		if (updated && priority_tmp > priority) {
-			orb_copy(ORB_ID(vehicle_attitude_setpoint), sub, &_v_att_sp);
-			priority = priority_tmp;
+		// only update if setpoint priority is larger equal than previous subscription
+		if (priority >= _priority_att_sp) {
+			// check if anything has updated
+			orb_check(sub, &updated);
+
+			if (updated) {
+				orb_copy(ORB_ID(vehicle_attitude_setpoint), sub, &_v_att_sp);
+				_priority_att_sp = priority;
+				_timeout_att_sp = hrt_absolute_time();
+
+			} else if (hrt_elapsed_time(&_timeout_att_sp) >= VEHICLE_ATT_SP_TIMEOUT){
+				_priority_att_sp = 0;
+				_timeout_att_sp = hrt_absolute_time();
+			}
 		}
 	}
 }

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -704,16 +704,9 @@ MulticopterPositionControl::task_main()
 				}
 			}
 
-			// Publish local position setpoint (for logging only) and attitude setpoint (for attitude controller).
+			// Publish local position setpoint (for logging only)
 			publish_local_pos_sp();
-
-			// publish attitude setpoint
-			// Note: this requires review. The reason for not sending
-			// an attitude setpoint is because for non-flighttask modes
-			// the attitude septoint should come from another source, otherwise
-			// they might conflict with each other such as in offboard attitude control.
-			publish_attitude();
-
+			// Publish desired waypoint fot avoidance module
 			publish_avoidance_desired_waypoint();
 
 		} else {
@@ -729,7 +722,11 @@ MulticopterPositionControl::task_main()
 			q_sp.copyTo(_att_sp.q_d);
 			_att_sp.q_d_valid = true;
 			_att_sp.thrust = 0.0f;
+			_att_sp.landing_gear = 0; // keep gears as they are
 		}
+
+		// Always publish attitude setpoint
+		publish_attitude();
 	}
 
 	_control_task = -1;
@@ -986,7 +983,7 @@ MulticopterPositionControl::execute_avoidance_waypoint()
 bool
 MulticopterPositionControl::use_obstacle_avoidance()
 {
-	/* check that external obstacle avoidance is sending data and that the first point is valid */
+	// check that external obstacle avoidance is sending data and that the first point is valid
 	return (MPC_OBS_AVOID.get()
 		&& (hrt_elapsed_time((hrt_abstime *)&_traj_wp_avoidance.timestamp) < TRAJECTORY_STREAM_TIMEOUT_US)
 		&& (_traj_wp_avoidance.waypoints[vehicle_trajectory_waypoint_s::POINT_0].point_valid == true)
@@ -997,7 +994,7 @@ MulticopterPositionControl::use_obstacle_avoidance()
 void
 MulticopterPositionControl::publish_avoidance_desired_waypoint()
 {
-	/* publish desired waypoint*/
+	// publish desired waypoint
 	if (_traj_wp_avoidance_desired_pub != nullptr) {
 		orb_publish(ORB_ID(vehicle_trajectory_waypoint_desired), _traj_wp_avoidance_desired_pub, &_traj_wp_avoidance_desired);
 
@@ -1014,21 +1011,15 @@ MulticopterPositionControl::publish_avoidance_desired_waypoint()
 void
 MulticopterPositionControl::publish_attitude()
 {
-
 	_att_sp.timestamp = hrt_absolute_time();
-
-	if (_att_sp_pub != nullptr) {
-		orb_publish(_attitude_setpoint_id, _att_sp_pub, &_att_sp);
-
-	} else if (_attitude_setpoint_id) {
-		_att_sp_pub = orb_advertise(_attitude_setpoint_id, &_att_sp);
-	}
+	int instance;
+	// publish with default priority
+	orb_publish_auto(_attitude_setpoint_id, &_att_sp_pub, &_att_sp, &instance, ORB_PRIO_DEFAULT);
 }
 
 void
 MulticopterPositionControl::publish_local_pos_sp()
 {
-
 	_local_pos_sp.timestamp = hrt_absolute_time();
 
 	// publish local position setpoint


### PR DESCRIPTION
Make use of multi publishing such that attitude setpoint can be sent independent of Flighttask is running or not. 
Originally the problem was that mavlink_receiver can send attitude setpoints directly if in offboard mode, which cause an conflict with mc_pos_control_main. 