### PR TITLE
Add iris benchmarking

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/1015_iris_obs_avoid
+++ b/ROMFS/px4fmu_common/init.d-posix/1015_iris_obs_avoid
@@ -10,4 +10,5 @@ sh /etc/init.d-posix/10016_iris
 if [ $AUTOCNF = yes ]
 then
 	param set COM_OBS_AVOID 1
+	param set MPC_XY_CRUISE 5.0
 fi

--- a/ROMFS/px4fmu_common/init.d-posix/1015_iris_obs_avoid.post
+++ b/ROMFS/px4fmu_common/init.d-posix/1015_iris_obs_avoid.post
@@ -1,0 +1,2 @@
+# shellcheck disable=SC2154
+mavlink start -x -u 14558 -r 4000000 -m onboard -o 14541 # add mavlink stream for SDK

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -51,7 +51,7 @@ ExternalProject_Add_Step(sitl_gazebo forceconfigure
 # create targets for each viewer/model/debugger combination
 set(viewers none jmavsim gazebo)
 set(debuggers none ide gdb lldb ddd valgrind callgrind)
-set(models none shell iris iris_opt_flow iris_vision iris_rplidar iris_irlock standard_vtol plane solo tailsitter typhoon_h480 rover hippocampus tiltrotor)
+set(models none shell iris iris_opt_flow iris_vision iris_rplidar iris_irlock iris_obs_avoid standard_vtol plane solo tailsitter typhoon_h480 rover hippocampus tiltrotor)
 set(all_posix_vmd_make_targets)
 foreach(viewer ${viewers})
 	foreach(debugger ${debuggers})


### PR DESCRIPTION
This PR adds the necessary SITL setup files for a new simulation vehicle used for benchmarking of Obstacle Avoidance.

Main difference to the regular `Iris` is an additional MAVLink stream, which is needed in order to be able to use both MAVROS and the SDK.

Depends on https://github.com/PX4/sitl_gazebo/pull/300