### PR TITLE
RPYrT Support. Format checked.

### DIFF
--- a/integrationtests/python_src/px4_it/util/manual_input.py
+++ b/integrationtests/python_src/px4_it/util/manual_input.py
@@ -129,7 +129,9 @@ class ManualInput(object):
         mode = offboard_control_mode()
         mode.ignore_thrust = ignore_thrust
         mode.ignore_attitude = ignore_attitude
-        mode.ignore_bodyrate = ignore_bodyrate
+        mode.ignore_bodyrate_x = ignore_bodyrate
+        mode.ignore_bodyrate_y = ignore_bodyrate
+        mode.ignore_bodyrate_z = ignore_bodyrate
         mode.ignore_position = ignore_position
         mode.ignore_velocity = ignore_velocity
         mode.ignore_acceleration_force = ignore_acceleration_force

--- a/msg/offboard_control_mode.msg
+++ b/msg/offboard_control_mode.msg
@@ -4,7 +4,6 @@ uint64 timestamp		# time since system start (microseconds)
 
 bool ignore_thrust
 bool ignore_attitude
-bool ignore_bodyrate
 bool ignore_bodyrate_x
 bool ignore_bodyrate_y
 bool ignore_bodyrate_z

--- a/msg/offboard_control_mode.msg
+++ b/msg/offboard_control_mode.msg
@@ -5,6 +5,9 @@ uint64 timestamp		# time since system start (microseconds)
 bool ignore_thrust
 bool ignore_attitude
 bool ignore_bodyrate
+bool ignore_bodyrate_x
+bool ignore_bodyrate_y
+bool ignore_bodyrate_z
 bool ignore_position
 bool ignore_velocity
 bool ignore_acceleration_force

--- a/msg/vehicle_control_mode.msg
+++ b/msg/vehicle_control_mode.msg
@@ -8,6 +8,7 @@ bool flag_control_auto_enabled			# true if onboard autopilot should act
 bool flag_control_offboard_enabled		# true if offboard control should be used
 bool flag_control_rates_enabled			# true if rates are stabilized
 bool flag_control_attitude_enabled		# true if attitude stabilization is mixed in
+bool flag_control_yawrate_override_enabled		# true if the yaw rate override is enabled
 bool flag_control_rattitude_enabled		# true if rate/attitude stabilization is enabled
 bool flag_control_force_enabled			# true if force control is mixed in
 bool flag_control_acceleration_enabled			# true if acceleration is controlled

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
@@ -152,7 +152,7 @@ bool FlightTask::_checkTakeoff()
 	bool position_triggered_takeoff = false;
 
 	if (PX4_ISFINITE(_position_setpoint(2))) {
-		//minimal altitude either 20cm or what is necessary for correct estimation e.g. optical flow
+		// minimal altitude either 20cm or what is necessary for correct estimation e.g. optical flow
 		float min_altitude = 0.2f;
 		const float min_distance_to_ground = _sub_vehicle_local_position->get().hagl_min;
 

--- a/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -347,7 +347,7 @@ void FlightTaskManualAltitude::_updateSetpoints()
 
 bool FlightTaskManualAltitude::_checkTakeoff()
 {
-	// stick is deflected above the middle 15% of the range
+	// stick is deflected above 65% throttle (_sticks(2) is in the range [-1,1])
 	return _sticks(2) < -0.3f;
 }
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3322,7 +3322,10 @@ set_control_mode()
 		 * The control flags depend on what is ignored according to the offboard control mode topic
 		 * Inner loop flags (e.g. attitude) also depend on outer loop ignore flags (e.g. position)
 		 */
-		control_mode.flag_control_rates_enabled = !offboard_control_mode.ignore_bodyrate ||
+		control_mode.flag_control_rates_enabled =
+				!offboard_control_mode.ignore_bodyrate_x ||
+				!offboard_control_mode.ignore_bodyrate_y ||
+				!offboard_control_mode.ignore_bodyrate_z ||
 				!offboard_control_mode.ignore_attitude ||
 				!offboard_control_mode.ignore_position ||
 				!offboard_control_mode.ignore_velocity ||
@@ -3332,6 +3335,12 @@ set_control_mode()
 				!offboard_control_mode.ignore_position ||
 				!offboard_control_mode.ignore_velocity ||
 				!offboard_control_mode.ignore_acceleration_force;
+
+		control_mode.flag_control_yawrate_override_enabled =
+				offboard_control_mode.ignore_bodyrate_x &&
+				offboard_control_mode.ignore_bodyrate_y &&
+				!offboard_control_mode.ignore_bodyrate_z &&
+				!offboard_control_mode.ignore_attitude;
 
 		control_mode.flag_control_rattitude_enabled = false;
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1516,7 +1516,9 @@ Commander::run()
 
 			if (old.ignore_thrust != offboard_control_mode.ignore_thrust ||
 			    old.ignore_attitude != offboard_control_mode.ignore_attitude ||
-			    old.ignore_bodyrate != offboard_control_mode.ignore_bodyrate ||
+			    old.ignore_bodyrate_x != offboard_control_mode.ignore_bodyrate_x ||
+			    old.ignore_bodyrate_y != offboard_control_mode.ignore_bodyrate_y ||
+			    old.ignore_bodyrate_z != offboard_control_mode.ignore_bodyrate_z ||
 			    old.ignore_position != offboard_control_mode.ignore_position ||
 			    old.ignore_velocity != offboard_control_mode.ignore_velocity ||
 			    old.ignore_acceleration_force != offboard_control_mode.ignore_acceleration_force ||
@@ -3323,24 +3325,25 @@ set_control_mode()
 		 * Inner loop flags (e.g. attitude) also depend on outer loop ignore flags (e.g. position)
 		 */
 		control_mode.flag_control_rates_enabled =
-				!offboard_control_mode.ignore_bodyrate_x ||
-				!offboard_control_mode.ignore_bodyrate_y ||
-				!offboard_control_mode.ignore_bodyrate_z ||
-				!offboard_control_mode.ignore_attitude ||
-				!offboard_control_mode.ignore_position ||
-				!offboard_control_mode.ignore_velocity ||
-				!offboard_control_mode.ignore_acceleration_force;
+			!offboard_control_mode.ignore_bodyrate_x ||
+			!offboard_control_mode.ignore_bodyrate_y ||
+			!offboard_control_mode.ignore_bodyrate_z ||
+			!offboard_control_mode.ignore_attitude ||
+			!offboard_control_mode.ignore_position ||
+			!offboard_control_mode.ignore_velocity ||
+			!offboard_control_mode.ignore_acceleration_force;
 
 		control_mode.flag_control_attitude_enabled = !offboard_control_mode.ignore_attitude ||
 				!offboard_control_mode.ignore_position ||
 				!offboard_control_mode.ignore_velocity ||
 				!offboard_control_mode.ignore_acceleration_force;
 
+		// TO-DO: Add support for other modes than yawrate control
 		control_mode.flag_control_yawrate_override_enabled =
-				offboard_control_mode.ignore_bodyrate_x &&
-				offboard_control_mode.ignore_bodyrate_y &&
-				!offboard_control_mode.ignore_bodyrate_z &&
-				!offboard_control_mode.ignore_attitude;
+			offboard_control_mode.ignore_bodyrate_x &&
+			offboard_control_mode.ignore_bodyrate_y &&
+			!offboard_control_mode.ignore_bodyrate_z &&
+			!offboard_control_mode.ignore_attitude;
 
 		control_mode.flag_control_rattitude_enabled = false;
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -833,8 +833,10 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 		/* yaw ignore flag mapps to ignore_attitude */
 		offboard_control_mode.ignore_attitude = (bool)(set_position_target_local_ned.type_mask & 0x400);
 		/* yawrate ignore flag mapps to ignore_bodyrate */
-		offboard_control_mode.ignore_bodyrate = (bool)(set_position_target_local_ned.type_mask & 0x800);
-
+		// offboard_control_mode.ignore_bodyrate = (bool)(set_position_target_local_ned.type_mask & 0x800);
+		offboard_control_mode.ignore_bodyrate_x = (bool)(set_position_target_local_ned.type_mask & 0x800);
+		offboard_control_mode.ignore_bodyrate_y = (bool)(set_position_target_local_ned.type_mask & 0x800);
+		offboard_control_mode.ignore_bodyrate_z = (bool)(set_position_target_local_ned.type_mask & 0x800);
 
 		bool is_takeoff_sp = (bool)(set_position_target_local_ned.type_mask & 0x1000);
 		bool is_land_sp = (bool)(set_position_target_local_ned.type_mask & 0x2000);
@@ -949,7 +951,9 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 					}
 
 					/* set the yawrate sp value */
-					if (!offboard_control_mode.ignore_bodyrate) {
+					if (!(offboard_control_mode.ignore_bodyrate_x ||
+					      offboard_control_mode.ignore_bodyrate_y ||
+					      offboard_control_mode.ignore_bodyrate_z)) {
 						pos_sp_triplet.current.yawspeed_valid = true;
 						pos_sp_triplet.current.yawspeed = set_position_target_local_ned.yaw_rate;
 
@@ -1005,7 +1009,9 @@ MavlinkReceiver::handle_message_set_actuator_control_target(mavlink_message_t *m
 		/* ignore all since we are setting raw actuators here */
 		offboard_control_mode.ignore_thrust             = true;
 		offboard_control_mode.ignore_attitude           = true;
-		offboard_control_mode.ignore_bodyrate           = true;
+		offboard_control_mode.ignore_bodyrate_x         = true;
+		offboard_control_mode.ignore_bodyrate_y         = true;
+		offboard_control_mode.ignore_bodyrate_z         = true;
 		offboard_control_mode.ignore_position           = true;
 		offboard_control_mode.ignore_velocity           = true;
 		offboard_control_mode.ignore_acceleration_force = true;
@@ -1311,16 +1317,28 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 		 * throttle and has the ignore bits set for attitude and rates don't change the flags for attitude and
 		 * body rates to keep the controllers running
 		 */
-		bool ignore_bodyrate_msg = (bool)(set_attitude_target.type_mask & 0x7);
+		bool ignore_bodyrate_msg_x = (bool)(set_attitude_target.type_mask & 0x1);
+		bool ignore_bodyrate_msg_y = (bool)(set_attitude_target.type_mask & 0x2);
+		bool ignore_bodyrate_msg_z = (bool)(set_attitude_target.type_mask & 0x4);
 		bool ignore_attitude_msg = (bool)(set_attitude_target.type_mask & (1 << 7));
 
-		if (ignore_bodyrate_msg && ignore_attitude_msg && !_offboard_control_mode.ignore_thrust) {
+
+		if ((ignore_bodyrate_msg_x || ignore_bodyrate_msg_y ||
+		     ignore_bodyrate_msg_z) &&
+		    ignore_attitude_msg && !_offboard_control_mode.ignore_thrust) {
 			/* Message want's us to ignore everything except thrust: only ignore if previously ignored */
-			_offboard_control_mode.ignore_bodyrate = ignore_bodyrate_msg && _offboard_control_mode.ignore_bodyrate;
+			_offboard_control_mode.ignore_bodyrate_x =
+				ignore_bodyrate_msg_x && _offboard_control_mode.ignore_bodyrate_x;
+			_offboard_control_mode.ignore_bodyrate_y =
+				ignore_bodyrate_msg_y && _offboard_control_mode.ignore_bodyrate_y;
+			_offboard_control_mode.ignore_bodyrate_z =
+				ignore_bodyrate_msg_z && _offboard_control_mode.ignore_bodyrate_z;
 			_offboard_control_mode.ignore_attitude = ignore_attitude_msg && _offboard_control_mode.ignore_attitude;
 
 		} else {
-			_offboard_control_mode.ignore_bodyrate = ignore_bodyrate_msg;
+			_offboard_control_mode.ignore_bodyrate_x = ignore_bodyrate_msg_x;
+			_offboard_control_mode.ignore_bodyrate_y = ignore_bodyrate_msg_y;
+			_offboard_control_mode.ignore_bodyrate_z = ignore_bodyrate_msg_z;
 			_offboard_control_mode.ignore_attitude = ignore_attitude_msg;
 		}
 
@@ -1383,13 +1401,22 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 
 				/* Publish attitude rate setpoint if bodyrate and thrust ignore bits are not set */
 				///XXX add support for ignoring individual axes
-				if (!(_offboard_control_mode.ignore_bodyrate)) {
+				if (!_offboard_control_mode.ignore_bodyrate_x ||
+				    !_offboard_control_mode.ignore_bodyrate_y ||
+				    !_offboard_control_mode.ignore_bodyrate_z) {
 					vehicle_rates_setpoint_s rates_sp = {};
 					rates_sp.timestamp = hrt_absolute_time();
 
-					if (!ignore_bodyrate_msg) { // only copy att rates sp if message contained new data
+					// only copy att rates sp if message contained new data
+					if (!ignore_bodyrate_msg_x) {
 						rates_sp.roll = set_attitude_target.body_roll_rate;
+					}
+
+					if (!ignore_bodyrate_msg_y) {
 						rates_sp.pitch = set_attitude_target.body_pitch_rate;
+					}
+
+					if (!ignore_bodyrate_msg_z) {
 						rates_sp.yaw = set_attitude_target.body_yaw_rate;
 					}
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -832,8 +832,6 @@ MavlinkReceiver::handle_message_set_position_target_local_ned(mavlink_message_t 
 		bool is_force_sp = (bool)(set_position_target_local_ned.type_mask & (1 << 9));
 		/* yaw ignore flag mapps to ignore_attitude */
 		offboard_control_mode.ignore_attitude = (bool)(set_position_target_local_ned.type_mask & 0x400);
-		/* yawrate ignore flag mapps to ignore_bodyrate */
-		// offboard_control_mode.ignore_bodyrate = (bool)(set_position_target_local_ned.type_mask & 0x800);
 		offboard_control_mode.ignore_bodyrate_x = (bool)(set_position_target_local_ned.type_mask & 0x800);
 		offboard_control_mode.ignore_bodyrate_y = (bool)(set_position_target_local_ned.type_mask & 0x800);
 		offboard_control_mode.ignore_bodyrate_z = (bool)(set_position_target_local_ned.type_mask & 0x800);
@@ -1400,7 +1398,6 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 				}
 
 				/* Publish attitude rate setpoint if bodyrate and thrust ignore bits are not set */
-				///XXX add support for ignoring individual axes
 				if (!_offboard_control_mode.ignore_bodyrate_x ||
 				    !_offboard_control_mode.ignore_bodyrate_y ||
 				    !_offboard_control_mode.ignore_bodyrate_z) {

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -834,7 +834,7 @@ MulticopterAttitudeControl::run()
 							!_v_control_mode.flag_control_position_enabled) {
 						generate_attitude_setpoint(attitude_dt, reset_yaw_sp);
 						attitude_setpoint_generated = true;
-					} 
+					}
 
 					control_attitude();
 					if (_v_control_mode.flag_control_yawrate_override_enabled)

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -834,9 +834,17 @@ MulticopterAttitudeControl::run()
 							!_v_control_mode.flag_control_position_enabled) {
 						generate_attitude_setpoint(attitude_dt, reset_yaw_sp);
 						attitude_setpoint_generated = true;
-					}
+					} 
 
 					control_attitude();
+					if (_v_control_mode.flag_control_yawrate_override_enabled)
+					{
+						/* Yaw rate override enabled, overwrite the yaw setpoint */
+						vehicle_rates_setpoint_poll();
+						const auto yawrate_reference = _v_rates_sp.yaw;	
+						_rates_sp(2) = yawrate_reference;
+					}
+
 					publish_rates_setpoint();
 				}
 

--- a/src/modules/mc_pos_control/Takeoff/Takeoff.cpp
+++ b/src/modules/mc_pos_control/Takeoff/Takeoff.cpp
@@ -38,7 +38,7 @@
 #include "Takeoff.hpp"
 #include <mathlib/mathlib.h>
 
-void Takeoff::generateInitialValue(const float hover_thrust, float velocity_p_gain)
+void Takeoff::generateInitialRampValue(const float hover_thrust, float velocity_p_gain)
 {
 	velocity_p_gain = math::max(velocity_p_gain, 0.01f);
 	_takeoff_ramp_vz_init = -hover_thrust / velocity_p_gain;

--- a/src/modules/mc_pos_control/Takeoff/Takeoff.hpp
+++ b/src/modules/mc_pos_control/Takeoff/Takeoff.hpp
@@ -61,7 +61,14 @@ public:
 	// initialize parameters
 	void setTakeoffRampTime(const float seconds) { _takeoff_ramp_time = seconds; }
 	void setSpoolupTime(const float seconds) { _spoolup_time_hysteresis.set_hysteresis_time_from(false, (hrt_abstime)(seconds * (float)1_s)); }
-	void generateInitialValue(const float hover_thrust, const float velocity_p_gain);
+
+	/**
+	 * Calculate a vertical velocity to initialize the takeoff ramp
+	 * that when passed to the velocity controller results in a zero throttle setpoint.
+	 * @param hover_thrust normalized thrsut value with which the vehicle hovers
+	 * @param velocity_p_gain proportional gain of the velocity controller to calculate the thrust
+	 */
+	void generateInitialRampValue(const float hover_thrust, const float velocity_p_gain);
 
 	/**
 	 * Update the state for the takeoff.
@@ -70,6 +77,15 @@ public:
 	 */
 	void updateTakeoffState(const bool armed, const bool landed, const bool want_takeoff,
 				const float takeoff_desired_vz, const bool skip_takeoff);
+
+	/**
+	 * Update and return the velocity constraint ramp value during takeoff.
+	 * By ramping up _takeoff_ramp_vz during the takeoff and using it to constain the maximum climb rate a smooth takeoff behavior is achieved.
+	 * Returns zero on the ground and takeoff_desired_vz in flight.
+	 * @param dt time in seconds since the last call/loop iteration
+	 * @param takeoff_desired_vz end value for the velocity ramp
+	 * @return true if setpoint has updated correctly
+	 */
 	float updateRamp(const float dt, const float takeoff_desired_vz);
 
 	TakeoffState getTakeoffState() { return _takeoff_state; }

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -360,7 +360,7 @@ MulticopterPositionControl::parameters_update(bool force)
 		// set trigger time for takeoff delay
 		_takeoff.setSpoolupTime(_param_mpc_spoolup_time.get());
 		_takeoff.setTakeoffRampTime(_param_mpc_tko_ramp_t.get());
-		_takeoff.generateInitialValue(_param_mpc_thr_hover.get(), _param_mpc_z_vel_p.get());
+		_takeoff.generateInitialRampValue(_param_mpc_thr_hover.get(), _param_mpc_z_vel_p.get());
 
 		if (_wv_controller != nullptr) {
 			_wv_controller->update_parameters();


### PR DESCRIPTION
**Test data / coverage**
Tested in SITL and flight arena. Here goes a link to the folder with the logs:
https://drive.google.com/open?id=1Ja1JjI3Ggmw383kDTZMdCB0cr3Hd5gfp

**Setpoints:** All data exchange happens through a SiK Radio (433Mhz), which is way less than ideal for the rates at which we are controlling - I am publishing at 100Hz, but I am pretty sure it can't handle such rates. Iris vehicle with PX4-FMU_v2. These use LPE estimator (these tests were made November 2018). It looks good, except for some points in which the telemetry radio looses connection (makes the UAV drop), but it recovers from it pretty fine. Both position and attitude changes are tested. It seems that the LPE sometimes drops to 0.2m in Z - is there any param I am missing to set? I am running this on an arena with MoCap. 

**TestWithDisturbances:** all data exchanged happends through a Mav-esp with custom firmware. The control frequency is 50Hz, while odometry is fed at 100Hz. Vehicle running Pixracer with the same changes present in this PR. The logs resamble 3 tests on a real UAV performed on a flight arena with Qualisys Mocap. RPYrT setpoints are externally given to the UAV via offboard mode by an in-house developed PID offboard controller, and external unmodeled disturbances are applied to the vehicles. The chain of control is: position setpoint --> PID controller (Offboard) --> RPYrT setpoint --> Attitude controller (onboard).

**Describe problem solved by the proposed pull request**
Essentially fixes the ignore_bodyrate for all axes, and adds functionality for single-axis only. At the moment, it targets just yawrate control mode.

**Describe your preferred solution**
Added offboard control mode yawrate, which ignores x and y rates, and uses the z rate as the setpoint for the rate controller. Roll and Pitch setpoints are still used for the attitude control to set the desired UAV attitude. At the moment, the yaw angle is kept to the same one that the UAV has (suggestions for this are welcome!)

**Describe possible alternatives**
-

**Additional context**
Flight tests show that RPYrT setpoints work as expected, as the UAV successfully converges to the right setpoints. Tested successfully in SITL as well.