### PR TITLE
CI: add git commit hash to file description of uploaded SITL log

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -147,7 +147,7 @@ def createTestNode(Map test_def) {
           }
 
           // upload log to flight review (https://logs.px4.io/)
-          sh('px4-px4_sitl_default*/px4/Tools/upload_log.py -q --description "${JOB_NAME}: ${STAGE_NAME}: ${GIT_COMMIT:0:6}" --feedback "${JOB_NAME} ${CHANGE_TITLE} ${CHANGE_URL}" --source CI .ros/log/*/*.ulg')
+          sh('px4-px4_sitl_default*/px4/Tools/upload_log.py -q --description "${JOB_NAME}: ${STAGE_NAME}: ${GIT_COMMIT}" --feedback "${JOB_NAME} ${CHANGE_TITLE} ${CHANGE_URL}" --source CI .ros/log/*/*.ulg')
 
           if (!test_ok) {
             error('ROS Test failed')

--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -147,7 +147,7 @@ def createTestNode(Map test_def) {
           }
 
           // upload log to flight review (https://logs.px4.io/)
-          sh('px4-px4_sitl_default*/px4/Tools/upload_log.py -q --description "${JOB_NAME}: ${STAGE_NAME}" --feedback "${JOB_NAME} ${CHANGE_TITLE} ${CHANGE_URL}" --source CI .ros/log/*/*.ulg')
+          sh('px4-px4_sitl_default*/px4/Tools/upload_log.py -q --description "${JOB_NAME}: ${STAGE_NAME}: ${GIT_COMMIT:0:6}" --feedback "${JOB_NAME} ${CHANGE_TITLE} ${CHANGE_URL}" --source CI .ros/log/*/*.ulg')
 
           if (!test_ok) {
             error('ROS Test failed')

--- a/.ci/Jenkinsfile-SITL_tests_ASan
+++ b/.ci/Jenkinsfile-SITL_tests_ASan
@@ -140,7 +140,7 @@ def createTestNode(Map test_def) {
           }
 
           // upload log to flight review (https://logs.px4.io/)
-          sh('px4-px4_sitl_default*/px4/Tools/upload_log.py -q --description "${JOB_NAME}: ${STAGE_NAME}: ${GIT_COMMIT:0:6}" --feedback "${JOB_NAME} ${CHANGE_TITLE} ${CHANGE_URL}" --source CI .ros/log/*/*.ulg')
+          sh('px4-px4_sitl_default*/px4/Tools/upload_log.py -q --description "${JOB_NAME}: ${STAGE_NAME}: ${GIT_COMMIT}" --feedback "${JOB_NAME} ${CHANGE_TITLE} ${CHANGE_URL}" --source CI .ros/log/*/*.ulg')
 
           if (!test_ok) {
             error('ROS Test failed')

--- a/.ci/Jenkinsfile-SITL_tests_ASan
+++ b/.ci/Jenkinsfile-SITL_tests_ASan
@@ -140,7 +140,7 @@ def createTestNode(Map test_def) {
           }
 
           // upload log to flight review (https://logs.px4.io/)
-          sh('px4-px4_sitl_default*/px4/Tools/upload_log.py -q --description "${JOB_NAME}: ${STAGE_NAME}" --feedback "${JOB_NAME} ${CHANGE_TITLE} ${CHANGE_URL}" --source CI .ros/log/*/*.ulg')
+          sh('px4-px4_sitl_default*/px4/Tools/upload_log.py -q --description "${JOB_NAME}: ${STAGE_NAME}: ${GIT_COMMIT:0:6}" --feedback "${JOB_NAME} ${CHANGE_TITLE} ${CHANGE_URL}" --source CI .ros/log/*/*.ulg')
 
           if (!test_ok) {
             error('ROS Test failed')

--- a/.ci/Jenkinsfile-SITL_tests_coverage
+++ b/.ci/Jenkinsfile-SITL_tests_coverage
@@ -165,7 +165,7 @@ def createTestNode(Map test_def) {
             }
 
             // upload log to flight review (https://logs.px4.io/) with python code coverage
-            sh('coverage run -p Tools/upload_log.py -q --description "${JOB_NAME}: ${STAGE_NAME}: ${GIT_COMMIT:0:6}" --feedback "${JOB_NAME} ${CHANGE_TITLE} ${CHANGE_URL}" --source CI .ros/log/*/*.ulg')
+            sh('coverage run -p Tools/upload_log.py -q --description "${JOB_NAME}: ${STAGE_NAME}: ${GIT_COMMIT}" --feedback "${JOB_NAME} ${CHANGE_TITLE} ${CHANGE_URL}" --source CI .ros/log/*/*.ulg')
 
             // upload python code coverage to codecov.io
             sh 'curl -s https://codecov.io/bash | bash -s - -X gcov -F sitl_python_${STAGE_NAME}'

--- a/.ci/Jenkinsfile-SITL_tests_coverage
+++ b/.ci/Jenkinsfile-SITL_tests_coverage
@@ -165,7 +165,7 @@ def createTestNode(Map test_def) {
             }
 
             // upload log to flight review (https://logs.px4.io/) with python code coverage
-            sh('coverage run -p Tools/upload_log.py -q --description "${JOB_NAME}: ${STAGE_NAME}" --feedback "${JOB_NAME} ${CHANGE_TITLE} ${CHANGE_URL}" --source CI .ros/log/*/*.ulg')
+            sh('coverage run -p Tools/upload_log.py -q --description "${JOB_NAME}: ${STAGE_NAME}: ${GIT_COMMIT:0:6}" --feedback "${JOB_NAME} ${CHANGE_TITLE} ${CHANGE_URL}" --source CI .ros/log/*/*.ulg')
 
             // upload python code coverage to codecov.io
             sh 'curl -s https://codecov.io/bash | bash -s - -X gcov -F sitl_python_${STAGE_NAME}'


### PR DESCRIPTION
This pull request adds the hash of the current git commit to the description field of the log file uploaded to PX4 flight review during CI.

Why?
better traceability of PX4 SITL logs uploaded to flight review.

This pull request makes use of the `GIT_COMMIT` environment variable described in the [Jenkins wiki](https://wiki.jenkins.io/display/JENKINS/Building+a+software+project#Buildingasoftwareproject-JenkinsSetEnvironmentVariables). According to the wiki `all the GIT_* variables require the git plugin`. Hence, this pull request might **not work**, if the git plugin is not available.