### PR TITLE
Rename MB12XX_MAX_RANGEFINDERS to RANGE_FINDER_MAX_SENSORS.

### DIFF
--- a/src/drivers/distance_sensor/mb12xx/mb12xx.cpp
+++ b/src/drivers/distance_sensor/mb12xx/mb12xx.cpp
@@ -131,7 +131,7 @@ private:
 	uint8_t				_cycle_counter;	/* counter in cycle to change i2c adresses */
 	int					_cycling_rate;	/* */
 	uint8_t				_index_counter;	/* temporary sonar i2c address */
-	px4::Array<uint8_t, MB12XX_MAX_RANGEFINDERS>	addr_ind; 	/* temp sonar i2c address vector */
+	px4::Array<uint8_t, RANGE_FINDER_MAX_SENSORS>	addr_ind; 	/* temp sonar i2c address vector */
 
 	/**
 	* Test whether the device supported by the driver is present at a
@@ -266,7 +266,7 @@ MB12XX::init()
 	/* check for connected rangefinders on each i2c port:
 	   We start from i2c base address (0x70 = 112) and count downwards
 	   So second iteration it uses i2c address 111, third iteration 110 and so on*/
-	for (unsigned counter = 0; counter <= MB12XX_MAX_RANGEFINDERS; counter++) {
+	for (unsigned counter = 0; counter <= RANGE_FINDER_MAX_SENSORS; counter++) {
 		_index_counter = MB12XX_BASEADDR - counter;	/* set temp sonar i2c address to base adress - counter */
 		set_device_address(_index_counter);			/* set I2c port to temp sonar i2c adress */
 		int ret2 = measure();

--- a/src/drivers/distance_sensor/srf02/srf02.cpp
+++ b/src/drivers/distance_sensor/srf02/srf02.cpp
@@ -131,7 +131,7 @@ private:
 	uint8_t				_cycle_counter;	/* counter in cycle to change i2c adresses */
 	int					_cycling_rate;	/* */
 	uint8_t				_index_counter;	/* temporary sonar i2c address */
-	px4::Array<uint8_t, MB12XX_MAX_RANGEFINDERS>	addr_ind; 	/* temp sonar i2c address vector */
+	px4::Array<uint8_t, RANGE_FINDER_MAX_SENSORS>	addr_ind; 	/* temp sonar i2c address vector */
 
 	/**
 	* Test whether the device supported by the driver is present at a
@@ -266,7 +266,7 @@ SRF02::init()
 	/* check for connected rangefinders on each i2c port:
 	   We start from i2c base address (0x70 = 112) and count downwards
 	   So second iteration it uses i2c address 111, third iteration 110 and so on*/
-	for (unsigned counter = 0; counter <= MB12XX_MAX_RANGEFINDERS; counter++) {
+	for (unsigned counter = 0; counter <= RANGE_FINDER_MAX_SENSORS; counter++) {
 		_index_counter = SRF02_BASEADDR - counter;	/* set temp sonar i2c address to base adress - counter */
 		set_device_address(_index_counter);			/* set I2c port to temp sonar i2c adress */
 		int ret2 = measure();

--- a/src/drivers/drv_range_finder.h
+++ b/src/drivers/drv_range_finder.h
@@ -46,6 +46,6 @@
 
 #define RANGE_FINDER_BASE_DEVICE_PATH	"/dev/range_finder"
 #define RANGE_FINDER0_DEVICE_PATH	"/dev/range_finder0"
-#define MB12XX_MAX_RANGEFINDERS	12	// Maximum number of Maxbotix sensors on bus
+#define RANGE_FINDER_MAX_SENSORS	12	// Maximum number of sensors on bus
 
 #endif /* _DRV_RANGEFINDER_H */


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
The `#define MB12XX_MAX_RANGEFINDERS` was being used by the srf02 driver as well.  This PR gives a more generic name not tied specifically to the mb12xx sensors.

**Describe possible alternatives**
Alternatively, we could move `#define MB12XX_MAX_RANGEFINDERS ` into mb12xx.cpp and create a unique `#define` in `srf02.cpp`. 

Let me know if the alternative if preferable.

-Mark
