### PR TITLE
cmake configs: remove posix_sitl_ekf2.cmake

### DIFF
--- a/cmake/configs/posix_sitl_ekf2.cmake
+++ b/cmake/configs/posix_sitl_ekf2.cmake
@@ -1,1 +1,0 @@
-include(cmake/configs/posix_sitl_default.cmake)


### PR DESCRIPTION
One more file that I forgot to remove in #10380.