### PR TITLE
Jenkins compile mac double timeout

### DIFF
--- a/.ci/Jenkinsfile-compile_mac
+++ b/.ci/Jenkinsfile-compile_mac
@@ -82,6 +82,6 @@ pipeline {
   }
   options {
     buildDiscarder(logRotator(numToKeepStr: '5', artifactDaysToKeepStr: '14'))
-    timeout(time: 60, unit: 'MINUTES')
+    timeout(time: 120, unit: 'MINUTES')
   }
 }


### PR DESCRIPTION
The CI system is currently struggling with only a single old mac mini (dronecode-macmini).

We need to get `gus-mac` (http://ci.px4.io:8080/computer/) back online.