### PR TITLE
MC rate controller: add I term reduction factor 

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
+++ b/ROMFS/px4fmu_common/init.d/airframes/4041_beta75x
@@ -31,7 +31,7 @@ then
 
 	param set MC_AIRMODE 2
 	param set MC_PITCHRATE_D 0.0010
-	param set MC_PITCHRATE_I 0.4
+	param set MC_PITCHRATE_I 0.5
 	param set MC_PITCHRATE_MAX 600
 	param set MC_PITCHRATE_P 0.0750
 	param set MC_PITCH_P 6

--- a/ROMFS/px4fmu_common/init.d/airframes/4050_generic_250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4050_generic_250
@@ -17,7 +17,7 @@ if [ $AUTOCNF = yes ]
 then
 	param set MC_ROLL_P 8
 	param set MC_ROLLRATE_P 0.08
-	param set MC_ROLLRATE_I 0.2
+	param set MC_ROLLRATE_I 0.25
 	param set MC_ROLLRATE_D 0.001
 	param set MC_PITCH_P 8
 	param set MC_PITCHRATE_P 0.08

--- a/ROMFS/px4fmu_common/init.d/airframes/4052_holybro_qav250
+++ b/ROMFS/px4fmu_common/init.d/airframes/4052_holybro_qav250
@@ -26,12 +26,12 @@ then
 
 	param set MC_AIRMODE 1
 	param set MC_PITCHRATE_D 0.0012
-	param set MC_PITCHRATE_I 0.25
+	param set MC_PITCHRATE_I 0.35
 	param set MC_PITCHRATE_MAX 1200
 	param set MC_PITCHRATE_P 0.082
 	param set MC_PITCH_P 8
 	param set MC_ROLLRATE_D 0.0012
-	param set MC_ROLLRATE_I 0.2
+	param set MC_ROLLRATE_I 0.3
 	param set MC_ROLLRATE_MAX 1200
 	param set MC_ROLLRATE_P 0.076
 	param set MC_ROLL_P 8

--- a/src/modules/mc_att_control/mc_att_control_main.cpp
+++ b/src/modules/mc_att_control/mc_att_control_main.cpp
@@ -481,8 +481,17 @@ MulticopterAttitudeControl::control_attitude_rates(float dt)
 
 			}
 
+			// I term factor: reduce the I gain with increasing rate error.
+			// This counteracts a non-linear effect where the integral builds up quickly upon a large setpoint
+			// change (noticeable in a bounce-back effect after a flip).
+			// The formula leads to a gradual decrease w/o steps, while only affecting the cases where it should:
+			// with the parameter set to 400 degrees, up to 100 deg rate error, i_factor is almost 1 (having no effect),
+			// and up to 200 deg error leads to <25% reduction of I.
+			float i_factor = rates_err(i) / math::radians(400.f);
+			i_factor = math::max(0.0f, 1.f - i_factor * i_factor);
+
 			// Perform the integration using a first order method and do not propagate the result if out of range or invalid
-			float rate_i = _rates_int(i) + rates_i_scaled(i) * rates_err(i) * dt;
+			float rate_i = _rates_int(i) + i_factor * rates_i_scaled(i) * rates_err(i) * dt;
 
 			if (PX4_ISFINITE(rate_i) && rate_i > -_rate_int_lim(i) && rate_i < _rate_int_lim(i)) {
 				_rates_int(i) = rate_i;


### PR DESCRIPTION
As mentioned in https://github.com/PX4/Firmware/pull/11560, as a result of keeping the integrators enabled, there is a bounce-back effect after a flip, due to integral build-up. This effect is non-linear, and therefore cannot be accounted for by the existing PID controller.

So this PR adds another factor to the I gain. It reduces the I gain in cases of very large rate tracking errors (in which case the P gain should reduce the error, not the I gain). The formula is visualized here: https://www.desmos.com/calculator/3o8tfaetan. Red is the existing behavior, and blue the adjusted I gain.
Up to 100 degrees tracking error, the behavior is nearly identical. And up to 200 degrees the gain is almost not reduced (<25%), so it really only takes effect where it should, without introducing steps. In the logs I checked, the tracking error is generally around or below 100 degrees for 'normal' flight.

The result is noticeably better, and it allows to considerably increase I gains in general w/o negative side-effects.
### master:
![bokeh_plot_roll_rate_i_factor_disabled](https://user-images.githubusercontent.com/281593/59593882-0eb97a80-90f3-11e9-8b40-4caa479886dd.png)
### this PR:
![bokeh_plot_roll_rate_i_factor_enabled](https://user-images.githubusercontent.com/281593/59593879-0bbe8a00-90f3-11e9-95c2-010ed3848954.png)


The better the rate tracking, the less this is required (because of the lower tracking error). At the same time it also does not harm, as the i_factor will always be close to 1.

I have flown this for several weeks/months and have not noticed any negative side-effects.

Here are some logs:
- https://logs.px4.io/plot_app?log=1548c302-3172-4cad-985c-b233903b2f97
- https://logs.px4.io/plot_app?log=fb569865-77b1-4a8c-92b5-9888ed9460c2
- https://logs.px4.io/plot_app?log=1a3fb8a8-770e-411c-98ed-87b5f4d79a0a
- https://logs.px4.io/plot_app?log=d76881ac-9b21-4cd9-9489-2e76c2ac9fbb