### PR TITLE
uORB Subscription callbacks with WorkItem scheduling on publication

### DIFF
--- a/src/modules/uORB/Subscription.hpp
+++ b/src/modules/uORB/Subscription.hpp
@@ -48,6 +48,8 @@
 namespace uORB
 {
 
+class SubscriptionCallback;
+
 // Base subscription wrapper class
 class Subscription
 {
@@ -106,6 +108,10 @@ public:
 	orb_id_t	get_topic() const { return _meta; }
 
 protected:
+
+	friend class SubscriptionCallback;
+
+	DeviceNode	*get_node() { return _node; }
 
 	bool subscribe();
 	void unsubscribe();

--- a/src/modules/uORB/SubscriptionCallback.hpp
+++ b/src/modules/uORB/SubscriptionCallback.hpp
@@ -1,0 +1,136 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file SubscriptionCallback.hpp
+ *
+ */
+
+#pragma once
+
+#include <uORB/SubscriptionInterval.hpp>
+#include <containers/List.hpp>
+#include <px4_work_queue/WorkItem.hpp>
+
+namespace uORB
+{
+
+// Subscription wrapper class with callbacks on new publications
+class SubscriptionCallback : public SubscriptionInterval, public ListNode<SubscriptionCallback *>
+{
+public:
+	/**
+	 * Constructor
+	 *
+	 * @param meta The uORB metadata (usually from the ORB_ID() macro) for the topic.
+	 * @param instance The instance for multi sub.
+	 */
+	SubscriptionCallback(const orb_metadata *meta, uint8_t interval_ms = 0, uint8_t instance = 0) :
+		SubscriptionInterval(meta, interval_ms, instance)
+	{
+	}
+
+	virtual ~SubscriptionCallback()
+	{
+		unregister_callback();
+	};
+
+	bool register_callback()
+	{
+		bool ret = false;
+
+		if (_subscription.get_node() && _subscription.get_node()->register_callback(this)) {
+			// registered
+			ret = true;
+
+		} else {
+			// force topic creation by subscribing with old API
+			int fd = orb_subscribe_multi(_subscription.get_topic(), _subscription.get_instance());
+
+			// try to register callback again
+			if (_subscription.forceInit()) {
+				if (_subscription.get_node() && _subscription.get_node()->register_callback(this)) {
+					ret = true;
+				}
+			}
+
+			orb_unsubscribe(fd);
+		}
+
+
+		return ret;
+	}
+
+	void unregister_callback()
+	{
+		if (_subscription.get_node()) {
+			_subscription.get_node()->unregister_callback(this);
+		}
+	}
+
+	virtual void call() = 0;
+
+};
+
+// Subscription with callback that schedules a WorkItem
+class SubscriptionCallbackWorkItem : public SubscriptionCallback
+{
+public:
+	/**
+	 * Constructor
+	 *
+	 * @param work_item The WorkItem that will be scheduled immediately on new publications.
+	 * @param meta The uORB metadata (usually from the ORB_ID() macro) for the topic.
+	 * @param instance The instance for multi sub.
+	 */
+	SubscriptionCallbackWorkItem(px4::WorkItem *work_item, const orb_metadata *meta, uint8_t instance = 0) :
+		SubscriptionCallback(meta, 0, instance),	// interval 0
+		_work_item(work_item)
+	{
+	}
+
+	virtual ~SubscriptionCallbackWorkItem() = default;
+
+	void call() override
+	{
+		// schedule immediately if no interval, otherwise check time elapsed
+		if ((_interval == 0) || (hrt_elapsed_time(&_last_update) >= _interval)) {
+			_work_item->ScheduleNow();
+		}
+	}
+
+private:
+	px4::WorkItem *_work_item;
+};
+
+} // namespace uORB

--- a/src/modules/uORB/SubscriptionInterval.hpp
+++ b/src/modules/uORB/SubscriptionInterval.hpp
@@ -1,0 +1,133 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file SubscriptionInterval.hpp
+ *
+ */
+
+#pragma once
+
+#include <uORB/uORB.h>
+#include <px4_defines.h>
+
+#include "uORBDeviceNode.hpp"
+#include "uORBManager.hpp"
+#include "uORBUtils.hpp"
+
+#include "Subscription.hpp"
+
+namespace uORB
+{
+
+// Base subscription wrapper class
+class SubscriptionInterval
+{
+public:
+
+	/**
+	 * Constructor
+	 *
+	 * @param meta The uORB metadata (usually from the ORB_ID() macro) for the topic.
+	 * @param interval The requested maximum update interval in microseconds.
+	 * @param instance The instance for multi sub.
+	 */
+	SubscriptionInterval(const orb_metadata *meta, uint32_t interval_us = 0, uint8_t instance = 0) :
+		_subscription{meta, instance},
+		_interval(interval_us)
+	{}
+
+	SubscriptionInterval() : _subscription{nullptr} {}
+
+	~SubscriptionInterval() = default;
+
+	bool published() { return _subscription.published(); }
+
+	/**
+	 * Check if there is a new update.
+	 * */
+	bool updated()
+	{
+		if (published() && (hrt_elapsed_time(&_last_update) >= _interval)) {
+			return _subscription.updated();
+		}
+
+		return false;
+	}
+
+	/**
+	 * Copy the struct if updated.
+	 * @param dst The destination pointer where the struct will be copied.
+	 * @return true only if topic was updated and copied successfully.
+	 */
+	bool update(void *dst)
+	{
+		if (updated()) {
+			return copy(dst);
+		}
+
+		return false;
+	}
+
+	/**
+	 * Copy the struct
+	 * @param dst The destination pointer where the struct will be copied.
+	 * @return true only if topic was copied successfully.
+	 */
+	bool copy(void *dst)
+	{
+		if (_subscription.copy(dst)) {
+			_last_update = hrt_absolute_time();
+			return true;
+		}
+
+		return false;
+	}
+
+	bool		valid() const { return _subscription.valid(); }
+
+	uint8_t		get_instance() const { return _subscription.get_instance(); }
+	orb_id_t	get_topic() const { return _subscription.get_topic(); }
+	uint32_t	get_interval() const { return _interval; }
+
+	void		set_interval(uint32_t interval) { _interval = interval; }
+
+protected:
+
+	Subscription	_subscription;
+	uint64_t	_last_update{0};	// last update in microseconds
+	uint32_t	_interval{0};		// maximum update interval in microseconds
+
+};
+
+} // namespace uORB

--- a/src/modules/uORB/uORBDeviceNode.cpp
+++ b/src/modules/uORB/uORBDeviceNode.cpp
@@ -37,6 +37,8 @@
 #include "uORBUtils.hpp"
 #include "uORBManager.hpp"
 
+#include "SubscriptionCallback.hpp"
+
 #ifdef ORB_COMMUNICATOR
 #include "uORBCommunicator.hpp"
 #endif /* ORB_COMMUNICATOR */
@@ -316,6 +318,11 @@ uORB::DeviceNode::write(cdev::file_t *filp, const char *buffer, size_t buflen)
 	_generation++;
 
 	_published = true;
+
+	// callbacks
+	for (auto item : _callbacks) {
+		item->call();
+	}
 
 	ATOMIC_LEAVE;
 
@@ -672,4 +679,34 @@ int uORB::DeviceNode::update_queue_size(unsigned int queue_size)
 
 	_queue_size = queue_size;
 	return PX4_OK;
+}
+
+bool
+uORB::DeviceNode::register_callback(uORB::SubscriptionCallback *callback_sub)
+{
+	if (callback_sub != nullptr) {
+		ATOMIC_ENTER;
+
+		// prevent duplicate registrations
+		for (auto existing_callbacks : _callbacks) {
+			if (callback_sub == existing_callbacks) {
+				ATOMIC_LEAVE;
+				return true;
+			}
+		}
+
+		_callbacks.add(callback_sub);
+		ATOMIC_LEAVE;
+		return true;
+	}
+
+	return false;
+}
+
+void
+uORB::DeviceNode::unregister_callback(uORB::SubscriptionCallback *callback_sub)
+{
+	ATOMIC_ENTER;
+	_callbacks.remove(callback_sub);
+	ATOMIC_LEAVE;
 }

--- a/src/modules/uORB/uORBDeviceNode.hpp
+++ b/src/modules/uORB/uORBDeviceNode.hpp
@@ -45,6 +45,7 @@ namespace uORB
 class DeviceNode;
 class DeviceMaster;
 class Manager;
+class SubscriptionCallback;
 }
 
 /**
@@ -231,6 +232,12 @@ public:
 	 */
 	uint64_t copy_and_get_timestamp(void *dst, unsigned &generation);
 
+	// add item to list of work items to schedule on node update
+	bool register_callback(SubscriptionCallback *callback_sub);
+
+	// remove item from list of work items
+	void unregister_callback(SubscriptionCallback *callback_sub);
+
 protected:
 
 	pollevent_t poll_state(cdev::file_t *filp) override;
@@ -269,6 +276,7 @@ private:
 	uint8_t     *_data{nullptr};   /**< allocated object buffer */
 	hrt_abstime   _last_update{0}; /**< time the object was last updated */
 	volatile unsigned   _generation{0};  /**< object generation count */
+	List<uORB::SubscriptionCallback *>	_callbacks;
 	uint8_t   _priority;  /**< priority of the topic */
 	bool _published{false};  /**< has ever data been published */
 	uint8_t _queue_size; /**< maximum number of elements in the queue */

--- a/src/platforms/common/px4_work_queue/WorkItem.cpp
+++ b/src/platforms/common/px4_work_queue/WorkItem.cpp
@@ -49,8 +49,16 @@ WorkItem::WorkItem(const wq_config_t &config)
 	}
 }
 
+WorkItem::~WorkItem()
+{
+	Deinit();
+}
+
 bool WorkItem::Init(const wq_config_t &config)
 {
+	// clear any existing first
+	Deinit();
+
 	px4::WorkQueue *wq = WorkQueueFindOrCreate(config);
 
 	if (wq == nullptr) {
@@ -62,6 +70,18 @@ bool WorkItem::Init(const wq_config_t &config)
 	}
 
 	return false;
+}
+
+void WorkItem::Deinit()
+{
+	// remove any currently queued work
+	if (_wq != nullptr) {
+		// prevent additional insertions
+		px4::WorkQueue *wq_temp = _wq;
+		_wq = nullptr;
+
+		wq_temp->Remove(this);
+	}
 }
 
 } // namespace px4

--- a/src/platforms/common/px4_work_queue/WorkItem.hpp
+++ b/src/platforms/common/px4_work_queue/WorkItem.hpp
@@ -51,7 +51,7 @@ public:
 	explicit WorkItem(const wq_config_t &config);
 	WorkItem() = delete;
 
-	virtual ~WorkItem() = default;
+	virtual ~WorkItem();
 
 	inline void ScheduleNow() { if (_wq != nullptr) _wq->Add(this); }
 
@@ -60,6 +60,7 @@ public:
 protected:
 
 	bool Init(const wq_config_t &config);
+	void Deinit();
 
 private:
 

--- a/src/platforms/common/px4_work_queue/WorkQueue.cpp
+++ b/src/platforms/common/px4_work_queue/WorkQueue.cpp
@@ -74,12 +74,32 @@ WorkQueue::~WorkQueue()
 
 void WorkQueue::Add(WorkItem *item)
 {
+	// TODO: prevent additions when shutting down
+
 	work_lock();
 	_q.push(item);
 	work_unlock();
 
 	// Wake up the worker thread
 	px4_sem_post(&_process_lock);
+}
+
+void WorkQueue::Remove(WorkItem *item)
+{
+	work_lock();
+	_q.remove(item);
+	work_unlock();
+}
+
+void WorkQueue::Clear()
+{
+	work_lock();
+
+	while (!_q.empty()) {
+		_q.pop();
+	}
+
+	work_unlock();
 }
 
 void WorkQueue::Run()

--- a/src/platforms/common/px4_work_queue/WorkQueue.hpp
+++ b/src/platforms/common/px4_work_queue/WorkQueue.hpp
@@ -58,10 +58,9 @@ public:
 	const char *get_name() { return _config.name; }
 
 	void Add(WorkItem *item);
+	void Remove(WorkItem *item);
 
-	// TODO: need helpers to handle clean shutdown - remove and clear?
-	//void remove(WorkItem *item);
-	//void clear();
+	void Clear();
 
 	void Run();
 

--- a/src/platforms/common/px4_work_queue/WorkQueueManager.cpp
+++ b/src/platforms/common/px4_work_queue/WorkQueueManager.cpp
@@ -198,19 +198,26 @@ static void WorkQueueManagerRun()
 			}
 
 			// stack size
+#ifndef __PX4_QURT
 			const size_t stacksize = math::max(PTHREAD_STACK_MIN, PX4_STACK_ADJUSTED(wq->stacksize));
+#else
+			const size_t stacksize = math::max(8 * 1024, PX4_STACK_ADJUSTED(wq->stacksize));
+#endif
 			int ret_setstacksize = pthread_attr_setstacksize(&attr, stacksize);
 
 			if (ret_setstacksize != 0) {
 				PX4_ERR("setting stack size for %s failed (%i)", wq->name, ret_setstacksize);
 			}
 
+#ifndef __PX4_QURT
 			// schedule policy FIFO
 			int ret_setschedpolicy = pthread_attr_setschedpolicy(&attr, SCHED_FIFO);
 
 			if (ret_setschedpolicy != 0) {
 				PX4_ERR("failed to set sched policy SCHED_FIFO (%i)", ret_setschedpolicy);
 			}
+
+#endif // ! QuRT
 
 			// priority
 			param.sched_priority = sched_get_priority_max(SCHED_FIFO) + wq->relative_priority;

--- a/src/platforms/common/px4_work_queue/WorkQueueManager.hpp
+++ b/src/platforms/common/px4_work_queue/WorkQueueManager.hpp
@@ -48,7 +48,7 @@ struct wq_config_t {
 
 namespace wq_configurations
 {
-static constexpr wq_config_t rate_ctrl{"wq:rate_ctrl", 1500, 0}; // PX4 inner loop highest priority
+static constexpr wq_config_t rate_ctrl{"wq:rate_ctrl", 1600, 0}; // PX4 inner loop highest priority
 
 static constexpr wq_config_t SPI1{"wq:SPI1", 1250, -1};
 static constexpr wq_config_t SPI2{"wq:SPI2", 1250, -2};
@@ -62,8 +62,10 @@ static constexpr wq_config_t I2C2{"wq:I2C2", 1250, -8};
 static constexpr wq_config_t I2C3{"wq:I2C3", 1250, -9};
 static constexpr wq_config_t I2C4{"wq:I2C4", 1250, -10};
 
-static constexpr wq_config_t hp_default{"wq:hp_default", 1250, -11};
-static constexpr wq_config_t lp_default{"wq:lp_default", 1250, -50};
+static constexpr wq_config_t att_pos_ctrl{"wq:att_pos_ctrl", 7000, -11}; // PX4 att/pos controllers, highest priority after sensors
+
+static constexpr wq_config_t hp_default{"wq:hp_default", 1500, -12};
+static constexpr wq_config_t lp_default{"wq:lp_default", 1500, -50};
 
 static constexpr wq_config_t test1{"wq:test1", 800, 0};
 static constexpr wq_config_t test2{"wq:test2", 800, 0};


### PR DESCRIPTION
The goal of this PR is to introduce a new module scheduling mechanism that combines the best aspects of tasks and work queues.

## Background
Historically PX4 modules have been either individual tasks (primarily) or run out of the NuttX work queues (HPWORK/LPWORK). There are pros and cons to each.

### Tasks


* **+** minimal latency (task runs with minimal latency on data publication)
* **-** dedicated stack (wasted memory)
* **-** memory overhead of each task (fairly significant)
* **-** poll and context switch relatively slow

### Work queues


* **+** minimal overhead (shared stack, no additional nuttx task)
* **-** fixed cycle schedule, not event driven 
* **-** usually shared with unrelated drivers/modules (non-deterministic)
* **-** HPWORK + LPWORK are each a task

## Pull Request
This PR adds a new uORB Subscription class (uORB::SubscriptionCallbackWorkItem) that has a callback mechanism to schedule a cycle of a WorkItem when new data is published.

As an example I've also updated px4fmu (the pwm output module) and mc_att_control (multicopter attitude + rate controller) to run in the rate_ctrl WQ, rather than as two separate tasks.

### New PX4 Work queue + ORB callback scheduling (PR)


* **+** minimal overhead (shared stack, no additional nuttx task)
* **+** scheduled on relevant data publication (event driven, minimal latency)
* **+** PX4 work queues are relatively inexpensive and we can create many of them (threads within a single task)
* **+** PX4 work queues group together inherently serialized processes (sharing a physical bus or other workflow)
* **+** no context switch if scheduling is back to back in the same WQ (thread)

## Example (compared to master)
Generic multicopter on a pixracer

#### master

	 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE FD
	   0 Idle Task                   12660 26.662   284/  748   0 (  0)  READY  3
	   1 hpwork                        271  0.629   704/ 1780 249 (249)  w:sig  6
	   2 lpwork                         34  0.139   712/ 1780  50 ( 50)  w:sig  8
	   3 init                         1755  0.000  1888/ 2604 100 (100)  w:sem  3
	   4 wq:manager                      2  0.000   824/ 1172 244 (244)  w:sem  5
	  17 dataman                         1  0.000   752/ 1180  90 ( 90)  w:sem  4
	  20 wq:lp_default                   7  0.000   848/ 1244 205 (205)  w:sem  5
	  22 wq:I2C1                         0  0.000   360/ 1244 248 (248)  w:sem  5
	  26 wq:hp_default                 121  0.209   664/ 1244 244 (244)  w:sem  5
	 144 wq:SPI1                      9095 22.183   888/ 1244 254 (254)  READY  5
	 152 wq:SPI4                         0  0.000   360/ 1244 251 (251)  w:sem  5
	 165 wq:SPI2                       199  0.489   544/ 1244 253 (253)  w:sem  5
	 179 sensors                      1592  3.708  1336/ 1964 238 (238)  READY 11
	 183 commander                     415  0.699  1632/ 3212 175 (140)  w:sig  6
	 185 commander_low_prio              1  0.000   680/ 2996  50 ( 50)  w:sem  6
	 198 mavlink_if0                  2213  4.338  1632/ 2532 100 (100)  READY  4
	 199 mavlink_rcv_if0               178  0.349  1408/ 2836 175 (175)  w:sem  4
	 242 gps                            48  0.139  1064/ 1516 209 (209)  w:sem  4
	 285 mavlink_if1                  3724  8.607  1656/ 2492 100 (100)  w:sig  4
	 286 mavlink_rcv_if1               198  0.419  1424/ 2836 175 (175)  w:sem  4
	 302 fmu                           859  2.169   888/ 1324 241 (241)  w:sem  8
	 427 ekf2                         3664  9.167  4520/ 6572 239 (239)  READY  4
	 429 mc_att_control               1446  3.848  1000/ 1660 240 (240)  w:sem  5
	 437 mc_pos_control                137  0.279   936/ 1860 239 (239)  w:sem  4
	 456 navigator                     158  0.279   992/ 1764 105 (105)  w:sem  4
	 623 log_writer_file                 0  0.000   376/ 1164  60 ( 60)  w:sem 28
	 490 mavlink_if2                  2312  5.178  1656/ 2540 100 (100)  w:sig  4
	 492 mavlink_rcv_if2               207  0.489  1424/ 2836 175 (175)  w:sem  4
	 585 logger                        428  1.119  1352/ 3644 234 (234)  w:sem 28
	 635 top                          1580  4.548  1312/ 1684 255 (255)  RUN    3

	Processes: 30 total, 6 running, 24 sleeping, max FDs: 54
	CPU usage: 69.00% tasks, 4.34% sched, 26.66% idle
	DMA Memory: 5120 total, 1024 used 1024 peak
	Uptime: 45.223s total, 12.661s idle

	nsh> free
		     total       used       free    largest
	Umem:       231280     191664      39616      31328

#### PR


	 PID COMMAND                   CPU(ms) CPU(%)  USED/STACK PRIO(BASE) STATE FD
	   0 Idle Task                   26165 29.802   284/  748   0 (  0)  READY  3
	   1 hpwork                        508  0.635   592/ 1780 249 (249)  w:sig  6
	   2 lpwork                         63  0.141   712/ 1780  50 ( 50)  w:sig  8
	   3 init                         1752  0.000  1864/ 2604 100 (100)  w:sem  3
	   4 wq:manager                      2  0.000   760/ 1172 244 (244)  w:sem  4
	 581 top                          1553  3.884  1320/ 1684 255 (255)  RUN    3
	  17 dataman                         1  0.000   752/ 1180  90 ( 90)  w:sem  4
	  20 wq:lp_default                  12  0.000   784/ 1500 205 (205)  w:sem  4
	  22 wq:I2C1                         0  0.000   360/ 1244 248 (248)  w:sem  4
	 138 wq:SPI1                     16933 22.033   888/ 1244 254 (254)  READY  4
	 143 wq:SPI4                         0  0.000   360/ 1244 251 (251)  w:sem  4
	 153 wq:SPI2                       370  0.494   544/ 1244 253 (253)  w:sem  4
	 171 sensors                      2918  3.742  1368/ 1964 238 (238)  w:sem 11
	 173 commander                     650  0.706  1632/ 3212 140 (140)  READY  6
	 174 commander_low_prio              2  0.000   560/ 2996  50 ( 50)  w:sem  6
	 184 mavlink_if0                  4017  4.519  1648/ 2532 100 (100)  READY  4
	 186 mavlink_rcv_if0               313  0.423  1336/ 2836 175 (175)  w:sem  4
	 191 wq:hp_default                 214  0.211  1104/ 1500 244 (244)  w:sem  4
	 233 gps                            82  0.141  1064/ 1516 209 (209)  w:sem  4
	 275 mavlink_if1                  6933  8.686  1648/ 2492 100 (100)  w:sig  4
	 277 mavlink_rcv_if1               338  0.423  1336/ 2836 175 (175)  w:sem  4
	 317 wq:rate_ctrl                 3440  4.661  1008/ 1500 255 (255)  w:sem  4
	 414 ekf2                         6951  9.251  4520/ 6572 239 (239)  w:sem  4
	 423 mc_pos_control                226  0.282   952/ 1860 239 (239)  w:sem  4
	 434 navigator                     227  0.141   992/ 1764 105 (105)  w:sem  4
	 560 log_writer_file                 0  0.000   376/ 1164  60 ( 60)  w:sem 28
	 471 mavlink_if2                  4150  5.084  1648/ 2540 100 (100)  w:sig  4
	 475 mavlink_rcv_if2               359  0.353  1424/ 2836 175 (175)  READY  4
	 540 logger                        726  0.776  1352/ 3644 234 (234)  w:sem 28

	Processes: 29 total, 6 running, 23 sleeping, max FDs: 54
	CPU usage: 66.60% tasks, 3.60% sched, 29.80% idle
	DMA Memory: 5120 total, 1024 used 1024 peak
	Uptime: 81.630s total, 26.165s idle

	nsh> free
		     total       used       free    largest
	Umem:       231344     186336      45008      36656

## Summary


|| Relevant CPU (%) | Memory (bytes free) ||
|----|----|----|----|
| Master (90bf26b239) |6.017% (fmu 3.848% + mc_att_control 2.169%) |39616 B||
| PR (cfbdf2a) |4.661% (wq:rate_ctrl) |45008 B||

By only moving two tasks to a workqueue overall cpu load decreased by a couple percent and we've saved over 5 kB of ram.

The downside? End-to-end control latency increased slightly (~ 90 us), but this is a result of the combined mc_att_control that can easily be split following this PR.

There are a number of other opportunities for merging multiple tasks into workqueues like this that will result in significant memory savings and performance improvements. Perhaps more importantly for some is that this structure will enable us to run the multicopter rate controller significantly faster without choking. The small cpu savings above mainly comes from reducing the number of context switches (at a paltry 250 Hz) that become crippling at significantly higher rates (1 - 4 kHz).

