### PR TITLE
Add camera trigger PWM params

### DIFF
--- a/src/drivers/camera_trigger/camera_trigger_params.c
+++ b/src/drivers/camera_trigger/camera_trigger_params.c
@@ -139,3 +139,29 @@ PARAM_DEFINE_INT32(TRIG_PINS, 56);
  * @group Camera trigger
  */
 PARAM_DEFINE_FLOAT(TRIG_DISTANCE, 25.0f);
+
+/**
+ * PWM output to trigger shot.
+ *
+ * @reboot_required true
+ *
+ * @min 1000
+ * @max 2000
+ * @unit us
+ * @group Camera trigger
+ * @reboot_required true
+ */
+PARAM_DEFINE_INT32(TRIG_PWM_SHOOT, 1900);
+
+
+/**
+ * PWM neutral output on trigger pin.
+ *
+ * @min 1000
+ * @max 2000
+ * @unit us
+ * @group Camera trigger
+ * @reboot_required true
+ */
+PARAM_DEFINE_INT32(TRIG_PWM_NEUTRAL, 1500);
+

--- a/src/drivers/camera_trigger/camera_trigger_params.c
+++ b/src/drivers/camera_trigger/camera_trigger_params.c
@@ -143,8 +143,6 @@ PARAM_DEFINE_FLOAT(TRIG_DISTANCE, 25.0f);
 /**
  * PWM output to trigger shot.
  *
- * @reboot_required true
- *
  * @min 1000
  * @max 2000
  * @unit us

--- a/src/drivers/camera_trigger/interfaces/src/pwm.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.cpp
@@ -2,13 +2,22 @@
 
 #include <sys/ioctl.h>
 #include <lib/mathlib/mathlib.h>
+#include <parameters/param.h>
+
 
 #include "drivers/drv_pwm_trigger.h"
 #include "pwm.h"
 
+
 // TODO : make these parameters later
-#define PWM_CAMERA_SHOOT 1900
-#define PWM_CAMERA_NEUTRAL 1500
+//#define PWM_CAMERA_SHOOT 1900
+//#define PWM_CAMERA_NEUTRAL 1500
+
+int32_t pwm_camera_shoot = 0;
+param_get(param_find("TRIG_PWM_SHOOT"), &pwm_camera_shoot);
+int32_t pwm_camera_neutral = 0;
+param_get(param_find("TRIG_PWM_NEUTRAL"), &pwm_camera_neutral);
+
 
 CameraInterfacePWM::CameraInterfacePWM():
 	CameraInterface()
@@ -40,7 +49,7 @@ void CameraInterfacePWM::setup()
 	// Set neutral pulsewidths
 	for (unsigned i = 0; i < arraySize(_pins); i++) {
 		if (_pins[i] >= 0) {
-			up_pwm_trigger_set(_pins[i], math::constrain(PWM_CAMERA_NEUTRAL, PWM_CAMERA_NEUTRAL, 2000));
+			up_pwm_trigger_set(_pins[i], math::constrain(pwm_camera_neutral, 0, 2000));
 		}
 	}
 
@@ -51,7 +60,7 @@ void CameraInterfacePWM::trigger(bool trigger_on_true)
 	for (unsigned i = 0; i < arraySize(_pins); i++) {
 		if (_pins[i] >= 0) {
 			// Set all valid pins to shoot or neutral levels
-			up_pwm_trigger_set(_pins[i], math::constrain(trigger_on_true ? PWM_CAMERA_SHOOT : PWM_CAMERA_NEUTRAL, 1000, 2000));
+			up_pwm_trigger_set(_pins[i], math::constrain(trigger_on_true ? pwm_camera_shoot : pwm_camera_neutral, 0, 2000));
 		}
 	}
 }

--- a/src/drivers/camera_trigger/interfaces/src/pwm.cpp
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.cpp
@@ -9,19 +9,11 @@
 #include "pwm.h"
 
 
-// TODO : make these parameters later
-//#define PWM_CAMERA_SHOOT 1900
-//#define PWM_CAMERA_NEUTRAL 1500
-
-int32_t pwm_camera_shoot = 0;
-param_get(param_find("TRIG_PWM_SHOOT"), &pwm_camera_shoot);
-int32_t pwm_camera_neutral = 0;
-param_get(param_find("TRIG_PWM_NEUTRAL"), &pwm_camera_neutral);
-
-
 CameraInterfacePWM::CameraInterfacePWM():
 	CameraInterface()
 {
+	param_get(param_find("TRIG_PWM_SHOOT"), &_pwm_camera_shoot);
+	param_get(param_find("TRIG_PWM_NEUTRAL"), &_pwm_camera_neutral);
 	get_pins();
 	setup();
 }
@@ -49,7 +41,7 @@ void CameraInterfacePWM::setup()
 	// Set neutral pulsewidths
 	for (unsigned i = 0; i < arraySize(_pins); i++) {
 		if (_pins[i] >= 0) {
-			up_pwm_trigger_set(_pins[i], math::constrain(pwm_camera_neutral, 0, 2000));
+			up_pwm_trigger_set(_pins[i], math::constrain(_pwm_camera_neutral, 0, 2000));
 		}
 	}
 
@@ -60,7 +52,7 @@ void CameraInterfacePWM::trigger(bool trigger_on_true)
 	for (unsigned i = 0; i < arraySize(_pins); i++) {
 		if (_pins[i] >= 0) {
 			// Set all valid pins to shoot or neutral levels
-			up_pwm_trigger_set(_pins[i], math::constrain(trigger_on_true ? pwm_camera_shoot : pwm_camera_neutral, 0, 2000));
+			up_pwm_trigger_set(_pins[i], math::constrain(trigger_on_true ? _pwm_camera_shoot : _pwm_camera_neutral, 0, 2000));
 		}
 	}
 }

--- a/src/drivers/camera_trigger/interfaces/src/pwm.h
+++ b/src/drivers/camera_trigger/interfaces/src/pwm.h
@@ -25,7 +25,8 @@ public:
 	void info();
 
 private:
-
+	int32_t _pwm_camera_shoot = 0;
+	int32_t _pwm_camera_neutral = 0;
 	void setup();
 
 };


### PR DESCRIPTION
This adds parameters for hard coded values in the camera trigger (Fixes https://github.com/PX4/Firmware/issues/10822#issuecomment-437673911)

Note that this uses old-style parameters and requires reboot if values are changed.