### PR TITLE
ak09916: fail if device is not found

### DIFF
--- a/src/drivers/magnetometer/ak09916/ak09916.hpp
+++ b/src/drivers/magnetometer/ak09916/ak09916.hpp
@@ -139,6 +139,7 @@ public:
 	void read_block(uint8_t reg, uint8_t *val, uint8_t count);
 
 	int reset(void);
+	int probe(void);
 	int setup(void);
 	void print_info(void);
 	int setup_master_i2c(void);


### PR DESCRIPTION
This should fix the case where the driver initializes even though the device is not found. The change changes the behavior to return ERROR if the whoami call fails several times instead of returning OK.

Also, the reset() and thus probe() calls are moved before initializing
the ringbuffer and device name.

Could fix #11844.

This only compiles, @AndreasAntener could you test this please?