### PR TITLE
move icm20948 (Here GPS compass) to Cube sensors start

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -105,9 +105,6 @@ then
 	teraranger start -a
 fi
 
-# ICM20948 as external magnetometer on I2C (e.g. Here GPS)
-icm20948 -X -M -R 6 start
-
 ###############################################################################
 #                            End Optional drivers                             #
 ###############################################################################

--- a/boards/px4/fmu-v3/init/rc.board_sensors
+++ b/boards/px4/fmu-v3/init/rc.board_sensors
@@ -59,6 +59,9 @@ then
 	# sensor heating is available, but we disable it for now
 	param set SENS_EN_THERMAL 0
 
+	# ICM20948 as external magnetometer on I2C (e.g. Here GPS)
+	icm20948 -X -M -R 6 start
+
 	# external L3GD20H is rotated 180 degrees yaw
 	l3gd20 -X -R 4 start
 

--- a/boards/px4/fmu-v5/default.cmake
+++ b/boards/px4/fmu-v5/default.cmake
@@ -30,7 +30,6 @@ px4_add_board(
 		imu/adis16497
 		#imu # all available imu drivers
 		imu/bmi055
-		imu/icm20948
 		imu/mpu6000
 		imu/mpu9250
 		irlock

--- a/boards/px4/fmu-v5/rtps.cmake
+++ b/boards/px4/fmu-v5/rtps.cmake
@@ -29,7 +29,6 @@ px4_add_board(
 		imu/adis16448
 		#imu # all available imu drivers
 		imu/bmi055
-		imu/icm20948
 		imu/mpu6000
 		imu/mpu9250
 		irlock

--- a/boards/px4/fmu-v5/stackcheck.cmake
+++ b/boards/px4/fmu-v5/stackcheck.cmake
@@ -29,7 +29,6 @@ px4_add_board(
 		imu/adis16448
 		#imu # all available imu drivers
 		imu/bmi055
-		imu/icm20948
 		imu/mpu6000
 		imu/mpu9250
 		#irlock


### PR DESCRIPTION
Given the special cable I don't think this is actually being used anywhere but the Cube.

https://github.com/PX4/Firmware/pull/11837#issuecomment-482116269