### PR TITLE
Obstacle Avoidance prearm checks and log health status

### DIFF
--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -33,3 +33,5 @@ bool rc_input_blocked                                # set if RC input should be
 bool rc_calibration_valid                            # set if RC calibration is valid
 bool vtol_transition_failure                        # Set to true if vtol transition failed
 bool usb_connected                                # status of the USB power supply
+
+bool avoidance_system_valid                       # status of the obstacle avoidance system

--- a/msg/vehicle_status_flags.msg
+++ b/msg/vehicle_status_flags.msg
@@ -34,4 +34,5 @@ bool rc_calibration_valid                            # set if RC calibration is 
 bool vtol_transition_failure                        # Set to true if vtol transition failed
 bool usb_connected                                # status of the USB power supply
 
-bool avoidance_system_valid                       # status of the obstacle avoidance system
+bool avoidance_system_required					  # Set to true if avoidance system is enabled via COM_OBS_AVOID parameter
+bool avoidance_system_valid                       # Status of the obstacle avoidance system

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3981,6 +3981,7 @@ void Commander::data_link_check(bool &status_changed)
 			_avoidance_system_lost = true;
 			mavlink_log_critical(&mavlink_log_pub, "Avoidance system lost");
 			status_flags.avoidance_system_valid = false;
+			print_msg_once = false;
 		}
 
 		//if status changed

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3964,14 +3964,15 @@ void Commander::data_link_check(bool &status_changed)
 	if (status_flags.avoidance_system_required && !_onboard_controller_lost) {
 
 		//if avoidance never started
-		if (_datalink_last_heartbeat_avoidance_system == 0 && hrt_elapsed_time(&_avoidance_system_not_started) > 10_s
+		if (_datalink_last_heartbeat_avoidance_system == 0
+		    && hrt_elapsed_time(&_avoidance_system_not_started) > _onboard_boot_timeout.get() * 1_s
 		    && avoidance_waiting_count < AVOIDANCE_MAX_TRIALS) {
 			_avoidance_system_not_started = hrt_absolute_time();
 			mavlink_log_info(&mavlink_log_pub, "Waiting for avoidance system to start");
 			avoidance_waiting_count++;
 
 		} else if (avoidance_waiting_count == AVOIDANCE_MAX_TRIALS) {
-			mavlink_log_critical(&mavlink_log_pub, "Avoidance system not responding. Try reboot vehicle.");
+			mavlink_log_critical(&mavlink_log_pub, "Avoidance not responding. Try reboot vehicle.");
 			avoidance_waiting_count++;
 		}
 

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3988,6 +3988,7 @@ void Commander::data_link_check(bool &status_changed)
 			if (_datalink_last_status_avoidance_system == telemetry_status_s::MAV_STATE_FLIGHT_TERMINATION) {
 				mavlink_log_critical(&mavlink_log_pub, "Avoidance system abort");
 				status_flags.avoidance_system_valid = false;
+				status_changed = true;
 			}
 
 			_avoidance_system_status_change = false;

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3834,7 +3834,6 @@ bool Commander::preflight_check(bool report)
 void Commander::data_link_check(bool &status_changed)
 {
 	bool updated = false;
-	static bool print_msg_once = false;
 
 	orb_check(_telemetry_status_sub, &updated);
 
@@ -3968,9 +3967,9 @@ void Commander::data_link_check(bool &status_changed)
 		//if avoidance never started
 		if (_datalink_last_heartbeat_avoidance_system == 0
 		    && hrt_elapsed_time(&_datalink_last_heartbeat_avoidance_system) > _oa_boot_timeout.get() * 1_s) {
-			if (!print_msg_once) {
+			if (!_print_msg_once) {
 				mavlink_log_critical(&mavlink_log_pub, "Avoidance system not available!");
-				print_msg_once = true;
+				_print_msg_once = true;
 
 			}
 		}
@@ -3981,7 +3980,7 @@ void Commander::data_link_check(bool &status_changed)
 			_avoidance_system_lost = true;
 			mavlink_log_critical(&mavlink_log_pub, "Avoidance system lost");
 			status_flags.avoidance_system_valid = false;
-			print_msg_once = false;
+			_print_msg_once = false;
 		}
 
 		//if status changed

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3967,9 +3967,9 @@ void Commander::data_link_check(bool &status_changed)
 		//if avoidance never started
 		if (_datalink_last_heartbeat_avoidance_system == 0
 		    && hrt_elapsed_time(&_datalink_last_heartbeat_avoidance_system) > _oa_boot_timeout.get() * 1_s) {
-			if (!_print_msg_once) {
+			if (!_print_avoidance_msg_once) {
 				mavlink_log_critical(&mavlink_log_pub, "Avoidance system not available!");
-				_print_msg_once = true;
+				_print_avoidance_msg_once = true;
 
 			}
 		}
@@ -3980,7 +3980,7 @@ void Commander::data_link_check(bool &status_changed)
 			_avoidance_system_lost = true;
 			mavlink_log_critical(&mavlink_log_pub, "Avoidance system lost");
 			status_flags.avoidance_system_valid = false;
-			_print_msg_once = false;
+			_print_avoidance_msg_once = false;
 		}
 
 		//if status changed

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -580,6 +580,7 @@ Commander::Commander() :
 
 	status_flags.condition_power_input_valid = true;
 	status_flags.rc_calibration_valid = true;
+	status_flags.avoidance_system_valid = false;
 }
 
 Commander::~Commander()
@@ -3918,6 +3919,7 @@ void Commander::data_link_check(bool &status_changed)
 						mavlink_log_info(&mavlink_log_pub, "Avoidance system regained");
 						status_changed = true;
 						_avoidance_system_lost = false;
+						status_flags.avoidance_system_valid = true;
 					}
 				}
 
@@ -3965,6 +3967,7 @@ void Commander::data_link_check(bool &status_changed)
 		    && (hrt_elapsed_time(&_datalink_last_heartbeat_avoidance_system) > 5_s)) {
 			_avoidance_system_lost = true;
 			mavlink_log_critical(&mavlink_log_pub, "Avoidance system lost");
+			status_flags.avoidance_system_valid = false;
 		}
 
 		//if status changed
@@ -3975,6 +3978,7 @@ void Commander::data_link_check(bool &status_changed)
 
 			if (_datalink_last_status_avoidance_system == telemetry_status_s::MAV_STATE_ACTIVE) {
 				mavlink_log_info(&mavlink_log_pub, "Avoidance system healthy");
+				status_flags.avoidance_system_valid = true;
 			}
 
 			if (_datalink_last_status_avoidance_system == telemetry_status_s::MAV_STATE_CRITICAL) {
@@ -3983,6 +3987,7 @@ void Commander::data_link_check(bool &status_changed)
 
 			if (_datalink_last_status_avoidance_system == telemetry_status_s::MAV_STATE_FLIGHT_TERMINATION) {
 				mavlink_log_critical(&mavlink_log_pub, "Avoidance system abort");
+				status_flags.avoidance_system_valid = false;
 			}
 
 			_avoidance_system_status_change = false;

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3967,7 +3967,7 @@ void Commander::data_link_check(bool &status_changed)
 
 		//if avoidance never started
 		if (_datalink_last_heartbeat_avoidance_system == 0
-		    && hrt_elapsed_time(&_datalink_last_heartbeat_avoidance_system) > _onboard_boot_timeout.get() * 1_s) {
+		    && hrt_elapsed_time(&_datalink_last_heartbeat_avoidance_system) > _oa_boot_timeout.get() * 1_s) {
 			if (!print_msg_once) {
 				mavlink_log_critical(&mavlink_log_pub, "Avoidance system not available!");
 				print_msg_once = true;

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3964,14 +3964,14 @@ void Commander::data_link_check(bool &status_changed)
 	if (status_flags.avoidance_system_required && !_onboard_controller_lost) {
 
 		//if avoidance never started
-		if (_datalink_last_heartbeat_avoidance_system == 0 && hrt_elapsed_time(&_avoidance_system_not_started) > 5_s
+		if (_datalink_last_heartbeat_avoidance_system == 0 && hrt_elapsed_time(&_avoidance_system_not_started) > 10_s
 		    && avoidance_waiting_count < AVOIDANCE_MAX_TRIALS) {
 			_avoidance_system_not_started = hrt_absolute_time();
 			mavlink_log_info(&mavlink_log_pub, "Waiting for avoidance system to start");
 			avoidance_waiting_count++;
 
 		} else if (avoidance_waiting_count == AVOIDANCE_MAX_TRIALS) {
-			mavlink_log_critical(&mavlink_log_pub, "Avoidance system stuck. Try reboot vehicle.");
+			mavlink_log_critical(&mavlink_log_pub, "Avoidance system not responding. Try reboot vehicle.");
 			avoidance_waiting_count++;
 		}
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -187,7 +187,6 @@ private:
 
 	hrt_abstime	_datalink_last_heartbeat_avoidance_system{0};
 	bool				_avoidance_system_lost{false};
-	hrt_abstime	_avoidance_system_not_started{0};
 
 	bool		_avoidance_system_status_change{false};
 	uint8_t	_datalink_last_status_avoidance_system{telemetry_status_s::MAV_STATE_UNINIT};
@@ -203,6 +202,8 @@ private:
 
 	systemlib::Hysteresis	_auto_disarm_landed{false};
 	systemlib::Hysteresis	_auto_disarm_killed{false};
+
+	bool _print_msg_once{false};
 
 	// Subscriptions
 	Subscription<estimator_status_s>		_estimator_status_sub{ORB_ID(estimator_status)};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -118,7 +118,7 @@ private:
 		(ParamFloat<px4::params::COM_DISARM_LAND>) _disarm_when_landed_timeout,
 
 		(ParamInt<px4::params::COM_OBS_AVOID>) _obs_avoid,
-		(ParamInt<px4::params::COM_ONB_BOOT_T>) _onboard_boot_timeout
+		(ParamInt<px4::params::COM_OA_BOOT_T>) _oa_boot_timeout
 
 	)
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -203,7 +203,7 @@ private:
 	systemlib::Hysteresis	_auto_disarm_landed{false};
 	systemlib::Hysteresis	_auto_disarm_killed{false};
 
-	bool _print_msg_once{false};
+	bool _print_avoidance_msg_once{false};
 
 	// Subscriptions
 	Subscription<estimator_status_s>		_estimator_status_sub{ORB_ID(estimator_status)};

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -117,7 +117,9 @@ private:
 		(ParamInt<px4::params::COM_LOW_BAT_ACT>) _low_bat_action,
 		(ParamFloat<px4::params::COM_DISARM_LAND>) _disarm_when_landed_timeout,
 
-		(ParamInt<px4::params::COM_OBS_AVOID>) _obs_avoid
+		(ParamInt<px4::params::COM_OBS_AVOID>) _obs_avoid,
+		(ParamInt<px4::params::COM_ONB_BOOT_T>) _onboard_boot_timeout
+
 	)
 
 	const int64_t POSVEL_PROBATION_MIN = 1_s;	/**< minimum probation duration (usec) */

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -798,7 +798,7 @@ PARAM_DEFINE_INT32(NAV_DLL_ACT, 0);
 PARAM_DEFINE_INT32(NAV_RCL_ACT, 2);
 
 /**
- * Flag to enable obstacle avoidance
+ * Flag to enable obstacle avoidance.
  *
  * @boolean
  * @group Mission
@@ -806,14 +806,14 @@ PARAM_DEFINE_INT32(NAV_RCL_ACT, 2);
 PARAM_DEFINE_INT32(COM_OBS_AVOID, 0);
 
 /**
- * Set onboard controller bootup timeout
+ * Set avoidance system bootup timeout.
  *
- * This parameter defines the bootup timeout.
- * After the timeout, a mavlink message that tells the user that the avoidance system
- * is not available is sent.
+ * The avoidance system running on the companion computer is expected to boot
+ * within this time and start providing trajectory points.
+ * If no avoidance system is detected a MAVLink warning message is sent.
  * @group Commander
  * @unit s
  * @min 0
  * @max 200
  */
-PARAM_DEFINE_INT32(COM_ONB_BOOT_T, 100);
+PARAM_DEFINE_INT32(COM_OA_BOOT_T, 100);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -806,3 +806,17 @@ PARAM_DEFINE_INT32(NAV_RCL_ACT, 2);
  * @group Mission
  */
 PARAM_DEFINE_INT32(COM_OBS_AVOID, 0);
+
+/**
+ * Set onboard controller bootup timeout
+ *
+ * This parameter defines the bootup timeout.
+ * After the timeout a mavlink message to warn the user that the system
+ * is still booting up is triggered.
+ *
+ * @group Commander
+ * @unit s
+ * @min 0
+ * @max 120
+ */
+PARAM_DEFINE_INT32(COM_ONB_BOOT_T, 15);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -802,6 +802,7 @@ PARAM_DEFINE_INT32(NAV_RCL_ACT, 2);
  * Temporary Parameter to enable interface testing
  *
  * @boolean
+ * @reboot_required true
  * @group Mission
  */
 PARAM_DEFINE_INT32(COM_OBS_AVOID, 0);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -799,10 +799,8 @@ PARAM_DEFINE_INT32(NAV_RCL_ACT, 2);
 
 /**
  * Flag to enable obstacle avoidance
- * Temporary Parameter to enable interface testing
  *
  * @boolean
- * @reboot_required true
  * @group Mission
  */
 PARAM_DEFINE_INT32(COM_OBS_AVOID, 0);
@@ -811,12 +809,11 @@ PARAM_DEFINE_INT32(COM_OBS_AVOID, 0);
  * Set onboard controller bootup timeout
  *
  * This parameter defines the bootup timeout.
- * After the timeout a mavlink message to warn the user that the system
- * is still booting up is triggered.
- *
+ * After the timeout, a mavlink message that tells the user that the avoidance system
+ * is not available is sent.
  * @group Commander
  * @unit s
  * @min 0
- * @max 120
+ * @max 200
  */
-PARAM_DEFINE_INT32(COM_ONB_BOOT_T, 15);
+PARAM_DEFINE_INT32(COM_ONB_BOOT_T, 100);

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -999,9 +999,9 @@ bool prearm_check(orb_advert_t *mavlink_log_pub, const vehicle_status_flags_s &s
 		}
 	}
 
-	if (!status_flags.avoidance_system_valid) {
+	if (status_flags.avoidance_system_required && !status_flags.avoidance_system_valid) {
 		if (prearm_ok && reportFailures) {
-			mavlink_log_critical(mavlink_log_pub, "ARMING DENIED: AVOIDANCE SYSTEM NOT READY");
+			mavlink_log_critical(mavlink_log_pub, "ARMING DENIED: Avoidance system not ready");
 		}
 
 		prearm_ok = false;

--- a/src/modules/commander/state_machine_helper.cpp
+++ b/src/modules/commander/state_machine_helper.cpp
@@ -46,6 +46,7 @@
 #include <systemlib/mavlink_log.h>
 #include <drivers/drv_hrt.h>
 
+
 #include "state_machine_helper.h"
 #include "commander_helper.h"
 #include "PreflightCheck.h"
@@ -915,6 +916,7 @@ bool prearm_check(orb_advert_t *mavlink_log_pub, const vehicle_status_flags_s &s
 	bool reportFailures = true;
 	bool prearm_ok = true;
 
+
 	// USB not connected
 	if (!status_flags.circuit_breaker_engaged_usb_check && status_flags.usb_connected) {
 		if (reportFailures) {
@@ -995,6 +997,15 @@ bool prearm_check(orb_advert_t *mavlink_log_pub, const vehicle_status_flags_s &s
 			// feedback provided in arm_auth_check
 			prearm_ok = false;
 		}
+	}
+
+	if (!status_flags.avoidance_system_valid) {
+		if (prearm_ok && reportFailures) {
+			mavlink_log_critical(mavlink_log_pub, "ARMING DENIED: AVOIDANCE SYSTEM NOT READY");
+		}
+
+		prearm_ok = false;
+
 	}
 
 	return prearm_ok;


### PR DESCRIPTION
This PR is an incremental piece of #11550 and substitutes #11456. Adds Obstacle Avoidance to the prearm checks. 

If Obstacle Avoidance system is enabled (COM_OBS_AVOID set to 1) then arming will be temporary denied as long as OA is not up and running.
Moreover the status of OA is now logged in the `vehicle_status_flags` message:
- Topic `avoidance_system_required`: is set to 1 if avoidance system is enabled, 0 if not.
- Topic `avoidance_system_valid`: is set to 1 when avoidance system is up and running, 0 when avoidance system dies.

Eventually another parameter has been added:
- `COM_ONB_BOOT_T`: Allows to specify the timeout time for an onboard controller to bootup and start avoidance. Default set to 10s. After 3 times this timeout has occurred a mavlink message saying "_Avoidance not responding. Try reboot vehicle._" will happear.

**Test data / coverage**
Tested in SITL with upstream avoidance and bench tested on a vehicle.

Example of the logged signal when avoidance is lost and regained:
![image](https://user-images.githubusercontent.com/7490213/54285947-34d6f800-45a3-11e9-9d43-80e0f71da46b.png)

@bkueng @mrivi FYI