### PR TITLE
parameters test save restored parameters when finished

### DIFF
--- a/src/systemcmds/tests/test_parameters.cpp
+++ b/src/systemcmds/tests/test_parameters.cpp
@@ -481,6 +481,12 @@ bool ParameterTest::exportImportAll()
 		return false;
 	}
 
+	// save
+	if (param_save_default() != PX4_OK) {
+		PX4_ERR("param_save_default failed");
+		return false;
+	}
+
 	return ret;
 }
 


### PR DESCRIPTION
Otherwise the stored parameters are still set to test values.