### PR TITLE
param compare/greater: do not print 'parameter not found' message

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.logging
+++ b/ROMFS/px4fmu_common/init.d/rc.logging
@@ -4,13 +4,10 @@
 # NOTE: Script variables are declared/initialized/unset in the rcS script.
 #
 
-if ! ver hwcmp PX4_SITL
+if param greater UAVCAN_ENABLE 1
 then
-	if param greater UAVCAN_ENABLE 1
-	then
-		# Reduce logger buffer to free up some RAM for UAVCAN servers.
-		set LOGGER_BUF 6
-	fi
+	# Reduce logger buffer to free up some RAM for UAVCAN servers.
+	set LOGGER_BUF 6
 fi
 
 ###############################################################################

--- a/src/systemcmds/param/param.cpp
+++ b/src/systemcmds/param/param.cpp
@@ -709,7 +709,7 @@ do_compare(const char *name, char *vals[], unsigned comparisons, enum COMPARE_OP
 	/* set nothing if parameter cannot be found */
 	if (param == PARAM_INVALID) {
 		/* param not found */
-		PX4_ERR("Parameter %s not found", name);
+		PX4_DEBUG("Parameter %s not found", name);
 		return 1;
 	}
 


### PR DESCRIPTION
Reduces clutter in the boot output (now that we have it in the log).
On omnibus for example we see:
```
ERROR [param] Parameter SENS_EN_BATT not found
ERROR [param] Parameter SENS_EN_LL40LS not found
ERROR [param] Parameter SENS_EN_LL40LS not found
ERROR [param] Parameter SENS_EN_MB12XX not found
ERROR [param] Parameter SENS_EN_PGA460 not found
ERROR [param] Parameter SENS_EN_SF1XX not found
ERROR [param] Parameter SENS_EN_TRANGER not found
```

Especially in the drivers there is more cleanup we can do.