### PR TITLE
Revert "sitl_gazebo: update submodule"

### DIFF
--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -262,7 +262,9 @@ void Simulator::update_sensors(const mavlink_hil_sensor_t *imu)
 
 	RawAirspeedData airspeed = {};
 	airspeed.temperature = imu->temperature;
-	airspeed.diff_pressure = imu->diff_pressure;
+	// FIXME: diff_pressure needs some noise to pass preflight checks, so we just take the
+	//        noise from the gyro.
+	airspeed.diff_pressure = imu->diff_pressure + ((imu->ygyro > 0) ? 0.001f : 0.0f);
 
 	write_airspeed_data(&airspeed);
 }


### PR DESCRIPTION
This reverts commit 585b9d8cf17b377fff681a48dcbcb6005412d78d.

We're seeing a number of intermittent failures after this sitl_gazebo update. Unless we can find a proper fix today let's revert.

@julianoes @EliaTarasov @TSC21 

![image](https://user-images.githubusercontent.com/84712/56899265-07fe7780-6a61-11e9-8f12-9383f1bf933b.png)
