### PR TITLE
re-word Preflight Fail msg for consistency

### DIFF
--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -555,7 +555,7 @@ static bool ekf2Check(orb_advert_t *mavlink_log_pub, vehicle_status_s &vehicle_s
 
 	if (status.pos_test_ratio > test_limit) {
 		if (report_fail) {
-			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Horizontal estimate Pos Error");
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Horizontal position estimate Error");
 		}
 
 		success = false;


### PR DESCRIPTION
changed: "Preflight Fail: Horizontal estimate Pos Error"
to: "Preflight Fail: Horizontal position estimate Error"
