### PR TITLE
logger limit trajectory_setpoint rate

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -641,7 +641,7 @@ void Logger::add_default_topics()
 	add_topic("sensor_preflight", 200);
 	add_topic("system_power", 500);
 	add_topic("tecs_status", 200);
-	add_topic("trajectory_setpoint");
+	add_topic("trajectory_setpoint", 200);
 	add_topic("telemetry_status");
 	add_topic("vehicle_air_data", 200);
 	add_topic("vehicle_attitude", 30);


### PR DESCRIPTION
This ends up being a big chunk of a typical MC log.

Example log -  https://logs.px4.io/plot_app?log=287214e8-74c6-44d6-af32-47af0701bf56

	Logging start time: 0:07:10, duration: 0:04:03
	Dropouts: count: 289, total duration: 13.7 s, max: 1292 ms, mean: 47 ms
	Info Messages:
	 sys_mcu: STM32F42x, rev. 3
	 sys_name: PX4
	 sys_os_name: NuttX
	 sys_os_ver: 166d898c70141d7ddb179b5ead1c5ea726574411
	 sys_os_ver_release: 118882559
	 sys_toolchain: GNU GCC
	 sys_toolchain_ver: 7.2.1 20170904 (release) [ARM/embedded-7-branch revision 255204]
	 sys_uuid: 000100000000363533353336510900500021
	 time_ref_utc: 0
	 ver_hw: PX4FMU_V2
	 ver_hw_subtype: V2
	 ver_sw: 3ee596284d4d19226ac921696d0cb55835af975b
	 ver_sw_release: 17301504
	Info Multiple Messages: [perf_counter_postflight: 1], [perf_counter_preflight: 1], [perf_top_postflight: 1], [perf_top_preflight: 1]

	Name (multi id, message size in bytes)    number of data points, total bytes
	 actuator_controls_0 (0, 48)                 2266     108768
	 actuator_outputs (0, 76)                    2246     170696
	 actuator_outputs (1, 76)                    2241     170316
	 battery_status (0, 83)                       459      38097
	 cpuload (0, 16)                              225       3600
	 ekf2_innovations (0, 164)                   1121     183844
	 ekf2_timestamps (0, 22)                    57023    1254506
	 ekf_gps_drift (0, 21)                         29        609
	 estimator_status (0, 268)                   1116     299088
	 home_position (0, 47)                          1         47
	 input_rc (0, 69)                            1124      77556
	 manual_control_setpoint (0, 63)             1121      70623
	 mission_result (0, 32)                        18        576
	 position_setpoint_triplet (0, 320)            20       6400
	 radio_status (0, 17)                         230       3910
	 rate_ctrl_status (0, 36)                    7250     261000
	 sensor_combined (0, 44)                    57120    2513280
	 sensor_preflight (0, 20)                       6        120
	 system_power (0, 23)                         456      10488
	 telemetry_status (0, 45)                     226      10170
	 trajectory_setpoint (0, 76)                28487    2165012
	 vehicle_air_data (0, 24)                   15861     380664
	 vehicle_attitude (0, 53)                    7225     382925
	 vehicle_attitude_setpoint (0, 54)           2233     120582
	 vehicle_command (0, 52)                        5        260
	 vehicle_global_position (0, 64)             1123      71872
	 vehicle_gps_position (0, 99)                1146     113454
	 vehicle_land_detected (0, 16)                230       3680
	 vehicle_local_position (0, 155)             2236     346580
	 vehicle_local_position_setpoint (0, 76)     2231     169556
	 vehicle_magnetometer (0, 20)                9833     196660
	 vehicle_rates_setpoint (0, 24)              7219     173256
	 vehicle_status (0, 40)                       232       9280
	 vehicle_status_flags (0, 36)                 230       8280
