### PR TITLE
Read test params from yaml file

### DIFF
--- a/integrationtests/tests/mission.yml
+++ b/integrationtests/tests/mission.yml
@@ -2,11 +2,10 @@
 
 
 simulation_setup:
-    maneuver: 'mission'
     world: 'iris'
     sim: 'gazebo'
     headless: True
     start_script: 'rcS'
 
-deactivate_tests: # All tests that are NOT listed here are started
-    - test_rtl
+deactivate_tests: # All tests listed here will NOT be run
+    # - test_rtl

--- a/integrationtests/tests/run_tests.py
+++ b/integrationtests/tests/run_tests.py
@@ -54,14 +54,13 @@ if __name__ == '__main__':
     config = yaml.load(yaml_file)
 
     deactivate_tests = config['deactivate_tests']
-
     simulation_setup = config['simulation_setup']
+
+    maneuver = simulation_setup['maneuver']
     world = simulation_setup['world']
     sim = simulation_setup['sim']
     headless = simulation_setup['headless']
     start_script = simulation_setup['start_script']
-
-    maneuver = 'mission'
 
     # path to px4-src directory
     px4_src_dir = args.px4dir

--- a/integrationtests/tests/run_tests.py
+++ b/integrationtests/tests/run_tests.py
@@ -10,6 +10,7 @@ import yaml
 
 parser = argparse.ArgumentParser(description='Runs maneuver, simulation and tests based on yaml file')
 parser.add_argument('px4dir', help='PX4 src directory')
+parser.add_argument('maneuver_name', help='Name of the maneuver that we want to start. Also: Name of the yaml file that belongs to the maneuver')
 
 class ProcessWrapper(mp.Process):
     def __init__(self, cmds, env=None):
@@ -49,14 +50,12 @@ if __name__ == '__main__':
     mp.set_start_method('fork')
 
     # read yaml
-    dir_path = os.path.dirname(__file__)
-    yaml_file = open(dir_path + "/test_config.yml", "r")
+    yaml_file = open(os.path.dirname(__file__) + '/' + args.maneuver_name + '.yml', 'r')
     config = yaml.load(yaml_file)
 
     deactivate_tests = config['deactivate_tests']
     simulation_setup = config['simulation_setup']
 
-    maneuver = simulation_setup['maneuver']
     world = simulation_setup['world']
     sim = simulation_setup['sim']
     headless = simulation_setup['headless']
@@ -67,7 +66,7 @@ if __name__ == '__main__':
 
     # define processes
     global p_maneuver, p_server, p_gui, p_px4
-    cmds = ['{0}/Tools/Maneuvers/build/maneuvers/{1}'.format(px4_src_dir, maneuver), 'udp://:14540']
+    cmds = ['{0}/Tools/Maneuvers/build/maneuvers/{1}'.format(px4_src_dir, args.maneuver_name), 'udp://:14540']
     p_maneuver = ProcessWrapper(cmds)
 
     cmds = ['gzserver', '{0}/Tools/sitl_gazebo/worlds/{1}.world'.format(px4_src_dir, world)]
@@ -116,6 +115,7 @@ if __name__ == '__main__':
     print("Simulation closed")
     p_px4.join()
     print("PX4 closed")
+
 
     ################
     ### log-Analysis

--- a/integrationtests/tests/test_config.yml
+++ b/integrationtests/tests/test_config.yml
@@ -2,6 +2,7 @@
 
 
 simulation_setup:
+    maneuver: 'mission'
     world: 'iris'
     sim: 'gazebo'
     headless: True

--- a/integrationtests/tests/test_config.yml
+++ b/integrationtests/tests/test_config.yml
@@ -1,0 +1,11 @@
+# Contains parameters that are needed to start simulation, maneuvers and tests
+
+
+simulation_setup:
+    world: 'iris'
+    sim: 'gazebo'
+    headless: True
+    start_script: 'rcS'
+
+deactivate_tests: # All tests that are NOT listed here are started
+    - test_rtl

--- a/integrationtests/tests/test_runner.sh
+++ b/integrationtests/tests/test_runner.sh
@@ -2,11 +2,12 @@
 
 set -e
 
+maneuver=$1 # The name of the maneuver that should be started is passed as the first argument
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 px4_dir=$( dirname $( dirname ${script_dir} ) )
 rootfs_test=${px4_dir}/build/px4_sitl_default/tmp/rootfs_test
 mkdir -p ${rootfs_test}
 pushd ${rootfs_test} > /dev/null
 source "${px4_dir}/Tools/setup_gazebo.bash" "${px4_dir}" "${px4_dir}/build/px4_sitl_default"
-${script_dir}/run_tests.py ${px4_dir}
+${script_dir}/run_tests.py ${px4_dir} ${maneuver}
 popd > /dev/null


### PR DESCRIPTION
The parameters used in the run_tests.py module are read from a yaml file. This config file contains simulation parameters and the names of the tests that should be excluded (they get deselected)

The names of the deselected tests are given as an argument to the general_tests file. 