### PR TITLE
Avoidance Interface CI

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -80,7 +80,7 @@ pipeline {
               vehicle: "tiltrotor"
             ],
             [
-              name: "avoidance",
+              name: "MC_avoidance",
               test: "mavros_posix_test_avoidance.test",
               mission: "avoidance",
               vehicle: "iris_obs_avoid",

--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -127,7 +127,7 @@ def createTestNode(Map test_def) {
 
           // run test
           try {
-            sh('px4-px4_sitl_default*/px4/test/rostest_px4_run.sh ' + test_def.test + ' mission:=' + test_def.mission + ' vehicle:=' + test_def.vehicle)
+            sh('px4-px4_sitl_default*/px4/test/' + run_script + ' ' + test_def.test + ' mission:=' + test_def.mission + ' vehicle:=' + test_def.vehicle)
 
           } catch (exc) {
             // save all test artifacts for debugging

--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -83,7 +83,7 @@ pipeline {
               name: "avoidance",
               test: "mavros_posix_test_avoidance.test",
               mission: "avoidance",
-              vehicle: "iris",
+              vehicle: "iris_obs_avoid",
               run_script: "rostest_avoidance_run.sh"
             ],
 

--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -79,6 +79,12 @@ pipeline {
               mission: "VTOL_mission_1",
               vehicle: "tiltrotor"
             ],
+            [
+              name: "avoidance",
+              test: "mavros_posix_test_avoidance.test",
+              mission: "avoidance",
+              vehicle: "iris"
+            ],
 
           ]
 

--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -83,7 +83,8 @@ pipeline {
               name: "avoidance",
               test: "mavros_posix_test_avoidance.test",
               mission: "avoidance",
-              vehicle: "iris"
+              vehicle: "iris",
+              run_script: "rostest_avoidance_run.sh"
             ],
 
           ]
@@ -117,6 +118,7 @@ def createTestNode(Map test_def) {
       cleanWs()
       docker.image("px4io/px4-dev-ros-kinetic:2019-03-08").inside('-e HOME=${WORKSPACE}') {
         stage(test_def.name) {
+          def run_script = test_def.get('run_script', 'rostest_px4_run.sh')
           def test_ok = true
           sh('export')
 

--- a/Makefile
+++ b/Makefile
@@ -337,7 +337,7 @@ format:
 
 # Testing
 # --------------------------------------------------------------------
-.PHONY: tests tests_coverage tests_mission tests_mission_coverage tests_offboard
+.PHONY: tests tests_coverage tests_mission tests_mission_coverage tests_offboard tests_avoidance
 .PHONY: rostest python_coverage test_mixer_multirotor
 
 test_mixer_multirotor:
@@ -374,6 +374,9 @@ tests_offboard: rostest
 	@"$(SRC_DIR)"/test/rostest_px4_run.sh mavros_posix_tests_offboard_attctl.test
 	@"$(SRC_DIR)"/test/rostest_px4_run.sh mavros_posix_tests_offboard_posctl.test
 
+tests_avoidance:
+	@$(SRC_DIR)/test/rostest_avoidance_run.sh mavros_posix_test_avoidance.test
+
 python_coverage:
 	@mkdir -p "$(SRC_DIR)"/build/python_coverage
 	@cd "$(SRC_DIR)"/build/python_coverage && cmake "$(SRC_DIR)" $(CMAKE_ARGS) -G"$(PX4_CMAKE_GENERATOR)" -DCONFIG=px4_sitl_default -DPYTHON_COVERAGE=ON
@@ -383,6 +386,7 @@ python_coverage:
 	#@$(PX4_MAKE) -C "$(SRC_DIR)"/build/python_coverage module_documentation # TODO: fix within coverage.py
 	@coverage combine `find . -name .coverage\*`
 	@coverage report -m
+
 
 # static analyzers (scan-build, clang-tidy, cppcheck)
 # --------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -375,7 +375,7 @@ tests_offboard: rostest
 	@"$(SRC_DIR)"/test/rostest_px4_run.sh mavros_posix_tests_offboard_posctl.test
 
 tests_avoidance:
-	@$(SRC_DIR)/test/rostest_avoidance_run.sh mavros_posix_test_avoidance.test
+	@"$(SRC_DIR)"/test/rostest_avoidance_run.sh mavros_posix_test_avoidance.test
 
 python_coverage:
 	@mkdir -p "$(SRC_DIR)"/build/python_coverage

--- a/ROMFS/px4fmu_common/init.d-posix/1015_iris_obs_avoid
+++ b/ROMFS/px4fmu_common/init.d-posix/1015_iris_obs_avoid
@@ -1,0 +1,13 @@
+#!nsh
+#
+# @name 3DR Iris Quadrotor SITL (Obstacle Avoidance)
+#
+# @type Quadrotor Wide
+#
+ 
+sh /etc/init.d-posix/10016_iris
+
+if [ $AUTOCNF = yes ]
+then
+	param set MPC_OBS_AVOID 1
+fi

--- a/ROMFS/px4fmu_common/init.d-posix/1015_iris_obs_avoid
+++ b/ROMFS/px4fmu_common/init.d-posix/1015_iris_obs_avoid
@@ -1,10 +1,10 @@
-#!nsh
+#!/bin/sh
 #
 # @name 3DR Iris Quadrotor SITL (Obstacle Avoidance)
 #
 # @type Quadrotor Wide
 #
- 
+
 sh /etc/init.d-posix/10016_iris
 
 if [ $AUTOCNF = yes ]

--- a/ROMFS/px4fmu_common/init.d-posix/1015_iris_obs_avoid
+++ b/ROMFS/px4fmu_common/init.d-posix/1015_iris_obs_avoid
@@ -9,5 +9,5 @@ sh /etc/init.d-posix/10016_iris
 
 if [ $AUTOCNF = yes ]
 then
-	param set MPC_OBS_AVOID 1
+	param set COM_OBS_AVOID 1
 fi

--- a/integrationtests/python_src/px4_it/mavros/missions/avoidance.plan
+++ b/integrationtests/python_src/px4_it/mavros/missions/avoidance.plan
@@ -15,7 +15,7 @@
         "items": [
             {
                 "AMSLAltAboveTerrain": null,
-                "Altitude": 3,
+                "Altitude": 4,
                 "AltitudeMode": 0,
                 "autoContinue": true,
                 "command": 22,
@@ -26,15 +26,15 @@
                     0,
                     0,
                     null,
-                    47.397741947804356,
-                    8.545597913136334,
-                    3
+                    47.3977432,
+                    8.5456085,
+                    4
                 ],
                 "type": "SimpleItem"
             },
             {
                 "AMSLAltAboveTerrain": null,
-                "Altitude": 3,
+                "Altitude": 4,
                 "AltitudeMode": 0,
                 "autoContinue": true,
                 "command": 16,
@@ -45,9 +45,9 @@
                     0,
                     0,
                     null,
-                    47.3977428945147,
-                    8.545867506377846,
-                    3
+                    47.3977432,
+                    8.5458765,
+                    4
                 ],
                 "type": "SimpleItem"
             },
@@ -60,21 +60,21 @@
                 "doJumpId": 3,
                 "frame": 3,
                 "params": [
-                    25,
+                    0,
                     0,
                     0,
                     null,
-                    47.397740564979635,
-                    8.545876861212832,
+                    47.3977432,
+                    8.5458812,
                     0
                 ],
                 "type": "SimpleItem"
             }
         ],
         "plannedHomePosition": [
-            47.3977418,
-            8.5455938,
-            487.999
+            47.3977421,
+            8.545594,
+            489
         ],
         "vehicleType": 2,
         "version": 2

--- a/integrationtests/python_src/px4_it/mavros/missions/avoidance.plan
+++ b/integrationtests/python_src/px4_it/mavros/missions/avoidance.plan
@@ -1,6 +1,11 @@
 {
     "fileType": "Plan",
     "geoFence": {
+        "circles": [
+        ],
+        "polygons": [
+        ],
+        "version": 2
     },
     "groundStation": "QGroundControl",
     "mission": {
@@ -9,6 +14,9 @@
         "hoverSpeed": 5,
         "items": [
             {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 3,
+                "AltitudeMode": 0,
                 "autoContinue": true,
                 "command": 22,
                 "doJumpId": 1,
@@ -25,6 +33,9 @@
                 "type": "SimpleItem"
             },
             {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 3,
+                "AltitudeMode": 0,
                 "autoContinue": true,
                 "command": 16,
                 "doJumpId": 2,
@@ -34,17 +45,36 @@
                     0,
                     0,
                     null,
-                    47.39774557119683,
-                    8.545792374696958,
+                    47.3977428945147,
+                    8.545867506377846,
                     3
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 0,
+                "AltitudeMode": 0,
+                "autoContinue": true,
+                "command": 21,
+                "doJumpId": 3,
+                "frame": 3,
+                "params": [
+                    25,
+                    0,
+                    0,
+                    null,
+                    47.397740564979635,
+                    8.545876861212832,
+                    0
                 ],
                 "type": "SimpleItem"
             }
         ],
         "plannedHomePosition": [
-            47.3977419,
+            47.3977418,
             8.5455938,
-            489
+            487.999
         ],
         "vehicleType": 2,
         "version": 2
@@ -52,7 +82,7 @@
     "rallyPoints": {
         "points": [
         ],
-        "version": 1
+        "version": 2
     },
     "version": 1
 }

--- a/integrationtests/python_src/px4_it/mavros/missions/avoidance.plan
+++ b/integrationtests/python_src/px4_it/mavros/missions/avoidance.plan
@@ -1,0 +1,58 @@
+{
+    "fileType": "Plan",
+    "geoFence": {
+    },
+    "groundStation": "QGroundControl",
+    "mission": {
+        "cruiseSpeed": 15,
+        "firmwareType": 12,
+        "hoverSpeed": 5,
+        "items": [
+            {
+                "autoContinue": true,
+                "command": 22,
+                "doJumpId": 1,
+                "frame": 3,
+                "params": [
+                    15,
+                    0,
+                    0,
+                    null,
+                    47.397741947804356,
+                    8.545597913136334,
+                    3
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 2,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    47.39774557119683,
+                    8.545792374696958,
+                    3
+                ],
+                "type": "SimpleItem"
+            }
+        ],
+        "plannedHomePosition": [
+            47.3977419,
+            8.5455938,
+            489
+        ],
+        "vehicleType": 2,
+        "version": 2
+    },
+    "rallyPoints": {
+        "points": [
+        ],
+        "version": 1
+    },
+    "version": 1
+}

--- a/integrationtests/python_src/px4_it/mavros/missions/avoidance.plan
+++ b/integrationtests/python_src/px4_it/mavros/missions/avoidance.plan
@@ -14,7 +14,7 @@
         "hoverSpeed": 5,
         "items": [
             {
-                "AMSLAltAboveTerrain": 4,
+                "AMSLAltAboveTerrain": null,
                 "Altitude": 4,
                 "AltitudeMode": 0,
                 "autoContinue": true,
@@ -33,7 +33,7 @@
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": 4,
+                "AMSLAltAboveTerrain": null,
                 "Altitude": 4,
                 "AltitudeMode": 0,
                 "autoContinue": true,
@@ -52,7 +52,7 @@
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": -2,
+                "AMSLAltAboveTerrain": null,
                 "Altitude": -1,
                 "AltitudeMode": 0,
                 "autoContinue": true,

--- a/integrationtests/python_src/px4_it/mavros/missions/avoidance.plan
+++ b/integrationtests/python_src/px4_it/mavros/missions/avoidance.plan
@@ -14,7 +14,7 @@
         "hoverSpeed": 5,
         "items": [
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 4,
                 "Altitude": 4,
                 "AltitudeMode": 0,
                 "autoContinue": true,
@@ -33,7 +33,7 @@
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 4,
                 "Altitude": 4,
                 "AltitudeMode": 0,
                 "autoContinue": true,
@@ -52,8 +52,8 @@
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
-                "Altitude": 0,
+                "AMSLAltAboveTerrain": -2,
+                "Altitude": -1,
                 "AltitudeMode": 0,
                 "autoContinue": true,
                 "command": 21,
@@ -66,15 +66,15 @@
                     null,
                     47.3977432,
                     8.5458812,
-                    0
+                    -1
                 ],
                 "type": "SimpleItem"
             }
         ],
         "plannedHomePosition": [
-            47.3977421,
-            8.545594,
-            489
+            47.3977419,
+            8.5458854,
+            487.923
         ],
         "vehicleType": 2,
         "version": 2

--- a/test/mavros_posix_test_avoidance.test
+++ b/test/mavros_posix_test_avoidance.test
@@ -5,19 +5,20 @@
     <arg name="est" default="ekf2"/>
     <arg name="gui" default="false"/>
     <arg name="interactive" default="false"/>
-    <arg name="vehicle" default="iris_obs_avoid"/>
-    <arg name="sdf" default="$(find local_planner)/../sim/models/iris_depth_camera/iris_depth_camera.sdf"/>
-    <arg name="world" default="$(find local_planner)/../sim/worlds/boxes1.world"/>
     <arg name="mission" default="avoidance"/>
+    <arg name="sdf" default="$(find local_planner)/../sim/models/iris_depth_camera/iris_depth_camera.sdf"/>
+    <arg name="vehicle" default="iris_obs_avoid"/>
+    <arg name="world" default="$(find local_planner)/../sim/worlds/boxes1.world"/>
     <!-- PX4 SITL and Gazebo -->
     <include file="$(find px4)/launch/posix_sitl.launch">
         <arg name="est" value="$(arg est)"/>
         <arg name="gui" value="$(arg gui)"/>
         <arg name="interactive" value="$(arg interactive)"/>
-        <arg name="vehicle" value="$(arg vehicle)"/>
-        <arg name="world" value="$(arg world)"/>
-        <arg name="sdf" value="$(arg sdf)"/>
         <arg name="respawn_gazebo" value="true"/>
+        <arg name="sdf" value="$(arg sdf)"/>
+        <arg name="vehicle" value="$(arg vehicle)"/>
+        <arg name="verbose" value="true"/>
+        <arg name="world" value="$(arg world)"/>
     </include>
     <!-- MAVROS -->
     <include file="$(find mavros)/launch/node.launch">

--- a/test/mavros_posix_test_avoidance.test
+++ b/test/mavros_posix_test_avoidance.test
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<launch>
+   <arg name="fcu_url" default="udp://:14540@localhost:14557"/>
+    <arg name="gcs_url" default="" />   <!-- GCS link is provided by SITL -->
+    <arg name="tgt_system" default="1" />
+    <arg name="tgt_component" default="1" />
+    <arg name="est" default="ekf2"/>
+    <arg name="vehicle" default="iris"/>
+    <arg name="rcS" default="$(find px4)/posix-configs/SITL/init/$(arg est)/$(arg vehicle)"/>
+    <arg name="headless" default="false"/>
+    <arg name="gui" default="false"/>
+    <arg name="ns" default="/"/>
+    <arg name="model" default="iris"/>
+
+    <arg name="world_path" default="$(find local_planner)/../sim/worlds/boxes1.world" />
+    
+    <!-- Launch FCU -->
+    <node name="sitl" pkg="px4" type="px4" output="screen"
+        args="$(find px4) $(arg rcS)">
+    </node>
+
+    <!-- Launch MavROS -->
+    <group ns="$(arg ns)">
+        <include file="$(find mavros)/launch/node.launch">
+            <arg name="pluginlists_yaml" value="$(find mavros)/launch/px4_pluginlists.yaml" />
+            <arg name="config_yaml" value="$(find local_planner)/resource/px4_config.yaml" />
+            <arg name="fcu_url" value="$(arg fcu_url)" />
+            <arg name="gcs_url" value="$(arg gcs_url)" />
+            <arg name="tgt_system" value="$(arg tgt_system)" />
+            <arg name="tgt_component" value="$(arg tgt_component)" />
+        </include>
+    </group>
+
+    <!-- Launch Gazebo -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="headless" value="$(arg headless)"/>
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="world_name" value="$(arg world_path)" />
+    </include>
+
+    <!-- Spawn iris with depth camera -->
+    <node name="spawn_model" pkg="gazebo_ros" type="spawn_model" output="screen"
+          args="-file $(find local_planner)/../sim/models/iris_depth_camera/iris_depth_camera.sdf -sdf -model iris">
+    </node>
+
+    <arg name="mavros_transformation" default="0" />
+    <node pkg="tf" type="static_transform_publisher" name="tf_90_deg"
+          args="0 0 0 $(arg mavros_transformation) 0 0 world local_origin 10"/>
+    <node pkg="tf" type="static_transform_publisher" name="tf_depth_camera"
+          args="0 0 0 -1.57 0 -1.57 fcu camera_link 10"/>
+
+    <!-- Launch Local Planner -->
+    <node name="local_planner_node" pkg="local_planner" type="local_planner_node">
+        <param name="goal_x_param" value="17" />
+        <param name="goal_y_param" value="15"/>
+        <param name="goal_z_param" value="3" />
+    </node>
+
+    <test test-name="avoidance_interface" pkg="px4" type="mission_test.py" time-limit="300.0" args="avoidance.plan"/>
+</launch>

--- a/test/mavros_posix_test_avoidance.test
+++ b/test/mavros_posix_test_avoidance.test
@@ -5,7 +5,7 @@
     <arg name="est" default="ekf2"/>
     <arg name="gui" default="false"/>
     <arg name="interactive" default="false"/>
-    <arg name="vehicle" default="iris"/>
+    <arg name="vehicle" default="iris_obs_avoid"/>
     <arg name="sdf" default="$(find local_planner)/../sim/models/iris_depth_camera/iris_depth_camera.sdf"/>
     <arg name="world" default="$(find local_planner)/../sim/worlds/boxes1.world"/>
     <arg name="mission" default="avoidance"/>

--- a/test/mavros_posix_test_avoidance.test
+++ b/test/mavros_posix_test_avoidance.test
@@ -1,60 +1,46 @@
 <?xml version="1.0"?>
 <launch>
-   <arg name="fcu_url" default="udp://:14540@localhost:14557"/>
-    <arg name="gcs_url" default="" />   <!-- GCS link is provided by SITL -->
-    <arg name="tgt_system" default="1" />
-    <arg name="tgt_component" default="1" />
+    <!-- Posix SITL MAVROS integration tests -->
+    <!-- Test a mission -->
     <arg name="est" default="ekf2"/>
-    <arg name="vehicle" default="iris"/>
-    <arg name="rcS" default="$(find px4)/posix-configs/SITL/init/$(arg est)/$(arg vehicle)"/>
-    <arg name="headless" default="false"/>
     <arg name="gui" default="false"/>
-    <arg name="ns" default="/"/>
-    <arg name="model" default="iris"/>
-
-    <arg name="world_path" default="$(find local_planner)/../sim/worlds/boxes1.world" />
-    
-    <!-- Launch FCU -->
-    <node name="sitl" pkg="px4" type="px4" output="screen"
-        args="$(find px4) $(arg rcS)">
-    </node>
-
-    <!-- Launch MavROS -->
-    <group ns="$(arg ns)">
-        <include file="$(find mavros)/launch/node.launch">
-            <arg name="pluginlists_yaml" value="$(find mavros)/launch/px4_pluginlists.yaml" />
-            <arg name="config_yaml" value="$(find local_planner)/resource/px4_config.yaml" />
-            <arg name="fcu_url" value="$(arg fcu_url)" />
-            <arg name="gcs_url" value="$(arg gcs_url)" />
-            <arg name="tgt_system" value="$(arg tgt_system)" />
-            <arg name="tgt_component" value="$(arg tgt_component)" />
-        </include>
-    </group>
-
-    <!-- Launch Gazebo -->
-    <include file="$(find gazebo_ros)/launch/empty_world.launch">
-        <arg name="headless" value="$(arg headless)"/>
+    <arg name="interactive" default="false"/>
+    <arg name="vehicle" default="iris"/>
+    <arg name="sdf" default="$(find local_planner)/../sim/models/iris_depth_camera/iris_depth_camera.sdf"/>
+    <arg name="world" default="$(find local_planner)/../sim/worlds/boxes1.world"/>
+    <arg name="mission" default="avoidance"/>
+    <!-- PX4 SITL and Gazebo -->
+    <include file="$(find px4)/launch/posix_sitl.launch">
+        <arg name="est" value="$(arg est)"/>
         <arg name="gui" value="$(arg gui)"/>
-        <arg name="world_name" value="$(arg world_path)" />
+        <arg name="interactive" value="$(arg interactive)"/>
+        <arg name="vehicle" value="$(arg vehicle)"/>
+        <arg name="world" value="$(arg world)"/>
+        <arg name="sdf" value="$(arg sdf)"/>
+        <arg name="respawn_gazebo" value="true"/>
     </include>
-
-    <!-- Spawn iris with depth camera -->
-    <node name="spawn_model" pkg="gazebo_ros" type="spawn_model" output="screen"
-          args="-file $(find local_planner)/../sim/models/iris_depth_camera/iris_depth_camera.sdf -sdf -model iris">
-    </node>
-
+    <!-- MAVROS -->
+    <include file="$(find mavros)/launch/node.launch">
+        <arg name="pluginlists_yaml" value="$(find mavros)/launch/px4_pluginlists.yaml"/>
+        <arg name="config_yaml" value="$(find local_planner)/resource/px4_config.yaml"/>
+        <arg name="gcs_url" value=""/>
+        <arg name="fcu_url" value="udp://:14540@localhost:14557"/>
+        <arg name="tgt_system" value="1"/>
+        <arg name="tgt_component" value="1"/>
+        <arg name="respawn_mavros" value="true"/>
+    </include>
+    <!-- Transformation Publishers -->
     <arg name="mavros_transformation" default="0" />
     <node pkg="tf" type="static_transform_publisher" name="tf_90_deg"
           args="0 0 0 $(arg mavros_transformation) 0 0 world local_origin 10"/>
     <node pkg="tf" type="static_transform_publisher" name="tf_depth_camera"
           args="0 0 0 -1.57 0 -1.57 fcu camera_link 10"/>
-
     <!-- Launch Local Planner -->
     <node name="local_planner_node" pkg="local_planner" type="local_planner_node">
         <param name="goal_x_param" value="17" />
         <param name="goal_y_param" value="15"/>
         <param name="goal_z_param" value="3" />
     </node>
-
-    <test test-name="avoidance_interface" pkg="px4" type="mission_test.py" time-limit="300.0" args="avoidance.plan"/>
+    <!-- ROStest -->
+    <test test-name="$(arg mission)" pkg="px4" type="mission_test.py" time-limit="300.0" args="$(arg mission).plan"/>
 </launch>

--- a/test/mavros_posix_test_avoidance.test
+++ b/test/mavros_posix_test_avoidance.test
@@ -36,7 +36,7 @@
     <node pkg="tf" type="static_transform_publisher" name="tf_depth_camera"
           args="0 0 0 -1.57 0 -1.57 fcu camera_link 10"/>
     <!-- Launch Local Planner -->
-    <node name="local_planner_node" pkg="local_planner" type="local_planner_node">
+    <node name="local_planner_node" pkg="local_planner" type="local_planner_node" output="screen">
         <param name="goal_x_param" value="17" />
         <param name="goal_y_param" value="15"/>
         <param name="goal_z_param" value="3" />

--- a/test/mavros_posix_test_avoidance.test
+++ b/test/mavros_posix_test_avoidance.test
@@ -30,16 +30,16 @@
         <arg name="respawn_mavros" value="true"/>
     </include>
     <!-- Transformation Publishers -->
-    <arg name="mavros_transformation" default="0" />
-    <node pkg="tf" type="static_transform_publisher" name="tf_90_deg"
-          args="0 0 0 $(arg mavros_transformation) 0 0 world local_origin 10"/>
     <node pkg="tf" type="static_transform_publisher" name="tf_depth_camera"
           args="0 0 0 -1.57 0 -1.57 fcu camera_link 10"/>
     <!-- Launch Local Planner -->
+    <rosparam command="load" file="$(find local_planner)/cfg/params.yaml"/>
+    <arg name="pointcloud_topics" default="[/camera/depth/points]"/>
     <node name="local_planner_node" pkg="local_planner" type="local_planner_node" output="screen">
         <param name="goal_x_param" value="17" />
         <param name="goal_y_param" value="15"/>
         <param name="goal_z_param" value="3" />
+        <rosparam param="pointcloud_topics" subst_value="True">$(arg pointcloud_topics)</rosparam>
     </node>
     <!-- ROStest -->
     <test test-name="$(arg mission)" pkg="px4" type="mission_test.py" time-limit="300.0" args="$(arg mission).plan"/>

--- a/test/mavros_posix_test_avoidance.test
+++ b/test/mavros_posix_test_avoidance.test
@@ -6,7 +6,7 @@
     <arg name="gui" default="false"/>
     <arg name="interactive" default="false"/>
     <arg name="mission" default="avoidance"/>
-    <arg name="sdf" default="$(find local_planner)/../sim/models/iris_depth_camera/iris_depth_camera.sdf"/>
+    <arg name="sdf" default="$(find local_planner)/../sim/models/iris_depth_camera_3/iris_depth_camera.sdf"/>
     <arg name="vehicle" default="iris_obs_avoid"/>
     <arg name="world" default="$(find local_planner)/../sim/worlds/boxes1.world"/>
     <!-- PX4 SITL and Gazebo -->
@@ -31,10 +31,14 @@
         <arg name="respawn_mavros" value="true"/>
     </include>
     <!-- Transformation Publishers -->
-    <node pkg="tf" type="static_transform_publisher" name="tf_depth_camera"
-          args="0 0 0 -1.57 0 -1.57 fcu camera_link 10"/>
+    <node pkg="tf" type="static_transform_publisher" name="tf_front_camera"
+          args="0 0 0 -1.57 0 -1.57 fcu front_camera_link 10"/>
+    <node pkg="tf" type="static_transform_publisher" name="tf_right_camera"
+          args="0 0 0 -3.14 0 -1.57 fcu right_camera_link 10"/>
+    <node pkg="tf" type="static_transform_publisher" name="tf_left_camera"
+          args="0 0 0 0 0 -1.57 fcu left_camera_link 10"/>
     <!-- Launch Local Planner -->
-    <arg name="pointcloud_topics" default="[/camera/depth/points]"/>
+    <arg name="pointcloud_topics" default="[/camera_front/depth/points,/camera_left/depth/points,/camera_right/depth/points]"/>
     <node name="local_planner_node" pkg="local_planner" type="local_planner_node" output="screen">
         <param name="goal_x_param" value="17" />
         <param name="goal_y_param" value="15"/>

--- a/test/mavros_posix_test_avoidance.test
+++ b/test/mavros_posix_test_avoidance.test
@@ -34,7 +34,6 @@
     <node pkg="tf" type="static_transform_publisher" name="tf_depth_camera"
           args="0 0 0 -1.57 0 -1.57 fcu camera_link 10"/>
     <!-- Launch Local Planner -->
-    <rosparam command="load" file="$(find local_planner)/cfg/params.yaml"/>
     <arg name="pointcloud_topics" default="[/camera/depth/points]"/>
     <node name="local_planner_node" pkg="local_planner" type="local_planner_node" output="screen">
         <param name="goal_x_param" value="17" />

--- a/test/mavros_posix_test_avoidance.test
+++ b/test/mavros_posix_test_avoidance.test
@@ -37,6 +37,8 @@
           args="0 0 0 -3.14 0 -1.57 fcu right_camera_link 10"/>
     <node pkg="tf" type="static_transform_publisher" name="tf_left_camera"
           args="0 0 0 0 0 -1.57 fcu left_camera_link 10"/>
+    <!-- Suppress console outputs -->
+    <env name="ROSCONSOLE_CONFIG_FILE" value="$(find local_planner)/resource/custom_rosconsole.conf"/>
     <!-- Launch Local Planner -->
     <arg name="pointcloud_topics" default="[/camera_front/depth/points,/camera_left/depth/points,/camera_right/depth/points]"/>
     <node name="local_planner_node" pkg="local_planner" type="local_planner_node" output="screen">

--- a/test/rostest_avoidance_run.sh
+++ b/test/rostest_avoidance_run.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+PX4_SRC_DIR=${DIR}/..
+
+source /opt/ros/kinetic/setup.bash
+mkdir ~/catkin_ws/src
+cd ~/catkin_ws
+git clone --depth=1 https://github.com/PX4/avoidance.git src/
+
+catkin init
+catkin build local_planner --cmake-args -DCMAKE_BUILD_TYPE=Release
+source ${PX4_SRC_DIR}/Tools/setup_gazebo.bash ${PX4_SRC_DIR} ${PX4_SRC_DIR}/build/posix_sitl_default
+
+source ~/catkin_ws/devel/setup.bash 2>/dev/null
+export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:${PX4_SRC_DIR}:${PX4_SRC_DIR}/Tools/sitl_gazebo
+
+rostest px4 "$@"

--- a/test/rostest_avoidance_run.sh
+++ b/test/rostest_avoidance_run.sh
@@ -6,13 +6,14 @@ PX4_SRC_DIR=${DIR}/..
 source /opt/ros/kinetic/setup.bash
 mkdir -p ${PX4_SRC_DIR}/catkin_ws/src
 cd ${PX4_SRC_DIR}/catkin_ws/
-git clone --depth=1 https://github.com/PX4/avoidance.git src/
+git clone --depth=1 https://github.com/PX4/avoidance.git src/avoidance/
 
 catkin init
 catkin build local_planner --cmake-args -DCMAKE_BUILD_TYPE=Release
 
 source ${PX4_SRC_DIR}/catkin_ws/devel/setup.bash
 export CATKIN_SETUP_UTIL_ARGS=--extend
+export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:${PX4_SRC_DIR}/catkin_ws/src/avoidance/sim/models
 
 source $DIR/rostest_px4_run.sh "$@"
 

--- a/test/rostest_avoidance_run.sh
+++ b/test/rostest_avoidance_run.sh
@@ -3,6 +3,8 @@
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 PX4_SRC_DIR=${DIR}/..
 
+Xvfb :1 -screen 0 1600x1200x24+32 &
+
 source /opt/ros/kinetic/setup.bash
 mkdir -p ${PX4_SRC_DIR}/catkin_ws/src
 cd ${PX4_SRC_DIR}/catkin_ws/
@@ -18,4 +20,3 @@ export CATKIN_SETUP_UTIL_ARGS=--extend
 export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:${PX4_SRC_DIR}/catkin_ws/src/avoidance/sim/models
 
 source $DIR/rostest_px4_run.sh "$@"
-

--- a/test/rostest_avoidance_run.sh
+++ b/test/rostest_avoidance_run.sh
@@ -3,8 +3,6 @@
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 PX4_SRC_DIR=${DIR}/..
 
-Xvfb :1 -screen 0 1600x1200x24+32 &
-
 source /opt/ros/kinetic/setup.bash
 mkdir -p ${PX4_SRC_DIR}/catkin_ws/src
 cd ${PX4_SRC_DIR}/catkin_ws/

--- a/test/rostest_avoidance_run.sh
+++ b/test/rostest_avoidance_run.sh
@@ -12,6 +12,8 @@ catkin init
 catkin build local_planner --cmake-args -DCMAKE_BUILD_TYPE=Release
 
 source ${PX4_SRC_DIR}/catkin_ws/devel/setup.bash
+source /usr/share/gazebo/setup.sh
+
 export CATKIN_SETUP_UTIL_ARGS=--extend
 export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:${PX4_SRC_DIR}/catkin_ws/src/avoidance/sim/models
 

--- a/test/rostest_avoidance_run.sh
+++ b/test/rostest_avoidance_run.sh
@@ -4,15 +4,15 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 PX4_SRC_DIR=${DIR}/..
 
 source /opt/ros/kinetic/setup.bash
-mkdir -p /tmp/jenkins/workspace/catkin_ws/src
-cd /tmp/jenkins/workspace/catkin_ws/
+mkdir -p ${PX4_SRC_DIR}/catkin_ws/src
+cd ${PX4_SRC_DIR}/catkin_ws/
 git clone --depth=1 https://github.com/PX4/avoidance.git src/
 
 catkin init
 catkin build local_planner --cmake-args -DCMAKE_BUILD_TYPE=Release
-source ${PX4_SRC_DIR}/Tools/setup_gazebo.bash ${PX4_SRC_DIR} ${PX4_SRC_DIR}/build/posix_sitl_default
 
-source /tmp/jenkins/workspace/catkin_ws/devel/setup.bash 2>/dev/null
-export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:${PX4_SRC_DIR}:${PX4_SRC_DIR}/Tools/sitl_gazebo
+source ${PX4_SRC_DIR}/catkin_ws/devel/setup.bash
+export CATKIN_SETUP_UTIL_ARGS=--extend
 
-rostest px4 "$@"
+source $DIR/rostest_px4_run.sh "$@"
+

--- a/test/rostest_avoidance_run.sh
+++ b/test/rostest_avoidance_run.sh
@@ -4,15 +4,15 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 PX4_SRC_DIR=${DIR}/..
 
 source /opt/ros/kinetic/setup.bash
-mkdir ~/catkin_ws/src
-cd ~/catkin_ws
+mkdir -p /tmp/jenkins/workspace/catkin_ws/src
+cd /tmp/jenkins/workspace/catkin_ws/
 git clone --depth=1 https://github.com/PX4/avoidance.git src/
 
 catkin init
 catkin build local_planner --cmake-args -DCMAKE_BUILD_TYPE=Release
 source ${PX4_SRC_DIR}/Tools/setup_gazebo.bash ${PX4_SRC_DIR} ${PX4_SRC_DIR}/build/posix_sitl_default
 
-source ~/catkin_ws/devel/setup.bash 2>/dev/null
+source /tmp/jenkins/workspace/catkin_ws/devel/setup.bash 2>/dev/null
 export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:${PX4_SRC_DIR}:${PX4_SRC_DIR}/Tools/sitl_gazebo
 
 rostest px4 "$@"

--- a/test/rostest_avoidance_run.sh
+++ b/test/rostest_avoidance_run.sh
@@ -3,7 +3,7 @@
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 PX4_SRC_DIR=${DIR}/..
 
-source /opt/ros/kinetic/setup.bash
+source /opt/ros/${ROS_DISTRO}/setup.bash
 mkdir -p ${PX4_SRC_DIR}/catkin_ws/src
 cd ${PX4_SRC_DIR}/catkin_ws/
 git clone --depth=1 https://github.com/PX4/avoidance.git src/avoidance/

--- a/test/rostest_avoidance_run.sh
+++ b/test/rostest_avoidance_run.sh
@@ -3,7 +3,7 @@
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 PX4_SRC_DIR=${DIR}/..
 
-source /opt/ros/${ROS_DISTRO}/setup.bash
+source /opt/ros/${ROS_DISTRO:-kinetic}/setup.bash
 mkdir -p ${PX4_SRC_DIR}/catkin_ws/src
 cd ${PX4_SRC_DIR}/catkin_ws/
 git clone -b '0.1.0' --single-branch --depth 1 https://github.com/PX4/avoidance.git src/avoidance

--- a/test/rostest_avoidance_run.sh
+++ b/test/rostest_avoidance_run.sh
@@ -6,7 +6,7 @@ PX4_SRC_DIR=${DIR}/..
 source /opt/ros/${ROS_DISTRO}/setup.bash
 mkdir -p ${PX4_SRC_DIR}/catkin_ws/src
 cd ${PX4_SRC_DIR}/catkin_ws/
-git clone --depth=1 https://github.com/PX4/avoidance.git src/avoidance/
+git clone -b '0.1.0' --single-branch --depth 1 https://github.com/PX4/avoidance.git src/avoidance
 
 catkin init
 catkin build local_planner --cmake-args -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
This PR is an attempt to get an automated test on the avoidance interface going to check if any future PR would brake the interface.

Test: the vehicle will fly a mission where flying a direct line between the two waypoints leads to a collision with a wall. The avoidance maneuver is simple enough to assure that the local_planner can always find a path around the wall. If the vehicle cannot finish the mission before a timeout, the test fails. 

Current Work in Progress: I need to setup the catkin environment for the avoidance to run. All the steps are done in the script `rostest_avoidance_run.sh`. I see that in the other ROS tests the equivalent script is called [here](https://github.com/PX4/Firmware/blob/d7580aa676b502b755281a0c7a7e5780b1df9066/.ci/Jenkinsfile-SITL_tests#L218). How can I change it to run `rostest_avoidance_run.sh` for the avoidance test?

Future Work: we can use the Gazebo collision topic to detect if the vehicle has crashed


