### PR TITLE
Re-add glitch-free position unlock

### DIFF
--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -777,6 +777,10 @@ MulticopterPositionControl::run()
 			// vehicle intention.
 			publish_local_pos_sp(local_pos_sp);
 
+			// Inform FlightTask about the input and output of the velocity controller
+			// This is used to properly initialize the velocity setpoint when onpening the position loop (position unlock)
+			_flight_tasks.updateVelocityControllerIO(_control.getVelSp(), local_pos_sp.thrust);
+
 			// Part of landing logic: if ground-contact/maybe landed was detected, turn off
 			// controller. This message does not have to be logged as part of the vehicle_local_position_setpoint topic.
 			// Note: only adust thrust output if there was not thrust-setpoint demand in D-direction.


### PR DESCRIPTION
In #10746 I introduced a new trajectory generator for Auto and Manual Position control modes. In the position control part, information from the controller is used to properly initialize the velocity setpoint during a position unlock transition (position control -> velocity control) : https://github.com/PX4/Firmware/pull/10746/files#diff-fc77c3ef569029d45764664c75d4b0c1R773

The link has been broken in #11056 : https://github.com/PX4/Firmware/commit/5887a2393cefad7268d165e07352384be61e1404#diff-fc77c3ef569029d45764664c75d4b0c1L786

This PR re-introduce this strategy.

**Without this PR:**
The FlightTask ignores the previous velocity setpoint -> the velocity setpoint jumps -> jump in thrust/attitude setpoint
![position_unlock_glitch](https://user-images.githubusercontent.com/14822839/53481640-ee02e180-3a7d-11e9-841c-1d97c6306d43.png)

**With this PR:**
The velocity coming from the FlightTask initializes to the previous velocity setpoint -> no jump in thrust/attitude setpoint
![position_unlock_fix](https://user-images.githubusercontent.com/14822839/53481693-07a42900-3a7e-11e9-8f87-29aa17d9e009.png)

**NOTE:** thrust[2] is in the legend of the graphs above, but not shown in the graphs. The blue curve is vx.