### PR TITLE
vehicle_control_mode needs to be updated when offboard_control_mode is changed

### DIFF
--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -1511,7 +1511,18 @@ Commander::run()
 		orb_check(offboard_control_mode_sub, &updated);
 
 		if (updated) {
+			offboard_control_mode_s old = offboard_control_mode;
 			orb_copy(ORB_ID(offboard_control_mode), offboard_control_mode_sub, &offboard_control_mode);
+
+			if (old.ignore_thrust != offboard_control_mode.ignore_thrust ||
+			    old.ignore_attitude != offboard_control_mode.ignore_attitude ||
+			    old.ignore_bodyrate != offboard_control_mode.ignore_bodyrate ||
+			    old.ignore_position != offboard_control_mode.ignore_position ||
+			    old.ignore_velocity != offboard_control_mode.ignore_velocity ||
+			    old.ignore_acceleration_force != offboard_control_mode.ignore_acceleration_force ||
+			    old.ignore_alt_hold != offboard_control_mode.ignore_alt_hold) {
+				status_changed = true;
+			}
 		}
 
 		if (offboard_control_mode.timestamp != 0 &&


### PR DESCRIPTION
For dynamic flights in `OFFBOARD` mode it's necessary to switch between position/velocity/attitude/rates submodes fast.

For now, changes is `offboard_control_mode` topic does not trigger Commander to update the status, so the `vehicle_control_mode` doesn't get updated, causing delays (_0.1–0.2 s_) for publishing appropriate setpoints. 

Like in this log, where automatic flip is performed (notice the delay between `offboard_control_mode` and `vehicle_control_mode` updates):

<img width="1123" alt="nofix" src="https://user-images.githubusercontent.com/1683279/57567551-92d95d80-73e3-11e9-90ff-bbd8bb3bfcf8.png">

https://logs.px4.io/plot_app?log=fd5ad882-c4fb-49cc-9713-9201a6ee1379

This fix makes updates simultaneous:

<img width="1123" alt="fix" src="https://user-images.githubusercontent.com/1683279/57567566-f6638b00-73e3-11e9-985f-2a1612e6b857.png">

https://logs.px4.io/plot_app?log=8c115337-4469-4de3-8490-33d619d66d21

These logs are from SITL, but we experienced the same on real hardware. In v1.8.2 it was making automatic flips impossible, without ugly hacks to switch to position control earlier to compensate the possible delay.

@dagar 