### PR TITLE
Implement ModuleParams inheritance and DEFINE_PARAMETERS in the LandDetector class

### DIFF
--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -78,7 +78,7 @@ void LandDetector::Run()
 {
 	perf_begin(_cycle_perf);
 
-	_check_params();
+	_check_params(false);
 	_actuator_armed_sub.update(&_arming);
 	_update_topics();
 	_update_state();
@@ -148,11 +148,11 @@ void LandDetector::Run()
 	}
 }
 
-void LandDetector::_check_params()
+void LandDetector::_check_params(const bool force)
 {
 	parameter_update_s param_update;
 
-	if (_param_update_sub.update(&param_update)) {
+	if (_param_update_sub.update(&param_update) || force) {
 		_update_params();
 		_total_flight_time = static_cast<uint64_t>(_param_total_flight_time_high.get()) << 32;
 		_total_flight_time |= _param_total_flight_time_low.get();

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -71,6 +71,7 @@ LandDetector::~LandDetector()
 
 void LandDetector::start()
 {
+	_check_params(true);
 	ScheduleOnInterval(LAND_DETECTOR_UPDATE_INTERVAL);
 }
 
@@ -154,8 +155,7 @@ void LandDetector::_check_params(const bool force)
 
 	if (_param_update_sub.update(&param_update) || force) {
 		_update_params();
-		_total_flight_time = static_cast<uint64_t>(_param_total_flight_time_high.get()) << 32;
-		_total_flight_time |= _param_total_flight_time_low.get();
+		_update_total_flight_time();
 	}
 }
 
@@ -185,6 +185,12 @@ void LandDetector::_update_state()
 	} else {
 		_state = LandDetectionState::FLYING;
 	}
+}
+
+void LandDetector::_update_total_flight_time()
+{
+	_total_flight_time = static_cast<uint64_t>(_param_total_flight_time_high.get()) << 32;
+	_total_flight_time |= _param_total_flight_time_low.get();
 }
 
 } // namespace land_detector

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -165,13 +165,11 @@ private:
 
 	bool _previous_armed_state{false}; ///< stores the previous actuator_armed.armed state
 
-	uint32_t _measure_interval{LAND_DETECTOR_UPDATE_INTERVAL};
-
 	uint64_t _total_flight_time{0}; ///< in microseconds
 
 	hrt_abstime _takeoff_time{0};
 
-	perf_counter_t _cycle_perf{(perf_alloc(PC_ELAPSED, "land_detector_cycle"))};
+	perf_counter_t _cycle_perf{perf_alloc(PC_ELAPSED, "land_detector_cycle")};
 
 	uORB::Subscription _actuator_armed_sub{ORB_ID(actuator_armed)};
 	uORB::Subscription _param_update_sub{ORB_ID(parameter_update)};

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -157,7 +157,7 @@ protected:
 
 private:
 
-	void _check_params();
+	void _check_params(bool force = false);
 
 	void Run() override;
 

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -163,6 +163,8 @@ private:
 
 	void _update_state();
 
+	void _update_total_flight_time();
+
 	bool _previous_armed_state{false}; ///< stores the previous actuator_armed.armed state
 
 	uint64_t _total_flight_time{0}; ///< in microseconds

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -43,6 +43,7 @@
 #pragma once
 
 #include <px4_module.h>
+#include <px4_module_params.h>
 #include <lib/hysteresis/hysteresis.h>
 #include <parameters/param.h>
 #include <perf/perf_counter.h>
@@ -57,7 +58,7 @@ using namespace time_literals;
 namespace land_detector
 {
 
-class LandDetector : public ModuleBase<LandDetector>, px4::ScheduledWorkItem
+class LandDetector : public ModuleBase<LandDetector>, ModuleParams, px4::ScheduledWorkItem
 {
 public:
 	enum class LandDetectionState {
@@ -71,7 +72,6 @@ public:
 	LandDetector();
 	virtual ~LandDetector();
 
-	static int task_spawn(int argc, char *argv[]);
 
 	/** @see ModuleBase */
 	static int custom_command(int argc, char *argv[])
@@ -88,27 +88,26 @@ public:
 	/**
 	 * @return current state.
 	 */
-	LandDetectionState get_state() const
-	{
-		return _state;
-	}
+	LandDetectionState get_state() const { return _state; }
 
 	/**
 	 * Get the work queue going.
 	 */
 	void start();
 
-protected:
+	static int task_spawn(int argc, char *argv[]);
 
-	/**
-	 * Update uORB topics.
-	 */
-	virtual void _update_topics() = 0;
+protected:
 
 	/**
 	 * Update parameters.
 	 */
 	virtual void _update_params() = 0;
+
+	/**
+	 * Update uORB topics.
+	 */
+	virtual void _update_topics() = 0;
 
 	/**
 	 * @return true if UAV is in a landed state.
@@ -143,7 +142,7 @@ protected:
 	/** Run main land detector loop at this interval. */
 	static constexpr uint32_t LAND_DETECTOR_UPDATE_INTERVAL = 20_ms;
 
-	orb_advert_t _landDetectedPub{nullptr};
+	orb_advert_t _land_detected_pub{nullptr};
 	vehicle_land_detected_s _landDetected{};
 
 	LandDetectionState _state{LandDetectionState::LANDED};
@@ -154,26 +153,33 @@ protected:
 	systemlib::Hysteresis _ground_contact_hysteresis{true};
 	systemlib::Hysteresis _ground_effect_hysteresis{false};
 
-	struct actuator_armed_s	_arming {};
+	actuator_armed_s _arming {};
 
 private:
-	void Run() override;
 
-	void _check_params(bool force = false);
+	void _check_params();
+
+	void Run() override;
 
 	void _update_state();
 
-	param_t _p_total_flight_time_high{PARAM_INVALID};
-	param_t _p_total_flight_time_low{PARAM_INVALID};
+	bool _previous_armed_state{false}; ///< stores the previous actuator_armed.armed state
+
+	uint32_t _measure_interval{LAND_DETECTOR_UPDATE_INTERVAL};
+
 	uint64_t _total_flight_time{0}; ///< in microseconds
+
 	hrt_abstime _takeoff_time{0};
 
-	perf_counter_t	_cycle_perf;
+	perf_counter_t _cycle_perf{(perf_alloc(PC_ELAPSED, "land_detector_cycle"))};
 
-	bool _previous_arming_state{false}; ///< stores the previous _arming.armed state
+	uORB::Subscription _actuator_armed_sub{ORB_ID(actuator_armed)};
+	uORB::Subscription _param_update_sub{ORB_ID(parameter_update)};
 
-	uORB::Subscription _parameterSub{ORB_ID(parameter_update)};
-	uORB::Subscription _armingSub{ORB_ID(actuator_armed)};
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::LND_FLIGHT_T_HI>) _param_total_flight_time_high,
+		(ParamInt<px4::params::LND_FLIGHT_T_LO>) _param_total_flight_time_low
+	);
 };
 
 } // namespace land_detector


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR modifies the LandDetector class to inherit from ModuleParams and utilize the `DEFINE_PARAMETERS()` macro.

This PR also renames `_armingSub`->`arming_sub` and `parameterSub`->`parameter_sub` to match the most prevalent usage in the other classes.

**Test data / coverage**
Additional test data and flight logs will be added below.

**Additional context**
This PR advances the work in #9756 and #11874.

Please let me know if you have any feedback for me on this PR. Thanks!

-Mark

