### PR TITLE
fix bmp280 driver init faild.

### DIFF
--- a/src/drivers/barometer/bmp280/bmp280.h
+++ b/src/drivers/barometer/bmp280/bmp280.h
@@ -154,6 +154,6 @@ public:
 
 
 /* interface factories */
-extern bmp280::IBMP280 *bmp280_spi_interface(uint8_t busnum, uint8_t device, bool external);
-extern bmp280::IBMP280 *bmp280_i2c_interface(uint8_t busnum, uint8_t device, bool external);
-typedef bmp280::IBMP280 *(*BMP280_constructor)(uint8_t, uint8_t, bool);
+extern bmp280::IBMP280 *bmp280_spi_interface(uint8_t busnum, uint32_t device, bool external);
+extern bmp280::IBMP280 *bmp280_i2c_interface(uint8_t busnum, uint32_t device, bool external);
+typedef bmp280::IBMP280 *(*BMP280_constructor)(uint8_t, uint32_t, bool);

--- a/src/drivers/barometer/bmp280/bmp280_i2c.cpp
+++ b/src/drivers/barometer/bmp280/bmp280_i2c.cpp
@@ -49,7 +49,7 @@
 class BMP280_I2C: public device::I2C, public bmp280::IBMP280
 {
 public:
-	BMP280_I2C(uint8_t bus, uint8_t device, bool external);
+	BMP280_I2C(uint8_t bus, uint32_t device, bool external);
 	virtual ~BMP280_I2C() = default;
 
 	bool is_external();
@@ -66,12 +66,12 @@ private:
 	bool _external;
 };
 
-bmp280::IBMP280 *bmp280_i2c_interface(uint8_t busnum, uint8_t device, bool external)
+bmp280::IBMP280 *bmp280_i2c_interface(uint8_t busnum, uint32_t device, bool external)
 {
 	return new BMP280_I2C(busnum, device, external);
 }
 
-BMP280_I2C::BMP280_I2C(uint8_t bus, uint8_t device, bool external) :
+BMP280_I2C::BMP280_I2C(uint8_t bus, uint32_t device, bool external) :
 	I2C("BMP280_I2C", nullptr, bus, device, 100 * 1000)
 {
 	_external = external;

--- a/src/drivers/barometer/bmp280/bmp280_spi.cpp
+++ b/src/drivers/barometer/bmp280/bmp280_spi.cpp
@@ -82,7 +82,7 @@ private:
 	bool _external;
 };
 
-bmp280::IBMP280 *bmp280_spi_interface(uint8_t busnum, uint8_t device, bool external)
+bmp280::IBMP280 *bmp280_spi_interface(uint8_t busnum, uint32_t device, bool external)
 {
 	return new BMP280_SPI(busnum, device, external);
 }


### PR DESCRIPTION
Change uint8_t device to uint32_t device.

Because 'device'  types is uint32_t in SPI device  and 'address'  types is uint16_t in I2C device. 
So 'device' in bmp280_spi_interface and bmp280_i2c_interface must also uint32_t .  Otherwise, init function can't find the right device at bus(SPI or I2C) if PX4_SPIDEV_XXX bigger than 0xff.
