### PR TITLE
nxphlite-v3:Disable internal mag due to random spikes.

### DIFF
--- a/src/drivers/boards/nxphlite-v3/board_config.h
+++ b/src/drivers/boards/nxphlite-v3/board_config.h
@@ -543,6 +543,7 @@ __BEGIN_DECLS
 #  endif
 #endif /* HAVE_AUTOMOUNTER */
 
+#define BOARD_HAS_NOISY_FXOS8700_MAG 1 // Disable internal MAG
 
 /************************************************************************************
  * Public data

--- a/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
+++ b/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
@@ -1200,7 +1200,9 @@ FXOS8701CQ::start()
 		       1000,
 		       _call_accel_interval - FXOS8701C_TIMER_REDUCTION,
 		       (hrt_callout)&FXOS8701CQ::measure_trampoline, this);
+#if !defined(BOARD_HAS_NOISY_FXOS8700_MAG)
 	hrt_call_every(&_mag_call, 1000, _call_mag_interval, (hrt_callout)&FXOS8701CQ::mag_measure_trampoline, this);
+#endif
 }
 
 void


### PR DESCRIPTION
  This will disable the fxos8701cq internal mag on
  the NXPHlite. There are random noise spikes on the
  HIGHRES_IMU.[x|y|x]mag. Even with all other SPI
  devices shut down, the noise is still present.

Adresses https://github.com/PX4/Firmware/issues/10453
