### PR TITLE
SITL: add IF750A model

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/10020_if750a
+++ b/ROMFS/px4fmu_common/init.d-posix/10020_if750a
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# @name IF750A SITL
+# InspiredFlight 750 Auterion edition. Gazebo Only.
+#
+# @type Quadrotor
+#
+
+sh /etc/init.d/rc.mc_defaults
+
+set MIXER quad_x
+

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -51,7 +51,11 @@ ExternalProject_Add_Step(sitl_gazebo forceconfigure
 # create targets for each viewer/model/debugger combination
 set(viewers none jmavsim gazebo)
 set(debuggers none ide gdb lldb ddd valgrind callgrind)
-set(models none shell iris iris_opt_flow iris_vision iris_rplidar iris_irlock iris_obs_avoid standard_vtol plane solo tailsitter typhoon_h480 rover hippocampus tiltrotor)
+set(models none shell
+	if750a iris iris_opt_flow iris_vision iris_rplidar iris_irlock iris_obs_avoid solo typhoon_h480
+	plane
+	standard_vtol tailsitter tiltrotor
+	hippocampus rover)
 set(all_posix_vmd_make_targets)
 foreach(viewer ${viewers})
 	foreach(debugger ${debuggers})


### PR DESCRIPTION
This brings https://github.com/PX4/sitl_gazebo/pull/279, which is the Inspired Flight 750 Auterion edition reference airframe (https://inspiredflight.com/drones/).

It updates the gazebo submodule, so do not merge yet until https://github.com/PX4/Firmware/pull/11931 is resolved.