### PR TITLE
Redefine Simulator::handle_message() prototype and create Simulator::set_publish() method.

### DIFF
--- a/src/modules/simulator/simulator.cpp
+++ b/src/modules/simulator/simulator.cpp
@@ -163,12 +163,13 @@ int Simulator::start(int argc, char *argv[])
 			_instance->initialize_sensor_data();
 #ifndef __PX4_QURT
 			// Update sensor data
-			_instance->poll_for_MAVLink_messages(false);
+			_instance->poll_for_MAVLink_messages();
 #endif
 
 		} else if (argv[2][1] == 'p') {
 			// Update sensor data
-			_instance->poll_for_MAVLink_messages(true);
+			_instance->set_publish(true);
+			_instance->poll_for_MAVLink_messages();
 
 		} else {
 			_instance->initialize_sensor_data();

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -344,7 +344,7 @@ private:
 	void send_controls();
 	void send_heartbeat();
 	void send_mavlink_message(const mavlink_message_t &aMsg);
-	void set_publish(const bool publish);
+	void set_publish(const bool publish = false);
 	void update_sensors(mavlink_hil_sensor_t *imu);
 	void update_gps(mavlink_hil_gps_t *gps_sim);
 

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -344,7 +344,7 @@ private:
 	void send_controls();
 	void send_heartbeat();
 	void send_mavlink_message(const mavlink_message_t &aMsg);
-	void set_publish(const bool publish = false);
+	void set_publish(const bool publish = true);
 	void update_sensors(mavlink_hil_sensor_t *imu);
 	void update_gps(mavlink_hil_gps_t *gps_sim);
 

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -330,7 +330,7 @@ private:
 
 	mavlink_hil_actuator_controls_t actuator_controls_from_outputs(const actuator_outputs_s &actuators);
 
-	void handle_message(mavlink_message_t *msg, bool publish);
+	void handle_message(mavlink_message_t *msg);
 	void handle_message_distance_sensor(const mavlink_message_t *msg);
 	void handle_message_hil_state_quaternion(const mavlink_message_t *msg);
 	void handle_message_landing_target(const mavlink_message_t *msg);
@@ -338,12 +338,13 @@ private:
 
 	void parameters_update(bool force);
 	void poll_topics();
-	void poll_for_MAVLink_messages(bool publish);
+	void poll_for_MAVLink_messages();
 	void request_hil_state_quaternion();
 	void send();
 	void send_controls();
 	void send_heartbeat();
 	void send_mavlink_message(const mavlink_message_t &aMsg);
+	void set_publish(const bool publish);
 	void update_sensors(mavlink_hil_sensor_t *imu);
 	void update_gps(mavlink_hil_gps_t *gps_sim);
 
@@ -365,6 +366,8 @@ private:
 	struct map_projection_reference_s _hil_local_proj_ref {};
 
 	bool _hil_local_proj_inited{false};
+	bool _publish{false};
+
 	double _hil_ref_lat{0};
 	double _hil_ref_lon{0};
 	float _hil_ref_alt{0.0f};

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -837,8 +837,10 @@ void Simulator::poll_for_MAVLink_messages()
 				for (int i = 0; i < len; ++i) {
 					if (mavlink_parse_char(MAVLINK_COMM_1, serial_buf[i], &msg, &serial_status)) {
 						// have a message, handle it
+						bool prev_publish = _publish;
 						set_publish(true);
 						handle_message(&msg);
+						set_publish(prev_publish);
 					}
 				}
 			}
@@ -846,8 +848,6 @@ void Simulator::poll_for_MAVLink_messages()
 
 #endif
 	}
-
-	set_publish(false);
 }
 
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR redefines the `Simulator::handle_message()` prototype to match `MavlinkReceiver::handle_message()` and creates the `Simulator::set_publish()` method and associated `_publish` member variable to preserve functionality.

The work in this PR creates the path for additional refactoring of the Simulator::handle_message() started in #11499.

Please let me know if you have any questions about this PR.  Thanks!

-Mark

@bkueng