### PR TITLE
Fix for initializing Landing Target Estimator in SITL

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/1011_iris_irlock
+++ b/ROMFS/px4fmu_common/init.d-posix/1011_iris_irlock
@@ -13,3 +13,6 @@ then
 	param set LTEST_MODE 1
 	param set PLD_HACC_RAD 0.1
 fi
+
+# Start up Landing Target Estimator module
+landing_target_estimator start


### PR DESCRIPTION
**Test data / coverage**
Tested in SITL

**Describe problem solved by the proposed pull request**
Landing Target Estimator is not being started by default when running iris_irlock, adding module start to new init script.

**Describe your preferred solution**
Added landing_target_estimator start to iris_irlock init.

**Describe possible alternatives**
Otherwise, have to manually start module from PX4 terminal.

**Additional context**
Please see http://discuss.px4.io/t/precision-landing-in-sitl-issue/8369/12
