### PR TITLE
Omnibus: add support for the BetaFPV Beta75X 2S Brushless Whoop

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
@@ -5,6 +5,12 @@
 # @type Quadrotor H
 # @class Copter
 #
+# @board px4_fmu-v2 exclude
+# @board px4_fmu-v3 exclude
+# @board px4_fmu-v4 exclude
+# @board px4_fmu-v4pro exclude
+# @board px4_fmu-v5 exclude
+#
 # @output MAIN1 motor 1
 # @output MAIN2 motor 2
 # @output MAIN3 motor 3

--- a/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
@@ -1,0 +1,59 @@
+#!nsh
+#
+# @name BetaFPV Beta75X 2S Brushless Whoop
+#
+# @type Quadrotor H
+# @class Copter
+#
+# @output MAIN1 motor 1
+# @output MAIN2 motor 2
+# @output MAIN3 motor 3
+# @output MAIN4 motor 4
+#
+# @maintainer Beat Kueng <beat-kueng@gmx.net>
+#
+
+sh /etc/init.d/rc.mc_defaults
+
+if [ $AUTOCNF = yes ]
+then
+	param set CBRK_SUPPLY_CHK 894281
+	param set CBRK_USB_CHK 197848
+
+	param set IMU_GYRO_CUTOFF 100
+	param set MC_DTERM_CUTOFF 60
+
+	param set MC_AIRMODE 2
+	param set MC_PITCHRATE_D 0.0010
+	param set MC_PITCHRATE_I 0.5
+	param set MC_PITCHRATE_MAX 600
+	param set MC_PITCHRATE_P 0.0750
+	param set MC_PITCH_P 6
+	param set MC_ROLLRATE_D 0.0010
+	param set MC_ROLLRATE_I 0.4
+	param set MC_ROLLRATE_MAX 600
+	param set MC_ROLLRATE_P 0.0750
+	param set MC_YAWRATE_I 0.3
+	param set MC_YAWRATE_MAX 400
+	param set MC_YAWRATE_P 0.17
+	param set MC_YAW_P 4
+
+	param set MPC_MANTHR_MIN 0
+	param set MPC_MAN_TILT_MAX 60
+
+	param set MOT_ORDERING 1
+	param set PWM_DISARMED 950
+	param set PWM_MAX 1900
+	param set PWM_MIN 1100
+	param set PWM_RATE 0
+
+	param set RC_FLT_CUTOFF 0
+
+	param set SYS_HAS_BARO 0
+	param set SYS_HAS_MAG 0
+fi
+
+# The Whoop uses reversed props
+set MIXER quad_h
+set PWM_OUT 1234
+

--- a/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
@@ -72,6 +72,7 @@ px4_add_romfs_files(
 	4030_3dr_solo
 	4031_3dr_quad
 	4040_reaper
+	4041_beta75x
 	4050_generic_250
 	4051_s250aq
 	4060_dji_matrice_100

--- a/boards/omnibus/f4sd/init/rc.board
+++ b/boards/omnibus/f4sd/init/rc.board
@@ -14,6 +14,16 @@
 #------------------------------------------------------------------------------
 #
 
+# transision from params file to flash-based params (2018-12-20)
+if [ -f $PARAM_FILE ]
+then
+	param load $PARAM_FILE
+	param save
+	# create a backup
+	mv $PARAM_FILE ${PARAM_FILE}.bak
+	reboot
+fi
+
 if [ $AUTOCNF = yes ]
 then
 	# Disable safety switch by default

--- a/boards/omnibus/f4sd/nuttx-config/scripts/ld.script
+++ b/boards/omnibus/f4sd/nuttx-config/scripts/ld.script
@@ -44,12 +44,13 @@
  * where the code expects to begin execution by jumping to the entry point in
  * the 0x0800:0000 address range.
  *
- * The first 0x4000 of flash is reserved for the bootloader.
+ * The first 16 KiB of flash is reserved for the bootloader.
+ * Paramater storage will use the next 16KiB Sector.
  */
 
 MEMORY
 {
-    flash (rx)   : ORIGIN = 0x08004000, LENGTH = 1008K
+    flash (rx)   : ORIGIN = 0x08008000, LENGTH = 992K
     sram (rwx)   : ORIGIN = 0x20000000, LENGTH = 128K
     ccsram (rwx) : ORIGIN = 0x10000000, LENGTH = 64K
 }

--- a/boards/omnibus/f4sd/src/board_config.h
+++ b/boards/omnibus/f4sd/src/board_config.h
@@ -61,6 +61,8 @@
 
 #define BOARD_OVERLOAD_LED     LED_BLUE
 
+#define  FLASH_BASED_PARAMS
+
 /*
  * ADC channels
  *

--- a/boards/omnibus/f4sd/src/init.c
+++ b/boards/omnibus/f4sd/src/init.c
@@ -78,6 +78,10 @@
 
 #include <parameters/param.h>
 
+# if defined(FLASH_BASED_PARAMS)
+#  include <parameters/flashparams/flashfs.h>
+#endif
+
 /****************************************************************************
  * Pre-Processor Definitions
  ****************************************************************************/
@@ -372,6 +376,24 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 	SPI_SETMODE(spi3, SPIDEV_MODE3);
 	SPI_SELECT(spi3, PX4_SPIDEV_BARO, false);
 	up_udelay(20);
+
+#if defined(FLASH_BASED_PARAMS)
+	static sector_descriptor_t params_sector_map[] = {
+		{1, 16 * 1024, 0x08004000},
+		{0, 0, 0},
+	};
+
+	/* Initialize the flashfs layer to use heap allocated memory */
+	result = parameter_flashfs_init(params_sector_map, NULL, 0);
+
+	if (result != OK) {
+		message("[boot] FAILED to init params in FLASH %d\n", result);
+		led_on(LED_AMBER);
+		return -ENODEV;
+	}
+
+#endif
+
 
 	return OK;
 }

--- a/src/lib/parameters/flashparams/flashparams.cpp
+++ b/src/lib/parameters/flashparams/flashparams.cpp
@@ -353,9 +353,9 @@ out:
 	return result;
 }
 
-int flash_param_save()
+int flash_param_save(bool only_unsaved)
 {
-	return param_export_internal(false);
+	return param_export_internal(only_unsaved);
 }
 
 int flash_param_load()
@@ -366,5 +366,5 @@ int flash_param_load()
 
 int flash_param_import()
 {
-	return -1;
+	return param_import_internal(false);
 }

--- a/src/lib/parameters/flashparams/flashparams.h
+++ b/src/lib/parameters/flashparams/flashparams.h
@@ -63,7 +63,7 @@ __EXPORT int param_set_external(param_t param, const void *val, bool mark_saved,
 __EXPORT const void *param_get_value_ptr_external(param_t param);
 
 /* The interface hooks to the Flash based storage. The caller is responsible for locking */
-__EXPORT int flash_param_save();
+__EXPORT int flash_param_save(bool only_unsaved);
 __EXPORT int flash_param_load();
 __EXPORT int flash_param_import();
 

--- a/src/lib/parameters/param.h
+++ b/src/lib/parameters/param.h
@@ -309,7 +309,7 @@ __EXPORT void		param_reset_excludes(const char *excludes[], int num_excludes);
  * Export changed parameters to a file.
  * Note: this method requires a large amount of stack size!
  *
- * @param fd		File descriptor to export to.
+ * @param fd		File descriptor to export to (-1 selects the FLASH storage).
  * @param only_unsaved	Only export changed parameters that have not yet been exported.
  * @return		Zero on success, nonzero on failure.
  */
@@ -320,7 +320,7 @@ __EXPORT int		param_export(int fd, bool only_unsaved);
  *
  * This function merges the imported parameters with the current parameter set.
  *
- * @param fd		File descriptor to import from.  (Currently expected to be a file.)
+ * @param fd		File descriptor to import from (-1 selects the FLASH storage).
  * @return		Zero on success, nonzero if an error occurred during import.
  *			Note that in the failure case, parameters may be inconsistent.
  */
@@ -332,7 +332,7 @@ __EXPORT int		param_import(int fd);
  * This function resets all parameters to their default values, then loads new
  * values from a file.
  *
- * @param fd		File descriptor to import from.  (Currently expected to be a file.)
+ * @param fd		File descriptor to import from (-1 selects the FLASH storage).
  * @return		Zero on success, nonzero if an error occurred during import.
  *			Note that in the failure case, parameters may be inconsistent.
  */
@@ -356,8 +356,9 @@ __EXPORT void		param_foreach(void (*func)(void *arg, param_t param), void *arg, 
 
 /**
  * Set the default parameter file name.
+ * This has no effect if the FLASH-based storage is enabled.
  *
- * @param filename	Path to the default parameter file.  The file is not require to
+ * @param filename	Path to the default parameter file.  The file is not required to
  *			exist.
  * @return		Zero on success.
  */

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -69,9 +69,14 @@
 
 #if defined(FLASH_BASED_PARAMS)
 #include "flashparams/flashparams.h"
+static const char *param_default_file = nullptr; // nullptr means to store to FLASH
+#else
+inline static int flash_param_save(bool only_unsaved) { return -1; }
+inline static int flash_param_load() { return -1; }
+inline static int flash_param_import() { return -1; }
+static const char *param_default_file = PX4_ROOTFSDIR"/eeprom/parameters";
 #endif
 
-static const char *param_default_file = PX4_ROOTFSDIR"/eeprom/parameters";
 static char *param_user_file = nullptr;
 
 #ifdef __PX4_QURT
@@ -921,6 +926,11 @@ param_reset_excludes(const char *excludes[], int num_excludes)
 int
 param_set_default_file(const char *filename)
 {
+#ifdef FLASH_BASED_PARAMS
+	// the default for flash-based params is always the FLASH
+	(void)filename;
+#else
+
 	if (param_user_file != nullptr) {
 		// we assume this is not in use by some other thread
 		free(param_user_file);
@@ -930,6 +940,8 @@ param_set_default_file(const char *filename)
 	if (filename) {
 		param_user_file = strdup(filename);
 	}
+
+#endif /* FLASH_BASED_PARAMS */
 
 	return 0;
 }
@@ -944,9 +956,15 @@ int
 param_save_default()
 {
 	int res = PX4_ERROR;
-#if !defined(FLASH_BASED_PARAMS)
 
 	const char *filename = param_get_default_file();
+
+	if (!filename) {
+		param_lock_writer();
+		res = flash_param_save(false);
+		param_unlock_writer();
+		return res;
+	}
 
 	/* write parameters to temp file */
 	int fd = PARAM_OPEN(filename, O_WRONLY | O_CREAT, PX4_O_MODE_666);
@@ -973,11 +991,6 @@ param_save_default()
 	}
 
 	PARAM_CLOSE(fd);
-#else
-	param_lock_writer();
-	res = flash_param_save();
-	param_unlock_writer();
-#endif
 
 	return res;
 }
@@ -989,13 +1002,18 @@ int
 param_load_default()
 {
 	int res = 0;
-#if !defined(FLASH_BASED_PARAMS)
-	int fd_load = PARAM_OPEN(param_get_default_file(), O_RDONLY);
+	const char *filename = param_get_default_file();
+
+	if (!filename) {
+		return flash_param_load();
+	}
+
+	int fd_load = PARAM_OPEN(filename, O_RDONLY);
 
 	if (fd_load < 0) {
 		/* no parameter file is OK, otherwise this is an error */
 		if (errno != ENOENT) {
-			PX4_ERR("open '%s' for reading failed", param_get_default_file());
+			PX4_ERR("open '%s' for reading failed", filename);
 			return -1;
 		}
 
@@ -1006,25 +1024,29 @@ param_load_default()
 	PARAM_CLOSE(fd_load);
 
 	if (result != 0) {
-		PX4_ERR("error reading parameters from '%s'", param_get_default_file());
+		PX4_ERR("error reading parameters from '%s'", filename);
 		return -2;
 	}
 
-#else
-	// no need for locking
-	res = flash_param_load();
-#endif
 	return res;
 }
 
 int
 param_export(int fd, bool only_unsaved)
 {
+	int	result = -1;
 	perf_begin(param_export_perf);
 
-	param_wbuf_s *s = nullptr;
-	int	result = -1;
+	if (fd < 0) {
+		param_lock_writer();
+		// flash_param_save() will take the shutdown lock
+		result = flash_param_save(only_unsaved);
+		param_unlock_writer();
+		perf_end(param_export_perf);
+		return result;
+	}
 
+	param_wbuf_s *s = nullptr;
 	struct bson_encoder_s encoder;
 
 	int shutdown_lock_ret = px4_shutdown_lock();
@@ -1290,18 +1312,20 @@ param_import_internal(int fd, bool mark_saved)
 int
 param_import(int fd)
 {
-#if !defined(FLASH_BASED_PARAMS)
+	if (fd < 0) {
+		return flash_param_import();
+	}
+
 	return param_import_internal(fd, false);
-#else
-	(void)fd; // unused
-	// no need for locking here
-	return flash_param_import();
-#endif
 }
 
 int
 param_load(int fd)
 {
+	if (fd < 0) {
+		return flash_param_load();
+	}
+
 	param_reset_all_internal(false);
 	return param_import_internal(fd, true);
 }


### PR DESCRIPTION
The Beta75X uses an Omnibus F4 board, but comes without an SD card slot. To use it with PX4 we need to store the params in FLASH instead of relying on the SD card.

This PR includes the following changes:
- Switches the Omnibus board to a FLASH-based parameter storage. This is a **breaking** change and requires a bootloader update. See https://github.com/PX4/Bootloader/pull/124.
  I added transition support such that the params file is read into FLASH automatically.
- Ability to use file-based params in parallel with FLASH-based params. This removes most of the ifdef's as well, see e100d1697d679d41b2ba9227193fcb62c75118aa.
- add an airframe config for the Whoop

@DanielePettenuzzo @bresch can you test this on yours?