### PR TITLE
mavlink_mission: round lat/lon

### DIFF
--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -1560,8 +1560,8 @@ MavlinkMissionManager::format_mavlink_mission_item(const struct mission_item_s *
 			mavlink_mission_item_int_t *item_int =
 				reinterpret_cast<mavlink_mission_item_int_t *>(mavlink_mission_item);
 
-			item_int->x = (int32_t)(mission_item->lat * 1e7);
-			item_int->y = (int32_t)(mission_item->lon * 1e7);
+			item_int->x = std::round(mission_item->lat * 1e7);
+			item_int->y = std::round(mission_item->lon * 1e7);
 
 		} else {
 			mavlink_mission_item->x = (float)mission_item->lat;


### PR DESCRIPTION
This avoids casting errors.

An alternative to `std::round` would be to add 0.5 before casting for positive values and subtract 0.5 before casting for negative values. https://stackoverflow.com/questions/9695329/c-how-to-round-a-double-to-an-int

This was found by an upcoming Dronecode SDK test where some mission items were uploaded, downloaded again, and then compared.

There might be more places where this is required.