### PR TITLE
[DO NOT MERGE] Test ccache for Windows CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,8 @@ define cmake-build
 +@$(eval PX4_CONFIG = $(1))
 +@$(eval BUILD_DIR = $(SRC_DIR)/build/$(PX4_CONFIG)$(BUILD_DIR_SUFFIX))
 +@if [ $(PX4_CMAKE_GENERATOR) = "Ninja" ] && [ -e $(BUILD_DIR)/Makefile ]; then rm -rf $(BUILD_DIR); fi
-+@if [ ! -e $(BUILD_DIR)/CMakeCache.txt ]; then mkdir -p $(BUILD_DIR) && cd $(BUILD_DIR) && cmake $(SRC_DIR) -G"$(PX4_CMAKE_GENERATOR)" $(CMAKE_ARGS) -DCONFIG=$(PX4_CONFIG) || (rm -rf $(BUILD_DIR)); fi
-+@$(PX4_MAKE) -C $(BUILD_DIR) $(PX4_MAKE_ARGS) $(ARGS)
++@if [ ! -e $(BUILD_DIR)/CMakeCache.txt ]; then mkdir -p $(BUILD_DIR) && cd $(BUILD_DIR) && CCACHE_BASEDIR=$(BUILD_DIR) cmake $(SRC_DIR) -G"$(PX4_CMAKE_GENERATOR)" $(CMAKE_ARGS) -DCONFIG=$(PX4_CONFIG) || (rm -rf $(BUILD_DIR)); fi
++@CCACHE_BASEDIR=$(BUILD_DIR) $(PX4_MAKE) -C $(BUILD_DIR) $(PX4_MAKE_ARGS) $(ARGS)
 endef
 
 COLOR_BLUE = \033[0;94m

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ init:
 - ver
 
 install:
-- ps: if (-not (Test-Path C:\Toolchain.msi)) {Invoke-WebRequest https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.3.msi -OutFile C:\Toolchain.msi}
+- ps: if (-not (Test-Path C:\Toolchain.msi)) {Invoke-WebRequest https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Toolchain+Cygwin+Toolchain+ccache+beta.msi -OutFile C:\Toolchain.msi}
 - start /wait msiexec /i C:\Toolchain.msi /quiet /qn /norestart /log C:\install.log
 
 # Note: using start /wait is important
@@ -32,10 +32,18 @@ build_script:
 - for /f %%i in ('cygpath -u %%CD%%') do set repopath=%%i
 # fetch all submodules in parallel
 - call bash --login -c "cd $repopath && git submodule update --init --recursive --jobs=10"
+
+# clear ccache stats for posix build
+- call bash --login -c "ccache -z"
 # make SITL
 - call bash --login -c "cd $repopath && make posix"
+- call bash --login -c "ccache -s"
+
+# clear ccache stats for NuttX build
+- call bash --login -c "ccache -z"
 # make pixracer to check NuttX build
 - call bash --login -c "cd $repopath && make px4fmu-v4_default"
+- call bash --login -c "ccache -s"
 
 # Note: using bash --login is important
 # because otherwise certain things (like python; import numpy) do not work
@@ -44,3 +52,4 @@ cache:
 # cache toolchain installation file to avoid downloading it from AWS S3 each time
 # it's ~496MB < 1GB free limit for build caches
 - C:\Toolchain.msi -> appveyor.yml
+- C:\PX4\home\.ccache


### PR DESCRIPTION
This pr is setup as a test bench to allow cooperation for making the NuttX build work with ccache for CI. It was requested by @dagar in a private discussion.

It uses a beta installer to with ccache present in Windows CI which currently makes the NuttX builds fail. As soon as the problem is found I can do a new official installer release and we can just leave the resulting fix in this pr.