### PR TITLE
Make it clear up front that SDLOG is a bitmask

### DIFF
--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -67,9 +67,9 @@ PARAM_DEFINE_INT32(SDLOG_UTC_OFFSET, 0);
 PARAM_DEFINE_INT32(SDLOG_MODE, 0);
 
 /**
- * Logging Topic Profile
+ * Logging topic profile (integer bitmask).
  *
- * This is an integer bitmask controlling the set and rates of logged topics.
+ * This integer bitmask controls the set and rates of logged topics.
  * The default allows for general log analysis and estimator replay, while
  * keeping the log file size reasonably small.
  *


### PR DESCRIPTION
Avoid confusion by stating that the param is a bitmask up front. Ie reduce misunderstandings like https://github.com/PX4/Firmware/issues/9951