### PR TITLE
cmake px4_add_module add unity build support

### DIFF
--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -66,4 +66,5 @@ px4_add_module(
 		git_ecl
 		ecl_geo
 		version
+	UNITY_BUILD
 	)

--- a/src/modules/mavlink/mavlink_tests/CMakeLists.txt
+++ b/src/modules/mavlink/mavlink_tests/CMakeLists.txt
@@ -47,7 +47,4 @@ px4_add_module(
 		mavlink_ftp_test.cpp
 		../mavlink_stream.cpp
 		../mavlink_ftp.cpp
-		../mavlink.c
-	DEPENDS
 	)
-


### PR DESCRIPTION
 - a unity build is a single compilation unit per module

On px4fmu-v2_default this saves 16 kB of flash relative to current master.

![image](https://user-images.githubusercontent.com/84712/44165462-d5f5e280-a096-11e8-8574-627413ccfd80.png)
