### PR TITLE
[DO NOT MERGE] NuttX don't use std inc path

### DIFF
--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -83,6 +83,7 @@ target_link_libraries(nuttx_cxx INTERFACE nuttx_c)
 
 target_link_libraries(px4 PRIVATE
 
+	-nostartfiles
 	-nodefaultlibs
 	-nostdlib
 
@@ -99,6 +100,7 @@ target_link_libraries(px4 PRIVATE
 	-Wl,--end-group
 
 	m
+	gcc
 	)
 
 target_link_libraries(px4 PRIVATE ${module_libraries})

--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -79,6 +79,77 @@ add_custom_command(
 	WORKING_DIRECTORY ${NUTTX_DIR}/tools
 	COMMENT "Copying NuttX config ${NUTTX_CONFIG} and configuring"
 	)
+	
+# determine toolchain sysroot
+execute_process(
+	COMMAND ${CMAKE_C_COMPILER} --print-sysroot
+	OUTPUT_VARIABLE GCC_SYSROOT
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# copy newlib math.h into include
+# remove includes sys/reent.h and sys/cdefs.h
+add_custom_command(
+	OUTPUT
+		${NUTTX_DIR}/include/math.h
+	COMMAND
+		cp ${GCC_SYSROOT}/include/math.h ${NUTTX_DIR}/include/
+	COMMAND
+		sed -i 's@\#include \<sys/reent.h\>@@' ${NUTTX_DIR}/include/math.h
+	COMMAND
+		sed -i 's@\#include \<sys/cdefs.h\>@@' ${NUTTX_DIR}/include/math.h
+	DEPENDS ${NUTTX_DIR}/.config
+)
+
+# copy the unmodified newlib headers
+set(newlib_headers)
+list(APPEND newlib_headers
+	_ansi.h
+	_newlib_version.h
+	getopt.h
+	newlib.h
+	sys/_types.h
+	sys/config.h
+	sys/features.h
+)
+
+set(newlib_header_deps)
+foreach(h ${newlib_headers})
+	add_custom_command(
+		OUTPUT ${NUTTX_DIR}/include/${h}
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${GCC_SYSROOT}/include/${h} ${NUTTX_DIR}/include/${h}
+		DEPENDS ${NUTTX_DIR}/include/math.h
+		COMMENT "copying newlib ${h} into buildroot"
+	)
+	list(APPEND newlib_header_deps ${NUTTX_DIR}/include/${h})
+endforeach()
+
+# machine/ieeefp.h
+add_custom_command(
+	OUTPUT ${NUTTX_DIR}/include/machine/ieeefp.h
+	COMMAND mkdir -p ${NUTTX_DIR}/include/machine
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different ${GCC_SYSROOT}/include/machine/ieeefp.h ${NUTTX_DIR}/include/machine/ieeefp.h
+	DEPENDS ${NUTTX_DIR}/.config
+	COMMENT "copying newlib machine/ieeefp.h into buildroot"
+)
+list(APPEND newlib_header_deps ${NUTTX_DIR}/include/machine/ieeefp.h)
+
+# TODO: what's the proper way to find this in GCC?
+set(newlib_headers_alt)
+list(APPEND newlib_headers_alt
+	float.h
+	stdarg.h
+)
+foreach(h ${newlib_headers_alt})
+	add_custom_command(
+		OUTPUT ${NUTTX_DIR}/include/${h}
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${GCC_SYSROOT}/../lib/gcc/arm-none-eabi/7.2.1/include/${h} ${NUTTX_DIR}/include/${h}
+		DEPENDS ${NUTTX_DIR}/include/math.h
+		COMMENT "copying newlib ${h} into buildroot"
+	)
+	list(APPEND newlib_header_deps ${NUTTX_DIR}/include/${h})
+endforeach()
+
 
 # verbose build settings (V=1 or VERBOSE=1)
 option(PX4_NUTTX_VERBOSE "PX4 NuttX verbose build" off)
@@ -101,7 +172,10 @@ endif()
 # context
 add_custom_command(OUTPUT ${NUTTX_DIR}/include/nuttx/version.h ${NUTTX_DIR}/include/nuttx/config.h
 	COMMAND make ${nuttx_build_options} --no-print-directory context ${nuttx_build_output}
-	DEPENDS ${NUTTX_DIR}/.config
+	DEPENDS
+		${NUTTX_DIR}/.config
+		${NUTTX_DIR}/include/math.h
+		${newlib_header_deps}
 	WORKING_DIRECTORY ${NUTTX_DIR}
 	${nuttx_build_uses_terminal}
 	)

--- a/platforms/nuttx/NuttX/Make.defs.in
+++ b/platforms/nuttx/NuttX/Make.defs.in
@@ -63,6 +63,8 @@ ifeq ($(WINTOOL),y)
 endif
 
 FLAGS = -Os -g2 \
+	-nostdlib \
+	-nostdinc \
 	-fdata-sections \
 	-ffunction-sections \
 	-fno-builtin-printf \
@@ -108,6 +110,7 @@ CFLAGS = $(ARCHINCLUDES) \
 
 CXXFLAGS = $(ARCHXXINCLUDES) \
 	-std=gnu++11 \
+	-nostdinc++ \
 	${CMAKE_CXX_FLAGS} \
 	$(FLAGS) \
 	-fcheck-new \

--- a/platforms/nuttx/cmake/px4_impl_os.cmake
+++ b/platforms/nuttx/cmake/px4_impl_os.cmake
@@ -68,6 +68,15 @@ function(px4_os_add_flags)
 		-D__PX4_NUTTX
 		-D__DF_NUTTX
 		)
+		
+	add_compile_options(
+		-nostartfiles
+		-nodefaultlibs
+		-nostdlib
+
+		#-nostdinc
+		#-nostdinc++
+	)
 
 	if("${CONFIG_ARMV7M_STACKCHECK}" STREQUAL "y")
 		message(STATUS "NuttX Stack Checking (CONFIG_ARMV7M_STACKCHECK) enabled")

--- a/platforms/posix/include/queue.h
+++ b/platforms/posix/include/queue.h
@@ -42,11 +42,7 @@
 
 #include <sys/types.h>
 
-#ifdef __cplusplus
-#include <cstddef>	// NULL
-#else
-#include <stddef.h>	// NULL
-#endif
+#include <stddef.h>
 
 /************************************************************************
  * Pre-processor Definitions

--- a/platforms/qurt/include/queue.h
+++ b/platforms/qurt/include/queue.h
@@ -42,11 +42,7 @@
 
 #include <sys/types.h>
 
-#ifdef __cplusplus
-#include <cstddef>	// NULL
-#else
-#include <stddef.h>	// NULL
-#endif
+#include <stddef.h>
 
 /************************************************************************
  * Pre-processor Definitions

--- a/src/drivers/pca9685/pca9685.cpp
+++ b/src/drivers/pca9685/pca9685.cpp
@@ -330,9 +330,9 @@ PCA9685::i2cpwm()
 					     (double)_actuator_controls.control[i]);
 
 				if (new_value != _current_values[i] &&
-				    isfinite(new_value) &&
 				    new_value >= PCA9685_PWMMIN &&
 				    new_value <= PCA9685_PWMMAX) {
+
 					/* This value was updated, send the command to adjust the PWM value */
 					setPin(i, new_value);
 					_current_values[i] = new_value;

--- a/src/drivers/telemetry/frsky_telemetry/frsky_data.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/frsky_data.cpp
@@ -50,6 +50,7 @@
 #include <lib/ecl/geo/geo.h>
 #include <stdbool.h>
 #include <math.h>
+#include <px4_defines.h>
 
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/sensor_combined.h>

--- a/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
+++ b/src/drivers/telemetry/frsky_telemetry/sPort_data.cpp
@@ -50,6 +50,7 @@
 #include <math.h>
 
 #include <lib/ecl/geo/geo.h>
+#include <px4_defines.h>
 
 #include <uORB/topics/battery_status.h>
 #include <uORB/topics/sensor_combined.h>

--- a/src/drivers/telemetry/hott/messages.cpp
+++ b/src/drivers/telemetry/hott/messages.cpp
@@ -43,6 +43,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <lib/ecl/geo/geo.h>
+#include <px4_defines.h>
 #include <unistd.h>
 #include <uORB/topics/airspeed.h>
 #include <uORB/topics/battery_status.h>

--- a/src/modules/uORB/uORB_tests/uORBTest_UnitTest.cpp
+++ b/src/modules/uORB/uORB_tests/uORBTest_UnitTest.cpp
@@ -38,6 +38,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <poll.h>
+#include <math.h>
 #include <lib/cdev/CDev.hpp>
 
 ORB_DEFINE(orb_test, struct orb_test, sizeof(orb_test), "ORB_TEST:int val;hrt_abstime time;");

--- a/src/platforms/px4_defines.h
+++ b/src/platforms/px4_defines.h
@@ -61,13 +61,6 @@
 /* Wrapper for rotation matrices stored in arrays */
 #define PX4_R(_array, _x, _y) PX4_ARRAY2D(_array, 3, _x, _y)
 
-/* Define a usable PX4_ISFINITE. Note that PX4_ISFINITE is ONLY used in C++ files,
- * therefore, by default, we want to use std::isfinite. */
-#ifdef __cplusplus
-#include <cmath>
-#define PX4_ISFINITE(x) std::isfinite(x)
-#endif
-
 #if defined(__PX4_ROS)
 /****************************************************************************
  * Building for running within the ROS environment.
@@ -132,24 +125,21 @@ typedef param_t px4_param_t;
 
 // Workaround for broken NuttX math.h.
 #ifdef __cplusplus
-#include <cmath>
-#undef isfinite
 template<typename T>
-inline bool isfinite(T __y)
-{
-	int __cy = fpclassify(__y);
-	return __cy != FP_INFINITE && __cy != FP_NAN;
-}
-namespace std
-{
-using ::isfinite;
-}
+constexpr bool PX4_ISFINITE(T __y) { return __builtin_isfinite(__y); }
 #endif // __cplusplus
 
 #elif defined(__PX4_POSIX)
 /****************************************************************************
  * POSIX Specific defines
  ****************************************************************************/
+
+/* Define a usable PX4_ISFINITE. Note that PX4_ISFINITE is ONLY used in C++ files,
+ * therefore, by default, we want to use std::isfinite. */
+#ifdef __cplusplus
+#include <cmath>
+#define PX4_ISFINITE(x) std::isfinite(x)
+#endif
 
 // Flag is meaningless on Linux
 #ifndef O_BINARY
@@ -214,34 +204,23 @@ __END_DECLS
 #define ERROR -1
 #define MAX_RAND 32767
 
-/* Math macro's for float literals. Do not use M_PI et al as they aren't
- * defined (neither C nor the C++ standard define math constants) */
-#define M_E_F			2.71828183f
-#define M_LOG2E_F		1.44269504f
-#define M_LOG10E_F		0.43429448f
-#define M_LN2_F			0.69314718f
-#define M_LN10_F		2.30258509f
-#define M_PI_F			3.14159265f
-#define M_TWOPI_F		6.28318531f
-#define M_PI_2_F		1.57079632f
-#define M_PI_4_F		0.78539816f
-#define M_3PI_4_F		2.35619449f
-#define M_SQRTPI_F		1.77245385f
-#define M_1_PI_F		0.31830989f
-#define M_2_PI_F		0.63661977f
-#define M_2_SQRTPI_F		1.12837917f
-#define M_DEG_TO_RAD_F		0.0174532925f
-#define M_RAD_TO_DEG_F		57.2957795f
-#define M_SQRT2_F		1.41421356f
-#define M_SQRT1_2_F		0.70710678f
-#define M_LN2LO_F		1.90821484E-10f
-#define M_LN2HI_F		0.69314718f
-#define M_SQRT3_F		1.73205081f
-#define M_IVLN10_F		0.43429448f	// 1 / log(10)
-#define M_LOG2_E_F		0.69314718f
-#define M_INVLN2_F		1.44269504f	// 1 / log(2)
-
-#define M_DEG_TO_RAD 		0.017453292519943295
-#define M_RAD_TO_DEG 		57.295779513082323
 
 #endif // defined(__PX4_ROS) || defined(__PX4_POSIX)
+
+#define M_DEG_TO_RAD 		0.017453292519943295
+#define M_DEG_TO_RAD_F		((float)M_DEG_TO_RAD)
+
+#define M_RAD_TO_DEG 		57.295779513082323
+#define M_RAD_TO_DEG_F		((float)M_RAD_TO_DEG)
+
+
+#include <math.h>
+#define M_PI_F ((float)M_PI)
+#define M_PI_2_F ((float)M_PI_2)
+#define M_SQRT1_2_F ((float)M_SQRT1_2)
+
+#ifndef M_TWOPI
+# define M_TWOPI (2 * M_PI)
+#endif
+
+#define M_TWOPI_F ((float)M_TWOPI)

--- a/src/platforms/px4_log.h
+++ b/src/platforms/px4_log.h
@@ -130,7 +130,6 @@ __END_DECLS
 
 #include <inttypes.h>
 #include <stdint.h>
-#include <sys/cdefs.h>
 #include <stdio.h>
 #include <stdarg.h>
 


### PR DESCRIPTION
@davids5 out of curiosity I tried pulling in only the newlib headers we actually use. It's a relatively small list and the only thing I had to modify was strip a couple unused includes out of math.h.

We've actually become fairly dependent on c++ headers, although obviously not linking anything. I think it's still worth reconsidering libc++ (https://github.com/PX4/Firmware/pull/7874), but with the sysroot include paths completely removed (-nostdinc and -nostdinc++). We'd effectively have the entire toolchain contained.

Finding most of the headers is easy from the sysroot path, except for float.h and stdarg.h. They're under `/opt/gcc-arm-none-eabi-7-2017-q4-major/lib/gcc/arm-none-eabi/7.2.1/include/`.

The full list of toolchain headers pulled into the NuttX build.


	math.h # strip out 2 includes
	_ansi.h
	_newlib_version.h
	getopt.h
	newlib.h
	sys/_types.h
	sys/config.h
	sys/features.h
	machine/ieeefp.h
	float.h # different include path
	stdarg.h # different include path