### PR TITLE
smooth takeoff - Support smooth takeoff triggered by jerk setpoint

### DIFF
--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
@@ -49,10 +49,12 @@ bool FlightTaskManualPositionSmoothVel::activate()
 
 void FlightTaskManualPositionSmoothVel::reActivate()
 {
-	reset(Axes::XY);
+	// The task is reacivated while the vehicle is on the ground. To detect takeoff in mc_pos_control_main properly
+	// using the generated jerk, reset the z derivatives to zero
+	reset(Axes::XYZ, true);
 }
 
-void FlightTaskManualPositionSmoothVel::reset(Axes axes)
+void FlightTaskManualPositionSmoothVel::reset(Axes axes, bool force_z_zero)
 {
 	int count;
 
@@ -73,6 +75,11 @@ void FlightTaskManualPositionSmoothVel::reset(Axes axes)
 	// TODO: get current accel
 	for (int i = 0; i < count; ++i) {
 		_smoothing[i].reset(0.f, _velocity(i), _position(i));
+	}
+
+	// Set the z derivatives to zero
+	if (force_z_zero) {
+		_smoothing[2].reset(0.f, 0.f, _position(2));
 	}
 
 	_position_lock_xy_active = false;

--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.hpp
@@ -65,7 +65,12 @@ protected:
 private:
 
 	enum class Axes {XY, XYZ};
-	void reset(Axes axes);
+
+	/**
+	 * Reset the required axes. when force_z_zero is set to true, the z derivatives are set to sero and not to the estimated states
+	 */
+	void reset(Axes axes, bool force_z_zero = false);
+
 	VelocitySmoothing _smoothing[3]; ///< Smoothing in x, y and z directions
 	matrix::Vector3f _vel_sp_smooth;
 	bool _position_lock_xy_active{false};


### PR DESCRIPTION
fixes #11452 

**Test data / coverage**
Tested in SITL
![jerk-triggered_takeoff](https://user-images.githubusercontent.com/14822839/52783911-b777a080-3053-11e9-8003-c210bea18530.png)

**Describe problem solved by the proposed pull request**
A (hard to predict) delay before takeoff was present on all the non spring-loaded remotes while using the `SmoothVelocity` position sub mode. This PR enables a full reset of the `ManualSmoothVel` FlightTask by adding a jerk-based check to trigger "smooth takeoff" in `mc_pos_control_main`.
Takeoff is now triggered as soon as the throttle stick is above 50%.

**Describe possible alternatives**
Setting the `vel_down` constraint to 0 while on ground.