### PR TITLE
Fix RC RSSI reading on FMUv4 (pixracer)

### DIFF
--- a/boards/px4/fmu-v4/src/init.c
+++ b/boards/px4/fmu-v4/src/init.c
@@ -206,7 +206,6 @@ stm32_boardinitialize(void)
 
 	// Safety - led on in led driver.
 	stm32_configgpio(GPIO_BTN_SAFETY);
-	stm32_configgpio(GPIO_RSSI_IN);
 	stm32_configgpio(GPIO_PPM_IN);
 
 	int spi_init_mask = SPI_BUS_INIT_MASK;

--- a/src/drivers/rc_input/RCInput.cpp
+++ b/src/drivers/rc_input/RCInput.cpp
@@ -795,6 +795,10 @@ int RCInput::print_status()
 	PX4_INFO("CRSF Telemetry: %s", _crsf_telemetry ? "yes" : "no");
 	PX4_INFO("SBUS frame drops: %u", sbus_dropped_frames());
 
+#if ADC_RC_RSSI_CHANNEL
+        PX4_INFO("vrssi: %dmV", (int)(_analog_rc_rssi_volt * 1000.0f));
+#endif
+
 	perf_print_counter(_cycle_perf);
 	perf_print_counter(_publish_interval_perf);
 


### PR DESCRIPTION
On FMUv4 RSSI pin (PC1) was initialized twice - first as analog (GPIO_ADC1_IN11) and second - as digital (GPIO_RSSI_IN) so ADC readings was invalid. Also I've added output of rssi voltage to `fmu status` command.