### PR TITLE
fast-RTPS: IDL generation: add constants fields for IDL's

### DIFF
--- a/msg/templates/urtps/msg.idl.template
+++ b/msg/templates/urtps/msg.idl.template
@@ -83,6 +83,15 @@ def add_msg_fields():
                            key=sizeof_field_type, reverse=True)
     for field in sorted_fields:
         add_msg_field(field)
+
+
+def add_msg_constants():
+    sorted_constants = sorted(spec.constants,
+                           key=sizeof_field_type, reverse=True)
+    for constant in sorted_constants:
+        constant_value = '%d' % constant.val
+        print("const " + get_idl_type_name(constant.type) + " " + constant.name + " = " + constant_value + ";")
+
 }@
 #ifndef __@(spec.short_name)__idl__
 #define __@(spec.short_name)__idl__
@@ -93,6 +102,9 @@ def add_msg_fields():
 @[for line in get_include_directives(spec)]@
 @(line)
 @[end for]@
+
+@# Constants
+@add_msg_constants()
 
 @[for type in builtin_types]@
 typedef @(type + '_') @(type);

--- a/msg/tools/generate_microRTPS_bridge.py
+++ b/msg/tools/generate_microRTPS_bridge.py
@@ -221,11 +221,11 @@ else:
 
 if args.fastrtpsgen is None or args.fastrtpsgen == "":
     # Assume fastrtpsgen is in PATH
-    fastrtpsgen_path = "fastrtpsgen"
+    fastrtpsgen_path = 'fastrtpsgen'
 else:
     # Path to fastrtpsgen is explicitly specified
     fastrtpsgen_path = os.path.join(
-        get_absolute_path(args.fastrtpsgen), "/fastrtpsgen")
+        get_absolute_path(args.fastrtpsgen), 'fastrtpsgen')
 fastrtpsgen_include = args.fastrtpsgen_include
 if fastrtpsgen_include is not None and fastrtpsgen_include != '':
     fastrtpsgen_include = "-I " + \


### PR DESCRIPTION
Fixes https://github.com/PX4/px4_ros_com/issues/7. Allows adding uORB constants to IDL's, which are required to properly set enumeration dependent fields.
