### PR TITLE
platforms: fix linking for Snapdragon

### DIFF
--- a/src/platforms/px4_time.h
+++ b/src/platforms/px4_time.h
@@ -17,7 +17,7 @@ __END_DECLS
 #define px4_clock_gettime system_clock_gettime
 #endif
 
-#if defined(ENABLE_LOCKSTEP_SCHEDULER) || defined(__PX4_QURT)
+#if defined(ENABLE_LOCKSTEP_SCHEDULER)
 
 __BEGIN_DECLS
 __EXPORT int px4_clock_settime(clockid_t clk_id, const struct timespec *tp);
@@ -35,5 +35,17 @@ __END_DECLS
 #define px4_usleep system_usleep
 #define px4_sleep system_sleep
 #define px4_pthread_cond_timedwait system_pthread_cond_timedwait
+
+#if defined(__PX4_QURT)
+__BEGIN_DECLS
+__EXPORT int clock_settime(clockid_t clk_id, const struct timespec *tp);
+
+__EXPORT int usleep(useconds_t usec);
+__EXPORT unsigned int sleep(unsigned int seconds);
+__EXPORT int pthread_cond_timedwait(pthread_cond_t *cond,
+				    pthread_mutex_t *mutex,
+				    const struct timespec *abstime);
+__END_DECLS
+#endif
 
 #endif


### PR DESCRIPTION
The Qurt side doesn't have the time symbols with the `px4_` prefix.

Fixes #11110.