### PR TITLE
Jenkins increase history retention

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -100,7 +100,7 @@ pipeline {
   }
 
   options {
-    buildDiscarder(logRotator(numToKeepStr: '10', artifactDaysToKeepStr: '14'))
+    buildDiscarder(logRotator(numToKeepStr: '10', artifactDaysToKeepStr: '30'))
     timeout(time: 60, unit: 'MINUTES')
   }
 } // pipeline

--- a/.ci/Jenkinsfile-SITL_tests_coverage
+++ b/.ci/Jenkinsfile-SITL_tests_coverage
@@ -119,7 +119,7 @@ pipeline {
   }
 
   options {
-    buildDiscarder(logRotator(numToKeepStr: '5', artifactDaysToKeepStr: '14'))
+    buildDiscarder(logRotator(numToKeepStr: '10', artifactDaysToKeepStr: '30'))
     timeout(time: 60, unit: 'MINUTES')
   }
 } // pipeline

--- a/.ci/Jenkinsfile-compile_mac
+++ b/.ci/Jenkinsfile-compile_mac
@@ -81,7 +81,7 @@ pipeline {
     CI = true
   }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '5', artifactDaysToKeepStr: '14'))
+    buildDiscarder(logRotator(numToKeepStr: '10', artifactDaysToKeepStr: '30'))
     timeout(time: 120, unit: 'MINUTES')
   }
 }

--- a/.ci/Jenkinsfile-hardware
+++ b/.ci/Jenkinsfile-hardware
@@ -83,7 +83,7 @@ pipeline {
     CI = true
   }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '5', artifactDaysToKeepStr: '30'))
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactDaysToKeepStr: '30'))
     timeout(time: 60, unit: 'MINUTES')
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -596,7 +596,7 @@ pipeline {
     GIT_COMMITTER_NAME = "PX4BuildBot"
   }
   options {
-    buildDiscarder(logRotator(numToKeepStr: '10', artifactDaysToKeepStr: '30'))
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactDaysToKeepStr: '30'))
     timeout(time: 60, unit: 'MINUTES')
   }
 }


### PR DESCRIPTION
We can increase the build history for most of Jenkins. It's really only Jenkins-compile that requires significant storage for archiving all the artifacts.


``` Console
ubuntu@ip-172-31-32-211:/mnt/jenkins/jenkins_home/jobs$ du -sh PX4/jobs/*
27M     PX4/jobs/Bootloader
34M     PX4/jobs/containers
5.0G    PX4/jobs/Devguide
258M    PX4/jobs/ecl
4.3G    PX4/jobs/Firmware
188K    PX4/jobs/libcxx
49M     PX4/jobs/NuttX
1.6M    PX4/jobs/NuttX-legacy
8.8G    PX4/jobs/px4-user-guide.us9mhv

ubuntu@ip-172-31-32-211:/mnt/jenkins/jenkins_home/jobs$ du -sh PX4_misc/jobs/*
20M     PX4_misc/jobs/check-slaves
28K     PX4_misc/jobs/ecl_coverity_scan
344K    PX4_misc/jobs/Firmware_branch_test_nuttx
124K    PX4_misc/jobs/Firmware_build_grind
122G    PX4_misc/jobs/Firmware-compile
80M     PX4_misc/jobs/Firmware-compile_mac
68K     PX4_misc/jobs/Firmware_coverity_scan
4.0M    PX4_misc/jobs/Firmware_flight_review_status
205M    PX4_misc/jobs/Firmware-hardware
72K     PX4_misc/jobs/Firmware_s3_deploy_beta
460K    PX4_misc/jobs/Firmware_s3_deploy_master
16K     PX4_misc/jobs/Firmware_s3_deploy_stable
20G     PX4_misc/jobs/Firmware-SITL_tests
1.8G    PX4_misc/jobs/Firmware-SITL_tests_coverage
16K     PX4_misc/jobs/Firmware_submodules_upstream
184K    PX4_misc/jobs/Firmware_update_submodules
100K    PX4_misc/jobs/Nuttx_update_apps
124K    PX4_misc/jobs/Nuttx_update_nuttx
```

### Jenkins (ci.px4.io) storage 
``` Console
ubuntu@ip-172-31-32-211:/mnt/jenkins/jenkins_home/jobs$ df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/xvda1       30G  3.3G   26G  12% /
/dev/xvdf1      296G  177G  119G  60% /mnt/jenkins

```