### PR TITLE
Windows CI: run `make tests`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,8 @@ build_script:
 - call bash --login -c "cd $repopath && make posix"
 # make pixracer to check NuttX build
 - call bash --login -c "cd $repopath && make px4fmu-v4_default"
+# run tests
+- call bash --login -c "cd $repopath && make tests"
 
 # Note: using bash --login is important
 # because otherwise certain things (like python; import numpy) do not work

--- a/platforms/posix/cmake/sitl_tests.cmake
+++ b/platforms/posix/cmake/sitl_tests.cmake
@@ -43,6 +43,14 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	)
 endif()
 
+if (CMAKE_SYSTEM_NAME STREQUAL "CYGWIN")
+	list(REMOVE_ITEM tests
+		uorb
+	)
+endif()
+
+message("${tests}")
+
 foreach(test_name ${tests})
 	configure_file(${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/test_template.in ${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/test_${test_name}_generated)
 


### PR DESCRIPTION
As discussed with @dagar it's desirable to also run available test in the Windows CI.
I tested `make tests` from the beginning on but it was always the uorb test that fails with:
```
uORB note: try single-topic support
uORB note: publish handle 0x6000bff00
uORB note: subscribe fd 5
uORB note: try publish
uORB note: PASS single-topic test
uORB note: try multi-topic support
uORB note: advertised
uORB note: published
uORB note: ---------------- LATENCY TEST ------------------
uORB note: PASS multi-topic test
uORB note: try multi-topic support subscribing before publishing
uORB note: advertised
uORB note: published
uORB note: PASS multi-topic reversed
uORB note: Testing unadvertise
uORB note: PASS unadvertise
uORB note: Testing multi-topic 2 test (queue simulation)
uORB FAIL: Timestamp not increasing! (3162112 >= 3162112)
  [uORBTest]            FAIL
```

So the suggestion was to at least run the passing tests and omit the currently failing one until I can hopefully fix it (it's still on the todo list).