### PR TITLE
Fix mission speed

### DIFF
--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -128,10 +128,13 @@ bool FlightTaskAuto::_evaluateTriplets()
 	// Always update cruise speed since that can change without waypoint changes.
 	_mc_cruise_speed = _sub_triplet_setpoint->get().current.cruising_speed;
 
-	if (!PX4_ISFINITE(_mc_cruise_speed) || (_mc_cruise_speed < 0.0f) || (_mc_cruise_speed > _constraints.speed_xy)) {
-		// Use default limit.
+	if (!PX4_ISFINITE(_mc_cruise_speed) || (_mc_cruise_speed < 0.0f)) {
+		// If no speed is planned use the default cruise speed as limit
 		_mc_cruise_speed = _constraints.speed_xy;
 	}
+
+	// Ensure planned cruise speed is below the maximum such that the smooth trajectory doesn't get capped
+	_mc_cruise_speed = math::min(_mc_cruise_speed, _param_mpc_xy_vel_max.get());
 
 	// Temporary target variable where we save the local reprojection of the latest navigator current triplet.
 	Vector3f tmp_target;

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -167,7 +167,7 @@ void FlightTaskAutoLineSmoothVel::_prepareSetpoints()
 		Vector2f u_pos_traj_to_dest_xy(Vector2f(pos_traj_to_dest).unit_or_zero());
 
 		float speed_sp_track = Vector2f(pos_traj_to_dest).length() * _param_mpc_xy_traj_p.get();
-		speed_sp_track = math::constrain(speed_sp_track, 0.0f, _param_mpc_xy_cruise.get());
+		speed_sp_track = math::constrain(speed_sp_track, 0.0f, _mc_cruise_speed);
 
 		Vector2f vel_sp_xy = u_pos_traj_to_dest_xy * speed_sp_track;
 


### PR DESCRIPTION
**Test data / coverage**
I tested using the DronecodeSDK with command `make && build/default/integration_tests/integration_tests_runner --gtest_filter="SitlTest.MissionChangeSpeed"` and the following configuration combinations:
- `MPC_AUTO_MODE` 0 and 1 for default line tracking and jerk-limited trajectory
- `MPC_XY_VEL_MAX` to 12m/s default (which is above the tested 8m/s) and on 6m/s

The speed gets correctly applied and correctly limited.

**Describe problem solved by the proposed pull request**
fixes #11764 

**Additional context**
#11772, #11811
