### PR TITLE
Remove logic from rc.vehicle_setup that results in redundantly setting the MAV_TYPE to the initialized value in the script.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.vehicle_setup
+++ b/ROMFS/px4fmu_common/init.d/rc.vehicle_setup
@@ -48,18 +48,6 @@ then
 		set MAV_TYPE 2
 
 		# Use mixer to detect vehicle type
-		if [ $MIXER == quad_x -o $MIXER == quad_+ ]
-		then
-			set MAV_TYPE 2
-		fi
-		if [ $MIXER == quad_w -o $MIXER == quad_dc ]
-		then
-			set MAV_TYPE 2
-		fi
-		if [ $MIXER == quad_h ]
-		then
-			set MAV_TYPE 2
-		fi
 		if [ $MIXER == coax ]
 		then
 			set MAV_TYPE 3


### PR DESCRIPTION
Hi,

This PR deprecates code from rc.vehicle_setup that (re)sets the `MAV_TYPE` variable to the same value it is initialized within the logic block.

This logic change impacts can be verified through inspection, and hardware testing has been done on pixracer based hardware that has been flashed with this PR and parameters reset, utilizing an airframe config file that does not set `MAV_TYPE` but does set 'MIXER = quad_x', 'MIXER = quad_+', 'MIXER = quad_w', 'MIXER = quad_dc', and 'MIXER = quad_h'.

Each test case shows the correct setting of MAV_TYPE, however this is also a special case as the default value is the same value to be set... So, I further tested cases for the occurrence that the airframe config file does not set `MAV_TYPE` but a `MAV_TYPE` has been set through QGroundControl or the nuttshell and the system is rebooted.  Tests for that scenario result in the predicted results for each of the `MIXER_TYPE` configurations listed above.

![image](https://user-images.githubusercontent.com/2497951/45726697-96cb1d80-bb7d-11e8-95eb-05f01ddb142f.png)
![image](https://user-images.githubusercontent.com/2497951/45726730-b95d3680-bb7d-11e8-92c9-bd9335db102e.png)

Please let me know if you have any questions on this PR!

-Mark
