### PR TITLE
Geofence safety fixes

### DIFF
--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -165,6 +165,12 @@ private:
 	float		_load_factor_ratio{0.5f};	/**< ratio of maximum load factor predicted by stall speed to measured load factor */
 	float		_apsd_innov_integ_state{0.0f};	/**< inegral of excess normalised airspeed innovation (sec) */
 
+	/* geofence flags */
+	bool _geofence_loiter_on{false};
+	bool _geofence_rtl_on{false};
+	bool _warning_action_on{false};
+	hrt_abstime _last_geofence_violation{0};
+
 	FailureDetector _failure_detector;
 	bool _failure_detector_termination_printed{false};
 

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -165,10 +165,9 @@ private:
 	float		_load_factor_ratio{0.5f};	/**< ratio of maximum load factor predicted by stall speed to measured load factor */
 	float		_apsd_innov_integ_state{0.0f};	/**< inegral of excess normalised airspeed innovation (sec) */
 
-	/* geofence flags */
 	bool _geofence_loiter_on{false};
 	bool _geofence_rtl_on{false};
-	bool _warning_action_on{false};
+	bool _geofence_warning_action_on{false};
 	bool _geofence_violated_prev{false};
 
 	FailureDetector _failure_detector;

--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -169,7 +169,7 @@ private:
 	bool _geofence_loiter_on{false};
 	bool _geofence_rtl_on{false};
 	bool _warning_action_on{false};
-	hrt_abstime _last_geofence_violation{0};
+	bool _geofence_violated_prev{false};
 
 	FailureDetector _failure_detector;
 	bool _failure_detector_termination_printed{false};


### PR DESCRIPTION
Currently, the geofence failsafe has a higher priority than the low battery check. It means that in case of a low battery failsafe action (e.g.: land) while in the no-flight zone (NFZ), the geofence action will override the action and can hold the drone in air until death. Also, when the geofence failsafe is set to "Loiter", the user cannot bring the drone back into the fence because as soon as he switches into a manual mode, the failsafe is triggered again and the drone stops.

In summary, the following scenario is currently possible: 
- The user flies the drone that goes out of the geofence, the geofence failsafe is triggered and switches to loiter (hold). 
- The user wants to bring the drone back inside the flight zone in manual position control mode; he switches to that mode, the geofence failsafe triggers again and stops the drone.
- After a few tries, the batteries are low and the battery failsafe triggers and commands the drone to land.
- The geofence failsafe triggers again and stops the drone.
- The batteries are now empty, the drone crashes.

This PR changes the following things:
- Geofence failsafe cannot trigger while in low battery emergency action
- Geofence failsafe only triggers on transition `flight zone -> no-flight zone`. This means that the user can switch to a manual mode and fly back into the fly zone. I also means that the user can fly further, but this is not a concern for now.

Note that the purpose of this PR is to bring the geofence action into a safe state. Further improvements will arrive later.