### PR TITLE
IMU heater -- fix "stuck on"

### DIFF
--- a/src/drivers/heater/heater.cpp
+++ b/src/drivers/heater/heater.cpp
@@ -150,7 +150,7 @@ void Heater::cycle()
 		return;
 	}
 
-	int _controller_time_on_usec = 0;
+	int controller_time_on_usec = 0;
 
 	if (_heater_on) {
 		// Turn the heater off.
@@ -182,14 +182,14 @@ void Heater::cycle()
 		// Constrain the integrator value to no more than 25% of the duty cycle.
 		_integrator_value = math::constrain(_integrator_value, -0.25f, 0.25f);
 
-		_controller_time_on_usec = (int)((_p_feed_forward_value.get() + _proportional_value +
-						  _integrator_value) * (float)_controller_period_usec);
+		controller_time_on_usec = (int)((_p_feed_forward_value.get() + _proportional_value +
+						 _integrator_value) * (float)_controller_period_usec);
 
 		// Constrain the heater time within the allowable duty cycle.
-		_controller_time_on_usec = math::constrain(_controller_period_usec, 0, _controller_time_on_usec);
+		controller_time_on_usec = math::constrain(controller_time_on_usec, 0, _controller_period_usec);
 
 		// Filter the duty cycle value over a ~2 second time constant.
-		_duty_cycle = (0.05f * ((float)_controller_time_on_usec / (float)_controller_period_usec)) + (0.95f * _duty_cycle);
+		_duty_cycle = (0.05f * ((float)controller_time_on_usec / (float)_controller_period_usec)) + (0.95f * _duty_cycle);
 
 		// Turn the heater on.
 		_heater_on = true;
@@ -197,15 +197,14 @@ void Heater::cycle()
 		px4_arch_gpiowrite(GPIO_HEATER_OUTPUT, 1);
 	}
 
-
 	// Schedule the next cycle.
 	if (_heater_on) {
 		work_queue(LPWORK, &_work, (worker_t)&Heater::cycle_trampoline, this,
-			   USEC2TICK(_controller_time_on_usec));
+			   USEC2TICK(controller_time_on_usec));
 
 	} else {
 		work_queue(LPWORK, &_work, (worker_t)&Heater::cycle_trampoline, this,
-			   USEC2TICK(_controller_period_usec - _controller_time_on_usec));
+			   USEC2TICK(_controller_period_usec - controller_time_on_usec));
 	}
 }
 

--- a/src/drivers/heater/heater.h
+++ b/src/drivers/heater/heater.h
@@ -41,16 +41,10 @@
 
 #pragma once
 
-#include <string.h>
-#include <getopt.h>
-#include <parameters/param.h>
-
 #include <px4_workqueue.h>
 #include <px4_module.h>
 #include <px4_module_params.h>
-
 #include <px4_config.h>
-#include <px4_log.h>
 #include <px4_getopt.h>
 
 #include <uORB/uORB.h>

--- a/src/drivers/heater/heater_params.c
+++ b/src/drivers/heater/heater_params.c
@@ -67,7 +67,7 @@ PARAM_DEFINE_FLOAT(SENS_IMU_TEMP, 55.0f);
  * @max 1.0
  * @decimal 3
  */
-PARAM_DEFINE_FLOAT(SENS_IMU_TEMP_FF, 0.5f);
+PARAM_DEFINE_FLOAT(SENS_IMU_TEMP_FF, 0.0f);
 
 /**
  * IMU heater controller integrator gain value.


### PR DESCRIPTION
Fixed a problem where the heater was getting stuck on. This was due to the next "on" time being calculated as a negative time, thus causing it to not get rescheduled in the work_queue and GPIO being left high. Looks like this bug crept in on the last refactor, the arguments on `math::constrain` were swapped.

This has been tested successfully on a TealOne (pixracer). I think we are the only ones using this driver at the moment, so it should be good to just merge.

Thanks.