### PR TITLE
MC gyro cutoffs - Reduce IMU_GYRO_CUTOFF to 20Hz and disable MC_DTERM_CUTOFF

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -547,7 +547,7 @@ PARAM_DEFINE_FLOAT(MC_TPA_RATE_D, 0.0f);
  * @increment 10
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MC_DTERM_CUTOFF, 30.f);
+PARAM_DEFINE_FLOAT(MC_DTERM_CUTOFF, 0.f);
 
 /**
  * Multicopter air-mode

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -220,7 +220,7 @@ PARAM_DEFINE_INT32(SENS_EN_THERMAL, -1);
 * @reboot_required true
 * @group Sensors
 */
-PARAM_DEFINE_FLOAT(IMU_GYRO_CUTOFF, 80.0f);
+PARAM_DEFINE_FLOAT(IMU_GYRO_CUTOFF, 30.0f);
 
 /**
 * Driver level cutoff frequency for accel


### PR DESCRIPTION
#### IMY_GYRO_CUTOFF decreased to ~20Hz~ 30Hz
A lot of people realized that their drone is more sensitive to noise since the last release - possibly due to the increased default cutoff frequency of the gyroscope. A low gyro cutoff is needed for most medium/large size drones as the structural natural and blade-pass frequencies are low and people are flying more and more large powerful drones.
- A higher value is still desirable for small platforms such as racers or well isolated autopilots and should be tuned by the user.
- Specific values for config files are untouched.

#### MC_DTERM_CUTOFF deactivated by default
The cutoff filter for the D term is disabled here as the required cutoff frequency for the default D term of the rate controller is higher than the gyro cutoff. In that case, enabling the D term cutoff would just add some undesired phase lag to the derivative.

_Proof:_
A common rule of thumb used in the industry is to set the D term filter cutoff frequency equal to one tenth of the derivative time constant (ref: [controlguru.com (bottom of the page)](https://controlguru.com/using-signal-filters-in-our-pid-loop/)):
<a href="https://www.codecogs.com/eqnedit.php?latex=\tau_f&space;=&space;\frac{\tau_d}{10}" target="_blank"><img src="https://latex.codecogs.com/gif.latex?\tau_f&space;=&space;\frac{\tau_d}{10}" title="\tau_f = \frac{\tau_d}{10}" /></a>
The time constant of a 2nd order with a cutoff frequency of <img src="https://latex.codecogs.com/gif.latex?f_f" title="f_f" /> is given by:
<a href="https://www.codecogs.com/eqnedit.php?latex=\tau_f&space;=&space;\frac{1}{2\pi&space;f_f}" target="_blank"><img src="https://latex.codecogs.com/gif.latex?\tau_f&space;=&space;\frac{1}{2\pi&space;f_f}" title="\tau_f = \frac{1}{2\pi f_f}" /></a>
Since the time constant of the derivative part of the controller is
<a href="https://www.codecogs.com/eqnedit.php?latex=\tau_d&space;=&space;\frac{K_d}{K_p}" target="_blank"><img src="https://latex.codecogs.com/gif.latex?\tau_d&space;=&space;\frac{K_d}{K_p}" title="\tau_d = \frac{K_d}{K_p}" /></a>
We can express the desired filter cutoff as a function of the P and D gains:
<a href="https://www.codecogs.com/eqnedit.php?latex=f_f&space;=&space;\frac{10K_p}{2\pi&space;K_d}" target="_blank"><img src="https://latex.codecogs.com/gif.latex?f_f&space;=&space;\frac{10K_p}{2\pi&space;K_d}" title="f_f = \frac{10K_p}{2\pi K_d}" /></a>

Since the default gains of PX4 are:
`MC_ROLLRATE_P = 0.15`
`MC_ROLLRATE_D = 0.003`
The desired cutoff frequency would be
<a href="https://www.codecogs.com/eqnedit.php?latex=f_f&space;=&space;\frac{10\cdot0.15}{2\pi\cdot0.003}&space;\approx&space;80Hz" target="_blank"><img src="https://latex.codecogs.com/gif.latex?f_f&space;=&space;\frac{10\cdot0.15}{2\pi\cdot0.003}&space;\approx&space;80Hz" title="f_f = \frac{10\cdot0.15}{2\pi\cdot0.003} \approx 80Hz" /></a>
and is smaller than the gyro cutoff frequency of ~20Hz~ 30Hz.

FYI @LorenzMeier 

We will test it on a few vehicles ASAP