### PR TITLE
CI: test: set verbose

### DIFF
--- a/test/mavros_posix_test_mission.test
+++ b/test/mavros_posix_test_mission.test
@@ -5,16 +5,16 @@
     <arg name="est" default="ekf2"/>
     <arg name="gui" default="false"/>
     <arg name="interactive" default="false"/>
+    <arg name="mission"/>  <!-- no default, required input -->
     <arg name="vehicle" default="iris"/>
-    <arg name="mission"/>
     <!-- MAVROS, PX4 SITL, Gazebo -->
     <include file="$(find px4)/launch/mavros_posix_sitl.launch">
         <arg name="est" value="$(arg est)"/>
         <arg name="gui" value="$(arg gui)"/>
         <arg name="interactive" value="$(arg interactive)"/>
-        <arg name="vehicle" value="$(arg vehicle)"/>
         <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>
+        <arg name="vehicle" value="$(arg vehicle)"/>
         <arg name="verbose" value="true"/>
     </include>
     <!-- ROStest -->

--- a/test/mavros_posix_test_mission.test
+++ b/test/mavros_posix_test_mission.test
@@ -15,6 +15,7 @@
         <arg name="vehicle" value="$(arg vehicle)"/>
         <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>
+        <arg name="verbose" value="true"/>
     </include>
     <!-- ROStest -->
     <test test-name="$(arg mission)" pkg="px4" type="mission_test.py" time-limit="300.0" args="$(arg mission).plan"/>

--- a/test/mavros_posix_tests_iris_opt_flow.test
+++ b/test/mavros_posix_tests_iris_opt_flow.test
@@ -13,6 +13,7 @@
         <arg name="vehicle" value="iris_opt_flow"/>
         <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>
+        <arg name="verbose" value="true"/>
     </include>
     <!-- ROStest -->
     <test test-name="mavros_flow_offboard_posctl_test" pkg="px4" type="mavros_offboard_posctl_test.py" time-limit="300.0"/>

--- a/test/mavros_posix_tests_iris_opt_flow.test
+++ b/test/mavros_posix_tests_iris_opt_flow.test
@@ -10,9 +10,9 @@
         <arg name="est" value="$(arg est)"/>
         <arg name="gui" value="$(arg gui)"/>
         <arg name="interactive" value="$(arg interactive)"/>
-        <arg name="vehicle" value="iris_opt_flow"/>
         <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>
+        <arg name="vehicle" value="iris_opt_flow"/>
         <arg name="verbose" value="true"/>
     </include>
     <!-- ROStest -->

--- a/test/mavros_posix_tests_missions.test
+++ b/test/mavros_posix_tests_missions.test
@@ -14,6 +14,7 @@
         <arg name="vehicle" value="$(arg vehicle)"/>
         <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>
+        <arg name="verbose" value="true"/>
     </include>
     <!-- ROStest -->
     <test test-name="FW_mission_1" pkg="px4" type="mission_test.py" time-limit="300.0" args="FW_mission_1.plan" vehicle="plane"/>

--- a/test/mavros_posix_tests_missions.test
+++ b/test/mavros_posix_tests_missions.test
@@ -4,16 +4,16 @@
     <!-- Test all missions -->
     <arg name="est" default="ekf2"/>
     <arg name="gui" default="false"/>
-    <arg name="vehicle" default="standard_vtol"/>
     <arg name="interactive" default="false"/>
+    <arg name="vehicle" default="standard_vtol"/>
     <!-- MAVROS, PX4 SITL, Gazebo -->
     <include file="$(find px4)/launch/mavros_posix_sitl.launch">
         <arg name="est" value="$(arg est)"/>
         <arg name="gui" value="$(arg gui)"/>
         <arg name="interactive" value="$(arg interactive)"/>
-        <arg name="vehicle" value="$(arg vehicle)"/>
         <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>
+        <arg name="vehicle" value="$(arg vehicle)"/>
         <arg name="verbose" value="true"/>
     </include>
     <!-- ROStest -->

--- a/test/mavros_posix_tests_offboard_attctl.test
+++ b/test/mavros_posix_tests_offboard_attctl.test
@@ -4,16 +4,16 @@
     <!-- Test offboard attitude control -->
     <arg name="est" default="ekf2"/>
     <arg name="gui" default="false"/>
-    <arg name="vehicle" default="iris"/>
     <arg name="interactive" default="false"/>
+    <arg name="vehicle" default="iris"/>
     <!-- MAVROS, PX4 SITL, Gazebo -->
     <include file="$(find px4)/launch/mavros_posix_sitl.launch">
         <arg name="est" value="$(arg est)"/>
         <arg name="gui" value="$(arg gui)"/>
         <arg name="interactive" value="$(arg interactive)"/>
-        <arg name="vehicle" value="$(arg vehicle)"/>
         <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>
+        <arg name="vehicle" value="$(arg vehicle)"/>
         <arg name="verbose" value="true"/>
     </include>
     <!-- ROStest -->

--- a/test/mavros_posix_tests_offboard_attctl.test
+++ b/test/mavros_posix_tests_offboard_attctl.test
@@ -14,6 +14,7 @@
         <arg name="vehicle" value="$(arg vehicle)"/>
         <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>
+        <arg name="verbose" value="true"/>
     </include>
     <!-- ROStest -->
     <test test-name="mavros_offboard_attctl_test" pkg="px4" type="mavros_offboard_attctl_test.py" time-limit="300.0"/>

--- a/test/mavros_posix_tests_offboard_posctl.test
+++ b/test/mavros_posix_tests_offboard_posctl.test
@@ -14,6 +14,7 @@
         <arg name="vehicle" value="$(arg vehicle)"/>
         <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>
+        <arg name="verbose" value="true"/>
     </include>
     <!-- ROStest -->
     <test test-name="mavros_offboard_posctl_test" pkg="px4" type="mavros_offboard_posctl_test.py" time-limit="300.0"/>

--- a/test/mavros_posix_tests_offboard_posctl.test
+++ b/test/mavros_posix_tests_offboard_posctl.test
@@ -4,16 +4,16 @@
     <!-- Test offboard local posistion control -->
     <arg name="est" default="ekf2"/>
     <arg name="gui" default="false"/>
-    <arg name="vehicle" default="iris"/>
     <arg name="interactive" default="false"/>
+    <arg name="vehicle" default="iris"/>
     <!-- MAVROS, PX4 SITL, Gazebo -->
     <include file="$(find px4)/launch/mavros_posix_sitl.launch">
         <arg name="est" value="$(arg est)"/>
         <arg name="gui" value="$(arg gui)"/>
         <arg name="interactive" value="$(arg interactive)"/>
-        <arg name="vehicle" value="$(arg vehicle)"/>
         <arg name="respawn_gazebo" value="true"/>
         <arg name="respawn_mavros" value="true"/>
+        <arg name="vehicle" value="$(arg vehicle)"/>
         <arg name="verbose" value="true"/>
     </include>
     <!-- ROStest -->


### PR DESCRIPTION
More data here will help identify issues with sitl_gazebo and gazebo. It doesn't spam the console as one might think. I also organized the args in the `.test` files.

TL;DR: You'll see ~15 lines of additional `[Msg]` and `[Dbg]` messages (on current master, without errors).

Here is a chunk of the output for the MC_mission_box (run locally, same as CI):
```
tony@COMPUTER:~/px4/Firmware$ test/rostest_px4_run.sh mavros_posix_test_mission.test mission:=MC_mission_box
GAZEBO_PLUGIN_PATH :/home/tony/px4/member/Firmware/build/posix_sitl_default/build_gazebo:/home/tony/px4/member/Firmware/build/posix_sitl_default/build_gazebo:/home/tony/px4/Firmware/test/../build/px4_sitl_default/build_gazebo
GAZEBO_MODEL_PATH :/home/tony/px4/member/Firmware/Tools/sitl_gazebo/models:/home/tony/px4/member/Firmware/Tools/sitl_gazebo/models:/home/tony/px4/Firmware/test/../Tools/sitl_gazebo/models
LD_LIBRARY_PATH /opt/ros/kinetic/lib:/opt/ros/kinetic/lib/x86_64-linux-gnu:/home/tony/px4/member/Firmware/build/posix_sitl_default/build_gazebo:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/pulse:/home/tony/px4/member/Firmware/build/posix_sitl_default/build_gazebo:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/pulse:/home/tony/px4/Firmware/test/../build/px4_sitl_default/build_gazebo
... logging to /home/tony/.ros/ros_logs/rostest-COMPUTER-11909.log
[ROSUNIT] Outputting test results to /home/tony/.ros/test_results/px4/rostest-test_mavros_posix_test_mission.xml
INFO  [px4] Creating symlink /home/tony/px4/Firmware/ROMFS/px4fmu_common -> /home/tony/.ros/etc
0 WARNING: setRealtimeSched failed (not run as root?)

______  __   __    ___
| ___ \ \ \ / /   /   |
| |_/ /  \ V /   / /| |
|  __/   /   \  / /_| |
| |     / /^\ \ \___  |
\_|     \/   \/     |_/

px4 starting.

INFO  [px4] Calling startup script: /bin/sh etc/init.d-posix/rcS 0
+ SYS_AUTOSTART: curr: 10017 -> new: 10016
+ MPC_XY_VEL_P: curr: 0.1500 -> new: 0.2000
+ MPC_XY_VEL_I: curr: 0.2000 -> new: 0.0200
+ MPC_XY_VEL_D: curr: 0.0050 -> new: 0.0160
  MPC_JERK_MIN: curr: 8.0000 -> new: 10.0000
+ MPC_ACC_HOR_MAX: curr: 2.0000 -> new: 3.0000
+ RTL_DESCEND_ALT: curr: 10.0000 -> new: 5.0000
+ RTL_LAND_DELAY: curr: 0.0000 -> new: 5.0000
  SDLOG_PROFILE: curr: 3 -> new: 131
* RTL_DESCEND_ALT: curr: 5.0000 -> new: 10.0000
* RTL_LAND_DELAY: curr: 5.0000 -> new: 0.0000
INFO  [dataman] Unknown restart, data manager file './dataman' size is 11405132 bytes
INFO  [simulator] Waiting for simulator to connect on TCP port 4560
Gazebo multi-robot simulator, version 7.0.0
Copyright (C) 2012-2016 Open Source Robotics Foundation.
Released under the Apache 2 License.
http://gazebosim.org

[ INFO] [1548907499.694922652]: FCU URL: udp://:14540@localhost:14557
[ INFO] [1548907499.696221367]: udp0: Bind address: 0.0.0.0:14540
[ INFO] [1548907499.696285312]: udp0: Remote address: 127.0.0.1:14557
[ INFO] [1548907499.696386105]: GCS bridge disabled
[ INFO] [1548907499.713261642]: Plugin 3dr_radio loaded
[ INFO] [1548907499.714896788]: Plugin 3dr_radio initialized
[ INFO] [1548907499.714953649]: Plugin actuator_control loaded
[ INFO] [1548907499.717561227]: Plugin actuator_control initialized
[ INFO] [1548907499.722219919]: Plugin adsb loaded
[ INFO] [1548907499.727915754]: Plugin adsb initialized
[ INFO] [1548907499.728047162]: Plugin altitude loaded
[ INFO] [1548907499.728339236]: Finished loading Gazebo ROS API Plugin.
[ INFO] [1548907499.728850320]: Plugin altitude initialized
[ INFO] [1548907499.728912836]: Plugin cam_imu_sync loaded
[ INFO] [1548907499.729326820]: Plugin cam_imu_sync initialized
[ INFO] [1548907499.729393329]: Plugin command loaded
[Msg] Waiting for master.
[ INFO] [1548907499.733259675]: waitForService: Service [/gazebo/set_physics_properties] has not been advertised, waiting...
[Msg] Connected to gazebo master @ http://127.0.0.1:11345
[Msg] Publicized address: 172.17.0.1
[ INFO] [1548907499.738445068]: Plugin command initialized
[ INFO] [1548907499.738521654]: Plugin companion_process_status loaded
[ INFO] [1548907499.745173365]: Plugin companion_process_status initialized
[ INFO] [1548907499.745270485]: Plugin debug_value loaded
[ INFO] [1548907499.753483991]: Plugin debug_value initialized
[ INFO] [1548907499.753520226]: Plugin distance_sensor blacklisted
[ INFO] [1548907499.753630184]: Plugin fake_gps loaded
[ INFO] [1548907499.778827765]: Plugin fake_gps initialized
[ INFO] [1548907499.778923820]: Plugin ftp loaded
[ INFO] [1548907499.785353271]: Plugin ftp initialized
[ INFO] [1548907499.785465677]: Plugin global_position loaded
[ INFO] [1548907499.802569217]: Plugin global_position initialized
[ INFO] [1548907499.802652416]: Plugin gps_rtk loaded
[ INFO] [1548907499.804935434]: Plugin gps_rtk initialized
[ INFO] [1548907499.805071904]: Plugin hil loaded
[ INFO] [1548907499.817614041]: Plugin hil initialized
[ INFO] [1548907499.817700702]: Plugin home_position loaded
[ INFO] [1548907499.821261142]: Plugin home_position initialized
[ INFO] [1548907499.821341817]: Plugin imu loaded
[ INFO] [1548907499.828128292]: Plugin imu initialized
[ INFO] [1548907499.828218082]: Plugin local_position loaded
[ INFO] [1548907499.834239937]: Plugin local_position initialized
[ INFO] [1548907499.834320379]: Plugin log_transfer loaded
[ INFO] [1548907499.836614397]: Plugin log_transfer initialized
[ INFO] [1548907499.836699863]: Plugin manual_control loaded
[ INFO] [1548907499.839457651]: Plugin manual_control initialized
[ INFO] [1548907499.839611559]: Plugin mocap_pose_estimate loaded
[ INFO] [1548907499.843893096]: Plugin mocap_pose_estimate initialized
[ INFO] [1548907499.844003978]: Plugin obstacle_distance loaded
[ INFO] [1548907499.848585422]: Plugin obstacle_distance initialized
[ INFO] [1548907499.848677189]: Plugin odom loaded
[ INFO] [1548907499.856442686]: Plugin odom initialized
[ INFO] [1548907499.856541479]: Plugin param loaded
[ INFO] [1548907499.859766609]: Plugin param initialized
[ INFO] [1548907499.859863511]: Plugin px4flow loaded
[ INFO] [1548907499.866855645]: Plugin px4flow initialized
[ INFO] [1548907499.866890785]: Plugin rangefinder blacklisted
[ INFO] [1548907499.866993728]: Plugin rc_io loaded
[ INFO] [1548907499.870202869]: Plugin rc_io initialized
[ INFO] [1548907499.870228559]: Plugin safety_area blacklisted
[ INFO] [1548907499.870301040]: Plugin setpoint_accel loaded
[ INFO] [1548907499.873876431]: Plugin setpoint_accel initialized
[ INFO] [1548907499.874020712]: Plugin setpoint_attitude loaded
[ INFO] [1548907499.884324966]: Plugin setpoint_attitude initialized
[ INFO] [1548907499.884500086]: Plugin setpoint_position loaded
[ INFO] [1548907499.899560340]: Plugin setpoint_position initialized
[ INFO] [1548907499.899659526]: Plugin setpoint_raw loaded
[ INFO] [1548907499.909791020]: Plugin setpoint_raw initialized
[ INFO] [1548907499.909906597]: Plugin setpoint_velocity loaded
[ INFO] [1548907499.915273163]: Plugin setpoint_velocity initialized
[ INFO] [1548907499.915418631]: Plugin sys_status loaded
[ INFO] [1548907499.925019713]: Plugin sys_status initialized
[ INFO] [1548907499.925133116]: Plugin sys_time loaded
[ INFO] [1548907499.930281605]: TM: Timesync mode: MAVLINK
[ INFO] [1548907499.931360774]: Plugin sys_time initialized
[ INFO] [1548907499.931455004]: Plugin trajectory loaded
[ INFO] [1548907499.937060824]: Plugin trajectory initialized
[ INFO] [1548907499.937206728]: Plugin vfr_hud loaded
[ INFO] [1548907499.937813646]: Plugin vfr_hud initialized
[ INFO] [1548907499.937836680]: Plugin vibration blacklisted
[ INFO] [1548907499.937913832]: Plugin vision_pose_estimate loaded
[ INFO] [1548907499.945947092]: Plugin vision_pose_estimate initialized
[ INFO] [1548907499.946034567]: Plugin vision_speed_estimate loaded
[ INFO] [1548907499.949503417]: Plugin vision_speed_estimate initialized
[ INFO] [1548907499.949651687]: Plugin waypoint loaded
[ INFO] [1548907499.954179080]: Plugin waypoint initialized
[ INFO] [1548907499.954278772]: Plugin wind_estimation loaded
[ INFO] [1548907499.954773230]: Plugin wind_estimation initialized
[ INFO] [1548907499.954797459]: Autostarting mavlink via USB on PX4
[ INFO] [1548907499.954823470]: Built-in SIMD instructions: SSE, SSE2
[ INFO] [1548907499.954836925]: Built-in MAVLink package version: 2019.1.12
[ INFO] [1548907499.954863179]: Known MAVLink dialects: common ardupilotmega ASLUAV autoquad icarous matrixpilot paparazzi slugs standard uAvionix ualberta
[ INFO] [1548907499.954877706]: MAVROS started. MY ID 1.240, TARGET ID 1.1
SpawnModel script started
[INFO] [1548907500.213394, 0.000000]: Loading model XML from file
[INFO] [1548907500.213632, 0.000000]: Waiting for service /gazebo/spawn_sdf_model
[ INFO] [1548907500.988084580, 0.024000000]: waitForService: Service [/gazebo/set_physics_properties] is now available.
[ INFO] [1548907501.018992249, 0.056000000]: Physics dynamic reconfigure ready.
[INFO] [1548907501.120387, 0.156000]: Calling service /gazebo/spawn_sdf_model
[INFO] [1548907501.201582, 0.172000]: Spawn status: SpawnModel: Successfully spawned entity
[Dbg] [gazebo_mavlink_interface.cpp:137] <joint_name> not found for channel[0] no joint control will be performed for this channel.
[Dbg] [gazebo_mavlink_interface.cpp:137] <joint_name> not found for channel[1] no joint control will be performed for this channel.
[Dbg] [gazebo_mavlink_interface.cpp:137] <joint_name> not found for channel[2] no joint control will be performed for this channel.
[Dbg] [gazebo_mavlink_interface.cpp:137] <joint_name> not found for channel[3] no joint control will be performed for this channel.
[Wrn] [gazebo_mavlink_interface.cpp:126] joint [zephyr_delta_wing::propeller_joint] not found for channel[4] no joint control for this channel.
[Wrn] [gazebo_mavlink_interface.cpp:126] joint [zephyr_delta_wing::flap_left_joint] not found for channel[5] no joint control for this channel.
[Wrn] [gazebo_mavlink_interface.cpp:126] joint [zephyr_delta_wing::flap_right_joint] not found for channel[6] no joint control for this channel.
[Dbg] [gazebo_mavlink_interface.cpp:137] <joint_name> not found for channel[7] no joint control will be performed for this channel.
[Msg] Conecting to PX4 SITL using TCP
[Msg] Lockstep is enabled
[Msg] Speed factor set to: 1
[Msg] Using MAVLink protocol v2.0
INFO  [simulator] Simulator connected on TCP port 4560.
INFO  [init] Mixer: etc/mixers/quad_w.main.mix on /dev/pwm_output0
INFO  [mavlink] mode: Normal, data rate: 4000000 B/s on udp port 14570 remote port 14550
INFO  [mavlink] mode: Onboard, data rate: 4000000 B/s on udp port 14580 remote port 14540
INFO  [logger] logger started (mode=all)
INFO  [mavlink] MAVLink only on localhost (set param MAV_BROADCAST = 1 to enable network)
INFO  [logger] Start file log (type: full)
INFO  [logger] Opened full log file: ./log/2019-01-31/04_05_02.ulg
INFO  [px4] Startup script returned successfully
[ INFO] [1548907502.823285999, 1.396000000]: udp0: Remote address: 127.0.0.1:14580
[ INFO] [1548907502.823388233, 1.396000000]: IMU: High resolution IMU detected!
INFO  [mavlink] partner IP: 127.0.0.1
[ INFO] [1548907503.108035881, 1.680000000]: FCU: [logger] file: ./log/2019-01-31/04_05_02.ulg
INFO  [ecl/EKF] EKF aligned, (pressure height, IMU buf: 22, OBS buf: 14)
[ INFO] [1548907503.716832830, 2.288000000]: IMU: Attitude quaternion IMU detected!
[ERROR] [1548907503.741416026, 2.312000000]: ODOM: Ex: The tf tree is invalid because it contains a loop.
Frame local_origin_ned exists with parent local_origin.
Frame fcu_frd exists with parent fcu.
Frame fcu exists with parent fcu_frd.

[ INFO] [1548907503.803887943, 2.376000000]: CON: Got HEARTBEAT, connected. FCU: PX4 Autopilot
[ INFO] [1548907503.804577253, 2.376000000]: IMU: High resolution IMU detected!
[ INFO] [1548907503.815924386, 2.388000000]: IMU: Attitude quaternion IMU detected!
[ INFO] [1548907504.810288452, 3.380000000]: VER: 1.1: Capabilities         0x000000000000e4ef
[ INFO] [1548907504.810436682, 3.380000000]: VER: 1.1: Flight software:     01090080 (98faccd173eaddc4)
[ INFO] [1548907504.810520496, 3.380000000]: VER: 1.1: Middleware software: 01090080 (98faccd173eaddc4)
[ INFO] [1548907504.810600536, 3.380000000]: VER: 1.1: OS software:         040f00ff (0000000000000000)
[ INFO] [1548907504.810671170, 3.380000000]: VER: 1.1: Board hardware:      00000001
[ INFO] [1548907504.810736706, 3.380000000]: VER: 1.1: VID/PID:             0000:0000
[ INFO] [1548907504.810834186, 3.380000000]: VER: 1.1: UID:                 4954414c44494e4f
INFO  [ecl/EKF] EKF GPS checks passed (WGS-84 origin set)
INFO  [ecl/EKF] EKF commencing GPS fusion
[ INFO] [1548907518.821067940, 17.376000000]: WP: mission received
[ INFO] [1548907519.471030029, 18.024000000]: WP: mission sended
[ WARN] [1548907520.491049504, 19.044000000]: CMD: Unexpected command 176, result 0
[ INFO] [1548907520.498483269, 19.052000000]: FCU: Takeoff to 5.0 meters above home.
[ INFO] [1548907521.487192923, 20.040000000]: FCU: ARMED by arm/disarm component command
INFO  [commander] Takeoff detected
[ INFO] [1548907522.059835637, 20.612000000]: FCU: Takeoff detected
[ INFO] [1548907528.519480126, 27.064000000]: WP: reached #0
....
```
