### PR TITLE
Auto - Yaw fixes for goto and hold

### DIFF
--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
@@ -104,6 +104,8 @@ protected:
 	float _target_acceptance_radius = 0.0f; /**< Acceptances radius of the target */
 	int _mission_gear = landing_gear_s::GEAR_KEEP;
 
+	float _yaw_sp_prev = NAN;
+
 	ObstacleAvoidance _obstacle_avoidance; /**< class adjusting setpoints according to external avoidance module's input */
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTask,
@@ -119,7 +121,6 @@ protected:
 private:
 	matrix::Vector2f _lock_position_xy{NAN, NAN}; /**< if no valid triplet is received, lock positition to current position */
 	bool _yaw_lock = false; /**< if within acceptance radius, lock yaw to current yaw */
-	float _yaw_sp_prev = NAN;
 	uORB::Subscription<position_setpoint_triplet_s> *_sub_triplet_setpoint{nullptr};
 	uORB::Subscription<vehicle_status_s> *_sub_vehicle_status{nullptr};
 

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -254,6 +254,15 @@ void FlightTaskAutoLineSmoothVel::_generateTrajectory()
 
 	_updateTrajConstraints();
 
+	// If the acceleration and velocities are small and that we want to stop, reduce the amplitude of the jerk signal
+	// to help the optimizer to converge towards zero
+	if (Vector2f(_velocity_setpoint).length() < (0.01f * _param_mpc_xy_traj_p.get())
+	    && Vector2f(accel_sp_smooth).length() < 0.2f
+	    && Vector2f(vel_sp_smooth).length() < 0.1f) {
+		_trajectory[0].setMaxJerk(1.f);
+		_trajectory[1].setMaxJerk(1.f);
+	}
+
 	for (int i = 0; i < 3; ++i) {
 		_trajectory[i].updateDurations(_deltatime, _velocity_setpoint(i));
 	}

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -91,7 +91,7 @@ bool FlightTaskAutoLineSmoothVel::_generateHeadingAlongTraj()
 	bool res = false;
 	Vector2f vel_sp_xy(_velocity_setpoint);
 
-	if (vel_sp_xy.length() > .01f) {
+	if (vel_sp_xy.length() > .1f) {
 		// Generate heading from velocity vector, only if it is long enough
 		_compute_heading_from_2D_vector(_yaw_setpoint, vel_sp_xy);
 		res = true;

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -82,8 +82,6 @@ void FlightTaskAutoLineSmoothVel::_generateHeading()
 	if (!_generateHeadingAlongTraj()) {
 		_yaw_setpoint = _yaw_sp_prev;
 	}
-
-	_yaw_sp_prev = _yaw_setpoint;
 }
 
 bool FlightTaskAutoLineSmoothVel::_generateHeadingAlongTraj()

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -79,7 +79,6 @@ protected:
 	void _generateTrajectory();
 	VelocitySmoothing _trajectory[3]; ///< Trajectories in x, y and z directions
 
-	float _yaw_sp_prev{NAN};
 	bool _want_takeoff{false};
 
 	/* counters for estimator local position resets */


### PR DESCRIPTION
This PR brings the following improvements:
- fixes https://github.com/PX4/Firmware/issues/11960 by increasing the threshold used to determine if the velocity setpoint vector is large enough to generate a yaw setpoint  with `MPC_YAW_MODE` 3 (along trajectory)
- jerk reduction when at low speed/acceleration to help the trajectory optimizer to converge towards zero

@tops4u Can you test that please?