### PR TITLE
mavlink temporary workarounds for dronekit: added parameters to disable

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -546,7 +546,8 @@ Mavlink::forward_message(const mavlink_message_t *msg, Mavlink *self)
 			// Broadcast or addressing this system and not trying to talk
 			// to the autopilot component -> pass on to other components
 			if ((target_system_id == 0 || target_system_id == self->get_system_id())
-			    && (target_component_id == 0 || target_component_id != self->get_component_id())) {
+			    && (target_component_id == 0 || target_component_id != self->get_component_id())
+			    && !(!self->forward_heartbeats_enabled() && msg->msgid == MAVLINK_MSG_ID_HEARTBEAT)) {
 
 				inst->pass_message(msg);
 			}

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -487,6 +487,10 @@ public:
 
 	bool ftp_enabled() const { return _ftp_on; }
 
+	bool hash_check_enabled() { return _param_hash_check_enabled.get(); }
+
+	bool forward_heartbeats_enabled() { return _param_heartbeat_forwarding_enabled.get(); }
+
 	struct ping_statistics_s {
 		uint64_t last_ping_time;
 		uint32_t last_ping_seq;
@@ -629,7 +633,9 @@ private:
 		(ParamInt<px4::params::MAV_TYPE>) _param_system_type,
 		(ParamBool<px4::params::MAV_USEHILGPS>) _param_use_hil_gps,
 		(ParamBool<px4::params::MAV_FWDEXTSP>) _param_forward_externalsp,
-		(ParamInt<px4::params::MAV_BROADCAST>) _param_broadcast_mode
+		(ParamInt<px4::params::MAV_BROADCAST>) _param_broadcast_mode,
+		(ParamInt<px4::params::MAV_EN_HASH_CHK>) _param_hash_check_enabled,
+		(ParamInt<px4::params::MAV_EN_HB_FORW>) _param_heartbeat_forwarding_enabled
 	)
 
 	perf_counter_t		_loop_perf;			/**< loop performance counter */

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -134,7 +134,7 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 				name[MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN] = '\0';
 
 				/* Whatever the value is, we're being told to stop sending */
-				if (strncmp(name, "_HASH_CHECK", sizeof(name)) == 0) {
+				if (strncmp(name, "_HASH_CHECK", sizeof(name)) == 0 && _mavlink->hash_check_enabled()) {
 					_send_all_index = -1;
 					/* No other action taken, return */
 					return;

--- a/src/modules/mavlink/mavlink_params.c
+++ b/src/modules/mavlink/mavlink_params.c
@@ -141,3 +141,27 @@ PARAM_DEFINE_INT32(MAV_FWDEXTSP, 1);
  * @group MAVLink
  */
 PARAM_DEFINE_INT32(MAV_BROADCAST, 0);
+
+/**
+ * Parameter hash check.
+ *
+ * Disabling the parameter hash check functionality will make the mavlink instance
+ * stream parameters continuously.
+ *
+ * @boolean 0 Hash check disabled.
+ * @boolean 1 Hash check enabled.
+ * @group MAVLink
+ */
+PARAM_DEFINE_INT32(MAV_EN_HASH_CHK, 1);
+
+/**
+ * Hearbeat message forwarding.
+ *
+ * The mavlink hearbeat message will not be forwarded if this parameter is set to 'disabled'.
+ * The main reason for disabling heartbeats to be forwarded is because they confuse dronekit.
+ *
+ * @boolean 0 Forwarding disabled.
+ * @boolean 1 Forwarding enabled.
+ * @group MAVLink
+ */
+PARAM_DEFINE_INT32(MAV_EN_HB_FORW, 1);


### PR DESCRIPTION
Replaces #10326 

@dagar It's now using the module parameters as you suggested.
@sanderux Can you test and confirm that this enables you to use your system?
You need to set
> MAV_EN_HASH_CHK = 0
> MAV_EN_HB_FORW = 0



