### PR TITLE
Add `virtual` specifier to updateParamsImpl definition in  _DEFINE_PARAMETER_UPDATE_METHOD(...) macro definition

### DIFF
--- a/src/platforms/px4_param.h
+++ b/src/platforms/px4_param.h
@@ -64,7 +64,7 @@ inline static param_t param_handle(px4::params p)
 // It is marked as 'final', so that wrong usages lead to a compile error (see below)
 #define _DEFINE_PARAMETER_UPDATE_METHOD(...) \
 	protected: \
-	void updateParamsImpl() final { \
+	void virtual updateParamsImpl() final { \
 		APPLY_ALL(_CALL_UPDATE, __VA_ARGS__) \
 	} \
 	private:


### PR DESCRIPTION
Hi there,

**Describe problem solved by the proposed pull request**
Attempting to utilize the px4_params macro `DEFINE_PARAMETERS()` in mavlink_receiver.h as is already done in [mavlink_main.h](https://github.com/PX4/Firmware/blob/c6edf41a7401e3cfcad9d9ce703bdef5055c196b/src/modules/mavlink/mavlink_main.h#L634), navigator, and other instances, a compiler error is thrown that does not match the notes described at the macro:

```
In file included from ../../src/platforms/px4_module_params.h:44:0,
                 from ../../src/modules/mavlink/mavlink_main.h:46,
                 from ../../src/modules/mavlink/mavlink_main.cpp:89:
../../src/platforms/px4_param.h:67:7: error: 'void MavlinkReceiver::updateParamsImpl()' marked 'final', but is not virtual
  void updateParamsImpl() final { \
       ^
../../src/platforms/px4_param.h:80:2: note: in expansion of macro '_DEFINE_PARAMETER_UPDATE_METHOD'
  _DEFINE_PARAMETER_UPDATE_METHOD(__VA_ARGS__)
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../src/modules/mavlink/mavlink_receiver.h:267:2: note: in expansion of macro 'DEFINE_PARAMETERS'
  DEFINE_PARAMETERS(
  ^~~~~~~~~~~~~~~~~
compilation terminated due to -Wfatal-errors.
```

**NOTE**  In this case, `MavlinkReceiver` is not a child class inheriting from a parent already using the macro, but is instead being passed a pointer to the `Mavlink` class which is already using the macro.  In addition, mavlink_receiver.h #includes mavlink_main.h, where the `Mavlink` class is declared.

**Describe your preferred solution**
All of the C++11 documentation I find for the `final` specifier indicates that it should be applied to `virtual` functions with the intent of not overriding that implementation.  Inheriting method instances are not required to restate the `virtual` specifier, however the original parent class should, or the result is not overriding the method but overloading it.   As I understand it, this macro is essentially inlining the code contained in the declaration/definition of the macro, so for the `MavlinkReceiver` class that `#includes` mavlink_main.h, there would never have first been a `virtual` declared but it would appear to be the second instance of that code being inlined.  (Structs can be declared as final such that they cannot be inherited, but that usage is different because you cannot overload a struct like you can overload a function.)  Please teach me more if I missing something about the intent of this macro.

**Describe possible alternatives**
`mavlink_receiver.h` is not required to use the `DEFINE_PARAMETERS` macro, the code can stay as is and function just as well. 

**Additional context**
See review comment in [PR#11274](https://github.com/PX4/Firmware/pull/11274#discussion_r253913848) for additional context.

@dagar and @bkueng, would you mind advising?  Thanks for your help!
