### PR TITLE
Small practical Orbit fixes

### DIFF
--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -118,3 +118,8 @@ px4_add_board(
 		#rover_steering_control # Rover example app
 		#segway
 	)
+
+# remove optional flight task features from fmu-v2 to save flash memory
+list(APPEND flight_tasks_to_remove
+		Orbit
+	)

--- a/src/lib/FlightTasks/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/lib/FlightTasks/tasks/Orbit/FlightTaskOrbit.cpp
@@ -117,19 +117,18 @@ bool FlightTaskOrbit::sendTelemetry()
 	return true;
 }
 
-bool FlightTaskOrbit::setRadius(const float r)
+bool FlightTaskOrbit::setRadius(float r)
 {
-	if (math::isInRange(r, _radius_min, _radius_max)) {
-		// small radius is more important than high velocity for safety
-		if (!checkAcceleration(r, _v, _acceleration_max)) {
-			_v = math::sign(_v) * sqrtf(_acceleration_max * r);
-		}
+	// clip the radius to be within range
+	r = math::constrain(r, _radius_min, _radius_max);
 
-		_r = r;
-		return true;
+	// small radius is more important than high velocity for safety
+	if (!checkAcceleration(r, _v, _acceleration_max)) {
+		_v = math::sign(_v) * sqrtf(_acceleration_max * r);
 	}
 
-	return false;
+	_r = r;
+	return true;
 }
 
 bool FlightTaskOrbit::setVelocity(const float v)

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -4110,7 +4110,6 @@ protected:
 		vehicle_status_s status;
 
 		if (_status_sub->update(&status)) {
-
 			mavlink_command_long_t msg = {};
 
 			msg.target_system = 0;
@@ -4185,7 +4184,6 @@ protected:
 		distance_sensor_s dist_sensor;
 
 		if (_distance_sensor_sub->update(&_dist_sensor_time, &dist_sensor)) {
-
 			mavlink_distance_sensor_t msg = {};
 
 			msg.time_boot_ms = dist_sensor.timestamp / 1000; /* us to ms */
@@ -4520,7 +4518,6 @@ protected:
 		wind_estimate_s wind_estimate;
 
 		if (_wind_estimate_sub->update(&_wind_estimate_time, &wind_estimate)) {
-
 			mavlink_wind_cov_t msg = {};
 
 			msg.time_usec = wind_estimate.timestamp;
@@ -4600,7 +4597,6 @@ protected:
 		struct mount_orientation_s mount_orientation;
 
 		if (_mount_orientation_sub->update(&_mount_orientation_time, &mount_orientation)) {
-
 			mavlink_mount_orientation_t msg = {};
 
 			msg.roll = math::degrees(mount_orientation.attitude_euler_angle[0]);
@@ -4670,14 +4666,12 @@ protected:
 
 	bool send(const hrt_abstime t)
 	{
-
 		vehicle_attitude_s att = {};
 		vehicle_global_position_s gpos = {};
 		bool att_updated = _att_sub->update(&_att_time, &att);
 		bool gpos_updated = _gpos_sub->update(&_gpos_time, &gpos);
 
 		if (att_updated || gpos_updated) {
-
 			mavlink_hil_state_quaternion_t msg = {};
 
 			// vehicle_attitude -> hil_state_quaternion
@@ -4829,7 +4823,7 @@ protected:
 		struct orbit_status_s _orbit_status;
 
 		if (_sub->update(&_orbit_status_time, &_orbit_status)) {
-			mavlink_orbit_execution_status_t _msg_orbit_execution_status;
+			mavlink_orbit_execution_status_t _msg_orbit_execution_status = {};
 
 			_msg_orbit_execution_status.time_usec = _orbit_status.timestamp;
 			_msg_orbit_execution_status.radius = _orbit_status.radius;


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
- MAVLink message struct was not explicitly initialized which did not cause any problems but better be safe than sorry.
- The orbit radius setter did just not set a radius that's out of range but in practice the lead to executing the orbit with a default radius when the command contains an out of range radius. In the future this should be handled by denying the execution completely but as a hotfix clipping to the closest possible radius rather than taking the default is already better.

**Additional context**
These practical fixes result from testing the feature before putting it into a release.

**Test data / coverage**
SITL