### PR TITLE
commander run preflight immediately

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1428,6 +1428,9 @@ Commander::run()
 
 	arm_auth_init(&mavlink_log_pub, &status.system_id);
 
+	// run preflight immediately to find all relevant parameters, but don't report
+	preflight_check(false);
+
 	while (!should_exit()) {
 
 		transition_result_t arming_ret = TRANSITION_NOT_CHANGED;


### PR DESCRIPTION
This is to make sure the preflight parameters are already found (param_find) before the initial mavlink parameter sync. When the parameters are marked active late it changes the param index used by mavlink.

Partially addresses #11017, but there's much more to do for a proper robust fix.

