### PR TITLE
Change variable initialization to uniform initialization style and format whitespace in the pga460 driver.

### DIFF
--- a/src/drivers/distance_sensor/pga460/pga460.cpp
+++ b/src/drivers/distance_sensor/pga460/pga460.cpp
@@ -41,8 +41,6 @@
 #include "pga460.h"
 
 
-extern "C" __EXPORT int pga460_main(int argc, char *argv[]);
-
 PGA460::PGA460(const char *port)
 {
 	// Store port name.
@@ -313,7 +311,6 @@ int PGA460::open_serial()
 	// no NL to CR translation, don't mark parity errors or breaks
 	// no input parity check, don't strip high bit off,
 	// no XON/XOFF software flow control
-	//
 	uart_config.c_iflag &= ~(IGNBRK | BRKINT | ICRNL |  INLCR | IGNCR | PARMRK | INPCK | ISTRIP | IXON | IXOFF);
 
 	uart_config.c_iflag |= IGNPAR;
@@ -339,7 +336,7 @@ int PGA460::open_serial()
 
 	uart_config.c_cc[VTIME] = 0;
 
-	unsigned speed = 115200;
+	speed_t speed = 115200;
 
 	// Set the baud rate.
 	if ((termios_state = cfsetispeed(&uart_config, speed)) < 0) {
@@ -899,7 +896,7 @@ int PGA460::write_register(const uint8_t reg, const uint8_t val)
 	}
 }
 
-int pga460_main(int argc, char *argv[])
+extern "C" __EXPORT int pga460_main(int argc, char *argv[])
 {
 	return PGA460::main(argc, argv);
 }

--- a/src/drivers/distance_sensor/pga460/pga460.h
+++ b/src/drivers/distance_sensor/pga460/pga460.h
@@ -129,13 +129,13 @@
 #define USER_DATA18     0x0     //reg addr      0x11
 #define USER_DATA19     0x0     //reg addr      0x12
 #define USER_DATA20     0x0     //reg addr      0x13
-#define TVGAIN0 0x9D            //reg addr      0x14
-#define TVGAIN1 0xBD            //reg addr      0x15
-#define TVGAIN2 0xEF            //reg addr      0x16
-#define TVGAIN3 0x31            //reg addr      0x17
-#define TVGAIN4 0x48            //reg addr      0x18
-#define TVGAIN5 0x67            //reg addr      0x19
-#define TVGAIN6 0xAC            //reg addr      0x1A
+#define TVGAIN0         0x9D    //reg addr      0x14
+#define TVGAIN1         0xBD    //reg addr      0x15
+#define TVGAIN2         0xEF    //reg addr      0x16
+#define TVGAIN3         0x31    //reg addr      0x17
+#define TVGAIN4         0x48    //reg addr      0x18
+#define TVGAIN5         0x67    //reg addr      0x19
+#define TVGAIN6         0xAC    //reg addr      0x1A
 #define INIT_GAIN       0x40    //reg addr      0x1B
 #define FREQUENCY   (uint8_t)(5*(_resonant_frequency - 30.0f))       //reg addr      0x1C
 #define DEADTIME        0xF0    //reg addr      0x1D
@@ -152,7 +152,7 @@
 #define TEMP_TRIM       0x0     //reg addr      0x28
 #define P1_GAIN_CTRL    0x0     //reg addr      0x29
 #define P2_GAIN_CTRL    0x8     //reg addr      0x2A
-#define EE_CRC  0x29            //reg addr      0x2B
+#define EE_CRC          0x29    //reg addr      0x2B
 
 // Register-based -- volatile
 #define EE_CNTRL        0x0     //reg addr      0x40
@@ -385,28 +385,28 @@ private:
 	void uORB_publish_results(const float dist);
 
 	/** @orb_advert_t orb_advert_t uORB advertisement topic. */
-	orb_advert_t _distance_sensor_topic = nullptr;
+	orb_advert_t _distance_sensor_topic{nullptr};
 
 	/** @param _fd Returns the file descriptor from px4_open(). */
-	int _fd = -1;
+	int _fd{-1};
 
 	/** @param _port Stores the port name. */
-	char _port[20];
+	char _port[20] {};
 
 	/** @param _previous_report_distance The previous reported sensor distance. */
-	float _previous_report_distance = 0;
+	float _previous_report_distance{0};
 
 	/** @param _previous_valid_report_distance The previous valid reported sensor distance. */
-	float _previous_valid_report_distance = 0;
+	float _previous_valid_report_distance{0};
 
 	/** @param _resonant_frequency The sensor resonant (transmit) frequency. */
-	float _resonant_frequency = 41.0f;
+	float _resonant_frequency{41.0f};
 
 	/** @param _mode_long_range Flag for long range mode. If false, sensor is in short range mode. */
-	uint8_t _ranging_mode = MODE_SHORT_RANGE;
+	uint8_t _ranging_mode{MODE_SHORT_RANGE};
 
 	/** @param _start_loop The starting value for the loop time of the main loop. */
-	uint64_t _start_loop = 0;
+	uint64_t _start_loop{0};
 };
 
 #endif


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR only migrates the pga460 driver to uniform initialization style and formats whitespace.

**Describe your preferred solution**
Standardizing all of the distance sensor driver variable initialization, method ordering and general style will allow for future inheritance structure work to be performed on the distance sensor driver classes.

This PR is additional work to promote #9279 in conjunction with #11853, #11857, #11858 and remaining distance sensor driver work.

**Describe possible alternatives**
All of the distance sensor driver work could be accomplished in one massive PR, but breaking up work in each driver should minimize risk and reduce review effort.

**Additional context**
See #9279, #11853, #11857, #1858, #11859.

Please let me know if you have any questions on this PR. Thanks!

-Mark

@dakejahl  This driver is fantastic!  I would love to see all the other serial device driver methods modeled after your methods here. Nice work!
