### PR TITLE
Adding parameter to scale velocity in flight task get current state

### DIFF
--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -428,11 +428,11 @@ State FlightTaskAuto::_getCurrentState()
 		// Target is behind.
 		return_state = State::target_behind;
 
-	} else if (u_prev_to_target * prev_to_pos < 0.0f && prev_to_pos.length() > _mc_cruise_speed) {
+	} else if (u_prev_to_target * prev_to_pos < 0.0f && prev_to_pos.length() > _mc_cruise_speed * _param_mpc_wp_nav_acc.get()) {
 		// Current position is more than cruise speed in front of previous setpoint.
 		return_state = State::previous_infront;
 
-	} else if (Vector2f(Vector2f(_position) - _closest_pt).length() > _mc_cruise_speed) {
+	} else if (Vector2f(Vector2f(_position) - _closest_pt).length() > _mc_cruise_speed * _param_mpc_wp_nav_acc.get()) {
 		// Vehicle is more than cruise speed off track.
 		return_state = State::offtrack;
 

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -428,7 +428,8 @@ State FlightTaskAuto::_getCurrentState()
 		// Target is behind.
 		return_state = State::target_behind;
 
-	} else if (u_prev_to_target * prev_to_pos < 0.0f && prev_to_pos.length() > _mc_cruise_speed * _param_mpc_wp_nav_acc.get()) {
+	} else if (u_prev_to_target * prev_to_pos < 0.0f
+		   && prev_to_pos.length() > _mc_cruise_speed * _param_mpc_wp_nav_acc.get()) {
 		// Current position is more than cruise speed in front of previous setpoint.
 		return_state = State::previous_infront;
 

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
@@ -107,6 +107,7 @@ protected:
 	ObstacleAvoidance _obstacle_avoidance; /**< class adjusting setpoints according to external avoidance module's input */
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTask,
+					(ParamFloat<px4::params::MPC_WP_NAV_ACC>) _param_mpc_wp_nav_acc,
 					(ParamFloat<px4::params::MPC_XY_CRUISE>) _param_mpc_xy_cruise,
 					(ParamFloat<px4::params::MPC_CRUISE_90>) _param_mpc_cruise_90, // speed at corner when angle is 90 degrees move to line
 					(ParamFloat<px4::params::NAV_MC_ALT_RAD>)

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -250,6 +250,20 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_D, 0.01f);
 PARAM_DEFINE_FLOAT(MPC_XY_CRUISE, 5.0f);
 
 /**
+ * Navigator waypoint acceptance threshold
+ *
+ * Threshold for the internal waypoint update in 
+ * FLightTaskAuto state machine.
+ * 
+ * @min 1.0
+ * @max 1000.0
+ * @increment 1
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_WP_NAV_ACC, 1.0f);
+
+/**
  * Proportional gain for horizontal trajectory position error
  *
  * @min 0.1

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -252,9 +252,8 @@ PARAM_DEFINE_FLOAT(MPC_XY_CRUISE, 5.0f);
 /**
  * Navigator waypoint acceptance threshold
  *
- * Threshold for the internal waypoint update in 
- * FLightTaskAuto state machine.
- * 
+ * Threshold for the internal waypoint update in FLightTaskAuto state machine.
+ *
  * @min 1.0
  * @max 1000.0
  * @increment 1


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
The state machine in FlightTaskAuto, which is aimed to update the internal waypoint triplet, uses the velocity (_mc_cruise_speed) as parameter. However, one may want a different condition to meet one of those states. With the addition of MPC_WP_NAV_ACC there is the freedom to scale the parameter used by the state machine. If it is equal to 1 nothing changes.
This feature is interesting also because if the acceptance radius is big, it is possible that the drone does not move to the next waypoint because it is in "offtrack" or "previous_infront" state. If the value of MPC_WP_NAV_ACC is large enough this problem can be avoided.
