### PR TITLE
Collision prevention with distance_sensor data

### DIFF
--- a/msg/distance_sensor.msg
+++ b/msg/distance_sensor.msg
@@ -23,3 +23,8 @@ uint8 ROTATION_BACKWARD_FACING = 12 # MAV_SENSOR_ROTATION_PITCH_180
 uint8 ROTATION_FORWARD_FACING  = 0  # MAV_SENSOR_ROTATION_NONE
 uint8 ROTATION_LEFT_FACING     = 6  # MAV_SENSOR_ROTATION_YAW_270
 uint8 ROTATION_RIGHT_FACING    = 2  # MAV_SENSOR_ROTATION_YAW_90
+uint8 ROTATION_CUSTOM          =100 # MAV_SENSOR_ROTATION_CUSTOM
+
+float32 h_fov # Sensor horizontal field of view (rad)
+float32 v_fov # Sensor vertical field of view (rad)
+float32[4] q # Quaterion sensor orientation to specify the orientation ROTATION_CUSTOM

--- a/msg/obstacle_distance.msg
+++ b/msg/obstacle_distance.msg
@@ -13,3 +13,6 @@ uint8 increment # Angular width in degrees of each array element.
 
 uint16 min_distance # Minimum distance the sensor can measure in centimeters.
 uint16 max_distance # Maximum distance the sensor can measure in centimeters.
+
+float32 increment_f # Angular width in degrees of each array element. If greater than 0, it's used instead of increment.
+float32 angle_offset # Relative angle offset of the 0-index element in the distances array. Value of 0 corresponds to forward. Positive values are offsets to the right.

--- a/src/drivers/distance_sensor/cm8jl65/cm8jl65.cpp
+++ b/src/drivers/distance_sensor/cm8jl65/cm8jl65.cpp
@@ -381,7 +381,7 @@ CM8JL65::collect()
 
 	//printf("val (int): %d, raw: 0x%08X, valid: %s \n", _distance_mm, _frame_data, ((crc_valid) ? "OK" : "NO"));
 
-	struct distance_sensor_s report;
+	struct distance_sensor_s report = {};
 
 	report.timestamp = hrt_absolute_time();
 	report.type = distance_sensor_s::MAV_DISTANCE_SENSOR_LASER;
@@ -391,6 +391,7 @@ CM8JL65::collect()
 	report.max_distance = get_maximum_distance();
 	report.variance = 0.0f;
 	report.signal_quality = -1;
+	report.h_fov = 2.8f;
 	/* TODO: set proper ID */
 	report.id = 0;
 

--- a/src/drivers/distance_sensor/cm8jl65/module.yaml
+++ b/src/drivers/distance_sensor/cm8jl65/module.yaml
@@ -1,6 +1,6 @@
 module_name: Lanbao PSK-CM8JL65-CC5
 serial_config:
-    - command: cm8jl65 start -d ${SERIAL_DEV}
+    - command: cm8jl65 start -d ${SERIAL_DEV} -R 0
       port_config_param:
         name: SENS_CM8JL65_CFG
         group: Sensors

--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -187,7 +187,8 @@ void CollisionPrevention::_updateDistanceSensor(obstacle_distance_s &obstacle_di
 			// if increment_f is lower than 5deg, use an offset
 			const int distances_array_size = sizeof(obstacle_distance.distances) / sizeof(obstacle_distance.distances[0]);
 
-			if (lower_bound > distances_array_size || upper_bound > distances_array_size) {
+			if (((lower_bound < 0 || upper_bound < 0) || (lower_bound >= distances_array_size
+					|| upper_bound >= distances_array_size)) && obstacle_distance.increment_f < 5.f) {
 				obstacle_distance.angle_offset = sensor_orientation;
 				upper_bound  = abs(upper_bound - lower_bound);
 				lower_bound  = 0;
@@ -199,6 +200,11 @@ void CollisionPrevention::_updateDistanceSensor(obstacle_distance_s &obstacle_di
 				if (wrap_bin < 0) {
 					// wrap bin index around the array
 					wrap_bin = (int)floor(360.f / obstacle_distance.increment_f) + bin;
+				}
+
+				if (wrap_bin >= distances_array_size) {
+					// wrap bin index around the array
+					wrap_bin = bin - distances_array_size;
 				}
 
 				// compensate measurement for vehicle tilt and convert to cm

--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -157,7 +157,8 @@ obstacle_distance_s CollisionPrevention::update_distance_sensor()
 			}
 
 			// convert the sensor orientation from body to local frame
-			float sensor_orientation = math::degrees(wrap_pi(_yaw + offset));
+			float sensor_orientation = math::degrees(wrap_pi(matrix::Eulerf(matrix::Quatf(_sub_vehicle_attitude->get().q)).psi() +
+						   offset));
 
 			// convert orientation from range [-180, 180] to [0, 360]
 			if ((sensor_orientation <= FLT_EPSILON) || (sensor_orientation >= 180.0f)) {
@@ -220,9 +221,8 @@ void CollisionPrevention::update_range_constraints()
 	}
 }
 
-void CollisionPrevention::modifySetpoint(Vector2f &original_setpoint, const float max_speed, const float yaw)
+void CollisionPrevention::modifySetpoint(Vector2f &original_setpoint, const float max_speed)
 {
-	_yaw = yaw;
 	reset_constraints();
 
 	//calculate movement constraints based on range data

--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -156,10 +156,10 @@ obstacle_distance_s CollisionPrevention::update_distance_sensor()
 				break;
 			}
 
-			// covert the sensor orientation from body to local frame
+			// convert the sensor orientation from body to local frame
 			float sensor_orientation = math::degrees(wrap_pi(_yaw + offset));
 
-			// covert orientation from range [-180, 180] to [0, 360]
+			// convert orientation from range [-180, 180] to [0, 360]
 			if ((sensor_orientation <= FLT_EPSILON) || (sensor_orientation >= 180.0f)) {
 				sensor_orientation += 360.0f;
 			}

--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -79,7 +79,7 @@ bool CollisionPrevention::initializeSubscriptions(SubscriptionArray &subscriptio
 	return true;
 }
 
-void CollisionPrevention::reset_constraints()
+void CollisionPrevention::_resetConstraints()
 {
 
 	_move_constraints_x_normalized.zero();  //normalized constraint in x-direction
@@ -89,7 +89,7 @@ void CollisionPrevention::reset_constraints()
 	_move_constraints_y.zero();  //constraint in y-direction
 }
 
-void CollisionPrevention::publish_constraints(const Vector2f &original_setpoint, const Vector2f &adapted_setpoint)
+void CollisionPrevention::_publishConstraints(const Vector2f &original_setpoint, const Vector2f &adapted_setpoint)
 {
 
 	collision_constraints_s	constraints;	/**< collision constraints message */
@@ -115,7 +115,7 @@ void CollisionPrevention::publish_constraints(const Vector2f &original_setpoint,
 	}
 }
 
-void CollisionPrevention::update_distance_sensor(obstacle_distance_s &obstacle_distance)
+void CollisionPrevention::_updateDistanceSensor(obstacle_distance_s &obstacle_distance)
 {
 
 	for (unsigned i = 0; i < ORB_MULTI_MAX_INSTANCES; i++) {
@@ -176,14 +176,14 @@ void CollisionPrevention::update_distance_sensor(obstacle_distance_s &obstacle_d
 
 }
 
-void CollisionPrevention::update_range_constraints()
+void CollisionPrevention::_updateRangeConstraints()
 {
 	const obstacle_distance_s &obstacle_distance = _sub_obstacle_distance->get();
 	obstacle_distance_s distance_data = obstacle_distance;
 
 	// if there aren't distance data from offboard on obstacle_distance, check for onboard sensors on distance_sensor
 	if (!_sub_obstacle_distance->updated()) {
-		update_distance_sensor(distance_data);
+		_updateDistanceSensor(distance_data);
 	}
 
 	if (hrt_elapsed_time(&distance_data.timestamp) < RANGE_STREAM_TIMEOUT_US) {
@@ -222,10 +222,10 @@ void CollisionPrevention::update_range_constraints()
 
 void CollisionPrevention::modifySetpoint(Vector2f &original_setpoint, const float max_speed)
 {
-	reset_constraints();
+	_resetConstraints();
 
 	//calculate movement constraints based on range data
-	update_range_constraints();
+	_updateRangeConstraints();
 
 	//clamp constraints to be in [0,1]. Constraints > 1 occur if the vehicle is closer than _param_mpc_col_prev_d to the obstacle.
 	//they would lead to the vehicle being pushed back from the obstacle which we do not yet support
@@ -257,6 +257,6 @@ void CollisionPrevention::modifySetpoint(Vector2f &original_setpoint, const floa
 
 	_interfering = currently_interfering;
 
-	publish_constraints(original_setpoint, new_setpoint);
+	_publishConstraints(original_setpoint, new_setpoint);
 	original_setpoint = new_setpoint;
 }

--- a/src/lib/CollisionPrevention/CollisionPrevention.hpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.hpp
@@ -106,6 +106,6 @@ private:
 
 	void publish_constraints(const matrix::Vector2f &original_setpoint, const matrix::Vector2f &adapted_setpoint);
 
-	void update_distance_sensor(obstacle_distance_s &obstacle_distance);
+	obstacle_distance_s update_distance_sensor();
 
 };

--- a/src/lib/CollisionPrevention/CollisionPrevention.hpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.hpp
@@ -106,6 +106,6 @@ private:
 
 	void publish_constraints(const matrix::Vector2f &original_setpoint, const matrix::Vector2f &adapted_setpoint);
 
-	obstacle_distance_s update_distance_sensor();
+	void update_distance_sensor(obstacle_distance_s &obstacle_distance);
 
 };

--- a/src/lib/CollisionPrevention/CollisionPrevention.hpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.hpp
@@ -70,7 +70,7 @@ public:
 
 	bool is_active() { return _param_mpc_col_prev_d.get() > 0; }
 
-	void modifySetpoint(matrix::Vector2f &original_setpoint, const float max_speed, const float yaw);
+	void modifySetpoint(matrix::Vector2f &original_setpoint, const float max_speed);
 
 private:
 
@@ -93,8 +93,6 @@ private:
 	matrix::Vector2f _move_constraints_y_normalized;
 	matrix::Vector2f _move_constraints_x;
 	matrix::Vector2f _move_constraints_y;
-
-	float _yaw;
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MPC_COL_PREV_D>) _param_mpc_col_prev_d /**< collision prevention keep minimum distance */

--- a/src/lib/CollisionPrevention/CollisionPrevention.hpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.hpp
@@ -68,7 +68,7 @@ public:
 	 */
 	bool initializeSubscriptions(SubscriptionArray &subscription_array);
 
-	bool is_active() { return _param_mpc_col_prev_d.get() > 0; }
+	bool isActive() { return _param_mpc_col_prev_d.get() > 0; }
 
 	void modifySetpoint(matrix::Vector2f &original_setpoint, const float max_speed);
 
@@ -98,14 +98,13 @@ private:
 		(ParamFloat<px4::params::MPC_COL_PREV_D>) _param_mpc_col_prev_d /**< collision prevention keep minimum distance */
 	)
 
-	void update();
+	void _updateRangeConstraints();
 
-	void update_range_constraints();
+	void _resetConstraints();
 
-	void reset_constraints();
+	void _publishConstraints(const matrix::Vector2f &original_setpoint, const matrix::Vector2f &adapted_setpoint);
 
-	void publish_constraints(const matrix::Vector2f &original_setpoint, const matrix::Vector2f &adapted_setpoint);
+	void _updateDistanceSensor(obstacle_distance_s &obstacle_distance);
 
-	void update_distance_sensor(obstacle_distance_s &obstacle_distance);
 
 };

--- a/src/lib/CollisionPrevention/CollisionPrevention.hpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.hpp
@@ -79,9 +79,9 @@ private:
 	orb_advert_t _constraints_pub{nullptr};		/**< constraints publication */
 	orb_advert_t _mavlink_log_pub{nullptr};	 	/**< Mavlink log uORB handle */
 
-	uORB::Subscription<obstacle_distance_s> *_sub_obstacle_distance{nullptr}; /**< obstacle distances received form offboard */
+	uORB::Subscription<obstacle_distance_s> *_sub_obstacle_distance{nullptr}; /**< obstacle distances received from offboard */
 	uORB::Subscription<distance_sensor_s>
-	*_sub_distance_sensor[ORB_MULTI_MAX_INSTANCES]; /**< distance sensor data received form onboard */
+	*_sub_distance_sensor[ORB_MULTI_MAX_INSTANCES]; /**< distance sensor data received from onboard */
 	uORB::Subscription<vehicle_attitude_s> *_sub_vehicle_attitude{nullptr}; /**< vehicle attitude subscription */
 
 	static constexpr uint64_t RANGE_STREAM_TIMEOUT_US = 500000;

--- a/src/lib/CollisionPrevention/CollisionPrevention.hpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.hpp
@@ -46,6 +46,7 @@
 #include <matrix/matrix/math.hpp>
 #include <uORB/topics/obstacle_distance.h>
 #include <uORB/topics/collision_constraints.h>
+#include <uORB/topics/distance_sensor.h>
 #include <mathlib/mathlib.h>
 #include <drivers/drv_hrt.h>
 #include <uORB/topics/mavlink_log.h>
@@ -68,7 +69,7 @@ public:
 
 	bool is_active() { return _param_mpc_col_prev_d.get() > 0; }
 
-	void modifySetpoint(matrix::Vector2f &original_setpoint, const float max_speed);
+	void modifySetpoint(matrix::Vector2f &original_setpoint, const float max_speed, const float yaw);
 
 private:
 
@@ -78,6 +79,8 @@ private:
 	orb_advert_t _mavlink_log_pub{nullptr};	 	/**< Mavlink log uORB handle */
 
 	uORB::Subscription<obstacle_distance_s> *_sub_obstacle_distance{nullptr}; /**< obstacle distances received form a range sensor */
+	uORB::Subscription<distance_sensor_s> *_sub_distance_sensor[ORB_MULTI_MAX_INSTANCES];
+
 
 	static constexpr uint64_t RANGE_STREAM_TIMEOUT_US = 500000;
 	static constexpr uint64_t MESSAGE_THROTTLE_US = 5000000;
@@ -88,6 +91,8 @@ private:
 	matrix::Vector2f _move_constraints_y_normalized;
 	matrix::Vector2f _move_constraints_x;
 	matrix::Vector2f _move_constraints_y;
+
+	float _yaw;
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MPC_COL_PREV_D>) _param_mpc_col_prev_d /**< collision prevention keep minimum distance */
@@ -100,5 +105,7 @@ private:
 	void reset_constraints();
 
 	void publish_constraints(const matrix::Vector2f &original_setpoint, const matrix::Vector2f &adapted_setpoint);
+
+	void update_distance_sensor(obstacle_distance_s &obstacle_distance);
 
 };

--- a/src/lib/CollisionPrevention/CollisionPrevention.hpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.hpp
@@ -47,6 +47,7 @@
 #include <uORB/topics/obstacle_distance.h>
 #include <uORB/topics/collision_constraints.h>
 #include <uORB/topics/distance_sensor.h>
+#include <uORB/topics/vehicle_attitude.h>
 #include <mathlib/mathlib.h>
 #include <drivers/drv_hrt.h>
 #include <uORB/topics/mavlink_log.h>
@@ -78,9 +79,10 @@ private:
 	orb_advert_t _constraints_pub{nullptr};		/**< constraints publication */
 	orb_advert_t _mavlink_log_pub{nullptr};	 	/**< Mavlink log uORB handle */
 
-	uORB::Subscription<obstacle_distance_s> *_sub_obstacle_distance{nullptr}; /**< obstacle distances received form a range sensor */
-	uORB::Subscription<distance_sensor_s> *_sub_distance_sensor[ORB_MULTI_MAX_INSTANCES];
-
+	uORB::Subscription<obstacle_distance_s> *_sub_obstacle_distance{nullptr}; /**< obstacle distances received form offboard */
+	uORB::Subscription<distance_sensor_s>
+	*_sub_distance_sensor[ORB_MULTI_MAX_INSTANCES]; /**< distance sensor data received form onboard */
+	uORB::Subscription<vehicle_attitude_s> *_sub_vehicle_attitude{nullptr}; /**< vehicle attitude subscription */
 
 	static constexpr uint64_t RANGE_STREAM_TIMEOUT_US = 500000;
 	static constexpr uint64_t MESSAGE_THROTTLE_US = 5000000;

--- a/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -133,7 +133,7 @@ void FlightTaskManualPosition::_scaleSticks()
 	_rotateIntoHeadingFrame(vel_sp_xy);
 
 	// collision prevention
-	if (_collision_prevention.is_active()) {
+	if (_collision_prevention.isActive()) {
 		_collision_prevention.modifySetpoint(vel_sp_xy, _constraints.speed_xy);
 	}
 

--- a/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -134,7 +134,7 @@ void FlightTaskManualPosition::_scaleSticks()
 
 	// collision prevention
 	if (_collision_prevention.is_active()) {
-		_collision_prevention.modifySetpoint(vel_sp_xy, _constraints.speed_xy, _yaw);
+		_collision_prevention.modifySetpoint(vel_sp_xy, _constraints.speed_xy);
 	}
 
 	_velocity_setpoint(0) = vel_sp_xy(0);

--- a/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -134,7 +134,7 @@ void FlightTaskManualPosition::_scaleSticks()
 
 	// collision prevention
 	if (_collision_prevention.is_active()) {
-		_collision_prevention.modifySetpoint(vel_sp_xy, _velocity_scale);
+		_collision_prevention.modifySetpoint(vel_sp_xy, _constraints.speed_xy, _yaw);
 	}
 
 	_velocity_setpoint(0) = vel_sp_xy(0);

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -1237,6 +1237,13 @@ int Simulator::publish_distance_topic(const mavlink_distance_sensor_t *dist_mavl
 	dist.variance = dist_mavlink->covariance * 1e-4f; // cm^2 to m^2
 	dist.signal_quality = -1;
 
+	dist.h_fov = dist_mavlink->h_fov;
+	dist.v_fov = dist_mavlink->v_fov;
+	dist.q[0] = dist_mavlink->q[0];
+	dist.q[1] = dist_mavlink->q[1];
+	dist.q[2] = dist_mavlink->q[2];
+	dist.q[3] = dist_mavlink->q[3];
+
 	int dist_multi;
 	orb_publish_auto(ORB_ID(distance_sensor), &_dist_pub, &dist, &dist_multi, ORB_PRIO_HIGH);
 

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -1237,12 +1237,12 @@ int Simulator::publish_distance_topic(const mavlink_distance_sensor_t *dist_mavl
 	dist.variance = dist_mavlink->covariance * 1e-4f; // cm^2 to m^2
 	dist.signal_quality = -1;
 
-	dist.h_fov = dist_mavlink->h_fov;
-	dist.v_fov = dist_mavlink->v_fov;
-	dist.q[0] = dist_mavlink->q[0];
-	dist.q[1] = dist_mavlink->q[1];
-	dist.q[2] = dist_mavlink->q[2];
-	dist.q[3] = dist_mavlink->q[3];
+	dist.h_fov = dist_mavlink->horizontal_fov;
+	dist.v_fov = dist_mavlink->vertical_fov;
+	dist.q[0] = dist_mavlink->quaternion[0];
+	dist.q[1] = dist_mavlink->quaternion[1];
+	dist.q[2] = dist_mavlink->quaternion[2];
+	dist.q[3] = dist_mavlink->quaternion[3];
 
 	int dist_multi;
 	orb_publish_auto(ORB_ID(distance_sensor), &_dist_pub, &dist, &dist_multi, ORB_PRIO_HIGH);


### PR DESCRIPTION
**Test data / coverage**
SITL with typhoon_h480 sonar sensor

**Describe problem solved by the proposed pull request**
The CollisionPreventation library works up to this PR with the obstacle distance message. `obstacle_distance` isn't published anywhere in the Firmware but only by the local_planner avoidance algorithm running on a companion computer. This PR maps `distance_sensor` measurements to `obstacle_distance` such has it's possible to directly use the distance sensors supported by PX4. 

Side Note: The PR would support using multiple distance sensors but I think this isn't yet supported by PX4.

Furthermore, it's a bit annoying that the orientation field in `distance_sensor` is an enum. It would be nice to work directly with angles and be able to specify all kinds of orientations (not only forward, left, right, bottom, up, and a generic others). But that would require an extension of the mavlink message as well so I guess it isn't that easy. 

TODO:
- for sonars, map measurement to more bins (or increase bin size) depending on cone width