### PR TITLE
pwm_out_sim add mixer saturation status publication

### DIFF
--- a/src/drivers/pwm_out_sim/PWMSim.hpp
+++ b/src/drivers/pwm_out_sim/PWMSim.hpp
@@ -112,6 +112,7 @@ private:
 
 	actuator_outputs_s _actuator_outputs = {};
 	orb_advert_t	_outputs_pub{nullptr};
+	orb_advert_t	_mixer_status{nullptr};
 
 	unsigned	_num_outputs{0};
 


### PR DESCRIPTION
Many of the output modules are missing the motor saturation status publication used by the multicopter attitude controller. As a start let's get it in SITL to see if it even works.

It's already in the logger defaults (SITL only extras).

TODO:
 - create output module interface to enforce consistency