### PR TITLE
rcS: start frsky_telemetry on Pixracer if not enabled already

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -511,6 +511,15 @@ else
 	#
 	sh /etc/init.d/rc.serial
 
+	if ver hwcmp PX4FMU_V4
+	then
+		# Run FrSky Telemetry on Pixracer on the FrSky port if not enabled already
+		if param compare TEL_FRSKY_CONFIG 0
+		then
+			frsky_telemetry start -d /dev/ttyS6 -t 15
+		fi
+	fi
+
 	#
 	# Configure vehicle type specific parameters.
 	# Note: rc.vehicle_setup is the entry point for rc.interface,


### PR DESCRIPTION
This got lost in #10337.