### PR TITLE
precland: store result of _target_pose_sub.update() for later use

### DIFF
--- a/src/modules/navigator/precland.cpp
+++ b/src/modules/navigator/precland.cpp
@@ -106,7 +106,9 @@ void
 PrecLand::on_active()
 {
 	// get new target measurement
-	if (_target_pose_sub.update(&_target_pose)) {
+	_target_pose_updated = _target_pose_sub.update(&_target_pose);
+
+	if (_target_pose_updated) {
 		_target_pose_valid = true;
 	}
 


### PR DESCRIPTION
Fixes #12391
precland: store result of _target_pose_sub.update() for later use

Tested in SITL.
