### PR TITLE
commander: fix toggling datalink lost and regained

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -3900,7 +3900,11 @@ void Commander::data_link_check(bool &status_changed)
 					}
 				}
 
-				_datalink_last_heartbeat_gcs = telemetry.heartbeat_time;
+				// Only keep the very last heartbeat timestamp, so we don't get confused
+				// by multiple mavlink instances publishing different timestamps.
+				if (telemetry.heartbeat_time > _datalink_last_heartbeat_gcs) {
+					_datalink_last_heartbeat_gcs = telemetry.heartbeat_time;
+				}
 
 				break;
 


### PR DESCRIPTION
When using QGC and/or the Dronecode SDK it was possible to get in a state where the two mavlink instances were both publishing their last heartbeat_time and cause commander to consistently toggle between data link lost and regained.

With this fix, we only ever look at the very last heartbeat time and therefore seem to avoid this issue.

Tested in SITL, fixes #11794.