### PR TITLE
ObstacleAvoidance: refactor check on z mission progression

### DIFF
--- a/src/lib/FlightTasks/tasks/Utility/ObstacleAvoidance.cpp
+++ b/src/lib/FlightTasks/tasks/Utility/ObstacleAvoidance.cpp
@@ -44,6 +44,7 @@ using namespace time_literals;
 static constexpr uint64_t TRAJECTORY_STREAM_TIMEOUT_US = 500_ms;
 /** If Flighttask fails, keep 0.5 seconds the current setpoint before going into failsafe land */
 static constexpr uint64_t TIME_BEFORE_FAILSAFE = 500_ms;
+static constexpr uint64_t Z_PROGRESS_TIMEOUT_US = 2_s;
 
 const vehicle_trajectory_waypoint_s empty_trajectory_waypoint = {0, 0, {0, 0, 0, 0, 0, 0, 0},
 	{	{0, {NAN, NAN, NAN}, {NAN, NAN, NAN}, {NAN, NAN, NAN}, NAN, NAN, false, {0, 0, 0}},
@@ -60,6 +61,7 @@ ObstacleAvoidance::ObstacleAvoidance(ModuleParams *parent) :
 	_desired_waypoint = empty_trajectory_waypoint;
 	_failsafe_position.setNaN();
 	_avoidance_point_not_valid_hysteresis.set_hysteresis_time_from(false, TIME_BEFORE_FAILSAFE);
+	_no_progress_z_hysteresis.set_hysteresis_time_from(false, Z_PROGRESS_TIMEOUT_US);
 
 }
 
@@ -199,11 +201,16 @@ void ObstacleAvoidance::checkAvoidanceProgress(const Vector3f &pos, const Vector
 
 	const float pos_to_target_z = fabsf(_curr_wp(2) - _position(2));
 
+	bool no_progress_z = (pos_to_target_z > _prev_pos_to_target_z);
+	_no_progress_z_hysteresis.set_state_and_update(no_progress_z, hrt_absolute_time());
+
 	if (pos_to_target.length() < target_acceptance_radius && pos_to_target_z > _param_nav_mc_alt_rad.get()
-	    && wp_type != position_setpoint_s::SETPOINT_TYPE_TAKEOFF) {
+	    && _no_progress_z_hysteresis.get_state()) {
 		// vehicle above or below the target waypoint
 		pos_control_status.altitude_acceptance = pos_to_target_z + 0.5f;
 	}
+
+	_prev_pos_to_target_z = pos_to_target_z;
 
 	// do not check for waypoints yaw acceptance in navigator
 	pos_control_status.yaw_acceptance = NAN;

--- a/src/lib/FlightTasks/tasks/Utility/ObstacleAvoidance.hpp
+++ b/src/lib/FlightTasks/tasks/Utility/ObstacleAvoidance.hpp
@@ -123,6 +123,9 @@ private:
 	matrix::Vector3f _failsafe_position = {}; /**< vehicle position when entered in failsafe */
 
 	systemlib::Hysteresis _avoidance_point_not_valid_hysteresis{false}; /**< becomes true if the companion doesn't start sending valid setpoints */
+	systemlib::Hysteresis _no_progress_z_hysteresis{false};
+
+	float _prev_pos_to_target_z = -1.f;
 
 	bool _ext_yaw_active = false; /**< true, if external yaw handling is active */
 


### PR DESCRIPTION
Refactors the mission progession check on the z component. Right now the check excludes takeoff points because the condition of being inside the xy acceptance radius but more than z acceptance away is always true. However this condition happens not only at takeoff. The refactor uses an hysteresis on the z distance to the goal to judge is the mission is progressing. 