### PR TITLE
Stop RC Loss alarm on reconnect

### DIFF
--- a/src/lib/tunes/tunes.cpp
+++ b/src/lib/tunes/tunes.cpp
@@ -94,6 +94,12 @@ int Tunes::set_control(const tune_control_s &tune_control)
 	    tune_control.tune_override ||  // Override interrupts everything
 	    _default_tunes_interruptable[_current_tune_id]) {
 
+		// Check if this exact tune is already being played back
+		if (tune_control.tune_id != static_cast<int>(TuneID::CUSTOM) &&
+		    _tune == _default_tunes[tune_control.tune_id]) {
+			return OK; // Nothing to do
+		}
+
 		// Reset repeat flag. Can jump to true again while tune is being parsed later
 		_repeat = false;
 

--- a/src/modules/events/rc_loss_alarm.h
+++ b/src/modules/events/rc_loss_alarm.h
@@ -68,9 +68,13 @@ private:
 	/** Publish tune control to sound alarm */
 	void play_tune();
 
+	/** Publish tune control to interrupt any sound */
+	void stop_tune();
+
 	struct vehicle_status_s	_vehicle_status = {};
 	bool 		_was_armed = false;
 	bool 		_had_rc = false;  // Don't trigger alarm for systems without RC
+	bool		_alarm_playing = false;
 	orb_advert_t 	_tune_control_pub = nullptr;
 	const events::SubscriberHandler &_subscriber_handler;
 };


### PR DESCRIPTION
**Context**
PX4 has an RC loss alarm that goes off when
* `EV_TSK_RC_LOSS` is `1`
* The drone was armed at least once since power off
* The drone had RC link at least once since power off
* The drone does not have RC link anymore

**Describe problem solved by the proposed pull request**
RC Loss alarm never stops. Reconnecting the RC does not stop the alarm, because it's a repeated tune. Only another tune will stop it. which the RC Loss alarm event currently does not send.

**Describe your preferred solution**
This PR does two things:
* Stop the RC Loss alarm when RC reconnects
* Extend the tunes library to not interrupt an existing tune with the same tune. I noticed that the RC Loss alarm would always play the first half of the S.O.S tune, before it would be interrupted by itself. 

**Test data / coverage**
Bench-tested the RC Loss alarm feature as well as interrupting.