### PR TITLE
[WIP] Fix Cygwin SITL Simulation after posix shell merge

### DIFF
--- a/platforms/posix/src/px4_daemon/server.cpp
+++ b/platforms/posix/src/px4_daemon/server.cpp
@@ -50,6 +50,12 @@
 #include "pxh.h"
 #include "server.h"
 
+// Cygwin handling
+#if !defined(__PX4_CYGWIN)
+	#define CLIENT_SEND_PIPE_OFLAGS O_RDONLY
+#else
+	#define CLIENT_SEND_PIPE_OFLAGS O_RDWR
+#endif
 
 
 namespace px4_daemon
@@ -121,7 +127,7 @@ Server::_server_main(void *arg)
 	}
 
 	std::string client_send_pipe_path = get_client_send_pipe_path(_instance_id);
-	int client_send_pipe_fd = open(client_send_pipe_path.c_str(), O_RDONLY);
+	int client_send_pipe_fd = open(client_send_pipe_path.c_str(), CLIENT_SEND_PIPE_OFLAGS);
 
 	while (true) {
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
After a lot of debugging I found out that the problem is the cygwin is that named pipes also called fifos which are used for the posix shell server client IPC (inter process communication) are not fully POSIX compliant. Namely opening the same pipe "file" multiple times from the same process is not supported. But exactly this is done in the implementation to server multiple clients corresponding to multiple `px4-...` bash commands e.g. one for every entry in the startup script.

There are multiple discussions in the web (I don't find all of them anymore) and they show that it is a persistent problem which is not likely solved anytime soon:
https://stackoverflow.com/questions/14450547/multiple-reader-writer-on-fifo-named-pipe
http://cygwin.1069669.n5.nabble.com/Bug-Named-Pipes-FIFO-Bash-td10925.html

**Describe your preferred solution**
It's the fastest, easiest working solution I could come up with to unblock people who cannot use the simulation anymore. The commit message explains it:

posix-shell server: switch pipe flag to read/write
to make it non-blocking and ommit opening the same
named pipe multiple times inside the same process
which seems to be not supported in cygwin.

**Test data / coverage**
I tested several times on my work and home pc, it starts again and the startup script run through but sometimes I run into other problems like sensor errors probably because of performance.

**Describe possible alternatives**
Use a different IPC under cygwin or in general. E.g. only some WinAPI calls on Windows or POSIX socket implementation in general. All comments are welcome.
**Additional context**
fixes #10098