### PR TITLE
Jerk parameter for auto mode

### DIFF
--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -201,9 +201,9 @@ void FlightTaskAutoLineSmoothVel::_updateTrajConstraints()
 	_trajectory[1].setMaxAccel(_param_mpc_acc_hor_max.get());
 	_trajectory[0].setMaxVel(_param_mpc_xy_vel_max.get());
 	_trajectory[1].setMaxVel(_param_mpc_xy_vel_max.get());
-	_trajectory[0].setMaxJerk(_param_mpc_jerk_min.get()); // TODO : Should be computed using heading
-	_trajectory[1].setMaxJerk(_param_mpc_jerk_min.get());
-	_trajectory[2].setMaxJerk(_param_mpc_jerk_min.get());
+	_trajectory[0].setMaxJerk(_param_mpc_jerk_auto.get()); // TODO : Should be computed using heading
+	_trajectory[1].setMaxJerk(_param_mpc_jerk_auto.get());
+	_trajectory[2].setMaxJerk(_param_mpc_jerk_auto.get());
 
 	if (_velocity_setpoint(2) < 0.f) { // up
 		_trajectory[2].setMaxAccel(_param_mpc_acc_up_max.get());

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -60,7 +60,7 @@ protected:
 					(ParamFloat<px4::params::MPC_ACC_UP_MAX>) _param_mpc_acc_up_max,
 					(ParamFloat<px4::params::MPC_ACC_DOWN_MAX>) _param_mpc_acc_down_max,
 					(ParamFloat<px4::params::MPC_ACC_HOR_MAX>) _param_mpc_acc_hor_max,
-					(ParamFloat<px4::params::MPC_JERK_MIN>) _param_mpc_jerk_min,
+					(ParamFloat<px4::params::MPC_JERK_AUTO>) _param_mpc_jerk_auto,
 					(ParamFloat<px4::params::MPC_XY_TRAJ_P>) _param_mpc_xy_traj_p,
 					(ParamFloat<px4::params::MPC_Z_TRAJ_P>) _param_mpc_z_traj_p
 				       );

--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.hpp
@@ -57,7 +57,6 @@ protected:
 	virtual void _updateSetpoints() override;
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTaskManualPosition,
-					(ParamFloat<px4::params::MPC_JERK_MIN>) _param_mpc_jerk_min, /**< Minimum jerk (velocity-based if > 0) */
 					(ParamFloat<px4::params::MPC_JERK_MAX>) _param_mpc_jerk_max,
 					(ParamFloat<px4::params::MPC_ACC_UP_MAX>) _param_mpc_acc_up_max,
 					(ParamFloat<px4::params::MPC_ACC_DOWN_MAX>) _param_mpc_acc_down_max

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -87,7 +87,7 @@ PARAM_DEFINE_FLOAT(MPC_THR_HOVER, 0.5f);
  * (e.g. if hover thrust is set to 20%, 80% of the upper thrust range is squeezed into the
  * upper half of the stick range).
  *
- * Note: in case MPC_THR_HOVER is set to 50%, the modes 0 and 1 are the same.
+ * Note: In case MPC_THR_HOVER is set to 50%, the modes 0 and 1 are the same.
  *
  * @value 0 Rescale to hover thrust
  * @value 1 No Rescale
@@ -427,7 +427,10 @@ PARAM_DEFINE_FLOAT(MPC_HOLD_MAX_Z, 0.6f);
 PARAM_DEFINE_FLOAT(MPC_VELD_LP, 5.0f);
 
 /**
- * Maximum horizontal acceleration for auto mode and maximum deceleration for manual mode
+ * Maximum horizontal acceleration for auto mode and for manual mode
+ *
+ * Manual mode: Maximum deceleration for MPC_POS_MODE 1 and 2. Maximum acceleration and deceleration for MPC_POS_MODE 3.
+ * Auto mode: Used with MPC_AUTO_MODE 0 only. For MPC_AUTO_MODE 1, MPC_ACC_HOR is always used.
  *
  * @unit m/s/s
  * @min 2.0
@@ -441,6 +444,8 @@ PARAM_DEFINE_FLOAT(MPC_ACC_HOR_MAX, 10.0f);
 /**
  * Acceleration for auto and for manual
  *
+ * Note: In manual, this parameter is only used in MPC_POS_MODE 1 and 2
+ *
  * @unit m/s/s
  * @min 2.0
  * @max 15.0
@@ -453,6 +458,8 @@ PARAM_DEFINE_FLOAT(MPC_ACC_HOR, 5.0f);
 
 /**
  * Slow horizontal manual deceleration for manual mode
+ *
+ * Note: This is only used when MPC_POS_MODE is set to 1 or 2.
  *
  * @unit m/s/s
  * @min 0.5
@@ -511,7 +518,7 @@ PARAM_DEFINE_FLOAT(MPC_ACC_DOWN_MAX, 10.0f);
  *
  * Setting this to the maximum value essentially disables the limit.
  *
- * Note: this is only used when MPC_POS_MODE is set to a smoothing mode.
+ * Note: This is only used when MPC_POS_MODE is set to a smoothing mode.
  *
  * @unit m/s/s/s
  * @min 0.5
@@ -534,7 +541,7 @@ PARAM_DEFINE_FLOAT(MPC_JERK_MAX, 20.0f);
  *
  * Set this to zero to use a fixed maximum jerk limit (MPC_JERK_MAX).
  *
- * Note: this is only used when MPC_POS_MODE is set to a smoothing mode.
+ * Note: This is only used when MPC_POS_MODE is set to 1 or 2.
  *
  * @unit m/s/s/s
  * @min 0
@@ -544,6 +551,24 @@ PARAM_DEFINE_FLOAT(MPC_JERK_MAX, 20.0f);
  * @group Multicopter Position Control
  */
 PARAM_DEFINE_FLOAT(MPC_JERK_MIN, 8.0f);
+
+/**
+ * Jerk limit in auto mode
+ *
+ * Limit the maximum jerk of the vehicle (how fast the acceleration can change).
+ * A lower value leads to smoother vehicle motions, but it also limits its
+ * agility.
+ *
+ * Note: This is only used in jerk-limited trajectory mode (MPC_AUTO_MODE 1)
+ *
+ * @unit m/s/s/s
+ * @min 5.0
+ * @max 80.0
+ * @increment 1
+ * @decimal 1
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_JERK_AUTO, 8.0f);
 
 /**
  * Altitude control mode.

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -444,7 +444,7 @@ PARAM_DEFINE_FLOAT(MPC_ACC_HOR_MAX, 10.0f);
 /**
  * Acceleration for auto and for manual
  *
- * Note: In manual, this parameter is only used in MPC_POS_MODE 1 and 2
+ * Note: In manual, this parameter is only used in MPC_POS_MODE 1.
  *
  * @unit m/s/s
  * @min 2.0
@@ -459,7 +459,7 @@ PARAM_DEFINE_FLOAT(MPC_ACC_HOR, 5.0f);
 /**
  * Slow horizontal manual deceleration for manual mode
  *
- * Note: This is only used when MPC_POS_MODE is set to 1 or 2.
+ * Note: This is only used when MPC_POS_MODE is set to 1.
  *
  * @unit m/s/s
  * @min 0.5
@@ -518,7 +518,7 @@ PARAM_DEFINE_FLOAT(MPC_ACC_DOWN_MAX, 10.0f);
  *
  * Setting this to the maximum value essentially disables the limit.
  *
- * Note: This is only used when MPC_POS_MODE is set to a smoothing mode.
+ * Note: This is only used when MPC_POS_MODE is set to a smoothing mode 1 or 3.
  *
  * @unit m/s/s/s
  * @min 0.5
@@ -541,7 +541,7 @@ PARAM_DEFINE_FLOAT(MPC_JERK_MAX, 20.0f);
  *
  * Set this to zero to use a fixed maximum jerk limit (MPC_JERK_MAX).
  *
- * Note: This is only used when MPC_POS_MODE is set to 1 or 2.
+ * Note: This is only used when MPC_POS_MODE is set to 1.
  *
  * @unit m/s/s/s
  * @min 0


### PR DESCRIPTION
Until now, `MPC_JERK_MIN` was used in `MPC_AUTO_MODE` 1 (limited-jerk trajectory). This was not specified in the description of the parameter and was not a good choice.

I created here a dedicated jerk parameter for auto mode. Also, the parameters specify in which manual/auto modes they are used and how.