### PR TITLE
Enable auto disarm by default

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/1001_rc_quad_x.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1001_rc_quad_x.hil
@@ -13,9 +13,4 @@ sh /etc/init.d/rc.mc_defaults
 set MIXER quad_x
 set PWM_OUT 1234
 
-if [ $AUTOCNF = yes ]
-then
-	param set COM_DISARM_LAND 5
-fi
-
 param set SYS_HITL 1

--- a/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
+++ b/ROMFS/px4fmu_common/init.d/airframes/1002_standard_vtol.hil
@@ -14,7 +14,6 @@ if [ $AUTOCNF = yes ]
 then
 	param set BAT_N_CELLS 3
 
-	param set COM_DISARM_LAND 5
 	param set COM_RC_IN_MODE 1
 
 	param set EKF2_AID_MASK 1

--- a/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
+++ b/ROMFS/px4fmu_common/init.d/airframes/13013_deltaquad
@@ -25,8 +25,6 @@ then
 	param set BAT_N_CELLS 4
 	param set BAT_R_INTERNAL 0.0025
 
-	param set COM_DISARM_LAND 5
-
 	param set CBRK_AIRSPD_CHK 162128
 	param set CBRK_IO_SAFETY 22027
 

--- a/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
+++ b/ROMFS/px4fmu_common/init.d/airframes/13014_vtol_babyshark
@@ -25,8 +25,6 @@ then
 
 	param set BAT_N_CELLS 6
 
-	param set COM_DISARM_LAND 3
-
 	param set FW_AIRSPD_MAX   30
 	param set FW_AIRSPD_MIN   19
 	param set FW_AIRSPD_TRIM  23

--- a/ROMFS/px4fmu_common/init.d/airframes/4030_3dr_solo
+++ b/ROMFS/px4fmu_common/init.d/airframes/4030_3dr_solo
@@ -32,7 +32,6 @@ then
 
 	# takeoff, land and RTL settings
 	param set MIS_TAKEOFF_ALT   4
-	param set COM_DISARM_LAND   1
 	param set RTL_LAND_DELAY    1
 	param set RTL_DESCEND_ALT   5
 	param set RTL_RETURN_ALT    15

--- a/ROMFS/px4fmu_common/init.d/airframes/4070_aerofc
+++ b/ROMFS/px4fmu_common/init.d/airframes/4070_aerofc
@@ -22,9 +22,6 @@ sh /etc/init.d/rc.mc_defaults
 if [ $AUTOCNF = yes ]
 then
 	# Set all params here, then disable autoconfig
-
-	param set COM_DISARM_LAND 3
-
 	param set EKF2_GPS_POS_X -0.0600
 	param set EKF2_GPS_POS_Z -0.1000
 	param set EKF2_MIN_OBS_DT 50

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -273,7 +273,7 @@ PARAM_DEFINE_INT32(COM_RC_ARM_HYST, 1000);
  * @unit s
  * @decimal 2
  */
-PARAM_DEFINE_FLOAT(COM_DISARM_LAND, -1.0f);
+PARAM_DEFINE_FLOAT(COM_DISARM_LAND, 2.0f);
 
 /**
  * Allow arming without GPS


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Based on defaults used by products at Yuneec and Auterion, feedback from @MikeGoesDrones and discussions with @RomanBapst and @LorenzMeier I think we need to adjust our defaults to the more common use-case of adopters having a good out of the box experience instead of needing to look up how to enable everything that seems intuitive.

**Test data / coverage**
Untested but it's only a parameter change to a configuration that was used a lot before.