### PR TITLE
mavlink: switch back from _mavlink_timesync.sync_stamp to hrt_absolute_time

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -3560,7 +3560,7 @@ protected:
 		if (_debug_sub->update(&_debug_time, &debug)) {
 			mavlink_named_value_float_t msg = {};
 
-			msg.time_boot_ms = debug.timestamp * 1e-3f;
+			msg.time_boot_ms = debug.timestamp / 1000ULL;
 			memcpy(msg.name, debug.key, sizeof(msg.name));
 			/* enforce null termination */
 			msg.name[sizeof(msg.name) - 1] = '\0';
@@ -3629,7 +3629,7 @@ protected:
 		if (_debug_sub->update(&_debug_time, &debug)) {
 			mavlink_debug_t msg = {};
 
-			msg.time_boot_ms = debug.timestamp * 1e-3f;
+			msg.time_boot_ms = debug.timestamp / 1000ULL;
 			msg.ind = debug.ind;
 			msg.value = debug.value;
 


### PR DESCRIPTION
- the timestamp is only used for logging and log analysis. For that it's
  important to have the timestamp when a setpoint becomes active.
- there was a consistent problem with the position_setpoint_triplet
  timestamp, where the timestamp was just bogus. Timesync seems to work
  correctly though. Might be a problem on the sender side?
  For example here:
  https://logs.px4.io/plot_app?log=41918a7d-4c1d-464d-9abe-aef2c0818d92

The timestamp change got introduced in https://github.com/PX4/Firmware/pull/10178.

@TSC21 fyi