### PR TITLE
New anti-reset windup for multicopter position controller

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -132,6 +132,11 @@ then
 	param set MPC_Z_VEL_I 0.15
 	param set MPC_Z_VEL_P 0.6
 
+	param set MPC_XY_VEL_P 0.6
+	param set MPC_XY_VEL_I 1.77
+	param set MPC_XY_VEL_D 0.05
+	param set MPC_XY_VEL_ARW 3.0
+
 	param set NAV_ACC_RAD 2.0
 	param set NAV_DLL_ACT 2
 

--- a/src/modules/mc_pos_control/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl.cpp
@@ -306,25 +306,41 @@ void PositionControl::_velocityController(const float &dt)
 			_thr_sp(1) = thrust_desired_NE(1) / mag * thrust_max_NE;
 		}
 
-		// Get the direction of (r-y) in NE-direction.
-		float direction_NE = Vector2f(vel_err) * Vector2f(_vel_sp);
+		if (MPC_XY_VEL_ARW.get() > FLT_EPSILON) { // Standard anti-reset windup
+			Vector2f vel_err_lim;
+			vel_err_lim(0) = vel_err(0) - (thrust_desired_NE(0) - _thr_sp(0)) * (MPC_XY_VEL_ARW.get());
+			vel_err_lim(1) = vel_err(1) - (thrust_desired_NE(1) - _thr_sp(1)) * (MPC_XY_VEL_ARW.get());
 
-		// Apply Anti-Windup in NE-direction.
-		bool stop_integral_NE = (thrust_desired_NE * thrust_desired_NE >= thrust_max_NE * thrust_max_NE &&
-					 direction_NE >= 0.0f);
+			// Update integral
+			_thr_int(0) += MPC_XY_VEL_I.get() * vel_err_lim(0) * dt;
+			_thr_int(1) += MPC_XY_VEL_I.get() * vel_err_lim(1) * dt;
 
-		if (!stop_integral_NE) {
-			_thr_int(0) += vel_err(0) * MPC_XY_VEL_I.get() * dt;
-			_thr_int(1) += vel_err(1) * MPC_XY_VEL_I.get() * dt;
+		} else if (MPC_XY_VEL_ARW.get() > -0.5f) { // Legacy anti-reset windup
+			// Get the direction of (r-y) in NE-direction.
+			float direction_NE = Vector2f(vel_err) * Vector2f(_vel_sp);
 
-			// magnitude of thrust integral can never exceed maximum throttle in NE
-			float integral_mag_NE = Vector2f(_thr_int).length();
+			// Apply Anti-Windup in NE-direction.
+			bool stop_integral_NE = (thrust_desired_NE * thrust_desired_NE >= thrust_max_NE * thrust_max_NE &&
+						 direction_NE >= 0.0f);
 
-			if (integral_mag_NE > 0.0f && integral_mag_NE > thrust_max_NE) {
-				_thr_int(0) = _thr_int(0) / integral_mag_NE * thrust_max_NE;
-				_thr_int(1) = _thr_int(1) / integral_mag_NE * thrust_max_NE;
+			if (!stop_integral_NE) {
+				_thr_int(0) += vel_err(0) * MPC_XY_VEL_I.get() * dt;
+				_thr_int(1) += vel_err(1) * MPC_XY_VEL_I.get() * dt;
+
+				// magnitude of thrust integral can never exceed maximum throttle in NE
+				float integral_mag_NE = Vector2f(_thr_int).length();
+
+				if (integral_mag_NE > 0.0f && integral_mag_NE > thrust_max_NE) {
+					_thr_int(0) = _thr_int(0) / integral_mag_NE * thrust_max_NE;
+					_thr_int(1) = _thr_int(1) / integral_mag_NE * thrust_max_NE;
+				}
 			}
+
+		} else { // No anti-reset windup
+			_thr_int(0) += MPC_XY_VEL_I.get() * vel_err(0) * dt;
+			_thr_int(1) += MPC_XY_VEL_I.get() * vel_err(1) * dt;
 		}
+
 	}
 }
 

--- a/src/modules/mc_pos_control/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl.hpp
@@ -202,6 +202,7 @@ private:
 		(ParamFloat<px4::params::MPC_XY_P>) MPC_XY_P,
 		(ParamFloat<px4::params::MPC_XY_VEL_P>) MPC_XY_VEL_P,
 		(ParamFloat<px4::params::MPC_XY_VEL_I>) MPC_XY_VEL_I,
-		(ParamFloat<px4::params::MPC_XY_VEL_D>) MPC_XY_VEL_D
+		(ParamFloat<px4::params::MPC_XY_VEL_D>) MPC_XY_VEL_D,
+		(ParamFloat<px4::params::MPC_XY_VEL_ARW>) MPC_XY_VEL_ARW
 	)
 };

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -207,7 +207,7 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_P, 0.09f);
  * Non-zero value allows to resist wind.
  *
  * @min 0.0
- * @max 0.1
+ * @max 3.0
  * @decimal 3
  * @group Multicopter Position Control
  */

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -214,6 +214,18 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_P, 0.09f);
 PARAM_DEFINE_FLOAT(MPC_XY_VEL_I, 0.02f);
 
 /**
+ * Anti-reset windup gain for horizontal velocity integrator
+ *
+ * Non-zero value enables ARW loop.
+ *
+ * @min -1.0
+ * @max 5.0
+ * @decimal 3
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_XY_VEL_ARW, 3.f);
+
+/**
  * Differential gain for horizontal velocity error. Small values help reduce fast oscillations. If value is too big oscillations will appear again.
  *
  * @min 0.005


### PR DESCRIPTION
This PR introduces a "new" type of Anti-Reset Windup (ARW) method for integrator handling in the velocity controller. This type of method is knowm as "Tracking Anti-Windup" and is described in [this paper](https://ac.els-cdn.com/S1474667017518650/1-s2.0-S1474667017518650-main.pdf?_tid=ed135642-d163-4aa6-98e7-4a912a5a87a4&acdnat=1538986751_bb7f14c5bd5e1a5803f50659631e671d)
 
**Test data / coverage**
In the following log, the first step response is with no ARW, the 2nd one is with the legacy ARW and the 3rd one is with the new ARW strategy this PR introduces.
https://logs.px4.io/plot_app?log=b8a97c5f-d186-475f-a804-1eeff36e9866#Nav-Velocity
![bokeh_plot 1](https://user-images.githubusercontent.com/14822839/46422452-b42ee880-c734-11e8-942f-b2514d17562d.png)

You can clearly see that in the first one, the integral takes time to slowly wind down, in the second one, the integral rapidly winds down and in the 3rd one, the integral didn't wind up at all.

Setting the parameter `MPC_XY_VEL_ARW` < -0.5 disables ARW. Between -0.5 and 0 the legacy ARW is used and > 0, the new strategy is used and the value corresponds to the ARW gain. A good starting value is 3.0.

**Describe problem solved by the proposed pull request**
Integral windup is a common problem in PID loops and prevents increasing the integral gain without increasing the overshoot. The strategy used so far was sufficient to prevent large windups but not good enough to be able to set really aggressive gains.

**Describe your preferred solution**
The new ARW introduced by this PR is known as "Tracking ARW" and is a simple feedback loop that uses the integral to track the saturation.

**Describe possible alternatives**
Another strategy is to set the integral such that it always unsaturates the output. The drawback of that method is that it is sensitive to spikes. 

**Additional context**
I'll add something in the user guide.
- https://ac.els-cdn.com/S1474667017518650/1-s2.0-S1474667017518650-main.pdf?_tid=ed135642-d163-4aa6-98e7-4a912a5a87a4&acdnat=1538986751_bb7f14c5bd5e1a5803f50659631e671d

 FYI @dagar , @LorenzMeier , @thomasgubler 