### PR TITLE
mavlink/MavlinkReceiver: Use hrt_absolute_time for distance_sensor timestamps

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -824,7 +824,7 @@ MavlinkReceiver::handle_message_distance_sensor(mavlink_message_t *msg)
 	struct distance_sensor_s d;
 	memset(&d, 0, sizeof(d));
 
-	d.timestamp = dist_sensor.time_boot_ms * 1000; /* ms to us */
+	d.timestamp = hrt_absolute_time(); /* Use system time for now, don't trust sender to attach correct timestamp */
 	d.min_distance = float(dist_sensor.min_distance) * 1e-2f; /* cm to m */
 	d.max_distance = float(dist_sensor.max_distance) * 1e-2f; /* cm to m */
 	d.current_distance = float(dist_sensor.current_distance) * 1e-2f; /* cm to m */


### PR DESCRIPTION
As of the current master, ```MavlinkReceiver``` uses the timestamp from [```distance_sensor```](https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR) message. Unfortunately, the timestamp used in [```distance_sensor```](https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR) is ```time_boot_ms```, which is the amount of time since device boot. Filling this field properly requires converting the timestamp from sender's to FCU's, which some senders neglect (case in point: ```mavros```'s [```distacnce_sensor``` plugin](https://github.com/mavlink/mavros/blob/master/mavros_extras/src/plugins/distance_sensor.cpp#L294) that sends ROS's timestamp instead of FCU's).

Since filling this field properly is not always a trivial task, I suggest using ```hrt_absolute_time``` instead. Other messages that have ```time_boot_ms``` already seem to be using that. That's suboptimal, but at least gets us to a working state.

A better solution would probably be to use ```time_usec``` in all MAVLink messages, but that would require a major overhaul of the protocol. Another option is to review and fix all MAVLink senders that send ```distance_sensor``` message; still, that would probably be as much (or even more) work to implement.

For the record, our use case is using a distance sensor that is not directly attached to the FCU. Data is sent to the FCU via MAVROS.