### PR TITLE
removed non used _getMaxCruiseSpeed

### DIFF
--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
@@ -87,7 +87,6 @@ public:
 
 protected:
 	void _setDefaultConstraints() override;
-	float _getMaxCruiseSpeed() {return MPC_XY_CRUISE.get();} /**< getter for default cruise speed */
 	matrix::Vector2f _getTargetVelocityXY(); /**< only used for follow-me and only here because of legacy reason.*/
 	void _updateInternalWaypoints(); /**< Depending on state of vehicle, the internal waypoints might differ from target (for instance if offtrack). */
 	bool _compute_heading_from_2D_vector(float &heading, matrix::Vector2f v); /**< Computes and sets heading a 2D vector */


### PR DESCRIPTION
as part of doing some cleanups of parameters related code, this line has jumped, as a dead code that can be removed.
in order to '_getMaxCruiseSpeed' we can just use MPC_XY_CRUISE.get()