### PR TITLE
sitl_run.sh: fix process grep for jMAVSim

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -47,7 +47,7 @@ pkill -x gazebo || true
 pkill -x px4 || true
 pkill -x px4_$model || true
 
-jmavsim_pid=`ps aux | grep java | grep Simulator | cut -d" " -f1`
+jmavsim_pid=`ps aux | grep java | grep "\-jar jmavsim_run.jar" | awk '{ print $2 }'`
 if [ -n "$jmavsim_pid" ]
 then
 	kill $jmavsim_pid


### PR DESCRIPTION
It seems that the oneline to find the process ID of any running jMAVSim
instance was not working correctly.
1. On Linux, the name of the process does not contain Simulator but
   jmavsim_run.jar. Also, it triggers incorrectly, if you have opened
   Simulator.java using the command line :).
2. The cutting to get the PID at the end does not work as intenteded and
   gives the username instead of PID, at least on Arch Linux. Using awk
   should fix this.

Fixes #10440.