### PR TITLE
hardfault_log: fix NULL terminator truncation

### DIFF
--- a/src/systemcmds/hardfault_log/hardfault_log.c
+++ b/src/systemcmds/hardfault_log/hardfault_log.c
@@ -172,7 +172,7 @@ static int format_fault_file_name(struct timespec *ts, char *buffer, unsigned in
 		unsigned int plen = LOG_PATH_BASE_LEN;
 
 		if (maxsz >= LOG_PATH_LEN) {
-			strncpy(buffer, LOG_PATH_BASE, plen);
+			memcpy(buffer, LOG_PATH_BASE, plen);
 			maxsz -= plen;
 			int rv = format_fault_time(TIME_FMT, ts, fmtbuff, arraySize(fmtbuff));
 
@@ -312,7 +312,7 @@ static int  write_stack(bool inValid, int winsize, uint32_t wtopaddr,
 					if (wtopaddr == topaddr) {
 						strncpy(marker, "<-- ", sizeof(marker));
 						strncat(marker, sp_name, sizeof(marker) - 1);
-						strncat(marker, " top", sizeof(marker));
+						strncat(marker, " top", sizeof(marker) - 1);
 
 					} else if (wtopaddr == spaddr) {
 						strncpy(marker, "<-- ", sizeof(marker));
@@ -321,7 +321,7 @@ static int  write_stack(bool inValid, int winsize, uint32_t wtopaddr,
 					} else if (wtopaddr == botaddr) {
 						strncpy(marker, "<-- ", sizeof(marker));
 						strncat(marker, sp_name, sizeof(marker) - 1);
-						strncat(marker, " bottom", sizeof(marker));
+						strncat(marker, " bottom", sizeof(marker) - 1);
 
 					} else {
 						marker[0] = '\0';


### PR DESCRIPTION
building "make omnibus_f4sd_default" with gcc 8.2.1 failes with:
hardfault_log.c:315:7: error: 'strncat' specified bound 30 equals destination size

gcc8 introduced -Wstringop-truncation, which will warn about NULL terminator
truncation.

This patch fixes two similar issues:
- strncpy() makes no sense if we want to copy without NULL terminator
- strncat() needs space to append the NULL terminator

fixes #12283

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by the proposed pull request**
A clear and concise description of the problem this proposed change will solve. E.g. For this use case I ran into...

**Test data / coverage**
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.

**Describe your preferred solution**
A clear and concise description of what you have implemented.

**Describe possible alternatives**
A clear and concise description of alternative solutions or features you've considered.

**Additional context**
Add any other related context or media.
