### PR TITLE
mavlink config: remove Iridium option

### DIFF
--- a/src/modules/mavlink/module.yaml
+++ b/src/modules/mavlink/module.yaml
@@ -37,7 +37,7 @@ parameters:
                 3: OSD
                 4: Magic
                 5: Config
-                6: Iridium
+                #6: Iridium # as the user does not need to configure this, hide it from the UI
                 7: Minimal
             reboot_required: true
             num_instances: *max_num_config_instances


### PR DESCRIPTION
The user does not need to configure this, so we can hide it from the UI.

@hamishwillee 