### PR TITLE
Correted list of serial ports for lpe target for fmu v2 board

### DIFF
--- a/boards/px4/fmu-v2/lpe.cmake
+++ b/boards/px4/fmu-v2/lpe.cmake
@@ -13,10 +13,10 @@ px4_add_board(
 	#UAVCAN_INTERFACES 2
 
 	SERIAL_PORTS
-		GPS1:/dev/ttyS0
+		GPS1:/dev/ttyS3
 		TEL1:/dev/ttyS1
 		TEL2:/dev/ttyS2
-		TEL4:/dev/ttyS3
+		TEL4:/dev/ttyS6
 
 	DRIVERS
 		#barometer # all available barometer drivers


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary.

**Test data / coverage**
After this modification GPS starts normally as it is should be

**Describe problem solved by the proposed pull request**
In LPE target the list of serial ports is different from default, due to this GPS starts with wrong serial port - ttyS0 instead of ttyS3

**Describe your preferred solution**
I have copied list of serial ports from default cmake list to LPE make list

**Describe possible alternatives**
No idea

**Additional context**
This issue can touch other boards, as you can see in screenshots in my topic
http://discuss.px4.io/t/lpe-issue-with-gps-serial-port-ttys0-insthead-of-ttys3/9753
