### PR TITLE
Cygwin: Fix target upload by catching non-standard baud exception

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -346,7 +346,7 @@ class uploader(object):
             # if it fails we are on a real Serial Port
             self.ackWindowedMode = True
 
-        self.port.baudrate =self.baudrate_bootloader
+        self.port.baudrate = self.baudrate_bootloader
 
     # send the GET_DEVICE command and wait for an info parameter
     def __getInfo(self, param):
@@ -398,7 +398,7 @@ class uploader(object):
 
     # send the CHIP_ERASE command and wait for the bootloader to become ready
     def __erase(self, label):
-        print("Windowed mode:%s" % self.ackWindowedMode)
+        print("Windowed mode: %s" % self.ackWindowedMode)
         print("\n", end='')
         self.__send(uploader.CHIP_ERASE +
                     uploader.EOC)

--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -336,7 +336,12 @@ class uploader(object):
         self.port.flushInput()
         # Set a baudrate that can not work on a real serial port
         # in that it is 233% off.
-        self.port.baudrate = self.baudrate_bootloader * 2.33
+        try:
+            self.port.baudrate = self.baudrate_bootloader * 2.33
+        except NotImplementedError as e:
+            # This error can occur because pySerial on Windows does not support odd baudrates
+            print(str(e) + " -> could not check for FTDI device, assuming USB connection")
+            return
 
         self.__send(uploader.GET_SYNC +
                     uploader.EOC)


### PR DESCRIPTION
fixes #10429

**Test data / coverage**
I tried multiple uploads with different branches to a pixhawk 4 board using my home PC. It always worked and didn't use windowed mode. This results in a working upload and <40s upload time (compared to >167s with windowed mode).

**Describe problem solved by the proposed pull request**
All uploads to "NuttX targets" using Cygwin failed since https://github.com/PX4/Firmware/commit/f12acd7b0fec8fc953b5f777301511e0b0196022. See #10375 & #10429.

**Describe your preferred solution**
Perfect solution would be to have a platform independent detection for an FTDI UART connection like dicussed in https://github.com/PX4/Firmware/issues/10429#issuecomment-424136315. But I don't have the correct setup to test this at home and instead of just letting all Windows users wait further without working upload I decided to just catch the exception and handle it correctly which is anyways a good idea and covers most cases.

**Additional context**
I fixed some small spacing stuff as well, see first commit.