### PR TITLE
lockstep_scheduler: check if mutex is still valid

### DIFF
--- a/platforms/posix/src/lockstep_scheduler/include/lockstep_scheduler/lockstep_scheduler.h
+++ b/platforms/posix/src/lockstep_scheduler/include/lockstep_scheduler/lockstep_scheduler.h
@@ -29,7 +29,10 @@ private:
 				// This destructor gets called as part of thread-local storage cleanup.
 				// This is really only a work-around for non-proper thread stopping. Note that we also assume,
 				// that we can still access the mutex.
-				pthread_mutex_unlock(passed_lock);
+				if (passed_lock) {
+					pthread_mutex_unlock(passed_lock);
+				}
+
 				done = true;
 			}
 


### PR DESCRIPTION
It turns out that we can fix the unit tests of the lockstep_scheduler just by checking if `passed_lock` is not `nullptr`.

Without this check, the unit tests segfaulted.