### PR TITLE
Mc pos control failsafe

### DIFF
--- a/src/lib/FlightTasks/CMakeLists.txt
+++ b/src/lib/FlightTasks/CMakeLists.txt
@@ -60,6 +60,7 @@ list(APPEND flight_tasks_all
 	AutoLine
 	AutoFollowMe
 	Offboard
+	Failsafe
 	${flight_tasks_to_add}
 )
 

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -262,10 +262,12 @@ void FlightTaskAuto::_set_heading_from_mode()
 		if (v.length() > NAV_ACC_RAD.get()) {
 			_compute_heading_from_2D_vector(_yaw_setpoint, v);
 			_yaw_lock = false;
+
 		} else {
 			if (!_yaw_lock) {
 				_yaw_setpoint = _yaw;
 				_yaw_lock = true;
+			}
 		}
 
 	} else {

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -256,13 +256,20 @@ void FlightTaskAuto::_set_heading_from_mode()
 	}
 
 	if (PX4_ISFINITE(v.length())) {
-		// We only adjust yaw if vehicle is outside of acceptance radius.
+		// We only adjust yaw if vehicle is outside of acceptance radius. Once we enter acceptance
+		// radius, lock yaw to current yaw.
 		// This prevents excessive yawing.
 		if (v.length() > NAV_ACC_RAD.get()) {
 			_compute_heading_from_2D_vector(_yaw_setpoint, v);
+			_yaw_lock = false;
+		} else {
+			if (!_yaw_lock) {
+				_yaw_setpoint = _yaw;
+				_yaw_lock = true;
 		}
 
 	} else {
+		_yaw_lock = false;
 		_yaw_setpoint = NAN;
 	}
 }

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
@@ -107,7 +107,7 @@ protected:
 
 private:
 	matrix::Vector2f _lock_position_xy{NAN, NAN}; /**< if no valid triplet is received, lock positition to current position */
-
+	bool _yaw_lock = false; /**< if within acceptance radius, lock yaw to current yaw */
 	uORB::Subscription<position_setpoint_triplet_s> *_sub_triplet_setpoint{nullptr};
 
 	matrix::Vector3f

--- a/src/lib/FlightTasks/tasks/AutoLine/FlightTaskAutoLine.cpp
+++ b/src/lib/FlightTasks/tasks/AutoLine/FlightTaskAutoLine.cpp
@@ -56,12 +56,8 @@ void FlightTaskAutoLine::_generateSetpoints()
 void FlightTaskAutoLine::_generateHeadingAlongTrack()
 {
 	Vector2f prev_to_dest = Vector2f(&(_target - _prev_wp)(0));
+	_compute_heading_from_2D_vector(_yaw_setpoint, prev_to_dest);
 
-	if (!_compute_heading_from_2D_vector(_yaw_setpoint, prev_to_dest)) {
-		// heading could not be computed. best we can do is to set heading
-		// to current yaw
-		_yaw_setpoint = _yaw;
-	}
 }
 
 void FlightTaskAutoLine::_generateXYsetpoints()

--- a/src/lib/FlightTasks/tasks/Failsafe/CMakeLists.txt
+++ b/src/lib/FlightTasks/tasks/Failsafe/CMakeLists.txt
@@ -1,0 +1,39 @@
+############################################################################
+#
+#   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+px4_add_library(FlightTaskFailsafe
+	FlightTaskFailsafe.cpp
+)
+
+target_link_libraries(FlightTaskFailsafe PUBLIC FlightTask)
+target_include_directories(FlightTaskFailsafe PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/lib/FlightTasks/tasks/Failsafe/FlightTaskFailsafe.cpp
+++ b/src/lib/FlightTasks/tasks/Failsafe/FlightTaskFailsafe.cpp
@@ -1,0 +1,72 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file FlightTaskFailsafe.cpp
+ */
+
+#include "FlightTaskFailsafe.hpp"
+
+bool FlightTaskFailsafe::activate()
+{
+	bool ret = FlightTask::activate();
+	_position_setpoint = _position;
+	_velocity_setpoint *= 0.0f;
+	_thrust_setpoint = matrix::Vector3f(0.0f, 0.0f, -MPC_THR_HOVER.get() * 0.5f);
+	_yaw_setpoint = _yaw;
+	_yawspeed_setpoint = 0.0f;
+	return ret;
+}
+
+bool FlightTaskFailsafe::update()
+{
+	if (PX4_ISFINITE(_position(0)) && PX4_ISFINITE(_position(1))) {
+		_velocity_setpoint(0) = _velocity_setpoint(1) = 0.0f;
+		_thrust_setpoint(0) = _thrust_setpoint(1) = 0.0f;
+
+	} else if (PX4_ISFINITE(_velocity(0)) && PX4_ISFINITE(_velocity(1))) {
+		_position_setpoint(0) = _position_setpoint(1) = NAN;
+		_thrust_setpoint(0) = _thrust_setpoint(1) = NAN;
+	}
+
+	if (PX4_ISFINITE(_position(2))) {
+		_velocity_setpoint(2) = 0.0f;
+		_thrust_setpoint(2) = NAN;
+
+	} else if (PX4_ISFINITE(_velocity(2))) {
+		_position_setpoint(2) = NAN;
+		_thrust_setpoint(2) = NAN;
+	}
+
+	return true;
+
+}

--- a/src/lib/FlightTasks/tasks/Failsafe/FlightTaskFailsafe.cpp
+++ b/src/lib/FlightTasks/tasks/Failsafe/FlightTaskFailsafe.cpp
@@ -40,7 +40,7 @@ bool FlightTaskFailsafe::activate()
 {
 	bool ret = FlightTask::activate();
 	_position_setpoint = _position;
-	_velocity_setpoint *= 0.0f;
+	_velocity_setpoint.zero();
 	_thrust_setpoint = matrix::Vector3f(0.0f, 0.0f, -MPC_THR_HOVER.get() * 0.6f);
 	_yaw_setpoint = _yaw;
 	_yawspeed_setpoint = 0.0f;

--- a/src/lib/FlightTasks/tasks/Failsafe/FlightTaskFailsafe.cpp
+++ b/src/lib/FlightTasks/tasks/Failsafe/FlightTaskFailsafe.cpp
@@ -41,7 +41,7 @@ bool FlightTaskFailsafe::activate()
 	bool ret = FlightTask::activate();
 	_position_setpoint = _position;
 	_velocity_setpoint *= 0.0f;
-	_thrust_setpoint = matrix::Vector3f(0.0f, 0.0f, -MPC_THR_HOVER.get() * 0.5f);
+	_thrust_setpoint = matrix::Vector3f(0.0f, 0.0f, -MPC_THR_HOVER.get() * 0.6f);
 	_yaw_setpoint = _yaw;
 	_yawspeed_setpoint = 0.0f;
 	return ret;
@@ -50,19 +50,24 @@ bool FlightTaskFailsafe::activate()
 bool FlightTaskFailsafe::update()
 {
 	if (PX4_ISFINITE(_position(0)) && PX4_ISFINITE(_position(1))) {
+		// stay at current position setpoint
 		_velocity_setpoint(0) = _velocity_setpoint(1) = 0.0f;
 		_thrust_setpoint(0) = _thrust_setpoint(1) = 0.0f;
 
 	} else if (PX4_ISFINITE(_velocity(0)) && PX4_ISFINITE(_velocity(1))) {
+		// don't move along xy
 		_position_setpoint(0) = _position_setpoint(1) = NAN;
 		_thrust_setpoint(0) = _thrust_setpoint(1) = NAN;
 	}
 
 	if (PX4_ISFINITE(_position(2))) {
+		// stay at current altitude setpoint
 		_velocity_setpoint(2) = 0.0f;
 		_thrust_setpoint(2) = NAN;
 
 	} else if (PX4_ISFINITE(_velocity(2))) {
+		// land with landspeed
+		_velocity_setpoint(2) = MPC_LAND_SPEED.get();
 		_position_setpoint(2) = NAN;
 		_thrust_setpoint(2) = NAN;
 	}

--- a/src/lib/FlightTasks/tasks/Failsafe/FlightTaskFailsafe.hpp
+++ b/src/lib/FlightTasks/tasks/Failsafe/FlightTaskFailsafe.hpp
@@ -1,0 +1,57 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file FlightTaskFailsafe.hpp
+ *
+ */
+
+#pragma once
+
+#include "FlightTask.hpp"
+
+class FlightTaskFailsafe : public FlightTask
+{
+public:
+	FlightTaskFailsafe() = default;
+
+	virtual ~FlightTaskFailsafe() = default;
+	bool update() override;
+	bool activate() override;
+
+private:
+	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTask,
+					(ParamFloat<px4::params::MPC_LAND_SPEED>) MPC_LAND_SPEED,
+					(ParamFloat<px4::params::MPC_THR_HOVER>) MPC_THR_HOVER /**< throttle value at which vehicle is at hover equilibrium */
+				       )
+};

--- a/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.cpp
+++ b/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.cpp
@@ -37,8 +37,10 @@
 #include "FlightTaskManual.hpp"
 #include <mathlib/mathlib.h>
 #include <float.h>
+#include <drivers/drv_hrt.h>
 
 using namespace matrix;
+using namespace time_literals;
 
 bool FlightTaskManual::initializeSubscriptions(SubscriptionArray &subscription_array)
 {
@@ -67,8 +69,10 @@ bool FlightTaskManual::updateInitialize()
 
 bool FlightTaskManual::_evaluateSticks()
 {
+	hrt_abstime rc_timeout = (COM_RC_LOSS_T.get() * 1.5f) * 1_s;
+
 	/* Sticks are rescaled linearly and exponentially to [-1,1] */
-	if ((_time_stamp_current - _sub_manual_control_setpoint->get().timestamp) < _timeout) {
+	if ((_time_stamp_current - _sub_manual_control_setpoint->get().timestamp) < rc_timeout) {
 
 		/* Linear scale  */
 		_sticks(0) = _sub_manual_control_setpoint->get().x; /* NED x, "pitch" [-1,1] */

--- a/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.hpp
+++ b/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.hpp
@@ -76,6 +76,7 @@ private:
 					(ParamFloat<px4::params::MPC_Z_MAN_EXPO>)
 					_z_vel_man_expo, /**< ratio of exponential curve for stick input in z direction */
 					(ParamFloat<px4::params::MPC_YAW_EXPO>)
-					_yaw_expo /**< ratio of exponential curve for stick input in yaw for modes except acro */
+					_yaw_expo, /**< ratio of exponential curve for stick input in yaw for modes except acro */
+					(ParamFloat<px4::params::COM_RC_LOSS_T>) COM_RC_LOSS_T /**< time at which commander considers RC lost */
 				       )
 };

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -159,7 +159,7 @@ private:
 	static constexpr uint64_t TRAJECTORY_STREAM_TIMEOUT_US = 500000;
 	/**< number of tries before switching to a failsafe flight task */
 	static constexpr int NUM_FAILURE_TRIES = 10;
-	/**< If Flighttask fails, keep 1s the current setpoint before going into failsafe land */
+	/**< If Flighttask fails, keep 0.2 seconds the current setpoint before going into failsafe land */
 	static constexpr uint64_t LOITER_TIME_BEFORE_DESCEND = 200000;
 
 
@@ -884,15 +884,12 @@ MulticopterPositionControl::start_flight_task()
 		// for some reason no flighttask was able to start.
 		// go into failsafe flighttask
 		int error = _flight_tasks.switchTask(FlightTaskIndex::Failsafe);
-		task_failure = false;
 
 		if (error != 0) {
 			// No task was activated.
 			_flight_tasks.switchTask(FlightTaskIndex::None);
-
 		}
 	}
-
 }
 
 void

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -160,7 +160,7 @@ private:
 	/**< number of tries before switching to a failsafe flight task */
 	static constexpr int NUM_FAILURE_TRIES = 10;
 	/**< If Flighttask fails, keep 1s the current setpoint before going into failsafe land */
-	static constexpr uint64_t LOITER_TIME_BEFORE_DESCEND = 1000000;
+	static constexpr uint64_t LOITER_TIME_BEFORE_DESCEND = 200000;
 
 
 	/**

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -741,7 +741,6 @@ MulticopterPositionControl::task_main()
 			publish_avoidance_desired_waypoint();
 
 		} else {
-
 			// no flighttask is active: set attitude setpoint to idle
 			_att_sp.roll_body = _att_sp.pitch_body = 0.0f;
 			_att_sp.yaw_body = _local_pos.yaw;
@@ -863,7 +862,6 @@ MulticopterPositionControl::start_flight_task()
 		}
 	}
 
-
 	// manual stabilized control
 	if (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_MANUAL
 	    ||  _vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_STAB || task_failure) {
@@ -882,9 +880,17 @@ MulticopterPositionControl::start_flight_task()
 
 	// check task failure
 	if (task_failure) {
-		// No task was activated.
-		_flight_tasks.switchTask(FlightTaskIndex::None);
-		warn_rate_limited("No Flighttask is running");
+
+		// for some reason no flighttask was able to start.
+		// go into failsafe flighttask
+		int error = _flight_tasks.switchTask(FlightTaskIndex::Failsafe);
+		task_failure = false;
+
+		if (error != 0) {
+			// No task was activated.
+			_flight_tasks.switchTask(FlightTaskIndex::None);
+
+		}
 	}
 
 }

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -70,8 +70,6 @@
 #include "PositionControl.hpp"
 #include "Utility/ControlMath.hpp"
 
-#define NUM_FAILURE_TRIES 10 /**< number of tries before switching to a failsafe flight task */
-
 /**
  * Multicopter position control app start / stop handling function
  *
@@ -159,6 +157,11 @@ private:
 
 	/** Timeout in us for trajectory data to get considered invalid */
 	static constexpr uint64_t TRAJECTORY_STREAM_TIMEOUT_US = 500000;
+	/**< number of tries before switching to a failsafe flight task */
+	static constexpr int NUM_FAILURE_TRIES = 10;
+	/**< If Flighttask fails, keep 1s the current setpoint before going into failsafe land */
+	static constexpr uint64_t LOITER_TIME_BEFORE_DESCEND = 1000000;
+
 
 	/**
 	 * Hysteresis that turns true once vehicle is armed for MPC_IDLE_TKO seconds.
@@ -167,6 +170,8 @@ private:
 	 * is added.
 	 */
 	systemlib::Hysteresis _arm_hysteresis{false}; /**< becomes true once vehicle is armed for MPC_IDLE_TKO seconds */
+
+	systemlib::Hysteresis _failsafe_land_hysteresis{false}; /**< becomes true if task did not update correctly for LOITER_TIME_BEFORE_DESCEND */
 
 	/**
 	 * Update our local parameter cache.
@@ -241,9 +246,10 @@ private:
 	 * Failsafe.
 	 * If flighttask fails for whatever reason, then do failsafe. This could
 	 * occur if the commander fails to switch to a mode in case of invalid states or
-	 * setpoints.
+	 * setpoints. The failsafe will occur after LOITER_TIME_BEFORE_DESCEND. If force is set
+	 * to true, the failsafe will be initiated immediately.
 	 */
-	void failsafe(vehicle_local_position_setpoint_s &setpoint, const PositionControlStates &states);
+	void failsafe(vehicle_local_position_setpoint_s &setpoint, const PositionControlStates &states, const bool force);
 
 	/**
 	 * Fill desired vehicle_trajectory_waypoint:
@@ -304,6 +310,8 @@ MulticopterPositionControl::MulticopterPositionControl() :
 {
 	// fetch initial parameter values
 	parameters_update(true);
+	// set failsafe hysteresis
+	_failsafe_land_hysteresis.set_hysteresis_time_from(false, LOITER_TIME_BEFORE_DESCEND);
 }
 
 MulticopterPositionControl::~MulticopterPositionControl()
@@ -605,22 +613,23 @@ MulticopterPositionControl::task_main()
 			if (!_flight_tasks.update()) {
 				// FAILSAFE
 				// Task was not able to update correctly. Do Failsafe.
-				failsafe(setpoint, _states);
+				failsafe(setpoint, _states, false);
 
 			} else {
 				setpoint = _flight_tasks.getPositionSetpoint();
+				_failsafe_land_hysteresis.set_state_and_update(false);
 
 				// Check if position, velocity or thrust pairs are valid -> trigger failsaife if no pair is valid
 				if (!(PX4_ISFINITE(setpoint.x) && PX4_ISFINITE(setpoint.y)) &&
 				    !(PX4_ISFINITE(setpoint.vx) && PX4_ISFINITE(setpoint.vy)) &&
 				    !(PX4_ISFINITE(setpoint.thrust[0]) && PX4_ISFINITE(setpoint.thrust[1]))) {
-					failsafe(setpoint, _states);
+					failsafe(setpoint, _states, true);
 				}
 
 				// Check if altitude, climbrate or thrust in D-direction are valid -> trigger failsafe if none
 				// of these setpoints are valid
 				if (!PX4_ISFINITE(setpoint.z) && !PX4_ISFINITE(setpoint.vz) && !PX4_ISFINITE(setpoint.thrust[2])) {
-					failsafe(setpoint, _states);
+					failsafe(setpoint, _states, true);
 				}
 			}
 
@@ -962,23 +971,33 @@ MulticopterPositionControl::limit_thrust_during_landing(matrix::Vector3f &thr_sp
 }
 
 void
-MulticopterPositionControl::failsafe(vehicle_local_position_setpoint_s &setpoint, const PositionControlStates &states)
+MulticopterPositionControl::failsafe(vehicle_local_position_setpoint_s &setpoint, const PositionControlStates &states,
+				     const bool force)
 {
+	_failsafe_land_hysteresis.set_state_and_update(true);
 
-	setpoint.x = setpoint.y = setpoint.z = NAN;
-	setpoint.vx = setpoint.vy = setpoint.vz = NAN;
-	setpoint.thrust[0] = setpoint.thrust[1] = setpoint.thrust[2] = NAN;
+	if (!_failsafe_land_hysteresis.get_state() && !force) {
+		// just keep current setpoint and don't do anything.
 
-	if (PX4_ISFINITE(_states.velocity(2))) {
-		// We have a valid velocity in D-direction.
-		// descend downwards with landspeed.
-		setpoint.vz = _land_speed.get();
-		setpoint.thrust[0] = setpoint.thrust[1] = 0.0f;
-		warn_rate_limited("Failsafe: Descend with land-speed.");
+
 
 	} else {
-		// Use the failsafe from the PositionController.
-		warn_rate_limited("Failsafe: Descend with just attitude control.");
+		setpoint.x = setpoint.y = setpoint.z = NAN;
+		setpoint.vx = setpoint.vy = setpoint.vz = NAN;
+		setpoint.thrust[0] = setpoint.thrust[1] = setpoint.thrust[2] = NAN;
+		setpoint.yaw = setpoint.yawspeed = NAN;
+
+		if (PX4_ISFINITE(_states.velocity(2))) {
+			// We have a valid velocity in D-direction.
+			// descend downwards with landspeed.
+			setpoint.vz = _land_speed.get();
+			setpoint.thrust[0] = setpoint.thrust[1] = 0.0f;
+			warn_rate_limited("Failsafe: Descend with land-speed.");
+
+		} else {
+			// Use the failsafe from the PositionController.
+			warn_rate_limited("Failsafe: Descend with just attitude control.");
+		}
 	}
 }
 


### PR DESCRIPTION
- if flighttask update fails then just chill before initiating mc_pos_control failsafe. This can happen if flightask does not have the required data and commander has not updated the state.
- if no flighttask can be started for whatever reason, then enter FllightTaskFailsafe which will just hover if position is available, land if velocity is valid or land with hover-thrust * 0.3 if nothing is valid. This can occur if commander demands to switch into a taks, but not all data is available. 



