### PR TITLE
Jenkins enable rover SITL test

### DIFF
--- a/.ci/Jenkinsfile-SITL_tests
+++ b/.ci/Jenkinsfile-SITL_tests
@@ -62,6 +62,13 @@ pipeline {
             ],
 
             [
+              name: "Rover 1",
+              test: "mavros_posix_test_mission.test",
+              mission: "rover_mission_1",
+              vehicle: "rover"
+            ],
+
+            [
               name: "VTOL_standard",
               test: "mavros_posix_test_mission.test",
               mission: "VTOL_mission_1",

--- a/.ci/Jenkinsfile-SITL_tests_ASan
+++ b/.ci/Jenkinsfile-SITL_tests_ASan
@@ -62,6 +62,13 @@ pipeline {
             ],
 
             [
+              name: "Rover 1",
+              test: "mavros_posix_test_mission.test",
+              mission: "rover_mission_1",
+              vehicle: "rover"
+            ],
+
+            [
               name: "VTOL_standard",
               test: "mavros_posix_test_mission.test",
               mission: "VTOL_mission_1",

--- a/.ci/Jenkinsfile-SITL_tests_coverage
+++ b/.ci/Jenkinsfile-SITL_tests_coverage
@@ -36,6 +36,13 @@ pipeline {
             ],
 
             [
+              name: "Rover 1",
+              test: "mavros_posix_test_mission.test",
+              mission: "rover_mission_1",
+              vehicle: "rover"
+            ],
+
+            [
               name: "VTOL_standard",
               test: "mavros_posix_test_mission.test",
               mission: "VTOL_mission_1",

--- a/integrationtests/python_src/px4_it/mavros/missions/rover_mission_1.plan
+++ b/integrationtests/python_src/px4_it/mavros/missions/rover_mission_1.plan
@@ -26,14 +26,14 @@
                     0,
                     0,
                     null,
-                    47.3976553874599,
-                    8.54927199587803,
+                    47.39773780490375,
+                    8.54604903179387,
                     0
                 ],
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 0,
                 "Altitude": 0,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -45,14 +45,14 @@
                     0,
                     0,
                     null,
-                    47.39582242551285,
-                    8.549123889123223,
+                    47.397488802748335,
+                    8.54604396073961,
                     0
                 ],
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 0,
                 "Altitude": 0,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -64,8 +64,8 @@
                     0,
                     0,
                     null,
-                    47.39616801,
-                    8.54515369,
+                    47.397475935201946,
+                    8.545597816497462,
                     0
                 ],
                 "type": "SimpleItem"
@@ -73,7 +73,7 @@
         ],
         "plannedHomePosition": [
             47.3977419,
-            8.545594,
+            8.5455944,
             489
         ],
         "vehicleType": 10,

--- a/integrationtests/python_src/px4_it/mavros/missions/rover_mission_1.plan
+++ b/integrationtests/python_src/px4_it/mavros/missions/rover_mission_1.plan
@@ -1,0 +1,88 @@
+{
+    "fileType": "Plan",
+    "geoFence": {
+        "circles": [
+        ],
+        "polygons": [
+        ],
+        "version": 2
+    },
+    "groundStation": "QGroundControl",
+    "mission": {
+        "cruiseSpeed": 15,
+        "firmwareType": 12,
+        "hoverSpeed": 5,
+        "items": [
+            {
+                "AMSLAltAboveTerrain": 0,
+                "Altitude": 0,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 1,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    47.3976553874599,
+                    8.54927199587803,
+                    0
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 0,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 2,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    47.39582242551285,
+                    8.549123889123223,
+                    0
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 0,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 3,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    47.39616801,
+                    8.54515369,
+                    0
+                ],
+                "type": "SimpleItem"
+            }
+        ],
+        "plannedHomePosition": [
+            47.3977419,
+            8.545594,
+            489
+        ],
+        "vehicleType": 10,
+        "version": 2
+    },
+    "rallyPoints": {
+        "points": [
+        ],
+        "version": 2
+    },
+    "version": 1
+}


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
There are no existing SITL tests for the rover.

**Describe your preferred solution**
A rover mission, `rover_mission_1`, was added to Jenkins. It is a simple mission consisting of driving to 3 waypoints.
