### PR TITLE
Fix snapdragon build

### DIFF
--- a/boards/atlflight/eagle/CMakeLists.txt
+++ b/boards/atlflight/eagle/CMakeLists.txt
@@ -42,8 +42,8 @@ if("${PX4_PLATFORM}" MATCHES "qurt")
 
 	add_custom_target(upload
 		COMMAND
-			${PX4_SOURCE_DIR}/Tools/adb_upload.sh
-				${CMAKE_CURRENT_BINARY_DIR}/libpx4.so ${CMAKE_CURRENT_BINARY_DIR}/libpx4muorb_skel.so ${PX4_SOURCE_DIR}/posix-configs/eagle/flight/px4.config	# source
+			${CMAKE_CURRENT_SOURCE_DIR}/scripts/adb_upload.sh
+				${PX4_BINARY_DIR}/platforms/qurt/libpx4.so ${PX4_BINARY_DIR}/platforms/qurt/libpx4muorb_skel.so ${PX4_SOURCE_DIR}/posix-configs/eagle/flight/px4.config	# source
 				/usr/share/data/adsp	# destination
 		DEPENDS px4 px4muorb_skel
 		COMMENT "uploading px4"
@@ -55,7 +55,7 @@ else()
 	add_custom_target(upload
 		COMMAND
 			${CMAKE_CURRENT_SOURCE_DIR}/scripts/adb_upload.sh
-				${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${PX4_SOURCE_DIR}/posix-configs/eagle/flight/mainapp.config # source
+				${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/bin ${PX4_SOURCE_DIR}/posix-configs/eagle/flight/mainapp.config # source
 				/home/linaro	# destination
 		DEPENDS px4
 		COMMENT "uploading px4"

--- a/boards/atlflight/eagle/qurt-default.cmake
+++ b/boards/atlflight/eagle/qurt-default.cmake
@@ -10,7 +10,6 @@ if (DEFINED ENV{QC_SOC_TARGET})
 else()
 	set(QC_SOC_TARGET "APQ8074")
 endif()
-add_definitions(-D__PX4_QURT_EAGLE_${QC_SOC_TARGET})
 
 include(px4_git)
 px4_add_git_submodule(TARGET git_cmake_hexagon PATH "${PX4_SOURCE_DIR}/boards/atlflight/cmake_hexagon")

--- a/boards/atlflight/eagle/qurt-default.cmake
+++ b/boards/atlflight/eagle/qurt-default.cmake
@@ -10,6 +10,7 @@ if (DEFINED ENV{QC_SOC_TARGET})
 else()
 	set(QC_SOC_TARGET "APQ8074")
 endif()
+add_definitions(-D__PX4_QURT_EAGLE_${QC_SOC_TARGET})
 
 include(px4_git)
 px4_add_git_submodule(TARGET git_cmake_hexagon PATH "${PX4_SOURCE_DIR}/boards/atlflight/cmake_hexagon")

--- a/cmake/px4_add_board.cmake
+++ b/cmake/px4_add_board.cmake
@@ -261,7 +261,7 @@ function(px4_add_board)
 		foreach(driver ${DF_DRIVERS})
 			list(APPEND config_df_driver_list ${driver})
 
-			if(EXISTS "${PX4_SOUCE_DIR}/platforms/posix/drivers/df_${driver}_wrapper")
+			if(EXISTS "${PX4_SOURCE_DIR}/src/platforms/posix/drivers/df_${driver}_wrapper")
 				list(APPEND config_module_list platforms/posix/drivers/df_${driver}_wrapper)
 			endif()
 		endforeach()

--- a/platforms/posix/src/px4_layer/shmem_posix.cpp
+++ b/platforms/posix/src/px4_layer/shmem_posix.cpp
@@ -54,10 +54,8 @@
 #include "px4muorb.h"
 
 //#define SHMEM_DEBUG
-void update_to_shmem(param_t param, union param_value_u value);
-int update_from_shmem(param_t param, union param_value_u *value);
-void update_index_from_shmem(void);
-uint64_t update_from_shmem_prev_time = 0, update_from_shmem_current_time = 0;
+
+static uint64_t update_from_shmem_prev_time = 0, update_from_shmem_current_time = 0;
 extern unsigned char *adsp_changed_index;
 
 struct param_wbuf_s {

--- a/platforms/qurt/src/px4_layer/qurt_stubs.c
+++ b/platforms/qurt/src/px4_layer/qurt_stubs.c
@@ -118,3 +118,42 @@ void __cxa_pure_virtual()
 	PX4_WARN("Error: Calling unresolved symbol stub[%s]", __FUNCTION__);
 	block_indefinite();
 }
+
+#ifdef __PX4_QURT_EAGLE_APQ8074
+
+float _Stof(const char *p0, char **p1, long p2)
+{
+	PX4_WARN("Error: Calling unresolved symbol stub[%s]", __FUNCTION__);
+	block_indefinite();
+	return 0;
+}
+
+void *bsearch(const void *key, const void *ptr, size_t count, size_t size, int (*comp)(const void *, const void *))
+{
+	const char *first = (const char *)ptr;
+
+	while (count > 1) {
+		size_t m = count / 2;
+		const char *middle_element = first + m * size;
+		int cmp_res = comp(middle_element, key);
+
+		if (cmp_res > 0) {
+			count = m;
+
+		} else if (cmp_res == 0) {
+			return (void *)middle_element;
+
+		} else {
+			first = middle_element + size;
+			count = count - m - 1;
+		}
+	}
+
+	if (count && comp(first, key) == 0) {
+		return (void *)first;
+	}
+
+	return NULL;
+}
+
+#endif

--- a/platforms/qurt/src/px4_layer/qurt_stubs.c
+++ b/platforms/qurt/src/px4_layer/qurt_stubs.c
@@ -119,8 +119,6 @@ void __cxa_pure_virtual()
 	block_indefinite();
 }
 
-#ifdef __PX4_QURT_EAGLE_APQ8074
-
 float _Stof(const char *p0, char **p1, long p2)
 {
 	PX4_WARN("Error: Calling unresolved symbol stub[%s]", __FUNCTION__);
@@ -155,5 +153,3 @@ void *bsearch(const void *key, const void *ptr, size_t count, size_t size, int (
 
 	return NULL;
 }
-
-#endif

--- a/platforms/qurt/src/px4_layer/shmem_qurt.cpp
+++ b/platforms/qurt/src/px4_layer/shmem_qurt.cpp
@@ -51,18 +51,11 @@
 
 static atomic_word_t mem_lock;
 
-int mem_fd;
-unsigned char *map_base, *virt_addr;
-struct shmem_info *shmem_info_p;
-int get_shmem_lock(const char *caller_file_name, int caller_line_number);
-void release_shmem_lock(const char *caller_file_name, int caller_line_number);
-void init_shared_memory();
-void copy_params_to_shmem(param_info_s *);
-void update_to_shmem(param_t param, union param_value_u value);
-int update_from_shmem(param_t param, union param_value_u *value);
-void update_index_from_shmem();
-uint64_t update_from_shmem_prev_time = 0, update_from_shmem_current_time = 0;
+static unsigned char *map_base, *virt_addr;
+static uint64_t update_from_shmem_prev_time = 0, update_from_shmem_current_time = 0;
 static unsigned char krait_changed_index[MAX_SHMEM_PARAMS / 8 + 1];
+
+struct shmem_info *shmem_info_p;
 
 // Small helper to get log2 for ints
 static unsigned log2_for_int(unsigned v)

--- a/src/lib/parameters/parameters_shmem.cpp
+++ b/src/lib/parameters/parameters_shmem.cpp
@@ -120,24 +120,10 @@ int size_param_changed_storage_bytes = 0;
 const int bits_per_allocation_unit  = (sizeof(*param_changed_storage) * 8);
 
 //#define ENABLE_SHMEM_DEBUG
-
-extern int get_shmem_lock(const char *caller_file_name, int caller_line_number);
-extern void release_shmem_lock(const char *caller_file_name, int caller_line_number);
-
 static void init_params();
-extern void init_shared_memory();
-
-extern void copy_params_to_shmem(const param_info_s *param_info_base);
-
-extern struct shmem_info *shmem_info_p;
-uint64_t sync_other_prev_time = 0, sync_other_current_time = 0;
-
-extern void update_to_shmem(param_t param, union param_value_u value);
-extern int update_from_shmem(param_t param, union param_value_u *value);
-extern void update_index_from_shmem();
 
 static int param_set_internal(param_t param, const void *val, bool mark_saved, bool notify_changes);
-unsigned char set_called_from_get = 0;
+static unsigned char set_called_from_get = 0;
 
 static int param_import_done =
 	0; /*at startup, params are loaded from file, if present. we dont want to send notifications that time since muorb is not ready*/

--- a/src/lib/parameters/parameters_shmem.cpp
+++ b/src/lib/parameters/parameters_shmem.cpp
@@ -325,7 +325,7 @@ param_compare_values(const void *a, const void *b)
  * @return			The structure holding the modified value, or
  *				nullptr if the parameter has not been modified.
  */
-static param_wbuf_s *
+param_wbuf_s *
 param_find_changed(param_t param)
 {
 	param_wbuf_s	*s = nullptr;

--- a/src/modules/muorb/adsp/px4muorb.cpp
+++ b/src/modules/muorb/adsp/px4muorb.cpp
@@ -48,11 +48,12 @@
 __BEGIN_DECLS
 extern int dspal_main(int argc, char *argv[]);
 extern struct shmem_info *shmem_info_p;
+__END_DECLS
 extern int get_shmem_lock(const char *caller_file_name, int caller_line_number);
 extern void release_shmem_lock(const char *caller_file_name,
 			       int caller_line_number);
 extern void init_shared_memory(void);
-__END_DECLS
+
 int px4muorb_orb_initialize()
 {
 	HAP_power_request(100, 100, 1000);

--- a/src/modules/muorb/adsp/px4muorb.cpp
+++ b/src/modules/muorb/adsp/px4muorb.cpp
@@ -47,12 +47,7 @@
 
 __BEGIN_DECLS
 extern int dspal_main(int argc, char *argv[]);
-extern struct shmem_info *shmem_info_p;
 __END_DECLS
-extern int get_shmem_lock(const char *caller_file_name, int caller_line_number);
-extern void release_shmem_lock(const char *caller_file_name,
-			       int caller_line_number);
-extern void init_shared_memory(void);
 
 int px4muorb_orb_initialize()
 {

--- a/src/platforms/shmem.h
+++ b/src/platforms/shmem.h
@@ -33,6 +33,8 @@
 
 #pragma once
 
+#include <parameters/param.h>
+
 #define MAX_SHMEM_PARAMS 2000 //MAP_SIZE - (LOCK_SIZE - sizeof(struct shmem_info))
 
 #define PARAM_BUFFER_SIZE (MAX_SHMEM_PARAMS / 8 + 1)
@@ -64,3 +66,17 @@ struct shmem_info {
 #define TYPE_MASK 	0x1
 
 extern bool handle_in_range(param_t);
+
+#ifdef __PX4_QURT
+extern struct shmem_info *shmem_info_p;
+
+int get_shmem_lock(const char *caller_file_name, int caller_line_number);
+void release_shmem_lock(const char *caller_file_name, int caller_line_number);
+void init_shared_memory(void);
+
+void copy_params_to_shmem(const param_info_s *param_info_base);
+#endif
+
+void update_to_shmem(param_t param, union param_value_u value);
+int update_from_shmem(param_t param, union param_value_u *value);
+void update_index_from_shmem(void);


### PR DESCRIPTION
**Test data / coverage**
Basic systems starts and I get driver readings, tested with APQ8074. Further adjustments might be required for Excelsior/APQ8096.

**Describe problem solved by the proposed pull request**
See #9971

**Describe your preferred solution**
I am not too happy about 2ae83dd5457b85386104da134bc4bb4eb6dcdc4b, but it doesn't seem like much can be done without getting newer ADSP image. 
Someone familiar with parameter code should confirmt that sharing param_find_changed between parameters_shmem.cpp and shmem_qurt.cpp makes sense.
