### PR TITLE
Improve robustness to bad and lost airspeed data

### DIFF
--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -81,3 +81,10 @@ uint8 failure_detector_status			# Bitmask containing FailureDetector status [0, 
 uint32 onboard_control_sensors_present
 uint32 onboard_control_sensors_enabled
 uint32 onboard_control_sensors_health
+
+# airspeed fault and airspeed use status
+bool aspd_check_failing		# true when airspeed consistency checks are failing
+bool aspd_fault_declared	# true when an airspeed fault has been declared
+bool aspd_use_inhibit		# true if switching to a non-airspeed control mode has been requested
+bool aspd_fail_rtl		# true if airspeed failure invoked RTL has been requested
+float32 load_factor_ratio	# ratio of measured to aerodynamic load factor limit. Greater than 1 indicates airspeed low error condition.

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -4202,12 +4202,12 @@ void Commander::airspeed_use_check()
 
 		//  Decide if the control loops should be using the airspeed data based on the length of time the
 		// airspeed data has been declared bad
-		if (_tas_check_fail || load_factor_ratio_fail || data_missing) {
+		if (_tas_check_fail || load_factor_ratio_fail || data_missing || bad_number_fail) {
 			// either load factor or EKF innovation or missing data test failure can declare the airspeed bad
 			_time_tas_bad_declared = hrt_absolute_time();
 			status.aspd_check_failing = true;
 
-		} else if (!_tas_check_fail && !load_factor_ratio_fail && !data_missing) {
+		} else if (!_tas_check_fail && !load_factor_ratio_fail && !data_missing && !bad_number_fail) {
 			// All checks must pass to declare airspeed good
 			_time_tas_good_declared = hrt_absolute_time();
 			status.aspd_check_failing = false;

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2211,8 +2211,6 @@ Commander::run()
 						PX4_ERR("Engine Failure");
 						set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_MOTORCONTROL, true, true, false, status);
 					}
-				} else {
-					_engine_thrust_high = (throttle > ef_throttle_thres) && (current2throttle > ef_current2throttle_thres);
 				}
 
 			} else {

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -4219,6 +4219,9 @@ void Commander::airspeed_use_check()
 	}
 
 	// Do actions based on value of COM_ASPD_FS_ACT parameter
+	status.aspd_fault_declared = false;
+	status.aspd_use_inhibit = false;
+	status.aspd_fail_rtl = false;
 	switch (_airspeed_fail_action.get()) {
 	case 4: // log a message, warn the user, switch to non-airspeed TECS mode, switch to Return mode
 		{
@@ -4235,9 +4238,6 @@ void Commander::airspeed_use_check()
 				}
 			} else if (fault_cleared) {
 				mavlink_log_critical(&mavlink_log_pub, "AIRSPEED DATA GOOD - restarting use");
-				status.aspd_fault_declared = false;
-				status.aspd_use_inhibit = false;
-				status.aspd_fail_rtl = false;
 			}
 			return;
 		}
@@ -4247,12 +4247,8 @@ void Commander::airspeed_use_check()
 				mavlink_log_critical(&mavlink_log_pub, "AIRSPEED DATA  %s  - stopping use", _airspeed_fault_type);
 				status.aspd_fault_declared = true;
 				status.aspd_use_inhibit = true;
-				status.aspd_fail_rtl = false;
 			} else if (fault_cleared) {
 				mavlink_log_critical(&mavlink_log_pub, "AIRSPEED DATA GOOD - restarting use");
-				status.aspd_fault_declared = false;
-				status.aspd_use_inhibit = false;
-				status.aspd_fail_rtl = false;
 			}
 			return;
 		}
@@ -4261,13 +4257,8 @@ void Commander::airspeed_use_check()
 			if (fault_declared) {
 				mavlink_log_critical(&mavlink_log_pub, "AIRSPEED DATA %s", _airspeed_fault_type);
 				status.aspd_fault_declared = true;
-				status.aspd_use_inhibit = false;
-				status.aspd_fail_rtl = false;
 			} else if (fault_cleared) {
 				mavlink_log_critical(&mavlink_log_pub, "AIRSPEED DATA GOOD");
-				status.aspd_fault_declared = false;
-				status.aspd_use_inhibit = false;
-				status.aspd_fail_rtl = false;
 			}
 			return;
 		}
@@ -4276,21 +4267,13 @@ void Commander::airspeed_use_check()
 			if (fault_declared) {
 				mavlink_log_info(&mavlink_log_pub, "AIRSPEED DATA %s", _airspeed_fault_type);
 				status.aspd_fault_declared = true;
-				status.aspd_use_inhibit = false;
-				status.aspd_fail_rtl = false;
 			} else if (fault_cleared) {
 				mavlink_log_info(&mavlink_log_pub, "AIRSPEED DATA GOOD");
-				status.aspd_fault_declared = false;
-				status.aspd_use_inhibit = false;
-				status.aspd_fail_rtl = false;
 			}
 			return;
 		}
 	default:
 		// Do nothing
-		status.aspd_fault_declared = false;
-		status.aspd_use_inhibit = false;
-		status.aspd_fail_rtl = true;
 		return;
 	}
 }

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -102,6 +102,8 @@
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/vehicle_status_flags.h>
 #include <uORB/topics/vtol_vehicle_status.h>
+#include <uORB/topics/airspeed.h>
+#include <uORB/topics/sensor_combined.h>
 
 typedef enum VEHICLE_MODE_FLAG {
 	VEHICLE_MODE_FLAG_CUSTOM_MODE_ENABLED = 1, /* 0b00000001 Reserved for future use. | */
@@ -1245,6 +1247,11 @@ Commander::run()
 	status_flags.condition_power_input_valid = true;
 	status_flags.rc_calibration_valid = true;
 
+	status.aspd_check_failing = false;
+	status.aspd_fault_declared = false;
+	status.aspd_use_inhibit = false;
+	status.aspd_fail_rtl = false;
+
 	get_circuit_breaker_params();
 
 	/* publish initial state */
@@ -1705,6 +1712,7 @@ Commander::run()
 		}
 
 		estimator_check(&status_changed);
+		airspeed_use_check();
 
 		/* Update land detector */
 		orb_check(land_detector_sub, &updated);
@@ -2174,6 +2182,7 @@ Commander::run()
 		// engine failure detection
 		// TODO: move out of commander
 		orb_check(actuator_controls_sub, &updated);
+		actuator_controls_s actuator_controls = {};
 
 		if (updated) {
 			/* Check engine failure
@@ -2182,7 +2191,6 @@ Commander::run()
 			if (!status_flags.circuit_breaker_engaged_enginefailure_check &&
 			    !status.is_rotary_wing && !status.is_vtol && armed.armed) {
 
-				actuator_controls_s actuator_controls = {};
 				orb_copy(ORB_ID_VEHICLE_ATTITUDE_CONTROLS, actuator_controls_sub, &actuator_controls);
 
 				const float throttle = actuator_controls.control[actuator_controls_s::INDEX_THROTTLE];
@@ -2203,6 +2211,8 @@ Commander::run()
 						PX4_ERR("Engine Failure");
 						set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_MOTORCONTROL, true, true, false, status);
 					}
+				} else {
+					_engine_thrust_high = (throttle > ef_throttle_thres) && (current2throttle > ef_current2throttle_thres);
 				}
 
 			} else {
@@ -4129,6 +4139,164 @@ void Commander::battery_status_check()
 	}
 }
 
+void Commander::airspeed_use_check()
+{
+	// assume airspeed sensor is good before starting FW flight
+	bool valid_flight_condition = (status.arming_state == vehicle_status_s::ARMING_STATE_ARMED) &&
+			!status.is_rotary_wing &&
+			!land_detector.landed;
+	bool fault_declared = false;
+	bool fault_cleared = false;
+	if (!valid_flight_condition) {
+		_tas_use_inhibit = false;
+		_time_tas_good_declared = hrt_absolute_time();
+		_time_tas_bad_declared = 0;
+		status.aspd_check_failing = false;
+		status.aspd_fault_declared = false;
+		status.aspd_use_inhibit = false;
+		status.aspd_fail_rtl = false;
+		_time_last_airspeed = hrt_absolute_time();
+		_airspeed_fault_type = new(char[7]);
+	} else {
+		// The vehicle is flying so use the status of the airspeed innovation check '_tas_check_fail' in
+		// addition to a sanity check using airspeed and load factor and a missing sensor data check.
+
+		// Check if sensor data is missing - assume a minimum 5Hz data rate.
+		bool data_missing = false;
+		if ((hrt_absolute_time() -_time_last_airspeed) > 200000) {
+			data_missing = true;
+		}
+
+		// Declare data stopped if not received for longer than 1 second
+		bool data_stopped = false;
+		if ((hrt_absolute_time() -_time_last_airspeed) > 1000000) {
+			data_stopped = true;
+		}
+		_time_last_airspeed = hrt_absolute_time();
+
+		// Check if the airpeed reading is lower than physically possible given the load factor
+		_airspeed_sub.update();
+		_airspeed = _airspeed_sub.get();
+		_sensor_combined_sub.update();
+		_sensor_combined = _sensor_combined_sub.get();
+		float max_lift_ratio = _airspeed.indicated_airspeed_m_s /fmaxf(_airspeed_stall.get(),1.0f);
+		max_lift_ratio *= max_lift_ratio;
+		status.load_factor_ratio = 0.95f * status.load_factor_ratio - 0.05f * (_sensor_combined.accelerometer_m_s2[2] / 9.80665f) / max_lift_ratio;
+		status.load_factor_ratio = math::constrain(status.load_factor_ratio, 0.25f, 2.0f);
+		bool load_factor_ratio_fail = status.load_factor_ratio > 1.1f;
+
+		//  Decide if the control loops should be using the airspeed data based on the length of time the
+		// airspeed data has been declared bad
+		if (_tas_check_fail || load_factor_ratio_fail || data_missing) {
+			// either load factor or EKF innovation or missing data test failure can declare the airspeed bad
+			_time_tas_bad_declared = hrt_absolute_time();
+			status.aspd_check_failing = true;
+		} else if (!_tas_check_fail && !load_factor_ratio_fail && !data_missing) {
+			// All checks must pass to declare airspeed good
+			_time_tas_good_declared = hrt_absolute_time();
+			status.aspd_check_failing = false;
+		}
+		if (!_tas_use_inhibit) {
+			// A simultaneous load factor and innovaton check fail makes it more likely that a large
+			// airspeed measurement fault has developed, so a fault should be declared immediately
+			bool both_checks_failed = _tas_check_fail && load_factor_ratio_fail;
+
+			// Because the innovation, load factor and data missing checks are subject to short duration false positives
+			// a timeout period is applied.
+			bool single_check_fail_timeout = (hrt_absolute_time() - _time_tas_good_declared) > 1000000 * (hrt_abstime)_tas_use_stop_delay.get();
+
+			if (data_stopped || both_checks_failed || single_check_fail_timeout) {
+				_tas_use_inhibit = true;
+				fault_declared = true;
+				if (data_stopped || data_missing) {
+					strcpy(_airspeed_fault_type, "MISSING");
+				} else  {
+					strcpy(_airspeed_fault_type, "FAULTY ");
+				}
+			}
+		} else if ((hrt_absolute_time() - _time_tas_bad_declared) > 1000000 * (hrt_abstime)_tas_use_start_delay.get()) {
+			_tas_use_inhibit = false;
+			fault_cleared = true;
+		}
+	}
+
+	// Do actions based on value of COM_ASPD_FS_ACT parameter
+	switch (_airspeed_fail_action.get()) {
+	case 4: // log a message, warn the user, switch to non-airspeed TECS mode, switch to Return mode
+		{
+			if (fault_declared) {
+				status.aspd_fault_declared = true;
+				status.aspd_use_inhibit = true;
+				status.aspd_fail_rtl = true;
+				// let us send the critical message even if already in RTL
+				if (TRANSITION_DENIED != main_state_transition(status, commander_state_s::MAIN_STATE_AUTO_RTL, status_flags, &internal_state)) {
+					mavlink_log_critical(&mavlink_log_pub, "AIRSPEED DATA %s - stopping use and returning", _airspeed_fault_type);
+
+				} else {
+					mavlink_log_emergency(&mavlink_log_pub, "AIRSPEED DATA  %s - stopping use, return failed", _airspeed_fault_type);
+				}
+			} else if (fault_cleared) {
+				mavlink_log_critical(&mavlink_log_pub, "AIRSPEED DATA GOOD - restarting use");
+				status.aspd_fault_declared = false;
+				status.aspd_use_inhibit = false;
+				status.aspd_fail_rtl = false;
+			}
+			return;
+		}
+	case 3: // log a message, warn the user, switch to non-airspeed TECS mode
+		{
+			if (fault_declared) {
+				mavlink_log_critical(&mavlink_log_pub, "AIRSPEED DATA  %s  - stopping use", _airspeed_fault_type);
+				status.aspd_fault_declared = true;
+				status.aspd_use_inhibit = true;
+				status.aspd_fail_rtl = false;
+			} else if (fault_cleared) {
+				mavlink_log_critical(&mavlink_log_pub, "AIRSPEED DATA GOOD - restarting use");
+				status.aspd_fault_declared = false;
+				status.aspd_use_inhibit = false;
+				status.aspd_fail_rtl = false;
+			}
+			return;
+		}
+	case 2: // log a message, warn the user
+		{
+			if (fault_declared) {
+				mavlink_log_critical(&mavlink_log_pub, "AIRSPEED DATA %s", _airspeed_fault_type);
+				status.aspd_fault_declared = true;
+				status.aspd_use_inhibit = false;
+				status.aspd_fail_rtl = false;
+			} else if (fault_cleared) {
+				mavlink_log_critical(&mavlink_log_pub, "AIRSPEED DATA GOOD");
+				status.aspd_fault_declared = false;
+				status.aspd_use_inhibit = false;
+				status.aspd_fail_rtl = false;
+			}
+			return;
+		}
+	case 1: // log a message
+		{
+			if (fault_declared) {
+				mavlink_log_info(&mavlink_log_pub, "AIRSPEED DATA %s", _airspeed_fault_type);
+				status.aspd_fault_declared = true;
+				status.aspd_use_inhibit = false;
+				status.aspd_fail_rtl = false;
+			} else if (fault_cleared) {
+				mavlink_log_info(&mavlink_log_pub, "AIRSPEED DATA GOOD");
+				status.aspd_fault_declared = false;
+				status.aspd_use_inhibit = false;
+				status.aspd_fail_rtl = false;
+			}
+			return;
+		}
+	default:
+		// Do nothing
+		status.aspd_fault_declared = false;
+		status.aspd_use_inhibit = false;
+		status.aspd_fail_rtl = true;
+		return;
+	}
+}
+
 void Commander::estimator_check(bool *status_changed)
 {
 	// Check if quality checking of position accuracy and consistency is to be performed
@@ -4211,6 +4379,36 @@ void Commander::estimator_check(bool *status_changed)
 						}
 					}
 				}
+			}
+		}
+
+		// Perform airspeed sensor validity checks
+		bool valid_flight_condition = (status.arming_state == vehicle_status_s::ARMING_STATE_ARMED) &&
+				!status.is_rotary_wing &&
+				!land_detector.landed;
+		// assume airspeed sensor is good before starting FW flight
+		if (!valid_flight_condition) {
+			_tas_check_fail =  false;
+			_time_last_tas_pass = hrt_absolute_time();
+			_time_last_tas_fail = 0;
+			status.aspd_check_failing = false;
+			status.aspd_fault_declared = false;
+			status.aspd_use_inhibit = false;
+			status.aspd_fail_rtl = false;
+		} else {
+			// Check normalised innovation levels with requirement for continuous data and use of hysteresis
+			// to prevent false triggering.
+			if (estimator_status.tas_test_ratio < 1.0f * _tas_innov_threshold.get()) {
+				_time_last_tas_pass = hrt_absolute_time();
+			}
+			bool nav_data_good = estimator_status.vel_test_ratio < 1.0f && estimator_status.mag_test_ratio < 1.0f;
+			if (estimator_status.tas_test_ratio > 0.7f * _tas_innov_threshold.get() && nav_data_good) {
+				_time_last_tas_fail = hrt_absolute_time();
+			}
+			if (!_tas_check_fail) {
+				_tas_check_fail = (hrt_absolute_time() - _time_last_tas_pass) > TAS_INNOV_FAIL_DELAY;
+			} else {
+				_tas_check_fail = (hrt_absolute_time() - _time_last_tas_fail) < TAS_INNOV_FAIL_DELAY;
 			}
 		}
 	}

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -4155,6 +4155,7 @@ void Commander::airspeed_use_check()
 		status.aspd_fail_rtl = false;
 		_time_last_airspeed = hrt_absolute_time();
 		_airspeed_fault_type = new(char[7]);
+		_load_factor_ratio = 0.5f;
 	} else {
 		// The vehicle is flying so use the status of the airspeed innovation check '_tas_check_fail' in
 		// addition to a sanity check using airspeed and load factor and a missing sensor data check.
@@ -4179,9 +4180,10 @@ void Commander::airspeed_use_check()
 		_sensor_bias = _sensor_bias_sub.get();
 		float max_lift_ratio = fmaxf(_airspeed.indicated_airspeed_m_s, 0.7f) / fmaxf(_airspeed_stall.get(), 1.0f);
 		max_lift_ratio *= max_lift_ratio;
-		status.load_factor_ratio = 0.95f * status.load_factor_ratio + 0.05f * (fabsf(_sensor_bias.accel_z) / 9.80665f) / max_lift_ratio;
-		status.load_factor_ratio = math::constrain(status.load_factor_ratio, 0.25f, 2.0f);
-		bool load_factor_ratio_fail = status.load_factor_ratio > 1.1f;
+		_load_factor_ratio = 0.95f * _load_factor_ratio + 0.05f * (fabsf(_sensor_bias.accel_z) / 9.80665f) / max_lift_ratio;
+		_load_factor_ratio = math::constrain(_load_factor_ratio, 0.25f, 2.0f);
+		bool load_factor_ratio_fail = _load_factor_ratio > 1.1f;
+		status.load_factor_ratio = _load_factor_ratio;
 
 		//  Decide if the control loops should be using the airspeed data based on the length of time the
 		// airspeed data has been declared bad

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2182,7 +2182,6 @@ Commander::run()
 		// engine failure detection
 		// TODO: move out of commander
 		orb_check(actuator_controls_sub, &updated);
-		actuator_controls_s actuator_controls = {};
 
 		if (updated) {
 			/* Check engine failure
@@ -2191,6 +2190,7 @@ Commander::run()
 			if (!status_flags.circuit_breaker_engaged_enginefailure_check &&
 			    !status.is_rotary_wing && !status.is_vtol && armed.armed) {
 
+				actuator_controls_s actuator_controls = {};
 				orb_copy(ORB_ID_VEHICLE_ATTITUDE_CONTROLS, actuator_controls_sub, &actuator_controls);
 
 				const float throttle = actuator_controls.control[actuator_controls_s::INDEX_THROTTLE];

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -4154,7 +4154,6 @@ void Commander::airspeed_use_check()
 		status.aspd_use_inhibit = false;
 		status.aspd_fail_rtl = false;
 		_time_last_airspeed = hrt_absolute_time();
-		_airspeed_fault_type = new(char[7]);
 		_load_factor_ratio = 0.5f;
 	} else {
 		// The vehicle is flying so use the status of the airspeed innovation check '_tas_check_fail' in

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -4177,11 +4177,11 @@ void Commander::airspeed_use_check()
 		// Check if the airpeed reading is lower than physically possible given the load factor
 		_airspeed_sub.update();
 		_airspeed = _airspeed_sub.get();
-		_sensor_combined_sub.update();
-		_sensor_combined = _sensor_combined_sub.get();
+		_sensor_bias_sub.update();
+		_sensor_bias = _sensor_bias_sub.get();
 		float max_lift_ratio = _airspeed.indicated_airspeed_m_s /fmaxf(_airspeed_stall.get(),1.0f);
 		max_lift_ratio *= max_lift_ratio;
-		status.load_factor_ratio = 0.95f * status.load_factor_ratio - 0.05f * (_sensor_combined.accelerometer_m_s2[2] / 9.80665f) / max_lift_ratio;
+		status.load_factor_ratio = 0.95f * status.load_factor_ratio + 0.05f * (fabsf(_sensor_bias.accel_z) / 9.80665f) / max_lift_ratio;
 		status.load_factor_ratio = math::constrain(status.load_factor_ratio, 0.25f, 2.0f);
 		bool load_factor_ratio_fail = status.load_factor_ratio > 1.1f;
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -4163,13 +4163,13 @@ void Commander::airspeed_use_check()
 
 		// Check if sensor data is missing - assume a minimum 5Hz data rate.
 		bool data_missing = false;
-		if ((hrt_absolute_time() -_time_last_airspeed) > 200000) {
+		if ((hrt_absolute_time() -_time_last_airspeed) > 200_ms) {
 			data_missing = true;
 		}
 
 		// Declare data stopped if not received for longer than 1 second
 		bool data_stopped = false;
-		if ((hrt_absolute_time() -_time_last_airspeed) > 1000000) {
+		if ((hrt_absolute_time() -_time_last_airspeed) > 1_s) {
 			data_stopped = true;
 		}
 		_time_last_airspeed = hrt_absolute_time();
@@ -4203,7 +4203,7 @@ void Commander::airspeed_use_check()
 
 			// Because the innovation, load factor and data missing checks are subject to short duration false positives
 			// a timeout period is applied.
-			bool single_check_fail_timeout = (hrt_absolute_time() - _time_tas_good_declared) > 1000000 * (hrt_abstime)_tas_use_stop_delay.get();
+			bool single_check_fail_timeout = (hrt_absolute_time() - _time_tas_good_declared) > 1_s * (hrt_abstime)_tas_use_stop_delay.get();
 
 			if (data_stopped || both_checks_failed || single_check_fail_timeout) {
 				_tas_use_inhibit = true;
@@ -4214,7 +4214,7 @@ void Commander::airspeed_use_check()
 					strcpy(_airspeed_fault_type, "FAULTY ");
 				}
 			}
-		} else if ((hrt_absolute_time() - _time_tas_bad_declared) > 1000000 * (hrt_abstime)_tas_use_start_delay.get()) {
+		} else if ((hrt_absolute_time() - _time_tas_bad_declared) > 1_s * (hrt_abstime)_tas_use_start_delay.get()) {
 			_tas_use_inhibit = false;
 			fault_cleared = true;
 		}

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -4179,7 +4179,7 @@ void Commander::airspeed_use_check()
 		_sensor_bias = _sensor_bias_sub.get();
 		float max_lift_ratio = fmaxf(_airspeed.indicated_airspeed_m_s, 0.7f) / fmaxf(_airspeed_stall.get(), 1.0f);
 		max_lift_ratio *= max_lift_ratio;
-		_load_factor_ratio = 0.95f * _load_factor_ratio + 0.05f * (fabsf(_sensor_bias.accel_z) / 9.80665f) / max_lift_ratio;
+		_load_factor_ratio = 0.95f * _load_factor_ratio + 0.05f * (fabsf(_sensor_bias.accel_z) / CONSTANTS_ONE_G) / max_lift_ratio;
 		_load_factor_ratio = math::constrain(_load_factor_ratio, 0.25f, 2.0f);
 		bool load_factor_ratio_fail = _load_factor_ratio > 1.1f;
 		status.load_factor_ratio = _load_factor_ratio;

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -4177,7 +4177,7 @@ void Commander::airspeed_use_check()
 		_airspeed = _airspeed_sub.get();
 		_sensor_bias_sub.update();
 		_sensor_bias = _sensor_bias_sub.get();
-		float max_lift_ratio = _airspeed.indicated_airspeed_m_s /fmaxf(_airspeed_stall.get(),1.0f);
+		float max_lift_ratio = fmaxf(_airspeed.indicated_airspeed_m_s, 0.7f) / fmaxf(_airspeed_stall.get(), 1.0f);
 		max_lift_ratio *= max_lift_ratio;
 		status.load_factor_ratio = 0.95f * status.load_factor_ratio + 0.05f * (fabsf(_sensor_bias.accel_z) / 9.80665f) / max_lift_ratio;
 		status.load_factor_ratio = math::constrain(status.load_factor_ratio, 0.25f, 2.0f);

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -113,7 +113,8 @@ private:
 		(ParamInt<px4::params::COM_TAS_FS_T1>) _tas_use_stop_delay,
 		(ParamInt<px4::params::COM_TAS_FS_T2>) _tas_use_start_delay,
 		(ParamInt<px4::params::COM_ASPD_FS_ACT>) _airspeed_fail_action,
-		(ParamFloat<px4::params::COM_ASPD_STALL>) _airspeed_stall
+		(ParamFloat<px4::params::COM_ASPD_STALL>) _airspeed_stall,
+		(ParamInt<px4::params::COM_ASPD_FS_DLY>) _airspeed_rtl_delay
 
 	)
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -203,7 +203,6 @@ private:
 	int _battery_sub{-1};
 	uint8_t _battery_warning{battery_status_s::BATTERY_WARNING_NONE};
 	float _battery_current{0.0f};
-	bool _engine_thrust_high = false;
 
 	void battery_status_check();
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -57,7 +57,7 @@
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_local_position.h>
-#include <uORB/topics/sensor_combined.h>
+#include <uORB/topics/sensor_bias.h>
 #include <uORB/topics/airspeed.h>
 
 using math::constrain;
@@ -213,7 +213,7 @@ private:
 	Subscription<mission_result_s>			_mission_result_sub{ORB_ID(mission_result)};
 	Subscription<vehicle_global_position_s>		_global_position_sub{ORB_ID(vehicle_global_position)};
 	Subscription<vehicle_local_position_s>		_local_position_sub{ORB_ID(vehicle_local_position)};
-	Subscription<sensor_combined_s>			_sensor_combined_sub{ORB_ID(sensor_combined)};
+	Subscription<sensor_bias_s>			_sensor_bias_sub{ORB_ID(sensor_bias)};
 	Subscription<airspeed_s>			_airspeed_sub{ORB_ID(airspeed)};
 
 	Publication<home_position_s>			_home_pub{ORB_ID(home_position)};
@@ -221,7 +221,7 @@ private:
 	orb_advert_t					_status_pub{nullptr};
 
 	struct airspeed_s _airspeed = {};
-	struct sensor_combined_s _sensor_combined = {};
+	struct sensor_bias_s _sensor_bias = {};
 
 };
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -145,6 +145,7 @@ private:
 	hrt_abstime	_time_tas_bad_declared{0};	/**< time TAS use was stopped (uSec) */
 	hrt_abstime	_time_last_airspeed{0};		/**< time last airspeed measurement was received (uSec) */
 	char		*_airspeed_fault_type = new char[7];
+	float		_load_factor_ratio{0.5f};	/**< ratio of maximum load factor predicted by stall speed to measured load factor */
 
 	FailureDetector _failure_detector;
 	bool _failure_detector_termination_printed{false};

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -818,7 +818,17 @@ PARAM_DEFINE_FLOAT(COM_ASPD_STALL, 10.0f);
  * @value 1 log a message
  * @value 2 log a message, warn the user
  * @value 3 log a message, warn the user, switch to non-airspeed TECS mode
- * @value 4 log a message, warn the user, switch to non-airspeed TECS mode, switch to Return mode
+ * @value 4 log a message, warn the user, switch to non-airspeed TECS mode, switch to Return mode after COM_ASPD_FS_DLY seconds
  * @group Mission
  */
 PARAM_DEFINE_INT32(COM_ASPD_FS_ACT, 0);
+
+/**
+ * RTL delay after bad airspeed measurements are detected if COM_ASPD_FS_ACT is set to 4. Ensure the COM_ASPD_STALL parameter is set correctly before use.
+ *
+ * @min 0
+ * @max 300
+ * @group Commander
+ * @unit s
+ */
+PARAM_DEFINE_INT32(COM_ASPD_FS_DLY, 0);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -769,3 +769,56 @@ PARAM_DEFINE_INT32(COM_FLIGHT_UUID, 0);
  * @group Mission
  */
 PARAM_DEFINE_INT32(COM_TAKEOFF_ACT, 0);
+
+/**
+ * Airspeed Consistency Threshold.
+ *
+ * This scales the minimum airspeed inconsistency required to trigger a failsafe. Increase to make the check less sensitive, decrease to make it more sensitive. The failsafe response is controlled by the COM_ASPD_FS_ACT parameter.
+ *
+ * @min 0.5
+ * @max 2.0
+ * @group Commander
+ */
+PARAM_DEFINE_FLOAT(COM_TAS_FS_INNOV, 1.0f);
+
+/**
+ * Delay before stopping use of airspeed sensor if checks indicate sensor is bad. The failsafe response is controlled by the COM_ASPD_FS_ACT parameter.
+ *
+ * @unit sec
+ * @group Commander
+ * @min 1
+ * @max 10
+ */
+PARAM_DEFINE_INT32(COM_TAS_FS_T1, 3);
+
+/**
+ * Delay before switching back to using airspeed sensor if checks indicate sensor is good. The failsafe response is controlled by the COM_ASPD_FS_ACT parameter.
+ *
+ * @unit sec
+ * @group Commander
+ * @min 10
+ * @max 1000
+ */
+PARAM_DEFINE_INT32(COM_TAS_FS_T2, 100);
+
+/**
+ * Stall airspeed.
+ *
+ * This is the minimum indicated airspeed at which the wing can produce 1g of lift. It is used by the airspeed sensor fault detection and failsafe calculation to detect a significant airspeed low measurement error condition and should be set based on flight test for reliable operation. The failsafe response is controlled by the COM_ASPD_FS_ACT parameter.
+ *
+ * @group Commander
+ * @unit m/s
+ */
+PARAM_DEFINE_FLOAT(COM_ASPD_STALL, 10.0f);
+
+/**
+ * Failsafe action when bad airspeed measurements are detected. Ensure the COM_ASPD_STALL parameter is set correctly before use.
+ *
+ * @value 0 do nothing
+ * @value 1 log a message
+ * @value 2 log a message, warn the user
+ * @value 3 log a message, warn the user, switch to non-airspeed TECS mode
+ * @value 4 log a message, warn the user, switch to non-airspeed TECS mode, switch to Return mode
+ * @group Mission
+ */
+PARAM_DEFINE_INT32(COM_ASPD_FS_ACT, 0);

--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -470,7 +470,8 @@ void FixedwingAttitudeControl::get_airspeed_and_scaling(float &airspeed, float &
 {
 	const bool airspeed_valid = PX4_ISFINITE(_airspeed_sub.get().indicated_airspeed_m_s)
 				    && (_airspeed_sub.get().indicated_airspeed_m_s > 0.0f)
-				    && (hrt_elapsed_time(&_airspeed_sub.get().timestamp) < 1e6);
+				    && (hrt_elapsed_time(&_airspeed_sub.get().timestamp) < 1e6)
+					&& !_vehicle_status.aspd_use_inhibit;
 
 	if (!_parameters.airspeed_disabled && airspeed_valid) {
 		/* prevent numerical drama by requiring 0.5 m/s minimal speed */

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -382,7 +382,8 @@ FixedwingPositionControl::airspeed_poll()
 
 		if (PX4_ISFINITE(as.indicated_airspeed_m_s)
 		    && PX4_ISFINITE(as.true_airspeed_m_s)
-		    && (as.indicated_airspeed_m_s > 0.0f)) {
+		    && (as.indicated_airspeed_m_s > 0.0f
+			&& !_vehicle_status.aspd_use_inhibit) {
 
 			airspeed_valid = true;
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -382,7 +382,7 @@ FixedwingPositionControl::airspeed_poll()
 
 		if (PX4_ISFINITE(as.indicated_airspeed_m_s)
 		    && PX4_ISFINITE(as.true_airspeed_m_s)
-		    && (as.indicated_airspeed_m_s > 0.0f
+		    && (as.indicated_airspeed_m_s > 0.0f)
 			&& !_vehicle_status.aspd_use_inhibit) {
 
 			airspeed_valid = true;


### PR DESCRIPTION
**Description**

Added in response to https://github.com/PX4/Firmware/issues/9869

Enables detection and recovery from disconnected and blocked airspeed sensors.

Uses a combined airspeed innovation check and normal load factor sanity check.

False positives to bad EKF operation are reduced by requiring that GPS and magnetomer innovations are within limits from other sensors are within limits before declaring airspeed innovations bad.

The normal load factor sanity check will fail the airspeed sensor if the normal load factor sustains a value that is greater than what is physically possible given the measured airspeed.

The feature is off by default and controlled by the following parameters:

COM_ASPD_FS_ACT
Sets failsafe action when bad airspeed measurements are detected:
0 do nothing
1 log a message
2 log a message, warn the user
3 log a message, warn the user, switch to non-airspeed TECS mode
4 log a message, warn the user, switch to non-airspeed TECS mode, switch to Return mode

COM_ASPD_STALL
This is the minimum indicated airspeed at which the wing can produce 1g of lift. It is used by the airspeed sensor fault detection and failsafe calculation to detect a significant airspeed low measurement error condition and should be set based on flight test for reliable operation. The failsafe response is controlled by the COM_ASPD_FS_ACT parameter.

COM_TAS_FS_INNOV
This scales the minimum airspeed innovation level required to trigger a failsafe. Increase to make the check less sensitive, decrease to make it more sensitive. The default value of 1.0 uses the same threshold as the EKF does for airspeed acceptance. 

COM_TAS_FS_T1
Number of seconds checks need to fail before an airspeed fault is declared and any failsafe response is actioned. Note - if both

COM_TAS_FS_T2
Number of seconds checks need to pass before an airspeed fault is cleared.

**Test data / coverage**
Preliminary testing in SITL was performed by modifying it here :https://github.com/PX4/sitl_gazebo/blob/3d80f63562c24c1537e1f8423ce649c99ebc15ea/src/gazebo_mavlink_interface.cpp#L549-L555 to fail the airspeed at specified times or heights, eg

```
// block airspeed sensor immediately after takeoff
// clear blockage afer 30 seconds
static common::Time fail_time = 0.0;
static bool faulty = false;
if (faulty || ((pos_n.Z() < -5.0f) && (fail_time == 0.0))) {
sensor_msg.diff_pressure = 0.0f;
if (!faulty) {
fail_time = world_->GetSimTime();
faulty = true;
}
}
if ((world_->SimTime() - fail_time) > 30.0) {
faulty = false;
}
```

**SITL test logs**
COM_ASPD_FS_ACT = 4
COM_ASPD_STALL = 10
COM_TAS_FS_INNOV = 1.0
COM_TAS_FS_T1 = 3
COM_TAS_FS_T2 = 100

Pitot permanently blocked immediately after takeoff.
https://logs.px4.io/plot_app?log=569f7887-378a-465d-87fe-2e22fbd1163b

Pitot blocked immediately after takeoff and unblocked after 30 sec. Airspeed fault status eventually clears, but vehicle remains in RTL loiter as expected.
https://logs.px4.io/plot_app?log=b42fbf34-25aa-42d6-ab16-52baf613a81a

Flight testing will be required.

