### PR TITLE
px_uploader.py: exit code=1 if upload was not successful

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -781,6 +781,7 @@ def main():
 
             baud_flightstack = [int(x) for x in args.baud_flightstack.split(',')]
 
+            successful = False
             for port in portlist:
 
                 # print("Trying %s" % port)
@@ -845,6 +846,9 @@ def main():
                     # ok, we have a bootloader, try flashing it
                     up.upload(fw, force=args.force, boot_delay=args.boot_delay)
 
+                    # if we made this far without raising exceptions, the upload was successful
+                    successful = True
+
                 except RuntimeError as ex:
                     # print the error
                     print("\nERROR: %s" % ex.args)
@@ -858,7 +862,10 @@ def main():
                     up.close()
 
                 # we could loop here if we wanted to wait for more boards...
-                sys.exit(0)
+                if successful:
+                    sys.exit(0)
+                else:
+                    sys.exit(1)
 
             # Delay retries to < 20 Hz to prevent spin-lock from hogging the CPU
             time.sleep(0.05)


### PR DESCRIPTION
In my setup, I am automating the autopilot's firmware upload/upgrade process in an [Ansible](https://en.wikipedia.org/wiki/Ansible_(software)) workflow.
In doing this, it is critical to know (programmatically) whether the upload process succeeded or failed.

Currently, `px_uploader.py` exits with a return code of 0 even if the upload fails (for example, if an `IOError` or a `RuntimeError` are thrown and then [caught](https://github.com/PX4/Firmware/blob/e167e6bec49b680c89a52e60fe4053924b835299/Tools/px_uploader.py#L848) in the main loop).
It would be nice to let the caller know if the upload failed by returning a non-zero exit code.

This simple patch does the job, by assuming that the upload succeeded if and only if an invocation of the [`uploader.upload`](https://github.com/PX4/Firmware/blob/e167e6bec49b680c89a52e60fe4053924b835299/Tools/px_uploader.py#L573) method succeeds without exceptions.
