### PR TITLE
AutoMapper1/2: set thrust to NAN at idle

### DIFF
--- a/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
@@ -110,7 +110,7 @@ void FlightTaskAutoMapper::_generateIdleSetpoints()
 	// Send zero thrust setpoint
 	_position_setpoint = Vector3f(NAN, NAN, NAN); // Don't require any position/velocity setpoints
 	_velocity_setpoint = Vector3f(NAN, NAN, NAN);
-	_thrust_setpoint.zero();
+	_thrust_setpoint = Vector3f(NAN, NAN, NAN);
 }
 
 void FlightTaskAutoMapper::_generateLandSetpoints()

--- a/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.cpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.cpp
@@ -117,7 +117,7 @@ void FlightTaskAutoMapper2::_prepareIdleSetpoints()
 	// Send zero thrust setpoint
 	_position_setpoint = Vector3f(NAN, NAN, NAN); // Don't require any position/velocity setpoints
 	_velocity_setpoint = Vector3f(NAN, NAN, NAN);
-	_thrust_setpoint.zero();
+	_thrust_setpoint = Vector3f(NAN, NAN, NAN);
 }
 
 void FlightTaskAutoMapper2::_prepareLandSetpoints()


### PR DESCRIPTION
I don't understand all the things that you guys are talking about but I would like to have the regression fixed and this change seems to do it.

Fixes #11197.

If we can't fix this quickly, then I'd suggest to revert #11056 for now.