### PR TITLE
FlightTask: decline unimplemented callbacks, improve comments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2012 - 2018, PX4 Development Team
+Copyright (c) 2012 - 2019, PX4 Development Team
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
@@ -69,6 +69,7 @@ public:
 
 	/**
 	 * Initialize the uORB subscriptions using an array
+	 * @param subscription_array handling uORB subscribtions externally across task switches
 	 * @return true on success, false on error
 	 */
 	virtual bool initializeSubscriptions(SubscriptionArray &subscription_array);
@@ -86,9 +87,10 @@ public:
 
 	/**
 	 * To be called to adopt parameters from an arrived vehicle command
+	 * @param command received command message containing the parameters
 	 * @return true if accepted, false if declined
 	 */
-	virtual bool applyCommandParameters(const vehicle_command_s &command) { return true; }
+	virtual bool applyCommandParameters(const vehicle_command_s &command) { return false; }
 
 	/**
 	 * Call before activate() or update()
@@ -105,6 +107,7 @@ public:
 
 	/**
 	 * Get the output data
+	 * @return task output setpoints that get executed by the positon controller
 	 */
 	const vehicle_local_position_setpoint_s getPositionSetpoint();
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
The case where `applyCommandParameters()` is called for a task that does not implement it, should never happen but if it ever happens we should decline the parameters because we have no implementation processing them.
https://github.com/PX4/Firmware/blob/573dd89cbfad6e389d7a10db20d4ac8a6ede682e/src/lib/FlightTasks/FlightTasks.cpp#L186

Additionally some parameter descriptions were missing from the comment documentation.
