### PR TITLE
airframes: add Holybro QAV250

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4052_holybro_qav250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4052_holybro_qav250
@@ -1,0 +1,57 @@
+#!/bin/sh
+#
+# @name HolyBro QAV250
+#
+# @board px4_fmu-v2 exclude
+# @url https://docs.px4.io/en/frames_multicopter/holybro_qav250_pixhawk4_mini.html
+#
+# @type Quadrotor x
+# @class Copter
+#
+# @maintainer Beat Kueng <beat-kueng@gmx.net>
+#
+
+sh /etc/init.d/rc.mc_defaults
+
+set MIXER quad_x
+set PWM_OUT 1234
+
+if [ $AUTOCNF = yes ]
+then
+	# The set does not include a battery, but most people will probably use 4S
+	param set BAT_N_CELLS 4
+
+	param set IMU_GYRO_CUTOFF 120
+	param set MC_DTERM_CUTOFF 45
+
+	param set MC_AIRMODE 1
+	param set MC_PITCHRATE_D 0.0012
+	param set MC_PITCHRATE_I 0.45
+	param set MC_PITCHRATE_MAX 1200
+	param set MC_PITCHRATE_P 0.084
+	param set MC_PITCH_P 8
+	param set MC_ROLLRATE_D 0.0012
+	param set MC_ROLLRATE_I 0.45
+	param set MC_ROLLRATE_MAX 1200
+	param set MC_ROLLRATE_P 0.078
+	param set MC_ROLL_P 8
+	param set MC_YAWRATE_I 0.3
+	param set MC_YAWRATE_MAX 600
+	param set MC_YAWRATE_P 0.25
+	param set MC_YAW_P 4
+
+	param set MPC_MANTHR_MIN 0
+	param set MPC_MAN_TILT_MAX 60
+	param set MPC_THR_CURVE 1
+	param set MPC_THR_HOVER 0.25
+	param set MPC_THR_MIN 0.05
+	param set MPC_Z_VEL_I 0.085
+
+	param set PWM_MAX 1950
+	param set PWM_MIN 1050
+
+	param set PWM_RATE 0
+	param set RC_FLT_CUTOFF 0
+	param set THR_MDL_FAC 0.3
+fi
+

--- a/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
@@ -75,6 +75,7 @@ px4_add_romfs_files(
 	4041_beta75x
 	4050_generic_250
 	4051_s250aq
+	4052_holybro_qav250
 	4060_dji_matrice_100
 	4070_aerofc
 	4080_zmr250


### PR DESCRIPTION
This adds an airframe config for the Holybro QAV250, documented on https://docs.px4.io/en/frames_multicopter/holybro_qav250_pixhawk4_mini.html.

@hamishwillee @jinger26 @DanielePettenuzzo @bresch @RomanBapst 
Would be good if one of you could quickly test it.
I did an ESC calibration, so the PWM min/max values might need to be adjusted a bit.