### PR TITLE
input_rc related cleanup

### DIFF
--- a/src/drivers/drv_rc_input.h
+++ b/src/drivers/drv_rc_input.h
@@ -42,6 +42,7 @@
 
 #include <stdint.h>
 #include <sys/ioctl.h>
+#include <uORB/topics/input_rc.h>
 
 #include "drv_orb_dev.h"
 
@@ -76,9 +77,6 @@
  * Maximum deadzone value
  */
 #define RC_INPUT_MAX_DEADZONE_US	500
-
-#include <uORB/topics/input_rc.h>
-#define rc_input_values input_rc_s
 
 /**
  * Input signal type, value is a control position from zero to 100

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -335,7 +335,7 @@ private:
 	 * @param input_rc	Input structure to populate.
 	 * @return		OK if data was returned.
 	 */
-	int			io_get_raw_rc_input(rc_input_values &input_rc);
+	int			io_get_raw_rc_input(input_rc_s &input_rc);
 
 	/**
 	 * Fetch and publish raw RC input data.
@@ -1742,7 +1742,7 @@ PX4IO::io_get_status()
 }
 
 int
-PX4IO::io_get_raw_rc_input(rc_input_values &input_rc)
+PX4IO::io_get_raw_rc_input(input_rc_s &input_rc)
 {
 	uint32_t channel_count;
 	int	ret;
@@ -1849,7 +1849,7 @@ PX4IO::io_publish_raw_rc()
 {
 
 	/* fetch values from IO */
-	rc_input_values	rc_val;
+	input_rc_s	rc_val;
 
 	/* set the RC status flag ORDER MATTERS! */
 	rc_val.rc_lost = !(_status & PX4IO_P_STATUS_FLAGS_RC_OK);

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -47,7 +47,6 @@
 
 #include <commander/px4_custom_mode.h>
 #include <drivers/drv_pwm_output.h>
-#include <drivers/drv_rc_input.h>
 #include <lib/ecl/geo/geo.h>
 #include <lib/mathlib/mathlib.h>
 #include <lib/matrix/matrix/math.hpp>
@@ -70,6 +69,7 @@
 #include <uORB/topics/estimator_status.h>
 #include <uORB/topics/geofence_result.h>
 #include <uORB/topics/home_position.h>
+#include <uORB/topics/input_rc.h>
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/mavlink_log.h>
 #include <uORB/topics/vehicle_trajectory_waypoint.h>
@@ -3198,7 +3198,7 @@ protected:
 
 	bool send(const hrt_abstime t)
 	{
-		rc_input_values rc;
+		input_rc_s rc;
 
 		if (_rc_sub->update(&_rc_time, &rc)) {
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1821,7 +1821,7 @@ MavlinkReceiver::handle_message_rc_channels_override(mavlink_message_t *msg)
 		return;
 	}
 
-	struct rc_input_values rc = {};
+	struct input_rc_s rc = {};
 
 	rc.timestamp = hrt_absolute_time();
 
@@ -1881,7 +1881,7 @@ MavlinkReceiver::handle_message_manual_control(mavlink_message_t *msg)
 
 	if (_mavlink->get_manual_input_mode_generation()) {
 
-		struct rc_input_values rc = {};
+		struct input_rc_s rc = {};
 		rc.timestamp = hrt_absolute_time();
 		rc.timestamp_last_signal = rc.timestamp;
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1821,51 +1821,43 @@ MavlinkReceiver::handle_message_rc_channels_override(mavlink_message_t *msg)
 		return;
 	}
 
+	// fill uORB message
 	struct input_rc_s rc = {};
-
+	// metadata
 	rc.timestamp = hrt_absolute_time();
-
 	rc.timestamp_last_signal = rc.timestamp;
-
-	rc.channel_count = 8;
-
-	rc.rc_failsafe = false;
-
-	rc.rc_lost = false;
-
-	rc.rc_lost_frame_count = 0;
-
-	rc.rc_total_frame_count = 1;
-
-	rc.rc_ppm_frame_length = 0;
-
-	rc.input_source = input_rc_s::RC_INPUT_SOURCE_MAVLINK;
-
+	rc.channel_count = 18;
 	rc.rssi = RC_INPUT_RSSI_MAX;
-
-	/* channels */
+	rc.rc_failsafe = false;
+	rc.rc_lost = false;
+	rc.rc_lost_frame_count = 0;
+	rc.rc_total_frame_count = 1;
+	rc.rc_ppm_frame_length = 0;
+	rc.input_source = input_rc_s::RC_INPUT_SOURCE_MAVLINK;
+	// channels
 	rc.values[0] = man.chan1_raw;
-
 	rc.values[1] = man.chan2_raw;
-
 	rc.values[2] = man.chan3_raw;
-
 	rc.values[3] = man.chan4_raw;
-
 	rc.values[4] = man.chan5_raw;
-
 	rc.values[5] = man.chan6_raw;
-
 	rc.values[6] = man.chan7_raw;
-
 	rc.values[7] = man.chan8_raw;
+	rc.values[8] = man.chan9_raw;
+	rc.values[9] = man.chan10_raw;
+	rc.values[10] = man.chan11_raw;
+	rc.values[11] = man.chan12_raw;
+	rc.values[12] = man.chan13_raw;
+	rc.values[13] = man.chan14_raw;
+	rc.values[14] = man.chan15_raw;
+	rc.values[15] = man.chan16_raw;
+	rc.values[16] = man.chan17_raw;
+	rc.values[17] = man.chan18_raw;
 
-	if (_rc_pub == nullptr) {
-		_rc_pub = orb_advertise(ORB_ID(input_rc), &rc);
-
-	} else {
-		orb_publish(ORB_ID(input_rc), _rc_pub, &rc);
-	}
+	// publish uORB message
+	int instance; // provides the instance ID or the publication
+	ORB_PRIO priority = ORB_PRIO_HIGH; // since it is an override, set priority high
+	orb_publish_auto(ORB_ID(input_rc), &_rc_pub, &rc, &instance, priority);
 }
 
 void

--- a/src/modules/sensors/parameters.h
+++ b/src/modules/sensors/parameters.h
@@ -47,7 +47,7 @@
 #include <mathlib/mathlib.h>
 
 #include <uORB/topics/rc_parameter_map.h>
-
+#include <uORB/topics/input_rc.h>
 
 namespace sensors
 {

--- a/src/modules/sensors/rc_update.cpp
+++ b/src/modules/sensors/rc_update.cpp
@@ -46,6 +46,7 @@
 #include <uORB/uORB.h>
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/manual_control_setpoint.h>
+#include <uORB/topics/input_rc.h>
 
 using namespace sensors;
 
@@ -256,7 +257,7 @@ RCUpdate::rc_poll(const ParameterHandles &parameter_handles)
 
 	if (rc_updated) {
 		/* read low-level values from FMU or IO RC inputs (PPM, Spektrum, S.Bus) */
-		struct rc_input_values rc_input;
+		struct input_rc_s rc_input;
 
 		orb_copy(ORB_ID(input_rc), _rc_sub, &rc_input);
 

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -369,7 +369,7 @@ private:
 	uint64_t _hil_ref_timestamp;
 
 	// uORB data containers
-	struct rc_input_values _rc_input;
+	struct input_rc_s _rc_input;
 	struct actuator_outputs_s _actuators[ORB_MULTI_MAX_INSTANCES];
 	struct vehicle_attitude_s _attitude;
 	struct manual_control_setpoint_s _manual;

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -185,7 +185,7 @@ void Simulator::send_controls()
 	}
 }
 
-static void fill_rc_input_msg(struct rc_input_values *rc, mavlink_rc_channels_t *rc_channels)
+static void fill_rc_input_msg(input_rc_s *rc, mavlink_rc_channels_t *rc_channels)
 {
 	rc->timestamp = hrt_absolute_time();
 	rc->timestamp_last_signal = rc->timestamp;

--- a/src/modules/syslink/syslink_main.cpp
+++ b/src/modules/syslink/syslink_main.cpp
@@ -549,7 +549,7 @@ Syslink::handle_raw(syslink_message_t *sys)
 
 		crtp_commander *cmd = (crtp_commander *) &c->data[0];
 
-		struct rc_input_values rc = {};
+		input_rc_s rc = {};
 
 		rc.timestamp = hrt_absolute_time();
 		rc.timestamp_last_signal = rc.timestamp;

--- a/src/systemcmds/tests/test_ppm_loopback.c
+++ b/src/systemcmds/tests/test_ppm_loopback.c
@@ -134,7 +134,7 @@ int test_ppm_loopback(int argc, char *argv[])
 	/* give driver 10 ms to propagate */
 
 	/* read low-level values from FMU or IO RC inputs (PPM, Spektrum, S.Bus) */
-	struct rc_input_values	rc_input;
+	struct input_rc_s rc_input;
 	orb_copy(ORB_ID(input_rc), _rc_sub, &rc_input);
 	usleep(100000);
 
@@ -151,7 +151,7 @@ int test_ppm_loopback(int argc, char *argv[])
 
 
 
-		// struct rc_input_values rc;
+		// struct input_rc_s rc;
 		// result = read(ppm_fd, &rc, sizeof(rc));
 
 		// if (result != sizeof(rc)) {

--- a/src/systemcmds/tests/test_rc.c
+++ b/src/systemcmds/tests/test_rc.c
@@ -61,12 +61,11 @@
 
 int test_rc(int argc, char *argv[])
 {
-
 	int _rc_sub = orb_subscribe(ORB_ID(input_rc));
 
 	/* read low-level values from FMU or IO RC inputs (PPM, Spektrum, S.Bus) */
-	struct rc_input_values	rc_input;
-	struct rc_input_values	rc_last;
+	struct input_rc_s rc_input;
+	struct input_rc_s rc_last;
 	orb_copy(ORB_ID(input_rc), _rc_sub, &rc_input);
 	usleep(100000);
 


### PR DESCRIPTION
**Test data / coverage**
These changes are in our latest release and got tested for more than a month now.

**Describe problem solved by the proposed pull request**
Split into the two commits:
- `#define rc_input_values input_rc_s` seems to me like a deprecated construct that simplified a bigger change in the past but creates confusion now and screws up the file include tree (`drv_rc_input.h` vs `input_rc.h`). I removed the define because it seems unnecessary.
- https://github.com/mavlink/mavlink/pull/855 introduced a higher number of rc channels to the message `RC_CHANNELS_OVERRIDE` and we want to support that in PX4.
