### PR TITLE
Whitespace fixes - Delete trailing whitespace, newlines to quiet git hooks

### DIFF
--- a/.vscode/cmake-variants.yaml
+++ b/.vscode/cmake-variants.yaml
@@ -15,7 +15,7 @@ CONFIG:
       short: px4_sitl (Address Sanitizer)
       buildType: AddressSanitizer
       settings:
-        CONFIG: px4_sitl_default        
+        CONFIG: px4_sitl_default
     px4_fmu-v2_default:
       short: px4_fmu-v2
       buildType: MinSizeRel

--- a/ROMFS/px4fmu_common/init.d/rc.logging
+++ b/ROMFS/px4fmu_common/init.d/rc.logging
@@ -28,4 +28,3 @@ if ! param compare SDLOG_MODE -1
 then
 	logger start -b ${LOGGER_BUF} -t ${LOGGER_ARGS}
 fi
-

--- a/boards/bitcraze/crazyflie/nuttx-config/scripts/script.ld
+++ b/boards/bitcraze/crazyflie/nuttx-config/scripts/script.ld
@@ -59,7 +59,7 @@ OUTPUT_ARCH(arm)
 ENTRY(__start)		/* treat __start as the anchor for dead code stripping */
 EXTERN(_vectors)	/* force the vectors to be included in the output */
 
-/* 
+/*
  * Ensure that abort() is present in the final object.  The exception handling
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */

--- a/boards/px4/io-v2/nuttx-config/scripts/script.ld
+++ b/boards/px4/io-v2/nuttx-config/scripts/script.ld
@@ -50,7 +50,7 @@ OUTPUT_ARCH(arm)
 ENTRY(__start)		/* treat __start as the anchor for dead code stripping */
 EXTERN(_vectors)	/* force the vectors to be included in the output */
 
-/* 
+/*
  * Ensure that abort() is present in the final object.  The exception handling
  * code pulled in by libgcc.a requires it (and that code cannot be easily avoided).
  */
@@ -61,10 +61,10 @@ SECTIONS
 	.text : {
 		_stext = ABSOLUTE(.);
 		*(.vectors)
-		*(.text .text.*)        
+		*(.text .text.*)
 		*(.fixup)
 		*(.gnu.warning)
-		*(.rodata .rodata.*)        
+		*(.rodata .rodata.*)
 		*(.gnu.linkonce.t.*)
 		*(.glue_7)
 		*(.glue_7t)
@@ -72,7 +72,7 @@ SECTIONS
 		*(.gcc_except_table)
 		*(.gnu.linkonce.r.*)
 		_etext = ABSOLUTE(.);
-		/* 
+		/*
 		 * This is a hack to make the newlib libm __errno() call
 		 * use the NuttX get_errno_ptr() function.
 		 */

--- a/platforms/nuttx/NuttX/tools/menuconfig.py
+++ b/platforms/nuttx/NuttX/tools/menuconfig.py
@@ -43,7 +43,7 @@ A few different modes are available:
 
 
 Running
-=======
+========
 
 menuconfig.py can be run either as a standalone executable or by calling the
 menuconfig() function with an existing Kconfig instance. The second option is a


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR deletes trailing whitespace, a newline, and adds an additional `=` to a line in `platforms/nuttx/NuttX/tools/menuconfig.py` to quiet the githook complaining about it being a merge conflict marker.

Please let me know if you have any questions on this PR.  Thanks!

-Mark
