### PR TITLE
Pr new vision mav mode

### DIFF
--- a/src/lib/systemlib/system_params.c
+++ b/src/lib/systemlib/system_params.c
@@ -44,7 +44,7 @@
  *
  * @reboot_required true
  * @min 0
- * @max 99999
+ * @max 9999999
  * @group System
  */
 PARAM_DEFINE_INT32(SYS_AUTOSTART, 0);

--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -1678,28 +1678,49 @@ Mavlink::configure_streams_to_default(const char *configure_single_stream)
 		break;
 
 	case MAVLINK_MODE_EXTVISION:
-		configure_stream_local("ALTITUDE", 10.0f); // for avoidance
-		configure_stream_local("ATTITUDE", 25.0f);
-		configure_stream_local("ATTITUDE_TARGET", 10.0f);
-		configure_stream_local("CAMERA_TRIGGER", unlimited_rate); // for VIO
-		configure_stream_local("DISTANCE_SENSOR", 10.0f);		// for avoidance
+		configure_stream_local("HIGHRES_IMU", unlimited_rate);		// for VIO
+		configure_stream_local("TIMESYNC", 10.0f);
+
+	// FALLTHROUGH
+	case MAVLINK_MODE_EXTVISIONMIN:
+		configure_stream_local("ADSB_VEHICLE", unlimited_rate);
+		configure_stream_local("ALTITUDE", 10.0f);
+		configure_stream_local("ATTITUDE", 20.0f);
+		configure_stream_local("ATTITUDE_TARGET", 2.0f);
+		configure_stream_local("CAMERA_IMAGE_CAPTURED", unlimited_rate);
+		configure_stream_local("CAMERA_TRIGGER", unlimited_rate);
+		configure_stream_local("COLLISION", unlimited_rate);
+		configure_stream_local("DEBUG", 1.0f);
+		configure_stream_local("DEBUG_FLOAT_ARRAY", 1.0f);
+		configure_stream_local("DEBUG_VECT", 1.0f);
+		configure_stream_local("DISTANCE_SENSOR", 10.0f);
 		configure_stream_local("ESTIMATOR_STATUS", 1.0f);
 		configure_stream_local("EXTENDED_SYS_STATE", 1.0f);
-		configure_stream_local("GLOBAL_POSITION_INT", 10.0f);
+		configure_stream_local("GLOBAL_POSITION_INT", 5.0f);
+		configure_stream_local("GPS2_RAW", 1.0f);
 		configure_stream_local("GPS_RAW_INT", 1.0f);
 		configure_stream_local("HOME_POSITION", 0.5f);
-		configure_stream_local("HIGHRES_IMU", unlimited_rate);		// for VIO
-		configure_stream_local("LOCAL_POSITION_NED", 30.0f); //for VIO and avoidance
+		configure_stream_local("LOCAL_POSITION_NED", 30.0f);
+		configure_stream_local("NAMED_VALUE_FLOAT", 1.0f);
+		configure_stream_local("NAV_CONTROLLER_OUTPUT", 1.5f);
+		configure_stream_local("ODOMETRY", 30.0f);
+		configure_stream_local("OPTICAL_FLOW_RAD", 1.0f);
+		configure_stream_local("ORBIT_EXECUTION_STATUS", 5.0f);
+		configure_stream_local("PING", 0.1f);
+		configure_stream_local("POSITION_TARGET_GLOBAL_INT", 1.5f);
+		configure_stream_local("POSITION_TARGET_LOCAL_NED", 1.5f);
+		configure_stream_local("RC_CHANNELS", 5.0f);
+		configure_stream_local("SERVO_OUTPUT_RAW_0", 1.0f);
 		configure_stream_local("SYS_STATUS", 5.0f);
-		configure_stream_local("SYSTEM_TIME", 1.0f);
-		configure_stream_local("TIMESYNC", 10.0f);
-		configure_stream_local("TRAJECTORY_REPRESENTATION_WAYPOINTS", 5.0f); // for avoidance
-		configure_stream_local("VFR_HUD", 25.0f);
-		configure_stream_local("WIND_COV", 2.0f);
+		configure_stream_local("TRAJECTORY_REPRESENTATION_WAYPOINTS", 5.0f);
+		configure_stream_local("UTM_GLOBAL_POSITION", 1.0f);
+		configure_stream_local("VFR_HUD", 4.0f);
+		configure_stream_local("WIND_COV", 1.0f);
 		break;
 
+
 	case MAVLINK_MODE_OSD:
-		configure_stream_local("ALTITUDE", 1.0f);
+		configure_stream_local("ALTITUDE", 10.0f);
 		configure_stream_local("ATTITUDE", 25.0f);
 		configure_stream_local("ATTITUDE_TARGET", 10.0f);
 		configure_stream_local("ESTIMATOR_STATUS", 1.0f);
@@ -1987,6 +2008,9 @@ Mavlink::task_main(int argc, char *argv[])
 
 					} else if (strcmp(myoptarg, "extvision") == 0) {
 						_mode = MAVLINK_MODE_EXTVISION;
+
+					} else if (strcmp(myoptarg, "extvisionmin") == 0) {
+						_mode = MAVLINK_MODE_EXTVISIONMIN;
 
 					} else {
 						PX4_ERR("invalid mode");

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -189,6 +189,7 @@ public:
 		MAVLINK_MODE_IRIDIUM,
 		MAVLINK_MODE_MINIMAL,
 		MAVLINK_MODE_EXTVISION,
+		MAVLINK_MODE_EXTVISIONMIN,
 
 		MAVLINK_MODE_COUNT
 	};
@@ -234,6 +235,9 @@ public:
 
 		case MAVLINK_MODE_EXTVISION:
 			return "ExtVision";
+
+		case MAVLINK_MODE_EXTVISIONMIN:
+			return "ExtVisionMin";
 
 		default:
 			return "Unknown";


### PR DESCRIPTION
We've been having many issues on the serial link connecting the Pixhawk 4 to a companion computer. It seems that even if we raise the baudrate to 1.5Mb/s there is not enough bandwidth to use the onboard or extvision modes together with log streaming. Since the onboard mode basically contains any possible mavlink stream, we actually use a small percentage of these for external vision. This pr divides the ext vision mode into two modes, a basic one (extvisionmin) for avoidance and then a normal extvision mode that adds the imu stream that should only be necessary for other applications such as VIO. With this new mavlink mode we were able to reduce the baudrate to 921600 and now we hardly have any drops when running both the mavlink streams and the log streaming on the telem port to the companion.
