### PR TITLE
Fix HIL actuator_outputs

### DIFF
--- a/src/drivers/pwm_out_sim/PWMSim.cpp
+++ b/src/drivers/pwm_out_sim/PWMSim.cpp
@@ -158,6 +158,9 @@ PWMSim::run()
 
 	_armed_sub = orb_subscribe(ORB_ID(actuator_armed));
 
+	/* advertise the mixed control outputs, insist on the first group output */
+	_outputs_pub = orb_advertise(ORB_ID(actuator_outputs), &_actuator_outputs);
+
 	update_params();
 	int params_sub = orb_subscribe(ORB_ID(parameter_update));
 
@@ -284,8 +287,7 @@ PWMSim::run()
 
 			/* and publish for anyone that cares to see */
 			_actuator_outputs.timestamp = hrt_absolute_time();
-			int instance;
-			orb_publish_auto(ORB_ID(actuator_outputs), &_outputs_pub, &_actuator_outputs, &instance, ORB_PRIO_DEFAULT);
+			orb_publish(ORB_ID(actuator_outputs), _outputs_pub, &_actuator_outputs);
 
 			// use first valid timestamp_sample for latency tracking
 			for (int i = 0; i < actuator_controls_s::NUM_ACTUATOR_CONTROL_GROUPS; i++) {

--- a/src/drivers/pwm_out_sim/PWMSim.hpp
+++ b/src/drivers/pwm_out_sim/PWMSim.hpp
@@ -110,7 +110,7 @@ private:
 
 	int		_armed_sub{-1};
 
-	actuator_outputs_s _actuator_outputs{};
+	actuator_outputs_s _actuator_outputs = {};
 	orb_advert_t	_outputs_pub{nullptr};
 
 	unsigned	_num_outputs{0};


### PR DESCRIPTION
This reverts commit [bcad940a9f529388781433f30d432eb1f25a9feb](https://github.com/PX4/Firmware/commit/bcad940a9f529388781433f30d432eb1f25a9feb)

The problem is that with this commit, IO starts to publish `actuator_output` on instance 0 so PWMSim gets the instance 1 and HIL doesn't work anymore.
There is maybe a better fix, but reverting this commit is enough to re-enable HIL.