### PR TITLE
Hotfix SDK Revert "Skip controller" line

### DIFF
--- a/src/modules/mc_pos_control/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl.cpp
@@ -84,8 +84,8 @@ bool PositionControl::updateSetpoint(const vehicle_local_position_setpoint_s &se
 
 	// If full manual is required (thrust already generated), don't run position/velocity
 	// controller and just return thrust.
-	_skip_controller = PX4_ISFINITE(_thr_sp(0)) && PX4_ISFINITE(_thr_sp(1))
-			   && PX4_ISFINITE(_thr_sp(2));
+	_skip_controller = PX4_ISFINITE(setpoint.thrust[0]) && PX4_ISFINITE(setpoint.thrust[1])
+			   && PX4_ISFINITE(setpoint.thrust[2]);
 
 	return mapping_succeeded;
 }


### PR DESCRIPTION
Hot fixes #11197

Exists since https://github.com/PX4/Firmware/commit/5887a2393cefad7268d165e07352384be61e1404

I have no idea why. @Stifael and I will have to find out.
I tested with SDK master `make && build/default/integration_tests/integration_tests_runner --gtest_filter="SitlTest.ActionGoto"` works again.