### PR TITLE
ekf2: increase min value of MAG_YAWLIM

### DIFF
--- a/Tools/process_sensor_caldata.py
+++ b/Tools/process_sensor_caldata.py
@@ -31,7 +31,7 @@ Outputs summary plots in a pdf file named <inputfilename>.pdf
 
 """
 
-parser = argparse.ArgumentParser(description='Analyse the sensor_gyro  message data')
+parser = argparse.ArgumentParser(description='Reads in IMU data from a static thermal calibration test and performs a curve fit of gyro, accel and baro bias vs temperature')
 parser.add_argument('filename', metavar='file.ulg', help='ULog input file')
 
 def is_valid_directory(parser, arg):

--- a/src/drivers/boards/ocpoc/board_config.h
+++ b/src/drivers/boards/ocpoc/board_config.h
@@ -48,7 +48,7 @@
 #define BOARD_HAS_NO_BOOTLOADER
 
 #define BOARD_NUMBER_I2C_BUSES 4
-#define BOARD_MAX_LEDS 1 // Number external of LED's this board has
+#define BOARD_MAX_LEDS 1 // Number of external LED's this board has
 #define PX4_I2C_BUS_LED 1
 #define PX4_I2C_BUS_EXPANSION 1
 

--- a/src/drivers/boards/rpi/board_config.h
+++ b/src/drivers/boards/rpi/board_config.h
@@ -53,7 +53,7 @@
 #define BOARD_HAS_NO_RESET
 #define BOARD_HAS_NO_BOOTLOADER
 
-#define BOARD_MAX_LEDS 1 // Number external of LED's this board has
+#define BOARD_MAX_LEDS 1 // Number of external LED's this board has
 
 /*
  * I2C busses

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2331,7 +2331,7 @@ Commander::run()
 			}
 
 			/* Set home position altitude to EKF origin height if home is not set and the EKF has a global origin.
-			 * This allows home atitude to be used in the calculation of height above takeoff location when GPS
+			 * This allows home altitude to be used in the calculation of height above takeoff location when GPS
 			 * use has commenced after takeoff. */
 			if (!_home.valid_alt && local_position.z_global) {
 				set_home_position(home_pub, _home, true);

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -125,7 +125,7 @@ private:
 
 	/* class variables used to check for navigation failure after takeoff */
 	hrt_abstime	_time_at_takeoff{0};		/**< last time we were on the ground */
-	hrt_abstime	_time_last_innov_pass{0};	/**< last time velocity innovations passed */
+	hrt_abstime	_time_last_innov_pass{0};	/**< last time velocity or position innovations passed */
 	bool		_nav_test_passed{false};	/**< true if the post takeoff navigation test has passed */
 	bool		_nav_test_failed{false};	/**< true if the post takeoff navigation test has failed */
 

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -245,7 +245,7 @@ main_state_transition(const vehicle_status_s &status, const main_state_t new_mai
 		      const vehicle_status_flags_s &status_flags, commander_state_s *internal_state)
 {
 	// IMPORTANT: The assumption of callers of this function is that the execution of
-	// this check if essentially "free". Therefore any runtime checking in here has to be
+	// this check is essentially "free". Therefore any runtime checking in here has to be
 	// kept super lightweight. No complex logic or calls on external function should be
 	// implemented here.
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1518,7 +1518,7 @@ void Ekf2::run()
 			{
 				/* Check and save learned magnetometer bias estimates */
 
-				// Check if conditions are OK to for learning of magnetometer bias values
+				// Check if conditions are OK for learning of magnetometer bias values
 				if (!vehicle_land_detected.landed && // not on ground
 				    (vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED) && // vehicle is armed
 				    !status.filter_fault_flags && // there are no filter faults

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -132,7 +132,7 @@ private:
 	 * Update the internal state estimate for a blended GPS solution that is a weighted average of the phsyical
 	 * receiver solutions. This internal state cannot be used directly by estimators because if physical receivers
 	 * have significant position differences, variation in receiver estimated accuracy will cause undesirable
-	 * variation in the position soution.
+	 * variation in the position solution.
 	*/
 	bool blend_gps_data();
 
@@ -2038,7 +2038,7 @@ bool Ekf2::blend_gps_data()
  * Update the internal state estimate for a blended GPS solution that is a weighted average of the phsyical receiver solutions
  * with weights are calculated in calc_gps_blend_weights(). This internal state cannot be used directly by estimators
  * because if physical receivers have significant position differences,  variation in receiver estimated accuracy will
- * cause undesirable variation in the position soution.
+ * cause undesirable variation in the position solution.
 */
 void Ekf2::update_gps_blend_states()
 {

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -520,7 +520,7 @@ PARAM_DEFINE_FLOAT(EKF2_MAG_ACCLIM, 0.5f);
  *
  * @group EKF2
  * @min 0.0
- * @max 0.5
+ * @max 1.0
  * @unit rad/s
  * @decimal 2
  */

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -39,7 +39,7 @@ FixedwingPositionControl::FixedwingPositionControl() :
 	ModuleParams(nullptr),
 	_sub_airspeed(ORB_ID(airspeed)),
 	_sub_sensors(ORB_ID(sensor_bias)),
-	_loop_perf(perf_alloc(PC_ELAPSED, "fw l1 control")),
+	_loop_perf(perf_alloc(PC_ELAPSED, "fw_l1_control")),
 	_launchDetector(this),
 	_runway_takeoff(this)
 {

--- a/src/modules/gpio_led/gpio_led.c
+++ b/src/modules/gpio_led/gpio_led.c
@@ -137,7 +137,7 @@ This module is responsible for drving a single LED on one of the FMU AUX pins.
 It listens on the vehicle_status and battery_status topics and provides visual annunciation on the LED.
 
 ### Implementation
-The module runs on the work queue. It schedules at a fixed frequency or 5 Hz
+The module runs on the work queue. It schedules at a fixed frequency of 5 Hz
 
 ### Examples
 It is started with:

--- a/src/modules/navigator/mission_block.cpp
+++ b/src/modules/navigator/mission_block.cpp
@@ -554,7 +554,7 @@ MissionBlock::mission_item_to_position_setpoint(const mission_item_s &item, posi
 	case NAV_CMD_LOITER_TO_ALT:
 
 		// initially use current altitude, and switch to mission item altitude once in loiter position
-		if (_navigator->get_loiter_min_alt() > 0.0f) { // ignore _param_loiter_min_alt if smaller then 0 (-1)
+		if (_navigator->get_loiter_min_alt() > 0.0f) { // ignore _param_loiter_min_alt if smaller than 0 (-1)
 			sp->alt = math::max(_navigator->get_global_position()->alt,
 					    _navigator->get_home_position()->alt + _navigator->get_loiter_min_alt());
 

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -126,7 +126,7 @@ enum NAV_FRAME {
 /**
  * Global position setpoint in WGS84 coordinates.
  *
- * This is the position the MAV is heading towards. If it of type loiter,
+ * This is the position the MAV is heading towards. If it is of type loiter,
  * the MAV is circling around it with the given loiter radius in meters.
  *
  * Corresponds to one of the DM_KEY_WAYPOINTS_OFFBOARD_* dataman items

--- a/src/modules/sensors/voted_sensors_update.cpp
+++ b/src/modules/sensors/voted_sensors_update.cpp
@@ -703,7 +703,7 @@ void VotedSensorsUpdate::gyro_poll(struct sensor_combined_s &raw)
 					_last_sensor_data[uorb_index].timestamp = gyro_report.timestamp - 1000;
 				}
 
-				// approximate the  delta time using the difference in gyro data time stamps
+				// approximate the delta time using the difference in gyro data time stamps
 				_last_sensor_data[uorb_index].gyro_integral_dt =
 					(gyro_report.timestamp - _last_sensor_data[uorb_index].timestamp);
 			}


### PR DESCRIPTION
- Some fixed wing platforms require a higher value of EKF2_MAG_YAWLIM in order not to constantly switch mag fusion mode during straight lines in gusty weather. [Relevant commit](https://github.com/PX4/Firmware/commit/1cdfaaf2e19d1a8fb988679d968c68ae0b0d1742)
- Also fixed some typos