### PR TITLE
SYS_MC_EST_GROUP: add q-estimator option

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -65,7 +65,9 @@ fi
 
 
 # Use environment variable PX4_ESTIMATOR to choose estimator.
-if [ "$PX4_ESTIMATOR" = "ekf2" ]; then
+if [ "$PX4_ESTIMATOR" = "q" ]; then
+	param set SYS_MC_EST_GROUP 3
+elif [ "$PX4_ESTIMATOR" = "ekf2" ]; then
 	param set SYS_MC_EST_GROUP 2
 elif [ "$PX4_ESTIMATOR" = "lpe" ]; then
 	param set SYS_MC_EST_GROUP 1

--- a/ROMFS/px4fmu_common/init.d/rc.mc_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_apps
@@ -30,10 +30,18 @@ then
 	fi
 else
 	#
-	# EKF2
+	# Q estimator (attitude estimation only)
 	#
-	param set SYS_MC_EST_GROUP 2
-	ekf2 start
+	if param compare SYS_MC_EST_GROUP 3
+	then
+		attitude_estimator_q start
+	else
+		#
+		# EKF2
+		#
+		param set SYS_MC_EST_GROUP 2
+		ekf2 start
+	fi
 fi
 
 ###############################################################################

--- a/boards/intel/aerofc-v1/init/rc.board_defaults
+++ b/boards/intel/aerofc-v1/init/rc.board_defaults
@@ -13,21 +13,6 @@ fi
 # other configurations.
 param set SYS_AUTOSTART 4070
 
-if [ $AUTOCNF = yes ]
-then
-	# Disable safety switch by default
-	param set CBRK_IO_SAFETY 22027
-
-	# use the Q attitude estimator, it works w/o mag or GPS.
-	param set SYS_MC_EST_GROUP 1
-	param set ATT_ACC_COMP 0
-	param set ATT_W_ACC 0.4000
-	param set ATT_W_GYRO_BIAS 0.0000
-
-	param set SYS_HAS_MAG 0
-fi
-
-
 set DATAMAN_OPT -i
 set LOGGER_ARGS "-m mavlink"
 set MIXER_AUX none

--- a/boards/omnibus/f4sd/default.cmake
+++ b/boards/omnibus/f4sd/default.cmake
@@ -72,6 +72,7 @@ px4_add_board(
 
 	SYSTEMCMDS
 		#bl_update
+		dmesg
 		config
 		dumpfile
 		esc_calib

--- a/boards/omnibus/f4sd/init/rc.board_defaults
+++ b/boards/omnibus/f4sd/init/rc.board_defaults
@@ -4,6 +4,12 @@
 #------------------------------------------------------------------------------
 
 
+# transition from LPE+Q to Q estimator (2019-06-05)
+if param compare SYS_MC_EST_GROUP 1
+then
+	param set SYS_MC_EST_GROUP 3
+fi
+
 
 if [ $AUTOCNF = yes ]
 then
@@ -11,7 +17,7 @@ then
 	param set CBRK_IO_SAFETY 22027
 
 	# use the Q attitude estimator, it works w/o mag or GPS.
-	param set SYS_MC_EST_GROUP 1
+	param set SYS_MC_EST_GROUP 3
 	param set ATT_ACC_COMP 0
 	param set ATT_W_ACC 0.4000
 	param set ATT_W_GYRO_BIAS 0.0000

--- a/boards/omnibus/f4sd/init/rc.board_defaults
+++ b/boards/omnibus/f4sd/init/rc.board_defaults
@@ -4,15 +4,6 @@
 #------------------------------------------------------------------------------
 
 
-# transition from params file to flash-based params (2018-12-20)
-if [ -f $PARAM_FILE ]
-then
-	param load $PARAM_FILE
-	param save
-	# create a backup
-	mv $PARAM_FILE ${PARAM_FILE}.bak
-	reboot
-fi
 
 if [ $AUTOCNF = yes ]
 then

--- a/boards/omnibus/f4sd/src/board_config.h
+++ b/boards/omnibus/f4sd/src/board_config.h
@@ -264,6 +264,9 @@
 
 #define BOARD_HAS_ON_RESET 1
 
+#define BOARD_ENABLE_CONSOLE_BUFFER
+#define BOARD_CONSOLE_BUFFER_SIZE (1024*3)
+
 __BEGIN_DECLS
 
 /****************************************************************************************************

--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -102,9 +102,8 @@ PARAM_DEFINE_INT32(SYS_RESTART_TYPE, 2);
  *
  * @value 1 local_position_estimator, attitude_estimator_q (unsupported)
  * @value 2 ekf2 (recommended)
+ * @value 3 Q attitude estimator (no position)
  *
- * @min 1
- * @max 2
  * @reboot_required true
  * @group System
  */


### PR DESCRIPTION
Since we deprecated Q+LPE.

Activated on omnibus, and we can now also enable the dmesg buffer there.