### PR TITLE
logger: fix uninitialized member variable

### DIFF
--- a/src/modules/logger/logger.h
+++ b/src/modules/logger/logger.h
@@ -405,7 +405,7 @@ private:
 											will be stopped after load printing (for the full log) */
 	print_load_s					_load{}; ///< process load data
 	hrt_abstime					_next_load_print{0}; ///< timestamp when to print the process load
-	PrintLoadReason					_print_load_reason;
+	PrintLoadReason					_print_load_reason {PrintLoadReason::Preflight};
 
 	param_t						_sdlog_profile_handle{PARAM_INVALID};
 	param_t						_log_utc_offset{PARAM_INVALID};


### PR DESCRIPTION
This was reported by Coverity Scan:

```
*** CID 341231: Uninitialized members (UNINIT_CTOR)
/src/modules/logger/logger.cpp: 457 in px4::logger::Logger::Logger(unsigned char, unsigned long, unsigned int, const char *, px4::logger::Logger::LogMode, bool, unsigned int)()
451 }
452
453 if (!_polling_topic_meta) {
454 PX4_ERR("Failed to find topic %s", poll_topic_name);
455 }
456 }
>>> CID 341231: Uninitialized members (UNINIT_CTOR)
>>> Non-static class member "_print_load_reason" is not initialized in this constructor nor in any functions that it calls.
457 }
458
459 Logger::~Logger()
460 {
461 if (_replay_file_name) {
462 free(_replay_file_name);
```

