### PR TITLE
Alphabetize a few methods and variable orders in mavlink_receiver.h - (Break apart PR#11274 into easily verifiable steps - Step 5)

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -84,11 +84,11 @@ using matrix::wrap_2pi;
 
 MavlinkReceiver::MavlinkReceiver(Mavlink *parent) :
 	_mavlink(parent),
-	_mission_manager(parent),
-	_parameters_manager(parent),
 	_mavlink_ftp(parent),
 	_mavlink_log_handler(parent),
 	_mavlink_timesync(parent),
+	_mission_manager(parent),
+	_parameters_manager(parent),
 	_p_bat_emergen_thr(param_find("BAT_EMERGEN_THR")),
 	_p_bat_crit_thr(param_find("BAT_CRIT_THR")),
 	_p_bat_low_thr(param_find("BAT_LOW_THR")),

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -119,9 +119,6 @@ public:
 private:
 
 	void acknowledge(uint8_t sysid, uint8_t compid, uint16_t command, uint8_t result);
-	void handle_message(mavlink_message_t *msg);
-	void handle_message_command_long(mavlink_message_t *msg);
-	void handle_message_command_int(mavlink_message_t *msg);
 
 	/**
 	 * Common method to handle both mavlink command types. T is one of mavlink_command_int_t or mavlink_command_long_t.
@@ -130,11 +127,14 @@ private:
 	void handle_message_command_both(mavlink_message_t *msg, const T &cmd_mavlink,
 					 const vehicle_command_s &vehicle_command);
 
+	void handle_message(mavlink_message_t *msg);
 	void handle_message_adsb_vehicle(mavlink_message_t *msg);
 	void handle_message_att_pos_mocap(mavlink_message_t *msg);
 	void handle_message_battery_status(mavlink_message_t *msg);
 	void handle_message_collision(mavlink_message_t *msg);
 	void handle_message_command_ack(mavlink_message_t *msg);
+	void handle_message_command_int(mavlink_message_t *msg);
+	void handle_message_command_long(mavlink_message_t *msg);
 	void handle_message_debug(mavlink_message_t *msg);
 	void handle_message_debug_float_array(mavlink_message_t *msg);
 	void handle_message_debug_vect(mavlink_message_t *msg);
@@ -199,11 +199,11 @@ private:
 
 	Mavlink	*_mavlink;
 
-	MavlinkMissionManager		_mission_manager;
-	MavlinkParametersManager	_parameters_manager;
 	MavlinkFTP			_mavlink_ftp;
 	MavlinkLogHandler		_mavlink_log_handler;
 	MavlinkTimesync			_mavlink_timesync;
+	MavlinkMissionManager		_mission_manager;
+	MavlinkParametersManager	_parameters_manager;
 
 	mavlink_status_t _status{}; ///< receiver status, used for mavlink_parse_char()
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR alphabetizes the orders of a few handle_message_xxx() methods and class member variables in mavlink_receiver.h to further simplify the work submitted in PR #11274 .

**Additional context**
See PR #11274 for the remaining work proposed.

Please let me know if you have any questions on this PR!

-Mark