### PR TITLE
Mavlink split BATTERY_STATUS from SYS_STATUS update and handle all bricks

### DIFF
--- a/src/modules/mavlink/mavlink_high_latency2.cpp
+++ b/src/modules/mavlink/mavlink_high_latency2.cpp
@@ -158,20 +158,19 @@ bool MavlinkStreamHighLatency2::send(const hrt_abstime t)
 				_airspeed_sp.get_scaled(msg.airspeed_sp, 5.0f);
 			}
 
-			int lowest = -1;
+			int lowest = 0;
 
-			for (int i = 0; i < BOARD_NUMBER_BRICKS; i++) {
+			for (int i = 1; i < BOARD_NUMBER_BRICKS; i++) {
 				const bool battery_connected = _battery_connected[i] && _battery[i].valid();
-				const bool battery_is_lowest =  lowest < 0 ||
-								_battery[i].get_scaled(100.0f) <= _battery[lowest].get_scaled(100.0f);
+				const bool battery_is_lowest = _battery[i].get_scaled(100.0f) <= _battery[lowest].get_scaled(100.0f);
 
-				if (battery_connected && (lowest == -1 || battery_is_lowest)) {
+				if (battery_connected && battery_is_lowest) {
 					lowest = i;
 				}
 
 			}
 
-			if (lowest >= 0) {
+			if (_battery_connected[lowest]) {
 				_battery[lowest].get_scaled(msg.battery, 100.0f);
 
 			} else {

--- a/src/modules/mavlink/mavlink_high_latency2.h
+++ b/src/modules/mavlink/mavlink_high_latency2.h
@@ -44,6 +44,12 @@
 #include "mavlink_simple_analyzer.h"
 #include "mavlink_stream.h"
 
+class SimplerAnalyzer : public SimpleAnalyzer
+{
+public:
+	SimplerAnalyzer() : SimpleAnalyzer(SimpleAnalyzer::AVERAGE) {}
+};
+
 class MavlinkStreamHighLatency2 : public MavlinkStream
 {
 public:
@@ -95,8 +101,8 @@ private:
 	MavlinkOrbSubscription *_attitude_sp_sub;
 	uint64_t _attitude_sp_time;
 
-	MavlinkOrbSubscription *_battery_sub;
-	uint64_t _battery_time;
+	MavlinkOrbSubscription *_battery_sub[BOARD_NUMBER_BRICKS];
+	uint64_t _battery_time[BOARD_NUMBER_BRICKS];
 
 	MavlinkOrbSubscription *_estimator_status_sub;
 	uint64_t _estimator_status_time;
@@ -130,7 +136,8 @@ private:
 
 	SimpleAnalyzer _airspeed;
 	SimpleAnalyzer _airspeed_sp;
-	SimpleAnalyzer _battery;
+	// Use the SimplerAnalyzer because C++ needs this data type to have a default constructor
+	SimplerAnalyzer _battery[BOARD_NUMBER_BRICKS];
 	SimpleAnalyzer _climb_rate;
 	SimpleAnalyzer _eph;
 	SimpleAnalyzer _epv;
@@ -142,6 +149,8 @@ private:
 	hrt_abstime _last_reset_time = 0;
 	hrt_abstime _last_update_time = 0;
 	float _update_rate_filtered = 0.0f;
+
+	bool _battery_connected[BOARD_NUMBER_BRICKS];
 
 	/* do not allow top copying this class */
 	MavlinkStreamHighLatency2(MavlinkStreamHighLatency2 &);

--- a/src/modules/mavlink/mavlink_high_latency2.h
+++ b/src/modules/mavlink/mavlink_high_latency2.h
@@ -44,12 +44,6 @@
 #include "mavlink_simple_analyzer.h"
 #include "mavlink_stream.h"
 
-class SimplerAnalyzer : public SimpleAnalyzer
-{
-public:
-	SimplerAnalyzer() : SimpleAnalyzer(SimpleAnalyzer::AVERAGE) {}
-};
-
 class MavlinkStreamHighLatency2 : public MavlinkStream
 {
 public:
@@ -89,6 +83,15 @@ public:
 	}
 
 private:
+
+	struct PerBatteryData {
+		PerBatteryData() {}
+		MavlinkOrbSubscription *subscription;
+		SimpleAnalyzer analyzer{SimpleAnalyzer::AVERAGE};
+		uint64_t timestamp{0};
+		bool connected{false};
+	};
+
 	MavlinkOrbSubscription *_actuator_sub_0;
 	uint64_t _actuator_time_0;
 
@@ -100,9 +103,6 @@ private:
 
 	MavlinkOrbSubscription *_attitude_sp_sub;
 	uint64_t _attitude_sp_time;
-
-	MavlinkOrbSubscription *_battery_sub[BOARD_NUMBER_BRICKS];
-	uint64_t _battery_time[BOARD_NUMBER_BRICKS];
 
 	MavlinkOrbSubscription *_estimator_status_sub;
 	uint64_t _estimator_status_time;
@@ -136,8 +136,6 @@ private:
 
 	SimpleAnalyzer _airspeed;
 	SimpleAnalyzer _airspeed_sp;
-	// Use the SimplerAnalyzer because C++ needs this data type to have a default constructor
-	SimplerAnalyzer _battery[BOARD_NUMBER_BRICKS];
 	SimpleAnalyzer _climb_rate;
 	SimpleAnalyzer _eph;
 	SimpleAnalyzer _epv;
@@ -150,7 +148,7 @@ private:
 	hrt_abstime _last_update_time = 0;
 	float _update_rate_filtered = 0.0f;
 
-	bool _battery_connected[BOARD_NUMBER_BRICKS];
+	PerBatteryData _batteries[BOARD_NUMBER_BRICKS];
 
 	/* do not allow top copying this class */
 	MavlinkStreamHighLatency2(MavlinkStreamHighLatency2 &);

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1633,7 +1633,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("UTM_GLOBAL_POSITION", 1.0f);
 		configure_stream_local("VFR_HUD", 4.0f);
 		configure_stream_local("WIND_COV", 1.0f);
-		configure_stream_local("BATTERY_STATUS", 1.0f);
+		configure_stream_local("BATTERY_STATUS", 0.5f);
 		break;
 
 	case MAVLINK_MODE_ONBOARD:
@@ -1676,7 +1676,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("UTM_GLOBAL_POSITION", 1.0f);
 		configure_stream_local("VFR_HUD", 10.0f);
 		configure_stream_local("WIND_COV", 10.0f);
-		configure_stream_local("BATTERY_STATUS", 1.0f);
+		configure_stream_local("BATTERY_STATUS", 0.5f);
 		break;
 
 	case MAVLINK_MODE_EXTVISION:
@@ -1718,7 +1718,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("UTM_GLOBAL_POSITION", 1.0f);
 		configure_stream_local("VFR_HUD", 4.0f);
 		configure_stream_local("WIND_COV", 1.0f);
-		configure_stream_local("BATTERY_STATUS", 1.0f);
+		configure_stream_local("BATTERY_STATUS", 0.5f);
 		break;
 
 
@@ -1737,7 +1737,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("SYSTEM_TIME", 1.0f);
 		configure_stream_local("VFR_HUD", 25.0f);
 		configure_stream_local("WIND_COV", 2.0f);
-		configure_stream_local("BATTERY_STATUS", 1.0f);
+		configure_stream_local("BATTERY_STATUS", 0.5f);
 		break;
 
 	case MAVLINK_MODE_MAGIC:
@@ -1790,7 +1790,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("UTM_GLOBAL_POSITION", 1.0f);
 		configure_stream_local("VFR_HUD", 20.0f);
 		configure_stream_local("WIND_COV", 10.0f);
-		configure_stream_local("BATTERY_STATUS", 1.0f);
+		configure_stream_local("BATTERY_STATUS", 0.5f);
 		break;
 
 	case MAVLINK_MODE_IRIDIUM:

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1633,6 +1633,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("UTM_GLOBAL_POSITION", 1.0f);
 		configure_stream_local("VFR_HUD", 4.0f);
 		configure_stream_local("WIND_COV", 1.0f);
+		configure_stream_local("BATTERY_STATUS", 1.0f);
 		break;
 
 	case MAVLINK_MODE_ONBOARD:
@@ -1675,6 +1676,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("UTM_GLOBAL_POSITION", 1.0f);
 		configure_stream_local("VFR_HUD", 10.0f);
 		configure_stream_local("WIND_COV", 10.0f);
+		configure_stream_local("BATTERY_STATUS", 1.0f);
 		break;
 
 	case MAVLINK_MODE_EXTVISION:
@@ -1716,6 +1718,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("UTM_GLOBAL_POSITION", 1.0f);
 		configure_stream_local("VFR_HUD", 4.0f);
 		configure_stream_local("WIND_COV", 1.0f);
+		configure_stream_local("BATTERY_STATUS", 1.0f);
 		break;
 
 
@@ -1734,6 +1737,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("SYSTEM_TIME", 1.0f);
 		configure_stream_local("VFR_HUD", 25.0f);
 		configure_stream_local("WIND_COV", 2.0f);
+		configure_stream_local("BATTERY_STATUS", 1.0f);
 		break;
 
 	case MAVLINK_MODE_MAGIC:
@@ -1786,6 +1790,7 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		configure_stream_local("UTM_GLOBAL_POSITION", 1.0f);
 		configure_stream_local("VFR_HUD", 20.0f);
 		configure_stream_local("WIND_COV", 10.0f);
+		configure_stream_local("BATTERY_STATUS", 1.0f);
 		break;
 
 	case MAVLINK_MODE_IRIDIUM:

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -589,7 +589,7 @@ protected:
 
 			for (int i = 0; i < BOARD_NUMBER_BRICKS; i++) {
 				if (!updated_battery[i]) {
-					_battery_status_sub[i]->update(&_battery_status_timestamp[i], &battery_status[i]);
+					_battery_status_sub[i]->update(&battery_status[i]);
 				}
 
 				if (battery_status[i].connected && battery_status[i].remaining < lowest_battery->remaining) {
@@ -692,7 +692,7 @@ protected:
 				continue;
 			}
 
-			battery_status_s battery_status{};
+			battery_status_s battery_status;
 
 			if (_battery_status_sub[i]->update(&_battery_status_timestamp[i], &battery_status)) {
 				/* battery status message with higher resolution */

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -602,34 +602,6 @@ protected:
 
 			mavlink_msg_sys_status_send_struct(_mavlink->get_channel(), &msg);
 
-			/* battery status message with higher resolution */
-			mavlink_battery_status_t bat_msg = {};
-			bat_msg.id = 0;
-			bat_msg.battery_function = MAV_BATTERY_FUNCTION_ALL;
-			bat_msg.type = MAV_BATTERY_TYPE_LIPO;
-			bat_msg.current_consumed = (battery_status.connected) ? battery_status.discharged_mah : -1;
-			bat_msg.energy_consumed = -1;
-			bat_msg.current_battery = (battery_status.connected) ? battery_status.current_filtered_a * 100 : -1;
-			bat_msg.battery_remaining = (battery_status.connected) ? ceilf(battery_status.remaining * 100.0f) : -1;
-			bat_msg.temperature = (battery_status.connected) ? (int16_t)battery_status.temperature : INT16_MAX;
-			//bat_msg.average_current_battery = (battery_status.connected) ? battery_status.average_current_a * 100.0f : -1;
-			//bat_msg.serial_number = (battery_status.connected) ? battery_status.serial_number : 0;
-			//bat_msg.capacity = (battery_status.connected) ? battery_status.capacity : 0;
-			//bat_msg.cycle_count = (battery_status.connected) ? battery_status.cycle_count : UINT16_MAX;
-			//bat_msg.run_time_to_empty = (battery_status.connected) ? battery_status.run_time_to_empty * 60 : 0;
-			//bat_msg.average_time_to_empty = (battery_status.connected) ? battery_status.average_time_to_empty * 60 : 0;
-
-			for (unsigned int i = 0; i < (sizeof(bat_msg.voltages) / sizeof(bat_msg.voltages[0])); i++) {
-				if ((int)i < battery_status.cell_count && battery_status.connected) {
-					bat_msg.voltages[i] = (battery_status.voltage_v / battery_status.cell_count) * 1000.0f;
-
-				} else {
-					bat_msg.voltages[i] = UINT16_MAX;
-				}
-			}
-
-			mavlink_msg_battery_status_send_struct(_mavlink->get_channel(), &bat_msg);
-
 			return true;
 		}
 
@@ -637,6 +609,101 @@ protected:
 	}
 };
 
+class MavlinkStreamBatteryStatus : public MavlinkStream
+{
+public:
+	const char *get_name() const
+	{
+		return MavlinkStreamBatteryStatus::get_name_static();
+	}
+
+	static const char *get_name_static()
+	{
+		return "BATTERY_STATUS";
+	}
+
+	static uint16_t get_id_static()
+	{
+		return MAVLINK_MSG_ID_BATTERY_STATUS;
+	}
+
+	uint16_t get_id()
+	{
+		return get_id_static();
+	}
+
+	static MavlinkStream *new_instance(Mavlink *mavlink)
+	{
+		return new MavlinkStreamBatteryStatus(mavlink);
+	}
+
+	unsigned get_size()
+	{
+		return MAVLINK_MSG_ID_BATTERY_STATUS_LEN + MAVLINK_NUM_NON_PAYLOAD_BYTES;
+	}
+
+private:
+	MavlinkOrbSubscription *_battery_status_sub[BOARD_NUMBER_BRICKS] {};
+
+	uint64_t _battery_status_timestamp[BOARD_NUMBER_BRICKS] {};
+
+	/* do not allow top copying this class */
+	MavlinkStreamBatteryStatus(MavlinkStreamSysStatus &) = delete;
+	MavlinkStreamBatteryStatus &operator = (const MavlinkStreamSysStatus &) = delete;
+
+protected:
+	explicit MavlinkStreamBatteryStatus(Mavlink *mavlink) : MavlinkStream(mavlink)
+	{
+		for (int i = 0; i < BOARD_NUMBER_BRICKS; i++) {
+			_battery_status_sub[i] = _mavlink->add_orb_subscription(ORB_ID(battery_status), i);
+		}
+	}
+
+	bool send(const hrt_abstime t)
+	{
+		bool updated = false;
+
+		for (int i = 0; i < BOARD_NUMBER_BRICKS; i++) {
+			if (_battery_status_sub[i]) {
+				battery_status_s battery_status{};
+
+				if (_battery_status_sub[i]->update(&_battery_status_timestamp[i], &battery_status)) {
+					/* battery status message with higher resolution */
+					mavlink_battery_status_t bat_msg{};
+					bat_msg.id = i;
+					bat_msg.battery_function = MAV_BATTERY_FUNCTION_ALL;
+					bat_msg.type = MAV_BATTERY_TYPE_LIPO;
+					bat_msg.current_consumed = (battery_status.connected) ? battery_status.discharged_mah : -1;
+					bat_msg.energy_consumed = -1;
+					bat_msg.current_battery = (battery_status.connected) ? battery_status.current_filtered_a * 100 : -1;
+					bat_msg.battery_remaining = (battery_status.connected) ? ceilf(battery_status.remaining * 100.0f) : -1;
+					bat_msg.temperature = (battery_status.connected) ? (int16_t)battery_status.temperature : INT16_MAX;
+					//bat_msg.average_current_battery = (battery_status.connected) ? battery_status.average_current_a * 100.0f : -1;
+					//bat_msg.serial_number = (battery_status.connected) ? battery_status.serial_number : 0;
+					//bat_msg.capacity = (battery_status.connected) ? battery_status.capacity : 0;
+					//bat_msg.cycle_count = (battery_status.connected) ? battery_status.cycle_count : UINT16_MAX;
+					//bat_msg.run_time_to_empty = (battery_status.connected) ? battery_status.run_time_to_empty * 60 : 0;
+					//bat_msg.average_time_to_empty = (battery_status.connected) ? battery_status.average_time_to_empty * 60 : 0;
+
+					for (unsigned cell = 0; cell < (sizeof(bat_msg.voltages) / sizeof(bat_msg.voltages[0])); cell++) {
+						if ((int32_t)cell < battery_status.cell_count && battery_status.connected) {
+							bat_msg.voltages[cell] = (battery_status.voltage_v / battery_status.cell_count) * 1000.0f;
+
+						} else {
+							bat_msg.voltages[cell] = UINT16_MAX;
+						}
+					}
+
+					mavlink_msg_battery_status_send_struct(_mavlink->get_channel(), &bat_msg);
+
+					updated = true;
+				}
+			}
+		}
+
+		return updated;
+	}
+};
 
 class MavlinkStreamHighresIMU : public MavlinkStream
 {

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -559,6 +559,7 @@ protected:
 	{
 		for (int i = 0; i < BOARD_NUMBER_BRICKS; i++) {
 			_battery_status_sub[i] = _mavlink->add_orb_subscription(ORB_ID(battery_status), i);
+			_battery_status_timestamp[i] = 0;
 		}
 	}
 
@@ -687,41 +688,44 @@ protected:
 
 		for (int i = 0; i < BOARD_NUMBER_BRICKS; i++) {
 
-			if (_battery_status_sub[i]) {
-				battery_status_s battery_status{};
-
-				if (_battery_status_sub[i]->update(&_battery_status_timestamp[i], &battery_status)) {
-					/* battery status message with higher resolution */
-					mavlink_battery_status_t bat_msg{};
-					bat_msg.id = i;
-					bat_msg.battery_function = MAV_BATTERY_FUNCTION_ALL;
-					bat_msg.type = MAV_BATTERY_TYPE_LIPO;
-					bat_msg.current_consumed = (battery_status.connected) ? battery_status.discharged_mah : -1;
-					bat_msg.energy_consumed = -1;
-					bat_msg.current_battery = (battery_status.connected) ? battery_status.current_filtered_a * 100 : -1;
-					bat_msg.battery_remaining = (battery_status.connected) ? ceilf(battery_status.remaining * 100.0f) : -1;
-					bat_msg.temperature = (battery_status.connected) ? (int16_t)battery_status.temperature : INT16_MAX;
-					//bat_msg.average_current_battery = (battery_status.connected) ? battery_status.average_current_a * 100.0f : -1;
-					//bat_msg.serial_number = (battery_status.connected) ? battery_status.serial_number : 0;
-					//bat_msg.capacity = (battery_status.connected) ? battery_status.capacity : 0;
-					//bat_msg.cycle_count = (battery_status.connected) ? battery_status.cycle_count : UINT16_MAX;
-					//bat_msg.run_time_to_empty = (battery_status.connected) ? battery_status.run_time_to_empty * 60 : 0;
-					//bat_msg.average_time_to_empty = (battery_status.connected) ? battery_status.average_time_to_empty * 60 : 0;
-
-					for (unsigned cell = 0; cell < (sizeof(bat_msg.voltages) / sizeof(bat_msg.voltages[0])); cell++) {
-						if ((int32_t)cell < battery_status.cell_count && battery_status.connected) {
-							bat_msg.voltages[cell] = (battery_status.voltage_v / battery_status.cell_count) * 1000.0f;
-
-						} else {
-							bat_msg.voltages[cell] = UINT16_MAX;
-						}
-					}
-
-					mavlink_msg_battery_status_send_struct(_mavlink->get_channel(), &bat_msg);
-
-					updated = true;
-				}
+			if (!_battery_status_sub[i]) {
+				continue;
 			}
+
+			battery_status_s battery_status{};
+
+			if (_battery_status_sub[i]->update(&_battery_status_timestamp[i], &battery_status)) {
+				/* battery status message with higher resolution */
+				mavlink_battery_status_t bat_msg{};
+				bat_msg.id = i;
+				bat_msg.battery_function = MAV_BATTERY_FUNCTION_ALL;
+				bat_msg.type = MAV_BATTERY_TYPE_LIPO;
+				bat_msg.current_consumed = (battery_status.connected) ? battery_status.discharged_mah : -1;
+				bat_msg.energy_consumed = -1;
+				bat_msg.current_battery = (battery_status.connected) ? battery_status.current_filtered_a * 100 : -1;
+				bat_msg.battery_remaining = (battery_status.connected) ? ceilf(battery_status.remaining * 100.0f) : -1;
+				bat_msg.temperature = (battery_status.connected) ? (int16_t)battery_status.temperature : INT16_MAX;
+				//bat_msg.average_current_battery = (battery_status.connected) ? battery_status.average_current_a * 100.0f : -1;
+				//bat_msg.serial_number = (battery_status.connected) ? battery_status.serial_number : 0;
+				//bat_msg.capacity = (battery_status.connected) ? battery_status.capacity : 0;
+				//bat_msg.cycle_count = (battery_status.connected) ? battery_status.cycle_count : UINT16_MAX;
+				//bat_msg.run_time_to_empty = (battery_status.connected) ? battery_status.run_time_to_empty * 60 : 0;
+				//bat_msg.average_time_to_empty = (battery_status.connected) ? battery_status.average_time_to_empty * 60 : 0;
+
+				for (unsigned cell = 0; cell < (sizeof(bat_msg.voltages) / sizeof(bat_msg.voltages[0])); cell++) {
+					if ((int32_t)cell < battery_status.cell_count && battery_status.connected) {
+						bat_msg.voltages[cell] = (battery_status.voltage_v / battery_status.cell_count) * 1000.0f;
+
+					} else {
+						bat_msg.voltages[cell] = UINT16_MAX;
+					}
+				}
+
+				mavlink_msg_battery_status_send_struct(_mavlink->get_channel(), &bat_msg);
+
+				updated = true;
+			}
+
 		}
 
 		return updated;

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -664,6 +664,7 @@ protected:
 		bool updated = false;
 
 		for (int i = 0; i < BOARD_NUMBER_BRICKS; i++) {
+
 			if (_battery_status_sub[i]) {
 				battery_status_s battery_status{};
 
@@ -4981,6 +4982,7 @@ static const StreamListItem streams_list[] = {
 	StreamListItem(&MavlinkStreamStatustext::new_instance, &MavlinkStreamStatustext::get_name_static, &MavlinkStreamStatustext::get_id_static),
 	StreamListItem(&MavlinkStreamCommandLong::new_instance, &MavlinkStreamCommandLong::get_name_static, &MavlinkStreamCommandLong::get_id_static),
 	StreamListItem(&MavlinkStreamSysStatus::new_instance, &MavlinkStreamSysStatus::get_name_static, &MavlinkStreamSysStatus::get_id_static),
+	StreamListItem(&MavlinkStreamBatteryStatus::new_instance, &MavlinkStreamBatteryStatus::get_name_static, &MavlinkStreamBatteryStatus::get_id_static),
 	StreamListItem(&MavlinkStreamHighresIMU::new_instance, &MavlinkStreamHighresIMU::get_name_static, &MavlinkStreamHighresIMU::get_id_static),
 	StreamListItem(&MavlinkStreamScaledIMU::new_instance, &MavlinkStreamScaledIMU::get_name_static, &MavlinkStreamScaledIMU::get_id_static),
 	StreamListItem(&MavlinkStreamScaledIMU2::new_instance, &MavlinkStreamScaledIMU2::get_name_static, &MavlinkStreamScaledIMU2::get_id_static),

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -589,6 +589,8 @@ protected:
 			msg.onboard_control_sensors_enabled = status.onboard_control_sensors_enabled;
 			msg.onboard_control_sensors_health = status.onboard_control_sensors_health;
 			msg.load = cpuload.load * 1000.0f;
+			// TODO: Determine what data should be put here when there are multiple batteries.
+			//  Is Battery 0 the primary? Should I average the voltage/current/remaining of all batteries?
 			msg.voltage_battery = (battery_status.connected) ? battery_status.voltage_filtered_v * 1000.0f : UINT16_MAX;
 			msg.current_battery = (battery_status.connected) ? battery_status.current_filtered_a * 100.0f : -1;
 			msg.battery_remaining = (battery_status.connected) ? ceilf(battery_status.remaining * 100.0f) : -1;


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
The firmware should be able to handle the case when more than one battery is being used.

**Test data / coverage**
A Pixhawk 4 was used, with two batteries at different charge levels. Each battery was plugged in and removed from the board, and the MAVLink messages were observed. The batteries were switched so that in some tests, batter 1 was lowest, and in others, battery 2 was lowest. In every case, the correct MAVLink messages were sent.

**Describe your preferred solution**
For the `BATTERY_STATUS` topic, one message is sent for each battery, each with a unique `id`. For the `SYS_STATUS` and `HIGH_LATENCY2` topics, the battery with the lowest remaining percentage is used.

**Describe possible alternatives**
`SYS_STATUS` and `HIGH_LATENCY2` could be populated always with Battery 0, or with the "main" battery. But using the lowest battery is the safest option, so that a user will not fail to see a low battery if it is the secondary.