### PR TITLE
Collision prevention improvements

### DIFF
--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -158,10 +158,10 @@ void CollisionPrevention::modifySetpoint(Vector2f &original_setpoint, const floa
 	_move_constraints_y_normalized(1) = math::constrain(_move_constraints_y_normalized(1), 0.f, 1.f);
 
 	//apply the velocity reductions to form velocity limits
-	_move_constraints_x(0) = max_speed * (1 - _move_constraints_x_normalized(0));
-	_move_constraints_x(1) = max_speed * (1 - _move_constraints_x_normalized(1));
-	_move_constraints_y(0) = max_speed * (1 - _move_constraints_y_normalized(0));
-	_move_constraints_y(1) = max_speed * (1 - _move_constraints_y_normalized(1));
+	_move_constraints_x(0) = max_speed * (1.f - _move_constraints_x_normalized(0));
+	_move_constraints_x(1) = max_speed * (1.f - _move_constraints_x_normalized(1));
+	_move_constraints_y(0) = max_speed * (1.f - _move_constraints_y_normalized(0));
+	_move_constraints_y(1) = max_speed * (1.f - _move_constraints_y_normalized(1));
 
 	//constrain the velocity setpoint to respect the velocity limits
 	Vector2f new_setpoint;
@@ -169,10 +169,10 @@ void CollisionPrevention::modifySetpoint(Vector2f &original_setpoint, const floa
 	new_setpoint(1) = math::constrain(original_setpoint(1), -_move_constraints_y(0), _move_constraints_y(1));
 
 	//warn user if collision prevention starts to interfere
-	bool currently_interfering = (new_setpoint(0) < original_setpoint(0) - 0.05 * max_speed
-				      || new_setpoint(0) > original_setpoint(0) + 0.05 * max_speed
-				      || new_setpoint(1) < original_setpoint(1) - 0.05 * max_speed
-				      || new_setpoint(1) > original_setpoint(1) + 0.05 * max_speed);
+	bool currently_interfering = (new_setpoint(0) < original_setpoint(0) - 0.05f * max_speed
+				      || new_setpoint(0) > original_setpoint(0) + 0.05f * max_speed
+				      || new_setpoint(1) < original_setpoint(1) - 0.05f * max_speed
+				      || new_setpoint(1) > original_setpoint(1) + 0.05f * max_speed);
 
 	if (currently_interfering && (currently_interfering != _interfering)) {
 		mavlink_log_critical(&_mavlink_log_pub, "Collision Warning");

--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -162,9 +162,10 @@ void CollisionPrevention::modifySetpoint(Vector2f &original_setpoint, const floa
 	new_setpoint(1) = math::constrain(original_setpoint(1), -_move_constraints_y(0), _move_constraints_y(1));
 
 	//warn user if collision prevention starts to interfere
-	bool currently_interfering = (new_setpoint(0) < 0.95f * original_setpoint(0)
-				      || new_setpoint(0) > 1.05f * original_setpoint(0) || new_setpoint(1) < 0.95f * original_setpoint(1)
-				      || new_setpoint(1) > 1.05f * original_setpoint(1));
+	bool currently_interfering = (new_setpoint(0) < original_setpoint(0) - 0.05 * max_speed
+				      || new_setpoint(0) > original_setpoint(0) + 0.05 * max_speed
+				      || new_setpoint(1) < original_setpoint(1) - 0.05 * max_speed
+				      || new_setpoint(1) > original_setpoint(1) + 0.05 * max_speed);
 
 	if (currently_interfering && (currently_interfering != _interfering)) {
 		mavlink_log_critical(&_mavlink_log_pub, "Collision Warning");

--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -150,6 +150,13 @@ void CollisionPrevention::modifySetpoint(Vector2f &original_setpoint, const floa
 	//calculate movement constraints based on range data
 	update_range_constraints();
 
+	//clamp constraints to be in [0,1]. Constraints > 1 occur if the vehicle is closer than _param_mpc_col_prev_d to the obstacle.
+	//they would lead to the vehicle being pushed back from the obstacle which we do not yet support
+	_move_constraints_x_normalized(0) = math::constrain(_move_constraints_x_normalized(0), 0.f, 1.f);
+	_move_constraints_x_normalized(1) = math::constrain(_move_constraints_x_normalized(1), 0.f, 1.f);
+	_move_constraints_y_normalized(0) = math::constrain(_move_constraints_y_normalized(0), 0.f, 1.f);
+	_move_constraints_y_normalized(1) = math::constrain(_move_constraints_y_normalized(1), 0.f, 1.f);
+
 	//apply the velocity reductions to form velocity limits
 	_move_constraints_x(0) = max_speed * (1 - _move_constraints_x_normalized(0));
 	_move_constraints_x(1) = max_speed * (1 - _move_constraints_x_normalized(1));

--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -149,31 +149,12 @@ void CollisionPrevention::modifySetpoint(Vector2f &original_setpoint, const floa
 
 	//calculate movement constraints based on range data
 	update_range_constraints();
-	_move_constraints_x = _move_constraints_x_normalized;
-	_move_constraints_y = _move_constraints_y_normalized;
-
-	// calculate the maximum velocity along x,y axis when moving in the demanded direction
-	float vel_mag = original_setpoint.norm();
-	float v_max_x, v_max_y;
-
-	if (vel_mag > 0.0f) {
-		v_max_x = abs(max_speed / vel_mag * original_setpoint(0));
-		v_max_y = abs(max_speed / vel_mag * original_setpoint(1));
-
-	} else {
-		v_max_x = 0.0f;
-		v_max_y = 0.0f;
-	}
-
-	//scale the velocity reductions with the maximum possible velocity along the respective axis
-	_move_constraints_x *= v_max_x;
-	_move_constraints_y *= v_max_y;
 
 	//apply the velocity reductions to form velocity limits
-	_move_constraints_x(0) = v_max_x - _move_constraints_x(0);
-	_move_constraints_x(1) = v_max_x - _move_constraints_x(1);
-	_move_constraints_y(0) = v_max_y - _move_constraints_y(0);
-	_move_constraints_y(1) = v_max_y - _move_constraints_y(1);
+	_move_constraints_x(0) = max_speed * (1 - _move_constraints_x_normalized(0));
+	_move_constraints_x(1) = max_speed * (1 - _move_constraints_x_normalized(1));
+	_move_constraints_y(0) = max_speed * (1 - _move_constraints_y_normalized(0));
+	_move_constraints_y(1) = max_speed * (1 - _move_constraints_y_normalized(1));
 
 	//constrain the velocity setpoint to respect the velocity limits
 	Vector2f new_setpoint;

--- a/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -134,7 +134,7 @@ void FlightTaskManualPosition::_scaleSticks()
 
 	// collision prevention
 	if (_collision_prevention.is_active()) {
-		_collision_prevention.modifySetpoint(vel_sp_xy, _constraints.speed_xy);
+		_collision_prevention.modifySetpoint(vel_sp_xy, _velocity_scale);
 	}
 
 	_velocity_setpoint(0) = vel_sp_xy(0);


### PR DESCRIPTION
This fixes the following issues in the collision prevention library:

There were warnings of collision prevention interference, even when there was none, in the case of near zero stick input due to floating errors. This was fixed by changing the warning output criterion.

Constraints > 1 are disabled for the moment. They lead to the drone moving in the opposite direction of the stick input, which is counter intuitive. Also as we do not have sensors to the back it might be dangerous.

We noticed that even if there are no obstacles present, the collision prevention interferes with the original setpoint (see plots below). This was due to a misalignment of the use of the speed_xy parameter. In the position controller it is used on each axis independently (meaning the maximum allowed absolute speed is root(2)*speed_xy), whereas the collision prevention used it as a maximum absolute speed. Therefore the collision prevention cropped the stick input in some cases.


BEFORE:

![before](https://user-images.githubusercontent.com/25756842/56214282-df887d80-605d-11e9-81c2-e4af696d0f95.png)

AFTER:
![after](https://user-images.githubusercontent.com/25756842/56214291-e1524100-605d-11e9-91a4-e4268d118e91.png)



