### PR TITLE
fmu:Fix Safety switch breakage from bc9c25a

### DIFF
--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1284,7 +1284,7 @@ PX4FMU::cycle()
 		if (updated) {
 			safety_s safety;
 
-			if (orb_copy(ORB_ID(actuator_armed), _safety_sub, &safety) == 0) {
+			if (orb_copy(ORB_ID(safety), _safety_sub, &safety) == 0) {
 				_safety_off = !safety.safety_switch_available || safety.safety_off;
 			}
 		}


### PR DESCRIPTION
**Test data / coverage**
Bench NXPHlite - PWM stuck disarmed value

**Describe problem solved by the proposed pull request**
   The update check is on ORB_ID(safety) but the copy was from ORB_ID(actuator_armed).

**Describe your preferred solution**
Copy ORB_ID(safety) 

**Describe possible alternatives**
We should have a 'lint' check for this class of C&P error. 

**Additional context**
See https://github.com/PX4/Firmware/issues/10318
https://github.com/PX4/Firmware/issues/10469
https://github.com/PX4/Firmware/issues/10457
