### PR TITLE
MAVLink: Generate correct RC channel count

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1834,7 +1834,6 @@ MavlinkReceiver::handle_message_rc_channels_override(mavlink_message_t *msg)
 	// metadata
 	rc.timestamp = hrt_absolute_time();
 	rc.timestamp_last_signal = rc.timestamp;
-	rc.channel_count = 18;
 	rc.rssi = RC_INPUT_RSSI_MAX;
 	rc.rc_failsafe = false;
 	rc.rc_lost = false;
@@ -1861,6 +1860,17 @@ MavlinkReceiver::handle_message_rc_channels_override(mavlink_message_t *msg)
 	rc.values[15] = man.chan16_raw;
 	rc.values[16] = man.chan17_raw;
 	rc.values[17] = man.chan18_raw;
+
+	// check how many channels are valid
+	for (int i = 17; i >= 0; i--) {
+		const bool ignore_field = rc.values[i] == UINT16_MAX ||
+					  (rc.values[i] == 0 && (i > 7));
+
+		if (!ignore_field) {
+			rc.channel_count = i + 1;
+			break;
+		}
+	}
 
 	// publish uORB message
 	int instance; // provides the instance ID or the publication

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1863,11 +1863,10 @@ MavlinkReceiver::handle_message_rc_channels_override(mavlink_message_t *msg)
 
 	// check how many channels are valid
 	for (int i = 17; i >= 0; i--) {
-		// definition: ignore any channel with value UINT16_MAX and channel 8-18 with value 0
-		const bool ignore_channel = rc.values[i] == UINT16_MAX ||
-					    (rc.values[i] == 0 && (i > 7));
+		const bool ignore_max = rc.values[i] == UINT16_MAX; // ignore any channel with value UINT16_MAX
+		const bool ignore_zero = (i > 7) && (rc.values[i] == 0); // ignore channel 8-18 if value is 0
 
-		if (ignore_channel) {
+		if (ignore_max || ignore_zero) {
 			// set all ignored values to zero
 			rc.values[i] = 0;
 

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1863,10 +1863,16 @@ MavlinkReceiver::handle_message_rc_channels_override(mavlink_message_t *msg)
 
 	// check how many channels are valid
 	for (int i = 17; i >= 0; i--) {
-		const bool ignore_field = rc.values[i] == UINT16_MAX ||
-					  (rc.values[i] == 0 && (i > 7));
+		// definition: ignore any channel with value UINT16_MAX and channel 8-18 with value 0
+		const bool ignore_channel = rc.values[i] == UINT16_MAX ||
+					    (rc.values[i] == 0 && (i > 7));
 
-		if (!ignore_field) {
+		if (ignore_channel) {
+			// set all ignored values to zero
+			rc.values[i] = 0;
+
+		} else {
+			// first channel to not ignore -> set count considering zero-based index
 			rc.channel_count = i + 1;
 			break;
 		}


### PR DESCRIPTION
**Introduction**
According to the message definition https://mavlink.io/en/messages/common.html#RC_CHANNELS_OVERRIDE
channels 1-8 should be ignored when they contain the value `UINT16_MAX` and the MAVLink 2 extension channels 9-18 should be ignored if they are either `UINT16_MAX` or zero.

**Problem**
Currently, the channel count is always 18 which doesn't reflect this definition. Hence I'm implementing the definition.

**Solution**
We loop from the last to the first channel and if one of them doesn't satisfy the conditions to be ignored we set the channel count to that number. Hence if the message is full of `UINT16_MAX`'s the channel count stays 0, if the message is full of zeroes the count will be 8 because of the different definition in the extension and everything in between gets checked if it's ignored.

**Test data**
We use this implementation for half a year now on the H520.

**Additional Context**
https://github.com/mavlink/mavlink/pull/855
https://github.com/PX4/Firmware/pull/10535
