### PR TITLE
Fill in thrust field correctly for offboard rates setpoints on fixed wing

### DIFF
--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1419,8 +1419,6 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 					}
 
 					if (!_offboard_control_mode.ignore_thrust) { // dont't overwrite thrust if it's invalid
-						// Fill correct field by checking frametype
-						// TODO: add as needed
 						switch (_mavlink->get_system_type()) {
 						case MAV_TYPE_GENERIC:
 							break;

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -1419,7 +1419,29 @@ MavlinkReceiver::handle_message_set_attitude_target(mavlink_message_t *msg)
 					}
 
 					if (!_offboard_control_mode.ignore_thrust) { // dont't overwrite thrust if it's invalid
-						rates_sp.thrust_body[2] = -set_attitude_target.thrust;
+						// Fill correct field by checking frametype
+						// TODO: add as needed
+						switch (_mavlink->get_system_type()) {
+						case MAV_TYPE_GENERIC:
+							break;
+
+						case MAV_TYPE_FIXED_WING:
+							rates_sp.thrust_body[0] = set_attitude_target.thrust;
+							break;
+
+						case MAV_TYPE_QUADROTOR:
+						case MAV_TYPE_HEXAROTOR:
+						case MAV_TYPE_OCTOROTOR:
+						case MAV_TYPE_TRICOPTER:
+						case MAV_TYPE_HELICOPTER:
+							rates_sp.thrust_body[2] = -set_attitude_target.thrust;
+							break;
+
+						case MAV_TYPE_GROUND_ROVER:
+							rates_sp.thrust_body[0] = set_attitude_target.thrust;
+							break;
+						}
+
 					}
 
 					if (_rates_sp_pub == nullptr) {


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This is a follow up PR of #12149 which enables body rate setpoints in offboard mode for fixed wing. Previously body rate setpoints were not properly supported as the thrust field was assumed to be always in the z direction as in multicopters. I believe being able to control bodyrates of a fixed wing drone can lead to exciting robotic applications for fixed wing systems.

**Test data / coverage**
This is the log of sending body rate setpoints in offboard mode on a fixed wing in SITL: https://review.px4.io/plot_app?log=dfd84960-01fa-4f69-b452-8f3b34c6891c

**Describe your preferred solution**
Apply the fix from #12149 for rate setpoints