### PR TITLE
Jenkinsfile temporarily disable catkin and colcon builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,72 +6,72 @@ pipeline {
 
       parallel {
 
-        stage('Catkin build on ROS workspace') {
-          agent {
-            docker {
-              image 'px4io/px4-dev-ros:2019-02-09'
-              args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
-            }
-          }
-          steps {
-            sh 'ls -l'
-            sh '''#!/bin/bash -l
-              echo $0;
-              mkdir -p catkin_ws/src;
-              cd catkin_ws;
-              git -C ${WORKSPACE}/catkin_ws/src/Firmware submodule update --init --recursive --force Tools/sitl_gazebo
-              git clone --recursive ${WORKSPACE}/catkin_ws/src/Firmware/Tools/sitl_gazebo src/mavlink_sitl_gazebo;
-              source /opt/ros/melodic/setup.bash;
-              catkin init;
-              catkin build -j$(nproc) -l$(nproc);
-            '''
-            // test if the binary was correctly installed and runs using 'mavros_posix_silt.launch'
-            sh '''#!/bin/bash -l
-              echo $0;
-              source catkin_ws/devel/setup.bash;
-              rostest px4 pub_test.launch;
-            '''
-          }
-          post {
-            always {
-              sh 'rm -rf catkin_ws'
-            }
-          }
-          options {
-            checkoutToSubdirectory('catkin_ws/src/Firmware')
-          }
-        }
+        // stage('Catkin build on ROS workspace') {
+        //   agent {
+        //     docker {
+        //       image 'px4io/px4-dev-ros:2019-02-09'
+        //       args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
+        //     }
+        //   }
+        //   steps {
+        //     sh 'ls -l'
+        //     sh '''#!/bin/bash -l
+        //       echo $0;
+        //       mkdir -p catkin_ws/src;
+        //       cd catkin_ws;
+        //       git -C ${WORKSPACE}/catkin_ws/src/Firmware submodule update --init --recursive --force Tools/sitl_gazebo
+        //       git clone --recursive ${WORKSPACE}/catkin_ws/src/Firmware/Tools/sitl_gazebo src/mavlink_sitl_gazebo;
+        //       source /opt/ros/melodic/setup.bash;
+        //       catkin init;
+        //       catkin build -j$(nproc) -l$(nproc);
+        //     '''
+        //     // test if the binary was correctly installed and runs using 'mavros_posix_silt.launch'
+        //     sh '''#!/bin/bash -l
+        //       echo $0;
+        //       source catkin_ws/devel/setup.bash;
+        //       rostest px4 pub_test.launch;
+        //     '''
+        //   }
+        //   post {
+        //     always {
+        //       sh 'rm -rf catkin_ws'
+        //     }
+        //   }
+        //   options {
+        //     checkoutToSubdirectory('catkin_ws/src/Firmware')
+        //   }
+        // }
 
-        stage('Colcon build on ROS2 workspace') {
-          agent {
-            docker {
-              image 'px4io/px4-dev-ros2-bouncy:2019-02-09'
-              args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
-            }
-          }
-          steps {
-            sh 'ls -l'
-            sh '''#!/bin/bash -l
-              echo $0;
-              unset ROS_DISTRO;
-              mkdir -p colcon_ws/src;
-              cd colcon_ws;
-              git -C ${WORKSPACE}/colcon_ws/src/Firmware submodule update --init --recursive --force Tools/sitl_gazebo
-              git clone --recursive ${WORKSPACE}/colcon_ws/src/Firmware/Tools/sitl_gazebo src/mavlink_sitl_gazebo;
-              source /opt/ros/bouncy/setup.sh;
-              source /opt/ros/melodic/setup.sh;
-              colcon build --event-handlers console_direct+ --symlink-install;
-            '''
-          }
-          post {
-            always {
-              sh 'rm -rf colcon_ws'
-            }
-          }
-          options {
-            checkoutToSubdirectory('colcon_ws/src/Firmware')
-          }
-        }
+        // stage('Colcon build on ROS2 workspace') {
+        //   agent {
+        //     docker {
+        //       image 'px4io/px4-dev-ros2-bouncy:2019-02-09'
+        //       args '-e CCACHE_BASEDIR=$WORKSPACE -v ${CCACHE_DIR}:${CCACHE_DIR}:rw -e HOME=$WORKSPACE'
+        //     }
+        //   }
+        //   steps {
+        //     sh 'ls -l'
+        //     sh '''#!/bin/bash -l
+        //       echo $0;
+        //       unset ROS_DISTRO;
+        //       mkdir -p colcon_ws/src;
+        //       cd colcon_ws;
+        //       git -C ${WORKSPACE}/colcon_ws/src/Firmware submodule update --init --recursive --force Tools/sitl_gazebo
+        //       git clone --recursive ${WORKSPACE}/colcon_ws/src/Firmware/Tools/sitl_gazebo src/mavlink_sitl_gazebo;
+        //       source /opt/ros/bouncy/setup.sh;
+        //       source /opt/ros/melodic/setup.sh;
+        //       colcon build --event-handlers console_direct+ --symlink-install;
+        //     '''
+        //   }
+        //   post {
+        //     always {
+        //       sh 'rm -rf colcon_ws'
+        //     }
+        //   }
+        //   options {
+        //     checkoutToSubdirectory('colcon_ws/src/Firmware')
+        //   }
+        // }
 
         stage('Style check') {
           agent {


### PR DESCRIPTION
~~These can't be dependant on the current state of sitl_gazebo.~~ Updated to use submodule, but still failing until the mavlink change makes it everywhere.

@TSC21 we either need to quickly update these jobs to use the corresponding sitl_gazebo or temporarily disable these jobs.