### PR TITLE
Migrate HC_SR04 class member variable initialization to declarations, augment code so that it compiles.

### DIFF
--- a/src/drivers/distance_sensor/hc_sr04/hc_sr04.cpp
+++ b/src/drivers/distance_sensor/hc_sr04/hc_sr04.cpp
@@ -37,46 +37,59 @@
  * Driver for the hc_sr04 sonar range finders .
  */
 
-#include <px4_config.h>
-#include <px4_workqueue.h>
-#include <drivers/device/device.h>
-#include <px4_defines.h>
-#include <containers/Array.hpp>
-
-#include <sys/types.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <stdbool.h>
-#include <semaphore.h>
-#include <string.h>
-#include <fcntl.h>
-#include <poll.h>
 #include <errno.h>
-#include <stdio.h>
+#include <fcntl.h>
 #include <math.h>
+#include <poll.h>
+#include <semaphore.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <termios.h>
 #include <unistd.h>
 
-#include <perf/perf_counter.h>
-#include <systemlib/err.h>
-
+#include <containers/Array.hpp>
+#include <drivers/device/device.h>
+#include <drivers/device/ringbuffer.h>
 #include <drivers/drv_hrt.h>
 #include <drivers/drv_range_finder.h>
-#include <drivers/device/ringbuffer.h>
-
+#include <perf/perf_counter.h>
+#include <px4_config.h>
+#include <px4_defines.h>
+#include <px4_getopt.h>
+#include <px4_workqueue.h>
+#include <systemlib/err.h>
 #include <uORB/uORB.h>
 #include <uORB/topics/distance_sensor.h>
 
-#define SR04_MAX_RANGEFINDERS 6
-#define SR04_ID_BASE	 0x10
 
-/* Configuration Constants */
-#define SR04_DEVICE_PATH	"/dev/hc_sr04"
+#define SR04_ID_BASE			0x10
+#define SR04_DEVICE_PATH		"/dev/hc_sr04"
+#define SR04_MAX_RANGEFINDERS		6
 
 /* Device limits */
-#define SR04_MIN_DISTANCE 	(0.10f)
-#define SR04_MAX_DISTANCE 	(4.00f)
+#define SR04_MIN_DISTANCE		(0.10f)
+#define SR04_MAX_DISTANCE		(4.00f)
 
-#define SR04_CONVERSION_INTERVAL 	100000 /* 100ms for one sonar */
+#define SR04_CONVERSION_INTERVAL	100000 /* 100ms for one sonar */
+
+#define GPIO_GPIO8_INPUT		0	// Not currrently defined for any board.
+#define GPIO_GPIO9_INPUT		0	// Not currrently defined for any board.
+#define GPIO_GPIO10_INPUT		0	// Not currrently defined for any board.
+#define GPIO_GPIO11_INPUT		0	// Not currrently defined for any board.
+#define GPIO_GPIO12_INPUT		0	// Not currrently defined for any board.
+
+const HC_SR04::GPIOConfig HC_SR04::_gpio_tab[] = {
+	{GPIO_GPIO6_OUTPUT, GPIO_GPIO7_INPUT,  0},
+	{GPIO_GPIO6_OUTPUT, GPIO_GPIO8_INPUT,  0},
+	{GPIO_GPIO6_OUTPUT, GPIO_GPIO9_INPUT,  0},
+	{GPIO_GPIO6_OUTPUT, GPIO_GPIO10_INPUT, 0},
+	{GPIO_GPIO6_OUTPUT, GPIO_GPIO11_INPUT, 0},
+	{GPIO_GPIO6_OUTPUT, GPIO_GPIO12_INPUT, 0}
+};
 
 
 class HC_SR04 : public cdev::CDev
@@ -85,138 +98,105 @@ public:
 	HC_SR04();
 	virtual ~HC_SR04();
 
-	virtual int 		init();
+	virtual int init();
 
-	virtual ssize_t		read(device::file_t *filp, char *buffer, size_t buflen);
-	virtual int			ioctl(device::file_t *filp, int cmd, unsigned long arg);
+	void interrupt(unsigned time);
+
+	virtual int ioctl(device::file_t *filp, int cmd, unsigned long arg) override;
 
 	/**
-	* Diagnostics - print some basic information about the driver.
-	*/
-	void				print_info();
-	void                            interrupt(unsigned time);
+	 * Diagnostics - print some basic information about the driver.
+	 */
+	void print_info();
+
+	virtual ssize_t read(device::file_t *filp, char *buffer, size_t buflen);
 
 protected:
-	virtual int			probe();
+	virtual int probe() override;
 
 private:
-	float				_min_distance;
-	float				_max_distance;
-	ringbuffer::RingBuffer	*_reports;
-	bool				_sensor_ok;
-	int					_measure_interval;
-	bool				_collect_phase;
-	int					_class_instance;
-	int					_orb_class_instance;
 
-	orb_advert_t		_distance_sensor_topic;
+	int collect();
 
-	perf_counter_t		_sample_perf;
-	perf_counter_t		_comms_errors;
+	int measure();
 
-	uint8_t				_cycle_counter;	/* counter in cycle to change i2c adresses */
-	int					_cycling_rate;	/* */
-	uint8_t				_index_counter;	/* temporary sonar i2c address */
+	/**
+	 * Test whether the device supported by the driver is present at a
+	 * specific address.
+	 *
+	 * @param address	The I2C bus address to probe.
+	 * @return			True if the device is present.
+	 */
+	int probe_address(uint8_t address);
 
-	px4::Array<float, 6>
-	_latest_sonar_measurements; /* vector to store latest sonar measurements in before writing to report */
-	unsigned 		_sonars{6};
-	struct GPIOConfig {
-		uint32_t        trig_port;
-		uint32_t        echo_port;
-		uint32_t        alt;
-	};
+	/**
+	 * Perform a poll cycle; collect from the previous measurement
+	 * and start a new one.
+	 */
+	void Run() override;
+
+	/**
+	 * Initialise the automatic measurement state machine and start it.
+	 *
+	 * @note This function is called at open and error time.  It might make sense
+	 *       to make it more aggressive about resetting the bus in case of errors.
+	 */
+	void start();
+
+	/**
+	 * Stop the automatic measurement state machine.
+	 */
+	void stop();
+
 	static const GPIOConfig _gpio_tab[];
-	unsigned 		_raising_time;
-	unsigned 		_falling_time;
-	unsigned 		_status;
-	/**
-	* Test whether the device supported by the driver is present at a
-	* specific address.
-	*
-	* @param address	The I2C bus address to probe.
-	* @return			True if the device is present.
-	*/
-	int					probe_address(uint8_t address);
 
-	/**
-	* Initialise the automatic measurement state machine and start it.
-	*
-	* @note This function is called at open and error time.  It might make sense
-	*       to make it more aggressive about resetting the bus in case of errors.
-	*/
-	void				start();
+	struct GPIOConfig {
+		uint32_t alt;
+		uint32_t echo_port;
+		uint32_t trig_port;
+	};
 
-	/**
-	* Stop the automatic measurement state machine.
-	*/
-	void				stop();
+	px4::Array<float, 6> _latest_sonar_measurements {};	// Array to store latest sonar measurements in before writing to report.
 
-	/**
-	* Set the min and max distance thresholds if you want the end points of the sensors
-	* range to be brought in at all, otherwise it will use the defaults MB12XX_MIN_DISTANCE
-	* and MB12XX_MAX_DISTANCE
-	*/
-	void				set_minimum_distance(float min);
-	void				set_maximum_distance(float max);
-	float				get_minimum_distance();
-	float				get_maximum_distance();
+	bool _collect_phase{false};
+	bool _sensor_ok{false};
 
-	/**
-	* Perform a poll cycle; collect from the previous measurement
-	* and start a new one.
-	*/
-	void				Run() override;
-	int					measure();
-	int					collect();
+	int _class_instance{-1};
+	int _cycling_rate{0};		// Initialize cycling rate to zero, (can differ depending on one sonar or multiple).
+	int _measure_interval{0};
+	int _orb_class_instance{-1};
 
+	unsigned int _falling_time{0};
+	unsigned int _raising_time{0};
+	unsigned int _sonars{6};
+	unsigned int _status{0};
+
+	uint8_t _cycle_counter{0};	// Initialize counter for cycling function to zero.
+	uint8_t _index_counter{0};	// Initialize temp sonar i2c address to zero.
+
+	float _max_distance{SR04_MIN_DISTANCE};
+	float _min_distance{SR04_MAX_DISTANCE};
+
+	ringbuffer::RingBuffer	*_reports{nullptr};
+
+	orb_advert_t _distance_sensor_topic{nullptr};
+
+	perf_counter_t _comms_errors{perf_alloc(PC_COUNT, "hc_sr04_comms_errors")};
+	perf_counter_t _sample_perf{perf_alloc(PC_ELAPSED, "hc_sr04_read")};
 };
 
-const HC_SR04::GPIOConfig HC_SR04::_gpio_tab[] = {
-	{GPIO_GPIO6_OUTPUT,      GPIO_GPIO7_INPUT,       0},
-	{GPIO_GPIO6_OUTPUT,      GPIO_GPIO8_INPUT,       0},
-	{GPIO_GPIO6_OUTPUT,      GPIO_GPIO9_INPUT,       0},
-	{GPIO_GPIO6_OUTPUT,      GPIO_GPIO10_INPUT,       0},
-	{GPIO_GPIO6_OUTPUT,      GPIO_GPIO11_INPUT,       0},
-	{GPIO_GPIO6_OUTPUT,      GPIO_GPIO12_INPUT,       0}
-};
-
-/*
- * Driver 'main' command.
- */
-extern "C"  __EXPORT int hc_sr04_main(int argc, char *argv[]);
-static int sonar_isr(int irq, void *context);
 
 HC_SR04::HC_SR04() :
-	CDev(SR04_DEVICE_PATH, 0),
-	_min_distance(SR04_MIN_DISTANCE),
-	_max_distance(SR04_MAX_DISTANCE),
-	_reports(nullptr),
-	_sensor_ok(false),
-	_measure_interval(0),
-	_collect_phase(false),
-	_class_instance(-1),
-	_orb_class_instance(-1),
-	_distance_sensor_topic(nullptr),
-	_sample_perf(perf_alloc(PC_ELAPSED, "hc_sr04_read")),
-	_comms_errors(perf_alloc(PC_COUNT, "hc_sr04_comms_errors")),
-	_cycle_counter(0),	/* initialising counter for cycling function to zero */
-	_cycling_rate(0),	/* initialising cycling rate (which can differ depending on one sonar or multiple) */
-	_index_counter(0), 	/* initialising temp sonar i2c address to zero */
-	_sonars(sonars),
-	_raising_time(0),
-	_falling_time(0),
-	_status(0)
-
+	CDev(SR04_DEVICE_PATH)
 {
 }
 
 HC_SR04::~HC_SR04()
 {
-	/* make sure we are truly inactive */
+	// Ensure we are truly inactive.
 	stop();
 
-	/* free any existing reports */
+	// Free any existing reports.
 	if (_reports != nullptr) {
 		delete _reports;
 	}
@@ -225,246 +205,9 @@ HC_SR04::~HC_SR04()
 		unregister_class_devname(RANGE_FINDER_BASE_DEVICE_PATH, _class_instance);
 	}
 
-	/* free perf counters */
+	// Free perf counters.
 	perf_free(_sample_perf);
 	perf_free(_comms_errors);
-}
-
-int
-HC_SR04::init()
-{
-	int ret = PX4_ERROR;
-
-	/* do I2C init (and probe) first */
-	if (CDev::init() != OK) {
-		return PX4_ERROR;
-	}
-
-	/* allocate basic report buffers */
-	_reports = new ringbuffer::RingBuffer(2, sizeof(distance_sensor_s));
-
-	if (_reports == nullptr) {
-		return PX4_ERROR;
-	}
-
-	_class_instance = register_class_devname(RANGE_FINDER_BASE_DEVICE_PATH);
-
-	/* get a publish handle on the range finder topic */
-	struct distance_sensor_s ds_report = {};
-
-	_distance_sensor_topic = orb_advertise_multi(ORB_ID(distance_sensor), &ds_report,
-				 &_orb_class_instance, ORB_PRIO_LOW);
-
-	if (_distance_sensor_topic == nullptr) {
-		PX4_ERR("failed to create distance_sensor object");
-	}
-
-	/* init echo port : */
-	for (unsigned i = 0; i <= _sonars; i++) {
-		px4_arch_configgpio(_gpio_tab[i].trig_port);
-		px4_arch_gpiowrite(_gpio_tab[i].trig_port, false);
-		px4_arch_configgpio(_gpio_tab[i].echo_port);
-		_latest_sonar_measurements.push_back(0);
-	}
-
-	usleep(200000); /* wait for 200ms; */
-
-	_cycling_rate = SR04_CONVERSION_INTERVAL;
-
-	/* show the connected sonars in terminal */
-	PX4_DEBUG("Number of sonars set: %d", _sonars);
-
-	ret = OK;
-	/* sensor is ok, but we don't really know if it is within range */
-	_sensor_ok = true;
-
-	return ret;
-}
-
-int
-HC_SR04::probe()
-{
-	return (OK);
-}
-
-void
-HC_SR04::set_minimum_distance(float min)
-{
-	_min_distance = min;
-}
-
-void
-HC_SR04::set_maximum_distance(float max)
-{
-	_max_distance = max;
-}
-
-float
-HC_SR04::get_minimum_distance()
-{
-	return _min_distance;
-}
-
-float
-HC_SR04::get_maximum_distance()
-{
-	return _max_distance;
-}
-void
-HC_SR04::interrupt(unsigned time)
-{
-	if (_status == 0) {
-		_raising_time = time;
-		_status++;
-		return;
-
-	} else if (_status == 1) {
-		_falling_time = time;
-		_status++;
-		return;
-	}
-
-	return;
-}
-
-int
-HC_SR04::ioctl(device::file_t *filp, int cmd, unsigned long arg)
-{
-	switch (cmd) {
-
-	case SENSORIOCSPOLLRATE: {
-			switch (arg) {
-
-			/* zero would be bad */
-			case 0:
-				return -EINVAL;
-
-			/* set default polling rate */
-			case SENSOR_POLLRATE_DEFAULT: {
-					/* do we need to start internal polling? */
-					bool want_start = (_measure_interval == 0);
-
-					/* set interval for next measurement to minimum legal value */
-					_measure_interval = _cycling_rate;
-
-					/* if we need to start the poll state machine, do it */
-					if (want_start) {
-						start();
-
-					}
-
-					return OK;
-				}
-
-			/* adjust to a legal polling interval in Hz */
-			default: {
-					/* do we need to start internal polling? */
-					bool want_start = (_measure_interval == 0);
-
-					/* convert hz to tick interval via microseconds */
-					int interval = (1000000 / arg);
-
-					/* check against maximum rate */
-					if (interval < _cycling_rate) {
-						return -EINVAL;
-					}
-
-					/* update interval for next measurement */
-					_measure_interval = interval;
-
-					/* if we need to start the poll state machine, do it */
-					if (want_start) {
-						start();
-					}
-
-					return OK;
-				}
-			}
-		}
-
-	default:
-		/* give it to the superclass */
-		return CDev::ioctl(filp, cmd, arg);
-	}
-}
-
-ssize_t
-HC_SR04::read(device::file_t *filp, char *buffer, size_t buflen)
-{
-
-	unsigned count = buflen / sizeof(struct distance_sensor_s);
-	struct distance_sensor_s *rbuf = reinterpret_cast<struct distance_sensor_s *>(buffer);
-	int ret = 0;
-
-	/* buffer must be large enough */
-	if (count < 1) {
-		return -ENOSPC;
-	}
-
-	/* if automatic measurement is enabled */
-	if (_measure_interval > 0) {
-		/*
-		 * While there is space in the caller's buffer, and reports, copy them.
-		 * Note that we may be pre-empted by the workq thread while we are doing this;
-		 * we are careful to avoid racing with them.
-		 */
-		while (count--) {
-			if (_reports->get(rbuf)) {
-				ret += sizeof(*rbuf);
-				rbuf++;
-			}
-		}
-
-		/* if there was no data, warn the caller */
-		return ret ? ret : -EAGAIN;
-	}
-
-	/* manual measurement - run one conversion */
-	do {
-		_reports->flush();
-
-		/* trigger a measurement */
-		if (OK != measure()) {
-			ret = -EIO;
-			break;
-		}
-
-		/* wait for it to complete */
-		usleep(_cycling_rate * 2);
-
-		/* run the collection phase */
-		if (OK != collect()) {
-			ret = -EIO;
-			break;
-		}
-
-		/* state machine will have generated a report, copy it out */
-		if (_reports->get(rbuf)) {
-			ret = sizeof(*rbuf);
-		}
-
-	} while (0);
-
-	return ret;
-}
-
-int
-HC_SR04::measure()
-{
-
-	int ret;
-	/*
-	 * Send a plus begin a measurement.
-	 */
-	px4_arch_gpiowrite(_gpio_tab[_cycle_counter].trig_port, true);
-	usleep(10);  // 10us
-	px4_arch_gpiowrite(_gpio_tab[_cycle_counter].trig_port, false);
-
-	px4_arch_gpiosetevent(_gpio_tab[_cycle_counter].echo_port, true, true, false, sonar_isr);
-	_status = 0;
-	ret = OK;
-
-	return ret;
 }
 
 int
@@ -548,47 +291,145 @@ HC_SR04::collect()
 	return ret;
 }
 
-void
-HC_SR04::start()
+int
+HC_SR04::init()
 {
-	/* reset the report ring and state machine */
-	_collect_phase = false;
-	_reports->flush();
+	// Perform I2C init (and probe) first.
+	if (CDev::init() != OK) {
+		return PX4_ERROR;
+	}
 
-	measure();  /* begin measure */
+	// Allocate basic report buffers.
+	_reports = new ringbuffer::RingBuffer(2, sizeof(distance_sensor_s));
 
-	/* schedule a cycle to start things */
-	ScheduleDelayed(_cycling_rate);
+	if (_reports == nullptr) {
+		return PX4_ERROR;
+	}
+
+	_class_instance = register_class_devname(RANGE_FINDER_BASE_DEVICE_PATH);
+
+	// Get a publish handle on the range finder topic.
+	struct distance_sensor_s ds_report = {};
+
+	_distance_sensor_topic = orb_advertise_multi(ORB_ID(distance_sensor), &ds_report,
+				 &_orb_class_instance, ORB_PRIO_LOW);
+
+	if (_distance_sensor_topic == nullptr) {
+		PX4_ERR("failed to create distance_sensor object");
+	}
+
+	// Init echo port:
+	for (unsigned i = 0; i <= _sonars; i++) {
+		px4_arch_configgpio(_gpio_tab[i].trig_port);
+		px4_arch_gpiowrite(_gpio_tab[i].trig_port, false);
+		px4_arch_configgpio(_gpio_tab[i].echo_port);
+		_latest_sonar_measurements.push_back(0);
+	}
+
+	usleep(200000); // Wait for 200ms for the sensor to configure.
+
+	// sensor is ok, but we don't really know if it is within range.
+	_sensor_ok = true;
+	_cycling_rate = SR04_CONVERSION_INTERVAL;
+
+	// Show the connected sonars in terminal.
+	PX4_INFO("Number of sonars set: %d", _sonars);
+
+	return PX4_OK;
 }
 
 void
-HC_SR04::stop()
+HC_SR04::interrupt(unsigned time)
 {
-	ScheduleClear();
+	if (_status == 0) {
+		_raising_time = time;
+		_status++;
+		return;
+
+	} else if (_status == 1) {
+		_falling_time = time;
+		_status++;
+		return;
+	}
+
+	return;
 }
 
-void
-HC_SR04::Run()
+int
+HC_SR04::ioctl(device::file_t *filp, int cmd, unsigned long arg)
 {
-	/*_circle_count 计录当前sonar　*/
-	/* perform collection */
-	if (OK != collect()) {
-		PX4_DEBUG("collection error");
+	switch (cmd) {
+
+	case SENSORIOCSPOLLRATE: {
+			switch (arg) {
+
+			/* zero would be bad */
+			case 0:
+				return -EINVAL;
+
+			/* set default polling rate */
+			case SENSOR_POLLRATE_DEFAULT: {
+					/* do we need to start internal polling? */
+					bool want_start = (_measure_interval == 0);
+
+					/* set interval for next measurement to minimum legal value */
+					_measure_interval = _cycling_rate;
+
+					/* if we need to start the poll state machine, do it */
+					if (want_start) {
+						start();
+
+					}
+
+					return OK;
+				}
+
+			/* adjust to a legal polling interval in Hz */
+			default: {
+					/* do we need to start internal polling? */
+					bool want_start = (_measure_interval == 0);
+
+					/* convert hz to tick interval via microseconds */
+					int interval = (1000000 / arg);
+
+					/* check against maximum rate */
+					if (interval < _cycling_rate) {
+						return -EINVAL;
+					}
+
+					/* update interval for next measurement */
+					_measure_interval = interval;
+
+					/* if we need to start the poll state machine, do it */
+					if (want_start) {
+						start();
+					}
+
+					return OK;
+				}
+			}
+		}
+
+	default:
+		/* give it to the superclass */
+		return CDev::ioctl(filp, cmd, arg);
 	}
+}
 
-	/* change to next sonar */
-	_cycle_counter = _cycle_counter + 1;
+int
+HC_SR04::measure()
+{
+	// Send a plus begin a measurement.
+	px4_arch_gpiowrite(_gpio_tab[_cycle_counter].trig_port, true);
 
-	if (_cycle_counter >= _sonars) {
-		_cycle_counter = 0;
-	}
+	usleep(10);  // Allow 10us for register write to complete.
 
-	/* 测量next sonar */
-	if (OK != measure()) {
-		PX4_DEBUG("measure error sonar adress %d", _cycle_counter);
-	}
+	px4_arch_gpiowrite(_gpio_tab[_cycle_counter].trig_port, false);
+	px4_arch_gpiosetevent(_gpio_tab[_cycle_counter].echo_port, true, true, false, sonar_isr);
 
-	ScheduleDelayed(_cycling_rate);
+	_status = 0;
+
+	return PX4_OK;
 }
 
 void
@@ -598,6 +439,114 @@ HC_SR04::print_info()
 	perf_print_counter(_comms_errors);
 	printf("poll interval:  %u \n", _measure_interval);
 	_reports->print_info("report queue");
+}
+
+int
+HC_SR04::probe()
+{
+	return measure();
+}
+
+ssize_t
+HC_SR04::read(device::file_t *filp, char *buffer, size_t buflen)
+{
+	unsigned count = buflen / sizeof(struct distance_sensor_s);
+	struct distance_sensor_s *rbuf = reinterpret_cast<struct distance_sensor_s *>(buffer);
+	int ret = 0;
+
+	/* buffer must be large enough */
+	if (count < 1) {
+		return -ENOSPC;
+	}
+
+	/* if automatic measurement is enabled */
+	if (_measure_interval > 0) {
+		/*
+		 * While there is space in the caller's buffer, and reports, copy them.
+		 * Note that we may be pre-empted by the workq thread while we are doing this;
+		 * we are careful to avoid racing with them.
+		 */
+		while (count--) {
+			if (_reports->get(rbuf)) {
+				ret += sizeof(*rbuf);
+				rbuf++;
+			}
+		}
+
+		/* if there was no data, warn the caller */
+		return ret ? ret : -EAGAIN;
+	}
+
+	/* manual measurement - run one conversion */
+	do {
+		_reports->flush();
+
+		/* trigger a measurement */
+		if (OK != measure()) {
+			ret = -EIO;
+			break;
+		}
+
+		/* wait for it to complete */
+		usleep(_cycling_rate * 2);
+
+		/* run the collection phase */
+		if (OK != collect()) {
+			ret = -EIO;
+			break;
+		}
+
+		/* state machine will have generated a report, copy it out */
+		if (_reports->get(rbuf)) {
+			ret = sizeof(*rbuf);
+		}
+
+	} while (0);
+
+	return ret;
+}
+
+void
+HC_SR04::Run()
+{
+	int ret = collect();
+
+	// perform collection */
+	if (ret != PX4_OK) {
+		PX4_DEBUG("collection error");
+	}
+
+	// change to next sonar.
+	_cycle_counter++;
+	_cycle_counter %= _sonars;
+
+	ret = measure();
+
+	if (ret != PX4_OK) {
+		PX4_DEBUG("measure error sonar adress %d", _cycle_counter);
+	}
+
+	ScheduleDelayed(_cycling_rate);
+}
+
+void
+HC_SR04::start()
+{
+	// Reset the report ring and state machine.
+	_collect_phase = false;
+	_reports->flush();
+
+	// Begin measure.
+	measure();
+
+	// Schedule a cycle to start things.
+	ScheduleDelayed(_cycling_rate);
+}
+
+void
+HC_SR04::stop()
+{
+	ScheduleClear();
 }
 
 /**
@@ -782,54 +731,47 @@ info()
 
 } /* namespace */
 
-static int sonar_isr(int irq, void *context)
+
+// static int sonar_isr(int irq, void *context);
+
+// static int sonar_isr(int irq, void *context)
+// {
+// 	unsigned time = hrt_absolute_time();
+// 	 ack the interrupts we just read
+
+// 	if (hc_sr04::g_dev != nullptr) {
+// 		hc_sr04::g_dev->interrupt(time);
+// 	}
+
+// 	return OK;
+// }
+
+/**
+ * Driver 'main' command.
+ */
+extern "C"  __EXPORT int hc_sr04_main(int argc, char *argv[])
 {
-	unsigned time = hrt_absolute_time();
-	/* ack the interrupts we just read */
-
-	if (hc_sr04::g_dev != nullptr) {
-		hc_sr04::g_dev->interrupt(time);
-	}
-
-	return OK;
-}
-
-
-
-int
-hc_sr04_main(int argc, char *argv[])
-{
-	/*
-	 * Start/load the driver.
-	 */
+	// Start/load the driver.
 	if (!strcmp(argv[1], "start")) {
 		hc_sr04::start();
 	}
 
-	/*
-	 * Stop the driver
-	 */
+	// Stop the driver.
 	if (!strcmp(argv[1], "stop")) {
 		hc_sr04::stop();
 	}
 
-	/*
-	 * Test the driver/device.
-	 */
+	// Test the driver/device.
 	if (!strcmp(argv[1], "test")) {
 		hc_sr04::test();
 	}
 
-	/*
-	 * Reset the driver.
-	 */
+	// Reset the driver.
 	if (!strcmp(argv[1], "reset")) {
 		hc_sr04::reset();
 	}
 
-	/*
-	 * Print driver information.
-	 */
+	// Print driver information.
 	if (!strcmp(argv[1], "info") || !strcmp(argv[1], "status")) {
 		hc_sr04::info();
 	}


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR migrates HC_SR04 class member variable initialization to their respective declarations, formats whitespace, organizes variable ordering, and modifies the code so that it at least compiles, (it is very much still broken, however).

*NOTE* the hc_sr04 driver has been in a disfunctional state since prior to January 2018.  This PR aims to align the driver with other distance sensor drivers, however it could easily be argued that this PR should be modified to deprecate the hc_sr04 driver entirely.

**Describe your preferred solution**
Ultimately all distance sensor drivers should inherit from a common base class, and this PR makes incremental steps toward that objective.

**Describe possible alternatives**
Deprecate this particular driver entirely.

**Additional context**
See Issue #9279.
*NOTE:* This driver is badly broken... A decision should be made about whether or not it should be fixed or deprecated.

https://www.mouser.com/ds/2/813/HCSR04-1022824.pdf

Please let me know if you have any questions on this PR.  Thanks!

-Mark
