### PR TITLE
[WIP] MC auto mode - Use L1-like logic for lateral line tracking

### DIFF
--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -61,7 +61,8 @@ protected:
 					(ParamFloat<px4::params::MPC_ACC_DOWN_MAX>) _param_mpc_acc_down_max,
 					(ParamFloat<px4::params::MPC_ACC_HOR_MAX>) _param_mpc_acc_hor_max,
 					(ParamFloat<px4::params::MPC_JERK_MIN>) _param_mpc_jerk_min,
-					(ParamFloat<px4::params::MPC_XY_TRAJ_P>) _param_mpc_xy_traj_p,
+					(ParamFloat<px4::params::MPC_L1_SPEED_P>) _param_mpc_l1_speed_p,
+					(ParamFloat<px4::params::MPC_L1_DISTANCE>) _param_mpc_l1_distance,
 					(ParamFloat<px4::params::MPC_Z_TRAJ_P>) _param_mpc_z_traj_p
 				       );
 

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -250,14 +250,32 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_D, 0.01f);
 PARAM_DEFINE_FLOAT(MPC_XY_CRUISE, 5.0f);
 
 /**
- * Proportional gain for horizontal trajectory position error
+ * Proportional gain that generates the desired current velocity
+ * given the distance to the tracking point on the line. The tracking
+ * point is at most L1 meters in front of the drone and decreases while
+ * approaching the waypoint. In order to reach cruise speed between two
+ * waypoints, this value has to be at least MPC_XY_CRUISE / MPC_L1_DISTANCE.
  *
  * @min 0.1
  * @max 5.0
  * @decimal 1
  * @group Multicopter Position Control
  */
-PARAM_DEFINE_FLOAT(MPC_XY_TRAJ_P, 0.3f);
+PARAM_DEFINE_FLOAT(MPC_L1_SPEED_P, 0.4f);
+
+/**
+ * L1 distance used for cross-track control of the limited-jerk
+ * trajectory generator.
+ * Shorten to have a sharper response until the setpoint starts
+ * to oscillate. This parameter highly depends on cruise speed,
+ * maximum acceleration and maximum jerk settings.
+ *
+ * @min 1.0
+ * @max 30.0
+ * @decimal 1
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_L1_DISTANCE, 15.f);
 
 /**
  * Proportional gain for vertical trajectory position error


### PR DESCRIPTION
 #### Context
Auto mode uses a model-following tracking approach where the model is composed of 3 integrators with limited outputs (limited jerk, acceleration and velocity). This virtual vehicle is driven from one waypoint to the other using a control loop that generates desired velocities in the local frame. This controller is basically a "virtual pilot" that moves the sticks of the remote.

#### Current state
So far, a simple 2D proportional controller in the local frame was used to drive the vehicle and gives acceptable results for a first iteration.

#### L1 approach
A second approach I am trying now is to use the same approach as the fixedwing L1 controller to drive the virtual model.
Basically, a L1 distance of length `MPC_L1_DISTANCE` is used to compute the position of a virtual point to track on a line defined by two waypoints. The generated vector (limited-jerk model to virtual point) is used to generate the forward speed using `MPC_L1_SPEED_P` and its direction drives the model to the line asymptotically.
A nice side effect of this controller is that increasing the acceptance radius of the mission items produces a smooth "auto-continue behavior", similar to a fixed-wing flight.

**Test data / coverage**
I tested that controller extensively in SITL:
![Screenshot from 2019-04-12 10-14-50](https://user-images.githubusercontent.com/14822839/56051581-6d5b2480-5d4f-11e9-9c5f-fd5e143db97d.png)
A log: https://logs.px4.io/plot_app?log=fa390045-c598-4800-b393-ac22c2cc0812

An other log of the F450:
https://logs.px4.io/plot_app?log=23542ad5-d204-40a3-8787-6b9c31c5756e

### Todo
Check if the we can simplify the equations.