### PR TITLE
ADIS16477 cleanup and improvements

### DIFF
--- a/src/drivers/imu/adis16477/ADIS16477_main.cpp
+++ b/src/drivers/imu/adis16477/ADIS16477_main.cpp
@@ -57,8 +57,6 @@ void	usage();
 void
 start(enum Rotation rotation)
 {
-	int fd = -1;
-
 	if (g_dev != nullptr)
 		/* if already started, the still command succeeded */
 	{
@@ -78,22 +76,10 @@ start(enum Rotation rotation)
 		goto fail;
 	}
 
-	if (OK != (g_dev)->init()) {
+	if (OK != g_dev->init()) {
 		goto fail;
 	}
 
-	/* set the poll rate to default, starts automatic data collection */
-	fd = px4_open(ADIS16477_DEVICE_PATH_ACCEL, O_RDONLY);
-
-	if (fd < 0) {
-		goto fail;
-	}
-
-	if (px4_ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT) < 0) {
-		goto fail;
-	}
-
-	px4_close(fd);
 	exit(0);
 fail:
 
@@ -173,10 +159,6 @@ reset()
 
 	if (px4_ioctl(fd, SENSORIOCRESET, 0) < 0) {
 		err(1, "driver reset failed");
-	}
-
-	if (px4_ioctl(fd, SENSORIOCSPOLLRATE, SENSOR_POLLRATE_DEFAULT) < 0) {
-		err(1, "driver poll restart failed");
 	}
 
 	px4_close(fd);

--- a/src/lib/drivers/device/integrator.cpp
+++ b/src/lib/drivers/device/integrator.cpp
@@ -44,14 +44,15 @@
 
 #include <drivers/drv_hrt.h>
 
-Integrator::Integrator(uint64_t auto_reset_interval, bool coning_compensation) :
-	_auto_reset_interval(auto_reset_interval),
+Integrator::Integrator(uint32_t auto_reset_interval, bool coning_compensation) :
 	_coning_comp_on(coning_compensation)
 {
+	set_autoreset_interval(auto_reset_interval);
 }
 
 bool
-Integrator::put(uint64_t timestamp, matrix::Vector3f &val, matrix::Vector3f &integral, uint32_t &integral_dt)
+Integrator::put(const uint64_t &timestamp, const matrix::Vector3f &val, matrix::Vector3f &integral,
+		uint32_t &integral_dt)
 {
 	if (_last_integration_time == 0) {
 		/* this is the first item in the integrator */
@@ -72,7 +73,7 @@ Integrator::put(uint64_t timestamp, matrix::Vector3f &val, matrix::Vector3f &int
 	}
 
 	// Use trapezoidal integration to calculate the delta integral
-	matrix::Vector3f delta_alpha = (val + _last_val) * dt * 0.5f;
+	const matrix::Vector3f delta_alpha = (val + _last_val) * dt * 0.5f;
 	_last_val = val;
 
 	// Calculate coning corrections if required
@@ -128,7 +129,7 @@ Integrator::put_with_interval(unsigned interval_us, matrix::Vector3f &val, matri
 	}
 
 	// Create the timestamp artifically.
-	uint64_t timestamp = _last_integration_time + interval_us;
+	const uint64_t timestamp = _last_integration_time + interval_us;
 
 	return put(timestamp, val, integral, integral_dt);
 }
@@ -149,12 +150,10 @@ matrix::Vector3f
 Integrator::get_and_filtered(bool reset, uint32_t &integral_dt, matrix::Vector3f &filtered_val)
 {
 	// Do the usual get with reset first but don't return yet.
-	matrix::Vector3f ret_integral = get(reset, integral_dt);
+	const matrix::Vector3f ret_integral = get(reset, integral_dt);
 
 	// Because we need both the integral and the integral_dt.
-	filtered_val(0) = ret_integral(0) * 1000000 / integral_dt;
-	filtered_val(1) = ret_integral(1) * 1000000 / integral_dt;
-	filtered_val(2) = ret_integral(2) * 1000000 / integral_dt;
+	filtered_val = ret_integral * 1000000 / integral_dt;
 
 	return ret_integral;
 }

--- a/src/lib/drivers/device/integrator.h
+++ b/src/lib/drivers/device/integrator.h
@@ -48,7 +48,7 @@
 class Integrator
 {
 public:
-	Integrator(uint64_t auto_reset_interval = 4000 /* 250 Hz */, bool coning_compensation = false);
+	Integrator(uint32_t auto_reset_interval = 4000 /* 250 Hz */, bool coning_compensation = false);
 	~Integrator() = default;
 
 	// no copy, assignment, move, move assignment
@@ -67,7 +67,7 @@ public:
 	 * @return		true if putting the item triggered an integral reset and the integral should be
 	 *			published.
 	 */
-	bool put(uint64_t timestamp, matrix::Vector3f &val, matrix::Vector3f &integral, uint32_t &integral_dt);
+	bool put(const uint64_t &timestamp, const matrix::Vector3f &val, matrix::Vector3f &integral, uint32_t &integral_dt);
 
 	/**
 	 * Put an item into the integral but provide an interval instead of a timestamp.
@@ -108,12 +108,12 @@ public:
 	/**
 	 * Set auto reset interval during runtime. This won't reset the integrator.
 	 *
-	 * @param auto_reset_interval	    	New reset time interval for the integrator.
+	 * @param auto_reset_interval	    	New reset time interval for the integrator (+- 10%).
 	 */
-	void set_autoreset_interval(uint64_t auto_reset_interval) { _auto_reset_interval = auto_reset_interval; }
+	void set_autoreset_interval(uint32_t auto_reset_interval) { _auto_reset_interval = 0.90f * auto_reset_interval; }
 
 private:
-	uint64_t _auto_reset_interval{0};			/**< the interval after which the content will be published
+	uint32_t _auto_reset_interval{0};			/**< the interval after which the content will be published
 							     and the integrator reset, 0 if no auto-reset */
 
 	uint64_t _last_integration_time{0};		/**< timestamp of the last integration step */


### PR DESCRIPTION
  * test both sensor and memory
  * always restore factory calibration at init
  * verify all registers are set correctly
  * run from ADIS16477 data ready if available


  * integrator add 10% reset interval tolerance
    * the integrator currently resets once `dt interval is >= reset interval`, but due to jitter it's occasionally slightly below the reset interval

Example: 4000 us integrator reset interval, if requirement for reset is dt >= 4000, then the effective publish rate might only be 240 Hz. If you look closely at the data you'll see it's occasionally 3987 us, 3965 us, etc. This makes sense if you consider the system jitter. When using DRDY it's even more common.