### PR TITLE
[WIP] cmake and Tools/setup.sh default to python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,7 +336,22 @@ if (CATKIN_DEVEL_PREFIX)
 	endif()
 endif()
 
-find_package(PythonInterp REQUIRED)
+
+# Python3
+if(${CMAKE_VERSION} VERSION_GREATER "3.11.0")
+	find_package(Python3 COMPONENTS Interpreter)
+	if(Python3_FOUND)
+		set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+	else()
+		message(FATAL_ERROR "Python3 required")
+	endif()
+else()
+	find_package(PythonInterp 3)
+
+	if(NOT PYTHONINTERP_FOUND)
+		message(FATAL_ERROR "Python3 required")
+	endif()
+endif()
 
 option(PYTHON_COVERAGE "Python code coverage" OFF)
 if(PYTHON_COVERAGE)
@@ -345,6 +360,8 @@ if(PYTHON_COVERAGE)
 else()
 	# run normally (broken under coveragepy)
 	px4_find_python_module(jinja2 REQUIRED)
+	px4_find_python_module(toml REQUIRED)
+	px4_find_python_module(yaml REQUIRED)
 endif()
 
 #=============================================================================

--- a/Tools/setup/OSX.sh
+++ b/Tools/setup/OSX.sh
@@ -18,22 +18,34 @@ do
   fi
 done
 
+# install Homebrew
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" < /dev/null
+
+# confirm Homebrew installed correctly
+brew doctor
+
 # Install px4-dev formula
-brew tap PX4/px4
-if [ brew ls --versions px4-dev > /dev/null ]; then
-  brew install px4-dev
-elif [[ $REINSTALL_FORMULAS == "--reinstall" ]]; then
+echo
+echo "Installing PX4 general dependencies (homebrew px4-dev)"
+
+if [[ $REINSTALL_FORMULAS == "--reinstall" ]]; then
+  brew tap PX4/px4
   brew reinstall px4-dev
+elif brew ls --versions px4-dev > /dev/null; then
+  brew tap PX4/px4
+  brew install px4-dev
 fi
 
-# Python dependencies
-sudo easy_install pip
-sudo -H python3 -m pip install --upgrade --force-reinstall pip
-sudo -H python3 -m pip install -I -r ${DIR}/requirements.txt
+# Python3 dependencies
+echo
+echo "Installing PX4 Python3 dependencies"
+brew install python3
+sudo -H python3 -m pip install --upgrade pip
+sudo -H python3 -m pip install -r ${DIR}/requirements.txt
 
 # Optional, but recommended additional simulation tools:
 if [[ $INSTALL_SIM == "--sim-tools" ]]; then
-  if [ brew ls --versions px4-sim > /dev/null ]; then
+  if brew ls --versions px4-sim > /dev/null; then
     brew install px4-sim
   elif [[ $REINSTALL_FORMULAS == "--reinstall" ]]; then
     brew reinstall px4-sim

--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -2,6 +2,7 @@ argparse>=1.2
 cerberus
 empy>=3.3
 jinja2>=2.8
+matplotlib
 nose
 numpy>=1.13
 pandas>=0.21
@@ -12,4 +13,3 @@ setuptools>=39.2.0
 toml>=0.9
 tornado
 wheel>=0.31.1
-matplotlib

--- a/Tools/setup/ubuntu.sh
+++ b/Tools/setup/ubuntu.sh
@@ -49,6 +49,7 @@ fi
 
 export DEBIAN_FRONTEND=noninteractive
 
+echo
 echo "Installing PX4 general dependencies"
 
 sudo apt-get update -yy --quiet
@@ -81,20 +82,16 @@ sudo apt-get -yy --quiet --no-install-recommends install \
 	;
 
 
-# python dependencies
-echo "Installing PX4 Python dependencies"
-
-# TODO: deprecate python 2
-sudo python -m pip install --upgrade pip setuptools wheel
-sudo python -m pip install -r ${DIR}/requirements.txt
-
+# Python3 dependencies
+echo
+echo "Installing PX4 Python3 dependencies"
 sudo python3 -m pip install --upgrade pip setuptools wheel
 sudo python3 -m pip install -r ${DIR}/requirements.txt
-
 
 # NuttX toolchain (arm-none-eabi-gcc)
 if [[ $INSTALL_NUTTX == "true" ]]; then
 
+	echo
 	echo "Installing NuttX dependencies"
 
 	sudo apt-get -yy --quiet --no-install-recommends install \
@@ -145,6 +142,7 @@ fi
 # Simulation tools
 if [[ $INSTALL_SIM == "true" ]]; then
 
+	echo
 	echo "Installing PX4 simulation dependencies"
 
 	# java (jmavsim or fastrtps)
@@ -156,6 +154,7 @@ if [[ $INSTALL_SIM == "true" ]]; then
 
 	# Gazebo
 	sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+	wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 	sudo apt-get update -yy --quiet
 	sudo apt-get -yy --quiet --no-install-recommends install gazebo9
 

--- a/cmake/px4_base.cmake
+++ b/cmake/px4_base.cmake
@@ -138,15 +138,15 @@ function(px4_find_python_module module)
 			OUTPUT_STRIP_TRAILING_WHITESPACE)
 		if(NOT _${module}_status)
 			set(PY_${module_upper} ${_${module}_location} CACHE STRING
-				"Location of Python module ${module}")
+				"Location of Python3 module ${module}")
 		endif()
 	endif()
 	find_package_handle_standard_args(PY_${module}
-		"couldn't find python module ${module}:
+		"couldn't find python3 module ${module}:
 		\nfor debian systems try: \
-		\n\tsudo apt-get install python-${module} \
+		\n\tsudo apt-get install python3-${module} \
 		\nor for all other OSs/debian: \
-		\n\tsudo -H pip install ${module}\n" PY_${module_upper})
+		\n\tsudo -H ${PYTHON_EXECUTABLE} -m pip install ${module}\n" PY_${module_upper})
 	#if (NOT PY_${module}_FOUND)
 		#message(FATAL_ERROR "python module not found, exiting")
 	#endif()

--- a/msg/tools/px_generate_uorb_topic_files.py
+++ b/msg/tools/px_generate_uorb_topic_files.py
@@ -56,15 +56,15 @@ try:
 except ImportError as e:
     print("python import error: ", e)
     print('''
-Required python packages not installed.
+Required python3 packages not installed.
 
 On a Debian/Ubuntu system please run:
 
-  sudo apt-get install python-empy
-  sudo pip install catkin_pkg
+  sudo apt-get install python3-empy
+  sudo python3 -m pip install catkin_pkg
 
 On MacOS please run:
-  sudo pip install empy catkin_pkg
+  sudo python3 -m pip install empy catkin_pkg
 
 On Windows please run:
   easy_install empy catkin_pkg


### PR DESCRIPTION
Python 2 is end of life in 7 months.

This PR updates cmake to find and use python3 first, but then falls back to python2. I've also updated the setup helper scripts to install the python dependencies only python3, and made a few other improvements to make it easier and safer to repeatedly rerun the script.