### PR TITLE
mavlink send_statustext_critical() remove redundant print

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1146,7 +1146,6 @@ void
 Mavlink::send_statustext_critical(const char *string)
 {
 	mavlink_log_critical(&_mavlink_log_pub, "%s", string);
-	PX4_ERR("%s", string);
 }
 
 void


### PR DESCRIPTION
We don't need both mavlink_log_critical and PX4_ERR.
![image](https://user-images.githubusercontent.com/84712/59519814-b7b76980-8e96-11e9-940a-6541cce4f54a.png)
