### PR TITLE
vscode minor updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,8 @@ posix-configs/SITL/init/test/*_generated
 *.gcov
 .coverage
 .coverage.*
+
+.vscode/.cortex-debug.peripherals.state.json
+.vscode/.cortex-debug.registers.state.json
+.vscode/c_cpp_properties.json
+

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,11 +2,12 @@
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-        "ms-vscode.cpptools",
-        "github.vscode-pull-request-github",
         "chiehyu.vscode-astyle",
+        "github.vscode-pull-request-github",
         "marus25.cortex-debug",
         "ms-python.python",
+        "ms-vscode.cpptools",
+        "twxs.cmake",
         "vector-of-bool.cmake-tools"
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -106,7 +106,7 @@
                 "type": "cortex-debug",
                 "servertype": "jlink",
                 "device": "STM32F427VI",
-                //"svdFile": "",
+                "svdFile": "${workspaceRoot}/../cmsis-svd/data/STMicro/STM32F427.svd",
                 "interface": "swd",
                 "ipAddress": null,
                 "serialNumber": null


### PR DESCRIPTION
 - add cmake language support to recommend extensions
 - jlink debug add stm32f427 svd
 - gitignore updates for vscode

@davids5 FYI debugging is working on embedded targets with jlink, including cortex peripherals via SVD file.

![Screenshot from 2019-03-17 11-07-29](https://user-images.githubusercontent.com/84712/54493314-df516280-48a4-11e9-8adb-92d65224d844.png)
