### PR TITLE
rtps: fix and minor cleanup of scripts and templates

### DIFF
--- a/msg/templates/urtps/RtpsTopics.cpp.template
+++ b/msg/templates/urtps/RtpsTopics.cpp.template
@@ -17,7 +17,6 @@ import gencpp
 from px_generate_uorb_topic_helper import * # this is in Tools/
 from px_generate_uorb_topic_files import MsgScope # this is in Tools/
 
-topic_names = [single_spec.short_name for single_spec in spec]
 send_topics = [s.short_name for idx, s in enumerate(spec) if scope[idx] == MsgScope.SEND]
 recv_topics = [s.short_name for idx, s in enumerate(spec) if scope[idx] == MsgScope.RECEIVE]
 }@

--- a/msg/tools/generate_microRTPS_bridge.py
+++ b/msg/tools/generate_microRTPS_bridge.py
@@ -81,18 +81,30 @@ def check_rtps_id_uniqueness(classifier):
 
     # check if there are repeated ID's on the messages to send
     for key, value in classifier.msgs_to_send.items():
-        if classifier.msgs_to_send.values().count(value) > 1:
-            repeated_ids.update({key: value})
+        if sys.version_info[0] < 3:
+            if classifier.msgs_to_send.values().count(value) > 1:
+                repeated_ids.update({key: value})
+        else:
+            if list(classifier.msgs_to_send.values()).count(value) > 1:
+                repeated_ids.update({key: value})
 
     # check if there are repeated ID's on the messages to receive
     for key, value in classifier.msgs_to_receive.items():
-        if classifier.msgs_to_receive.values().count(value) > 1:
-            repeated_ids.update({key: value})
+        if sys.version_info[0] < 3:
+            if classifier.msgs_to_receive.values().count(value) > 1:
+                repeated_ids.update({key: value})
+        else:
+            if list(classifier.msgs_to_receive.values()).count(value) > 1:
+                repeated_ids.update({key: value})
 
     # check if there are repeated ID's on the messages to ignore
     for key, value in classifier.msgs_to_ignore.items():
-        if classifier.msgs_to_ignore.values().count(value) > 1:
-            repeated_ids.update({key: value})
+        if sys.version_info[0] < 3:
+            if classifier.msgs_to_ignore.values().count(value) > 1:
+                repeated_ids.update({key: value})
+        else:
+            if list(classifier.msgs_to_ignore.values()).count(value) > 1:
+                repeated_ids.update({key: value})
 
     # check if there are repeated IDs between classfied and unclassified msgs
     # check send and ignore lists
@@ -122,7 +134,11 @@ def check_rtps_id_uniqueness(classifier):
     all_msgs = classifier.msgs_to_send
     all_msgs.update(classifier.msgs_to_receive)
     all_msgs.update(classifier.msgs_to_ignore)
-    all_ids = all_msgs.values()
+    all_ids = list()
+    if sys.version_info[0] < 3:
+        all_ids = all_msgs.values()
+    else:
+        all_ids = list(all_msgs.values())
     all_ids.sort()
 
     if not repeated_ids:

--- a/msg/tools/uorb_rtps_classifier.py
+++ b/msg/tools/uorb_rtps_classifier.py
@@ -53,39 +53,6 @@ class Classifier():
         self.msg_files_receive = self.set_msg_files_receive()
         self.msg_files_ignore = self.set_msg_files_ignore()
 
-    # getters
-    @property
-    def msg_id_map(self):
-        return self.__msg_id_map
-
-    @property
-    def msg_folder(self):
-        return self.__msg_folder
-
-    @property
-    def msgs_to_send(self):
-        return self.__msgs_to_send
-
-    @property
-    def msgs_to_receive(self):
-        return self.__msgs_to_receive
-
-    @property
-    def msgs_to_ignore(self):
-        return self.__msgs_to_ignore
-
-    @property
-    def msg_files_send(self):
-        return self.__msg_files_send
-
-    @property
-    def msg_files_receive(self):
-        return self.__msg_files_receive
-
-    @property
-    def msg_files_ignore(self):
-        return self.__msg_files_ignore
-
     # setters (for class init)
     def set_msgs_to_send(self):
         send = {}
@@ -156,7 +123,9 @@ if __name__ == "__main__":
     # Parse arguments
     args = parser.parse_args()
 
-    msg_folder = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    msg_folder = args.msgdir
+    if args.msgdir == 'msg':
+        msg_folder = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     classifier = Classifier(os.path.join(
         msg_folder, args.yaml_file), msg_folder)
 


### PR DESCRIPTION
This represents some minor fixes and cleanups required to use the RPTS headers and sources generators outside the PX4 Firmware, more in specific, in the upcoming `px4_ros_com` package.

- properly handle `dict_values` depending on the Python version;
- `uorb_rtps_classifier.py`: delete unused properties;
- `uorb_rtps_classifier.py`: fix `msgdir` arg parsing
