### PR TITLE
Yaw rate saturation for auto modes

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/13005_vtol_AAERT_quad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13005_vtol_AAERT_quad
@@ -42,7 +42,8 @@ then
 	param set MC_YAWRATE_D 0
 	param set MC_YAWRATE_FF 0
 	param set MC_YAWRATE_MAX 40
-	param set MC_YAWRAUTO_MAX 40
+
+	param set MPC_YAWRAUTO_MAX 40
 
 	param set FW_PR_FF 0.5
 	param set FW_PR_I 0.02

--- a/ROMFS/px4fmu_common/init.d/airframes/13006_vtol_standard_delta
+++ b/ROMFS/px4fmu_common/init.d/airframes/13006_vtol_standard_delta
@@ -36,11 +36,11 @@ then
 	param set MC_YAWRATE_D 0
 	param set MC_YAWRATE_FF 0
 	param set MC_YAWRATE_MAX 50
-	param set MC_YAWRAUTO_MAX 20
 
 	param set MPC_XY_P 0.8
 	param set MPC_XY_VEL_P 0.1
 	param set MPC_ACC_HOR_MAX 2
+	param set MPC_YAWRAUTO_MAX 20
 
 	param set PWM_AUX_DIS3 950
 	param set PWM_RATE 400

--- a/ROMFS/px4fmu_common/init.d/airframes/13007_vtol_AAVVT_quad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13007_vtol_AAVVT_quad
@@ -28,7 +28,8 @@ then
 	param set MC_YAWRATE_D 0
 	param set MC_YAWRATE_FF 0
 	param set MC_YAWRATE_MAX 40
-	param set MC_YAWRAUTO_MAX 40
+
+	param set MPC_YAWRAUTO_MAX 40
 
 	param set PWM_AUX_DIS5 950
 	param set PWM_RATE 400

--- a/ROMFS/px4fmu_common/init.d/airframes/13008_QuadRanger
+++ b/ROMFS/px4fmu_common/init.d/airframes/13008_QuadRanger
@@ -36,12 +36,12 @@ then
 	param set MC_YAWRATE_D 0
 	param set MC_YAWRATE_FF 0
 	param set MC_YAWRATE_MAX 40
-	param set MC_YAWRAUTO_MAX 40
 
 	param set MPC_ACC_HOR_MAX 2
 	param set MPC_Z_VEL_MAX_DN 1.5
 	param set MPC_TKO_SPEED 1.5
 	param set MPC_LAND_SPEED 0.8
+	param set MPC_YAWRAUTO_MAX 40
 
 	param set PWM_AUX_DIS5 950
 	param set PWM_AUX_REV1 1

--- a/ROMFS/px4fmu_common/init.d/airframes/13009_vtol_spt_ranger
+++ b/ROMFS/px4fmu_common/init.d/airframes/13009_vtol_spt_ranger
@@ -36,7 +36,6 @@ then
 	param set MC_YAWRATE_I 0.02
 	param set MC_YAWRATE_MAX 40
 	param set MC_YAWRATE_P 0.18
-	param set MC_YAWRAUTO_MAX 40
 
 	param set MIS_TAKEOFF_ALT 2.5
 	param set MIS_YAW_TMT 20
@@ -56,6 +55,7 @@ then
 	param set MPC_XY_VEL_P    0.05
 	param set MPC_Z_P 0.5
 	param set MPC_Z_VEL_P 0.1
+	param set MPC_YAWRAUTO_MAX 40
 
 	param set NAV_ACC_RAD 3
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
@@ -88,7 +88,6 @@ then
 	param set MC_YAWRATE_D 0
 	param set MC_YAWRATE_FF 0
 	param set MC_YAWRATE_MAX 20
-	param set MC_YAWRAUTO_MAX 20
 	param set MC_AIRMODE 1
 
 	param set MIS_DIST_1WP 100
@@ -111,6 +110,7 @@ then
 	param set MPC_XY_CRUISE 5
 	param set MPC_TILTMAX_AIR 25
 	param set MPC_TILTMAX_LND 25
+	param set MPC_YAWRAUTO_MAX 20
 
 	param set NAV_DLL_ACT 0
 	param set NAV_LOITER_RAD 100

--- a/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
+++ b/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
@@ -42,7 +42,6 @@ then
 	param set MC_YAWRATE_I 0.15
 	param set MC_YAWRATE_MAX 40
 	param set MC_YAWRATE_P 0.3
-	param set MC_YAWRAUTO_MAX 40
 
 	param set MPC_MAN_TILT_MAX 25
 	param set MPC_MAN_Y_MAX 40
@@ -53,6 +52,7 @@ then
 	param set MPC_VEL_MANUAL 3
 	param set MPC_XY_VEL_MAX 3.5
 	param set MPC_Z_VEL_MAX_UP 2
+	param set MPC_YAWRAUTO_MAX 40
 
 	param set PWM_MAIN_DIS3 1000
 	param set PWM_MAIN_MIN3 1120

--- a/src/lib/FlightTasks/FlightTasks.cpp
+++ b/src/lib/FlightTasks/FlightTasks.cpp
@@ -21,7 +21,7 @@ bool FlightTasks::update()
 
 	if (isAnyTaskActive()) {
 		_subscription_array.update();
-		return _current_task.task->updateInitialize() && _current_task.task->update();
+		return _current_task.task->updateInitialize() && _current_task.task->update() && _current_task.task->updateFinalize();
 	}
 
 	return false;

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -113,7 +113,7 @@ void FlightTaskAuto::_limitYawRate()
 {
 	if (PX4_ISFINITE(_yaw_setpoint) || PX4_ISFINITE(_yaw_sp_prev)) {
 		// Limit the rate of change of the yaw setpoint
-		float dy_max = math::radians(_param_mc_yawrauto_max.get()) * _deltatime;
+		float dy_max = math::radians(_param_mpc_yawrauto_max.get()) * _deltatime;
 
 		if (fabsf(_yaw_setpoint - _yaw_sp_prev) < M_PI_F) {
 			// Wrap around 0
@@ -134,7 +134,7 @@ void FlightTaskAuto::_limitYawRate()
 	}
 
 	if (PX4_ISFINITE(_yawspeed_setpoint)) {
-		_yawspeed_setpoint = math::constrain(_yawspeed_setpoint, -_param_mc_yawrauto_max.get(), _param_mc_yawrauto_max.get());
+		_yawspeed_setpoint = math::constrain(_yawspeed_setpoint, -_param_mpc_yawrauto_max.get(), _param_mpc_yawrauto_max.get());
 	}
 }
 

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
@@ -113,7 +113,7 @@ protected:
 					_param_nav_mc_alt_rad, //vertical acceptance radius at which waypoints are updated
 					(ParamInt<px4::params::MPC_YAW_MODE>) _param_mpc_yaw_mode, // defines how heading is executed,
 					(ParamInt<px4::params::COM_OBS_AVOID>) _param_com_obs_avoid, // obstacle avoidance active
-					(ParamFloat<px4::params::MC_YAWRAUTO_MAX>) _param_mc_yawrauto_max
+					(ParamFloat<px4::params::MPC_YAWRAUTO_MAX>) _param_mpc_yawrauto_max
 				       );
 
 private:

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
@@ -79,6 +79,7 @@ public:
 	bool initializeSubscriptions(SubscriptionArray &subscription_array) override;
 	bool activate() override;
 	bool updateInitialize() override;
+	bool updateFinalize() override;
 
 	/**
 	 * Sets an external yaw handler which can be used to implement a different yaw control strategy.
@@ -111,12 +112,14 @@ protected:
 					(ParamFloat<px4::params::NAV_MC_ALT_RAD>)
 					_param_nav_mc_alt_rad, //vertical acceptance radius at which waypoints are updated
 					(ParamInt<px4::params::MPC_YAW_MODE>) _param_mpc_yaw_mode, // defines how heading is executed,
-					(ParamInt<px4::params::COM_OBS_AVOID>) _param_com_obs_avoid // obstacle avoidance active
+					(ParamInt<px4::params::COM_OBS_AVOID>) _param_com_obs_avoid, // obstacle avoidance active
+					(ParamFloat<px4::params::MC_YAWRAUTO_MAX>) _param_mc_yawrauto_max
 				       );
 
 private:
 	matrix::Vector2f _lock_position_xy{NAN, NAN}; /**< if no valid triplet is received, lock positition to current position */
 	bool _yaw_lock = false; /**< if within acceptance radius, lock yaw to current yaw */
+	float _yaw_sp_prev = NAN;
 	uORB::Subscription<position_setpoint_triplet_s> *_sub_triplet_setpoint{nullptr};
 	uORB::Subscription<vehicle_status_s> *_sub_vehicle_status{nullptr};
 
@@ -136,6 +139,7 @@ private:
 		nullptr;	/**< external weathervane library, used to implement a yaw control law that turns the vehicle nose into the wind */
 
 
+	void _limitYawRate(); /**< Limits the rate of change of the yaw setpoint. */
 	bool _evaluateTriplets(); /**< Checks and sets triplets. */
 	bool _isFinite(const position_setpoint_s &sp); /**< Checks if all waypoint triplets are finite. */
 	bool _evaluateGlobalReference(); /**< Check is global reference is available. */

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
@@ -106,6 +106,14 @@ public:
 	virtual bool update() = 0;
 
 	/**
+	 * Call after update()
+	 * to constrain the generated setpoints in order to comply
+	 * with the constraints of the current mode
+	 * @return true on success, false on error
+	 */
+	virtual bool updateFinalize() { return true; };
+
+	/**
 	 * Get the output data
 	 * @return task output setpoints that get executed by the positon controller
 	 */

--- a/src/modules/mc_att_control/mc_att_control.hpp
+++ b/src/modules/mc_att_control/mc_att_control.hpp
@@ -147,9 +147,6 @@ private:
 	 */
 	matrix::Vector3f pid_attenuations(float tpa_breakpoint, float tpa_rate);
 
-	/** lower yawspeed limit in auto modes because we expect yaw steps */
-	void adapt_auto_yaw_rate_limit();
-
 	AttitudeControl _attitude_control; /**< class for attitude control calculations */
 
 	int		_v_att_sub{-1};			/**< vehicle attitude subscription */
@@ -249,7 +246,6 @@ private:
 		(ParamFloat<px4::params::MC_ROLLRATE_MAX>) _param_mc_rollrate_max,
 		(ParamFloat<px4::params::MC_PITCHRATE_MAX>) _param_mc_pitchrate_max,
 		(ParamFloat<px4::params::MC_YAWRATE_MAX>) _param_mc_yawrate_max,
-		(ParamFloat<px4::params::MC_YAWRAUTO_MAX>) _param_mc_yawrauto_max,
 		(ParamFloat<px4::params::MPC_MAN_Y_MAX>) _param_mpc_man_y_max,			/**< scaling factor from stick to yaw rate */
 
 		(ParamFloat<px4::params::MC_ACRO_R_MAX>) _param_mc_acro_r_max,

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -149,7 +149,6 @@ MulticopterAttitudeControl::parameters_updated()
 	// angular rate limits
 	using math::radians;
 	_attitude_control.setRateLimit(Vector3f(radians(_param_mc_rollrate_max.get()), radians(_param_mc_pitchrate_max.get()), radians(_param_mc_yawrate_max.get())));
-	adapt_auto_yaw_rate_limit();
 
 	// manual rate control acro mode rate limits
 	_acro_rate_max = Vector3f(radians(_param_mc_acro_r_max.get()), radians(_param_mc_acro_p_max.get()), radians(_param_mc_acro_y_max.get()));
@@ -195,16 +194,6 @@ MulticopterAttitudeControl::vehicle_control_mode_poll()
 
 	if (updated) {
 		orb_copy(ORB_ID(vehicle_control_mode), _v_control_mode_sub, &_v_control_mode);
-		adapt_auto_yaw_rate_limit();
-	}
-}
-
-void MulticopterAttitudeControl::adapt_auto_yaw_rate_limit() {
-	if ((_v_control_mode.flag_control_velocity_enabled || _v_control_mode.flag_control_auto_enabled) &&
-		!_v_control_mode.flag_control_manual_enabled) {
-		_attitude_control.setRateLimitYaw(math::radians(_param_mc_yawrauto_max.get()));
-	} else {
-		_attitude_control.setRateLimitYaw(math::radians(_param_mc_yawrate_max.get()));
 	}
 }
 

--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -314,21 +314,6 @@ PARAM_DEFINE_FLOAT(MC_PITCHRATE_MAX, 220.0f);
 PARAM_DEFINE_FLOAT(MC_YAWRATE_MAX, 200.0f);
 
 /**
- * Max yaw rate in auto mode
- *
- * Limit for yaw rate, has effect for large rotations in autonomous mode,
- * to avoid large control output and mixer saturation.
- *
- * @unit deg/s
- * @min 0.0
- * @max 360.0
- * @decimal 1
- * @increment 5
- * @group Multicopter Attitude Control
- */
-PARAM_DEFINE_FLOAT(MC_YAWRAUTO_MAX, 45.0f);
-
-/**
  * Max acro roll rate
  * default: 2 turns per second
  *

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -616,6 +616,21 @@ PARAM_DEFINE_FLOAT(MPC_Z_MAN_EXPO, 0.0f);
 PARAM_DEFINE_FLOAT(MPC_YAW_EXPO, 0.0f);
 
 /**
+ * Max yaw rate in auto mode
+ *
+ * Limit the rate of change of the yaw setpoint in autonomous mode
+ * to avoid large control output and mixer saturation.
+ *
+ * @unit deg/s
+ * @min 0.0
+ * @max 360.0
+ * @decimal 1
+ * @increment 5
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MPC_YAWRAUTO_MAX, 45.0f);
+
+/**
  * Altitude for 1. step of slow landing (descend)
  *
  * Below this altitude descending velocity gets limited


### PR DESCRIPTION
Until now, the yaw rate is saturated by [MC_YAWRAUTO_MAX](https://dev.px4.io/master/en/advanced/parameter_reference.html#MC_YAWRAUTO_MAX) in the rate controller itself. The problem is that changing the saturation of the inner loop of cascaded controllers can lead to an unstability: a stable yaw control in manual can suddenly become unstable in auto mode because the saturation is more restrictive.

The proposed solution is to handle that yaw rate saturation in the Auto FlightTask directly such that the rate of change of the generated setpoint is limited to the value defined by the parameter. This yaw, the rate of change of the setpoint is constrained in auto mode and the yaw stability margins defined in manual modes are preserved in auto modes.

SITL tests with `MC_YAWRAUTO_MAX = 20`:
_Default line-tracking_ `MPC_AUTO_MODE = 0`
![2019-04-26_12-20-07_01_plot_standard](https://user-images.githubusercontent.com/14822839/56801726-7bfd0d80-681e-11e9-8e10-d3629516bc4e.png)



_Jerk-limited trajectory_ `MPC_AUTO_MODE = 1`
![2019-04-26_12-25-12_01_plot_jerk-lim](https://user-images.githubusercontent.com/14822839/56801729-80292b00-681e-11e9-80f8-3b5dbcdc815e.png)


One can easily imagine that if that is the yaw rate setpoint (lower graphs in both plots) is saturated, the yaw response of the vehicle is different.

@dagar The problem now is that the `MC_` parameter is used in position control. Should I replace it by `MPC_`?