### PR TITLE
Mission Log

### DIFF
--- a/cmake/configs/nuttx_aerofc-v1_default.cmake
+++ b/cmake/configs/nuttx_aerofc-v1_default.cmake
@@ -62,7 +62,6 @@ set(config_module_list
 	#
 	modules/mc_att_control
 	modules/mc_pos_control
-	modules/vtol_att_control # FIXME: only required for params needed by Navigator
 
 	#
 	# Logging

--- a/cmake/configs/nuttx_crazyflie_default.cmake
+++ b/cmake/configs/nuttx_crazyflie_default.cmake
@@ -62,7 +62,6 @@ set(config_module_list
 	# modules/fw_att_control
 	modules/mc_att_control
 	modules/mc_pos_control
-	modules/vtol_att_control # FIXME: only required for params needed by Navigator
 
 	#
 	# Logging

--- a/cmake/configs/nuttx_omnibus-f4sd_default.cmake
+++ b/cmake/configs/nuttx_omnibus-f4sd_default.cmake
@@ -89,13 +89,13 @@ set(config_module_list
 	#
 	# Vehicle Control
 	#
-	modules/fw_att_control
-	modules/fw_pos_control_l1
+	#modules/fw_att_control
+	#modules/fw_pos_control_l1
 	#modules/gnd_att_control
 	#modules/gnd_pos_control
 	modules/mc_att_control
 	modules/mc_pos_control
-	modules/vtol_att_control
+	#modules/vtol_att_control
 
 	#
 	# Logging

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -35,7 +35,7 @@ set(config_module_list
 	drivers/distance_sensor/ll40ls
 	#drivers/distance_sensor/mb12xx
 	drivers/distance_sensor/sf0x
-	drivers/distance_sensor/sf1xx
+	#drivers/distance_sensor/sf1xx
 	#drivers/distance_sensor/srf02
 	#drivers/distance_sensor/teraranger
 	#drivers/distance_sensor/tfmini

--- a/src/modules/logger/CMakeLists.txt
+++ b/src/modules/logger/CMakeLists.txt
@@ -42,6 +42,7 @@ px4_add_module(
 		log_writer.cpp
 		log_writer_file.cpp
 		log_writer_mavlink.cpp
+		util.cpp
 		watchdog.cpp
 	DEPENDS
 		version

--- a/src/modules/logger/log_writer.cpp
+++ b/src/modules/logger/log_writer.cpp
@@ -100,7 +100,7 @@ bool LogWriter::is_started() const
 	bool ret = false;
 
 	if (_log_writer_file) {
-		ret = _log_writer_file->is_started();
+		ret = _log_writer_file->is_started(LogType::Full);
 	}
 
 	if (_log_writer_mavlink) {
@@ -113,7 +113,7 @@ bool LogWriter::is_started() const
 bool LogWriter::is_started(Backend query_backend) const
 {
 	if (query_backend == BackendFile && _log_writer_file) {
-		return _log_writer_file->is_started();
+		return _log_writer_file->is_started(LogType::Full);
 	}
 
 	if (query_backend == BackendMavlink && _log_writer_mavlink) {
@@ -126,14 +126,14 @@ bool LogWriter::is_started(Backend query_backend) const
 void LogWriter::start_log_file(const char *filename)
 {
 	if (_log_writer_file) {
-		_log_writer_file->start_log(filename);
+		_log_writer_file->start_log(LogType::Full, filename);
 	}
 }
 
 void LogWriter::stop_log_file()
 {
 	if (_log_writer_file) {
-		_log_writer_file->stop_log();
+		_log_writer_file->stop_log(LogType::Full);
 	}
 }
 
@@ -163,7 +163,7 @@ int LogWriter::write_message(void *ptr, size_t size, uint64_t dropout_start)
 	int ret_file = 0, ret_mavlink = 0;
 
 	if (_log_writer_file_for_write) {
-		ret_file = _log_writer_file_for_write->write_message(ptr, size, dropout_start);
+		ret_file = _log_writer_file_for_write->write_message(LogType::Full, ptr, size, dropout_start);
 	}
 
 	if (_log_writer_mavlink_for_write) {

--- a/src/modules/logger/log_writer.cpp
+++ b/src/modules/logger/log_writer.cpp
@@ -95,45 +95,45 @@ LogWriter::~LogWriter()
 	}
 }
 
-bool LogWriter::is_started() const
+bool LogWriter::is_started(LogType type) const
 {
 	bool ret = false;
 
 	if (_log_writer_file) {
-		ret = _log_writer_file->is_started(LogType::Full);
+		ret = _log_writer_file->is_started(type);
 	}
 
-	if (_log_writer_mavlink) {
+	if (_log_writer_mavlink && type == LogType::Full) {
 		ret = ret || _log_writer_mavlink->is_started();
 	}
 
 	return ret;
 }
 
-bool LogWriter::is_started(Backend query_backend) const
+bool LogWriter::is_started(LogType type, Backend query_backend) const
 {
 	if (query_backend == BackendFile && _log_writer_file) {
-		return _log_writer_file->is_started(LogType::Full);
+		return _log_writer_file->is_started(type);
 	}
 
-	if (query_backend == BackendMavlink && _log_writer_mavlink) {
+	if (query_backend == BackendMavlink && _log_writer_mavlink && type == LogType::Full) {
 		return _log_writer_mavlink->is_started();
 	}
 
 	return false;
 }
 
-void LogWriter::start_log_file(const char *filename)
+void LogWriter::start_log_file(LogType type, const char *filename)
 {
 	if (_log_writer_file) {
-		_log_writer_file->start_log(LogType::Full, filename);
+		_log_writer_file->start_log(type, filename);
 	}
 }
 
-void LogWriter::stop_log_file()
+void LogWriter::stop_log_file(LogType type)
 {
 	if (_log_writer_file) {
-		_log_writer_file->stop_log(LogType::Full);
+		_log_writer_file->stop_log(type);
 	}
 }
 
@@ -158,15 +158,15 @@ void LogWriter::thread_stop()
 	}
 }
 
-int LogWriter::write_message(void *ptr, size_t size, uint64_t dropout_start)
+int LogWriter::write_message(LogType type, void *ptr, size_t size, uint64_t dropout_start)
 {
 	int ret_file = 0, ret_mavlink = 0;
 
 	if (_log_writer_file_for_write) {
-		ret_file = _log_writer_file_for_write->write_message(LogType::Full, ptr, size, dropout_start);
+		ret_file = _log_writer_file_for_write->write_message(type, ptr, size, dropout_start);
 	}
 
-	if (_log_writer_mavlink_for_write) {
+	if (_log_writer_mavlink_for_write && type == LogType::Full) {
 		ret_mavlink = _log_writer_mavlink_for_write->write_message(ptr, size);
 	}
 

--- a/src/modules/logger/log_writer.h
+++ b/src/modules/logger/log_writer.h
@@ -118,21 +118,21 @@ public:
 
 	size_t get_total_written_file() const
 	{
-		if (_log_writer_file) { return _log_writer_file->get_total_written(); }
+		if (_log_writer_file) { return _log_writer_file->get_total_written(LogType::Full); }
 
 		return 0;
 	}
 
 	size_t get_buffer_size_file() const
 	{
-		if (_log_writer_file) { return _log_writer_file->get_buffer_size(); }
+		if (_log_writer_file) { return _log_writer_file->get_buffer_size(LogType::Full); }
 
 		return 0;
 	}
 
 	size_t get_buffer_fill_count_file() const
 	{
-		if (_log_writer_file) { return _log_writer_file->get_buffer_fill_count(); }
+		if (_log_writer_file) { return _log_writer_file->get_buffer_fill_count(LogType::Full); }
 
 		return 0;
 	}

--- a/src/modules/logger/log_writer.h
+++ b/src/modules/logger/log_writer.h
@@ -65,9 +65,9 @@ public:
 	/** stop all running threads and wait for them to exit */
 	void thread_stop();
 
-	void start_log_file(const char *filename);
+	void start_log_file(LogType type, const char *filename);
 
-	void stop_log_file();
+	void stop_log_file(LogType type);
 
 	void start_log_mavlink();
 
@@ -76,20 +76,21 @@ public:
 	/**
 	 * whether logging is currently active or not (any of the selected backends).
 	 */
-	bool is_started() const;
+	bool is_started(LogType type) const;
 
 	/**
 	 * whether logging is currently active or not for a specific backend.
 	 */
-	bool is_started(Backend query_backend) const;
+	bool is_started(LogType type, Backend query_backend) const;
 
 	/**
 	 * Write a single ulog message (including header). The caller must call lock() before calling this.
 	 * @param dropout_start timestamp when lastest dropout occured. 0 if no dropout at the moment.
 	 * @return 0 on success (or if no logging started),
 	 *         -1 if not enough space in the buffer left (file backend), -2 mavlink backend failed
+	 *  add type -> pass through, but not to mavlink if mission log
 	 */
-	int write_message(void *ptr, size_t size, uint64_t dropout_start = 0);
+	int write_message(LogType type, void *ptr, size_t size, uint64_t dropout_start = 0);
 
 	/**
 	 * Select a backend, so that future calls to write_message() only write to the selected
@@ -116,23 +117,23 @@ public:
 		if (_log_writer_file) { _log_writer_file->notify(); }
 	}
 
-	size_t get_total_written_file() const
+	size_t get_total_written_file(LogType type) const
 	{
-		if (_log_writer_file) { return _log_writer_file->get_total_written(LogType::Full); }
+		if (_log_writer_file) { return _log_writer_file->get_total_written(type); }
 
 		return 0;
 	}
 
-	size_t get_buffer_size_file() const
+	size_t get_buffer_size_file(LogType type) const
 	{
-		if (_log_writer_file) { return _log_writer_file->get_buffer_size(LogType::Full); }
+		if (_log_writer_file) { return _log_writer_file->get_buffer_size(type); }
 
 		return 0;
 	}
 
-	size_t get_buffer_fill_count_file() const
+	size_t get_buffer_fill_count_file(LogType type) const
 	{
-		if (_log_writer_file) { return _log_writer_file->get_buffer_fill_count(LogType::Full); }
+		if (_log_writer_file) { return _log_writer_file->get_buffer_fill_count(type); }
 
 		return 0;
 	}

--- a/src/modules/logger/log_writer_file.cpp
+++ b/src/modules/logger/log_writer_file.cpp
@@ -51,17 +51,21 @@ namespace logger
 {
 constexpr size_t LogWriterFile::_min_write_chunk;
 
-
-LogWriterFile::LogWriterFile(size_t buffer_size) :
+LogWriterFile::LogWriterFile(size_t buffer_size)
+	: _buffers{
 	//We always write larger chunks (orb messages) to the buffer, so the buffer
 	//needs to be larger than the minimum write chunk (300 is somewhat arbitrary)
-	_buffer_size(math::max(buffer_size, _min_write_chunk + 300))
+	{
+		math::max(buffer_size, _min_write_chunk + 300),
+		perf_alloc(PC_ELAPSED, "logger_sd_write"), perf_alloc(PC_ELAPSED, "logger_sd_fsync")},
+
+	{
+		300, // buffer size for the mission log (can be kept fairly small)
+		perf_alloc(PC_ELAPSED, "logger_sd_write_mission"), perf_alloc(PC_ELAPSED, "logger_sd_fsync_mission")}
+}
 {
 	pthread_mutex_init(&_mtx, nullptr);
 	pthread_cond_init(&_cv, nullptr);
-	/* allocate write performance counters */
-	_perf_write = perf_alloc(PC_ELAPSED, "logger_sd_write");
-	_perf_fsync = perf_alloc(PC_ELAPSED, "logger_sd_fsync");
 }
 
 bool LogWriterFile::init()
@@ -73,59 +77,26 @@ LogWriterFile::~LogWriterFile()
 {
 	pthread_mutex_destroy(&_mtx);
 	pthread_cond_destroy(&_cv);
-	perf_free(_perf_write);
-	perf_free(_perf_fsync);
-
-	if (_fd >= 0) {
-		::close(_fd);
-	}
-
-	if (_buffer) {
-		delete[] _buffer;
-	}
 }
 
-void LogWriterFile::start_log(const char *filename)
+void LogWriterFile::start_log(LogType type, const char *filename)
 {
-	// register the current file with the hardfault handler: if the system crashes,
-	// the hardfault handler will append the crash log to that file on the next reboot.
-	// Note that we don't deregister it when closing the log, so that crashes after disarming
-	// are appended as well (the same holds for crashes before arming, which can be a bit misleading)
-	int ret = hardfault_store_filename(filename);
+	if (type == LogType::Full) {
+		// register the current file with the hardfault handler: if the system crashes,
+		// the hardfault handler will append the crash log to that file on the next reboot.
+		// Note that we don't deregister it when closing the log, so that crashes after disarming
+		// are appended as well (the same holds for crashes before arming, which can be a bit misleading)
+		int ret = hardfault_store_filename(filename);
 
-	if (ret) {
-		PX4_ERR("Failed to register ULog file to the hardfault handler (%i)", ret);
-	}
-
-	_fd = ::open(filename, O_CREAT | O_WRONLY, PX4_O_MODE_666);
-
-	if (_fd < 0) {
-		PX4_ERR("Can't open log file %s, errno: %d", filename, errno);
-		_should_run = false;
-		return;
-	}
-
-	if (_buffer == nullptr) {
-		_buffer = new uint8_t[_buffer_size];
-
-		if (_buffer == nullptr) {
-			PX4_ERR("Can't create log buffer");
-			::close(_fd);
-			_fd = -1;
-			_should_run = false;
-			return;
+		if (ret) {
+			PX4_ERR("Failed to register ULog file to the hardfault handler (%i)", ret);
 		}
 	}
 
-	PX4_INFO("Opened log file: %s", filename);
-	_should_run = true;
-	_running = true;
-
-	// Clear buffer and counters
-	_head = 0;
-	_count = 0;
-	_total_written = 0;
-	notify();
+	if (_buffers[(int)type].start_log(filename)) {
+		PX4_INFO("Opened %s log file: %s", log_type_str(type), filename);
+		notify();
+	}
 }
 
 int LogWriterFile::hardfault_store_filename(const char *log_file)
@@ -160,9 +131,9 @@ int LogWriterFile::hardfault_store_filename(const char *log_file)
 	return 0;
 }
 
-void LogWriterFile::stop_log()
+void LogWriterFile::stop_log(LogType type)
 {
-	_should_run = false;
+	_buffers[(int)type]._should_run = false;
 	notify();
 }
 
@@ -188,7 +159,7 @@ void LogWriterFile::thread_stop()
 {
 	// this will terminate the main loop of the writer thread
 	_exit_thread = true;
-	_should_run = false;
+	_buffers[0]._should_run = _buffers[1]._should_run = false;
 
 	notify();
 
@@ -218,7 +189,7 @@ void LogWriterFile::run()
 			bool start = false;
 			pthread_mutex_lock(&_mtx);
 			pthread_cond_wait(&_cv, &_mtx);
-			start = _should_run;
+			start = _buffers[0]._should_run || _buffers[1]._should_run;
 			pthread_mutex_unlock(&_mtx);
 
 			if (start) {
@@ -234,95 +205,95 @@ void LogWriterFile::run()
 		int written = 0;
 		hrt_abstime last_fsync = hrt_absolute_time();
 
+		pthread_mutex_lock(&_mtx);
+
 		while (true) {
-			size_t available = 0;
-			void *read_ptr = nullptr;
-			bool is_part = false;
 
-			/* lock _buffer
-			 * wait for sufficient data, cycle on notify()
-			 */
-			pthread_mutex_lock(&_mtx);
+			const hrt_abstime now = hrt_absolute_time();
 
-			while (true) {
-				available = get_read_ptr(&read_ptr, &is_part);
+			/* call fsync periodically to minimize potential loss of data */
+			const bool call_fsync = ++poll_count >= 100 || now - last_fsync > 1_s;
 
-				/* if sufficient data available or partial read or terminating, exit this wait loop */
-				if ((available >= _min_write_chunk) || is_part || !_should_run) {
-					/* GOTO end of block */
-					break;
-				}
-
-				/* wait for a call to notify()
-				 * this call unlocks the mutex while waiting, and returns with the mutex locked
-				 */
-				pthread_cond_wait(&_cv, &_mtx);
+			if (call_fsync) {
+				last_fsync = now;
+				poll_count = 0;
 			}
 
-			pthread_mutex_unlock(&_mtx);
-			written = 0;
+			constexpr size_t min_available[(int)LogType::Count] = {
+				_min_write_chunk,
+				1 // For the mission log, write as soon as there is data available
+			};
 
-			if (available > 0) {
-				perf_begin(_perf_write);
-				written = ::write(_fd, read_ptr, available);
-				perf_end(_perf_write);
+			/* Check all buffers for available data. Mission log is first to avoid drops */
+			int i = (int)LogType::Count - 1;
 
-				const hrt_abstime now = hrt_absolute_time();
+			while (i >= 0) {
+				void *read_ptr;
+				bool is_part;
+				LogFileBuffer &buffer = _buffers[i];
+				size_t available = buffer.get_read_ptr(&read_ptr, &is_part);
 
-				/* call fsync periodically to minimize potential loss of data */
-				if (++poll_count >= 100 || now - last_fsync > 1_s) {
-					perf_begin(_perf_fsync);
-					::fsync(_fd);
-					perf_end(_perf_fsync);
-					poll_count = 0;
-					last_fsync = now;
-				}
+				/* if sufficient data available or partial read or terminating, write data */
+				if (available >= min_available[i] || is_part || (!buffer._should_run && available > 0)) {
+					pthread_mutex_unlock(&_mtx);
 
-				if (written < 0) {
-					PX4_WARN("error writing log file");
-					_should_run = false;
-					/* GOTO end of block */
-					break;
-				}
+					written = buffer.write_to_file(read_ptr, available, call_fsync);
 
-				pthread_mutex_lock(&_mtx);
-				/* subtract bytes written from number in _buffer (_count -= written) */
-				mark_read(written);
-				pthread_mutex_unlock(&_mtx);
+					/* buffer.mark_read() requires _mtx to be locked */
+					pthread_mutex_lock(&_mtx);
 
-				_total_written += written;
-			}
+					if (written >= 0) {
+						/* subtract bytes written from number in buffer (count -= written) */
+						buffer.mark_read(written);
 
-			if (!_should_run && written == static_cast<int>(available) && !is_part) {
-				// Stop only when all data written
-				_running = false;
-				_head = 0;
-				_count = 0;
-
-				if (_fd >= 0) {
-					int res = ::close(_fd);
-					_fd = -1;
-
-					if (res) {
-						PX4_WARN("error closing log file");
+						if (!buffer._should_run && written == static_cast<int>(available) && !is_part) {
+							/* Stop only when all data written */
+							buffer.close_file();
+						}
 
 					} else {
-						PX4_INFO("closed logfile, bytes written: %zu", _total_written);
+						PX4_ERR("write failed (%i)", errno);
+						buffer._should_run = false;
+						buffer.close_file();
 					}
+
+				} else if (call_fsync) {
+					buffer.fsync();
+
+				} else if (available == 0 && !buffer._should_run) {
+					buffer.close_file();
 				}
 
+				/* if split into 2 parts, write the second part immediately as well */
+				if (!is_part) {
+					--i;
+				}
+			}
+
+
+			if (_buffers[0].fd() < 0 && _buffers[1].fd() < 0) {
+				// stop when both files are closed
 				break;
 			}
+
+			/* Wait for a call to notify(), which indicates new data is available.
+			 * Note that at this point there could already be new data available (because of a longer write),
+			 * and calling pthread_cond_wait() will still wait for the next notify(). But this is generally
+			 * not an issue because notify() is called regularly. */
+			pthread_cond_wait(&_cv, &_mtx);
 		}
+
+		// go back to idle
+		pthread_mutex_unlock(&_mtx);
 	}
 }
 
-int LogWriterFile::write_message(void *ptr, size_t size, uint64_t dropout_start)
+int LogWriterFile::write_message(LogType type, void *ptr, size_t size, uint64_t dropout_start)
 {
 	if (_need_reliable_transfer) {
 		int ret;
 
-		while ((ret = write(ptr, size, dropout_start)) == -1) {
+		while ((ret = write(type, ptr, size, dropout_start)) == -1) {
 			unlock();
 			notify();
 			usleep(3000);
@@ -332,17 +303,17 @@ int LogWriterFile::write_message(void *ptr, size_t size, uint64_t dropout_start)
 		return ret;
 	}
 
-	return write(ptr, size, dropout_start);
+	return write(type, ptr, size, dropout_start);
 }
 
-int LogWriterFile::write(void *ptr, size_t size, uint64_t dropout_start)
+int LogWriterFile::write(LogType type, void *ptr, size_t size, uint64_t dropout_start)
 {
-	if (!is_started()) {
+	if (!is_started(type)) {
 		return 0;
 	}
 
 	// Bytes available to write
-	size_t available = _buffer_size - _count;
+	size_t available = _buffers[(int)type].available();
 	size_t dropout_size = 0;
 
 	if (dropout_start) {
@@ -358,14 +329,44 @@ int LogWriterFile::write(void *ptr, size_t size, uint64_t dropout_start)
 		//write dropout msg
 		ulog_message_dropout_s dropout_msg;
 		dropout_msg.duration = (uint16_t)(hrt_elapsed_time(&dropout_start) / 1000);
-		write_no_check(&dropout_msg, sizeof(dropout_msg));
+		_buffers[(int)type].write_no_check(&dropout_msg, sizeof(dropout_msg));
 	}
 
-	write_no_check(ptr, size);
+	_buffers[(int)type].write_no_check(ptr, size);
 	return 0;
 }
 
-void LogWriterFile::write_no_check(void *ptr, size_t size)
+const char *log_type_str(LogType type)
+{
+	switch (type) {
+	case LogType::Full: return "full";
+
+	case LogType::Mission: return "mission";
+
+	case LogType::Count: break;
+	}
+
+	return "unknown";
+}
+
+LogWriterFile::LogFileBuffer::LogFileBuffer(size_t buffer_size, perf_counter_t perf_write, perf_counter_t perf_fsync)
+	: _buffer_size(buffer_size), _perf_write(perf_write), _perf_fsync(perf_fsync)
+{
+}
+
+LogWriterFile::LogFileBuffer::~LogFileBuffer()
+{
+	if (_fd >= 0) {
+		close(_fd);
+	}
+
+	delete[] _buffer;
+
+	perf_free(_perf_write);
+	perf_free(_perf_fsync);
+}
+
+void LogWriterFile::LogFileBuffer::write_no_check(void *ptr, size_t size)
 {
 	size_t n = _buffer_size - _head;	// bytes to end of the buffer
 
@@ -387,7 +388,7 @@ void LogWriterFile::write_no_check(void *ptr, size_t size)
 	_count += size;
 }
 
-size_t LogWriterFile::get_read_ptr(void **ptr, bool *is_part)
+size_t LogWriterFile::LogFileBuffer::get_read_ptr(void **ptr, bool *is_part)
 {
 	// bytes available to read
 	int read_ptr = _head - _count;
@@ -402,6 +403,74 @@ size_t LogWriterFile::get_read_ptr(void **ptr, bool *is_part)
 		*ptr = &_buffer[read_ptr];
 		*is_part = false;
 		return _count;
+	}
+}
+
+bool LogWriterFile::LogFileBuffer::start_log(const char *filename)
+{
+	_fd = ::open(filename, O_CREAT | O_WRONLY, PX4_O_MODE_666);
+
+	if (_fd < 0) {
+		PX4_ERR("Can't open log file %s, errno: %d", filename, errno);
+		return false;
+	}
+
+	if (_buffer == nullptr) {
+		_buffer = new uint8_t[_buffer_size];
+
+		if (_buffer == nullptr) {
+			PX4_ERR("Can't create log buffer");
+			::close(_fd);
+			_fd = -1;
+			return false;
+		}
+	}
+
+	// Clear buffer and counters
+	_head = 0;
+	_count = 0;
+	_total_written = 0;
+
+	_should_run = true;
+
+	return true;
+}
+
+void LogWriterFile::LogFileBuffer::fsync() const
+{
+	perf_begin(_perf_fsync);
+	::fsync(_fd);
+	perf_end(_perf_fsync);
+}
+
+ssize_t LogWriterFile::LogFileBuffer::write_to_file(const void *buffer, size_t size, bool call_fsync) const
+{
+	perf_begin(_perf_write);
+	ssize_t ret = ::write(_fd, buffer, size);
+	perf_end(_perf_write);
+
+	if (call_fsync) {
+		fsync();
+	}
+
+	return ret;
+}
+
+void LogWriterFile::LogFileBuffer::close_file()
+{
+	_head = 0;
+	_count = 0;
+
+	if (_fd >= 0) {
+		int res = close(_fd);
+		_fd = -1;
+
+		if (res) {
+			PX4_WARN("closing log file failed (%i)", errno);
+
+		} else {
+			PX4_INFO("closed logfile, bytes written: %zu", _total_written);
+		}
 	}
 }
 

--- a/src/modules/logger/log_writer_file.cpp
+++ b/src/modules/logger/log_writer_file.cpp
@@ -369,8 +369,9 @@ const char *log_type_str(LogType type)
 	return "unknown";
 }
 
-LogWriterFile::LogFileBuffer::LogFileBuffer(size_t buffer_size, perf_counter_t perf_write, perf_counter_t perf_fsync)
-	: _buffer_size(buffer_size), _perf_write(perf_write), _perf_fsync(perf_fsync)
+LogWriterFile::LogFileBuffer::LogFileBuffer(size_t log_buffer_size, perf_counter_t perf_write,
+		perf_counter_t perf_fsync)
+	: _buffer_size(log_buffer_size), _perf_write(perf_write), _perf_fsync(perf_fsync)
 {
 }
 

--- a/src/modules/logger/log_writer_file.h
+++ b/src/modules/logger/log_writer_file.h
@@ -45,6 +45,19 @@ namespace logger
 {
 
 /**
+ * @enum LogType
+ * Defines different log (file) types
+ */
+enum class LogType {
+	Full = 0, //!< Normal, full size log
+	Mission,  //!< reduced mission log (e.g. for geotagging)
+
+	Count
+};
+
+const char *log_type_str(LogType type);
+
+/**
  * @class LogWriterFile
  * Writes logging data to a file
  */
@@ -64,14 +77,14 @@ public:
 
 	void thread_stop();
 
-	void start_log(const char *filename);
+	void start_log(LogType type, const char *filename);
 
-	void stop_log();
+	void stop_log(LogType type);
 
-	bool is_started() const { return _should_run; }
+	bool is_started(LogType type) const { return _buffers[(int)type]._should_run; }
 
 	/** @see LogWriter::write_message() */
-	int write_message(void *ptr, size_t size, uint64_t dropout_start = 0);
+	int write_message(LogType type, void *ptr, size_t size, uint64_t dropout_start = 0);
 
 	void lock()
 	{
@@ -88,19 +101,19 @@ public:
 		pthread_cond_broadcast(&_cv);
 	}
 
-	size_t get_total_written() const
+	size_t get_total_written(LogType type) const
 	{
-		return _total_written;
+		return _buffers[(int)type].total_written();
 	}
 
-	size_t get_buffer_size() const
+	size_t get_buffer_size(LogType type) const
 	{
-		return _buffer_size;
+		return _buffers[(int)type].buffer_size();
 	}
 
-	size_t get_buffer_fill_count() const
+	size_t get_buffer_fill_count(LogType type) const
 	{
-		return _count;
+		return _buffers[(int)type].count();
 	}
 
 	void set_need_reliable_transfer(bool need_reliable)
@@ -120,13 +133,6 @@ private:
 
 	void run();
 
-	size_t get_read_ptr(void **ptr, bool *is_part);
-
-	void mark_read(size_t n)
-	{
-		_count -= n;
-	}
-
 	/**
 	 * permanently store the ulog file name for the hardfault crash handler, so that it can
 	 * append crash logs to the last ulog file.
@@ -138,30 +144,62 @@ private:
 	/**
 	 * write w/o waiting/blocking
 	 */
-	int write(void *ptr, size_t size, uint64_t dropout_start);
-
-	/**
-	 * Write to the buffer but assuming there is enough space
-	 */
-	inline void write_no_check(void *ptr, size_t size);
+	int write(LogType type, void *ptr, size_t size, uint64_t dropout_start);
 
 	/* 512 didn't seem to work properly, 4096 should match the FAT cluster size */
 	static constexpr size_t	_min_write_chunk = 4096;
 
-	int			_fd = -1;
-	uint8_t 	*_buffer = nullptr;
-	const size_t	_buffer_size;
-	size_t			_head = 0; ///< next position to write to
-	size_t			_count = 0; ///< number of bytes in _buffer to be written
-	size_t		_total_written = 0;
-	bool		_should_run = false;
-	bool		_running = false;
+	class LogFileBuffer
+	{
+	public:
+		LogFileBuffer(size_t buffer_size, perf_counter_t perf_write, perf_counter_t perf_fsync);
+
+		~LogFileBuffer();
+
+		bool start_log(const char *filename);
+
+		void close_file();
+
+		size_t get_read_ptr(void **ptr, bool *is_part);
+
+		/**
+		 * Write to the buffer but assuming there is enough space
+		 */
+		inline void write_no_check(void *ptr, size_t size);
+
+		size_t available() const { return _buffer_size - _count; }
+
+		int fd() const { return _fd; }
+
+		inline ssize_t write_to_file(const void *buffer, size_t size, bool call_fsync) const;
+
+		inline void fsync() const;
+
+		void mark_read(size_t n) { _count -= n; _total_written += n; }
+
+		size_t total_written() const { return _total_written; }
+		size_t buffer_size() const { return _buffer_size; }
+		size_t count() const { return _count; }
+
+		bool _should_run = false;
+
+	private:
+		const size_t _buffer_size;
+		int	_fd = -1;
+		uint8_t *_buffer = nullptr;
+		size_t _head = 0; ///< next position to write to
+		size_t _count = 0; ///< number of bytes in _buffer to be written
+		size_t _total_written = 0;
+		perf_counter_t _perf_write;
+		perf_counter_t _perf_fsync;
+	};
+
+	LogFileBuffer _buffers[(int)LogType::Count];
+
 	bool 		_exit_thread = false;
 	bool		_need_reliable_transfer = false;
 	pthread_mutex_t		_mtx;
 	pthread_cond_t		_cv;
-	perf_counter_t _perf_write;
-	perf_counter_t _perf_fsync;
 	pthread_t _thread = 0;
 };
 

--- a/src/modules/logger/log_writer_file.h
+++ b/src/modules/logger/log_writer_file.h
@@ -152,7 +152,7 @@ private:
 	class LogFileBuffer
 	{
 	public:
-		LogFileBuffer(size_t buffer_size, perf_counter_t perf_write, perf_counter_t perf_fsync);
+		LogFileBuffer(size_t log_buffer_size, perf_counter_t perf_write, perf_counter_t perf_fsync);
 
 		~LogFileBuffer();
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1752,7 +1752,12 @@ void Logger::write_add_logged_msg(LoggerSubscription &subscription, int instance
 {
 	ulog_message_add_logged_s msg;
 
-	if (subscription.msg_ids[instance] == (uint16_t) - 1) {
+	if (subscription.msg_ids[instance] == (uint8_t) - 1) {
+		if (_next_topic_id == (uint8_t) - 1) {
+			// if we land here an uint8 is too small -> switch to uint16
+			PX4_ERR("limit for _next_topic_id reached");
+			return;
+		}
 		subscription.msg_ids[instance] = _next_topic_id++;
 	}
 

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -35,6 +35,7 @@
 
 #include "log_writer.h"
 #include "array.h"
+#include "util.h"
 #include <px4_defines.h>
 #include <drivers/drv_hrt.h>
 #include <uORB/Subscription.hpp>
@@ -49,12 +50,6 @@ extern "C" __EXPORT int logger_main(int argc, char *argv[]);
 
 #define TRY_SUBSCRIBE_INTERVAL 1000*1000	// interval in microseconds at which we try to subscribe to a topic
 // if we haven't succeeded before
-
-#ifdef __PX4_NUTTX
-#define LOG_DIR_LEN 64
-#else
-#define LOG_DIR_LEN 256
-#endif
 
 namespace px4
 {
@@ -185,25 +180,10 @@ private:
 	 */
 	int create_log_dir(tm *tt);
 
-	/** recursively remove a directory
-	 * @return 0 on success, <0 otherwise
-	 */
-	int remove_directory(const char *dir);
-
-	static bool file_exist(const char *filename);
-
 	/**
 	 * Get log file name with directory (create it if necessary)
 	 */
 	int get_log_file_name(char *file_name, size_t file_name_size);
-
-	/**
-	 * Check if there is enough free space left on the SD Card.
-	 * It will remove old log files if there is not enough space,
-	 * and if that fails return 1
-	 * @return 0 on success, 1 if not enough space, <0 on error
-	 */
-	int check_free_space();
 
 	void start_log_file();
 
@@ -274,14 +254,6 @@ private:
 	 * @return true if data written, false otherwise (on overflow)
 	 */
 	bool write_message(void *ptr, size_t size);
-
-	/**
-	 * Get the time for log file name
-	 * @param tt returned time
-	 * @param boot_time use time when booted instead of current time
-	 * @return true on success, false otherwise (eg. if no gps)
-	 */
-	bool get_log_time(struct tm *tt, bool boot_time = false);
 
 	/**
 	 * Parse a file containing a list of uORB topics to log, calling add_topic for each

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -262,6 +262,11 @@ private:
 	 */
 	int add_topics_from_file(const char *fname);
 
+	/**
+	 * Add topic subscriptions based on the _sdlog_profile_handle parameter
+	 */
+	void initialize_configured_topics();
+
 	void add_default_topics();
 	void add_estimator_replay_topics();
 	void add_thermal_calibration_topics();
@@ -270,6 +275,14 @@ private:
 	void add_debug_topics();
 	void add_sensor_comparison_topics();
 
+	/**
+	 * check current arming state and start/stop logging if state changed and according to configured params.
+	 * @param vehicle_status_sub
+	 * @return true if log started
+	 */
+	bool check_arming_state(int vehicle_status_sub);
+
+	void handle_vehicle_command_update(int vehicle_command_sub, orb_advert_t &vehicle_command_ack_pub);
 	void ack_vehicle_command(orb_advert_t &vehicle_command_ack_pub, vehicle_command_s *cmd, uint32_t result);
 
 	/**

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -354,6 +354,13 @@ private:
 	 */
 	void write_load_output();
 
+	/**
+	 * Regularly print the buffer fill state (only if DBGPRINT is set)
+	 * @param total_bytes total written bytes (to the full file), will be reset on each print
+	 * @param timer_start time since last print
+	 */
+	inline void debug_print_buffer(uint32_t &total_bytes, hrt_abstime &timer_start);
+
 
 	uint8_t						*_msg_buffer{nullptr};
 	int						_msg_buffer_len{0};

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -75,8 +75,8 @@ inline bool operator&(SDLogProfileMask a, SDLogProfileMask b)
 struct LoggerSubscription {
 	int fd[ORB_MULTI_MAX_INSTANCES]; ///< uorb subscription. The first fd is also used to store the interval if
 	/// not subscribed yet (-interval - 1)
-	uint16_t msg_ids[ORB_MULTI_MAX_INSTANCES];
 	const orb_metadata *metadata = nullptr;
+	uint8_t msg_ids[ORB_MULTI_MAX_INSTANCES];
 
 	LoggerSubscription() {}
 
@@ -90,7 +90,7 @@ struct LoggerSubscription {
 		}
 
 		for (int i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
-			msg_ids[i] = (uint16_t) - 1;
+			msg_ids[i] = (uint8_t) - 1;
 		}
 	}
 };
@@ -330,7 +330,7 @@ private:
 	uint32_t					_log_interval{0};
 	const orb_metadata				*_polling_topic_meta{nullptr}; ///< if non-null, poll on this topic instead of sleeping
 	orb_advert_t					_mavlink_log_pub{nullptr};
-	uint16_t					_next_topic_id{0}; ///< id of next subscribed ulog topic
+	uint8_t						_next_topic_id{0}; ///< id of next subscribed ulog topic
 	char						*_replay_file_name{nullptr};
 	bool						_should_stop_file_log{false}; /**< if true _next_load_print is set and file logging
 											will be stopped after load printing */

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -34,6 +34,7 @@
 #pragma once
 
 #include "log_writer.h"
+#include "messages.h"
 #include "array.h"
 #include "util.h"
 #include <px4_defines.h>
@@ -162,6 +163,10 @@ private:
 		Watchdog
 	};
 
+	static constexpr size_t 	MAX_TOPICS_NUM = 64; /**< Maximum number of logged topics */
+	static constexpr unsigned	MAX_NO_LOGFILE = 999;	/**< Maximum number of log files */
+	static constexpr const char	*LOG_ROOT = PX4_STORAGEDIR "/log";
+
 	/**
 	 * Write an ADD_LOGGED_MSG to the log for a all current subscriptions and instances
 	 */
@@ -207,6 +212,10 @@ private:
 	 */
 	void write_header();
 
+	/// Array to store written formats (add some more for nested definitions)
+	using WrittenFormats = Array < const orb_metadata *, MAX_TOPICS_NUM + 10 >;
+
+	void write_format(const orb_metadata &meta, WrittenFormats &written_formats, ulog_message_format_s &msg, int level = 1);
 	void write_formats();
 
 	/**
@@ -295,10 +304,6 @@ private:
 	 */
 	void write_load_output();
 
-
-	static constexpr size_t 	MAX_TOPICS_NUM = 64; /**< Maximum number of logged topics */
-	static constexpr unsigned	MAX_NO_LOGFILE = 999;	/**< Maximum number of log files */
-	static constexpr const char	*LOG_ROOT = PX4_STORAGEDIR "/log";
 
 	uint8_t						*_msg_buffer{nullptr};
 	int						_msg_buffer_len{0};

--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -64,7 +64,13 @@ enum class SDLogProfileMask : int32_t {
 	SYSTEM_IDENTIFICATION = 1 << 3,
 	HIGH_RATE =             1 << 4,
 	DEBUG_TOPICS =          1 << 5,
-	SENSOR_COMPARISON =	1 << 6
+	SENSOR_COMPARISON =     1 << 6
+};
+
+enum class MissionLogType : int32_t {
+	Disabled =               0,
+	Complete =               1,
+	Geotagging =             2
 };
 
 inline bool operator&(SDLogProfileMask a, SDLogProfileMask b)
@@ -151,7 +157,7 @@ public:
 	 */
 	static bool request_stop_static();
 
-	void print_statistics();
+	void print_statistics(LogType type);
 
 	void set_arm_override(bool override) { _arm_override = override; }
 
@@ -164,35 +170,62 @@ private:
 	};
 
 	static constexpr size_t 	MAX_TOPICS_NUM = 64; /**< Maximum number of logged topics */
+	static constexpr int		MAX_MISSION_TOPICS_NUM = 5; /**< Maximum number of mission topics */
 	static constexpr unsigned	MAX_NO_LOGFILE = 999;	/**< Maximum number of log files */
-	static constexpr const char	*LOG_ROOT = PX4_STORAGEDIR "/log";
+	static constexpr const char	*LOG_ROOT[(int)LogType::Count] = {
+		PX4_STORAGEDIR "/log",
+		PX4_STORAGEDIR "/mission_log"
+	};
+
+	struct LogFileName {
+		char log_dir[12];           ///< e.g. "2018-01-01" or "sess001"
+		int sess_dir_index{1};      ///< search starting index for 'sess<i>' directory name
+		char log_file_name[31];     ///< e.g. "log001.ulg" or "12_09_00_replayed.ulg"
+		bool has_log_dir{false};
+	};
+
+	struct Statistics {
+		hrt_abstime start_time_file{0};				///< Time when logging started, file backend (not the logger thread)
+		hrt_abstime dropout_start{0};				///< start of current dropout (0 = no dropout)
+		float max_dropout_duration{0.0f};			///< max duration of dropout [s]
+		size_t write_dropouts{0};				///< failed buffer writes due to buffer overflow
+		size_t high_water{0};					///< maximum used write buffer
+	};
+
+	struct MissionSubscription {
+		unsigned min_delta_ms;        ///< minimum time between 2 topic writes [ms]
+		unsigned next_write_time;     ///< next time to write in 0.1 seconds
+	};
 
 	/**
 	 * Write an ADD_LOGGED_MSG to the log for a all current subscriptions and instances
 	 */
-	void write_all_add_logged_msg();
+	void write_all_add_logged_msg(LogType type);
 
 	/**
 	 * Write an ADD_LOGGED_MSG to the log for a given subscription and instance.
 	 * _writer.lock() must be held when calling this.
 	 */
-	void write_add_logged_msg(LoggerSubscription &subscription, int instance);
+	void write_add_logged_msg(LogType type, LoggerSubscription &subscription, int instance);
 
 	/**
 	 * Create logging directory
+	 * @param type
 	 * @param tt if not null, use it for the directory name
-	 * @return 0 on success
+	 * @param log_dir returned log directory path
+	 * @param log_dir_len log_dir buffer length
+	 * @return string length of log_dir (excluding terminating null-char), <0 on error
 	 */
-	int create_log_dir(tm *tt);
+	int create_log_dir(LogType type, tm *tt, char *log_dir, int log_dir_len);
 
 	/**
 	 * Get log file name with directory (create it if necessary)
 	 */
-	int get_log_file_name(char *file_name, size_t file_name_size);
+	int get_log_file_name(LogType type, char *file_name, size_t file_name_size);
 
-	void start_log_file();
+	void start_log_file(LogType type);
 
-	void stop_log_file();
+	void stop_log_file(LogType type);
 
 	void start_log_mavlink();
 
@@ -201,7 +234,8 @@ private:
 	/** check if mavlink logging can be started */
 	bool can_start_mavlink_log() const
 	{
-		return !_writer.is_started(LogWriter::BackendMavlink) && (_writer.backend() & LogWriter::BackendMavlink) != 0;
+		return !_writer.is_started(LogType::Full, LogWriter::BackendMavlink)
+		       && (_writer.backend() & LogWriter::BackendMavlink) != 0;
 	}
 
 	/** get the configured backend as string */
@@ -210,13 +244,14 @@ private:
 	/**
 	 * write the file header with file magic and timestamp.
 	 */
-	void write_header();
+	void write_header(LogType type);
 
 	/// Array to store written formats (add some more for nested definitions)
 	using WrittenFormats = Array < const orb_metadata *, MAX_TOPICS_NUM + 10 >;
 
-	void write_format(const orb_metadata &meta, WrittenFormats &written_formats, ulog_message_format_s &msg, int level = 1);
-	void write_formats();
+	void write_format(LogType type, const orb_metadata &meta, WrittenFormats &written_formats, ulog_message_format_s &msg,
+			  int level = 1);
+	void write_formats(LogType type);
 
 	/**
 	 * write performance counters
@@ -234,22 +269,22 @@ private:
 	 */
 	static void print_load_callback(void *user);
 
-	void write_version();
+	void write_version(LogType type);
 
-	void write_info(const char *name, const char *value);
-	void write_info_multiple(const char *name, const char *value, bool is_continued);
-	void write_info(const char *name, int32_t value);
-	void write_info(const char *name, uint32_t value);
+	void write_info(LogType type, const char *name, const char *value);
+	void write_info_multiple(LogType type, const char *name, const char *value, bool is_continued);
+	void write_info(LogType type, const char *name, int32_t value);
+	void write_info(LogType type, const char *name, uint32_t value);
 
 	/** generic common template method for write_info variants */
 	template<typename T>
-	void write_info_template(const char *name, T value, const char *type_str);
+	void write_info_template(LogType type, const char *name, T value, const char *type_str);
 
-	void write_parameters();
+	void write_parameters(LogType type);
 
-	void write_changed_parameters();
+	void write_changed_parameters(LogType type);
 
-	inline bool copy_if_updated_multi(LoggerSubscription &sub, int multi_instance, void *buffer, bool try_to_subscribe);
+	inline bool copy_if_updated_multi(int sub_idx, int multi_instance, void *buffer, bool try_to_subscribe);
 
 	/**
 	 * Check if a topic instance exists and subscribe to it
@@ -262,7 +297,7 @@ private:
 	 * Must be called with _writer.lock() held.
 	 * @return true if data written, false otherwise (on overflow)
 	 */
-	bool write_message(void *ptr, size_t size);
+	bool write_message(LogType type, void *ptr, size_t size);
 
 	/**
 	 * Parse a file containing a list of uORB topics to log, calling add_topic for each
@@ -270,6 +305,20 @@ private:
 	 * @return number of topics added
 	 */
 	int add_topics_from_file(const char *fname);
+
+	/**
+	 * Add topic subscriptions based on the configured mission log type
+	 */
+	void initialize_mission_topics(MissionLogType type);
+
+	/**
+	 * Add a topic to be logged for the mission log (it's also added to the full log).
+	 * The interval is expected to be 0 or large (in the order of 0.1 seconds or higher).
+	 * Must be called before all other topics are added.
+	 * @param name topic name
+	 * @param interval limit rate if >0 [ms], otherwise log as fast as the topic is updated.
+	 */
+	void add_mission_topic(const char *name, unsigned interval = 0);
 
 	/**
 	 * Add topic subscriptions based on the _sdlog_profile_handle parameter
@@ -287,9 +336,10 @@ private:
 	/**
 	 * check current arming state and start/stop logging if state changed and according to configured params.
 	 * @param vehicle_status_sub
+	 * @param mission_log_type
 	 * @return true if log started
 	 */
-	bool check_arming_state(int vehicle_status_sub);
+	bool check_arming_state(int vehicle_status_sub, MissionLogType mission_log_type);
 
 	void handle_vehicle_command_update(int vehicle_command_sub, orb_advert_t &vehicle_command_ack_pub);
 	void ack_vehicle_command(orb_advert_t &vehicle_command_ack_pub, vehicle_command_s *cmd, uint32_t result);
@@ -307,25 +357,22 @@ private:
 
 	uint8_t						*_msg_buffer{nullptr};
 	int						_msg_buffer_len{0};
-	char 						_log_dir[LOG_DIR_LEN] {};
-	int						_sess_dir_index{1}; ///< search starting index for 'sess<i>' directory name
-	char 						_log_file_name[32];
-	bool						_has_log_dir{false};
+
+	LogFileName					_file_name[(int)LogType::Count];
+
 	bool						_was_armed{false};
 	bool						_arm_override{false};
 
-
-	// statistics
-	hrt_abstime					_start_time_file{0}; ///< Time when logging started, file backend (not the logger thread)
-	hrt_abstime					_dropout_start{0}; ///< start of current dropout (0 = no dropout)
-	float						_max_dropout_duration{0.0f}; ///< max duration of dropout [s]
-	size_t						_write_dropouts{0}; ///< failed buffer writes due to buffer overflow
-	size_t						_high_water{0}; ///< maximum used write buffer
+	Statistics					_statistics[(int)LogType::Count];
 
 	const bool 					_log_on_start;
 	const bool 					_log_until_shutdown;
 	const bool					_log_name_timestamp;
-	Array<LoggerSubscription, MAX_TOPICS_NUM>	_subscriptions;
+
+	Array<LoggerSubscription, MAX_TOPICS_NUM>	_subscriptions; ///< all subscriptions for full & mission log (in front)
+	MissionSubscription 				_mission_subscriptions[MAX_MISSION_TOPICS_NUM]; ///< additional data for mission subscriptions
+	int						_num_mission_subs{0};
+
 	LogWriter					_writer;
 	uint32_t					_log_interval{0};
 	const orb_metadata				*_polling_topic_meta{nullptr}; ///< if non-null, poll on this topic instead of sleeping
@@ -333,15 +380,15 @@ private:
 	uint8_t						_next_topic_id{0}; ///< id of next subscribed ulog topic
 	char						*_replay_file_name{nullptr};
 	bool						_should_stop_file_log{false}; /**< if true _next_load_print is set and file logging
-											will be stopped after load printing */
+											will be stopped after load printing (for the full log) */
 	print_load_s					_load{}; ///< process load data
 	hrt_abstime					_next_load_print{0}; ///< timestamp when to print the process load
 	PrintLoadReason					_print_load_reason;
 
-	// control
 	param_t						_sdlog_profile_handle{PARAM_INVALID};
 	param_t						_log_utc_offset{PARAM_INVALID};
 	param_t						_log_dirs_max{PARAM_INVALID};
+	param_t						_mission_log{PARAM_INVALID};
 };
 
 } //namespace logger

--- a/src/modules/logger/messages.h
+++ b/src/modules/logger/messages.h
@@ -67,7 +67,7 @@ struct ulog_message_format_s {
 	uint16_t msg_size; //size of message - ULOG_MSG_HEADER_LEN
 	uint8_t msg_type = static_cast<uint8_t>(ULogMessageType::FORMAT);
 
-	char format[2096];
+	char format[1500];
 };
 
 struct ulog_message_add_logged_s {

--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -86,7 +86,7 @@ PARAM_DEFINE_INT32(SDLOG_MODE, 0);
  * @reboot_required true
  * @group SD Logging
  */
-PARAM_DEFINE_INT32(SDLOG_MISSION, 0);
+PARAM_DEFINE_INT32(SDLOG_MISSION, 1);
 
 /**
  * Logging topic profile (integer bitmask).

--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -67,21 +67,20 @@ PARAM_DEFINE_INT32(SDLOG_MODE, 0);
 /**
  * Mission Log
  *
- * If enabled, a second mission log file will be written to the SD card.
- * This is a small log file with reduced information content (such as the
- * vehicle position) that for example can be used for flight statistics,
- * regulatory purposes or geotagging.
+ * If enabled, a small additional "mission" log file will be written to the SD card.
+ * The log contains just those messages that are useful for tasks like
+ * generating flight statistics and geotagging.
  *
- * The normal full log file will still be generated and it contains all
- * the data that a mission log contains.
- *
- * The different modes can be used to further reduce the amount of logged data
- * and thus the log file size. Geotagging for instance will only log data
- * required for geotagging.
+ * The different modes can be used to further reduce the logged data
+ * (and thus the log file size). For example, choose geotagging mode to
+ * only log data required for geotagging.
+
+ * Note that the normal/full log is still created, and contains all
+ * the data in the mission log (and more).
  *
  * @value 0 Disabled
- * @value 1 Complete
- * @value 2 Geotagging
+ * @value 1 All mission messages
+ * @value 2 Geotagging messages
  *
  * @reboot_required true
  * @group SD Logging

--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -59,12 +59,34 @@ PARAM_DEFINE_INT32(SDLOG_UTC_OFFSET, 0);
  * @value 1 from boot until disarm
  * @value 2 from boot until shutdown
  *
- * @min 0
- * @max 2
  * @reboot_required true
  * @group SD Logging
  */
 PARAM_DEFINE_INT32(SDLOG_MODE, 0);
+
+/**
+ * Mission Log
+ *
+ * If enabled, a second mission log file will be written to the SD card.
+ * This is a small log file with reduced information content (such as the
+ * vehicle position) that for example can be used for flight statistics,
+ * regulatory purposes or geotagging.
+ *
+ * The normal full log file will still be generated and it contains all
+ * the data that a mission log contains.
+ *
+ * The different modes can be used to further reduce the amount of logged data
+ * and thus the log file size. Geotagging for instance will only log data
+ * required for geotagging.
+ *
+ * @value 0 Disabled
+ * @value 1 Complete
+ * @value 2 Geotagging
+ *
+ * @reboot_required true
+ * @group SD Logging
+ */
+PARAM_DEFINE_INT32(SDLOG_MISSION, 0);
 
 /**
  * Logging topic profile (integer bitmask).
@@ -110,6 +132,8 @@ PARAM_DEFINE_INT32(SDLOG_PROFILE, 3);
  *
  * If this is set to 0, old directories will only be removed if the free space falls below
  * the minimum.
+ *
+ * Note: this does not apply to mission log files.
  *
  * @min 0
  * @max 1000

--- a/src/modules/logger/util.cpp
+++ b/src/modules/logger/util.cpp
@@ -1,0 +1,295 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "util.h"
+
+#include <dirent.h>
+#include <sys/stat.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include <uORB/topics/vehicle_gps_position.h>
+
+#include <drivers/drv_hrt.h>
+#include <px4_log.h>
+#include <px4_time.h>
+#include <systemlib/mavlink_log.h>
+
+#if defined(__PX4_DARWIN)
+#include <sys/param.h>
+#include <sys/mount.h>
+#else
+#include <sys/statfs.h>
+#endif
+
+#define GPS_EPOCH_SECS ((time_t)1234567890ULL)
+
+typedef decltype(statfs::f_bavail) px4_statfs_buf_f_bavail_t;
+
+namespace px4
+{
+namespace logger
+{
+namespace util
+{
+
+bool file_exist(const char *filename)
+{
+	struct stat buffer;
+	return stat(filename, &buffer) == 0;
+}
+
+bool get_log_time(struct tm *tt, int utc_offset_sec, bool boot_time)
+{
+	int vehicle_gps_position_sub = orb_subscribe(ORB_ID(vehicle_gps_position));
+
+	if (vehicle_gps_position_sub < 0) {
+		return false;
+	}
+
+	/* Get the latest GPS publication */
+	vehicle_gps_position_s gps_pos;
+	time_t utc_time_sec;
+	bool use_clock_time = true;
+
+	if (orb_copy(ORB_ID(vehicle_gps_position), vehicle_gps_position_sub, &gps_pos) == 0) {
+		utc_time_sec = gps_pos.time_utc_usec / 1e6;
+
+		if (gps_pos.fix_type >= 2 && utc_time_sec >= GPS_EPOCH_SECS) {
+			use_clock_time = false;
+		}
+	}
+
+	orb_unsubscribe(vehicle_gps_position_sub);
+
+	if (use_clock_time) {
+		/* take clock time if there's no fix (yet) */
+		struct timespec ts = {};
+		px4_clock_gettime(CLOCK_REALTIME, &ts);
+		utc_time_sec = ts.tv_sec + (ts.tv_nsec / 1e9);
+
+		if (utc_time_sec < GPS_EPOCH_SECS) {
+			return false;
+		}
+	}
+
+	/* strip the time elapsed since boot */
+	if (boot_time) {
+		utc_time_sec -= hrt_absolute_time() / 1e6;
+	}
+
+	/* apply utc offset */
+	utc_time_sec += utc_offset_sec;
+
+	return gmtime_r(&utc_time_sec, tt) != nullptr;
+}
+
+int check_free_space(const char *log_root_dir, int32_t max_log_dirs_to_keep, orb_advert_t &mavlink_log_pub,
+		     int &sess_dir_index)
+{
+	struct statfs statfs_buf;
+
+	if (max_log_dirs_to_keep == 0) {
+		max_log_dirs_to_keep = INT32_MAX;
+	}
+
+	// remove old logs if the free space falls below a threshold
+	do {
+		if (statfs(log_root_dir, &statfs_buf) != 0) {
+			return PX4_ERROR;
+		}
+
+		DIR *dp = opendir(log_root_dir);
+
+		if (dp == nullptr) {
+			break; // ignore if we cannot access the log directory
+		}
+
+		struct dirent *result = nullptr;
+
+		int num_sess = 0, num_dates = 0;
+
+		// There are 2 directory naming schemes: sess<i> or <year>-<month>-<day>.
+		// For both we find the oldest and then remove the one which has more directories.
+		int year_min = 10000, month_min = 99, day_min = 99, sess_idx_min = 99999999, sess_idx_max = 0;
+
+		while ((result = readdir(dp))) {
+			int year, month, day, sess_idx;
+
+			if (sscanf(result->d_name, "sess%d", &sess_idx) == 1) {
+				++num_sess;
+
+				if (sess_idx > sess_idx_max) {
+					sess_idx_max = sess_idx;
+				}
+
+				if (sess_idx < sess_idx_min) {
+					sess_idx_min = sess_idx;
+				}
+
+			} else if (sscanf(result->d_name, "%d-%d-%d", &year, &month, &day) == 3) {
+				++num_dates;
+
+				if (year < year_min) {
+					year_min = year;
+					month_min = month;
+					day_min = day;
+
+				} else if (year == year_min) {
+					if (month < month_min) {
+						month_min = month;
+						day_min = day;
+
+					} else if (month == month_min) {
+						if (day < day_min) {
+							day_min = day;
+						}
+					}
+				}
+			}
+		}
+
+		closedir(dp);
+
+		sess_dir_index = sess_idx_max + 1;
+
+
+		uint64_t min_free_bytes = 300ULL * 1024ULL * 1024ULL;
+		uint64_t total_bytes = (uint64_t)statfs_buf.f_blocks * statfs_buf.f_bsize;
+
+		if (total_bytes / 10 < min_free_bytes) { // reduce the minimum if it's larger than 10% of the disk size
+			min_free_bytes = total_bytes / 10;
+		}
+
+		if (num_sess + num_dates <= max_log_dirs_to_keep &&
+		    statfs_buf.f_bavail >= (px4_statfs_buf_f_bavail_t)(min_free_bytes / statfs_buf.f_bsize)) {
+			break; // enough free space and limit not reached
+		}
+
+		if (num_sess == 0 && num_dates == 0) {
+			break; // nothing to delete
+		}
+
+		char directory_to_delete[LOG_DIR_LEN];
+		int n;
+
+		if (num_sess >= num_dates) {
+			n = snprintf(directory_to_delete, sizeof(directory_to_delete), "%s/sess%03u", log_root_dir, sess_idx_min);
+
+		} else {
+			n = snprintf(directory_to_delete, sizeof(directory_to_delete), "%s/%04u-%02u-%02u", log_root_dir, year_min, month_min,
+				     day_min);
+		}
+
+		if (n >= (int)sizeof(directory_to_delete)) {
+			PX4_ERR("log path too long (%i)", n);
+			break;
+		}
+
+		PX4_INFO("removing log directory %s to get more space (left=%u MiB)", directory_to_delete,
+			 (unsigned int)(statfs_buf.f_bavail * statfs_buf.f_bsize / 1024U / 1024U));
+
+		if (remove_directory(directory_to_delete)) {
+			PX4_ERR("Failed to delete directory");
+			break;
+		}
+
+	} while (true);
+
+
+	/* use a threshold of 50 MiB: if below, do not start logging */
+	if (statfs_buf.f_bavail < (px4_statfs_buf_f_bavail_t)(50 * 1024 * 1024 / statfs_buf.f_bsize)) {
+		mavlink_log_critical(&mavlink_log_pub,
+				     "[logger] Not logging; SD almost full: %u MiB",
+				     (unsigned int)(statfs_buf.f_bavail * statfs_buf.f_bsize / 1024U / 1024U));
+		return 1;
+	}
+
+	return PX4_OK;
+}
+
+int remove_directory(const char *dir)
+{
+	DIR *d = opendir(dir);
+	size_t dir_len = strlen(dir);
+	struct dirent *p;
+	int ret = 0;
+
+	if (!d) {
+		return -1;
+	}
+
+	while (!ret && (p = readdir(d))) {
+		int ret2 = -1;
+		char *buf;
+		size_t len;
+
+		if (!strcmp(p->d_name, ".") || !strcmp(p->d_name, "..")) {
+			continue;
+		}
+
+		len = dir_len + strlen(p->d_name) + 2;
+		buf = new char[len];
+
+		if (buf) {
+			struct stat statbuf;
+
+			snprintf(buf, len, "%s/%s", dir, p->d_name);
+
+			if (!stat(buf, &statbuf)) {
+				if (S_ISDIR(statbuf.st_mode)) {
+					ret2 = remove_directory(buf);
+
+				} else {
+					ret2 = unlink(buf);
+				}
+			}
+
+			delete[] buf;
+		}
+
+		ret = ret2;
+	}
+
+	closedir(d);
+
+	if (!ret) {
+		ret = rmdir(dir);
+	}
+
+	return ret;
+}
+
+} //namespace util
+} //namespace logger
+} //namespace px4

--- a/src/modules/logger/util.h
+++ b/src/modules/logger/util.h
@@ -1,0 +1,89 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <stdint.h>
+#include <time.h>
+
+#include <uORB/uORB.h>
+
+#ifdef __PX4_NUTTX
+#define LOG_DIR_LEN 64
+#else
+#define LOG_DIR_LEN 256
+#endif
+
+namespace px4
+{
+namespace logger
+{
+namespace util
+{
+
+/**
+ * Recursively remove a directory
+ * @return 0 on success, <0 otherwise
+ */
+int remove_directory(const char *dir);
+
+/**
+ * check if a file exists
+ */
+bool file_exist(const char *filename);
+
+/**
+ * Check if there is enough free space left on the SD Card.
+ * It will remove old log files if there is not enough space,
+ * and if that fails return 1, and send a user message
+ * @param log_root_dir log root directory: it's expected to contain directories in the form of sess%i or %d-%d-%d (year, month, day)
+ * @param max_log_dirs_to_keep maximum log directories to keep (set to 0 for unlimited)
+ * @param mavlink_log_pub
+ * @param sess_dir_index output argument: will be set to the next free directory sess%i index.
+ * @return 0 on success, 1 if not enough space, <0 on error
+ */
+int check_free_space(const char *log_root_dir, int32_t max_log_dirs_to_keep, orb_advert_t &mavlink_log_pub,
+		     int &sess_dir_index);
+
+/**
+ * Get the time for log file name
+ * @param tt returned time
+ * @param utc_offset_sec UTC time offset [s]
+ * @param boot_time use time when booted instead of current time
+ * @return true on success, false otherwise (eg. if no gps)
+ */
+bool get_log_time(struct tm *tt, int utc_offset_sec = 0, bool boot_time = false);
+
+} //namespace util
+} //namespace logger
+} //namespace px4

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -283,8 +283,8 @@ public:
 	float		get_yaw_timeout() const { return _param_yaw_timeout.get(); }
 	float		get_yaw_threshold() const { return _param_yaw_err.get(); }
 
-	float		get_vtol_back_trans_deceleration() const { return _param_back_trans_dec_mss.get(); }
-	float		get_vtol_reverse_delay() const { return _param_reverse_delay.get(); }
+	float		get_vtol_back_trans_deceleration() const { return _param_back_trans_dec_mss; }
+	float		get_vtol_reverse_delay() const { return _param_reverse_delay; }
 
 	bool		force_vtol();
 
@@ -371,12 +371,13 @@ private:
 		(ParamFloat<px4::params::MIS_LTRMIN_ALT>) _param_loiter_min_alt,
 		(ParamFloat<px4::params::MIS_TAKEOFF_ALT>) _param_takeoff_min_alt,
 		(ParamFloat<px4::params::MIS_YAW_TMT>) _param_yaw_timeout,
-		(ParamFloat<px4::params::MIS_YAW_ERR>) _param_yaw_err,
-
-		// VTOL parameters TODO: get these out of navigator
-		(ParamFloat<px4::params::VT_B_DEC_MSS>) _param_back_trans_dec_mss,
-		(ParamFloat<px4::params::VT_B_REV_DEL>) _param_reverse_delay
+		(ParamFloat<px4::params::MIS_YAW_ERR>) _param_yaw_err
 	)
+
+	param_t _handle_back_trans_dec_mss{PARAM_INVALID};
+	param_t _handle_reverse_delay{PARAM_INVALID};
+	float _param_back_trans_dec_mss{0.f};
+	float _param_reverse_delay{0.f};
 
 	float _mission_cruising_speed_mc{-1.0f};
 	float _mission_cruising_speed_fw{-1.0f};

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -110,6 +110,9 @@ Navigator::Navigator() :
 	_navigation_mode_array[8] = &_land;
 	_navigation_mode_array[9] = &_precland;
 	_navigation_mode_array[10] = &_follow_target;
+
+	_handle_back_trans_dec_mss = param_find("VT_B_DEC_MSS");
+	_handle_reverse_delay = param_find("VT_B_REV_DEL");
 }
 
 void
@@ -162,6 +165,14 @@ Navigator::params_update()
 	parameter_update_s param_update;
 	orb_copy(ORB_ID(parameter_update), _param_update_sub, &param_update);
 	updateParams();
+
+	if (_handle_back_trans_dec_mss != PARAM_INVALID) {
+		param_get(_handle_back_trans_dec_mss, &_param_back_trans_dec_mss);
+	}
+
+	if (_handle_reverse_delay != PARAM_INVALID) {
+		param_get(_handle_reverse_delay, &_param_reverse_delay);
+	}
 }
 
 void


### PR DESCRIPTION
This adds a new log file to the SD card configurable via `SDLOG_MISSION` parameter.

### Use-cases
It's also a ULog file, but only contains minimal information for the following use-cases:
- geotagging/survey (more generally: extract data collected by the pixhawk during a mission and needed for post-processing)
- cloud upload & statistics: keeping track of where and how long a vehicle has flown, and if there were problems.
- regulation: keeping a small log to show where a drone was flown, what failures happened etc.

It is stored in another directory (`mission_log`) to keep the logs separate from the normal flight logs.

@dogmaphobic This will need an interface update on the QGC side, and maybe changes/extensions to the log download. I have not looked into that yet.

### Implementation
- the general structure of the logger is the same, but the mission logs use a separate independent write buffer.
- optimization to reduce the header size: now only the message formats are written for messages that are actually logged. Reduces the header size by about 13KB for a normal log.
- due to other optimizations, RAM usage does not increase if the mission log is disabled.
  If enabled, only the additional buffer of 300 bytes is required.

### Testing
I ran a stress-test on a low-quality SD card for 1h:30min with 90KB/s normal logging rate and enabled mission log with 5Hz camera capture publication. There were no drops for the mission log, and the maximum used buffer was 200 bytes, so 300 bytes buffer size will be enough.
CPU load minimally increased from 5.6% + 1.7% to 5.7% + 1.8% for the main and writer threads.

Fixes https://github.com/PX4/Firmware/issues/10189.

I enabled the mission log by default so that we get it field-tested. But it does not have to be enabled later on.