### PR TITLE
Add lockstep scheduler test to gtest unit test

### DIFF
--- a/platforms/posix/src/CMakeLists.txt
+++ b/platforms/posix/src/CMakeLists.txt
@@ -31,9 +31,8 @@
 #
 ############################################################################
 
-if (ENABLE_LOCKSTEP_SCHEDULER)
-	add_subdirectory(lockstep_scheduler)
-endif()
 
 add_subdirectory(px4_daemon)
 add_subdirectory(px4_layer)
+
+add_subdirectory(lockstep_scheduler)

--- a/platforms/posix/src/lockstep_scheduler/CMakeLists.txt
+++ b/platforms/posix/src/lockstep_scheduler/CMakeLists.txt
@@ -1,41 +1,13 @@
 cmake_minimum_required(VERSION 2.8.12)
 
-if(NOT PROJECT_NAME STREQUAL "px4")
+# We want to test the lockstep schedule even if it is not used otherwise.
+add_library(lockstep_scheduler
+	src/lockstep_scheduler.cpp
+)
 
-	project(lockstep_scheduler)
+target_include_directories(lockstep_scheduler
+	PUBLIC
+	${CMAKE_CURRENT_SOURCE_DIR}/include
+)
 
-	set (CMAKE_CXX_STANDARD 11)
-
-	add_definitions(-DUNIT_TESTS)
-
-	add_library(lockstep_scheduler
-		src/lockstep_scheduler.cpp
-	)
-
-	target_include_directories(lockstep_scheduler
-		PUBLIC
-			$<INSTALL_INTERFACE:include>
-			$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-		PRIVATE
-			${CMAKE_CURRENT_SOURCE_DIR}/src
-	)
-
-	target_link_libraries(lockstep_scheduler
-		pthread
-	)
-
-	target_compile_options(lockstep_scheduler PRIVATE -Wall -Wextra -Werror -O2)
-
-	add_subdirectory(test)
-
-else()
-
-	add_library(lockstep_scheduler
-		src/lockstep_scheduler.cpp
-	)
-	target_include_directories(lockstep_scheduler
-		PUBLIC
-		${CMAKE_CURRENT_SOURCE_DIR}/include
-	)
-
-endif()
+px4_add_gtest(SRC test/src/lockstep_scheduler_test.cpp LINKLIBS lockstep_scheduler)

--- a/platforms/posix/src/lockstep_scheduler/include/lockstep_scheduler/lockstep_scheduler.h
+++ b/platforms/posix/src/lockstep_scheduler/include/lockstep_scheduler/lockstep_scheduler.h
@@ -40,9 +40,7 @@ private:
 			// thread_local object can still be in the linked list. In that case
 			// we need to wait until it's removed.
 			while (!removed) {
-#ifndef UNIT_TESTS // unit tests don't define system_usleep and execute faster w/o sleeping here
 				system_usleep(5000);
-#endif
 			}
 		}
 

--- a/src/include/visibility.h
+++ b/src/include/visibility.h
@@ -101,6 +101,9 @@
 
 #else // defined(ENABLE_LOCKSTEP_SCHEDULER)
 
+#include <stdlib.h>
+#include <unistd.h>
+
 #define system_usleep usleep
 #define system_sleep sleep
 #define system_clock_gettime clock_gettime

--- a/src/include/visibility.h
+++ b/src/include/visibility.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2012-2018 PX4 Development Team. All rights reserved.
+ *   Copyright (C) 2012-2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -59,68 +59,67 @@
 #  define __END_DECLS
 #endif
 
+
+
+
+
 /* exit() is used on NuttX to exit a task. However on Posix, it will exit the
  * whole application, so we prevent its use there. There are cases where it
  * still needs to be used, thus we remap system_exit to exit.
  */
 #define system_exit exit
-
-#if defined(ENABLE_LOCKSTEP_SCHEDULER)
-
+#if !defined(__PX4_NUTTX)
 #include <stdlib.h>
-#include <unistd.h>
-
-#define system_usleep usleep
-#pragma GCC poison usleep
-#define system_sleep sleep
-#pragma GCC poison sleep
-
-#define system_clock_gettime clock_gettime
-#define system_clock_settime clock_settime
-
-#include <pthread.h>
-#define system_pthread_cond_timedwait pthread_cond_timedwait
-// We can't poison pthread_cond_timedwait because it seems to be used in the
-// <string> include.
-
 #ifdef __cplusplus
 #include <cstdlib>
 #endif
+/* We should include cstdlib or stdlib.h but this doesn't
+ * compile because many C++ files include stdlib.h and would
+ * need to get changed. */
 #pragma GCC poison exit
+#endif // !defined(__PX4_NUTTX)
 
-#include <stdlib.h>
 
-#ifdef __cplusplus
-#include <cstdlib>
-#endif
-
-// We don't poison usleep and sleep on NuttX because it is used in dependencies
-// like uavcan and we don't need to fake time on the real system.
-#include <unistd.h>
+/* For SITL lockstep we fake the clock, sleeping, and timedwaits
+ * Therefore, we prefix these syscalls with system_. */
 #include <time.h>
-
-#else // defined(ENABLE_LOCKSTEP_SCHEDULER)
-
-#include <stdlib.h>
-#include <unistd.h>
-
-#define system_usleep usleep
-#define system_sleep sleep
 #define system_clock_gettime clock_gettime
 #define system_clock_settime clock_settime
+/* We can't poison clock_settime/clock_gettime because they are
+ * used in DriverFramework. */
+
+#if !defined(__PX4_NUTTX)
+#include <pthread.h>
+// We can't include this for NuttX otherwise we get conflicts for read/write
+// symbols in cannode.
+#endif // !defined(__PX4_NUTTX)
 #define system_pthread_cond_timedwait pthread_cond_timedwait
+/* We can't poison pthread_cond_timedwait because it seems to be used in the
+ * <string> include. */
 
-#endif
+
+/* We don't poison usleep and sleep because it is used in dependencies
+ * like uavcan and DriverFramework. */
+#if !defined(__PX4_NUTTX)
+#include <unistd.h>
+// We can't include this for NuttX otherwise we get conflicts for read/write
+// symbols in cannode.
+#endif // !defined(__PX4_NUTTX)
+#define system_usleep usleep
+#define system_sleep sleep
 
 
-#if defined(__PX4_NUTTX)
 /* On NuttX we call clearenv() so we cannot use getenv() and others (see
  * px4_task_spawn_cmd() in px4_nuttx_tasks.c).
  * We need to include the headers declaring getenv() before the pragma,
  * otherwise it will trigger a poison error.  */
+#if defined(__PX4_NUTTX)
 #include <stdlib.h>
 #ifdef __cplusplus
 #include <cstdlib>
 #endif
+/* We should include cstdlib or stdlib.h but this doesn't
+ * compile because many C++ files include stdlib.h and would
+ * need to get changed. */
 #pragma GCC poison getenv setenv putenv
 #endif // defined(__PX4_NUTTX)


### PR DESCRIPTION
This adds the existing but unused lockstep scheduler tests to the gtest unit test framework. It now runs with `make tests` even though lockstep is in general disabled for the test target (at least for now).