### PR TITLE
omnibus: (temporarily) disable the topic listener

### DIFF
--- a/cmake/configs/nuttx_omnibus-f4sd_default.cmake
+++ b/cmake/configs/nuttx_omnibus-f4sd_default.cmake
@@ -43,7 +43,7 @@ set(config_module_list
 	systemcmds/reboot
 	systemcmds/sd_bench
 	systemcmds/top
-	systemcmds/topic_listener
+	#systemcmds/topic_listener
 	systemcmds/tune_control
 	systemcmds/ver
 


### PR DESCRIPTION
To reduce flash usage, until we can disable the FW & VTOL modules.

Can be re-enabled after #10531.