### PR TITLE
create example vehicle type build configs for fmu-v2 and fmu-v5

### DIFF
--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -30,7 +30,12 @@ pipeline {
           ]
 
           def nuttx_builds_archive = [
-            target: ["px4_fmu-v2_default", "px4_fmu-v3_default", "px4_fmu-v4_default", "px4_fmu-v4pro_default", "px4_fmu-v5_default", "px4_fmu-v5_rtps", "px4_fmu-v5_stackcheck",
+            target: [
+                     "px4_fmu-v2_default", "px4_fmu-v2_fixedwing", "px4_fmu-v2_lpe", "px4_fmu-v2_multicopter", "px4_fmu-v2_rover", "px4_fmu-v2_test",
+                     "px4_fmu-v3_default",
+                     "px4_fmu-v4_default",
+                     "px4_fmu-v4pro_default",
+                     "px4_fmu-v5_default", "px4_fmu-v5_fixedwing", "px4_fmu-v5_multicopter", "px4_fmu-v5_rover", "px4_fmu-v5_rtps", "px4_fmu-v5_stackcheck",
                      "intel_aerofc-v1_default", "gumstix_aerocore2_default", "auav_x21_default", "av_x-v1_default", "bitcraze_crazyflie_default", "airmind_mindpx-v2_default",
                      "nxp_fmuk66-v3_default", "omnibus_f4sd_default"],
             image: docker_images.nuttx,

--- a/boards/px4/fmu-v2/fixedwing.cmake
+++ b/boards/px4/fmu-v2/fixedwing.cmake
@@ -1,0 +1,83 @@
+
+px4_add_board(
+	PLATFORM nuttx
+	VENDOR px4
+	MODEL fmu-v2
+	LABEL fixedwing
+	TOOLCHAIN arm-none-eabi
+	ARCHITECTURE cortex-m4
+	ROMFSROOT px4fmu_common
+	IO px4_io-v2_default
+	#TESTING
+	#UAVCAN_INTERFACES 2
+
+	SERIAL_PORTS
+		GPS1:/dev/ttyS3
+		TEL1:/dev/ttyS1
+		TEL2:/dev/ttyS2
+		TEL4:/dev/ttyS6
+
+	DRIVERS
+		#barometer # all available barometer drivers
+		barometer/ms5611
+		batt_smbus
+		camera_trigger
+		differential_pressure # all available differential pressure drivers
+		distance_sensor # all available distance sensor drivers
+		gps
+		imu/l3gd20
+		imu/lsm303d
+		imu/mpu6000
+		imu/mpu9250
+		lights/rgbled
+		#magnetometer # all available magnetometer drivers
+		magnetometer/hmc5883
+		px4fmu
+		px4io
+		stm32
+		stm32/adc
+		stm32/tone_alarm
+		#telemetry # all available telemetry drivers
+		telemetry/iridiumsbd
+		#uavcan
+
+	MODULES
+		camera_feedback
+		commander
+		dataman
+		ekf2
+		events
+		fw_att_control
+		fw_pos_control_l1
+		land_detector
+		load_mon
+		logger
+		mavlink
+		navigator
+		sensors
+		vmount
+		wind_estimator
+
+	SYSTEMCMDS
+		bl_update
+		#config
+		#dumpfile
+		#esc_calib
+		hardfault_log
+		#led_control
+		mixer
+		#motor_ramp
+		#motor_test
+		mtd
+		#nshterm
+		param
+		perf
+		pwm
+		reboot
+		#sd_bench
+		top
+		#topic_listener
+		tune_control
+		usb_connected
+		ver
+	)

--- a/boards/px4/fmu-v2/multicopter.cmake
+++ b/boards/px4/fmu-v2/multicopter.cmake
@@ -1,0 +1,80 @@
+
+px4_add_board(
+	PLATFORM nuttx
+	VENDOR px4
+	MODEL fmu-v2
+	LABEL multicopter
+	TOOLCHAIN arm-none-eabi
+	ARCHITECTURE cortex-m4
+	ROMFSROOT px4fmu_common
+	IO px4_io-v2_default
+	#UAVCAN_INTERFACES 2
+
+	SERIAL_PORTS
+		GPS1:/dev/ttyS3
+		TEL1:/dev/ttyS1
+		TEL2:/dev/ttyS2
+		TEL4:/dev/ttyS6
+
+	DRIVERS
+		barometer/ms5611
+		batt_smbus
+		camera_trigger
+		distance_sensor # all available distance sensor drivers
+		gps
+		imu/l3gd20
+		imu/lsm303d
+		imu/mpu6000
+		imu/mpu9250
+		irlock
+		lights/rgbled
+		magnetometer/hmc5883
+		px4flow
+		px4fmu
+		px4io
+		stm32
+		stm32/adc
+		stm32/tone_alarm
+
+	MODULES
+		#attitude_estimator_q
+		camera_feedback
+		commander
+		dataman
+		ekf2
+		events
+		land_detector
+		landing_target_estimator
+		load_mon
+		#local_position_estimator
+		logger
+		mavlink
+		mc_att_control
+		mc_pos_control
+		navigator
+		sensors
+		vmount
+
+	SYSTEMCMDS
+		bl_update
+		#config
+		#dumpfile
+		#esc_calib
+		hardfault_log
+		#led_control
+		mixer
+		#motor_ramp
+		#motor_test
+		mtd
+		#nshterm
+		param
+		perf
+		pwm
+		reboot
+		#sd_bench
+		top
+		#topic_listener
+		tune_control
+		usb_connected
+		ver
+	)

--- a/boards/px4/fmu-v2/rover.cmake
+++ b/boards/px4/fmu-v2/rover.cmake
@@ -1,0 +1,75 @@
+
+px4_add_board(
+	PLATFORM nuttx
+	VENDOR px4
+	MODEL fmu-v2
+	LABEL rover
+	TOOLCHAIN arm-none-eabi
+	ARCHITECTURE cortex-m4
+	ROMFSROOT px4fmu_common
+	IO px4_io-v2_default
+
+	SERIAL_PORTS
+		GPS1:/dev/ttyS3
+		TEL1:/dev/ttyS1
+		TEL2:/dev/ttyS2
+		TEL4:/dev/ttyS6
+
+	DRIVERS
+		barometer/ms5611
+		batt_smbus
+		camera_trigger
+		distance_sensor # all available distance sensor drivers
+		gps
+		imu/l3gd20
+		imu/lsm303d
+		imu/mpu6000
+		imu/mpu9250
+		lights/rgbled
+		magnetometer/hmc5883
+		px4flow
+		px4fmu
+		px4io
+		stm32
+		stm32/adc
+		stm32/tone_alarm
+
+	MODULES
+		camera_feedback
+		commander
+		dataman
+		ekf2
+		events
+		gnd_att_control
+		gnd_pos_control
+		land_detector
+		load_mon
+		logger
+		mavlink
+		navigator
+		sensors
+		vmount
+
+	SYSTEMCMDS
+		bl_update
+		#config
+		#dumpfile
+		#esc_calib
+		hardfault_log
+		#led_control
+		mixer
+		#motor_ramp
+		#motor_test
+		mtd
+		#nshterm
+		param
+		perf
+		pwm
+		reboot
+		#sd_bench
+		top
+		#topic_listener
+		tune_control
+		usb_connected
+		ver
+	)

--- a/boards/px4/fmu-v5/fixedwing.cmake
+++ b/boards/px4/fmu-v5/fixedwing.cmake
@@ -3,12 +3,11 @@ px4_add_board(
 	PLATFORM nuttx
 	VENDOR px4
 	MODEL fmu-v5
-	LABEL default
+	LABEL fixedwing
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m7
 	ROMFSROOT px4fmu_common
 	IO px4_io-v2_default
-	TESTING
 	UAVCAN_INTERFACES 2
 
 	SERIAL_PORTS
@@ -24,44 +23,25 @@ px4_add_board(
 		differential_pressure # all available differential pressure drivers
 		distance_sensor # all available distance sensor drivers
 		gps
-		#heater
 		imu/adis16448
-		#imu # all available imu drivers
 		imu/bmi055
 		imu/mpu6000
-		imu/mpu9250
-		imu/icm20948
-		irlock
-		lights/blinkm
-		lights/oreoled
-		lights/pca8574
 		lights/rgbled
 		lights/rgbled_ncp5623c
 		lights/rgbled_pwm
 		magnetometer # all available magnetometer drivers
-		#md25
-		mkblctrl
-		pca9685
-		pmw3901
-		#protocol_splitter
 		pwm_input
 		pwm_out_sim
-		px4flow
 		px4fmu
 		px4io
 		rc_input
-		roboclaw
 		stm32
 		stm32/adc
 		stm32/tone_alarm
-		tap_esc
 		telemetry # all available telemetry drivers
-		test_ppm
-		tone_alarm
 		uavcan
 
 	MODULES
-		attitude_estimator_q
 		camera_feedback
 		commander
 		dataman
@@ -69,20 +49,13 @@ px4_add_board(
 		events
 		fw_att_control
 		fw_pos_control_l1
-		gnd_att_control
-		gnd_pos_control
 		land_detector
-		landing_target_estimator
 		load_mon
-		local_position_estimator
 		logger
 		mavlink
-		mc_att_control
-		mc_pos_control
 		navigator
 		sensors
 		vmount
-		vtol_att_control
 		wind_estimator
 
 	SYSTEMCMDS
@@ -104,23 +77,9 @@ px4_add_board(
 		reflect
 		sd_bench
 		shutdown
-		tests # tests and test runner
 		top
 		topic_listener
 		tune_control
 		usb_connected
 		ver
-
-	EXAMPLES
-		bottle_drop # OBC challenge
-		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
-		hello
-		hwtest # Hardware test
-		#matlab_csv_serial
-		position_estimator_inav
-		px4_mavlink_debug # Tutorial code from https://px4.io/dev/debug_values
-		px4_simple_app # Tutorial code from https://px4.io/dev/px4_simple_app
-		rover_steering_control # Rover example app
-		segway
-		uuv_example_app
 	)

--- a/boards/px4/fmu-v5/multicopter.cmake
+++ b/boards/px4/fmu-v5/multicopter.cmake
@@ -3,7 +3,7 @@ px4_add_board(
 	PLATFORM nuttx
 	VENDOR px4
 	MODEL fmu-v5
-	LABEL default
+	LABEL multicopter
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m7
 	ROMFSROOT px4fmu_common
@@ -21,29 +21,18 @@ px4_add_board(
 		barometer # all available barometer drivers
 		batt_smbus
 		camera_trigger
-		differential_pressure # all available differential pressure drivers
 		distance_sensor # all available distance sensor drivers
 		gps
-		#heater
-		imu/adis16448
-		#imu # all available imu drivers
 		imu/bmi055
 		imu/mpu6000
-		imu/mpu9250
-		imu/icm20948
 		irlock
 		lights/blinkm
 		lights/oreoled
-		lights/pca8574
 		lights/rgbled
 		lights/rgbled_ncp5623c
 		lights/rgbled_pwm
 		magnetometer # all available magnetometer drivers
-		#md25
-		mkblctrl
-		pca9685
 		pmw3901
-		#protocol_splitter
 		pwm_input
 		pwm_out_sim
 		px4flow
@@ -56,8 +45,6 @@ px4_add_board(
 		stm32/tone_alarm
 		tap_esc
 		telemetry # all available telemetry drivers
-		test_ppm
-		tone_alarm
 		uavcan
 
 	MODULES
@@ -67,10 +54,6 @@ px4_add_board(
 		dataman
 		ekf2
 		events
-		fw_att_control
-		fw_pos_control_l1
-		gnd_att_control
-		gnd_pos_control
 		land_detector
 		landing_target_estimator
 		load_mon
@@ -82,7 +65,6 @@ px4_add_board(
 		navigator
 		sensors
 		vmount
-		vtol_att_control
 		wind_estimator
 
 	SYSTEMCMDS
@@ -104,23 +86,9 @@ px4_add_board(
 		reflect
 		sd_bench
 		shutdown
-		tests # tests and test runner
 		top
 		topic_listener
 		tune_control
 		usb_connected
 		ver
-
-	EXAMPLES
-		bottle_drop # OBC challenge
-		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
-		hello
-		hwtest # Hardware test
-		#matlab_csv_serial
-		position_estimator_inav
-		px4_mavlink_debug # Tutorial code from https://px4.io/dev/debug_values
-		px4_simple_app # Tutorial code from https://px4.io/dev/px4_simple_app
-		rover_steering_control # Rover example app
-		segway
-		uuv_example_app
 	)

--- a/boards/px4/fmu-v5/rover.cmake
+++ b/boards/px4/fmu-v5/rover.cmake
@@ -3,12 +3,11 @@ px4_add_board(
 	PLATFORM nuttx
 	VENDOR px4
 	MODEL fmu-v5
-	LABEL default
+	LABEL rover
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m7
 	ROMFSROOT px4fmu_common
 	IO px4_io-v2_default
-	TESTING
 	UAVCAN_INTERFACES 2
 
 	SERIAL_PORTS
@@ -21,19 +20,10 @@ px4_add_board(
 		barometer # all available barometer drivers
 		batt_smbus
 		camera_trigger
-		differential_pressure # all available differential pressure drivers
 		distance_sensor # all available distance sensor drivers
 		gps
-		#heater
-		imu/adis16448
-		#imu # all available imu drivers
 		imu/bmi055
 		imu/mpu6000
-		imu/mpu9250
-		imu/icm20948
-		irlock
-		lights/blinkm
-		lights/oreoled
 		lights/pca8574
 		lights/rgbled
 		lights/rgbled_ncp5623c
@@ -43,7 +33,6 @@ px4_add_board(
 		mkblctrl
 		pca9685
 		pmw3901
-		#protocol_splitter
 		pwm_input
 		pwm_out_sim
 		px4flow
@@ -54,36 +43,24 @@ px4_add_board(
 		stm32
 		stm32/adc
 		stm32/tone_alarm
-		tap_esc
 		telemetry # all available telemetry drivers
-		test_ppm
-		tone_alarm
 		uavcan
 
 	MODULES
-		attitude_estimator_q
 		camera_feedback
 		commander
 		dataman
 		ekf2
 		events
-		fw_att_control
-		fw_pos_control_l1
 		gnd_att_control
 		gnd_pos_control
 		land_detector
-		landing_target_estimator
 		load_mon
-		local_position_estimator
 		logger
 		mavlink
-		mc_att_control
-		mc_pos_control
 		navigator
 		sensors
 		vmount
-		vtol_att_control
-		wind_estimator
 
 	SYSTEMCMDS
 		bl_update
@@ -104,23 +81,9 @@ px4_add_board(
 		reflect
 		sd_bench
 		shutdown
-		tests # tests and test runner
 		top
 		topic_listener
 		tune_control
 		usb_connected
 		ver
-
-	EXAMPLES
-		bottle_drop # OBC challenge
-		fixedwing_control # Tutorial code from https://px4.io/dev/example_fixedwing_control
-		hello
-		hwtest # Hardware test
-		#matlab_csv_serial
-		position_estimator_inav
-		px4_mavlink_debug # Tutorial code from https://px4.io/dev/debug_values
-		px4_simple_app # Tutorial code from https://px4.io/dev/px4_simple_app
-		rover_steering_control # Rover example app
-		segway
-		uuv_example_app
 	)

--- a/src/modules/navigator/precland.h
+++ b/src/modules/navigator/precland.h
@@ -77,6 +77,9 @@ public:
 	PrecLandMode get_mode() { return _mode; };
 
 private:
+
+	void updateParams() override;
+
 	// run the control loop for each state
 	void run_state_start();
 	void run_state_horizontal_approach();
@@ -127,9 +130,13 @@ private:
 		(ParamFloat<px4::params::PLD_FAPPR_ALT>) _param_final_approach_alt,
 		(ParamFloat<px4::params::PLD_SRCH_ALT>) _param_search_alt,
 		(ParamFloat<px4::params::PLD_SRCH_TOUT>) _param_search_timeout,
-		(ParamInt<px4::params::PLD_MAX_SRCH>) _param_max_searches,
-		(ParamFloat<px4::params::MPC_ACC_HOR>) _param_acceleration_hor,
-		(ParamFloat<px4::params::MPC_XY_CRUISE>) _param_xy_vel_cruise
+		(ParamInt<px4::params::PLD_MAX_SRCH>) _param_max_searches
 	)
+
+	// non-navigator parameters
+	param_t	_handle_param_acceleration_hor{PARAM_INVALID};
+	param_t	_handle_param_xy_vel_cruise{PARAM_INVALID};
+	float	_param_acceleration_hor{0.0f};
+	float	_param_xy_vel_cruise{0.0f};
 
 };


### PR DESCRIPTION
This PR adds vehicle specific builds for px4_fmu-v2 and px4_fmu-v5. These serve as examples for how to easily create specialized builds and ensures we don't introduce dependencies cross module dependencies preventing it.

