### PR TITLE
test time:Fixed bad assumption about RAND_MAX  

### DIFF
--- a/src/systemcmds/tests/test_time.c
+++ b/src/systemcmds/tests/test_time.c
@@ -104,7 +104,7 @@ int test_time(int argc, char *argv[])
 	/* loop checking the time */
 	for (unsigned i = 0; i < 100; i++) {
 
-		usleep(rand());
+		usleep(rand() % SHRT_MAX);
 
 		uint32_t flags = px4_enter_critical_section();
 


### PR DESCRIPTION
   usleep range was up to 2147 Seconds

   Per open group: The rand() function shall compute a
   sequence of pseudo-random integers in the range
   [0, {RAND_MAX}]  with a period of at least 2^32

   {RAND_MAX} Maximum value returned by rand();
   at least 32767.

   /* Maximum value returned by rand().  Must be a minimum of 32767. */

   #define RAND_MAX INT_MAX

  and

  #define INT_MAX     2147483647

Fixes https://github.com/PX4/Firmware/issues/11361

@dagar , @LorenzMeier this bad assumption may be repeated in PX4 in other places.