### PR TITLE
MC: add thrust curve param

### DIFF
--- a/src/lib/FlightTasks/tasks/ManualStabilized/FlightTaskManualStabilized.cpp
+++ b/src/lib/FlightTasks/tasks/ManualStabilized/FlightTaskManualStabilized.cpp
@@ -145,16 +145,22 @@ void FlightTaskManualStabilized::_updateSetpoints()
 
 float FlightTaskManualStabilized::_throttleCurve()
 {
-	/* Scale stick z from [-1,1] to [min thrust, max thrust]
-	 * with hover throttle at 0.5 stick */
+	// Scale stick z from [-1,1] to [min thrust, max thrust]
 	float throttle = -((_sticks(2) - 1.0f) * 0.5f);
 
-	if (throttle < 0.5f) {
-		return (_throttle_hover.get() - _throttle_min_stabilized.get()) / 0.5f * throttle + _throttle_min_stabilized.get();
+	switch (_throttle_curve.get()) {
+	case 1: // no rescaling
+		return throttle;
 
-	} else {
-		return (_throttle_max.get() - _throttle_hover.get()) / 0.5f * (throttle - 1.0f) + _throttle_max.get();
+	default: // 0 or other: rescale to hover throttle at 0.5 stick
+		if (throttle < 0.5f) {
+			return (_throttle_hover.get() - _throttle_min_stabilized.get()) / 0.5f * throttle + _throttle_min_stabilized.get();
+
+		} else {
+			return (_throttle_max.get() - _throttle_hover.get()) / 0.5f * (throttle - 1.0f) + _throttle_max.get();
+		}
 	}
+
 }
 
 bool FlightTaskManualStabilized::update()

--- a/src/lib/FlightTasks/tasks/ManualStabilized/FlightTaskManualStabilized.hpp
+++ b/src/lib/FlightTasks/tasks/ManualStabilized/FlightTaskManualStabilized.hpp
@@ -77,6 +77,7 @@ private:
 					(ParamFloat<px4::params::MPC_MAN_TILT_MAX>) _tilt_max_man, /**< maximum tilt allowed for manual flight */
 					(ParamFloat<px4::params::MPC_MANTHR_MIN>) _throttle_min_stabilized, /**< minimum throttle for stabilized */
 					(ParamFloat<px4::params::MPC_THR_MAX>) _throttle_max, /**< maximum throttle that always has to be satisfied in flight*/
-					(ParamFloat<px4::params::MPC_THR_HOVER>) _throttle_hover /**< throttle value at which vehicle is at hover equilibrium */
+					(ParamFloat<px4::params::MPC_THR_HOVER>) _throttle_hover, /**< throttle at which vehicle is at hover equilibrium */
+					(ParamInt<px4::params::MPC_THR_CURVE>) _throttle_curve /**< throttle curve behavior */
 				       )
 };

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -75,7 +75,6 @@ MulticopterLandDetector::MulticopterLandDetector()
 	_paramHandle.maxRotation = param_find("LNDMC_ROT_MAX");
 	_paramHandle.maxVelocity = param_find("LNDMC_XY_VEL_MAX");
 	_paramHandle.maxClimbRate = param_find("LNDMC_Z_VEL_MAX");
-	_paramHandle.throttleRange = param_find("LNDMC_THR_RANGE");
 	_paramHandle.minThrottle = param_find("MPC_THR_MIN");
 	_paramHandle.hoverThrottle = param_find("MPC_THR_HOVER");
 	_paramHandle.minManThrottle = param_find("MPC_MANTHR_MIN");
@@ -121,7 +120,6 @@ void MulticopterLandDetector::_update_params()
 	_params.maxRotation_rad_s = math::radians(_params.maxRotation_rad_s);
 	param_get(_paramHandle.minThrottle, &_params.minThrottle);
 	param_get(_paramHandle.hoverThrottle, &_params.hoverThrottle);
-	param_get(_paramHandle.throttleRange, &_params.throttleRange);
 	param_get(_paramHandle.minManThrottle, &_params.minManThrottle);
 	param_get(_paramHandle.freefall_acc_threshold, &_params.freefall_acc_threshold);
 	param_get(_paramHandle.freefall_trigger_time, &_params.freefall_trigger_time);
@@ -320,7 +318,7 @@ bool MulticopterLandDetector::_has_low_thrust()
 bool MulticopterLandDetector::_has_minimal_thrust()
 {
 	// 10% of throttle range between min and hover once we entered ground contact
-	float sys_min_throttle = _params.minThrottle + (_params.hoverThrottle - _params.minThrottle) * _params.throttleRange;
+	float sys_min_throttle = _params.minThrottle + (_params.hoverThrottle - _params.minThrottle) * 0.1f;
 
 	// Determine the system min throttle based on flight mode
 	if (!_control_mode.flag_control_climb_rate_enabled) {

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -101,7 +101,6 @@ private:
 		param_t maxRotation;
 		param_t minThrottle;
 		param_t hoverThrottle;
-		param_t throttleRange;
 		param_t minManThrottle;
 		param_t freefall_acc_threshold;
 		param_t freefall_trigger_time;
@@ -115,7 +114,6 @@ private:
 		float maxRotation_rad_s;
 		float minThrottle;
 		float hoverThrottle;
-		float throttleRange;
 		float minManThrottle;
 		float freefall_acc_threshold;
 		float freefall_trigger_time;

--- a/src/modules/land_detector/land_detector_params_mc.c
+++ b/src/modules/land_detector/land_detector_params_mc.c
@@ -82,22 +82,6 @@ PARAM_DEFINE_FLOAT(LNDMC_ROT_MAX, 20.0f);
 PARAM_DEFINE_FLOAT(LNDMC_FFALL_THR, 2.0f);
 
 /**
- * Multicopter sub-hover throttle scaling
- *
- * The range between throttle_min and throttle_hover is scaled
- * by this parameter to define how close to minimum throttle
- * the current throttle value needs to be in order to get
- * accepted as landed.
- *
- * @min 0.05
- * @max 0.5
- * @decimal 2
- *
- * @group Land Detector
- */
-PARAM_DEFINE_FLOAT(LNDMC_THR_RANGE, 0.1f);
-
-/**
  * Multicopter free-fall trigger time
  *
  * Seconds (decimal) that freefall conditions have to met before triggering a freefall.

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -72,6 +72,28 @@ PARAM_DEFINE_FLOAT(MPC_THR_MIN, 0.12f);
 PARAM_DEFINE_FLOAT(MPC_THR_HOVER, 0.5f);
 
 /**
+ * Thrust curve in Manual Mode
+ *
+ * This parameter defines how the throttle stick input is mapped to commanded thrust
+ * in Manual/Stabilized flight mode.
+ *
+ * In case the default is used ('Rescale to hover thrust'), the stick input is linearly
+ * rescaled, such that a centered stick corresponds to the hover throttle (see MPC_THR_HOVER).
+ *
+ * Select 'No Rescale' to directly map the stick 1:1 to the output. This can be useful
+ * in case the hover thrust is very low and the default would lead to too much distortion
+ * (e.g. if hover thrust is set to 20%, 80% of the upper thrust range is squeezed into the
+ * upper half of the stick range).
+ *
+ * Note: in case MPC_THR_HOVER is set to 50%, the modes 0 and 1 are the same.
+ *
+ * @value 0 Rescale to hover thrust
+ * @value 1 No Rescale
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_INT32(MPC_THR_CURVE, 0);
+
+/**
  * Maximum thrust in auto thrust control
  *
  * Limit max allowed thrust

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -58,12 +58,14 @@ PARAM_DEFINE_FLOAT(MPC_THR_MIN, 0.12f);
  * Vertical thrust required to hover.
  * This value is mapped to center stick for manual throttle control.
  * With this value set to the thrust required to hover, transition
- * from manual to ALTCTL mode while hovering will occur with the
+ * from manual to Altitude or Position mode while hovering will occur with the
  * throttle stick near center, which is then interpreted as (near)
  * zero demand for vertical speed.
  *
+ * This parameter is also important for the landing detection to work correctly.
+ *
  * @unit norm
- * @min 0.2
+ * @min 0.1
  * @max 0.8
  * @decimal 2
  * @increment 0.01


### PR DESCRIPTION
For the land detector to work correctly the hover thrust param needs to be set correctly. However on powerful vehicles, where it's below 20%, this leads to a very distorted thrust curve in stabilized mode: 80% (or more) of the thurst is squeezed into the upper half of the throttle stick range.

So this adds a thrust curve parameter that can be used to disable the rescaling, so that the throttle stick is mapped directly 1:1 to the output in stabilized mode (same behavior as if hover throttle is at 50%).

The thrust curve parameter might be extended in future by other modes (e.g. square root).

This also removes the `LNDMC_THR_RANGE` param, because:
- no airframe sets it
- it does not make much sense to configure the 0.1 (=`LNDMC_THR_RANGE`) threshold for landing, but there's another hardcoded 0.3 threshold for ground contact detection.

@MaEtUgR as discussed, and thanks for the tips :)