### PR TITLE
logger: disable mission log by default (SDLOG_MISSION=0)

### DIFF
--- a/src/modules/logger/params.c
+++ b/src/modules/logger/params.c
@@ -85,7 +85,7 @@ PARAM_DEFINE_INT32(SDLOG_MODE, 0);
  * @reboot_required true
  * @group SD Logging
  */
-PARAM_DEFINE_INT32(SDLOG_MISSION, 1);
+PARAM_DEFINE_INT32(SDLOG_MISSION, 0);
 
 /**
  * Logging topic profile (integer bitmask).


### PR DESCRIPTION
- I enabled it by default mostly for testing purposes
- Disabling it reduces resource usage as most setups don't need it