### PR TITLE
Fix px4_fmu-v3 serial port mapping

### DIFF
--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -13,10 +13,10 @@ px4_add_board(
 	#UAVCAN_INTERFACES 2
 
 	SERIAL_PORTS
-		GPS1:/dev/ttyS0
+		GPS1:/dev/ttyS3
 		TEL1:/dev/ttyS1
 		TEL2:/dev/ttyS2
-		TEL4:/dev/ttyS3
+		TEL4:/dev/ttyS0
 
 	DRIVERS
 		#barometer # all available barometer drivers

--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -16,7 +16,7 @@ px4_add_board(
 		GPS1:/dev/ttyS3
 		TEL1:/dev/ttyS1
 		TEL2:/dev/ttyS2
-		TEL4:/dev/ttyS0
+		TEL4:/dev/ttyS6
 
 	DRIVERS
 		#barometer # all available barometer drivers

--- a/boards/px4/fmu-v3/default.cmake
+++ b/boards/px4/fmu-v3/default.cmake
@@ -14,10 +14,10 @@ px4_add_board(
 	UAVCAN_INTERFACES 2
 
 	SERIAL_PORTS
-		GPS1:/dev/ttyS0
+		GPS1:/dev/ttyS3
 		TEL1:/dev/ttyS1
 		TEL2:/dev/ttyS2
-		TEL4:/dev/ttyS3
+		TEL4:/dev/ttyS0
 
 	DRIVERS
 		barometer # all available barometer drivers

--- a/boards/px4/fmu-v3/default.cmake
+++ b/boards/px4/fmu-v3/default.cmake
@@ -17,7 +17,7 @@ px4_add_board(
 		GPS1:/dev/ttyS3
 		TEL1:/dev/ttyS1
 		TEL2:/dev/ttyS2
-		TEL4:/dev/ttyS0
+		TEL4:/dev/ttyS6
 
 	DRIVERS
 		barometer # all available barometer drivers


### PR DESCRIPTION
GPS not work with current mapping, try to fix

reference:
![image](https://user-images.githubusercontent.com/4748411/50064355-aba26600-01eb-11e9-840d-e0d41529bd23.png)
