### PR TITLE
pxh.cpp: fix invalid reference if words is empty

### DIFF
--- a/platforms/posix/src/px4_daemon/pxh.cpp
+++ b/platforms/posix/src/px4_daemon/pxh.cpp
@@ -84,6 +84,10 @@ int Pxh::process_line(const std::string &line, bool silently_fail)
 		words.push_back(word);
 	}
 
+	if (words.empty()) {
+		return 0;
+	}
+
 	const std::string &command(words.front());
 
 	if (_apps.find(command) != _apps.end()) {


### PR DESCRIPTION
This can happen for example if 'line' is a space.