### PR TITLE
Jenkins firmware compile readd av-x-v1_default

### DIFF
--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -88,7 +88,7 @@ pipeline {
 
           def nuttx_builds_archive = [
             target: ["px4fmu-v2_default", "px4fmu-v3_default", "px4fmu-v4_default", "px4fmu-v4pro_default", "px4fmu-v5_default", "px4fmu-v5_rtps", "px4fmu-v5_stackcheck",
-                     "aerofc-v1_default", "aerocore2_default", "auav-x21_default", "crazyflie_default", "mindpx-v2_default",
+                     "aerofc-v1_default", "aerocore2_default", "auav-x21_default", "av-x-v1_default", "crazyflie_default", "mindpx-v2_default",
                      "nxphlite-v3_default", "tap-v1_default", "omnibus-f4sd_default"],
             image: docker_images.nuttx,
             archive: true


### PR DESCRIPTION
Somewhere along the line this was dropped unintentionally.