### PR TITLE
Create MC FlightTask for VTOL Transition

### DIFF
--- a/src/lib/FlightTasks/CMakeLists.txt
+++ b/src/lib/FlightTasks/CMakeLists.txt
@@ -61,6 +61,7 @@ list(APPEND flight_tasks_all
 	AutoFollowMe
 	Offboard
 	Failsafe
+	Transition
 	${flight_tasks_to_add}
 )
 

--- a/src/lib/FlightTasks/tasks/Transition/CMakeLists.txt
+++ b/src/lib/FlightTasks/tasks/Transition/CMakeLists.txt
@@ -1,0 +1,39 @@
+############################################################################
+#
+#   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+px4_add_library(FlightTaskTransition
+	FlightTaskTransition.cpp
+)
+
+target_link_libraries(FlightTaskTransition PUBLIC FlightTask)
+target_include_directories(FlightTaskTransition PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.cpp
+++ b/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.cpp
@@ -1,0 +1,66 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file FlightTaskTranstion.cpp
+ */
+
+#include "FlightTaskTransition.hpp"
+
+bool FlightTaskTransition::updateInitialize()
+{
+	return FlightTask::updateInitialize();
+}
+
+bool FlightTaskTransition::activate()
+{
+	// transition at the current altitude and current yaw at the time of activation
+	// it would be better to use the last setpoint from the previous running flighttask but that interface
+	// is not available
+	_transition_altitude = _position(2);
+	_transition_yaw = _yaw;
+	return FlightTask::activate();
+}
+
+bool FlightTaskTransition::update()
+{
+	// level wings during the transition, altitude should be controlled
+	_thrust_setpoint(0) = _thrust_setpoint(1) = 0.0f;
+	_thrust_setpoint(2) = NAN;
+	_position_setpoint *= NAN;
+	_velocity_setpoint *= NAN;
+	_position_setpoint(2) = _transition_altitude;
+
+	_yaw_setpoint = _transition_yaw;
+	return true;
+}

--- a/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.hpp
+++ b/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.hpp
@@ -1,0 +1,57 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file FlightTaskTransition.hpp
+ *
+ * Flight task for automatic VTOL transitions between hover and forward flight and vice versa.
+ */
+
+#pragma once
+
+#include "FlightTask.hpp"
+
+class FlightTaskTransition : public FlightTask
+{
+public:
+	FlightTaskTransition() = default;
+
+	virtual ~FlightTaskTransition() = default;
+	bool activate();
+	bool updateInitialize() override;
+	bool update() override;
+
+private:
+	float _transition_altitude = 0.0f;
+	float _transition_yaw = 0.0f;
+};

--- a/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.hpp
+++ b/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.hpp
@@ -47,7 +47,7 @@ public:
 	FlightTaskTransition() = default;
 
 	virtual ~FlightTaskTransition() = default;
-	bool activate();
+	bool activate() override;
 	bool updateInitialize() override;
 	bool update() override;
 


### PR DESCRIPTION
Flighttask which enables automatic VTOL transitions.
I personally believe that we need another interface other than flighttask to do these kind of things.
However, this should at least enable VTOL to fly again on master.

Will follow up with more explanation.