### PR TITLE
px4_poll posix: fix wrap-around for large timeouts

### DIFF
--- a/src/lib/cdev/posix/cdev_platform.cpp
+++ b/src/lib/cdev/posix/cdev_platform.cpp
@@ -377,7 +377,7 @@ extern "C" {
 
 				// Calculate an absolute time in the future
 				const unsigned billion = (1000 * 1000 * 1000);
-				uint64_t nsecs = ts.tv_nsec + (timeout * 1000 * 1000);
+				uint64_t nsecs = ts.tv_nsec + ((uint64_t)timeout * 1000 * 1000);
 				ts.tv_sec += nsecs / billion;
 				nsecs -= (nsecs / billion) * billion;
 				ts.tv_nsec = nsecs;


### PR DESCRIPTION
`timeout` is an int, so it wraps when the poll timeout is >2147ms.
This happened in logger, resulting in poll never returning.