### PR TITLE
Replace math::min() and additional limit logic with math::constrain() calls

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -808,11 +808,7 @@ MulticopterAttitudeControl::run()
 	_motor_limits_sub = orb_subscribe(ORB_ID(multirotor_motor_limits));
 	_battery_status_sub = orb_subscribe(ORB_ID(battery_status));
 
-	_gyro_count = math::min(orb_group_count(ORB_ID(sensor_gyro)), MAX_GYRO_COUNT);
-
-	if (_gyro_count == 0) {
-		_gyro_count = 1;
-	}
+	_gyro_count = math::constrain(orb_group_count(ORB_ID(sensor_gyro)), 1, MAX_GYRO_COUNT);
 
 	for (unsigned s = 0; s < _gyro_count; s++) {
 		_sensor_gyro_sub[s] = orb_subscribe_multi(ORB_ID(sensor_gyro), s);
@@ -865,13 +861,8 @@ MulticopterAttitudeControl::run()
 			float dt = (now - last_run) / 1e6f;
 			last_run = now;
 
-			/* guard against too small (< 0.2ms) and too large (> 20ms) dt's */
-			if (dt < 0.0002f) {
-				dt = 0.0002f;
-
-			} else if (dt > 0.02f) {
-				dt = 0.02f;
-			}
+			// Guard against too small (< 0.2ms) and too large (> 20ms) dt's.
+			math::constrain(dt, 0.0002f, 0.02f);
 
 			/* copy gyro data */
 			orb_copy(ORB_ID(sensor_gyro), _sensor_gyro_sub[_selected_gyro], &_sensor_gyro);

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -858,11 +858,10 @@ MulticopterAttitudeControl::run()
 		/* run controller on gyro changes */
 		if (poll_fds.revents & POLLIN) {
 			const hrt_abstime now = hrt_absolute_time();
-			float dt = (now - last_run) / 1e6f;
-			last_run = now;
 
 			// Guard against too small (< 0.2ms) and too large (> 20ms) dt's.
-			math::constrain(dt, 0.0002f, 0.02f);
+			const float dt = math::constrain(((now - last_run) / 1e6f), 0.0002f, 0.02f);
+			last_run = now;
 
 			/* copy gyro data */
 			orb_copy(ORB_ID(sensor_gyro), _sensor_gyro_sub[_selected_gyro], &_sensor_gyro);


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR simplifies a bit of logic by replacing a math::min() call and additional limit logic in two instances with math::constrain() calls in `mc_att_control.cpp`.

If the code is better off left as-is just let me know, this PR is fairly inconsequential.

Thanks!

-Mark
