### PR TITLE
Add Plane VTail to image group metadata

### DIFF
--- a/Tools/px4airframes/markdownout.py
+++ b/Tools/px4airframes/markdownout.py
@@ -30,9 +30,8 @@ class MarkdownTablesOutput():
             # Display an image of the frame
             image_name = group.GetImageName()
             result += '<div>\n'
-            if image_name != 'AirframeUnknown':
-                image_name = image_path + image_name
-                result += '<img src="%s.svg" width="29%%" style="max-height: 180px;"/>\n' % (image_name)
+            image_name = image_path + image_name
+            result += '<img src="%s.svg" width="29%%" style="max-height: 180px;"/>\n' % (image_name)
 
             # check if all outputs are equal for the group: if so, show them
             # only once

--- a/Tools/px4airframes/srcparser.py
+++ b/Tools/px4airframes/srcparser.py
@@ -64,6 +64,8 @@ class ParameterGroup(object):
             return "AirframeSimulation"
         elif (self.name == "Plane A-Tail"):
             return "PlaneATail"
+        elif (self.name == "Plane V-Tail"):
+            return "PlaneVTail"
         elif (self.name == "VTOL Duo Tailsitter"):
             return "VTOLDuoRotorTailSitter"
         elif (self.name == "Standard VTOL"):


### PR DESCRIPTION
This fixes airframe information output:
1. Adds correct image generation for new type: Plane VTail
2. Fixes bug in markdown output that was not showing unknown frame for unknown image.

@dagar Not sure where the source images themselves are supposed to come from? Does Jenkins copy them from somewhere? I will manually add to docs.