### PR TITLE
Pr tecs front trans new

### DIFF
--- a/msg/vehicle_status.msg
+++ b/msg/vehicle_status.msg
@@ -66,7 +66,8 @@ bool is_rotary_wing			# True if system is in rotary wing configuration, so for a
 bool is_vtol				# True if the system is VTOL capable
 bool vtol_fw_permanent_stab		# True if VTOL should stabilize attitude for fw in manual mode
 bool in_transition_mode			# True if VTOL is doing a transition
-bool in_transition_to_fw		# True if VTOL is doing a transition from MC to FW
+bool in_transition_to_fw_phase_1		# True if VTOL is doing a transition from MC to FW and is in phase 1 (prior blending and (optionally) TECS activation)
+bool in_transition_to_fw_phase_2		# True if VTOL is doing a transition from MC to FW and is in phase 2 (post blending and (optionally) TECS activation)
 
 bool rc_signal_lost				# true if RC reception lost
 uint8 rc_input_mode				# set to 1 to disable the RC input, 2 to enable manual control to RC in mapping.

--- a/msg/vtol_vehicle_status.msg
+++ b/msg/vtol_vehicle_status.msg
@@ -1,14 +1,16 @@
 # VEHICLE_VTOL_STATE, should match 1:1 MAVLinks's MAV_VTOL_STATE
 uint8 VEHICLE_VTOL_STATE_UNDEFINED = 0
-uint8 VEHICLE_VTOL_STATE_TRANSITION_TO_FW = 1
+uint8 VEHICLE_VTOL_STATE_TRANSITION_TO_FW_PHASE_1 = 1
 uint8 VEHICLE_VTOL_STATE_TRANSITION_TO_MC = 2
 uint8 VEHICLE_VTOL_STATE_MC = 3
 uint8 VEHICLE_VTOL_STATE_FW = 4
+uint8 VEHICLE_VTOL_STATE_TRANSITION_TO_FW_PHASE_2 = 5
 
 uint64 timestamp			# time since system start (microseconds)
 
 bool vtol_in_rw_mode			# true: vtol vehicle is in rotating wing mode
 bool vtol_in_trans_mode
-bool in_transition_to_fw		# True if VTOL is doing a transition from MC to FW
+bool in_transition_to_fw_phase_1		# True if VTOL is doing a transition from MC to FW and is in phase 1 (prior blending and (optionally) TECS activation)
+bool in_transition_to_fw_phase_2		# True if VTOL is doing a transition from MC to FW and is in phase 2 (post blending and (optionally) TECS activation)
 bool vtol_transition_failsafe		# vtol in transition failsafe mode
 bool fw_permanent_stab			# In fw mode stabilize attitude even if in manual mode

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1621,8 +1621,13 @@ Commander::run()
 					status_changed = true;
 				}
 
-				if (status.in_transition_to_fw != vtol_status.in_transition_to_fw) {
-					status.in_transition_to_fw = vtol_status.in_transition_to_fw;
+				if (status.in_transition_to_fw_phase_1 != vtol_status.in_transition_to_fw_phase_1) {
+					status.in_transition_to_fw_phase_1 = vtol_status.in_transition_to_fw_phase_1;
+					status_changed = true;
+				}
+
+				if (status.in_transition_to_fw_phase_2 != vtol_status.in_transition_to_fw_phase_2) {
+					status.in_transition_to_fw_phase_2 = vtol_status.in_transition_to_fw_phase_2;
 					status_changed = true;
 				}
 

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -795,7 +795,8 @@ void
 FixedwingPositionControl::do_takeoff_help(float *hold_altitude, float *pitch_limit_min)
 {
 	/* demand "climbout_diff" m above ground if user switched into this mode during takeoff */
-	if (in_takeoff_situation()) {
+	/* disable takeoff help for VTOLs */
+	if (in_takeoff_situation() && !_vehicle_status.is_vtol) {
 		*hold_altitude = _takeoff_ground_alt + _parameters.climbout_diff;
 		*pitch_limit_min = radians(10.0f);
 

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -4278,7 +4278,7 @@ protected:
 				} else if (!status.in_transition_mode) {
 					_msg.vtol_state = MAV_VTOL_STATE_FW;
 
-				} else if (status.in_transition_mode && status.in_transition_to_fw) {
+				} else if (status.in_transition_mode && (status.in_transition_to_fw_phase_1 || status.in_transition_to_fw_phase_1)) {
 					_msg.vtol_state = MAV_VTOL_STATE_TRANSITION_TO_FW;
 
 				} else if (status.in_transition_mode) {

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -171,6 +171,7 @@ private:
 	orb_advert_t	_landing_gear_pub{nullptr};
 
 	orb_id_t _actuators_id{nullptr};	/**< pointer to correct actuator controls0 uORB metadata structure */
+	orb_id_t _attitude_setpoint_id{nullptr};	/**< pointer to correct attitude setpoint */
 
 	bool		_actuators_0_circuit_breaker_enabled{false};	/**< circuit breaker to suppress output */
 
@@ -271,7 +272,8 @@ private:
 		(ParamFloat<px4::params::MPC_THR_HOVER>) _throttle_hover,			/**< throttle at which vehicle is at hover equilibrium */
 		(ParamInt<px4::params::MPC_THR_CURVE>) _throttle_curve,				/**< throttle curve behavior */
 
-		(ParamInt<px4::params::MC_AIRMODE>) _airmode
+		(ParamInt<px4::params::MC_AIRMODE>) _airmode,
+		(ParamInt<px4::params::VT_TYPE>) _vtol_type
 	)
 
 	matrix::Vector3f _attitude_p;		/**< P gain for attitude control */
@@ -287,4 +289,3 @@ private:
 	float _man_tilt_max;			/**< maximum tilt allowed for manual flight [rad] */
 
 };
-

--- a/src/modules/navigator/navigator_main.cpp
+++ b/src/modules/navigator/navigator_main.cpp
@@ -1181,7 +1181,7 @@ bool
 Navigator::force_vtol()
 {
 	return _vstatus.is_vtol &&
-	       (!_vstatus.is_rotary_wing || _vstatus.in_transition_to_fw)
+	       (!_vstatus.is_rotary_wing || _vstatus.in_transition_to_fw_phase_1 || _vstatus.in_transition_to_fw_phase_2)
 	       && _param_force_vtol.get();
 }
 

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -62,7 +62,6 @@ public:
 	void update_fw_state() override;
 	void update_mc_state() override;
 	void fill_actuator_outputs() override;
-	void waiting_on_tecs() override;
 
 private:
 
@@ -88,7 +87,8 @@ private:
 
 	enum vtol_mode {
 		MC_MODE = 0,
-		TRANSITION_TO_FW,
+		TRANSITION_TO_FW_PHASE_1,
+		TRANSITION_TO_FW_PHASE_2,
 		TRANSITION_TO_MC,
 		FW_MODE
 	};
@@ -96,11 +96,13 @@ private:
 	struct {
 		vtol_mode flight_mode;			// indicates in which mode the vehicle is in
 		hrt_abstime transition_start;	// at what time did we start a transition (front- or backtransition)
+		hrt_abstime transition_to_fw_phase_2_start;	// at what time did we start phase 2 of a forward transition
 	} _vtol_schedule;
 
 	float _pusher_throttle{0.0f};
 	float _reverse_output{0.0f};
 	float _airspeed_trans_blend_margin{0.0f};
+	float _transition_to_fw_phase_2_start{0.0f}; // time at which phase 2 of FW transition was started
 
 	void parameters_update() override;
 };

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -163,7 +163,7 @@ void Tailsitter::update_vtol_state()
 		break;
 
 	case TRANSITION_FRONT_P1:
-		_vtol_mode = TRANSITION_TO_FW;
+		_vtol_mode = TRANSITION_TO_FW_PHASE_2;
 		_vtol_vehicle_status->vtol_in_trans_mode = true;
 		break;
 

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -189,7 +189,7 @@ void Tiltrotor::update_vtol_state()
 
 	case TRANSITION_FRONT_P1:
 	case TRANSITION_FRONT_P2:
-		_vtol_mode = TRANSITION_TO_FW;
+		_vtol_mode = TRANSITION_TO_FW_PHASE_2;
 		break;
 
 	case TRANSITION_BACK:

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -572,7 +572,8 @@ void VtolAttitudeControl::task_main()
 
 		// run vtol_att on MC actuator publications, unless in full FW mode
 		switch (_vtol_type->get_mode()) {
-		case TRANSITION_TO_FW:
+		case TRANSITION_TO_FW_PHASE_1:
+		case TRANSITION_TO_FW_PHASE_2:
 		case TRANSITION_TO_MC:
 		case ROTARY_WING:
 			fds[0].fd = _actuator_inputs_mc;
@@ -639,7 +640,8 @@ void VtolAttitudeControl::task_main()
 			// vehicle is in rotary wing mode
 			_vtol_vehicle_status.vtol_in_rw_mode = true;
 			_vtol_vehicle_status.vtol_in_trans_mode = false;
-			_vtol_vehicle_status.in_transition_to_fw = false;
+			_vtol_vehicle_status.in_transition_to_fw_phase_1 = false;
+			_vtol_vehicle_status.in_transition_to_fw_phase_2 = false;
 
 			// got data from mc attitude controller
 			_vtol_type->update_mc_state();
@@ -651,11 +653,14 @@ void VtolAttitudeControl::task_main()
 			// vehicle is in fw mode
 			_vtol_vehicle_status.vtol_in_rw_mode = false;
 			_vtol_vehicle_status.vtol_in_trans_mode = false;
-			_vtol_vehicle_status.in_transition_to_fw = false;
+			_vtol_vehicle_status.in_transition_to_fw_phase_1 = false;
+			_vtol_vehicle_status.in_transition_to_fw_phase_2 = false;
 
 			_vtol_type->update_fw_state();
 
-		} else if (_vtol_type->get_mode() == TRANSITION_TO_MC || _vtol_type->get_mode() == TRANSITION_TO_FW) {
+		} else if (_vtol_type->get_mode() == TRANSITION_TO_MC ||
+		_vtol_type->get_mode() == TRANSITION_TO_FW_PHASE_1 ||
+		_vtol_type->get_mode() == TRANSITION_TO_FW_PHASE_2) {
 
 			mc_virtual_att_sp_poll();
 			fw_virtual_att_sp_poll();
@@ -663,7 +668,8 @@ void VtolAttitudeControl::task_main()
 			// vehicle is doing a transition
 			_vtol_vehicle_status.vtol_in_trans_mode = true;
 			_vtol_vehicle_status.vtol_in_rw_mode = true; //making mc attitude controller work during transition
-			_vtol_vehicle_status.in_transition_to_fw = (_vtol_type->get_mode() == TRANSITION_TO_FW);
+			_vtol_vehicle_status.in_transition_to_fw_phase_1 = (_vtol_type->get_mode() == TRANSITION_TO_FW_PHASE_1);
+			_vtol_vehicle_status.in_transition_to_fw_phase_2 = (_vtol_type->get_mode() == TRANSITION_TO_FW_PHASE_2);
 
 			_vtol_type->update_transition_state();
 		}

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -75,10 +75,11 @@ struct Params {
 
 // Has to match 1:1 msg/vtol_vehicle_status.msg
 enum mode {
-	TRANSITION_TO_FW = 1,
+	TRANSITION_TO_FW_PHASE_1 = 1,
 	TRANSITION_TO_MC = 2,
 	ROTARY_WING = 3,
-	FIXED_WING = 4
+	FIXED_WING = 4,
+	TRANSITION_TO_FW_PHASE_2 = 5
 };
 
 enum vtol_type {


### PR DESCRIPTION
Improved VTOL transition to fixed-wing behavior. Based on #11012 and #535. 

-split transition to fixed-wign into 2 phases:
 -1st phase: pusher is ramped up
 -2nd phase: controls of MC-motors are blended out, and if in alt/pos control mode TECS is activated and outputs pitch sp to control the vehicles altitude. Throttle outputs from TECS are ignored and instead is held at the value defined by user (VT_F_TRANS_THR). 

The switching from phase1 --> phase2 --> fixed-wing is done with airspeed thresholds (if airspeed enabled) or user defined duration times (without airspeed measurement). Current params:
-phase1 --> phase2: VT_ARSP_BLEND or VT_TRANS_MIN_TM
-phase2 --> fixed-wing: VT_ARSP_TRANS or VT_F_TR_OL_TM

Not yet flight tested.