### PR TITLE
px_uploader.py: fix version check

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -728,7 +728,7 @@ def main():
     # We need to check for pyserial because the import itself doesn't
     # seem to fail, at least not on macOS.
     try:
-        if serial.__version__:
+        if serial.__version__ or serial.VERSION:
             pass
     except:
         print("Error: pyserial not installed!")


### PR DESCRIPTION
Presumably older versions of pyserial do not implement __version__ but only VERSION, so we need to check for that as well.

Fixes #11885.