### PR TITLE
[WIP] ekf2: reduce GPS initialization time for SITL from 10s to 0.5s

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -116,6 +116,8 @@ then
 	param set EKF2_ANGERR_INIT 0.01
 	param set EKF2_HGT_MODE 0
 	param set EKF2_GBIAS_INIT 0.01
+	# Speedup SITL startup
+	param set EKF2_REQ_GPS_H 0.5
 
 	# LPE: GPS only mode
 	param set LPE_FUSION 145

--- a/src/modules/ekf2/ekf2_main.cpp
+++ b/src/modules/ekf2/ekf2_main.cpp
@@ -521,7 +521,9 @@ private:
 
 		// Test used to determine if the vehicle is static or moving
 		(ParamExtFloat<px4::params::EKF2_MOVE_TEST>)
-		_param_ekf2_move_test	///< scaling applied to IMU data thresholds used to determine if the vehicle is static or moving.
+		_param_ekf2_move_test,	///< scaling applied to IMU data thresholds used to determine if the vehicle is static or moving.
+
+		(ParamFloat<px4::params::EKF2_REQ_GPS_H>) _param_ekf2_req_gps_h	///< Required GPS health time
 
 	)
 
@@ -651,6 +653,8 @@ Ekf2::Ekf2():
 
 	// initialise parameter cache
 	updateParams();
+
+	_ekf.set_min_required_gps_health_time(_param_ekf2_req_gps_h.get() * 1_s);
 }
 
 Ekf2::~Ekf2()

--- a/src/modules/ekf2/ekf2_params.c
+++ b/src/modules/ekf2/ekf2_params.c
@@ -1355,3 +1355,17 @@ PARAM_DEFINE_FLOAT(EKF2_GPS_TAU, 10.0f);
  * @decimal 1
  */
 PARAM_DEFINE_FLOAT(EKF2_MOVE_TEST, 1.0f);
+
+/**
+ * Required GPS health time on startup
+ *
+ * Minimum continuous period without GPS failure required to mark a healthy GPS status.
+ * It can be reduced to speed up initialization, but it's recommended to keep this unchanged for a vehicle.
+ *
+ * @group EKF2
+ * @min 0.1
+ * @decimal 1
+ * @unit s
+ * @reboot_required true
+ */
+PARAM_DEFINE_FLOAT(EKF2_REQ_GPS_H, 10.0f);


### PR DESCRIPTION
Speeds up SITL startup (from https://github.com/PX4/ecl/pull/603).

The ecl submodule update also includes https://github.com/PX4/ecl/pull/597, which is why this PR is marked as WIP and not meant to be merged before the release.
@RomanBapst fyi.