### PR TITLE
Enable convenient unit testing using googletest on POSIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,17 +416,29 @@ endif()
 # optionally enable cmake testing (supported only on posix)
 option(CMAKE_TESTING "Configure test targets" OFF)
 if(CMAKE_TESTING)
-	include(CTest)
+	include(CTest) # sets BUILD_TESTING variable
 endif()
+
+# enable test filtering to run only specific tests with the ctest -R regex functionality
 set(TESTFILTER "" CACHE STRING "Filter string for ctest to selectively only run specific tests (ctest -R)")
 
+# if testing is enabled download and configure gtest
 list(APPEND CMAKE_MODULE_PATH ${PX4_SOURCE_DIR}/cmake/gtest/)
 include(px4_add_gtest)
-
 if(BUILD_TESTING)
 	include(gtest)
-	add_custom_target(unit_test COMMAND GTEST_COLOR=1 ${CMAKE_CTEST_COMMAND} -V -R ${TESTFILTER} USES_TERMINAL)
 endif()
+
+add_custom_target(test_results
+		COMMAND GTEST_COLOR=1 ${CMAKE_CTEST_COMMAND} --output-on-failure -T Test -R ${TESTFILTER} USES_TERMINAL
+		DEPENDS
+			px4
+			examples__dyn_hello
+			test_mixer_multirotor
+		USES_TERMINAL
+		COMMENT "Running tests"
+		WORKING_DIRECTORY ${PX4_BINARY_DIR})
+set_target_properties(test_results PROPERTIES EXCLUDE_FROM_ALL TRUE)
 
 #=============================================================================
 # subdirectories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,7 +424,7 @@ include(px4_add_gtest)
 
 if(unit_testing)
    include(gtest)
-   add_custom_target(unit_test COMMAND GTEST_COLOR=1 ${CMAKE_CTEST_COMMAND} -V -R Test USES_TERMINAL)
+   add_custom_target(unit_test COMMAND GTEST_COLOR=1 ${CMAKE_CTEST_COMMAND} -V -R UnitTest- USES_TERMINAL)
 endif()
 
 #=============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,6 +414,20 @@ if (NOT EXTERNAL_MODULES_LOCATION STREQUAL "")
 endif()
 
 #=============================================================================
+# Testing - Automatic unit and integration testing with CTest
+#
+
+option(unit_testing "Configure unit test targets" OFF)
+
+list(APPEND CMAKE_MODULE_PATH ${PX4_SOURCE_DIR}/cmake/gtest/)
+include(px4_add_gtest)
+
+if(unit_testing)
+   include(gtest)
+   add_custom_target(unit_test COMMAND GTEST_COLOR=1 ${CMAKE_CTEST_COMMAND} -V -R Test USES_TERMINAL)
+endif()
+
+#=============================================================================
 # subdirectories
 #
 add_library(parameters_interface INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-# Copyright (c) 2017 PX4 Development Team. All rights reserved.
+# Copyright (c) 2017 - 2019 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,13 +418,14 @@ option(CMAKE_TESTING "Configure test targets" OFF)
 if(CMAKE_TESTING)
 	include(CTest)
 endif()
+set(TESTFILTER "" CACHE STRING "Filter string for ctest to selectively only run specific tests (ctest -R)")
 
 list(APPEND CMAKE_MODULE_PATH ${PX4_SOURCE_DIR}/cmake/gtest/)
 include(px4_add_gtest)
 
 if(BUILD_TESTING)
 	include(gtest)
-	add_custom_target(unit_test COMMAND GTEST_COLOR=1 ${CMAKE_CTEST_COMMAND} -V -R UnitTest- USES_TERMINAL)
+	add_custom_target(unit_test COMMAND GTEST_COLOR=1 ${CMAKE_CTEST_COMMAND} -V -R ${TESTFILTER} USES_TERMINAL)
 endif()
 
 #=============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,10 +299,6 @@ if (${PX4_PLATFORM} STREQUAL "posix")
 	if (NOT CMAKE_INSTALL_PREFIX)
 		set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "Install path prefix" FORCE)
 	endif()
-
-	# cmake testing only on posix
-	enable_testing()
-	include(CTest)
 endif()
 
 #=============================================================================
@@ -417,14 +413,18 @@ endif()
 # Testing - Automatic unit and integration testing with CTest
 #
 
-option(unit_testing "Configure unit test targets" OFF)
+# optionally enable cmake testing (supported only on posix)
+option(CMAKE_TESTING "Configure test targets" OFF)
+if(CMAKE_TESTING)
+	include(CTest)
+endif()
 
 list(APPEND CMAKE_MODULE_PATH ${PX4_SOURCE_DIR}/cmake/gtest/)
 include(px4_add_gtest)
 
-if(unit_testing)
-   include(gtest)
-   add_custom_target(unit_test COMMAND GTEST_COLOR=1 ${CMAKE_CTEST_COMMAND} -V -R UnitTest- USES_TERMINAL)
+if(BUILD_TESTING)
+	include(gtest)
+	add_custom_target(unit_test COMMAND GTEST_COLOR=1 ${CMAKE_CTEST_COMMAND} -V -R UnitTest- USES_TERMINAL)
 endif()
 
 #=============================================================================

--- a/Makefile
+++ b/Makefile
@@ -340,14 +340,8 @@ format:
 
 # Testing
 # --------------------------------------------------------------------
-.PHONY: tests tests_coverage tests_mission tests_mission_coverage tests_offboard tests_avoidance unit_test
+.PHONY: tests tests_coverage tests_mission tests_mission_coverage tests_offboard tests_avoidance
 .PHONY: rostest python_coverage
-
-unit_test:
-	$(eval CMAKE_ARGS += -DCMAKE_TESTING=ON)
-	$(eval CMAKE_ARGS += -DCONFIG=px4_sitl_test)
-	$(eval ARGS += unit_test)
-	$(call cmake-build,px4_sitl_test)
 
 tests:
 	$(eval CMAKE_ARGS += -DCMAKE_TESTING=ON)

--- a/Makefile
+++ b/Makefile
@@ -337,8 +337,13 @@ format:
 
 # Testing
 # --------------------------------------------------------------------
-.PHONY: tests tests_coverage tests_mission tests_mission_coverage tests_offboard tests_avoidance
+.PHONY: tests tests_coverage tests_mission tests_mission_coverage tests_offboard tests_avoidance unit_test
 .PHONY: rostest python_coverage
+
+unit_test:
+	$(eval CMAKE_ARGS += -Dunit_testing=ON)
+	$(eval ARGS += unit_test)
+	$(call cmake-build,px4_sitl_default)
 
 tests:
 	@$(MAKE) --no-print-directory px4_sitl_test test_results \

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,11 @@ endif
 # directory build/px4_fmu-v2_default and then call make
 # in that directory with the target upload.
 
-#  explicity set default build target
+# explicity set default build target
 all: px4_sitl_default
+
+# define a space character to be able to explicitly find it in strings
+space := $(subst ,, )
 
 # Parsing
 # --------------------------------------------------------------------
@@ -165,8 +168,8 @@ define cmake-cache-check
 	@$(eval CACHED_CMAKE_OPTIONS = $(shell cd $(BUILD_DIR) 2>/dev/null && cmake -L 2>/dev/null | sed -n 's/\([^[:blank:]]*\):[^[:blank:]]*\(=[^[:blank:]]*\)/\1\2/gp' ))
 	@# transform the options in CMAKE_ARGS into the OPTION=VALUE format without -D
 	@$(eval DESIRED_CMAKE_OPTIONS = $(shell echo $(CMAKE_ARGS) | sed -n 's/-D\([^[:blank:]]*=[^[:blank:]]*\)/\1/gp' ))
-	@# find each currently desired option in the already cached ones
-	@$(eval VERIFIED_CMAKE_OPTIONS = $(foreach option,$(DESIRED_CMAKE_OPTIONS),$(findstring $(option),$(CACHED_CMAKE_OPTIONS))))
+	@# find each currently desired option in the already cached ones making sure the complete configured string value is the same
+	@$(eval VERIFIED_CMAKE_OPTIONS = $(foreach option,$(DESIRED_CMAKE_OPTIONS),$(strip $(findstring $(option)$(space),$(CACHED_CMAKE_OPTIONS)))))
 	@# if the complete list of desired options is found in the list of verified options we don't need to reconfigure and CMAKE_CACHE_CHECK stays empty
 	@$(eval CMAKE_CACHE_CHECK = $(if $(findstring $(DESIRED_CMAKE_OPTIONS),$(VERIFIED_CMAKE_OPTIONS)),,y))
 endef
@@ -474,7 +477,6 @@ distclean: gazeboclean
 		$(error "$@ cannot be the first argument. Use '$(MAKE) help|list_config_targets' to get a list of all possible [configuration] targets."),@#)
 
 # Print a list of non-config targets (based on http://stackoverflow.com/a/26339924/1487069)
-space := $(subst ,, )
 help:
 	@echo "Usage: $(MAKE) <target>"
 	@echo "Where <target> is one of:"

--- a/Makefile
+++ b/Makefile
@@ -349,6 +349,7 @@ unit_test:
 tests:
 	$(eval CMAKE_ARGS += -DCMAKE_TESTING=ON)
 	$(eval CMAKE_ARGS += -DCONFIG=px4_sitl_test)
+	$(eval CMAKE_ARGS += -DTESTFILTER=$(TESTFILTER))
 	$(eval ARGS += test_results)
 	$(eval ASAN_OPTIONS += color=always:check_initialization_order=1:detect_stack_use_after_return=1)
 	$(eval UBSAN_OPTIONS += color=always)

--- a/Makefile
+++ b/Makefile
@@ -341,14 +341,18 @@ format:
 .PHONY: rostest python_coverage
 
 unit_test:
-	$(eval CMAKE_ARGS += -Dunit_testing=ON)
+	$(eval CMAKE_ARGS += -DCMAKE_TESTING=ON)
+	$(eval CMAKE_ARGS += -DCONFIG=px4_sitl_test)
 	$(eval ARGS += unit_test)
-	$(call cmake-build,px4_sitl_default)
+	$(call cmake-build,px4_sitl_test)
 
 tests:
-	@$(MAKE) --no-print-directory px4_sitl_test test_results \
-	ASAN_OPTIONS="color=always:check_initialization_order=1:detect_stack_use_after_return=1" \
-	UBSAN_OPTIONS="color=always"
+	$(eval CMAKE_ARGS += -DCMAKE_TESTING=ON)
+	$(eval CMAKE_ARGS += -DCONFIG=px4_sitl_test)
+	$(eval ARGS += test_results)
+	$(eval ASAN_OPTIONS += color=always:check_initialization_order=1:detect_stack_use_after_return=1)
+	$(eval UBSAN_OPTIONS += color=always)
+	$(call cmake-build,px4_sitl_test)
 
 tests_coverage:
 	@$(MAKE) clean

--- a/cmake/gtest/CMakeLists.txt.in
+++ b/cmake/gtest/CMakeLists.txt.in
@@ -4,7 +4,7 @@ project(googletest-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(googletest
-	URL https://github.com/google/googletest/archive/master.zip
+	URL https://github.com/google/googletest/archive/8b6d3f9c4a774bef3081195d422993323b6bb2e0.zip
 	SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
 	BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
 	CONFIGURE_COMMAND ""

--- a/cmake/gtest/CMakeLists.txt.in
+++ b/cmake/gtest/CMakeLists.txt.in
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 2.8.4)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+	URL https://github.com/google/googletest/archive/master.zip
+	SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+	BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+	CONFIGURE_COMMAND ""
+	BUILD_COMMAND ""
+	INSTALL_COMMAND ""
+	TEST_COMMAND ""
+	# Wrap download, configure and build steps in a script to log output
+    LOG_DOWNLOAD ON
+    LOG_CONFIGURE ON
+    LOG_BUILD ON
+)

--- a/cmake/gtest/gtest.cmake
+++ b/cmake/gtest/gtest.cmake
@@ -41,3 +41,9 @@ endif()
 
 # Add googletest, defines gtest and gtest_main targets
 add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src ${CMAKE_CURRENT_BINARY_DIR}/googletest-build EXCLUDE_FROM_ALL)
+
+# Remove visibility.h from the compile flags for gtest because of poisoned exit()
+get_target_property(GTEST_COMPILE_FLAGS gtest COMPILE_OPTIONS)
+list(REMOVE_ITEM GTEST_COMPILE_FLAGS "-include")
+list(REMOVE_ITEM GTEST_COMPILE_FLAGS "visibility.h")
+set_target_properties(gtest PROPERTIES COMPILE_OPTIONS "${GTEST_COMPILE_FLAGS}")

--- a/cmake/gtest/gtest.cmake
+++ b/cmake/gtest/gtest.cmake
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+# Copyright (c) 2019 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,12 +31,13 @@
 #
 ############################################################################
 
-px4_add_library(AttitudeControl
-	AttitudeControl.cpp
-)
-target_include_directories(AttitudeControl
-	PUBLIC
-	${CMAKE_CURRENT_SOURCE_DIR}
-)
+# Download and unpack googletest at configure time
+configure_file(${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt.in googletest-download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" . RESULT_VARIABLE result1 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
+execute_process(COMMAND ${CMAKE_COMMAND} --build . RESULT_VARIABLE result2 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
+if(result1 OR result2)
+	message(FATAL_ERROR "Preparing googletest failed: ${result1} ${result2}")
+endif()
 
-px4_add_gtest(SRC AttitudeControlTest.cpp LINKLIBS AttitudeControl)
+# Add googletest, defines gtest and gtest_main targets
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src ${CMAKE_CURRENT_BINARY_DIR}/googletest-build EXCLUDE_FROM_ALL)

--- a/cmake/gtest/px4_add_gtest.cmake
+++ b/cmake/gtest/px4_add_gtest.cmake
@@ -37,7 +37,7 @@ include(px4_base)
 #
 #	px4_add_gtest
 #
-#	Adds a googletest unit test to the unit_test target.
+#	Adds a googletest unit test to the test_results target.
 #
 function(px4_add_gtest)
 	# skip if unit testing is not configured
@@ -65,6 +65,6 @@ function(px4_add_gtest)
 		add_test(NAME ${TESTNAME} COMMAND ${TESTNAME})
 
 		# attach it to the unit test target
-		add_dependencies(unit_test ${TESTNAME})
+		add_dependencies(test_results ${TESTNAME})
 	endif()
 endfunction()

--- a/cmake/gtest/px4_add_gtest.cmake
+++ b/cmake/gtest/px4_add_gtest.cmake
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+# Copyright (c) 2019 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,12 +31,38 @@
 #
 ############################################################################
 
-px4_add_library(AttitudeControl
-	AttitudeControl.cpp
-)
-target_include_directories(AttitudeControl
-	PUBLIC
-	${CMAKE_CURRENT_SOURCE_DIR}
-)
+include(px4_base)
 
-px4_add_gtest(SRC AttitudeControlTest.cpp LINKLIBS AttitudeControl)
+#=============================================================================
+#
+#	px4_add_gtest
+#
+#	Adds a googletest unit test to the unit_test target.
+#
+function(px4_add_gtest)
+	# skip if unit testing is not configured
+	if(unit_testing)
+		# parse source file and library dependencies from arguments
+		px4_parse_function_args(
+			NAME px4_add_gtest
+			ONE_VALUE SRC
+			MULTI_VALUE LINKLIBS
+			REQUIRED SRC
+			ARGN ${ARGN})
+
+		# infer test name from source filname without extension
+		get_filename_component(TESTNAME ${SRC} NAME_WE)
+
+		# build a binary for the unit test
+		add_executable(${TESTNAME} EXCLUDE_FROM_ALL ${SRC})
+
+		# link the libary to test and gtest
+		target_link_libraries(${TESTNAME} ${LINKLIBS} gtest_main)
+
+		# add the test to the ctest plan
+		add_test(NAME ${TESTNAME} COMMAND ${TESTNAME})
+
+		# attach it to the unit test target
+		add_dependencies(unit_test ${TESTNAME})
+	endif()
+endfunction()

--- a/cmake/gtest/px4_add_gtest.cmake
+++ b/cmake/gtest/px4_add_gtest.cmake
@@ -50,8 +50,10 @@ function(px4_add_gtest)
 			REQUIRED SRC
 			ARGN ${ARGN})
 
-		# infer test name from source filname without extension
+		# infer test name from source filname
 		get_filename_component(TESTNAME ${SRC} NAME_WE)
+		string(REPLACE Test "" TESTNAME ${TESTNAME})
+		set(TESTNAME UnitTest-${TESTNAME})
 
 		# build a binary for the unit test
 		add_executable(${TESTNAME} EXCLUDE_FROM_ALL ${SRC})

--- a/cmake/gtest/px4_add_gtest.cmake
+++ b/cmake/gtest/px4_add_gtest.cmake
@@ -41,7 +41,7 @@ include(px4_base)
 #
 function(px4_add_gtest)
 	# skip if unit testing is not configured
-	if(unit_testing)
+	if(BUILD_TESTING)
 		# parse source file and library dependencies from arguments
 		px4_parse_function_args(
 			NAME px4_add_gtest

--- a/cmake/gtest/px4_add_gtest.cmake
+++ b/cmake/gtest/px4_add_gtest.cmake
@@ -53,7 +53,7 @@ function(px4_add_gtest)
 		# infer test name from source filname
 		get_filename_component(TESTNAME ${SRC} NAME_WE)
 		string(REPLACE Test "" TESTNAME ${TESTNAME})
-		set(TESTNAME UnitTest-${TESTNAME})
+		set(TESTNAME unit-${TESTNAME})
 
 		# build a binary for the unit test
 		add_executable(${TESTNAME} EXCLUDE_FROM_ALL ${SRC})

--- a/platforms/posix/cmake/sitl_tests.cmake
+++ b/platforms/posix/cmake/sitl_tests.cmake
@@ -145,19 +145,6 @@ foreach(cmd_name ${test_cmds})
 	set_tests_properties(posix_${cmd_name} PROPERTIES PASS_REGULAR_EXPRESSION "Shutting down")
 endforeach()
 
-
-add_custom_target(test_results
-		COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -T Test -R ${TESTFILTER}
-		DEPENDS
-			px4
-			examples__dyn_hello
-			test_mixer_multirotor
-			unit_test
-		USES_TERMINAL
-		COMMENT "Running tests in sitl"
-		WORKING_DIRECTORY ${PX4_BINARY_DIR})
-set_target_properties(test_results PROPERTIES EXCLUDE_FROM_ALL TRUE)
-
 if (CMAKE_BUILD_TYPE STREQUAL Coverage)
 	setup_target_for_coverage(test_coverage "${CMAKE_CTEST_COMMAND} --output-on-failure -T Test" tests)
 	setup_target_for_coverage(generate_coverage "${CMAKE_COMMAND} -E echo" generic)

--- a/platforms/posix/cmake/sitl_tests.cmake
+++ b/platforms/posix/cmake/sitl_tests.cmake
@@ -147,7 +147,7 @@ endforeach()
 
 
 add_custom_target(test_results
-		COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -T Test
+		COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -T Test -R ${TESTFILTER}
 		DEPENDS
 			px4
 			examples__dyn_hello

--- a/platforms/posix/cmake/sitl_tests.cmake
+++ b/platforms/posix/cmake/sitl_tests.cmake
@@ -151,6 +151,7 @@ add_custom_target(test_results
 			px4
 			examples__dyn_hello
 			test_mixer_multirotor
+			unit_test
 		USES_TERMINAL
 		COMMENT "Running tests in sitl"
 		WORKING_DIRECTORY ${PX4_BINARY_DIR})

--- a/platforms/posix/cmake/sitl_tests.cmake
+++ b/platforms/posix/cmake/sitl_tests.cmake
@@ -54,9 +54,10 @@ if (CMAKE_SYSTEM_NAME STREQUAL "CYGWIN")
 endif()
 
 foreach(test_name ${tests})
+	set(test_name_prefix sitl-${test_name})
 	configure_file(${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/test_template.in ${PX4_SOURCE_DIR}/posix-configs/SITL/init/test/test_${test_name}_generated)
 
-	add_test(NAME ${test_name}
+	add_test(NAME ${test_name_prefix}
 		COMMAND ${PX4_SOURCE_DIR}/Tools/sitl_run.sh
 			$<TARGET_FILE:px4>
 			none
@@ -66,10 +67,10 @@ foreach(test_name ${tests})
 			${PX4_BINARY_DIR}
 		WORKING_DIRECTORY ${SITL_WORKING_DIR})
 
-	set_tests_properties(${test_name} PROPERTIES FAIL_REGULAR_EXPRESSION "${test_name} FAILED")
-	set_tests_properties(${test_name} PROPERTIES PASS_REGULAR_EXPRESSION "${test_name} PASSED")
+	set_tests_properties(${test_name_prefix} PROPERTIES FAIL_REGULAR_EXPRESSION "${test_name} FAILED")
+	set_tests_properties(${test_name_prefix} PROPERTIES PASS_REGULAR_EXPRESSION "${test_name} PASSED")
 
-	sanitizer_fail_test_on_error(${test_name})
+	sanitizer_fail_test_on_error(${test_name_prefix})
 endforeach()
 
 

--- a/src/include/visibility.h
+++ b/src/include/visibility.h
@@ -86,7 +86,7 @@
 #ifdef __cplusplus
 #include <cstdlib>
 #endif
-#pragma GCC poison exit
+//#pragma GCC poison exit
 
 #include <stdlib.h>
 

--- a/src/include/visibility.h
+++ b/src/include/visibility.h
@@ -86,7 +86,7 @@
 #ifdef __cplusplus
 #include <cstdlib>
 #endif
-//#pragma GCC poison exit
+#pragma GCC poison exit
 
 #include <stdlib.h>
 

--- a/src/modules/mc_att_control/AttitudeControl/AttitudeControlTest.cpp
+++ b/src/modules/mc_att_control/AttitudeControl/AttitudeControlTest.cpp
@@ -3,7 +3,8 @@
 
 using namespace matrix;
 
-TEST(AttitudeControlTest, AllZeroCase) {
+TEST(AttitudeControlTest, AllZeroCase)
+{
 	AttitudeControl attitude_control;
 	matrix::Vector3f rate_setpoint = attitude_control.update(Quatf(), Quatf(), 0.f);
 	EXPECT_EQ(rate_setpoint(0), 0.f);

--- a/src/modules/mc_att_control/AttitudeControl/AttitudeControlTest.cpp
+++ b/src/modules/mc_att_control/AttitudeControl/AttitudeControlTest.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+#include <AttitudeControl.hpp>
+
+using namespace matrix;
+
+TEST(AttitudeControlTest, AllZeroCase) {
+	AttitudeControl attitude_control;
+	matrix::Vector3f rate_setpoint = attitude_control.update(Quatf(), Quatf(), 0.f);
+	EXPECT_EQ(rate_setpoint(0), 0.f);
+	EXPECT_EQ(rate_setpoint(1), 0.f);
+	EXPECT_EQ(rate_setpoint(2), 0.f);
+}

--- a/src/modules/mc_att_control/AttitudeControl/AttitudeControlTest.cpp
+++ b/src/modules/mc_att_control/AttitudeControl/AttitudeControlTest.cpp
@@ -7,7 +7,5 @@ TEST(AttitudeControlTest, AllZeroCase)
 {
 	AttitudeControl attitude_control;
 	matrix::Vector3f rate_setpoint = attitude_control.update(Quatf(), Quatf(), 0.f);
-	EXPECT_EQ(rate_setpoint(0), 0.f);
-	EXPECT_EQ(rate_setpoint(1), 0.f);
-	EXPECT_EQ(rate_setpoint(2), 0.f);
+	EXPECT_EQ(rate_setpoint, Vector3f());
 }

--- a/src/modules/mc_att_control/AttitudeControl/AttitudeControlTest.cpp
+++ b/src/modules/mc_att_control/AttitudeControl/AttitudeControlTest.cpp
@@ -1,3 +1,36 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
 #include <gtest/gtest.h>
 #include <AttitudeControl.hpp>
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Part of the description I wrote in #11308

The idea is to enable unit testing for any C++ class of the project with very low overhead. For example if you want to test the class `AttitudeControl` you:

* Create a file `AttitudeControlTest.cpp` next to the classes source files
* Add `px4_add_gtest(SRC AttitudeControlTest.cpp LINKLIBS AttitudeControl)` to the folder's `CMakeLists.txt`
* Start writing your test e.g. :

```
#include <gtest/gtest.h>
#include <AttitudeControl.hpp>

TEST(AttitudeControlTest, AllZeroCase) {
AttitudeControl attitude_control;
matrix::Vector3f rate_setpoint = attitude_control.update(matrix::Quatf(), matrix::Quatf(), 0.f);
EXPECT_EQ(rate_setpoint(0), 0.f);
}
```

When you run `make unit_test` you get the following output (runs all the unit tests):
![first!UNITO-UNDERSCORE!test](https://user-images.githubusercontent.com/4668506/53685343-8799ef80-3d19-11e9-9d8b-ac4feb508af6.PNG)
And it neither needs to rebuild all the libraries you want to test if you're using `px4_sitl_default` anyways nor does gtest need to be loaded when you're not unit testing with it thanks to https://github.com/PX4/Firmware/pull/11533

**Describe your preferred solution**
A clear and concise description of what you have implemented.

**Additional context**

* https://github.com/google/googletest/pull/2101 was necessary such that the global gtest configuration builds under Cygwin.
* A future goal is to be able to run all those test also on the targets.

**Test data / coverage**
Developed and tested on Cygwin Windows toolchain, I will also test on Ubuntu.

