### PR TITLE
FixedWingAttitudeControl: don't lock integrator during transition

### DIFF
--- a/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
+++ b/src/modules/fw_att_control/FixedwingAttitudeControl.cpp
@@ -562,7 +562,7 @@ void FixedwingAttitudeControl::run()
 
 			/* lock integrator until control is started */
 			bool lock_integrator = !_vcontrol_mode.flag_control_rates_enabled
-					       || _vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING;
+					       || (_vehicle_status.vehicle_type == vehicle_status_s::VEHICLE_TYPE_ROTARY_WING && ! _vehicle_status.in_transition_mode);
 
 			/* Simple handling of failsafe: deploy parachute if failsafe is on */
 			if (_vcontrol_mode.flag_control_termination_enabled) {


### PR DESCRIPTION
This change enables the integrator of the fixed wing rate controller during transitions.
This can help improve attitude tracking during transitions, especially if there are trim offsets that need to be learned.

This change was tested on a delta quad and showed to improve attitude tracking and thus altitude tracking during transitions.

Results prior to this fix:
![image](https://user-images.githubusercontent.com/7610489/60328002-92922300-998d-11e9-914e-0b9716d54d6a.png)

Results with the fix:
![image](https://user-images.githubusercontent.com/7610489/60327353-e3088100-998b-11e9-96ca-d7e7586637ce.png)
