### PR TITLE
Add an Atomic Interface

### DIFF
--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -132,13 +132,13 @@ int BATT_SMBUS::task_spawn(int argc, char *argv[])
 
 	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
 
-		if (_object == nullptr && (busid == BATT_SMBUS_BUS_ALL || bus_options[i].busid == busid)) {
+		if (!is_running() && (busid == BATT_SMBUS_BUS_ALL || bus_options[i].busid == busid)) {
 
 			SMBus *interface = new SMBus(bus_options[i].busnum, BATT_SMBUS_ADDR);
 			BATT_SMBUS *dev = new BATT_SMBUS(interface, bus_options[i].devpath);
 
 			// Successful read of device type, we've found our battery
-			_object = dev;
+			_object.store(dev);
 			_task_id = task_id_is_work_queue;
 
 			int result = dev->get_startup_info();

--- a/src/drivers/heater/heater.cpp
+++ b/src/drivers/heater/heater.cpp
@@ -92,7 +92,7 @@ int Heater::controller_period(char *argv[])
 int Heater::custom_command(int argc, char *argv[])
 {
 	// Check if the driver is running.
-	if (!is_running() && !_object) {
+	if (!is_running()) {
 		PX4_INFO("not running");
 		return PX4_ERROR;
 	}
@@ -240,7 +240,7 @@ void Heater::initialize_trampoline(void *argv)
 		return;
 	}
 
-	_object = heater;
+	_object.store(heater);
 	heater->start();
 }
 

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -1008,7 +1008,7 @@ PX4FMU::cycle_trampoline(void *arg)
 			return;
 		}
 
-		_object = dev;
+		_object.store(dev);
 	}
 
 	dev->cycle();

--- a/src/drivers/rc_input/RCInput.cpp
+++ b/src/drivers/rc_input/RCInput.cpp
@@ -189,7 +189,7 @@ RCInput::cycle_trampoline(void *arg)
 			return;
 		}
 
-		_object = dev;
+		_object.store(dev);
 	}
 
 	dev->cycle();

--- a/src/modules/events/send_event.cpp
+++ b/src/modules/events/send_event.cpp
@@ -113,7 +113,7 @@ void SendEvent::initialize_trampoline(void *arg)
 	}
 
 	send_event->start();
-	_object = send_event;
+	_object.store(send_event);
 }
 
 void SendEvent::cycle_trampoline(void *arg)

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -92,7 +92,7 @@ void LandDetector::_cycle()
 {
 	perf_begin(_cycle_perf);
 
-	if (_object == nullptr) { // not initialized yet
+	if (_object.load() == nullptr) { // not initialized yet
 		// Advertise the first land detected uORB.
 		_landDetected.timestamp = hrt_absolute_time();
 		_landDetected.freefall = false;
@@ -110,7 +110,7 @@ void LandDetector::_cycle()
 
 		_check_params(true);
 
-		_object = this;
+		_object.store(this);
 	}
 
 	_check_params(false);

--- a/src/modules/load_mon/load_mon.cpp
+++ b/src/modules/load_mon/load_mon.cpp
@@ -151,7 +151,7 @@ int LoadMon::task_spawn(int argc, char *argv[])
 		return ret;
 	}
 
-	_object = obj;
+	_object.store(obj);
 	_task_id = task_id_is_work_queue;
 	return 0;
 }

--- a/src/modules/wind_estimator/wind_estimator_main.cpp
+++ b/src/modules/wind_estimator/wind_estimator_main.cpp
@@ -173,7 +173,7 @@ WindEstimatorModule::cycle_trampoline(void *arg)
 			return;
 		}
 
-		_object = dev;
+		_object.store(dev);
 	}
 
 	if (dev) {

--- a/src/platforms/px4_atomic.h
+++ b/src/platforms/px4_atomic.h
@@ -1,0 +1,171 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file px4_atomic.h
+ *
+ * Provides atomic integers and counters. Each method is executed atomically and thus
+ * can be used to prevent data races and add memory synchronization between threads.
+ *
+ * In addition to the atomicity, each method serves as a memory barrier (sequential
+ * consistent ordering). This means all operations that happen before and could
+ * potentially have visible side-effects in other threads will happen before
+ * the method is executed.
+ *
+ * The implementation uses the built-in methods from GCC (supported by Clang as well).
+ * @see https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html.
+ *
+ * @note: on ARM, the instructions LDREX and STREX might be emitted. To ensure correct
+ * behavior, the exclusive monitor needs to be cleared on a task switch (via CLREX).
+ * This happens automatically e.g. on ARMv7-M as part of an exception entry or exit
+ * sequence.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+
+#include <stdbool.h>
+#include <stdint.h>
+
+namespace px4
+{
+
+template <typename T>
+class atomic
+{
+public:
+
+#ifdef __PX4_NUTTX
+	// Ensure that all operations are lock-free, so that 'atomic' can be used from
+	// IRQ handlers. This might not be required everywhere though.
+	static_assert(__atomic_always_lock_free(sizeof(T), 0), "atomic is not lock-free for the given type T");
+#endif
+
+
+	explicit atomic(T value) : _value(value) {}
+
+	/**
+	 * Atomically read the current value
+	 */
+	inline T load() const
+	{
+		return __atomic_load_n(&_value, __ATOMIC_SEQ_CST);
+	}
+
+	/**
+	 * Atomically store a value
+	 */
+	inline void store(T value)
+	{
+		__atomic_store(&_value, &value, __ATOMIC_SEQ_CST);
+	}
+
+	/**
+	 * Atomically add a number and return the previous value.
+	 * @return value prior to the addition
+	 */
+	inline T fetch_add(T num)
+	{
+		return __atomic_fetch_add(&_value, num, __ATOMIC_SEQ_CST);
+	}
+
+	/**
+	 * Atomically substract a number and return the previous value.
+	 * @return value prior to the substraction
+	 */
+	inline T fetch_sub(T num)
+	{
+		return __atomic_fetch_sub(&_value, num, __ATOMIC_SEQ_CST);
+	}
+
+	/**
+	 * Atomic AND with a number
+	 * @return value prior to the operation
+	 */
+	inline T fetch_and(T num)
+	{
+		return __atomic_fetch_and(&_value, num, __ATOMIC_SEQ_CST);
+	}
+
+	/**
+	 * Atomic XOR with a number
+	 * @return value prior to the operation
+	 */
+	inline T fetch_xor(T num)
+	{
+		return __atomic_fetch_xor(&_value, num, __ATOMIC_SEQ_CST);
+	}
+
+	/**
+	 * Atomic OR with a number
+	 * @return value prior to the operation
+	 */
+	inline T fetch_or(T num)
+	{
+		return __atomic_fetch_or(&_value, num, __ATOMIC_SEQ_CST);
+	}
+
+	/**
+	 * Atomic NAND (~(_value & num)) with a number
+	 * @return value prior to the operation
+	 */
+	inline T fetch_nand(T num)
+	{
+		return __atomic_fetch_nand(&_value, num, __ATOMIC_SEQ_CST);
+	}
+
+	/**
+	 * Atomic compare and exchange operation.
+	 * This compares the contents of _value with the contents of *expected. If
+	 * equal, the operation is a read-modify-write operation that writes desired
+	 * into _value. If they are not equal, the operation is a read and the current
+	 * contents of _value are written into *expected.
+	 * @return If desired is written into _value then true is returned
+	 */
+	inline bool compare_exchange(T *expected, T num)
+	{
+		return __atomic_compare_exchange(&_value, expected, num, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+	}
+
+private:
+	T _value;
+};
+
+using atomic_int = atomic<int>;
+using atomic_int32_t = atomic<int32_t>;
+using atomic_bool = atomic<bool>;
+
+} /* namespace px4 */
+
+#endif /* __cplusplus */

--- a/src/platforms/px4_module.h
+++ b/src/platforms/px4_module.h
@@ -115,7 +115,7 @@ template<class T>
 class ModuleBase
 {
 public:
-	ModuleBase() = default;
+	ModuleBase() : _task_should_exit{false} {}
 	virtual ~ModuleBase() {}
 
 	/**

--- a/src/platforms/px4_module.h
+++ b/src/platforms/px4_module.h
@@ -41,6 +41,7 @@
 #include <unistd.h>
 #include <stdbool.h>
 
+#include <px4_atomic.h>
 #include <px4_time.h>
 #include <px4_log.h>
 #include <px4_tasks.h>
@@ -174,10 +175,10 @@ public:
 		argv += 1;
 #endif
 
-		_object = T::instantiate(argc, argv);
+		T *object = T::instantiate(argc, argv);
+		_object.store(object);
 
-		if (_object) {
-			T *object = (T *)_object;
+		if (object) {
 			object->run();
 
 		} else {
@@ -229,8 +230,9 @@ public:
 		lock_module();
 
 		if (is_running()) {
-			if (_object) {
-				T *object = (T *)_object;
+			T *object = _object.load();
+
+			if (object) {
 				object->request_stop();
 
 				unsigned int i = 0;
@@ -247,10 +249,8 @@ public:
 
 						_task_id = -1;
 
-						if (_object) {
-							delete _object;
-							_object = nullptr;
-						}
+						delete _object.load();
+						_object.store(nullptr);
 
 						ret = -1;
 						break;
@@ -279,8 +279,8 @@ public:
 		int ret = -1;
 		lock_module();
 
-		if (is_running() && _object) {
-			T *object = (T *)_object;
+		if (is_running() && _object.load()) {
+			T *object = _object.load();
 			ret = object->print_status();
 
 		} else {
@@ -326,7 +326,7 @@ protected:
 	 */
 	virtual void request_stop()
 	{
-		_task_should_exit = true;
+		_task_should_exit.store(true);
 	}
 
 	/**
@@ -335,7 +335,7 @@ protected:
 	 */
 	bool should_exit() const
 	{
-		return _task_should_exit;
+		return _task_should_exit.load();
 	}
 
 	/**
@@ -351,10 +351,8 @@ protected:
 		// - deleting the object must take place inside the lock.
 		lock_module();
 
-		if (_object) {
-			delete _object;
-			_object = nullptr;
-		}
+		delete _object.load();
+		_object.store(nullptr);
 
 		_task_id = -1; // Signal a potentially waiting thread for the module to exit that it can continue.
 		unlock_module();
@@ -372,7 +370,7 @@ protected:
 			/* Wait up to 1s. */
 			px4_usleep(2500);
 
-		} while (!_object && ++i < 400);
+		} while (!_object.load() && ++i < 400);
 
 		if (i == 400) {
 			PX4_ERR("Timed out while waiting for thread to start");
@@ -387,14 +385,14 @@ protected:
 	 */
 	static T *get_instance()
 	{
-		return (T *)_object;
+		return (T *)_object.load();
 	}
 
 	/**
 	 * @var _object Instance if the module is running.
 	 * @note There will be one instance for each template type.
 	 */
-	static volatile T *_object;
+	static px4::atomic<T *> _object;
 
 	/** @var _task_id The task handle: -1 = invalid, otherwise task is assumed to be running. */
 	static int _task_id;
@@ -420,11 +418,11 @@ private:
 	}
 
 	/** @var _task_should_exit Boolean flag to indicate if the task should exit. */
-	volatile bool _task_should_exit = false;
+	px4::atomic_bool _task_should_exit{false};
 };
 
 template<class T>
-volatile T *ModuleBase<T>::_object = nullptr;
+px4::atomic<T *> ModuleBase<T>::_object{nullptr};
 
 template<class T>
 int ModuleBase<T>::_task_id = -1;


### PR DESCRIPTION
We are moving towards more fine-grained locking and synchronization, and therefore we need need to ensure certain data accesses and modifications are atomic. This PR introduces a simple API based on GCC's atomic builtins (also available on clang).

I deliberately did not add type conversion and assignment operators, to make the operations explicit.