### PR TITLE
Maximum numbers of connected ESCs in uORB and in UAVCAN expanded to 16.

### DIFF
--- a/msg/esc_status.msg
+++ b/msg/esc_status.msg
@@ -1,5 +1,5 @@
 uint64 timestamp					# time since system start (microseconds)
-uint8 CONNECTED_ESC_MAX = 8				# The number of ESCs supported. Current (Q2/2013) we support 8 ESCs
+uint8 CONNECTED_ESC_MAX = 16				# The number of ESCs supported. Current (Q2/2019) we support 16 ESCs
 
 uint8 ESC_VENDOR_GENERIC = 0				# generic ESC
 uint8 ESC_VENDOR_MIKROKOPTER = 1			# Mikrokopter
@@ -17,4 +17,4 @@ uint16 counter  					# incremented by the writing thread everytime new data is s
 uint8 esc_count						# number of connected ESCs
 uint8 esc_connectiontype				# how ESCs connected to the system
 
-esc_report[8] esc
+esc_report[16] esc

--- a/msg/test_motor.msg
+++ b/msg/test_motor.msg
@@ -1,5 +1,5 @@
 uint64 timestamp				# time since system start (microseconds)
-uint8 NUM_MOTOR_OUTPUTS = 8
+uint8 NUM_MOTOR_OUTPUTS = 16
 
 uint32 motor_number				# number of motor to spin
 float32 value					# output power, range [0..1]

--- a/src/drivers/uavcan/uavcan_main.cpp
+++ b/src/drivers/uavcan/uavcan_main.cpp
@@ -901,9 +901,11 @@ int UavcanNode::run()
 
 			} else if (controls_updated && (_mixers != nullptr)) {
 
-				// XXX one output group has 8 outputs max,
+				// XXX one output group has 16 (esc_status_s::CONNECTED_ESC_MAX) outputs max (Q2/2019),
 				// but this driver could well serve multiple groups.
-				unsigned num_outputs_max = 8;
+				unsigned num_outputs_max = (
+								   esc_status_s::CONNECTED_ESC_MAX < static_cast<unsigned>(uavcan::equipment::esc::RawCommand::FieldTypes::cmd::MaxSize) ?
+								   esc_status_s::CONNECTED_ESC_MAX : static_cast<unsigned>(uavcan::equipment::esc::RawCommand::FieldTypes::cmd::MaxSize));
 
 				_mixers->set_airmode(_airmode);
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
At this time maximum number of supported ESC is 8.
This restriction does not meet modern requirements.
For example, some VTOLs could have 8 motors for MC mode and one or more push/pull motors for FW mode.

**Test data / coverage**
It was tested on real VTOL with 8 MC motors and one push FW motor (with Pixhawk 4 onboard).
The flying plan included MC mode and FW mode.
The flight went well, without any lags or problems.

**Describe your preferred solution**
Increase maximum number of connected ESC in uORB messages and in UAVCAN ESC driver.

**Additional context**
This [PR](https://github.com/PX4/Firmware/pull/12166) also associated with this task as it allow to use VTOL copters with more than 8 motors in simulator.
