### PR TITLE
PX4 general work queue

### DIFF
--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -43,7 +43,7 @@ pipeline {
           ]
 
           def nuttx_builds_other = [
-            target: ["px4_cannode-v1_default", "px4_esc-v1_default", "thiemar_s2740vc-v1_default"],
+            target: ["px4_esc-v1_default", "thiemar_s2740vc-v1_default"],
             image: docker_images.nuttx,
             archive: false
           ]

--- a/platforms/posix/CMakeLists.txt
+++ b/platforms/posix/CMakeLists.txt
@@ -62,10 +62,11 @@ else()
 			${df_driver_libs}
 			df_driver_framework
 			pthread m
-			
+
 			# horrible circular dependencies that need to be teased apart
-			px4_layer
-			px4_platform
+			px4_layer px4_platform
+			work_queue
+			parameters
 	)
 
 	if (NOT APPLE)

--- a/platforms/posix/src/px4_layer/CMakeLists.txt
+++ b/platforms/posix/src/px4_layer/CMakeLists.txt
@@ -54,7 +54,7 @@ add_library(px4_layer
 	${SHMEM_SRCS}
 )
 target_compile_definitions(px4_layer PRIVATE MODULE_NAME="px4")
-target_link_libraries(px4_layer PRIVATE work_queue)
+target_link_libraries(px4_layer PRIVATE work_queue px4_work_queue)
 target_link_libraries(px4_layer PRIVATE px4_daemon)
 
 if(ENABLE_LOCKSTEP_SCHEDULER)

--- a/platforms/qurt/src/px4_layer/px4_init.cpp
+++ b/platforms/qurt/src/px4_layer/px4_init.cpp
@@ -37,12 +37,15 @@
 #include <px4_defines.h>
 #include <drivers/drv_hrt.h>
 #include <lib/parameters/param.h>
+#include <px4_work_queue/WorkQueueManager.hpp>
 
 int px4_platform_init(void)
 {
 	hrt_init();
 
 	param_init();
+
+	px4::WorkQueueManagerStart();
 
 	return PX4_OK;
 }

--- a/posix-configs/SITL/init/test/cmd_template.in
+++ b/posix-configs/SITL/init/test/cmd_template.in
@@ -25,7 +25,7 @@ mavlink start -x -u 14556 -r 2000000
 mavlink boot_complete
 
 @cmd_name@ start
-sleep 1
+sleep 3
 @cmd_name@ start
 sleep 1
 @cmd_name@ stop

--- a/src/drivers/barometer/bmp280/CMakeLists.txt
+++ b/src/drivers/barometer/bmp280/CMakeLists.txt
@@ -40,5 +40,7 @@ px4_add_module(
 		bmp280_spi.cpp
 		bmp280_i2c.cpp
 		bmp280.cpp
+	DEPENDS
+		px4_work_queue
 	)
 

--- a/src/drivers/barometer/bmp280/bmp280.cpp
+++ b/src/drivers/barometer/bmp280/bmp280.cpp
@@ -54,7 +54,6 @@
 #include <px4_log.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/wqueue.h>
 #include <nuttx/clock.h>
 
 #include <arch/board/board.h>
@@ -68,6 +67,7 @@
 
 #include <perf/perf_counter.h>
 #include <systemlib/err.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 
 enum BMP280_BUS {
@@ -78,15 +78,11 @@ enum BMP280_BUS {
 	BMP280_BUS_SPI_EXTERNAL
 };
 
-#ifndef CONFIG_SCHED_WORKQUEUE
-# error This requires CONFIG_SCHED_WORKQUEUE.
-#endif
-
 /*
  * BMP280 internal constants and data structures.
  */
 
-class BMP280 : public cdev::CDev
+class BMP280 : public cdev::CDev, public px4::ScheduledWorkItem
 {
 public:
 	BMP280(bmp280::IBMP280 *interface, const char *path);
@@ -109,9 +105,8 @@ private:
 
 	uint8_t				_curr_ctrl;
 
-	struct work_s		_work;
-	unsigned			_report_ticks; // 0 - no cycling, otherwise period of sending a report
-	unsigned			_max_mesure_ticks; //ticks needed to measure
+	unsigned			_report_interval; // 0 - no cycling, otherwise period of sending a report
+	unsigned			_max_measure_interval;
 
 	ringbuffer::RingBuffer	*_reports;
 
@@ -135,8 +130,8 @@ private:
 	/* periodic execution helpers */
 	void			start_cycle();
 	void			stop_cycle();
-	void			cycle(); //main execution
-	static void		cycle_trampoline(void *arg);
+
+	void			Run() override;
 
 	int		measure(); //start measure
 	int		collect(); //get results and publish
@@ -149,9 +144,10 @@ extern "C" __EXPORT int bmp280_main(int argc, char *argv[]);
 
 BMP280::BMP280(bmp280::IBMP280 *interface, const char *path) :
 	CDev(path),
+	ScheduledWorkItem(px4::device_bus_to_wq(interface->get_device_id())),
 	_interface(interface),
 	_running(false),
-	_report_ticks(0),
+	_report_interval(0),
 	_reports(nullptr),
 	_collect_phase(false),
 	_baro_topic(nullptr),
@@ -161,8 +157,6 @@ BMP280::BMP280(bmp280::IBMP280 *interface, const char *path) :
 	_measure_perf(perf_alloc(PC_ELAPSED, "bmp280_measure")),
 	_comms_errors(perf_alloc(PC_COUNT, "bmp280_comms_errors"))
 {
-	// work_cancel in stop_cycle called from the dtor will explode if we don't do this...
-	memset(&_work, 0, sizeof(_work));
 }
 
 BMP280::~BMP280()
@@ -226,7 +220,7 @@ BMP280::init()
 	/* set config, recommended settings */
 	_curr_ctrl = BPM280_CTRL_P16 | BPM280_CTRL_T2;
 	_interface->set_reg(_curr_ctrl, BPM280_ADDR_CTRL);
-	_max_mesure_ticks = USEC2TICK(BPM280_MT_INIT + BPM280_MT * (16 - 1 + 2 - 1));
+	_max_measure_interval = BPM280_MT_INIT + BPM280_MT * (16 - 1 + 2 - 1);
 	_interface->set_reg(BPM280_CONFIG_F16, BPM280_ADDR_CONFIG);
 
 	/* get calibration and pre process them*/
@@ -256,7 +250,7 @@ BMP280::init()
 		return -EIO;
 	}
 
-	usleep(TICK2USEC(_max_mesure_ticks));
+	usleep(_max_measure_interval);
 
 	if (collect()) {
 		return -EIO;
@@ -289,7 +283,7 @@ BMP280::read(struct file *filp, char *buffer, size_t buflen)
 	}
 
 	/* if automatic measurement is enabled */
-	if (_report_ticks > 0) {
+	if (_report_interval > 0) {
 
 		/*
 		 * While there is space in the caller's buffer, and reports, copy them.
@@ -315,7 +309,7 @@ BMP280::read(struct file *filp, char *buffer, size_t buflen)
 		return -EIO;
 	}
 
-	usleep(TICK2USEC(_max_mesure_ticks));
+	usleep(_max_measure_interval);
 
 	if (collect()) {
 		return -EIO;
@@ -335,7 +329,7 @@ BMP280::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 	case SENSORIOCSPOLLRATE: {
 
-			unsigned ticks = 0;
+			unsigned interval = 0;
 
 			switch (arg) {
 
@@ -343,23 +337,23 @@ BMP280::ioctl(struct file *filp, int cmd, unsigned long arg)
 				return -EINVAL;
 
 			case SENSOR_POLLRATE_DEFAULT:
-				ticks = _max_mesure_ticks;
+				interval = _max_measure_interval;
 
 			/* FALLTHROUGH */
 			default: {
-					if (ticks == 0) {
-						ticks = USEC2TICK(USEC_PER_SEC / arg);
+					if (interval == 0) {
+						interval = (USEC_PER_SEC / arg);
 					}
 
 					/* do we need to start internal polling? */
-					bool want_start = (_report_ticks == 0);
+					bool want_start = (_report_interval == 0);
 
 					/* check against maximum rate */
-					if (ticks < _max_mesure_ticks) {
+					if (interval < _max_measure_interval) {
 						return -EINVAL;
 					}
 
-					_report_ticks = ticks;
+					_report_interval = interval;
 
 					if (want_start) {
 						start_cycle();
@@ -389,41 +383,33 @@ BMP280::ioctl(struct file *filp, int cmd, unsigned long arg)
 void
 BMP280::start_cycle()
 {
-
 	/* reset the report ring and state machine */
 	_collect_phase = false;
 	_running = true;
 	_reports->flush();
 
 	/* schedule a cycle to start things */
-	work_queue(HPWORK, &_work, (worker_t)&BMP280::cycle_trampoline, this, 1);
+	ScheduleNow();
 }
 
 void
 BMP280::stop_cycle()
 {
 	_running = false;
-	work_cancel(HPWORK, &_work);
+	ScheduleClear();
 }
 
 void
-BMP280::cycle_trampoline(void *arg)
-{
-	BMP280 *dev = reinterpret_cast<BMP280 *>(arg);
-
-	dev->cycle();
-}
-
-void
-BMP280::cycle()
+BMP280::Run()
 {
 	if (_collect_phase) {
 		collect();
-		unsigned wait_gap = _report_ticks - _max_mesure_ticks;
+		unsigned wait_gap = _report_interval - _max_measure_interval;
 
 		if ((wait_gap != 0) && (_running)) {
-			work_queue(HPWORK, &_work, (worker_t)&BMP280::cycle_trampoline, this,
-				   wait_gap); //need to wait some time before new measurement
+			//need to wait some time before new measurement
+			ScheduleDelayed(wait_gap);
+
 			return;
 		}
 
@@ -432,9 +418,8 @@ BMP280::cycle()
 	measure();
 
 	if (_running) {
-		work_queue(HPWORK, &_work, (worker_t)&BMP280::cycle_trampoline, this, _max_mesure_ticks);
+		ScheduleDelayed(_max_measure_interval);
 	}
-
 }
 
 int
@@ -517,7 +502,7 @@ BMP280::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	printf("poll interval:  %u us \n", _report_ticks * USEC_PER_TICK);
+	printf("poll interval:  %u us \n", _report_interval);
 	_reports->print_info("report queue");
 
 	sensor_baro_s brp = {};

--- a/src/drivers/barometer/bmp280/bmp280.h
+++ b/src/drivers/barometer/bmp280/bmp280.h
@@ -148,6 +148,8 @@ public:
 	// bulk read of calibration data into buffer, return same pointer
 	virtual bmp280::calibration_s *get_calibration(uint8_t addr) = 0;
 
+	virtual uint32_t get_device_id() const = 0;
+
 };
 
 } /* namespace */

--- a/src/drivers/barometer/bmp280/bmp280_i2c.cpp
+++ b/src/drivers/barometer/bmp280/bmp280_i2c.cpp
@@ -60,6 +60,8 @@ public:
 	bmp280::data_s *get_data(uint8_t addr);
 	bmp280::calibration_s *get_calibration(uint8_t addr);
 
+	uint32_t get_device_id() const override { return device::I2C::get_device_id(); }
+
 private:
 	struct bmp280::calibration_s _cal;
 	struct bmp280::data_s _data;

--- a/src/drivers/barometer/bmp280/bmp280_spi.cpp
+++ b/src/drivers/barometer/bmp280/bmp280_spi.cpp
@@ -76,6 +76,8 @@ public:
 	bmp280::data_s *get_data(uint8_t addr);
 	bmp280::calibration_s *get_calibration(uint8_t addr);
 
+	uint32_t get_device_id() const override { return device::SPI::get_device_id(); }
+
 private:
 	spi_calibration_s _cal;
 	spi_data_s _data;

--- a/src/drivers/barometer/lps22hb/LPS22HB.hpp
+++ b/src/drivers/barometer/lps22hb/LPS22HB.hpp
@@ -36,7 +36,7 @@
 #include <lib/cdev/CDev.hpp>
 #include <drivers/device/Device.hpp>
 #include <px4_config.h>
-#include <px4_workqueue.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 #include <perf/perf_counter.h>
 
@@ -84,7 +84,7 @@ extern device::Device *LPS22HB_SPI_interface(int bus);
 extern device::Device *LPS22HB_I2C_interface(int bus);
 typedef device::Device *(*LPS22HB_constructor)(int);
 
-class LPS22HB : public cdev::CDev
+class LPS22HB : public cdev::CDev, public px4::ScheduledWorkItem
 {
 public:
 	LPS22HB(device::Device *interface, const char *path);
@@ -103,8 +103,7 @@ protected:
 	device::Device			*_interface;
 
 private:
-	work_s			_work{};
-	unsigned		_measure_ticks{0};
+	unsigned		_measure_interval{0};
 
 	bool			_collect_phase{false};
 
@@ -149,15 +148,7 @@ private:
 	 * and measurement to provide the most recent measurement possible
 	 * at the next interval.
 	 */
-	void			cycle();
-
-	/**
-	 * Static trampoline from the workq context; because we don't have a
-	 * generic workq wrapper yet.
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		cycle_trampoline(void *arg);
+	void			Run() override;
 
 	/**
 	 * Write a register.

--- a/src/drivers/barometer/lps25h/lps25h.cpp
+++ b/src/drivers/barometer/lps25h/lps25h.cpp
@@ -57,7 +57,7 @@
 #include <unistd.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/wqueue.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 #include <nuttx/clock.h>
 
 #include <board_config.h>
@@ -189,11 +189,7 @@ enum LPS25H_BUS {
 	LPS25H_BUS_SPI
 };
 
-#ifndef CONFIG_SCHED_WORKQUEUE
-# error This requires CONFIG_SCHED_WORKQUEUE.
-#endif
-
-class LPS25H : public cdev::CDev
+class LPS25H : public cdev::CDev, public px4::ScheduledWorkItem
 {
 public:
 	LPS25H(device::Device *interface, const char *path);
@@ -213,8 +209,7 @@ protected:
 	device::Device			*_interface;
 
 private:
-	work_s			_work{};
-	unsigned		_measure_ticks{0};
+	unsigned		_measure_interval{0};
 
 	ringbuffer::RingBuffer	*_reports{nullptr};
 	bool			_collect_phase{false};
@@ -259,15 +254,7 @@ private:
 	 * and measurement to provide the most recent measurement possible
 	 * at the next interval.
 	 */
-	void			cycle();
-
-	/**
-	 * Static trampoline from the workq context; because we don't have a
-	 * generic workq wrapper yet.
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		cycle_trampoline(void *arg);
+	void			Run() override;
 
 	/**
 	 * Write a register.
@@ -312,6 +299,7 @@ extern "C" __EXPORT int lps25h_main(int argc, char *argv[]);
 
 LPS25H::LPS25H(device::Device *interface, const char *path) :
 	CDev(path),
+	ScheduledWorkItem(px4::device_bus_to_wq(interface->get_device_id())),
 	_interface(interface),
 	_sample_perf(perf_alloc(PC_ELAPSED, "lps25h_read")),
 	_comms_errors(perf_alloc(PC_COUNT, "lps25h_comms_errors"))
@@ -386,7 +374,7 @@ LPS25H::read(struct file *filp, char *buffer, size_t buflen)
 	}
 
 	/* if automatic measurement is enabled */
-	if (_measure_ticks > 0) {
+	if (_measure_interval > 0) {
 
 		/*
 		 * While there is space in the caller's buffer, and reports, copy them.
@@ -448,10 +436,10 @@ LPS25H::ioctl(struct file *filp, int cmd, unsigned long arg)
 			/* set default polling rate */
 			case SENSOR_POLLRATE_DEFAULT: {
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
 					/* set interval for next measurement to minimum legal value */
-					_measure_ticks = USEC2TICK(LPS25H_CONVERSION_INTERVAL);
+					_measure_interval = (LPS25H_CONVERSION_INTERVAL);
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -464,18 +452,18 @@ LPS25H::ioctl(struct file *filp, int cmd, unsigned long arg)
 			/* adjust to a legal polling interval in Hz */
 			default: {
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
 					/* convert hz to tick interval via microseconds */
-					unsigned ticks = USEC2TICK(1000000 / arg);
+					unsigned interval = (1000000 / arg);
 
 					/* check against maximum rate */
-					if (ticks < USEC2TICK(LPS25H_CONVERSION_INTERVAL)) {
+					if (interval < (LPS25H_CONVERSION_INTERVAL)) {
 						return -EINVAL;
 					}
 
 					/* update interval for next measurement */
-					_measure_ticks = ticks;
+					_measure_interval = interval;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -507,13 +495,13 @@ LPS25H::start()
 	_reports->flush();
 
 	/* schedule a cycle to start things */
-	work_queue(HPWORK, &_work, (worker_t)&LPS25H::cycle_trampoline, this, 1);
+	ScheduleNow();
 }
 
 void
 LPS25H::stop()
 {
-	work_cancel(HPWORK, &_work);
+	ScheduleClear();
 }
 
 int
@@ -540,15 +528,7 @@ LPS25H::reset()
 }
 
 void
-LPS25H::cycle_trampoline(void *arg)
-{
-	LPS25H *dev = reinterpret_cast<LPS25H *>(arg);
-
-	dev->cycle();
-}
-
-void
-LPS25H::cycle()
+LPS25H::Run()
 {
 	/* collection phase? */
 	if (_collect_phase) {
@@ -567,14 +547,10 @@ LPS25H::cycle()
 		/*
 		 * Is there a collect->measure gap?
 		 */
-		if (_measure_ticks > USEC2TICK(LPS25H_CONVERSION_INTERVAL)) {
+		if (_measure_interval > (LPS25H_CONVERSION_INTERVAL)) {
 
 			/* schedule a fresh cycle call when we are ready to measure again */
-			work_queue(HPWORK,
-				   &_work,
-				   (worker_t)&LPS25H::cycle_trampoline,
-				   this,
-				   _measure_ticks - USEC2TICK(LPS25H_CONVERSION_INTERVAL));
+			ScheduleDelayed(_measure_interval - LPS25H_CONVERSION_INTERVAL);
 
 			return;
 		}
@@ -589,11 +565,7 @@ LPS25H::cycle()
 	_collect_phase = true;
 
 	/* schedule a fresh cycle call when the measurement is done */
-	work_queue(HPWORK,
-		   &_work,
-		   (worker_t)&LPS25H::cycle_trampoline,
-		   this,
-		   USEC2TICK(LPS25H_CONVERSION_INTERVAL));
+	ScheduleDelayed(LPS25H_CONVERSION_INTERVAL);
 }
 
 int
@@ -713,7 +685,7 @@ LPS25H::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	printf("poll interval:  %u ticks\n", _measure_ticks);
+	printf("poll interval:  %u \n", _measure_interval);
 	print_message(_last_report);
 
 	_reports->print_info("report queue");

--- a/src/drivers/barometer/ms5611/CMakeLists.txt
+++ b/src/drivers/barometer/ms5611/CMakeLists.txt
@@ -30,18 +30,15 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
-set(srcs
-	ms5611_spi.cpp
-	ms5611_i2c.cpp
-	ms5611.cpp
-)
 
 px4_add_module(
 	MODULE drivers__ms5611
 	MAIN ms5611
 	STACK_MAIN 1500
-	COMPILE_FLAGS
-	SRCS ${srcs}
+	SRCS
+		ms5611_spi.cpp
+		ms5611_i2c.cpp
+		ms5611.cpp
 	DEPENDS
+		px4_work_queue
 	)
-

--- a/src/drivers/differential_pressure/ets/ets_airspeed.cpp
+++ b/src/drivers/differential_pressure/ets/ets_airspeed.cpp
@@ -84,9 +84,9 @@ protected:
 	* Perform a poll cycle; collect from the previous measurement
 	* and start a new one.
 	*/
-	virtual void	cycle();
-	virtual int	measure();
-	virtual int	collect();
+	void	Run() override;
+	int	measure() override;
+	int	collect() override;
 
 };
 
@@ -174,7 +174,7 @@ ETSAirspeed::collect()
 }
 
 void
-ETSAirspeed::cycle()
+ETSAirspeed::Run()
 {
 	int ret;
 
@@ -198,14 +198,10 @@ ETSAirspeed::cycle()
 		/*
 		 * Is there a collect->measure gap?
 		 */
-		if (_measure_ticks > USEC2TICK(CONVERSION_INTERVAL)) {
+		if (_measure_interval > CONVERSION_INTERVAL) {
 
 			/* schedule a fresh cycle call when we are ready to measure again */
-			work_queue(HPWORK,
-				   &_work,
-				   (worker_t)&Airspeed::cycle_trampoline,
-				   this,
-				   _measure_ticks - USEC2TICK(CONVERSION_INTERVAL));
+			ScheduleDelayed(_measure_interval - CONVERSION_INTERVAL);
 
 			return;
 		}
@@ -224,11 +220,7 @@ ETSAirspeed::cycle()
 	_collect_phase = true;
 
 	/* schedule a fresh cycle call when the measurement is done */
-	work_queue(HPWORK,
-		   &_work,
-		   (worker_t)&Airspeed::cycle_trampoline,
-		   this,
-		   USEC2TICK(CONVERSION_INTERVAL));
+	ScheduleDelayed(CONVERSION_INTERVAL);
 }
 
 /**

--- a/src/drivers/differential_pressure/ms5525/MS5525.cpp
+++ b/src/drivers/differential_pressure/ms5525/MS5525.cpp
@@ -272,7 +272,7 @@ MS5525::collect()
 }
 
 void
-MS5525::cycle()
+MS5525::Run()
 {
 	int ret = PX4_ERROR;
 
@@ -292,11 +292,10 @@ MS5525::cycle()
 		_collect_phase = false;
 
 		// is there a collect->measure gap?
-		if (_measure_ticks > USEC2TICK(CONVERSION_INTERVAL)) {
+		if (_measure_interval > CONVERSION_INTERVAL) {
 
 			// schedule a fresh cycle call when we are ready to measure again
-			work_queue(HPWORK, &_work, (worker_t)&Airspeed::cycle_trampoline, this,
-				   _measure_ticks - USEC2TICK(CONVERSION_INTERVAL));
+			ScheduleDelayed(_measure_interval - CONVERSION_INTERVAL);
 
 			return;
 		}
@@ -315,5 +314,5 @@ MS5525::cycle()
 	_collect_phase = true;
 
 	// schedule a fresh cycle call when the measurement is done
-	work_queue(HPWORK, &_work, (worker_t)&Airspeed::cycle_trampoline, this, USEC2TICK(CONVERSION_INTERVAL));
+	ScheduleDelayed(CONVERSION_INTERVAL);
 }

--- a/src/drivers/differential_pressure/ms5525/MS5525.hpp
+++ b/src/drivers/differential_pressure/ms5525/MS5525.hpp
@@ -71,7 +71,7 @@ private:
 	* Perform a poll cycle; collect from the previous measurement
 	* and start a new one.
 	*/
-	void cycle() override;
+	void Run() override;
 
 	int measure() override;
 	int collect() override;

--- a/src/drivers/differential_pressure/sdp3x/SDP3X.cpp
+++ b/src/drivers/differential_pressure/sdp3x/SDP3X.cpp
@@ -168,7 +168,7 @@ SDP3X::collect()
 }
 
 void
-SDP3X::cycle()
+SDP3X::Run()
 {
 	int ret = PX4_ERROR;
 
@@ -181,7 +181,7 @@ SDP3X::cycle()
 	}
 
 	// schedule a fresh cycle call when the measurement is done
-	work_queue(HPWORK, &_work, (worker_t)&Airspeed::cycle_trampoline, this, USEC2TICK(CONVERSION_INTERVAL));
+	ScheduleDelayed(CONVERSION_INTERVAL);
 }
 
 bool SDP3X::crc(const uint8_t data[], unsigned size, uint8_t checksum)

--- a/src/drivers/differential_pressure/sdp3x/SDP3X.hpp
+++ b/src/drivers/differential_pressure/sdp3x/SDP3X.hpp
@@ -87,7 +87,7 @@ private:
 	 * Perform a poll cycle; collect from the previous measurement
 	 * and start a new one.
 	 */
-	void	cycle() override;
+	void	Run() override;
 	int	measure() override { return 0; }
 	int	collect() override;
 	int	probe() override;

--- a/src/drivers/distance_sensor/cm8jl65/cm8jl65.cpp
+++ b/src/drivers/distance_sensor/cm8jl65/cm8jl65.cpp
@@ -43,7 +43,7 @@
 
 #include <px4_config.h>
 #include <px4_getopt.h>
-#include <px4_workqueue.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 #include <sys/types.h>
 #include <stdint.h>
@@ -69,10 +69,6 @@
 
 /* Configuration Constants */
 
-#ifndef CONFIG_SCHED_WORKQUEUE
-# error This requires CONFIG_SCHED_WORKQUEUE.
-#endif
-
 #define CM8JL65_TAKE_RANGE_REG		'd'
 
 // designated serial port on Pixhawk (TELEM2)
@@ -82,7 +78,7 @@
 #define CM8JL65_CONVERSION_INTERVAL 50*1000UL/* 50ms */
 
 
-class CM8JL65 : public cdev::CDev
+class CM8JL65 : public cdev::CDev, public px4::ScheduledWorkItem
 {
 public:
 
@@ -90,10 +86,10 @@ public:
 	CM8JL65(const char *port = CM8JL65_DEFAULT_PORT, uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING);
 
 	// Virtual destructor
-	virtual ~CM8JL65();
+	virtual ~CM8JL65() override;
 
-	virtual int  init();
-	virtual int  ioctl(device::file_t *filp, int cmd, unsigned long arg);
+	virtual int  init() override;
+	virtual int  ioctl(device::file_t *filp, int cmd, unsigned long arg) override;
 
 	/**
 	* Diagnostics - print some basic information about the driver.
@@ -107,7 +103,6 @@ private:
 	float				             _min_distance;
 	float				             _max_distance;
 	int         	             _conversion_interval;
-	work_s				             _work{};
 	ringbuffer::RingBuffer	  *_reports;
 	int				               _fd;
 	uint8_t			             _linebuf[25];
@@ -151,15 +146,9 @@ private:
 	* Perform a reading cycle; collect from the previous measurement
 	* and start a new one.
 	*/
-	void				cycle();
+	void				Run() override;
+
 	int				collect();
-	/**
-	* Static trampoline from the workq context; because we don't have a
-	* generic workq wrapper yet.
-	*
-	* @param arg		Instance pointer for the driver that is polling.
-	*/
-	static void			cycle_trampoline(void *arg);
 
 };
 
@@ -176,6 +165,7 @@ extern "C" __EXPORT int cm8jl65_main(int argc, char *argv[]);
 
 CM8JL65::CM8JL65(const char *port, uint8_t rotation) :
 	CDev(RANGE_FINDER0_DEVICE_PATH),
+	ScheduledWorkItem(px4::wq_configurations::hp_default),
 	_rotation(rotation),
 	_min_distance(0.10f),
 	_max_distance(9.0f),
@@ -195,9 +185,9 @@ CM8JL65::CM8JL65(const char *port, uint8_t rotation) :
 {
 	/* store port name */
 	strncpy(_port, port, sizeof(_port));
+
 	/* enforce null termination */
 	_port[sizeof(_port) - 1] = '\0';
-
 }
 
 // Destructor
@@ -310,10 +300,10 @@ CM8JL65::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			default: {
 
 					/* convert hz to tick interval via microseconds */
-					int ticks = USEC2TICK(1000000 / arg);
+					int interval = (1000000 / arg);
 
 					/* check against maximum rate */
-					if (ticks < USEC2TICK(_conversion_interval)) {
+					if (interval < _conversion_interval) {
 						return -EINVAL;
 					}
 
@@ -428,26 +418,17 @@ CM8JL65::start()
 	_reports->flush();
 
 	/* schedule a cycle to start things */
-	work_queue(HPWORK, &_work, (worker_t)&CM8JL65::cycle_trampoline, this, 1);
-
+	ScheduleNow();
 }
 
 void
 CM8JL65::stop()
 {
-	work_cancel(HPWORK, &_work);
+	ScheduleClear();
 }
 
 void
-CM8JL65::cycle_trampoline(void *arg)
-{
-	CM8JL65 *dev = static_cast<CM8JL65 *>(arg);
-
-	dev->cycle();
-}
-
-void
-CM8JL65::cycle()
+CM8JL65::Run()
 {
 	/* fds initialized? */
 	if (_fd < 0) {
@@ -495,9 +476,8 @@ CM8JL65::cycle()
 		_cycle_counter++;
 	}
 
-
 	/* schedule a fresh cycle call when a complete packet has been received */
-	work_queue(HPWORK, &_work, (worker_t)&CM8JL65::cycle_trampoline, this, USEC2TICK(_conversion_interval));
+	ScheduleDelayed(_conversion_interval);
 	_cycle_counter = 0;
 }
 

--- a/src/drivers/distance_sensor/ll40ls/LidarLite.cpp
+++ b/src/drivers/distance_sensor/ll40ls/LidarLite.cpp
@@ -41,38 +41,6 @@
 
 #include "LidarLite.h"
 
-LidarLite::LidarLite() :
-	_min_distance(LL40LS_MIN_DISTANCE),
-	_max_distance(LL40LS_MAX_DISTANCE_V3),
-	_measure_ticks(0)
-{
-}
-
-void LidarLite::set_minimum_distance(const float min)
-{
-	_min_distance = min;
-}
-
-void LidarLite::set_maximum_distance(const float max)
-{
-	_max_distance = max;
-}
-
-float LidarLite::get_minimum_distance() const
-{
-	return _min_distance;
-}
-
-float LidarLite::get_maximum_distance() const
-{
-	return _max_distance;
-}
-
-uint32_t LidarLite::getMeasureTicks() const
-{
-	return _measure_ticks;
-}
-
 int LidarLite::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 {
 	switch (cmd) {
@@ -87,10 +55,10 @@ int LidarLite::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			/* set default polling rate */
 			case SENSOR_POLLRATE_DEFAULT: {
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
 					/* set interval for next measurement to minimum legal value */
-					_measure_ticks = USEC2TICK(LL40LS_CONVERSION_INTERVAL);
+					_measure_interval = (LL40LS_CONVERSION_INTERVAL);
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -103,18 +71,18 @@ int LidarLite::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			/* adjust to a legal polling interval in Hz */
 			default: {
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
 					/* convert hz to tick interval via microseconds */
-					unsigned ticks = USEC2TICK(1000000 / arg);
+					unsigned interval = (1000000 / arg);
 
 					/* check against maximum rate */
-					if (ticks < USEC2TICK(LL40LS_CONVERSION_INTERVAL)) {
+					if (interval < (LL40LS_CONVERSION_INTERVAL)) {
 						return -EINVAL;
 					}
 
 					/* update interval for next measurement */
-					_measure_ticks = ticks;
+					_measure_interval = interval;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {

--- a/src/drivers/distance_sensor/ll40ls/LidarLite.h
+++ b/src/drivers/distance_sensor/ll40ls/LidarLite.h
@@ -57,8 +57,7 @@
 class LidarLite
 {
 public:
-	LidarLite();
-
+	LidarLite() = default;
 	virtual ~LidarLite() = default;
 
 	virtual int init() = 0;
@@ -89,12 +88,12 @@ protected:
 	* range to be brought in at all, otherwise it will use the defaults LL40LS_MIN_DISTANCE
 	* and LL40LS_MAX_DISTANCE_V3
 	*/
-	void                set_minimum_distance(const float min);
-	void                set_maximum_distance(const float max);
-	float               get_minimum_distance() const;
-	float               get_maximum_distance() const;
+	void                set_minimum_distance(const float min) { _min_distance = min; }
+	void                set_maximum_distance(const float max) { _max_distance = max; }
+	float               get_minimum_distance() const { return _min_distance; }
+	float               get_maximum_distance() const { return _max_distance; }
 
-	uint32_t            getMeasureTicks() const;
+	uint32_t            getMeasureInterval() const { return _measure_interval; }
 
 	virtual int         measure() = 0;
 	virtual int         collect() = 0;
@@ -102,7 +101,7 @@ protected:
 	virtual int         reset_sensor() = 0;
 
 private:
-	float               _min_distance;
-	float               _max_distance;
-	uint32_t            _measure_ticks;
+	float               _min_distance{LL40LS_MIN_DISTANCE};
+	float               _max_distance{LL40LS_MAX_DISTANCE_V3};
+	uint32_t            _measure_interval{0};
 };

--- a/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.h
+++ b/src/drivers/distance_sensor/ll40ls/LidarLiteI2C.h
@@ -42,7 +42,7 @@
 
 #include "LidarLite.h"
 
-#include <px4_workqueue.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 #include <perf/perf_counter.h>
 
@@ -78,7 +78,7 @@
 #define LL40LS_PEAK_STRENGTH_LOW 135			// Minimum peak strength raw value for accepting a measurement
 #define LL40LS_PEAK_STRENGTH_HIGH 234			// Max peak strength raw value
 
-class LidarLiteI2C : public LidarLite, public device::I2C
+class LidarLiteI2C : public LidarLite, public device::I2C, public px4::ScheduledWorkItem
 {
 public:
 	LidarLiteI2C(int bus, const char *path,
@@ -113,7 +113,6 @@ protected:
 
 private:
 	uint8_t _rotation;
-	work_s              _work;
 	ringbuffer::RingBuffer          *_reports;
 	bool                _sensor_ok;
 	bool                _collect_phase;
@@ -173,16 +172,8 @@ private:
 	* Perform a poll cycle; collect from the previous measurement
 	* and start a new one.
 	*/
-	void                cycle();
+	void                Run() override;
 	int                 collect() override;
-
-	/**
-	* Static trampoline from the workq context; because we don't have a
-	* generic workq wrapper yet.
-	*
-	* @param arg        Instance pointer for the driver that is polling.
-	*/
-	static void     cycle_trampoline(void *arg);
 
 private:
 	LidarLiteI2C(const LidarLiteI2C &copy) = delete;

--- a/src/drivers/distance_sensor/ll40ls/LidarLitePWM.h
+++ b/src/drivers/distance_sensor/ll40ls/LidarLitePWM.h
@@ -45,8 +45,7 @@
 
 #include "LidarLite.h"
 
-#include <px4_workqueue.h>
-
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 #include <drivers/device/ringbuffer.h>
 #include <perf/perf_counter.h>
@@ -57,7 +56,7 @@
 
 
 
-class LidarLitePWM : public LidarLite, public cdev::CDev
+class LidarLitePWM : public LidarLite, public cdev::CDev, public px4::ScheduledWorkItem
 {
 public:
 	LidarLitePWM(const char *path, uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING);
@@ -72,7 +71,7 @@ public:
 
 	void stop() override;
 
-	void cycle();
+	void Run() override;
 
 	/**
 	* @brief
@@ -85,14 +84,6 @@ public:
 	 *   print registers to console
 	 */
 	void print_registers() override;
-
-	/**
-	* Static trampoline from the workq context; because we don't have a
-	* generic workq wrapper yet.
-	*
-	* @param arg        Instance pointer for the driver that is polling.
-	*/
-	static void     cycle_trampoline(void *arg);
 
 	const char *get_dev_name() override;
 
@@ -108,7 +99,6 @@ protected:
 
 private:
 	uint8_t _rotation;
-	work_s			_work;
 	ringbuffer::RingBuffer	*_reports;
 	int			_class_instance;
 	int			_orb_class_instance;

--- a/src/drivers/distance_sensor/ll40ls/ll40ls.cpp
+++ b/src/drivers/distance_sensor/ll40ls/ll40ls.cpp
@@ -51,10 +51,6 @@
 #include <stdio.h>
 #include <px4_getopt.h>
 
-#ifndef CONFIG_SCHED_WORKQUEUE
-# error This requires CONFIG_SCHED_WORKQUEUE.
-#endif
-
 #define LL40LS_DEVICE_PATH_PWM  "/dev/ll40ls_pwm"
 
 enum LL40LS_BUS {

--- a/src/drivers/distance_sensor/mb12xx/mb12xx.cpp
+++ b/src/drivers/distance_sensor/mb12xx/mb12xx.cpp
@@ -41,7 +41,7 @@
 
 #include <px4_config.h>
 #include <px4_getopt.h>
-#include <px4_workqueue.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 #include <containers/Array.hpp>
 
 #include <drivers/device/i2c.h>
@@ -85,23 +85,19 @@
 #define MB12XX_MAX_DISTANCE 	(7.65f)
 
 #define MB12XX_CONVERSION_INTERVAL 	100000 /* 60ms for one sonar */
-#define TICKS_BETWEEN_SUCCESIVE_FIRES 	100000 /* 30ms between each sonar measurement (watch out for interference!) */
+#define MB12XX_INTERVAL_BETWEEN_SUCCESIVE_FIRES 	100000 /* 30ms between each sonar measurement (watch out for interference!) */
 
-#ifndef CONFIG_SCHED_WORKQUEUE
-# error This requires CONFIG_SCHED_WORKQUEUE.
-#endif
-
-class MB12XX : public device::I2C
+class MB12XX : public device::I2C, public px4::ScheduledWorkItem
 {
 public:
 	MB12XX(uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING,
 	       int bus = MB12XX_BUS_DEFAULT, int address = MB12XX_BASEADDR);
 	virtual ~MB12XX();
 
-	virtual int 		init();
+	virtual int 		init() override;
 
-	virtual ssize_t		read(device::file_t *filp, char *buffer, size_t buflen);
-	virtual int			ioctl(device::file_t *filp, int cmd, unsigned long arg);
+	virtual ssize_t		read(device::file_t *filp, char *buffer, size_t buflen) override;
+	virtual int			ioctl(device::file_t *filp, int cmd, unsigned long arg) override;
 
 	/**
 	* Diagnostics - print some basic information about the driver.
@@ -109,16 +105,15 @@ public:
 	void				print_info();
 
 protected:
-	virtual int			probe();
+	virtual int			probe() override;
 
 private:
 	uint8_t _rotation;
 	float				_min_distance;
 	float				_max_distance;
-	work_s				_work{};
 	ringbuffer::RingBuffer		*_reports;
 	bool				_sensor_ok;
-	int				_measure_ticks;
+	int				_measure_interval;
 	bool				_collect_phase;
 	int				_class_instance;
 	int				_orb_class_instance;
@@ -169,17 +164,9 @@ private:
 	* Perform a poll cycle; collect from the previous measurement
 	* and start a new one.
 	*/
-	void				cycle();
+	void					Run() override;
 	int					measure();
 	int					collect();
-	/**
-	* Static trampoline from the workq context; because we don't have a
-	* generic workq wrapper yet.
-	*
-	* @param arg		Instance pointer for the driver that is polling.
-	*/
-	static void			cycle_trampoline(void *arg);
-
 
 };
 
@@ -190,12 +177,13 @@ extern "C" __EXPORT int mb12xx_main(int argc, char *argv[]);
 
 MB12XX::MB12XX(uint8_t rotation, int bus, int address) :
 	I2C("MB12xx", MB12XX_DEVICE_PATH, bus, address, 100000),
+	ScheduledWorkItem(px4::device_bus_to_wq(get_device_id())),
 	_rotation(rotation),
 	_min_distance(MB12XX_MIN_DISTANCE),
 	_max_distance(MB12XX_MAX_DISTANCE),
 	_reports(nullptr),
 	_sensor_ok(false),
-	_measure_ticks(0),
+	_measure_interval(0),
 	_collect_phase(false),
 	_class_instance(-1),
 	_orb_class_instance(-1),
@@ -205,7 +193,6 @@ MB12XX::MB12XX(uint8_t rotation, int bus, int address) :
 	_cycle_counter(0),	/* initialising counter for cycling function to zero */
 	_cycling_rate(0),	/* initialising cycling rate (which can differ depending on one sonar or multiple) */
 	_index_counter(0) 	/* initialising temp sonar i2c address to zero */
-
 {
 }
 
@@ -285,7 +272,7 @@ MB12XX::init()
 		_cycling_rate = MB12XX_CONVERSION_INTERVAL;
 
 	} else {
-		_cycling_rate = TICKS_BETWEEN_SUCCESIVE_FIRES;
+		_cycling_rate = MB12XX_INTERVAL_BETWEEN_SUCCESIVE_FIRES;
 	}
 
 	/* show the connected sonars in terminal */
@@ -347,10 +334,10 @@ MB12XX::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			/* set default polling rate */
 			case SENSOR_POLLRATE_DEFAULT: {
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
 					/* set interval for next measurement to minimum legal value */
-					_measure_ticks = USEC2TICK(_cycling_rate);
+					_measure_interval = (_cycling_rate);
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -364,18 +351,18 @@ MB12XX::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			/* adjust to a legal polling interval in Hz */
 			default: {
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
 					/* convert hz to tick interval via microseconds */
-					int ticks = USEC2TICK(1000000 / arg);
+					int interval = (1000000 / arg);
 
 					/* check against maximum rate */
-					if (ticks < USEC2TICK(_cycling_rate)) {
+					if (interval < (_cycling_rate)) {
 						return -EINVAL;
 					}
 
 					/* update interval for next measurement */
-					_measure_ticks = ticks;
+					_measure_interval = interval;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -407,7 +394,7 @@ MB12XX::read(device::file_t *filp, char *buffer, size_t buflen)
 	}
 
 	/* if automatic measurement is enabled */
-	if (_measure_ticks > 0) {
+	if (_measure_interval > 0) {
 
 		/*
 		 * While there is space in the caller's buffer, and reports, copy them.
@@ -537,27 +524,17 @@ MB12XX::start()
 	_reports->flush();
 
 	/* schedule a cycle to start things */
-	work_queue(HPWORK, &_work, (worker_t)&MB12XX::cycle_trampoline, this, 5);
+	ScheduleDelayed(5);
 }
 
 void
 MB12XX::stop()
 {
-	work_cancel(HPWORK, &_work);
+	ScheduleClear();
 }
 
 void
-MB12XX::cycle_trampoline(void *arg)
-{
-
-	MB12XX *dev = (MB12XX *)arg;
-
-	dev->cycle();
-
-}
-
-void
-MB12XX::cycle()
+MB12XX::Run()
 {
 	if (_collect_phase) {
 		_index_counter = addr_ind[_cycle_counter]; /*sonar from previous iteration collect is now read out */
@@ -584,14 +561,11 @@ MB12XX::cycle()
 		/* Is there a collect->measure gap? Yes, and the timing is set equal to the cycling_rate
 		   Otherwise the next sonar would fire without the first one having received its reflected sonar pulse */
 
-		if (_measure_ticks > USEC2TICK(_cycling_rate)) {
+		if (_measure_interval > _cycling_rate) {
 
 			/* schedule a fresh cycle call when we are ready to measure again */
-			work_queue(HPWORK,
-				   &_work,
-				   (worker_t)&MB12XX::cycle_trampoline,
-				   this,
-				   _measure_ticks - USEC2TICK(_cycling_rate));
+			ScheduleDelayed(_measure_interval - _cycling_rate);
+
 			return;
 		}
 	}
@@ -611,12 +585,7 @@ MB12XX::cycle()
 	_collect_phase = true;
 
 	/* schedule a fresh cycle call when the measurement is done */
-	work_queue(HPWORK,
-		   &_work,
-		   (worker_t)&MB12XX::cycle_trampoline,
-		   this,
-		   USEC2TICK(_cycling_rate));
-
+	ScheduleDelayed(_cycling_rate);
 }
 
 void
@@ -624,7 +593,7 @@ MB12XX::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	printf("poll interval:  %u ticks\n", _measure_ticks);
+	printf("poll interval:  %u\n", _measure_interval);
 	_reports->print_info("report queue");
 }
 

--- a/src/drivers/distance_sensor/sf0x/sf0x.cpp
+++ b/src/drivers/distance_sensor/sf0x/sf0x.cpp
@@ -41,7 +41,7 @@
 
 #include <px4_config.h>
 #include <px4_getopt.h>
-#include <px4_workqueue.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 #include <sys/types.h>
 #include <stdint.h>
@@ -71,25 +71,21 @@
 
 /* Configuration Constants */
 
-#ifndef CONFIG_SCHED_WORKQUEUE
-# error This requires CONFIG_SCHED_WORKQUEUE.
-#endif
-
 #define SF0X_TAKE_RANGE_REG		'd'
 
 // designated SERIAL4/5 on Pixhawk
 #define SF0X_DEFAULT_PORT		"/dev/ttyS6"
 
-class SF0X : public cdev::CDev
+class SF0X : public cdev::CDev, public px4::ScheduledWorkItem
 {
 public:
 	SF0X(const char *port = SF0X_DEFAULT_PORT, uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING);
 	virtual ~SF0X();
 
-	virtual int 			init();
+	virtual int 			init() override;
 
-	virtual ssize_t			read(device::file_t *filp, char *buffer, size_t buflen);
-	virtual int			ioctl(device::file_t *filp, int cmd, unsigned long arg);
+	virtual ssize_t			read(device::file_t *filp, char *buffer, size_t buflen) override;
+	virtual int			ioctl(device::file_t *filp, int cmd, unsigned long arg) override;
 
 	/**
 	* Diagnostics - print some basic information about the driver.
@@ -102,9 +98,8 @@ private:
 	float				_min_distance;
 	float				_max_distance;
 	int         		        _conversion_interval;
-	work_s				_work{};
 	ringbuffer::RingBuffer		*_reports;
-	int				_measure_ticks;
+	int				_measure_interval;
 	bool				_collect_phase;
 	int				_fd;
 	char				_linebuf[10];
@@ -149,17 +144,9 @@ private:
 	* Perform a poll cycle; collect from the previous measurement
 	* and start a new one.
 	*/
-	void				cycle();
+	void				Run() override;
 	int				measure();
 	int				collect();
-	/**
-	* Static trampoline from the workq context; because we don't have a
-	* generic workq wrapper yet.
-	*
-	* @param arg		Instance pointer for the driver that is polling.
-	*/
-	static void			cycle_trampoline(void *arg);
-
 
 };
 
@@ -170,12 +157,13 @@ extern "C" __EXPORT int sf0x_main(int argc, char *argv[]);
 
 SF0X::SF0X(const char *port, uint8_t rotation) :
 	CDev(RANGE_FINDER0_DEVICE_PATH),
+	ScheduledWorkItem(px4::wq_configurations::hp_default),
 	_rotation(rotation),
 	_min_distance(0.30f),
 	_max_distance(40.0f),
 	_conversion_interval(83334),
 	_reports(nullptr),
-	_measure_ticks(0),
+	_measure_interval(0),
 	_collect_phase(false),
 	_fd(-1),
 	_linebuf_index(0),
@@ -190,6 +178,7 @@ SF0X::SF0X(const char *port, uint8_t rotation) :
 {
 	/* store port name */
 	strncpy(_port, port, sizeof(_port));
+
 	/* enforce null termination */
 	_port[sizeof(_port) - 1] = '\0';
 
@@ -332,10 +321,10 @@ SF0X::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			/* set default polling rate */
 			case SENSOR_POLLRATE_DEFAULT: {
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
 					/* set interval for next measurement to minimum legal value */
-					_measure_ticks = USEC2TICK(_conversion_interval);
+					_measure_interval = (_conversion_interval);
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -349,18 +338,18 @@ SF0X::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			default: {
 
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
 					/* convert hz to tick interval via microseconds */
-					int ticks = USEC2TICK(1000000 / arg);
+					int interval = (1000000 / arg);
 
 					/* check against maximum rate */
-					if (ticks < USEC2TICK(_conversion_interval)) {
+					if (interval < (_conversion_interval)) {
 						return -EINVAL;
 					}
 
 					/* update interval for next measurement */
-					_measure_ticks = ticks;
+					_measure_interval = interval;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -391,7 +380,7 @@ SF0X::read(device::file_t *filp, char *buffer, size_t buflen)
 	}
 
 	/* if automatic measurement is enabled */
-	if (_measure_ticks > 0) {
+	if (_measure_interval > 0) {
 
 		/*
 		 * While there is space in the caller's buffer, and reports, copy them.
@@ -463,8 +452,6 @@ SF0X::measure()
 int
 SF0X::collect()
 {
-	int	ret;
-
 	perf_begin(_sample_perf);
 
 	/* clear buffer if last read was too long ago */
@@ -475,7 +462,7 @@ SF0X::collect()
 	unsigned readlen = sizeof(readbuf) - 1;
 
 	/* read from the sensor (uart buffer) */
-	ret = ::read(_fd, &readbuf[0], readlen);
+	int ret = ::read(_fd, &readbuf[0], readlen);
 
 	if (ret < 0) {
 		PX4_DEBUG("read err: %d", ret);
@@ -546,26 +533,17 @@ SF0X::start()
 	_reports->flush();
 
 	/* schedule a cycle to start things */
-	work_queue(HPWORK, &_work, (worker_t)&SF0X::cycle_trampoline, this, 1);
-
+	ScheduleNow();
 }
 
 void
 SF0X::stop()
 {
-	work_cancel(HPWORK, &_work);
+	ScheduleClear();
 }
 
 void
-SF0X::cycle_trampoline(void *arg)
-{
-	SF0X *dev = static_cast<SF0X *>(arg);
-
-	dev->cycle();
-}
-
-void
-SF0X::cycle()
+SF0X::Run()
 {
 	/* fds initialized? */
 	if (_fd < 0) {
@@ -614,11 +592,8 @@ SF0X::cycle()
 
 		if (collect_ret == -EAGAIN) {
 			/* reschedule to grab the missing bits, time to transmit 8 bytes @ 9600 bps */
-			work_queue(HPWORK,
-				   &_work,
-				   (worker_t)&SF0X::cycle_trampoline,
-				   this,
-				   USEC2TICK(1042 * 8));
+			ScheduleDelayed(1042 * 8);
+
 			return;
 		}
 
@@ -646,14 +621,10 @@ SF0X::cycle()
 		/*
 		 * Is there a collect->measure gap?
 		 */
-		if (_measure_ticks > USEC2TICK(_conversion_interval)) {
+		if (_measure_interval > (_conversion_interval)) {
 
 			/* schedule a fresh cycle call when we are ready to measure again */
-			work_queue(HPWORK,
-				   &_work,
-				   (worker_t)&SF0X::cycle_trampoline,
-				   this,
-				   _measure_ticks - USEC2TICK(_conversion_interval));
+			ScheduleDelayed(_measure_interval - _conversion_interval);
 
 			return;
 		}
@@ -668,11 +639,7 @@ SF0X::cycle()
 	_collect_phase = true;
 
 	/* schedule a fresh cycle call when the measurement is done */
-	work_queue(HPWORK,
-		   &_work,
-		   (worker_t)&SF0X::cycle_trampoline,
-		   this,
-		   USEC2TICK(_conversion_interval));
+	ScheduleDelayed(_conversion_interval);
 }
 
 void
@@ -680,7 +647,7 @@ SF0X::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	printf("poll interval:  %d ticks\n", _measure_ticks);
+	printf("poll interval:  %d\n", _measure_interval);
 	_reports->print_info("report queue");
 }
 

--- a/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
+++ b/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
@@ -44,7 +44,7 @@
 #include <px4_config.h>
 #include <px4_defines.h>
 #include <px4_getopt.h>
-#include <px4_workqueue.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 #include <px4_module.h>
 
 #include <drivers/device/i2c.h>
@@ -78,21 +78,18 @@
 #define SF1XX_DEVICE_PATH	"/dev/sf1xx"
 
 
-#ifndef CONFIG_SCHED_WORKQUEUE
-# error This requires CONFIG_SCHED_WORKQUEUE.
-#endif
-
-class SF1XX : public device::I2C
+class SF1XX : public device::I2C, public px4::ScheduledWorkItem
 {
 public:
 	SF1XX(uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING, int bus = SF1XX_BUS_DEFAULT,
 	      int address = SF1XX_BASEADDR);
-	virtual ~SF1XX();
 
-	virtual int init();
+	virtual ~SF1XX() override;
 
-	virtual ssize_t read(device::file_t *filp, char *buffer, size_t buflen);
-	virtual int ioctl(device::file_t *filp, int cmd, unsigned long arg);
+	int init() override;
+
+	ssize_t read(device::file_t *filp, char *buffer, size_t buflen) override;
+	int ioctl(device::file_t *filp, int cmd, unsigned long arg) override;
 
 	/**
 	* Diagnostics - print some basic information about the driver.
@@ -100,7 +97,7 @@ public:
 	void print_info();
 
 protected:
-	virtual int probe();
+	int probe() override;
 
 private:
 	/**
@@ -139,31 +136,21 @@ private:
 	* Perform a poll cycle; collect from the previous measurement
 	* and start a new one.
 	*/
-	void cycle();
+	void Run() override;
 	int measure();
 	int collect();
-
-	/**
-	* Static trampoline from the workq context; because we don't have a
-	* generic workqueue wrapper yet.
-	*
-	* @param arg Instance pointer for the driver that is polling.
-	*/
-	static void cycle_trampoline(void *arg);
 
 	bool _sensor_ok{false};
 
 	int _class_instance{-1};
 	int _conversion_interval{-1};
-	int _measure_ticks{0};
+	int _measure_interval{0};
 	int _orb_class_instance{-1};
 
 	float _max_distance{-1.0f};
 	float _min_distance{-1.0f};
 
 	uint8_t _rotation{0};
-
-	work_s _work{};
 
 	ringbuffer::RingBuffer  *_reports{nullptr};
 
@@ -180,6 +167,7 @@ extern "C" __EXPORT int sf1xx_main(int argc, char *argv[]);
 
 SF1XX::SF1XX(uint8_t rotation, int bus, int address) :
 	I2C("SF1XX", SF1XX_DEVICE_PATH, bus, address, 400000),
+	ScheduledWorkItem(px4::device_bus_to_wq(get_device_id())),
 	_rotation(rotation)
 {
 }
@@ -340,10 +328,10 @@ SF1XX::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			/* set default polling rate */
 			case SENSOR_POLLRATE_DEFAULT: {
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
 					/* set interval for next measurement to minimum legal value */
-					_measure_ticks = USEC2TICK(_conversion_interval);
+					_measure_interval = (_conversion_interval);
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -357,18 +345,18 @@ SF1XX::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			/* adjust to a legal polling interval in Hz */
 			default: {
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
 					/* convert hz to tick interval via microseconds */
-					int ticks = USEC2TICK(1000000 / arg);
+					int interval = (1000000 / arg);
 
 					/* check against maximum rate */
-					if (ticks < USEC2TICK(_conversion_interval)) {
+					if (interval < _conversion_interval) {
 						return -EINVAL;
 					}
 
 					/* update interval for next measurement */
-					_measure_ticks = ticks;
+					_measure_interval = interval;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -399,7 +387,7 @@ SF1XX::read(device::file_t *filp, char *buffer, size_t buflen)
 	}
 
 	/* if automatic measurement is enabled */
-	if (_measure_ticks > 0) {
+	if (_measure_interval > 0) {
 
 		/*
 		 * While there is space in the caller's buffer, and reports, copy them.
@@ -528,25 +516,17 @@ SF1XX::start()
 	measure();
 
 	/* schedule a cycle to start things */
-	work_queue(HPWORK, &_work, (worker_t)&SF1XX::cycle_trampoline, this, USEC2TICK(_conversion_interval));
+	ScheduleDelayed(_conversion_interval);
 }
 
 void
 SF1XX::stop()
 {
-	work_cancel(HPWORK, &_work);
+	ScheduleClear();
 }
 
 void
-SF1XX::cycle_trampoline(void *arg)
-{
-	SF1XX *dev = (SF1XX *)arg;
-
-	dev->cycle();
-}
-
-void
-SF1XX::cycle()
+SF1XX::Run()
 {
 	/* Collect results */
 	if (OK != collect()) {
@@ -557,12 +537,7 @@ SF1XX::cycle()
 	}
 
 	/* schedule a fresh cycle call when the measurement is done */
-	work_queue(HPWORK,
-		   &_work,
-		   (worker_t)&SF1XX::cycle_trampoline,
-		   this,
-		   USEC2TICK(_conversion_interval));
-
+	ScheduleDelayed(_conversion_interval);
 }
 
 void
@@ -570,7 +545,7 @@ SF1XX::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	printf("poll interval:  %u ticks\n", _measure_ticks);
+	printf("poll interval:  %u\n", _measure_interval);
 	_reports->print_info("report queue");
 }
 

--- a/src/drivers/distance_sensor/tfmini/tfmini.cpp
+++ b/src/drivers/distance_sensor/tfmini/tfmini.cpp
@@ -43,7 +43,7 @@
  */
 
 #include <px4_config.h>
-#include <px4_workqueue.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 #include <px4_getopt.h>
 #include <px4_module.h>
 
@@ -82,20 +82,16 @@
 
 /* Configuration Constants */
 
-#ifndef CONFIG_SCHED_WORKQUEUE
-# error This requires CONFIG_SCHED_WORKQUEUE.
-#endif
-
-class TFMINI : public cdev::CDev
+class TFMINI : public cdev::CDev, public px4::ScheduledWorkItem
 {
 public:
 	TFMINI(const char *port, uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING);
 	virtual ~TFMINI();
 
-	virtual int init();
+	virtual int init() override;
 
-	virtual ssize_t read(device::file_t *filp, char *buffer, size_t buflen);
-	virtual int ioctl(device::file_t *filp, int cmd, unsigned long arg);
+	virtual ssize_t read(device::file_t *filp, char *buffer, size_t buflen) override;
+	virtual int ioctl(device::file_t *filp, int cmd, unsigned long arg) override;
 
 	/**
 	* Diagnostics - print some basic information about the driver.
@@ -108,9 +104,8 @@ private:
 	float                    _min_distance;
 	float                    _max_distance;
 	int                      _conversion_interval;
-	work_s                   _work{};
 	ringbuffer::RingBuffer  *_reports;
-	int                      _measure_ticks;
+	int                      _measure_interval;
 	bool                     _collect_phase;
 	int                      _fd;
 	char                     _linebuf[10];
@@ -151,17 +146,8 @@ private:
 	* Perform a poll cycle; collect from the previous measurement
 	* and start a new one.
 	*/
-	void				cycle();
+	void				Run() override;
 	int				collect();
-
-	/**
-	* Static trampoline from the workq context; because we don't have a
-	* generic workq wrapper yet.
-	*
-	* @param arg		Instance pointer for the driver that is polling.
-	*/
-	static void			cycle_trampoline(void *arg);
-
 
 };
 
@@ -172,12 +158,13 @@ extern "C" __EXPORT int tfmini_main(int argc, char *argv[]);
 
 TFMINI::TFMINI(const char *port, uint8_t rotation) :
 	CDev(RANGE_FINDER0_DEVICE_PATH),
+	ScheduledWorkItem(px4::wq_configurations::hp_default),
 	_rotation(rotation),
 	_min_distance(0.30f),
 	_max_distance(12.0f),
 	_conversion_interval(9000),
 	_reports(nullptr),
-	_measure_ticks(0),
+	_measure_interval(0),
 	_collect_phase(false),
 	_fd(-1),
 	_linebuf_index(0),
@@ -191,6 +178,7 @@ TFMINI::TFMINI(const char *port, uint8_t rotation) :
 {
 	/* store port name */
 	strncpy(_port, port, sizeof(_port));
+
 	/* enforce null termination */
 	_port[sizeof(_port) - 1] = '\0';
 }
@@ -370,10 +358,10 @@ TFMINI::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			/* set default polling rate */
 			case SENSOR_POLLRATE_DEFAULT: {
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
 					/* set interval for next measurement to minimum legal value */
-					_measure_ticks = USEC2TICK(_conversion_interval);
+					_measure_interval = (_conversion_interval);
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -387,18 +375,18 @@ TFMINI::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			default: {
 
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
 					/* convert hz to tick interval via microseconds */
-					int ticks = USEC2TICK(1000000 / arg);
+					int interval = (1000000 / arg);
 
 					/* check against maximum rate */
-					if (ticks < USEC2TICK(_conversion_interval)) {
+					if (interval < _conversion_interval) {
 						return -EINVAL;
 					}
 
 					/* update interval for next measurement */
-					_measure_ticks = ticks;
+					_measure_interval = interval;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -429,7 +417,7 @@ TFMINI::read(device::file_t *filp, char *buffer, size_t buflen)
 	}
 
 	/* if automatic measurement is enabled */
-	if (_measure_ticks > 0) {
+	if (_measure_interval > 0) {
 
 		/*
 		 * While there is space in the caller's buffer, and reports, copy them.
@@ -567,25 +555,17 @@ TFMINI::start()
 	_reports->flush();
 
 	/* schedule a cycle to start things */
-	work_queue(HPWORK, &_work, (worker_t)&TFMINI::cycle_trampoline, this, 1);
+	ScheduleNow();
 }
 
 void
 TFMINI::stop()
 {
-	work_cancel(HPWORK, &_work);
+	ScheduleClear();
 }
 
 void
-TFMINI::cycle_trampoline(void *arg)
-{
-	TFMINI *dev = (TFMINI *)arg;
-
-	dev->cycle();
-}
-
-void
-TFMINI::cycle()
+TFMINI::Run()
 {
 	/* fds initialized? */
 	if (_fd < 0) {
@@ -601,11 +581,8 @@ TFMINI::cycle()
 
 		if (collect_ret == -EAGAIN) {
 			/* reschedule to grab the missing bits, time to transmit 9 bytes @ 115200 bps */
-			work_queue(HPWORK,
-				   &_work,
-				   (worker_t)&TFMINI::cycle_trampoline,
-				   this,
-				   USEC2TICK(87 * 9));
+			ScheduleDelayed(87 * 9);
+
 			return;
 		}
 
@@ -615,14 +592,10 @@ TFMINI::cycle()
 		/*
 		 * Is there a collect->measure gap?
 		 */
-		if (_measure_ticks > USEC2TICK(_conversion_interval)) {
-
-			/* schedule a fresh cycle call when we are ready to measure again */
-			work_queue(HPWORK,
-				   &_work,
-				   (worker_t)&TFMINI::cycle_trampoline,
-				   this,
-				   _measure_ticks - USEC2TICK(_conversion_interval));
+		if (_measure_interval > (_conversion_interval)) {
+			/* schedule a fresh cycle call when
+			 * we are ready to measure again */
+			ScheduleDelayed(_measure_interval - _conversion_interval);
 
 			return;
 		}
@@ -632,11 +605,7 @@ TFMINI::cycle()
 	_collect_phase = true;
 
 	/* schedule a fresh cycle call when the measurement is done */
-	work_queue(HPWORK,
-		   &_work,
-		   (worker_t)&TFMINI::cycle_trampoline,
-		   this,
-		   USEC2TICK(_conversion_interval));
+	ScheduleDelayed(_conversion_interval);
 }
 
 void
@@ -645,7 +614,7 @@ TFMINI::print_info()
 	printf("Using port '%s'\n", _port);
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	printf("poll interval:  %d ticks\n", _measure_ticks);
+	printf("poll interval:  %d \n", _measure_interval);
 	_reports->print_info("report queue");
 }
 

--- a/src/drivers/distance_sensor/vl53lxx/vl53lxx.cpp
+++ b/src/drivers/distance_sensor/vl53lxx/vl53lxx.cpp
@@ -41,7 +41,7 @@
 #include <px4_config.h>
 #include <px4_defines.h>
 #include <px4_getopt.h>
-#include <px4_workqueue.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 #include <drivers/device/i2c.h>
 
@@ -101,11 +101,7 @@
 #define VL53LXX_MAX_RANGING_DISTANCE 2.0f
 #define VL53LXX_MIN_RANGING_DISTANCE 0.0f
 
-#ifndef CONFIG_SCHED_WORKQUEUE
-# error This requires CONFIG_SCHED_WORKQUEUE.
-#endif
-
-class VL53LXX : public device::I2C
+class VL53LXX : public device::I2C, public px4::ScheduledWorkItem
 {
 public:
 	VL53LXX(uint8_t rotation = distance_sensor_s::ROTATION_DOWNWARD_FACING,
@@ -113,11 +109,11 @@ public:
 
 	virtual ~VL53LXX();
 
-	virtual int init();
+	virtual int init() override;
 
-	virtual ssize_t read(device::file_t *filp, char *buffer, size_t buflen);
+	virtual ssize_t read(device::file_t *filp, char *buffer, size_t buflen) override;
 
-	virtual int ioctl(device::file_t *filp, int cmd, unsigned long arg);
+	virtual int ioctl(device::file_t *filp, int cmd, unsigned long arg) override;
 
 	/**
 	* Diagnostics - print some basic information about the driver.
@@ -125,14 +121,13 @@ public:
 	void print_info();
 
 protected:
-	virtual int probe();
+	virtual int probe() override;
 
 private:
 	uint8_t _rotation;
-	work_s _work;
 	ringbuffer::RingBuffer *_reports;
 	bool _sensor_ok;
-	int _measure_ticks;
+	int _measure_interval;
 	bool _collect_phase;
 	bool _new_measurement;
 	bool _measurement_started;
@@ -162,7 +157,7 @@ private:
 	* Perform a poll cycle; collect from the previous measurement
 	* and start a new one.
 	*/
-	void cycle();
+	void Run() override;
 	int measure();
 	int collect();
 
@@ -176,15 +171,6 @@ private:
 	bool spadCalculations();
 	bool sensorTuning();
 	bool singleRefCalibration(uint8_t byte);
-
-	/**
-	* Static trampoline from the workq context; because we don't have a
-	* generic workq wrapper yet.
-	*
-	* @param arg		Instance pointer for the driver that is polling.
-	*/
-	static void cycle_trampoline(void *arg);
-
 };
 
 
@@ -195,10 +181,11 @@ extern "C" __EXPORT int vl53lxx_main(int argc, char *argv[]);
 
 VL53LXX::VL53LXX(uint8_t rotation, int bus, int address) :
 	I2C("VL53LXX", VL53LXX_DEVICE_PATH, bus, address, 400000),
+	ScheduledWorkItem(px4::device_bus_to_wq(get_device_id())),
 	_rotation(rotation),
 	_reports(nullptr),
 	_sensor_ok(false),
-	_measure_ticks(0),
+	_measure_interval(0),
 	_collect_phase(false),
 	_new_measurement(true),
 	_measurement_started(false),
@@ -211,12 +198,6 @@ VL53LXX::VL53LXX(uint8_t rotation, int bus, int address) :
 {
 	// up the retries since the device misses the first measure attempts
 	I2C::_retries = 3;
-
-	// enable debug() calls
-	_debug_enabled = false;
-
-	// work_cancel in the dtor will explode if we don't do this...
-	memset(&_work, 0, sizeof(_work));
 }
 
 VL53LXX::~VL53LXX()
@@ -351,10 +332,10 @@ VL53LXX::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 
 			case SENSOR_POLLRATE_DEFAULT: {
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
 					/* set interval for next measurement to minimum legal value */
-					_measure_ticks = USEC2TICK(VL53LXX_SAMPLE_RATE);
+					_measure_interval = (VL53LXX_SAMPLE_RATE);
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -369,13 +350,13 @@ VL53LXX::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			/* adjust to a legal polling interval in Hz */
 			default: {
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
 					/* convert hz to tick interval via microseconds */
-					unsigned ticks = USEC2TICK(1000000 / arg);
+					unsigned interval = (1000000 / arg);
 
 					/* update interval for next measurement */
-					_measure_ticks = ticks;
+					_measure_interval = interval;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -407,7 +388,7 @@ VL53LXX::read(device::file_t *filp, char *buffer, size_t buflen)
 	}
 
 	/* if automatic measurement is enabled */
-	if (_measure_ticks > 0) {
+	if (_measure_interval > 0) {
 
 		/*
 		 * While there is space in the caller's buffer, and reports, copy them.
@@ -585,8 +566,8 @@ VL53LXX::measure()
 		readRegister(SYSRANGE_START_REG, system_start);
 
 		if ((system_start & 0x01) == 1) {
-			work_queue(LPWORK, &_work, (worker_t)&VL53LXX::cycle_trampoline, this,
-				   USEC2TICK(VL53LXX_US));		// reschedule every 1 ms until measurement is ready
+			ScheduleDelayed(VL53LXX_US);
+
 			ret = OK;
 			return ret;
 
@@ -601,8 +582,7 @@ VL53LXX::measure()
 		readRegister(SYSRANGE_START_REG, system_start);
 
 		if ((system_start & 0x01) == 1) {
-			work_queue(LPWORK, &_work, (worker_t)&VL53LXX::cycle_trampoline, this,
-				   USEC2TICK(VL53LXX_US));		// reschedule every 1 ms until measurement is ready
+			ScheduleDelayed(VL53LXX_US);
 			ret = OK;
 			return ret;
 
@@ -614,8 +594,7 @@ VL53LXX::measure()
 	readRegister(RESULT_INTERRUPT_STATUS_REG, wait_for_measurement);
 
 	if ((wait_for_measurement & 0x07) == 0) {
-		work_queue(LPWORK, &_work, (worker_t)&VL53LXX::cycle_trampoline, this,
-			   USEC2TICK(VL53LXX_US));		// reschedule every 1 ms until measurement is ready
+		ScheduleDelayed(VL53LXX_US); // reschedule every 1 ms until measurement is ready
 		ret = OK;
 		return ret;
 	}
@@ -699,28 +678,17 @@ VL53LXX::start()
 	_reports->flush();
 
 	/* schedule a cycle to start things */
-	work_queue(LPWORK, &_work, (worker_t)&VL53LXX::cycle_trampoline, this, USEC2TICK(VL53LXX_US));
+	ScheduleDelayed(VL53LXX_US);
 }
-
 
 void
 VL53LXX::stop()
 {
-	work_cancel(LPWORK, &_work);
+	ScheduleClear();
 }
 
-
 void
-VL53LXX::cycle_trampoline(void *arg)
-{
-	VL53LXX *dev = (VL53LXX *)arg;
-
-	dev->cycle();
-}
-
-
-void
-VL53LXX::cycle()
+VL53LXX::Run()
 {
 	measure();
 
@@ -731,25 +699,18 @@ VL53LXX::cycle()
 
 		collect();
 
-		work_queue(LPWORK,
-			   &_work,
-			   (worker_t)&VL53LXX::cycle_trampoline,
-			   this,
-			   _measure_ticks);
+		ScheduleDelayed(_measure_interval);
 	}
-
 }
-
 
 void
 VL53LXX::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	printf("poll interval:  %u ticks\n", _measure_ticks);
+	printf("poll interval:  %u\n", _measure_interval);
 	_reports->print_info("report queue");
 }
-
 
 bool
 VL53LXX::spadCalculations()

--- a/src/drivers/imu/adis16448/adis16448.cpp
+++ b/src/drivers/imu/adis16448/adis16448.cpp
@@ -68,7 +68,6 @@
 #include <nuttx/clock.h>
 
 #include <board_config.h>
-#include <drivers/drv_hrt.h>
 
 #include <drivers/device/spi.h>
 #include <drivers/device/ringbuffer.h>
@@ -80,6 +79,7 @@
 #include <drivers/drv_mag.h>
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
 #include <lib/conversion/rotation.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 #define DIR_READ				0x00
 #define DIR_WRITE				0x80
@@ -185,7 +185,7 @@
 class ADIS16448_gyro;
 class ADIS16448_mag;
 
-class ADIS16448 : public device::SPI
+class ADIS16448 : public device::SPI, public px4::ScheduledWorkItem
 {
 public:
 	ADIS16448(int bus, const char *path_accel, const char *path_gyro, const char *path_mag, uint32_t device,
@@ -224,7 +224,6 @@ private:
 
 	uint16_t			_product;	/** product code */
 
-	struct hrt_call		_call;
 	unsigned			_call_interval;
 
 	ringbuffer::RingBuffer			*_gyro_reports;
@@ -324,16 +323,7 @@ private:
 	 */
 	int			reset();
 
-	/**
-	 * Static trampoline from the hrt_call context; because we don't have a
-	 * generic hrt wrapper yet.
-	 *
-	 * Called by the HRT in interrupt context at the specified rate if
-	 * automatic polling is enabled.
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		measure_trampoline(void *arg);
+	void		Run() override;
 
 	/**
 	 * Fetch measurements from the sensor and update the report buffers.
@@ -471,10 +461,10 @@ extern "C" { __EXPORT int adis16448_main(int argc, char *argv[]); }
 ADIS16448::ADIS16448(int bus, const char *path_accel, const char *path_gyro, const char *path_mag, uint32_t device,
 		     enum Rotation rotation) :
 	SPI("ADIS16448", path_accel, bus, device, SPIDEV_MODE3, SPI_BUS_SPEED),
+	ScheduledWorkItem(px4::device_bus_to_wq(this->get_device_id())),
 	_gyro(new ADIS16448_gyro(this, path_gyro)),
 	_mag(new ADIS16448_mag(this, path_mag)),
 	_product(0),
-	_call{},
 	_call_interval(0),
 	_gyro_reports(nullptr),
 	_gyro_scale{},
@@ -544,8 +534,6 @@ ADIS16448::ADIS16448(int bus, const char *path_accel, const char *path_gyro, con
 	_mag_scale.y_scale  = 1.0f;
 	_mag_scale.z_offset = 0;
 	_mag_scale.z_scale  = 1.0f;
-
-	memset(&_call, 0, sizeof(_call));
 }
 
 ADIS16448::~ADIS16448()
@@ -994,16 +982,16 @@ ADIS16448::ioctl(struct file *filp, int cmd, unsigned long arg)
 					bool want_start = (_call_interval == 0);
 
 					/* convert hz to hrt interval via microseconds */
-					unsigned ticks = 1000000 / arg;
+					unsigned interval = 1000000 / arg;
 
 					/* check against maximum sane rate */
-					if (ticks < 1000) {
+					if (interval < 1000) {
 						return -EINVAL;
 					}
 
 					// adjust filters
 					float cutoff_freq_hz = _accel_filter_x.get_cutoff_freq();
-					float sample_rate = 1.0e6f / ticks;
+					float sample_rate = 1.0e6f / interval;
 					_accel_filter_x.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
 					_accel_filter_y.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
 					_accel_filter_z.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
@@ -1022,7 +1010,7 @@ ADIS16448::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 					/* update interval for next measurement */
 					/* XXX this is a bit shady, but no other way to adjust... */
-					_call.period = _call_interval = ticks;
+					_call_interval = interval;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -1171,23 +1159,19 @@ ADIS16448::start()
 	_mag_reports->flush();
 
 	/* start polling at the specified rate */
-	hrt_call_every(&_call, 1000, _call_interval, (hrt_callout)&ADIS16448::measure_trampoline, this);
-
+	ScheduleOnInterval(_call_interval, 10000);
 }
 
 void
 ADIS16448::stop()
 {
-	hrt_cancel(&_call);
+	ScheduleClear();
 }
 
 void
-ADIS16448::measure_trampoline(void *arg)
+ADIS16448::Run()
 {
-	ADIS16448 *dev = reinterpret_cast<ADIS16448 *>(arg);
-
-	/* make another measurement */
-	dev->measure();
+	measure();
 }
 
 int

--- a/src/drivers/imu/adis16477/ADIS16477.cpp
+++ b/src/drivers/imu/adis16477/ADIS16477.cpp
@@ -79,6 +79,7 @@ using namespace time_literals;
 
 ADIS16477::ADIS16477(int bus, const char *path_accel, const char *path_gyro, uint32_t device, enum Rotation rotation) :
 	SPI("ADIS16477", path_accel, bus, device, SPIDEV_MODE3, 1000000),
+	ScheduledWorkItem(px4::device_bus_to_wq(this->get_device_id())),
 	_gyro(new ADIS16477_gyro(this, path_gyro)),
 	_sample_perf(perf_alloc(PC_ELAPSED, "adis16477_read")),
 	_bad_transfers(perf_alloc(PC_COUNT, "adis16477_bad_transfers")),
@@ -358,16 +359,16 @@ ADIS16477::ioctl(struct file *filp, int cmd, unsigned long arg)
 					bool want_start = (_call_interval == 0);
 
 					/* convert hz to hrt interval via microseconds */
-					unsigned ticks = 1000000 / arg;
+					unsigned interval = 1000000 / arg;
 
 					/* check against maximum sane rate */
-					if (ticks < 1000) {
+					if (interval < 1000) {
 						return -EINVAL;
 					}
 
 					// adjust filters
 					float cutoff_freq_hz = _accel_filter_x.get_cutoff_freq();
-					float sample_rate = 1.0e6f / ticks;
+					float sample_rate = 1.0e6f / interval;
 					_accel_filter_x.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
 					_accel_filter_y.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
 					_accel_filter_z.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
@@ -379,7 +380,7 @@ ADIS16477::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 					/* update interval for next measurement */
 					/* XXX this is a bit shady, but no other way to adjust... */
-					_call.period = _call_interval = ticks;
+					_call_interval = interval;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -478,22 +479,20 @@ ADIS16477::start()
 	_call_interval = last_call_interval;
 
 	/* start polling at the specified rate */
-	hrt_call_every(&_call, 1000, _call_interval, (hrt_callout)&ADIS16477::measure_trampoline, this);
+	ScheduleOnInterval(_call_interval, 10000);
 }
 
 void
 ADIS16477::stop()
 {
-	hrt_cancel(&_call);
+	ScheduleClear();
 }
 
 void
-ADIS16477::measure_trampoline(void *arg)
+ADIS16477::Run()
 {
-	ADIS16477 *dev = reinterpret_cast<ADIS16477 *>(arg);
-
 	/* make another measurement */
-	dev->measure();
+	measure();
 }
 
 int

--- a/src/drivers/imu/bmi055/BMI055.hpp
+++ b/src/drivers/imu/bmi055/BMI055.hpp
@@ -41,6 +41,7 @@
 #include <px4_config.h>
 #include <systemlib/conversions.h>
 #include <systemlib/err.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 #define DIR_READ                0x80
 #define DIR_WRITE               0x00
@@ -59,7 +60,6 @@ protected:
 
 	uint8_t         _whoami;    /** whoami result */
 
-	struct hrt_call     _call;
 	unsigned        _call_interval;
 
 	uint8_t         _register_wait;

--- a/src/drivers/imu/bmi055/BMI055_accel.hpp
+++ b/src/drivers/imu/bmi055/BMI055_accel.hpp
@@ -148,7 +148,7 @@
 /* Mask definitions for ACCD_X_LSB, ACCD_Y_LSB and ACCD_Z_LSB Register */
 #define BMI055_NEW_DATA_MASK                 0x01
 
-class BMI055_accel : public BMI055
+class BMI055_accel : public BMI055, public px4::ScheduledWorkItem
 {
 public:
 	BMI055_accel(int bus, const char *path_accel, uint32_t device, enum Rotation rotation);
@@ -227,16 +227,7 @@ private:
 	 */
 	int         reset();
 
-	/**
-	 * Static trampoline from the hrt_call context; because we don't have a
-	 * generic hrt wrapper yet.
-	 *
-	 * Called by the HRT in interrupt context at the specified rate if
-	 * automatic polling is enabled.
-	 *
-	 * @param arg       Instance pointer for the driver that is polling.
-	 */
-	static void     measure_trampoline(void *arg);
+	void     Run() override;
 
 	/**
 	 * Fetch measurements from the sensor and update the report buffers.

--- a/src/drivers/imu/bmi055/BMI055_gyro.hpp
+++ b/src/drivers/imu/bmi055/BMI055_gyro.hpp
@@ -140,7 +140,7 @@
 
 #define BMI055_ACC_TEMP             0x08
 
-class BMI055_gyro : public BMI055
+class BMI055_gyro : public BMI055, public px4::ScheduledWorkItem
 {
 public:
 	BMI055_gyro(int bus, const char *path_gyro, uint32_t device, enum Rotation rotation);
@@ -218,16 +218,7 @@ private:
 	 */
 	int         reset();
 
-	/**
-	 * Static trampoline from the hrt_call context; because we don't have a
-	 * generic hrt wrapper yet.
-	 *
-	 * Called by the HRT in interrupt context at the specified rate if
-	 * automatic polling is enabled.
-	 *
-	 * @param arg       Instance pointer for the driver that is polling.
-	 */
-	static void     measure_trampoline(void *arg);
+	void     Run() override;
 
 	/**
 	 * Fetch measurements from the sensor and update the report buffers.

--- a/src/drivers/imu/bmi055/bmi055_main.cpp
+++ b/src/drivers/imu/bmi055/bmi055_main.cpp
@@ -446,7 +446,6 @@ BMI055::BMI055(const char *name, const char *devname, int bus, uint32_t device, 
 	       uint32_t frequency, enum Rotation rotation):
 	SPI(name, devname, bus, device, mode, frequency),
 	_whoami(0),
-	_call{},
 	_call_interval(0),
 	_register_wait(0),
 	_reset_wait(0),

--- a/src/drivers/imu/bmi160/bmi160.cpp
+++ b/src/drivers/imu/bmi160/bmi160.cpp
@@ -20,9 +20,9 @@ const uint8_t BMI160::_checked_registers[BMI160_NUM_CHECKED_REGISTERS] = {    BM
 
 BMI160::BMI160(int bus, const char *path_accel, const char *path_gyro, uint32_t device, enum Rotation rotation) :
 	SPI("BMI160", path_accel, bus, device, SPIDEV_MODE3, BMI160_BUS_SPEED),
+	ScheduledWorkItem(px4::device_bus_to_wq(this->get_device_id())),
 	_gyro(new BMI160_gyro(this, path_gyro)),
 	_whoami(0),
-	_call{},
 	_call_interval(0),
 	_accel_reports(nullptr),
 	_accel_scale{},
@@ -86,8 +86,6 @@ BMI160::BMI160(int bus, const char *path_accel, const char *path_gyro, uint32_t 
 	_gyro_scale.y_scale  = 1.0f;
 	_gyro_scale.z_offset = 0;
 	_gyro_scale.z_scale  = 1.0f;
-
-	memset(&_call, 0, sizeof(_call));
 }
 
 
@@ -575,16 +573,16 @@ BMI160::ioctl(struct file *filp, int cmd, unsigned long arg)
 					bool want_start = (_call_interval == 0);
 
 					/* convert hz to hrt interval via microseconds */
-					unsigned ticks = 1000000 / arg;
+					unsigned interval = 1000000 / arg;
 
 					/* check against maximum sane rate */
-					if (ticks < 1000) {
+					if (interval < 1000) {
 						return -EINVAL;
 					}
 
 					// adjust filters
 					float cutoff_freq_hz = _accel_filter_x.get_cutoff_freq();
-					float sample_rate = 1.0e6f / ticks;
+					float sample_rate = 1.0e6f / interval;
 					_accel_filter_x.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
 					_accel_filter_y.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
 					_accel_filter_z.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
@@ -597,15 +595,7 @@ BMI160::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 					/* update interval for next measurement */
 					/* XXX this is a bit shady, but no other way to adjust... */
-					_call_interval = ticks;
-
-					/*
-					  set call interval faster then the sample time. We
-					  then detect when we have duplicate samples and reject
-					  them. This prevents aliasing due to a beat between the
-					  stm32 clock and the bmi160 clock
-					 */
-					_call.period = _call_interval - BMI160_TIMER_REDUCTION;
+					_call_interval = interval;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -817,26 +807,22 @@ BMI160::start()
 	_gyro_reports->flush();
 
 	/* start polling at the specified rate */
-	hrt_call_every(&_call,
-		       1000,
-		       _call_interval - BMI160_TIMER_REDUCTION,
-		       (hrt_callout)&BMI160::measure_trampoline, this);
+	ScheduleOnInterval(_call_interval - BMI160_TIMER_REDUCTION, 1000);
+
 	reset();
 }
 
 void
 BMI160::stop()
 {
-	hrt_cancel(&_call);
+	ScheduleClear();
 }
 
 void
-BMI160::measure_trampoline(void *arg)
+BMI160::Run()
 {
-	BMI160 *dev = reinterpret_cast<BMI160 *>(arg);
-
 	/* make another measurement */
-	dev->measure();
+	measure();
 }
 
 void

--- a/src/drivers/imu/bmi160/bmi160.hpp
+++ b/src/drivers/imu/bmi160/bmi160.hpp
@@ -35,6 +35,7 @@
 #include <drivers/drv_mag.h>
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
 #include <lib/conversion/rotation.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 #define DIR_READ                0x80
 #define DIR_WRITE               0x00
@@ -243,7 +244,7 @@
 
 class BMI160_gyro;
 
-class BMI160 : public device::SPI
+class BMI160 : public device::SPI, public px4::ScheduledWorkItem
 {
 public:
 	BMI160(int bus, const char *path_accel, const char *path_gyro, uint32_t device, enum Rotation rotation);
@@ -276,7 +277,6 @@ private:
 	BMI160_gyro		*_gyro;
 	uint8_t			_whoami;	/** whoami result */
 
-	struct hrt_call		_call;
 	unsigned		_call_interval;
 
 	ringbuffer::RingBuffer	*_accel_reports;
@@ -355,16 +355,7 @@ private:
 	 */
 	int			reset();
 
-	/**
-	 * Static trampoline from the hrt_call context; because we don't have a
-	 * generic hrt wrapper yet.
-	 *
-	 * Called by the HRT in interrupt context at the specified rate if
-	 * automatic polling is enabled.
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		measure_trampoline(void *arg);
+	void			Run() override;
 
 	/**
 	 * Fetch measurements from the sensor and update the report buffers.

--- a/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
+++ b/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
@@ -78,6 +78,7 @@
 #include <lib/conversion/rotation.h>
 #include <px4_getopt.h>
 #include <systemlib/err.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 /* SPI protocol address bits */
 #define DIR_READ(a)                     ((a) & 0x7f)
@@ -159,7 +160,7 @@ extern "C" { __EXPORT int fxos8701cq_main(int argc, char *argv[]); }
 class FXOS8701CQ_mag;
 #endif
 
-class FXOS8701CQ : public device::SPI
+class FXOS8701CQ : public device::SPI, public px4::ScheduledWorkItem
 {
 public:
 	FXOS8701CQ(int bus, const char *path, uint32_t device, enum Rotation rotation);
@@ -197,9 +198,10 @@ protected:
 
 private:
 
+	void Run() override;
+
 #if !defined(BOARD_HAS_NOISY_FXOS8700_MAG)
 	FXOS8701CQ_mag		*_mag;
-	struct hrt_call   _mag_call;
 	unsigned    _call_mag_interval;
 	ringbuffer::RingBuffer    *_mag_reports;
 
@@ -212,9 +214,9 @@ private:
 	int16_t     _last_raw_mag_x;
 	int16_t     _last_raw_mag_y;
 	int16_t     _last_raw_mag_z;
-#endif
 
-	struct hrt_call		_accel_call;
+	hrt_abstime		_mag_last_measure{0};
+#endif
 
 	unsigned		_call_accel_interval;
 
@@ -284,24 +286,6 @@ private:
 	 * disable I2C on the chip
 	 */
 	void			disable_i2c();
-
-	/**
-	 * Static trampoline from the hrt_call context; because we don't have a
-	 * generic hrt wrapper yet.
-	 *
-	 * Called by the HRT in interrupt context at the specified rate if
-	 * automatic polling is enabled.
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		measure_trampoline(void *arg);
-
-	/**
-	 * Static trampoline for the mag because it runs at a lower rate
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		mag_measure_trampoline(void *arg);
 
 	/**
 	 * check key registers for correct values
@@ -456,8 +440,6 @@ private:
 
 	void				measure();
 
-	void				measure_trampoline(void *arg);
-
 	/* this class does not allow copying due to ptr data members */
 	FXOS8701CQ_mag(const FXOS8701CQ_mag &);
 	FXOS8701CQ_mag operator=(const FXOS8701CQ_mag &);
@@ -467,9 +449,9 @@ private:
 FXOS8701CQ::FXOS8701CQ(int bus, const char *path, uint32_t device, enum Rotation rotation) :
 	SPI("FXOS8701CQ", path, bus, device, SPIDEV_MODE0,
 	    1 * 1000 * 1000),
+	ScheduledWorkItem(px4::device_bus_to_wq(get_device_id())),
 #if !defined(BOARD_HAS_NOISY_FXOS8700_MAG)
 	_mag(new FXOS8701CQ_mag(this)),
-	_mag_call{},
 	_call_mag_interval(0),
 	_mag_reports(nullptr),
 	_mag_scale{},
@@ -482,7 +464,6 @@ FXOS8701CQ::FXOS8701CQ(int bus, const char *path, uint32_t device, enum Rotation
 	_last_raw_mag_y(0),
 	_last_raw_mag_z(0),
 #endif
-	_accel_call {},
 	_call_accel_interval(0),
 	_accel_reports(nullptr),
 	_accel_scale{},
@@ -819,10 +800,10 @@ FXOS8701CQ::ioctl(struct file *filp, int cmd, unsigned long arg)
 					bool want_start = (_call_accel_interval == 0);
 
 					/* convert hz to hrt interval via microseconds */
-					unsigned ticks = 1000000 / arg;
+					unsigned interval = 1000000 / arg;
 
 					/* check against maximum sane rate */
-					if (ticks < 500) {
+					if (interval < 500) {
 						return -EINVAL;
 					}
 
@@ -831,9 +812,7 @@ FXOS8701CQ::ioctl(struct file *filp, int cmd, unsigned long arg)
 
 					/* update interval for next measurement */
 					/* XXX this is a bit shady, but no other way to adjust... */
-					_call_accel_interval = ticks;
-
-					_accel_call.period = _call_accel_interval - FXOS8701C_TIMER_REDUCTION;
+					_call_accel_interval = interval;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -893,16 +872,16 @@ FXOS8701CQ::mag_ioctl(struct file *filp, int cmd, unsigned long arg)
 					bool want_start = (_call_mag_interval == 0);
 
 					/* convert hz to hrt interval via microseconds */
-					unsigned ticks = 1000000 / arg;
+					unsigned interval = 1000000 / arg;
 
 					/* check against maximum sane rate */
-					if (ticks < 1000) {
+					if (interval < 1000) {
 						return -EINVAL;
 					}
 
 					/* update interval for next measurement */
 					/* XXX this is a bit shady, but no other way to adjust... */
-					_mag_call.period = _call_mag_interval = ticks;
+					_call_mag_interval = interval;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -1141,22 +1120,14 @@ FXOS8701CQ::start()
 #endif
 
 	/* start polling at the specified rate */
-	hrt_call_every(&_accel_call,
-		       1000,
-		       _call_accel_interval - FXOS8701C_TIMER_REDUCTION,
-		       (hrt_callout)&FXOS8701CQ::measure_trampoline, this);
-#if !defined(BOARD_HAS_NOISY_FXOS8700_MAG)
-	hrt_call_every(&_mag_call, 1000, _call_mag_interval, (hrt_callout)&FXOS8701CQ::mag_measure_trampoline, this);
-#endif
+	ScheduleOnInterval(_call_accel_interval - FXOS8701C_TIMER_REDUCTION, 10000);
 }
 
 void
 FXOS8701CQ::stop()
 {
-	hrt_cancel(&_accel_call);
-#if !defined(BOARD_HAS_NOISY_FXOS8700_MAG)
-	hrt_cancel(&_mag_call);
-#endif
+	ScheduleClear();
+
 	/* reset internal states */
 	memset(_last_accel, 0, sizeof(_last_accel));
 
@@ -1168,21 +1139,18 @@ FXOS8701CQ::stop()
 }
 
 void
-FXOS8701CQ::measure_trampoline(void *arg)
+FXOS8701CQ::Run()
 {
-	FXOS8701CQ *dev = (FXOS8701CQ *)arg;
-
 	/* make another measurement */
-	dev->measure();
-}
+	measure();
 
-void
-FXOS8701CQ::mag_measure_trampoline(void *arg)
-{
-	FXOS8701CQ *dev = (FXOS8701CQ *)arg;
+#if !defined(BOARD_HAS_NOISY_FXOS8700_MAG)
 
-	/* make another measurement */
-	dev->mag_measure();
+	if (hrt_elapsed_time(&_mag_last_measure) >= _call_mag_interval) {
+		mag_measure();
+	}
+
+#endif
 }
 
 void
@@ -1413,6 +1381,9 @@ FXOS8701CQ::mag_measure()
 	 */
 
 	mag_report.timestamp = hrt_absolute_time();
+
+	_mag_last_measure = mag_report.timestamp;
+
 	mag_report.is_external = external();
 
 	mag_report.x_raw = _last_raw_mag_x;
@@ -1580,11 +1551,6 @@ FXOS8701CQ_mag::measure()
 	_parent->mag_measure();
 }
 
-void
-FXOS8701CQ_mag::measure_trampoline(void *arg)
-{
-	_parent->mag_measure_trampoline(arg);
-}
 #endif
 
 /**

--- a/src/drivers/imu/icm20948/icm20948.cpp
+++ b/src/drivers/imu/icm20948/icm20948.cpp
@@ -98,6 +98,7 @@ ICM20948::ICM20948(device::Device *interface, device::Device *mag_interface, con
 		   const char *path_gyro, const char *path_mag,
 		   enum Rotation rotation,
 		   bool magnetometer_only) :
+	ScheduledWorkItem(px4::device_bus_to_wq(interface->get_device_id())),
 	_interface(interface),
 	_whoami(0),
 	_accel(magnetometer_only ? nullptr : new ICM20948_accel(this, path_accel)),
@@ -105,13 +106,6 @@ ICM20948::ICM20948(device::Device *interface, device::Device *mag_interface, con
 	_mag(new ICM20948_mag(this, mag_interface, path_mag)),
 	_selected_bank(0xFF),	// invalid/improbable bank value, will be set on first read/write
 	_magnetometer_only(magnetometer_only),
-#if defined(USE_I2C)
-	_work {},
-	_use_hrt(false),
-#else
-	_use_hrt(true),
-#endif
-	_call {},
 	_call_interval(0),
 	_accel_reports(nullptr),
 	_accel_scale{},
@@ -239,16 +233,14 @@ ICM20948::init()
 {
 	irqstate_t state;
 
-#if defined(USE_I2C)
-	use_i2c(_interface->get_device_bus_type() == device::Device::DeviceBusType_I2C);
-#endif
-
 	/*
 	 * If the MPU is using I2C we should reduce the sample rate to 200Hz and
 	 * make the integration autoreset faster so that we integrate just one
 	 * sample since the sampling rate is already low.
 	*/
-	if (is_i2c() && !_magnetometer_only) {
+	const bool is_i2c = (_interface->get_device_bus_type() == device::Device::DeviceBusType_I2C);
+
+	if (is_i2c && !_magnetometer_only) {
 		_sample_rate = 200;
 		_accel_int.set_autoreset_interval(1000000 / 1000);
 		_gyro_int.set_autoreset_interval(1000000 / 1000);
@@ -257,7 +249,7 @@ ICM20948::init()
 	int ret = probe();
 
 	if (ret != OK) {
-		PX4_DEBUG("ICM20948 probe failed");
+		PX4_DEBUG("probe failed");
 		return ret;
 	}
 
@@ -457,10 +449,8 @@ int ICM20948::reset_mpu()
 	}
 
 	// Enable I2C bus or Disable I2C bus (recommended on data sheet)
-
-
-	write_checked_reg(MPU_OR_ICM(MPUREG_USER_CTRL, ICMREG_20948_USER_CTRL), is_i2c() ? 0 : BIT_I2C_IF_DIS);
-
+	const bool is_i2c = (_interface->get_device_bus_type() == device::Device::DeviceBusType_I2C);
+	write_checked_reg(ICMREG_20948_USER_CTRL, is_i2c ? 0 : BIT_I2C_IF_DIS);
 
 	// SAMPLE RATE
 	_set_sample_rate(_sample_rate);
@@ -617,16 +607,16 @@ ICM20948::_set_pollrate(unsigned long rate)
 		bool want_start = (_call_interval == 0);
 
 		/* convert hz to hrt interval via microseconds */
-		unsigned ticks = 1000000 / rate;
+		unsigned interval = 1000000 / rate;
 
 		/* check against maximum sane rate */
-		if (ticks < 1000) {
+		if (interval < 1000) {
 			return -EINVAL;
 		}
 
 		// adjust filters
 		float cutoff_freq_hz = _accel_filter_x.get_cutoff_freq();
-		float sample_rate = 1.0e6f / ticks;
+		float sample_rate = 1.0e6f / interval;
 		_accel_filter_x.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
 		_accel_filter_y.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
 		_accel_filter_z.set_cutoff_frequency(sample_rate, cutoff_freq_hz);
@@ -639,15 +629,7 @@ ICM20948::_set_pollrate(unsigned long rate)
 
 		/* update interval for next measurement */
 		/* XXX this is a bit shady, but no other way to adjust... */
-		_call_interval = ticks;
-
-		/*
-		  set call interval faster than the sample time. We
-		  then detect when we have duplicate samples and reject
-		  them. This prevents aliasing due to a beat between the
-		  stm32 clock and the mpu9250 clock
-		 */
-		_call.period = _call_interval - MPU9250_TIMER_REDUCTION;
+		_call_interval = interval;
 
 		/* if we need to start the poll state machine, do it */
 		if (want_start) {
@@ -955,78 +937,20 @@ ICM20948::start()
 
 	_mag->_mag_reports->flush();
 
-	if (_use_hrt) {
-		/* start polling at the specified rate */
-		hrt_call_every(&_call,
-			       1000,
-			       _call_interval - MPU9250_TIMER_REDUCTION,
-			       (hrt_callout)&ICM20948::measure_trampoline, this);
-
-	} else {
-#ifdef USE_I2C
-		/* schedule a cycle to start things */
-		work_queue(HPWORK, &_work, (worker_t)&ICM20948::cycle_trampoline, this, 1);
-#endif
-	}
-
+	ScheduleOnInterval(_call_interval - MPU9250_TIMER_REDUCTION, 10000);
 }
 
 void
 ICM20948::stop()
 {
-	if (_use_hrt) {
-		hrt_cancel(&_call);
-
-	} else {
-#ifdef USE_I2C
-		work_cancel(HPWORK, &_work);
-#endif
-	}
-}
-
-
-#if defined(USE_I2C)
-void
-ICM20948::cycle_trampoline(void *arg)
-{
-	ICM20948 *dev = (ICM20948 *)arg;
-
-	dev->cycle();
+	ScheduleClear();
 }
 
 void
-ICM20948::cycle()
+ICM20948::Run()
 {
-
-//	int ret = measure();
-
-	measure();
-
-//	if (ret != OK) {
-//		/* issue a reset command to the sensor */
-//		reset();
-//		start();
-//		return;
-//	}
-
-	if (_call_interval != 0) {
-		work_queue(HPWORK,
-			   &_work,
-			   (worker_t)&ICM20948::cycle_trampoline,
-			   this,
-			   USEC2TICK(_call_interval - MPU9250_TIMER_REDUCTION));
-	}
-}
-#endif
-
-
-void
-ICM20948::measure_trampoline(void *arg)
-{
-	ICM20948 *dev = reinterpret_cast<ICM20948 *>(arg);
-
 	/* make another measurement */
-	dev->measure();
+	measure();
 }
 
 void

--- a/src/drivers/imu/mpu9250/CMakeLists.txt
+++ b/src/drivers/imu/mpu9250/CMakeLists.txt
@@ -45,5 +45,5 @@ px4_add_module(
 		mag.cpp
 		mag_i2c.cpp
 	DEPENDS
+		px4_work_queue
 	)
-

--- a/src/drivers/imu/mpu9250/mpu9250.h
+++ b/src/drivers/imu/mpu9250/mpu9250.h
@@ -36,8 +36,6 @@
 #include <perf/perf_counter.h>
 #include <systemlib/conversions.h>
 
-#include <nuttx/wqueue.h>
-
 #include <board_config.h>
 #include <drivers/drv_hrt.h>
 
@@ -49,9 +47,9 @@
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
 #include <lib/conversion/rotation.h>
 #include <systemlib/err.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 #include <uORB/uORB.h>
-#include <uORB/topics/debug_key_value.h>
 
 #include "mag.h"
 #include "accel.h"
@@ -253,7 +251,7 @@ class MPU9250_mag;
 class MPU9250_accel;
 class MPU9250_gyro;
 
-class MPU9250
+class MPU9250 : public px4::ScheduledWorkItem
 {
 public:
 	MPU9250(device::Device *interface, device::Device *mag_interface, const char *path_accel, const char *path_gyro,
@@ -281,6 +279,8 @@ protected:
 	friend class MPU9250_mag;
 	friend class MPU9250_gyro;
 
+	void Run() override;
+
 private:
 	MPU9250_accel   *_accel;
 	MPU9250_gyro	*_gyro;
@@ -289,16 +289,6 @@ private:
 	bool
 	_magnetometer_only;     /* To disable accel and gyro reporting if only magnetometer is used (e.g. as external magnetometer) */
 
-#if defined(USE_I2C)
-	/*
-	 * SPI bus based device use hrt
-	 * I2C bus needs to use work queue
-	 */
-	work_s			_work{};
-#endif
-	bool 			_use_hrt;
-
-	struct hrt_call		_call {};
 	unsigned		_call_interval;
 
 	ringbuffer::RingBuffer	*_accel_reports;
@@ -391,52 +381,6 @@ private:
 	 * Resets the main chip (excluding the magnetometer if any).
 	 */
 	int			reset_mpu();
-
-
-#if defined(USE_I2C)
-	/**
-	 * When the I2C interfase is on
-	 * Perform a poll cycle; collect from the previous measurement
-	 * and start a new one.
-	 *
-	 * This is the heart of the measurement state machine.  This function
-	 * alternately starts a measurement, or collects the data from the
-		 * previous measurement.
-		 *
-		 * When the interval between measurements is greater than the minimum
-		 * measurement interval, a gap is inserted between collection
-		 * and measurement to provide the most recent measurement possible
-		 * at the next interval.
-		 */
-	void			cycle();
-
-	/**
-	 * Static trampoline from the workq context; because we don't have a
-	 * generic workq wrapper yet.
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		cycle_trampoline(void *arg);
-
-	void use_i2c(bool on_true) { _use_hrt = !on_true; }
-
-#endif
-
-	bool is_i2c(void) { return !_use_hrt; }
-
-
-
-
-	/**
-	 * Static trampoline from the hrt_call context; because we don't have a
-	 * generic hrt wrapper yet.
-	 *
-	 * Called by the HRT in interrupt context at the specified rate if
-	 * automatic polling is enabled.
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		measure_trampoline(void *arg);
 
 	/**
 	 * Fetch measurements from the sensor and update the report buffers.

--- a/src/drivers/irlock/irlock.cpp
+++ b/src/drivers/irlock/irlock.cpp
@@ -56,7 +56,7 @@
 #include <px4_getopt.h>
 
 #include <nuttx/clock.h>
-#include <nuttx/wqueue.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 #include <systemlib/err.h>
 
 #include <uORB/uORB.h>
@@ -86,10 +86,6 @@
 #define IRLOCK_TAN_ANG_PER_PIXEL_X	(2*IRLOCK_TAN_HALF_FOV_X/IRLOCK_RES_X)
 #define IRLOCK_TAN_ANG_PER_PIXEL_Y	(2*IRLOCK_TAN_HALF_FOV_Y/IRLOCK_RES_Y)
 
-#ifndef CONFIG_SCHED_WORKQUEUE
-# error This requires CONFIG_SCHED_WORKQUEUE.
-#endif
-
 #define IRLOCK_BASE_DEVICE_PATH	"/dev/irlock"
 #define IRLOCK0_DEVICE_PATH	"/dev/irlock0"
 
@@ -110,7 +106,7 @@ struct irlock_s {
 	struct irlock_target_s targets[IRLOCK_OBJECTS_MAX];
 };
 
-class IRLOCK : public device::I2C
+class IRLOCK : public device::I2C, public px4::ScheduledWorkItem
 {
 public:
 	IRLOCK(int bus = IRLOCK_I2C_BUS, int address = IRLOCK_I2C_ADDRESS);
@@ -131,11 +127,8 @@ private:
 	/** stop periodic reads from sensor **/
 	void 		stop();
 
-	/** static function that is called by worker queue, arg will be pointer to instance of this class **/
-	static void	cycle_trampoline(void *arg);
-
 	/** read from device and schedule next read **/
-	void		cycle();
+	void		Run() override;
 
 	/** low level communication with sensor **/
 	int 		read_device();
@@ -146,7 +139,6 @@ private:
 	/** internal variables **/
 	ringbuffer::RingBuffer *_reports;
 	bool _sensor_ok;
-	work_s _work;
 	uint32_t _read_failures;
 
 	int _orb_class_instance;
@@ -166,13 +158,13 @@ extern "C" __EXPORT int irlock_main(int argc, char *argv[]);
 /** constructor **/
 IRLOCK::IRLOCK(int bus, int address) :
 	I2C("irlock", IRLOCK0_DEVICE_PATH, bus, address, 400000),
+	ScheduledWorkItem(px4::device_bus_to_wq(get_device_id())),
 	_reports(nullptr),
 	_sensor_ok(false),
 	_read_failures(0),
 	_orb_class_instance(-1),
 	_irlock_report_topic(nullptr)
 {
-	memset(&_work, 0, sizeof(_work));
 }
 
 /** destructor **/
@@ -293,32 +285,22 @@ void IRLOCK::start()
 	_reports->flush();
 
 	/** start work queue cycle **/
-	work_queue(HPWORK, &_work, (worker_t)&IRLOCK::cycle_trampoline, this, 1);
+	ScheduleNow();
 }
 
 /** stop periodic reads from sensor **/
 void IRLOCK::stop()
 {
-	work_cancel(HPWORK, &_work);
+	ScheduleClear();
 }
 
-void IRLOCK::cycle_trampoline(void *arg)
-{
-	IRLOCK *device = (IRLOCK *)arg;
-
-	/** check global irlock reference and cycle **/
-	if (g_irlock != nullptr) {
-		device->cycle();
-	}
-}
-
-void IRLOCK::cycle()
+void IRLOCK::Run()
 {
 	/** ignoring failure, if we do, we will be back again right away... **/
 	read_device();
 
 	/** schedule the next cycle **/
-	work_queue(HPWORK, &_work, (worker_t)&IRLOCK::cycle_trampoline, this, USEC2TICK(IRLOCK_CONVERSION_INTERVAL_US));
+	ScheduleDelayed(IRLOCK_CONVERSION_INTERVAL_US);
 }
 
 ssize_t IRLOCK::read(struct file *filp, char *buffer, size_t buflen)

--- a/src/drivers/lights/oreoled/oreoled.cpp
+++ b/src/drivers/lights/oreoled/oreoled.cpp
@@ -57,7 +57,7 @@
 #include <px4_getopt.h>
 
 #include <nuttx/arch.h>
-#include <nuttx/wqueue.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 #include <nuttx/clock.h>
 
 #include <perf/perf_counter.h>
@@ -80,7 +80,7 @@
 
 #define OREOLED_CMD_QUEUE_SIZE	10		///< up to 10 messages can be queued up to send to the LEDs
 
-class OREOLED : public device::I2C
+class OREOLED : public device::I2C, public px4::ScheduledWorkItem
 {
 public:
 	OREOLED(int bus, int i2c_addr, bool autoupdate, bool alwaysupdate);
@@ -113,14 +113,9 @@ private:
 	void			stop();
 
 	/**
-	 * static function that is called by worker queue
-	 */
-	static void		cycle_trampoline(void *arg);
-
-	/**
 	 * update the colours displayed by the LEDs
 	 */
-	void			cycle();
+	void			Run() override;
 
 	int				bootloader_app_reset(int led_num);
 	int				bootloader_app_ping(int led_num);
@@ -136,7 +131,6 @@ private:
 	int				bootloader_coerce_healthy(void);
 
 	/* internal variables */
-	work_s			_work;							///< work queue for scheduling reads
 	bool			_healthy[OREOLED_NUM_LEDS];		///< health of each LED
 	bool			_in_boot[OREOLED_NUM_LEDS];		///< true for each LED that is in bootloader mode
 	uint8_t			_num_healthy;					///< number of healthy LEDs
@@ -171,7 +165,7 @@ extern "C" __EXPORT int oreoled_main(int argc, char *argv[]);
 /* constructor */
 OREOLED::OREOLED(int bus, int i2c_addr, bool autoupdate, bool alwaysupdate) :
 	I2C("oreoled", OREOLED0_DEVICE_PATH, bus, i2c_addr, 100000),
-	_work{},
+	ScheduledWorkItem(px4::device_bus_to_wq(get_device_id())),
 	_num_healthy(0),
 	_num_inboot(0),
 	_cmd_queue(nullptr),
@@ -279,28 +273,17 @@ void
 OREOLED::start()
 {
 	/* schedule a cycle to start things */
-	work_queue(HPWORK, &_work, (worker_t)&OREOLED::cycle_trampoline, this, 1);
+	ScheduleNow();
 }
 
 void
 OREOLED::stop()
 {
-	work_cancel(HPWORK, &_work);
+	ScheduleClear();
 }
 
 void
-OREOLED::cycle_trampoline(void *arg)
-{
-	OREOLED *dev = (OREOLED *)arg;
-
-	/* check global oreoled and cycle */
-	if (g_oreoled != nullptr) {
-		dev->cycle();
-	}
-}
-
-void
-OREOLED::cycle()
+OREOLED::Run()
 {
 	/* check time since startup */
 	uint64_t now = hrt_absolute_time();
@@ -369,8 +352,8 @@ OREOLED::cycle()
 		}
 
 		/* schedule another attempt in 0.1 sec */
-		work_queue(HPWORK, &_work, (worker_t)&OREOLED::cycle_trampoline, this,
-			   USEC2TICK(OREOLED_STARTUP_INTERVAL_US));
+		ScheduleDelayed(OREOLED_STARTUP_INTERVAL_US);
+
 		return;
 
 	} else if (_alwaysupdate) {
@@ -406,8 +389,7 @@ OREOLED::cycle()
 		_alwaysupdate = false;
 
 		/* schedule a fresh cycle call when the measurement is done */
-		work_queue(HPWORK, &_work, (worker_t)&OREOLED::cycle_trampoline, this,
-			   USEC2TICK(OREOLED_UPDATE_INTERVAL_US));
+		ScheduleDelayed(OREOLED_UPDATE_INTERVAL_US);
 		return;
 
 	} else if (_autoupdate) {
@@ -461,8 +443,7 @@ OREOLED::cycle()
 		_autoupdate = false;
 
 		/* schedule a fresh cycle call when the measurement is done */
-		work_queue(HPWORK, &_work, (worker_t)&OREOLED::cycle_trampoline, this,
-			   USEC2TICK(OREOLED_UPDATE_INTERVAL_US));
+		ScheduleDelayed(OREOLED_UPDATE_INTERVAL_US);
 		return;
 
 	} else if (_num_inboot > 0) {
@@ -480,8 +461,7 @@ OREOLED::cycle()
 		_num_inboot = 0;
 
 		/* schedule a fresh cycle call when the measurement is done */
-		work_queue(HPWORK, &_work, (worker_t)&OREOLED::cycle_trampoline, this,
-			   USEC2TICK(OREOLED_UPDATE_INTERVAL_US));
+		ScheduleDelayed(OREOLED_UPDATE_INTERVAL_US);
 		return;
 
 	} else if (!_is_ready) {
@@ -539,8 +519,7 @@ OREOLED::cycle()
 	}
 
 	/* schedule a fresh cycle call when the command is sent */
-	work_queue(HPWORK, &_work, (worker_t)&OREOLED::cycle_trampoline, this,
-		   USEC2TICK(OREOLED_UPDATE_INTERVAL_US));
+	ScheduleDelayed(OREOLED_UPDATE_INTERVAL_US);
 }
 
 int

--- a/src/drivers/linux_sbus/linux_sbus.cpp
+++ b/src/drivers/linux_sbus/linux_sbus.cpp
@@ -119,8 +119,8 @@ int RcInput::start(char *device, int channels)
 	}
 
 	_isRunning = true;
-	result = work_queue(HPWORK, &_work, (worker_t) & RcInput::cycle_trampoline,
-			    this, 0);
+
+	ScheduleNow();
 
 	if (result == -1) {
 		_isRunning = false;
@@ -134,20 +134,14 @@ void RcInput::stop()
 	close(_device_fd);
 	_shouldExit = true;
 }
+
 //---------------------------------------------------------------------------------------------------------//
-void RcInput::cycle_trampoline(void *arg)
-{
-	RcInput *dev = reinterpret_cast<RcInput *>(arg);
-	dev->_cycle();
-}
-//---------------------------------------------------------------------------------------------------------//
-void RcInput::_cycle()
+void RcInput::Run()
 {
 	_measure();
 
 	if (!_shouldExit) {
-		work_queue(HPWORK, &_work, (worker_t) & RcInput::cycle_trampoline, this,
-			   USEC2TICK(RCINPUT_MEASURE_INTERVAL_US));
+		ScheduleDelayed(RCINPUT_MEASURE_INTERVAL_US);
 	}
 }
 //---------------------------------------------------------------------------------------------------------//

--- a/src/drivers/linux_sbus/linux_sbus.h
+++ b/src/drivers/linux_sbus/linux_sbus.h
@@ -48,7 +48,7 @@
 #include <asm-generic/termbits.h>
 #include <errno.h>
 #include <px4_config.h>
-#include <px4_workqueue.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 #include <px4_defines.h>
 #include <drivers/drv_hrt.h>
 #include <uORB/uORB.h>
@@ -66,13 +66,13 @@
 
 namespace linux_sbus
 {
-class RcInput
+class RcInput : public px4::ScheduledWorkItem
 {
 public:
 	RcInput() :
+		ScheduledWorkItem(px4::wq_configurations::hp_default),
 		_shouldExit(false),
 		_isRunning(false),
-		_work { },
 		_rcinput_pub(nullptr),
 		_data { }, _sbusData {   0x0f, 0x01, 0x04, 0x20, 0x00,
 					 0xff, 0x07, 0x40, 0x00, 0x02,
@@ -82,7 +82,7 @@ public:
 	{ }
 	~RcInput()
 	{
-		work_cancel(HPWORK, &_work);
+		ScheduleClear();
 		_isRunning = false;
 		close(_device_fd);
 	}
@@ -90,20 +90,16 @@ public:
 	int start(char *device, int channels);
 	void stop();
 
-	/** Trampoline for the work queue. */
-	static void cycle_trampoline(void *arg);
-
 	bool isRunning()
 	{
 		return _isRunning;
 	}
 
 private:
-	void _cycle();
+	void Run() override;
 	void _measure();
 	bool _shouldExit;
 	bool _isRunning;
-	struct work_s _work;
 	orb_advert_t _rcinput_pub;
 	struct input_rc_s _data;
 	uint8_t _sbusData[25];

--- a/src/drivers/magnetometer/bmm150/bmm150.hpp
+++ b/src/drivers/magnetometer/bmm150/bmm150.hpp
@@ -20,7 +20,7 @@
 
 #include <perf/perf_counter.h>
 #include <systemlib/err.h>
-#include <nuttx/wqueue.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 #include <systemlib/conversions.h>
 
 #include <nuttx/arch.h>
@@ -191,7 +191,7 @@ struct bmm150_data {
 };
 
 
-class BMM150 : public device::I2C
+class BMM150 : public device::I2C, public px4::ScheduledWorkItem
 {
 public:
 	BMM150(int bus, const char *path, enum Rotation rotation);
@@ -217,7 +217,6 @@ protected:
 	virtual int       probe();
 
 private:
-	work_s            _work{};
 
 	bool _running;
 
@@ -278,8 +277,7 @@ private:
 	int     measure(); //start measure
 	int     collect(); //get results and publish
 
-	static void     cycle_trampoline(void *arg);
-	void            cycle(); //main execution
+	void	Run() override;
 
 	/**
 	 * Read the specified number of bytes from BMM150.

--- a/src/drivers/magnetometer/hmc5883/CMakeLists.txt
+++ b/src/drivers/magnetometer/hmc5883/CMakeLists.txt
@@ -40,5 +40,6 @@ px4_add_module(
 		hmc5883_spi.cpp
 		hmc5883.cpp
 	DEPENDS
+		px4_work_queue
 	)
 

--- a/src/drivers/magnetometer/ist8310/CMakeLists.txt
+++ b/src/drivers/magnetometer/ist8310/CMakeLists.txt
@@ -36,5 +36,7 @@ px4_add_module(
 	STACK_MAIN 1500
 	SRCS
 		ist8310.cpp
+	DEPENDS
+		px4_work_queue
 	)
 

--- a/src/drivers/magnetometer/lis3mdl/lis3mdl.h
+++ b/src/drivers/magnetometer/lis3mdl/lis3mdl.h
@@ -48,13 +48,10 @@
 
 #include <lib/conversion/rotation.h>
 #include <systemlib/err.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 #include <perf/perf_counter.h>
 #include <px4_defines.h>
-
-#ifndef CONFIG_SCHED_WORKQUEUE
-# error This requires CONFIG_SCHED_WORKQUEUE.
-#endif
 
 /**
  * LIS3MDL internal constants and data structures.
@@ -111,7 +108,7 @@ enum OPERATING_MODE {
 };
 
 
-class LIS3MDL : public device::CDev
+class LIS3MDL : public device::CDev, public px4::ScheduledWorkItem
 {
 public:
 	LIS3MDL(device::Device *interface, const char *path, enum Rotation rotation);
@@ -143,7 +140,6 @@ protected:
 	Device *_interface;
 
 private:
-	work_s _work;
 
 	ringbuffer::RingBuffer *_reports;
 
@@ -165,7 +161,7 @@ private:
 	enum OPERATING_MODE _mode;
 	enum Rotation _rotation;
 
-	unsigned int _measure_ticks;
+	unsigned int _measure_interval;
 
 	int _class_instance;
 	int _orb_class_instance;
@@ -227,15 +223,7 @@ private:
 	 * and measurement to provide the most recent measurement possible
 	 * at the next interval.
 	 */
-	void cycle();
-
-	/**
-	 * @brief Static trampoline from the workq context; because we don't have a
-	 *         generic workq wrapper yet.
-	 *
-	 * @param arg Instance pointer for the driver that is polling.
-	 */
-	static void cycle_trampoline(void *arg);
+	void Run() override;
 
 	/**
 	 * Issue a measurement command.

--- a/src/drivers/magnetometer/rm3100/rm3100.cpp
+++ b/src/drivers/magnetometer/rm3100/rm3100.cpp
@@ -43,8 +43,8 @@
 
 RM3100::RM3100(device::Device *interface, const char *path, enum Rotation rotation) :
 	CDev("RM3100", path),
+	ScheduledWorkItem(px4::device_bus_to_wq(interface->get_device_id())),
 	_interface(interface),
-	_work{},
 	_reports(nullptr),
 	_scale{},
 	_last_report{},
@@ -57,7 +57,7 @@ RM3100::RM3100(device::Device *interface, const char *path, enum Rotation rotati
 	_continuous_mode_set(false),
 	_mode(SINGLE),
 	_rotation(rotation),
-	_measure_ticks(0),
+	_measure_interval(0),
 	_class_instance(-1),
 	_orb_class_instance(-1),
 	_range_scale(1.0f / (RM3100_SENSITIVITY * UTESLA_TO_GAUSS)),
@@ -69,9 +69,6 @@ RM3100::RM3100(device::Device *interface, const char *path, enum Rotation rotati
 	_device_id.devid_s.address = _interface->get_device_address();
 	_device_id.devid_s.devtype = DRV_MAG_DEVTYPE_RM3100;
 
-	// enable debug() calls
-	_debug_enabled = false;
-
 	// default scaling
 	_scale.x_offset = 0;
 	_scale.x_scale = 1.0f;
@@ -79,9 +76,6 @@ RM3100::RM3100(device::Device *interface, const char *path, enum Rotation rotati
 	_scale.y_scale = 1.0f;
 	_scale.z_offset = 0;
 	_scale.z_scale = 1.0f;
-
-	// work_cancel in the dtor will explode if we don't do this...
-	memset(&_work, 0, sizeof(_work));
 }
 
 RM3100::~RM3100()
@@ -293,10 +287,10 @@ RM3100::convert_signed(int32_t *n)
 }
 
 void
-RM3100::cycle()
+RM3100::Run()
 {
-	/* _measure_ticks == 0  is used as _task_should_exit */
-	if (_measure_ticks == 0) {
+	/* _measure_interval == 0  is used as _task_should_exit */
+	if (_measure_interval == 0) {
 		return;
 	}
 
@@ -313,22 +307,10 @@ RM3100::cycle()
 		DEVICE_DEBUG("measure error");
 	}
 
-	if (_measure_ticks > 0) {
+	if (_measure_interval > 0) {
 		/* schedule a fresh cycle call when the measurement is done */
-		work_queue(HPWORK,
-			   &_work,
-			   (worker_t)&RM3100::cycle_trampoline,
-			   this,
-			   _measure_ticks);
+		ScheduleDelayed(_measure_interval);
 	}
-}
-
-void
-RM3100::cycle_trampoline(void *arg)
-{
-	RM3100 *dev = (RM3100 *)arg;
-
-	dev->cycle();
 }
 
 int
@@ -379,10 +361,10 @@ RM3100::ioctl(struct file *file_pointer, int cmd, unsigned long arg)
 
 			case SENSOR_POLLRATE_DEFAULT: {
 					/* do we need to start internal polling? */
-					bool not_started = (_measure_ticks == 0);
+					bool not_started = (_measure_interval == 0);
 
 					/* set interval for next measurement to minimum legal value */
-					_measure_ticks = USEC2TICK(RM3100_CONVERSION_INTERVAL);
+					_measure_interval = (RM3100_CONVERSION_INTERVAL);
 
 					/* if we need to start the poll state machine, do it */
 					if (not_started) {
@@ -395,18 +377,18 @@ RM3100::ioctl(struct file *file_pointer, int cmd, unsigned long arg)
 			/* Uses arg (hz) for a custom poll rate */
 			default: {
 					/* do we need to start internal polling? */
-					bool not_started = (_measure_ticks == 0);
+					bool not_started = (_measure_interval == 0);
 
 					/* convert hz to tick interval via microseconds */
-					unsigned ticks = USEC2TICK(1000000 / arg);
+					unsigned interval = (1000000 / arg);
 
 					/* check against maximum rate */
-					if (ticks < USEC2TICK(RM3100_CONVERSION_INTERVAL)) {
+					if (interval < RM3100_CONVERSION_INTERVAL) {
 						return -EINVAL;
 					}
 
 					/* update interval for next measurement */
-					_measure_ticks = ticks;
+					_measure_interval = interval;
 
 					/* if we need to start the poll state machine, do it */
 					if (not_started) {
@@ -496,7 +478,7 @@ RM3100::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	PX4_INFO("poll interval:  %u ticks", _measure_ticks);
+	PX4_INFO("poll interval:  %u", _measure_interval);
 	print_message(_last_report);
 	_reports->print_info("report queue");
 }
@@ -528,7 +510,7 @@ RM3100::read(struct file *file_pointer, char *buffer, size_t buffer_len)
 	}
 
 	/* if automatic measurement is enabled */
-	if (_measure_ticks > 0) {
+	if (_measure_interval > 0) {
 		/*
 		 * While there is space in the caller's buffer, and reports, copy them.
 		 * Note that we may be pre-empted by the workq thread while we are doing this;
@@ -609,18 +591,18 @@ RM3100::start()
 	_reports->flush();
 
 	set_default_register_values();
-	_measure_ticks = USEC2TICK(RM3100_CONVERSION_INTERVAL);
+	_measure_interval = (RM3100_CONVERSION_INTERVAL);
 
 	/* schedule a cycle to start things */
-	work_queue(HPWORK, &_work, (worker_t)&RM3100::cycle_trampoline, this, 1);
+	ScheduleNow();
 }
 
 void
 RM3100::stop()
 {
-	if (_measure_ticks > 0) {
+	if (_measure_interval > 0) {
 		/* ensure no new items are queued while we cancel this one */
-		_measure_ticks = 0;
-		work_cancel(HPWORK, &_work);
+		_measure_interval = 0;
+		ScheduleClear();
 	}
 }

--- a/src/drivers/rpi_rc_in/rpi_rc_in.cpp
+++ b/src/drivers/rpi_rc_in/rpi_rc_in.cpp
@@ -42,7 +42,7 @@ RcInput::~RcInput()
 		_mem = nullptr;
 	}
 
-	work_cancel(HPWORK, &_work);
+	ScheduleClear();
 	_is_running = false;
 }
 
@@ -68,6 +68,7 @@ int RcInput::rpi_rc_init()
 
 	return 0;
 }
+
 int RcInput::start()
 {
 	int result = 0;
@@ -80,11 +81,8 @@ int RcInput::start()
 	}
 
 	_is_running = true;
-	result = work_queue(HPWORK, &_work, (worker_t) & RcInput::cycle_trampoline, this, 0);
 
-	if (result == -1) {
-		_is_running = false;
-	}
+	ScheduleNow();
 
 	return result;
 }
@@ -94,19 +92,12 @@ void RcInput::stop()
 	_should_exit = true;
 }
 
-void RcInput::cycle_trampoline(void *arg)
-{
-	RcInput *dev = reinterpret_cast<RcInput *>(arg);
-	dev->_cycle();
-}
-
-void RcInput::_cycle()
+void RcInput::Run()
 {
 	_measure();
 
 	if (!_should_exit) {
-		work_queue(HPWORK, &_work, (worker_t) & RcInput::cycle_trampoline, this,
-			   USEC2TICK(RCINPUT_MEASURE_INTERVAL_US));
+		ScheduleDelayed(RCINPUT_MEASURE_INTERVAL_US);
 	}
 }
 

--- a/src/drivers/rpi_rc_in/rpi_rc_in.h
+++ b/src/drivers/rpi_rc_in/rpi_rc_in.h
@@ -49,7 +49,7 @@
 #include <unistd.h>
 
 #include <px4_config.h>
-#include <px4_workqueue.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 #include <px4_defines.h>
 
 #include <drivers/drv_hrt.h>
@@ -61,10 +61,10 @@
 
 namespace rpi_rc_in
 {
-class RcInput
+class RcInput, public px4::ScheduledWorkItem
 {
 public:
-	RcInput() = default;
+	RcInput() : ScheduledWorkItem(px4::wq_configurations::hp_default) {}
 
 	~RcInput();
 
@@ -74,23 +74,19 @@ public:
 	/** @return 0 on success, -errno on failure */
 	void stop();
 
-	/** Trampoline for the work queue. */
-	static void cycle_trampoline(void *arg);
-
 	bool is_running()
 	{
 		return _is_running;
 	}
 
 private:
-	void _cycle();
+	void Run() override;
 	void _measure();
 
 	int rpi_rc_init();
 
 	bool _should_exit = false;
 	bool _is_running = false;
-	struct work_s _work = {};
 	orb_advert_t _rcinput_pub = nullptr;
 	int _channels = 8; //D8R-II plus
 	struct input_rc_s _data = {};

--- a/src/drivers/telemetry/bst/bst.cpp
+++ b/src/drivers/telemetry/bst/bst.cpp
@@ -41,7 +41,7 @@
 
 #include <px4_config.h>
 #include <px4_getopt.h>
-#include <px4_workqueue.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 #include <drivers/device/i2c.h>
 #include <systemlib/err.h>
 #include <string.h>
@@ -111,7 +111,7 @@ struct BSTBattery {
 
 #pragma pack(pop)
 
-class BST : public device::I2C
+class BST : public device::I2C, public px4::ScheduledWorkItem
 {
 public:
 	BST(int bus);
@@ -126,14 +126,12 @@ public:
 
 	virtual int		ioctl(device::file_t *filp, int cmd, unsigned long arg) { return 0; }
 
-	work_s *work_ptr() { return &_work; }
-
 	void stop();
 
 	static void		start_trampoline(void *arg);
 
 private:
-	work_s			_work = {};
+
 	bool			_should_run = false;
 	unsigned		_interval = 100;
 	int				_gps_sub;
@@ -142,7 +140,7 @@ private:
 
 	void			start();
 
-	static void		cycle_trampoline(void *arg);
+	void			Run() override;
 
 	void			cycle();
 
@@ -196,19 +194,16 @@ private:
 static BST *g_bst = nullptr;
 
 BST::BST(int bus) :
-	I2C("bst", BST_DEVICE_PATH, bus, BST_ADDR
-#ifdef __PX4_NUTTX
-	    , 100000 /* maximum speed supported */
-#endif
-	   )
+	I2C("bst", BST_DEVICE_PATH, bus, BST_ADDR, 100000),
+	ScheduledWorkItem(px4::device_bus_to_wq(get_device_id()))
 {
 }
 
 BST::~BST()
 {
-	_should_run = false;
+	ScheduleClear();
 
-	work_cancel(LPWORK, &_work);
+	_should_run = false;
 }
 
 int BST::probe()
@@ -248,39 +243,30 @@ int BST::probe()
 
 int BST::init()
 {
-	int ret;
-	ret = I2C::init();
+	int ret = I2C::init();
 
 	if (ret != OK) {
 		return ret;
 	}
 
-	work_queue(LPWORK, &_work, BST::start_trampoline, g_bst, 0);
+	ScheduleNow();
 
 	return OK;
 }
 
-void BST::start_trampoline(void *arg)
+void BST::Run()
 {
-	reinterpret_cast<BST *>(arg)->start();
-}
+	if (!_should_run) {
+		_should_run = true;
 
-void BST::start()
-{
-	_should_run = true;
+		_attitude_sub = orb_subscribe(ORB_ID(vehicle_attitude));
+		_gps_sub = orb_subscribe(ORB_ID(vehicle_gps_position));
+		_battery_sub = orb_subscribe(ORB_ID(battery_status));
 
-	_attitude_sub = orb_subscribe(ORB_ID(vehicle_attitude));
-	_gps_sub = orb_subscribe(ORB_ID(vehicle_gps_position));
-	_battery_sub = orb_subscribe(ORB_ID(battery_status));
+		set_device_address(0x00); // General call address
+	}
 
-	set_device_address(0x00);	// General call address
-
-	work_queue(LPWORK, &_work, BST::cycle_trampoline, this, 0);
-}
-
-void BST::cycle_trampoline(void *arg)
-{
-	reinterpret_cast<BST *>(arg)->cycle();
+	cycle();
 }
 
 void BST::cycle()
@@ -340,7 +326,7 @@ void BST::cycle()
 			}
 		}
 
-		work_queue(LPWORK, &_work, BST::cycle_trampoline, this, _interval);
+		ScheduleDelayed(_interval);
 	}
 }
 

--- a/src/drivers/tone_alarm/ToneAlarm.cpp
+++ b/src/drivers/tone_alarm/ToneAlarm.cpp
@@ -40,7 +40,8 @@
 #include <px4_time.h>
 
 ToneAlarm::ToneAlarm() :
-	CDev(TONE_ALARM0_DEVICE_PATH)
+	CDev(TONE_ALARM0_DEVICE_PATH),
+	ScheduledWorkItem(px4::wq_configurations::hp_default)
 {
 }
 
@@ -65,7 +66,9 @@ int ToneAlarm::init()
 	ToneAlarmInterface::init();
 
 	_running = true;
-	work_queue(HPWORK, &_work, (worker_t)&ToneAlarm::next_trampoline, this, 0);
+
+	ScheduleNow();
+
 	return OK;
 }
 
@@ -122,13 +125,12 @@ void ToneAlarm::next_note()
 	}
 
 	// Schedule a callback when the note should stop.
-	work_queue(HPWORK, &_work, (worker_t)&ToneAlarm::next_trampoline, this, USEC2TICK(duration));
+	ScheduleDelayed(duration);
 }
 
-void ToneAlarm::next_trampoline(void *argv)
+void ToneAlarm::Run()
 {
-	ToneAlarm *toneAlarm = (ToneAlarm *)argv;
-	toneAlarm->next_note();
+	next_note();
 }
 
 void ToneAlarm::orb_update()
@@ -173,9 +175,6 @@ void ToneAlarm::stop_note()
 	// NOTE: Implement hardware specific detail in the ToneAlarmInterface class implementation.
 	ToneAlarmInterface::stop_note();
 }
-
-
-struct work_s ToneAlarm::_work = {};
 
 /**
  * Local functions in support of the shell command.

--- a/src/drivers/tone_alarm/ToneAlarm.h
+++ b/src/drivers/tone_alarm/ToneAlarm.h
@@ -46,7 +46,7 @@
 #include <lib/drivers/tone_alarm/ToneAlarmInterface.h>
 #include <lib/tunes/tunes.h>
 #include <px4_defines.h>
-#include <px4_workqueue.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 #include <string.h>
 
 
@@ -54,7 +54,7 @@
 #  define UNUSED(a) ((void)(a))
 #endif
 
-class ToneAlarm : public cdev::CDev
+class ToneAlarm : public cdev::CDev, public px4::ScheduledWorkItem
 {
 public:
 	ToneAlarm();
@@ -63,7 +63,7 @@ public:
 	/**
 	 * @brief Initializes the character device and hardware registers.
 	 */
-	int init();
+	int init() override;
 
 	/**
 	 * @brief Prints the driver status to the console.
@@ -79,9 +79,8 @@ protected:
 
 	/**
 	 * @brief Trampoline for the work queue.
-	 * @param argv Pointer to the task startup arguments.
 	 */
-	static void next_trampoline(void *argv);
+	void Run() override;
 
 	/**
 	 * @brief Updates the uORB topics for local subscribers.
@@ -115,6 +114,4 @@ private:
 	tune_control_s _tune{};
 
 	Tunes _tunes = Tunes();
-
-	static work_s _work;
 };

--- a/src/include/containers/LockGuard.hpp
+++ b/src/include/containers/LockGuard.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,21 +31,24 @@
  *
  ****************************************************************************/
 
-#include "px4_init.h"
+#pragma once
 
-#include <px4_config.h>
-#include <px4_defines.h>
-#include <drivers/drv_hrt.h>
-#include <lib/parameters/param.h>
-#include <px4_work_queue/WorkQueueManager.hpp>
+#include <pthread.h>
 
-int px4_platform_init(void)
+class LockGuard
 {
-	hrt_init();
+public:
+	explicit LockGuard(pthread_mutex_t &mutex) :
+		_mutex(mutex)
+	{
+		pthread_mutex_lock(&_mutex);
+	}
 
-	param_init();
+	~LockGuard()
+	{
+		pthread_mutex_unlock(&_mutex);
+	}
 
-	px4::WorkQueueManagerStart();
-
-	return PX4_OK;
-}
+private:
+	pthread_mutex_t &_mutex;
+};

--- a/src/include/containers/Queue.hpp
+++ b/src/include/containers/Queue.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,21 +31,61 @@
  *
  ****************************************************************************/
 
-#include "px4_init.h"
+#pragma once
 
-#include <px4_config.h>
-#include <px4_defines.h>
-#include <drivers/drv_hrt.h>
-#include <lib/parameters/param.h>
-#include <px4_work_queue/WorkQueueManager.hpp>
+template<class T>
+struct QueueNode {
+	T next{nullptr};
+};
 
-int px4_platform_init(void)
+template<class T>
+class Queue
 {
-	hrt_init();
+public:
 
-	param_init();
+	bool empty() const { return _head == nullptr; }
 
-	px4::WorkQueueManagerStart();
+	T front() const { return _head; }
+	T back() const { return _tail; }
 
-	return PX4_OK;
-}
+	void push(T newNode)
+	{
+		if (newNode->next != nullptr) {
+			// error, node already queued
+			return;
+		}
+
+		if (_head == nullptr) {
+			_head = newNode;
+		}
+
+		if (_tail != nullptr) {
+			_tail->next = newNode;
+		}
+
+		_tail = newNode;
+	}
+
+	void pop()
+	{
+		if (!empty()) {
+			if (_head != _tail) {
+				T old_head = _head;
+				_head = _head->next;
+				old_head->next = nullptr;
+
+			} else {
+				// only one item left
+				_head->next = nullptr;
+				_head = nullptr;
+				_tail = nullptr;
+			}
+		}
+	}
+
+protected:
+
+	T _head{nullptr};
+	T _tail{nullptr};
+
+};

--- a/src/lib/drivers/airspeed/airspeed.cpp
+++ b/src/lib/drivers/airspeed/airspeed.cpp
@@ -58,8 +58,9 @@
 
 Airspeed::Airspeed(int bus, int address, unsigned conversion_interval, const char *path) :
 	I2C("Airspeed", path, bus, address, 100000),
+	ScheduledWorkItem(px4::device_bus_to_wq(get_device_id())),
 	_sensor_ok(false),
-	_measure_ticks(0),
+	_measure_interval(0),
 	_collect_phase(false),
 	_diff_pres_offset(0.0f),
 	_airspeed_pub(nullptr),
@@ -69,11 +70,6 @@ Airspeed::Airspeed(int bus, int address, unsigned conversion_interval, const cha
 	_sample_perf(perf_alloc(PC_ELAPSED, "aspd_read")),
 	_comms_errors(perf_alloc(PC_COUNT, "aspd_com_err"))
 {
-	// enable debug() calls
-	_debug_enabled = false;
-
-	// work_cancel in the dtor will explode if we don't do this...
-	memset(&_work, 0, sizeof(_work));
 }
 
 Airspeed::~Airspeed()
@@ -148,10 +144,10 @@ Airspeed::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			/* set default polling rate */
 			case SENSOR_POLLRATE_DEFAULT: {
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
 					/* set interval for next measurement to minimum legal value */
-					_measure_ticks = USEC2TICK(_conversion_interval);
+					_measure_interval = USEC2TICK(_conversion_interval);
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -164,18 +160,18 @@ Airspeed::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 			/* adjust to a legal polling interval in Hz */
 			default: {
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
 					/* convert hz to tick interval via microseconds */
-					unsigned ticks = USEC2TICK(1000000 / arg);
+					unsigned interval = (1000000 / arg);
 
 					/* check against maximum rate */
-					if (ticks < USEC2TICK(_conversion_interval)) {
+					if (interval < _conversion_interval) {
 						return -EINVAL;
 					}
 
 					/* update interval for next measurement */
-					_measure_ticks = ticks;
+					_measure_interval = interval;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -207,18 +203,11 @@ Airspeed::start()
 	_collect_phase = false;
 
 	/* schedule a cycle to start things */
-	work_queue(HPWORK, &_work, (worker_t)&Airspeed::cycle_trampoline, this, 1);
+	ScheduleNow();
 }
 
 void
 Airspeed::stop()
 {
-	work_cancel(HPWORK, &_work);
-}
-
-void
-Airspeed::cycle_trampoline(void *arg)
-{
-	Airspeed *dev = (Airspeed *)arg;
-	dev->cycle();
+	ScheduleClear();
 }

--- a/src/platforms/common/CMakeLists.txt
+++ b/src/platforms/common/CMakeLists.txt
@@ -52,4 +52,5 @@ if (NOT "${PX4_PLATFORM}" MATCHES "qurt" AND NOT "${PX4_BOARD}" MATCHES "io-v2")
 	target_link_libraries(px4_platform PRIVATE modules__uORB) # px4_log awkward dependency with uORB, TODO: orb should part of the platform layer
 endif()
 
+add_subdirectory(px4_work_queue)
 add_subdirectory(work_queue)

--- a/src/platforms/common/px4_work_queue/CMakeLists.txt
+++ b/src/platforms/common/px4_work_queue/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2019 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,22 +31,15 @@
 #
 ############################################################################
 
-# skip for px4_layer support on an IO board
-if (NOT ${PX4_BOARD} MATCHES "px4_io")
+px4_add_library(px4_work_queue
+	ScheduledWorkItem.cpp
+	WorkItem.cpp
+	WorkQueue.cpp
+	WorkQueueManager.cpp
+)
 
-	add_library(px4_layer
-		px4_nuttx_tasks.c
-		px4_nuttx_impl.cpp
-		px4_init.cpp
-	)
-	target_link_libraries(px4_layer
-		PRIVATE
-			nuttx_apps # up_cxxinitialize
-			nuttx_sched
-			drivers_boards_common_arch
-			px4_work_queue
-		)
-else()
-	add_library(px4_layer ${PX4_SOURCE_DIR}/src/platforms/empty.c)
+if(PX4_TESTING)
+	add_subdirectory(test)
 endif()
-add_dependencies(px4_layer prebuild_targets)
+
+target_link_libraries(px4_work_queue PRIVATE px4_platform)

--- a/src/platforms/common/px4_work_queue/WorkItem.cpp
+++ b/src/platforms/common/px4_work_queue/WorkItem.cpp
@@ -31,81 +31,37 @@
  *
  ****************************************************************************/
 
-#include "px4_init.h"
+#include "WorkItem.hpp"
 
-#include <px4_config.h>
-#include <px4_defines.h>
+#include "WorkQueue.hpp"
+#include "WorkQueueManager.hpp"
+
+#include <px4_log.h>
 #include <drivers/drv_hrt.h>
-#include <lib/parameters/param.h>
-#include <px4_work_queue/WorkQueueManager.hpp>
-#include <systemlib/cpuload.h>
 
-#include <fcntl.h>
-
-
-#include "platform/cxxinitialize.h"
-
-int px4_platform_init(void)
+namespace px4
 {
 
-#if defined(CONFIG_HAVE_CXX) && defined(CONFIG_HAVE_CXXINITIALIZE)
-	/* run C++ ctors before we go any further */
-	up_cxxinitialize();
+WorkItem::WorkItem(const wq_config_t &config)
+{
+	if (!Init(config)) {
+		PX4_ERR("init failed");
+	}
+}
 
-#	if defined(CONFIG_SYSTEM_NSH_CXXINITIALIZE)
-#  		error CONFIG_SYSTEM_NSH_CXXINITIALIZE Must not be defined! Use CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE.
-#	endif
+bool WorkItem::Init(const wq_config_t &config)
+{
+	px4::WorkQueue *wq = WorkQueueFindOrCreate(config);
 
-#else
-#  error platform is dependent on c++ both CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE must be defined.
-#endif
-
-
-#if !defined(CONFIG_DEV_CONSOLE) && defined(CONFIG_DEV_NULL)
-
-	/* Support running nsh on a board with out a console
-	 * Without this the assumption that the fd 0..2 are
-	 * std{in..err} will be wrong. NSH will read/write to the
-	 * fd it opens for the init script or nested scripts assigned
-	 * to fd 0..2.
-	 *
-	 */
-
-	int fd = open("/dev/null", O_RDWR);
-
-	if (fd == 0) {
-		/* Successfully opened /dev/null as stdin (fd == 0) */
-
-		(void)fs_dupfd2(0, 1);
-		(void)fs_dupfd2(0, 2);
-		(void)fs_fdopen(0, O_RDONLY,         NULL);
-		(void)fs_fdopen(1, O_WROK | O_CREAT, NULL);
-		(void)fs_fdopen(2, O_WROK | O_CREAT, NULL);
+	if (wq == nullptr) {
+		PX4_ERR("%s not available", config.name);
 
 	} else {
-		/* We failed to open /dev/null OR for some reason, we opened
-		 * it and got some file descriptor other than 0.
-		 */
-
-		if (fd > 0) {
-			(void)close(fd);
-		}
-
-		return -ENFILE;
+		_wq = wq;
+		return true;
 	}
 
-#endif
-
-	hrt_init();
-
-	param_init();
-
-	/* configure CPU load estimation */
-#ifdef CONFIG_SCHED_INSTRUMENTATION
-	cpuload_initialize_once();
-#endif
-
-	px4::WorkQueueManagerStart();
-
-	return PX4_OK;
+	return false;
 }
+
+} // namespace px4

--- a/src/platforms/common/px4_work_queue/WorkItem.hpp
+++ b/src/platforms/common/px4_work_queue/WorkItem.hpp
@@ -31,81 +31,40 @@
  *
  ****************************************************************************/
 
-#include "px4_init.h"
+#pragma once
 
-#include <px4_config.h>
+
+#include "WorkQueueManager.hpp"
+#include "WorkQueue.hpp"
+
+#include <containers/Queue.hpp>
 #include <px4_defines.h>
 #include <drivers/drv_hrt.h>
-#include <lib/parameters/param.h>
-#include <px4_work_queue/WorkQueueManager.hpp>
-#include <systemlib/cpuload.h>
 
-#include <fcntl.h>
-
-
-#include "platform/cxxinitialize.h"
-
-int px4_platform_init(void)
+namespace px4
 {
 
-#if defined(CONFIG_HAVE_CXX) && defined(CONFIG_HAVE_CXXINITIALIZE)
-	/* run C++ ctors before we go any further */
-	up_cxxinitialize();
+class WorkItem : public QueueNode<WorkItem *>
+{
+public:
 
-#	if defined(CONFIG_SYSTEM_NSH_CXXINITIALIZE)
-#  		error CONFIG_SYSTEM_NSH_CXXINITIALIZE Must not be defined! Use CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE.
-#	endif
+	explicit WorkItem(const wq_config_t &config);
+	WorkItem() = delete;
 
-#else
-#  error platform is dependent on c++ both CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE must be defined.
-#endif
+	virtual ~WorkItem() = default;
 
+	inline void ScheduleNow() { if (_wq != nullptr) _wq->Add(this); }
 
-#if !defined(CONFIG_DEV_CONSOLE) && defined(CONFIG_DEV_NULL)
+	virtual void Run() = 0;
 
-	/* Support running nsh on a board with out a console
-	 * Without this the assumption that the fd 0..2 are
-	 * std{in..err} will be wrong. NSH will read/write to the
-	 * fd it opens for the init script or nested scripts assigned
-	 * to fd 0..2.
-	 *
-	 */
+protected:
 
-	int fd = open("/dev/null", O_RDWR);
+	bool Init(const wq_config_t &config);
 
-	if (fd == 0) {
-		/* Successfully opened /dev/null as stdin (fd == 0) */
+private:
 
-		(void)fs_dupfd2(0, 1);
-		(void)fs_dupfd2(0, 2);
-		(void)fs_fdopen(0, O_RDONLY,         NULL);
-		(void)fs_fdopen(1, O_WROK | O_CREAT, NULL);
-		(void)fs_fdopen(2, O_WROK | O_CREAT, NULL);
+	WorkQueue *_wq{nullptr};
 
-	} else {
-		/* We failed to open /dev/null OR for some reason, we opened
-		 * it and got some file descriptor other than 0.
-		 */
+};
 
-		if (fd > 0) {
-			(void)close(fd);
-		}
-
-		return -ENFILE;
-	}
-
-#endif
-
-	hrt_init();
-
-	param_init();
-
-	/* configure CPU load estimation */
-#ifdef CONFIG_SCHED_INSTRUMENTATION
-	cpuload_initialize_once();
-#endif
-
-	px4::WorkQueueManagerStart();
-
-	return PX4_OK;
-}
+} // namespace px4

--- a/src/platforms/common/px4_work_queue/WorkQueue.cpp
+++ b/src/platforms/common/px4_work_queue/WorkQueue.cpp
@@ -31,81 +31,81 @@
  *
  ****************************************************************************/
 
-#include "px4_init.h"
+#include "WorkQueue.hpp"
+#include "WorkItem.hpp"
 
-#include <px4_config.h>
-#include <px4_defines.h>
+#include <string.h>
+
+#include <px4_tasks.h>
+#include <px4_time.h>
 #include <drivers/drv_hrt.h>
-#include <lib/parameters/param.h>
-#include <px4_work_queue/WorkQueueManager.hpp>
-#include <systemlib/cpuload.h>
 
-#include <fcntl.h>
-
-
-#include "platform/cxxinitialize.h"
-
-int px4_platform_init(void)
+namespace px4
 {
 
-#if defined(CONFIG_HAVE_CXX) && defined(CONFIG_HAVE_CXXINITIALIZE)
-	/* run C++ ctors before we go any further */
-	up_cxxinitialize();
-
-#	if defined(CONFIG_SYSTEM_NSH_CXXINITIALIZE)
-#  		error CONFIG_SYSTEM_NSH_CXXINITIALIZE Must not be defined! Use CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE.
-#	endif
-
-#else
-#  error platform is dependent on c++ both CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE must be defined.
+WorkQueue::WorkQueue(const wq_config_t &config) :
+	_config(config)
+{
+	// set the threads name
+#ifdef __PX4_DARWIN
+	pthread_setname_np(_config.name);
+#elif !defined(__PX4_QURT)
+	pthread_setname_np(pthread_self(), _config.name);
 #endif
 
+#ifndef __PX4_NUTTX
+	px4_sem_init(&_qlock, 0, 1);
+#endif /* __PX4_NUTTX */
 
-#if !defined(CONFIG_DEV_CONSOLE) && defined(CONFIG_DEV_NULL)
+	px4_sem_init(&_process_lock, 0, 0);
+	px4_sem_setprotocol(&_process_lock, SEM_PRIO_NONE);
+}
 
-	/* Support running nsh on a board with out a console
-	 * Without this the assumption that the fd 0..2 are
-	 * std{in..err} will be wrong. NSH will read/write to the
-	 * fd it opens for the init script or nested scripts assigned
-	 * to fd 0..2.
-	 *
-	 */
+WorkQueue::~WorkQueue()
+{
+	work_lock();
+	px4_sem_destroy(&_process_lock);
+	work_unlock();
 
-	int fd = open("/dev/null", O_RDWR);
+#ifndef __PX4_NUTTX
+	px4_sem_destroy(&_qlock);
+#endif /* __PX4_NUTTX */
+}
 
-	if (fd == 0) {
-		/* Successfully opened /dev/null as stdin (fd == 0) */
+void WorkQueue::Add(WorkItem *item)
+{
+	work_lock();
+	_q.push(item);
+	work_unlock();
 
-		(void)fs_dupfd2(0, 1);
-		(void)fs_dupfd2(0, 2);
-		(void)fs_fdopen(0, O_RDONLY,         NULL);
-		(void)fs_fdopen(1, O_WROK | O_CREAT, NULL);
-		(void)fs_fdopen(2, O_WROK | O_CREAT, NULL);
+	// Wake up the worker thread
+	px4_sem_post(&_process_lock);
+}
 
-	} else {
-		/* We failed to open /dev/null OR for some reason, we opened
-		 * it and got some file descriptor other than 0.
-		 */
+void WorkQueue::Run()
+{
+	while (!should_exit()) {
+		px4_sem_wait(&_process_lock);
 
-		if (fd > 0) {
-			(void)close(fd);
+		work_lock();
+
+		// process queued work
+		while (!_q.empty()) {
+			WorkItem *work = _q.front();
+			_q.pop();
+
+			work_unlock(); // unlock work queue to run (item may requeue itself)
+			work->Run();
+			work_lock(); // re-lock
 		}
 
-		return -ENFILE;
+		work_unlock();
 	}
-
-#endif
-
-	hrt_init();
-
-	param_init();
-
-	/* configure CPU load estimation */
-#ifdef CONFIG_SCHED_INSTRUMENTATION
-	cpuload_initialize_once();
-#endif
-
-	px4::WorkQueueManagerStart();
-
-	return PX4_OK;
 }
+
+void WorkQueue::print_status()
+{
+	PX4_INFO("WorkQueue: %s running", get_name());
+}
+
+} // namespace px4

--- a/src/platforms/common/px4_work_queue/WorkQueue.hpp
+++ b/src/platforms/common/px4_work_queue/WorkQueue.hpp
@@ -31,81 +31,64 @@
  *
  ****************************************************************************/
 
-#include "px4_init.h"
+#pragma once
 
-#include <px4_config.h>
+#include "WorkQueueManager.hpp"
+
+#include <containers/List.hpp>
+#include <containers/Queue.hpp>
+#include <px4_atomic.h>
 #include <px4_defines.h>
-#include <drivers/drv_hrt.h>
-#include <lib/parameters/param.h>
-#include <px4_work_queue/WorkQueueManager.hpp>
-#include <systemlib/cpuload.h>
+#include <px4_sem.h>
+#include <px4_tasks.h>
 
-#include <fcntl.h>
-
-
-#include "platform/cxxinitialize.h"
-
-int px4_platform_init(void)
+namespace px4
 {
 
-#if defined(CONFIG_HAVE_CXX) && defined(CONFIG_HAVE_CXXINITIALIZE)
-	/* run C++ ctors before we go any further */
-	up_cxxinitialize();
+class WorkItem;
 
-#	if defined(CONFIG_SYSTEM_NSH_CXXINITIALIZE)
-#  		error CONFIG_SYSTEM_NSH_CXXINITIALIZE Must not be defined! Use CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE.
-#	endif
+class WorkQueue : public ListNode<WorkQueue *>
+{
+public:
+	explicit WorkQueue(const wq_config_t &wq_config);
+	WorkQueue() = delete;
 
+	~WorkQueue();
+
+	const char *get_name() { return _config.name; }
+
+	void Add(WorkItem *item);
+
+	// TODO: need helpers to handle clean shutdown - remove and clear?
+	//void remove(WorkItem *item);
+	//void clear();
+
+	void Run();
+
+	void request_stop() { _should_exit.store(true); }
+
+	void print_status();
+
+private:
+
+	bool should_exit() const { return _should_exit.load(); }
+
+#ifdef __PX4_NUTTX
+	void work_lock() { _flags = enter_critical_section(); }
+	void work_unlock() { leave_critical_section(_flags); }
+	irqstate_t _flags;
 #else
-#  error platform is dependent on c++ both CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE must be defined.
+	void work_lock() { px4_sem_wait(&_qlock); }
+	void work_unlock() { px4_sem_post(&_qlock); }
+	px4_sem_t _qlock;
 #endif
 
+	Queue<WorkItem *>	_q;
+	px4_sem_t		_process_lock;
 
-#if !defined(CONFIG_DEV_CONSOLE) && defined(CONFIG_DEV_NULL)
+	px4::atomic_bool	_should_exit{false};
+	const wq_config_t	&_config;
 
-	/* Support running nsh on a board with out a console
-	 * Without this the assumption that the fd 0..2 are
-	 * std{in..err} will be wrong. NSH will read/write to the
-	 * fd it opens for the init script or nested scripts assigned
-	 * to fd 0..2.
-	 *
-	 */
+};
 
-	int fd = open("/dev/null", O_RDWR);
-
-	if (fd == 0) {
-		/* Successfully opened /dev/null as stdin (fd == 0) */
-
-		(void)fs_dupfd2(0, 1);
-		(void)fs_dupfd2(0, 2);
-		(void)fs_fdopen(0, O_RDONLY,         NULL);
-		(void)fs_fdopen(1, O_WROK | O_CREAT, NULL);
-		(void)fs_fdopen(2, O_WROK | O_CREAT, NULL);
-
-	} else {
-		/* We failed to open /dev/null OR for some reason, we opened
-		 * it and got some file descriptor other than 0.
-		 */
-
-		if (fd > 0) {
-			(void)close(fd);
-		}
-
-		return -ENFILE;
-	}
-
-#endif
-
-	hrt_init();
-
-	param_init();
-
-	/* configure CPU load estimation */
-#ifdef CONFIG_SCHED_INSTRUMENTATION
-	cpuload_initialize_once();
-#endif
-
-	px4::WorkQueueManagerStart();
-
-	return PX4_OK;
-}
+} // namespace px4

--- a/src/platforms/common/px4_work_queue/WorkQueueManager.cpp
+++ b/src/platforms/common/px4_work_queue/WorkQueueManager.cpp
@@ -1,0 +1,259 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "WorkQueueManager.hpp"
+
+#include "WorkQueue.hpp"
+
+#include <string.h>
+
+#include <drivers/drv_hrt.h>
+#include <px4_posix.h>
+#include <px4_tasks.h>
+#include <px4_time.h>
+#include <px4_atomic.h>
+#include <containers/BlockingList.hpp>
+#include <containers/BlockingQueue.hpp>
+
+#include <lib/drivers/device/Device.hpp>
+
+using namespace time_literals;
+
+namespace px4
+{
+
+// list of current work queues
+static BlockingList<WorkQueue *> _wq_manager_wqs_list;
+
+// queue of WorkQueues to be created (as threads in the wq manager task)
+static BlockingQueue<const wq_config_t *, 1> _wq_manager_create_queue;
+
+static px4::atomic_bool _wq_manager_should_exit{false};
+
+
+static WorkQueue *FindWorkQueueByName(const char *name)
+{
+	auto lg = _wq_manager_wqs_list.getLockGuard();
+
+	// search list
+	for (WorkQueue *wq : _wq_manager_wqs_list) {
+		if (strcmp(wq->get_name(), name) == 0) {
+			return wq;
+		}
+	}
+
+	return nullptr;
+}
+
+WorkQueue *WorkQueueFindOrCreate(const wq_config_t &new_wq)
+{
+	// search list for existing work queue
+	WorkQueue *wq = FindWorkQueueByName(new_wq.name);
+
+	// create work queue if it doesn't already exist
+	if (wq == nullptr) {
+
+		// add WQ config to list
+		//  main thread wakes up, creates the thread
+		_wq_manager_create_queue.push(&new_wq);
+
+		// we wait until new wq is created, then return
+		uint64_t t = 0;
+
+		while (wq == nullptr && t < 10_s) {
+			// Wait up to 10 seconds, checking every 1 ms
+			t += 1_ms;
+			px4_usleep(1_ms);
+
+			wq = FindWorkQueueByName(new_wq.name);
+		}
+
+		if (wq == nullptr) {
+			PX4_ERR("failed to create %s", new_wq.name);
+		}
+	}
+
+	return wq;
+}
+
+const wq_config_t &device_bus_to_wq(uint32_t device_id_int)
+{
+	union device::Device::DeviceId device_id;
+	device_id.devid = device_id_int;
+
+	const device::Device::DeviceBusType bus_type = device_id.devid_s.bus_type;
+	const uint8_t bus = device_id.devid_s.bus;
+
+	if (bus_type == device::Device::DeviceBusType_I2C) {
+		switch (bus) {
+		case 1: return wq_configurations::I2C1;
+
+		case 2: return wq_configurations::I2C2;
+
+		case 3: return wq_configurations::I2C3;
+
+		case 4: return wq_configurations::I2C4;
+		}
+
+	} else if (bus_type == device::Device::DeviceBusType_SPI) {
+		switch (bus) {
+		case 1: return wq_configurations::SPI1;
+
+		case 2: return wq_configurations::SPI2;
+
+		case 3: return wq_configurations::SPI3;
+
+		case 4: return wq_configurations::SPI4;
+
+		case 5: return wq_configurations::SPI5;
+
+		case 6: return wq_configurations::SPI6;
+		}
+	}
+
+	// otherwise use high priority
+	return wq_configurations::hp_default;
+};
+
+static void *WorkQueueRunner(void *context)
+{
+	wq_config_t *config = static_cast<wq_config_t *>(context);
+	WorkQueue wq(*config);
+
+	// add to work queue list
+	_wq_manager_wqs_list.add(&wq);
+
+	wq.Run();
+
+	// remove from work queue list
+	_wq_manager_wqs_list.remove(&wq);
+
+	return nullptr;
+}
+
+static void WorkQueueManagerRun()
+{
+	while (!_wq_manager_should_exit.load()) {
+		// create new work queues as needed
+		const wq_config_t *wq = _wq_manager_create_queue.pop();
+
+		if (wq != nullptr) {
+			// create new work queue
+
+			pthread_attr_t attr;
+			int ret_attr_init = pthread_attr_init(&attr);
+
+			if (ret_attr_init != 0) {
+				PX4_ERR("attr init for %s failed (%i)", wq->name, ret_attr_init);
+			}
+
+			sched_param param;
+			int ret_getschedparam = pthread_attr_getschedparam(&attr, &param);
+
+			if (ret_getschedparam != 0) {
+				PX4_ERR("getting sched param for %s failed (%i)", wq->name, ret_getschedparam);
+			}
+
+			// stack size
+			int ret_setstacksize = pthread_attr_setstacksize(&attr, PX4_STACK_ADJUSTED(wq->stacksize));
+
+			if (ret_setstacksize != 0) {
+				PX4_ERR("setting stack size for %s failed (%i)", wq->name, ret_setstacksize);
+			}
+
+			// priority
+			param.sched_priority = SCHED_PRIORITY_MAX + wq->relative_priority;
+			int ret_setschedparam = pthread_attr_setschedparam(&attr, &param);
+
+			if (ret_setschedparam != 0) {
+				PX4_ERR("setting sched params for %s failed (%i)", wq->name, ret_setschedparam);
+			}
+
+			// create thread
+			pthread_t thread;
+			int ret_create = pthread_create(&thread, &attr, WorkQueueRunner, (void *)wq);
+
+			if (ret_create == 0) {
+				PX4_INFO("creating: %s, priority: %d, stack: %d bytes",
+					 wq->name, param.sched_priority, PX4_STACK_ADJUSTED(wq->stacksize));
+
+			} else {
+				PX4_ERR("failed to create thread for %s (%i)", wq->name, ret_create);
+			}
+
+			// destroy thread attributes
+			int ret_destroy = pthread_attr_destroy(&attr);
+
+			if (ret_destroy != 0) {
+				PX4_ERR("failed to destroy thread attributes for %s (%i)", wq->name, ret_create);
+			}
+		}
+	}
+}
+
+int WorkQueueManagerStart()
+{
+	int task_id = px4_task_spawn_cmd("wq:manager",
+					 SCHED_DEFAULT,
+					 PX4_WQ_HP_BASE,
+					 1200,
+					 (px4_main_t)&WorkQueueManagerRun,
+					 nullptr);
+
+	if (task_id < 0) {
+		PX4_ERR("task start failed (%i)", task_id);
+		return -errno;
+	}
+
+	return 0;
+}
+
+int WorkQueueManagerStop()
+{
+	auto lg = _wq_manager_wqs_list.getLockGuard();
+
+	// ask all work queues (threads) to stop
+	// NOTE: not currently safe without all WorkItems stopping first
+	for (WorkQueue *wq : _wq_manager_wqs_list) {
+		wq->request_stop();
+	}
+
+	_wq_manager_should_exit.store(true);
+
+	// push nullptr to wake the wq manager task
+	_wq_manager_create_queue.push(nullptr);
+
+	return PX4_OK;
+}
+
+} // namespace px4

--- a/src/platforms/common/px4_work_queue/WorkQueueManager.hpp
+++ b/src/platforms/common/px4_work_queue/WorkQueueManager.hpp
@@ -1,0 +1,100 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <stdint.h>
+
+namespace px4
+{
+
+class WorkQueue; // forward declaration
+
+struct wq_config_t {
+	const char *name;
+	uint16_t stacksize;
+	int8_t relative_priority; // relative to max
+};
+
+namespace wq_configurations
+{
+static constexpr wq_config_t rate_ctrl{"wq:rate_ctrl", 1500, 0}; // PX4 inner loop highest priority
+
+static constexpr wq_config_t SPI1{"wq:SPI1", 1200, -1};
+static constexpr wq_config_t SPI2{"wq:SPI2", 1200, -2};
+static constexpr wq_config_t SPI3{"wq:SPI3", 1200, -3};
+static constexpr wq_config_t SPI4{"wq:SPI4", 1200, -4};
+static constexpr wq_config_t SPI5{"wq:SPI5", 1200, -5};
+static constexpr wq_config_t SPI6{"wq:SPI6", 1200, -6};
+
+static constexpr wq_config_t I2C1{"wq:I2C1", 1000, -7};
+static constexpr wq_config_t I2C2{"wq:I2C2", 1000, -8};
+static constexpr wq_config_t I2C3{"wq:I2C3", 1000, -9};
+static constexpr wq_config_t I2C4{"wq:I2C4", 1000, -10};
+
+static constexpr wq_config_t hp_default{"wq:hp_default", 1000, -11};
+static constexpr wq_config_t lp_default{"wq:lp_default", 1000, -50};
+
+static constexpr wq_config_t test1{"wq:test1", 800, 0};
+static constexpr wq_config_t test2{"wq:test2", 800, 0};
+
+} // namespace wq_configurations
+
+/**
+ * Start the work queue manager task.
+ */
+int WorkQueueManagerStart();
+
+/**
+ * Stop the work queue manager task.
+ */
+int WorkQueueManagerStop();
+
+/**
+ * Create (or find) a work queue with a particular configuration.
+ *
+ * @param new_wq		The work queue configuration (see WorkQueueManager.hpp).
+ * @return		A pointer to the WorkQueue, or nullptr on failure.
+ */
+WorkQueue *WorkQueueFindOrCreate(const wq_config_t &new_wq);
+
+/**
+ * Map a PX4 driver device id to a work queue (by sensor bus).
+ *
+ * @param device_id		The PX4 driver's device id.
+ * @return		A work queue configuration.
+ */
+const wq_config_t &device_bus_to_wq(uint32_t device_id);
+
+
+} // namespace px4

--- a/src/platforms/common/px4_work_queue/test/CMakeLists.txt
+++ b/src/platforms/common/px4_work_queue/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2019 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,22 +31,14 @@
 #
 ############################################################################
 
-# skip for px4_layer support on an IO board
-if (NOT ${PX4_BOARD} MATCHES "px4_io")
-
-	add_library(px4_layer
-		px4_nuttx_tasks.c
-		px4_nuttx_impl.cpp
-		px4_init.cpp
+px4_add_module(
+	MODULE lib__work_queue__test__wqueue_test
+	MAIN wqueue_test
+	SRCS
+		wqueue_main.cpp
+		wqueue_scheduled_test.cpp
+		wqueue_start.cpp
+		wqueue_test.cpp
+	DEPENDS
+		px4_work_queue
 	)
-	target_link_libraries(px4_layer
-		PRIVATE
-			nuttx_apps # up_cxxinitialize
-			nuttx_sched
-			drivers_boards_common_arch
-			px4_work_queue
-		)
-else()
-	add_library(px4_layer ${PX4_SOURCE_DIR}/src/platforms/empty.c)
-endif()
-add_dependencies(px4_layer prebuild_targets)

--- a/src/platforms/common/px4_work_queue/test/wqueue_main.cpp
+++ b/src/platforms/common/px4_work_queue/test/wqueue_main.cpp
@@ -31,81 +31,27 @@
  *
  ****************************************************************************/
 
-#include "px4_init.h"
+#include "wqueue_test.h"
+#include "wqueue_scheduled_test.h"
 
-#include <px4_config.h>
-#include <px4_defines.h>
-#include <drivers/drv_hrt.h>
-#include <lib/parameters/param.h>
-#include <px4_work_queue/WorkQueueManager.hpp>
-#include <systemlib/cpuload.h>
+#include <px4_log.h>
+#include <px4_middleware.h>
+#include <px4_app.h>
+#include <stdio.h>
 
-#include <fcntl.h>
-
-
-#include "platform/cxxinitialize.h"
-
-int px4_platform_init(void)
+int PX4_MAIN(int argc, char **argv)
 {
+	px4::init(argc, argv, "wqueue_test");
 
-#if defined(CONFIG_HAVE_CXX) && defined(CONFIG_HAVE_CXXINITIALIZE)
-	/* run C++ ctors before we go any further */
-	up_cxxinitialize();
+	PX4_INFO("wqueue test 1");
+	WQueueTest wq1;
+	wq1.main();
 
-#	if defined(CONFIG_SYSTEM_NSH_CXXINITIALIZE)
-#  		error CONFIG_SYSTEM_NSH_CXXINITIALIZE Must not be defined! Use CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE.
-#	endif
+	PX4_INFO("wqueue test 2 (scheduled)");
+	WQueueScheduledTest wq2;
+	wq2.main();
 
-#else
-#  error platform is dependent on c++ both CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE must be defined.
-#endif
+	PX4_INFO("wqueue test complete, exiting");
 
-
-#if !defined(CONFIG_DEV_CONSOLE) && defined(CONFIG_DEV_NULL)
-
-	/* Support running nsh on a board with out a console
-	 * Without this the assumption that the fd 0..2 are
-	 * std{in..err} will be wrong. NSH will read/write to the
-	 * fd it opens for the init script or nested scripts assigned
-	 * to fd 0..2.
-	 *
-	 */
-
-	int fd = open("/dev/null", O_RDWR);
-
-	if (fd == 0) {
-		/* Successfully opened /dev/null as stdin (fd == 0) */
-
-		(void)fs_dupfd2(0, 1);
-		(void)fs_dupfd2(0, 2);
-		(void)fs_fdopen(0, O_RDONLY,         NULL);
-		(void)fs_fdopen(1, O_WROK | O_CREAT, NULL);
-		(void)fs_fdopen(2, O_WROK | O_CREAT, NULL);
-
-	} else {
-		/* We failed to open /dev/null OR for some reason, we opened
-		 * it and got some file descriptor other than 0.
-		 */
-
-		if (fd > 0) {
-			(void)close(fd);
-		}
-
-		return -ENFILE;
-	}
-
-#endif
-
-	hrt_init();
-
-	param_init();
-
-	/* configure CPU load estimation */
-#ifdef CONFIG_SCHED_INSTRUMENTATION
-	cpuload_initialize_once();
-#endif
-
-	px4::WorkQueueManagerStart();
-
-	return PX4_OK;
+	return 0;
 }

--- a/src/platforms/common/px4_work_queue/test/wqueue_scheduled_test.h
+++ b/src/platforms/common/px4_work_queue/test/wqueue_scheduled_test.h
@@ -31,81 +31,26 @@
  *
  ****************************************************************************/
 
-#include "px4_init.h"
+#pragma once
 
-#include <px4_config.h>
-#include <px4_defines.h>
-#include <drivers/drv_hrt.h>
-#include <lib/parameters/param.h>
-#include <px4_work_queue/WorkQueueManager.hpp>
-#include <systemlib/cpuload.h>
+#include <px4_app.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
+#include <string.h>
 
-#include <fcntl.h>
+using namespace px4;
 
-
-#include "platform/cxxinitialize.h"
-
-int px4_platform_init(void)
+class WQueueScheduledTest : public px4::ScheduledWorkItem
 {
+public:
+	WQueueScheduledTest() : px4::ScheduledWorkItem(px4::wq_configurations::test2) {}
+	~WQueueScheduledTest() = default;
 
-#if defined(CONFIG_HAVE_CXX) && defined(CONFIG_HAVE_CXXINITIALIZE)
-	/* run C++ ctors before we go any further */
-	up_cxxinitialize();
+	int main();
 
-#	if defined(CONFIG_SYSTEM_NSH_CXXINITIALIZE)
-#  		error CONFIG_SYSTEM_NSH_CXXINITIALIZE Must not be defined! Use CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE.
-#	endif
+	void Run() override;
 
-#else
-#  error platform is dependent on c++ both CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE must be defined.
-#endif
+	static px4::AppState appState; /* track requests to terminate app */
 
-
-#if !defined(CONFIG_DEV_CONSOLE) && defined(CONFIG_DEV_NULL)
-
-	/* Support running nsh on a board with out a console
-	 * Without this the assumption that the fd 0..2 are
-	 * std{in..err} will be wrong. NSH will read/write to the
-	 * fd it opens for the init script or nested scripts assigned
-	 * to fd 0..2.
-	 *
-	 */
-
-	int fd = open("/dev/null", O_RDWR);
-
-	if (fd == 0) {
-		/* Successfully opened /dev/null as stdin (fd == 0) */
-
-		(void)fs_dupfd2(0, 1);
-		(void)fs_dupfd2(0, 2);
-		(void)fs_fdopen(0, O_RDONLY,         NULL);
-		(void)fs_fdopen(1, O_WROK | O_CREAT, NULL);
-		(void)fs_fdopen(2, O_WROK | O_CREAT, NULL);
-
-	} else {
-		/* We failed to open /dev/null OR for some reason, we opened
-		 * it and got some file descriptor other than 0.
-		 */
-
-		if (fd > 0) {
-			(void)close(fd);
-		}
-
-		return -ENFILE;
-	}
-
-#endif
-
-	hrt_init();
-
-	param_init();
-
-	/* configure CPU load estimation */
-#ifdef CONFIG_SCHED_INSTRUMENTATION
-	cpuload_initialize_once();
-#endif
-
-	px4::WorkQueueManagerStart();
-
-	return PX4_OK;
-}
+private:
+	int _iter{0};
+};

--- a/src/platforms/common/px4_work_queue/test/wqueue_start.cpp
+++ b/src/platforms/common/px4_work_queue/test/wqueue_start.cpp
@@ -31,81 +31,60 @@
  *
  ****************************************************************************/
 
-#include "px4_init.h"
+#include "wqueue_test.h"
 
-#include <px4_config.h>
-#include <px4_defines.h>
-#include <drivers/drv_hrt.h>
-#include <lib/parameters/param.h>
-#include <px4_work_queue/WorkQueueManager.hpp>
-#include <systemlib/cpuload.h>
+#include <px4_app.h>
+#include <px4_log.h>
+#include <px4_tasks.h>
+#include <stdio.h>
+#include <string.h>
+#include <sched.h>
 
-#include <fcntl.h>
+static int daemon_task = -1;             /* Handle of daemon task / thread */
 
-
-#include "platform/cxxinitialize.h"
-
-int px4_platform_init(void)
+extern "C" __EXPORT int wqueue_test_main(int argc, char *argv[]);
+int wqueue_test_main(int argc, char *argv[])
 {
 
-#if defined(CONFIG_HAVE_CXX) && defined(CONFIG_HAVE_CXXINITIALIZE)
-	/* run C++ ctors before we go any further */
-	up_cxxinitialize();
-
-#	if defined(CONFIG_SYSTEM_NSH_CXXINITIALIZE)
-#  		error CONFIG_SYSTEM_NSH_CXXINITIALIZE Must not be defined! Use CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE.
-#	endif
-
-#else
-#  error platform is dependent on c++ both CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE must be defined.
-#endif
-
-
-#if !defined(CONFIG_DEV_CONSOLE) && defined(CONFIG_DEV_NULL)
-
-	/* Support running nsh on a board with out a console
-	 * Without this the assumption that the fd 0..2 are
-	 * std{in..err} will be wrong. NSH will read/write to the
-	 * fd it opens for the init script or nested scripts assigned
-	 * to fd 0..2.
-	 *
-	 */
-
-	int fd = open("/dev/null", O_RDWR);
-
-	if (fd == 0) {
-		/* Successfully opened /dev/null as stdin (fd == 0) */
-
-		(void)fs_dupfd2(0, 1);
-		(void)fs_dupfd2(0, 2);
-		(void)fs_fdopen(0, O_RDONLY,         NULL);
-		(void)fs_fdopen(1, O_WROK | O_CREAT, NULL);
-		(void)fs_fdopen(2, O_WROK | O_CREAT, NULL);
-
-	} else {
-		/* We failed to open /dev/null OR for some reason, we opened
-		 * it and got some file descriptor other than 0.
-		 */
-
-		if (fd > 0) {
-			(void)close(fd);
-		}
-
-		return -ENFILE;
+	if (argc < 2) {
+		PX4_INFO("usage: wqueue_test {start|stop|status}\n");
+		return 1;
 	}
 
-#endif
+	if (!strcmp(argv[1], "start")) {
 
-	hrt_init();
+		if (WQueueTest::appState.isRunning()) {
+			PX4_INFO("already running\n");
+			/* this is not an error */
+			return 0;
+		}
 
-	param_init();
+		daemon_task = px4_task_spawn_cmd("wqueue",
+						 SCHED_DEFAULT,
+						 SCHED_PRIORITY_MAX - 5,
+						 2000,
+						 PX4_MAIN,
+						 (argv) ? (char *const *)&argv[2] : (char *const *)nullptr);
 
-	/* configure CPU load estimation */
-#ifdef CONFIG_SCHED_INSTRUMENTATION
-	cpuload_initialize_once();
-#endif
+		return 0;
+	}
 
-	px4::WorkQueueManagerStart();
+	if (!strcmp(argv[1], "stop")) {
+		WQueueTest::appState.requestExit();
+		return 0;
+	}
 
-	return PX4_OK;
+	if (!strcmp(argv[1], "status")) {
+		if (WQueueTest::appState.isRunning()) {
+			PX4_INFO("is running\n");
+
+		} else {
+			PX4_INFO("not started\n");
+		}
+
+		return 0;
+	}
+
+	PX4_INFO("usage: wqueue_test {start|stop|status}\n");
+	return 1;
 }

--- a/src/platforms/common/px4_work_queue/test/wqueue_test.cpp
+++ b/src/platforms/common/px4_work_queue/test/wqueue_test.cpp
@@ -31,81 +31,53 @@
  *
  ****************************************************************************/
 
-#include "px4_init.h"
+#include "wqueue_test.h"
 
-#include <px4_config.h>
-#include <px4_defines.h>
 #include <drivers/drv_hrt.h>
-#include <lib/parameters/param.h>
-#include <px4_work_queue/WorkQueueManager.hpp>
-#include <systemlib/cpuload.h>
+#include <px4_log.h>
+#include <px4_time.h>
 
-#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <inttypes.h>
 
+using namespace px4;
 
-#include "platform/cxxinitialize.h"
+AppState WQueueTest::appState;
 
-int px4_platform_init(void)
+void WQueueTest::Run()
 {
+	//PX4_INFO("iter: %d elapsed: %" PRId64 " us", _iter, hrt_elapsed_time(&_qtime));
 
-#if defined(CONFIG_HAVE_CXX) && defined(CONFIG_HAVE_CXXINITIALIZE)
-	/* run C++ ctors before we go any further */
-	up_cxxinitialize();
-
-#	if defined(CONFIG_SYSTEM_NSH_CXXINITIALIZE)
-#  		error CONFIG_SYSTEM_NSH_CXXINITIALIZE Must not be defined! Use CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE.
-#	endif
-
-#else
-#  error platform is dependent on c++ both CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE must be defined.
-#endif
-
-
-#if !defined(CONFIG_DEV_CONSOLE) && defined(CONFIG_DEV_NULL)
-
-	/* Support running nsh on a board with out a console
-	 * Without this the assumption that the fd 0..2 are
-	 * std{in..err} will be wrong. NSH will read/write to the
-	 * fd it opens for the init script or nested scripts assigned
-	 * to fd 0..2.
-	 *
-	 */
-
-	int fd = open("/dev/null", O_RDWR);
-
-	if (fd == 0) {
-		/* Successfully opened /dev/null as stdin (fd == 0) */
-
-		(void)fs_dupfd2(0, 1);
-		(void)fs_dupfd2(0, 2);
-		(void)fs_fdopen(0, O_RDONLY,         NULL);
-		(void)fs_fdopen(1, O_WROK | O_CREAT, NULL);
-		(void)fs_fdopen(2, O_WROK | O_CREAT, NULL);
+	if (_iter > 10000) {
+		appState.requestExit();
 
 	} else {
-		/* We failed to open /dev/null OR for some reason, we opened
-		 * it and got some file descriptor other than 0.
-		 */
-
-		if (fd > 0) {
-			(void)close(fd);
-		}
-
-		return -ENFILE;
+		ScheduleNow();
 	}
 
-#endif
+	_iter++;
+}
 
-	hrt_init();
+int WQueueTest::main()
+{
+	appState.setRunning(true);
 
-	param_init();
+	_iter = 0;
 
-	/* configure CPU load estimation */
-#ifdef CONFIG_SCHED_INSTRUMENTATION
-	cpuload_initialize_once();
-#endif
+	// Put work in the work queue
+	ScheduleNow();
 
-	px4::WorkQueueManagerStart();
+	// Wait for work to finsh
+	while (!appState.exitRequested()) {
+		px4_usleep(5000);
+	}
 
-	return PX4_OK;
+	PX4_INFO("WQueueTest finished");
+
+	//print_status();
+
+	px4_sleep(2);
+
+	return 0;
 }

--- a/src/platforms/common/px4_work_queue/test/wqueue_test.h
+++ b/src/platforms/common/px4_work_queue/test/wqueue_test.h
@@ -31,81 +31,26 @@
  *
  ****************************************************************************/
 
-#include "px4_init.h"
+#pragma once
 
-#include <px4_config.h>
-#include <px4_defines.h>
-#include <drivers/drv_hrt.h>
-#include <lib/parameters/param.h>
-#include <px4_work_queue/WorkQueueManager.hpp>
-#include <systemlib/cpuload.h>
+#include <px4_app.h>
+#include <px4_work_queue/WorkItem.hpp>
+#include <string.h>
 
-#include <fcntl.h>
+using namespace px4;
 
-
-#include "platform/cxxinitialize.h"
-
-int px4_platform_init(void)
+class WQueueTest : public px4::WorkItem
 {
+public:
+	WQueueTest() : px4::WorkItem(px4::wq_configurations::test1) {}
+	~WQueueTest() = default;
 
-#if defined(CONFIG_HAVE_CXX) && defined(CONFIG_HAVE_CXXINITIALIZE)
-	/* run C++ ctors before we go any further */
-	up_cxxinitialize();
+	int main();
 
-#	if defined(CONFIG_SYSTEM_NSH_CXXINITIALIZE)
-#  		error CONFIG_SYSTEM_NSH_CXXINITIALIZE Must not be defined! Use CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE.
-#	endif
+	void Run() override;
 
-#else
-#  error platform is dependent on c++ both CONFIG_HAVE_CXX and CONFIG_HAVE_CXXINITIALIZE must be defined.
-#endif
+	static px4::AppState appState; /* track requests to terminate app */
 
-
-#if !defined(CONFIG_DEV_CONSOLE) && defined(CONFIG_DEV_NULL)
-
-	/* Support running nsh on a board with out a console
-	 * Without this the assumption that the fd 0..2 are
-	 * std{in..err} will be wrong. NSH will read/write to the
-	 * fd it opens for the init script or nested scripts assigned
-	 * to fd 0..2.
-	 *
-	 */
-
-	int fd = open("/dev/null", O_RDWR);
-
-	if (fd == 0) {
-		/* Successfully opened /dev/null as stdin (fd == 0) */
-
-		(void)fs_dupfd2(0, 1);
-		(void)fs_dupfd2(0, 2);
-		(void)fs_fdopen(0, O_RDONLY,         NULL);
-		(void)fs_fdopen(1, O_WROK | O_CREAT, NULL);
-		(void)fs_fdopen(2, O_WROK | O_CREAT, NULL);
-
-	} else {
-		/* We failed to open /dev/null OR for some reason, we opened
-		 * it and got some file descriptor other than 0.
-		 */
-
-		if (fd > 0) {
-			(void)close(fd);
-		}
-
-		return -ENFILE;
-	}
-
-#endif
-
-	hrt_init();
-
-	param_init();
-
-	/* configure CPU load estimation */
-#ifdef CONFIG_SCHED_INSTRUMENTATION
-	cpuload_initialize_once();
-#endif
-
-	px4::WorkQueueManagerStart();
-
-	return PX4_OK;
-}
+private:
+	int _iter{0};
+};

--- a/src/platforms/px4_tasks.h
+++ b/src/platforms/px4_tasks.h
@@ -100,6 +100,9 @@ typedef struct {
 #error "No target OS defined"
 #endif
 
+// PX4 work queue starting high priority
+#define PX4_WQ_HP_BASE (SCHED_PRIORITY_MAX - 11)
+
 // Fast drivers - they need to run as quickly as possible to minimize control
 // latency.
 #define SCHED_PRIORITY_FAST_DRIVER		(SCHED_PRIORITY_MAX - 0)
@@ -108,37 +111,37 @@ typedef struct {
 // they should be the first to run on an update, using the current sensor
 // data and the *previous* attitude reference from the position controller
 // which typically runs at a slower rate
-#define SCHED_PRIORITY_ATTITUDE_CONTROL		(SCHED_PRIORITY_MAX - 4)
+#define SCHED_PRIORITY_ATTITUDE_CONTROL		(PX4_WQ_HP_BASE - 4)
 
 // Actuator outputs should run as soon as the rate controller publishes
 // the actuator controls topic
-#define SCHED_PRIORITY_ACTUATOR_OUTPUTS		(SCHED_PRIORITY_MAX - 3)
+#define SCHED_PRIORITY_ACTUATOR_OUTPUTS		(PX4_WQ_HP_BASE - 3)
 
 // Position controllers typically are in a blocking wait on estimator data
 // so when new sensor data is available they will run last. Keeping them
 // on a high priority ensures that they are the first process to be run
 // when the estimator updates.
-#define SCHED_PRIORITY_POSITION_CONTROL		(SCHED_PRIORITY_MAX - 5)
+#define SCHED_PRIORITY_POSITION_CONTROL		(PX4_WQ_HP_BASE - 5)
 
 // Estimators should run after the attitude controller but before anything
 // else in the system. They wait on sensor data which is either coming
 // from the sensor hub or from a driver. Keeping this class at a higher
 // priority ensures that the estimator runs first if it can, but will
 // wait for the sensor hub if its data is coming from it.
-#define SCHED_PRIORITY_ESTIMATOR		(SCHED_PRIORITY_MAX - 5)
+#define SCHED_PRIORITY_ESTIMATOR		(PX4_WQ_HP_BASE - 5)
 
 // The sensor hub conditions sensor data. It is not the fastest component
 // in the controller chain, but provides easy-to-use data to the more
 // complex downstream consumers
-#define SCHED_PRIORITY_SENSOR_HUB		(SCHED_PRIORITY_MAX - 6)
+#define SCHED_PRIORITY_SENSOR_HUB		(PX4_WQ_HP_BASE - 6)
 
 // The log capture (which stores log data into RAM) should run faster
 // than other components, but should not run before the control pipeline
-#define SCHED_PRIORITY_LOG_CAPTURE		(SCHED_PRIORITY_MAX - 10)
+#define SCHED_PRIORITY_LOG_CAPTURE		(PX4_WQ_HP_BASE - 10)
 
 // Slow drivers should run at a rate where they do not impact the overall
 // system execution
-#define SCHED_PRIORITY_SLOW_DRIVER		(SCHED_PRIORITY_MAX - 35)
+#define SCHED_PRIORITY_SLOW_DRIVER		(PX4_WQ_HP_BASE - 35)
 
 // The navigation system needs to execute regularly but has no realtime needs
 #define SCHED_PRIORITY_NAVIGATION		(SCHED_PRIORITY_DEFAULT + 5)


### PR DESCRIPTION
More background to come, but in short this general px4 work queue will allow us to finally unblock several important things.


 - SPI DMA IMU drivers
 - running rate controllers at 1 kHz or faster
 - better all around real time system performance
 - significant memory savings


Closes https://github.com/PX4/Firmware/issues/8814
 - https://github.com/PX4/Firmware/issues/9891
 - https://github.com/PX4/Firmware/issues/9279
 - https://github.com/PX4/Firmware/pull/10602

Blocked on https://github.com/PX4/Firmware/pull/11302

### Design Notes
Each PX4 module that previously used hrt_calls, HPWORK, or LPWORK can now easily be moved into this framework. These classes inherit either WorkItem to be run as needed, or ScheduledWorkItem if a fixed interval is desired.

The reason for the (somewhat awkward) WorkQueueManager is to get every queue running as a thread within the same task on Nuttx. This significantly reduces overhead, and when combined with uORB changes (https://github.com/PX4/Firmware/pull/11176) has no disadvantages. The cost of each work queue is little more than the stack.

The other option for scheduling WorkItems is something I've bolted into uORB itself. The common pattern throughout most important PX4 modules is a task that polls a uORB topic for updates. Many of these processes are already fundamentally serialized, so the coexistence of all these tasks uses quite a lot of memory. Anything work pipeline (a collection of tasks) that's fundamentally serial can be moved to share the same WorkQueue. Then we can lean on the uORB publication to schedule appropriate work.

