### PR TITLE
Notify user if EKF fails compass

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -4028,6 +4028,12 @@ void Commander::estimator_check(bool *status_changed)
 	if (_estimator_status_sub.update()) {
 		const estimator_status_s& estimator_status = _estimator_status_sub.get();
 
+		// Check for a magnetomer fault and notify the user
+		if (!_mag_sensor_failed && (estimator_status.control_mode_flags & (1 << estimator_status_s::CS_MAG_FAULT))) {
+			_mag_sensor_failed = true;
+			mavlink_log_critical(&mavlink_log_pub, "Stopping compass use, check calibration on landing");
+		}
+
 		// Set the allowable position uncertainty based on combination of flight and estimator state
 		// When we are in a operator demanded position control mode and are solely reliant on optical flow, do not check position error because it will gradually increase throughout flight and the operator will compensate for the drift
 		const bool reliant_on_opt_flow = ((estimator_status.control_mode_flags & (1 << estimator_status_s::CS_OPT_FLOW))

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -4025,12 +4025,14 @@ void Commander::estimator_check(bool *status_changed)
 	const vehicle_local_position_s &lpos = _local_position_sub.get();
 	const vehicle_global_position_s &gpos = _global_position_sub.get();
 
+	const bool mag_fault_prev = (_estimator_status_sub.get().control_mode_flags & (1 << estimator_status_s::CS_MAG_FAULT));
+
 	if (_estimator_status_sub.update()) {
 		const estimator_status_s& estimator_status = _estimator_status_sub.get();
 
 		// Check for a magnetomer fault and notify the user
-		if (!_mag_sensor_failed && (estimator_status.control_mode_flags & (1 << estimator_status_s::CS_MAG_FAULT))) {
-			_mag_sensor_failed = true;
+		const bool mag_fault = (estimator_status.control_mode_flags & (1 << estimator_status_s::CS_MAG_FAULT));
+		if (!mag_fault_prev && mag_fault) {
 			mavlink_log_critical(&mavlink_log_pub, "Stopping compass use, check calibration on landing");
 		}
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -130,7 +130,6 @@ private:
 	hrt_abstime	_time_last_innov_pass{0};	/**< last time velocity or position innovations passed */
 	bool		_nav_test_passed{false};	/**< true if the post takeoff navigation test has passed */
 	bool		_nav_test_failed{false};	/**< true if the post takeoff navigation test has failed */
-	bool		_mag_sensor_failed{false};	/**< true if the magnetometer has been declared faulty */
 
 	FailureDetector _failure_detector;
 	bool _failure_detector_termination_printed{false};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -130,6 +130,7 @@ private:
 	hrt_abstime	_time_last_innov_pass{0};	/**< last time velocity or position innovations passed */
 	bool		_nav_test_passed{false};	/**< true if the post takeoff navigation test has passed */
 	bool		_nav_test_failed{false};	/**< true if the post takeoff navigation test has failed */
+	bool		_mag_sensor_failed{false};	/**< true if the magnetometer has been declared faulty */
 
 	FailureDetector _failure_detector;
 	bool _failure_detector_termination_printed{false};


### PR DESCRIPTION
Fixes https://github.com/PX4/ecl/issues/526

This creates two messages appearing on the console, eg

<img width="558" alt="screen shot 2018-11-27 at 9 31 11 am" src="https://user-images.githubusercontent.com/3596952/49046161-4fb97280-f227-11e8-966f-d4e51ce9dffd.png">

Depending on how the GCS parses these messages, it night be better to modify the text in the ecl/EKF message instead

**Test data**

SiTL test with ecl modified to declare mag failed at 60 seconds
https://logs.px4.io/plot_app?log=abf6d846-6245-4c8d-8a16-d75ea1ea8a74

Attempts to simulate failure by rotating the magnetometer data were unsuccessful - either the size of rotation was so large that the EKF ignored the sensor or small enough that it was able to tolerate the error. Rather than spend additional time experimenting with the amount of sensor rotation required, some timer code was inserted into the ecl/EKF to set the flag.