### PR TITLE
px_uploader.py: write timeout workaround

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -205,7 +205,7 @@ class uploader(object):
         self.window_max = 256
         self.window_per = 2  # Sync,<result>
         self.ackWindowedMode = False  # Assume Non Widowed mode for all USB CDC
-        self.port = serial.Serial(portname, baudrate_bootloader, timeout=0.5, write_timeout=0.5)
+        self.port = serial.Serial(portname, baudrate_bootloader, timeout=0.5, write_timeout=0)
         self.otp = b''
         self.sn = b''
         self.baudrate_bootloader = baudrate_bootloader
@@ -247,14 +247,7 @@ class uploader(object):
 
     def __send(self, c):
         # print("send " + binascii.hexlify(c))
-        while True:
-            try:
-                self.port.write(c)
-                break
-            except serial.SerialTimeoutException as e:
-                print("Write timeout (%s), trying again" % e)
-                time.sleep(0.04)
-                continue
+        self.port.write(c)
 
     def __recv(self, count=1):
         c = self.port.read(count)
@@ -440,7 +433,7 @@ class uploader(object):
         self.__send(data)
         self.__send(uploader.EOC)
         if (not windowMode):
-            self.__getSync()
+            self.__getSync(False)
         else:
             # The following is done to have minimum delay on the transmission
             # of the ne fw. The per block cost of __getSync was about 16 mS per.


### PR DESCRIPTION
This is a workaround for the write timeout that we have seen for some
host computers trying to flash the firmware.

We don't know the root cause of the problem but we do observed the
following:

- For blocking writes with timeout (Pyserial `write_timeout=0.5`):
  `write()` throws `SerialTimeoutException`. In systrace we see that the
  `select()` call after write waiting for the write to be finished hangs
  and finally times out.
- For blocking writes without timeout (Pyserial `write_timeout=None`):
  `write()` hangs indefinitely. In systrace we see that the
  `select()` call after write waiting for the write to be finished hangs.
- For non-blocking writes (Pyserial `write_timeout=0`):
  `write()` works but flush() hangs. In systrace we see that
  `ioctl(fd, TCSBRK, 1)` which is (correctly) triggered by termios tcdrain
  hangs.

Inspecting USB traffic using usbmon, we can see that the data which is
written actually seems to be sent and looking at responses from the
Pixhawk bootloader and the timings it looks like all the data has
arrived.

This workaround uses non-blocking writes without flushing and this
seemed to prevent the issue from happening so far.

Debugging was done in collaboration with @bkueng  and @davids5.

Fixes #11704.