### PR TITLE
cmake nuttx use wrapper script to call "make olddefconfig"

### DIFF
--- a/platforms/nuttx/NuttX/CMakeLists.txt
+++ b/platforms/nuttx/NuttX/CMakeLists.txt
@@ -141,7 +141,7 @@ if (NOT config_expanded)
 	add_custom_command(
 		OUTPUT ${NUTTX_DIR}/.config
 		COMMAND ${CMAKE_COMMAND} -E copy_if_different ${NUTTX_DEFCONFIG} ${NUTTX_DIR}/.config
-		COMMAND PATH=${CMAKE_CURRENT_SOURCE_DIR}/tools:$ENV{PATH} make --no-print-directory --silent -C ${NUTTX_DIR} CONFIG_ARCH_BOARD_CUSTOM=y CONFIG_APPS_DIR="../apps" olddefconfig > nuttx_olddefconfig.log
+		COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/px4_nuttx_make_olddefconfig.sh ${NUTTX_DIR}
 		DEPENDS
 			${NUTTX_DEFCONFIG}
 			${NUTTX_DIR}/configs/dummy/Kconfig

--- a/platforms/nuttx/NuttX/tools/kconfig-tweak
+++ b/platforms/nuttx/NuttX/tools/kconfig-tweak
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-echo "DEBUG: kconfiglib kconfig-tweak wrapper, arguments: ${@}"
+#echo "DEBUG: kconfiglib kconfig-tweak wrapper, arguments: ${@}"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 export APPSDIR="`pwd`/../apps"

--- a/platforms/nuttx/NuttX/tools/px4_nuttx_make_olddefconfig.sh
+++ b/platforms/nuttx/NuttX/tools/px4_nuttx_make_olddefconfig.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+NUTTX_DIR=${1}
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# update PATH to include kconfiglib scripts
+export PATH=${DIR}:${PATH}
+
+make --no-print-directory --silent -C ${NUTTX_DIR} CONFIG_ARCH_BOARD_CUSTOM=y CONFIG_APPS_DIR="../apps" olddefconfig > nuttx_olddefconfig.log


### PR DESCRIPTION
 - this is a workaround for PATH variables that exceed the maximum cmake custom command length
