### PR TITLE
uORB simplify handling of subscriptions with configured intervals

### DIFF
--- a/src/modules/uORB/uORBDeviceNode.hpp
+++ b/src/modules/uORB/uORBDeviceNode.hpp
@@ -202,24 +202,17 @@ protected:
 	void poll_notify_one(px4_pollfd_struct_t *fds, pollevent_t events) override;
 
 private:
+
 	struct UpdateIntervalData {
-		struct hrt_call update_call;  /**< deferred wakeup call if update_period is nonzero */
-#ifndef __PX4_NUTTX
-		uint64_t last_update; /**< time at which the last update was provided, used when update_interval is nonzero */
-#endif
-		unsigned  interval; /**< if nonzero minimum interval between updates */
-		bool update_reported;
+		uint64_t last_update{0}; /**< time at which the last update was provided, used when update_interval is nonzero */
+		unsigned interval{0}; /**< if nonzero minimum interval between updates */
 	};
+
 	struct SubscriberData {
 		~SubscriberData() { if (update_interval) { delete (update_interval); } }
 
-		unsigned  generation; /**< last generation the subscriber has seen */
-		UpdateIntervalData *update_interval; /**< if null, no update interval */
-
-		// these flags are only used if update_interval != null
-		bool update_reported() const { return update_interval ? update_interval->update_reported : false; }
-		void set_update_reported(bool update_reported_flag)
-		{ if (update_interval) { update_interval->update_reported = update_reported_flag; } }
+		unsigned generation{0}; /**< last generation the subscriber has seen */
+		UpdateIntervalData *update_interval{nullptr}; /**< if null, no update interval */
 	};
 
 	const orb_metadata *_meta; /**< object metadata information */
@@ -240,18 +233,6 @@ private:
 					message, it is counted as two. */
 
 	inline static SubscriberData    *filp_to_sd(cdev::file_t *filp);
-
-	/**
-	 * Perform a deferred update for a rate-limited subscriber.
-	 */
-	void      update_deferred();
-
-	/**
-	 * Bridge from hrt_call to update_deferred
-	 *
-	 * void *arg    ORBDevNode pointer for which the deferred update is performed.
-	 */
-	static void   update_deferred_trampoline(void *arg);
 
 	/**
 	 * Check whether a topic appears updated to a subscriber.


### PR DESCRIPTION
Currently in master when setting an interval on an orb subscription an hrt call is initialized. When you check if the topic is updated (or polled) that hrt call is scheduled to call poll_notify after the interval has passed from the last update.

Given how we actually use orb in the system now this is wasteful and adds a lot of unnecessary hrt calls that end up hurting performance in important areas.

This pull request simplifies how an orb subscription handles an interval. Instead of scheduling a deferred update, we simply check the last time a subscription was updated + configured interval before considering it updated or not. Note, this is roughly how it's always functioned on linux and qurt.

The potentially important difference to understand is what this means when polling an orb subscription with an interval (a minority of our usage). **The difference with this pull request is that the subscription poll will only be notified when a publication occurs after/on the interval, rather than when the interval itself elapses.** If you think about the PX4 modules that poll orb at a lower rate than published (eg navigator, fw_pos_ctrl_l1) this is fine, and actually what we'd prefer (minimal latency for processing changes). The downside is if the configured orb interval does not align with the publication rate (eg topic publishing every 4 ms (250 Hz) and subscriber interval is set to 10 ms (100 Hz)).

Overall compared to master this saves about 1% cpu (fmu-v4 tested), a little bit of ram, but more importantly it reduces the worst case hrt call latency.

HRT latency buckets (perf latency) compared to master.

|latency (us) | master (count) | master (%) | PR (count) | PR (%)|
|----|----|----|----|----|
|1 | 255598 | 85.32% | 254934 | 91.45%|
|2 | 8590 | 2.87% | 5669 | 2.03%|
|5 | 7458 | 2.49% | 5813 | 2.09%|
|10 | 8674 | 2.90% | 5956 | 2.14%|
|20 | 16756 | 5.59% | 6232 | 2.24%|
|50 | 2506 | 0.84% | 152 | 0.05%|
|100 | 0 | 0.00% | 0 | 0.00%|
|1000 | 0 | 0.00% | 0 | 0.00%|

**Average HRT latency(REVISED, previous numbers were incorrectly weighted)**
master: 2.86 us
PR: 1.75 us

What makes this particularly egregious is that it's the lower priority aspects of the system like tasks running at a lower rate or logging a subset of updates that are making use of orb intervals. Ensuring interval accurate updates (effectively only lower priority subscribers) is actually hurting important real time performance.

