### PR TITLE
EKF2: add usage to new exposed covariance

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,6 +30,10 @@
 	path = src/lib/DriverFramework
 	url = https://github.com/PX4/DriverFramework.git
 	branch = master
+[submodule "src/lib/ecl"]
+	path = src/lib/ecl
+	url = https://github.com/PX4/ecl.git
+	branch = master
 [submodule "boards/atlflight/cmake_hexagon"]
 	path = boards/atlflight/cmake_hexagon
 	url = https://github.com/PX4/cmake_hexagon.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -30,10 +30,6 @@
 	path = src/lib/DriverFramework
 	url = https://github.com/PX4/DriverFramework.git
 	branch = master
-[submodule "src/lib/ecl"]
-	path = src/lib/ecl
-	url = https://github.com/PX4/ecl.git
-	branch = master
 [submodule "boards/atlflight/cmake_hexagon"]
 	path = boards/atlflight/cmake_hexagon
 	url = https://github.com/PX4/cmake_hexagon.git

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1455,25 +1455,20 @@ void Ekf2::run()
 					lpos.hagl_max = INFINITY;
 				}
 
+				// get pose covariance and copy the URT to the uORB message
+				float *pos_p = &odom.pose_covariance[0];
 
-				// get pose covariance
-				float pose_covariance[36];
-				_ekf.get_pose_covariances(pose_covariance);
-
-				for (unsigned x = 0; x < 6; x++)
-					for (unsigned y = x; y < 6; y++)
-						odom.pose_covariance[x + y] = pose_covariance[x * 6 + y];
+				for (unsigned x = 0; x < 6; x++) {
+					for (unsigned y = x; y < 6; y++) {
+						*pos_p++ = _ekf.pose_covariances()(x, y);
+					}
+				}
 
 				// get the velocity covariances
 				// note: unknown angular velocity covariance matrix
 				matrix::SquareMatrix<float, 6> twist_cov = matrix::eye<float, 6>();
-				// unknown angular velocity covariance matrix
-				float lv_cov[9];
-				_ekf.get_velocity_covariances(lv_cov);
-				matrix::SquareMatrix<float, 3> linvel_cov(lv_cov);
-
-				// parse twist covariance
-				twist_cov.slice<3, 3>(0, 0) = linvel_cov;
+				twist_cov.set(_ekf.velocity_covariances(), 0, 0);
+				float *vel_p = &odom.velocity_covariance[0];
 
 				for (unsigned x = 0; x < 6; x++)
 					for (unsigned y = x; y < 6; y++)
@@ -1568,6 +1563,7 @@ void Ekf2::run()
 			_ekf.get_state_delayed(status.states);
 			status.n_states = 24;
 <<<<<<< HEAD
+<<<<<<< HEAD
 			_ekf.covariances_diagonal().copyTo(status.covariances);
 =======
 <<<<<<< HEAD
@@ -1576,6 +1572,9 @@ void Ekf2::run()
 			*status.covariances = (*_ekf.covariances_diagonal().data());
 >>>>>>> ekf2: tide new covariance methods
 >>>>>>> ekf2: tide new covariance methods
+=======
+			*status.covariances = (*_ekf.covariances_diagonal().data());
+>>>>>>> ekf2_main: fix covariance copy to messages
 			_ekf.get_gps_check_status(&status.gps_check_fail_flags);
 			// only report enabled GPS check failures (the param indexes are shifted by 1 bit, because they don't include
 			// the GPS Fix bit, which is always checked)

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1503,7 +1503,7 @@ void Ekf2::run()
 
 				// get the position and orientation covariances and fil the pose covariance matrix
 				// it's not a cross-covariance matrix but simplifies propagating the data
-				matrix::SquareMatrix<float, 6> pose_cov = matrix::eye<float, 6>() * 9999.0f;
+				matrix::SquareMatrix<float, 6> pose_cov = matrix::eye<float, 6>();
 				pose_cov.set(_ekf.position_covariances(), 0, 0);
 				pose_cov.set(propagate_covariances_from_quat_to_euler(q, _ekf.orientation_covariances()), 3, 3);
 
@@ -1515,7 +1515,7 @@ void Ekf2::run()
 
 				// get the velocity covariances
 				// note: unknown angular velocity covariance matrix
-				matrix::SquareMatrix<float, 6> twist_cov = matrix::eye<float, 6>() * 9999.0f;
+				matrix::SquareMatrix<float, 6> twist_cov = matrix::eye<float, 6>() * NAN;
 				twist_cov.set(_ekf.velocity_covariances(), 0, 0);
 				float *vel_p = &odom.velocity_covariance[0];
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1503,7 +1503,7 @@ void Ekf2::run()
 
 				// get the position and orientation covariances and fil the pose covariance matrix
 				// it's not a cross-covariance matrix but simplifies propagating the data
-				matrix::SquareMatrix<float, 6> pose_cov = matrix::eye<float, 6>();
+				matrix::SquareMatrix<float, 6> pose_cov = matrix::eye<float, 6>() * 9999.0f;
 				pose_cov.set(_ekf.position_covariances(), 0, 0);
 				pose_cov.set(propagate_covariances_from_quat_to_euler(q, _ekf.quaternion_covariances()), 3, 3);
 
@@ -1515,7 +1515,7 @@ void Ekf2::run()
 
 				// get the velocity covariances
 				// note: unknown angular velocity covariance matrix
-				matrix::SquareMatrix<float, 6> twist_cov = matrix::eye<float, 6>();
+				matrix::SquareMatrix<float, 6> twist_cov = matrix::eye<float, 6>() * 9999.0f;
 				twist_cov.set(_ekf.velocity_covariances(), 0, 0);
 				float *vel_p = &odom.velocity_covariance[0];
 

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -165,6 +165,50 @@ private:
 	 */
 	float filter_altitude_ellipsoid(float amsl_hgt);
 
+	/* Covariance propagation from quaternions to euler angles using the covariance law
+	 * source: "Development of a Real-Time Attitude System Using a Quaternion
+	 * Parameterization and Non-Dedicated GPS Receivers", John B. Schleppe 1996
+	 */
+	const matrix::SquareMatrix<float, 3> propagate_covariances_from_quat_to_euler(
+		const matrix::Quatf q,
+		const matrix::SquareMatrix<float, 4> quat_covariances) const
+	{
+		// Jacobian matrix (3x4) containing the partial derivatives of the
+		// Euler angle equations with respect to the quaternions
+		matrix::Matrix<float, 3, 4> G;
+
+		float q1 = q(0);
+		float q2 = q(1);
+		float q3 = q(2);
+		float q4 = q(3);
+
+		// Protect against division by 0
+		float d1 = (2 * q1 * q2 + 2 * q2 * q4) * (2 * q1 * q2 + 2 * q2 * q4) + (-2 * q2 * q2 - 2 * q3 * q3 + 1) *
+			   (-2 * q2 * q2 - 2 * q3 * q3 + 1);
+		float d2 = (2 * q1 * q4 + 2 * q2 * q3) * (2 * q1 * q4 + 2 * q2 * q3) + (-2 * q3 * q3 - 2 * q4 * q4 + 1) *
+			   (-2 * q3 * q3 - 2 * q4 * q4 + 1);
+		d1 = fabsf(d1) >= FLT_EPSILON ? d1 : FLT_EPSILON;
+		d2 = fabsf(d2) >= FLT_EPSILON ? d2 : FLT_EPSILON;
+
+		// Protect against square root of negative numbers
+		float x = fmaxf(-(2 * q1 * q3 + 2 * q2 * q4) * (2 * q1 * q3 + 2 * q2 * q4) + 1, FLT_EPSILON);
+
+		G(0, 0) =  2 * q2 * (-2 * q2 * q2 - 2 * q3 * q3 + 1) / d1;
+		G(0, 1) = -4 * q2 * (-2 * q1 * q2 - 2 * q2 * q4) / d1 + (2 * q1 + 2 * q4) * (-2 * q2 * q2 - 2 * q3 * q3 + 1) / d1;
+		G(0, 2) = -4 * q3 * (-2 * q1 * q2 - 2 * q2 * q4) / d1;
+		G(0, 3) =  2 * q2 * (-2 * q2 * q2 - 2 * q3 * q3 + 1) / d1;
+		G(1, 0) =  2 * q3 / sqrtf(x);
+		G(1, 1) =  2 * q4 / sqrtf(x);
+		G(1, 2) =  2 * q1 / sqrtf(x);
+		G(1, 3) =  2 * q2 / sqrtf(x);
+		G(2, 0) =  2 * q4 * (-2 * q3 * q3 - 2 * q4 * q4 + 1) / d2;
+		G(2, 1) =  2 * q3 * (-2 * q3 * q3 - 2 * q4 * q4 + 1) / d2;
+		G(2, 2) =  2 * q2 * (-2 * q3 * q3 - 2 * q4 * q4 + 1) / d2 - 4 * q3 * (-2 * q1 * q4 - 2 * q2 * q3) / d2;
+		G(2, 3) =  2 * q1 * (-2 * q3 * q3 - 2 * q4 * q4 + 1) / d2 - 4 * q4 * (-2 * q1 * q4 - 2 * q2 * q3) / d2;
+
+		return G * quat_covariances * G.transpose();
+	}
+
 	bool 	_replay_mode = false;			///< true when we use replay data from a log
 
 	// time slip monitoring
@@ -523,7 +567,6 @@ private:
 		_param_ekf2_move_test	///< scaling applied to IMU data thresholds used to determine if the vehicle is static or moving.
 
 	)
-
 };
 
 Ekf2::Ekf2():
@@ -1457,6 +1500,12 @@ void Ekf2::run()
 
 				// get pose covariance and copy the URT to the uORB message
 				float *pos_p = &odom.pose_covariance[0];
+
+				// get the position and orientation covariances and fil the pose covariance matrix
+				// it's not a cross-covariance matrix but simplifies propagating the data
+				matrix::SquareMatrix<float, 6> pose_cov = matrix::eye<float, 6>();
+				pose_cov.set(_ekf.position_covariances(), 0, 0);
+				pose_cov.set(propagate_covariances_from_quat_to_euler(q, _ekf.quaternion_covariances()), 3, 3);
 
 				for (unsigned x = 0; x < 6; x++) {
 					for (unsigned y = x; y < 6; y++) {

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -169,9 +169,9 @@ private:
 	 * source: "Development of a Real-Time Attitude System Using a Quaternion
 	 * Parameterization and Non-Dedicated GPS Receivers", John B. Schleppe 1996
 	 */
-	const matrix::SquareMatrix<float, 3> propagate_covariances_from_quat_to_euler(
-		const matrix::Quatf q,
-		const matrix::SquareMatrix<float, 4> quat_covariances) const
+	matrix::SquareMatrix<float, 3> propagate_covariances_from_quat_to_euler(
+		const matrix::Quatf &q,
+		const matrix::SquareMatrix<float, 4> &quat_covariances) const
 	{
 		// Jacobian matrix (3x4) containing the partial derivatives of the
 		// Euler angle equations with respect to the quaternions
@@ -1613,19 +1613,7 @@ void Ekf2::run()
 			status.timestamp = now;
 			_ekf.get_state_delayed(status.states);
 			status.n_states = 24;
-<<<<<<< HEAD
-<<<<<<< HEAD
 			_ekf.covariances_diagonal().copyTo(status.covariances);
-=======
-<<<<<<< HEAD
-			_ekf.get_covariances(status.covariances);
-=======
-			*status.covariances = (*_ekf.covariances_diagonal().data());
->>>>>>> ekf2: tide new covariance methods
->>>>>>> ekf2: tide new covariance methods
-=======
-			*status.covariances = (*_ekf.covariances_diagonal().data());
->>>>>>> ekf2_main: fix covariance copy to messages
 			_ekf.get_gps_check_status(&status.gps_check_fail_flags);
 			// only report enabled GPS check failures (the param indexes are shifted by 1 bit, because they don't include
 			// the GPS Fix bit, which is always checked)

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1455,6 +1455,7 @@ void Ekf2::run()
 					lpos.hagl_max = INFINITY;
 				}
 
+
 				// get pose covariance
 				float pose_covariance[36];
 				_ekf.get_pose_covariances(pose_covariance);
@@ -1463,9 +1464,9 @@ void Ekf2::run()
 					for (unsigned y = x; y < 6; y++)
 						odom.pose_covariance[x + y] = pose_covariance[x * 6 + y];
 
-				// get linear velocity covariance
+				// get the velocity covariances
+				// note: unknown angular velocity covariance matrix
 				matrix::SquareMatrix<float, 6> twist_cov = matrix::eye<float, 6>();
-
 				// unknown angular velocity covariance matrix
 				float lv_cov[9];
 				_ekf.get_velocity_covariances(lv_cov);
@@ -1566,7 +1567,15 @@ void Ekf2::run()
 			status.timestamp = now;
 			_ekf.get_state_delayed(status.states);
 			status.n_states = 24;
+<<<<<<< HEAD
 			_ekf.covariances_diagonal().copyTo(status.covariances);
+=======
+<<<<<<< HEAD
+			_ekf.get_covariances(status.covariances);
+=======
+			*status.covariances = (*_ekf.covariances_diagonal().data());
+>>>>>>> ekf2: tide new covariance methods
+>>>>>>> ekf2: tide new covariance methods
 			_ekf.get_gps_check_status(&status.gps_check_fail_flags);
 			// only report enabled GPS check failures (the param indexes are shifted by 1 bit, because they don't include
 			// the GPS Fix bit, which is always checked)

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1505,7 +1505,7 @@ void Ekf2::run()
 				// it's not a cross-covariance matrix but simplifies propagating the data
 				matrix::SquareMatrix<float, 6> pose_cov = matrix::eye<float, 6>() * 9999.0f;
 				pose_cov.set(_ekf.position_covariances(), 0, 0);
-				pose_cov.set(propagate_covariances_from_quat_to_euler(q, _ekf.quaternion_covariances()), 3, 3);
+				pose_cov.set(propagate_covariances_from_quat_to_euler(q, _ekf.orientation_covariances()), 3, 3);
 
 				for (unsigned x = 0; x < 6; x++) {
 					for (unsigned y = x; y < 6; y++) {

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1509,7 +1509,7 @@ void Ekf2::run()
 
 				for (unsigned x = 0; x < 6; x++) {
 					for (unsigned y = x; y < 6; y++) {
-						*pos_p++ = _ekf.pose_covariances()(x, y);
+						*pos_p++ = pose_cov(x, y);
 					}
 				}
 
@@ -1519,9 +1519,11 @@ void Ekf2::run()
 				twist_cov.set(_ekf.velocity_covariances(), 0, 0);
 				float *vel_p = &odom.velocity_covariance[0];
 
-				for (unsigned x = 0; x < 6; x++)
-					for (unsigned y = x; y < 6; y++)
-						odom.velocity_covariance[x * 6 + y] = linvel_cov(x,y);
+				for (unsigned x = 0; x < 6; x++) {
+					for (unsigned y = x; y < 6; y++) {
+						*vel_p++ = twist_cov(x, y);
+					}
+				}
 
 				// publish vehicle local position data
 				_vehicle_local_position_pub.update();


### PR DESCRIPTION
Brings https://github.com/PX4/ecl/pull/543 in, by getting use of the new covariances interface methods.

Tested with SITL.
![test_odometry_new_covariance_methods](https://user-images.githubusercontent.com/5048656/50380393-c5193700-065d-11e9-9e31-a24447851e88.png)