### PR TITLE
using only px4_getopt() and never the unsafe getopt()

### DIFF
--- a/src/drivers/barometer/lps25h/lps25h.cpp
+++ b/src/drivers/barometer/lps25h/lps25h.cpp
@@ -73,7 +73,7 @@
 #include <uORB/uORB.h>
 
 #include <float.h>
-#include <getopt.h>
+#include <px4_getopt.h>
 
 #include "lps25h.h"
 
@@ -967,9 +967,12 @@ int
 lps25h_main(int argc, char *argv[])
 {
 	enum LPS25H_BUS busid = LPS25H_BUS_ALL;
-	int ch;
 
-	while ((ch = getopt(argc, argv, "XIS:")) != EOF) {
+	int myoptind = 1;
+	int ch;
+	const char *myoptarg = nullptr;
+
+	while ((ch = px4_getopt(argc, argv, "XIS:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 #if (PX4_I2C_BUS_ONBOARD || PX4_SPIDEV_HMC)
 
@@ -992,7 +995,12 @@ lps25h_main(int argc, char *argv[])
 		}
 	}
 
-	const char *verb = argv[optind];
+	if (myoptind >= argc) {
+		lps25h::usage();
+		exit(0);
+	}
+
+	const char *verb = argv[myoptind];
 
 	/*
 	 * Start/load the driver.

--- a/src/drivers/barometer/mpl3115a2/mpl3115a2.cpp
+++ b/src/drivers/barometer/mpl3115a2/mpl3115a2.cpp
@@ -54,7 +54,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <unistd.h>
-#include <getopt.h>
+#include <px4_getopt.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/wqueue.h>
@@ -70,7 +70,6 @@
 
 #include <perf/perf_counter.h>
 #include <systemlib/err.h>
-#include <platforms/px4_getopt.h>
 
 #include "mpl3115a2.h"
 
@@ -897,8 +896,8 @@ int
 mpl3115a2_main(int argc, char *argv[])
 {
 	enum MPL3115A2_BUS busid = MPL3115A2_BUS_ALL;
-	int ch;
 	int myoptind = 1;
+	int ch;
 	const char *myoptarg = NULL;
 
 	/* jump over start/off/etc and look at options first */
@@ -916,6 +915,11 @@ mpl3115a2_main(int argc, char *argv[])
 			mpl3115a2::usage();
 			exit(0);
 		}
+	}
+
+	if (myoptind >= argc) {
+		mpl3115a2::usage();
+		exit(0);
 	}
 
 	const char *verb = argv[myoptind];

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -134,11 +134,6 @@ int BATT_SMBUS::task_spawn(int argc, char *argv[])
 		}
 	}
 
-	if (myoptind >= argc) {
-		print_usage();
-		return PX4_ERROR;
-	}
-
 	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {
 
 		if (!is_running() && (busid == BATT_SMBUS_BUS_ALL || bus_options[i].busid == busid)) {

--- a/src/drivers/batt_smbus/batt_smbus.cpp
+++ b/src/drivers/batt_smbus/batt_smbus.cpp
@@ -42,6 +42,7 @@
  */
 
 #include "batt_smbus.h"
+#include <px4_getopt.h>
 
 #include <stdlib.h>
 
@@ -100,9 +101,12 @@ BATT_SMBUS::~BATT_SMBUS()
 int BATT_SMBUS::task_spawn(int argc, char *argv[])
 {
 	enum BATT_SMBUS_BUS busid = BATT_SMBUS_BUS_ALL;
-	int ch;
 
-	while ((ch = getopt(argc, argv, "XTRIA:")) != EOF) {
+	int myoptind = 1;
+	int ch;
+	const char *myoptarg = nullptr;
+
+	while ((ch = px4_getopt(argc, argv, "XTRIA:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'X':
 			busid = BATT_SMBUS_BUS_I2C_EXTERNAL;
@@ -128,6 +132,11 @@ int BATT_SMBUS::task_spawn(int argc, char *argv[])
 			print_usage();
 			return PX4_ERROR;
 		}
+	}
+
+	if (myoptind >= argc) {
+		print_usage();
+		return PX4_ERROR;
 	}
 
 	for (unsigned i = 0; i < NUM_BUS_OPTIONS; i++) {

--- a/src/drivers/distance_sensor/ll40ls/ll40ls.cpp
+++ b/src/drivers/distance_sensor/ll40ls/ll40ls.cpp
@@ -49,7 +49,7 @@
 #include <cstdlib>
 #include <string.h>
 #include <stdio.h>
-#include <platforms/px4_getopt.h>
+#include <px4_getopt.h>
 
 #ifndef CONFIG_SCHED_WORKQUEUE
 # error This requires CONFIG_SCHED_WORKQUEUE.

--- a/src/drivers/imu/adis16448/adis16448.cpp
+++ b/src/drivers/imu/adis16448/adis16448.cpp
@@ -1789,7 +1789,7 @@ adis16448_main(int argc, char *argv[])
 	while ((ch = px4_getopt(argc, argv, "R:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'R':
-			rotation = (enum Rotation)atoi(optarg);
+			rotation = (enum Rotation)atoi(myoptarg);
 			break;
 
 		default:

--- a/src/drivers/imu/adis16448/adis16448.cpp
+++ b/src/drivers/imu/adis16448/adis16448.cpp
@@ -58,7 +58,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <unistd.h>
-#include <getopt.h>
+#include <px4_getopt.h>
 
 #include <perf/perf_counter.h>
 #include <systemlib/err.h>
@@ -1780,10 +1780,13 @@ int
 adis16448_main(int argc, char *argv[])
 {
 	enum Rotation rotation = ROTATION_NONE;
+
+	int myoptind = 1;
 	int ch;
+	const char *myoptarg = nullptr;
 
 	/* start options */
-	while ((ch = getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "R:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'R':
 			rotation = (enum Rotation)atoi(optarg);
@@ -1795,7 +1798,13 @@ adis16448_main(int argc, char *argv[])
 		}
 	}
 
-	const char *verb = argv[optind];
+	if (myoptind >= argc) {
+		adis16448::usage();
+		return -1;
+	}
+
+	const char *verb = argv[myoptind];
+
 
 	/*
 	 * Start/load the driver.

--- a/src/drivers/imu/adis16477/ADIS16477_main.cpp
+++ b/src/drivers/imu/adis16477/ADIS16477_main.cpp
@@ -33,6 +33,8 @@
 
 #include "ADIS16477.hpp"
 
+#include <px4_getopt.h>
+
 #define ADIS16477_DEVICE_PATH_ACCEL		"/dev/adis16477_accel"
 #define ADIS16477_DEVICE_PATH_GYRO		"/dev/adis16477_gyro"
 
@@ -215,10 +217,13 @@ int
 adis16477_main(int argc, char *argv[])
 {
 	enum Rotation rotation = ROTATION_NONE;
+
+	int myoptind = 1;
 	int ch;
+	const char *myoptarg = nullptr;
 
 	/* start options */
-	while ((ch = getopt(argc, argv, "R:")) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "R:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'R':
 			rotation = (enum Rotation)atoi(optarg);
@@ -226,11 +231,16 @@ adis16477_main(int argc, char *argv[])
 
 		default:
 			adis16477::usage();
-			exit(0);
+			return 0;
 		}
 	}
 
-	const char *verb = argv[optind];
+	if (myoptind >= argc) {
+		adis16477::usage();
+		return -1;
+	}
+
+	const char *verb = argv[myoptind];
 
 	/*
 	 * Start/load the driver.

--- a/src/drivers/imu/adis16477/ADIS16477_main.cpp
+++ b/src/drivers/imu/adis16477/ADIS16477_main.cpp
@@ -226,7 +226,7 @@ adis16477_main(int argc, char *argv[])
 	while ((ch = px4_getopt(argc, argv, "R:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'R':
-			rotation = (enum Rotation)atoi(optarg);
+			rotation = (enum Rotation)atoi(myoptarg);
 			break;
 
 		default:

--- a/src/drivers/imu/bmi055/bmi055_main.cpp
+++ b/src/drivers/imu/bmi055/bmi055_main.cpp
@@ -35,7 +35,7 @@
 #include "BMI055_gyro.hpp"
 
 #include <px4_config.h>
-#include <platforms/px4_getopt.h>
+#include <px4_getopt.h>
 
 /** driver 'main' command */
 extern "C" { __EXPORT int bmi055_main(int argc, char *argv[]); }

--- a/src/drivers/imu/bmi160/bmi160.hpp
+++ b/src/drivers/imu/bmi160/bmi160.hpp
@@ -16,7 +16,6 @@
 #include <stdio.h>
 #include <math.h>
 #include <unistd.h>
-#include <getopt.h>
 
 #include <perf/perf_counter.h>
 #include <systemlib/err.h>

--- a/src/drivers/imu/fxas21002c/fxas21002c.cpp
+++ b/src/drivers/imu/fxas21002c/fxas21002c.cpp
@@ -72,7 +72,7 @@
 #include <board_config.h>
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
 #include <lib/conversion/rotation.h>
-#include <platforms/px4_getopt.h>
+#include <px4_getopt.h>
 #include <systemlib/err.h>
 
 /* SPI protocol address bits */

--- a/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
+++ b/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
@@ -76,7 +76,7 @@
 #include <board_config.h>
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
 #include <lib/conversion/rotation.h>
-#include <platforms/px4_getopt.h>
+#include <px4_getopt.h>
 #include <systemlib/err.h>
 
 /* SPI protocol address bits */

--- a/src/drivers/imu/lsm303d/lsm303d.cpp
+++ b/src/drivers/imu/lsm303d/lsm303d.cpp
@@ -54,7 +54,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <unistd.h>
-#include <getopt.h>
+#include <px4_getopt.h>
 
 #include <perf/perf_counter.h>
 #include <systemlib/err.h>
@@ -1932,12 +1932,15 @@ int
 lsm303d_main(int argc, char *argv[])
 {
 	bool external_bus = false;
-	int ch;
 	enum Rotation rotation = ROTATION_NONE;
 	int accel_range = 8;
 
+	int myoptind = 1;
+	int ch;
+	const char *myoptarg = nullptr;
+
 	/* jump over start/off/etc and look at options first */
-	while ((ch = getopt(argc, argv, "XR:a:")) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "XR:a:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'X':
 			external_bus = true;
@@ -1957,7 +1960,12 @@ lsm303d_main(int argc, char *argv[])
 		}
 	}
 
-	const char *verb = argv[optind];
+	if (myoptind >= argc) {
+		lsm303d::usage();
+		exit(0);
+	}
+
+	const char *verb = argv[myoptind];
 
 	/*
 	 * Start/load the driver.

--- a/src/drivers/imu/lsm303d/lsm303d.cpp
+++ b/src/drivers/imu/lsm303d/lsm303d.cpp
@@ -1947,11 +1947,11 @@ lsm303d_main(int argc, char *argv[])
 			break;
 
 		case 'R':
-			rotation = (enum Rotation)atoi(optarg);
+			rotation = (enum Rotation)atoi(myoptarg);
 			break;
 
 		case 'a':
-			accel_range = atoi(optarg);
+			accel_range = atoi(myoptarg);
 			break;
 
 		default:

--- a/src/drivers/lights/oreoled/oreoled.cpp
+++ b/src/drivers/lights/oreoled/oreoled.cpp
@@ -54,6 +54,7 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <sys/stat.h>
+#include <px4_getopt.h>
 
 #include <nuttx/arch.h>
 #include <nuttx/wqueue.h>
@@ -1611,10 +1612,13 @@ oreoled_main(int argc, char *argv[])
 	int i2cdevice = -1;
 	int i2c_addr = OREOLED_BASE_I2C_ADDR; /* 7bit */
 
+	int myoptind = 1;
 	int ch;
+	const char *myoptarg = nullptr;
+
 
 	/* jump over start/off/etc and look at options first */
-	while ((ch = getopt(argc, argv, "a:b:")) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "a:b:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'a':
 			i2c_addr = (int)strtol(optarg, NULL, 0);
@@ -1630,12 +1634,12 @@ oreoled_main(int argc, char *argv[])
 		}
 	}
 
-	if (optind >= argc) {
+	if (myoptind >= argc) {
 		oreoled_usage();
 		exit(1);
 	}
 
-	const char *verb = argv[optind];
+	const char *verb = argv[myoptind];
 
 	int ret;
 
@@ -2008,18 +2012,18 @@ oreoled_main(int argc, char *argv[])
 		}
 
 		/* check led num */
-		sendb.led_num = (uint8_t)strtol(argv[optind + 1], NULL, 0);
+		sendb.led_num = (uint8_t)strtol(argv[myoptind + 1], NULL, 0);
 
 		if (sendb.led_num > 3) {
 			errx(1, "led number must be between 0 ~ 3");
 		}
 
 		/* get bytes */
-		sendb.num_bytes = argc - (optind + 2);
+		sendb.num_bytes = argc - (myoptind + 2);
 		uint8_t byte_count;
 
 		for (byte_count = 0; byte_count < sendb.num_bytes; byte_count++) {
-			sendb.buff[byte_count] = (uint8_t)strtol(argv[byte_count + optind + 2], NULL, 0);
+			sendb.buff[byte_count] = (uint8_t)strtol(argv[byte_count + myoptind + 2], NULL, 0);
 		}
 
 		/* send bytes */

--- a/src/drivers/lights/oreoled/oreoled.cpp
+++ b/src/drivers/lights/oreoled/oreoled.cpp
@@ -1621,11 +1621,11 @@ oreoled_main(int argc, char *argv[])
 	while ((ch = px4_getopt(argc, argv, "a:b:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'a':
-			i2c_addr = (int)strtol(optarg, NULL, 0);
+			i2c_addr = (int)strtol(myoptarg, NULL, 0);
 			break;
 
 		case 'b':
-			i2cdevice = (int)strtol(optarg, NULL, 0);
+			i2cdevice = (int)strtol(myoptarg, NULL, 0);
 			break;
 
 		default:

--- a/src/drivers/lights/pca8574/pca8574.cpp
+++ b/src/drivers/lights/pca8574/pca8574.cpp
@@ -381,11 +381,11 @@ pca8574_main(int argc, char *argv[])
 	while ((ch = px4_getopt(argc, argv, "a:b:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'a':
-			pca8574adr = strtol(optarg, NULL, 0);
+			pca8574adr = strtol(myoptarg, NULL, 0);
 			break;
 
 		case 'b':
-			i2cdevice = strtol(optarg, NULL, 0);
+			i2cdevice = strtol(myoptarg, NULL, 0);
 			break;
 
 		default:

--- a/src/drivers/lights/pca8574/pca8574.cpp
+++ b/src/drivers/lights/pca8574/pca8574.cpp
@@ -54,6 +54,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <px4_getopt.h>
 
 #include <nuttx/wqueue.h>
 
@@ -371,10 +372,13 @@ pca8574_main(int argc, char *argv[])
 	int i2cdevice = -1;
 	int pca8574adr = ADDR; // 7bit
 
+	int myoptind = 1;
 	int ch;
+	const char *myoptarg = nullptr;
+
 
 	// jump over start/off/etc and look at options first
-	while ((ch = getopt(argc, argv, "a:b:")) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "a:b:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'a':
 			pca8574adr = strtol(optarg, NULL, 0);
@@ -390,12 +394,12 @@ pca8574_main(int argc, char *argv[])
 		}
 	}
 
-	if (optind >= argc) {
+	if (myoptind >= argc) {
 		pca8574_usage();
-		exit(1);
+		exit(0);
 	}
 
-	const char *verb = argv[optind];
+	const char *verb = argv[myoptind];
 
 	int fd;
 	int ret;

--- a/src/drivers/lights/rgbled_pwm/rgbled_pwm.cpp
+++ b/src/drivers/lights/rgbled_pwm/rgbled_pwm.cpp
@@ -52,6 +52,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <px4_getopt.h>
 
 #include <nuttx/wqueue.h>
 #include <drivers/drv_hrt.h>
@@ -293,10 +294,13 @@ rgbled_usage()
 int
 rgbled_pwm_main(int argc, char *argv[])
 {
+	int myoptind = 1;
 	int ch;
+	const char *myoptarg = nullptr;
+
 
 	/* jump over start/off/etc and look at options first */
-	while ((ch = getopt(argc, argv, "a:b:")) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "a:b:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'a':
 			break;
@@ -310,12 +314,13 @@ rgbled_pwm_main(int argc, char *argv[])
 		}
 	}
 
-	if (optind >= argc) {
+	if (myoptind >= argc) {
 		rgbled_usage();
-		exit(1);
+		exit(0);
 	}
 
-	const char *verb = argv[optind];
+	const char *verb = argv[myoptind];
+
 
 	if (!strcmp(verb, "start")) {
 		if (g_rgbled != nullptr) {

--- a/src/drivers/magnetometer/hmc5883/hmc5883.cpp
+++ b/src/drivers/magnetometer/hmc5883/hmc5883.cpp
@@ -1719,7 +1719,7 @@ hmc5883_main(int argc, char *argv[])
 	while ((ch = px4_getopt(argc, argv, "XISR:CT", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'R':
-			rotation = (enum Rotation)atoi(optarg);
+			rotation = (enum Rotation)atoi(myoptarg);
 			break;
 #if (PX4_I2C_BUS_ONBOARD || PX4_SPIDEV_HMC)
 

--- a/src/drivers/magnetometer/hmc5883/hmc5883.cpp
+++ b/src/drivers/magnetometer/hmc5883/hmc5883.cpp
@@ -73,7 +73,7 @@
 #include <uORB/uORB.h>
 
 #include <float.h>
-#include <getopt.h>
+#include <px4_getopt.h>
 #include <lib/conversion/rotation.h>
 
 #include "hmc5883.h"
@@ -1701,7 +1701,11 @@ usage()
 int
 hmc5883_main(int argc, char *argv[])
 {
+	int myoptind = 1;
 	int ch;
+	const char *myoptarg = nullptr;
+
+
 	enum HMC5883_BUS busid = HMC5883_BUS_ALL;
 	enum Rotation rotation = ROTATION_NONE;
 	bool calibrate = false;
@@ -1712,7 +1716,7 @@ hmc5883_main(int argc, char *argv[])
 		exit(0);
 	}
 
-	while ((ch = getopt(argc, argv, "XISR:CT")) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "XISR:CT", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'R':
 			rotation = (enum Rotation)atoi(optarg);
@@ -1746,7 +1750,13 @@ hmc5883_main(int argc, char *argv[])
 		}
 	}
 
-	const char *verb = argv[optind];
+	if (myoptind >= argc) {
+		hmc5883::usage();
+		exit(0);
+	}
+
+	const char *verb = argv[myoptind];
+
 
 	/*
 	 * Start/load the driver.

--- a/src/drivers/magnetometer/ist8310/ist8310.cpp
+++ b/src/drivers/magnetometer/ist8310/ist8310.cpp
@@ -75,7 +75,6 @@
 #include <uORB/uORB.h>
 
 #include <float.h>
-#include <getopt.h>
 #include <lib/conversion/rotation.h>
 
 /*

--- a/src/drivers/magnetometer/lsm303agr/lsm303agr_main.cpp
+++ b/src/drivers/magnetometer/lsm303agr/lsm303agr_main.cpp
@@ -35,6 +35,7 @@
 
 #include <px4_config.h>
 #include <px4_defines.h>
+#include <px4_getopt.h>
 
 #define LSM303AGR_DEVICE_PATH_MAG	"/dev/lsm303agr_mag"
 
@@ -135,11 +136,14 @@ usage()
 int
 lsm303agr_main(int argc, char *argv[])
 {
+	int myoptind = 1;
 	int ch;
+	const char *myoptarg = nullptr;
+
 	enum Rotation rotation = ROTATION_NONE;
 
 	/* jump over start/off/etc and look at options first */
-	while ((ch = getopt(argc, argv, "XR:a:")) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "XR:a:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'R':
 			rotation = (enum Rotation)atoi(optarg);
@@ -151,7 +155,12 @@ lsm303agr_main(int argc, char *argv[])
 		}
 	}
 
-	const char *verb = argv[optind];
+	if (myoptind >= argc) {
+		lsm303agr::usage();
+		exit(0);
+	}
+
+	const char *verb = argv[myoptind];
 
 	/*
 	 * Start/load the driver.

--- a/src/drivers/magnetometer/lsm303agr/lsm303agr_main.cpp
+++ b/src/drivers/magnetometer/lsm303agr/lsm303agr_main.cpp
@@ -146,7 +146,7 @@ lsm303agr_main(int argc, char *argv[])
 	while ((ch = px4_getopt(argc, argv, "XR:a:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'R':
-			rotation = (enum Rotation)atoi(optarg);
+			rotation = (enum Rotation)atoi(myoptarg);
 			break;
 
 		default:

--- a/src/drivers/pca9685/pca9685.cpp
+++ b/src/drivers/pca9685/pca9685.cpp
@@ -61,6 +61,7 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <math.h>
+#include <px4_getopt.h>
 
 #include <nuttx/wqueue.h>
 #include <nuttx/clock.h>
@@ -531,10 +532,13 @@ pca9685_main(int argc, char *argv[])
 	int i2cdevice = -1;
 	int i2caddr = ADDR; // 7bit
 
+	int myoptind = 1;
 	int ch;
+	const char *myoptarg = nullptr;
+
 
 	// jump over start/off/etc and look at options first
-	while ((ch = getopt(argc, argv, "a:b:")) != EOF) {
+	while ((ch = px4_getopt(argc, argv, "a:b:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'a':
 			i2caddr = strtol(optarg, NULL, 0);
@@ -550,12 +554,12 @@ pca9685_main(int argc, char *argv[])
 		}
 	}
 
-	if (optind >= argc) {
+	if (myoptind >= argc) {
 		pca9685_usage();
-		exit(1);
+		exit(0);
 	}
 
-	const char *verb = argv[optind];
+	const char *verb = argv[myoptind];
 
 	int fd;
 	int ret;

--- a/src/drivers/pca9685/pca9685.cpp
+++ b/src/drivers/pca9685/pca9685.cpp
@@ -541,7 +541,7 @@ pca9685_main(int argc, char *argv[])
 	while ((ch = px4_getopt(argc, argv, "a:b:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
 		case 'a':
-			i2caddr = strtol(optarg, NULL, 0);
+			i2caddr = strtol(myoptarg, NULL, 0);
 			break;
 
 		case 'b':

--- a/src/drivers/pca9685/pca9685.cpp
+++ b/src/drivers/pca9685/pca9685.cpp
@@ -545,7 +545,7 @@ pca9685_main(int argc, char *argv[])
 			break;
 
 		case 'b':
-			i2cdevice = strtol(optarg, NULL, 0);
+			i2cdevice = strtol(myoptarg, NULL, 0);
 			break;
 
 		default:

--- a/src/drivers/test_ppm/test_ppm.cpp
+++ b/src/drivers/test_ppm/test_ppm.cpp
@@ -52,7 +52,6 @@
 #include <stdio.h>
 #include <math.h>
 #include <unistd.h>
-#include <getopt.h>
 
 #include <perf/perf_counter.h>
 #include <systemlib/err.h>

--- a/src/modules/dataman/dataman.cpp
+++ b/src/modules/dataman/dataman.cpp
@@ -46,6 +46,7 @@
 #include <px4_module.h>
 #include <px4_posix.h>
 #include <px4_tasks.h>
+#include <px4_getopt.h>
 #include <stdio.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -56,7 +57,6 @@
 #include <string.h>
 #include <semaphore.h>
 #include <unistd.h>
-#include <platforms/px4_getopt.h>
 #include <drivers/drv_hrt.h>
 
 #include "dataman.h"


### PR DESCRIPTION
using only px4_getopt() and never the unsafe getopt()
using only <px4_getopt.h> as include, cleanup related includes
added check that all the option are valid (myoptind >= argc). if there are invalid options on some script that might now lead not to run commands. this should be tested somehow...

related to several issues:
fmu_v5 NSH some commands force an instant reboot #9532
various getopt & argc index check fixes #9589
l3gd20: add argc check and use px4_getopt #9647
