### PR TITLE
create generic dma allocator (from fat_dma_alloc)

### DIFF
--- a/boards/airmind/mindpx-v2/src/init.c
+++ b/boards/airmind/mindpx-v2/src/init.c
@@ -72,6 +72,7 @@
 #include <drivers/drv_board_led.h>
 
 #include <px4_init.h>
+#include <drivers/boards/common/board_dma_alloc.h>
 
 /****************************************************************************
  * Pre-Processor Definitions

--- a/boards/auav/x21/src/init.c
+++ b/boards/auav/x21/src/init.c
@@ -73,6 +73,7 @@
 #include <systemlib/px4_macros.h>
 
 #include <px4_init.h>
+#include <drivers/boards/common/board_dma_alloc.h>
 
 /****************************************************************************
  * Pre-Processor Definitions

--- a/boards/av/x-v1/src/init.c
+++ b/boards/av/x-v1/src/init.c
@@ -71,6 +71,7 @@
 #include <systemlib/px4_macros.h>
 #include <px4_init.h>
 #include <px4_i2c.h>
+#include <drivers/boards/common/board_dma_alloc.h>
 
 static int configure_switch(void);
 

--- a/boards/nxp/fmuk66-v3/src/init.c
+++ b/boards/nxp/fmuk66-v3/src/init.c
@@ -74,6 +74,7 @@
 #include <systemlib/px4_macros.h>
 
 #include <px4_init.h>
+#include <drivers/boards/common/board_dma_alloc.h>
 
 /****************************************************************************
  * Pre-Processor Definitions

--- a/boards/omnibus/f4sd/src/init.c
+++ b/boards/omnibus/f4sd/src/init.c
@@ -73,6 +73,7 @@
 #include <systemlib/px4_macros.h>
 
 #include <px4_init.h>
+#include <drivers/boards/common/board_dma_alloc.h>
 
 # if defined(FLASH_BASED_PARAMS)
 #  include <parameters/flashparams/flashfs.h>

--- a/boards/px4/fmu-v2/src/init.c
+++ b/boards/px4/fmu-v2/src/init.c
@@ -73,6 +73,7 @@
 #include <systemlib/px4_macros.h>
 
 #include <px4_init.h>
+#include <drivers/boards/common/board_dma_alloc.h>
 
 /****************************************************************************
  * Pre-Processor Definitions

--- a/boards/px4/fmu-v3/src/init.c
+++ b/boards/px4/fmu-v3/src/init.c
@@ -73,6 +73,7 @@
 #include <systemlib/px4_macros.h>
 
 #include <px4_init.h>
+#include <drivers/boards/common/board_dma_alloc.h>
 
 /****************************************************************************
  * Pre-Processor Definitions

--- a/boards/px4/fmu-v4/src/init.c
+++ b/boards/px4/fmu-v4/src/init.c
@@ -74,6 +74,7 @@
 #include <systemlib/px4_macros.h>
 
 #include <px4_init.h>
+#include <drivers/boards/common/board_dma_alloc.h>
 
 /****************************************************************************
  * Pre-Processor Definitions

--- a/boards/px4/fmu-v4pro/src/init.c
+++ b/boards/px4/fmu-v4pro/src/init.c
@@ -74,6 +74,7 @@
 #include <systemlib/px4_macros.h>
 
 #include <px4_init.h>
+#include <drivers/boards/common/board_dma_alloc.h>
 
 /****************************************************************************
  * Pre-Processor Definitions

--- a/boards/px4/fmu-v5/src/init.c
+++ b/boards/px4/fmu-v5/src/init.c
@@ -70,6 +70,7 @@
 #include <drivers/drv_board_led.h>
 #include <systemlib/px4_macros.h>
 #include <px4_init.h>
+#include <drivers/boards/common/board_dma_alloc.h>
 
 /****************************************************************************
  * Pre-Processor Definitions

--- a/src/drivers/boards/common/CMakeLists.txt
+++ b/src/drivers/boards/common/CMakeLists.txt
@@ -37,6 +37,7 @@ if ((${PX4_PLATFORM} MATCHES "nuttx") AND NOT ${PX4_BOARD} MATCHES "io")
 	add_library(drivers_boards_common
 		board_crashdump.c
 		board_dma_alloc.c
+		board_fat_dma_alloc.c
 		board_gpio_init.c
 		board_dcache_control.c
 		)

--- a/src/drivers/boards/common/board_common.h
+++ b/src/drivers/boards/common/board_common.h
@@ -503,56 +503,6 @@ int board_read_VBUS_state(void);
 #endif
 
 /************************************************************************************
- * Name: board_dma_alloc_init
- *
- * Description:
- *   All boards may optionally provide this API to instantiate a pool of
- *   memory for uses with FAST FS DMA operations.
- *
- *   Provision is controlled by declaring BOARD_DMA_ALLOC_POOL_SIZE in board_config.h
- *
- * Input Parameters:
- *   None
- *
- * Returned Value:
- *   Zero (OK) is returned on success; a negated errno value is returned on failure
- *   EPERM - board does not support function
- *   ENOMEM - There is not enough memory to satisfy allocation.
- *
- ************************************************************************************/
-#if defined(BOARD_DMA_ALLOC_POOL_SIZE)
-__EXPORT int board_dma_alloc_init(void);
-#else
-#define board_dma_alloc_init() (-EPERM)
-#endif
-
-/************************************************************************************
- * Name: board_get_dma_usage
- *
- * Description:
- *   All boards may optionally provide this API to supply instrumentation for a pool of
- *   memory used for DMA operations.
- *
- *   Provision is controlled by declaring BOARD_DMA_ALLOC_POOL_SIZE in board_config.h
- *
- * Input Parameters:
- *   dma_total     -  A pointer to receive the total allocation size of the memory
- *                    allocated with board_dma_alloc_init. It should be equal to
- *                    BOARD_DMA_ALLOC_POOL_SIZE.
- *   dma_used      -  A pointer to receive the current allocation in use.
- *   dma_peak_used -  A pointer to receive the peak allocation used.
- *
- * Returned Value:
- *   Zero (OK) is returned on success;
- *
- ************************************************************************************/
-#if defined(BOARD_DMA_ALLOC_POOL_SIZE)
-__EXPORT int board_get_dma_usage(uint16_t *dma_total, uint16_t *dma_used, uint16_t *dma_peak_used);
-#else
-#define board_get_dma_usage(dma_total,dma_used, dma_peak_used) (-ENOMEM)
-#endif
-
-/************************************************************************************
  * Name: board_rc_input
  *
  * Description:

--- a/src/drivers/boards/common/board_dma_alloc.h
+++ b/src/drivers/boards/common/board_dma_alloc.h
@@ -1,0 +1,133 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2016-2019 PX4 Development Team. All rights reserved.
+ *                 Author: David Sidrane <david_s5@nscdg.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file board_dma_alloc.h
+ *
+ * Provide DMA capable memory allocation interface
+ */
+
+#pragma once
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+/************************************************************************************
+ * Name: board_dma_alloc_init
+ *
+ * Description:
+ *   All boards may optionally provide this API to instantiate a pool of
+ *   memory for uses with FAST FS DMA operations.
+ *
+ *   Provision is controlled by declaring BOARD_DMA_ALLOC_POOL_SIZE in board_config.h
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned on failure
+ *   EPERM - board does not support function
+ *   ENOMEM - There is not enough memory to satisfy allocation.
+ *
+ ************************************************************************************/
+#if defined(BOARD_DMA_ALLOC_POOL_SIZE)
+__EXPORT int board_dma_alloc_init(void);
+#else
+#define board_dma_alloc_init() (-EPERM)
+#endif
+
+/************************************************************************************
+ * Name: board_get_dma_usage
+ *
+ * Description:
+ *   All boards may optionally provide this API to supply instrumentation for a pool of
+ *   memory used for DMA operations.
+ *
+ *   Provision is controlled by declaring BOARD_DMA_ALLOC_POOL_SIZE in board_config.h
+ *
+ * Input Parameters:
+ *   dma_total     -  A pointer to receive the total allocation size of the memory
+ *                    allocated with board_dma_alloc_init. It should be equal to
+ *                    BOARD_DMA_ALLOC_POOL_SIZE.
+ *   dma_used      -  A pointer to receive the current allocation in use.
+ *   dma_peak_used -  A pointer to receive the peak allocation used.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success;
+ *
+ ************************************************************************************/
+#if defined(BOARD_DMA_ALLOC_POOL_SIZE)
+__EXPORT int board_get_dma_usage(uint16_t *dma_total, uint16_t *dma_used, uint16_t *dma_peak_used);
+#else
+#define board_get_dma_usage(dma_total,dma_used, dma_peak_used) (-ENOMEM)
+#endif
+
+/************************************************************************************
+ * Name: dma_alloc
+ *
+ * Description:
+ *   All boards may optionally provide this API to supply DMA capable memory
+ *
+ * Input Parameters:
+ *   size     -  A pointer to receive the total allocation size of the memory
+ *                    allocated with board_dma_alloc_init. It should be equal to
+ *                    BOARD_DMA_ALLOC_POOL_SIZE.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success;
+ *
+ ************************************************************************************/
+#if defined(BOARD_DMA_ALLOC_POOL_SIZE)
+__EXPORT void *board_dma_alloc(size_t size);
+#else
+#define board_dma_alloc(size) (NULL)
+#endif
+
+/************************************************************************************
+ * Name: dma_free
+ *
+ * Description:
+ *   All boards may optionally provide this API to supply DMA capable memory
+ *
+ * Input Parameters:
+ *   memory     -  A pointer to previously allocated DMA memory
+ *   size      -  Size of the previously allocated DMA memory
+ *
+ ************************************************************************************/
+#if defined(BOARD_DMA_ALLOC_POOL_SIZE)
+__EXPORT void board_dma_free(FAR void *memory, size_t size);
+#else
+#define board_dma_free(memory, size) ()
+#endif

--- a/src/drivers/boards/common/board_fat_dma_alloc.c
+++ b/src/drivers/boards/common/board_fat_dma_alloc.c
@@ -1,0 +1,71 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file board_dma_alloc.c
+ *
+ * Provide the board dma allocator interface.
+ */
+
+#include <px4_config.h>
+#include "board_config.h"
+
+#include "board_dma_alloc.h"
+#include <perf/perf_counter.h>
+
+#if defined(CONFIG_FAT_DMAMEMORY)
+
+#  if !defined(CONFIG_GRAN)
+#    error microSD DMA support requires CONFIG_GRAN and CONFIG_FAT_DMAMEMORY
+#  endif
+
+/*
+ * DMA-aware allocator stubs for the FAT filesystem.
+ */
+
+__EXPORT void *fat_dma_alloc(size_t size);
+__EXPORT void fat_dma_free(FAR void *memory, size_t size);
+
+void *
+fat_dma_alloc(size_t size)
+{
+	return board_dma_alloc(size);
+}
+
+void
+fat_dma_free(FAR void *memory, size_t size)
+{
+	return board_dma_free(memory, size);
+}
+
+#endif /* CONFIG_FAT_DMAMEMORY && CONFIG_GRAN */

--- a/src/lib/systemlib/print_load_nuttx.c
+++ b/src/lib/systemlib/print_load_nuttx.c
@@ -46,6 +46,10 @@
 #include <systemlib/printload.h>
 #include <drivers/drv_hrt.h>
 
+#if defined(BOARD_DMA_ALLOC_POOL_SIZE)
+#include <drivers/boards/common/board_dma_alloc.h>
+#endif /* BOARD_DMA_ALLOC_POOL_SIZE */
+
 #if defined(CONFIG_SCHED_INSTRUMENTATION)
 
 #if !defined(CONFIG_TASK_NAME_SIZE)


### PR DESCRIPTION
We need a mechanism to explicitly allocate DMA capable memory for our SPI drivers using DMA.

This is just a quick start to prompt the discussion. I think ultimately we should have something in platform for allocations with an optional argument for the type. That could also enable things like tracking allocations per module.