### PR TITLE
Remove hack for diff_pressure noise

### DIFF
--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -262,9 +262,7 @@ void Simulator::update_sensors(const mavlink_hil_sensor_t *imu)
 
 	RawAirspeedData airspeed = {};
 	airspeed.temperature = imu->temperature;
-	// FIXME: diff_pressure needs some noise to pass preflight checks, so we just take the
-	//        noise from the gyro.
-	airspeed.diff_pressure = imu->diff_pressure + ((imu->ygyro > 0) ? 0.001f : 0.0f);
+	airspeed.diff_pressure = imu->diff_pressure;
 
 	write_airspeed_data(&airspeed);
 }


### PR DESCRIPTION
This reverts the revert. From my perspective this hack should really not be needed anymore. If tests fail without the hack, I need to look at the noise generation in https://github.com/PX4/sitl_gazebo/blob/a0b0eb8df12b11e8f63d3cc766dee97cefa32ab7/src/gazebo_mavlink_interface.cpp#L733-L744.