### PR TITLE
gps: Emlid Reach support

### DIFF
--- a/src/drivers/gps/CMakeLists.txt
+++ b/src/drivers/gps/CMakeLists.txt
@@ -44,6 +44,7 @@ px4_add_module(
 		devices/src/ashtech.cpp
 		devices/src/ubx.cpp
 		devices/src/rtcm.cpp
+		devices/src/emlid_reach.cpp
 	MODULE_CONFIG
 		module.yaml
 	DEPENDS

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -86,6 +86,7 @@
 #include "devices/src/ubx.h"
 #include "devices/src/mtk.h"
 #include "devices/src/ashtech.h"
+#include "devices/src/emlid_reach.h"
 
 #ifdef __PX4_LINUX
 #include <linux/spi/spidev.h>
@@ -98,7 +99,8 @@ typedef enum {
 	GPS_DRIVER_MODE_NONE = 0,
 	GPS_DRIVER_MODE_UBX,
 	GPS_DRIVER_MODE_MTK,
-	GPS_DRIVER_MODE_ASHTECH
+	GPS_DRIVER_MODE_ASHTECH,
+	GPS_DRIVER_MODE_EMLIDREACH
 } gps_driver_mode_t;
 
 /* struct for dynamic allocation of satellite info data */
@@ -720,6 +722,10 @@ GPS::run()
 				_helper = new GPSDriverAshtech(&GPS::callback, this, &_report_gps_pos, _p_report_sat_info, heading_offset);
 				break;
 
+			case GPS_DRIVER_MODE_EMLIDREACH:
+				_helper = new GPSDriverEmlidReach(&GPS::callback, this, &_report_gps_pos, _p_report_sat_info);
+				break;
+
 			default:
 				break;
 			}
@@ -782,6 +788,10 @@ GPS::run()
 //							mode_str = "ASHTECH";
 //							break;
 //
+//						case GPS_DRIVER_MODE_EMLIDREACH:
+//							mode_str = "EMLID REACH";
+//							break;
+//
 //						default:
 //							break;
 //						}
@@ -809,6 +819,10 @@ GPS::run()
 					break;
 
 				case GPS_DRIVER_MODE_ASHTECH:
+					_mode = GPS_DRIVER_MODE_EMLIDREACH;
+					break;
+
+				case GPS_DRIVER_MODE_EMLIDREACH:
 					_mode = GPS_DRIVER_MODE_UBX;
 					px4_usleep(500000); // tried all possible drivers. Wait a bit before next round
 					break;
@@ -875,6 +889,10 @@ GPS::print_status()
 
 		case GPS_DRIVER_MODE_ASHTECH:
 			PX4_INFO("protocol: ASHTECH");
+			break;
+
+		case GPS_DRIVER_MODE_EMLIDREACH:
+			PX4_INFO("protocol: EMLIDREACH");
 			break;
 
 		default:
@@ -976,7 +994,7 @@ gps start -d /dev/ttyS3 -e /dev/ttyS4
 	PRINT_MODULE_USAGE_PARAM_FLAG('s', "Enable publication of satellite info", true);
 
 	PRINT_MODULE_USAGE_PARAM_STRING('i', "uart", "spi|uart", "GPS interface", true);
-	PRINT_MODULE_USAGE_PARAM_STRING('p', nullptr, "ubx|mtk|ash", "GPS Protocol (default=auto select)", true);
+	PRINT_MODULE_USAGE_PARAM_STRING('p', nullptr, "ubx|mtk|ash|eml", "GPS Protocol (default=auto select)", true);
 
 	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
 
@@ -1106,6 +1124,9 @@ GPS *GPS::instantiate(int argc, char *argv[], Instance instance)
 
 			} else if (!strcmp(myoptarg, "ash")) {
 				mode = GPS_DRIVER_MODE_ASHTECH;
+
+			} else if (!strcmp(myoptarg, "eml")) {
+				mode = GPS_DRIVER_MODE_EMLIDREACH;
 
 			} else {
 				PX4_ERR("unknown interface: %s", myoptarg);


### PR DESCRIPTION
Support for Emlid Reach in NMEA and ERB format

Related to the pull request 
https://github.com/PX4/GpsDrivers/pull/38

The NMEA part was written first, and then the ERB, because NMEA didn't provide the info for computing the "Down" component for NED velocity. Should both NMEA and ERB be kept in the code ?

This PR does not include support for RTK, which is the next step. But I would like feedback on that work, in case something is wrong in it

The conflict detected is about the gps devices submodules, besides that looks fine

During tests, with Pixhawk 4, I always got:
`Preflight: GPS Horizontal Pos Error too high`
If my understanding is good, that is the **eph** property return by the GPS that is outside threshold
Looks like the threshold can be changed by **EKF2_REQ_EPH**, which is by default 3.0m
That was a surprise because the default GPS receiver of Pixhawk4 always report an error below 1.0 once lock is acquired. Emlid Reach M+ went under 3.0 once only, on around 50 tests.
I am unsure why, but that may be related to using the Reach standalone (without RTCM from base). We also tried with the default Reach GPS antenna and a different one. I will post on Emlid forum about that topic

edit: I played around with emlid config, and now EKF2 accept the position. **eph** is at 2.9.
The **Position Mode** was set from Single to **Kinematic**