### PR TITLE
update all submodules to PX4 forks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,16 +4,16 @@
 	branch = master
 [submodule "src/drivers/uavcan/libuavcan"]
 	path = src/drivers/uavcan/libuavcan
-	url = https://github.com/UAVCAN/libuavcan.git
-	branch = master
+	url = https://github.com/PX4/uavcan.git
+	branch = px4
 [submodule "msg/tools/genmsg"]
 	path = msg/tools/genmsg
-	url = https://github.com/ros/genmsg.git
-	branch = indigo-devel
+	url = https://github.com/PX4/genmsg.git
+	branch = px4
 [submodule "msg/tools/gencpp"]
 	path = msg/tools/gencpp
-	url = https://github.com/ros/gencpp.git
-	branch = indigo-devel
+	url = https://github.com/PX4/gencpp.git
+	branch = px4
 [submodule "Tools/jMAVSim"]
 	path = Tools/jMAVSim
 	url = https://github.com/PX4/jMAVSim.git
@@ -36,16 +36,16 @@
 	branch = master
 [submodule "boards/atlflight/cmake_hexagon"]
 	path = boards/atlflight/cmake_hexagon
-	url = https://github.com/ATLFlight/cmake_hexagon.git
-	branch = master
+	url = https://github.com/PX4/cmake_hexagon.git
+	branch = px4
 [submodule "src/drivers/gps/devices"]
 	path = src/drivers/gps/devices
 	url = https://github.com/PX4/GpsDrivers.git
 	branch = master
 [submodule "src/modules/micrortps_bridge/micro-CDR"]
 	path = src/modules/micrortps_bridge/micro-CDR
-	url = https://github.com/eProsima/micro-CDR.git
-	branch = master
+	url = https://github.com/PX4/micro-CDR.git
+	branch = px4
 [submodule "platforms/nuttx/NuttX/nuttx"]
 	path = platforms/nuttx/NuttX/nuttx
 	url = https://github.com/PX4/NuttX.git


### PR DESCRIPTION
To avoid our submodule build dependencies from changing outside of our control I ultimately don't see a choice but to maintain forks.

Separately I'll have Jenkins jobs that pull in new upstream changes to each repo, but this will give us a safety net that prevents particular commits we depend on from ever disappearing.