### PR TITLE
Prevent duplicate reporting of GPS heading

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -882,6 +882,11 @@ GPS::publish()
 	if (_instance == Instance::Main || _is_gps_main_advertised) {
 		orb_publish_auto(ORB_ID(vehicle_gps_position), &_report_gps_pos_pub, &_report_gps_pos, &_gps_orb_instance,
 				 ORB_PRIO_DEFAULT);
+		if (_mode == GPS_DRIVER_MODE_ASHTECH) {
+			// Heading/yaw data can be updated at a lower rate than the other navigation data.
+			// The uORB message definition requires this data to be set to a NAN if no new valid data is available.
+			_report_gps_pos.heading = NAN;
+		}
 		_is_gps_main_advertised = true;
 	}
 }

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -882,11 +882,9 @@ GPS::publish()
 	if (_instance == Instance::Main || _is_gps_main_advertised) {
 		orb_publish_auto(ORB_ID(vehicle_gps_position), &_report_gps_pos_pub, &_report_gps_pos, &_gps_orb_instance,
 				 ORB_PRIO_DEFAULT);
-		if (_mode == GPS_DRIVER_MODE_ASHTECH) {
-			// Heading/yaw data can be updated at a lower rate than the other navigation data.
-			// The uORB message definition requires this data to be set to a NAN if no new valid data is available.
-			_report_gps_pos.heading = NAN;
-		}
+		// Heading/yaw data can be updated at a lower rate than the other navigation data.
+		// The uORB message definition requires this data to be set to a NAN if no new valid data is available.
+		_report_gps_pos.heading = NAN;
 		_is_gps_main_advertised = true;
 	}
 }


### PR DESCRIPTION
During replay log testing of changes for issue https://github.com/PX4/Firmware/issues/10284 is was noticed that the GPS driver was not setting the .heading data field to NAN when the data was not updated by the receiver.

The receiver used to generate the replay logs was updating heading at a 1Hz rate resulting in the  last measurement being held for subsequent frames instead of setting the value to NAN. This resulted in repeated fusion of the same data and large innovation transients when the vehicle yawed:

![screen shot 2018-08-24 at 7 46 15 am](https://user-images.githubusercontent.com/3596952/44687760-61a74000-aa95-11e8-8117-7970caec4881.png)

The 1Hz update and hold behaviour for the yaw data can be seen here:

![screen shot 2018-08-24 at 7 48 58 am](https://user-images.githubusercontent.com/3596952/44687857-b9de4200-aa95-11e8-9846-72302e0386df.png)

**Test data / coverage**
I do not have access to physical hardware to gather logs with this change.