### PR TITLE
Revert "VTOL: add parameter to prevent flight if roll direction was not checked

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/1040_standard_vtol
+++ b/ROMFS/px4fmu_common/init.d-posix/1040_standard_vtol
@@ -39,9 +39,6 @@ then
 	param set VT_TYPE 2
 
 	param set WEST_EN 1
-
-	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
-	param set V19_VT_ROLLDIR 0
 fi
 
 set MAV_TYPE 22

--- a/ROMFS/px4fmu_common/init.d-posix/1041_tailsitter
+++ b/ROMFS/px4fmu_common/init.d-posix/1041_tailsitter
@@ -39,9 +39,6 @@ then
 	param set VT_TYPE 0
 
 	param set WEST_EN 1
-
-	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
-	param set V19_VT_ROLLDIR 0
 fi
 
 set MAV_TYPE 20

--- a/ROMFS/px4fmu_common/init.d-posix/1042_tiltrotor
+++ b/ROMFS/px4fmu_common/init.d-posix/1042_tiltrotor
@@ -42,9 +42,6 @@ then
 	param set VT_TYPE 1
 
 	param set WEST_EN 1
-
-	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
-	param set V19_VT_ROLLDIR 0
 fi
 
 set MAV_TYPE 21

--- a/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
@@ -61,9 +61,6 @@ then
 	param set VT_F_TRANS_THR 0.75
 	param set VT_MOT_COUNT 4
 	param set VT_TYPE 2
-
-	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
-	param set V19_VT_ROLLDIR 0
 fi
 
 param set SYS_HITL 1

--- a/ROMFS/px4fmu_common/init.d/airframes/13000_generic_vtol_standard
+++ b/ROMFS/px4fmu_common/init.d/airframes/13000_generic_vtol_standard
@@ -27,9 +27,6 @@ then
 
 	param set VT_TYPE 2
 	param set VT_MOT_COUNT 4
-
-	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
-	param set V19_VT_ROLLDIR 0
 fi
 
 set MAV_TYPE 22

--- a/ROMFS/px4fmu_common/init.d/airframes/13001_caipirinha_vtol
+++ b/ROMFS/px4fmu_common/init.d/airframes/13001_caipirinha_vtol
@@ -37,9 +37,6 @@ then
 	param set VT_ELEV_MC_LOCK 0
 	param set VT_MOT_COUNT 2
 	param set VT_TYPE 0
-
-	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
-	param set V19_VT_ROLLDIR 0
 fi
 
 set MAV_TYPE 19

--- a/ROMFS/px4fmu_common/init.d/airframes/13002_firefly6
+++ b/ROMFS/px4fmu_common/init.d/airframes/13002_firefly6
@@ -48,9 +48,6 @@ then
 	param set VT_TILT_FW 0.9
 	param set VT_ELEV_MC_LOCK 0
 	param set VT_TYPE 1
-
-	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
-	param set V19_VT_ROLLDIR 0
 fi
 
 set MAV_TYPE 21

--- a/ROMFS/px4fmu_common/init.d/airframes/13003_quad_tailsitter
+++ b/ROMFS/px4fmu_common/init.d/airframes/13003_quad_tailsitter
@@ -19,9 +19,6 @@ then
 	param set VT_IDLE_PWM_MC  1080
 	param set VT_TYPE 0
 	param set VT_ELEV_MC_LOCK 1
-
-	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
-	param set V19_VT_ROLLDIR 0
 fi
 
 set MAV_TYPE 20

--- a/ROMFS/px4fmu_common/init.d/airframes/13004_quad+_tailsitter
+++ b/ROMFS/px4fmu_common/init.d/airframes/13004_quad+_tailsitter
@@ -30,9 +30,6 @@ then
 	param set VT_IDLE_PWM_MC  1080
 	param set VT_TYPE 0
 	param set VT_ELEV_MC_LOCK 1
-
-	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
-	param set V19_VT_ROLLDIR 0
 fi
 
 set MAV_TYPE 20

--- a/ROMFS/px4fmu_common/init.d/airframes/13005_vtol_AAERT_quad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13005_vtol_AAERT_quad
@@ -61,9 +61,6 @@ then
 	param set VT_MOT_COUNT 4
 	param set VT_IDLE_PWM_MC 1080
 	param set VT_TYPE 2
-
-	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
-	param set V19_VT_ROLLDIR 0
 fi
 
 set MAV_TYPE 22

--- a/ROMFS/px4fmu_common/init.d/airframes/13006_vtol_standard_delta
+++ b/ROMFS/px4fmu_common/init.d/airframes/13006_vtol_standard_delta
@@ -49,9 +49,6 @@ then
 	param set VT_F_TRANS_THR 0.75
 	param set VT_IDLE_PWM_MC 1080
 	param set VT_TYPE 2
-
-	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
-	param set V19_VT_ROLLDIR 0
 fi
 
 set MAV_TYPE 22

--- a/ROMFS/px4fmu_common/init.d/airframes/13007_vtol_AAVVT_quad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13007_vtol_AAVVT_quad
@@ -38,9 +38,6 @@ then
 	param set VT_MOT_COUNT 4
 	param set VT_IDLE_PWM_MC 1080
 	param set VT_TYPE 2
-
-	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
-	param set V19_VT_ROLLDIR 0
 fi
 
 set MAV_TYPE 22

--- a/ROMFS/px4fmu_common/init.d/airframes/13008_QuadRanger
+++ b/ROMFS/px4fmu_common/init.d/airframes/13008_QuadRanger
@@ -55,9 +55,6 @@ then
 	param set VT_IDLE_PWM_MC 1080
 	param set VT_MOT_COUNT 4
 	param set VT_TYPE 2
-
-	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
-	param set V19_VT_ROLLDIR 0
 fi
 
 set MAV_TYPE 22

--- a/ROMFS/px4fmu_common/init.d/airframes/13009_vtol_spt_ranger
+++ b/ROMFS/px4fmu_common/init.d/airframes/13009_vtol_spt_ranger
@@ -77,8 +77,6 @@ then
 	param set VT_TRANS_TIMEOUT    30
 	param set VT_TYPE 2
 
-	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
-	param set V19_VT_ROLLDIR 0
 fi
 
 set MAV_TYPE 22

--- a/ROMFS/px4fmu_common/init.d/airframes/13010_claire
+++ b/ROMFS/px4fmu_common/init.d/airframes/13010_claire
@@ -30,9 +30,6 @@ then
 	param set VT_TILT_TRANS 0.5
 	param set VT_ELEV_MC_LOCK 0
 	param set VT_TYPE 1
-
-	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
-	param set V19_VT_ROLLDIR 0
 fi
 
 set MAV_TYPE 21

--- a/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
+++ b/ROMFS/px4fmu_common/init.d/airframes/13012_convergence
@@ -77,9 +77,6 @@ then
 	param set VT_TRANS_P2_DUR 1.3
 	param set VT_ELEV_MC_LOCK 0
 	param set VT_TYPE 1
-
-	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
-	param set V19_VT_ROLLDIR 0
 fi
 
 set MAV_TYPE 21

--- a/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
@@ -151,8 +151,6 @@ then
 	param set VT_TRANS_TIMEOUT 22
 	param set VT_F_TRANS_RAMP 4
 
-	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
-	param set V19_VT_ROLLDIR 0
 fi
 
 set MAV_TYPE 22

--- a/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
+++ b/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
@@ -58,8 +58,6 @@ then
 	param set PWM_MAIN_MIN3 1120
 	param set PWM_MIN 950
 
-	param set V19_VT_ROLLDIR 0
-
 	param set VT_ARSP_TRANS 19
 	param set VT_B_TRANS_DUR 9
 	param set VT_ELEV_MC_LOCK 0

--- a/ROMFS/px4fmu_common/init.d/airframes/13050_generic_vtol_octo
+++ b/ROMFS/px4fmu_common/init.d/airframes/13050_generic_vtol_octo
@@ -31,9 +31,6 @@ then
 
 	param set VT_TYPE 2
 	param set VT_MOT_COUNT 8
-
-	# Indicate that FW roll direction was fixed in mixer, to be removed in v1.10
-	param set V19_VT_ROLLDIR 0
 fi
 
 set MAV_TYPE 22

--- a/src/modules/vtol_att_control/vtol_att_control_main.cpp
+++ b/src/modules/vtol_att_control/vtol_att_control_main.cpp
@@ -92,8 +92,6 @@ VtolAttitudeControl::VtolAttitudeControl()
 	_params_handles.diff_thrust = param_find("VT_FW_DIFTHR_EN");
 	_params_handles.diff_thrust_scale = param_find("VT_FW_DIFTHR_SC");
 
-	_params_handles.v19_vt_rolldir = param_find("V19_VT_ROLLDIR");
-
 	/* fetch initial parameter values */
 	parameters_update();
 
@@ -339,9 +337,6 @@ VtolAttitudeControl::parameters_update()
 	// make sure parameters are feasible, require at least 1 m/s difference between transition and blend airspeed
 	_params.airspeed_blend = math::min(_params.airspeed_blend, _params.transition_airspeed - 1.0f);
 
-	// Bugfix for v1.9, should be removed in 1.10
-	param_get(_params_handles.v19_vt_rolldir, &_params.v19_vt_rolldir);
-
 	// update the parameters of the instances of base VtolType
 	if (_vtol_type != nullptr) {
 		_vtol_type->parameters_update();
@@ -481,39 +476,7 @@ void VtolAttitudeControl::task_main()
 			_vtol_type->update_transition_state();
 		}
 
-		// Fill actuator output
-		if (_params.v19_vt_rolldir) {
-
-			// The mixer may not have been adapted to the roll inversion in v1.9
-			// Display error message and do not fill actuator outputs
-			// TODO: remove the parameter and this error message in v1.10
-			const int v19_rolldir_warning_throttling = 5000;
-			static int v19_rolldir_warning_counter = 0;
-			v19_rolldir_warning_counter += 1;
-
-			if ((v19_rolldir_warning_counter % v19_rolldir_warning_throttling) == 0) {
-				mavlink_log_critical(&_mavlink_log_pub,
-						     "The VTOL roll commands were inverted in v1.9!");
-				mavlink_log_critical(&_mavlink_log_pub,
-						     "Check roll mixing, then set V19_VT_ROLLDIR to 0");
-			}
-
-			// Do not fill actuator output
-			_actuators_out_0.timestamp = hrt_absolute_time();
-			_actuators_out_0.timestamp_sample = _actuators_mc_in.timestamp_sample;
-			_actuators_out_1.timestamp = hrt_absolute_time();
-			_actuators_out_1.timestamp_sample = _actuators_fw_in.timestamp_sample;
-
-			for (size_t i = 0; i < actuator_controls_s::NUM_ACTUATOR_CONTROLS; i++) {
-				_actuators_out_0.control[i] = 0.0f;
-				_actuators_out_1.control[i] = 0.0f;
-			}
-
-		} else {
-
-			// normal operation
-			_vtol_type->fill_actuator_outputs();
-		}
+		_vtol_type->fill_actuator_outputs();
 
 		// reinitialize the setpoint while not armed to make sure no value from the last mode or flight is still kept
 		if (!_v_control_mode.flag_armed) {

--- a/src/modules/vtol_att_control/vtol_att_control_main.h
+++ b/src/modules/vtol_att_control/vtol_att_control_main.h
@@ -197,7 +197,6 @@ private:
 		param_t fw_motors_off;
 		param_t diff_thrust;
 		param_t diff_thrust_scale;
-		param_t v19_vt_rolldir;
 	} _params_handles{};
 
 	/* for multicopters it is usual to have a non-zero idle speed of the engines

--- a/src/modules/vtol_att_control/vtol_att_control_params.c
+++ b/src/modules/vtol_att_control/vtol_att_control_params.c
@@ -315,27 +315,3 @@ PARAM_DEFINE_INT32(VT_FW_DIFTHR_EN, 0);
  * @group VTOL Attitude Control
  */
 PARAM_DEFINE_FLOAT(VT_FW_DIFTHR_SC, 0.1f);
-
-/**
- * Temporary parameter for the upgrade to v1.9, this is reminder to check the direction of
- * fixed-wing roll control surfaces on custom VTOLs platforms.
- *
- * This parameter is present in v1.9 to enable smooth transition, it will be removed in v1.10.
- *
- * In firmware versions before v1.9, the VTOL attitude controller generated reversed fixed
- * wing roll commands. As a consequence, all VTOL mixers had to reverse roll mixing. The
- * VTOL roll commands in fixed wing mode were fixed in v1.9!
- * - Standard VTOL platforms should be unaffected and this parameter can be ignored.
- * - Custom VTOL platforms may crash if no action is taken, please check the direction of
- * deflection of roll control surfaces before flight. Fix the roll mixer if necessary.
- *
- * Set to 1 to disable VTOL actuator outputs and display an info message (default).
- * Set to 0 AFTER CAREFULLY CHECKING the direction of deflection of roll control surfaces.
- *
- * @min 0
- * @max 1
- * @decimal 0
- * @category system
- * @group VTOL Attitude Control
- */
-PARAM_DEFINE_INT32(V19_VT_ROLLDIR, 1);

--- a/src/modules/vtol_att_control/vtol_type.h
+++ b/src/modules/vtol_att_control/vtol_type.h
@@ -70,7 +70,6 @@ struct Params {
 	int32_t fw_motors_off;			/**< bitmask of all motors that should be off in fixed wing mode */
 	int32_t diff_thrust;
 	float diff_thrust_scale;
-	int32_t v19_vt_rolldir;
 };
 
 // Has to match 1:1 msg/vtol_vehicle_status.msg


### PR DESCRIPTION
The VTOL roll direction warning was shipped in PX4 stable v1.9. Let's now get it out of the way for future VTOL development. Thanks again for finally doing this @jlecoeur!

Closes https://github.com/PX4/Firmware/issues/11650.
