### PR TITLE
Flight tasks: minor cleanup & corner case fix

### DIFF
--- a/ROMFS/px4fmu_common/init.d/4900_crazyflie
+++ b/ROMFS/px4fmu_common/init.d/4900_crazyflie
@@ -47,7 +47,6 @@ then
 	param set MC_YAW_P 3.0
 
 	param set MPC_THR_HOVER 0.7
-	param set MPC_MANTHR_MAX 1.0
 	param set MPC_THR_MAX 1.0
 	param set MPC_Z_P 1.5
 	param set MPC_Z_VEL_I 0.3

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -239,32 +239,29 @@ void FlightTaskAuto::_set_heading_from_mode()
 
 	switch (MPC_YAW_MODE.get()) {
 
-	case 0: { // Heading points towards the current waypoint.
-			v = Vector2f(_target) - Vector2f(_position);
-			break;
+	case 0: // Heading points towards the current waypoint.
+		v = Vector2f(_target) - Vector2f(_position);
+		break;
+
+	case 1: // Heading points towards home.
+		if (_sub_home_position->get().valid_hpos) {
+			v = Vector2f(&_sub_home_position->get().x) - Vector2f(_position);
 		}
 
-	case 1: { // Heading points towards home.
-			if (_sub_home_position->get().valid_hpos) {
-				v = Vector2f(&_sub_home_position->get().x) - Vector2f(_position);
-			}
+		break;
 
-			break;
+	case 2: // Heading point away from home.
+		if (_sub_home_position->get().valid_hpos) {
+			v = Vector2f(_position) - Vector2f(&_sub_home_position->get().x);
 		}
 
-	case 2: { // Heading point away from home.
-			if (_sub_home_position->get().valid_hpos) {
-				v = Vector2f(_position) - Vector2f(&_sub_home_position->get().x);
-			}
+		break;
 
-			break;
-		}
-
-	case 3: { // Along trajectory.
-			// The heading depends on the kind of setpoint generation. This needs to be implemented
-			// in the subclasses where the velocity setpoints are generated.
-			v *= NAN;
-		}
+	case 3: // Along trajectory.
+		// The heading depends on the kind of setpoint generation. This needs to be implemented
+		// in the subclasses where the velocity setpoints are generated.
+		v.setAll(NAN);
+		break;
 	}
 
 	if (PX4_ISFINITE(v.length())) {

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -136,7 +136,7 @@ bool FlightTaskAuto::_evaluateTriplets()
 		} else {
 			tmp_target(0) = _lock_position_xy(0);
 			tmp_target(1) = _lock_position_xy(1);
-			_lock_position_xy *= NAN;
+			_lock_position_xy.setAll(NAN);
 		}
 
 	} else {

--- a/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -251,9 +251,7 @@ void FlightTaskManualAltitude::_respectMaxAltitude()
 
 void FlightTaskManualAltitude::_updateSetpoints()
 {
-	FlightTaskManualStabilized::_updateSetpoints(); // get yaw and thrust setpoints
-
-	_thrust_setpoint *= NAN; // Don't need thrust setpoint from Stabilized mode.
+	FlightTaskManualStabilized::_updateHeadingSetpoints(); // get yaw setpoint
 
 	// Thrust in xy are extracted directly from stick inputs. A magnitude of
 	// 1 means that maximum thrust along xy is demanded. A magnitude of 0 means no
@@ -269,6 +267,7 @@ void FlightTaskManualAltitude::_updateSetpoints()
 
 	_thrust_setpoint(0) = sp(0);
 	_thrust_setpoint(1) = sp(1);
+	_thrust_setpoint(2) = NAN;
 
 	_updateAltitudeLock();
 }

--- a/src/lib/FlightTasks/tasks/ManualPositionSmooth/FlightTaskManualPositionSmooth.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmooth/FlightTaskManualPositionSmooth.cpp
@@ -57,7 +57,7 @@ void FlightTaskManualPositionSmooth::_updateSetpoints()
 	_velocity_setpoint(0) = vel_sp_xy(0);
 	_velocity_setpoint(1) = vel_sp_xy(1);
 
-	/* Check for altitude lock.*/
+	/* Check for xy position lock.*/
 	_updateXYlock();
 
 	/* Smooth velocity in z.*/

--- a/src/lib/FlightTasks/tasks/ManualStabilized/FlightTaskManualStabilized.hpp
+++ b/src/lib/FlightTasks/tasks/ManualStabilized/FlightTaskManualStabilized.hpp
@@ -58,12 +58,12 @@ public:
 	void setYawHandler(WeatherVane *ext_yaw_handler) override {_ext_yaw_handler = ext_yaw_handler;}
 
 protected:
-	virtual void _updateSetpoints(); /**< updates all setpoints*/
+	virtual void _updateSetpoints(); /**< updates all setpoints */
+	void _updateHeadingSetpoints(); /**< sets yaw or yaw speed */
 	virtual void _scaleSticks(); /**< scales sticks to yaw and thrust */
 	void _rotateIntoHeadingFrame(matrix::Vector2f &vec); /**< rotates vector into local frame */
 
 private:
-	void _updateHeadingSetpoints(); /**< sets yaw or yaw speed */
 	void _updateThrustSetpoints(); /**< sets thrust setpoint */
 	float _throttleCurve(); /**< piecewise linear mapping from stick to throttle */
 

--- a/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp
+++ b/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp
@@ -68,8 +68,8 @@ bool FlightTaskOffboard::activate()
 {
 	bool ret = FlightTask::activate();
 	_position_setpoint = _position;
-	_velocity_setpoint *= 0.0f;
-	_position_lock *= NAN;
+	_velocity_setpoint.setZero();
+	_position_lock.setAll(NAN);
 	return ret;
 }
 
@@ -117,7 +117,7 @@ bool FlightTaskOffboard::update()
 		return true;
 
 	} else {
-		_position_lock *= NAN;
+		_position_lock.setAll(NAN);
 	}
 
 	// Takeoff
@@ -135,7 +135,7 @@ bool FlightTaskOffboard::update()
 		return true;
 
 	} else {
-		_position_lock *= NAN;
+		_position_lock.setAll(NAN);
 	}
 
 	// Land
@@ -155,7 +155,7 @@ bool FlightTaskOffboard::update()
 		return true;
 
 	} else {
-		_position_lock *= NAN;
+		_position_lock.setAll(NAN);
 	}
 
 	// IDLE

--- a/src/lib/FlightTasks/tasks/Utility/ManualSmoothingXY.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/ManualSmoothingXY.cpp
@@ -36,7 +36,6 @@
  */
 
 #include "ManualSmoothingXY.hpp"
-#include "uORB/topics/parameter_update.h"
 #include <mathlib/mathlib.h>
 #include <float.h>
 

--- a/src/lib/FlightTasks/tasks/Utility/ManualSmoothingZ.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/ManualSmoothingZ.cpp
@@ -36,7 +36,6 @@
  */
 
 #include "ManualSmoothingZ.hpp"
-#include "uORB/topics/parameter_update.h"
 #include <mathlib/mathlib.h>
 #include <float.h>
 

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -101,20 +101,6 @@ PARAM_DEFINE_FLOAT(MPC_THR_MAX, 1.0f);
 PARAM_DEFINE_FLOAT(MPC_MANTHR_MIN, 0.08f);
 
 /**
- * Maximum manual thrust
- *
- * Limit max allowed thrust for Manual mode.
- *
- * @unit norm
- * @min 0.0
- * @max 1.0
- * @decimal 2
- * @increment 0.01
- * @group Multicopter Position Control
- */
-PARAM_DEFINE_FLOAT(MPC_MANTHR_MAX, 1.0f);
-
-/**
  * Proportional gain for vertical position error
  *
  * @min 0.0


### PR DESCRIPTION
See individual commits.

Fixes a corner case: `_velocity_setpoint *= 0.0f;` does not lead to the expected result when `_velocity_setpoint` is NAN already.