### PR TITLE
ROMFS: don't forget to prune rc.board

### DIFF
--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -84,6 +84,9 @@ add_custom_command(OUTPUT ${romfs_gen_root_dir}/init.d/rcS ${romfs_gen_root_dir}
 	COMMAND ${CMAKE_COMMAND} -E copy_directory ${romfs_src_dir} ${romfs_gen_root_dir}
 	COMMAND ${CMAKE_COMMAND} -E remove_directory ${romfs_gen_root_dir}/init.d-posix
 	COMMAND ${CMAKE_COMMAND} -E remove_directory ${romfs_gen_root_dir}/mixers-sitl
+	COMMAND ${CMAKE_COMMAND} -E remove ${romfs_gen_root_dir}/mixers/CMakeLists.txt
+	COMMAND ${CMAKE_COMMAND} -E remove ${romfs_gen_root_dir}/init.d/CMakeLists.txt
+	COMMAND ${CMAKE_COMMAND} -E remove ${romfs_gen_root_dir}/init.d/airframes/CMakeLists.txt
 	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/px_process_airframes.py
 		--airframes-path ${romfs_gen_root_dir}/init.d
 		--start-script ${romfs_gen_root_dir}/init.d/rc.autostart

--- a/ROMFS/CMakeLists.txt
+++ b/ROMFS/CMakeLists.txt
@@ -70,7 +70,7 @@ endfunction()
 add_subdirectory(${romfs_src_dir})
 
 # directory setup
-# copy all romfs files, process airframes, prune comments
+# copy all romfs files, process airframes
 get_property(romfs_cmake_files GLOBAL PROPERTY PX4_ROMFS_CMAKE_FILES)
 get_property(romfs_copy_files GLOBAL PROPERTY PX4_ROMFS_FILES)
 get_property(module_config_files GLOBAL PROPERTY PX4_MODULE_CONFIG_FILES)
@@ -92,17 +92,14 @@ add_custom_command(OUTPUT ${romfs_gen_root_dir}/init.d/rcS ${romfs_gen_root_dir}
 		--rc-dir ${romfs_gen_root_dir}/init.d
 		--serial-ports ${board_serial_ports} ${added_arguments}
 		--config-files ${module_config_files} #--verbose
-	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/px_romfs_pruner.py
-		--folder ${romfs_gen_root_dir} --board ${PX4_BOARD}
 	DEPENDS
 		${jinja_templates}
 		${module_config_files}
 		${romfs_cmake_files}
 		${romfs_copy_files}
 		${PX4_SOURCE_DIR}/Tools/px_process_airframes.py
-		${PX4_SOURCE_DIR}/Tools/px_romfs_pruner.py
 		${PX4_SOURCE_DIR}/Tools/serial/generate_config.py
-	COMMENT "ROMFS: copying, generating airframes, pruning"
+	COMMENT "ROMFS: copying, generating airframes"
 	)
 
 # copy extras into ROMFS
@@ -152,6 +149,17 @@ add_custom_command(OUTPUT romfs_extras.stamp
 	COMMENT "ROMFS: copying extras"
 	)
 
+add_custom_command(OUTPUT romfs_pruned.stamp
+	COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/Tools/px_romfs_pruner.py
+		--folder ${romfs_gen_root_dir} --board ${PX4_BOARD}
+	DEPENDS
+		${romfs_gen_root_dir}/init.d/rcS
+		${romfs_gen_root_dir}/init.d/rc.autostart
+		romfs_extras.stamp
+		${PX4_SOURCE_DIR}/Tools/px_romfs_pruner.py
+	COMMENT "ROMFS: pruning"
+	)
+
 # create romfs.img
 find_program(GENROMFS genromfs)
 if(NOT GENROMFS)
@@ -161,9 +169,7 @@ add_custom_command(OUTPUT romfs.img romfs.txt
 	COMMAND ${CMAKE_COMMAND} -E remove -f romfs.img romfs.txt
 	COMMAND ${GENROMFS} -f romfs.img -d ${romfs_gen_root_dir} -V "NSHInitVol" -v > romfs.txt 2>&1
 	DEPENDS
-		${romfs_gen_root_dir}/init.d/rcS
-		${romfs_gen_root_dir}/init.d/rc.autostart
-		romfs_extras.stamp
+		romfs_pruned.stamp
 	COMMENT "ROMFS: generating image"
 	)
 

--- a/ROMFS/px4fmu_common/init.d-posix/10016_iris
+++ b/ROMFS/px4fmu_common/init.d-posix/10016_iris
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name 3DR Iris Quadrotor SITL
 #

--- a/ROMFS/px4fmu_common/init.d-posix/1010_iris_opt_flow
+++ b/ROMFS/px4fmu_common/init.d-posix/1010_iris_opt_flow
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name 3DR Iris Quadrotor SITL (Optical Flow)
 #

--- a/ROMFS/px4fmu_common/init.d-posix/1011_iris_irlock
+++ b/ROMFS/px4fmu_common/init.d-posix/1011_iris_irlock
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name 3DR Iris Quadrotor SITL (irlock)
 #

--- a/ROMFS/px4fmu_common/init.d-posix/1012_iris_rplidar
+++ b/ROMFS/px4fmu_common/init.d-posix/1012_iris_rplidar
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name 3DR Iris Quadrotor SITL (rplidar)
 #

--- a/ROMFS/px4fmu_common/init.d-posix/1013_iris_vision
+++ b/ROMFS/px4fmu_common/init.d-posix/1013_iris_vision
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name 3DR Iris Quadrotor SITL (Vision)
 #

--- a/ROMFS/px4fmu_common/init.d-posix/1014_solo
+++ b/ROMFS/px4fmu_common/init.d-posix/1014_solo
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Solo
 #

--- a/ROMFS/px4fmu_common/init.d-posix/1020_hippocampus
+++ b/ROMFS/px4fmu_common/init.d-posix/1020_hippocampus
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Hippocampus UUV
 #

--- a/ROMFS/px4fmu_common/init.d-posix/1030_plane
+++ b/ROMFS/px4fmu_common/init.d-posix/1030_plane
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Plane SITL
 #

--- a/ROMFS/px4fmu_common/init.d-posix/1040_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/1040_standard_vtol
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Standard VTOL
 #

--- a/ROMFS/px4fmu_common/init.d-posix/1041_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/1041_tailsitter
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Quadrotor + Tailsitter
 #

--- a/ROMFS/px4fmu_common/init.d-posix/1042_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/1042_tiltrotor
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name VTOL Tiltrotor
 #

--- a/ROMFS/px4fmu_common/init.d-posix/1060_rover
+++ b/ROMFS/px4fmu_common/init.d-posix/1060_rover
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Rover
 #

--- a/ROMFS/px4fmu_common/init.d-posix/6011_typhoon_h480
+++ b/ROMFS/px4fmu_common/init.d-posix/6011_typhoon_h480
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Typhoon H480 SITL
 #

--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -45,7 +45,7 @@ else
 	REQUESTED_AUTOSTART=$(ls "$SCRIPT_DIR" | sed -n 's/^\([0-9][0-9]*\)_'${PX4_SIM_MODEL}'$/\1/p')
 	if [ -z "$REQUESTED_AUTOSTART" ]; then
 		echo "Error: Unknown model '$PX4_SIM_MODEL'"
-		exit -1
+		exit 1
 	fi
 fi
 
@@ -174,7 +174,7 @@ do
 done
 if [ ! -e "$autostart_file" ]; then
 	echo "Error: no autostart file found ($autostart_file)"
-	exit -1
+	exit 1
 fi
 
 sh "$autostart_file"

--- a/ROMFS/px4fmu_common/init.d/airframes/1000_rc_fw_easystar.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1000_rc_fw_easystar.hil
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name HILStar (XPlane)
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/10015_tbs_discovery
+++ b/ROMFS/px4fmu_common/init.d/airframes/10015_tbs_discovery
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Team Blacksheep Discovery
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/10016_3dr_iris
+++ b/ROMFS/px4fmu_common/init.d/airframes/10016_3dr_iris
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name 3DR Iris Quadrotor
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/10017_steadidrone_qu4d
+++ b/ROMFS/px4fmu_common/init.d/airframes/10017_steadidrone_qu4d
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Steadidrone QU4D
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/10018_tbs_endurance
+++ b/ROMFS/px4fmu_common/init.d/airframes/10018_tbs_endurance
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Team Blacksheep Discovery Endurance
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/1001_rc_quad_x.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1001_rc_quad_x.hil
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name HIL Quadcopter X
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name HIL Standard VTOL QuadPlane
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/11001_hexa_cox
+++ b/ROMFS/px4fmu_common/init.d/airframes/11001_hexa_cox
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Generic Hexarotor coaxial geometry
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/12001_octo_cox
+++ b/ROMFS/px4fmu_common/init.d/airframes/12001_octo_cox
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Generic 10" Octo coaxial geometry
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/12002_steadidrone_mavrik
+++ b/ROMFS/px4fmu_common/init.d/airframes/12002_steadidrone_mavrik
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Steadidrone MAVRIK
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/13000_generic_vtol_standard
+++ b/ROMFS/px4fmu_common/init.d/airframes/13000_generic_vtol_standard
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Generic Quadplane VTOL
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/13001_caipirinha_vtol
+++ b/ROMFS/px4fmu_common/init.d/airframes/13001_caipirinha_vtol
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Caipiroshka Duo Tailsitter
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/13002_firefly6
+++ b/ROMFS/px4fmu_common/init.d/airframes/13002_firefly6
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name BirdsEyeView Aerobotics FireFly6
 # @type VTOL Tiltrotor

--- a/ROMFS/px4fmu_common/init.d/airframes/13003_quad_tailsitter
+++ b/ROMFS/px4fmu_common/init.d/airframes/13003_quad_tailsitter
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Quadrotor X Tailsitter
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/13004_quad+_tailsitter
+++ b/ROMFS/px4fmu_common/init.d/airframes/13004_quad+_tailsitter
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Quadrotor + Tailsitter
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/13005_vtol_AAERT_quad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13005_vtol_AAERT_quad
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Fun Cub Quad VTOL
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/13006_vtol_standard_delta
+++ b/ROMFS/px4fmu_common/init.d/airframes/13006_vtol_standard_delta
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Generic quad delta VTOL
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/13007_vtol_AAVVT_quad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13007_vtol_AAVVT_quad
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Generic AAVVT v-tail plane airframe with Quad VTOL.
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/13008_QuadRanger
+++ b/ROMFS/px4fmu_common/init.d/airframes/13008_QuadRanger
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name QuadRanger
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/13009_vtol_spt_ranger
+++ b/ROMFS/px4fmu_common/init.d/airframes/13009_vtol_spt_ranger
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Sparkle Tech Ranger VTOL
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/13010_claire
+++ b/ROMFS/px4fmu_common/init.d/airframes/13010_claire
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name CruiseAder Claire
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
+++ b/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name E-flite Convergence
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Vertical Technologies DeltaQuad
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/14001_tri_y_yaw+
+++ b/ROMFS/px4fmu_common/init.d/airframes/14001_tri_y_yaw+
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Generic Tricopter Y+ Geometry
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/14002_tri_y_yaw-
+++ b/ROMFS/px4fmu_common/init.d/airframes/14002_tri_y_yaw-
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Generic Tricopter Y- Geometry
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/15001_coax_heli
+++ b/ROMFS/px4fmu_common/init.d/airframes/15001_coax_heli
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Esky (Big) Lama v4
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/16001_helicopter
+++ b/ROMFS/px4fmu_common/init.d/airframes/16001_helicopter
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Blade 130X
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/2100_standard_plane
+++ b/ROMFS/px4fmu_common/init.d/airframes/2100_standard_plane
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Standard Plane
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/2105_maja
+++ b/ROMFS/px4fmu_common/init.d/airframes/2105_maja
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Bormatec Maja
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/2106_albatross
+++ b/ROMFS/px4fmu_common/init.d/airframes/2106_albatross
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Applied Aeronautics Albatross
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/2200_mini_talon
+++ b/ROMFS/px4fmu_common/init.d/airframes/2200_mini_talon
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name X-UAV Mini Talon
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/24001_dodeca_cox
+++ b/ROMFS/px4fmu_common/init.d/airframes/24001_dodeca_cox
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Generic Dodecarotor cox geometry
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/3000_generic_wing
+++ b/ROMFS/px4fmu_common/init.d/airframes/3000_generic_wing
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Generic Flying Wing
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/3030_io_camflyer
+++ b/ROMFS/px4fmu_common/init.d/airframes/3030_io_camflyer
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name IO Camflyer
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/3031_phantom
+++ b/ROMFS/px4fmu_common/init.d/airframes/3031_phantom
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Phantom FPV Flying Wing
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/3032_skywalker_x5
+++ b/ROMFS/px4fmu_common/init.d/airframes/3032_skywalker_x5
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Skywalker X5 Flying Wing
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/3033_wingwing
+++ b/ROMFS/px4fmu_common/init.d/airframes/3033_wingwing
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Wing Wing (aka Z-84) Flying Wing
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/3034_fx79
+++ b/ROMFS/px4fmu_common/init.d/airframes/3034_fx79
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name FX-79 Buffalo Flying Wing
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/3035_viper
+++ b/ROMFS/px4fmu_common/init.d/airframes/3035_viper
@@ -1,5 +1,4 @@
-#
-#!nsh
+#!/bin/sh
 #
 # @name Viper
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/3036_pigeon
+++ b/ROMFS/px4fmu_common/init.d/airframes/3036_pigeon
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Sparkle Tech Pigeon
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/3037_parrot_disco_mod
+++ b/ROMFS/px4fmu_common/init.d/airframes/3037_parrot_disco_mod
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Modified Parrot Disco
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/3100_tbs_caipirinha
+++ b/ROMFS/px4fmu_common/init.d/airframes/3100_tbs_caipirinha
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name TBS Caipirinha
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4001_quad_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4001_quad_x
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Generic Quadrotor x
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4002_quad_x_mount
+++ b/ROMFS/px4fmu_common/init.d/airframes/4002_quad_x_mount
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Generic Quadrotor x with mount (e.g. gimbal)
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4003_qavr5
+++ b/ROMFS/px4fmu_common/init.d/airframes/4003_qavr5
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Lumenier QAV-R (raceblade) 5" arms
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4004_H4_680mm
+++ b/ROMFS/px4fmu_common/init.d/airframes/4004_H4_680mm
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name H4 680mm with Z1 Tiny2 Gimbal
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4009_qav250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4009_qav250
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Lumenier QAV250
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4010_dji_f330
+++ b/ROMFS/px4fmu_common/init.d/airframes/4010_dji_f330
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name DJI Flame Wheel F330
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4011_dji_f450
+++ b/ROMFS/px4fmu_common/init.d/airframes/4011_dji_f450
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name DJI Flame Wheel F450
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4012_quad_x_can
+++ b/ROMFS/px4fmu_common/init.d/airframes/4012_quad_x_can
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name F450-sized quadrotor with CAN
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4013_bebop
+++ b/ROMFS/px4fmu_common/init.d/airframes/4013_bebop
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Parrot Bebop Frame
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4014_s500
+++ b/ROMFS/px4fmu_common/init.d/airframes/4014_s500
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name S500
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4020_hk_micro_pcb
+++ b/ROMFS/px4fmu_common/init.d/airframes/4020_hk_micro_pcb
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Hobbyking Micro PCB
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4030_3dr_solo
+++ b/ROMFS/px4fmu_common/init.d/airframes/4030_3dr_solo
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name 3DR Solo
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4031_3dr_quad
+++ b/ROMFS/px4fmu_common/init.d/airframes/4031_3dr_quad
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name 3DR DIY Quad
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4040_reaper
+++ b/ROMFS/px4fmu_common/init.d/airframes/4040_reaper
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Reaper 500 Quad
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4050_generic_250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4050_generic_250
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Generic 250 Racer
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4051_s250aq
+++ b/ROMFS/px4fmu_common/init.d/airframes/4051_s250aq
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Spedix S250AQ
 # @url https://docs.px4.io/en/framebuild_multicopter/spedix_s250_pixracer.html

--- a/ROMFS/px4fmu_common/init.d/airframes/4060_dji_matrice_100
+++ b/ROMFS/px4fmu_common/init.d/airframes/4060_dji_matrice_100
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name DJI Matrice 100
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4070_aerofc
+++ b/ROMFS/px4fmu_common/init.d/airframes/4070_aerofc
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Intel Aero Ready to Fly Drone
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4080_zmr250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4080_zmr250
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name ZMR250 Racer
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4090_nanomind
+++ b/ROMFS/px4fmu_common/init.d/airframes/4090_nanomind
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name NanoMind 110 Quad
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4100_tiltquadrotor
+++ b/ROMFS/px4fmu_common/init.d/airframes/4100_tiltquadrotor
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Tilt-Quadrotor
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4250_teal
+++ b/ROMFS/px4fmu_common/init.d/airframes/4250_teal
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Teal One
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/4900_crazyflie
+++ b/ROMFS/px4fmu_common/init.d/airframes/4900_crazyflie
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Crazyflie 2
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
+++ b/ROMFS/px4fmu_common/init.d/airframes/50000_generic_ground_vehicle
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Generic Ground Vehicle
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/50001_axialracing_ax10
+++ b/ROMFS/px4fmu_common/init.d/airframes/50001_axialracing_ax10
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Axial Racing AX10
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/50002_traxxas_stampede_2wd
+++ b/ROMFS/px4fmu_common/init.d/airframes/50002_traxxas_stampede_2wd
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Traxxas stampede vxl 2wd
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/5001_quad_+
+++ b/ROMFS/px4fmu_common/init.d/airframes/5001_quad_+
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Generic 10" Quad + geometry
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/6001_hexa_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/6001_hexa_x
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Generic Hexarotor x geometry
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/7001_hexa_+
+++ b/ROMFS/px4fmu_common/init.d/airframes/7001_hexa_+
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Generic Hexarotor + geometry
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/8001_octo_x
+++ b/ROMFS/px4fmu_common/init.d/airframes/8001_octo_x
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Generic Octocopter X geometry
 #

--- a/ROMFS/px4fmu_common/init.d/airframes/9001_octo_+
+++ b/ROMFS/px4fmu_common/init.d/airframes/9001_octo_+
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name Generic Octocopter + geometry
 #

--- a/ROMFS/px4fmu_common/init.d/rc.fw_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.fw_apps
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # Standard apps for fixed wing
 #

--- a/ROMFS/px4fmu_common/init.d/rc.fw_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.fw_defaults
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # Fixed wing default parameters
 #

--- a/ROMFS/px4fmu_common/init.d/rc.interface
+++ b/ROMFS/px4fmu_common/init.d/rc.interface
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # Script to configure control interfaces.
 #

--- a/ROMFS/px4fmu_common/init.d/rc.io
+++ b/ROMFS/px4fmu_common/init.d/rc.io
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # PX4IO interface init script.
 #

--- a/ROMFS/px4fmu_common/init.d/rc.logging
+++ b/ROMFS/px4fmu_common/init.d/rc.logging
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 # Standard startup script for logging.
 #
 # NOTE: Script variables are declared/initialized/unset in the rcS script.

--- a/ROMFS/px4fmu_common/init.d/rc.mavlink
+++ b/ROMFS/px4fmu_common/init.d/rc.mavlink
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # MAVLink startup script.
 #

--- a/ROMFS/px4fmu_common/init.d/rc.mc_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_apps
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # Standard apps for multirotors. Attitude/Position estimator, Attitude/Position control.
 #

--- a/ROMFS/px4fmu_common/init.d/rc.mc_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_defaults
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # Multicopter default parameters.
 #

--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # Standard startup script for sensor drivers.
 #

--- a/ROMFS/px4fmu_common/init.d/rc.thermal_cal
+++ b/ROMFS/px4fmu_common/init.d/rc.thermal_cal
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # Thermal Calibration startup script.
 #

--- a/ROMFS/px4fmu_common/init.d/rc.ugv_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.ugv_apps
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # Standard apps for unmanned ground vehicles (UGV).
 #

--- a/ROMFS/px4fmu_common/init.d/rc.ugv_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.ugv_defaults
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # UGV default parameters.
 #

--- a/ROMFS/px4fmu_common/init.d/rc.vehicle_setup
+++ b/ROMFS/px4fmu_common/init.d/rc.vehicle_setup
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # Vehicle configuration setup script.
 #

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_apps
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # Standard apps for vtol: Attitude/Position estimator, Attitude/Position control.
 #

--- a/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.vtol_defaults
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # VTOL default parameters.
 #

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 # Un comment and use set +e to ignore and set -e to enable 'exit on error control'
 set +e
 # Un comment the line below to help debug scripts by printing a trace of the script commands

--- a/ROMFS/px4fmu_test/init.d/rc.sensors
+++ b/ROMFS/px4fmu_test/init.d/rc.sensors
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # Standard startup script for onboard sensor drivers.
 #

--- a/ROMFS/px4fmu_test/init.d/rc.standalone
+++ b/ROMFS/px4fmu_test/init.d/rc.standalone
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # Flight startup script for PX4FMU standalone configuration.
 #

--- a/ROMFS/px4fmu_test/init.d/rcS
+++ b/ROMFS/px4fmu_test/init.d/rcS
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # PX4FMU startup script for test hackery.
 #


### PR DESCRIPTION
The startup file rc.board is copied to the build/../genromfs folder after the pruning of the files happened. Thus, about 2000 bytes of comments and whitespace were included in the ROMFS.

This commit moves pruning of the files in ROMFS to a separate cmake custom command which happens after the ROMFS files have been copied and the extra files have been added.

Testing showed that this change only affected the rc.board file as expected:

```
diff -r genromfs.master genromfs.fix | diffstat
 rc.board |  162 ++++++++++++++++++---------------------------------------------
 1 file changed, 47 insertions(+), 115 deletions(-)

ls -l px4_fmu-v2.bin.fix px4_fmu-v2.bin.master
-rwxr-xr-x 1 julianoes julianoes 1020929 Dec 17 16:54 px4_fmu-v2.bin.fix
-rwxr-xr-x 1 julianoes julianoes 1022961 Dec 17 16:51 px4_fmu-v2.bin.master
```

(The build size is smaller because this was built with `ll40ls` and `sf0x` in order to get it to compile initially.)
