### PR TITLE
RM3100 : enable I2C

### DIFF
--- a/src/drivers/magnetometer/rm3100/rm3100.h
+++ b/src/drivers/magnetometer/rm3100/rm3100.h
@@ -59,7 +59,8 @@
  * RM3100 internal constants and data structures.
  */
 
-#define RM3100_CONVERSION_INTERVAL	6850	// Microseconds, corresponds to 146 Hz (cycle count 200 on 3 axis)
+/* At 146 Hz we encounter errors, 100 Hz is safer */
+#define RM3100_CONVERSION_INTERVAL	10000	// Microseconds, corresponds to 100 Hz (cycle count 200 on 3 axis)
 #define UTESLA_TO_GAUSS			100.0f
 #define RM3100_SENSITIVITY		75.0f
 

--- a/src/drivers/magnetometer/rm3100/rm3100_i2c.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100_i2c.cpp
@@ -146,7 +146,7 @@ RM3100_I2C::read(unsigned address, void *data, unsigned count)
 	/* We need a first transfer where we write the register to read */
 	ret = transfer(&cmd, 1, nullptr, 0);
 
-	if(ret != OK){
+	if (ret != OK) {
 		return ret;
 	}
 

--- a/src/drivers/magnetometer/rm3100/rm3100_i2c.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100_i2c.cpp
@@ -61,9 +61,6 @@
 
 #define RM3100_ADDRESS		0x20
 
-#define DIR_READ		(1<<7)
-#define DIR_WRITE		(0<<7)
-
 class RM3100_I2C : public device::I2C
 {
 public:
@@ -143,8 +140,20 @@ RM3100_I2C::probe()
 int
 RM3100_I2C::read(unsigned address, void *data, unsigned count)
 {
-	uint8_t cmd = address | DIR_READ;
-	return transfer(&cmd, 1, (uint8_t *)data, count);
+	uint8_t cmd = address;
+	int ret;
+
+	/* We need a first transfer where we write the register to read */
+	ret = transfer(&cmd, 1, nullptr, 0);
+
+	if(ret != OK){
+		return ret;
+	}
+
+	/* Now we read the previously selected register */
+	ret = transfer(nullptr, 0, (uint8_t *)data, count);
+
+	return ret;
 }
 
 int
@@ -156,7 +165,7 @@ RM3100_I2C::write(unsigned address, void *data, unsigned count)
 		return -EIO;
 	}
 
-	buf[0] = address | DIR_WRITE;
+	buf[0] = address;
 	memcpy(&buf[1], data, count);
 
 	return transfer(&buf[0], count + 1, nullptr, 0);

--- a/src/drivers/magnetometer/rm3100/rm3100_main.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100_main.cpp
@@ -73,7 +73,7 @@ rm3100::init(RM3100_BUS bus_id)
 		return false;
 
 	} else {
-		PX4_INFO("Poll rate set to max (146 Hz)");
+		PX4_INFO("Poll rate set to 100 Hz");
 	}
 
 	close(fd);


### PR DESCRIPTION
This PR enables I2C for the RM3100 magnetic sensor.

I2C has been bench-tested succesfully. Both external (SPI2 on Pixhawk 3 Pro) and internal (Pixracer-based design) SPI buses have been flight tested succesfully as well. Regarding I2C addresses, even if 0x20 -> 0x23 are possible only 0x20 is implemented as 0x21 -> 0x23 are already used by the SDP3x driver. @ryanjAA can you cross-check?