### PR TITLE
[WIP] tune refactor

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -168,7 +168,7 @@ then
 	else
 		echo "ERROR  [init] Failed loading mixer: ${MIXER_FILE}"
 		echo "ERROR  [init] Failed loading mixer: ${MIXER_FILE}" >> $LOG_FILE
-		tone_alarm ${TUNE_ERR}
+		tune_control play -t 20
 	fi
 
 else
@@ -176,7 +176,7 @@ else
 	then
 		echo "ERROR  [init] Mixer undefined"
 		echo "ERROR  [init] Mixer undefined" >> $LOG_FILE
-		tone_alarm ${TUNE_ERR}
+		tune_control play -t 20
 	fi
 fi
 
@@ -226,7 +226,7 @@ then
 			fi
 		else
 			echo "ERROR: Could not start: fmu mode_pwm" >> $LOG_FILE
-			tone_alarm ${TUNE_ERR}
+			tune_control play -t 20
 			set PWM_AUX_OUT none
 			set FAILSAFE_AUX none
 		fi

--- a/ROMFS/px4fmu_common/init.d/rc.io
+++ b/ROMFS/px4fmu_common/init.d/rc.io
@@ -13,6 +13,6 @@ then
 		px4io limit 400
 	else
 		echo "PX4IO start failed" >> $LOG_FILE
-		tune_control play -m ${TUNE_ERR}
+		tune_control play -t 20
 	fi
 fi

--- a/ROMFS/px4fmu_common/init.d/rc.mavlink
+++ b/ROMFS/px4fmu_common/init.d/rc.mavlink
@@ -182,7 +182,7 @@ then
 		then
 			mavlink start -d /dev/iridium -m iridium -b 115200
 		else
-			tune_control play -m "ML<<CP4CP4CP4CP4CP4"
+			tune_control play -t 20
 		fi
 	fi
 	if param compare SYS_COMPANION 5115200

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -138,6 +138,7 @@ then
 			hardfault_log reset
 		fi
 	else
+		# Play the startup tune.
 		tune_control play -t 1
 	fi
 else
@@ -348,15 +349,13 @@ else
 
 	if [ -f $IOFW ]
 	then
-		if px4io checkcrc ${IOFW}
+		# Check for the mini using build with px4io fw file
+		# but not a px4IO
+		if ! ver hwtypecmp V540
 		then
-			set IO_PRESENT yes
-		else
-			# Check for the mini using build with px4io fw file
-			# but not a px4IO
-			if ver hwtypecmp V540
+			if px4io checkcrc ${IOFW}
 			then
-				echo "PX4IO Not Suported" >> $LOG_FILE
+				set IO_PRESENT yes
 			else
 				# tune Program PX4IO
 				tune_control play -t 18

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -57,6 +57,8 @@ set +e
 
 #
 # Set default paramter values.
+# Do not add intra word spaces
+# it wastes flash
 #
 set AUX_MODE pwm
 set DATAMAN_OPT ""
@@ -67,7 +69,7 @@ set FEXTRAS /fs/microsd/etc/extras.txt
 set FRC /fs/microsd/etc/rc.txt
 set FMU_ARGS ""
 set FMU_MODE pwm
-set IO_FILE ""
+set IOFW "/etc/extras/px4io-v2.bin"
 set IO_PRESENT no
 set LOG_FILE /fs/microsd/bootlog.txt
 set MAVLINK_F default
@@ -93,7 +95,7 @@ set PWM_RATE p:PWM_RATE
 set SDCARD_MIXERS_PATH /fs/microsd/etc/mixers
 set USE_IO no
 set VEHICLE_TYPE none
-set TUNE_ERR "ML<<CP4CP4CP4CP4CP4"
+
 #
 # Mount the procfs.
 #
@@ -110,6 +112,18 @@ sercon
 ver all
 
 #
+# Start the ORB (first app to start)
+# tone_alarm and tune_control
+# is dependent.
+#
+uorb start
+
+#
+# Start the tone_alarm driver.
+#
+tone_alarm start
+
+#
 # Try to mount the microSD card.
 #
 # REBOOTWORK this needs to start after the flight control loop.
@@ -119,23 +133,24 @@ then
 	then
 		# Error tune.
 		tune_control play -t 2
-
 		if hardfault_log commit
 		then
 			hardfault_log reset
-			tone_alarm stop
 		fi
+	else
+		tune_control play -t 1
 	fi
 else
-	tone_alarm MBAGP
+	# tune SD_INIT
+	tune_control play -t 16
 	if mkfatfs /dev/mmcsd0
 	then
 		if mount -t vfat /dev/mmcsd0 /fs/microsd
 		then
 			echo "INFO [init] card formatted"
 		else
+			tune_control play -t 17
 			echo "ERROR [init] format failed"
-			tune_control play -m MNBG
 			set LOG_FILE /dev/null
 		fi
 	else
@@ -149,7 +164,7 @@ then
 	# Run no SD alarm.
 	if [ $LOG_FILE == /dev/null ]
 	then
-		# Error tune.
+		# tune Make FS MBAGP
 		tune_control play -t 2
 	fi
 fi
@@ -162,21 +177,6 @@ if [ -f $FRC ]
 then
 	sh $FRC
 else
-	#
-	# Start the ORB (first app to start).
-	#
-	uorb start
-
-	#
-	# Start the tone_alarm driver.
-	#
-	tone_alarm start
-
-	#
-	# Play the startup tone.
-	#
-	tune_control play -t 1
-
 	#
 	# Waypoint storage.
 	# REBOOTWORK this needs to start in parallel.
@@ -343,45 +343,53 @@ else
 
 	#
 	# Check if PX4IO present and update firmware if needed.
+	# Assumption IOFW set to firware file and IO_PRESENT = no
 	#
-	if [ -f /etc/extras/px4io-v2.bin ]
-	then
-		set IO_FILE /etc/extras/px4io-v2.bin
 
-		if px4io checkcrc ${IO_FILE}
+	if [ -f $IOFW ]
+	then
+		if px4io checkcrc ${IOFW}
 		then
 			set IO_PRESENT yes
 		else
-			tune_control play -m MLL32CP8MB
-
-			if px4io start
+			# Check for the mini using build with px4io fw file
+			# but not a px4IO
+			if ver hwtypecmp V540
 			then
-				# Try to safety px4 io so motor outputs don't go crazy.
-				if ! px4io safety_on
+				echo "PX4IO Not Suported" >> $LOG_FILE
+			else
+				# tune Program PX4IO
+				tune_control play -t 18
+
+				if px4io start
 				then
-					# px4io did not respond to the safety command.
-					px4io stop
+					# Try to safety px4 io so motor outputs don't go crazy.
+					if ! px4io safety_on
+					then
+						# px4io did not respond to the safety command.
+						px4io stop
+					fi
 				fi
-			fi
 
-			if px4io forceupdate 14662 ${IO_FILE}
-			then
-				usleep 10000
-				if px4io checkcrc ${IO_FILE}
+				if px4io forceupdate 14662 ${IOFW}
 				then
-					echo "PX4IO CRC OK after updating" >> $LOG_FILE
-					tune_control play -m MLL8CDE
+					usleep 10000
+					tune_control stop
+					if px4io checkcrc ${IOFW}
+					then
+						echo "PX4IO CRC OK after updating" >> $LOG_FILE
+						#tune MLL8CDE Program PX4IO success
+						tune_control play -t 19
+						set IO_PRESENT yes
+					fi
+				fi
 
-					set IO_PRESENT yes
-				else
+				if [ $IO_PRESENT == no ]
+				then
 					echo "PX4IO update failed" >> $LOG_FILE
 					# Error tune.
-					tune_control play -t 2
+					tune_control play -t 20
 				fi
-			else
-				echo "PX4IO update failed" >> $LOG_FILE
-				# Error tune.
-				tune_control play -t 2
 			fi
 		fi
 	fi
@@ -552,7 +560,7 @@ unset FEXTRAS
 unset FRC
 unset FMU_ARGS
 unset FMU_MODE
-unset IO_FILE
+unset IOFW
 unset IO_PRESENT
 unset LOG_FILE
 unset MAVLINK_F
@@ -579,7 +587,6 @@ unset PWM_MIN
 unset SDCARD_MIXERS_PATH
 unset USE_IO
 unset VEHICLE_TYPE
-unset TUNE_ERR
 
 #
 # Boot is complete, inform MAVLink app(s) that the system is now fully up and running.

--- a/ROMFS/px4fmu_test/init.d/rcS
+++ b/ROMFS/px4fmu_test/init.d/rcS
@@ -28,11 +28,11 @@ if [ $? == 0 ]
 then
 	echo "[i] card mounted at /fs/microsd"
 	# Start playing the startup tune
-	tone_alarm start
+	tune_control play -t 1
 else
 	echo "[i] no microSD card found"
 	# Play SOS
-	tone_alarm error
+	tune_control play -t 2
 fi
 
 #
@@ -79,22 +79,22 @@ then
 	echo "PX4IO CRC OK"
 else
 	echo "PX4IO CRC failure"
-	tone_alarm MBABGP
+	tune_control play -t  18
 	if px4io forceupdate 14662 $io_file
 	then
 		if px4io start
 		then
 			echo "PX4IO restart OK"
-			tone_alarm MSPAA
+			tune_control play -t  19
 		else
 			echo "PX4IO restart failed"
-			tone_alarm MNGGG
+			tune_control play -t  20
 			set unit_test_failure 1
 			set unit_test_failure_list "${unit_test_failure_list} px4io_flash"
 		fi
 	else
 		echo "PX4IO update failed"
-		tone_alarm MNGGG
+		tune_control play -t  20
 		set unit_test_failure 1
 		set unit_test_failure_list "${unit_test_failure_list} px4io_flash"
 	fi

--- a/ROMFS/tap_common/init.d/rc.interface
+++ b/ROMFS/tap_common/init.d/rc.interface
@@ -27,7 +27,7 @@ then
 	else
 		echo "ERROR [init] Error loading mixer: $MIXER_FILE"
 		echo "ERROR:[init] Could not load mixer: $MIXER_FILE" >> $LOG_FILE
-		tone_alarm $TUNE_ERR
+		tune_control play -t 20
 	fi
 
 	unset MIXER_FILE
@@ -36,7 +36,7 @@ else
 	then
 		echo "ERROR [init] Mixer not defined"
 		echo "ERROR [init] Mixer not defined" >> $LOG_FILE
-		tone_alarm $TUNE_ERR
+		tune_control play -t 20
 	fi
 fi
 

--- a/ROMFS/tap_common/init.d/rcS
+++ b/ROMFS/tap_common/init.d/rcS
@@ -18,9 +18,20 @@
 #
 sercon
 
-set TUNE_ERR ML<<CP4CP4CP4CP4CP4
 set LOG_FILE /fs/microsd/bootlog.txt
 set DATAMAN_OPT -r
+
+#
+# Start the ORB (first app to start)
+# tone_alarm and tune_control
+# is dependent.
+#
+uorb start
+
+#
+# Start the tone_alarm driver.
+#
+tone_alarm start
 
 #
 # Try to mount the microSD card.
@@ -38,18 +49,13 @@ else
 			unset DATAMAN_OPT
 		else
 			echo "ERROR [init] Format failed"
-			tone_alarm MNBG
+			tune_control play -t 17
 			set LOG_FILE /dev/null
 		fi
 	else
 		set LOG_FILE /dev/null
 	fi
 fi
-
-#
-# Start the ORB (first app to start)
-#
-uorb start
 
 #
 # Load parameters
@@ -65,8 +71,6 @@ if !param load
 then
 	param reset
 fi
-
-tone_alarm start
 
 #
 # Start system state indicator
@@ -356,6 +360,8 @@ fi
 # There is no further script processing, so we can free some RAM
 # XXX potentially unset all script variables.
 unset TUNE_ERR
+unset LOG_FILE
+unset DATAMAN_OPT
 
 # Boot is complete, inform MAVLink app(s) that the system is now fully up and running
 mavlink boot_complete

--- a/src/drivers/kinetis/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/kinetis/tone_alarm/tone_alarm.cpp
@@ -162,7 +162,6 @@ public:
 	virtual int init();
 	void status();
 
-
 	enum {
 		CBRK_OFF = 0,
 		CBRK_ON,
@@ -239,8 +238,7 @@ ToneAlarm::~ToneAlarm()
 	}
 }
 
-int
-ToneAlarm::init()
+int ToneAlarm::init()
 {
 	int ret;
 
@@ -254,6 +252,7 @@ ToneAlarm::init()
 	px4_arch_configgpio(GPIO_TONE_ALARM_IDLE);
 
 #ifdef GPIO_TONE_ALARM_NEG
+
 	px4_arch_configgpio(GPIO_TONE_ALARM_NEG);
 #endif
 
@@ -391,17 +390,11 @@ void ToneAlarm::next_note()
 
 	if (updated) {
 		orb_copy(ORB_ID(tune_control), _tune_control_sub, &_tune);
-
-		if (_tunes.set_control(_tune) == 0) {
-			_play_tone = true;
-
-		} else {
-			_play_tone = false;
-		}
+		_play_tone = _tunes.set_control(_tune) == 0;
 	}
 
-
-	unsigned frequency = 0, duration = 0;
+	unsigned frequency = 0;
+	unsigned duration = 0;
 
 	if (_play_tone) {
 		_play_tone = false;
@@ -432,6 +425,7 @@ void ToneAlarm::next_note()
 	}
 
 	// and arrange a callback when the note should stop
+	assert(duration != 0);
 	work_queue(HPWORK, &_work, (worker_t)&ToneAlarm::next_trampoline, this, USEC2TICK(duration));
 }
 

--- a/src/drivers/kinetis/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/kinetis/tone_alarm/tone_alarm.cpp
@@ -31,59 +31,10 @@
  *
  ****************************************************************************/
 
-/**
- * Driver for the PX4 audio alarm port, /dev/tone_alarm.
- *
- * The tone_alarm driver supports a set of predefined "alarm"
- * tunes and one user-supplied tune.
- *
- * The TONE_SET_ALARM ioctl can be used to select a predefined
- * alarm tune, from 1 - <TBD>.  Selecting tune zero silences
- * the alarm.
- *
- * Tunes follow the syntax of the Microsoft GWBasic/QBasic PLAY
- * statement, with some exceptions and extensions.
- *
- * From Wikibooks:
- *
- * PLAY "[string expression]"
- *
- * Used to play notes and a score ... The tones are indicated by letters A through G.
- * Accidentals are indicated with a "+" or "#" (for sharp) or "-" (for flat)
- * immediately after the note letter. See this example:
- *
- *   PLAY "C C# C C#"
- *
- * Whitespaces are ignored inside the string expression. There are also codes that
- * set the duration, octave and tempo. They are all case-insensitive. PLAY executes
- * the commands or notes the order in which they appear in the string. Any indicators
- * that change the properties are effective for the notes following that indicator.
- *
- * Ln     Sets the duration (length) of the notes. The variable n does not indicate an actual duration
- *        amount but rather a note type; L1 - whole note, L2 - half note, L4 - quarter note, etc.
- *        (L8, L16, L32, L64, ...). By default, n = 4.
- *        For triplets and quintets, use L3, L6, L12, ... and L5, L10, L20, ... series respectively.
- *        The shorthand notation of length is also provided for a note. For example, "L4 CDE L8 FG L4 AB"
- *        can be shortened to "L4 CDE F8G8 AB". F and G play as eighth notes while others play as quarter notes.
- * On     Sets the current octave. Valid values for n are 0 through 6. An octave begins with C and ends with B.
- *        Remember that C- is equivalent to B.
- * < >    Changes the current octave respectively down or up one level.
- * Nn     Plays a specified note in the seven-octave range. Valid values are from 0 to 84. (0 is a pause.)
- *        Cannot use with sharp and flat. Cannot use with the shorthand notation neither.
- * MN     Stand for Music Normal. Note duration is 7/8ths of the length indicated by Ln. It is the default mode.
- * ML     Stand for Music Legato. Note duration is full length of that indicated by Ln.
- * MS     Stand for Music Staccato. Note duration is 3/4ths of the length indicated by Ln.
- * Pn     Causes a silence (pause) for the length of note indicated (same as Ln).
- * Tn     Sets the number of "L4"s per minute (tempo). Valid values are from 32 to 255. The default value is T120.
- * .      When placed after a note, it causes the duration of the note to be 3/2 of the set duration.
- *        This is how to get "dotted" notes. "L4 C#." would play C sharp as a dotted quarter note.
- *        It can be used for a pause as well.
- *
- * Extensions/variations:
- *
- * MB MF  The MF command causes the tune to play once and then stop. The MB command causes the
- *        tune to repeat when it ends.
- *
+/*
+ * Low Level Driver for the PX4 audio alarm port. Subscribes to
+ * tune_control and plays notes on this architecture specific
+ * timer HW
  */
 
 #include <px4_config.h>

--- a/src/drivers/kinetis/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/kinetis/tone_alarm/tone_alarm.cpp
@@ -425,7 +425,6 @@ void ToneAlarm::next_note()
 	}
 
 	// and arrange a callback when the note should stop
-	assert(duration != 0);
 	work_queue(HPWORK, &_work, (worker_t)&ToneAlarm::next_trampoline, this, USEC2TICK(duration));
 }
 

--- a/src/drivers/samv7/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/samv7/tone_alarm/tone_alarm.cpp
@@ -388,13 +388,7 @@ void ToneAlarm::next_note()
 
 	if (updated) {
 		orb_copy(ORB_ID(tune_control), _tune_control_sub, &_tune);
-
-		if (_tunes.set_control(_tune) == 0) {
-			_play_tone = true;
-
-		} else {
-			_play_tone = false;
-		}
+		_play_tone = _tunes.set_control(_tune) == 0;
 	}
 
 	unsigned frequency = 0, duration = 0;

--- a/src/drivers/samv7/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/samv7/tone_alarm/tone_alarm.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2013 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2013, 2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,62 +31,14 @@
  *
  ****************************************************************************/
 
-/**
- * Driver for the PX4 audio alarm port, /dev/tone_alarm.
- *
- * The tone_alarm driver supports a set of predefined "alarm"
- * tunes and one user-supplied tune.
- *
- * The TONE_SET_ALARM ioctl can be used to select a predefined
- * alarm tune, from 1 - <TBD>.  Selecting tune zero silences
- * the alarm.
- *
- * Tunes follow the syntax of the Microsoft GWBasic/QBasic PLAY
- * statement, with some exceptions and extensions.
- *
- * From Wikibooks:
- *
- * PLAY "[string expression]"
- *
- * Used to play notes and a score ... The tones are indicated by letters A through G.
- * Accidentals are indicated with a "+" or "#" (for sharp) or "-" (for flat)
- * immediately after the note letter. See this example:
- *
- *   PLAY "C C# C C#"
- *
- * Whitespaces are ignored inside the string expression. There are also codes that
- * set the duration, octave and tempo. They are all case-insensitive. PLAY executes
- * the commands or notes the order in which they appear in the string. Any indicators
- * that change the properties are effective for the notes following that indicator.
- *
- * Ln     Sets the duration (length) of the notes. The variable n does not indicate an actual duration
- *        amount but rather a note type; L1 - whole note, L2 - half note, L4 - quarter note, etc.
- *        (L8, L16, L32, L64, ...). By default, n = 4.
- *        For triplets and quintets, use L3, L6, L12, ... and L5, L10, L20, ... series respectively.
- *        The shorthand notation of length is also provided for a note. For example, "L4 CDE L8 FG L4 AB"
- *        can be shortened to "L4 CDE F8G8 AB". F and G play as eighth notes while others play as quarter notes.
- * On     Sets the current octave. Valid values for n are 0 through 6. An octave begins with C and ends with B.
- *        Remember that C- is equivalent to B.
- * < >    Changes the current octave respectively down or up one level.
- * Nn     Plays a specified note in the seven-octave range. Valid values are from 0 to 84. (0 is a pause.)
- *        Cannot use with sharp and flat. Cannot use with the shorthand notation neither.
- * MN     Stand for Music Normal. Note duration is 7/8ths of the length indicated by Ln. It is the default mode.
- * ML     Stand for Music Legato. Note duration is full length of that indicated by Ln.
- * MS     Stand for Music Staccato. Note duration is 3/4ths of the length indicated by Ln.
- * Pn     Causes a silence (pause) for the length of note indicated (same as Ln).
- * Tn     Sets the number of "L4"s per minute (tempo). Valid values are from 32 to 255. The default value is T120.
- * .      When placed after a note, it causes the duration of the note to be 3/2 of the set duration.
- *        This is how to get "dotted" notes. "L4 C#." would play C sharp as a dotted quarter note.
- *        It can be used for a pause as well.
- *
- * Extensions/variations:
- *
- * MB MF  The MF command causes the tune to play once and then stop. The MB command causes the
- *        tune to repeat when it ends.
- *
+/*
+ * Low Level Driver for the PX4 audio alarm port. Subscribes to
+ * tune_control and plays notes on this architecture specific
+ * timer HW
  */
 
 #include <px4_config.h>
+#include <px4_log.h>
 #include <debug.h>
 
 #include <drivers/device/device.h>
@@ -117,6 +69,13 @@
 
 #include <systemlib/err.h>
 #include <circuit_breaker/circuit_breaker.h>
+
+#include <px4_workqueue.h>
+
+#include <lib/tunes/tunes.h>
+#include <uORB/uORB.h>
+#include <uORB/topics/tune_control.h>
+
 
 /* Check that tone alarm and HRT timers are different */
 #if defined(TONE_ALARM_CHANNEL)  && defined(HRT_TIMER_CHANNEL)
@@ -212,16 +171,10 @@ class ToneAlarm : public cdev::CDev
 {
 public:
 	ToneAlarm();
-	~ToneAlarm() = default;
+	~ToneAlarm();
 
-	virtual int		init();
-
-	virtual int		ioctl(file *filp, int cmd, unsigned long arg);
-	virtual ssize_t		write(file *filp, const char *buffer, size_t len);
-	inline const char	*name(int tune)
-	{
-		return _tune_names[tune];
-	}
+	virtual int init();
+	void status();
 
 	enum {
 		CBRK_OFF = 0,
@@ -230,81 +183,44 @@ public:
 	};
 
 private:
-	static const unsigned	_tune_max = 1024 * 8; // be reasonable about user tunes
-	const char		 *_default_tunes[TONE_NUMBER_OF_TUNES];
-	const char		 *_tune_names[TONE_NUMBER_OF_TUNES];
-	static const uint8_t	_note_tab[];
+	volatile bool _running;
+	volatile bool _should_run;
+	bool _play_tone;
 
-	unsigned		_default_tune_number; // number of currently playing default tune (0 for none)
+	Tunes _tunes;
 
-	const char		*_user_tune;
+	unsigned _silence_length; // if nonzero, silence before next note
 
-	const char		*_tune;		// current tune string
-	const char		*_next;		// next note in the string
+	int _cbrk; ///< if true, no audio output
+	int _tune_control_sub;
 
-	unsigned		_tempo;
-	unsigned		_note_length;
-	enum { MODE_NORMAL, MODE_LEGATO, MODE_STACCATO} _note_mode;
-	unsigned		_octave;
-	unsigned		_silence_length; // if nonzero, silence before next note
-	bool			_repeat;	// if true, tune restarts at end
-	int				_cbrk;	//if true, no audio output
+	tune_control_s _tune;
 
-	hrt_call		_note_call;	// HRT callout for note completion
+	static work_s _work;
 
-	// Convert a note value in the range C1 to B7 into a divisor for
-	// the configured timer's clock.
+	// Convert a frequency value into a divisor for the configured timer's clock.
 	//
-	unsigned		note_to_divisor(unsigned note);
-
-	// Calculate the duration in microseconds of play and silence for a
-	// note given the current tempo, length and mode and the number of
-	// dots following in the play string.
-	//
-	unsigned		note_duration(unsigned &silence, unsigned note_length, unsigned dots);
-
-	// Calculate the duration in microseconds of a rest corresponding to
-	// a given note length.
-	//
-	unsigned		rest_duration(unsigned rest_length, unsigned dots);
+	unsigned frequency_to_divisor(unsigned frequency);
 
 	// Start playing the note
 	//
-	void			start_note(unsigned note);
+	void start_note(unsigned frequency);
 
 	// Stop playing the current note and make the player 'safe'
 	//
-	void			stop_note();
-
-	// Start playing the tune
-	//
-	void			start_tune(const char *tune);
+	void stop_note();
 
 	// Parse the next note out of the string and play it
 	//
-	void			next_note();
+	void next_note();
 
-	// Find the next character in the string, discard any whitespace and
-	// return the canonical (uppercase) version.
+	// work queue trampoline for next_note
 	//
-	int			next_char();
-
-	// Extract a number from the string, consuming all the digit characters.
-	//
-	unsigned		next_number();
-
-	// Consume dot characters from the string, returning the number consumed.
-	//
-	unsigned		next_dots();
-
-	// hrt_call trampoline for next_note
-	//
-	static void		next_trampoline(void *arg);
+	static void next_trampoline(void *arg);
 
 };
 
-// semitone offsets from C for the characters 'A'-'G'
-const uint8_t ToneAlarm::_note_tab[] = {9, 11, 0, 2, 4, 5, 7};
+struct work_s ToneAlarm::_work = {};
 
 /*
  * Driver 'main' command.
@@ -313,50 +229,30 @@ extern "C" __EXPORT int tone_alarm_main(int argc, char *argv[]);
 
 
 ToneAlarm::ToneAlarm() :
-	CDev(TONEALARM0_DEVICE_PATH),
-	_default_tune_number(0),
-	_user_tune(nullptr),
-	_tune(nullptr),
-	_next(nullptr),
-	_cbrk(CBRK_UNINIT)
+   CDev(TONEALARM0_DEVICE_PATH),
+	_running(false),
+	_should_run(true),
+	_play_tone(false),
+	_tunes(),
+	_silence_length(0),
+	_cbrk(CBRK_UNINIT),
+	_tune_control_sub(-1)
 {
 	// enable debug() calls
 	//_debug_enabled = true;
-	_default_tunes[TONE_STARTUP_TUNE] = "MFT240L8 O4aO5dc O4aO5dc O4aO5dc L16dcdcdcdc";		// startup tune
-	_default_tunes[TONE_ERROR_TUNE] = "MBT200a8a8a8PaaaP";						// ERROR tone
-	_default_tunes[TONE_NOTIFY_POSITIVE_TUNE] = "MFT200e8a8a";					// Notify Positive tone
-	_default_tunes[TONE_NOTIFY_NEUTRAL_TUNE] = "MFT200e8e";						// Notify Neutral tone
-	_default_tunes[TONE_NOTIFY_NEGATIVE_TUNE] = "MFT200e8c8e8c8e8c8";				// Notify Negative tone
-	_default_tunes[TONE_ARMING_WARNING_TUNE] = "MNT75L1O2G";					//arming warning
-	_default_tunes[TONE_BATTERY_WARNING_SLOW_TUNE] = "MBNT100a8";					//battery warning slow
-	_default_tunes[TONE_BATTERY_WARNING_FAST_TUNE] = "MBNT255a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8";	//battery warning fast
-	_default_tunes[TONE_GPS_WARNING_TUNE] = "MFT255L4AAAL1F#";					//gps warning slow
-	_default_tunes[TONE_ARMING_FAILURE_TUNE] = "MFT255L4<<<BAP";
-	_default_tunes[TONE_PARACHUTE_RELEASE_TUNE] = "MFT255L16agagagag";			// parachute release
-	_default_tunes[TONE_EKF_WARNING_TUNE] = "MFT255L8ddd#d#eeff";				// ekf warning
-	_default_tunes[TONE_BARO_WARNING_TUNE] = "MFT255L4gf#fed#d";				// baro warning
-	_default_tunes[TONE_SINGLE_BEEP_TUNE] = "MFT100a8";                             // single beep
-	_default_tunes[TONE_HOME_SET] = "MFT100L4>G#6A#6B#4";
-
-	_tune_names[TONE_STARTUP_TUNE] = "startup";			// startup tune
-	_tune_names[TONE_ERROR_TUNE] = "error";				// ERROR tone
-	_tune_names[TONE_NOTIFY_POSITIVE_TUNE] = "positive";		// Notify Positive tone
-	_tune_names[TONE_NOTIFY_NEUTRAL_TUNE] = "neutral";		// Notify Neutral tone
-	_tune_names[TONE_NOTIFY_NEGATIVE_TUNE] = "negative";		// Notify Negative tone
-	_tune_names[TONE_ARMING_WARNING_TUNE] = "arming";		// arming warning
-	_tune_names[TONE_BATTERY_WARNING_SLOW_TUNE] = "slow_bat";	// battery warning slow
-	_tune_names[TONE_BATTERY_WARNING_FAST_TUNE] = "fast_bat";	// battery warning fast
-	_tune_names[TONE_GPS_WARNING_TUNE] = "gps_warning";	            // gps warning
-	_tune_names[TONE_ARMING_FAILURE_TUNE] = "arming_failure";            //fail to arm
-	_tune_names[TONE_PARACHUTE_RELEASE_TUNE] = "parachute_release";	// parachute release
-	_tune_names[TONE_EKF_WARNING_TUNE] = "ekf_warning";				// ekf warning
-	_tune_names[TONE_BARO_WARNING_TUNE] = "baro_warning";			// baro warning
-	_tune_names[TONE_SINGLE_BEEP_TUNE] = "beep";                    // single beep
-	_tune_names[TONE_HOME_SET] = "home_set";
 }
 
-int
-ToneAlarm::init()
+ToneAlarm::~ToneAlarm()
+{
+	_should_run = false;
+	int counter = 0;
+
+	while (_running && ++counter < 10) {
+		usleep(100000);
+	}
+}
+
+int ToneAlarm::init()
 {
 	int ret;
 
@@ -367,7 +263,7 @@ ToneAlarm::init()
 	}
 
 	/* configure the GPIO to the idle state */
-	sam_configgpio(GPIO_TONE_ALARM_IDLE);
+	px4_arch_configgpio(GPIO_TONE_ALARM_IDLE);
 
 #if TONE_ALARM_NOT_DONE	/* initialise the timer */
 	rCR1 = 0;
@@ -393,17 +289,25 @@ ToneAlarm::init()
 	/* make sure the timer is running */
 	rCR1 = GTIM_CR1_CEN;
 #endif
-
+	DEVICE_DEBUG("ready");
+	_running = true;
+	work_queue(HPWORK, &_work, (worker_t)&ToneAlarm::next_trampoline, this, 0);
 	return OK;
 }
 
-unsigned
-ToneAlarm::note_to_divisor(unsigned note)
+void ToneAlarm::status()
 {
-	// compute the frequency first (Hz)
-	float freq = 880.0f * expf(logf(2.0f) * ((int)note - 46) / 12.0f);
+	if (_running) {
+		PX4_INFO("running");
 
-	float period = 0.5f / freq;
+	} else {
+		PX4_INFO("stopped");
+	}
+}
+
+unsigned ToneAlarm::frequency_to_divisor(unsigned frequency)
+{
+	float period = 0.5f / frequency;
 
 	// and the divisor, rounded to the nearest integer
 	unsigned divisor = (period * TONE_ALARM_CLOCK) + 0.5f;
@@ -411,67 +315,7 @@ ToneAlarm::note_to_divisor(unsigned note)
 	return divisor;
 }
 
-unsigned
-ToneAlarm::note_duration(unsigned &silence, unsigned note_length, unsigned dots)
-{
-	unsigned whole_note_period = (60 * 1000000 * 4) / _tempo;
-
-	if (note_length == 0) {
-		note_length = 1;
-	}
-
-	unsigned note_period = whole_note_period / note_length;
-
-	switch (_note_mode) {
-	case MODE_NORMAL:
-		silence = note_period / 8;
-		break;
-
-	case MODE_STACCATO:
-		silence = note_period / 4;
-		break;
-
-	default:
-	case MODE_LEGATO:
-		silence = 0;
-		break;
-	}
-
-	note_period -= silence;
-
-	unsigned dot_extension = note_period / 2;
-
-	while (dots--) {
-		note_period += dot_extension;
-		dot_extension /= 2;
-	}
-
-	return note_period;
-}
-
-unsigned
-ToneAlarm::rest_duration(unsigned rest_length, unsigned dots)
-{
-	unsigned whole_note_period = (60 * 1000000 * 4) / _tempo;
-
-	if (rest_length == 0) {
-		rest_length = 1;
-	}
-
-	unsigned rest_period = whole_note_period / rest_length;
-
-	unsigned dot_extension = rest_period / 2;
-
-	while (dots--) {
-		rest_period += dot_extension;
-		dot_extension /= 2;
-	}
-
-	return rest_period;
-}
-
-void
-ToneAlarm::start_note(unsigned note)
+void ToneAlarm::start_note(unsigned frequency)
 {
 	// check if circuit breaker is enabled
 	if (_cbrk == CBRK_UNINIT) {
@@ -481,7 +325,7 @@ ToneAlarm::start_note(unsigned note)
 	if (_cbrk != CBRK_OFF) { return; }
 
 	// compute the divisor
-	unsigned divisor = note_to_divisor(note);
+	unsigned divisor = frequency_to_divisor(frequency);
 
 	// pick the lowest prescaler value that we can use
 	// (note that the effective prescale value is 1 greater)
@@ -499,11 +343,10 @@ ToneAlarm::start_note(unsigned note)
 	period++;
 #endif
 	// configure the GPIO to enable timer output
-	sam_configgpio(GPIO_TONE_ALARM);
+	px4_arch_configgpio(GPIO_TONE_ALARM);
 }
 
-void
-ToneAlarm::stop_note()
+void ToneAlarm::stop_note()
 {
 	/* stop the current note */
 #if TONE_ALARM_NOT_DONE
@@ -512,382 +355,86 @@ ToneAlarm::stop_note()
 	/*
 	 * Make sure the GPIO is not driving the speaker.
 	 */
-	sam_configgpio(GPIO_TONE_ALARM_IDLE);
+	px4_arch_configgpio(GPIO_TONE_ALARM_IDLE);
 }
 
-void
-ToneAlarm::start_tune(const char *tune)
+void ToneAlarm::next_note()
 {
-	// kill any current playback
-	hrt_cancel(&_note_call);
+	if (!_should_run) {
+		if (_tune_control_sub >= 0) {
+			orb_unsubscribe(_tune_control_sub);
+		}
 
-	// record the tune
-	_tune = tune;
-	_next = tune;
+		_running = false;
+		return;
+	}
 
-	// initialise player state
-	_tempo = 120;
-	_note_length = 4;
-	_note_mode = MODE_NORMAL;
-	_octave = 4;
-	_silence_length = 0;
-	_repeat = false;		// otherwise command-line tunes repeat forever...
+	// subscribe to tune_control
+	if (_tune_control_sub < 0) {
+		_tune_control_sub = orb_subscribe(ORB_ID(tune_control));
+	}
 
-	// schedule a callback to start playing
-	hrt_call_after(&_note_call, 0, (hrt_callout)next_trampoline, this);
-}
-
-void
-ToneAlarm::next_note()
-{
 	// do we have an inter-note gap to wait for?
 	if (_silence_length > 0) {
 		stop_note();
-		hrt_call_after(&_note_call, (hrt_abstime)_silence_length, (hrt_callout)next_trampoline, this);
+		work_queue(HPWORK, &_work, (worker_t)&ToneAlarm::next_trampoline, this, USEC2TICK(_silence_length));
 		_silence_length = 0;
 		return;
 	}
 
-	// make sure we still have a tune - may be removed by the write / ioctl handler
-	if ((_next == nullptr) || (_tune == nullptr)) {
-		stop_note();
-		return;
-	}
-
-	// parse characters out of the string until we have resolved a note
-	unsigned note = 0;
-	unsigned note_length = _note_length;
-	unsigned duration;
-
-	while (note == 0) {
-		// we always need at least one character from the string
-		int c = next_char();
-
-		if (c == 0) {
-			goto tune_end;
-		}
-
-		_next++;
-
-		switch (c) {
-		case 'L':	// select note length
-			_note_length = next_number();
-
-			if (_note_length < 1) {
-				goto tune_error;
-			}
-
-			break;
-
-		case 'O':	// select octave
-			_octave = next_number();
-
-			if (_octave > 6) {
-				_octave = 6;
-			}
-
-			break;
-
-		case '<':	// decrease octave
-			if (_octave > 0) {
-				_octave--;
-			}
-
-			break;
-
-		case '>':	// increase octave
-			if (_octave < 6) {
-				_octave++;
-			}
-
-			break;
-
-		case 'M':	// select inter-note gap
-			c = next_char();
-
-			if (c == 0) {
-				goto tune_error;
-			}
-
-			_next++;
-
-			switch (c) {
-			case 'N':
-				_note_mode = MODE_NORMAL;
-				break;
-
-			case 'L':
-				_note_mode = MODE_LEGATO;
-				break;
-
-			case 'S':
-				_note_mode = MODE_STACCATO;
-				break;
-
-			case 'F':
-				_repeat = false;
-				break;
-
-			case 'B':
-				_repeat = true;
-				break;
-
-			default:
-				goto tune_error;
-			}
-
-			break;
-
-		case 'P':	// pause for a note length
-			stop_note();
-			hrt_call_after(&_note_call,
-				       (hrt_abstime)rest_duration(next_number(), next_dots()),
-				       (hrt_callout)next_trampoline,
-				       this);
-			return;
-
-		case 'T': {	// change tempo
-				unsigned nt = next_number();
-
-				if ((nt >= 32) && (nt <= 255)) {
-					_tempo = nt;
-
-				} else {
-					goto tune_error;
-				}
-
-				break;
-			}
-
-		case 'N':	// play an arbitrary note
-			note = next_number();
-
-			if (note > 84) {
-				goto tune_error;
-			}
-
-			if (note == 0) {
-				// this is a rest - pause for the current note length
-				hrt_call_after(&_note_call,
-					       (hrt_abstime)rest_duration(_note_length, next_dots()),
-					       (hrt_callout)next_trampoline,
-					       this);
-				return;
-			}
-
-			break;
-
-		case 'A'...'G':	// play a note in the current octave
-			note = _note_tab[c - 'A'] + (_octave * 12) + 1;
-			c = next_char();
-
-			switch (c) {
-			case '#':	// up a semitone
-			case '+':
-				if (note < 84) {
-					note++;
-				}
-
-				_next++;
-				break;
-
-			case '-':	// down a semitone
-				if (note > 1) {
-					note--;
-				}
-
-				_next++;
-				break;
-
-			default:
-				// 0 / no next char here is OK
-				break;
-			}
-
-			// shorthand length notation
-			note_length = next_number();
-
-			if (note_length == 0) {
-				note_length = _note_length;
-			}
-
-			break;
-
-		default:
-			goto tune_error;
-		}
-	}
-
-	// compute the duration of the note and the following silence (if any)
-	duration = note_duration(_silence_length, note_length, next_dots());
-
-	// start playing the note
-	start_note(note);
-
-	// and arrange a callback when the note should stop
-	hrt_call_after(&_note_call, (hrt_abstime)duration, (hrt_callout)next_trampoline, this);
-	return;
-
-	// tune looks bad (unexpected EOF, bad character, etc.)
-tune_error:
-	syslog(LOG_ERR, "tune error\n");
-	_repeat = false;		// don't loop on error
-
-	// stop (and potentially restart) the tune
-tune_end:
-	stop_note();
-
-	if (_repeat) {
-		start_tune(_tune);
-
-	} else {
-		_tune = nullptr;
-		_default_tune_number = 0;
-	}
-
-	return;
-}
-
-int
-ToneAlarm::next_char()
-{
-	while (isspace(*_next)) {
-		_next++;
-	}
-
-	return toupper(*_next);
-}
-
-unsigned
-ToneAlarm::next_number()
-{
-	unsigned number = 0;
-	int c;
-
-	for (;;) {
-		c = next_char();
-
-		if (!isdigit(c)) {
-			return number;
-		}
-
-		_next++;
-		number = (number * 10) + (c - '0');
-	}
-}
-
-unsigned
-ToneAlarm::next_dots()
-{
-	unsigned dots = 0;
-
-	while (next_char() == '.') {
-		_next++;
-		dots++;
-	}
-
-	return dots;
-}
-
-void
-ToneAlarm::next_trampoline(void *arg)
-{
-	ToneAlarm *ta = (ToneAlarm *)arg;
-
-	ta->next_note();
-}
-
-
-int
-ToneAlarm::ioctl(file *filp, int cmd, unsigned long arg)
-{
-	int result = OK;
-
-	PX4_DEBUG("ioctl %i %u", cmd, arg);
-
-//	irqstate_t flags = enter_critical_section();
-
-	/* decide whether to increase the alarm level to cmd or leave it alone */
-	switch (cmd) {
-	case TONE_SET_ALARM:
-		PX4_DEBUG("TONE_SET_ALARM %u", arg);
-
-		if (arg < TONE_NUMBER_OF_TUNES) {
-			if (arg == TONE_STOP_TUNE) {
-				// stop the tune
-				_tune = nullptr;
-				_next = nullptr;
-				_repeat = false;
-				_default_tune_number = 0;
-
-			} else {
-				/* always interrupt alarms, unless they are repeating and already playing */
-				if (!(_repeat && _default_tune_number == arg)) {
-					/* play the selected tune */
-					_default_tune_number = arg;
-					start_tune(_default_tunes[arg]);
-				}
-			}
+	// check for updates
+	bool updated = false;
+	orb_check(_tune_control_sub, &updated);
+
+	if (updated) {
+		orb_copy(ORB_ID(tune_control), _tune_control_sub, &_tune);
+
+		if (_tunes.set_control(_tune) == 0) {
+			_play_tone = true;
 
 		} else {
-			result = -EINVAL;
+			_play_tone = false;
+		}
+	}
+
+	unsigned frequency = 0, duration = 0;
+
+	if (_play_tone) {
+		_play_tone = false;
+		int parse_ret_val = _tunes.get_next_tune(frequency, duration, _silence_length);
+
+		if (parse_ret_val >= 0) {
+			// a frequency of 0 correspond to stop_note
+			if (frequency > 0) {
+				// start playing the note
+				start_note(frequency);
+
+			} else {
+				stop_note();
+			}
+
+
+			if (parse_ret_val > 0) {
+				// continue playing
+				_play_tone = true;
+			}
 		}
 
-		break;
-
-	default:
-		result = -ENOTTY;
-		break;
+	} else {
+		// schedule a call with the tunes max interval
+		duration = _tunes.get_maximum_update_interval();
+		// stop playing the last note after the duration elapsed
+		stop_note();
 	}
 
-//	leave_critical_section(flags);
-
-	/* give it to the superclass if we didn't like it */
-	if (result == -ENOTTY) {
-		result = CDev::ioctl(filp, cmd, arg);
-	}
-
-	return result;
+	// and arrange a callback when the note should stop
+	work_queue(HPWORK, &_work, (worker_t)&ToneAlarm::next_trampoline, this, USEC2TICK(duration));
 }
 
-int
-ToneAlarm::write(file *filp, const char *buffer, size_t len)
+void ToneAlarm::next_trampoline(void *arg)
 {
-	// sanity-check the buffer for length and nul-termination
-	if (len > _tune_max) {
-		return -EFBIG;
-	}
-
-	// if we have an existing user tune, free it
-	if (_user_tune != nullptr) {
-
-		// if we are playing the user tune, stop
-		if (_tune == _user_tune) {
-			_tune = nullptr;
-			_next = nullptr;
-		}
-
-		// free the old user tune
-		free((void *)_user_tune);
-		_user_tune = nullptr;
-	}
-
-	// if the new tune is empty, we're done
-	if (buffer[0] == '\0') {
-		return OK;
-	}
-
-	// allocate a copy of the new tune
-	_user_tune = strndup(buffer, len);
-
-	if (_user_tune == nullptr) {
-		return -ENOMEM;
-	}
-
-	// and play it
-	start_tune(_user_tune);
-
-	return len;
+	ToneAlarm *ta = (ToneAlarm *)arg;
+	ta->next_note();
 }
 
 /**
@@ -898,130 +445,60 @@ namespace
 
 ToneAlarm	*g_dev;
 
-int
-play_tune(unsigned tune)
-{
-	exit(0);
-
-	int	fd, ret;
-
-	fd = open(TONEALARM0_DEVICE_PATH, 0);
-
-	if (fd < 0) {
-		err(1, TONEALARM0_DEVICE_PATH);
-	}
-
-	ret = ioctl(fd, TONE_SET_ALARM, tune);
-	close(fd);
-
-	if (ret != 0) {
-		err(1, "TONE_SET_ALARM");
-	}
-
-	exit(0);
-}
-
-int
-play_string(const char *str, bool free_buffer)
-{
-	int	fd, ret;
-
-	fd = open(TONEALARM0_DEVICE_PATH, O_WRONLY);
-
-	if (fd < 0) {
-		err(1, TONEALARM0_DEVICE_PATH);
-	}
-
-	ret = write(fd, str, strlen(str) + 1);
-	close(fd);
-
-	if (free_buffer) {
-		free((void *)str);
-	}
-
-	if (ret < 0) {
-		err(1, "play tune");
-	}
-
-	exit(0);
-}
-
 } // namespace
 
-int
-tone_alarm_main(int argc, char *argv[])
+void tone_alarm_usage();
+
+void tone_alarm_usage()
 {
-	unsigned tune = 0;
+	PX4_INFO("missing command, try 'start', status, 'stop'");
+}
 
-	/* start the driver lazily */
-	if (g_dev == nullptr) {
-		g_dev = new ToneAlarm;
-
-		if (g_dev == nullptr) {
-			errx(1, "couldn't allocate the ToneAlarm driver");
-		}
-
-		if (g_dev->init() != OK) {
-			delete g_dev;
-			errx(1, "ToneAlarm init failed");
-		}
-	}
+int tone_alarm_main(int argc, char *argv[])
+{
 
 	if (argc > 1) {
 		const char *argv1 = argv[1];
 
 		if (!strcmp(argv1, "start")) {
-			play_tune(TONE_STOP_TUNE);
+			if (g_dev != nullptr) {
+				PX4_ERR("already started");
+				exit(1);
+			}
+
+			if (g_dev == nullptr) {
+				g_dev = new ToneAlarm();
+
+				if (g_dev == nullptr) {
+					PX4_ERR("couldn't allocate the ToneAlarm driver");
+					exit(1);
+				}
+
+				if (OK != g_dev->init()) {
+					delete g_dev;
+					g_dev = nullptr;
+					PX4_ERR("ToneAlarm init failed");
+					exit(1);
+				}
+			}
+
+			exit(0);
 		}
 
 		if (!strcmp(argv1, "stop")) {
-			play_tune(TONE_STOP_TUNE);
+			delete g_dev;
+			g_dev = nullptr;
+			exit(0);
 		}
 
-		if ((tune = strtol(argv1, nullptr, 10)) != 0) {
-			play_tune(tune);
-		}
-
-		/* It might be a tune name */
-		for (tune = 1; tune < TONE_NUMBER_OF_TUNES; tune++)
-			if (!strcmp(g_dev->name(tune), argv1)) {
-				play_tune(tune);
-			}
-
-		/* If it is a file name then load and play it as a string */
-		if (*argv1 == '/') {
-			FILE *fd = fopen(argv1, "r");
-			int sz;
-			char *buffer;
-
-			if (fd == nullptr) {
-				errx(1, "couldn't open '%s'", argv1);
-			}
-
-			fseek(fd, 0, SEEK_END);
-			sz = ftell(fd);
-			fseek(fd, 0, SEEK_SET);
-			buffer = (char *)malloc(sz + 1);
-
-			if (buffer == nullptr) {
-				errx(1, "not enough memory memory");
-			}
-
-			fread(buffer, sz, 1, fd);
-			/* terminate the string */
-			buffer[sz] = 0;
-			play_string(buffer, true);
-		}
-
-		/* if it looks like a PLAY string... */
-		if (strlen(argv1) > 2) {
-			if (*argv1 == 'M') {
-				play_string(argv1, false);
-			}
+		if (!strcmp(argv1, "status")) {
+			g_dev->status();
+			exit(0);
 		}
 
 	}
 
-	errx(1, "unrecognized command, try 'start', 'stop', an alarm number or name, or a file name starting with a '/'");
+	tone_alarm_usage();
+	exit(0);
 }
 #endif /* TONE_ALARM_CHANNEL */

--- a/src/drivers/samv7/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/samv7/tone_alarm/tone_alarm.cpp
@@ -229,7 +229,7 @@ extern "C" __EXPORT int tone_alarm_main(int argc, char *argv[]);
 
 
 ToneAlarm::ToneAlarm() :
-   CDev(TONEALARM0_DEVICE_PATH),
+	CDev(TONEALARM0_DEVICE_PATH),
 	_running(false),
 	_should_run(true),
 	_play_tone(false),
@@ -289,7 +289,6 @@ int ToneAlarm::init()
 	/* make sure the timer is running */
 	rCR1 = GTIM_CR1_CEN;
 #endif
-	DEVICE_DEBUG("ready");
 	_running = true;
 	work_queue(HPWORK, &_work, (worker_t)&ToneAlarm::next_trampoline, this, 0);
 	return OK;

--- a/src/drivers/stm32/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/stm32/tone_alarm/tone_alarm.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2013, 2016 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2013, 2016, 2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,59 +31,10 @@
  *
  ****************************************************************************/
 
-/**
- * Driver for the PX4 audio alarm port, /dev/tone_alarm.
- *
- * The tone_alarm driver supports a set of predefined "alarm"
- * tunes and one user-supplied tune.
- *
- * The TONE_SET_ALARM ioctl can be used to select a predefined
- * alarm tune, from 1 - <TBD>.  Selecting tune zero silences
- * the alarm.
- *
- * Tunes follow the syntax of the Microsoft GWBasic/QBasic PLAY
- * statement, with some exceptions and extensions.
- *
- * From Wikibooks:
- *
- * PLAY "[string expression]"
- *
- * Used to play notes and a score ... The tones are indicated by letters A through G.
- * Accidentals are indicated with a "+" or "#" (for sharp) or "-" (for flat)
- * immediately after the note letter. See this example:
- *
- *   PLAY "C C# C C#"
- *
- * Whitespaces are ignored inside the string expression. There are also codes that
- * set the duration, octave and tempo. They are all case-insensitive. PLAY executes
- * the commands or notes the order in which they appear in the string. Any indicators
- * that change the properties are effective for the notes following that indicator.
- *
- * Ln     Sets the duration (length) of the notes. The variable n does not indicate an actual duration
- *        amount but rather a note type; L1 - whole note, L2 - half note, L4 - quarter note, etc.
- *        (L8, L16, L32, L64, ...). By default, n = 4.
- *        For triplets and quintets, use L3, L6, L12, ... and L5, L10, L20, ... series respectively.
- *        The shorthand notation of length is also provided for a note. For example, "L4 CDE L8 FG L4 AB"
- *        can be shortened to "L4 CDE F8G8 AB". F and G play as eighth notes while others play as quarter notes.
- * On     Sets the current octave. Valid values for n are 0 through 6. An octave begins with C and ends with B.
- *        Remember that C- is equivalent to B.
- * < >    Changes the current octave respectively down or up one level.
- * Nn     Plays a specified note in the seven-octave range. Valid values are from 0 to 84. (0 is a pause.)
- *        Cannot use with sharp and flat. Cannot use with the shorthand notation neither.
- * MN     Stand for Music Normal. Note duration is 7/8ths of the length indicated by Ln. It is the default mode.
- * ML     Stand for Music Legato. Note duration is full length of that indicated by Ln.
- * MS     Stand for Music Staccato. Note duration is 3/4ths of the length indicated by Ln.
- * Pn     Causes a silence (pause) for the length of note indicated (same as Ln).
- * Tn     Sets the number of "L4"s per minute (tempo). Valid values are from 32 to 255. The default value is T120.
- * .      When placed after a note, it causes the duration of the note to be 3/2 of the set duration.
- *        This is how to get "dotted" notes. "L4 C#." would play C sharp as a dotted quarter note.
- *        It can be used for a pause as well.
- *
- * Extensions/variations:
- *
- * MB MF  The MF command causes the tune to play once and then stop. The MB command causes the
- *        tune to repeat when it ends.
- *
+/*
+ * Low Level Driver for the PX4 audio alarm port. Subscribes to
+ * tune_control and plays notes on this architecture specific
+ * timer HW
  */
 
 #include <px4_config.h>

--- a/src/drivers/stm32/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/stm32/tone_alarm/tone_alarm.cpp
@@ -476,16 +476,11 @@ void ToneAlarm::next_note()
 
 	if (updated) {
 		orb_copy(ORB_ID(tune_control), _tune_control_sub, &_tune);
-
-		if (_tunes.set_control(_tune) == 0) {
-			_play_tone = true;
-
-		} else {
-			_play_tone = false;
-		}
+		_play_tone = _tunes.set_control(_tune) == 0;
 	}
 
-	unsigned frequency = 0, duration = 0;
+	unsigned frequency = 0;
+	unsigned duration = 0;
 
 	if (_play_tone) {
 		_play_tone = false;
@@ -516,6 +511,7 @@ void ToneAlarm::next_note()
 	}
 
 	// and arrange a callback when the note should stop
+	assert(duration != 0);
 	work_queue(HPWORK, &_work, (worker_t)&ToneAlarm::next_trampoline, this, USEC2TICK(duration));
 }
 

--- a/src/drivers/stm32/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/stm32/tone_alarm/tone_alarm.cpp
@@ -511,7 +511,6 @@ void ToneAlarm::next_note()
 	}
 
 	// and arrange a callback when the note should stop
-	assert(duration != 0);
 	work_queue(HPWORK, &_work, (worker_t)&ToneAlarm::next_trampoline, this, USEC2TICK(duration));
 }
 

--- a/src/lib/tunes/default_tunes.cpp
+++ b/src/lib/tunes/default_tunes.cpp
@@ -37,25 +37,19 @@
 
 #include "tunes.h"
 
-// initialise default tunes
+#define PX4_DEFINE_TUNE(ordinal,name,tune,interruptable) tune,
+// Initialize default tunes
 const char *const Tunes::_default_tunes[] = {
-	"", // empty to align with the index
-	"MFT240L8 O4aO5dc O4aO5dc O4aO5dc L16dcdcdcdc", // startup tune
-	"MBT200a8a8a8PaaaP", // ERROR tone
-	"MFT200e8a8a", // Notify Positive tone
-	"MFT200e8e", // Notify Neutral tone
-	"MFT200e8c8e8c8e8c8", // Notify Negative tone
-	"MNT75L1O2G", //arming warning
-	"MBNT100a8", //battery warning slow
-	"MBNT255a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8", //battery warning fast
-	"MFT255L4AAAL1F#", //gps warning slow
-	"MFT255L4<<<BAP", // arming failure tune
-	"MFT255L16agagagag", // parachute release
-	"MFT255L8ddd#d#eeff", // ekf warning
-	"MFT255L4gf#fed#d", // baro warning
-	"MFT100a8", // single beep
-	"MFT100L4>G#6A#6B#4", // home set tune
+#include "tune_definition.desc"
 };
+#undef PX4_DEFINE_TUNE
+
+#define PX4_DEFINE_TUNE(ordinal,name,tune,interruptable) interruptable,
+// Initialize default tunes
+const bool Tunes::_default_tunes_interruptable[] = {
+#include "tune_definition.desc"
+};
+#undef PX4_DEFINE_TUNE
 
 // set default_tunes array size
 const unsigned int Tunes::_default_tunes_size =  sizeof(_default_tunes) / sizeof(_default_tunes[0]);

--- a/src/lib/tunes/tune_definition.desc
+++ b/src/lib/tunes/tune_definition.desc
@@ -1,0 +1,108 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Driver for the PX4 audio .
+ *
+ * The tune_control supports a set of predefined "alarm" tunes and
+ * one user-supplied tune.
+ *
+ * Tunes follow the syntax of the Microsoft GWBasic/QBasic PLAY
+ * statement, with some exceptions and extensions.
+ *
+ * From Wikibooks:
+ *
+ * PLAY "[string expression]"
+ *
+ * Used to play notes and a score ... The tones are indicated by letters A through G.
+ * Accidentals are indicated with a "+" or "#" (for sharp) or "-" (for flat)
+ * immediately after the note letter. See this example:
+ *
+ *   PLAY "C C# C C#"
+ *
+ * Whitespaces are ignored inside the string expression. There are also codes that
+ * set the duration, octave and tempo. They are all case-insensitive. PLAY executes
+ * the commands or notes the order in which they appear in the string. Any indicators
+ * that change the properties are effective for the notes following that indicator.
+ *
+ * Ln     Sets the duration (length) of the notes. The variable n does not indicate an actual duration
+ *        amount but rather a note type; L1 - whole note, L2 - half note, L4 - quarter note, etc.
+ *        (L8, L16, L32, L64, ...). By default, n = 4.
+ *        For triplets and quintets, use L3, L6, L12, ... and L5, L10, L20, ... series respectively.
+ *        The shorthand notation of length is also provided for a note. For example, "L4 CDE L8 FG L4 AB"
+ *        can be shortened to "L4 CDE F8G8 AB". F and G play as eighth notes while others play as quarter notes.
+ * On     Sets the current octave. Valid values for n are 0 through 6. An octave begins with C and ends with B.
+ *        Remember that C- is equivalent to B.
+ * < >    Changes the current octave respectively down or up one level.
+ * Nn     Plays a specified note in the seven-octave range. Valid values are from 0 to 84. (0 is a pause.)
+ *        Cannot use with sharp and flat. Cannot use with the shorthand notation neither.
+ * MN     Stand for Music Normal. Note duration is 7/8ths of the length indicated by Ln. It is the default mode.
+ * ML     Stand for Music Legato. Note duration is full length of that indicated by Ln.
+ * MS     Stand for Music Staccato. Note duration is 3/4ths of the length indicated by Ln.
+ * Pn     Causes a silence (pause) for the length of note indicated (same as Ln).
+ * Tn     Sets the number of "L4"s per minute (tempo). Valid values are from 32 to 255. The default value is T120.
+ * .      When placed after a note, it causes the duration of the note to be 3/2 of the set duration.
+ *        This is how to get "dotted" notes. "L4 C#." would play C sharp as a dotted quarter note.
+ *        It can be used for a pause as well.
+ *
+ * Extensions/variations:
+ *
+ * MB MF  The MF command causes the tune to play once and then stop. The MB command causes the
+ *        tune to repeat when it ends.
+ *
+ */
+
+
+//           ordinal name                  tune                                        interruptable*     hint
+//  * Repeated tunes should always be defined as interruptable, if not an explict 'tone_control stop' is needed
+PX4_DEFINE_TUNE(0,  CUSTOM,                "",                                              true  /*  empty to align with the index */)
+PX4_DEFINE_TUNE(1,  STARTUP,               "MFT240L8 O4aO5dc O4aO5dc O4aO5dc L16dcdcdcdc",  true  /*  startup tune */)
+PX4_DEFINE_TUNE(2,  ERROR_TUNE,            "MBT200a8a8a8PaaaP",                             true  /*  ERROR tone */)
+PX4_DEFINE_TUNE(3,  NOTIFY_POSITIVE,       "MFT200e8a8a",                                   true  /*  Notify Positive tone */)
+PX4_DEFINE_TUNE(4,  NOTIFY_NEUTRAL,        "MFT200e8e",                                     true  /*  Notify Neutral tone */)
+PX4_DEFINE_TUNE(5,  NOTIFY_NEGATIVE,       "MFT200e8c8e8c8e8c8",                            true  /*  Notify Negative tone */)
+PX4_DEFINE_TUNE(6,  ARMING_WARNING,        "MNT75L1O2G",                                    false /*  arming warning */)
+PX4_DEFINE_TUNE(7,  BATTERY_WARNING_SLOW,  "MBNT100a8",                                     true  /*  battery warning slow */)
+PX4_DEFINE_TUNE(8,  BATTERY_WARNING_FAST,  "MBNT255a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8",       true  /*  battery warning fast */)
+PX4_DEFINE_TUNE(9,  GPS_WARNING,           "MFT255L4AAAL1F#",                               false /*  gps warning slow */)
+PX4_DEFINE_TUNE(10, ARMING_FAILURE,        "MFT255L4<<<BAP",                                false /*  arming failure tune */)
+PX4_DEFINE_TUNE(11, PARACHUTE_RELEASE,     "MFT255L16agagagag",                             false /*  parachute release */)
+PX4_DEFINE_TUNE(12, EKF_WARNING,           "MFT255L8ddd#d#eeff",                            false /*  ekf warning */)
+PX4_DEFINE_TUNE(13, BARO_WARNING,          "MFT255L4gf#fed#d",                              false /*  baro warning */)
+PX4_DEFINE_TUNE(14, SINGLE_BEEP,           "MFT100a8",                                      false /*  single beep */)
+PX4_DEFINE_TUNE(15, HOME_SET,              "MFT100L4>G#6A#6B#4",                            false /*  home set tune */)
+PX4_DEFINE_TUNE(16, SD_INIT,               "MBAGP",                                         false /*  Make FS */)
+PX4_DEFINE_TUNE(17, SD_ERROR,              "MNBG",                                          false /*  format failed */)
+PX4_DEFINE_TUNE(18, PROG_PX4IO,            "MLL32CP8MB",                                    false /*  Program PX4IO */)
+PX4_DEFINE_TUNE(19, PROG_PX4IO_OK,         "MLL8CDE",                                       false /*  Program PX4IO success */)
+PX4_DEFINE_TUNE(20, PROG_PX4IO_ERR,        "ML<<CP4CP4CP4CP4CP4",                           true  /*  Program PX4IO fail */)

--- a/src/lib/tunes/tune_definition.h
+++ b/src/lib/tunes/tune_definition.h
@@ -33,21 +33,9 @@
 
 #pragma once
 
+#define PX4_DEFINE_TUNE(ordinal,name,tune,interruptable) name,
 enum class TuneID {
-	CUSTOM = 0,
-	STARTUP,
-	ERROR_TUNE,
-	NOTIFY_POSITIVE,
-	NOTIFY_NEUTRAL,
-	NOTIFY_NEGATIVE,
-	ARMING_WARNING,
-	BATTERY_WARNING_SLOW,
-	BATTERY_WARNING_FAST,
-	GPS_WARNING,
-	ARMING_FAILURE,
-	PARACHUTE_RELEASE,
-	EKF_WARNING,
-	BARO_WARNING,
-	SINGLE_BEEP,
-	HOME_SET
+#include "tune_definition.desc"
+	NONE = -1
 };
+#undef PX4_DEFINE_TUNE

--- a/src/lib/tunes/tunes.h
+++ b/src/lib/tunes/tunes.h
@@ -127,8 +127,10 @@ public:
 
 private:
 	static const char *const _default_tunes[];
+	static const bool _default_tunes_interruptable[];
 	static const uint8_t _note_tab[];
 	static const unsigned int _default_tunes_size;
+	int _current_tune_id = static_cast<int>(TuneID::NONE);
 	bool _repeat = false;	     ///< if true, tune restarts at end
 	const char *_tune = nullptr; ///< current tune string
 	const char *_next = nullptr; ///< next note in the string

--- a/src/platforms/posix/drivers/tonealrmsim/tone_alarm.cpp
+++ b/src/platforms/posix/drivers/tonealrmsim/tone_alarm.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2013, 2017 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2013, 2017-2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,59 +31,10 @@
  *
  ****************************************************************************/
 
-/**
- * Driver for the PX4 audio alarm port, /dev/tone_alarm.
- *
- * The tone_alarm driver supports a set of predefined "alarm"
- * tunes and one user-supplied tune.
- *
- * The TONE_SET_ALARM ioctl can be used to select a predefined
- * alarm tune, from 1 - <TBD>.  Selecting tune zero silences
- * the alarm.
- *
- * Tunes follow the syntax of the Microsoft GWBasic/QBasic PLAY
- * statement, with some exceptions and extensions.
- *
- * From Wikibooks:
- *
- * PLAY "[string expression]"
- *
- * Used to play notes and a score ... The tones are indicated by letters A through G.
- * Accidentals are indicated with a "+" or "#" (for sharp) or "-" (for flat)
- * immediately after the note letter. See this example:
- *
- *   PLAY "C C# C C#"
- *
- * Whitespaces are ignored inside the string expression. There are also codes that
- * set the duration, octave and tempo. They are all case-insensitive. PLAY executes
- * the commands or notes the order in which they appear in the string. Any indicators
- * that change the properties are effective for the notes following that indicator.
- *
- * Ln     Sets the duration (length) of the notes. The variable n does not indicate an actual duration
- *        amount but rather a note type; L1 - whole note, L2 - half note, L4 - quarter note, etc.
- *        (L8, L16, L32, L64, ...). By default, n = 4.
- *        For triplets and quintets, use L3, L6, L12, ... and L5, L10, L20, ... series respectively.
- *        The shorthand notation of length is also provided for a note. For example, "L4 CDE L8 FG L4 AB"
- *        can be shortened to "L4 CDE F8G8 AB". F and G play as eighth notes while others play as quarter notes.
- * On     Sets the current octave. Valid values for n are 0 through 6. An octave begins with C and ends with B.
- *        Remember that C- is equivalent to B.
- * < >    Changes the current octave respectively down or up one level.
- * Nn     Plays a specified note in the seven-octave range. Valid values are from 0 to 84. (0 is a pause.)
- *        Cannot use with sharp and flat. Cannot use with the shorthand notation neither.
- * MN     Stand for Music Normal. Note duration is 7/8ths of the length indicated by Ln. It is the default mode.
- * ML     Stand for Music Legato. Note duration is full length of that indicated by Ln.
- * MS     Stand for Music Staccato. Note duration is 3/4ths of the length indicated by Ln.
- * Pn     Causes a silence (pause) for the length of note indicated (same as Ln).
- * Tn     Sets the number of "L4"s per minute (tempo). Valid values are from 32 to 255. The default value is T120.
- * .      When placed after a note, it causes the duration of the note to be 3/2 of the set duration.
- *        This is how to get "dotted" notes. "L4 C#." would play C sharp as a dotted quarter note.
- *        It can be used for a pause as well.
- *
- * Extensions/variations:
- *
- * MB MF  The MF command causes the tune to play once and then stop. The MB command causes the
- *        tune to repeat when it ends.
- *
+/*
+ * Simulated Low Level Driver for the PX4 audio alarm port. Subscribes to
+ * tune_control and plays notes on this architecture specific
+ * timer HW
  */
 
 #include <px4_config.h>
@@ -108,101 +59,76 @@
 #include <drivers/drv_hrt.h>
 
 #include <systemlib/err.h>
+#include <circuit_breaker/circuit_breaker.h>
+
+#include <lib/tunes/tunes.h>
+#include <uORB/uORB.h>
+#include <uORB/topics/tune_control.h>
 
 #include "VirtDevObj.hpp"
 
 using namespace DriverFramework;
 
+#if !defined(UNUSED)
+#  define UNUSED(a) ((void)(a))
+#endif
+
+#define CBRK_BUZZER_KEY 782097
+
 class ToneAlarm : public VirtDevObj
 {
 public:
 	ToneAlarm();
-	~ToneAlarm() = default;
+	~ToneAlarm();
 
-	virtual int		devIOCTL(unsigned long cmd, unsigned long arg);
-	virtual ssize_t		devWrite(const void *buffer, size_t len);
-	inline const char	*name(int tune)
-	{
-		return _tune_names[tune];
-	}
+	virtual int init();
+	void status();
+
+	enum {
+		CBRK_OFF = 0,
+		CBRK_ON,
+		CBRK_UNINIT
+	};
 
 private:
-	static const unsigned	_tune_max = 1024 * 8; // be reasonable about user tunes
-	const char		 *_default_tunes[TONE_NUMBER_OF_TUNES];
-	const char		 *_tune_names[TONE_NUMBER_OF_TUNES];
-	static const uint8_t	_note_tab[];
+	volatile bool _running;
+	volatile bool _should_run;
+	bool _play_tone;
 
-	unsigned		_default_tune_number; // number of currently playing default tune (0 for none)
-
-	const char		*_user_tune;
-
-	const char		*_tune;		// current tune string
-	const char		*_next;		// next note in the string
-
-	unsigned		_tempo;
-	unsigned		_note_length;
-	enum { MODE_NORMAL, MODE_LEGATO, MODE_STACCATO} _note_mode;
-	unsigned		_octave;
-	unsigned		_silence_length; // if nonzero, silence before next note
-	bool			_repeat;	// if true, tune restarts at end
+	Tunes _tunes;
 
 	hrt_call		_note_call;	// HRT callout for note completion
 
-	// Convert a note value in the range C1 to B7 into a divisor for
-	// the configured timer's clock.
-	//
-	unsigned		note_to_divisor(unsigned note);
+	unsigned _silence_length; // if nonzero, silence before next note
 
-	// Calculate the duration in microseconds of play and silence for a
-	// note given the current tempo, length and mode and the number of
-	// dots following in the play string.
-	//
-	unsigned		note_duration(unsigned &silence, unsigned note_length, unsigned dots);
+	int _cbrk; ///< if true, no audio output
+	int _tune_control_sub;
 
-	// Calculate the duration in microseconds of a rest corresponding to
-	// a given note length.
+	tune_control_s _tune;
+
+	// Convert a frequency value into a divisor for the configured timer's clock.
 	//
-	unsigned		rest_duration(unsigned rest_length, unsigned dots);
+	unsigned frequency_to_divisor(unsigned frequency);
 
 	// Start playing the note
 	//
-	void			start_note(unsigned note);
+	void start_note(unsigned frequency);
 
 	// Stop playing the current note and make the player 'safe'
 	//
-	void			stop_note();
-
-	// Start playing the tune
-	//
-	void			start_tune(const char *tune);
+	void stop_note();
 
 	// Parse the next note out of the string and play it
 	//
-	void			next_note();
-
-	// Find the next character in the string, discard any whitespace and
-	// return the canonical (uppercase) version.
-	//
-	int			next_char();
-
-	// Extract a number from the string, consuming all the digit characters.
-	//
-	unsigned		next_number();
-
-	// Consume dot characters from the string, returning the number consumed.
-	//
-	unsigned		next_dots();
+	void next_note();
 
 	// hrt_call trampoline for next_note
 	//
-	static void		next_trampoline(void *arg);
+	static void next_trampoline(void *arg);
 
 	// Unused
 	virtual void _measure() {}
 };
-
-// semitone offsets from C for the characters 'A'-'G'
-const uint8_t ToneAlarm::_note_tab[] = {9, 11, 0, 2, 4, 5, 7};
 
 /*
  * Driver 'main' command.
@@ -212,53 +138,57 @@ extern "C" __EXPORT int tone_alarm_main(int argc, char *argv[]);
 
 ToneAlarm::ToneAlarm() :
 	VirtDevObj("tone_alarm", TONEALARM0_DEVICE_PATH, nullptr, 0),
-	_default_tune_number(0),
-	_user_tune(nullptr),
-	_tune(nullptr),
-	_next(nullptr),
-	_note_call{}
+	_running(false),
+	_should_run(true),
+	_play_tone(false),
+	_tunes(),
+	_silence_length(0),
+	_cbrk(CBRK_UNINIT),
+	_tune_control_sub(-1)
 {
-	_default_tunes[TONE_STARTUP_TUNE] = "MFT240L8 O4aO5dc O4aO5dc O4aO5dc L16dcdcdcdc";		// startup tune
-	_default_tunes[TONE_ERROR_TUNE] = "MBT200a8a8a8PaaaP";						// ERROR tone
-	_default_tunes[TONE_NOTIFY_POSITIVE_TUNE] = "MFT200e8a8a";					// Notify Positive tone
-	_default_tunes[TONE_NOTIFY_NEUTRAL_TUNE] = "MFT200e8e";						// Notify Neutral tone
-	_default_tunes[TONE_NOTIFY_NEGATIVE_TUNE] = "MFT200e8c8e8c8e8c8";				// Notify Negative tone
-	_default_tunes[TONE_ARMING_WARNING_TUNE] = "MNT75L1O2G";					//arming warning
-	_default_tunes[TONE_BATTERY_WARNING_SLOW_TUNE] = "MBNT100a8";					//battery warning slow
-	_default_tunes[TONE_BATTERY_WARNING_FAST_TUNE] = "MBNT255a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8a8";	//battery warning fast
-	_default_tunes[TONE_GPS_WARNING_TUNE] = "MFT255L4AAAL1F#";					//gps warning slow
-	_default_tunes[TONE_ARMING_FAILURE_TUNE] = "MFT255L4<<<BAP";
-	_default_tunes[TONE_PARACHUTE_RELEASE_TUNE] = "MFT255L16agagagag";			// parachute release
-	_default_tunes[TONE_EKF_WARNING_TUNE] = "MFT255L8ddd#d#eeff";				// ekf warning
-	_default_tunes[TONE_BARO_WARNING_TUNE] = "MFT255L4gf#fed#d";				// baro warning
-	_default_tunes[TONE_SINGLE_BEEP_TUNE] = "MFT100a8";                             // single beep
-
-	_tune_names[TONE_STARTUP_TUNE] = "startup";			// startup tune
-	_tune_names[TONE_ERROR_TUNE] = "error";				// ERROR tone
-	_tune_names[TONE_NOTIFY_POSITIVE_TUNE] = "positive";		// Notify Positive tone
-	_tune_names[TONE_NOTIFY_NEUTRAL_TUNE] = "neutral";		// Notify Neutral tone
-	_tune_names[TONE_NOTIFY_NEGATIVE_TUNE] = "negative";		// Notify Negative tone
-	_tune_names[TONE_ARMING_WARNING_TUNE] = "arming";		// arming warning
-	_tune_names[TONE_BATTERY_WARNING_SLOW_TUNE] = "slow_bat";	// battery warning slow
-	_tune_names[TONE_BATTERY_WARNING_FAST_TUNE] = "fast_bat";	// battery warning fast
-	_tune_names[TONE_GPS_WARNING_TUNE] = "gps_warning";	            // gps warning
-	_tune_names[TONE_ARMING_FAILURE_TUNE] = "arming_failure";            //fail to arm
-	_tune_names[TONE_PARACHUTE_RELEASE_TUNE] = "parachute_release";	// parachute release
-	_tune_names[TONE_EKF_WARNING_TUNE] = "ekf_warning";				// ekf warning
-	_tune_names[TONE_BARO_WARNING_TUNE] = "baro_warning";			// baro warning
-	_tune_names[TONE_SINGLE_BEEP_TUNE] = "beep";                    // single beep
-	_tune_names[TONE_HOME_SET] = "home_set";
 }
 
-unsigned
-ToneAlarm::note_to_divisor(unsigned note)
+ToneAlarm::~ToneAlarm()
+{
+	_should_run = false;
+	int counter = 0;
+
+	while (_running && ++counter < 10) {
+		usleep(100000);
+	}
+}
+
+int ToneAlarm::init()
+{
+	int ret;
+
+	ret = VirtDevObj::init();
+
+	if (ret != OK) {
+		return ret;
+	}
+
+	_note_call = {};
+	hrt_call_after(&_note_call, (hrt_abstime)TUNE_MAX_UPDATE_INTERVAL_US, (hrt_callout)next_trampoline, this);
+	_running = true;
+	return OK;
+}
+
+void ToneAlarm::status()
+{
+	if (_running) {
+		PX4_INFO("running");
+
+	} else {
+		PX4_INFO("stopped");
+	}
+}
+
+unsigned ToneAlarm::frequency_to_divisor(unsigned frequency)
 {
 	const int TONE_ALARM_CLOCK = 120000000ul / 4;
 
-	// compute the frequency first (Hz)
-	float freq = 880.0f * expf(logf(2.0f) * ((int)note - 46) / 12.0f);
-
-	float period = 0.5f / freq;
+	float period = 0.5f / frequency;
 
 	// and the divisor, rounded to the nearest integer
 	unsigned divisor = (period * TONE_ALARM_CLOCK) + 0.5f;
@@ -266,74 +196,17 @@ ToneAlarm::note_to_divisor(unsigned note)
 	return divisor;
 }
 
-unsigned
-ToneAlarm::note_duration(unsigned &silence, unsigned note_length, unsigned dots)
+void ToneAlarm::start_note(unsigned frequency)
 {
-	unsigned whole_note_period = (60 * 1000000 * 4) / _tempo;
-
-	if (note_length == 0) {
-		note_length = 1;
+	// check if circuit breaker is enabled
+	if (_cbrk == CBRK_UNINIT) {
+		_cbrk = circuit_breaker_enabled("CBRK_BUZZER", CBRK_BUZZER_KEY);
 	}
 
-	unsigned note_period = whole_note_period / note_length;
+	if (_cbrk != CBRK_OFF) { return; }
 
-	switch (_note_mode) {
-	case MODE_NORMAL:
-		silence = note_period / 8;
-		break;
-
-	case MODE_STACCATO:
-		silence = note_period / 4;
-		break;
-
-	default:
-	case MODE_LEGATO:
-		silence = 0;
-		break;
-	}
-
-	note_period -= silence;
-
-	unsigned dot_extension = note_period / 2;
-
-	while (dots--) {
-		note_period += dot_extension;
-		dot_extension /= 2;
-	}
-
-	return note_period;
-}
-
-unsigned
-ToneAlarm::rest_duration(unsigned rest_length, unsigned dots)
-{
-	unsigned whole_note_period = (60 * 1000000 * 4) / _tempo;
-
-	if (rest_length == 0) {
-		rest_length = 1;
-	}
-
-	unsigned rest_period = whole_note_period / rest_length;
-
-	unsigned dot_extension = rest_period / 2;
-
-	while (dots--) {
-		rest_period += dot_extension;
-		dot_extension /= 2;
-	}
-
-	return rest_period;
-}
-
-static void do_something(unsigned x)
-{
-}
-
-void
-ToneAlarm::start_note(unsigned note)
-{
 	// compute the divisor
-	unsigned divisor = note_to_divisor(note);
+	unsigned divisor = frequency_to_divisor(frequency);
 
 	// pick the lowest prescaler value that we can use
 	// (note that the effective prescale value is 1 greater)
@@ -343,42 +216,30 @@ ToneAlarm::start_note(unsigned note)
 	unsigned period = (divisor / (prescale + 1)) - 1;
 
 	// Silence warning of unused var
-	do_something(period);
+	UNUSED(period);
 	PX4_DEBUG("ToneAlarm::start_note %u", period);
 }
 
-void
-ToneAlarm::stop_note()
+void ToneAlarm::stop_note()
 {
 }
 
-void
-ToneAlarm::start_tune(const char *tune)
+void ToneAlarm::next_note()
 {
-	PX4_DEBUG("ToneAlarm::start_tune");
-	// kill any current playback
-	hrt_cancel(&_note_call);
+	if (!_should_run) {
+		if (_tune_control_sub >= 0) {
+			orb_unsubscribe(_tune_control_sub);
+		}
 
-	// record the tune
-	_tune = tune;
-	_next = tune;
+		_running = false;
+		return;
+	}
 
-	// initialise player state
-	_tempo = 120;
-	_note_length = 4;
-	_note_mode = MODE_NORMAL;
-	_octave = 4;
-	_silence_length = 0;
-	_repeat = false;		// otherwise command-line tunes repeat forever...
+	// subscribe to tune_control
+	if (_tune_control_sub < 0) {
+		_tune_control_sub = orb_subscribe(ORB_ID(tune_control));
+	}
 
-	// schedule a callback to start playing
-	_note_call = {};
-	hrt_call_after(&_note_call, 0, (hrt_callout)next_trampoline, this);
-}
-
-void
-ToneAlarm::next_note()
-{
 	// do we have an inter-note gap to wait for?
 	if (_silence_length > 0) {
 		stop_note();
@@ -388,345 +249,56 @@ ToneAlarm::next_note()
 		return;
 	}
 
-	// make sure we still have a tune - may be removed by the write / ioctl handler
-	if ((_next == nullptr) || (_tune == nullptr)) {
-		stop_note();
-		return;
+	// check for updates
+	bool updated = false;
+	orb_check(_tune_control_sub, &updated);
+
+	if (updated) {
+		orb_copy(ORB_ID(tune_control), _tune_control_sub, &_tune);
+		_play_tone = _tunes.set_control(_tune) == 0;
 	}
 
-	// parse characters out of the string until we have resolved a note
-	unsigned note = 0;
-	unsigned note_length = _note_length;
-	unsigned duration;
-
-	while (note == 0) {
-		// we always need at least one character from the string
-		int c = next_char();
-
-		if (c == 0) {
-			goto tune_end;
-		}
-
-		_next++;
-
-		switch (c) {
-		case 'L':	// select note length
-			_note_length = next_number();
-
-			if (_note_length < 1) {
-				goto tune_error;
-			}
-
-			break;
-
-		case 'O':	// select octave
-			_octave = next_number();
-
-			if (_octave > 6) {
-				_octave = 6;
-			}
-
-			break;
-
-		case '<':	// decrease octave
-			if (_octave > 0) {
-				_octave--;
-			}
-
-			break;
-
-		case '>':	// increase octave
-			if (_octave < 6) {
-				_octave++;
-			}
-
-			break;
-
-		case 'M':	// select inter-note gap
-			c = next_char();
-
-			if (c == 0) {
-				goto tune_error;
-			}
-
-			_next++;
-
-			switch (c) {
-			case 'N':
-				_note_mode = MODE_NORMAL;
-				break;
-
-			case 'L':
-				_note_mode = MODE_LEGATO;
-				break;
-
-			case 'S':
-				_note_mode = MODE_STACCATO;
-				break;
-
-			case 'F':
-				_repeat = false;
-				break;
-
-			case 'B':
-				_repeat = true;
-				break;
-
-			default:
-				goto tune_error;
-			}
-
-			break;
-
-		case 'P':	// pause for a note length
-			stop_note();
-			_note_call = {};
-			hrt_call_after(&_note_call,
-				       (hrt_abstime)rest_duration(next_number(), next_dots()),
-				       (hrt_callout)next_trampoline,
-				       this);
-			return;
-
-		case 'T': {	// change tempo
-				unsigned nt = next_number();
-
-				if ((nt >= 32) && (nt <= 255)) {
-					_tempo = nt;
-
-				} else {
-					goto tune_error;
-				}
-
-				break;
-			}
-
-		case 'N':	// play an arbitrary note
-			note = next_number();
-
-			if (note > 84) {
-				goto tune_error;
-			}
-
-			if (note == 0) {
-				// this is a rest - pause for the current note length
-				_note_call = {};
-				hrt_call_after(&_note_call,
-					       (hrt_abstime)rest_duration(_note_length, next_dots()),
-					       (hrt_callout)next_trampoline,
-					       this);
-				return;
-			}
-
-			break;
-
-		case 'A'...'G':	// play a note in the current octave
-			note = _note_tab[c - 'A'] + (_octave * 12) + 1;
-			c = next_char();
-
-			switch (c) {
-			case '#':	// up a semitone
-			case '+':
-				if (note < 84) {
-					note++;
-				}
-
-				_next++;
-				break;
-
-			case '-':	// down a semitone
-				if (note > 1) {
-					note--;
-				}
-
-				_next++;
-				break;
-
-			default:
-				// 0 / no next char here is OK
-				break;
-			}
-
-			// shorthand length notation
-			note_length = next_number();
-
-			if (note_length == 0) {
-				note_length = _note_length;
-			}
-
-			break;
-
-		default:
-			goto tune_error;
-		}
-	}
-
-	// compute the duration of the note and the following silence (if any)
-	duration = note_duration(_silence_length, note_length, next_dots());
-
-	// start playing the note
-	start_note(note);
-
-	// and arrange a callback when the note should stop
-	_note_call = {};
-	hrt_call_after(&_note_call, (hrt_abstime)duration, (hrt_callout)next_trampoline, this);
-	return;
-
-	// tune looks bad (unexpected EOF, bad character, etc.)
-tune_error:
-	PX4_ERR("tune error\n");
-	_repeat = false;		// don't loop on error
-
-	// stop (and potentially restart) the tune
-tune_end:
-	stop_note();
-
-	if (_repeat) {
-		start_tune(_tune);
-
-	} else {
-		_tune = nullptr;
-		_default_tune_number = 0;
-	}
-
-}
-
-int
-ToneAlarm::next_char()
-{
-	while (isspace(*_next)) {
-		_next++;
-	}
-
-	return toupper(*_next);
-}
-
-unsigned
-ToneAlarm::next_number()
-{
-	unsigned number = 0;
-	int c;
-
-	for (;;) {
-		c = next_char();
-
-		if (!isdigit(c)) {
-			return number;
-		}
-
-		_next++;
-		number = (number * 10) + (c - '0');
-	}
-}
-
-unsigned
-ToneAlarm::next_dots()
-{
-	unsigned dots = 0;
-
-	while (next_char() == '.') {
-		_next++;
-		dots++;
-	}
-
-	return dots;
-}
-
-void
-ToneAlarm::next_trampoline(void *arg)
-{
-	ToneAlarm *ta = (ToneAlarm *)arg;
-
-	ta->next_note();
-}
-
-
-int
-ToneAlarm::devIOCTL(unsigned long cmd, unsigned long arg)
-{
-	int result = OK;
-
-	PX4_DEBUG("ToneAlarm::devIOCTL %i %lu", cmd, arg);
-
-	/* decide whether to increase the alarm level to cmd or leave it alone */
-	switch (cmd) {
-	case TONE_SET_ALARM:
-		if (arg < TONE_NUMBER_OF_TUNES) {
-			if (arg == TONE_STOP_TUNE) {
-				// stop the tune
-				_tune = nullptr;
-				_next = nullptr;
-				_repeat = false;
-				_default_tune_number = 0;
+	unsigned frequency = 0;
+	unsigned duration = 0;
+
+	if (_play_tone) {
+		_play_tone = false;
+		int parse_ret_val = _tunes.get_next_tune(frequency, duration, _silence_length);
+
+		if (parse_ret_val >= 0) {
+			// a frequency of 0 correspond to stop_note
+			if (frequency > 0) {
+				// start playing the note
+				start_note(frequency);
 
 			} else {
-				/* always interrupt alarms, unless they are repeating and already playing */
-				if (!(_repeat && _default_tune_number == arg)) {
-					/* play the selected tune */
-					_default_tune_number = arg;
-					start_tune(_default_tunes[arg]);
-					PX4_INFO("%s", _tune_names[arg]);
-				}
+				stop_note();
 			}
 
-		} else {
-			result = -EINVAL;
+
+			if (parse_ret_val > 0) {
+				// continue playing
+				_play_tone = true;
+			}
 		}
 
-		break;
-
-	default:
-		result = -ENOTTY;
-		break;
+	} else {
+		// schedule a call with the tunes max interval
+		duration = _tunes.get_maximum_update_interval();
+		// stop playing the last note after the duration elapsed
+		stop_note();
 	}
 
-	/* give it to the superclass if we didn't like it */
-	if (result == -ENOTTY) {
-		result = VirtDevObj::devIOCTL(cmd, arg);
-	}
-
-	return result;
+	// and arrange a callback when the note should stop
+	assert(duration != 0);
+	_note_call = {};
+	hrt_call_after(&_note_call, (hrt_abstime) duration, (hrt_callout)next_trampoline, this);
 }
 
-ssize_t
-ToneAlarm::devWrite(const void *buffer, size_t len)
+void ToneAlarm::next_trampoline(void *arg)
 {
-	// sanity-check the buffer for length and nul-termination
-	if (len > _tune_max) {
-		return -EFBIG;
-	}
-
-	// if we have an existing user tune, free it
-	if (_user_tune != nullptr) {
-
-		// if we are playing the user tune, stop
-		if (_tune == _user_tune) {
-			_tune = nullptr;
-			_next = nullptr;
-		}
-
-		// free the old user tune
-		free((void *)_user_tune);
-		_user_tune = nullptr;
-	}
-
-	const char *buf = reinterpret_cast<const char *>(buffer);
-
-	// if the new tune is empty, we're done
-	if (buf[0] == '\0') {
-		return OK;
-	}
-
-	// allocate a copy of the new tune
-	_user_tune = strndup(buf, len);
-
-	if (_user_tune == nullptr) {
-		return -ENOMEM;
-	}
-
-	// and play it
-	start_tune(_user_tune);
-
-	return len;
+	ToneAlarm *ta = (ToneAlarm *)arg;
+	ta->next_note();
 }
 
 /**
@@ -737,147 +309,59 @@ namespace
 
 ToneAlarm	*g_dev;
 
-int
-play_tune(unsigned tune)
-{
-	int ret;
-
-	DevHandle h;
-	DevMgr::getHandle(TONEALARM0_DEVICE_PATH, h);
-
-	if (!h.isValid()) {
-		PX4_WARN("Error: failed to open %s (%d)", TONEALARM0_DEVICE_PATH, h.getError());
-		return 1;
-	}
-
-	ret = h.ioctl(TONE_SET_ALARM, tune);
-
-	if (ret != 0) {
-		PX4_WARN("TONE_SET_ALARM");
-		return 1;
-	}
-
-	return ret;
-}
-
-int
-play_string(const char *str, bool free_buffer)
-{
-	int ret;
-
-	DevHandle h;
-	DevMgr::getHandle(TONEALARM0_DEVICE_PATH, h);
-
-	if (!h.isValid()) {
-		PX4_WARN("Error: failed to get handle to %s", TONEALARM0_DEVICE_PATH);
-		return 1;
-	}
-
-	ret = h.write(str, strlen(str) + 1);
-	DevMgr::releaseHandle(h);
-
-	if (free_buffer) {
-		free((void *)str);
-	}
-
-	if (ret < 0) {
-		PX4_WARN("play tune");
-		return 1;
-	}
-
-	return ret;
-}
-
 } // namespace
 
-int
-tone_alarm_main(int argc, char *argv[])
+void tone_alarm_usage();
+
+void tone_alarm_usage()
 {
-	unsigned tune;
-	int ret = 1;
+	PX4_INFO("missing command, try 'start', status, 'stop'");
+}
 
-	/* start the driver lazily */
-	if (g_dev == nullptr) {
-		g_dev = new ToneAlarm;
-
-		if (g_dev == nullptr) {
-			PX4_WARN("couldn't allocate the ToneAlarm driver");
-			return 1;
-		}
-
-		if (g_dev->init() != OK) {
-			delete g_dev;
-			PX4_WARN("ToneAlarm init failed");
-			return 1;
-		}
-	}
+int tone_alarm_main(int argc, char *argv[])
+{
 
 	if (argc > 1) {
 		const char *argv1 = argv[1];
 
 		if (!strcmp(argv1, "start")) {
-			ret = play_tune(TONE_STOP_TUNE);
-		}
-
-		else if (!strcmp(argv1, "stop")) {
-			ret = play_tune(TONE_STOP_TUNE);
-		}
-
-		else if ((tune = strtol(argv1, nullptr, 10)) != 0) {
-			ret = play_tune(tune);
-		}
-
-		/* If it is a file name then load and play it as a string */
-		else if (*argv1 == '/') {
-			FILE *fd = fopen(argv1, "r");
-			int sz;
-			char *buffer;
-
-			if (fd == nullptr) {
-				PX4_WARN("couldn't open '%s'", argv1);
-				return 1;
+			if (g_dev != nullptr) {
+				PX4_ERR("already started");
+				exit(1);
 			}
 
-			fseek(fd, 0, SEEK_END);
-			sz = ftell(fd);
-			fseek(fd, 0, SEEK_SET);
-			buffer = (char *)malloc(sz + 1);
+			if (g_dev == nullptr) {
+				g_dev = new ToneAlarm();
 
-			if (buffer == nullptr) {
-				PX4_WARN("not enough memory memory");
-				fclose(fd);
-				return 1;
-			}
+				if (g_dev == nullptr) {
+					PX4_ERR("couldn't allocate the ToneAlarm driver");
+					exit(1);
+				}
 
-			// FIXME - Make GCC happy
-			if (fread(buffer, sz, 1, fd)) { }
-
-			/* terminate the string */
-			buffer[sz] = 0;
-			ret = play_string(buffer, true);
-			fclose(fd);
-		}
-
-		/* if it looks like a PLAY string... */
-		else if (argv1 && (strlen(argv1) > 2)) {
-			if (*argv1 == 'M') {
-				ret = play_string(argv1, false);
-			}
-
-		} else {
-			/* It might be a tune name */
-			for (tune = 1; tune < TONE_NUMBER_OF_TUNES; tune++) {
-				if (!strcmp(g_dev->name(tune), argv1)) {
-					ret = play_tune(tune);
-					return ret;
+				if (OK != g_dev->init()) {
+					delete g_dev;
+					g_dev = nullptr;
+					PX4_ERR("ToneAlarm init failed");
+					exit(1);
 				}
 			}
 
-			PX4_WARN("unrecognized command, try 'start', 'stop', an alarm number or name, or a file name starting with a '/'");
-			ret = 1;
+			exit(0);
 		}
+
+		if (!strcmp(argv1, "stop")) {
+			delete g_dev;
+			g_dev = nullptr;
+			exit(0);
+		}
+
+		if (!strcmp(argv1, "status")) {
+			g_dev->status();
+			exit(0);
+		}
+
 	}
 
-	return ret;
+	tone_alarm_usage();
+	exit(0);
 }
-

--- a/src/systemcmds/tune_control/tune_control.cpp
+++ b/src/systemcmds/tune_control/tune_control.cpp
@@ -81,7 +81,8 @@ static void publish_tune_control(tune_control_s &tune_control)
 	tune_control.timestamp = hrt_absolute_time();
 
 	if (tune_control_pub == nullptr) {
-		tune_control_pub = orb_advertise(ORB_ID(tune_control), &tune_control);
+		// We have a minimum of 3 so that tune, stop, tune will fit
+		tune_control_pub = orb_advertise_queue(ORB_ID(tune_control), &tune_control, 3);
 
 	} else {
 		orb_publish(ORB_ID(tune_control), tune_control_pub, &tune_control);
@@ -233,6 +234,9 @@ tune_control_main(int argc, char *argv[])
 		tune_control.silence = 0;
 		tune_control.tune_override = true;
 		publish_tune_control(tune_control);
+		// We wait the maximum update interval to ensure
+		// The stop will not be overwritten
+		usleep(tunes.get_maximum_update_interval());
 
 	}	else {
 		usage();


### PR DESCRIPTION
WIP needs cross testing on v4 v2 NXPhlite, sitil

Removed all the legacy CLI for tone_alarms
 Removed stale doc from tone_alarms
Refactored all tone_alarms to use tone_control
'Small kine' cleanup in tone_alarms

 Refactored tune_control and friends:
1 ) Adds a single file definition to provide a single point to add new tunes which clearly documants, the usage and if a tune need to be stopped will it allow interruption.

2) Fixed orb overwrite on "play tune n, stop, play tune k" where n would continue to play.

Refactored all the rc to use tune_control.
 The requires uOrb and tone_alarem to be started before the rcS uses `tune_control` commands.

Added support for PX4V5 Mini ( required to be bin compatible with FMUv5) where the build has the px4io firmware file but not a px4io hw. 

TODO: Should param SYS_USE_IO be reset on Mini?