### PR TITLE
adds a parameter that scales the velocity in _getCurrentState in FlightTaskAuto 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ if(NOT PX4_CONFIG_FILE)
 		"boards/*.cmake"
 		)
 
-	set(PX4_CONFIGS ${board_configs} CACHE STRINGS "PX4 board configs" FORCE)
+	set(PX4_CONFIGS ${board_configs} CACHE STRING "PX4 board configs" FORCE)
 
 	foreach(filename ${board_configs})
 		# parse input CONFIG into components to match with existing in tree configs

--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,7 @@ px4fmu_firmware: \
 	sizes
 
 misc_qgc_extra_firmware: \
+	check_nxp_fmuk66-v3_default \
 	check_intel_aerofc-v1_default \
 	check_auav_x21_default \
 	check_bitcraze_crazyflie_default \
@@ -257,7 +258,6 @@ misc_qgc_extra_firmware: \
 
 # Other NuttX firmware
 alt_firmware: \
-	check_nxp_fmuk66-v3_default \
 	check_px4_cannode-v1_default \
 	check_px4_esc-v1_default \
 	check_auav_esc35-v1_default \

--- a/ROMFS/px4fmu_common/init.d-posix/10020_if750a
+++ b/ROMFS/px4fmu_common/init.d-posix/10020_if750a
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# @name IF750A SITL
+# InspiredFlight 750 Auterion edition. Gazebo Only.
+#
+# @type Quadrotor
+#
+
+sh /etc/init.d/rc.mc_defaults
+
+set MIXER quad_x
+

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -29,7 +29,6 @@ set FEXTRAS /fs/microsd/etc/extras.txt
 set FMU_ARGS ""
 set FMU_MODE pwm
 set FRC /fs/microsd/etc/rc.txt
-set IO_PRESENT no
 set IOFW "/etc/extras/px4_io-v2_default.bin"
 set IO_PRESENT no
 set LOG_FILE /fs/microsd/bootlog.txt

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -51,7 +51,11 @@ ExternalProject_Add_Step(sitl_gazebo forceconfigure
 # create targets for each viewer/model/debugger combination
 set(viewers none jmavsim gazebo)
 set(debuggers none ide gdb lldb ddd valgrind callgrind)
-set(models none shell iris iris_opt_flow iris_vision iris_rplidar iris_irlock iris_obs_avoid standard_vtol plane solo tailsitter typhoon_h480 rover hippocampus tiltrotor)
+set(models none shell
+	if750a iris iris_opt_flow iris_vision iris_rplidar iris_irlock iris_obs_avoid solo typhoon_h480
+	plane
+	standard_vtol tailsitter tiltrotor
+	hippocampus rover)
 set(all_posix_vmd_make_targets)
 foreach(viewer ${viewers})
 	foreach(debugger ${debuggers})

--- a/src/drivers/uavcan/uavcan_module.hpp
+++ b/src/drivers/uavcan/uavcan_module.hpp
@@ -50,7 +50,7 @@
 // firmware paths
 #define UAVCAN_MAX_PATH_LENGTH (128 + 40)
 #define UAVCAN_FIRMWARE_PATH   "/fs/microsd/fw"
-#define UAVCAN_ROMFS_FW_PATH   "/etc/firmware/uavcan"
+#define UAVCAN_ROMFS_FW_PATH   "/etc/uavcan/fw"
 #define UAVCAN_ROMFS_FW_PREFIX "_"
 
 // logging

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -428,11 +428,11 @@ State FlightTaskAuto::_getCurrentState()
 		// Target is behind.
 		return_state = State::target_behind;
 
-	} else if (u_prev_to_target * prev_to_pos < 0.0f && prev_to_pos.length() > _mc_cruise_speed) {
+	} else if (u_prev_to_target * prev_to_pos < 0.0f && prev_to_pos.length() > _mc_cruise_speed * _param_mpc_wp_nav_acc.get()) {
 		// Current position is more than cruise speed in front of previous setpoint.
 		return_state = State::previous_infront;
 
-	} else if (Vector2f(Vector2f(_position) - _closest_pt).length() > _mc_cruise_speed) {
+	} else if (Vector2f(Vector2f(_position) - _closest_pt).length() > _mc_cruise_speed * _param_mpc_wp_nav_acc.get()) {
 		// Vehicle is more than cruise speed off track.
 		return_state = State::offtrack;
 

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -428,7 +428,8 @@ State FlightTaskAuto::_getCurrentState()
 		// Target is behind.
 		return_state = State::target_behind;
 
-	} else if (u_prev_to_target * prev_to_pos < 0.0f && prev_to_pos.length() > _mc_cruise_speed * _param_mpc_wp_nav_acc.get()) {
+	} else if (u_prev_to_target * prev_to_pos < 0.0f
+		   && prev_to_pos.length() > _mc_cruise_speed * _param_mpc_wp_nav_acc.get()) {
 		// Current position is more than cruise speed in front of previous setpoint.
 		return_state = State::previous_infront;
 

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
@@ -107,6 +107,7 @@ protected:
 	ObstacleAvoidance _obstacle_avoidance; /**< class adjusting setpoints according to external avoidance module's input */
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTask,
+					(ParamFloat<px4::params::MPC_WP_NAV_ACC>) _param_mpc_wp_nav_acc,
 					(ParamFloat<px4::params::MPC_XY_CRUISE>) _param_mpc_xy_cruise,
 					(ParamFloat<px4::params::MPC_CRUISE_90>) _param_mpc_cruise_90, // speed at corner when angle is 90 degrees move to line
 					(ParamFloat<px4::params::NAV_MC_ALT_RAD>)

--- a/src/modules/local_position_estimator/sensors/flow.cpp
+++ b/src/modules/local_position_estimator/sensors/flow.cpp
@@ -10,9 +10,6 @@ extern orb_advert_t mavlink_log_pub;
 static const uint32_t		REQ_FLOW_INIT_COUNT = 10;
 static const uint32_t		FLOW_TIMEOUT = 1000000;	// 1 s
 
-// minimum flow altitude
-static const float flow_min_agl = 0.3;
-
 void BlockLocalPositionEstimator::flowInit()
 {
 	// measure
@@ -44,7 +41,7 @@ int BlockLocalPositionEstimator::flowMeasure(Vector<float, n_y_flow> &y)
 	}
 
 	// check for agl
-	if (agl() < flow_min_agl) {
+	if (agl() < _sub_flow.get().min_ground_distance) {
 		return -1;
 	}
 

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -250,6 +250,20 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_D, 0.01f);
 PARAM_DEFINE_FLOAT(MPC_XY_CRUISE, 5.0f);
 
 /**
+ * Navigator waypoint acceptance threshold
+ *
+ * Threshold for the internal waypoint update in 
+ * FLightTaskAuto state machine.
+ * 
+ * @min 1.0
+ * @max 1000.0
+ * @increment 1
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_WP_NAV_ACC, 1.0f);
+
+/**
  * Proportional gain for horizontal trajectory position error
  *
  * @min 0.1

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -252,9 +252,8 @@ PARAM_DEFINE_FLOAT(MPC_XY_CRUISE, 5.0f);
 /**
  * Navigator waypoint acceptance threshold
  *
- * Threshold for the internal waypoint update in 
- * FLightTaskAuto state machine.
- * 
+ * Threshold for the internal waypoint update in FLightTaskAuto state machine.
+ *
  * @min 1.0
  * @max 1000.0
  * @increment 1


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary.

**Test data / coverage**
Logs uploaded to http://logs.px4.io or screenshots.

**Describe problem solved by the proposed pull request**
A clear and concise description of the problem, if any, this feature will solve. E.g. I'm always frustrated when ..."
The state machine in FlightTaskAuto, which is aimed to update the internal waypoint triplet, uses the velocity (_mc_cruise_speed) as parameter. However, one may want a different condition to meet one of those states. With the addition of MPC_WP_NAV_ACC there is the freedom to scale the parameter used by the state machine. If it is equal to 1 nothing changes. 
This feature is interesting also because if the acceptance radius is big, it is possible that the drone does not move to the next waypoint because it is in "offtrack" or "previous_infront" state. If the value of MPC_WP_NAV_ACC is large enough this problem can be avoided.

**Describe your preferred solution**
A clear and concise description of what you have implemented.

**Describe possible alternatives**
A clear and concise description of alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots for the feature request here.
