### PR TITLE
Collision avoidance pos ctrl

### DIFF
--- a/msg/vehicle_constraints.msg
+++ b/msg/vehicle_constraints.msg
@@ -10,7 +10,8 @@ float32 speed_down	# in meters/sec
 float32 tilt    # in radians [0, PI]
 float32 min_distance_to_ground # in meters
 float32 max_distance_to_ground # in meters
-float32[4] velocity_limits    # maximum velocities determined by range sensor measurements [x positive, y positive, x negative, y negative] direction.
+float32[2] velocity_limits_x   # maximum velocities determined by range sensor measurements [x positive, x negative]
+float32[2] velocity_limits_y   # maximum velocities determined by range sensor measurements [y positive, y negative]
 
 int8 GEAR_DOWN = -1
 int8 GEAR_UP = 1

--- a/msg/vehicle_constraints.msg
+++ b/msg/vehicle_constraints.msg
@@ -10,6 +10,7 @@ float32 speed_down	# in meters/sec
 float32 tilt    # in radians [0, PI]
 float32 min_distance_to_ground # in meters
 float32 max_distance_to_ground # in meters
+float32[4] velocity_limits    # maximum velocities determined by range sensor measurements [x positive, y positive, x negative, y negative] direction.
 
 int8 GEAR_DOWN = -1
 int8 GEAR_UP = 1

--- a/src/lib/FlightTasks/FlightTasks.cpp
+++ b/src/lib/FlightTasks/FlightTasks.cpp
@@ -47,7 +47,7 @@ const vehicle_constraints_s FlightTasks::getConstraints()
 	}
 }
 
-void FlightTasks::setConstraints(vehicle_constraints_s& constraints)
+void FlightTasks::setConstraints(vehicle_constraints_s &constraints)
 {
 	if (isAnyTaskActive()) {
 		_current_task.task->setConstraints(constraints);

--- a/src/lib/FlightTasks/FlightTasks.cpp
+++ b/src/lib/FlightTasks/FlightTasks.cpp
@@ -47,6 +47,13 @@ const vehicle_constraints_s FlightTasks::getConstraints()
 	}
 }
 
+void FlightTasks::setConstraints(vehicle_constraints_s& constraints)
+{
+	if (isAnyTaskActive()) {
+		_current_task.task->setConstraints(constraints);
+	}
+}
+
 const vehicle_trajectory_waypoint_s FlightTasks::getAvoidanceWaypoint()
 {
 	if (isAnyTaskActive()) {

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -79,6 +79,11 @@ public:
 	const vehicle_constraints_s getConstraints();
 
 	/**
+	 * Set task dependent constraints
+	 */
+	void setConstraints(vehicle_constraints_s& constraints);
+
+	/**
 	 * Get task avoidance desired waypoints
 	 * @return auto triplets in the mc_pos_control
 	 */

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -81,7 +81,7 @@ public:
 	/**
 	 * Set task dependent constraints
 	 */
-	void setConstraints(vehicle_constraints_s& constraints);
+	void setConstraints(vehicle_constraints_s &constraints);
 
 	/**
 	 * Get task avoidance desired waypoints

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
@@ -6,7 +6,7 @@ constexpr uint64_t FlightTask::_timeout;
 // First index of empty_setpoint corresponds to time-stamp and requires a finite number.
 const vehicle_local_position_setpoint_s FlightTask::empty_setpoint = {0, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, {NAN, NAN, NAN}};
 
-const vehicle_constraints_s FlightTask::empty_constraints = {0, NAN, NAN, NAN, NAN, NAN, NAN, NAN, {}, vehicle_constraints_s::GEAR_KEEP, {}};
+const vehicle_constraints_s FlightTask::empty_constraints = {0, NAN, NAN, NAN, NAN, NAN, NAN, NAN, {}, {}, vehicle_constraints_s::GEAR_KEEP, {}};
 const vehicle_trajectory_waypoint_s FlightTask::empty_trajectory_waypoint = {0, 0, {0, 0, 0, 0, 0, 0, 0},
 	{	{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false, {0, 0, 0}},
 		{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false, {0, 0, 0}},
@@ -132,10 +132,10 @@ void FlightTask::_evaluateVehicleLocalPosition()
 
 void FlightTask::_setDefaultConstraints()
 {
-	_constraints.velocity_limits[0] = MPC_XY_VEL_MAX.get();
-	_constraints.velocity_limits[1] = MPC_XY_VEL_MAX.get();
-	_constraints.velocity_limits[2] = MPC_XY_VEL_MAX.get();
-	_constraints.velocity_limits[3] = MPC_XY_VEL_MAX.get();
+	_constraints.velocity_limits_x[0] = MPC_XY_VEL_MAX.get();
+	_constraints.velocity_limits_x[1] = MPC_XY_VEL_MAX.get();
+	_constraints.velocity_limits_y[0] = MPC_XY_VEL_MAX.get();
+	_constraints.velocity_limits_y[1] = MPC_XY_VEL_MAX.get();
 	_constraints.speed_xy = MPC_XY_VEL_MAX.get();
 	_constraints.speed_up = MPC_Z_VEL_MAX_UP.get();
 	_constraints.speed_down = MPC_Z_VEL_MAX_DN.get();

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
@@ -6,7 +6,7 @@ constexpr uint64_t FlightTask::_timeout;
 // First index of empty_setpoint corresponds to time-stamp and requires a finite number.
 const vehicle_local_position_setpoint_s FlightTask::empty_setpoint = {0, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, {NAN, NAN, NAN}};
 
-const vehicle_constraints_s FlightTask::empty_constraints = {0, NAN, NAN, NAN, NAN, NAN, NAN, NAN, vehicle_constraints_s::GEAR_KEEP, {}};
+const vehicle_constraints_s FlightTask::empty_constraints = {0, NAN, NAN, NAN, NAN, NAN, NAN, NAN, {}, vehicle_constraints_s::GEAR_KEEP, {}};
 const vehicle_trajectory_waypoint_s FlightTask::empty_trajectory_waypoint = {0, 0, {0, 0, 0, 0, 0, 0, 0},
 	{	{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false, {0, 0, 0}},
 		{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false, {0, 0, 0}},
@@ -132,6 +132,10 @@ void FlightTask::_evaluateVehicleLocalPosition()
 
 void FlightTask::_setDefaultConstraints()
 {
+	_constraints.velocity_limits[0] = MPC_XY_VEL_MAX.get();
+	_constraints.velocity_limits[1] = MPC_XY_VEL_MAX.get();
+	_constraints.velocity_limits[2] = MPC_XY_VEL_MAX.get();
+	_constraints.velocity_limits[3] = MPC_XY_VEL_MAX.get();
 	_constraints.speed_xy = MPC_XY_VEL_MAX.get();
 	_constraints.speed_up = MPC_Z_VEL_MAX_UP.get();
 	_constraints.speed_down = MPC_Z_VEL_MAX_DN.get();

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
@@ -110,6 +110,12 @@ public:
 	const vehicle_constraints_s &getConstraints() { return _constraints; }
 
 	/**
+	 * Set vehicle constraints.
+	 * The constraints can vary with task.
+	 */
+	void setConstraints(vehicle_constraints_s& constraints) { _constraints = constraints; }
+
+	/**
 	 * Get avoidance desired waypoint
 	 * @return desired waypoints
 	 */

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
@@ -219,6 +219,8 @@ protected:
 					(ParamFloat<px4::params::MPC_XY_VEL_MAX>) MPC_XY_VEL_MAX,
 					(ParamFloat<px4::params::MPC_Z_VEL_MAX_DN>) MPC_Z_VEL_MAX_DN,
 					(ParamFloat<px4::params::MPC_Z_VEL_MAX_UP>) MPC_Z_VEL_MAX_UP,
-					(ParamFloat<px4::params::MPC_TILTMAX_AIR>) MPC_TILTMAX_AIR
-				       )
+					(ParamFloat<px4::params::MPC_TILTMAX_AIR>) MPC_TILTMAX_AIR,
+					(ParamInt<px4::params::MPC_USE_OBS_SENS>) MPC_USE_OBS_SENS,
+					(ParamFloat<px4::params::MPC_MIN_OBS_DIST>) MPC_MIN_OBS_DIST
+					)
 };

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
@@ -113,7 +113,7 @@ public:
 	 * Set vehicle constraints.
 	 * The constraints can vary with task.
 	 */
-	void setConstraints(vehicle_constraints_s& constraints) { _constraints = constraints; }
+	void setConstraints(vehicle_constraints_s &constraints) { _constraints = constraints; }
 
 	/**
 	 * Get avoidance desired waypoint
@@ -220,7 +220,7 @@ protected:
 					(ParamFloat<px4::params::MPC_Z_VEL_MAX_DN>) MPC_Z_VEL_MAX_DN,
 					(ParamFloat<px4::params::MPC_Z_VEL_MAX_UP>) MPC_Z_VEL_MAX_UP,
 					(ParamFloat<px4::params::MPC_TILTMAX_AIR>) MPC_TILTMAX_AIR,
-					(ParamInt<px4::params::MPC_USE_OBS_SENS>) MPC_USE_OBS_SENS,
-					(ParamFloat<px4::params::MPC_MIN_OBS_DIST>) MPC_MIN_OBS_DIST
-					)
+					(ParamInt<px4::params::MPC_OBS_SENS_EN>) MPC_OBS_SENS_EN,
+					(ParamFloat<px4::params::MPC_OBS_MIN_DIST>) MPC_OBS_MIN_DIST
+				       )
 };

--- a/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -120,13 +120,13 @@ void FlightTaskManualPosition::_scaleSticks()
 		float vel_mag = sqrt(vel_sp_xy(0) * vel_sp_xy(0) + vel_sp_xy(1) * vel_sp_xy(1));
 		float v_max_x, v_max_y;
 
-		if (vel_mag > 0) {
+		if (vel_mag > 0.0f) {
 			v_max_x = abs(_constraints.speed_xy / vel_mag * vel_sp_xy(0));
 			v_max_y = abs(_constraints.speed_xy / vel_mag * vel_sp_xy(1));
 
 		} else {
-			v_max_x = 0.f;
-			v_max_y = 0.f;
+			v_max_x = 0.0f;
+			v_max_y = 0.0f;
 		}
 
 		//scale the velocity reductions with the maximum possible velocity along the respective axis

--- a/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -112,6 +112,11 @@ void FlightTaskManualPosition::_scaleSticks()
 
 	/* Rotate setpoint into local frame. */
 	_rotateIntoHeadingFrame(vel_sp_xy);
+
+	/*constrain setpoint to not collide with obstacles */
+	vel_sp_xy(0) = math::max(-_constraints.velocity_limits[2], math::min(vel_sp_xy(0), _constraints.velocity_limits[0]));
+	vel_sp_xy(1) = math::max(-_constraints.velocity_limits[3], math::min(vel_sp_xy(1), _constraints.velocity_limits[1]));
+
 	_velocity_setpoint(0) = vel_sp_xy(0);
 	_velocity_setpoint(1) = vel_sp_xy(1);
 }

--- a/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -130,20 +130,20 @@ void FlightTaskManualPosition::_scaleSticks()
 		}
 
 		//scale the velocity reductions with the maximum possible velocity along the respective axis
-		_constraints.velocity_limits[0] *= v_max_x;
-		_constraints.velocity_limits[1] *= v_max_y;
-		_constraints.velocity_limits[2] *= v_max_x;
-		_constraints.velocity_limits[3] *= v_max_y;
+		_constraints.velocity_limits_x[0] *= v_max_x;
+		_constraints.velocity_limits_y[0] *= v_max_y;
+		_constraints.velocity_limits_x[1] *= v_max_x;
+		_constraints.velocity_limits_y[1] *= v_max_y;
 
 		//apply the velocity reductions to form velocity limits
-		_constraints.velocity_limits[0] = v_max_x - _constraints.velocity_limits[0];
-		_constraints.velocity_limits[1] = v_max_y - _constraints.velocity_limits[1];
-		_constraints.velocity_limits[2] = v_max_x - _constraints.velocity_limits[2];
-		_constraints.velocity_limits[3] = v_max_y - _constraints.velocity_limits[3];
+		_constraints.velocity_limits_x[0] = v_max_x - _constraints.velocity_limits_x[0];
+		_constraints.velocity_limits_y[0] = v_max_y - _constraints.velocity_limits_y[0];
+		_constraints.velocity_limits_x[1] = v_max_x - _constraints.velocity_limits_x[1];
+		_constraints.velocity_limits_y[1] = v_max_y - _constraints.velocity_limits_y[1];
 
 		//constrain the velocity setpoint to respect the velocity limits
-		vel_sp_xy(0) = math::constrain(vel_sp_xy(0), -_constraints.velocity_limits[2], _constraints.velocity_limits[0]);
-		vel_sp_xy(1) = math::constrain(vel_sp_xy(1), -_constraints.velocity_limits[3], _constraints.velocity_limits[1]);
+		vel_sp_xy(0) = math::constrain(vel_sp_xy(0), -_constraints.velocity_limits_x[1], _constraints.velocity_limits_x[0]);
+		vel_sp_xy(1) = math::constrain(vel_sp_xy(1), -_constraints.velocity_limits_y[1], _constraints.velocity_limits_y[0]);
 	}
 
 	_velocity_setpoint(0) = vel_sp_xy(0);

--- a/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -142,8 +142,17 @@ void FlightTaskManualPosition::_scaleSticks()
 		_constraints.velocity_limits_y[1] = v_max_y - _constraints.velocity_limits_y[1];
 
 		//constrain the velocity setpoint to respect the velocity limits
-		vel_sp_xy(0) = math::constrain(vel_sp_xy(0), -_constraints.velocity_limits_x[1], _constraints.velocity_limits_x[0]);
-		vel_sp_xy(1) = math::constrain(vel_sp_xy(1), -_constraints.velocity_limits_y[1], _constraints.velocity_limits_y[0]);
+		Vector2f vel_sp_xy_new = vel_sp_xy;
+		vel_sp_xy_new(0) = math::constrain(vel_sp_xy(0), -_constraints.velocity_limits_x[1], _constraints.velocity_limits_x[0]);
+		vel_sp_xy_new(1) = math::constrain(vel_sp_xy(1), -_constraints.velocity_limits_y[1], _constraints.velocity_limits_y[0]);
+
+		//warn user if collision avoidance starts to interfere
+		bool interfering = (vel_sp_xy_new(0) < 0.95f * vel_sp_xy(0) || vel_sp_xy_new(0) > 1.05f * vel_sp_xy(0) || vel_sp_xy_new(1) < 0.95f * vel_sp_xy(1) || vel_sp_xy_new(1) > 1.05f * vel_sp_xy(1));
+		if(interfering && (interfering != _avoidance_interfering)){
+			PX4_INFO_RAW("AVOIDANCE STARTS INTERFERING\n");
+		}
+		_avoidance_interfering = interfering;
+		vel_sp_xy = vel_sp_xy_new;
 	}
 
 	_velocity_setpoint(0) = vel_sp_xy(0);

--- a/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -114,8 +114,10 @@ void FlightTaskManualPosition::_scaleSticks()
 	_rotateIntoHeadingFrame(vel_sp_xy);
 
 	/*constrain setpoint to not collide with obstacles */
-	vel_sp_xy(0) = math::max(-_constraints.velocity_limits[2], math::min(vel_sp_xy(0), _constraints.velocity_limits[0]));
-	vel_sp_xy(1) = math::max(-_constraints.velocity_limits[3], math::min(vel_sp_xy(1), _constraints.velocity_limits[1]));
+	if(MPC_USE_OBS_SENS.get()){
+		vel_sp_xy(0) = math::max(-_constraints.velocity_limits[2], math::min(vel_sp_xy(0), _constraints.velocity_limits[0]));
+		vel_sp_xy(1) = math::max(-_constraints.velocity_limits[3], math::min(vel_sp_xy(1), _constraints.velocity_limits[1]));
+	}
 
 	_velocity_setpoint(0) = vel_sp_xy(0);
 	_velocity_setpoint(1) = vel_sp_xy(1);

--- a/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -114,15 +114,17 @@ void FlightTaskManualPosition::_scaleSticks()
 	_rotateIntoHeadingFrame(vel_sp_xy);
 
 	/*constrain setpoint to not collide with obstacles */
-	if(MPC_USE_OBS_SENS.get()){
+	if (MPC_OBS_SENS_EN.get()) {
 
 		// calculate the maximum velocity along x,y axis when moving in the demanded direction
 		float vel_mag = sqrt(vel_sp_xy(0) * vel_sp_xy(0) + vel_sp_xy(1) * vel_sp_xy(1));
 		float v_max_x, v_max_y;
-		if(vel_mag > 0){
-			v_max_x = abs(_constraints.speed_xy/vel_mag * vel_sp_xy(0));
-			v_max_y = abs(_constraints.speed_xy/vel_mag * vel_sp_xy(1));
-		}else{
+
+		if (vel_mag > 0) {
+			v_max_x = abs(_constraints.speed_xy / vel_mag * vel_sp_xy(0));
+			v_max_y = abs(_constraints.speed_xy / vel_mag * vel_sp_xy(1));
+
+		} else {
 			v_max_x = 0.f;
 			v_max_y = 0.f;
 		}
@@ -136,10 +138,10 @@ void FlightTaskManualPosition::_scaleSticks()
 		//apply the velocity reductions to form velocity limits
 		_constraints.velocity_limits[0] = v_max_x - _constraints.velocity_limits[0];
 		_constraints.velocity_limits[1] = v_max_y - _constraints.velocity_limits[1];
-	    _constraints.velocity_limits[2] = v_max_x - _constraints.velocity_limits[2];
-	    _constraints.velocity_limits[3] = v_max_y - _constraints.velocity_limits[3];
+		_constraints.velocity_limits[2] = v_max_x - _constraints.velocity_limits[2];
+		_constraints.velocity_limits[3] = v_max_y - _constraints.velocity_limits[3];
 
-	    //constrain the velocity setpoint to respect the velocity limits
+		//constrain the velocity setpoint to respect the velocity limits
 		vel_sp_xy(0) = math::constrain(vel_sp_xy(0), -_constraints.velocity_limits[2], _constraints.velocity_limits[0]);
 		vel_sp_xy(1) = math::constrain(vel_sp_xy(1), -_constraints.velocity_limits[3], _constraints.velocity_limits[1]);
 	}

--- a/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.hpp
+++ b/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.hpp
@@ -65,4 +65,5 @@ protected:
 private:
 	float _velocity_scale{0.0f}; //scales the stick input to velocity
 	uint8_t _reset_counter{0}; /**< counter for estimator resets in xy-direction */
+	bool _avoidance_interfering = false;
 };

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -649,6 +649,8 @@ void Logger::add_default_topics()
 	add_topic("vehicle_vision_position");
 	add_topic("vtol_vehicle_status", 200);
 	add_topic("wind_estimate", 200);
+	add_topic("vehicle_constraints");
+	add_topic("obstacle_distance");
 
 #ifdef CONFIG_ARCH_BOARD_SITL
 	add_topic("actuator_armed");

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1133,10 +1133,10 @@ void
 MulticopterPositionControl::update_range_constraints(const obstacle_distance_s &obstacle_distance,
 		vehicle_constraints_s &constraints)
 {
-	constraints.velocity_limits[0] = 0.0;
-	constraints.velocity_limits[1] = 0.0;
-	constraints.velocity_limits[2] = 0.0;
-	constraints.velocity_limits[3] = 0.0;
+	constraints.velocity_limits_x[0] = 0.0;
+	constraints.velocity_limits_x[1] = 0.0;
+	constraints.velocity_limits_y[0] = 0.0;
+	constraints.velocity_limits_y[1] = 0.0;
 
 	float max_detection_distance = obstacle_distance.max_distance/100.0; //convert to meters
 
@@ -1152,10 +1152,10 @@ MulticopterPositionControl::update_range_constraints(const obstacle_distance_s &
 			//calculate normalized velocity reductions
 			float vel_lim_x =  (max_detection_distance - distance)/(max_detection_distance - MPC_OBS_MIN_DIST.get()) * cos(angle);
 			float vel_lim_y =  (max_detection_distance - distance)/(max_detection_distance - MPC_OBS_MIN_DIST.get()) * sin(angle);
-			if(vel_lim_x > 0 && vel_lim_x > constraints.velocity_limits[0]) constraints.velocity_limits[0] = vel_lim_x;
-			if(vel_lim_y > 0 && vel_lim_y > constraints.velocity_limits[1]) constraints.velocity_limits[1] = vel_lim_y;
-			if(vel_lim_x < 0 && -vel_lim_x > constraints.velocity_limits[2]) constraints.velocity_limits[2] = -vel_lim_x;
-			if(vel_lim_y < 0 && -vel_lim_y > constraints.velocity_limits[3]) constraints.velocity_limits[3] = -vel_lim_y;
+			if(vel_lim_x > 0 && vel_lim_x > constraints.velocity_limits_x[0]) constraints.velocity_limits_x[0] = vel_lim_x;
+			if(vel_lim_y > 0 && vel_lim_y > constraints.velocity_limits_y[0]) constraints.velocity_limits_y[0] = vel_lim_y;
+			if(vel_lim_x < 0 && -vel_lim_x > constraints.velocity_limits_x[1]) constraints.velocity_limits_x[1] = -vel_lim_x;
+			if(vel_lim_y < 0 && -vel_lim_y > constraints.velocity_limits_y[1]) constraints.velocity_limits_y[1] = -vel_lim_y;
 		}
 	}
 	publish_constraints(constraints);

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -736,6 +736,7 @@ MulticopterPositionControl::run()
 			//use range sensor to update constraints
 			//TODO: create parameter to switch on and off
 			update_range_constraints(_obstacle_distance, constraints);
+			_flight_tasks.setConstraints(constraints);
 
 
 			// Update states, setpoints and constraints.

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1133,12 +1133,12 @@ void
 MulticopterPositionControl::update_range_constraints(const obstacle_distance_s &obstacle_distance,
 		vehicle_constraints_s &constraints)
 {
-	constraints.velocity_limits_x[0] = 0.0;
-	constraints.velocity_limits_x[1] = 0.0;
-	constraints.velocity_limits_y[0] = 0.0;
-	constraints.velocity_limits_y[1] = 0.0;
+	constraints.velocity_limits_x[0] = 0.0f;
+	constraints.velocity_limits_x[1] = 0.0f;
+	constraints.velocity_limits_y[0] = 0.0f;
+	constraints.velocity_limits_y[1] = 0.0f;
 
-	float max_detection_distance = obstacle_distance.max_distance/100.0; //convert to meters
+	float max_detection_distance = obstacle_distance.max_distance/100.0f; //convert to meters
 
 	for(int i = 0; i<72; i++){
 
@@ -1146,7 +1146,7 @@ MulticopterPositionControl::update_range_constraints(const obstacle_distance_s &
 		if(obstacle_distance.distances[i] < obstacle_distance.max_distance &&
 				obstacle_distance.distances[i] > obstacle_distance.min_distance && i*obstacle_distance.increment < 360){
 
-			float distance = obstacle_distance.distances[i]/100.0; //convert to meters
+			float distance = obstacle_distance.distances[i]/100.0f; //convert to meters
 			float angle = i*obstacle_distance.increment * (M_PI/180.0);
 
 			//calculate normalized velocity reductions

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -55,6 +55,7 @@
 #include <uORB/topics/vehicle_local_position_setpoint.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_trajectory_waypoint.h>
+#include <uORB/topics/obstacle_distance.h>
 
 #include <float.h>
 #include <mathlib/mathlib.h>
@@ -112,6 +113,7 @@ private:
 	int		_local_pos_sub{-1};			/**< vehicle local position */
 	int		_home_pos_sub{-1}; 			/**< home position */
 	int		_traj_wp_avoidance_sub{-1};	/**< trajectory waypoint */
+	int		_range_sensor_sub{-1};	/**< obstacle distances */
 
 	int _task_failure_count{0};         /**< counter for task failures */
 
@@ -128,6 +130,7 @@ private:
 	home_position_s				_home_pos{};			/**< home position */
 	vehicle_trajectory_waypoint_s		_traj_wp_avoidance{};		/**< trajectory waypoint */
 	vehicle_trajectory_waypoint_s		_traj_wp_avoidance_desired{};	/**< desired waypoints, inputs to an obstacle avoidance module */
+	obstacle_distance_s			_obstacle_distance{};	/**< obstacle distances received form a range sensor */
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MPC_TKO_RAMP_T>) _takeoff_ramp_time, /**< time constant for smooth takeoff ramp */
@@ -444,6 +447,12 @@ MulticopterPositionControl::poll_subscriptions()
 	if (updated) {
 		orb_copy(ORB_ID(vehicle_trajectory_waypoint), _traj_wp_avoidance_sub, &_traj_wp_avoidance);
 	}
+
+	orb_check(_range_sensor_sub, &updated);
+
+	if (updated) {
+		orb_copy(ORB_ID(obstacle_distance), _range_sensor_sub, &_obstacle_distance);
+	}
 }
 
 void
@@ -552,6 +561,7 @@ MulticopterPositionControl::run()
 	_local_pos_sub = orb_subscribe(ORB_ID(vehicle_local_position));
 	_home_pos_sub = orb_subscribe(ORB_ID(home_position));
 	_traj_wp_avoidance_sub = orb_subscribe(ORB_ID(vehicle_trajectory_waypoint));
+	_range_sensor_sub = orb_subscribe(ORB_ID(obstacle_distance));
 
 	parameters_update(true);
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -145,8 +145,8 @@ private:
 		(ParamFloat<px4::params::MPC_IDLE_TKO>) MPC_IDLE_TKO, /**< time constant for smooth takeoff ramp */
 		(ParamInt<px4::params::MPC_OBS_AVOID>) MPC_OBS_AVOID, /**< enable obstacle avoidance */
 		(ParamFloat<px4::params::MPC_TILTMAX_LND>) MPC_TILTMAX_LND, /**< maximum tilt for landing and smooth takeoff */
-		(ParamInt<px4::params::MPC_USE_OBS_SENS>) MPC_USE_OBS_SENS, /**< use range sensor measurements to avoid collision */
-		(ParamFloat<px4::params::MPC_MIN_OBS_DIST>) MPC_MIN_OBS_DIST /**< enable obstacle avoidance */
+		(ParamInt<px4::params::MPC_OBS_SENS_EN>) MPC_OBS_SENS_EN, /**< use range sensor measurements to avoid collision */
+		(ParamFloat<px4::params::MPC_OBS_MIN_DIST>) MPC_OBS_MIN_DIST /**< enable obstacle avoidance */
 	);
 
 	control::BlockDerivative _vel_x_deriv; /**< velocity derivative in x */
@@ -742,7 +742,7 @@ MulticopterPositionControl::run()
 			}
 
 			//use range sensor to update constraints
-			if(MPC_USE_OBS_SENS.get()){
+			if(MPC_OBS_SENS_EN.get()){
 				update_range_constraints(_obstacle_distance, constraints);
 				_flight_tasks.setConstraints(constraints);
 			}
@@ -1150,8 +1150,8 @@ MulticopterPositionControl::update_range_constraints(const obstacle_distance_s &
 			float angle = i*obstacle_distance.increment * (M_PI/180.0);
 
 			//calculate normalized velocity reductions
-			float vel_lim_x =  (max_detection_distance - distance)/(max_detection_distance - MPC_MIN_OBS_DIST.get()) * cos(angle);
-			float vel_lim_y =  (max_detection_distance - distance)/(max_detection_distance - MPC_MIN_OBS_DIST.get()) * sin(angle);
+			float vel_lim_x =  (max_detection_distance - distance)/(max_detection_distance - MPC_OBS_MIN_DIST.get()) * cos(angle);
+			float vel_lim_y =  (max_detection_distance - distance)/(max_detection_distance - MPC_OBS_MIN_DIST.get()) * sin(angle);
 			if(vel_lim_x > 0 && vel_lim_x > constraints.velocity_limits[0]) constraints.velocity_limits[0] = vel_lim_x;
 			if(vel_lim_y > 0 && vel_lim_y > constraints.velocity_limits[1]) constraints.velocity_limits[1] = vel_lim_y;
 			if(vel_lim_x < 0 && -vel_lim_x > constraints.velocity_limits[2]) constraints.velocity_limits[2] = -vel_lim_x;

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -689,7 +689,7 @@ PARAM_DEFINE_INT32(MPC_YAW_MODE, 0);
  * @boolean
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_INT32(MPC_USE_OBS_SENS, 0);
+PARAM_DEFINE_INT32(MPC_OBS_SENS_EN, 0);
 
 /**
  * Minimum Obstacle Distance at which the vehicle should not get closer
@@ -701,4 +701,4 @@ PARAM_DEFINE_INT32(MPC_USE_OBS_SENS, 0);
  * @unit meters
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_MIN_OBS_DIST, 4.0f);
+PARAM_DEFINE_FLOAT(MPC_OBS_MIN_DIST, 4.0f);

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -682,3 +682,23 @@ PARAM_DEFINE_INT32(MPC_OBS_AVOID, 0);
  * @group Mission
  */
 PARAM_DEFINE_INT32(MPC_YAW_MODE, 0);
+
+/**
+ * Flag to enable the use of a range sensor.
+ *
+ * @boolean
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_INT32(MPC_USE_OBS_SENS, 0);
+
+/**
+ * Minimum Obstacle Distance at which the vehicle should not get closer
+ *
+ * Only relevant if in Position control and the range sensor is active
+ *
+ * @min 0
+ * @max 15
+ * @unit meters
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_MIN_OBS_DIST, 4.0f);


### PR DESCRIPTION
Use range sensor measurements to avoid collisions in position control mode.
Range sensor data is read in and transformed into velocity constraints which prevent the vehicle from approaching any obstacle closer than a specified distance. Only the velocity component towards the obstacles is limited all other velocity components of the stick input are preserved and executed.

SITL tested, flight tests pending