### PR TITLE
land_detector: use rangefinder for ground contact detection

### DIFF
--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -56,6 +56,7 @@
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/distance_sensor.h>
 
 using namespace time_literals;
 
@@ -108,6 +109,7 @@ private:
 		param_t altitude_max;
 		param_t landSpeed;
 		param_t low_thrust_threshold;
+		param_t clearance;
 	} _paramHandle{};
 
 	struct {
@@ -122,6 +124,7 @@ private:
 		float altitude_max;
 		float landSpeed;
 		float low_thrust_threshold;
+		float clearance;
 	} _params{};
 
 	int _vehicleLocalPositionSub{ -1};
@@ -131,6 +134,7 @@ private:
 	int _sensor_bias_sub{ -1};
 	int _vehicle_control_mode_sub{ -1};
 	int _battery_sub{ -1};
+	int _distance_sensor_sub{-1};
 
 	vehicle_local_position_s				_vehicleLocalPosition {};
 	vehicle_local_position_setpoint_s	_vehicleLocalPositionSetpoint {};
@@ -139,6 +143,7 @@ private:
 	sensor_bias_s					_sensors {};
 	vehicle_control_mode_s				_control_mode {};
 	battery_status_s						_battery {};
+	distance_sensor_s						_distance_sensor {};
 
 	hrt_abstime _min_trust_start{0};		///< timestamp when minimum trust was applied first
 	hrt_abstime _landed_time{0};

--- a/src/modules/land_detector/land_detector_params_mc.c
+++ b/src/modules/land_detector/land_detector_params_mc.c
@@ -131,3 +131,18 @@ PARAM_DEFINE_FLOAT(LNDMC_ALT_MAX, -1.0f);
  *
  */
 PARAM_DEFINE_FLOAT(LNDMC_LOW_T_THR, 0.3);
+
+/**
+ * Rangefinder clearance for ground contact detection
+ *
+ * Ground contact will be detected, if the rangeinder distance is less or equal this value.
+ * A negative value indicates no rangefinder usage.
+ *
+ * @unit m
+ * @min -1
+ * @max 10
+ * @decimal 3
+ * @group Land Detector
+ *
+ */
+PARAM_DEFINE_FLOAT(LNDMC_CLEARANCE, -1.0f);


### PR DESCRIPTION
We're experiencing a lot problems with current land detector (the drone is not getting disarmed in autonomous flights). But if you have a good quality rangefinder, detecting a ground contact is actually a trivial problem.

This PR introduces `LNDMC_CLEARANCE` parameter. If the current rangefinder distance is less than it, the ground contact is considered detected without other conditions taken into account.

We have had some tests of this patch (but only versus Firmware v1.8.2) with a VL53L1X rangefinder, and it showed much improvement of auto disarming on landing. We had about 20 short indoor flights, and all the time the drone disarmed successfully. 

Alternative way may be to have rangefinder clearance as a `SENS_` parameter instead of `LNDMC_` parameter. Also, multiple rangefinder setups support is not yet implemented.

