### PR TITLE
Hotfix for LowPassFilter2p: fix _cutoff_freq <= 0 (disabled filter)

### DIFF
--- a/src/lib/mathlib/math/filter/LowPassFilter2p.cpp
+++ b/src/lib/mathlib/math/filter/LowPassFilter2p.cpp
@@ -50,7 +50,7 @@ void LowPassFilter2p::set_cutoff_frequency(float sample_freq, float cutoff_freq)
 
 	if (_cutoff_freq <= 0.0f) {
 		// no filtering
-		_b0 = 0.0f;
+		_b0 = 1.0f;
 		_b1 = 0.0f;
 		_b2 = 0.0f;
 

--- a/src/lib/mathlib/math/filter/LowPassFilter2pVector3f.cpp
+++ b/src/lib/mathlib/math/filter/LowPassFilter2pVector3f.cpp
@@ -50,7 +50,7 @@ void LowPassFilter2pVector3f::set_cutoff_frequency(float sample_freq, float cuto
 
 	if (_cutoff_freq <= 0.0f) {
 		// no filtering
-		_b0 = 0.0f;
+		_b0 = 1.0f;
 		_b1 = 0.0f;
 		_b2 = 0.0f;
 


### PR DESCRIPTION
If the filter was disabled, the apply() would always return 0.