### PR TITLE
Removed negative sign from _takeoff_ramp_vz_init

### DIFF
--- a/src/modules/mc_pos_control/Takeoff/Takeoff.cpp
+++ b/src/modules/mc_pos_control/Takeoff/Takeoff.cpp
@@ -41,7 +41,7 @@
 void Takeoff::generateInitialRampValue(const float hover_thrust, float velocity_p_gain)
 {
 	velocity_p_gain = math::max(velocity_p_gain, 0.01f);
-	_takeoff_ramp_vz_init = -hover_thrust / velocity_p_gain;
+	_takeoff_ramp_vz_init = hover_thrust / velocity_p_gain;
 }
 
 void Takeoff::updateTakeoffState(const bool armed, const bool landed, const bool want_takeoff,


### PR DESCRIPTION


**Describe problem solved by the proposed pull request**
If the initial `_takeoff_ramp_vz_init` value is negative, as it is now in master, the takeoff ramp will go from that negative value to the parameter 'MPC_Z_VEL_MAX_UP', which is positive:
https://github.com/PX4/Firmware/blob/e0f3fc8d00850292a8309416574b34f6fbabaaa3/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp#L141

In mc_pos_control.cpp we assign the output of this ramp to constraint.ramp_up:
https://github.com/PX4/Firmware/blob/e0f3fc8d00850292a8309416574b34f6fbabaaa3/src/modules/mc_pos_control/mc_pos_control_main.cpp#L579

Which is then used in PositionControl.cpp:
https://github.com/PX4/Firmware/blob/e0f3fc8d00850292a8309416574b34f6fbabaaa3/src/modules/mc_pos_control/PositionControl.cpp#L229

Negative values in `constraints.speed_up` make no sense, that's why I think that this negative sign might be a bug.

