### PR TITLE
Avoidance CI: bump release

### DIFF
--- a/test/rostest_avoidance_run.sh
+++ b/test/rostest_avoidance_run.sh
@@ -6,7 +6,7 @@ PX4_SRC_DIR=${DIR}/..
 source /opt/ros/${ROS_DISTRO:-kinetic}/setup.bash
 mkdir -p ${PX4_SRC_DIR}/catkin_ws/src
 cd ${PX4_SRC_DIR}/catkin_ws/
-git clone -b '0.1.0' --single-branch --depth 1 https://github.com/PX4/avoidance.git src/avoidance
+git clone -b '0.2.0' --single-branch --depth 1 https://github.com/PX4/avoidance.git src/avoidance
 
 catkin init
 catkin build local_planner --cmake-args -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Use release 0.2.0 in the avoidance CI
 FYI @jkflying 