### PR TITLE
Faster disarm after land detection

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -108,7 +108,7 @@ then
 	param set SENS_DPRES_OFF 0.001
 	param set CBRK_AIRSPD_CHK 0
 
-	param set COM_DISARM_LAND 3
+	param set COM_DISARM_LAND 0.1
 	param set COM_OBL_ACT 2
 	param set COM_OBL_RC_ACT 0
 	param set COM_OF_LOSS_T 5

--- a/ROMFS/px4fmu_common/init.d/1002_standard_vtol.hil
+++ b/ROMFS/px4fmu_common/init.d/1002_standard_vtol.hil
@@ -14,7 +14,7 @@ if [ $AUTOCNF == yes ]
 then
 	param set BAT_N_CELLS 3
 
-	param set COM_DISARM_LAND 5
+	param set COM_DISARM_LAND 5.0
 	param set COM_RC_IN_MODE 1
 
 	param set EKF2_AID_MASK 1

--- a/ROMFS/px4fmu_common/init.d/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/13013_deltaquad
@@ -25,7 +25,7 @@ then
 	param set BAT_N_CELLS 4
 	param set BAT_R_INTERNAL 0.0025
 
-	param set COM_DISARM_LAND 5
+	param set COM_DISARM_LAND 5.0
 
 	param set VT_TYPE 2
 	param set VT_MOT_COUNT 4

--- a/ROMFS/px4fmu_common/init.d/4030_3dr_solo
+++ b/ROMFS/px4fmu_common/init.d/4030_3dr_solo
@@ -32,7 +32,7 @@ then
 
 	# takeoff, land and RTL settings
 	param set MIS_TAKEOFF_ALT   4.0
-	param set COM_DISARM_LAND   1
+	param set COM_DISARM_LAND   1.0
 	param set RTL_LAND_DELAY    1
 	param set RTL_DESCEND_ALT   5.0
 	param set RTL_RETURN_ALT    15.0

--- a/ROMFS/px4fmu_common/init.d/4070_aerofc
+++ b/ROMFS/px4fmu_common/init.d/4070_aerofc
@@ -23,7 +23,7 @@ if [ $AUTOCNF == yes ]
 then
 	# Set all params here, then disable autoconfig
 
-	param set COM_DISARM_LAND 3
+	param set COM_DISARM_LAND 3.0
 
 	param set LNDMC_Z_VEL_MAX 2.0000
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1383,7 +1383,7 @@ Commander::run()
 	float ef_time_thres = 1000.0f;
 	uint64_t timestamp_engine_healthy = 0; /**< absolute time when engine was healty */
 
-	int32_t disarm_when_landed = 0;
+	float disarm_when_landed_timeout = 0.f;
 
 	/* check which state machines for changes, clear "changed" flag */
 	bool main_state_changed = false;
@@ -1481,7 +1481,7 @@ Commander::run()
 			param_get(_param_ef_current2throttle_thres, &ef_current2throttle_thres);
 			param_get(_param_ef_time_thres, &ef_time_thres);
 			param_get(_param_geofence_action, &geofence_action);
-			param_get(_param_disarm_land, &disarm_when_landed);
+			param_get(_param_disarm_land, &disarm_when_landed_timeout);
 			param_get(_param_flight_uuid, &flight_uuid);
 
 			// If we update parameters the first time
@@ -1489,7 +1489,7 @@ Commander::run()
 			// After that it will be set in the main state
 			// machine based on the arming state.
 			if (param_init_forced) {
-				auto_disarm_hysteresis.set_hysteresis_time_from(false, disarm_when_landed * 1_s);
+				auto_disarm_hysteresis.set_hysteresis_time_from(false, disarm_when_landed_timeout * 1_s);
 			}
 
 			param_get(_param_offboard_loss_timeout, &offboard_loss_timeout);
@@ -1719,17 +1719,16 @@ Commander::run()
 			was_falling = land_detector.freefall;
 		}
 
-		/* Update hysteresis time. Use a time of factor 5 longer if we have not taken off yet. */
-		hrt_abstime timeout_time = disarm_when_landed * 1_s;
-
+		// Auto disarm when landed
 		if (!have_taken_off_since_arming) {
-			timeout_time *= 5;
+			// pilot has ten seconds time to take off
+			auto_disarm_hysteresis.set_hysteresis_time_from(false, 10_s);
+		} else {
+			auto_disarm_hysteresis.set_hysteresis_time_from(false, disarm_when_landed_timeout * 1_s);
 		}
 
-		auto_disarm_hysteresis.set_hysteresis_time_from(false, timeout_time);
-
 		// Check for auto-disarm
-		if (armed.armed && land_detector.landed && disarm_when_landed > 0) {
+		if (armed.armed && land_detector.landed && disarm_when_landed_timeout > FLT_EPSILON) {
 			auto_disarm_hysteresis.set_state_and_update(true);
 
 		} else {

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -107,7 +107,8 @@ private:
 		(ParamInt<px4::params::COM_POS_FS_PROB>) _failsafe_pos_probation,
 		(ParamInt<px4::params::COM_POS_FS_GAIN>) _failsafe_pos_gain,
 
-		(ParamInt<px4::params::COM_LOW_BAT_ACT>) _low_bat_action
+		(ParamInt<px4::params::COM_LOW_BAT_ACT>) _low_bat_action,
+		(ParamFloat<px4::params::COM_DISARM_LAND>) _disarm_when_landed_timeout
 	)
 
 	const int64_t POSVEL_PROBATION_MIN = 1_s;	/**< minimum probation duration (usec) */

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -278,18 +278,17 @@ PARAM_DEFINE_INT32(COM_RC_ARM_HYST, 1000);
  * automatically disarmed in case a landing situation has been detected during this period.
  *
  * The vehicle will also auto-disarm right after arming if it has not even flown, however the time
- * will be longer by a factor of 5.
+ * will always be 10 seconds such that the pilot has enough time to take off.
  *
- * A value of zero means that automatic disarming is disabled.
+ * A negative value means that automatic disarming triggered by landing detection is disabled.
  *
  * @group Commander
- * @min 0
+ * @min -1
  * @max 20
  * @unit s
- * @decimal 0
- * @increment 1
+ * @decimal 2
  */
-PARAM_DEFINE_INT32(COM_DISARM_LAND, 0);
+PARAM_DEFINE_FLOAT(COM_DISARM_LAND, -1.0f);
 
 /**
  * Allow arming without GPS


### PR DESCRIPTION
Make auto disarm timeout float such that fractions of a second are configurable.

**Test data / coverage**
This change is used on our product for 1 year now without any problem. There can only be errors in "cherry-picking". And I'll quickly SITL test and report back. **EDIT:** Done

**Describe problem solved by the proposed pull request**
When you have a vehicle with which landing detection works reliable and fast and you try to get it user friendly by instantly disarming when landing is detected then the integer seconds configuration for the auto disarm becomes the bottleneck. Reliable landing detection might take you a fraction of a second but you have to wait at least one second idle to auto disarm.

**Describe your preferred solution**
This change allows fractions of a second to be configured for the timeout to automatically disarm after landing was detected to allow auto disarm within less than a second after touching the ground.

As discussed in person with @bkueng and @Stifael .
