### PR TITLE
VSCode: move vscode specific .gitignore entries to the folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,9 +64,3 @@ posix-configs/SITL/init/test/*_generated
 *.gcov
 .coverage
 .coverage.*
-
-.vscode/.cortex-debug.peripherals.state.json
-.vscode/.cortex-debug.registers.state.json
-.vscode/compile_commands.json
-.vscode/ipch/
-

--- a/.vscode/.gitignore
+++ b/.vscode/.gitignore
@@ -1,0 +1,6 @@
+.cortex-debug.peripherals.state.json
+.cortex-debug.registers.state.json
+compile_commands.json
+
+# C/C++ extension does some local caching in this folder
+ipch/


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
~The latest Visual Studio Code version with the latest C/C++ extension is caching some information about your code presumably for faster search in the .vscode/ipch folder. This shows up as a change all the time so I added this folder to the `.gitignore`.~ It wokred before I was just on an outdated branch. I only move the ignores to the `.vscode` folder.

**Additional context**
https://github.com/Microsoft/vscode/issues/71061
https://github.com/Microsoft/vscode-cpptools/issues/3347
