### PR TITLE
HIL fixes for gazebo & jMAVSim

### DIFF
--- a/Tools/jmavsim_run.sh
+++ b/Tools/jmavsim_run.sh
@@ -10,7 +10,7 @@ extra_args=
 baudrate=921600
 device=
 ip="127.0.0.1"
-while getopts ":b:d:p:qr:f:i:" opt; do
+while getopts ":b:d:p:qr:f:i:l" opt; do
 	case $opt in
 		b)
 			baudrate=$OPTARG
@@ -32,6 +32,9 @@ while getopts ":b:d:p:qr:f:i:" opt; do
 			;;
 		f)
 			extra_args="$extra_args -f $OPTARG"
+			;;
+		l)
+			extra_args="$extra_args -lockstep"
 			;;
 		\?)
 			echo "Invalid option: -$OPTARG" >&2
@@ -61,11 +64,11 @@ fi
 ant create_run_jar copy_res
 cd out/production
 
-java -XX:GCTimeRatio=20 -Djava.ext.dirs= -jar jmavsim_run.jar -lockstep $device $extra_args
+java -XX:GCTimeRatio=20 -Djava.ext.dirs= -jar jmavsim_run.jar $device $extra_args
 ret=$?
 if [ $ret -ne 0 -a $ret -ne 130 ]; then # 130 is Ctrl-C
 	# if the start of java fails, it's probably because the GC option is not
 	# understood. Try starting without it
-	java -Djava.ext.dirs= -jar jmavsim_run.jar -lockstep $device $extra_args
+	java -Djava.ext.dirs= -jar jmavsim_run.jar $device $extra_args
 fi
 

--- a/Tools/sitl_multiple_run.sh
+++ b/Tools/sitl_multiple_run.sh
@@ -4,7 +4,7 @@
 
 # The simulator is expected to send to TCP port 4560+i for i in [0, N-1]
 # For example jmavsim can be run like this:
-#./Tools/jmavsim_run.sh -p 4561
+#./Tools/jmavsim_run.sh -p 4561 -l
 
 sitl_num=2
 [ -n "$1" ] && sitl_num="$1"

--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -72,7 +72,7 @@ fi
 
 if [ "$program" == "jmavsim" ] && [ ! -n "$no_sim" ]; then
 	# Start Java simulator
-	"$src_path"/Tools/jmavsim_run.sh -r 250 -f $speed_factor &
+	"$src_path"/Tools/jmavsim_run.sh -r 250 -f $speed_factor -l &
 	SIM_PID=`echo $!`
 elif [ "$program" == "gazebo" ] && [ ! -n "$no_sim" ]; then
 	if [ -x "$(command -v gazebo)" ]; then


### PR DESCRIPTION
We cannot add `-lockstep` by default to `Tools/jmavsim_run.sh`, as it breaks HIL.