### PR TITLE
Add dynamic modules on Posix.

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -8,6 +8,7 @@ program="$3"
 model="$4"
 src_path="$5"
 build_path="$6"
+# The rest of the arguments are files to copy into the working dir.
 
 echo SITL ARGS
 
@@ -57,6 +58,11 @@ pkill -x px4_$model || true
 
 cp $src_path/Tools/posix_lldbinit $rootfs/.lldbinit
 cp $src_path/Tools/posix.gdbinit $rootfs/.gdbinit
+
+shift 6
+for file in "$@"; do
+	cp "$file" $rootfs/
+done
 
 SIM_PID=0
 

--- a/cmake/configs/posix_rpi_common.cmake
+++ b/cmake/configs/posix_rpi_common.cmake
@@ -34,6 +34,7 @@ set(config_module_list
 	# System commands
 	#
 	systemcmds/param
+	systemcmds/dyn
 	systemcmds/led_control
 	systemcmds/mixer
 	systemcmds/ver

--- a/cmake/configs/posix_sitl_default.cmake
+++ b/cmake/configs/posix_sitl_default.cmake
@@ -24,6 +24,7 @@ set(config_module_list
 	#systemcmds/bl_update
 	#systemcmds/config
 	#systemcmds/dumpfile
+	systemcmds/dyn
 	systemcmds/esc_calib
 	systemcmds/led_control
 	systemcmds/mixer

--- a/cmake/configs/posix_sitl_default.cmake
+++ b/cmake/configs/posix_sitl_default.cmake
@@ -55,6 +55,7 @@ set(config_module_list
 	systemcmds/tests
 
 	platforms/posix/tests/hello
+	platforms/posix/tests/dyn_hello
 	platforms/posix/tests/hrt_test
 	platforms/posix/tests/vcdev_test
 

--- a/platforms/posix/cmake/px4_impl_os.cmake
+++ b/platforms/posix/cmake/px4_impl_os.cmake
@@ -48,6 +48,11 @@
 include(common/px4_base)
 list(APPEND CMAKE_MODULE_PATH ${PX4_SOURCE_DIR}/cmake/posix)
 
+# This makes it possible to dynamically load code which depends on symbols
+# inside the px4 executable.
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_ENABLE_EXPORTS ON)
+
 #=============================================================================
 #
 #	px4_posix_generate_builtin_commands

--- a/platforms/posix/cmake/sitl_tests.cmake
+++ b/platforms/posix/cmake/sitl_tests.cmake
@@ -93,6 +93,20 @@ add_test(NAME shutdown
 set_tests_properties(shutdown PROPERTIES PASS_REGULAR_EXPRESSION "Shutting down")
 sanitizer_fail_test_on_error(shutdown)
 
+# Dynamic module loading test
+add_test(NAME dyn
+	COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
+		$<TARGET_FILE:px4>
+		none
+		none
+		test_dyn_hello
+		${PX4_SOURCE_DIR}
+		${PX4_BINARY_DIR}
+		$<TARGET_FILE:platforms__posix__tests__dyn_hello>
+	WORKING_DIRECTORY ${SITL_WORKING_DIR})
+set_tests_properties(dyn PROPERTIES PASS_REGULAR_EXPRESSION "1: PASSED")
+sanitizer_fail_test_on_error(dyn)
+
 # run arbitrary commands
 set(test_cmds
 	hello
@@ -121,7 +135,7 @@ endforeach()
 
 add_custom_target(test_results
 		COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -T Test
-		DEPENDS px4
+		DEPENDS px4 platforms__posix__tests__dyn_hello
 		USES_TERMINAL
 		COMMENT "Running tests in sitl"
 		WORKING_DIRECTORY ${PX4_BINARY_DIR})

--- a/posix-configs/SITL/init/test/test_dyn_hello
+++ b/posix-configs/SITL/init/test/test_dyn_hello
@@ -1,0 +1,8 @@
+#!/bin/sh
+# PX4 commands need the 'px4-' prefix in bash.
+# (px4-alias.sh is expected to be in the PATH)
+. px4-alias.sh
+
+dyn ./platforms__posix__tests__dyn_hello.px4mod PASSED
+
+shutdown

--- a/src/platforms/posix/tests/dyn_hello/CMakeLists.txt
+++ b/src/platforms/posix/tests/dyn_hello/CMakeLists.txt
@@ -1,0 +1,8 @@
+px4_add_module(
+	MODULE platforms__posix__tests__dyn_hello
+	MAIN hello
+	SRCS
+		hello.cpp
+	DEPENDS
+	DYNAMIC
+	)

--- a/src/platforms/posix/tests/dyn_hello/hello.cpp
+++ b/src/platforms/posix/tests/dyn_hello/hello.cpp
@@ -1,0 +1,16 @@
+#include <px4_log.h>
+#include <px4_app.h>
+
+extern "C" __EXPORT int hello_main(int argc, char *argv[]);
+int hello_main(int argc, char *argv[])
+{
+	PX4_INFO("Hello, I am a dynamically loaded module.");
+
+	PX4_INFO("Argv:");
+
+	for (int i = 0; i < argc; ++i) {
+		PX4_INFO("  %d: %s", i, argv[i]);
+	}
+
+	return 0;
+}

--- a/src/systemcmds/dyn/CMakeLists.txt
+++ b/src/systemcmds/dyn/CMakeLists.txt
@@ -1,0 +1,8 @@
+px4_add_module(
+	MODULE systemcmds__dyn
+	MAIN dyn
+	SRCS
+		dyn.cpp
+	)
+
+target_link_libraries(systemcmds__dyn PUBLIC dl)

--- a/src/systemcmds/dyn/dyn.cpp
+++ b/src/systemcmds/dyn/dyn.cpp
@@ -1,0 +1,91 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file dyn.cpp
+ *
+ * @author Mara Bos <m-ou.se@m-ou.se>
+ */
+
+#include <dlfcn.h>
+
+#include <px4_module.h>
+#include <px4_log.h>
+
+static void usage();
+
+extern "C" {
+	__EXPORT int dyn_main(int argc, char *argv[]);
+}
+
+static void usage()
+{
+	PRINT_MODULE_DESCRIPTION(
+		R"(
+### Description
+Load and run a dynamic PX4 module, which was not compiled into the PX4 binary.
+
+### Example
+$ dyn ./hello.px4mod start
+
+)");
+	PRINT_MODULE_USAGE_NAME_SIMPLE("dyn", "command");
+	PRINT_MODULE_USAGE_ARG("<file>", "File containing the module", false);
+	PRINT_MODULE_USAGE_ARG("arguments...", "Arguments to the module", true);
+}
+
+int dyn_main(int argc, char *argv[]) {
+	if (argc < 2) {
+		usage();
+		return 1;
+	}
+
+	void *handle = dlopen(argv[1], RTLD_NOW);
+
+	if (!handle) {
+		PX4_ERR("%s", dlerror());
+		return 1;
+	}
+
+	void *main_address = dlsym(handle, "px4_module_main");
+
+	if (!main_address) {
+		PX4_ERR("%s", dlerror());
+		dlclose(handle);
+		return 1;
+	}
+
+	auto main_function = (int (*)(int, char **))main_address;
+
+	return main_function(argc - 1, argv + 1);
+}


### PR DESCRIPTION
You can now add `DYNAMIC` as an option to `px4_add_module`, which will
cause that module to no longer be compiled into the px4 executable, but
instead produce a separate shared library file, which can be loaded and
executed with the new `dyn` command:

    pxh> dyn ./hello.px4mod start

This will load the shared object file `hello.px4mod` if it wasn't
already loaded, and execute its main function with the given arguments.