### PR TITLE
px4_fmu-v2 enable CONSTRAINED_FLASH and disable mpu9250 driver

### DIFF
--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -37,7 +37,7 @@ px4_add_board(
 		imu/l3gd20
 		imu/lsm303d
 		imu/mpu6000
-		imu/mpu9250
+		#imu/mpu9250
 		#iridiumsbd
 		#irlock
 		#lights/blinkm

--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -10,7 +10,7 @@ px4_add_board(
 	BOOTLOADER ${PX4_SOURCE_DIR}/ROMFS/px4fmu_common/extras/px4fmuv3_bl.bin
 	IO px4_io-v2_default
 	#TESTING
-	#CONSTRAINED_FLASH
+	CONSTRAINED_FLASH
 	#UAVCAN_INTERFACES 2
 
 	SERIAL_PORTS

--- a/boards/px4/fmu-v2/default.cmake
+++ b/boards/px4/fmu-v2/default.cmake
@@ -95,7 +95,7 @@ px4_add_board(
 		#dumpfile
 		#esc_calib
 		hardfault_log
-		#i2c
+		#i2cdetect
 		#led_control
 		mixer
 		#motor_ramp

--- a/boards/px4/fmu-v2/multicopter.cmake
+++ b/boards/px4/fmu-v2/multicopter.cmake
@@ -7,7 +7,9 @@ px4_add_board(
 	TOOLCHAIN arm-none-eabi
 	ARCHITECTURE cortex-m4
 	ROMFSROOT px4fmu_common
+	BOOTLOADER ${PX4_SOURCE_DIR}/ROMFS/px4fmu_common/extras/px4fmuv3_bl.bin
 	IO px4_io-v2_default
+	CONSTRAINED_FLASH
 	#UAVCAN_INTERFACES 2
 
 	SERIAL_PORTS
@@ -63,7 +65,7 @@ px4_add_board(
 		#dumpfile
 		#esc_calib
 		hardfault_log
-		i2cdetect
+		#i2cdetect
 		#led_control
 		mixer
 		#motor_ramp


### PR DESCRIPTION
This PR saves about 7.6 KB of flash on fmu-v2_default.

There are px4_fmu-v2 variants with an mpu9250, however I believe they're mostly newer boards that could be flashing fmu-v3 (with a bootloader upgrade). Not ideal, but better than deprecating it entirely.