### PR TITLE
Fix pwm sim publishing when disarmed

### DIFF
--- a/src/drivers/pwm_out_sim/PWMSim.cpp
+++ b/src/drivers/pwm_out_sim/PWMSim.cpp
@@ -241,10 +241,8 @@ PWMSim::run()
 			_actuator_outputs.noutputs = num_outputs;
 
 			/* disable unused ports by setting their output to NaN */
-			for (size_t i = 0; i < sizeof(_actuator_outputs.output) / sizeof(_actuator_outputs.output[0]); i++) {
-				if (i >= num_outputs) {
-					_actuator_outputs.output[i] = NAN;
-				}
+			for (size_t i = num_outputs; i < sizeof(_actuator_outputs.output) / sizeof(_actuator_outputs.output[0]); i++) {
+				_actuator_outputs.output[i] = NAN;
 			}
 
 			/* iterate actuators */

--- a/src/drivers/pwm_out_sim/PWMSim.cpp
+++ b/src/drivers/pwm_out_sim/PWMSim.cpp
@@ -31,8 +31,10 @@
  *
  ****************************************************************************/
 
-#include <px4_time.h>
 #include "PWMSim.hpp"
+
+#include <px4_time.h>
+#include <mathlib/mathlib.h>
 
 #include <uORB/topics/multirotor_motor_limits.h>
 
@@ -254,14 +256,7 @@ PWMSim::run()
 				    _actuator_outputs.output[i] <= 1.0f) {
 					/* scale for PWM output 1000 - 2000us */
 					_actuator_outputs.output[i] = 1500 + (500 * _actuator_outputs.output[i]);
-
-					if (_actuator_outputs.output[i] > _pwm_max[i]) {
-						_actuator_outputs.output[i] = _pwm_max[i];
-					}
-
-					if (_actuator_outputs.output[i] < _pwm_min[i]) {
-						_actuator_outputs.output[i] = _pwm_min[i];
-					}
+					_actuator_outputs.output[i] = math::constrain(_actuator_outputs.output[i], (float)_pwm_min[i], (float)_pwm_max[i]);
 
 				} else {
 					/*

--- a/src/drivers/pwm_out_sim/PWMSim.cpp
+++ b/src/drivers/pwm_out_sim/PWMSim.cpp
@@ -237,16 +237,17 @@ PWMSim::run()
 		if (_mixers != nullptr) {
 
 			/* do mixing */
-			unsigned num_outputs = _mixers->mix(&_actuator_outputs.output[0], _num_outputs);
-			_actuator_outputs.noutputs = num_outputs;
+			_actuator_outputs.noutputs = _mixers->mix(&_actuator_outputs.output[0], _num_outputs);
 
 			/* disable unused ports by setting their output to NaN */
-			for (size_t i = num_outputs; i < sizeof(_actuator_outputs.output) / sizeof(_actuator_outputs.output[0]); i++) {
+			const size_t actuator_outputs_size = sizeof(_actuator_outputs.output) / sizeof(_actuator_outputs.output[0]);
+
+			for (size_t i = _actuator_outputs.noutputs; i < actuator_outputs_size; i++) {
 				_actuator_outputs.output[i] = NAN;
 			}
 
 			/* iterate actuators */
-			for (unsigned i = 0; i < num_outputs; i++) {
+			for (unsigned i = 0; i < _actuator_outputs.noutputs; i++) {
 				/* last resort: catch NaN, INF and out-of-band errors */
 				if (i < _actuator_outputs.noutputs &&
 				    PX4_ISFINITE(_actuator_outputs.output[i]) &&
@@ -268,14 +269,14 @@ PWMSim::run()
 
 			/* overwrite outputs in case of force_failsafe */
 			if (_failsafe) {
-				for (size_t i = 0; i < num_outputs; i++) {
+				for (size_t i = 0; i < _actuator_outputs.noutputs; i++) {
 					_actuator_outputs.output[i] = PWM_SIM_FAILSAFE_MAGIC;
 				}
 			}
 
 			/* overwrite outputs in case of lockdown */
 			if (_lockdown) {
-				for (size_t i = 0; i < num_outputs; i++) {
+				for (size_t i = 0; i < _actuator_outputs.noutputs; i++) {
 					_actuator_outputs.output[i] = 0.0;
 				}
 			}


### PR DESCRIPTION
References
Cause: https://github.com/PX4/Firmware/pull/10648/files#diff-2ce77a8bbb7b5dc57a3e7b1db5dacb18R234
Comments: https://github.com/PX4/Firmware/pull/11101#issuecomment-450163356

**Test data / coverage**
SITL on Windows

**Describe problem solved by the proposed pull request**
PWMSim needs to always publish `actuator_outputs` such that lock-step works when disarmed (see https://github.com/PX4/Firmware/pull/10648/). But after it was changed the controller output gets applied even if diarmed because there's nothing holding it back anymore. As a result the drone takes off if the controller would command more than hover thrust on SITL boot even when the drone is disarmed.

**Describe your preferred solution**
I added the armed check from before when the values get set to their in flight values instead of the disarmed value here: https://github.com/PX4/Firmware/compare/fix-pwm-sim?expand=1#diff-2ce77a8bbb7b5dc57a3e7b1db5dacb18R256 The rest is just refactoring.

**Describe possible alternatives**
I think running the controllers even when disarmed is very useful not only for debugging but also to see before arming if anything would go wrong in terms of exceptions, CPU usage, crazy output and so on. But for the future it would probably make sense to unify mixing and armed handling of all outputs to increase maintainability and make sure it's treated the same in any case.
