### PR TITLE
Commander: Don't spam battery tune messages

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1159,6 +1159,8 @@ Commander::run()
 {
 	bool sensor_fail_tune_played = false;
 	bool arm_tune_played = false;
+	bool low_bat_tune_played = false;
+	bool crit_bat_tune_played = false;
 	bool was_landed = true;
 	bool was_falling = false;
 	bool was_armed = false;
@@ -2492,16 +2494,18 @@ Commander::run()
 			set_tune(TONE_ARMING_WARNING_TUNE);
 			arm_tune_played = true;
 
-		} else if (!status_flags.usb_connected &&
+		} else if (!crit_bat_tune_played && !status_flags.usb_connected &&
 			   (status.hil_state != vehicle_status_s::HIL_STATE_ON) &&
 			   (_battery_warning == battery_status_s::BATTERY_WARNING_CRITICAL)) {
 			/* play tune on battery critical */
 			set_tune(TONE_BATTERY_WARNING_FAST_TUNE);
+			crit_bat_tune_played = true;
 
-		} else if ((status.hil_state != vehicle_status_s::HIL_STATE_ON) &&
+		} else if (!low_bat_tune_played && (status.hil_state != vehicle_status_s::HIL_STATE_ON) &&
 			   (_battery_warning == battery_status_s::BATTERY_WARNING_LOW)) {
 			/* play tune on battery warning */
 			set_tune(TONE_BATTERY_WARNING_SLOW_TUNE);
+			low_bat_tune_played = true;
 
 		} else if (status.failsafe) {
 			tune_failsafe(true);


### PR DESCRIPTION
When battery is low or critical, commander will publish a tune message. Not once though, but one message per thread cycle. The tunes library does take care of this and ignores messages with the same tune, but it's still unnecessary. Especially now when we have repeated tunes. 

### Solution: 
Use flags to make sure the message is only sent once. 

Adding more flags to the commander is not optimal, that I understand. But at least it will document the issue for future refactoring. 

### Implications
With this PR, the low and critical battery tunes can be interrupted by other tunes, since it's not continuously spammed.

