### PR TITLE
[WIP] Appveyor: Shallow clone repo and submodules

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 # Build version
 version: "{build}"
+clone_depth: 1
 
 branches:
   only:
@@ -35,7 +36,7 @@ build_script:
 # safe the repopath for switching to it in cygwin bash
 - for /f %%i in ('cygpath -u %%CD%%') do set repopath=%%i
 # fetch all submodules in parallel
-- call bash --login -c "cd $repopath && git submodule -q update --init --recursive --jobs=10"
+- call bash --login -c "cd $repopath && git submodule -q update --init --recursive --depth=50 --jobs=10"
 # make SITL
 - call bash --login -c "cd $repopath && make posix"
 # make pixracer to check NuttX build


### PR DESCRIPTION
In CI we only care about the latest commited files and it should be fine to just shallow clone without the whole history. This could save a ton of time especially for the big submodules like NuttX and so on.