### PR TITLE
Refactor the LeddarOne driver to standardize against other distance sensor drivers.

### DIFF
--- a/src/drivers/distance_sensor/leddar_one/leddar_one.cpp
+++ b/src/drivers/distance_sensor/leddar_one/leddar_one.cpp
@@ -333,21 +333,6 @@ LeddarOne::init()
 		px4_usleep(1000);
 	}
 
-	/*
-		hrt_abstime time_now = hrt_absolute_time();
-		hrt_abstime timeout_usec = time_now + PROBE_USEC_TIMEOUT;
-
-		for (time_now, timeout_usec; time_now < timeout_usec; time_now = hrt_absolute_time()) {
-
-			if (cycle() > 0) {;
-				PX4_INFO("LeddarOne initialized");
-				return PX4_OK;
-			}
-
-			px4_usleep(1000);
-		}
-	*/
-
 	PX4_ERR("No readings from LeddarOne");
 	return PX4_ERROR;
 }

--- a/src/drivers/distance_sensor/leddar_one/leddar_one.cpp
+++ b/src/drivers/distance_sensor/leddar_one/leddar_one.cpp
@@ -51,25 +51,24 @@
 
 #include <uORB/topics/distance_sensor.h>
 
-#define MIN_DISTANCE 0.01f
-#define MAX_DISTANCE 40.0f
+#define DEVICE_PATH "/dev/LeddarOne"
 
-#define NAME "leddar_one"
-#define DEVICE_PATH "/dev/" NAME
+#define MAX_DISTANCE         40.0f
+#define MIN_DISTANCE         0.01f
 
-#define SENSOR_READING_FREQ 10.0f
-#define READING_USEC_PERIOD (unsigned long)(1000000.0f / SENSOR_READING_FREQ)
-#define OVERSAMPLE 6
-#define WORK_USEC_INTERVAL READING_USEC_PERIOD / OVERSAMPLE
+#define SENSOR_READING_FREQ  10.0f
+#define READING_USEC_PERIOD  (unsigned long)(1000000.0f / SENSOR_READING_FREQ)
+#define OVERSAMPLE           6
+#define WORK_USEC_INTERVAL   READING_USEC_PERIOD / OVERSAMPLE
 #define COLLECT_USEC_TIMEOUT READING_USEC_PERIOD / (OVERSAMPLE / 2)
 
 /* 0.5sec */
-#define PROBE_USEC_TIMEOUT 500000
+#define PROBE_USEC_TIMEOUT   500000
 
-#define MODBUS_SLAVE_ADDRESS 0x01
+#define MODBUS_SLAVE_ADDRESS    0x01
 #define MODBUS_READING_FUNCTION 0x04
-#define READING_START_ADDR 0x14
-#define READING_LEN 0xA
+#define READING_START_ADDR      0x14
+#define READING_LEN             0xA
 
 static const uint8_t request_reading_msg[] = {
 	MODBUS_SLAVE_ADDRESS,
@@ -109,11 +108,11 @@ struct __attribute__((__packed__)) reading_msg {
 	uint16_t crc; /* little-endian */
 };
 
-class leddar_one : public cdev::CDev, public px4::ScheduledWorkItem
+class LeddarOne : public cdev::CDev, public px4::ScheduledWorkItem
 {
 public:
-	leddar_one(const char *device_path, const char *serial_port, uint8_t rotation);
-	virtual ~leddar_one();
+	LeddarOne(const char *device_path, const char *serial_port, uint8_t rotation);
+	virtual ~LeddarOne();
 
 	virtual int init() override;
 	void start();
@@ -123,41 +122,409 @@ public:
 
 private:
 
-	int _fd = -1;
-	const char *_serial_port;
+	int _collect();
 
-	uint8_t _rotation;
+	int _cycle();
 
-	uint8_t _buffer[sizeof(struct reading_msg)];
-	uint8_t _buffer_len = 0;
+	int _fd_open();
 
-	orb_advert_t _topic = nullptr;
-	ringbuffer::RingBuffer *_reports = nullptr;
+	void _publish(uint16_t distance_cm);
+
+	bool _request();
+
+	void Run() override;
 
 	enum {
 		state_waiting_reading = 0,
 		state_reading_requested
-	} _state = state_waiting_reading;
-	hrt_abstime _timeout_usec = 0;
+	} _state{state_waiting_reading};
 
-	perf_counter_t _collect_timeout_perf;
-	perf_counter_t _comm_error;
-	perf_counter_t _sample_perf;
+	const char *_serial_port;
 
-	int _fd_open();
-	bool _request();
-	int _collect();
-	void _publish(uint16_t distance_cm);
-	int _cycle();
+	int _fd{-1};
 
-	void Run() override;
+	uint8_t _buffer[sizeof(struct reading_msg)];
+	uint8_t _buffer_len{0};
+	uint8_t _rotation;
+
+	hrt_abstime _timeout_usec{0};
+
+	perf_counter_t _collect_timeout_perf{perf_alloc(PC_COUNT, "leddar_one_collect_timeout")};
+	perf_counter_t _comm_error{perf_alloc(PC_COUNT, "leddar_one_comm_errors")};
+	perf_counter_t _sample_perf{perf_alloc(PC_ELAPSED, "leddar_one_sample")};
+
+	orb_advert_t _topic{nullptr};
+	ringbuffer::RingBuffer *_reports{nullptr};
+
 };
 
+LeddarOne::LeddarOne(const char *device_path, const char *serial_port, uint8_t rotation):
+	CDev(device_path),
+	ScheduledWorkItem(px4::wq_configurations::hp_default),
+	_rotation(rotation)
+{
+	_serial_port = strdup(serial_port);
+}
+
+LeddarOne::~LeddarOne()
+{
+	stop();
+
+	free((char *)_serial_port);
+
+	if (_fd > -1) {
+		::close(_fd);
+	}
+
+	if (_reports) {
+		delete _reports;
+	}
+
+	if (_topic) {
+		orb_unadvertise(_topic);
+	}
+
+	perf_free(_collect_timeout_perf);
+	perf_free(_comm_error);
+	perf_free(_sample_perf);
+}
+
+uint16_t
+LeddarOne::calc_crc16(const uint8_t *buffer, uint8_t len)
+{
+	uint16_t crc = 0xFFFF;
+
+	for (uint8_t i = 0; i < len; i++) {
+		crc ^= buffer[i];
+
+		for (uint8_t j = 0; j < 8; j++) {
+			if (crc & 1) {
+				crc = (crc >> 1) ^ 0xA001;
+
+			} else {
+				crc >>= 1;
+			}
+		}
+	}
+
+	return crc;
+}
+
+/*
+ * returns 0 when still waiting for reading_msg, 1 when frame was read or
+ * -1 in case of error
+ */
+int
+LeddarOne::_collect()
+{
+	struct reading_msg *msg;
+
+	int bytes_read = ::read(_fd, _buffer + _buffer_len, sizeof(_buffer) - _buffer_len);
+
+	if (bytes_read < 1) {
+		return 0;
+	}
+
+	_buffer_len += bytes_read;
+
+	if (_buffer_len < sizeof(struct reading_msg)) {
+		return 0;
+	}
+
+	msg = (struct reading_msg *)_buffer;
+
+	if (msg->slave_addr != MODBUS_SLAVE_ADDRESS || msg->function != MODBUS_READING_FUNCTION) {
+		return -1;
+	}
+
+	const uint16_t crc16_calc = _calc_crc16(_buffer, _buffer_len - 2);
+
+	if (crc16_calc != msg->crc) {
+		return -1;
+	}
+
+	/* NOTE: little-endian support only */
+	_publish(msg->first_dist_high_byte << 8 | msg->first_dist_low_byte);
+	return 1;
+}
+
+int
+LeddarOne::_cycle()
+{
+	int ret = 0;
+	const hrt_abstime now = hrt_absolute_time();
+
+	switch (_state) {
+	case state_waiting_reading:
+		if (now > _timeout_usec) {
+			if (_request()) {
+				perf_begin(_sample_perf);
+				_buffer_len = 0;
+				_state = state_reading_requested;
+				_timeout_usec = now + COLLECT_USEC_TIMEOUT;
+			}
+		}
+
+		break;
+
+	case state_reading_requested:
+		ret = _collect();
+
+		if (ret == 1) {
+			perf_end(_sample_perf);
+			_state = state_waiting_reading;
+			_timeout_usec = now + READING_USEC_PERIOD;
+
+		} else {
+			if (ret == 0 && now < _timeout_usec) {
+				/* still waiting for reading */
+				break;
+			}
+
+			if (ret == -1) {
+				perf_count(_comm_error);
+
+			} else {
+				perf_count(_collect_timeout_perf);
+			}
+
+			perf_cancel(_sample_perf);
+			_state = state_waiting_reading;
+			_timeout_usec = 0;
+			return _cycle();
+		}
+	}
+
+	return ret;
+}
+
+int
+LeddarOne::init()
+{
+	if (CDev::init()) {
+		PX4_ERR("Unable to initialize device\n");
+		return -1;
+	}
+
+	_reports = new ringbuffer::RingBuffer(2, sizeof(distance_sensor_s));
+
+	if (!_reports) {
+		PX4_ERR("No memory to allocate RingBuffer");
+		return -1;
+	}
+
+	if (_fd_open()) {
+		return PX4_ERROR;
+	}
+
+	hrt_abstime timeout_usec, now;
+
+	for (now = hrt_absolute_time(), timeout_usec = now + PROBE_USEC_TIMEOUT;
+	     now < timeout_usec;
+	     now = hrt_absolute_time()) {
+
+		if (_cycle() > 0) {
+			printf(NAME " found\n");
+			return PX4_OK;
+		}
+
+		px4_usleep(1000);
+	}
+
+	PX4_ERR("No readings from " NAME);
+
+	return PX4_ERROR;
+}
+
+int
+LeddarOne::_fd_open()
+{
+	if (!_serial_port) {
+		return -1;
+	}
+
+	_fd = ::open(_serial_port, O_RDWR | O_NOCTTY | O_NONBLOCK);
+
+	if (_fd < 0) {
+		return -1;
+	}
+
+	struct termios config;
+
+	int r = tcgetattr(_fd, &config);
+
+	if (r) {
+		PX4_ERR("Unable to get termios from %s.", _serial_port);
+		goto error;
+	}
+
+	/* clear: data bit size, two stop bits, parity, hardware flow control */
+	config.c_cflag &= ~(CSIZE | CSTOPB | PARENB | CRTSCTS);
+	/* set: 8 data bits, enable receiver, ignore modem status lines */
+	config.c_cflag |= (CS8 | CREAD | CLOCAL);
+	/* turn off output processing */
+	config.c_oflag = 0;
+	/* clear: echo, echo new line, canonical input and extended input */
+	config.c_lflag &= (ECHO | ECHONL | ICANON | IEXTEN);
+
+	r = cfsetispeed(&config, B115200);
+	r |= cfsetospeed(&config, B115200);
+
+	if (r) {
+		PX4_ERR("Unable to set baudrate");
+		goto error;
+	}
+
+	r = tcsetattr(_fd, TCSANOW, &config);
+
+	if (r) {
+		PX4_ERR("Unable to set termios to %s", _serial_port);
+		goto error;
+	}
+
+	return PX4_OK;
+
+error:
+	::close(_fd);
+	_fd = -1;
+	return PX4_ERROR;
+}
+
+void
+LeddarOne::publish(uint16_t distance_mm)
+{
+	struct distance_sensor_s report;
+
+	report.timestamp = hrt_absolute_time();
+	report.type = distance_sensor_s::MAV_DISTANCE_SENSOR_ULTRASOUND;
+	report.orientation = _rotation;
+	report.current_distance = ((float)distance_mm / 1000.0f);
+	report.min_distance = MIN_DISTANCE;
+	report.max_distance = MAX_DISTANCE;
+	report.variance = 0.0f;
+	report.signal_quality = -1;
+	report.id = 0;
+
+	_reports->force(&report);
+
+	if (_topic == nullptr) {
+		_topic = orb_advertise(ORB_ID(distance_sensor), &report);
+
+	} else {
+		orb_publish(ORB_ID(distance_sensor), _topic, &report);
+	}
+}
+
+ssize_t
+LeddarOne::read(struct file *filp, char *buffer, size_t buflen)
+{
+	unsigned count = buflen / sizeof(struct distance_sensor_s);
+	struct distance_sensor_s *rbuf = reinterpret_cast<struct distance_sensor_s *>(buffer);
+	int ret = 0;
+
+	if (count < 1) {
+		return -ENOSPC;
+	}
+
+	while (count--) {
+		if (_reports->get(rbuf)) {
+			ret += sizeof(*rbuf);
+			rbuf++;
+		}
+	}
+
+	return ret ? ret : -EAGAIN;
+}
+
+bool
+LeddarOne::_request()
+{
+	/* flush anything in RX buffer */
+	tcflush(_fd, TCIFLUSH);
+
+	int r = ::write(_fd, request_reading_msg, sizeof(request_reading_msg));
+	return r == sizeof(request_reading_msg);
+}
+
+void
+LeddarOne::Run()
+{
+	if (_fd != -1) {
+		_cycle();
+
+	} else {
+		_fd_open();
+	}
+}
+
+void
+LeddarOne::start()
+{
+	/*
+	 * file descriptor can only be accessed by the process that opened it
+	 * so closing here and it will be opened from the High priority kernel
+	 * process
+	 */
+	::close(_fd);
+	_fd = -1;
+
+	ScheduleOnInterval(WORK_USEC_INTERVAL);
+}
+
+void
+LeddarOne::stop()
+{
+	ScheduleClear();
+}
+
+
+
+/**
+ * Local functions in support of the shell command.
+ */
+namespace leddar_one
+{
+
+LeddarOne *g_dev;
+
+int start(const char *port, uint8_t rotation);
+int status();
+int stop();
+int usage();
+
+void usage()
+{
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+
+Serial bus driver for the LeddarOne LiDAR.
+
+Most boards are configured to enable/start the driver on a specified UART using the SENS_LEDDAR1_CFG parameter.
+
+Setup/usage information: https://docs.px4.io/en/sensor/leddar_one.html
+
+### Examples
+
+Attempt to start driver on a specified serial device.
+$ leddar_one start -d /dev/ttyS1
+Stop driver
+$ leddar_one stop
+)DESCR_STR");
+
+	PRINT_MODULE_USAGE_NAME("leddar_one", "driver");
+	PRINT_MODULE_USAGE_SUBCATEGORY("distance_sensor");
+	PRINT_MODULE_USAGE_COMMAND_DESCR("start","Start driver");
+	PRINT_MODULE_USAGE_PARAM_STRING('d', nullptr, nullptr, "Serial device", false);
+	PRINT_MODULE_USAGE_PARAM_INT('r', 25, 1, 25, "Sensor rotation - downward facing by default", true);
+	PRINT_MODULE_USAGE_COMMAND_DESCR("stop","Stop driver");
+	PRINT_MODULE_USAGE_COMMAND_DESCR("test","Test driver (basic functional tests)");
+
+}
+
+} // namespace
+
 extern "C" __EXPORT int leddar_one_main(int argc, char *argv[]);
-
-static void help();
-
-int leddar_one_main(int argc, char *argv[])
 {
 	int ch;
 	int myoptind = 1;
@@ -236,349 +603,4 @@ int leddar_one_main(int argc, char *argv[])
 	}
 
 	return PX4_OK;
-}
-
-leddar_one::leddar_one(const char *device_path, const char *serial_port, uint8_t rotation):
-	CDev(device_path),
-	ScheduledWorkItem(px4::wq_configurations::hp_default),
-	_rotation(rotation),
-	_collect_timeout_perf(perf_alloc(PC_COUNT, "leddar_one_collect_timeout")),
-	_comm_error(perf_alloc(PC_COUNT, "leddar_one_comm_errors")),
-	_sample_perf(perf_alloc(PC_ELAPSED, "leddar_one_sample"))
-{
-	_serial_port = strdup(serial_port);
-}
-
-leddar_one::~leddar_one()
-{
-	stop();
-
-	free((char *)_serial_port);
-
-	if (_fd > -1) {
-		::close(_fd);
-	}
-
-	if (_reports) {
-		delete _reports;
-	}
-
-	if (_topic) {
-		orb_unadvertise(_topic);
-	}
-
-	perf_free(_sample_perf);
-	perf_free(_collect_timeout_perf);
-	perf_free(_comm_error);
-}
-
-int leddar_one::_fd_open()
-{
-	if (!_serial_port) {
-		return -1;
-	}
-
-	_fd = ::open(_serial_port, O_RDWR | O_NOCTTY | O_NONBLOCK);
-
-	if (_fd < 0) {
-		return -1;
-	}
-
-	struct termios config;
-
-	int r = tcgetattr(_fd, &config);
-
-	if (r) {
-		PX4_ERR("Unable to get termios from %s.", _serial_port);
-		goto error;
-	}
-
-	/* clear: data bit size, two stop bits, parity, hardware flow control */
-	config.c_cflag &= ~(CSIZE | CSTOPB | PARENB | CRTSCTS);
-	/* set: 8 data bits, enable receiver, ignore modem status lines */
-	config.c_cflag |= (CS8 | CREAD | CLOCAL);
-	/* turn off output processing */
-	config.c_oflag = 0;
-	/* clear: echo, echo new line, canonical input and extended input */
-	config.c_lflag &= (ECHO | ECHONL | ICANON | IEXTEN);
-
-	r = cfsetispeed(&config, B115200);
-	r |= cfsetospeed(&config, B115200);
-
-	if (r) {
-		PX4_ERR("Unable to set baudrate");
-		goto error;
-	}
-
-	r = tcsetattr(_fd, TCSANOW, &config);
-
-	if (r) {
-		PX4_ERR("Unable to set termios to %s", _serial_port);
-		goto error;
-	}
-
-	return PX4_OK;
-
-error:
-	::close(_fd);
-	_fd = -1;
-	return PX4_ERROR;
-}
-
-int leddar_one::init()
-{
-	if (CDev::init()) {
-		PX4_ERR("Unable to initialize device\n");
-		return -1;
-	}
-
-	_reports = new ringbuffer::RingBuffer(2, sizeof(distance_sensor_s));
-
-	if (!_reports) {
-		PX4_ERR("No memory to allocate RingBuffer");
-		return -1;
-	}
-
-	if (_fd_open()) {
-		return PX4_ERROR;
-	}
-
-	hrt_abstime timeout_usec, now;
-
-	for (now = hrt_absolute_time(), timeout_usec = now + PROBE_USEC_TIMEOUT;
-	     now < timeout_usec;
-	     now = hrt_absolute_time()) {
-
-		if (_cycle() > 0) {
-			printf(NAME " found\n");
-			return PX4_OK;
-		}
-
-		px4_usleep(1000);
-	}
-
-	PX4_ERR("No readings from " NAME);
-
-	return PX4_ERROR;
-}
-
-void
-leddar_one::stop()
-{
-	ScheduleClear();
-}
-
-void leddar_one::start()
-{
-	/*
-	 * file descriptor can only be accessed by the process that opened it
-	 * so closing here and it will be opened from the High priority kernel
-	 * process
-	 */
-	::close(_fd);
-	_fd = -1;
-
-	ScheduleDelayed(WORK_USEC_INTERVAL);
-}
-
-void
-leddar_one::Run()
-{
-	if (_fd != -1) {
-		_cycle();
-
-	} else {
-		_fd_open();
-	}
-
-	ScheduleDelayed(WORK_USEC_INTERVAL);
-}
-
-void leddar_one::_publish(uint16_t distance_mm)
-{
-	struct distance_sensor_s report;
-
-	report.timestamp = hrt_absolute_time();
-	report.type = distance_sensor_s::MAV_DISTANCE_SENSOR_ULTRASOUND;
-	report.orientation = _rotation;
-	report.current_distance = ((float)distance_mm / 1000.0f);
-	report.min_distance = MIN_DISTANCE;
-	report.max_distance = MAX_DISTANCE;
-	report.variance = 0.0f;
-	report.signal_quality = -1;
-	report.id = 0;
-
-	_reports->force(&report);
-
-	if (_topic == nullptr) {
-		_topic = orb_advertise(ORB_ID(distance_sensor), &report);
-
-	} else {
-		orb_publish(ORB_ID(distance_sensor), _topic, &report);
-	}
-}
-
-bool leddar_one::_request()
-{
-	/* flush anything in RX buffer */
-	tcflush(_fd, TCIFLUSH);
-
-	int r = ::write(_fd, request_reading_msg, sizeof(request_reading_msg));
-	return r == sizeof(request_reading_msg);
-}
-
-static uint16_t _calc_crc16(const uint8_t *buffer, uint8_t len)
-{
-	uint16_t crc = 0xFFFF;
-
-	for (uint8_t i = 0; i < len; i++) {
-		crc ^= buffer[i];
-
-		for (uint8_t j = 0; j < 8; j++) {
-			if (crc & 1) {
-				crc = (crc >> 1) ^ 0xA001;
-
-			} else {
-				crc >>= 1;
-			}
-		}
-	}
-
-	return crc;
-}
-
-/*
- * returns 0 when still waiting for reading_msg, 1 when frame was read or
- * -1 in case of error
- */
-int leddar_one::_collect()
-{
-	struct reading_msg *msg;
-
-	int r = ::read(_fd, _buffer + _buffer_len, sizeof(_buffer) - _buffer_len);
-
-	if (r < 1) {
-		return 0;
-	}
-
-	_buffer_len += r;
-
-	if (_buffer_len < sizeof(struct reading_msg)) {
-		return 0;
-	}
-
-	msg = (struct reading_msg *)_buffer;
-
-	if (msg->slave_addr != MODBUS_SLAVE_ADDRESS || msg->function != MODBUS_READING_FUNCTION) {
-		return -1;
-	}
-
-	const uint16_t crc16_calc = _calc_crc16(_buffer, _buffer_len - 2);
-
-	if (crc16_calc != msg->crc) {
-		return -1;
-	}
-
-	/* NOTE: little-endian support only */
-	_publish(msg->first_dist_high_byte << 8 | msg->first_dist_low_byte);
-	return 1;
-}
-
-int leddar_one::_cycle()
-{
-	int ret = 0;
-	const hrt_abstime now = hrt_absolute_time();
-
-	switch (_state) {
-	case state_waiting_reading:
-		if (now > _timeout_usec) {
-			if (_request()) {
-				perf_begin(_sample_perf);
-				_buffer_len = 0;
-				_state = state_reading_requested;
-				_timeout_usec = now + COLLECT_USEC_TIMEOUT;
-			}
-		}
-
-		break;
-
-	case state_reading_requested:
-		ret = _collect();
-
-		if (ret == 1) {
-			perf_end(_sample_perf);
-			_state = state_waiting_reading;
-			_timeout_usec = now + READING_USEC_PERIOD;
-
-		} else {
-			if (ret == 0 && now < _timeout_usec) {
-				/* still waiting for reading */
-				break;
-			}
-
-			if (ret == -1) {
-				perf_count(_comm_error);
-
-			} else {
-				perf_count(_collect_timeout_perf);
-			}
-
-			perf_cancel(_sample_perf);
-			_state = state_waiting_reading;
-			_timeout_usec = 0;
-			return _cycle();
-		}
-	}
-
-	return ret;
-}
-
-ssize_t leddar_one::read(struct file *filp, char *buffer, size_t buflen)
-{
-	unsigned count = buflen / sizeof(struct distance_sensor_s);
-	struct distance_sensor_s *rbuf = reinterpret_cast<struct distance_sensor_s *>(buffer);
-	int ret = 0;
-
-	if (count < 1) {
-		return -ENOSPC;
-	}
-
-	while (count--) {
-		if (_reports->get(rbuf)) {
-			ret += sizeof(*rbuf);
-			rbuf++;
-		}
-	}
-
-	return ret ? ret : -EAGAIN;
-}
-
-void help()
-{
-	PRINT_MODULE_DESCRIPTION(
-		R"DESCR_STR(
-### Description
-
-Serial bus driver for the LeddarOne LiDAR.
-
-Most boards are configured to enable/start the driver on a specified UART using the SENS_LEDDAR1_CFG parameter.
-
-Setup/usage information: https://docs.px4.io/en/sensor/leddar_one.html
-
-### Examples
-
-Attempt to start driver on a specified serial device.
-$ leddar_one start -d /dev/ttyS1
-Stop driver
-$ leddar_one stop
-)DESCR_STR");
-
-	PRINT_MODULE_USAGE_NAME("leddar_one", "driver");
-	PRINT_MODULE_USAGE_SUBCATEGORY("distance_sensor");
-	PRINT_MODULE_USAGE_COMMAND_DESCR("start","Start driver");
-	PRINT_MODULE_USAGE_PARAM_STRING('d', nullptr, nullptr, "Serial device", false);
-	PRINT_MODULE_USAGE_PARAM_INT('r', 25, 1, 25, "Sensor rotation - downward facing by default", true);
-	PRINT_MODULE_USAGE_COMMAND_DESCR("stop","Stop driver");
-	PRINT_MODULE_USAGE_COMMAND_DESCR("test","Test driver (basic functional tests)");
-
 }


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR refactors the LeddarOne distance sensor driver to better match other distance sensor driver implementations to allow for a future inheritance architecture.

This PR:
 - Creates a `measure()` method
 - Deprecates the cycle() method.
 - Simplifies error handling logic within the collect() method.
 - Standardizes methods/var naming with other CDev/UART distance sensor drivers.

**Test data / coverage**
This PR has been bench tested, see comments/plots below.  All bench tests show identical behavior to current PX4:master branch. 
Flight test data will be posted when available.

**Additional context**
See #9279, #11853, #11857

Please let me know if you have any questions on this PR. Thanks!

-Mark