### PR TITLE
PX4 workqueue add simple reference counting to shutdown empty queues

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -252,5 +252,6 @@ mavlink start -x -u $udp_offboard_port_local -r 4000000 -m onboard -o $udp_offbo
 # Run script to start logging
 sh etc/init.d/rc.logging
 
+wq_manager cleanup
 mavlink boot_complete
 replay trystart

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -545,6 +545,7 @@ unset USE_IO
 unset VEHICLE_TYPE
 
 #
-# Boot is complete, inform MAVLink app(s) that the system is now fully up and running.
+# Boot is complete, cleanup any unused workqueues and inform MAVLink app(s) that the system is now fully up and running.
 #
+wq_manager cleanup
 mavlink boot_complete

--- a/boards/aerotenna/ocpoc/ubuntu.cmake
+++ b/boards/aerotenna/ocpoc/ubuntu.cmake
@@ -71,6 +71,7 @@ px4_add_board(
 		topic_listener
 		tune_control
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/airmind/mindpx-v2/default.cmake
+++ b/boards/airmind/mindpx-v2/default.cmake
@@ -100,6 +100,7 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/atlflight/eagle/default.cmake
+++ b/boards/atlflight/eagle/default.cmake
@@ -112,6 +112,7 @@ px4_add_board(
 		topic_listener
 		tune_control
 		ver
+		wq_manager
 
 	EXAMPLES
 		#bottle_drop # OBC challenge

--- a/boards/atlflight/excelsior/default.cmake
+++ b/boards/atlflight/excelsior/default.cmake
@@ -112,6 +112,7 @@ px4_add_board(
 		topic_listener
 		tune_control
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/auav/esc35-v1/default.cmake
+++ b/boards/auav/esc35-v1/default.cmake
@@ -56,5 +56,6 @@ px4_add_board(
 		param
 		top
 		ver
+		wq_manager
 
 	)

--- a/boards/auav/x21/default.cmake
+++ b/boards/auav/x21/default.cmake
@@ -106,6 +106,7 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/av/x-v1/default.cmake
+++ b/boards/av/x-v1/default.cmake
@@ -107,6 +107,7 @@ px4_add_board(
 		topic_listener
 		tune_control
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/beaglebone/blue/cross.cmake
+++ b/boards/beaglebone/blue/cross.cmake
@@ -68,6 +68,7 @@ px4_add_board(
 		topic_listener
 		tune_control
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/beaglebone/blue/native.cmake
+++ b/boards/beaglebone/blue/native.cmake
@@ -66,6 +66,7 @@ px4_add_board(
 		topic_listener
 		tune_control
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/bitcraze/crazyflie/default.cmake
+++ b/boards/bitcraze/crazyflie/default.cmake
@@ -66,5 +66,6 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 
 	)

--- a/boards/emlid/navio2/cross.cmake
+++ b/boards/emlid/navio2/cross.cmake
@@ -75,6 +75,7 @@ px4_add_board(
 		topic_listener
 		tune_control
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/emlid/navio2/native.cmake
+++ b/boards/emlid/navio2/native.cmake
@@ -73,6 +73,7 @@ px4_add_board(
 		topic_listener
 		tune_control
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/intel/aerofc-v1/default.cmake
+++ b/boards/intel/aerofc-v1/default.cmake
@@ -82,6 +82,7 @@ px4_add_board(
 		#topic_listener
 		tune_control
 		ver
+		wq_manager
 
 	EXAMPLES
 		#bottle_drop # OBC challenge

--- a/boards/intel/aerofc-v1/rtps.cmake
+++ b/boards/intel/aerofc-v1/rtps.cmake
@@ -86,6 +86,7 @@ px4_add_board(
 		#topic_listener
 		tune_control
 		ver
+		wq_manager
 
 	EXAMPLES
 		#bottle_drop # OBC challenge

--- a/boards/nxp/fmuk66-v3/default.cmake
+++ b/boards/nxp/fmuk66-v3/default.cmake
@@ -102,6 +102,7 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/omnibus/f4sd/default.cmake
+++ b/boards/omnibus/f4sd/default.cmake
@@ -95,6 +95,7 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 
 	EXAMPLES
 		#bottle_drop # OBC challenge

--- a/boards/parrot/bebop/default.cmake
+++ b/boards/parrot/bebop/default.cmake
@@ -60,4 +60,5 @@ px4_add_board(
 		topic_listener
 		tune_control
 		ver
+		wq_manager
 	)

--- a/boards/px4/cannode-v1/default.cmake
+++ b/boards/px4/cannode-v1/default.cmake
@@ -53,5 +53,6 @@ px4_add_board(
 		reboot
 		top
 		ver
+		wq_manager
 
 	)

--- a/boards/px4/esc-v1/default.cmake
+++ b/boards/px4/esc-v1/default.cmake
@@ -56,5 +56,6 @@ px4_add_board(
 		param
 		top
 		ver
+		wq_manager
 
 	)

--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -112,6 +112,7 @@ px4_add_board(
 		tune_control
 		#usb_connected
 		ver
+		wq_manager
 
 	EXAMPLES
 		#bottle_drop # OBC challenge

--- a/boards/px4/fmu-v2/fixedwing.cmake
+++ b/boards/px4/fmu-v2/fixedwing.cmake
@@ -82,4 +82,5 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 	)

--- a/boards/px4/fmu-v2/lpe.cmake
+++ b/boards/px4/fmu-v2/lpe.cmake
@@ -107,6 +107,7 @@ px4_add_board(
 		#topic_listener
 		tune_control
 		ver
+		wq_manager
 
 	EXAMPLES
 		#bottle_drop # OBC challenge

--- a/boards/px4/fmu-v2/multicopter.cmake
+++ b/boards/px4/fmu-v2/multicopter.cmake
@@ -79,4 +79,5 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 	)

--- a/boards/px4/fmu-v2/rover.cmake
+++ b/boards/px4/fmu-v2/rover.cmake
@@ -74,4 +74,5 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 	)

--- a/boards/px4/fmu-v2/test.cmake
+++ b/boards/px4/fmu-v2/test.cmake
@@ -107,6 +107,7 @@ px4_add_board(
 		#topic_listener
 		tune_control
 		ver
+		wq_manager
 
 	EXAMPLES
 		#bottle_drop # OBC challenge

--- a/boards/px4/fmu-v3/default.cmake
+++ b/boards/px4/fmu-v3/default.cmake
@@ -114,6 +114,7 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/px4/fmu-v3/rtps.cmake
+++ b/boards/px4/fmu-v3/rtps.cmake
@@ -114,6 +114,7 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/px4/fmu-v3/stackcheck.cmake
+++ b/boards/px4/fmu-v3/stackcheck.cmake
@@ -113,6 +113,7 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 
 	EXAMPLES
 		#bottle_drop # OBC challenge

--- a/boards/px4/fmu-v4/default.cmake
+++ b/boards/px4/fmu-v4/default.cmake
@@ -98,6 +98,7 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/px4/fmu-v4/rtps.cmake
+++ b/boards/px4/fmu-v4/rtps.cmake
@@ -101,6 +101,7 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/px4/fmu-v4/stackcheck.cmake
+++ b/boards/px4/fmu-v4/stackcheck.cmake
@@ -98,6 +98,7 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 
 	EXAMPLES
 		#bottle_drop # OBC challenge

--- a/boards/px4/fmu-v4pro/default.cmake
+++ b/boards/px4/fmu-v4pro/default.cmake
@@ -112,6 +112,7 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/px4/fmu-v4pro/rtps.cmake
+++ b/boards/px4/fmu-v4pro/rtps.cmake
@@ -112,6 +112,7 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/px4/fmu-v5/default.cmake
+++ b/boards/px4/fmu-v5/default.cmake
@@ -114,6 +114,7 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/px4/fmu-v5/fixedwing.cmake
+++ b/boards/px4/fmu-v5/fixedwing.cmake
@@ -85,4 +85,5 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 	)

--- a/boards/px4/fmu-v5/multicopter.cmake
+++ b/boards/px4/fmu-v5/multicopter.cmake
@@ -94,4 +94,5 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 	)

--- a/boards/px4/fmu-v5/rover.cmake
+++ b/boards/px4/fmu-v5/rover.cmake
@@ -88,4 +88,5 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 	)

--- a/boards/px4/fmu-v5/rtps.cmake
+++ b/boards/px4/fmu-v5/rtps.cmake
@@ -112,6 +112,7 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/px4/fmu-v5/stackcheck.cmake
+++ b/boards/px4/fmu-v5/stackcheck.cmake
@@ -112,6 +112,7 @@ px4_add_board(
 		tune_control
 		usb_connected
 		ver
+		wq_manager
 
 	EXAMPLES
 		#bottle_drop # OBC challenge

--- a/boards/px4/raspberrypi/cross.cmake
+++ b/boards/px4/raspberrypi/cross.cmake
@@ -67,6 +67,7 @@ px4_add_board(
 		topic_listener
 		tune_control
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/px4/raspberrypi/native.cmake
+++ b/boards/px4/raspberrypi/native.cmake
@@ -66,6 +66,7 @@ px4_add_board(
 		topic_listener
 		tune_control
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/px4/sitl/default.cmake
+++ b/boards/px4/sitl/default.cmake
@@ -71,6 +71,7 @@ px4_add_board(
 		topic_listener
 		tune_control
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/px4/sitl/rtps.cmake
+++ b/boards/px4/sitl/rtps.cmake
@@ -72,6 +72,7 @@ px4_add_board(
 		topic_listener
 		tune_control
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/px4/sitl/test.cmake
+++ b/boards/px4/sitl/test.cmake
@@ -71,6 +71,7 @@ px4_add_board(
 		topic_listener
 		tune_control
 		ver
+		wq_manager
 
 	EXAMPLES
 		bottle_drop # OBC challenge

--- a/boards/thiemar/s2740vc-v1/default.cmake
+++ b/boards/thiemar/s2740vc-v1/default.cmake
@@ -46,5 +46,6 @@ px4_add_board(
 		reboot
 		top
 		ver
+		wq_manager
 
 	)

--- a/src/platforms/common/px4_work_queue/WorkItem.cpp
+++ b/src/platforms/common/px4_work_queue/WorkItem.cpp
@@ -49,19 +49,34 @@ WorkItem::WorkItem(const wq_config_t &config)
 	}
 }
 
-bool WorkItem::Init(const wq_config_t &config)
+WorkItem::~WorkItem()
 {
-	px4::WorkQueue *wq = WorkQueueFindOrCreate(config);
-
-	if (wq == nullptr) {
-		PX4_ERR("%s not available", config.name);
-
-	} else {
-		_wq = wq;
-		return true;
+	if (_wq) {
+		_wq->Close();
 	}
 
-	return false;
+	_wq = nullptr;
+}
+
+bool WorkItem::Init(const wq_config_t &config)
+{
+	if (_wq == nullptr) {
+		px4::WorkQueue *wq = WorkQueueFindOrCreate(config);
+
+		if (wq == nullptr) {
+			PX4_ERR("%s not available", config.name);
+
+		} else {
+			if (wq->Open()) {
+				_wq = wq;
+
+			} else {
+				PX4_ERR("unable to open WQ");
+			}
+		}
+	}
+
+	return (_wq != nullptr);
 }
 
 } // namespace px4

--- a/src/platforms/common/px4_work_queue/WorkQueue.hpp
+++ b/src/platforms/common/px4_work_queue/WorkQueue.hpp
@@ -65,9 +65,14 @@ public:
 
 	void Run();
 
-	void request_stop() { _should_exit.store(true); }
+	void request_stop() { _should_exit.store(true); px4_sem_post(&_process_lock); }
 
 	void print_status();
+
+	bool Open();
+	void Close();
+
+	uint8_t	open_count() const { return _open_count; }
 
 private:
 
@@ -89,6 +94,8 @@ private:
 
 	px4::atomic_bool	_should_exit{false};
 	const wq_config_t	&_config;
+
+	uint8_t			_open_count{0};
 
 };
 

--- a/src/platforms/common/px4_work_queue/WorkQueueManager.hpp
+++ b/src/platforms/common/px4_work_queue/WorkQueueManager.hpp
@@ -81,12 +81,30 @@ int WorkQueueManagerStart();
 int WorkQueueManagerStop();
 
 /**
+ * Stop the work queue manager task.
+ */
+int WorkQueueManagerStatus();
+
+/**
+ * Cleanup unused work queues.
+ */
+int WorkQueueManagerCleanup();
+
+/**
  * Create (or find) a work queue with a particular configuration.
  *
  * @param new_wq		The work queue configuration (see WorkQueueManager.hpp).
  * @return		A pointer to the WorkQueue, or nullptr on failure.
  */
 WorkQueue *WorkQueueFindOrCreate(const wq_config_t &new_wq);
+
+/**
+ * Shutdown a workqueue if it exists.
+ *
+ * @param wq		The work queue configuration (see WorkQueueManager.hpp).
+ * @return		True if the workqueue was found and stopped, otherwise false.
+ */
+bool WorkQueueShutdown(const wq_config_t &wq);
 
 /**
  * Map a PX4 driver device id to a work queue (by sensor bus).

--- a/src/systemcmds/wq_manager/CMakeLists.txt
+++ b/src/systemcmds/wq_manager/CMakeLists.txt
@@ -1,0 +1,42 @@
+############################################################################
+#
+#   Copyright (c) 2015 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+px4_add_module(
+	MODULE systemcmds__wq_manager
+	MAIN wq_manager
+	STACK_MAIN 1800
+	COMPILE_FLAGS
+	SRCS
+		wq_manager.cpp
+	DEPENDS
+		px4_work_queue
+	)

--- a/src/systemcmds/wq_manager/wq_manager.cpp
+++ b/src/systemcmds/wq_manager/wq_manager.cpp
@@ -31,40 +31,39 @@
  *
  ****************************************************************************/
 
-#pragma once
+#include <px4_config.h>
+#include <px4_module.h>
 
+#include <px4_work_queue/WorkQueueManager.hpp>
 
-#include "WorkQueueManager.hpp"
-#include "WorkQueue.hpp"
+extern "C" {
+	__EXPORT int wq_manager_main(int argc, char *argv[]);
+}
 
-#include <containers/IntrusiveQueue.hpp>
-#include <px4_defines.h>
-#include <drivers/drv_hrt.h>
-
-namespace px4
+static void print_usage()
 {
+	PRINT_MODULE_DESCRIPTION("Workqueue manager command line helper");
 
-class WorkItem : public IntrusiveQueueNode<WorkItem *>
+	PRINT_MODULE_USAGE_NAME_SIMPLE("wq_manager", "command");
+	PRINT_MODULE_USAGE_COMMAND_DESCR("status", "Print status of all running workqueues");
+	PRINT_MODULE_USAGE_COMMAND_DESCR("cleanup", "Stop all unused workqueues");
+}
+
+int wq_manager_main(int argc, char *argv[])
 {
-public:
+	if (argc > 1) {
+		if (strcmp(argv[1], "status") == 0) {
+			px4::WorkQueueManagerStatus();
+			return 0;
 
-	explicit WorkItem(const wq_config_t &config);
-	WorkItem() = delete;
+		} else if (strcmp(argv[1], "cleanup") == 0) {
+			px4::WorkQueueManagerCleanup();
+			return 0;
+		}
 
-	virtual ~WorkItem();
+		print_usage();
+		return -1;
+	}
 
-	inline void ScheduleNow() { if (_wq != nullptr) _wq->Add(this); }
-
-	virtual void Run() = 0;
-
-protected:
-
-	bool Init(const wq_config_t &config);
-
-private:
-
-	WorkQueue *_wq{nullptr};
-
-};
-
-} // namespace px4
+	return 0;
+}


### PR DESCRIPTION
When probing optional drivers at startup the corresponding workqueue per bus is created if it doesn't already exist. With the current init structure of attempting to start many possible external devices the result is a workqueue for every bus in the system. This doesn't actually waste that much memory, but we are starting to bump up against the NuttX task limit. https://github.com/PX4/Firmware/pull/11792#issuecomment-498224237

The downside of this PR is that in some cases the WQ for the same bus might be created, killed, then created again later as each optional driver is probing.

Example

```Console
INFO [px4_work_queue] creating: wq:I2C1, priority: 248, stack: 1200 bytes
WARN [bst] no devices found
INFO [px4_work_queue] wq:I2C1: last active WorkItem closing, stopping thread
INFO [px4_work_queue] wq:I2C1: exiting
```

