### PR TITLE
RTL - Skip descend state in "Return then land immediately" mode

### DIFF
--- a/src/modules/navigator/rtl.cpp
+++ b/src/modules/navigator/rtl.cpp
@@ -309,7 +309,14 @@ RTL::advance_rtl()
 		break;
 
 	case RTL_STATE_RETURN:
-		_rtl_state = RTL_STATE_DESCEND;
+
+		// Descend to desired altitude if delay is set, directly land otherwise
+		if (_param_rtl_land_delay.get() < -DELAY_SIGMA || _param_rtl_land_delay.get() > DELAY_SIGMA) {
+			_rtl_state = RTL_STATE_DESCEND;
+
+		} else {
+			_rtl_state = RTL_STATE_LAND;
+		}
 
 		if (_navigator->get_vstatus()->is_vtol && !_navigator->get_vstatus()->is_rotary_wing) {
 			_rtl_state = RTL_STATE_TRANSITION_TO_MC;


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
During RTL some users (thanks @bkueng ) reported that the behavior of the drone during the RTL final descent is weird: it accelerates and decelerates several times instead of simply performing a "land".
I discovered that this was caused by the intermediate waypoint placed by RTL between "descend" and "land.
This PR simply adds a shortcut in the state machine to directly go to land mode and skip that waypoint if RTL is configured as "Return home, then land immediately".

**Test data / coverage**
SITL tests:
Without this PR: https://logs.px4.io/plot_app?log=42c21502-6212-4ca1-82b8-34798e02fca0
As seen in the graph below, the drone reaches down speed of 1m/s then slows down to reach the "end of RTL descend" then accelerate to reach down speed and reduces speed to reach a land speed of 0.7m/s.
![bokeh_plot(16)](https://user-images.githubusercontent.com/14822839/56738049-0cc6e100-676c-11e9-9c58-940319da5f61.png)

With this PR: https://logs.px4.io/plot_app?log=cdbc8ad6-4ff8-4525-9e98-f1ce6ebe4e7d
The drone goes down at 1m/s until it reaches the "low altitude" where it reduces its speed to 0.7m/s, like it would do in a normal "land".
![bokeh_plot(15)](https://user-images.githubusercontent.com/14822839/56738208-6af3c400-676c-11e9-9460-7daa32de09c9.png)

Other modes:
- Loiter and land: https://logs.px4.io/plot_app?log=88a29c37-8348-4abe-b9e1-48ab64ae8eae
- Loiter and do **not** land: https://logs.px4.io/plot_app?log=45780f74-191d-42f8-af1d-25b28e84e892