### PR TITLE
create systemcmds/i2cdetect tool to scan bus

### DIFF
--- a/boards/airmind/mindpx-v2/default.cmake
+++ b/boards/airmind/mindpx-v2/default.cmake
@@ -81,6 +81,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/auav/x21/default.cmake
+++ b/boards/auav/x21/default.cmake
@@ -87,6 +87,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/av/x-v1/default.cmake
+++ b/boards/av/x-v1/default.cmake
@@ -90,6 +90,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/bitcraze/crazyflie/default.cmake
+++ b/boards/bitcraze/crazyflie/default.cmake
@@ -47,6 +47,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/intel/aerofc-v1/default.cmake
+++ b/boards/intel/aerofc-v1/default.cmake
@@ -64,6 +64,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/intel/aerofc-v1/rtps.cmake
+++ b/boards/intel/aerofc-v1/rtps.cmake
@@ -68,6 +68,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/omnibus/f4sd/default.cmake
+++ b/boards/omnibus/f4sd/default.cmake
@@ -77,6 +77,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		#motor_ramp

--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -95,6 +95,7 @@ px4_add_board(
 		#dumpfile
 		#esc_calib
 		hardfault_log
+		#i2c
 		#led_control
 		mixer
 		#motor_ramp

--- a/boards/px4/fmu-v2/fixedwing.cmake
+++ b/boards/px4/fmu-v2/fixedwing.cmake
@@ -66,6 +66,7 @@ px4_add_board(
 		#dumpfile
 		#esc_calib
 		hardfault_log
+		i2cdetect
 		#led_control
 		mixer
 		#motor_ramp

--- a/boards/px4/fmu-v2/lpe.cmake
+++ b/boards/px4/fmu-v2/lpe.cmake
@@ -91,6 +91,7 @@ px4_add_board(
 		#dumpfile
 		#esc_calib
 		hardfault_log
+		i2cdetect
 		#led_control
 		mixer
 		#motor_ramp

--- a/boards/px4/fmu-v2/multicopter.cmake
+++ b/boards/px4/fmu-v2/multicopter.cmake
@@ -63,6 +63,7 @@ px4_add_board(
 		#dumpfile
 		#esc_calib
 		hardfault_log
+		i2cdetect
 		#led_control
 		mixer
 		#motor_ramp

--- a/boards/px4/fmu-v2/rover.cmake
+++ b/boards/px4/fmu-v2/rover.cmake
@@ -58,6 +58,7 @@ px4_add_board(
 		#dumpfile
 		#esc_calib
 		hardfault_log
+		i2cdetect
 		#led_control
 		mixer
 		#motor_ramp

--- a/boards/px4/fmu-v2/test.cmake
+++ b/boards/px4/fmu-v2/test.cmake
@@ -91,6 +91,7 @@ px4_add_board(
 		#dumpfile
 		#esc_calib
 		hardfault_log
+		i2cdetect
 		#led_control
 		mixer
 		#motor_ramp

--- a/boards/px4/fmu-v3/default.cmake
+++ b/boards/px4/fmu-v3/default.cmake
@@ -95,6 +95,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/px4/fmu-v3/rtps.cmake
+++ b/boards/px4/fmu-v3/rtps.cmake
@@ -95,6 +95,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/px4/fmu-v3/stackcheck.cmake
+++ b/boards/px4/fmu-v3/stackcheck.cmake
@@ -94,6 +94,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/px4/fmu-v4/default.cmake
+++ b/boards/px4/fmu-v4/default.cmake
@@ -79,6 +79,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/px4/fmu-v4/rtps.cmake
+++ b/boards/px4/fmu-v4/rtps.cmake
@@ -82,6 +82,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/px4/fmu-v4/stackcheck.cmake
+++ b/boards/px4/fmu-v4/stackcheck.cmake
@@ -79,6 +79,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/px4/fmu-v4pro/default.cmake
+++ b/boards/px4/fmu-v4pro/default.cmake
@@ -93,6 +93,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/px4/fmu-v4pro/rtps.cmake
+++ b/boards/px4/fmu-v4pro/rtps.cmake
@@ -93,6 +93,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/px4/fmu-v5/default.cmake
+++ b/boards/px4/fmu-v5/default.cmake
@@ -95,6 +95,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/px4/fmu-v5/fixedwing.cmake
+++ b/boards/px4/fmu-v5/fixedwing.cmake
@@ -67,6 +67,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/px4/fmu-v5/multicopter.cmake
+++ b/boards/px4/fmu-v5/multicopter.cmake
@@ -76,6 +76,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/px4/fmu-v5/rover.cmake
+++ b/boards/px4/fmu-v5/rover.cmake
@@ -70,6 +70,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/px4/fmu-v5/rtps.cmake
+++ b/boards/px4/fmu-v5/rtps.cmake
@@ -93,6 +93,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/px4/fmu-v5/stackcheck.cmake
+++ b/boards/px4/fmu-v5/stackcheck.cmake
@@ -93,6 +93,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/px4/fmu-v5x/default.cmake
+++ b/boards/px4/fmu-v5x/default.cmake
@@ -95,6 +95,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/px4/fmu-v5x/fixedwing.cmake
+++ b/boards/px4/fmu-v5x/fixedwing.cmake
@@ -78,6 +78,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/px4/fmu-v5x/multicopter.cmake
+++ b/boards/px4/fmu-v5x/multicopter.cmake
@@ -84,6 +84,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/px4/fmu-v5x/rover.cmake
+++ b/boards/px4/fmu-v5x/rover.cmake
@@ -81,6 +81,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/px4/fmu-v5x/rtps.cmake
+++ b/boards/px4/fmu-v5x/rtps.cmake
@@ -96,6 +96,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/boards/px4/fmu-v5x/stackcheck.cmake
+++ b/boards/px4/fmu-v5x/stackcheck.cmake
@@ -95,6 +95,7 @@ px4_add_board(
 		dumpfile
 		esc_calib
 		hardfault_log
+		i2cdetect
 		led_control
 		mixer
 		motor_ramp

--- a/src/systemcmds/i2cdetect/CMakeLists.txt
+++ b/src/systemcmds/i2cdetect/CMakeLists.txt
@@ -1,0 +1,41 @@
+############################################################################
+#
+#   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+px4_add_module(
+	MODULE systemcmds__i2cdetect
+	MAIN i2cdetect
+	STACK_MAIN 4096
+	COMPILE_FLAGS
+	SRCS
+		i2cdetect.cpp
+	)

--- a/src/systemcmds/i2cdetect/i2cdetect.cpp
+++ b/src/systemcmds/i2cdetect/i2cdetect.cpp
@@ -1,0 +1,173 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file i2cdetect.cpp
+ *
+ * Simple tool to scan an I2C bus.
+ *
+ */
+
+#include <px4_config.h>
+#include <px4_log.h>
+#include <px4_module.h>
+#include <px4_getopt.h>
+#include <px4_i2c.h>
+
+namespace i2cdetect
+{
+
+int detect(int bus)
+{
+	printf("Scanning I2C bus: %d\n", bus);
+
+	int ret = PX4_ERROR;
+
+	// attach to the i2c bus
+	struct i2c_master_s *i2c_dev = px4_i2cbus_initialize(bus);
+
+	if (i2c_dev == nullptr) {
+		PX4_ERR("invalid bus %d", bus);
+		return PX4_ERROR;
+	}
+
+	printf("     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f\n");
+
+	for (int i = 0; i < 128; i += 16) {
+		printf("%02x: ", i);
+
+		for (int j = 0; j < 16; j++) {
+
+			fflush(stdout);
+
+			uint8_t addr = i + j;
+
+			unsigned retry_count = 0;
+			const unsigned retries = 5;
+
+			bool found = false;
+
+			do {
+				uint8_t send_data = 0;
+				uint8_t recv_data = 0;
+				px4_i2c_msg_t msgv[2];
+
+				// send
+				msgv[0].frequency = 1000000;
+				msgv[0].addr = addr;
+				msgv[0].flags = 0;
+				msgv[0].buffer = &send_data;
+				msgv[0].length = sizeof(send_data);
+
+				// recv
+				msgv[1].frequency = 1000000;
+				msgv[1].addr = addr;
+				msgv[1].flags = I2C_M_READ;
+				msgv[1].buffer = &recv_data;;
+				msgv[1].length = sizeof(recv_data);
+
+				ret = I2C_TRANSFER(i2c_dev, &msgv[0], 2);
+
+				// success
+				if (ret == PX4_OK) {
+					found = true;
+					break;
+				}
+
+				// if we have already retried once, or we are going to give up, then reset the bus
+				if ((retry_count >= 1) || (retry_count >= retries)) {
+					I2C_RESET(i2c_dev);
+				}
+
+			} while (retry_count++ < retries);
+
+			if (found) {
+				printf("%02x ", addr);
+
+			} else {
+				printf("-- ");
+			}
+		}
+
+		printf("\n");
+	}
+
+	px4_i2cbus_uninitialize(i2c_dev);
+
+	return ret;
+}
+
+int usage(const char *reason = nullptr)
+{
+	if (reason) {
+		PX4_ERR("%s", reason);
+	}
+
+	PRINT_MODULE_DESCRIPTION("Utility to scan for I2C devices on a particular bus.");
+
+	PRINT_MODULE_USAGE_NAME_SIMPLE("i2cdetect", "command");
+	PRINT_MODULE_USAGE_PARAM_INT('b', 1, 4, PX4_I2C_BUS_EXPANSION, "I2C bus", true);
+
+	return PX4_OK;
+}
+
+} // namespace i2cdetect
+
+extern "C" {
+	__EXPORT int i2cdetect_main(int argc, char *argv[]);
+}
+
+int i2cdetect_main(int argc, char *argv[])
+{
+	int i2c_bus = PX4_I2C_BUS_EXPANSION;
+
+	int myoptind = 1;
+	int ch = 0;
+	const char *myoptarg = nullptr;
+
+	while ((ch = px4_getopt(argc, argv, "b:", &myoptind, &myoptarg)) != EOF) {
+		switch (ch) {
+		case 'b':
+			// set i2c bus
+			i2c_bus = strtol(myoptarg, nullptr, 0);
+			break;
+
+		default:
+			i2cdetect::usage();
+			return -1;
+			break;
+		}
+	}
+
+	return i2cdetect::detect(i2c_bus);
+}


### PR DESCRIPTION
This is a simple command line tool to scan an I2C bus. Similar to i2cdetect on linux. https://learn.adafruit.com/using-the-bmp085-with-raspberry-pi/configuring-the-pi-for-i2c

![image](https://user-images.githubusercontent.com/84712/60740823-1ec7bb80-9f35-11e9-9498-9cf9d4abfb25.png)

![image](https://user-images.githubusercontent.com/84712/60740867-4028a780-9f35-11e9-8aba-2a7ea0a480b3.png)
