### PR TITLE
navigator: let vtol descend in fixed wing mode before transitioning

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -309,17 +309,25 @@ RTL::advance_rtl()
 	case RTL_STATE_RETURN:
 		_rtl_state = RTL_STATE_DESCEND;
 
+		break;
+
+	case RTL_STATE_DESCEND:
+
+		// if we are a VTOL and in fixed wing mode then we should now transition to rotary wing mode
 		if (_navigator->get_vstatus()->is_vtol && !_navigator->get_vstatus()->is_rotary_wing) {
 			_rtl_state = RTL_STATE_TRANSITION_TO_MC;
+
+		} else if (_param_land_delay.get() < -DELAY_SIGMA || _param_land_delay.get() > DELAY_SIGMA) {
+			// Only go to land if autoland is enabled.
+			_rtl_state = RTL_STATE_LOITER;
+
+		} else {
+			_rtl_state = RTL_STATE_LAND;
 		}
 
 		break;
 
 	case RTL_STATE_TRANSITION_TO_MC:
-		_rtl_state = RTL_STATE_RETURN;
-		break;
-
-	case RTL_STATE_DESCEND:
 
 		// Only go to land if autoland is enabled.
 		if (_param_land_delay.get() < -DELAY_SIGMA || _param_land_delay.get() > DELAY_SIGMA) {


### PR DESCRIPTION
Previously during an RTL the transition back to rotary wing mode was
triggered when the plane reached the home position at the RTL height.
It makes more sense to do the descent phase in fw mode in order to save
energy and for stability reasons. Note also that the RTL height could potentially be quite high and so we really should avoid descending in rotary wing mode.
The plane will now fly down to the descend altitude in fixed wing mode and
then do the transition to rotary wing mode.

Currently the descend altitude is quite low (10 m) by default which is probably too low for vtol transitions.
So we should handle that somehow before merging this.

@dagar @sanderux FYI

Signed-off-by: Roman <bapstroman@gmail.com>