### PR TITLE
Fix driver load order for external ICM20948/Here GNSS for Pixhawk Cube

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -105,9 +105,6 @@ then
 	teraranger start -a
 fi
 
-# ICM20948 as external magnetometer on I2C (e.g. Here GPS)
-mpu9250 -X -M -R 6 start
-
 # Check for flow sensor, launched as a background task to scan
 px4flow start &
 

--- a/boards/px4/fmu-v3/init/rc.board
+++ b/boards/px4/fmu-v3/init/rc.board
@@ -47,6 +47,9 @@ hmc5883 -C -T -X start
 lis3mdl -X start
 ist8310 -C start
 
+# ICM20948 as external magnetometer on I2C (with Rotation 6 for Here GNSS)
+mpu9250 -X -M -R 6 start
+
 # Internal I2C bus
 hmc5883 -C -T -I -R 4 start
 


### PR DESCRIPTION
With the driver load in rc.sensors, the external ICM20948 magnetometer on Here GNSS gets activated as last (and 4th) magnetometer on Pixhawk Cube.  It gets set as primary mag after calibration, but QGroundControl does not show the "External Compass Orientation" Dropdown in Parameters -> Sensors -> Set Orientations:

![here_gnss_orientations](https://user-images.githubusercontent.com/38494856/50992616-f3c95580-1517-11e9-94c2-c6875258cbed.png)

I moved the driver load to the start of rc.board of px4fmu-v3, after the load of external ist8310. This resolves the issue for Pixhawk Cube.