### PR TITLE
mavlink: always acknowledge a param write

### DIFF
--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -149,15 +149,9 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 					_mavlink->send_statustext_info(buf);
 
 				} else {
-					// Load current value before setting it
-					float curr_val;
-					param_get(param, &curr_val);
+					// According to the mavlink spec we should always acknowledge a write operation.
 					param_set(param, &(set.param_value));
-
-					// Check if the parameter changed. If it didn't change, send current value back
-					if (!(fabsf(curr_val - set.param_value) > 0.0f)) {
-						send_param(param);
-					}
+					send_param(param);
 				}
 			}
 


### PR DESCRIPTION
This change has two effects:
1. We always acknowledge a param write no matter if the value was
   actually changed or not. This is according to the spec:
   https://mavlink.io/en/services/parameter.html#write-parameters

2. This fixes the bug where int32 parameters were not actually acked
   because the memory of the param value was casted directly to float
   and then compared. In the case of a int32 parameter set from 0 to 1
   it would mean that the cast to float of the memory representation
   was still 0 and therefore it was assumed to be "no change" and the
   ack was omitted.
