### PR TITLE
PWM_(MAIN|AUX)_REV[1-8] - Clarify use case to avoid misusage

### DIFF
--- a/src/modules/sensors/pwm_params_aux.c
+++ b/src/modules/sensors/pwm_params_aux.c
@@ -608,6 +608,8 @@ PARAM_DEFINE_INT32(PWM_AUX_DIS8, -1);
  * Invert direction of auxiliary output channel 1
  *
  * Enable to invert the channel.
+ * Warning: Use this parameter when connected to a servo only.
+ * For a brushless motor, invert manually two phases to reverse the direction.
  *
  * @boolean
  * @group PWM Outputs
@@ -618,6 +620,8 @@ PARAM_DEFINE_INT32(PWM_AUX_REV1, 0);
  * Invert direction of auxiliary output channel 2
  *
  * Enable to invert the channel.
+ * Warning: Use this parameter when connected to a servo only.
+ * For a brushless motor, invert manually two phases to reverse the direction.
  *
  * @boolean
  * @group PWM Outputs
@@ -628,6 +632,8 @@ PARAM_DEFINE_INT32(PWM_AUX_REV2, 0);
  * Invert direction of auxiliary output channel 3
  *
  * Enable to invert the channel.
+ * Warning: Use this parameter when connected to a servo only.
+ * For a brushless motor, invert manually two phases to reverse the direction.
  *
  * @boolean
  * @group PWM Outputs
@@ -638,6 +644,8 @@ PARAM_DEFINE_INT32(PWM_AUX_REV3, 0);
  * Invert direction of auxiliary output channel 4
  *
  * Enable to invert the channel.
+ * Warning: Use this parameter when connected to a servo only.
+ * For a brushless motor, invert manually two phases to reverse the direction.
  *
  * @boolean
  * @group PWM Outputs
@@ -648,6 +656,8 @@ PARAM_DEFINE_INT32(PWM_AUX_REV4, 0);
  * Invert direction of auxiliary output channel 5
  *
  * Enable to invert the channel.
+ * Warning: Use this parameter when connected to a servo only.
+ * For a brushless motor, invert manually two phases to reverse the direction.
  *
  * @boolean
  * @group PWM Outputs
@@ -658,6 +668,8 @@ PARAM_DEFINE_INT32(PWM_AUX_REV5, 0);
  * Invert direction of auxiliary output channel 6
  *
  * Enable to invert the channel.
+ * Warning: Use this parameter when connected to a servo only.
+ * For a brushless motor, invert manually two phases to reverse the direction.
  *
  * @boolean
  * @group PWM Outputs
@@ -668,6 +680,8 @@ PARAM_DEFINE_INT32(PWM_AUX_REV6, 0);
  * Invert direction of auxiliary output channel 7
  *
  * Enable to invert the channel.
+ * Warning: Use this parameter when connected to a servo only.
+ * For a brushless motor, invert manually two phases to reverse the direction.
  *
  * @boolean
  * @group PWM Outputs
@@ -678,6 +692,8 @@ PARAM_DEFINE_INT32(PWM_AUX_REV7, 0);
  * Invert direction of auxiliary output channel 8
  *
  * Enable to invert the channel.
+ * Warning: Use this parameter when connected to a servo only.
+ * For a brushless motor, invert manually two phases to reverse the direction.
  *
  * @boolean
  * @group PWM Outputs

--- a/src/modules/sensors/pwm_params_main.c
+++ b/src/modules/sensors/pwm_params_main.c
@@ -611,6 +611,8 @@ PARAM_DEFINE_INT32(PWM_MAIN_DIS8, -1);
  * Invert direction of main output channel 1
  *
  * Enable to invert the channel.
+ * Warning: Use this parameter when connected to a servo only.
+ * For a brushless motor, invert manually two phases to reverse the direction.
  *
  * @boolean
  * @group PWM Outputs
@@ -621,6 +623,8 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV1, 0);
  * Invert direction of main output channel 2
  *
  * Enable to invert the channel.
+ * Warning: Use this parameter when connected to a servo only.
+ * For a brushless motor, invert manually two phases to reverse the direction.
  *
  * @boolean
  * @group PWM Outputs
@@ -631,6 +635,8 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV2, 0);
  * Invert direction of main output channel 3
  *
  * Enable to invert the channel.
+ * Warning: Use this parameter when connected to a servo only.
+ * For a brushless motor, invert manually two phases to reverse the direction.
  *
  * @boolean
  * @group PWM Outputs
@@ -641,6 +647,8 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV3, 0);
  * Invert direction of main output channel 4
  *
  * Enable to invert the channel.
+ * Warning: Use this parameter when connected to a servo only.
+ * For a brushless motor, invert manually two phases to reverse the direction.
  *
  * @boolean
  * @group PWM Outputs
@@ -651,6 +659,8 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV4, 0);
  * Invert direction of main output channel 5
  *
  * Enable to invert the channel.
+ * Warning: Use this parameter when connected to a servo only.
+ * For a brushless motor, invert manually two phases to reverse the direction.
  *
  * @boolean
  * @group PWM Outputs
@@ -661,6 +671,8 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV5, 0);
  * Invert direction of main output channel 6
  *
  * Enable to invert the channel.
+ * Warning: Use this parameter when connected to a servo only.
+ * For a brushless motor, invert manually two phases to reverse the direction.
  *
  * @boolean
  * @group PWM Outputs
@@ -671,6 +683,8 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV6, 0);
  * Invert direction of main output channel 7
  *
  * Enable to invert the channel.
+ * Warning: Use this parameter when connected to a servo only.
+ * For a brushless motor, invert manually two phases to reverse the direction.
  *
  * @boolean
  * @group PWM Outputs
@@ -681,6 +695,8 @@ PARAM_DEFINE_INT32(PWM_MAIN_REV7, 0);
  * Invert direction of main output channel 8
  *
  * Enable to invert the channel.
+ * Warning: Use this parameter when connected to a servo only.
+ * For a brushless motor, invert manually two phases to reverse the direction.
  *
  * @boolean
  * @group PWM Outputs


### PR DESCRIPTION
The description of the PWM reverse parameters could tempt the user to use it in order to reverse the rotation of a motor. This can be really dangerous and should be explicitly written in the parameter description.