### PR TITLE
microRTPS bridge: uORB RTPS ID mandatory; allow pub/sub for multi-topics/alias msgs

### DIFF
--- a/msg/templates/uorb_microcdr/microRTPS_client.cpp.em
+++ b/msg/templates/uorb_microcdr/microRTPS_client.cpp.em
@@ -18,7 +18,7 @@ import gencpp
 from px_generate_uorb_topic_helper import * # this is in Tools/
 from px_generate_uorb_topic_files import MsgScope # this is in Tools/
 
-topic_names = [s.short_name for idx, s in enumerate(spec)]
+topic_names = [s.short_name for s in spec]
 send_topics = [(alias[idx] if alias[idx] else s.short_name) for idx, s in enumerate(spec) if scope[idx] == MsgScope.SEND]
 send_base_types = [s.short_name for idx, s in enumerate(spec) if scope[idx] == MsgScope.SEND]
 recv_topics = [(alias[idx] if alias[idx] else s.short_name) for idx, s in enumerate(spec) if scope[idx] == MsgScope.RECEIVE]

--- a/msg/templates/urtps/Publisher.cpp.em
+++ b/msg/templates/urtps/Publisher.cpp.em
@@ -15,11 +15,12 @@ import genmsg.msgs
 import gencpp
 from px_generate_uorb_topic_helper import * # this is in Tools/
 
-topic = spec.short_name
+topic = alias if alias else spec.short_name
 }@
 /****************************************************************************
  *
  * Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ * Copyright (C) 2018-2019 PX4 Pro Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/msg/templates/urtps/Publisher.h.em
+++ b/msg/templates/urtps/Publisher.h.em
@@ -15,11 +15,12 @@ import genmsg.msgs
 import gencpp
 from px_generate_uorb_topic_helper import * # this is in Tools/
 
-topic = spec.short_name
+topic = alias if alias else spec.short_name
 }@
 /****************************************************************************
  *
  * Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ * Copyright (C) 2018-2019 PX4 Pro Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/msg/templates/urtps/RtpsTopics.cpp.em
+++ b/msg/templates/urtps/RtpsTopics.cpp.em
@@ -17,12 +17,13 @@ import gencpp
 from px_generate_uorb_topic_helper import * # this is in Tools/
 from px_generate_uorb_topic_files import MsgScope # this is in Tools/
 
-send_topics = [s.short_name for idx, s in enumerate(spec) if scope[idx] == MsgScope.SEND]
-recv_topics = [s.short_name for idx, s in enumerate(spec) if scope[idx] == MsgScope.RECEIVE]
+send_topics = [(alias[idx] if alias[idx] else s.short_name) for idx, s in enumerate(spec) if scope[idx] == MsgScope.SEND]
+recv_topics = [(alias[idx] if alias[idx] else s.short_name) for idx, s in enumerate(spec) if scope[idx] == MsgScope.RECEIVE]
 }@
 /****************************************************************************
  *
  * Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ * Copyright (C) 2018-2019 PX4 Pro Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -88,7 +89,7 @@ void RtpsTopics::publish(uint8_t topic_ID, char data_buffer[], size_t len)
 {
     switch (topic_ID)
     {
-@[for topic in send_topics]@
+@[for idx, topic in enumerate(send_topics)]@
         case @(rtps_message_id(ids, topic)): // @(topic)
         {
             @(topic)_ st;

--- a/msg/templates/urtps/RtpsTopics.cpp.em
+++ b/msg/templates/urtps/RtpsTopics.cpp.em
@@ -89,7 +89,7 @@ void RtpsTopics::publish(uint8_t topic_ID, char data_buffer[], size_t len)
 {
     switch (topic_ID)
     {
-@[for idx, topic in enumerate(send_topics)]@
+@[for topic in send_topics]@
         case @(rtps_message_id(ids, topic)): // @(topic)
         {
             @(topic)_ st;

--- a/msg/templates/urtps/RtpsTopics.h.em
+++ b/msg/templates/urtps/RtpsTopics.h.em
@@ -17,13 +17,13 @@ import gencpp
 from px_generate_uorb_topic_helper import * # this is in Tools/
 from px_generate_uorb_topic_files import MsgScope # this is in Tools/
 
-topic_names = [single_spec.short_name for single_spec in spec]
-send_topics = [s.short_name for idx, s in enumerate(spec) if scope[idx] == MsgScope.SEND]
-recv_topics = [s.short_name for idx, s in enumerate(spec) if scope[idx] == MsgScope.RECEIVE]
+send_topics = [(alias[idx] if alias[idx] else s.short_name) for idx, s in enumerate(spec) if scope[idx] == MsgScope.SEND]
+recv_topics = [(alias[idx] if alias[idx] else s.short_name) for idx, s in enumerate(spec) if scope[idx] == MsgScope.RECEIVE]
 }@
 /****************************************************************************
  *
  * Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ * Copyright (C) 2018-2019 PX4 Pro Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/msg/templates/urtps/Subscriber.cpp.em
+++ b/msg/templates/urtps/Subscriber.cpp.em
@@ -15,11 +15,12 @@ import genmsg.msgs
 import gencpp
 from px_generate_uorb_topic_helper import * # this is in Tools/
 
-topic = spec.short_name
+topic = alias if alias else spec.short_name
 }@
 /****************************************************************************
  *
  * Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ * Copyright (C) 2018-2019 PX4 Pro Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/msg/templates/urtps/Subscriber.h.em
+++ b/msg/templates/urtps/Subscriber.h.em
@@ -15,11 +15,12 @@ import genmsg.msgs
 import gencpp
 from px_generate_uorb_topic_helper import * # this is in Tools/
 
-topic = spec.short_name
+topic = alias if alias else spec.short_name
 }@
 /****************************************************************************
  *
  * Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ * Copyright (C) 2018-2019 PX4 Pro Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/msg/templates/urtps/microRTPS_agent.cpp.em
+++ b/msg/templates/urtps/microRTPS_agent.cpp.em
@@ -16,9 +16,8 @@ import gencpp
 from px_generate_uorb_topic_helper import * # this is in Tools/
 from px_generate_uorb_topic_files import MsgScope # this is in Tools/
 
-topic_names = [single_spec.short_name for single_spec in spec]
-send_topics = [s.short_name for idx, s in enumerate(spec) if scope[idx] == MsgScope.SEND]
-recv_topics = [s.short_name for idx, s in enumerate(spec) if scope[idx] == MsgScope.RECEIVE]
+send_topics = [(alias[idx] if alias[idx] else s.short_name) for idx, s in enumerate(spec) if scope[idx] == MsgScope.SEND]
+recv_topics = [(alias[idx] if alias[idx] else s.short_name) for idx, s in enumerate(spec) if scope[idx] == MsgScope.RECEIVE]
 }@
 /****************************************************************************
  *

--- a/msg/templates/urtps/microRTPS_agent_CMakeLists.txt.em
+++ b/msg/templates/urtps/microRTPS_agent_CMakeLists.txt.em
@@ -1,6 +1,7 @@
 ################################################################################
 #
 # Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright (C) 2018-2019 PX4 Pro Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/msg/templates/urtps/microRTPS_transport.h
+++ b/msg/templates/urtps/microRTPS_transport.h
@@ -1,6 +1,7 @@
 /****************************************************************************
  *
  * Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+ * Copyright (C) 2018-2019 PX4 Pro Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/msg/templates/urtps/msg.idl.em
+++ b/msg/templates/urtps/msg.idl.em
@@ -7,6 +7,7 @@
 @################################################################################
 @#
 @# Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+@# Copyright (C) 2018-2019 PX4 Development Team. All rights reserved.
 @#
 @# Redistribution and use in source and binary forms, with or without
 @# modification, are permitted provided that the following conditions are met:
@@ -42,6 +43,8 @@ from px_generate_uorb_topic_helper import *  # this is in Tools/
 
 builtin_types = set()
 array_types = set()
+
+topic = alias if alias else spec.short_name
 }@
 @#################################################
 @# Searching for serialize function per each field
@@ -71,7 +74,7 @@ def get_idl_type_name(field_type):
 def add_msg_field(field):
     if (not field.is_header):
         if field.is_array:
-            print('    {0}__{1}_array_{2} {3}_;'.format(spec.short_name, str(get_idl_type_name(field.base_type)).replace(" ", "_"), str(field.array_len), field.name))
+            print('    {0}__{1}_array_{2} {3}_;'.format(topic, str(get_idl_type_name(field.base_type)).replace(" ", "_"), str(field.array_len), field.name))
         else:
             base_type = get_idl_type_name(field.base_type) + "_" if get_idl_type_name(field.base_type) in builtin_types else get_idl_type_name(field.base_type)
             print('    {0} {1}_;'.format(base_type, field.name))
@@ -86,7 +89,7 @@ def add_array_typedefs():
     for field in spec.parsed_fields():
         if not field.is_header and field.is_array:
             base_type = get_idl_type_name(field.base_type) + "_" if get_idl_type_name(field.base_type) in builtin_types else get_idl_type_name(field.base_type)
-            array_type = 'typedef {0} {1}__{2}_array_{3}[{4}];'.format(base_type, spec.short_name, get_idl_type_name(field.base_type).replace(" ", "_"), field.array_len, field.array_len)
+            array_type = 'typedef {0} {1}__{2}_array_{3}[{4}];'.format(base_type, topic, get_idl_type_name(field.base_type).replace(" ", "_"), field.array_len, field.array_len)
             if array_type not in array_types:
                 array_types.add(array_type)
     for atype in array_types:
@@ -97,11 +100,11 @@ def add_msg_constants():
     sorted_constants = sorted(spec.constants,
                        key=sizeof_field_type, reverse=True)
     for constant in sorted_constants:
-        print('const {0} {1}__{2} = {3};'.format(get_idl_type_name(constant.type), spec.short_name, constant.name, constant.val))
+        print('const {0} {1}__{2} = {3};'.format(get_idl_type_name(constant.type), topic, constant.name, constant.val))
 
 }
-#ifndef __@(spec.short_name)__idl__
-#define __@(spec.short_name)__idl__
+#ifndef __@(topic)__idl__
+#define __@(topic)__idl__
 
 @#############################
 @# Include dependency messages
@@ -113,11 +116,11 @@ def add_msg_constants():
 @add_msg_constants()
 @# Array types
 @add_array_typedefs()
-struct @(spec.short_name)_
+struct @(topic)_
 {
 @add_msg_fields()
-}; // struct @(spec.short_name)_
+}; // struct @(topic)_
 
-#pragma keylist @(spec.short_name)_
+#pragma keylist @(topic)_
 
-#endif  // __@(spec.short_name)__idl__
+#endif  // __@(topic)__idl__

--- a/msg/tools/generate_microRTPS_bridge.py
+++ b/msg/tools/generate_microRTPS_bridge.py
@@ -3,7 +3,7 @@
 ################################################################################
 #
 # Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
-#           2018 PX4 Pro Development Team. All rights reserved.
+#           2018-2019 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -62,61 +62,66 @@ def check_rtps_id_uniqueness(classifier):
 
     repeated_ids = dict()
 
+    full_send_list = dict(list(msg for msg in classifier.msgs_to_send.items()) + list(msg[0].items()[0] for msg in classifier.alias_msgs_to_send))
+    full_receive_list = dict(list(msg for msg in classifier.msgs_to_receive.items()) + list(msg[0].items()[0] for msg in classifier.alias_msgs_to_receive))
+    full_ignore_list = dict(list(msg for msg in classifier.msgs_to_ignore.items()) + list(msg[0].items()[0] for msg in classifier.alias_msgs_to_ignore))
+
     # check if there are repeated ID's on the messages to send
-    for key, value in classifier.msgs_to_send.items():
+    for key, value in full_send_list.items():
         if sys.version_info[0] < 3:
-            if classifier.msgs_to_send.values().count(value) > 1:
+            if full_send_list.values().count(value) > 1:
                 repeated_ids.update({key: value})
         else:
-            if list(classifier.msgs_to_send.values()).count(value) > 1:
+            if list(full_send_list.values()).count(value) > 1:
                 repeated_ids.update({key: value})
 
     # check if there are repeated ID's on the messages to receive
-    for key, value in classifier.msgs_to_receive.items():
+    for key, value in full_receive_list.items():
         if sys.version_info[0] < 3:
-            if classifier.msgs_to_receive.values().count(value) > 1:
+            if full_receive_list.values().count(value) > 1:
                 repeated_ids.update({key: value})
         else:
-            if list(classifier.msgs_to_receive.values()).count(value) > 1:
+            if list(full_receive_list.values()).count(value) > 1:
                 repeated_ids.update({key: value})
 
     # check if there are repeated ID's on the messages to ignore
-    for key, value in classifier.msgs_to_ignore.items():
+    for key, value in full_ignore_list.items():
         if sys.version_info[0] < 3:
-            if classifier.msgs_to_ignore.values().count(value) > 1:
+            if full_ignore_list.values().count(value) > 1:
                 repeated_ids.update({key: value})
         else:
-            if list(classifier.msgs_to_ignore.values()).count(value) > 1:
+            if list(full_ignore_list.values()).count(value) > 1:
                 repeated_ids.update({key: value})
 
     # check if there are repeated IDs between classified and unclassified msgs
     # check send and ignore lists
-    send_ignore_common_ids = list(set(classifier.msgs_to_ignore.values(
-    )).intersection(classifier.msgs_to_send.values()))
-    for item in zip(classifier.msgs_to_send.items(), classifier.msgs_to_ignore.items()):
+    send_ignore_common_ids = list(set(full_ignore_list.values(
+    )).intersection(full_send_list.values()))
+    for item in full_send_list.items():
         for repeated in send_ignore_common_ids:
             if item[1] == repeated:
                 repeated_ids.update({item[0]: item[1]})
-    for item in classifier.msgs_to_ignore.items():
+    for item in full_ignore_list.items():
         for repeated in send_ignore_common_ids:
             if item[1] == repeated:
                 repeated_ids.update({item[0]: item[1]})
 
     # check receive and ignore lists
-    receive_ignore_common_ids = list(set(classifier.msgs_to_ignore.values(
-    )).intersection(classifier.msgs_to_receive.values()))
-    for item in classifier.msgs_to_receive.items():
+    receive_ignore_common_ids = list(set(full_ignore_list.values(
+    )).intersection(full_receive_list.values()))
+    for item in full_receive_list.items():
         for repeated in receive_ignore_common_ids:
             if item[1] == repeated:
                 repeated_ids.update({item[0]: item[1]})
-    for item in classifier.msgs_to_ignore.items():
+    for item in full_ignore_list.items():
         for repeated in receive_ignore_common_ids:
             if item[1] == repeated:
                 repeated_ids.update({item[0]: item[1]})
 
-    all_msgs = classifier.msgs_to_send
-    all_msgs.update(classifier.msgs_to_receive)
-    all_msgs.update(classifier.msgs_to_ignore)
+    all_msgs = {}
+    all_msgs.update(full_send_list)
+    all_msgs.update(full_receive_list)
+    all_msgs.update(full_ignore_list)
     all_ids = list()
     if sys.version_info[0] < 3:
         all_ids = all_msgs.values()
@@ -277,44 +282,76 @@ uRTPS_SUBSCRIBER_H_TEMPL_FILE = 'Subscriber.h.em'
 
 
 def generate_agent(out_dir):
-
-    if classifier.msg_files_send:
-        for msg_file in classifier.msg_files_send:
+    # raise Exception(classifier.msgs_to_receive)
+    if classifier.msgs_to_send:
+        for msg_file in classifier.msgs_to_send:
             if gen_idl:
                 if out_dir != agent_out_dir:
-                    px_generate_uorb_topic_files.generate_idl_file(msg_file, os.path.join(out_dir, "/idl"), urtps_templates_dir,
+                    px_generate_uorb_topic_files.generate_idl_file(msg_file, msg_dir, "", os.path.join(out_dir, "/idl"), urtps_templates_dir,
                                                                    package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map)
                 else:
-                    px_generate_uorb_topic_files.generate_idl_file(msg_file, idl_dir, urtps_templates_dir,
+                    px_generate_uorb_topic_files.generate_idl_file(msg_file, msg_dir, "", idl_dir, urtps_templates_dir,
                                                                    package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map)
-            px_generate_uorb_topic_files.generate_topic_file(msg_file, out_dir, urtps_templates_dir,
+            px_generate_uorb_topic_files.generate_topic_file(msg_file, msg_dir, "", out_dir, urtps_templates_dir,
                                                              package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, uRTPS_PUBLISHER_SRC_TEMPL_FILE)
-            px_generate_uorb_topic_files.generate_topic_file(msg_file, out_dir, urtps_templates_dir,
+            px_generate_uorb_topic_files.generate_topic_file(msg_file, msg_dir, "", out_dir, urtps_templates_dir,
                                                              package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, uRTPS_PUBLISHER_H_TEMPL_FILE)
 
-    if classifier.msg_files_receive:
-        for msg_file in classifier.msg_files_receive:
+    if classifier.alias_msgs_to_send:
+        for msg_file in classifier.alias_msgs_to_send:
+            msg_alias = msg_file[0].keys()[0]
+            msg_name = msg_file[1]
             if gen_idl:
                 if out_dir != agent_out_dir:
-                    px_generate_uorb_topic_files.generate_idl_file(msg_file, os.path.join(out_dir, "/idl"), urtps_templates_dir,
+                    px_generate_uorb_topic_files.generate_idl_file(msg_name, msg_dir, msg_alias, os.path.join(out_dir, "/idl"), urtps_templates_dir,
                                                                    package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map)
                 else:
-                    px_generate_uorb_topic_files.generate_idl_file(msg_file, idl_dir, urtps_templates_dir,
+                    px_generate_uorb_topic_files.generate_idl_file(msg_name, msg_dir, msg_alias, idl_dir, urtps_templates_dir,
                                                                    package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map)
-            px_generate_uorb_topic_files.generate_topic_file(msg_file, out_dir, urtps_templates_dir,
+            px_generate_uorb_topic_files.generate_topic_file(msg_name, msg_dir, msg_alias, out_dir, urtps_templates_dir,
+                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, uRTPS_PUBLISHER_SRC_TEMPL_FILE)
+            px_generate_uorb_topic_files.generate_topic_file(msg_name, msg_dir, msg_alias, out_dir, urtps_templates_dir,
+                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, uRTPS_PUBLISHER_H_TEMPL_FILE)
+
+    if classifier.msgs_to_receive:
+        for msg_file in classifier.msgs_to_receive:
+            if gen_idl:
+                if out_dir != agent_out_dir:
+                    px_generate_uorb_topic_files.generate_idl_file(msg_file, msg_dir, "", os.path.join(out_dir, "/idl"), urtps_templates_dir,
+                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map)
+                else:
+                    px_generate_uorb_topic_files.generate_idl_file(msg_file, msg_dir, "", idl_dir, urtps_templates_dir,
+                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map)
+            px_generate_uorb_topic_files.generate_topic_file(msg_file, msg_dir, "", out_dir, urtps_templates_dir,
                                                              package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, uRTPS_SUBSCRIBER_SRC_TEMPL_FILE)
-            px_generate_uorb_topic_files.generate_topic_file(msg_file, out_dir, urtps_templates_dir,
+            px_generate_uorb_topic_files.generate_topic_file(msg_file, msg_dir, "", out_dir, urtps_templates_dir,
                                                              package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, uRTPS_SUBSCRIBER_H_TEMPL_FILE)
 
-    px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msg_files_send, classifier.msg_files_receive, out_dir, urtps_templates_dir,
-                                                        package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, uRTPS_AGENT_TEMPL_FILE)
-    px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msg_files_send, classifier.msg_files_receive, out_dir, urtps_templates_dir,
-                                                        package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, uRTPS_AGENT_TOPICS_H_TEMPL_FILE)
-    px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msg_files_send, classifier.msg_files_receive, out_dir, urtps_templates_dir,
-                                                        package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, uRTPS_AGENT_TOPICS_SRC_TEMPL_FILE)
+    if classifier.alias_msgs_to_receive:
+        for msg_file in classifier.alias_msgs_to_receive:
+            msg_alias = msg_file[0].keys()[0]
+            msg_name = msg_file[1]
+            if gen_idl:
+                if out_dir != agent_out_dir:
+                    px_generate_uorb_topic_files.generate_idl_file(msg_name, msg_dir, msg_alias, os.path.join(out_dir, "/idl"), urtps_templates_dir,
+                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map)
+                else:
+                    px_generate_uorb_topic_files.generate_idl_file(msg_name, msg_dir, msg_alias, idl_dir, urtps_templates_dir,
+                                                                   package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map)
+            px_generate_uorb_topic_files.generate_topic_file(msg_name, msg_dir, msg_alias, out_dir, urtps_templates_dir,
+                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, uRTPS_SUBSCRIBER_SRC_TEMPL_FILE)
+            px_generate_uorb_topic_files.generate_topic_file(msg_name, msg_dir, msg_alias, out_dir, urtps_templates_dir,
+                                                             package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, uRTPS_SUBSCRIBER_H_TEMPL_FILE)
+
+    px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msgs_to_send, classifier.alias_msgs_to_send, classifier.msgs_to_receive, classifier.alias_msgs_to_receive, msg_dir, out_dir,
+                                                        urtps_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, uRTPS_AGENT_TEMPL_FILE)
+    px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msgs_to_send, classifier.alias_msgs_to_send, classifier.msgs_to_receive, classifier.alias_msgs_to_receive, msg_dir, out_dir,
+                                                        urtps_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, uRTPS_AGENT_TOPICS_H_TEMPL_FILE)
+    px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msgs_to_send, classifier.alias_msgs_to_send, classifier.msgs_to_receive, classifier.alias_msgs_to_receive, msg_dir, out_dir,
+                                                        urtps_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, uRTPS_AGENT_TOPICS_SRC_TEMPL_FILE)
     if cmakelists:
-        px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msg_files_send, classifier.msg_files_receive, out_dir, urtps_templates_dir,
-                                                            package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, uRTPS_AGENT_CMAKELISTS_TEMPL_FILE)
+        px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msgs_to_send, classifier.alias_msgs_to_send, classifier.msgs_to_receive, classifier.alias_msgs_to_receive, msg_dir, out_dir,
+                                                            urtps_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, uRTPS_AGENT_CMAKELISTS_TEMPL_FILE)
 
     # Final steps to install agent
     mkdir_p(os.path.join(out_dir, "fastrtpsgen"))
@@ -387,8 +424,8 @@ def generate_client(out_dir):
         if os.path.isfile(def_file):
             os.rename(def_file, def_file.replace(".h", ".h_"))
 
-    px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msg_files_send, classifier.msg_files_receive, out_dir, uorb_templates_dir,
-                                                        package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, uRTPS_CLIENT_TEMPL_FILE)
+    px_generate_uorb_topic_files.generate_uRTPS_general(classifier.msgs_to_send, classifier.alias_msgs_to_send, classifier.msgs_to_receive, classifier.alias_msgs_to_receive, msg_dir,
+                                                        out_dir, uorb_templates_dir, package, px_generate_uorb_topic_files.INCL_DEFAULT, classifier.msg_id_map, uRTPS_CLIENT_TEMPL_FILE)
 
     # Final steps to install client
     cp_wildcard(os.path.join(urtps_templates_dir,

--- a/msg/tools/generate_microRTPS_bridge.py
+++ b/msg/tools/generate_microRTPS_bridge.py
@@ -282,7 +282,6 @@ uRTPS_SUBSCRIBER_H_TEMPL_FILE = 'Subscriber.h.em'
 
 
 def generate_agent(out_dir):
-    # raise Exception(classifier.msgs_to_receive)
     if classifier.msgs_to_send:
         for msg_file in classifier.msgs_to_send:
             if gen_idl:

--- a/msg/tools/px_generate_uorb_topic_files.py
+++ b/msg/tools/px_generate_uorb_topic_files.py
@@ -174,10 +174,6 @@ def generate_idl_file(filename_msg, msg_dir, alias, outputdir, templatedir, pack
     """
     Generates an .idl from .msg file
     """
-    # Make sure input msg directory exists:
-    if not os.path.isdir(msg_dir):
-        os.makedirs(msg_dir)
-
     msg = os.path.join(msg_dir, filename_msg + ".msg")
 
     if (alias != ""):
@@ -205,10 +201,6 @@ def generate_uRTPS_general(filename_send_msgs, filename_alias_send_msgs, filenam
     """
     Generates source file by msg content
     """
-    # Make sure input msg directory exists:
-    if not os.path.isdir(msg_dir):
-        os.makedirs(msg_dir)
-
     send_msgs = list(os.path.join(msg_dir, msg + ".msg") for msg in filename_send_msgs)
     alias_send_msgs = list([os.path.join(msg_dir, msg[1] + ".msg"), msg[0].keys()[0]] for msg in filename_alias_send_msgs)
     receive_msgs = list(os.path.join(msg_dir, msg + ".msg") for msg in filename_receive_msgs)
@@ -248,10 +240,6 @@ def generate_topic_file(filename_msg, msg_dir, alias, outputdir, templatedir, pa
     """
     Generates a sources and headers from .msg file
     """
-    # Make sure input msg directory exists:
-    if not os.path.isdir(msg_dir):
-        os.makedirs(msg_dir)
-
     msg = os.path.join(msg_dir, filename_msg + ".msg")
 
     if (alias):

--- a/msg/tools/px_generate_uorb_topic_helper.py
+++ b/msg/tools/px_generate_uorb_topic_helper.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #############################################################################
 #
-#   Copyright (C) 2013-2018 PX4 Pro Development Team. All rights reserved.
+#   Copyright (C) 2013-2019 PX4 Pro Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/msg/tools/uorb_rtps_classifier.py
+++ b/msg/tools/uorb_rtps_classifier.py
@@ -152,7 +152,7 @@ class Classifier():
         base_types = {}
         for incorrect in incorrect_base_types:
             base_types.update({incorrect: difflib.get_close_matches(
-                incorrect, uorb_msg, n=1, cutoff=0.8)})
+                incorrect, uorb_msg, n=1, cutoff=0.6)})
 
         if len(base_types) > 0:
             raise AssertionError(

--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -1,11 +1,11 @@
 rtps:
   - msg: actuator_armed
     id: 0
-  - msg: actuator_control
+  - msg: actuator_controls
     id: 1
   - msg: actuator_direct
     id: 2
-  - msg: actuator_output
+  - msg: actuator_outputs
     id: 3
   - msg: adc_report
     id: 4
@@ -80,7 +80,7 @@ rtps:
     send: true
   - msg: irlock_report
     id: 32
-  - msg: landing_target_innovation
+  - msg: landing_target_innovations
     id: 33
   - msg: landing_target_pose
     id: 34
@@ -246,14 +246,24 @@ rtps:
   - msg: collision_constraints
     id: 107
     send: true
+  - msg: multirotor_motor_limits
+    id: 108
+  - msg: vehicle_constraints
+    id: 109
+  - msg: orbit_status
+    id: 110
+  - msg: power_monitor
+    id: 111
+  - msg: landing_gear
+    id: 112
   # multi topics
-  - msg: actuator_control0
+  - msg: actuator_controls_0
     id: 120
-  - msg: actuator_control1
+  - msg: actuator_controls_1
     id: 121
-  - msg: actuator_control2
+  - msg: actuator_controls_2
     id: 122
-  - msg: actuator_control3
+  - msg: actuator_controls_3
     id: 123
   - msg: actuator_controls_virtual_fw
     id: 124

--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -98,7 +98,7 @@ rtps:
     id: 40
   - msg: mount_orientation
     id: 41
-  - msg: multirotor_motor_limit
+  - msg: multirotor_motor_limits
     id: 42
   - msg: obstacle_distance
     id: 43
@@ -207,7 +207,7 @@ rtps:
     id: 89
   - msg: vehicle_command_ack
     id: 90
-  - msg: vehicle_constraint
+  - msg: vehicle_constraints
     id: 91
   - msg: vehicle_control_mode
     id: 92
@@ -246,46 +246,54 @@ rtps:
   - msg: collision_constraints
     id: 107
     send: true
-  - msg: multirotor_motor_limits
-    id: 108
-  - msg: vehicle_constraints
-    id: 109
   - msg: orbit_status
-    id: 110
+    id: 108
   - msg: power_monitor
-    id: 111
+    id: 109
   - msg: landing_gear
-    id: 112
+    id: 110
   # multi topics
   - msg: actuator_controls_0
     id: 120
+    alias: actuactor_controls
   - msg: actuator_controls_1
     id: 121
+    alias: actuactor_controls
   - msg: actuator_controls_2
     id: 122
+    alias: actuactor_controls
   - msg: actuator_controls_3
     id: 123
+    alias: actuactor_controls
   - msg: actuator_controls_virtual_fw
     id: 124
+    alias: actuactor_controls
   - msg: actuator_controls_virtual_mc
     id: 125
+    alias: actuactor_controls
   - msg: mc_virtual_attitude_setpoint
     id: 126
+    alias: vehicle_attitude_setpoint
   - msg: fw_virtual_attitude_setpoint
     id: 127
+    alias: vehicle_attitude_setpoint
   - msg: vehicle_attitude_groundtruth
     id: 128
+    alias: vehicle_attitude
   - msg: vehicle_global_position_groundtruth
     id: 129
+    alias: vehicle_global_position
   - msg: vehicle_local_position_groundtruth
     id: 130
+    alias: vehicle_local_position
   - msg: vehicle_mocap_odometry
+    alias: vehicle_odometry
     id: 131
+    receive: true
   - msg: vehicle_visual_odometry
     id: 132
-  - msg: mc_virtual_rates_setpoint
-    id: 133
-  - msg: fw_virtual_rates_setpoint
-    id: 134
+    alias: vehicle_odometry
+    receive: true
   - msg: vehicle_trajectory_waypoint_desired
-    id: 135
+    id: 133
+    alias: vehicle_trajectory_waypoint

--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -255,22 +255,22 @@ rtps:
   # multi topics
   - msg: actuator_controls_0
     id: 120
-    alias: actuactor_controls
+    alias: actuator_controls
   - msg: actuator_controls_1
     id: 121
-    alias: actuactor_controls
+    alias: actuator_controls
   - msg: actuator_controls_2
     id: 122
-    alias: actuactor_controls
+    alias: actuator_controls
   - msg: actuator_controls_3
     id: 123
-    alias: actuactor_controls
+    alias: actuator_controls
   - msg: actuator_controls_virtual_fw
     id: 124
-    alias: actuactor_controls
+    alias: actuator_controls
   - msg: actuator_controls_virtual_mc
     id: 125
-    alias: actuactor_controls
+    alias: actuator_controls
   - msg: mc_virtual_attitude_setpoint
     id: 126
     alias: vehicle_attitude_setpoint

--- a/src/modules/micrortps_bridge/CMakeLists.txt
+++ b/src/modules/micrortps_bridge/CMakeLists.txt
@@ -41,25 +41,37 @@ if(NOT FASTRTPSGEN)
 endif()
 
 if (EXISTS "${PX4_SOURCE_DIR}/msg/tools/uorb_rtps_message_ids.yaml")
-
-  set(config_rtps_send_topics)
+	set(config_rtps_send_topics)
 	execute_process(
-		COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/msg/tools/uorb_rtps_classifier.py -s
+		COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/msg/tools/uorb_rtps_classifier.py -sa
 		OUTPUT_VARIABLE config_rtps_send_topics
 	)
-
+	set(config_rtps_send_alias_topics "")
+	string(FIND ${config_rtps_send_topics} "alias" found_send_alias)
+	if (NOT ${found_send_alias} EQUAL "-1")
+		STRING(REGEX REPLACE ".*alias " "" config_rtps_send_alias_topics "${config_rtps_send_topics}")
+		STRING(REPLACE ", " ";" config_rtps_send_alias_topics "${config_rtps_send_alias_topics}")
+		STRING(REPLACE "\n" "" config_rtps_send_alias_topics "${config_rtps_send_alias_topics}")
+		STRING(REGEX REPLACE " alias.*" "" config_rtps_send_topics "${config_rtps_send_topics}")
+	endif()
 	STRING(REGEX REPLACE ", " ";" config_rtps_send_topics "${config_rtps_send_topics}")
 	STRING(REGEX REPLACE "\n" "" config_rtps_send_topics "${config_rtps_send_topics}")
 
 	set(config_rtps_receive_topics)
 	execute_process(
-		COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/msg/tools/uorb_rtps_classifier.py -r
+		COMMAND ${PYTHON_EXECUTABLE} ${PX4_SOURCE_DIR}/msg/tools/uorb_rtps_classifier.py -ra
 		OUTPUT_VARIABLE config_rtps_receive_topics
 	)
-
-	STRING(REGEX REPLACE ", " ";" config_rtps_receive_topics "${config_rtps_receive_topics}")
-	STRING(REGEX REPLACE "\n" "" config_rtps_receive_topics "${config_rtps_receive_topics}")
-
+	set(config_rtps_receive_alias_topics "")
+	string(FIND ${config_rtps_receive_topics} "alias" found_receive_alias)
+	if (NOT ${found_receive_alias} EQUAL "-1")
+		STRING(REGEX REPLACE ".*alias " "" config_rtps_receive_alias_topics "${config_rtps_receive_topics}")
+		STRING(REPLACE ", " ";" config_rtps_receive_alias_topics "${config_rtps_receive_alias_topics}")
+		STRING(REPLACE "\n" "" config_rtps_receive_alias_topics "${config_rtps_receive_alias_topics}")
+		STRING(REGEX REPLACE " alias.*" "" config_rtps_receive_topics "${config_rtps_receive_topics}")
+	endif()
+	STRING(REPLACE ", " ";" config_rtps_receive_topics "${config_rtps_receive_topics}")
+	STRING(REPLACE "\n" "" config_rtps_receive_topics "${config_rtps_receive_topics}")
 endif()
 
 if (FASTRTPSGEN AND (config_rtps_send_topics OR config_rtps_receive_topics))
@@ -87,7 +99,8 @@ if (GENERATE_RTPS_BRIDGE)
 	set(uorb_sources_microcdr)
 
 	# send topic files
-	message(STATUS "RTPS send: ${config_rtps_send_topics}")
+	STRING(REGEX REPLACE ";" ", " send_list "${config_rtps_send_topics};${config_rtps_send_alias_topics}")
+	message(STATUS "RTPS send: ${send_list}")
 	set(send_topic_files)
 	foreach(topic ${config_rtps_send_topics})
 		list(APPEND send_topic_files ${PX4_SOURCE_DIR}/msg/${topic}.msg)
@@ -96,7 +109,8 @@ if (GENERATE_RTPS_BRIDGE)
 	endforeach()
 
 	# receive topic files
-	message(STATUS "RTPS receive: ${config_rtps_receive_topics}")
+	STRING(REGEX REPLACE ";" ", " rcv_list "${config_rtps_receive_topics};${config_rtps_receive_alias_topics}")
+	message(STATUS "RTPS receive: ${rcv_list}")
 	set(receive_topic_files)
 	foreach(topic ${config_rtps_receive_topics})
 		list(APPEND receive_topic_files ${PX4_SOURCE_DIR}/msg/${topic}.msg)

--- a/src/modules/micrortps_bridge/micrortps_client/CMakeLists.txt
+++ b/src/modules/micrortps_bridge/micrortps_client/CMakeLists.txt
@@ -45,6 +45,14 @@ if (NOT "${config_rtps_send_topics}" STREQUAL "" OR NOT "${config_rtps_receive_t
 		list(APPEND receive_topic_files ${PX4_SOURCE_DIR}/msg/${topic}.msg)
 	endforeach()
 
+	if (NOT "${config_rtps_send_alias_topics}" STREQUAL "")
+		set(config_rtps_send_topics "${config_rtps_send_topics};${config_rtps_send_alias_topics}")
+	endif()
+
+	if (NOT "${config_rtps_receive_alias_topics}" STREQUAL "")
+		set(config_rtps_receive_topics "${config_rtps_receive_topics};${config_rtps_receive_alias_topics}")
+	endif()
+
 	foreach(topic ${config_rtps_send_topics})
 		list(APPEND topic_bridge_files_out ${msg_out_path}/micrortps_agent/${topic}_Publisher.cpp)
 		list(APPEND topic_bridge_files_out ${msg_out_path}/micrortps_agent/${topic}_Publisher.h)
@@ -54,16 +62,6 @@ if (NOT "${config_rtps_send_topics}" STREQUAL "" OR NOT "${config_rtps_receive_t
 		list(APPEND topic_bridge_files_out ${msg_out_path}/micrortps_agent/${topic}_Subscriber.cpp)
 		list(APPEND topic_bridge_files_out ${msg_out_path}/micrortps_agent/${topic}_Subscriber.h)
 	endforeach()
-
-	set(send_topic_files_opt)
-	if (NOT "${send_topic_files}" STREQUAL "")
-		set(send_topic_opt "--send")
-	endif()
-
-	set(receive_topic_files_opt)
-	if (NOT "${receive_topic_files}" STREQUAL "")
-		set(receive_topic_opt "--receive")
-	endif()
 
 	list(APPEND topic_bridge_files_out
 		${msg_out_path}/micrortps_client/microRTPS_client.cpp


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Following the works on the microRTPS bridge, makes sense that all added uORB messages should have their respective RTPS ID allocated, even if they are not used on the bridge.

**UPDATE:** I updated this PR to include a major structural change that allows us to use multi-topic msgs, meaning, alias msgs as `vehicle_visual_odometry`.