### PR TITLE
rgbled_ncp5623c set main stack 1500

### DIFF
--- a/src/drivers/lights/rgbled_ncp5623c/CMakeLists.txt
+++ b/src/drivers/lights/rgbled_ncp5623c/CMakeLists.txt
@@ -34,7 +34,8 @@
 px4_add_module(
 	MODULE drivers__rgbled_ncp5623c
 	MAIN rgbled_ncp5623c
-	COMPILE_FLAGS
+	STACK_MAIN
+		1500
 	SRCS
 		rgbled_ncp5623c.cpp
 	DEPENDS


### PR DESCRIPTION
Caught with the NuttX stackcheck build on Jenkins. http://ci.px4.io:8080/blue/organizations/jenkins/PX4_misc%2FFirmware-hardware/detail/master_nuttx_7.27%2B/14/pipeline