### PR TITLE
Fix gcc9 warnings

### DIFF
--- a/src/drivers/distance_sensor/cm8jl65/cm8jl65.cpp
+++ b/src/drivers/distance_sensor/cm8jl65/cm8jl65.cpp
@@ -194,7 +194,7 @@ CM8JL65::CM8JL65(const char *port, uint8_t rotation) :
 	_comms_errors(perf_alloc(PC_COUNT, "cm8jl65_com_err"))
 {
 	/* store port name */
-	strncpy(_port, port, sizeof(_port));
+	strncpy(_port, port, sizeof(_port) - 1);
 	/* enforce null termination */
 	_port[sizeof(_port) - 1] = '\0';
 

--- a/src/drivers/distance_sensor/pga460/pga460.cpp
+++ b/src/drivers/distance_sensor/pga460/pga460.cpp
@@ -46,7 +46,7 @@ extern "C" __EXPORT int pga460_main(int argc, char *argv[]);
 PGA460::PGA460(const char *port)
 {
 	// Store port name.
-	strncpy(_port, port, sizeof(_port));
+	strncpy(_port, port, sizeof(_port) - 1);
 	// Enforce null termination.
 	_port[sizeof(_port) - 1] = '\0';
 }

--- a/src/drivers/distance_sensor/sf0x/sf0x.cpp
+++ b/src/drivers/distance_sensor/sf0x/sf0x.cpp
@@ -189,7 +189,7 @@ SF0X::SF0X(const char *port, uint8_t rotation) :
 	_comms_errors(perf_alloc(PC_COUNT, "sf0x_com_err"))
 {
 	/* store port name */
-	strncpy(_port, port, sizeof(_port));
+	strncpy(_port, port, sizeof(_port) - 1);
 	/* enforce null termination */
 	_port[sizeof(_port) - 1] = '\0';
 

--- a/src/drivers/distance_sensor/tfmini/tfmini.cpp
+++ b/src/drivers/distance_sensor/tfmini/tfmini.cpp
@@ -190,7 +190,7 @@ TFMINI::TFMINI(const char *port, uint8_t rotation) :
 	_comms_errors(perf_alloc(PC_COUNT, "tfmini_com_err"))
 {
 	/* store port name */
-	strncpy(_port, port, sizeof(_port));
+	strncpy(_port, port, sizeof(_port) - 1);
 	/* enforce null termination */
 	_port[sizeof(_port) - 1] = '\0';
 }

--- a/src/drivers/distance_sensor/ulanding/ulanding.cpp
+++ b/src/drivers/distance_sensor/ulanding/ulanding.cpp
@@ -147,7 +147,7 @@ Radar::Radar(uint8_t rotation, const char *port) :
 
 {
 	/* store port name */
-	strncpy(_port, port, sizeof(_port));
+	strncpy(_port, port, sizeof(_port) - 1);
 	/* enforce null termination */
 	_port[sizeof(_port) - 1] = '\0';
 }

--- a/src/drivers/gps/gps.cpp
+++ b/src/drivers/gps/gps.cpp
@@ -285,7 +285,7 @@ GPS::GPS(const char *path, gps_driver_mode_t mode, GPSHelper::Interface interfac
 	_instance(instance)
 {
 	/* store port name */
-	strncpy(_port, path, sizeof(_port));
+	strncpy(_port, path, sizeof(_port) - 1);
 	/* enforce null termination */
 	_port[sizeof(_port) - 1] = '\0';
 

--- a/src/lib/FlightTasks/CMakeLists.txt
+++ b/src/lib/FlightTasks/CMakeLists.txt
@@ -104,7 +104,9 @@ add_custom_command(
 # Create Flight Tasks Library
 ###########################################
 
-add_compile_options(-Wno-cast-align) # TODO: fix and enable
+add_compile_options(
+	-Wno-cast-align
+	) # TODO: fix and enable
 
 px4_add_library(FlightTasks
 	FlightTasks.cpp

--- a/src/modules/mavlink/CMakeLists.txt
+++ b/src/modules/mavlink/CMakeLists.txt
@@ -40,6 +40,7 @@ px4_add_module(
 	STACK_MAX 1600
 	COMPILE_FLAGS
 		-Wno-cast-align # TODO: fix and enable
+		-Wno-address-of-packed-member # TODO: fix in c_library_v2
 	INCLUDES
 		${PX4_SOURCE_DIR}/mavlink/include/mavlink
 	SRCS

--- a/src/modules/mavlink/mavlink_tests/CMakeLists.txt
+++ b/src/modules/mavlink/mavlink_tests/CMakeLists.txt
@@ -43,6 +43,7 @@ px4_add_module(
 		-DMavlinkStream=MavlinkStreamTest
 		-DMavlinkFTP=MavlinkFTPTest
 		-Wno-cast-align # TODO: fix and enable
+		-Wno-address-of-packed-member # TODO: fix in c_library_v2
 	SRCS
 		mavlink_tests.cpp
 		mavlink_ftp_test.cpp

--- a/src/modules/simulator/CMakeLists.txt
+++ b/src/modules/simulator/CMakeLists.txt
@@ -61,6 +61,7 @@ px4_add_module(
 	COMPILE_FLAGS
 		-Wno-double-promotion
 		-Wno-cast-align
+		-Wno-address-of-packed-member # TODO: fix in c_library_v2
 	INCLUDES
 		${PX4_SOURCE_DIR}/mavlink/include/mavlink
 	SRCS

--- a/src/modules/simulator/accelsim/CMakeLists.txt
+++ b/src/modules/simulator/accelsim/CMakeLists.txt
@@ -37,6 +37,7 @@ px4_add_module(
 	COMPILE_FLAGS
 		-Wno-double-promotion
 		-Wno-cast-align # TODO: fix and enable
+		-Wno-address-of-packed-member # TODO: fix in c_library_v2
 	SRCS
 		accelsim.cpp
 	DEPENDS

--- a/src/modules/simulator/airspeedsim/CMakeLists.txt
+++ b/src/modules/simulator/airspeedsim/CMakeLists.txt
@@ -37,6 +37,7 @@ px4_add_module(
 	COMPILE_FLAGS
 		-Wno-double-promotion
 		-Wno-cast-align # TODO: fix and enable
+		-Wno-address-of-packed-member # TODO: fix in c_library_v2
 	SRCS
 		airspeedsim.cpp
 		meas_airspeed_sim.cpp

--- a/src/modules/simulator/barosim/CMakeLists.txt
+++ b/src/modules/simulator/barosim/CMakeLists.txt
@@ -37,6 +37,7 @@ px4_add_module(
 	COMPILE_FLAGS
 		-Wno-double-promotion
 		-Wno-cast-align # TODO: fix and enable
+		-Wno-address-of-packed-member # TODO: fix in c_library_v2
 	SRCS
 		baro.cpp
 	DEPENDS

--- a/src/modules/simulator/gpssim/CMakeLists.txt
+++ b/src/modules/simulator/gpssim/CMakeLists.txt
@@ -37,6 +37,7 @@ px4_add_module(
 	COMPILE_FLAGS
 		-Wno-double-promotion
 		-Wno-cast-align # TODO: fix and enable
+		-Wno-address-of-packed-member # TODO: fix in c_library_v2
 	SRCS
 		gpssim.cpp
 	DEPENDS

--- a/src/modules/simulator/gyrosim/CMakeLists.txt
+++ b/src/modules/simulator/gyrosim/CMakeLists.txt
@@ -37,6 +37,7 @@ px4_add_module(
 	COMPILE_FLAGS
 		-Wno-double-promotion
 		-Wno-cast-align # TODO: fix and enable
+		-Wno-address-of-packed-member # TODO: fix in c_library_v2
 	STACK_MAIN 1200
 	SRCS
 		gyrosim.cpp


### PR DESCRIPTION
This fixes build warnings with GCC 9. (Hello Fedora 30 :smiley:.)

I'll follow up on the MAVLink warnings elsewhere.