### PR TITLE
uORB remove unused SubscriptionInterval and SubscriptionIntervalData

### DIFF
--- a/src/modules/uORB/Subscription.hpp
+++ b/src/modules/uORB/Subscription.hpp
@@ -64,7 +64,7 @@ public:
 		init();
 	}
 
-	virtual ~Subscription() { unsubscribe(); }
+	~Subscription() { unsubscribe(); }
 
 	bool init();
 	bool forceInit();
@@ -75,13 +75,13 @@ public:
 	/**
 	 * Check if there is a new update.
 	 * */
-	virtual bool updated() { return published() ? (_node->published_message_count() != _last_generation) : false; }
+	bool updated() { return published() ? (_node->published_message_count() != _last_generation) : false; }
 
 	/**
 	 * Update the struct
 	 * @param data The uORB message struct we are updating.
 	 */
-	virtual bool update(void *dst) { return updated() ? copy(dst) : false; }
+	bool update(void *dst) { return updated() ? copy(dst) : false; }
 
 	/**
 	 * Check if subscription updated based on timestamp.
@@ -122,53 +122,6 @@ protected:
 	uint8_t			_instance{0};
 };
 
-// Subscription wrapper class with configured interval
-class SubscriptionInterval : public Subscription
-{
-public:
-	/**
-	 * Constructor
-	 *
-	 * @param meta The uORB metadata (usually from the ORB_ID() macro) for the topic.
-	 * @param interval  The minimum interval in milliseconds between updates
-	 * @param instance The instance for multi sub.
-	 */
-	SubscriptionInterval(const orb_metadata *meta, unsigned interval = 0, uint8_t instance = 0) :
-		Subscription(meta, instance),
-		_interval(interval)
-	{}
-
-	virtual ~SubscriptionInterval() = default;
-
-	bool updated() override
-	{
-		if (hrt_elapsed_time(&_last_update) >= (_interval * 1000)) {
-			return Subscription::updated();
-		}
-
-		return false;
-	}
-
-	bool update(void *dst) override
-	{
-		if (updated()) {
-			if (copy(dst)) {
-				_last_update = hrt_absolute_time();
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	int get_interval() const { return _interval; }
-	void set_interval(unsigned interval) { _interval = interval; }
-
-protected:
-	uint64_t _last_update{0};	// last update in microseconds
-	unsigned _interval{0};		// interval in milliseconds
-};
-
 // Subscription wrapper class with data
 template<class T>
 class SubscriptionData : public Subscription
@@ -186,7 +139,7 @@ public:
 		copy(&_data);
 	}
 
-	virtual ~SubscriptionData() = default;
+	~SubscriptionData() = default;
 
 	// no copy, assignment, move, move assignment
 	SubscriptionData(const SubscriptionData &) = delete;
@@ -201,41 +154,6 @@ public:
 
 private:
 
-	T _data{};
-};
-
-// Subscription wrapper class with data and configured interval
-template<class T>
-class SubscriptionIntervalData : public SubscriptionInterval
-{
-public:
-	/**
-	 * Constructor
-	 *
-	 * @param meta The uORB metadata (usually from the ORB_ID() macro) for the topic.
-	 * @param interval  The minimum interval in milliseconds between updates
-	 * @param instance The instance for multi sub.
-	 */
-	SubscriptionIntervalData(const orb_metadata *meta, unsigned interval = 0, uint8_t instance = 0) :
-		SubscriptionInterval(meta, interval, instance)
-	{
-		copy(&_data);
-	}
-
-	~SubscriptionIntervalData() override = default;
-
-	// no copy, assignment, move, move assignment
-	SubscriptionIntervalData(const SubscriptionIntervalData &) = delete;
-	SubscriptionIntervalData &operator=(const SubscriptionIntervalData &) = delete;
-	SubscriptionIntervalData(SubscriptionIntervalData &&) = delete;
-	SubscriptionIntervalData &operator=(SubscriptionIntervalData &&) = delete;
-
-	// update the embedded struct.
-	bool update() { return SubscriptionInterval::update((void *)(&_data)); }
-
-	const T &get() const { return _data; }
-
-private:
 	T _data{};
 };
 


### PR DESCRIPTION
After playing with logger updates to uORB::Subscription I've decided that uORB::SubscriptionInterval is simple enough to handle outside of the class hierarchy. This PR deletes the unused classes `uORB::SubscriptionInterval` and `uORB::SubscriptionIntervalData`.

A new standalone `uORB::SubscriptionInterval` will be introduced along with the logger updates in https://github.com/PX4/Firmware/pull/12123.

Making this change allowed dropping virtualization and saving a bit of flash and ram.

![image](https://user-images.githubusercontent.com/84712/58835707-abc0e180-8624-11e9-96b4-ab9856b3961a.png)
