### PR TITLE
Fix bug Auto Land

### DIFF
--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -177,10 +177,12 @@ bool FlightTaskAuto::_evaluateTriplets()
 		} else {
 			tmp_target(0) = _lock_position_xy(0);
 			tmp_target(1) = _lock_position_xy(1);
-			_lock_position_xy.setAll(NAN);
 		}
 
 	} else {
+		// reset locked position if current lon and lat are valid
+		_lock_position_xy.setAll(NAN);
+
 		// Convert from global to local frame.
 		map_projection_project(&_reference_position,
 				       _sub_triplet_setpoint->get().current.lat, _sub_triplet_setpoint->get().current.lon, &tmp_target(0), &tmp_target(1));


### PR DESCRIPTION
While working with Auto Land, I realized the position lock was reset at every iteration thus not actually locking the position when the current latitude and longitude aren't valid. 

EDIT: the other weird thing in auto land is this line https://github.com/PX4/Firmware/blob/master/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp#L189

it sets `_triplet_target` z to the `reference_altitude` since the triplet altitude is 0

**Test data / coverage**
SITL logs

before PR
![beforePR](https://user-images.githubusercontent.com/15078736/57919418-13db9d80-7899-11e9-8b26-f903cdf94b9c.png)
after PR
![afterPR](https://user-images.githubusercontent.com/15078736/57919433-19d17e80-7899-11e9-90e5-8ba00dbd9fe3.png)
