### PR TITLE
Collision Prevention with distance sensor 

### DIFF
--- a/msg/distance_sensor.msg
+++ b/msg/distance_sensor.msg
@@ -23,3 +23,8 @@ uint8 ROTATION_BACKWARD_FACING = 12 # MAV_SENSOR_ROTATION_PITCH_180
 uint8 ROTATION_FORWARD_FACING  = 0  # MAV_SENSOR_ROTATION_NONE
 uint8 ROTATION_LEFT_FACING     = 6  # MAV_SENSOR_ROTATION_YAW_270
 uint8 ROTATION_RIGHT_FACING    = 2  # MAV_SENSOR_ROTATION_YAW_90
+uint8 ROTATION_CUSTOM          =100 # MAV_SENSOR_ROTATION_CUSTOM
+
+float32 h_fov # Sensor horizontal field of view (rad)
+float32 v_fov # Sensor vertical field of view (rad)
+float32[4] q # Quaterion sensor orientation to specify the orientation ROTATION_CUSTOM

--- a/msg/distance_sensor.msg
+++ b/msg/distance_sensor.msg
@@ -27,4 +27,4 @@ uint8 ROTATION_CUSTOM          =100 # MAV_SENSOR_ROTATION_CUSTOM
 
 float32 h_fov # Sensor horizontal field of view (rad)
 float32 v_fov # Sensor vertical field of view (rad)
-float32[4] q # Quaterion sensor orientation to specify the orientation ROTATION_CUSTOM
+float32[4] q # Quaterion sensor orientation with respect to the vehicle body frame to specify the orientation ROTATION_CUSTOM

--- a/msg/obstacle_distance.msg
+++ b/msg/obstacle_distance.msg
@@ -13,3 +13,6 @@ uint8 increment # Angular width in degrees of each array element.
 
 uint16 min_distance # Minimum distance the sensor can measure in centimeters.
 uint16 max_distance # Maximum distance the sensor can measure in centimeters.
+
+float32 increment_f # Angular width in degrees of each array element. If greater than 0, it's used instead of increment.
+float32 angle_offset # Relative angle offset of the 0-index element in the distances array. Value of 0 corresponds to forward. Positive values are offsets to the right.

--- a/msg/obstacle_distance.msg
+++ b/msg/obstacle_distance.msg
@@ -15,3 +15,5 @@ uint16 min_distance # Minimum distance the sensor can measure in centimeters.
 uint16 max_distance # Maximum distance the sensor can measure in centimeters.
 
 float32 angle_offset # Relative angle offset of the 0-index element in the distances array. Value of 0 corresponds to forward. Positive values are offsets to the right.
+
+# TOPICS obstacle_distance obstacle_distance_fused

--- a/msg/obstacle_distance.msg
+++ b/msg/obstacle_distance.msg
@@ -9,10 +9,9 @@ uint8 MAV_DISTANCE_SENSOR_RADAR = 3
 
 uint16[72] distances # Distance of obstacles around the UAV with index 0 corresponding to local North. A value of 0 means that the obstacle is right in front of the sensor. A value of max_distance +1 means no obstacle is present. A value of UINT16_MAX for unknown/not used. In a array element, one unit corresponds to 1cm.
 
-uint8 increment # Angular width in degrees of each array element.
+float32 increment # Angular width in degrees of each array element.
 
 uint16 min_distance # Minimum distance the sensor can measure in centimeters.
 uint16 max_distance # Maximum distance the sensor can measure in centimeters.
 
-float32 increment_f # Angular width in degrees of each array element. If greater than 0, it's used instead of increment.
 float32 angle_offset # Relative angle offset of the 0-index element in the distances array. Value of 0 corresponds to forward. Positive values are offsets to the right.

--- a/src/drivers/distance_sensor/cm8jl65/cm8jl65.cpp
+++ b/src/drivers/distance_sensor/cm8jl65/cm8jl65.cpp
@@ -42,6 +42,7 @@
  */
 
 #include <poll.h>
+#include <px4_cli.h>
 #include <px4_config.h>
 #include <px4_getopt.h>
 #include <px4_work_queue/ScheduledWorkItem.hpp>
@@ -685,9 +686,17 @@ extern "C" __EXPORT int cm8jl65_main(int argc, char *argv[])
 
 	while ((ch = px4_getopt(argc, argv, "R:d:", &myoptind, &myoptarg)) != EOF) {
 		switch (ch) {
-		case 'R':
-			rotation = (uint8_t)atoi(myoptarg);
-			break;
+		case 'R': {
+				int rot = -1;
+
+				if (px4_get_parameter_value(myoptarg, rot) != 0) {
+					PX4_ERR("rotation parsing failed");
+					return -1;
+				}
+
+				rotation = (uint8_t)rot;
+				break;
+			}
 
 		case 'd':
 			device_path = myoptarg;

--- a/src/drivers/distance_sensor/cm8jl65/cm8jl65.cpp
+++ b/src/drivers/distance_sensor/cm8jl65/cm8jl65.cpp
@@ -327,9 +327,10 @@ CM8JL65::collect()
 
 	bytes_read = OK;
 
-	distance_sensor_s report;
+	distance_sensor_s report = {};
 	report.current_distance = static_cast<float>(distance_mm) / 1000.0f;
 	report.id               = 0;	// TODO: set proper ID.
+	report.h_fov            = 0.0488692f;
 	report.max_distance     = _max_distance;
 	report.min_distance     = _min_distance;
 	report.orientation      = _rotation;

--- a/src/drivers/distance_sensor/cm8jl65/module.yaml
+++ b/src/drivers/distance_sensor/cm8jl65/module.yaml
@@ -1,6 +1,27 @@
 module_name: Lanbao PSK-CM8JL65-CC5
 serial_config:
-    - command: cm8jl65 start -d ${SERIAL_DEV}
+    - command: cm8jl65 start -d ${SERIAL_DEV} -R p:SENS_CM8JL65_R_0
       port_config_param:
         name: SENS_CM8JL65_CFG
         group: Sensors
+
+parameters:
+    - group: Sensors
+      definitions:
+        SENS_CM8JL65_R_0:
+            description:
+                short: Distance Sensor Rotation
+                long: |
+                    Distance Sensor Rotation as MAV_SENSOR_ORIENTATION enum
+
+            type: enum
+            values:
+                25: ROTATION_DOWNWARD_FACING
+                24: ROTATION_UPWARD_FACING
+                12: ROTATION_BACKWARD_FACING
+                0: ROTATION_FORWARD_FACING
+                6: ROTATION_LEFT_FACING
+                2: ROTATION_RIGHT_FACING
+                100: ROTATION_CUSTOM
+            reboot_required: true
+            default: 25

--- a/src/drivers/distance_sensor/cm8jl65/module.yaml
+++ b/src/drivers/distance_sensor/cm8jl65/module.yaml
@@ -22,6 +22,5 @@ parameters:
                 0: ROTATION_FORWARD_FACING
                 6: ROTATION_LEFT_FACING
                 2: ROTATION_RIGHT_FACING
-                100: ROTATION_CUSTOM
             reboot_required: true
             default: 25

--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -113,7 +113,7 @@ void CollisionPrevention::_updateDistanceSensor(obstacle_distance_s &obstacle)
 
 			if (obstacle.increment > 0) {
 				// data from companion
-				obstacle.timestamp = math::min(obstacle.timestamp, distance_sensor.timestamp);
+				obstacle.timestamp = math::max(obstacle.timestamp, distance_sensor.timestamp);
 				obstacle.max_distance = math::max((int)obstacle.max_distance,
 								  (int)distance_sensor.max_distance * 100);
 				obstacle.min_distance = math::min((int)obstacle.min_distance,
@@ -264,13 +264,9 @@ void CollisionPrevention::_calculateConstrainedSetpoint(Vector2f &setpoint,
 		}
 
 	} else {
-		// if distance data are stale, switch to Loiter and disable Collision Prevention
-		// such that it is still possible to fly in Position Control Mode
+		// if distance data are stale, switch to Loiter
 		_publishVehicleCmdDoLoiter();
 		mavlink_log_critical(&_mavlink_log_pub, "No range data received, loitering.");
-		float col_prev_d = -1.f;
-		param_set(param_find("MPC_COL_PREV_D"), &col_prev_d);
-		mavlink_log_critical(&_mavlink_log_pub, "Collision Prevention disabled.");
 	}
 }
 

--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -160,9 +160,13 @@ void CollisionPrevention::updateDistanceSensor(obstacle_distance_s &obstacle)
 						wrap_bin = bin - distances_array_size;
 					}
 
+					// rotate vehicle attitude into the sensor body frame
+					matrix::Quatf attitude_sensor_frame = attitude;
+					attitude_sensor_frame.rotate(Vector3f(0.f, 0.f, sensor_yaw_body_rad));
+
 					// compensate measurement for vehicle tilt and convert to cm
 					obstacle.distances[wrap_bin] = math::min((int)obstacle.distances[wrap_bin],
-								       (int)(100 * distance_sensor.current_distance * cosf(Eulerf(attitude).theta())));
+								       (int)(100 * distance_sensor.current_distance * cosf(Eulerf(attitude_sensor_frame).theta())));
 				}
 			}
 		}

--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -77,6 +77,17 @@ void CollisionPrevention::publishConstrainedSetpoint(const Vector2f &original_se
 	}
 }
 
+void CollisionPrevention::publishObstacleDistance(obstacle_distance_s &obstacle)
+{
+	// publish fused obtacle distance message with data from offboard obstacle_distance and distance sensor
+	if (_obstacle_distance_pub != nullptr) {
+		orb_publish(ORB_ID(obstacle_distance_fused), _obstacle_distance_pub, &obstacle);
+
+	} else {
+		_obstacle_distance_pub = orb_advertise(ORB_ID(obstacle_distance_fused), &obstacle);
+	}
+}
+
 void CollisionPrevention::updateOffboardObstacleDistance(obstacle_distance_s &obstacle)
 {
 	_sub_obstacle_distance.update();
@@ -171,6 +182,8 @@ void CollisionPrevention::updateDistanceSensor(obstacle_distance_s &obstacle)
 			}
 		}
 	}
+
+	publishObstacleDistance(obstacle);
 }
 
 void CollisionPrevention::calculateConstrainedSetpoint(Vector2f &setpoint,

--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -125,26 +125,7 @@ void CollisionPrevention::updateDistanceSensor(obstacle_distance_s &obstacle)
 			if ((distance_sensor.current_distance > distance_sensor.min_distance) &&
 			    (distance_sensor.current_distance < distance_sensor.max_distance)) {
 
-				// init offset for sensor orientation distance_sensor_s::ROTATION_FORWARD_FACING or with offset coming from the companion
-				float sensor_yaw_body_rad = obstacle.angle_offset > 0.f ? math::radians(obstacle.angle_offset) : 0.0f;
-
-				switch (distance_sensor.orientation) {
-				case distance_sensor_s::ROTATION_RIGHT_FACING:
-					sensor_yaw_body_rad = M_PI_F / 2.0f;
-					break;
-
-				case distance_sensor_s::ROTATION_LEFT_FACING:
-					sensor_yaw_body_rad = -M_PI_F / 2.0f;
-					break;
-
-				case distance_sensor_s::ROTATION_BACKWARD_FACING:
-					sensor_yaw_body_rad = M_PI_F;
-					break;
-
-				case distance_sensor_s::ROTATION_CUSTOM:
-					sensor_yaw_body_rad = Eulerf(Quatf(distance_sensor.q)).psi();
-					break;
-				}
+				float sensor_yaw_body_rad = sensorOrientationToYawOffset(distance_sensor, obstacle.angle_offset);
 
 				matrix::Quatf attitude = Quatf(_sub_vehicle_attitude.get().q);
 				// convert the sensor orientation from body to local frame in the range [0, 360]

--- a/src/lib/CollisionPrevention/CollisionPrevention.cpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.cpp
@@ -126,7 +126,7 @@ void CollisionPrevention::_updateDistanceSensor(obstacle_distance_s &obstacle)
 				obstacle.timestamp = distance_sensor.timestamp;
 				obstacle.max_distance = distance_sensor.max_distance * 100; // convert to cm
 				obstacle.min_distance = distance_sensor.min_distance * 100; // convert to cm
-				memset(&obstacle.distances[0], UINT16_MAX, sizeof(obstacle.distances));
+				memset(&obstacle.distances[0], 0xff, sizeof(obstacle.distances));
 				obstacle.increment = math::degrees(distance_sensor.h_fov);
 				obstacle.angle_offset = 0.f;
 			}

--- a/src/lib/CollisionPrevention/CollisionPrevention.hpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.hpp
@@ -62,9 +62,18 @@ public:
 	CollisionPrevention(ModuleParams *parent);
 
 	~CollisionPrevention();
-
+	/**
+	 * Returs true if Collision Prevention is running
+	 */
 	bool is_active() { return _param_mpc_col_prev_d.get() > 0; }
 
+	/**
+	 * Computes collision free setpoints
+	 * @param original_setpoint, setpoint before collision prevention intervention
+	 * @param max_speed, maximum xy speed
+	 * @param curr_pos, current vehicle position
+	 * @param curr_vel, current vehicle velocity
+	 */
 	void modifySetpoint(matrix::Vector2f &original_setpoint, const float max_speed,
 			    const matrix::Vector2f &curr_pos, const matrix::Vector2f &curr_vel);
 
@@ -89,9 +98,12 @@ private:
 		(ParamFloat<px4::params::MPC_COL_PREV_DLY>) _param_mpc_col_prev_dly /**< delay of the range measurement data*/
 	)
 
-	void update();
-
-	inline float sensorOrientationToYawOffset(const distance_sensor_s &distance_sensor, float angle_offset)
+	/**
+	 * Transforms the sensor orientation into a yaw in the local frame
+	 * @param distance_sensor, distance sensor message
+	 * @param angle_offset, sensor body frame offset
+	 */
+	inline float _sensorOrientationToYawOffset(const distance_sensor_s &distance_sensor, float angle_offset)
 	{
 
 		float offset = angle_offset > 0.f ? math::radians(angle_offset) : 0.0f;
@@ -117,14 +129,38 @@ private:
 		return offset;
 	}
 
-	void calculateConstrainedSetpoint(matrix::Vector2f &setpoint, const matrix::Vector2f &curr_pos,
-					  const matrix::Vector2f &curr_vel);
-
-	void publishConstrainedSetpoint(const matrix::Vector2f &original_setpoint, const matrix::Vector2f &adapted_setpoint);
-	void publishObstacleDistance(obstacle_distance_s &obstacle);
-
-	void updateOffboardObstacleDistance(obstacle_distance_s &obstacle);
-	void updateDistanceSensor(obstacle_distance_s &obstacle);
+	/**
+	 * Computes collision free setpoints
+	 * @param setpoint, setpoint before collision prevention intervention
+	 * @param curr_pos, current vehicle position
+	 * @param curr_vel, current vehicle velocity
+	 */
+	void _calculateConstrainedSetpoint(matrix::Vector2f &setpoint, const matrix::Vector2f &curr_pos,
+					   const matrix::Vector2f &curr_vel);
+	/**
+	 * Publishes collision_constraints message
+	 * @param original_setpoint, setpoint before collision prevention intervention
+	 * @param adapted_setpoint, collision prevention adaped setpoint
+	 */
+	void _publishConstrainedSetpoint(const matrix::Vector2f &original_setpoint, const matrix::Vector2f &adapted_setpoint);
+	/**
+	 * Publishes obstacle_distance message with fused data from offboard and from distance sensors
+	 * @param obstacle, obstacle_distance message to be publsihed
+	 */
+	void _publishObstacleDistance(obstacle_distance_s &obstacle);
+	/**
+	 * Updates obstacle distance message with measurement from offboard
+	 * @param obstacle, obstacle_distance message to be updated
+	 */
+	void _updateOffboardObstacleDistance(obstacle_distance_s &obstacle);
+	/**
+	 * Updates obstacle distance message with measurement from distance sensors
+	 * @param obstacle, obstacle_distance message to be updated
+	 */
+	void _updateDistanceSensor(obstacle_distance_s &obstacle);
+	/**
+	 * Publishes vehicle command.
+	 */
 	void _publishVehicleCmdDoLoiter();
 
 };

--- a/src/lib/CollisionPrevention/CollisionPrevention.hpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.hpp
@@ -72,6 +72,7 @@ private:
 
 	orb_advert_t _constraints_pub{nullptr};  	/**< constraints publication */
 	orb_advert_t _mavlink_log_pub{nullptr};	 	/**< Mavlink log uORB handle */
+	orb_advert_t _obstacle_distance_pub{nullptr}; /**< obstacle_distance publication */
 
 	uORB::SubscriptionData<obstacle_distance_s> _sub_obstacle_distance{ORB_ID(obstacle_distance)}; /**< obstacle distances received form a range sensor */
 	uORB::Subscription _sub_distance_sensor[ORB_MULTI_MAX_INSTANCES] {{ORB_ID(distance_sensor), 0}, {ORB_ID(distance_sensor), 1}, {ORB_ID(distance_sensor), 2}, {ORB_ID(distance_sensor), 3}}; /**< distance data received from onboard rangefinders */
@@ -120,6 +121,7 @@ private:
 					  const matrix::Vector2f &curr_vel);
 
 	void publishConstrainedSetpoint(const matrix::Vector2f &original_setpoint, const matrix::Vector2f &adapted_setpoint);
+	void publishObstacleDistance(obstacle_distance_s &obstacle);
 
 	void updateOffboardObstacleDistance(obstacle_distance_s &obstacle);
 	void updateDistanceSensor(obstacle_distance_s &obstacle);

--- a/src/lib/CollisionPrevention/CollisionPrevention.hpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.hpp
@@ -44,8 +44,10 @@
 #include <px4_module_params.h>
 #include <float.h>
 #include <matrix/matrix/math.hpp>
+#include <uORB/topics/distance_sensor.h>
 #include <uORB/topics/obstacle_distance.h>
 #include <uORB/topics/collision_constraints.h>
+#include <uORB/topics/vehicle_attitude.h>
 #include <mathlib/mathlib.h>
 #include <drivers/drv_hrt.h>
 #include <uORB/topics/mavlink_log.h>
@@ -72,6 +74,8 @@ private:
 	orb_advert_t _mavlink_log_pub{nullptr};	 	/**< Mavlink log uORB handle */
 
 	uORB::SubscriptionData<obstacle_distance_s> _sub_obstacle_distance{ORB_ID(obstacle_distance)}; /**< obstacle distances received form a range sensor */
+	uORB::Subscription _sub_distance_sensor[ORB_MULTI_MAX_INSTANCES] {{ORB_ID(distance_sensor), 0}, {ORB_ID(distance_sensor), 1}, {ORB_ID(distance_sensor), 2}, {ORB_ID(distance_sensor), 3}}; /**< distance data received from onboard rangefinders */
+	uORB::SubscriptionData<vehicle_attitude_s> _sub_vehicle_attitude{ORB_ID(vehicle_attitude)};
 
 	static constexpr uint64_t RANGE_STREAM_TIMEOUT_US{500000};
 	static constexpr uint64_t MESSAGE_THROTTLE_US{5000000};
@@ -90,5 +94,8 @@ private:
 					  const matrix::Vector2f &curr_vel);
 
 	void publishConstrainedSetpoint(const matrix::Vector2f &original_setpoint, const matrix::Vector2f &adapted_setpoint);
+
+	void updateOffboardObstacleDistance(obstacle_distance_s &obstacle);
+	void updateDistanceSensor(obstacle_distance_s &obstacle);
 
 };

--- a/src/lib/CollisionPrevention/CollisionPrevention.hpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.hpp
@@ -90,6 +90,32 @@ private:
 
 	void update();
 
+	inline float sensorOrientationToYawOffset(const distance_sensor_s &distance_sensor, float angle_offset)
+	{
+
+		float offset = angle_offset > 0.f ? math::radians(angle_offset) : 0.0f;
+
+		switch (distance_sensor.orientation) {
+		case distance_sensor_s::ROTATION_RIGHT_FACING:
+			offset = M_PI_F / 2.0f;
+			break;
+
+		case distance_sensor_s::ROTATION_LEFT_FACING:
+			offset = -M_PI_F / 2.0f;
+			break;
+
+		case distance_sensor_s::ROTATION_BACKWARD_FACING:
+			offset = M_PI_F;
+			break;
+
+		case distance_sensor_s::ROTATION_CUSTOM:
+			offset = matrix::Eulerf(matrix::Quatf(distance_sensor.q)).psi();
+			break;
+		}
+
+		return offset;
+	}
+
 	void calculateConstrainedSetpoint(matrix::Vector2f &setpoint, const matrix::Vector2f &curr_pos,
 					  const matrix::Vector2f &curr_vel);
 

--- a/src/lib/CollisionPrevention/CollisionPrevention.hpp
+++ b/src/lib/CollisionPrevention/CollisionPrevention.hpp
@@ -48,11 +48,13 @@
 #include <uORB/topics/obstacle_distance.h>
 #include <uORB/topics/collision_constraints.h>
 #include <uORB/topics/vehicle_attitude.h>
+#include <uORB/topics/vehicle_command.h>
 #include <mathlib/mathlib.h>
 #include <drivers/drv_hrt.h>
 #include <uORB/topics/mavlink_log.h>
 #include <uORB/Subscription.hpp>
 #include <systemlib/mavlink_log.h>
+#include <commander/px4_custom_mode.h>
 
 class CollisionPrevention : public ModuleParams
 {
@@ -73,15 +75,13 @@ private:
 	orb_advert_t _constraints_pub{nullptr};  	/**< constraints publication */
 	orb_advert_t _mavlink_log_pub{nullptr};	 	/**< Mavlink log uORB handle */
 	orb_advert_t _obstacle_distance_pub{nullptr}; /**< obstacle_distance publication */
+	orb_advert_t _pub_vehicle_command{nullptr}; /**< vehicle command do publication */
 
 	uORB::SubscriptionData<obstacle_distance_s> _sub_obstacle_distance{ORB_ID(obstacle_distance)}; /**< obstacle distances received form a range sensor */
 	uORB::Subscription _sub_distance_sensor[ORB_MULTI_MAX_INSTANCES] {{ORB_ID(distance_sensor), 0}, {ORB_ID(distance_sensor), 1}, {ORB_ID(distance_sensor), 2}, {ORB_ID(distance_sensor), 3}}; /**< distance data received from onboard rangefinders */
 	uORB::SubscriptionData<vehicle_attitude_s> _sub_vehicle_attitude{ORB_ID(vehicle_attitude)};
 
 	static constexpr uint64_t RANGE_STREAM_TIMEOUT_US{500000};
-	static constexpr uint64_t MESSAGE_THROTTLE_US{5000000};
-
-	hrt_abstime _last_message{0};
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::MPC_COL_PREV_D>) _param_mpc_col_prev_d, /**< collision prevention keep minimum distance */
@@ -125,5 +125,6 @@ private:
 
 	void updateOffboardObstacleDistance(obstacle_distance_s &obstacle);
 	void updateDistanceSensor(obstacle_distance_s &obstacle);
+	void _publishVehicleCmdDoLoiter();
 
 };

--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -708,7 +708,7 @@ void Logger::add_sensor_comparison_topics()
 void Logger::add_vision_and_avoidance_topics()
 {
 	add_topic("collision_constraints");
-	add_topic("obstacle_distance");
+	add_topic("obstacle_distance_fused");
 	add_topic("vehicle_mocap_odometry", 30);
 	add_topic("vehicle_trajectory_waypoint", 200);
 	add_topic("vehicle_trajectory_waypoint_desired", 200);

--- a/src/modules/mavlink/mavlink_messages.cpp
+++ b/src/modules/mavlink/mavlink_messages.cpp
@@ -74,6 +74,7 @@
 #include <uORB/topics/manual_control_setpoint.h>
 #include <uORB/topics/mavlink_log.h>
 #include <uORB/topics/vehicle_trajectory_waypoint.h>
+#include <uORB/topics/obstacle_distance.h>
 #include <uORB/topics/optical_flow.h>
 #include <uORB/topics/orbit_status.h>
 #include <uORB/topics/position_controller_status.h>
@@ -4834,6 +4835,80 @@ protected:
 	}
 };
 
+class MavlinkStreamObstacleDistance : public MavlinkStream
+{
+public:
+	const char *get_name() const
+	{
+		return MavlinkStreamObstacleDistance::get_name_static();
+	}
+
+	static const char *get_name_static()
+	{
+		return "OBSTACLE_DISTANCE";
+	}
+
+	static uint16_t get_id_static()
+	{
+		return MAVLINK_MSG_ID_OBSTACLE_DISTANCE;
+	}
+
+	uint16_t get_id()
+	{
+		return get_id_static();
+	}
+
+	static MavlinkStream *new_instance(Mavlink *mavlink)
+	{
+		return new MavlinkStreamObstacleDistance(mavlink);
+	}
+
+	unsigned get_size()
+	{
+		return _obstacle_distance_fused_sub->is_published() ? (MAVLINK_MSG_ID_OBSTACLE_DISTANCE_LEN +
+				MAVLINK_NUM_NON_PAYLOAD_BYTES) :
+		       0;
+	}
+
+private:
+	MavlinkOrbSubscription *_obstacle_distance_fused_sub;
+	uint64_t _obstacle_distance_time;
+
+	/* do not allow top copying this class */
+	MavlinkStreamObstacleDistance(MavlinkStreamObstacleDistance &) = delete;
+	MavlinkStreamObstacleDistance &operator = (const MavlinkStreamObstacleDistance &) = delete;
+
+protected:
+	explicit MavlinkStreamObstacleDistance(Mavlink *mavlink) : MavlinkStream(mavlink),
+		_obstacle_distance_fused_sub(_mavlink->add_orb_subscription(ORB_ID(obstacle_distance_fused))),
+		_obstacle_distance_time(0)
+	{}
+
+	bool send(const hrt_abstime t)
+	{
+		obstacle_distance_s obstacke_distance;
+
+		if (_obstacle_distance_fused_sub->update(&_obstacle_distance_time, &obstacke_distance)) {
+			mavlink_obstacle_distance_t msg = {};
+
+			msg.time_usec = obstacke_distance.timestamp;
+			msg.sensor_type = obstacke_distance.sensor_type;
+			memcpy(msg.distances, obstacke_distance.distances, sizeof(msg.distances));
+			msg.increment = 0;
+			msg.min_distance = obstacke_distance.min_distance;
+			msg.max_distance = obstacke_distance.max_distance;
+			msg.angle_offset = obstacke_distance.angle_offset;
+			msg.increment_f = obstacke_distance.increment;
+
+			mavlink_msg_obstacle_distance_send_struct(_mavlink->get_channel(), &msg);
+
+			return true;
+		}
+
+		return false;
+	}
+};
+
 static const StreamListItem streams_list[] = {
 	StreamListItem(&MavlinkStreamHeartbeat::new_instance, &MavlinkStreamHeartbeat::get_name_static, &MavlinkStreamHeartbeat::get_id_static),
 	StreamListItem(&MavlinkStreamStatustext::new_instance, &MavlinkStreamStatustext::get_name_static, &MavlinkStreamStatustext::get_id_static),
@@ -4891,7 +4966,8 @@ static const StreamListItem streams_list[] = {
 	StreamListItem(&MavlinkStreamHighLatency2::new_instance, &MavlinkStreamHighLatency2::get_name_static, &MavlinkStreamHighLatency2::get_id_static),
 	StreamListItem(&MavlinkStreamGroundTruth::new_instance, &MavlinkStreamGroundTruth::get_name_static, &MavlinkStreamGroundTruth::get_id_static),
 	StreamListItem(&MavlinkStreamPing::new_instance, &MavlinkStreamPing::get_name_static, &MavlinkStreamPing::get_id_static),
-	StreamListItem(&MavlinkStreamOrbitStatus::new_instance, &MavlinkStreamOrbitStatus::get_name_static, &MavlinkStreamOrbitStatus::get_id_static)
+	StreamListItem(&MavlinkStreamOrbitStatus::new_instance, &MavlinkStreamOrbitStatus::get_name_static, &MavlinkStreamOrbitStatus::get_id_static),
+	StreamListItem(&MavlinkStreamObstacleDistance::new_instance, &MavlinkStreamObstacleDistance::get_name_static, &MavlinkStreamObstacleDistance::get_id_static)
 };
 
 const char *get_stream_name(const uint16_t msg_id)

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1677,9 +1677,17 @@ MavlinkReceiver::handle_message_obstacle_distance(mavlink_message_t *msg)
 	obstacle_distance.timestamp = hrt_absolute_time();
 	obstacle_distance.sensor_type = mavlink_obstacle_distance.sensor_type;
 	memcpy(obstacle_distance.distances, mavlink_obstacle_distance.distances, sizeof(obstacle_distance.distances));
-	obstacle_distance.increment = mavlink_obstacle_distance.increment;
+
+	if (mavlink_obstacle_distance.increment_f > 0.f) {
+		obstacle_distance.increment = mavlink_obstacle_distance.increment_f;
+
+	} else {
+		obstacle_distance.increment = (float)mavlink_obstacle_distance.increment;
+	}
+
 	obstacle_distance.min_distance = mavlink_obstacle_distance.min_distance;
 	obstacle_distance.max_distance = mavlink_obstacle_distance.max_distance;
+	obstacle_distance.angle_offset = mavlink_obstacle_distance.angle_offset;
 
 	if (_obstacle_distance_pub == nullptr) {
 		_obstacle_distance_pub = orb_advertise(ORB_ID(obstacle_distance), &obstacle_distance);

--- a/src/modules/mc_pos_control/CMakeLists.txt
+++ b/src/modules/mc_pos_control/CMakeLists.txt
@@ -37,7 +37,7 @@ px4_add_module(
 	MODULE modules__mc_pos_control
 	MAIN mc_pos_control
 	COMPILE_FLAGS
-	STACK_MAIN 1200
+	STACK_MAIN 1300
 	SRCS
 		mc_pos_control_main.cpp
 		PositionControl.cpp

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -1090,6 +1090,13 @@ int Simulator::publish_distance_topic(const mavlink_distance_sensor_t *dist_mavl
 	dist.variance = dist_mavlink->covariance * 1e-4f; // cm^2 to m^2
 	dist.signal_quality = -1;
 
+	dist.h_fov = dist_mavlink->horizontal_fov;
+	dist.v_fov = dist_mavlink->vertical_fov;
+	dist.q[0] = dist_mavlink->quaternion[0];
+	dist.q[1] = dist_mavlink->quaternion[1];
+	dist.q[2] = dist_mavlink->quaternion[2];
+	dist.q[3] = dist_mavlink->quaternion[3];
+
 	int dist_multi;
 	orb_publish_auto(ORB_ID(distance_sensor), &_dist_pub, &dist, &dist_multi, ORB_PRIO_HIGH);
 


### PR DESCRIPTION
Replacement for  #10998

Changes:
- map distance_sensor data to obstacle_distance message (Collision Prevention now supports range data from distance sensor only, companion computer only, both companion and distance sensor)
- start `cm8jl65` distance sensor with an orientation set by a parameter 
- add failsafe if the range data are stale. Go first into loiter