### PR TITLE
vscode minor settings update

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,4 @@
 {
-        "editor.insertSpaces": false,
-        "editor.tabSize": 8,
-        "editor.wordWrapColumn": 120,
-        "editor.suggest.localityBonus": true,
         "astyle.astylerc": "${workspaceFolder}/Tools/astyle/astylerc",
         "astyle.c.enable": true,
         "astyle.cpp.enable": true,
@@ -67,6 +63,17 @@
         "C_Cpp.intelliSenseEngine": "Default",
         "C_Cpp.intelliSenseEngineFallback": "Disabled",
         "debug.toolBarLocation": "docked",
+        "editor.insertSpaces": false,
+        "editor.minimap.maxColumn": 120,
+        "editor.minimap.renderCharacters": false,
+        "editor.minimap.showSlider": "always",
+        "editor.smoothScrolling": true,
+        "editor.suggest.localityBonus": true,
+        "editor.tabSize": 8,
+        "editor.wordWrapColumn": 120,
+        "explorer.openEditors.visible": 0,
+        "files.insertFinalNewline": true,
+        "files.trimTrailingWhitespace": true,
         "git.detectSubmodulesLimit": 20,
         "files.associations": {
                 "*.jinja": "jinja"
@@ -75,8 +82,10 @@
                 "build/**": true
         },
         "search.showLineNumbers": true,
-        "workbench.statusBar.feedback.visible": false,
+        "window.title": "${dirty} ${activeEditorMedium}${separator}${rootName}",
         "workbench.editor.enablePreview": false,
         "workbench.editor.enablePreviewFromQuickOpen": false,
-        "workbench.editor.highlightModifiedTabs": true
+        "workbench.editor.highlightModifiedTabs": true,
+        "workbench.settings.enableNaturalLanguageSearch": false,
+        "workbench.statusBar.feedback.visible": false
 }


### PR DESCRIPTION
A few minor vscode settings I've found to be useful (without being too opinionated).

 - minimap size and display
 - title bar show file path and modified
 - disable natural language search (sends keystrokes to Bing)

![Screenshot from 2019-05-06 15-54-25](https://user-images.githubusercontent.com/84712/57251233-512d6900-7017-11e9-882b-5c35ec408882.png)
