### PR TITLE
simulator: fix TCP on Cygwin-Windows and updated two world files for Gazebo

### DIFF
--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -149,29 +149,26 @@ int Simulator::start(int argc, char *argv[])
 	if (_instance) {
 		drv_led_start();
 
-		InternetProtocol ip = InternetProtocol::UDP;
-		unsigned port = 14560;
-
 		if (argc == 5 && strcmp(argv[3], "-u") == 0) {
-			ip = InternetProtocol::UDP;
-			port = atoi(argv[4]);
+			_instance->set_ip(InternetProtocol::UDP);
+			_instance->set_port(atoi(argv[4]));
 		}
 
 		if (argc == 5 && strcmp(argv[3], "-c") == 0) {
-			ip = InternetProtocol::TCP;
-			port = atoi(argv[4]);
+			_instance->set_ip(InternetProtocol::TCP);
+			_instance->set_port(atoi(argv[4]));
 		}
 
 		if (argv[2][1] == 's') {
 			_instance->initializeSensorData();
 #ifndef __PX4_QURT
 			// Update sensor data
-			_instance->pollForMAVLinkMessages(false, ip, port);
+			_instance->pollForMAVLinkMessages(false);
 #endif
 
 		} else if (argv[2][1] == 'p') {
 			// Update sensor data
-			_instance->pollForMAVLinkMessages(true, ip, port);
+			_instance->pollForMAVLinkMessages(true);
 
 		} else {
 			_instance->initializeSensorData();
@@ -184,6 +181,16 @@ int Simulator::start(int argc, char *argv[])
 		PX4_WARN("Simulator creation failed");
 		return 1;
 	}
+}
+
+void Simulator::set_ip(InternetProtocol ip)
+{
+	_ip = ip;
+}
+
+void Simulator::set_port(unsigned port)
+{
+	_port = port;
 }
 
 static void usage()

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -212,6 +212,11 @@ public:
 		sample(float a, float b, float c) : x(a), y(b), z(c) {}
 	};
 
+	enum class InternetProtocol {
+		TCP,
+		UDP
+	};
+
 	static int start(int argc, char *argv[]);
 
 	bool getRawAccelReport(uint8_t *buf, int len);
@@ -229,6 +234,9 @@ public:
 	void write_airspeed_data(void *buf);
 
 	bool isInitialized() { return _initialized; }
+
+	void set_ip(InternetProtocol ip);
+	void set_port(unsigned port);
 
 private:
 	Simulator() : ModuleParams(nullptr),
@@ -336,6 +344,9 @@ private:
 
 	int				_param_sub;
 
+	unsigned _port = 14560;
+	InternetProtocol _ip = InternetProtocol::UDP;
+
 	bool _initialized;
 	double _realtime_factor;		///< How fast the simulation runs in comparison to real system time
 	hrt_abstime _last_sim_timestamp;
@@ -385,17 +396,12 @@ private:
 
 	)
 
-	enum class InternetProtocol {
-		TCP,
-		UDP
-	};
-
 	void poll_topics();
 	void handle_message(mavlink_message_t *msg, bool publish);
 	void send_controls();
 	void send_heartbeat();
 	void request_hil_state_quaternion();
-	void pollForMAVLinkMessages(bool publish, InternetProtocol ip, int port);
+	void pollForMAVLinkMessages(bool publish);
 
 	void pack_actuator_message(mavlink_hil_actuator_controls_t &actuator_msg, unsigned index);
 	void send_mavlink_message(const mavlink_message_t &aMsg);


### PR DESCRIPTION
It turns out that `sendto` does not work for TCP on Cygwin-Windows, instead we need to use `send`. This required some refactoring since we need to have the internet protocol and the port stored as a member
variable.

This should fix that lockstep SITL simulation was not working on Windows.

Fixes #11090.

I've also updated sitl_gazebo since that fixes a worldfile which needed updating for lockstep.