### PR TITLE
Jenkins use px4_sitl_test build to run unit tests

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -177,7 +177,7 @@ pipeline {
           steps {
             sh 'export'
             sh 'make distclean'
-            sh 'make px4_sitl_default test_results_junit'
+            sh 'make px4_sitl_test test_results_junit'
             withCredentials([string(credentialsId: 'FIRMWARE_CODECOV_TOKEN', variable: 'CODECOV_TOKEN')]) {
               sh 'curl -s https://codecov.io/bash | bash -s - -F unittest'
             }


### PR DESCRIPTION
 - these only run if code coverage is enabled
http://ci.px4.io:8080/blue/organizations/jenkins/PX4_misc%2FFirmware-SITL_tests-CMAKE_BUILD_TYPE/detail/Firmware-SITL_tests-CMAKE_BUILD_TYPE/1252/pipeline

FYI @julianoes 