### PR TITLE
Indicate version in which SYS_COMPANION deprecated

### DIFF
--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -111,7 +111,7 @@ PARAM_DEFINE_INT32(SYS_MC_EST_GROUP, 2);
 /**
  * TELEM2 as companion computer link (deprecated)
  *
- * This parameter is deprecated (from PX4 v1.8.1). Use the generic serial
+ * This parameter is deprecated will be removed after 1.9.0. Use the generic serial
  * configuration parameters instead (e.g. MAV_0_CONFIG, MAV_0_MODE, etc.).
  *
  * @value 0 Disabled

--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -111,8 +111,8 @@ PARAM_DEFINE_INT32(SYS_MC_EST_GROUP, 2);
 /**
  * TELEM2 as companion computer link (deprecated)
  *
- * This parameter is deprecated. Do not change it, use the more generic serial
- * configuration parameters instead.
+ * This parameter is deprecated (from PX4 v1.8.1). Use the generic serial
+ * configuration parameters instead (e.g. MAV_0_CONFIG, MAV_0_MODE, etc.).
  *
  * @value 0 Disabled
  * @value 10 FrSky Telemetry

--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -111,7 +111,7 @@ PARAM_DEFINE_INT32(SYS_MC_EST_GROUP, 2);
 /**
  * TELEM2 as companion computer link (deprecated)
  *
- * This parameter is deprecated will be removed after 1.9.0. Use the generic serial
+ * This parameter is deprecated and will be removed after 1.9.0. Use the generic serial
  * configuration parameters instead (e.g. MAV_0_CONFIG, MAV_0_MODE, etc.).
  *
  * @value 0 Disabled


### PR DESCRIPTION
Useful to know what version the parameter was deprecated and more clearly identify the parameters to use instead - see https://github.com/PX4/Devguide/pull/724

@bkueng Do we need a deprecated / use instead flag in the markup?