### PR TITLE
Jenkins force push metadata git updates (Devguide, userguide, QGC)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -268,7 +268,7 @@ pipeline {
               sh('cp parameters.md Devguide/en/advanced/parameter_reference.md')
               sh('cp -R modules/*.md Devguide/en/middleware/')
               sh('cd Devguide; git checkout -B pr-firmware_metadata_update; git status; git add .; git commit -a -m "Update PX4 Firmware metadata `date`" || true')
-              sh('cd Devguide; git push origin pr-firmware_metadata_update || true')
+              sh('cd Devguide; git push --force origin pr-firmware_metadata_update || true')
             }
           }
           when {
@@ -295,7 +295,7 @@ pipeline {
               sh('cp airframes.md px4_user_guide/en/airframes/airframe_reference.md')
               sh('cp parameters.md px4_user_guide/en/advanced_config/parameter_reference.md')
               sh('cd px4_user_guide; git checkout -B pr-firmware_metadata_update; git status; git add .; git commit -a -m "Update PX4 Firmware metadata `date`" || true')
-              sh('cd px4_user_guide; git push origin pr-firmware_metadata_update || true')
+              sh('cd px4_user_guide; git push --force origin pr-firmware_metadata_update || true')
             }
           }
           when {
@@ -322,7 +322,7 @@ pipeline {
               sh('cp airframes.xml qgroundcontrol/src/AutoPilotPlugins/PX4/AirframeFactMetaData.xml')
               sh('cp parameters.xml qgroundcontrol/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml')
               sh('cd qgroundcontrol; git checkout -B pr-firmware_metadata_update; git status; git add .; git commit -a -m "Update PX4 Firmware metadata `date`" || true')
-              sh('cd qgroundcontrol; git push origin pr-firmware_metadata_update || true')
+              sh('cd qgroundcontrol; git push --force origin pr-firmware_metadata_update || true')
             }
           }
           when {


### PR DESCRIPTION
This ensures metadata updates always overwrite any existing `pr-firmware_metadata_update` branche in https://github.com/PX4/Devguide, https://github.com/PX4/px4_user_guide, or https://github.com/mavlink/qgroundcontrol.

@hamishwillee FYI