### PR TITLE
Fixed incorrect timestamps in vehicle_command, distance_sensor, and optical_flow topics

### DIFF
--- a/src/lib/FlightTasks/tasks/Utility/ObstacleAvoidance.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/ObstacleAvoidance.cpp
@@ -234,6 +234,7 @@ ObstacleAvoidance::_publishAvoidanceDesiredWaypoint()
 void ObstacleAvoidance::_publishVehicleCmdDoLoiter()
 {
 	vehicle_command_s command{};
+	command.timestamp = hrt_absolute_time();
 	command.command = vehicle_command_s::VEHICLE_CMD_DO_SET_MODE;
 	command.param1 = (float)1; // base mode
 	command.param3 = (float)0; // sub mode

--- a/src/modules/mavlink/mavlink_receiver.cpp
+++ b/src/modules/mavlink/mavlink_receiver.cpp
@@ -568,7 +568,7 @@ MavlinkReceiver::handle_message_optical_flow_rad(mavlink_message_t *msg)
 
 	optical_flow_s f = {};
 
-	f.timestamp = _mavlink_timesync.sync_stamp(flow.time_usec);
+	f.timestamp = hrt_absolute_time();
 	f.time_since_last_sonar_update = flow.time_delta_distance_us;
 	f.integration_timespan  = flow.integration_time_us;
 	f.pixel_flow_x_integral = flow.integrated_x;

--- a/src/modules/mc_pos_control/mc_pos_control_main.cpp
+++ b/src/modules/mc_pos_control/mc_pos_control_main.cpp
@@ -979,6 +979,7 @@ void MulticopterPositionControl::check_failure(bool task_failure, uint8_t nav_st
 void MulticopterPositionControl::send_vehicle_cmd_do(uint8_t nav_state)
 {
 	vehicle_command_s command{};
+	command.timestamp = hrt_absolute_time();
 	command.command = vehicle_command_s::VEHICLE_CMD_DO_SET_MODE;
 	command.param1 = (float)1; // base mode
 	command.param3 = (float)0; // sub mode


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
In the `optical_flow` and `distance_sensor` topics, the Mavlink Receiver was publishing UOrb messages with incorrect timestamps. In the Obstacle Avoidance module, the timestamp of a `vehicle_command` message was not being set.

**Describe your preferred solution**
In each place mentioned, the timestamp is set to `hrt_absolute_time()`.