### PR TITLE
Format strings

### DIFF
--- a/platforms/posix/src/px4_daemon/client.cpp
+++ b/platforms/posix/src/px4_daemon/client.cpp
@@ -293,7 +293,7 @@ Client::_stdout_msg_packet(const client_recv_packet_s &packet)
 		return 0;
 
 	} else {
-		PX4_ERR("payload size wrong (%i > %i)", packet.header.payload_length, sizeof(packet.payload.stdout_msg.text));
+		PX4_ERR("payload size wrong (%i > %zu)", packet.header.payload_length, sizeof(packet.payload.stdout_msg.text));
 		return -1;
 	}
 }

--- a/src/drivers/batt_smbus/batt_smbus_main.cpp
+++ b/src/drivers/batt_smbus/batt_smbus_main.cpp
@@ -128,7 +128,7 @@ int start(enum BATT_SMBUS_BUS busid)
 
 		if (busid == BATT_SMBUS_BUS_ALL && bus_options[i].dev != nullptr) {
 			// This device is already started.
-			PX4_INFO("Smart battery %d already started", bus_options[i].dev);
+			PX4_INFO("Smart battery %p already started", bus_options[i].dev);
 			continue;
 		}
 

--- a/src/drivers/distance_sensor/sf0x/sf0x.cpp
+++ b/src/drivers/distance_sensor/sf0x/sf0x.cpp
@@ -853,7 +853,7 @@ test()
 		sz = read(fd, &report, sizeof(report));
 
 		if (sz != sizeof(report)) {
-			PX4_ERR("read failed: got %d vs exp. %d", sz, sizeof(report));
+			PX4_ERR("read failed: got %zi vs exp. %zu", sz, sizeof(report));
 			break;
 		}
 

--- a/src/drivers/distance_sensor/tfmini/tfmini.cpp
+++ b/src/drivers/distance_sensor/tfmini/tfmini.cpp
@@ -822,7 +822,7 @@ test()
 		sz = px4_read(fd, &report, sizeof(report));
 
 		if (sz != sizeof(report)) {
-			PX4_ERR("read failed: got %d vs exp. %d", sz, sizeof(report));
+			PX4_ERR("read failed: got %zi vs exp. %zu", sz, sizeof(report));
 			break;
 		}
 

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -3182,7 +3182,7 @@ test(void)
 		ret = write(fd, servos, sizeof(servos));
 
 		if (ret != (int)sizeof(servos)) {
-			err(1, "error writing PWM servo data, wrote %lu got %d", sizeof(servos), ret);
+			err(1, "error writing PWM servo data, wrote %zu got %d", sizeof(servos), ret);
 		}
 
 		if (direction > 0) {

--- a/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/frsky_telemetry.cpp
@@ -778,19 +778,19 @@ int frsky_telemetry_main(int argc, char *argv[])
 			case SPORT:
 				PX4_INFO("running: SPORT");
 				PX4_INFO("port: %s", device_name);
-				PX4_INFO("packets sent: %d", sentPackets);
+				PX4_INFO("packets sent: %ld", sentPackets);
 				break;
 
 			case SPORT_SINGLE_WIRE:
 				PX4_INFO("running: SPORT (single wire)");
 				PX4_INFO("port: %s", device_name);
-				PX4_INFO("packets sent: %d", sentPackets);
+				PX4_INFO("packets sent: %ld", sentPackets);
 				break;
 
 			case DTYPE:
 				PX4_INFO("running: DTYPE");
 				PX4_INFO("port: %s", device_name);
-				PX4_INFO("packets sent: %d", sentPackets);
+				PX4_INFO("packets sent: %ld", sentPackets);
 				break;
 			}
 

--- a/src/examples/bottle_drop/bottle_drop.cpp
+++ b/src/examples/bottle_drop/bottle_drop.cpp
@@ -638,7 +638,7 @@ BottleDrop::task_main()
 
 					float approach_direction = get_bearing_to_next_waypoint(flight_vector_s.lat, flight_vector_s.lon, flight_vector_e.lat,
 								   flight_vector_e.lon);
-					mavlink_log_critical(&_mavlink_log_pub, "position set, approach heading: %u", (unsigned)distance_real,
+					mavlink_log_critical(&_mavlink_log_pub, "position set, approach heading: %u",
 							     (unsigned)math::degrees(approach_direction + M_PI_F));
 
 					_drop_state = DROP_STATE_TARGET_SET;

--- a/src/lib/rc/rc_tests/RCTest.cpp
+++ b/src/lib/rc/rc_tests/RCTest.cpp
@@ -122,7 +122,7 @@ bool RCTest::crsfTest()
 			}
 
 			if (expected_num_channels != num_values) {
-				PX4_ERR("File line: ", line_counter);
+				PX4_ERR("File line: %d", line_counter);
 				ut_compare("Unexpected number of decoded channels", expected_num_channels, num_values);
 			}
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2108,7 +2108,7 @@ Commander::run()
 
 		} else {
 			if (!status_flags.rc_input_blocked && !status.rc_signal_lost) {
-				mavlink_log_critical(&mavlink_log_pub, "MANUAL CONTROL LOST (at t=%llums)", hrt_absolute_time() / 1000);
+				mavlink_log_critical(&mavlink_log_pub, "MANUAL CONTROL LOST (at t=%" PRIu64 "ms)", hrt_absolute_time() / 1000);
 				status.rc_signal_lost = true;
 				rc_signal_lost_timestamp = sp_man.timestamp;
 				set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_RCRECEIVER, true, true, false, status);
@@ -3401,7 +3401,7 @@ print_reject_arm(const char *msg)
 
 	if (t - last_print_mode_reject_time > PRINT_MODE_REJECT_INTERVAL) {
 		last_print_mode_reject_time = t;
-		mavlink_log_critical(&mavlink_log_pub, msg);
+		mavlink_log_critical(&mavlink_log_pub, "%s", msg);
 		tune_negative(true);
 	}
 }

--- a/src/modules/commander/airspeed_calibration.cpp
+++ b/src/modules/commander/airspeed_calibration.cpp
@@ -143,7 +143,7 @@ int do_airspeed_calibration(orb_advert_t *mavlink_log_pub)
 
 			/* any differential pressure failure a reason to abort */
 			if (diff_pres.error_count != 0) {
-				calibration_log_critical(mavlink_log_pub, "[cal] Airspeed sensor is reporting errors (%llu)", diff_pres.error_count);
+				calibration_log_critical(mavlink_log_pub, "[cal] Airspeed sensor is reporting errors (%" PRIu64 ")", diff_pres.error_count);
 				calibration_log_critical(mavlink_log_pub, "[cal] Check your wiring before trying again");
 				feedback_calibration_failed(mavlink_log_pub);
 				goto error_return;

--- a/src/modules/commander/mag_calibration.cpp
+++ b/src/modules/commander/mag_calibration.cpp
@@ -307,7 +307,7 @@ static calibrate_return check_calibration_result(float offset_x, float offset_y,
 	for (unsigned i = 0; i < num_finite; ++i) {
 		if (!PX4_ISFINITE(must_be_finite[i])) {
 			calibration_log_emergency(mavlink_log_pub,
-							"ERROR: Retry calibration (sphere NaN, #%u)", cur_mag);
+							"ERROR: Retry calibration (sphere NaN, #%zu)", cur_mag);
 			return calibrate_return_error;
 		}
 	}

--- a/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
+++ b/src/modules/local_position_estimator/BlockLocalPositionEstimator.cpp
@@ -222,13 +222,13 @@ void BlockLocalPositionEstimator::update()
 				    s->get().orientation == distance_sensor_s::ROTATION_DOWNWARD_FACING &&
 				    _sub_lidar == nullptr) {
 					_sub_lidar = s;
-					mavlink_and_console_log_info(&mavlink_log_pub, "%sDownward-facing Lidar detected with ID %i", msg_label, i);
+					mavlink_and_console_log_info(&mavlink_log_pub, "%sDownward-facing Lidar detected with ID %zu", msg_label, i);
 
 				} else if (s->get().type == distance_sensor_s::MAV_DISTANCE_SENSOR_ULTRASOUND &&
 					   s->get().orientation == distance_sensor_s::ROTATION_DOWNWARD_FACING &&
 					   _sub_sonar == nullptr) {
 					_sub_sonar = s;
-					mavlink_and_console_log_info(&mavlink_log_pub, "%sDownward-facing Sonar detected with ID %i", msg_label, i);
+					mavlink_and_console_log_info(&mavlink_log_pub, "%sDownward-facing Sonar detected with ID %zu", msg_label, i);
 				}
 			}
 		}
@@ -373,7 +373,7 @@ void BlockLocalPositionEstimator::update()
 		// don't want it to take too long
 		if (!PX4_ISFINITE(_x(i))) {
 			reinit_x = true;
-			mavlink_and_console_log_info(&mavlink_log_pub, "%sreinit x, x(%d) not finite", msg_label, i);
+			mavlink_and_console_log_info(&mavlink_log_pub, "%sreinit x, x(%zu) not finite", msg_label, i);
 			break;
 		}
 	}
@@ -393,7 +393,7 @@ void BlockLocalPositionEstimator::update()
 		for (size_t j = 0; j <= i; j++) {
 			if (!PX4_ISFINITE(_P(i, j))) {
 				mavlink_and_console_log_info(&mavlink_log_pub,
-							     "%sreinit P (%d, %d) not finite", msg_label, i, j);
+							     "%sreinit P (%zu, %zu) not finite", msg_label, i, j);
 				reinit_P = true;
 			}
 
@@ -401,7 +401,7 @@ void BlockLocalPositionEstimator::update()
 				// make sure diagonal elements are positive
 				if (_P(i, i) <= 0) {
 					mavlink_and_console_log_info(&mavlink_log_pub,
-								     "%sreinit P (%d, %d) negative", msg_label, i, j);
+								     "%sreinit P (%zu, %zu) negative", msg_label, i, j);
 					reinit_P = true;
 				}
 

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1271,20 +1271,20 @@ Mavlink::handle_message(const mavlink_message_t *msg)
 void
 Mavlink::send_statustext_info(const char *string)
 {
-	mavlink_log_info(&_mavlink_log_pub, string);
+	mavlink_log_info(&_mavlink_log_pub, "%s", string);
 }
 
 void
 Mavlink::send_statustext_critical(const char *string)
 {
-	mavlink_log_critical(&_mavlink_log_pub, string);
-	PX4_ERR(string);
+	mavlink_log_critical(&_mavlink_log_pub, "%s", string);
+	PX4_ERR("%s", string);
 }
 
 void
 Mavlink::send_statustext_emergency(const char *string)
 {
-	mavlink_log_emergency(&_mavlink_log_pub, string);
+	mavlink_log_emergency(&_mavlink_log_pub, "%s", string);
 }
 
 void Mavlink::send_autopilot_capabilites()

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -351,7 +351,7 @@ MulticopterPositionControl::warn_rate_limited(const char *string)
 	hrt_abstime now = hrt_absolute_time();
 
 	if (now - _last_warn > 200000) {
-		PX4_WARN(string);
+		PX4_WARN("%s", string);
 		_last_warn = now;
 	}
 }

--- a/src/modules/navigator/mission_feasibility_checker.cpp
+++ b/src/modules/navigator/mission_feasibility_checker.cpp
@@ -170,7 +170,7 @@ MissionFeasibilityChecker::checkGeofence(const mission_s &mission, float home_al
 
 			if (MissionBlock::item_contains_position(missionitem) && !_navigator->get_geofence().check(missionitem)) {
 
-				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Geofence violation for waypoint %d", i + 1);
+				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Geofence violation for waypoint %zu", i + 1);
 				return false;
 			}
 		}
@@ -200,11 +200,11 @@ MissionFeasibilityChecker::checkHomePositionAltitude(const mission_s &mission, f
 			_navigator->get_mission_result()->warning = true;
 
 			if (throw_error) {
-				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: No home pos, WP %d uses rel alt", i + 1);
+				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: No home pos, WP %zu uses rel alt", i + 1);
 				return false;
 
 			} else	{
-				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Warning: No home pos, WP %d uses rel alt", i + 1);
+				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Warning: No home pos, WP %zu uses rel alt", i + 1);
 				return true;
 			}
 		}
@@ -217,11 +217,11 @@ MissionFeasibilityChecker::checkHomePositionAltitude(const mission_s &mission, f
 			_navigator->get_mission_result()->warning = true;
 
 			if (throw_error) {
-				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: Waypoint %d below home", i + 1);
+				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Mission rejected: Waypoint %zu below home", i + 1);
 				return false;
 
 			} else	{
-				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Warning: Waypoint %d below home", i + 1);
+				mavlink_log_critical(_navigator->get_mavlink_log_pub(), "Warning: Waypoint %zu below home", i + 1);
 				return true;
 			}
 		}

--- a/src/modules/uORB/uORBDeviceMaster.cpp
+++ b/src/modules/uORB/uORBDeviceMaster.cpp
@@ -367,21 +367,13 @@ void uORB::DeviceMaster::showTop(char **topic_filter, int num_filters)
 
 			PX4_INFO_RAW("\033[H"); // move cursor home and clear screen
 			PX4_INFO_RAW(CLEAR_LINE "update: 1s, num topics: %i\n", num_topics);
-#ifdef __PX4_NUTTX
-			PX4_INFO_RAW(CLEAR_LINE "%*-s INST #SUB #MSG #LOST #QSIZE\n", (int)max_topic_name_length - 2, "TOPIC NAME");
-#else
-			PX4_INFO_RAW(CLEAR_LINE "%*s INST #SUB #MSG #LOST #QSIZE\n", -(int)max_topic_name_length + 2, "TOPIC NAME");
-#endif
+			PX4_INFO_RAW(CLEAR_LINE "%-*s INST #SUB #MSG #LOST #QSIZE\n", (int)max_topic_name_length - 2, "TOPIC NAME");
 			cur_node = first_node;
 
 			while (cur_node) {
 
 				if (!print_active_only || cur_node->pub_msg_delta > 0) {
-#ifdef __PX4_NUTTX
-					PX4_INFO_RAW(CLEAR_LINE "%*-s %2i %4i %4i %5i %i\n", (int)max_topic_name_length,
-#else
-					PX4_INFO_RAW(CLEAR_LINE "%*s %2i %4i %4i %5i %i\n", -(int)max_topic_name_length,
-#endif
+					PX4_INFO_RAW(CLEAR_LINE "%-*s %2i %4i %4i %5i %i\n", (int)max_topic_name_length,
 						     cur_node->node->get_meta()->o_name, (int)cur_node->instance,
 						     (int)cur_node->node->subscriber_count(), cur_node->pub_msg_delta,
 						     (int)cur_node->lost_msg_delta, cur_node->node->get_queue_size());

--- a/src/modules/uORB/uORBDeviceNode.cpp
+++ b/src/modules/uORB/uORBDeviceNode.cpp
@@ -760,7 +760,7 @@ int16_t uORB::DeviceNode::process_received_message(int32_t length, uint8_t *data
 	int16_t ret = -1;
 
 	if (length != (int32_t)(_meta->o_size)) {
-		PX4_ERR("Received DataLength[%d] != ExpectedLen[%d]", _meta->o_name, (int)length, (int)_meta->o_size);
+		PX4_ERR("Received '%s' with DataLength[%d] != ExpectedLen[%d]", _meta->o_name, (int)length, (int)_meta->o_size);
 		return PX4_ERROR;
 	}
 

--- a/src/platforms/px4_log.h
+++ b/src/platforms/px4_log.h
@@ -141,8 +141,15 @@ __BEGIN_DECLS
 __EXPORT extern const char *__px4_log_level_str[_PX4_LOG_LEVEL_PANIC + 1];
 __EXPORT extern const char *__px4_log_level_color[_PX4_LOG_LEVEL_PANIC + 1];
 __EXPORT extern void px4_backtrace(void);
-__EXPORT void px4_log_modulename(int level, const char *moduleName, const char *fmt, ...);
-__EXPORT void px4_log_raw(int level, const char *fmt, ...);
+__EXPORT void px4_log_modulename(int level, const char *moduleName, const char *fmt, ...)
+__attribute__((format(printf, 3, 4)));
+__EXPORT void px4_log_raw(int level, const char *fmt, ...)
+__attribute__((format(printf, 2, 3)));
+
+#if __GNUC__
+// Allow empty format strings.
+#pragma GCC diagnostic ignored "-Wformat-zero-length"
+#endif
 
 __END_DECLS
 

--- a/src/systemcmds/bl_update/bl_update.c
+++ b/src/systemcmds/bl_update/bl_update.c
@@ -166,7 +166,7 @@ bl_update_main(int argc, char *argv[])
 
 	if (size != BL_FILE_SIZE_LIMIT)
 	{
-		PX4_ERR("erase error at 0x%08x", &base[size]);
+		PX4_ERR("erase error at %p", &base[size]);
 	}
 
 	PX4_INFO("flashing...");
@@ -177,7 +177,7 @@ bl_update_main(int argc, char *argv[])
 
 	if (size != s.st_size)
 	{
-		PX4_ERR("program error at 0x%0x8",  &base[size]);
+		PX4_ERR("program error at %p",  &base[size]);
 		goto flash_end;
 	}
 
@@ -191,7 +191,7 @@ bl_update_main(int argc, char *argv[])
 	for (int i = 0; i < s.st_size; i++)
 	{
 		if (base[i] != buf[i]) {
-			PX4_WARN("verify failed at %u - retry update, DO NOT reboot", i);
+			PX4_WARN("verify failed at %i - retry update, DO NOT reboot", i);
 			goto flash_end;
 		}
 	}
@@ -239,7 +239,7 @@ setopt(void)
 		return 0;
 	}
 
-	PX4_ERR("option bits setting failed; readback 0x%04x", *optcr);
+	PX4_ERR("option bits setting failed; readback 0x%04" PRIx32, *optcr);
 	return 1;
 }
 #endif // CONFIG_STM32_STM32F4XXX

--- a/src/systemcmds/tests/test_dataman.c
+++ b/src/systemcmds/tests/test_dataman.c
@@ -143,7 +143,7 @@ task_main(int argc, char *argv[])
 	}
 
 	hrt_abstime rend = hrt_absolute_time();
-	PX4_INFO("task %d pass, hit %d, miss %d, io time read %llums. write %llums.",
+	PX4_INFO("task %d pass, hit %d, miss %d, io time read %" PRIu64 "ms. write %" PRIu64 "ms.",
 		 my_id, hit, miss, (rend - rstart) / NUM_MISSIONS_TEST / 1000, (wend - wstart) / NUM_MISSIONS_TEST / 1000);
 	px4_sem_post(sems + my_id);
 	return 0;


### PR DESCRIPTION
In #10766, I forgot a `%s` in a format string. Surprisingly to me, the compiler didn't warn me.

This PR enables GCC's `__attribute__((format))` which will make it validate the format strings, to prevent this kind of bugs.

By enabling it, I found (and fixed) many simliar bugs already in the code:

- A `%d` for a pointer (replaced it by `%p`)
- 2 cases of `%d` for a `ssize_t` (replaced it by `%zi`)
- 18 cases of `%d`, `%u` or `%i` for a `size_t` (replaced it by `%zu`)
- An unused formatting argument (removed it)
- A missing `%d` (added it)
- 2 cases of `%llu` for a `uint64_t` (replaced it by `"%" PRIu64`)
- 6 cases of giving a string directly as format string, which would break if the string would contain any `%` signs. (replaced it by `("%s", string)`)

