### PR TITLE
Get full sensor status even if only subset has changed when composing…

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -569,6 +569,17 @@ protected:
 		const bool updated_battery = _battery_status_sub->update(&_battery_status_timestamp, &battery_status);
 
 		if (updated_status || updated_battery || updated_cpuload) {
+
+			if (!updated_status) {
+				_status_sub->update(&status);
+			}
+			if (!updated_battery) {
+				_battery_status_sub->update(&battery_status);
+			}
+			if (!updated_cpuload) {
+				_cpuload_sub->update(&cpuload);
+			}
+
 			mavlink_sys_status_t msg = {};
 
 			msg.onboard_control_sensors_present = status.onboard_control_sensors_present;


### PR DESCRIPTION
… SYS_STATUS message
This fixes the genration of SYS_STATUS message after the changes in MavlinkOrbSubscription::update(uint64_t *time, void *data) introduced by https://github.com/PX4/Firmware/pull/9894
SYS_SATUS message gather tlemetry from 3 datasets, solution is to force getting other telemetry data sets even if only one set has changed.

This should be revisited if MavlinkOrbSubscription::update(uint64_t *time, void *data) gets changed again.