### PR TITLE
[Breaking Change]fmuk66-v3: Only Support Rev BX11

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -194,20 +194,13 @@ else
 	#
 	# Start system state indicator.
 	#
-	if ! rgbled start
+	rgbled start
+	rgbled_ncp5623c start
+	rgbled_pwm start
+
+	if blinkm start
 	then
-
-		rgbled_ncp5623c start
-
-		#
-		# FMUv5 may have both PWM I2C RGB LED support.
-		#
-		rgbled_pwm start
-
-		if blinkm start
-		then
-			blinkm systemstate
-		fi
+		blinkm systemstate
 	fi
 
 	#

--- a/boards/nxp/fmuk66-v3/default.cmake
+++ b/boards/nxp/fmuk66-v3/default.cmake
@@ -36,6 +36,7 @@ px4_add_board(
 		lights/blinkm
 		lights/oreoled
 		lights/rgbled
+		lights/rgbled_ncp5623c
 		lights/rgbled_pwm
 		magnetometer # all available magnetometer drivers
 		mkblctrl

--- a/boards/nxp/fmuk66-v3/default.cmake
+++ b/boards/nxp/fmuk66-v3/default.cmake
@@ -12,6 +12,7 @@ px4_add_board(
 	SERIAL_PORTS
 		GPS1:/dev/ttyS3
 		TEL1:/dev/ttyS4
+		TEL2:/dev/ttyS1
 
 	DRIVERS
 		barometer # all available barometer drivers

--- a/boards/nxp/fmuk66-v3/init/rc.board_sensors
+++ b/boards/nxp/fmuk66-v3/init/rc.board_sensors
@@ -7,9 +7,8 @@
 # External I2C bus
 hmc5883 -C -X start
 
-# Internal Mag I2C bus
-echo "error! bmm150 roatation needs to be set"
-bmm150 -R 2 start
+# Internal Mag I2C bus roll 180, yaw 90
+bmm150 -R 10 start
 
 # Possible external compasses
 ist8310 -C -b 1 start

--- a/boards/nxp/fmuk66-v3/init/rc.board_sensors
+++ b/boards/nxp/fmuk66-v3/init/rc.board_sensors
@@ -7,14 +7,19 @@
 # External I2C bus
 hmc5883 -C -X start
 
+# Internal Mag I2C bus
+echo "error! bmm150 roatation needs to be set"
+bmm150 -R 2 start
+
 # Possible external compasses
-ist8310 -C -b 2 start
+ist8310 -C -b 1 start
 
 # External I2C bus
 lis3mdl -X start
 
-# Onboard I2C (baro) but an external bus on V3 RC15
-mpl3115a2 -X start
+# Onboard I2C baros
+bmp280 -I start
+mpl3115a2 -I start
 
 # Internal SPI (accel + mag)
 fxos8701cq start -R 0

--- a/boards/nxp/fmuk66-v3/nuttx-config/include/board.h
+++ b/boards/nxp/fmuk66-v3/nuttx-config/include/board.h
@@ -382,7 +382,7 @@
  *  -------- ----- ------ ---------
  */
 
-#define PIN_LPUART0_RX      PIN_LPUART0_RX_3
+#define PIN_LPUART0_RX      (PIN_LPUART0_RX_3 | GPIO_PULLUP)
 #define PIN_LPUART0_TX      PIN_LPUART0_TX_3
 
 /* UART0

--- a/boards/nxp/fmuk66-v3/src/board_config.h
+++ b/boards/nxp/fmuk66-v3/src/board_config.h
@@ -83,11 +83,11 @@ __BEGIN_DECLS
 /* UART tty Mapping
  * Device   tty        alt           Connector Name
  * ------- ---------- -------------- --------- -------------------------
- * LPUART0 /dev/tty0  /dev/console    P16      DCD-Mini
- * UART0   /dev/tty1      ---         P7       IR transmitter & receiver
- * UART1   /dev/tty2      ---         P14,P15  SERIAL4/FrSky, RC_IN
- * UART2   /dev/tty3      ---         P3       GPS connector
- * UART4   /dev/tty4      ---         P10      UART (Bluetooth)
+ * LPUART0 /dev/tty0  /dev/console    J16      DCD-Mini
+ * UART0   /dev/tty1      ---         J7       SERIAL 2 / TELEMETRY 2 / IRDA
+ * UART1   /dev/tty2      ---         J15      SERIAL4/FrSky, RC_IN
+ * UART2   /dev/tty3      ---         J3       GPS connector
+ * UART4   /dev/tty4      ---         J10      SERIAL 1 / TELEMETRY 1
  */
 
 /* High-resolution timer */
@@ -211,6 +211,7 @@ __BEGIN_DECLS
 #define GPIO_SPI_CS_MEMORY                  (GPIO_LOWDRIVE | GPIO_OUTPUT_ONE  | PIN_PORTC | PIN2)
 #define GPIO_SPI_CS_FXAS21002CQ_GYRO        (GPIO_LOWDRIVE | GPIO_OUTPUT_ONE  | PIN_PORTB | PIN9)
 #define GPIO_SPI_CS_FXOS8700CQ_ACCEL_MAG    (GPIO_LOWDRIVE | GPIO_OUTPUT_ONE  | PIN_PORTB | PIN10)
+#define GPIO_SPI1_CS_CALMEM                 (GPIO_LOWDRIVE | GPIO_OUTPUT_ONE  | PIN_PORTA | PIN19)
 #define GPIO_SPI2_CS                        (GPIO_LOWDRIVE | GPIO_OUTPUT_ONE  | PIN_PORTB | PIN20)
 #define GPIO_SPI2_EXT                       (GPIO_LOWDRIVE | GPIO_OUTPUT_ONE  | PIN_PORTD | PIN15)
 
@@ -240,9 +241,10 @@ __BEGIN_DECLS
 
 #define PX4_SPIDEV_ACCEL_MAG                PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS,0)
 #define PX4_SPIDEV_GYRO                     PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS,1)
-#define PX4_SENSOR_BUS_CS_GPIO              {GPIO_SPI_CS_FXOS8700CQ_ACCEL_MAG, GPIO_SPI_CS_FXAS21002CQ_GYRO}
+#define PX4_SPIDEV_CALMEM                   PX4_MK_SPI_SEL(PX4_SPI_BUS_SENSORS,2)
+#define PX4_SENSOR_BUS_CS_GPIO              {GPIO_SPI_CS_FXOS8700CQ_ACCEL_MAG, GPIO_SPI_CS_FXAS21002CQ_GYRO, GPIO_SPI1_CS_CALMEM}
 #define PX4_SENSOR_BUS_FIRST_CS             PX4_SPIDEV_ACCEL_MAG
-#define PX4_SENSOR_BUS_LAST_CS              PX4_SPIDEV_GYRO
+#define PX4_SENSOR_BUS_LAST_CS              PX4_SPIDEV_CALMEM
 
 #define PX4_SPIDEV_EXTERNAL1                PX4_MK_SPI_SEL(PX4_SPI_BUS_EXTERNAL,0)
 #define PX4_SPIDEV_EXTERNAL2                PX4_MK_SPI_SEL(PX4_SPI_BUS_EXTERNAL,1)
@@ -258,10 +260,13 @@ __BEGIN_DECLS
 
 /* I2C busses */
 
+#define PX4_I2C_BUS_ONBOARD                 PX4_BUS_NUMBER_TO_PX4(1)
 #define PX4_I2C_BUS_EXPANSION               PX4_BUS_NUMBER_TO_PX4(0)
-#define PX4_I2C_BUS_EXPANSION1              PX4_BUS_NUMBER_TO_PX4(1) // V3 RC15 has mpl3115a2 on onboard but this goes to a connector
-// So it is treated as external.
-#define PX4_I2C_BUS_LED                     PX4_I2C_BUS_EXPANSION1
+
+
+#define PX4_I2C_BUS_LED                     PX4_I2C_BUS_EXPANSION
+
+#define PX4_I2C_OBDEV_BMP280                0x76
 
 /*
  * ADC channels

--- a/boards/nxp/fmuk66-v3/src/timer_config.c
+++ b/boards/nxp/fmuk66-v3/src/timer_config.c
@@ -146,16 +146,16 @@ __EXPORT const struct io_timers_t led_pwm_timers[MAX_LED_TIMERS] = {
 
 __EXPORT const struct timer_io_channels_t led_pwm_channels[MAX_TIMER_LED_CHANNELS] = {
 	{
-		.gpio_out = LED_TIM3_CH5OUT, // RGB_G
-		.gpio_in  = 0,
-		.timer_index = 0,
-		.timer_channel = 6,
-	},
-	{
 		.gpio_out = LED_TIM3_CH1OUT, // RGB_R
 		.gpio_in  = 0,
 		.timer_index = 0,
 		.timer_channel = 2,
+	},
+	{
+		.gpio_out = LED_TIM3_CH5OUT, // RGB_G
+		.gpio_in  = 0,
+		.timer_index = 0,
+		.timer_channel = 6,
 	},
 	{
 		.gpio_out = LED_TIM3_CH4OUT, // RGB_B

--- a/boards/px4/fmu-v4/init/rc.board_sensors
+++ b/boards/px4/fmu-v4/init/rc.board_sensors
@@ -19,7 +19,7 @@ ist8310 start
 bmp280 -I start
 
 # expansion i2c used for BMM150 rotated by 90deg
-bmm150 -R 2 start
+bmm150 -X -R 2 start
 
 # For Teal One airframe
 if param compare SYS_AUTOSTART 4250

--- a/src/drivers/barometer/bmp280/bmp280.cpp
+++ b/src/drivers/barometer/bmp280/bmp280.cpp
@@ -553,8 +553,8 @@ struct bmp280_bus_option {
 	{ BMP280_BUS_SPI_INTERNAL, "/dev/bmp280_spi_int", &bmp280_spi_interface, PX4_SPI_BUS_SENSORS, PX4_SPIDEV_BARO, false, NULL },
 #  endif
 #endif
-#ifdef PX4_I2C_OBDEV_BMP280
-	{ BMP280_BUS_I2C_INTERNAL, "/dev/bmp280_i2c_int", &bmp280_i2c_interface, PX4_I2C_BUS_EXPANSION, PX4_I2C_OBDEV_BMP280, false, NULL },
+#if defined(PX4_I2C_BUS_ONBOARD) && defined(PX4_I2C_OBDEV_BMP280)
+	{ BMP280_BUS_I2C_INTERNAL, "/dev/bmp280_i2c_int", &bmp280_i2c_interface, PX4_I2C_BUS_ONBOARD, PX4_I2C_OBDEV_BMP280, false, NULL },
 #endif
 #if defined(PX4_I2C_BUS_EXPANSION) && defined(PX4_I2C_EXT_OBDEV_BMP280)
 	{ BMP280_BUS_I2C_EXTERNAL, "/dev/bmp280_i2c_ext", &bmp280_i2c_interface, PX4_I2C_BUS_EXPANSION, PX4_I2C_EXT_OBDEV_BMP280, true, NULL },

--- a/src/drivers/magnetometer/bmm150/bmm150.cpp
+++ b/src/drivers/magnetometer/bmm150/bmm150.cpp
@@ -86,8 +86,12 @@ void start(bool external_bus, enum Rotation rotation)
 #endif
 
 	} else {
+#if defined(PX4_I2C_BUS_ONBOARD)
+		*g_dev_ptr = new BMM150(PX4_I2C_BUS_ONBOARD, path, rotation);
+#else
 		PX4_ERR("Internal I2C not available");
 		exit(0);
+#endif
 	}
 
 	if (*g_dev_ptr == nullptr) {


### PR DESCRIPTION
   I2C bus chaged I2C0 is external, I2C1 internal
     Added BMM150 on I2C1 @ Addr 0x100
     Added BMP280 on I2C1 @ Addr 0x76

   UART0 (/dev/ttyS1) now used at Telem 2

   Chip select added for W25X40CLUXIG Calibration EE prom
     Driver is not added at this time

Add SW PU on LPUART0_RX - done
Set Rotation on BMM150 - done.
BMM150 - now starting
BMP280 - now starting.
RGBLED - added simultaneous support for new rgbled_ncp5623c, old TCA62724FMG and PWM 
Add RTC to NuttX and Start RTC - Done

To Do and Verify:
Add Cal EE prom Driver 
Add Secure element driver.