### PR TITLE
Improve docs for SD Log profile

### DIFF
--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -76,24 +76,24 @@ PARAM_DEFINE_INT32(SDLOG_MODE, 0);
  * Enabling multiple sets leads to higher bandwidth requirements and larger log
  * files.
  *
- * Set bits in the following positions to enable:
- * 0 : Set to true to use the default set (used for general log analysis)
- * 1 : Set to true to enable full rate estimator (EKF2) replay topics
- * 2 : Set to true to enable topics for thermal calibration (high rate raw IMU and Baro sensor data)
- * 3 : Set to true to enable topics for system identification (high rate actuator control and IMU data)
- * 4 : Set to true to enable full rates for analysis of fast maneuvers (RC, attitude, rates and actuators)
- * 5 : Set to true to enable debugging topics (debug_*.msg topics, for custom code)
- * 6 : Set to true to enable topics for sensor comparison (low rate raw IMU, Baro and Magnetomer data)
+ * Set bits true to enable:
+ * 0 : Default set (used for general log analysis)
+ * 1 : Full rate estimator (EKF2) replay topics
+ * 2 : Topics for thermal calibration (high rate raw IMU and Baro sensor data)
+ * 3 : Topics for system identification (high rate actuator control and IMU data)
+ * 4 : Full rates for analysis of fast maneuvers (RC, attitude, rates and actuators)
+ * 5 : Debugging topics (debug_*.msg topics, for custom code)
+ * 6 : Topics for sensor comparison (low rate raw IMU, Baro and Magnetomer data)
  *
  * @min 0
  * @max 127
- * @bit 0 default set (log analysis)
- * @bit 1 estimator replay (EKF2)
- * @bit 2 thermal calibration
- * @bit 3 system identification
- * @bit 4 high rate
- * @bit 5 debug
- * @bit 6 sensor comparison
+ * @bit 0 Default set (general log analysis)
+ * @bit 1 Estimator replay (EKF2)
+ * @bit 2 Thermal calibration
+ * @bit 3 System identification
+ * @bit 4 High rate
+ * @bit 5 Debug
+ * @bit 6 Sensor comparison
  * @reboot_required true
  * @group SD Logging
  */


### PR DESCRIPTION
As discussed in #10272

Can we reduce it further?

For example, we have:
* Topics for system identification (high rate actuator control and IMU data)

But we could remove the whole line if we don't need `(high rate actuator control and IMU data)`, because this is captured in the bit listing. 