### PR TITLE
Add Support for HW that indicates armed state.

### DIFF
--- a/boards/px4/fmu-v5/src/board_config.h
+++ b/boards/px4/fmu-v5/src/board_config.h
@@ -347,9 +347,14 @@
 
 #define DIRECT_PWM_CAPTURE_CHANNELS  3
 
-/* TIM5_CH4 SPARE PIN */
-#define GPIO_TIM5_CH4IN    /* PI0   T5C4  TIM5_SPARE_4 */  GPIO_TIM5_CH4IN_2
-#define GPIO_TIM5_CH4OUT   /* PI0   T5C4  TIM5_SPARE_4 */   GPIO_TIM5_CH4OUT_2
+/* PI0 is nARMED
+ *  The GPIO will be set as input while not armed HW will have external HW Pull UP.
+ *  While armed it shall be configured at a GPIO OUT set LOW
+ */
+#define GPIO_nARMED_INIT     /* PI0 */  (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTI|GPIO_PIN1)
+#define GPIO_nARMED          /* PI0 */  (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTI|GPIO_PIN1)
+
+#define BOARD_INDICATE_ARMED_STATE(on_armed)  px4_arch_configgpio((on_armed) ? GPIO_nARMED : GPIO_nARMED_INIT)
 
 /* PWM
  *
@@ -662,7 +667,8 @@
 		GPIO_TONE_ALARM_IDLE,             \
 		GPIO_RSSI_IN_INIT,                \
 		GPIO_nSAFETY_SWITCH_LED_OUT_INIT, \
-		GPIO_SAFETY_SWITCH_IN             \
+		GPIO_SAFETY_SWITCH_IN,            \
+		GPIO_nARMED_INIT                  \
 	}
 
 __BEGIN_DECLS

--- a/src/drivers/boards/common/board_common.h
+++ b/src/drivers/boards/common/board_common.h
@@ -316,6 +316,14 @@
 #  endif
 #endif //
 
+/* Provide an overridable default nop
+ * for BOARD_INDICATE_ARMED_STATE
+ */
+
+#if !defined(BOARD_INDICATE_ARMED_STATE)
+#  define BOARD_INDICATE_ARMED_STATE(on_armed)
+#endif
+
 /************************************************************************************
  * Public Data
  ************************************************************************************/

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2687,6 +2687,10 @@ control_status_leds(vehicle_status_s *status_local, const actuator_armed_s *actu
 
 	last_overload = overload;
 
+	/* board supports HW armed indicator */
+
+	BOARD_INDICATE_ARMED_STATE(actuator_armed->armed);
+
 #if !defined(CONFIG_ARCH_LEDS) && defined(BOARD_HAS_CONTROL_STATUS_LEDS)
 
 	/* this runs at around 20Hz, full cycle is 16 ticks = 10/16Hz */


### PR DESCRIPTION
Boards may choose to support this feature by defining the macro BOARD_INDICATE_ARMED_STATE in their board_config.h file.

fmuv5: Repurpose TIM5_SPARE_4 as nARMED 
On V5 nARMED is a Digital OUTPUT. GPIO will be set as input while not armed HW will have Pull UP. While armed it will be configured as a GPIO OUT set LOW.

![image](https://user-images.githubusercontent.com/1945821/52740171-52567900-2f87-11e9-93d0-410d88f14641.png)
