### PR TITLE
mc_att_control: fix vehicle_rates_setpoint_poll() error due to merge timing

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -687,10 +687,9 @@ MulticopterAttitudeControl::run()
 					}
 
 					control_attitude();
-					if (_v_control_mode.flag_control_yawrate_override_enabled)
-					{
+					if (_v_control_mode.flag_control_yawrate_override_enabled) {
 						/* Yaw rate override enabled, overwrite the yaw setpoint */
-						vehicle_rates_setpoint_poll();
+						_v_rates_sp_sub.update(&_v_rates_sp);
 						const auto yawrate_reference = _v_rates_sp.yaw;
 						_rates_sp(2) = yawrate_reference;
 					}


### PR DESCRIPTION
Due to the timing of  https://github.com/PX4/Firmware/pull/12061 and https://github.com/PX4/Firmware/pull/12120 merging the result in master was broken. This PR fixes mc_att_control, but really we should be doing something to enforce that the contents of branches are up to date before merging.