### PR TITLE
navigator: set yaw_valid flag in reposition triplet

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -323,9 +323,11 @@ Navigator::run()
 				// Go on and check which changes had been requested
 				if (PX4_ISFINITE(cmd.param4)) {
 					rep->current.yaw = cmd.param4;
+					rep->current.yaw_valid = true;
 
 				} else {
 					rep->current.yaw = NAN;
+					rep->current.yaw_valid = false;
 				}
 
 				if (PX4_ISFINITE(cmd.param5) && PX4_ISFINITE(cmd.param6)) {


### PR DESCRIPTION
@dagar @MaEtUgR @Stifael I'm wondering if we need these flags. On one hand we allow the yaw setpoint to be set to NAN on the other hand we still require a valid flag to be set.
And sometimes one means the other like here
https://github.com/PX4/Firmware/blob/master/src/modules/navigator/mission_block.cpp#L507

@DonLakeFlyer @LorenzMeier FYI


