### PR TITLE
Adding VTOL Octoplane airframe type

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/13050_generic_vtol_octo
+++ b/ROMFS/px4fmu_common/init.d/airframes/13050_generic_vtol_octo
@@ -1,0 +1,44 @@
+#!/bin/sh
+#
+# @name Generic Octoplane VTOL
+#
+# @type VTOL Octoplane
+# @class VTOL
+#
+# @maintainer
+#
+# @output MAIN1 motor 1
+# @output MAIN2 motor 2
+# @output MAIN3 motor 3
+# @output MAIN4 motor 4
+# @output MAIN5 motor 5
+# @output MAIN6 motor 6
+# @output MAIN7 motor 7
+# @output MAIN8 motor 8
+# @output AUX1 Aileron 1
+# @output AUX2 Aileron 2
+# @output AUX3 Elevator
+# @output AUX4 Rudder
+# @output AUX5 Throttle
+#
+
+sh /etc/init.d/rc.vtol_defaults
+
+if [ $AUTOCNF = yes ]
+then
+	param set PWM_AUX_DIS5 950
+	param set PWM_RATE 400
+
+	param set VT_TYPE 2
+	param set VT_MOT_COUNT 8
+
+	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
+	param set V19_VT_ROLLDIR 0
+fi
+
+set MAV_TYPE 22
+
+set MIXER octo_cox
+set MIXER_AUX vtol_AAERT
+
+set PWM_OUT 12345678

--- a/Tools/px4airframes/srcparser.py
+++ b/Tools/px4airframes/srcparser.py
@@ -74,6 +74,8 @@ class ParameterGroup(object):
             return "VTOLQuadRotorTailSitter"
         elif (self.name == "VTOL Tiltrotor"):
             return "VTOLTiltRotor"
+        elif (self.name == "VTOL Octoplane"):
+            return "VTOLPlaneOcto"
         elif (self.name == "Coaxial Helicopter"):
             return "HelicopterCoaxial"
         elif (self.name == "Helicopter"):


### PR DESCRIPTION
At this time some VTOLs could have 8 motors for MC mode.
I think that the ability to develop their support will be more convenient with the appropriate class.


Corresponding PR in User Guide: https://github.com/PX4/px4_user_guide/pull/503
Corresponding PR in Devguide: https://github.com/PX4/Devguide/pull/818
Corresponding PR in QGroundcontrol: https://github.com/mavlink/qgroundcontrol/pull/7537