### PR TITLE
Update jMAVsim submodule and use SDK port in HITL

### DIFF
--- a/Tools/jmavsim_run.sh
+++ b/Tools/jmavsim_run.sh
@@ -10,7 +10,7 @@ extra_args=
 baudrate=921600
 device=
 ip="127.0.0.1"
-while getopts ":b:d:p:qr:f:i:l" opt; do
+while getopts ":b:d:p:qsr:f:i:l" opt; do
 	case $opt in
 		b)
 			baudrate=$OPTARG
@@ -26,6 +26,9 @@ while getopts ":b:d:p:qr:f:i:l" opt; do
 			;;
 		q)
 			extra_args="$extra_args -qgc"
+			;;
+		s)
+			extra_args="$extra_args -sdk"
 			;;
 		r)
 			extra_args="$extra_args -r $OPTARG"


### PR DESCRIPTION
This includes two small fixes for jMAVSim HITL, for more detail check the commit messages.

Tested:
- jMAVSim HITL
- jMAVSim SITL
- jMAVSim SITL with two vehicles