### PR TITLE
Jenkins HITL exit upload monitor on nsh>

### DIFF
--- a/Tools/HIL/monitor_firmware_upload.py
+++ b/Tools/HIL/monitor_firmware_upload.py
@@ -26,6 +26,11 @@ def monitor_firmware_upload(port, baudrate):
             finished = 1
             break
 
+        if time.time() - timeout_start > 10:
+            if "nsh>" in serial_line:
+                finished = 1
+                break
+
         if time.time() > timeout_start + timeout:
             print("Error, timeout")
             finished = 1


### PR DESCRIPTION
Sometimes Jenkins misses the initial boot after upload and gets stuck until timeout.