### PR TITLE
HRT elapsed time update & atomic fix on IO

### DIFF
--- a/platforms/posix/src/px4_layer/drv_hrt.cpp
+++ b/platforms/posix/src/px4_layer/drv_hrt.cpp
@@ -205,19 +205,6 @@ hrt_abstime ts_to_abstime(const struct timespec *ts)
  * This function is safe to use even if the timestamp is updated
  * by an interrupt during execution.
  */
-hrt_abstime hrt_elapsed_time(const hrt_abstime *then)
-{
-	hrt_abstime delta = hrt_absolute_time() - *then;
-	return delta;
-}
-
-/*
- * Compute the delta between a timestamp taken in the past
- * and now.
- *
- * This function is safe to use even if the timestamp is updated
- * by an interrupt during execution.
- */
 hrt_abstime hrt_elapsed_time_atomic(const volatile hrt_abstime *then)
 {
 	// This is not atomic as the value on the application layer of POSIX is limited.

--- a/src/drivers/drv_hrt.h
+++ b/src/drivers/drv_hrt.h
@@ -98,7 +98,10 @@ __EXPORT extern void	abstime_to_ts(struct timespec *ts, hrt_abstime abstime);
  *
  * This function is not interrupt save.
  */
-__EXPORT extern hrt_abstime hrt_elapsed_time(const hrt_abstime *then);
+static inline hrt_abstime hrt_elapsed_time(const hrt_abstime *then)
+{
+	return hrt_absolute_time() - *then;
+}
 
 /**
  * Compute the delta between a timestamp taken in the past

--- a/src/drivers/kinetis/drv_hrt.c
+++ b/src/drivers/kinetis/drv_hrt.c
@@ -595,17 +595,6 @@ abstime_to_ts(struct timespec *ts, hrt_abstime abstime)
 }
 
 /**
- * Compare a time value with the current time.
- */
-hrt_abstime
-hrt_elapsed_time(const hrt_abstime *then)
-{
-	hrt_abstime delta = hrt_absolute_time() - *then;
-
-	return delta;
-}
-
-/**
  * Compare a time value with the current time as atomic operation.
  */
 hrt_abstime

--- a/src/drivers/samv7/drv_hrt.c
+++ b/src/drivers/samv7/drv_hrt.c
@@ -676,17 +676,6 @@ abstime_to_ts(struct timespec *ts, hrt_abstime abstime)
 }
 
 /**
- * Compare a time value with the current time.
- */
-hrt_abstime
-hrt_elapsed_time(const hrt_abstime *then)
-{
-	hrt_abstime delta = hrt_absolute_time() - *then;
-
-	return delta;
-}
-
-/**
  * Compare a time value with the current time as atomic operation.
  */
 hrt_abstime

--- a/src/drivers/stm32/drv_hrt.c
+++ b/src/drivers/stm32/drv_hrt.c
@@ -716,17 +716,6 @@ abstime_to_ts(struct timespec *ts, hrt_abstime abstime)
 }
 
 /**
- * Compare a time value with the current time.
- */
-hrt_abstime
-hrt_elapsed_time(const hrt_abstime *then)
-{
-	hrt_abstime delta = hrt_absolute_time() - *then;
-
-	return delta;
-}
-
-/**
  * Compare a time value with the current time as atomic operation
  */
 hrt_abstime


### PR DESCRIPTION
Follow-up to https://github.com/PX4/Firmware/pull/11248.
- inline hrt_elapsed_time
- fix atomic access to `system_state.fmu_data_received_time`. This was an issue that already existed before.