### PR TITLE
mavlink fix performance regression (#11125), add interval perf counter, and cleanup getters

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -581,34 +581,6 @@ Mavlink::get_uart_fd(unsigned index)
 	return -1;
 }
 
-int
-Mavlink::get_uart_fd()
-{
-	return _uart_fd;
-}
-
-int
-Mavlink::get_instance_id()
-{
-	return _instance_id;
-}
-
-mavlink_channel_t
-Mavlink::get_channel()
-{
-	return _channel;
-}
-
-int Mavlink::get_system_id()
-{
-	return mavlink_system.sysid;
-}
-
-int Mavlink::get_component_id()
-{
-	return mavlink_system.compid;
-}
-
 int Mavlink::mavlink_open_uart(int baud, const char *uart_name, bool force_flow_control)
 {
 #ifndef B460800
@@ -890,14 +862,6 @@ Mavlink::get_free_tx_buf()
 	}
 
 	return buf_free;
-}
-
-void
-Mavlink::begin_send()
-{
-	// must protect the network buffer so other calls from receive_thread do not
-	// mangle the message.
-	pthread_mutex_lock(&_send_mutex);
 }
 
 int
@@ -1521,13 +1485,6 @@ Mavlink::message_buffer_count()
 	return n;
 }
 
-int
-Mavlink::message_buffer_is_empty()
-{
-	return _message_buffer.read_ptr == _message_buffer.write_ptr;
-}
-
-
 bool
 Mavlink::message_buffer_write(const void *ptr, int size)
 {
@@ -1587,12 +1544,6 @@ Mavlink::message_buffer_get_ptr(void **ptr, bool *is_part)
 
 	*ptr = &(_message_buffer.data[_message_buffer.read_ptr]);
 	return n;
-}
-
-void
-Mavlink::message_buffer_mark_read(int n)
-{
-	_message_buffer.read_ptr = (_message_buffer.read_ptr + n) % _message_buffer.size;
 }
 
 void

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -294,7 +294,6 @@ public:
 	 */
 	bool			get_manual_input_mode_generation() { return _generate_rc; }
 
-
 	/**
 	 * This is the beginning of a MAVLINK_START_UART_SEND/MAVLINK_END_UART_SEND transaction
 	 */
@@ -647,6 +646,7 @@ private:
 	)
 
 	perf_counter_t		_loop_perf;			/**< loop performance counter */
+	perf_counter_t		_loop_interval_perf;		/**< loop interval performance counter */
 
 	void			mavlink_update_parameters();
 

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -154,21 +154,21 @@ public:
 
 	static int		get_uart_fd(unsigned index);
 
-	int			get_uart_fd();
+	int			get_uart_fd() const { return _uart_fd; }
 
 	/**
 	 * Get the MAVLink system id.
 	 *
 	 * @return		The system ID of this vehicle
 	 */
-	int			get_system_id();
+	int			get_system_id() const { return mavlink_system.sysid; }
 
 	/**
 	 * Get the MAVLink component id.
 	 *
 	 * @return		The component ID of this vehicle
 	 */
-	int			get_component_id();
+	int			get_component_id() const { return mavlink_system.compid; }
 
 	const char *_device_name;
 
@@ -297,7 +297,7 @@ public:
 	/**
 	 * This is the beginning of a MAVLINK_START_UART_SEND/MAVLINK_END_UART_SEND transaction
 	 */
-	void 			begin_send();
+	void 			begin_send() { pthread_mutex_lock(&_send_mutex); }
 
 	/**
 	 * Send bytes out on the link.
@@ -329,7 +329,7 @@ public:
 	 */
 	MavlinkOrbSubscription *add_orb_subscription(const orb_id_t topic, int instance = 0, bool disable_sharing = false);
 
-	int			get_instance_id();
+	int			get_instance_id() const { return _instance_id; }
 
 	/**
 	 * Enable / disable hardware flow control.
@@ -338,7 +338,7 @@ public:
 	 */
 	int			enable_flow_control(enum FLOW_CONTROL_MODE enabled);
 
-	mavlink_channel_t	get_channel();
+	mavlink_channel_t	get_channel() const { return _channel; }
 
 	void			configure_stream_threadsafe(const char *stream_name, float rate = -1.0f);
 
@@ -678,11 +678,11 @@ private:
 
 	int message_buffer_count();
 
-	int message_buffer_is_empty();
+	int message_buffer_is_empty() const { return (_message_buffer.read_ptr == _message_buffer.write_ptr); }
 
 	int message_buffer_get_ptr(void **ptr, bool *is_part);
 
-	void message_buffer_mark_read(int n);
+	void message_buffer_mark_read(int n) { _message_buffer.read_ptr = (_message_buffer.read_ptr + n) % _message_buffer.size; }
 
 	void pass_message(const mavlink_message_t *msg);
 

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -494,9 +494,9 @@ public:
 
 	bool ftp_enabled() const { return _ftp_on; }
 
-	bool hash_check_enabled() { return _param_hash_check_enabled.get(); }
-
-	bool forward_heartbeats_enabled() { return _param_heartbeat_forwarding_enabled.get(); }
+	bool hash_check_enabled() const { return _param_hash_check_enabled.get(); }
+	bool forward_heartbeats_enabled() const { return _param_heartbeat_forwarding_enabled.get(); }
+	bool odometry_loopback_enabled() const { return _param_send_odom_loopback.get(); }
 
 	struct ping_statistics_s {
 		uint64_t last_ping_time;
@@ -642,7 +642,8 @@ private:
 		(ParamBool<px4::params::MAV_FWDEXTSP>) _param_forward_externalsp,
 		(ParamInt<px4::params::MAV_BROADCAST>) _param_broadcast_mode,
 		(ParamBool<px4::params::MAV_HASH_CHK_EN>) _param_hash_check_enabled,
-		(ParamBool<px4::params::MAV_HB_FORW_EN>) _param_heartbeat_forwarding_enabled
+		(ParamBool<px4::params::MAV_HB_FORW_EN>) _param_heartbeat_forwarding_enabled,
+		(ParamBool<px4::params::MAV_ODOM_LP>) _param_send_odom_loopback
 	)
 
 	perf_counter_t		_loop_perf;			/**< loop performance counter */

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -2318,7 +2318,7 @@ protected:
 
 		mavlink_odometry_t msg = {};
 
-		if (_send_odom_loopback.get()) {
+		if (_mavlink->odometry_loopback_enabled()) {
 			odom_updated = _vodom_sub->update(&_vodom_time, &odom);
 			// frame matches the external vision system
 			msg.frame_id = MAV_FRAME_VISION_NED;
@@ -2361,8 +2361,8 @@ protected:
 			msg.yawspeed = odom.yawspeed;
 
 			// get the covariance matrix size
-			const size_t POS_URT_SIZE = sizeof(odom.pose_covariance) / sizeof(odom.pose_covariance[0]);
-			const size_t VEL_URT_SIZE = sizeof(odom.velocity_covariance) / sizeof(odom.velocity_covariance[0]);
+			static constexpr size_t POS_URT_SIZE = sizeof(odom.pose_covariance) / sizeof(odom.pose_covariance[0]);
+			static constexpr size_t VEL_URT_SIZE = sizeof(odom.velocity_covariance) / sizeof(odom.velocity_covariance[0]);
 			static_assert(POS_URT_SIZE == (sizeof(msg.pose_covariance) / sizeof(msg.pose_covariance[0])),
 				      "Odometry Pose Covariance matrix URT array size mismatch");
 			static_assert(VEL_URT_SIZE == (sizeof(msg.twist_covariance) / sizeof(msg.twist_covariance[0])),

--- a/src/modules/mavlink/mavlink_stream.cpp
+++ b/src/modules/mavlink/mavlink_stream.cpp
@@ -58,7 +58,6 @@ int
 MavlinkStream::update(const hrt_abstime &t)
 {
 	update_data();
-	ModuleParams::updateParams();
 
 	// If the message has never been sent before we want
 	// to send it immediately and can return right away

--- a/src/modules/mavlink/mavlink_stream.h
+++ b/src/modules/mavlink/mavlink_stream.h
@@ -127,10 +127,6 @@ protected:
 	 */
 	virtual void update_data() { }
 
-	DEFINE_PARAMETERS(
-		(ParamBool<px4::params::MAV_ODOM_LP>) _send_odom_loopback
-	)
-
 private:
 	hrt_abstime _last_sent{0};
 	bool _first_message_sent{false};


### PR DESCRIPTION
Fixes https://github.com/PX4/Firmware/issues/11125

I still find the odometry loopback (MAV_ODOM_LP) a bit weird. What about forwarding the incoming ODOMETRY mavlink message directly?