### PR TITLE
Do not start ttyS0 on pixracer for TealOne airframe

### DIFF
--- a/boards/px4/fmu-v4/init/rc.board
+++ b/boards/px4/fmu-v4/init/rc.board
@@ -89,8 +89,13 @@ then
 fi
 
 
-# Pixracer: start MAVLink on Wifi (ESP8266 port)
-mavlink start -r 20000 -b 921600 -d /dev/ttyS0
+# Pixracer: start MAVLink on Wifi (ESP8266 port). Except for the TealOne airframe.
+if param compare SYS_AUTOSTART 4250
+then
+else
+	mavlink start -r 20000 -b 921600 -d /dev/ttyS0
+fi
+
 
 # Run FrSky Telemetry on Pixracer on the FrSky port if not enabled already
 if param compare TEL_FRSKY_CONFIG 0


### PR DESCRIPTION
We have RAM problems and can't afford 4 mavlink instances. This PR only adds logic the `rc.board` for the fmu-v4 that only has an effect for SYS_AUTOSTART = 4250 (TealOne airframe).

@dagar My goal here is to have the Teal airframe fully supported in `PX4/master` for the 1.9.0 release.