### PR TITLE
[WIP] Add translation string support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -484,7 +484,7 @@ file(GLOB_RECURSE yaml_config_files ${PX4_SOURCE_DIR}/src/modules/*.yaml
 	${PX4_SOURCE_DIR}/src/drivers/*.yaml ${PX4_SOURCE_DIR}/src/lib/*.yaml)
 add_custom_target(metadata_parameters
 	COMMAND ${CMAKE_COMMAND} -E make_directory ${PX4_BINARY_DIR}/docs
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${PX4_SOURCE_DIR}/translations
+	COMMAND ${CMAKE_COMMAND} -E make_directory ${PX4_SOURCE_DIR}/translations
 	COMMAND ${PYTHON_EXECUTABLE}
 	${PX4_SOURCE_DIR}/Tools/serial/generate_config.py --all-ports --params-file ${PX4_SOURCE_DIR}/src/generated_serial_params.c --config-files ${yaml_config_files}
 	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/src/lib/parameters/px_process_params.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -484,6 +484,7 @@ file(GLOB_RECURSE yaml_config_files ${PX4_SOURCE_DIR}/src/modules/*.yaml
 	${PX4_SOURCE_DIR}/src/drivers/*.yaml ${PX4_SOURCE_DIR}/src/lib/*.yaml)
 add_custom_target(metadata_parameters
 	COMMAND ${CMAKE_COMMAND} -E make_directory ${PX4_BINARY_DIR}/docs
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${PX4_SOURCE_DIR}/translations
 	COMMAND ${PYTHON_EXECUTABLE}
 	${PX4_SOURCE_DIR}/Tools/serial/generate_config.py --all-ports --params-file ${PX4_SOURCE_DIR}/src/generated_serial_params.c --config-files ${yaml_config_files}
 	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/src/lib/parameters/px_process_params.py
@@ -494,6 +495,10 @@ add_custom_target(metadata_parameters
 		--src-path `find ${PX4_SOURCE_DIR}/src -maxdepth 4 -type d`
 		--inject-xml ${PX4_SOURCE_DIR}/src/lib/parameters/parameters_injected.xml
 		--xml ${PX4_BINARY_DIR}/docs/parameters.xml
+	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/src/lib/parameters/px_process_params.py
+		--src-path `find ${PX4_SOURCE_DIR}/src -maxdepth 4 -type d`
+		--inject-xml ${PX4_SOURCE_DIR}/src/lib/parameters/parameters_injected.xml
+		--translation_xml ${PX4_SOURCE_DIR}/translations/parameter_strings.xml
 	COMMENT "Generating full parameter metadata (markdown and xml)"
 	USES_TERMINAL
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,7 +498,7 @@ add_custom_target(metadata_parameters
 	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/src/lib/parameters/px_process_params.py
 		--src-path `find ${PX4_SOURCE_DIR}/src -maxdepth 4 -type d`
 		--inject-xml ${PX4_SOURCE_DIR}/src/lib/parameters/parameters_injected.xml
-		--translation_xml ${PX4_SOURCE_DIR}/translations/parameter_strings.xml
+		--translation_xml ${PX4_SOURCE_DIR}/src/lib/parameters/translations/parameter_strings.xml
 	COMMENT "Generating full parameter metadata (markdown and xml)"
 	USES_TERMINAL
 )

--- a/src/lib/parameters/px4params/translationscanner.py
+++ b/src/lib/parameters/px4params/translationscanner.py
@@ -10,7 +10,7 @@ def GetTranslations(filename=''):
 
     dir_path = dirname(realpath(__file__))
     translation_path = dir_path.split('Firmware/')[0]+'Firmware/translations/'
-    #print("DEBUG:Loading translation files from: %s" % translation_path)
+    print("DEBUG:Loading translation files from: %s" % translation_path)
     translation_files = [f for f in listdir(translation_path) if isfile(join(translation_path, f))]
 
     # Get english dict

--- a/src/lib/parameters/px4params/translationscanner.py
+++ b/src/lib/parameters/px4params/translationscanner.py
@@ -44,7 +44,7 @@ def GetTranslations(filename=''):
                 key = entry.attrib['key']
                 entry_text = entry.text
                 # Only add string if it has changed from English
-                if not entry_text == lang_translations['en'][key]:
+                if key in lang_translations['en'] and not lang_translations['en'][key] == entry_text:
                     lang_dict[key]=entry_text
         lang_translations[lang_key] = lang_dict
     return lang_translations

--- a/src/lib/parameters/px4params/translationscanner.py
+++ b/src/lib/parameters/px4params/translationscanner.py
@@ -1,7 +1,7 @@
 import xml.etree.ElementTree as ET
 #import os 
 from os import listdir
-from os.path import isfile, join, dirname, realpath
+from os.path import isfile, join, dirname, realpath, exists
 
 
 def GetTranslations(filename=''):
@@ -9,8 +9,10 @@ def GetTranslations(filename=''):
     # Get path to translation path
 
     dir_path = dirname(realpath(__file__))
-    translation_path = dir_path.split('Firmware/')[0]+'Firmware/translations/'
-    print("DEBUG:Loading translation files from: %s" % translation_path)
+    translation_path = dir_path.rsplit('/',1)[0]+'/translations/'
+    if not exists(translation_path):
+        #print("DEBUG: Translation direcory not found: %s" % translation_path)
+        return None
     translation_files = [f for f in listdir(translation_path) if isfile(join(translation_path, f))]
 
     # Get english dict

--- a/src/lib/parameters/px4params/translationscanner.py
+++ b/src/lib/parameters/px4params/translationscanner.py
@@ -1,0 +1,48 @@
+import xml.etree.ElementTree as ET
+#import os 
+from os import listdir
+from os.path import isfile, join, dirname, realpath
+
+
+def GetTranslations(filename=''):
+    lang_translations = dict()
+    # Get path to translation path
+
+    dir_path = dirname(realpath(__file__))
+    translation_path = dir_path.split('Firmware/')[0]+'Firmware/translations/'
+    #print("DEBUG:Loading translation files from: %s" % translation_path)
+    translation_files = [f for f in listdir(translation_path) if isfile(join(translation_path, f))]
+
+    # Get english dict
+    for filename in translation_files:
+        if filename=='parameter_strings.xml':
+            english_root = ET.parse(translation_path+filename)
+            lang_dict = dict()
+            for entry in english_root.findall("./entry"):
+                lang_dict[entry.attrib['key']]=entry.text
+                #print("DEBUG: %s " % entry.attrib['key'])
+                #print("DEBUG: %s " % entry.text)
+                lang_translations['en'] = lang_dict
+            break
+
+    # Return if no English version found (need for keys)
+    if len(lang_translations)==0:
+        return None
+
+    for filename in translation_files:
+        #print("DEBUG: %s" % filename)
+        if filename=='parameter_strings.xml':
+            continue
+        else:
+            root = ET.parse(translation_path+filename)
+            lang_dict = dict()
+            lang_key=filename.rsplit('-',1)[-1].rsplit('.',1)[0]
+            #print('DEBUG:lang_key: %s' % lang_key)
+            for entry in root.findall("./entry"):
+                key = entry.attrib['key']
+                entry_text = entry.text
+                # Only add string if it has changed from English
+                if not entry_text == lang_translations['en'][key]:
+                    lang_dict[key]=entry_text
+        lang_translations[lang_key] = lang_dict
+    return lang_translations

--- a/src/lib/parameters/px4params/xmlout.py
+++ b/src/lib/parameters/px4params/xmlout.py
@@ -18,7 +18,7 @@ def indent(elem, level=0):
 
 class XMLOutput():
 
-    def __init__(self, groups, board, inject_xml_file_name):
+    def __init__(self, groups, board, inject_xml_file_name, translation_dict=None):
         xml_parameters = ET.Element("parameters")
         xml_version = ET.SubElement(xml_parameters, "version")
         xml_version.text = "3"
@@ -75,8 +75,24 @@ class XMLOutput():
                         xml_value.attrib["index"] = index;
                         xml_value.text = param.GetBitmaskBit(index)
 
+        #Append translations - passed in to init as translation_dict
+        if translation_dict and len(translation_dict)>1: #At least English and one translation
+            xml_localization = ET.SubElement(xml_parameters, "localization")
+            for key, entries in translation_dict.items():
+                if not key == 'en':
+                    #print('DEBUG:key: %s' % key)
+                    locale = ET.SubElement(xml_localization, "locale")
+                    locale.attrib["name"] = key
+                    for string_key in entries:
+                        string_element = ET.SubElement(locale, "strings")
+                        string_element.attrib["original"] = translation_dict['en'][string_key]
+                        string_element.attrib["translated"] = translation_dict[key][string_key]
+        else:
+           print('Warn: No parameter translations found')
+             
         indent(xml_parameters)
         self.xml_document = ET.ElementTree(xml_parameters)
+
 
     def Save(self, filename):
         self.xml_document.write(filename, encoding="UTF-8")

--- a/src/lib/parameters/px4params/xmlstringsout.py
+++ b/src/lib/parameters/px4params/xmlstringsout.py
@@ -1,3 +1,7 @@
+#
+# Export all parameter strings for translation into key/value file.
+#
+
 import xml.etree.ElementTree as ET
 import codecs
 import os

--- a/src/lib/parameters/px4params/xmlstringsout.py
+++ b/src/lib/parameters/px4params/xmlstringsout.py
@@ -31,7 +31,7 @@ class XMLOutput():
             group_name=group.GetName()
             if group_name not in unique_strings:
                 xml_entry = ET.SubElement(xml_parameters, "entry")
-                xml_entry.attrib["key"] = group_name
+                xml_entry.attrib["key"] = 'group_%s' % group_name
                 #xml_entry.attrib["type"] = 'group'
                 xml_entry.text = group_name
                 unique_strings.add(group_name)
@@ -53,7 +53,7 @@ class XMLOutput():
                 #Add param_category (if exists)
                 if param_category not in unique_strings and param_category:
                     xml_entry = ET.SubElement(xml_parameters, "entry")
-                    xml_entry.attrib["key"] = param_category
+                    xml_entry.attrib["key"] = 'category_%s' % param_category
                     #xml_entry.attrib["type"] = 'param_category'
                     #xml_entry.attrib["param"] = 'param_name'
                     xml_entry.text = param_category
@@ -67,7 +67,7 @@ class XMLOutput():
                     if code in ['short_desc','long_desc']:  #Other fields are not translateable
                         if value not in unique_strings and value:
                             xml_entry = ET.SubElement(xml_parameters, "entry")
-                            xml_entry.attrib["key"] = param_name+'_'+code
+                            xml_entry.attrib["key"] = 'param_%s_%s' % (param_name,code)
                             #xml_entry.attrib["type"] = code
                             #xml_entry.attrib["param"] = param_name
                             xml_entry.text = value
@@ -83,7 +83,7 @@ class XMLOutput():
                         #print('DEBUG: code: %s, value: %s' % (code, value))
                         if value not in unique_strings and value:
                             xml_entry = ET.SubElement(xml_parameters, "entry")
-                            xml_entry.attrib["key"] = '%s_enumval_%s' % (param_name,code)
+                            xml_entry.attrib["key"] = 'enum_%s_val_%s' % (param_name,code)
                             #xml_entry.attrib["type"] = 'enumvalue'
                             #xml_entry.attrib["value"] = code
                             #xml_entry.attrib["param"] = param_name
@@ -98,7 +98,7 @@ class XMLOutput():
                         #print('DEBUG: index: %s, value: %s' % (index, value))
                         if value not in unique_strings and value:
                             xml_entry = ET.SubElement(xml_parameters, "entry")
-                            xml_entry.attrib["key"] = '%s_bit_%s' % (param_name,index)
+                            xml_entry.attrib["key"] = 'bitmask_%s_index_%s' % (param_name,index)
                             #xml_entry.attrib["type"] = 'bit'
                             #xml_entry.attrib["value"] = index
                             #xml_entry.attrib["param"] = param_name

--- a/src/lib/parameters/px4params/xmltranslationout.py
+++ b/src/lib/parameters/px4params/xmltranslationout.py
@@ -1,0 +1,119 @@
+import xml.etree.ElementTree as ET
+import codecs
+
+def indent(elem, level=0):
+    i = "\n" + level*"  "
+    if len(elem):
+        if not elem.text or not elem.text.strip():
+            elem.text = i + "  "
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+        for elem in elem:
+            indent(elem, level+1)
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+    else:
+        if level and (not elem.tail or not elem.tail.strip()):
+            elem.tail = i
+
+class XMLOutput():
+
+    def __init__(self, groups, board, inject_xml_file_name):
+        unique_strings = set()
+        xml_parameters = ET.Element("properties")
+
+        for group in groups:
+            group_name=group.GetName()
+            if group_name not in unique_strings:
+                xml_entry = ET.SubElement(xml_parameters, "entry")
+                xml_entry.attrib["key"] = group_name
+                #xml_entry.attrib["type"] = 'group'
+                xml_entry.text = group_name
+                unique_strings.add(group_name)
+            else:
+                pass
+            
+            for param in group.GetParams():
+                param_name = param.GetName()
+                param_default = param.GetDefault()
+                param_type = param.GetType()
+                param_volatile = param.GetVolatile()
+                param_category = param.GetCategory()
+                #print("DEBUG: param_name: %s" % param_name)
+                #print("DEBUG: param_default: %s" % param_default)
+                #print("DEBUG: param type: %s" % param_type)
+                #print("DEBUG: param_volatile: %s" % param_volatile)
+                #print("DEBUG: param_category: %s" % param_category)
+
+                #Add param_category (if exists)
+                if param_category not in unique_strings and param_category:
+                    xml_entry = ET.SubElement(xml_parameters, "entry")
+                    xml_entry.attrib["key"] = param_category
+                    #xml_entry.attrib["type"] = 'param_category'
+                    #xml_entry.attrib["param"] = 'param_name'
+                    xml_entry.text = param_category
+                    unique_strings.add(param_category)
+                else:
+                    pass
+                
+                for code in param.GetFieldCodes():
+                    value = param.GetFieldValue(code)
+                    #print('DEBUG: code: %s, value: %s' % (code, value))
+                    if code in ['short_desc','long_desc']:  #Other fields are not translateable
+                        if value not in unique_strings and value:
+                            xml_entry = ET.SubElement(xml_parameters, "entry")
+                            xml_entry.attrib["key"] = param_name+'_'+code
+                            #xml_entry.attrib["type"] = code
+                            #xml_entry.attrib["param"] = param_name
+                            xml_entry.text = value
+                            unique_strings.add(value)
+                        else:
+                            pass             
+
+
+
+                if len(param.GetEnumCodes()) > 0:
+                    for code in param.GetEnumCodes():
+                        value = param.GetEnumValue(code)
+                        #print('DEBUG: code: %s, value: %s' % (code, value))
+                        if value not in unique_strings and value:
+                            xml_entry = ET.SubElement(xml_parameters, "entry")
+                            xml_entry.attrib["key"] = '%s_enumval_%s' % (param_name,code)
+                            #xml_entry.attrib["type"] = 'enumvalue'
+                            #xml_entry.attrib["value"] = code
+                            #xml_entry.attrib["param"] = param_name
+                            xml_entry.text = value
+                            unique_strings.add(value)
+                        else:
+                            pass  
+
+                if len(param.GetBitmaskList()) > 0:
+                    for index in param.GetBitmaskList():
+                        value = param.GetBitmaskBit(index)
+                        #print('DEBUG: index: %s, value: %s' % (index, value))
+                        if value not in unique_strings and value:
+                            xml_entry = ET.SubElement(xml_parameters, "entry")
+                            xml_entry.attrib["key"] = '%s_bit_%s' % (param_name,index)
+                            #xml_entry.attrib["type"] = 'bit'
+                            #xml_entry.attrib["value"] = index
+                            #xml_entry.attrib["param"] = param_name
+                            xml_entry.text = value
+                            unique_strings.add(value)
+                        else:
+                            pass  
+
+
+
+        indent(xml_parameters)
+        self.xml_document = ET.ElementTree(xml_parameters)
+
+    def Save(self, filename):
+        self.xml_document.write(filename, encoding="UTF-8")
+        # Add doctype (Clunky, but not possible to avoid in ElementTree)
+        f=open(filename, "r")
+        filetext=f.read()
+        f.close
+        filetext=filetext.replace('<properties>','<!DOCTYPE properties SYSTEM "[http://java.sun.com/dtd/properties.dtd](http://java.sun.com/dtd/properties.dtd)">\n<properties>')
+        with open(filename, "w") as f:
+            f.write(filetext)
+

--- a/src/lib/parameters/px4params/xmltranslationout.py
+++ b/src/lib/parameters/px4params/xmltranslationout.py
@@ -1,5 +1,6 @@
 import xml.etree.ElementTree as ET
 import codecs
+import os
 
 def indent(elem, level=0):
     i = "\n" + level*"  "
@@ -108,6 +109,11 @@ class XMLOutput():
         self.xml_document = ET.ElementTree(xml_parameters)
 
     def Save(self, filename):
+        # Create target directory & all intermediate directories if don't exists
+        dirname=filename.rsplit('/',1)[0]
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
+
         self.xml_document.write(filename, encoding="UTF-8")
         # Add doctype (Clunky, but not possible to avoid in ElementTree)
         f=open(filename, "r")

--- a/src/lib/parameters/px_process_params.py
+++ b/src/lib/parameters/px_process_params.py
@@ -47,7 +47,7 @@ from __future__ import print_function
 import sys
 import os
 import argparse
-from px4params import srcscanner, srcparser, xmlout, xmltranslationout, markdownout, translationscanner
+from px4params import srcscanner, srcparser, xmlout, xmlstringsout, markdownout, translationscanner
 
 import re
 import json
@@ -154,7 +154,7 @@ def main():
         if args.verbose:
             print("Creating translation string XML file " + args.translation_xml)
         cur_dir = os.path.dirname(os.path.realpath(__file__))
-        out = xmltranslationout.XMLOutput(param_groups, args.board,
+        out = xmlstringsout.XMLOutput(param_groups, args.board,
                                os.path.join(cur_dir, args.inject_xml))
         #print("DEBUG:translation_xml: %s" % args.translation_xml)
         out.Save(args.translation_xml)

--- a/src/lib/parameters/px_process_params.py
+++ b/src/lib/parameters/px_process_params.py
@@ -86,10 +86,10 @@ def main():
                              " (default FILENAME: parameters.md)")
     parser.add_argument("-t", "--translation_xml",
                         nargs='?',
-                        const="parameters_en.md",
+                        const="parameter_strings.xml",
                         metavar="FILENAME",
                         help="Create translation string file"
-                             " (default FILENAME: parameters_en.md)")
+                             " (default FILENAME: parameter_strings.xml)")
     parser.add_argument('-v', '--verbose',
                         action='store_true',
                         help="verbose output")
@@ -135,6 +135,7 @@ def main():
                     print("OVERRIDING {:s} to {:s}!!!!!".format(name, val))
 
 
+
     # Load current translation info from Firmware/translations
     lang_translations = translationscanner.GetTranslations()
 
@@ -155,14 +156,15 @@ def main():
         cur_dir = os.path.dirname(os.path.realpath(__file__))
         out = xmltranslationout.XMLOutput(param_groups, args.board,
                                os.path.join(cur_dir, args.inject_xml))
+        #print("DEBUG:translation_xml: %s" % args.translation_xml)
         out.Save(args.translation_xml)
 
     # Output to Markdown/HTML tables
     if args.markdown:
-        out = markdownout.MarkdownTablesOutput(param_groups)
-        if args.markdown:
+        if args.verbose:
             print("Creating markdown file " + args.markdown)
-            out.Save(args.markdown)
+        out = markdownout.MarkdownTablesOutput(param_groups)
+        out.Save(args.markdown)
 
     #print("All done!")
 


### PR DESCRIPTION
@dagar This is my first shot at adding translation string support. Gus still needs to add support for the format described in part 3. This is apparently easy as it is a direct copy of what he does for the camera definition files.

It has three main parts:

1. Generation of parameter_strings.xml containing map of keys to English strings.
  * Created by a new option `--translation_xml` in *_px_process_params.py_
  * This is called in the cmakelists to copy new file to **parameters/translations/parameter_strings.xml**
  * Format looks like below. Has unique key based on param name and subinfo - ie enumvalue, bit index, short/long description. Groups and Categories are "Bare - ie no special key because they have no sub items. We could add group as a parent in parameter index but decided not to.
 ```
 <?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
 <entry key="Attitude Q estimator">Attitude Q estimator</entry>
 <entry key="ATT_ACC_COMP_short_desc">Acceleration compensation based on GPS velocity</entry>
 <entry key="ATT_EXT_HDG_M_enumval_1">Vision</entry>
 <entry key="EKF2_AID_MASK_bit_5">multi-rotor drag fusion</entry>
 </properties>
 ```
1. Crowdin integration
  * We can set up crowdin to monitor **Firmware/translations/parameter_strings.xml** in github and spit out translated files with format **Firmware/translations/parameter_strings-xx_YY.xml** (e.g. zh_CH) in the same directory.
1. Addition of localisation to the parameters.xml
  * We add a `localization` to end of `parameters` that has `locale` tags of following format for each locale.
 ```
 ...
 </group>
 <localization>
 <locale name="zh_CN">
 <strings original="Vision" translated="视觉训练" />
 <strings original="Motion Capture" translated="运动捕捉" />
 <strings original="Complimentary filter external heading weight" translated="互补过滤器外部航向权重值" />
 <strings original="Acceleration compensation based on GPS&#10;velocity" translated="基于 GPS 的加速度补偿&#10;速度" />
 <strings original="Complimentary filter magnetometer weight" translated="互补滤波器磁罗盘权重值" />
 <strings original="Attitude Q estimator" translated="姿态 Q 估计器" />
 <strings original="Battery Calibration" translated="电池校准" />
 <strings original="Magnetic declination, in degrees" translated="磁偏角, 以角度为单位" />
 <strings original="Gyro bias limit" translated="陀螺偏置极限值" />
 </locale>
 </localization>
 </parameters>
 ```
  * The code parses Firmware/translations and generates a dictionary of language dictionaries. The translations dict ONLY have translated terms.
  * This is passed into the xmlout to generate the locale information. 

This will not fall over if the translation files are missing. 

Once this (or something like it) is agreed we can add the crowdin integration.