### PR TITLE
[For Discussion] FlightTask: remove local position dependency for activating a task

### DIFF
--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
@@ -44,7 +44,7 @@ bool FlightTask::updateInitialize()
 	_time = (_time_stamp_current - _time_stamp_activate) / 1e6f;
 	_deltatime  = math::min((_time_stamp_current - _time_stamp_last), _timeout) / 1e6f;
 	_time_stamp_last = _time_stamp_current;
-	return _evaluateVehicleLocalPosition();
+	return true;
 }
 
 const vehicle_local_position_setpoint_s FlightTask::getPositionSetpoint()


### PR DESCRIPTION
Some vehicles such as racers don't have a local position.

So this removes the requirement from the base task, but we should discuss alternative options. I suggest something like:
- Requirement for a valid attitude in the base task
- Requirement for a valid altitude in alt control
- Requirement for a valid local pos in auto & pos ctrl modes

@Stifael what do you think?