### PR TITLE
SITL VTOL: scale outputs based on motor count (param VT_MOT_COUNT)

### DIFF
--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -349,7 +349,8 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::SIM_BAT_DRAIN>) _battery_drain_interval_s, ///< battery drain interval
-		(ParamInt<px4::params::MAV_TYPE>) _param_system_type
+		(ParamInt<px4::params::MAV_TYPE>) _param_system_type,
+		(ParamInt<px4::params::VT_MOT_COUNT>) _param_vtol_mot_count
 
 	)
 

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -105,19 +105,33 @@ mavlink_hil_actuator_controls_t Simulator::actuator_controls_from_outputs(const 
 			n = 2;
 			break;
 
+		case MAV_TYPE_TRICOPTER:
+			n = 3;
+			break;
+
 		case MAV_TYPE_QUADROTOR:
 		case MAV_TYPE_VTOL_QUADROTOR:
-		case MAV_TYPE_VTOL_TILTROTOR:
 			n = 4;
 			break;
 
+		case MAV_TYPE_VTOL_TILTROTOR:
 		case MAV_TYPE_VTOL_RESERVED2:
-			// this is the standard VTOL / quad plane with 5 propellers
-			n = 5;
+		case MAV_TYPE_VTOL_RESERVED3:
+		case MAV_TYPE_VTOL_RESERVED4:
+		case MAV_TYPE_VTOL_RESERVED5:
+			n = _param_vtol_mot_count.get();
 			break;
 
 		case MAV_TYPE_HEXAROTOR:
 			n = 6;
+			break;
+
+		case MAV_TYPE_OCTOROTOR:
+			n = 8;
+			break;
+
+		case MAV_TYPE_DODECAROTOR:
+			n = 12;
 			break;
 
 		default:

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -40,7 +40,7 @@
  */
 
 /**
- * VTOL number of engines
+ * VTOL number of engines when in multicopter mode
  *
  * @min 0
  * @max 8


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
In the SITL MAVLink module, the outputs are scaled based on the number of motors determined from the vehicle type. For tiltrotors and other types of VTOLs, the vehicle type is not sufficient to determine the number of motors.
Example: Tricopter tiltrotor with servo on 4th output. The servo output is scaled in range [0,1] (as a motor) instead of [-1, 1].
 
**Describe your preferred solution**
The parameter VT_MOT_COUNT is used to determine the number of motors and correctly scale outputs in the ranges [0,1] or [-1,1].

**Describe possible alternatives**
Getting rid of the dedicated simulation MAVLink module?