### PR TITLE
SITL perf improvements

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -128,19 +128,19 @@ then
     echo "Not running simulation (\$DONT_RUN is set)."
 elif [ "$debugger" == "lldb" ]
 then
-	lldb -- $sitl_command
+	eval lldb -- $sitl_command
 elif [ "$debugger" == "gdb" ]
 then
-	gdb --args $sitl_command
+	eval gdb --args $sitl_command
 elif [ "$debugger" == "ddd" ]
 then
-	ddd --debugger gdb --args $sitl_command
+	eval ddd --debugger gdb --args $sitl_command
 elif [ "$debugger" == "valgrind" ]
 then
-	valgrind --track-origins=yes --leak-check=full -v $sitl_command
+	eval valgrind --track-origins=yes --leak-check=full -v $sitl_command
 elif [ "$debugger" == "callgrind" ]
 then
-	valgrind --tool=callgrind -v $sitl_command
+	eval valgrind --tool=callgrind -v $sitl_command
 elif [ "$debugger" == "ide" ]
 then
 	echo "######################################################################"

--- a/platforms/posix/src/lockstep_scheduler/CMakeLists.txt
+++ b/platforms/posix/src/lockstep_scheduler/CMakeLists.txt
@@ -6,6 +6,8 @@ if(NOT PROJECT_NAME STREQUAL "px4")
 
     set (CMAKE_CXX_STANDARD 11)
 
+	add_definitions(-DUNIT_TESTS)
+
     add_library(lockstep_scheduler
         src/lockstep_scheduler.cpp
     )

--- a/platforms/posix/src/lockstep_scheduler/CMakeLists.txt
+++ b/platforms/posix/src/lockstep_scheduler/CMakeLists.txt
@@ -2,39 +2,39 @@ cmake_minimum_required(VERSION 2.8.12)
 
 if(NOT PROJECT_NAME STREQUAL "px4")
 
-    project(lockstep_scheduler)
+	project(lockstep_scheduler)
 
-    set (CMAKE_CXX_STANDARD 11)
+	set (CMAKE_CXX_STANDARD 11)
 
 	add_definitions(-DUNIT_TESTS)
 
-    add_library(lockstep_scheduler
-        src/lockstep_scheduler.cpp
-    )
+	add_library(lockstep_scheduler
+		src/lockstep_scheduler.cpp
+	)
 
-    target_include_directories(lockstep_scheduler
-        PUBLIC
-            $<INSTALL_INTERFACE:include>
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        PRIVATE
-            ${CMAKE_CURRENT_SOURCE_DIR}/src
-    )
+	target_include_directories(lockstep_scheduler
+		PUBLIC
+			$<INSTALL_INTERFACE:include>
+			$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+		PRIVATE
+			${CMAKE_CURRENT_SOURCE_DIR}/src
+	)
 
-    target_link_libraries(lockstep_scheduler
-        pthread
-    )
+	target_link_libraries(lockstep_scheduler
+		pthread
+	)
 
-    target_compile_options(lockstep_scheduler PRIVATE -Wall -Wextra -Werror -O2)
+	target_compile_options(lockstep_scheduler PRIVATE -Wall -Wextra -Werror -O2)
 
-    add_subdirectory(test)
+	add_subdirectory(test)
 
 else()
 
-    add_library(lockstep_scheduler
-        src/lockstep_scheduler.cpp
-    )
-    include_directories(
-        include
-    )
+	add_library(lockstep_scheduler
+		src/lockstep_scheduler.cpp
+	)
+	include_directories(
+		include
+	)
 
 endif()

--- a/platforms/posix/src/lockstep_scheduler/include/lockstep_scheduler/lockstep_scheduler.h
+++ b/platforms/posix/src/lockstep_scheduler/include/lockstep_scheduler/lockstep_scheduler.h
@@ -11,7 +11,7 @@ class LockstepScheduler
 {
 public:
 	void set_absolute_time(uint64_t time_us);
-	uint64_t get_absolute_time() const;
+	inline uint64_t get_absolute_time() const { return time_us_; }
 	int cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *lock, uint64_t time_us);
 	int usleep_until(uint64_t timed_us);
 

--- a/platforms/posix/src/lockstep_scheduler/include/lockstep_scheduler/lockstep_scheduler.h
+++ b/platforms/posix/src/lockstep_scheduler/include/lockstep_scheduler/lockstep_scheduler.h
@@ -27,6 +27,5 @@ private:
 	};
 	std::vector<std::shared_ptr<TimedWait>> timed_waits_{};
 	std::mutex timed_waits_mutex_{};
-	bool timed_waits_iterator_invalidated_{false};
 	std::atomic<bool> setting_time_{false}; ///< true if set_absolute_time() is currently being executed
 };

--- a/platforms/posix/src/lockstep_scheduler/include/lockstep_scheduler/lockstep_scheduler.h
+++ b/platforms/posix/src/lockstep_scheduler/include/lockstep_scheduler/lockstep_scheduler.h
@@ -23,9 +23,10 @@ private:
 		pthread_mutex_t *passed_lock{nullptr};
 		uint64_t time_us{0};
 		bool timeout{false};
-		bool done{false};
+		std::atomic<bool> done{false};
 	};
 	std::vector<std::shared_ptr<TimedWait>> timed_waits_{};
 	std::mutex timed_waits_mutex_{};
 	bool timed_waits_iterator_invalidated_{false};
+	std::atomic<bool> setting_time_{false}; ///< true if set_absolute_time() is currently being executed
 };

--- a/platforms/posix/src/lockstep_scheduler/include/lockstep_scheduler/lockstep_scheduler.h
+++ b/platforms/posix/src/lockstep_scheduler/include/lockstep_scheduler/lockstep_scheduler.h
@@ -13,13 +13,11 @@ public:
 	~LockstepScheduler();
 
 	void set_absolute_time(uint64_t time_us);
-	inline uint64_t get_absolute_time() const { return time_us_; }
+	inline uint64_t get_absolute_time() const { return _time_us; }
 	int cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *lock, uint64_t time_us);
 	int usleep_until(uint64_t timed_us);
 
 private:
-	std::atomic<uint64_t> time_us_{0};
-
 	struct TimedWait {
 		~TimedWait()
 		{
@@ -42,7 +40,10 @@ private:
 
 		TimedWait *next{nullptr}; ///< linked list
 	};
-	TimedWait *timed_waits_{nullptr}; ///< head of linked list
-	std::mutex timed_waits_mutex_;
-	std::atomic<bool> setting_time_{false}; ///< true if set_absolute_time() is currently being executed
+
+	std::atomic<uint64_t> _time_us{0};
+
+	TimedWait *_timed_waits{nullptr}; ///< head of linked list
+	std::mutex _timed_waits_mutex;
+	std::atomic<bool> _setting_time{false}; ///< true if set_absolute_time() is currently being executed
 };

--- a/platforms/posix/src/lockstep_scheduler/src/lockstep_scheduler.cpp
+++ b/platforms/posix/src/lockstep_scheduler/src/lockstep_scheduler.cpp
@@ -1,11 +1,6 @@
 #include "lockstep_scheduler/lockstep_scheduler.h"
 
 
-uint64_t LockstepScheduler::get_absolute_time() const
-{
-	return time_us_;
-}
-
 void LockstepScheduler::set_absolute_time(uint64_t time_us)
 {
 	time_us_ = time_us;

--- a/platforms/posix/src/lockstep_scheduler/src/lockstep_scheduler.cpp
+++ b/platforms/posix/src/lockstep_scheduler/src/lockstep_scheduler.cpp
@@ -87,10 +87,8 @@ int LockstepScheduler::cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *loc
 
 int LockstepScheduler::usleep_until(uint64_t time_us)
 {
-	pthread_mutex_t lock;
-	pthread_mutex_init(&lock, nullptr);
-	pthread_cond_t cond;
-	pthread_cond_init(&cond, nullptr);
+	pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+	pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
 
 	pthread_mutex_lock(&lock);
 
@@ -102,9 +100,6 @@ int LockstepScheduler::usleep_until(uint64_t time_us)
 	}
 
 	pthread_mutex_unlock(&lock);
-
-	pthread_cond_destroy(&cond);
-	pthread_mutex_destroy(&lock);
 
 	return result;
 }

--- a/platforms/posix/src/lockstep_scheduler/src/lockstep_scheduler.cpp
+++ b/platforms/posix/src/lockstep_scheduler/src/lockstep_scheduler.cpp
@@ -25,18 +25,10 @@ void LockstepScheduler::set_absolute_time(uint64_t time_us)
 			    !temp_timed_wait->timeout) {
 				// We are abusing the condition here to signal that the time
 				// has passed.
-				timed_waits_iterator_invalidated_ = false;
 				pthread_mutex_lock(temp_timed_wait->passed_lock);
 				temp_timed_wait->timeout = true;
 				pthread_cond_broadcast(temp_timed_wait->passed_cond);
 				pthread_mutex_unlock(temp_timed_wait->passed_lock);
-
-				if (timed_waits_iterator_invalidated_) {
-					// The vector might have changed, we need to start from the
-					// beginning.
-					it = std::begin(timed_waits_);
-					continue;
-				}
 			}
 
 			++it;
@@ -62,7 +54,6 @@ int LockstepScheduler::cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *loc
 		new_timed_wait->passed_cond = cond;
 		new_timed_wait->passed_lock = lock;
 		timed_waits_.push_back(new_timed_wait);
-		timed_waits_iterator_invalidated_ = true;
 	}
 
 	int result = pthread_cond_wait(cond, lock);

--- a/platforms/posix/src/px4_layer/drv_hrt.cpp
+++ b/platforms/posix/src/px4_layer/drv_hrt.cpp
@@ -154,6 +154,11 @@ uint64_t hrt_system_time()
  */
 hrt_abstime hrt_absolute_time()
 {
+#if defined(ENABLE_LOCKSTEP_SCHEDULER)
+	// optimized case (avoid ts_to_abstime) if lockstep scheduler is used
+	const uint64_t abstime = lockstep_scheduler.get_absolute_time();
+	return abstime - px4_timestart_monotonic;
+#else // defined(ENABLE_LOCKSTEP_SCHEDULER)
 	struct timespec ts;
 	px4_clock_gettime(CLOCK_MONOTONIC, &ts);
 #ifdef __PX4_QURT
@@ -161,6 +166,7 @@ hrt_abstime hrt_absolute_time()
 #else
 	return ts_to_abstime(&ts);
 #endif
+#endif // defined(ENABLE_LOCKSTEP_SCHEDULER)
 }
 
 #ifdef __PX4_QURT

--- a/src/drivers/drv_hrt.h
+++ b/src/drivers/drv_hrt.h
@@ -173,25 +173,6 @@ __EXPORT extern void	hrt_init(void);
 
 #ifdef __PX4_POSIX
 
-/**
- * Start to delay the HRT return value.
- *
- * Until hrt_stop_delay() is called the HRT calls will return the timestamp
- * at the instance then hrt_start_delay() was called.
- */
-__EXPORT extern	void	hrt_start_delay(void);
-
-/**
- * Stop to delay the HRT.
- */
-__EXPORT extern void	hrt_stop_delay(void);
-
-/**
- * Stop to delay the HRT, but with an exact delta time.
- */
-__EXPORT extern void	hrt_stop_delay_delta(hrt_abstime delta);
-
-
 __EXPORT extern hrt_abstime hrt_reset(void);
 
 __EXPORT extern hrt_abstime hrt_absolute_time_offset(void);

--- a/src/lib/cdev/posix/cdev_platform.cpp
+++ b/src/lib/cdev/posix/cdev_platform.cpp
@@ -54,10 +54,6 @@ const cdev::px4_file_operations_t cdev::CDev::fops = {};
 pthread_mutex_t devmutex = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t filemutex = PTHREAD_MUTEX_INITIALIZER;
 
-px4_sem_t lockstep_sem;
-bool sim_lockstep = false;
-volatile bool sim_delay = false;
-
 #define PX4_MAX_FD 350
 static map<string, void *> devmap;
 static cdev::file_t filemap[PX4_MAX_FD] = {};
@@ -333,10 +329,6 @@ extern "C" {
 		}
 
 #endif
-
-		while (sim_delay) {
-			px4_usleep(100);
-		}
 
 		PX4_DEBUG("Called px4_poll timeout = %d", timeout);
 


### PR DESCRIPTION
This brings some lockstep/timing/locking-related performance improvements.

In more detail:
- reduces SITL CPU usage by ~2% (28% -> 26%)
- reduces locking in `hrt_absolute_time` and the lockstep scheduler. This reduces the amount of time spent in (un)locking by a few percent, but it's still really high - around 30%. Heaviest remaining users are the driver framework and uORB.
- `hrt_absolute_time` used 11% of the total usage, it is now down to 0.35%
- removed the heavy use of `malloc` in the lockstep scheduler by using a thread_local object (required some changes to the unit-tests as well).
- replaced the `std::vector` with a more efficient linked list in the lockstep scheduler.
- fixes valgrind & gdb invocation