### PR TITLE
mpu9250: fix mag publishing garbage on IMU failure (SPI only, Pixhawk cube)

### DIFF
--- a/src/drivers/imu/mpu9250/mpu9250.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250.cpp
@@ -1058,7 +1058,9 @@ MPU9250::measure()
 	if (_mag->is_passthrough()) {
 #   endif
 
-		_mag->_measure(mpu_report.mag);
+		if (_register_wait == 0) {
+			_mag->_measure(mpu_report.mag);
+		}
 
 #   ifdef USE_I2C
 


### PR DESCRIPTION
I was testing IMU failures on the Pixhawk Cube by physically plugging out the connector to the vibration-mounted IMUs (regarding the issue on https://discuss.cubepilot.org/t/sb-0000002-critical-service-bulletin-for-cubes-purchased-between-january-2019-to-present-do-not-fly/406).

I noticed the mpu9250 kept publishing garbage data for the mag. This PR fixes that.

Other than that, failover is working as expected, for both rate controller and estimator. The attitude can get off by a few degrees, caused by the failover, and then recovers slowly within a couple of seconds.

Logs (plugging out the IMU, and triggering a failover on the bench):
Without moving the board:
- https://logs.px4.io/plot_app?log=da2c526c-8a38-4ccd-8419-1aa32d5cb252
- https://logs.px4.io/plot_app?log=7cd38fed-0f04-4dfe-8308-3a68fa0c73da
- https://logs.px4.io/plot_app?log=1b74fca5-a40b-4ae7-88ba-33b9d367a9d2
- https://logs.px4.io/plot_app?log=487d2a95-179e-4ea8-90bf-c4ec6a4e97bf
- https://logs.px4.io/plot_app?log=b645cd72-b16d-46bc-8ab6-a92769c6728e

While moving the board:
- https://logs.px4.io/plot_app?log=12b7d958-9a3b-4fd6-a41a-182b4c58b6d9
- https://logs.px4.io/plot_app?log=447213a1-7cbd-4ec5-b3e2-de753887ea08
- https://logs.px4.io/plot_app?log=2c894b80-a760-40c4-98de-6893232533a3
- https://logs.px4.io/plot_app?log=ae5d1d6f-8c38-4c50-a680-f0f3c3e66aa9
- https://logs.px4.io/plot_app?log=9bb72468-421a-4816-a21a-63826058ebaf
- https://logs.px4.io/plot_app?log=30363849-7b91-47c8-8ff0-370243ae353e


Everyone who is using an external mag via I2C is not affected by this (which is generally the case), and an IMU failure will be handled as expected even without this patch.