### PR TITLE
SBUS parsing: add time-based hardening on IO

### DIFF
--- a/src/lib/rc/sbus.cpp
+++ b/src/lib/rc/sbus.cpp
@@ -76,12 +76,6 @@
 // this is the rate of the old code
 #define SBUS1_DEFAULT_RATE_HZ	72
 
-#define SBUS_SINGLE_CHAR_LEN_US		(1/((100000/10)) * 1000 * 1000)
-
-#define SBUS_FRAME_INTERVAL_US	2500
-#define SBUS_MIN_CALL_INTERVAL_US	(SBUS_FRAME_GAP_US / 3)
-#define SBUS_EPSILON_US	2500
-
 /*
   Measured values with Futaba FX-30/R6108SB:
     -+100% on TX:  PCM 1.100/1.520/1.950ms -> SBus raw values: 350/1024/1700  (100% ATV)
@@ -105,7 +99,6 @@
 #define SBUS_SCALE_OFFSET (int)(SBUS_TARGET_MIN - (SBUS_SCALE_FACTOR * SBUS_RANGE_MIN + 0.5f))
 
 static hrt_abstime last_rx_time;
-static hrt_abstime last_frame_time;
 static hrt_abstime last_txframe_time = 0;
 
 #define SBUS2_FRAME_SIZE_RX_VOLTAGE	3
@@ -229,7 +222,6 @@ sbus_config(int sbus_fd, bool singlewire)
 		/* initialise the decoder */
 		partial_frame_count = 0;
 		last_rx_time = hrt_absolute_time();
-		last_frame_time = last_rx_time;
 		sbus_frame_drops = 0;
 
 		ret = 0;
@@ -404,8 +396,7 @@ sbus_parse(uint64_t now, uint8_t *frame, unsigned len, uint16_t *values,
 				}
 
 				/*
-				 * Great, it looks like we might have a frame.  Go ahead and
-				 * decode it.
+				 * Great, it looks like we might have a frame. Go ahead and decode it.
 				 */
 				decode_ret = sbus_decode(now, sbus_frame, values, num_values, sbus_failsafe, sbus_frame_drop, max_channels);
 
@@ -582,7 +573,7 @@ sbus_decode(uint64_t frame_time, uint8_t *frame, uint16_t *values, uint16_t *num
 {
 
 	/* check frame boundary markers to avoid out-of-sync cases */
-	if ((frame[0] != SBUS_START_SYMBOL)) {
+	if (frame[0] != SBUS_START_SYMBOL) {
 		sbus_frame_drops++;
 #if defined(SBUS_DEBUG_LEVEL) && SBUS_DEBUG_LEVEL > 0
 		printf("DECODE FAIL: ");
@@ -597,6 +588,7 @@ sbus_decode(uint64_t frame_time, uint8_t *frame, uint16_t *values, uint16_t *num
 		return false;
 	}
 
+	/* the last byte in the frame indicates what frame will follow after this one */
 	switch (frame[24]) {
 	case 0x00:
 		/* this is S.BUS 1 */
@@ -632,8 +624,6 @@ sbus_decode(uint64_t frame_time, uint8_t *frame, uint16_t *values, uint16_t *num
 	}
 
 	/* we have received something we think is a frame */
-	last_frame_time = frame_time;
-
 	unsigned chancount = (max_values > SBUS_INPUT_CHANNELS) ?
 			     SBUS_INPUT_CHANNELS : max_values;
 

--- a/src/lib/rc/sbus.cpp
+++ b/src/lib/rc/sbus.cpp
@@ -654,9 +654,9 @@ sbus_decode(uint64_t frame_time, uint8_t *frame, uint16_t *values, uint16_t *num
 		chancount = 18;
 
 		/* channel 17 (index 16) */
-		values[16] = (((frame[SBUS_FLAGS_BYTE] & (1 << 0)) > 0) ? 1 : 0) * 1000 + 998;
+		values[16] = ((frame[SBUS_FLAGS_BYTE] & (1 << 0)) ? 1000 : 0) + 998;
 		/* channel 18 (index 17) */
-		values[17] = (((frame[SBUS_FLAGS_BYTE] & (1 << 1)) > 0) ? 1 : 0) * 1000 + 998;
+		values[17] = ((frame[SBUS_FLAGS_BYTE] & (1 << 1)) ? 1000 : 0) + 998;
 	}
 
 	/* note the number of channels decoded */


### PR DESCRIPTION
Since SBUS does not have CRC, we can use timing information to improve parsing reliability and reject unexpected bytes.

Note that this patch only affects the parsing on IO. It is not directly applicable on the fmu, because of differences in scheduling (we can add a similar solution though).

The first 2 commits are cleanup only.

Tested on a Pixhawk 4 for an hour with an RrSky X4R, the conditions were never triggered.

@davids5 @dagar did you already look into the parity-bit handling of NuttX?