### PR TITLE
Delete extra newline character in qmc5883/CMakeLists.txt to quiet git hook

### DIFF
--- a/src/drivers/magnetometer/qmc5883/CMakeLists.txt
+++ b/src/drivers/magnetometer/qmc5883/CMakeLists.txt
@@ -41,4 +41,3 @@ px4_add_module(
 		qmc5883.cpp
 	DEPENDS
 	)
-


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR eliminates a newline at the end of qmc5883/CMakeLists.txt.  Merging PX4/Firmware master branch is causing a default (sample) githook to complain about this file and disallows further commits until the issue is resolved.

Let me know if you have any questions on this PR.

-Mark

