### PR TITLE
WIP: Omnibus MC only

### DIFF
--- a/cmake/configs/nuttx_omnibus-f4sd_default.cmake
+++ b/cmake/configs/nuttx_omnibus-f4sd_default.cmake
@@ -84,13 +84,13 @@ set(config_module_list
 	#
 	# Vehicle Control
 	#
-	modules/fw_att_control
-	modules/fw_pos_control_l1
+	#modules/fw_att_control
+	#modules/fw_pos_control_l1
 	#modules/gnd_att_control
 	#modules/gnd_pos_control
 	modules/mc_att_control
 	modules/mc_pos_control
-	modules/vtol_att_control
+	#modules/vtol_att_control
 
 	#
 	# Logging


### PR DESCRIPTION
Needed to unblock https://github.com/PX4/Firmware/pull/10355, but this is also a good excuse to fix these bogus dependencies.

Navigator is currently dependant on the VTOL parameters **VT_B_DEC_MSS** and **VT_B_REV_DEL**. Let's either handle this with the VTOL controller publishing a status message, or falling back to the old param API.

I'd vote for an orb based solution if @RomanBapst could assist. I'll be mostly unavailable until next week.

Similar to the way the FW position controller publishes `position_controller_status` for the L1 distance that's used by navigator as the acceptance radius, we could have the vtol controller publish an appropriate acceptance distance for back transition (how VT_B_DEC_MSS and VT_B_REV_DEL are used). https://github.com/PX4/Firmware/blob/master/src/modules/navigator/mission_block.cpp#L291-L305

Going forward I think we should strictly enforce parameter module boundaries with only a few global exceptions (SYS and CAL?).