### PR TITLE
replay: fix issue when original logfile had topics with zero timstamps

### DIFF
--- a/src/modules/replay/replay_main.cpp
+++ b/src/modules/replay/replay_main.cpp
@@ -773,6 +773,7 @@ void Replay::run()
 		//to be in chronological order, so we need to check all subscriptions
 		uint64_t next_file_time = 0;
 		int next_msg_id = -1;
+		bool first_time = true;
 
 		for (size_t i = 0; i < _subscriptions.size(); ++i) {
 			const Subscription *subscription = _subscriptions[i];
@@ -782,7 +783,8 @@ void Replay::run()
 			}
 
 			if (subscription->orb_meta && !subscription->ignored) {
-				if (next_file_time == 0 || subscription->next_timestamp < next_file_time) {
+				if (first_time || subscription->next_timestamp < next_file_time) {
+					first_time = false;
 					next_msg_id = (int)i;
 					next_file_time = subscription->next_timestamp;
 				}


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
If the original logfile contained a topic which at some point was logged with a zero timestamp `next_file_time` would be set to zero and in the next iteration of the for loop `next_file_time` is updated to the timestamp of the next topic in the `_subscriptions` list.

The result was that the topics which were before the zero timestamp topic in the `_subscriptions` list would never be published until the end. This was not visible in most log analysis software since the timestamp would still be correct but the order and timing of the published topics would be wrong.

**Additional context**
Another thing which makes replay not work as expected is the fact that the logger only tries to subscribe to a topic once a second. So e.g. when a VTOL transitions to cruise flight there will be a time right after transition when the fw_pos_controller publishes the virtual attitude setpoint but it is not logged for up to one second