### PR TITLE
Lockstep scheduler: shutdown fixes / work-arounds

### DIFF
--- a/platforms/posix/src/lockstep_scheduler/include/lockstep_scheduler/lockstep_scheduler.h
+++ b/platforms/posix/src/lockstep_scheduler/include/lockstep_scheduler/lockstep_scheduler.h
@@ -26,7 +26,7 @@ private:
 			// we need to wait until it's removed.
 			while (!removed) {
 #ifndef UNIT_TESTS // unit tests don't define system_usleep and execute faster w/o sleeping here
-				system_sleep(5000);
+				system_usleep(5000);
 #endif
 			}
 		}

--- a/platforms/posix/src/lockstep_scheduler/include/lockstep_scheduler/lockstep_scheduler.h
+++ b/platforms/posix/src/lockstep_scheduler/include/lockstep_scheduler/lockstep_scheduler.h
@@ -21,6 +21,18 @@ private:
 	struct TimedWait {
 		~TimedWait()
 		{
+			if (!done) {
+				// This can only happen when a thread gets canceled (e.g. via pthread_cancel), and since
+				// pthread_cond_wait is a cancellation point, the rest of LockstepScheduler::cond_timedwait afterwards
+				// might not be executed. Which means the mutex will not be unlocked either, so we unlock to avoid
+				// a dead-lock in LockstepScheduler::set_absolute_time().
+				// This destructor gets called as part of thread-local storage cleanup.
+				// This is really only a work-around for non-proper thread stopping. Note that we also assume,
+				// that we can still access the mutex.
+				pthread_mutex_unlock(passed_lock);
+				done = true;
+			}
+
 			// If a thread quickly exits after a cond_timedwait(), the
 			// thread_local object can still be in the linked list. In that case
 			// we need to wait until it's removed.


### PR DESCRIPTION
This fixes/works around potential shutdown issues in the lockstep scheduler. The underlying issue is that we call `exit()` while threads can be in arbitrary states. To cleanly solve that we need to gracefully exit all threads.
See individual commits for details.

@dagar this might help with shutdown issues you saw.