### PR TITLE
fix bmi055: increase DLPF from 62.5 to 500

### DIFF
--- a/src/drivers/imu/bmi055/BMI055_accel.cpp
+++ b/src/drivers/imu/bmi055/BMI055_accel.cpp
@@ -169,7 +169,7 @@ int BMI055_accel::reset()
 	write_reg(BMI055_ACC_SOFTRESET, BMI055_SOFT_RESET);//Soft-reset
 	up_udelay(5000);
 
-	write_checked_reg(BMI055_ACC_BW,    BMI055_ACCEL_BW_62_5); //Write accel bandwidth (DLPF)
+	write_checked_reg(BMI055_ACC_BW,    BMI055_ACCEL_BW_500); //Write accel bandwidth (DLPF)
 	write_checked_reg(BMI055_ACC_RANGE,     BMI055_ACCEL_RANGE_2_G);//Write range
 	write_checked_reg(BMI055_ACC_INT_EN_1,      BMI055_ACC_DRDY_INT_EN); //Enable DRDY interrupt
 	write_checked_reg(BMI055_ACC_INT_MAP_1,     BMI055_ACC_DRDY_INT1); //Map DRDY interrupt on pin INT1


### PR DESCRIPTION
https://github.com/PX4/Firmware/pull/11434 wasn't quite right.
With a DLPF of 62.5 Hz, the sampling rate is apparently not 1 kHz anymore,
because the driver got duplicate samples and published only at 128 Hz.
We have to increase the filter back to 500 Hz so that we get 1 kHz sampling
rate, with 250 Hz publications.