### PR TITLE
LPE: use minimum flow altitude from uORB instead of hardcoding

### DIFF
--- a/src/modules/local_position_estimator/sensors/flow.cpp
+++ b/src/modules/local_position_estimator/sensors/flow.cpp
@@ -10,9 +10,6 @@ extern orb_advert_t mavlink_log_pub;
 static const uint32_t		REQ_FLOW_INIT_COUNT = 10;
 static const uint32_t		FLOW_TIMEOUT = 1000000;	// 1 s
 
-// minimum flow altitude
-static const float flow_min_agl = 0.3;
-
 void BlockLocalPositionEstimator::flowInit()
 {
 	// measure
@@ -44,7 +41,7 @@ int BlockLocalPositionEstimator::flowMeasure(Vector<float, n_y_flow> &y)
 	}
 
 	// check for agl
-	if (agl() < flow_min_agl) {
+	if (agl() < _sub_flow.get().min_ground_distance) {
 		return -1;
 	}
 


### PR DESCRIPTION
Use minimum flow altitude from the uORB message, which is actually filled by the driver or by `mavlink_receiver`.

In most cases, it equals to `SENS_FLOW_MINHGT` parameter.