### PR TITLE
Bebop 2 improved control gains (and force failsafe)

### DIFF
--- a/posix-configs/bebop/px4.config
+++ b/posix-configs/bebop/px4.config
@@ -11,33 +11,38 @@ then
 fi
 param set SYS_AUTOSTART 4013
 param set MAV_BROADCAST 1
-param set MAV_TYPE 3
+param set MAV_TYPE 2
 
 param set MPC_XY_VEL_P 0.12
 param set MPC_XY_P 1.3
 param set MPC_XY_VEL_D 0.006
 param set MPC_XY_VEL_I 0.05
+param set MPC_XY_VEL_MAX 8
+
+param set MPC_Z_VEL_P 0.3
 param set MPC_Z_VEL_I 0.1
-param set MPC_ACC_HOR_MAX 2
-param set MPC_XY_VEL_MAX 2
 
-param set MC_YAW_P 4.0
-param set MC_YAWRATE_P 0.08
+param set MC_YAW_P 3.0
+param set MC_YAWRATE_P 0.05
+param set MC_YAWRATE_I 3.0
 
-param set MC_ROLLRATE_P 0.08
-param set MC_ROLLRATE_D 0.001
-param set MC_ROLLRATE_I 0.1
+param set MC_ROLLRATE_P 0.07
+param set MC_ROLLRATE_I 0.5
+param set MC_ROLLRATE_D 0.0
+param set MC_RR_INT_LIM 0.5
 
-param set MC_PITCHRATE_P 0.08
-param set MC_PITCHRATE_D 0.001
-param set MC_PITCHRATE_I 0.1
+param set MC_PITCHRATE_P 0.1
+param set MC_PITCHRATE_I 0.8
+param set MC_PITCHRATE_D 0.0
+param set MC_PR_INT_LIM 0.5
 
 param set SYS_MC_EST_GROUP 2
 
 df_ms5607_wrapper start
 df_mpu6050_wrapper start -R 8
 df_ak8963_wrapper start -R 32
-df_bebop_rangefinder_wrapper start
+# Rangefinder disabled for now. It was found to cause delays of more than 10ms
+#df_bebop_rangefinder_wrapper start
 gps start -d /dev/ttyPA1
 bebop_flow start
 sensors start
@@ -49,7 +54,7 @@ land_detector start multicopter
 mc_pos_control start
 mc_att_control start
 sleep 1
-mavlink start -x -u 14556 -r 1000000
+mavlink start -x -u 14556 -r 20000
 sleep 1
 mavlink stream -u 14556 -s HIGHRES_IMU -r 50
 mavlink stream -u 14556 -s ATTITUDE -r 50

--- a/src/platforms/posix/drivers/df_bebop_bus_wrapper/df_bebop_bus_wrapper.cpp
+++ b/src/platforms/posix/drivers/df_bebop_bus_wrapper/df_bebop_bus_wrapper.cpp
@@ -432,7 +432,7 @@ void task_main(int argc, char *argv[])
 			orb_copy(ORB_ID(actuator_armed), _armed_sub, &_armed);
 		}
 
-		const bool lockdown = _armed.manual_lockdown || _armed.lockdown;
+		const bool lockdown = _armed.manual_lockdown || _armed.lockdown || _armed.force_failsafe;
 
 		// Start the motors if armed but not alreay running
 		if (_armed.armed && !lockdown && !_motors_running) {


### PR DESCRIPTION
I've done some tuning on the PID settings on Bebop 2. It flies much better now, see video https://youtu.be/SsnzYhiuWiE. Still a little bit of overshoot in yaw, but not excessive. Also the frame is not very rigid, so you literally see it twisting when yawing. More agressive yaw control is tricky with such a flexible frame.

I also disabled the rangefinder for now, because it has real-time problems. When it is enabled, the compass notifies me sometimes that a frame was skipped. The compass runs at 100Hz and is polled at 200Hz. It looks like something within the rangefinder driver occupies the driver framework thread for more than 10ms.

Another minor addition: shut down motors on `armed.force_failsafe`. I added this to be able to kill the motors on a geofence violation (terminate).