### PR TITLE
Fix VTOL enum shadowing

### DIFF
--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -440,7 +440,7 @@ FixedwingAttitudeControl::vehicle_status_poll()
 				int32_t vt_type = -1;
 
 				if (param_get(param_find("VT_TYPE"), &vt_type) == PX4_OK) {
-					_is_tailsitter = (vt_type == vtol_type::TAILSITTER);
+					_is_tailsitter = (static_cast<vtol_type>(vt_type) == vtol_type::TAILSITTER);
 				}
 
 			} else {

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -432,7 +432,7 @@ FixedwingPositionControl::vehicle_attitude_poll()
 
 	// if the vehicle is a tailsitter we have to rotate the attitude by the pitch offset
 	// between multirotor and fixed wing flight
-	if (_parameters.vtol_type == vtol_type::TAILSITTER && _vehicle_status.is_vtol) {
+	if (static_cast<vtol_type>(_parameters.vtol_type) == vtol_type::TAILSITTER && _vehicle_status.is_vtol) {
 		Dcmf R_offset = Eulerf(0, M_PI_2_F, 0);
 		_R_nb = _R_nb * R_offset;
 	}
@@ -2004,7 +2004,7 @@ FixedwingPositionControl::tecs_update_pitch_throttle(float alt_sp, float airspee
 
 	// tailsitters use the multicopter frame as reference, in fixed wing
 	// we need to use the fixed wing frame
-	if (_parameters.vtol_type == vtol_type::TAILSITTER && _vehicle_status.is_vtol) {
+	if (static_cast<vtol_type>(_parameters.vtol_type) == vtol_type::TAILSITTER && _vehicle_status.is_vtol) {
 		float tmp = accel_body(0);
 		accel_body(0) = -accel_body(2);
 		accel_body(2) = tmp;

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -256,7 +256,7 @@ MulticopterAttitudeControl::vehicle_status_poll()
 
 				int32_t vt_type = -1;
 				if (param_get(param_find("VT_TYPE"), &vt_type) == PX4_OK) {
-					_is_tailsitter = (vt_type == vtol_type::TAILSITTER);
+					_is_tailsitter = (static_cast<vtol_type>(vt_type) == vtol_type::TAILSITTER);
 				}
 
 			} else {

--- a/src/modules/vtol_att_control/standard.h
+++ b/src/modules/vtol_att_control/standard.h
@@ -86,7 +86,7 @@ private:
 		param_t reverse_delay;
 	} _params_handles_standard;
 
-	enum vtol_mode {
+	enum class vtol_mode {
 		MC_MODE = 0,
 		TRANSITION_TO_FW,
 		TRANSITION_TO_MC,

--- a/src/modules/vtol_att_control/tailsitter.cpp
+++ b/src/modules/vtol_att_control/tailsitter.cpp
@@ -151,24 +151,24 @@ void Tailsitter::update_vtol_state()
 	// map tailsitter specific control phases to simple control modes
 	switch (_vtol_schedule.flight_mode) {
 	case MC_MODE:
-		_vtol_mode = ROTARY_WING;
+		_vtol_mode = mode::ROTARY_WING;
 		_vtol_vehicle_status->vtol_in_trans_mode = false;
 		_flag_was_in_trans_mode = false;
 		break;
 
 	case FW_MODE:
-		_vtol_mode = FIXED_WING;
+		_vtol_mode = mode::FIXED_WING;
 		_vtol_vehicle_status->vtol_in_trans_mode = false;
 		_flag_was_in_trans_mode = false;
 		break;
 
 	case TRANSITION_FRONT_P1:
-		_vtol_mode = TRANSITION_TO_FW;
+		_vtol_mode = mode::TRANSITION_TO_FW;
 		_vtol_vehicle_status->vtol_in_trans_mode = true;
 		break;
 
 	case TRANSITION_BACK:
-		_vtol_mode = TRANSITION_TO_MC;
+		_vtol_mode = mode::TRANSITION_TO_MC;
 		_vtol_vehicle_status->vtol_in_trans_mode = true;
 		break;
 	}

--- a/src/modules/vtol_att_control/tiltrotor.cpp
+++ b/src/modules/vtol_att_control/tiltrotor.cpp
@@ -180,20 +180,20 @@ void Tiltrotor::update_vtol_state()
 	// map tiltrotor specific control phases to simple control modes
 	switch (_vtol_schedule.flight_mode) {
 	case MC_MODE:
-		_vtol_mode = ROTARY_WING;
+		_vtol_mode = mode::ROTARY_WING;
 		break;
 
 	case FW_MODE:
-		_vtol_mode = FIXED_WING;
+		_vtol_mode = mode::FIXED_WING;
 		break;
 
 	case TRANSITION_FRONT_P1:
 	case TRANSITION_FRONT_P2:
-		_vtol_mode = TRANSITION_TO_FW;
+		_vtol_mode = mode::TRANSITION_TO_FW;
 		break;
 
 	case TRANSITION_BACK:
-		_vtol_mode = TRANSITION_TO_MC;
+		_vtol_mode = mode::TRANSITION_TO_MC;
 		break;
 	}
 }
@@ -227,8 +227,8 @@ void Tiltrotor::update_transition_state()
 
 	if (_vtol_schedule.flight_mode == TRANSITION_FRONT_P1) {
 		// for the first part of the transition the rear rotors are enabled
-		if (_motor_state != ENABLED) {
-			_motor_state = set_motor_state(_motor_state, ENABLED);
+		if (_motor_state != motor_state::ENABLED) {
+			_motor_state = set_motor_state(_motor_state, motor_state::ENABLED);
 		}
 
 		// tilt rotors forward up to certain angle
@@ -277,14 +277,14 @@ void Tiltrotor::update_transition_state()
 				 (PWM_DEFAULT_MAX - PWM_DEFAULT_MIN) + PWM_DEFAULT_MIN;
 
 
-		_motor_state = set_motor_state(_motor_state, VALUE, rear_value);
+		_motor_state = set_motor_state(_motor_state, motor_state::VALUE, rear_value);
 
 
 		_thrust_transition = -_mc_virtual_att_sp->thrust_body[2];
 
 	} else if (_vtol_schedule.flight_mode == TRANSITION_BACK) {
-		if (_motor_state != ENABLED) {
-			_motor_state = set_motor_state(_motor_state, ENABLED);
+		if (_motor_state != motor_state::ENABLED) {
+			_motor_state = set_motor_state(_motor_state, motor_state::ENABLED);
 		}
 
 

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -94,13 +94,13 @@ VtolAttitudeControl::VtolAttitudeControl()
 	/* fetch initial parameter values */
 	parameters_update();
 
-	if (_params.vtol_type == vtol_type::TAILSITTER) {
+	if (static_cast<vtol_type>(_params.vtol_type) == vtol_type::TAILSITTER) {
 		_vtol_type = new Tailsitter(this);
 
-	} else if (_params.vtol_type == vtol_type::TILTROTOR) {
+	} else if (static_cast<vtol_type>(_params.vtol_type) == vtol_type::TILTROTOR) {
 		_vtol_type = new Tiltrotor(this);
 
-	} else if (_params.vtol_type == vtol_type::STANDARD) {
+	} else if (static_cast<vtol_type>(_params.vtol_type) == vtol_type::STANDARD) {
 		_vtol_type = new Standard(this);
 
 	} else {
@@ -499,7 +499,7 @@ VtolAttitudeControl::parameters_update()
 	// normally the parameter fw_motors_off can be used to specify this, however, since historically standard vtol code
 	// did not use the interface of the VtolType class to disable motors we will have users flying  around with a wrong
 	// parameter value. Therefore, explicitly set it here such that all motors will be disabled as expected.
-	if (_params.vtol_type == vtol_type::STANDARD) {
+	if (static_cast<vtol_type>(_params.vtol_type) == vtol_type::STANDARD) {
 		_params.fw_motors_off = 12345678;
 	}
 
@@ -571,13 +571,13 @@ void VtolAttitudeControl::task_main()
 
 		// run vtol_att on MC actuator publications, unless in full FW mode
 		switch (_vtol_type->get_mode()) {
-		case TRANSITION_TO_FW:
-		case TRANSITION_TO_MC:
-		case ROTARY_WING:
+		case mode::TRANSITION_TO_FW:
+		case mode::TRANSITION_TO_MC:
+		case mode::ROTARY_WING:
 			fds[0].fd = _actuator_inputs_mc;
 			break;
 
-		case FIXED_WING:
+		case mode::FIXED_WING:
 			fds[0].fd = _actuator_inputs_fw;
 			break;
 		}
@@ -616,13 +616,13 @@ void VtolAttitudeControl::task_main()
 
 		// reset transition command if not auto control
 		if (_v_control_mode.flag_control_manual_enabled) {
-			if (_vtol_type->get_mode() == ROTARY_WING) {
+			if (_vtol_type->get_mode() == mode::ROTARY_WING) {
 				_transition_command = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_MC;
 
-			} else if (_vtol_type->get_mode() == FIXED_WING) {
+			} else if (_vtol_type->get_mode() == mode::FIXED_WING) {
 				_transition_command = vtol_vehicle_status_s::VEHICLE_VTOL_STATE_FW;
 
-			} else if (_vtol_type->get_mode() == TRANSITION_TO_MC) {
+			} else if (_vtol_type->get_mode() == mode::TRANSITION_TO_MC) {
 				/* We want to make sure that a mode change (manual>auto) during the back transition
 				 * doesn't result in an unsafe state. This prevents the instant fall back to
 				 * fixed-wing on the switch from manual to auto */
@@ -631,7 +631,7 @@ void VtolAttitudeControl::task_main()
 		}
 
 		// check in which mode we are in and call mode specific functions
-		if (_vtol_type->get_mode() == ROTARY_WING) {
+		if (_vtol_type->get_mode() == mode::ROTARY_WING) {
 
 			mc_virtual_att_sp_poll();
 
@@ -643,7 +643,7 @@ void VtolAttitudeControl::task_main()
 			// got data from mc attitude controller
 			_vtol_type->update_mc_state();
 
-		} else if (_vtol_type->get_mode() == FIXED_WING) {
+		} else if (_vtol_type->get_mode() == mode::FIXED_WING) {
 
 			fw_virtual_att_sp_poll();
 
@@ -654,7 +654,7 @@ void VtolAttitudeControl::task_main()
 
 			_vtol_type->update_fw_state();
 
-		} else if (_vtol_type->get_mode() == TRANSITION_TO_MC || _vtol_type->get_mode() == TRANSITION_TO_FW) {
+		} else if (_vtol_type->get_mode() == mode::TRANSITION_TO_MC || _vtol_type->get_mode() == mode::TRANSITION_TO_FW) {
 
 			mc_virtual_att_sp_poll();
 			fw_virtual_att_sp_poll();
@@ -662,7 +662,7 @@ void VtolAttitudeControl::task_main()
 			// vehicle is doing a transition
 			_vtol_vehicle_status.vtol_in_trans_mode = true;
 			_vtol_vehicle_status.vtol_in_rw_mode = true; //making mc attitude controller work during transition
-			_vtol_vehicle_status.in_transition_to_fw = (_vtol_type->get_mode() == TRANSITION_TO_FW);
+			_vtol_vehicle_status.in_transition_to_fw = (_vtol_type->get_mode() == mode::TRANSITION_TO_FW);
 
 			_vtol_type->update_transition_state();
 		}

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -48,7 +48,7 @@
 
 VtolType::VtolType(VtolAttitudeControl *att_controller) :
 	_attc(att_controller),
-	_vtol_mode(ROTARY_WING)
+	_vtol_mode(mode::ROTARY_WING)
 {
 	_v_att = _attc->get_att();
 	_v_att_sp = _attc->get_att_sp();
@@ -123,8 +123,8 @@ void VtolType::update_mc_state()
 		flag_idle_mc = set_idle_mc();
 	}
 
-	if (_motor_state != ENABLED) {
-		_motor_state = VtolType::set_motor_state(_motor_state, ENABLED);
+	if (_motor_state != motor_state::ENABLED) {
+		_motor_state = VtolType::set_motor_state(_motor_state, motor_state::ENABLED);
 	}
 
 	// copy virtual attitude setpoint to real attitude setpoint
@@ -142,8 +142,8 @@ void VtolType::update_fw_state()
 		flag_idle_mc = !set_idle_fw();
 	}
 
-	if (_motor_state != DISABLED) {
-		_motor_state = VtolType::set_motor_state(_motor_state, DISABLED);
+	if (_motor_state != motor_state::DISABLED) {
+		_motor_state = VtolType::set_motor_state(_motor_state, motor_state::DISABLED);
 	}
 
 	// copy virtual attitude setpoint to real attitude setpoint
@@ -323,10 +323,10 @@ motor_state VtolType::set_motor_state(const motor_state current_state, const mot
 	}
 
 	switch (next_state) {
-	case ENABLED:
+	case motor_state::ENABLED:
 		break;
 
-	case DISABLED:
+	case motor_state::DISABLED:
 		for (int i = 0; i < _params->vtol_motor_count; i++) {
 			if (is_motor_off_channel(i)) {
 				pwm_values.values[i] = _disarmed_pwm_values.values[i];
@@ -335,7 +335,7 @@ motor_state VtolType::set_motor_state(const motor_state current_state, const mot
 
 		break;
 
-	case IDLE:
+	case motor_state::IDLE:
 
 		for (int i = 0; i < _params->vtol_motor_count; i++) {
 			if (is_motor_off_channel(i)) {
@@ -345,7 +345,7 @@ motor_state VtolType::set_motor_state(const motor_state current_state, const mot
 
 		break;
 
-	case VALUE:
+	case motor_state::VALUE:
 		for (int i = 0; i < _params->vtol_motor_count; i++) {
 			if (is_motor_off_channel(i)) {
 				pwm_values.values[i] = value;

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -74,14 +74,14 @@ struct Params {
 };
 
 // Has to match 1:1 msg/vtol_vehicle_status.msg
-enum mode {
+enum class mode {
 	TRANSITION_TO_FW = 1,
 	TRANSITION_TO_MC = 2,
 	ROTARY_WING = 3,
 	FIXED_WING = 4
 };
 
-enum vtol_type {
+enum class vtol_type {
 	TAILSITTER = 0,
 	TILTROTOR,
 	STANDARD
@@ -91,7 +91,7 @@ enum vtol_type {
 // e.g. if we need to shut off some motors after transitioning to fixed wing mode
 // we can individually disable them while others might still need to be enabled to produce thrust.
 // we can select the target motors via VT_FW_MOT_OFFID
-enum motor_state {
+enum class motor_state {
 	ENABLED = 0,		// motor max pwm will be set to the standard max pwm value
 	DISABLED,			// motor max pwm will be set to a value that shuts the motor off
 	IDLE,				// motor max pwm will be set to VT_IDLE_PWM_MC
@@ -101,7 +101,7 @@ enum motor_state {
 /**
  * @brief      Used to specify if min or max pwm values should be altered
  */
-enum pwm_limit_type {
+enum class pwm_limit_type {
 	TYPE_MINIMUM = 0,
 	TYPE_MAXIMUM
 };


### PR DESCRIPTION
This changes the enums used for various VTOL states to enum classes which makes them type-safe and should avoid shadowing.

This change was motivated by a Clang warning about shadowing of the enum const `TRANSITION_TO_FW` which was declared twice, once in `vtol_type.h` and once in `standard.h`.
```
In file included from /home/julianoes/src/Firmware/src/modules/vtol_att_control/vtol_att_control_main.cpp:49:
In file included from /home/julianoes/src/Firmware/src/modules/vtol_att_control/vtol_att_control_main.h:83:
/home/julianoes/src/Firmware/src/modules/vtol_att_control/standard.h:91:3: fatal error: declaration shadows a variable in the global namespace [-Wshadow]
                TRANSITION_TO_FW,
                ^
/home/julianoes/src/Firmware/src/modules/vtol_att_control/vtol_type.h:78:2: note: previous declaration is here
        TRANSITION_TO_FW = 1,
        ^
1 error generated.
```

This change only removes the shadowing but presumably these enums could be cleaned up and consolidated further.

FYI @sfuhrer 