### PR TITLE
Rename `_arming -> _actuator_armed` , `_battery -> _battery_status` in the land_detector module.

### DIFF
--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -88,7 +88,7 @@ float FixedwingLandDetector::_get_max_altitude()
 bool FixedwingLandDetector::_get_landed_state()
 {
 	// only trigger flight conditions if we are armed
-	if (!_arming.armed) {
+	if (!_actuator_armed.armed) {
 		return true;
 	}
 

--- a/src/modules/land_detector/LandDetector.cpp
+++ b/src/modules/land_detector/LandDetector.cpp
@@ -80,7 +80,7 @@ void LandDetector::Run()
 	perf_begin(_cycle_perf);
 
 	_check_params(false);
-	_actuator_armed_sub.update(&_arming);
+	_actuator_armed_sub.update(&_actuator_armed);
 	_update_topics();
 	_update_state();
 
@@ -124,7 +124,7 @@ void LandDetector::Run()
 
 	// set the flight time when disarming (not necessarily when landed, because all param changes should
 	// happen on the same event and it's better to set/save params while not in armed state)
-	if (_takeoff_time != 0 && !_arming.armed && _previous_armed_state) {
+	if (_takeoff_time != 0 && !_actuator_armed.armed && _previous_armed_state) {
 		_total_flight_time += now - _takeoff_time;
 		_takeoff_time = 0;
 
@@ -139,7 +139,7 @@ void LandDetector::Run()
 		_param_total_flight_time_low.commit_no_notification();
 	}
 
-	_previous_armed_state = _arming.armed;
+	_previous_armed_state = _actuator_armed.armed;
 
 	perf_end(_cycle_perf);
 

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -153,7 +153,7 @@ protected:
 	systemlib::Hysteresis _ground_contact_hysteresis{true};
 	systemlib::Hysteresis _ground_effect_hysteresis{false};
 
-	actuator_armed_s _arming {};
+	actuator_armed_s _actuator_armed {};
 
 private:
 

--- a/src/modules/land_detector/MulticopterLandDetector.cpp
+++ b/src/modules/land_detector/MulticopterLandDetector.cpp
@@ -93,7 +93,7 @@ MulticopterLandDetector::MulticopterLandDetector()
 void MulticopterLandDetector::_update_topics()
 {
 	_actuator_controls_sub.update(&_actuator_controls);
-	_battery_sub.update(&_battery);
+	_battery_sub.update(&_battery_status);
 	_sensor_bias_sub.update(&_sensor_bias);
 	_vehicle_attitude_sub.update(&_vehicle_attitude);
 	_vehicle_control_mode_sub.update(&_control_mode);
@@ -141,7 +141,7 @@ bool MulticopterLandDetector::_get_freefall_state()
 bool MulticopterLandDetector::_get_ground_contact_state()
 {
 	// When not armed, consider to have ground-contact
-	if (!_arming.armed) {
+	if (!_actuator_armed.armed) {
 		return true;
 	}
 
@@ -192,7 +192,7 @@ bool MulticopterLandDetector::_get_maybe_landed_state()
 	const hrt_abstime now = hrt_absolute_time();
 
 	// When not armed, consider to be maybe-landed
-	if (!_arming.armed) {
+	if (!_actuator_armed.armed) {
 		return true;
 	}
 
@@ -239,7 +239,7 @@ bool MulticopterLandDetector::_get_maybe_landed_state()
 bool MulticopterLandDetector::_get_landed_state()
 {
 	// When not armed, consider to be landed
-	if (!_arming.armed) {
+	if (!_actuator_armed.armed) {
 		return true;
 	}
 
@@ -265,15 +265,15 @@ float MulticopterLandDetector::_get_max_altitude()
 	/* ToDo: add a meaningful altitude */
 	float valid_altitude_max = _params.altitude_max;
 
-	if (_battery.warning == battery_status_s::BATTERY_WARNING_LOW) {
+	if (_battery_status.warning == battery_status_s::BATTERY_WARNING_LOW) {
 		valid_altitude_max = _params.altitude_max * 0.75f;
 	}
 
-	if (_battery.warning == battery_status_s::BATTERY_WARNING_CRITICAL) {
+	if (_battery_status.warning == battery_status_s::BATTERY_WARNING_CRITICAL) {
 		valid_altitude_max = _params.altitude_max * 0.5f;
 	}
 
-	if (_battery.warning == battery_status_s::BATTERY_WARNING_EMERGENCY) {
+	if (_battery_status.warning == battery_status_s::BATTERY_WARNING_EMERGENCY) {
 		valid_altitude_max = _params.altitude_max * 0.25f;
 	}
 

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -132,7 +132,7 @@ private:
 	uORB::Subscription _vehicle_local_position_setpoint_sub{ORB_ID(vehicle_local_position_setpoint)};
 
 	actuator_controls_s               _actuator_controls {};
-	battery_status_s                  _battery {};
+	battery_status_s                  _battery_status {};
 	vehicle_control_mode_s            _control_mode {};
 	sensor_bias_s                     _sensor_bias {};
 	vehicle_attitude_s                _vehicle_attitude {};

--- a/src/modules/land_detector/RoverLandDetector.cpp
+++ b/src/modules/land_detector/RoverLandDetector.cpp
@@ -67,7 +67,7 @@ bool RoverLandDetector::_get_maybe_landed_state()
 
 bool RoverLandDetector::_get_landed_state()
 {
-	if (!_arming.armed) {
+	if (!_actuator_armed.armed) {
 		return true;
 	}
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR renames `_arming` -> `_actuator_armed`  and `_battery` -> `_battery_status` to standardize two variables that were not included in PR #12339;  `_arming` is utilized in multiple classes in the land_detector module, so this is also a simpler diff to review in that regard.

**Test data / coverage**
This commit was flight tested on a 250 quad with pixhawk 4 mini:
1) https://review.px4.io/plot_app?log=bd337c09-87e2-46b9-a3c4-3c59490a2dcf
2) https://review.px4.io/plot_app?log=58db08fb-74d2-44a3-bc77-aa6affa081f3
3) https://review.px4.io/plot_app?log=ce3b0ede-19e2-4be9-b502-e34de6ead3f0

**Additional context**
@dagar, this PR streamlines remaining work for #9756 and minimizes the diff in #11857 .

Please let me know if you have any questions on this PR.  Thanks!

-Mark
