### PR TITLE
posix rcS: use sed instead of grep -P

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -40,8 +40,8 @@ if [ "$PX4_SIM_MODEL" == "shell" ]; then
 	set RUN_MINIMAL_SHELL yes
 else
 	# Find the matching Autostart ID (file name has the form: [0-9]+_${PX4_SIM_MODEL})
-	# shellcheck disable=SC2010 #(the file names don't contain spaces)
-	REQUESTED_AUTOSTART=$(ls "$SCRIPT_DIR" | grep -oP '^[0-9]+(?=_'${PX4_SIM_MODEL}'$)')
+	# shellcheck disable=SC2012 #(the file names don't contain spaces)
+	REQUESTED_AUTOSTART=$(ls "$SCRIPT_DIR" | sed -n 's/^\([0-9][0-9]*\)_'${PX4_SIM_MODEL}'$/\1/p')
 	if [ -z "$REQUESTED_AUTOSTART" ]; then
 		echo "Error: Unknown model '$PX4_SIM_MODEL'"
 		exit -1

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -93,7 +93,7 @@ set PWM_RATE                    p:PWM_RATE
 set SDCARD_MIXERS_PATH          /fs/microsd/etc/mixers
 set USE_IO                      no
 set VEHICLE_TYPE                none
-set TUNE_ERR                    ML<<CP4CP4CP4CP4CP4
+set TUNE_ERR                    "ML<<CP4CP4CP4CP4CP4"
 #
 # Mount the procfs.
 #


### PR DESCRIPTION
The -P argument seems not to be supported on OSX

@ecmnet can you test this?

Fixes #10228