### PR TITLE
VS Code: remove matter of taste tabs customization

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -83,8 +83,6 @@
         },
         "search.showLineNumbers": true,
         "window.title": "${dirty} ${activeEditorMedium}${separator}${rootName}",
-        "workbench.editor.enablePreview": false,
-        "workbench.editor.enablePreviewFromQuickOpen": false,
         "workbench.editor.highlightModifiedTabs": true,
         "workbench.settings.enableNaturalLanguageSearch": false,
         "workbench.statusBar.feedback.visible": false


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
There is a lot of very useful project specific configuration contributed by @dagar in the .vscode folder for the PX4 repo. But this setting is a matter of taste changing the UI behavior for the editor and not project specific. It determines if new code tabs are kept open when you just take a quick glance without changing anything. Since this feature is default and I like it a lot I would prefer to not have it disabled for PX4 by workspace settings.

**Note:** When you want to keep a tab that is in preview mode open you can double click to open it, double click on the tab name or press Ctrl+K followed by Enter.

**Test data / coverage**
Without these lines it runs again like expected.

**Describe your preferred solution**
Can we have matter of taste settings kept in our local user configuration?
