### PR TITLE
rcS,rc.serial.jinja:ensure proper unset hygiene

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -498,6 +498,8 @@ unset PWM_MIN
 unset SDCARD_MIXERS_PATH
 unset USE_IO
 unset VEHICLE_TYPE
+unset BOARD_RC
+unset AUTOCNF
 
 #
 # Boot is complete, inform MAVLink app(s) that the system is now fully up and running.

--- a/Tools/serial/rc.serial.jinja
+++ b/Tools/serial/rc.serial.jinja
@@ -22,9 +22,13 @@ fi
 
 {% endfor %}
 
+{% for serial_device in serial_devices -%}
+unset PRT_{{ serial_device.tag }}_
+{% endfor %}
 unset i
 unset SERIAL_DEV
 unset PRT
 unset PRT_F
 unset BAUD_PARAM
+unset MAV_ARGS
 


### PR DESCRIPTION
@bkueng This PR ensures there are no vars left in the env. I was not sure about the lifecycle of the PRT_xxxx vars. Does this look OK to you?





