### PR TITLE
adis16497: fix TEMP_OUT conversion according to the datasheet

### DIFF
--- a/src/drivers/imu/adis16497/ADIS16497.cpp
+++ b/src/drivers/imu/adis16497/ADIS16497.cpp
@@ -613,7 +613,7 @@ ADIS16497::publish_accel(const hrt_abstime &t, const ADISReport &report)
 		arb.y_integral = aval_integrated(1);
 		arb.z_integral = aval_integrated(2);
 
-		arb.temperature = report.TEMP_OUT * 0.0125f - 25.0f; // 1 LSB = 0.0125°C, 0x0000 at 25°C
+		arb.temperature = (int16_t(report.TEMP_OUT) * 0.0125f) + 25.0f; // 1 LSB = 0.0125°C, 0x0000 at 25°C
 
 		orb_publish(ORB_ID(sensor_accel), _accel_topic, &arb);
 	}
@@ -662,7 +662,7 @@ ADIS16497::publish_gyro(const hrt_abstime &t, const ADISReport &report)
 		grb.y_integral = gval_integrated(1);
 		grb.z_integral = gval_integrated(2);
 
-		grb.temperature = report.TEMP_OUT * 0.0125f - 25.0f; // 1 LSB = 0.0125°C, 0x0000 at 25°C
+		grb.temperature = (int16_t(report.TEMP_OUT) * 0.0125f) + 25.0f; // 1 LSB = 0.0125°C, 0x0000 at 25°C
 
 		orb_publish(ORB_ID(sensor_gyro), _gyro->_gyro_topic, &grb);
 	}


### PR DESCRIPTION
**Test data / coverage**
Not available.

**Describe problem solved by the proposed pull request**
Temperature read outs from the adis16497 are incorrect, because the conversion process is incorrect. The [datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/ADIS16497.pdf) describes the correct conversion process.

**Describe your preferred solution**
I've changed the temperature conversion to ensure that:
- Negative temperatures are possible (`0xEBB0` should be `-40 °C`)
- Temperatures are centered around `25 °C` (not `-25 °C`)

**Describe possible alternatives**
None.

**Additional context**
None.
