### PR TITLE
cmake build - check directory existance before copy_directory

### DIFF
--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -105,6 +105,7 @@ endif()
 
 add_custom_command(OUTPUT romfs_extras.stamp
 	COMMAND ${CMAKE_COMMAND} -E make_directory ${romfs_gen_root_dir}/extras/
+	COMMAND ${CMAKE_COMMAND} -E make_directory ${PX4_BINARY_DIR}/romfs_extras/
 	COMMAND ${CMAKE_COMMAND} -E copy_directory ${PX4_BINARY_DIR}/romfs_extras/ ${romfs_gen_root_dir}/extras/
 	COMMAND ${CMAKE_COMMAND} -E touch romfs_extras.stamp
 	DEPENDS


### PR DESCRIPTION
Starting with cmake version 3.12 the cmake -E copy_directory
command fails if the source directory does not exist. This results
in a build failure. This fix checks the existance of the
source directory before the copy_directory command ist started.

Closes: #10368

**Describe possible alternatives**
I could not find a cmake only way without the use of shell script to achieve this
