### PR TITLE
Set pmw3901 driver with HPWORK queue

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -162,7 +162,10 @@ then
 	hmc5883 -C -T -X start
 	lis3mdl -X start
 	ist8310 -C start
-
+	
+    # External SPI bus PMW3901
+    pmw3901 start
+	
 	# Internal I2C bus
 	hmc5883 -C -T -I -R 4 start
 

--- a/cmake/configs/nuttx_px4fmu-v2_default.cmake
+++ b/cmake/configs/nuttx_px4fmu-v2_default.cmake
@@ -29,8 +29,8 @@ set(config_module_list
 	#drivers/bst
 	#drivers/camera_trigger
 	#drivers/differential_pressure/ets
-	drivers/differential_pressure/ms4525
-	drivers/differential_pressure/ms5525
+	#drivers/differential_pressure/ms4525
+	#drivers/differential_pressure/ms5525
 	#drivers/differential_pressure/sdp3x
 	drivers/distance_sensor/ll40ls
 	#drivers/distance_sensor/mb12xx
@@ -67,6 +67,7 @@ set(config_module_list
 	drivers/stm32/tone_alarm
 	#drivers/tap_esc
 	drivers/vmount
+	drivers/pmw3901
 	modules/sensors
 
 	#

--- a/src/drivers/boards/px4fmu-v2/board_config.h
+++ b/src/drivers/boards/px4fmu-v2/board_config.h
@@ -277,6 +277,10 @@
 #define GPIO_SPI1_CS_BARO                GPIO_SPI1_CS_PD7  /* MS5611    MS5611  */
 #define GPIO_SPI1_CS_HMC                 GPIO_SPI1_CS_PC1  /* HMC5983   Removed */
 
+/*  SPI1 External Bus */
+#define PX4_SPI_BUS_EXPANSION 			1
+#define PX4_SPIDEV_EXPANSION_2      	PX4_MK_SPI_SEL(PX4_SPI_BUS_EXPANSION, 1) 		// OPTICAL FLOW BREAKOUT
+
 /* N.B. bus moves from SPI1 to SPI4 */
 #define GPIO_SPI4_GYRO_EXT_CS            GPIO_SPI4_CS_PC13
 #define GPIO_SPI4_BARO_EXT_CS            GPIO_SPI4_CS_PC14

--- a/src/drivers/distance_sensor/ll40ls/LidarLitePWM.cpp
+++ b/src/drivers/distance_sensor/ll40ls/LidarLitePWM.cpp
@@ -177,7 +177,7 @@ int LidarLitePWM::measure()
 	_range.type = distance_sensor_s::MAV_DISTANCE_SENSOR_LASER;
 	_range.max_distance = get_maximum_distance();
 	_range.min_distance = get_minimum_distance();
-	_range.current_distance = float(_pwm.pulse_width) * 1e-3f;   /* 10 usec = 1 cm distance for LIDAR-Lite */
+	_range.current_distance = float(_pwm.pulse_width) * 2e-4f;   /* 10 usec = 1 cm distance for LIDAR-Lite */
 	_range.covariance = 0.0f;
 	_range.orientation = _rotation;
 	/* TODO: set proper ID */

--- a/src/drivers/pmw3901/pmw3901.cpp
+++ b/src/drivers/pmw3901/pmw3901.cpp
@@ -572,8 +572,8 @@ PMW3901::collect()
 	readMotionCount(delta_x_raw, delta_y_raw);
 
 
-	delta_x = - delta_x_raw / 500.0f;		// proportional factor + convert from pixels to radians
-	delta_y = - delta_y_raw / 500.0f;		// proportional factor + convert from pixels to radians
+	delta_x = - delta_y_raw / 500.0f;		// proportional factor + convert from pixels to radians
+	delta_y = delta_x_raw / 500.0f;		// proportional factor + convert from pixels to radians
 
 	struct optical_flow_s report;
 


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary.

**Test data / coverage**
Logs uploaded to http://logs.px4.io or screenshots.

**Describe problem solved by the proposed pull request**
Refer to my topic here http://discuss.px4.io/t/indoor-position-hold-using-ekf2-with-flow-sensor-has-toilet-bowling/8154 
Irregular time dt between optical flow data acquisition from sensor on SPI bus found and is due from the work queue being set as LPWORK. dt_flow is suppose to be 10ms but it gets to even 40ms in worst case.
Changing LPWORK to HPWORK seems to resolve this issue and time dt become more solid with no more than 1~2ms delay. 

**Describe your preferred solution**
A clear and concise description of what you have implemented.
In void PMW3901::cycle()
Change work_queue(LPWORK  to work_queue(HPWORK

**Describe possible alternatives**
A clear and concise description of alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots for the feature request here.
