### PR TITLE
Jenkins SITL tests temporarily disable tiltrotor

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -73,12 +73,12 @@ pipeline {
               mission: "VTOL_mission_1",
               vehicle: "tailsitter"
             ],
-            [
-              name: "VTOL_tiltrotor",
-              test: "mavros_posix_test_mission.test",
-              mission: "VTOL_mission_1",
-              vehicle: "tiltrotor"
-            ],
+            // [
+            //   name: "VTOL_tiltrotor",
+            //   test: "mavros_posix_test_mission.test",
+            //   mission: "VTOL_mission_1",
+            //   vehicle: "tiltrotor"
+            // ],
             [
               name: "MC_avoidance",
               test: "mavros_posix_test_avoidance.test",

--- a/.ci/Jenkinsfile-SITL_tests_ASan
+++ b/.ci/Jenkinsfile-SITL_tests_ASan
@@ -73,12 +73,12 @@ pipeline {
               mission: "VTOL_mission_1",
               vehicle: "tailsitter"
             ],
-            [
-              name: "VTOL_tiltrotor",
-              test: "mavros_posix_test_mission.test",
-              mission: "VTOL_mission_1",
-              vehicle: "tiltrotor"
-            ],
+            // [
+            //   name: "VTOL_tiltrotor",
+            //   test: "mavros_posix_test_mission.test",
+            //   mission: "VTOL_mission_1",
+            //   vehicle: "tiltrotor"
+            // ],
 
           ]
 

--- a/.ci/Jenkinsfile-SITL_tests_coverage
+++ b/.ci/Jenkinsfile-SITL_tests_coverage
@@ -47,12 +47,12 @@ pipeline {
               mission: "VTOL_mission_1",
               vehicle: "tailsitter"
             ],
-            [
-              name: "VTOL_tiltrotor",
-              test: "mavros_posix_test_mission.test",
-              mission: "VTOL_mission_1",
-              vehicle: "tiltrotor"
-            ],
+            // [
+            //   name: "VTOL_tiltrotor",
+            //   test: "mavros_posix_test_mission.test",
+            //   mission: "VTOL_mission_1",
+            //   vehicle: "tiltrotor"
+            // ],
 
           ]
 


### PR DESCRIPTION
Temporarily disabling the tiltrotor test until the intermittent failures can be sorted out. https://github.com/PX4/Firmware/pull/12081#issuecomment-496071968