### PR TITLE
Param docs explain how create

### DIFF
--- a/src/lib/parameters/px4params/markdownout.py
+++ b/src/lib/parameters/px4params/markdownout.py
@@ -4,7 +4,7 @@ import codecs
 class MarkdownTablesOutput():
     def __init__(self, groups):
         result = ("# Parameter Reference\n"
-                  "> **Note** **This list is auto-generated from the source code** and contains the most recent parameter documentation.\n"
+                  "> **Note** **This list is auto-generated from the source code** (using `make parameters_metadata`) and contains the most recent parameter documentation.\n"
                   "\n")
         for group in groups:
             result += '## %s\n\n' % group.GetName()


### PR DESCRIPTION
This adds text to markdown output to explain how params are generated

Ensures that questions like http://discuss.px4.io/t/question-about-px4-parameter-xml-document-generation/7750 are self-answering