### PR TITLE
GPS increase task stack 1530 -> 1600 bytes

### DIFF
--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -998,7 +998,7 @@ int GPS::task_spawn(int argc, char *argv[], Instance instance)
 	}
 
 	int task_id = px4_task_spawn_cmd("gps", SCHED_DEFAULT,
-				   SCHED_PRIORITY_SLOW_DRIVER, 1530,
+				   SCHED_PRIORITY_SLOW_DRIVER, 1600,
 				   entry_point, (char *const *)argv);
 
 	if (task_id < 0) {


### PR DESCRIPTION
From a recent pixhawk 4 mini flight test.

https://review.px4.io/plot_app?log=90410fa5-edc1-4b3e-9599-984008a8df2f

![image](https://user-images.githubusercontent.com/84712/51400476-7ce31c80-1b16-11e9-876b-ee80cd3fd948.png)
