### PR TITLE
pmw3901: add specs from datasheet to opt flow msg

### DIFF
--- a/src/drivers/pmw3901/pmw3901.cpp
+++ b/src/drivers/pmw3901/pmw3901.cpp
@@ -608,6 +608,11 @@ PMW3901::collect()
 	report.gyro_y_rate_integral = NAN;
 	report.gyro_z_rate_integral = NAN;
 
+	// set (conservative) specs according to datasheet
+	report.max_flow_rate = 5.0f;       // Datasheet: 7.4 rad/s
+	report.min_ground_distance = 0.1f; // Datasheet: 80mm
+	report.max_ground_distance = 5.0f; // Datasheet: infinity
+
 	_flow_dt_sum_usec = 0;
 	_flow_sum_x = 0;
 	_flow_sum_y = 0;


### PR DESCRIPTION
Part of the optical flow msg is missing in the pmw3901 driver. Without this EKF rejects flow ([here](https://github.com/PX4/ecl/blob/master/EKF/estimator_interface.cpp#L369) and [here](https://github.com/PX4/ecl/blob/master/EKF/ekf_helper.cpp#L1089-L1090))
Datasheet:
https://wiki.bitcraze.io/_media/projects:crazyflie2:expansionboards:pot0189-pmw3901mb-txqt-ds-r1.00-200317_20170331160807_public.pdf