### PR TITLE
update cmake NuttX helper save behaviour (oldconfig, menuconfig, etc)

### DIFF
--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -1,3 +1,35 @@
+############################################################################
+#
+#   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
 
 if (CMAKE_HOST_APPLE OR CMAKE_HOST_WIN32)
 	# copy with rsync and create file dependencies
@@ -27,7 +59,7 @@ file(GLOB_RECURSE copy_nuttx_files LIST_DIRECTORIES false ${NUTTX_SRC_DIR}/nuttx
 add_custom_command(
 	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/nuttx_copy.stamp
 	COMMAND ${cp_cmd} ${cp_opts} ${CP_SRC} ${CP_DST}
-	COMMAND cmake -E touch ${CMAKE_CURRENT_BINARY_DIR}/nuttx_copy.stamp
+	COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/nuttx_copy.stamp
 	DEPENDS ${copy_nuttx_files} git_nuttx
 	COMMENT "Copying NuttX/nuttx to ${CP_DST}"
 	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
@@ -44,7 +76,7 @@ file(GLOB_RECURSE copy_apps_files LIST_DIRECTORIES false ${NUTTX_SRC_DIR}/apps/*
 add_custom_command(
 	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/apps_copy.stamp
 	COMMAND ${cp_cmd} ${cp_opts} ${CP_SRC} ${CP_DST}
-	COMMAND cmake -E touch ${CMAKE_CURRENT_BINARY_DIR}/apps_copy.stamp
+	COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/apps_copy.stamp
 	DEPENDS ${copy_apps_files} git_nuttx_apps
 	COMMENT "Copying NuttX/apps to ${CP_DST}"
 	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
@@ -75,53 +107,61 @@ endif()
 # NuttX configure
 ###############################################################################
 
-if ("x${config_expanded}" STREQUAL "x")
-	# copy PX4 board Compressed config into nuttx and inflate it
+# copy NuttX config directory
+add_custom_command(
+	OUTPUT
+		${NUTTX_DIR}/arch/arm/include/math.h
+		${PX4_BINARY_DIR}/NuttX/nuttx-config/include/board.h
+		${PX4_BINARY_DIR}/NuttX/nuttx-config/include/nsh_romfsimg.h
+		${PX4_BINARY_DIR}/NuttX/nuttx-config/scripts/ld.script
+		${CMAKE_CURRENT_BINARY_DIR}/nuttx_copy_config_dir.stamp
+	COMMAND ${CMAKE_COMMAND} -E remove -f ${NUTTX_DIR}/include/nuttx/config.h
+	COMMAND ${CMAKE_COMMAND} -E copy_directory ${NUTTX_CONFIG_DIR}/ ${PX4_BINARY_DIR}/NuttX/nuttx-config
+	COMMAND ${CMAKE_COMMAND} -E make_directory ${PX4_BINARY_DIR}/NuttX/nuttx-config/src
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different ${NUTTX_SRC_DIR}/math.h ${NUTTX_DIR}/arch/arm/include/math.h # copy arm math.h into NuttX source
+	COMMAND ${CMAKE_COMMAND} -E copy_if_different ${NUTTX_SRC_DIR}/nsh_romfsimg.h ${PX4_BINARY_DIR}/NuttX/nuttx-config/include/nsh_romfsimg.h
+	COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/nuttx_copy_config_dir.stamp
+	DEPENDS
+		${NUTTX_SRC_DIR}/math.h
+		${NUTTX_SRC_DIR}/nsh_romfsimg.h
+		${NUTTX_CONFIG_DIR}/include/board.h
+		${NUTTX_CONFIG_DIR}/scripts/ld.script
+		${CMAKE_CURRENT_BINARY_DIR}/nuttx_copy.stamp
+		${CMAKE_CURRENT_BINARY_DIR}/apps_copy.stamp
+	WORKING_DIRECTORY ${NUTTX_DIR}
+	COMMENT "Copying NuttX config ${NUTTX_CONFIG} and configuring"
+)
+
+# NuttX defconfig
+#  cmake should trigger reconfigure if defconfig changes
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${NUTTX_DEFCONFIG})
+file(STRINGS ${NUTTX_DEFCONFIG} config_expanded REGEX "# Automatically generated file; DO NOT EDIT.")
+if (NOT config_expanded)
+	# copy compressed PX4 defconfig into nuttx and inflate
 	add_custom_command(
-		OUTPUT
-			${NUTTX_DIR}/.config
-			${NUTTX_DIR}/arch/arm/include/math.h
+		OUTPUT ${NUTTX_DIR}/.config
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${NUTTX_DEFCONFIG} ${NUTTX_DIR}/.config
 		COMMAND kconfig-tweak --set-str CONFIG_APPS_DIR "../apps"
-		COMMAND ${CMAKE_COMMAND} -E remove -f ${NUTTX_DIR}/include/nuttx/config.h
-		COMMAND ${CMAKE_COMMAND} -E copy_directory ${NUTTX_CONFIG_DIR}/ ${PX4_BINARY_DIR}/NuttX/nuttx-config
-		COMMAND ${CMAKE_COMMAND} -E make_directory ${PX4_BINARY_DIR}/NuttX/nuttx-config/src
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${NUTTX_SRC_DIR}/math.h ${NUTTX_DIR}/arch/arm/include/math.h # copy arm math.h into NuttX source
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${NUTTX_SRC_DIR}/nsh_romfsimg.h ${PX4_BINARY_DIR}/NuttX/nuttx-config/include/nsh_romfsimg.h
 		COMMAND make --no-print-directory --silent -C ${NUTTX_DIR} CONFIG_ARCH_BOARD_CUSTOM=y olddefconfig
 		DEPENDS
-			${NUTTX_CONFIG_DIR}/${NUTTX_CONFIG}/defconfig
-			${NUTTX_CONFIG_DIR}/include/board.h
-			${NUTTX_CONFIG_DIR}/scripts/ld.script
-			${NUTTX_SRC_DIR}/math.h
-			${NUTTX_SRC_DIR}/nsh_romfsimg.h
+			${NUTTX_DEFCONFIG}
+			${NUTTX_DIR}/configs/dummy/Kconfig
+			${CMAKE_CURRENT_BINARY_DIR}/nuttx_copy_config_dir.stamp
 		WORKING_DIRECTORY ${NUTTX_DIR}
 		COMMENT "Copying NuttX config ${NUTTX_CONFIG} and configuring"
-		)
+	)
 else()
-	# copy PX4 board config into nuttx
+	# copy uncompressed PX4 defconfig into nuttx
 	add_custom_command(
-		OUTPUT
-			${NUTTX_DIR}/.config
-			${NUTTX_DIR}/arch/arm/include/math.h
-		COMMAND ${CMAKE_COMMAND} -E copy ${NUTTX_CONFIG_DIR}/${NUTTX_CONFIG}/defconfig ${NUTTX_DIR}/.config
-		COMMAND ${CMAKE_COMMAND} -E remove -f ${NUTTX_DIR}/include/nuttx/config.h
-		COMMAND ${CMAKE_COMMAND} -E copy_directory ${NUTTX_CONFIG_DIR}/ ${CMAKE_CURRENT_BINARY_DIR}/nuttx-config
-		COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/nuttx-config/src
-		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/math.h ${NUTTX_DIR}/arch/arm/include/ # copy arm math.h into NuttX source
-		COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/nsh_romfsimg.h ${CMAKE_CURRENT_BINARY_DIR}/nuttx-config/include/
+		OUTPUT ${NUTTX_DIR}/.config
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${NUTTX_DEFCONFIG} ${NUTTX_DIR}/.config
 		DEPENDS
-			${NUTTX_CONFIG_DIR}/${NUTTX_CONFIG}/defconfig
-			${NUTTX_CONFIG_DIR}/include/board.h
-			${NUTTX_CONFIG_DIR}/scripts/ld.script
-			${CMAKE_CURRENT_BINARY_DIR}/nuttx_copy.stamp
-			${CMAKE_CURRENT_BINARY_DIR}/apps_copy.stamp
+			${NUTTX_DEFCONFIG}
 			${NUTTX_DIR}/configs/dummy/Kconfig
-			${CMAKE_CURRENT_SOURCE_DIR}/math.h
-			${CMAKE_CURRENT_SOURCE_DIR}/nsh_romfsimg.h
+			${CMAKE_CURRENT_BINARY_DIR}/nuttx_copy_config_dir.stamp
 		WORKING_DIRECTORY ${NUTTX_DIR}
 		COMMENT "Copying NuttX uncompressed config ${NUTTX_CONFIG} and configuring"
-		)
+	)
 endif()
 
 ###############################################################################
@@ -149,8 +189,11 @@ else()
 endif()
 
 # context
-add_custom_command(OUTPUT ${NUTTX_DIR}/include/nuttx/version.h ${NUTTX_DIR}/include/nuttx/config.h
-	COMMAND make ${nuttx_build_options} --no-print-directory context ${nuttx_build_output}
+add_custom_command(
+	OUTPUT
+		${NUTTX_DIR}/include/nuttx/version.h
+		${NUTTX_DIR}/include/nuttx/config.h
+	COMMAND make ${nuttx_build_options} --no-print-directory CONFIG_ARCH_BOARD_CUSTOM=y context ${nuttx_build_output}
 	DEPENDS ${NUTTX_DIR}/.config
 	WORKING_DIRECTORY ${NUTTX_DIR}
 	${nuttx_build_uses_terminal}
@@ -254,70 +297,122 @@ if (CONFIG_NET)
 	add_nuttx_dir(net net y -D__KERNEL__)
 endif()
 
-# oldconfig helper
-add_custom_target(oldconfig
-	COMMAND make --no-print-directory --silent -C ${NUTTX_DIR} CONFIG_ARCH_BOARD=${PX4_BOARD} oldconfig
-	COMMAND cp ${NUTTX_DIR}/.config ${NUTTX_CONFIG_DIR}/${NUTTX_CONFIG}/defconfig
+###############################################################################
+# NuttX oldconfig
+add_custom_target(oldconfig_nuttx
+	COMMAND make --no-print-directory --silent -C ${NUTTX_DIR} CONFIG_ARCH_BOARD_CUSTOM=y oldconfig
 	DEPENDS ${NUTTX_DIR}/.config
 	WORKING_DIRECTORY ${NUTTX_DIR}
 	COMMENT "Running NuttX make oldconfig for ${NUTTX_CONFIG}"
 	USES_TERMINAL
-	)
+)
 
-# olddefconfig helper
-add_custom_target(olddefconfig
-	COMMAND make --no-print-directory --silent -C ${NUTTX_DIR} CONFIG_ARCH_BOARD=${PX4_BOARD} olddefconfig
-	COMMAND cp ${NUTTX_DIR}/.config ${NUTTX_CONFIG_DIR}/${NUTTX_CONFIG}/defconfig
+# NuttX oldconfig + savedefconfig back to PX4
+add_custom_target(oldconfig
+	COMMAND make --no-print-directory --silent -C ${NUTTX_DIR} CONFIG_ARCH_BOARD_CUSTOM=y savedefconfig
+	COMMAND ${CMAKE_COMMAND} -E copy ${NUTTX_DIR}/defconfig ${NUTTX_DEFCONFIG}
+	COMMAND ${CMAKE_COMMAND} -E remove -f ${NUTTX_DIR}/.config
+	DEPENDS oldconfig_nuttx
+	WORKING_DIRECTORY ${NUTTX_DIR}
+	COMMENT "Running make oldconfig then savedefconfig for ${NUTTX_CONFIG}"
+	USES_TERMINAL
+)
+
+# NuttX oldconfig + copy uncompressed back to PX4
+add_custom_target(oldconfig_uncompressed
+	COMMAND ${CMAKE_COMMAND} -E copy ${NUTTX_DIR}/.config ${NUTTX_DEFCONFIG}
+	DEPENDS oldconfig_nuttx
+	WORKING_DIRECTORY ${NUTTX_DIR}
+	COMMENT "Running make oldconfig then saving uncompressed defconfig for ${NUTTX_CONFIG}"
+	USES_TERMINAL
+)
+
+###############################################################################
+# NuttX olddefconfig
+add_custom_target(olddefconfig_nuttx
+	COMMAND make --no-print-directory --silent -C ${NUTTX_DIR} CONFIG_ARCH_BOARD_CUSTOM=y olddefconfig
 	DEPENDS ${NUTTX_DIR}/.config
 	WORKING_DIRECTORY ${NUTTX_DIR}
 	COMMENT "Running NuttX make olddefconfig for ${NUTTX_CONFIG}"
 	USES_TERMINAL
 	)
 
-# menuconfig helper
-add_custom_target(menuconfig
-	COMMAND make --no-print-directory --silent -C ${NUTTX_DIR} CONFIG_ARCH_BOARD=${PX4_BOARD} menuconfig
+# NuttX olddefconfig + savedefconfig back to PX4
+add_custom_target(olddefconfig
+	COMMAND make --no-print-directory --silent -C ${NUTTX_DIR} CONFIG_ARCH_BOARD_CUSTOM=y savedefconfig
+	COMMAND ${CMAKE_COMMAND} -E copy ${NUTTX_DIR}/defconfig ${NUTTX_DEFCONFIG}
+	COMMAND ${CMAKE_COMMAND} -E remove -f ${NUTTX_DIR}/.config
+	DEPENDS olddefconfig_nuttx
+	WORKING_DIRECTORY ${NUTTX_DIR}
+	COMMENT "Running make olddefconfig then savedefconfig for ${NUTTX_CONFIG}"
+	USES_TERMINAL
+)
+
+# NuttX oldconfig + copy uncompressed back to PX4
+add_custom_target(olddefconfig_uncompressed
+	COMMAND ${CMAKE_COMMAND} -E copy ${NUTTX_DIR}/.config ${NUTTX_DEFCONFIG}
+	DEPENDS olddefconfig_nuttx
+	WORKING_DIRECTORY ${NUTTX_DIR}
+	COMMENT "Running make olddefconfig then saving uncompressed defconfig for ${NUTTX_CONFIG}"
+	USES_TERMINAL
+)
+
+###############################################################################
+# NuttX menuconfig
+add_custom_target(menuconfig_nuttx
+	COMMAND make --no-print-directory --silent -C ${NUTTX_DIR} CONFIG_ARCH_BOARD_CUSTOM=y menuconfig
 	DEPENDS ${NUTTX_DIR}/.config
 	WORKING_DIRECTORY ${NUTTX_DIR}
 	COMMENT "Running NuttX make menuconfig for ${NUTTX_CONFIG}"
 	USES_TERMINAL
 	)
 
-# qconfig helper
-add_custom_target(qconfig
-	COMMAND make --no-print-directory --silent -C ${NUTTX_DIR} CONFIG_ARCH_BOARD=${PX4_BOARD} qconfig
+# NuttX menuconfig + savedefconfig back to PX4
+add_custom_target(menuconfig
+	COMMAND make --no-print-directory --silent -C ${NUTTX_DIR} CONFIG_ARCH_BOARD_CUSTOM=y savedefconfig
+	COMMAND ${CMAKE_COMMAND} -E copy ${NUTTX_DIR}/defconfig ${NUTTX_DEFCONFIG}
+	COMMAND ${CMAKE_COMMAND} -E remove -f ${NUTTX_DIR}/.config
+	DEPENDS menuconfig_nuttx
+	WORKING_DIRECTORY ${NUTTX_DIR}
+	COMMENT "Running make nuttx_menuconfig then savedefconfig for ${NUTTX_CONFIG}"
+	USES_TERMINAL
+)
+
+# NuttX menuconfig + copy uncompressed back to PX4
+add_custom_target(menuconfig_uncompressed
+	COMMAND ${CMAKE_COMMAND} -E copy ${NUTTX_DIR}/.config ${NUTTX_DEFCONFIG}
+	DEPENDS menuconfig_nuttx
+	WORKING_DIRECTORY ${NUTTX_DIR}
+	COMMENT "Running make nuttx_menuconfig then saving uncompressed defconfig for ${NUTTX_CONFIG}"
+	USES_TERMINAL
+)
+
+###############################################################################
+# NuttX qconfig
+add_custom_target(qconfig_nuttx
+	COMMAND make --no-print-directory --silent -C ${NUTTX_DIR} CONFIG_ARCH_BOARD_CUSTOM=y qconfig
 	DEPENDS ${NUTTX_DIR}/.config
 	WORKING_DIRECTORY ${NUTTX_DIR}
 	COMMENT "Running NuttX make qconfig for ${NUTTX_CONFIG}"
 	USES_TERMINAL
 	)
 
-# savedefconfig helper
-add_custom_target(savedefconfig
-	COMMAND make --no-print-directory --silent -C ${NUTTX_DIR} CONFIG_ARCH_BOARD=${PX4_BOARD} savedefconfig
-	COMMAND ${CMAKE_COMMAND} -E copy_if_different ${NUTTX_DIR}/defconfig ${NUTTX_CONFIG_DIR}/${NUTTX_CONFIG}/defconfig
-	DEPENDS ${NUTTX_DIR}/.config
-	COMMENT "Compressing .config and saving back to ${NUTTX_CONFIG_DIR}/${NUTTX_CONFIG}/defconfig"
+# NuttX qconfig + savedefconfig back to PX4
+add_custom_target(qconfig
+	COMMAND make --no-print-directory --silent -C ${NUTTX_DIR} CONFIG_ARCH_BOARD_CUSTOM=y savedefconfig
+	COMMAND ${CMAKE_COMMAND} -E copy ${NUTTX_DIR}/defconfig ${NUTTX_DEFCONFIG}
+	COMMAND ${CMAKE_COMMAND} -E remove -f ${NUTTX_DIR}/.config
+	DEPENDS qconfig_nuttx
 	WORKING_DIRECTORY ${NUTTX_DIR}
+	COMMENT "Running make qconfig then savedefconfig for ${NUTTX_CONFIG}"
+	USES_TERMINAL
 )
 
-# menuconfig and save
-add_custom_target(menuconfig_save
-	COMMAND
-		${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} -- savedefconfig # this is hacky, but forces menuconfig to run before savedefconfig
-	DEPENDS menuconfig
-)
-
-# oldconfig and save
-add_custom_target(oldconfig_save
-	COMMAND
-		${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} -- savedefconfig # this is hacky, but forces oldconfig to run before savedefconfig
-	DEPENDS oldconfig
-)
-
-# qconfig and save
-add_custom_target(qconfig_save
-	COMMAND
-		${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} -- savedefconfig # this is hacky, but forces qconfig to run before savedefconfig
-	DEPENDS qconfig
+# NuttX qconfig + copy uncompressed back to PX4
+add_custom_target(qconfig_uncompressed
+	COMMAND ${CMAKE_COMMAND} -E copy ${NUTTX_DIR}/.config ${NUTTX_DEFCONFIG}
+	DEPENDS qconfig_nuttx
+	WORKING_DIRECTORY ${NUTTX_DIR}
+	COMMENT "Running make qconfig then saving uncompressed defconfig for ${NUTTX_CONFIG}"
+	USES_TERMINAL
 )

--- a/platforms/nuttx/cmake/init.cmake
+++ b/platforms/nuttx/cmake/init.cmake
@@ -1,3 +1,35 @@
+############################################################################
+#
+#   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
 
 if(NOT PX4_BOARD)
 	message(FATAL_ERROR "PX4_BOARD must be set (eg px4_fmu-v2)")
@@ -80,9 +112,8 @@ execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${NUTTX_SRC_DIR}/n
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${NUTTX_DEFCONFIG} ${NUTTX_DIR}/.config)
 
 # copy PX4 board config into nuttx
-file(STRINGS ${NUTTX_CONFIG_DIR}/${NUTTX_CONFIG}/defconfig config_expanded REGEX "# Automatically generated file; DO NOT EDIT.")
-
-if ("x${config_expanded}" STREQUAL "x")
+file(STRINGS ${NUTTX_DEFCONFIG} config_expanded REGEX "# Automatically generated file; DO NOT EDIT.")
+if (NOT config_expanded)
 	execute_process(COMMAND kconfig-tweak --set-str CONFIG_APPS_DIR "../apps" WORKING_DIRECTORY ${NUTTX_DIR})
 	execute_process(COMMAND make --no-print-directory --silent -C ${NUTTX_DIR} CONFIG_ARCH_BOARD_CUSTOM=y olddefconfig WORKING_DIRECTORY ${NUTTX_DIR})
 endif()


### PR DESCRIPTION
This PR updates the behavior of the PX4 NuttX cmake helper targets oldconfig, olddefconfig, menuconfig, qconfig to now compress and save back to PX4 by default.

There are also new helper targets for saving the uncompressed version back.
   * oldconfig_uncompressed
   * olddefconfig_uncompressed
   * menuconfig_uncompressed
   * qconfig_uncompressed

