### PR TITLE
IMU heater improvements

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4250_teal
+++ b/ROMFS/px4fmu_common/init.d/airframes/4250_teal
@@ -200,6 +200,9 @@ then
 
 fi
 
+# Logger mode. Default(1) + estimator replay(2) + thermal calibration(4)
+param set SDLOG_PROFILE 6
+
 # Do not start frsky_telemetry on port ttyS6 by default, PGA460 lives there. 500 is in arbitrary unused number.
 param set TEL_FRSKY_CONFIG 500
 # We want to make sure these always start

--- a/src/drivers/heater/heater.cpp
+++ b/src/drivers/heater/heater.cpp
@@ -104,16 +104,6 @@ int Heater::custom_command(int argc, char *argv[])
 		return get_instance()->controller_period(argv);
 	}
 
-	// Display the heater on duty cycle as a percent.
-	if (strcmp(arg_v, "duty_cycle") == 0) {
-		return get_instance()->duty_cycle();
-	}
-
-	// Display/Set the heater driver feed forward value.
-	if (strcmp(arg_v, "feed_forward") == 0) {
-		return get_instance()->feed_forward(argv);
-	}
-
 	// Display/Set the heater driver integrator gain value.
 	if (strcmp(arg_v, "integrator") == 0) {
 		return get_instance()->integrator(argv);
@@ -134,11 +124,6 @@ int Heater::custom_command(int argc, char *argv[])
 		return get_instance()->temperature_setpoint(argv);
 	}
 
-	// Displays the IMU reported temperature.
-	if (strcmp(arg_v, "temp") == 0) {
-		return get_instance()->sensor_temperature();
-	}
-
 	get_instance()->print_usage("Unrecognized command.");
 	return PX4_OK;
 }
@@ -149,8 +134,6 @@ void Heater::cycle()
 		exit_and_cleanup();
 		return;
 	}
-
-	int controller_time_on_usec = 0;
 
 	if (_heater_on) {
 		// Turn the heater off.
@@ -182,14 +165,13 @@ void Heater::cycle()
 		// Constrain the integrator value to no more than 25% of the duty cycle.
 		_integrator_value = math::constrain(_integrator_value, -0.25f, 0.25f);
 
-		controller_time_on_usec = (int)((_p_feed_forward_value.get() + _proportional_value +
-						 _integrator_value) * (float)_controller_period_usec);
+		// Calculate the duty cycle. This is a value between 0 and 1.
+		float duty = _proportional_value + _integrator_value;
+
+		_controller_time_on_usec = (int)(duty * (float)_controller_period_usec);
 
 		// Constrain the heater time within the allowable duty cycle.
-		controller_time_on_usec = math::constrain(controller_time_on_usec, 0, _controller_period_usec);
-
-		// Filter the duty cycle value over a ~2 second time constant.
-		_duty_cycle = (0.05f * ((float)controller_time_on_usec / (float)_controller_period_usec)) + (0.95f * _duty_cycle);
+		_controller_time_on_usec = math::constrain(_controller_time_on_usec, 0, _controller_period_usec);
 
 		// Turn the heater on.
 		_heater_on = true;
@@ -200,11 +182,11 @@ void Heater::cycle()
 	// Schedule the next cycle.
 	if (_heater_on) {
 		work_queue(LPWORK, &_work, (worker_t)&Heater::cycle_trampoline, this,
-			   USEC2TICK(controller_time_on_usec));
+			   USEC2TICK(_controller_time_on_usec));
 
 	} else {
 		work_queue(LPWORK, &_work, (worker_t)&Heater::cycle_trampoline, this,
-			   USEC2TICK(_controller_period_usec - controller_time_on_usec));
+			   USEC2TICK(_controller_period_usec - _controller_time_on_usec));
 	}
 }
 
@@ -212,23 +194,6 @@ void Heater::cycle_trampoline(void *argv)
 {
 	Heater *obj = reinterpret_cast<Heater *>(argv);
 	obj->cycle();
-}
-
-float Heater::duty_cycle()
-{
-	PX4_INFO("Average duty cycle:  %3.1f%%", (double)(_duty_cycle * 100.f));
-	return _duty_cycle;
-}
-
-float Heater::feed_forward(char *argv[])
-{
-	if (argv[1]) {
-		_p_feed_forward_value.set(atof(argv[1]));
-
-	}
-
-	PX4_INFO("Feed forward value:  %2.5f", (double)_p_feed_forward_value.get());
-	return _p_feed_forward_value.get();
 }
 
 void Heater::initialize_topics()
@@ -335,8 +300,6 @@ This task can be started at boot from the startup scripts by setting SENS_EN_THE
 
 	PRINT_MODULE_USAGE_NAME("heater", "system");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("controller_period", "Reports the heater driver cycle period value, (us), and sets it if supplied an argument.");
-	PRINT_MODULE_USAGE_COMMAND_DESCR("duty_cycle", "Reports the heater duty cycle (%).");
-	PRINT_MODULE_USAGE_COMMAND_DESCR("feed_forward", "Sets the feedforward value if supplied an argument and reports the current value.");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("integrator", "Sets the integrator gain value if supplied an argument and reports the current value.");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("proportional", "Sets the proportional gain value if supplied an argument and reports the current value.");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("sensor_id", "Reports the current IMU the heater is temperature controlling.");
@@ -364,12 +327,6 @@ uint32_t Heater::sensor_id()
 {
 	PX4_INFO("Sensor ID:  %d", _sensor_accel.device_id);
 	return _sensor_accel.device_id;
-}
-
-float Heater::sensor_temperature()
-{
-	PX4_INFO("IMU temp:  %3.3f", (double)_sensor_temperature);
-	return _sensor_temperature;
 }
 
 int Heater::start()

--- a/src/drivers/heater/heater.h
+++ b/src/drivers/heater/heater.h
@@ -103,19 +103,6 @@ public:
 	int controller_period(char *argv[]);
 
 	/**
-	 * @brief Reports the average heater on duty cycle as a percent.
-	 * @return Returns the average heater on cycle duty cycle as a percent.
-	 */
-	float duty_cycle();
-
-	/**
-	 * @brief Sets and/or reports the heater controller feed fordward value.
-	 * @param argv Pointer to the input argument array.
-	 * @return Returns the heater feed forward value iff successful, 0.0f otherwise.
-	 */
-	float feed_forward(char *argv[]);
-
-	/**
 	 * @brief Sets and/or reports the heater controller integrator gain value.
 	 * @param argv Pointer to the input argument array.
 	 * @return Returns the heater integrator gain value iff successful, 0.0f otherwise.
@@ -149,12 +136,6 @@ public:
 	int print_status();
 
 	/**
-	 * @brief Reports the current heater temperature.
-	 * @return Returns the current heater temperature value iff successful, -1.0f otherwise.
-	 */
-	float sensor_temperature();
-
-	/**
 	 * @brief Sets and/or reports the heater target temperature.
 	 * @param argv Pointer to the input argument array.
 	 * @return Returns the heater target temperature value iff successful, -1.0f otherwise.
@@ -176,11 +157,6 @@ protected:
 	static void initialize_trampoline(void *argv);
 
 private:
-
-	/**
-	 * @brief Checks for new commands and processes them.
-	 */
-	void process_commands();
 
 	/**
 	 * @brief Trampoline for the work queue.
@@ -215,7 +191,7 @@ private:
 
 	int _controller_period_usec = CONTROLLER_PERIOD_DEFAULT;
 
-	float _duty_cycle = 0.0f;
+	int _controller_time_on_usec = 0;
 
 	bool _heater_on = false;
 
@@ -233,7 +209,6 @@ private:
 
 	/** @note Declare local parameters using defined parameters. */
 	DEFINE_PARAMETERS(
-		(ParamFloat<px4::params::SENS_IMU_TEMP_FF>)  _p_feed_forward_value,
 		(ParamFloat<px4::params::SENS_IMU_TEMP_I>)  _p_integrator_gain,
 		(ParamFloat<px4::params::SENS_IMU_TEMP_P>)  _p_proportional_gain,
 		(ParamInt<px4::params::SENS_TEMP_ID>) _p_sensor_id,

--- a/src/drivers/heater/heater_params.c
+++ b/src/drivers/heater/heater_params.c
@@ -59,17 +59,6 @@ PARAM_DEFINE_INT32(SENS_TEMP_ID, 1442826);
 PARAM_DEFINE_FLOAT(SENS_IMU_TEMP, 55.0f);
 
 /**
- * IMU heater controller feedforward value.
- *
- * @group Sensors
- * @unit microseconds
- * @min 0
- * @max 1.0
- * @decimal 3
- */
-PARAM_DEFINE_FLOAT(SENS_IMU_TEMP_FF, 0.0f);
-
-/**
  * IMU heater controller integrator gain value.
  *
  * @group Sensors
@@ -87,7 +76,7 @@ PARAM_DEFINE_FLOAT(SENS_IMU_TEMP_I, 0.025f);
  * @group Sensors
  * @unit microseconds/C
  * @min 0
- * @max 1.0
+ * @max 2.0
  * @decimal 3
  */
-PARAM_DEFINE_FLOAT(SENS_IMU_TEMP_P, 0.25f);
+PARAM_DEFINE_FLOAT(SENS_IMU_TEMP_P, 1.0f);


### PR DESCRIPTION
I noticed the IMU was taking a long time to get up to temperature. I discovered and fixed a bug in the code relating to the use of a local variable instead of a member variable. I also increased the **P** term of the controller to reduce the rise time (100% duty cycle now). I removed the feedforward from the controller, as it was not needed to achieve good results. I also removed some of the custom commands that didn't really serve any purpose.

**Heres the data**
![selection_002](https://user-images.githubusercontent.com/37091262/50857922-4229f900-134c-11e9-8ff7-28fdc10afb7f.png)
**Zooming in on the end of the curve**
![selection_001](https://user-images.githubusercontent.com/37091262/50857926-43f3bc80-134c-11e9-9bdc-c3897557cd01.png)