### PR TITLE
Fix RC mode switch first evaluation after boot

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2730,20 +2730,23 @@ Commander::set_main_state_rc(const vehicle_status_s &status_local, bool *changed
 	// we want to allow rc mode change to take precidence.  This is a safety
 	// feature, just in case offboard control goes crazy.
 
+	const bool position_got_valid = !_last_condition_global_position_valid && status_flags.condition_global_position_valid;
+	const bool had_rc_before = _last_sp_man.timestamp != 0;
+	const bool rc_values_not_updated = _last_sp_man.timestamp == sp_man.timestamp;
+	const bool all_switches_stayed =
+		(_last_sp_man.offboard_switch == sp_man.offboard_switch)
+		&& (_last_sp_man.return_switch == sp_man.return_switch)
+		&& (_last_sp_man.mode_switch == sp_man.mode_switch)
+		&& (_last_sp_man.acro_switch == sp_man.acro_switch)
+		&& (_last_sp_man.rattitude_switch == sp_man.rattitude_switch)
+		&& (_last_sp_man.posctl_switch == sp_man.posctl_switch)
+		&& (_last_sp_man.loiter_switch == sp_man.loiter_switch)
+		&& (_last_sp_man.mode_slot == sp_man.mode_slot)
+		&& (_last_sp_man.stab_switch == sp_man.stab_switch)
+		&& (_last_sp_man.man_switch == sp_man.man_switch);
+
 	/* manual setpoint has not updated, do not re-evaluate it */
-	if (!(!_last_condition_global_position_valid &&
-	      status_flags.condition_global_position_valid)
-	    && (((_last_sp_man.timestamp != 0) && (_last_sp_man.timestamp == sp_man.timestamp)) ||
-		((_last_sp_man.offboard_switch == sp_man.offboard_switch) &&
-		 (_last_sp_man.return_switch == sp_man.return_switch) &&
-		 (_last_sp_man.mode_switch == sp_man.mode_switch) &&
-		 (_last_sp_man.acro_switch == sp_man.acro_switch) &&
-		 (_last_sp_man.rattitude_switch == sp_man.rattitude_switch) &&
-		 (_last_sp_man.posctl_switch == sp_man.posctl_switch) &&
-		 (_last_sp_man.loiter_switch == sp_man.loiter_switch) &&
-		 (_last_sp_man.mode_slot == sp_man.mode_slot) &&
-		 (_last_sp_man.stab_switch == sp_man.stab_switch) &&
-		 (_last_sp_man.man_switch == sp_man.man_switch)))) {
+	if (!position_got_valid && ((had_rc_before && rc_values_not_updated) || all_switches_stayed)) {
 
 		// store the last manual control setpoint set by the pilot in a manual state
 		// if the system now later enters an autonomous state the pilot can move

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -2746,8 +2746,9 @@ Commander::set_main_state_rc(const vehicle_status_s &status_local, bool *changed
 		|| (_last_sp_man.man_switch != sp_man.man_switch);
 
 	// only switch mode based on RC switch if necessary to also allow mode switching via MAVLink
-	const bool should_evaluate_rc_mode_switch = position_got_valid || ((first_time_rc || rc_values_updated)
-			&& some_switch_changed);
+	const bool should_evaluate_rc_mode_switch = first_time_rc
+			|| position_got_valid
+			|| (rc_values_updated && some_switch_changed);
 
 	if (!should_evaluate_rc_mode_switch) {
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Fixes #11914
First two commits are refactoring to make the analyzed condition readable. The last commit fixes the problem that sometimes the mode chosen by the RC switch does not get evaluated after bootup when the RC connects for the first time. Result was it stayed in "Manual" mode which can lead to unexpected behavior e.g. switch is in altitude or position mode state but does not get applied when not flicking the mode switch back and forth once.

**Test data / coverage**
I tested this the same way I debugged the problem: In SITL and with the virtual controller overlay feature in QGC. Using the virtual controller results in having the initialization values which are zeros in the manual control setpoint for the "unused" fields e.g. mode_slot. And a zero in mode_slot is the first configured mode. So I configured the first mode to "Acro" and did my testing. I tried turning on with RC, turning on without RC and ticking the virtual joystick shortly after to get RC and waiting until position is locked and then connecting the RC. The last case also worked by accident before because if you gain position lock you reconsider the RC mode switch and the whole condition (`_last_condition_global_position_valid`) is only updated when there's RC at all. 

**Additional context**
I found additional unwanted corner cases e.g. with the position lock gained condition while debugging this but I don't consider them release blocking and I'll open issues for them separately.

FYI @DanielePettenuzzo 