### PR TITLE
cmake use ${PYTHON_EXECUTABLE} for mixer test

### DIFF
--- a/src/lib/mixer/CMakeLists.txt
+++ b/src/lib/mixer/CMakeLists.txt
@@ -107,7 +107,7 @@ if(BUILD_TESTING)
 	target_compile_options(test_mixer_multirotor PRIVATE -Wno-unused-result)
 
 	add_test(NAME mixer_multirotor
-		COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/mixer_multirotor.py --test --mixer-multirotor-binary $<TARGET_FILE:test_mixer_multirotor>
+		COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/mixer_multirotor.py --test --mixer-multirotor-binary $<TARGET_FILE:test_mixer_multirotor>
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 	)
 


### PR DESCRIPTION
 - needed for code coverage of python scripts
