### PR TITLE
Enhancement: added X-UAV Mini Talon V-Tail airframe

### DIFF
--- a/ROMFS/px4fmu_common/init.d/2200_mini_talon
+++ b/ROMFS/px4fmu_common/init.d/2200_mini_talon
@@ -1,0 +1,53 @@
+#!nsh
+#
+# @name X-UAV Mini Talon
+#
+# @type Plane V-Tail
+# @class Plane
+#
+# The Mini Talon does not have a wheel and
+# no flaps. I leave them here because the mixer
+# computes also wheel and flap controls.
+#
+# @output MAIN1 aileron right
+# @output MAIN2 aileron left
+# @output MAIN3 v-tail right
+# @output MAIN4 v-tail left
+# @output MAIN5 throttle
+# @output MAIN6 wheel
+# @output MAIN7 flaps right
+# @output MAIN8 flaps left
+#
+# @output AUX1 feed-through of RC AUX1 channel
+# @output AUX2 feed-through of RC AUX2 channel
+# @output AUX3 feed-through of RC AUX3 channel
+#
+# @maintainer Friedrich Beckmann <friedrich.beckmann@hs-augsburg.de>
+#
+
+sh /etc/init.d/rc.fw_defaults
+
+if [ $AUTOCNF = yes ]
+then
+	param set FW_AIRSPD_MIN 10
+	param set FW_AIRSPD_TRIM 15
+	param set FW_AIRSPD_MAX 20
+
+	param set FW_MAN_P_MAX 55
+	param set FW_MAN_R_MAX 55
+	param set FW_R_LIM 55
+
+	param set FW_WR_FF 0.2
+	param set FW_WR_I 0.2
+	param set FW_WR_IMAX 0.8
+	param set FW_WR_P 1
+	param set FW_W_RMAX 0
+
+	# set disarmed value for the ESC
+	param set PWM_DISARMED 1000
+fi
+
+set MIXER AAVVTWFF_vtail
+
+# use PWM parameters for throttle channel
+set PWM_OUT 5

--- a/ROMFS/px4fmu_common/init.d/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/CMakeLists.txt
@@ -37,6 +37,7 @@ px4_add_romfs_files(
 	2100_standard_plane
 	2105_maja
 	2106_albatross
+	2200_mini_talon
 	24001_dodeca_cox
 	3000_generic_wing
 	3030_io_camflyer

--- a/ROMFS/px4fmu_common/mixers/AAVVTWFF_vtail.main.mix
+++ b/ROMFS/px4fmu_common/mixers/AAVVTWFF_vtail.main.mix
@@ -1,0 +1,70 @@
+Aileron/v-tail/throttle/wheel/flaps mixer for PX4FMU
+=======================================================
+
+This file defines mixers suitable for controlling a fixed wing aircraft with
+aileron, v-tail (rudder, elevator), throttle, steerable wheel and flaps
+using PX4FMU.
+The configuration assumes the aileron servos are connected to PX4FMU servo
+output 0 and 1, the tail servos to output 2 and 3, the throttle
+to output 4, the wheel to output 5 and the flaps to output 6 and 7.
+
+Inputs to the mixer come from channel group 0 (vehicle attitude), channels 0
+(roll), 1 (pitch), 2 (yaw) and 3 (thrust) 4 (flaps) 6 (flaperon).
+
+Aileron mixer (roll + flaperon)
+---------------------------------
+
+This mixer assumes that the aileron servos are set up mechanically reversed.
+
+M: 2
+S: 0 0 -10000 -10000      0 -10000  10000
+S: 0 6  10000  10000      0 -10000  10000
+
+M: 2
+S: 0 0 -10000 -10000      0 -10000  10000
+S: 0 6 -10000 -10000      0 -10000  10000
+
+V-tail mixers
+-------------
+Three scalers total (output, roll, pitch).
+
+M: 2
+S: 0 2   7000   7000      0 -10000  10000
+S: 0 1  -8000  -8000      0 -10000  10000
+
+M: 2
+S: 0 2   7000   7000      0 -10000  10000
+S: 0 1   8000   8000      0 -10000  10000
+
+Motor speed mixer
+-----------------
+Two scalers total (output, thrust).
+
+This mixer generates a full-range output (-1 to 1) from an input in the (0 - 1)
+range.  Inputs below zero are treated as zero.
+
+M: 1
+S: 0 3      0  20000 -10000 -10000  10000
+
+Wheel mixer
+------------
+Two scalers total (output, yaw).
+
+This mixer assumes that the wheel servo is set up correctly mechanically;
+depending on the actual configuration it may be necessary to reverse the scaling
+factors (to reverse the servo movement) and adjust the offset, scaling and
+endpoints to suit.
+
+M: 1
+S: 0 2 -10000 -10000      0 -10000  10000
+
+Flaps mixer
+------------
+Flap servos are physically reversed.
+
+M: 1
+S: 0 4      0   5000 -10000 -10000  10000
+
+M: 1
+S: 0 4      0  -5000  10000 -10000  10000
+


### PR DESCRIPTION
The X-UAV Mini Talon airframe with the
new type "Plane V-Tail" uses the AAVVTWFF mixer
and is derived from the Albatross A-Tail.

This airframe introduces a new airframe group "Plane V-Tail". There
is a corresponding PR mavlink/qgroundcontrol#6852 to introduce the
new airframe group in qgroundcontrol with a picture.

We use the X-UAV Mini Talon in our [research project](https://www.hs-augsburg.de/homes/beckmanf/dokuwiki/doku.php?id=searchwing) and I plan to maintain
the parameters. We have done several flights with these parameters for example
[this one](https://review.px4.io/plot_app?log=0af78132-95a9-4260-aa7b-19f211b62aa2) although they are simply copied from the Albatros A-Tail. Nothing is optimized, but it flies.