### PR TITLE
Appveyor: Switch build cache to the entire PX4 folder

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,10 +19,14 @@ init:
 - ver
 
 install:
-- ps: if (-not (Test-Path C:\Toolchain.msi)) {Invoke-WebRequest https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.4.msi -OutFile C:\Toolchain.msi}
-- start /wait msiexec /i C:\Toolchain.msi /quiet /qn /norestart /log C:\install.log
+# if the toolchain wasn't restored from build cache download and install it
+- ps: >-
+    if (-not (Test-Path C:\PX4)) {
+        Invoke-WebRequest https://s3-us-west-2.amazonaws.com/px4-tools/PX4+Windows+Cygwin+Toolchain/PX4+Windows+Cygwin+Toolchain+0.4.msi -OutFile C:\Toolchain.msi
+        Start-Process -Wait msiexec -ArgumentList '/I C:\Toolchain.msi /quiet /qn /norestart /log C:\install.log'
+    }
 
-# Note: using start /wait is important
+# Note: using Start-Process -Wait is important
 # because otherwise the install begins but non-blocking and the result cannot be used just after
 
 build_script:
@@ -31,7 +35,7 @@ build_script:
 # safe the repopath for switching to it in cygwin bash
 - for /f %%i in ('cygpath -u %%CD%%') do set repopath=%%i
 # fetch all submodules in parallel
-- call bash --login -c "cd $repopath && git submodule update --init --recursive --jobs=10"
+- call bash --login -c "cd $repopath && git submodule -q update --init --recursive --jobs=10"
 # make SITL
 - call bash --login -c "cd $repopath && make posix"
 # make pixracer to check NuttX build
@@ -41,6 +45,7 @@ build_script:
 # because otherwise certain things (like python; import numpy) do not work
 
 cache:
-# cache toolchain installation file to avoid downloading it from AWS S3 each time
-# it's ~496MB < 1GB free limit for build caches
-- C:\Toolchain.msi -> appveyor.yml
+# cache the entire toolchain installation folder to avoid
+# downloading it from AWS S3 and installing the MSI each time
+# it's ~1.8GB > 1GB free limit for build caches
+- C:\PX4 -> appveyor.yml


### PR DESCRIPTION
to save the time running the installer for every build
which was necessary before because the folder exceedes
the maximum of 1GB cache of the appveyor free plan

this should save CI time as discussed with @dagar over slack