### PR TITLE
px4fmu-v2 disable sdp3x to save flash

### DIFF
--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -31,7 +31,7 @@ set(config_module_list
 	#drivers/differential_pressure/ets
 	drivers/differential_pressure/ms4525
 	drivers/differential_pressure/ms5525
-	drivers/differential_pressure/sdp3x
+	#drivers/differential_pressure/sdp3x
 	drivers/distance_sensor/ll40ls
 	#drivers/distance_sensor/mb12xx
 	drivers/distance_sensor/sf0x


### PR DESCRIPTION
 - temporarily fixes https://github.com/PX4/Firmware/issues/10599