### PR TITLE
Re-order the tap_common/init.d/rcS script contents to better match the px4_common/init.d/rcS script.

### DIFF
--- a/ROMFS/tap_common/init.d/CMakeLists.txt
+++ b/ROMFS/tap_common/init.d/CMakeLists.txt
@@ -39,8 +39,8 @@ px4_add_romfs_files(
 	rc.interface
 	rc.mc_apps
 	rc.mc_defaults
-	rcS
 	rc.sensors
 	rc.vtol_apps
 	rc.vtol_defaults
+	rcS
 	)

--- a/ROMFS/tap_common/init.d/rc.interface
+++ b/ROMFS/tap_common/init.d/rc.interface
@@ -3,7 +3,7 @@
 # Script to configure control interface
 #
 
-set SDCARD_MIXERS_PATH /fs/microsd/etc/mixers
+set OUTPUT_DEV none
 
 if [ $MIXER != none -a $MIXER != skip ]
 then
@@ -75,9 +75,4 @@ then
 	fi
 fi
 
-unset PWM_OUT
-unset PWM_RATE
-unset PWM_MIN
-unset PWM_MAX
-unset FAILSAFE
 unset OUTPUT_DEV

--- a/ROMFS/tap_common/init.d/rcS
+++ b/ROMFS/tap_common/init.d/rcS
@@ -14,12 +14,27 @@
 # /dev/ttyS5: RC input
 
 #
+# Set default values
+#
+set AUTOCNF no
+set DATAMAN_OPT -r
+set FAILSAFE none
+set FMU_MODE pwm
+set LOG_FILE /fs/microsd/bootlog.txt
+set MAV_TYPE none
+set MIXER none
+set OUTPUT_MODE none
+set PWM_DISARMED none
+set PWM_OUT none
+set PWM_MAX none
+set PWM_MIN none
+set PWM_RATE none
+set VEHICLE_TYPE none
+
+#
 # Start CDC/ACM serial driver
 #
 sercon
-
-set LOG_FILE /fs/microsd/bootlog.txt
-set DATAMAN_OPT -r
 
 #
 # Start the ORB (first app to start)
@@ -39,14 +54,12 @@ tone_alarm start
 if mount -t vfat /dev/mmcsd0 /fs/microsd
 then
 	echo "microSD present"
-	unset DATAMAN_OPT
 else
 	if mkfatfs /dev/mmcsd0
 	then
 		if mount -t vfat /dev/mmcsd0 /fs/microsd
 		then
 			echo "microSD card formatted"
-			unset DATAMAN_OPT
 		else
 			echo "ERROR [init] Format failed"
 			tune_control play -t 17
@@ -56,6 +69,17 @@ else
 		set LOG_FILE /dev/null
 	fi
 fi
+
+# waypoint storage
+# REBOOTWORK this needs to start in parallel
+if dataman start $DATAMAN_OPT
+then
+fi
+
+#
+# Start CPU load monitor
+#
+load_mon start
 
 #
 # Load parameters
@@ -100,24 +124,7 @@ then
 	# Wipe out params except RC*
 	param reset_nostart RC*
 	set AUTOCNF yes
-else
-	set AUTOCNF no
 fi
-
-#
-# Set default values
-#
-set VEHICLE_TYPE none
-set MIXER none
-set OUTPUT_MODE none
-set PWM_OUT none
-set PWM_RATE none
-set PWM_DISARMED none
-set PWM_MIN none
-set PWM_MAX none
-set FMU_MODE pwm
-set MAV_TYPE none
-set FAILSAFE none
 
 # Start canned airframe config
 sh /etc/init.d/rc.autostart
@@ -130,7 +137,6 @@ then
 	param set SYS_AUTOCONFIG 0
 	param save
 fi
-unset AUTOCNF
 
 #
 # Set default output if not set
@@ -145,13 +151,150 @@ then
 	fi
 fi
 
-gps start -d /dev/ttyS0
+#
+# Start the RC input driver
+#
+rc_input start
 
-# waypoint storage
-# REBOOTWORK this needs to start in parallel
-if dataman start $DATAMAN_OPT
+if fmu mode_pwm1
 then
 fi
+
+#
+# Fixed wing setup.
+#
+if [ $VEHICLE_TYPE = fw ]
+then
+	if [ $MIXER = none ]
+	then
+		# Set default mixer for fixed wing if not defined.
+		set MIXER AERT
+	fi
+
+	if [ $MAV_TYPE = none ]
+	then
+		# Set a default MAV_TYPE = 1 if not defined.
+		set MAV_TYPE 1
+	fi
+
+	# Set the mav type parameter.
+	param set MAV_TYPE ${MAV_TYPE}
+
+	# Load mixer and configure outputs.
+	sh /etc/init.d/rc.interface
+
+	# Start standard fixedwing apps.
+	sh /etc/init.d/rc.fw_apps
+fi
+
+#
+# Multicopter setup.
+#
+if [ $VEHICLE_TYPE = mc ]
+then
+	if [ $MIXER = none ]
+	then
+		echo "MC mixer undefined"
+	fi
+
+	if [ $MAV_TYPE = none ]
+	then
+		# Set a default MAV_TYPE = 2 if not defined.
+		set MAV_TYPE 2
+
+		# Use mixer to detect vehicle type
+		if [ $MIXER = coax ]
+		then
+			set MAV_TYPE 3
+		fi
+		if [ $MIXER = hexa_x -o $MIXER = hexa_+ ]
+		then
+			set MAV_TYPE 13
+		fi
+		if [ $MIXER = hexa_cox ]
+		then
+			set MAV_TYPE 13
+		fi
+		if [ $MIXER = octo_x -o $MIXER = octo_+ ]
+		then
+			set MAV_TYPE 14
+		fi
+		if [ $MIXER = octo_cox -o $MIXER = octo_cox_w ]
+		then
+			set MAV_TYPE 14
+		fi
+		if [ $MIXER = tri_y_yaw- -o $MIXER = tri_y_yaw+ ]
+		then
+			set MAV_TYPE 15
+		fi
+	fi
+
+	# Set the mav type parameter.
+	param set MAV_TYPE ${MAV_TYPE}
+
+	# Load mixer and configure outputs.
+	sh /etc/init.d/rc.interface
+
+	# Start standard multicopter apps.
+	sh /etc/init.d/rc.mc_apps
+fi
+
+#
+# VTOL setup.
+#
+if [ $VEHICLE_TYPE = vtol ]
+then
+	if [ $MIXER = none ]
+	then
+		echo "VTOL mixer undefined"
+	fi
+
+	if [ $MAV_TYPE = none ]
+	then
+		# Set a default MAV_TYPE = 19 if not defined.
+		set MAV_TYPE 19
+
+		# Use mixer to detect vehicle type.
+		if [ $MIXER = firefly6 ]
+		then
+			set MAV_TYPE 21
+		fi
+		if [ $MIXER = quad_x_pusher_vtol ]
+		then
+			set MAV_TYPE 22
+		fi
+	fi
+
+	# Set the mav type parameter.
+	param set MAV_TYPE ${MAV_TYPE}
+
+	# Load mixer and configure outputs.
+	sh /etc/init.d/rc.interface
+
+	# Start standard vtol apps.
+	sh /etc/init.d/rc.vtol_apps
+fi
+
+#
+# Generic setup (autostart ID not found).
+#
+if [ $VEHICLE_TYPE = none ]
+then
+	echo "No autostart ID found"
+	ekf2 start
+fi
+
+#
+# Use 400 Hz PWM output for landing gear (frequency also affects RGB LED)
+#
+pwm rate -c 1 -r 400
+
+#
+# Load the gear mixer onto fmu
+#
+mixer load /dev/px4fmu /etc/mixers/gear.mix
+
+gps start -d /dev/ttyS0
 
 #
 # Sensors System (start before Commander so Preflight checks are properly run)
@@ -159,11 +302,6 @@ fi
 sh /etc/init.d/rc.sensors
 
 commander start
-
-#
-# Start CPU load monitor
-#
-load_mon start
 
 # Start MAVLink on the gimbal port
 #mavlink start -r 1200 -d /dev/ttyS1
@@ -179,189 +317,31 @@ mavlink start -r 60000 -d /dev/ttyACM0 -m config
 #fi
 
 #
-# Fixed wing setup
-#
-if [ $VEHICLE_TYPE = fw ]
-then
-	echo "INFO  [init] Fixedwing"
-
-	if [ $MIXER = none ]
-	then
-		# Set default mixer for fixed wing if not defined
-		set MIXER AERT
-	fi
-
-	if [ $MAV_TYPE = none ]
-	then
-		# Use MAV_TYPE = 1 (fixed wing) if not defined
-		set MAV_TYPE 1
-	fi
-
-	param set MAV_TYPE $MAV_TYPE
-
-	# Load mixer and configure outputs
-	sh /etc/init.d/rc.interface
-
-	# Start standard fixedwing apps
-	sh /etc/init.d/rc.fw_apps
-fi
-
-#
-# Multicopters setup
-#
-if [ $VEHICLE_TYPE = mc ]
-then
-	echo "INFO  [init] Multicopter"
-
-	if [ $MIXER = none ]
-	then
-		echo "INFO  [init] Mixer undefined"
-	fi
-
-	if [ $MAV_TYPE = none ]
-	then
-		# Use mixer to detect vehicle type
-		if [ $MIXER = quad_x -o $MIXER = quad_+ ]
-		then
-			set MAV_TYPE 2
-		fi
-		if [ $MIXER = quad_w ]
-		then
-			set MAV_TYPE 2
-		fi
-		if [ $MIXER = quad_h ]
-		then
-			set MAV_TYPE 2
-		fi
-		if [ $MIXER = tri_y_yaw- -o $MIXER = tri_y_yaw+ ]
-		then
-			set MAV_TYPE 15
-		fi
-		if [ $MIXER = hexa_x -o $MIXER = hexa_+ ]
-		then
-			set MAV_TYPE 13
-		fi
-		if [ $MIXER = hexa_cox ]
-		then
-			set MAV_TYPE 13
-		fi
-		if [ $MIXER = octo_x -o $MIXER = octo_+ ]
-		then
-			set MAV_TYPE 14
-		fi
-	fi
-
-	# Still no MAV_TYPE found
-	if [ $MAV_TYPE = none ]
-	then
-		echo "WARN  [init] Unknown MAV_TYPE"
-		param set MAV_TYPE 2
-	else
-		param set MAV_TYPE $MAV_TYPE
-	fi
-
-	# Load mixer and configure outputs
-	sh /etc/init.d/rc.interface
-
-	# Start standard multicopter apps
-	sh /etc/init.d/rc.mc_apps
-fi
-
-#
-# VTOL setup
-#
-if [ $VEHICLE_TYPE = vtol ]
-then
-	echo "INFO  [init] VTOL"
-
-	if [ $MIXER = none ]
-	then
-		echo "WARN  [init] VTOL mixer undefined"
-	fi
-
-	if [ $MAV_TYPE = none ]
-	then
-		# Use mixer to detect vehicle type
-		if [ $MIXER = caipirinha_vtol ]
-		then
-			set MAV_TYPE 19
-		fi
-		if [ $MIXER = firefly6 ]
-		then
-			set MAV_TYPE 21
-		fi
-		if [ $MIXER = quad_x_pusher_vtol ]
-		then
-			set MAV_TYPE 22
-		fi
-	fi
-
-	# Still no MAV_TYPE found
-	if [ $MAV_TYPE = none ]
-	then
-		echo "WARN  [init] Unknown MAV_TYPE"
-		param set MAV_TYPE 19
-	else
-		param set MAV_TYPE $MAV_TYPE
-	fi
-
-	# Load mixer and configure outputs
-	sh /etc/init.d/rc.interface
-
-	# Start standard vtol apps
-	sh /etc/init.d/rc.vtol_apps
-fi
-
-#
-# UGV/Rover setup
-#
-if [ $VEHICLE_TYPE = ugv ]
-then
-	# 10 is MAV_TYPE_GROUND_ROVER
-	set MAV_TYPE 10
-
-	# Load mixer and configure outputs
-	sh /etc/init.d/rc.interface
-
-	# Start standard rover apps
-	sh /etc/init.d/rc.ugv_apps
-
-	param set MAV_TYPE 10
-fi
-
-unset MIXER
-unset MAV_TYPE
-unset OUTPUT_MODE
-
-#
-# Start the RC input driver
-#
-if fmu mode_pwm1
-then
-fi
-
-#
-# Use 400 Hz PWM output for landing gear (frequency also affects RGB LED)
-#
-pwm rate -c 1 -r 400
-
-#
-# Load the gear mixer onto fmu
-#
-mixer load /dev/px4fmu /etc/mixers/gear.mix
-
-#
 # Start the navigator
 #
 if navigator start
 then
 fi
 
-# There is no further script processing, so we can free some RAM
-# XXX potentially unset all script variables.
-unset TUNE_ERR
-unset LOG_FILE
+#
+# Unset all script parameters to free RAM.
+#
+unset AUTOCNF
 unset DATAMAN_OPT
+unset FAILSAFE
+unset FMU_MODE
+unset LOG_FILE
+unset MAV_TYPE
+unset MIXER
+unset OUTPUT_MODE
+unset PWM_DISARMED
+unset PWM_OUT
+unset PWM_MAX
+unset PWM_MIN
+unset PWM_RATE
+unset VEHICLE_TYPE
 
-# Boot is complete, inform MAVLink app(s) that the system is now fully up and running
+#
+# Boot is complete, inform MAVLink app(s) that the system is now fully up and running.
+#
 mavlink boot_complete


### PR DESCRIPTION
Hi there,

I noticed that the `tap_common/init.d/rcS` script very closely resembles the `px4_common/init.d/rcS` script and makes calls to files in the `px4_common/init.d/` directory.

Given that, it seemed appropriate to reduce/re-use code in `rc.vehicle_setup` and also structure the script in the same basic order/outline as the `px4_common/init.d/rcS` file.  This PR is that work.

**In Full Disclosure**... I am unaware if CI tests are in place to test this PR and I do not have hardware to test this PR myself.  This PR requires testing/validating if any help might be available... Thank you in advance!

Please let me know if you have any questions on this PR!

-Mark