### PR TITLE
Jenkins SITL tests increase test history from 2 -> 5

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -100,7 +100,7 @@ pipeline {
   }
 
   options {
-    buildDiscarder(logRotator(numToKeepStr: '2', artifactDaysToKeepStr: '14'))
+    buildDiscarder(logRotator(numToKeepStr: '5', artifactDaysToKeepStr: '14'))
     timeout(time: 60, unit: 'MINUTES')
   }
 } // pipeline


### PR DESCRIPTION
The Jenkins master has significantly more storage available now. This is a combination of increasing the actual storage available and cleaning up old PRs and branches.

![image](https://user-images.githubusercontent.com/84712/52354350-3dfe0380-29fe-11e9-8d4e-96833dfbd46f.png)
