### PR TITLE
Rename Tunes::get_next_tune() to Tunes::get_next_note().

### DIFF
--- a/src/drivers/tone_alarm/ToneAlarm.cpp
+++ b/src/drivers/tone_alarm/ToneAlarm.cpp
@@ -98,7 +98,7 @@ void ToneAlarm::next_note()
 		_silence_length = 0;
 
 	} else if (_play_tone) {
-		int parse_ret_val = _tunes.get_next_tune(frequency, duration, _silence_length);
+		int parse_ret_val = _tunes.get_next_note(frequency, duration, _silence_length);
 
 		if (parse_ret_val > 0) {
 			// Continue playing.

--- a/src/lib/tunes/tunes.cpp
+++ b/src/lib/tunes/tunes.cpp
@@ -147,10 +147,10 @@ void Tunes::set_string(const char *const string, uint8_t strength)
 	}
 }
 
-int Tunes::get_next_tune(unsigned &frequency, unsigned &duration,
+int Tunes::get_next_note(unsigned &frequency, unsigned &duration,
 			 unsigned &silence, uint8_t &strength)
 {
-	int ret = get_next_tune(frequency, duration, silence);
+	int ret = get_next_note(frequency, duration, silence);
 
 	// Check if note should not be heard -> adjust strength to 0 to be safe.
 	if (frequency == 0 || duration == 0) {
@@ -163,7 +163,7 @@ int Tunes::get_next_tune(unsigned &frequency, unsigned &duration,
 	return ret;
 }
 
-int Tunes::get_next_tune(unsigned &frequency, unsigned &duration,
+int Tunes::get_next_note(unsigned &frequency, unsigned &duration,
 			 unsigned &silence)
 {
 	// Return the values for frequency and duration if the custom msg was received.

--- a/src/lib/tunes/tunes.h
+++ b/src/lib/tunes/tunes.h
@@ -100,7 +100,7 @@ public:
 	 * @param  silence   return silence duration (us)
 	 * @return           -1 for error, 0 for play one tone and 1 for continue a sequence
 	 */
-	int get_next_tune(unsigned &frequency, unsigned &duration, unsigned &silence);
+	int get_next_note(unsigned &frequency, unsigned &duration, unsigned &silence);
 
 	/**
 	 * Get next note in the current tune, which has been provided by either
@@ -111,7 +111,7 @@ public:
 	 * @param  strength  return the strength of the note (between 0-100)
 	 * @return           -1 for error, 0 for play one tone and 1 for continue a sequence
 	 */
-	int get_next_tune(unsigned &frequency, unsigned &duration,
+	int get_next_note(unsigned &frequency, unsigned &duration,
 			  unsigned &silence, uint8_t &strength);
 
 	/**

--- a/src/systemcmds/tune_control/tune_control.cpp
+++ b/src/systemcmds/tune_control/tune_control.cpp
@@ -202,7 +202,7 @@ tune_control_main(int argc, char *argv[])
 			PX4_INFO("Start playback...");
 			tunes.set_string(tune_string, tune_control.strength);
 
-			while (tunes.get_next_tune(frequency, duration, silence, strength) > 0) {
+			while (tunes.get_next_note(frequency, duration, silence, strength) > 0) {
 				tune_control.tune_id = 0;
 				tune_control.frequency = (uint16_t)frequency;
 				tune_control.duration = (uint32_t)duration;
@@ -236,7 +236,7 @@ tune_control_main(int argc, char *argv[])
 			PX4_WARN("Tune ID not recognized.");
 		}
 
-		while (tunes.get_next_tune(frequency, duration, silence, strength) > 0) {
+		while (tunes.get_next_note(frequency, duration, silence, strength) > 0) {
 			PX4_INFO("frequency: %d, duration %d, silence %d, strength%d",
 				 frequency, duration, silence, strength);
 			px4_usleep(500000);


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
The current `Tunes::get_next_tune()` name is somewhat misleading.  This PR renames `get_next_tune()` to `get_next_note()` to clarify what is taking place within the method.

Let me know if you'd prefer to see anything different in this PR!  Thanks!

-Mark

@bkueng, @catch-twenty-two 