### PR TITLE
Simplify px4_log.c by always using a FILE* for standard output.

### DIFF
--- a/platforms/posix/include/px4_daemon/server_io.h
+++ b/platforms/posix/include/px4_daemon/server_io.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2016 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,11 +33,7 @@
 /**
  * @file server_io.h
  *
- * These are helper functions to send the stdout over a pipe
- * back to the client.
- *
- * @author Julian Oes <julian@oes.ch>
- * @author Beat Küng <beat-kueng@gmx.net>
+ * @author Mara Bos <m-ou.se@m-ou.se>
  */
 #pragma once
 
@@ -46,20 +42,11 @@
 __BEGIN_DECLS
 
 /**
- * Get the stdout pipe buffer in order to write to fill it.
+ * Get the stdout of the current thread.
  *
- * @param buffer: pointer to buffer that will be set in function.
- * @param max_length: length of the assigned buffer.
- * @param is_atty: true if we are writing to a terminal (and can e.g. use colors).
- * @return 0 on success
+ * @param isatty_: if not NULL, *isatty_ will be set to wether the stream points to a terminal (true) or not (false).
+ * @return The FILE* which represents the standard output of the current thread.
  */
-__EXPORT int get_stdout_pipe_buffer(char **buffer, unsigned *max_length, bool *is_atty);
+__EXPORT FILE *get_stdout(bool *isatty_);
 
-/**
- * Write the filled bytes to the pipe.
- *
- * @param buffer_length: the number of bytes that should be written.
- * @return 0 on success
- */
-__EXPORT int send_stdout_pipe_buffer(unsigned buffer_length);
 __END_DECLS

--- a/platforms/posix/src/px4_daemon/client.cpp
+++ b/platforms/posix/src/px4_daemon/client.cpp
@@ -46,6 +46,7 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/un.h>
+#include <unistd.h>
 
 #include <string>
 

--- a/platforms/posix/src/px4_daemon/server.h
+++ b/platforms/posix/src/px4_daemon/server.h
@@ -49,6 +49,7 @@
  */
 #pragma once
 
+#include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <pthread.h>
@@ -75,9 +76,8 @@ public:
 	int start();
 
 	struct CmdThreadSpecificData {
-		int fd; // fd to send stdout to
+		FILE *thread_stdout; // stdout of this thread
 		bool is_atty; // whether file descriptor refers to a terminal
-		char buffer[1024];
 	};
 
 	static bool is_running()

--- a/src/drivers/linux_pwm_out/navio_sysfs.cpp
+++ b/src/drivers/linux_pwm_out/navio_sysfs.cpp
@@ -35,6 +35,7 @@
 
 #include <fcntl.h>
 #include <errno.h>
+#include <unistd.h>
 #include <px4_log.h>
 
 using namespace linux_pwm_out;

--- a/src/drivers/linux_pwm_out/ocpoc_mmap.cpp
+++ b/src/drivers/linux_pwm_out/ocpoc_mmap.cpp
@@ -37,6 +37,7 @@
 
 #include <fcntl.h>
 #include <sys/mman.h>
+#include <unistd.h>
 
 using namespace linux_pwm_out;
 

--- a/src/drivers/navio_sysfs_rc_in/navio_sysfs_rc_in.cpp
+++ b/src/drivers/navio_sysfs_rc_in/navio_sysfs_rc_in.cpp
@@ -37,6 +37,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <unistd.h>
 
 #include <px4_config.h>
 #include <px4_workqueue.h>

--- a/src/drivers/rpi_rc_in/rpi_rc_in.h
+++ b/src/drivers/rpi_rc_in/rpi_rc_in.h
@@ -46,6 +46,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <unistd.h>
 
 #include <px4_config.h>
 #include <px4_workqueue.h>

--- a/src/modules/logger/util.cpp
+++ b/src/modules/logger/util.cpp
@@ -37,6 +37,7 @@
 #include <sys/stat.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include <uORB/topics/vehicle_gps_position.h>
 

--- a/src/modules/uORB/uORB_tests/uORBTest_UnitTest.hpp
+++ b/src/modules/uORB/uORB_tests/uORBTest_UnitTest.hpp
@@ -37,6 +37,7 @@
 #include "../uORB.h"
 #include <px4_time.h>
 #include <px4_tasks.h>
+#include <unistd.h>
 
 struct orb_test {
 	int val;

--- a/src/platforms/common/CMakeLists.txt
+++ b/src/platforms/common/CMakeLists.txt
@@ -33,7 +33,7 @@
 
 set(SRCS)
 
-if (NOT "${OS}" MATCHES "qurt")
+if (NOT "${OS}" MATCHES "qurt" AND NOT "${CONFIG}" MATCHES "px4io")
 	list(APPEND SRCS
 		px4_log.c
 		)

--- a/src/platforms/px4_log.h
+++ b/src/platforms/px4_log.h
@@ -196,24 +196,6 @@ __END_DECLS
 #endif /* __PX4_POSIX */
 
 
-#ifdef PX4_LOG_COLORIZED_OUTPUT
-#include <unistd.h>
-#define PX4_LOG_COLOR_START \
-	int use_color = isatty(STDOUT_FILENO); \
-	if (use_color) printf("%s", __px4_log_level_color[level]);
-#define PX4_LOG_COLOR_MODULE \
-	if (use_color) printf(PX4_ANSI_COLOR_GRAY);
-#define PX4_LOG_COLOR_MESSAGE \
-	if (use_color) printf("%s", __px4_log_level_color[level]);
-#define PX4_LOG_COLOR_END \
-	if (use_color) printf(PX4_ANSI_COLOR_RESET);
-#else
-#define PX4_LOG_COLOR_START
-#define PX4_LOG_COLOR_MODULE
-#define PX4_LOG_COLOR_MESSAGE
-#define PX4_LOG_COLOR_END
-#endif /* PX4_LOG_COLORIZED_OUTPUT */
-
 /****************************************************************************
  * Output format macros
  * Use these to implement the code level macros below

--- a/src/systemcmds/tests/test_hysteresis.cpp
+++ b/src/systemcmds/tests/test_hysteresis.cpp
@@ -1,4 +1,5 @@
 #include <unit_test.h>
+#include <unistd.h>
 
 #include <systemlib/hysteresis/hysteresis.h>
 

--- a/src/systemcmds/tests/test_microbench_hrt.cpp
+++ b/src/systemcmds/tests/test_microbench_hrt.cpp
@@ -35,6 +35,7 @@
 
 #include <time.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include <drivers/drv_hrt.h>
 #include <perf/perf_counter.h>

--- a/src/systemcmds/tests/test_microbench_math.cpp
+++ b/src/systemcmds/tests/test_microbench_math.cpp
@@ -35,6 +35,7 @@
 
 #include <time.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include <drivers/drv_hrt.h>
 #include <perf/perf_counter.h>

--- a/src/systemcmds/tests/test_microbench_matrix.cpp
+++ b/src/systemcmds/tests/test_microbench_matrix.cpp
@@ -35,6 +35,7 @@
 
 #include <time.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include <drivers/drv_hrt.h>
 #include <perf/perf_counter.h>

--- a/src/systemcmds/tests/test_microbench_uorb.cpp
+++ b/src/systemcmds/tests/test_microbench_uorb.cpp
@@ -35,6 +35,7 @@
 
 #include <time.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include <drivers/drv_hrt.h>
 #include <perf/perf_counter.h>

--- a/src/systemcmds/tests/test_mixer.cpp
+++ b/src/systemcmds/tests/test_mixer.cpp
@@ -40,6 +40,7 @@
 #include <limits>
 #include <dirent.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <px4_config.h>
 #include <mixer/mixer.h>

--- a/src/systemcmds/tests/test_parameters.cpp
+++ b/src/systemcmds/tests/test_parameters.cpp
@@ -2,6 +2,7 @@
 
 #include <px4_defines.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 class ParameterTest : public UnitTest
 {


### PR DESCRIPTION
The threads running commands for clients through the Posix daemon used
to write to a char buffer through snprintf (etc.) which was then written
directly to the file descriptor, whereas in the other case printf
(etc.) was used to write to stdout. Both versions used some
macro's and repeated code to have the same output.

This change unifies these two cases by using a FILE* in both cases. The
(line) buffering is done by the standard C library's implementation
(just like with stdout), and px4_log.c now uses the same code in all
cases (using fprintf, etc.) for printing (colored) output.