### PR TITLE
distance_sensor: update ulanding_radar driver for new hardware

### DIFF
--- a/src/drivers/distance_sensor/ulanding/ulanding.cpp
+++ b/src/drivers/distance_sensor/ulanding/ulanding.cpp
@@ -360,8 +360,9 @@ bool Radar::read_and_parse(uint8_t *buf, int len, float *range)
 		if (is_header_byte(_buf[index])) {
 			if (no_header_counter >= BUF_LEN / 3 - 1) {
 				if (ULANDING_VERSION == 1) {
-					if (((_buf[index + 1] + _buf[index + 2] + _buf[index + 3] + _buf[index + 4])) != (_buf[index + 5])
-					    || (_buf[index + 1] <= 0)) {
+					bool checksum_passed = (((_buf[index + 1] + _buf[index + 2] + _buf[index + 3] + _buf[index + 4]) & 0xFF) == _buf[index + 5]);
+					if (!checksum_passed) {
+						// checksum failed
 						ret = false;
 						break;
 					}

--- a/src/drivers/distance_sensor/ulanding/ulanding.cpp
+++ b/src/drivers/distance_sensor/ulanding/ulanding.cpp
@@ -360,7 +360,9 @@ bool Radar::read_and_parse(uint8_t *buf, int len, float *range)
 		if (is_header_byte(_buf[index])) {
 			if (no_header_counter >= BUF_LEN / 3 - 1) {
 				if (ULANDING_VERSION == 1) {
-					bool checksum_passed = (((_buf[index + 1] + _buf[index + 2] + _buf[index + 3] + _buf[index + 4]) & 0xFF) == _buf[index + 5]);
+					bool checksum_passed = (((_buf[index + 1] + _buf[index + 2] + _buf[index + 3] + _buf[index + 4]) & 0xFF) == _buf[index +
+								5]);
+
 					if (!checksum_passed) {
 						// checksum failed
 						ret = false;


### PR DESCRIPTION
We have a second generation radar altimeter available now that requires a slight modification to the driver. Functionally, the only difference is that the driver isn't checking the second byte of the six byte data format. The checksum is sufficient for making sure the received data is good.
