### PR TITLE
logger: unlock the mutex for fsync()

### DIFF
--- a/src/modules/logger/log_writer_file.cpp
+++ b/src/modules/logger/log_writer_file.cpp
@@ -257,8 +257,10 @@ void LogWriterFile::run()
 						buffer.close_file();
 					}
 
-				} else if (call_fsync) {
+				} else if (call_fsync && buffer._should_run) {
+					pthread_mutex_unlock(&_mtx);
 					buffer.fsync();
+					pthread_mutex_lock(&_mtx);
 
 				} else if (available == 0 && !buffer._should_run) {
 					buffer.close_file();


### PR DESCRIPTION
Recent logs on master show sampling irregularities (e.g. https://review.px4.io/plot_app?log=2a642472-cdd9-4707-b134-ce9a81b41844), as noticed by @dagar (thanks!). It seems to be introduced with the mission log (https://github.com/PX4/Firmware/pull/10738).
I was not able to replicate the exact same behavior on the bench (likely due to different SD cards), but this PR will help for sure and is likely to fix the cause entirely.

Changes:
- fsync can be a long blocking operation, so we need to make sure the main
  logger thread does not block during this time, when it tries to aquire
  the mutex
- call fsync only when backend is running: fixes calling fsync on an invalid file descriptor

