### PR TITLE
Fixing some typos, new-lines and headers

### DIFF
--- a/msg/input_rc.msg
+++ b/msg/input_rc.msg
@@ -22,7 +22,7 @@ uint64 timestamp_last_signal		# last valid reception time
 uint32 channel_count			# number of channels actually being seen
 int32 rssi				# receive signal strength indicator (RSSI): < 0: Undefined, 0: no signal, 100: full reception
 bool rc_failsafe			# explicit failsafe flag: true on TX failure or TX out of range , false otherwise. Only the true state is reliable, as there are some (PPM) receivers on the market going into failsafe without telling us explicitly.
-bool rc_lost				# RC receiver connection status: True,if no frame has arrived in the expected time, false otherwise. True usUally means that the receiver has been disconnected, but can also indicate a radio link loss on "stupid" systems. Will remain false, if a RX with failsafe option continues to transmit frames after a link loss.
+bool rc_lost				# RC receiver connection status: True,if no frame has arrived in the expected time, false otherwise. True usually means that the receiver has been disconnected, but can also indicate a radio link loss on "stupid" systems. Will remain false, if a RX with failsafe option continues to transmit frames after a link loss.
 uint16 rc_lost_frame_count		# Number of lost RC frames. Note: intended purpose: observe the radio link quality if RSSI is not available. This value must not be used to trigger any failsafe-alike funtionality.
 uint16 rc_total_frame_count		# Number of total RC frames. Note: intended purpose: observe the radio link quality if RSSI is not available. This value must not be used to trigger any failsafe-alike funtionality.
 uint16 rc_ppm_frame_length		# Length of a single PPM frame. Zero for non-PPM systems

--- a/msg/position_setpoint.msg
+++ b/msg/position_setpoint.msg
@@ -32,7 +32,6 @@ bool alt_valid		# do not set for 3D position control. Set to true if you want z-
 float64 lat			# latitude, in deg
 float64 lon			# longitude, in deg
 float32 alt			# altitude AMSL, in m
-
 float32 yaw			# yaw (only for multirotors), in rad [-PI..PI), NaN = hold current yaw
 bool yaw_valid			# true if yaw setpoint valid
 

--- a/src/drivers/px4flow/i2c_frame.h
+++ b/src/drivers/px4flow/i2c_frame.h
@@ -78,4 +78,3 @@ typedef struct i2c_integral_frame {
 } i2c_integral_frame;
 
 #define I2C_INTEGRAL_FRAME_SIZE (sizeof(i2c_integral_frame))
-

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2429,10 +2429,10 @@ Commander::run()
 			status_changed = true;
 
 			if (status.failsafe) {
-				mavlink_log_info(&mavlink_log_pub, "Failsafe mode enabled");
+				mavlink_log_info(&mavlink_log_pub, "Failsafe mode activated");
 
 			} else {
-				mavlink_log_info(&mavlink_log_pub, "Failsafe mode disabled");
+				mavlink_log_info(&mavlink_log_pub, "Failsafe mode deactivated");
 			}
 
 			failsafe_old = status.failsafe;

--- a/src/modules/commander/calibration_routines.h
+++ b/src/modules/commander/calibration_routines.h
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 /// @file calibration_routines.h
-///	@authot Don Gagne <don@thegagnes.com>
+///	@author Don Gagne <don@thegagnes.com>
 
 #pragma once
 

--- a/src/modules/navigator/mission_feasibility_checker.h
+++ b/src/modules/navigator/mission_feasibility_checker.h
@@ -85,4 +85,3 @@ public:
 				  bool land_start_req);
 
 };
-

--- a/src/modules/navigator/navigation.h
+++ b/src/modules/navigator/navigation.h
@@ -212,5 +212,3 @@ struct mission_save_point_s {
 /**
  * @}
  */
-
-

--- a/src/modules/navigator/rcloss.cpp
+++ b/src/modules/navigator/rcloss.cpp
@@ -116,7 +116,7 @@ RCLoss::set_rcl_item()
 			/* Request flight termination from the commander */
 			_navigator->get_mission_result()->flight_termination = true;
 			_navigator->set_mission_result_updated();
-			warnx("rc not recovered: request flight termination");
+			warnx("RC not recovered: request flight termination");
 			pos_sp_triplet->previous.valid = false;
 			pos_sp_triplet->current.valid = false;
 			pos_sp_triplet->next.valid = false;
@@ -144,12 +144,12 @@ RCLoss::advance_rcl()
 	case RCL_STATE_NONE:
 		if (_param_loitertime.get() > 0.0f) {
 			warnx("RC loss, OBC mode, loiter");
-			mavlink_log_critical(_navigator->get_mavlink_log_pub(), "rc loss, loitering");
+			mavlink_log_critical(_navigator->get_mavlink_log_pub(), "RC loss, loitering");
 			_rcl_state = RCL_STATE_LOITER;
 
 		} else {
 			warnx("RC loss, OBC mode, slip loiter, terminate");
-			mavlink_log_critical(_navigator->get_mavlink_log_pub(), "rc loss, terminating");
+			mavlink_log_critical(_navigator->get_mavlink_log_pub(), "RC loss, terminating");
 			_rcl_state = RCL_STATE_TERMINATE;
 			_navigator->get_mission_result()->stay_in_failsafe = true;
 			_navigator->set_mission_result_updated();

--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -31,8 +31,10 @@
  *
  ****************************************************************************/
 /**
- * @file navigator_rtl.cpp
+ * @file rtl.cpp
+ *
  * Helper class to access RTL
+ *
  * @author Julian Oes <julian@oes.ch>
  * @author Anton Babushkin <anton.babushkin@me.com>
  */

--- a/src/modules/navigator/rtl.h
+++ b/src/modules/navigator/rtl.h
@@ -31,7 +31,8 @@
  *
  ****************************************************************************/
 /**
- * @file navigator_rtl.h
+ * @file rtl.h
+ *
  * Helper class for RTL
  *
  * @author Julian Oes <julian@oes.ch>

--- a/src/modules/navigator/takeoff.cpp
+++ b/src/modules/navigator/takeoff.cpp
@@ -31,11 +31,11 @@
  *
  ****************************************************************************/
 /**
- * @file Takeoff.cpp
+ * @file takeoff.cpp
  *
  * Helper class to Takeoff
  *
- * @author Lorenz Meier <lorenz@px4.io
+ * @author Lorenz Meier <lorenz@px4.io>
  */
 
 #include "takeoff.h"


### PR DESCRIPTION
Fixed typos in comments, removed some new lines, corrected headers. Modified a few mavlink warning messages, but I understand that's a matter of taste. 

In the future I would like to be more precise when we pint messages about sub-systems or safeguards and distinguish "enabled/disabled", "active/inactive" and "on/off". Enabled/Disabled sounds to me like a configuration, not a temporary state. "Failsafe mode disabled" sounds to me like it has been permanently disabled by parameter. The message suggests that a setting was modified.

It's the same thing with driving assistance functions in cars: ABS, ESC and Traction Control can be enabled without being active. But when enabled and if necessary, these systems will become active on their own.

If the community agrees with this view-point, I can go through other mavlink messages and modify some more. 