### PR TITLE
Parameter for virtual battery in SITL

### DIFF
--- a/src/modules/simulator/simulator.h
+++ b/src/modules/simulator/simulator.h
@@ -300,6 +300,7 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::SIM_BAT_DRAIN>) _param_sim_bat_drain, ///< battery drain interval
+		(ParamFloat<px4::params::SIM_BAT_MIN_PCT>) _battery_min_percentage, //< minimum battery percentage
 		(ParamInt<px4::params::MAV_TYPE>) _param_mav_type,
 		(ParamInt<px4::params::MAV_SYS_ID>) _param_mav_sys_id,
 		(ParamInt<px4::params::MAV_COMP_ID>) _param_mav_comp_id

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -383,12 +383,11 @@ void Simulator::handle_message_hil_sensor(const mavlink_message_t *msg)
 		}
 
 		float ibatt = -1.0f; // no current sensor in simulation
-		const float minimum_percentage = 0.499f; // change this value if you want to simulate low battery reaction
 
 		/* Simulate the voltage of a linearly draining battery but stop at the minimum percentage */
 		float battery_percentage = 1.0f - (now_us - batt_sim_start) / discharge_interval_us;
 
-		battery_percentage = math::max(battery_percentage, minimum_percentage);
+		battery_percentage = math::max(battery_percentage, _battery_min_percentage.get() / 100);
 		float vbatt = math::gradual(battery_percentage, 0.f, 1.f, _battery.empty_cell_voltage(), _battery.full_cell_voltage());
 		vbatt *= _battery.cell_count();
 

--- a/src/modules/simulator/simulator_mavlink.cpp
+++ b/src/modules/simulator/simulator_mavlink.cpp
@@ -387,7 +387,7 @@ void Simulator::handle_message_hil_sensor(const mavlink_message_t *msg)
 		/* Simulate the voltage of a linearly draining battery but stop at the minimum percentage */
 		float battery_percentage = 1.0f - (now_us - batt_sim_start) / discharge_interval_us;
 
-		battery_percentage = math::max(battery_percentage, _battery_min_percentage.get() / 100);
+		battery_percentage = math::max(battery_percentage, _battery_min_percentage.get() / 100.f);
 		float vbatt = math::gradual(battery_percentage, 0.f, 1.f, _battery.empty_cell_voltage(), _battery.full_cell_voltage());
 		vbatt *= _battery.cell_count();
 

--- a/src/modules/simulator/simulator_params.c
+++ b/src/modules/simulator/simulator_params.c
@@ -53,7 +53,9 @@
 PARAM_DEFINE_FLOAT(SIM_BAT_DRAIN, 60);
 
 /**
- * Simulator Battery minimal percentage
+ * Simulator Battery minimal percentage. Can be used to alter
+ * the battery level during SITL- or HITL-simulation on the fly.
+ * Particularly useful for testing different low-battery behaviour.
  *
  * @min 0
  * @max 100

--- a/src/modules/simulator/simulator_params.c
+++ b/src/modules/simulator/simulator_params.c
@@ -51,3 +51,15 @@
  * @group SITL
  */
 PARAM_DEFINE_FLOAT(SIM_BAT_DRAIN, 60);
+
+/**
+ * Simulator Battery minimal percentage
+ *
+ * @min 0
+ * @max 100
+ * @increment 0.1
+ * @unit %
+ *
+ * @group SITL
+ */
+PARAM_DEFINE_FLOAT(SIM_BAT_MIN_PCT, 50.0f);


### PR DESCRIPTION
Adds a parameter to configure the battery level in SITL. Useful for testing on different battery levels. From a PX4 developer perspective this is probably not necessary, because it's easy and quick to change the hard-coded value when necessary. But for people creating their own apps using the DroneCode SDK, this might be useful.