### PR TITLE
multicopter position controller use const references

### DIFF
--- a/src/lib/FlightTasks/FlightTasks.cpp
+++ b/src/lib/FlightTasks/FlightTasks.cpp
@@ -57,7 +57,7 @@ const vehicle_trajectory_waypoint_s FlightTasks::getAvoidanceWaypoint()
 	}
 }
 
-const vehicle_trajectory_waypoint_s FlightTasks::getEmptyAvoidanceWaypoint()
+const vehicle_trajectory_waypoint_s &FlightTasks::getEmptyAvoidanceWaypoint()
 {
 	return FlightTask::empty_trajectory_waypoint;
 }

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -87,7 +87,7 @@ public:
 	 * Get empty avoidance desired waypoints
 	 * @return empty triplets in the mc_pos_control
 	 */
-	const vehicle_trajectory_waypoint_s getEmptyAvoidanceWaypoint();
+	const vehicle_trajectory_waypoint_s &getEmptyAvoidanceWaypoint();
 
 	/**
 	 * Switch to the next task in the available list (for testing)

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
@@ -81,7 +81,7 @@ public:
 	 * To be called to adopt parameters from an arrived vehicle command
 	 * @return true if accepted, false if declined
 	 */
-	virtual bool applyCommandParameters(const vehicle_command_s &command) { return true; };
+	virtual bool applyCommandParameters(const vehicle_command_s &command) { return true; }
 
 	/**
 	 * Call before activate() or update()
@@ -106,13 +106,13 @@ public:
 	 * The constraints can vary with task.
 	 * @return constraints
 	 */
-	const vehicle_constraints_s getConstraints() {return _constraints;};
+	const vehicle_constraints_s &getConstraints() { return _constraints; }
 
 	/**
 	 * Get avoidance desired waypoint
 	 * @return desired waypoints
 	 */
-	const vehicle_trajectory_waypoint_s getAvoidanceWaypoint() {return _desired_waypoint;};
+	const vehicle_trajectory_waypoint_s &getAvoidanceWaypoint() { return _desired_waypoint; }
 
 	/**
 	 * Empty setpoint.

--- a/src/modules/mc_pos_control/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl.hpp
@@ -111,54 +111,54 @@ public:
 	 * @see _yawspeed_sp
 	 * @param dt the delta-time
 	 */
-	void generateThrustYawSetpoint(const float &dt);
+	void generateThrustYawSetpoint(const float dt);
 
 	/**
 	 * 	Set the integral term in xy to 0.
 	 * 	@see _thr_int
 	 */
-	void resetIntegralXY() {_thr_int(0) = _thr_int(1) = 0.0f;};
+	void resetIntegralXY() { _thr_int(0) = _thr_int(1) = 0.0f; }
 
 	/**
 	 * 	Set the integral term in z to 0.
 	 * 	@see _thr_int
 	 */
-	void resetIntegralZ() {_thr_int(2) = 0.0f;};
+	void resetIntegralZ() { _thr_int(2) = 0.0f; }
 
 	/**
 	 * 	Get the
 	 * 	@see _thr_sp
 	 * 	@return The thrust set-point member.
 	 */
-	matrix::Vector3f getThrustSetpoint() {return _thr_sp;}
+	const matrix::Vector3f &getThrustSetpoint() { return _thr_sp; }
 
 	/**
 	 * 	Get the
 	 * 	@see _yaw_sp
 	 * 	@return The yaw set-point member.
 	 */
-	float getYawSetpoint() { return _yaw_sp;}
+	const float &getYawSetpoint() { return _yaw_sp; }
 
 	/**
 	 * 	Get the
 	 * 	@see _yawspeed_sp
 	 * 	@return The yawspeed set-point member.
 	 */
-	float getYawspeedSetpoint() {return _yawspeed_sp;}
+	const float &getYawspeedSetpoint() { return _yawspeed_sp; }
 
 	/**
 	 * 	Get the
 	 * 	@see _vel_sp
 	 * 	@return The velocity set-point member.
 	 */
-	matrix::Vector3f getVelSp() {return _vel_sp;}
+	const matrix::Vector3f &getVelSp() { return _vel_sp; }
 
 	/**
 	 * 	Get the
 	 * 	@see _pos_sp
 	 * 	@return The position set-point member.
 	 */
-	matrix::Vector3f getPosSp() {return _pos_sp;}
+	const matrix::Vector3f &getPosSp() { return _pos_sp; }
 
 protected:
 


### PR DESCRIPTION
A few minor improvements.

 - return const references where possible instead of copies
 - don't create Vectors from pointers (this hole in Matrix will be closed eventually)
 - stack allocate vehicle_local_position_setpoint