### PR TITLE
MK BL CTRL: Fix startup routine to be compliant with signature.

### DIFF
--- a/src/drivers/mkblctrl/mkblctrl.cpp
+++ b/src/drivers/mkblctrl/mkblctrl.cpp
@@ -177,8 +177,8 @@ private:
 	actuator_controls_s 	_controls;
 	MotorData_t 			Motor[MAX_MOTORS];
 
-	static void				task_main_trampoline(int argc, char *argv[]);
-	void					task_main();
+	static int				task_main_trampoline(int argc, char *argv[]);
+	int					task_main();
 
 	static int				control_callback(uintptr_t handle,
 			uint8_t control_group,
@@ -319,10 +319,10 @@ MK::init(unsigned motors)
 	return OK;
 }
 
-void
+int
 MK::task_main_trampoline(int argc, char *argv[])
 {
-	g_mk->task_main();
+	return g_mk->task_main();
 }
 
 void
@@ -458,7 +458,7 @@ MK::play_beep(int count)
 
 }
 
-void
+int
 MK::task_main()
 {
 	int32_t param_mkblctrl_test = 0;
@@ -664,7 +664,7 @@ MK::task_main()
 
 	/* tell the dtor that we are exiting */
 	_task = -1;
-	_exit(0);
+	return 0;
 }
 
 


### PR DESCRIPTION
Minimal changes required to fix GCC 8 compile failure.