### PR TITLE
fix MPU6000: restore orb priority

### DIFF
--- a/src/drivers/imu/mpu6000/MPU6000.cpp
+++ b/src/drivers/imu/mpu6000/MPU6000.cpp
@@ -48,8 +48,8 @@ MPU6000::MPU6000(device::Device *interface, const char *path, enum Rotation rota
 #else
 	_use_hrt(true),
 #endif
-	_px4_accel(_interface->get_device_id(), (_interface->external() ? ORB_PRIO_HIGH : ORB_PRIO_DEFAULT), rotation),
-	_px4_gyro(_interface->get_device_id(), (_interface->external() ? ORB_PRIO_HIGH : ORB_PRIO_DEFAULT), rotation),
+	_px4_accel(_interface->get_device_id(), (_interface->external() ? ORB_PRIO_MAX : ORB_PRIO_HIGH), rotation),
+	_px4_gyro(_interface->get_device_id(), (_interface->external() ? ORB_PRIO_MAX : ORB_PRIO_HIGH), rotation),
 	_sample_perf(perf_alloc(PC_ELAPSED, "mpu6k_read")),
 	_measure_interval(perf_alloc(PC_INTERVAL, "mpu6k_measure_interval")),
 	_bad_transfers(perf_alloc(PC_COUNT, "mpu6k_bad_trans")),


### PR DESCRIPTION
Fixes regression from https://github.com/PX4/Firmware/pull/11216 (@dagar if this change was on purpose, it should have been mentioned in a commit message).
I'm fine with using default prio's by default, but it needs to be consistent for all drivers.

The problem was that the BMI055 driver had a higher prio than the ICM-20689 on the Pixhawk 4.