### PR TITLE
navigator: Reset vehicle_roi before a mission

### DIFF
--- a/src/modules/navigator/mission.cpp
+++ b/src/modules/navigator/mission.cpp
@@ -448,6 +448,11 @@ Mission::update_mission()
 	/* reset triplets */
 	_navigator->reset_triplets();
 
+	/* Reset vehicle_roi
+	 * Missions that do not explicitly configure ROI would not override
+	 * an existing ROI setting from previous missions */
+	_navigator->reset_vroi();
+
 	struct mission_s old_mission = _mission;
 
 	if (orb_copy(ORB_ID(mission), _navigator->get_mission_sub(), &_mission) == OK) {

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -159,6 +159,7 @@ public:
 	PrecLand *get_precland() { return &_precland; } /**< allow others, e.g. Mission, to use the precision land block */
 
 	const vehicle_roi_s &get_vroi() { return _vroi; }
+	void reset_vroi() { _vroi = {}; }
 
 	bool home_alt_valid() { return (_home_pos.timestamp > 0 && _home_pos.valid_alt); }
 	bool home_position_valid() { return (_home_pos.timestamp > 0 && _home_pos.valid_alt && _home_pos.valid_hpos); }


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Navigator parses ROI `vehicle_command` messages into `vehicle_roi` messages and keeps this info as a class member:

https://github.com/PX4/Firmware/blob/6762f094906cfd4c53d35e1b1ab5d1fb44bb2cc2/src/modules/navigator/navigator.h#L330

These `vehicle_command` messages can be triggered by specific mission items. Problem is that the navigator's information is never flushed/reset, except for when it's overwritten by a new ROI setting. 

In the case where a mission with an ROI item is flown, followed by a mission without any ROI items, the navigator's member `_vroi` is outdated. Calling this
https://github.com/PX4/Firmware/blob/6762f094906cfd4c53d35e1b1ab5d1fb44bb2cc2/src/modules/navigator/navigator.h#L161

will therefore return information not matching the current mission.

**Describe your preferred solution**
The proposed changes make navigator reset `_vroi` whenever a new mission is loaded. Missions with a ROI mission item will overwrite it anyway. In any event, calling `get_vroi()` always reflects the current mission's settings according to navigator.

**Additional context**
Note that navigator sends out a `vehicle_roi` uorb message when it receives a ROI command:
https://github.com/PX4/Firmware/blob/6762f094906cfd4c53d35e1b1ab5d1fb44bb2cc2/src/modules/navigator/navigator_main.cpp#L525-L532

So whatever component receives `vehicle_roi` messages might still have the old one buffered. I thought about re-sending an empty `vehicle_roi` message when resetting it in navigator, but decided against it:
1. In many PX4 modules the last setting remains until specifically overwritten.
2. Other modules might also publish `vehicle_roi` messages, in which case navigator's internal copy is outdated anyway. 

In practice this doesn't change anything yet, except for that `Navigator::get_vroi` always returns the up-to-date ROI setting **from the navigator's perspective**. 