### PR TITLE
Check NuttX configuration for DMA and load monitoring

### DIFF
--- a/src/lib/drivers/device/nuttx/I2C.hpp
+++ b/src/lib/drivers/device/nuttx/I2C.hpp
@@ -44,6 +44,10 @@
 
 #include <px4_i2c.h>
 
+#if !defined(CONFIG_I2C)
+#  error I2C support requires CONFIG_I2C
+#endif
+
 namespace device __EXPORT
 {
 

--- a/src/modules/load_mon/load_mon.cpp
+++ b/src/modules/load_mon/load_mon.cpp
@@ -58,6 +58,10 @@
 #include <uORB/topics/cpuload.h>
 #include <uORB/topics/task_stack_info.h>
 
+#if defined(__PX4_NUTTX) && !defined(CONFIG_SCHED_INSTRUMENTATION)
+#  error load_mon support requires CONFIG_SCHED_INSTRUMENTATION
+#endif
+
 extern struct system_load_s system_load;
 
 #define STACK_LOW_WARNING_THRESHOLD 300 ///< if free stack space falls below this, print a warning

--- a/src/modules/logger/watchdog.cpp
+++ b/src/modules/logger/watchdog.cpp
@@ -35,6 +35,10 @@
 
 #include <px4_log.h>
 
+#if defined(__PX4_NUTTX) && !defined(CONFIG_SCHED_INSTRUMENTATION)
+#  error watchdog support requires CONFIG_SCHED_INSTRUMENTATION
+#endif
+
 using namespace time_literals;
 
 namespace px4

--- a/src/modules/systemlib/print_load_nuttx.c
+++ b/src/modules/systemlib/print_load_nuttx.c
@@ -48,6 +48,10 @@
 
 #if defined(CONFIG_SCHED_INSTRUMENTATION)
 
+#if !defined(CONFIG_TASK_NAME_SIZE)
+#error print_load_nuttx requires CONFIG_TASK_NAME_SIZE
+#endif
+
 extern struct system_load_s system_load;
 
 #define CL "\033[K" // clear line

--- a/src/modules/systemlib/print_load_nuttx.c
+++ b/src/modules/systemlib/print_load_nuttx.c
@@ -46,6 +46,8 @@
 #include <systemlib/printload.h>
 #include <drivers/drv_hrt.h>
 
+#if defined(CONFIG_SCHED_INSTRUMENTATION)
+
 extern struct system_load_s system_load;
 
 #define CL "\033[K" // clear line
@@ -380,3 +382,5 @@ void print_load(uint64_t t, int fd, struct print_load_s *print_state)
 
 	print_load_buffer(t, data.buffer, sizeof(data.buffer), print_load_callback, &data, print_state);
 }
+
+#endif // if CONFIG_SCHED_INSTRUMENTATION

--- a/src/modules/systemlib/print_load_nuttx.c
+++ b/src/modules/systemlib/print_load_nuttx.c
@@ -52,6 +52,10 @@
 #error print_load_nuttx requires CONFIG_TASK_NAME_SIZE
 #endif
 
+#if !defined(CONFIG_STACK_COLORATION)
+#error print_load_nuttx requires CONFIG_STACK_COLORATION
+#endif
+
 extern struct system_load_s system_load;
 
 #define CL "\033[K" // clear line

--- a/src/platforms/px4_defines.h
+++ b/src/platforms/px4_defines.h
@@ -41,6 +41,10 @@
 
 #include <px4_log.h>
 
+#if defined(__PX4_NUTTX) && !defined(CONFIG_ARCH_MATH_H)
+#error CONFIG_ARCH_MATH_H is required to use math definitions and functions
+#endif
+
 /****************************************************************************
  * Defines for all platforms.
  ****************************************************************************/


### PR DESCRIPTION
The load monitoring and SD card writing require additional NuttX configuration options (`CONFIG_GRAN`, `CONFIG_FAT_DMAMEMORY`, `CONFIG_SCHED_INSTRUMENTATION`). Without these options enabled, hard to track compilation errors occur.
 
This PR enables explicit compilation errors if these options are not enabled and gives a hint which option needs to be enabled in menuconfig / qconfig.
