### PR TITLE
cleanup nuttx cxx header usage (step 1)

### DIFF
--- a/msg/templates/uorb/msg.cpp.template
+++ b/msg/templates/uorb/msg.cpp.template
@@ -65,7 +65,7 @@ struct_size, padding_end_size = add_padding_bytes(sorted_fields, search_path)
 topic_fields = ["%s %s" % (convert_type(field.type), field.name) for field in sorted_fields]
 }@
 
-#include <cinttypes>
+#include <inttypes.h>
 #include <px4_log.h>
 #include <px4_defines.h>
 #include <uORB/topics/@(topic_name).h>

--- a/msg/templates/uorb_microcdr/microRTPS_client.cpp.template
+++ b/msg/templates/uorb_microcdr/microRTPS_client.cpp.template
@@ -58,7 +58,7 @@ recv_topics = [s.short_name for idx, s in enumerate(spec) if scope[idx] == MsgSc
 #include "microRTPS_transport.h"
 #include "microRTPS_client.h"
 
-#include <cinttypes>
+#include <inttypes.h>
 #include <cstdio>
 #include <ctime>
 #include <pthread.h>

--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -83,6 +83,7 @@ target_link_libraries(nuttx_cxx INTERFACE nuttx_c)
 
 target_link_libraries(px4 PRIVATE
 
+	-nostartfiles
 	-nodefaultlibs
 	-nostdlib
 
@@ -99,6 +100,7 @@ target_link_libraries(px4 PRIVATE
 	-Wl,--end-group
 
 	m
+	gcc
 	)
 
 target_link_libraries(px4 PRIVATE ${module_libraries})

--- a/platforms/nuttx/NuttX/Make.defs.in
+++ b/platforms/nuttx/NuttX/Make.defs.in
@@ -108,6 +108,7 @@ CFLAGS = $(ARCHINCLUDES) \
 
 CXXFLAGS = $(ARCHXXINCLUDES) \
 	-std=gnu++11 \
+	-nostdinc++ \
 	${CMAKE_CXX_FLAGS} \
 	$(FLAGS) \
 	-fcheck-new \

--- a/src/drivers/differential_pressure/ets/ets_airspeed.cpp
+++ b/src/drivers/differential_pressure/ets/ets_airspeed.cpp
@@ -38,7 +38,7 @@
  * Driver for the Eagle Tree Airspeed V3 connected via I2C.
  */
 
-#include <cfloat>
+#include <float.h>
 
 #include <px4_config.h>
 

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -37,7 +37,7 @@
  * Driver/configurator for the PX4 FMU
  */
 
-#include <cfloat>
+#include <float.h>
 
 #include <board_config.h>
 #include <drivers/device/device.h>

--- a/src/drivers/rc_input/RCInput.hpp
+++ b/src/drivers/rc_input/RCInput.hpp
@@ -33,7 +33,7 @@
 
 #pragma once
 
-#include <cfloat>
+#include <float.h>
 
 #include <board_config.h>
 #include <drivers/drv_hrt.h>

--- a/src/lib/cdev/nuttx/cdev_platform.hpp
+++ b/src/lib/cdev/nuttx/cdev_platform.hpp
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <cinttypes>
+#include <inttypes.h>
 
 #include <nuttx/arch.h>
 

--- a/src/lib/cdev/posix/cdev_platform.hpp
+++ b/src/lib/cdev/posix/cdev_platform.hpp
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <cinttypes>
+#include <inttypes.h>
 
 #define ATOMIC_ENTER lock()
 #define ATOMIC_LEAVE unlock()

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -39,7 +39,7 @@
 
 #include "mixer.h"
 
-#include <cfloat>
+#include <float.h>
 #include <cstring>
 #include <cstdio>
 

--- a/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
+++ b/src/modules/attitude_estimator_q/attitude_estimator_q_main.cpp
@@ -39,7 +39,7 @@
  * @author Anton Babushkin <anton.babushkin@me.com>
  */
 
-#include <cfloat>
+#include <float.h>
 #include <drivers/drv_hrt.h>
 #include <lib/ecl/geo/geo.h>
 #include <lib/ecl/geo_lookup/geo_mag_declination.h>

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -80,7 +80,7 @@
 #include <parameters/param.h>
 
 #include <cmath>
-#include <cfloat>
+#include <float.h>
 #include <cstring>
 
 #include <uORB/topics/actuator_armed.h>

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -38,7 +38,7 @@
  * @author Roman Bapst
  */
 
-#include <cfloat>
+#include <float.h>
 
 #include <drivers/drv_hrt.h>
 #include <lib/ecl/EKF/ekf.h>

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.hpp
@@ -51,7 +51,7 @@
 #include "launchdetection/LaunchDetector.h"
 #include "runway_takeoff/RunwayTakeoff.h"
 
-#include <cfloat>
+#include <float.h>
 
 #include <drivers/drv_hrt.h>
 #include <lib/ecl/geo/geo.h>

--- a/src/modules/gnd_pos_control/GroundRoverPositionControl.hpp
+++ b/src/modules/gnd_pos_control/GroundRoverPositionControl.hpp
@@ -41,7 +41,7 @@
  * @author Marco Zorzi <mzorzi@student.ethz.ch>
  */
 
-#include <cfloat>
+#include <float.h>
 
 #include <drivers/drv_hrt.h>
 #include <lib/ecl/geo/geo.h>

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -40,7 +40,7 @@
 
 #include "LandDetector.h"
 
-#include <cfloat>
+#include <float.h>
 
 #include <px4_config.h>
 #include <px4_defines.h>

--- a/src/modules/micrortps_bridge/micrortps_client/microRTPS_client.h
+++ b/src/modules/micrortps_bridge/micrortps_client/microRTPS_client.h
@@ -34,7 +34,7 @@
 
 #include "microRTPS_transport.h"
 
-#include <cinttypes>
+#include <inttypes.h>
 #include <cstdio>
 #include <ctime>
 #include <pthread.h>

--- a/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
+++ b/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
@@ -33,7 +33,7 @@
 #include "microRTPS_transport.h"
 #include "microRTPS_client.h"
 
-#include <cinttypes>
+#include <inttypes.h>
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>

--- a/src/modules/navigator/geofence.h
+++ b/src/modules/navigator/geofence.h
@@ -40,7 +40,7 @@
 
 #pragma once
 
-#include <cfloat>
+#include <float.h>
 
 #include <px4_module_params.h>
 #include <drivers/drv_hrt.h>

--- a/src/modules/navigator/mission.h
+++ b/src/modules/navigator/mission.h
@@ -48,7 +48,7 @@
 #include "mission_feasibility_checker.h"
 #include "navigator_mode.h"
 
-#include <cfloat>
+#include <float.h>
 
 #include <dataman/dataman.h>
 #include <drivers/drv_hrt.h>

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -45,7 +45,7 @@
 
 #include "navigator.h"
 
-#include <cfloat>
+#include <float.h>
 #include <sys/stat.h>
 
 #include <dataman/dataman.h>

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -42,7 +42,7 @@
 #include "vtol_type.h"
 #include "vtol_att_control_main.h"
 
-#include <cfloat>
+#include <float.h>
 #include <px4_defines.h>
 #include <matrix/math.hpp>
 

--- a/src/systemcmds/tests/test_controlmath.cpp
+++ b/src/systemcmds/tests/test_controlmath.cpp
@@ -1,7 +1,7 @@
 #include <unit_test.h>
 #include <mc_pos_control/Utility/ControlMath.hpp>
 #include <mathlib/mathlib.h>
-#include <cfloat>
+#include <float.h>
 
 #define SIGMA_SINGLE_OP			0.000001f
 

--- a/src/systemcmds/tests/test_float.cpp
+++ b/src/systemcmds/tests/test_float.cpp
@@ -1,7 +1,7 @@
 #include <unit_test.h>
 
 #include <px4_config.h>
-#include <cfloat>
+#include <float.h>
 
 typedef union {
 	float f;


### PR DESCRIPTION
We're currently using a somewhat dangerous mix of NuttX cxx system headers and the toolchain cxx system headers. This PR is a small step towards fixing that.

https://github.com/PX4/Firmware/issues/11152