### PR TITLE
px4_posix: add px4_exit()

### DIFF
--- a/src/platforms/px4_posix.h
+++ b/src/platforms/px4_posix.h
@@ -83,6 +83,12 @@ typedef struct pollfd px4_pollfd_struct_t;
 
 #define	 PX4_STACK_OVERHEAD	8192
 
+/**
+ * Terminates the calling process immediately.
+ * @return 0 on success, 1 on error
+ */
+#define px4_exit(status) ({return status;})
+
 __BEGIN_DECLS
 
 typedef short pollevent_t;


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
While doing some adaptations on the uavcan driver, I faced that, for a POSIX target, one bumps into `error: attempt to use poisoned "exit"`.

**Test data / coverage**
Tested under SITL.

**Describe your preferred solution**
This solution creates a `px4_exit(status)` under `px4_posix.h`, replacing the `exit()` call with a `return` call.

**Additional context**
I don't have any clear usage on the current source code, but maybe there is. @julianoes @dagar maybe you can point out some places where we can use this as a replacement to the `exit` calls.

**TODO**

- [ ] Add usage?