### PR TITLE
Pr add ground effect deadzone

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -337,7 +337,7 @@ private:
 		(ParamExtFloat<px4::params::EKF2_BARO_GATE>)
 		_baro_innov_gate,	///< barometric height innovation consistency gate size (STD)
 		(ParamInt<px4::params::EKF2_GND_EFF_EN>)
-		_enableGndEff,	///< Controls barometric deadzone fusion, 0 disables, 1 enables
+		_enable_gnd_effect,	///< Controls barometric deadzone fusion, 0 disables, 1 enables
 		(ParamExtFloat<px4::params::EKF2_GND_EFF_DZ>)
 		_gnd_effect_deadzone,	///< barometric deadzone range for negative innovations (m)
 		(ParamExtFloat<px4::params::EKF2_GPS_P_GATE>)
@@ -928,7 +928,7 @@ void Ekf2::run()
 					float balt_data_avg = _balt_data_sum / (float)_balt_sample_count;
 
 					_ekf.set_air_density(airdata.rho);
-					_ekf.set_gnd_effect_flag(_enableGndEff.get());
+					_ekf.set_gnd_effect_flag(_enable_gnd_effect.get());
 
 					// calculate static pressure error = Pmeas - Ptruth
 					// model position error sensitivity as a body fixed ellipse with different scale in the positive and negtive X direction

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -336,6 +336,10 @@ private:
 		(ParamExtFloat<px4::params::EKF2_BARO_NOISE>) _baro_noise,	///< observation noise for barometric height fusion (m)
 		(ParamExtFloat<px4::params::EKF2_BARO_GATE>)
 		_baro_innov_gate,	///< barometric height innovation consistency gate size (STD)
+		(ParamInt<px4::params::EKF2_GND_EFF_EN>)
+		_enableGndEff,	///< Controls barometric deadzone fusion, 0 disables, 1 enables
+		(ParamExtFloat<px4::params::EKF2_GND_EFF_DZ>)
+		_gnd_effect_deadzone,	///< barometric deadzone range for negative innovations (m)
 		(ParamExtFloat<px4::params::EKF2_GPS_P_GATE>)
 		_posNE_innov_gate,	///< GPS horizontal position innovation consistency gate size (STD)
 		(ParamExtFloat<px4::params::EKF2_GPS_V_GATE>) _vel_innov_gate,	///< GPS velocity innovation consistency gate size (STD)
@@ -533,6 +537,7 @@ Ekf2::Ekf2():
 	_pos_noaid_noise(_params->pos_noaid_noise),
 	_baro_noise(_params->baro_noise),
 	_baro_innov_gate(_params->baro_innov_gate),
+	_gnd_effect_deadzone(_params->gnd_effect_deadzone),
 	_posNE_innov_gate(_params->posNE_innov_gate),
 	_vel_innov_gate(_params->vel_innov_gate),
 	_tas_innov_gate(_params->tas_innov_gate),
@@ -923,6 +928,7 @@ void Ekf2::run()
 					float balt_data_avg = _balt_data_sum / (float)_balt_sample_count;
 
 					_ekf.set_air_density(airdata.rho);
+					_ekf.set_gnd_effect_flag(_enableGndEff.get());
 
 					// calculate static pressure error = Pmeas - Ptruth
 					// model position error sensitivity as a body fixed ellipse with different scale in the positive and negtive X direction

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -549,6 +549,19 @@ PARAM_DEFINE_FLOAT(EKF2_BARO_GATE, 5.0f);
 PARAM_DEFINE_INT32(EKF2_GND_EFF_EN, 0);
 
 /**
+ * Baro deadzone range for height fusion
+ *
+ * Sets the value of deadzone applied to negative baro innovations when ground effect compensation is active
+ *
+ * @group EKF2
+ * @min 0.5
+ * @max 10.0
+ * @unit M
+ * @decimal 1
+ */
+PARAM_DEFINE_FLOAT(EKF2_GND_EFF_DZ, 5.0f);
+
+/**
  * Gate size for GPS horizontal position fusion
  *
  * Sets the number of standard deviations used by the innovation consistency test.

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -539,6 +539,16 @@ PARAM_DEFINE_FLOAT(EKF2_MAG_YAWLIM, 0.25f);
 PARAM_DEFINE_FLOAT(EKF2_BARO_GATE, 5.0f);
 
 /**
+ * Boolean determining if barometer deadzone near ground should be accounted.
+ *
+ * A value of 1 indicates that deadzone is active
+ *
+ * @group EKF2
+ * @boolean
+ */
+PARAM_DEFINE_INT32(EKF2_GND_EFF_EN, 0);
+
+/**
  * Gate size for GPS horizontal position fusion
  *
  * Sets the number of standard deviations used by the innovation consistency test.


### PR DESCRIPTION
* Adds the ability to enable/disable support for baro deadzone near ground.
* Adds default range for baro deadzone.
