### PR TITLE
Break apart handle_message() method into multiple handle_message_xxx() methods in simulator_mavlink.cpp…

### DIFF
--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -332,6 +332,7 @@ private:
 
 	void handle_message(mavlink_message_t *msg, bool publish);
 	void handle_message_distance_sensor(const mavlink_message_t *msg);
+	void handle_message_hil_state_quaternion(const mavlink_message_t *msg);
 	void handle_message_landing_target(const mavlink_message_t *msg);
 	void handle_message_optical_flow(const mavlink_message_t *msg);
 

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -331,6 +331,7 @@ private:
 	mavlink_hil_actuator_controls_t actuator_controls_from_outputs(const actuator_outputs_s &actuators);
 
 	void handle_message(mavlink_message_t *msg, bool publish);
+	void handle_message_distance_sensor(const mavlink_message_t *msg);
 	void handle_message_landing_target(const mavlink_message_t *msg);
 
 	void parameters_update(bool force);

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -331,6 +331,8 @@ private:
 	mavlink_hil_actuator_controls_t actuator_controls_from_outputs(const actuator_outputs_s &actuators);
 
 	void handle_message(mavlink_message_t *msg, bool publish);
+	void handle_message_landing_target(const mavlink_message_t *msg);
+
 	void parameters_update(bool force);
 	void poll_topics();
 	void pollForMAVLinkMessages(bool publish);

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -333,6 +333,7 @@ private:
 	void handle_message(mavlink_message_t *msg, bool publish);
 	void handle_message_distance_sensor(const mavlink_message_t *msg);
 	void handle_message_landing_target(const mavlink_message_t *msg);
+	void handle_message_optical_flow(const mavlink_message_t *msg);
 
 	void parameters_update(bool force);
 	void poll_topics();

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -368,9 +368,7 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 		break;
 
 	case MAVLINK_MSG_ID_DISTANCE_SENSOR:
-		mavlink_distance_sensor_t dist;
-		mavlink_msg_distance_sensor_decode(msg, &dist);
-		publish_distance_topic(&dist);
+		handle_message_distance_sensor(msg);
 		break;
 
 	case MAVLINK_MSG_ID_HIL_GPS:
@@ -497,6 +495,13 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 		break;
 	}
 
+}
+
+void Simulator::handle_message_distance_sensor(const mavlink_message_t *msg)
+{
+	mavlink_distance_sensor_t dist;
+	mavlink_msg_distance_sensor_decode(msg, &dist);
+	publish_distance_topic(&dist);
 }
 
 void Simulator::handle_message_landing_target(const mavlink_message_t *msg)

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -357,9 +357,7 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 		break;
 
 	case MAVLINK_MSG_ID_HIL_OPTICAL_FLOW:
-		mavlink_hil_optical_flow_t flow;
-		mavlink_msg_hil_optical_flow_decode(msg, &flow);
-		publish_flow_topic(&flow);
+		handle_message_optical_flow(msg);
 		break;
 
 	case MAVLINK_MSG_ID_ODOMETRY:
@@ -520,6 +518,13 @@ void Simulator::handle_message_landing_target(const mavlink_message_t *msg)
 
 	int irlock_multi;
 	orb_publish_auto(ORB_ID(irlock_report), &_irlock_report_pub, &report, &irlock_multi, ORB_PRIO_HIGH);
+}
+
+void Simulator::handle_message_optical_flow(const mavlink_message_t *msg)
+{
+	mavlink_hil_optical_flow_t flow;
+	mavlink_msg_hil_optical_flow_decode(msg, &flow);
+	publish_flow_topic(&flow);
 }
 
 void Simulator::send_mavlink_message(const mavlink_message_t &aMsg)

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -398,21 +398,7 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 		break;
 
 	case MAVLINK_MSG_ID_LANDING_TARGET: {
-			mavlink_landing_target_t landing_target_mavlink;
-			mavlink_msg_landing_target_decode(msg, &landing_target_mavlink);
-
-			struct irlock_report_s report = {};
-
-			report.timestamp = hrt_absolute_time();
-			report.signature = landing_target_mavlink.target_num;
-			report.pos_x = landing_target_mavlink.angle_x;
-			report.pos_y = landing_target_mavlink.angle_y;
-			report.size_x = landing_target_mavlink.size_x;
-			report.size_y = landing_target_mavlink.size_y;
-
-			int irlock_multi;
-			orb_publish_auto(ORB_ID(irlock_report), &_irlock_report_pub, &report, &irlock_multi, ORB_PRIO_HIGH);
-
+			handle_message_landing_target(msg);
 			break;
 		}
 
@@ -511,6 +497,24 @@ void Simulator::handle_message(mavlink_message_t *msg, bool publish)
 		break;
 	}
 
+}
+
+void Simulator::handle_message_landing_target(const mavlink_message_t *msg)
+{
+	mavlink_landing_target_t landing_target_mavlink;
+	mavlink_msg_landing_target_decode(msg, &landing_target_mavlink);
+
+	struct irlock_report_s report = {};
+
+	report.timestamp = hrt_absolute_time();
+	report.signature = landing_target_mavlink.target_num;
+	report.pos_x = landing_target_mavlink.angle_x;
+	report.pos_y = landing_target_mavlink.angle_y;
+	report.size_x = landing_target_mavlink.size_x;
+	report.size_y = landing_target_mavlink.size_y;
+
+	int irlock_multi;
+	orb_publish_auto(ORB_ID(irlock_report), &_irlock_report_pub, &report, &irlock_multi, ORB_PRIO_HIGH);
 }
 
 void Simulator::send_mavlink_message(const mavlink_message_t &aMsg)


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR cuts/pastes code from the monolithic `Simulator::handle_message()` method into multiple `Simulator::handle_message_xxx()` methods in `simulator_mavlink.cpp` as is currently done in the `MavlinkReceiver` class in `mavlink_receiver.cpp`.

@bkueng and @catch-twenty-two  this work should help prepare for an equivalent `Simulator::handle_message_play_tune(mavlink_message_t *msg)` method to be created.

Let me know if you have any questions on this PR!  Thanks!

-Mark
