### PR TITLE
ROMFS 4041 change nsh shebang to /bin/sh

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
@@ -1,4 +1,4 @@
-#!nsh
+#!/bin/sh
 #
 # @name BetaFPV Beta75X 2S Brushless Whoop
 #


### PR DESCRIPTION
Fixes shellcheck break in master.