### PR TITLE
Jenkins CI: update containers tag to 2019-01-25

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -17,7 +17,7 @@ pipeline {
 
       agent {
         docker {
-          image 'px4io/px4-dev-ros-kinetic:2019-01-24'
+          image 'px4io/px4-dev-ros-kinetic:2019-01-25'
           args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE --cap-add SYS_PTRACE'
         }
       }
@@ -147,7 +147,7 @@ pipeline {
         stage('code coverage (python)') {
           agent {
             docker {
-              image 'px4io/px4-dev-base:2019-01-24'
+              image 'px4io/px4-dev-base:2019-01-25'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw --cap-add SYS_PTRACE'
             }
           }
@@ -170,7 +170,7 @@ pipeline {
         stage('unit tests') {
           agent {
             docker {
-              image 'px4io/px4-dev-base:2019-01-24'
+              image 'px4io/px4-dev-base:2019-01-25'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw --cap-add SYS_PTRACE'
             }
           }
@@ -211,7 +211,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-kinetic:2019-01-24").inside('-e HOME=${WORKSPACE} --cap-add SYS_PTRACE') {
+      docker.image("px4io/px4-dev-ros-kinetic:2019-01-25").inside('-e HOME=${WORKSPACE} --cap-add SYS_PTRACE') {
         stage(test_def.name) {
           def test_ok = true
           sh('export')

--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -17,7 +17,7 @@ pipeline {
 
       agent {
         docker {
-          image 'px4io/px4-dev-ros-kinetic:2018-09-11'
+          image 'px4io/px4-dev-ros-kinetic:2019-01-24'
           args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE --cap-add SYS_PTRACE'
         }
       }
@@ -147,7 +147,7 @@ pipeline {
         stage('code coverage (python)') {
           agent {
             docker {
-              image 'px4io/px4-dev-base:2019-01-01'
+              image 'px4io/px4-dev-base:2019-01-24'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw --cap-add SYS_PTRACE'
             }
           }
@@ -170,7 +170,7 @@ pipeline {
         stage('unit tests') {
           agent {
             docker {
-              image 'px4io/px4-dev-base:2019-01-01'
+              image 'px4io/px4-dev-base:2019-01-24'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw --cap-add SYS_PTRACE'
             }
           }
@@ -211,7 +211,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-kinetic:2018-09-11").inside('-e HOME=${WORKSPACE} --cap-add SYS_PTRACE') {
+      docker.image("px4io/px4-dev-ros-kinetic:2019-01-24").inside('-e HOME=${WORKSPACE} --cap-add SYS_PTRACE') {
         stage(test_def.name) {
           def test_ok = true
           sh('export')

--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -10,11 +10,11 @@ pipeline {
           def build_nodes = [:]
           def docker_images = [
             arch: "px4io/px4-dev-base-archlinux:2019-01-01",
-            armhf: "px4io/px4-dev-armhf:2019-01-01",
-            base: "px4io/px4-dev-base:2019-01-01",
-            nuttx: "px4io/px4-dev-nuttx:2019-01-01",
-            ros: "px4io/px4-dev-ros:2019-01-01",
-            rpi: "px4io/px4-dev-raspi:2019-01-01",
+            armhf: "px4io/px4-dev-armhf:2019-01-24",
+            base: "px4io/px4-dev-base:2019-01-24",
+            nuttx: "px4io/px4-dev-nuttx:2019-01-24",
+            ros: "px4io/px4-dev-ros:2019-01-24",
+            rpi: "px4io/px4-dev-raspi:2019-01-24",
             snapdragon: "lorenzmeier/px4-dev-snapdragon:2018-09-12"
           ]
 
@@ -134,7 +134,7 @@ pipeline {
     // TODO: actually upload artifacts to S3
     stage('S3 Upload') {
       agent {
-        docker { image 'px4io/px4-dev-base:2019-01-01' }
+        docker { image 'px4io/px4-dev-base:2019-01-24' }
       }
       options {
             skipDefaultCheckout()

--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -10,11 +10,11 @@ pipeline {
           def build_nodes = [:]
           def docker_images = [
             arch: "px4io/px4-dev-base-archlinux:2019-01-01",
-            armhf: "px4io/px4-dev-armhf:2019-01-24",
-            base: "px4io/px4-dev-base:2019-01-24",
-            nuttx: "px4io/px4-dev-nuttx:2019-01-24",
-            ros: "px4io/px4-dev-ros:2019-01-24",
-            rpi: "px4io/px4-dev-raspi:2019-01-24",
+            armhf: "px4io/px4-dev-armhf:2019-01-25",
+            base: "px4io/px4-dev-base:2019-01-25",
+            nuttx: "px4io/px4-dev-nuttx:2019-01-25",
+            ros: "px4io/px4-dev-ros:2019-01-25",
+            rpi: "px4io/px4-dev-raspi:2019-01-25",
             snapdragon: "lorenzmeier/px4-dev-snapdragon:2018-09-12"
           ]
 
@@ -134,7 +134,7 @@ pipeline {
     // TODO: actually upload artifacts to S3
     stage('S3 Upload') {
       agent {
-        docker { image 'px4io/px4-dev-base:2019-01-24' }
+        docker { image 'px4io/px4-dev-base:2019-01-25' }
       }
       options {
             skipDefaultCheckout()

--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -9,7 +9,7 @@ pipeline {
         stage('px4_fmu-v4_default') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-01-01'
+              image 'px4io/px4-dev-nuttx:2019-01-24'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -34,7 +34,7 @@ pipeline {
         stage('px4_fmu-v4_stackcheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-01-01'
+              image 'px4io/px4-dev-nuttx:2019-01-24'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }

--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -9,7 +9,7 @@ pipeline {
         stage('px4_fmu-v4_default') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-01-24'
+              image 'px4io/px4-dev-nuttx:2019-01-25'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -34,7 +34,7 @@ pipeline {
         stage('px4_fmu-v4_stackcheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-01-24'
+              image 'px4io/px4-dev-nuttx:2019-01-25'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
         stage('Colcon build on ROS2 workspace') {
           agent {
             docker {
-              image 'px4io/px4-dev-ros2-bouncy:2019-01-25'
+              image 'px4io/px4-dev-ros2-crystal:2019-01-25'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
             }
           }
@@ -56,7 +56,7 @@ pipeline {
               mkdir -p colcon_ws/src;
               cd colcon_ws;
               git clone --recursive https://github.com/PX4/sitl_gazebo.git src/mavlink_sitl_gazebo;
-              source /opt/ros/bouncy/setup.sh;
+              source /opt/ros/crystal/setup.sh;
               source /opt/ros/melodic/setup.sh;
               colcon build --event-handlers console_direct+ --symlink-install;
             '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
         stage('Catkin build on ROS workspace') {
           agent {
             docker {
-              image 'px4io/px4-dev-ros:2019-01-24'
+              image 'px4io/px4-dev-ros:2019-01-25'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
             }
           }
@@ -44,7 +44,7 @@ pipeline {
         stage('Colcon build on ROS2 workspace') {
           agent {
             docker {
-              image 'px4io/px4-dev-ros2-bouncy:2019-01-24'
+              image 'px4io/px4-dev-ros2-bouncy:2019-01-25'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
             }
           }
@@ -73,7 +73,7 @@ pipeline {
 
         stage('Style check') {
           agent {
-            docker { image 'px4io/px4-dev-base:2019-01-24' }
+            docker { image 'px4io/px4-dev-base:2019-01-25' }
           }
           steps {
             sh 'make check_format'
@@ -88,7 +88,7 @@ pipeline {
         stage('Bloaty px4_fmu-v2') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-01-24'
+              image 'px4io/px4-dev-nuttx:2019-01-25'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -116,7 +116,7 @@ pipeline {
         stage('Bloaty px4_fmu-v5') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-01-24'
+              image 'px4io/px4-dev-nuttx:2019-01-25'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -144,7 +144,7 @@ pipeline {
         stage('Clang analyzer') {
           agent {
             docker {
-              image 'px4io/px4-dev-clang:2019-01-24'
+              image 'px4io/px4-dev-clang:2019-01-25'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -202,7 +202,7 @@ pipeline {
         stage('Cppcheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-base:2019-01-24'
+              image 'px4io/px4-dev-base:2019-01-25'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -239,7 +239,7 @@ pipeline {
         stage('Check stack') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-01-24'
+              image 'px4io/px4-dev-nuttx:2019-01-25'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -258,7 +258,7 @@ pipeline {
         stage('ShellCheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-01-24'
+              image 'px4io/px4-dev-nuttx:2019-01-25'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -277,7 +277,7 @@ pipeline {
         stage('Module config validation') {
           agent {
             docker {
-              image 'px4io/px4-dev-base:2019-01-24'
+              image 'px4io/px4-dev-base:2019-01-25'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -302,7 +302,7 @@ pipeline {
 
         stage('Airframe') {
           agent {
-            docker { image 'px4io/px4-dev-base:2019-01-24' }
+            docker { image 'px4io/px4-dev-base:2019-01-25' }
           }
           steps {
             sh 'make distclean'
@@ -321,7 +321,7 @@ pipeline {
 
         stage('Parameter') {
           agent {
-            docker { image 'px4io/px4-dev-base:2019-01-24' }
+            docker { image 'px4io/px4-dev-base:2019-01-25' }
           }
           steps {
             sh 'make distclean'
@@ -340,7 +340,7 @@ pipeline {
 
         stage('Module') {
           agent {
-            docker { image 'px4io/px4-dev-base:2019-01-24' }
+            docker { image 'px4io/px4-dev-base:2019-01-25' }
           }
           steps {
             sh 'make distclean'
@@ -360,7 +360,7 @@ pipeline {
         stage('uORB graphs') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-01-24'
+              image 'px4io/px4-dev-nuttx:2019-01-25'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -389,7 +389,7 @@ pipeline {
 
         stage('Devguide') {
           agent {
-            docker { image 'px4io/px4-dev-base:2019-01-24' }
+            docker { image 'px4io/px4-dev-base:2019-01-25' }
           }
           steps {
             sh('export')
@@ -419,7 +419,7 @@ pipeline {
 
         stage('Userguide') {
           agent {
-            docker { image 'px4io/px4-dev-base:2019-01-24' }
+            docker { image 'px4io/px4-dev-base:2019-01-25' }
           }
           steps {
             sh('export')
@@ -447,7 +447,7 @@ pipeline {
 
         stage('QGroundControl') {
           agent {
-            docker { image 'px4io/px4-dev-base:2019-01-24' }
+            docker { image 'px4io/px4-dev-base:2019-01-25' }
           }
           steps {
             sh('export')
@@ -475,7 +475,7 @@ pipeline {
 
         stage('S3') {
           agent {
-            docker { image 'px4io/px4-dev-base:2019-01-24' }
+            docker { image 'px4io/px4-dev-base:2019-01-25' }
           }
           steps {
             sh('export')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
         stage('Catkin build on ROS workspace') {
           agent {
             docker {
-              image 'px4io/px4-dev-ros:2019-01-01'
+              image 'px4io/px4-dev-ros:2019-01-24'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
             }
           }
@@ -44,7 +44,7 @@ pipeline {
         stage('Colcon build on ROS2 workspace') {
           agent {
             docker {
-              image 'px4io/px4-dev-ros2-bouncy:2019-01-01'
+              image 'px4io/px4-dev-ros2-bouncy:2019-01-24'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
             }
           }
@@ -73,7 +73,7 @@ pipeline {
 
         stage('Style check') {
           agent {
-            docker { image 'px4io/px4-dev-base:2019-01-01' }
+            docker { image 'px4io/px4-dev-base:2019-01-24' }
           }
           steps {
             sh 'make check_format'
@@ -88,7 +88,7 @@ pipeline {
         stage('Bloaty px4_fmu-v2') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-01-01'
+              image 'px4io/px4-dev-nuttx:2019-01-24'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -116,7 +116,7 @@ pipeline {
         stage('Bloaty px4_fmu-v5') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-01-01'
+              image 'px4io/px4-dev-nuttx:2019-01-24'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -144,7 +144,7 @@ pipeline {
         stage('Clang analyzer') {
           agent {
             docker {
-              image 'px4io/px4-dev-clang:2019-01-01'
+              image 'px4io/px4-dev-clang:2019-01-24'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -202,7 +202,7 @@ pipeline {
         stage('Cppcheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-base:2019-01-01'
+              image 'px4io/px4-dev-base:2019-01-24'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -239,7 +239,7 @@ pipeline {
         stage('Check stack') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-01-01'
+              image 'px4io/px4-dev-nuttx:2019-01-24'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -258,7 +258,7 @@ pipeline {
         stage('ShellCheck') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-01-01'
+              image 'px4io/px4-dev-nuttx:2019-01-24'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -277,7 +277,7 @@ pipeline {
         stage('Module config validation') {
           agent {
             docker {
-              image 'px4io/px4-dev-base:2019-01-01'
+              image 'px4io/px4-dev-base:2019-01-24'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -302,7 +302,7 @@ pipeline {
 
         stage('Airframe') {
           agent {
-            docker { image 'px4io/px4-dev-base:2019-01-01' }
+            docker { image 'px4io/px4-dev-base:2019-01-24' }
           }
           steps {
             sh 'make distclean'
@@ -321,7 +321,7 @@ pipeline {
 
         stage('Parameter') {
           agent {
-            docker { image 'px4io/px4-dev-base:2019-01-01' }
+            docker { image 'px4io/px4-dev-base:2019-01-24' }
           }
           steps {
             sh 'make distclean'
@@ -340,7 +340,7 @@ pipeline {
 
         stage('Module') {
           agent {
-            docker { image 'px4io/px4-dev-base:2019-01-01' }
+            docker { image 'px4io/px4-dev-base:2019-01-24' }
           }
           steps {
             sh 'make distclean'
@@ -360,7 +360,7 @@ pipeline {
         stage('uORB graphs') {
           agent {
             docker {
-              image 'px4io/px4-dev-nuttx:2019-01-01'
+              image 'px4io/px4-dev-nuttx:2019-01-24'
               args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -389,7 +389,7 @@ pipeline {
 
         stage('Devguide') {
           agent {
-            docker { image 'px4io/px4-dev-base:2019-01-01' }
+            docker { image 'px4io/px4-dev-base:2019-01-24' }
           }
           steps {
             sh('export')
@@ -419,7 +419,7 @@ pipeline {
 
         stage('Userguide') {
           agent {
-            docker { image 'px4io/px4-dev-base:2019-01-01' }
+            docker { image 'px4io/px4-dev-base:2019-01-24' }
           }
           steps {
             sh('export')
@@ -447,7 +447,7 @@ pipeline {
 
         stage('QGroundControl') {
           agent {
-            docker { image 'px4io/px4-dev-base:2019-01-01' }
+            docker { image 'px4io/px4-dev-base:2019-01-24' }
           }
           steps {
             sh('export')
@@ -475,7 +475,7 @@ pipeline {
 
         stage('S3') {
           agent {
-            docker { image 'px4io/px4-dev-base:2019-01-01' }
+            docker { image 'px4io/px4-dev-base:2019-01-24' }
           }
           steps {
             sh('export')


### PR DESCRIPTION
This brings also a fix on the `ros-kinetic` container by reverting back to Python2.7 and avoid problems with not found dependencies, as `px4tools`.