### PR TITLE
MC: towards 1kHz rate controller loop

### DIFF
--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -102,12 +102,12 @@ private:
 	void		sensor_bias_poll();
 	void		vehicle_land_detected_poll();
 	void		sensor_correction_poll();
-	void		vehicle_attitude_poll();
+	bool		vehicle_attitude_poll();
 	void		vehicle_attitude_setpoint_poll();
 	void		vehicle_control_mode_poll();
-	void		vehicle_manual_poll();
+	bool		vehicle_manual_poll();
 	void		vehicle_motor_limits_poll();
-	void		vehicle_rates_setpoint_poll();
+	bool		vehicle_rates_setpoint_poll();
 	void		vehicle_status_poll();
 
 	void		publish_actuator_controls();
@@ -117,7 +117,7 @@ private:
 	/**
 	 * Attitude controller.
 	 */
-	void		control_attitude(float dt);
+	void		control_attitude();
 
 	/**
 	 * Attitude rates controller.

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -110,6 +110,10 @@ private:
 	void		vehicle_rates_setpoint_poll();
 	void		vehicle_status_poll();
 
+	void		publish_actuator_controls();
+	void		publish_rates_setpoint();
+	void		publish_rate_controller_status();
+
 	/**
 	 * Attitude controller.
 	 */

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -720,6 +720,14 @@ MulticopterAttitudeControl::run()
 			/* copy gyro data */
 			orb_copy(ORB_ID(sensor_gyro), _sensor_gyro_sub[_selected_gyro], &_sensor_gyro);
 
+			/* run the rate controller immediately after a gyro update */
+			if (_v_control_mode.flag_control_rates_enabled) {
+				control_attitude_rates(dt);
+
+				publish_actuator_controls();
+				publish_rate_controller_status();
+			}
+
 			/* check for updates in other topics */
 			vehicle_control_mode_poll();
 			vehicle_status_poll();
@@ -770,13 +778,6 @@ MulticopterAttitudeControl::run()
 						_thrust_sp = _v_rates_sp.thrust;
 					}
 				}
-			}
-
-			if (_v_control_mode.flag_control_rates_enabled) {
-				control_attitude_rates(dt);
-
-				publish_actuator_controls();
-				publish_rate_controller_status();
 			}
 
 			if (_v_control_mode.flag_control_termination_enabled) {

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -703,9 +703,9 @@ MulticopterAttitudeControl::run()
 			float dt = (now - last_run) / 1e6f;
 			last_run = now;
 
-			/* guard against too small (< 2ms) and too large (> 20ms) dt's */
-			if (dt < 0.002f) {
-				dt = 0.002f;
+			/* guard against too small (< 0.2ms) and too large (> 20ms) dt's */
+			if (dt < 0.0002f) {
+				dt = 0.0002f;
 
 			} else if (dt > 0.02f) {
 				dt = 0.02f;

--- a/src/platforms/px4_tasks.h
+++ b/src/platforms/px4_tasks.h
@@ -114,9 +114,9 @@ typedef struct {
 // which typically runs at a slower rate
 #define SCHED_PRIORITY_ATTITUDE_CONTROL		(SCHED_PRIORITY_MAX - 4)
 
-// Actuator outputs should run before right after the attitude controller
-// updated
-#define SCHED_PRIORITY_ACTUATOR_OUTPUTS		(SCHED_PRIORITY_MAX - 4)
+// Actuator outputs should run as soon as the rate controller publishes
+// the actuator controls topic
+#define SCHED_PRIORITY_ACTUATOR_OUTPUTS		(SCHED_PRIORITY_MAX - 3)
 
 // Position controllers typically are in a blocking wait on estimator data
 // so when new sensor data is available they will run last. Keeping them


### PR DESCRIPTION
This is a refactoring of the attitude/rate controller to decouple them. The attitude controller is only run when the attitude updates, whereas the rate controller runs in sync with the gyro update.

In addition the rate controller is run before everything else. Together with a prio increase of the fmu, it reduces the fmu control latency from 219us to 134us.
The drawback is that the attitude to rate setpoint generation is delayed by one cycle (4ms), but it will be reduced to 1ms as soon as we run at 1kHz (we can also do this change when we actually run at 1kHz).

Tested in HIL & SITL.

I came accross an ESC that activates OneShot only if it receives the signal with at least 1kHz, so it's time that we push for this.