### PR TITLE
update micro-CDR version and msg templates to fit the up to date version

### DIFF
--- a/msg/templates/uorb_microcdr/microRTPS_client.cpp.template
+++ b/msg/templates/uorb_microcdr/microRTPS_client.cpp.template
@@ -24,7 +24,8 @@ recv_topics = [s.short_name for idx, s in enumerate(spec) if scope[idx] == MsgSc
 }@
 /****************************************************************************
  *
- * Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ * Copyright (c) 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ * Copyright (c) 2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -62,7 +63,7 @@ recv_topics = [s.short_name for idx, s in enumerate(spec) if scope[idx] == MsgSc
 #include <ctime>
 #include <pthread.h>
 
-#include <microcdr/microcdr.h>
+#include <ucdr/microcdr.h>
 #include <px4_time.h>
 #include <uORB/uORB.h>
 
@@ -91,10 +92,10 @@ void* send(void* /*unused*/)
     orb_set_interval(fds[@(idx)], _options.update_time_ms);
 @[end for]@
 
-    // MicroBuffer to serialized using the user defined buffer
-    MicroBuffer MicroBufferWriter;
+    // ucdrBuffer to serialize using the user defined buffer
+    ucdrBuffer writer;
     header_length=transport_node->get_header_length();
-    init_micro_buffer(&MicroBufferWriter, (uint8_t*)&data_buffer[header_length], BUFFER_SIZE - header_length);
+    ucdr_init_buffer(&writer, (uint8_t*)&data_buffer[header_length], BUFFER_SIZE - header_length);
 
     struct timespec begin;
     px4_clock_gettime(CLOCK_REALTIME, &begin);
@@ -111,7 +112,7 @@ void* send(void* /*unused*/)
             // copy raw data into local buffer
             if (orb_copy(ORB_ID(@(topic)), fds[@(idx)], &data) == 0) {
                 /* payload is shifted by header length to make room for header*/
-                serialize_@(topic)(&MicroBufferWriter, &data, &data_buffer[header_length], &length);
+                serialize_@(topic)(&writer, &data, &data_buffer[header_length], &length);
 
                 if (0 < (read = transport_node->write((char)@(rtps_message_id(ids, topic)), data_buffer, length)))
                 {
@@ -165,9 +166,9 @@ void micrortps_start_topics(struct timespec &begin, int &total_read, uint32_t &r
     orb_advert_t @(topic)_pub = nullptr;
 @[end for]@
 
-    // MicroBuffer to deserialized using the user defined buffer
-    MicroBuffer MicroBufferReader;
-    init_micro_buffer(&MicroBufferReader, (uint8_t*)data_buffer, BUFFER_SIZE);
+    // ucdrBuffer to deserialize using the user defined buffer
+    ucdrBuffer reader;
+    ucdr_init_buffer(&reader, (uint8_t*)data_buffer, BUFFER_SIZE);
 @[end if]@
 
     px4_clock_gettime(CLOCK_REALTIME, &begin);
@@ -191,7 +192,7 @@ void micrortps_start_topics(struct timespec &begin, int &total_read, uint32_t &r
 
                 case @(rtps_message_id(ids, topic)):
                 {
-                    deserialize_@(topic)(&MicroBufferReader, &@(topic)_data, data_buffer);
+                    deserialize_@(topic)(&reader, &@(topic)_data, data_buffer);
                     if (!@(topic)_pub) {
                         @(topic)_pub = orb_advertise(ORB_ID(@(topic)), &@(topic)_data);
                     } else {

--- a/msg/templates/uorb_microcdr/msg.cpp.template
+++ b/msg/templates/uorb_microcdr/msg.cpp.template
@@ -19,7 +19,7 @@
 @###############################################
 /****************************************************************************
  *
- *   Copyright (C) 2013-2016 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2013-2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -62,7 +62,7 @@ topic_name = spec.short_name
 }@
 
 #include <px4_config.h>
-#include <microcdr/microcdr.h>
+#include <ucdr/microcdr.h>
 #include <uORB/topics/@(topic_name).h>
 #include <uORB_microcdr/topics/@(topic_name).h>
 
@@ -99,9 +99,9 @@ def add_serialize_functions(fields, scope_name):
         if (not field.is_header):
             if (field.is_builtin):
                 if (not field.is_array):
-                    print("    serialize_" + str(get_serialization_type_name(field.type)) + "(microCDRWriter, input->" + scope_name+str(field.name) + ");")
+                    print("    ucdr_serialize_" + str(get_serialization_type_name(field.type)) + "(writer, input->" + scope_name+str(field.name) + ");")
                 else:
-                    print("    serialize_array_" + str(get_serialization_type_name(field.base_type)) + "(microCDRWriter, input->" + scope_name+str(field.name) + ", " + str(field.array_len) + ");")
+                    print("    ucdr_serialize_array_" + str(get_serialization_type_name(field.base_type)) + "(writer, input->" + scope_name+str(field.name) + ", " + str(field.array_len) + ");")
             else:
                 name = field.name
                 children_fields = get_children_fields(field.base_type, search_path)
@@ -117,9 +117,9 @@ def add_deserialize_functions(fields, scope_name):
         if (not field.is_header):
             if (field.is_builtin):
                 if (not field.is_array):
-                    print("    deserialize_" + str(get_serialization_type_name(field.type)) + "(microCDRReader, &output->" + scope_name+str(field.name) + ");")
+                    print("    ucdr_deserialize_" + str(get_serialization_type_name(field.type)) + "(reader, &output->" + scope_name+str(field.name) + ");")
                 else:
-                    print("    deserialize_array_" + str(get_serialization_type_name(field.base_type)) + "(microCDRReader, output->" + scope_name+str(field.name) + ", " + str(field.array_len) + ");")
+                    print("    ucdr_deserialize_array_" + str(get_serialization_type_name(field.base_type)) + "(reader, output->" + scope_name+str(field.name) + ", " + str(field.array_len) + ");")
             else:
                 name = field.name
                 children_fields = get_children_fields(field.base_type, search_path)
@@ -141,23 +141,23 @@ def add_code_to_deserialize():
     add_deserialize_functions(sorted_fields, "")
 }@
 
-void serialize_@(topic_name)(MicroBuffer *microCDRWriter, const struct @(uorb_struct) *input, char *output, uint32_t *length)
+void serialize_@(topic_name)(ucdrBuffer *writer, const struct @(uorb_struct) *input, char *output, uint32_t *length)
 {
-    if (nullptr == microCDRWriter || nullptr == input || nullptr == output || nullptr == length)
+    if (nullptr == writer || nullptr == input || nullptr == output || nullptr == length)
 	return;
 
-    reset_micro_buffer(microCDRWriter);
+    ucdr_reset_buffer(writer);
 
 @add_code_to_serialize()
-    (*length) = micro_buffer_length(microCDRWriter);
+    (*length) = ucdr_buffer_length(writer);
 }
 
-void deserialize_@(topic_name)(MicroBuffer *microCDRReader, struct @(uorb_struct) *output, const char *input)
+void deserialize_@(topic_name)(ucdrBuffer *reader, struct @(uorb_struct) *output, const char *input)
 {
-    if (nullptr == microCDRReader || nullptr == output || nullptr == input)
+    if (nullptr == reader || nullptr == output || nullptr == input)
 	return;
 
-    reset_micro_buffer(microCDRReader);
+    ucdr_reset_buffer(reader);
 
 @add_code_to_deserialize()
 }

--- a/msg/templates/uorb_microcdr/msg.h.template
+++ b/msg/templates/uorb_microcdr/msg.h.template
@@ -19,7 +19,7 @@
 @###############################################
 /****************************************************************************
  *
- *   Copyright (C) 2013-2016 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2013-2018 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -69,7 +69,5 @@ topic_name = spec.short_name
 #include <uORB/topics/@(topic_name).h>
 #include <uORB_microcdr/topics/@(topic_name).h>
 
-struct MicroBuffer;
-
-void serialize_@(topic_name)(MicroBuffer *microCDRWriter, const struct @(uorb_struct) *input, char *output, uint32_t *length);
-void deserialize_@(topic_name)(MicroBuffer *microCDRReader, struct @(uorb_struct) *output, const char *input);
+void serialize_@(topic_name)(ucdrBuffer *writer, const struct @(uorb_struct) *input, char *output, uint32_t *length);
+void deserialize_@(topic_name)(ucdrBuffer *reader, struct @(uorb_struct) *output, const char *input);

--- a/src/modules/micrortps_bridge/micrortps_client/microRTPS_client.h
+++ b/src/modules/micrortps_bridge/micrortps_client/microRTPS_client.h
@@ -40,7 +40,7 @@
 #include <pthread.h>
 #include <termios.h>
 
-#include <microcdr/microcdr.h>
+#include <ucdr/microcdr.h>
 #include <px4_config.h>
 #include <px4_getopt.h>
 #include <px4_posix.h>
@@ -92,4 +92,3 @@ struct options {
 extern struct options _options;
 extern bool _should_exit_task;
 extern Transport_node *transport_node;
-


### PR DESCRIPTION
This updates the Micro-CDR submodule to latest `develop` branch of Micro-CDR, with the respective changes on the `micrortps_client` code and templates. Replaces https://github.com/PX4/Firmware/pull/10728.
