### PR TITLE
WIP: linux basic SPI support and split qurt

### DIFF
--- a/src/lib/drivers/device/CMakeLists.txt
+++ b/src/lib/drivers/device/CMakeLists.txt
@@ -32,7 +32,7 @@
 ############################################################################
 
 set(SRCS_PLATFORM)
-if (${OS} STREQUAL "nuttx")
+if (${OS} MATCHES "nuttx")
 	if ("${CONFIG_I2C}" STREQUAL "y")
 		list(APPEND SRCS_PLATFORM nuttx/I2C.cpp)
 	endif()
@@ -40,9 +40,15 @@ if (${OS} STREQUAL "nuttx")
 	if ("${CONFIG_SPI}" STREQUAL "y")
 		list(APPEND SRCS_PLATFORM nuttx/SPI.cpp)
 	endif()
+elseif (${OS} MATCHES "qurt")
+	list(APPEND SRCS_PLATFORM
+		#qurt/I2C.cpp
+		#qurt/SPI.cpp
+	)
 else()
 	list(APPEND SRCS_PLATFORM
 		posix/I2C.cpp
+		posix/SPI.cpp
 	)
 endif()
 

--- a/src/lib/drivers/device/i2c.h
+++ b/src/lib/drivers/device/i2c.h
@@ -35,11 +35,16 @@
 #ifdef __PX4_NUTTX
 #include "nuttx/I2C.hpp"
 #else
+
+#ifdef __PX4_QURT
+#include "qurt/I2C.hpp"
+#else
 #include "posix/I2C.hpp"
 #endif
 
-#include <board_config.h>
+#endif
 
+#include <board_config.h>
 
 static const int i2c_bus_options[] = {
 #ifdef PX4_I2C_BUS_EXPANSION

--- a/src/lib/drivers/device/posix/I2C.cpp
+++ b/src/lib/drivers/device/posix/I2C.cpp
@@ -47,15 +47,6 @@
 #include <linux/i2c-dev.h>
 #endif
 
-#ifdef __PX4_QURT
-#define PX4_SIMULATE_I2C 1
-#else
-#define PX4_SIMULATE_I2C 0
-#endif
-
-static constexpr const int simulate = PX4_SIMULATE_I2C;
-
-
 namespace device
 {
 
@@ -74,9 +65,7 @@ I2C::I2C(const char *name, const char *devname, int bus, uint16_t address, uint3
 I2C::~I2C()
 {
 	if (_fd >= 0) {
-#ifndef __PX4_QURT
 		::close(_fd);
-#endif /* !__PX4_QURT */
 		_fd = -1;
 	}
 }
@@ -95,24 +84,15 @@ I2C::init()
 		return ret;
 	}
 
-	if (simulate) {
-		_fd = 10000;
+	// Open the actual I2C device
+	char dev_path[16];
+	snprintf(dev_path, sizeof(dev_path), "/dev/i2c-%i", get_device_bus());
+	_fd = ::open(dev_path, O_RDWR);
 
-	} else {
-#ifndef __PX4_QURT
-
-		// Open the actual I2C device
-		char dev_path[16];
-		snprintf(dev_path, sizeof(dev_path), "/dev/i2c-%i", get_device_bus());
-		_fd = ::open(dev_path, O_RDWR);
-
-		if (_fd < 0) {
-			PX4_ERR("could not open %s", dev_path);
-			px4_errno = errno;
-			return PX4_ERROR;
-		}
-
-#endif /* !__PX4_QURT */
+	if (_fd < 0) {
+		PX4_ERR("could not open %s", dev_path);
+		px4_errno = errno;
+		return PX4_ERROR;
 	}
 
 	return ret;
@@ -164,20 +144,14 @@ I2C::transfer(const uint8_t *send, unsigned send_len, uint8_t *recv, unsigned re
 
 		packets.nmsgs = msgs;
 
-		if (simulate) {
-			DEVICE_DEBUG("I2C SIM: transfer_4 on %s", get_devname());
-			ret = PX4_OK;
+		ret = ::ioctl(_fd, I2C_RDWR, (unsigned long)&packets);
+
+		if (ret == -1) {
+			DEVICE_DEBUG("I2C transfer failed");
+			ret = PX4_ERROR;
 
 		} else {
-			ret = ::ioctl(_fd, I2C_RDWR, (unsigned long)&packets);
-
-			if (ret == -1) {
-				DEVICE_DEBUG("I2C transfer failed");
-				ret = PX4_ERROR;
-
-			} else {
-				ret = PX4_OK;
-			}
+			ret = PX4_OK;
 		}
 
 		/* success */

--- a/src/lib/drivers/device/posix/SPI.cpp
+++ b/src/lib/drivers/device/posix/SPI.cpp
@@ -1,0 +1,169 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2012 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file spi.cpp
+ *
+ * Base class for devices connected via SPI.
+ *
+ * @todo Work out if caching the mode/frequency would save any time.
+ *
+ * @todo A separate bus/device abstraction would allow for mixed interrupt-mode
+ * and non-interrupt-mode clients to arbitrate for the bus.  As things stand,
+ * a bus shared between clients of both kinds is vulnerable to races between
+ * the two, where an interrupt-mode client will ignore the lock held by the
+ * non-interrupt-mode client.
+ */
+
+#include "SPI.hpp"
+
+#include <px4_config.h>
+
+#define DIR_READ    0x80
+#define DIR_WRITE   0x00
+
+namespace device
+{
+
+SPI::SPI(const char *name,
+	 const char *devname,
+	 int bus,
+	 uint32_t device,
+	 enum spi_mode_e mode,
+	 uint32_t frequency) :
+	// base class
+	CDev(name, devname),
+	// public
+	// protected
+	locking_mode(LOCK_PREEMPTION)
+{
+	// fill in _device_id fields for a SPI device
+	_device_id.devid_s.bus_type = DeviceBusType_SPI;
+	_device_id.devid_s.bus = bus;
+	_device_id.devid_s.address = (uint8_t)device;
+	// devtype needs to be filled in by the driver
+	_device_id.devid_s.devtype = 0;
+}
+
+SPI::~SPI()
+{
+	if (_fd >= 0) {
+		::close(_fd);
+		_fd = -1;
+	}
+}
+
+int
+SPI::init()
+{
+	// Assume the driver set the desired bus frequency. There is no standard
+	// way to set it from user space.
+
+	// do base class init, which will create device node, etc
+	int ret = CDev::init();
+
+	if (ret != PX4_OK) {
+		DEVICE_DEBUG("CDev::init failed");
+		return ret;
+	}
+
+	// Open the actual I2C device
+	char dev_path[16];
+	snprintf(dev_path, sizeof(dev_path), "/dev/spi-%i", get_device_bus());
+	_fd = ::open(dev_path, O_RDWR);
+
+	if (_fd < 0) {
+		PX4_ERR("could not open %s", dev_path);
+		px4_errno = errno;
+		return PX4_ERROR;
+	}
+
+	return ret;
+}
+
+int
+SPI::transfer(uint8_t *send, uint8_t *recv, unsigned length)
+{
+	uint8_t address = *send;
+
+	PX4_DEBUG("transfer: length = %d", length);
+
+	/* implement sensor interface via rpi spi */
+	int transfer_bytes = 1 + length; // first byte is address
+
+	// automatic write buffer
+	uint8_t *write_buffer = (uint8_t *)alloca(transfer_bytes);
+	memset(write_buffer, 0, transfer_bytes);
+	// automatic read buffer
+	uint8_t *read_buffer = (uint8_t *)alloca(transfer_bytes);
+	memset(read_buffer, 0, transfer_bytes);
+
+	write_buffer[0] = address | DIR_READ; // read mode
+
+	struct spi_ioc_transfer spi_transfer; // datastructure for linux spi interface
+	memset(&spi_transfer, 0, sizeof(spi_ioc_transfer));
+
+	spi_transfer.rx_buf = (unsigned long)read_buffer;
+	spi_transfer.len = transfer_bytes;
+	spi_transfer.tx_buf = (unsigned long)write_buffer;
+	// spi_transfer.speed_hz = SPI_FREQUENCY_1MHZ;
+	spi_transfer.bits_per_word = 8;
+	spi_transfer.delay_usecs = 0;
+
+	int result = 0;
+	result = ::ioctl(_fd, SPI_IOC_MESSAGE(1), &spi_transfer);
+
+	if (result != transfer_bytes) {
+		PX4_DEBUG("transfer error %d", result);
+		return result;
+	}
+
+	PX4_DEBUG("transfer: read_buffer = %u, %u, %u, %u, %u, %u, %u, %u, %u",
+		  read_buffer[1], read_buffer[2], read_buffer[3],
+		  read_buffer[4], read_buffer[5], read_buffer[6],
+		  read_buffer[7], read_buffer[8], read_buffer[9]);
+
+	memcpy(recv, &read_buffer[1], transfer_bytes - 1);
+
+	return 0;
+}
+
+int
+SPI::transferhword(uint16_t *send, uint16_t *recv, unsigned len)
+{
+	// TODO: implement
+
+	return PX4_ERROR;
+}
+
+} // namespace device

--- a/src/lib/drivers/device/qurt/I2C.hpp
+++ b/src/lib/drivers/device/qurt/I2C.hpp
@@ -1,0 +1,109 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2012 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file i2c.h
+ *
+ * Base class for devices connected via I2C.
+ */
+
+#ifndef _DEVICE_I2C_H
+#define _DEVICE_I2C_H
+
+#include "../CDev.hpp"
+
+#include <px4_i2c.h>
+
+namespace device __EXPORT
+{
+
+/**
+ * Abstract class for character device on I2C
+ */
+class __EXPORT I2C : public CDev
+{
+
+public:
+
+protected:
+	/**
+	 * The number of times a read or write operation will be retried on
+	 * error.
+	 */
+	uint8_t		_retries{0};
+
+	/**
+	 * @ Constructor
+	 *
+	 * @param name		Driver name
+	 * @param devname	Device node name
+	 * @param bus		I2C bus on which the device lives
+	 * @param address	I2C bus address, or zero if set_address will be used
+	 * @param frequency	I2C bus frequency for the device (currently not used)
+	 */
+	I2C(const char *name, const char *devname, int bus, uint16_t address, uint32_t frequency = 0);
+	virtual ~I2C();
+
+	virtual int	init();
+
+	/**
+	 * Check for the presence of the device on the bus.
+	 */
+	virtual int	probe() { return PX4_OK; }
+
+	/**
+	 * Perform an I2C transaction to the device.
+	 *
+	 * At least one of send_len and recv_len must be non-zero.
+	 *
+	 * @param send		Pointer to bytes to send.
+	 * @param send_len	Number of bytes to send.
+	 * @param recv		Pointer to buffer for bytes received.
+	 * @param recv_len	Number of bytes to receive.
+	 * @return		OK if the transfer was successful, -errno
+	 *			otherwise.
+	 */
+	int		transfer(const uint8_t *send, unsigned send_len, uint8_t *recv, unsigned recv_len);
+
+	bool		external() { return px4_i2c_bus_external(_device_id.devid_s.bus); }
+
+private:
+	int 			_fd{-1};
+
+	I2C(const device::I2C &);
+	I2C operator=(const device::I2C &);
+};
+
+} // namespace device
+
+#endif /* _DEVICE_I2C_H */

--- a/src/lib/drivers/device/qurt/SPI.hpp
+++ b/src/lib/drivers/device/qurt/SPI.hpp
@@ -44,12 +44,7 @@
 
 #include <px4_spi.h>
 
-#ifdef __PX4_LINUX
-#include <sys/ioctl.h>
-#include <linux/types.h>
-#include <alloca.h>
-#include <linux/spi/spidev.h>
-#endif
+#include "dev_fs_lib_spi.h"
 
 namespace device __EXPORT
 {

--- a/src/lib/drivers/device/spi.h
+++ b/src/lib/drivers/device/spi.h
@@ -35,5 +35,11 @@
 #ifdef __PX4_NUTTX
 #include "nuttx/SPI.hpp"
 #else
+
+#ifdef __PX4_QURT
+#include "qurt/SPI.hpp"
+#else
 #include "posix/SPI.hpp"
+#endif
+
 #endif


### PR DESCRIPTION
This will enable use of the existing nuttx SPI drivers (eg IMU) on linux and qurt.