### PR TITLE
fix for HIL

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -212,12 +212,22 @@ else
 		fi
 	fi
 
+	#
+	# Set parameters and env variables for selected AUTOSTART.
+	#
+	if ! param compare SYS_AUTOSTART 0
+	then
+		sh /etc/init.d/rc.autostart
+	fi
+
 	###############################################################################
 	#               Begin setup for board specific configurations.                #
 	###############################################################################
 
 	#
-	# run boards rc.board if available
+	# run boards rc.board if available.
+	# This comes after rc.autostart, so that rc.board can use parameters that
+	# are set in the frame-specific autoconf section.
 	#
 	if [ -f $BOARD_RC ]
 	then
@@ -235,14 +245,6 @@ else
 	fi
 
 	#
-	# Set parameters and env variables for selected AUTOSTART.
-	#
-	if ! param compare SYS_AUTOSTART 0
-	then
-		sh /etc/init.d/rc.autostart
-	fi
-
-	#
 	# Override parameters from user configuration file.
 	#
 	if [ -f $FCONFIG ]
@@ -252,7 +254,7 @@ else
 	fi
 
 	#
-	# If autoconfig parameter was set, reset it and save parameters.
+	# If autoconfig parameter was set, reset it.
 	#
 	if [ $AUTOCNF = yes ]
 	then
@@ -263,7 +265,6 @@ else
 	# Check if PX4IO present and update firmware if needed.
 	# Assumption IOFW set to firmware file and IO_PRESENT = no
 	#
-
 	if [ -f $IOFW ]
 	then
 		# Check for the mini using build with px4io fw file

--- a/boards/airmind/mindpx-v2/init/rc.board
+++ b/boards/airmind/mindpx-v2/init/rc.board
@@ -32,8 +32,6 @@ then
 	param set SYS_FMU_TASK 1
 fi
 
-set MIXER_AUX none
-
 
 # Start sensor drivers if not in HIL mode
 if param compare SYS_HITL 0

--- a/boards/airmind/mindpx-v2/init/rc.board
+++ b/boards/airmind/mindpx-v2/init/rc.board
@@ -35,15 +35,19 @@ fi
 set MIXER_AUX none
 
 
-# External I2C bus
-hmc5883 -C -T -X start
+# Start sensor drivers if not in HIL mode
+if param compare SYS_HITL 0
+then
+	# External I2C bus
+	hmc5883 -C -T -X start
 
-# Internal I2C bus
-hmc5883 -C -T -I -R 12 start
+	# Internal I2C bus
+	hmc5883 -C -T -I -R 12 start
 
-mpu6000 -s -R 8 start
-mpu9250 -s -R 8 start
-lsm303d -R 10 start
-l3gd20 -R 14 start
+	mpu6000 -s -R 8 start
+	mpu9250 -s -R 8 start
+	lsm303d -R 10 start
+	l3gd20 -R 14 start
 
-px4flow start &
+	px4flow start &
+fi

--- a/boards/atmel/same70xplained/init/rc.board
+++ b/boards/atmel/same70xplained/init/rc.board
@@ -10,8 +10,12 @@ then
 
 fi
 
-# External I2C bus
-hmc5883 -C -T -X start
+# Start sensor drivers if not in HIL mode
+if param compare SYS_HITL 0
+then
+	# External I2C bus
+	hmc5883 -C -T -X start
 
-# Internal SPI bus mpu9250 is rotated 90 deg yaw
-mpu9250 -R 2 start
+	# Internal SPI bus mpu9250 is rotated 90 deg yaw
+	mpu9250 -R 2 start
+fi

--- a/boards/auav/x21/init/rc.board
+++ b/boards/auav/x21/init/rc.board
@@ -24,18 +24,22 @@ then
 fi
 
 
-# External I2C bus
-hmc5883 -C -T -X start
-lis3mdl -X start
-ist8310 -C start
+# Start sensor drivers if not in HIL mode
+if param compare SYS_HITL 0
+then
+	# External I2C bus
+	hmc5883 -C -T -X start
+	lis3mdl -X start
+	ist8310 -C start
 
-# Internal SPI bus ICM-20608-G is rotated 90 deg yaw
-mpu6000 -R 2 -T 20608 start
+	# Internal SPI bus ICM-20608-G is rotated 90 deg yaw
+	mpu6000 -R 2 -T 20608 start
 
-# Internal SPI bus ICM-20602-G is rotated 90 deg yaw
-mpu6000 -R 2 -T 20602 start
+	# Internal SPI bus ICM-20602-G is rotated 90 deg yaw
+	mpu6000 -R 2 -T 20602 start
 
-# Internal SPI bus mpu9250 is rotated 90 deg yaw
-mpu9250 -R 2 start
+	# Internal SPI bus mpu9250 is rotated 90 deg yaw
+	mpu9250 -R 2 start
 
-px4flow start &
+	px4flow start &
+fi

--- a/boards/av/x-v1/init/rc.board
+++ b/boards/av/x-v1/init/rc.board
@@ -13,15 +13,19 @@ set LOGGER_BUF 64
 set MIXER_AUX none
 
 
-adis16477 -R 8 start
+# Start sensor drivers if not in HIL mode
+if param compare SYS_HITL 0
+then
+	adis16477 -R 8 start
 
-#adis16497 start
+	#adis16497 start
 
-lps22hb -S start
+	lps22hb -S start
 
-lsm303agr -R 4 start
+	lsm303agr -R 4 start
 
-ms4525_airspeed -T 4515 -b 3 start
+	ms4525_airspeed -T 4515 -b 3 start
+fi
 
 
 # AV-X: start MAVLink to companion (connected to TX2)

--- a/boards/av/x-v1/init/rc.board
+++ b/boards/av/x-v1/init/rc.board
@@ -10,7 +10,6 @@ then
 fi
 
 set LOGGER_BUF 64
-set MIXER_AUX none
 
 
 # Start sensor drivers if not in HIL mode

--- a/boards/bitcraze/crazyflie/init/rc.board
+++ b/boards/bitcraze/crazyflie/init/rc.board
@@ -18,12 +18,16 @@ fi
 
 set MIXER_AUX none
 
-# Onboard I2C
-mpu9250 -R 12 start
+# Start sensor drivers if not in HIL mode
+if param compare SYS_HITL 0
+then
+	# Onboard I2C
+	mpu9250 -R 12 start
 
-# I2C bypass of mpu
-lps25h start
+	# I2C bypass of mpu
+	lps25h start
 
-# Optical flow deck
-vl53lxx start
-pmw3901 start
+	# Optical flow deck
+	vl53lxx start
+	pmw3901 start
+fi

--- a/boards/bitcraze/crazyflie/init/rc.board
+++ b/boards/bitcraze/crazyflie/init/rc.board
@@ -16,8 +16,6 @@ then
 
 fi
 
-set MIXER_AUX none
-
 # Start sensor drivers if not in HIL mode
 if param compare SYS_HITL 0
 then

--- a/boards/gumstix/aerocore2/init/rc.board
+++ b/boards/gumstix/aerocore2/init/rc.board
@@ -14,7 +14,6 @@ then
 fi
 
 set DATAMAN_OPT "-f /fs/mtd_dataman"
-set MIXER_AUX none
 
 # Start sensor drivers if not in HIL mode
 if param compare SYS_HITL 0

--- a/boards/gumstix/aerocore2/init/rc.board
+++ b/boards/gumstix/aerocore2/init/rc.board
@@ -16,5 +16,9 @@ fi
 set DATAMAN_OPT "-f /fs/mtd_dataman"
 set MIXER_AUX none
 
-l3gd20 -R 12 start
-lsm303d start
+# Start sensor drivers if not in HIL mode
+if param compare SYS_HITL 0
+then
+	l3gd20 -R 12 start
+	lsm303d start
+fi

--- a/boards/intel/aerofc-v1/init/rc.board
+++ b/boards/intel/aerofc-v1/init/rc.board
@@ -35,13 +35,17 @@ set LOGGER_ARGS "-m mavlink"
 set MIXER_AUX none
 
 
-ms5611 -T 0 start
-mpu9250 -s -R 14 start
+# Start sensor drivers if not in HIL mode
+if param compare SYS_HITL 0
+then
+	ms5611 -T 0 start
+	mpu9250 -s -R 14 start
 
-# Possible external compasses
-hmc5883 -X start
+	# Possible external compasses
+	hmc5883 -X start
 
-ist8310 -C -b 1 -R 4 start
-aerofc_adc start
+	ist8310 -C -b 1 -R 4 start
+	aerofc_adc start
 
-ll40ls start i2c
+	ll40ls start i2c
+fi

--- a/boards/intel/aerofc-v1/init/rc.board
+++ b/boards/intel/aerofc-v1/init/rc.board
@@ -32,7 +32,6 @@ fi
 
 set DATAMAN_OPT -i
 set LOGGER_ARGS "-m mavlink"
-set MIXER_AUX none
 
 
 # Start sensor drivers if not in HIL mode

--- a/boards/nxp/fmuk66-v3/init/rc.board
+++ b/boards/nxp/fmuk66-v3/init/rc.board
@@ -23,20 +23,24 @@ fi
 
 set MIXER_AUX none
 
-# External I2C bus
-hmc5883 -C -X start
+# Start sensor drivers if not in HIL mode
+if param compare SYS_HITL 0
+then
+	# External I2C bus
+	hmc5883 -C -X start
 
-# Possible external compasses
-ist8310 -C -b 2 start
+	# Possible external compasses
+	ist8310 -C -b 2 start
 
-# External I2C bus
-lis3mdl -X start
+	# External I2C bus
+	lis3mdl -X start
 
-# Onboard I2C (baro) but an external bus on V3 RC15
-mpl3115a2 -X start
+	# Onboard I2C (baro) but an external bus on V3 RC15
+	mpl3115a2 -X start
 
-# Internal SPI (accel + mag)
-fxos8701cq start -R 0
+	# Internal SPI (accel + mag)
+	fxos8701cq start -R 0
 
-# Internal SPI (gyro)
-fxas21002c start -R 0
+	# Internal SPI (gyro)
+	fxas21002c start -R 0
+fi

--- a/boards/nxp/fmuk66-v3/init/rc.board
+++ b/boards/nxp/fmuk66-v3/init/rc.board
@@ -21,8 +21,6 @@ then
 	param set SYS_FMU_TASK 1
 fi
 
-set MIXER_AUX none
-
 # Start sensor drivers if not in HIL mode
 if param compare SYS_HITL 0
 then

--- a/boards/omnibus/f4sd/init/rc.board
+++ b/boards/omnibus/f4sd/init/rc.board
@@ -32,18 +32,22 @@ fi
 set MIXER_AUX none
 
 
-if ! mpu6000 -R 12 -s start
+# Start sensor drivers if not in HIL mode
+if param compare SYS_HITL 0
 then
-	# some boards such as the Hobbywing XRotor F4 G2 use the ICM-20602
-	mpu6000 -R 12 -T 20602 -s start
+	if ! mpu6000 -R 12 -s start
+	then
+		# some boards such as the Hobbywing XRotor F4 G2 use the ICM-20602
+		mpu6000 -R 12 -T 20602 -s start
+	fi
+
+	# Possible external compasses
+	hmc5883 -X start
+
+	bmp280 start
+
+	adc start
+
+
+	px4flow start &
 fi
-
-# Possible external compasses
-hmc5883 -X start
-
-bmp280 start
-
-adc start
-
-
-px4flow start &

--- a/boards/omnibus/f4sd/init/rc.board
+++ b/boards/omnibus/f4sd/init/rc.board
@@ -29,8 +29,6 @@ then
 	param set SYS_FMU_TASK 1
 fi
 
-set MIXER_AUX none
-
 
 # Start sensor drivers if not in HIL mode
 if param compare SYS_HITL 0

--- a/boards/px4/fmu-v2/init/rc.board
+++ b/boards/px4/fmu-v2/init/rc.board
@@ -41,101 +41,105 @@ then
 fi
 
 
-# External I2C bus
-hmc5883 -C -T -X start
-lis3mdl -X start
-ist8310 -C start
-
-# Internal I2C bus
-hmc5883 -C -T -I -R 4 start
-
-# Internal SPI bus ICM-20608-G
-mpu6000 -T 20608 start
-
-set BOARD_FMUV3 0
-
-# V3 build hwtypecmp supports V2|V2M|V30
-if ver hwtypecmp V30
+# Start sensor drivers if not in HIL mode
+if param compare SYS_HITL 0
 then
-	# Check for Pixhawk 2.0 cube
-	# external MPU6K is rotated 180 degrees yaw
-	if mpu6000 -S -R 4 start
-	then
-		set BOARD_FMUV3 20
-	else
-		# Check for Pixhawk 2.1 cube
-		# external MPU9250 is rotated 180 degrees yaw
-		if mpu9250 -S -R 4 start
-		then
-			set BOARD_FMUV3 21
-		fi
-	fi
-fi
+	# External I2C bus
+	hmc5883 -C -T -X start
+	lis3mdl -X start
+	ist8310 -C start
 
-# Check if a Pixhack (which reports as V2M) is present
-if ver hwtypecmp V2M
-then
-	# Pixhawk Mini doesn't have these sensors,
-	# so if they are found we know its a Pixhack
+	# Internal I2C bus
+	hmc5883 -C -T -I -R 4 start
 
-	# external MPU6K is rotated 180 degrees yaw
-	if mpu6000 -S -R 4 start
-	then
-		set BOARD_FMUV3 20
-	else
-		# Check for Pixhack 3.1
-		# external MPU9250 is rotated 180 degrees yaw
-		if mpu9250 -S -R 4 start
-		then
-			set BOARD_FMUV3 21
-		fi
-	fi
-fi
+	# Internal SPI bus ICM-20608-G
+	mpu6000 -T 20608 start
 
-if [ $BOARD_FMUV3 != 0 ]
-then
-	# sensor heating is available, but we disable it for now
-	param set SENS_EN_THERMAL 0
+	set BOARD_FMUV3 0
 
-	# external L3GD20H is rotated 180 degrees yaw
-	l3gd20 -X -R 4 start
-
-	# external LSM303D is rotated 270 degrees yaw
-	lsm303d -X -R 6 start
-
-	if [ $BOARD_FMUV3 = 20 ]
-	then
-		# v2.0 internal MPU6000 is rotated 180 deg roll, 270 deg yaw
-		mpu6000 -R 14 start
-
-		# v2.0 Has internal hmc5883 on SPI1
-		hmc5883 -C -T -S -R 8 start
-	fi
-
-	if [ $BOARD_FMUV3 = 21 ]
-	then
-		# v2.1 internal MPU9250 is rotated 180 deg roll, 270 deg yaw
-		mpu9250 -R 14 start
-	fi
-
-else
-	# $BOARD_FMUV3 = 0 -> FMUv2
-
-	mpu6000 start
-
-	# As we will use the external mag and the ICM-20608-G
-	# V2 build hwtypecmp is always false
 	# V3 build hwtypecmp supports V2|V2M|V30
-	if ! ver hwtypecmp V2M
+	if ver hwtypecmp V30
 	then
-		mpu9250 start
-	# else: On the PixhawkMini the mpu9250 has been disabled due to HW errata
+		# Check for Pixhawk 2.0 cube
+		# external MPU6K is rotated 180 degrees yaw
+		if mpu6000 -S -R 4 start
+		then
+			set BOARD_FMUV3 20
+		else
+			# Check for Pixhawk 2.1 cube
+			# external MPU9250 is rotated 180 degrees yaw
+			if mpu9250 -S -R 4 start
+			then
+				set BOARD_FMUV3 21
+			fi
+		fi
 	fi
 
-	l3gd20 start
-	lsm303d start
-fi
+	# Check if a Pixhack (which reports as V2M) is present
+	if ver hwtypecmp V2M
+	then
+		# Pixhawk Mini doesn't have these sensors,
+		# so if they are found we know its a Pixhack
 
-px4flow start &
+		# external MPU6K is rotated 180 degrees yaw
+		if mpu6000 -S -R 4 start
+		then
+			set BOARD_FMUV3 20
+		else
+			# Check for Pixhack 3.1
+			# external MPU9250 is rotated 180 degrees yaw
+			if mpu9250 -S -R 4 start
+			then
+				set BOARD_FMUV3 21
+			fi
+		fi
+	fi
+
+	if [ $BOARD_FMUV3 != 0 ]
+	then
+		# sensor heating is available, but we disable it for now
+		param set SENS_EN_THERMAL 0
+
+		# external L3GD20H is rotated 180 degrees yaw
+		l3gd20 -X -R 4 start
+
+		# external LSM303D is rotated 270 degrees yaw
+		lsm303d -X -R 6 start
+
+		if [ $BOARD_FMUV3 = 20 ]
+		then
+			# v2.0 internal MPU6000 is rotated 180 deg roll, 270 deg yaw
+			mpu6000 -R 14 start
+
+			# v2.0 Has internal hmc5883 on SPI1
+			hmc5883 -C -T -S -R 8 start
+		fi
+
+		if [ $BOARD_FMUV3 = 21 ]
+		then
+			# v2.1 internal MPU9250 is rotated 180 deg roll, 270 deg yaw
+			mpu9250 -R 14 start
+		fi
+
+	else
+		# $BOARD_FMUV3 = 0 -> FMUv2
+
+		mpu6000 start
+
+		# As we will use the external mag and the ICM-20608-G
+		# V2 build hwtypecmp is always false
+		# V3 build hwtypecmp supports V2|V2M|V30
+		if ! ver hwtypecmp V2M
+		then
+			mpu9250 start
+		# else: On the PixhawkMini the mpu9250 has been disabled due to HW errata
+		fi
+
+		l3gd20 start
+		lsm303d start
+	fi
+
+	px4flow start &
+fi
 
 unset BOARD_FMUV3

--- a/boards/px4/fmu-v3/init/rc.board
+++ b/boards/px4/fmu-v3/init/rc.board
@@ -42,101 +42,105 @@ then
 fi
 
 
-# External I2C bus
-hmc5883 -C -T -X start
-lis3mdl -X start
-ist8310 -C start
-
-# Internal I2C bus
-hmc5883 -C -T -I -R 4 start
-
-# Internal SPI bus ICM-20608-G
-mpu6000 -T 20608 start
-
-set BOARD_FMUV3 0
-
-# V3 build hwtypecmp supports V2|V2M|V30
-if ver hwtypecmp V30
+# Start sensor drivers if not in HIL mode
+if param compare SYS_HITL 0
 then
-	# Check for Pixhawk 2.0 cube
-	# external MPU6K is rotated 180 degrees yaw
-	if mpu6000 -S -R 4 start
-	then
-		set BOARD_FMUV3 20
-	else
-		# Check for Pixhawk 2.1 cube
-		# external MPU9250 is rotated 180 degrees yaw
-		if mpu9250 -S -R 4 start
-		then
-			set BOARD_FMUV3 21
-		fi
-	fi
-fi
+	# External I2C bus
+	hmc5883 -C -T -X start
+	lis3mdl -X start
+	ist8310 -C start
 
-# Check if a Pixhack (which reports as V2M) is present
-if ver hwtypecmp V2M
-then
-	# Pixhawk Mini doesn't have these sensors,
-	# so if they are found we know its a Pixhack
+	# Internal I2C bus
+	hmc5883 -C -T -I -R 4 start
 
-	# external MPU6K is rotated 180 degrees yaw
-	if mpu6000 -S -R 4 start
-	then
-		set BOARD_FMUV3 20
-	else
-		# Check for Pixhack 3.1
-		# external MPU9250 is rotated 180 degrees yaw
-		if mpu9250 -S -R 4 start
-		then
-			set BOARD_FMUV3 21
-		fi
-	fi
-fi
+	# Internal SPI bus ICM-20608-G
+	mpu6000 -T 20608 start
 
-if [ $BOARD_FMUV3 != 0 ]
-then
-	# sensor heating is available, but we disable it for now
-	param set SENS_EN_THERMAL 0
+	set BOARD_FMUV3 0
 
-	# external L3GD20H is rotated 180 degrees yaw
-	l3gd20 -X -R 4 start
-
-	# external LSM303D is rotated 270 degrees yaw
-	lsm303d -X -R 6 start
-
-	if [ $BOARD_FMUV3 = 20 ]
-	then
-		# v2.0 internal MPU6000 is rotated 180 deg roll, 270 deg yaw
-		mpu6000 -R 14 start
-
-		# v2.0 Has internal hmc5883 on SPI1
-		hmc5883 -C -T -S -R 8 start
-	fi
-
-	if [ $BOARD_FMUV3 = 21 ]
-	then
-		# v2.1 internal MPU9250 is rotated 180 deg roll, 270 deg yaw
-		mpu9250 -R 14 start
-	fi
-
-else
-	# $BOARD_FMUV3 = 0 -> FMUv2
-
-	mpu6000 start
-
-	# As we will use the external mag and the ICM-20608-G
-	# V2 build hwtypecmp is always false
 	# V3 build hwtypecmp supports V2|V2M|V30
-	if ! ver hwtypecmp V2M
+	if ver hwtypecmp V30
 	then
-		mpu9250 start
-	# else: On the PixhawkMini the mpu9250 has been disabled due to HW errata
+		# Check for Pixhawk 2.0 cube
+		# external MPU6K is rotated 180 degrees yaw
+		if mpu6000 -S -R 4 start
+		then
+			set BOARD_FMUV3 20
+		else
+			# Check for Pixhawk 2.1 cube
+			# external MPU9250 is rotated 180 degrees yaw
+			if mpu9250 -S -R 4 start
+			then
+				set BOARD_FMUV3 21
+			fi
+		fi
 	fi
 
-	l3gd20 start
-	lsm303d start
-fi
+	# Check if a Pixhack (which reports as V2M) is present
+	if ver hwtypecmp V2M
+	then
+		# Pixhawk Mini doesn't have these sensors,
+		# so if they are found we know its a Pixhack
 
-px4flow start &
+		# external MPU6K is rotated 180 degrees yaw
+		if mpu6000 -S -R 4 start
+		then
+			set BOARD_FMUV3 20
+		else
+			# Check for Pixhack 3.1
+			# external MPU9250 is rotated 180 degrees yaw
+			if mpu9250 -S -R 4 start
+			then
+				set BOARD_FMUV3 21
+			fi
+		fi
+	fi
+
+	if [ $BOARD_FMUV3 != 0 ]
+	then
+		# sensor heating is available, but we disable it for now
+		param set SENS_EN_THERMAL 0
+
+		# external L3GD20H is rotated 180 degrees yaw
+		l3gd20 -X -R 4 start
+
+		# external LSM303D is rotated 270 degrees yaw
+		lsm303d -X -R 6 start
+
+		if [ $BOARD_FMUV3 = 20 ]
+		then
+			# v2.0 internal MPU6000 is rotated 180 deg roll, 270 deg yaw
+			mpu6000 -R 14 start
+
+			# v2.0 Has internal hmc5883 on SPI1
+			hmc5883 -C -T -S -R 8 start
+		fi
+
+		if [ $BOARD_FMUV3 = 21 ]
+		then
+			# v2.1 internal MPU9250 is rotated 180 deg roll, 270 deg yaw
+			mpu9250 -R 14 start
+		fi
+
+	else
+		# $BOARD_FMUV3 = 0 -> FMUv2
+
+		mpu6000 start
+
+		# As we will use the external mag and the ICM-20608-G
+		# V2 build hwtypecmp is always false
+		# V3 build hwtypecmp supports V2|V2M|V30
+		if ! ver hwtypecmp V2M
+		then
+			mpu9250 start
+		# else: On the PixhawkMini the mpu9250 has been disabled due to HW errata
+		fi
+
+		l3gd20 start
+		lsm303d start
+	fi
+
+	px4flow start &
+fi
 
 unset BOARD_FMUV3

--- a/boards/px4/fmu-v4/init/rc.board
+++ b/boards/px4/fmu-v4/init/rc.board
@@ -32,8 +32,6 @@ then
 	param set SYS_FMU_TASK 1
 fi
 
-set MIXER_AUX none
-
 # Start sensor drivers if not in HIL mode
 if param compare SYS_HITL 0
 then

--- a/boards/px4/fmu-v4/init/rc.board
+++ b/boards/px4/fmu-v4/init/rc.board
@@ -34,60 +34,64 @@ fi
 
 set MIXER_AUX none
 
-
-# External I2C bus
-hmc5883 -C -T -X start
-lis3mdl -X start
-ist8310 start
-bmp280 -I start
-
-# expansion i2c used for BMM150 rotated by 90deg
-bmm150 -R 2 start
-
-# For Teal One airframe
-if param compare SYS_AUTOSTART 4250
+# Start sensor drivers if not in HIL mode
+if param compare SYS_HITL 0
 then
-	mpu9250 -s -R 14 start
-	mpu9250 -t -R 14 start
-fi
+	# External I2C bus
+	hmc5883 -C -T -X start
+	lis3mdl -X start
+	ist8310 start
+	bmp280 -I start
 
-# hmc5883 internal SPI bus is rotated 90 deg yaw
-if ! hmc5883 -C -T -S -R 2 start
-then
-	# lis3mdl internal SPI bus is rotated 90 deg yaw
-	if ! lis3mdl start
+	# expansion i2c used for BMM150 rotated by 90deg
+	bmm150 -R 2 start
+
+	# For Teal One airframe
+	if param compare SYS_AUTOSTART 4250
 	then
-		# BMI055 gyro internal SPI bus
-		bmi055 -G start
+		mpu9250 -s -R 14 start
+		mpu9250 -t -R 14 start
 	fi
-fi
 
-# Start either ICM2060X or BMI055. They are both connected to the same SPI bus and use the same
-# chip select pin. There are different boards with either one of them and the WHO_AM_I register
-# will prevent the incorrect driver from a successful initialization.
-
-# ICM20602 internal SPI bus ICM-20608-G is rotated 90 deg yaw
-if ! mpu6000 -R 2 -T 20602 start
-then
-	# ICM20608 internal SPI bus ICM-20602-G is rotated 90 deg yaw
-	if ! mpu6000 -R 2 -T 20608 start
+	# hmc5883 internal SPI bus is rotated 90 deg yaw
+	if ! hmc5883 -C -T -S -R 2 start
 	then
-		# BMI055 accel internal SPI bus
-		bmi055 -A start
+		# lis3mdl internal SPI bus is rotated 90 deg yaw
+		if ! lis3mdl start
+		then
+			# BMI055 gyro internal SPI bus
+			bmi055 -G start
+		fi
 	fi
+
+	# Start either ICM2060X or BMI055. They are both connected to the same SPI bus and use the same
+	# chip select pin. There are different boards with either one of them and the WHO_AM_I register
+	# will prevent the incorrect driver from a successful initialization.
+
+	# ICM20602 internal SPI bus ICM-20608-G is rotated 90 deg yaw
+	if ! mpu6000 -R 2 -T 20602 start
+	then
+		# ICM20608 internal SPI bus ICM-20602-G is rotated 90 deg yaw
+		if ! mpu6000 -R 2 -T 20608 start
+		then
+			# BMI055 accel internal SPI bus
+			bmi055 -A start
+		fi
+	fi
+
+	# Start either MPU9250 or BMI160. They are both connected to the same SPI bus and use the same
+	# chip select pin. There are different boards with either one of them and the WHO_AM_I register
+	# will prevent the incorrect driver from a successful initialization.
+
+	# mpu9250 internal SPI bus mpu9250 is rotated 90 deg yaw
+	if ! mpu9250 -R 2 start
+	then
+		# BMI160 internal SPI bus
+		bmi160 start
+	fi
+
+	px4flow start &
 fi
-
-# Start either MPU9250 or BMI160. They are both connected to the same SPI bus and use the same
-# chip select pin. There are different boards with either one of them and the WHO_AM_I register
-# will prevent the incorrect driver from a successful initialization.
-
-# mpu9250 internal SPI bus mpu9250 is rotated 90 deg yaw
-if ! mpu9250 -R 2 start
-then
-	# BMI160 internal SPI bus
-	bmi160 start
-fi
-
 
 # Pixracer: start MAVLink on Wifi (ESP8266 port)
 mavlink start -r 20000 -b 921600 -d /dev/ttyS0
@@ -98,4 +102,3 @@ then
 	frsky_telemetry start -d /dev/ttyS6 -t 15
 fi
 
-px4flow start &

--- a/boards/px4/fmu-v4pro/init/rc.board
+++ b/boards/px4/fmu-v4pro/init/rc.board
@@ -25,22 +25,26 @@ fi
 set LOGGER_BUF 64
 
 
-# Internal SPI bus ICM-20608-G
-mpu6000 -R 2 -T 20608 start
+# Start sensor drivers if not in HIL mode
+if param compare SYS_HITL 0
+then
+	# Internal SPI bus ICM-20608-G
+	mpu6000 -R 2 -T 20608 start
 
-# Internal SPI bus ICM-20602
-mpu6000 -R 2 -T 20602 start
+	# Internal SPI bus ICM-20602
+	mpu6000 -R 2 -T 20602 start
 
-# Internal SPI bus mpu9250
-mpu9250 -R 2 start
+	# Internal SPI bus mpu9250
+	mpu9250 -R 2 start
 
-# Internal SPI bus
-lis3mdl -R 0 start
+	# Internal SPI bus
+	lis3mdl -R 0 start
 
-# Possible external compasses
-hmc5883 -C -T -X start
+	# Possible external compasses
+	hmc5883 -C -T -X start
 
-# RM3100
-rm3100 start
+	# RM3100
+	rm3100 start
 
-px4flow start &
+	px4flow start &
+fi

--- a/boards/px4/fmu-v5/init/rc.board
+++ b/boards/px4/fmu-v5/init/rc.board
@@ -24,29 +24,33 @@ fi
 
 set LOGGER_BUF 64
 
-# Internal SPI bus ICM-20602
-mpu6000 -R 8 -s -T 20602 start
+# Start sensor drivers if not in HIL mode
+if param compare SYS_HITL 0
+then
+	# Internal SPI bus ICM-20602
+	mpu6000 -R 8 -s -T 20602 start
 
-# Internal SPI bus ICM-20689
-mpu6000 -R 8 -z -T 20689 start
+	# Internal SPI bus ICM-20689
+	mpu6000 -R 8 -z -T 20689 start
 
-# Internal SPI bus BMI055 accel
-bmi055 -A -R 10 start
+	# Internal SPI bus BMI055 accel
+	bmi055 -A -R 10 start
 
-# Internal SPI bus BMI055 gyro
-bmi055 -G -R 10 start
+	# Internal SPI bus BMI055 gyro
+	bmi055 -G -R 10 start
 
-# Possible external compasses
-hmc5883 -C -T -X start
+	# Possible external compasses
+	hmc5883 -C -T -X start
 
-# Possible external compasses
-ist8310 -C -b 1 start
-ist8310 -C -b 2 start
+	# Possible external compasses
+	ist8310 -C -b 1 start
+	ist8310 -C -b 2 start
 
-# Possible internal compass
-ist8310 -C -b 5 start
+	# Possible internal compass
+	ist8310 -C -b 5 start
 
-# Possible pmw3901 optical flow sensor
-pmw3901 start
+	# Possible pmw3901 optical flow sensor
+	pmw3901 start
 
-px4flow start &
+	px4flow start &
+fi


### PR DESCRIPTION
Fixes regression from https://github.com/PX4/Firmware/pull/10960, by checking for `SYS_HITL` in rc.board, and not running the sensors in HIL mode. This and other parameters require rc.board to be executed after rc.autostart.
Not sure if that's the best way, but it resolves the dependency issues (except for the already existing dataman argument).
