### PR TITLE
uorb_rtps_message_ids: for now, remove vehicle_global_position send

### DIFF
--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -213,7 +213,6 @@ rtps:
     id: 92
   - msg: vehicle_global_position
     id: 93
-    send: true
   - msg: vehicle_gps_position
     id: 94
   - msg: vehicle_land_detected


### PR DESCRIPTION
Still related with https://github.com/PX4/Firmware/pull/11120. Seems like `vehicle_global_position` slipped by. It also returns errors with booleans. While not pushing a permanent fix, this will be quick work around.
