### PR TITLE
Update submodule matrix to latest Fri Aug 31 21:31:02 UTC 2018

### DIFF
--- a/src/systemcmds/tests/test_matrix.cpp
+++ b/src/systemcmds/tests/test_matrix.cpp
@@ -449,8 +449,7 @@ bool MatrixTest::matrixAssignmentTests()
 	ut_test(isEqual(m4, Matrix3f(data_row_02_swap)));
 	ut_test(fabs(m4.min() - 1) < 1e-5);
 
-	Scalar<float> s;
-	s = 1;
+	Scalar<float> s = 1;
 	ut_test(fabs(s - 1) < 1e-5);
 
 	Matrix<float, 1, 1> m5 = s;


### PR DESCRIPTION
    - matrix in PX4/Firmware (468f28463eabc30843e606546d642adc1a62fe10): https://github.com/PX4/Matrix/commit/b815fc97c4e686a93a8074f27d1830a031b0d38d
    - matrix current upstream: https://github.com/PX4/Matrix/commit/dc3af8097798881b9b2e72a029a3c6c10abd059b
    - Changes: https://github.com/PX4/Matrix/compare/b815fc97c4e686a93a8074f27d1830a031b0d38d...dc3af8097798881b9b2e72a029a3c6c10abd059b

dc3af80 2018-08-27 Daniel Agar - constructors use array size rather than pointers
f1bee77 2018-08-27 Daniel Agar - use default constructors and skip unnecessary initialization
1bcf48b 2018-08-30 Daniel Agar - Quaternion from_dcm don't pass by value
