### PR TITLE
Jenkins: bypass entrypoint temporarily 

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -18,7 +18,7 @@ pipeline {
       agent {
         docker {
           image 'px4io/px4-dev-ros-kinetic:2018-09-11'
-          args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE --cap-add SYS_PTRACE'
+          args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE --cap-add SYS_PTRACE --entrypoint=""'
         }
       }
 
@@ -211,7 +211,7 @@ def createTestNode(Map test_def) {
   return {
     node {
       cleanWs()
-      docker.image("px4io/px4-dev-ros-kinetic:2018-09-11").inside('-e HOME=${WORKSPACE} --cap-add SYS_PTRACE') {
+      docker.image("px4io/px4-dev-ros-kinetic:2018-09-11").inside('-e HOME=${WORKSPACE} --cap-add SYS_PTRACE --entrypoint=""') {
         stage(test_def.name) {
           def test_ok = true
           sh('export')

--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -156,9 +156,16 @@ pipeline {
 
 def createBuildNode(Boolean archive, String docker_image, String target) {
   return {
+
+    // TODO: fix the snapdragon image
+    bypass_entrypoint = ''
+    if (docker_image == 'lorenzmeier/px4-dev-snapdragon:2018-09-12') {
+      bypass_entrypoint = ' --entrypoint=""'
+    }
+
     node {
       docker.withRegistry('https://registry.hub.docker.com', 'docker_hub_dagar') {
-        docker.image(docker_image).inside('-e CCACHE_BASEDIR=${WORKSPACE} -v ${CCACHE_DIR}:${CCACHE_DIR}:rw') {
+        docker.image(docker_image).inside('-e CCACHE_BASEDIR=${WORKSPACE} -v ${CCACHE_DIR}:${CCACHE_DIR}:rw' + bypass_entrypoint) {
           stage(target) {
             try {
               sh('export')


### PR DESCRIPTION
Problem: Jenkins fails SITL test with: 
> Error response from daemon: Container *********** is not running

The bigger problem is that it actually blocks the agents and doesn't fail for a while.

This is because we can't update SITL containers with the good entrypoint fix (included in 2019-01-27, the `exec` line) because of the MAVROS incompatibility with the newest version (https://github.com/mavlink/mavros/pull/1161 is the fix, not yet released). We also can't select an older compatible version of MAVROS because the ROS repo used by apt only keeps the most current version.

I had to do the same thing to the compile job for snapdragon builds.

What I've done here is essentially a hack and disabled the `entrypoint`.

This will let us get back to "a working CI" for now. Without this all compile jobs and SITL jobs will fail with the recent updates to Jenkins, specifically the docker workflow plugin > 1.14.
