### PR TITLE
travis-ci (coverity scan) update to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
   fast_finish: true
   include:
     - os: linux
+      dist: xenial
       if: branch = coverity_scan
 
 before_install:


### PR DESCRIPTION
Coverity builds were failing. https://travis-ci.org/PX4/Firmware/builds/472223698

![image](https://user-images.githubusercontent.com/84712/50450651-3de9ee80-08fd-11e9-9990-6981db0f1eed.png)
