### PR TITLE
Fix covery scan warnings for wqueue

### DIFF
--- a/src/include/containers/BlockingQueue.hpp
+++ b/src/include/containers/BlockingQueue.hpp
@@ -81,7 +81,7 @@ private:
 	px4_sem_t	_sem_head;
 	px4_sem_t	_sem_tail;
 
-	T _data[N];
+	T _data[N] {};
 
 	size_t _head{0};
 	size_t _tail{0};

--- a/src/platforms/common/px4_work_queue/test/wqueue_start.cpp
+++ b/src/platforms/common/px4_work_queue/test/wqueue_start.cpp
@@ -64,7 +64,7 @@ int wqueue_test_main(int argc, char *argv[])
 						 SCHED_PRIORITY_MAX - 5,
 						 2000,
 						 PX4_MAIN,
-						 (argv) ? (char *const *)&argv[2] : (char *const *)nullptr);
+						 (argv[2]) ? (char *const *)&argv[2] : (char *const *)nullptr);
 
 		return 0;
 	}


### PR DESCRIPTION
This was my take at the coverity scan warnings:

```
** CID 341063: Uninitialized members (UNINIT_CTOR)
/src/include/containers/BlockingQueue.hpp: 49 in BlockingQueue<const px4::wq_config_t *, (unsigned long)1>::BlockingQueue()()


________________________________________________________________________________________________________
*** CID 341063: Uninitialized members (UNINIT_CTOR)
/src/include/containers/BlockingQueue.hpp: 49 in BlockingQueue<const px4::wq_config_t *, (unsigned long)1>::BlockingQueue()()
43 public:
44
45 BlockingQueue()
46 {
47 px4_sem_init(&_sem_head, 0, N);
48 px4_sem_init(&_sem_tail, 0, 0);
>>> CID 341063: Uninitialized members (UNINIT_CTOR)
>>> Non-static class member "_data" is not initialized in this constructor nor in any functions that it calls.
49 }
50
51 ~BlockingQueue()
52 {
53 px4_sem_destroy(&_sem_head);
54 px4_sem_destroy(&_sem_tail);

** CID 196765: Null pointer dereferences (REVERSE_INULL)
/src/platforms/common/px4_work_queue/test/wqueue_start.cpp: 67 in wqueue_test_main()


________________________________________________________________________________________________________
*** CID 196765: Null pointer dereferences (REVERSE_INULL)
/src/platforms/common/px4_work_queue/test/wqueue_start.cpp: 67 in wqueue_test_main()
61
62 daemon_task = px4_task_spawn_cmd("wqueue",
63 SCHED_DEFAULT,
64 SCHED_PRIORITY_MAX - 5,
65 2000,
66 PX4_MAIN,
>>> CID 196765: Null pointer dereferences (REVERSE_INULL)
>>> Null-checking "argv" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
67 (argv) ? (char *const *)&argv[2] : (char *const *)nullptr);
68
69 return 0;
70 }
71
72 if (!strcmp(argv[1], "stop")) {
```

