### PR TITLE
UAVCAN - update ROMFS_FW_PATH to /etc/uavcan/fw. to match documentation

### DIFF
--- a/src/drivers/uavcan/uavcan_module.hpp
+++ b/src/drivers/uavcan/uavcan_module.hpp
@@ -50,7 +50,7 @@
 // firmware paths
 #define UAVCAN_MAX_PATH_LENGTH (128 + 40)
 #define UAVCAN_FIRMWARE_PATH   "/fs/microsd/fw"
-#define UAVCAN_ROMFS_FW_PATH   "/etc/firmware/uavcan"
+#define UAVCAN_ROMFS_FW_PATH   "/etc/uavcan/fw"
 #define UAVCAN_ROMFS_FW_PREFIX "_"
 
 // logging


### PR DESCRIPTION
The UAVCAN firmware update PATH changed and does not correspond to the documented one [here](https://dev.px4.io/en/uavcan/node_firmware.html#placing-the-binaries-in-the-px4-romfs). Is there a reason for that?
Should we change the path here or the documentation?