### PR TITLE
warn pos ctrl failsafe

### DIFF
--- a/src/modules/mc_pos_control/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl.hpp
@@ -94,8 +94,9 @@ public:
 	/**
 	 * Update the desired setpoints.
 	 * @param setpoint a vehicle_local_position_setpoint_s structure
+	 * @return true if setpoint has updated correctly
 	 */
-	void updateSetpoint(const vehicle_local_position_setpoint_s &setpoint);
+	bool updateSetpoint(const vehicle_local_position_setpoint_s &setpoint);
 
 	/**
 	 * Set constraints that are stricter than the global limits.
@@ -165,7 +166,12 @@ protected:
 	void updateParams() override;
 
 private:
-	void _interfaceMapping(); /** maps set-points to internal member set-points */
+	/**
+	 * Maps setpoints to internal-setpoints.
+	 * @return true if mapping succeeded.
+	 */
+	bool _interfaceMapping();
+
 	void _positionController(); /** applies the P-position-controller */
 	void _velocityController(const float &dt); /** applies the PID-velocity-controller */
 


### PR DESCRIPTION
The last failsafe implemented in the mc-position controller is just for sanity check and should in normal situation not be executed. However, if for whatever reason something is demanded that cannot be executed (for instance velocity control but no velocity estimate is available), then the position controller will enter failsafe (slowly goes down). I added now a warning-message if that happens.

I also refactored the logic where obstacle avoidance is called for better readability.