### PR TITLE
lockstep_scheduler: improve cmake target includes

### DIFF
--- a/platforms/posix/src/lockstep_scheduler/CMakeLists.txt
+++ b/platforms/posix/src/lockstep_scheduler/CMakeLists.txt
@@ -34,7 +34,7 @@ else()
 		src/lockstep_scheduler.cpp
 	)
 	target_include_directories(lockstep_scheduler
-	PUBLIC
+		PUBLIC
 		${CMAKE_CURRENT_SOURCE_DIR}/include
 	)
 

--- a/platforms/posix/src/lockstep_scheduler/CMakeLists.txt
+++ b/platforms/posix/src/lockstep_scheduler/CMakeLists.txt
@@ -33,8 +33,9 @@ else()
 	add_library(lockstep_scheduler
 		src/lockstep_scheduler.cpp
 	)
-	include_directories(
-		include
+	target_include_directories(lockstep_scheduler
+	PUBLIC
+		${CMAKE_CURRENT_SOURCE_DIR}/include
 	)
 
 endif()

--- a/platforms/posix/src/lockstep_scheduler/src/lockstep_scheduler.cpp
+++ b/platforms/posix/src/lockstep_scheduler/src/lockstep_scheduler.cpp
@@ -1,4 +1,4 @@
-#include "lockstep_scheduler/lockstep_scheduler.h"
+#include <lockstep_scheduler/lockstep_scheduler.h>
 
 LockstepScheduler::~LockstepScheduler()
 {

--- a/platforms/posix/src/px4_layer/CMakeLists.txt
+++ b/platforms/posix/src/px4_layer/CMakeLists.txt
@@ -59,7 +59,6 @@ target_link_libraries(px4_layer PRIVATE px4_daemon)
 
 if(ENABLE_LOCKSTEP_SCHEDULER)
 	target_link_libraries(px4_layer PRIVATE lockstep_scheduler)
-	include_directories(${PX4_SOURCE_DIR}/platforms/posix/src/lockstep_scheduler/include)
 endif()
 
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
CMake enables you to shape your code base in a very modular way. You can define target libraries which are contained in one directory and then from the outside just reference the dependency on that target with its name without having to worry about any build configuration like include directories anymore.

CMake also allows you to not use any targets and just include everything directly e.g. with `include_directories` but I think we should try to move towards the most modular build system we can build.

Further documentation about `target_include_directories`
https://cmake.org/cmake/help/v3.0/command/target_include_directories.html

Thanks to @Stifael for sharing his experience and [his example in the DronecodeSDK](https://github.com/Dronecode/DronecodeSDK/blob/1d3cf889c02ed4f08c405284c8c6d45359e3ada7/plugins/camera/CMakeLists.txt#L44-L49) with me.

**Test data / coverage**
- `make posix` still builds and finds all dependencies
- ```
  cd platforms/posix/src/lockstep_scheduler/
  mkdir build
  cd build
  cmake ..
  make
  ./test/lockstep_scheduler_test
  ```
  Still runs the tests fine.
