### PR TITLE
MC position control - Add acceleration/thrust feedforward to velocity PID controller

### DIFF
--- a/msg/vehicle_local_position_setpoint.msg
+++ b/msg/vehicle_local_position_setpoint.msg
@@ -18,5 +18,8 @@ float32 jerk_x		# in meters/(sec*sec*sec)
 float32 jerk_y		# in meters/(sec*sec*sec)
 float32 jerk_z		# in meters/(sec*sec*sec)
 float32[3] thrust	# normalized thrust vector in NED
+float32 vx_target 	# desired velocity from stick input in meters/sec
+float32 vy_target 	# desired velocity from stick input in meters/sec
+float32 vz_target 	# desired velocity from stick input in meters/sec
 
 # TOPICS vehicle_local_position_setpoint trajectory_setpoint

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
@@ -69,6 +69,10 @@ const vehicle_local_position_setpoint_s FlightTask::getPositionSetpoint()
 	vehicle_local_position_setpoint.jerk_y = _jerk_setpoint(1);
 	vehicle_local_position_setpoint.jerk_z = _jerk_setpoint(2);
 
+	vehicle_local_position_setpoint.vx_target = _velocity_target(0);
+	vehicle_local_position_setpoint.vy_target = _velocity_target(1);
+	vehicle_local_position_setpoint.vz_target = _velocity_target(2);
+
 	_thrust_setpoint.copyTo(vehicle_local_position_setpoint.thrust);
 	vehicle_local_position_setpoint.yaw = _yaw_setpoint;
 	vehicle_local_position_setpoint.yawspeed = _yawspeed_setpoint;
@@ -83,6 +87,7 @@ void FlightTask::_resetSetpoints()
 	_acceleration_setpoint.setAll(NAN);
 	_jerk_setpoint.setAll(NAN);
 	_thrust_setpoint.setAll(NAN);
+	_velocity_target.setAll(NAN);
 	_yaw_setpoint = _yawspeed_setpoint = NAN;
 }
 

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
@@ -224,6 +224,7 @@ protected:
 	matrix::Vector3f _acceleration_setpoint;
 	matrix::Vector3f _jerk_setpoint;
 	matrix::Vector3f _thrust_setpoint;
+	matrix::Vector3f _velocity_target;
 	float _yaw_setpoint;
 	float _yawspeed_setpoint;
 

--- a/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.cpp
+++ b/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.cpp
@@ -80,11 +80,17 @@ bool FlightTaskManual::_evaluateSticks()
 		_sticks(2) = -(_sub_manual_control_setpoint->get().z - 0.5f) * 2.f; /* NED z, "thrust" resacaled from [0,1] to [-1,1] */
 		_sticks(3) = _sub_manual_control_setpoint->get().r; /* "yaw" [-1,1] */
 
+		float delta = 0.1f;
+		_sticks_filtered(0) = math::hysteretic_filter(_sticks(0), _sticks_filtered(0), delta);
+		_sticks_filtered(1) = math::hysteretic_filter(_sticks(1), _sticks_filtered(1), delta);
+		_sticks_filtered(2) = math::hysteretic_filter(_sticks(2), _sticks_filtered(2), delta);
+		_sticks_filtered(3) = math::hysteretic_filter(_sticks(3), _sticks_filtered(3), delta);
+
 		/* Exponential scale */
-		_sticks_expo(0) = math::expo_deadzone(_sticks(0), _param_mpc_xy_man_expo.get(), _param_mpc_hold_dz.get());
-		_sticks_expo(1) = math::expo_deadzone(_sticks(1), _param_mpc_xy_man_expo.get(), _param_mpc_hold_dz.get());
-		_sticks_expo(2) = math::expo_deadzone(_sticks(2), _param_mpc_z_man_expo.get(), _param_mpc_hold_dz.get());
-		_sticks_expo(3) = math::expo_deadzone(_sticks(3), _param_mpc_yaw_expo.get(), _param_mpc_hold_dz.get());
+		_sticks_expo(0) = math::expo_deadzone(_sticks_filtered(0), _param_mpc_xy_man_expo.get(), _param_mpc_hold_dz.get());
+		_sticks_expo(1) = math::expo_deadzone(_sticks_filtered(1), _param_mpc_xy_man_expo.get(), _param_mpc_hold_dz.get());
+		_sticks_expo(2) = math::expo_deadzone(_sticks_filtered(2), _param_mpc_z_man_expo.get(), _param_mpc_hold_dz.get());
+		_sticks_expo(3) = math::expo_deadzone(_sticks_filtered(3), _param_mpc_yaw_expo.get(), _param_mpc_hold_dz.get());
 
 		// Only switch the landing gear up if the user switched from gear down to gear up.
 		// If the user had the switch in the gear up position and took off ignore it

--- a/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.cpp
+++ b/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.cpp
@@ -80,11 +80,10 @@ bool FlightTaskManual::_evaluateSticks()
 		_sticks(2) = -(_sub_manual_control_setpoint->get().z - 0.5f) * 2.f; /* NED z, "thrust" resacaled from [0,1] to [-1,1] */
 		_sticks(3) = _sub_manual_control_setpoint->get().r; /* "yaw" [-1,1] */
 
-		float delta = 0.1f;
-		_sticks_filtered(0) = math::hysteretic_filter(_sticks(0), _sticks_filtered(0), delta);
-		_sticks_filtered(1) = math::hysteretic_filter(_sticks(1), _sticks_filtered(1), delta);
-		_sticks_filtered(2) = math::hysteretic_filter(_sticks(2), _sticks_filtered(2), delta);
-		_sticks_filtered(3) = math::hysteretic_filter(_sticks(3), _sticks_filtered(3), delta);
+		_sticks_filtered(0) = math::hysteretic_filter(_sticks(0), _sticks_filtered(0), _param_mpc_man_hyst.get());
+		_sticks_filtered(1) = math::hysteretic_filter(_sticks(1), _sticks_filtered(1), _param_mpc_man_hyst.get());
+		_sticks_filtered(2) = math::hysteretic_filter(_sticks(2), _sticks_filtered(2), _param_mpc_man_hyst.get());
+		_sticks_filtered(3) = math::hysteretic_filter(_sticks(3), _sticks_filtered(3), _param_mpc_man_hyst.get());
 
 		/* Exponential scale */
 		_sticks_expo(0) = math::expo_deadzone(_sticks_filtered(0), _param_mpc_xy_man_expo.get(), _param_mpc_hold_dz.get());

--- a/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.hpp
+++ b/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.hpp
@@ -58,6 +58,7 @@ protected:
 
 	bool _sticks_data_required = true; /**< let inherited task-class define if it depends on stick data */
 	matrix::Vector<float, 4> _sticks; /**< unmodified manual stick inputs */
+	matrix::Vector<float, 4> _sticks_filtered; /**< filtered stick inputs */
 	matrix::Vector<float, 4> _sticks_expo; /**< modified manual sticks using expo function*/
 	int _gear_switch_old = manual_control_setpoint_s::SWITCH_POS_NONE; /**< old switch state*/
 

--- a/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.hpp
+++ b/src/lib/FlightTasks/tasks/Manual/FlightTaskManual.hpp
@@ -73,6 +73,7 @@ private:
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTask,
 					(ParamFloat<px4::params::MPC_HOLD_DZ>) _param_mpc_hold_dz, /**< 0-deadzone around the center for the sticks */
+					(ParamFloat<px4::params::MPC_MAN_HYST>) _param_mpc_man_hyst, /**< hysteresis width for stick filtering*/
 					(ParamFloat<px4::params::MPC_XY_MAN_EXPO>)
 					_param_mpc_xy_man_expo, /**< ratio of exponential curve for stick input in xy direction */
 					(ParamFloat<px4::params::MPC_Z_MAN_EXPO>)

--- a/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -100,6 +100,8 @@ void FlightTaskManualAltitude::_scaleSticks()
 
 	const float vel_max_z = (_sticks(2) > 0.0f) ? _constraints.speed_down : _constraints.speed_up;
 	_velocity_setpoint(2) = vel_max_z * _sticks_expo(2);
+	_velocity_target(2) = _velocity_setpoint(2);
+
 }
 
 void FlightTaskManualAltitude::_updateAltitudeLock()

--- a/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -139,6 +139,8 @@ void FlightTaskManualPosition::_scaleSticks()
 
 	_velocity_setpoint(0) = vel_sp_xy(0);
 	_velocity_setpoint(1) = vel_sp_xy(1);
+	_velocity_target(0) = _velocity_setpoint(0);
+	_velocity_target(1) = _velocity_setpoint(1);
 }
 
 void FlightTaskManualPosition::_updateXYlock()

--- a/src/lib/mathlib/math/Functions.hpp
+++ b/src/lib/mathlib/math/Functions.hpp
@@ -125,6 +125,24 @@ const T expo_deadzone(const T &value, const T &e, const T &dz)
 	return expo(deadzone(value, dz), e);
 }
 
+template<typename T>
+const T hysteretic_filter(const T &input, const T &output_prev, const T &delta)
+{
+	T output;
+	T input_abs = fabsf(input);
+
+	if ((input_abs >= fabsf(output_prev) + delta)
+	    || (input_abs <= fabsf(output_prev) - delta)
+	    || (input_abs < 0.01f)
+	    || (input_abs >= 0.99f)) {
+		output  = input;
+
+	} else {
+		output = output_prev;
+	}
+
+	return output;
+}
 
 /*
  * Constant, linear, constant function with the two corner points as parameters

--- a/src/modules/mc_pos_control/PositionControl.cpp
+++ b/src/modules/mc_pos_control/PositionControl.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018 - 2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -170,6 +170,9 @@ bool PositionControl::_interfaceMapping()
 			// nothing is valid. do failsafe
 			failsafe = true;
 		}
+
+		// Set the acceleration setpoint to 0 if it's unused to not add anything in the feed-forward.
+		_acc_sp(i) = PX4_ISFINITE(_acc_sp(i)) ? _acc_sp(i) : 0.f;
 	}
 
 	// ensure that vel_dot is finite, otherwise set to 0

--- a/src/modules/mc_pos_control/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl.hpp
@@ -221,6 +221,7 @@ private:
 	float _yaw_sp{}; /**< desired yaw */
 	float _yawspeed_sp{}; /** desired yaw-speed */
 	matrix::Vector3f _thr_int{}; /**< thrust integral term */
+	matrix::Vector3f _acc_sp_filtered{};
 	vehicle_constraints_s _constraints{}; /**< variable constraints */
 	bool _skip_controller{false}; /**< skips position/velocity controller. true for stabilized mode */
 	bool _ctrl_pos[3] = {true, true, true}; /**< True if the control-loop for position was used */
@@ -245,6 +246,7 @@ private:
 		(ParamFloat<px4::params::MPC_XY_P>) _param_mpc_xy_p,
 		(ParamFloat<px4::params::MPC_XY_VEL_P>) _param_mpc_xy_vel_p,
 		(ParamFloat<px4::params::MPC_XY_VEL_I>) _param_mpc_xy_vel_i,
-		(ParamFloat<px4::params::MPC_XY_VEL_D>) _param_mpc_xy_vel_d
+		(ParamFloat<px4::params::MPC_XY_VEL_D>) _param_mpc_xy_vel_d,
+		(ParamFloat<px4::params::MPC_A_FF_CUTOFF>) _param_mpc_a_ff_cutoff
 	)
 };

--- a/src/modules/mc_pos_control/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl.hpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2018 - 2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -148,6 +148,13 @@ public:
 	 * 	@return The yawspeed set-point member.
 	 */
 	const float &getYawspeedSetpoint() { return _yawspeed_sp; }
+
+	/**
+	 * 	Get the
+	 * 	@see _acc_sp
+	 * 	@return The velocity set-point that was executed in the control-loop. Nan if velocity control-loop was skipped.
+	 */
+	const matrix::Vector3f getAccelerationSetpoint() { return _acc_sp; }
 
 	/**
 	 * 	Get the

--- a/src/modules/mc_pos_control/PositionControl.hpp
+++ b/src/modules/mc_pos_control/PositionControl.hpp
@@ -196,6 +196,9 @@ protected:
 	void updateParams() override;
 
 private:
+
+	static constexpr float CONSTANTS_ONE_G = 9.80665f; // m/s^2
+
 	/**
 	 * Maps setpoints to internal-setpoints.
 	 * @return true if mapping succeeded.

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -234,6 +234,25 @@ PARAM_DEFINE_FLOAT(MPC_XY_VEL_I, 0.02f);
 PARAM_DEFINE_FLOAT(MPC_XY_VEL_D, 0.01f);
 
 /**
+ * Cutoff frequency for the low pass filter on the acceleration feedforward of the PID velocity controller
+ *
+ * The velocity controller can use acceleration as a feedforward to improve tracking performance. However,
+ * since this feedforward is directly translated to attitude setpoint, the signal need to be low-passed if
+ * it is not smooth.
+ *
+ * A value of 0 disables the filter.
+ * A value of -1 disables acceleration feedforward.
+ *
+ * @unit Hz
+ * @min -1
+ * @max 20
+ * @decimal 0
+ * @increment 1
+ * @group Multicopter Attitude Control
+ */
+PARAM_DEFINE_FLOAT(MPC_A_FF_CUTOFF, 10.f);
+
+/**
  * Maximum horizontal velocity in mission
  *
  * Normal horizontal velocity in AUTO modes (includes

--- a/src/modules/mc_pos_control/mc_pos_control_params.c
+++ b/src/modules/mc_pos_control/mc_pos_control_params.c
@@ -413,6 +413,18 @@ PARAM_DEFINE_FLOAT(MPC_MAN_Y_MAX, 200.0f);
 PARAM_DEFINE_FLOAT(MPC_HOLD_DZ, 0.1f);
 
 /**
+ * Half-width of the hysteretic filter applied to the sticks.
+ * The hysteretic filter is used to supress noise while not adding
+ * delay or phase lag to the signal.
+ *
+ * @min 0.0
+ * @max 1.0
+ * @decimal 2
+ * @group Multicopter Position Control
+ */
+PARAM_DEFINE_FLOAT(MPC_MAN_HYST, 0.01f);
+
+/**
  * Maximum horizontal velocity for which position hold is enabled (use 0 to disable check)
  *
  * @unit m/s


### PR DESCRIPTION
### Describe problem solved by the proposed pull request
**Current state:**
The model controlled by the velocity PID controller is contains one integrator which removes steady-state error when a constant setpoint is applied. To track a ramp setpoint, an integrator (I term of the PID controller) increases the order of the closed-loop system and remove the steady-state error.

**Problems:**
- The controller cannot track a parabolic setpoint
- To reduce the steady-state error during acceleration, the gain of the integrator has to be quite high, which causes an overshoot at the end of the ramp. This can be attenuated by a jerk-limited setpoint, but isn't enough.
- The drone does not feel responsive and the setpoints are tweaked as an attempt to hide bad tracking (setpoint resets, increase jerk and acceleration limits). This leads to hazardous behaviors.

### Solution proposed by this PR
A feedforward on the controller is commonly used in industry to improve tracking. Since some flight tasks already produce acceleration setpoints, they can easily be fed as feedforwards. With a feedforward, the feedback controller is then only needed to remove the steady-state error and reject disturbances.

### Describe possible alternatives
- Increase the order of the system by 1 (add an other integrator)
- A different type of controller.

### Tests
SITL tests:
_Without feedforward (now):_
![2019-05-21_15-01-08_01_plot](https://user-images.githubusercontent.com/14822839/58098308-8fab5200-7bd9-11e9-8ca5-d46bba9fde46.png)
_With feedforward (this PR):_
![2019-05-21_14-55-01_01_plot](https://user-images.githubusercontent.com/14822839/58098336-9e920480-7bd9-11e9-970c-4f6f9aa1e8c9.png)

FYI @RomanBapst @MaEtUgR 