### PR TITLE
CollisionPevention: remove unused var

### DIFF
--- a/src/lib/CollisionPrevention/CollisionPrevention.hpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.hpp
@@ -74,10 +74,10 @@ private:
 
 	bool _interfering = false;		/**< states if the collision prevention interferes with the user input */
 
-	orb_advert_t _constraints_pub{nullptr};		/**< constraints publication */
+	orb_advert_t _constraints_pub = nullptr;		/**< constraints publication */
 	orb_advert_t _mavlink_log_pub = nullptr;	 	/**< Mavlink log uORB handle */
 
-	uORB::Subscription<obstacle_distance_s> *_sub_obstacle_distance{nullptr}; /**< obstacle distances received form a range sensor */
+	uORB::Subscription<obstacle_distance_s> *_sub_obstacle_distance = nullptr; /**< obstacle distances received form a range sensor */
 
 	static constexpr uint64_t RANGE_STREAM_TIMEOUT_US = 500000;
 	static constexpr uint64_t MESSAGE_THROTTLE_US = 5000000;

--- a/src/lib/CollisionPrevention/CollisionPrevention.hpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.hpp
@@ -72,7 +72,6 @@ public:
 
 private:
 
-	bool _is_active = true;
 	bool _interfering = false;		/**< states if the collision prevention interferes with the user input */
 
 	orb_advert_t _constraints_pub{nullptr};		/**< constraints publication */

--- a/src/lib/CollisionPrevention/CollisionPrevention.hpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.hpp
@@ -74,10 +74,10 @@ private:
 
 	bool _interfering = false;		/**< states if the collision prevention interferes with the user input */
 
-	orb_advert_t _constraints_pub = nullptr;		/**< constraints publication */
-	orb_advert_t _mavlink_log_pub = nullptr;	 	/**< Mavlink log uORB handle */
+	orb_advert_t _constraints_pub{nullptr};		/**< constraints publication */
+	orb_advert_t _mavlink_log_pub{nullptr};	 	/**< Mavlink log uORB handle */
 
-	uORB::Subscription<obstacle_distance_s> *_sub_obstacle_distance = nullptr; /**< obstacle distances received form a range sensor */
+	uORB::Subscription<obstacle_distance_s> *_sub_obstacle_distance{nullptr}; /**< obstacle distances received form a range sensor */
 
 	static constexpr uint64_t RANGE_STREAM_TIMEOUT_US = 500000;
 	static constexpr uint64_t MESSAGE_THROTTLE_US = 5000000;


### PR DESCRIPTION
Minor cleanup.

Another remark I have is about `is_active()`:
https://github.com/PX4/Firmware/blob/6a33b797ac271c41136dd80697287298ee1f9c1f/src/lib/CollisionPrevention/CollisionPrevention.hpp#L69

I know that it was copied from the WeatherVane controller and the naming was kept for the sake of consistency. But in the context of CollisionPrevention, being "active" suggests that the algorithm is currently doing something, i.e. interfering. Just my opinion :)