### PR TITLE
 EKF data analysis false positives

### DIFF
--- a/Tools/ecl_ekf/analyse_logdata_ekf.py
+++ b/Tools/ecl_ekf/analyse_logdata_ekf.py
@@ -1303,15 +1303,23 @@ def analyse_ekf(estimator_status, ekf2_innovations, sensor_preflight, check_leve
         test_results['tas_sensor_status'][0] = 'Warning'
     # check for IMU sensor warnings
     if ((test_results.get('imu_coning_peak')[0] > check_levels.get('imu_coning_peak_warn')) or
-            (test_results.get('imu_coning_mean')[0] > check_levels.get('imu_coning_mean_warn')) or
-            (test_results.get('imu_hfdang_peak')[0] > check_levels.get('imu_hfdang_peak_warn')) or
-            (test_results.get('imu_hfdang_mean')[0] > check_levels.get('imu_hfdang_mean_warn')) or
-            (test_results.get('imu_hfdvel_peak')[0] > check_levels.get('imu_hfdvel_peak_warn')) or
+            (test_results.get('imu_coning_mean')[0] > check_levels.get('imu_coning_mean_warn'))):
+        test_results['master_status'][0] = 'Warning'
+        test_results['imu_sensor_status'][0] = 'Warning'
+        test_results['imu_vibration_check'][0] = 'Warning'
+        print('IMU gyro coning check warning.')
+    if ((test_results.get('imu_hfdang_peak')[0] > check_levels.get('imu_hfdang_peak_warn')) or
+            (test_results.get('imu_hfdang_mean')[0] > check_levels.get('imu_hfdang_mean_warn'))):
+        test_results['master_status'][0] = 'Warning'
+        test_results['imu_sensor_status'][0] = 'Warning'
+        test_results['imu_vibration_check'][0] = 'Warning'
+        print('IMU gyro vibration check warning.')
+    if ((test_results.get('imu_hfdvel_peak')[0] > check_levels.get('imu_hfdvel_peak_warn')) or
             (test_results.get('imu_hfdvel_mean')[0] > check_levels.get('imu_hfdvel_mean_warn'))):
         test_results['master_status'][0] = 'Warning'
         test_results['imu_sensor_status'][0] = 'Warning'
         test_results['imu_vibration_check'][0] = 'Warning'
-        print('IMU vibration check warning.')
+        print('IMU accel vibration check warning.')
     if ((test_results.get('imu_dang_bias_median')[0] > check_levels.get('imu_dang_bias_median_warn')) or
             (test_results.get('imu_dvel_bias_median')[0] > check_levels.get('imu_dvel_bias_median_warn'))):
         test_results['master_status'][0] = 'Warning'

--- a/Tools/ecl_ekf/check_level_dict.csv
+++ b/Tools/ecl_ekf/check_level_dict.csv
@@ -22,8 +22,8 @@ imu_coning_peak_warn,1.8E-5
 imu_coning_mean_warn,3.6E-6
 imu_hfdang_peak_warn,3.0E-3
 imu_hfdang_mean_warn,6.0E-4
-imu_hfdvel_peak_warn,1.8E-2
-imu_hfdvel_mean_warn,3.6E-3
+imu_hfdvel_peak_warn,9.0E-2
+imu_hfdvel_mean_warn,1.8E-2
 obs_ang_err_median_warn,8.0E-3
 obs_vel_err_median_warn,0.05
 obs_pos_err_median_warn,0.15


### PR DESCRIPTION
The high frequency acceleration noise levels in the gazebo models and also seen on some hardware is causing the IMU vibration check warning to fail.

The thresholds have been lifted and the reporting improved to make it clearer which sensor noise is causing the failure.

See https://github.com/PX4/Firmware/issues/10352 for details