### PR TITLE
Fix MAV_CMD_DO_REPOSITION

### DIFF
--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -328,7 +328,15 @@ Navigator::run()
 				rep->current.loiter_radius = get_loiter_radius();
 				rep->current.loiter_direction = 1;
 				rep->current.type = position_setpoint_s::SETPOINT_TYPE_LOITER;
-				rep->current.cruising_speed = get_cruising_speed();
+
+				// If no argument for ground speed, use default value.
+				if (cmd.param1 <= 0 || !PX4_ISFINITE(cmd.param1)) {
+					rep->current.cruising_speed = get_cruising_speed();
+
+				} else {
+					rep->current.cruising_speed = cmd.param1;
+				}
+
 				rep->current.cruising_throttle = get_cruising_throttle();
 				rep->current.acceptance_radius = get_acceptance_radius();
 


### PR DESCRIPTION
**MAV_CMD_DO_REPOSITION** now obeys the ground speed argument.
https://mavlink.io/en/messages/common.html#MAV_CMD_DO_REPOSITION
![selection_002](https://user-images.githubusercontent.com/37091262/49676692-f677ed00-fa37-11e8-9fc2-59dc3cd7fbdf.png)
