### PR TITLE
Add PX4 magnetometer and barometer classes

### DIFF
--- a/src/lib/drivers/barometer/CMakeLists.txt
+++ b/src/lib/drivers/barometer/CMakeLists.txt
@@ -1,0 +1,34 @@
+############################################################################
+#
+#   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+px4_add_library(drivers_barometer PX4Barometer.cpp)

--- a/src/lib/drivers/barometer/PX4Barometer.cpp
+++ b/src/lib/drivers/barometer/PX4Barometer.cpp
@@ -1,0 +1,89 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+
+#include "PX4Barometer.hpp"
+
+#include <lib/drivers/device/Device.hpp>
+
+PX4Barometer::PX4Barometer(uint32_t device_id, uint8_t priority) :
+	CDev(nullptr),
+	_sensor_baro_pub{ORB_ID(sensor_baro), priority}
+{
+	_class_device_instance = register_class_devname(BARO_BASE_DEVICE_PATH);
+
+	_sensor_baro_pub.get().device_id = device_id;
+
+	// force initial publish to allocate uORB buffer
+	// TODO: can be removed once all drivers are in threads
+	_sensor_baro_pub.update();
+}
+
+PX4Barometer::~PX4Barometer()
+{
+	if (_class_device_instance != -1) {
+		unregister_class_devname(BARO_BASE_DEVICE_PATH, _class_device_instance);
+	}
+}
+
+void PX4Barometer::set_device_type(uint8_t devtype)
+{
+	// current DeviceStructure
+	union device::Device::DeviceId device_id;
+	device_id.devid = _sensor_baro_pub.get().device_id;
+
+	// update to new device type
+	device_id.devid_s.devtype = devtype;
+
+	// copy back to report
+	_sensor_baro_pub.get().device_id = device_id.devid;
+}
+
+void PX4Barometer::update(hrt_abstime timestamp, float pressure)
+{
+	sensor_baro_s &report = _sensor_baro_pub.get();
+
+	report.timestamp = timestamp;
+	report.pressure = pressure;
+
+	poll_notify(POLLIN);
+
+	_sensor_baro_pub.update();
+}
+
+void PX4Barometer::print_status()
+{
+	PX4_INFO(BARO_BASE_DEVICE_PATH " device instance: %d", _class_device_instance);
+
+	print_message(_sensor_baro_pub.get());
+}

--- a/src/lib/drivers/barometer/PX4Barometer.hpp
+++ b/src/lib/drivers/barometer/PX4Barometer.hpp
@@ -1,0 +1,64 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <drivers/drv_baro.h>
+#include <drivers/drv_hrt.h>
+#include <lib/cdev/CDev.hpp>
+#include <lib/conversion/rotation.h>
+#include <uORB/uORB.h>
+#include <uORB/Publication.hpp>
+#include <uORB/topics/sensor_baro.h>
+
+class PX4Barometer : public cdev::CDev
+{
+
+public:
+	PX4Barometer(uint32_t device_id, uint8_t priority);
+	~PX4Barometer() override;
+
+	void set_device_type(uint8_t devtype);
+	void set_error_count(uint64_t error_count) { _sensor_baro_pub.get().error_count = error_count; }
+
+	void set_temperature(float temperature) { _sensor_baro_pub.get().temperature = temperature; }
+
+	void update(hrt_abstime timestamp, float pressure);
+
+	void print_status();
+
+private:
+
+	uORB::Publication<sensor_baro_s>	_sensor_baro_pub;
+
+	int			_class_device_instance{-1};
+
+};

--- a/src/lib/drivers/magnetometer/CMakeLists.txt
+++ b/src/lib/drivers/magnetometer/CMakeLists.txt
@@ -31,4 +31,4 @@
 #
 ############################################################################
 
-px4_add_library(drivers__magnetometer PX4Magnetometer.cpp)
+px4_add_library(drivers_magnetometer PX4Magnetometer.cpp)

--- a/src/lib/drivers/magnetometer/PX4Magnetometer.cpp
+++ b/src/lib/drivers/magnetometer/PX4Magnetometer.cpp
@@ -34,118 +34,100 @@
 
 #include "PX4Magnetometer.hpp"
 
-PX4Magnetometer::PX4Magnetometer(const char *path, device::Device  *interface, uint8_t dev_type, enum Rotation rotation,
-				 float scale) :
-	CDev(path),
-	_interface(interface)
+#include <lib/drivers/device/Device.hpp>
+
+PX4Magnetometer::PX4Magnetometer(uint32_t device_id, uint8_t priority, enum Rotation rotation) :
+	CDev(nullptr),
+	_sensor_mag_pub{ORB_ID(sensor_mag), priority},
+	_rotation{rotation}
 {
-	_device_id.devid = _interface->get_device_id();
-	// _device_id.devid_s.bus_type = (device::Device::DeviceBusType)_interface->get_device_bus_type();
-	// _device_id.devid_s.bus = _interface->get_device_bus();
-	// _device_id.devid_s.address = _interface->get_device_address();
-	_device_id.devid_s.devtype = dev_type;
-
-	CDev::init();
-
 	_class_device_instance = register_class_devname(MAG_BASE_DEVICE_PATH);
 
-	_rotation = rotation;
-	_scale = scale;
+	_sensor_mag_pub.get().device_id = device_id;
+	_sensor_mag_pub.get().scaling = 1.0f;
 
-	_cal.x_offset = 0;
-	_cal.x_scale  = 1.0f;
-	_cal.y_offset = 0;
-	_cal.y_scale  = 1.0f;
-	_cal.z_offset = 0;
-	_cal.z_scale  = 1.0f;
+	// force initial publish to allocate uORB buffer
+	// TODO: can be removed once all drivers are in threads
+	_sensor_mag_pub.update();
 }
 
 PX4Magnetometer::~PX4Magnetometer()
 {
-	if (_topic != nullptr) {
-		orb_unadvertise(_topic);
+	if (_class_device_instance != -1) {
+		unregister_class_devname(MAG_BASE_DEVICE_PATH, _class_device_instance);
 	}
-}
-
-int PX4Magnetometer::init()
-{
-	mag_report report{};
-	report.device_id = _device_id.devid;
-
-	if (_topic == nullptr) {
-		_topic = orb_advertise_multi(ORB_ID(sensor_mag), &report, &_orb_class_instance, ORB_PRIO_HIGH - 1);
-
-		if (_topic == nullptr) {
-			PX4_ERR("Advertise failed.");
-			return PX4_ERROR;
-		}
-	}
-
-	return PX4_OK;
 }
 
 int PX4Magnetometer::ioctl(cdev::file_t *filp, int cmd, unsigned long arg)
 {
 	switch (cmd) {
-	case MAGIOCSSCALE:
-		// Copy scale in.
-		memcpy(&_cal, (struct mag_calibration_s *) arg, sizeof(_cal));
-		return OK;
+	case MAGIOCSSCALE: {
+			// Copy offsets and scale factors in
+			mag_calibration_s cal{};
+			memcpy(&cal, (mag_calibration_s *) arg, sizeof(cal));
 
-	case MAGIOCGSCALE:
-		// Copy scale out.
-		memcpy((struct mag_calibration_s *) arg, &_cal, sizeof(_cal));
-		return OK;
+			_calibration_offset = matrix::Vector3f{cal.x_offset, cal.y_offset, cal.z_offset};
+			_calibration_scale = matrix::Vector3f{cal.x_scale, cal.y_scale, cal.z_scale};
+		}
+
+		return PX4_OK;
 
 	case DEVIOCGDEVICEID:
-		return _device_id.devid;
+		return _sensor_mag_pub.get().device_id;
 
 	default:
-		// Give it to the superclass.
-		return CDev::ioctl(filp, cmd, arg);
+		return -ENOTTY;
 	}
 }
 
-void PX4Magnetometer::configure_filter(float sample_freq, float cutoff_freq)
+void PX4Magnetometer::set_device_type(uint8_t devtype)
 {
-	_filter_x.set_cutoff_frequency(sample_freq, cutoff_freq);
-	_filter_y.set_cutoff_frequency(sample_freq, cutoff_freq);
-	_filter_z.set_cutoff_frequency(sample_freq, cutoff_freq);
+	// current DeviceStructure
+	union device::Device::DeviceId device_id;
+	device_id.devid = _sensor_mag_pub.get().device_id;
+
+	// update to new device type
+	device_id.devid_s.devtype = devtype;
+
+	// copy back to report
+	_sensor_mag_pub.get().device_id = device_id.devid;
 }
 
-// @TODO: use fixed point math to reclaim CPU usage
-int PX4Magnetometer::publish(float x, float y, float z, float temperature)
+void PX4Magnetometer::update(hrt_abstime timestamp, int16_t x, int16_t y, int16_t z)
 {
-	sensor_mag_s report{};
+	sensor_mag_s &report = _sensor_mag_pub.get();
+	report.timestamp = timestamp;
 
-	report.device_id   = _device_id.devid;
-	report.error_count = 0;
-	report.scaling 	   = _scale;
-	report.timestamp   = hrt_absolute_time();
-	report.temperature = temperature;
-	report.is_external = false;
+	// Apply rotation (before scaling)
+	float xraw_f = x;
+	float yraw_f = y;
+	float zraw_f = z;
+	rotate_3f(_rotation, xraw_f, yraw_f, zraw_f);
 
+	// Apply range scale and the calibrating offset/scale
+	const matrix::Vector3f val_calibrated{(((matrix::Vector3f{xraw_f, yraw_f, zraw_f} * report.scaling) - _calibration_offset).emult(_calibration_scale))};
 
 	// Raw values (ADC units 0 - 65535)
 	report.x_raw = x;
 	report.y_raw = y;
 	report.z_raw = z;
 
-	// Apply the rotation.
-	rotate_3f(_rotation, x, y, z);
-
-	// Apply FS range scale and the calibrating offset/scale
-	x = ((x * _scale) - _cal.x_offset) * _cal.x_scale;
-	y = ((y * _scale) - _cal.y_offset) * _cal.y_scale;
-	z = ((z * _scale) - _cal.z_offset) * _cal.z_scale;
-
-	// Filtered values
-	report.x = _filter_x.apply(x);
-	report.y = _filter_y.apply(y);
-	report.z = _filter_z.apply(z);
+	report.x = val_calibrated(0);
+	report.y = val_calibrated(1);
+	report.z = val_calibrated(2);
 
 	poll_notify(POLLIN);
-	orb_publish(ORB_ID(sensor_mag), _topic, &report);
+	_sensor_mag_pub.update();
+}
 
-	return PX4_OK;
+void PX4Magnetometer::print_status()
+{
+	PX4_INFO(MAG_BASE_DEVICE_PATH " device instance: %d", _class_device_instance);
+
+	PX4_INFO("calibration scale: %.5f %.5f %.5f", (double)_calibration_scale(0), (double)_calibration_scale(1),
+		 (double)_calibration_scale(2));
+	PX4_INFO("calibration offset: %.5f %.5f %.5f", (double)_calibration_offset(0), (double)_calibration_offset(1),
+		 (double)_calibration_offset(2));
+
+	print_message(_sensor_mag_pub.get());
 }

--- a/src/lib/drivers/magnetometer/PX4Magnetometer.hpp
+++ b/src/lib/drivers/magnetometer/PX4Magnetometer.hpp
@@ -31,51 +31,42 @@
  *
  ****************************************************************************/
 
-
-#include <mathlib/math/filter/LowPassFilter2p.hpp>
-
-#include <drivers/device/integrator.h>
 #include <drivers/drv_mag.h>
 #include <drivers/drv_hrt.h>
-#include <lib/drivers/device/Device.hpp>
 #include <lib/cdev/CDev.hpp>
 #include <lib/conversion/rotation.h>
-#include <uORB/topics/sensor_mag.h>
 #include <uORB/uORB.h>
+#include <uORB/Publication.hpp>
+#include <uORB/topics/sensor_mag.h>
 
 class PX4Magnetometer : public cdev::CDev
 {
 
 public:
-	PX4Magnetometer(const char *name, device::Device  *interface, uint8_t dev_type, enum Rotation rotation, float scale);
+	PX4Magnetometer(uint32_t device_id, uint8_t priority, enum Rotation rotation);
 	~PX4Magnetometer() override;
 
-	int	init() override;
 	int	ioctl(cdev::file_t *filp, int cmd, unsigned long arg) override;
 
-	int publish(float x, float y, float z, float temperature);
+	void set_device_type(uint8_t devtype);
+	void set_error_count(uint64_t error_count) { _sensor_mag_pub.get().error_count = error_count; }
+	void set_scale(float scale) { _sensor_mag_pub.get().scaling = scale; }
+	void set_temperature(float temperature) { _sensor_mag_pub.get().temperature = temperature; }
+	void set_external(bool external) { _sensor_mag_pub.get().is_external = external; }
 
-	void configure_filter(float sample_freq, float cutoff_freq);
+	void update(hrt_abstime timestamp, int16_t x, int16_t y, int16_t z);
+
+	void print_status();
 
 private:
-	// Pointer to the communication interface
-	const device::Device *_interface{nullptr};
 
-	mag_calibration_s _cal{};
+	uORB::Publication<sensor_mag_s>	_sensor_mag_pub;
 
-	orb_advert_t _topic{nullptr};
+	const enum Rotation	_rotation;
 
-	device::Device::DeviceId _device_id{};
+	matrix::Vector3f	_calibration_scale{1.0f, 1.0f, 1.0f};
+	matrix::Vector3f	_calibration_offset{0.0f, 0.0f, 0.0f};
 
-	int	_orb_class_instance{-1};
+	int			_class_device_instance{-1};
 
-	int _class_device_instance{-1};
-
-	enum Rotation _rotation {ROTATION_NONE};
-
-	float _scale{1.0f};
-
-	math::LowPassFilter2p _filter_x{100, 20};
-	math::LowPassFilter2p _filter_y{100, 20};
-	math::LowPassFilter2p _filter_z{100, 20};
 };


### PR DESCRIPTION
Similar to PX4Accelerometer and PX4Gyroscope these classes collect the common pieces and requirements for each driver from the PX4 perspective.
 - orb publication (eg `sensor_mag` instances)
 - cdev registration (eg /dev/magX)
 - calibration (currently over IOCTL)
 - rotation
 - common filtering and integration (for accels and gyros)
 - status messages

Once all drivers have been transitioned we'll be able to (sanely) make more interesting sweeping changes to the sensor pipeline.