### PR TITLE
Makefile: streamline cmake-build & cleanup nuttx_, _default targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -439,6 +439,7 @@ distclean: gazeboclean
 	@git submodule deinit -f .
 	@git clean -ff -x -d -e ".project" -e ".cproject" -e ".idea" -e ".settings" -e ".vscode"
 
+# Help / Error
 # --------------------------------------------------------------------
 
 # All other targets are handled by PX4_MAKE. Add a rule here to avoid printing an error.
@@ -446,22 +447,14 @@ distclean: gazeboclean
 	$(if $(filter $(FIRST_ARG),$@), \
 		$(error "$@ cannot be the first argument. Use '$(MAKE) help|list_config_targets' to get a list of all possible [configuration] targets."),@#)
 
-#help:
-#	@echo
-#	@echo "Type 'make ' and hit the tab key twice to see a list of the available"
-#	@echo "build configurations."
-#	@echo
-
-empty :=
-space := $(empty) $(empty)
-
 # Print a list of non-config targets (based on http://stackoverflow.com/a/26339924/1487069)
+space := $(subst ,, )
 help:
 	@echo "Usage: $(MAKE) <target>"
 	@echo "Where <target> is one of:"
 	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | \
 		awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | \
-		egrep -v -e '^[^[:alnum:]]' -e '^($(subst $(space),|,$(ALL_CONFIG_TARGETS) $(NUTTX_CONFIG_TARGETS)))$$' -e '_default$$' -e '^(posix|eagle|Makefile)'
+		egrep -v -e '^[^[:alnum:]]' -e '^($(subst $(space),|,$(ALL_CONFIG_TARGETS)))$$' -e '_default$$' -e '^(posix|eagle|Makefile)'
 	@echo
 	@echo "Or, $(MAKE) <config_target> [<make_target(s)>]"
 	@echo "Use '$(MAKE) list_config_targets' for a list of configuration targets."


### PR DESCRIPTION
**Test data / coverage**
Cygwin Windows SITL, draft unit test builds and some manual artificial test target builds to check for corner cases.

**Describe problem solved by the proposed pull request**
1. CMake invocations using the makefile function `cmake-build` were limited to the `-DCONFIG=$(PX4_CONFIG)` cmake parameter. There are currently multiple other makefile targets e.g. `python_coverage`, `scan-build`, `px4_sitl_default-clang`, ... that also run cmake with their own invocation which could easily be streamlined to just calling the `cmake-build` function that containes the latest tweaks for generator transitions, space escaping, caching. I came across this solution since I'm looking into how to best unify and improve unit testing setup (see the early draft here: https://github.com/PX4/Firmware/compare/master...MaEtUgR:gtest#diff-b67911656ef5d18c4ae36cb6741b7965R323).
1. Switched to the `cmake --build ...` command to abstract the actually used build tool (see https://cmake.org/cmake/help/v2.8.11/cmake.html#opt%3a--builddir).
1. The `NUTTX_CONFIG_TARGETS` target list was removed by @dagar in https://github.com/PX4/Firmware/commit/f692ad04d0ea22b8874926e9dc0cac23263bbeae#diff-b67911656ef5d18c4ae36cb6741b7965L162 because the `nuttx_` prefix does not exist anymore. If this filtered multi target is still needed the list generation needs to be reimplemented anyways.
1. If we already have a multitarget for all defaults I also added one for all the targets `ALL_CONFIG_TARGETS` for testing purposes
1. Improved cmake reconfiguration necessity detection see https://github.com/PX4/Firmware/pull/11533#issuecomment-467189536
1. Readability, comments
