### PR TITLE
LPS22HB: Fix invalid driver reset (I2C bus)

### DIFF
--- a/src/drivers/barometer/lps22hb/LPS22HB.cpp
+++ b/src/drivers/barometer/lps22hb/LPS22HB.cpp
@@ -186,7 +186,7 @@ LPS22HB::reset()
 {
 	int ret = PX4_ERROR;
 
-	ret = write_reg(CTRL_REG2, BOOT | I2C_DIS | SWRESET);
+	ret = write_reg(CTRL_REG2, BOOT | SWRESET);
 
 	return ret;
 }


### PR DESCRIPTION
Driver sets I2C_DIS (I2C disable) flag during the reset. Reset operation will fail (on write_reg()) if the sensor is on the I2C bus. Driver works after a failed reset but doesn't create a BARO_BASE_DEVICE_PATH device file (/dev/baro*). It affects checks that use device files to determine a working barometer.

To fix the problem we should remove I2C_DIS flag from the driver's reset operation. Is there any reason why I2C_DIS flag has been added in the first place?
