### PR TITLE
[WIP] navigator initialization and mode change improvements

### DIFF
--- a/src/modules/navigator/land.cpp
+++ b/src/modules/navigator/land.cpp
@@ -56,7 +56,7 @@ Land::on_activation()
 	reset_mission_item_reached();
 
 	/* convert mission item to current setpoint */
-	struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
+	position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 	pos_sp_triplet->previous.valid = false;
 	mission_apply_limitation(_mission_item);
 	mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
@@ -73,19 +73,22 @@ Land::on_active()
 	/* for VTOL update landing location during back transition */
 	if (_navigator->get_vstatus()->is_vtol &&
 	    _navigator->get_vstatus()->in_transition_mode) {
-		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
+
+		position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 		pos_sp_triplet->current.lat = _navigator->get_global_position()->lat;
 		pos_sp_triplet->current.lon = _navigator->get_global_position()->lon;
+
 		_navigator->set_position_setpoint_triplet_updated();
 	}
 
 
 	if (_navigator->get_land_detected()->landed) {
+
 		_navigator->get_mission_result()->finished = true;
 		_navigator->set_mission_result_updated();
 		set_idle_item(&_mission_item);
 
-		struct position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
+		position_setpoint_triplet_s *pos_sp_triplet = _navigator->get_position_setpoint_triplet();
 		mission_item_to_position_setpoint(_mission_item, &pos_sp_triplet->current);
 		_navigator->set_position_setpoint_triplet_updated();
 	}

--- a/src/modules/navigator/loiter.h
+++ b/src/modules/navigator/loiter.h
@@ -55,14 +55,7 @@ public:
 	void on_activation() override;
 	void on_active() override;
 
-	// TODO: share this with mission
-	enum mission_yaw_mode {
-		MISSION_YAWMODE_NONE = 0,
-		MISSION_YAWMODE_FRONT_TO_WAYPOINT = 1,
-		MISSION_YAWMODE_FRONT_TO_HOME = 2,
-		MISSION_YAWMODE_BACK_TO_HOME = 3,
-		MISSION_YAWMODE_MAX = 4
-	};
+	position_setpoint_s &get_reposition() { return _reposition; }
 
 private:
 	/**
@@ -75,6 +68,8 @@ private:
 	 * Set the position to hold based on the current local position
 	 */
 	void set_loiter_position();
+
+	position_setpoint_s			_reposition{};	/**< position setpoint for non-mission direct position command */
 
 	bool _loiter_pos_set{false};
 };

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -80,14 +80,6 @@ public:
 		MISSION_ALTMODE_FOH = 1
 	};
 
-	enum mission_yaw_mode {
-		MISSION_YAWMODE_NONE = 0,
-		MISSION_YAWMODE_FRONT_TO_WAYPOINT = 1,
-		MISSION_YAWMODE_FRONT_TO_HOME = 2,
-		MISSION_YAWMODE_BACK_TO_HOME = 3,
-		MISSION_YAWMODE_MAX = 4
-	};
-
 	bool set_current_offboard_mission_index(uint16_t index);
 
 	bool land_start();

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -59,6 +59,14 @@ using matrix::wrap_pi;
 MissionBlock::MissionBlock(Navigator *navigator) :
 	NavigatorMode(navigator)
 {
+	_mission_item.lat = (double)NAN;
+	_mission_item.lon = (double)NAN;
+	_mission_item.yaw = NAN;
+	_mission_item.loiter_radius = _navigator->get_loiter_radius();
+	_mission_item.acceptance_radius = _navigator->get_acceptance_radius();
+	_mission_item.time_inside = 0.0f;
+	_mission_item.autocontinue = true;
+	_mission_item.origin = ORIGIN_ONBOARD;
 }
 
 bool
@@ -469,10 +477,14 @@ MissionBlock::issue_command(const mission_item_s &item)
 }
 
 float
-MissionBlock::get_time_inside(const struct mission_item_s &item)
+MissionBlock::get_time_inside(const mission_item_s &item) const
 {
-	if (item.nav_cmd != NAV_CMD_TAKEOFF) {
-		return item.time_inside;
+	if ((item.nav_cmd == NAV_CMD_WAYPOINT && _navigator->get_vstatus()->is_rotary_wing) ||
+	    item.nav_cmd == NAV_CMD_LOITER_TIME_LIMIT ||
+	    item.nav_cmd == NAV_CMD_DELAY) {
+
+		// TODO: set appropriate upper limit
+		return math::constrain(item.time_inside, 0.0f, 3600.0f);
 	}
 
 	return 0.0f;
@@ -502,7 +514,7 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 
 	sp->lat = item.lat;
 	sp->lon = item.lon;
-	sp->alt = item.altitude_is_relative ? item.altitude + _navigator->get_home_position()->alt : item.altitude;
+	sp->alt = get_absolute_altitude_for_item(item);
 	sp->yaw = item.yaw;
 	sp->yaw_valid = PX4_ISFINITE(item.yaw);
 	sp->loiter_radius = (fabsf(item.loiter_radius) > NAV_EPSILON_POSITION) ? fabsf(item.loiter_radius) :
@@ -728,7 +740,7 @@ MissionBlock::mission_apply_limitation(mission_item_s &item)
 }
 
 float
-MissionBlock::get_absolute_altitude_for_item(struct mission_item_s &mission_item) const
+MissionBlock::get_absolute_altitude_for_item(const mission_item_s &mission_item) const
 {
 	if (mission_item.altitude_is_relative) {
 		return mission_item.altitude + _navigator->get_home_position()->alt;

--- a/src/modules/navigator/mission_block.h
+++ b/src/modules/navigator/mission_block.h
@@ -115,13 +115,13 @@ protected:
 	/**
 	 * General function used to adjust the mission item based on vehicle specific limitations
 	 */
-	void	mission_apply_limitation(mission_item_s &item);
+	void mission_apply_limitation(mission_item_s &item);
 
 	void issue_command(const mission_item_s &item);
 
-	float get_time_inside(const struct mission_item_s &item);
+	float get_time_inside(const mission_item_s &item) const ;
 
-	float get_absolute_altitude_for_item(struct mission_item_s &mission_item) const;
+	float get_absolute_altitude_for_item(const mission_item_s &mission_item) const;
 
 	mission_item_s _mission_item{};
 

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -84,7 +84,8 @@ class Navigator : public ModuleBase<Navigator>, public ModuleParams
 {
 public:
 	Navigator();
-	virtual ~Navigator() = default;
+	~Navigator() override;
+
 	Navigator(const Navigator &) = delete;
 	Navigator operator=(const Navigator &) = delete;
 
@@ -149,8 +150,6 @@ public:
 	struct home_position_s *get_home_position() { return &_home_pos; }
 	struct mission_result_s *get_mission_result() { return &_mission_result; }
 	struct position_setpoint_triplet_s *get_position_setpoint_triplet() { return &_pos_sp_triplet; }
-	struct position_setpoint_triplet_s *get_reposition_triplet() { return &_reposition_triplet; }
-	struct position_setpoint_triplet_s *get_takeoff_triplet() { return &_takeoff_triplet; }
 	struct vehicle_global_position_s *get_global_position() { return &_global_pos; }
 	struct vehicle_land_detected_s *get_land_detected() { return &_land_detected; }
 	struct vehicle_local_position_s *get_local_position() { return &_local_pos; }
@@ -324,8 +323,6 @@ private:
 	// Publications
 	geofence_result_s				_geofence_result{};
 	position_setpoint_triplet_s			_pos_sp_triplet{};	/**< triplet of position setpoints */
-	position_setpoint_triplet_s			_reposition_triplet{};	/**< triplet for non-mission direct position command */
-	position_setpoint_triplet_s			_takeoff_triplet{};	/**< triplet for non-mission direct takeoff command */
 	vehicle_roi_s					_vroi{};		/**< vehicle ROI */
 
 	perf_counter_t	_loop_perf;			/**< loop performance counter */
@@ -335,7 +332,6 @@ private:
 
 	bool		_can_loiter_at_sp{false};			/**< flags if current position SP can be used to loiter */
 	bool		_pos_sp_triplet_updated{false};		/**< flags if position SP triplet needs to be published */
-	bool 		_pos_sp_triplet_published_invalid_once{false};	/**< flags if position SP triplet has been published once to UORB */
 	bool		_mission_result_updated{false};		/**< flags if mission result has seen an update */
 
 	NavigatorMode	*_navigation_mode{nullptr};		/**< abstract pointer to current navigation mode class */

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -55,9 +55,7 @@ Takeoff::on_activation()
 void
 Takeoff::on_active()
 {
-	struct position_setpoint_triplet_s *rep = _navigator->get_takeoff_triplet();
-
-	if (rep->current.valid) {
+	if (_reposition.valid) {
 		// reset the position
 		set_takeoff_position();
 
@@ -77,8 +75,6 @@ Takeoff::on_active()
 void
 Takeoff::set_takeoff_position()
 {
-	struct position_setpoint_triplet_s *rep = _navigator->get_takeoff_triplet();
-
 	float abs_altitude = 0.0f;
 
 	float min_abs_altitude;
@@ -91,8 +87,8 @@ Takeoff::set_takeoff_position()
 	}
 
 	// Use altitude if it has been set. If home position is invalid use min_abs_altitude
-	if (rep->current.valid && PX4_ISFINITE(rep->current.alt) && _navigator->home_position_valid()) {
-		abs_altitude = rep->current.alt;
+	if (_reposition.valid && PX4_ISFINITE(_reposition.alt) && _navigator->home_position_valid()) {
+		abs_altitude = _reposition.alt;
 
 		// If the altitude suggestion is lower than home + minimum clearance, raise it and complain.
 		if (abs_altitude < min_abs_altitude) {
@@ -132,20 +128,20 @@ Takeoff::set_takeoff_position()
 	pos_sp_triplet->current.yaw_valid = true;
 	pos_sp_triplet->next.valid = false;
 
-	if (rep->current.valid) {
+	if (_reposition.valid) {
 
 		// Go on and check which changes had been requested
-		if (PX4_ISFINITE(rep->current.yaw)) {
-			pos_sp_triplet->current.yaw = rep->current.yaw;
+		if (PX4_ISFINITE(_reposition.yaw)) {
+			pos_sp_triplet->current.yaw = _reposition.yaw;
 		}
 
-		if (PX4_ISFINITE(rep->current.lat) && PX4_ISFINITE(rep->current.lon)) {
-			pos_sp_triplet->current.lat = rep->current.lat;
-			pos_sp_triplet->current.lon = rep->current.lon;
+		if (PX4_ISFINITE(_reposition.lat) && PX4_ISFINITE(_reposition.lon)) {
+			pos_sp_triplet->current.lat = _reposition.lat;
+			pos_sp_triplet->current.lon = _reposition.lon;
 		}
 
 		// mark this as done
-		memset(rep, 0, sizeof(*rep));
+		_reposition = position_setpoint_s{};
 	}
 
 	_navigator->set_can_loiter_at_sp(true);

--- a/src/modules/navigator/takeoff.h
+++ b/src/modules/navigator/takeoff.h
@@ -52,7 +52,11 @@ public:
 	void on_activation() override;
 	void on_active() override;
 
+	position_setpoint_s &get_reposition() { return _reposition; }
+
 private:
 
 	void set_takeoff_position();
+
+	position_setpoint_s			_reposition{};	/**< position setpoint for non-mission direct position command */
 };


### PR DESCRIPTION
 - safely initialize every MissionBlock's _mission_item
 - allow position setpoint triplets with no valid position setpoint to be published
   - this ensures that the position controllers don't accidentally use an old position setpoint 
 - move loiter and takeoff reposition handling into each class (full position setpoint triplet isn't needed)
 - delete dead code


**Needs testing**

### Test
 - [ ] takeoff -> hold
 - [ ] reposition usage
 - [ ] switching modes