### PR TITLE
Sensordots Mappydot+ driver

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -75,6 +75,12 @@ then
 	ll40ls start i2c
 fi
 
+# mappydot lidar sensor
+if param compare SENS_EN_MPDT 1
+then
+	mappydot start -a
+fi
+
 # mb12xx sonar sensor
 if param greater SENS_EN_MB12XX 0
 then

--- a/src/drivers/distance_sensor/mappydot/CMakeLists.txt
+++ b/src/drivers/distance_sensor/mappydot/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2019 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -34,9 +34,6 @@ px4_add_module(
 	MODULE drivers__mappydot
 	MAIN mappydot
 	STACK_MAIN 1200
-	COMPILE_FLAGS
-		-Wno-cast-align # TODO: fix and enable
 	SRCS
 		MappyDot.cpp
-	DEPENDS
 	)

--- a/src/drivers/distance_sensor/mappydot/CMakeLists.txt
+++ b/src/drivers/distance_sensor/mappydot/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################################################################
 #
-#   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,18 +30,13 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
-
-add_subdirectory(cm8jl65)
-#add_subdirectory(hc_sr04) # not currently supported
-add_subdirectory(leddar_one)
-add_subdirectory(ll40ls)
-add_subdirectory(mappydot)
-add_subdirectory(mb12xx)
-add_subdirectory(pga460)
-add_subdirectory(sf0x)
-add_subdirectory(sf1xx)
-add_subdirectory(srf02)
-add_subdirectory(teraranger)
-add_subdirectory(tfmini)
-add_subdirectory(ulanding)
-add_subdirectory(vl53lxx)
+px4_add_module(
+	MODULE drivers__mappydot
+	MAIN mappydot
+	STACK_MAIN 1200
+	COMPILE_FLAGS
+		-Wno-cast-align # TODO: fix and enable
+	SRCS
+		MappyDot.cpp
+	DEPENDS
+	)

--- a/src/drivers/distance_sensor/mappydot/MappyDot.cpp
+++ b/src/drivers/distance_sensor/mappydot/MappyDot.cpp
@@ -407,8 +407,6 @@ MappyDot::print_info()
 void
 MappyDot::Run()
 {
-	hrt_abstime _cycle_start_time = hrt_absolute_time();
-
 	// Collect the sensor data.
 	if (collect() != PX4_OK) {
 		PX4_INFO("collection error");
@@ -416,11 +414,6 @@ MappyDot::Run()
 		start();
 		return;
 	}
-
-	hrt_abstime time_remaining = hrt_elapsed_time(&_cycle_start_time);
-
-	// Schedule the next cycle call.
-	ScheduleDelayed(MAPPYDOT_MEASUREMENT_INTERVAL_USEC - time_remaining);
 }
 
 void
@@ -429,8 +422,8 @@ MappyDot::start()
 	// Fetch parameter values.
 	ModuleParams::updateParams();
 
-	// Schedule the first cycle.
-	ScheduleNow();
+	// Schedule the driver to run on a set interval
+	ScheduleOnInterval(MAPPYDOT_MEASUREMENT_INTERVAL_USEC, 10000);
 }
 
 void

--- a/src/drivers/distance_sensor/mappydot/MappyDot.cpp
+++ b/src/drivers/distance_sensor/mappydot/MappyDot.cpp
@@ -1,0 +1,690 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2018-2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file MappyDot.cpp
+ * @author Mohammed Kabir (mhkabir@mit.edu)
+ * @author Mark Sauder (mcsauder@gmail.com)
+ *
+ * Driver for the Mappydot infrared rangefinders connected via I2C.
+ */
+
+#include <string.h>
+
+#include <containers/Array.hpp>
+#include <drivers/device/i2c.h>
+#include <drivers/drv_range_finder.h>
+#include <perf/perf_counter.h>
+#include <px4_getopt.h>
+#include <px4_module_params.h>
+#include <px4_work_queue/ScheduledWorkItem.hpp>
+#include <uORB/topics/distance_sensor.h>
+#include <uORB/topics/parameter_update.h>
+
+
+/* MappyDot Registers */
+/* Basics */
+#define MAPPYDOT_IDENTIFICATION__MODEL_ID                   0x010F
+#define MAPPYDOT_MEASUREMENT_BUDGET                         0x42
+#define MAPPYDOT_READ_ERROR_CODE                            0x45
+#define MAPPYDOT_CHECK_INTERRUPT                            0x49
+#define MAPPYDOT_READ_ACCURACY                              0x52
+#define MAPPYDOT_PERFORM_SINGLE_RANGE                       0x53
+#define MAPPYDOT_SET_CONTINUOUS_RANGING_MODE                0x63
+#define MAPPYDOT_RANGING_MEASUREMENT_MODE                   0x6D
+#define MAPPYDOT_READ_DISTANCE                              0x72
+#define MAPPYDOT_SET_SINGLE_RANGING_MODE                    0x73
+
+/* Configuration */
+#define MAPPYDOT_FILTERING_ENABLE                           0x46
+#define MAPPYDOT_SIGNAL_LIMIT_CHECK_VALUE                   0x47
+#define MAPPYDOT_ENABLE_CROSSTALK_COMPENSATION              0x4B
+#define MAPPYDOT_SIGMA_LIMIT_CHECK_VALUE                    0x4C
+#define MAPPYDOT_INTERSENSOR_CROSSTALK_MEASUREMENT_DELAY    0x51
+#define MAPPYDOT_INTERSENSOR_CROSSTALK_REDUCTION_ENABLE     0x54
+#define MAPPYDOT_AVERAGING_ENABLE                           0x56
+#define MAPPYDOT_INTERSENSOR_SYNC_ENABLE                    0x59
+#define MAPPYDOT_CALIBRATE_DISTANCE_OFFSET                  0x61
+#define MAPPYDOT_SET_LED_THRESHOLD_DISTANCE_IN_MM           0x65
+#define MAPPYDOT_FILTERING_DISABLE                          0x66
+#define MAPPYDOT_SET_GPIO_MODE                              0x67
+#define MAPPYDOT_AVERAGING_SAMPLES                          0x69
+#define MAPPYDOT_DISABLE_CROSSTALK_COMPENSATION             0x6B
+#define MAPPYDOT_SET_LED_MODE                               0x6C
+#define MAPPYDOT_SET_GPIO_THRESHOLD_DISTANCE_IN_MM          0x6F
+#define MAPPYDOT_REGION_OF_INTEREST                         0x70
+#define MAPPYDOT_INTERSENSOR_CROSSTALK_TIMEOUT              0x71
+#define MAPPYDOT_INTERSENSOR_CROSSTALK_REDUCTION_DISABLE    0x74
+#define MAPPYDOT_CALIBRATE_SPAD                             0x75
+#define MAPPYDOT_AVERAGING_DISABLE                          0x76
+#define MAPPYDOT_CALIBRATE_CROSSTALK                        0x78
+#define MAPPYDOT_INTERSENSOR_SYNC_DISABLE                   0x79
+
+/* Settings */
+#define MAPPYDOT_FIRMWARE_VERSION                           0x4E
+#define MAPPYDOT_READ_CURRENT_SETTINGS                      0x62
+#define MAPPYDOT_DEVICE_NAME                                0x64
+#define MAPPYDOT_NAME_DEVICE                                0x6E
+#define MAPPYDOT_WRITE_CURRENT_SETTINGS_AS_START_UP_DEFAULT 0x77
+#define MAPPYDOT_RESTORE_FACTORY_DEFAULTS                   0x7A
+
+/* Advanced */
+#define MAPPYDOT_AMBIENT_RATE_RETURN                        0x41
+#define MAPPYDOT_VL53L1X_NOT_SHUTDOWN                       0x48
+#define MAPPYDOT_SIGNAL_RATE_RETURN                         0x4A
+#define MAPPYDOT_RESET_VL53L1X_RANGING                      0x58
+#define MAPPYDOT_VL53L1X_SHUTDOWN                           0x68
+#define MAPPYDOT_READ_NONFILTERED_VALUE                     0x6A
+
+/* Super Advanced */
+#define MAPPYDOT_ENTER_FACTORY_MODE                         0x23 //"#"//"!#!#!#"
+#define MAPPYDOT_WIPE_ALL_SETTINGS                          0x3C //"<"//"><><><" (Must be in factory mode)
+
+/* Ranging Modes */
+#define MAPPYDOT_LONG_RANGE                                 0x6C
+#define MAPPYDOT_MED_RANGE                                  0x6D
+#define MAPPYDOT_SHORT_RANGE                                0x73
+
+/* LED Modes */
+#define MAPPYDOT_LED_OFF                                    0x66
+#define MAPPYDOT_LED_MEASUREMENT_OUTPUT                     0x6D
+#define MAPPYDOT_LED_ON                                     0x6F
+#define MAPPYDOT_LED_PWM_ENABLED                            0x70
+#define MAPPYDOT_LED_THRESHOLD_ENABLED                      0x74
+
+/* GPIO Modes */
+#define MAPPYDOT_GPIO_LOW                                   0x66
+#define MAPPYDOT_GPIO_MEASUREMENT_INTERRUPT                 0x6D
+#define MAPPYDOT_GPIO_HIGH                                  0x6F
+#define MAPPYDOT_GPIO_PWM_ENABLED                           0x70
+#define MAPPYDOT_GPIO_THRESHOLD_ENABLED                     0x74
+
+/* I2C Bootloader */
+#define MAPPYDOT_REBOOT_TO_BOOTLOADER                       0x01
+
+/* Device limits */
+#define MAPPYDOT_MIN_DISTANCE                               (0.2f) // meters
+#define MAPPYDOT_MAX_DISTANCE                               (4.f) // meters
+
+#define MAPPYDOT_BUS_CLOCK                                  400000 // 400kHz bus speed
+#define MAPPYDOT_DEVICE_PATH                                "/dev/mappydot"
+
+/* Configuration Constants */
+#define MAPPYDOT_BASE_ADDR                                  0x08
+#define MAPPYDOT_BUS_DEFAULT                                PX4_I2C_BUS_EXPANSION2
+#define MAPPYDOT_MEASUREMENT_INTERVAL_USEC                  10000  // 10ms measurement interval, 100Hz.
+
+
+class MappyDot : public device::I2C, public ModuleParams, public px4::ScheduledWorkItem
+{
+public:
+	MappyDot(const int bus = MAPPYDOT_BUS_DEFAULT, const int address = MAPPYDOT_BASE_ADDR);
+	virtual ~MappyDot();
+
+	/**
+	 * Initializes the ringbuffer, advertises uORB topic,
+	 * sets device addresses and records the driver start time.
+	 */
+	virtual int init() override;
+
+	/**
+	 * Prints basic diagnostic information about the driver.
+	 */
+	void print_info();
+
+	/**
+	 * Initializes the automatic measurement state machine and starts the driver.
+	 */
+	void start();
+
+	/**
+	 * Stop the automatic measurement state machine.
+	 */
+	void stop();
+
+protected:
+
+private:
+
+	/**
+	 * Collects the most recent sensor measurement data from the i2c bus.
+	 */
+	int collect();
+
+	/**
+	 * Gets the current sensor rotation value.
+	 */
+	int get_sensor_rotation(const size_t index);
+
+	/**
+	 * Sends an i2c measure command to the sensors.
+	 */
+	int measure();
+
+	/**
+	 * Tests whether the device supported by the driver is present at a specific address.
+	 * @param address The I2C bus address to probe.
+	 * @return True if the device is present.
+	 */
+	int probe_address(const uint8_t address);
+
+	/**
+	* Performs a poll cycle; collect from the previous measurement and start a new one.
+	*/
+	void Run() override;
+
+	/**
+	 * Updates and checks for updated uORB parameters.
+	 * @param force Boolean to determine if an update check should be forced.
+	 */
+	void update_params(const bool force = false);
+
+	px4::Array<uint8_t, RANGE_FINDER_MAX_SENSORS> _sensor_addresses {};
+	px4::Array<uint8_t, RANGE_FINDER_MAX_SENSORS> _sensor_rotations {};
+
+	int _orb_class_instance{-1};
+	int _param_sub{0};
+	int _sensor_rotation{0};
+
+	uint64_t _measure_interval{MAPPYDOT_MEASUREMENT_INTERVAL_USEC};
+
+	size_t _measurement_count{0};
+	size_t _sensor_count{0};
+
+	hrt_abstime _driver_start_time{0};
+
+	orb_advert_t _distance_sensor_topic{nullptr};  // Change to _distance_sensor_topic.
+
+	perf_counter_t _comms_errors{perf_alloc(PC_ELAPSED, "mappydot_comms_err")};
+	perf_counter_t _sample_perf{perf_alloc(PC_COUNT, "mappydot_sample_perf")};
+
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::SENS_EN_MPDT>)    _p_sensor_enabled,
+		(ParamInt<px4::params::SENS_MPDT0_ROT>)  _p_sensor0_rot,
+		(ParamInt<px4::params::SENS_MPDT1_ROT>)  _p_sensor1_rot,
+		(ParamInt<px4::params::SENS_MPDT2_ROT>)  _p_sensor2_rot,
+		(ParamInt<px4::params::SENS_MPDT3_ROT>)  _p_sensor3_rot,
+		(ParamInt<px4::params::SENS_MPDT4_ROT>)  _p_sensor4_rot,
+		(ParamInt<px4::params::SENS_MPDT5_ROT>)  _p_sensor5_rot,
+		(ParamInt<px4::params::SENS_MPDT6_ROT>)  _p_sensor6_rot,
+		(ParamInt<px4::params::SENS_MPDT7_ROT>)  _p_sensor7_rot,
+		(ParamInt<px4::params::SENS_MPDT8_ROT>)  _p_sensor8_rot,
+		(ParamInt<px4::params::SENS_MPDT9_ROT>)  _p_sensor9_rot,
+		(ParamInt<px4::params::SENS_MPDT10_ROT>) _p_sensor10_rot,
+		(ParamInt<px4::params::SENS_MPDT11_ROT>) _p_sensor11_rot
+	);
+};
+
+
+MappyDot::MappyDot(const int bus, const int address) :
+	I2C("MappyDot", MAPPYDOT_DEVICE_PATH, bus, address, MAPPYDOT_BUS_CLOCK),
+	ModuleParams(nullptr),
+	ScheduledWorkItem(px4::device_bus_to_wq(get_device_id()))
+{
+	_param_sub = orb_subscribe(ORB_ID(parameter_update));
+}
+
+MappyDot::~MappyDot()
+{
+	// Ensure we are truly inactive.
+	stop();
+
+	// Unadvertise the distance sensor topic.
+	if (_distance_sensor_topic != nullptr) {
+		orb_unadvertise(_distance_sensor_topic);
+	}
+
+	// Unsubscribe from uORB topics.
+	orb_unsubscribe(_param_sub);
+
+	// Free perf counters.
+	perf_free(_comms_errors);
+	perf_free(_sample_perf);
+}
+
+int
+MappyDot::collect()
+{
+	uint8_t val[2] = {};
+	perf_begin(_sample_perf);
+
+	// Increment the sensor index, (limited to the number of sensors connected).
+	for (size_t index = 0; index < _sensor_count; index++) {
+
+		// Set address of the current sensor to collect data from.
+		set_device_address(_sensor_addresses[index]);
+
+		// Transfer data from the bus.
+		int ret_val = transfer(nullptr, 0, &val[0], 2);
+		_measurement_count++;
+
+		if (ret_val < 0) {
+			PX4_INFO("error reading from sensor: %i, address: 0x%02X", index, _sensor_addresses[index]);
+			perf_count(_comms_errors);
+			perf_end(_sample_perf);
+			return ret_val;
+		}
+
+		uint16_t distance_mm = val[0] << 8 | val[1];
+		float distance_m = distance_mm / 1000.f;
+
+		distance_sensor_s report {};
+		report.current_distance = distance_m;
+		report.id               = _sensor_addresses[index];
+		report.max_distance     = MAPPYDOT_MAX_DISTANCE;
+		report.min_distance     = MAPPYDOT_MIN_DISTANCE;
+		report.orientation      = _sensor_rotations[index];
+		report.signal_quality   = 0;
+		report.timestamp        = hrt_absolute_time();
+		report.type             = distance_sensor_s::MAV_DISTANCE_SENSOR_LASER;
+		report.variance         = 0;
+
+		// Publish the report data if we have a valid topic.
+		if (_distance_sensor_topic != nullptr) {
+			orb_publish_auto(ORB_ID(distance_sensor), &_distance_sensor_topic, &report, &_orb_class_instance,
+					 ORB_PRIO_DEFAULT);
+		}
+
+		// Notify anyone waiting for data.
+		poll_notify(POLLIN);
+		perf_count(_sample_perf);
+	}
+
+	perf_end(_sample_perf);
+	return PX4_OK;
+}
+
+int
+MappyDot::get_sensor_rotation(const size_t index)
+{
+	switch (index) {
+	case 0: return _p_sensor0_rot.get();
+
+	case 1: return _p_sensor1_rot.get();
+
+	case 2: return _p_sensor2_rot.get();
+
+	case 3: return _p_sensor3_rot.get();
+
+	case 4: return _p_sensor4_rot.get();
+
+	case 5: return _p_sensor5_rot.get();
+
+	case 6: return _p_sensor6_rot.get();
+
+	case 7: return _p_sensor7_rot.get();
+
+	case 8: return _p_sensor8_rot.get();
+
+	case 9: return _p_sensor9_rot.get();
+
+	case 10: return _p_sensor10_rot.get();
+
+	case 11: return _p_sensor11_rot.get();
+
+	default: return PX4_ERROR;
+	}
+}
+
+int
+MappyDot::init()
+{
+	if (_p_sensor_enabled.get() == 0) {
+		PX4_WARN("disabled");
+		return PX4_ERROR;
+	}
+
+	if (I2C::init() != PX4_OK) {
+		return PX4_ERROR;
+	}
+
+	// Get a publish handle on the obstacle distance topic.
+	distance_sensor_s report {};
+	_distance_sensor_topic = orb_advertise_multi(ORB_ID(distance_sensor), &report,
+				 &_orb_class_instance, ORB_PRIO_DEFAULT);
+
+	if (_distance_sensor_topic == nullptr) {
+		PX4_ERR("failed to create distance_sensor object");
+		return PX4_ERROR;
+	}
+
+	// Check for connected rangefinders on each i2c port,
+	// starting from the base address 0x08 and incrementing.
+	for (size_t i = 0; i <= RANGE_FINDER_MAX_SENSORS; i++) {
+		set_device_address(MAPPYDOT_BASE_ADDR + i);
+
+		// Check if a sensor is present.
+		if (measure() != PX4_OK) {
+			break;
+		}
+
+		// Store I2C address.
+		_sensor_addresses[i] = MAPPYDOT_BASE_ADDR + i;
+		_sensor_rotations[i] = get_sensor_rotation(i);
+		_sensor_count++;
+
+		PX4_INFO("sensor %i at address 0x%02X added", i, get_device_address());
+	}
+
+	if (_sensor_count == 0) {
+		return PX4_ERROR;
+	}
+
+	PX4_INFO("%i sensors connected at %i Hz", _sensor_count, 1000000 / MAPPYDOT_MEASUREMENT_INTERVAL_USEC);
+
+	_driver_start_time = hrt_absolute_time();
+	return PX4_OK;
+}
+
+int
+MappyDot::measure()
+{
+	uint8_t cmd = MAPPYDOT_PERFORM_SINGLE_RANGE;
+	int ret_val = transfer(&cmd, 1, nullptr, 0);
+
+	if (ret_val != PX4_OK) {
+		perf_count(_comms_errors);
+		PX4_DEBUG("i2c::transfer returned %d", ret_val);
+		return ret_val;
+	}
+
+	return PX4_OK;
+}
+
+void
+MappyDot::print_info()
+{
+	hrt_abstime time_since_start_usec = hrt_elapsed_time(&_driver_start_time);
+	float time_since_start_sec = time_since_start_usec * 1e-6f;
+	float measurement_rate = _measurement_count / (_sensor_count * time_since_start_sec);
+
+	perf_print_counter(_comms_errors);
+	perf_print_counter(_sample_perf);
+	PX4_INFO("measurement count:    %u", _measurement_count);
+	PX4_INFO("measurement interval: %u msec", MAPPYDOT_MEASUREMENT_INTERVAL_USEC / 1000);
+	PX4_INFO("measurement rate:     %.2f Hz", static_cast<double>(measurement_rate));
+}
+
+void
+MappyDot::Run()
+{
+	hrt_abstime _cycle_start_time = hrt_absolute_time();
+
+	// Collect the sensor data.
+	if (collect() != PX4_OK) {
+		PX4_INFO("sensor measurement collection error");
+		// If an error occurred, restart the measurement state machine.
+		start();
+		return;
+	}
+
+	hrt_abstime time_remaining = hrt_elapsed_time(&_cycle_start_time);
+
+	// Schedule the next cycle call.
+	ScheduleDelayed(_measure_interval - time_remaining);
+}
+
+void
+MappyDot::start()
+{
+	// Update uORB subscription topics.
+	update_params(true);
+
+	// Schedule the first cycle.
+	ScheduleNow();
+}
+
+void
+MappyDot::stop()
+{
+	ScheduleClear();
+}
+
+void
+MappyDot::update_params(const bool force)
+{
+	bool updated = false;
+	parameter_update_s param_update {};
+
+	orb_check(_param_sub, &updated);
+
+	if (updated || force) {
+		ModuleParams::updateParams();
+		orb_copy(ORB_ID(parameter_update), _param_sub, &param_update);
+	}
+}
+
+
+/**
+ * Local functions in support of the shell command.
+ */
+namespace mappydot
+{
+
+MappyDot *g_dev;
+
+int reset();
+int start();
+int start_bus(int i2c_bus);
+int status();
+int stop();
+int usage();
+
+/**
+ * Reset the driver.
+ */
+int
+reset()
+{
+	if (g_dev == nullptr) {
+		PX4_ERR("driver not running");
+		return PX4_ERROR;
+	}
+
+	g_dev->stop();
+	g_dev->start();
+	PX4_INFO("driver reset");
+	return PX4_OK;
+}
+
+/**
+ * Attempt to start driver on all available I2C busses.
+ *
+ * This function will return as soon as the first sensor
+ * is detected on one of the available busses or if no
+ * sensors are detected.
+ */
+int
+start()
+{
+	if (g_dev != nullptr) {
+		PX4_ERR("already started");
+		return PX4_ERROR;
+	}
+
+	for (size_t i = 0; i < NUM_I2C_BUS_OPTIONS; i++) {
+		if (start_bus(i2c_bus_options[i]) == PX4_OK) {
+			return PX4_OK;
+		}
+	}
+
+	return PX4_ERROR;
+}
+
+/**
+ * Start the driver on a specific bus.
+ *
+ * This function only returns if the sensor is up and running
+ * or could not be detected successfully.
+ */
+int
+start_bus(int i2c_bus)
+{
+	if (g_dev != nullptr) {
+		PX4_ERR("already started");
+		return PX4_OK;
+	}
+
+	// Instantiate the driver.
+	g_dev = new MappyDot(i2c_bus);
+
+	if (g_dev == nullptr) {
+		delete g_dev;
+		return PX4_ERROR;
+	}
+
+	// Initialize the sensor.
+	if (g_dev->init() != PX4_OK) {
+		delete g_dev;
+		g_dev = nullptr;
+		return PX4_ERROR;
+	}
+
+	// Start the driver.
+	g_dev->start();
+
+	PX4_INFO("driver started");
+	return PX4_OK;
+}
+
+/**
+ * Print the driver status.
+ */
+int
+status()
+{
+	if (g_dev == nullptr) {
+		PX4_ERR("driver not running");
+		return PX4_ERROR;
+	}
+
+	g_dev->print_info();
+
+	return PX4_OK;
+}
+
+/**
+ * Stop the driver.
+ */
+int
+stop()
+{
+	if (g_dev != nullptr) {
+		delete g_dev;
+		g_dev = nullptr;
+
+	}
+
+	PX4_INFO("driver stopped");
+	return PX4_OK;
+}
+
+/**
+ * Print usage information about the driver.
+ */
+int
+usage()
+{
+	PX4_INFO("Usage: mappydot <command> [options]");
+	PX4_INFO("options:");
+	PX4_INFO("\t-a --all");
+	PX4_INFO("\t-b --bus i2cbus (%i)", MAPPYDOT_BUS_DEFAULT);
+	PX4_INFO("command:");
+	PX4_INFO("\treset|start|start_bus|status|stop|usage");
+	return PX4_OK;
+}
+
+} // namespace mappydot
+
+
+/**
+ * Driver 'main' command.
+ */
+extern "C" __EXPORT int mappydot_main(int argc, char *argv[])
+{
+	const char *myoptarg = nullptr;
+
+	int ch;
+	int i2c_bus = MAPPYDOT_BUS_DEFAULT;
+	int myoptind = 1;
+
+	bool start_all = false;
+
+	while ((ch = px4_getopt(argc, argv, "ab:", &myoptind, &myoptarg)) != EOF) {
+		switch (ch) {
+		case 'a':
+			start_all = true;
+			break;
+
+		case 'b':
+			i2c_bus = atoi(myoptarg);
+			PX4_INFO("Specific I2C Bus selected: %i", i2c_bus);
+			break;
+
+		default:
+			PX4_WARN("Unknown option!");
+			return mappydot::usage();
+		}
+	}
+
+	if (myoptind >= argc) {
+		return mappydot::usage();
+	}
+
+	// Reset the driver.
+	if (!strcmp(argv[myoptind], "reset")) {
+		return mappydot::reset();
+	}
+
+	if (!strcmp(argv[myoptind], "start")) {
+		if (start_all) {
+			return mappydot::start();
+
+		} else {
+			return mappydot::start_bus(i2c_bus);
+		}
+	}
+
+	// Print the driver status.
+	if (!strcmp(argv[myoptind], "status")) {
+		return mappydot::status();
+	}
+
+	// Stop the driver.
+	if (!strcmp(argv[myoptind], "stop")) {
+		return mappydot::stop();
+	}
+
+	// Print driver usage information.
+	return mappydot::usage();
+}

--- a/src/drivers/distance_sensor/mappydot/parameters.c
+++ b/src/drivers/distance_sensor/mappydot/parameters.c
@@ -1,0 +1,323 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+
+/**
+ * MappyDot Rangefinder (i2c)
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 1
+ * @group Sensors
+ * @value 0 Disabled
+ * @value 1 Autodetect
+ */
+PARAM_DEFINE_INT32(SENS_EN_MPDT, 0);
+
+/**
+ * MappyDot sensor 0
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 19
+ * @group Sensors
+ * @value 0 Disabled (?)
+ * @value 8 Address
+ * @value 9 Address
+ * @value 10 Address
+ * @value 11 Address
+ * @value 12 Address
+ * @value 13 Address
+ * @value 14 Address
+ * @value 15 Address
+ * @value 16 Address
+ * @value 17 Address
+ * @value 18 Address
+ * @value 19 Address
+ */
+PARAM_DEFINE_INT32(SENS_MPDT0_ROT, 0);
+
+
+/**
+ * MappyDot sensor 1
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 19
+ * @group Sensors
+ * @value 0 Disabled (?)
+ * @value 8 Address
+ * @value 9 Address
+ * @value 10 Address
+ * @value 11 Address
+ * @value 12 Address
+ * @value 13 Address
+ * @value 14 Address
+ * @value 15 Address
+ * @value 16 Address
+ * @value 17 Address
+ * @value 18 Address
+ * @value 19 Address
+ */
+
+
+PARAM_DEFINE_INT32(SENS_MPDT1_ROT, 0);
+/**
+ * MappyDot sensor 2
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 19
+ * @group Sensors
+ * @value 0 Disabled (?)
+ * @value 8 Address
+ * @value 9 Address
+ * @value 10 Address
+ * @value 11 Address
+ * @value 12 Address
+ * @value 13 Address
+ * @value 14 Address
+ * @value 15 Address
+ * @value 16 Address
+ * @value 17 Address
+ * @value 18 Address
+ * @value 19 Address
+ */
+PARAM_DEFINE_INT32(SENS_MPDT2_ROT, 0);
+
+/**
+ * MappyDot sensor 3
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 19
+ * @group Sensors
+ * @value 0 Disabled (?)
+ * @value 8 Address
+ * @value 9 Address
+ * @value 10 Address
+ * @value 11 Address
+ * @value 12 Address
+ * @value 13 Address
+ * @value 14 Address
+ * @value 15 Address
+ * @value 16 Address
+ * @value 17 Address
+ * @value 18 Address
+ * @value 19 Address
+ */
+PARAM_DEFINE_INT32(SENS_MPDT3_ROT, 0);
+
+/**
+ * MappyDot sensor 4
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 19
+ * @group Sensors
+ * @value 0 Disabled (?)
+ * @value 8 Address
+ * @value 9 Address
+ * @value 10 Address
+ * @value 11 Address
+ * @value 12 Address
+ * @value 13 Address
+ * @value 14 Address
+ * @value 15 Address
+ * @value 16 Address
+ * @value 17 Address
+ * @value 18 Address
+ * @value 19 Address
+ */
+PARAM_DEFINE_INT32(SENS_MPDT4_ROT, 0);
+
+/**
+ * MappyDot sensor 5
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 19
+ * @group Sensors
+ * @value 0 Disabled (?)
+ * @value 8 Address
+ * @value 9 Address
+ * @value 10 Address
+ * @value 11 Address
+ * @value 12 Address
+ * @value 13 Address
+ * @value 14 Address
+ * @value 15 Address
+ * @value 16 Address
+ * @value 17 Address
+ * @value 18 Address
+ * @value 19 Address
+ */
+PARAM_DEFINE_INT32(SENS_MPDT5_ROT, 0);
+
+/**
+ * MappyDot sensor 6
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 19
+ * @group Sensors
+ * @value 0 Disabled (?)
+ * @value 8 Address
+ * @value 9 Address
+ * @value 10 Address
+ * @value 11 Address
+ * @value 12 Address
+ * @value 13 Address
+ * @value 14 Address
+ * @value 15 Address
+ * @value 16 Address
+ * @value 17 Address
+ * @value 18 Address
+ * @value 19 Address
+ */
+PARAM_DEFINE_INT32(SENS_MPDT6_ROT, 0);
+
+/**
+ * MappyDot sensor 7
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 19
+ * @group Sensors
+ * @value 0 Disabled (?)
+ * @value 8 Address
+ * @value 9 Address
+ * @value 10 Address
+ * @value 11 Address
+ * @value 12 Address
+ * @value 13 Address
+ * @value 14 Address
+ * @value 15 Address
+ * @value 16 Address
+ * @value 17 Address
+ * @value 18 Address
+ * @value 19 Address
+ */
+PARAM_DEFINE_INT32(SENS_MPDT7_ROT, 0);
+
+/**
+ * MappyDot sensor 8
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 19
+ * @group Sensors
+ * @value 0 Disabled (?)
+ * @value 8 Address
+ * @value 9 Address
+ * @value 10 Address
+ * @value 11 Address
+ * @value 12 Address
+ * @value 13 Address
+ * @value 14 Address
+ * @value 15 Address
+ * @value 16 Address
+ * @value 17 Address
+ * @value 18 Address
+ * @value 19 Address
+ */
+PARAM_DEFINE_INT32(SENS_MPDT8_ROT, 0);
+
+/**
+ * MappyDot sensor 9
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 19
+ * @group Sensors
+ * @value 0 Disabled (?)
+ * @value 8 Address
+ * @value 9 Address
+ * @value 10 Address
+ * @value 11 Address
+ * @value 12 Address
+ * @value 13 Address
+ * @value 14 Address
+ * @value 15 Address
+ * @value 16 Address
+ * @value 17 Address
+ * @value 18 Address
+ * @value 19 Address
+ */
+PARAM_DEFINE_INT32(SENS_MPDT9_ROT, 0);
+
+/**
+ * MappyDot sensor 10
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 19
+ * @group Sensors
+ * @value 0 Disabled (?)
+ * @value 8 Address
+ * @value 9 Address
+ * @value 10 Address
+ * @value 11 Address
+ * @value 12 Address
+ * @value 13 Address
+ * @value 14 Address
+ * @value 15 Address
+ * @value 16 Address
+ * @value 17 Address
+ * @value 18 Address
+ * @value 19 Address
+ */
+PARAM_DEFINE_INT32(SENS_MPDT10_ROT, 0);
+
+/**
+ * MappyDot sensor 11
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 19
+ * @group Sensors
+ * @value 0 Disabled (?)
+ * @value 8 Address
+ * @value 9 Address
+ * @value 10 Address
+ * @value 11 Address
+ * @value 12 Address
+ * @value 13 Address
+ * @value 14 Address
+ * @value 15 Address
+ * @value 16 Address
+ * @value 17 Address
+ * @value 18 Address
+ * @value 19 Address
+ */
+PARAM_DEFINE_INT32(SENS_MPDT11_ROT, 0);

--- a/src/drivers/distance_sensor/mappydot/parameters.c
+++ b/src/drivers/distance_sensor/mappydot/parameters.c
@@ -33,7 +33,7 @@
 
 
 /**
- * MappyDot Rangefinder (i2c)
+ * Enable Mappydot rangefinder (i2c)
  *
  * @reboot_required true
  * @min 0
@@ -45,279 +45,253 @@
 PARAM_DEFINE_INT32(SENS_EN_MPDT, 0);
 
 /**
- * MappyDot sensor 0
+ * MappyDot Sensor 0 Rotation
+ *
+ * This parameter defines the rotation of the Mappydot sensor relative to the platform.
  *
  * @reboot_required true
  * @min 0
- * @max 19
+ * @max 7
  * @group Sensors
- * @value 0 Disabled (?)
- * @value 8 Address
- * @value 9 Address
- * @value 10 Address
- * @value 11 Address
- * @value 12 Address
- * @value 13 Address
- * @value 14 Address
- * @value 15 Address
- * @value 16 Address
- * @value 17 Address
- * @value 18 Address
- * @value 19 Address
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
  */
 PARAM_DEFINE_INT32(SENS_MPDT0_ROT, 0);
 
-
 /**
- * MappyDot sensor 1
+ * MappyDot Sensor 1 Rotation
+ *
+ * This parameter defines the rotation of the Mappydot sensor relative to the platform.
  *
  * @reboot_required true
  * @min 0
- * @max 19
+ * @max 7
  * @group Sensors
- * @value 0 Disabled (?)
- * @value 8 Address
- * @value 9 Address
- * @value 10 Address
- * @value 11 Address
- * @value 12 Address
- * @value 13 Address
- * @value 14 Address
- * @value 15 Address
- * @value 16 Address
- * @value 17 Address
- * @value 18 Address
- * @value 19 Address
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
  */
-
-
 PARAM_DEFINE_INT32(SENS_MPDT1_ROT, 0);
+
 /**
- * MappyDot sensor 2
+ * MappyDot Sensor 2 Rotation
+ *
+ * This parameter defines the rotation of the Mappydot sensor relative to the platform.
  *
  * @reboot_required true
  * @min 0
- * @max 19
+ * @max 7
  * @group Sensors
- * @value 0 Disabled (?)
- * @value 8 Address
- * @value 9 Address
- * @value 10 Address
- * @value 11 Address
- * @value 12 Address
- * @value 13 Address
- * @value 14 Address
- * @value 15 Address
- * @value 16 Address
- * @value 17 Address
- * @value 18 Address
- * @value 19 Address
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
  */
 PARAM_DEFINE_INT32(SENS_MPDT2_ROT, 0);
 
 /**
- * MappyDot sensor 3
+ * MappyDot Sensor 3 Rotation
+ *
+ * This parameter defines the rotation of the Mappydot sensor relative to the platform.
  *
  * @reboot_required true
  * @min 0
- * @max 19
+ * @max 7
  * @group Sensors
- * @value 0 Disabled (?)
- * @value 8 Address
- * @value 9 Address
- * @value 10 Address
- * @value 11 Address
- * @value 12 Address
- * @value 13 Address
- * @value 14 Address
- * @value 15 Address
- * @value 16 Address
- * @value 17 Address
- * @value 18 Address
- * @value 19 Address
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
  */
 PARAM_DEFINE_INT32(SENS_MPDT3_ROT, 0);
 
 /**
- * MappyDot sensor 4
+ * MappyDot Sensor 4 Rotation
+ *
+ * This parameter defines the rotation of the Mappydot sensor relative to the platform.
  *
  * @reboot_required true
  * @min 0
- * @max 19
+ * @max 7
  * @group Sensors
- * @value 0 Disabled (?)
- * @value 8 Address
- * @value 9 Address
- * @value 10 Address
- * @value 11 Address
- * @value 12 Address
- * @value 13 Address
- * @value 14 Address
- * @value 15 Address
- * @value 16 Address
- * @value 17 Address
- * @value 18 Address
- * @value 19 Address
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
  */
 PARAM_DEFINE_INT32(SENS_MPDT4_ROT, 0);
 
 /**
- * MappyDot sensor 5
+ * MappyDot Sensor 5 Rotation
+ *
+ * This parameter defines the rotation of the Mappydot sensor relative to the platform.
  *
  * @reboot_required true
  * @min 0
- * @max 19
+ * @max 7
  * @group Sensors
- * @value 0 Disabled (?)
- * @value 8 Address
- * @value 9 Address
- * @value 10 Address
- * @value 11 Address
- * @value 12 Address
- * @value 13 Address
- * @value 14 Address
- * @value 15 Address
- * @value 16 Address
- * @value 17 Address
- * @value 18 Address
- * @value 19 Address
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
  */
 PARAM_DEFINE_INT32(SENS_MPDT5_ROT, 0);
 
 /**
- * MappyDot sensor 6
+ * MappyDot Sensor 6 Rotation
+ *
+ * This parameter defines the rotation of the Mappydot sensor relative to the platform.
  *
  * @reboot_required true
  * @min 0
- * @max 19
+ * @max 7
  * @group Sensors
- * @value 0 Disabled (?)
- * @value 8 Address
- * @value 9 Address
- * @value 10 Address
- * @value 11 Address
- * @value 12 Address
- * @value 13 Address
- * @value 14 Address
- * @value 15 Address
- * @value 16 Address
- * @value 17 Address
- * @value 18 Address
- * @value 19 Address
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
  */
 PARAM_DEFINE_INT32(SENS_MPDT6_ROT, 0);
 
 /**
- * MappyDot sensor 7
+ * MappyDot Sensor 7 Rotation
+ *
+ * This parameter defines the rotation of the Mappydot sensor relative to the platform.
  *
  * @reboot_required true
  * @min 0
- * @max 19
+ * @max 7
  * @group Sensors
- * @value 0 Disabled (?)
- * @value 8 Address
- * @value 9 Address
- * @value 10 Address
- * @value 11 Address
- * @value 12 Address
- * @value 13 Address
- * @value 14 Address
- * @value 15 Address
- * @value 16 Address
- * @value 17 Address
- * @value 18 Address
- * @value 19 Address
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
  */
 PARAM_DEFINE_INT32(SENS_MPDT7_ROT, 0);
 
 /**
- * MappyDot sensor 8
+ * MappyDot Sensor 8 Rotation
+ *
+ * This parameter defines the rotation of the Mappydot sensor relative to the platform.
  *
  * @reboot_required true
  * @min 0
- * @max 19
+ * @max 7
  * @group Sensors
- * @value 0 Disabled (?)
- * @value 8 Address
- * @value 9 Address
- * @value 10 Address
- * @value 11 Address
- * @value 12 Address
- * @value 13 Address
- * @value 14 Address
- * @value 15 Address
- * @value 16 Address
- * @value 17 Address
- * @value 18 Address
- * @value 19 Address
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
  */
 PARAM_DEFINE_INT32(SENS_MPDT8_ROT, 0);
 
 /**
- * MappyDot sensor 9
+ * MappyDot Sensor 9 Rotation
+ *
+ * This parameter defines the rotation of the Mappydot sensor relative to the platform.
  *
  * @reboot_required true
  * @min 0
- * @max 19
+ * @max 7
  * @group Sensors
- * @value 0 Disabled (?)
- * @value 8 Address
- * @value 9 Address
- * @value 10 Address
- * @value 11 Address
- * @value 12 Address
- * @value 13 Address
- * @value 14 Address
- * @value 15 Address
- * @value 16 Address
- * @value 17 Address
- * @value 18 Address
- * @value 19 Address
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
  */
 PARAM_DEFINE_INT32(SENS_MPDT9_ROT, 0);
 
 /**
- * MappyDot sensor 10
+ * MappyDot Sensor 10 Rotation
+ *
+ * This parameter defines the rotation of the Mappydot sensor relative to the platform.
  *
  * @reboot_required true
  * @min 0
- * @max 19
+ * @max 7
  * @group Sensors
- * @value 0 Disabled (?)
- * @value 8 Address
- * @value 9 Address
- * @value 10 Address
- * @value 11 Address
- * @value 12 Address
- * @value 13 Address
- * @value 14 Address
- * @value 15 Address
- * @value 16 Address
- * @value 17 Address
- * @value 18 Address
- * @value 19 Address
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
  */
 PARAM_DEFINE_INT32(SENS_MPDT10_ROT, 0);
 
 /**
- * MappyDot sensor 11
+ * MappyDot Sensor 12 Rotation
+ *
+ * This parameter defines the rotation of the Mappydot sensor relative to the platform.
  *
  * @reboot_required true
  * @min 0
- * @max 19
+ * @max 7
  * @group Sensors
- * @value 0 Disabled (?)
- * @value 8 Address
- * @value 9 Address
- * @value 10 Address
- * @value 11 Address
- * @value 12 Address
- * @value 13 Address
- * @value 14 Address
- * @value 15 Address
- * @value 16 Address
- * @value 17 Address
- * @value 18 Address
- * @value 19 Address
+ *
+ * @value 0 No rotation
+ * @value 1 Yaw 45°
+ * @value 2 Yaw 90°
+ * @value 3 Yaw 135°
+ * @value 4 Yaw 180°
+ * @value 5 Yaw 225°
+ * @value 6 Yaw 270°
+ * @value 7 Yaw 315°
  */
 PARAM_DEFINE_INT32(SENS_MPDT11_ROT, 0);


### PR DESCRIPTION
Driver for Sensordots Mappydot+ (https://sensordots.org/mappydot_plus) rangefinder arrays.

These have a range of up to 4m, can be used for low-level collision avoidance. Support for integrating data from these in collision prevention will come in a follow-up PR.

A large portion of the driver was contributed by @mcsauder!

TODO : 

* [x] Squash commits before merge
* [x] Start all (`-a`) doesn't actually work
* [x] Bench test ranging mode changes

