### PR TITLE
Appveyor: Enable build matrix for parallel CI targets

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ build_script:
 # safe the repopath for switching to it in cygwin bash
 - for /f %%i in ('cygpath -u %%CD%%') do set repopath=%%i
 # fetch all submodules in parallel with limited depth
-- call bash --login -c "cd $repopath && git submodule -q update --init --recursive --jobs=10 --depth 200"
+#- call bash --login -c "cd $repopath && git submodule -q update --init --recursive --jobs=10 --depth 200"
 # build the make target
 - call bash --login -c "cd $repopath && make $PX4_CONFIG"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,11 @@ platform:
 init:
 - ver
 
+environment:
+  matrix:
+    - PX4_CONFIG: tests # this builds posix in px4_sitl_test folder and runs tests
+    - PX4_CONFIG: px4_fmu-v5_default
+
 install:
 # if the toolchain wasn't restored from build cache download and install it
 - ps: >-
@@ -40,12 +45,8 @@ build_script:
 - for /f %%i in ('cygpath -u %%CD%%') do set repopath=%%i
 # fetch all submodules in parallel
 - call bash --login -c "cd $repopath && git submodule -q update --init --recursive --jobs=10"
-# make SITL
-- call bash --login -c "cd $repopath && make px4_sitl_test"
-# make pixracer to check NuttX build
-- call bash --login -c "cd $repopath && make px4_fmu-v4_default"
-# run tests
-- call bash --login -c "cd $repopath && make tests"
+# build the make target
+- call bash --login -c "cd $repopath && make $PX4_CONFIG"
 
 # Note: using bash --login is important
 # because otherwise certain things (like python; import numpy) do not work

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,8 +43,8 @@ build_script:
 - call C:\PX4\toolchain\scripts\setup-environment.bat x
 # safe the repopath for switching to it in cygwin bash
 - for /f %%i in ('cygpath -u %%CD%%') do set repopath=%%i
-# fetch all submodules in parallel
-- call bash --login -c "cd $repopath && git submodule -q update --init --recursive --jobs=10"
+# fetch all submodules in parallel with limited depth
+- call bash --login -c "cd $repopath && git submodule -q update --init --recursive --jobs=10 --depth 200"
 # build the make target
 - call bash --login -c "cd $repopath && make $PX4_CONFIG"
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Currently the Appveyor CI builds `px4_sitl_test`, `px4_fmu-v4_default` and `tests` sequentially and a build matrix resulting in multiple parallel build jobs would accelerate CI execution times.

**Additional context**
Follow up to #10865
