### PR TITLE
hysteresis cleanup and better field packing

### DIFF
--- a/src/lib/systemlib/hysteresis/hysteresis.h
+++ b/src/lib/systemlib/hysteresis/hysteresis.h
@@ -49,31 +49,17 @@ namespace systemlib
 class Hysteresis
 {
 public:
-	Hysteresis(bool init_state) :
+	explicit Hysteresis(bool init_state) :
 		_state(init_state),
-		_requested_state(init_state),
-		_hysteresis_time_from_true_us(0),
-		_hysteresis_time_from_false_us(0),
-		_last_time_to_change_state(0)
+		_requested_state(init_state)
 	{}
+	Hysteresis() = delete; // no default constructor
 
-	~Hysteresis()
-	{}
+	~Hysteresis() = default;
 
-	void set_hysteresis_time_from(const bool from_state, const hrt_abstime new_hysteresis_time_us)
-	{
-		if (from_state == true) {
-			_hysteresis_time_from_true_us = new_hysteresis_time_us;
+	bool get_state() const { return _state; }
 
-		} else {
-			_hysteresis_time_from_false_us = new_hysteresis_time_us;
-		}
-	}
-
-	bool get_state() const
-	{
-		return _state;
-	}
+	void set_hysteresis_time_from(const bool from_state, const hrt_abstime new_hysteresis_time_us);
 
 	void set_state_and_update(const bool new_state);
 
@@ -81,11 +67,13 @@ public:
 
 private:
 
+	hrt_abstime _last_time_to_change_state{0};
+
+	hrt_abstime _time_from_true_us{0};
+	hrt_abstime _time_from_false_us{0};
+
 	bool _state;
 	bool _requested_state;
-	hrt_abstime _hysteresis_time_from_true_us;
-	hrt_abstime _hysteresis_time_from_false_us;
-	hrt_abstime _last_time_to_change_state;
 };
 
 } // namespace systemlib


### PR DESCRIPTION
Save a little memory with smaller fields (time from true/false < 4 billion microseconds) and ordering to reduce unnecessary padding in the class.