### PR TITLE
Use  `return INFINITY` for `FixedwingLandDetector::_get_max_altitude()`.

### DIFF
--- a/src/modules/land_detector/FixedwingLandDetector.cpp
+++ b/src/modules/land_detector/FixedwingLandDetector.cpp
@@ -57,13 +57,6 @@ void FixedwingLandDetector::_update_topics()
 	_airspeed_sub.update(&_airspeed);
 }
 
-float FixedwingLandDetector::_get_max_altitude()
-{
-	// TODO: This means no altitude limit as the limit
-	// is always current position plus 10000 meters.
-	return roundf(-_vehicle_local_position.z + 10000);
-}
-
 bool FixedwingLandDetector::_get_landed_state()
 {
 	// Only trigger flight conditions if we are armed.

--- a/src/modules/land_detector/FixedwingLandDetector.h
+++ b/src/modules/land_detector/FixedwingLandDetector.h
@@ -43,7 +43,6 @@
 #pragma once
 
 #include <matrix/math.hpp>
-#include <uORB/Subscription.hpp>
 #include <uORB/topics/airspeed.h>
 
 #include "LandDetector.h"
@@ -61,9 +60,6 @@ public:
 protected:
 
 	bool _get_landed_state() override;
-
-	float _get_max_altitude() override;
-
 	void _update_topics() override;
 
 private:

--- a/src/modules/land_detector/LandDetector.h
+++ b/src/modules/land_detector/LandDetector.h
@@ -61,7 +61,6 @@
 #include <uORB/topics/vehicle_land_detected.h>
 #include <uORB/topics/vehicle_local_position.h>
 
-
 using namespace time_literals;
 
 namespace land_detector

--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -42,16 +42,11 @@
 
 #pragma once
 
-#include <math.h>
-
 #include <uORB/topics/actuator_controls.h>
 #include <uORB/topics/battery_status.h>
-#include <uORB/topics/parameter_update.h>
-#include <uORB/topics/vehicle_acceleration.h>
 #include <uORB/topics/vehicle_angular_velocity.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_control_mode.h>
-#include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_local_position_setpoint.h>
 
 #include "LandDetector.h"

--- a/src/modules/land_detector/VtolLandDetector.h
+++ b/src/modules/land_detector/VtolLandDetector.h
@@ -41,7 +41,6 @@
 
 #pragma once
 
-#include <uORB/Subscription.hpp>
 #include <uORB/topics/airspeed.h>
 #include <uORB/topics/vehicle_status.h>
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
~~This PR adds a return value to the LandDetector `_get_max_altitude()` method declaration so that implementations can be deleted from the `FixedWingLandDetector` and `RoverLandDetector` classes.~~  (Updated by #11874)

This PR simplifies the FixedwingLandDetector `_get_max_altitude()` logic by using the LandDetector base class logic return default.  A few `#includes` in the land_detector module that can be deleted are also removed. 

Please let me know if you have any questions on this PR. Thanks!

-Mark
