### PR TITLE
[WIP] uORB: add px4 work queue call back mechanism on publish

### DIFF
--- a/.ci/Jenkinsfile-compile
+++ b/.ci/Jenkinsfile-compile
@@ -43,7 +43,7 @@ pipeline {
           ]
 
           def nuttx_builds_other = [
-            target: ["px4_cannode-v1_default", "px4_esc-v1_default", "thiemar_s2740vc-v1_default"],
+            target: ["px4_esc-v1_default", "thiemar_s2740vc-v1_default"],
             image: docker_images.nuttx,
             archive: false
           ]

--- a/platforms/nuttx/src/px4_layer/px4_init.cpp
+++ b/platforms/nuttx/src/px4_layer/px4_init.cpp
@@ -37,6 +37,7 @@
 #include <px4_defines.h>
 #include <drivers/drv_hrt.h>
 #include <lib/parameters/param.h>
+#include <px4_work_queue/WorkQueueManager.hpp>
 #include <systemlib/cpuload.h>
 
 #include <fcntl.h>
@@ -103,6 +104,8 @@ int px4_platform_init(void)
 #ifdef CONFIG_SCHED_INSTRUMENTATION
 	cpuload_initialize_once();
 #endif
+
+	px4::work_queue_manager_start();
 
 	return PX4_OK;
 }

--- a/platforms/posix/src/px4_layer/CMakeLists.txt
+++ b/platforms/posix/src/px4_layer/CMakeLists.txt
@@ -54,7 +54,7 @@ add_library(px4_layer
 	${SHMEM_SRCS}
 )
 target_compile_definitions(px4_layer PRIVATE MODULE_NAME="px4")
-target_link_libraries(px4_layer PRIVATE work_queue)
+target_link_libraries(px4_layer PRIVATE work_queue px4_work_queue)
 target_link_libraries(px4_layer PRIVATE px4_daemon)
 
 if(ENABLE_LOCKSTEP_SCHEDULER)

--- a/platforms/posix/src/px4_layer/px4_init.cpp
+++ b/platforms/posix/src/px4_layer/px4_init.cpp
@@ -37,12 +37,15 @@
 #include <px4_defines.h>
 #include <drivers/drv_hrt.h>
 #include <lib/parameters/param.h>
+#include <px4_work_queue/WorkQueueManager.hpp>
 
 int px4_platform_init(void)
 {
 	hrt_init();
 
 	param_init();
+
+	px4::work_queue_manager_start();
 
 	return PX4_OK;
 }

--- a/platforms/qurt/src/px4_layer/px4_init.cpp
+++ b/platforms/qurt/src/px4_layer/px4_init.cpp
@@ -37,12 +37,15 @@
 #include <px4_defines.h>
 #include <drivers/drv_hrt.h>
 #include <lib/parameters/param.h>
+#include <px4_work_queue/WorkQueueManager.hpp>
 
 int px4_platform_init(void)
 {
 	hrt_init();
 
 	param_init();
+
+	px4::work_queue_manager_start();
 
 	return PX4_OK;
 }

--- a/posix-configs/SITL/init/test/cmd_template.in
+++ b/posix-configs/SITL/init/test/cmd_template.in
@@ -25,7 +25,7 @@ mavlink start -x -u 14556 -r 2000000
 mavlink boot_complete
 
 @cmd_name@ start
-sleep 1
+sleep 3
 @cmd_name@ start
 sleep 1
 @cmd_name@ stop

--- a/src/drivers/barometer/ms5611/CMakeLists.txt
+++ b/src/drivers/barometer/ms5611/CMakeLists.txt
@@ -30,18 +30,15 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
-set(srcs
-	ms5611_spi.cpp
-	ms5611_i2c.cpp
-	ms5611.cpp
-)
 
 px4_add_module(
 	MODULE drivers__ms5611
 	MAIN ms5611
 	STACK_MAIN 1500
-	COMPILE_FLAGS
-	SRCS ${srcs}
+	SRCS
+		ms5611_spi.cpp
+		ms5611_i2c.cpp
+		ms5611.cpp
 	DEPENDS
+		px4_work_queue
 	)
-

--- a/src/drivers/barometer/ms5611/ms5611.cpp
+++ b/src/drivers/barometer/ms5611/ms5611.cpp
@@ -33,7 +33,7 @@
 
 /**
  * @file ms5611.cpp
- * Driver for the MS5611 and MS6507 barometric pressure sensor connected via I2C or SPI.
+ * Driver for the MS5611 and MS5607 barometric pressure sensor connected via I2C or SPI.
  */
 
 #include <px4_config.h>
@@ -51,21 +51,16 @@
 #include <math.h>
 #include <unistd.h>
 
-#include <nuttx/arch.h>
-#include <nuttx/wqueue.h>
-#include <nuttx/clock.h>
-
-#include <arch/board/board.h>
 #include <board_config.h>
 
 #include <drivers/device/device.h>
 #include <drivers/drv_baro.h>
 #include <drivers/drv_hrt.h>
 #include <drivers/device/ringbuffer.h>
-
-#include <perf/perf_counter.h>
+#include <lib/perf/perf_counter.h>
 #include <systemlib/err.h>
 #include <platforms/px4_getopt.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 #include "ms5611.h"
 
@@ -82,10 +77,6 @@ enum MS5611_BUS {
 	MS5611_BUS_SPI_INTERNAL,
 	MS5611_BUS_SPI_EXTERNAL
 };
-
-#ifndef CONFIG_SCHED_WORKQUEUE
-# error This requires CONFIG_SCHED_WORKQUEUE.
-#endif
 
 /* helper macro for handling report buffer indices */
 #define INCREMENT(_x, _lim)	do { __typeof__(_x) _tmp = _x+1; if (_tmp >= _lim) _tmp = 0; _x = _tmp; } while(0)
@@ -126,7 +117,7 @@ enum MS5611_BUS {
 #define MS5611_BARO_DEVICE_PATH_EXT	"/dev/ms5611_ext"
 #define MS5611_BARO_DEVICE_PATH_INT	"/dev/ms5611_int"
 
-class MS5611 : public cdev::CDev
+class MS5611 : public cdev::CDev, public px4::ScheduledWorkItem
 {
 public:
 	MS5611(device::Device *interface, ms5611::prom_u &prom_buf, const char *path, enum MS56XX_DEVICE_TYPES device_type);
@@ -147,8 +138,7 @@ protected:
 
 	ms5611::prom_s		_prom;
 
-	struct work_s		_work {};
-	unsigned		_measure_ticks;
+	unsigned		_measure_interval{0};
 
 	ringbuffer::RingBuffer	*_reports;
 	enum MS56XX_DEVICE_TYPES _device_type;
@@ -178,7 +168,7 @@ protected:
 	 * @note This function is called at open and error time.  It might make sense
 	 *       to make it more aggressive about resetting the bus in case of errors.
 	 */
-	void			start_cycle(unsigned delay_ticks = 1);
+	void			start_cycle();
 
 	/**
 	 * Stop the automatic measurement state machine.
@@ -198,15 +188,7 @@ protected:
 	 * and measurement to provide the most recent measurement possible
 	 * at the next interval.
 	 */
-	void			cycle();
-
-	/**
-	 * Static trampoline from the workq context; because we don't have a
-	 * generic workq wrapper yet.
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		cycle_trampoline(void *arg);
+	void			Run() override;
 
 	/**
 	 * Issue a measurement command for the current state.
@@ -229,9 +211,9 @@ extern "C" __EXPORT int ms5611_main(int argc, char *argv[]);
 MS5611::MS5611(device::Device *interface, ms5611::prom_u &prom_buf, const char *path,
 	       enum MS56XX_DEVICE_TYPES device_type) :
 	CDev(path),
+	ScheduledWorkItem(px4::device_bus_to_wq(interface->get_device_id())),
 	_interface(interface),
 	_prom(prom_buf.s),
-	_measure_ticks(0),
 	_reports(nullptr),
 	_device_type(device_type),
 	_collect_phase(false),
@@ -400,7 +382,7 @@ MS5611::read(struct file *filp, char *buffer, size_t buflen)
 	}
 
 	/* if automatic measurement is enabled */
-	if (_measure_ticks > 0) {
+	if (_measure_interval > 0) {
 
 		/*
 		 * While there is space in the caller's buffer, and reports, copy them.
@@ -474,10 +456,10 @@ MS5611::ioctl(struct file *filp, int cmd, unsigned long arg)
 			/* set default polling rate */
 			case SENSOR_POLLRATE_DEFAULT: {
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
 					/* set interval for next measurement to minimum legal value */
-					_measure_ticks = USEC2TICK(MS5611_CONVERSION_INTERVAL);
+					_measure_interval = MS5611_CONVERSION_INTERVAL;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -490,18 +472,18 @@ MS5611::ioctl(struct file *filp, int cmd, unsigned long arg)
 			/* adjust to a legal polling interval in Hz */
 			default: {
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
-					/* convert hz to tick interval via microseconds */
-					unsigned ticks = USEC2TICK(1000000 / arg);
+					/* convert hz to interval via microseconds */
+					unsigned interval = (1000000 / arg);
 
 					/* check against maximum rate */
-					if (ticks < USEC2TICK(MS5611_CONVERSION_INTERVAL)) {
+					if (_measure_interval < MS5611_CONVERSION_INTERVAL) {
 						return -EINVAL;
 					}
 
 					/* update interval for next measurement */
-					_measure_ticks = ticks;
+					_measure_interval = interval;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -530,34 +512,25 @@ MS5611::ioctl(struct file *filp, int cmd, unsigned long arg)
 }
 
 void
-MS5611::start_cycle(unsigned delay_ticks)
+MS5611::start_cycle()
 {
-
 	/* reset the report ring and state machine */
 	_collect_phase = false;
 	_measure_phase = 0;
 	_reports->flush();
 
 	/* schedule a cycle to start things */
-	work_queue(HPWORK, &_work, (worker_t)&MS5611::cycle_trampoline, this, delay_ticks);
+	ScheduleNow();
 }
 
 void
 MS5611::stop_cycle()
 {
-	work_cancel(HPWORK, &_work);
+	ScheduleClear();
 }
 
 void
-MS5611::cycle_trampoline(void *arg)
-{
-	MS5611 *dev = reinterpret_cast<MS5611 *>(arg);
-
-	dev->cycle();
-}
-
-void
-MS5611::cycle()
+MS5611::Run()
 {
 	int ret;
 	unsigned dummy;
@@ -585,7 +558,7 @@ MS5611::cycle()
 			 * to wait 2.8 ms after issuing the sensor reset command
 			 * according to the MS5611 datasheet
 			 */
-			start_cycle(USEC2TICK(2800));
+			ScheduleDelayed(2800);
 			return;
 		}
 
@@ -598,14 +571,10 @@ MS5611::cycle()
 		 * doing pressure measurements at something close to the desired rate.
 		 */
 		if ((_measure_phase != 0) &&
-		    (_measure_ticks > USEC2TICK(MS5611_CONVERSION_INTERVAL))) {
+		    (_measure_interval > MS5611_CONVERSION_INTERVAL)) {
 
 			/* schedule a fresh cycle call when we are ready to measure again */
-			work_queue(HPWORK,
-				   &_work,
-				   (worker_t)&MS5611::cycle_trampoline,
-				   this,
-				   _measure_ticks - USEC2TICK(MS5611_CONVERSION_INTERVAL));
+			ScheduleDelayed(_measure_interval - MS5611_CONVERSION_INTERVAL);
 
 			return;
 		}
@@ -626,11 +595,7 @@ MS5611::cycle()
 	_collect_phase = true;
 
 	/* schedule a fresh cycle call when the measurement is done */
-	work_queue(HPWORK,
-		   &_work,
-		   (worker_t)&MS5611::cycle_trampoline,
-		   this,
-		   USEC2TICK(MS5611_CONVERSION_INTERVAL));
+	ScheduleDelayed(MS5611_CONVERSION_INTERVAL);
 }
 
 int
@@ -788,7 +753,7 @@ MS5611::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	printf("poll interval:  %u ticks\n", _measure_ticks);
+	printf("poll interval:  %u\n", _measure_interval);
 	_reports->print_info("report queue");
 	printf("device:         %s\n", _device_type == MS5611_DEVICE ? "ms5611" : "ms5607");
 

--- a/src/drivers/imu/bma180/bma180.cpp
+++ b/src/drivers/imu/bma180/bma180.cpp
@@ -66,6 +66,7 @@
 #include <drivers/device/spi.h>
 #include <drivers/drv_accel.h>
 #include <drivers/device/ringbuffer.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 #define ACCEL_DEVICE_PATH	"/dev/bma180"
 
@@ -121,7 +122,7 @@
 
 extern "C" { __EXPORT int bma180_main(int argc, char *argv[]); }
 
-class BMA180 : public device::SPI
+class BMA180 : public device::SPI, public px4::ScheduledWorkItem
 {
 public:
 	BMA180(int bus, uint32_t device);
@@ -142,7 +143,6 @@ protected:
 
 private:
 
-	struct hrt_call		_call;
 	unsigned		_call_interval;
 
 	ringbuffer::RingBuffer		*_reports;
@@ -168,16 +168,7 @@ private:
 	 */
 	void			stop();
 
-	/**
-	 * Static trampoline from the hrt_call context; because we don't have a
-	 * generic hrt wrapper yet.
-	 *
-	 * Called by the HRT in interrupt context at the specified rate if
-	 * automatic polling is enabled.
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		measure_trampoline(void *arg);
+	void		Run() override;
 
 	/**
 	 * Fetch measurements from the sensor and update the report ring.
@@ -232,6 +223,7 @@ private:
 
 BMA180::BMA180(int bus, uint32_t device) :
 	SPI("BMA180", ACCEL_DEVICE_PATH, bus, device, SPIDEV_MODE3, 8000000),
+	ScheduledWorkItem(px4::device_bus_to_wq(this->get_device_id())),
 	_call_interval(0),
 	_reports(nullptr),
 	_accel_range_scale(0.0f),
@@ -423,10 +415,6 @@ BMA180::ioctl(struct file *filp, int cmd, unsigned long arg)
 						return -EINVAL;
 					}
 
-					/* update interval for next measurement */
-					/* XXX this is a bit shady, but no other way to adjust... */
-					_call.period = _call_interval = ticks;
-
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
 						start();
@@ -598,22 +586,20 @@ BMA180::start()
 	_reports->flush();
 
 	/* start polling at the specified rate */
-	hrt_call_every(&_call, 1000, _call_interval, (hrt_callout)&BMA180::measure_trampoline, this);
+	ScheduleOnInterval(_call_interval, 10000);
 }
 
 void
 BMA180::stop()
 {
-	hrt_cancel(&_call);
+	ScheduleClear();
 }
 
 void
-BMA180::measure_trampoline(void *arg)
+BMA180::Run()
 {
-	BMA180 *dev = (BMA180 *)arg;
-
 	/* make another measurement */
-	dev->measure();
+	measure();
 }
 
 void

--- a/src/drivers/imu/bmi055/BMI055.hpp
+++ b/src/drivers/imu/bmi055/BMI055.hpp
@@ -41,6 +41,7 @@
 #include <px4_config.h>
 #include <systemlib/conversions.h>
 #include <systemlib/err.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 #define DIR_READ                0x80
 #define DIR_WRITE               0x00
@@ -59,7 +60,6 @@ protected:
 
 	uint8_t         _whoami;    /** whoami result */
 
-	struct hrt_call     _call;
 	unsigned        _call_interval;
 
 	unsigned        _dlpf_freq;

--- a/src/drivers/imu/bmi055/BMI055_accel.cpp
+++ b/src/drivers/imu/bmi055/BMI055_accel.cpp
@@ -48,6 +48,7 @@ const uint8_t BMI055_accel::_checked_registers[BMI055_ACCEL_NUM_CHECKED_REGISTER
 
 BMI055_accel::BMI055_accel(int bus, const char *path_accel, uint32_t device, enum Rotation rotation) :
 	BMI055("BMI055_ACCEL", path_accel, bus, device, SPIDEV_MODE3, BMI055_BUS_SPEED, rotation),
+	ScheduledWorkItem(px4::device_bus_to_wq(this->get_device_id())),
 	_sample_perf(perf_alloc(PC_ELAPSED, "bmi055_accel_read")),
 	_measure_interval(perf_alloc(PC_INTERVAL, "bmi055_accel_measure_interval")),
 	_bad_transfers(perf_alloc(PC_COUNT, "bmi055_accel_bad_transfers")),
@@ -77,8 +78,6 @@ BMI055_accel::BMI055_accel(int bus, const char *path_accel, uint32_t device, enu
 	_accel_scale.y_scale  = 1.0f;
 	_accel_scale.z_offset = 0;
 	_accel_scale.z_scale  = 1.0f;
-
-	memset(&_call, 0, sizeof(_call));
 }
 
 BMI055_accel::~BMI055_accel()
@@ -369,7 +368,6 @@ BMI055_accel::ioctl(struct file *filp, int cmd, unsigned long arg)
 					  them. This prevents aliasing due to a beat between the
 					  stm32 clock and the bmi055 clock
 					 */
-					_call.period = _call_interval - BMI055_TIMER_REDUCTION;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -479,26 +477,22 @@ BMI055_accel::start()
 	_accel_reports->flush();
 
 	/* start polling at the specified rate */
-	hrt_call_every(&_call,
-		       1000,
-		       _call_interval - BMI055_TIMER_REDUCTION,
-		       (hrt_callout)&BMI055_accel::measure_trampoline, this);
+	ScheduleOnInterval(_call_interval - BMI055_TIMER_REDUCTION, 10000);
+
 	reset();
 }
 
 void
 BMI055_accel::stop()
 {
-	hrt_cancel(&_call);
+	ScheduleClear();
 }
 
 void
-BMI055_accel::measure_trampoline(void *arg)
+BMI055_accel::Run()
 {
-	BMI055_accel *dev = reinterpret_cast<BMI055_accel *>(arg);
-
 	/* make another measurement */
-	dev->measure();
+	measure();
 }
 
 void

--- a/src/drivers/imu/bmi055/BMI055_accel.hpp
+++ b/src/drivers/imu/bmi055/BMI055_accel.hpp
@@ -148,7 +148,7 @@
 /* Mask definitions for ACCD_X_LSB, ACCD_Y_LSB and ACCD_Z_LSB Register */
 #define BMI055_NEW_DATA_MASK                 0x01
 
-class BMI055_accel : public BMI055
+class BMI055_accel : public BMI055, public px4::ScheduledWorkItem
 {
 public:
 	BMI055_accel(int bus, const char *path_accel, uint32_t device, enum Rotation rotation);
@@ -229,16 +229,7 @@ private:
 	 */
 	int         reset();
 
-	/**
-	 * Static trampoline from the hrt_call context; because we don't have a
-	 * generic hrt wrapper yet.
-	 *
-	 * Called by the HRT in interrupt context at the specified rate if
-	 * automatic polling is enabled.
-	 *
-	 * @param arg       Instance pointer for the driver that is polling.
-	 */
-	static void     measure_trampoline(void *arg);
+	void     Run() override;
 
 	/**
 	 * Fetch measurements from the sensor and update the report buffers.

--- a/src/drivers/imu/bmi055/BMI055_gyro.cpp
+++ b/src/drivers/imu/bmi055/BMI055_gyro.cpp
@@ -49,6 +49,7 @@ const uint8_t BMI055_gyro::_checked_registers[BMI055_GYRO_NUM_CHECKED_REGISTERS]
 
 BMI055_gyro::BMI055_gyro(int bus, const char *path_gyro, uint32_t device, enum Rotation rotation) :
 	BMI055("BMI055_GYRO", path_gyro, bus, device, SPIDEV_MODE3, BMI055_BUS_SPEED, rotation),
+	ScheduledWorkItem(px4::device_bus_to_wq(this->get_device_id())),
 	_sample_perf(perf_alloc(PC_ELAPSED, "bmi055_gyro_read")),
 	_measure_interval(perf_alloc(PC_INTERVAL, "bmi055_gyro_measure_interval")),
 	_bad_transfers(perf_alloc(PC_COUNT, "bmi055_gyro_bad_transfers")),
@@ -76,8 +77,6 @@ BMI055_gyro::BMI055_gyro(int bus, const char *path_gyro, uint32_t device, enum R
 	_gyro_scale.y_scale  = 1.0f;
 	_gyro_scale.z_offset = 0;
 	_gyro_scale.z_scale  = 1.0f;
-
-	memset(&_call, 0, sizeof(_call));
 }
 
 BMI055_gyro::~BMI055_gyro()
@@ -347,14 +346,6 @@ BMI055_gyro::ioctl(struct file *filp, int cmd, unsigned long arg)
 					/* update interval for next measurement */
 					_call_interval = ticks;
 
-					/*
-					  set call interval faster than the sample time. We
-					  then detect when we have duplicate samples and reject
-					  them. This prevents aliasing due to a beat between the
-					  stm32 clock and the bmi055 clock
-					 */
-					_call.period = _call_interval - BMI055_TIMER_REDUCTION;
-
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
 						start();
@@ -459,26 +450,22 @@ BMI055_gyro::start()
 	_gyro_reports->flush();
 
 	/* start polling at the specified rate */
-	hrt_call_every(&_call,
-		       1000,
-		       _call_interval - BMI055_TIMER_REDUCTION,
-		       (hrt_callout)&BMI055_gyro::measure_trampoline, this);
+	ScheduleOnInterval(_call_interval - BMI055_TIMER_REDUCTION, 10000);
+
 	reset();
 }
 
 void
 BMI055_gyro::stop()
 {
-	hrt_cancel(&_call);
+	ScheduleClear();
 }
 
 void
-BMI055_gyro::measure_trampoline(void *arg)
+BMI055_gyro::Run()
 {
-	BMI055_gyro *dev = reinterpret_cast<BMI055_gyro *>(arg);
-
 	/* make another measurement */
-	dev->measure();
+	measure();
 }
 
 void

--- a/src/drivers/imu/bmi055/BMI055_gyro.hpp
+++ b/src/drivers/imu/bmi055/BMI055_gyro.hpp
@@ -140,7 +140,7 @@
 
 #define BMI055_ACC_TEMP             0x08
 
-class BMI055_gyro : public BMI055
+class BMI055_gyro : public BMI055, public px4::ScheduledWorkItem
 {
 public:
 	BMI055_gyro(int bus, const char *path_gyro, uint32_t device, enum Rotation rotation);
@@ -218,16 +218,7 @@ private:
 	 */
 	int         reset();
 
-	/**
-	 * Static trampoline from the hrt_call context; because we don't have a
-	 * generic hrt wrapper yet.
-	 *
-	 * Called by the HRT in interrupt context at the specified rate if
-	 * automatic polling is enabled.
-	 *
-	 * @param arg       Instance pointer for the driver that is polling.
-	 */
-	static void     measure_trampoline(void *arg);
+	void     Run() override;
 
 	/**
 	 * Fetch measurements from the sensor and update the report buffers.

--- a/src/drivers/imu/bmi055/bmi055_main.cpp
+++ b/src/drivers/imu/bmi055/bmi055_main.cpp
@@ -446,7 +446,6 @@ BMI055::BMI055(const char *name, const char *devname, int bus, uint32_t device, 
 	       uint32_t frequency, enum Rotation rotation):
 	SPI(name, devname, bus, device, mode, frequency),
 	_whoami(0),
-	_call{},
 	_call_interval(0),
 	_dlpf_freq(0),
 	_register_wait(0),

--- a/src/drivers/imu/fxas21002c/fxas21002c.cpp
+++ b/src/drivers/imu/fxas21002c/fxas21002c.cpp
@@ -74,6 +74,7 @@
 #include <lib/conversion/rotation.h>
 #include <platforms/px4_getopt.h>
 #include <systemlib/err.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 /* SPI protocol address bits */
 #define DIR_READ(a)                     ((a) | (1 << 7))
@@ -222,7 +223,7 @@
 
 extern "C" { __EXPORT int fxas21002c_main(int argc, char *argv[]); }
 
-class FXAS21002C : public device::SPI
+class FXAS21002C : public device::SPI, public px4::ScheduledWorkItem
 {
 public:
 	FXAS21002C(int bus, const char *path, uint32_t device, enum Rotation rotation);
@@ -252,8 +253,6 @@ protected:
 	virtual int probe();
 
 private:
-
-	struct hrt_call _gyro_call;
 
 	unsigned _call_interval;
 
@@ -325,16 +324,7 @@ private:
 	 */
 	void set_standby(int rate, bool standby_true);
 
-	/**
-	 * Static trampoline from the hrt_call context; because we don't have a
-	 * generic hrt wrapper yet.
-	 *
-	 * Called by the HRT in interrupt context at the specified rate if
-	 * automatic polling is enabled.
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void measure_trampoline(void *arg);
+	void Run() override;
 
 	/**
 	 * check key registers for correct values
@@ -442,9 +432,8 @@ const uint8_t FXAS21002C::_checked_registers[FXAS21002C_NUM_CHECKED_REGISTERS] =
 
 
 FXAS21002C::FXAS21002C(int bus, const char *path, uint32_t device, enum Rotation rotation) :
-	SPI("FXAS21002C", path, bus, device, SPIDEV_MODE0,
-	    2 * 1000 * 1000),
-	_gyro_call{},
+	SPI("FXAS21002C", path, bus, device, SPIDEV_MODE0, 2 * 1000 * 1000),
+	ScheduledWorkItem(px4::device_bus_to_wq(this->get_device_id())),
 	_call_interval(0),
 	_reports(nullptr),
 	_gyro_scale{},
@@ -681,8 +670,6 @@ FXAS21002C::ioctl(struct file *filp, int cmd, unsigned long arg)
 					/* update interval for next measurement */
 					/* XXX this is a bit shady, but no other way to adjust... */
 					_call_interval = ticks;
-
-					_gyro_call.period = _call_interval - FXAS21002C_TIMER_REDUCTION;
 
 					/* adjust filters */
 					float cutoff_freq_hz = _gyro_filter_x.get_cutoff_freq();
@@ -940,16 +927,13 @@ FXAS21002C::start()
 	_reports->flush();
 
 	/* start polling at the specified rate */
-	hrt_call_every(&_gyro_call,
-		       1000,
-		       _call_interval - FXAS21002C_TIMER_REDUCTION,
-		       (hrt_callout)&FXAS21002C::measure_trampoline, this);
+	ScheduleOnInterval(_call_interval - FXAS21002C_TIMER_REDUCTION, 10000);
 }
 
 void
 FXAS21002C::stop()
 {
-	hrt_cancel(&_gyro_call);
+	ScheduleClear();
 
 	/* reset internal states */
 	/* discard unread data in the buffers */
@@ -957,18 +941,15 @@ FXAS21002C::stop()
 }
 
 void
-FXAS21002C::measure_trampoline(void *arg)
+FXAS21002C::Run()
 {
-	FXAS21002C *dev = (FXAS21002C *)arg;
-
 	/* make another measurement */
-	dev->measure();
+	measure();
 }
 
 void
 FXAS21002C::check_registers(void)
 {
-
 	uint8_t v;
 
 	if ((v = read_reg(_checked_registers[_checked_next])) != _checked_values[_checked_next]) {

--- a/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
+++ b/src/drivers/imu/fxos8701cq/fxos8701cq.cpp
@@ -78,6 +78,7 @@
 #include <lib/conversion/rotation.h>
 #include <platforms/px4_getopt.h>
 #include <systemlib/err.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 /* SPI protocol address bits */
 #define DIR_READ(a)                     ((a) & 0x7f)
@@ -159,7 +160,7 @@ extern "C" { __EXPORT int fxos8701cq_main(int argc, char *argv[]); }
 class FXOS8701CQ_mag;
 #endif
 
-class FXOS8701CQ : public device::SPI
+class FXOS8701CQ : public device::SPI, public px4::ScheduledWorkItem
 {
 public:
 	FXOS8701CQ(int bus, const char *path, uint32_t device, enum Rotation rotation);
@@ -197,9 +198,10 @@ protected:
 
 private:
 
+	void Run() override;
+
 #if !defined(BOARD_HAS_NOISY_FXOS8700_MAG)
 	FXOS8701CQ_mag		*_mag;
-	struct hrt_call   _mag_call;
 	unsigned    _call_mag_interval;
 	ringbuffer::RingBuffer    *_mag_reports;
 
@@ -212,9 +214,9 @@ private:
 	int16_t     _last_raw_mag_x;
 	int16_t     _last_raw_mag_y;
 	int16_t     _last_raw_mag_z;
-#endif
 
-	struct hrt_call		_accel_call;
+	hrt_abstime		_mag_last_measure{0};
+#endif
 
 	unsigned		_call_accel_interval;
 
@@ -284,24 +286,6 @@ private:
 	 * disable I2C on the chip
 	 */
 	void			disable_i2c();
-
-	/**
-	 * Static trampoline from the hrt_call context; because we don't have a
-	 * generic hrt wrapper yet.
-	 *
-	 * Called by the HRT in interrupt context at the specified rate if
-	 * automatic polling is enabled.
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		measure_trampoline(void *arg);
-
-	/**
-	 * Static trampoline for the mag because it runs at a lower rate
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		mag_measure_trampoline(void *arg);
 
 	/**
 	 * check key registers for correct values
@@ -456,8 +440,6 @@ private:
 
 	void				measure();
 
-	void				measure_trampoline(void *arg);
-
 	/* this class does not allow copying due to ptr data members */
 	FXOS8701CQ_mag(const FXOS8701CQ_mag &);
 	FXOS8701CQ_mag operator=(const FXOS8701CQ_mag &);
@@ -467,9 +449,9 @@ private:
 FXOS8701CQ::FXOS8701CQ(int bus, const char *path, uint32_t device, enum Rotation rotation) :
 	SPI("FXOS8701CQ", path, bus, device, SPIDEV_MODE0,
 	    1 * 1000 * 1000),
+	ScheduledWorkItem(px4::device_bus_to_wq(get_device_id())),
 #if !defined(BOARD_HAS_NOISY_FXOS8700_MAG)
 	_mag(new FXOS8701CQ_mag(this)),
-	_mag_call{},
 	_call_mag_interval(0),
 	_mag_reports(nullptr),
 	_mag_scale{},
@@ -482,7 +464,6 @@ FXOS8701CQ::FXOS8701CQ(int bus, const char *path, uint32_t device, enum Rotation
 	_last_raw_mag_y(0),
 	_last_raw_mag_z(0),
 #endif
-	_accel_call {},
 	_call_accel_interval(0),
 	_accel_reports(nullptr),
 	_accel_scale{},
@@ -833,8 +814,6 @@ FXOS8701CQ::ioctl(struct file *filp, int cmd, unsigned long arg)
 					/* XXX this is a bit shady, but no other way to adjust... */
 					_call_accel_interval = ticks;
 
-					_accel_call.period = _call_accel_interval - FXOS8701C_TIMER_REDUCTION;
-
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
 						start();
@@ -902,7 +881,7 @@ FXOS8701CQ::mag_ioctl(struct file *filp, int cmd, unsigned long arg)
 
 					/* update interval for next measurement */
 					/* XXX this is a bit shady, but no other way to adjust... */
-					_mag_call.period = _call_mag_interval = ticks;
+					_call_mag_interval = ticks;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -1141,22 +1120,14 @@ FXOS8701CQ::start()
 #endif
 
 	/* start polling at the specified rate */
-	hrt_call_every(&_accel_call,
-		       1000,
-		       _call_accel_interval - FXOS8701C_TIMER_REDUCTION,
-		       (hrt_callout)&FXOS8701CQ::measure_trampoline, this);
-#if !defined(BOARD_HAS_NOISY_FXOS8700_MAG)
-	hrt_call_every(&_mag_call, 1000, _call_mag_interval, (hrt_callout)&FXOS8701CQ::mag_measure_trampoline, this);
-#endif
+	ScheduleOnInterval(_call_accel_interval - FXOS8701C_TIMER_REDUCTION, 10000);
 }
 
 void
 FXOS8701CQ::stop()
 {
-	hrt_cancel(&_accel_call);
-#if !defined(BOARD_HAS_NOISY_FXOS8700_MAG)
-	hrt_cancel(&_mag_call);
-#endif
+	ScheduleClear();
+
 	/* reset internal states */
 	memset(_last_accel, 0, sizeof(_last_accel));
 
@@ -1168,21 +1139,18 @@ FXOS8701CQ::stop()
 }
 
 void
-FXOS8701CQ::measure_trampoline(void *arg)
+FXOS8701CQ::Run()
 {
-	FXOS8701CQ *dev = (FXOS8701CQ *)arg;
-
 	/* make another measurement */
-	dev->measure();
-}
+	measure();
 
-void
-FXOS8701CQ::mag_measure_trampoline(void *arg)
-{
-	FXOS8701CQ *dev = (FXOS8701CQ *)arg;
+#if !defined(BOARD_HAS_NOISY_FXOS8700_MAG)
 
-	/* make another measurement */
-	dev->mag_measure();
+	if (hrt_elapsed_time(&_mag_last_measure) >= _call_mag_interval) {
+		mag_measure();
+	}
+
+#endif
 }
 
 void
@@ -1413,6 +1381,9 @@ FXOS8701CQ::mag_measure()
 	 */
 
 	mag_report.timestamp = hrt_absolute_time();
+
+	_mag_last_measure = mag_report.timestamp;
+
 	mag_report.is_external = external();
 
 	mag_report.x_raw = _last_raw_mag_x;
@@ -1580,11 +1551,6 @@ FXOS8701CQ_mag::measure()
 	_parent->mag_measure();
 }
 
-void
-FXOS8701CQ_mag::measure_trampoline(void *arg)
-{
-	_parent->mag_measure_trampoline(arg);
-}
 #endif
 
 /**

--- a/src/drivers/imu/icm20948/icm20948.cpp
+++ b/src/drivers/imu/icm20948/icm20948.cpp
@@ -98,6 +98,7 @@ ICM20948::ICM20948(device::Device *interface, device::Device *mag_interface, con
 		   const char *path_gyro, const char *path_mag,
 		   enum Rotation rotation,
 		   bool magnetometer_only) :
+	ScheduledWorkItem(px4::device_bus_to_wq(interface->get_device_id())),
 	_interface(interface),
 	_whoami(0),
 	_accel(magnetometer_only ? nullptr : new ICM20948_accel(this, path_accel)),
@@ -105,13 +106,6 @@ ICM20948::ICM20948(device::Device *interface, device::Device *mag_interface, con
 	_mag(new ICM20948_mag(this, mag_interface, path_mag)),
 	_selected_bank(0xFF),	// invalid/improbable bank value, will be set on first read/write
 	_magnetometer_only(magnetometer_only),
-#if defined(USE_I2C)
-	_work {},
-	_use_hrt(false),
-#else
-	_use_hrt(true),
-#endif
-	_call {},
 	_call_interval(0),
 	_accel_reports(nullptr),
 	_accel_scale{},
@@ -239,16 +233,14 @@ ICM20948::init()
 {
 	irqstate_t state;
 
-#if defined(USE_I2C)
-	use_i2c(_interface->get_device_bus_type() == device::Device::DeviceBusType_I2C);
-#endif
-
 	/*
 	 * If the MPU is using I2C we should reduce the sample rate to 200Hz and
 	 * make the integration autoreset faster so that we integrate just one
 	 * sample since the sampling rate is already low.
 	*/
-	if (is_i2c() && !_magnetometer_only) {
+	const bool is_i2c = (_interface->get_device_bus_type() == device::Device::DeviceBusType_I2C);
+
+	if (is_i2c && !_magnetometer_only) {
 		_sample_rate = 200;
 		_accel_int.set_autoreset_interval(1000000 / 1000);
 		_gyro_int.set_autoreset_interval(1000000 / 1000);
@@ -257,7 +249,7 @@ ICM20948::init()
 	int ret = probe();
 
 	if (ret != OK) {
-		PX4_DEBUG("ICM20948 probe failed");
+		PX4_DEBUG("probe failed");
 		return ret;
 	}
 
@@ -457,10 +449,8 @@ int ICM20948::reset_mpu()
 	}
 
 	// Enable I2C bus or Disable I2C bus (recommended on data sheet)
-
-
-	write_checked_reg(MPU_OR_ICM(MPUREG_USER_CTRL, ICMREG_20948_USER_CTRL), is_i2c() ? 0 : BIT_I2C_IF_DIS);
-
+	const bool is_i2c = (_interface->get_device_bus_type() == device::Device::DeviceBusType_I2C);
+	write_checked_reg(ICMREG_20948_USER_CTRL, is_i2c ? 0 : BIT_I2C_IF_DIS);
 
 	// SAMPLE RATE
 	_set_sample_rate(_sample_rate);
@@ -640,14 +630,6 @@ ICM20948::_set_pollrate(unsigned long rate)
 		/* update interval for next measurement */
 		/* XXX this is a bit shady, but no other way to adjust... */
 		_call_interval = ticks;
-
-		/*
-		  set call interval faster than the sample time. We
-		  then detect when we have duplicate samples and reject
-		  them. This prevents aliasing due to a beat between the
-		  stm32 clock and the mpu9250 clock
-		 */
-		_call.period = _call_interval - MPU9250_TIMER_REDUCTION;
 
 		/* if we need to start the poll state machine, do it */
 		if (want_start) {
@@ -955,78 +937,20 @@ ICM20948::start()
 
 	_mag->_mag_reports->flush();
 
-	if (_use_hrt) {
-		/* start polling at the specified rate */
-		hrt_call_every(&_call,
-			       1000,
-			       _call_interval - MPU9250_TIMER_REDUCTION,
-			       (hrt_callout)&ICM20948::measure_trampoline, this);
-
-	} else {
-#ifdef USE_I2C
-		/* schedule a cycle to start things */
-		work_queue(HPWORK, &_work, (worker_t)&ICM20948::cycle_trampoline, this, 1);
-#endif
-	}
-
+	ScheduleOnInterval(_call_interval - MPU9250_TIMER_REDUCTION, 10000);
 }
 
 void
 ICM20948::stop()
 {
-	if (_use_hrt) {
-		hrt_cancel(&_call);
-
-	} else {
-#ifdef USE_I2C
-		work_cancel(HPWORK, &_work);
-#endif
-	}
-}
-
-
-#if defined(USE_I2C)
-void
-ICM20948::cycle_trampoline(void *arg)
-{
-	ICM20948 *dev = (ICM20948 *)arg;
-
-	dev->cycle();
+	ScheduleClear();
 }
 
 void
-ICM20948::cycle()
+ICM20948::Run()
 {
-
-//	int ret = measure();
-
-	measure();
-
-//	if (ret != OK) {
-//		/* issue a reset command to the sensor */
-//		reset();
-//		start();
-//		return;
-//	}
-
-	if (_call_interval != 0) {
-		work_queue(HPWORK,
-			   &_work,
-			   (worker_t)&ICM20948::cycle_trampoline,
-			   this,
-			   USEC2TICK(_call_interval - MPU9250_TIMER_REDUCTION));
-	}
-}
-#endif
-
-
-void
-ICM20948::measure_trampoline(void *arg)
-{
-	ICM20948 *dev = reinterpret_cast<ICM20948 *>(arg);
-
 	/* make another measurement */
-	dev->measure();
+	measure();
 }
 
 void

--- a/src/drivers/imu/l3gd20/l3gd20.cpp
+++ b/src/drivers/imu/l3gd20/l3gd20.cpp
@@ -63,7 +63,6 @@
 #include <nuttx/arch.h>
 #include <nuttx/clock.h>
 
-#include <drivers/drv_hrt.h>
 #include <drivers/device/spi.h>
 #include <drivers/drv_gyro.h>
 #include <drivers/device/ringbuffer.h>
@@ -72,6 +71,7 @@
 #include <board_config.h>
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
 #include <lib/conversion/rotation.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 #define L3GD20_DEVICE_PATH "/dev/l3gd20"
 
@@ -192,7 +192,7 @@
 
 extern "C" { __EXPORT int l3gd20_main(int argc, char *argv[]); }
 
-class L3GD20 : public device::SPI
+class L3GD20 : public device::SPI, public px4::ScheduledWorkItem
 {
 public:
 	L3GD20(int bus, const char *path, uint32_t device, enum Rotation rotation);
@@ -219,7 +219,6 @@ protected:
 
 private:
 
-	struct hrt_call		_call;
 	unsigned		_call_interval;
 
 	ringbuffer::RingBuffer	*_reports;
@@ -282,16 +281,7 @@ private:
 	 */
 	void			disable_i2c();
 
-	/**
-	 * Static trampoline from the hrt_call context; because we don't have a
-	 * generic hrt wrapper yet.
-	 *
-	 * Called by the HRT in interrupt context at the specified rate if
-	 * automatic polling is enabled.
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		measure_trampoline(void *arg);
+	void		Run() override;
 
 	/**
 	 * check key registers for correct values
@@ -395,7 +385,7 @@ const uint8_t L3GD20::_checked_registers[L3GD20_NUM_CHECKED_REGISTERS] = { ADDR_
 L3GD20::L3GD20(int bus, const char *path, uint32_t device, enum Rotation rotation) :
 	SPI("L3GD20", path, bus, device, SPIDEV_MODE3,
 	    11 * 1000 * 1000 /* will be rounded to 10.4 MHz, within margins for L3GD20 */),
-	_call{},
+	ScheduledWorkItem(px4::device_bus_to_wq(this->get_device_id())),
 	_call_interval(0),
 	_reports(nullptr),
 	_gyro_scale{},
@@ -605,8 +595,6 @@ L3GD20::ioctl(struct file *filp, int cmd, unsigned long arg)
 					/* XXX this is a bit shady, but no other way to adjust... */
 					_call_interval = ticks;
 
-					_call.period = _call_interval - L3GD20_TIMER_REDUCTION;
-
 					/* adjust filters */
 					float cutoff_freq_hz = _gyro_filter_x.get_cutoff_freq();
 					float sample_rate = 1.0e6f / ticks;
@@ -778,16 +766,13 @@ L3GD20::start()
 	_reports->flush();
 
 	/* start polling at the specified rate */
-	hrt_call_every(&_call,
-		       1000,
-		       _call_interval - L3GD20_TIMER_REDUCTION,
-		       (hrt_callout)&L3GD20::measure_trampoline, this);
+	ScheduleOnInterval(_call_interval - L3GD20_TIMER_REDUCTION, 10000);
 }
 
 void
 L3GD20::stop()
 {
-	hrt_cancel(&_call);
+	ScheduleClear();
 }
 
 void
@@ -841,12 +826,10 @@ L3GD20::reset()
 }
 
 void
-L3GD20::measure_trampoline(void *arg)
+L3GD20::Run()
 {
-	L3GD20 *dev = (L3GD20 *)arg;
-
 	/* make another measurement */
-	dev->measure();
+	measure();
 }
 
 void

--- a/src/drivers/imu/lsm303d/lsm303d.cpp
+++ b/src/drivers/imu/lsm303d/lsm303d.cpp
@@ -72,6 +72,7 @@
 #include <board_config.h>
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
 #include <lib/conversion/rotation.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 /* SPI protocol address bits */
 #define DIR_READ				(1<<7)
@@ -220,7 +221,7 @@ extern "C" { __EXPORT int lsm303d_main(int argc, char *argv[]); }
 
 class LSM303D_mag;
 
-class LSM303D : public device::SPI
+class LSM303D : public device::SPI, public px4::ScheduledWorkItem
 {
 public:
 	LSM303D(int bus, const char *path, uint32_t device, enum Rotation rotation);
@@ -256,10 +257,9 @@ protected:
 
 private:
 
-	LSM303D_mag		*_mag;
+	void Run() override;
 
-	struct hrt_call		_accel_call;
-	struct hrt_call		_mag_call;
+	LSM303D_mag		*_mag;
 
 	unsigned		_call_accel_interval;
 	unsigned		_call_mag_interval;
@@ -308,6 +308,8 @@ private:
 	// last temperature value
 	float			_last_temperature;
 
+	hrt_abstime		_mag_last_measure{0};
+
 	// this is used to support runtime checking of key
 	// configuration registers to detect SPI bus errors and sensor
 	// reset
@@ -337,24 +339,6 @@ private:
 	 * disable I2C on the chip
 	 */
 	void			disable_i2c();
-
-	/**
-	 * Static trampoline from the hrt_call context; because we don't have a
-	 * generic hrt wrapper yet.
-	 *
-	 * Called by the HRT in interrupt context at the specified rate if
-	 * automatic polling is enabled.
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		measure_trampoline(void *arg);
-
-	/**
-	 * Static trampoline for the mag because it runs at a lower rate
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		mag_measure_trampoline(void *arg);
 
 	/**
 	 * check key registers for correct values
@@ -508,8 +492,6 @@ private:
 
 	void				measure();
 
-	void				measure_trampoline(void *arg);
-
 	/* this class does not allow copying due to ptr data members */
 	LSM303D_mag(const LSM303D_mag &);
 	LSM303D_mag operator=(const LSM303D_mag &);
@@ -519,9 +501,8 @@ private:
 LSM303D::LSM303D(int bus, const char *path, uint32_t device, enum Rotation rotation) :
 	SPI("LSM303D", path, bus, device, SPIDEV_MODE3,
 	    11 * 1000 * 1000 /* will be rounded to 10.4 MHz, within safety margins for LSM303D */),
+	ScheduledWorkItem(px4::device_bus_to_wq(get_device_id())),
 	_mag(new LSM303D_mag(this)),
-	_accel_call{},
-	_mag_call{},
 	_call_accel_interval(0),
 	_call_mag_interval(0),
 	_accel_reports(nullptr),
@@ -844,8 +825,6 @@ LSM303D::ioctl(struct file *filp, int cmd, unsigned long arg)
 					/* XXX this is a bit shady, but no other way to adjust... */
 					_call_accel_interval = ticks;
 
-					_accel_call.period = _call_accel_interval - LSM303D_TIMER_REDUCTION;
-
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
 						start();
@@ -912,7 +891,7 @@ LSM303D::mag_ioctl(struct file *filp, int cmd, unsigned long arg)
 
 					/* update interval for next measurement */
 					/* XXX this is a bit shady, but no other way to adjust... */
-					_mag_call.period = _call_mag_interval = ticks;
+					_call_mag_interval = ticks;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -1214,18 +1193,13 @@ LSM303D::start()
 	_mag_reports->flush();
 
 	/* start polling at the specified rate */
-	hrt_call_every(&_accel_call,
-		       1000,
-		       _call_accel_interval - LSM303D_TIMER_REDUCTION,
-		       (hrt_callout)&LSM303D::measure_trampoline, this);
-	hrt_call_every(&_mag_call, 1000, _call_mag_interval, (hrt_callout)&LSM303D::mag_measure_trampoline, this);
+	ScheduleOnInterval(_call_accel_interval - LSM303D_TIMER_REDUCTION, 10000);
 }
 
 void
 LSM303D::stop()
 {
-	hrt_cancel(&_accel_call);
-	hrt_cancel(&_mag_call);
+	ScheduleClear();
 
 	/* reset internal states */
 	memset(_last_accel, 0, sizeof(_last_accel));
@@ -1236,21 +1210,14 @@ LSM303D::stop()
 }
 
 void
-LSM303D::measure_trampoline(void *arg)
+LSM303D::Run()
 {
-	LSM303D *dev = (LSM303D *)arg;
-
 	/* make another measurement */
-	dev->measure();
-}
+	measure();
 
-void
-LSM303D::mag_measure_trampoline(void *arg)
-{
-	LSM303D *dev = (LSM303D *)arg;
-
-	/* make another measurement */
-	dev->mag_measure();
+	if (hrt_elapsed_time(&_mag_last_measure) >= _call_mag_interval) {
+		mag_measure();
+	}
 }
 
 void
@@ -1473,6 +1440,9 @@ LSM303D::mag_measure()
 	 */
 
 	mag_report.timestamp = hrt_absolute_time();
+
+	_mag_last_measure = mag_report.timestamp;
+
 	mag_report.is_external = external();
 
 	mag_report.x_raw = raw_mag_report.x;
@@ -1670,12 +1640,6 @@ void
 LSM303D_mag::measure()
 {
 	_parent->mag_measure();
-}
-
-void
-LSM303D_mag::measure_trampoline(void *arg)
-{
-	_parent->mag_measure_trampoline(arg);
 }
 
 /**

--- a/src/drivers/imu/mpu6000/MPU6000.cpp
+++ b/src/drivers/imu/mpu6000/MPU6000.cpp
@@ -41,13 +41,9 @@ constexpr uint8_t MPU6000::_checked_registers[MPU6000_NUM_CHECKED_REGISTERS];
 
 MPU6000::MPU6000(device::Device *interface, const char *path, enum Rotation rotation, int device_type) :
 	CDev(path),
+	ScheduledWorkItem(px4::device_bus_to_wq(interface->get_device_id())),
 	_interface(interface),
 	_device_type(device_type),
-#if defined(USE_I2C)
-	_use_hrt(false),
-#else
-	_use_hrt(true),
-#endif
 	_px4_accel(_interface->get_device_id(), (_interface->external() ? ORB_PRIO_MAX : ORB_PRIO_HIGH), rotation),
 	_px4_gyro(_interface->get_device_id(), (_interface->external() ? ORB_PRIO_MAX : ORB_PRIO_HIGH), rotation),
 	_sample_perf(perf_alloc(PC_ELAPSED, "mpu6k_read")),
@@ -98,11 +94,6 @@ MPU6000::~MPU6000()
 int
 MPU6000::init()
 {
-
-#if defined(USE_I2C)
-	use_i2c(_interface->get_device_bus_type() == Device::DeviceBusType_I2C);
-#endif
-
 	/* probe again to get our settings that are based on the device type */
 	int ret = probe();
 
@@ -153,7 +144,8 @@ int MPU6000::reset()
 		up_udelay(1000);
 
 		// Enable I2C bus or Disable I2C bus (recommended on data sheet)
-		write_checked_reg(MPUREG_USER_CTRL, is_i2c() ? 0 : BIT_I2C_IF_DIS);
+		const bool is_i2c = (_interface->get_device_bus_type() == device::Device::DeviceBusType_I2C);
+		write_checked_reg(MPUREG_USER_CTRL, is_i2c ? 0 : BIT_I2C_IF_DIS);
 
 		px4_leave_critical_section(state);
 
@@ -654,79 +646,23 @@ MPU6000::start()
 	stop();
 	_call_interval = last_call_interval;
 
-	if (!is_i2c()) {
-
-		_call.period = _call_interval - MPU6000_TIMER_REDUCTION;
-
-		/* start polling at the specified rate */
-		hrt_call_every(&_call,
-			       1000,
-			       _call_interval - MPU6000_TIMER_REDUCTION,
-			       (hrt_callout)&MPU6000::measure_trampoline, this);
-
-	} else {
-#ifdef USE_I2C
-		/* schedule a cycle to start things */
-		work_queue(HPWORK, &_work, (worker_t)&MPU6000::cycle_trampoline, this, 1);
-#endif
-	}
+	ScheduleOnInterval(_call_interval - MPU6000_TIMER_REDUCTION, 10000);
 }
 
 void
 MPU6000::stop()
 {
-	if (!is_i2c()) {
-		hrt_cancel(&_call);
-
-	} else {
-#ifdef USE_I2C
-		_call_interval = 0;
-		work_cancel(HPWORK, &_work);
-#endif
-	}
+	ScheduleClear();
 
 	/* reset internal states */
 	memset(_last_accel, 0, sizeof(_last_accel));
 }
 
-#if defined(USE_I2C)
 void
-MPU6000::cycle_trampoline(void *arg)
+MPU6000::Run()
 {
-	MPU6000 *dev = (MPU6000 *)arg;
-
-	dev->cycle();
-}
-
-void
-MPU6000::cycle()
-{
-	int ret = measure();
-
-	if (ret != OK) {
-		/* issue a reset command to the sensor */
-		reset();
-		start();
-		return;
-	}
-
-	if (_call_interval != 0) {
-		work_queue(HPWORK,
-			   &_work,
-			   (worker_t)&MPU6000::cycle_trampoline,
-			   this,
-			   USEC2TICK(_call_interval - MPU6000_TIMER_REDUCTION));
-	}
-}
-#endif
-
-void
-MPU6000::measure_trampoline(void *arg)
-{
-	MPU6000 *dev = reinterpret_cast<MPU6000 *>(arg);
-
 	/* make another measurement */
-	dev->measure();
+	measure();
 }
 
 void

--- a/src/drivers/imu/mpu6000/MPU6000.hpp
+++ b/src/drivers/imu/mpu6000/MPU6000.hpp
@@ -66,9 +66,9 @@
 #include <px4_config.h>
 #include <px4_getopt.h>
 #include <px4_time.h>
-#include <px4_workqueue.h>
 #include <systemlib/conversions.h>
 #include <systemlib/px4_macros.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 /*
   we set the timer interrupt to run a bit faster than the desired
@@ -302,7 +302,7 @@ enum MPU6000_BUS {
 	MPU6000_BUS_SPI_EXTERNAL2
 };
 
-class MPU6000 : public cdev::CDev
+class MPU6000 : public cdev::CDev, public px4::ScheduledWorkItem
 {
 public:
 	MPU6000(device::Device *interface, const char *path, enum Rotation rotation, int device_type);
@@ -346,19 +346,12 @@ protected:
 	virtual int		probe();
 
 private:
+
+	void Run() override;
+
 	int 			_device_type;
 	uint8_t			_product{0};	/** product code */
 
-#if defined(USE_I2C)
-	/*
-	 * SPI bus based device use hrt
-	 * I2C bus needs to use work queue
-	 */
-	work_s			_work{};
-#endif
-	bool 			_use_hrt;
-
-	struct hrt_call		_call {};
 	unsigned		_call_interval{1000};
 
 	PX4Accelerometer	_px4_accel;
@@ -419,50 +412,6 @@ private:
 	 * is_mpu_device
 	 */
 	bool 		is_mpu_device() { return _device_type == MPU_DEVICE_TYPE_MPU6000; }
-
-
-#if defined(USE_I2C)
-	/**
-	 * When the I2C interfase is on
-	 * Perform a poll cycle; collect from the previous measurement
-	 * and start a new one.
-	 *
-	 * This is the heart of the measurement state machine.  This function
-	 * alternately starts a measurement, or collects the data from the
-	 * previous measurement.
-	 *
-	 * When the interval between measurements is greater than the minimum
-	 * measurement interval, a gap is inserted between collection
-	 * and measurement to provide the most recent measurement possible
-	 * at the next interval.
-	 */
-	void			cycle();
-
-	/**
-	 * Static trampoline from the workq context; because we don't have a
-	 * generic workq wrapper yet.
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		cycle_trampoline(void *arg);
-
-	void use_i2c(bool on_true) { _use_hrt = !on_true; }
-
-#endif
-
-	bool is_i2c(void) { return !_use_hrt; }
-
-
-	/**
-	 * Static trampoline from the hrt_call context; because we don't have a
-	 * generic hrt wrapper yet.
-	 *
-	 * Called by the HRT in interrupt context at the specified rate if
-	 * automatic polling is enabled.
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		measure_trampoline(void *arg);
 
 	/**
 	 * Fetch measurements from the sensor and update the report buffers.

--- a/src/drivers/imu/mpu9250/CMakeLists.txt
+++ b/src/drivers/imu/mpu9250/CMakeLists.txt
@@ -45,5 +45,5 @@ px4_add_module(
 		mag.cpp
 		mag_i2c.cpp
 	DEPENDS
+		px4_work_queue
 	)
-

--- a/src/drivers/imu/mpu9250/mpu9250.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250.cpp
@@ -93,6 +93,7 @@ MPU9250::MPU9250(device::Device *interface, device::Device *mag_interface, const
 		 const char *path_gyro, const char *path_mag,
 		 enum Rotation rotation,
 		 bool magnetometer_only) :
+	ScheduledWorkItem(px4::device_bus_to_wq(interface->get_device_id())),
 	_interface(interface),
 	_whoami(0),
 	_accel(magnetometer_only ? nullptr : new MPU9250_accel(this, path_accel)),
@@ -100,13 +101,6 @@ MPU9250::MPU9250(device::Device *interface, device::Device *mag_interface, const
 	_mag(new MPU9250_mag(this, mag_interface, path_mag)),
 	_selected_bank(0xFF),	// invalid/improbable bank value, will be set on first read/write
 	_magnetometer_only(magnetometer_only),
-#if defined(USE_I2C)
-	_work {},
-	_use_hrt(false),
-#else
-	_use_hrt(true),
-#endif
-	_call {},
 	_call_interval(0),
 	_accel_reports(nullptr),
 	_accel_scale{},
@@ -232,16 +226,14 @@ MPU9250::init()
 {
 	irqstate_t state;
 
-#if defined(USE_I2C)
-	use_i2c(_interface->get_device_bus_type() == device::Device::DeviceBusType_I2C);
-#endif
-
 	/*
 	 * If the MPU is using I2C we should reduce the sample rate to 200Hz and
 	 * make the integration autoreset faster so that we integrate just one
 	 * sample since the sampling rate is already low.
 	*/
-	if (is_i2c() && !_magnetometer_only) {
+	const bool is_i2c = (_interface->get_device_bus_type() == device::Device::DeviceBusType_I2C);
+
+	if (is_i2c && !_magnetometer_only) {
 		_sample_rate = 200;
 		_accel_int.set_autoreset_interval(1000000 / 1000);
 		_gyro_int.set_autoreset_interval(1000000 / 1000);
@@ -250,7 +242,7 @@ MPU9250::init()
 	int ret = probe();
 
 	if (ret != OK) {
-		PX4_DEBUG("MPU9250 probe failed");
+		PX4_DEBUG("probe failed");
 		return ret;
 	}
 
@@ -453,7 +445,8 @@ int MPU9250::reset_mpu()
 	}
 
 	// Enable I2C bus or Disable I2C bus (recommended on data sheet)
-	write_checked_reg(MPUREG_USER_CTRL, is_i2c() ? 0 : BIT_I2C_IF_DIS);
+	const bool is_i2c = (_interface->get_device_bus_type() == device::Device::DeviceBusType_I2C);
+	write_checked_reg(MPUREG_USER_CTRL, is_i2c ? 0 : BIT_I2C_IF_DIS);
 
 	// SAMPLE RATE
 	_set_sample_rate(_sample_rate);
@@ -622,14 +615,6 @@ MPU9250::_set_pollrate(unsigned long rate)
 		/* update interval for next measurement */
 		/* XXX this is a bit shady, but no other way to adjust... */
 		_call_interval = ticks;
-
-		/*
-		  set call interval faster than the sample time. We
-		  then detect when we have duplicate samples and reject
-		  them. This prevents aliasing due to a beat between the
-		  stm32 clock and the mpu9250 clock
-		 */
-		_call.period = _call_interval - MPU9250_TIMER_REDUCTION;
 
 		/* if we need to start the poll state machine, do it */
 		if (want_start) {
@@ -826,78 +811,20 @@ MPU9250::start()
 
 	_mag->_mag_reports->flush();
 
-	if (_use_hrt) {
-		/* start polling at the specified rate */
-		hrt_call_every(&_call,
-			       1000,
-			       _call_interval - MPU9250_TIMER_REDUCTION,
-			       (hrt_callout)&MPU9250::measure_trampoline, this);
-
-	} else {
-#ifdef USE_I2C
-		/* schedule a cycle to start things */
-		work_queue(HPWORK, &_work, (worker_t)&MPU9250::cycle_trampoline, this, 1);
-#endif
-	}
-
+	ScheduleOnInterval(_call_interval - MPU9250_TIMER_REDUCTION, 10000);
 }
 
 void
 MPU9250::stop()
 {
-	if (_use_hrt) {
-		hrt_cancel(&_call);
-
-	} else {
-#ifdef USE_I2C
-		work_cancel(HPWORK, &_work);
-#endif
-	}
-}
-
-
-#if defined(USE_I2C)
-void
-MPU9250::cycle_trampoline(void *arg)
-{
-	MPU9250 *dev = (MPU9250 *)arg;
-
-	dev->cycle();
+	ScheduleClear();
 }
 
 void
-MPU9250::cycle()
+MPU9250::Run()
 {
-
-//	int ret = measure();
-
-	measure();
-
-//	if (ret != OK) {
-//		/* issue a reset command to the sensor */
-//		reset();
-//		start();
-//		return;
-//	}
-
-	if (_call_interval != 0) {
-		work_queue(HPWORK,
-			   &_work,
-			   (worker_t)&MPU9250::cycle_trampoline,
-			   this,
-			   USEC2TICK(_call_interval - MPU9250_TIMER_REDUCTION));
-	}
-}
-#endif
-
-
-void
-MPU9250::measure_trampoline(void *arg)
-{
-	MPU9250 *dev = reinterpret_cast<MPU9250 *>(arg);
-
 	/* make another measurement */
-	dev->measure();
+	measure();
 }
 
 void

--- a/src/drivers/imu/mpu9250/mpu9250.h
+++ b/src/drivers/imu/mpu9250/mpu9250.h
@@ -36,8 +36,6 @@
 #include <perf/perf_counter.h>
 #include <systemlib/conversions.h>
 
-#include <nuttx/wqueue.h>
-
 #include <board_config.h>
 #include <drivers/drv_hrt.h>
 
@@ -49,9 +47,9 @@
 #include <mathlib/math/filter/LowPassFilter2p.hpp>
 #include <lib/conversion/rotation.h>
 #include <systemlib/err.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
 
 #include <uORB/uORB.h>
-#include <uORB/topics/debug_key_value.h>
 
 #include "mag.h"
 #include "accel.h"
@@ -253,7 +251,7 @@ class MPU9250_mag;
 class MPU9250_accel;
 class MPU9250_gyro;
 
-class MPU9250
+class MPU9250 : public px4::ScheduledWorkItem
 {
 public:
 	MPU9250(device::Device *interface, device::Device *mag_interface, const char *path_accel, const char *path_gyro,
@@ -281,6 +279,8 @@ protected:
 	friend class MPU9250_mag;
 	friend class MPU9250_gyro;
 
+	void Run() override;
+
 private:
 	MPU9250_accel   *_accel;
 	MPU9250_gyro	*_gyro;
@@ -289,16 +289,6 @@ private:
 	bool
 	_magnetometer_only;     /* To disable accel and gyro reporting if only magnetometer is used (e.g. as external magnetometer) */
 
-#if defined(USE_I2C)
-	/*
-	 * SPI bus based device use hrt
-	 * I2C bus needs to use work queue
-	 */
-	work_s			_work{};
-#endif
-	bool 			_use_hrt;
-
-	struct hrt_call		_call {};
 	unsigned		_call_interval;
 
 	ringbuffer::RingBuffer	*_accel_reports;
@@ -391,52 +381,6 @@ private:
 	 * Resets the main chip (excluding the magnetometer if any).
 	 */
 	int			reset_mpu();
-
-
-#if defined(USE_I2C)
-	/**
-	 * When the I2C interfase is on
-	 * Perform a poll cycle; collect from the previous measurement
-	 * and start a new one.
-	 *
-	 * This is the heart of the measurement state machine.  This function
-	 * alternately starts a measurement, or collects the data from the
-		 * previous measurement.
-		 *
-		 * When the interval between measurements is greater than the minimum
-		 * measurement interval, a gap is inserted between collection
-		 * and measurement to provide the most recent measurement possible
-		 * at the next interval.
-		 */
-	void			cycle();
-
-	/**
-	 * Static trampoline from the workq context; because we don't have a
-	 * generic workq wrapper yet.
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		cycle_trampoline(void *arg);
-
-	void use_i2c(bool on_true) { _use_hrt = !on_true; }
-
-#endif
-
-	bool is_i2c(void) { return !_use_hrt; }
-
-
-
-
-	/**
-	 * Static trampoline from the hrt_call context; because we don't have a
-	 * generic hrt wrapper yet.
-	 *
-	 * Called by the HRT in interrupt context at the specified rate if
-	 * automatic polling is enabled.
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		measure_trampoline(void *arg);
 
 	/**
 	 * Fetch measurements from the sensor and update the report buffers.

--- a/src/drivers/magnetometer/hmc5883/CMakeLists.txt
+++ b/src/drivers/magnetometer/hmc5883/CMakeLists.txt
@@ -40,5 +40,6 @@ px4_add_module(
 		hmc5883_spi.cpp
 		hmc5883.cpp
 	DEPENDS
+		px4_work_queue
 	)
 

--- a/src/drivers/magnetometer/hmc5883/hmc5883.cpp
+++ b/src/drivers/magnetometer/hmc5883/hmc5883.cpp
@@ -56,10 +56,6 @@
 #include <math.h>
 #include <unistd.h>
 
-#include <nuttx/arch.h>
-#include <nuttx/wqueue.h>
-#include <nuttx/clock.h>
-
 #include <board_config.h>
 
 #include <perf/perf_counter.h>
@@ -75,6 +71,8 @@
 #include <float.h>
 #include <getopt.h>
 #include <lib/conversion/rotation.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
+#include <lib/perf/perf_counter.h>
 
 #include "hmc5883.h"
 
@@ -125,11 +123,7 @@ enum HMC5883_BUS {
 	HMC5883_BUS_SPI
 };
 
-#ifndef CONFIG_SCHED_WORKQUEUE
-# error This requires CONFIG_SCHED_WORKQUEUE.
-#endif
-
-class HMC5883 : public device::CDev
+class HMC5883 : public device::CDev, public px4::ScheduledWorkItem
 {
 public:
 	HMC5883(device::Device *interface, const char *path, enum Rotation rotation);
@@ -154,8 +148,8 @@ protected:
 	Device			*_interface;
 
 private:
-	work_s			_work{};
-	unsigned		_measure_ticks;
+
+	unsigned		_measure_interval{0};
 
 	ringbuffer::RingBuffer	*_reports;
 	struct mag_calibration_s	_scale;
@@ -263,15 +257,7 @@ private:
 	 * and measurement to provide the most recent measurement possible
 	 * at the next interval.
 	 */
-	void			cycle();
-
-	/**
-	 * Static trampoline from the workq context; because we don't have a
-	 * generic workq wrapper yet.
-	 *
-	 * @param arg		Instance pointer for the driver that is polling.
-	 */
-	static void		cycle_trampoline(void *arg);
+	void			Run() override;
 
 	/**
 	 * Write a register.
@@ -338,8 +324,8 @@ extern "C" __EXPORT int hmc5883_main(int argc, char *argv[]);
 
 HMC5883::HMC5883(device::Device *interface, const char *path, enum Rotation rotation) :
 	CDev("HMC5883", path),
+	ScheduledWorkItem(px4::device_bus_to_wq(interface->get_device_id())),
 	_interface(interface),
-	_measure_ticks(0),
 	_reports(nullptr),
 	_scale{},
 	_range_scale(0), /* default range scale from counts to gauss */
@@ -376,9 +362,6 @@ HMC5883::HMC5883(device::Device *interface, const char *path, enum Rotation rota
 	_scale.y_scale = 1.0f;
 	_scale.z_offset = 0;
 	_scale.z_scale = 1.0f;
-
-	// work_cancel in the dtor will explode if we don't do this...
-	memset(&_work, 0, sizeof(_work));
 }
 
 HMC5883::~HMC5883()
@@ -563,7 +546,7 @@ HMC5883::read(struct file *filp, char *buffer, size_t buflen)
 	}
 
 	/* if automatic measurement is enabled */
-	if (_measure_ticks > 0) {
+	if (_measure_interval > 0) {
 		/*
 		 * While there is space in the caller's buffer, and reports, copy them.
 		 * Note that we may be pre-empted by the workq thread while we are doing this;
@@ -624,10 +607,10 @@ HMC5883::ioctl(struct file *filp, int cmd, unsigned long arg)
 			/* set default polling rate */
 			case SENSOR_POLLRATE_DEFAULT: {
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
 					/* set interval for next measurement to minimum legal value */
-					_measure_ticks = USEC2TICK(HMC5883_CONVERSION_INTERVAL);
+					_measure_interval = HMC5883_CONVERSION_INTERVAL;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -640,18 +623,18 @@ HMC5883::ioctl(struct file *filp, int cmd, unsigned long arg)
 			/* adjust to a legal polling interval in Hz */
 			default: {
 					/* do we need to start internal polling? */
-					bool want_start = (_measure_ticks == 0);
+					bool want_start = (_measure_interval == 0);
 
 					/* convert hz to tick interval via microseconds */
-					unsigned ticks = USEC2TICK(1000000 / arg);
+					unsigned interval = (1000000 / arg);
 
 					/* check against maximum rate */
-					if (ticks < USEC2TICK(HMC5883_CONVERSION_INTERVAL)) {
+					if (interval < HMC5883_CONVERSION_INTERVAL) {
 						return -EINVAL;
 					}
 
 					/* update interval for next measurement */
-					_measure_ticks = ticks;
+					_measure_interval = interval;
 
 					/* if we need to start the poll state machine, do it */
 					if (want_start) {
@@ -706,16 +689,16 @@ HMC5883::start()
 	_reports->flush();
 
 	/* schedule a cycle to start things */
-	work_queue(HPWORK, &_work, (worker_t)&HMC5883::cycle_trampoline, this, 1);
+	ScheduleNow();
 }
 
 void
 HMC5883::stop()
 {
-	if (_measure_ticks > 0) {
+	if (_measure_interval > 0) {
 		/* ensure no new items are queued while we cancel this one */
-		_measure_ticks = 0;
-		work_cancel(HPWORK, &_work);
+		_measure_interval = 0;
+		ScheduleClear();
 	}
 }
 
@@ -727,17 +710,9 @@ HMC5883::reset()
 }
 
 void
-HMC5883::cycle_trampoline(void *arg)
+HMC5883::Run()
 {
-	HMC5883 *dev = (HMC5883 *)arg;
-
-	dev->cycle();
-}
-
-void
-HMC5883::cycle()
-{
-	if (_measure_ticks == 0) {
+	if (_measure_interval == 0) {
 		return;
 	}
 
@@ -758,14 +733,10 @@ HMC5883::cycle()
 		/*
 		 * Is there a collect->measure gap?
 		 */
-		if (_measure_ticks > USEC2TICK(HMC5883_CONVERSION_INTERVAL)) {
+		if (_measure_interval > HMC5883_CONVERSION_INTERVAL) {
 
 			/* schedule a fresh cycle call when we are ready to measure again */
-			work_queue(HPWORK,
-				   &_work,
-				   (worker_t)&HMC5883::cycle_trampoline,
-				   this,
-				   _measure_ticks - USEC2TICK(HMC5883_CONVERSION_INTERVAL));
+			ScheduleDelayed(_measure_interval - HMC5883_CONVERSION_INTERVAL);
 
 			return;
 		}
@@ -779,13 +750,9 @@ HMC5883::cycle()
 	/* next phase is collection */
 	_collect_phase = true;
 
-	if (_measure_ticks > 0) {
+	if (_measure_interval > 0) {
 		/* schedule a fresh cycle call when the measurement is done */
-		work_queue(HPWORK,
-			   &_work,
-			   (worker_t)&HMC5883::cycle_trampoline,
-			   this,
-			   USEC2TICK(HMC5883_CONVERSION_INTERVAL));
+		ScheduleDelayed(HMC5883_CONVERSION_INTERVAL);
 	}
 }
 
@@ -1341,7 +1308,7 @@ HMC5883::print_info()
 {
 	perf_print_counter(_sample_perf);
 	perf_print_counter(_comms_errors);
-	printf("poll interval:  %u ticks\n", _measure_ticks);
+	printf("interval:  %u us\n", _measure_interval);
 	print_message(_last_report);
 	_reports->print_info("report queue");
 }

--- a/src/include/containers/Queue.hpp
+++ b/src/include/containers/Queue.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2012 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,70 +31,57 @@
  *
  ****************************************************************************/
 
-/**
- * @file List.hpp
- *
- * A linked list.
- */
-
 #pragma once
 
 template<class T>
-class ListNode
-{
-public:
-
-	void setSibling(T sibling) { _sibling = sibling; }
-	const T getSibling() const { return _sibling; }
-
-protected:
-
-	T _sibling{nullptr};
-
+struct QueueNode {
+	T next{nullptr};
 };
 
 template<class T>
-class List
+class Queue
 {
 public:
 
-	void add(T newNode)
-	{
-		newNode->setSibling(getHead());
-		_head = newNode;
-	}
+	bool empty() const { return _head == nullptr; }
 
-	bool remove(T removeNode)
+	T front() const { return _head; }
+	T back() const { return _tail; }
+
+	void push(T newNode)
 	{
-		// base case
-		if (removeNode == _head) {
-			_head = nullptr;
-			return true;
+		if (_head == nullptr) {
+			_head = newNode;
 		}
 
-		for (T node = _head; node != nullptr; node = node->getSibling()) {
-			// is sibling the node to remove?
-			if (node->getSibling() == removeNode) {
-				// replace sibling
-				if (node->getSibling() != nullptr) {
-					node->setSibling(node->getSibling()->getSibling());
+		if (_tail != nullptr) {
+			_tail->next = newNode;
+		}
 
-				} else {
-					node->setSibling(nullptr);
-				}
+		_tail = newNode;
+	}
 
-				return true;
+	T pop()
+	{
+		T ret = _head;
+
+		if (!empty()) {
+			if (_head != _tail) {
+				_head = _head->next;
+
+			} else {
+				// only one item left
+				_head = nullptr;
+				_tail = nullptr;
 			}
 		}
 
-		return false;
+		return ret;
 	}
-
-	const T getHead() const { return _head; }
-
-	bool empty() const { return _head == nullptr; }
 
 protected:
 
 	T _head{nullptr};
+	T _tail{nullptr};
+
 };

--- a/src/modules/uORB/uORB.cpp
+++ b/src/modules/uORB/uORB.cpp
@@ -107,6 +107,11 @@ int  orb_exists(const struct orb_metadata *meta, int instance)
 	return uORB::Manager::get_instance()->orb_exists(meta, instance);
 }
 
+int orb_register_work_callback(const struct orb_metadata *meta, int instance, px4::WorkItem *item)
+{
+	return uORB::Manager::get_instance()->orb_register_work_callback(meta, instance, item);
+}
+
 int  orb_group_count(const struct orb_metadata *meta)
 {
 	unsigned instance = 0;

--- a/src/modules/uORB/uORB.h
+++ b/src/modules/uORB/uORB.h
@@ -43,6 +43,12 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+namespace px4
+{
+class WorkItem; // forward declaration
+} // namespace px4
+#endif
 
 /**
  * Object metadata.
@@ -226,6 +232,13 @@ extern int	orb_stat(int handle, uint64_t *time) __EXPORT;
  * @see uORB::Manager::orb_exists()
  */
 extern int	orb_exists(const struct orb_metadata *meta, int instance) __EXPORT;
+
+/**
+ * @see uORB::Manager::orb_register_work_callback()
+ */
+#ifdef __cplusplus
+extern int orb_register_work_callback(const struct orb_metadata *meta, int instance, px4::WorkItem *item) __EXPORT;
+#endif
 
 /**
  * Get the number of published instances of a topic group

--- a/src/modules/uORB/uORBDeviceNode.hpp
+++ b/src/modules/uORB/uORBDeviceNode.hpp
@@ -39,6 +39,7 @@
 #include <lib/cdev/CDev.hpp>
 
 #include <containers/List.hpp>
+#include <px4_work_queue/WorkItem.hpp>
 
 namespace uORB
 {
@@ -195,6 +196,12 @@ public:
 	int get_priority() const { return _priority; }
 	void set_priority(uint8_t priority) { _priority = priority; }
 
+	// add item to list of work items to schedule on node update
+	bool register_work_item(px4::WorkItem *item);
+
+	// remove item from list of work items
+	bool unregister_work_item(px4::WorkItem *item);
+
 protected:
 
 	pollevent_t poll_state(cdev::file_t *filp) override;
@@ -227,6 +234,10 @@ private:
 	uint8_t     *_data{nullptr};   /**< allocated object buffer */
 	hrt_abstime   _last_update{0}; /**< time the object was last updated */
 	volatile unsigned   _generation{0};  /**< object generation count */
+
+	List<px4::WorkItem *> _registered_work_items;
+	bool			_work_items_available{false};
+
 	uint8_t   _priority;  /**< priority of the topic */
 	bool _published{false};  /**< has ever data been published */
 	uint8_t _queue_size; /**< maximum number of elements in the queue */
@@ -262,5 +273,8 @@ private:
 	 * @return    True if the topic should appear updated to the subscriber
 	 */
 	bool      appears_updated(SubscriberData *sd);
+
+
+	void	schedule_work_items();
 
 };

--- a/src/modules/uORB/uORBManager.cpp
+++ b/src/modules/uORB/uORBManager.cpp
@@ -44,6 +44,8 @@
 #include "uORBUtils.hpp"
 #include "uORBManager.hpp"
 
+#include <px4_work_queue/WorkItem.hpp>
+
 uORB::Manager *uORB::Manager::_Instance = nullptr;
 
 bool uORB::Manager::initialize()
@@ -90,6 +92,24 @@ uORB::DeviceMaster *uORB::Manager::get_device_master()
 	}
 
 	return _device_master;
+}
+
+int uORB::Manager::orb_register_work_callback(const struct orb_metadata *meta, int instance, px4::WorkItem *item)
+{
+	// find node
+	// insert callback (like pollset)
+
+	if (get_device_master()) {
+		uORB::DeviceNode *node = _device_master->getDeviceNode(meta, instance);
+
+		if (node != nullptr) {
+			if (node->register_work_item(item)) {
+				return PX4_OK;
+			}
+		}
+	}
+
+	return PX4_ERROR;
 }
 
 int uORB::Manager::orb_exists(const struct orb_metadata *meta, int instance)

--- a/src/modules/uORB/uORBManager.hpp
+++ b/src/modules/uORB/uORBManager.hpp
@@ -51,6 +51,8 @@
 #include "uORBCommunicator.hpp"
 #endif /* ORB_COMMUNICATOR */
 
+#include <px4_work_queue/WorkItem.hpp>
+
 namespace uORB
 {
 class Manager;
@@ -314,6 +316,16 @@ public:
 	 * @return    OK if the topic exists, PX4_ERROR otherwise.
 	 */
 	int  orb_exists(const struct orb_metadata *meta, int instance);
+
+	/**
+	 * Register work item callback on orb publish
+	 *
+	 * @param meta    ORB topic metadata.
+	 * @param instance  ORB instance
+	 * @param item   Valid WorkItem to schedule on new publication
+	 * @return    OK if the topic exists, PX4_ERROR otherwise.
+	 */
+	int  orb_register_work_callback(const struct orb_metadata *meta, int instance, px4::WorkItem *item);
 
 	/**
 	 * Return the priority of the topic

--- a/src/platforms/common/CMakeLists.txt
+++ b/src/platforms/common/CMakeLists.txt
@@ -52,4 +52,5 @@ if (NOT "${PX4_PLATFORM}" MATCHES "qurt" AND NOT "${PX4_BOARD}" MATCHES "io-v2")
 	target_link_libraries(px4_platform PRIVATE modules__uORB) # px4_log awkward dependency with uORB, TODO: orb should part of the platform layer
 endif()
 
+add_subdirectory(px4_work_queue)
 add_subdirectory(work_queue)

--- a/src/platforms/common/px4_work_queue/CMakeLists.txt
+++ b/src/platforms/common/px4_work_queue/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2019 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,22 +31,15 @@
 #
 ############################################################################
 
-# skip for px4_layer support on an IO board
-if (NOT ${PX4_BOARD} MATCHES "px4_io")
+px4_add_library(px4_work_queue
+	ScheduledWorkItem.cpp
+	WorkItem.cpp
+	WorkQueue.cpp
+	WorkQueueManager.cpp
+)
 
-	add_library(px4_layer
-		px4_nuttx_tasks.c
-		px4_nuttx_impl.cpp
-		px4_init.cpp
-	)
-	target_link_libraries(px4_layer
-		PRIVATE
-			nuttx_apps # up_cxxinitialize
-			nuttx_sched
-			drivers_boards_common_arch
-			px4_work_queue
-		)
-else()
-	add_library(px4_layer ${PX4_SOURCE_DIR}/src/platforms/empty.c)
+if(PX4_TESTING)
+	add_subdirectory(test)
 endif()
-add_dependencies(px4_layer prebuild_targets)
+
+target_link_libraries(px4_work_queue PRIVATE px4_platform)

--- a/src/platforms/common/px4_work_queue/ScheduledWorkItem.cpp
+++ b/src/platforms/common/px4_work_queue/ScheduledWorkItem.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2012 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,70 +31,35 @@
  *
  ****************************************************************************/
 
-/**
- * @file List.hpp
- *
- * A linked list.
- */
+#include "ScheduledWorkItem.hpp"
 
-#pragma once
-
-template<class T>
-class ListNode
+namespace px4
 {
-public:
 
-	void setSibling(T sibling) { _sibling = sibling; }
-	const T getSibling() const { return _sibling; }
-
-protected:
-
-	T _sibling{nullptr};
-
-};
-
-template<class T>
-class List
+ScheduledWorkItem::~ScheduledWorkItem()
 {
-public:
+	ScheduleClear();
+}
 
-	void add(T newNode)
-	{
-		newNode->setSibling(getHead());
-		_head = newNode;
-	}
+void ScheduledWorkItem::schedule_trampoline(void *arg)
+{
+	ScheduledWorkItem *dev = reinterpret_cast<ScheduledWorkItem *>(arg);
+	dev->ScheduleNow();
+}
 
-	bool remove(T removeNode)
-	{
-		// base case
-		if (removeNode == _head) {
-			_head = nullptr;
-			return true;
-		}
+void ScheduledWorkItem::ScheduleDelayed(uint32_t delay_us)
+{
+	hrt_call_after(&_call, delay_us, (hrt_callout)&ScheduledWorkItem::schedule_trampoline, this);
+}
 
-		for (T node = _head; node != nullptr; node = node->getSibling()) {
-			// is sibling the node to remove?
-			if (node->getSibling() == removeNode) {
-				// replace sibling
-				if (node->getSibling() != nullptr) {
-					node->setSibling(node->getSibling()->getSibling());
+void ScheduledWorkItem::ScheduleOnInterval(uint32_t interval_us, uint32_t delay_us)
+{
+	hrt_call_every(&_call, delay_us, interval_us, (hrt_callout)&ScheduledWorkItem::schedule_trampoline, this);
+}
 
-				} else {
-					node->setSibling(nullptr);
-				}
+void ScheduledWorkItem::ScheduleClear()
+{
+	hrt_cancel(&_call);
+}
 
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	const T getHead() const { return _head; }
-
-	bool empty() const { return _head == nullptr; }
-
-protected:
-
-	T _head{nullptr};
-};
+} // namespace px4

--- a/src/platforms/common/px4_work_queue/WorkQueueManager.cpp
+++ b/src/platforms/common/px4_work_queue/WorkQueueManager.cpp
@@ -1,0 +1,237 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "WorkQueueManager.hpp"
+
+#include "WorkQueue.hpp"
+
+#include <string.h>
+
+#include <px4_posix.h>
+#include <px4_tasks.h>
+#include <px4_time.h>
+#include <drivers/drv_hrt.h>
+#include <px4_atomic.h>
+#include <containers/BlockingQueue.hpp>
+#include <containers/List.hpp>
+
+#include <lib/drivers/device/Device.hpp>
+
+using namespace time_literals;
+
+namespace px4
+{
+
+// list of current work queues
+static List<WorkQueue *> _px4_work_queues_list;
+static pthread_mutex_t _px4_work_queues_list_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+// queue of WorkQueues to be created (as threads in the wq manager task)
+static BlockingQueue<wq_config *, 1> _px4_wq_manager_new;
+
+static px4::atomic_bool _wq_task_should_exit{false};
+
+
+static WorkQueue *find_work_queue(const char *name)
+{
+	pthread_mutex_lock(&_px4_work_queues_list_mutex);
+
+	// search list
+	for (WorkQueue *wq = _px4_work_queues_list.getHead(); wq != nullptr; wq = wq->getSibling()) {
+		if (strcmp(wq->get_name(), name) == 0) {
+			pthread_mutex_unlock(&_px4_work_queues_list_mutex);
+			return wq;
+		}
+	}
+
+	pthread_mutex_unlock(&_px4_work_queues_list_mutex);
+
+	return nullptr;
+}
+
+WorkQueue *work_queue_create(const wq_config &new_wq)
+{
+	// search list for existing work queue
+	WorkQueue *wq = find_work_queue(new_wq.name);
+
+	// create work queue if it doesn't exist
+	if (wq == nullptr) {
+
+		// add to list
+		// main thread wakes up, creates the thread
+		_px4_wq_manager_new.push((wq_config *)&new_wq);
+
+		// we wait until new wq is created, then return
+		uint64_t t = 0;
+
+		while (wq == nullptr && t < 10_s) {
+			wq = find_work_queue(new_wq.name);
+
+			// Wait up to 10s, checking every 2.5ms
+			t += 2500;
+			px4_usleep(2500);
+		}
+
+		if (wq == nullptr) {
+			PX4_ERR("work queue: %s failed to create", new_wq.name);
+		}
+	}
+
+	return wq;
+}
+
+const wq_config &device_bus_to_wq(uint32_t device_id_int)
+{
+	union device::Device::DeviceId device_id;
+	device_id.devid = device_id_int;
+
+	const device::Device::DeviceBusType bus_type = device_id.devid_s.bus_type;
+	const uint8_t bus = device_id.devid_s.bus;
+
+	if (bus_type == device::Device::DeviceBusType_I2C) {
+		if (bus == 1) {
+			return wq_configurations[I2C1];
+
+		} else if (bus == 2) {
+			return wq_configurations[I2C2];
+		}
+
+	} else if (bus_type == device::Device::DeviceBusType_SPI) {
+		if (bus == 1) {
+			return wq_configurations[SPI1];
+
+		} else if (bus == 2) {
+			return wq_configurations[SPI2];
+		}
+	}
+
+	// otherwise use high priority
+	return wq_configurations[hp_default];
+};
+
+static void *work_queue_runner(void *context)
+{
+	wq_config *config = static_cast<wq_config *>(context);
+	WorkQueue wq(*config);
+
+	// add to work queue list
+	pthread_mutex_lock(&_px4_work_queues_list_mutex);
+	_px4_work_queues_list.add(&wq);
+	pthread_mutex_unlock(&_px4_work_queues_list_mutex);
+
+	wq.Run();
+
+	// remove from work queue list
+	pthread_mutex_lock(&_px4_work_queues_list_mutex);
+	_px4_work_queues_list.remove(&wq);
+	pthread_mutex_unlock(&_px4_work_queues_list_mutex);
+
+	return nullptr;
+}
+
+static void work_queue_manager_run()
+{
+	while (!_wq_task_should_exit.load()) {
+
+		// create new work queues as needed
+		wq_config *wq = _px4_wq_manager_new.pop();
+
+		if (wq != nullptr) {
+			// create new work queue
+
+			pthread_attr_t attr{};
+			sched_param param{};
+			pthread_attr_init(&attr);
+			pthread_attr_getschedparam(&attr, &param);
+
+			if (pthread_attr_setstacksize(&attr, PX4_STACK_ADJUSTED(wq->stacksize)) != OK) {
+				PX4_ERR("setting stack size failed");
+			}
+
+			param.sched_priority = SCHED_PRIORITY_MAX - wq->priority;
+
+			if (pthread_attr_setschedparam(&attr, &param) != OK) {
+				PX4_ERR("setting sched params failed");
+			}
+
+			PX4_INFO("New WQ: %s priority: %d stack: %d", wq->name, param.sched_priority, PX4_STACK_ADJUSTED(wq->stacksize));
+
+			pthread_t thread;
+			int ret_create = pthread_create(&thread, &attr, work_queue_runner, (void *)wq);
+
+			if (ret_create != 0) {
+				PX4_ERR("failed to create thread");
+			}
+
+			pthread_attr_destroy(&attr);
+		}
+	}
+}
+
+int work_queue_manager_start()
+{
+	int task_id = px4_task_spawn_cmd("wq_manager",
+					 SCHED_DEFAULT,
+					 SCHED_PRIORITY_DEFAULT,
+					 1200,
+					 (px4_main_t)&work_queue_manager_run,
+					 nullptr);
+
+	if (task_id < 0) {
+		PX4_ERR("start failed");
+		return -errno;
+
+	} else {
+		PX4_INFO("starting");
+	}
+
+	return 0;
+}
+
+int work_queue_manager_stop()
+{
+	// ask all work queues (threads) to stop
+	// NOTE: not currently safe without all WorkItems stopping first
+	for (WorkQueue *wq = _px4_work_queues_list.getHead(); wq != nullptr; wq = wq->getSibling()) {
+		wq->request_stop();
+	}
+
+	_wq_task_should_exit.store(true);
+
+	// push nullptr to wake the wq manager task
+	_px4_wq_manager_new.push(nullptr);
+
+	return PX4_OK;
+}
+
+} // namespace px4

--- a/src/platforms/common/px4_work_queue/test/CMakeLists.txt
+++ b/src/platforms/common/px4_work_queue/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2019 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,22 +31,14 @@
 #
 ############################################################################
 
-# skip for px4_layer support on an IO board
-if (NOT ${PX4_BOARD} MATCHES "px4_io")
-
-	add_library(px4_layer
-		px4_nuttx_tasks.c
-		px4_nuttx_impl.cpp
-		px4_init.cpp
+px4_add_module(
+	MODULE lib__work_queue__test__wqueue_test
+	MAIN wqueue_test
+	SRCS
+		wqueue_main.cpp
+		wqueue_scheduled_test.cpp
+		wqueue_start.cpp
+		wqueue_test.cpp
+	DEPENDS
+		px4_work_queue
 	)
-	target_link_libraries(px4_layer
-		PRIVATE
-			nuttx_apps # up_cxxinitialize
-			nuttx_sched
-			drivers_boards_common_arch
-			px4_work_queue
-		)
-else()
-	add_library(px4_layer ${PX4_SOURCE_DIR}/src/platforms/empty.c)
-endif()
-add_dependencies(px4_layer prebuild_targets)

--- a/src/platforms/common/px4_work_queue/test/wqueue_main.cpp
+++ b/src/platforms/common/px4_work_queue/test/wqueue_main.cpp
@@ -1,0 +1,25 @@
+
+#include "wqueue_test.h"
+#include "wqueue_scheduled_test.h"
+
+#include <px4_log.h>
+#include <px4_middleware.h>
+#include <px4_app.h>
+#include <stdio.h>
+
+int PX4_MAIN(int argc, char **argv)
+{
+	px4::init(argc, argv, "wqueue_test");
+
+	PX4_INFO("wqueue test 1");
+	WQueueTest wq1;
+	wq1.main();
+
+	PX4_INFO("wqueue test 2 (scheduled)");
+	WQueueScheduledTest wq2;
+	wq2.main();
+
+	PX4_INFO("wqueue test complete, exiting");
+
+	return 0;
+}

--- a/src/platforms/common/px4_work_queue/test/wqueue_scheduled_test.cpp
+++ b/src/platforms/common/px4_work_queue/test/wqueue_scheduled_test.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2012 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,70 +31,50 @@
  *
  ****************************************************************************/
 
-/**
- * @file List.hpp
- *
- * A linked list.
- */
+#include "wqueue_scheduled_test.h"
 
-#pragma once
+#include <drivers/drv_hrt.h>
+#include <px4_log.h>
+#include <px4_time.h>
 
-template<class T>
-class ListNode
+#include <unistd.h>
+#include <stdio.h>
+#include <inttypes.h>
+
+using namespace px4;
+
+AppState WQueueScheduledTest::appState;
+
+void WQueueScheduledTest::Run()
 {
-public:
+	//PX4_INFO("iter: %d elapsed: %" PRId64 " us", _iter, hrt_elapsed_time(&_qtime));
 
-	void setSibling(T sibling) { _sibling = sibling; }
-	const T getSibling() const { return _sibling; }
-
-protected:
-
-	T _sibling{nullptr};
-
-};
-
-template<class T>
-class List
-{
-public:
-
-	void add(T newNode)
-	{
-		newNode->setSibling(getHead());
-		_head = newNode;
+	if (_iter > 1000) {
+		appState.requestExit();
 	}
 
-	bool remove(T removeNode)
-	{
-		// base case
-		if (removeNode == _head) {
-			_head = nullptr;
-			return true;
-		}
+	_iter++;
+}
 
-		for (T node = _head; node != nullptr; node = node->getSibling()) {
-			// is sibling the node to remove?
-			if (node->getSibling() == removeNode) {
-				// replace sibling
-				if (node->getSibling() != nullptr) {
-					node->setSibling(node->getSibling()->getSibling());
+int WQueueScheduledTest::main()
+{
+	appState.setRunning(true);
 
-				} else {
-					node->setSibling(nullptr);
-				}
+	_iter = 0;
 
-				return true;
-			}
-		}
+	// Put work in the work queue
+	ScheduleOnInterval(4000);
 
-		return false;
+	// Wait for work to finsh
+	while (!appState.exitRequested()) {
+		px4_usleep(10000);
 	}
 
-	const T getHead() const { return _head; }
+	PX4_INFO("WQueueScheduledTest finished");
 
-	bool empty() const { return _head == nullptr; }
+	//print_status();
 
-protected:
+	px4_sleep(2);
 
-	T _head{nullptr};
-};
+	return 0;
+}

--- a/src/platforms/common/px4_work_queue/test/wqueue_scheduled_test.h
+++ b/src/platforms/common/px4_work_queue/test/wqueue_scheduled_test.h
@@ -1,0 +1,24 @@
+
+#pragma once
+
+#include <px4_app.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
+#include <string.h>
+
+using namespace px4;
+
+class WQueueScheduledTest : public px4::ScheduledWorkItem
+{
+public:
+	WQueueScheduledTest() : px4::ScheduledWorkItem(px4::wq_configurations[test2]) {}
+	~WQueueScheduledTest() = default;
+
+	int main();
+
+	void Run() override;
+
+	static px4::AppState appState; /* track requests to terminate app */
+
+private:
+	int _iter{0};
+};

--- a/src/platforms/common/px4_work_queue/test/wqueue_test.cpp
+++ b/src/platforms/common/px4_work_queue/test/wqueue_test.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2012 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,70 +31,53 @@
  *
  ****************************************************************************/
 
-/**
- * @file List.hpp
- *
- * A linked list.
- */
+#include "wqueue_test.h"
 
-#pragma once
+#include <drivers/drv_hrt.h>
+#include <px4_log.h>
+#include <px4_time.h>
 
-template<class T>
-class ListNode
+#include <unistd.h>
+#include <stdio.h>
+#include <inttypes.h>
+
+using namespace px4;
+
+AppState WQueueTest::appState;
+
+void WQueueTest::Run()
 {
-public:
+	//PX4_INFO("iter: %d elapsed: %" PRId64 " us", _iter, hrt_elapsed_time(&_qtime));
 
-	void setSibling(T sibling) { _sibling = sibling; }
-	const T getSibling() const { return _sibling; }
+	if (_iter > 10000) {
+		appState.requestExit();
 
-protected:
-
-	T _sibling{nullptr};
-
-};
-
-template<class T>
-class List
-{
-public:
-
-	void add(T newNode)
-	{
-		newNode->setSibling(getHead());
-		_head = newNode;
+	} else {
+		ScheduleNow();
 	}
 
-	bool remove(T removeNode)
-	{
-		// base case
-		if (removeNode == _head) {
-			_head = nullptr;
-			return true;
-		}
+	_iter++;
+}
 
-		for (T node = _head; node != nullptr; node = node->getSibling()) {
-			// is sibling the node to remove?
-			if (node->getSibling() == removeNode) {
-				// replace sibling
-				if (node->getSibling() != nullptr) {
-					node->setSibling(node->getSibling()->getSibling());
+int WQueueTest::main()
+{
+	appState.setRunning(true);
 
-				} else {
-					node->setSibling(nullptr);
-				}
+	_iter = 0;
 
-				return true;
-			}
-		}
+	// Put work in the work queue
+	ScheduleNow();
 
-		return false;
+	// Wait for work to finsh
+	while (!appState.exitRequested()) {
+		px4_usleep(5000);
 	}
 
-	const T getHead() const { return _head; }
+	PX4_INFO("WQueueTest finished");
 
-	bool empty() const { return _head == nullptr; }
+	//print_status();
 
-protected:
+	px4_sleep(2);
 
-	T _head{nullptr};
-};
+	return 0;
+}

--- a/src/platforms/common/px4_work_queue/test/wqueue_test.h
+++ b/src/platforms/common/px4_work_queue/test/wqueue_test.h
@@ -1,0 +1,24 @@
+
+#pragma once
+
+#include <px4_app.h>
+#include <px4_work_queue/WorkItem.hpp>
+#include <string.h>
+
+using namespace px4;
+
+class WQueueTest : public px4::WorkItem
+{
+public:
+	WQueueTest() : px4::WorkItem(px4::wq_configurations[test1]) {}
+	~WQueueTest() = default;
+
+	int main();
+
+	void Run() override;
+
+	static px4::AppState appState; /* track requests to terminate app */
+
+private:
+	int _iter{0};
+};


### PR DESCRIPTION
ORB callback mechanism for new px4 work queue.
**Requires https://github.com/PX4/Firmware/pull/11570.**

This is another option for scheduling WorkItems and is something I've bolted onto uORB itself. The common pattern throughout most PX4 modules is a task that sits waiting for a particular uORB publication before running (currently implemented with `poll()`). In many cases these processes are fundamentally serialized, so the coexistence of all multiple tasks wastes quite a lot of memory. Any work pipeline (a collection of tasks) that's fundamentally serial can be moved to share the same WorkQueue. Then we can lean on the uORB publication to schedule appropriate work.

Examples
 - `IMU filter` -> `rate controller` -> `PWM output module` (https://github.com/PX4/Firmware/tree/pr-vehicle_rates_mc_rate)
 - `IMU integration` -> `Estimator` -> `attitude controller` -> `position controller` (future work)