### PR TITLE
jMAVSim: update submodule, use -lockstep CLI arg

### DIFF
--- a/Tools/jmavsim_run.sh
+++ b/Tools/jmavsim_run.sh
@@ -61,11 +61,11 @@ fi
 ant create_run_jar copy_res
 cd out/production
 
-java -XX:GCTimeRatio=20 -Djava.ext.dirs= -jar jmavsim_run.jar $device $extra_args
+java -XX:GCTimeRatio=20 -Djava.ext.dirs= -jar jmavsim_run.jar -lockstep $device $extra_args
 ret=$?
 if [ $ret -ne 0 -a $ret -ne 130 ]; then # 130 is Ctrl-C
 	# if the start of java fails, it's probably because the GC option is not
 	# understood. Try starting without it
-	java -Djava.ext.dirs= -jar jmavsim_run.jar $device $extra_args
+	java -Djava.ext.dirs= -jar jmavsim_run.jar -lockstep $device $extra_args
 fi
 


### PR DESCRIPTION
This updates the jMAVSim submodule which includes a fix for HITL.
In order to fix HITL, a CLI argument `-lockstep` was required to enable
lockstep. This has now been added to the command in jmavsim_run.sh.

Contains https://github.com/PX4/jMAVSim/pull/94.