### PR TITLE
mc_att_control: copy sensor_correction topic once initially

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -613,6 +613,14 @@ MulticopterAttitudeControl::run()
 	}
 
 	_sensor_correction_sub = orb_subscribe(ORB_ID(sensor_correction));
+
+	// sensor correction topic is not being published regularly and we might have missed the first update.
+	// so copy it once initially so that we have the latest data. In future this will not be needed anymore as the
+	// behavior of the orb_check function will change
+	if (_sensor_correction_sub > 0) {
+		orb_copy(ORB_ID(sensor_correction), _sensor_correction_sub, &_sensor_correction);
+	}
+
 	_sensor_bias_sub = orb_subscribe(ORB_ID(sensor_bias));
 
 	/* wakeup source: gyro data from sensor selected by the sensor app */


### PR DESCRIPTION
This was causing the mc_att_controller and the sensors module not to be in sync after a reboot regarding which instance of the gyro topic was selected.
This is relevant when using the CAL_GYROx_EN parameters to disable a specific IMU.