### PR TITLE
ControlMath: Empty initializer for vehicle_attitude_setpoint

### DIFF
--- a/src/modules/mc_pos_control/Utility/ControlMath.cpp
+++ b/src/modules/mc_pos_control/Utility/ControlMath.cpp
@@ -45,7 +45,7 @@ namespace ControlMath
 {
 vehicle_attitude_setpoint_s thrustToAttitude(const matrix::Vector3f &thr_sp, const float yaw_sp)
 {
-	vehicle_attitude_setpoint_s att_sp;
+	vehicle_attitude_setpoint_s att_sp = {};
 	att_sp.yaw_body = yaw_sp;
 
 	// desired body_z axis = -normalize(thrust_vector)


### PR DESCRIPTION
Without initializing the object there is no guarantee what values the fields that are *not* set in this method will have.

In my case `att_sp.landing_gear` was `NaN`. Now it's at least initialized to `0` :)