### PR TITLE
Fix px_uploader.py to work with Python 2.7.

### DIFF
--- a/Tools/px_uploader.py
+++ b/Tools/px_uploader.py
@@ -727,10 +727,20 @@ def main():
 
     # We need to check for pyserial because the import itself doesn't
     # seem to fail, at least not on macOS.
+    pyserial_installed = False
     try:
-        if serial.__version__ or serial.VERSION:
-            pass
+        if serial.__version__:
+            pyserial_installed = True
     except:
+        pass
+    
+    try:
+        if serial.VERSION:
+            pyserial_installed = True
+    except:
+        pass
+    
+    if not pyserial_installed:
         print("Error: pyserial not installed!")
         print("    (Install using: sudo pip install pyserial)")
         sys.exit(1)


### PR DESCRIPTION
This was broken on my machine with Ubuntu 16.04 and Python 2.7.

Before, the pyserial check would fail trying to read `serial.__version__` before it could check for the `serial.VERSION` that the Python 2.7 version contains. This fixes it to check for the `serial.VERSION` independently.