### PR TITLE
topic_listener: document how to exit

### DIFF
--- a/src/systemcmds/topic_listener/listener_main.cpp
+++ b/src/systemcmds/topic_listener/listener_main.cpp
@@ -182,6 +182,8 @@ usage()
 	PRINT_MODULE_DESCRIPTION(
 		R"DESCR_STR(
 Utility to listen on uORB topics and print the data to the console.
+
+The listener can be exited any time by pressing Ctrl+C, Esc, or Q.
 )DESCR_STR");
 
 	PRINT_MODULE_USAGE_NAME("listener", "command");


### PR DESCRIPTION
This was left out when the feature was added in #12113.