### PR TITLE
FlightTask - Proper initialization after switching task

### DIFF
--- a/src/lib/FlightTasks/FlightTasks.cpp
+++ b/src/lib/FlightTasks/FlightTasks.cpp
@@ -64,6 +64,9 @@ int FlightTasks::switchTask(FlightTaskIndex new_task_index)
 		return 0;
 	}
 
+	// Save current setpoints for the nex FlightTask
+	vehicle_local_position_setpoint_s current_state = getPositionSetpoint();
+
 	if (_initTask(new_task_index)) {
 		// invalid task
 		return -1;
@@ -85,7 +88,7 @@ int FlightTasks::switchTask(FlightTaskIndex new_task_index)
 	_subscription_array.forcedUpdate(); // make sure data is available for all new subscriptions
 
 	// activation failed
-	if (!_current_task.task->updateInitialize() || !_current_task.task->activate()) {
+	if (!_current_task.task->updateInitialize() || !_current_task.task->activate(current_state)) {
 		_current_task.task->~FlightTask();
 		_current_task.task = nullptr;
 		_current_task.index = FlightTaskIndex::None;

--- a/src/lib/FlightTasks/FlightTasks.cpp
+++ b/src/lib/FlightTasks/FlightTasks.cpp
@@ -65,7 +65,7 @@ int FlightTasks::switchTask(FlightTaskIndex new_task_index)
 	}
 
 	// Save current setpoints for the nex FlightTask
-	vehicle_local_position_setpoint_s current_state = getPositionSetpoint();
+	vehicle_local_position_setpoint_s last_setpoint = getPositionSetpoint();
 
 	if (_initTask(new_task_index)) {
 		// invalid task
@@ -88,7 +88,7 @@ int FlightTasks::switchTask(FlightTaskIndex new_task_index)
 	_subscription_array.forcedUpdate(); // make sure data is available for all new subscriptions
 
 	// activation failed
-	if (!_current_task.task->updateInitialize() || !_current_task.task->activate(current_state)) {
+	if (!_current_task.task->updateInitialize() || !_current_task.task->activate(last_setpoint)) {
 		_current_task.task->~FlightTask();
 		_current_task.task = nullptr;
 		_current_task.index = FlightTaskIndex::None;

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -77,9 +77,9 @@ bool FlightTaskAuto::initializeSubscriptions(SubscriptionArray &subscription_arr
 	return true;
 }
 
-bool FlightTaskAuto::activate(vehicle_local_position_setpoint_s state_prev)
+bool FlightTaskAuto::activate(vehicle_local_position_setpoint_s last_setpoint)
 {
-	bool ret = FlightTask::activate(state_prev);
+	bool ret = FlightTask::activate(last_setpoint);
 	_position_setpoint = _position;
 	_velocity_setpoint = _velocity;
 	_yaw_setpoint = _yaw_sp_prev = _yaw;

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.cpp
@@ -77,9 +77,9 @@ bool FlightTaskAuto::initializeSubscriptions(SubscriptionArray &subscription_arr
 	return true;
 }
 
-bool FlightTaskAuto::activate()
+bool FlightTaskAuto::activate(vehicle_local_position_setpoint_s state_prev)
 {
-	bool ret = FlightTask::activate();
+	bool ret = FlightTask::activate(state_prev);
 	_position_setpoint = _position;
 	_velocity_setpoint = _velocity;
 	_yaw_setpoint = _yaw_sp_prev = _yaw;

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
@@ -78,7 +78,7 @@ public:
 
 	virtual ~FlightTaskAuto() = default;
 	bool initializeSubscriptions(SubscriptionArray &subscription_array) override;
-	bool activate(vehicle_local_position_setpoint_s state_prev) override;
+	bool activate(vehicle_local_position_setpoint_s last_setpoint) override;
 	bool updateInitialize() override;
 	bool updateFinalize() override;
 

--- a/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
+++ b/src/lib/FlightTasks/tasks/Auto/FlightTaskAuto.hpp
@@ -78,7 +78,7 @@ public:
 
 	virtual ~FlightTaskAuto() = default;
 	bool initializeSubscriptions(SubscriptionArray &subscription_array) override;
-	bool activate() override;
+	bool activate(vehicle_local_position_setpoint_s state_prev) override;
 	bool updateInitialize() override;
 	bool updateFinalize() override;
 

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -41,12 +41,17 @@
 
 using namespace matrix;
 
-bool FlightTaskAutoLineSmoothVel::activate()
+bool FlightTaskAutoLineSmoothVel::activate(vehicle_local_position_setpoint_s state_prev)
 {
-	bool ret = FlightTaskAutoMapper2::activate();
+	bool ret = FlightTaskAutoMapper2::activate(state_prev);
+
+	checkSetpoints(state_prev);
+	const Vector3f accel_prev{state_prev.acc_x, state_prev.acc_y, state_prev.acc_z};
+	const Vector3f vel_prev = Vector3f(state_prev.vx, state_prev.vy, state_prev.vz);
+	const Vector3f pos_prev = Vector3f(state_prev.x, state_prev.y, state_prev.z);
 
 	for (int i = 0; i < 3; ++i) {
-		_trajectory[i].reset(0.f, _velocity(i), _position(i));
+		_trajectory[i].reset(accel_prev(i), vel_prev(i), pos_prev(i));
 	}
 
 	_yaw_sp_prev = _yaw;

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -54,7 +54,7 @@ bool FlightTaskAutoLineSmoothVel::activate(vehicle_local_position_setpoint_s sta
 		_trajectory[i].reset(accel_prev(i), vel_prev(i), pos_prev(i));
 	}
 
-	_yaw_sp_prev = _yaw;
+	_yaw_sp_prev = state_prev.yaw;
 	_updateTrajConstraints();
 	_initEkfResetCounters();
 
@@ -70,6 +70,32 @@ void FlightTaskAutoLineSmoothVel::reActivate()
 
 	_trajectory[2].reset(0.f, 0.7f, _position(2));
 	_initEkfResetCounters();
+}
+
+void FlightTaskAutoLineSmoothVel::checkSetpoints(vehicle_local_position_setpoint_s &setpoints)
+{
+	// If the position setpoint is unknown, set to the current postion
+	if (!PX4_ISFINITE(setpoints.x)) { setpoints.x = _position(0); }
+
+	if (!PX4_ISFINITE(setpoints.y)) { setpoints.y = _position(1); }
+
+	if (!PX4_ISFINITE(setpoints.z)) { setpoints.z = _position(2); }
+
+	// If the velocity setpoint is unknown, set to the current velocity
+	if (!PX4_ISFINITE(setpoints.vx)) { setpoints.vx = _velocity(0); }
+
+	if (!PX4_ISFINITE(setpoints.vy)) { setpoints.vy = _velocity(1); }
+
+	if (!PX4_ISFINITE(setpoints.vz)) { setpoints.vz = _velocity(2); }
+
+	// No acceleration estimate available, set to zero if the setpoint is NAN
+	if (!PX4_ISFINITE(setpoints.acc_x)) { setpoints.acc_x = 0.f; }
+
+	if (!PX4_ISFINITE(setpoints.acc_y)) { setpoints.acc_y = 0.f; }
+
+	if (!PX4_ISFINITE(setpoints.acc_z)) { setpoints.acc_z = 0.f; }
+
+	if (!PX4_ISFINITE(setpoints.yaw)) { setpoints.yaw = _yaw; }
 }
 
 void FlightTaskAutoLineSmoothVel::_generateSetpoints()

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -56,6 +56,7 @@ bool FlightTaskAutoLineSmoothVel::activate(vehicle_local_position_setpoint_s sta
 
 	_yaw_sp_prev = _yaw;
 	_updateTrajConstraints();
+	_initEkfResetCounters();
 
 	return ret;
 }
@@ -68,6 +69,7 @@ void FlightTaskAutoLineSmoothVel::reActivate()
 	}
 
 	_trajectory[2].reset(0.f, 0.7f, _position(2));
+	_initEkfResetCounters();
 }
 
 void FlightTaskAutoLineSmoothVel::_generateSetpoints()
@@ -113,6 +115,14 @@ inline float FlightTaskAutoLineSmoothVel::_constrainOneSide(float val, float con
 	const float max = (constrain > FLT_EPSILON) ? constrain : 0.f;
 
 	return math::constrain(val, min, max);
+}
+
+void FlightTaskAutoLineSmoothVel::_initEkfResetCounters()
+{
+	_reset_counters.xy = _sub_vehicle_local_position->get().xy_reset_counter;
+	_reset_counters.vxy = _sub_vehicle_local_position->get().vxy_reset_counter;
+	_reset_counters.z = _sub_vehicle_local_position->get().z_reset_counter;
+	_reset_counters.vz = _sub_vehicle_local_position->get().vz_reset_counter;
 }
 
 void FlightTaskAutoLineSmoothVel::_checkEkfResetCounters()

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.cpp
@@ -41,20 +41,20 @@
 
 using namespace matrix;
 
-bool FlightTaskAutoLineSmoothVel::activate(vehicle_local_position_setpoint_s state_prev)
+bool FlightTaskAutoLineSmoothVel::activate(vehicle_local_position_setpoint_s last_setpoint)
 {
-	bool ret = FlightTaskAutoMapper2::activate(state_prev);
+	bool ret = FlightTaskAutoMapper2::activate(last_setpoint);
 
-	checkSetpoints(state_prev);
-	const Vector3f accel_prev{state_prev.acc_x, state_prev.acc_y, state_prev.acc_z};
-	const Vector3f vel_prev = Vector3f(state_prev.vx, state_prev.vy, state_prev.vz);
-	const Vector3f pos_prev = Vector3f(state_prev.x, state_prev.y, state_prev.z);
+	checkSetpoints(last_setpoint);
+	const Vector3f accel_prev(last_setpoint.acc_x, last_setpoint.acc_y, last_setpoint.acc_z);
+	const Vector3f vel_prev(last_setpoint.vx, last_setpoint.vy, last_setpoint.vz);
+	const Vector3f pos_prev(last_setpoint.x, last_setpoint.y, last_setpoint.z);
 
 	for (int i = 0; i < 3; ++i) {
 		_trajectory[i].reset(accel_prev(i), vel_prev(i), pos_prev(i));
 	}
 
-	_yaw_sp_prev = state_prev.yaw;
+	_yaw_sp_prev = last_setpoint.yaw;
 	_updateTrajConstraints();
 	_initEkfResetCounters();
 

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -70,6 +70,7 @@ protected:
 	bool _checkTakeoff() override { return _want_takeoff; };
 
 	inline float _constrainOneSide(float val, float constrain);
+	void _initEkfResetCounters();
 	void _checkEkfResetCounters(); /**< Reset the trajectories when the ekf resets velocity or position */
 	void _generateHeading();
 	bool _generateHeadingAlongTraj(); /**< Generates heading along trajectory. */

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -64,6 +64,7 @@ protected:
 					(ParamFloat<px4::params::MPC_Z_TRAJ_P>) _param_mpc_z_traj_p
 				       );
 
+	void checkSetpoints(vehicle_local_position_setpoint_s &setpoints);
 	void _generateSetpoints() override; /**< Generate setpoints along line. */
 
 	/** determines when to trigger a takeoff (ignored in flight) */

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -49,7 +49,7 @@ public:
 	FlightTaskAutoLineSmoothVel() = default;
 	virtual ~FlightTaskAutoLineSmoothVel() = default;
 
-	bool activate() override;
+	bool activate(vehicle_local_position_setpoint_s state_prev) override;
 	void reActivate() override;
 
 protected:

--- a/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/AutoLineSmoothVel/FlightTaskAutoLineSmoothVel.hpp
@@ -49,7 +49,7 @@ public:
 	FlightTaskAutoLineSmoothVel() = default;
 	virtual ~FlightTaskAutoLineSmoothVel() = default;
 
-	bool activate(vehicle_local_position_setpoint_s state_prev) override;
+	bool activate(vehicle_local_position_setpoint_s last_setpoint) override;
 	void reActivate() override;
 
 protected:

--- a/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
@@ -40,9 +40,9 @@
 
 using namespace matrix;
 
-bool FlightTaskAutoMapper::activate()
+bool FlightTaskAutoMapper::activate(vehicle_local_position_setpoint_s state_prev)
 {
-	bool ret = FlightTaskAuto::activate();
+	bool ret = FlightTaskAuto::activate(state_prev);
 	_reset();
 	return ret;
 }

--- a/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.cpp
@@ -40,9 +40,9 @@
 
 using namespace matrix;
 
-bool FlightTaskAutoMapper::activate(vehicle_local_position_setpoint_s state_prev)
+bool FlightTaskAutoMapper::activate(vehicle_local_position_setpoint_s last_setpoint)
 {
-	bool ret = FlightTaskAuto::activate(state_prev);
+	bool ret = FlightTaskAuto::activate(last_setpoint);
 	_reset();
 	return ret;
 }

--- a/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.hpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.hpp
@@ -47,7 +47,7 @@ class FlightTaskAutoMapper : public FlightTaskAuto
 public:
 	FlightTaskAutoMapper() = default;
 	virtual ~FlightTaskAutoMapper() = default;
-	bool activate() override;
+	bool activate(vehicle_local_position_setpoint_s state_prev) override;
 	bool update() override;
 
 protected:

--- a/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.hpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper/FlightTaskAutoMapper.hpp
@@ -47,7 +47,7 @@ class FlightTaskAutoMapper : public FlightTaskAuto
 public:
 	FlightTaskAutoMapper() = default;
 	virtual ~FlightTaskAutoMapper() = default;
-	bool activate(vehicle_local_position_setpoint_s state_prev) override;
+	bool activate(vehicle_local_position_setpoint_s last_setpoint) override;
 	bool update() override;
 
 protected:

--- a/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.cpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.cpp
@@ -40,9 +40,9 @@
 
 using namespace matrix;
 
-bool FlightTaskAutoMapper2::activate()
+bool FlightTaskAutoMapper2::activate(vehicle_local_position_setpoint_s state_prev)
 {
-	bool ret = FlightTaskAuto::activate();
+	bool ret = FlightTaskAuto::activate(state_prev);
 	_reset();
 	return ret;
 }

--- a/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.cpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.cpp
@@ -40,9 +40,9 @@
 
 using namespace matrix;
 
-bool FlightTaskAutoMapper2::activate(vehicle_local_position_setpoint_s state_prev)
+bool FlightTaskAutoMapper2::activate(vehicle_local_position_setpoint_s last_setpoint)
 {
-	bool ret = FlightTaskAuto::activate(state_prev);
+	bool ret = FlightTaskAuto::activate(last_setpoint);
 	_reset();
 	return ret;
 }

--- a/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.hpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.hpp
@@ -47,7 +47,7 @@ class FlightTaskAutoMapper2 : public FlightTaskAuto
 public:
 	FlightTaskAutoMapper2() = default;
 	virtual ~FlightTaskAutoMapper2() = default;
-	bool activate() override;
+	bool activate(vehicle_local_position_setpoint_s state_prev) override;
 	bool update() override;
 
 protected:

--- a/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.hpp
+++ b/src/lib/FlightTasks/tasks/AutoMapper2/FlightTaskAutoMapper2.hpp
@@ -47,7 +47,7 @@ class FlightTaskAutoMapper2 : public FlightTaskAuto
 public:
 	FlightTaskAutoMapper2() = default;
 	virtual ~FlightTaskAutoMapper2() = default;
-	bool activate(vehicle_local_position_setpoint_s state_prev) override;
+	bool activate(vehicle_local_position_setpoint_s last_setpoint) override;
 	bool update() override;
 
 protected:

--- a/src/lib/FlightTasks/tasks/Failsafe/FlightTaskFailsafe.cpp
+++ b/src/lib/FlightTasks/tasks/Failsafe/FlightTaskFailsafe.cpp
@@ -36,9 +36,9 @@
 
 #include "FlightTaskFailsafe.hpp"
 
-bool FlightTaskFailsafe::activate()
+bool FlightTaskFailsafe::activate(vehicle_local_position_setpoint_s state_prev)
 {
-	bool ret = FlightTask::activate();
+	bool ret = FlightTask::activate(state_prev);
 	_position_setpoint = _position;
 	_velocity_setpoint.zero();
 	_thrust_setpoint = matrix::Vector3f(0.0f, 0.0f, -_param_mpc_thr_hover.get() * 0.6f);

--- a/src/lib/FlightTasks/tasks/Failsafe/FlightTaskFailsafe.cpp
+++ b/src/lib/FlightTasks/tasks/Failsafe/FlightTaskFailsafe.cpp
@@ -36,9 +36,9 @@
 
 #include "FlightTaskFailsafe.hpp"
 
-bool FlightTaskFailsafe::activate(vehicle_local_position_setpoint_s state_prev)
+bool FlightTaskFailsafe::activate(vehicle_local_position_setpoint_s last_setpoint)
 {
-	bool ret = FlightTask::activate(state_prev);
+	bool ret = FlightTask::activate(last_setpoint);
 	_position_setpoint = _position;
 	_velocity_setpoint.zero();
 	_thrust_setpoint = matrix::Vector3f(0.0f, 0.0f, -_param_mpc_thr_hover.get() * 0.6f);

--- a/src/lib/FlightTasks/tasks/Failsafe/FlightTaskFailsafe.hpp
+++ b/src/lib/FlightTasks/tasks/Failsafe/FlightTaskFailsafe.hpp
@@ -47,7 +47,7 @@ public:
 
 	virtual ~FlightTaskFailsafe() = default;
 	bool update() override;
-	bool activate() override;
+	bool activate(vehicle_local_position_setpoint_s state_prev) override;
 
 private:
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTask,

--- a/src/lib/FlightTasks/tasks/Failsafe/FlightTaskFailsafe.hpp
+++ b/src/lib/FlightTasks/tasks/Failsafe/FlightTaskFailsafe.hpp
@@ -47,7 +47,7 @@ public:
 
 	virtual ~FlightTaskFailsafe() = default;
 	bool update() override;
-	bool activate(vehicle_local_position_setpoint_s state_prev) override;
+	bool activate(vehicle_local_position_setpoint_s last_setpoint) override;
 
 private:
 	DEFINE_PARAMETERS_CUSTOM_PARENT(FlightTask,

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
@@ -47,47 +47,6 @@ bool FlightTask::updateInitialize()
 	return true;
 }
 
-void FlightTask::checkSetpoints(vehicle_local_position_setpoint_s &setpoints)
-{
-	// If the position setpoint is unknown, set to the current postion
-	if (!PX4_ISFINITE(setpoints.x)) { setpoints.x = _position(0); }
-
-	if (!PX4_ISFINITE(setpoints.y)) { setpoints.y = _position(1); }
-
-	if (!PX4_ISFINITE(setpoints.z)) { setpoints.z = _position(2); }
-
-	// If the velocity setpoint is unknown, set to the current velocity
-	if (!PX4_ISFINITE(setpoints.vx)) { setpoints.vx = _velocity(0); }
-
-	if (!PX4_ISFINITE(setpoints.vy)) { setpoints.vy = _velocity(1); }
-
-	if (!PX4_ISFINITE(setpoints.vz)) { setpoints.vz = _velocity(2); }
-
-	// No acceleration estimate available, set to zero if the setpoint is NAN
-	if (!PX4_ISFINITE(setpoints.acc_x)) { setpoints.acc_x = 0.f; }
-
-	if (!PX4_ISFINITE(setpoints.acc_y)) { setpoints.acc_y = 0.f; }
-
-	if (!PX4_ISFINITE(setpoints.acc_z)) { setpoints.acc_z = 0.f; }
-
-	// No jerk estimate available, set to zero if the setpoint is NAN
-	if (!PX4_ISFINITE(setpoints.jerk_x)) { setpoints.jerk_x = 0.f; }
-
-	if (!PX4_ISFINITE(setpoints.jerk_y)) { setpoints.jerk_y = 0.f; }
-
-	if (!PX4_ISFINITE(setpoints.jerk_z)) { setpoints.jerk_z = 0.f; }
-
-	if (!PX4_ISFINITE(setpoints.thrust[0])) { setpoints.thrust[0] = 0.f; }
-
-	if (!PX4_ISFINITE(setpoints.thrust[1])) { setpoints.thrust[1] = 0.f; }
-
-	if (!PX4_ISFINITE(setpoints.thrust[2])) { setpoints.thrust[2] = -0.5f; }
-
-	if (!PX4_ISFINITE(setpoints.yaw)) { setpoints.yaw = _yaw; }
-
-	if (!PX4_ISFINITE(setpoints.yawspeed)) { setpoints.yawspeed = 0.f; }
-}
-
 const vehicle_local_position_setpoint_s FlightTask::getPositionSetpoint()
 {
 	/* fill position setpoint message */

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
@@ -22,7 +22,7 @@ bool FlightTask::initializeSubscriptions(SubscriptionArray &subscription_array)
 	return true;
 }
 
-bool FlightTask::activate()
+bool FlightTask::activate(vehicle_local_position_setpoint_s state_prev)
 {
 	_resetSetpoints();
 	_setDefaultConstraints();
@@ -34,7 +34,7 @@ bool FlightTask::activate()
 
 void FlightTask::reActivate()
 {
-	activate();
+	activate(getPositionSetpoint());
 }
 
 bool FlightTask::updateInitialize()
@@ -45,6 +45,47 @@ bool FlightTask::updateInitialize()
 	_time_stamp_last = _time_stamp_current;
 	_evaluateVehicleLocalPosition();
 	return true;
+}
+
+void FlightTask::checkSetpoints(vehicle_local_position_setpoint_s &setpoints)
+{
+	// If the position setpoint is unknown, set to the current postion
+	if (!PX4_ISFINITE(setpoints.x)) { setpoints.x = _position(0); }
+
+	if (!PX4_ISFINITE(setpoints.y)) { setpoints.y = _position(1); }
+
+	if (!PX4_ISFINITE(setpoints.z)) { setpoints.z = _position(2); }
+
+	// If the velocity setpoint is unknown, set to the current velocity
+	if (!PX4_ISFINITE(setpoints.vx)) { setpoints.vx = _velocity(0); }
+
+	if (!PX4_ISFINITE(setpoints.vy)) { setpoints.vy = _velocity(1); }
+
+	if (!PX4_ISFINITE(setpoints.vz)) { setpoints.vz = _velocity(2); }
+
+	// No acceleration estimate available, set to zero if the setpoint is NAN
+	if (!PX4_ISFINITE(setpoints.acc_x)) { setpoints.acc_x = 0.f; }
+
+	if (!PX4_ISFINITE(setpoints.acc_y)) { setpoints.acc_y = 0.f; }
+
+	if (!PX4_ISFINITE(setpoints.acc_z)) { setpoints.acc_z = 0.f; }
+
+	// No jerk estimate available, set to zero if the setpoint is NAN
+	if (!PX4_ISFINITE(setpoints.jerk_x)) { setpoints.jerk_x = 0.f; }
+
+	if (!PX4_ISFINITE(setpoints.jerk_y)) { setpoints.jerk_y = 0.f; }
+
+	if (!PX4_ISFINITE(setpoints.jerk_z)) { setpoints.jerk_z = 0.f; }
+
+	if (!PX4_ISFINITE(setpoints.thrust[0])) { setpoints.thrust[0] = 0.f; }
+
+	if (!PX4_ISFINITE(setpoints.thrust[1])) { setpoints.thrust[1] = 0.f; }
+
+	if (!PX4_ISFINITE(setpoints.thrust[2])) { setpoints.thrust[2] = -0.5f; }
+
+	if (!PX4_ISFINITE(setpoints.yaw)) { setpoints.yaw = _yaw; }
+
+	if (!PX4_ISFINITE(setpoints.yawspeed)) { setpoints.yawspeed = 0.f; }
 }
 
 const vehicle_local_position_setpoint_s FlightTask::getPositionSetpoint()

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.cpp
@@ -22,7 +22,7 @@ bool FlightTask::initializeSubscriptions(SubscriptionArray &subscription_array)
 	return true;
 }
 
-bool FlightTask::activate(vehicle_local_position_setpoint_s state_prev)
+bool FlightTask::activate(vehicle_local_position_setpoint_s last_setpoint)
 {
 	_resetSetpoints();
 	_setDefaultConstraints();

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
@@ -120,8 +120,6 @@ public:
 	 */
 	const vehicle_local_position_setpoint_s getPositionSetpoint();
 
-	void checkSetpoints(vehicle_local_position_setpoint_s &setpoints);
-
 	/**
 	 * Get vehicle constraints.
 	 * The constraints can vary with task.

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
@@ -76,9 +76,10 @@ public:
 
 	/**
 	 * Call once on the event where you switch to the task
+	 * @param state of the previous task
 	 * @return true on success, false on error
 	 */
-	virtual bool activate();
+	virtual bool activate(vehicle_local_position_setpoint_s state_prev);
 
 	/**
 	 * Call this to reset an active Flight Task
@@ -118,6 +119,8 @@ public:
 	 * @return task output setpoints that get executed by the positon controller
 	 */
 	const vehicle_local_position_setpoint_s getPositionSetpoint();
+
+	void checkSetpoints(vehicle_local_position_setpoint_s &setpoints);
 
 	/**
 	 * Get vehicle constraints.

--- a/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
+++ b/src/lib/FlightTasks/tasks/FlightTask/FlightTask.hpp
@@ -79,7 +79,7 @@ public:
 	 * @param state of the previous task
 	 * @return true on success, false on error
 	 */
-	virtual bool activate(vehicle_local_position_setpoint_s state_prev);
+	virtual bool activate(vehicle_local_position_setpoint_s last_setpoint);
 
 	/**
 	 * Call this to reset an active Flight Task

--- a/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -61,9 +61,9 @@ bool FlightTaskManualAltitude::updateInitialize()
 	return ret && PX4_ISFINITE(_position(2)) && PX4_ISFINITE(_velocity(2)) && PX4_ISFINITE(_yaw);
 }
 
-bool FlightTaskManualAltitude::activate()
+bool FlightTaskManualAltitude::activate(vehicle_local_position_setpoint_s state_prev)
 {
-	bool ret = FlightTaskManual::activate();
+	bool ret = FlightTaskManual::activate(state_prev);
 	_yaw_setpoint = NAN;
 	_yawspeed_setpoint = 0.0f;
 	_thrust_setpoint = matrix::Vector3f(0.0f, 0.0f, NAN); // altitude is controlled from position/velocity

--- a/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.cpp
@@ -61,9 +61,9 @@ bool FlightTaskManualAltitude::updateInitialize()
 	return ret && PX4_ISFINITE(_position(2)) && PX4_ISFINITE(_velocity(2)) && PX4_ISFINITE(_yaw);
 }
 
-bool FlightTaskManualAltitude::activate(vehicle_local_position_setpoint_s state_prev)
+bool FlightTaskManualAltitude::activate(vehicle_local_position_setpoint_s last_setpoint)
 {
-	bool ret = FlightTaskManual::activate(state_prev);
+	bool ret = FlightTaskManual::activate(last_setpoint);
 	_yaw_setpoint = NAN;
 	_yawspeed_setpoint = 0.0f;
 	_thrust_setpoint = matrix::Vector3f(0.0f, 0.0f, NAN); // altitude is controlled from position/velocity

--- a/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
@@ -48,7 +48,7 @@ public:
 	FlightTaskManualAltitude() = default;
 	virtual ~FlightTaskManualAltitude() = default;
 	bool initializeSubscriptions(SubscriptionArray &subscription_array) override;
-	bool activate() override;
+	bool activate(vehicle_local_position_setpoint_s state_prev) override;
 	bool updateInitialize() override;
 	bool update() override;
 

--- a/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitude/FlightTaskManualAltitude.hpp
@@ -48,7 +48,7 @@ public:
 	FlightTaskManualAltitude() = default;
 	virtual ~FlightTaskManualAltitude() = default;
 	bool initializeSubscriptions(SubscriptionArray &subscription_array) override;
-	bool activate(vehicle_local_position_setpoint_s state_prev) override;
+	bool activate(vehicle_local_position_setpoint_s last_setpoint) override;
 	bool updateInitialize() override;
 	bool update() override;
 

--- a/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
@@ -66,6 +66,18 @@ void FlightTaskManualAltitudeSmoothVel::reActivate()
 	_resetPositionLock();
 }
 
+void FlightTaskManualAltitudeSmoothVel::checkSetpoints(vehicle_local_position_setpoint_s &setpoints)
+{
+	// If the position setpoint is unknown, set to the current postion
+	if (!PX4_ISFINITE(setpoints.z)) { setpoints.z = _position(2); }
+
+	// If the velocity setpoint is unknown, set to the current velocity
+	if (!PX4_ISFINITE(setpoints.vz)) { setpoints.vz = _velocity(2); }
+
+	// No acceleration estimate available, set to zero if the setpoint is NAN
+	if (!PX4_ISFINITE(setpoints.acc_z)) { setpoints.acc_z = 0.f; }
+}
+
 void FlightTaskManualAltitudeSmoothVel::_resetPositionLock()
 {
 	// Always start unlocked

--- a/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
@@ -50,6 +50,7 @@ bool FlightTaskManualAltitudeSmoothVel::activate(vehicle_local_position_setpoint
 
 	_smoothing.reset(state_prev.acc_z, state_prev.vz, state_prev.z);
 
+	_initEkfResetCounters();
 	_resetPositionLock();
 
 	return ret;
@@ -61,6 +62,7 @@ void FlightTaskManualAltitudeSmoothVel::reActivate()
 	// using the generated jerk, reset the z derivatives to zero
 	_smoothing.reset(0.f, 0.f, _position(2));
 
+	_initEkfResetCounters();
 	_resetPositionLock();
 }
 
@@ -69,6 +71,12 @@ void FlightTaskManualAltitudeSmoothVel::_resetPositionLock()
 	// Always start unlocked
 	_position_lock_z_active = false;
 	_position_setpoint_z_locked = NAN;
+}
+
+void FlightTaskManualAltitudeSmoothVel::_initEkfResetCounters()
+{
+	_reset_counters.z = _sub_vehicle_local_position->get().z_reset_counter;
+	_reset_counters.vz = _sub_vehicle_local_position->get().vz_reset_counter;
 }
 
 void FlightTaskManualAltitudeSmoothVel::_checkEkfResetCounters()

--- a/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.cpp
@@ -41,14 +41,14 @@
 
 using namespace matrix;
 
-bool FlightTaskManualAltitudeSmoothVel::activate(vehicle_local_position_setpoint_s state_prev)
+bool FlightTaskManualAltitudeSmoothVel::activate(vehicle_local_position_setpoint_s last_setpoint)
 {
-	bool ret = FlightTaskManualAltitude::activate(state_prev);
+	bool ret = FlightTaskManualAltitude::activate(last_setpoint);
 
 	// Check if the previous FlightTask provided setpoints
-	checkSetpoints(state_prev);
+	checkSetpoints(last_setpoint);
 
-	_smoothing.reset(state_prev.acc_z, state_prev.vz, state_prev.z);
+	_smoothing.reset(last_setpoint.acc_z, last_setpoint.vz, last_setpoint.z);
 
 	_initEkfResetCounters();
 	_resetPositionLock();

--- a/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
@@ -48,7 +48,7 @@ public:
 	FlightTaskManualAltitudeSmoothVel() = default;
 	virtual ~FlightTaskManualAltitudeSmoothVel() = default;
 
-	bool activate() override;
+	bool activate(vehicle_local_position_setpoint_s state_prev) override;
 	void reActivate() override;
 
 protected:
@@ -63,10 +63,7 @@ protected:
 
 private:
 
-	/**
-	 * Reset the required axes. when force_z_zero is set to true, the z derivatives are set to sero and not to the estimated states
-	 */
-	void _reset(bool force_vz_zero = false);
+	void _resetPositionLock();
 	void _checkEkfResetCounters(); /**< Reset the trajectories when the ekf resets velocity or position */
 
 	VelocitySmoothing _smoothing; ///< Smoothing in z direction

--- a/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
@@ -63,6 +63,7 @@ protected:
 
 private:
 
+	void checkSetpoints(vehicle_local_position_setpoint_s &setpoints);
 	void _resetPositionLock();
 	void _initEkfResetCounters();
 	void _checkEkfResetCounters(); /**< Reset the trajectories when the ekf resets velocity or position */

--- a/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
@@ -64,6 +64,7 @@ protected:
 private:
 
 	void _resetPositionLock();
+	void _initEkfResetCounters();
 	void _checkEkfResetCounters(); /**< Reset the trajectories when the ekf resets velocity or position */
 
 	VelocitySmoothing _smoothing; ///< Smoothing in z direction

--- a/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/ManualAltitudeSmoothVel/FlightTaskManualAltitudeSmoothVel.hpp
@@ -48,7 +48,7 @@ public:
 	FlightTaskManualAltitudeSmoothVel() = default;
 	virtual ~FlightTaskManualAltitudeSmoothVel() = default;
 
-	bool activate(vehicle_local_position_setpoint_s state_prev) override;
+	bool activate(vehicle_local_position_setpoint_s last_setpoint) override;
 	void reActivate() override;
 
 protected:

--- a/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -65,10 +65,10 @@ bool FlightTaskManualPosition::updateInitialize()
 	       && PX4_ISFINITE(_velocity(1));
 }
 
-bool FlightTaskManualPosition::activate()
+bool FlightTaskManualPosition::activate(vehicle_local_position_setpoint_s state_prev)
 {
 	// all requirements from altitude-mode still have to hold
-	bool ret = FlightTaskManualAltitude::activate();
+	bool ret = FlightTaskManualAltitude::activate(state_prev);
 
 	_constraints.tilt = math::radians(_param_mpc_tiltmax_air.get());
 

--- a/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.cpp
@@ -65,10 +65,10 @@ bool FlightTaskManualPosition::updateInitialize()
 	       && PX4_ISFINITE(_velocity(1));
 }
 
-bool FlightTaskManualPosition::activate(vehicle_local_position_setpoint_s state_prev)
+bool FlightTaskManualPosition::activate(vehicle_local_position_setpoint_s last_setpoint)
 {
 	// all requirements from altitude-mode still have to hold
-	bool ret = FlightTaskManualAltitude::activate(state_prev);
+	bool ret = FlightTaskManualAltitude::activate(last_setpoint);
 
 	_constraints.tilt = math::radians(_param_mpc_tiltmax_air.get());
 

--- a/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.hpp
+++ b/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.hpp
@@ -50,7 +50,7 @@ public:
 
 	virtual ~FlightTaskManualPosition() = default;
 	bool initializeSubscriptions(SubscriptionArray &subscription_array) override;
-	bool activate() override;
+	bool activate(vehicle_local_position_setpoint_s state_prev) override;
 	bool updateInitialize() override;
 
 	/**

--- a/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.hpp
+++ b/src/lib/FlightTasks/tasks/ManualPosition/FlightTaskManualPosition.hpp
@@ -50,7 +50,7 @@ public:
 
 	virtual ~FlightTaskManualPosition() = default;
 	bool initializeSubscriptions(SubscriptionArray &subscription_array) override;
-	bool activate(vehicle_local_position_setpoint_s state_prev) override;
+	bool activate(vehicle_local_position_setpoint_s last_setpoint) override;
 	bool updateInitialize() override;
 
 	/**

--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
@@ -52,6 +52,7 @@ bool FlightTaskManualPositionSmoothVel::activate(vehicle_local_position_setpoint
 		_smoothing[i].reset(accel_prev(i), vel_prev(i), pos_prev(i));
 	}
 
+	_initEkfResetCounters();
 	_resetPositionLock();
 
 	return ret;
@@ -78,6 +79,14 @@ void FlightTaskManualPositionSmoothVel::_resetPositionLock()
 	_position_setpoint_xy_locked(0) = NAN;
 	_position_setpoint_xy_locked(1) = NAN;
 	_position_setpoint_z_locked = NAN;
+}
+
+void FlightTaskManualPositionSmoothVel::_initEkfResetCounters()
+{
+	_reset_counters.xy = _sub_vehicle_local_position->get().xy_reset_counter;
+	_reset_counters.vxy = _sub_vehicle_local_position->get().vxy_reset_counter;
+	_reset_counters.z = _sub_vehicle_local_position->get().z_reset_counter;
+	_reset_counters.vz = _sub_vehicle_local_position->get().vz_reset_counter;
 }
 
 void FlightTaskManualPositionSmoothVel::_checkEkfResetCounters()

--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
@@ -72,6 +72,30 @@ void FlightTaskManualPositionSmoothVel::reActivate()
 	_resetPositionLock();
 }
 
+void FlightTaskManualPositionSmoothVel::checkSetpoints(vehicle_local_position_setpoint_s &setpoints)
+{
+	// If the position setpoint is unknown, set to the current postion
+	if (!PX4_ISFINITE(setpoints.x)) { setpoints.x = _position(0); }
+
+	if (!PX4_ISFINITE(setpoints.y)) { setpoints.y = _position(1); }
+
+	if (!PX4_ISFINITE(setpoints.z)) { setpoints.z = _position(2); }
+
+	// If the velocity setpoint is unknown, set to the current velocity
+	if (!PX4_ISFINITE(setpoints.vx)) { setpoints.vx = _velocity(0); }
+
+	if (!PX4_ISFINITE(setpoints.vy)) { setpoints.vy = _velocity(1); }
+
+	if (!PX4_ISFINITE(setpoints.vz)) { setpoints.vz = _velocity(2); }
+
+	// No acceleration estimate available, set to zero if the setpoint is NAN
+	if (!PX4_ISFINITE(setpoints.acc_x)) { setpoints.acc_x = 0.f; }
+
+	if (!PX4_ISFINITE(setpoints.acc_y)) { setpoints.acc_y = 0.f; }
+
+	if (!PX4_ISFINITE(setpoints.acc_z)) { setpoints.acc_z = 0.f; }
+}
+
 void FlightTaskManualPositionSmoothVel::_resetPositionLock()
 {
 	_position_lock_xy_active = false;

--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.cpp
@@ -38,9 +38,9 @@
 
 using namespace matrix;
 
-bool FlightTaskManualPositionSmoothVel::activate(vehicle_local_position_setpoint_s state_prev)
+bool FlightTaskManualPositionSmoothVel::activate(vehicle_local_position_setpoint_s last_setpoint)
 {
-	bool ret = FlightTaskManualPosition::activate(state_prev);
+	bool ret = FlightTaskManualPosition::activate(last_setpoint);
 
 	// Check if the previous FlightTask provided setpoints
 	checkSetpoints(last_setpoint);

--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.hpp
@@ -49,7 +49,7 @@ public:
 
 	virtual ~FlightTaskManualPositionSmoothVel() = default;
 
-	bool activate() override;
+	bool activate(vehicle_local_position_setpoint_s state_prev) override;
 	void reActivate() override;
 
 protected:
@@ -62,13 +62,7 @@ protected:
 					(ParamFloat<px4::params::MPC_ACC_DOWN_MAX>) _param_mpc_acc_down_max
 				       )
 private:
-
-	enum class Axes {XY, XYZ};
-
-	/**
-	 * Reset the required axes. when force_z_zero is set to true, the z derivatives are set to sero and not to the estimated states
-	 */
-	void reset(Axes axes, bool force_z_zero = false);
+	void _resetPositionLock();
 	void _checkEkfResetCounters(); /**< Reset the trajectories when the ekf resets velocity or position */
 
 	VelocitySmoothing _smoothing[3]; ///< Smoothing in x, y and z directions

--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.hpp
@@ -62,6 +62,7 @@ protected:
 					(ParamFloat<px4::params::MPC_ACC_DOWN_MAX>) _param_mpc_acc_down_max
 				       )
 private:
+	void checkSetpoints(vehicle_local_position_setpoint_s &setpoints);
 	void _resetPositionLock();
 	void _initEkfResetCounters();
 	void _checkEkfResetCounters(); /**< Reset the trajectories when the ekf resets velocity or position */

--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.hpp
@@ -63,6 +63,7 @@ protected:
 				       )
 private:
 	void _resetPositionLock();
+	void _initEkfResetCounters();
 	void _checkEkfResetCounters(); /**< Reset the trajectories when the ekf resets velocity or position */
 
 	VelocitySmoothing _smoothing[3]; ///< Smoothing in x, y and z directions

--- a/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.hpp
+++ b/src/lib/FlightTasks/tasks/ManualPositionSmoothVel/FlightTaskManualPositionSmoothVel.hpp
@@ -49,7 +49,7 @@ public:
 
 	virtual ~FlightTaskManualPositionSmoothVel() = default;
 
-	bool activate(vehicle_local_position_setpoint_s state_prev) override;
+	bool activate(vehicle_local_position_setpoint_s last_setpoint) override;
 	void reActivate() override;
 
 protected:

--- a/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp
+++ b/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp
@@ -64,9 +64,9 @@ bool FlightTaskOffboard::updateInitialize()
 	       && PX4_ISFINITE(_velocity(1));
 }
 
-bool FlightTaskOffboard::activate()
+bool FlightTaskOffboard::activate(vehicle_local_position_setpoint_s state_prev)
 {
-	bool ret = FlightTask::activate();
+	bool ret = FlightTask::activate(state_prev);
 	_position_setpoint = _position;
 	_velocity_setpoint.setZero();
 	_position_lock.setAll(NAN);

--- a/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp
+++ b/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.cpp
@@ -64,9 +64,9 @@ bool FlightTaskOffboard::updateInitialize()
 	       && PX4_ISFINITE(_velocity(1));
 }
 
-bool FlightTaskOffboard::activate(vehicle_local_position_setpoint_s state_prev)
+bool FlightTaskOffboard::activate(vehicle_local_position_setpoint_s last_setpoint)
 {
-	bool ret = FlightTask::activate(state_prev);
+	bool ret = FlightTask::activate(last_setpoint);
 	_position_setpoint = _position;
 	_velocity_setpoint.setZero();
 	_position_lock.setAll(NAN);

--- a/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.hpp
+++ b/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.hpp
@@ -49,7 +49,7 @@ public:
 	virtual ~FlightTaskOffboard() = default;
 	bool initializeSubscriptions(SubscriptionArray &subscription_array) override;
 	bool update() override;
-	bool activate() override;
+	bool activate(vehicle_local_position_setpoint_s state_prev) override;
 	bool updateInitialize() override;
 
 protected:

--- a/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.hpp
+++ b/src/lib/FlightTasks/tasks/Offboard/FlightTaskOffboard.hpp
@@ -49,7 +49,7 @@ public:
 	virtual ~FlightTaskOffboard() = default;
 	bool initializeSubscriptions(SubscriptionArray &subscription_array) override;
 	bool update() override;
-	bool activate(vehicle_local_position_setpoint_s state_prev) override;
+	bool activate(vehicle_local_position_setpoint_s last_setpoint) override;
 	bool updateInitialize() override;
 
 protected:

--- a/src/lib/FlightTasks/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/lib/FlightTasks/tasks/Orbit/FlightTaskOrbit.cpp
@@ -147,9 +147,9 @@ bool FlightTaskOrbit::checkAcceleration(float r, float v, float a)
 	return v * v < a * r;
 }
 
-bool FlightTaskOrbit::activate()
+bool FlightTaskOrbit::activate(vehicle_local_position_setpoint_s state_prev)
 {
-	bool ret = FlightTaskManualAltitudeSmooth::activate();
+	bool ret = FlightTaskManualAltitudeSmooth::activate(state_prev);
 	_r = _radius_min;
 	_v =  1.f;
 	_center = Vector2f(_position);

--- a/src/lib/FlightTasks/tasks/Orbit/FlightTaskOrbit.cpp
+++ b/src/lib/FlightTasks/tasks/Orbit/FlightTaskOrbit.cpp
@@ -147,9 +147,9 @@ bool FlightTaskOrbit::checkAcceleration(float r, float v, float a)
 	return v * v < a * r;
 }
 
-bool FlightTaskOrbit::activate(vehicle_local_position_setpoint_s state_prev)
+bool FlightTaskOrbit::activate(vehicle_local_position_setpoint_s last_setpoint)
 {
-	bool ret = FlightTaskManualAltitudeSmooth::activate(state_prev);
+	bool ret = FlightTaskManualAltitudeSmooth::activate(last_setpoint);
 	_r = _radius_min;
 	_v =  1.f;
 	_center = Vector2f(_position);

--- a/src/lib/FlightTasks/tasks/Orbit/FlightTaskOrbit.hpp
+++ b/src/lib/FlightTasks/tasks/Orbit/FlightTaskOrbit.hpp
@@ -51,7 +51,7 @@ public:
 	virtual ~FlightTaskOrbit();
 
 	bool applyCommandParameters(const vehicle_command_s &command) override;
-	bool activate() override;
+	bool activate(vehicle_local_position_setpoint_s state_prev) override;
 	bool update() override;
 
 	/**

--- a/src/lib/FlightTasks/tasks/Orbit/FlightTaskOrbit.hpp
+++ b/src/lib/FlightTasks/tasks/Orbit/FlightTaskOrbit.hpp
@@ -51,7 +51,7 @@ public:
 	virtual ~FlightTaskOrbit();
 
 	bool applyCommandParameters(const vehicle_command_s &command) override;
-	bool activate(vehicle_local_position_setpoint_s state_prev) override;
+	bool activate(vehicle_local_position_setpoint_s last_setpoint) override;
 	bool update() override;
 
 	/**

--- a/src/lib/FlightTasks/tasks/Sport/FlightTaskSport.hpp
+++ b/src/lib/FlightTasks/tasks/Sport/FlightTaskSport.hpp
@@ -52,9 +52,9 @@ public:
 
 	virtual ~FlightTaskSport() = default;
 
-	bool activate() override
+	bool activate(vehicle_local_position_setpoint_s state_prev) override
 	{
-		bool ret = FlightTaskManualPosition::activate();
+		bool ret = FlightTaskManualPosition::activate(state_prev);
 
 		// default constraints already are the maximum allowed limits
 		_setDefaultConstraints();

--- a/src/lib/FlightTasks/tasks/Sport/FlightTaskSport.hpp
+++ b/src/lib/FlightTasks/tasks/Sport/FlightTaskSport.hpp
@@ -52,9 +52,9 @@ public:
 
 	virtual ~FlightTaskSport() = default;
 
-	bool activate(vehicle_local_position_setpoint_s state_prev) override
+	bool activate(vehicle_local_position_setpoint_s last_setpoint) override
 	{
-		bool ret = FlightTaskManualPosition::activate(state_prev);
+		bool ret = FlightTaskManualPosition::activate(last_setpoint);
 
 		// default constraints already are the maximum allowed limits
 		_setDefaultConstraints();

--- a/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.cpp
+++ b/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.cpp
@@ -42,14 +42,29 @@ bool FlightTaskTransition::updateInitialize()
 	return FlightTask::updateInitialize();
 }
 
-bool FlightTaskTransition::activate()
+bool FlightTaskTransition::activate(vehicle_local_position_setpoint_s state_prev)
 {
-	// transition at the current altitude and current yaw at the time of activation
-	// it would be better to use the last setpoint from the previous running flighttask but that interface
-	// is not available
-	_transition_altitude = _position(2);
-	_transition_yaw = _yaw;
-	return FlightTask::activate();
+	checkSetpoints(state_prev);
+	_transition_altitude = state_prev.z;
+	_transition_yaw = state_prev.yaw;
+	_acceleration_setpoint.setAll(0.f);
+	_velocity_prev = _velocity;
+	return FlightTask::activate(state_prev);
+}
+
+void FlightTaskTransition::updateAccelerationEstimate()
+{
+	// Estimate the acceleration by filtering the raw derivative of the velocity estimate
+	// This is done to provide a good estimate of the current acceleration to the next flight task after back-transition
+	_acceleration_setpoint = 0.9f * _acceleration_setpoint + 0.1f * (_velocity - _velocity_prev) / _deltatime;
+
+	if (!PX4_ISFINITE(_acceleration_setpoint(0)) ||
+	    !PX4_ISFINITE(_acceleration_setpoint(1)) ||
+	    !PX4_ISFINITE(_acceleration_setpoint(2))) {
+		_acceleration_setpoint.setAll(0.f);
+	}
+
+	_velocity_prev = _velocity;
 }
 
 bool FlightTaskTransition::update()
@@ -60,6 +75,8 @@ bool FlightTaskTransition::update()
 	_position_setpoint *= NAN;
 	_velocity_setpoint *= NAN;
 	_position_setpoint(2) = _transition_altitude;
+
+	updateAccelerationEstimate();
 
 	_yaw_setpoint = _transition_yaw;
 	return true;

--- a/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.cpp
+++ b/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.cpp
@@ -52,6 +52,14 @@ bool FlightTaskTransition::activate(vehicle_local_position_setpoint_s state_prev
 	return FlightTask::activate(state_prev);
 }
 
+void FlightTaskTransition::checkSetpoints(vehicle_local_position_setpoint_s &setpoints)
+{
+	// If the setpoint is unknown, set to the current estimate
+	if (!PX4_ISFINITE(setpoints.z)) { setpoints.z = _position(2); }
+
+	if (!PX4_ISFINITE(setpoints.yaw)) { setpoints.yaw = _yaw; }
+}
+
 void FlightTaskTransition::updateAccelerationEstimate()
 {
 	// Estimate the acceleration by filtering the raw derivative of the velocity estimate

--- a/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.cpp
+++ b/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.cpp
@@ -42,14 +42,14 @@ bool FlightTaskTransition::updateInitialize()
 	return FlightTask::updateInitialize();
 }
 
-bool FlightTaskTransition::activate(vehicle_local_position_setpoint_s state_prev)
+bool FlightTaskTransition::activate(vehicle_local_position_setpoint_s last_setpoint)
 {
-	checkSetpoints(state_prev);
-	_transition_altitude = state_prev.z;
-	_transition_yaw = state_prev.yaw;
+	checkSetpoints(last_setpoint);
+	_transition_altitude = last_setpoint.z;
+	_transition_yaw = last_setpoint.yaw;
 	_acceleration_setpoint.setAll(0.f);
 	_velocity_prev = _velocity;
-	return FlightTask::activate(state_prev);
+	return FlightTask::activate(last_setpoint);
 }
 
 void FlightTaskTransition::checkSetpoints(vehicle_local_position_setpoint_s &setpoints)

--- a/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.hpp
+++ b/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.hpp
@@ -52,6 +52,7 @@ public:
 	bool update() override;
 
 private:
+	void checkSetpoints(vehicle_local_position_setpoint_s &setpoints);
 	void updateAccelerationEstimate();
 
 	float _transition_altitude = 0.0f;

--- a/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.hpp
+++ b/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.hpp
@@ -47,11 +47,14 @@ public:
 	FlightTaskTransition() = default;
 
 	virtual ~FlightTaskTransition() = default;
-	bool activate() override;
+	bool activate(vehicle_local_position_setpoint_s state_prev) override;
 	bool updateInitialize() override;
 	bool update() override;
 
 private:
+	void updateAccelerationEstimate();
+
 	float _transition_altitude = 0.0f;
 	float _transition_yaw = 0.0f;
+	matrix::Vector3f _velocity_prev{};
 };

--- a/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.hpp
+++ b/src/lib/FlightTasks/tasks/Transition/FlightTaskTransition.hpp
@@ -47,7 +47,7 @@ public:
 	FlightTaskTransition() = default;
 
 	virtual ~FlightTaskTransition() = default;
-	bool activate(vehicle_local_position_setpoint_s state_prev) override;
+	bool activate(vehicle_local_position_setpoint_s last_setpoint) override;
 	bool updateInitialize() override;
 	bool update() override;
 


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
Currently, a task doesn't know the setpoints that the previous one was outputting. The best initial setpoint is then to set it to the current estimate. The problem with this strategy is that the setpoints are discontinuous and this generates glitches when stitching tasks. This problem is particularly visible when switching out of the transition FlightTask: the switch generally occurs at a high speed and deceleration; without proper initialization, an attitude glitch is quite visible.

The image below shows a back transition of a standard VTOL plane. We can see that initializing the current acceleration setpoint to zero is a quite bad assumption.
![2019-07-01_11-46-36_01_plot](https://user-images.githubusercontent.com/14822839/60523933-ebdeb700-9ceb-11e9-9f87-fdf0bd6cea8d.png)

Also, between manual position control and auto (hold in this example), the velocity setpoint is discontinuous:
![2019-07-02_17-12-27_01_plot](https://user-images.githubusercontent.com/14822839/60524376-b71f2f80-9cec-11e9-9362-9d2ed4b24851.png)

**Solution**
When switching tasks, the FlightTask**s** class can get the last setpoints of the previous task and transfer them to the new task through the activate function.

Result on a VTOL back-transition:
During transition, the FlightTask estimates the current acceleration and can transmit it to the manual or auto flight task for proper initialization.
![2019-07-02_15-51-31_01_plot](https://user-images.githubusercontent.com/14822839/60524654-3f9dd000-9ced-11e9-9af6-50ebad15cf94.png)

Result when switching from manual position to auto:
The switch is invisible as the auto task initializes with the exact setpoints of the manual position one.
![2019-07-02_17-11-56_01_plot](https://user-images.githubusercontent.com/14822839/60524775-770c7c80-9ced-11e9-8f14-546712ca13e5.png)

@Stifael the checkSetpoints() function is there to replace the NANs in the setpoints with the estimate. This is called in the activate function; The problem is that if the activate function calls an other activate function, checkSetpoints could be called multiple times and this is inefficient. On the other hand, I don't want to store all those setpoints in the base class because they are only needed during initialization. Do you have a better idea?