### PR TITLE
mavlink: fix uninitialized messages fields

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -2688,6 +2688,8 @@ protected:
 					msg.approach_y = 0.0f;
 					msg.approach_z = 0.0f;
 
+					msg.time_usec = hrt_absolute_time();
+
 					mavlink_msg_home_position_send_struct(_mavlink->get_channel(), &msg);
 
 					return true;
@@ -3407,7 +3409,7 @@ protected:
 
 			/* send override message - harmless if connected to GCS, allows to connect a board to a Linux system */
 			/* http://mavlink.org/messages/common#RC_CHANNELS_OVERRIDE */
-			mavlink_rc_channels_override_t over;
+			mavlink_rc_channels_override_t over = {};
 			over.target_system = mavlink_system.sysid;
 			over.target_component = 0;
 			over.chan1_raw = msg.chan1_raw;

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -368,7 +368,7 @@ MavlinkMissionManager::send_mission_item(uint8_t sysid, uint8_t compid, uint16_t
 		_time_last_sent = hrt_absolute_time();
 
 		if (_int_mode) {
-			mavlink_mission_item_int_t wp;
+			mavlink_mission_item_int_t wp = {};
 			format_mavlink_mission_item(&mission_item, reinterpret_cast<mavlink_mission_item_t *>(&wp));
 
 			wp.target_system = sysid;
@@ -381,7 +381,7 @@ MavlinkMissionManager::send_mission_item(uint8_t sysid, uint8_t compid, uint16_t
 			PX4_DEBUG("WPM: Send MISSION_ITEM_INT seq %u to ID %u", wp.seq, wp.target_system);
 
 		} else {
-			mavlink_mission_item_t wp;
+			mavlink_mission_item_t wp = {};
 			format_mavlink_mission_item(&mission_item, &wp);
 
 			wp.target_system = sysid;


### PR DESCRIPTION
Some mavlink message's structs are not being cleared on creation, and later not all fields are being set.
Not clearing on struct creation might save runtime, but can lead later errors,
I found that sometime 'time_usec' on HOME_POSITION is just garbage
On the proposed pr I found some messages that are not fully initilized (i went over all messages, but I might miss some...)

fixes 'Extension field not initialized in HOME_POSITION message #10923'
this pr replace prev pr: 'mavlink: fix uninitialized messages fields #11039'