### PR TITLE
introduce sensor_gyro_control message (1 kHz rate controller)

### DIFF
--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -105,6 +105,7 @@ set(msg_files
 	sensor_combined.msg
 	sensor_correction.msg
 	sensor_gyro.msg
+	sensor_gyro_control.msg
 	sensor_mag.msg
 	sensor_preflight.msg
 	sensor_selection.msg

--- a/msg/sensor_gyro_control.msg
+++ b/msg/sensor_gyro_control.msg
@@ -1,0 +1,7 @@
+uint32 device_id	# unique device ID for the sensor that does not change between power cycles
+
+uint64 timestamp	# time since system start (microseconds)
+
+uint64 timestamp_sample	# time the raw data was sampled (microseconds)
+
+float32[3] xyz		# filtered angular velocity in the NED X board axis in rad/s

--- a/msg/sensor_gyro_control.msg
+++ b/msg/sensor_gyro_control.msg
@@ -4,4 +4,4 @@ uint64 timestamp	# time since system start (microseconds)
 
 uint64 timestamp_sample	# time the raw data was sampled (microseconds)
 
-float32[3] xyz		# filtered angular velocity in the NED X board axis in rad/s
+float32[3] xyz		# filtered angular velocity in the board axis in rad/s

--- a/msg/sensor_gyro_control.msg
+++ b/msg/sensor_gyro_control.msg
@@ -1,3 +1,7 @@
+
+# WARNING: Not recommend for custom development.
+#  This topic is part of an incremental refactoring of the sensor pipeline and will likely disappear post PX4 release v1.10
+
 uint32 device_id	# unique device ID for the sensor that does not change between power cycles
 
 uint64 timestamp	# time since system start (microseconds)

--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -258,6 +258,8 @@ rtps:
     id: 112
   - msg: vehicle_acceleration
     id: 113
+  - msg: sensor_gyro_control
+    id: 114
   # multi topics
   - msg: actuator_controls_0
     id: 120

--- a/src/lib/drivers/gyroscope/PX4Gyroscope.hpp
+++ b/src/lib/drivers/gyroscope/PX4Gyroscope.hpp
@@ -43,6 +43,7 @@
 #include <uORB/uORB.h>
 #include <uORB/PublicationMulti.hpp>
 #include <uORB/topics/sensor_gyro.h>
+#include <uORB/topics/sensor_gyro_control.h>
 
 class PX4Gyroscope : public cdev::CDev, public ModuleParams
 {
@@ -68,7 +69,8 @@ private:
 
 	void configure_filter(float cutoff_freq) { _filter.set_cutoff_frequency(_sample_rate, cutoff_freq); }
 
-	uORB::PublicationMultiData<sensor_gyro_s>	_sensor_gyro_pub;
+	uORB::PublicationMultiData<sensor_gyro_s>		_sensor_gyro_pub;
+	uORB::PublicationMultiData<sensor_gyro_control_s>	_sensor_gyro_control_pub;
 
 	math::LowPassFilter2pVector3f _filter{1000, 100};
 	Integrator _integrator{4000, true};

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -292,7 +292,7 @@ VehicleAngularVelocity::PrintStatus()
 		PX4_INFO("using sensor_gyro_control: %d (%d)", _selected_sensor_device_id, _selected_sensor_control);
 
 	} else {
-		PX4_WARN("sensor_gyro_control unavailable for selected sensor: %d", _selected_sensor);
+		PX4_WARN("sensor_gyro_control unavailable for selected sensor: %d (%d)", _selected_sensor_device_id,  _selected_sensor);
 	}
 
 	perf_print_counter(_cycle_perf);

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -152,7 +152,7 @@ VehicleAngularVelocity::SensorCorrectionsUpdate(bool force)
 
 				const int sensor_new = corrections.selected_gyro_instance;
 
-				// subscribe to sensor_gyro_control if avialable
+				// subscribe to sensor_gyro_control if available
 				//  currently not all drivers (eg df_*) provide sensor_gyro_control
 				for (int i = 0; i < MAX_SENSOR_COUNT; i++) {
 					sensor_gyro_control_s report{};

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -175,7 +175,6 @@ VehicleAngularVelocity::SensorCorrectionsUpdate(bool force)
 
 				// otherwise fallback to using sensor_gyro (legacy that will be removed)
 				_sensor_control_available = false;
-				_selected_sensor_device_id = 0;
 
 				if (_sensor_sub[sensor_new].register_callback()) {
 					PX4_DEBUG("selected sensor changed %d -> %d", _selected_sensor, sensor_new);

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.cpp
@@ -103,6 +103,17 @@ VehicleAngularVelocity::SensorBiasUpdate(bool force)
 bool
 VehicleAngularVelocity::SensorCorrectionsUpdate(bool force)
 {
+	if (_sensor_selection_sub.updated() || force) {
+		sensor_selection_s sensor_selection;
+
+		if (_sensor_selection_sub.copy(&sensor_selection)) {
+			if (_selected_sensor_device_id != sensor_selection.gyro_device_id) {
+				_selected_sensor_device_id = sensor_selection.gyro_device_id;
+				force = true;
+			}
+		}
+	}
+
 	// check if the selected sensor has updated
 	if (_sensor_correction_sub.updated() || force) {
 
@@ -131,11 +142,34 @@ VehicleAngularVelocity::SensorCorrectionsUpdate(bool force)
 		if ((_selected_sensor != corrections.selected_gyro_instance) || force) {
 			if (corrections.selected_gyro_instance < MAX_SENSOR_COUNT) {
 				// clear all registered callbacks
+				for (auto &sub : _sensor_control_sub) {
+					sub.unregister_callback();
+				}
+
 				for (auto &sub : _sensor_sub) {
 					sub.unregister_callback();
 				}
 
 				const int sensor_new = corrections.selected_gyro_instance;
+
+				// subscribe to sensor_gyro_control if avialable
+				for (int i = 0; i < MAX_SENSOR_COUNT; i++) {
+					sensor_gyro_control_s report{};
+					_sensor_control_sub[i].copy(&report);
+
+					if ((report.device_id != 0) && (report.device_id == _selected_sensor_device_id)) {
+						if (_sensor_control_sub[i].register_callback()) {
+							PX4_DEBUG("selected sensor (control) changed %d -> %d", _selected_sensor, i);
+							_selected_sensor_control = i;
+							_selected_sensor = sensor_new;
+
+							return true;
+						}
+					}
+				}
+
+				// otherwise use sensor_gyro
+				_selected_sensor_device_id = 0;
 
 				if (_sensor_sub[sensor_new].register_callback()) {
 					PX4_DEBUG("selected sensor changed %d -> %d", _selected_sensor, sensor_new);
@@ -183,32 +217,61 @@ VehicleAngularVelocity::Run()
 	// update corrections first to set _selected_sensor
 	SensorCorrectionsUpdate();
 
-	sensor_gyro_s sensor_data;
+	if (_selected_sensor_device_id == 0) {
+		sensor_gyro_s sensor_data;
 
-	if (_sensor_sub[_selected_sensor].update(&sensor_data)) {
-		perf_set_elapsed(_sensor_latency_perf, hrt_elapsed_time(&sensor_data.timestamp));
+		if (_sensor_sub[_selected_sensor].update(&sensor_data)) {
+			perf_set_elapsed(_sensor_latency_perf, hrt_elapsed_time(&sensor_data.timestamp));
 
-		ParametersUpdate();
-		SensorBiasUpdate();
+			ParametersUpdate();
+			SensorBiasUpdate();
 
-		// get the sensor data and correct for thermal errors
-		const Vector3f val{sensor_data.x, sensor_data.y, sensor_data.z};
+			// get the sensor data and correct for thermal errors
+			const Vector3f val{sensor_data.x, sensor_data.y, sensor_data.z};
 
-		// apply offsets and scale
-		Vector3f rates{(val - _offset).emult(_scale)};
+			// apply offsets and scale
+			Vector3f rates{(val - _offset).emult(_scale)};
 
-		// rotate corrected measurements from sensor to body frame
-		rates = _board_rotation * rates;
+			// rotate corrected measurements from sensor to body frame
+			rates = _board_rotation * rates;
 
-		// correct for in-run bias errors
-		rates -= _bias;
+			// correct for in-run bias errors
+			rates -= _bias;
 
-		vehicle_angular_velocity_s angular_velocity;
-		angular_velocity.timestamp_sample = sensor_data.timestamp;
-		rates.copyTo(angular_velocity.xyz);
-		angular_velocity.timestamp = hrt_absolute_time();
+			vehicle_angular_velocity_s angular_velocity;
+			angular_velocity.timestamp_sample = sensor_data.timestamp;
+			rates.copyTo(angular_velocity.xyz);
+			angular_velocity.timestamp = hrt_absolute_time();
 
-		_vehicle_angular_velocity_pub.publish(angular_velocity);
+			_vehicle_angular_velocity_pub.publish(angular_velocity);
+		}
+
+	} else {
+
+		sensor_gyro_control_s sensor_data;
+
+		if (_sensor_control_sub[_selected_sensor].update(&sensor_data)) {
+			perf_set_elapsed(_sensor_latency_perf, hrt_elapsed_time(&sensor_data.timestamp));
+
+			ParametersUpdate();
+			SensorBiasUpdate();
+
+			// get the sensor data and correct for thermal errors (apply offsets and scale)
+			Vector3f rates{(Vector3f{sensor_data.xyz} - _offset).emult(_scale)};
+
+			// rotate corrected measurements from sensor to body frame
+			rates = _board_rotation * rates;
+
+			// correct for in-run bias errors
+			rates -= _bias;
+
+			vehicle_angular_velocity_s angular_velocity;
+			angular_velocity.timestamp_sample = sensor_data.timestamp;
+			rates.copyTo(angular_velocity.xyz);
+			angular_velocity.timestamp = hrt_absolute_time();
+
+			_vehicle_angular_velocity_pub.publish(angular_velocity);
+		}
 	}
 
 	perf_end(_cycle_perf);
@@ -218,6 +281,13 @@ void
 VehicleAngularVelocity::PrintStatus()
 {
 	PX4_INFO("selected sensor: %d", _selected_sensor);
+
+	if (_selected_sensor_device_id != 0) {
+		PX4_INFO("using sensor_gyro_control: %d (%d)", _selected_sensor_device_id, _selected_sensor_control);
+
+	} else {
+		PX4_WARN("sensor_gyro_control unavailable for selected sensor: %d", _selected_sensor);
+	}
 
 	perf_print_counter(_cycle_perf);
 	perf_print_counter(_interval_perf);

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
@@ -116,5 +116,6 @@ private:
 	uint32_t				_selected_sensor_device_id{0};
 	uint8_t					_selected_sensor{0};
 	uint8_t					_selected_sensor_control{0};
+	bool					_sensor_control_available{false};
 
 };

--- a/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
+++ b/src/modules/sensors/vehicle_angular_velocity/VehicleAngularVelocity.hpp
@@ -50,6 +50,7 @@
 #include <uORB/topics/sensor_selection.h>
 
 #include <uORB/topics/sensor_gyro.h>
+#include <uORB/topics/sensor_gyro_control.h>
 #include <uORB/topics/vehicle_angular_velocity.h>
 
 class VehicleAngularVelocity : public ModuleParams, public px4::WorkItem
@@ -89,10 +90,17 @@ private:
 	uORB::Subscription			_sensor_correction_sub{ORB_ID(sensor_correction)};	/**< sensor thermal correction subscription */
 
 	uORB::SubscriptionCallbackWorkItem	_sensor_selection_sub{this, ORB_ID(sensor_selection)};	/**< selected primary sensor subscription */
+
 	uORB::SubscriptionCallbackWorkItem	_sensor_sub[MAX_SENSOR_COUNT] {				/**< sensor data subscription */
 		{this, ORB_ID(sensor_gyro), 0},
 		{this, ORB_ID(sensor_gyro), 1},
 		{this, ORB_ID(sensor_gyro), 2}
+	};
+
+	uORB::SubscriptionCallbackWorkItem	_sensor_control_sub[MAX_SENSOR_COUNT] {			/**< sensor control data subscription */
+		{this, ORB_ID(sensor_gyro_control), 0},
+		{this, ORB_ID(sensor_gyro_control), 1},
+		{this, ORB_ID(sensor_gyro_control), 2}
 	};
 
 	matrix::Dcmf				_board_rotation;				/**< rotation matrix for the orientation that the board is mounted */
@@ -105,6 +113,8 @@ private:
 	perf_counter_t				_interval_perf;
 	perf_counter_t				_sensor_latency_perf;
 
+	uint32_t				_selected_sensor_device_id{0};
 	uint8_t					_selected_sensor{0};
+	uint8_t					_selected_sensor_control{0};
 
 };


### PR DESCRIPTION
With the code sprawl in the existing IMU drivers gradually coming under control (https://github.com/PX4/Firmware/pull/12079, https://github.com/PX4/Firmware/pull/12128, https://github.com/PX4/Firmware/pull/12139, https://github.com/PX4/Firmware/pull/12140, https://github.com/PX4/Firmware/pull/12141) one of the things we can now easily do is change the underlying message architecture.

This PR creates a new `sensor_gyro_control` message that contains only calibrated + filtered (IMU_GYRO_CUTOFF) gyro data published for every sample. The existing `sensor_gyro` is only published with each integrator reset (250 Hz).

The result is the primary gyro, rate controller, and output module running synchronized at the native sample rate (currently 1 kHz on most setups).

	update: 1s, num topics: 78
	TOPIC NAME                       INST #SUB #MSG #LOST #QSIZE
	vehicle_odometry                    0    3  125   396 1
	ekf2_innovations                    0    1  125     0 1
	rate_ctrl_status                    0    1 1000     0 1
	landing_gear                        0    1  248     0 1
	vehicle_rates_setpoint              0    5  248   876 1
	ekf2_timestamps                     0    1  248     0 1
	multirotor_motor_limits             0    1 1000     0 1
	actuator_outputs                    0    4 1000  2242 1
	commander_state                     0    0    1     0 1
	vehicle_magnetometer                0    5   50    90 1
	vehicle_air_data                    0    6   74   197 1
	safety                              0    2    9     0 1
	vehicle_land_detected               0    9    1     0 1
	actuator_armed                      0    8    1     0 1
	telemetry_status                    0    2    2     0 3
	vehicle_local_position              0    8  125   325 1
	sensor_bias                         0    6  125   309 1
	estimator_status                    0    5  125   223 1
	sensor_combined                     0    5  248   466 1
	vehicle_attitude                    0   11  248  1093 1
	vehicle_attitude_setpoint           0    6  248   876 1
	sensor_preflight                    0    1  248     0 1
	actuator_controls_0                 0    6 1000  2862 1
	vehicle_control_mode                0   10    1     0 1
	system_power                        0    2  100    11 1
	sensor_gyro_control                 1    1  989     0 1
	sensor_baro                         0    1   73     0 1
	sensor_gyro_control                 0    1 1000     0 1
	sensor_mag                          1    1  125    11 1
	sensor_gyro                         1    1  248     0 1
	sensor_accel                        1    1  248     0 1
	sensor_gyro                         0    1  248     0 1
	sensor_accel                        0    1  248     0 1
	sensor_mag                          0    1   50     0 1
	adc_report                          0    1  100     0 1
	task_stack_info                     0    0    1     0 2
	vehicle_status_flags                0    2    1     0 1
	vehicle_status                      0   10    1     0 1
	battery_status                      0    8   82   155 1


The downside is the increased cpu usage from mc_att_control and the output module (px4fmu, px4io, etc), but I have several ideas (https://github.com/PX4/Firmware/pull/12207) that will get that under control. This also won't be safe to merge until all gyro sources are updated to utilize the PX4Gyroscope class (eg https://github.com/PX4/Firmware/pull/12142, https://github.com/PX4/Firmware/pull/12141, https://github.com/PX4/Firmware/pull/12140, https://github.com/PX4/Firmware/pull/12139, https://github.com/PX4/Firmware/pull/12136, https://github.com/PX4/Firmware/pull/12128).