### PR TITLE
rcS tone_alarm: fix CBRK_BUZZER

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -80,11 +80,6 @@ ver all
 uorb start
 
 #
-# Start the tone_alarm driver.
-#
-tone_alarm start
-
-#
 # Try to mount the microSD card.
 #
 # REBOOTWORK this needs to start after the flight control loop.
@@ -172,6 +167,13 @@ else
 	then
 		param reset
 	fi
+
+	#
+	# Start the tone_alarm driver.
+	# Needs to be started after the parameters are loaded (for CBRK_BUZZER).
+	# Note that this will still play the already published startup tone.
+	#
+	tone_alarm start
 
 	#
 	# Start system state indicator.


### PR DESCRIPTION
tone_alarm was started before the parameters were loaded, and the first tune was played before that as well. CBRK_BUZZER was then read as default, ignoring the user-configured value.

We now start tone_alarm after we load the parameters. Note that a previously published startup tone or SD card error will still be played.

On a related note: I find it questionable if we really want to keep the system beeping endlessly if there is no SD card inserted.