### PR TITLE
Dev traj fixes

### DIFF
--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
@@ -95,11 +95,11 @@ void FlightTaskManualPositionSmoothVel::_updateSetpoints()
 
 	if (_velocity_setpoint(2) < 0.f) { // up
 		_smoothing[2].setMaxAccel(MPC_ACC_UP_MAX.get());
-		_smoothing[2].setMaxVel(_constraints.speed_up);
+		_smoothing[2].setMaxVel(MPC_Z_VEL_MAX_UP.get());
 
 	} else { // down
 		_smoothing[2].setMaxAccel(MPC_ACC_DOWN_MAX.get());
-		_smoothing[2].setMaxVel(_constraints.speed_down);
+		_smoothing[2].setMaxVel(MPC_Z_VEL_MAX_DN.get());
 	}
 
 	Vector2f vel_xy_sp = Vector2f(&_velocity_setpoint(0));

--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
@@ -95,11 +95,11 @@ void FlightTaskManualPositionSmoothVel::_updateSetpoints()
 
 	if (_velocity_setpoint(2) < 0.f) { // up
 		_smoothing[2].setMaxAccel(MPC_ACC_UP_MAX.get());
-		_smoothing[2].setMaxVel(MPC_Z_VEL_MAX_UP.get());
+		_smoothing[2].setMaxVel(_constraints.speed_up);
 
 	} else { // down
 		_smoothing[2].setMaxAccel(MPC_ACC_DOWN_MAX.get());
-		_smoothing[2].setMaxVel(MPC_Z_VEL_MAX_DN.get());
+		_smoothing[2].setMaxVel(_constraints.speed_down);
 	}
 
 	float jerk[3] = {_jerk_max.get(), _jerk_max.get(), _jerk_max.get()};

--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
@@ -102,25 +102,7 @@ void FlightTaskManualPositionSmoothVel::_updateSetpoints()
 		_smoothing[2].setMaxVel(MPC_Z_VEL_MAX_DN.get());
 	}
 
-	Vector2f vel_xy_sp = Vector2f(&_velocity_setpoint(0));
 	float jerk[3] = {_jerk_max.get(), _jerk_max.get(), _jerk_max.get()};
-	float jerk_xy = _jerk_max.get();
-
-	if (_jerk_min.get() > _jerk_max.get()) {
-		_jerk_min.set(0.f);
-	}
-
-	if (_jerk_min.get() > FLT_EPSILON) {
-		if (vel_xy_sp.length() < FLT_EPSILON) { // Brake
-			jerk_xy = _jerk_max.get();
-
-		} else {
-			jerk_xy = _jerk_min.get();
-		}
-	}
-
-	jerk[0] = jerk_xy;
-	jerk[1] = jerk_xy;
 
 	/* Check for position unlock
 	 * During a position lock -> position unlock transition, we have to make sure that the velocity setpoint
@@ -145,7 +127,7 @@ void FlightTaskManualPositionSmoothVel::_updateSetpoints()
 	if (fabsf(_sticks_expo(2)) > FLT_EPSILON) {
 		if (_position_lock_z_active) {
 			_smoothing[2].setCurrentVelocity(_velocity_setpoint_feedback(
-					0)); // Start the trajectory at the current velocity setpoint
+					2)); // Start the trajectory at the current velocity setpoint
 			_position_setpoint_z_locked = NAN;
 		}
 

--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
@@ -155,11 +155,13 @@ void FlightTaskManualPositionSmoothVel::_updateSetpoints()
 		_smoothing[0].setCurrentPosition(_position(0));
 		_smoothing[1].setCurrentPosition(_position(1));
 	}
+
 	if (!_position_lock_z_active) {
 		_smoothing[2].setCurrentPosition(_position(2));
 	}
 
 	Vector3f pos_sp_smooth;
+
 	for (int i = 0; i < 3; ++i) {
 
 		_smoothing[i].integrate(_acceleration_setpoint(i), _vel_sp_smooth(i), pos_sp_smooth(i));
@@ -175,6 +177,7 @@ void FlightTaskManualPositionSmoothVel::_updateSetpoints()
 		_position_setpoint_xy_locked(1) = pos_sp_smooth(1);
 		_position_lock_xy_active = true;
 	}
+
 	if (fabsf(_vel_sp_smooth(2)) < 0.01f &&
 	    fabsf(_acceleration_setpoint(2)) < .2f &&
 	    fabsf(_sticks_expo(2)) <= FLT_EPSILON) {

--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.hpp
@@ -69,6 +69,9 @@ private:
 	VelocitySmoothing _smoothing[3]; ///< Smoothing in x, y and z directions
 	matrix::Vector3f _vel_sp_smooth;
 	bool _position_lock_xy_active{false};
+	bool _position_lock_z_active{false};
 	matrix::Vector2f _position_setpoint_xy_locked;
+	float _position_setpoint_z_locked;
+
 	uint8_t _reset_counter{0}; /**< counter for estimator resets in xy-direction */
 };

--- a/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.cpp
@@ -92,7 +92,7 @@ float VelocitySmoothing::computeT1(float accel_prev, float vel_prev, float vel_s
 	if (T1_plus >= 0.f && T3_plus >= 0.f) {
 		T1 = T1_plus;
 
-	} else if ( T1_minus >= 0.f && T3_minus >= 0.f) {
+	} else if (T1_minus >= 0.f && T3_minus >= 0.f) {
 		T1 = T1_minus;
 	}
 

--- a/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.hpp
+++ b/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.hpp
@@ -134,7 +134,6 @@ private:
 	 */
 	inline float computeT1(float T123, float accel_prev, float vel_prev, float vel_setpoint, float max_jerk);
 	inline float saturateT1ForAccel(float accel_prev, float max_jerk, float T1);
-	inline float recomputeMaxJerk(float accel_prev, float max_jerk, float T1);
 	/**
 	 * Compute constant acceleration time
 	 */

--- a/src/modules/mc_pos_control/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl.cpp
@@ -221,11 +221,11 @@ void PositionControl::_positionController()
 	// Constrain horizontal velocity by prioritizing the velocity component along the
 	// the desired position setpoint over the feed-forward term.
 	const Vector2f vel_sp_xy = ControlMath::constrainXY(Vector2f(vel_sp_position),
-				   Vector2f(_vel_sp - vel_sp_position), _constraints.speed_xy);
+				   Vector2f(_vel_sp - vel_sp_position), MPC_XY_VEL_MAX.get());
 	_vel_sp(0) = vel_sp_xy(0);
 	_vel_sp(1) = vel_sp_xy(1);
 	// Constrain velocity in z-direction.
-	_vel_sp(2) = math::constrain(_vel_sp(2), -_constraints.speed_up, _constraints.speed_down);
+	_vel_sp(2) = math::constrain(_vel_sp(2), -MPC_Z_VEL_MAX_UP.get(), MPC_Z_VEL_MAX_DN.get());
 }
 
 void PositionControl::_velocityController(const float &dt)

--- a/src/modules/mc_pos_control/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl.cpp
@@ -225,7 +225,7 @@ void PositionControl::_positionController()
 	_vel_sp(0) = vel_sp_xy(0);
 	_vel_sp(1) = vel_sp_xy(1);
 	// Constrain velocity in z-direction.
-	_vel_sp(2) = math::constrain(_vel_sp(2), -MPC_Z_VEL_MAX_UP.get(), MPC_Z_VEL_MAX_DN.get());
+	_vel_sp(2) = math::constrain(_vel_sp(2), -_constraints.speed_up, _constraints.speed_down);
 }
 
 void PositionControl::_velocityController(const float &dt)

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -1051,12 +1051,9 @@ MulticopterPositionControl::check_for_smooth_takeoff(const float &z_sp, const fl
 			// There is a position setpoint above current position or velocity setpoint larger than
 			// takeoff speed. Enable smooth takeoff.
 			_in_smooth_takeoff = true;
-			_takeoff_speed = -0.5f;
+			_takeoff_speed = 0.f;
 			_takeoff_reference_z = _states.position(2);
 
-		} else {
-			// Default
-			_in_smooth_takeoff = false;
 		}
 	}
 }

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -686,6 +686,8 @@ MulticopterPositionControl::run()
 				}
 			}
 
+			publish_trajectory_sp(setpoint);
+
 			/* desired waypoints for obstacle avoidance:
 			 * point_0 contains the current position with the desired velocity
 			 * point_1 contains _pos_sp_triplet.current if valid
@@ -758,7 +760,6 @@ MulticopterPositionControl::run()
 			// Generate desired thrust and yaw.
 			_control.generateThrustYawSetpoint(_dt);
 
-			publish_trajectory_sp(setpoint);
 
 			// Fill local position, velocity and thrust setpoint.
 			// This message contains setpoints where each type of setpoint is either the input to the PositionController

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -650,8 +650,9 @@ PARAM_DEFINE_FLOAT(MPC_LAND_ALT2, 5.0f);
  *
  * Increasing this value will make automatic and manual takeoff slower.
  * If it's too slow the drone might scratch the ground and tip over.
+ * A time constant of 0 disables the ramp
  *
- * @min 0.1
+ * @min 0
  * @max 1
  * @group Multicopter Position Control
  */


### PR DESCRIPTION
### Summary of the changes:
**FlightTaskManualSmoothVel:**
- Add Z position lock. Until now, this flight task was controlling the Z velocity but relied on AltitudeSmooth FlightTask to perform altitude hold.
![trajectory_generator_altitude_lock](https://user-images.githubusercontent.com/14822839/52355620-f5ad0880-2a32-11e9-9b13-942facaef716.png)


**PositionControl:**
- Saturate the velocity setpoints using constant parameters. The constraints are used inside the FlightTask and not re-saturated to avoid non-linearities. 

**VelocitySmoothing:**
- Add trajectory logging
- Global improvements, remove the `recomputeMaxJerk` logic that doesn't really help and only adjust the jerk when the current dt is longer than the previous one and that this was the last jerk pulse needed to reach the desired acceleration. This avoids acceleration oscillation due to jitter. See below.
Before this PR:
![traj_generator_before](https://user-images.githubusercontent.com/14822839/52355281-59830180-2a32-11e9-9b8e-db46f53212a7.png)
Now:
![trajectory_generator_after](https://user-images.githubusercontent.com/14822839/52355305-69024a80-2a32-11e9-9bb3-7faf901651ac.png)

FYI: @MaEtUgR , @dagar 