### PR TITLE
Rename Simulator class methods names to match convention in the class

### DIFF
--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -160,18 +160,18 @@ int Simulator::start(int argc, char *argv[])
 		}
 
 		if (argv[2][1] == 's') {
-			_instance->initializeSensorData();
+			_instance->initialize_sensor_data();
 #ifndef __PX4_QURT
 			// Update sensor data
-			_instance->pollForMAVLinkMessages(false);
+			_instance->poll_for_MAVLink_messages(false);
 #endif
 
 		} else if (argv[2][1] == 'p') {
 			// Update sensor data
-			_instance->pollForMAVLinkMessages(true);
+			_instance->poll_for_MAVLink_messages(true);
 
 		} else {
-			_instance->initializeSensorData();
+			_instance->initialize_sensor_data();
 			_instance->_initialized = true;
 		}
 

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -272,7 +272,7 @@ private:
 	}
 
 	// class methods
-	void initializeSensorData();
+	void initialize_sensor_data();
 
 	int publish_sensor_topics(mavlink_hil_sensor_t *imu);
 	int publish_flow_topic(mavlink_hil_optical_flow_t *flow);
@@ -333,7 +333,7 @@ private:
 	void handle_message(mavlink_message_t *msg, bool publish);
 	void parameters_update(bool force);
 	void poll_topics();
-	void pollForMAVLinkMessages(bool publish);
+	void poll_for_MAVLink_messages(bool publish);
 	void request_hil_state_quaternion();
 	void send();
 	void send_controls();

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -614,7 +614,7 @@ void Simulator::send_heartbeat()
 	send_mavlink_message(message);
 }
 
-void Simulator::initializeSensorData()
+void Simulator::initialize_sensor_data()
 {
 	// Write sensor data to memory so that drivers can copy data from there.
 	RawMPUData mpu = {};
@@ -646,7 +646,7 @@ void Simulator::initializeSensorData()
 	write_airspeed_data(&airspeed);
 }
 
-void Simulator::pollForMAVLinkMessages(bool publish)
+void Simulator::poll_for_MAVLink_messages(bool publish)
 {
 #ifdef __PX4_DARWIN
 	pthread_setname_np("sim_rcv");


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR renames only the `private` class method names to match the snake case naming convention of other methods in this class.

This PR follows cleanup in PR #11447 .

Let me know if you'd prefer to see anything different done with this PR.  Thanks!

-Mark

