### PR TITLE
fix reposition: set acceptance radius

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -319,6 +319,7 @@ Navigator::run()
 				rep->current.type = position_setpoint_s::SETPOINT_TYPE_LOITER;
 				rep->current.cruising_speed = get_cruising_speed();
 				rep->current.cruising_throttle = get_cruising_throttle();
+				rep->current.acceptance_radius = get_acceptance_radius();
 
 				// Go on and check which changes had been requested
 				if (PX4_ISFINITE(cmd.param4)) {


### PR DESCRIPTION
Previously the acceptance radius was 0, so the FlightTaskAutoLine was
randomly changing yaw and sometimes going into a random direction (see  #10757).

There is still something else wrong in there, but this patch avoids the reposition bug. I see 2 problems:
- The FlightTaskAuto contains states and resets certain attributes when switching (https://github.com/PX4/Firmware/blob/master/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp#L468). In case of the reposition, the switches were random due to numerical inaccuracies. If possible we should avoid these states.
- FlightTaskAutoLine uses _target and _prev_wp to determine the velocity direction (https://github.com/PX4/Firmware/blob/master/src/lib/FlightTasks/tasks/AutoLine/FlightTaskAutoLine.cpp#L79). However this might not reflect where the vehicle currently is (I guess the states are meant to prevent this, but it doesn't seem to work).

The combination of all these led to the unexpected behavior.

Fixes #10757
