### PR TITLE
Add pwm test mode to overcome pwm test not outputting or stuttering.

### DIFF
--- a/src/drivers/drv_pwm_output.h
+++ b/src/drivers/drv_pwm_output.h
@@ -265,6 +265,8 @@ struct pwm_output_rc_config {
 #define PWM_SERVO_MODE_4CAP        10
 #define PWM_SERVO_MODE_5CAP        11
 #define PWM_SERVO_MODE_6CAP        12
+#define PWM_SERVO_ENTER_TEST_MODE  13
+#define PWM_SERVO_EXIT_TEST_MODE   14
 #define PWM_SERVO_SET_MODE         _PX4_IOC(_PWM_SERVO_BASE, 34)
 
 /*

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1735,6 +1735,12 @@ PX4FMU::pwm_ioctl(file *filp, int cmd, unsigned long arg)
 				break;
 			}
 
+			if (_mixers == nullptr) {
+				PX4_ERR("error: no mixer loaded");
+				ret = -EIO;
+				break;
+			}
+
 			/* copy the trim values to the mixer offsets */
 			_mixers->set_trims((int16_t *)pwm->values, pwm->channel_count);
 			PX4_DEBUG("set_trims: %d, %d, %d, %d", pwm->values[0], pwm->values[1], pwm->values[2], pwm->values[3]);
@@ -1745,7 +1751,14 @@ PX4FMU::pwm_ioctl(file *filp, int cmd, unsigned long arg)
 	case PWM_SERVO_GET_TRIM_PWM: {
 			struct pwm_output_values *pwm = (struct pwm_output_values *)arg;
 
-			pwm->channel_count = _mixers->get_trims((int16_t *)pwm->values);
+			if (_mixers == nullptr) {
+				memset(pwm, 0, sizeof(pwm_output_values));
+				PX4_WARN("warning: trim values not valid - no mixer loaded");
+
+			} else {
+
+				pwm->channel_count = _mixers->get_trims((int16_t *)pwm->values);
+			}
 
 			break;
 		}

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -2745,6 +2745,10 @@ PX4IO::ioctl(file *filep, int cmd, unsigned long arg)
 			break;
 		}
 
+	case PWM_SERVO_SET_MODE:
+		ret = (arg == PWM_SERVO_ENTER_TEST_MODE || PWM_SERVO_EXIT_TEST_MODE) ? 0 : -EINVAL;
+		break;
+
 	case GPIO_RESET: {
 			ret = -EINVAL;
 			break;

--- a/src/systemcmds/pwm/pwm.cpp
+++ b/src/systemcmds/pwm/pwm.cpp
@@ -208,6 +208,7 @@ pwm_main(int argc, char *argv[])
 	bool oneshot = false;
 	int ch;
 	int ret;
+	int rv = 1;
 	char *ep;
 	uint32_t set_mask = 0;
 	unsigned group;
@@ -679,6 +680,11 @@ pwm_main(int argc, char *argv[])
 		fds.fd = 0; /* stdin */
 		fds.events = POLLIN;
 
+		if (::ioctl(fd, PWM_SERVO_SET_MODE, PWM_SERVO_ENTER_TEST_MODE) < 0) {
+				PX4_ERR("Failed to Enter pwm test mode");
+				goto err_out_no_test;
+		}
+
 		PX4_INFO("Press CTRL-C or 'c' to abort.");
 
 		while (1) {
@@ -688,7 +694,7 @@ pwm_main(int argc, char *argv[])
 
 					if (ret != OK) {
 						PX4_ERR("PWM_SERVO_SET(%d)", i);
-						return 1;
+						goto err_out;
 					}
 				}
 			}
@@ -709,13 +715,14 @@ pwm_main(int argc, char *argv[])
 
 							if (ret != OK) {
 								PX4_ERR("PWM_SERVO_SET(%d)", i);
-								return 1;
+								goto err_out;
 							}
 						}
 					}
 
 					PX4_INFO("User abort\n");
-					return 0;
+					rv = 0;
+					goto err_out;
 				}
 			}
 
@@ -731,8 +738,15 @@ pwm_main(int argc, char *argv[])
 			up_pwm_update();
 #endif
 		}
+		rv = 0;
+err_out:
+			if (::ioctl(fd, PWM_SERVO_SET_MODE, PWM_SERVO_EXIT_TEST_MODE) < 0) {
+					rv = 1;
+					PX4_ERR("Failed to Exit pwm test mode");
+			}
 
-		return 0;
+err_out_no_test:
+		return rv;
 
 
 	} else if (!strcmp(command, "steps")) {

--- a/src/systemcmds/pwm/pwm.cpp
+++ b/src/systemcmds/pwm/pwm.cpp
@@ -779,6 +779,11 @@ err_out_no_test:
 		PX4_WARN("Running 5 steps. WARNING! Motors will be live in 5 seconds\nPress any key to abort now.");
 		sleep(5);
 
+		if (::ioctl(fd, PWM_SERVO_SET_MODE, PWM_SERVO_ENTER_TEST_MODE) < 0) {
+				PX4_ERR("Failed to Enter pwm test mode");
+				goto err_out_no_test;
+		}
+
 		unsigned off = 900;
 		unsigned idle = 1300;
 		unsigned full = 2000;
@@ -815,7 +820,7 @@ err_out_no_test:
 
 						if (ret != OK) {
 							PX4_ERR("PWM_SERVO_SET(%d)", i);
-							return 1;
+							goto err_out;
 						}
 					}
 				}
@@ -836,13 +841,14 @@ err_out_no_test:
 
 								if (ret != OK) {
 									PX4_ERR("PWM_SERVO_SET(%d)", i);
-									return 1;
+									goto err_out;
 								}
 							}
 						}
 
 						PX4_INFO("User abort\n");
-						return 0;
+						rv = 0;
+						goto err_out;
 					}
 				}
 
@@ -868,7 +874,8 @@ err_out_no_test:
 			}
 		}
 
-		return 0;
+		rv = 0;
+		goto err_out;
 
 
 	} else if (!strcmp(command, "info")) {


### PR DESCRIPTION
This adds PWM_SERVO_{ENTER|EXIT}_TEST_MODE  ioctl to the fmu as a no-op to the px4io to disable the mixer output from overwriting the test values from `fmu test` and `pwm test -p NNNN -c 1234`.

 