### PR TITLE
FlightTaskManualStabilized: allow attitude control with 0 throttle

### DIFF
--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
@@ -74,10 +74,10 @@ const vehicle_local_position_setpoint_s FlightTask::getPositionSetpoint()
 
 void FlightTask::_resetSetpoints()
 {
-	_position_setpoint *= NAN;
-	_velocity_setpoint *= NAN;
-	_acceleration_setpoint *= NAN;
-	_thrust_setpoint *= NAN;
+	_position_setpoint.setAll(NAN);
+	_velocity_setpoint.setAll(NAN);
+	_acceleration_setpoint.setAll(NAN);
+	_thrust_setpoint.setAll(NAN);
 	_yaw_setpoint = _yawspeed_setpoint = NAN;
 	_desired_waypoint = FlightTask::empty_trajectory_waypoint;
 }

--- a/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -130,8 +130,7 @@ void FlightTaskManualPosition::_updateXYlock()
 	} else if (PX4_ISFINITE(_position_setpoint(0)) && apply_brake) {
 		// Position is locked but check if a reset event has happened.
 		// We will shift the setpoints.
-		if (_sub_vehicle_local_position->get().xy_reset_counter
-		    != _reset_counter) {
+		if (_sub_vehicle_local_position->get().xy_reset_counter != _reset_counter) {
 			_position_setpoint(0) = _position(0);
 			_position_setpoint(1) = _position(1);
 			_reset_counter = _sub_vehicle_local_position->get().xy_reset_counter;
@@ -147,6 +146,6 @@ void FlightTaskManualPosition::_updateXYlock()
 void FlightTaskManualPosition::_updateSetpoints()
 {
 	FlightTaskManualAltitude::_updateSetpoints(); // needed to get yaw and setpoints in z-direction
-	_thrust_setpoint *= NAN; // don't require any thrust setpoints
+	_thrust_setpoint.setAll(NAN); // don't require any thrust setpoints
 	_updateXYlock(); // check for position lock
 }

--- a/src/lib/FlightTasks/tasks/ManualStabilized/FlightTaskManualStabilized.cpp
+++ b/src/lib/FlightTasks/tasks/ManualStabilized/FlightTaskManualStabilized.cpp
@@ -123,9 +123,10 @@ void FlightTaskManualStabilized::_updateThrustSetpoints()
 
 	/* The final thrust setpoint is found by rotating the scaled unit vector pointing
 	 * upward by the Axis-Angle.
+	 * Make sure that the attitude can be controlled even at 0 throttle.
 	 */
 	Quatf q_sp = AxisAnglef(v(0), v(1), 0.0f);
-	_thrust_setpoint = q_sp.conjugate(Vector3f(0.0f, 0.0f, -1.0f)) * _throttle;
+	_thrust_setpoint = q_sp.conjugate(Vector3f(0.0f, 0.0f, -1.0f)) * math::max(_throttle, 0.0001f);
 }
 
 void FlightTaskManualStabilized::_rotateIntoHeadingFrame(Vector2f &v)


### PR DESCRIPTION
With minimum throttle set to 0, it was not possible to control the attitude
anymore at 0 throttle, the vehicle would just stay level.

@MaEtUgR @Stifael do you have another way of fixing it? Other flight tasks might be affected too.