### PR TITLE
fmu:Add Range checking for PWM5 modes

### DIFF
--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1835,10 +1835,14 @@ PX4FMU::pwm_ioctl(file *filp, int cmd, unsigned long arg)
 
 	/* FALLTHROUGH */
 	case PWM_SERVO_SET(5):
+		if (_mode < MODE_6PWM) {
+			ret = -EINVAL;
+			break;
+		}
 
 	/* FALLTHROUGH */
 	case PWM_SERVO_SET(4):
-		if (_mode < MODE_6PWM) {
+		if (_mode < MODE_5PWM1CAP) {
 			ret = -EINVAL;
 			break;
 		}
@@ -1901,8 +1905,13 @@ PX4FMU::pwm_ioctl(file *filp, int cmd, unsigned long arg)
 
 	/* FALLTHROUGH */
 	case PWM_SERVO_GET(5):
-	case PWM_SERVO_GET(4):
 		if (_mode < MODE_6PWM) {
+			ret = -EINVAL;
+			break;
+		}
+
+	case PWM_SERVO_GET(4):
+		if (_mode < MODE_5PWM1CAP) {
 			ret = -EINVAL;
 			break;
 		}


### PR DESCRIPTION
was:
```
pwm info
device: /dev/pwm_output0
channel 1: 900 us (default rate: 50 Hz failsafe: 0, disarmed: 900 us, min: 1075 us, max: 1950 us, trim:  0.00)
channel 2: 900 us (default rate: 50 Hz failsafe: 0, disarmed: 900 us, min: 1075 us, max: 1950 us, trim:  0.00)
channel 3: 900 us (default rate: 50 Hz failsafe: 0, disarmed: 900 us, min: 1075 us, max: 1950 us, trim:  0.00)
channel 4: 900 us (default rate: 50 Hz failsafe: 0, disarmed: 900 us, min: 1075 us, max: 1950 us, trim:  0.00)
4: ERROR
channel group 0: channels 1 2 3 4
channel group 1: channels 5
channel group 2: channels 7 8

```
is:
```
pwm info
device: /dev/pwm_output0
channel 1: 900 us (default rate: 50 Hz failsafe: 0, disarmed: 900 us, min: 1075 us, max: 1950 us, trim:  0.00)
channel 2: 900 us (default rate: 50 Hz failsafe: 0, disarmed: 900 us, min: 1075 us, max: 1950 us, trim:  0.00)
channel 3: 900 us (default rate: 50 Hz failsafe: 0, disarmed: 900 us, min: 1075 us, max: 1950 us, trim:  0.00)
channel 4: 900 us (default rate: 50 Hz failsafe: 0, disarmed: 900 us, min: 1075 us, max: 1950 us, trim:  0.00)
channel 5: 1500 us (default rate: 50 Hz failsafe: 0, disarmed: 0 us, min: 1000 us, max: 2000 us, trim:  0.00)
channel group 0: channels 1 2 3 4
channel group 1: channels 5
channel group 2: channels 7 8
```
