### PR TITLE
VTOL attitude control during transitions

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -562,7 +562,7 @@ void
 MulticopterAttitudeControl::control_attitude_rates(float dt)
 {
 	/* reset integral if disarmed */
-	if (!_v_control_mode.flag_armed || !_vehicle_status.is_rotary_wing) {
+	if (!_v_control_mode.flag_armed || !_vehicle_status.is_rotary_wing ||  _vehicle_status.in_transition_mode) {
 		_rates_int.zero();
 	}
 
@@ -816,7 +816,7 @@ MulticopterAttitudeControl::run()
 
 			bool attitude_setpoint_generated = false;
 
-			if (_v_control_mode.flag_control_attitude_enabled && _vehicle_status.is_rotary_wing) {
+			if (_v_control_mode.flag_control_attitude_enabled && _vehicle_status.is_rotary_wing && !_vehicle_status.in_transition_mode) {
 				if (attitude_updated) {
 					// Generate the attitude setpoint from stick inputs if we are in Manual/Stabilized mode
 					if (_v_control_mode.flag_control_manual_enabled &&
@@ -833,7 +833,7 @@ MulticopterAttitudeControl::run()
 
 			} else {
 				/* attitude controller disabled, poll rates setpoint topic */
-				if (_v_control_mode.flag_control_manual_enabled && _vehicle_status.is_rotary_wing) {
+				if (_v_control_mode.flag_control_manual_enabled && _vehicle_status.is_rotary_wing && !_vehicle_status.in_transition_mode) {
 					if (manual_control_updated) {
 						/* manual rates control - ACRO mode */
 						Vector3f man_rate_sp(


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7610489/56161931-16fa1a00-5fcb-11e9-9a00-3ec65e4805df.png)

In the upper figure you can see how a standard vtol just entered the backtransition and begins to oscillate in roll. Notice that the quad motors are still not active when the oscillations begin. Given that no oscillations were present during fixed wing flight and the airspeed scaling in the fixed wing rate controller was still active the cause of the oscillations is probably the fact that the rate setpoints were generated by the mc attitude controller which has a time constant that is about 3 times larger than the one of the fixed wing attitude controller.
This PR changes the logic such that during transitions the fixed wing attitude controller generates the rate setpoint.