### PR TITLE
bebop2 fixed upload script and slightly improved gains

### DIFF
--- a/boards/parrot/bebop/CMakeLists.txt
+++ b/boards/parrot/bebop/CMakeLists.txt
@@ -39,7 +39,7 @@ add_subdirectory(flow)
 ############################################################################
 
 add_custom_target(upload
-	COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/adb_upload_to_bebop.sh ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/. /data/ftp/internal_000
+	COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/adb_upload_to_bebop.sh ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/bin/. /data/ftp/internal_000/px4
 	DEPENDS px4
 	COMMENT "uploading px4"
 	USES_TERMINAL

--- a/boards/parrot/bebop/scripts/adb_upload.sh
+++ b/boards/parrot/bebop/scripts/adb_upload.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+if [[ "$#" < 2 ]]; then
+	echo "usage: adb_upload.sh SRC1 [SRC2 ...] DEST"
+	exit
+fi
+
+# Get last argument
+for last; do true; done
+
+echo "Wait for device..."
+adb wait-for-device
+
+echo "Creating folder structure..."
+adb shell mkdir -p $last
+
+echo "Uploading..."
+# Go through source files and push them one by one.
+i=0
+for arg
+do
+	if [[ $((i+1)) == "$#" ]]; then
+		break
+	fi
+	echo "Pushing $arg to $last"
+	adb push $arg $last
+	((i+=1))
+done
+
+# Make sure they are synced to the file system
+echo "Syncing FS..."
+adb shell sync

--- a/boards/parrot/bebop/scripts/adb_upload_to_bebop.sh
+++ b/boards/parrot/bebop/scripts/adb_upload_to_bebop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-SRC_DIR="$BASEDIR/../"
+SRC_DIR="$BASEDIR/../../../../"
 
 if [ -z ${BEBOP_IP+x} ]; then 
   ip=192.168.42.1
@@ -65,3 +65,7 @@ adb shell sync
 
 echo "Disconnecting from Bebop"
 adb disconnect
+
+echo ""
+echo "To start PX4, run the following command on the Bebop:"
+echo "/data/ftp/internal_000/px4/px4 -s /home/root/px4.config /data/ftp/internal_000/px4/"

--- a/posix-configs/bebop/px4.config
+++ b/posix-configs/bebop/px4.config
@@ -17,7 +17,7 @@ param set MPC_XY_VEL_P 0.12
 param set MPC_XY_P 1.3
 param set MPC_XY_VEL_D 0.006
 param set MPC_XY_VEL_I 0.05
-param set MPC_XY_VEL_MAX 8
+param set MPC_XY_VEL_MAX 12
 
 param set MPC_Z_VEL_P 0.3
 param set MPC_Z_VEL_I 0.1
@@ -26,15 +26,15 @@ param set MC_YAW_P 3.0
 param set MC_YAWRATE_P 0.05
 param set MC_YAWRATE_I 3.0
 
-param set MC_ROLLRATE_P 0.07
+param set MC_ROLLRATE_P 0.05
 param set MC_ROLLRATE_I 0.5
 param set MC_ROLLRATE_D 0.0
-param set MC_RR_INT_LIM 0.5
+param set MC_RR_INT_LIM 0.3
 
 param set MC_PITCHRATE_P 0.1
 param set MC_PITCHRATE_I 0.8
 param set MC_PITCHRATE_D 0.0
-param set MC_PR_INT_LIM 0.5
+param set MC_PR_INT_LIM 0.3
 
 df_ms5607_wrapper start
 df_mpu6050_wrapper start -R 8

--- a/src/platforms/px4_defines.h
+++ b/src/platforms/px4_defines.h
@@ -159,7 +159,7 @@ __END_DECLS
 #  if defined(__PX4_POSIX_EAGLE) || defined(__PX4_POSIX_EXCELSIOR)
 #    define PX4_ROOTFSDIR "/home/linaro"
 #  elif defined(__PX4_POSIX_BEBOP)
-#    define PX4_ROOTFSDIR "/data/ftp/internal_000"
+#    define PX4_ROOTFSDIR "/data/ftp/internal_000/px4"
 #  else
 #    define PX4_ROOTFSDIR "."
 #  endif


### PR DESCRIPTION
The upload script for Parrot Bebop 2 was broken. This PR fixes that. It does not (yet) automatically start PX4 after uploading.

Also changed the default installation folder on the bebop to `/data/ftp/internal_000/px4/` which is similar to installation directories of ardupilot and paparazzi.