### PR TITLE
ToneAlarm: ignore topic updates with 0 timestamp

### DIFF
--- a/src/drivers/tone_alarm/ToneAlarm.cpp
+++ b/src/drivers/tone_alarm/ToneAlarm.cpp
@@ -139,7 +139,10 @@ void ToneAlarm::orb_update()
 
 	if (updated) {
 		orb_copy(ORB_ID(tune_control), _tune_control_sub, &_tune);
-		_play_tone = _tunes.set_control(_tune) == 0;
+
+		if (_tune.timestamp > 0) {
+			_play_tone = _tunes.set_control(_tune) == 0;
+		}
 	}
 }
 


### PR DESCRIPTION
Commander initially publishes a tune_control topic set to 0, which can interfere with the startup tone (as happening on the Pixhawk Cube).

A nicer solution would be if we had a separate orb_advertise API w/o initial publication.

Fixes https://github.com/PX4/Firmware/issues/11980.