### PR TITLE
Deprecate `_hil_frames` and `_old_timestamp` member vars and dead logic from MavlinkReceiver class - (Break apart PR#11274 into easily verifiable steps - Step 6)

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -2080,16 +2080,6 @@ MavlinkReceiver::handle_message_hil_sensor(mavlink_message_t *msg)
 			orb_publish(ORB_ID(battery_status), _battery_pub, &hil_battery_status);
 		}
 	}
-
-	/* increment counters */
-	_hil_frames++;
-
-	/* print HIL sensors rate */
-	if ((timestamp - _old_timestamp) > 10000000) {
-		// printf("receiving HIL sensors at %d hz\n", _hil_frames / 10);
-		_old_timestamp = timestamp;
-		_hil_frames = 0;
-	}
 }
 
 void

--- a/src/modules/mavlink/mavlink_receiver.h
+++ b/src/modules/mavlink/mavlink_receiver.h
@@ -261,11 +261,9 @@ private:
 	int _control_mode_sub{orb_subscribe(ORB_ID(vehicle_control_mode))};
 	int _vehicle_attitude_sub{orb_subscribe(ORB_ID(vehicle_attitude))};
 
-	int _hil_frames{0};
 	int _orb_class_instance{-1};
 
 	uint64_t _global_ref_timestamp{0};
-	uint64_t _old_timestamp{0};
 
 	bool _hil_local_proj_inited{false};
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR deletes the `_hil_frames` and `_old_timestamp` member variables and associated dead logic from the MavlinkReceiver class.  This PR further simplifies the work submitted in PR #11274 in a step-by-step approach to that work.

**Additional context**
See PR #11274 and #11611 for additional work ongoing in this class.

Please let me know if you have any questions on this PR!

-Mark
