### PR TITLE
EKF: only set in_air flag true if not landed and armed

### DIFF
--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -1237,7 +1237,7 @@ void Ekf2::run()
 
 		if (vehicle_land_detected_updated) {
 			if (orb_copy(ORB_ID(vehicle_land_detected), _vehicle_land_detected_sub, &vehicle_land_detected) == PX4_OK) {
-				_ekf.set_in_air_status(!vehicle_land_detected.landed);
+				_ekf.set_in_air_status(!vehicle_land_detected.landed && vehicle_status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
 			}
 		}
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
If the user carries the vehicle around the landed flag might be false. Without this change that could result in the EKF initializing the earth magnetic field states and commencing 3D axis mag fusion when still close to the ground.