### PR TITLE
[WIP]: PX4IO F7 DMA buffer review (dcache flush and alignment)

### DIFF
--- a/src/drivers/px4io/px4io_serial.h
+++ b/src/drivers/px4io/px4io_serial.h
@@ -252,7 +252,7 @@ private:
 	/**
 	 * IO Buffer storage
 	 */
-	static uint8_t _io_buffer_storage[];
+	static uint8_t _io_buffer_storage[] __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
 };
 
 #else

--- a/src/drivers/px4io/px4io_serial_f7.cpp
+++ b/src/drivers/px4io/px4io_serial_f7.cpp
@@ -57,12 +57,10 @@
 #define rCR3		REG(STM32_USART_CR3_OFFSET)
 #define rGTPR		REG(STM32_USART_GTPR_OFFSET)
 
-#define CACHE_LINE_SIZE 32
+#define DMA_BUFFER_MASK    (ARMV7M_DCACHE_LINESIZE - 1)
+#define DMA_ALIGN_UP(n)    (((n) + DMA_BUFFER_MASK) & ~DMA_BUFFER_MASK)
 
-#define ROUND_UP_TO_POW2_CT(size, alignment) (((uintptr_t)((size) + ((alignment) - 1u))) & (~((uintptr_t)((alignment) - 1u))))
-#define ALIGNED_IO_BUFFER_SIZE ROUND_UP_TO_POW2_CT(sizeof(IOPacket), CACHE_LINE_SIZE)
-
-uint8_t PX4IO_serial_f7::_io_buffer_storage[ALIGNED_IO_BUFFER_SIZE + CACHE_LINE_SIZE];
+uint8_t PX4IO_serial_f7::_io_buffer_storage[DMA_ALIGN_UP(sizeof(IOPacket))];
 
 PX4IO_serial_f7::PX4IO_serial_f7() :
 	_tx_dma(nullptr),
@@ -119,9 +117,9 @@ int
 PX4IO_serial_f7::init()
 {
 	/* initialize base implementation */
-	int r;
+	int r = PX4IO_serial::init((IOPacket *)&_io_buffer_storage[0]);
 
-	if ((r = PX4IO_serial::init((IOPacket *)ROUND_UP_TO_POW2_CT((uintptr_t)_io_buffer_storage, CACHE_LINE_SIZE))) != 0) {
+	if (r != 0) {
 		return r;
 	}
 
@@ -289,7 +287,7 @@ PX4IO_serial_f7::_bus_exchange(IOPacket *_packet)
 
 	/* Clean _current_packet, so DMA can see the data */
 	arch_clean_dcache((uintptr_t)_current_packet,
-			  (uintptr_t)_current_packet + ALIGNED_IO_BUFFER_SIZE);
+			  (uintptr_t)_current_packet + sizeof(_current_packet));
 
 	/* start TX DMA - no callback if we also expect a reply */
 	/* DMA setup time ~3µs */
@@ -459,7 +457,7 @@ PX4IO_serial_f7::_do_interrupt()
 		if (_rx_dma_status == _dma_status_waiting) {
 			/* Invalidate _current_packet, so we get fresh data from RAM */
 			arch_invalidate_dcache((uintptr_t)_current_packet,
-					       (uintptr_t)_current_packet + ALIGNED_IO_BUFFER_SIZE);
+					       (uintptr_t)_current_packet + sizeof(_current_packet));
 
 			/* verify that the received packet is complete */
 			size_t length = sizeof(*_current_packet) - stm32_dmaresidual(_rx_dma);


### PR DESCRIPTION
 - explicitly align the buffer to ARMV7M_DCACHE_LINESIZE
 - simpler alignment rounding logic (from stm32_ethernet.c)


With the current code in master `_io_buffer_storage` ends up as 128 bytes, however the dcache flush size (ALIGNED_IO_BUFFER_SIZE) is only 96 bytes.
