### PR TITLE
Jenkins: allow test to specify docker image with default

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -17,7 +17,7 @@ pipeline {
 
       agent {
         docker {
-          image 'px4io/px4-dev-ros-kinetic:2018-09-11'
+          image 'px4io/px4-dev-ros-kinetic:2019-01-25'
           args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE --cap-add SYS_PTRACE'
         }
       }
@@ -101,7 +101,8 @@ pipeline {
               name: "MC_offboard_att",
               test: "mavros_posix_tests_offboard_attctl.test",
               mission: "",
-              vehicle: "iris"
+              vehicle: "iris",
+              docker_image: "px4io/px4-dev-ros-kinetic:2018-09-11" // TODO: Update image after https://github.com/mavlink/mavros/pull/1161
             ],
             [
               name: "MC_offboard_pos",
@@ -208,7 +209,7 @@ pipeline {
 } // pipeline
 
 def createTestNode(Map test_def) {
-  def docker_image = test_def.get('docker_image', 'px4io/px4-dev-ros-kinetic:2018-09-11')
+  def docker_image = test_def.get('docker_image', 'px4io/px4-dev-ros-kinetic:2019-01-25')
   return {
     node {
       cleanWs()

--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -208,10 +208,11 @@ pipeline {
 } // pipeline
 
 def createTestNode(Map test_def) {
+  def docker_image = test_def.get('docker_image', 'px4io/px4-dev-ros-kinetic:2018-09-11')
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-kinetic:2018-09-11").inside('-e HOME=${WORKSPACE} --cap-add SYS_PTRACE') {
+      docker.image(docker_image).inside('-e HOME=${WORKSPACE} --cap-add SYS_PTRACE') {
         stage(test_def.name) {
           def test_ok = true
           sh('export')


### PR DESCRIPTION
This will allow for specialized environments or for testing multiple setup. Use case -- Gazebo 8 for https://github.com/PX4/Firmware/pull/10780

~~Additionally I'll push a DO NOT MERGE commit once we have a Gazebo 8 container built for testing.~~

@TSC21 @mrivi