### PR TITLE
[WIP] Fix bus scanning in irlock driver

### DIFF
--- a/src/drivers/irlock/irlock.cpp
+++ b/src/drivers/irlock/irlock.cpp
@@ -54,6 +54,8 @@
 #include <drivers/drv_irlock.h>
 #include <drivers/drv_hrt.h>
 
+#include <px4_getopt.h>
+
 #include <nuttx/clock.h>
 #include <nuttx/wqueue.h>
 #include <systemlib/err.h>
@@ -449,17 +451,28 @@ int irlock_main(int argc, char *argv[])
 {
 	int i2cdevice = IRLOCK_I2C_BUS;
 
-	/** jump over start/off/etc and look at options first **/
-	if (getopt(argc, argv, "b:") != EOF) {
-		i2cdevice = (int)strtol(optarg, NULL, 0);
+	int ch;
+	int myoptind = 1;
+	const char *myoptarg = nullptr;
+
+	while ((ch = px4_getopt(argc, argv, "b:", &myoptind, &myoptarg)) != EOF) {
+		switch (ch) {
+		case 'b':
+			i2cdevice = (uint8_t)atoi(myoptarg);
+			break;
+
+		default:
+			PX4_WARN("Unknown option!");
+			return -1;
+		}
 	}
 
-	if (optind >= argc) {
+	if (myoptind >= argc) {
 		irlock_usage();
 		exit(1);
 	}
 
-	const char *command = argv[optind];
+	const char *command = argv[myoptind];
 
 	/** start driver **/
 	if (!strcmp(command, "start")) {


### PR DESCRIPTION
-b flag was not working. Now driver can be started like this:
irlock start -b <i2c_bus>

On pixhawk 4:
i2ca: bus 4
i2c b: bus 2
gps port: bus 1

The default bus is number 1.

Now I will also implement the -a flag to scan all busses, but I just want to quickly change the driver format before I do this. I want to have the local functions for the shell commands instead of directly calling the start function inside the irlock class.