### PR TITLE
CI: update px4-dev-snapdragon container tag

### DIFF
--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -15,7 +15,7 @@ pipeline {
             nuttx: "px4io/px4-dev-nuttx:2019-01-01",
             ros: "px4io/px4-dev-ros:2019-01-01",
             rpi: "px4io/px4-dev-raspi:2019-01-01",
-            snapdragon: "lorenzmeier/px4-dev-snapdragon:2018-09-12"
+            snapdragon: "lorenzmeier/px4-dev-snapdragon:2019-01-04"
           ]
 
           // MAC OSX px4_sitl_default


### PR DESCRIPTION
Updates the container tag to 2019-01-04.
