### PR TITLE
fmuv5:Move stage 0 dache disable to later in boot

### DIFF
--- a/boards/av/x-v1/src/init.c
+++ b/boards/av/x-v1/src/init.c
@@ -191,8 +191,6 @@ stm32_boardinitialize(void)
 {
 	board_on_reset(-1); /* Reset PWM first thing */
 
-	board_configure_dcache(0);
-
 	/* configure LEDs */
 	board_autoled_initialize();
 
@@ -232,6 +230,9 @@ stm32_boardinitialize(void)
 
 __EXPORT int board_app_initialize(uintptr_t arg)
 {
+
+	board_configure_dcache(0);
+
 	px4_platform_init();
 
 	/* configure the DMA allocator */

--- a/boards/px4/fmu-v5/src/init.c
+++ b/boards/px4/fmu-v5/src/init.c
@@ -230,8 +230,6 @@ stm32_boardinitialize(void)
 {
 	board_on_reset(-1); /* Reset PWM first thing */
 
-	board_configure_dcache(0);
-
 	/* configure LEDs */
 
 	board_autoled_initialize();
@@ -280,6 +278,8 @@ stm32_boardinitialize(void)
 __EXPORT int board_app_initialize(uintptr_t arg)
 {
 	/* Power on Interfaces */
+
+	board_configure_dcache(0);
 
 	VDD_3V3_SD_CARD_EN(true);
 	VDD_5V_PERIPH_EN(true);


### PR DESCRIPTION
Fixes https://github.com/PX4/Firmware/issues/11786
@dagar - we are going to need to add power cycling to the test rack.

I had the disable too early in the boot sequence: before the dcache was enabled. I believe the reason this did not get caught in test was related to the jtag connected and or the power state. 

This has been tested with no power nor jtag to boot.