### PR TITLE
weathervane: added configuration option via paramter

### DIFF
--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -198,7 +198,7 @@ bool FlightTaskAuto::_evaluateTriplets()
 	}
 
 	// set heading
-	if (_ext_yaw_handler != nullptr && _ext_yaw_handler->is_active()) {
+	if (_ext_yaw_handler != nullptr && _ext_yaw_handler->should_run_in_mission(_sub_triplet_setpoint->get().current.type)) {
 		_yaw_setpoint = _yaw;
 		_yawspeed_setpoint = _ext_yaw_handler->get_weathervane_yawrate();
 

--- a/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -173,7 +173,7 @@ void FlightTaskManualPosition::_updateSetpoints()
 	FlightTaskManualAltitude::_updateSetpoints(); // needed to get yaw and setpoints in z-direction
 
 	// check if an external yaw handler is active and if yes, let it update the yaw setpoints
-	if (_weathervane_yaw_handler != nullptr && _weathervane_yaw_handler->is_active()) {
+	if (_weathervane_yaw_handler != nullptr && _weathervane_yaw_handler->should_run_in_manual()) {
 		_yaw_setpoint = NAN;
 		_yawspeed_setpoint += _weathervane_yaw_handler->get_weathervane_yawrate();
 	}

--- a/src/lib/WeatherVane/WeatherVane.cpp
+++ b/src/lib/WeatherVane/WeatherVane.cpp
@@ -39,6 +39,7 @@
 
 #include "WeatherVane.hpp"
 #include <mathlib/mathlib.h>
+#include <uORB/topics/position_setpoint.h>
 
 
 WeatherVane::WeatherVane() :
@@ -46,6 +47,45 @@ WeatherVane::WeatherVane() :
 {
 	_R_sp_prev = matrix::Dcmf();
 }
+
+bool WeatherVane::should_run_in_manual()
+{
+	return (bool)(_wv_config.get() & MASK_MAN_EN);
+}
+
+bool WeatherVane::should_run_in_mission(uint8_t position_setpoint_type)
+{
+	bool active = true;
+
+	switch (position_setpoint_type) {
+	case position_setpoint_s::SETPOINT_TYPE_TAKEOFF:
+		if ((_wv_config.get() & MASK_AUTO_TK_EN) == 0) {
+			active = false;
+		}
+
+		break;
+
+	case position_setpoint_s::SETPOINT_TYPE_LAND:
+		if ((_wv_config.get() & MASK_AUTO_LND_EN) == 0) {
+			active = false;
+		}
+
+		break;
+
+	case position_setpoint_s::SETPOINT_TYPE_LOITER:
+		if ((_wv_config.get() & MASK_AUTO_LTR_EN) == 0) {
+			active = false;
+		}
+
+		break;
+
+	default:
+		break;
+	}
+
+	return active;
+}
+
 
 void WeatherVane::update(const matrix::Quatf &q_sp_prev, float yaw)
 {

--- a/src/lib/WeatherVane/WeatherVane.cpp
+++ b/src/lib/WeatherVane/WeatherVane.cpp
@@ -50,37 +50,21 @@ WeatherVane::WeatherVane() :
 
 bool WeatherVane::should_run_in_manual()
 {
-	return (bool)(_wv_config.get() & MASK_MAN_EN);
+	return (bool)(_wv_config.get() & MASK_EN);
 }
 
 bool WeatherVane::should_run_in_mission(uint8_t position_setpoint_type)
 {
-	bool active = true;
+	bool active;
 
-	switch (position_setpoint_type) {
-	case position_setpoint_s::SETPOINT_TYPE_TAKEOFF:
-		if ((_wv_config.get() & MASK_AUTO_TK_EN) == 0) {
-			active = false;
-		}
+	// weathervane is active for the following two cases:
+	// 1) vehicle is doing an auto takeoff and weathervane auto takeoff bit is set
+	// 2) vehicle is not doing an auto takeoff and the general weathervane enable bit is set
+	if (position_setpoint_type == position_setpoint_s::SETPOINT_TYPE_TAKEOFF) {
+		active = (bool)(_wv_config.get() & MASK_AUTO_TK_EN);
 
-		break;
-
-	case position_setpoint_s::SETPOINT_TYPE_LAND:
-		if ((_wv_config.get() & MASK_AUTO_LND_EN) == 0) {
-			active = false;
-		}
-
-		break;
-
-	case position_setpoint_s::SETPOINT_TYPE_LOITER:
-		if ((_wv_config.get() & MASK_AUTO_LTR_EN) == 0) {
-			active = false;
-		}
-
-		break;
-
-	default:
-		break;
+	} else {
+		active = (bool)(_wv_config.get() & MASK_EN);
 	}
 
 	return active;

--- a/src/lib/WeatherVane/WeatherVane.hpp
+++ b/src/lib/WeatherVane/WeatherVane.hpp
@@ -45,6 +45,11 @@
 #include <px4_module_params.h>
 #include <matrix/matrix/math.hpp>
 
+#define MASK_MAN_EN 		(1<<0)	// weathervane enabled for manual position control
+#define MASK_AUTO_TK_EN 	(1<<1)	// weathervane enabled for takeoff in auto mode
+#define MASK_AUTO_LND_EN 	(1<<2)	// weathervane enabled for landing in auto mode
+#define MASK_AUTO_LTR_EN 	(1<<3)	// weathervane enabled for loiter in auto mode
+
 class WeatherVane : public ModuleParams
 {
 public:
@@ -52,13 +57,9 @@ public:
 
 	~WeatherVane() = default;
 
-	void activate() {_is_active = true;}
+	bool should_run_in_manual();
 
-	void deactivate() {_is_active = false;}
-
-	bool is_active() {return _is_active;}
-
-	bool weathervane_enabled() { return _wv_enabled.get(); }
+	bool should_run_in_mission(uint8_t type);
 
 	void update(const matrix::Quatf &q_sp_prev, float yaw);
 
@@ -70,10 +71,8 @@ private:
 	matrix::Dcmf _R_sp_prev;	// previous attitude setpoint rotation matrix
 	float _yaw = 0.0f;			// current yaw angle
 
-	bool _is_active = true;
-
 	DEFINE_PARAMETERS(
-		(ParamBool<px4::params::WV_EN>) _wv_enabled,
+		(ParamInt<px4::params::WV_CONFIG>) _wv_config,
 		(ParamFloat<px4::params::WV_ROLL_MIN>) _wv_min_roll,
 		(ParamFloat<px4::params::WV_GAIN>) _wv_gain,
 		(ParamFloat<px4::params::WV_YRATE_MAX>) _wv_max_yaw_rate

--- a/src/lib/WeatherVane/WeatherVane.hpp
+++ b/src/lib/WeatherVane/WeatherVane.hpp
@@ -45,10 +45,8 @@
 #include <px4_module_params.h>
 #include <matrix/matrix/math.hpp>
 
-#define MASK_MAN_EN 		(1<<0)	// weathervane enabled for manual position control
+#define MASK_EN 			(1<<0)	// weathervane enabled
 #define MASK_AUTO_TK_EN 	(1<<1)	// weathervane enabled for takeoff in auto mode
-#define MASK_AUTO_LND_EN 	(1<<2)	// weathervane enabled for landing in auto mode
-#define MASK_AUTO_LTR_EN 	(1<<3)	// weathervane enabled for loiter in auto mode
 
 class WeatherVane : public ModuleParams
 {

--- a/src/lib/WeatherVane/weathervane_params.c
+++ b/src/lib/WeatherVane/weathervane_params.c
@@ -44,8 +44,15 @@
  *
  * @boolean
  * @group Multicopter Position Control
+ * @min 0
+ * @max 15
+ * @bit 0 Manual position control.
+ * @bit 1 Mission general.
+ * @bit 1 Mission takeoff.
+ * @bit 2 Mission landing.
+ * @bit 3 Mission loiter.
  */
-PARAM_DEFINE_INT32(WV_EN, 0);
+PARAM_DEFINE_INT32(WV_CONFIG, 15);
 
 /**
  * Weather-vane roll angle to yawrate.

--- a/src/lib/WeatherVane/weathervane_params.c
+++ b/src/lib/WeatherVane/weathervane_params.c
@@ -45,14 +45,11 @@
  * @boolean
  * @group Multicopter Position Control
  * @min 0
- * @max 15
- * @bit 0 Manual position control.
- * @bit 1 Mission general.
- * @bit 1 Mission takeoff.
- * @bit 2 Mission landing.
- * @bit 3 Mission loiter.
+ * @max 3
+ * @bit 0 Enabled.
+ * @bit 1 Enabled for auto takeoff.
  */
-PARAM_DEFINE_INT32(WV_CONFIG, 15);
+PARAM_DEFINE_INT32(WV_CONFIG, 3);
 
 /**
  * Weather-vane roll angle to yawrate.

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -628,19 +628,7 @@ MulticopterPositionControl::run()
 		const bool was_in_failsafe = _in_failsafe;
 		_in_failsafe = false;
 
-		// activate the weathervane controller if required. If activated a flighttask can use it to implement a yaw-rate control strategy
-		// that turns the nose of the vehicle into the wind
 		if (_wv_controller != nullptr) {
-
-			// in manual mode we just want to use weathervane if position is controlled as well
-			if (_wv_controller->weathervane_enabled() && (!_control_mode.flag_control_manual_enabled
-					|| _control_mode.flag_control_position_enabled)) {
-				_wv_controller->activate();
-
-			} else {
-				_wv_controller->deactivate();
-			}
-
 			_wv_controller->update(matrix::Quatf(_att_sp.q_d), _states.yaw);
 		}
 


### PR DESCRIPTION
@sanderux Requires the weathervane feature to be disabled for takeoff, landing and loiter.