### PR TITLE
Implement ModuleParams inheritance in the VtolLandDetector class.

### DIFF
--- a/src/modules/land_detector/MulticopterLandDetector.h
+++ b/src/modules/land_detector/MulticopterLandDetector.h
@@ -84,6 +84,7 @@ private:
 
 	/* get control mode dependent pilot throttle threshold with which we should quit landed state and take off */
 	float _get_takeoff_throttle();
+
 	bool _has_low_thrust();
 	bool _has_minimal_thrust();
 	bool _has_altitude_lock();

--- a/src/modules/land_detector/VtolLandDetector.cpp
+++ b/src/modules/land_detector/VtolLandDetector.cpp
@@ -48,13 +48,11 @@ namespace land_detector
 
 VtolLandDetector::VtolLandDetector()
 {
-	_paramHandle.maxAirSpeed = param_find("LNDFW_AIRSPD_MAX");
 }
 
 void VtolLandDetector::_update_topics()
 {
 	MulticopterLandDetector::_update_topics();
-
 	_airspeed_sub.update(&_airspeed);
 	_vehicle_status_sub.update(&_vehicle_status);
 }
@@ -92,20 +90,13 @@ bool VtolLandDetector::_get_landed_state()
 
 	// only consider airspeed if we have been in air before to avoid false
 	// detections in the case of wind on the ground
-	if (_was_in_air && (_airspeed_filtered > _params.maxAirSpeed)) {
+	if (_was_in_air && (_airspeed_filtered > _param_lndfw_airspd_max.get())) {
 		landed = false;
 	}
 
 	_was_in_air = !landed;
 
 	return landed;
-}
-
-void VtolLandDetector::_update_params()
-{
-	MulticopterLandDetector::_update_params();
-
-	param_get(_paramHandle.maxAirSpeed, &_params.maxAirSpeed);
 }
 
 } // namespace land_detector

--- a/src/modules/land_detector/VtolLandDetector.h
+++ b/src/modules/land_detector/VtolLandDetector.h
@@ -56,19 +56,11 @@ public:
 	VtolLandDetector();
 
 protected:
-	void _update_params() override;
 	void _update_topics() override;
 	bool _get_landed_state() override;
 	bool _get_maybe_landed_state() override;
 
 private:
-	struct {
-		param_t maxAirSpeed;
-	} _paramHandle{};
-
-	struct {
-		float maxAirSpeed;
-	} _params{};
 
 	uORB::Subscription _airspeed_sub{ORB_ID(airspeed)};
 	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
@@ -78,7 +70,11 @@ private:
 
 	bool _was_in_air{false}; /**< indicates whether the vehicle was in the air in the previous iteration */
 	float _airspeed_filtered{0.0f}; /**< low pass filtered airspeed */
-};
 
+	DEFINE_PARAMETERS_CUSTOM_PARENT(
+		MulticopterLandDetector,
+		(ParamFloat<px4::params::LNDFW_AIRSPD_MAX>) _param_lndfw_airspd_max
+	);
+};
 
 } // namespace land_detector


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR implements `ModuleParams` inheritance in the `VtolLandDetector` class following PR #12356.

**Test data / coverage**
**NOTE:** I do not have hardware to flight test this PR.

**Additional context**
See PR #12356, #12209 and #9756.  This PR requires #12356 prior to acceptance.

@dagar and @bkueng , please let me know if you have any questions on this PR.  Thanks!

-Mark
