### PR TITLE
land_detector: rover return not landed if disarmed

### DIFF
--- a/src/modules/land_detector/RoverLandDetector.cpp
+++ b/src/modules/land_detector/RoverLandDetector.cpp
@@ -60,7 +60,7 @@ void RoverLandDetector::_update_params()
 
 bool RoverLandDetector::_get_ground_contact_state()
 {
-	return false;
+	return true;
 }
 
 bool RoverLandDetector::_get_maybe_landed_state()
@@ -71,6 +71,10 @@ bool RoverLandDetector::_get_maybe_landed_state()
 
 bool RoverLandDetector::_get_landed_state()
 {
+	if (!_arming.armed) {
+		return true;
+	}
+
 	return false;
 }
 


### PR DESCRIPTION
This was causing problems for QGC.