### PR TITLE
FlightTaskAuto - Recover position control after local position reset

### DIFF
--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -153,8 +153,8 @@ bool FlightTaskAuto::_evaluateTriplets()
 
 	bool triplet_update = true;
 
-	if (!(fabsf(_triplet_target(0) - tmp_target(0)) > 0.001f || fabsf(_triplet_target(1) - tmp_target(1)) > 0.001f
-	      || fabsf(_triplet_target(2) - tmp_target(2)) > 0.001f)) {
+	if (fabsf(_triplet_target(0) - tmp_target(0)) < 0.001f && fabsf(_triplet_target(1) - tmp_target(1)) < 0.001f
+	    && fabsf(_triplet_target(2) - tmp_target(2)) < 0.001f) {
 		// Nothing has changed: just keep old waypoints.
 		triplet_update = false;
 

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -153,7 +153,11 @@ bool FlightTaskAuto::_evaluateTriplets()
 
 	bool triplet_update = true;
 
-	if (fabsf(_triplet_target(0) - tmp_target(0)) < 0.001f && fabsf(_triplet_target(1) - tmp_target(1)) < 0.001f
+	if (PX4_ISFINITE(_triplet_target(0))
+	    && PX4_ISFINITE(_triplet_target(1))
+	    && PX4_ISFINITE(_triplet_target(2))
+	    && fabsf(_triplet_target(0) - tmp_target(0)) < 0.001f
+	    && fabsf(_triplet_target(1) - tmp_target(1)) < 0.001f
 	    && fabsf(_triplet_target(2) - tmp_target(2)) < 0.001f) {
 		// Nothing has changed: just keep old waypoints.
 		triplet_update = false;


### PR DESCRIPTION
When the local position is invalid, the `_position` is set to `NAN` and the _triplet_target gets a `NAN`. In that state, the result of the if condition is always true (because `!(NAN > 0.001f) = true`) and the target cannot be updated anymore. 
The target get stucks in a `NAN` condition even if local position is recovered and the vehicle drifts away. Changing the condition to (`_triplet_target - tmp_target < 0.001f`) returns a `false` if `_triplet_target` is NAN (because `NAN < 0.001f = false`) and the target gets a valid position as soon as local position is valid.

Without this PR:
https://logs.px4.io/plot_app?log=501f7173-36a6-407d-b0da-4095bb020eb4
![bokeh_plot(14)](https://user-images.githubusercontent.com/14822839/54275107-1a445500-458a-11e9-86eb-41ebe66fec4f.png)

With this PR:
https://logs.px4.io/plot_app?log=0f4fc7cb-b228-41bc-ab0e-8d576cbc34fd
![bokeh_plot(13)](https://user-images.githubusercontent.com/14822839/54275120-1fa19f80-458a-11e9-814d-f416c7545a00.png)
(Note that the position setpoint is generated as soon as the local position is again valid)

@sanderux This is why the XY position was not controlled during the land phase of the DQ of the flight test team after the EKF position reset.