### PR TITLE
Migrate remaining variable initializations from constructor list to declarations in mavlink_main.cpp/h.

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -161,34 +161,7 @@ static void usage();
 bool Mavlink::_boot_complete = false;
 
 Mavlink::Mavlink() :
-	ModuleParams(nullptr),
-	_last_write_success_time(0),
-	_last_write_try_time(0),
-	_mavlink_start_time(0),
-	_protocol_version_switch(-1),
-	_protocol_version(0),
-	_bytes_tx(0),
-	_bytes_txerr(0),
-	_bytes_rx(0),
-	_bytes_timestamp(0),
-#if defined(CONFIG_NET) || defined(__PX4_POSIX)
-	_myaddr {},
-	_src_addr{},
-	_bcast_addr{},
-	_src_addr_initialized(false),
-	_broadcast_address_found(false),
-	_broadcast_address_not_found_warned(false),
-	_broadcast_failed_warned(false),
-	_network_buf{},
-	_network_buf_len(0),
-#endif
-	_socket_fd(-1),
-	_protocol(SERIAL),
-	_network_port(14556),
-	_remote_port(DEFAULT_REMOTE_PORT_UDP),
-	/* performance counters */
-	_loop_perf(perf_alloc(PC_ELAPSED, "mavlink_el")),
-	_loop_interval_perf(perf_alloc(PC_INTERVAL, "mavlink_int"))
+	ModuleParams(nullptr)
 {
 	_instance_id = Mavlink::instance_count();
 

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -599,41 +599,41 @@ private:
 
 	FLOW_CONTROL_MODE	_flow_control_mode{Mavlink::FLOW_CONTROL_OFF};
 
-	uint64_t		_last_write_success_time;
-	uint64_t		_last_write_try_time;
-	uint64_t		_mavlink_start_time;
-	int32_t			_protocol_version_switch;
-	int32_t			_protocol_version;
+	uint64_t		_last_write_success_time{0};
+	uint64_t		_last_write_try_time{0};
+	uint64_t		_mavlink_start_time{0};
+	int32_t			_protocol_version_switch{-1};
+	int32_t			_protocol_version{0};
 
-	unsigned		_bytes_tx;
-	unsigned		_bytes_txerr;
-	unsigned		_bytes_rx;
-	uint64_t		_bytes_timestamp;
+	unsigned		_bytes_tx{0};
+	unsigned		_bytes_txerr{0};
+	unsigned		_bytes_rx{0};
+	uint64_t		_bytes_timestamp{0};
 
 #if defined(CONFIG_NET) || defined(__PX4_POSIX)
-	sockaddr_in		_myaddr;
-	sockaddr_in		_src_addr;
-	sockaddr_in		_bcast_addr;
+	sockaddr_in		_myaddr {};
+	sockaddr_in		_src_addr {};
+	sockaddr_in		_bcast_addr {};
 
-	bool			_src_addr_initialized;
-	bool			_broadcast_address_found;
-	bool			_broadcast_address_not_found_warned;
-	bool			_broadcast_failed_warned;
-	uint8_t			_network_buf[MAVLINK_MAX_PACKET_LEN];
-	unsigned		_network_buf_len;
+	bool			_src_addr_initialized{false};
+	bool			_broadcast_address_found{false};
+	bool			_broadcast_address_not_found_warned{false};
+	bool			_broadcast_failed_warned{false};
+	uint8_t			_network_buf[MAVLINK_MAX_PACKET_LEN] {};
+	unsigned		_network_buf_len{0};
 #endif
 
-	const char 		*_interface_name;
+	const char 		*_interface_name{nullptr};
 
-	int			_socket_fd;
-	Protocol		_protocol;
-	unsigned short		_network_port;
-	unsigned short		_remote_port;
+	int			_socket_fd{-1};
+	Protocol		_protocol{SERIAL};
+	unsigned short		_network_port{14556};
+	unsigned short		_remote_port{DEFAULT_REMOTE_PORT_UDP};
 
-	radio_status_s		_rstatus{};
-	telemetry_status_s	_tstatus{};
+	radio_status_s		_rstatus {};
+	telemetry_status_s	_tstatus {};
 
-	ping_statistics_s	_ping_stats{};
+	ping_statistics_s	_ping_stats {};
 
 	struct mavlink_message_buffer {
 		int write_ptr;
@@ -662,8 +662,8 @@ private:
 		(ParamInt<px4::params::SYS_HITL>) _param_sys_hitl
 	)
 
-	perf_counter_t		_loop_perf;			/**< loop performance counter */
-	perf_counter_t		_loop_interval_perf;		/**< loop interval performance counter */
+	perf_counter_t		_loop_perf{perf_alloc(PC_ELAPSED, "mavlink_el")};		/**< loop performance counter */
+	perf_counter_t		_loop_interval_perf{perf_alloc(PC_INTERVAL, "mavlink_int")};	/**< loop interval performance counter */
 
 	void			mavlink_update_parameters();
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR completes migration of the remaining variable initialization from the Mavlink class constructor list to their respective declarations following work in #11610 and #11623.

Additional context
See also PR #11610, #11623.

Thanks @bresch and @dagar for your reviews of the previous related PRs.  Please let me know if you have any questions on this PR.

-Mark