### PR TITLE
cmake nuttx use defconfig matching config label if available

### DIFF
--- a/platforms/nuttx/cmake/px4_impl_os.cmake
+++ b/platforms/nuttx/cmake/px4_impl_os.cmake
@@ -115,8 +115,8 @@ function(px4_os_prebuild_targets)
 			REQUIRED OUT
 			ARGN ${ARGN})
 
-	if(PX4_BOARD_LABEL MATCHES "stackcheck")
-		set(NUTTX_CONFIG "stackcheck" CACHE INTERNAL "NuttX config" FORCE)
+	if(EXISTS ${PX4_BOARD_DIR}/nuttx-config/${PX4_BOARD_LABEL})
+		set(NUTTX_CONFIG "${PX4_BOARD_LABEL}" CACHE INTERNAL "NuttX config" FORCE)
 	else()
 		set(NUTTX_CONFIG "nsh" CACHE INTERNAL "NuttX config" FORCE)
 	endif()


### PR DESCRIPTION
 - otherwise use default nsh

Example
 `px4_fmu-v5_deafult: boards/px4/fmu-v5/nuttx-config/nsh/`
 `px4_fmu-v5_stackcheck: boards/px4/fmu-v5/nuttx-config/stackcheck/`