### PR TITLE
Fix usage of errno in POSIX semaphore error handling

### DIFF
--- a/platforms/posix/src/lockstep_scheduler/src/lockstep_scheduler.cpp
+++ b/platforms/posix/src/lockstep_scheduler/src/lockstep_scheduler.cpp
@@ -57,8 +57,7 @@ int LockstepScheduler::cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *loc
 
 		// The time has already passed.
 		if (time_us <= time_us_) {
-			errno = ETIMEDOUT;
-			return -1;
+			return ETIMEDOUT;
 		}
 
 		new_timed_wait = std::make_shared<TimedWait>();
@@ -80,8 +79,7 @@ int LockstepScheduler::cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *loc
 			std::lock_guard<std::mutex> lock_timed_waits(timed_waits_mutex_);
 
 			if (result == 0 && new_timed_wait->timeout) {
-				errno = ETIMEDOUT;
-				result = -1;
+				result = ETIMEDOUT;
 			}
 
 			new_timed_wait->done = true;
@@ -104,9 +102,8 @@ int LockstepScheduler::usleep_until(uint64_t time_us)
 
 	int result = cond_timedwait(&cond, &lock, time_us);
 
-	if (result == -1 && errno == ETIMEDOUT) {
+	if (result == ETIMEDOUT) {
 		// This is expected because we never notified to the condition.
-		errno = 0;
 		result = 0;
 	}
 

--- a/platforms/posix/src/lockstep_scheduler/test/src/lockstep_scheduler_test.cpp
+++ b/platforms/posix/src/lockstep_scheduler/test/src/lockstep_scheduler_test.cpp
@@ -34,8 +34,7 @@ void test_condition_timing_out()
 	// Use a thread to wait for condition while we already have the lock.
 	// This ensures the synchronization happens in the right order.
 	std::thread thread([&ls, &cond, &lock, &should_have_timed_out]() {
-		assert(ls.cond_timedwait(&cond, &lock, some_time_us + 1000) == -1);
-		assert(errno == ETIMEDOUT);
+		assert(ls.cond_timedwait(&cond, &lock, some_time_us + 1000) == ETIMEDOUT);
 		assert(should_have_timed_out);
 		// It should be re-locked afterwards, so we should be able to unlock it.
 		assert(pthread_mutex_unlock(&lock) == 0);
@@ -139,7 +138,7 @@ public:
 		else if (timeout_reached) {
 			is_done_ = true;
 			thread_->join();
-			assert(result_ == -1);
+			assert(result_ == ETIMEDOUT);
 		}
 	}
 private:

--- a/platforms/posix/src/px4_layer/px4_sem.cpp
+++ b/platforms/posix/src/px4_layer/px4_sem.cpp
@@ -142,7 +142,7 @@ int px4_sem_timedwait(px4_sem_t *s, const struct timespec *abstime)
 
 	int err = ret;
 
-	if (err != 0 && errno != ETIMEDOUT) {
+	if (err != 0 && err != ETIMEDOUT) {
 		setbuf(stdout, nullptr);
 		setbuf(stderr, nullptr);
 		const unsigned NAMELEN = 32;

--- a/platforms/posix/src/px4_layer/px4_sem.cpp
+++ b/platforms/posix/src/px4_layer/px4_sem.cpp
@@ -140,20 +140,24 @@ int px4_sem_timedwait(px4_sem_t *s, const struct timespec *abstime)
 		ret = 0;
 	}
 
-	int err = ret;
+	errno = ret;
 
-	if (err != 0 && err != ETIMEDOUT) {
+	if (ret != 0 && ret != ETIMEDOUT) {
 		setbuf(stdout, nullptr);
 		setbuf(stderr, nullptr);
 		const unsigned NAMELEN = 32;
 		char thread_name[NAMELEN] = {};
 		(void)pthread_getname_np(pthread_self(), thread_name, NAMELEN);
-		PX4_WARN("%s: px4_sem_timedwait failure: ret: %d, %s", thread_name, ret, strerror(err));
+		PX4_WARN("%s: px4_sem_timedwait failure: ret: %d, %s", thread_name, ret, strerror(ret));
 	}
 
 	int mret = pthread_mutex_unlock(&(s->lock));
 
-	return (err) ? err : mret;
+	if (ret || mret) {
+		return -1;
+	}
+
+	return 0;
 }
 
 int px4_sem_post(px4_sem_t *s)


### PR DESCRIPTION
Previous commit 98ae0186e93 changed the err variable to errno, which is not the return value we are looking for.

Fixes #11118.