### PR TITLE
Reduce false positives in pre-flight accel bias check

### DIFF
--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -592,16 +592,6 @@ static bool ekf2Check(orb_advert_t *mavlink_log_pub, vehicle_status_s &vehicle_s
 		}
 	}
 
-	if (fabsf(status.states[13]) > test_limit || fabsf(status.states[14]) > test_limit
-	    || fabsf(status.states[15]) > test_limit) {
-		if (report_fail) {
-			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: High Accelerometer Bias");
-		}
-
-		success = false;
-		goto out;
-	}
-
 	// check gyro delta angle bias estimates
 	param_get(param_find("COM_ARM_EKF_GB"), &test_limit);
 

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -576,10 +576,12 @@ static bool ekf2Check(orb_advert_t *mavlink_log_pub, vehicle_status_s &vehicle_s
 
 	// check accelerometer delta velocity bias estimates
 	param_get(param_find("COM_ARM_EKF_AB"), &test_limit);
-	for (uint8_t index=13; index<16; index++) {
+
+	for (uint8_t index = 13; index < 16; index++) {
 		// allow for higher uncertainty in estimates for axes that are less observable to prevent false positives
 		// adjust test threshold by 3-sigma
-		float test_uncertainty = 3.0f * sqrtf(fmaxf(status.covariances[index],0.0f));
+		float test_uncertainty = 3.0f * sqrtf(fmaxf(status.covariances[index], 0.0f));
+
 		if (fabsf(status.states[index]) > test_limit + test_uncertainty) {
 			if (report_fail) {
 				mavlink_log_critical(mavlink_log_pub, "Preflight Fail: High Accelerometer Bias");

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -575,7 +575,7 @@ PARAM_DEFINE_FLOAT(COM_ARM_EKF_YAW, 0.5f);
  * @decimal 4
  * @increment 0.0001
  */
-PARAM_DEFINE_FLOAT(COM_ARM_EKF_AB, 2.4e-3f);
+PARAM_DEFINE_FLOAT(COM_ARM_EKF_AB, 1.73e-3f);
 
 /**
  * Maximum value of EKF gyro delta angle bias estimate that will allow arming


### PR DESCRIPTION
Addresses issue https://github.com/PX4/Firmware/issues/10833 

This PR adjusts the test threshold so that the threshold is scaled up with increasing uncertainty in state estimate. Eventually given sufficient acceleration/rotation all delta velocity bias variances collapse to 5E-8, eg:

![screen shot 2019-01-31 at 8 51 26 am](https://user-images.githubusercontent.com/3596952/52015144-6933af00-2535-11e9-95b5-0f33d4ce3d9b.png)

which equates to an effective test threshold of   1.73E-3 + 3*sqrt(5E-8) = 2.4E-3 which is the same as the previous threshold and equates to an accel bias of 2.4E-3 / dtEKF = 2.4E-3 / 8E-3 = 0.3 m/s/s

Note that the EKF internally limits the max bias estimate to within an equivalent +-0.4 m/s/s, so we need this check to stay inside that range.

The horizontal axes are poorly observable when on ground and the variances remain high until the vehicle is moved/tilted. In the example shown below the XY axes stay at 100E-8 which would result in a test threshold of (1.73E-3 + 3*sqrt(100E-8)) / 8E-3 = 0.59 m/s/s which would not trigger.

![screen shot 2019-01-31 at 9 10 35 am](https://user-images.githubusercontent.com/3596952/52016223-16a7c200-2538-11e9-890e-9b599fc81244.png)

**Test data / coverage**
Request for testing from affected users in https://github.com/PX4/Firmware/issues/10833 .