### PR TITLE
FlightTask : PositionSmoothVel and AutoSmoothVel - Handle XY reset

### DIFF
--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -27,7 +27,7 @@ px4_add_board(
 		differential_pressure/ms4525
 		#distance_sensor # all available distance sensor drivers
 		distance_sensor/ll40ls
-		distance_sensor/sf0x
+		#distance_sensor/sf0x
 		gps
 		#heater
 		#imu/adis16448

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -123,6 +123,14 @@ void FlightTaskAutoLineSmoothVel::_prepareSetpoints()
 	// that one is used as a velocity limit.
 	// If the position setpoints are set to NAN, the values in the velocity setpoints are used as velocity targets: nothing to do here.
 
+	// Check if a reset event has happened.
+	if (_sub_vehicle_local_position->get().xy_reset_counter != _reset_counter) {
+		// Reset the XY axes
+		_trajectory[0].setCurrentPosition(_position(0));
+		_trajectory[1].setCurrentPosition(_position(1));
+		_reset_counter = _sub_vehicle_local_position->get().xy_reset_counter;
+	}
+
 	if (PX4_ISFINITE(_position_setpoint(0)) &&
 	    PX4_ISFINITE(_position_setpoint(1))) {
 		// Use position setpoints to generate velocity setpoints

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -76,4 +76,5 @@ protected:
 	void _generateTrajectory();
 	VelocitySmoothing _trajectory[3]; ///< Trajectories in x, y and z directions
 	float _yaw_sp_prev;
+	uint8_t _reset_counter{0}; /**< counter for estimator resets in xy-direction */
 };

--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
@@ -147,6 +147,16 @@ void FlightTaskManualPositionSmoothVel::_updateSetpoints()
 
 	VelocitySmoothing::timeSynchronization(_smoothing, 2); // Synchronize x and y only
 
+	if (_position_lock_xy_active) {
+		// Check if a reset event has happened.
+		if (_sub_vehicle_local_position->get().xy_reset_counter != _reset_counter) {
+			// Reset the XY axes
+			_smoothing[0].setCurrentPosition(_position(0));
+			_smoothing[1].setCurrentPosition(_position(1));
+			_reset_counter = _sub_vehicle_local_position->get().xy_reset_counter;
+		}
+	}
+
 	Vector3f pos_sp_smooth;
 	Vector3f accel_sp_smooth;
 

--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.hpp
@@ -70,4 +70,5 @@ private:
 	matrix::Vector3f _vel_sp_smooth;
 	bool _position_lock_xy_active{false};
 	matrix::Vector2f _position_setpoint_xy_locked;
+	uint8_t _reset_counter{0}; /**< counter for estimator resets in xy-direction */
 };


### PR DESCRIPTION
When the EKF resets its position, the `xy_reset_counter` is incremented. When a reset happens, the flight task has to take care about this prevent dangerous behaviors. 
This is already handled in the other position control flight tasks, but not in that one.

Flight test: GPS and optic flow fusion, with a switch that controls GPS fusion
1. Fly with GPS
2. Disable GPS fusion (fuse OF only)
2. Navigate with optic flow and yaw a lot to force position drift
3. Reactivate GPS fusion

Before that PR, the drone tried to suddenly correct for the jump in position: 
https://logs.px4.io/plot_app?log=4e981506-0c42-48cd-92eb-702ce321dc6f

With that PR, the drone stays at the current position:
https://logs.px4.io/plot_app?log=989150c7-6d5b-4347-910a-6fe366bd0e9a

@AnnaDaiZH FYI
