### PR TITLE
Trajectory generator fixes

### DIFF
--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
@@ -141,6 +141,19 @@ void FlightTaskManualPositionSmoothVel::_updateSetpoints()
 		_position_lock_z_active = false;
 	}
 
+	// During position lock, lower jerk to help the optimizer
+	// to converge to 0 acceleration and velocity
+	if (_position_lock_xy_active) {
+		jerk[0] = 1.f;
+		jerk[1] = 1.f;
+
+	} else {
+		jerk[0] = _jerk_max.get();
+		jerk[1] = _jerk_max.get();
+	}
+
+	jerk[2] = _position_lock_z_active ? 1.f : _jerk_max.get();
+
 	for (int i = 0; i < 3; ++i) {
 		_smoothing[i].setMaxJerk(jerk[i]);
 		_smoothing[i].updateDurations(_deltatime, _velocity_setpoint(i));

--- a/src/lib/FlightTasks/tasks/Utility/Makefile
+++ b/src/lib/FlightTasks/tasks/Utility/Makefile
@@ -1,0 +1,12 @@
+
+.PHONY: all tests clean
+all: test_velocity_smoothing
+
+test_velocity_smoothing: test_velocity_smoothing.cpp VelocitySmoothing.cpp
+	@g++ $^ -std=c++11 -I ../../../ -o $@
+
+tests: test_velocity_smoothing
+	@echo "Test velocity smoothing"
+
+clean:
+	@rm test_velocity_smoothing

--- a/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.cpp
@@ -35,8 +35,6 @@
 
 #include <cstdio>
 #include <float.h>
-#include <math.h>
-#include <px4_defines.h>
 
 #include <mathlib/mathlib.h>
 
@@ -210,22 +208,22 @@ void VelocitySmoothing::updateDurations(float T123)
 	_max_jerk_T1 = (_vel_sp - _vel > 0.f) ? _max_jerk : -_max_jerk;
 
 	// compute increasing acceleration time
-	if (PX4_ISFINITE(T123)) {
-		T1 = computeT1(T123, _accel, _vel, _vel_sp, _max_jerk_T1);
+	if (T123 < 0.f) {
+		T1 = computeT1(_accel, _vel, _vel_sp, _max_jerk_T1);
 
 	} else {
-		T1 = computeT1(_accel, _vel, _vel_sp, _max_jerk_T1);
+		T1 = computeT1(T123, _accel, _vel, _vel_sp, _max_jerk_T1);
 	}
 
 	// compute decreasing acceleration time
 	T3 = computeT3(T1, _accel, _max_jerk_T1);
 
 	// compute constant acceleration time
-	if (PX4_ISFINITE(T123)) {
-		T2 = computeT2(T123, T1, T3);
+	if (T123 < 0.f) {
+		T2 = computeT2(T1, T3, _accel, _vel, _vel_sp, _max_jerk_T1);
 
 	} else {
-		T2 = computeT2(T1, T3, _accel, _vel, _vel_sp, _max_jerk_T1);
+		T2 = computeT2(T123, T1, T3);
 	}
 
 	_T1 = T1;

--- a/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.hpp
+++ b/src/lib/FlightTasks/tasks/Utility/VelocitySmoothing.hpp
@@ -33,8 +33,6 @@
 
 #pragma once
 
-#include <matrix/matrix/math.hpp>
-
 /**
  * @class VelocitySmoothing
  *
@@ -115,6 +113,9 @@ public:
 	static void timeSynchronization(VelocitySmoothing *traj, int n_traj);
 
 	float getTotalTime() const { return _T1 + _T2 + _T3; }
+	float getT1() const { return _T1; }
+	float getT2() const { return _T2; }
+	float getT3() const { return _T3; }
 	float getVelSp() const { return _vel_sp; }
 
 private:
@@ -124,7 +125,7 @@ private:
 	 * @param T123 optional parameter. If set, the total trajectory time will be T123, if not,
 	 * 		the algorithm optimizes for time.
 	 */
-	void updateDurations(float T123 = NAN);
+	void updateDurations(float T123 = -1.f);
 	/**
 	 * Compute increasing acceleration time
 	 */

--- a/src/lib/FlightTasks/tasks/Utility/test_velocity_smoothing.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/test_velocity_smoothing.cpp
@@ -1,0 +1,85 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Test code for the Velocity Smoothing library
+ * Build and run using: make && ./test_velocity_smoothing
+ */
+
+#include "VelocitySmoothing.hpp"
+#include <cstdio>
+
+int main(int argc, char *argv[])
+{
+	VelocitySmoothing trajectory[3];
+
+	float a0[3] = {0.22, 0.f, 0.22f};
+	float v0[3] = {2.47f, -5.59e-6f, 2.47f};
+	float x0[3] = {0.f, 0.f, 0.f};
+
+	float j_max = 55.2f;
+	float a_max = 6.f;
+	float v_max = 6.f;
+
+	for (int i = 0; i < 3; i++) {
+		trajectory[i].setMaxJerk(j_max);
+		trajectory[i].setMaxAccel(a_max);
+		trajectory[i].setMaxVel(v_max);
+		trajectory[i].setCurrentAcceleration(a0[i]);
+		trajectory[i].setCurrentVelocity(v0[i]);
+	}
+
+	float dt = 0.01f;
+
+	float velocity_setpoint[3] = {0.f, 1.f, 0.f};
+
+	for (int i = 0; i < 3; i++) {
+		trajectory[i].updateDurations(dt, velocity_setpoint[i]);
+	}
+
+	VelocitySmoothing::timeSynchronization(trajectory, 2);
+
+	for (int i = 0; i < 3; i++) {
+		trajectory[i].integrate(a0[i], v0[i], x0[i]);
+	}
+
+	for (int i = 0; i < 3; i++) {
+		printf("Traj[%d]\n", i);
+		printf("jerk = %.3f\taccel = %.3f\tvel = %.3f\n", trajectory[i].getCurrentJerk(),
+		       trajectory[i].getCurrentAcceleration(), trajectory[i].getCurrentVelocity());
+		printf("T1 = %.3f\tT2 = %.3f\tT3 = %.3f\n", trajectory[i].getT1(), trajectory[i].getT2(), trajectory[i].getT3());
+		printf("\n");
+	}
+
+	return 0;
+}


### PR DESCRIPTION
### Context:
The trajectory generator (called VelocitySmoothing here) is basically an optimizer that tries to find an optimal jerk signal of fixed amplitude to control each output of a chain of two integrators (i.e.: control acceleration and velocity) while minimizing the time to reach the desired state and satisfying maximum acceleration.

### Problem:
When the defined jerk is large and the velocity/acceleration targets are small, the problem cannot be solved given the fixed time interval (this is a discrete-time problem). The drone sometimes keeps drifting while the stick is centered because the velocity is non-zero.

### Proposed solution:
When the velocity and acceleration are small, decrease the jerk (set it to 1) such that the optimizer can find a new solution and move closer to zero. Once the outputs are small enough, force them to 0.

### Other changes:
- Some division by 0 and sqrt of negative number protections.
- A simple script that uses the VelocitySmoothing library. This is used to debug the code, verify the outputs and compare them to the original python script. The next step is to run a true unit test to compare the outputs automatically.