### PR TITLE
Complete Simulator class mavlink handle_message_XXX() method implementations.

### DIFF
--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -337,6 +337,7 @@ private:
 	void handle_message_hil_state_quaternion(const mavlink_message_t *msg);
 	void handle_message_landing_target(const mavlink_message_t *msg);
 	void handle_message_optical_flow(const mavlink_message_t *msg);
+	void handle_message_rc_channels(const mavlink_message_t *msg);
 
 	void parameters_update(bool force);
 	void poll_topics();

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -274,10 +274,10 @@ private:
 	// class methods
 	void initialize_sensor_data();
 
-	int publish_sensor_topics(mavlink_hil_sensor_t *imu);
-	int publish_flow_topic(mavlink_hil_optical_flow_t *flow);
+	int publish_sensor_topics(const mavlink_hil_sensor_t *imu);
+	int publish_flow_topic(const mavlink_hil_optical_flow_t *flow);
 	int publish_odometry_topic(const mavlink_message_t *odom_mavlink);
-	int publish_distance_topic(mavlink_distance_sensor_t *dist);
+	int publish_distance_topic(const mavlink_distance_sensor_t *dist);
 
 	static Simulator *_instance;
 
@@ -330,7 +330,7 @@ private:
 
 	mavlink_hil_actuator_controls_t actuator_controls_from_outputs(const actuator_outputs_s &actuators);
 
-	void handle_message(mavlink_message_t *msg);
+	void handle_message(const mavlink_message_t *msg);
 	void handle_message_distance_sensor(const mavlink_message_t *msg);
 	void handle_message_hil_gps(const mavlink_message_t *msg);
 	void handle_message_hil_sensor(const mavlink_message_t *msg);
@@ -350,8 +350,8 @@ private:
 	void send_heartbeat();
 	void send_mavlink_message(const mavlink_message_t &aMsg);
 	void set_publish(const bool publish = true);
-	void update_sensors(mavlink_hil_sensor_t *imu);
-	void update_gps(mavlink_hil_gps_t *gps_sim);
+	void update_sensors(const mavlink_hil_sensor_t *imu);
+	void update_gps(const mavlink_hil_gps_t *gps_sim);
 
 	static void *sending_trampoline(void *);
 

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -276,7 +276,7 @@ private:
 
 	int publish_sensor_topics(mavlink_hil_sensor_t *imu);
 	int publish_flow_topic(mavlink_hil_optical_flow_t *flow);
-	int publish_odometry_topic(mavlink_message_t *odom_mavlink);
+	int publish_odometry_topic(const mavlink_message_t *odom_mavlink);
 	int publish_distance_topic(mavlink_distance_sensor_t *dist);
 
 	static Simulator *_instance;
@@ -338,6 +338,7 @@ private:
 	void handle_message_landing_target(const mavlink_message_t *msg);
 	void handle_message_optical_flow(const mavlink_message_t *msg);
 	void handle_message_rc_channels(const mavlink_message_t *msg);
+	void handle_message_vision_position_estimate(const mavlink_message_t *msg);
 
 	void parameters_update(bool force);
 	void poll_topics();

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -332,6 +332,7 @@ private:
 
 	void handle_message(mavlink_message_t *msg);
 	void handle_message_distance_sensor(const mavlink_message_t *msg);
+	void handle_message_hil_gps(const mavlink_message_t *msg);
 	void handle_message_hil_sensor(const mavlink_message_t *msg);
 	void handle_message_hil_state_quaternion(const mavlink_message_t *msg);
 	void handle_message_landing_target(const mavlink_message_t *msg);

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -336,6 +336,7 @@ private:
 	void handle_message_hil_sensor(const mavlink_message_t *msg);
 	void handle_message_hil_state_quaternion(const mavlink_message_t *msg);
 	void handle_message_landing_target(const mavlink_message_t *msg);
+	void handle_message_odometry(const mavlink_message_t *msg);
 	void handle_message_optical_flow(const mavlink_message_t *msg);
 	void handle_message_rc_channels(const mavlink_message_t *msg);
 	void handle_message_vision_position_estimate(const mavlink_message_t *msg);

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -332,6 +332,7 @@ private:
 
 	void handle_message(mavlink_message_t *msg);
 	void handle_message_distance_sensor(const mavlink_message_t *msg);
+	void handle_message_hil_sensor(const mavlink_message_t *msg);
 	void handle_message_hil_state_quaternion(const mavlink_message_t *msg);
 	void handle_message_landing_target(const mavlink_message_t *msg);
 	void handle_message_optical_flow(const mavlink_message_t *msg);

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -302,7 +302,7 @@ void Simulator::handle_message(mavlink_message_t *msg)
 
 	case MAVLINK_MSG_ID_ODOMETRY:
 	case MAVLINK_MSG_ID_VISION_POSITION_ESTIMATE:
-		publish_odometry_topic(msg);
+		handle_message_vision_position_estimate(msg);
 		break;
 
 	case MAVLINK_MSG_ID_DISTANCE_SENSOR:
@@ -540,6 +540,11 @@ void Simulator::handle_message_rc_channels(const mavlink_message_t *msg)
 		int rc_multi;
 		orb_publish_auto(ORB_ID(input_rc), &_rc_channels_pub, &_rc_input, &rc_multi, ORB_PRIO_HIGH);
 	}
+}
+
+void Simulator::handle_message_vision_position_estimate(const mavlink_message_t *msg)
+{
+	publish_odometry_topic(msg);
 }
 
 void Simulator::send_mavlink_message(const mavlink_message_t &aMsg)
@@ -1100,7 +1105,7 @@ int Simulator::publish_flow_topic(mavlink_hil_optical_flow_t *flow_mavlink)
 	return OK;
 }
 
-int Simulator::publish_odometry_topic(mavlink_message_t *odom_mavlink)
+int Simulator::publish_odometry_topic(const mavlink_message_t *odom_mavlink)
 {
 	uint64_t timestamp = hrt_absolute_time();
 

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -317,10 +317,9 @@ void Simulator::handle_message(mavlink_message_t *msg)
 		handle_message_rc_channels(msg);
 		break;
 
-	case MAVLINK_MSG_ID_LANDING_TARGET: {
-			handle_message_landing_target(msg);
-			break;
-		}
+	case MAVLINK_MSG_ID_LANDING_TARGET:
+		handle_message_landing_target(msg);
+		break;
 
 	case MAVLINK_MSG_ID_HIL_STATE_QUATERNION:
 		handle_message_hil_state_quaternion(msg);

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -314,16 +314,7 @@ void Simulator::handle_message(mavlink_message_t *msg)
 		break;
 
 	case MAVLINK_MSG_ID_RC_CHANNELS:
-		mavlink_rc_channels_t rc_channels;
-		mavlink_msg_rc_channels_decode(msg, &rc_channels);
-		fill_rc_input_msg(&_rc_input, &rc_channels);
-
-		// publish message
-		if (_publish) {
-			int rc_multi;
-			orb_publish_auto(ORB_ID(input_rc), &_rc_channels_pub, &_rc_input, &rc_multi, ORB_PRIO_HIGH);
-		}
-
+		handle_message_rc_channels(msg);
 		break;
 
 	case MAVLINK_MSG_ID_LANDING_TARGET: {
@@ -537,6 +528,19 @@ void Simulator::handle_message_optical_flow(const mavlink_message_t *msg)
 	mavlink_hil_optical_flow_t flow;
 	mavlink_msg_hil_optical_flow_decode(msg, &flow);
 	publish_flow_topic(&flow);
+}
+
+void Simulator::handle_message_rc_channels(const mavlink_message_t *msg)
+{
+	mavlink_rc_channels_t rc_channels;
+	mavlink_msg_rc_channels_decode(msg, &rc_channels);
+	fill_rc_input_msg(&_rc_input, &rc_channels);
+
+	// publish message
+	if (_publish) {
+		int rc_multi;
+		orb_publish_auto(ORB_ID(input_rc), &_rc_channels_pub, &_rc_input, &rc_multi, ORB_PRIO_HIGH);
+	}
 }
 
 void Simulator::send_mavlink_message(const mavlink_message_t &aMsg)

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -301,6 +301,9 @@ void Simulator::handle_message(mavlink_message_t *msg)
 		break;
 
 	case MAVLINK_MSG_ID_ODOMETRY:
+		handle_message_odometry(msg);
+		break;
+
 	case MAVLINK_MSG_ID_VISION_POSITION_ESTIMATE:
 		handle_message_vision_position_estimate(msg);
 		break;
@@ -520,6 +523,11 @@ void Simulator::handle_message_landing_target(const mavlink_message_t *msg)
 
 	int irlock_multi;
 	orb_publish_auto(ORB_ID(irlock_report), &_irlock_report_pub, &report, &irlock_multi, ORB_PRIO_HIGH);
+}
+
+void Simulator::handle_message_odometry(const mavlink_message_t *msg)
+{
+	publish_odometry_topic(msg);
 }
 
 void Simulator::handle_message_optical_flow(const mavlink_message_t *msg)

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -310,14 +310,7 @@ void Simulator::handle_message(mavlink_message_t *msg)
 		break;
 
 	case MAVLINK_MSG_ID_HIL_GPS:
-		mavlink_hil_gps_t gps_sim;
-		mavlink_msg_hil_gps_decode(msg, &gps_sim);
-
-		if (_publish) {
-			//PX4_WARN("FIXME:  Need to publish GPS topic.  Not done yet.");
-		}
-
-		update_gps(&gps_sim);
+		handle_message_hil_gps(msg);
 		break;
 
 	case MAVLINK_MSG_ID_RC_CHANNELS:
@@ -349,6 +342,18 @@ void Simulator::handle_message_distance_sensor(const mavlink_message_t *msg)
 	mavlink_distance_sensor_t dist;
 	mavlink_msg_distance_sensor_decode(msg, &dist);
 	publish_distance_topic(&dist);
+}
+
+void Simulator::handle_message_hil_gps(const mavlink_message_t *msg)
+{
+	mavlink_hil_gps_t gps_sim;
+	mavlink_msg_hil_gps_decode(msg, &gps_sim);
+
+	if (_publish) {
+		//PX4_WARN("FIXME:  Need to publish GPS topic.  Not done yet.");
+	}
+
+	update_gps(&gps_sim);
 }
 
 void Simulator::handle_message_hil_sensor(const mavlink_message_t *msg)

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -220,7 +220,7 @@ static void fill_rc_input_msg(input_rc_s *rc, mavlink_rc_channels_t *rc_channels
 	rc->values[17] = rc_channels->chan18_raw;
 }
 
-void Simulator::update_sensors(mavlink_hil_sensor_t *imu)
+void Simulator::update_sensors(const mavlink_hil_sensor_t *imu)
 {
 	// write sensor data to memory so that drivers can copy data from there
 	RawMPUData mpu = {};
@@ -269,7 +269,7 @@ void Simulator::update_sensors(mavlink_hil_sensor_t *imu)
 	write_airspeed_data(&airspeed);
 }
 
-void Simulator::update_gps(mavlink_hil_gps_t *gps_sim)
+void Simulator::update_gps(const mavlink_hil_gps_t *gps_sim)
 {
 	RawGPSData gps = {};
 	gps.timestamp = hrt_absolute_time();
@@ -289,7 +289,7 @@ void Simulator::update_gps(mavlink_hil_gps_t *gps_sim)
 	write_gps_data((void *)&gps);
 }
 
-void Simulator::handle_message(mavlink_message_t *msg)
+void Simulator::handle_message(const mavlink_message_t *msg)
 {
 	switch (msg->msgid) {
 	case MAVLINK_MSG_ID_HIL_SENSOR:
@@ -970,7 +970,7 @@ int openUart(const char *uart_name, int baud)
 }
 #endif
 
-int Simulator::publish_sensor_topics(mavlink_hil_sensor_t *imu)
+int Simulator::publish_sensor_topics(const mavlink_hil_sensor_t *imu)
 {
 	uint64_t timestamp = hrt_absolute_time();
 
@@ -1065,7 +1065,7 @@ int Simulator::publish_sensor_topics(mavlink_hil_sensor_t *imu)
 	return OK;
 }
 
-int Simulator::publish_flow_topic(mavlink_hil_optical_flow_t *flow_mavlink)
+int Simulator::publish_flow_topic(const mavlink_hil_optical_flow_t *flow_mavlink)
 {
 	uint64_t timestamp = hrt_absolute_time();
 
@@ -1220,7 +1220,7 @@ int Simulator::publish_odometry_topic(const mavlink_message_t *odom_mavlink)
 	return OK;
 }
 
-int Simulator::publish_distance_topic(mavlink_distance_sensor_t *dist_mavlink)
+int Simulator::publish_distance_topic(const mavlink_distance_sensor_t *dist_mavlink)
 {
 	uint64_t timestamp = hrt_absolute_time();
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR completes refactoring work started in PR #11499 to break switch statement contents into handle_message_XXX() methods.  The following methods are added by this PR:
 - `void handle_message_hil_gps(const mavlink_message_t *msg);`
 - `void handle_message_hil_sensor(const mavlink_message_t *msg);`
 -  `void handle_message_odometry(const mavlink_message_t *msg);`
 - `void handle_message_rc_channels(const mavlink_message_t *msg);`
 - `void handle_message_vision_position_estimate(const mavlink_message_t *msg);`

A `const` specifier has also been added to the `publish_odometry_topic()` method to preserve constness in the `handle_message_odometry()` and `handle_message_vision_position_estimate()` methods.

**Additional context**
See PRs PR #11499 and #11564

Please let me know if you have any questions on this PR!

-Mark
