### PR TITLE
MC rate controller: do not disable integrators at min/max throttle

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
@@ -31,7 +31,7 @@ then
 
 	param set MC_AIRMODE 2
 	param set MC_PITCHRATE_D 0.0010
-	param set MC_PITCHRATE_I 0.5
+	param set MC_PITCHRATE_I 0.4
 	param set MC_PITCHRATE_MAX 600
 	param set MC_PITCHRATE_P 0.0750
 	param set MC_PITCH_P 6

--- a/ROMFS/px4fmu_common/init.d/airframes/4050_generic_250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4050_generic_250
@@ -17,7 +17,7 @@ if [ $AUTOCNF = yes ]
 then
 	param set MC_ROLL_P 8
 	param set MC_ROLLRATE_P 0.08
-	param set MC_ROLLRATE_I 0.25
+	param set MC_ROLLRATE_I 0.2
 	param set MC_ROLLRATE_D 0.001
 	param set MC_PITCH_P 8
 	param set MC_PITCHRATE_P 0.08

--- a/ROMFS/px4fmu_common/init.d/airframes/4052_holybro_qav250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4052_holybro_qav250
@@ -26,14 +26,14 @@ then
 
 	param set MC_AIRMODE 1
 	param set MC_PITCHRATE_D 0.0012
-	param set MC_PITCHRATE_I 0.45
+	param set MC_PITCHRATE_I 0.25
 	param set MC_PITCHRATE_MAX 1200
-	param set MC_PITCHRATE_P 0.084
+	param set MC_PITCHRATE_P 0.082
 	param set MC_PITCH_P 8
 	param set MC_ROLLRATE_D 0.0012
-	param set MC_ROLLRATE_I 0.45
+	param set MC_ROLLRATE_I 0.2
 	param set MC_ROLLRATE_MAX 1200
-	param set MC_ROLLRATE_P 0.078
+	param set MC_ROLLRATE_P 0.076
 	param set MC_ROLL_P 8
 	param set MC_YAWRATE_I 0.3
 	param set MC_YAWRATE_MAX 600

--- a/src/lib/mixer/mixer.h
+++ b/src/lib/mixer/mixer.h
@@ -799,7 +799,7 @@ private:
 	 */
 	inline void mix_yaw(float yaw, float *outputs);
 
-	void update_saturation_status(unsigned index, bool clipping_high, bool clipping_low);
+	void update_saturation_status(unsigned index, bool clipping_high, bool clipping_low_roll_pitch, bool clipping_low_yaw);
 
 	float				_roll_scale;
 	float				_pitch_scale;


### PR DESCRIPTION
When trying to fly FPV with the Beta75X whoop, I noticed severe tracking loss in certain situations: the attitude would suddenly change by more than 30 degrees. This makes flying FPV very uncontrolled and pretty much unusable.
I then noticed it happened always at min/max throttle situations. The reason is that the [rate controller disables](https://github.com/PX4/Firmware/blob/master/src/modules/mc_att_control/mc_att_control_main.cpp#L702) the integrals due to saturation feedback from the mixer. However we don't have to do that because it's not really saturating, as thrust is reduced/boosted as needed instead.
So this PR makes sure the integrators keep running. As a result tracking is much better, therefore greatly improving the FPV experience (there are still various details we can improve).

The difference is best shown in a video, where I simply throttle straight up w/o any other stick input:
- master: https://youtu.be/w7M6FzuhuwQ
- with this patch: https://youtu.be/KIhiwJCIQPU

### Testing
Cross-tested on a 250 frame in pos/manual/acro with all 3 airmodes, landing and takeoff on uneven ground: I did not notice any difference in behavior.

---

Unrelated: both landing and takeoff are not handled well on uneven ground: w/o airmode the position controller just cuts throttle when landing, making the vehicle fall to the ground on the side where not touching ground yet. With airmode it's worse: after cutting throttle, the attitude is still kept level, thus the vehicle will touch only on one side (landing does get detected), and only when disarming it will fall even to the ground. We should make sure the attitude controller handles this smoothly. The effect is stronger, the better a vehicle is tuned.

---

One side-effect I noticed with this PR is that during flips the integrals now build up (for large step inputs), and you see a visible bounce-back after the flip, because it's overshooting. Therefore I reduced the I gains a bit where needed (most airframes have set it too low anyway, so not an issue in general). However there's a trade-off and we should find a better solution so we can keep the I gains high.

This is how it flies now: https://youtu.be/Fs_kdnzv_Js