### PR TITLE
Removed condition to move straight to RTL_LAND state.

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -69,11 +69,6 @@ RTL::on_activation()
 		// For safety reasons don't go into RTL if landed.
 		_rtl_state = RTL_STATE_LANDED;
 
-	} else if (_navigator->get_position_setpoint_triplet()->current.valid
-		   && _navigator->get_position_setpoint_triplet()->current.type == position_setpoint_s::SETPOINT_TYPE_LAND) {
-		// Skip straight to land if already performing a land.
-		_rtl_state = RTL_STATE_LAND;
-
 	} else if ((rtl_type() == RTL_LAND) && _navigator->on_mission_landing()) {
 		// RTL straight to RETURN state, but mission will takeover for landing.
 


### PR DESCRIPTION
Essentially this not only doesn't work after adding the `_navigator->get_position_setpoint_triplet()->current.valid` check (setpoints are invalidated when navigator changes nav state) but sometimes it DOES work and instead of landing where it is AT (i.e `gpos.lat` and `gpos.lon`) the lat/lon setpoints are `home.lat` and `home.lon`. This is extremely bad, the vehicle just beelines towards `home.lat`, `home.lon`, and `home.alt`.

This wasn't a problem previously when we were using the `mc_pos_controller` for all the control, as previously the logic for `SETPOINT_TYPE_LAND` within `mc_pos_controller` would just set the lat/lon setpoints to NaN, which then caused the controller to default those setpoints to the current gpos.lat/gpos.lon and just land where it is at. 

I hope this didn't impact anyone other than ourselves. We've seen it maybe 5 times total over the course of the last few weeks of consistent flying. I don't know why it sometimes "works" and sometimes does not. Either way it needs to be removed!