### PR TITLE
px4_fmu-v2_default disable constained flash options

### DIFF
--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -10,7 +10,7 @@ px4_add_board(
 	BOOTLOADER ${PX4_SOURCE_DIR}/ROMFS/px4fmu_common/extras/px4fmuv3_bl.bin
 	IO px4_io-v2_default
 	#TESTING
-	CONSTRAINED_FLASH
+	#CONSTRAINED_FLASH
 	#UAVCAN_INTERFACES 2
 
 	SERIAL_PORTS
@@ -52,6 +52,7 @@ px4_add_board(
 		px4flow
 		px4fmu
 		px4io
+		#roboclaw
 		stm32
 		stm32/adc
 		stm32/tone_alarm
@@ -106,6 +107,7 @@ px4_add_board(
 		top
 		#topic_listener
 		tune_control
+		#usb_connected
 		ver
 
 	EXAMPLES
@@ -120,9 +122,4 @@ px4_add_board(
 		#rover_steering_control # Rover example app
 		#segway
 		#uuv_example_app
-	)
-
-# remove optional flight task features from fmu-v2 to save flash memory
-list(APPEND flight_tasks_to_remove
-		Orbit
 	)


### PR DESCRIPTION
I'd rather minimize board and support differences until absolutely necessary.

	     VM SIZE                                                                                    FILE SIZE
	 --------------                                                                              --------------
	  [NEW]    +340 FlightTaskOrbit::update()                                                       +340  [NEW]
	  +0.3%    +277 g_cromfs_image                                                                  +277  +0.3%
	  [NEW]    +202 FlightTaskOrbit::applyCommandParameters(vehicle_command_s const&)               +202  [NEW]
	  [NEW]    +144 FlightTaskOrbit::sendTelemetry()                                                +144  [NEW]
	  [NEW]    +114 FlightTaskOrbit::activate()                                                     +114  [NEW]
	  [NEW]    +108 FlightTaskOrbit::setRadius(float)                                               +108  [NEW]
	  [NEW]     +84 FlightTaskOrbit::FlightTaskOrbit()                                               +84  [NEW]
	  [NEW]     +64 vtable for FlightTaskOrbit                                                       +64  [NEW]
	  [NEW]     +60 globallocalconverter_toglobal(float, float, float, double*, double*, float*)     +60  [NEW]
	  [NEW]     +60 globallocalconverter_tolocal(double, double, float, float*, float*, float*)      +60  [NEW]
	  [NEW]     +56 FlightTaskOrbit::setVelocity(float)                                              +56  [NEW]
	  [NEW]     +42 FlightTaskOrbit::~FlightTaskOrbit()                                              +42  [NEW]
	  +0.0%     +19 [Unmapped]                                                                    +206Ki  +1.8%
	  [NEW]     +16 map_projection_global_project(double, double, float*, float*)                    +16  [NEW]
	  [NEW]     +16 map_projection_global_reproject(float, float, double*, double*)                  +16  [NEW]
	  +1.9%      +8 FlightTasks::_initTask(FlightTaskIndex)                                           +8  +1.9%
	  +100%      +6 FlightTasks::switchVehicleCommand(int)                                            +6  +100%
	  +0.2% +1.58Ki TOTAL     