### PR TITLE
cmake nuttx set CMP0079 policy

### DIFF
--- a/platforms/nuttx/CMakeLists.txt
+++ b/platforms/nuttx/CMakeLists.txt
@@ -31,6 +31,11 @@
 #
 ############################################################################
 
+# target_link_libraries() allow use with targets in other directories.
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13.0")
+	cmake_policy(SET CMP0079 NEW)
+endif()
+
 include(cygwin_cygpath)
 
 set(NUTTX_DIR ${PX4_BINARY_DIR}/NuttX/nuttx)


### PR DESCRIPTION
This silences the verbose output with newer cmake.

![Screen Shot 2019-03-08 at 11 18 00 PM](https://user-images.githubusercontent.com/84712/54066093-7c066700-41f8-11e9-8988-c3a895bd5f85.png)
