### PR TITLE
Allow more than 4 MC motors in VTOL Simulator

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/1040_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/1040_standard_vtol
@@ -35,7 +35,7 @@ then
 	param set VT_F_TRANS_DUR 5
 	param set VT_F_TRANS_THR 0.75
 	param set VT_ARSP_TRANS 16
-	param set VT_MOT_COUNT 4
+	param set VT_MC_MOT_COUNT 4
 	param set VT_TYPE 2
 
 	param set WEST_EN 1

--- a/ROMFS/px4fmu_common/init.d-posix/1041_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/1041_tailsitter
@@ -35,7 +35,7 @@ then
 
 	param set VT_F_TRANS_DUR 1.5
 	param set VT_F_TRANS_THR 0.7
-	param set VT_MOT_COUNT 0
+	param set VT_MC_MOT_COUNT 0
 	param set VT_TYPE 0
 
 	param set WEST_EN 1

--- a/ROMFS/px4fmu_common/init.d-posix/1042_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/1042_tiltrotor
@@ -35,7 +35,7 @@ then
 
 	param set VT_F_TRANS_DUR 1.5
 	param set VT_F_TRANS_THR 0.75
-	param set VT_MOT_COUNT 4
+	param set VT_MC_MOT_COUNT 4
 	param set VT_TILT_FW 3.1415
 	param set VT_TILT_TRANS 1.2
 	param set VT_ELEV_MC_LOCK 0

--- a/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
@@ -59,7 +59,7 @@ then
 	param set SYS_RESTART_TYPE 2
 
 	param set VT_F_TRANS_THR 0.75
-	param set VT_MOT_COUNT 4
+	param set VT_MC_MOT_COUNT 4
 	param set VT_TYPE 2
 
 	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10

--- a/ROMFS/px4fmu_common/init.d/airframes/13000_generic_vtol_standard
+++ b/ROMFS/px4fmu_common/init.d/airframes/13000_generic_vtol_standard
@@ -26,7 +26,7 @@ then
 	param set PWM_RATE 400
 
 	param set VT_TYPE 2
-	param set VT_MOT_COUNT 4
+	param set VT_MC_MOT_COUNT 4
 
 	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
 	param set V19_VT_ROLLDIR 0

--- a/ROMFS/px4fmu_common/init.d/airframes/13001_caipirinha_vtol
+++ b/ROMFS/px4fmu_common/init.d/airframes/13001_caipirinha_vtol
@@ -35,7 +35,7 @@ then
 
 	param set VT_IDLE_PWM_MC  1080
 	param set VT_ELEV_MC_LOCK 0
-	param set VT_MOT_COUNT 2
+	param set VT_MC_MOT_COUNT 2
 	param set VT_TYPE 0
 
 	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10

--- a/ROMFS/px4fmu_common/init.d/airframes/13002_firefly6
+++ b/ROMFS/px4fmu_common/init.d/airframes/13002_firefly6
@@ -42,7 +42,7 @@ then
 
 	param set VT_FW_MOT_OFFID 34
 	param set VT_IDLE_PWM_MC 1080
-	param set VT_MOT_COUNT 6
+	param set VT_MC_MOT_COUNT 6
 	param set VT_TILT_MC 0.08
 	param set VT_TILT_TRANS 0.5
 	param set VT_TILT_FW 0.9

--- a/ROMFS/px4fmu_common/init.d/airframes/13003_quad_tailsitter
+++ b/ROMFS/px4fmu_common/init.d/airframes/13003_quad_tailsitter
@@ -15,7 +15,7 @@ then
 	param set PWM_MAX 2000
 	param set PWM_RATE 400
 
-	param set VT_MOT_COUNT 4
+	param set VT_MC_MOT_COUNT 4
 	param set VT_IDLE_PWM_MC  1080
 	param set VT_TYPE 0
 	param set VT_ELEV_MC_LOCK 1

--- a/ROMFS/px4fmu_common/init.d/airframes/13004_quad+_tailsitter
+++ b/ROMFS/px4fmu_common/init.d/airframes/13004_quad+_tailsitter
@@ -26,7 +26,7 @@ then
 	param set PWM_MAX 2000
 	param set PWM_RATE 400
 
-	param set VT_MOT_COUNT 4
+	param set VT_MC_MOT_COUNT 4
 	param set VT_IDLE_PWM_MC  1080
 	param set VT_TYPE 0
 	param set VT_ELEV_MC_LOCK 1

--- a/ROMFS/px4fmu_common/init.d/airframes/13005_vtol_AAERT_quad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13005_vtol_AAERT_quad
@@ -58,7 +58,7 @@ then
 	param set VT_ARSP_BLEND 6
 	param set VT_ARSP_TRANS 12
 	param set VT_F_TRANS_THR 0.75
-	param set VT_MOT_COUNT 4
+	param set VT_MC_MOT_COUNT 4
 	param set VT_IDLE_PWM_MC 1080
 	param set VT_TYPE 2
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13006_vtol_standard_delta
+++ b/ROMFS/px4fmu_common/init.d/airframes/13006_vtol_standard_delta
@@ -45,7 +45,7 @@ then
 	param set PWM_AUX_DIS3 950
 	param set PWM_RATE 400
 
-	param set VT_MOT_COUNT 4
+	param set VT_MC_MOT_COUNT 4
 	param set VT_F_TRANS_THR 0.75
 	param set VT_IDLE_PWM_MC 1080
 	param set VT_TYPE 2

--- a/ROMFS/px4fmu_common/init.d/airframes/13007_vtol_AAVVT_quad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13007_vtol_AAVVT_quad
@@ -35,7 +35,7 @@ then
 	param set PWM_RATE 400
 
 	param set VT_F_TRANS_THR 0.75
-	param set VT_MOT_COUNT 4
+	param set VT_MC_MOT_COUNT 4
 	param set VT_IDLE_PWM_MC 1080
 	param set VT_TYPE 2
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13008_QuadRanger
+++ b/ROMFS/px4fmu_common/init.d/airframes/13008_QuadRanger
@@ -53,7 +53,7 @@ then
 	param set VT_B_TRANS_DUR 4
 	param set VT_F_TRANS_THR 0.75
 	param set VT_IDLE_PWM_MC 1080
-	param set VT_MOT_COUNT 4
+	param set VT_MC_MOT_COUNT 4
 	param set VT_TYPE 2
 
 	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10

--- a/ROMFS/px4fmu_common/init.d/airframes/13009_vtol_spt_ranger
+++ b/ROMFS/px4fmu_common/init.d/airframes/13009_vtol_spt_ranger
@@ -72,7 +72,7 @@ then
 	param set VT_B_TRANS_DUR  4
 	param set VT_F_TRANS_THR    0.6
 	param set VT_IDLE_PWM_MC 1180
-	param set VT_MOT_COUNT 4
+	param set VT_MC_MOT_COUNT 4
 	param set VT_TRANS_MIN_TM 5
 	param set VT_TRANS_TIMEOUT    30
 	param set VT_TYPE 2

--- a/ROMFS/px4fmu_common/init.d/airframes/13010_claire
+++ b/ROMFS/px4fmu_common/init.d/airframes/13010_claire
@@ -22,7 +22,7 @@ then
 	param set PWM_MAX 2000
 	param set PWM_RATE 400
 
-	param set VT_MOT_COUNT 4
+	param set VT_MC_MOT_COUNT 4
 	param set VT_FW_MOT_OFFID 13
 	param set VT_IDLE_PWM_MC 1080
 	param set VT_TILT_FW 0.9

--- a/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
+++ b/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
@@ -69,7 +69,7 @@ then
 	param set VT_FW_MOT_OFFID 3
 	param set VT_FW_PERM_STAB 0
 	param set VT_IDLE_PWM_MC 1200
-	param set VT_MOT_COUNT 3
+	param set VT_MC_MOT_COUNT 3
 	param set VT_TILT_FW  1
 	param set VT_TILT_MC  0
 	param set VT_TILT_TRANS   0.45

--- a/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
@@ -133,7 +133,7 @@ then
 	param set SER_TEL2_BAUD 57600
 
 	param set VT_TYPE 2
-	param set VT_MOT_COUNT 4
+	param set VT_MC_MOT_COUNT 4
 	param set VT_F_TRANS_THR 1
 	param set VT_DWN_PITCH_MAX 8
 	param set VT_FW_QC_P 55

--- a/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
+++ b/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
@@ -69,7 +69,7 @@ then
 	param set VT_F_TRANS_THR 0.85
 	param set VT_F_TR_OL_TM 7
 	param set VT_IDLE_PWM_MC 1000
-	param set VT_MOT_COUNT 8
+	param set VT_MC_MOT_COUNT 8
 	param set VT_PSHER_RMP_DT 2
 	param set VT_TRANS_MIN_TM 6
 	param set VT_TYPE 2

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -2972,13 +2972,13 @@ protected:
 	{
 		param_t ph;
 
-		ph = param_find("VT_MC_MOT_COUNT");
+		ph = param_find_no_notification("VT_MC_MOT_COUNT");
 
 		if (ph == PARAM_INVALID || param_get(ph, &_param_vtol_mc_mot_count_val) != PX4_OK) {
 			_param_vtol_mc_mot_count_val = 0;
 		}
 
-		ph = param_find("VT_FW_MOT_COUNT");
+		ph = param_find_no_notification("VT_FW_MOT_COUNT");
 
 		if (ph == PARAM_INVALID || param_get(ph, &_param_vtol_fw_mot_count_val) != PX4_OK) {
 			_param_vtol_fw_mot_count_val = 1;

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -302,7 +302,9 @@ private:
 		(ParamFloat<px4::params::SIM_BAT_DRAIN>) _param_sim_bat_drain, ///< battery drain interval
 		(ParamInt<px4::params::MAV_TYPE>) _param_mav_type,
 		(ParamInt<px4::params::MAV_SYS_ID>) _param_mav_sys_id,
-		(ParamInt<px4::params::MAV_COMP_ID>) _param_mav_comp_id
+		(ParamInt<px4::params::MAV_COMP_ID>) _param_mav_comp_id,
+		(ParamInt<px4::params::VT_MOT_COUNT>) _param_vtol_mot_count,
+		(ParamInt<px4::params::VT_PSH_MOT_COUNT>) _param_vtol_push_mot_count
 	)
 
 #endif

--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -303,8 +303,8 @@ private:
 		(ParamInt<px4::params::MAV_TYPE>) _param_mav_type,
 		(ParamInt<px4::params::MAV_SYS_ID>) _param_mav_sys_id,
 		(ParamInt<px4::params::MAV_COMP_ID>) _param_mav_comp_id,
-		(ParamInt<px4::params::VT_MOT_COUNT>) _param_vtol_mot_count,
-		(ParamInt<px4::params::VT_PSH_MOT_COUNT>) _param_vtol_push_mot_count
+		(ParamInt<px4::params::VT_MC_MOT_COUNT>) _param_vtol_mc_mot_count,
+		(ParamInt<px4::params::VT_FW_MOT_COUNT>) _param_vtol_fw_mot_count
 	)
 
 #endif

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -94,7 +94,8 @@ mavlink_hil_actuator_controls_t Simulator::actuator_controls_from_outputs(const 
 	    _system_type == MAV_TYPE_VTOL_DUOROTOR ||
 	    _system_type == MAV_TYPE_VTOL_QUADROTOR ||
 	    _system_type == MAV_TYPE_VTOL_TILTROTOR ||
-	    _system_type == MAV_TYPE_VTOL_RESERVED2) {
+	    _system_type == MAV_TYPE_VTOL_RESERVED2 ||
+	    _system_type == MAV_TYPE_VTOL_RESERVED3) {
 
 		/* multirotors: set number of rotor outputs depending on type */
 
@@ -114,6 +115,12 @@ mavlink_hil_actuator_controls_t Simulator::actuator_controls_from_outputs(const 
 		case MAV_TYPE_VTOL_RESERVED2:
 			// this is the standard VTOL / quad plane with 5 propellers
 			n = 5;
+			break;
+
+		case MAV_TYPE_VTOL_RESERVED3:
+			// this is the nonstandard VTOL plane with one or more push / pull propellers
+			n = _param_vtol_mot_count.get();
+			n += _param_vtol_push_mot_count.get();
 			break;
 
 		case MAV_TYPE_HEXAROTOR:

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -119,8 +119,8 @@ mavlink_hil_actuator_controls_t Simulator::actuator_controls_from_outputs(const 
 
 		case MAV_TYPE_VTOL_RESERVED3:
 			// this is the nonstandard VTOL plane with one or more push / pull propellers
-			n = _param_vtol_mot_count.get();
-			n += _param_vtol_push_mot_count.get();
+			n = _param_vtol_mc_mot_count.get();
+			n += _param_vtol_fw_mot_count.get();
 			break;
 
 		case MAV_TYPE_HEXAROTOR:

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -62,10 +62,10 @@ VtolAttitudeControl::VtolAttitudeControl()
 	_vtol_vehicle_status.vtol_in_rw_mode = true;	/* start vtol in rotary wing mode*/
 
 	_params.idle_pwm_mc = PWM_DEFAULT_MIN;
-	_params.vtol_motor_count = 0;
+	_params.vtol_mc_motor_count = 0;
 
 	_params_handles.idle_pwm_mc = param_find("VT_IDLE_PWM_MC");
-	_params_handles.vtol_motor_count = param_find("VT_MOT_COUNT");
+	_params_handles.vtol_mc_motor_count = param_find("VT_MC_MOT_COUNT");
 	_params_handles.vtol_fw_permanent_stab = param_find("VT_FW_PERM_STAB");
 	_params_handles.vtol_type = param_find("VT_TYPE");
 	_params_handles.elevons_mc_lock = param_find("VT_ELEV_MC_LOCK");
@@ -438,7 +438,7 @@ VtolAttitudeControl::parameters_update()
 	param_get(_params_handles.idle_pwm_mc, &_params.idle_pwm_mc);
 
 	/* vtol motor count */
-	param_get(_params_handles.vtol_motor_count, &_params.vtol_motor_count);
+	param_get(_params_handles.vtol_mc_motor_count, &_params.vtol_mc_motor_count);
 
 	/* vtol fw permanent stabilization */
 	param_get(_params_handles.vtol_fw_permanent_stab, &l);

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -174,7 +174,7 @@ private:
 
 	struct {
 		param_t idle_pwm_mc;
-		param_t vtol_motor_count;
+		param_t vtol_mc_motor_count;
 		param_t vtol_fw_permanent_stab;
 		param_t vtol_type;
 		param_t elevons_mc_lock;

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -40,7 +40,7 @@
  */
 
 /**
- * VTOL number of engines
+ * VTOL number of engines when in multicopter mode
  *
  * @min 0
  * @max 8
@@ -49,6 +49,17 @@
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_INT32(VT_MOT_COUNT, 0);
+
+/**
+ * VTOL number of push / pull engines
+ *
+ * @min 1
+ * @max 8
+ * @increment 1
+ * @decimal 0
+ * @group VTOL Attitude Control
+ */
+PARAM_DEFINE_INT32(VT_PSH_MOT_COUNT, 1);
 
 /**
  * Idle speed of VTOL when in multicopter mode

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -48,7 +48,7 @@
  * @decimal 0
  * @group VTOL Attitude Control
  */
-PARAM_DEFINE_INT32(VT_MOT_COUNT, 0);
+PARAM_DEFINE_INT32(VT_MC_MOT_COUNT, 0);
 
 /**
  * VTOL number of push / pull engines
@@ -59,7 +59,7 @@ PARAM_DEFINE_INT32(VT_MOT_COUNT, 0);
  * @decimal 0
  * @group VTOL Attitude Control
  */
-PARAM_DEFINE_INT32(VT_PSH_MOT_COUNT, 1);
+PARAM_DEFINE_INT32(VT_FW_MOT_COUNT, 1);
 
 /**
  * Idle speed of VTOL when in multicopter mode

--- a/src/modules/vtol_att_control/vtol_type.cpp
+++ b/src/modules/vtol_att_control/vtol_type.cpp
@@ -248,7 +248,7 @@ bool VtolType::set_idle_mc()
 	struct pwm_output_values pwm_values;
 	memset(&pwm_values, 0, sizeof(pwm_values));
 
-	for (int i = 0; i < _params->vtol_motor_count; i++) {
+	for (int i = 0; i < _params->vtol_mc_motor_count; i++) {
 		if (is_motor_off_channel(i)) {
 			pwm_values.values[i] = pwm_value;
 
@@ -268,7 +268,7 @@ bool VtolType::set_idle_fw()
 
 	memset(&pwm_values, 0, sizeof(pwm_values));
 
-	for (int i = 0; i < _params->vtol_motor_count; i++) {
+	for (int i = 0; i < _params->vtol_mc_motor_count; i++) {
 		if (is_motor_off_channel(i)) {
 			pwm_values.values[i] = PWM_MOTOR_OFF;
 
@@ -315,10 +315,10 @@ bool VtolType::apply_pwm_limits(struct pwm_output_values &pwm_values, pwm_limit_
 motor_state VtolType::set_motor_state(const motor_state current_state, const motor_state next_state, const int value)
 {
 	struct pwm_output_values pwm_values = {};
-	pwm_values.channel_count = _params->vtol_motor_count;
+	pwm_values.channel_count = _params->vtol_mc_motor_count;
 
-	// per default all motors are running
-	for (int i = 0; i < _params->vtol_motor_count; i++) {
+	// per default all mc mode motors are running
+	for (int i = 0; i < _params->vtol_mc_motor_count; i++) {
 		pwm_values.values[i] = _max_mc_pwm_values.values[i];
 	}
 
@@ -327,7 +327,7 @@ motor_state VtolType::set_motor_state(const motor_state current_state, const mot
 		break;
 
 	case motor_state::DISABLED:
-		for (int i = 0; i < _params->vtol_motor_count; i++) {
+		for (int i = 0; i < _params->vtol_mc_motor_count; i++) {
 			if (is_motor_off_channel(i)) {
 				pwm_values.values[i] = _disarmed_pwm_values.values[i];
 			}
@@ -337,7 +337,7 @@ motor_state VtolType::set_motor_state(const motor_state current_state, const mot
 
 	case motor_state::IDLE:
 
-		for (int i = 0; i < _params->vtol_motor_count; i++) {
+		for (int i = 0; i < _params->vtol_mc_motor_count; i++) {
 			if (is_motor_off_channel(i)) {
 				pwm_values.values[i] = _params->idle_pwm_mc;
 			}
@@ -346,7 +346,7 @@ motor_state VtolType::set_motor_state(const motor_state current_state, const mot
 		break;
 
 	case motor_state::VALUE:
-		for (int i = 0; i < _params->vtol_motor_count; i++) {
+		for (int i = 0; i < _params->vtol_mc_motor_count; i++) {
 			if (is_motor_off_channel(i)) {
 				pwm_values.values[i] = value;
 			}

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -49,7 +49,7 @@
 
 struct Params {
 	int32_t idle_pwm_mc;			// pwm value for idle in mc mode
-	int32_t vtol_motor_count;		// number of motors
+	int32_t vtol_mc_motor_count;		// number of motors in mc mode
 	int32_t vtol_type;
 	bool elevons_mc_lock;		// lock elevons in multicopter mode
 	float fw_min_alt;			// minimum relative altitude for FW mode (QuadChute)


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
In the SITL MAVLink module, the outputs are scaled based on the number of motors determined from the vehicle type. For tiltrotors and some other types of VTOLs, the vehicle type is not sufficient to determine the number of motors.

**Describe your preferred solution**
The VT_PSH_MOT_COUNT (push / pull motors count) parameter specifies the number of pushing / pulling motors for the copter. This new parameter together with VT_MOT_COUNT used to define total amount of motors in VTOL vehicle.

The default value is 1, so the old description files will be valid in case of reuse it to describe the new VTOL copters.

This parameter is necessary because of without it you can't give a full description of the nonstandard VTOL vehicle type with several push or pull engines.

For the new parameter used reserved vehicle type MAV_TYPE_VTOL_RESERVED3, which may coverage most of future nonstandard VTOL types.

**Additional context**
Thanks to @jlecoeur for https://github.com/PX4/Firmware/pull/11287.

