### PR TITLE
Add a close(fd) call to platforms/posix/src/main.cpp to close a resource leak

### DIFF
--- a/platforms/posix/src/main.cpp
+++ b/platforms/posix/src/main.cpp
@@ -582,7 +582,6 @@ bool is_already_running(int instance)
 	int fd = open(file_lock_path.c_str(), O_RDWR | O_CREAT, 0666);
 
 	if (fd < 0) {
-		close(fd);
 		return false;
 	}
 
@@ -598,10 +597,12 @@ bool is_already_running(int instance)
 			return true;
 		}
 
+		close(fd);
 		return false;
 	}
 
 	errno = 0;
+	close(fd);
 	return false;
 }
 

--- a/platforms/posix/src/main.cpp
+++ b/platforms/posix/src/main.cpp
@@ -578,10 +578,11 @@ void print_usage()
 bool is_already_running(int instance)
 {
 	const std::string file_lock_path = std::string(LOCK_FILE_PATH) + '-' + std::to_string(instance);
-	struct flock fl;
+	struct flock fl {};
 	int fd = open(file_lock_path.c_str(), O_RDWR | O_CREAT, 0666);
 
 	if (fd < 0) {
+		close(fd);
 		return false;
 	}
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR closes a file descriptor identified by Coverity as a resource leak, (shown below), default initializes the flock struct in the same method and deprecates the unneeded struct specifier.

**Additional context**
Logs uploaded to http://logs.px4.io or screenshots.
![image](https://user-images.githubusercontent.com/2497951/54444780-125eef00-4709-11e9-8039-16bbe13f6e6e.png)

Please let me know if you have any feedback for this PR.

-Mark