### PR TITLE
Fix cruise speed in auto mode

### DIFF
--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -63,13 +63,6 @@ void FlightTaskAutoLineSmoothVel::reActivate()
 	// flight task is always reset.
 }
 
-void FlightTaskAutoLineSmoothVel::_setDefaultConstraints()
-{
-	FlightTaskAuto::_setDefaultConstraints();
-
-	_constraints.speed_xy = _param_mpc_xy_vel_max.get(); // TODO : Should be computed using heading
-}
-
 void FlightTaskAutoLineSmoothVel::_generateSetpoints()
 {
 	_prepareSetpoints();
@@ -206,8 +199,8 @@ void FlightTaskAutoLineSmoothVel::_updateTrajConstraints()
 	// Update the constraints of the trajectories
 	_trajectory[0].setMaxAccel(_param_mpc_acc_hor_max.get()); // TODO : Should be computed using heading
 	_trajectory[1].setMaxAccel(_param_mpc_acc_hor_max.get());
-	_trajectory[0].setMaxVel(_constraints.speed_xy);
-	_trajectory[1].setMaxVel(_constraints.speed_xy);
+	_trajectory[0].setMaxVel(_param_mpc_xy_vel_max.get());
+	_trajectory[1].setMaxVel(_param_mpc_xy_vel_max.get());
 	_trajectory[0].setMaxJerk(_param_mpc_jerk_min.get()); // TODO : Should be computed using heading
 	_trajectory[1].setMaxJerk(_param_mpc_jerk_min.get());
 	_trajectory[2].setMaxJerk(_param_mpc_jerk_min.get());

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -66,7 +66,6 @@ protected:
 				       );
 
 	void _generateSetpoints() override; /**< Generate setpoints along line. */
-	void _setDefaultConstraints() override;
 
 	inline float _constrainOneSide(float val, float constrain);
 	void _checkEkfResetCounters(); /**< Reset the trajectories when the ekf resets velocity or position */


### PR DESCRIPTION
Context: #11836  fixes the DO_CHANGE_SPEED mavlink command but breaks the default behavior.
Without that PR, the drone files at max speed if no DO_CHANGE_SPEED command is sent.

Tested with `make && build/default/integration_tests/integration_tests_runner --gtest_filter="SitlTest.MissionChangeSpeed"`

And with a normal STIL mission