### PR TITLE
PGA460: fail gracefully

### DIFF
--- a/src/drivers/distance_sensor/pga460/pga460.cpp
+++ b/src/drivers/distance_sensor/pga460/pga460.cpp
@@ -649,7 +649,13 @@ void PGA460::request_results()
 void PGA460::run()
 {
 	open_serial();
-	initialize_device_settings();
+	int ret = initialize_device_settings();
+
+	if(ret != PX4_OK) {
+		close_serial();
+		PX4_INFO("Could not initialize device settings. Exiting.");
+		return;
+	}
 
 	struct distance_sensor_s report = {};
 	_distance_sensor_topic = orb_advertise(ORB_ID(distance_sensor), &report);


### PR DESCRIPTION
Added a check to ensure the initialize settings function succeeds. If it does not, the driver fails gracefully. This handles the case that the device is not there. 

![selection_004](https://user-images.githubusercontent.com/37091262/44753155-5de9dc80-aada-11e8-913f-611ff8d7cee5.png)

We didn't catch this until now because we've always had this sensor connected. :roll_eyes: 