### PR TITLE
Direct PWM control of the main outputs.

### DIFF
--- a/msg/offboard_control_mode.msg
+++ b/msg/offboard_control_mode.msg
@@ -7,3 +7,4 @@ bool ignore_position
 bool ignore_velocity
 bool ignore_acceleration_force
 bool ignore_alt_hold
+bool ignore_mixed_outputs

--- a/msg/vehicle_control_mode.msg
+++ b/msg/vehicle_control_mode.msg
@@ -9,6 +9,7 @@ bool flag_external_manual_override_ok		# external override non-fatal for system.
 bool flag_system_hil_enabled
 
 bool flag_control_manual_enabled		# true if manual input is mixed in
+bool flag_control_motor_output_enabled	# true if direct motor input is requested from offboard
 bool flag_control_auto_enabled			# true if onboard autopilot should act
 bool flag_control_offboard_enabled		# true if offboard control should be used
 bool flag_control_rates_enabled			# true if rates are stabilized

--- a/src/drivers/pwm_out_sim/PWMSim.hpp
+++ b/src/drivers/pwm_out_sim/PWMSim.hpp
@@ -51,6 +51,7 @@
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/actuator_outputs.h>
 #include <uORB/topics/parameter_update.h>
+#include <uORB/topics/vehicle_control_mode.h>
 
 class PWMSim : public device::CDev, public ModuleBase<PWMSim>
 {
@@ -110,6 +111,8 @@ private:
 	unsigned	_poll_fds_num{0};
 
 	int		_armed_sub{-1};
+	int     _v_control_mode_sub{-1};
+	struct vehicle_control_mode_s _v_control_mode;
 
 	actuator_outputs_s _actuator_outputs = {};
 	orb_advert_t	_outputs_pub{nullptr};

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -73,10 +73,6 @@
 #include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_status.h>
 
-#ifdef HRT_PPM_CHANNEL
-# include <systemlib/ppm_decode.h>
-#endif
-
 #define SCHEDULE_INTERVAL	2000	/**< The schedule interval in usec (500 Hz) */
 
 static constexpr uint8_t CYCLE_COUNT = 10; /* safety switch must be held for 1 second to activate */
@@ -263,7 +259,7 @@ private:
 
 	static pwm_limit_t	_pwm_limit;
 	static actuator_armed_s	_armed;
-	static struct vehicle_control_mode_s _v_control_mode;
+	struct vehicle_control_mode_s _v_control_mode;
 	uint16_t	_failsafe_pwm[_max_actuators];
 	uint16_t	_disarmed_pwm[_max_actuators];
 	uint16_t	_min_pwm[_max_actuators];
@@ -1313,7 +1309,7 @@ PX4FMU::cycle()
 				if (_v_control_mode.flag_control_motor_output_enabled) {
 					for (size_t i = 0; i < mixed_num_outputs; i++) {
 						/* Feed the input directly to the motors, range [-1,1] */
-						outputs[i] = _controls[i]; 
+						outputs[i] = _controls->control[i]; 
 					} 
 				}
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1036,6 +1036,12 @@ MavlinkReceiver::handle_message_set_actuator_control_target(mavlink_message_t *m
 		offboard_control_mode.ignore_velocity           = true;
 		offboard_control_mode.ignore_acceleration_force = true;
 
+		if (set_actuator_control_target.group_mlx == 99) {
+			offboard_control_mode.ignore_mixed_outputs = true;
+		} else {
+			offboard_control_mode.ignore_mixed_outputs = false;
+		}
+
 		offboard_control_mode.timestamp = hrt_absolute_time();
 
 		if (_offboard_control_mode_pub == nullptr) {


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary.

**Test data / coverage**
Tested with SITL, video shown below:
https://drive.google.com/open?id=1ojMMRyiiii7A6pIMROro7hTnzVVwQ9em
I can provide logs (is it possible to take them from SITL?)

**Describe problem solved by the proposed pull request**
This PR enables direct pwm control of the motors by bypassing the mixer results. A control mode flag is set when mavros ActuatorControl->group_mix = 99 (this shall be changed by something more convenient, maybe a change on the message definition to add a constant for that. This control flag is verified at the FMU level (and on PWMSim for the simulation part), and if true, then the actuator_controls from the mixer are overridden. This happens before the safety constraints, so the user inputs still go through them to make sure they are bounded and within the usual limits. 

This is a desired feature from the Automatic Control standpoint, as there is the need to have a very low-level control on the vehicle. This solution also does not interfere with any other modules or safety measures/routines. 

Minor: fixed a small leak on the FMU, where the _adc_sub was not being unsubscribed at the destructor. 

**Describe your preferred solution**
Proposed solution.

**Describe possible alternatives**
-

**Additional context**
-
