### PR TITLE
[WIP] Add script to set the correct ulimit on Mac OS

### DIFF
--- a/Tools/mac_set_ulimit.sh
+++ b/Tools/mac_set_ulimit.sh
@@ -1,0 +1,3 @@
+#/usr/bin/sh
+
+ulimit -S -n 2048

--- a/Tools/mac_set_ulimit.sh
+++ b/Tools/mac_set_ulimit.sh
@@ -1,3 +1,3 @@
-#/usr/bin/sh
+#!/usr/bin/env bash
 
 ulimit -S -n 2048


### PR DESCRIPTION
This does not have automation yet.

Using `call` or `shell` or a direct call didn't work in the Makefile - likely because it is a different process group. Checking the user's bash config and appending if missing would be one way to do it (along with a bash restart).