### PR TITLE
param command updates (change show default and add status)

### DIFF
--- a/src/lib/parameters/param.h
+++ b/src/lib/parameters/param.h
@@ -397,6 +397,11 @@ __EXPORT int 		param_load_default(void);
  */
 __EXPORT uint32_t	param_hash_check(void);
 
+/**
+ * Print the status of the param system
+ *
+ */
+__EXPORT void	param_print_status(void);
 
 /**
  * Enable/disable the param autosaving.

--- a/src/lib/parameters/param.h
+++ b/src/lib/parameters/param.h
@@ -349,7 +349,7 @@ __EXPORT int		param_load(int fd);
  * @param arg		Argument passed to the function.
  * @param only_changed	If true, the function is only called for parameters whose values have
  *			been changed from the default.
- * @param only_changed	If true, the function is only called for parameters which have been
+ * @param only_used	If true, the function is only called for parameters which have been
  *			used in one of the running applications.
  */
 __EXPORT void		param_foreach(void (*func)(void *arg, param_t param), void *arg, bool only_changed, bool only_used);

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -50,14 +50,15 @@
 #include <math.h>
 
 #include <drivers/drv_hrt.h>
+#include <lib/perf/perf_counter.h>
 #include <px4_config.h>
 #include <px4_defines.h>
 #include <px4_posix.h>
 #include <px4_sem.h>
 #include <px4_shutdown.h>
-
-#include <perf/perf_counter.h>
 #include <systemlib/uthash/utarray.h>
+
+using namespace time_literals;
 
 //#define PARAM_NO_ORB ///< if defined, avoid uorb dependency. This disables publication of parameter_update on param change
 //#define PARAM_NO_AUTOSAVE ///< if defined, do not autosave (avoids LP work queue dependency)
@@ -91,8 +92,8 @@ static char *param_user_file = nullptr;
 #include <px4_workqueue.h>
 /* autosaving variables */
 static hrt_abstime last_autosave_timestamp = 0;
-static struct work_s autosave_work;
-static bool autosave_scheduled = false;
+static struct work_s autosave_work {};
+static volatile bool autosave_scheduled = false;
 static bool autosave_disabled = false;
 #endif /* PARAM_NO_AUTOSAVE */
 
@@ -627,7 +628,7 @@ autosave_worker(void *arg)
 	int ret = param_save_default();
 
 	if (ret != 0) {
-		PX4_ERR("param save failed (%i)", ret);
+		PX4_ERR("param auto save failed (%i)", ret);
 	}
 }
 #endif /* PARAM_NO_AUTOSAVE */
@@ -651,10 +652,10 @@ param_autosave()
 	// - tasks often call param_set() for multiple params, so this avoids unnecessary save calls
 	// - the logger stores changed params. He gets notified on a param change via uORB and then
 	//   looks at all unsaved params.
-	hrt_abstime delay = 300 * 1000;
+	hrt_abstime delay = 300_ms;
 
-	const hrt_abstime rate_limit = 2000 * 1000; // rate-limit saving to 2 seconds
-	hrt_abstime last_save_elapsed = hrt_elapsed_time(&last_autosave_timestamp);
+	static constexpr const hrt_abstime rate_limit = 2_s; // rate-limit saving to 2 seconds
+	const hrt_abstime last_save_elapsed = hrt_elapsed_time(&last_autosave_timestamp);
 
 	if (last_save_elapsed < rate_limit && rate_limit > last_save_elapsed + delay) {
 		delay = rate_limit - last_save_elapsed;
@@ -1370,4 +1371,37 @@ uint32_t param_hash_check()
 	param_unlock_reader();
 
 	return param_hash;
+}
+
+void param_print_status()
+{
+	PX4_INFO("summary: %d/%d (used/total)", param_count_used(), param_count());
+
+#ifndef FLASH_BASED_PARAMS
+	const char *filename = param_get_default_file();
+
+	if (filename != nullptr) {
+		PX4_INFO("file: %s", param_get_default_file());
+	}
+
+#endif /* FLASH_BASED_PARAMS */
+
+	if (param_values != nullptr) {
+		PX4_INFO("storage array: %d/%d elements (%zu bytes total)",
+			 utarray_len(param_values), param_values->n, param_values->n * sizeof(UT_icd));
+	}
+
+#ifndef PARAM_NO_AUTOSAVE
+	PX4_INFO("auto save: %s", autosave_disabled ? "off" : "on");
+
+	if (!autosave_disabled && (last_autosave_timestamp > 0)) {
+		PX4_INFO("last auto save: %.3f seconds ago", hrt_elapsed_time(&last_autosave_timestamp) * 1e-6);
+	}
+
+#endif /* PARAM_NO_AUTOSAVE */
+
+	perf_print_counter(param_export_perf);
+	perf_print_counter(param_find_perf);
+	perf_print_counter(param_get_perf);
+	perf_print_counter(param_set_perf);
 }

--- a/src/lib/parameters/parameters_shmem.cpp
+++ b/src/lib/parameters/parameters_shmem.cpp
@@ -1479,6 +1479,39 @@ uint32_t param_hash_check()
 	return param_hash;
 }
 
+void param_print_status()
+{
+	PX4_INFO("summary: %d/%d (used/total)", param_count_used(), param_count());
+
+#ifndef FLASH_BASED_PARAMS
+	const char *filename = param_get_default_file();
+
+	if (filename != nullptr) {
+		PX4_INFO("file: %s", param_get_default_file());
+	}
+
+#endif /* FLASH_BASED_PARAMS */
+
+	if (param_values != nullptr) {
+		PX4_INFO("storage array: %d/%d elements (%zu bytes total)",
+			 utarray_len(param_values), param_values->n, param_values->n * sizeof(UT_icd));
+	}
+
+#ifndef PARAM_NO_AUTOSAVE
+	PX4_INFO("auto save: %s", autosave_disabled ? "off" : "on");
+
+	if (!autosave_disabled && (last_autosave_timestamp > 0)) {
+		PX4_INFO("last auto save: %.3f seconds ago", hrt_elapsed_time(&last_autosave_timestamp) * 1e-6);
+	}
+
+#endif /* PARAM_NO_AUTOSAVE */
+
+	perf_print_counter(param_export_perf);
+	perf_print_counter(param_find_perf);
+	perf_print_counter(param_get_perf);
+	perf_print_counter(param_set_perf);
+}
+
 void init_params()
 {
 #ifdef __PX4_QURT

--- a/src/systemcmds/param/param.cpp
+++ b/src/systemcmds/param/param.cpp
@@ -81,6 +81,7 @@ static int	do_save_default();
 static int 	do_load(const char *param_file_name);
 static int	do_import(const char *param_file_name);
 static int	do_show(const char *search_string, bool only_changed);
+static int	do_show_all();
 static int	do_show_quiet(const char *param_name);
 static int	do_show_index(const char *index, bool used_index);
 static void	do_show_print(void *arg, param_t param);
@@ -130,7 +131,8 @@ $ reboot
 	PRINT_MODULE_USAGE_ARG("<file>", "File name (use <root>/eeprom/parameters if not given)", true);
 
 	PRINT_MODULE_USAGE_COMMAND_DESCR("show", "Show parameter values");
-	PRINT_MODULE_USAGE_PARAM_FLAG('c', "Show only changed params", true);
+	PRINT_MODULE_USAGE_PARAM_FLAG('a', "Show all parameters (not just used)", true);
+	PRINT_MODULE_USAGE_PARAM_FLAG('c', "Show only changed and used params", true);
 	PRINT_MODULE_USAGE_PARAM_FLAG('q', "quiet mode, print only param value (name needs to be exact)", true);
 	PRINT_MODULE_USAGE_ARG("<filter>", "Filter by param name (wildcard at end allowed, eg. sys_*)", true);
 
@@ -226,6 +228,9 @@ param_main(int argc, char *argv[])
 					} else {
 						return do_show(nullptr, true);
 					}
+
+				} else if (!strcmp(argv[2], "-a")) {
+					return do_show_all();
 
 				} else if (!strcmp(argv[2], "-q")) {
 					if (argc >= 4) {
@@ -426,11 +431,22 @@ static int
 do_show(const char *search_string, bool only_changed)
 {
 	PARAM_PRINT("Symbols: x = used, + = saved, * = unsaved\n");
-	param_foreach(do_show_print, (char *)search_string, only_changed, false);
+	param_foreach(do_show_print, (char *)search_string, only_changed, true);
+	PARAM_PRINT("\n %u/%u parameters used.\n", param_count_used(), param_count());
+
+	return 0;
+}
+
+static int
+do_show_all()
+{
+	PARAM_PRINT("Symbols: x = used, + = saved, * = unsaved\n");
+	param_foreach(do_show_print, nullptr, false, false);
 	PARAM_PRINT("\n %u parameters total, %u used.\n", param_count(), param_count_used());
 
 	return 0;
 }
+
 static int
 do_show_quiet(const char *param_name)
 {

--- a/src/systemcmds/param/param.cpp
+++ b/src/systemcmds/param/param.cpp
@@ -136,6 +136,8 @@ $ reboot
 	PRINT_MODULE_USAGE_PARAM_FLAG('q', "quiet mode, print only param value (name needs to be exact)", true);
 	PRINT_MODULE_USAGE_ARG("<filter>", "Filter by param name (wildcard at end allowed, eg. sys_*)", true);
 
+	PRINT_MODULE_USAGE_COMMAND_DESCR("status", "Print status of parameter system");
+
 	PRINT_MODULE_USAGE_COMMAND_DESCR("set", "Set parameter to a value");
 	PRINT_MODULE_USAGE_ARG("<param_name> <value>", "Parameter name and value to set", false);
 	PRINT_MODULE_USAGE_ARG("fail", "If provided, let the command fail if param is not found", true);
@@ -243,6 +245,11 @@ param_main(int argc, char *argv[])
 			} else {
 				return do_show(nullptr, false);
 			}
+		}
+
+		if (!strcmp(argv[1], "status")) {
+			param_print_status();
+			return PX4_OK;
 		}
 
 		if (!strcmp(argv[1], "set")) {


### PR DESCRIPTION
These PR contains 2 changes to the param command.
1. param show change default to show active/used parameters and add -a to show all (the current default)
2. Add `param status` to print status of the param system (current file, memory usage, perf counters)

Example

```bash
nsh> param status
INFO  [parameters] summary: 638/1241 (used/total)
INFO  [parameters] file: /fs/mtd_params
INFO  [parameters] storage array: 22/32 elements (512 bytes total)
INFO  [parameters] auto save: on
INFO  [parameters] last auto save: 3.109 seconds ago
param_export: 4 events, 17386us elapsed, 4346.50us avg, min 3598us max 5006us 577.939us rms
param_find: 786 events, 7474us elapsed, 9.51us avg, min 3us max 413us 25.181us rms
param_get: 14164 events, 94875us elapsed, 6.70us avg, min 3us max 1994us 36.532us rms
param_set: 23 events, 347us elapsed, 15.09us avg, min 5us max 27us 6.536us rms
```