### PR TITLE
mavlink temporary workarounds for dronekit

### DIFF
--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -484,6 +484,10 @@ public:
 
 	bool ftp_enabled() const { return _ftp_on; }
 
+	bool hash_check_disabled() { return _hash_check_disabled; }
+
+	bool forward_heartbeats_disabled() { return _heartbeat_forwarding_disabled; }
+
 	struct ping_statistics_s {
 		uint64_t last_ping_time;
 		uint32_t last_ping_seq;
@@ -623,6 +627,8 @@ private:
 
 	bool			_param_initialized;
 	int32_t			_broadcast_mode;
+	bool 			_hash_check_disabled;
+	bool 			_heartbeat_forwarding_disabled;
 
 	param_t			_param_system_id;
 	param_t			_param_component_id;
@@ -632,6 +638,8 @@ private:
 	param_t			_param_use_hil_gps;
 	param_t			_param_forward_externalsp;
 	param_t			_param_broadcast;
+	param_t 		_param_hash_check_disabled;
+	param_t 		_param_heartbeat_forwarding_disabled;
 
 	unsigned		_system_type;
 

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -134,7 +134,7 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 				name[MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN] = '\0';
 
 				/* Whatever the value is, we're being told to stop sending */
-				if (strncmp(name, "_HASH_CHECK", sizeof(name)) == 0) {
+				if (strncmp(name, "_HASH_CHECK", sizeof(name)) == 0 && !_mavlink->hash_check_disabled()) {
 					_send_all_index = -1;
 					/* No other action taken, return */
 					return;

--- a/src/modules/mavlink/mavlink_params.c
+++ b/src/modules/mavlink/mavlink_params.c
@@ -141,3 +141,27 @@ PARAM_DEFINE_INT32(MAV_FWDEXTSP, 1);
  * @group MAVLink
  */
 PARAM_DEFINE_INT32(MAV_BROADCAST, 0);
+
+/**
+ * Parameter hash check.
+ *
+ * Disabling the parameter hash check functionality will make the mavlink instance
+ * stream parameters continuously.
+ *
+ * @boolean 0 Hash check disabled.
+ * @boolean 1 Hash check enabled.
+ * @group MAVLink
+ */
+PARAM_DEFINE_INT32(MAV_DIS_HASH_CHK, 1);
+
+/**
+ * Hearbeat message forwarding.
+ *
+ * The mavlink hearbeat message will not be forwarded if this parameter is set to 'disabled'.
+ * The main reason for disabling heartbeats to be forwarded is because they confuse dronekit.
+ *
+ * @boolean 0 Forwarding disabled.
+ * @boolean 1 Forwarding enabled.
+ * @group MAVLink
+ */
+PARAM_DEFINE_INT32(MAV_DIS_HB_FORW, 1);


### PR DESCRIPTION
Temporary workaround for companion systems which rely on dronekit.
See commit message for further explanation.
@sanderux Could you review and also correct me if I haven't explained the motivation well enough?