### PR TITLE
sitl_gazebo updates and cleanup

### DIFF
--- a/Tools/sitl_run.sh
+++ b/Tools/sitl_run.sh
@@ -65,9 +65,9 @@ SIM_PID=0
 
 # Allow speed factor to bet set from environment.
 if [[ -n "$PX4_SIM_SPEED_FACTOR" ]]; then
-    speed_factor=$PX4_SIM_SPEED_FACTOR
+	speed_factor=$PX4_SIM_SPEED_FACTOR
 else
-    speed_factor=1
+	speed_factor=1
 fi
 
 if [ "$program" == "jmavsim" ] && [ ! -n "$no_sim" ]; then
@@ -116,7 +116,7 @@ export PX4_SIM_MODEL=${model}
 
 
 if [[ -n "$DONT_RUN" ]]; then
-    echo "Not running simulation (\$DONT_RUN is set)."
+	echo "Not running simulation (\$DONT_RUN is set)."
 elif [ "$debugger" == "lldb" ]; then
 	eval lldb -- $sitl_command
 elif [ "$debugger" == "gdb" ]; then


### PR DESCRIPTION
This contains https://github.com/PX4/sitl_gazebo/pull/316 which enables communication on UDP port 14550 for QGC and 14540 for the SDK for HITL simulation. This is now as it is already described in the [docs](https://dev.px4.io/master/en/simulation/hitl.html#jmavsimgazebo-hitl-environment). 

~Also, we now give `gzserver` and `gzclient` one second to clean up before escalating to `SIGKILL`. This is an attempt to prevent bind errors where the port is not cleaned up properly.~

We now disable the `TIME_WAIT` TCP state and reset the port using `RST` immediately on `gzserver` shutdown.

~Hopefully~ fixes: https://github.com/PX4/sitl_gazebo/issues/289