### PR TITLE
tests command ignore -Wunused-variable

### DIFF
--- a/src/systemcmds/tests/CMakeLists.txt
+++ b/src/systemcmds/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ set(srcs
 	test_autodeclination.cpp
 	test_bezierQuad.cpp
 	test_bson.cpp
+	test_controlmath.cpp
 	test_conv.cpp
 	test_dataman.c
 	test_file.c
@@ -65,13 +66,12 @@ set(srcs
 	test_sensors.c
 	test_servo.c
 	test_sleep.c
+	test_smooth_z.cpp
 	test_uart_baudchange.c
 	test_uart_console.c
 	test_uart_loopback.c
 	test_uart_send.c
 	test_versioning.cpp
-	test_smooth_z.cpp
-	test_controlmath.cpp
 	tests_main.c
 	)
 
@@ -87,13 +87,14 @@ px4_add_module(
 	MAIN tests
 	STACK_MAIN 10000
 	COMPILE_FLAGS
-		-Wno-sign-compare # TODO: fix all sign-compare
-		-Wno-unused-result
+		-Wno-double-promotion
 		-Wno-float-equal
 		-Wno-missing-declarations
-		-Wno-double-promotion
+		-Wno-sign-compare # TODO: fix all sign-compare
 		-Wno-unknown-warning-option
 		-Wno-unused-but-set-variable
+		-Wno-unused-result
+		-Wno-unused-variable
 	SRCS
 		${srcs}
 	DEPENDS


### PR DESCRIPTION
To placate newer clang. http://ci.px4.io:8080/blue/organizations/jenkins/PX4%2Fcontainers/detail/pr-ros_split/1/pipeline/31