### PR TITLE
mavlink hash check: return early in case of hash check parameter

### DIFF
--- a/platforms/posix/src/px4_layer/px4_posix_tasks.cpp
+++ b/platforms/posix/src/px4_layer/px4_posix_tasks.cpp
@@ -144,9 +144,9 @@ px4_task_t px4_task_spawn_cmd(const char *name, int scheduler, int priority, int
 
 	// not safe to pass stack data to the thread creation
 	pthdata_t *taskdata = (pthdata_t *)malloc(structsize + len);
-	
+
 	if (taskdata == nullptr) {
-		return -ENOMEM;			
+		return -ENOMEM;
 	}
 
 	memset(taskdata, 0, structsize + len);

--- a/platforms/qurt/src/px4_layer/px4_qurt_tasks.cpp
+++ b/platforms/qurt/src/px4_layer/px4_qurt_tasks.cpp
@@ -149,7 +149,7 @@ px4_task_t px4_task_spawn_cmd(const char *name, int scheduler, int priority, int
 	taskdata = (pthdata_t *)malloc(structsize + len);
 
 	if (taskdata == nullptr) {
-		return -ENOMEM;			
+		return -ENOMEM;
 	}
 
 	offset = ((unsigned long)taskdata) + structsize;

--- a/src/modules/mavlink/mavlink_parameters.cpp
+++ b/src/modules/mavlink/mavlink_parameters.cpp
@@ -134,8 +134,12 @@ MavlinkParametersManager::handle_message(const mavlink_message_t *msg)
 				name[MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN] = '\0';
 
 				/* Whatever the value is, we're being told to stop sending */
-				if (strncmp(name, "_HASH_CHECK", sizeof(name)) == 0 && _mavlink->hash_check_enabled()) {
-					_send_all_index = -1;
+				if (strncmp(name, "_HASH_CHECK", sizeof(name)) == 0) {
+
+					if (_mavlink->hash_check_enabled()) {
+						_send_all_index = -1;
+					}
+
 					/* No other action taken, return */
 					return;
 				}


### PR DESCRIPTION
A request for setting the '_HASH_CHECK' parameter is handled differently
than the same request for a standard parameter. Make sure we don't actually
try to set the parameter.

Signed-off-by: Roman <bapstroman@gmail.com>

