### PR TITLE
Refactor mb12xx driver class to allow for multiple sensors. Add ability to set sensor addresses. Deprecate rignbuffer and IOCTL.

### DIFF
--- a/src/drivers/distance_sensor/mb12xx/CMakeLists.txt
+++ b/src/drivers/distance_sensor/mb12xx/CMakeLists.txt
@@ -33,6 +33,7 @@
 px4_add_module(
 	MODULE drivers__mb12xx
 	MAIN mb12xx
+	STACK_MAIN 1200
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/distance_sensor/mb12xx/CMakeLists.txt
+++ b/src/drivers/distance_sensor/mb12xx/CMakeLists.txt
@@ -33,7 +33,7 @@
 px4_add_module(
 	MODULE drivers__mb12xx
 	MAIN mb12xx
-	STACK_MAIN 1200
+	STACK_MAIN 1400
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
 	SRCS

--- a/src/drivers/distance_sensor/mb12xx/mb12xx.cpp
+++ b/src/drivers/distance_sensor/mb12xx/mb12xx.cpp
@@ -72,7 +72,7 @@ using namespace time_literals;
 /* Configuration Constants */
 #define MB12XX_BASE_ADDR                        0x70   // 7-bit address is 0x70 = 112. 8-bit address is 0xE0 = 224.
 #define MB12XX_MIN_ADDR                         0x5A   // 7-bit address is 0x5A = 90.  8-bit address is 0xB4 = 180.
-#define MB12XX_BUS_DEFAULT                      PX4_I2C_BUS_EXPANSION2
+#define MB12XX_BUS_DEFAULT                      PX4_I2C_BUS_EXPANSION
 #define MB12XX_BUS_SPEED                        100000 // 100kHz bus speed.
 #define MB12XX_DEVICE_PATH                      "/dev/mb12xx"
 

--- a/src/drivers/distance_sensor/mb12xx/parameters.c
+++ b/src/drivers/distance_sensor/mb12xx/parameters.c
@@ -40,3 +40,255 @@
  * @group Sensors
  */
 PARAM_DEFINE_INT32(SENS_EN_MB12XX, 0);
+
+/**
+ * MaxBotix MB12XX Sensor 0 Rotation
+ *
+ * This parameter defines the rotation of the sensor relative to the platform.
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 7
+ * @group Sensors
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ */
+PARAM_DEFINE_INT32(SENS_MB12_0_ROT, 0);
+
+/**
+ * MaxBotix MB12XX Sensor 1 Rotation
+ *
+ * This parameter defines the rotation of the sensor relative to the platform.
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 7
+ * @group Sensors
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ */
+PARAM_DEFINE_INT32(SENS_MB12_1_ROT, 0);
+
+/**
+ * MaxBotix MB12XX Sensor 2 Rotation
+ *
+ * This parameter defines the rotation of the sensor relative to the platform.
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 7
+ * @group Sensors
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ */
+PARAM_DEFINE_INT32(SENS_MB12_2_ROT, 0);
+
+/**
+ * MaxBotix MB12XX Sensor 3 Rotation
+ *
+ * This parameter defines the rotation of the sensor relative to the platform.
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 7
+ * @group Sensors
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ */
+PARAM_DEFINE_INT32(SENS_MB12_3_ROT, 0);
+
+/**
+ * MaxBotix MB12XX Sensor 4 Rotation
+ *
+ * This parameter defines the rotation of the sensor relative to the platform.
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 7
+ * @group Sensors
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ */
+PARAM_DEFINE_INT32(SENS_MB12_4_ROT, 0);
+
+/**
+ * MaxBotix MB12XX Sensor 5 Rotation
+ *
+ * This parameter defines the rotation of the sensor relative to the platform.
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 7
+ * @group Sensors
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ */
+PARAM_DEFINE_INT32(SENS_MB12_5_ROT, 0);
+
+/**
+ * MaxBotix MB12XX Sensor 6 Rotation
+ *
+ * This parameter defines the rotation of the sensor relative to the platform.
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 7
+ * @group Sensors
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ */
+PARAM_DEFINE_INT32(SENS_MB12_6_ROT, 0);
+
+/**
+ * MaxBotix MB12XX Sensor 7 Rotation
+ *
+ * This parameter defines the rotation of the sensor relative to the platform.
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 7
+ * @group Sensors
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ */
+PARAM_DEFINE_INT32(SENS_MB12_7_ROT, 0);
+
+/**
+ * MaxBotix MB12XX Sensor 8 Rotation
+ *
+ * This parameter defines the rotation of the sensor relative to the platform.
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 7
+ * @group Sensors
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ */
+PARAM_DEFINE_INT32(SENS_MB12_8_ROT, 0);
+
+/**
+ * MaxBotix MB12XX Sensor 9 Rotation
+ *
+ * This parameter defines the rotation of the sensor relative to the platform.
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 7
+ * @group Sensors
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ */
+PARAM_DEFINE_INT32(SENS_MB12_9_ROT, 0);
+
+/**
+ * MaxBotix MB12XX Sensor 10 Rotation
+ *
+ * This parameter defines the rotation of the sensor relative to the platform.
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 7
+ * @group Sensors
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ */
+PARAM_DEFINE_INT32(SENS_MB12_10_ROT, 0);
+
+/**
+ * MaxBotix MB12XX Sensor 12 Rotation
+ *
+ * This parameter defines the rotation of the sensor relative to the platform.
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 7
+ * @group Sensors
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
+ */
+PARAM_DEFINE_INT32(SENS_MB12_11_ROT, 0);


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR refactors the MB12XX class to allow multiple sensors to be run simultaneously, set sensor device addresses, and deprecates use of the hardware ringbuffer and IOCTL.

This PR is a major re-write/refactor with flight test validation demonstrated in the comments below.

**Describe your preferred solution**
This PR standardizes the MB12XX class with the MappyDot distance sensor driver. Standardizing the distance sensor drivers will allow for future inheritance structure work to be performed on the distance sensor driver classes.

This PR is additional work to promote #9279 in conjunction with #11853, #11857,  #11858, et al., and remaining distance sensor driver work.

**Describe possible alternatives**
All of the distance sensor driver work could be accomplished in one massive PR, but breaking up work in each driver should minimize risk and reduce review effort.

**Additional context**
See #9279, #11853, #11857, #1858

Please let me know if you have any questions on this PR. Thanks!

-Mark