### PR TITLE
ekf2: Allow use of RTK GPS heading

### DIFF
--- a/msg/ekf_gps_position.msg
+++ b/msg/ekf_gps_position.msg
@@ -14,4 +14,6 @@ float32 vel_e_m_s		# GPS East velocity, (metres/sec)
 float32 vel_d_m_s		# GPS Down velocity, (metres/sec)
 bool vel_ned_valid		# True if NED velocity is valid
 uint8 satellites_used		# Number of satellites used
+float32 heading			# heading angle of XYZ body frame rel to NED. Set to NaN if not available and updated (used for dual antenna GPS), (rad, [-PI, PI])
+float32 heading_offset		# heading offset of dual antenna array in body frame. Set to NaN if not applicable. (rad, [-PI, PI])
 uint8 selected			# GPS selection: 0: GPS1, 1: GPS2. 2: GPS1+GPS2 blend

--- a/msg/vehicle_gps_position.msg
+++ b/msg/vehicle_gps_position.msg
@@ -32,4 +32,5 @@ uint64 time_utc_usec		# Timestamp (microseconds, UTC), this is the timestamp whi
 
 uint8 satellites_used		# Number of satellites used
 
-float32 heading		# heading in NED. Set to NaN if not set (used for dual antenna GPS), (rad, [-PI, PI])
+float32 heading			# heading angle of XYZ body frame rel to NED. Set to NaN if not available and updated (used for dual antenna GPS), (rad, [-PI, PI])
+float32 heading_offset		# heading offset of dual antenna array in body frame. Set to NaN if not applicable. (rad, [-PI, PI])

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -268,6 +268,7 @@ GPS::GPS(const char *path, gps_driver_mode_t mode, GPSHelper::Interface interfac
 	_port[sizeof(_port) - 1] = '\0';
 
 	_report_gps_pos.heading = NAN;
+	_report_gps_pos.heading_offset = NAN;
 
 	/* create satellite info data object if requested */
 	if (enable_sat_info) {
@@ -655,6 +656,7 @@ GPS::run()
 			_report_gps_pos.vel_ned_valid = true;
 			_report_gps_pos.satellites_used = 10;
 			_report_gps_pos.heading = NAN;
+			_report_gps_pos.heading_offset = NAN;
 
 			/* no time and satellite information simulated */
 
@@ -699,6 +701,7 @@ GPS::run()
 				/* reset report */
 				memset(&_report_gps_pos, 0, sizeof(_report_gps_pos));
 				_report_gps_pos.heading = NAN;
+				_report_gps_pos.heading_offset = heading_offset;
 
 				if (_mode == GPS_DRIVER_MODE_UBX) {
 

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -490,13 +490,14 @@ PARAM_DEFINE_INT32(EKF2_DECL_TYPE, 7);
  * If set to '3-axis' 3-axis field fusion is used at all times.
  * If set to 'VTOL custom' the behaviour is the same as 'Automatic', but if fusing airspeed, magnetometer fusion is only allowed to modify the magnetic field states. This can be used by VTOL platforms with large magnetic field disturbances to prevent incorrect bias states being learned during forward flight operation which can adversely affect estimation accuracy after transition to hovering flight.
  * If set to 'MC custom' the behaviour is the same as 'Automatic, but if there are no earth frame position or velocity observations being used, the magnetometer will not be used. This enables vehicles to operate with no GPS in environments where the magnetic field cannot be used to provide a heading reference. Prior to flight, the yaw angle is assumed to be constant if movement tests controlled by the EKF2_MOVE_TEST parameter indicate that the vehicle is static. This allows the vehicle to be placed on the ground to learn the yaw gyro bias prior to flight.
- *
+ * If set to 'None' the magnetometer will not be used under any circumstance. Other sources of yaw may be used if selected via the EKF2_AID_MASK parameter.
  * @group EKF2
  * @value 0 Automatic
  * @value 1 Magnetic heading
  * @value 2 3-axis
  * @value 3 VTOL customn
  * @value 4 MC custom
+ * @value 5 None
  * @reboot_required true
  */
 PARAM_DEFINE_INT32(EKF2_MAG_TYPE, 0);
@@ -581,13 +582,14 @@ PARAM_DEFINE_FLOAT(EKF2_TAS_GATE, 3.0f);
  * 1 : Set to true to use optical flow data if available
  * 2 : Set to true to inhibit IMU bias estimation
  * 3 : Set to true to enable vision position fusion
- * 4 : Set to true to enable vision yaw fusion
+ * 4 : Set to true to enable vision yaw fusion. Cannot be used if bit position 7 is true.
  * 5 : Set to true to enable multi-rotor drag specific force fusion
  * 6 : set to true if the EV observations are in a non NED reference frame and need to be rotated before being used
+ * 7 : Set to true to enable GPS yaw fusion. Cannot be used if bit position 4 is true.
  *
  * @group EKF2
  * @min 0
- * @max 127
+ * @max 255
  * @bit 0 use GPS
  * @bit 1 use optical flow
  * @bit 2 inhibit IMU bias estimation
@@ -595,6 +597,7 @@ PARAM_DEFINE_FLOAT(EKF2_TAS_GATE, 3.0f);
  * @bit 4 vision yaw fusion
  * @bit 5 multi-rotor drag fusion
  * @bit 6 rotate external vision
+ * @bit 7 GPS yaw fusion
  * @reboot_required true
  */
 PARAM_DEFINE_INT32(EKF2_AID_MASK, 1);

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2189,6 +2189,7 @@ MavlinkReceiver::handle_message_hil_gps(mavlink_message_t *msg)
 	hil_gps.satellites_used = gps.satellites_visible;  //TODO: rename mavlink_hil_gps_t sats visible to used?
 
 	hil_gps.heading = NAN;
+	hil_gps.heading_offset = NAN;
 
 	if (_gps_pub == nullptr) {
 		_gps_pub = orb_advertise(ORB_ID(vehicle_gps_position), &hil_gps);

--- a/src/modules/simulator/gpssim/gpssim.cpp
+++ b/src/modules/simulator/gpssim/gpssim.cpp
@@ -179,6 +179,7 @@ GPSSIM::GPSSIM(bool fake_gps, bool enable_sat_info,
 	/* we need this potentially before it could be set in task_main */
 	g_dev = this;
 	_report_gps_pos.heading = NAN;
+	_report_gps_pos.heading_offset = NAN;
 
 	/* create satellite info data object if requested */
 	if (enable_sat_info) {

--- a/src/modules/uavcan/sensors/gnss.cpp
+++ b/src/modules/uavcan/sensors/gnss.cpp
@@ -380,6 +380,7 @@ void UavcanGnssBridge::process_fixx(const uavcan::ReceivedDataStructure<FixType>
 	report.vdop = msg.pdop;
 
 	report.heading = NAN;
+	report.heading_offset = NAN;
 
 	// Publish to a multi-topic
 	int32_t gps_orb_instance;


### PR DESCRIPTION
Adds feature requested by https://github.com/PX4/Firmware/issues/10284

Requires https://github.com/PX4/ecl/pull/497

Is inactive with default parameters.

**Testing**

See https://github.com/PX4/ecl/pull/497 for details of previous testing using replay.

Testing this branch requires setting EKF2_AID_MASK = 129 and EKF2_MAG_TYPE = 5. That will force the EKF to wait until GPS yaw is available before performing the yaw alignment. If EKF2_MAG_TYPE = 0, then the yaw will be set using the magnetomer intially and then reset to the GPS yaw when it becomes available.

Testing using replay was repeated and documented in the comments below.