### PR TITLE
MC mixer: prioritize roll/pitch over yaw for full airmode

### DIFF
--- a/src/lib/mixer/mixer.h
+++ b/src/lib/mixer/mixer.h
@@ -773,7 +773,8 @@ private:
 	 * Mix roll, pitch, yaw, thrust and set the outputs vector.
 	 *
 	 * Desaturation behavior: full airmode for roll/pitch/yaw:
-	 * thrust is increased/decreased as much as required to meet demanded the roll/pitch/yaw.
+	 * thrust is increased/decreased as much as required to meet demanded the roll/pitch/yaw,
+	 * while giving priority to roll and pitch over yaw.
 	 */
 	inline void mix_airmode_rpy(float roll, float pitch, float yaw, float thrust, float *outputs);
 

--- a/src/lib/mixer/mixer_multirotor.cpp
+++ b/src/lib/mixer/mixer_multirotor.cpp
@@ -285,6 +285,14 @@ void MultirotorMixer::mix_airmode_rpy(float roll, float pitch, float yaw, float 
 	}
 
 	minimize_saturation(_tmp_array, outputs, _saturation_status);
+
+	// Unsaturate yaw (in case upper and lower bounds are exceeded)
+	// to prioritize roll/pitch over yaw.
+	for (unsigned i = 0; i < _rotor_count; i++) {
+		_tmp_array[i] = _rotors[i].yaw_scale;
+	}
+
+	minimize_saturation(_tmp_array, outputs, _saturation_status);
 }
 
 void MultirotorMixer::mix_airmode_disabled(float roll, float pitch, float yaw, float thrust, float *outputs)

--- a/src/lib/mixer/mixer_multirotor.py
+++ b/src/lib/mixer/mixer_multirotor.py
@@ -134,7 +134,13 @@ def airmode_rpy(m_sp, P, u_min, u_max):
     # Use thrust to unsaturate the outputs if needed
     u_T = P[:, 3]
     u_prime = minimize_sat(u, u_min, u_max, u_T)
-    return (u, u_prime)
+
+    # Unsaturate yaw (in case upper and lower bounds are exceeded)
+    # to prioritize roll/pitch over yaw.
+    u_T = P[:, 2]
+    u_prime_yaw = minimize_sat(u_prime, u_min, u_max, u_T)
+
+    return (u, u_prime_yaw)
 
 
 def normal_mode(m_sp, P, u_min, u_max):


### PR DESCRIPTION
Only the full airmode gives equal priority to roll, pitch and yaw, the others reduce yaw priority. I find that behavior also desirable in full airmode, as it improves roll/pitch tracking for large yaw sp changes (for example). I have already flown with this over the last weeks/months.

Here are some logs:
- https://logs.px4.io/plot_app?log=1548c302-3172-4cad-985c-b233903b2f97
- https://logs.px4.io/plot_app?log=fb569865-77b1-4a8c-92b5-9888ed9460c2
- https://logs.px4.io/plot_app?log=1a3fb8a8-770e-411c-98ed-87b5f4d79a0a
- https://logs.px4.io/plot_app?log=d76881ac-9b21-4cd9-9489-2e76c2ac9fbb