### PR TITLE
Tracking anti-reset windup for multicopter velocity controller

### DIFF
--- a/src/modules/mc_pos_control/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl.cpp
@@ -305,25 +305,17 @@ void PositionControl::_velocityController(const float &dt)
 			_thr_sp(1) = thrust_desired_NE(1) / mag * thrust_max_NE;
 		}
 
-		// Get the direction of (r-y) in NE-direction.
-		float direction_NE = Vector2f(vel_err) * Vector2f(_vel_sp);
+		// Use tracking Anti-Windup for NE-direction: during saturation, the integrator is used to unsaturate the output
+		// see Anti-Reset Windup for PID controllers, L.Rundqwist, 1990
+		float arw_gain = 2.f / MPC_XY_VEL_P.get();
 
-		// Apply Anti-Windup in NE-direction.
-		bool stop_integral_NE = (thrust_desired_NE * thrust_desired_NE >= thrust_max_NE * thrust_max_NE &&
-					 direction_NE >= 0.0f);
+		Vector2f vel_err_lim;
+		vel_err_lim(0) = vel_err(0) - (thrust_desired_NE(0) - _thr_sp(0)) * arw_gain;
+		vel_err_lim(1) = vel_err(1) - (thrust_desired_NE(1) - _thr_sp(1)) * arw_gain;
 
-		if (!stop_integral_NE) {
-			_thr_int(0) += vel_err(0) * MPC_XY_VEL_I.get() * dt;
-			_thr_int(1) += vel_err(1) * MPC_XY_VEL_I.get() * dt;
-
-			// magnitude of thrust integral can never exceed maximum throttle in NE
-			float integral_mag_NE = Vector2f(_thr_int).length();
-
-			if (integral_mag_NE > 0.0f && integral_mag_NE > thrust_max_NE) {
-				_thr_int(0) = _thr_int(0) / integral_mag_NE * thrust_max_NE;
-				_thr_int(1) = _thr_int(1) / integral_mag_NE * thrust_max_NE;
-			}
-		}
+		// Update integral
+		_thr_int(0) += MPC_XY_VEL_I.get() * vel_err_lim(0) * dt;
+		_thr_int(1) += MPC_XY_VEL_I.get() * vel_err_lim(1) * dt;
 	}
 }
 

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -214,7 +214,7 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_P, 0.09f);
 /**
  * Integral gain for horizontal velocity error
  *
- * Non-zero value allows to resist wind.
+ * Non-zero value allows to eliminate steady state errors in the presence of disturbances like wind.
  *
  * @min 0.0
  * @max 3.0

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -217,7 +217,7 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_P, 0.09f);
  * Non-zero value allows to resist wind.
  *
  * @min 0.0
- * @max 0.1
+ * @max 3.0
  * @decimal 3
  * @group Multicopter Position Control
  */


### PR DESCRIPTION
Replaces #10636 
The tracking anti-reset windup is widely used in industry as it is simple to implement and give good performances. It gives similar performance to the conditional integration method during step responses and reduces the delay in some special cases (e.g.:ramp-saturation-negative step).

One other main advantage is that it simplifies the code, no `if` statement required!

The ARW gain is computed automatically as it is shown in this [paper](https://www.sciencedirect.com/science/article/pii/S1474667017518650) that a good choice of this time constant is `Tt = 0.5*Ti`. Since in our case, `Ki = Kp/Ti` and `Karw = 1/(Tt*Ki)` (we correct the error, before the integral gain, unlike in the schematic below), the ARW gain becomes `Karw = 2 / Kp`.
![tracking_arw](https://user-images.githubusercontent.com/14822839/47032402-902ac880-d172-11e8-94c0-4a51a315229c.png)
(Image from _Anti-Reset Windup for PID Controllers_, L. Rundqwist, 1990, )
@Stifael I left the Z integrator with the current conditional integration method as in my opinion, it is good that the integral stays loaded with the required force to compensate gravity, even during saturation.

Log from a survey, before this PR: 
https://logs.px4.io/plot_app?log=22a4db3b-163f-4175-8be9-c762e550e2a5
Log from the same survey, with this PR: 
https://logs.px4.io/plot_app?log=35f24468-a378-4058-8da5-7da39aee79bd