### PR TITLE
fw_pos_control_l1: reset runway state if not armed

### DIFF
--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1269,6 +1269,8 @@ FixedwingPositionControl::control_takeoff(const Vector2f &curr_pos, const Vector
 
 	// continuously reset launch detection and runway takeoff until armed
 	if (!_control_mode.flag_armed) {
+		_runway_takeoff.reset();
+
 		_launchDetector.reset();
 		_launch_detection_state = LAUNCHDETECTION_RES_NONE;
 		_launch_detection_notify = 0;


### PR DESCRIPTION
This is an attempt to fix a problem where a reboot is required after
each mission because throttle won't go above 0 anymore.

Maybe fixes #11588.