### PR TITLE
rcS: add airframe parameter versioning and extend SYS_AUTOCONFIG

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -57,6 +57,12 @@ set SDCARD_MIXERS_PATH /fs/microsd/etc/mixers
 set USE_IO no
 set VEHICLE_TYPE none
 
+# Airframe parameter versioning: airframe maintainers can set this in the
+# airframe startup script, and then increase it by one whenever an airframe
+# parameter is updated - it will ensure that these parameters will be updated
+# when the firmware is flashed.
+set PARAM_DEFAULTS_VER 1
+
 #
 # Mount the procfs.
 #
@@ -161,7 +167,12 @@ else
 		param reset_nostart RC* COM_FLTMODE* LND_FLIGHT_T_* TC_* CAL_ACC* CAL_GYRO*
 		set AUTOCNF yes
 	else
-		set AUTOCNF no
+		if param compare SYS_AUTOCONFIG 2
+		then
+			set AUTOCNF yes
+		else
+			set AUTOCNF no
+		fi
 	fi
 
 	#
@@ -480,6 +491,16 @@ else
 	#
 	sh /etc/init.d/rc.logging
 
+
+	if ! param compare SYS_PARAM_VER ${PARAM_DEFAULTS_VER}
+	then
+		echo "Switched to different parameter version. Resetting parameters."
+		param set SYS_PARAM_VER ${PARAM_DEFAULTS_VER}
+		param set SYS_AUTOCONFIG 2
+		param save
+		reboot
+	fi
+
 #
 # End of autostart.
 #
@@ -510,6 +531,7 @@ unset MIXER_FILE
 unset MK_MODE
 unset MKBLCTRL_ARG
 unset OUTPUT_MODE
+unset PARAM_DEFAULTS_VER
 unset PARAM_FILE
 unset PWM_AUX_DISARMED
 unset PWM_AUX_MAX

--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -56,10 +56,9 @@ PARAM_DEFINE_INT32(SYS_AUTOSTART, 0);
  * Platform-specific values are used if available.
  * RC* parameters are preserved.
  *
- * @min 0
- * @max 1
  * @value 0 Keep parameters
  * @value 1 Reset parameters
+ * @value 2 Reload airframe parameters
  * @group System
  */
 PARAM_DEFINE_INT32(SYS_AUTOCONFIG, 0);
@@ -144,9 +143,10 @@ PARAM_DEFINE_INT32(SYS_COMPANION, 0);
 /**
  * Parameter version
  *
- * This monotonically increasing number encodes the parameter compatibility set.
- * whenever it increases parameters might not be backwards compatible and
- * ground control stations should suggest a fresh configuration.
+ * This is used internally only: an airframe configuration might set an expected
+ * parameter version value via PARAM_DEFAULTS_VER. This is checked on bootup
+ * against SYS_PARAM_VER, and if they do not match, parameters from the airframe
+ * configuration are reloaded.
  *
  * @min 0
  * @group System


### PR DESCRIPTION
It is currently not easy for downstream adopters to update airframe parameters, while still allowing for some other customizations.
This PR provides a minimal solution for that, by adding an (optional) airframe parameter versioning variable, that is compared against `SYS_PARAM_VER`. Airframe defaults are reloaded if they don't match.
While this has limitations, it has proven to be useful and effective in practice.
Ideally on an update we could show a param diff to the user, and let him/her decide which values to use.

To use it for an airframe, add `set PARAM_DEFAULTS_VER 2` to the airframe config, and whenever one of the parameters change, also increase that number.

This reuses `SYS_PARAM_VER`, which is currently unused (in QGC as well).