### PR TITLE
enable bst telemetry by enable new TEL_BST_EN parameter

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -21,9 +21,6 @@ then
 	# Internal SPI (auto detect ms5611 or ms5607)
 	ms5611 -T 0 -s start
 
-	# Blacksheep telemetry
-	bst start
-
 	adc start
 fi
 

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -463,6 +463,12 @@ else
 	# Check for flow sensor, launched as a background task to scan
 	px4flow start &
 
+	# Blacksheep telemetry
+	if param greater TEL_BST_EN 0
+	then
+		bst start
+	fi
+
 	#
 	# Optional board supplied extras: rc.board_extras
 	#

--- a/src/drivers/telemetry/bst/bst_params.c
+++ b/src/drivers/telemetry/bst/bst_params.c
@@ -1,0 +1,43 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Blacksheep telemetry Enable
+ *
+ * If true, the FMU will try to connect to Blacksheep telemetry on start up
+ *
+ * @boolean
+ * @reboot_required true
+ * @group Telemetry
+ */
+PARAM_DEFINE_INT32(TEL_BST_EN, 0);


### PR DESCRIPTION
This suppose to make start-up cleaner for some boards that don't uses some sensors but try do start them because they are on the common rc.sensors.
some disscution is here #12409

This pr focus the bst telemetry.
related to  #12424