### PR TITLE
jMAVSim: update to latest master

### DIFF
--- a/Tools/jmavsim_run.sh
+++ b/Tools/jmavsim_run.sh
@@ -1,4 +1,6 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
+set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR/jMAVSim"

--- a/Tools/jmavsim_run.sh
+++ b/Tools/jmavsim_run.sh
@@ -43,6 +43,18 @@ else
 	device="-serial $device $baudrate"
 fi
 
+# jMAVSim crashes with Java 9 on macOS, therefore we need to use Java 8
+if [ "$(uname)" == "Darwin" ]; then
+    bold=$(tput bold)
+    normal=$(tput sgr0)
+    if ! /usr/libexec/java_home -V 2>&1 | grep --quiet "Java SE 8" ; then
+        echo "${bold}You need to have Java 8 installed for macOS, for more info, see:${normal}"
+        echo "${bold}https://github.com/PX4/jMAVSim/issues/81${normal}"
+        exit 1
+    fi
+    export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
+fi
+
 ant create_run_jar copy_res
 cd out/production
 


### PR DESCRIPTION
This should resolve the issues with Java 9/10.

For more info, see: https://github.com/PX4/jMAVSim/pull/79

Fixes #10443.