### PR TITLE
Disable data link and RC loss reactions for SITL

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -140,7 +140,9 @@ then
 	param set MPC_ACC_HOR_MAX 3
 
 	param set NAV_ACC_RAD 2
-	param set NAV_DLL_ACT 2
+
+	# don't react on RC loss in simulation
+	param set NAV_RCL_ACT 0
 
 	param set RTL_DESCEND_ALT 5
 	param set RTL_LAND_DELAY 5


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
It is totally counter-intuitive why the simulation (SITL) should react on links not being available.
- Especially when you're a beginner following the [dev guide here](https://dev.px4.io/en/setup/building_px4.html#jmavsim_build) and the first thing you do is `commander takeoff` which results in an immediate failsafe. When I was a rookie that still worked and I was excited about the drone just hovering there for me as long as I want.
- Also as a developer this regularly annoys me because e.g. sometimes I manage to crash QGC and then the simulated drone stops doing my test but starts to RTL until I recovered QGC and command it to continue.

**Describe your preferred solution**
Let's disable both reactions by default and have a comment such that every developer who wants to test the reactions specifically can change the parameters. That's the same like low battery reactions, they don't happen by default in SITL but you can test them by changing: https://github.com/PX4/Firmware/blob/9d67bbc328553bbd0891ffb8e73b8112bca33fcc/src/modules/simulator/simulator_mavlink.cpp#L330

**Additional context**
https://px4.slack.com/archives/C0V533X4N/p1548921635485900