### PR TITLE
Correct board-config PIN1/PIN0 typo in fmu-v5/src/board_config.h.

### DIFF
--- a/boards/px4/fmu-v5/src/board_config.h
+++ b/boards/px4/fmu-v5/src/board_config.h
@@ -351,8 +351,8 @@
  *  The GPIO will be set as input while not armed HW will have external HW Pull UP.
  *  While armed it shall be configured at a GPIO OUT set LOW
  */
-#define GPIO_nARMED_INIT     /* PI0 */  (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTI|GPIO_PIN1)
-#define GPIO_nARMED          /* PI0 */  (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTI|GPIO_PIN1)
+#define GPIO_nARMED_INIT     /* PI0 */  (GPIO_INPUT|GPIO_PULLUP|GPIO_PORTI|GPIO_PIN0)
+#define GPIO_nARMED          /* PI0 */  (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_2MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTI|GPIO_PIN0)
 
 #define BOARD_INDICATE_ARMED_STATE(on_armed)  px4_arch_configgpio((on_armed) ? GPIO_nARMED : GPIO_nARMED_INIT)
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
An inadvertent typo was causing fmu-v5 to fail to save params and disarm, localized to this [commit](https://github.com/PX4/Firmware/commit/0846059646990fd4fbe4a884dbd1a8ff46d559c1).

See #11569

**Describe your preferred solution**
Specifying GPIO_PIN0 corrects the issue and also matches the hardware documentation.

Thanks @dagar for understanding the root cause of the issue and driving the bughunt.

@davids5 and @dagar , let me know if you need anything else from me on this PR.

-Mark
