### PR TITLE
ROMFS: use auto-disarm in HITL Gazebo with Iris

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/1001_rc_quad_x.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1001_rc_quad_x.hil
@@ -13,4 +13,9 @@ sh /etc/init.d/rc.mc_defaults
 set MIXER quad_x
 set PWM_OUT 1234
 
+if [ $AUTOCNF = yes ]
+then
+	param set COM_DISARM_LAND 5
+fi
+
 param set SYS_HITL 1


### PR DESCRIPTION
It is expected that Iris auto-disarms the same as in SITL.