### PR TITLE
BUGFIX stm32:drv_io_timer:Prevent glitch on PWM outputs 

### DIFF
--- a/src/drivers/stm32/drv_io_timer.c
+++ b/src/drivers/stm32/drv_io_timer.c
@@ -461,12 +461,9 @@ static int allocate_channel(unsigned channel, io_timer_channel_mode_t mode)
 
 static int timer_set_rate(unsigned timer, unsigned rate)
 {
-
 	/* configure the timer to update at the desired rate */
-	rARR(timer) = (BOARD_PWM_FREQ / rate) - 1;
 
-	/* generate an update event; reloads the counter and all registers */
-	rEGR(timer) = GTIM_EGR_UG;
+	rARR(timer) = (BOARD_PWM_FREQ / rate) - 1;
 
 	return 0;
 }


### PR DESCRIPTION
Fixes #11326 

   Rate changes were doing an asynchronous register reload via the
   EGR_UG. This could extend a PWM pulse up to 2X.

   This fix removes the asynchronous update. The net effect
   is that the rate change will occur on the next counter
   expiration. The worst case is the rate change is delayed
   by 20 Ms.
