### PR TITLE
make: tests_avoidance add prerequisite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -374,7 +374,7 @@ tests_offboard: rostest
 	@"$(SRC_DIR)"/test/rostest_px4_run.sh mavros_posix_tests_offboard_attctl.test
 	@"$(SRC_DIR)"/test/rostest_px4_run.sh mavros_posix_tests_offboard_posctl.test
 
-tests_avoidance:
+tests_avoidance: rostest
 	@"$(SRC_DIR)"/test/rostest_avoidance_run.sh mavros_posix_test_avoidance.test
 
 python_coverage:


### PR DESCRIPTION
Tiny fix. Needed to launch from a clean repo.