### PR TITLE
Fix Snapdragon linking

### DIFF
--- a/boards/atlflight/eagle/default.cmake
+++ b/boards/atlflight/eagle/default.cmake
@@ -84,7 +84,7 @@ px4_add_board(
 		mc_pos_control
 		navigator
 		sensors
-		sih
+		#sih
 		simulator
 		vmount
 		vtol_att_control

--- a/boards/atlflight/eagle/qurt-default.cmake
+++ b/boards/atlflight/eagle/qurt-default.cmake
@@ -74,7 +74,7 @@ px4_add_board(
 		mc_att_control
 		mc_pos_control
 		sensors
-		sih
+		#sih
 		vmount
 		vtol_att_control
 		wind_estimator

--- a/src/platforms/px4_atomic.h
+++ b/src/platforms/px4_atomic.h
@@ -80,7 +80,11 @@ public:
 	 */
 	inline T load() const
 	{
+#ifdef __PX4_QURT
+		return _value;
+#else
 		return __atomic_load_n(&_value, __ATOMIC_SEQ_CST);
+#endif
 	}
 
 	/**
@@ -88,7 +92,11 @@ public:
 	 */
 	inline void store(T value)
 	{
+#ifdef __PX4_QURT
+		_value = value;
+#else
 		__atomic_store(&_value, &value, __ATOMIC_SEQ_CST);
+#endif
 	}
 
 	/**
@@ -159,7 +167,13 @@ public:
 	}
 
 private:
+#ifdef __PX4_QURT
+	// It seems that __atomic_store  and __atomic_load are not supported on Qurt,
+	// so the best that we can do is to use volatile.
+	volatile T _value;
+#else
 	T _value;
+#endif
 };
 
 using atomic_int = atomic<int>;


### PR DESCRIPTION
This fixes two linking issues on Snapdragon. For more infos check out the commit messages.

The fix for the missing atomic builtin was fairly obvious, for the `_LSin` symbol I had to bisect and then remove `sih` from the Snappy build.

Fixes #11945.