### PR TITLE
Fix for problems with ICM20948 introduced in #11020

### DIFF
--- a/boards/px4/fmu-v3/init/rc.board
+++ b/boards/px4/fmu-v3/init/rc.board
@@ -116,7 +116,7 @@ then
 	if [ $BOARD_FMUV3 = 21 ]
 	then
 		# v2.1 internal MPU9250 is rotated 180 deg roll, 270 deg yaw
-		mpu9250 -R 14 start
+		mpu9250 -s -R 14 start
 	fi
 
 else

--- a/src/drivers/imu/mpu9250/main.cpp
+++ b/src/drivers/imu/mpu9250/main.cpp
@@ -264,7 +264,17 @@ start_bus(struct mpu9250_bus_option &bus, enum Rotation rotation, bool external,
 		goto fail;
 	}
 
-	fd = open(bus.accelpath, O_RDONLY);
+	/*
+	 * Set the poll rate to default, starts automatic data collection.
+	 * Doing this through the mag device for the time being - it's always there, even in magnetometer only mode.
+	 * Using accel device for MPU6500.
+	 */
+	if (bus.dev->get_whoami() == MPU_WHOAMI_6500) {
+		fd = open(bus.accelpath, O_RDONLY);
+
+	} else {
+		fd = open(bus.magpath, O_RDONLY);
+	}
 
 	if (fd < 0) {
 		PX4_INFO("ioctl failed");

--- a/src/drivers/imu/mpu9250/mpu9250.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250.cpp
@@ -421,6 +421,11 @@ MPU9250::init()
 	return ret;
 }
 
+uint8_t MPU9250::get_whoami()
+{
+	return _whoami;
+}
+
 int MPU9250::reset()
 {
 	irqstate_t state;
@@ -574,6 +579,8 @@ MPU9250::probe()
 
 	// If it's not an MPU it must be an ICM
 	if ((_whoami != MPU_WHOAMI_9250) && (_whoami != MPU_WHOAMI_6500)) {
+		// Make sure selected register bank is bank 0 (which contains WHOAMI)
+		select_register_bank(REG_BANK(ICMREG_20948_WHOAMI));
 		_whoami = read_reg(ICMREG_20948_WHOAMI);
 	}
 

--- a/src/drivers/imu/mpu9250/mpu9250.h
+++ b/src/drivers/imu/mpu9250/mpu9250.h
@@ -386,6 +386,7 @@ public:
 	virtual ~MPU9250();
 
 	virtual int		init();
+	uint8_t			get_whoami();
 
 	/**
 	 * Diagnostics - print some basic information about the driver.


### PR DESCRIPTION
Fixes problems for ICM20948 introduced by #11020 (discussed in #11019):

1. Unreliable ICM20948 detection due to wrong register bank selected after flight control reboot, so read of WHOAMI returned wrong value.

2. Broken ICM20948 magnetometer only option, defect by use of (in mag only mode) non-existent magnetometer device file.

3. Driver for internal mpu9250 on Pixhawk 2.1 was loaded (in rc.board) without the bus specified and found the external ICM20948 instead. This activated the external sensor in full IMU mode, but with the wrong orientation, and blocked the activation of the internal mpu9250.  Due to this, the proper entry for ICM20948 in rc.sensors didn't load either.

Fixes:
1. Fixed by trying to set the register bank before reading ICM20948 WHOAMI and after neither MPU9250 or MPU6500 found. This triggers one I2C register write to a not fully detected device though (but on the correct address).

2. Implemented get_whoami() method on driver and using this get detected device type in main.cpp. For MPU6500 (no mag there), always using accelerometer device file. Using magnetometer device file for MPU9250 and ICM20948 (always there, even in magnetometer only mode).

3. Specified bus for internal mpu9250 on Pixhawk 2.1 to avoid premature detection of
other device (especially external ICM20948 in Here GPS, getting initialized with wrong orientation and in full IMU mode instead of magnetometer only, while internal MPU9250 is not used at all while GPS connected)

Also see #11019