### PR TITLE
moved comment from class section to avoid PX4Buildbot confusion

### DIFF
--- a/ROMFS/px4fmu_common/init.d/2200_mini_talon
+++ b/ROMFS/px4fmu_common/init.d/2200_mini_talon
@@ -5,10 +5,6 @@
 # @type Plane V-Tail
 # @class Plane
 #
-# The Mini Talon does not have a wheel and
-# no flaps. I leave them here because the mixer
-# computes also wheel and flap controls.
-#
 # @output MAIN1 aileron right
 # @output MAIN2 aileron left
 # @output MAIN3 v-tail right
@@ -47,6 +43,9 @@ then
 	param set PWM_DISARMED 1000
 fi
 
+# The Mini Talon does not have a wheel and
+# no flaps. I leave them here because the mixer
+# computes also wheel and flap controls.
 set MIXER AAVVTWFF_vtail
 
 # use PWM parameters for throttle channel


### PR DESCRIPTION
The PX4BuildBot extracted the comments from the lines following the class line which says "Plane" as the class. This was generated in PR mavlink/qgroundcontrol#6923. To avoid the confusion for the bot I moved the comment further down out of the section which is parsed by various bots.

The problem occured after PR #10414 was merged.
