### PR TITLE
tiltrotor: fix transition check when airspeed is invalid

### DIFF
--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -149,7 +149,7 @@ void Tiltrotor::update_vtol_state()
 
 				// check if airspeed is invalid and transition by time
 				transition_to_p2 |= _params->airspeed_disabled &&
-						    _tilt_control > _params_tiltrotor.tilt_transition &&
+						    _tilt_control >= _params_tiltrotor.tilt_transition &&
 						    time_since_trans_start > _params->front_trans_time_openloop;
 
 				if (transition_to_p2) {


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This is a small fix for a bug very unlikely to happen. 
By reviewing the tiltrotor code, I noticed that `_tilt_control` might never exceed VT_TILT_TRANS during the transition phase P1. This would cause a transition timeout.

**Describe your preferred solution**
Check `>=` instead of `>`