### PR TITLE
tiltrotor back-transition improvements

### DIFF
--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -124,6 +124,7 @@ void VtolType::update_mc_state()
 	_mc_roll_weight = 1.0f;
 	_mc_pitch_weight = 1.0f;
 	_mc_yaw_weight = 1.0f;
+	_mc_throttle_weight = 1.0f;
 }
 
 void VtolType::update_fw_state()


### PR DESCRIPTION
Generally improves the tiltrotor back-transition a lot (see commit message for further information).

Flight Log:
https://logs.px4.io/plot_app?log=d8c46dbc-59fd-4e9a-866b-bfbeb7fec402

@PX4/testflights Please give this a test on the convergence.
Please set the parameter VT_B_TRANS_DUR to 4 if not already set (default).