### PR TITLE
Move test_tone and test_ppm out of test_hrt.cpp file into their own respective files.

### DIFF
--- a/src/systemcmds/tests/CMakeLists.txt
+++ b/src/systemcmds/tests/CMakeLists.txt
@@ -59,6 +59,7 @@ set(srcs
 	test_param.c
 	test_parameters.cpp
 	test_perf.c
+	test_ppm.cpp
 	test_ppm_loopback.c
 	test_rc.c
 	test_search_min.cpp
@@ -66,6 +67,7 @@ set(srcs
 	test_servo.c
 	test_sleep.c
 	test_smooth_z.cpp
+	test_tone.cpp
 	test_uart_baudchange.c
 	test_uart_console.c
 	test_uart_loopback.c

--- a/src/systemcmds/tests/test_ppm.cpp
+++ b/src/systemcmds/tests/test_ppm.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *  Copyright (C) 2012-2019 PX4 Development Team. All rights reserved.
+ *  Copyright (c) 2012-2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -12,7 +12,7 @@
  *    notice, this list of conditions and the following disclaimer in
  *    the documentation and/or other materials provided with the
  *    distribution.
- * 3. Neither the name PX4 nor the names of its contributors may be
+ * 3. Neither the name NuttX nor the names of its contributors may be
  *    used to endorse or promote products derived from this software
  *    without specific prior written permission.
  *
@@ -32,52 +32,47 @@
  ****************************************************************************/
 
 /**
- * @file test_hrt.c
- * Tests the high resolution timer.
+ * @file test_ppm.cpp
+ * Test for ppm channel values.
  */
 
-#include <drivers/drv_hrt.h>
-#include <px4_posix.h>
-#include <sys/time.h>
+#include <stdio.h>
 
 #include "tests_main.h"
 
-int test_hrt(int argc, char *argv[])
+
+extern uint16_t ppm_buffer[];
+extern unsigned ppm_decoded_channels;
+// extern uint16_t ppm_edge_history[];
+// extern uint16_t ppm_pulse_history[];
+
+
+int test_ppm(int argc, char *argv[])
 {
-	struct hrt_call call;
-	hrt_abstime prev, now;
-	int i;
-	struct timeval tv1, tv2;
+#ifdef HRT_PPM_CHANNEL
+	unsigned i;
 
-	printf("start-time (hrt, sec/usec), end-time (hrt, sec/usec), microseconds per 1/10 second\n");
+	printf("channels: %u\n", ppm_decoded_channels);
 
-	for (i = 0; i < 10; i++) {
-		prev = hrt_absolute_time();
-		gettimeofday(&tv1, nullptr);
-		px4_usleep(100000);
-		now = hrt_absolute_time();
-		gettimeofday(&tv2, nullptr);
-		printf("%lu (%lu/%lu), %lu (%lu/%lu), %lu\n",
-		       (unsigned long)prev, (unsigned long)tv1.tv_sec, (unsigned long)tv1.tv_usec,
-		       (unsigned long)now, (unsigned long)tv2.tv_sec, (unsigned long)tv2.tv_usec,
-		       (unsigned long)(hrt_absolute_time() - prev));
-		fflush(stdout);
+	for (i = 0; i < ppm_decoded_channels; i++) {
+		printf("  %u\n", ppm_buffer[i]);
 	}
 
-	px4_usleep(1000000);
+	// printf("edges\n");
 
-	printf("one-second ticks\n");
+	// for (i = 0; i < 32; i++) {
+	// 	printf("  %u\n", ppm_edge_history[i]);
+	// }
 
-	for (i = 0; i < 3; i++) {
-		hrt_call_after(&call, 1000000, nullptr, nullptr);
+	// printf("pulses\n");
 
-		while (!hrt_called(&call)) {
-			px4_usleep(1000);
-		}
+	// for (i = 0; i < 32; i++) {
+	// 	printf("  %u\n", ppm_pulse_history[i]);
+	// }
 
-		printf("tick\n");
-		fflush(stdout);
-	}
-
+	fflush(stdout);
+#else
+	printf("PPM not configured\n");
+#endif
 	return 0;
 }

--- a/src/systemcmds/tests/test_tone.cpp
+++ b/src/systemcmds/tests/test_tone.cpp
@@ -72,16 +72,18 @@ int test_tone(int argc, char *argv[])
 	}
 
 	if (argc == 2) {
+		tune_control.tune_id = atoi(argv[1]);
+
 		if (tune_control.tune_id <= 20) {
-			tune_control.tune_id = atoi(argv[1]);
-			PX4_INFO("Testing TuneID: %d", tune_control.tune_id);
+			PX4_INFO("TuneID: %d", tune_control.tune_id);
 		}
 	}
 
 	if (argc == 3) {
+		int volume = 40;
 		Tunes tunes{};
-		tunes.set_string(argv[2], 40);
-		PX4_INFO("Testing custom tune.");
+		tunes.set_string(argv[2], volume);
+		PX4_INFO("Custom tune.");
 	}
 
 	tune_control.strength = 40;

--- a/src/systemcmds/tests/tests_main.c
+++ b/src/systemcmds/tests/tests_main.c
@@ -51,103 +51,99 @@
 #define TESTS_EIGEN_DISABLE
 
 
+static int test_all(int argc, char *argv[]);
 static int test_help(int argc, char *argv[]);
+static int test_jig(int argc, char *argv[]);
 static int test_runner(unsigned option);
 
-static int test_all(int argc, char *argv[]);
-static int test_jig(int argc, char *argv[]);
 
 const struct {
-	const char 	*name;
-	int	(* fn)(int argc, char *argv[]);
-	unsigned	options;
-#define OPT_NOHELP	(1<<0)
-#define OPT_NOALLTEST	(1<<1)
-#define OPT_NOJIGTEST	(1<<2)
+	const char  *name;
+	int (* fn)(int argc, char *argv[]);
+	unsigned    options;
+#define OPT_NOHELP  (1<<0)
+#define OPT_NOALLTEST   (1<<1)
+#define OPT_NOJIGTEST   (1<<2)
 } tests[] = {
-	{"help",		test_help,	OPT_NOALLTEST | OPT_NOHELP | OPT_NOJIGTEST},
-	{"all",			test_all,	OPT_NOALLTEST | OPT_NOJIGTEST},
-	{"jig",			test_jig,	OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"all",             test_all,                   OPT_NOALLTEST | OPT_NOJIGTEST},
+	{"help",            test_help,                  OPT_NOALLTEST | OPT_NOHELP | OPT_NOJIGTEST},
+	{"jig",             test_jig,                   OPT_NOJIGTEST | OPT_NOALLTEST},
 #ifdef __PX4_NUTTX
-	{"adc",			test_adc,	OPT_NOJIGTEST},
-	{"file",		test_file,	OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"led",			test_led,	0},
-	{"sensors",		test_sensors,	0},
-	{"time",		test_time,	OPT_NOJIGTEST},
-	{"uart_baudchange",	test_uart_baudchange,	OPT_NOJIGTEST},
-	{"uart_break",		test_uart_break,	OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"uart_console",	test_uart_console,	OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"adc",             test_adc,                   OPT_NOJIGTEST},
+	{"file",            test_file,                  OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"led",             test_led,                   0},
+	{"sensors",         test_sensors,               0},
+	{"time",            test_time,                  OPT_NOJIGTEST},
+	{"uart_baudchange", test_uart_baudchange,       OPT_NOJIGTEST},
+	{"uart_break",      test_uart_break,            OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"uart_console",    test_uart_console,          OPT_NOJIGTEST | OPT_NOALLTEST},
 #else
-	{"rc",			rc_tests_main,	0},
+	{"mavlink",         mavlink_tests_main,         0},
+	{"rc",              rc_tests_main,              0},
 #endif /* __PX4_NUTTX */
 
 	/* external tests */
-	{"commander",		commander_tests_main,	0},
-	{"controllib",		controllib_test_main,	0},
-#ifndef __PX4_NUTTX
-	{"mavlink",		mavlink_tests_main,	0},
-#endif
-	{"sf0x",		sf0x_tests_main,	0},
-	{"uorb",		uorb_tests_main,	0},
-	{"hysteresis",		test_hysteresis,	0},
+	{"commander",           commander_tests_main,   0},
+	{"controllib",          controllib_test_main,   0},
+	{"sf0x",                sf0x_tests_main,        0},
+	{"uorb",                uorb_tests_main,        0},
 
-	{"mixer",		test_mixer,	OPT_NOJIGTEST},
-	{"autodeclination",	test_autodeclination,	0},
-	{"bezier",		test_bezierQuad, 0},
-	{"bson",		test_bson,	0},
-	{"conv",		test_conv, 0},
-	{"dataman",		test_dataman, OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"file2",		test_file2,	OPT_NOJIGTEST},
-	{"float",		test_float,	0},
-	{"hott_telemetry",	test_hott_telemetry,	OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"hrt",			test_hrt,	OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"int",			test_int,	0},
-	{"jig_voltages",	test_jig_voltages,	OPT_NOALLTEST},
-	{"mathlib",		test_mathlib,	0},
-	{"matrix",		test_matrix,	0},
-	{"microbench_hrt",		test_microbench_hrt,	0},
-	{"microbench_math",		test_microbench_math,	0},
-	{"microbench_matrix",		test_microbench_matrix,	0},
-	{"microbench_uorb",		test_microbench_uorb,	0},
-	{"mount",		test_mount,	OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"param",		test_param,	0},
-	{"parameters",	test_parameters,	0},
-	{"perf",		test_perf,	OPT_NOJIGTEST},
-	{"ppm",			test_ppm,	OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"ppm_loopback",	test_ppm_loopback,	OPT_NOALLTEST},
-	{"rc",			test_rc,	OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"search_min",	test_search_min, 0},
-	{"servo",		test_servo,	OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"sleep",		test_sleep,	OPT_NOJIGTEST},
-	{"tone",		test_tone,	0},
-	{"uart_loopback",	test_uart_loopback,	OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"uart_send",		test_uart_send,	OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"versioning",		test_versioning,	0},
-	{"ctlmath",		test_controlmath, 0},
-	{"smoothz", 	test_smooth_z, 0},
-	{NULL,			NULL, 		0}
+	{"autodeclination",     test_autodeclination,   0},
+	{"bezier",              test_bezierQuad,        0},
+	{"bson",                test_bson,              0},
+	{"conv",                test_conv,              0},
+	{"ctlmath",             test_controlmath,       0},
+	{"dataman",             test_dataman,           OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"file2",               test_file2,             OPT_NOJIGTEST},
+	{"float",               test_float,             0},
+	{"hott_telemetry",      test_hott_telemetry,    OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"hrt",                 test_hrt,               OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"hysteresis",          test_hysteresis,        0},
+	{"int",                 test_int,               0},
+	{"jig_voltages",        test_jig_voltages,      OPT_NOALLTEST},
+	{"mathlib",             test_mathlib,           0},
+	{"matrix",              test_matrix,            0},
+	{"microbench_hrt",      test_microbench_hrt,    0},
+	{"microbench_math",     test_microbench_math,   0},
+	{"microbench_matrix",   test_microbench_matrix, 0},
+	{"microbench_uorb",     test_microbench_uorb,   0},
+	{"mixer",               test_mixer,             OPT_NOJIGTEST},
+	{"mount",               test_mount,             OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"param",               test_param,             0},
+	{"parameters",          test_parameters,        0},
+	{"perf",                test_perf,              OPT_NOJIGTEST},
+	{"ppm",                 test_ppm,               OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"ppm_loopback",        test_ppm_loopback,      OPT_NOALLTEST},
+	{"rc",                  test_rc,                OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"search_min",          test_search_min,        0},
+	{"servo",               test_servo,             OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"sleep",               test_sleep,             OPT_NOJIGTEST},
+	{"smooth_z",            test_smooth_z,          0},
+	{"tone",                test_tone,              0},
+	{"uart_loopback",       test_uart_loopback,     OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"uart_send",           test_uart_send,         OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"versioning",          test_versioning,        0},
+	{NULL, NULL, 0}
 };
 
 #define NTESTS (sizeof(tests) / sizeof(tests[0]))
 
 static int
+test_all(int argc, char *argv[])
+{
+	return test_runner(OPT_NOALLTEST);
+}
+
+static int
 test_help(int argc, char *argv[])
 {
-	unsigned	i;
-
 	printf("Available tests:\n");
 
-	for (i = 0; tests[i].name; i++) {
+	for (size_t i = 0; tests[i].name; i++) {
 		printf("  %s\n", tests[i].name);
 	}
 
 	return 0;
-}
-
-static int
-test_all(int argc, char *argv[])
-{
-	return test_runner(OPT_NOALLTEST);
 }
 
 static int
@@ -159,11 +155,11 @@ test_jig(int argc, char *argv[])
 static int
 test_runner(unsigned option)
 {
-	unsigned	i;
-	char		*args[2] = {"all", NULL};
+	size_t i = 0;
+	char *args[2] = {"all", NULL};
 	unsigned int failcount = 0;
 	unsigned int testcount = 0;
-	unsigned		passed[NTESTS];
+	unsigned passed[NTESTS] = {};
 
 	printf("\nRunning all tests...\n\n");
 
@@ -262,7 +258,7 @@ int tests_main(int argc, char *argv[])
 		return 1;
 	}
 
-	for (unsigned i = 0; tests[i].name; i++) {
+	for (size_t i = 0; tests[i].name; i++) {
 		if (!strcmp(tests[i].name, argv[1])) {
 			if (tests[i].fn(argc - 1, argv + 1) == 0) {
 				printf("%s PASSED\n", tests[i].name);

--- a/src/systemcmds/tests/tests_main.c
+++ b/src/systemcmds/tests/tests_main.c
@@ -51,99 +51,103 @@
 #define TESTS_EIGEN_DISABLE
 
 
-static int test_all(int argc, char *argv[]);
 static int test_help(int argc, char *argv[]);
-static int test_jig(int argc, char *argv[]);
 static int test_runner(unsigned option);
 
+static int test_all(int argc, char *argv[]);
+static int test_jig(int argc, char *argv[]);
 
 const struct {
-	const char  *name;
-	int (* fn)(int argc, char *argv[]);
-	unsigned    options;
-#define OPT_NOHELP  (1<<0)
-#define OPT_NOALLTEST   (1<<1)
-#define OPT_NOJIGTEST   (1<<2)
+	const char 	*name;
+	int	(* fn)(int argc, char *argv[]);
+	unsigned	options;
+#define OPT_NOHELP	(1<<0)
+#define OPT_NOALLTEST	(1<<1)
+#define OPT_NOJIGTEST	(1<<2)
 } tests[] = {
-	{"all",             test_all,                   OPT_NOALLTEST | OPT_NOJIGTEST},
-	{"help",            test_help,                  OPT_NOALLTEST | OPT_NOHELP | OPT_NOJIGTEST},
-	{"jig",             test_jig,                   OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"help",		test_help,	OPT_NOALLTEST | OPT_NOHELP | OPT_NOJIGTEST},
+	{"all",			test_all,	OPT_NOALLTEST | OPT_NOJIGTEST},
+	{"jig",			test_jig,	OPT_NOJIGTEST | OPT_NOALLTEST},
 #ifdef __PX4_NUTTX
-	{"adc",             test_adc,                   OPT_NOJIGTEST},
-	{"file",            test_file,                  OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"led",             test_led,                   0},
-	{"sensors",         test_sensors,               0},
-	{"time",            test_time,                  OPT_NOJIGTEST},
-	{"uart_baudchange", test_uart_baudchange,       OPT_NOJIGTEST},
-	{"uart_break",      test_uart_break,            OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"uart_console",    test_uart_console,          OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"adc",			test_adc,	OPT_NOJIGTEST},
+	{"file",		test_file,	OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"led",			test_led,	0},
+	{"sensors",		test_sensors,	0},
+	{"time",		test_time,	OPT_NOJIGTEST},
+	{"uart_baudchange",	test_uart_baudchange,	OPT_NOJIGTEST},
+	{"uart_break",		test_uart_break,	OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"uart_console",	test_uart_console,	OPT_NOJIGTEST | OPT_NOALLTEST},
 #else
-	{"mavlink",         mavlink_tests_main,         0},
-	{"rc",              rc_tests_main,              0},
+	{"rc",			rc_tests_main,	0},
 #endif /* __PX4_NUTTX */
 
 	/* external tests */
-	{"commander",           commander_tests_main,   0},
-	{"controllib",          controllib_test_main,   0},
-	{"sf0x",                sf0x_tests_main,        0},
-	{"uorb",                uorb_tests_main,        0},
+	{"commander",		commander_tests_main,	0},
+	{"controllib",		controllib_test_main,	0},
+#ifndef __PX4_NUTTX
+	{"mavlink",		mavlink_tests_main,	0},
+#endif
+	{"sf0x",		sf0x_tests_main,	0},
+	{"uorb",		uorb_tests_main,	0},
+	{"hysteresis",		test_hysteresis,	0},
 
-	{"autodeclination",     test_autodeclination,   0},
-	{"bezier",              test_bezierQuad,        0},
-	{"bson",                test_bson,              0},
-	{"conv",                test_conv,              0},
-	{"ctlmath",             test_controlmath,       0},
-	{"dataman",             test_dataman,           OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"file2",               test_file2,             OPT_NOJIGTEST},
-	{"float",               test_float,             0},
-	{"hott_telemetry",      test_hott_telemetry,    OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"hrt",                 test_hrt,               OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"hysteresis",          test_hysteresis,        0},
-	{"int",                 test_int,               0},
-	{"jig_voltages",        test_jig_voltages,      OPT_NOALLTEST},
-	{"mathlib",             test_mathlib,           0},
-	{"matrix",              test_matrix,            0},
-	{"microbench_hrt",      test_microbench_hrt,    0},
-	{"microbench_math",     test_microbench_math,   0},
-	{"microbench_matrix",   test_microbench_matrix, 0},
-	{"microbench_uorb",     test_microbench_uorb,   0},
-	{"mixer",               test_mixer,             OPT_NOJIGTEST},
-	{"mount",               test_mount,             OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"param",               test_param,             0},
-	{"parameters",          test_parameters,        0},
-	{"perf",                test_perf,              OPT_NOJIGTEST},
-	{"ppm",                 test_ppm,               OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"ppm_loopback",        test_ppm_loopback,      OPT_NOALLTEST},
-	{"rc",                  test_rc,                OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"search_min",          test_search_min,        0},
-	{"servo",               test_servo,             OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"sleep",               test_sleep,             OPT_NOJIGTEST},
-	{"smooth_z",            test_smooth_z,          0},
-	{"tone",                test_tone,              0},
-	{"uart_loopback",       test_uart_loopback,     OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"uart_send",           test_uart_send,         OPT_NOJIGTEST | OPT_NOALLTEST},
-	{"versioning",          test_versioning,        0},
-	{NULL, NULL, 0}
+	{"mixer",		test_mixer,	OPT_NOJIGTEST},
+	{"autodeclination",	test_autodeclination,	0},
+	{"bezier",		test_bezierQuad, 0},
+	{"bson",		test_bson,	0},
+	{"conv",		test_conv, 0},
+	{"dataman",		test_dataman, OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"file2",		test_file2,	OPT_NOJIGTEST},
+	{"float",		test_float,	0},
+	{"hott_telemetry",	test_hott_telemetry,	OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"hrt",			test_hrt,	OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"int",			test_int,	0},
+	{"jig_voltages",	test_jig_voltages,	OPT_NOALLTEST},
+	{"mathlib",		test_mathlib,	0},
+	{"matrix",		test_matrix,	0},
+	{"microbench_hrt",		test_microbench_hrt,	0},
+	{"microbench_math",		test_microbench_math,	0},
+	{"microbench_matrix",		test_microbench_matrix,	0},
+	{"microbench_uorb",		test_microbench_uorb,	0},
+	{"mount",		test_mount,	OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"param",		test_param,	0},
+	{"parameters",	test_parameters,	0},
+	{"perf",		test_perf,	OPT_NOJIGTEST},
+	{"ppm",			test_ppm,	OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"ppm_loopback",	test_ppm_loopback,	OPT_NOALLTEST},
+	{"rc",			test_rc,	OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"search_min",	test_search_min, 0},
+	{"servo",		test_servo,	OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"sleep",		test_sleep,	OPT_NOJIGTEST},
+	{"tone",		test_tone,	0},
+	{"uart_loopback",	test_uart_loopback,	OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"uart_send",		test_uart_send,	OPT_NOJIGTEST | OPT_NOALLTEST},
+	{"versioning",		test_versioning,	0},
+	{"ctlmath",		test_controlmath, 0},
+	{"smoothz", 	test_smooth_z, 0},
+	{NULL,			NULL, 		0}
 };
 
 #define NTESTS (sizeof(tests) / sizeof(tests[0]))
 
 static int
-test_all(int argc, char *argv[])
-{
-	return test_runner(OPT_NOALLTEST);
-}
-
-static int
 test_help(int argc, char *argv[])
 {
+	unsigned	i;
+
 	printf("Available tests:\n");
 
-	for (size_t i = 0; tests[i].name; i++) {
+	for (i = 0; tests[i].name; i++) {
 		printf("  %s\n", tests[i].name);
 	}
 
 	return 0;
+}
+
+static int
+test_all(int argc, char *argv[])
+{
+	return test_runner(OPT_NOALLTEST);
 }
 
 static int
@@ -155,24 +159,22 @@ test_jig(int argc, char *argv[])
 static int
 test_runner(unsigned option)
 {
-	size_t i = 0;
+	size_t i;
 	char *args[2] = {"all", NULL};
 	unsigned int failcount = 0;
 	unsigned int testcount = 0;
-	unsigned passed[NTESTS] = {};
+	unsigned int passed[NTESTS];
 
 	printf("\nRunning all tests...\n\n");
 
 	for (i = 0; tests[i].name; i++) {
-		/* Only run tests that are not excluded */
+		// Only run tests that are not excluded.
 		if (!(tests[i].options & option)) {
 			for (int j = 0; j < 80; j++) {
 				printf("-");
 			}
 
-			printf("\n");
-
-			printf("  [%s] \t\tSTARTING TEST\n", tests[i].name);
+			printf("\n  [%s] \t\tSTARTING TEST\n", tests[i].name);
 			fflush(stdout);
 
 			/* Execute test */
@@ -192,22 +194,19 @@ test_runner(unsigned option)
 				printf("-");
 			}
 
-			printf("\n\n");
-
 			testcount++;
+			printf("\n\n");
 		}
 	}
 
-	/* Print summary */
+	// Print summary.
 	printf("\n");
 
-	for (unsigned j = 0; j < 80; j++) {
+	for (size_t j = 0; j < 80; j++) {
 		printf("#");
 	}
 
-	printf("\n\n");
-
-	printf("     T E S T    S U M M A R Y\n\n");
+	printf("\n\n     T E S T    S U M M A R Y\n\n");
 
 	if (failcount == 0) {
 		printf("  ______     __         __            ______     __  __    \n");
@@ -216,7 +215,7 @@ test_runner(unsigned option)
 		printf("  \\ \\_\\ \\_\\  \\ \\_____\\  \\ \\_____\\     \\ \\_____\\  \\ \\_\\ \\_\\ \n");
 		printf("   \\/_/\\/_/   \\/_____/   \\/_____/      \\/_____/   \\/_/\\/_/ \n");
 		printf("\n");
-		printf(" All tests passed (%d of %d)\n", testcount, testcount);
+		printf(" All tests passed (%d of %d)\n\n", testcount, testcount);
 
 	} else {
 		printf("  ______   ______     __     __ \n");
@@ -225,24 +224,21 @@ test_runner(unsigned option)
 		printf("  \\ \\_\\    \\ \\_\\ \\_\\  \\ \\_\\  \\ \\_____\\ \n");
 		printf("   \\/_/     \\/_/\\/_/   \\/_/   \\/_____/ \n");
 		printf("\n");
-		printf(" Some tests failed (%d of %d)\n", failcount, testcount);
+		printf(" Some tests failed (%d of %d)\n\n", failcount, testcount);
 	}
 
-	printf("\n");
-
-	/* Print failed tests */
+	// Print failed tests.
 	if (failcount > 0) {
 		printf(" Failed tests:\n\n");
 	}
 
-	for (unsigned k = 0; k < i; k++) {
+	for (size_t k = 0; k < i; k++) {
 		if (!passed[k] && !(tests[k].options & option)) {
 			printf(" [%s] to obtain details, please re-run with\n\t nsh> tests %s\n\n", tests[k].name, tests[k].name);
 		}
 	}
 
 	fflush(stdout);
-
 	return (failcount > 0);
 }
 
@@ -258,13 +254,33 @@ int tests_main(int argc, char *argv[])
 		return 1;
 	}
 
+	int tone_test_index = -1;
+	char *tone_test = {"tone"};
+	char *tone_fail[2] = {NULL, "2"};
+	char *tone_pass[2] = {NULL, "14"};
+
+	// Identify the tone test index for later use.
+	for (size_t i = 0; tests[i].name; i++) {
+		if (*tone_test == *tests[i].name) {
+			tone_test_index = i;
+		}
+	}
+
 	for (size_t i = 0; tests[i].name; i++) {
 		if (!strcmp(tests[i].name, argv[1])) {
 			if (tests[i].fn(argc - 1, argv + 1) == 0) {
+				if (tone_test_index != -1) {
+					tests[tone_test_index].fn(2, tone_pass); // Play a notification.
+				}
+
 				printf("%s PASSED\n", tests[i].name);
 				return 0;
 
 			} else {
+				if (tone_test_index != -1) {
+					tests[tone_test_index].fn(2, tone_fail); // Play an error notification.
+				}
+
 				printf("%s FAILED\n", tests[i].name);
 				return -1;
 			}

--- a/src/systemcmds/tests/tests_main.h
+++ b/src/systemcmds/tests/tests_main.h
@@ -45,9 +45,9 @@ __BEGIN_DECLS
 
 extern int test_adc(int argc, char *argv[]);
 extern int test_autodeclination(int argc, char *argv[]);
-extern int test_hysteresis(int argc, char *argv[]);
 extern int test_bezierQuad(int argc, char *argv[]);
 extern int test_bson(int argc, char *argv[]);
+extern int test_controlmath(int argc, char *argv[]);
 extern int test_conv(int argc, char *argv[]);
 extern int test_dataman(int argc, char *argv[]);
 extern int test_file(int argc, char *argv[]);
@@ -55,6 +55,7 @@ extern int test_file2(int argc, char *argv[]);
 extern int test_float(int argc, char *argv[]);
 extern int test_hott_telemetry(int argc, char *argv[]);
 extern int test_hrt(int argc, char *argv[]);
+extern int test_hysteresis(int argc, char *argv[]);
 extern int test_int(int argc, char *argv[]);
 extern int test_jig_voltages(int argc, char *argv[]);
 extern int test_led(int argc, char *argv[]);
@@ -67,6 +68,7 @@ extern int test_microbench_uorb(int argc, char *argv[]);
 extern int test_mixer(int argc, char *argv[]);
 extern int test_mount(int argc, char *argv[]);
 extern int test_param(int argc, char *argv[]);
+extern int test_parameters(int argc, char *argv[]);
 extern int test_perf(int argc, char *argv[]);
 extern int test_ppm(int argc, char *argv[]);
 extern int test_ppm_loopback(int argc, char *argv[]);
@@ -75,6 +77,7 @@ extern int test_search_min(int argc, char *argv[]);
 extern int test_sensors(int argc, char *argv[]);
 extern int test_servo(int argc, char *argv[]);
 extern int test_sleep(int argc, char *argv[]);
+extern int test_smooth_z(int argc, char *argv[]);
 extern int test_time(int argc, char *argv[]);
 extern int test_tone(int argc, char *argv[]);
 extern int test_uart_baudchange(int argc, char *argv[]);
@@ -82,10 +85,7 @@ extern int test_uart_break(int argc, char *argv[]);
 extern int test_uart_console(int argc, char *argv[]);
 extern int test_uart_loopback(int argc, char *argv[]);
 extern int test_uart_send(int argc, char *argv[]);
-extern int test_parameters(int argc, char *argv[]);
 extern int test_versioning(int argc, char *argv[]);
-extern int test_smooth_z(int argc, char *argv[]);
-extern int test_controlmath(int argc, char *argv[]);
 
 /* external */
 extern int commander_tests_main(int argc, char *argv[]);


### PR DESCRIPTION
Hi there,

This PR places test_tone and test_ppm into their own files to follow the convention in all of the other `src/systemcmds/tests/*` files.

Let me know if you have any questions on this PR!

-Mark