### PR TITLE
Testing: hotfix to recover test coverage CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,6 +415,9 @@ endif()
 
 # optionally enable cmake testing (supported only on posix)
 option(CMAKE_TESTING "Configure test targets" OFF)
+if (${PX4_CONFIG} STREQUAL "px4_sitl_test")
+	set(CMAKE_TESTING ON)
+endif()
 if(CMAKE_TESTING)
 	include(CTest) # sets BUILD_TESTING variable
 endif()

--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,6 @@ format:
 .PHONY: rostest python_coverage
 
 tests:
-	$(eval CMAKE_ARGS += -DCMAKE_TESTING=ON)
 	$(eval CMAKE_ARGS += -DCONFIG=px4_sitl_test)
 	$(eval CMAKE_ARGS += -DTESTFILTER=$(TESTFILTER))
 	$(eval ARGS += test_results)


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
CMAKE_TESTING should automatically be enabled but I hoped to do that in the test.cmake target specific options and not in the main CMakeLists. I have to see if I can reorder to have a nicer separation working. Here the hotfix to make CI work again.

**Test data / coverage**
I tested locally if it properly configures `make tests` as well as `make px4_sitl_test test_results_junit` used by CI.

**Additional context**
https://codecov.io/gh/PX4/Firmware/
@dagar informed me about CI coverage builds failing:
e.g. http://ci.px4.io:8080/blue/organizations/jenkins/PX4_misc%2FFirmware-SITL_tests_coverage/detail/master/310/pipeline/
after #11573 was merged. This was not caught by CI running on the PR because there are additional targets only built on master.