### PR TITLE
CI: SITL test run: select ROS version based on ROS_DISTRO

### DIFF
--- a/test/rostest_px4_run.sh
+++ b/test/rostest_px4_run.sh
@@ -3,7 +3,7 @@
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 PX4_SRC_DIR=${DIR}/..
 
-source /opt/ros/kinetic/setup.bash
+source /opt/ros/${ROS_DISTRO:-kinetic}/setup.bash
 source ${PX4_SRC_DIR}/Tools/setup_gazebo.bash ${PX4_SRC_DIR} ${PX4_SRC_DIR}/build/px4_sitl_default
 
 export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:${PX4_SRC_DIR}:${PX4_SRC_DIR}/Tools/sitl_gazebo


### PR DESCRIPTION
As we introduce SITL testing on Melodic this is important as we'll have Kinetic at the same time.