### PR TITLE
PositionControl: tiny minimal thrust length

### DIFF
--- a/src/modules/mc_pos_control/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl.cpp
@@ -265,6 +265,9 @@ void PositionControl::_velocityController(const float &dt)
 	float uMax = -_param_mpc_thr_min.get();
 	float uMin = -_param_mpc_thr_max.get();
 
+	// make sure there's always enough thrust vector length to infer the attitude
+	uMax = math::min(uMax, -10e-4f);
+
 	// Apply Anti-Windup in D-direction.
 	bool stop_integral_D = (thrust_desired_D >= uMax && vel_err(2) >= 0.0f) ||
 			       (thrust_desired_D <= uMin && vel_err(2) <= 0.0f);

--- a/src/modules/mc_pos_control/Utility/ControlMath.cpp
+++ b/src/modules/mc_pos_control/Utility/ControlMath.cpp
@@ -57,8 +57,7 @@ vehicle_attitude_setpoint_s thrustToAttitude(const Vector3f &thr_sp, const float
 
 	} else {
 		// no thrust, set Z axis to safe value
-		body_z.zero();
-		body_z(2) = 1.0f;
+		body_z = Vector3f(0.f, 0.f, 1.f);
 	}
 
 	// vector of desired yaw direction in XY plane, rotated by PI/2


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
To be able to still infer the direction of the thrust vector we limit it to a minimal length even if `MPC_THR_MIN` is set to zero. The parameter `MPC_THR_MIN` already needs to be forced to 0 so this is really an extreme corner case.

Note: This is a hotfix for certain specific applications. The direction of the thrust vector in this corner case is very likely to get into the tilt limit which is generally undesired.

**Test data / coverage**
SITL tests:
- **Without** a tiny minimal thrust added in this PR flying unsmoothed position control with `MPC_THR_MIN` set to 0 and demanding a downwards step which results in hard downwards acceleration:
https://logs.px4.io/plot_app?log=4ef6a4cf-359e-4561-adbb-5a93387a981e
thrust goes to (0,0,0) attitude roll and pitch go to level.
![without](https://user-images.githubusercontent.com/4668506/57354740-931bf380-716c-11e9-9843-40bc3ef41749.PNG)

- **With** a tiny minimal thrust added in this PR flying unsmoothed position control with `MPC_THR_MIN` set to 0 and demanding a downwards step:
https://logs.px4.io/plot_app?log=58cae91c-5896-45ea-8e12-b45551d28250
The thrust keeps a minimum length and hence roll and pitch can still be infered.
![with](https://user-images.githubusercontent.com/4668506/57357162-9a460000-7172-11e9-8c29-6c8c9348ac54.PNG)


**Describe your preferred solution**
It's desirable to keep the attitude information in the thrust vector and therefore it should never be exactly (0,0,0).

**Additional context**
A remaining problem that existed before is that if e.g. to accelerate downwards very hard the thrust vector in z-axis direction gets zero (which means demanded idle thrust and hence almost freefall) the desired attitude should not tilt extremely just because the result of the velocity control is 90 degree tilt in the direction of the horizontal error.

I disucussed with @bresch that it would makes sense to at least not demand the direction of the thrust vector to change faster than the maximal rate to rate controller will execute in the end. Otherwise we know beforehands it will result in a large unfeasible error.
