### PR TITLE
VTOL tiltrotor: respect VT_ELEV_MC_LOCK

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/1042_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/1042_tiltrotor
@@ -38,6 +38,7 @@ then
 	param set VT_MOT_COUNT 4
 	param set VT_TILT_FW 3.1415
 	param set VT_TILT_TRANS 1.2
+	param set VT_ELEV_MC_LOCK 0
 	param set VT_TYPE 1
 
 	param set WEST_EN 1

--- a/ROMFS/px4fmu_common/init.d/airframes/13002_firefly6
+++ b/ROMFS/px4fmu_common/init.d/airframes/13002_firefly6
@@ -46,6 +46,7 @@ then
 	param set VT_TILT_MC 0.08
 	param set VT_TILT_TRANS 0.5
 	param set VT_TILT_FW 0.9
+	param set VT_ELEV_MC_LOCK 0
 	param set VT_TYPE 1
 fi
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13010_claire
+++ b/ROMFS/px4fmu_common/init.d/airframes/13010_claire
@@ -28,6 +28,7 @@ then
 	param set VT_TILT_FW 0.9
 	param set VT_TILT_MC 0.08
 	param set VT_TILT_TRANS 0.5
+	param set VT_ELEV_MC_LOCK 0
 	param set VT_TYPE 1
 fi
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
+++ b/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
@@ -75,6 +75,7 @@ then
 	param set VT_TILT_TRANS   0.45
 	param set VT_TRANS_MIN_TM 1.2
 	param set VT_TRANS_P2_DUR 1.3
+	param set VT_ELEV_MC_LOCK 0
 	param set VT_TYPE 1
 fi
 

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -334,15 +334,16 @@ void Tiltrotor::waiting_on_tecs()
 */
 void Tiltrotor::fill_actuator_outputs()
 {
+	// Multirotor output
 	_actuators_out_0->timestamp = hrt_absolute_time();
 	_actuators_out_0->timestamp_sample = _actuators_mc_in->timestamp_sample;
 
-	_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] = _actuators_mc_in->control[actuator_controls_s::INDEX_ROLL]
-			* _mc_roll_weight;
+	_actuators_out_0->control[actuator_controls_s::INDEX_ROLL] =
+		_actuators_mc_in->control[actuator_controls_s::INDEX_ROLL] * _mc_roll_weight;
 	_actuators_out_0->control[actuator_controls_s::INDEX_PITCH] =
 		_actuators_mc_in->control[actuator_controls_s::INDEX_PITCH] * _mc_pitch_weight;
-	_actuators_out_0->control[actuator_controls_s::INDEX_YAW] = _actuators_mc_in->control[actuator_controls_s::INDEX_YAW] *
-			_mc_yaw_weight;
+	_actuators_out_0->control[actuator_controls_s::INDEX_YAW] =
+		_actuators_mc_in->control[actuator_controls_s::INDEX_YAW] * _mc_yaw_weight;
 
 	if (_vtol_schedule.flight_mode == FW_MODE) {
 		_actuators_out_0->control[actuator_controls_s::INDEX_THROTTLE] =
@@ -359,14 +360,23 @@ void Tiltrotor::fill_actuator_outputs()
 			_actuators_mc_in->control[actuator_controls_s::INDEX_THROTTLE] * _mc_throttle_weight;
 	}
 
+	// Fixed wing output
 	_actuators_out_1->timestamp = hrt_absolute_time();
 	_actuators_out_1->timestamp_sample = _actuators_fw_in->timestamp_sample;
 
-	_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] =
-		-_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL];
-	_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =
-		(_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH]);
-	_actuators_out_1->control[actuator_controls_s::INDEX_YAW] =
-		_actuators_fw_in->control[actuator_controls_s::INDEX_YAW];	// yaw
 	_actuators_out_1->control[4] = _tilt_control;
+
+	if (_params->elevons_mc_lock && _vtol_schedule.flight_mode == MC_MODE) {
+		_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] = 0.0f;
+		_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] = 0.0f;
+		_actuators_out_1->control[actuator_controls_s::INDEX_YAW] = 0.0f;
+
+	} else {
+		_actuators_out_1->control[actuator_controls_s::INDEX_ROLL] =
+			-_actuators_fw_in->control[actuator_controls_s::INDEX_ROLL];
+		_actuators_out_1->control[actuator_controls_s::INDEX_PITCH] =
+			_actuators_fw_in->control[actuator_controls_s::INDEX_PITCH];
+		_actuators_out_1->control[actuator_controls_s::INDEX_YAW] =
+			_actuators_fw_in->control[actuator_controls_s::INDEX_YAW];
+	}
 }


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Elevon lock in multicopter mode (VT_ELEV_MC_LOCK) was not respected for tiltrotor VTOLs.

**Describe your preferred solution**
- Disable FW actuator output when in MC mode and the param is set (similar to standard vtol and tailsitter vtol)
- Set VT_ELEV_MC_LOCK to 0 in existing tiltrotor startup scripts because these platforms might rely on actuated elevons when in multirotor mode.