### PR TITLE
[WIP] camera trigger: add support for fmu pins 7 and 8

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -462,15 +462,22 @@ else
 
 	if param greater TRIG_MODE 0
 	then
-		# We ONLY support trigger on pins 5 and 6 when simultanously using AUX for actuator output.
-		if param compare TRIG_PINS 56
+		# We ONLY support trigger on pins 5, 6, 7 and 8 when simultanously using AUX for actuator output.
+		if param compare TRIG_PINS 78
 		then
-			# clear pins 5 and 6
+			# clear pins 7 and 8
 			set FMU_MODE pwm4
 			set AUX_MODE pwm4
 		else
-			set FMU_MODE none
-			set AUX_MODE none
+			if param compare TRIG_PINS 56
+			then
+				# clear pins 5, 6
+				set FMU_MODE pwm4
+				set AUX_MODE pwm4
+			else
+				set FMU_MODE none
+				set AUX_MODE none
+			fi
 		fi
 
 		camera_trigger start

--- a/src/drivers/camera_trigger/interfaces/src/camera_interface.h
+++ b/src/drivers/camera_trigger/interfaces/src/camera_interface.h
@@ -6,6 +6,13 @@
 
 #include <parameters/param.h>
 #include <px4_log.h>
+#include <board_config.h>
+
+#ifdef DIRECT_PWM_OUTPUT_CHANNELS
+#define TRIGGER_OUT_CHANNELS DIRECT_PWM_OUTPUT_CHANNELS
+#else
+#define TRIGGER_OUT_CHANNELS 6
+#endif
 
 #define arraySize(a) (sizeof((a))/sizeof(((a)[0])))
 
@@ -74,6 +81,6 @@ protected:
 
 	param_t _p_pin;
 
-	int _pins[6];
+	int _pins[TRIGGER_OUT_CHANNELS];
 
 };

--- a/src/drivers/camera_trigger/interfaces/src/gpio.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/gpio.cpp
@@ -3,7 +3,7 @@
 #include "gpio.h"
 #include <cstring>
 
-constexpr uint32_t CameraInterfaceGPIO::_gpios[6];
+constexpr uint32_t CameraInterfaceGPIO::_gpios[TRIGGER_OUT_CHANNELS];
 
 CameraInterfaceGPIO::CameraInterfaceGPIO():
 	CameraInterface(),
@@ -50,9 +50,17 @@ void CameraInterfaceGPIO::trigger(bool trigger_on_true)
 
 void CameraInterfaceGPIO::info()
 {
+
+#if defined(TRIGGER_OUT_CHANNELS) && TRIGGER_OUT_CHANNELS <= 6
 	PX4_INFO("GPIO trigger mode, pins enabled : [%d][%d][%d][%d][%d][%d], polarity : %s",
 		 _pins[5], _pins[4], _pins[3], _pins[2], _pins[1], _pins[0],
 		 _trigger_invert ? "ACTIVE_LOW" : "ACTIVE_HIGH");
+#else
+	PX4_INFO("GPIO trigger mode, pins enabled : [%d][%d][%d][%d][%d][%d][%d][%d], polarity : %s",
+		 _pins[7], _pins[6], _pins[5], _pins[4], _pins[3], _pins[2], _pins[1], _pins[0],
+		 _trigger_invert ? "ACTIVE_LOW" : "ACTIVE_HIGH");
+#endif
+
 }
 
 #endif /* ifdef __PX4_NUTTX */

--- a/src/drivers/camera_trigger/interfaces/src/gpio.h
+++ b/src/drivers/camera_trigger/interfaces/src/gpio.h
@@ -30,13 +30,17 @@ private:
 
 	bool _trigger_invert;
 
-	static constexpr uint32_t _gpios[6] = {
+	static constexpr uint32_t _gpios[TRIGGER_OUT_CHANNELS] = {
 		GPIO_GPIO0_OUTPUT,
 		GPIO_GPIO1_OUTPUT,
 		GPIO_GPIO2_OUTPUT,
 		GPIO_GPIO3_OUTPUT,
 		GPIO_GPIO4_OUTPUT,
-		GPIO_GPIO5_OUTPUT
+		GPIO_GPIO5_OUTPUT,
+#if defined(TRIGGER_OUT_CHANNELS) && TRIGGER_OUT_CHANNELS > 6
+		GPIO_GPIO6_OUTPUT,
+		GPIO_GPIO7_OUTPUT,
+#endif
 	};
 
 	uint32_t _triggers[arraySize(_gpios)];

--- a/src/drivers/camera_trigger/interfaces/src/pwm.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.cpp
@@ -58,8 +58,14 @@ void CameraInterfacePWM::trigger(bool trigger_on_true)
 
 void CameraInterfacePWM::info()
 {
+#if defined(TRIGGER_OUT_CHANNELS) && TRIGGER_OUT_CHANNELS <= 6
 	PX4_INFO("PWM trigger mode (generic), pins enabled : [%d][%d][%d][%d][%d][%d]",
 		 _pins[5], _pins[4], _pins[3], _pins[2], _pins[1], _pins[0]);
+#else
+	PX4_INFO("PWM trigger mode (generic), pins enabled : [%d][%d][%d][%d][%d][%d][%d][%d]",
+		 _pins[7], _pins[6], _pins[5], _pins[4], _pins[3], _pins[2], _pins[1], _pins[0]);
+#endif
+
 }
 
 #endif /* ifdef __PX4_NUTTX */

--- a/src/drivers/camera_trigger/interfaces/src/seagull_map2.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/seagull_map2.cpp
@@ -102,8 +102,13 @@ void CameraInterfaceSeagull::send_toggle_power(bool enable)
 
 void CameraInterfaceSeagull::info()
 {
+#if defined(TRIGGER_OUT_CHANNELS) && TRIGGER_OUT_CHANNELS <= 6
 	PX4_INFO("PWM trigger mode (Seagull MAP2) , pins enabled : [%d][%d][%d][%d][%d][%d]",
 		 _pins[5], _pins[4], _pins[3], _pins[2], _pins[1], _pins[0]);
+#else
+	PX4_INFO("PWM trigger mode (Seagull MAP2) , pins enabled : [%d][%d][%d][%d][%d][%d][%d][%d]",
+		 _pins[7], _pins[6], _pins[5], _pins[4], _pins[3], _pins[2], _pins[1], _pins[0]);
+#endif
 }
 
 #endif /* ifdef __PX4_NUTTX */


### PR DESCRIPTION
This pr adds support for fmu pwm pins 7 and 8. It was currently just tested on fmu-v5 (Pixhawk 4) for both GPIO and PWM triggering.