### PR TITLE
ecl tools: fix logdata processing without preflight message present

### DIFF
--- a/Tools/ecl_ekf/analyse_logdata_ekf.py
+++ b/Tools/ecl_ekf/analyse_logdata_ekf.py
@@ -323,7 +323,7 @@ def analyse_ekf(estimator_status, ekf2_innovations, sensor_preflight, check_leve
         plt.plot(1e-6 * ekf2_innovations['timestamp'], ekf2_innovations['beta_innov'], 'b')
         plt.plot(1e-6 * ekf2_innovations['timestamp'], np.sqrt(ekf2_innovations['beta_innov_var']), 'r')
         plt.plot(1e-6 * ekf2_innovations['timestamp'], -np.sqrt(ekf2_innovations['beta_innov_var']), 'r')
-        plt.title('Sythetic Sideslip Innovations')
+        plt.title('Synthetic Sideslip Innovations')
         plt.ylabel('innovation (rad)')
         plt.xlabel('time (sec)')
         plt.grid()

--- a/Tools/ecl_ekf/process_logdata_ekf.py
+++ b/Tools/ecl_ekf/process_logdata_ekf.py
@@ -39,18 +39,21 @@ ulog = ULog(args.filename, None)
 data = ulog.data_list
 
 # extract data from EKF status message
+estimator_status_data = {}
 try:
     estimator_status_data = ulog.get_dataset('estimator_status').data;
 except (KeyError, IndexError, ValueError) as error:
     print(type(error), "(estimator_status):", error)
 
 # extract data from EKF innovations message
+ekf2_innovations_data = {}
 try:
     ekf2_innovations_data = ulog.get_dataset('ekf2_innovations').data;
 except (KeyError, IndexError, ValueError) as error:
     print(type(error), "(ekf2_innovations):", error)
 
 # extract data from sensor preflight check message
+sensor_preflight_data = {}
 try:
     sensor_preflight_data = ulog.get_dataset('sensor_preflight').data;
 except (KeyError, IndexError, ValueError) as error:

--- a/Tools/ecl_ekf/process_logdata_ekf.py
+++ b/Tools/ecl_ekf/process_logdata_ekf.py
@@ -39,13 +39,22 @@ ulog = ULog(args.filename, None)
 data = ulog.data_list
 
 # extract data from EKF status message
-estimator_status_data = ulog.get_dataset('estimator_status').data;
+try:
+    estimator_status_data = ulog.get_dataset('estimator_status').data;
+except (KeyError, IndexError, ValueError) as error:
+    print(type(error), "(estimator_status):", error)
 
 # extract data from EKF innovations message
-ekf2_innovations_data = ulog.get_dataset('ekf2_innovations').data;
+try:
+    ekf2_innovations_data = ulog.get_dataset('ekf2_innovations').data;
+except (KeyError, IndexError, ValueError) as error:
+    print(type(error), "(ekf2_innovations):", error)
 
 # extract data from sensor preflight check message
-sensor_preflight_data = ulog.get_dataset('sensor_preflight').data;
+try:
+    sensor_preflight_data = ulog.get_dataset('sensor_preflight').data;
+except (KeyError, IndexError, ValueError) as error:
+    print(type(error), "(sensor_preflight):", error)
 
 if args.check_level_thresholds:
     check_level_dict_filename = args.check_level_thresholds

--- a/Tools/ecl_ekf/process_logdata_ekf.py
+++ b/Tools/ecl_ekf/process_logdata_ekf.py
@@ -38,23 +38,14 @@ args = parser.parse_args()
 ulog = ULog(args.filename, None)
 data = ulog.data_list
 
-# extract data from innovations and status messages
-for d in data:
-    if d.name == 'estimator_status':
-        estimator_status_data = d.data
-        print('found estimator_status data')
-for d in data:
-    if d.name == 'ekf2_innovations':
-        ekf2_innovations_data = d.data
-        print('found ekf2_innovation data')
+# extract data from EKF status message
+estimator_status_data = ulog.get_dataset('estimator_status').data;
+
+# extract data from EKF innovations message
+ekf2_innovations_data = ulog.get_dataset('ekf2_innovations').data;
 
 # extract data from sensor preflight check message
-sensor_preflight = {}
-for d in data:
-    if d.name == 'sensor_preflight':
-        sensor_preflight_data = d.data
-        print('found sensor_preflight data')
-
+sensor_preflight_data = ulog.get_dataset('sensor_preflight').data;
 
 if args.check_level_thresholds:
     check_level_dict_filename = args.check_level_thresholds


### PR DESCRIPTION
- Allows ```process_logdata_ekf.py``` to run on logfiles that not include the sensor_preflight message
- Some cleanup