### PR TITLE
Add back Slowdown close to ground in manual flight

### DIFF
--- a/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -274,7 +274,7 @@ void FlightTaskManualAltitude::_respectGroundSlowdown()
 	if (PX4_ISFINITE(_dist_to_bottom)) {
 		dist_to_ground = _dist_to_bottom;
 
-	} else if (PX4_ISFINITE(_sub_home_position->get().valid_alt)) {
+	} else if (_sub_home_position->get().valid_alt) {
 		dist_to_ground = -(_position(2) - _sub_home_position->get().z);
 	}
 

--- a/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
@@ -40,12 +40,14 @@
 #pragma once
 
 #include "FlightTaskManual.hpp"
+#include <uORB/topics/home_position.h>
 
 class FlightTaskManualAltitude : public FlightTaskManual
 {
 public:
 	FlightTaskManualAltitude() = default;
 	virtual ~FlightTaskManualAltitude() = default;
+	bool initializeSubscriptions(SubscriptionArray &subscription_array) override;
 	bool activate() override;
 	bool updateInitialize() override;
 	bool update() override;
@@ -73,7 +75,10 @@ protected:
 					(ParamFloat<px4::params::MPC_HOLD_MAX_XY>) MPC_HOLD_MAX_XY,
 					(ParamFloat<px4::params::MPC_Z_P>) MPC_Z_P, /**< position controller altitude propotional gain */
 					(ParamFloat<px4::params::MPC_MAN_Y_MAX>) MPC_MAN_Y_MAX, /**< scaling factor from stick to yaw rate */
-					(ParamFloat<px4::params::MPC_MAN_TILT_MAX>) MPC_MAN_TILT_MAX /**< maximum tilt allowed for manual flight */
+					(ParamFloat<px4::params::MPC_MAN_TILT_MAX>) MPC_MAN_TILT_MAX, /**< maximum tilt allowed for manual flight */
+					(ParamFloat<px4::params::MPC_LAND_ALT1>) MPC_LAND_ALT1, // altitude at which to start downwards slowdown
+					(ParamFloat<px4::params::MPC_LAND_ALT2>) MPC_LAND_ALT2, // altitude below which to land with land speed
+					(ParamFloat<px4::params::MPC_LAND_SPEED>) MPC_LAND_SPEED
 				       )
 private:
 	/**
@@ -95,7 +100,13 @@ private:
 
 	void _respectMaxAltitude();
 
+	/**
+	 * Sets downwards velocity constraint based on the distance to ground.
+	 * To ensure a slowdown to land speed before hitting the ground.
+	 */
+	void _respectGroundSlowdown();
 
+	uORB::Subscription<home_position_s> *_sub_home_position{nullptr}; /**< home position as reference altitude */
 	uint8_t _reset_counter = 0; /**< counter for estimator resets in z-direction */
 	float _max_speed_up = 10.0f;
 	float _min_speed_down = 1.0f;


### PR DESCRIPTION
I'm bringing back the slow down functionality that keeps the drone from hitting the floor too hard when pressing full down configurable with `MPC_LAND_ALT1` and `MPC_LAND_ALT2`. It was lost in the flight task changes and readded in FlightTaskAuto but no for manual flight.

As a reference here's the implementation of the 1.8 stable branch: https://github.com/PX4/Firmware/blob/f13bbacd5277123d6af2cb5ed21587c220031353/src/modules/mc_pos_control/mc_pos_control_main.cpp#L2437-L2441