### PR TITLE
rc.board_sensors: added lis3mdl to v5 sensors init

### DIFF
--- a/boards/px4/fmu-v5/init/rc.board_sensors
+++ b/boards/px4/fmu-v5/init/rc.board_sensors
@@ -20,6 +20,7 @@ ist8310 -C -b 1 start
 ist8310 -C -b 2 start
 hmc5883 -C -T -X start
 qmc5883 -X start
+lis3mdl -X start
 
 # Possible internal compass
 ist8310 -C -b 5 start


### PR DESCRIPTION
Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by the proposed pull request**
The LIS3MDL compass is not started on v5 firmware, although the driver is available and able to start manually.

**Test data / coverage**
Startup script is showing the lis3mdl as sensor_mag_0 and external with priority 255
![sensors_status_output_lis3mdl](https://user-images.githubusercontent.com/6790455/60453415-f151d980-9be5-11e9-9618-5c461f182c27.png)


**Describe your preferred solution**
Add LIS3MD to sensor init script

**Describe possible alternatives**



