### PR TITLE
Add Param "User Flight Profile"

### DIFF
--- a/src/modules/commander/Commander.hpp
+++ b/src/modules/commander/Commander.hpp
@@ -127,7 +127,8 @@ private:
 		(ParamInt<px4::params::COM_TAS_FS_T2>) _tas_use_start_delay,
 		(ParamInt<px4::params::COM_ASPD_FS_ACT>) _airspeed_fail_action,
 		(ParamFloat<px4::params::COM_ASPD_STALL>) _airspeed_stall,
-		(ParamInt<px4::params::COM_ASPD_FS_DLY>) _airspeed_rtl_delay
+		(ParamInt<px4::params::COM_ASPD_FS_DLY>) _airspeed_rtl_delay,
+		(ParamInt<px4::params::COM_FLT_PROFILE>) _param_com_flt_profile
 
 	)
 

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -914,13 +914,11 @@ PARAM_DEFINE_INT32(COM_ASPD_FS_DLY, 0);
  * Can be used by ground control software or log post processing.
  * This param does not influence the behavior within the firmware. This means for example the control logic is independent of the setting of this param (but depends on other params).
  *
- * 0: Default
- * 100: Pro User
- * 200: Flight Tester
- * 300: Developer
+ * @value 0 Default
+ * @value 100 Pro User
+ * @value 200 Flight Tester
+ * @value 300 Developer
  *
- * @min 0
- * @max 1000
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_FLT_PROFILE, 0);

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -907,3 +907,20 @@ PARAM_DEFINE_INT32(COM_ASPD_FS_ACT, 0);
  */
 PARAM_DEFINE_INT32(COM_ASPD_FS_DLY, 0);
 
+/**
+ * User Flight Profile
+ *
+ * Describes the intended use of the vehicle.
+ * Can be used by ground control software or log post processing.
+ * This param does not influence the behavior within the firmware. This means for example the control logic is independent of the setting of this param (but depends on other params).
+ *
+ * 0: Default
+ * 100: Pro User
+ * 200: Flight Tester
+ * 300: Developer
+ *
+ * @min 0
+ * @max 1000
+ * @group Commander
+ */
+PARAM_DEFINE_INT32(COM_FLT_PROFILE, 0);


### PR DESCRIPTION
This param has no effect within the Firmware.

The param can be used for example:

* in log post processing to have context about the flight
* in ground stations to adapt the UI automatically


**Test data / coverage**
I started sitl and checked that the param appears in QGC. I changed the param and uploaded the .ulg file to logs.px4.io and verified that the changed param appears in the analysis.
