### PR TITLE
Populate distance sensor id in the the MavlinkStreamDistanceSensor class in mavlink_messages.cpp

### DIFF
--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -4183,8 +4183,6 @@ protected:
 
 			msg.time_boot_ms = dist_sensor.timestamp / 1000; /* us to ms */
 
-			/* TODO: use correct ID here */
-			msg.id = 0;
 
 			switch (dist_sensor.type) {
 			case MAV_DISTANCE_SENSOR_ULTRASOUND:
@@ -4204,11 +4202,12 @@ protected:
 				break;
 			}
 
-			msg.orientation = dist_sensor.orientation;
-			msg.min_distance = dist_sensor.min_distance * 100.0f; /* m to cm */
-			msg.max_distance = dist_sensor.max_distance * 100.0f; /* m to cm */
-			msg.current_distance = dist_sensor.current_distance * 100.0f; /* m to cm */
-			msg.covariance = dist_sensor.variance * 1e4f; // m^2 to cm^2
+			msg.current_distance = dist_sensor.current_distance * 1e2f; // m to cm
+			msg.id               = dist_sensor.id;
+			msg.max_distance     = dist_sensor.max_distance * 1e2f;     // m to cm
+			msg.min_distance     = dist_sensor.min_distance * 1e2f;     // m to cm
+			msg.orientation      = dist_sensor.orientation;
+			msg.covariance       = dist_sensor.variance * 1e4f;         // m^2 to cm^2
 
 			mavlink_msg_distance_sensor_send_struct(_mavlink->get_channel(), &msg);
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
For an unknown reason, the sensor ID was not being populated in the MavlinkStreamDistanceSensor class in mavlink_messages.cpp.  This PR simply populates the `msg.id` field and performs minor formatting.

**Test data / coverage**
This PR was tested with a SensorDots MappyDot+ driver polling data from 3 sensors on the I2CA bus of a pixhawk 4 and QGC.
![image](https://user-images.githubusercontent.com/2497951/58665254-afcfc500-82ed-11e9-8477-542862828f94.png)

Without this PR, the value reported is always `0`:
![image](https://user-images.githubusercontent.com/2497951/58665325-d8f05580-82ed-11e9-8102-6e6a44130ff7.png)

@mhkabir , @dagar 

Please let me know if you have any questions on this PR! Thanks!

Mark
