### PR TITLE
Holybro S500 Airframe

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/4014_s500
+++ b/ROMFS/px4fmu_common/init.d/airframes/4014_s500
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# @name S500
+# @name S500 Generic
 #
 # @type Quadrotor x
 # @class Copter
@@ -15,12 +15,10 @@ set PWM_OUT 1234
 
 if [ $AUTOCNF = yes ]
 then
-	param set MC_ROLL_P 6.5
 	param set MC_ROLLRATE_P 0.18
-	param set MC_ROLLRATE_I 0.15
-	param set MC_ROLLRATE_D 0.003
-	param set MC_PITCH_P 6.5
 	param set MC_PITCHRATE_P 0.18
+	param set MC_ROLLRATE_I 0.15
 	param set MC_PITCHRATE_I 0.15
+	param set MC_ROLLRATE_D 0.003
 	param set MC_PITCHRATE_D 0.003
 fi

--- a/ROMFS/px4fmu_common/init.d/airframes/4015_holybro_s500
+++ b/ROMFS/px4fmu_common/init.d/airframes/4015_holybro_s500
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+# @name Holybro S500
+#
+# @type Quadrotor x
+# @class Copter
+#
+# @maintainer Lorenz Meier <lorenz@px4.io>
+#
+
+sh /etc/init.d/rc.mc_defaults
+
+set MIXER quad_x
+set PWM_OUT 1234
+
+if [ $AUTOCNF = yes ]
+then
+	param set IMU_GYRO_CUTOFF 80
+	param set MC_DTERM_CUTOFF 40
+	param set MC_ROLLRATE_P 0.14
+	param set MC_PITCHRATE_P 0.14
+	param set MC_ROLLRATE_I 0.3
+	param set MC_PITCHRATE_I 0.3
+	param set MC_ROLLRATE_D 0.004
+	param set MC_PITCHRATE_D 0.004
+fi

--- a/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
@@ -69,6 +69,7 @@ px4_add_romfs_files(
 	4012_quad_x_can
 	4013_bebop
 	4014_s500
+	4015_holybro_s500
 	4020_hk_micro_pcb
 	4030_3dr_solo
 	4031_3dr_quad

--- a/src/modules/mc_att_control/mc_att_control_params.c
+++ b/src/modules/mc_att_control/mc_att_control_params.c
@@ -76,7 +76,7 @@ PARAM_DEFINE_FLOAT(MC_ROLLRATE_P, 0.15f);
  * @increment 0.01
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MC_ROLLRATE_I, 0.05f);
+PARAM_DEFINE_FLOAT(MC_ROLLRATE_I, 0.2f);
 
 /**
  * Roll rate integrator limit
@@ -151,7 +151,7 @@ PARAM_DEFINE_FLOAT(MC_PITCHRATE_P, 0.15f);
  * @increment 0.01
  * @group Multicopter Attitude Control
  */
-PARAM_DEFINE_FLOAT(MC_PITCHRATE_I, 0.05f);
+PARAM_DEFINE_FLOAT(MC_PITCHRATE_I, 0.2f);
 
 /**
  * Pitch rate integrator limit


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Thanks to feedback from Holybro we realized that on their S500 Kit the default parameters don't result in a user-friendly tuning and we created a profile for users using that exact kit. Furthermore we'll check the default gains on 450-500 size quadcopters to see if they need to be adjusted for best first flight experience.

Additionally the default rate constrol integral gain for roll and pitch was increased because @bkueang and me realized that on every frame we tune it's much too low. Usually it needs to be increased to 0.3 or even 0.4 to have better "locked in" flight performance and 0.2 seems like a good compromise for a safe default.

**Test data / coverage**
The tuning of the Holybro S500 airframe was tested on site on a brand new assembled kit (with calibrated ESCs). The team from Holybro that was present at the PX4 Dev Summit was able to test it.
