### PR TITLE
Tko altitude fix +  xy control

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -687,7 +687,7 @@ MulticopterPositionControl::run()
 				setpoint.thrust[0] = setpoint.thrust[1] = NAN;
 
 				if (PX4_ISFINITE(_states.velocity(0)) && PX4_ISFINITE(_states.velocity(1))) {
-					setpoint.vx = setpoint.vy = NAN; // try to keep zero velocity
+					setpoint.vx = setpoint.vy = 0.0f; // try to keep zero velocity
 
 				} else {
 					setpoint.thrust[0] = setpoint.thrust[1] = 0.0f; // just keeping pointing upwards

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -683,11 +683,9 @@ MulticopterPositionControl::run()
 				constraints.speed_up = _takeoff_speed;
 				// altitude above reference takeoff
 				const float alt_above_tko = -(_states.position(2) - _takeoff_reference_z);
-				// altitude threshold at which full control is enabled
-				const float alt_threshold = 0.5f; //at 0.5m above grouund, control all setpoints
 
 				// disable position-xy / yaw control when close to ground
-				if (alt_above_tko <= alt_threshold) {
+				if (alt_above_tko <= ALTITUDE_THRESHOLD) {
 					// don't control position in xy
 					setpoint.x = setpoint.y = NAN;
 					setpoint.vx = setpoint.vy = NAN;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -684,7 +684,14 @@ MulticopterPositionControl::run()
 				// don't control position in xy
 				setpoint.x = setpoint.y = NAN;
 				setpoint.vx = setpoint.vy = NAN;
-				setpoint.thrust[0] = setpoint.thrust[1] = 0.0f; // just keeping pointing upwards
+				setpoint.thrust[0] = setpoint.thrust[1] = NAN;
+
+				if (PX4_ISFINITE(_states.velocity(0)) && PX4_ISFINITE(_states.velocity(1))) {
+					setpoint.vx = setpoint.vy = NAN; // try to keep zero velocity
+
+				} else {
+					setpoint.thrust[0] = setpoint.thrust[1] = 0.0f; // just keeping pointing upwards
+				}
 			}
 
 			if (_vehicle_land_detected.landed && !_in_smooth_takeoff && !PX4_ISFINITE(setpoint.thrust[2])) {

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -161,7 +161,8 @@ private:
 	static constexpr int NUM_FAILURE_TRIES = 10;
 	/**< If Flighttask fails, keep 0.2 seconds the current setpoint before going into failsafe land */
 	static constexpr uint64_t LOITER_TIME_BEFORE_DESCEND = 200000;
-
+	/**< During smooth-takeoff, below ALTITUDE_THRESHOLD the yaw-control is turned off ant tilt is limited */
+	static constexpr float ALTITUDE_THRESHOLD = 0.3f;
 
 	/**
 	 * Hysteresis that turns true once vehicle is armed for MPC_IDLE_TKO seconds.

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -117,6 +117,8 @@ private:
 
 	float _takeoff_speed = -1.f; /**< For flighttask interface used only. It can be thrust or velocity setpoints */
 	float _takeoff_reference_z; /**< Z-position when takeoff was initiated */
+	bool _smooth_velocity_takeoff =
+		false; /**< Smooth velocity takeoff can be initiated either through position or velocity setpoint */
 
 	vehicle_status_s 			_vehicle_status{};		/**< vehicle status */
 	vehicle_land_detected_s 		_vehicle_land_detected{};	/**< vehicle land detected */
@@ -681,7 +683,8 @@ MulticopterPositionControl::run()
 				setpoint.yaw = setpoint.yawspeed = NAN;
 				// don't control position in xy
 				setpoint.x = setpoint.y = NAN;
-				setpoint.vx = setpoint.vy = 0.0f;
+				setpoint.vx = setpoint.vy = NAN;
+				setpoint.thrust[0] = setpoint.thrust[1] = 0.0f; // just keeping pointing upwards
 			}
 
 			if (_vehicle_land_detected.landed && !_in_smooth_takeoff && !PX4_ISFINITE(setpoint.thrust[2])) {
@@ -945,8 +948,10 @@ MulticopterPositionControl::check_for_smooth_takeoff(const float &z_sp, const fl
 		float min_altitude = PX4_ISFINITE(constraints.min_distance_to_ground) ? (constraints.min_distance_to_ground + 0.05f) :
 				     0.2f;
 
-		if ((PX4_ISFINITE(z_sp) && z_sp < _states.position(2) - min_altitude) ||
-		    (PX4_ISFINITE(vz_sp) && vz_sp < math::min(-_tko_speed.get(), -0.6f))) {
+		// takeoff was initiated through velocity setpoint
+		_smooth_velocity_takeoff = PX4_ISFINITE(vz_sp) && vz_sp < math::min(-_tko_speed.get(), -0.6f);
+
+		if ((PX4_ISFINITE(z_sp) && z_sp < _states.position(2) - min_altitude) ||  _smooth_velocity_takeoff) {
 			// There is a position setpoint above current position or velocity setpoint larger than
 			// takeoff speed. Enable smooth takeoff.
 			_in_smooth_takeoff = true;
@@ -970,7 +975,7 @@ MulticopterPositionControl::update_smooth_takeoff(const float &z_sp, const float
 		float desired_tko_speed = -vz_sp;
 
 		// If there is a valid position setpoint, then set the desired speed to the takeoff speed.
-		if (PX4_ISFINITE(z_sp)) {
+		if (!_smooth_velocity_takeoff) {
 			desired_tko_speed = _tko_speed.get();
 		}
 
@@ -979,7 +984,7 @@ MulticopterPositionControl::update_smooth_takeoff(const float &z_sp, const float
 		_takeoff_speed = math::min(_takeoff_speed, desired_tko_speed);
 
 		// Smooth takeoff is achieved once desired altitude/velocity setpoint is reached.
-		if (PX4_ISFINITE(z_sp)) {
+		if (!_smooth_velocity_takeoff) {
 			_in_smooth_takeoff = _states.position(2) - 0.2f > math::max(z_sp, _takeoff_reference_z - MPC_LAND_ALT2.get());
 
 		} else  {


### PR DESCRIPTION
The smooth altitude takeoff is broken if there is no velocity estimate available. In addition, xy control was turned off during smooth takeoff. Both issues are addressed in this PR. 
Instead of turning of xy control during smooth takeoff, the tilt is limited 

@PX4/testflights can you please test altitude takeoff when no gps is available (indoors) and compare it to current master. 