### PR TITLE
 Add support for mavlink message DEBUG_FLOAT_ARRAY 

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -44,6 +44,7 @@ set(msg_files
 	collision_report.msg
 	commander_state.msg
 	cpuload.msg
+	debug_array.msg
 	debug_key_value.msg
 	debug_value.msg
 	debug_vect.msg

--- a/msg/debug_array.msg
+++ b/msg/debug_array.msg
@@ -1,0 +1,5 @@
+uint8 ARRAY_SIZE = 58
+uint64 timestamp            # time since system start (microseconds)
+uint16 id                   # unique ID of debug array, used to discriminate between arrays
+char[10] name               # name of the debug array (max. 10 characters)
+float32[58] data            # data

--- a/src/examples/px4_mavlink_debug/CMakeLists.txt
+++ b/src/examples/px4_mavlink_debug/CMakeLists.txt
@@ -35,6 +35,6 @@ px4_add_module(
 	MAIN px4_mavlink_debug
 	STACK_MAIN 2000
 	SRCS
-		px4_mavlink_debug.c
+		px4_mavlink_debug.cpp
 	DEPENDS
 	)

--- a/src/examples/px4_mavlink_debug/px4_mavlink_debug.cpp
+++ b/src/examples/px4_mavlink_debug/px4_mavlink_debug.cpp
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 /**
- * @file px4_mavlink_debug.c
+ * @file px4_mavlink_debug.cpp
  * Debug application example for PX4 autopilot
  *
  * @author Example User <mail@example.com>
@@ -41,6 +41,7 @@
 #include <px4_config.h>
 #include <unistd.h>
 #include <stdio.h>
+#include <string.h>
 #include <poll.h>
 
 #include <systemlib/err.h>
@@ -50,39 +51,53 @@
 #include <uORB/topics/debug_key_value.h>
 #include <uORB/topics/debug_value.h>
 #include <uORB/topics/debug_vect.h>
+#include <uORB/topics/debug_array.h>
 
-__EXPORT int px4_mavlink_debug_main(int argc, char *argv[]);
+extern "C" __EXPORT int px4_mavlink_debug_main(int argc, char *argv[]);
 
 int px4_mavlink_debug_main(int argc, char *argv[])
 {
 	printf("Hello Debug!\n");
 
 	/* advertise named debug value */
-	struct debug_key_value_s dbg_key = { .key = "velx", .value = 0.0f };
+	struct debug_key_value_s dbg_key;
+	strncpy(dbg_key.key, "velx", 10);
+	dbg_key.value = 0.0f;
 	orb_advert_t pub_dbg_key = orb_advertise(ORB_ID(debug_key_value), &dbg_key);
 
 	/* advertise indexed debug value */
-	struct debug_value_s dbg_ind = { .ind = 42, .value = 0.5f };
+	struct debug_value_s dbg_ind;
+	dbg_ind.ind = 42;
+	dbg_ind.value = 0.5f;
 	orb_advert_t pub_dbg_ind = orb_advertise(ORB_ID(debug_value), &dbg_ind);
 
 	/* advertise debug vect */
-	struct debug_vect_s dbg_vect = { .name = "vel3D", .x = 1.0f, .y = 2.0f, .z = 3.0f };
+	struct debug_vect_s dbg_vect;
+	strncpy(dbg_vect.name, "vel3D", 10);
+	dbg_vect.x = 1.0f;
+	dbg_vect.y = 2.0f;
+	dbg_vect.z = 3.0f;
 	orb_advert_t pub_dbg_vect = orb_advertise(ORB_ID(debug_vect), &dbg_vect);
+
+	/* advertise debug array */
+	struct debug_array_s dbg_array;
+	dbg_array.id = 1;
+	strncpy(dbg_array.name, "dbg_array", 10);
+	orb_advert_t pub_dbg_array = orb_advertise(ORB_ID(debug_array), &dbg_array);
 
 	int value_counter = 0;
 
 	while (value_counter < 100) {
 		uint64_t timestamp_us = hrt_absolute_time();
-		uint32_t timestamp_ms = timestamp_us / 1000;
 
 		/* send one named value */
 		dbg_key.value = value_counter;
-		dbg_key.timestamp = timestamp_ms * 1e3f;
+		dbg_key.timestamp = timestamp_us;
 		orb_publish(ORB_ID(debug_key_value), pub_dbg_key, &dbg_key);
 
 		/* send one indexed value */
 		dbg_ind.value = 0.5f * value_counter;
-		dbg_ind.timestamp = timestamp_ms * 1e3f;
+		dbg_ind.timestamp = timestamp_us;
 		orb_publish(ORB_ID(debug_value), pub_dbg_ind, &dbg_ind);
 
 		/* send one vector */
@@ -91,6 +106,14 @@ int px4_mavlink_debug_main(int argc, char *argv[])
 		dbg_vect.z = 3.0f * value_counter;
 		dbg_vect.timestamp = timestamp_us;
 		orb_publish(ORB_ID(debug_vect), pub_dbg_vect, &dbg_vect);
+
+		/* send one array */
+		for (size_t i = 0; i < debug_array_s::ARRAY_SIZE; i++) {
+			dbg_array.data[i] = value_counter + i * 0.01f;
+		}
+
+		dbg_array.timestamp = timestamp_us;
+		orb_publish(ORB_ID(debug_array), pub_dbg_array, &dbg_array);
 
 		warnx("sent one more value..");
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -687,6 +687,7 @@ void Logger::add_debug_topics()
 	add_topic("debug_key_value");
 	add_topic("debug_value");
 	add_topic("debug_vect");
+	add_topic("debug_array");
 }
 
 void Logger::add_estimator_replay_topics()

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1745,6 +1745,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("COLLISION", unlimited_rate);
 		configure_stream_local("DEBUG", 1.0f);
 		configure_stream_local("DEBUG_VECT", 1.0f);
+		configure_stream_local("DEBUG_FLOAT_ARRAY", 1.0f);
 		configure_stream_local("DISTANCE_SENSOR", 0.5f);
 		configure_stream_local("ESTIMATOR_STATUS", 0.5f);
 		configure_stream_local("EXTENDED_SYS_STATE", 1.0f);
@@ -1782,6 +1783,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("COLLISION", unlimited_rate);
 		configure_stream_local("DEBUG", 10.0f);
 		configure_stream_local("DEBUG_VECT", 10.0f);
+		configure_stream_local("DEBUG_FLOAT_ARRAY", 10.0f);
 		configure_stream_local("DISTANCE_SENSOR", 10.0f);
 		configure_stream_local("ESTIMATOR_STATUS", 1.0f);
 		configure_stream_local("EXTENDED_SYS_STATE", 5.0f);
@@ -1846,6 +1848,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("COLLISION", unlimited_rate);
 		configure_stream_local("DEBUG", 50.0f);
 		configure_stream_local("DEBUG_VECT", 50.0f);
+		configure_stream_local("DEBUG_FLOAT_ARRAY", 50.0f);
 		configure_stream_local("DISTANCE_SENSOR", 10.0f);
 		configure_stream_local("GPS_RAW_INT", unlimited_rate);
 		configure_stream_local("GPS2_RAW", unlimited_rate);

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -64,6 +64,7 @@
 #include <uORB/topics/debug_key_value.h>
 #include <uORB/topics/debug_value.h>
 #include <uORB/topics/debug_vect.h>
+#include <uORB/topics/debug_array.h>
 #include <uORB/topics/differential_pressure.h>
 #include <uORB/topics/distance_sensor.h>
 #include <uORB/topics/estimator_status.h>
@@ -3707,6 +3708,79 @@ protected:
 	}
 };
 
+class MavlinkStreamDebugFloatArray : public MavlinkStream
+{
+public:
+	const char *get_name() const
+	{
+		return MavlinkStreamDebugFloatArray::get_name_static();
+	}
+
+	static const char *get_name_static()
+	{
+		return "DEBUG_FLOAT_ARRAY";
+	}
+
+	static uint16_t get_id_static()
+	{
+		return MAVLINK_MSG_ID_DEBUG_FLOAT_ARRAY;
+	}
+
+	uint16_t get_id()
+	{
+		return get_id_static();
+	}
+
+	static MavlinkStream *new_instance(Mavlink *mavlink)
+	{
+		return new MavlinkStreamDebugFloatArray(mavlink);
+	}
+
+	unsigned get_size()
+	{
+		return (_debug_time > 0) ? MAVLINK_MSG_ID_DEBUG_FLOAT_ARRAY_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES : 0;
+	}
+
+private:
+	MavlinkOrbSubscription *_debug_array_sub;
+	uint64_t _debug_time;
+
+	/* do not allow top copying this class */
+	MavlinkStreamDebugFloatArray(MavlinkStreamDebugFloatArray &);
+	MavlinkStreamDebugFloatArray &operator = (const MavlinkStreamDebugFloatArray &);
+
+protected:
+	explicit MavlinkStreamDebugFloatArray(Mavlink *mavlink) : MavlinkStream(mavlink),
+		_debug_array_sub(_mavlink->add_orb_subscription(ORB_ID(debug_array))),
+		_debug_time(0)
+	{}
+
+	bool send(const hrt_abstime t)
+	{
+		struct debug_array_s debug = {};
+
+		if (_debug_array_sub->update(&_debug_time, &debug)) {
+			mavlink_debug_float_array_t msg = {};
+
+			msg.time_usec = debug.timestamp;
+			msg.array_id = debug.id;
+			memcpy(msg.name, debug.name, sizeof(msg.name));
+			/* enforce null termination */
+			msg.name[sizeof(msg.name) - 1] = '\0';
+
+			for (size_t i = 0; i < debug_array_s::ARRAY_SIZE; i++) {
+				msg.data[i] = debug.data[i];
+			}
+
+			mavlink_msg_debug_float_array_send_struct(_mavlink->get_channel(), &msg);
+
+			return true;
+		}
+
+		return false;
+	}
+};
+
 class MavlinkStreamNavControllerOutput : public MavlinkStream
 {
 public:
@@ -4546,6 +4620,7 @@ static const StreamListItem streams_list[] = {
 	StreamListItem(&MavlinkStreamNamedValueFloat::new_instance, &MavlinkStreamNamedValueFloat::get_name_static, &MavlinkStreamNamedValueFloat::get_id_static),
 	StreamListItem(&MavlinkStreamDebug::new_instance, &MavlinkStreamDebug::get_name_static, &MavlinkStreamDebug::get_id_static),
 	StreamListItem(&MavlinkStreamDebugVect::new_instance, &MavlinkStreamDebugVect::get_name_static, &MavlinkStreamDebugVect::get_id_static),
+	StreamListItem(&MavlinkStreamDebugFloatArray::new_instance, &MavlinkStreamDebugFloatArray::get_name_static, &MavlinkStreamDebugFloatArray::get_id_static),
 	StreamListItem(&MavlinkStreamNavControllerOutput::new_instance, &MavlinkStreamNavControllerOutput::get_name_static, &MavlinkStreamNavControllerOutput::get_id_static),
 	StreamListItem(&MavlinkStreamCameraCapture::new_instance, &MavlinkStreamCameraCapture::get_name_static, &MavlinkStreamCameraCapture::get_id_static),
 	StreamListItem(&MavlinkStreamCameraTrigger::new_instance, &MavlinkStreamCameraTrigger::get_name_static, &MavlinkStreamCameraTrigger::get_id_static),

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -53,6 +53,7 @@
 #include <uORB/topics/debug_key_value.h>
 #include <uORB/topics/debug_value.h>
 #include <uORB/topics/debug_vect.h>
+#include <uORB/topics/debug_array.h>
 #include <uORB/topics/distance_sensor.h>
 #include <uORB/topics/follow_target.h>
 #include <uORB/topics/gps_inject_data.h>
@@ -161,6 +162,7 @@ private:
 	void handle_message_named_value_float(mavlink_message_t *msg);
 	void handle_message_debug(mavlink_message_t *msg);
 	void handle_message_debug_vect(mavlink_message_t *msg);
+	void handle_message_debug_float_array(mavlink_message_t *msg);
 
 	void *receive_thread(void *arg);
 
@@ -242,6 +244,7 @@ private:
 	orb_advert_t _debug_key_value_pub;
 	orb_advert_t _debug_value_pub;
 	orb_advert_t _debug_vect_pub;
+	orb_advert_t _debug_array_pub;
 	static const int _gps_inject_data_queue_size = 6;
 	orb_advert_t _gps_inject_data_pub;
 	orb_advert_t _command_ack_pub;


### PR DESCRIPTION
For context, see https://github.com/PX4/Firmware/issues/7770.

This is the continuation of https://github.com/PX4/Firmware/pull/7373 now that DEBUG_FLOAT_ARRAY was added to MAVLink (see https://github.com/mavlink/mavlink/pull/734).

Similarly to the previous PR it:
- converts uorb `debug_array` to MAVLink `DEBUG_FLOAT_ARRAY`
- converts MAVLink `DEBUG_FLOAT_ARRAY` to uorb `debug_array`
- adds an example usage

@TSC21 