### PR TITLE
GPS updates (reduce delay & support for u-blox protocol version 27)

### DIFF
--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -27,7 +27,7 @@ set(config_module_list
 	drivers/barometer/ms5611
 	#drivers/blinkm
 	#drivers/bst
-	drivers/camera_trigger
+	#drivers/camera_trigger
 	#drivers/differential_pressure/ets
 	drivers/differential_pressure/ms4525
 	drivers/differential_pressure/ms5525

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -965,7 +965,7 @@ int GPS::task_spawn(int argc, char *argv[], Instance instance)
 	}
 
 	int task_id = px4_task_spawn_cmd("gps", SCHED_DEFAULT,
-				   SCHED_PRIORITY_SLOW_DRIVER, 1630,
+				   SCHED_PRIORITY_SLOW_DRIVER, 1530,
 				   entry_point, (char *const *)argv);
 
 	if (task_id < 0) {

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -260,7 +260,7 @@ private:
 	int _range_finder_sub_index = -1; // index for downward-facing range finder subscription
 
 	// because we can have multiple GPS instances
-	int _gps_subs[ORB_MULTI_MAX_INSTANCES] {};
+	int _gps_subs[GPS_MAX_RECEIVERS] {};
 	int _gps_orb_instance{-1};
 
 	orb_advert_t _att_pub{nullptr};
@@ -281,7 +281,7 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamExtInt<px4::params::EKF2_MIN_OBS_DT>)
-		_obs_dt_min_ms,	///< Maximmum time delay of any sensor used to increse buffer length to handle large timing jitter (mSec)
+		_obs_dt_min_ms,	///< Maximum time delay of any sensor used to increase buffer length to handle large timing jitter (mSec)
 		(ParamExtFloat<px4::params::EKF2_MAG_DELAY>)
 		_mag_delay_ms,	///< magnetometer measurement delay relative to the IMU (mSec)
 		(ParamExtFloat<px4::params::EKF2_BARO_DELAY>)
@@ -605,8 +605,11 @@ Ekf2::Ekf2():
 	_status_sub = orb_subscribe(ORB_ID(vehicle_status));
 	_vehicle_land_detected_sub = orb_subscribe(ORB_ID(vehicle_land_detected));
 
-	for (unsigned i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
+	for (unsigned i = 0; i < GPS_MAX_RECEIVERS; i++) {
 		_gps_subs[i] = orb_subscribe_multi(ORB_ID(vehicle_gps_position), i);
+	}
+
+	for (unsigned i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
 		_range_finder_subs[i] = orb_subscribe_multi(ORB_ID(distance_sensor), i);
 	}
 
@@ -633,9 +636,10 @@ Ekf2::~Ekf2()
 
 	for (unsigned i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
 		orb_unsubscribe(_range_finder_subs[i]);
-		_range_finder_subs[i] = -1;
+	}
+
+	for (unsigned i = 0; i < GPS_MAX_RECEIVERS; i++) {
 		orb_unsubscribe(_gps_subs[i]);
-		_gps_subs[i] = -1;
 	}
 }
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2657,7 +2657,7 @@ MavlinkReceiver::receive_thread(void *arg)
 
 				/* non-blocking read. read may return negative values */
 				if ((nread = ::read(fds[0].fd, buf, sizeof(buf))) < (ssize_t)character_count) {
-					unsigned sleeptime = (1.0f / (_mavlink->get_baudrate() / 10)) * character_count * 1000000;
+					const unsigned sleeptime = character_count * 1000000 / (_mavlink->get_baudrate() / 10);
 					usleep(sleeptime);
 				}
 			}


### PR DESCRIPTION
Reduces message delay by reducing the sleep time (around 20ms less).
This uses now the same sleep time logic as mavlink, depending on the
baudrate.

CPU usage on a Pixracer for different sleep times:
```
#num reads/sec    sleep time         CPU usage
17-18             2.8ms              0.233-0.31% (this PR)
12                5ms                0.155-0.3%
9-10              10ms               0.155-0.233%
6                 20ms               0.155-0.233% (previous)
```


~~Requires https://github.com/PX4/GpsDrivers/pull/32~~ EDIT: submodule updated.
(all testing there was done with this change as well)

@priseborough I did some replay testing with different `EKF2_GPS_DELAY`, but changing it by +-20 ms did not show significant changes of the innovation. Maybe you want to cross-check?