### PR TITLE
Bmi055 temperature fix

### DIFF
--- a/src/drivers/imu/bmi055/BMI055_accel.cpp
+++ b/src/drivers/imu/bmi055/BMI055_accel.cpp
@@ -510,7 +510,7 @@ BMI055_accel::measure()
 {
 	perf_count(_measure_interval);
 
-	uint8_t index = 0, accel_data[7];
+	uint8_t index = 0, accel_data[8];
 	uint16_t lsb, msb, msblsb;
 	uint8_t status_x, status_y, status_z;
 
@@ -559,6 +559,9 @@ BMI055_accel::measure()
 	msb = (uint16_t)accel_data[index++];
 	msblsb = (msb << 8) | lsb;
 	report.accel_z = ((int16_t)msblsb >> 4); /* Data in Z axis */
+	
+	// Byte 
+	report.temp = accel_data[index];
 
 	// Checking the status of new data
 	if ((!status_x) || (!status_y) || (!status_z)) {

--- a/src/drivers/imu/bmi055/BMI055_accel.cpp
+++ b/src/drivers/imu/bmi055/BMI055_accel.cpp
@@ -571,7 +571,7 @@ BMI055_accel::measure()
 
 	_got_duplicate = false;
 
-	uint8_t temp = read_reg(BMI055_ACC_TEMP);
+	int8_t temp = read_reg(BMI055_ACC_TEMP);
 	report.temp = temp;
 
 	if (report.accel_x == 0 &&
@@ -649,9 +649,13 @@ BMI055_accel::measure()
 
 	arb.scaling = _accel_range_scale;
 
-	_last_temperature = 23 + report.temp * 1.0f / 512.0f;
-
+	/*
+	 * Temperature is reported as Eight-bit 2’s complement sensor temperature value 
+	 * with 0.5 °C/LSB sensitivity and an offset of 23.0 °C
+	 */
+	_last_temperature = (report.temp * 0.5f) + 23.0f;
 	arb.temperature = _last_temperature;
+
 	arb.device_id = _device_id.devid;
 
 	_accel_reports->force(&arb);

--- a/src/drivers/imu/bmi055/BMI055_accel.cpp
+++ b/src/drivers/imu/bmi055/BMI055_accel.cpp
@@ -650,7 +650,7 @@ BMI055_accel::measure()
 	arb.scaling = _accel_range_scale;
 
 	/*
-	 * Temperature is reported as Eight-bit 2’s complement sensor temperature value 
+	 * Temperature is reported as Eight-bit 2’s complement sensor temperature value
 	 * with 0.5 °C/LSB sensitivity and an offset of 23.0 °C
 	 */
 	_last_temperature = (report.temp * 0.5f) + 23.0f;

--- a/src/drivers/imu/bmi055/BMI055_accel.cpp
+++ b/src/drivers/imu/bmi055/BMI055_accel.cpp
@@ -523,7 +523,7 @@ BMI055_accel::measure()
 		int16_t     accel_x;
 		int16_t     accel_y;
 		int16_t     accel_z;
-		int16_t     temp;
+		int8_t     temp;
 	} report;
 
 	/* start measuring */
@@ -570,9 +570,6 @@ BMI055_accel::measure()
 
 
 	_got_duplicate = false;
-
-	int8_t temp = read_reg(BMI055_ACC_TEMP);
-	report.temp = temp;
 
 	if (report.accel_x == 0 &&
 	    report.accel_y == 0 &&

--- a/src/drivers/imu/bmi055/BMI055_accel.cpp
+++ b/src/drivers/imu/bmi055/BMI055_accel.cpp
@@ -559,8 +559,8 @@ BMI055_accel::measure()
 	msb = (uint16_t)accel_data[index++];
 	msblsb = (msb << 8) | lsb;
 	report.accel_z = ((int16_t)msblsb >> 4); /* Data in Z axis */
-	
-	// Byte 
+
+	// Byte
 	report.temp = accel_data[index];
 
 	// Checking the status of new data

--- a/src/drivers/imu/bmi055/BMI055_gyro.cpp
+++ b/src/drivers/imu/bmi055/BMI055_gyro.cpp
@@ -648,7 +648,7 @@ BMI055_gyro::measure()
 	grb.scaling = _gyro_range_scale;
 
 	/*
-	 * Temperature is reported as Eight-bit 2’s complement sensor temperature value 
+	 * Temperature is reported as Eight-bit 2’s complement sensor temperature value
 	 * with 0.5 °C/LSB sensitivity and an offset of 23.0 °C
 	 */
 	_last_temperature = (report.temp * 0.5f) + 23.0f;

--- a/src/drivers/imu/bmi055/BMI055_gyro.cpp
+++ b/src/drivers/imu/bmi055/BMI055_gyro.cpp
@@ -562,8 +562,7 @@ BMI055_gyro::measure()
 
 	check_registers();
 
-	uint8_t temp = read_reg(BMI055_ACC_TEMP);
-
+	int8_t temp = read_reg(BMI055_ACC_TEMP);
 	report.temp = temp;
 
 	report.gyro_x = bmi_gyroreport.gyro_x;
@@ -648,7 +647,13 @@ BMI055_gyro::measure()
 
 	grb.scaling = _gyro_range_scale;
 
+	/*
+	 * Temperature is reported as Eight-bit 2’s complement sensor temperature value 
+	 * with 0.5 °C/LSB sensitivity and an offset of 23.0 °C
+	 */
+	_last_temperature = (report.temp * 0.5f) + 23.0f;
 	grb.temperature = _last_temperature;
+
 	grb.device_id = _device_id.devid;
 
 	_gyro_reports->force(&grb);


### PR DESCRIPTION
Fixes issue #11854 
Discussion of this bug is here:
http://discuss.px4.io/t/pixhawk-4-temperature-compensation-failure

Problem- the BMI055 IMU driver was not reporting temperature correctly, making it impossible to perform temperature compensation on this sensor.

Fixed it by:
 -modified the register read value to be stored in an int8_t instead of uint8_t, in order to preserve the sign for values less than zero
 -Perform scaling and offset according to the BMI055 datasheet before populating the report buffer

Test performed in an industrial environmental chamber run from -40 C to +60 C.  Results now match the temperature reported by the other IMU (ICM20689) and the temperature compensation script runs without errors.
