### PR TITLE
Fix catkin build of PX4 Firmware

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,11 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PX4_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${PX4_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${PX4_BINARY_DIR})
 
+# For the catkin build process, unset build of dynamically-linked binaries
+if (CATKIN_DEVEL_PREFIX)
+	SET(BUILD_SHARED_LIBS OFF)
+endif()
+
 #=============================================================================
 
 # Setup install paths

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,32 @@ pipeline {
     stage('Analysis') {
 
       parallel {
+        stage('catkin') {
+          agent {
+            docker {
+              image 'px4io/px4-dev-ros:2018-09-24'
+              args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
+            }
+          }
+
+          steps {
+            sh 'ls -l'
+            sh '''#!/bin/bash -l
+              echo $0;
+              mkdir -p catkin_ws/src;
+              cp -R . catkin_ws/src/Firmware
+              cd catkin_ws;
+              source /opt/ros/melodic/setup.bash;
+              catkin init;
+              source devel/setup.bash;
+              catkin build -j$(nproc) -l$(nproc);
+            '''
+            sh 'rm -rf catkin_ws'
+          }
+          options {
+            checkoutToSubdirectory('catkin_ws/src/Firmware')
+          }
+        }
 
         stage('Style Check') {
           agent {


### PR DESCRIPTION
Replaces #10573.

Ended up being simpler than first thought, after @dagar suggested to play with `BUILD_SHARED_LIBS` CMake variable.

The problem with catkin is that it explicitly sets `BUILD_SHARED_LIBS` if not explicitly overridden by the user (https://github.com/ros/catkin/blob/kinetic-devel/cmake/tools/libraries.cmake#L12). This means that, by default, catkin tries to build all libraries added by `add_library()` as shared libraries, which ends up breaking the build system were some targets expect static libraries.

This also avoids adding explicit includes on the top CMake module of PX4.

Adds also CI based on #9679 (@dagar I tried to cherry-pick but didn't work as I expected). 
