### PR TITLE
mc_att_control: don't generate attitude setpoint for tailsitters during transitions

### DIFF
--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -264,7 +264,9 @@ private:
 		(ParamFloat<px4::params::MPC_MANTHR_MIN>) _man_throttle_min,			/**< minimum throttle for stabilized */
 		(ParamFloat<px4::params::MPC_THR_MAX>) _throttle_max,				/**< maximum throttle for stabilized */
 		(ParamFloat<px4::params::MPC_THR_HOVER>) _throttle_hover,			/**< throttle at which vehicle is at hover equilibrium */
-		(ParamInt<px4::params::MPC_THR_CURVE>) _throttle_curve				/**< throttle curve behavior */
+		(ParamInt<px4::params::MPC_THR_CURVE>) _throttle_curve,				/**< throttle curve behavior */
+
+		(ParamInt<px4::params::VT_TYPE>) _vtol_type
 	)
 
 	matrix::Vector3f _attitude_p;		/**< P gain for attitude control */

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -51,6 +51,7 @@
 #include <circuit_breaker/circuit_breaker.h>
 #include <mathlib/math/Limits.hpp>
 #include <mathlib/math/Functions.hpp>
+#include <vtol_att_control/vtol_type.h>
 
 #define TPA_RATE_LOWER_LIMIT 0.05f
 
@@ -891,10 +892,12 @@ MulticopterAttitudeControl::run()
 			if (_v_control_mode.flag_control_attitude_enabled && _vehicle_status.is_rotary_wing) {
 				if (attitude_updated) {
 					// Generate the attitude setpoint from stick inputs if we are in Manual/Stabilized mode
+					// For Tailsitters doing transitions the attitude setpoint is generated in tailsitter.cpp
 					if (_v_control_mode.flag_control_manual_enabled &&
 							!_v_control_mode.flag_control_altitude_enabled &&
 							!_v_control_mode.flag_control_velocity_enabled &&
-							!_v_control_mode.flag_control_position_enabled) {
+							!_v_control_mode.flag_control_position_enabled &&
+							!(_vtol_type.get() == vtol_type::TAILSITTER && _vehicle_status.in_transition_mode)) {
 						generate_attitude_setpoint(attitude_dt, reset_yaw_sp);
 						attitude_setpoint_generated = true;
 					}


### PR DESCRIPTION
This regression most likely comes from PR #10805

Without this, transitions in manual / stabilized mode are broken. The vehicle does not react to the transition command as the mc attitude controller controls an attitude setpoint which it generates by itself.

Tested in SITL.

This bug was found by @VTOLDavid 

@VTOLDavid Can you test this and report back?

Signed-off-by: Roman <bapstroman@gmail.com>