### PR TITLE
gpssim: populate s_variance_m_s with 0.25

### DIFF
--- a/src/modules/simulator/gpssim/gpssim.cpp
+++ b/src/modules/simulator/gpssim/gpssim.cpp
@@ -286,6 +286,7 @@ GPSSIM::receive(int timeout)
 		_report_gps_pos.cog_rad = (float)(gps.cog) * 3.1415f / (100.0f * 180.0f);
 		_report_gps_pos.fix_type = gps.fix_type;
 		_report_gps_pos.satellites_used = gps.satellites_visible;
+		_report_gps_pos.s_variance_m_s = 0.25f;
 
 		timestamp_last = gps.timestamp;
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Solves https://github.com/PX4/sitl_gazebo/issues/285

gps->s_variance_m_s was published as zero in SITL which is bad since the EKF is using it at several places e.g. to initialize the uncertainty in the velocity states

**Plots:**
PR (left) vs Master (right)
![image](https://user-images.githubusercontent.com/7795133/53248608-66505800-36b6-11e9-997b-54f4443b2c26.png)



