### PR TITLE
Fix: ROS install space

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -226,7 +226,7 @@ def createTestNode(Map test_def) {
 
           // run test
           try {
-            sh('px4-px4_sitl_default*/px4/test/rostest_px4_run.sh ' + test_def.test + ' mission:=' + test_def.mission + ' vehicle:=' + test_def.vehicle)
+            sh('px4-px4_sitl_default*/share/px4/test/rostest_px4_run.sh ' + test_def.test + ' mission:=' + test_def.mission + ' vehicle:=' + test_def.vehicle)
 
           } catch (exc) {
             // save all test artifacts for debugging
@@ -241,7 +241,7 @@ def createTestNode(Map test_def) {
 
               // process log data (with python code coverage)
               try {
-                sh('coverage run -p px4-px4_sitl_default*/px4/Tools/ecl_ekf/process_logdata_ekf.py .ros/log/*/*.ulg')
+                sh('coverage run -p px4-px4_sitl_default*/share/px4/Tools/ecl_ekf/process_logdata_ekf.py .ros/log/*/*.ulg')
               } catch (exc) {
                 // save log analysis artifacts for debugging
                 archiveArtifacts(allowEmptyArchive: false, artifacts: '.ros/**/*.pdf, .ros/**/*.csv')
@@ -250,7 +250,7 @@ def createTestNode(Map test_def) {
               }
 
               // upload log to flight review (https://logs.px4.io/) with python code coverage
-              sh('coverage run -p px4-px4_sitl_default*/px4/Tools/upload_log.py -q --description "${JOB_NAME}: ${STAGE_NAME}" --feedback "${JOB_NAME} ${CHANGE_TITLE} ${CHANGE_URL}" --source CI .ros/log/*/*.ulg')
+              sh('coverage run -p px4-px4_sitl_default*/share/px4/Tools/upload_log.py -q --description "${JOB_NAME}: ${STAGE_NAME}" --feedback "${JOB_NAME} ${CHANGE_TITLE} ${CHANGE_URL}" --source CI .ros/log/*/*.ulg')
 
               // upload python code coverage to codecov.io
               sh 'curl -s https://codecov.io/bash | bash -s - -X gcov -F sitl_python_${STAGE_NAME}'
@@ -258,7 +258,7 @@ def createTestNode(Map test_def) {
           } else { // non code coverage
             // process ekf log data
             try {
-              sh('px4-px4_sitl_default*/px4/Tools/ecl_ekf/process_logdata_ekf.py .ros/log/*/*.ulg')
+              sh('px4-px4_sitl_default*/share/px4/Tools/ecl_ekf/process_logdata_ekf.py .ros/log/*/*.ulg')
             } catch (exc) {
               // save log analysis artifacts for debugging
               archiveArtifacts(allowEmptyArchive: false, artifacts: '.ros/**/*.pdf, .ros/**/*.csv')
@@ -267,7 +267,7 @@ def createTestNode(Map test_def) {
             }
 
             // upload log to flight review (https://logs.px4.io/)
-            sh('px4-px4_sitl_default*/px4/Tools/upload_log.py -q --description "${JOB_NAME}: ${STAGE_NAME}" --feedback "${JOB_NAME} ${CHANGE_TITLE} ${CHANGE_URL}" --source CI .ros/log/*/*.ulg')
+            sh('px4-px4_sitl_default*/share/px4/Tools/upload_log.py -q --description "${JOB_NAME}: ${STAGE_NAME}" --feedback "${JOB_NAME} ${CHANGE_TITLE} ${CHANGE_URL}" --source CI .ros/log/*/*.ulg')
           }
 
           if (!test_ok) {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,11 @@ if (${PX4_PLATFORM} STREQUAL "posix")
 	# cmake testing only on posix
 	enable_testing()
 	include(CTest)
+
+	if (CATKIN_DEVEL_PREFIX)
+		# Install launch files
+		install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
+	endif()
 endif()
 
 #=============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,11 +303,6 @@ if (${PX4_PLATFORM} STREQUAL "posix")
 	# cmake testing only on posix
 	enable_testing()
 	include(CTest)
-
-	if (CATKIN_DEVEL_PREFIX)
-		# Install launch files
-		install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
-	endif()
 endif()
 
 #=============================================================================

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,6 +60,12 @@ pipeline {
               source /opt/ros/melodic/setup.sh;
               colcon build --event-handlers console_direct+ --symlink-install;
             '''
+            // test if the binary was correctly installed and runs using 'mavros_posix_silt.launch'
+            sh '''#!/bin/bash -l
+              echo $0;
+              source colcon_ws/install/local_setup.bash;
+              rostest px4 pub_test.launch;
+            '''
           }
           post {
             always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,6 +63,7 @@ pipeline {
             // test if the binary was correctly installed and runs using 'mavros_posix_silt.launch'
             sh '''#!/bin/bash -l
               echo $0;
+              source /opt/ros/melodic/setup.bash;
               source colcon_ws/install/local_setup.bash;
               rostest px4 pub_test.launch;
             '''

--- a/platforms/posix/CMakeLists.txt
+++ b/platforms/posix/CMakeLists.txt
@@ -62,7 +62,7 @@ else()
 			${df_driver_libs}
 			df_driver_framework
 			pthread m
-			
+
 			# horrible circular dependencies that need to be teased apart
 			px4_layer
 			px4_platform
@@ -88,7 +88,7 @@ else()
 			${PROJECT_SOURCE_DIR}/test
 			${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
 		DESTINATION
-			${PROJECT_NAME}
+			share/${PROJECT_NAME}
 		USE_SOURCE_PERMISSIONS
 		)
 
@@ -127,7 +127,7 @@ elseif ("${PX4_BOARD}" MATCHES "sitl")
 			${PROJECT_SOURCE_DIR}/launch
 			${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
 		DESTINATION
-			${PROJECT_NAME}
+			share/${PROJECT_NAME}
 		USE_SOURCE_PERMISSIONS
 		)
 
@@ -137,7 +137,7 @@ elseif ("${PX4_BOARD}" MATCHES "sitl")
 			${PROJECT_SOURCE_DIR}/CMakeLists.txt
 			${PROJECT_SOURCE_DIR}/package.xml
 		DESTINATION
-			${PROJECT_NAME}
+			share/${PROJECT_NAME}
 		)
 
 	# px4 Tools dirs
@@ -145,7 +145,7 @@ elseif ("${PX4_BOARD}" MATCHES "sitl")
 		DIRECTORY
 			${PROJECT_SOURCE_DIR}/Tools/ecl_ekf
 		DESTINATION
-			${PROJECT_NAME}/Tools
+			share/${PROJECT_NAME}/Tools
 		USE_SOURCE_PERMISSIONS
 		)
 
@@ -155,7 +155,7 @@ elseif ("${PX4_BOARD}" MATCHES "sitl")
 			${PROJECT_SOURCE_DIR}/Tools/setup_gazebo.bash
 			${PROJECT_SOURCE_DIR}/Tools/upload_log.py
 		DESTINATION
-			${PROJECT_NAME}/Tools
+			share/${PROJECT_NAME}/Tools
 		)
 
 	# sitl_gazebo built plugins
@@ -163,7 +163,7 @@ elseif ("${PX4_BOARD}" MATCHES "sitl")
 		DIRECTORY
 			${PROJECT_SOURCE_DIR}/build/px4_sitl_default/build_gazebo
 		DESTINATION
-			${PROJECT_NAME}/build/px4_sitl_default
+			share/${PROJECT_NAME}/build/px4_sitl_default
 		FILES_MATCHING
 			PATTERN "CMakeFiles" EXCLUDE
 			PATTERN "*.so"
@@ -175,7 +175,7 @@ elseif ("${PX4_BOARD}" MATCHES "sitl")
 			${PROJECT_SOURCE_DIR}/Tools/sitl_gazebo/models
 			${PROJECT_SOURCE_DIR}/Tools/sitl_gazebo/worlds
 		DESTINATION
-			${PROJECT_NAME}/Tools/sitl_gazebo
+			share/${PROJECT_NAME}/Tools/sitl_gazebo
 		)
 
 	# sitl_gazebo files
@@ -184,7 +184,7 @@ elseif ("${PX4_BOARD}" MATCHES "sitl")
 			${PROJECT_SOURCE_DIR}/Tools/sitl_gazebo/CMakeLists.txt
 			${PROJECT_SOURCE_DIR}/Tools/sitl_gazebo/package.xml
 		DESTINATION
-			${PROJECT_NAME}/Tools/sitl_gazebo
+			share/${PROJECT_NAME}/Tools/sitl_gazebo
 		)
 
 endif()


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Inside a ROS context, there are currently two distinctive ways we can build packages inside a workspace: using `catkin tools` or using `colcon`. While the first one supports a *devel* space, the second one doesn't and installs the project according to the directives on the `CMakeLists.txt` files.

So, while using `catkin tools`, the solution would work as expected, since everything will be set and under a *devel* space, when using an *install* space, things wouldn't work properly, as we are not installing the required files onto the expected directories.

**Describe your preferred solution**
The solution was to get into the posix platform build structure, specifically for the sitl target, and rearrange the install dirs, in a way that they match the expected organisation for a ROS workspace. While this continues to work in a normal raw CMake build, the current install dirs also allow it to work inside a ROS workspace.

**Additional context**
To test it, one can use and install `colcon` on his system (assuming that you have ROS installed already). If you are under a ROS 1 context:
```sh
$ sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list'
$ sudo apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
$ sudo apt update
$ sudo apt install python3-colcon-common-extensions
```

Then, to build PX4 under a ROS1 workspace:
```sh
$ mkdir -p colcon_ws/src
$ cd colcon_ws/src
$ git clone --recursive https://github.com/PX4/Firmware
$ ln -s Firmware/Tools/sitl_gazebo mavlink_sitl_gazebo
$ colcon build --event-handlers console_direct+
```

The above can also be tested using `catkin` by setting an `install` space: `catkin config --install`.

Then, to test if it works, first source your workspace using `source install/local_setup.bash` (or `setup.bash` for the `catkin` case). Then, try running one of the launch files: `roslaunch px4 mavros_posix_sitl.launch`. If all was properly set, the Gazebo simulation with PX4 SITL and MAVROS will launch as they should.