### PR TITLE
Fix link to code style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ git checkout -b mydescriptivebranchname
 
 ### Edit and build the code
 
-The [developer guide](http://dev.px4.io/) explains how to set up the development environment on Mac OS, Linux or Windows. Please take note of our [coding style](http://px4.io/dev/code_style) when editing files.
+The [developer guide](http://dev.px4.io/) explains how to set up the development environment on Mac OS, Linux or Windows. Please take note of our [coding style](http://dev.px4.io/en/contribute/code.html) when editing files.
 
 ### Commit your changes
 


### PR DESCRIPTION
In CONTRIBUTING.md, the current link to the coding style leads to a
404 error. I've replaced it with a link to the Source Code Management
part of the developer documentation, which is where the style guide
seems to be now.