### PR TITLE
cmake git submodules handle all paths consistently

### DIFF
--- a/Tools/check_submodules.sh
+++ b/Tools/check_submodules.sh
@@ -6,11 +6,12 @@ function check_git_submodule {
 if [[ -f $1"/.git" || -d $1"/.git" ]];
 then
 
+	# CI environment always force update everything
 	if [ "$CI" == "true" ];
 	then
-		git submodule sync --recursive -- $1
-		git submodule update --init --recursive --force -- $1  || true
-		git submodule update --init --recursive --force -- $1
+		git submodule --quiet sync --recursive -- $1
+		git submodule --quiet update --init --recursive --force -- $1  || true
+		git submodule --quiet update --init --recursive --force -- $1
 		exit 0
 	fi
 
@@ -53,9 +54,9 @@ then
 		fi
 	fi
 else
-	git submodule sync --recursive --quiet -- $1
-	git submodule update --init --recursive -- $1  || true
-	git submodule update --init --recursive -- $1
+	git submodule --quiet sync --recursive --quiet -- $1
+	git submodule --quiet update --init --recursive -- $1  || true
+	git submodule --quiet update --init --recursive -- $1
 fi
 
 }

--- a/cmake/common/px4_git.cmake
+++ b/cmake/common/px4_git.cmake
@@ -68,19 +68,28 @@ function(px4_add_git_submodule)
 		REQUIRED TARGET PATH
 		ARGN ${ARGN})
 
-	execute_process(COMMAND ${PX4_SOURCE_DIR}/Tools/check_submodules.sh ${PATH}
-			WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-			)
+	set(REL_PATH)
+
+	if(IS_ABSOLUTE ${PATH})
+		file(RELATIVE_PATH REL_PATH ${PX4_SOURCE_DIR} ${PATH})
+	else()
+		file(RELATIVE_PATH REL_PATH ${PX4_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/${PATH})
+	endif()
+
+	execute_process(
+		COMMAND Tools/check_submodules.sh ${REL_PATH}
+		WORKING_DIRECTORY ${PX4_SOURCE_DIR}
+		)
 
 	string(REPLACE "/" "_" NAME ${PATH})
 	string(REPLACE "." "_" NAME ${NAME})
 
 	add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/git_init_${NAME}.stamp
-		COMMAND bash ${PX4_SOURCE_DIR}/Tools/check_submodules.sh ${PATH}
+		COMMAND Tools/check_submodules.sh ${REL_PATH}
 		COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/git_init_${NAME}.stamp
 		DEPENDS ${PX4_SOURCE_DIR}/.gitmodules ${PATH}/.git
-		COMMENT "git submodule ${PATH}"
-		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+		COMMENT "git submodule ${REL_PATH}"
+		WORKING_DIRECTORY ${PX4_SOURCE_DIR}
 		USES_TERMINAL
 		)
 


### PR DESCRIPTION
 - relative to the PX4 source directory root

![image](https://user-images.githubusercontent.com/84712/45929734-b9fe2000-bf23-11e8-99e5-44ced7b67da0.png)
