### PR TITLE
uORB remove unnecessary priority from each subscriber

### DIFF
--- a/src/modules/uORB/uORBDeviceNode.cpp
+++ b/src/modules/uORB/uORBDeviceNode.cpp
@@ -123,9 +123,6 @@ uORB::DeviceNode::open(cdev::file_t *filp)
 		/* If there were any previous publications, allow the subscriber to read them */
 		sd->generation = _generation - (_queue_size < _generation ? _queue_size : _generation);
 
-		/* set priority */
-		sd->set_priority(_priority);
-
 		FILE_PRIV(filp) = (void *)sd;
 
 		ret = CDev::open(filp);
@@ -214,9 +211,6 @@ uORB::DeviceNode::read(cdev::file_t *filp, char *buffer, size_t buflen)
 	if (sd->generation < _generation) {
 		++sd->generation;
 	}
-
-	/* set priority */
-	sd->set_priority(_priority);
 
 	/*
 	 * Clear the flag that indicates that an update has been reported, as
@@ -362,7 +356,7 @@ uORB::DeviceNode::ioctl(cdev::file_t *filp, int cmd, unsigned long arg)
 		return PX4_OK;
 
 	case ORBIOCGPRIORITY:
-		*(int *)arg = sd->priority();
+		*(int *)arg = get_priority();
 		return PX4_OK;
 
 	case ORBIOCSETQUEUESIZE:

--- a/src/modules/uORB/uORBDeviceNode.hpp
+++ b/src/modules/uORB/uORBDeviceNode.hpp
@@ -175,6 +175,7 @@ public:
 	unsigned int published_message_count() const { return _generation; }
 	const struct orb_metadata *get_meta() const { return _meta; }
 
+	int get_priority() const { return _priority; }
 	void set_priority(uint8_t priority) { _priority = priority; }
 
 protected:
@@ -195,9 +196,6 @@ private:
 		unsigned  generation; /**< last generation the subscriber has seen */
 		int   flags; /**< lowest 8 bits: priority of publisher, 9. bit: update_reported bit */
 		UpdateIntervalData *update_interval; /**< if null, no update interval */
-
-		int priority() const { return flags & 0xff; }
-		void set_priority(uint8_t prio) { flags = (flags & ~0xff) | prio; }
 
 		bool update_reported() const { return flags & (1 << 8); }
 		void set_update_reported(bool update_reported_flag) { flags = (flags & ~(1 << 8)) | (((int)update_reported_flag) << 8); }


### PR DESCRIPTION
Currently the uORB priority (a property of each publisher) is also stored in each subscriber. During open and every single read the subscriber's priority is set from the uORBDeviceNode (publisher). This is all unnecessary, as the priority can be returned (via IOCTL) from the node itself.