### PR TITLE
Allow empty -f argument for generate_microRTPS_bridge.py fixing #11901

### DIFF
--- a/msg/tools/generate_microRTPS_bridge.py
+++ b/msg/tools/generate_microRTPS_bridge.py
@@ -167,7 +167,7 @@ parser.add_argument("-o", "--agent-outdir", dest='agentdir', type=str,
                     help="Agent output dir, by default using relative path 'src/modules/micrortps_bridge/micrortps_agent'", default=default_agent_out)
 parser.add_argument("-u", "--client-outdir", dest='clientdir', type=str,
                     help="Client output dir, by default using relative path 'src/modules/micrortps_bridge/micrortps_client'", default=default_client_out)
-parser.add_argument("-f", "--fastrtpsgen-dir", dest='fastrtpsgen', type=str,
+parser.add_argument("-f", "--fastrtpsgen-dir", dest='fastrtpsgen', type=str, nargs='?',
                     help="fastrtpsgen installation dir, only needed if fastrtpsgen is not in PATH, by default empty", default="")
 parser.add_argument("-g", "--fastrtpsgen-include", dest='fastrtpsgen_include', type=str,
                     help="directory(ies) to add to preprocessor include paths of fastrtpsgen, by default empty", default="")


### PR DESCRIPTION
**Problem solved**
The --fastrtpsgen-dir is always set to `FASTRTPSGEN_DIR` environment variable in the `CMakeLists.txt` of `micrortps_bridge`. This will allow the option to be empty and thererfore allow autodetection of fastrtpsgen if the environment variable `FASTRTPSGEN_DIR` is empty.

This PR fixes https://github.com/PX4/Firmware/issues/11901

https://github.com/PX4/Firmware/blob/a9c3bce20da57e2fdd9c3ad630892506677ca377/src/modules/micrortps_bridge/micrortps_client/CMakeLists.txt#L76

**Describe your preferred solution**
Add `nargs=?` to argparse to allow empty data.


