### PR TITLE
[WIP] Failsafe improvement

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1306,6 +1306,11 @@ void MulticopterPositionControl::send_vehicle_cmd_do(uint8_t nav_state)
 		command.param2 = (float)PX4_CUSTOM_MAIN_MODE_ALTCTL;
 		break;
 
+	case vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER:
+		command.param2 = (float)PX4_CUSTOM_MAIN_MODE_AUTO;
+		command.param3 = (float)PX4_CUSTOM_SUB_MODE_AUTO_LOITER;
+		break;
+
 	default: //vehicle_status_s::NAVIGATION_STATE_POSCTL
 		command.param2 = (float)PX4_CUSTOM_MAIN_MODE_POSCTL;
 		break;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -750,14 +750,14 @@ MulticopterPositionControl::run()
 				limit_altitude(setpoint);
 			}
 
-			// Update states, setpoints and constraints.
-			_control.updateConstraints(constraints);
-			_control.updateState(_states);
-
 			// adjust setpoints based on avoidance
 			if (use_obstacle_avoidance()) {
 				execute_avoidance_waypoint(setpoint);
 			}
+
+			// Update states, setpoints and constraints.
+			_control.updateConstraints(constraints);
+			_control.updateState(_states);
 
 			// update position controller setpoints
 			if (!_control.updateSetpoint(setpoint)) {


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Fit the safety requirements of obstacle avoidance testing #11058
To test OA you typically plan a mission through an obstacle. The OA "module" then processes the setpoints and adjusts if needed. If this module for some reason fails the drone should not continue the mission and crash into the obstacle.

**Describe your preferred solution**
In my eyes this error case should be handeled through the following path:
- ~Obstacle Avoidance wrapper sees something went wrong, no connection anymore.~
- ~The flight task calling the OA wrapper gets to know via return value and returns `false` to its `update()` method to indicate the task can not be further pursued.~
- ~The flight task host (currently the postion control module) handles the failsafe case by switching to the appropriate reaction which is ideally the the Failsafe flight task.~

**EDIT:** There is no OA wrapper/library yet and everything is called in the position control module class directly.

The last point is where I'm trying to find an interim solution to unblock currently unsafe tests and a future proof solution asap.

Right now I'm thinking about just informing the commander it should switch mode in that case.

**Test data / coverage**
SITL (I have no OA setup and just mock inputs)