### PR TITLE
re-word Preflight Fail msg, attempt 2

### DIFF
--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -555,7 +555,7 @@ static bool ekf2Check(orb_advert_t *mavlink_log_pub, vehicle_status_s &vehicle_s
 
 	if (status.pos_test_ratio > test_limit) {
 		if (report_fail) {
-			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Horizontal position estimate Error");
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Position estimate Error");
 		}
 
 		success = false;

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -531,7 +531,7 @@ static bool ekf2Check(orb_advert_t *mavlink_log_pub, vehicle_status_s &vehicle_s
 
 	if (status.hgt_test_ratio > test_limit) {
 		if (report_fail) {
-			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Height estimate Error");
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Height estimate error");
 		}
 
 		success = false;
@@ -543,7 +543,7 @@ static bool ekf2Check(orb_advert_t *mavlink_log_pub, vehicle_status_s &vehicle_s
 
 	if (status.vel_test_ratio > test_limit) {
 		if (report_fail) {
-			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Velocity estimate Error");
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Velocity estimate error");
 		}
 
 		success = false;
@@ -555,7 +555,7 @@ static bool ekf2Check(orb_advert_t *mavlink_log_pub, vehicle_status_s &vehicle_s
 
 	if (status.pos_test_ratio > test_limit) {
 		if (report_fail) {
-			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Position estimate Error");
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Position estimate error");
 		}
 
 		success = false;
@@ -567,7 +567,7 @@ static bool ekf2Check(orb_advert_t *mavlink_log_pub, vehicle_status_s &vehicle_s
 
 	if (status.mag_test_ratio > test_limit) {
 		if (report_fail) {
-			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Yaw estimate Error");
+			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Yaw estimate error");
 		}
 
 		success = false;


### PR DESCRIPTION
My recent PR exceeded the 50 char limit (apparently the last character must be null?).  ref: https://github.com/PX4/Firmware/pull/11480

This new attempt changes: "Preflight Fail: Horizontal position estimate Error"  to: "Preflight Fail: Position estimate error"

In fact, this newest wording is more easily understood by the average user and is actually more consistent with the other COM_ARM_EKF_xxx related errors:

COM_ARM_EKF_HGT --> "Preflight Fail: Height estimate error"
COM_ARM_EKF_VEL --> "Preflight Fail: Velocity estimate error"
COM_ARM_EKF_POS --> "Preflight Fail: Position estimate error"
COM_ARM_EKF_YAW --> "Preflight Fail: Yaw estimate error"

edit: I also changed the capitalization of "error" in the 4 messages above.