### PR TITLE
Navigator: RC loss yaw mission item

### DIFF
--- a/src/modules/navigator/rcloss.cpp
+++ b/src/modules/navigator/rcloss.cpp
@@ -100,7 +100,7 @@ RCLoss::set_rcl_item()
 			_mission_item.lon = _navigator->get_global_position()->lon;
 			_mission_item.altitude = _navigator->get_global_position()->alt;
 			_mission_item.altitude_is_relative = false;
-			_mission_item.yaw = NAN;
+			_mission_item.yaw = _navigator->get_global_position()->yaw;
 			_mission_item.loiter_radius = _navigator->get_loiter_radius();
 			_mission_item.nav_cmd = NAV_CMD_LOITER_TIME_LIMIT;
 			_mission_item.acceptance_radius = _navigator->get_acceptance_radius();


### PR DESCRIPTION
Added yaw mission item to `rcloss` state in `navigator`. This fixes the issue mentioned #10262 where the vehicle yaws in a seemingly random direction when RC is lost.

**Test data / coverage**
Current behavior:
![selection_001](https://user-images.githubusercontent.com/37091262/44412682-c3f8c180-a526-11e8-9941-05af1f521a36.png)
Proposed behavior with this PR:
![selection_002](https://user-images.githubusercontent.com/37091262/44414401-ed1b5100-a52a-11e8-837a-d81ea6349acb.png)
https://review.px4.io/plot_app?log=2e96b2de-f511-49c0-a51a-a34ba7cabc13