### PR TITLE
Remove whitespaces to quiet git commit trailing whitespace warnings.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/13012_convergence
+++ b/ROMFS/px4fmu_common/init.d/13012_convergence
@@ -60,7 +60,7 @@ then
 	param set PWM_RATE 400
 
 	param set SENS_BOARD_ROT 8
-	
+
 	param set VT_B_TRANS_DUR  1.0
 	param set VT_F_TRANS_DUR  1.2
 	param set VT_F_TR_OL_TM   4.0

--- a/ROMFS/px4fmu_common/init.d/4003_qavr5
+++ b/ROMFS/px4fmu_common/init.d/4003_qavr5
@@ -31,6 +31,6 @@ then
 
 	param set MPC_THR_MIN 0.06
 	param set MPC_MANTHR_MIN 0.06
-	
+
 	param set PWM_MIN 1075
 fi

--- a/ROMFS/px4fmu_common/init.d/4900_crazyflie
+++ b/ROMFS/px4fmu_common/init.d/4900_crazyflie
@@ -66,7 +66,7 @@ then
 
 	param set SDLOG_PROFILE 1
 	param set SENS_FLOW_MINRNG 0.05
-	param set SYS_COMPANION 20	
+	param set SYS_COMPANION 20
 	param set SYS_FMU_TASK 1
 
 fi


### PR DESCRIPTION
Hi there,

This PR just removes a few trailing whitespaces to quiet git commit warnings.

Let me know if you have any questions on this PR!

-Mark
