### PR TITLE
ManualSmoothVel - Split position lock condition and flag action

### DIFF
--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
@@ -180,16 +180,26 @@ void FlightTaskManualPositionSmoothVel::_updateSetpoints()
 	if (Vector2f(_vel_sp_smooth).length() < 0.01f &&
 	    Vector2f(_acceleration_setpoint).length() < .2f &&
 	    sticks_expo_xy.length() <= FLT_EPSILON) {
-		_position_setpoint_xy_locked(0) = pos_sp_smooth(0);
-		_position_setpoint_xy_locked(1) = pos_sp_smooth(1);
 		_position_lock_xy_active = true;
 	}
 
 	if (fabsf(_vel_sp_smooth(2)) < 0.01f &&
 	    fabsf(_acceleration_setpoint(2)) < .2f &&
 	    fabsf(_sticks_expo(2)) <= FLT_EPSILON) {
-		_position_setpoint_z_locked = pos_sp_smooth(2);
 		_position_lock_z_active = true;
+	}
+
+	// Set valid position setpoint while in position lock.
+	// When the position lock condition above is false, it does not
+	// mean that the unlock condition is true. This is why
+	// we are checking the lock flag here.
+	if (_position_lock_xy_active) {
+		_position_setpoint_xy_locked(0) = pos_sp_smooth(0);
+		_position_setpoint_xy_locked(1) = pos_sp_smooth(1);
+	}
+
+	if (_position_lock_z_active) {
+		_position_setpoint_z_locked = pos_sp_smooth(2);
 	}
 
 	_position_setpoint(0) = _position_setpoint_xy_locked(0);


### PR DESCRIPTION
In some special cases, the controller enters *position lock* and the velocity/acceleration setpoint leaves the *position lock* condition, without actually triggering the unlocking condition (condition depending on the stick only). The position setpoint then drift "behind the scenes" (because it's the integral of the non-zero velocity setpoint) and when the condition becomes again true, a severe position jump can occur. We had a jump of 10m due to a slow drift during a fixed hover of 1 min

This should **never** happen, but it seems that the trajectory generator fails to find a solution is some specific cases that lead to unexpected behaviors.

This PR doesn't fix the root cause of the problem, but at least, the drone will follow the drift (in my case, move 10m in 1min) and not do a sudden jump of 10m.

I'm actively trying to find the root issue but this PR has to be merged as that behavior could cause severe damages.

See below the position jump in the y axis at t=210s
![01_plot](https://user-images.githubusercontent.com/14822839/53366776-b47a8b00-3944-11e9-97b3-b37b41041846.png)
