### PR TITLE
Pass through horizontal and vertical covariances

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1173,8 +1173,9 @@ void Ekf2::run()
 			ev_data.quat = q;
 
 			// position measurement error from parameters. TODO : use covariances from topic
-			ev_data.posErr = fmaxf(_ev_pos_noise.get(), fmaxf(ev_pos.eph, ev_pos.epv));
+			ev_data.posErr = fmaxf(_ev_pos_noise.get(), ev_pos.eph);
 			ev_data.angErr = _ev_ang_noise.get();
+			ev_data.hgtErr = fmaxf(_ev_pos_noise.get(), ev_pos.epv);
 
 			// only set data if all positions and velocities are valid
 			if (ev_pos.xy_valid && ev_pos.z_valid && ev_pos.v_xy_valid && ev_pos.v_z_valid) {

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1253,6 +1253,10 @@ MavlinkReceiver::handle_message_vision_position_estimate(mavlink_message_t *msg)
 	vision_position.y = pos.y;
 	vision_position.z = pos.z;
 
+	//copy horizontal and vertical covariances
+	vision_position.eph = fmaxf(pos.covariance[0], pos.covariance[6]);
+	vision_position.epv = pos.covariance[11];
+
 	vision_position.xy_valid = true;
 	vision_position.z_valid = true;
 	vision_position.v_xy_valid = true;


### PR DESCRIPTION
**Test data / coverage**
Coming.. if desired for this minor change. 

**Describe problem solved by the proposed pull request**
For the vision input to the ekf there is only single variance figure used (posErr in the structs) for position representing a spherical error around said position. Some companion computer sensor systems have different errors on horizontal and vertical positions. I guess this is one of the reasons you can set the height mode independently via the EKF2_HGT_MODE flag.
I came across the issue where I wanted to influence the horizontal position accurately, but influence the vertical position only a little (or varying variances).

**Describe your preferred solution**
I've expanded the struct in ecl and included a separate hgtErr which is used on this line instead. I've modified Firmware to push the variances from the vision mavlink message into `vehicle_local_position_s.eph/epv`. It's all tested and working with the variance correctly influencing the EKF. 

**This PR relies on https://github.com/PX4/ecl/pull/507 to be merged first, then i can update the submodule tracking in a commit here.**

**Additional bugfix**
The original variances for `posErr` were never actually being copied into `vision_position.eph`  in `mavlilnk_reciever.cpp`, so the struct has either 0's or randomly initialized data from memory. End result, mavlink msg variances weren't be used to fuse into the EKF