### PR TITLE
Fix standard_vtol vibration on ground

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/1040_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/1040_standard_vtol
@@ -34,6 +34,7 @@ then
 
 	param set VT_F_TRANS_DUR 5
 	param set VT_F_TRANS_THR 0.75
+	param set VT_ARSP_TRANS 16
 	param set VT_MOT_COUNT 4
 	param set VT_TYPE 2
 

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -262,9 +262,7 @@ void Simulator::update_sensors(const mavlink_hil_sensor_t *imu)
 
 	RawAirspeedData airspeed = {};
 	airspeed.temperature = imu->temperature;
-	// FIXME: diff_pressure needs some noise to pass preflight checks, so we just take the
-	//        noise from the gyro.
-	airspeed.diff_pressure = imu->diff_pressure + ((imu->ygyro > 0) ? 0.001f : 0.0f);
+	airspeed.diff_pressure = imu->diff_pressure;
 
 	write_airspeed_data(&airspeed);
 }


### PR DESCRIPTION
This addresses the issue where the `standard_vtol` (delta quad) vibrates on the ground.

Also, this moves the airspeed noise from `simulator_mavlink.cpp` to the Gazebo side.

Fixes #11912, fixes #11213.