### PR TITLE
Avionics power only circuit breaker

### DIFF
--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -22,6 +22,7 @@ bool circuit_breaker_engaged_gpsfailure_check
 bool circuit_breaker_flight_termination_disabled
 bool circuit_breaker_engaged_usb_check
 bool circuit_breaker_engaged_posfailure_check	# set to true when the position valid checks have been disabled
+bool circuit_breaker_engaged_avionics_check
 
 bool offboard_control_signal_found_once
 bool offboard_control_signal_lost

--- a/src/lib/circuit_breaker/circuit_breaker.h
+++ b/src/lib/circuit_breaker/circuit_breaker.h
@@ -58,6 +58,7 @@
 #define CBRK_GPSFAIL_KEY	240024
 #define CBRK_USB_CHK_KEY	197848
 #define CBRK_VELPOSERR_KEY	201607
+#define CBRK_AVIO_CHK_KEY	586987
 
 #include <stdint.h>
 

--- a/src/lib/circuit_breaker/circuit_breaker_params.c
+++ b/src/lib/circuit_breaker/circuit_breaker_params.c
@@ -193,3 +193,18 @@ PARAM_DEFINE_INT32(CBRK_USB_CHK, 0);
  * @group Circuit Breaker
  */
 PARAM_DEFINE_INT32(CBRK_VELPOSERR, 0);
+
+/**
+ * Circuit breaker for power avionics check
+ *
+ * Setting this parameter to 586987 will disable the power avionics valid
+ * checks in the commander.
+ * WARNING: ENABLING THIS CIRCUIT BREAKER IS AT OWN RISK
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 586987
+ * @category Developer
+ * @group Circuit Breaker
+ */
+PARAM_DEFINE_INT32(CBRK_AVIO_CHK, 0);

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2603,6 +2603,7 @@ get_circuit_breaker_params()
 	status_flags.circuit_breaker_flight_termination_disabled = circuit_breaker_enabled("CBRK_FLIGHTTERM",
 			CBRK_FLIGHTTERM_KEY);
 	status_flags.circuit_breaker_engaged_posfailure_check = circuit_breaker_enabled("CBRK_VELPOSERR", CBRK_VELPOSERR_KEY);
+	status_flags.circuit_breaker_engaged_avionics_check = circuit_breaker_enabled("CBRK_AVIO_CHK", CBRK_AVIO_CHK_KEY);
 }
 
 void

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -703,7 +703,8 @@ bool preflightCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &status,
 	bool checkSensors = !hil_enabled;
 	const bool checkRC = (status.rc_input_mode == vehicle_status_s::RC_IN_MODE_DEFAULT);
 	const bool checkDynamic = !hil_enabled;
-	const bool checkPower = (status_flags.condition_power_input_valid && !status_flags.circuit_breaker_engaged_power_check);
+	const bool checkPower = (status_flags.condition_power_input_valid && !status_flags.circuit_breaker_engaged_power_check
+				 && !status_flags.circuit_breaker_engaged_avionics_check);
 
 	bool checkAirspeed = false;
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
The `CBRK_SUPPLY_CHK` circuit breaker is used  to disable the preflight checks
https://github.com/PX4/Firmware/blob/103fcc6c0583645e742a1ecac1651554bc73f9c3/src/modules/commander/PreflightCheck.cpp#L706 
https://github.com/PX4/Firmware/blob/103fcc6c0583645e742a1ecac1651554bc73f9c3/src/modules/commander/PreflightCheck.cpp#L936-L940
but also the low battery arming behavior.
https://github.com/PX4/Firmware/blob/103fcc6c0583645e742a1ecac1651554bc73f9c3/src/modules/commander/state_machine_helper.cpp#L909-L929 

**Describe your preferred solution**
The new circuit breaker `CBRK_AVIO_CHK` disables only the avionics checks (5V and 3.3V) without impacting the arming behavior on low battery. This solution does not impact the behavior on the `CBRK_SUPPLY_CHK` circuit breaker.

Maybe we should separate the two functionalities, thoughts?
