### PR TITLE
Hotfix for PX4 application not exiting anymore on Cygwin

### DIFF
--- a/platforms/posix/src/main.cpp
+++ b/platforms/posix/src/main.cpp
@@ -407,7 +407,14 @@ void register_sig_handler()
 	sig_segv.sa_handler = sig_segv_handler;
 	sig_segv.sa_flags = SA_RESTART | SA_SIGINFO;
 
+#ifdef __PX4_CYGWIN
+	// Do not catch SIGINT on Cygwin such that the process gets killed
+	// TODO: All threads should exit gracefully see https://github.com/PX4/Firmware/issues/11027
+	(void)sig_int; // this variable is unused
+#else
 	sigaction(SIGINT, &sig_int, nullptr);
+#endif
+
 	//sigaction(SIGTERM, &sig_int, nullptr);
 	sigaction(SIGFPE, &sig_fpe, nullptr);
 	sigaction(SIGPIPE, &sig_pipe, nullptr);


### PR DESCRIPTION
Hotfix for #11027

**Test data / coverage**
SITL on Cygwin (Wndows)

**Describe problem solved by the proposed pull request**
Some threads do not exit and are still running when trying to exit SITL running under Windows in Cygwin.

This problem was introduced with:
- posix shell #10173 because of strating a child process for the startup script and mixing up the signal handling (only Ctrl+C broken)
- lockstep #10648 because of simulator threads not stopping gracefully anymore with timing race conditions (no graceful exit possible anymore)

**Describe your solution**
I leave the SIGINT handler on its default implementation for Cygwin which kills the process and all its threads when pressing Ctrl+C.

This hotfix at least allows the usage of Ctrl+C again instead of forcing the user to use the task manager to shut down px4.exe going crazy on CPU load instead of exiting everytime.

**Describe possible alternatives**
An analysis of what exactly goes wrong when trying to exit gracefully would be the desired way but my limited experience with debugging the overly complex thread structure of PX4 through multiple wrapping layers and my already spent countless hours on this problem lead me to this hotfix.