### PR TITLE
Pr vtol att controller new

### DIFF
--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -296,7 +296,8 @@ void
 FixedwingAttitudeControl::vehicle_manual_poll()
 {
 
-	if (_vcontrol_mode.flag_control_manual_enabled && !_vehicle_status.is_rotary_wing) {
+	if (_vcontrol_mode.flag_control_manual_enabled && !(_vehicle_status.is_rotary_wing ||
+	 		_vehicle_status.in_transition_mode)) {
 
 		// Always copy the new manual setpoint, even if it wasn't updated, to fill the _actuators with valid values
 		if (orb_copy(ORB_ID(manual_control_setpoint), _manual_sub, &_manual) == PX4_OK) {
@@ -426,7 +427,8 @@ FixedwingAttitudeControl::vehicle_status_poll()
 		// by the multicoper attitude controller. Therefore, modify the control mode to achieve rate
 		// control only
 		if (_vehicle_status.is_vtol) {
-			if (_vehicle_status.is_rotary_wing) {
+			if (_vehicle_status.is_rotary_wing && (!_vehicle_status.in_transition_mode ||
+					_parameters.vtol_type == vtol_type::TAILSITTER)) {
 				_vcontrol_mode.flag_control_attitude_enabled = false;
 				_vcontrol_mode.flag_control_manual_enabled = false;
 			}
@@ -617,7 +619,9 @@ void FixedwingAttitudeControl::run()
 			_att_sp.fw_control_yaw = _att_sp.fw_control_yaw && _vcontrol_mode.flag_control_auto_enabled;
 
 			/* lock integrator until control is started */
-			bool lock_integrator = !(_vcontrol_mode.flag_control_rates_enabled && !_vehicle_status.is_rotary_wing);
+			bool lock_integrator = !(_vcontrol_mode.flag_control_rates_enabled);
+			lock_integrator &= _vehicle_status.is_rotary_wing;
+			lock_integrator &= (!_vehicle_status.in_transition_mode || _parameters.vtol_type == vtol_type::TAILSITTER);
 
 			/* Simple handling of failsafe: deploy parachute if failsafe is on */
 			if (_vcontrol_mode.flag_control_termination_enabled) {
@@ -667,7 +671,7 @@ void FixedwingAttitudeControl::run()
 				 * or a multicopter (but not transitioning VTOL)
 				 */
 				if (_landed
-				    || (_vehicle_status.is_rotary_wing && !_vehicle_status.in_transition_mode)) {
+				    || (_vehicle_status.is_rotary_wing && !_vehicle_status.in_transition_mode)) { // VTOL TRANS new: change this?
 
 					_roll_ctrl.reset_integrator();
 					_pitch_ctrl.reset_integrator();


### PR DESCRIPTION
Based on #11856: pr VTOL attitude control during transitions. 

Two changes compared to that:
-during transitions, the MC rate controller gets its setpoints from the MC att C, the FW rate controller from the FW attitude controller (current Master: MC and FW rate sp from MC attitude controller; #11856: MC and FW rate sp from FW attitude controller). 
-tailsitters still get the MC and FW sp from MC att controller

Has been tested in sitl with quadplane and tailsitter, and test flown with tailsitter (tailsitter transition has some other issues independent of this PR).