### PR TITLE
logger: handle 'char' type in messages

### DIFF
--- a/src/modules/logger/logger.cpp
+++ b/src/modules/logger/logger.cpp
@@ -1889,7 +1889,8 @@ void Logger::write_format(LogType type, const orb_metadata &meta, WrittenFormats
 		    strcmp(type_name, "uint64_t") != 0 &&
 		    strcmp(type_name, "float") != 0 &&
 		    strcmp(type_name, "double") != 0 &&
-		    strcmp(type_name, "bool") != 0) {
+		    strcmp(type_name, "bool") != 0 &&
+		    strcmp(type_name, "char") != 0) {
 
 			// find orb meta for type
 			const orb_metadata *const *topics = orb_get_topics();


### PR DESCRIPTION
Fixes errors like:
```
ERROR [logger] No definition for topic char[10] key;uint8_t[2] _padding0; found
```
when the Debug logging profile is selected.

This will need to go to stable as well.