### PR TITLE
hysteresis test increase time on cygwin

### DIFF
--- a/src/systemcmds/tests/test_hysteresis.cpp
+++ b/src/systemcmds/tests/test_hysteresis.cpp
@@ -17,8 +17,8 @@ private:
 	bool _change_after_multiple_sets();
 	bool _take_change_back();
 
-	// The CI system for Mac OS is not very fast
-#ifdef __PX4_DARWIN
+	// timing on MacOS and Cygwin isn't great
+#if defined(__PX4_DARWIN) ||  defined(__PX4_CYGWIN)
 	static const int f = 10;
 #else
 	static const int f = 1;


### PR DESCRIPTION
@MaEtUgR the hysteresis test is failing consistently on appveyor. Let's see if this helps.

This is also something to be aware of for using windows/cygwin in general.