### PR TITLE
Fix macOS SITL after unix sockets change

### DIFF
--- a/platforms/posix/src/px4_daemon/client.cpp
+++ b/platforms/posix/src/px4_daemon/client.cpp
@@ -155,6 +155,7 @@ Client::_listen()
 
 			} else {
 				// Missing return value at end of stream. Stream was abruptly ended.
+				PX4_ERR("stream abruptly ended");
 				return -1;
 			}
 

--- a/platforms/posix/src/px4_daemon/server.cpp
+++ b/platforms/posix/src/px4_daemon/server.cpp
@@ -259,7 +259,7 @@ void
 	char buf[2] = {0, (char)retval};
 
 	if (write(fd, buf, sizeof buf) < 0) {
-		// Don't care it went wrong, as we're cleaning up anyway.
+		PX4_ERR("write failed: %s", strerror(errno));
 	}
 
 	_cleanup(fd);

--- a/platforms/posix/src/px4_daemon/server_io.cpp
+++ b/platforms/posix/src/px4_daemon/server_io.cpp
@@ -107,7 +107,7 @@ int send_stdout_pipe_buffer(unsigned buffer_length)
 	int bytes_sent = write(thread_data_ptr->fd, thread_data_ptr->buffer, buffer_length);
 
 	if (bytes_sent != (int)buffer_length) {
-		printf("write fail\n");
+		printf("write fail: %s", strerror(errno));
 		return -1;
 	}
 


### PR DESCRIPTION
This fixes a regression on macOS for SITL after #10766, and fixes #10839.

It turns out that poll is not implemented consistently across platforms, especially when it comes to which bits are set for which event, for a comparison, checkout:
https://www.greenend.org.uk/rjk/tech/poll.html

The takeaway as mentioned in the conlusion in the link above is that you can't rely on `POLLIN` or `POLLHUP` to check if a pipe/socket has been closed but you need to do a `read` and check for `EOF`.

Therefore, I removed the logic polling for `POLLHUP` which triggered too early on macOS. `POLLHUP` was triggered on `shutdown(SHUT_WR)` of the client side when really we were interested in the server side doing a `shutdown(SHUT_RDWR)`.

Instead, we can just do a `shutdown` and `close` in the server, once we're done and have sent the return code to the client.

@m-ou-se I would appreciate your review/feedback, thanks!