### PR TITLE
init.d-posix: support running SITL slower

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -167,15 +167,19 @@ fi
 
 # Adapt timeout parameters if simulation runs faster or slower than realtime.
 if [ ! -z $PX4_SIM_SPEED_FACTOR ]; then
-	COM_DL_LOSS_T_LONGER=$((PX4_SIM_SPEED_FACTOR * 10))
+
+	# We need to use bc for floating point arithmetic.
+	set SPEED_FACTOR_TIMES_10 $(echo "$PX4_SIM_SPEED_FACTOR * 10" | bc -l)
+
+	COM_DL_LOSS_T_LONGER=$SPEED_FACTOR_TIMES_10
 	echo "COM_DL_LOSS_T set to $COM_DL_LOSS_T_LONGER"
 	param set COM_DL_LOSS_T $COM_DL_LOSS_T_LONGER
 
-	COM_RC_LOSS_T_LONGER=$((PX4_SIM_SPEED_FACTOR * 1))
+	COM_RC_LOSS_T_LONGER=$PX4_SIM_SPEED_FACTOR
 	echo "COM_RC_LOSS_T set to $COM_RC_LOSS_T_LONGER"
 	param set COM_RC_LOSS_T $COM_RC_LOSS_T_LONGER
 
-	COM_OF_LOSS_T_LONGER=$((PX4_SIM_SPEED_FACTOR * 10))
+	COM_OF_LOSS_T_LONGER=$SPEED_FACTOR_TIMES_10
 	echo "COM_OF_LOSS_T set to $COM_OF_LOSS_T_LONGER"
 	param set COM_OF_LOSS_T $COM_OF_LOSS_T_LONGER
 fi

--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -165,24 +165,6 @@ then
 	param set WEST_EN 0
 fi
 
-# Adapt timeout parameters if simulation runs faster or slower than realtime.
-if [ ! -z $PX4_SIM_SPEED_FACTOR ]; then
-
-	# We need to use bc for floating point arithmetic.
-	set SPEED_FACTOR_TIMES_10 $(echo "$PX4_SIM_SPEED_FACTOR * 10" | bc -l)
-
-	COM_DL_LOSS_T_LONGER=$SPEED_FACTOR_TIMES_10
-	echo "COM_DL_LOSS_T set to $COM_DL_LOSS_T_LONGER"
-	param set COM_DL_LOSS_T $COM_DL_LOSS_T_LONGER
-
-	COM_RC_LOSS_T_LONGER=$PX4_SIM_SPEED_FACTOR
-	echo "COM_RC_LOSS_T set to $COM_RC_LOSS_T_LONGER"
-	param set COM_RC_LOSS_T $COM_RC_LOSS_T_LONGER
-
-	COM_OF_LOSS_T_LONGER=$SPEED_FACTOR_TIMES_10
-	echo "COM_OF_LOSS_T set to $COM_OF_LOSS_T_LONGER"
-	param set COM_OF_LOSS_T $COM_OF_LOSS_T_LONGER
-fi
 
 # Autostart ID
 autostart_file=''

--- a/src/drivers/drv_hrt.h
+++ b/src/drivers/drv_hrt.h
@@ -80,8 +80,21 @@ typedef struct hrt_call {
 
 /**
  * Get absolute time in [us] (does not wrap).
+ * This time is faked for simulation purposes.
  */
 __EXPORT extern hrt_abstime hrt_absolute_time(void);
+
+#ifdef __PX4_POSIX
+/**
+ * Get absolute time in [us] (does not wrap).
+ * This time won't be faked for simulation purposes but uses
+ * the host / environment time.
+ */
+__EXPORT extern hrt_abstime hrt_absolute_env_time(void);
+#else
+// On everything else but Posix this is always the same as hrt_absolute_time.
+#define hrt_absolute_env_time hrt_absolute_time
+#endif
 
 /**
  * Convert a timespec to absolute time.
@@ -103,6 +116,21 @@ static inline hrt_abstime hrt_elapsed_time(const hrt_abstime *then)
 {
 	return hrt_absolute_time() - *then;
 }
+
+#ifdef __PX4_POSIX
+/**
+ * This elapsed time won't be faked for simulation purposes but uses
+ * the host / environment time.
+ */
+static inline hrt_abstime hrt_elapsed_env_time(const hrt_abstime *then)
+{
+	return hrt_absolute_env_time() - *then;
+}
+#else
+// On everything else but Posix this is always the same as hrt_elapsed_time.
+#define hrt_elapsed_env_time hrt_elapsed_time
+#endif
+
 
 /**
  * Compute the delta between a timestamp taken in the past


### PR DESCRIPTION
This enables using a rational number for `PX4_SIM_SPEED_FACTOR`.
This is required if the simulation is run slower than realtime, for instance 0.5 to simulate at half the speed.

Since bash can't natively do floating point arithmetic, we need to use `bc`.

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.