### PR TITLE
logger: fix vision topics naming

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -653,13 +653,13 @@ void Logger::add_default_topics()
 	add_topic("vehicle_local_position", 100);
 	add_topic("vehicle_local_position_setpoint", 100);
 	add_topic("vehicle_magnetometer", 200);
-	add_topic("vehicle_mocap_odometry");
+	add_topic("vehicle_mocap_odometry", 30);
 	add_topic("vehicle_rates_setpoint", 30);
 	add_topic("vehicle_status", 200);
 	add_topic("vehicle_status_flags");
 	add_topic("vehicle_trajectory_waypoint", 200);
 	add_topic("vehicle_trajectory_waypoint_desired", 200);
-	add_topic("vehicle_visual_odometry");
+	add_topic("vehicle_visual_odometry", 30);
 	add_topic("vtol_vehicle_status", 200);
 	add_topic("wind_estimate", 200);
 

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -653,13 +653,13 @@ void Logger::add_default_topics()
 	add_topic("vehicle_local_position", 100);
 	add_topic("vehicle_local_position_setpoint", 100);
 	add_topic("vehicle_magnetometer", 200);
+	add_topic("vehicle_mocap_odometry");
 	add_topic("vehicle_rates_setpoint", 30);
 	add_topic("vehicle_status", 200);
 	add_topic("vehicle_status_flags");
 	add_topic("vehicle_trajectory_waypoint", 200);
 	add_topic("vehicle_trajectory_waypoint_desired", 200);
-	add_topic("vehicle_vision_attitude");
-	add_topic("vehicle_vision_position");
+	add_topic("vehicle_visual_odometry");
 	add_topic("vtol_vehicle_status", 200);
 	add_topic("wind_estimate", 200);
 
@@ -720,8 +720,7 @@ void Logger::add_estimator_replay_topics()
 	add_topic("vehicle_land_detected");
 	add_topic("vehicle_magnetometer");
 	add_topic("vehicle_status");
-	add_topic("vehicle_vision_attitude");
-	add_topic("vehicle_vision_position");
+	add_topic("vehicle_visual_odometry");
 }
 
 void Logger::add_thermal_calibration_topics()


### PR DESCRIPTION
https://github.com/PX4/Firmware/pull/9895 introduced a new `vehicle_odometry` message, with some aliases that are used to propagate odometry data to the estimators. On this process, forgot to add the respective topics to log. This PR fixes that.

@AnnaDaiZH this should address your request.