### PR TITLE
flighttask reactivate before taekoff

### DIFF
--- a/src/lib/FlightTasks/FlightTasks.cpp
+++ b/src/lib/FlightTasks/FlightTasks.cpp
@@ -132,7 +132,6 @@ const char *FlightTasks::errorToString(const int error)
 
 void FlightTasks::reActivate()
 {
-
 	if (_current_task.task) {
 		_current_task.task->activate();
 	}

--- a/src/lib/FlightTasks/FlightTasks.cpp
+++ b/src/lib/FlightTasks/FlightTasks.cpp
@@ -130,6 +130,14 @@ const char *FlightTasks::errorToString(const int error)
 	return "This error is not mapped to a string or is unknown.";
 }
 
+void FlightTasks::reActivate()
+{
+
+	if (_current_task.task) {
+		_current_task.task->activate();
+	}
+}
+
 void FlightTasks::_updateCommand()
 {
 	// lazy subscription to command topic

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -131,6 +131,11 @@ public:
 	 */
 	void setYawHandler(WeatherVane *ext_yaw_handler) {_current_task.task->setYawHandler(ext_yaw_handler);}
 
+	/**
+	 *   This method will re-activate current task.
+	 */
+	void reActivate();
+
 private:
 
 	/**

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -692,6 +692,8 @@ MulticopterPositionControl::run()
 				setpoint.yawspeed = NAN;
 				setpoint.yaw = _states.yaw;
 				constraints.landing_gear = vehicle_constraints_s::GEAR_KEEP;
+				// reactivate the task which will reset the setpoint to current state
+				_flight_tasks.reActivate();
 			}
 
 			// limit altitude only if local position is valid


### PR DESCRIPTION
Since the state estimation can significantly change from  the disarmed-state to idle-state, I added a re-activation method for  flighttask. This method will be called until the vehicle state changes  from idle to smooth-takeoff state.




