### PR TITLE
rcS: fix typhoon_h480

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -149,9 +149,21 @@ then
 fi
 
 # Autostart ID
-autostart_file=$( ls -- etc/init.d-posix/"$(param show -q SYS_AUTOSTART)"_* )
+autostart_file=''
+for f in etc/init.d-posix/"$(param show -q SYS_AUTOSTART)"_*
+do
+	filename=$(basename "$f")
+	case "$filename" in
+		*\.*)
+			# ignore files that contain a dot (e.g. <vehicle>.post)
+			;;
+		*)
+			autostart_file="$f"
+			;;
+	esac
+done
 if [ ! -e "$autostart_file" ]; then
-	echo "Error: no autostart file found"
+	echo "Error: no autostart file found ($autostart_file)"
 	exit -1
 fi
 


### PR DESCRIPTION
The typhoon has a 6011_typhoon_h480.post script that got matched as well.
Now we exclude all files that contain a dot (apparently it's not so easy
to do generic pattern matching in a portable way, but this works).