### PR TITLE
OA: hysteresis on failsafe

### DIFF
--- a/src/lib/FlightTasks/tasks/Utility/ObstacleAvoidance.hpp
+++ b/src/lib/FlightTasks/tasks/Utility/ObstacleAvoidance.hpp
@@ -52,6 +52,7 @@
 #include <uORB/topics/vehicle_trajectory_waypoint.h>
 #include <uORB/topics/position_setpoint.h>
 
+#include <lib/hysteresis/hysteresis.h>
 
 #include <matrix/matrix/math.hpp>
 
@@ -120,6 +121,8 @@ private:
 	matrix::Vector3f _curr_wp = {}; /**< current position triplet */
 	matrix::Vector3f _position = {}; /**< current vehicle position */
 	matrix::Vector3f _failsafe_position = {}; /**< vehicle position when entered in failsafe */
+
+	systemlib::Hysteresis _avoidance_point_not_valid_hysteresis{false}; /**< becomes true if the companion doesn't start sending valid setpoints */
 
 	bool _ext_yaw_active = false; /**< true, if external yaw handling is active */
 


### PR DESCRIPTION
Scenarios that this PR is trying to fix:
You have a vehicle with a companion computer. You take off in PosControl and fly around. The companion doesn't receive any `vehicle_trajectory_waypoint_desired` because it isn't in a Auto Mode. 
Since the algorithm running on the companion always waits for the desired goal from the FCU, it's sending back (NAN, NAN, NAN) position and velocity setpoints. Since you are in PosControl and they don't get fused, your flight is fine.
As soon as you switch into a Auto Flight mode, those NAN setpoints get injected into the AutoMapper. This happens because there is a delay until the companion receives `vehicle_trajectory_waypoint_desired`, computes the changed setpoints and sends them back on `vehicle_trajectory_waypoint` . The flight task failsafe will therefore kick in.

How to fix it: on the companion side, if `(xy_pos_sp_valid || xy_vel_sp_valid) && (z_pos_sp_valid || z_vel_sp_valid)` the valid flag `point_valid` is set to true otherwise is false.
If `point_valid` is false, we don't overwrite the setpoints from the companion such that the FCU failsafe from the flight task doesn't kick in. Otherwise, if the point keeps not being valid for more than 500ms, the OA specific failsafe will kick in.


Any other ideas on how to handle the delay with the companion when it isn't always computing a trajectory?
