### PR TITLE
Tidy up an OUTPUT_DEV set/unset in rc.interace and rcS.

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -11,6 +11,7 @@
 
 set MIXER_AUX_FILE none
 set OUTPUT_AUX_DEV /dev/pwm_output1
+set OUTPUT_DEV none
 
 #
 # If mount (gimbal) control is enabled and output mode is AUX, set the aux
@@ -391,3 +392,4 @@ fi
 
 unset MIXER_AUX_FILE
 unset OUTPUT_AUX_DEV
+unset OUTPUT_DEV

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -591,7 +591,6 @@ unset MIXER_AUX
 unset MIXER_FILE
 unset MK_MODE
 unset MKBLCTRL_ARG
-unset OUTPUT_DEV
 unset OUTPUT_MODE
 unset PARAM_FILE
 unset PWM_AUX_DISARMED


### PR DESCRIPTION
Hi,

This PR just moves an initial set for `OUTPUT_DEV` to the top of rc.Interface and moves the unset back into rc.interface where the script variable is utilized.  `OUTPUT_DEV` is not utilized outside of rc.interface, so this PR has no material impact outside of housekeeping.

Please let me know if you have any questions on this PR!

(I was careful about submodule commits in this PR. :) )

-Mark