### PR TITLE
HRT: Create new separate call for atomic HRT elapsed time calculation

### DIFF
--- a/platforms/posix/src/px4_layer/drv_hrt.cpp
+++ b/platforms/posix/src/px4_layer/drv_hrt.cpp
@@ -212,6 +212,20 @@ hrt_abstime hrt_elapsed_time(const volatile hrt_abstime *then)
 }
 
 /*
+ * Compute the delta between a timestamp taken in the past
+ * and now.
+ *
+ * This function is safe to use even if the timestamp is updated
+ * by an interrupt during execution.
+ */
+hrt_abstime hrt_elapsed_time_atomic(const volatile hrt_abstime *then)
+{
+	// This is not atomic as the value on the application layer of POSIX is limited.
+	hrt_abstime delta = hrt_absolute_time() - *then;
+	return delta;
+}
+
+/*
  * Store the absolute time in an interrupt-safe fashion.
  *
  * This function ensures that the timestamp cannot be seen half-written by an interrupt handler.

--- a/platforms/posix/src/px4_layer/drv_hrt.cpp
+++ b/platforms/posix/src/px4_layer/drv_hrt.cpp
@@ -205,7 +205,7 @@ hrt_abstime ts_to_abstime(const struct timespec *ts)
  * This function is safe to use even if the timestamp is updated
  * by an interrupt during execution.
  */
-hrt_abstime hrt_elapsed_time(const volatile hrt_abstime *then)
+hrt_abstime hrt_elapsed_time(const hrt_abstime *then)
 {
 	hrt_abstime delta = hrt_absolute_time() - *then;
 	return delta;

--- a/src/drivers/drv_hrt.h
+++ b/src/drivers/drv_hrt.h
@@ -98,7 +98,7 @@ __EXPORT extern void	abstime_to_ts(struct timespec *ts, hrt_abstime abstime);
  *
  * This function is not interrupt save.
  */
-__EXPORT extern hrt_abstime hrt_elapsed_time(const volatile hrt_abstime *then);
+__EXPORT extern hrt_abstime hrt_elapsed_time(const hrt_abstime *then);
 
 /**
  * Compute the delta between a timestamp taken in the past

--- a/src/drivers/drv_hrt.h
+++ b/src/drivers/drv_hrt.h
@@ -96,10 +96,18 @@ __EXPORT extern void	abstime_to_ts(struct timespec *ts, hrt_abstime abstime);
  * Compute the delta between a timestamp taken in the past
  * and now.
  *
+ * This function is not interrupt save.
+ */
+__EXPORT extern hrt_abstime hrt_elapsed_time(const volatile hrt_abstime *then);
+
+/**
+ * Compute the delta between a timestamp taken in the past
+ * and now.
+ *
  * This function is safe to use even if the timestamp is updated
  * by an interrupt during execution.
  */
-__EXPORT extern hrt_abstime hrt_elapsed_time(const volatile hrt_abstime *then);
+__EXPORT extern hrt_abstime hrt_elapsed_time_atomic(const volatile hrt_abstime *then);
 
 /**
  * Store the absolute time in an interrupt-safe fashion.

--- a/src/drivers/kinetis/drv_hrt.c
+++ b/src/drivers/kinetis/drv_hrt.c
@@ -598,7 +598,7 @@ abstime_to_ts(struct timespec *ts, hrt_abstime abstime)
  * Compare a time value with the current time.
  */
 hrt_abstime
-hrt_elapsed_time(const volatile hrt_abstime *then)
+hrt_elapsed_time(const hrt_abstime *then)
 {
 	hrt_abstime delta = hrt_absolute_time() - *then;
 

--- a/src/drivers/kinetis/drv_hrt.c
+++ b/src/drivers/kinetis/drv_hrt.c
@@ -600,6 +600,17 @@ abstime_to_ts(struct timespec *ts, hrt_abstime abstime)
 hrt_abstime
 hrt_elapsed_time(const volatile hrt_abstime *then)
 {
+	hrt_abstime delta = hrt_absolute_time() - *then;
+
+	return delta;
+}
+
+/**
+ * Compare a time value with the current time as atomic operation.
+ */
+hrt_abstime
+hrt_elapsed_time_atomic(const volatile hrt_abstime *then)
+{
 	irqstate_t flags = px4_enter_critical_section();
 
 	hrt_abstime delta = hrt_absolute_time() - *then;

--- a/src/drivers/samv7/drv_hrt.c
+++ b/src/drivers/samv7/drv_hrt.c
@@ -681,6 +681,17 @@ abstime_to_ts(struct timespec *ts, hrt_abstime abstime)
 hrt_abstime
 hrt_elapsed_time(const volatile hrt_abstime *then)
 {
+	hrt_abstime delta = hrt_absolute_time() - *then;
+
+	return delta;
+}
+
+/**
+ * Compare a time value with the current time as atomic operation.
+ */
+hrt_abstime
+hrt_elapsed_time_atomic(const volatile hrt_abstime *then)
+{
 	irqstate_t flags = enter_critical_section();
 
 	hrt_abstime delta = hrt_absolute_time() - *then;

--- a/src/drivers/samv7/drv_hrt.c
+++ b/src/drivers/samv7/drv_hrt.c
@@ -679,7 +679,7 @@ abstime_to_ts(struct timespec *ts, hrt_abstime abstime)
  * Compare a time value with the current time.
  */
 hrt_abstime
-hrt_elapsed_time(const volatile hrt_abstime *then)
+hrt_elapsed_time(const hrt_abstime *then)
 {
 	hrt_abstime delta = hrt_absolute_time() - *then;
 

--- a/src/drivers/stm32/drv_hrt.c
+++ b/src/drivers/stm32/drv_hrt.c
@@ -719,7 +719,7 @@ abstime_to_ts(struct timespec *ts, hrt_abstime abstime)
  * Compare a time value with the current time.
  */
 hrt_abstime
-hrt_elapsed_time(const volatile hrt_abstime *then)
+hrt_elapsed_time(const hrt_abstime *then)
 {
 	hrt_abstime delta = hrt_absolute_time() - *then;
 

--- a/src/drivers/stm32/drv_hrt.c
+++ b/src/drivers/stm32/drv_hrt.c
@@ -721,6 +721,17 @@ abstime_to_ts(struct timespec *ts, hrt_abstime abstime)
 hrt_abstime
 hrt_elapsed_time(const volatile hrt_abstime *then)
 {
+	hrt_abstime delta = hrt_absolute_time() - *then;
+
+	return delta;
+}
+
+/**
+ * Compare a time value with the current time as atomic operation
+ */
+hrt_abstime
+hrt_elapsed_time_atomic(const volatile hrt_abstime *then)
+{
 	irqstate_t flags = px4_enter_critical_section();
 
 	hrt_abstime delta = hrt_absolute_time() - *then;

--- a/src/modules/px4iofirmware/controls.c
+++ b/src/modules/px4iofirmware/controls.c
@@ -460,7 +460,7 @@ controls_tick()
 	 * If we haven't seen any new control data in 200ms, assume we
 	 * have lost input.
 	 */
-	if (!rc_input_lost && hrt_elapsed_time(&system_state.rc_channels_timestamp_received) > 200000) {
+	if (!rc_input_lost && hrt_elapsed_time_atomic(&system_state.rc_channels_timestamp_received) > 200000) {
 		rc_input_lost = true;
 
 		/* clear the input-kind flags here */

--- a/src/modules/px4iofirmware/mixer.cpp
+++ b/src/modules/px4iofirmware/mixer.cpp
@@ -119,7 +119,7 @@ mixer_tick(void)
 
 	/* check that we are receiving fresh data from the FMU */
 	if ((system_state.fmu_data_received_time == 0) ||
-	    hrt_elapsed_time(&system_state.fmu_data_received_time) > FMU_INPUT_DROP_LIMIT_US) {
+	    hrt_elapsed_time_atomic(&system_state.fmu_data_received_time) > FMU_INPUT_DROP_LIMIT_US) {
 
 		/* too long without FMU input, time to go to failsafe */
 		if (r_status_flags & PX4IO_P_STATUS_FLAGS_FMU_OK) {

--- a/src/modules/uORB/uORB_tests/uORBTest_UnitTest.cpp
+++ b/src/modules/uORB/uORB_tests/uORBTest_UnitTest.cpp
@@ -121,7 +121,7 @@ int uORBTest::UnitTest::pubsublatency_main()
 		num_missed += t.val - current_value - 1;
 		current_value = t.val;
 
-		unsigned elt = (unsigned)hrt_elapsed_time(&t.time);
+		unsigned elt = (unsigned)hrt_elapsed_time_atomic(&t.time);
 		latency_integral += elt;
 		timings[i] = elt;
 

--- a/src/systemcmds/sd_bench/sd_bench.c
+++ b/src/systemcmds/sd_bench/sd_bench.c
@@ -157,7 +157,7 @@ unsigned int time_fsync(int fd)
 {
 	hrt_abstime fsync_start = hrt_absolute_time();
 	fsync(fd);
-	return hrt_elapsed_time_atomic(&fsync_start) / 1000;
+	return hrt_elapsed_time(&fsync_start) / 1000;
 }
 
 void write_test(int fd, uint8_t *block, int block_size)

--- a/src/systemcmds/sd_bench/sd_bench.c
+++ b/src/systemcmds/sd_bench/sd_bench.c
@@ -157,7 +157,7 @@ unsigned int time_fsync(int fd)
 {
 	hrt_abstime fsync_start = hrt_absolute_time();
 	fsync(fd);
-	return hrt_elapsed_time(&fsync_start) / 1000;
+	return hrt_elapsed_time_atomic(&fsync_start) / 1000;
 }
 
 void write_test(int fd, uint8_t *block, int block_size)

--- a/src/systemcmds/tests/hrt_test/hrt_test.cpp
+++ b/src/systemcmds/tests/hrt_test/hrt_test.cpp
@@ -71,13 +71,13 @@ int HRTTest::main()
 
 	hrt_abstime t = hrt_absolute_time();
 	px4_usleep(1000000);
-	hrt_abstime elt = hrt_elapsed_time(&t);
+	hrt_abstime elt = hrt_elapsed_time_atomic(&t);
 	PX4_INFO("Elapsed time %llu in 1 sec (usleep)\n", (unsigned long long)elt);
 	PX4_INFO("Start time %llu\n", (unsigned long long)t);
 
 	t = hrt_absolute_time();
 	px4_sleep(1);
-	elt = hrt_elapsed_time(&t);
+	elt = hrt_elapsed_time_atomic(&t);
 	PX4_INFO("Elapsed time %llu in 1 sec (sleep)\n", (unsigned long long)elt);
 	PX4_INFO("Start time %llu\n", (unsigned long long)t);
 

--- a/src/systemcmds/tests/test_microbench_hrt.cpp
+++ b/src/systemcmds/tests/test_microbench_hrt.cpp
@@ -137,7 +137,7 @@ ut_declare_test_c(test_microbench_hrt, MicroBenchHRT)
 bool MicroBenchHRT::time_px4_hrt()
 {
 	PERF("hrt_absolute_time()", u_64_out = hrt_absolute_time(), 1000);
-	PERF("hrt_elapsed_time()", u_64_out = hrt_elapsed_time(&u_64), 1000);
+	PERF("hrt_elapsed_time()", u_64_out = hrt_elapsed_time_atomic(&u_64), 1000);
 
 	return true;
 }


### PR DESCRIPTION
This call rarely needs to be truly atomic and the involved CPU overhead in making it atomic was unnecessary and introduces a lot of IRQ jitter with no value-add. The call has been moved to be non-atomic and the codebase will be inspected and changed in follow-up commits for the few instances where it is truly needed.

Fixes #11245.

After fix (more CPU idle = better):
<img width="455" alt="screenshot 2019-01-19 at 21 37 45" src="https://user-images.githubusercontent.com/1208119/51438622-dc743000-1cae-11e9-8dc5-1d60ba6502d9.png">

Current:
<img width="467" alt="screenshot 2019-01-19 at 21 45 14" src="https://user-images.githubusercontent.com/1208119/51438626-e5650180-1cae-11e9-92b5-a9e958c72b62.png">