### PR TITLE
px4flow start in rc.sensors instead of per board

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -108,6 +108,9 @@ fi
 # ICM20948 as external magnetometer on I2C (e.g. Here GPS)
 mpu9250 -X -M -R 6 start
 
+# Check for flow sensor, launched as a background task to scan
+px4flow start &
+
 ###############################################################################
 #                            End Optional drivers                             #
 ###############################################################################

--- a/boards/airmind/mindpx-v2/init/rc.board
+++ b/boards/airmind/mindpx-v2/init/rc.board
@@ -45,5 +45,3 @@ mpu6000 -s -R 8 start
 mpu9250 -s -R 8 start
 lsm303d -R 10 start
 l3gd20 -R 14 start
-
-px4flow start &

--- a/boards/auav/x21/init/rc.board
+++ b/boards/auav/x21/init/rc.board
@@ -37,5 +37,3 @@ mpu6000 -R 2 -T 20602 start
 
 # Internal SPI bus mpu9250 is rotated 90 deg yaw
 mpu9250 -R 2 start
-
-px4flow start &

--- a/boards/omnibus/f4sd/init/rc.board
+++ b/boards/omnibus/f4sd/init/rc.board
@@ -54,6 +54,3 @@ hmc5883 -X start
 bmp280 start
 
 adc start
-
-
-px4flow start &

--- a/boards/px4/fmu-v2/init/rc.board
+++ b/boards/px4/fmu-v2/init/rc.board
@@ -136,6 +136,4 @@ else
 	lsm303d start
 fi
 
-px4flow start &
-
 unset BOARD_FMUV3

--- a/boards/px4/fmu-v3/init/rc.board
+++ b/boards/px4/fmu-v3/init/rc.board
@@ -137,6 +137,4 @@ else
 	lsm303d start
 fi
 
-px4flow start &
-
 unset BOARD_FMUV3

--- a/boards/px4/fmu-v4/init/rc.board
+++ b/boards/px4/fmu-v4/init/rc.board
@@ -97,5 +97,3 @@ if param compare TEL_FRSKY_CONFIG 0
 then
 	frsky_telemetry start -d /dev/ttyS6 -t 15
 fi
-
-px4flow start &

--- a/boards/px4/fmu-v4pro/init/rc.board
+++ b/boards/px4/fmu-v4pro/init/rc.board
@@ -42,5 +42,3 @@ hmc5883 -C -T -X start
 
 # RM3100
 rm3100 start
-
-px4flow start &

--- a/boards/px4/fmu-v5/init/rc.board
+++ b/boards/px4/fmu-v5/init/rc.board
@@ -48,5 +48,3 @@ ist8310 -C -b 5 start
 
 # Possible pmw3901 optical flow sensor
 pmw3901 start
-
-px4flow start &


### PR DESCRIPTION
 - fixes #11009