### PR TITLE
commander: PreflightCheck: check for 'airspeed' topic only on the 'airspeedCheck'

### DIFF
--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -385,9 +385,6 @@ static bool airspeedCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &statu
 	int fd_airspeed = orb_subscribe(ORB_ID(airspeed));
 	airspeed_s airspeed = {};
 
-	int fd_diffpres = orb_subscribe(ORB_ID(differential_pressure));
-	differential_pressure_s differential_pressure = {};
-
 	if ((orb_copy(ORB_ID(airspeed), fd_airspeed, &airspeed) != PX4_OK) ||
 	    (hrt_elapsed_time(&airspeed.timestamp) > 1_s)) {
 		if (report_fail && !optional) {
@@ -416,11 +413,11 @@ static bool airspeedCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &statu
 	}
 
 	/**
-	 * Check if differential pressure is off by more than 15Pa which equals ~5m/s when measuring no airspeed.
+	 * Check if airspeed is higher than 4m/s (accepted max) while the vehicle is landed / not flying
 	 * Negative and positive offsets are considered. Do not check anymore while arming because pitot cover
 	 * might have been removed.
 	 */
-	if (fabsf(differential_pressure.differential_pressure_filtered_pa) > 15.0f && !prearm) {
+	if (fabsf(airspeed.indicated_airspeed_m_s) > 4.0f && !prearm) {
 		if (report_fail) {
 			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: check Airspeed Cal or Pitot");
 		}
@@ -434,7 +431,6 @@ out:
 	set_health_flags(subsystem_info_s::SUBSYSTEM_TYPE_DIFFPRESSURE, present, !optional, success, status);
 
 	orb_unsubscribe(fd_airspeed);
-	orb_unsubscribe(fd_diffpres);
 
 	return success;
 }

--- a/src/modules/commander/PreflightCheck.cpp
+++ b/src/modules/commander/PreflightCheck.cpp
@@ -388,17 +388,6 @@ static bool airspeedCheck(orb_advert_t *mavlink_log_pub, vehicle_status_s &statu
 	int fd_diffpres = orb_subscribe(ORB_ID(differential_pressure));
 	differential_pressure_s differential_pressure = {};
 
-	if ((orb_copy(ORB_ID(differential_pressure), fd_diffpres, &differential_pressure) != PX4_OK) ||
-	    (hrt_elapsed_time(&differential_pressure.timestamp) > 1_s)) {
-		if (report_fail && !optional) {
-			mavlink_log_critical(mavlink_log_pub, "Preflight Fail: Airspeed Sensor missing");
-		}
-
-		present = false;
-		success = false;
-		goto out;
-	}
-
 	if ((orb_copy(ORB_ID(airspeed), fd_airspeed, &airspeed) != PX4_OK) ||
 	    (hrt_elapsed_time(&airspeed.timestamp) > 1_s)) {
 		if (report_fail && !optional) {


### PR DESCRIPTION
While testing HIL with a VTOL airframe, I found out I was obliged to set the `CBRK_AIRSPD_CHK` so to be able to overpass the pre-flight check for airspeed. Taking a look on the data that is propagated in `HIL_SENSOR`, we can see that the differential pressure data exists, and on the `mavlink_receiver` published as `airspeed` after being computed. On the commander `PreflightCheck`, the same check is done for the `airspeed` and the `differential_pressure` topics, but in HIL, only the `airspeed` exists and being published by the `mavlink_receiver`.

**Test data / coverage**
Tested on Gazebo with HIL mode set.

**Describe problem solved by the proposed pull request**
This PR solves the issue of the PreflightCheck not finding the `differential_pressure` topic while in HIL mode, since this topic is never actually published, even though there's airspeed data.

**Describe your preferred solution**
There's a check for the `hil_state` flag in `vehicle_status` when verifying the `differential_pressure` topic. If it is in HIL, then this check is ignored.

**Describe possible alternatives**
Another possible alternative is to publish the `differential_pressure` data coming from `HIL_SENSOR` as a `differential_pressure` uORB topic. But given that we already have `airspeed` data, I think this would become redundant.
