### PR TITLE
Fix to first order altitude hold gradient calculation

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1318,7 +1318,7 @@ Mission::altitude_sp_foh_update()
 =======
                 float delta_alt = (get_absolute_altitude_for_item(_mission_item) - _foh_calculation_start_altitude);
                 // avoiding division by 0
-                float grad = -delta_alt / max((_distance_current_previous - acc_rad), 0.1f);
+                float grad = -delta_alt / math::max((_distance_current_previous - acc_rad), 0.1f);
                 float a = _foh_calculation_start_altitude - grad * _distance_current_previous;
 >>>>>>> updates to altitude foh calculation
 		pos_sp_triplet->current.alt = a + grad * _min_current_sp_distance_xy;

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1312,7 +1312,7 @@ Mission::altitude_sp_foh_update()
 		 **/
                 float delta_alt = (get_absolute_altitude_for_item(_mission_item) - _foh_calculation_start_altitude);
                 // avoiding division by 0
-                float grad = -delta_alt / max((_distance_current_previous - acc_rad), 0.1f);
+                float grad = -delta_alt / math::max((_distance_current_previous - acc_rad), 0.1f);
                 float a = _foh_calculation_start_altitude - grad * _distance_current_previous;
 		pos_sp_triplet->current.alt = a + grad * _min_current_sp_distance_xy;
 	}

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1310,10 +1310,17 @@ Mission::altitude_sp_foh_update()
 		 * The setpoint is set linearly and such that the system reaches the current altitude at the acceptance
 		 * radius around the current waypoint
 		 **/
+<<<<<<< HEAD
 		float delta_alt = (get_absolute_altitude_for_item(_mission_item) - _foh_calculation_start_altitude);
 		// avoiding division by 0
 		float grad = -delta_alt / math::max((_distance_current_previous - acc_rad), 0.1f);
 		float a = _foh_calculation_start_altitude - grad * _distance_current_previous;
+=======
+                float delta_alt = (get_absolute_altitude_for_item(_mission_item) - _foh_calculation_start_altitude);
+                // avoiding division by 0
+                float grad = -delta_alt / max((_distance_current_previous - acc_rad), 0.1f);
+                float a = _foh_calculation_start_altitude - grad * _distance_current_previous;
+>>>>>>> updates to altitude foh calculation
 		pos_sp_triplet->current.alt = a + grad * _min_current_sp_distance_xy;
 	}
 

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1057,6 +1057,8 @@ Mission::set_mission_items()
 		_distance_current_previous = get_distance_to_next_waypoint(
 						     pos_sp_triplet->current.lat, pos_sp_triplet->current.lon,
                                                      _navigator->get_global_position()->lat, _navigator->get_global_position()->lon);
+
+                _foh_calculation_start_altitude = _navigator->get_global_position()->alt;
 	}
 
 	_navigator->set_position_setpoint_triplet_updated();
@@ -1308,9 +1310,10 @@ Mission::altitude_sp_foh_update()
 		 * The setpoint is set linearly and such that the system reaches the current altitude at the acceptance
 		 * radius around the current waypoint
 		 **/
-		float delta_alt = (get_absolute_altitude_for_item(_mission_item) - pos_sp_triplet->previous.alt);
-		float grad = -delta_alt / (_distance_current_previous - acc_rad);
-		float a = pos_sp_triplet->previous.alt - grad * _distance_current_previous;
+                float delta_alt = (get_absolute_altitude_for_item(_mission_item) - _foh_calculation_start_altitude);
+                // avoiding division by 0
+                float grad = -delta_alt / max((_distance_current_previous - acc_rad), 0.1f);
+                float a = _foh_calculation_start_altitude - grad * _distance_current_previous;
 		pos_sp_triplet->current.alt = a + grad * _min_current_sp_distance_xy;
 	}
 

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1051,12 +1051,12 @@ Mission::set_mission_items()
 		pos_sp_triplet->next.valid = false;
 	}
 
-	/* Save the distance between the current sp and the previous one */
-	if (pos_sp_triplet->current.valid && pos_sp_triplet->previous.valid) {
+        /* Save the distance between the current sp and our current position */
+        if (pos_sp_triplet->current.valid) {
 
 		_distance_current_previous = get_distance_to_next_waypoint(
 						     pos_sp_triplet->current.lat, pos_sp_triplet->current.lon,
-						     pos_sp_triplet->previous.lat, pos_sp_triplet->previous.lon);
+                                                     _navigator->get_global_position()->lat, _navigator->get_global_position()->lon);
 	}
 
 	_navigator->set_position_setpoint_triplet_updated();

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1057,8 +1057,6 @@ Mission::set_mission_items()
 		_distance_current_previous = get_distance_to_next_waypoint(
 						     pos_sp_triplet->current.lat, pos_sp_triplet->current.lon,
 						     _navigator->get_global_position()->lat, _navigator->get_global_position()->lon);
-
-		_foh_calculation_start_altitude = _navigator->get_global_position()->alt;
 	}
 
 	_navigator->set_position_setpoint_triplet_updated();
@@ -1310,7 +1308,7 @@ Mission::altitude_sp_foh_update()
 		 * The setpoint is set linearly and such that the system reaches the current altitude at the acceptance
 		 * radius around the current waypoint
 		 **/
-		float delta_alt = (get_absolute_altitude_for_item(_mission_item) - _foh_calculation_start_altitude);
+		float delta_alt = (get_absolute_altitude_for_item(_mission_item) - pos_sp_triplet->previous.alt);
 		// avoiding division by 0
 		float grad = -delta_alt / math::max((_distance_current_previous - acc_rad), 0.1f);
 		float a = _foh_calculation_start_altitude - grad * _distance_current_previous;

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1311,7 +1311,7 @@ Mission::altitude_sp_foh_update()
 		float delta_alt = (get_absolute_altitude_for_item(_mission_item) - pos_sp_triplet->previous.alt);
 		// avoiding division by 0
 		float grad = -delta_alt / math::max((_distance_current_previous - acc_rad), 0.1f);
-		float a = _foh_calculation_start_altitude - grad * _distance_current_previous;
+		float a = pos_sp_triplet->previous.alt - grad * _distance_current_previous;
 		pos_sp_triplet->current.alt = a + grad * _min_current_sp_distance_xy;
 	}
 

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1051,14 +1051,14 @@ Mission::set_mission_items()
 		pos_sp_triplet->next.valid = false;
 	}
 
-        /* Save the distance between the current sp and our current position */
-        if (pos_sp_triplet->current.valid) {
+	/* Save the distance between the current sp and our current position */
+	if (pos_sp_triplet->current.valid) {
 
 		_distance_current_previous = get_distance_to_next_waypoint(
 						     pos_sp_triplet->current.lat, pos_sp_triplet->current.lon,
-                                                     _navigator->get_global_position()->lat, _navigator->get_global_position()->lon);
+						     _navigator->get_global_position()->lat, _navigator->get_global_position()->lon);
 
-                _foh_calculation_start_altitude = _navigator->get_global_position()->alt;
+		_foh_calculation_start_altitude = _navigator->get_global_position()->alt;
 	}
 
 	_navigator->set_position_setpoint_triplet_updated();
@@ -1310,10 +1310,10 @@ Mission::altitude_sp_foh_update()
 		 * The setpoint is set linearly and such that the system reaches the current altitude at the acceptance
 		 * radius around the current waypoint
 		 **/
-                float delta_alt = (get_absolute_altitude_for_item(_mission_item) - _foh_calculation_start_altitude);
-                // avoiding division by 0
-                float grad = -delta_alt / math::max((_distance_current_previous - acc_rad), 0.1f);
-                float a = _foh_calculation_start_altitude - grad * _distance_current_previous;
+		float delta_alt = (get_absolute_altitude_for_item(_mission_item) - _foh_calculation_start_altitude);
+		// avoiding division by 0
+		float grad = -delta_alt / math::max((_distance_current_previous - acc_rad), 0.1f);
+		float a = _foh_calculation_start_altitude - grad * _distance_current_previous;
 		pos_sp_triplet->current.alt = a + grad * _min_current_sp_distance_xy;
 	}
 

--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -1310,17 +1310,10 @@ Mission::altitude_sp_foh_update()
 		 * The setpoint is set linearly and such that the system reaches the current altitude at the acceptance
 		 * radius around the current waypoint
 		 **/
-<<<<<<< HEAD
 		float delta_alt = (get_absolute_altitude_for_item(_mission_item) - _foh_calculation_start_altitude);
 		// avoiding division by 0
 		float grad = -delta_alt / math::max((_distance_current_previous - acc_rad), 0.1f);
 		float a = _foh_calculation_start_altitude - grad * _distance_current_previous;
-=======
-                float delta_alt = (get_absolute_altitude_for_item(_mission_item) - _foh_calculation_start_altitude);
-                // avoiding division by 0
-                float grad = -delta_alt / math::max((_distance_current_previous - acc_rad), 0.1f);
-                float a = _foh_calculation_start_altitude - grad * _distance_current_previous;
->>>>>>> updates to altitude foh calculation
 		pos_sp_triplet->current.alt = a + grad * _min_current_sp_distance_xy;
 	}
 

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -267,7 +267,6 @@ private:
 
 	float _distance_current_previous{0.0f}; /**< distance from previous to current sp in pos_sp_triplet,
 					    only use if current and previous are valid */
-	float _foh_calculation_start_altitude{0.0}; /**< altitude that is used as the starting point for foh calculation */
 
 	enum work_item_type {
 		WORK_ITEM_TYPE_DEFAULT,		/**< default mission item */

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -267,6 +267,7 @@ private:
 
 	float _distance_current_previous{0.0f}; /**< distance from previous to current sp in pos_sp_triplet,
 					    only use if current and previous are valid */
+        float _foh_calculation_start_altitude{0.0}; /**< altitude that is used as the starting point for foh calculation */
 
 	enum work_item_type {
 		WORK_ITEM_TYPE_DEFAULT,		/**< default mission item */

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -267,7 +267,7 @@ private:
 
 	float _distance_current_previous{0.0f}; /**< distance from previous to current sp in pos_sp_triplet,
 					    only use if current and previous are valid */
-        float _foh_calculation_start_altitude{0.0}; /**< altitude that is used as the starting point for foh calculation */
+	float _foh_calculation_start_altitude{0.0}; /**< altitude that is used as the starting point for foh calculation */
 
 	enum work_item_type {
 		WORK_ITEM_TYPE_DEFAULT,		/**< default mission item */


### PR DESCRIPTION
**Test data / coverage**
After pr: The altitude setpoint (black) is performing the first order hold seemingly well. (There are some weird spikes here and there, don't know why. Any ideas? However, they don't seem to affect the tecs altitude setpoint.) Tested with at least 20 flight.
![image](https://user-images.githubusercontent.com/5569656/50109996-dd461c00-0241-11e9-818c-8168f07b458f.png)

Before pr: the altitude setpoint will change transiently if the current waypoint is within the acceptance radius of the next one.
![image](https://user-images.githubusercontent.com/5569656/50111159-d076f780-0244-11e9-8638-2d2a2dc3d08b.png)

**Describe problem solved by the proposed pull request**
![nimeton](https://user-images.githubusercontent.com/5569656/50109199-cacae300-023f-11e9-8649-71372e0f5d04.png)
Before pr: Upon arriving to point A (which is within the acceptance radius of waypoint 1) we calculate the altitude gradient between waypoints 1 and 2. However, if waypoint 1 is **within** the acceptance radius of waypoint 2, the altitude setpoint will change transiently. 
After pr: The altitude control will follow the red line between the actual starting point of the descent (A) and C, which is at the start of waypoint 2 acceptance radius. 

**Describe your preferred solution**
Instead of using the lat, lon and altitude of the previous waypoint (in this case 1), use the lat, lon and altitude of the vehicle at the beginning of the altitude change.

