### PR TITLE
SPI: support for ISR and work_queue driven transfers

### DIFF
--- a/src/lib/drivers/device/nuttx/SPI.cpp
+++ b/src/lib/drivers/device/nuttx/SPI.cpp
@@ -160,7 +160,7 @@ SPI::transfer(uint8_t *send, uint8_t *recv, unsigned len)
 		}
 
 	case LOCK_NONE: {
-			if (_is_locked && (1 << _device_id.devid_s.bus)) {
+			if (_is_locked & (1 << _device_id.devid_s.bus)) {
 				// Someone is using the bus
 				perf_count(_isr_deferred);
 				return PX4_ERROR;

--- a/src/lib/drivers/device/nuttx/SPI.cpp
+++ b/src/lib/drivers/device/nuttx/SPI.cpp
@@ -133,7 +133,7 @@ void SPI::unlock(struct spi_dev_s *dev)
 {
 	SPI_LOCK(dev, false);
 	// _is_locked &= ~(1 << _device_id.devid_s.bus);
-	_is_locked.fetch_nand(1 << _device_id.devid_s.bus);
+	_is_locked.fetch_and(~(1 << _device_id.devid_s.bus));
 }
 
 int

--- a/src/lib/drivers/device/nuttx/SPI.cpp
+++ b/src/lib/drivers/device/nuttx/SPI.cpp
@@ -217,7 +217,7 @@ SPI::transferhword(uint16_t *send, uint16_t *recv, unsigned len)
 		}
 
 	case LOCK_NONE: {
-			if (_is_locked) {
+			if (_is_locked & (1 << _device_id.devid_s.bus)) {
 				// Someone is using the bus
 				perf_count(_isr_deferred);
 				return PX4_ERROR;

--- a/src/lib/drivers/device/nuttx/SPI.cpp
+++ b/src/lib/drivers/device/nuttx/SPI.cpp
@@ -53,7 +53,7 @@ namespace device
 {
 
 // static member bitmask
-uint8_t SPI::_is_locked = 0;
+uint32_t SPI::_is_locked = 0;
 
 SPI::SPI(const char *name,
 	 const char *devname,
@@ -124,14 +124,14 @@ SPI::init()
 
 void SPI::lock(struct spi_dev_s *dev)
 {
-	_is_locked |= 1 << (_device_id.devid_s.bus - 1);
+	_is_locked |= (1 << _device_id.devid_s.bus);
 	SPI_LOCK(dev, true);
 }
 
 void SPI::unlock(struct spi_dev_s *dev)
 {
 	SPI_LOCK(dev, false);
-	_is_locked &= ~(1 << (_device_id.devid_s.bus - 1));
+	_is_locked &= ~(1 << _device_id.devid_s.bus);
 }
 
 int
@@ -160,7 +160,7 @@ SPI::transfer(uint8_t *send, uint8_t *recv, unsigned len)
 		}
 
 	case LOCK_NONE: {
-			if (_is_locked && (1 << (_device_id.devid_s.bus - 1))) {
+			if (_is_locked && (1 << _device_id.devid_s.bus)) {
 				// Someone is using the bus
 				perf_count(_isr_deferred);
 				return PX4_ERROR;

--- a/src/lib/drivers/device/nuttx/SPI.cpp
+++ b/src/lib/drivers/device/nuttx/SPI.cpp
@@ -57,6 +57,9 @@
 namespace device
 {
 
+// static member bitmask
+uint8_t SPI::_is_locked = 0;
+
 SPI::SPI(const char *name,
 	 const char *devname,
 	 int bus,
@@ -126,8 +129,8 @@ SPI::init()
 
 void SPI::lock(struct spi_dev_s *dev)
 {
-	SPI_LOCK(dev, true);
 	_is_locked |= 1 << (_device_id.devid_s.bus - 1);
+	SPI_LOCK(dev, true);
 }
 
 void SPI::unlock(struct spi_dev_s *dev)
@@ -140,7 +143,7 @@ int
 SPI::transfer(uint8_t *send, uint8_t *recv, unsigned len)
 {
 	if ((send == nullptr) && (recv == nullptr)) {
-		return -EINVAL;
+		return PX4_ERROR;
 	}
 
 	// LOCK_NONE if we are in interrupt context because we cannot wait on a semaphore.

--- a/src/lib/drivers/device/nuttx/SPI.hpp
+++ b/src/lib/drivers/device/nuttx/SPI.hpp
@@ -153,7 +153,7 @@ protected:
 
 	LockMode			_locking_mode;	/**< selected locking mode */
 
-	static uint8_t 		_is_locked; /** Bit mask. Bit position corresponds to bus number. */
+	static uint32_t 		_is_locked; /** Bit mask. Bit position corresponds to bus number. */
 
 private:
 	uint32_t			_device;

--- a/src/lib/drivers/device/nuttx/SPI.hpp
+++ b/src/lib/drivers/device/nuttx/SPI.hpp
@@ -80,6 +80,10 @@ protected:
 
 	virtual int	init();
 
+	int lock(struct spi_dev_s *dev);
+
+	int unlock(struct spi_dev_s *dev);
+
 	/**
 	 * Check for the presence of the device on the bus.
 	 */
@@ -146,14 +150,15 @@ protected:
 	 *
 	 * @param mode	Locking mode
 	 */
-	void		set_lockmode(enum LockMode mode) { locking_mode = mode; }
+	void		set_lockmode(enum LockMode mode) { _locking_mode = mode; }
 
-	LockMode	locking_mode;	/**< selected locking mode */
+	LockMode	_locking_mode;	/**< selected locking mode */
 
 private:
 	uint32_t			_device;
 	enum spi_mode_e		_mode;
 	uint32_t		_frequency;
+	uint8_t 		_is_locked{0};
 	struct spi_dev_s	*_dev;
 
 	/* this class does not allow copying */
@@ -161,9 +166,9 @@ private:
 	SPI operator=(const SPI &);
 
 protected:
-	int	_transfer(uint8_t *send, uint8_t *recv, unsigned len);
+	void	_transfer(uint8_t *send, uint8_t *recv, unsigned len);
 
-	int	_transferhword(uint16_t *send, uint16_t *recv, unsigned len);
+	void	_transferhword(uint16_t *send, uint16_t *recv, unsigned len);
 
 	bool	external() { return px4_spi_bus_external(get_device_bus()); }
 

--- a/src/lib/drivers/device/nuttx/SPI.hpp
+++ b/src/lib/drivers/device/nuttx/SPI.hpp
@@ -41,6 +41,7 @@
 #define _DEVICE_SPI_H
 
 #include "../CDev.hpp"
+#include <perf/perf_counter.h>
 
 namespace device __EXPORT
 {
@@ -80,9 +81,9 @@ protected:
 
 	virtual int	init();
 
-	int lock(struct spi_dev_s *dev);
+	void lock(struct spi_dev_s *dev);
 
-	int unlock(struct spi_dev_s *dev);
+	void unlock(struct spi_dev_s *dev);
 
 	/**
 	 * Check for the presence of the device on the bus.
@@ -160,6 +161,9 @@ private:
 	uint32_t		_frequency;
 	uint8_t 		_is_locked{0};
 	struct spi_dev_s	*_dev;
+
+	// For debugging
+	perf_counter_t 	_isr_deferred;
 
 	/* this class does not allow copying */
 	SPI(const SPI &);

--- a/src/lib/drivers/device/nuttx/SPI.hpp
+++ b/src/lib/drivers/device/nuttx/SPI.hpp
@@ -36,9 +36,7 @@
  *
  * Base class for devices connected via SPI.
  */
-
-#ifndef _DEVICE_SPI_H
-#define _DEVICE_SPI_H
+#pragma once
 
 #include "../CDev.hpp"
 #include <perf/perf_counter.h>
@@ -153,17 +151,18 @@ protected:
 	 */
 	void		set_lockmode(enum LockMode mode) { _locking_mode = mode; }
 
-	LockMode	_locking_mode;	/**< selected locking mode */
+	LockMode			_locking_mode;	/**< selected locking mode */
+
+	static uint8_t 		_is_locked; /** Bit mask. Bit position corresponds to bus number. */
 
 private:
 	uint32_t			_device;
 	enum spi_mode_e		_mode;
-	uint32_t		_frequency;
-	uint8_t 		_is_locked{0};
+	uint32_t			_frequency;
 	struct spi_dev_s	*_dev;
 
-	// For debugging
-	perf_counter_t 	_isr_deferred;
+	// For debugging. For all SPI busses.
+	perf_counter_t 		_isr_deferred;
 
 	/* this class does not allow copying */
 	SPI(const SPI &);
@@ -179,5 +178,3 @@ protected:
 };
 
 } // namespace device
-
-#endif /* _DEVICE_SPI_H */

--- a/src/lib/drivers/device/nuttx/SPI.hpp
+++ b/src/lib/drivers/device/nuttx/SPI.hpp
@@ -40,6 +40,7 @@
 
 #include "../CDev.hpp"
 #include <perf/perf_counter.h>
+#include <px4_atomic.h>
 
 namespace device __EXPORT
 {
@@ -153,7 +154,7 @@ protected:
 
 	LockMode			_locking_mode;	/**< selected locking mode */
 
-	static uint32_t 		_is_locked; /** Bit mask. Bit position corresponds to bus number. */
+	static px4::atomic<uint32_t> 		_is_locked; /** Bit mask. Bit position corresponds to bus number. */
 
 private:
 	uint32_t			_device;


### PR DESCRIPTION
Added an `_is_locked` variable to the `SPI` class which is a simple bit mask where the bit position corresponds to the SPI bus number. When running `SPI::transfer` from an ISR, `LockMode` is selected as `LOCK_NONE` (because you cannot pend on a sem in interrupt context). I have added a check for the `_is_locked` flag for the given bus when `LockMode` is none, thus preventing an ISR driven `SPI::transfer` from clobbering an already active transfer taking place in workqueue/task/etc.