### PR TITLE
Use configurable vertical smoothing also in altitude mode

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -919,13 +919,7 @@ MulticopterPositionControl::start_flight_task()
 		should_disable_task = false;
 		int error = 0;
 		switch (MPC_AUTO_MODE.get()) {
-		case 0:
 		case 1:
-		case 2:
-			error =  _flight_tasks.switchTask(FlightTaskIndex::AutoLine);
-			break;
-
-		case 3:
 			error =  _flight_tasks.switchTask(FlightTaskIndex::AutoLineSmoothVel);
 			break;
 
@@ -965,7 +959,6 @@ MulticopterPositionControl::start_flight_task()
 			error =  _flight_tasks.switchTask(FlightTaskIndex::ManualPositionSmoothVel);
 			break;
 
-		case 0:
 		default:
 			error =  _flight_tasks.switchTask(FlightTaskIndex::ManualPosition);
 			break;
@@ -994,9 +987,6 @@ MulticopterPositionControl::start_flight_task()
 			error =  _flight_tasks.switchTask(FlightTaskIndex::ManualAltitudeSmooth);
 			break;
 
-		case 0:
-		case 2:
-		case 3:
 		default:
 			error =  _flight_tasks.switchTask(FlightTaskIndex::ManualAltitude);
 			break;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -949,15 +949,10 @@ MulticopterPositionControl::start_flight_task()
 
 	// manual position control
 	if (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_POSCTL || task_failure) {
-
 		should_disable_task = false;
 		int error = 0;
 
 		switch (MPC_POS_MODE.get()) {
-		case 0:
-			error =  _flight_tasks.switchTask(FlightTaskIndex::ManualPosition);
-			break;
-
 		case 1:
 			error =  _flight_tasks.switchTask(FlightTaskIndex::ManualPositionSmooth);
 			break;
@@ -970,6 +965,7 @@ MulticopterPositionControl::start_flight_task()
 			error =  _flight_tasks.switchTask(FlightTaskIndex::ManualPositionSmoothVel);
 			break;
 
+		case 0:
 		default:
 			error =  _flight_tasks.switchTask(FlightTaskIndex::ManualPosition);
 			break;
@@ -991,7 +987,20 @@ MulticopterPositionControl::start_flight_task()
 	// manual altitude control
 	if (_vehicle_status.nav_state == vehicle_status_s::NAVIGATION_STATE_ALTCTL || task_failure) {
 		should_disable_task = false;
-		int error = _flight_tasks.switchTask(FlightTaskIndex::ManualAltitude);
+		int error = 0;
+
+		switch (MPC_POS_MODE.get()) {
+		case 1:
+			error =  _flight_tasks.switchTask(FlightTaskIndex::ManualAltitudeSmooth);
+			break;
+
+		case 0:
+		case 2:
+		case 3:
+		default:
+			error =  _flight_tasks.switchTask(FlightTaskIndex::ManualAltitude);
+			break;
+		}
 
 		if (error != 0) {
 			if (prev_failure_count == 0) {

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -681,22 +681,11 @@ PARAM_DEFINE_INT32(MPC_POS_MODE, 1);
 /**
  * Auto sub-mode.
  *
- * The supported sub-modes are:
- * 0 Direct line tracking, no smoothing
- *
- * 1 Not used
- *
- * 2 Not used
- *
- * 3 Jerk-limited trajectory
- *
  * @value 0 Default line tracking
- * @value 1 N/A
- * @value 2 N/A
- * @value 3 Jerk-limited trajectory
+ * @value 1 Jerk-limited trajectory
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_INT32(MPC_AUTO_MODE, 3);
+PARAM_DEFINE_INT32(MPC_AUTO_MODE, 1);
 
 /**
  * Delay from idle state to arming state.


### PR DESCRIPTION
Smoothing can be configured by MPC_POS_MODE parameter
put before only for position mode and not for altitude mode.

**Test data / coverage**
One indoor flight before cherry-picking with conflicts.