### PR TITLE
Improve the module doc parser - subcategories/empty defaults

### DIFF
--- a/Tools/px4moduledoc/markdownout.py
+++ b/Tools/px4moduledoc/markdownout.py
@@ -40,21 +40,39 @@ The generated files will be written to the `modules` directory.
 
         self._outputs['main'] = result
 
-
         for category in sorted(module_groups):
             result = "# Modules Reference: %s\n" % category.capitalize()
-            module_list = module_groups[category]
-            for module in module_list:
-                result += "## %s\n" % module.name()
-                result += "Source: [%s](https://github.com/PX4/Firmware/tree/master/src/%s)\n\n" % (module.scope(), module.scope())
-                doc = module.documentation()
-                if len(doc) > 0:
-                    result += "%s\n" % doc
-                usage_string = module.usage_string()
-                if len(usage_string) > 0:
-                    result += "### Usage {#%s_usage}\n```\n%s\n```\n" % (module.name(), usage_string)
+            subcategories = module_groups[category]
+            if len(subcategories) > 1:
+                result += 'Subcategories:\n'
+                for subcategory in subcategories:
+                    if subcategory == '':
+                        continue
+                    subcategory_label = subcategory.replace('_', ' ').title()
+                    subcategory_file_name = category+'_'+subcategory
+                    result += '- [%s](modules_%s.md)\n' % (subcategory_label, subcategory_file_name)
 
+                    # add a sub-page for the subcategory
+                    result_subpage = '# Modules Reference: %s (%s)\n' % \
+                        (subcategory_label, category.capitalize())
+                    result_subpage += self._ProcessModules(subcategories[subcategory])
+                    self._outputs[subcategory_file_name] = result_subpage
+
+            result += '\n' + self._ProcessModules(subcategories[''])
             self._outputs[category] = result
+
+    def _ProcessModules(self, module_list):
+        result = ''
+        for module in module_list:
+            result += "## %s\n" % module.name()
+            result += "Source: [%s](https://github.com/PX4/Firmware/tree/master/src/%s)\n\n" % (module.scope(), module.scope())
+            doc = module.documentation()
+            if len(doc) > 0:
+                result += "%s\n" % doc
+            usage_string = module.usage_string()
+            if len(usage_string) > 0:
+                result += "### Usage {#%s_usage}\n```\n%s\n```\n" % (module.name(), usage_string)
+        return result
 
     def Save(self, dirname):
         for output_name in self._outputs:

--- a/Tools/px4moduledoc/srcparser.py
+++ b/Tools/px4moduledoc/srcparser.py
@@ -92,7 +92,8 @@ class ModuleDocumentation(object):
         description = self._get_string(args[4])
         if self._is_bool_true(args[5]):
             self._usage_string += "     [-%s <val>]  %s\n" % (option_char, description)
-            self._usage_string += "                 default: %i\n" % default_val
+            if default_val != -1:
+                self._usage_string += "                 default: %i\n" % default_val
         else:
             self._usage_string += "     -%s <val>    %s\n" % (option_char, description)
 
@@ -103,7 +104,8 @@ class ModuleDocumentation(object):
         description = self._get_string(args[4])
         if self._is_bool_true(args[5]):
             self._usage_string += "     [-%s <val>]  %s\n" % (option_char, description)
-            self._usage_string += "                 default: %.1f\n" % default_val
+            if not math.isnan(default_val):
+                self._usage_string += "                 default: %.1f\n" % default_val
         else:
             self._usage_string += "     -%s <val>    %s\n" % (option_char, description)
 

--- a/Tools/px_process_module_doc.py
+++ b/Tools/px_process_module_doc.py
@@ -93,7 +93,7 @@ def main():
 
     # Output to Markdown/HTML tables
     if args.markdown:
-        if (args.verbose): print("Creating markdown output to directory " + str(args.markdown))
+        if args.verbose: print("Creating markdown output to directory " + str(args.markdown))
         if not os.path.exists(args.markdown):
             os.makedirs(args.markdown)
         out = markdownout.MarkdownOutput(module_groups)

--- a/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
+++ b/src/drivers/distance_sensor/sf1xx/sf1xx.cpp
@@ -835,6 +835,7 @@ $ sf1xx stop
 )DESCR_STR");
 
 	PRINT_MODULE_USAGE_NAME("sf1xx", "driver");
+	PRINT_MODULE_USAGE_SUBCATEGORY("distance_sensor");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("start","Start driver");
 	PRINT_MODULE_USAGE_PARAM_FLAG('a', "Attempt to start driver on all I2C buses", true);
 	PRINT_MODULE_USAGE_PARAM_INT('b', 1, 1, 2000, "Start driver on specific I2C bus", true);

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -3057,7 +3057,7 @@ $ mavlink stream -u 14556 -s HIGHRES_IMU -r 50
 
 	PRINT_MODULE_USAGE_COMMAND_DESCR("stream", "Configure the sending rate of a stream for a running instance");
 #if defined(CONFIG_NET) || defined(__PX4_POSIX)
-	PRINT_MODULE_USAGE_PARAM_INT('u', 0, 0, 65536, "Select Mavlink instance via local Network Port", true);
+	PRINT_MODULE_USAGE_PARAM_INT('u', -1, 0, 65536, "Select Mavlink instance via local Network Port", true);
 #endif
 	PRINT_MODULE_USAGE_PARAM_STRING('d', nullptr, "<file:dev>", "Select Mavlink instance via Serial Device", true);
 	PRINT_MODULE_USAGE_PARAM_STRING('s', nullptr, nullptr, "Mavlink stream to configure", false);

--- a/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
+++ b/src/modules/micrortps_bridge/micrortps_client/microRTPS_client_main.cpp
@@ -76,7 +76,7 @@ static void usage(const char *name)
 	PRINT_MODULE_USAGE_PARAM_STRING('t', "UART", "UART|UDP", "Transport protocol", true);
 	PRINT_MODULE_USAGE_PARAM_STRING('d', "/dev/ttyACM0", "<file:dev>", "Select Serial Device", true);
 	PRINT_MODULE_USAGE_PARAM_INT('b', 460800, 9600, 3000000, "Baudrate (can also be p:<param_name>)", true);
-	PRINT_MODULE_USAGE_PARAM_INT('p', 1, 1, 1000, "Poll timeout for UART in ms", true);
+	PRINT_MODULE_USAGE_PARAM_INT('p', -1, 1, 1000, "Poll timeout for UART in ms", true);
 	PRINT_MODULE_USAGE_PARAM_INT('u', 0, 0, 10000,
 				     "Interval in ms to limit the update rate of all sent topics (0=unlimited)", true);
 	PRINT_MODULE_USAGE_PARAM_INT('l', 10000, -1, 100000, "Limit number of iterations until the program exits (-1=infinite)",

--- a/src/platforms/common/module.cpp
+++ b/src/platforms/common/module.cpp
@@ -64,6 +64,11 @@ void PRINT_MODULE_USAGE_NAME(const char *executable_name, const char *category)
 	PX4_INFO_RAW(" Commands:\n");
 }
 
+void PRINT_MODULE_USAGE_SUBCATEGORY(const char *subcategory)
+{
+	(void)subcategory;
+}
+
 void PRINT_MODULE_USAGE_NAME_SIMPLE(const char *executable_name, const char *category)
 {
 	PX4_INFO_RAW("Usage: %s [arguments...]\n", executable_name);

--- a/src/platforms/common/module.cpp
+++ b/src/platforms/common/module.cpp
@@ -41,6 +41,7 @@
 #endif
 
 #include <px4_module.h>
+#include <px4_defines.h>
 #include <px4_log.h>
 
 pthread_mutex_t px4_modules_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -88,7 +89,10 @@ void PRINT_MODULE_USAGE_PARAM_INT(char option_char, int default_val, int min_val
 {
 	if (is_optional) {
 		PX4_INFO_RAW("     [-%c <val>]  %s\n", option_char, description);
-		PX4_INFO_RAW("                 default: %i\n", default_val);
+
+		if (default_val != -1) {
+			PX4_INFO_RAW("                 default: %i\n", default_val);
+		}
 
 	} else {
 		PX4_INFO_RAW("     -%c <val>    %s\n", option_char, description);
@@ -100,7 +104,10 @@ void PRINT_MODULE_USAGE_PARAM_FLOAT(char option_char, float default_val, float m
 {
 	if (is_optional) {
 		PX4_INFO_RAW("     [-%c <val>]  %s\n", option_char, description);
-		PX4_INFO_RAW("                 default: %.1f\n", (double)default_val);
+
+		if (PX4_ISFINITE(default_val)) {
+			PX4_INFO_RAW("                 default: %.1f\n", (double)default_val);
+		}
 
 	} else {
 		PX4_INFO_RAW("     -%c <val>    %s\n", option_char, description);

--- a/src/platforms/px4_module.h
+++ b/src/platforms/px4_module.h
@@ -473,6 +473,12 @@ __EXPORT void PRINT_MODULE_DESCRIPTION(const char *description);
 __EXPORT void PRINT_MODULE_USAGE_NAME(const char *executable_name, const char *category);
 
 /**
+ * @brief Specify a subcategory.
+ * @param subcategory e.g. if the category is 'driver', subcategory can be 'distance_sensor'
+ */
+__EXPORT void PRINT_MODULE_USAGE_SUBCATEGORY(const char *subcategory);
+
+/**
  * @brief Prints the name for a command without any sub-commands (@see PRINT_MODULE_USAGE_NAME()).
  */
 __EXPORT void PRINT_MODULE_USAGE_NAME_SIMPLE(const char *executable_name, const char *category);

--- a/src/platforms/px4_module.h
+++ b/src/platforms/px4_module.h
@@ -473,7 +473,7 @@ __EXPORT void PRINT_MODULE_DESCRIPTION(const char *description);
 __EXPORT void PRINT_MODULE_USAGE_NAME(const char *executable_name, const char *category);
 
 /**
- * @brief Specify a subcategory.
+ * @brief Specify a subcategory (optional).
  * @param subcategory e.g. if the category is 'driver', subcategory can be 'distance_sensor'
  */
 __EXPORT void PRINT_MODULE_USAGE_SUBCATEGORY(const char *subcategory);

--- a/src/platforms/px4_module.h
+++ b/src/platforms/px4_module.h
@@ -499,7 +499,7 @@ __EXPORT void PRINT_MODULE_USAGE_COMMAND_DESCR(const char *name, const char *des
 /**
  * @brief Prints an integer parameter.
  * @param option_char The option character.
- * @param default_val The parameter default value.
+ * @param default_val The parameter default value (set to -1 if not applicable).
  * @param min_val The parameter minimum value.
  * @param max_val The parameter value.
  * @param description Pointer to the usage description.
@@ -511,7 +511,7 @@ __EXPORT void PRINT_MODULE_USAGE_PARAM_INT(char option_char, int default_val, in
 /**
  * @brief Prints a float parameter.
  * @note See PRINT_MODULE_USAGE_PARAM_INT().
- * @param default_val The parameter default value.
+ * @param default_val The parameter default value (set to NaN if not applicable).
  * @param min_val The parameter minimum value.
  * @param max_val The parameter maximum value.
  * @param description Pointer to the usage description. Pointer to the usage description.

--- a/src/systemcmds/esc_calib/esc_calib.c
+++ b/src/systemcmds/esc_calib/esc_calib.c
@@ -84,7 +84,7 @@ usage(const char *reason)
 	PRINT_MODULE_USAGE_PARAM_INT('h', 2000, 0, 3000, "High PWM value in us", true);
 	PRINT_MODULE_USAGE_PARAM_STRING('c', NULL, NULL, "select channels in the form: 1234 (1 digit per channel, 1=first)",
 					true);
-	PRINT_MODULE_USAGE_PARAM_INT('m', 0, 0, 4096, "Select channels via bitmask (eg. 0xF, 3)", true);
+	PRINT_MODULE_USAGE_PARAM_INT('m', -1, 0, 4096, "Select channels via bitmask (eg. 0xF, 3)", true);
 	PRINT_MODULE_USAGE_PARAM_FLAG('a', "Select all channels", true);
 }
 

--- a/src/systemcmds/pwm/pwm.cpp
+++ b/src/systemcmds/pwm/pwm.cpp
@@ -139,14 +139,14 @@ $ pwm test -c 13 -p 1200
 
 
 	PRINT_MODULE_USAGE_PARAM_COMMENT("The commands 'failsafe', 'disarmed', 'min', 'max' and 'test' require a PWM value:");
-	PRINT_MODULE_USAGE_PARAM_INT('p', 0, 0, 4000, "PWM value (eg. 1100)", false);
+	PRINT_MODULE_USAGE_PARAM_INT('p', -1, 0, 4000, "PWM value (eg. 1100)", false);
 
 	PRINT_MODULE_USAGE_PARAM_COMMENT("The commands 'rate', 'oneshot', 'failsafe', 'disarmed', 'min', 'max', 'test' and 'steps' "
 					 "additionally require to specify the channels with one of the following commands:");
 	PRINT_MODULE_USAGE_PARAM_STRING('c', nullptr, nullptr, "select channels in the form: 1234 (1 digit per channel, 1=first)",
 					true);
-	PRINT_MODULE_USAGE_PARAM_INT('m', 0, 0, 4096, "Select channels via bitmask (eg. 0xF, 3)", true);
-	PRINT_MODULE_USAGE_PARAM_INT('g', 0, 0, 10, "Select channels by group (eg. 0, 1, 2. use 'pwm info' to show groups)",
+	PRINT_MODULE_USAGE_PARAM_INT('m', -1, 0, 4096, "Select channels via bitmask (eg. 0xF, 3)", true);
+	PRINT_MODULE_USAGE_PARAM_INT('g', -1, 0, 10, "Select channels by group (eg. 0, 1, 2. use 'pwm info' to show groups)",
 				     true);
 	PRINT_MODULE_USAGE_PARAM_FLAG('a', "Select all channels", true);
 

--- a/src/systemcmds/tune_control/tune_control.cpp
+++ b/src/systemcmds/tune_control/tune_control.cpp
@@ -87,9 +87,9 @@ $ tune_control play -t 2
 
 	PRINT_MODULE_USAGE_NAME("tune_control", "system");
 	PRINT_MODULE_USAGE_COMMAND_DESCR("play","Play system tune, tone, or melody");
-        PRINT_MODULE_USAGE_PARAM_INT('t', 1, 1, 21, "Play predefined system tune", true);
-        PRINT_MODULE_USAGE_PARAM_INT('f', 0, 0, 22, "Frequency of tone in Hz (0-22kHz)", true);
-	PRINT_MODULE_USAGE_PARAM_INT('d', 1, 1, 21, "Duration of tone in us", true);
+	PRINT_MODULE_USAGE_PARAM_INT('t', 1, 1, 21, "Play predefined system tune", true);
+	PRINT_MODULE_USAGE_PARAM_INT('f', -1, 0, 22, "Frequency of tone in Hz (0-22kHz)", true);
+	PRINT_MODULE_USAGE_PARAM_INT('d', -1, 1, 21, "Duration of tone in us", true);
 	PRINT_MODULE_USAGE_PARAM_INT('s', 40, 0, 100, "Strength of tone (0-100)", true);
 	PRINT_MODULE_USAGE_PARAM_STRING('m', nullptr,  R"(<string> - e.g. "MFT200e8a8a")",
 					 "Melody in string form", true);


### PR DESCRIPTION
Fixes #10706

@hamishwillee this adds support for empty defaults and subcategories (we currently have module docs only for one distance driver). The subcategories need to be added to the TOC of the dev-guide as well.