### PR TITLE
mavlink_receiver: fill some missing fields in OPTICAL_FLOW_RAD handler

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -163,7 +163,11 @@ MavlinkReceiver::MavlinkReceiver(Mavlink *parent) :
 	_mom_switch_state(0),
 	_p_bat_emergen_thr(param_find("BAT_EMERGEN_THR")),
 	_p_bat_crit_thr(param_find("BAT_CRIT_THR")),
-	_p_bat_low_thr(param_find("BAT_LOW_THR"))
+	_p_bat_low_thr(param_find("BAT_LOW_THR")),
+	_p_flow_rot(param_find("SENS_FLOW_ROT")),
+	_p_flow_maxr(param_find("SENS_FLOW_MAXR")),
+	_p_flow_minhgt(param_find("SENS_FLOW_MINHGT")),
+	_p_flow_maxhgt(param_find("SENS_FLOW_MAXHGT"))
 {
 }
 
@@ -650,8 +654,9 @@ MavlinkReceiver::handle_message_optical_flow_rad(mavlink_message_t *msg)
 	mavlink_optical_flow_rad_t flow;
 	mavlink_msg_optical_flow_rad_decode(msg, &flow);
 
+	/* read flow sensor parameters */
 	int32_t flow_rot_int;
-	param_get(param_find("SENS_FLOW_ROT"), &flow_rot_int);
+	param_get(_p_flow_rot, &flow_rot_int);
 	const enum Rotation flow_rot = (Rotation)flow_rot_int;
 
 	struct optical_flow_s f = {};
@@ -668,6 +673,9 @@ MavlinkReceiver::handle_message_optical_flow_rad(mavlink_message_t *msg)
 	f.quality = flow.quality;
 	f.sensor_id = flow.sensor_id;
 	f.gyro_temperature = flow.temperature;
+	param_get(_p_flow_maxr, &f.max_flow_rate);
+	param_get(_p_flow_minhgt, &f.min_ground_distance);
+	param_get(_p_flow_maxhgt, &f.max_ground_distance);
 
 	/* rotate measurements according to parameter */
 	float zeroval = 0.0f;

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -265,6 +265,10 @@ private:
 	param_t _p_bat_emergen_thr;
 	param_t _p_bat_crit_thr;
 	param_t _p_bat_low_thr;
+	param_t _p_flow_rot;
+	param_t _p_flow_maxr;
+	param_t _p_flow_minhgt;
+	param_t _p_flow_maxhgt;
 
 	MavlinkReceiver(const MavlinkReceiver &) = delete;
 	MavlinkReceiver operator=(const MavlinkReceiver &) = delete;


### PR DESCRIPTION
`OPTICAL_FLOW_RAD` handler doesn't fill some necessary fields of a uORB `optical_flow` message.

Filled them with the appropriate sensor parameters (which seems reasonable) to make everything work.

@mhkabir 