### PR TITLE
[WIP]: px4fmu & mc_att_control move to WQ with uORB callback scheduling

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -220,11 +220,6 @@ else
 	#
 	tone_alarm start
 
-	if param compare SYS_FMU_TASK 1
-	then
-		set FMU_ARGS "-t"
-	fi
-
 	#
 	# Set parameters and env variables for selected AUTOSTART.
 	#

--- a/boards/auav/x21/init/rc.board_defaults
+++ b/boards/auav/x21/init/rc.board_defaults
@@ -6,5 +6,5 @@
 
 if [ $AUTOCNF = yes ]
 then
-	param set SYS_FMU_TASK 0
+
 fi

--- a/boards/px4/fmu-v2/init/rc.board_defaults
+++ b/boards/px4/fmu-v2/init/rc.board_defaults
@@ -24,5 +24,5 @@ unset BL_FILE
 
 if [ $AUTOCNF = yes ]
 then
-	param set SYS_FMU_TASK 0
+
 fi

--- a/boards/px4/fmu-v3/init/rc.board_defaults
+++ b/boards/px4/fmu-v3/init/rc.board_defaults
@@ -6,5 +6,5 @@
 
 if [ $AUTOCNF = yes ]
 then
-	param set SYS_FMU_TASK 0
+
 fi

--- a/src/drivers/px4fmu/px4fmu_params.c
+++ b/src/drivers/px4fmu/px4fmu_params.c
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (c) 2015-2018 PX4 Development Team. All rights reserved.
+ *   Copyright (c) 2015-2019 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -50,19 +50,3 @@
  * @group PWM Outputs
  */
 PARAM_DEFINE_INT32(MOT_ORDERING, 0);
-
-/**
- * Run the FMU as a task to reduce latency
- *
- * If true, the FMU will run in a separate task instead of on the work queue.
- * Set this if low latency is required, for example for racing.
- *
- * This is a trade-off between RAM usage and latency: running as a task, it
- * requires a separate stack and directly polls on the control topics, whereas
- * running on the work queue, it runs at a fixed update rate.
- *
- * @boolean
- * @reboot_required true
- * @group System
- */
-PARAM_DEFINE_INT32(SYS_FMU_TASK, 1);

--- a/src/modules/mc_att_control/CMakeLists.txt
+++ b/src/modules/mc_att_control/CMakeLists.txt
@@ -46,4 +46,5 @@ px4_add_module(
 		conversion
 		mathlib
 		AttitudeControl
+		px4_work_queue
 	)

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -63,12 +63,9 @@ using namespace matrix;
 
 MulticopterAttitudeControl::MulticopterAttitudeControl() :
 	ModuleParams(nullptr),
+	WorkItem(px4::wq_configurations::rate_ctrl),
 	_loop_perf(perf_alloc(PC_ELAPSED, "mc_att_control"))
 {
-	for (uint8_t i = 0; i < MAX_GYRO_COUNT; i++) {
-		_sensor_gyro_sub[i] = -1;
-	}
-
 	_vehicle_status.is_rotary_wing = true;
 
 	/* initialize quaternions in messages to be valid */
@@ -91,6 +88,8 @@ MulticopterAttitudeControl::MulticopterAttitudeControl() :
 	}
 
 	parameters_updated();
+
+	_gyro_count = math::constrain(orb_group_count(ORB_ID(sensor_gyro)), 1, MAX_GYRO_COUNT);
 }
 
 void
@@ -549,220 +548,172 @@ MulticopterAttitudeControl::publish_actuator_controls()
 }
 
 void
-MulticopterAttitudeControl::run()
+MulticopterAttitudeControl::Run()
 {
-	_gyro_count = math::constrain(orb_group_count(ORB_ID(sensor_gyro)), 1, MAX_GYRO_COUNT);
+	// check if the selected gyro has updated first
+	_sensor_correction_sub.update(&_sensor_correction);
 
-	for (unsigned s = 0; s < _gyro_count; s++) {
-		_sensor_gyro_sub[s] = orb_subscribe_multi(ORB_ID(sensor_gyro), s);
+	/* update the latest gyro selection */
+	if (_sensor_correction.selected_gyro_instance < _gyro_count) {
+		if (_selected_gyro != _sensor_correction.selected_gyro_instance) {
+			if (_sensor_gyro_sub.change_topic(ORB_ID(sensor_gyro), _selected_gyro)) {
+				_selected_gyro = _sensor_correction.selected_gyro_instance;
+				PX4_WARN("selected gyro changed %d -> %d", _selected_gyro, _sensor_correction.selected_gyro_instance);
+			}
+		}
 	}
 
-	/* wakeup source: gyro data from sensor selected by the sensor app */
-	px4_pollfd_struct_t poll_fds = {};
-	poll_fds.events = POLLIN;
+	perf_begin(_loop_perf);
 
-	const hrt_abstime task_start = hrt_absolute_time();
-	hrt_abstime last_run = task_start;
-	float dt_accumulator = 0.f;
-	int loop_counter = 0;
+	/* run controller on gyro changes */
+	if (_sensor_gyro_sub.update(&_sensor_gyro)) {
+		const hrt_abstime now = hrt_absolute_time();
 
-	bool reset_yaw_sp = true;
-	float attitude_dt = 0.f;
+		// Guard against too small (< 0.2ms) and too large (> 20ms) dt's.
+		const float dt = math::constrain(((now - _last_run) / 1e6f), 0.0002f, 0.02f);
+		_last_run = now;
 
-	while (!should_exit()) {
+		/* run the rate controller immediately after a gyro update */
+		if (_v_control_mode.flag_control_rates_enabled) {
+			control_attitude_rates(dt);
 
-		// check if the selected gyro has updated first
-		_sensor_correction_sub.update(&_sensor_correction);
-
-		/* update the latest gyro selection */
-		if (_sensor_correction.selected_gyro_instance < _gyro_count) {
-			_selected_gyro = _sensor_correction.selected_gyro_instance;
+			publish_actuator_controls();
+			publish_rate_controller_status();
 		}
 
-		poll_fds.fd = _sensor_gyro_sub[_selected_gyro];
+		/* check for updates in other topics */
+		_v_control_mode_sub.update(&_v_control_mode);
+		_battery_status_sub.update(&_battery_status);
+		_sensor_bias_sub.update(&_sensor_bias);
+		_vehicle_land_detected_sub.update(&_vehicle_land_detected);
+		_landing_gear_sub.update(&_landing_gear);
+		vehicle_status_poll();
+		vehicle_motor_limits_poll();
+		const bool manual_control_updated = _manual_control_sp_sub.update(&_manual_control_sp);
+		const bool attitude_updated = vehicle_attitude_poll();
 
-		/* wait for up to 100ms for data */
-		int pret = px4_poll(&poll_fds, 1, 100);
+		_attitude_dt += dt;
 
-		/* timed out - periodic check for should_exit() */
-		if (pret == 0) {
-			continue;
+		/* Check if we are in rattitude mode and the pilot is above the threshold on pitch
+			* or roll (yaw can rotate 360 in normal att control). If both are true don't
+			* even bother running the attitude controllers */
+		if (_v_control_mode.flag_control_rattitude_enabled) {
+			_v_control_mode.flag_control_attitude_enabled =
+				fabsf(_manual_control_sp.y) <= _param_mc_ratt_th.get() &&
+				fabsf(_manual_control_sp.x) <= _param_mc_ratt_th.get();
 		}
 
-		/* this is undesirable but not much we can do - might want to flag unhappy status */
-		if (pret < 0) {
-			PX4_ERR("poll error %d, %d", pret, errno);
-			/* sleep a bit before next try */
-			px4_usleep(100000);
-			continue;
-		}
+		bool attitude_setpoint_generated = false;
 
-		perf_begin(_loop_perf);
+		const bool is_hovering = _vehicle_status.is_rotary_wing && !_vehicle_status.in_transition_mode;
 
-		/* run controller on gyro changes */
-		if (poll_fds.revents & POLLIN) {
-			const hrt_abstime now = hrt_absolute_time();
+		// vehicle is a tailsitter in transition mode
+		const bool is_tailsitter_transition = _vehicle_status.in_transition_mode && _is_tailsitter;
 
-			// Guard against too small (< 0.2ms) and too large (> 20ms) dt's.
-			const float dt = math::constrain(((now - last_run) / 1e6f), 0.0002f, 0.02f);
-			last_run = now;
+		bool run_att_ctrl = _v_control_mode.flag_control_attitude_enabled && (is_hovering || is_tailsitter_transition);
 
-			/* copy gyro data */
-			orb_copy(ORB_ID(sensor_gyro), _sensor_gyro_sub[_selected_gyro], &_sensor_gyro);
 
-			/* run the rate controller immediately after a gyro update */
-			if (_v_control_mode.flag_control_rates_enabled) {
-				control_attitude_rates(dt);
+		if (run_att_ctrl) {
+			if (attitude_updated) {
+				// Generate the attitude setpoint from stick inputs if we are in Manual/Stabilized mode
+				if (_v_control_mode.flag_control_manual_enabled &&
+				    !_v_control_mode.flag_control_altitude_enabled &&
+				    !_v_control_mode.flag_control_velocity_enabled &&
+				    !_v_control_mode.flag_control_position_enabled) {
+					generate_attitude_setpoint(_attitude_dt, _reset_yaw_sp);
+					attitude_setpoint_generated = true;
+				}
 
-				publish_actuator_controls();
-				publish_rate_controller_status();
+				control_attitude();
+
+				if (_v_control_mode.flag_control_yawrate_override_enabled) {
+					/* Yaw rate override enabled, overwrite the yaw setpoint */
+					_v_rates_sp_sub.update(&_v_rates_sp);
+					const auto yawrate_reference = _v_rates_sp.yaw;
+					_rates_sp(2) = yawrate_reference;
+				}
+
+				publish_rates_setpoint();
 			}
 
-			/* check for updates in other topics */
-			_v_control_mode_sub.update(&_v_control_mode);
-			_battery_status_sub.update(&_battery_status);
-			_sensor_bias_sub.update(&_sensor_bias);
-			_vehicle_land_detected_sub.update(&_vehicle_land_detected);
-			_landing_gear_sub.update(&_landing_gear);
-			vehicle_status_poll();
-			vehicle_motor_limits_poll();
-			const bool manual_control_updated = _manual_control_sp_sub.update(&_manual_control_sp);
-			const bool attitude_updated = vehicle_attitude_poll();
-
-			attitude_dt += dt;
-
-			/* Check if we are in rattitude mode and the pilot is above the threshold on pitch
-			 * or roll (yaw can rotate 360 in normal att control). If both are true don't
-			 * even bother running the attitude controllers */
-			if (_v_control_mode.flag_control_rattitude_enabled) {
-				_v_control_mode.flag_control_attitude_enabled =
-					fabsf(_manual_control_sp.y) <= _param_mc_ratt_th.get() &&
-					fabsf(_manual_control_sp.x) <= _param_mc_ratt_th.get();
-			}
-
-			bool attitude_setpoint_generated = false;
-
-			const bool is_hovering = _vehicle_status.is_rotary_wing && !_vehicle_status.in_transition_mode;
-
-			// vehicle is a tailsitter in transition mode
-			const bool is_tailsitter_transition = _vehicle_status.in_transition_mode && _is_tailsitter;
-
-			bool run_att_ctrl = _v_control_mode.flag_control_attitude_enabled && (is_hovering || is_tailsitter_transition);
-
-
-			if (run_att_ctrl) {
-				if (attitude_updated) {
-					// Generate the attitude setpoint from stick inputs if we are in Manual/Stabilized mode
-					if (_v_control_mode.flag_control_manual_enabled &&
-					    !_v_control_mode.flag_control_altitude_enabled &&
-					    !_v_control_mode.flag_control_velocity_enabled &&
-					    !_v_control_mode.flag_control_position_enabled) {
-						generate_attitude_setpoint(attitude_dt, reset_yaw_sp);
-						attitude_setpoint_generated = true;
-					}
-
-					control_attitude();
-
-					if (_v_control_mode.flag_control_yawrate_override_enabled) {
-						/* Yaw rate override enabled, overwrite the yaw setpoint */
-						_v_rates_sp_sub.update(&_v_rates_sp);
-						const auto yawrate_reference = _v_rates_sp.yaw;
-						_rates_sp(2) = yawrate_reference;
-					}
-
+		} else {
+			/* attitude controller disabled, poll rates setpoint topic */
+			if (_v_control_mode.flag_control_manual_enabled && is_hovering) {
+				if (manual_control_updated) {
+					/* manual rates control - ACRO mode */
+					Vector3f man_rate_sp(
+						math::superexpo(_manual_control_sp.y, _param_mc_acro_expo.get(), _param_mc_acro_supexpo.get()),
+						math::superexpo(-_manual_control_sp.x, _param_mc_acro_expo.get(), _param_mc_acro_supexpo.get()),
+						math::superexpo(_manual_control_sp.r, _param_mc_acro_expo_y.get(), _param_mc_acro_supexpoy.get()));
+					_rates_sp = man_rate_sp.emult(_acro_rate_max);
+					_thrust_sp = _manual_control_sp.z;
 					publish_rates_setpoint();
 				}
 
 			} else {
 				/* attitude controller disabled, poll rates setpoint topic */
-				if (_v_control_mode.flag_control_manual_enabled && is_hovering) {
-					if (manual_control_updated) {
-						/* manual rates control - ACRO mode */
-						Vector3f man_rate_sp(
-							math::superexpo(_manual_control_sp.y, _param_mc_acro_expo.get(), _param_mc_acro_supexpo.get()),
-							math::superexpo(-_manual_control_sp.x, _param_mc_acro_expo.get(), _param_mc_acro_supexpo.get()),
-							math::superexpo(_manual_control_sp.r, _param_mc_acro_expo_y.get(), _param_mc_acro_supexpoy.get()));
-						_rates_sp = man_rate_sp.emult(_acro_rate_max);
-						_thrust_sp = _manual_control_sp.z;
-						publish_rates_setpoint();
-					}
-
-				} else {
-					/* attitude controller disabled, poll rates setpoint topic */
-					if (_v_rates_sp_sub.update(&_v_rates_sp)) {
-						_rates_sp(0) = _v_rates_sp.roll;
-						_rates_sp(1) = _v_rates_sp.pitch;
-						_rates_sp(2) = _v_rates_sp.yaw;
-						_thrust_sp = -_v_rates_sp.thrust_body[2];
-					}
+				if (_v_rates_sp_sub.update(&_v_rates_sp)) {
+					_rates_sp(0) = _v_rates_sp.roll;
+					_rates_sp(1) = _v_rates_sp.pitch;
+					_rates_sp(2) = _v_rates_sp.yaw;
+					_thrust_sp = -_v_rates_sp.thrust_body[2];
 				}
 			}
-
-			if (_v_control_mode.flag_control_termination_enabled) {
-				if (!_vehicle_status.is_vtol) {
-					_rates_sp.zero();
-					_rates_int.zero();
-					_thrust_sp = 0.0f;
-					_att_control.zero();
-					publish_actuator_controls();
-				}
-			}
-
-			if (attitude_updated) {
-				// reset yaw setpoint during transitions, tailsitter.cpp generates
-				// attitude setpoint for the transition
-				reset_yaw_sp = (!attitude_setpoint_generated && !_v_control_mode.flag_control_rattitude_enabled) ||
-					       _vehicle_land_detected.landed ||
-					       (_vehicle_status.is_vtol && _vehicle_status.in_transition_mode);
-
-				attitude_dt = 0.f;
-			}
-
-			/* calculate loop update rate while disarmed or at least a few times (updating the filter is expensive) */
-			if (!_v_control_mode.flag_armed || (now - task_start) < 3300000) {
-				dt_accumulator += dt;
-				++loop_counter;
-
-				if (dt_accumulator > 1.f) {
-					const float loop_update_rate = (float)loop_counter / dt_accumulator;
-					_loop_update_rate_hz = _loop_update_rate_hz * 0.5f + loop_update_rate * 0.5f;
-					dt_accumulator = 0;
-					loop_counter = 0;
-					_lp_filters_d.set_cutoff_frequency(_loop_update_rate_hz, _param_mc_dterm_cutoff.get());
-				}
-			}
-
-			parameter_update_poll();
 		}
 
-		perf_end(_loop_perf);
+		if (_v_control_mode.flag_control_termination_enabled) {
+			if (!_vehicle_status.is_vtol) {
+				_rates_sp.zero();
+				_rates_int.zero();
+				_thrust_sp = 0.0f;
+				_att_control.zero();
+				publish_actuator_controls();
+			}
+		}
+
+		if (attitude_updated) {
+			// reset yaw setpoint during transitions, tailsitter.cpp generates
+			// attitude setpoint for the transition
+			_reset_yaw_sp = (!attitude_setpoint_generated && !_v_control_mode.flag_control_rattitude_enabled) ||
+					_vehicle_land_detected.landed ||
+					(_vehicle_status.is_vtol && _vehicle_status.in_transition_mode);
+
+			_attitude_dt = 0.f;
+		}
+
+		/* calculate loop update rate while disarmed or at least a few times (updating the filter is expensive) */
+		if (!_v_control_mode.flag_armed || (now - _task_start) < 3300000) {
+			_dt_accumulator += dt;
+			++_loop_counter;
+
+			if (_dt_accumulator > 1.f) {
+				const float loop_update_rate = (float)_loop_counter / _dt_accumulator;
+				_loop_update_rate_hz = _loop_update_rate_hz * 0.5f + loop_update_rate * 0.5f;
+				_dt_accumulator = 0;
+				_loop_counter = 0;
+				_lp_filters_d.set_cutoff_frequency(_loop_update_rate_hz, _param_mc_dterm_cutoff.get());
+			}
+		}
+
+		parameter_update_poll();
 	}
 
-	for (unsigned s = 0; s < _gyro_count; s++) {
-		orb_unsubscribe(_sensor_gyro_sub[s]);
-	}
+	perf_end(_loop_perf);
 }
 
 int MulticopterAttitudeControl::task_spawn(int argc, char *argv[])
 {
-	_task_id = px4_task_spawn_cmd("mc_att_control",
-				      SCHED_DEFAULT,
-				      SCHED_PRIORITY_ATTITUDE_CONTROL,
-				      1700,
-				      (px4_main_t)&run_trampoline,
-				      (char *const *)argv);
+	MulticopterAttitudeControl *instance = new MulticopterAttitudeControl();
 
-	if (_task_id < 0) {
-		_task_id = -1;
-		return -errno;
+	if (instance == nullptr) {
+		PX4_ERR("alloc failed");
+		return PX4_ERROR;
 	}
 
-	return 0;
-}
+	_object.store(instance);
+	_task_id = task_id_is_work_queue;
 
-MulticopterAttitudeControl *MulticopterAttitudeControl::instantiate(int argc, char *argv[])
-{
-	return new MulticopterAttitudeControl();
+	return PX4_OK;
 }
 
 int MulticopterAttitudeControl::custom_command(int argc, char *argv[])

--- a/src/modules/uORB/Subscription.hpp
+++ b/src/modules/uORB/Subscription.hpp
@@ -105,6 +105,19 @@ public:
 	uint8_t		get_instance() const { return _instance; }
 	orb_id_t	get_topic() const { return _meta; }
 
+	bool change_topic(const orb_metadata *meta, uint8_t instance = 0)
+	{
+		unsubscribe();
+
+		// switch to new topic and instance
+		_meta = meta;
+		_instance = instance;
+
+		return forceInit();
+	}
+
+	DeviceNode		*get_node() { return _node; }
+
 protected:
 
 	bool subscribe();

--- a/src/modules/uORB/SubscriptionCallback.hpp
+++ b/src/modules/uORB/SubscriptionCallback.hpp
@@ -1,0 +1,121 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file SubscriptionCallback.hpp
+ *
+ */
+
+#pragma once
+
+#include <uORB/SubscriptionInterval.hpp>
+#include <containers/List.hpp>
+#include <px4_work_queue/WorkItem.hpp>
+
+namespace uORB
+{
+
+// Subscription wrapper class with callbacks on new publications
+class SubscriptionCallback : public SubscriptionInterval, public ListNode<SubscriptionCallback *>
+{
+public:
+	/**
+	 * Constructor
+	 *
+	 * @param meta The uORB metadata (usually from the ORB_ID() macro) for the topic.
+	 * @param instance The instance for multi sub.
+	 */
+	SubscriptionCallback() = default;
+	SubscriptionCallback(const orb_metadata *meta, uint8_t interval_ms, uint8_t instance = 0) :
+		SubscriptionInterval(meta, interval_ms, instance)
+	{
+		register_callback();
+	}
+
+	virtual ~SubscriptionCallback()
+	{
+		unregister_callback();
+	};
+
+	bool init() override
+	{
+		SubscriptionInterval::init();
+		return register_callback();
+	}
+
+	bool register_callback() { return _subscription.get_node() ? _subscription.get_node()->register_callback(this) : false; }
+	void unregister_callback() { if (_subscription.get_node()) _subscription.get_node()->unregister_callback(this); }
+
+	bool change_topic(const orb_metadata *meta, uint8_t instance = 0)
+	{
+		unregister_callback();
+		_subscription.change_topic(meta, instance);
+		return register_callback();
+	}
+
+	virtual void call() = 0;
+
+};
+
+// Subscription with callback that schedules a WorkItem
+class SubscriptionCallbackWorkItem : public SubscriptionCallback
+{
+public:
+	/**
+	 * Constructor
+	 *
+	 * @param work_item The WorkItem that will be scheduled immediately on new publications.
+	 * @param meta The uORB metadata (usually from the ORB_ID() macro) for the topic.
+	 * @param instance The instance for multi sub.
+	 */
+	SubscriptionCallbackWorkItem() = default;
+	SubscriptionCallbackWorkItem(px4::WorkItem *work_item, const orb_metadata *meta, uint8_t instance = 0) :
+		SubscriptionCallback(meta, instance),
+		_work_item(work_item)
+	{
+	}
+
+	virtual ~SubscriptionCallbackWorkItem() = default;
+
+	void call() override
+	{
+		if (hrt_absolute_time() >= next_update_time()) {
+			_work_item->ScheduleNow();
+		}
+	}
+
+private:
+	px4::WorkItem *_work_item;
+};
+
+} // namespace uORB

--- a/src/modules/uORB/SubscriptionInterval.hpp
+++ b/src/modules/uORB/SubscriptionInterval.hpp
@@ -1,0 +1,132 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file SubscriptionInterval.hpp
+ *
+ */
+
+#pragma once
+
+#include <uORB/uORB.h>
+#include <px4_defines.h>
+
+#include "uORBDeviceNode.hpp"
+#include "uORBManager.hpp"
+#include "uORBUtils.hpp"
+
+#include "Subscription.hpp"
+
+namespace uORB
+{
+
+// Base subscription wrapper class
+class SubscriptionInterval
+{
+public:
+
+	/**
+	 * Constructor
+	 *
+	 * @param meta The uORB metadata (usually from the ORB_ID() macro) for the topic.
+	 * @param interval The requested maximum update interval in milliseconds.
+	 * @param instance The instance for multi sub.
+	 */
+	SubscriptionInterval(const orb_metadata *meta, uint16_t interval_ms = 0, uint8_t instance = 0) :
+		_subscription{meta, instance},
+		_interval(interval_ms)
+	{
+	}
+	SubscriptionInterval() : _subscription{nullptr} {}
+
+	~SubscriptionInterval() = default;
+
+	virtual bool init() { return _subscription.init(); }
+
+	bool forceInit() { return _subscription.forceInit(); }
+
+	bool published()
+	{
+		if (_subscription.valid()) {
+			return true;
+		}
+
+		return init();
+	}
+
+	/**
+	 * Check if there is a new update.
+	 * */
+	bool updated()
+	{
+		if (hrt_elapsed_time(&_last_update) >= (_interval * 1000)) {
+			return published();
+		}
+
+		return false;
+	}
+
+	/**
+	 * Update the struct
+	 * @param data The uORB message struct we are updating.
+	 */
+	bool update(void *dst)
+	{
+		if (updated()) {
+			if (_subscription.copy(dst)) {
+				_last_update = hrt_absolute_time();
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	// Simple accessors
+	bool		valid() const { return _subscription.valid(); }
+	hrt_abstime	next_update_time() const { return _last_update + (_interval * 1000); }
+	uint8_t		get_instance() const { return _subscription.get_instance(); }
+	orb_id_t	get_topic() const { return _subscription.get_topic(); }
+	uint16_t	get_interval() const { return _interval; }
+
+	void		set_interval(uint16_t interval) { _interval = interval; }
+
+protected:
+
+	Subscription	_subscription;
+	uint64_t	_last_update{0};	// last update in microseconds
+	uint16_t	_interval{0};		// maximum update interval in milliseconds
+
+};
+
+} // namespace uORB

--- a/src/modules/uORB/uORBDeviceNode.cpp
+++ b/src/modules/uORB/uORBDeviceNode.cpp
@@ -37,6 +37,8 @@
 #include "uORBUtils.hpp"
 #include "uORBManager.hpp"
 
+#include "SubscriptionCallback.hpp"
+
 #ifdef ORB_COMMUNICATOR
 #include "uORBCommunicator.hpp"
 #endif /* ORB_COMMUNICATOR */
@@ -316,6 +318,11 @@ uORB::DeviceNode::write(cdev::file_t *filp, const char *buffer, size_t buflen)
 	_generation++;
 
 	_published = true;
+
+	// callbacks
+	for (auto item : _callbacks) {
+		item->call();
+	}
 
 	ATOMIC_LEAVE;
 
@@ -672,4 +679,36 @@ int uORB::DeviceNode::update_queue_size(unsigned int queue_size)
 
 	_queue_size = queue_size;
 	return PX4_OK;
+}
+
+bool
+uORB::DeviceNode::register_callback(uORB::SubscriptionCallback *callback_sub)
+{
+	if (callback_sub != nullptr) {
+		ATOMIC_ENTER;
+
+		// prevent duplicate registrations
+		for (auto existing_callbacks : _callbacks) {
+			if (callback_sub == existing_callbacks) {
+				ATOMIC_LEAVE;
+				return true;
+			}
+		}
+
+		_callbacks.add(callback_sub);
+		ATOMIC_LEAVE;
+		return true;
+	}
+
+	return false;
+}
+
+void
+uORB::DeviceNode::unregister_callback(uORB::SubscriptionCallback *callback_sub)
+{
+	if (callback_sub != nullptr) {
+		ATOMIC_ENTER;
+		_callbacks.remove(callback_sub);
+		ATOMIC_LEAVE;
+	}
 }

--- a/src/modules/uORB/uORBDeviceNode.hpp
+++ b/src/modules/uORB/uORBDeviceNode.hpp
@@ -45,6 +45,7 @@ namespace uORB
 class DeviceNode;
 class DeviceMaster;
 class Manager;
+class SubscriptionCallback;
 }
 
 /**
@@ -231,6 +232,12 @@ public:
 	 */
 	uint64_t copy_and_get_timestamp(void *dst, unsigned &generation);
 
+	// add item to list of work items to schedule on node update
+	bool register_callback(SubscriptionCallback *callback_sub);
+
+	// remove item from list of work items
+	void unregister_callback(SubscriptionCallback *callback_sub);
+
 protected:
 
 	pollevent_t poll_state(cdev::file_t *filp) override;
@@ -269,6 +276,7 @@ private:
 	uint8_t     *_data{nullptr};   /**< allocated object buffer */
 	hrt_abstime   _last_update{0}; /**< time the object was last updated */
 	volatile unsigned   _generation{0};  /**< object generation count */
+	List<uORB::SubscriptionCallback *>	_callbacks;
 	uint8_t   _priority;  /**< priority of the topic */
 	bool _published{false};  /**< has ever data been published */
 	uint8_t _queue_size; /**< maximum number of elements in the queue */

--- a/src/platforms/common/px4_work_queue/WorkQueueManager.cpp
+++ b/src/platforms/common/px4_work_queue/WorkQueueManager.cpp
@@ -198,19 +198,26 @@ static void WorkQueueManagerRun()
 			}
 
 			// stack size
+#ifndef __PX4_QURT
 			const size_t stacksize = math::max(PTHREAD_STACK_MIN, PX4_STACK_ADJUSTED(wq->stacksize));
+#else
+			const size_t stacksize = math::max(8 * 1024, PX4_STACK_ADJUSTED(wq->stacksize));
+#endif
 			int ret_setstacksize = pthread_attr_setstacksize(&attr, stacksize);
 
 			if (ret_setstacksize != 0) {
 				PX4_ERR("setting stack size for %s failed (%i)", wq->name, ret_setstacksize);
 			}
 
+#ifndef __PX4_QURT
 			// schedule policy FIFO
 			int ret_setschedpolicy = pthread_attr_setschedpolicy(&attr, SCHED_FIFO);
 
 			if (ret_setschedpolicy != 0) {
 				PX4_ERR("failed to set sched policy SCHED_FIFO (%i)", ret_setschedpolicy);
 			}
+
+#endif // ! QuRT
 
 			// priority
 			param.sched_priority = sched_get_priority_max(SCHED_FIFO) + wq->relative_priority;

--- a/src/platforms/common/px4_work_queue/WorkQueueManager.hpp
+++ b/src/platforms/common/px4_work_queue/WorkQueueManager.hpp
@@ -62,8 +62,8 @@ static constexpr wq_config_t I2C2{"wq:I2C2", 1250, -8};
 static constexpr wq_config_t I2C3{"wq:I2C3", 1250, -9};
 static constexpr wq_config_t I2C4{"wq:I2C4", 1250, -10};
 
-static constexpr wq_config_t hp_default{"wq:hp_default", 1250, -11};
-static constexpr wq_config_t lp_default{"wq:lp_default", 1250, -50};
+static constexpr wq_config_t hp_default{"wq:hp_default", 1500, -11};
+static constexpr wq_config_t lp_default{"wq:lp_default", 1500, -50};
 
 static constexpr wq_config_t test1{"wq:test1", 800, 0};
 static constexpr wq_config_t test2{"wq:test2", 800, 0};


### PR DESCRIPTION
DO NOT MERGE, requires https://github.com/PX4/Firmware/pull/12207.

First use of https://github.com/PX4/Firmware/pull/12207. For more background see https://github.com/PX4/Firmware/pull/12207#issue-286258153.

tl;dr - Moving px4fmu (pwm output module) and mc_att_control (multicopter attitude + rate controller) to the WQ saves quite a bit of ram and cpu (especially once we start running the rate controller much faster).