### PR TITLE
SITL fixes: avoid using exit()

### DIFF
--- a/platforms/posix/src/px4_daemon/client.cpp
+++ b/platforms/posix/src/px4_daemon/client.cpp
@@ -330,7 +330,7 @@ Client::_sig_handler(int sig_num)
 
 	if (_client_send_pipe_fd < 0) {
 		PX4_ERR("pipe open fail");
-		exit(-1);
+		system_exit(-1);
 	}
 
 	int bytes_to_send = get_client_send_packet_length(&packet);
@@ -338,7 +338,7 @@ Client::_sig_handler(int sig_num)
 
 	if (bytes_sent != bytes_to_send) {
 		PX4_ERR("write fail");
-		exit(-1);
+		system_exit(-1);
 	}
 }
 

--- a/platforms/posix/src/px4_layer/px4_posix_tasks.cpp
+++ b/platforms/posix/src/px4_layer/px4_posix_tasks.cpp
@@ -115,7 +115,7 @@ void
 px4_systemreset(bool to_bootloader)
 {
 	PX4_WARN("Called px4_system_reset");
-	exit(0);
+	system_exit(0);
 }
 
 px4_task_t px4_task_spawn_cmd(const char *name, int scheduler, int priority, int stack_size, px4_main_t entry,

--- a/src/drivers/kinetis/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/kinetis/tone_alarm/tone_alarm.cpp
@@ -460,7 +460,7 @@ int tone_alarm_main(int argc, char *argv[])
 		if (!strcmp(argv1, "start")) {
 			if (g_dev != nullptr) {
 				PX4_ERR("already started");
-				exit(1);
+				return 1;
 			}
 
 			if (g_dev == nullptr) {
@@ -468,33 +468,33 @@ int tone_alarm_main(int argc, char *argv[])
 
 				if (g_dev == nullptr) {
 					PX4_ERR("couldn't allocate the ToneAlarm driver");
-					exit(1);
+					return 1;
 				}
 
 				if (OK != g_dev->init()) {
 					delete g_dev;
 					g_dev = nullptr;
 					PX4_ERR("ToneAlarm init failed");
-					exit(1);
+					return 1;
 				}
 			}
 
-			exit(0);
+			return 0;
 		}
 
 		if (!strcmp(argv1, "stop")) {
 			delete g_dev;
 			g_dev = nullptr;
-			exit(0);
+			return 0;
 		}
 
 		if (!strcmp(argv1, "status")) {
 			g_dev->status();
-			exit(0);
+			return 0;
 		}
 
 	}
 
 	tone_alarm_usage();
-	exit(0);
+	return 0;
 }

--- a/src/drivers/samv7/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/samv7/tone_alarm/tone_alarm.cpp
@@ -456,7 +456,7 @@ int tone_alarm_main(int argc, char *argv[])
 		if (!strcmp(argv1, "start")) {
 			if (g_dev != nullptr) {
 				PX4_ERR("already started");
-				exit(1);
+				return 1;
 			}
 
 			if (g_dev == nullptr) {
@@ -464,34 +464,34 @@ int tone_alarm_main(int argc, char *argv[])
 
 				if (g_dev == nullptr) {
 					PX4_ERR("couldn't allocate the ToneAlarm driver");
-					exit(1);
+					return 1;
 				}
 
 				if (OK != g_dev->init()) {
 					delete g_dev;
 					g_dev = nullptr;
 					PX4_ERR("ToneAlarm init failed");
-					exit(1);
+					return 1;
 				}
 			}
 
-			exit(0);
+			return 0;
 		}
 
 		if (!strcmp(argv1, "stop")) {
 			delete g_dev;
 			g_dev = nullptr;
-			exit(0);
+			return 0;
 		}
 
 		if (!strcmp(argv1, "status")) {
 			g_dev->status();
-			exit(0);
+			return 0;
 		}
 
 	}
 
 	tone_alarm_usage();
-	exit(0);
+	return 0;
 }
 #endif /* TONE_ALARM_CHANNEL */

--- a/src/drivers/stm32/tone_alarm/tone_alarm.cpp
+++ b/src/drivers/stm32/tone_alarm/tone_alarm.cpp
@@ -546,7 +546,7 @@ int tone_alarm_main(int argc, char *argv[])
 		if (!strcmp(argv1, "start")) {
 			if (g_dev != nullptr) {
 				PX4_ERR("already started");
-				exit(1);
+				return 1;
 			}
 
 			if (g_dev == nullptr) {
@@ -554,33 +554,33 @@ int tone_alarm_main(int argc, char *argv[])
 
 				if (g_dev == nullptr) {
 					PX4_ERR("couldn't allocate the ToneAlarm driver");
-					exit(1);
+					return 1;
 				}
 
 				if (OK != g_dev->init()) {
 					delete g_dev;
 					g_dev = nullptr;
 					PX4_ERR("ToneAlarm init failed");
-					exit(1);
+					return 1;
 				}
 			}
 
-			exit(0);
+			return 0;
 		}
 
 		if (!strcmp(argv1, "stop")) {
 			delete g_dev;
 			g_dev = nullptr;
-			exit(0);
+			return 0;
 		}
 
 		if (!strcmp(argv1, "status")) {
 			g_dev->status();
-			exit(0);
+			return 0;
 		}
 
 	}
 
 	tone_alarm_usage();
-	exit(0);
+	return 0;
 }

--- a/src/examples/fixedwing_control/main.cpp
+++ b/src/examples/fixedwing_control/main.cpp
@@ -450,7 +450,6 @@ usage(const char *reason)
 	}
 
 	fprintf(stderr, "usage: ex_fixedwing_control {start|stop|status}\n\n");
-	exit(1);
 }
 
 /**
@@ -465,6 +464,7 @@ int ex_fixedwing_control_main(int argc, char *argv[])
 {
 	if (argc < 2) {
 		usage("missing command");
+		return 1;
 	}
 
 	if (!strcmp(argv[1], "start")) {
@@ -472,7 +472,7 @@ int ex_fixedwing_control_main(int argc, char *argv[])
 		if (thread_running) {
 			printf("ex_fixedwing_control already running\n");
 			/* this is not an error */
-			exit(0);
+			return 0;
 		}
 
 		thread_should_exit = false;
@@ -483,12 +483,12 @@ int ex_fixedwing_control_main(int argc, char *argv[])
 						 fixedwing_control_thread_main,
 						 (argv) ? (char *const *)&argv[2] : (char *const *)nullptr);
 		thread_running = true;
-		exit(0);
+		return 0;
 	}
 
 	if (!strcmp(argv[1], "stop")) {
 		thread_should_exit = true;
-		exit(0);
+		return 0;
 	}
 
 	if (!strcmp(argv[1], "status")) {
@@ -499,9 +499,9 @@ int ex_fixedwing_control_main(int argc, char *argv[])
 			printf("\tex_fixedwing_control not started\n");
 		}
 
-		exit(0);
+		return 0;
 	}
 
 	usage("unrecognized command");
-	exit(1);
+	return 0;
 }

--- a/src/examples/rover_steering_control/main.cpp
+++ b/src/examples/rover_steering_control/main.cpp
@@ -395,7 +395,6 @@ usage(const char *reason)
 	}
 
 	fprintf(stderr, "usage: rover_steering_control {start|stop|status}\n\n");
-	exit(1);
 }
 
 /**
@@ -410,6 +409,7 @@ int rover_steering_control_main(int argc, char *argv[])
 {
 	if (argc < 2) {
 		usage("missing command");
+		return 1;
 	}
 
 	if (!strcmp(argv[1], "start")) {
@@ -417,7 +417,7 @@ int rover_steering_control_main(int argc, char *argv[])
 		if (thread_running) {
 			warnx("running");
 			/* this is not an error */
-			exit(0);
+			return 0;
 		}
 
 		thread_should_exit = false;
@@ -428,12 +428,12 @@ int rover_steering_control_main(int argc, char *argv[])
 						 rover_steering_control_thread_main,
 						 (argv) ? (char *const *)&argv[2] : (char *const *)nullptr);
 		thread_running = true;
-		exit(0);
+		return 0;
 	}
 
 	if (!strcmp(argv[1], "stop")) {
 		thread_should_exit = true;
-		exit(0);
+		return 0;
 	}
 
 	if (!strcmp(argv[1], "status")) {
@@ -444,11 +444,11 @@ int rover_steering_control_main(int argc, char *argv[])
 			warnx("not started");
 		}
 
-		exit(0);
+		return 0;
 	}
 
 	usage("unrecognized command");
-	exit(1);
+	return 1;
 }
 
 

--- a/src/examples/segway/segway_main.cpp
+++ b/src/examples/segway/segway_main.cpp
@@ -78,7 +78,6 @@ usage(const char *reason)
 	}
 
 	fprintf(stderr, "usage: segway {start|stop|status} [-p <additional params>]\n\n");
-	exit(1);
 }
 
 /**
@@ -94,6 +93,7 @@ int segway_main(int argc, char *argv[])
 
 	if (argc < 2) {
 		usage("missing command");
+		return -1;
 	}
 
 	if (!strcmp(argv[1], "start")) {
@@ -101,7 +101,7 @@ int segway_main(int argc, char *argv[])
 		if (thread_running) {
 			warnx("already running");
 			/* this is not an error */
-			exit(0);
+			return 0;
 		}
 
 		thread_should_exit = false;
@@ -112,12 +112,12 @@ int segway_main(int argc, char *argv[])
 						 5120,
 						 segway_thread_main,
 						 (argv) ? (char *const *)&argv[2] : (char *const *)nullptr);
-		exit(0);
+		return 0;
 	}
 
 	if (!strcmp(argv[1], "stop")) {
 		thread_should_exit = true;
-		exit(0);
+		return 0;
 	}
 
 	if (!strcmp(argv[1], "status")) {
@@ -128,11 +128,11 @@ int segway_main(int argc, char *argv[])
 			warnx("not started");
 		}
 
-		exit(0);
+		return 0;
 	}
 
 	usage("unrecognized command");
-	exit(1);
+	return -1;
 }
 
 int segway_thread_main(int argc, char *argv[])

--- a/src/include/visibility.h
+++ b/src/include/visibility.h
@@ -59,6 +59,18 @@
 #  define __END_DECLS
 #endif
 
+/* exit() is used on NuttX to exit a task. However on Posix, it will exit the
+ * whole application, so we prevent its use there. There are cases where it
+ * still needs to be used, thus we remap system_exit to exit.
+ */
+#define system_exit exit
+#ifdef __PX4_POSIX
+#include <stdlib.h>
+#ifdef __cplusplus
+#include <cstdlib>
+#endif
+#pragma GCC poison exit
+#endif
 
 #ifdef __PX4_NUTTX
 /* On NuttX we call clearenv() so we cannot use getenv() and others (see px4_task_spawn_cmd() in px4_nuttx_tasks.c).

--- a/src/lib/parameters/param_shmem.c
+++ b/src/lib/parameters/param_shmem.c
@@ -943,14 +943,14 @@ param_save_default(void)
 
 	if (fd < 0) {
 		PX4_ERR("failed to open param file: %s", filename);
-		goto exit;
+		goto do_exit;
 	}
 
 	res = param_export(fd, false);
 
 	if (res != OK) {
 		PX4_ERR("failed to write parameters to file: %s", filename);
-		goto exit;
+		goto do_exit;
 	}
 
 	PARAM_CLOSE(fd);
@@ -958,7 +958,7 @@ param_save_default(void)
 
 	fd = -1;
 
-exit:
+do_exit:
 
 	if (fd >= 0) {
 		close(fd);

--- a/src/modules/events/temperature_calibration/task.cpp
+++ b/src/modules/events/temperature_calibration/task.cpp
@@ -87,7 +87,7 @@ public:
 
 	void		task_main();
 
-	void exit() { _force_task_exit = true; }
+	void exit_task() { _force_task_exit = true; }
 
 private:
 	void publish_led_control(led_control_s &led_control);

--- a/src/modules/systemlib/uthash/utarray.h
+++ b/src/modules/systemlib/uthash/utarray.h
@@ -39,7 +39,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>  /* memset, etc */
 #include <stdlib.h>  /* exit */
 
-#define oom() exit(-1)
+// FIXME: this needs to be checked: we need to handle OOM properly instead of just exiting
+#define oom() system_exit(-1)
 
 typedef void (ctor_f)(void *dst, const void *src);
 typedef void (dtor_f)(void *elt);

--- a/src/platforms/apps.cpp.in
+++ b/src/platforms/apps.cpp.in
@@ -48,7 +48,7 @@ void list_builtins(apps_map_type &apps)
 int shutdown_main(int argc, char *argv[])
 {
 	printf("Shutting down\n");
-	exit(0);
+	system_exit(0);
 }
 
 int list_tasks_main(int argc, char *argv[])

--- a/src/platforms/posix/drivers/tonealrmsim/tone_alarm.cpp
+++ b/src/platforms/posix/drivers/tonealrmsim/tone_alarm.cpp
@@ -326,7 +326,7 @@ int tone_alarm_main(int argc, char *argv[])
 		if (!strcmp(argv1, "start")) {
 			if (g_dev != nullptr) {
 				PX4_ERR("already started");
-				exit(1);
+				return 1;
 			}
 
 			if (g_dev == nullptr) {
@@ -334,33 +334,33 @@ int tone_alarm_main(int argc, char *argv[])
 
 				if (g_dev == nullptr) {
 					PX4_ERR("couldn't allocate the ToneAlarm driver");
-					exit(1);
+					return 1;
 				}
 
 				if (OK != g_dev->init()) {
 					delete g_dev;
 					g_dev = nullptr;
 					PX4_ERR("ToneAlarm init failed");
-					exit(1);
+					return 1;
 				}
 			}
 
-			exit(0);
+			return 0;
 		}
 
 		if (!strcmp(argv1, "stop")) {
 			delete g_dev;
 			g_dev = nullptr;
-			exit(0);
+			return 0;
 		}
 
 		if (!strcmp(argv1, "status")) {
 			g_dev->status();
-			exit(0);
+			return 0;
 		}
 
 	}
 
 	tone_alarm_usage();
-	exit(0);
+	return 0;
 }

--- a/src/systemcmds/tests/test_uart_loopback.c
+++ b/src/systemcmds/tests/test_uart_loopback.c
@@ -82,7 +82,7 @@ int test_uart_loopback(int argc, char *argv[])
 		}
 
 		printf("ERROR opening UART5, aborting..\n");
-		exit(uart5);
+		return 1;
 	}
 
 	uint8_t sample_stdout_fd[] = {'C', 'O', 'U', 'N', 'T', ' ', '#', '\n'};


### PR DESCRIPTION
`exit()` exits the whole process instead of only the task (which is different on NuttX). @davids5 fyi

Fixes https://github.com/PX4/Firmware/issues/10377