### PR TITLE
Move remaining variable initialization from constructor list, add orb_unsubscribe() to Simulation class destructor.

### DIFF
--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -255,9 +255,18 @@ private:
 
 	~Simulator()
 	{
-		if (_instance != nullptr) {
-			delete _instance;
-		}
+		// Unsubscribe from uORB topics.
+		orb_unsubscribe(_param_sub);
+
+		// free perf counters
+		perf_free(_perf_accel);
+		perf_free(_perf_airspeed);
+		perf_free(_perf_baro);
+		perf_free(_perf_gps);
+		perf_free(_perf_mag);
+		perf_free(_perf_mpu);
+		perf_free(_perf_sim_delay);
+		perf_free(_perf_sim_interval);
 
 		_instance = NULL;
 	}
@@ -358,8 +367,8 @@ private:
 
 	// uORB data containers
 	input_rc_s _rc_input {};
-	vehicle_attitude_s _attitude {};
 	manual_control_setpoint_s _manual {};
+	vehicle_attitude_s _attitude {};
 	vehicle_status_s _vehicle_status {};
 
 	DEFINE_PARAMETERS(


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR:

- Moves remaining variable initialization from the Simluation class constructor list,
- Removes an incorrect `delete _instance`,
- Adds perf_free() calls and an orb_unsubscribe() call to the Simulation class destructor, and
- Groups/alphabetizes methods and variables for readability.

@dagar, this follows up on your recent init work in these files.

Let me know if you have any questions on this PR.
