### PR TITLE
VTOL: apply multicopter takeoff hotfix also for vtol

### DIFF
--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -358,7 +358,7 @@ MulticopterAttitudeControl::control_attitude()
 {
 	_v_att_sp_sub.update(&_v_att_sp);
 
-	// reinitialize the setpoint while not armed to make sure no value from the last flight is still kept
+	// reinitialize the setpoint while not armed to make sure no value from the last mode or flight is still kept
 	if (!_v_control_mode.flag_armed) {
 		Quatf().copyTo(_v_att_sp.q_d);
 		Vector3f().copyTo(_v_att_sp.thrust_body);

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -48,6 +48,9 @@
  */
 #include "vtol_att_control_main.h"
 #include <systemlib/mavlink_log.h>
+#include <matrix/matrix/math.hpp>
+
+using namespace matrix;
 
 namespace VTOL_att_control
 {
@@ -510,6 +513,14 @@ void VtolAttitudeControl::task_main()
 
 			// normal operation
 			_vtol_type->fill_actuator_outputs();
+		}
+
+		// reinitialize the setpoint while not armed to make sure no value from the last mode or flight is still kept
+		if (!_v_control_mode.flag_armed) {
+			Quatf().copyTo(_mc_virtual_att_sp.q_d);
+			Vector3f().copyTo(_mc_virtual_att_sp.thrust_body);
+			Quatf().copyTo(_v_att_sp.q_d);
+			Vector3f().copyTo(_v_att_sp.thrust_body);
 		}
 
 		/* Only publish if the proper mode(s) are enabled */


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Fixes #12171

**Test data / coverage**
SITL tested with `make px4_sitl gazebo_standard_vtol`

Before:
![vtol_before](https://user-images.githubusercontent.com/4668506/59339400-69726100-8d04-11e9-991f-155fb888a734.PNG)

After:
![vtol_after](https://user-images.githubusercontent.com/4668506/59339401-69726100-8d04-11e9-8b39-a2118c6e4e79.PNG)


**Describe your preferred solution**
As disscussed before the final solution for this problem is the multicopter position controller needs to publish the correct setpoints as soon as a corresponding mode is running even when disarmed. Then there is no setpoint being kept until the next one is published. This hotfix is for the release and we should be able to get rid of it again.

**Additional context**
This should be cherry-picked to 1.9.1 to fix the bug still existing for VTOLs in the 1.9.0 release.

FYI @sfuhrer