### PR TITLE
px4fmu-v2 disable SRF02 ultra sonic range finder

### DIFF
--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -27,7 +27,7 @@ set(config_module_list
 	#drivers/distance_sensor/mb12xx
 	drivers/distance_sensor/sf0x
 	drivers/distance_sensor/sf1xx
-	drivers/distance_sensor/srf02
+	#drivers/distance_sensor/srf02
 	#drivers/distance_sensor/teraranger
 	#drivers/distance_sensor/tfmini
 	#drivers/distance_sensor/ulanding


### PR DESCRIPTION
@LorenzMeier @bkueng are you aware of anyone using this sensor on a pixhawk? Disabling it frees up 3 kB of flash.