### PR TITLE
avoidance failsafe in commander

### DIFF
--- a/src/lib/FlightTasks/tasks/Utility/ObstacleAvoidance.hpp
+++ b/src/lib/FlightTasks/tasks/Utility/ObstacleAvoidance.hpp
@@ -47,7 +47,6 @@
 #include <drivers/drv_hrt.h>
 
 #include <uORB/topics/position_controller_status.h>
-#include <uORB/topics/vehicle_command.h>
 #include <uORB/topics/vehicle_status.h>
 #include <uORB/topics/vehicle_trajectory_waypoint.h>
 
@@ -113,7 +112,6 @@ private:
 	vehicle_trajectory_waypoint_s _desired_waypoint = {};  /**< desired vehicle trajectory waypoint to be sent to OA */
 	orb_advert_t _pub_traj_wp_avoidance_desired{nullptr}; /**< trajectory waypoint desired publication */
 	orb_advert_t _pub_pos_control_status{nullptr}; /**< position controller status publication */
-	orb_advert_t _pub_vehicle_command{nullptr}; /**< vehicle command do publication */
 
 	matrix::Vector3f _curr_wp = {}; /**< current position triplet */
 
@@ -121,10 +119,5 @@ private:
 	 * Publishes vehicle trajectory waypoint desired.
 	 */
 	void _publishAvoidanceDesiredWaypoint();
-
-	/**
-	 * Publishes vehicle command.
-	 */
-	void _publishVehicleCmdDoLoiter();
 
 };

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -515,6 +515,10 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 			set_link_loss_nav_state(status, armed, status_flags, internal_state, rc_loss_act,
 						vehicle_status_s::NAVIGATION_STATE_AUTO_RCRECOVER);
 
+		} else if (status_flags.avoidance_system_required && !status_flags.avoidance_system_valid) {
+			/* avoidance system not healty -> loiter */
+			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LOITER;
+
 		} else if (!stay_in_failsafe) {
 			/* stay where you are if you should stay in failsafe, otherwise everything is perfect */
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_MISSION;
@@ -566,6 +570,13 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 
 		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, true)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
+		} else if (status_flags.avoidance_system_required && !status_flags.avoidance_system_valid) {
+			/* avoidance system not healty -> switch it off */
+			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_RTL;
+			int32_t com_obs_avoid = 0;
+			param_set(param_find("COM_OBS_AVOID"), &com_obs_avoid);
+			mavlink_log_critical(mavlink_log_pub, "Avoidance system disabled.");
+
 		} else {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_RTL;
 		}
@@ -625,6 +636,10 @@ bool set_nav_state(vehicle_status_s *status, actuator_armed_s *armed, commander_
 
 		} else if (is_armed && check_invalid_pos_nav_state(status, old_failsafe, mavlink_log_pub, status_flags, false, false)) {
 			// nothing to do - everything done in check_invalid_pos_nav_state
+
+		} else if (status_flags.avoidance_system_required && !status_flags.avoidance_system_valid) {
+			/* avoidance system not healty -> land */
+			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_LAND;
 
 		} else {
 			status->nav_state = vehicle_status_s::NAVIGATION_STATE_AUTO_TAKEOFF;


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
I would like to unify the failsafe action with the communication to the user for the obstacle avoidance. Right now the failsafe happens in the the mc_pos_control issuing a vehicle command. 

EDIT: another reason why I would like to make this change is that there is a refactor of the avoidance interface in the works ( #11445). The setpoints coming from the avoidance will be injected directly into the flight task (AutoMapper and Manual Position) therefore the subscription to `vehicle_trajectory_waypoint` and check for validity doesn't need to be anymore in the mc_pos_control. 

EDIT2: the PR now refactors the failsafe to be handled differently according to the navigation states in which the avoidance is enabled. Here's a summary of the desired behavior 

| Nav State  | Failsafe |
| ------------- | ------------- |
| Mission  | Loiter  |
| Takeoff  | Land  |
| Land  | OA not available  |
| Loiter  | OA not available  |
| RTL  | disabled OA and stay in RTL |
| Follow Target  | OA not available  |


**Test data / coverage**
SITL tested