### PR TITLE
Enable gimbal control using SET_ACTUATOR_CONTROL_TARGET while controlling the vehicle offboard

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -992,8 +992,8 @@ MavlinkReceiver::handle_message_set_actuator_control_target(mavlink_message_t *m
 	    (mavlink_system.compid == set_actuator_control_target.target_component ||
 	     set_actuator_control_target.target_component == 0) &&
 	    values_finite) {
+		/* Ignore all setpoints except when controlling the gimbal(group_mlx==2) as we are setting raw actuators here */
 		bool ignore_setpoints = bool(set_actuator_control_target.group_mlx != 2);
-		/* ignore all since we are setting raw actuators here */
 		offboard_control_mode.ignore_thrust             = ignore_setpoints;
 		offboard_control_mode.ignore_attitude           = ignore_setpoints;
 		offboard_control_mode.ignore_bodyrate_x         = ignore_setpoints;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -992,16 +992,16 @@ MavlinkReceiver::handle_message_set_actuator_control_target(mavlink_message_t *m
 	    (mavlink_system.compid == set_actuator_control_target.target_component ||
 	     set_actuator_control_target.target_component == 0) &&
 	    values_finite) {
-
+		bool ignore_setpoints = bool(set_actuator_control_target.group_mlx != 2);
 		/* ignore all since we are setting raw actuators here */
-		offboard_control_mode.ignore_thrust             = true;
-		offboard_control_mode.ignore_attitude           = true;
-		offboard_control_mode.ignore_bodyrate_x         = true;
-		offboard_control_mode.ignore_bodyrate_y         = true;
-		offboard_control_mode.ignore_bodyrate_z         = true;
-		offboard_control_mode.ignore_position           = true;
-		offboard_control_mode.ignore_velocity           = true;
-		offboard_control_mode.ignore_acceleration_force = true;
+		offboard_control_mode.ignore_thrust             = ignore_setpoints;
+		offboard_control_mode.ignore_attitude           = ignore_setpoints;
+		offboard_control_mode.ignore_bodyrate_x         = ignore_setpoints;
+		offboard_control_mode.ignore_bodyrate_y         = ignore_setpoints;
+		offboard_control_mode.ignore_bodyrate_z         = ignore_setpoints;
+		offboard_control_mode.ignore_position           = ignore_setpoints;
+		offboard_control_mode.ignore_velocity           = ignore_setpoints;
+		offboard_control_mode.ignore_acceleration_force = ignore_setpoints;
 
 		offboard_control_mode.timestamp = hrt_absolute_time();
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
When controlling gimbal using mavlink command `SET_ACTUATOR_CONTROL_TARGET`, all other setpoints are ignored. This leads on making the SITL crash `SET_ACTUATOR_CONTROL_TARGET` when sending body_rate and thrust setpoints while flying in offboard mode. Issue reported in #12029 
Currently sending body_rate and thrust setpoints with `SET_ACTUATOR_CONTROL_TARGET` makes PX4 SITL crash.

This PR sets a flag so that all setpoints are not ignored if `SET_ACTUATOR_CONTROL_TARGET` is controlling the gimbal control group. This enables controlling the gimbal simultaneously for applications such as human tracking while the vehicle is in offboard mode.

**Test data / coverage**
The gimbal actuator setpoints were tested while the vehicle was flown a circular trajectory with body_rate and thrust setpoints. vmount was disabled in order to control the gimbal directly in all the tests. [Video](https://youtu.be/vEbUaGOuFjs)
- Sending actuator_setpoints(group_mix=2) at 10Hz
https://review.px4.io/plot_app?log=88dfba29-549d-4dc0-bf86-bc3e68815a33

![Screenshot from 2019-06-03 02-44-47](https://user-images.githubusercontent.com/5248102/58771350-f6564580-85b3-11e9-8cdb-1ff61a38f0e3.png)

**Describe your preferred solution**
`SET_ACTUATOR_CONTROL_TARGET` is not ignored iff the control group of the actuator setpoint is a gimbal. 

**Additional context**
Sending high rate actuator_setpoints still make the vehicle unstable. body_rate setpoints becomes jittery when actuator setpoints are sent at high rates(100Hz). This is still being looked into, but enabling this at 10Hz seems still worth merging into master.

- Sending actuator_setpoints(group_mix=2) at 10Hz
log: https://review.px4.io/plot_app?log=88dfba29-549d-4dc0-bf86-bc3e68815a33
![Screenshot from 2019-06-02 00-38-15](https://user-images.githubusercontent.com/5248102/58754377-e1ec4d00-84ce-11e9-99c0-6ceb005cb9ea.png)

- Sending actuator_setpoints(group_mix=2) at 100Hz
log: https://review.px4.io/plot_app?log=5fc25c22-ab35-41b4-b23e-4633e708935c
![Screenshot from 2019-06-02 00-38-21](https://user-images.githubusercontent.com/5248102/58754382-fc262b00-84ce-11e9-9c0d-d2d640ea55d6.png)