### PR TITLE
Cherry pick the `src/modules/land_detector/` directory work from PR #9756

### DIFF
--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -39,8 +39,6 @@
  * @author Julian Oes <julian@oes.ch>
  */
 
-#include <matrix/math.hpp>
-
 #include "FixedwingLandDetector.h"
 
 namespace land_detector
@@ -55,35 +53,20 @@ FixedwingLandDetector::FixedwingLandDetector()
 
 void FixedwingLandDetector::_update_topics()
 {
+	LandDetector::_update_topics();
 	_airspeed_sub.update(&_airspeed);
-	_vehicle_acceleration_sub.update(&_vehicle_acceleration);
-	_vehicle_local_position_sub.update(&_vehicle_local_position);
-}
-
-void FixedwingLandDetector::_update_params()
-{
-	// check for parameter updates
-	if (_parameter_update_sub.updated()) {
-		// clear update
-		parameter_update_s pupdate;
-		_parameter_update_sub.copy(&pupdate);
-
-		// update parameters from storage
-		_update_params();
-	}
 }
 
 float FixedwingLandDetector::_get_max_altitude()
 {
-	// TODO
-	// This means no altitude limit as the limit
-	// is always current position plus 10000 meters
+	// TODO: This means no altitude limit as the limit
+	// is always current position plus 10000 meters.
 	return roundf(-_vehicle_local_position.z + 10000);
 }
 
 bool FixedwingLandDetector::_get_landed_state()
 {
-	// only trigger flight conditions if we are armed
+	// Only trigger flight conditions if we are armed.
 	if (!_actuator_armed.armed) {
 		return true;
 	}
@@ -116,11 +99,11 @@ bool FixedwingLandDetector::_get_landed_state()
 
 		_xy_accel_filtered = _xy_accel_filtered * 0.8f + acc_hor * 0.18f;
 
-		// crude land detector for fixedwing
-		landDetected = _xy_accel_filtered       < _param_lndfw_xyaccel_max.get()
-			       && _airspeed_filtered    < _param_lndfw_airspd.get()
+		// Crude land detector for fixedwing.
+		landDetected = _airspeed_filtered       < _param_lndfw_airspd.get()
 			       && _velocity_xy_filtered < _param_lndfw_vel_xy_max.get()
-			       && _velocity_z_filtered  < _param_lndfw_vel_z_max.get();
+			       && _velocity_z_filtered  < _param_lndfw_vel_z_max.get()
+			       && _xy_accel_filtered    < _param_lndfw_xyaccel_max.get();
 
 	} else {
 		// Control state topic has timed out and we need to assume we're landed.

--- a/src/modules/land_detector/FixedwingLandDetector.h
+++ b/src/modules/land_detector/FixedwingLandDetector.h
@@ -42,10 +42,9 @@
 
 #pragma once
 
+#include <matrix/math.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/airspeed.h>
-#include <uORB/topics/vehicle_acceleration.h>
-#include <uORB/topics/vehicle_local_position.h>
 
 #include "LandDetector.h"
 
@@ -60,11 +59,12 @@ public:
 	FixedwingLandDetector();
 
 protected:
-	void _update_params() override;
-	void _update_topics() override;
 
 	bool _get_landed_state() override;
+
 	float _get_max_altitude() override;
+
+	void _update_topics() override;
 
 private:
 
@@ -73,13 +73,8 @@ private:
 	static constexpr hrt_abstime FLYING_TRIGGER_TIME_US = 0_us;
 
 	uORB::Subscription _airspeed_sub{ORB_ID(airspeed)};
-	uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
-	uORB::Subscription _vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
-	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
 
 	airspeed_s _airspeed{};
-	vehicle_acceleration_s _vehicle_acceleration{};
-	vehicle_local_position_s _vehicle_local_position{};
 
 	float _airspeed_filtered{0.0f};
 	float _velocity_xy_filtered{0.0f};
@@ -93,7 +88,6 @@ private:
 		(ParamFloat<px4::params::LNDFW_VEL_XY_MAX>) _param_lndfw_vel_xy_max,
 		(ParamFloat<px4::params::LNDFW_VEL_Z_MAX>)  _param_lndfw_vel_z_max
 	);
-
 };
 
 } // namespace land_detector

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -86,17 +86,19 @@ MulticopterLandDetector::MulticopterLandDetector()
 
 void MulticopterLandDetector::_update_topics()
 {
+	LandDetector::_update_topics();
+
 	_actuator_controls_sub.update(&_actuator_controls);
 	_battery_sub.update(&_battery_status);
-	_vehicle_acceleration_sub.update(&_vehicle_acceleration);
 	_vehicle_angular_velocity_sub.update(&_vehicle_angular_velocity);
 	_vehicle_control_mode_sub.update(&_vehicle_control_mode);
-	_vehicle_local_position_sub.update(&_vehicle_local_position);
 	_vehicle_local_position_setpoint_sub.update(&_vehicle_local_position_setpoint);
 }
 
-void MulticopterLandDetector::_update_params()
+void MulticopterLandDetector::_update_params(const bool force)
 {
+	LandDetector::_update_params(force);
+
 	_freefall_hysteresis.set_hysteresis_time_from(false, (hrt_abstime)(1e6f * _param_lndmc_ffall_ttri.get()));
 
 	param_get(_paramHandle.minThrottle, &_params.minThrottle);

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -67,7 +67,7 @@ public:
 	MulticopterLandDetector();
 
 protected:
-	void _update_params() override;
+	void _update_params(const bool force = false) override;
 	void _update_topics() override;
 
 	bool _get_landed_state() override;
@@ -79,7 +79,7 @@ protected:
 	float _get_max_altitude() override;
 private:
 
-	/* get control mode dependent pilot throttle threshold with which we should quit landed state and take off */
+	/** Get control mode dependent pilot throttle threshold with which we should quit landed state and take off. */
 	float _get_takeoff_throttle();
 
 	bool _has_low_thrust();
@@ -100,9 +100,7 @@ private:
 	/** Time interval in us in which wider acceptance thresholds are used after landed. */
 	static constexpr hrt_abstime LAND_DETECTOR_LAND_PHASE_TIME_US = 2_s;
 
-	/**
-	* @brief Handles for interesting parameters
-	**/
+	/** Handles for interesting parameters. **/
 	struct {
 		param_t minThrottle;
 		param_t hoverThrottle;
@@ -127,10 +125,8 @@ private:
 
 	actuator_controls_s               _actuator_controls {};
 	battery_status_s                  _battery_status {};
-	vehicle_acceleration_s            _vehicle_acceleration{};
 	vehicle_angular_velocity_s        _vehicle_angular_velocity{};
 	vehicle_control_mode_s            _vehicle_control_mode {};
-	vehicle_local_position_s          _vehicle_local_position {};
 	vehicle_local_position_setpoint_s _vehicle_local_position_setpoint {};
 
 	hrt_abstime _min_trust_start{0};	///< timestamp when minimum trust was applied first

--- a/src/modules/land_detector/RoverLandDetector.cpp
+++ b/src/modules/land_detector/RoverLandDetector.cpp
@@ -44,14 +44,6 @@
 namespace land_detector
 {
 
-void RoverLandDetector::_update_topics()
-{
-}
-
-void RoverLandDetector::_update_params()
-{
-}
-
 bool RoverLandDetector::_get_ground_contact_state()
 {
 	return true;
@@ -64,11 +56,6 @@ bool RoverLandDetector::_get_landed_state()
 	}
 
 	return false;
-}
-
-float RoverLandDetector::_get_max_altitude()
-{
-	return 0.0f;
 }
 
 } // namespace land_detector

--- a/src/modules/land_detector/RoverLandDetector.h
+++ b/src/modules/land_detector/RoverLandDetector.h
@@ -41,8 +41,6 @@
 
 #pragma once
 
-#include <uORB/topics/airspeed.h>
-
 #include "LandDetector.h"
 
 namespace land_detector
@@ -54,18 +52,11 @@ public:
 	RoverLandDetector() = default;
 
 protected:
-	virtual void _update_params() override;
-
-	virtual void _update_topics() override;
-
-	virtual bool _get_landed_state() override;
-
-	virtual bool  _get_ground_contact_state() override;
-
-	virtual float _get_max_altitude() override;
+	bool _get_ground_contact_state() override;
+	bool _get_landed_state() override;
 
 private:
-};
 
+};
 
 } // namespace land_detector


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR captures the remaining `src/modules/land_detector/` directory changes from PR #9756 to simplify that PR.

The changes in the `land_detector` directory are fairly straightforward:
 - Break out common features of the child class functionality and move to the `LandDetector::initialize_topics()` and `LandDetector::update_topics()` parent class methods.
 - Standardize class member variable naming, uniform initialization, and whitespace formatting across all class implementations in the land_detector module. 

This PR primarily aims to reduce the scope of PR #9756.

**Describe possible alternatives**
Keeping the current implementations is certainly a viable option; please let me know if that is the preference!

**Additional context**
See PR #9756.

Much of the original work proposed in this PR has already been carried out by #12209, #12677, #12702, #13079, and #13077.

Thanks!

-Mark
