### PR TITLE
Individual cell voltages and batt_smbus

### DIFF
--- a/msg/battery_status.msg
+++ b/msg/battery_status.msg
@@ -17,6 +17,7 @@ uint16 cycle_count         # number of discharge cycles the battery has experien
 uint16 run_time_to_empty   # predicted remaining battery capacity based on the present rate of discharge in min
 uint16 average_time_to_empty   # predicted remaining battery capacity based on the average rate of discharge in min
 uint16 serial_number       # serial number of the battery pack
+uint16[10] voltages_ind #array of voltages if smart battery supports check
 
 
 bool is_powering_off		# Power off event imminent indication, false if unknown

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -59,7 +59,8 @@ BATT_SMBUS::BATT_SMBUS(device::Device *interface, const char *path) :
 	_crit_thr(0.0f),
 	_emergency_thr(0.0f),
 	_low_thr(0.0f),
-	_manufacturer_name(nullptr)
+    _manufacturer_name(nullptr),
+    _cell_count(0)
 {
 }
 
@@ -211,6 +212,19 @@ void BATT_SMBUS::cycle()
 		} else {
 			success = false;
 		}
+
+        //Testing the cell count option
+        //Check if smart battery supports standard
+        if (_cell_count > 0){
+            new_report.cell_count = _cell_count;
+            for (uint8_t j = 0; j < _cell_count; j++) {
+                if (read_word((BATT_SMBUS_VOLTAGE_C1+j), &tmp) == PX4_OK) {
+                   new_report.voltages_ind[j] = tmp;
+                }
+            }
+        } else {
+            new_report.cell_count = 0;
+        }
 
 		// Read remaining capacity.
 		if (read_word(BATT_SMBUS_REMAINING_CAPACITY, &tmp) == PX4_OK) {
@@ -416,6 +430,19 @@ int BATT_SMBUS::get_startup_info()
 		_batt_capacity = tmp;
 		result = PX4_OK;
 	}
+
+    //try for loop with (BATT_SMBUS_VOLTAGE_C1 + i) as address to read individual cell voltages
+    if (read_word(BATT_SMBUS_VOLTAGE_C1, &tmp) == PX4_OK) {
+        _cell_count++;
+        for (uint8_t j = 1; j < 10; j++) { //Though spec only lists 4 cells, query up to 10 because pixhawk mavlink battery messages support it
+            if (read_word((BATT_SMBUS_VOLTAGE_C1+j), &tmp) == PX4_OK) {
+               _cell_count++;
+            }
+        }
+        PX4_INFO("Smart battery has %d cells", _cell_count);
+    } else {
+        PX4_INFO("Smart battery does not report cell voltages");
+    }
 
 	// Read battery threshold params on startup.
 	param_get(param_find("BAT_CRIT_THR"), &_crit_thr);

--- a/src/drivers/batt_smbus/batt_smbus.h
+++ b/src/drivers/batt_smbus/batt_smbus.h
@@ -320,8 +320,8 @@ private:
 	/** @param _manufacturer_name Name of the battery manufacturer. */
 	char *_manufacturer_name;
 
-    /** @param _cell_count Number of cells reported by checking individual voltages (0 means unknown). */
-    uint8_t _cell_count;
+	/** @param _cell_count Number of cells reported by checking individual voltages (0 means unknown). */
+	uint8_t _cell_count;
 
 	/* Do not allow copy construction or move assignment of this class. */
 	BATT_SMBUS(const BATT_SMBUS &);

--- a/src/drivers/batt_smbus/batt_smbus.h
+++ b/src/drivers/batt_smbus/batt_smbus.h
@@ -83,6 +83,10 @@
 #define BATT_SMBUS_MANUFACTURER_NAME                    0x20                    ///< manufacturer name
 #define BATT_SMBUS_MANUFACTURE_DATE                     0x1B                    ///< manufacture date register
 #define BATT_SMBUS_SERIAL_NUMBER                        0x1C                    ///< serial number register
+#define BATT_SMBUS_VOLTAGE_C1                           0x3C                    ///< voltage register for cell 1
+#define BATT_SMBUS_VOLTAGE_C2                           0x3D                    ///< voltage register for cell 2
+#define BATT_SMBUS_VOLTAGE_C3                           0x3E                    ///< voltage register for cell 3
+#define BATT_SMBUS_VOLTAGE_C4                           0x3F                    ///< voltage register for cell 4
 #define BATT_SMBUS_MEASUREMENT_INTERVAL_US              100000                  ///< time in microseconds, measure at 10Hz
 #define BATT_SMBUS_TIMEOUT_US                           1000000                ///< timeout looking for battery 10seconds after startup
 #define BATT_SMBUS_MANUFACTURER_ACCESS                  0x00
@@ -315,6 +319,9 @@ private:
 
 	/** @param _manufacturer_name Name of the battery manufacturer. */
 	char *_manufacturer_name;
+
+    /** @param _cell_count Number of cells reported by checking individual voltages (0 means unknown). */
+    uint8_t _cell_count;
 
 	/* Do not allow copy construction or move assignment of this class. */
 	BATT_SMBUS(const BATT_SMBUS &);

--- a/src/drivers/batt_smbus/batt_smbus_main.cpp
+++ b/src/drivers/batt_smbus/batt_smbus_main.cpp
@@ -56,12 +56,12 @@ struct batt_smbus_bus_option {
 	uint8_t busnum;
 	BATT_SMBUS      *dev;
 } bus_options[] = {
-	{ BATT_SMBUS_BUS_I2C_EXTERNAL, "/dev/batt_smbus_ext", &BATT_SMBUS_I2C_interface, PX4_I2C_BUS_EXPANSION, nullptr },
+	{ BATT_SMBUS_BUS_I2C_EXTERNAL, "/dev/batt_smbus_ext2", &BATT_SMBUS_I2C_interface, PX4_I2C_BUS_EXPANSION2, nullptr },
 #ifdef PX4_I2C_BUS_EXPANSION1
-    { BATT_SMBUS_BUS_I2C_EXTERNAL, "/dev/batt_smbus_ext1", &BATT_SMBUS_I2C_interface, PX4_I2C_BUS_EXPANSION1, nullptr }, //Options not working from nuttx shell for now
+	{ BATT_SMBUS_BUS_I2C_EXTERNAL, "/dev/batt_smbus_ext1", &BATT_SMBUS_I2C_interface, PX4_I2C_BUS_EXPANSION1, nullptr }, //Options not working from nuttx shell for now
 #endif
 #ifdef PX4_I2C_BUS_EXPANSION2
-    { BATT_SMBUS_BUS_I2C_EXTERNAL, "/dev/batt_smbus_ext2", &BATT_SMBUS_I2C_interface, PX4_I2C_BUS_EXPANSION2, nullptr },
+	{ BATT_SMBUS_BUS_I2C_EXTERNAL, "/dev/batt_smbus_ext2", &BATT_SMBUS_I2C_interface, PX4_I2C_BUS_EXPANSION2, nullptr },
 #endif
 #ifdef PX4_I2C_BUS_ONBOARD
 	{ BATT_SMBUS_BUS_I2C_INTERNAL, "/dev/batt_smbus_int", &BATT_SMBUS_I2C_interface, PX4_I2C_BUS_ONBOARD, nullptr },

--- a/src/drivers/batt_smbus/batt_smbus_main.cpp
+++ b/src/drivers/batt_smbus/batt_smbus_main.cpp
@@ -57,6 +57,12 @@ struct batt_smbus_bus_option {
 	BATT_SMBUS      *dev;
 } bus_options[] = {
 	{ BATT_SMBUS_BUS_I2C_EXTERNAL, "/dev/batt_smbus_ext", &BATT_SMBUS_I2C_interface, PX4_I2C_BUS_EXPANSION, nullptr },
+#ifdef PX4_I2C_BUS_EXPANSION1
+    { BATT_SMBUS_BUS_I2C_EXTERNAL, "/dev/batt_smbus_ext1", &BATT_SMBUS_I2C_interface, PX4_I2C_BUS_EXPANSION1, nullptr }, //Options not working from nuttx shell for now
+#endif
+#ifdef PX4_I2C_BUS_EXPANSION2
+    { BATT_SMBUS_BUS_I2C_EXTERNAL, "/dev/batt_smbus_ext2", &BATT_SMBUS_I2C_interface, PX4_I2C_BUS_EXPANSION2, nullptr },
+#endif
 #ifdef PX4_I2C_BUS_ONBOARD
 	{ BATT_SMBUS_BUS_I2C_INTERNAL, "/dev/batt_smbus_int", &BATT_SMBUS_I2C_interface, PX4_I2C_BUS_ONBOARD, nullptr },
 #endif

--- a/src/drivers/batt_smbus/batt_smbus_main.cpp
+++ b/src/drivers/batt_smbus/batt_smbus_main.cpp
@@ -56,7 +56,7 @@ struct batt_smbus_bus_option {
 	uint8_t busnum;
 	BATT_SMBUS      *dev;
 } bus_options[] = {
-	{ BATT_SMBUS_BUS_I2C_EXTERNAL, "/dev/batt_smbus_ext2", &BATT_SMBUS_I2C_interface, PX4_I2C_BUS_EXPANSION2, nullptr },
+	{ BATT_SMBUS_BUS_I2C_EXTERNAL, "/dev/batt_smbus_ext", &BATT_SMBUS_I2C_interface, PX4_I2C_BUS_EXPANSION, nullptr },
 #ifdef PX4_I2C_BUS_EXPANSION1
 	{ BATT_SMBUS_BUS_I2C_EXTERNAL, "/dev/batt_smbus_ext1", &BATT_SMBUS_I2C_interface, PX4_I2C_BUS_EXPANSION1, nullptr }, //Options not working from nuttx shell for now
 #endif

--- a/src/drivers/boards/common/board_common.h
+++ b/src/drivers/boards/common/board_common.h
@@ -665,7 +665,7 @@ typedef enum {
 typedef enum {
 	px4_hw_con_unknown  = 0,
 	px4_hw_con_onboard  = 1,
-	px4_hw_con_connector = 3,
+	px4_hw_con_conector = 3,
 } px4_hw_connection_t;
 
 
@@ -685,7 +685,7 @@ __EXPORT px4_hw_mft_item board_query_manifest(px4_hw_mft_item_id_t id);
 #  define PX4_MFT_HW_SUPPORTED(ID)           (board_query_manifest((ID))->present)
 #  define PX4_MFT_HW_REQUIRED(ID)            (board_query_manifest((ID))->mandatory)
 #  define PX4_MFT_HW_IS_ONBOARD(ID)          (board_query_manifest((ID))->connection == px4_hw_con_onboard)
-#  define PX4_MFT_HW_IS_OFFBOARD(ID)         (board_query_manifest((ID))->connection == px4_hw_con_connector)
+#  define PX4_MFT_HW_IS_OFFBOARD(ID)         (board_query_manifest((ID))->connection == px4_hw_con_conector)
 #  define PX4_MFT_HW_IS_CONNECTION_KNOWN(ID) (board_query_manifest((ID))->connection != px4_hw_con_unknown)
 #elif defined(BOARD_HAS_STATIC_MANIFEST) && BOARD_HAS_STATIC_MANIFEST == 1
 /* Board has a static configuration and will supply what it has */

--- a/src/drivers/boards/px4fmu-v5/manifest.c
+++ b/src/drivers/boards/px4fmu-v5/manifest.c
@@ -66,14 +66,16 @@ typedef px4_hw_mft_list_entry_t *px4_hw_mft_list_entry;
 
 static const px4_hw_mft_item_t device_unsupported = {0, 0, 0};
 
-// List of components on a specific board configuration
-// The index of those components is given by the enum (px4_hw_mft_item_id_t)
-// declared in board_common.h
 static const px4_hw_mft_item_t hw_mft_list_v0500[] = {
 	{
 		.present     = 1,
 		.mandatory   = 1,
 		.connection  = px4_hw_con_onboard,
+	},
+	{
+		.present     = 1,
+		.mandatory   = 1,
+		.connection  = 1,
 	},
 };
 

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -598,7 +598,7 @@ protected:
 
 			for (unsigned int i = 0; i < (sizeof(bat_msg.voltages) / sizeof(bat_msg.voltages[0])); i++) {
 				if ((int)i < battery_status.cell_count && battery_status.connected) {
-                                        bat_msg.voltages[i] = battery_status.voltages_ind[i] * 1.0f;
+					bat_msg.voltages[i] = battery_status.voltages_ind[i] * 1.0f;
 
 				} else {
 					bat_msg.voltages[i] = UINT16_MAX;

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -598,7 +598,7 @@ protected:
 
 			for (unsigned int i = 0; i < (sizeof(bat_msg.voltages) / sizeof(bat_msg.voltages[0])); i++) {
 				if ((int)i < battery_status.cell_count && battery_status.connected) {
-					bat_msg.voltages[i] = (battery_status.voltage_v / battery_status.cell_count) * 1000.0f;
+                                        bat_msg.voltages[i] = battery_status.voltages_ind[i] * 1.0f;
 
 				} else {
 					bat_msg.voltages[i] = UINT16_MAX;


### PR DESCRIPTION
Hello all,
This is my first pull request ever. I am still very new to development in general, so please forgive me. I know there are errors, But I would love some feedback while I fix them.

Changes to files are for two reasons:
- Try to fix an issue where the batt_smbus driver does not include I2C bus options for Pixhawk hardware with buses other than `PX4_I2C_BUS_ONBOARD` and `PX4_I2C_BUS_EXPANSION`  (Example: I am using a Pixhawk 4, so px4fmu-v5 defines the external I2C A port as `PX4_I2C_BUS_EXPANSION2`, which the driver cannot start on currently)
- Implement real individual voltage checking and reporting to the ground station via the existing individual voltage array in MAVlink `BATTERY_STATUS` messages. The existing code divides total pack voltage by number of cells (up to 10 cells) to calculate individual cell voltages, but I want to populate that array with measured cell voltages. 

The registers beyond 0x3f are specific to the custom voltage and temperature measuring board I am working on, but because they are not defined for most TI fuel gauge chips (the BQ40Z50 does not define any registers in the range of 0x40 - 0x49), I don't think I am breaking compatibility by adding this behavior. However, I do not have a BQ40Z50 to test this on.

Possible alternatives:
- Write custom driver for up to 10 cell voltages and up to three temperature values that works with my hardware to publish `battery_status` messages 
- Separate core SMbus functionality (`read_word, write_word, block_read, etc.`) from device specific functionality to prevent bloating of `batt_smbus` and make development easier as @dakejahl suggested 

Example:
Test bench setup for custom board connected to Pixhawk 4 I2C A port
![img_20181005_200912](https://user-images.githubusercontent.com/35938826/46565296-bda68500-c8db-11e8-80da-4ff188e52c15.jpg)

Starting the driver manually
![screenshot from 2018-10-05 20-12-58](https://user-images.githubusercontent.com/35938826/46565273-9059d700-c8db-11e8-84ab-dcfeb4439a84.png)

Result of sweeping benchtop through voltage range 
![screenshot from 2018-10-05 20-15-06](https://user-images.githubusercontent.com/35938826/46565257-7a4c1680-c8db-11e8-9678-207aee60306d.png)

Thanks,
Zack Selgrath
