### PR TITLE
uavcan: use px4 timestamp for the esc status message

### DIFF
--- a/src/drivers/uavcan/actuators/esc.cpp
+++ b/src/drivers/uavcan/actuators/esc.cpp
@@ -203,7 +203,7 @@ void UavcanEscController::esc_status_sub_cb(const uavcan::ReceivedDataStructure<
 {
 	if (msg.esc_index < esc_status_s::CONNECTED_ESC_MAX) {
 		_esc_status.esc_count = uavcan::max<int>(_esc_status.esc_count, msg.esc_index + 1);
-		_esc_status.timestamp = msg.getMonotonicTimestamp().toUSec();
+		_esc_status.timestamp = hrt_absolute_time();
 
 		auto &ref = _esc_status.esc[msg.esc_index];
 


### PR DESCRIPTION
When analyzing esc status messages in FlightPlot there is an undefined timeshift between those messages and all other px4 messages. This is because there is not synchronization between time on the ESC and px4 time. Using px4 time at the time when the messages are published eliminates the confusion.  