### PR TITLE
[WIP] Fx79 Frame: Reverse aileron outputs

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/3000_generic_wing
+++ b/ROMFS/px4fmu_common/init.d/airframes/3000_generic_wing
@@ -5,6 +5,14 @@
 # @type Flying Wing
 # @class Plane
 #
+# @output MAIN1 left aileron
+# @output MAIN2 right aileron
+# @output MAIN4 throttle
+#
+# @output AUX1 feed-through of RC AUX1 channel
+# @output AUX2 feed-through of RC AUX2 channel
+# @output AUX3 feed-through of RC AUX3 channel
+#
 # @maintainer
 #
 

--- a/ROMFS/px4fmu_common/init.d/airframes/3034_fx79
+++ b/ROMFS/px4fmu_common/init.d/airframes/3034_fx79
@@ -9,6 +9,10 @@
 # @output MAIN2 left aileron
 # @output MAIN4 throttle
 #
+# @output AUX1 feed-through of RC AUX1 channel
+# @output AUX2 feed-through of RC AUX2 channel
+# @output AUX3 feed-through of RC AUX3 channel
+#
 # @maintainer Simon Wilks <simon@uaventure.com>
 #
 

--- a/ROMFS/px4fmu_common/init.d/airframes/3034_fx79
+++ b/ROMFS/px4fmu_common/init.d/airframes/3034_fx79
@@ -5,6 +5,10 @@
 # @type Flying Wing
 # @class Plane
 #
+# @output MAIN1 right aileron
+# @output MAIN2 left aileron
+# @output MAIN4 throttle
+#
 # @maintainer Simon Wilks <simon@uaventure.com>
 #
 

--- a/ROMFS/px4fmu_common/init.d/airframes/3035_viper
+++ b/ROMFS/px4fmu_common/init.d/airframes/3035_viper
@@ -5,6 +5,14 @@
 # @type Flying Wing
 # @class Plane
 #
+# @output MAIN1 left aileron
+# @output MAIN2 right aileron
+# @output MAIN4 throttle
+#
+# @output AUX1 feed-through of RC AUX1 channel
+# @output AUX2 feed-through of RC AUX2 channel
+# @output AUX3 feed-through of RC AUX3 channel
+#
 # @maintainer Simon Wilks <simon@uaventure.com>
 #
 

--- a/ROMFS/px4fmu_common/init.d/airframes/3100_tbs_caipirinha
+++ b/ROMFS/px4fmu_common/init.d/airframes/3100_tbs_caipirinha
@@ -5,6 +5,14 @@
 # @type Flying Wing
 # @class Plane
 #
+# @output MAIN1 left aileron
+# @output MAIN2 right aileron
+# @output MAIN4 throttle
+#
+# @output AUX1 feed-through of RC AUX1 channel
+# @output AUX2 feed-through of RC AUX2 channel
+# @output AUX3 feed-through of RC AUX3 channel
+#
 # @maintainer Lorenz Meier <lorenz@px4.io>
 #
 


### PR DESCRIPTION
[FX-79 Buffalo Flying Wing](https://dev.px4.io/master/en/airframes/airframe_reference.html#plane_flying_wing_fx-79_buffalo_flying_wing) as shown below had reversed MAIN 1/2 (it has its own mixer)

![image](https://user-images.githubusercontent.com/5368500/52929502-c3879900-3398-11e9-97a9-6e022b5ffbdf.png)

@bkueng This modification does the correct thing for the Buffalo and some of the other cases, but as you can see it gets some wrong - ie the other ones below that are empty of MAIN outputs now. 
Also, I had to add the thruster MAIN option to the init file, and I would have expected this would be fetched from the default configuration if I did not define it.

Have I done it wrong, or is the toolchain misbehaving?

![image](https://user-images.githubusercontent.com/5368500/52929680-8243b900-3399-11e9-8342-95f1130d023f.png)

