### PR TITLE
px4_sitl_default temporarily disable lockstep scheduler

### DIFF
--- a/boards/px4/sitl/default.cmake
+++ b/boards/px4/sitl/default.cmake
@@ -99,4 +99,5 @@ if(REPLAY_FILE)
 	add_definitions(-DORB_USE_PUBLISHER_RULES)
 endif()
 
-set(ENABLE_LOCKSTEP_SCHEDULER yes)
+# temporarily disabled, see PX4/Firmware issues #11380 and #11384
+set(ENABLE_LOCKSTEP_SCHEDULER no)


### PR DESCRIPTION
Attempting to temporarily disable px4_sitl_default lockstep scheduler until we can address https://github.com/PX4/Firmware/issues/11380 and https://github.com/PX4/Firmware/issues/11384.

@julianoes can this be done Firmware side alone?