### PR TITLE
adis16497: fix TEMP_OUT scaling

### DIFF
--- a/src/drivers/imu/adis16497/ADIS16497.cpp
+++ b/src/drivers/imu/adis16497/ADIS16497.cpp
@@ -613,7 +613,7 @@ ADIS16497::publish_accel(const hrt_abstime &t, const ADISReport &report)
 		arb.y_integral = aval_integrated(1);
 		arb.z_integral = aval_integrated(2);
 
-		arb.temperature = report.TEMP_OUT * 0.1f - 25.0f; // 1 LSB = 0.1°C, 0x0000 at 25°C
+		arb.temperature = report.TEMP_OUT * 0.0125f - 25.0f; // 1 LSB = 0.0125°C, 0x0000 at 25°C
 
 		orb_publish(ORB_ID(sensor_accel), _accel_topic, &arb);
 	}
@@ -662,7 +662,7 @@ ADIS16497::publish_gyro(const hrt_abstime &t, const ADISReport &report)
 		grb.y_integral = gval_integrated(1);
 		grb.z_integral = gval_integrated(2);
 
-		grb.temperature = report.TEMP_OUT * 0.1f - 25.0f; // 1 LSB = 0.1°C, 0x0000 at 25°C
+		grb.temperature = report.TEMP_OUT * 0.0125f - 25.0f; // 1 LSB = 0.0125°C, 0x0000 at 25°C
 
 		orb_publish(ORB_ID(sensor_gyro), _gyro->_gyro_topic, &grb);
 	}


### PR DESCRIPTION
**Test data / coverage**
Not available.

**Describe problem solved by the proposed pull request**
Page 19 of the [data sheet of the adis16497](https://www.analog.com/media/en/technical-documentation/data-sheets/ADIS16497.pdf) defines the scale of the internal temperature register as `1°C per 80 LSB`. The current implementation has this scale set as `1°C per 1 LSB`, which is incorrect.

**Describe your preferred solution**
Change the scale of the TEMP_OUT register to `1°C per 80 LSB` to comply with the data sheet.

**Describe possible alternatives**
Not available.
