### PR TITLE
AV-X mavlink network and companion defaults

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.mavlink
+++ b/ROMFS/px4fmu_common/init.d/rc.mavlink
@@ -17,6 +17,14 @@ then
 	mavlink start -r 20000 -b 921600 -d /dev/ttyS0
 fi
 
+if ver hwcmp AV_X_V1
+then
+	# AV-X: start MAVLink to companion (connected to TX2)
+	mavlink start -d /dev/ttyS5 -r 80000 -b 921600 -m onboard
+
+	# AV-X: start MAVLink UDP port 14570
+	mavlink start -x -u 14570
+fi
 
 #
 # SYS_COMPANION transition support. Can be removed after the next release (currently at 1.8.0)


### PR DESCRIPTION
 - start mavlink on network by default (port 14570)
 - start mavlink for TX2 companion by default
