### PR TITLE
Landing gear improvement

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -66,6 +66,7 @@ set(msg_files
 	input_rc.msg
 	iridiumsbd_status.msg
 	irlock_report.msg
+	landing_gear.msg
 	landing_target_innovations.msg
 	landing_target_pose.msg
 	led_control.msg

--- a/msg/landing_gear.msg
+++ b/msg/landing_gear.msg
@@ -1,6 +1,7 @@
-uint64 timestamp            # time since system start (microseconds)
+uint64 timestamp # time since system start (microseconds)
 
-int8 LANDING_GEAR_UP = 1	# landing gear up
-int8 LANDING_GEAR_DOWN = -1	# landing gear down
+int8 GEAR_UP = 1 # landing gear up
+int8 GEAR_DOWN = -1 # landing gear down
+int8 GEAR_KEEP = 0 # keep the current state
 
 int8 landing_gear

--- a/msg/landing_gear.msg
+++ b/msg/landing_gear.msg
@@ -3,4 +3,4 @@ uint64 timestamp            # time since system start (microseconds)
 int8 LANDING_GEAR_UP = 1	# landing gear up
 int8 LANDING_GEAR_DOWN = -1	# landing gear down
 
-float32 landing_gear
+int8 landing_gear

--- a/msg/landing_gear.msg
+++ b/msg/landing_gear.msg
@@ -1,0 +1,6 @@
+uint64 timestamp            # time since system start (microseconds)
+
+int8 LANDING_GEAR_UP = 1	# landing gear up
+int8 LANDING_GEAR_DOWN = -1	# landing gear down
+
+float32 landing_gear

--- a/msg/position_setpoint.msg
+++ b/msg/position_setpoint.msg
@@ -39,7 +39,7 @@ bool yaw_valid			# true if yaw setpoint valid
 float32 yawspeed		# yawspeed (only for multirotors, in rad/s)
 bool yawspeed_valid		# true if yawspeed setpoint valid
 
-bool deploy_gear		# deploy landing gear
+int8 landing_gear		# landing gear: see definition of the states in landing_gear.msg
 
 float32 loiter_radius		# loiter radius (only for fixed wing), in m
 int8 loiter_direction		# loiter direction: 1 = CW, -1 = CCW

--- a/msg/position_setpoint.msg
+++ b/msg/position_setpoint.msg
@@ -39,6 +39,8 @@ bool yaw_valid			# true if yaw setpoint valid
 float32 yawspeed		# yawspeed (only for multirotors, in rad/s)
 bool yawspeed_valid		# true if yawspeed setpoint valid
 
+bool deploy_gear		# deploy landing gear
+
 float32 loiter_radius		# loiter radius (only for fixed wing), in m
 int8 loiter_direction		# loiter direction: 1 = CW, -1 = CCW
 float32 pitch_min		# minimal pitch angle for fixed wing takeoff waypoints

--- a/msg/vehicle_attitude_setpoint.msg
+++ b/msg/vehicle_attitude_setpoint.msg
@@ -1,6 +1,4 @@
 uint64 timestamp		# time since system start (microseconds)
-int8 LANDING_GEAR_UP = 1	# landing gear up
-int8 LANDING_GEAR_DOWN = -1	# landing gear down
 
 float32 roll_body		# body angle in NED frame (can be NaN for FW)
 float32 pitch_body		# body angle in NED frame (can be NaN for FW)
@@ -26,7 +24,5 @@ uint8 apply_flaps       	# flap config specifier
 uint8 FLAPS_OFF = 0     	# no flaps
 uint8 FLAPS_LAND = 1    	# landing config flaps
 uint8 FLAPS_TAKEOFF = 2 	# take-off config flaps
-
-float32 landing_gear
 
 # TOPICS vehicle_attitude_setpoint mc_virtual_attitude_setpoint fw_virtual_attitude_setpoint

--- a/msg/vehicle_constraints.msg
+++ b/msg/vehicle_constraints.msg
@@ -10,8 +10,3 @@ float32 speed_down	# in meters/sec
 float32 tilt    # in radians [0, PI]
 float32 min_distance_to_ground # in meters
 float32 max_distance_to_ground # in meters
-
-int8 GEAR_DOWN = -1
-int8 GEAR_UP = 1
-int8 GEAR_KEEP = 0
-int8 landing_gear # Down, UP or KEEP

--- a/src/lib/FlightTasks/FlightTasks.cpp
+++ b/src/lib/FlightTasks/FlightTasks.cpp
@@ -53,7 +53,7 @@ const landing_gear_s FlightTasks::getGear()
 		return _current_task.task->getGear();
 
 	} else {
-		return FlightTask::landing_gear_default_keep;
+		return FlightTask::empty_landing_gear_default_keep;
 	}
 }
 

--- a/src/lib/FlightTasks/FlightTasks.cpp
+++ b/src/lib/FlightTasks/FlightTasks.cpp
@@ -47,6 +47,16 @@ const vehicle_constraints_s FlightTasks::getConstraints()
 	}
 }
 
+const landing_gear_s FlightTasks::getGear()
+{
+	if (isAnyTaskActive()) {
+		return _current_task.task->getGear();
+
+	} else {
+		return FlightTask::landing_gear_default_keep;
+	}
+}
+
 const vehicle_trajectory_waypoint_s FlightTasks::getAvoidanceWaypoint()
 {
 	if (isAnyTaskActive()) {

--- a/src/lib/FlightTasks/FlightTasks.hpp
+++ b/src/lib/FlightTasks/FlightTasks.hpp
@@ -79,6 +79,12 @@ public:
 	const vehicle_constraints_s getConstraints();
 
 	/**
+	 * Get landing gear position.
+	 * @return landing gear
+	 */
+	const landing_gear_s getGear();
+
+	/**
 	 * Get task avoidance desired waypoints
 	 * @return auto triplets in the mc_pos_control
 	 */

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -224,6 +224,7 @@ bool FlightTaskAuto::_evaluateTriplets()
 	if (triplet_update || (_current_state != previous_state)) {
 		_updateInternalWaypoints();
 		_updateAvoidanceWaypoints();
+		_deploy_gear = _sub_triplet_setpoint->get().current.deploy_gear;
 	}
 
 	if (MPC_OBS_AVOID.get() && _sub_vehicle_status->get().is_rotary_wing) {

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -224,7 +224,7 @@ bool FlightTaskAuto::_evaluateTriplets()
 	if (triplet_update || (_current_state != previous_state)) {
 		_updateInternalWaypoints();
 		_updateAvoidanceWaypoints();
-		_deploy_gear = _sub_triplet_setpoint->get().current.deploy_gear;
+		_mission_gear = _sub_triplet_setpoint->get().current.landing_gear;
 	}
 
 	if (MPC_OBS_AVOID.get() && _sub_vehicle_status->get().is_rotary_wing) {

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
@@ -103,6 +103,7 @@ protected:
 
 	State _current_state{State::none};
 	float _target_acceptance_radius = 0.0f; /**< Acceptances radius of the target */
+	bool _deploy_gear = false;
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTask,
 					(ParamFloat<px4::params::MPC_XY_CRUISE>) MPC_XY_CRUISE,

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
@@ -103,7 +103,7 @@ protected:
 
 	State _current_state{State::none};
 	float _target_acceptance_radius = 0.0f; /**< Acceptances radius of the target */
-	bool _deploy_gear = false;
+	int _mission_gear = landing_gear_s::GEAR_KEEP;
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTask,
 					(ParamFloat<px4::params::MPC_XY_CRUISE>) MPC_XY_CRUISE,

--- a/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
@@ -89,7 +89,7 @@ bool FlightTaskAutoMapper::update()
 	// during mission and reposition, raise the landing gears but only
 	// if altitude is high enough
 	if (_highEnoughForLandingGear()) {
-		_gear.landing_gear = landing_gear_s::GEAR_UP;
+		_gear.landing_gear = _deploy_gear ? landing_gear_s::GEAR_DOWN : landing_gear_s::GEAR_UP;
 	}
 
 	// update previous type

--- a/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
@@ -89,7 +89,7 @@ bool FlightTaskAutoMapper::update()
 	// during mission and reposition, raise the landing gears but only
 	// if altitude is high enough
 	if (_highEnoughForLandingGear()) {
-		_gear.landing_gear = _deploy_gear ? landing_gear_s::GEAR_DOWN : landing_gear_s::GEAR_UP;
+		_gear.landing_gear = _mission_gear;
 	}
 
 	// update previous type

--- a/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
@@ -89,7 +89,7 @@ bool FlightTaskAutoMapper::update()
 	// during mission and reposition, raise the landing gears but only
 	// if altitude is high enough
 	if (_highEnoughForLandingGear()) {
-		_constraints.landing_gear = vehicle_constraints_s::GEAR_UP;
+		_gear.landing_gear = landing_gear_s::GEAR_UP;
 	}
 
 	// update previous type
@@ -121,7 +121,7 @@ void FlightTaskAutoMapper::_generateLandSetpoints()
 	// set constraints
 	_constraints.tilt = MPC_TILTMAX_LND.get();
 	_constraints.speed_down = MPC_LAND_SPEED.get();
-	_constraints.landing_gear = vehicle_constraints_s::GEAR_DOWN;
+	_gear.landing_gear = landing_gear_s::GEAR_DOWN;
 }
 
 void FlightTaskAutoMapper::_generateTakeoffSetpoints()
@@ -134,7 +134,7 @@ void FlightTaskAutoMapper::_generateTakeoffSetpoints()
 	_constraints.speed_up = math::gradual(_alt_above_ground, MPC_LAND_ALT2.get(),
 					      MPC_LAND_ALT1.get(), MPC_TKO_SPEED.get(), _constraints.speed_up);
 
-	_constraints.landing_gear = vehicle_constraints_s::GEAR_DOWN;
+	_gear.landing_gear = landing_gear_s::GEAR_DOWN;
 }
 
 void FlightTaskAutoMapper::_generateVelocitySetpoints()

--- a/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.cpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.cpp
@@ -96,7 +96,7 @@ bool FlightTaskAutoMapper2::update()
 	// during mission and reposition, raise the landing gears but only
 	// if altitude is high enough
 	if (_highEnoughForLandingGear()) {
-		_constraints.landing_gear = vehicle_constraints_s::GEAR_UP;
+		_gear.landing_gear = landing_gear_s::GEAR_UP;
 	}
 
 	// update previous type
@@ -129,7 +129,7 @@ void FlightTaskAutoMapper2::_prepareLandSetpoints()
 
 	// set constraints
 	_constraints.tilt = MPC_TILTMAX_LND.get();
-	_constraints.landing_gear = vehicle_constraints_s::GEAR_DOWN;
+	_gear.landing_gear = landing_gear_s::GEAR_DOWN;
 }
 
 void FlightTaskAutoMapper2::_prepareTakeoffSetpoints()
@@ -139,7 +139,7 @@ void FlightTaskAutoMapper2::_prepareTakeoffSetpoints()
 	const float speed_tko = (_alt_above_ground > MPC_LAND_ALT1.get()) ? _constraints.speed_up : MPC_TKO_SPEED.get();
 	_velocity_setpoint = Vector3f(NAN, NAN, -speed_tko); // Limit the maximum vertical speed
 
-	_constraints.landing_gear = vehicle_constraints_s::GEAR_DOWN;
+	_gear.landing_gear = landing_gear_s::GEAR_DOWN;
 }
 
 void FlightTaskAutoMapper2::_prepareVelocitySetpoints()

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
@@ -36,6 +36,7 @@ bool FlightTask::activate()
 	_setDefaultConstraints();
 	_time_stamp_activate = hrt_absolute_time();
 	_heading_reset_counter = _sub_attitude->get().quat_reset_counter;
+	_gear = landing_gear_default_keep;
 	return true;
 }
 

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
@@ -7,7 +7,7 @@ constexpr uint64_t FlightTask::_timeout;
 const vehicle_local_position_setpoint_s FlightTask::empty_setpoint = {0, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, {NAN, NAN, NAN}};
 
 const vehicle_constraints_s FlightTask::empty_constraints = {0, NAN, NAN, NAN, NAN, NAN, NAN, NAN, {}};
-const landing_gear_s FlightTask::landing_gear_default_keep = {0, landing_gear_s::GEAR_KEEP, {}};
+const landing_gear_s FlightTask::empty_landing_gear_default_keep = {0, landing_gear_s::GEAR_KEEP, {}};
 const vehicle_trajectory_waypoint_s FlightTask::empty_trajectory_waypoint = {0, 0, {0, 0, 0, 0, 0, 0, 0},
 	{	{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false, {0, 0, 0}},
 		{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false, {0, 0, 0}},
@@ -36,7 +36,7 @@ bool FlightTask::activate()
 	_setDefaultConstraints();
 	_time_stamp_activate = hrt_absolute_time();
 	_heading_reset_counter = _sub_attitude->get().quat_reset_counter;
-	_gear = landing_gear_default_keep;
+	_gear = empty_landing_gear_default_keep;
 	return true;
 }
 

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
@@ -6,7 +6,8 @@ constexpr uint64_t FlightTask::_timeout;
 // First index of empty_setpoint corresponds to time-stamp and requires a finite number.
 const vehicle_local_position_setpoint_s FlightTask::empty_setpoint = {0, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, NAN, {NAN, NAN, NAN}};
 
-const vehicle_constraints_s FlightTask::empty_constraints = {0, NAN, NAN, NAN, NAN, NAN, NAN, NAN, vehicle_constraints_s::GEAR_KEEP, {}};
+const vehicle_constraints_s FlightTask::empty_constraints = {0, NAN, NAN, NAN, NAN, NAN, NAN, NAN, {}};
+const landing_gear_s FlightTask::landing_gear_default_keep = {0, landing_gear_s::GEAR_KEEP, {}};
 const vehicle_trajectory_waypoint_s FlightTask::empty_trajectory_waypoint = {0, 0, {0, 0, 0, 0, 0, 0, 0},
 	{	{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false, {0, 0, 0}},
 		{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false, {0, 0, 0}},
@@ -148,7 +149,6 @@ void FlightTask::_setDefaultConstraints()
 	_constraints.speed_up = MPC_Z_VEL_MAX_UP.get();
 	_constraints.speed_down = MPC_Z_VEL_MAX_DN.get();
 	_constraints.tilt = math::radians(MPC_TILTMAX_AIR.get());
-	_constraints.landing_gear = vehicle_constraints_s::GEAR_KEEP;
 	_constraints.min_distance_to_ground = NAN;
 	_constraints.max_distance_to_ground = NAN;
 }

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
@@ -45,6 +45,7 @@
 #include <drivers/drv_hrt.h>
 #include <matrix/matrix/math.hpp>
 #include <uORB/Subscription.hpp>
+#include <uORB/topics/landing_gear.h>
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_local_position_setpoint.h>
 #include <uORB/topics/vehicle_command.h>
@@ -115,6 +116,13 @@ public:
 	const vehicle_constraints_s &getConstraints() { return _constraints; }
 
 	/**
+	 * Get landing gear position.
+	 * The constraints can vary with task.
+	 * @return landing gear
+	 */
+	const landing_gear_s &getGear() { return _gear; }
+
+	/**
 	 * Get avoidance desired waypoint
 	 * @return desired waypoints
 	 */
@@ -131,6 +139,11 @@ public:
 	 * All constraints are set to NAN.
 	 */
 	static const vehicle_constraints_s empty_constraints;
+
+	/**
+	 * default landing gear state
+	 */
+	static const landing_gear_s landing_gear_default_keep;
 
 	/**
 	 * Empty desired waypoints.
@@ -214,6 +227,8 @@ protected:
 	 * The constraints can vary with tasks.
 	 */
 	vehicle_constraints_s _constraints{};
+
+	landing_gear_s _gear{};
 
 	/**
 	 * Desired waypoints.

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
@@ -143,7 +143,7 @@ public:
 	/**
 	 * default landing gear state
 	 */
-	static const landing_gear_s landing_gear_default_keep;
+	static const landing_gear_s empty_landing_gear_default_keep;
 
 	/**
 	 * Empty desired waypoints.

--- a/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.cpp
+++ b/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.cpp
@@ -91,14 +91,11 @@ bool FlightTaskManual::_evaluateSticks()
 		// until he toggles the switch to avoid retracting the gear immediately on takeoff.
 		int8_t gear_switch = _sub_manual_control_setpoint->get().gear_switch;
 
-		if (!_gear.landing_gear) {
-			if (gear_switch == manual_control_setpoint_s::SWITCH_POS_OFF) {
-				_applyGearSwitch(gear_switch);
-			}
-
-		} else {
+		if (_gear_switch_old != gear_switch) {
 			_applyGearSwitch(gear_switch);
 		}
+
+		_gear_switch_old = gear_switch;
 
 		// valid stick inputs are required
 		const bool valid_sticks =  PX4_ISFINITE(_sticks(0))

--- a/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.cpp
+++ b/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.cpp
@@ -91,7 +91,7 @@ bool FlightTaskManual::_evaluateSticks()
 		// until he toggles the switch to avoid retracting the gear immediately on takeoff.
 		int8_t gear_switch = _sub_manual_control_setpoint->get().gear_switch;
 
-		if (!_constraints.landing_gear) {
+		if (!_gear.landing_gear) {
 			if (gear_switch == manual_control_setpoint_s::SWITCH_POS_OFF) {
 				_applyGearSwitch(gear_switch);
 			}
@@ -112,7 +112,7 @@ bool FlightTaskManual::_evaluateSticks()
 		/* Timeout: set all sticks to zero */
 		_sticks.zero();
 		_sticks_expo.zero();
-		_constraints.landing_gear = vehicle_constraints_s::GEAR_KEEP;
+		_gear.landing_gear = landing_gear_s::GEAR_KEEP;
 		return false;
 	}
 }
@@ -120,10 +120,10 @@ bool FlightTaskManual::_evaluateSticks()
 void FlightTaskManual::_applyGearSwitch(uint8_t gswitch)
 {
 	if (gswitch == manual_control_setpoint_s::SWITCH_POS_OFF) {
-		_constraints.landing_gear = vehicle_constraints_s::GEAR_DOWN;
+		_gear.landing_gear = landing_gear_s::GEAR_DOWN;
 	}
 
 	if (gswitch == manual_control_setpoint_s::SWITCH_POS_ON) {
-		_constraints.landing_gear = vehicle_constraints_s::GEAR_UP;
+		_gear.landing_gear = landing_gear_s::GEAR_UP;
 	}
 }

--- a/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.hpp
+++ b/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.hpp
@@ -59,6 +59,7 @@ protected:
 	bool _sticks_data_required = true; /**< let inherited task-class define if it depends on stick data */
 	matrix::Vector<float, 4> _sticks; /**< unmodified manual stick inputs */
 	matrix::Vector<float, 4> _sticks_expo; /**< modified manual sticks using expo function*/
+	int _gear_switch_old = manual_control_setpoint_s::SWITCH_POS_NONE; /**< old switch state*/
 
 	float stickDeadzone() const { return _stick_dz.get(); }
 

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -56,6 +56,7 @@
 #include <uORB/topics/vehicle_rates_setpoint.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_land_detected.h>
+#include <uORB/topics/landing_gear.h>
 
 /**
  * Multicopter attitude control app start / stop handling function
@@ -109,6 +110,7 @@ private:
 	void		vehicle_motor_limits_poll();
 	bool		vehicle_rates_setpoint_poll();
 	void		vehicle_status_poll();
+	void 		landing_gear_state_poll();
 
 	void		publish_actuator_controls();
 	void		publish_rates_setpoint();
@@ -157,6 +159,7 @@ private:
 	int		_sensor_correction_sub{-1};	/**< sensor thermal correction subscription */
 	int		_sensor_bias_sub{-1};		/**< sensor in-run bias correction subscription */
 	int		_vehicle_land_detected_sub{-1};	/**< vehicle land detected subscription */
+	int		_landing_gear_sub{-1};
 
 	unsigned _gyro_count{1};
 	int _selected_gyro{0};
@@ -165,6 +168,7 @@ private:
 	orb_advert_t	_actuators_0_pub{nullptr};		/**< attitude actuator controls publication */
 	orb_advert_t	_controller_status_pub{nullptr};	/**< controller status publication */
 	orb_advert_t	_vehicle_attitude_setpoint_pub{nullptr};
+	orb_advert_t	_landing_gear_pub{nullptr};
 
 	orb_id_t _actuators_id{nullptr};	/**< pointer to correct actuator controls0 uORB metadata structure */
 
@@ -182,6 +186,7 @@ private:
 	struct sensor_correction_s		_sensor_correction {};	/**< sensor thermal corrections */
 	struct sensor_bias_s			_sensor_bias {};	/**< sensor in-run bias corrections */
 	struct vehicle_land_detected_s		_vehicle_land_detected {};
+	struct landing_gear_s 			_landing_gear_state {};
 
 	MultirotorMixer::saturation_status _saturation_status{};
 

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -186,7 +186,7 @@ private:
 	struct sensor_correction_s		_sensor_correction {};	/**< sensor thermal corrections */
 	struct sensor_bias_s			_sensor_bias {};	/**< sensor in-run bias corrections */
 	struct vehicle_land_detected_s		_vehicle_land_detected {};
-	struct landing_gear_s 			_landing_gear_state {};
+	struct landing_gear_s 			_landing_gear {};
 
 	MultirotorMixer::saturation_status _saturation_status{};
 

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -773,7 +773,7 @@ MulticopterAttitudeControl::publish_actuator_controls()
 	_actuators.control[1] = (PX4_ISFINITE(_att_control(1))) ? _att_control(1) : 0.0f;
 	_actuators.control[2] = (PX4_ISFINITE(_att_control(2))) ? _att_control(2) : 0.0f;
 	_actuators.control[3] = (PX4_ISFINITE(_thrust_sp)) ? _thrust_sp : 0.0f;
-	_actuators.control[7] = _landing_gear_state.landing_gear;
+	_actuators.control[7] = (float)_landing_gear_state.landing_gear;
 	_actuators.timestamp = hrt_absolute_time();
 	_actuators.timestamp_sample = _sensor_gyro.timestamp;
 

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -415,9 +415,9 @@ MulticopterAttitudeControl::get_landing_gear_state()
 	if (_vehicle_land_detected.landed) {
 		_gear_state_initialized = false;
 	}
-	float landing_gear = landing_gear_s::LANDING_GEAR_DOWN; // default to down
+	float landing_gear = landing_gear_s::GEAR_DOWN; // default to down
 	if (_manual_control_sp.gear_switch == manual_control_setpoint_s::SWITCH_POS_ON && _gear_state_initialized) {
-		landing_gear = landing_gear_s::LANDING_GEAR_UP;
+		landing_gear = landing_gear_s::GEAR_UP;
 
 	} else if (_manual_control_sp.gear_switch == manual_control_setpoint_s::SWITCH_POS_OFF) {
 		// Switching the gear off does put it into a safe defined state

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -383,7 +383,7 @@ MulticopterAttitudeControl::landing_gear_state_poll()
 	orb_check(_landing_gear_sub, &updated);
 
 	if (updated) {
-		orb_copy(ORB_ID(landing_gear), _landing_gear_sub, &_landing_gear_state);
+		orb_copy(ORB_ID(landing_gear), _landing_gear_sub, &_landing_gear);
 	}
 }
 
@@ -520,7 +520,7 @@ MulticopterAttitudeControl::generate_attitude_setpoint(float dt, bool reset_yaw_
 
 	attitude_setpoint.thrust_body[2] = -throttle_curve(_manual_control_sp.z);
 
-	_landing_gear_state.landing_gear = get_landing_gear_state();
+	_landing_gear.landing_gear = get_landing_gear_state();
 
 	attitude_setpoint.timestamp = landing_gear.timestamp = hrt_absolute_time();
 	orb_publish_auto(ORB_ID(vehicle_attitude_setpoint), &_vehicle_attitude_setpoint_pub, &attitude_setpoint, nullptr, ORB_PRIO_DEFAULT);
@@ -773,7 +773,7 @@ MulticopterAttitudeControl::publish_actuator_controls()
 	_actuators.control[1] = (PX4_ISFINITE(_att_control(1))) ? _att_control(1) : 0.0f;
 	_actuators.control[2] = (PX4_ISFINITE(_att_control(2))) ? _att_control(2) : 0.0f;
 	_actuators.control[3] = (PX4_ISFINITE(_thrust_sp)) ? _thrust_sp : 0.0f;
-	_actuators.control[7] = (float)_landing_gear_state.landing_gear;
+	_actuators.control[7] = (float)_landing_gear.landing_gear;
 	_actuators.timestamp = hrt_absolute_time();
 	_actuators.timestamp_sample = _sensor_gyro.timestamp;
 
@@ -819,7 +819,7 @@ MulticopterAttitudeControl::run()
 	_sensor_correction_sub = orb_subscribe(ORB_ID(sensor_correction));
 	_sensor_bias_sub = orb_subscribe(ORB_ID(sensor_bias));
 	_vehicle_land_detected_sub = orb_subscribe(ORB_ID(vehicle_land_detected));
-	_landing_gear_sub =  orb_subscribe(ORB_ID(landing_gear));
+	_landing_gear_sub = orb_subscribe(ORB_ID(landing_gear));
 
 	/* wakeup source: gyro data from sensor selected by the sensor app */
 	px4_pollfd_struct_t poll_fds = {};

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -691,6 +691,7 @@ MulticopterPositionControl::run()
 			update_avoidance_waypoint_desired(_states, setpoint);
 
 			vehicle_constraints_s constraints = _flight_tasks.getConstraints();
+			landing_gear_s gear = _flight_tasks.getGear();
 
 			// check if all local states are valid and map accordingly
 			set_vehicle_states(setpoint.vz);
@@ -732,7 +733,7 @@ MulticopterPositionControl::run()
 				setpoint.vx = setpoint.vy = setpoint.vz = NAN;
 				setpoint.yawspeed = NAN;
 				setpoint.yaw = _states.yaw;
-				constraints.landing_gear = vehicle_constraints_s::GEAR_KEEP;
+				gear.landing_gear = landing_gear_s::GEAR_KEEP;
 				// reactivate the task which will reset the setpoint to current state
 				_flight_tasks.reActivate();
 			}
@@ -801,11 +802,11 @@ MulticopterPositionControl::run()
 			// they might conflict with each other such as in offboard attitude control.
 			publish_attitude();
 
-			// if theres any change in landing gear setpoint publish it
-			if (_old_landing_gear_position != constraints.landing_gear
-				&& constraints.landing_gear != vehicle_constraints_s::GEAR_KEEP) {
+			// if there's any change in landing gear setpoint publish it
+			if (gear.landing_gear != _old_landing_gear_position
+				&& gear.landing_gear != landing_gear_s::GEAR_KEEP) {
 
-				_landing_gear.landing_gear = constraints.landing_gear;
+				_landing_gear.landing_gear = gear.landing_gear;
 				_landing_gear.timestamp = hrt_absolute_time();
 
 				if (_landing_gear_pub != nullptr) {
@@ -816,7 +817,7 @@ MulticopterPositionControl::run()
 				}
 			}
 
-			_old_landing_gear_position = constraints.landing_gear;
+			_old_landing_gear_position = gear.landing_gear;
 
 		} else {
 			// no flighttask is active: set attitude setpoint to idle

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -137,7 +137,7 @@ private:
 	home_position_s				_home_pos{};			/**< home position */
 	vehicle_trajectory_waypoint_s		_traj_wp_avoidance{};		/**< trajectory waypoint */
 	vehicle_trajectory_waypoint_s		_traj_wp_avoidance_desired{};	/**< desired waypoints, inputs to an obstacle avoidance module */
-	landing_gear_s _landing_gear_state{};
+	landing_gear_s _landing_gear{};
 
 	int8_t		_old_landing_gear_position;
 
@@ -597,17 +597,6 @@ MulticopterPositionControl::run()
 	parameters_update(true);
 	poll_subscriptions();
 
-	// Let's be safe and have the landing gear down by default
-	_landing_gear_state.landing_gear = landing_gear_s::LANDING_GEAR_DOWN;
-	_landing_gear_state.timestamp = hrt_absolute_time();
-
-	if (_landing_gear_pub != nullptr) {
-		orb_publish(ORB_ID(landing_gear), _landing_gear_pub, &_landing_gear_state);
-
-	} else {
-		_landing_gear_pub = orb_advertise(ORB_ID(landing_gear), &_landing_gear_state);
-	}
-
 	// setup file descriptor to poll the local position as loop wakeup source
 	px4_pollfd_struct_t poll_fd = {.fd = _local_pos_sub};
 	poll_fd.events = POLLIN;
@@ -816,14 +805,14 @@ MulticopterPositionControl::run()
 			if (_old_landing_gear_position != constraints.landing_gear
 				&& constraints.landing_gear != vehicle_constraints_s::GEAR_KEEP) {
 
-				_landing_gear_state.landing_gear = constraints.landing_gear;
-				_landing_gear_state.timestamp = hrt_absolute_time();
+				_landing_gear.landing_gear = constraints.landing_gear;
+				_landing_gear.timestamp = hrt_absolute_time();
 
 				if (_landing_gear_pub != nullptr) {
-					orb_publish(ORB_ID(landing_gear), _landing_gear_pub, &_landing_gear_state);
+					orb_publish(ORB_ID(landing_gear), _landing_gear_pub, &_landing_gear);
 
 				} else {
-					_landing_gear_pub = orb_advertise(ORB_ID(landing_gear), &_landing_gear_state);
+					_landing_gear_pub = orb_advertise(ORB_ID(landing_gear), &_landing_gear);
 				}
 			}
 

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -812,12 +812,11 @@ MulticopterPositionControl::run()
 			// they might conflict with each other such as in offboard attitude control.
 			publish_attitude();
 
-			if (_old_landing_gear_position != constraints.landing_gear) {
-				_landing_gear_state.landing_gear =
-					(constraints.landing_gear == vehicle_constraints_s::GEAR_UP) ?
-					landing_gear_s::LANDING_GEAR_UP :
-					landing_gear_s::LANDING_GEAR_DOWN;
+			// if theres any change in landing gear setpoint publish it
+			if (_old_landing_gear_position != constraints.landing_gear
+				&& constraints.landing_gear != vehicle_constraints_s::GEAR_KEEP) {
 
+				_landing_gear_state.landing_gear = constraints.landing_gear;
 				_landing_gear_state.timestamp = hrt_absolute_time();
 
 				if (_landing_gear_pub != nullptr) {

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -733,7 +733,6 @@ MulticopterPositionControl::run()
 				setpoint.vx = setpoint.vy = setpoint.vz = NAN;
 				setpoint.yawspeed = NAN;
 				setpoint.yaw = _states.yaw;
-				gear.landing_gear = landing_gear_s::GEAR_KEEP;
 				// reactivate the task which will reset the setpoint to current state
 				_flight_tasks.reActivate();
 			}

--- a/src/modules/navigator/gpsfailure.cpp
+++ b/src/modules/navigator/gpsfailure.cpp
@@ -46,6 +46,7 @@
 #include <uORB/uORB.h>
 #include <uORB/topics/mission.h>
 #include <uORB/topics/home_position.h>
+#include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <mathlib/mathlib.h>
 
 using matrix::Eulerf;

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -67,7 +67,6 @@
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/position_controller_status.h>
 #include <uORB/topics/position_setpoint_triplet.h>
-#include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_global_position.h>
 #include <uORB/topics/vehicle_gps_position.h>


### PR DESCRIPTION
**Test data / coverage**
SITL/HITL and field tested ~20 flights in H520 Firmware before cherry-picking.

**Describe problem solved by the proposed pull request**
Controlling the landing gear is tied to the attitude setpoint message which is just misusing an existing message that lead to a lot of problems when implementing landing gear behaviour according to product requirements.

**Describe your preferred solution**
We took the time to solve these problems and make it more flexible and want to contribute this architecture.

**Additional context**
There were conflicts with #10805. (FYI @bkueng)

---

**State:** I'm still porting commits.