### PR TITLE
uORB add WorkItem callbacks on publication

### DIFF
--- a/src/modules/uORB/uORB.cpp
+++ b/src/modules/uORB/uORB.cpp
@@ -107,6 +107,16 @@ int  orb_exists(const struct orb_metadata *meta, int instance)
 	return uORB::Manager::get_instance()->orb_exists(meta, instance);
 }
 
+int orb_register_work_callback(px4::WorkItem *item, const orb_metadata *meta, int instance)
+{
+	return uORB::Manager::get_instance()->orb_register_work_callback(item, meta, instance);
+}
+
+int orb_unregister_work_callback(px4::WorkItem *item, const orb_metadata *meta, int instance)
+{
+	return uORB::Manager::get_instance()->orb_unregister_work_callback(item, meta, instance);
+}
+
 int  orb_group_count(const struct orb_metadata *meta)
 {
 	unsigned instance = 0;

--- a/src/modules/uORB/uORB.h
+++ b/src/modules/uORB/uORB.h
@@ -43,6 +43,12 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+namespace px4
+{
+class WorkItem; // forward declaration
+} // namespace px4
+#endif
 
 /**
  * Object metadata.
@@ -249,6 +255,22 @@ extern int	orb_set_interval(int handle, unsigned interval) __EXPORT;
  * @see uORB::Manager::orb_get_interval()
  */
 extern int	orb_get_interval(int handle, unsigned *interval) __EXPORT;
+
+#ifdef __cplusplus
+/**
+ * @see uORB::Manager::orb_register_work_callback()
+ */
+extern int
+orb_register_work_callback(px4::WorkItem *item, const orb_metadata *meta, int instance = 0) __EXPORT;
+
+/**
+ * @see uORB::Manager::orb_unregister_work_callback()
+ */
+
+extern int
+orb_unregister_work_callback(px4::WorkItem *item, const orb_metadata *meta, int instance = 0) __EXPORT;
+
+#endif /* __cplusplus */
 
 __END_DECLS
 

--- a/src/modules/uORB/uORBDeviceNode.hpp
+++ b/src/modules/uORB/uORBDeviceNode.hpp
@@ -39,6 +39,7 @@
 #include <lib/cdev/CDev.hpp>
 
 #include <containers/List.hpp>
+#include <px4_work_queue/WorkItem.hpp>
 
 namespace uORB
 {
@@ -231,6 +232,12 @@ public:
 	 */
 	uint64_t copy_and_get_timestamp(void *dst, unsigned &generation);
 
+	// add item to list of work items to schedule on node update
+	bool register_work_item(px4::WorkItem *item);
+
+	// remove item from list of work items
+	bool unregister_work_item(px4::WorkItem *item);
+
 protected:
 
 	pollevent_t poll_state(cdev::file_t *filp) override;
@@ -269,6 +276,7 @@ private:
 	uint8_t     *_data{nullptr};   /**< allocated object buffer */
 	hrt_abstime   _last_update{0}; /**< time the object was last updated */
 	volatile unsigned   _generation{0};  /**< object generation count */
+	List<px4::WorkItem *>	_registered_work_items;
 	uint8_t   _priority;  /**< priority of the topic */
 	bool _published{false};  /**< has ever data been published */
 	uint8_t _queue_size; /**< maximum number of elements in the queue */

--- a/src/modules/uORB/uORBManager.hpp
+++ b/src/modules/uORB/uORBManager.hpp
@@ -51,6 +51,8 @@
 #include "uORBCommunicator.hpp"
 #endif /* ORB_COMMUNICATOR */
 
+#include <px4_work_queue/WorkItem.hpp>
+
 namespace uORB
 {
 class Manager;
@@ -347,7 +349,6 @@ public:
 	 */
 	int  orb_set_interval(int handle, unsigned interval);
 
-
 	/**
 	 * Get the minimum interval between which updates are seen for a subscription.
 	 *
@@ -358,6 +359,26 @@ public:
 	 * @return    OK on success, PX4_ERROR otherwise with ERRNO set accordingly.
 	 */
 	int	orb_get_interval(int handle, unsigned *interval);
+
+	/**
+	 * Register work item callback on orb publish
+	 *
+	 * @param item   Valid WorkItem to schedule on new publication
+	 * @param meta    ORB topic metadata.
+	 * @param instance  ORB instance
+	 * @return    OK if the item was registered successfully, PX4_ERROR otherwise.
+	 */
+	int  orb_register_work_callback(px4::WorkItem *item, const orb_metadata *meta, int instance = 0);
+
+	/**
+	 * Unregister work item callback on orb publish
+	 *
+	 * @param item   Valid WorkItem to schedule on new publication
+	 * @param meta    ORB topic metadata.
+	 * @param instance  ORB instance
+	 * @return    OK if the item was unregistered successfully, PX4_ERROR otherwise.
+	 */
+	int  orb_unregister_work_callback(px4::WorkItem *item, const orb_metadata *meta, int instance = 0);
 
 #ifdef ORB_COMMUNICATOR
 	/**

--- a/src/platforms/common/px4_work_queue/WorkItem.hpp
+++ b/src/platforms/common/px4_work_queue/WorkItem.hpp
@@ -38,13 +38,14 @@
 #include "WorkQueue.hpp"
 
 #include <containers/IntrusiveQueue.hpp>
+#include <containers/List.hpp>
 #include <px4_defines.h>
 #include <drivers/drv_hrt.h>
 
 namespace px4
 {
 
-class WorkItem : public IntrusiveQueueNode<WorkItem *>
+class WorkItem : public IntrusiveQueueNode<WorkItem *>, public ListNode<WorkItem *>
 {
 public:
 


### PR DESCRIPTION
This PR adds a simple callback mechanism to uORB on publication that schedules a cycle of a WorkItem in the new PX4 work queue.

This is effectively an alternative to the typical PX4 pattern of a task per module with a main loop polling a single topic.

Coupling uORB to WorkItems wasn't my first choice, but after experimenting with various c++ delegate options the simplicity of this with the intended usage is appealing. I'm certainly open to suggestions though.