### PR TITLE
px4io depend on NuttX submodules

### DIFF
--- a/Tools/check_submodules.sh
+++ b/Tools/check_submodules.sh
@@ -6,12 +6,12 @@ function check_git_submodule {
 if [[ -f $1"/.git" || -d $1"/.git" ]];
 then
 
-	# CI environment always force update everything
+	# CI environment always update
 	if [ "$CI" == "true" ];
 	then
 		git submodule --quiet sync --recursive -- $1
-		git submodule --quiet update --init --recursive --force -- $1  || true
-		git submodule --quiet update --init --recursive --force -- $1
+		git submodule --quiet update --init --recursive -- $1  || true
+		git submodule --quiet update --init --recursive -- $1
 		exit 0
 	fi
 

--- a/src/drivers/px4io/CMakeLists.txt
+++ b/src/drivers/px4io/CMakeLists.txt
@@ -57,6 +57,7 @@ ExternalProject_Add(px4io_firmware
 	CMAKE_ARGS -DCONFIG=${config_io_board}
 	INSTALL_COMMAND ""
 	USES_TERMINAL_BUILD true
+	DEPENDS git_nuttx git_nuttx_apps
 )
 
 ExternalProject_Get_Property(px4io_firmware BINARY_DIR)


### PR DESCRIPTION
This prevents a race condition in the builds (mainly CI) where multiple components might be touching the submodules simultaneously.

![image](https://user-images.githubusercontent.com/84712/52294889-6d523900-2948-11e9-8275-510c625d642c.png)
