### PR TITLE
Fix for flight task to allow attitude estimator only.

### DIFF
--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
@@ -135,14 +135,11 @@ bool FlightTask::_evaluateVehicleLocalPosition()
 						  _sub_vehicle_local_position->get().ref_alt, _sub_vehicle_local_position->get().ref_timestamp);
 		}
 
-		// We don't check here if states are valid or not.
-		// Validity checks are done in the sub-classes.
-		return true;
-
-	} else {
-		_resetSetpoints();
-		return false;
 	}
+
+	// We don't check here if states are valid or not.
+	// Validity checks are done in the sub-classes.
+	return true;
 }
 
 void FlightTask::_setDefaultConstraints()


### PR DESCRIPTION
FlightTasks requires a local position publication. I'm doing some development with an attitude only estimator and don't see why we need position publication to fly in manual.

This PR simply always returns true and doesn't reset the set points if the position publication is not being sent. It was continually calling and resetting my yaw setpoint which was an issue. Also if I don't return true it will not allow control after arming due to the failed return status.

I think it is important that we sync on this and that it doesn't cause any edge cases by always returning true.
