### PR TITLE
launch: add px4.launch script that only starts the px4 binary

### DIFF
--- a/launch/px4.launch
+++ b/launch/px4.launch
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<launch>
+    <!-- Posix SITL PX4 launch script -->
+    <!-- Launches Only PX4 SITL. This can be used by external projects -->
+
+    <!-- PX4 config arguments -->
+    <arg name="est" default="ekf2"/>
+    <arg name="vehicle" default="iris"/>
+    <arg name="ID" default="0"/>
+    <arg name="interactive" default="true"/>
+
+    <env name="PX4_SIM_MODEL" value="$(arg vehicle)" />
+    <env name="PX4_ESTIMATOR" value="$(arg est)" />
+    <arg unless="$(arg interactive)" name="px4_command_arg1" value=""/>
+    <arg     if="$(arg interactive)" name="px4_command_arg1" value="-d"/>
+    <node name="sitl_$(arg ID)" pkg="px4" type="px4" output="screen" args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg ID) $(arg px4_command_arg1)">
+    </node>
+</launch>
+


### PR DESCRIPTION
This provides a clean ROS interface for external projects which is independent from the px4 CLI interface.

It can be used with:

```
        <include file="$(find px4)/launch/px4.launch">
        </include>
```

@mhkabir this should fix your ROS issues.

