### PR TITLE
test_file2:test fails due to missing slash

### DIFF
--- a/src/systemcmds/tests/test_file2.c
+++ b/src/systemcmds/tests/test_file2.c
@@ -175,7 +175,7 @@ int test_file2(int argc, char *argv[])
 {
 	int opt;
 	uint16_t flags = 0;
-	const char *filename = LOG_PATH "testfile2.dat";
+	const char *filename = LOG_PATH "/testfile2.dat";
 	uint32_t write_chunk = 64;
 	uint32_t write_size = 5 * 1024;
 


### PR DESCRIPTION
**Test data / coverage**
CI FAIL

![image](https://user-images.githubusercontent.com/1945821/45506910-7f3b0180-b745-11e8-90c7-42fb8486d581.png)


**Describe problem solved by the proposed pull request**
Missing / in macros concatenation for file name

**Describe your preferred solution**
Added a slash

**Describe possible alternatives**
none

**Additional context**
CI HW fail
