### PR TITLE
tfmini : fix scheduling, parsing and modernize output

### DIFF
--- a/src/drivers/distance_sensor/tfmini/tfmini_parser.cpp
+++ b/src/drivers/distance_sensor/tfmini/tfmini_parser.cpp
@@ -63,7 +63,7 @@ const char *parser_state[] = {
 };
 #endif
 
-int tfmini_parser(char c, char *parserbuf, unsigned *parserbuf_index, enum TFMINI_PARSE_STATE *state, float *dist)
+int tfmini_parse(char c, char *parserbuf, unsigned *parserbuf_index, enum TFMINI_PARSE_STATE *state, float *dist)
 {
 	int ret = -1;
 	//char *end;

--- a/src/drivers/distance_sensor/tfmini/tfmini_parser.h
+++ b/src/drivers/distance_sensor/tfmini/tfmini_parser.h
@@ -69,4 +69,4 @@ enum TFMINI_PARSE_STATE {
 	TFMINI_PARSE_STATE6_GOT_CHECKSUM
 };
 
-int tfmini_parser(char c, char *parserbuf, unsigned *parserbuf_index, enum TFMINI_PARSE_STATE *state, float *dist);
+int tfmini_parse(char c, char *parserbuf, unsigned *parserbuf_index, enum TFMINI_PARSE_STATE *state, float *dist);


### PR DESCRIPTION
This PR :
1. Reduces the driver scheduling interval to 9ms, such that the driver is always ready to read new data. Running it at exactly 100Hz is not correct since the driver and sensor measurement intervals are not "in sync", causing the driver to miss data. This caused a fill-up of the UART buffer.
2. Rejigs parsing logic to always publish the latest measurement. This gets rid of the 600ms delay we had been seeing, since the driver was always parsing old data from the UART buffer, fixed at 10 bytes per every collect call.
3. Removes useless reset() function.
4. Modernizes output, removing `errx()` and `warnx()` calls.

Fixes #10264 