### PR TITLE
device id pretty print and listener support

### DIFF
--- a/msg/templates/uorb/msg.cpp.template
+++ b/msg/templates/uorb/msg.cpp.template
@@ -69,6 +69,7 @@ topic_fields = ["%s %s" % (convert_type(field.type), field.name) for field in so
 #include <px4_defines.h>
 #include <uORB/topics/@(topic_name).h>
 #include <drivers/drv_hrt.h>
+#include <lib/drivers/device/Device.hpp>
 
 @# join all msg files in one line e.g: "float[3] position;float[3] velocity;bool armed"
 @# This is used for the logger

--- a/msg/tools/px_generate_uorb_topic_helper.py
+++ b/msg/tools/px_generate_uorb_topic_helper.py
@@ -250,6 +250,10 @@ def print_field(field):
         print("if (message.timestamp != 0) {\n\t\tPX4_INFO_RAW(\"\\t" + field.name + \
             ": " + c_type + "  (%.6f seconds ago)\\n\", " + field_name + \
             ", hrt_elapsed_time(&message.timestamp) / 1e6);\n\t} else {\n\t\tPX4_INFO_RAW(\"\\n\");\n\t}" )
+    elif field.name == 'device_id':
+        print("char device_id_buffer[80];")
+        print("device::Device::device_id_print_buffer(device_id_buffer, sizeof(device_id_buffer), message.device_id);")
+        print("PX4_INFO_RAW(\"\\tdevice_id: %d (%s) \\n\", message.device_id, device_id_buffer);" )
     else:
         print("PX4_INFO_RAW(\"\\t" + field.name + ": " + c_type + "\\n\", " + field_name + ");" )
 

--- a/msg/tools/px_generate_uorb_topic_helper.py
+++ b/msg/tools/px_generate_uorb_topic_helper.py
@@ -77,8 +77,8 @@ type_printf_map = {
     'uint16': '%u',
     'uint32': '%" PRIu32 "',
     'uint64': '%" PRIu64 "',
-    'float32': '%.3f',
-    'float64': '%.3f',
+    'float32': '%.4f',
+    'float64': '%.6f',
     'bool': '%u',
     'char': '%c',
 }

--- a/src/lib/drivers/device/Device.hpp
+++ b/src/lib/drivers/device/Device.hpp
@@ -148,6 +148,24 @@ public:
 	 */
 	DeviceBusType get_device_bus_type() const { return _device_id.devid_s.bus_type; }
 
+	static const char *get_device_bus_string(DeviceBusType bus)
+	{
+		switch (bus) {
+		case DeviceBusType_I2C:
+			return "I2C";
+
+		case DeviceBusType_SPI:
+			return "SPI";
+
+		case DeviceBusType_UAVCAN:
+			return "UAVCAN";
+
+		case DeviceBusType_UNKNOWN:
+		default:
+			return "UNKNOWN";
+		}
+	}
+
 	/**
 	 * Return the bus address of the device.
 	 *
@@ -183,6 +201,27 @@ public:
 		struct DeviceStructure devid_s;
 		uint32_t devid;
 	};
+
+	/**
+	 * Print decoded device id string to a buffer.
+	 *
+	 * @param buffer                        buffer to write to
+	 * @param length                        buffer length
+	 * @param id	                        The device id.
+	 * @param return                        number of bytes written
+	 */
+	static int device_id_print_buffer(char *buffer, int length, uint32_t id)
+	{
+		DeviceId dev_id;
+		dev_id.devid = id;
+
+		int num_written = snprintf(buffer, length, "Type: 0x%02X, %s:%d (0x%02X)", dev_id.devid_s.devtype,
+					   get_device_bus_string(dev_id.devid_s.bus_type), dev_id.devid_s.bus, dev_id.devid_s.address);
+
+		buffer[length - 1] = 0; // ensure 0-termination
+
+		return num_written;
+	}
 
 protected:
 	union DeviceId	_device_id;             /**< device identifier information */


### PR DESCRIPTION
    nsh> listener sensor_gyro

    TOPIC: sensor_gyro instance 0 #1
    sensor_gyro_s
        timestamp: 6166722830  (0.001146 seconds ago)
        error_count: 0
        device_id: 2360354 (Type: 0x24, SPI:4 (0x04))
        x: -0.0041
        y: 0.0070
        z: 0.0014
        integral_dt: 4009
        x_integral: -0.0000
        y_integral: 0.0000
        z_integral: 0.0000
        temperature: 72.7867
        scaling: 0.0011
        x_raw: 5
        y_raw: -6
        z_raw: 2
