### PR TITLE
Fix mavlink config stream corner case where USB is not connected at boot.

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -163,50 +163,6 @@ bool Mavlink::_boot_complete = false;
 Mavlink::Mavlink() :
 	ModuleParams(nullptr)
 {
-	_instance_id = Mavlink::instance_count();
-
-	/* set channel according to instance id */
-	switch (_instance_id) {
-	case 0:
-		_channel = MAVLINK_COMM_0;
-		break;
-
-	case 1:
-		_channel = MAVLINK_COMM_1;
-		break;
-
-	case 2:
-		_channel = MAVLINK_COMM_2;
-		break;
-
-	case 3:
-		_channel = MAVLINK_COMM_3;
-		break;
-#ifdef MAVLINK_COMM_4
-
-	case 4:
-		_channel = MAVLINK_COMM_4;
-		break;
-#endif
-#ifdef MAVLINK_COMM_5
-
-	case 5:
-		_channel = MAVLINK_COMM_5;
-		break;
-#endif
-#ifdef MAVLINK_COMM_6
-
-	case 6:
-		_channel = MAVLINK_COMM_6;
-		break;
-#endif
-
-	default:
-		PX4_WARN("instance ID is out of range");
-		px4_task_exit(1);
-		break;
-	}
-
 	// initialise parameter cache
 	mavlink_update_parameters();
 
@@ -267,6 +223,58 @@ Mavlink::mavlink_update_parameters()
 		_param_mav_type.commit_no_notification();
 		PX4_ERR("MAV_TYPE parameter invalid, resetting to 0.");
 	}
+}
+
+void
+Mavlink::set_channel()
+{
+	/* set channel according to instance id */
+	switch (_instance_id) {
+	case 0:
+		_channel = MAVLINK_COMM_0;
+		break;
+
+	case 1:
+		_channel = MAVLINK_COMM_1;
+		break;
+
+	case 2:
+		_channel = MAVLINK_COMM_2;
+		break;
+
+	case 3:
+		_channel = MAVLINK_COMM_3;
+		break;
+#ifdef MAVLINK_COMM_4
+
+	case 4:
+		_channel = MAVLINK_COMM_4;
+		break;
+#endif
+#ifdef MAVLINK_COMM_5
+
+	case 5:
+		_channel = MAVLINK_COMM_5;
+		break;
+#endif
+#ifdef MAVLINK_COMM_6
+
+	case 6:
+		_channel = MAVLINK_COMM_6;
+		break;
+#endif
+
+	default:
+		PX4_WARN("instance ID is out of range");
+		px4_task_exit(1);
+		break;
+	}
+}
+
+void
+Mavlink::set_instance_id()
+{
+	_instance_id = Mavlink::instance_count();
 }
 
 void
@@ -485,7 +493,7 @@ Mavlink::get_uart_fd(unsigned index)
 }
 
 int
-Mavlink::mavlink_open_uart(int baud, const char *uart_name, bool force_flow_control)
+Mavlink::mavlink_open_uart(const int baud, const char *uart_name, const bool force_flow_control)
 {
 #ifndef B460800
 #define B460800 460800
@@ -603,7 +611,9 @@ Mavlink::mavlink_open_uart(int baud, const char *uart_name, bool force_flow_cont
 				return -1;
 			}
 
-			px4_usleep(100000);
+			int errcode = errno;
+			/* ENOTCONN means that the USB device is not yet connected */
+			px4_usleep(errcode == ENOTCONN ? 1000000 :  100000);
 			_uart_fd = ::open(uart_name, O_RDWR | O_NOCTTY);
 		}
 	}
@@ -2171,6 +2181,10 @@ Mavlink::task_main(int argc, char *argv[])
 	if (_main_loop_delay > MAVLINK_MAX_INTERVAL) {
 		_main_loop_delay = MAVLINK_MAX_INTERVAL;
 	}
+
+	set_instance_id();
+
+	set_channel();
 
 	/* now the instance is fully initialized and we can bump the instance count */
 	LL_APPEND(_mavlink_instances, this);

--- a/src/modules/mavlink/mavlink_main.h
+++ b/src/modules/mavlink/mavlink_main.h
@@ -83,6 +83,7 @@
 #include "mavlink_shell.h"
 #include "mavlink_ulog.h"
 
+#define DEFAULT_BAUD_RATE       57600
 #define DEFAULT_REMOTE_PORT_UDP 14550 ///< GCS port per MAVLink spec
 #define DEFAULT_DEVICE_NAME     "/dev/ttyS1"
 #define HASH_PARAM              "_HASH_CHECK"
@@ -675,7 +676,9 @@ private:
 
 	void			mavlink_update_parameters();
 
-	int			mavlink_open_uart(int baudrate, const char *uart_name, bool force_flow_control);
+	int mavlink_open_uart(const int baudrate = DEFAULT_BAUD_RATE,
+			      const char *uart_name = DEFAULT_DEVICE_NAME,
+			      const bool force_flow_control = false);
 
 	static constexpr unsigned RADIO_BUFFER_CRITICAL_LOW_PERCENTAGE = 25;
 	static constexpr unsigned RADIO_BUFFER_LOW_PERCENTAGE = 35;
@@ -730,10 +733,14 @@ private:
 
 	void init_udp();
 
+	void set_channel();
+
+	void set_instance_id();
+
 	/**
 	 * Main mavlink task.
 	 */
-	int		task_main(int argc, char *argv[]);
+	int task_main(int argc, char *argv[]);
 
 	// Disallow copy construction and move assignment.
 	Mavlink(const Mavlink &) = delete;


### PR DESCRIPTION
**Describe problem solved by the proposed pull request**
This PR resolves issue #12201 that prevents a config stream from connecting properly when the USB cable is not plugged in at boot.

**Test data / coverage**
This PR was bench tested on pixracer (fmu-v4), pixhawk4 (fmu-v5), and bench and flight tested on pixhawk 4 mini (fmu-v5): https://review.px4.io/plot_app?log=599f3173-5b9c-4614-9426-86f3eee76113

Bench test failures can easily be identified by examining if the mavlink stream instance and channel do not match as in the following:
```
instance #2:
    mavlink chan: #0
    type:        USB CDC
    flow control: OFF
    rates:
      tx: 0.000 kB/s
      txerr: 0.000 kB/s
      tx rate mult: 1.000
      tx rate max: 800000 B/s
      rx: 0.000 kB/s
    FTP enabled: YES, TX enabled: YES
    mode: Config
    MAVLink version: 1
    transport protocol: serial (/dev/ttyACM0 @2000000)
```

Likewise, it is simple to identify when the system is working correctly if QGC successfully communicates with with the autopilot over USB when the system was powered on without USB connected and USB is connected after boot completes.

**Additional context**
See issue #12201. @sfalexrog , @julianoes , @dagar , @davids5 .

Please let me know if you have any questions or concerns with this PR.  Thanks!

-Mark

NOTE: This issue does not reveal itself in the current PX4:master branch, so testing was primarily conducted on this patch applied to v1.9.2.  Flight log posted above was conducted on this PR commit.