### PR TITLE
jmavsim_run.sh: fix issue with Java 10

### DIFF
--- a/Tools/jmavsim_run.sh
+++ b/Tools/jmavsim_run.sh
@@ -44,11 +44,14 @@ fi
 ant create_run_jar copy_res
 cd out/production
 
-java -XX:GCTimeRatio=20 -Djava.ext.dirs= -jar jmavsim_run.jar $device $extra_args
+classpath="$SCRIPT_DIR/jMAVSim/out/production/jMAVSim:$SCRIPT_DIR/jMAVSim/lib/*"
+
+java -XX:GCTimeRatio=20 -Djava.ext.dirs= -classpath $classpath me.drton.jmavsim.Simulator $device $extra_args
+
 ret=$?
 if [ $ret -ne 0 -a $ret -ne 130 ]; then # 130 is Ctrl-C
 	# if the start of java fails, it's probably because the GC option is not
 	# understood. Try starting without it
-	java -Djava.ext.dirs= -jar jmavsim_run.jar $device $extra_args
+	java -Djava.ext.dirs= -classpath $classpath me.drton.jmavsim.Simulator $device $extra_args
 fi
 


### PR DESCRIPTION
This runs the Simulator directly and adds all jar files to the classpath.

This fixes #10443, however, it means that the packaged jar does not work any longer for Java 10, and we might require a proper fix.