### PR TITLE
posix: restore original SEGV signal handler upon first entry of our handler

### DIFF
--- a/platforms/posix/src/main.cpp
+++ b/platforms/posix/src/main.cpp
@@ -405,7 +405,7 @@ void register_sig_handler()
 	// SIGSEGV
 	struct sigaction sig_segv {};
 	sig_segv.sa_handler = sig_segv_handler;
-	sig_segv.sa_flags = SA_RESTART | SA_SIGINFO;
+	sig_segv.sa_flags = SA_RESTART | SA_SIGINFO | SA_RESETHAND;
 
 #ifdef __PX4_CYGWIN
 	// Do not catch SIGINT on Cygwin such that the process gets killed


### PR DESCRIPTION
The current SEGV handling on posix is not useful: as soon as our handler is left, it's triggered again, infinitely.
This patch changes to restore the original handler, so the OS can create a core dump, etc.

I'm also ok with removing our custom handler altogether, since the stack trace addresses are not resolved to function names, and therefore not very useful.