### PR TITLE
appveyor: fix mkdir on existing directory

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ install:
 
 build_script:
 # FIXME Temporary we need to create the home folder because it's not contained in installer 0.5 and CI fails if it doesn't exist
-- mkdir C:\PX4\home
+- if not exist "C:\PX4\home" mkdir C:\PX4\home
 # setup the environmental variables to work within the installed cygwin toolchain
 - call C:\PX4\toolchain\scripts\setup-environment.bat x
 # safe the repopath for switching to it in cygwin bash


### PR DESCRIPTION
All the failing builds:
https://ci.appveyor.com/project/Dronecode/firmware/builds/20586733

Just because I had to add that the home directory needs to be there the first time but mkdir fails if it already exists because it was build cached...