### PR TITLE
Avoidance feedback to Navigator (rebased)

### DIFF
--- a/msg/position_controller_status.msg
+++ b/msg/position_controller_status.msg
@@ -12,3 +12,5 @@ float32 wp_dist
 float32 acceptance_radius		# the optimal distance to a waypoint to switch to the next
 
 float32 yaw_acceptance			# NaN if not set
+
+float32 altitude_acceptance_radius # the optimal vertical distance to a waypoint to switch to the next

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -217,7 +217,9 @@ bool FlightTaskAuto::_evaluateTriplets()
 		_updateAvoidanceWaypoints();
 	}
 
-	_checkAvoidanceProgress();
+	if (MPC_OBS_AVOID.get()) {
+		_checkAvoidanceProgress();
+	}
 
 	return true;
 }

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -320,6 +320,14 @@ void FlightTaskAuto::_checkAvoidanceProgress()
 		pos_control_status.acceptance_radius = Vector2f(&(_triplet_target - _position)(0)).length() + 0.5f;
 	}
 
+	Vector2f pos_to_target = Vector2f(&(_triplet_target - _position)(0));
+	const float pos_to_target_z = fabsf(_triplet_target(2) - _position(2));
+
+	if (pos_to_target.length() < NAV_ACC_RAD.get() && pos_to_target_z > NAV_MC_ALT_RAD.get()) {
+		// vehicle above or below the target waypoint
+		pos_control_status.altitude_acceptance_radius = pos_to_target_z + 0.5f;
+	}
+
 	// do not check for waypoints yaw acceptance in navigator
 	pos_control_status.yaw_acceptance = NAN;
 

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -217,6 +217,8 @@ bool FlightTaskAuto::_evaluateTriplets()
 		_updateAvoidanceWaypoints();
 	}
 
+	_checkAvoidanceProgress();
+
 	return true;
 }
 
@@ -298,6 +300,37 @@ void FlightTaskAuto::_updateAvoidanceWaypoints()
 		_sub_triplet_setpoint->get().next.yawspeed_valid ?
 		_sub_triplet_setpoint->get().next.yawspeed : NAN;
 	_desired_waypoint.waypoints[vehicle_trajectory_waypoint_s::POINT_2].point_valid = true;
+}
+
+void FlightTaskAuto::_checkAvoidanceProgress()
+{
+	position_controller_status_s pos_control_status = {};
+	pos_control_status.timestamp = hrt_absolute_time();
+
+	// vector from previous triplet to current target
+	Vector2f prev_to_target = Vector2f(&(_triplet_target - _triplet_prev_wp)(0));
+	// vector from previous triplet to the vehicle projected position on the line previous-target triplet
+	Vector2f prev_to_closest_pt = _closest_pt - Vector2f(&(_triplet_prev_wp)(0));
+	// fraction of the previous-tagerget line that has been flown
+	const float prev_curr_travelled = prev_to_closest_pt.length() / prev_to_target.length();
+
+	if (prev_curr_travelled > 1.0f) {
+		// if the vehicle projected position on the line previous-target is past the target waypoint,
+		// increase the target acceptance radius such that navigator will update the triplets
+		pos_control_status.acceptance_radius = Vector2f(&(_triplet_target - _position)(0)).length() + 0.5f;
+	}
+
+	// do not check for waypoints yaw acceptance in navigator
+	pos_control_status.yaw_acceptance = NAN;
+
+	if (_pub_pos_control_status == nullptr) {
+		_pub_pos_control_status = orb_advertise(ORB_ID(position_controller_status), &pos_control_status);
+
+	} else {
+		orb_publish(ORB_ID(position_controller_status), _pub_pos_control_status, &pos_control_status);
+
+	}
+
 }
 
 bool FlightTaskAuto::_isFinite(const position_setpoint_s &sp)

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
@@ -104,7 +104,8 @@ protected:
 					(ParamFloat<px4::params::MPC_CRUISE_90>) MPC_CRUISE_90, // speed at corner when angle is 90 degrees move to line
 					(ParamFloat<px4::params::NAV_ACC_RAD>) NAV_ACC_RAD, // acceptance radius at which waypoints are updated move to line
 					(ParamFloat<px4::params::NAV_MC_ALT_RAD>) NAV_MC_ALT_RAD, //vertical acceptance radius at which waypoints are updated
-					(ParamInt<px4::params::MPC_YAW_MODE>) MPC_YAW_MODE // defines how heading is executed
+					(ParamInt<px4::params::MPC_YAW_MODE>) MPC_YAW_MODE, // defines how heading is executed,
+					(ParamInt<px4::params::MPC_OBS_AVOID>) MPC_OBS_AVOID // obstacle avoidance active
 				       );
 
 private:

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
@@ -103,6 +103,7 @@ protected:
 					(ParamFloat<px4::params::MPC_XY_CRUISE>) MPC_XY_CRUISE,
 					(ParamFloat<px4::params::MPC_CRUISE_90>) MPC_CRUISE_90, // speed at corner when angle is 90 degrees move to line
 					(ParamFloat<px4::params::NAV_ACC_RAD>) NAV_ACC_RAD, // acceptance radius at which waypoints are updated move to line
+					(ParamFloat<px4::params::NAV_MC_ALT_RAD>) NAV_MC_ALT_RAD, //vertical acceptance radius at which waypoints are updated
 					(ParamInt<px4::params::MPC_YAW_MODE>) MPC_YAW_MODE // defines how heading is executed
 				       );
 

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
@@ -43,6 +43,7 @@
 #include <uORB/topics/position_setpoint_triplet.h>
 #include <uORB/topics/position_setpoint.h>
 #include <uORB/topics/home_position.h>
+#include <uORB/topics/position_controller_status.h>
 #include <lib/ecl/geo/geo.h>
 
 /**
@@ -122,10 +123,13 @@ private:
 	float _reference_altitude = NAN;  /**< Altitude relative to ground. */
 	hrt_abstime _time_stamp_reference = 0; /**< time stamp when last reference update occured. */
 
+	orb_advert_t _pub_pos_control_status = nullptr; /**< Publisher for the position controller status */
+
 	bool _evaluateTriplets(); /**< Checks and sets triplets. */
 	bool _isFinite(const position_setpoint_s &sp); /**< Checks if all waypoint triplets are finite. */
 	bool _evaluateGlobalReference(); /**< Check is global reference is available. */
 	float _getVelocityFromAngle(const float angle); /**< Computes the speed at target depending on angle. */
 	State _getCurrentState(); /**< Computes the current vehicle state based on the vehicle position and navigator triplets. */
 	void _set_heading_from_mode(); /**< @see  MPC_YAW_MODE */
+	void _checkAvoidanceProgress();
 };

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -322,7 +322,7 @@ MissionBlock::is_mission_item_reached()
 
 		if ((_navigator->get_vstatus()->is_rotary_wing
 		     || (_mission_item.nav_cmd == NAV_CMD_LOITER_TO_ALT && _mission_item.force_heading))
-		    && PX4_ISFINITE(_mission_item.yaw)) {
+		    && PX4_ISFINITE(_navigator->get_yaw_acceptance(_mission_item.yaw))) {
 
 			/* check course if defined only for rotary wing except takeoff */
 			float cog = _navigator->get_vstatus()->is_rotary_wing ? _navigator->get_global_position()->yaw : atan2f(

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -248,6 +248,16 @@ public:
 	 */
 	float		get_acceptance_radius(float mission_item_radius);
 
+	/**
+	 * Get the yaw acceptance given the current mission item
+	 *
+	 * @param mission_item_yaw the yaw to use in case the controller-derived radius is finite
+	 *
+	 * @return the yaw at which the next waypoint should be used or if the yaw at a waypoint
+	 * should be ignored
+	 */
+	float 		get_yaw_acceptance(float mission_item_yaw);
+
 	orb_advert_t	*get_mavlink_log_pub() { return &_mavlink_log_pub; }
 
 	void		increment_mission_instance_count() { _mission_result.instance_count++; }

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -845,7 +845,16 @@ Navigator::get_default_altitude_acceptance_radius()
 		return _param_fw_alt_acceptance_radius.get();
 
 	} else {
-		return _param_mc_alt_acceptance_radius.get();
+		float alt_acceptance_radius = _param_mc_alt_acceptance_radius.get();
+
+		const position_controller_status_s &pos_ctrl_status = _position_controller_status_sub.get();
+
+		if ((pos_ctrl_status.timestamp > _pos_sp_triplet.timestamp)
+		    && pos_ctrl_status.altitude_acceptance_radius > alt_acceptance_radius) {
+			alt_acceptance_radius = pos_ctrl_status.altitude_acceptance_radius;
+		}
+
+		return alt_acceptance_radius;
 	}
 }
 

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -944,6 +944,20 @@ Navigator::get_acceptance_radius(float mission_item_radius)
 	return radius;
 }
 
+float
+Navigator::get_yaw_acceptance(float mission_item_yaw)
+{
+	float yaw = mission_item_yaw;
+
+	const position_controller_status_s &pos_ctrl_status = _position_controller_status_sub.get();
+
+	if ((pos_ctrl_status.timestamp > _pos_sp_triplet.timestamp) && !PX4_ISFINITE(pos_ctrl_status.yaw_acceptance)) {
+		yaw = pos_ctrl_status.yaw_acceptance;
+	}
+
+	return yaw;
+}
+
 void
 Navigator::load_fence_from_file(const char *filename)
 {


### PR DESCRIPTION
Rebased version of  #10240 

 -  if the vehicle projected position on the line previous-current triplet is past the current triplet, acceptance radius is enlarged such that navigator updates the triplets
 -   if the vehicle is within the xy acceptance radius but not inside the z one, enlarge the altitude acceptance radius such that navigator updates the triplets set the feedback yaw acceptance to NAN such that it is ignored by navigator

Missions shouldn't get stuck anymore because a waypoint is not reachable or a waypoint is reached with a heading different from what navigator expects
