### PR TITLE
Fix memory errors found using Valgrind

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -3135,7 +3135,7 @@ protected:
 
 		if (control_mode.flag_control_position_enabled) {
 
-			position_setpoint_triplet_s pos_sp_triplet;
+			position_setpoint_triplet_s pos_sp_triplet = {};
 			_pos_sp_triplet_sub->update(&pos_sp_triplet);
 
 			if (pos_sp_triplet.timestamp > 0 && pos_sp_triplet.current.valid

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -62,6 +62,8 @@ int32_t MavlinkMissionManager::_current_seq = 0;
 bool MavlinkMissionManager::_transfer_in_progress = false;
 constexpr uint16_t MavlinkMissionManager::MAX_COUNT[];
 uint16_t MavlinkMissionManager::_geofence_update_counter = 0;
+uint16_t MavlinkMissionManager::_safepoint_update_counter = 0;
+
 
 #define CHECK_SYSID_COMPID_MISSION(_msg)		(_msg.target_system == mavlink_system.sysid && \
 		((_msg.target_component == mavlink_system.compid) || \
@@ -236,6 +238,7 @@ MavlinkMissionManager::update_safepoint_count(unsigned count)
 {
 	mission_stats_entry_s stats;
 	stats.num_items = count;
+	stats.update_counter = ++_safepoint_update_counter;
 
 	/* update stats in dataman */
 	int res = dm_write(DM_KEY_SAFE_POINTS, 0, DM_PERSIST_POWER_ON_RESET, &stats, sizeof(mission_stats_entry_s));

--- a/src/modules/mavlink/mavlink_mission.cpp
+++ b/src/modules/mavlink/mavlink_mission.cpp
@@ -158,7 +158,8 @@ MavlinkMissionManager::load_safepoint_stats()
 int
 MavlinkMissionManager::update_active_mission(dm_item_t dataman_id, uint16_t count, int32_t seq)
 {
-	mission_s mission;
+	// We want to make sure the whole struct is initialized including padding before getting written by dataman.
+	mission_s mission {};
 	mission.timestamp = hrt_absolute_time();
 	mission.dataman_id = dataman_id;
 	mission.count = count;

--- a/src/modules/mavlink/mavlink_mission.h
+++ b/src/modules/mavlink/mavlink_mission.h
@@ -130,6 +130,7 @@ private:
 	orb_advert_t		_offboard_mission_pub{nullptr};
 
 	static uint16_t		_geofence_update_counter;
+	static uint16_t		_safepoint_update_counter;
 	bool			_geofence_locked{false};		///< if true, we currently hold the dm_lock for the geofence (transaction in progress)
 
 	MavlinkRateLimiter	_slow_rate_limiter{100 * 1000};		///< Rate limit sending of the current WP sequence to 10 Hz

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -676,7 +676,7 @@ MulticopterAttitudeControl::publish_rates_setpoint()
 void
 MulticopterAttitudeControl::publish_rate_controller_status()
 {
-	rate_ctrl_status_s rate_ctrl_status;
+	rate_ctrl_status_s rate_ctrl_status = {};
 	rate_ctrl_status.timestamp = hrt_absolute_time();
 	rate_ctrl_status.rollspeed = _rates_prev(0);
 	rate_ctrl_status.pitchspeed = _rates_prev(1);

--- a/src/modules/navigator/navigator.h
+++ b/src/modules/navigator/navigator.h
@@ -291,6 +291,27 @@ public:
 	bool		force_vtol();
 
 private:
+	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::NAV_LOITER_RAD>) _param_nav_loiter_rad,	/**< loiter radius for fixedwing */
+		(ParamFloat<px4::params::NAV_ACC_RAD>) _param_nav_acc_rad,	/**< acceptance for takeoff */
+		(ParamFloat<px4::params::NAV_FW_ALT_RAD>)
+		_param_nav_fw_alt_rad,	/**< acceptance radius for fixedwing altitude */
+		(ParamFloat<px4::params::NAV_FW_ALTL_RAD>)
+		_param_nav_fw_altl_rad,	/**< acceptance radius for fixedwing altitude before landing*/
+		(ParamFloat<px4::params::NAV_MC_ALT_RAD>)
+		_param_nav_mc_alt_rad,	/**< acceptance radius for multicopter altitude */
+		(ParamInt<px4::params::NAV_FORCE_VT>) _param_nav_force_vt,	/**< acceptance radius for multicopter altitude */
+		(ParamInt<px4::params::NAV_TRAFF_AVOID>) _param_nav_traff_avoid,	/**< avoiding other aircraft is enabled */
+
+		// non-navigator parameters
+		// Mission (MIS_*)
+		(ParamFloat<px4::params::MIS_LTRMIN_ALT>) _param_mis_ltrmin_alt,
+		(ParamFloat<px4::params::MIS_TAKEOFF_ALT>) _param_mis_takeoff_alt,
+		(ParamBool<px4::params::MIS_TAKEOFF_REQ>) _param_mis_takeoff_req,
+		(ParamFloat<px4::params::MIS_YAW_TMT>) _param_mis_yaw_tmt,
+		(ParamFloat<px4::params::MIS_YAW_ERR>) _param_mis_yaw_err
+	)
+
 	int		_global_pos_sub{-1};		/**< global position subscription */
 	int		_gps_pos_sub{-1};		/**< gps position subscription */
 	int		_home_pos_sub{-1};		/**< home position subscription */
@@ -355,27 +376,6 @@ private:
 	FollowTarget	_follow_target;
 
 	NavigatorMode *_navigation_mode_array[NAVIGATOR_MODE_ARRAY_SIZE];	/**< array of navigation modes */
-
-	DEFINE_PARAMETERS(
-		(ParamFloat<px4::params::NAV_LOITER_RAD>) _param_nav_loiter_rad,	/**< loiter radius for fixedwing */
-		(ParamFloat<px4::params::NAV_ACC_RAD>) _param_nav_acc_rad,	/**< acceptance for takeoff */
-		(ParamFloat<px4::params::NAV_FW_ALT_RAD>)
-		_param_nav_fw_alt_rad,	/**< acceptance radius for fixedwing altitude */
-		(ParamFloat<px4::params::NAV_FW_ALTL_RAD>)
-		_param_nav_fw_altl_rad,	/**< acceptance radius for fixedwing altitude before landing*/
-		(ParamFloat<px4::params::NAV_MC_ALT_RAD>)
-		_param_nav_mc_alt_rad,	/**< acceptance radius for multicopter altitude */
-		(ParamInt<px4::params::NAV_FORCE_VT>) _param_nav_force_vt,	/**< acceptance radius for multicopter altitude */
-		(ParamInt<px4::params::NAV_TRAFF_AVOID>) _param_nav_traff_avoid,	/**< avoiding other aircraft is enabled */
-
-		// non-navigator parameters
-		// Mission (MIS_*)
-		(ParamFloat<px4::params::MIS_LTRMIN_ALT>) _param_mis_ltrmin_alt,
-		(ParamFloat<px4::params::MIS_TAKEOFF_ALT>) _param_mis_takeoff_alt,
-		(ParamBool<px4::params::MIS_TAKEOFF_REQ>) _param_mis_takeoff_req,
-		(ParamFloat<px4::params::MIS_YAW_TMT>) _param_mis_yaw_tmt,
-		(ParamFloat<px4::params::MIS_YAW_ERR>) _param_mis_yaw_err
-	)
 
 	param_t _handle_back_trans_dec_mss{PARAM_INVALID};
 	param_t _handle_reverse_delay{PARAM_INVALID};


### PR DESCRIPTION
These were discovered by running `make px4_sitl gazebo___valgrind`

Some small initialization issues fixed to start with, there are still a few outstanding issues.

Outstanding issues

- [x]  `_param_nav_loiter_rad` is uninitialized

```
==2112== Conditional jump or move depends on uninitialised value(s)
==2112==    at 0x5119F5: MissionBlock::mission_item_to_position_setpoint(mission_item_s const&, position_setpoint_s*) (mission_block.cpp:521)
==2112==    by 0x509041: RTL::set_rtl_item() (rtl.cpp:298)
==2112==    by 0x5050C1: NavigatorMode::run(bool) (navigator_mode.cpp:62)
==2112==    by 0x503D2C: Navigator::run() (navigator_main.cpp:765)
==2112==    by 0x502C54: ModuleBase<Navigator>::run_trampoline(int, char**) (px4_module.h:182)
==2112==    by 0x585B9C: entry_adapter(void*) (px4_posix_tasks.cpp:105)
==2112==    by 0x4E416B9: start_thread (pthread_create.c:333)
==2112==    by 0x5BF541C: clone (clone.S:109)
==2112==  Uninitialised value was created by a heap allocation
==2112==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2112==    by 0x502BFA: Navigator::instantiate(int, char**) (navigator_main.cpp:817)
==2112==    by 0x502C3A: ModuleBase<Navigator>::run_trampoline(int, char**) (px4_module.h:178)
==2112==    by 0x585B9C: entry_adapter(void*) (px4_posix_tasks.cpp:105)
==2112==    by 0x4E416B9: start_thread (pthread_create.c:333)
==2112==    by 0x5BF541C: clone (clone.S:109)
```

- [ ] Something in logging baro data
```
==2112== Thread 25 log_writer_file:
==2112== Syscall param write(buf) points to uninitialised byte(s)
==2112==    at 0x4E4A4BD: ??? (syscall-template.S:84)
==2112==    by 0x49D823: write_to_file (log_writer_file.cpp:474)
==2112==    by 0x49D823: px4::logger::LogWriterFile::run() (log_writer_file.cpp:242)
==2112==    by 0x49D9A3: px4::logger::LogWriterFile::run_helper(void*) (log_writer_file.cpp:181)
==2112==    by 0x4E416B9: start_thread (pthread_create.c:333)
==2112==    by 0x5BF541C: clone (clone.S:109)
==2112==  Address 0x6189adc is 103,596 bytes inside a block of size 1,024,000 alloc'd
==2112==    at 0x4C2E80F: operator new[](unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2112==    by 0x49D4E0: px4::logger::LogWriterFile::LogFileBuffer::start_log(char const*) (log_writer_file.cpp:444)
==2112==    by 0x49D53F: px4::logger::LogWriterFile::start_log(px4::logger::LogType, char const*) (log_writer_file.cpp:98)
==2112==    by 0x49B37F: px4::logger::Logger::start_log_file(px4::logger::LogType) (logger.cpp:1571)
==2112==    by 0x49C628: px4::logger::Logger::run() (logger.cpp:1010)
==2112==    by 0x499AC4: ModuleBase<px4::logger::Logger>::run_trampoline(int, char**) (px4_module.h:182)
==2112==    by 0x585B9C: entry_adapter(void*) (px4_posix_tasks.cpp:105)
==2112==    by 0x4E416B9: start_thread (pthread_create.c:333)
==2112==    by 0x5BF541C: clone (clone.S:109)
==2112==  Uninitialised value was created by a heap allocation
==2112==    at 0x4C2E80F: operator new[](unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2112==    by 0x5A4A22: allocate (RingBuffer.h:70)
==2112==    by 0x5A4A22: EstimatorInterface::setBaroData(unsigned long, float) (estimator_interface.cpp:263)
==2112==    by 0x4703FF: Ekf2::run() (ekf2_main.cpp:975)
==2112==    by 0x471642: ModuleBase<Ekf2>::run_trampoline(int, char**) (px4_module.h:182)
==2112==    by 0x585B9C: entry_adapter(void*) (px4_posix_tasks.cpp:105)
==2112==    by 0x4E416B9: start_thread (pthread_create.c:333)
==2112==    by 0x5BF541C: clone (clone.S:109)
==2112== 
```

- [x] Navigator acceptance radius not initialized
```
==4650== Thread 7 navigator:
==4650== Conditional jump or move depends on uninitialised value(s)
==4650==    at 0x511A27: MissionBlock::mission_item_to_position_setpoint(mission_item_s const&, position_setpoint_s*) (mission_block.cpp:524)
==4650==    by 0x50990B: Takeoff::set_takeoff_position() (takeoff.cpp:130)
==4650==    by 0x5050C1: NavigatorMode::run(bool) (navigator_mode.cpp:62)
==4650==    by 0x503D2C: Navigator::run() (navigator_main.cpp:765)
==4650==    by 0x502C54: ModuleBase<Navigator>::run_trampoline(int, char**) (px4_module.h:182)
==4650==    by 0x585B9C: entry_adapter(void*) (px4_posix_tasks.cpp:105)
==4650==    by 0x4E416B9: start_thread (pthread_create.c:333)
==4650==    by 0x5BF541C: clone (clone.S:109)
==4650==  Uninitialised value was created by a heap allocation
==4650==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4650==    by 0x502BFA: Navigator::instantiate(int, char**) (navigator_main.cpp:817)
==4650==    by 0x502C3A: ModuleBase<Navigator>::run_trampoline(int, char**) (px4_module.h:178)
==4650==    by 0x585B9C: entry_adapter(void*) (px4_posix_tasks.cpp:105)
==4650==    by 0x4E416B9: start_thread (pthread_create.c:333)
==4650==    by 0x5BF541C: clone (clone.S:109)
==4650== 
```

- [x] updating a mission in mid flight
```
==4650== Thread 8 dataman:
==4650== Syscall param write(buf) points to uninitialised byte(s)
==4650==    at 0x4E4A4BD: ??? (syscall-template.S:84)
==4650==    by 0x466CA7: _file_write(dm_item_t, unsigned int, dm_persitence_t, void const*, unsigned long) (dataman.cpp:530)
==4650==    by 0x4672E9: task_main(int, char**) (dataman.cpp:1384)
==4650==    by 0x585B9C: entry_adapter(void*) (px4_posix_tasks.cpp:105)
==4650==    by 0x4E416B9: start_thread (pthread_create.c:333)
==4650==    by 0x5BF541C: clone (clone.S:109)
==4650==  Address 0x404de53 is on thread 8's stack
==4650==  in frame #1, created by _file_write(dm_item_t, unsigned int, dm_persitence_t, void const*, unsigned long) (dataman.cpp:496)
==4650==  Uninitialised value was created by a stack allocation
==4650==    at 0x4DF710: MavlinkMissionManager::update_active_mission(dm_item_t, unsigned short, int) (mavlink_mission.cpp:158)
==4650== 
```