### PR TITLE
Correct the mpu6000 temperature scalar to match the datasheet

### DIFF
--- a/src/drivers/imu/mpu6000/MPU6000.cpp
+++ b/src/drivers/imu/mpu6000/MPU6000.cpp
@@ -943,7 +943,7 @@ MPU6000::measure()
 		temperature = (report.temp / 326.8f + 25.0f);
 
 	} else { // If it is an MPU6000
-		temperature = (report.temp / 361.0f + 35.0f);
+		temperature = (report.temp / 340.0f + 35.0f);
 	}
 
 	_px4_accel.set_temperature(temperature);


### PR DESCRIPTION
The mpu6000 driver contains an error in the temperature scalar value.  This PR corrects that bug.

![image](https://user-images.githubusercontent.com/2497951/51804432-1e0c5a00-221e-11e9-8433-9a634c16a2be.png)

(Taken from page 14 of the current datasheet revision [here](https://store.invensense.com/datasheets/invensense/MPU-6050_DataSheet_V3%204.pdf).) 

The mpu9250 contained a similar error last year and when it was corrected the disruption seemed to be minimal.

Let me know if you have any questions on this PR!

-Mark

@dakejahl , @mhkabir , @dagar 