### PR TITLE
Reintroduce slow takeoff and landing

### DIFF
--- a/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.cpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.cpp
@@ -136,7 +136,7 @@ void FlightTaskAutoMapper2::_prepareTakeoffSetpoints()
 {
 	// Takeoff is completely defined by target position
 	_position_setpoint = _target;
-	const float speed_tko = (_alt_above_ground > MPC_LAND_ALT1.get()) ? _constraints.speed_up : MPC_TKO_SPEED.get();
+	const float speed_tko = (_alt_above_ground > MPC_LAND_ALT2.get()) ? _constraints.speed_up : MPC_TKO_SPEED.get();
 	_velocity_setpoint = Vector3f(NAN, NAN, -speed_tko); // Limit the maximum vertical speed
 
 	_gear.landing_gear = landing_gear_s::GEAR_DOWN;

--- a/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
@@ -54,6 +54,7 @@ protected:
 	void _updateHeadingSetpoints(); /**< sets yaw or yaw speed */
 	virtual void _updateSetpoints(); /**< updates all setpoints */
 	virtual void _scaleSticks(); /**< scales sticks to velocity in z */
+	void _updateConstraints(); /**< update dynamic constraints */
 
 	/**
 	 * rotates vector into local frame
@@ -73,7 +74,11 @@ protected:
 					(ParamFloat<px4::params::MPC_HOLD_MAX_XY>) MPC_HOLD_MAX_XY,
 					(ParamFloat<px4::params::MPC_Z_P>) MPC_Z_P, /**< position controller altitude propotional gain */
 					(ParamFloat<px4::params::MPC_MAN_Y_MAX>) MPC_MAN_Y_MAX, /**< scaling factor from stick to yaw rate */
-					(ParamFloat<px4::params::MPC_MAN_TILT_MAX>) MPC_MAN_TILT_MAX /**< maximum tilt allowed for manual flight */
+					(ParamFloat<px4::params::MPC_MAN_TILT_MAX>) MPC_MAN_TILT_MAX, /**< maximum tilt allowed for manual flight */
+					(ParamFloat<px4::params::MPC_LAND_ALT1>) MPC_LAND_ALT1,
+					(ParamFloat<px4::params::MPC_LAND_ALT2>) MPC_LAND_ALT2,
+					(ParamFloat<px4::params::MPC_LAND_SPEED>) MPC_LAND_SPEED,
+					(ParamFloat<px4::params::MPC_TKO_SPEED>) MPC_TKO_SPEED
 				       )
 private:
 	/**

--- a/src/modules/mc_pos_control/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl.cpp
@@ -225,7 +225,7 @@ void PositionControl::_positionController()
 	_vel_sp(0) = vel_sp_xy(0);
 	_vel_sp(1) = vel_sp_xy(1);
 	// Constrain velocity in z-direction.
-	_vel_sp(2) = math::constrain(_vel_sp(2), -_constraints.speed_up, _constraints.speed_down);
+	_vel_sp(2) = math::constrain(_vel_sp(2), -MPC_Z_VEL_MAX_UP.get(), MPC_Z_VEL_MAX_DN.get());
 }
 
 void PositionControl::_velocityController(const float &dt)
@@ -330,18 +330,6 @@ void PositionControl::updateConstraints(const vehicle_constraints_s &constraints
 	if (!PX4_ISFINITE(constraints.tilt)
 	    || !(constraints.tilt < math::max(MPC_TILTMAX_AIR_rad.get(), MPC_MAN_TILT_MAX_rad.get()))) {
 		_constraints.tilt = math::max(MPC_TILTMAX_AIR_rad.get(), MPC_MAN_TILT_MAX_rad.get());
-	}
-
-	if (!PX4_ISFINITE(constraints.speed_up) || !(constraints.speed_up < MPC_Z_VEL_MAX_UP.get())) {
-		_constraints.speed_up = MPC_Z_VEL_MAX_UP.get();
-	}
-
-	if (!PX4_ISFINITE(constraints.speed_down) || !(constraints.speed_down < MPC_Z_VEL_MAX_DN.get())) {
-		_constraints.speed_down = MPC_Z_VEL_MAX_DN.get();
-	}
-
-	if (!PX4_ISFINITE(constraints.speed_xy) || !(constraints.speed_xy < MPC_XY_VEL_MAX.get())) {
-		_constraints.speed_xy = MPC_XY_VEL_MAX.get();
 	}
 }
 


### PR DESCRIPTION
fixes #10659 

Landing should be done full stick down but at the moment, this can result in hard landing since the drone will descend at `MPC_Z_VEL_MAX_DN` speed. In auto modes, the drone already uses the `MPC_LAND_SPEED` to perform slow  landings and this logic also worked for manual control in the past.
This PR is an attempt to reintroduce the desired behavior in a simple way.

Tests were only performed in SITL with the following parameters:
```
MPC_LAND_ALT1 = MPC_LAND_ALT2 = 5 m
MPC_LAND_SPEED = 0.5 m/s
MPC_TKO_SPEED = 1.5 m/s
MPC_Z_VEL_MAX_DN = 1.0 m/s
MPC_Z_VEL_MAX_UP = 3.0 m/s
```

**Manual altitude:**
![manualaltitude](https://user-images.githubusercontent.com/14822839/52964990-04d17600-33a4-11e9-9d89-6d0e6be91748.png)
Log: https://logs.px4.io/plot_app?log=749f7de3-32b8-4280-87eb-c77012098ae1

**Default smooth position control:**
![alt12_smoothpos](https://user-images.githubusercontent.com/14822839/52965064-3ba78c00-33a4-11e9-85a6-deeafeab2f04.png)
Log: https://logs.px4.io/plot_app?log=ea85ed04-e926-4793-bc0d-d6ddaea7418f

**Smooth velocity position control:**
![alt12_manualsmoothvel](https://user-images.githubusercontent.com/14822839/52965162-790c1980-33a4-11e9-91e9-681e9b20611a.png)

Log: https://logs.px4.io/plot_app?log=b7dcd2f4-5b2c-4511-b003-678eeae45e2d

@Stifael @MaEtUgR 
This PR is on draft since it breaks the "Smooth takeoff" logic because of the line change in `PositionControl.cpp`:
``` c++
_vel_sp(2) = math::constrain(_vel_sp(2), -_constraints.speed_up, _constraints.speed_down);
=> _vel_sp(2) = math::constrain(_vel_sp(2), -MPC_Z_VEL_MAX_UP.get(), MPC_Z_VEL_MAX_DN.get());
```

Can we discuss here or during the devcall how we can restore the smooth takeoff logic without constraining the velocity setpoint here?