### PR TITLE
start px4flow after all rangefinders (including the ones going throug…

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -108,9 +108,6 @@ fi
 # ICM20948 as external magnetometer on I2C (e.g. Here GPS)
 icm20948 -X -M -R 6 start
 
-# Check for flow sensor, launched as a background task to scan
-px4flow start &
-
 ###############################################################################
 #                            End Optional drivers                             #
 ###############################################################################

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -452,6 +452,9 @@ else
 		vmount start
 	fi
 
+	# Check for flow sensor, launched as a background task to scan
+	px4flow start &
+
 	#
 	# Optional board supplied extras: rc.board_extras
 	#


### PR DESCRIPTION
In rc.sensors the px4flow driver is started after all the distance sensors. This makes sense because if we have an external distance sensor we want to use that one instead of the one on the flow board. With the serial interface we have now, the distance sensor running over serial will be started in rc.serial which is after rc.sensors. This will cause the px4flow distance sensor to be used instead of the external one. 

This pr moves the px4flow start at the end of the rcS (from rc.sensors). I didn't want to move rc.serial before rc.sensors because I was not sure if it would have other effects. 

Partially solving: https://github.com/PX4/Firmware/issues/11689. 

FYI @bkueng 
